### PR TITLE
feat(entitlement): feature_spec_at_batch + runtime_spec_at_batch + endpoints

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -4079,6 +4079,137 @@ def runtime_spec_at(tier: str, runtime: str) -> dict | None:
         return None
 
 
+def feature_spec_at_batch(tier: str, features) -> dict | None:
+    """What-if + batch sibling of :func:`feature_spec_batch`: return spec
+    rows for a caller-supplied subset of feature ids, with ``allowed`` /
+    ``locked`` / ``entitled`` computed as if the install were on ``tier``.
+
+    Composes :func:`feature_spec_at` (scalar what-if) and
+    :func:`feature_spec_batch` (live batch) -- same shape as the batch
+    helper, same hypothetical perspective as the ``_at`` helper. Lets a
+    pricing-comparison matrix UI ("here is what 6 features look like on
+    Cloud Pro") hydrate the N visible rows off ONE round-trip instead of
+    N calls to :func:`feature_spec_at`.
+
+    Each returned row is byte-identical to a row from
+    :func:`feature_catalog_at` -- a parity test pins this so the scalar
+    what-if (`feature_spec_at`) and bulk what-if (`feature_catalog_at`)
+    and batch what-if accessors cannot drift.
+
+    Shape::
+
+        {
+          "features": [<spec_row>, ...],   # one per known supplied id, in supply order
+          "unknown":  ["bogus_id", ...],   # supplied ids not in ALL_FEATURES, in supply order
+        }
+
+    Returns ``None`` for empty / unknown ``tier`` (caller renders "unknown
+    tier" / 404). Supplied feature ids are normalised via
+    :func:`_normalise_csv`; an empty feature list returns
+    ``{"features": [], "unknown": []}`` -- the HTTP wrapper turns that
+    into a 400, this helper does not raise.
+
+    Never raises: a synthesis failure short-circuits to the OSS-free
+    fallback so the matrix keeps rendering.
+    """
+    try:
+        t = (tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if not t or t not in _TIER_ORDER:
+        return None
+    feats = _normalise_csv(features)
+    try:
+        ent = _hypothetical_entitlement(t)
+    except Exception as exc:
+        logger.warning(
+            "entitlements: feature_spec_at_batch falling back to OSS-free: %s", exc
+        )
+        ent = _oss_free()
+    rows: list[dict] = []
+    unknown: list[str] = []
+    for fid in feats:
+        if fid in ALL_FEATURES:
+            try:
+                rows.append(_feature_spec_row(ent, fid))
+            except Exception as exc:
+                logger.warning(
+                    "entitlements: feature_spec_at_batch row %r failed: %s",
+                    fid,
+                    exc,
+                )
+                unknown.append(fid)
+        else:
+            unknown.append(fid)
+    return {"features": rows, "unknown": unknown}
+
+
+def runtime_spec_at_batch(tier: str, runtimes) -> dict | None:
+    """What-if + batch sibling of :func:`runtime_spec_batch`: return spec
+    rows for a caller-supplied subset of runtime ids, with ``allowed`` /
+    ``locked`` / ``entitled`` computed as if the install were on ``tier``.
+
+    Mirrors :func:`feature_spec_at_batch` for the runtime axis; together
+    they let a pricing-comparison matrix UI hydrate a viewport's worth
+    of feature + runtime rows at a hypothetical tier off TWO calls
+    instead of N + M.
+
+    Aliases are canonicalised via :func:`canonical_runtime`
+    (``claude-code`` -> ``claude_code``) and aliases that collapse to a
+    canonical id already in the response are silently de-duplicated --
+    same behaviour as :func:`runtime_spec_batch`.
+
+    Each returned row is byte-identical to a row from
+    :func:`runtime_catalog_at` (parity-pinned by the tests below).
+
+    Shape::
+
+        {
+          "runtimes": [<spec_row>, ...],   # one per known supplied id, in (canonical) first-seen order
+          "unknown":  ["bogus_id", ...],   # supplied ids not in ALL_RUNTIMES after canonicalisation
+        }
+
+    Returns ``None`` for empty / unknown ``tier``. Never raises: a
+    synthesis failure short-circuits to the OSS-free fallback so the
+    matrix keeps rendering.
+    """
+    try:
+        t = (tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if not t or t not in _TIER_ORDER:
+        return None
+    rts = _normalise_csv(runtimes)
+    try:
+        ent = _hypothetical_entitlement(t)
+    except Exception as exc:
+        logger.warning(
+            "entitlements: runtime_spec_at_batch falling back to OSS-free: %s", exc
+        )
+        ent = _oss_free()
+    rows: list[dict] = []
+    unknown: list[str] = []
+    seen: set[str] = set()
+    for raw in rts:
+        rt = canonical_runtime(raw)
+        if rt and rt in ALL_RUNTIMES:
+            if rt in seen:
+                continue
+            seen.add(rt)
+            try:
+                rows.append(_runtime_spec_row(ent, rt))
+            except Exception as exc:
+                logger.warning(
+                    "entitlements: runtime_spec_at_batch row %r failed: %s",
+                    rt,
+                    exc,
+                )
+                unknown.append(raw)
+        else:
+            unknown.append(raw)
+    return {"runtimes": rows, "unknown": unknown}
+
+
 def lock_reason_at(
     perspective_tier: str, item: str, *, kind: str | None = None
 ) -> str | None:

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -2610,6 +2610,190 @@ def api_entitlement_runtime_spec_batch():
         )
 
 
+@bp_entitlement.route("/api/entitlement/feature-spec-at-batch")
+def api_entitlement_feature_spec_at_batch():
+    """``GET /api/entitlement/feature-spec-at-batch?tier=<perspective>
+    &features=a,b,c`` -- what-if + batch sibling of
+    ``/api/entitlement/feature-spec-batch``.
+
+    Where ``/feature-spec-batch`` returns batch rows against the LIVE
+    resolved entitlement, this returns them against a HYPOTHETICAL
+    ``perspective_tier``. Pairs with ``/feature-spec-at`` the same way
+    ``/feature-spec-batch`` pairs with ``/feature-spec``: scalar -> matrix
+    in one round-trip.
+
+    Use case: a pricing-comparison matrix UI ("here are the 6 features I
+    want to render at Cloud Pro") hydrates the visible rows off ONE call
+    instead of N calls to ``/feature-spec-at``.
+
+    Each ``features[]`` entry is byte-identical to a row from
+    :func:`entitlements.feature_catalog_at` -- pinned by the parity
+    tests so the scalar / bulk / batch what-if accessors cannot drift.
+    Supplied ids are normalised (whitespace stripped, lowercased,
+    duplicates dropped, first-seen order preserved). Unknown ids do not
+    404 the call -- they are echoed in ``unknown[]`` so a partially-bad
+    caller still gets rows back for the valid ids alongside a list of
+    what was dropped.
+
+    Response shape (mirrors ``/feature-spec-batch`` plus a
+    ``perspective_tier`` echo for caller round-trip safety)::
+
+        {
+          "features":              [<spec_row>, ...],
+          "unknown":               ["bogus_id", ...],
+          "perspective_tier":      "...",
+          "perspective_tier_rank": <int>,
+          "current_tier":          "...",
+          "current_tier_rank":     <int>,
+          "grace":                 <bool>,
+          "enforced":              <bool>,
+        }
+
+    - **400** when ``tier=`` is missing / blank or ``features=`` is
+      missing / empty after normalisation
+    - **404** when ``tier`` is unknown (body carries ``which: "tier"``)
+    - **Never 5xxs**: a synthesis failure short-circuits to the OSS-free
+      shape (empty rows, ``current_tier=oss``, ``grace=true``) with the
+      perspective tier echoed so the UI keeps rendering.
+    """
+    raw_tier = request.args.get("tier")
+    tier_in = (raw_tier or "").strip().lower()
+    if not tier_in:
+        return jsonify({"error": "missing tier"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        if tier_in not in _ent._TIER_ORDER:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "tier", "tier": tier_in}
+                ),
+                404,
+            )
+        features = _parse_csv_arg("features")
+        if not features:
+            return (
+                jsonify({"error": "supply features=<csv>"}),
+                400,
+            )
+        batch = _ent.feature_spec_at_batch(tier_in, features)
+        if batch is None:
+            batch = {"features": [], "unknown": []}
+        ent = _ent.get_entitlement()
+        batch["perspective_tier"] = tier_in
+        batch["perspective_tier_rank"] = _ent.tier_rank(tier_in)
+        batch["current_tier"] = ent.tier
+        batch["current_tier_rank"] = _ent.tier_rank(ent.tier)
+        batch["grace"] = bool(ent.grace)
+        batch["enforced"] = _ent.is_enforced()
+        return jsonify(batch)
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_feature_spec_at_batch: error: %s", exc
+        )
+        return jsonify(
+            {
+                "features": [],
+                "unknown": [],
+                "perspective_tier": tier_in,
+                "perspective_tier_rank": 0,
+                "current_tier": "oss",
+                "current_tier_rank": 0,
+                "grace": True,
+                "enforced": False,
+            }
+        )
+
+
+@bp_entitlement.route("/api/entitlement/runtime-spec-at-batch")
+def api_entitlement_runtime_spec_at_batch():
+    """``GET /api/entitlement/runtime-spec-at-batch?tier=<perspective>
+    &runtimes=a,b,c`` -- what-if + batch sibling of
+    ``/api/entitlement/runtime-spec-batch``.
+
+    Mirrors :func:`api_entitlement_feature_spec_at_batch` for the
+    runtime axis; together they let a pricing-comparison matrix UI
+    hydrate per-row state for a viewport's worth of features + runtimes
+    at a hypothetical tier off TWO calls instead of N + M calls to
+    ``/feature-spec-at`` + ``/runtime-spec-at``.
+
+    Each ``runtimes[]`` entry is byte-identical to a row from
+    :func:`entitlements.runtime_catalog_at`. Aliases are canonicalised
+    the same way ``/runtime-spec`` already does (``claude-code`` ->
+    ``claude_code``), and aliases that collapse to a canonical id
+    already in the response are silently de-duplicated so the row count
+    matches the unique-canonical-id count.
+
+    Response shape (mirrors ``/runtime-spec-batch`` plus a
+    ``perspective_tier`` echo)::
+
+        {
+          "runtimes":              [<spec_row>, ...],
+          "unknown":               ["bogus_id", ...],
+          "perspective_tier":      "...",
+          "perspective_tier_rank": <int>,
+          "current_tier":          "...",
+          "current_tier_rank":     <int>,
+          "grace":                 <bool>,
+          "enforced":              <bool>,
+        }
+
+    - **400** when ``tier=`` is missing / blank or ``runtimes=`` is
+      missing / empty after normalisation
+    - **404** when ``tier`` is unknown (body carries ``which: "tier"``)
+    - **Never 5xxs**: a synthesis failure short-circuits to the OSS-free
+      shape (empty rows, ``current_tier=oss``, ``grace=true``) with the
+      perspective tier echoed.
+    """
+    raw_tier = request.args.get("tier")
+    tier_in = (raw_tier or "").strip().lower()
+    if not tier_in:
+        return jsonify({"error": "missing tier"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        if tier_in not in _ent._TIER_ORDER:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "tier", "tier": tier_in}
+                ),
+                404,
+            )
+        runtimes = _parse_csv_arg("runtimes")
+        if not runtimes:
+            return (
+                jsonify({"error": "supply runtimes=<csv>"}),
+                400,
+            )
+        batch = _ent.runtime_spec_at_batch(tier_in, runtimes)
+        if batch is None:
+            batch = {"runtimes": [], "unknown": []}
+        ent = _ent.get_entitlement()
+        batch["perspective_tier"] = tier_in
+        batch["perspective_tier_rank"] = _ent.tier_rank(tier_in)
+        batch["current_tier"] = ent.tier
+        batch["current_tier_rank"] = _ent.tier_rank(ent.tier)
+        batch["grace"] = bool(ent.grace)
+        batch["enforced"] = _ent.is_enforced()
+        return jsonify(batch)
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_runtime_spec_at_batch: error: %s", exc
+        )
+        return jsonify(
+            {
+                "runtimes": [],
+                "unknown": [],
+                "perspective_tier": tier_in,
+                "perspective_tier_rank": 0,
+                "current_tier": "oss",
+                "current_tier_rank": 0,
+                "grace": True,
+                "enforced": False,
+            }
+        )
+
+
 @bp_entitlement.route("/api/entitlement/affordable-tiers")
 def api_entitlement_affordable_tiers():
     """``GET /api/entitlement/affordable-tiers?features=a,b,c&runtimes=x,y

--- a/tests/test_entitlement_spec_at_batch.py
+++ b/tests/test_entitlement_spec_at_batch.py
@@ -1,0 +1,592 @@
+"""Tests for ``feature_spec_at_batch(tier, features)`` /
+``runtime_spec_at_batch(tier, runtimes)`` plus their HTTP endpoints.
+
+These are the what-if + batch siblings of ``feature_spec_at`` /
+``runtime_spec_at``: where the scalar what-if accessors hydrate one row
+at a hypothetical tier, the batch what-if accessors hydrate the N rows a
+pricing-comparison matrix UI is about to render off a single round-trip.
+
+Each returned row must be byte-identical to a row from the corresponding
+``_catalog_at`` accessor (``feature_catalog_at`` / ``runtime_catalog_at``)
+so the scalar what-if / bulk what-if / batch what-if accessors cannot
+drift -- pinned by the parity tests below.
+
+Coverage:
+
+* row shape matches the catalog (and matches the scalar ``_spec_at`` row)
+* perspective tier really shifts the ``allowed`` / ``locked`` / ``entitled``
+  fields (paid feature locked at OSS but allowed at Cloud Pro)
+* input is normalised (whitespace stripped, lowercased, duplicates dropped,
+  first-seen order preserved)
+* unknown ids are echoed in ``unknown[]`` instead of 404'ing the call
+* runtime aliases canonicalise (``claude-code`` -> ``claude_code``) and
+  collapse against already-supplied canonical ids without double-emitting
+  a row
+* unknown / blank ``tier`` returns ``None`` (helper) / 400 / 404 (HTTP)
+* the helpers never raise -- a resolver crash short-circuits to the
+  OSS-free fallback so the matrix keeps rendering
+* the HTTP endpoints 400 on missing / empty input, 404 on unknown tier,
+  never 5xx on a resolver crash, and carry the standard ``grace`` /
+  ``enforced`` / ``current_tier`` / ``current_tier_rank`` envelope plus
+  ``perspective_tier`` / ``perspective_tier_rank``.
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+
+_FEATURE_SPEC_KEYS = {
+    "id",
+    "label",
+    "tier",
+    "tiers",
+    "free",
+    "allowed",
+    "locked",
+    "entitled",
+    "alias",
+}
+
+_RUNTIME_SPEC_KEYS = {
+    "id",
+    "label",
+    "free",
+    "tier",
+    "tiers",
+    "allowed",
+    "locked",
+    "entitled",
+}
+
+_ENVELOPE_KEYS = {
+    "perspective_tier",
+    "perspective_tier_rank",
+    "current_tier",
+    "current_tier_rank",
+    "grace",
+    "enforced",
+}
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    """Fresh entitlements module with HOME pointed at an empty tmp dir so no
+    real ~/.clawmetry/license.key or cloud_plan.json leaks in. Enforcement
+    off by default (grace mode); the helpers still synthesise a non-grace
+    hypothetical entitlement under the perspective tier so the ``locked``
+    flags actually reflect the per-tier grant."""
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from flask import Flask
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# ── feature_spec_at_batch helper: tier handling ──────────────────────────────
+
+
+def test_feature_at_batch_unknown_tier_returns_none(ent):
+    assert ent.feature_spec_at_batch("nope_tier", ["sessions"]) is None
+
+
+def test_feature_at_batch_blank_tier_returns_none(ent):
+    assert ent.feature_spec_at_batch("", ["sessions"]) is None
+    assert ent.feature_spec_at_batch("  ", ["sessions"]) is None
+
+
+def test_feature_at_batch_none_tier_returns_none(ent):
+    assert ent.feature_spec_at_batch(None, ["sessions"]) is None
+
+
+def test_feature_at_batch_int_tier_returns_none(ent):
+    # Bad type must not raise.
+    assert ent.feature_spec_at_batch(123, ["sessions"]) is None
+
+
+# ── feature_spec_at_batch helper: shape + parity ─────────────────────────────
+
+
+def test_feature_at_batch_empty_features_returns_empty_envelope(ent):
+    body = ent.feature_spec_at_batch(ent.TIER_CLOUD_PRO, [])
+    assert body == {"features": [], "unknown": []}
+
+
+def test_feature_at_batch_none_features_returns_empty_envelope(ent):
+    body = ent.feature_spec_at_batch(ent.TIER_CLOUD_PRO, None)
+    assert body == {"features": [], "unknown": []}
+
+
+def test_feature_at_batch_row_shape_matches_catalog(ent):
+    fid = next(iter(ent.FREE_FEATURES))
+    body = ent.feature_spec_at_batch(ent.TIER_CLOUD_PRO, [fid])
+    assert len(body["features"]) == 1
+    assert set(body["features"][0].keys()) == _FEATURE_SPEC_KEYS
+
+
+def test_feature_at_batch_every_row_matches_feature_spec_at_exactly(ent):
+    """Pin scalar / batch no-drift: every batch row equals the scalar
+    ``feature_spec_at`` row for the same tier + id."""
+    ids = sorted(ent.ALL_FEATURES)
+    body = ent.feature_spec_at_batch(ent.TIER_CLOUD_PRO, ids)
+    rows_by_id = {row["id"]: row for row in body["features"]}
+    assert set(rows_by_id) == set(ids)
+    for fid in ids:
+        assert rows_by_id[fid] == ent.feature_spec_at(ent.TIER_CLOUD_PRO, fid), fid
+
+
+def test_feature_at_batch_rows_match_feature_catalog_at(ent):
+    """Pin bulk / batch no-drift: every batch row is byte-identical to the
+    same row from ``feature_catalog_at(tier)``."""
+    cat_by_id = {
+        row["id"]: row for row in ent.feature_catalog_at(ent.TIER_CLOUD_PRO)
+    }
+    body = ent.feature_spec_at_batch(ent.TIER_CLOUD_PRO, list(cat_by_id))
+    for row in body["features"]:
+        assert row == cat_by_id[row["id"]], row["id"]
+
+
+# ── feature_spec_at_batch helper: perspective shifts ─────────────────────────
+
+
+def test_feature_at_batch_paid_feature_locked_at_oss_allowed_at_pro(ent):
+    fid = next(iter(ent.STARTER_FEATURES))
+    at_oss = ent.feature_spec_at_batch(ent.TIER_OSS, [fid])
+    at_pro = ent.feature_spec_at_batch(ent.TIER_CLOUD_PRO, [fid])
+    assert at_oss["features"][0]["locked"] is True
+    assert at_oss["features"][0]["allowed"] is False
+    assert at_pro["features"][0]["locked"] is False
+    assert at_pro["features"][0]["allowed"] is True
+
+
+def test_feature_at_batch_free_feature_always_allowed(ent):
+    fid = next(iter(ent.FREE_FEATURES))
+    for tier in (ent.TIER_OSS, ent.TIER_CLOUD_STARTER, ent.TIER_CLOUD_PRO):
+        body = ent.feature_spec_at_batch(tier, [fid])
+        assert body["features"][0]["allowed"] is True
+        assert body["features"][0]["locked"] is False
+
+
+# ── feature_spec_at_batch helper: normalisation ──────────────────────────────
+
+
+def test_feature_at_batch_supply_order_preserved(ent):
+    body = ent.feature_spec_at_batch(
+        ent.TIER_CLOUD_PRO, ["sso", "sessions", "fleet"]
+    )
+    assert [r["id"] for r in body["features"]] == ["sso", "sessions", "fleet"]
+
+
+def test_feature_at_batch_string_csv_input(ent):
+    body = ent.feature_spec_at_batch(
+        ent.TIER_CLOUD_PRO, "sessions,fleet,sso"
+    )
+    assert [r["id"] for r in body["features"]] == ["sessions", "fleet", "sso"]
+
+
+def test_feature_at_batch_whitespace_and_case_normalised(ent):
+    body = ent.feature_spec_at_batch(
+        ent.TIER_CLOUD_PRO, ["  Sessions  ", "FLEET"]
+    )
+    assert [r["id"] for r in body["features"]] == ["sessions", "fleet"]
+
+
+def test_feature_at_batch_duplicates_dropped_first_seen_wins(ent):
+    body = ent.feature_spec_at_batch(
+        ent.TIER_CLOUD_PRO, ["sessions", "sessions", "fleet", "sessions"]
+    )
+    assert [r["id"] for r in body["features"]] == ["sessions", "fleet"]
+
+
+def test_feature_at_batch_tier_whitespace_and_case_normalised(ent):
+    body = ent.feature_spec_at_batch(
+        "  CLOUD_PRO  ", ["sessions"]
+    )
+    assert body is not None
+    assert body["features"][0]["id"] == "sessions"
+
+
+def test_feature_at_batch_unknown_ids_echoed_in_unknown(ent):
+    body = ent.feature_spec_at_batch(
+        ent.TIER_CLOUD_PRO, ["sessions", "nope_xyz", "also_bogus"]
+    )
+    assert [r["id"] for r in body["features"]] == ["sessions"]
+    assert body["unknown"] == ["nope_xyz", "also_bogus"]
+
+
+def test_feature_at_batch_unknown_only_returns_empty_features(ent):
+    body = ent.feature_spec_at_batch(
+        ent.TIER_CLOUD_PRO, ["nope_xyz", "also_bogus"]
+    )
+    assert body["features"] == []
+    assert body["unknown"] == ["nope_xyz", "also_bogus"]
+
+
+# ── feature_spec_at_batch helper: never-raise ────────────────────────────────
+
+
+def test_feature_at_batch_never_raises_when_synth_crashes(ent, monkeypatch):
+    def boom(*_a, **_kw):
+        raise RuntimeError("simulated synth failure")
+
+    monkeypatch.setattr(ent, "_hypothetical_entitlement", boom)
+    fid = next(iter(ent.FREE_FEATURES))
+    body = ent.feature_spec_at_batch(ent.TIER_CLOUD_PRO, [fid])
+    assert len(body["features"]) == 1
+    # Free feature stays free under the OSS-free fallback.
+    assert body["features"][0]["free"] is True
+
+
+# ── runtime_spec_at_batch helper: tier handling ──────────────────────────────
+
+
+def test_runtime_at_batch_unknown_tier_returns_none(ent):
+    assert ent.runtime_spec_at_batch("nope_tier", ["openclaw"]) is None
+
+
+def test_runtime_at_batch_blank_tier_returns_none(ent):
+    assert ent.runtime_spec_at_batch("", ["openclaw"]) is None
+    assert ent.runtime_spec_at_batch("  ", ["openclaw"]) is None
+
+
+def test_runtime_at_batch_none_tier_returns_none(ent):
+    assert ent.runtime_spec_at_batch(None, ["openclaw"]) is None
+
+
+# ── runtime_spec_at_batch helper: shape + parity ─────────────────────────────
+
+
+def test_runtime_at_batch_empty_runtimes_returns_empty_envelope(ent):
+    body = ent.runtime_spec_at_batch(ent.TIER_CLOUD_PRO, [])
+    assert body == {"runtimes": [], "unknown": []}
+
+
+def test_runtime_at_batch_row_shape_matches_catalog(ent):
+    body = ent.runtime_spec_at_batch(ent.TIER_CLOUD_PRO, ["openclaw"])
+    assert len(body["runtimes"]) == 1
+    assert set(body["runtimes"][0].keys()) == _RUNTIME_SPEC_KEYS
+
+
+def test_runtime_at_batch_every_row_matches_runtime_spec_at_exactly(ent):
+    ids = sorted(ent.ALL_RUNTIMES)
+    body = ent.runtime_spec_at_batch(ent.TIER_CLOUD_PRO, ids)
+    rows_by_id = {row["id"]: row for row in body["runtimes"]}
+    assert set(rows_by_id) == set(ids)
+    for rt in ids:
+        assert rows_by_id[rt] == ent.runtime_spec_at(ent.TIER_CLOUD_PRO, rt), rt
+
+
+def test_runtime_at_batch_rows_match_runtime_catalog_at(ent):
+    cat_by_id = {
+        row["id"]: row for row in ent.runtime_catalog_at(ent.TIER_CLOUD_PRO)
+    }
+    body = ent.runtime_spec_at_batch(ent.TIER_CLOUD_PRO, list(cat_by_id))
+    for row in body["runtimes"]:
+        assert row == cat_by_id[row["id"]], row["id"]
+
+
+# ── runtime_spec_at_batch helper: perspective shifts ─────────────────────────
+
+
+def test_runtime_at_batch_paid_runtime_locked_at_oss(ent):
+    """All PAID_RUNTIMES are locked at the OSS perspective; FREE_RUNTIMES
+    stay free."""
+    body = ent.runtime_spec_at_batch(ent.TIER_OSS, sorted(ent.ALL_RUNTIMES))
+    rows_by_id = {row["id"]: row for row in body["runtimes"]}
+    for rt in ent.FREE_RUNTIMES:
+        assert rows_by_id[rt]["locked"] is False, rt
+        assert rows_by_id[rt]["allowed"] is True, rt
+    for rt in ent.PAID_RUNTIMES:
+        assert rows_by_id[rt]["locked"] is True, rt
+        assert rows_by_id[rt]["allowed"] is False, rt
+
+
+def test_runtime_at_batch_paid_runtime_allowed_at_pro(ent):
+    body = ent.runtime_spec_at_batch(
+        ent.TIER_CLOUD_PRO, sorted(ent.ALL_RUNTIMES)
+    )
+    for row in body["runtimes"]:
+        assert row["allowed"] is True, row["id"]
+        assert row["locked"] is False, row["id"]
+
+
+# ── runtime_spec_at_batch helper: aliasing + de-dup ──────────────────────────
+
+
+def test_runtime_at_batch_alias_canonicalises(ent):
+    body = ent.runtime_spec_at_batch(ent.TIER_CLOUD_PRO, ["claude-code"])
+    assert [r["id"] for r in body["runtimes"]] == ["claude_code"]
+
+
+def test_runtime_at_batch_alias_collapses_against_seen_canonical(ent):
+    body = ent.runtime_spec_at_batch(
+        ent.TIER_CLOUD_PRO, ["claude-code", "claude_code", "openclaw"]
+    )
+    assert [r["id"] for r in body["runtimes"]] == ["claude_code", "openclaw"]
+
+
+def test_runtime_at_batch_unknown_ids_echoed_in_unknown(ent):
+    body = ent.runtime_spec_at_batch(
+        ent.TIER_CLOUD_PRO, ["openclaw", "nope_runtime"]
+    )
+    assert [r["id"] for r in body["runtimes"]] == ["openclaw"]
+    assert body["unknown"] == ["nope_runtime"]
+
+
+def test_runtime_at_batch_whitespace_and_case_normalised(ent):
+    body = ent.runtime_spec_at_batch(
+        ent.TIER_CLOUD_PRO, ["  Openclaw  ", "CLAUDE-CODE"]
+    )
+    assert [r["id"] for r in body["runtimes"]] == ["openclaw", "claude_code"]
+
+
+# ── runtime_spec_at_batch helper: never-raise ────────────────────────────────
+
+
+def test_runtime_at_batch_never_raises_when_synth_crashes(ent, monkeypatch):
+    def boom(*_a, **_kw):
+        raise RuntimeError("simulated synth failure")
+
+    monkeypatch.setattr(ent, "_hypothetical_entitlement", boom)
+    body = ent.runtime_spec_at_batch(ent.TIER_CLOUD_PRO, ["openclaw"])
+    assert len(body["runtimes"]) == 1
+    assert body["runtimes"][0]["free"] is True
+
+
+# ── HTTP: feature-spec-at-batch endpoint ─────────────────────────────────────
+
+
+def test_endpoint_feature_at_batch_returns_rows_and_envelope(client, ent):
+    fid_free = next(iter(ent.FREE_FEATURES))
+    fid_paid = next(iter(ent.STARTER_FEATURES))
+    resp = client.get(
+        "/api/entitlement/feature-spec-at-batch"
+        f"?tier={ent.TIER_CLOUD_PRO}&features={fid_free},{fid_paid}"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert _ENVELOPE_KEYS <= set(body.keys())
+    assert [r["id"] for r in body["features"]] == [fid_free, fid_paid]
+    assert body["unknown"] == []
+    assert body["perspective_tier"] == ent.TIER_CLOUD_PRO
+    assert body["perspective_tier_rank"] == ent.tier_rank(ent.TIER_CLOUD_PRO)
+
+
+def test_endpoint_feature_at_batch_perspective_shifts_lock(client, ent):
+    fid = next(iter(ent.STARTER_FEATURES))
+    at_oss = client.get(
+        f"/api/entitlement/feature-spec-at-batch?tier={ent.TIER_OSS}&features={fid}"
+    )
+    at_pro = client.get(
+        f"/api/entitlement/feature-spec-at-batch?tier={ent.TIER_CLOUD_PRO}&features={fid}"
+    )
+    assert at_oss.get_json()["features"][0]["locked"] is True
+    assert at_pro.get_json()["features"][0]["locked"] is False
+
+
+def test_endpoint_feature_at_batch_missing_tier_returns_400(client, ent):
+    fid = next(iter(ent.FREE_FEATURES))
+    resp = client.get(f"/api/entitlement/feature-spec-at-batch?features={fid}")
+    assert resp.status_code == 400
+    assert "error" in resp.get_json()
+
+
+def test_endpoint_feature_at_batch_blank_tier_returns_400(client, ent):
+    fid = next(iter(ent.FREE_FEATURES))
+    resp = client.get(
+        f"/api/entitlement/feature-spec-at-batch?tier=%20%20&features={fid}"
+    )
+    assert resp.status_code == 400
+
+
+def test_endpoint_feature_at_batch_unknown_tier_returns_404(client, ent):
+    fid = next(iter(ent.FREE_FEATURES))
+    resp = client.get(
+        f"/api/entitlement/feature-spec-at-batch?tier=nope_tier&features={fid}"
+    )
+    assert resp.status_code == 404
+    body = resp.get_json()
+    assert body.get("which") == "tier"
+    assert body.get("tier") == "nope_tier"
+
+
+def test_endpoint_feature_at_batch_missing_features_returns_400(client, ent):
+    resp = client.get(
+        f"/api/entitlement/feature-spec-at-batch?tier={ent.TIER_CLOUD_PRO}"
+    )
+    assert resp.status_code == 400
+
+
+def test_endpoint_feature_at_batch_blank_features_returns_400(client, ent):
+    resp = client.get(
+        "/api/entitlement/feature-spec-at-batch"
+        f"?tier={ent.TIER_CLOUD_PRO}&features=%20%20,%20"
+    )
+    assert resp.status_code == 400
+
+
+def test_endpoint_feature_at_batch_unknown_only_returns_200(client, ent):
+    """Unknown ids alone do not 400 -- they normalise to a non-empty list
+    so the helper runs and returns ``unknown=[...]`` with empty features."""
+    resp = client.get(
+        "/api/entitlement/feature-spec-at-batch"
+        f"?tier={ent.TIER_CLOUD_PRO}&features=not_a_feature,also_bogus"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["features"] == []
+    assert body["unknown"] == ["not_a_feature", "also_bogus"]
+
+
+def test_endpoint_feature_at_batch_lowercases_tier_and_features(client, ent):
+    fid = next(iter(ent.FREE_FEATURES))
+    resp = client.get(
+        "/api/entitlement/feature-spec-at-batch"
+        f"?tier=CLOUD_PRO&features={fid.upper()},{fid}"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["perspective_tier"] == ent.TIER_CLOUD_PRO
+    assert [r["id"] for r in body["features"]] == [fid]
+
+
+def test_endpoint_feature_at_batch_envelope_carries_current_tier(client, ent):
+    fid = next(iter(ent.FREE_FEATURES))
+    resp = client.get(
+        f"/api/entitlement/feature-spec-at-batch?tier={ent.TIER_CLOUD_PRO}&features={fid}"
+    )
+    body = resp.get_json()
+    # Live resolved tier is OSS (no license / no cloud plan); perspective is Pro.
+    assert body["current_tier"] == "oss"
+    assert body["current_tier_rank"] == ent.tier_rank("oss")
+    assert body["grace"] is True
+    assert body["enforced"] is False
+
+
+def test_endpoint_feature_at_batch_never_5xxs_when_resolver_crashes(
+    client, ent, monkeypatch
+):
+    def boom(*_a, **_kw):
+        raise RuntimeError("simulated resolver failure")
+
+    monkeypatch.setattr(ent, "get_entitlement", boom)
+    fid = next(iter(ent.FREE_FEATURES))
+    resp = client.get(
+        f"/api/entitlement/feature-spec-at-batch?tier={ent.TIER_CLOUD_PRO}&features={fid}"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    # Endpoint short-circuits to the OSS-free envelope on resolver failure.
+    assert body["current_tier"] == "oss"
+    assert body["perspective_tier"] == ent.TIER_CLOUD_PRO
+    assert body["grace"] is True
+    assert body["enforced"] is False
+
+
+# ── HTTP: runtime-spec-at-batch endpoint ─────────────────────────────────────
+
+
+def test_endpoint_runtime_at_batch_returns_rows_and_envelope(client, ent):
+    resp = client.get(
+        "/api/entitlement/runtime-spec-at-batch"
+        f"?tier={ent.TIER_CLOUD_PRO}&runtimes=openclaw,claude_code"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert _ENVELOPE_KEYS <= set(body.keys())
+    assert [r["id"] for r in body["runtimes"]] == ["openclaw", "claude_code"]
+    assert body["unknown"] == []
+    assert body["perspective_tier"] == ent.TIER_CLOUD_PRO
+
+
+def test_endpoint_runtime_at_batch_perspective_shifts_lock(client, ent):
+    """A PAID runtime is locked at OSS but allowed at Cloud Pro."""
+    paid_rt = next(iter(ent.PAID_RUNTIMES))
+    at_oss = client.get(
+        f"/api/entitlement/runtime-spec-at-batch?tier={ent.TIER_OSS}&runtimes={paid_rt}"
+    )
+    at_pro = client.get(
+        f"/api/entitlement/runtime-spec-at-batch?tier={ent.TIER_CLOUD_PRO}&runtimes={paid_rt}"
+    )
+    assert at_oss.get_json()["runtimes"][0]["locked"] is True
+    assert at_pro.get_json()["runtimes"][0]["locked"] is False
+
+
+def test_endpoint_runtime_at_batch_missing_tier_returns_400(client):
+    resp = client.get("/api/entitlement/runtime-spec-at-batch?runtimes=openclaw")
+    assert resp.status_code == 400
+
+
+def test_endpoint_runtime_at_batch_unknown_tier_returns_404(client):
+    resp = client.get(
+        "/api/entitlement/runtime-spec-at-batch?tier=nope_tier&runtimes=openclaw"
+    )
+    assert resp.status_code == 404
+    body = resp.get_json()
+    assert body.get("which") == "tier"
+
+
+def test_endpoint_runtime_at_batch_missing_runtimes_returns_400(client, ent):
+    resp = client.get(
+        f"/api/entitlement/runtime-spec-at-batch?tier={ent.TIER_CLOUD_PRO}"
+    )
+    assert resp.status_code == 400
+
+
+def test_endpoint_runtime_at_batch_blank_runtimes_returns_400(client, ent):
+    resp = client.get(
+        f"/api/entitlement/runtime-spec-at-batch?tier={ent.TIER_CLOUD_PRO}&runtimes=%20%20"
+    )
+    assert resp.status_code == 400
+
+
+def test_endpoint_runtime_at_batch_alias_canonicalises(client, ent):
+    resp = client.get(
+        f"/api/entitlement/runtime-spec-at-batch?tier={ent.TIER_CLOUD_PRO}&runtimes=claude-code"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert [r["id"] for r in body["runtimes"]] == ["claude_code"]
+
+
+def test_endpoint_runtime_at_batch_unknown_only_returns_200(client, ent):
+    resp = client.get(
+        "/api/entitlement/runtime-spec-at-batch"
+        f"?tier={ent.TIER_CLOUD_PRO}&runtimes=not_a_runtime"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["runtimes"] == []
+    assert body["unknown"] == ["not_a_runtime"]
+
+
+def test_endpoint_runtime_at_batch_never_5xxs_when_resolver_crashes(
+    client, ent, monkeypatch
+):
+    def boom(*_a, **_kw):
+        raise RuntimeError("simulated resolver failure")
+
+    monkeypatch.setattr(ent, "get_entitlement", boom)
+    resp = client.get(
+        f"/api/entitlement/runtime-spec-at-batch?tier={ent.TIER_CLOUD_PRO}&runtimes=openclaw"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["current_tier"] == "oss"
+    assert body["perspective_tier"] == ent.TIER_CLOUD_PRO
+    assert body["grace"] is True
+    assert body["enforced"] is False


### PR DESCRIPTION
## Summary

What-if + batch composition of the existing `_spec_at` and `_spec_batch` helpers. Returns spec rows for a caller-supplied subset of feature / runtime ids with `allowed` / `locked` / `entitled` computed against a HYPOTHETICAL perspective tier, in one round-trip.

Continues the `scalar → bulk → batch → _at → _at_batch` matrix established by recent PRs (#3311, #3312, #3328, #3335, etc.):

| | scalar | bulk | batch | scalar what-if | bulk what-if | **batch what-if (this PR)** |
|---|---|---|---|---|---|---|
| feature | `feature_spec` | `feature_catalog` | `feature_spec_batch` | `feature_spec_at` | `feature_catalog_at` | **`feature_spec_at_batch`** |
| runtime | `runtime_spec` | `runtime_catalog` | `runtime_spec_batch` | `runtime_spec_at` | `runtime_catalog_at` | **`runtime_spec_at_batch`** |

### Helpers (`clawmetry/entitlements.py`)
- `feature_spec_at_batch(tier, features) -> {features, unknown} | None`
- `runtime_spec_at_batch(tier, runtimes) -> {runtimes, unknown} | None`

Each row is byte-identical to the matching row from `feature_catalog_at(tier)` / `runtime_catalog_at(tier)` — parity-pinned by tests so the scalar what-if, bulk what-if, and batch what-if accessors cannot drift.

### Endpoints (`routes/entitlement.py`)
- `GET /api/entitlement/feature-spec-at-batch?tier=<perspective>&features=a,b,c`
- `GET /api/entitlement/runtime-spec-at-batch?tier=<perspective>&runtimes=a,b,c`

Response envelope mirrors `/feature-spec-batch` / `/runtime-spec-batch` plus a `perspective_tier` / `perspective_tier_rank` echo for caller round-trip safety.

Contract:
- **400** on missing / blank `tier=` or missing / empty `features=` / `runtimes=` after normalisation
- **404** on unknown `tier=` (body carries `which: "tier"`)
- **Never 5xxs**: a synthesis or resolver failure short-circuits to the OSS-free envelope (empty rows, `current_tier=oss`, `grace=true`) with the perspective tier echoed so the matrix UI keeps rendering

### Grace-mode safe
Helpers operate against a synthesised hypothetical `Entitlement` (`_hypothetical_entitlement(tier)`), identical to how `feature_catalog_at` / `runtime_catalog_at` already work. They do not consult `is_enforced()` or invent locks against the live resolved entitlement — no behaviour change at the live entitlement layer.

### Tests (`tests/test_entitlement_spec_at_batch.py`)
53 new tests covering:
- row shape matches catalog + matches the scalar `_spec_at` row exactly
- perspective tier really shifts `allowed` / `locked` / `entitled` (paid feature locked at OSS, allowed at Cloud Pro; paid runtime locked at OSS, allowed at Cloud Pro)
- input normalisation (whitespace, case, duplicates, first-seen order)
- tier normalisation (`"  CLOUD_PRO  "` → `cloud_pro`)
- runtime alias canonicalisation (`claude-code` → `claude_code`) + de-dup against already-seen canonical ids
- unknown / blank / `None` / non-string `tier` returns `None` (helper) / 400 / 404 (HTTP)
- empty input returns `{features|runtimes: [], unknown: []}` (helper) / 400 (HTTP)
- helpers never raise — a `_hypothetical_entitlement` crash short-circuits to OSS-free
- endpoints never 5xx — a `get_entitlement()` crash short-circuits to the OSS-free envelope with the perspective tier echoed

## Test plan

- [x] `python -m pytest tests/test_entitlement_spec_at_batch.py -q` → 53 passed
- [x] `python -m pytest tests/test_entitlement_spec_batch.py tests/test_entitlement_feature_spec_at.py tests/test_entitlement_runtime_spec_at.py tests/test_entitlement_api.py -q` → 126 passed (no regression)
- [x] `python -m py_compile` on changed files
- [ ] Full CI matrix (waiting on `gh actions`)

## Local operator verification checklist

This PR is DRAFT only — I cannot reach the operator's machine, daemon, or live cloud snapshot. Local steps to flip to ready-for-review:

- [ ] Copy changed files into `~/.clawmetry/lib/python3.X/site-packages/clawmetry/` (`entitlements.py`) and `~/.clawmetry/lib/python3.X/site-packages/routes/` (`entitlement.py`)
- [ ] `find ~/.clawmetry -name __pycache__ -type d -exec rm -rf {} +`
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
- [ ] `curl -s 'http://localhost:8900/api/entitlement/feature-spec-at-batch?tier=cloud_pro&features=sessions,sso' | jq` → expect `features[].locked=false`, `perspective_tier="cloud_pro"`, envelope intact
- [ ] `curl -s 'http://localhost:8900/api/entitlement/feature-spec-at-batch?tier=oss&features=sso' | jq` → expect `features[0].locked=true`, `perspective_tier="oss"`
- [ ] `curl -s 'http://localhost:8900/api/entitlement/runtime-spec-at-batch?tier=cloud_pro&runtimes=openclaw,claude-code' | jq` → expect 2 rows, second one `id=claude_code` (alias canonicalised), `locked=false`
- [ ] `curl -s 'http://localhost:8900/api/entitlement/runtime-spec-at-batch?tier=oss&runtimes=claude_code' | jq` → expect `locked=true`
- [ ] `curl -i 'http://localhost:8900/api/entitlement/feature-spec-at-batch?features=sso'` → expect 400 (missing tier)
- [ ] `curl -i 'http://localhost:8900/api/entitlement/feature-spec-at-batch?tier=nope_tier&features=sso'` → expect 404 with `which: "tier"`
- [ ] Decrypt the live cloud snapshot and browser-check that no existing surface regressed (this PR is purely additive, no existing endpoint was touched)

Operator owns: version bump, `[RELEASE]` PR, tag, PyPI push, and ready-for-review flip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Ynmqrg42Yjt9UC5QhwppS

---
_Generated by [Claude Code](https://claude.ai/code/session_013Ynmqrg42Yjt9UC5QhwppS)_