### PR TITLE
feat(entitlement): tier_unlocks_at_batch + tier_locks_at_batch + endpoints

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -4494,3 +4494,112 @@ def tier_locks_at(tier: str, target: str) -> dict | None:
     except Exception as exc:
         logger.warning("entitlements: tier_locks_at failed: %s", exc)
         return None
+
+
+def tier_unlocks_at_batch(tier: str) -> list[dict] | None:
+    """What-if + batch sibling of :func:`tier_unlocks_batch`: marginal
+    unlocks against the caller-supplied ``tier`` for every purchasable
+    tier as a target, in one pass.
+
+    Composes :func:`tier_unlocks_at` (scalar what-if) and
+    :func:`tier_unlocks_batch` (live batch): same row shape and ordering
+    as the live batch helper, same hypothetical perspective as the
+    ``_at`` helper. Lets a pricing-comparison matrix UI render the
+    "marginal unlocks vs <hypothetical-tier>" column for every rung off
+    **one** round-trip instead of N calls to
+    :func:`tier_unlocks_at`.
+
+    Each row is byte-identical to ``tier_unlocks_at(tier, target)`` for
+    the same ``(tier, target)`` pair -- a parity test pins this so the
+    batch what-if cannot drift from the scalar what-if (the same
+    invariant ``feature_spec_at_batch`` / ``runtime_spec_at_batch``
+    enforce against their scalar siblings).
+
+    Rows are sorted by ``(tier_rank, tier_id)`` ascending -- byte-
+    stable against :func:`tier_unlocks_batch`'s ordering so a UI can
+    swap the live anchor for a hypothetical perspective without
+    re-sorting client-side. Same-rank sibling tiers (``cloud_pro`` /
+    ``pro`` both at rank 2) are both returned.
+
+    Target list is :data:`_PURCHASABLE_TIERS` (trial excluded), matching
+    :func:`tier_unlocks_batch`. The source ``tier`` accepts any id in
+    :data:`_TIER_ORDER` including :data:`TIER_TRIAL` -- the lenient
+    ``_at`` posture, since the source is hypothetical and may legitimately
+    answer "what would Cloud Pro unlock vs a trial install?".
+
+    Returns ``None`` for empty / unknown source ``tier`` (caller renders
+    "unknown tier" / 404). Never raises: a builder failure short-circuits
+    to ``[]`` so the matrix keeps rendering instead of breaking.
+    """
+    try:
+        a = (tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if not a or a not in _TIER_ORDER:
+        return None
+    try:
+        out: list[dict] = []
+        ordered = sorted(
+            _PURCHASABLE_TIERS, key=lambda t: (_TIER_RANK.get(t, -1), t)
+        )
+        for tid in ordered:
+            row = _unlocks_row(a, tid)
+            if row is not None:
+                out.append(row)
+        return out
+    except Exception as exc:
+        logger.warning("entitlements: tier_unlocks_at_batch failed: %s", exc)
+        return []
+
+
+def tier_locks_at_batch(tier: str) -> list[dict] | None:
+    """What-if + batch sibling of :func:`tier_locks_batch`: marginal
+    losses against the caller-supplied ``tier`` for every purchasable
+    tier as a target, in one pass.
+
+    Marginal-loss mirror of :func:`tier_unlocks_at_batch` and pairs
+    with :func:`tier_locks_batch` the same way
+    :func:`tier_unlocks_at_batch` pairs with :func:`tier_unlocks_batch`
+    -- the downgrade-warning column on the same matrix the unlocks
+    batch renders the upgrade-CTA column for, pivoted around a
+    hypothetical perspective tier.
+
+    Each row is byte-identical to ``tier_locks_at(tier, target)`` for
+    the same ``(tier, target)`` pair -- a parity test pins this so the
+    batch what-if cannot drift from the scalar what-if.
+
+    Rows are sorted by ``(tier_rank, tier_id)`` ascending -- byte-
+    stable against :func:`tier_locks_batch`'s ordering and against
+    :func:`tier_unlocks_at_batch` for the same source tier so a UI can
+    fold the two responses into an "if you upgrade / if you downgrade"
+    matrix without re-sorting client-side. Same-rank sibling tiers are
+    both returned.
+
+    Target list is :data:`_PURCHASABLE_TIERS` (trial excluded), matching
+    :func:`tier_locks_batch`. The source ``tier`` accepts any id in
+    :data:`_TIER_ORDER` including :data:`TIER_TRIAL` -- the lenient
+    ``_at`` posture.
+
+    Returns ``None`` for empty / unknown source ``tier``. Never raises:
+    a builder failure short-circuits to ``[]`` so the matrix keeps
+    rendering.
+    """
+    try:
+        a = (tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if not a or a not in _TIER_ORDER:
+        return None
+    try:
+        out: list[dict] = []
+        ordered = sorted(
+            _PURCHASABLE_TIERS, key=lambda t: (_TIER_RANK.get(t, -1), t)
+        )
+        for tid in ordered:
+            row = _locks_row(a, tid)
+            if row is not None:
+                out.append(row)
+        return out
+    except Exception as exc:
+        logger.warning("entitlements: tier_locks_at_batch failed: %s", exc)
+        return []

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -2991,6 +2991,175 @@ def api_entitlement_tier_locks_at():
         )
 
 
+@bp_entitlement.route("/api/entitlement/tier-unlocks-at-batch")
+def api_entitlement_tier_unlocks_at_batch():
+    """``GET /api/entitlement/tier-unlocks-at-batch?tier=<source>`` --
+    what-if + batch sibling of ``/api/entitlement/tier-unlocks-batch``:
+    marginal-unlocks rows for every purchasable tier as a target,
+    computed against the caller-supplied ``tier`` rather than the
+    global next-lower-purchasable-tier anchor ``/tier-unlocks-batch``
+    uses.
+
+    Composes the scalar what-if (``/tier-unlocks-at``) and the live
+    batch (``/tier-unlocks-batch``) -- same row shape and ordering as
+    the live batch, same hypothetical perspective as the ``_at``
+    endpoint. Lets a pricing-comparison matrix UI render the "marginal
+    unlocks vs <hypothetical-tier>" column for every rung off **one**
+    round-trip instead of N calls to ``/tier-unlocks-at``.
+
+    Accepts any tier id in :data:`entitlements._TIER_ORDER` on the
+    ``tier`` arg (including ``trial``), matching the other ``_at``
+    family endpoints. The target list mirrors ``/tier-unlocks-batch``
+    (purchasable tiers only -- trial excluded), so the rows match the
+    live batch's target axis byte-for-byte and the response can be
+    folded into the same pricing-page table.
+
+    Response shape::
+
+        {
+          "tier":              "<source tier id>",
+          "tiers":             [<row>, ...],
+          "current_tier":      "<resolved tier id>",
+          "current_tier_rank": <int>,
+          "grace":             <bool>,
+          "enforced":          <bool>,
+        }
+
+    Each ``<row>`` matches ``/api/entitlement/tier-unlocks-at`` for the
+    same ``(tier, target)`` pair exactly (``tier``, ``tier_label``,
+    ``tier_rank``, ``previous_tier``, ``previous_tier_label``,
+    ``previous_tier_rank``, ``features``, ``runtimes``) -- with
+    ``previous_tier`` carrying the caller-supplied ``tier`` arg, NOT
+    the global next-lower-purchasable anchor.
+
+    - **400** when ``tier=`` is missing / blank.
+    - **404** when ``tier`` is unknown. The body carries ``which=tier``
+      so a caller can render the right "unknown tier" message.
+    - **Never 5xxs**: a resolver failure yields an empty ``tiers`` list
+      and the grace-shape envelope so the matrix keeps rendering.
+    """
+    raw_tier = request.args.get("tier")
+    tier_in = (raw_tier or "").strip().lower()
+    if not tier_in:
+        return jsonify({"error": "missing tier"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        if tier_in not in _ent._TIER_ORDER:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "tier", "tier": tier_in}
+                ),
+                404,
+            )
+        rows = _ent.tier_unlocks_at_batch(tier_in) or []
+        ent = _ent.get_entitlement()
+        return jsonify(
+            {
+                "tier": tier_in,
+                "tiers": rows,
+                "current_tier": ent.tier,
+                "current_tier_rank": _ent.tier_rank(ent.tier),
+                "grace": bool(ent.grace),
+                "enforced": _ent.is_enforced(),
+            }
+        )
+    except Exception as exc:
+        logger.warning("api_entitlement_tier_unlocks_at_batch: error: %s", exc)
+        return jsonify(
+            {
+                "tier": tier_in,
+                "tiers": [],
+                "current_tier": "oss",
+                "current_tier_rank": 0,
+                "grace": True,
+                "enforced": False,
+            }
+        )
+
+
+@bp_entitlement.route("/api/entitlement/tier-locks-at-batch")
+def api_entitlement_tier_locks_at_batch():
+    """``GET /api/entitlement/tier-locks-at-batch?tier=<source>`` --
+    what-if + batch sibling of ``/api/entitlement/tier-locks-batch``:
+    marginal-loss rows for every purchasable tier as a target, computed
+    against the caller-supplied ``tier`` rather than the global next-
+    higher-purchasable-tier anchor ``/tier-locks-batch`` uses.
+
+    Marginal-loss mirror of ``/tier-unlocks-at-batch`` and pairs with
+    ``/tier-locks-batch`` the same way ``/tier-unlocks-at-batch`` pairs
+    with ``/tier-unlocks-batch``. Pair the two ``_at_batch`` endpoints
+    to render the upgrade-CTA + downgrade-warning columns of a
+    "compared against any hypothetical perspective" pricing matrix in
+    two round-trips.
+
+    Accepts any tier id in :data:`entitlements._TIER_ORDER` on the
+    ``tier`` arg (including ``trial``). The target list mirrors
+    ``/tier-locks-batch`` (purchasable tiers only -- trial excluded).
+
+    Response shape::
+
+        {
+          "tier":              "<source tier id>",
+          "tiers":             [<row>, ...],
+          "current_tier":      "<resolved tier id>",
+          "current_tier_rank": <int>,
+          "grace":             <bool>,
+          "enforced":          <bool>,
+        }
+
+    Each ``<row>`` matches ``/api/entitlement/tier-locks-at`` for the
+    same ``(tier, target)`` pair exactly (``tier``, ``tier_label``,
+    ``tier_rank``, ``next_tier``, ``next_tier_label``,
+    ``next_tier_rank``, ``lost_features``, ``lost_runtimes``) -- with
+    ``next_tier`` carrying the caller-supplied ``tier`` arg (the rung
+    you'd be stepping FROM).
+
+    - **400** when ``tier=`` is missing / blank.
+    - **404** when ``tier`` is unknown. The body carries ``which=tier``.
+    - **Never 5xxs**: a resolver failure yields an empty ``tiers`` list
+      and the grace-shape envelope so the matrix keeps rendering.
+    """
+    raw_tier = request.args.get("tier")
+    tier_in = (raw_tier or "").strip().lower()
+    if not tier_in:
+        return jsonify({"error": "missing tier"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        if tier_in not in _ent._TIER_ORDER:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "tier", "tier": tier_in}
+                ),
+                404,
+            )
+        rows = _ent.tier_locks_at_batch(tier_in) or []
+        ent = _ent.get_entitlement()
+        return jsonify(
+            {
+                "tier": tier_in,
+                "tiers": rows,
+                "current_tier": ent.tier,
+                "current_tier_rank": _ent.tier_rank(ent.tier),
+                "grace": bool(ent.grace),
+                "enforced": _ent.is_enforced(),
+            }
+        )
+    except Exception as exc:
+        logger.warning("api_entitlement_tier_locks_at_batch: error: %s", exc)
+        return jsonify(
+            {
+                "tier": tier_in,
+                "tiers": [],
+                "current_tier": "oss",
+                "current_tier_rank": 0,
+                "grace": True,
+                "enforced": False,
+            }
+        )
+
+
 @bp_entitlement.route("/api/entitlement/affordable-tiers")
 def api_entitlement_affordable_tiers():
     """``GET /api/entitlement/affordable-tiers?features=a,b,c&runtimes=x,y

--- a/tests/test_entitlement_tier_locks_at_batch.py
+++ b/tests/test_entitlement_tier_locks_at_batch.py
@@ -1,0 +1,419 @@
+"""Tests for ``tier_locks_at_batch(tier)`` +
+``GET /api/entitlement/tier-locks-at-batch``.
+
+What-if + batch sibling of :func:`tier_locks_batch`: marginal-loss
+rows for every purchasable tier as a target, computed against the
+caller-supplied ``tier`` rather than the global next-higher-purchasable-
+tier anchor :func:`tier_locks_batch` uses. Marginal-loss mirror of
+:func:`tier_unlocks_at_batch`.
+
+Pins:
+
+* one row per :data:`_PURCHASABLE_TIERS` entry, sorted by ``(rank, id)``
+  ascending (byte-stable against :func:`tier_locks_batch` AND against
+  :func:`tier_unlocks_at_batch` for the same source -- so the two
+  responses fold into one "if you upgrade / if you downgrade" matrix
+  without re-sorting client-side)
+* row shape matches :func:`tier_locks_at` / :func:`tier_locks` exactly
+* each row byte-equals ``tier_locks_at(tier, target)`` for the same
+  pair -- the scalar-batch parity that stops the batch what-if drifting
+  away from the scalar
+* ``next_tier`` on every row echoes the caller-supplied source ``tier``
+  (the rung you'd be stepping FROM), NOT the global anchor
+  :func:`tier_locks_batch` uses
+* swap-the-endpoints invariant: ``tier_locks_at_batch(A)`` row for
+  target B has ``lost_*`` byte-equal to
+  ``tier_unlocks_at_batch(B)`` row for target A's ``features`` /
+  ``runtimes`` -- the same invariant ``tier_diff`` already pins
+* the trial tier is excluded from the **target** axis; accepted on the
+  **source** ``tier`` arg
+* upgrade-direction rows collapse to empty loss lists; identity row
+  collapses too
+* unknown / empty / ``None`` / non-string source returns ``None``
+* the source ``tier`` is trimmed + lowercased before resolution
+* helper is independent of the live resolver (grace flips no field)
+* endpoint 400s on missing input, 404s on unknown source (with
+  ``which=tier``), and never 5xxs
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+_ROW_KEYS = {
+    "tier",
+    "tier_label",
+    "tier_rank",
+    "next_tier",
+    "next_tier_label",
+    "next_tier_rank",
+    "lost_features",
+    "lost_runtimes",
+}
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# ── shape ─────────────────────────────────────────────────────────────────────
+
+
+def test_returns_list_for_known_tier(ent):
+    rows = ent.tier_locks_at_batch(ent.TIER_ENTERPRISE)
+    assert isinstance(rows, list)
+    assert len(rows) > 0
+
+
+def test_each_row_has_scalar_shape(ent):
+    rows = ent.tier_locks_at_batch(ent.TIER_ENTERPRISE)
+    for row in rows:
+        assert set(row.keys()) == _ROW_KEYS
+
+
+def test_excludes_trial_from_targets(ent):
+    rows = ent.tier_locks_at_batch(ent.TIER_ENTERPRISE)
+    ids = {row["tier"] for row in rows}
+    assert ent.TIER_TRIAL not in ids
+
+
+def test_includes_every_purchasable_tier_as_target(ent):
+    rows = ent.tier_locks_at_batch(ent.TIER_ENTERPRISE)
+    ids = {row["tier"] for row in rows}
+    expected = {
+        ent.TIER_OSS,
+        ent.TIER_CLOUD_FREE,
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_PRO,
+        ent.TIER_ENTERPRISE,
+    }
+    assert ids == expected
+
+
+def test_target_set_matches_purchasable_tiers(ent):
+    rows = ent.tier_locks_at_batch(ent.TIER_ENTERPRISE)
+    ids = {row["tier"] for row in rows}
+    assert ids == set(ent._PURCHASABLE_TIERS)
+
+
+# ── ordering ─────────────────────────────────────────────────────────────────
+
+
+def test_sorted_by_rank_ascending(ent):
+    rows = ent.tier_locks_at_batch(ent.TIER_ENTERPRISE)
+    ranks = [row["tier_rank"] for row in rows]
+    assert ranks == sorted(ranks)
+
+
+def test_same_rank_sorted_by_tier_id(ent):
+    rows = ent.tier_locks_at_batch(ent.TIER_ENTERPRISE)
+    by_rank: dict[int, list[str]] = {}
+    for row in rows:
+        by_rank.setdefault(row["tier_rank"], []).append(row["tier"])
+    for ids in by_rank.values():
+        assert ids == sorted(ids)
+
+
+def test_target_axis_matches_tier_locks_batch_ordering(ent):
+    """Byte-stable against :func:`tier_locks_batch`'s ordering so a UI
+    can swap the live anchor for a hypothetical one without re-sorting
+    client-side."""
+    at_rows = ent.tier_locks_at_batch(ent.TIER_ENTERPRISE)
+    live_rows = ent.tier_locks_batch()
+    assert [r["tier"] for r in at_rows] == [r["tier"] for r in live_rows]
+
+
+def test_target_axis_matches_unlocks_at_batch_ordering(ent):
+    """Byte-stable against :func:`tier_unlocks_at_batch` for the same
+    source so the two ``_at_batch`` responses fold into one pricing
+    matrix without re-sorting client-side."""
+    at_locks = ent.tier_locks_at_batch(ent.TIER_ENTERPRISE)
+    at_unlocks = ent.tier_unlocks_at_batch(ent.TIER_ENTERPRISE)
+    assert [r["tier"] for r in at_locks] == [r["tier"] for r in at_unlocks]
+
+
+# ── parity with scalar tier_locks_at ─────────────────────────────────────────
+
+
+def test_each_row_byte_equals_scalar_at(ent):
+    """Every row byte-equals ``tier_locks_at(tier, target)`` for the
+    same pair -- the parity that stops the batch what-if drifting from
+    the scalar what-if."""
+    for src in ent._TIER_ORDER:
+        rows = ent.tier_locks_at_batch(src)
+        assert rows is not None, src
+        for row in rows:
+            scalar = ent.tier_locks_at(src, row["tier"])
+            assert row == scalar, (src, row["tier"])
+
+
+def test_each_row_byte_equals_tier_diff_lost(ent):
+    """Composes the cumulative-diff parity ``tier_locks_at`` already
+    pins, lifted to the batch."""
+    for src in ent._TIER_ORDER:
+        rows = ent.tier_locks_at_batch(src)
+        for row in rows:
+            diff = ent.tier_diff(src, row["tier"])
+            assert row["lost_features"] == diff["lost_features"], (src, row["tier"])
+            assert row["lost_runtimes"] == diff["lost_runtimes"], (src, row["tier"])
+
+
+def test_swap_endpoints_mirrors_unlocks_at_batch(ent):
+    """``tier_locks_at_batch(A)`` row for target B's ``lost_*`` byte-
+    equals ``tier_unlocks_at_batch(B)`` row for target A's ``features``
+    / ``runtimes`` -- the swap-the-endpoints invariant ``tier_diff``
+    already pins, lifted to the ``_at_batch`` pair."""
+    for a in ent._PURCHASABLE_TIERS:
+        locks_rows = {r["tier"]: r for r in ent.tier_locks_at_batch(a)}
+        for b in ent._PURCHASABLE_TIERS:
+            unlocks_rows = {r["tier"]: r for r in ent.tier_unlocks_at_batch(b)}
+            locks_row = locks_rows[b]
+            unlocks_row = unlocks_rows[a]
+            assert locks_row["lost_features"] == unlocks_row["features"], (a, b)
+            assert locks_row["lost_runtimes"] == unlocks_row["runtimes"], (a, b)
+
+
+def test_next_tier_echoes_caller_perspective_on_every_row(ent):
+    """``next_tier`` on every row is the caller-supplied source ``tier``
+    (the rung you'd be stepping FROM), NOT the global next-higher-
+    purchasable anchor :func:`tier_locks_batch` uses."""
+    rows = ent.tier_locks_at_batch(ent.TIER_ENTERPRISE)
+    for row in rows:
+        assert row["next_tier"] == ent.TIER_ENTERPRISE
+        assert row["next_tier_label"] == ent.tier_label(ent.TIER_ENTERPRISE)
+        assert row["next_tier_rank"] == ent.tier_rank(ent.TIER_ENTERPRISE)
+
+
+def test_source_perspective_differs_from_live_batch(ent):
+    """The source-perspective batch must NOT match the live batch on
+    the ``next_tier`` axis (otherwise the helper is silently falling
+    through to the live anchor)."""
+    at_rows = ent.tier_locks_at_batch(ent.TIER_OSS)
+    live_rows = ent.tier_locks_batch()
+    live_by_tier = {r["tier"]: r for r in live_rows}
+    # OSS live row anchors to CLOUD_STARTER (the next-higher purchasable);
+    # the OSS-perspective row anchors to OSS itself.
+    at_oss = next(r for r in at_rows if r["tier"] == ent.TIER_OSS)
+    live_oss = live_by_tier[ent.TIER_OSS]
+    assert at_oss["next_tier"] == ent.TIER_OSS
+    assert live_oss["next_tier"] == ent.TIER_CLOUD_STARTER
+
+
+# ── direction semantics ──────────────────────────────────────────────────────
+
+
+def test_enterprise_source_loses_full_paid_grant_dropping_to_oss(ent):
+    rows = ent.tier_locks_at_batch(ent.TIER_ENTERPRISE)
+    oss_row = next(r for r in rows if r["tier"] == ent.TIER_OSS)
+    assert set(oss_row["lost_features"]) == set(ent.PAID_FEATURES) | set(
+        ent.ENTERPRISE_FEATURES
+    )
+    assert set(oss_row["lost_runtimes"]) == set(ent.PAID_RUNTIMES)
+
+
+def test_identity_row_is_empty(ent):
+    """Staying put loses nothing -- the row whose target matches the
+    source tier carries empty loss lists."""
+    for src in ent._PURCHASABLE_TIERS:
+        rows = ent.tier_locks_at_batch(src)
+        identity = next(r for r in rows if r["tier"] == src)
+        assert identity["lost_features"] == [], src
+        assert identity["lost_runtimes"] == [], src
+
+
+def test_oss_source_collapses_all_targets_to_empty(ent):
+    """From the floor tier (OSS), there's nothing to lose going UP to
+    any other tier -- every target row collapses to empty loss lists."""
+    rows = ent.tier_locks_at_batch(ent.TIER_OSS)
+    for row in rows:
+        assert row["lost_features"] == [], row["tier"]
+        assert row["lost_runtimes"] == [], row["tier"]
+
+
+# ── source-axis: trial accepted (lenient _at family) ─────────────────────────
+
+
+def test_trial_accepted_as_source(ent):
+    rows = ent.tier_locks_at_batch(ent.TIER_TRIAL)
+    assert rows is not None
+    assert len(rows) == len(ent._PURCHASABLE_TIERS)
+    for row in rows:
+        assert row["next_tier"] == ent.TIER_TRIAL
+
+
+# ── every source resolves ────────────────────────────────────────────────────
+
+
+def test_every_source_round_trips(ent):
+    for src in ent._TIER_ORDER:
+        rows = ent.tier_locks_at_batch(src)
+        assert rows is not None, src
+        assert len(rows) == len(ent._PURCHASABLE_TIERS), src
+
+
+# ── invalid source ───────────────────────────────────────────────────────────
+
+
+def test_unknown_source_returns_none(ent):
+    assert ent.tier_locks_at_batch("not_a_real_tier") is None
+
+
+def test_empty_source_returns_none(ent):
+    assert ent.tier_locks_at_batch("") is None
+
+
+def test_none_source_returns_none(ent):
+    assert ent.tier_locks_at_batch(None) is None  # type: ignore[arg-type]
+
+
+def test_non_string_source_returns_none(ent):
+    assert ent.tier_locks_at_batch(123) is None  # type: ignore[arg-type]
+    assert ent.tier_locks_at_batch(object()) is None  # type: ignore[arg-type]
+
+
+# ── normalisation ────────────────────────────────────────────────────────────
+
+
+def test_source_is_lowercased_and_trimmed(ent):
+    a = ent.tier_locks_at_batch(ent.TIER_ENTERPRISE)
+    b = ent.tier_locks_at_batch(ent.TIER_ENTERPRISE.upper())
+    c = ent.tier_locks_at_batch(f"  {ent.TIER_ENTERPRISE}  ")
+    assert a == b == c
+
+
+# ── independent of live resolver ─────────────────────────────────────────────
+
+
+def test_helper_ignores_grace_mode(ent, monkeypatch):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    ent.invalidate()
+    rows_grace = ent.tier_locks_at_batch(ent.TIER_ENTERPRISE)
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    rows_enforce = ent.tier_locks_at_batch(ent.TIER_ENTERPRISE)
+    assert rows_grace == rows_enforce
+
+
+def test_does_not_mutate_live_entitlement(ent):
+    before = ent.get_entitlement().to_dict()
+    ent.tier_locks_at_batch(ent.TIER_ENTERPRISE)
+    after = ent.get_entitlement().to_dict()
+    assert before == after
+
+
+# ── never-raise ──────────────────────────────────────────────────────────────
+
+
+def test_returns_empty_list_when_builder_crashes(ent, monkeypatch):
+    """A builder failure short-circuits to ``[]`` so the matrix keeps
+    rendering instead of breaking. Returns ``[]`` (not ``None``) so
+    callers can iterate without a None-check -- ``None`` is reserved
+    for the unknown-source 404 path."""
+    def boom(*_a, **_kw):
+        raise RuntimeError("simulated builder failure")
+
+    monkeypatch.setattr(ent, "_locks_row", boom)
+    assert ent.tier_locks_at_batch(ent.TIER_ENTERPRISE) == []
+
+
+# ── HTTP endpoint ────────────────────────────────────────────────────────────
+
+
+def test_endpoint_known_source_returns_full_ladder(client, ent):
+    resp = client.get(
+        f"/api/entitlement/tier-locks-at-batch?tier={ent.TIER_ENTERPRISE}"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["tier"] == ent.TIER_ENTERPRISE
+    assert body["tiers"] == ent.tier_locks_at_batch(ent.TIER_ENTERPRISE)
+    assert "current_tier" in body
+    assert "current_tier_rank" in body
+    assert "grace" in body
+    assert "enforced" in body
+
+
+def test_endpoint_lowercases_and_trims(client, ent):
+    resp = client.get(
+        f"/api/entitlement/tier-locks-at-batch?tier=%20%20{ent.TIER_ENTERPRISE.upper()}%20%20"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["tier"] == ent.TIER_ENTERPRISE
+
+
+def test_endpoint_missing_tier_returns_400(client):
+    resp = client.get("/api/entitlement/tier-locks-at-batch")
+    assert resp.status_code == 400
+    assert "error" in resp.get_json()
+
+
+def test_endpoint_blank_tier_returns_400(client):
+    resp = client.get("/api/entitlement/tier-locks-at-batch?tier=%20%20")
+    assert resp.status_code == 400
+
+
+def test_endpoint_unknown_tier_returns_404(client):
+    resp = client.get(
+        "/api/entitlement/tier-locks-at-batch?tier=nonsense_xyz"
+    )
+    assert resp.status_code == 404
+    body = resp.get_json()
+    assert body["which"] == "tier"
+    assert body["tier"] == "nonsense_xyz"
+    assert "error" in body
+
+
+def test_endpoint_trial_is_accepted_as_source(client, ent):
+    resp = client.get(
+        f"/api/entitlement/tier-locks-at-batch?tier={ent.TIER_TRIAL}"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["tier"] == ent.TIER_TRIAL
+    for row in body["tiers"]:
+        assert row["next_tier"] == ent.TIER_TRIAL
+
+
+def test_endpoint_every_source_round_trips(client, ent):
+    for src in ent._TIER_ORDER:
+        resp = client.get(
+            f"/api/entitlement/tier-locks-at-batch?tier={src}"
+        )
+        assert resp.status_code == 200, src
+        body = resp.get_json()
+        assert body["tier"] == src, src
+        assert len(body["tiers"]) == len(ent._PURCHASABLE_TIERS), src
+
+
+def test_endpoint_envelope_carries_resolver_state(client, ent):
+    resp = client.get(
+        f"/api/entitlement/tier-locks-at-batch?tier={ent.TIER_ENTERPRISE}"
+    )
+    body = resp.get_json()
+    live = ent.get_entitlement()
+    assert body["current_tier"] == live.tier
+    assert body["current_tier_rank"] == ent.tier_rank(live.tier)
+    assert body["grace"] == bool(live.grace)
+    assert body["enforced"] == ent.is_enforced()

--- a/tests/test_entitlement_tier_unlocks_at_batch.py
+++ b/tests/test_entitlement_tier_unlocks_at_batch.py
@@ -1,0 +1,407 @@
+"""Tests for ``tier_unlocks_at_batch(tier)`` +
+``GET /api/entitlement/tier-unlocks-at-batch``.
+
+What-if + batch sibling of :func:`tier_unlocks_batch`: marginal-unlocks
+rows for every purchasable tier as a target, computed against the
+caller-supplied ``tier`` rather than the global next-lower-purchasable-
+tier anchor :func:`tier_unlocks_batch` uses. Composes
+:func:`tier_unlocks_at` (scalar what-if) and :func:`tier_unlocks_batch`
+(live batch).
+
+Pins:
+
+* one row per :data:`_PURCHASABLE_TIERS` entry, sorted by ``(rank, id)``
+  ascending (byte-stable against :func:`tier_unlocks_batch`)
+* row shape matches :func:`tier_unlocks_at` / :func:`tier_unlocks`
+  exactly
+* each row byte-equals ``tier_unlocks_at(tier, target)`` for the same
+  pair -- the scalar-batch parity that stops the batch what-if drifting
+  away from the scalar what-if (mirrors the parity ``feature_spec_at_batch``
+  / ``runtime_spec_at_batch`` pin against their scalar siblings)
+* ``previous_tier`` on every row echoes the caller-supplied source
+  ``tier``, NOT the global anchor :func:`tier_unlocks_batch` uses
+* the trial tier is excluded from the **target** axis (mirrors
+  :func:`tier_unlocks_batch`), but accepted on the **source** ``tier``
+  arg (the lenient ``_at`` posture)
+* downgrade-direction rows collapse to empty grant lists; the source
+  tier's identity row collapses too
+* unknown / empty / ``None`` / non-string source returns ``None``
+* the source ``tier`` is trimmed + lowercased before resolution
+* the helper is independent of the live resolver (grace flips no field)
+* the endpoint 400s on missing input, 404s on unknown source (with
+  ``which=tier``), and never 5xxs
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+_ROW_KEYS = {
+    "tier",
+    "tier_label",
+    "tier_rank",
+    "previous_tier",
+    "previous_tier_label",
+    "previous_tier_rank",
+    "features",
+    "runtimes",
+}
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    """Fresh entitlements module with HOME pointed at an empty tmp dir
+    so no real ~/.clawmetry/license.key or cloud_plan.json leaks in.
+    Enforcement off by default (grace mode) -- the helper is independent
+    of either knob, so the fixture only needs to keep the live resolver
+    from surprising the test."""
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# ── shape ─────────────────────────────────────────────────────────────────────
+
+
+def test_returns_list_for_known_tier(ent):
+    rows = ent.tier_unlocks_at_batch(ent.TIER_OSS)
+    assert isinstance(rows, list)
+    assert len(rows) > 0
+
+
+def test_each_row_has_scalar_shape(ent):
+    rows = ent.tier_unlocks_at_batch(ent.TIER_OSS)
+    for row in rows:
+        assert set(row.keys()) == _ROW_KEYS
+
+
+def test_excludes_trial_from_targets(ent):
+    rows = ent.tier_unlocks_at_batch(ent.TIER_OSS)
+    ids = {row["tier"] for row in rows}
+    assert ent.TIER_TRIAL not in ids
+
+
+def test_includes_every_purchasable_tier_as_target(ent):
+    rows = ent.tier_unlocks_at_batch(ent.TIER_OSS)
+    ids = {row["tier"] for row in rows}
+    expected = {
+        ent.TIER_OSS,
+        ent.TIER_CLOUD_FREE,
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_PRO,
+        ent.TIER_ENTERPRISE,
+    }
+    assert ids == expected
+
+
+def test_target_set_matches_purchasable_tiers(ent):
+    """Hard-pin against ``_PURCHASABLE_TIERS`` so the target axis stays
+    in lock-step with :func:`tier_unlocks_batch` even if the purchasable
+    set ever changes."""
+    rows = ent.tier_unlocks_at_batch(ent.TIER_OSS)
+    ids = {row["tier"] for row in rows}
+    assert ids == set(ent._PURCHASABLE_TIERS)
+
+
+# ── ordering ─────────────────────────────────────────────────────────────────
+
+
+def test_sorted_by_rank_ascending(ent):
+    rows = ent.tier_unlocks_at_batch(ent.TIER_OSS)
+    ranks = [row["tier_rank"] for row in rows]
+    assert ranks == sorted(ranks)
+
+
+def test_same_rank_sorted_by_tier_id(ent):
+    rows = ent.tier_unlocks_at_batch(ent.TIER_OSS)
+    # Group rank -> [ids], confirm each group is sorted by id ascending.
+    by_rank: dict[int, list[str]] = {}
+    for row in rows:
+        by_rank.setdefault(row["tier_rank"], []).append(row["tier"])
+    for ids in by_rank.values():
+        assert ids == sorted(ids)
+
+
+def test_target_axis_matches_tier_unlocks_batch_ordering(ent):
+    """The target axis is byte-stable against :func:`tier_unlocks_batch`'s
+    ordering so a UI can swap the live anchor for a hypothetical one
+    without re-sorting client-side."""
+    at_rows = ent.tier_unlocks_at_batch(ent.TIER_OSS)
+    live_rows = ent.tier_unlocks_batch()
+    assert [r["tier"] for r in at_rows] == [r["tier"] for r in live_rows]
+
+
+# ── parity with scalar tier_unlocks_at ───────────────────────────────────────
+
+
+def test_each_row_byte_equals_scalar_at(ent):
+    """Every row byte-equals ``tier_unlocks_at(tier, target)`` for the
+    same pair -- the parity that stops the batch what-if drifting from
+    the scalar what-if."""
+    for src in ent._TIER_ORDER:
+        rows = ent.tier_unlocks_at_batch(src)
+        assert rows is not None, src
+        for row in rows:
+            scalar = ent.tier_unlocks_at(src, row["tier"])
+            assert row == scalar, (src, row["tier"])
+
+
+def test_each_row_byte_equals_tier_diff_added(ent):
+    """Composes the cumulative-diff parity ``tier_unlocks_at`` already
+    pins, lifted to the batch (so a regression on either side of the
+    pipeline trips here too)."""
+    for src in ent._TIER_ORDER:
+        rows = ent.tier_unlocks_at_batch(src)
+        for row in rows:
+            diff = ent.tier_diff(src, row["tier"])
+            assert row["features"] == diff["added_features"], (src, row["tier"])
+            assert row["runtimes"] == diff["added_runtimes"], (src, row["tier"])
+
+
+def test_previous_tier_echoes_caller_perspective_on_every_row(ent):
+    """``previous_tier`` on every row is the caller-supplied source
+    ``tier``, NOT the global next-lower-purchasable anchor
+    :func:`tier_unlocks_batch` uses."""
+    rows = ent.tier_unlocks_at_batch(ent.TIER_OSS)
+    for row in rows:
+        assert row["previous_tier"] == ent.TIER_OSS
+        assert row["previous_tier_label"] == ent.tier_label(ent.TIER_OSS)
+        assert row["previous_tier_rank"] == ent.tier_rank(ent.TIER_OSS)
+
+
+def test_oss_source_perspective_differs_from_live_batch(ent):
+    """The source-perspective batch must NOT match the live batch on
+    the ``previous_tier`` axis (otherwise the helper is silently
+    falling through to the live anchor)."""
+    at_rows = ent.tier_unlocks_at_batch(ent.TIER_OSS)
+    live_rows = ent.tier_unlocks_batch()
+    live_by_tier = {r["tier"]: r for r in live_rows}
+    # Enterprise live row anchors to CLOUD_PRO (the next-lower-purchasable);
+    # the OSS-perspective row must anchor to OSS instead.
+    at_enterprise = next(r for r in at_rows if r["tier"] == ent.TIER_ENTERPRISE)
+    live_enterprise = live_by_tier[ent.TIER_ENTERPRISE]
+    assert at_enterprise["previous_tier"] == ent.TIER_OSS
+    assert live_enterprise["previous_tier"] == ent.TIER_CLOUD_PRO
+
+
+# ── direction semantics ──────────────────────────────────────────────────────
+
+
+def test_oss_source_grants_full_paid_ladder_upward(ent):
+    """From OSS, every upgrade target unlocks at least what OSS lacks
+    (paid features/runtimes); the enterprise target unlocks the most."""
+    rows = ent.tier_unlocks_at_batch(ent.TIER_OSS)
+    enterprise_row = next(r for r in rows if r["tier"] == ent.TIER_ENTERPRISE)
+    assert set(enterprise_row["features"]) == set(ent.PAID_FEATURES) | set(
+        ent.ENTERPRISE_FEATURES
+    )
+    assert set(enterprise_row["runtimes"]) == set(ent.PAID_RUNTIMES)
+
+
+def test_identity_row_is_empty(ent):
+    """The row whose target matches the source tier carries empty
+    grant lists -- staying put unlocks nothing."""
+    for src in ent._PURCHASABLE_TIERS:
+        rows = ent.tier_unlocks_at_batch(src)
+        identity = next(r for r in rows if r["tier"] == src)
+        assert identity["features"] == [], src
+        assert identity["runtimes"] == [], src
+
+
+def test_enterprise_source_collapses_all_targets_to_empty(ent):
+    """From the ceiling tier (ENTERPRISE), there is nothing to unlock
+    going to any other tier -- every target row collapses to empty
+    grant lists."""
+    rows = ent.tier_unlocks_at_batch(ent.TIER_ENTERPRISE)
+    for row in rows:
+        assert row["features"] == [], row["tier"]
+        assert row["runtimes"] == [], row["tier"]
+
+
+# ── source-axis: trial accepted (lenient _at family) ─────────────────────────
+
+
+def test_trial_accepted_as_source(ent):
+    rows = ent.tier_unlocks_at_batch(ent.TIER_TRIAL)
+    assert rows is not None
+    assert len(rows) == len(ent._PURCHASABLE_TIERS)
+    for row in rows:
+        assert row["previous_tier"] == ent.TIER_TRIAL
+
+
+# ── every source resolves ────────────────────────────────────────────────────
+
+
+def test_every_source_round_trips(ent):
+    """Every id in :data:`_TIER_ORDER` (including trial) is a valid
+    source -- the helper must answer hypothetical comparisons against
+    any rung in the catalog."""
+    for src in ent._TIER_ORDER:
+        rows = ent.tier_unlocks_at_batch(src)
+        assert rows is not None, src
+        assert len(rows) == len(ent._PURCHASABLE_TIERS), src
+
+
+# ── invalid source ───────────────────────────────────────────────────────────
+
+
+def test_unknown_source_returns_none(ent):
+    assert ent.tier_unlocks_at_batch("not_a_real_tier") is None
+
+
+def test_empty_source_returns_none(ent):
+    assert ent.tier_unlocks_at_batch("") is None
+
+
+def test_none_source_returns_none(ent):
+    assert ent.tier_unlocks_at_batch(None) is None  # type: ignore[arg-type]
+
+
+def test_non_string_source_returns_none(ent):
+    assert ent.tier_unlocks_at_batch(123) is None  # type: ignore[arg-type]
+    assert ent.tier_unlocks_at_batch(object()) is None  # type: ignore[arg-type]
+
+
+# ── normalisation ────────────────────────────────────────────────────────────
+
+
+def test_source_is_lowercased_and_trimmed(ent):
+    a = ent.tier_unlocks_at_batch(ent.TIER_OSS)
+    b = ent.tier_unlocks_at_batch(ent.TIER_OSS.upper())
+    c = ent.tier_unlocks_at_batch(f"  {ent.TIER_OSS}  ")
+    assert a == b == c
+
+
+# ── independent of live resolver ─────────────────────────────────────────────
+
+
+def test_helper_ignores_grace_mode(ent, monkeypatch):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    ent.invalidate()
+    rows_grace = ent.tier_unlocks_at_batch(ent.TIER_OSS)
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    rows_enforce = ent.tier_unlocks_at_batch(ent.TIER_OSS)
+    assert rows_grace == rows_enforce
+
+
+def test_does_not_mutate_live_entitlement(ent):
+    before = ent.get_entitlement().to_dict()
+    ent.tier_unlocks_at_batch(ent.TIER_OSS)
+    after = ent.get_entitlement().to_dict()
+    assert before == after
+
+
+# ── never-raise ──────────────────────────────────────────────────────────────
+
+
+def test_returns_empty_list_when_builder_crashes(ent, monkeypatch):
+    """A builder failure short-circuits to ``[]`` so the matrix keeps
+    rendering instead of breaking. Returns ``[]`` (not ``None``) so
+    callers can iterate without a None-check -- ``None`` is reserved
+    for the unknown-source 404 path."""
+    def boom(*_a, **_kw):
+        raise RuntimeError("simulated builder failure")
+
+    monkeypatch.setattr(ent, "_unlocks_row", boom)
+    assert ent.tier_unlocks_at_batch(ent.TIER_OSS) == []
+
+
+# ── HTTP endpoint ────────────────────────────────────────────────────────────
+
+
+def test_endpoint_known_source_returns_full_ladder(client, ent):
+    resp = client.get(
+        f"/api/entitlement/tier-unlocks-at-batch?tier={ent.TIER_OSS}"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["tier"] == ent.TIER_OSS
+    assert body["tiers"] == ent.tier_unlocks_at_batch(ent.TIER_OSS)
+    assert "current_tier" in body
+    assert "current_tier_rank" in body
+    assert "grace" in body
+    assert "enforced" in body
+
+
+def test_endpoint_lowercases_and_trims(client, ent):
+    resp = client.get(
+        f"/api/entitlement/tier-unlocks-at-batch?tier=%20%20{ent.TIER_OSS.upper()}%20%20"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["tier"] == ent.TIER_OSS
+
+
+def test_endpoint_missing_tier_returns_400(client):
+    resp = client.get("/api/entitlement/tier-unlocks-at-batch")
+    assert resp.status_code == 400
+    assert "error" in resp.get_json()
+
+
+def test_endpoint_blank_tier_returns_400(client):
+    resp = client.get("/api/entitlement/tier-unlocks-at-batch?tier=%20%20")
+    assert resp.status_code == 400
+
+
+def test_endpoint_unknown_tier_returns_404(client):
+    resp = client.get(
+        "/api/entitlement/tier-unlocks-at-batch?tier=nonsense_xyz"
+    )
+    assert resp.status_code == 404
+    body = resp.get_json()
+    assert body["which"] == "tier"
+    assert body["tier"] == "nonsense_xyz"
+    assert "error" in body
+
+
+def test_endpoint_trial_is_accepted_as_source(client, ent):
+    resp = client.get(
+        f"/api/entitlement/tier-unlocks-at-batch?tier={ent.TIER_TRIAL}"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["tier"] == ent.TIER_TRIAL
+    for row in body["tiers"]:
+        assert row["previous_tier"] == ent.TIER_TRIAL
+
+
+def test_endpoint_every_source_round_trips(client, ent):
+    for src in ent._TIER_ORDER:
+        resp = client.get(
+            f"/api/entitlement/tier-unlocks-at-batch?tier={src}"
+        )
+        assert resp.status_code == 200, src
+        body = resp.get_json()
+        assert body["tier"] == src, src
+        assert len(body["tiers"]) == len(ent._PURCHASABLE_TIERS), src
+
+
+def test_endpoint_envelope_carries_resolver_state(client, ent):
+    resp = client.get(
+        f"/api/entitlement/tier-unlocks-at-batch?tier={ent.TIER_OSS}"
+    )
+    body = resp.get_json()
+    live = ent.get_entitlement()
+    assert body["current_tier"] == live.tier
+    assert body["current_tier_rank"] == ent.tier_rank(live.tier)
+    assert body["grace"] == bool(live.grace)
+    assert body["enforced"] == ent.is_enforced()


### PR DESCRIPTION
## Summary

Adds the batch siblings for the scalar what-if pivots that landed in #3337, completing the `_at_batch` family alongside `feature_spec_at_batch`, `runtime_spec_at_batch`, and `lock_reasons_at_batch`.

### Helpers (`clawmetry/entitlements.py`)
- **`tier_unlocks_at_batch(tier)`** — marginal-unlocks rows for every purchasable tier as a target, computed against the caller-supplied source `tier` rather than the global next-lower-purchasable-tier anchor `tier_unlocks_batch` uses. Walks `_PURCHASABLE_TIERS` in `(rank, id)` order; each row byte-equals `tier_unlocks_at(tier, target)` for the same pair. Source accepts any `_TIER_ORDER` id including `trial` (lenient `_at` posture); targets exclude `trial` (matches `tier_unlocks_batch`).
- **`tier_locks_at_batch(tier)`** — marginal-loss mirror with byte-stable ordering against both `tier_locks_batch` and `tier_unlocks_at_batch` (so a pricing matrix can fold the two `_at_batch` responses without re-sorting client-side).
- Both return `None` on unknown / empty / non-string source so the HTTP wrapper can 404; a builder failure short-circuits to `[]` instead of raising so the matrix UI keeps rendering.

### Endpoints (`routes/entitlement.py`)
- **`GET /api/entitlement/tier-unlocks-at-batch?tier=<source>`**
- **`GET /api/entitlement/tier-locks-at-batch?tier=<source>`**

Both follow the existing `_batch` envelope shape: `{tier, tiers, current_tier, current_tier_rank, grace, enforced}`. 400 on missing / blank `tier`, 404 with `which=tier` on unknown source, never 5xxs (resolver failure yields the grace-shape envelope with an empty `tiers` list).

### Tests
- `tests/test_entitlement_tier_unlocks_at_batch.py` — 33 tests
- `tests/test_entitlement_tier_locks_at_batch.py` — 35 tests

Key invariants pinned:
- Row shape matches the scalar `_at` siblings exactly.
- Target axis is byte-stable against `tier_unlocks_batch` / `tier_locks_batch` AND across the two `_at_batch` helpers for the same source.
- Every row byte-equals `tier_unlocks_at(tier, target)` / `tier_locks_at(tier, target)` — the scalar-batch parity that stops the batch what-if drifting from the scalar.
- Every row byte-equals `tier_diff(tier, target)['added_*']` / `['lost_*']` — the cumulative-diff parity lifted from the scalar.
- `previous_tier` / `next_tier` on every row echoes the caller-supplied source, NOT the global anchor (a regression here would mean the helper silently falls through to the live batch).
- `lost_*` byte-equals `unlocks_at_batch(B)[A]['features'|'runtimes']` for every `(A, B)` swap pair — the swap-the-endpoints invariant lifted from `tier_diff`.
- Identity row collapses to empty grant/loss lists; source-at-ceiling (Enterprise unlocks) and source-at-floor (OSS locks) collapse all target rows to empty.
- Trial is accepted as source (lenient `_at`) but excluded as target (matches the live `_batch`).
- Helper is independent of the live resolver (grace flips no field) and does not mutate the live entitlement.
- Inputs trimmed + lowercased before resolution.
- Endpoint envelope carries the live resolver state (`current_tier`, `current_tier_rank`, `grace`, `enforced`) so a UI can render "current vs hypothetical" without a separate `/api/entitlement` round-trip.

68 new tests pass; the 1852-test entitlement + license suite stays green.

## Test plan
- [x] `python3 -m py_compile` on changed files
- [x] `pytest tests/test_entitlement_tier_unlocks_at_batch.py tests/test_entitlement_tier_locks_at_batch.py` — 68 passed
- [x] `pytest tests/test_entitlement*.py tests/test_entitlements*.py tests/test_license*.py` — 1852 passed (no regressions)
- [x] `ruff check` on changed files — clean

## Local operator verification checklist

Cannot exercise the daemon / live cloud snapshot remotely; please run locally before flipping out of draft:

- [ ] Copy changed files into `~/.clawmetry/lib/pythonX.Y/site-packages/clawmetry/` and `~/.clawmetry/lib/pythonX.Y/site-packages/routes/`, clear `__pycache__`
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
- [ ] Smoke the new endpoints against the running daemon:
  - `curl 'http://localhost:8900/api/entitlement/tier-unlocks-at-batch?tier=oss' | jq`
  - `curl 'http://localhost:8900/api/entitlement/tier-locks-at-batch?tier=enterprise' | jq`
  - Confirm every row's `previous_tier` / `next_tier` echoes the supplied `tier`, NOT the global anchor.
  - Confirm the `tiers` list ordering matches `/api/entitlement/tier-unlocks-batch` / `/api/entitlement/tier-locks-batch` byte-for-byte.
- [ ] Hit `/api/entitlement` to confirm the existing live entitlement shape is unchanged.
- [ ] Decrypt the live cloud snapshot — no schema fields touched, just additive helpers/endpoints, should be unaffected.
- [ ] Browser-check the dashboard renders normally (no UI consumer added yet — endpoints are API-only for now).
- [ ] If happy, flip out of draft. Do **not** bump `__version__` or open `[RELEASE]` — leave that to the release loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P7iw8B5UdcqAzBgaBZXvku

---
_Generated by [Claude Code](https://claude.ai/code/session_01P7iw8B5UdcqAzBgaBZXvku)_