### PR TITLE
feat(status): surface NemoClaw as free runtime in clawmetry status

### DIFF
--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -1727,6 +1727,13 @@ def _cmd_status(args) -> None:
             _det = []
         print("  Runtimes:")
         print("    🦞 OpenClaw            ✅ syncing  (free)")
+        try:
+            from clawmetry.adapters.nemo import NemoClawAdapter as _NCA
+            _nemo = _NCA().detect()
+            if _nemo.detected:
+                print("    ⚡ NemoClaw            ✅ syncing  (free)")
+        except Exception:
+            pass
         for _r in _det:
             _n = int(_r.get("sessionCount") or 0)
             _nm = _r.get("displayName") or _r.get("name") or "runtime"


### PR DESCRIPTION
Closes #3301

## What

`clawmetry status` lists paid runtimes detected by `clawmetry-pro` but silently omits NemoClaw, even though it's a free runtime like OpenClaw. A user with NemoClaw events in DuckDB had no indication it was being captured.

## Change

7 lines in `clawmetry/cli.py` — a guarded `try/except` block after the hardcoded OpenClaw line that:
1. Calls `NemoClawAdapter().detect()` (queries `COUNT(*) FROM events WHERE agent_type = 'nemoclaw'`)
2. Prints `⚡ NemoClaw  ✅ syncing  (free)` if events are present
3. Silently no-ops otherwise — `except Exception: pass` means it can never crash the status command

Before:
```
  Runtimes:
    🦞 OpenClaw            ✅ syncing  (free)
```

After (on a machine with NemoClaw data):
```
  Runtimes:
    🦞 OpenClaw            ✅ syncing  (free)
    ⚡ NemoClaw            ✅ syncing  (free)
```

## Test plan

- [ ] `python3 -c "import ast; ast.parse(open('clawmetry/cli.py').read())"` — syntax clean ✅
- [ ] `make lint` — no new warnings introduced ✅
- [ ] Manual: seed DuckDB with a `nemoclaw` event → `clawmetry status` shows the NemoClaw line
- [ ] Manual: on a machine with no NemoClaw events → status output unchanged

---
_Generated by [Claude Code](https://claude.ai/code/session_012u1D7e7gdoEGb5x9F3WTbE)_