### PR TITLE
feat: observe-only authority tracking — flag tool-scope violations in proxy

### DIFF
--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -604,6 +604,22 @@ _DDL = [
     """,
     "CREATE INDEX IF NOT EXISTS idx_guardrail_events_ts      ON guardrail_events(ts)",
     "CREATE INDEX IF NOT EXISTS idx_guardrail_events_session ON guardrail_events(session_id, ts)",
+    # Issue #3305 — authority-violation events from the enforcement proxy.
+    # ``allowed_tools`` / ``declared_tools`` stored as JSON strings so no
+    # schema version bump is needed.  Idempotent (CREATE TABLE IF NOT EXISTS).
+    """
+    CREATE TABLE IF NOT EXISTS authority_violations (
+        id             VARCHAR PRIMARY KEY,
+        session_id     VARCHAR,
+        ts             VARCHAR NOT NULL,
+        tool           VARCHAR,
+        violation_type VARCHAR,
+        declared_tools VARCHAR,
+        allowed_tools  VARCHAR
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_authority_violations_ts      ON authority_violations(ts)",
+    "CREATE INDEX IF NOT EXISTS idx_authority_violations_session ON authority_violations(session_id, ts)",
     # Issue #2201 — asset registry. Evidence + review layer that turns
     # individual agent discoveries (Self-Evolve findings, useful prompts,
     # improved skills) into reviewable, reusable assets without auto-promoting
@@ -7317,6 +7333,64 @@ class LocalStore:
         params.append(int(limit))
         cols = ["id", "owner_hash", "ts", "rule_name", "verdict",
                 "session_id", "action", "latency_ms"]
+        return [dict(zip(cols, r)) for r in self._fetch(sql, params)]
+
+    def ingest_authority_violation(self, event: dict[str, Any]) -> None:
+        """Upsert one proxy authority-violation row. Required: ``id``, ``ts``."""
+        import json as _json
+        eid = event.get("id")
+        if not eid:
+            raise ValueError("authority_violation event must include 'id'")
+        ts = event.get("ts") or datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S")
+        declared = event.get("declared_tools")
+        allowed = event.get("allowed_tools")
+        with self._write_lock:
+            self._conn.execute("""
+                INSERT INTO authority_violations (
+                    id, session_id, ts, tool, violation_type, declared_tools, allowed_tools
+                ) VALUES (?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT (id) DO UPDATE SET
+                    tool           = COALESCE(excluded.tool,           authority_violations.tool),
+                    violation_type = COALESCE(excluded.violation_type, authority_violations.violation_type),
+                    declared_tools = COALESCE(excluded.declared_tools, authority_violations.declared_tools),
+                    allowed_tools  = COALESCE(excluded.allowed_tools,  authority_violations.allowed_tools)
+            """, [
+                str(eid),
+                event.get("session_id"),
+                ts,
+                event.get("tool"),
+                event.get("violation_type", "tool_not_in_allowed_list"),
+                _json.dumps(declared) if isinstance(declared, list) else declared,
+                _json.dumps(allowed) if isinstance(allowed, list) else allowed,
+            ])
+
+    def query_authority_violations(
+        self,
+        *,
+        session_id: str | None = None,
+        since: str | None = None,
+        limit: int = 200,
+    ) -> list[dict[str, Any]]:
+        """Read authority-violation rows, most-recent first."""
+        clauses: list[str] = []
+        params: list[Any] = []
+        if session_id:
+            clauses.append("session_id = ?")
+            params.append(session_id)
+        if since:
+            clauses.append("ts >= ?")
+            params.append(since)
+        where = ("WHERE " + " AND ".join(clauses)) if clauses else ""
+        sql = f"""
+            SELECT id, session_id, ts, tool, violation_type, declared_tools, allowed_tools
+            FROM authority_violations
+            {where}
+            ORDER BY ts DESC, id
+            LIMIT ?
+        """
+        params.append(int(limit))
+        cols = ["id", "session_id", "ts", "tool", "violation_type",
+                "declared_tools", "allowed_tools"]
         return [dict(zip(cols, r)) for r in self._fetch(sql, params)]
 
     def query_nemoclaw_metrics(

--- a/clawmetry/proxy.py
+++ b/clawmetry/proxy.py
@@ -282,6 +282,20 @@ class AutoRoutingConfig:
 
 
 @dataclass
+class AuthorityConfig:
+    """Observe-only agent authority tracker (#3305).
+
+    When ``allowed_tools`` is non-empty, any request that declares a tool
+    not in the list is recorded as an ``authority_violation`` event in DuckDB.
+    Requests are NEVER blocked in v1 — observe only.
+    """
+
+    enabled: bool = False
+    allowed_tools: List[str] = field(default_factory=list)
+    allowed_hosts: List[str] = field(default_factory=list)
+
+
+@dataclass
 class RoutingRule:
     """Route requests matching a pattern to a different model."""
 
@@ -308,6 +322,7 @@ class ProxyConfig:
     rate_breaker: RateBreakerConfig = field(default_factory=RateBreakerConfig)
     cost_spiral: CostSpiralConfig = field(default_factory=CostSpiralConfig)
     auto_routing: AutoRoutingConfig = field(default_factory=AutoRoutingConfig)
+    authority: AuthorityConfig = field(default_factory=AuthorityConfig)
     routing_rules: List[RoutingRule] = field(default_factory=list)
     providers: Dict[str, ProviderConfig] = field(default_factory=dict)
     log_requests: bool = False
@@ -389,6 +404,14 @@ class ProxyConfig:
                         require_no_tools=ar.get("require_no_tools", True),
                         include_heartbeat=ar.get("include_heartbeat", True),
                         downgrade_map=ar.get("downgrade_map", {}) or {},
+                    )
+
+                if "authority" in raw:
+                    av = raw["authority"]
+                    config.authority = AuthorityConfig(
+                        enabled=av.get("enabled", False),
+                        allowed_tools=list(av.get("allowed_tools") or []),
+                        allowed_hosts=list(av.get("allowed_hosts") or []),
                     )
 
                 if "routing" in raw and "rules" in raw["routing"]:
@@ -482,6 +505,11 @@ class ProxyConfig:
                 "require_no_tools": self.auto_routing.require_no_tools,
                 "include_heartbeat": self.auto_routing.include_heartbeat,
                 "downgrade_map": self.auto_routing.downgrade_map,
+            },
+            "authority": {
+                "enabled": self.authority.enabled,
+                "allowed_tools": self.authority.allowed_tools,
+                "allowed_hosts": self.authority.allowed_hosts,
             },
             "routing": {
                 "rules": [
@@ -1448,6 +1476,46 @@ class CostSpiralBreaker:
         return False, ""
 
 
+# ── Authority Checker (tool-scope enforcement, observe-only) ───────────
+
+
+class AuthorityChecker:
+    """Observe-only checker: flags when an agent declares tools outside the
+    allowed list. Never blocks — violations are written to DuckDB so the
+    dashboard can surface them. Global-config v1 (#3305)."""
+
+    def __init__(self, config: AuthorityConfig):
+        self.config = config
+
+    def check(self, session_id: str, body: dict) -> list:
+        """Return a list of violating tool names (empty → no violation).
+
+        Only active when ``enabled=True`` and ``allowed_tools`` is non-empty.
+        Zero-copy: does not mutate *body*.
+        """
+        if not self.config.enabled or not self.config.allowed_tools:
+            return []
+        allowed = set(self.config.allowed_tools)
+        tools = body.get("tools") or []
+        if not isinstance(tools, list):
+            return []
+        violations = [
+            t["name"] for t in tools
+            if isinstance(t, dict) and t.get("name") and t["name"] not in allowed
+        ]
+        if violations:
+            _emit_duckdb_event("authority_violation", session_id, {
+                "violating_tools": violations,
+                "declared_tools":  [t.get("name") for t in tools if isinstance(t, dict)],
+                "allowed_tools":   self.config.allowed_tools,
+            })
+            logger.info(
+                "authority_violation session=%s tools=%s",
+                session_id, violations,
+            )
+        return violations
+
+
 # ── Model Router ───────────────────────────────────────────────────────
 
 
@@ -1681,6 +1749,7 @@ def create_proxy_app(config: ProxyConfig = None) -> "Flask":
     rate_breaker = RateBreaker(config.rate_breaker, db)
     cost_spiral_breaker = CostSpiralBreaker(config.cost_spiral, db)
     auto_router = AutoRouter(config.auto_routing)
+    authority_checker = AuthorityChecker(config.authority)
     router = ModelRouter(config.routing_rules)
 
     _stats = {
@@ -2069,6 +2138,18 @@ def create_proxy_app(config: ProxyConfig = None) -> "Flask":
             if "downgrade_map" in ar and isinstance(ar["downgrade_map"], dict):
                 config.auto_routing.downgrade_map = ar["downgrade_map"]
 
+        if "authority" in data:
+            av = data["authority"]
+            if "enabled" in av:
+                config.authority.enabled = bool(av["enabled"])
+                authority_checker.config.enabled = config.authority.enabled
+            if "allowed_tools" in av and isinstance(av["allowed_tools"], list):
+                config.authority.allowed_tools = list(av["allowed_tools"])
+                authority_checker.config.allowed_tools = config.authority.allowed_tools
+            if "allowed_hosts" in av and isinstance(av["allowed_hosts"], list):
+                config.authority.allowed_hosts = list(av["allowed_hosts"])
+                authority_checker.config.allowed_hosts = config.authority.allowed_hosts
+
         config.save()
         db.record_event(
             "config_updated",
@@ -2227,6 +2308,12 @@ def create_proxy_app(config: ProxyConfig = None) -> "Flask":
                 logger.warning(f"Cost spiral: {spiral_reason}")
                 _arm_backoff_pause(session_id, "cost_spiral", spiral_reason)
                 return _error_response(429, "cost_spiral", spiral_reason, provider)
+            # ── Authority checker (#3305): tool-scope observe-only ─────────
+            try:
+                authority_checker.check(session_id, body)
+            except Exception as _exc:  # noqa: BLE001 — never break enforcement
+                logger.debug("authority check skipped: %s", _exc)
+
             # ── Cache-bust risk (Headroom-inspired, #2839/#2840) ───────────
             # Detect prompts that self-bust the prompt cache: volatile content in the
             # cache-stable prefix (timestamps/UUIDs/JWTs) and prefix DRIFT turn over

--- a/routes/alerts.py
+++ b/routes/alerts.py
@@ -133,6 +133,27 @@ DEFAULT_ALERT_RULES = [
             "Catches genuine spinning, not just busy productive burn."
         ),
     },
+    # #3305 (authority tracking): fires when the proxy detects a tool
+    # declaration outside the operator's allowed_tools list. Off by default
+    # because allowed_tools is empty (= no restriction) until explicitly
+    # configured. Pro-only because it requires the enforcement proxy.
+    {
+        "id":           "authority_violation_default",
+        "type":         "authority_violation",
+        "event_type":   "authority_violation",
+        "window_hours": 24,
+        "threshold":    1,
+        "channels":     ["banner"],
+        "cooldown_min": 60,
+        "enabled":      False,
+        "pro_only":     True,
+        "label":        "Agent exceeded declared authority",
+        "description": (
+            "Fires when the proxy detects a tool declaration not in the "
+            "session's allowed_tools list. Configure allowed_tools in "
+            "proxy.json to activate. Observe-only: requests are never blocked."
+        ),
+    },
     # G3 of #1708 (Wolfgang burnout): the proxy now emits a structured
     # BUDGET_EXCEEDED abort signal when the daily cap is hit. This seed
     # rule surfaces those aborts in the alerts UI as an opt-in template

--- a/routes/health.py
+++ b/routes/health.py
@@ -3458,3 +3458,44 @@ def api_version_health():
         "regression": {"detected": False},
         "_source": "unavailable",
     })
+
+
+@bp_health.route("/api/authority-violations")
+def api_authority_violations():
+    """Return recent authority-violation events from the enforcement proxy (#3305).
+
+    Query params:
+      session_id — narrow to one session
+      since      — ISO timestamp lower bound
+      limit      — max rows (default 200)
+    """
+    session_id = (request.args.get("session_id") or "").strip() or None
+    since = (request.args.get("since") or "").strip() or None
+    try:
+        limit = max(1, min(1000, int(request.args.get("limit", 200))))
+    except (TypeError, ValueError):
+        limit = 200
+
+    rows = None
+    if is_local_store_read_enabled():
+        try:
+            from routes.local_query import local_store_via_daemon
+            rows = local_store_via_daemon(
+                "query_authority_violations",
+                session_id=session_id,
+                since=since,
+                limit=limit,
+            )
+        except Exception:
+            rows = None
+
+    if rows is None:
+        try:
+            from clawmetry import local_store as _ls
+            rows = _ls.get_store().query_authority_violations(
+                session_id=session_id, since=since, limit=limit
+            )
+        except Exception:
+            rows = []
+
+    return jsonify({"violations": rows or [], "total": len(rows or [])})


### PR DESCRIPTION
Closes #3305

## Summary

- Adds `AuthorityConfig` dataclass and `AuthorityChecker` to `clawmetry/proxy.py`. When `authority.enabled=true` and `allowed_tools` is non-empty, any LLM request that declares a tool outside that list is logged as an `authority_violation` event in DuckDB — **requests are never blocked in v1**, observe-only.
- Adds `authority_violations` DuckDB table + `ingest_authority_violation()` + `query_authority_violations()` to `local_store.py` (idempotent DDL, no schema-version bump).
- Adds `GET /api/authority-violations` to `routes/health.py` (reads via daemon proxy, same pattern as every other `bp_health` endpoint).
- Adds `authority_violation_default` seed rule to `routes/alerts.py` `DEFAULT_ALERT_RULES` (off by default, pro-only, one-click install from Alerts tab).

**Tradeoff:** v1 is global-config only — one `allowed_tools` list in `proxy.json` applies to all sessions. Per-session scope is the natural v2 follow-up.

## Test plan

- [ ] `python3 -c "import ast; ast.parse(open('clawmetry/proxy.py').read())"` — syntax clean
- [ ] `python3 -m pytest tests/test_proxy_enforcement.py -q` — 32 existing tests pass, no regressions
- [ ] Set `authority: {enabled: true, allowed_tools: ["read_file"]}` in `proxy.json`, send a request with `tools: [{name: "write_file"}]` via the proxy → expect one `authority_violation` row in `GET /api/authority-violations`
- [ ] Same request with `allowed_tools: []` (empty = no restriction) → no violation row
- [ ] `GET /api/authority-violations` returns `{violations: [], total: 0}` when no proxy is running

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q2TvAcsNxWhZbXKKc8e2qV)_