### PR TITLE
fix: persist security threats to DuckDB + add /api/security-threats

### DIFF
--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -620,6 +620,23 @@ _DDL = [
     """,
     "CREATE INDEX IF NOT EXISTS idx_authority_violations_ts      ON authority_violations(ts)",
     "CREATE INDEX IF NOT EXISTS idx_authority_violations_session ON authority_violations(session_id, ts)",
+    # Issue #3302 — security threat events. Written by /api/security/threats
+    # when it detects hits; read by /api/security-threats on the Health tab.
+    # Idempotent (CREATE TABLE IF NOT EXISTS).
+    """
+    CREATE TABLE IF NOT EXISTS security_events (
+        id          VARCHAR PRIMARY KEY,
+        ts          VARCHAR NOT NULL,
+        type        VARCHAR,
+        severity    VARCHAR,
+        session_id  VARCHAR,
+        rule_id     VARCHAR,
+        description VARCHAR,
+        snippet     VARCHAR
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_security_events_ts      ON security_events(ts)",
+    "CREATE INDEX IF NOT EXISTS idx_security_events_session ON security_events(session_id, ts)",
     # Issue #2201 — asset registry. Evidence + review layer that turns
     # individual agent discoveries (Self-Evolve findings, useful prompts,
     # improved skills) into reviewable, reusable assets without auto-promoting
@@ -7391,6 +7408,64 @@ class LocalStore:
         params.append(int(limit))
         cols = ["id", "session_id", "ts", "tool", "violation_type",
                 "declared_tools", "allowed_tools"]
+        return [dict(zip(cols, r)) for r in self._fetch(sql, params)]
+
+    def ingest_security_event(self, event: dict[str, Any]) -> None:
+        """Upsert one security-threat event row. Required: ``id``."""
+        eid = event.get("id")
+        if not eid:
+            raise ValueError("security event must include 'id'")
+        ts = event.get("ts") or datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S")
+        with self._write_lock:
+            self._conn.execute("""
+                INSERT INTO security_events (
+                    id, ts, type, severity, session_id, rule_id, description, snippet
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT (id) DO UPDATE SET
+                    severity    = COALESCE(excluded.severity,    security_events.severity),
+                    description = COALESCE(excluded.description, security_events.description),
+                    snippet     = COALESCE(excluded.snippet,     security_events.snippet)
+            """, [
+                str(eid),
+                ts,
+                event.get("type"),
+                event.get("severity"),
+                event.get("session_id"),
+                event.get("rule_id"),
+                event.get("description"),
+                event.get("snippet"),
+            ])
+
+    def query_security_events(
+        self,
+        *,
+        session_id: str | None = None,
+        severity: str | None = None,
+        since: str | None = None,
+        limit: int = 200,
+    ) -> list[dict[str, Any]]:
+        """Read security-event rows, most-recent first."""
+        clauses: list[str] = []
+        params: list[Any] = []
+        if session_id:
+            clauses.append("session_id = ?")
+            params.append(session_id)
+        if severity:
+            clauses.append("severity = ?")
+            params.append(severity)
+        if since:
+            clauses.append("ts >= ?")
+            params.append(since)
+        where = ("WHERE " + " AND ".join(clauses)) if clauses else ""
+        sql = f"""
+            SELECT id, ts, type, severity, session_id, rule_id, description, snippet
+            FROM security_events
+            {where}
+            ORDER BY ts DESC, id
+            LIMIT ?
+        """
+        params.append(int(limit))
+        cols = ["id", "ts", "type", "severity", "session_id", "rule_id", "description", "snippet"]
         return [dict(zip(cols, r)) for r in self._fetch(sql, params)]
 
     def query_nemoclaw_metrics(

--- a/routes/health.py
+++ b/routes/health.py
@@ -3499,3 +3499,48 @@ def api_authority_violations():
             rows = []
 
     return jsonify({"violations": rows or [], "total": len(rows or [])})
+
+
+@bp_health.route("/api/security-threats")
+def api_security_threats_history():
+    """Return persisted security-threat events from DuckDB (#3302).
+
+    These are written by /api/security/threats each time a scan runs.
+    Query params:
+      session_id — narrow to one session
+      severity   — filter by severity (critical/high/medium/low)
+      since      — ISO timestamp lower bound
+      limit      — max rows (default 200)
+    """
+    session_id = (request.args.get("session_id") or "").strip() or None
+    severity = (request.args.get("severity") or "").strip() or None
+    since = (request.args.get("since") or "").strip() or None
+    try:
+        limit = max(1, min(1000, int(request.args.get("limit", 200))))
+    except (TypeError, ValueError):
+        limit = 200
+
+    rows = None
+    if is_local_store_read_enabled():
+        try:
+            from routes.local_query import local_store_via_daemon
+            rows = local_store_via_daemon(
+                "query_security_events",
+                session_id=session_id,
+                severity=severity,
+                since=since,
+                limit=limit,
+            )
+        except Exception:
+            rows = None
+
+    if rows is None:
+        try:
+            from clawmetry import local_store as _ls
+            rows = _ls.get_store().query_security_events(
+                session_id=session_id, severity=severity, since=since, limit=limit
+            )
+        except Exception:
+            rows = []
+
+    return jsonify({"threats": rows or [], "total": len(rows or [])})

--- a/routes/infra.py
+++ b/routes/infra.py
@@ -1516,6 +1516,31 @@ def api_security_threats():
                 channels=["banner", "telegram"],
             )
 
+    # Persist to DuckDB so /api/security-threats has a history to serve.
+    if threats:
+        try:
+            from routes.local_query import local_store_via_daemon
+            from clawmetry import local_store as _ls_mod
+            for t in threats:
+                ts_key = (t.get("time") or "").replace(":", "").replace("-", "")[:15]
+                src_key = (t.get("source") or "").replace("/", "_")[:32]
+                ev_id = f"sec_{t.get('rule_id', 'x')}_{src_key}_{ts_key}"
+                ev = {
+                    "id": ev_id,
+                    "ts": t.get("time") or "",
+                    "type": t.get("event_type"),
+                    "severity": t.get("severity"),
+                    "session_id": t.get("source"),
+                    "rule_id": t.get("rule_id"),
+                    "description": t.get("description"),
+                    "snippet": t.get("detail", "")[:200],
+                }
+                result = local_store_via_daemon("ingest_security_event", event=ev)
+                if result is None:
+                    _ls_mod.get_store().ingest_security_event(ev)
+        except Exception:
+            pass
+
     return jsonify(
         {"threats": threats, "counts": counts, "scanned_events": len(events)}
     )

--- a/routes/local_query.py
+++ b/routes/local_query.py
@@ -776,6 +776,12 @@ _DAEMON_METHODS = frozenset({
     # sessions + heartbeats; routed through the daemon proxy so the
     # dashboard process never opens DuckDB writable.
     "query_version_health",
+    # Issue #3302 — security threat events. ingest_ is a write (called from
+    # /api/security/threats after each scan); query_ is read-only (serves
+    # /api/security-threats on the Health tab). Both routed through the daemon
+    # proxy so the dashboard process never opens DuckDB writable.
+    "ingest_security_event",
+    "query_security_events",
 })
 
 


### PR DESCRIPTION
## Summary

Closes #3302

The security scanning infrastructure (15 signatures, `/api/security/threats`, policy-events endpoint) was already shipped in #2369. The missing piece was **persistence** — scan results were computed on-demand and discarded, so there was no DuckDB history and no flat `/api/security-threats` endpoint for the Health tab to badge off.

- **`clawmetry/local_store.py`** — `security_events` table (DDL + indexes) and `ingest_security_event()` / `query_security_events()` methods, following the `authority_violations` pattern from #3305
- **`routes/local_query.py`** — `ingest_security_event` + `query_security_events` added to `_DAEMON_METHODS` so the daemon proxy routes both
- **`routes/infra.py`** — `/api/security/threats` now persists each hit to DuckDB after scanning (daemon proxy first, direct-store fallback)
- **`routes/health.py`** — `GET /api/security-threats` reads from DuckDB (`session_id`, `severity`, `since`, `limit` query params); returns `{threats: [...], total: N}`

## Test plan

- [ ] `python3 -c "import ast; ast.parse(open('clawmetry/local_store.py').read())"` — passes ✓
- [ ] `python3 -m ruff check clawmetry/local_store.py routes/local_query.py routes/infra.py routes/health.py` — no new errors ✓
- [ ] Call `GET /api/security/threats` on a running instance to trigger a scan; then `GET /api/security-threats` should return the persisted rows
- [ ] `GET /api/security-threats?severity=high` filters correctly
- [ ] In single-process dev mode (`python3 dashboard.py`), both endpoints work without daemon

---
_Generated by [Claude Code](https://claude.ai/code/session_01XM8Dz5K3WKdJthpzYSULTn)_