### PR TITLE
feat(entitlement): feature_catalog() + /api/features

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -185,6 +185,56 @@ ENTERPRISE_FEATURES = frozenset(
 
 ALL_FEATURES = FREE_FEATURES | PAID_FEATURES | ENTERPRISE_FEATURES
 
+# Display labels for every known feature. Mirrors what /pricing and the UI
+# settings surfaces render so the dashboard and the API agree on the human-
+# readable name. The frontend falls back to the feature id when a label is
+# missing, so adding a feature without a label is safe — but please add one.
+FEATURE_LABELS = {
+    # Free / core observability
+    "sessions": "Sessions",
+    "transcripts": "Transcripts",
+    "usage": "Usage",
+    "brain": "Brain",
+    "flow": "Flow",
+    "tracing": "Tracing",
+    "health": "Health",
+    "logs": "Logs",
+    "crons": "Crons",
+    "channels": "Channels",
+    "nemo_governance": "NeMo Governance",
+    "overview": "Overview",
+    # Starter
+    "multi_runtime": "Multi-Runtime",
+    "fleet": "Fleet View",
+    "cloud_sync": "Cloud Sync",
+    "all_channels": "All Channels",
+    "approval_queue": "Approval Queue",
+    "budget_limits": "Budget Limits",
+    "per_runtime_health_timeline": "Per-Runtime Health Timeline",
+    # Pro
+    "per_run_waste_flags": "Per-Run Waste Flags",
+    "per_run_compare": "Per-Run Compare",
+    "error_triage": "Error Triage",
+    "self_evolve": "Self-Evolve",
+    "asset_registry": "Asset Registry",
+    "eval_suite": "Eval Suite",
+    "tool_policy": "Tool Policy",
+    "otel_export": "OTel Export",
+    "custom_webhooks": "Custom Webhooks",
+    "custom_runtime_ingest": "Custom Runtime Ingest",
+    "custom_alerts": "Custom Alerts",
+    "alert_webhooks": "Alert Webhooks",
+    "anomaly_detection": "Anomaly Detection",
+    "cost_optimizer": "Cost Optimizer",
+    # Enterprise
+    "siem_export": "SIEM Export",
+    "sso": "SSO",
+    "audit_logs": "Audit Logs",
+    "rbac": "RBAC",
+    "air_gapped_license": "Air-Gapped License",
+    "custom_data_residency": "Custom Data Residency",
+}
+
 # Per-tier paid feature grants (free features are always included on top).
 _TIER_FEATURES = {
     TIER_OSS: frozenset(),
@@ -466,4 +516,71 @@ def runtime_catalog() -> list[dict]:
                 "locked": not allowed,
             }
         )
+    return out
+
+
+def feature_label(feature: str) -> str:
+    """Human-readable label for ``feature``. Falls back to the id when unknown
+    so unknown plugin features still render with *something*."""
+    fid = (feature or "").strip().lower()
+    return FEATURE_LABELS.get(fid, fid)
+
+
+# Per-bucket → tier identifier the feature_catalog row carries. The order
+# here is also the catalog's row order (free first, then starter, pro, and
+# enterprise) so the UI dropdown is deterministic.
+_FEATURE_BUCKETS = (
+    (FREE_FEATURES, TIER_OSS),
+    (STARTER_FEATURES, TIER_CLOUD_STARTER),
+    (PRO_ONLY_FEATURES, TIER_CLOUD_PRO),
+    (ENTERPRISE_FEATURES, TIER_ENTERPRISE),
+)
+
+
+def feature_catalog() -> list[dict]:
+    """The full feature catalog with the entitlement-derived availability for
+    each entry. Feature-side sibling of :func:`runtime_catalog` — single source
+    of truth the UI uses to render *every* known feature (including paid ones
+    on a free install) so the locked-but-visible upgrade affordance has data
+    to render against.
+
+    Each entry::
+
+        {
+          "id":      "<feature>",            # canonical key
+          "label":   "<Display Name>",       # falls back to id
+          "tier":    "oss" | "cloud_starter" # tier the feature first appears in
+                   | "cloud_pro" | "enterprise",
+          "free":    True | False,           # FREE_FEATURES membership
+          "allowed": True | False,           # entitlement allows it now
+          "locked":  True | False,           # paid + not allowed (UI shows 🔒)
+        }
+
+    Ordering: free features first, then starter, pro-only, and enterprise —
+    each bucket sorted alphabetically so the UI surface is deterministic.
+
+    Never raises; on any resolution error every paid feature is reported as
+    ``locked=False`` (grace) to match the OSS-free fallback in
+    :func:`get_entitlement`.
+    """
+    try:
+        ent = get_entitlement()
+    except Exception as exc:  # never crash a catalog read
+        logger.warning("entitlements: feature_catalog falling back to grace: %s", exc)
+        ent = _oss_free()
+    out: list[dict] = []
+    for bucket, tier in _FEATURE_BUCKETS:
+        for fid in sorted(bucket):
+            is_free = fid in FREE_FEATURES
+            allowed = ent.allows_feature(fid)
+            out.append(
+                {
+                    "id": fid,
+                    "label": feature_label(fid),
+                    "tier": tier,
+                    "free": is_free,
+                    "allowed": allowed,
+                    "locked": (not is_free) and (not allowed),
+                }
+            )
     return out

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -8,6 +8,7 @@ is the single source of truth — handlers never re-derive tier logic here.
 
   GET /api/entitlement — the current Entitlement as JSON.
   GET /api/runtimes    — the full runtime catalog with locked/free flags.
+  GET /api/features    — the full feature catalog with locked/free/tier flags.
 
 Side-effect-free and never-raise, so it is safe to classify ``oss-passthrough``
 on the cloud side: when no license/cloud plan is present it returns a graceful
@@ -106,6 +107,84 @@ def api_runtimes():
                         "allowed": True,
                         "locked": False,
                     },
+                ],
+                "grace": True,
+                "enforced": False,
+            }
+        )
+
+
+@bp_entitlement.route("/api/features")
+def api_features():
+    """Return the full feature catalog with per-feature ``free``/``allowed``/
+    ``locked``/``tier`` flags so the dashboard can render *every* known feature
+    in the settings + paywall surfaces — including paid ones on a free install
+    — and overlay a lock affordance on the locked rows once enforcement is on.
+
+    Feature-side sibling of ``/api/runtimes``: same envelope (``grace`` /
+    ``enforced`` mirror ``/api/entitlement``), same never-crash contract.
+
+    Shape::
+
+        {
+          "features": [
+            {"id": "sessions", "label": "Sessions",
+             "tier": "oss", "free": true,
+             "allowed": true, "locked": false},
+            {"id": "fleet", "label": "Fleet View",
+             "tier": "cloud_starter", "free": false,
+             "allowed": true,  # grace
+             "locked": false},
+            ...
+          ],
+          "grace":    true | false,   # mirrors /api/entitlement.grace
+          "enforced": true | false
+        }
+
+    Side-effect-free and never-raise: any resolution error falls back to a
+    grace OSS-free shape that still lists the free features so the UI has
+    something safe to render.
+    """
+    try:
+        from clawmetry import entitlements as _ent
+
+        ent = _ent.get_entitlement()
+        return jsonify(
+            {
+                "features": _ent.feature_catalog(),
+                "grace": ent.grace,
+                "enforced": not ent.grace,
+            }
+        )
+    except Exception as exc:  # never crash the dashboard over a gate read
+        logger.warning("api_features: falling back to OSS-free: %s", exc)
+        return jsonify(
+            {
+                "features": [
+                    {
+                        "id": fid,
+                        "label": fid,
+                        "tier": "oss",
+                        "free": True,
+                        "allowed": True,
+                        "locked": False,
+                    }
+                    for fid in sorted(
+                        [
+                            "sessions",
+                            "transcripts",
+                            "usage",
+                            "brain",
+                            "flow",
+                            "tracing",
+                            "health",
+                            "logs",
+                            "crons",
+                            "channels",
+                            "nemo_governance",
+                            "overview",
+                        ]
+                    )
                 ],
                 "grace": True,
                 "enforced": False,

--- a/tests/test_entitlements_feature_catalog.py
+++ b/tests/test_entitlements_feature_catalog.py
@@ -1,0 +1,187 @@
+"""Tests for ``feature_catalog()`` + ``feature_label()``.
+
+``feature_catalog`` is the feature-side sibling of ``runtime_catalog`` — the
+single shape the UI uses to render the locked-but-visible feature affordance
+on settings + paywall surfaces. Companion to
+``tests/test_entitlements_catalogue.py`` (which pins the underlying tier
+buckets to /pricing).
+
+Pins:
+
+* every id in ``ALL_FEATURES`` appears exactly once in the catalog
+* row ordering is free → starter → pro → enterprise; each bucket is sorted
+  alphabetically so the UI is deterministic
+* grace mode reports zero locked rows (zero behaviour change)
+* enforce-mode lock state on an OSS install locks every paid feature
+* every known feature has a non-empty label
+* ``feature_label`` falls back to the id for unknown features and is empty-
+  safe for missing input
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+
+_ROW_KEYS = {"id", "label", "tier", "free", "allowed", "locked"}
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    """Fresh entitlements module against an empty HOME so no real
+    ~/.clawmetry/license.key or cloud_plan.json leaks in. Enforcement off by
+    default (grace mode)."""
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+# ── shape ─────────────────────────────────────────────────────────────────────
+
+
+def test_catalog_lists_every_known_feature_exactly_once(ent):
+    cat = ent.feature_catalog()
+    ids = [row["id"] for row in cat]
+    assert set(ids) == set(ent.ALL_FEATURES)
+    assert len(ids) == len(set(ids))
+
+
+def test_catalog_row_shape_is_stable(ent):
+    for row in ent.feature_catalog():
+        assert set(row.keys()) == _ROW_KEYS, row
+        assert isinstance(row["id"], str) and row["id"]
+        assert isinstance(row["label"], str) and row["label"]
+        assert isinstance(row["tier"], str) and row["tier"]
+        assert isinstance(row["free"], bool)
+        assert isinstance(row["allowed"], bool)
+        assert isinstance(row["locked"], bool)
+        # locked = paid-and-not-allowed; mutually exclusive with free=True.
+        if row["free"]:
+            assert row["locked"] is False, row
+
+
+def test_catalog_ordering_is_free_starter_pro_enterprise(ent):
+    cat = ent.feature_catalog()
+    free = len(ent.FREE_FEATURES)
+    starter = len(ent.STARTER_FEATURES)
+    pro = len(ent.PRO_ONLY_FEATURES)
+    ent_n = len(ent.ENTERPRISE_FEATURES)
+    assert {r["id"] for r in cat[:free]} == set(ent.FREE_FEATURES)
+    assert {r["id"] for r in cat[free : free + starter]} == set(ent.STARTER_FEATURES)
+    assert {r["id"] for r in cat[free + starter : free + starter + pro]} == set(
+        ent.PRO_ONLY_FEATURES
+    )
+    assert {
+        r["id"] for r in cat[free + starter + pro : free + starter + pro + ent_n]
+    } == set(ent.ENTERPRISE_FEATURES)
+
+
+def test_catalog_bucket_rows_are_alphabetically_sorted(ent):
+    """Within each tier bucket the rows are sorted by id so the UI is
+    deterministic."""
+    cat = ent.feature_catalog()
+    free = len(ent.FREE_FEATURES)
+    starter = len(ent.STARTER_FEATURES)
+    pro = len(ent.PRO_ONLY_FEATURES)
+    slices = {
+        "free": [r["id"] for r in cat[:free]],
+        "starter": [r["id"] for r in cat[free : free + starter]],
+        "pro": [r["id"] for r in cat[free + starter : free + starter + pro]],
+        "enterprise": [r["id"] for r in cat[free + starter + pro :]],
+    }
+    for name, ids in slices.items():
+        assert ids == sorted(ids), name
+
+
+def test_catalog_tier_field_matches_bucket(ent):
+    by_id = {r["id"]: r for r in ent.feature_catalog()}
+    for fid in ent.FREE_FEATURES:
+        assert by_id[fid]["tier"] == ent.TIER_OSS, fid
+    for fid in ent.STARTER_FEATURES:
+        assert by_id[fid]["tier"] == ent.TIER_CLOUD_STARTER, fid
+    for fid in ent.PRO_ONLY_FEATURES:
+        assert by_id[fid]["tier"] == ent.TIER_CLOUD_PRO, fid
+    for fid in ent.ENTERPRISE_FEATURES:
+        assert by_id[fid]["tier"] == ent.TIER_ENTERPRISE, fid
+
+
+def test_catalog_free_flag_matches_membership(ent):
+    for row in ent.feature_catalog():
+        assert row["free"] == (row["id"] in ent.FREE_FEATURES), row
+
+
+# ── grace vs enforce ──────────────────────────────────────────────────────────
+
+
+def test_catalog_grace_locks_nothing(ent):
+    """Grace mode (the default until enforcement flips on): every row reports
+    ``locked=False``/``allowed=True`` so the UI behaves exactly as it did
+    before this endpoint existed."""
+    for row in ent.feature_catalog():
+        assert row["allowed"] is True, row
+        assert row["locked"] is False, row
+
+
+def test_catalog_enforced_oss_locks_every_paid_feature(ent, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    by_id = {r["id"]: r for r in ent.feature_catalog()}
+    for fid in ent.FREE_FEATURES:
+        assert by_id[fid]["allowed"] is True, fid
+        assert by_id[fid]["locked"] is False, fid
+    for fid in ent.STARTER_FEATURES | ent.PRO_ONLY_FEATURES | ent.ENTERPRISE_FEATURES:
+        assert by_id[fid]["allowed"] is False, fid
+        assert by_id[fid]["locked"] is True, fid
+
+
+# ── labels ────────────────────────────────────────────────────────────────────
+
+
+def test_every_known_feature_has_a_label(ent):
+    """Catches "added a feature but forgot the human-readable label". The UI
+    will still render the id as a fallback, but a deliberate label makes the
+    paywall copy readable."""
+    for fid in ent.ALL_FEATURES:
+        assert fid in ent.FEATURE_LABELS, fid
+        assert ent.FEATURE_LABELS[fid], fid
+
+
+def test_feature_label_falls_back_to_id(ent):
+    assert ent.feature_label("sessions") == "Sessions"
+    # Unknown feature → graceful fallback to the id so future plugin features
+    # still render with *something*.
+    assert ent.feature_label("brand_new_plugin_feature") == "brand_new_plugin_feature"
+    assert ent.feature_label("") == ""
+    assert ent.feature_label(None) == ""
+
+
+def test_feature_label_is_input_normalised(ent):
+    assert ent.feature_label("SESSIONS") == ent.feature_label("sessions")
+    assert ent.feature_label("  sessions  ") == ent.feature_label("sessions")
+
+
+# ── never-raise ───────────────────────────────────────────────────────────────
+
+
+def test_catalog_never_raises_when_resolver_crashes(ent, monkeypatch):
+    """A blown resolver still returns the catalog built against the OSS-free
+    fallback — matches the never-crash contract on ``runtime_catalog``."""
+
+    def boom(*_a, **_kw):
+        raise RuntimeError("simulated resolver failure")
+
+    monkeypatch.setattr(ent, "get_entitlement", boom)
+    cat = ent.feature_catalog()
+    assert isinstance(cat, list)
+    ids = {row["id"] for row in cat}
+    assert ids == set(ent.ALL_FEATURES)
+    # OSS-free fallback in grace mode → nothing locked.
+    for row in cat:
+        assert row["allowed"] is True, row
+        assert row["locked"] is False, row

--- a/tests/test_routes_features.py
+++ b/tests/test_routes_features.py
@@ -1,0 +1,153 @@
+"""Tests for the ``/api/features`` endpoint (``routes/entitlement.py``).
+
+The endpoint feeds the locked-but-visible feature affordance on the settings
+and paywall surfaces — every paid feature appears in the catalog even on a
+free install, with ``locked`` set from the resolved entitlement. Feature-side
+sibling of ``/api/runtimes`` (covered by ``tests/test_routes_runtimes.py``).
+
+The headline invariant: in GRACE mode (the default), every catalog row reports
+``locked=False`` so the UI behaves exactly as it did before this endpoint
+existed. ``CLAWMETRY_ENFORCE=1`` flips the paid rows to ``locked=True`` for an
+OSS install.
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def client(monkeypatch, tmp_path):
+    """Flask test client wired with bp_entitlement against a clean HOME."""
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+def test_features_grace_locks_nothing(client):
+    resp = client.get("/api/features")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["grace"] is True
+    assert data["enforced"] is False
+    by_id = {r["id"]: r for r in data["features"]}
+    # Sessions is always free.
+    assert by_id["sessions"]["free"] is True
+    assert by_id["sessions"]["locked"] is False
+    # Every published paid feature is present and not locked in grace mode.
+    for fid in (
+        "multi_runtime",
+        "fleet",
+        "self_evolve",
+        "otel_export",
+        "sso",
+        "audit_logs",
+        "rbac",
+    ):
+        assert fid in by_id, fid
+        assert by_id[fid]["free"] is False, fid
+        assert by_id[fid]["locked"] is False, fid
+        assert by_id[fid]["label"], fid  # never blank
+
+
+def test_features_enforced_oss_locks_paid(monkeypatch, tmp_path):
+    """When CLAWMETRY_ENFORCE=1 and no license/cloud plan is present every paid
+    feature is reported locked — the UI uses this to render the 🔒 affordance
+    on settings + paywall surfaces."""
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    c = app.test_client()
+    data = c.get("/api/features").get_json()
+    assert data["enforced"] is True
+    assert data["grace"] is False
+    by_id = {r["id"]: r for r in data["features"]}
+    assert by_id["sessions"]["locked"] is False  # free stays free
+    assert by_id["multi_runtime"]["locked"] is True  # starter
+    assert by_id["self_evolve"]["locked"] is True  # pro
+    assert by_id["sso"]["locked"] is True  # enterprise
+
+
+def test_features_shape_is_stable(client):
+    """Each row carries the keys the frontend reads — defends against an
+    accidental rename breaking settings/paywall surfaces."""
+    data = client.get("/api/features").get_json()
+    assert isinstance(data["features"], list)
+    for row in data["features"]:
+        for key in ("id", "label", "tier", "free", "allowed", "locked"):
+            assert key in row, row
+        assert isinstance(row["id"], str)
+        assert isinstance(row["label"], str)
+        assert isinstance(row["tier"], str)
+        assert isinstance(row["free"], bool)
+        assert isinstance(row["allowed"], bool)
+        assert isinstance(row["locked"], bool)
+        if row["free"]:
+            assert row["locked"] is False, row
+
+
+def test_features_tier_field_matches_bucket(client):
+    """Each row's ``tier`` reflects the tier bucket the feature first appears
+    in — drives the "STARTER+" / "PRO+" badges in the UI."""
+    import clawmetry.entitlements as e
+
+    data = client.get("/api/features").get_json()
+    by_id = {r["id"]: r for r in data["features"]}
+    for fid in e.FREE_FEATURES:
+        assert by_id[fid]["tier"] == e.TIER_OSS, fid
+    for fid in e.STARTER_FEATURES:
+        assert by_id[fid]["tier"] == e.TIER_CLOUD_STARTER, fid
+    for fid in e.PRO_ONLY_FEATURES:
+        assert by_id[fid]["tier"] == e.TIER_CLOUD_PRO, fid
+    for fid in e.ENTERPRISE_FEATURES:
+        assert by_id[fid]["tier"] == e.TIER_ENTERPRISE, fid
+
+
+def test_features_endpoint_never_5xxs_when_resolver_crashes(monkeypatch, tmp_path):
+    """A blown resolver still returns 200 with the OSS-free fallback shape so
+    the dashboard never sees a 5xx over a gate read."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+
+    def boom(*_a, **_kw):
+        raise RuntimeError("simulated resolver failure")
+
+    monkeypatch.setattr(e, "get_entitlement", boom)
+
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    c = app.test_client()
+    resp = c.get("/api/features")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["grace"] is True
+    assert data["enforced"] is False
+    assert isinstance(data["features"], list)
+    # Fallback lists at least the free features.
+    ids = {r["id"] for r in data["features"]}
+    for fid in ("sessions", "transcripts", "usage", "overview"):
+        assert fid in ids, fid


### PR DESCRIPTION
## Summary

Feature-side sibling of the existing `runtime_catalog()` / `/api/runtimes`. Single source of truth the UI uses to render *every* known feature on the settings + paywall surfaces — including paid ones on a free install — so the locked-but-visible upgrade affordance has data to render against. Pure symmetry with the runtime side; no behaviour gates flip.

## What's new

| File | Change |
|---|---|
| `clawmetry/entitlements.py` | `FEATURE_LABELS` table, `feature_label(feature)`, `feature_catalog()` |
| `routes/entitlement.py` | `GET /api/features` on `bp_entitlement` |
| `tests/test_entitlements_feature_catalog.py` | 12 tests pinning row shape, ordering, tier-bucket carriage, grace vs enforce, never-raise |
| `tests/test_routes_features.py` | 5 tests pinning the HTTP shape + fallback path |

### `feature_catalog()` row shape

```json
{
  "id":      "fleet",
  "label":   "Fleet View",
  "tier":    "cloud_starter",
  "free":    false,
  "allowed": true,   // grace mode -> everything allowed
  "locked":  false
}
```

- `tier` uses the existing `TIER_*` ids (`"oss" | "cloud_starter" | "cloud_pro" | "enterprise"`) so the row composes cleanly with the rest of the entitlement payload. Drives the `"STARTER+"` / `"PRO+"` badges in the UI.
- Ordering: free → starter → pro → enterprise, each bucket alphabetically sorted. Deterministic so the UI dropdown doesn't shuffle on reload.
- Every id in `ALL_FEATURES` appears exactly once (parity-test pinned).

### `/api/features`

Mirrors `/api/runtimes`:

```json
{
  "features": [ <row>, ... ],
  "grace":    true | false,
  "enforced": true | false
}
```

- Never 5xxs: a resolver crash short-circuits to a hand-rolled OSS-free shape carrying the 12 free features, so the dashboard always has something safe to render.
- Side-effect-free + never-raise, so it stays safe to classify `oss-passthrough` on the cloud side.

### Why this is grace-mode safe

Until enforcement flips on, `Entitlement.grace` is `True` and `allows_feature(...)` returns `True` for everything. Every catalog row therefore reports `allowed=true` / `locked=false` — wiring this in changes **no current behaviour**. The `CLAWMETRY_ENFORCE=1` path correctly flips every paid row to `locked=true` on an OSS install (test pins this).

## Test plan

- [x] `python3 -m pytest tests/test_entitlements_feature_catalog.py tests/test_routes_features.py -x -q` → **17 passed** in 0.35s
- [x] Adjacent regression sweep: `tests/test_entitlements.py`, `tests/test_entitlements_catalogue.py`, `tests/test_entitlement_api.py`, `tests/test_routes_runtimes.py` → **44 passed** in 0.46s
- [x] `ruff check clawmetry/entitlements.py routes/entitlement.py tests/test_entitlements_feature_catalog.py tests/test_routes_features.py` → **All checks passed!**
- [x] `python3 -m py_compile` on all four changed files

## Local operator verification checklist

The autonomous fire cannot touch the user's machine, the running daemon, `~/.openclaw`, the live cloud snapshot, or a browser. The following must be done by the local operator before flipping to ready-for-review:

- [ ] Copy changed files into the installed package:
      `cp clawmetry/entitlements.py ~/.clawmetry/lib/python*/site-packages/clawmetry/`
      `cp routes/entitlement.py ~/.clawmetry/lib/python*/site-packages/routes/`
- [ ] Clear bytecode: `find ~/.clawmetry/lib -name __pycache__ -exec rm -rf {} +`
- [ ] Kick the daemon: `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
- [ ] Hit the new endpoint and inspect the shape:
      `curl -s http://localhost:8900/api/features | jq '.grace,.enforced,.features|length'`
      `curl -s http://localhost:8900/api/features | jq '.features[] | select(.id=="sessions")'` → `tier: "oss"`, `free: true`, `locked: false`
      `curl -s http://localhost:8900/api/features | jq '.features[] | select(.id=="fleet")'` → `tier: "cloud_starter"`, `free: false`, in grace mode `locked: false`
      `curl -s http://localhost:8900/api/features | jq '.features[] | select(.id=="sso")'` → `tier: "enterprise"`, `free: false`
- [ ] Confirm grace mode reports `locked=false` on every row (zero behaviour change vs main).
- [ ] Set `CLAWMETRY_ENFORCE=1`, restart the daemon, and confirm every paid row flips to `locked=true` while free rows stay `locked=false`. **Unset** before returning to normal operation.
- [ ] Decrypt the live cloud snapshot and browser-check that no existing settings/paywall tooltip surface regressed (this endpoint is new and unconsumed, so the check is purely defensive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01WNgWAftfYGgJRVPX5TGTyo)_