### PR TITLE
feat(entitlement): feature_spec_batch + runtime_spec_batch + endpoints

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -3542,6 +3542,113 @@ def runtime_spec(runtime: str) -> dict | None:
         return None
 
 
+def feature_spec_batch(features) -> dict:
+    """Plural sibling of :func:`feature_spec`: return spec rows for a
+    caller-supplied subset of feature ids in one pass.
+
+    Where :func:`feature_catalog` returns rows for *every* known feature,
+    this lets a paywall matrix UI hydrate only the N rows it is about to
+    render off **one** round-trip instead of N calls to
+    ``/api/entitlement/feature-spec``. Each returned row is byte-identical
+    to a row from :func:`feature_catalog` -- a parity test pins this so
+    the scalar / bulk / batch accessors cannot drift.
+
+    Shape::
+
+        {
+          "features": [<spec_row>, ...],   # one per known supplied id, in supply order
+          "unknown":  ["bogus_id", ...],   # supplied ids not in ALL_FEATURES, in supply order
+        }
+
+    Supplied ids are normalised via :func:`_normalise_csv` (whitespace
+    stripped, lowercased, duplicates dropped while preserving first-seen
+    order) so the response is stable across repeated calls. Empty input
+    returns ``{"features": [], "unknown": []}`` -- the HTTP wrapper turns
+    that into a 400, this helper does not raise.
+
+    Grace mode (the default until enforcement flips on): every row reports
+    ``locked=False`` / ``allowed=True`` -- this helper does not invent
+    locks. Never raises: a resolver failure short-circuits to the OSS-free
+    fallback so the matrix keeps rendering.
+    """
+    feats = _normalise_csv(features)
+    try:
+        ent = get_entitlement()
+    except Exception as exc:
+        logger.warning("entitlements: feature_spec_batch falling back to grace: %s", exc)
+        ent = _oss_free()
+    rows: list[dict] = []
+    unknown: list[str] = []
+    for fid in feats:
+        if fid in ALL_FEATURES:
+            try:
+                rows.append(_feature_spec_row(ent, fid))
+            except Exception as exc:
+                logger.warning(
+                    "entitlements: feature_spec_batch row %r failed: %s", fid, exc
+                )
+                unknown.append(fid)
+        else:
+            unknown.append(fid)
+    return {"features": rows, "unknown": unknown}
+
+
+def runtime_spec_batch(runtimes) -> dict:
+    """Plural sibling of :func:`runtime_spec`: return spec rows for a
+    caller-supplied subset of runtime ids in one pass.
+
+    Mirrors :func:`feature_spec_batch` for the runtime axis. Lets a
+    runtime-matrix UI ("show me the lock state for the 4 runtimes
+    detected on this node") hydrate off **one** round-trip instead of N
+    calls to ``/api/entitlement/runtime-spec``. Each returned row is
+    byte-identical to a row from :func:`runtime_catalog`.
+
+    Supplied ids are normalised via :func:`_normalise_csv` and then
+    canonicalised via :func:`canonical_runtime`, so aliases (``claude-code``
+    -> ``claude_code``) resolve the same way they do on
+    ``/api/entitlement/runtime-spec``. Duplicates that collapse after
+    aliasing (e.g. ``claude-code,claude_code``) only contribute one row;
+    later aliases that already mapped to a seen canonical id drop into
+    the response in their first-seen position.
+
+    Shape::
+
+        {
+          "runtimes": [<spec_row>, ...],   # one per known supplied id, in (canonical) first-seen order
+          "unknown":  ["bogus_id", ...],   # supplied ids not in ALL_RUNTIMES after canonicalisation
+        }
+
+    Grace mode (the default until enforcement flips on): every row reports
+    ``locked=False`` / ``allowed=True``. Never raises: a resolver failure
+    short-circuits to the OSS-free fallback so the matrix keeps rendering.
+    """
+    rts = _normalise_csv(runtimes)
+    try:
+        ent = get_entitlement()
+    except Exception as exc:
+        logger.warning("entitlements: runtime_spec_batch falling back to grace: %s", exc)
+        ent = _oss_free()
+    rows: list[dict] = []
+    unknown: list[str] = []
+    seen: set[str] = set()
+    for raw in rts:
+        rt = canonical_runtime(raw)
+        if rt and rt in ALL_RUNTIMES:
+            if rt in seen:
+                continue
+            seen.add(rt)
+            try:
+                rows.append(_runtime_spec_row(ent, rt))
+            except Exception as exc:
+                logger.warning(
+                    "entitlements: runtime_spec_batch row %r failed: %s", rt, exc
+                )
+                unknown.append(raw)
+        else:
+            unknown.append(raw)
+    return {"runtimes": rows, "unknown": unknown}
+
+
 def tier_catalog() -> list[dict]:
     try:
         ent = get_entitlement()

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -2480,6 +2480,136 @@ def api_entitlement_runtime_spec():
         return jsonify({"error": "runtime-spec failed"}), 500
 
 
+@bp_entitlement.route("/api/entitlement/feature-spec-batch")
+def api_entitlement_feature_spec_batch():
+    """``GET /api/entitlement/feature-spec-batch?features=a,b,c`` -- plural
+    sibling of ``/api/entitlement/feature-spec``.
+
+    Returns the full catalogue spec row for every supplied feature id in
+    one round-trip. Mirrors the
+    ``scalar -> /feature-spec`` / ``batch -> /feature-spec-batch`` pair
+    that ``/lock-reason`` <-> ``/lock-reason-batch`` already establishes,
+    so a paywall matrix UI hydrates the N visible rows off one call
+    instead of N calls to ``/feature-spec``.
+
+    Each ``features[]`` entry is byte-identical to a row from
+    :func:`entitlements.feature_catalog` -- a parity test pins this so
+    the scalar / bulk / batch accessors cannot drift. Supplied ids are
+    normalised (whitespace stripped, lowercased, duplicates dropped while
+    preserving first-seen order). Unknown ids do not 404 the call --
+    they are echoed in ``unknown[]`` so a partially-bad caller still
+    gets rows back for the valid ids alongside a list of what was
+    dropped.
+
+    Response shape::
+
+        {
+          "features":          [<spec_row>, ...],
+          "unknown":           ["bogus_id", ...],
+          "current_tier":      "...",
+          "current_tier_rank": <int>,
+          "grace":             <bool>,
+          "enforced":          <bool>,
+        }
+
+    - **400** when ``features=`` is missing or empty after normalisation
+    - **Never 5xxs**: a resolver crash short-circuits to the OSS-free
+      shape (empty rows, ``current_tier=oss``, ``grace=true``).
+    """
+    try:
+        features = _parse_csv_arg("features")
+        if not features:
+            return (
+                jsonify({"error": "supply features=<csv>"}),
+                400,
+            )
+        from clawmetry import entitlements as _ent
+
+        batch = _ent.feature_spec_batch(features)
+        ent = _ent.get_entitlement()
+        batch["current_tier"] = ent.tier
+        batch["current_tier_rank"] = _ent.tier_rank(ent.tier)
+        batch["grace"] = bool(ent.grace)
+        batch["enforced"] = _ent.is_enforced()
+        return jsonify(batch)
+    except Exception as exc:
+        logger.warning("api_entitlement_feature_spec_batch: error: %s", exc)
+        return jsonify(
+            {
+                "features": [],
+                "unknown": [],
+                "current_tier": "oss",
+                "current_tier_rank": 0,
+                "grace": True,
+                "enforced": False,
+            }
+        )
+
+
+@bp_entitlement.route("/api/entitlement/runtime-spec-batch")
+def api_entitlement_runtime_spec_batch():
+    """``GET /api/entitlement/runtime-spec-batch?runtimes=a,b,c`` -- plural
+    sibling of ``/api/entitlement/runtime-spec``.
+
+    Returns the full catalogue spec row for every supplied runtime id in
+    one round-trip. Mirrors :func:`api_entitlement_feature_spec_batch` for
+    the runtime axis; together they let a Settings or paywall matrix UI
+    hydrate the per-row state ("lock badge + required tier + entitled
+    flag") for a viewport's worth of features + runtimes off TWO calls
+    instead of N + M.
+
+    Each ``runtimes[]`` entry is byte-identical to a row from
+    :func:`entitlements.runtime_catalog`. Aliases are canonicalised the
+    same way ``/api/entitlement/runtime-spec`` already does
+    (``claude-code`` -> ``claude_code``), and aliases that collapse to a
+    canonical id already in the response are silently de-duplicated so
+    the row count matches the unique-canonical-id count.
+
+    Response shape::
+
+        {
+          "runtimes":          [<spec_row>, ...],
+          "unknown":           ["bogus_id", ...],
+          "current_tier":      "...",
+          "current_tier_rank": <int>,
+          "grace":             <bool>,
+          "enforced":          <bool>,
+        }
+
+    - **400** when ``runtimes=`` is missing or empty after normalisation
+    - **Never 5xxs**: a resolver crash short-circuits to the OSS-free
+      shape (empty rows, ``current_tier=oss``, ``grace=true``).
+    """
+    try:
+        runtimes = _parse_csv_arg("runtimes")
+        if not runtimes:
+            return (
+                jsonify({"error": "supply runtimes=<csv>"}),
+                400,
+            )
+        from clawmetry import entitlements as _ent
+
+        batch = _ent.runtime_spec_batch(runtimes)
+        ent = _ent.get_entitlement()
+        batch["current_tier"] = ent.tier
+        batch["current_tier_rank"] = _ent.tier_rank(ent.tier)
+        batch["grace"] = bool(ent.grace)
+        batch["enforced"] = _ent.is_enforced()
+        return jsonify(batch)
+    except Exception as exc:
+        logger.warning("api_entitlement_runtime_spec_batch: error: %s", exc)
+        return jsonify(
+            {
+                "runtimes": [],
+                "unknown": [],
+                "current_tier": "oss",
+                "current_tier_rank": 0,
+                "grace": True,
+                "enforced": False,
+            }
+        )
+
+
 @bp_entitlement.route("/api/entitlement/affordable-tiers")
 def api_entitlement_affordable_tiers():
     """``GET /api/entitlement/affordable-tiers?features=a,b,c&runtimes=x,y

--- a/tests/test_entitlement_spec_batch.py
+++ b/tests/test_entitlement_spec_batch.py
@@ -1,0 +1,430 @@
+"""Tests for ``feature_spec_batch(features)`` / ``runtime_spec_batch(runtimes)``
+plus their HTTP endpoints.
+
+These are the plural / caller-subset siblings of ``feature_spec`` and
+``runtime_spec``: where the scalar accessors hydrate one row, the batch
+accessors hydrate the N rows a paywall matrix UI is about to render
+off a single round-trip. Each returned row must be byte-identical to a
+row from the corresponding catalogue (``feature_catalog`` /
+``runtime_catalog``) so the scalar / bulk / batch accessors cannot
+drift -- pinned by the parity tests below.
+
+Coverage:
+
+* row shape matches the catalogue (and matches the scalar ``_spec`` row)
+* input is normalised (whitespace stripped, lowercased, duplicates dropped,
+  first-seen order preserved)
+* unknown ids are echoed in ``unknown[]`` instead of 404'ing the call
+* runtime aliases canonicalise (``claude-code`` -> ``claude_code``) and
+  collapse against already-supplied canonical ids without double-emitting
+  a row
+* grace mode reports zero locked rows (zero behaviour change)
+* enforce-mode lock state matches what ``feature_catalog`` /
+  ``runtime_catalog`` already report for the same install
+* the helpers never raise -- a resolver crash short-circuits to the
+  OSS-free fallback so the matrix keeps rendering
+* the HTTP endpoints 400 on missing / empty input, never 5xx on a
+  resolver crash, and carry the standard ``grace`` / ``enforced`` /
+  ``current_tier`` / ``current_tier_rank`` envelope fields
+"""
+from __future__ import annotations
+
+import importlib
+import json
+
+import pytest
+
+
+_FEATURE_SPEC_KEYS = {
+    "id",
+    "label",
+    "tier",
+    "tiers",
+    "free",
+    "allowed",
+    "locked",
+    "entitled",
+    "alias",
+}
+
+_RUNTIME_SPEC_KEYS = {
+    "id",
+    "label",
+    "free",
+    "tier",
+    "tiers",
+    "allowed",
+    "locked",
+    "entitled",
+}
+
+_ENVELOPE_KEYS = {"current_tier", "current_tier_rank", "grace", "enforced"}
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    """Fresh entitlements module with HOME pointed at an empty tmp dir so no
+    real ~/.clawmetry/license.key or cloud_plan.json leaks in. Enforcement off
+    by default (grace mode)."""
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from flask import Flask
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# ── feature_spec_batch helper: shape + parity ────────────────────────────────
+
+
+def test_feature_batch_empty_input_returns_empty_envelope(ent):
+    body = ent.feature_spec_batch([])
+    assert body == {"features": [], "unknown": []}
+
+
+def test_feature_batch_none_input_returns_empty_envelope(ent):
+    body = ent.feature_spec_batch(None)
+    assert body == {"features": [], "unknown": []}
+
+
+def test_feature_batch_row_shape_matches_catalog(ent):
+    fid = next(iter(ent.FREE_FEATURES))
+    body = ent.feature_spec_batch([fid])
+    assert len(body["features"]) == 1
+    assert set(body["features"][0].keys()) == _FEATURE_SPEC_KEYS
+
+
+def test_feature_batch_every_row_matches_feature_spec_exactly(ent):
+    ids = sorted(ent.ALL_FEATURES)
+    body = ent.feature_spec_batch(ids)
+    rows_by_id = {row["id"]: row for row in body["features"]}
+    assert set(rows_by_id) == set(ids)
+    for fid in ids:
+        assert rows_by_id[fid] == ent.feature_spec(fid), fid
+
+
+def test_feature_batch_rows_match_feature_catalog(ent):
+    """Pin scalar / bulk / batch no-drift: every batch row is byte-identical
+    to the same row from feature_catalog()."""
+    cat_by_id = {row["id"]: row for row in ent.feature_catalog()}
+    ids = list(cat_by_id)
+    body = ent.feature_spec_batch(ids)
+    for row in body["features"]:
+        assert row == cat_by_id[row["id"]], row["id"]
+
+
+# ── feature_spec_batch helper: normalisation ─────────────────────────────────
+
+
+def test_feature_batch_supply_order_preserved(ent):
+    body = ent.feature_spec_batch(["sso", "sessions", "fleet"])
+    assert [r["id"] for r in body["features"]] == ["sso", "sessions", "fleet"]
+
+
+def test_feature_batch_string_csv_input(ent):
+    body = ent.feature_spec_batch("sessions,fleet,sso")
+    assert [r["id"] for r in body["features"]] == ["sessions", "fleet", "sso"]
+
+
+def test_feature_batch_whitespace_and_case_normalised(ent):
+    body = ent.feature_spec_batch(["  Sessions  ", "FLEET"])
+    assert [r["id"] for r in body["features"]] == ["sessions", "fleet"]
+
+
+def test_feature_batch_duplicates_dropped_first_seen_wins(ent):
+    body = ent.feature_spec_batch(["sessions", "sessions", "fleet", "sessions"])
+    assert [r["id"] for r in body["features"]] == ["sessions", "fleet"]
+
+
+def test_feature_batch_unknown_ids_echoed_in_unknown(ent):
+    body = ent.feature_spec_batch(["sessions", "nope_xyz", "also_bogus"])
+    assert [r["id"] for r in body["features"]] == ["sessions"]
+    assert body["unknown"] == ["nope_xyz", "also_bogus"]
+
+
+def test_feature_batch_unknown_only_returns_empty_features(ent):
+    body = ent.feature_spec_batch(["nope_xyz", "also_bogus"])
+    assert body["features"] == []
+    assert body["unknown"] == ["nope_xyz", "also_bogus"]
+
+
+# ── feature_spec_batch helper: grace vs enforce ──────────────────────────────
+
+
+def test_feature_batch_grace_locks_nothing(ent):
+    body = ent.feature_spec_batch(sorted(ent.ALL_FEATURES))
+    assert all(r["locked"] is False for r in body["features"])
+    assert all(r["allowed"] is True for r in body["features"])
+
+
+def test_feature_batch_enforce_oss_matches_catalog_locks(ent, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    cat_by_id = {row["id"]: row for row in ent.feature_catalog()}
+    body = ent.feature_spec_batch(sorted(cat_by_id))
+    for row in body["features"]:
+        assert row["locked"] == cat_by_id[row["id"]]["locked"], row["id"]
+        assert row["allowed"] == cat_by_id[row["id"]]["allowed"], row["id"]
+
+
+# ── feature_spec_batch helper: never-raise ───────────────────────────────────
+
+
+def test_feature_batch_never_raises_when_resolver_crashes(ent, monkeypatch):
+    def boom(*_a, **_kw):
+        raise RuntimeError("simulated resolver failure")
+
+    monkeypatch.setattr(ent, "get_entitlement", boom)
+    fid = next(iter(ent.FREE_FEATURES))
+    body = ent.feature_spec_batch([fid])
+    assert len(body["features"]) == 1
+    # Free feature stays free under the OSS-free fallback.
+    assert body["features"][0]["free"] is True
+
+
+# ── runtime_spec_batch helper: shape + parity ────────────────────────────────
+
+
+def test_runtime_batch_empty_input_returns_empty_envelope(ent):
+    assert ent.runtime_spec_batch([]) == {"runtimes": [], "unknown": []}
+
+
+def test_runtime_batch_row_shape_matches_catalog(ent):
+    body = ent.runtime_spec_batch(["openclaw"])
+    assert len(body["runtimes"]) == 1
+    assert set(body["runtimes"][0].keys()) == _RUNTIME_SPEC_KEYS
+
+
+def test_runtime_batch_every_row_matches_runtime_spec_exactly(ent):
+    ids = sorted(ent.ALL_RUNTIMES)
+    body = ent.runtime_spec_batch(ids)
+    rows_by_id = {row["id"]: row for row in body["runtimes"]}
+    assert set(rows_by_id) == set(ids)
+    for rt in ids:
+        assert rows_by_id[rt] == ent.runtime_spec(rt), rt
+
+
+def test_runtime_batch_rows_match_runtime_catalog(ent):
+    cat_by_id = {row["id"]: row for row in ent.runtime_catalog()}
+    body = ent.runtime_spec_batch(list(cat_by_id))
+    for row in body["runtimes"]:
+        assert row == cat_by_id[row["id"]], row["id"]
+
+
+# ── runtime_spec_batch helper: aliasing + de-dup ─────────────────────────────
+
+
+def test_runtime_batch_alias_canonicalises(ent):
+    body = ent.runtime_spec_batch(["claude-code"])
+    assert [r["id"] for r in body["runtimes"]] == ["claude_code"]
+
+
+def test_runtime_batch_alias_collapses_against_seen_canonical(ent):
+    """``claude-code`` and ``claude_code`` both normalise to the same id;
+    the row appears once, in first-seen position."""
+    body = ent.runtime_spec_batch(["claude-code", "claude_code", "openclaw"])
+    assert [r["id"] for r in body["runtimes"]] == ["claude_code", "openclaw"]
+
+
+def test_runtime_batch_unknown_ids_echoed_in_unknown(ent):
+    body = ent.runtime_spec_batch(["openclaw", "nope_runtime"])
+    assert [r["id"] for r in body["runtimes"]] == ["openclaw"]
+    assert body["unknown"] == ["nope_runtime"]
+
+
+def test_runtime_batch_whitespace_and_case_normalised(ent):
+    body = ent.runtime_spec_batch(["  Openclaw  ", "CLAUDE-CODE"])
+    assert [r["id"] for r in body["runtimes"]] == ["openclaw", "claude_code"]
+
+
+# ── runtime_spec_batch helper: grace vs enforce ──────────────────────────────
+
+
+def test_runtime_batch_grace_locks_nothing(ent):
+    body = ent.runtime_spec_batch(sorted(ent.ALL_RUNTIMES))
+    assert all(r["locked"] is False for r in body["runtimes"])
+    assert all(r["allowed"] is True for r in body["runtimes"])
+
+
+def test_runtime_batch_enforce_oss_locks_paid_runtimes(ent, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    body = ent.runtime_spec_batch(sorted(ent.ALL_RUNTIMES))
+    rows_by_id = {row["id"]: row for row in body["runtimes"]}
+    for rt in ent.FREE_RUNTIMES:
+        assert rows_by_id[rt]["locked"] is False, rt
+        assert rows_by_id[rt]["allowed"] is True, rt
+    for rt in ent.PAID_RUNTIMES:
+        assert rows_by_id[rt]["locked"] is True, rt
+        assert rows_by_id[rt]["allowed"] is False, rt
+
+
+# ── runtime_spec_batch helper: never-raise ───────────────────────────────────
+
+
+def test_runtime_batch_never_raises_when_resolver_crashes(ent, monkeypatch):
+    def boom(*_a, **_kw):
+        raise RuntimeError("simulated resolver failure")
+
+    monkeypatch.setattr(ent, "get_entitlement", boom)
+    body = ent.runtime_spec_batch(["openclaw"])
+    assert len(body["runtimes"]) == 1
+    assert body["runtimes"][0]["free"] is True
+
+
+# ── HTTP: feature-spec-batch endpoint ────────────────────────────────────────
+
+
+def test_endpoint_feature_batch_returns_rows_and_envelope(client, ent):
+    fid_free = next(iter(ent.FREE_FEATURES))
+    fid_paid = next(iter(ent.STARTER_FEATURES))
+    resp = client.get(
+        f"/api/entitlement/feature-spec-batch?features={fid_free},{fid_paid}"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert _ENVELOPE_KEYS <= set(body.keys())
+    assert [r["id"] for r in body["features"]] == [fid_free, fid_paid]
+    assert body["unknown"] == []
+    assert body["grace"] is True
+    assert body["enforced"] is False
+
+
+def test_endpoint_feature_batch_missing_arg_returns_400(client):
+    resp = client.get("/api/entitlement/feature-spec-batch")
+    assert resp.status_code == 400
+    assert "error" in resp.get_json()
+
+
+def test_endpoint_feature_batch_blank_arg_returns_400(client):
+    resp = client.get("/api/entitlement/feature-spec-batch?features=%20%20,%20")
+    assert resp.status_code == 400
+
+
+def test_endpoint_feature_batch_unknown_only_returns_200(client):
+    """Unknown ids alone do not 400 -- they normalise to a non-empty list
+    so the helper runs and returns ``unknown=[...]`` with empty features."""
+    resp = client.get(
+        "/api/entitlement/feature-spec-batch?features=not_a_feature,also_bogus"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["features"] == []
+    assert body["unknown"] == ["not_a_feature", "also_bogus"]
+
+
+def test_endpoint_feature_batch_lowercases_and_dedupes(client, ent):
+    fid = next(iter(ent.FREE_FEATURES))
+    resp = client.get(
+        f"/api/entitlement/feature-spec-batch?features={fid.upper()},{fid}"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert [r["id"] for r in body["features"]] == [fid]
+
+
+def test_endpoint_feature_batch_envelope_carries_resolved_tier(client, ent, monkeypatch, tmp_path):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    cache = tmp_path / ".clawmetry" / "cloud_plan.json"
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    cache.write_text(json.dumps({"plan": "cloud_pro"}))
+    ent.invalidate()
+    fid = next(iter(ent.STARTER_FEATURES))
+    resp = client.get(f"/api/entitlement/feature-spec-batch?features={fid}")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["current_tier"] == ent.TIER_CLOUD_PRO
+    assert body["current_tier_rank"] == ent.tier_rank(ent.TIER_CLOUD_PRO)
+    assert body["grace"] is False
+    assert body["enforced"] is True
+
+
+def test_endpoint_feature_batch_never_5xxs_when_resolver_crashes(
+    client, ent, monkeypatch
+):
+    def boom(*_a, **_kw):
+        raise RuntimeError("simulated resolver failure")
+
+    monkeypatch.setattr(ent, "get_entitlement", boom)
+    fid = next(iter(ent.FREE_FEATURES))
+    resp = client.get(f"/api/entitlement/feature-spec-batch?features={fid}")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    # Endpoint short-circuits to the OSS-free envelope on resolver failure.
+    assert body["current_tier"] == "oss"
+    assert body["grace"] is True
+    assert body["enforced"] is False
+
+
+# ── HTTP: runtime-spec-batch endpoint ────────────────────────────────────────
+
+
+def test_endpoint_runtime_batch_returns_rows_and_envelope(client):
+    resp = client.get(
+        "/api/entitlement/runtime-spec-batch?runtimes=openclaw,claude_code"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert _ENVELOPE_KEYS <= set(body.keys())
+    assert [r["id"] for r in body["runtimes"]] == ["openclaw", "claude_code"]
+    assert body["unknown"] == []
+    assert body["grace"] is True
+
+
+def test_endpoint_runtime_batch_missing_arg_returns_400(client):
+    resp = client.get("/api/entitlement/runtime-spec-batch")
+    assert resp.status_code == 400
+    assert "error" in resp.get_json()
+
+
+def test_endpoint_runtime_batch_blank_arg_returns_400(client):
+    resp = client.get("/api/entitlement/runtime-spec-batch?runtimes=%20%20")
+    assert resp.status_code == 400
+
+
+def test_endpoint_runtime_batch_alias_canonicalises(client):
+    resp = client.get(
+        "/api/entitlement/runtime-spec-batch?runtimes=claude-code"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert [r["id"] for r in body["runtimes"]] == ["claude_code"]
+
+
+def test_endpoint_runtime_batch_unknown_only_returns_200(client):
+    resp = client.get(
+        "/api/entitlement/runtime-spec-batch?runtimes=not_a_runtime"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["runtimes"] == []
+    assert body["unknown"] == ["not_a_runtime"]
+
+
+def test_endpoint_runtime_batch_never_5xxs_when_resolver_crashes(
+    client, ent, monkeypatch
+):
+    def boom(*_a, **_kw):
+        raise RuntimeError("simulated resolver failure")
+
+    monkeypatch.setattr(ent, "get_entitlement", boom)
+    resp = client.get(
+        "/api/entitlement/runtime-spec-batch?runtimes=openclaw"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["current_tier"] == "oss"
+    assert body["grace"] is True
+    assert body["enforced"] is False


### PR DESCRIPTION
## Summary

Plural / caller-subset siblings of `feature_spec` and `runtime_spec`. Where the scalar accessors hydrate one row, the batch accessors hydrate the N rows a paywall matrix UI is about to render off **one** round-trip instead of N calls. Closes the missing column on the live `(scalar | bulk catalog | live batch | what-if)` matrix for the feature + runtime axes.

| Axis | Scalar | Bulk (full set) | Caller-subset batch |
|---|---|---|---|
| feature, live | `feature_spec(f)` | `feature_catalog()` | **`feature_spec_batch(features)` — new** |
| runtime, live | `runtime_spec(r)` | `runtime_catalog()` | **`runtime_spec_batch(runtimes)` — new** |

Pairs with the `/lock-reason` → `/lock-reason-batch` shape already shipping. No behaviour gates flip.

## What's new

| File | Change |
|---|---|
| `clawmetry/entitlements.py` | `feature_spec_batch(features)`, `runtime_spec_batch(runtimes)` |
| `routes/entitlement.py` | `GET /api/entitlement/feature-spec-batch` + `GET /api/entitlement/runtime-spec-batch` on `bp_entitlement` |
| `tests/test_entitlement_spec_batch.py` | 38 tests pinning row shape, parity vs scalar + catalog, normalisation, alias canonicalisation, grace vs enforce, never-raise, HTTP contract |

### Helper shape

```json
{
  "features": [<spec_row>, ...],   // one per known supplied id, in supply order
  "unknown":  ["bogus_id", ...]    // ids dropped after normalisation (not in ALL_FEATURES)
}
```

- Each row is **byte-identical** to the same row from `feature_catalog()` / `runtime_catalog()` — both reuse the existing `_feature_spec_row` / `_runtime_spec_row` builders the scalar + catalog accessors already share, so all four (scalar / bulk catalog / live batch / what-if) cannot drift. Pinned by parity tests.
- Inputs normalise via `_normalise_csv`: whitespace stripped, lowercased, duplicates dropped while preserving first-seen order so the response is stable.
- Runtime aliases (`claude-code` → `claude_code`) canonicalise via `canonical_runtime`; aliases that collapse against an already-seen canonical id are silently de-duplicated so the row count matches the unique-canonical-id count.
- Unknown ids are echoed in `unknown[]` instead of failing the call — a partially-bad caller still gets rows back for the valid ids alongside a list of what was dropped.
- Never raises: a resolver crash short-circuits to the OSS-free fallback so the matrix keeps rendering.

### HTTP endpoints

```json
{
  "features":          [<spec_row>, ...],
  "unknown":           ["bogus_id", ...],
  "current_tier":      "...",
  "current_tier_rank": <int>,
  "grace":             <bool>,
  "enforced":          <bool>
}
```

Envelope adds `current_tier` / `current_tier_rank` / `grace` / `enforced` (matches the `/lock-reason-batch` envelope so a paywall surface can render lock chips + the resolved-tier banner off one call). **400** on missing / empty input after normalisation, **never 5xx** (resolver crash short-circuits to the OSS-free envelope).

### Why this is grace-mode safe

Until enforcement flips on, `Entitlement.grace` is `True` and `allows_feature(...)` / `allows_runtime(...)` return `True` for everything. Every batch row therefore reports `allowed=true` / `locked=false` — wiring this in changes **no current behaviour**. The `CLAWMETRY_ENFORCE=1` path correctly flips every paid row to `locked=true` (test pins this against the equivalent `feature_catalog()` / `runtime_catalog()` rows for the same install).

## Test plan

- [x] `python3 -m pytest tests/test_entitlement_spec_batch.py -x -q` → **38 passed** in 0.47s
- [x] Adjacent regression sweep: `tests/test_entitlement_feature_spec.py`, `tests/test_entitlement_runtime_spec.py`, `tests/test_entitlements.py`, `tests/test_entitlement_lock_reason_batch.py`, `tests/test_entitlements_catalogue.py` → **162 passed** in 1.44s
- [x] `ruff check clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_spec_batch.py` → **All checks passed!**
- [x] `python3 -m py_compile` on all three changed files

## Local operator verification checklist

The autonomous fire cannot touch the user's machine, the running daemon, `~/.openclaw`, the live cloud snapshot, or a browser. The following must be done by the local operator before flipping to ready-for-review:

- [ ] Copy changed files into the installed package:
      `cp clawmetry/entitlements.py ~/.clawmetry/lib/python*/site-packages/clawmetry/`
      `cp routes/entitlement.py ~/.clawmetry/lib/python*/site-packages/routes/`
- [ ] Clear bytecode: `find ~/.clawmetry/lib -name __pycache__ -exec rm -rf {} +`
- [ ] Kick the daemon: `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
- [ ] Hit the new endpoints and inspect shape:
      `curl -s 'http://localhost:8900/api/entitlement/feature-spec-batch?features=sessions,fleet,sso' | jq '.features[].id,.unknown,.current_tier,.grace,.enforced'`
      `curl -s 'http://localhost:8900/api/entitlement/runtime-spec-batch?runtimes=openclaw,claude-code,nope_runtime' | jq '.runtimes[].id,.unknown'` → second runtime id is `claude_code` (alias canonicalised), `unknown=["nope_runtime"]`
      `curl -s 'http://localhost:8900/api/entitlement/feature-spec-batch?features=sessions,SESSIONS,%20sessions%20' | jq '.features | length'` → `1` (dedup + normalisation)
      `curl -sw '%{http_code}\n' -o /dev/null 'http://localhost:8900/api/entitlement/feature-spec-batch'` → `400`
- [ ] Confirm parity with the scalar accessor:
      `curl -s 'http://localhost:8900/api/entitlement/feature-spec?feature=fleet' > /tmp/scalar.json`
      `curl -s 'http://localhost:8900/api/entitlement/feature-spec-batch?features=fleet' | jq '.features[0]' > /tmp/batch.json`
      `diff /tmp/scalar.json /tmp/batch.json` → empty diff
- [ ] Confirm `grace=true` on every row (zero behaviour change vs main).
- [ ] Set `CLAWMETRY_ENFORCE=1`, restart the daemon, and confirm paid rows flip to `locked=true` while free rows stay `locked=false`. **Unset** before returning to normal operation.
- [ ] Decrypt the live cloud snapshot and browser-check that no existing settings / paywall surface regressed (these endpoints are new and currently unconsumed, so this is purely defensive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PmNAJUPxCSfgJCwRb36kiM

---
_Generated by [Claude Code](https://claude.ai/code/session_01PmNAJUPxCSfgJCwRb36kiM)_