### PR TITLE
feat(entitlement): capacity_diff_at + capacity_diff_at_batch + endpoints

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -4603,3 +4603,130 @@ def tier_locks_at_batch(tier: str) -> list[dict] | None:
     except Exception as exc:
         logger.warning("entitlements: tier_locks_at_batch failed: %s", exc)
         return []
+
+
+def capacity_diff_at(tier: str, target: str) -> dict | None:
+    """Scalar what-if sibling of :func:`capacity_diff`: per-axis capacity
+    transition (channels / retention / nodes) from a caller-supplied
+    ``tier`` to ``target``, computed off the static per-tier caps rather
+    than the resolved entitlement :func:`capacity_diff` anchors to.
+
+    Pairs with :func:`capacity_diff` (live, anchored to the resolver) the
+    same way :func:`tier_unlocks_at` pairs with :func:`tier_unlocks`:
+    same row shape, hypothetical source. Lets a pricing-comparison
+    tooltip render "capacity at B vs A" for any ``(A, B)`` pair in one
+    round-trip -- the single-hop view of :func:`capacity_diff_path` that
+    elides intermediate rungs and just reports the cumulative
+    ``A -> B`` marginal capacity step.
+
+    Row shape matches :func:`capacity_diff` exactly -- ``target``,
+    ``channel_limit``, ``retention_days``, ``node_limit`` where each
+    axis is the ``{before, after, delta, unlocked, locked}`` triple
+    :func:`_capacity_transition` builds. The ``before`` side comes off
+    the static per-tier caps (not the resolved entitlement), so the
+    helper is independent of grace mode and the per-axis caps do NOT
+    collapse to the unlimited sentinel the way :func:`capacity_diff`
+    does under grace -- the ``_at`` posture is "if I were at A, what
+    would B cost", not "from where I am now".
+
+    Each row is byte-identical to the destination row of
+    :func:`capacity_diff_path` for the same ``(tier, target)`` pair --
+    a parity test pins this so the scalar what-if and the path-walker
+    cannot drift (the same invariant ``tier_unlocks_at`` already
+    enforces against :func:`tier_unlocks_path`).
+
+    Both endpoints accept any tier id in :data:`_TIER_FEATURES`
+    (including :data:`TIER_TRIAL`), matching :func:`_capacity_row` and
+    the other ``_at`` family helpers; the live :func:`capacity_diff`
+    accepts any id but anchors ``before`` to the resolver, while this
+    scalar what-if anchors ``before`` to the caller-supplied ``tier``.
+
+    Direction is *not* normalised: an upgrade pair flips ``unlocked``
+    on axes that go from a finite cap to unlimited; a downgrade pair
+    flips ``locked`` on axes that go from unlimited to a finite cap;
+    identity / lateral-rank pairs collapse every axis to a no-op
+    triple (``before == after``, ``delta == 0`` or ``None``, both flags
+    ``False``).
+
+    Returns ``None`` for empty / unknown ``tier`` or ``target`` ids
+    (caller renders "unknown tier" / 404). Never raises: a builder
+    failure short-circuits to ``None`` so the tooltip surface stays
+    mute instead of breaking.
+    """
+    try:
+        a = (tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if not a or a not in _TIER_FEATURES:
+        return None
+    try:
+        t = (target or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if not t or t not in _TIER_FEATURES:
+        return None
+    try:
+        return _capacity_row(a, t)
+    except Exception as exc:
+        logger.warning("entitlements: capacity_diff_at failed: %s", exc)
+        return None
+
+
+def capacity_diff_at_batch(tier: str) -> list[dict] | None:
+    """What-if + batch sibling of :func:`capacity_diff_batch`: per-axis
+    capacity-transition rows for every purchasable tier as a target,
+    computed against the caller-supplied ``tier`` rather than the
+    resolved entitlement :func:`capacity_diff_batch` anchors to.
+
+    Composes :func:`capacity_diff_at` (scalar what-if) and
+    :func:`capacity_diff_batch` (live batch): same row shape and
+    ordering as the live batch helper, same hypothetical perspective
+    as the ``_at`` helper. Lets a pricing-comparison matrix UI render
+    the "capacity vs <hypothetical-tier>" column for every rung off
+    **one** round-trip instead of N calls to :func:`capacity_diff_at`.
+
+    Each row is byte-identical to ``capacity_diff_at(tier, target)``
+    for the same ``(tier, target)`` pair -- a parity test pins this so
+    the batch what-if cannot drift from the scalar what-if (the same
+    invariant ``tier_unlocks_at_batch`` / ``tier_locks_at_batch`` enforce
+    against their scalar siblings).
+
+    Rows are sorted by ``(tier_rank, tier_id)`` ascending -- byte-
+    stable against :func:`capacity_diff_batch`'s ordering, against
+    :func:`tier_unlocks_at_batch` / :func:`tier_locks_at_batch` for the
+    same source tier, and against :func:`preview_batch`, so a UI can
+    fold the four responses into a single "what's at X / new at X /
+    lost at X / capacity at X" matrix without re-sorting client-side.
+    Same-rank sibling tiers (``cloud_pro`` / ``pro`` both at rank 2)
+    are both returned.
+
+    Target list is :data:`_PURCHASABLE_TIERS` (trial excluded), matching
+    :func:`capacity_diff_batch`. The source ``tier`` accepts any id in
+    :data:`_TIER_FEATURES` including :data:`TIER_TRIAL` -- the lenient
+    ``_at`` posture, since the source is hypothetical and may
+    legitimately answer "what would Cloud Pro cost in capacity vs a
+    trial install?".
+
+    Returns ``None`` for empty / unknown source ``tier`` (caller renders
+    "unknown tier" / 404). Never raises: a builder failure short-circuits
+    to ``[]`` so the matrix keeps rendering instead of breaking.
+    """
+    try:
+        a = (tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if not a or a not in _TIER_FEATURES:
+        return None
+    try:
+        out: list[dict] = []
+        ordered = sorted(
+            _PURCHASABLE_TIERS, key=lambda t: (_TIER_RANK.get(t, -1), t)
+        )
+        for tid in ordered:
+            row = _capacity_row(a, tid)
+            if row is not None:
+                out.append(row)
+        return out
+    except Exception as exc:
+        logger.warning("entitlements: capacity_diff_at_batch failed: %s", exc)
+        return []

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -594,6 +594,201 @@ def api_entitlement_capacity_diff_batch():
         )
 
 
+@bp_entitlement.route("/api/entitlement/capacity-diff-at")
+def api_entitlement_capacity_diff_at():
+    """``GET /api/entitlement/capacity-diff-at?tier=<source>&target=<dest>``
+    -- scalar what-if sibling of ``/api/entitlement/capacity-diff``: per-
+    axis capacity transition (channels / retention / nodes) from a
+    caller-supplied ``tier`` to ``target``, computed off the static
+    per-tier caps rather than the resolved entitlement
+    ``/capacity-diff`` anchors to.
+
+    Lets a pricing-comparison tooltip render "capacity at B vs A" for
+    any ``(A, B)`` pair in one round-trip without fetching the full
+    ``/capacity-diff-path?from=A&to=B`` payload and reading the
+    destination row client-side. The returned row matches the
+    destination row of ``/capacity-diff-path`` for the same pair --
+    a parity test pins this so the scalar what-if and the path-walker
+    cannot drift.
+
+    Accepts any tier id in :data:`entitlements._TIER_FEATURES` on either
+    argument (including ``trial``), matching the other ``_at`` family
+    endpoints. Direction is not normalised: an upgrade pair flips
+    ``unlocked`` on axes that go from a finite cap to unlimited; a
+    downgrade pair flips ``locked`` on axes that go from unlimited to
+    finite; identity / lateral-rank pairs collapse every axis to a
+    no-op triple.
+
+    Response shape::
+
+        {
+          "tier":   "<source tier id>",
+          "target": "<destination tier id>",
+          "row":    {<capacity_diff row>},
+        }
+
+    The inner ``row`` matches the singular ``/capacity-diff`` row shape
+    exactly (``target``, ``channel_limit``, ``retention_days``,
+    ``node_limit`` where each axis is the same ``{before, after, delta,
+    unlocked, locked}`` triple) -- with the ``before`` side carrying the
+    caller-supplied ``tier``'s static caps (NOT the resolved
+    entitlement's caps the singular endpoint uses).
+
+    - **400** when either ``tier=`` or ``target=`` is missing / blank.
+    - **404** when ``tier`` or ``target`` is unknown. The body carries
+      ``which`` so a caller can render the right "unknown ..." message.
+    - **Never 5xxs**: builder failure falls through to a 404 so the
+      tooltip surface stays mute instead of breaking.
+    """
+    raw_tier = request.args.get("tier")
+    tier_in = (raw_tier or "").strip().lower()
+    if not tier_in:
+        return jsonify({"error": "missing tier"}), 400
+    raw_target = request.args.get("target")
+    target_in = (raw_target or "").strip().lower()
+    if not target_in:
+        return jsonify({"error": "missing target"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        if tier_in not in _ent._TIER_FEATURES:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "tier", "tier": tier_in}
+                ),
+                404,
+            )
+        if target_in not in _ent._TIER_FEATURES:
+            return (
+                jsonify(
+                    {
+                        "error": "unknown target",
+                        "which": "target",
+                        "target": target_in,
+                    }
+                ),
+                404,
+            )
+        row = _ent.capacity_diff_at(tier_in, target_in)
+        if row is None:
+            return (
+                jsonify(
+                    {
+                        "error": "capacity-diff-at failed",
+                        "tier": tier_in,
+                        "target": target_in,
+                    }
+                ),
+                404,
+            )
+        return jsonify({"tier": tier_in, "target": target_in, "row": row})
+    except Exception as exc:
+        logger.warning("api_entitlement_capacity_diff_at: error: %s", exc)
+        return (
+            jsonify(
+                {
+                    "error": "capacity-diff-at failed",
+                    "tier": tier_in,
+                    "target": target_in,
+                }
+            ),
+            404,
+        )
+
+
+@bp_entitlement.route("/api/entitlement/capacity-diff-at-batch")
+def api_entitlement_capacity_diff_at_batch():
+    """``GET /api/entitlement/capacity-diff-at-batch?tier=<source>`` --
+    what-if + batch sibling of ``/api/entitlement/capacity-diff-batch``:
+    per-axis capacity-transition rows for every purchasable tier as a
+    target, computed against the caller-supplied ``tier`` rather than
+    the resolved entitlement ``/capacity-diff-batch`` anchors to.
+
+    Composes the scalar what-if (``/capacity-diff-at``) and the live
+    batch (``/capacity-diff-batch``) -- same row shape and ordering as
+    the live batch, same hypothetical perspective as the ``_at``
+    endpoint. Lets a pricing-comparison matrix UI render the "capacity
+    vs <hypothetical-tier>" column for every rung off **one** round-
+    trip instead of N calls to ``/capacity-diff-at``.
+
+    Pair with ``/tier-unlocks-at-batch`` (marginal feature/runtime
+    grant per rung) and ``/tier-locks-at-batch`` (marginal loss per
+    rung) to render the full "what's new at X / what you'd give up at
+    X / capacity at X" view of a pricing matrix pivoted around any
+    hypothetical perspective tier without client-side composition.
+
+    Accepts any tier id in :data:`entitlements._TIER_FEATURES` on the
+    ``tier`` arg (including ``trial``), matching the other ``_at``
+    family endpoints. The target list mirrors ``/capacity-diff-batch``
+    (purchasable tiers only -- trial excluded), so the rows match the
+    live batch's target axis byte-for-byte and the response can be
+    folded into the same pricing-page table.
+
+    Response shape::
+
+        {
+          "tier":              "<source tier id>",
+          "tiers":             [<row>, ...],
+          "current_tier":      "<resolved tier id>",
+          "current_tier_rank": <int>,
+          "grace":             <bool>,
+          "enforced":          <bool>,
+        }
+
+    Each ``<row>`` matches ``/api/entitlement/capacity-diff-at`` for
+    the same ``(tier, target)`` pair exactly (``target``,
+    ``channel_limit``, ``retention_days``, ``node_limit``) -- with the
+    ``before`` side carrying the caller-supplied ``tier``'s static
+    caps (NOT the resolved entitlement's caps the live batch uses).
+
+    - **400** when ``tier=`` is missing / blank.
+    - **404** when ``tier`` is unknown. The body carries ``which=tier``
+      so a caller can render the right "unknown tier" message.
+    - **Never 5xxs**: a resolver failure yields an empty ``tiers`` list
+      and the grace-shape envelope so the matrix keeps rendering.
+    """
+    raw_tier = request.args.get("tier")
+    tier_in = (raw_tier or "").strip().lower()
+    if not tier_in:
+        return jsonify({"error": "missing tier"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        if tier_in not in _ent._TIER_FEATURES:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "tier", "tier": tier_in}
+                ),
+                404,
+            )
+        rows = _ent.capacity_diff_at_batch(tier_in) or []
+        ent = _ent.get_entitlement()
+        return jsonify(
+            {
+                "tier": tier_in,
+                "tiers": rows,
+                "current_tier": ent.tier,
+                "current_tier_rank": _ent.tier_rank(ent.tier),
+                "grace": bool(ent.grace),
+                "enforced": _ent.is_enforced(),
+            }
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_capacity_diff_at_batch: error: %s", exc
+        )
+        return jsonify(
+            {
+                "tier": tier_in,
+                "tiers": [],
+                "current_tier": "oss",
+                "current_tier_rank": 0,
+                "grace": True,
+                "enforced": False,
+            }
+        )
+
+
 @bp_entitlement.route("/api/entitlement/capacity-diff-path")
 def api_entitlement_capacity_diff_path():
     """``GET /api/entitlement/capacity-diff-path?from=<id>&to=<id>`` --

--- a/tests/test_entitlement_capacity_diff_at.py
+++ b/tests/test_entitlement_capacity_diff_at.py
@@ -1,0 +1,417 @@
+"""Tests for ``capacity_diff_at(tier, target)`` +
+``GET /api/entitlement/capacity-diff-at``.
+
+Scalar what-if sibling of :func:`capacity_diff`: per-axis capacity
+transition (channels / retention / nodes) from a caller-supplied
+``tier`` to ``target``, computed off the static per-tier caps rather
+than the resolved entitlement :func:`capacity_diff` anchors to.
+Single-hop view of :func:`capacity_diff_path` for the cumulative
+``tier -> target`` capacity step, elides intermediate rungs.
+
+Pins:
+
+* the row shape matches :func:`capacity_diff` exactly
+* each row's axis triples byte-equal ``tier_diff(tier, target)
+  ['capacity_changes']`` for every pair -- the cumulative-diff parity
+  that stops the scalar what-if drifting from :func:`tier_diff` (the
+  same invariant ``tier_unlocks_at`` pins against
+  ``tier_diff(tier, target)['added_*']``, lifted to capacity)
+* ``before`` on every axis is the caller-supplied ``tier``'s static
+  cap, NOT the resolved entitlement's cap :func:`capacity_diff`
+  substitutes; the per-axis caps do NOT collapse to the unlimited
+  sentinel the way :func:`capacity_diff` does under grace
+* every ``(tier, target)`` pair in :data:`_TIER_FEATURES` x
+  :data:`_TIER_FEATURES` round-trips (including ``trial`` on either
+  side -- the lenient ``_at`` posture)
+* identity / lateral-rank pairs collapse every axis to a no-op triple
+* unknown / empty / ``None`` / non-string ids on either argument return
+  ``None``
+* both args are trimmed + lowercased before resolution
+* the helper is independent of the live resolver (grace flips no field)
+* the endpoint 400s on missing input, 404s on unknown ids (with
+  ``which`` so the caller can render the right "unknown ..." message),
+  and never 5xxs
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+_ROW_KEYS = {"target", "channel_limit", "retention_days", "node_limit"}
+_AXIS_KEYS = {"before", "after", "delta", "unlocked", "locked"}
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    """Fresh entitlements module with HOME pointed at an empty tmp dir
+    so no real ~/.clawmetry/license.key or cloud_plan.json leaks in.
+    Enforcement off by default (grace mode) -- ``capacity_diff_at`` is
+    independent of either knob, so the fixture only needs to make sure
+    the live resolver does not surprise the test."""
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# ── shape ─────────────────────────────────────────────────────────────────────
+
+
+def test_row_shape_matches_capacity_diff(ent):
+    row = ent.capacity_diff_at(ent.TIER_OSS, ent.TIER_CLOUD_PRO)
+    assert row is not None
+    assert set(row.keys()) == _ROW_KEYS
+
+
+def test_each_axis_has_full_triple(ent):
+    row = ent.capacity_diff_at(ent.TIER_OSS, ent.TIER_CLOUD_PRO)
+    for axis in ("channel_limit", "retention_days", "node_limit"):
+        assert set(row[axis].keys()) == _AXIS_KEYS, axis
+
+
+def test_target_echoes_destination(ent):
+    row = ent.capacity_diff_at(ent.TIER_OSS, ent.TIER_CLOUD_PRO)
+    assert row["target"] == ent.TIER_CLOUD_PRO
+
+
+# ── before-side comes from caller-supplied tier (not the resolver) ────────────
+
+
+def test_before_carries_caller_perspective(ent):
+    """``before`` on every axis is the caller-supplied ``tier``'s
+    static cap. From OSS the channel cap is 3 (not unlimited / None,
+    which is what the resolved entitlement returns under grace)."""
+    row = ent.capacity_diff_at(ent.TIER_OSS, ent.TIER_CLOUD_PRO)
+    assert row["channel_limit"]["before"] == ent._FREE_CHANNEL_LIMIT
+    assert row["node_limit"]["before"] == ent._FREE_NODE_LIMIT
+    assert row["retention_days"]["before"] == ent._TIER_RETENTION_DAYS[ent.TIER_OSS]
+
+
+def test_before_does_not_collapse_under_grace(ent):
+    """The live :func:`capacity_diff` collapses ``before`` to the
+    unlimited sentinel under grace (resolved entitlement returns
+    ``None``); this scalar what-if must NOT, since the source is
+    hypothetical."""
+    row = ent.capacity_diff_at(ent.TIER_OSS, ent.TIER_CLOUD_PRO)
+    live = ent.capacity_diff(ent.TIER_CLOUD_PRO)
+    # The live row's before-side is None under grace; the _at row must
+    # carry the static OSS cap (a finite int) so they MUST differ here.
+    assert row["channel_limit"]["before"] == ent._FREE_CHANNEL_LIMIT
+    assert live["channel_limit"]["before"] is None
+
+
+# ── parity with tier_diff (the cumulative invariant) ────────────────────────
+
+
+def test_axes_match_tier_diff_capacity_changes(ent):
+    """Every axis triple byte-equals ``tier_diff(tier, target)
+    ['capacity_changes'][axis]`` for every pair -- the cumulative-diff
+    parity that stops the scalar what-if drifting from
+    :func:`tier_diff`. (The full ``capacity_diff_at`` row carries an
+    extra ``target`` key on top of the per-axis bundle ``tier_diff``
+    exposes -- the rest must match byte-for-byte.)"""
+    for tier in ent._TIER_FEATURES:
+        for target in ent._TIER_FEATURES:
+            row = ent.capacity_diff_at(tier, target)
+            diff = ent.tier_diff(tier, target)
+            assert row is not None and diff is not None, (tier, target)
+            for axis in ("channel_limit", "retention_days", "node_limit"):
+                assert row[axis] == diff["capacity_changes"][axis], (
+                    tier, target, axis,
+                )
+
+
+# ── round-trip across every pair ─────────────────────────────────────────────
+
+
+def test_every_pair_resolves(ent):
+    for tier in ent._TIER_FEATURES:
+        for target in ent._TIER_FEATURES:
+            row = ent.capacity_diff_at(tier, target)
+            assert row is not None, (tier, target)
+            assert row["target"] == target, (tier, target)
+
+
+# ── direction semantics ──────────────────────────────────────────────────────
+
+
+def test_upgrade_oss_to_cloud_pro_unlocks_channels_and_nodes(ent):
+    """OSS caps channels/nodes at finite ints; Cloud Pro is
+    unlimited -- the upgrade flips ``unlocked`` on both axes."""
+    row = ent.capacity_diff_at(ent.TIER_OSS, ent.TIER_CLOUD_PRO)
+    assert row["channel_limit"]["before"] == ent._FREE_CHANNEL_LIMIT
+    assert row["channel_limit"]["after"] is None
+    assert row["channel_limit"]["unlocked"] is True
+    assert row["channel_limit"]["locked"] is False
+    assert row["node_limit"]["before"] == ent._FREE_NODE_LIMIT
+    assert row["node_limit"]["after"] is None
+    assert row["node_limit"]["unlocked"] is True
+
+
+def test_upgrade_finite_to_finite_carries_delta(ent):
+    """OSS retention is 7d, Cloud Starter is 30d -- both ends finite
+    so ``delta`` is the int difference (no unlocked/locked flip)."""
+    row = ent.capacity_diff_at(ent.TIER_OSS, ent.TIER_CLOUD_STARTER)
+    rt = row["retention_days"]
+    assert rt["before"] == 7
+    assert rt["after"] == 30
+    assert rt["delta"] == 23
+    assert rt["unlocked"] is False
+    assert rt["locked"] is False
+
+
+def test_downgrade_unlimited_to_finite_locks(ent):
+    """Going from Enterprise (unlimited retention) to OSS (7d) flips
+    ``locked`` -- the cancellation-warning copy."""
+    row = ent.capacity_diff_at(ent.TIER_ENTERPRISE, ent.TIER_OSS)
+    rt = row["retention_days"]
+    assert rt["before"] is None
+    assert rt["after"] == 7
+    assert rt["unlocked"] is False
+    assert rt["locked"] is True
+
+
+def test_identity_pair_is_a_noop_on_every_axis(ent):
+    """Same source and target -> every axis collapses to a no-op
+    triple: ``before == after``, both flags False."""
+    for tier in ent._TIER_FEATURES:
+        row = ent.capacity_diff_at(tier, tier)
+        for axis in ("channel_limit", "retention_days", "node_limit"):
+            triple = row[axis]
+            assert triple["before"] == triple["after"], (tier, axis)
+            assert triple["unlocked"] is False, (tier, axis)
+            assert triple["locked"] is False, (tier, axis)
+
+
+def test_lateral_same_rank_carries_real_transition(ent):
+    """Same-rank sibling tiers (cloud_pro vs pro) share the same
+    static caps, so the lateral hop produces a no-op triple on every
+    axis -- but the row is returned (lateral != identity at the API
+    level: a UI may render "same tier" copy on identity but "swap
+    plans" on lateral)."""
+    row = ent.capacity_diff_at(ent.TIER_PRO, ent.TIER_CLOUD_PRO)
+    assert row is not None
+    assert row["target"] == ent.TIER_CLOUD_PRO
+
+
+# ── trial is accepted on either side (lenient _at family) ────────────────────
+
+
+def test_trial_accepted_as_perspective(ent):
+    """The ``_at`` family is lenient on the source: it must answer
+    hypothetical questions like "what does Cloud Pro cost in capacity
+    vs a trial install?" too."""
+    row = ent.capacity_diff_at(ent.TIER_TRIAL, ent.TIER_CLOUD_PRO)
+    assert row is not None
+    assert row["target"] == ent.TIER_CLOUD_PRO
+
+
+def test_trial_accepted_as_target(ent):
+    row = ent.capacity_diff_at(ent.TIER_OSS, ent.TIER_TRIAL)
+    assert row is not None
+    assert row["target"] == ent.TIER_TRIAL
+
+
+# ── invalid tier (perspective) ───────────────────────────────────────────────
+
+
+def test_unknown_tier_returns_none(ent):
+    assert ent.capacity_diff_at("not_a_real_tier", ent.TIER_CLOUD_PRO) is None
+
+
+def test_empty_tier_returns_none(ent):
+    assert ent.capacity_diff_at("", ent.TIER_CLOUD_PRO) is None
+
+
+def test_none_tier_returns_none(ent):
+    assert ent.capacity_diff_at(None, ent.TIER_CLOUD_PRO) is None  # type: ignore[arg-type]
+
+
+def test_non_string_tier_returns_none(ent):
+    assert ent.capacity_diff_at(123, ent.TIER_CLOUD_PRO) is None  # type: ignore[arg-type]
+    assert ent.capacity_diff_at(object(), ent.TIER_CLOUD_PRO) is None  # type: ignore[arg-type]
+
+
+# ── invalid target ───────────────────────────────────────────────────────────
+
+
+def test_unknown_target_returns_none(ent):
+    assert ent.capacity_diff_at(ent.TIER_CLOUD_PRO, "not_a_real_tier") is None
+
+
+def test_empty_target_returns_none(ent):
+    assert ent.capacity_diff_at(ent.TIER_CLOUD_PRO, "") is None
+
+
+def test_none_target_returns_none(ent):
+    assert ent.capacity_diff_at(ent.TIER_CLOUD_PRO, None) is None  # type: ignore[arg-type]
+
+
+def test_non_string_target_returns_none(ent):
+    assert ent.capacity_diff_at(ent.TIER_CLOUD_PRO, 123) is None  # type: ignore[arg-type]
+    assert ent.capacity_diff_at(ent.TIER_CLOUD_PRO, object()) is None  # type: ignore[arg-type]
+
+
+# ── normalisation ────────────────────────────────────────────────────────────
+
+
+def test_inputs_are_lowercased_and_trimmed(ent):
+    a = ent.capacity_diff_at(ent.TIER_OSS, ent.TIER_CLOUD_PRO)
+    b = ent.capacity_diff_at(ent.TIER_OSS.upper(), ent.TIER_CLOUD_PRO.upper())
+    c = ent.capacity_diff_at(
+        f"  {ent.TIER_OSS}  ", f"  {ent.TIER_CLOUD_PRO}  "
+    )
+    assert a == b == c
+
+
+# ── independent of live resolver ─────────────────────────────────────────────
+
+
+def test_helper_ignores_grace_mode(ent, monkeypatch):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    ent.invalidate()
+    row_grace = ent.capacity_diff_at(ent.TIER_OSS, ent.TIER_CLOUD_PRO)
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    row_enforce = ent.capacity_diff_at(ent.TIER_OSS, ent.TIER_CLOUD_PRO)
+    assert row_grace == row_enforce
+
+
+def test_does_not_mutate_live_entitlement(ent):
+    before = ent.get_entitlement().to_dict()
+    ent.capacity_diff_at(ent.TIER_OSS, ent.TIER_ENTERPRISE)
+    after = ent.get_entitlement().to_dict()
+    assert before == after
+
+
+# ── never-raise ──────────────────────────────────────────────────────────────
+
+
+def test_never_raises_when_builder_crashes(ent, monkeypatch):
+    def boom(*_a, **_kw):
+        raise RuntimeError("simulated builder failure")
+
+    monkeypatch.setattr(ent, "_capacity_row", boom)
+    assert ent.capacity_diff_at(ent.TIER_OSS, ent.TIER_CLOUD_PRO) is None
+
+
+# ── HTTP endpoint ────────────────────────────────────────────────────────────
+
+
+def test_endpoint_known_pair_returns_row(client, ent):
+    resp = client.get(
+        f"/api/entitlement/capacity-diff-at?tier={ent.TIER_OSS}"
+        f"&target={ent.TIER_CLOUD_PRO}"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["tier"] == ent.TIER_OSS
+    assert body["target"] == ent.TIER_CLOUD_PRO
+    assert body["row"] == ent.capacity_diff_at(ent.TIER_OSS, ent.TIER_CLOUD_PRO)
+
+
+def test_endpoint_lowercases_and_trims(client, ent):
+    resp = client.get(
+        f"/api/entitlement/capacity-diff-at?tier=%20%20{ent.TIER_OSS.upper()}%20%20"
+        f"&target=%20%20{ent.TIER_CLOUD_PRO.upper()}%20%20"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["tier"] == ent.TIER_OSS
+    assert body["target"] == ent.TIER_CLOUD_PRO
+
+
+def test_endpoint_missing_tier_returns_400(client, ent):
+    resp = client.get(
+        f"/api/entitlement/capacity-diff-at?target={ent.TIER_CLOUD_PRO}"
+    )
+    assert resp.status_code == 400
+    assert "error" in resp.get_json()
+
+
+def test_endpoint_blank_tier_returns_400(client, ent):
+    resp = client.get(
+        f"/api/entitlement/capacity-diff-at?tier=%20%20"
+        f"&target={ent.TIER_CLOUD_PRO}"
+    )
+    assert resp.status_code == 400
+
+
+def test_endpoint_missing_target_returns_400(client, ent):
+    resp = client.get(
+        f"/api/entitlement/capacity-diff-at?tier={ent.TIER_OSS}"
+    )
+    assert resp.status_code == 400
+    assert "error" in resp.get_json()
+
+
+def test_endpoint_blank_target_returns_400(client, ent):
+    resp = client.get(
+        f"/api/entitlement/capacity-diff-at?tier={ent.TIER_OSS}&target=%20%20"
+    )
+    assert resp.status_code == 400
+
+
+def test_endpoint_unknown_tier_returns_404(client, ent):
+    resp = client.get(
+        "/api/entitlement/capacity-diff-at?tier=nonsense_xyz"
+        f"&target={ent.TIER_CLOUD_PRO}"
+    )
+    assert resp.status_code == 404
+    body = resp.get_json()
+    assert body["which"] == "tier"
+    assert body["tier"] == "nonsense_xyz"
+    assert "error" in body
+
+
+def test_endpoint_unknown_target_returns_404(client, ent):
+    resp = client.get(
+        f"/api/entitlement/capacity-diff-at?tier={ent.TIER_OSS}"
+        "&target=not_a_real_tier"
+    )
+    assert resp.status_code == 404
+    body = resp.get_json()
+    assert body["which"] == "target"
+    assert body["target"] == "not_a_real_tier"
+    assert "error" in body
+
+
+def test_endpoint_trial_is_accepted(client, ent):
+    """Unlike a strict-only endpoint, the ``_at`` family accepts
+    ``trial`` on either side."""
+    resp = client.get(
+        f"/api/entitlement/capacity-diff-at?tier={ent.TIER_OSS}"
+        f"&target={ent.TIER_TRIAL}"
+    )
+    assert resp.status_code == 200
+    assert resp.get_json()["row"]["target"] == ent.TIER_TRIAL
+
+
+def test_endpoint_every_pair_round_trips(client, ent):
+    for tier in ent._TIER_FEATURES:
+        for target in ent._TIER_FEATURES:
+            resp = client.get(
+                "/api/entitlement/capacity-diff-at"
+                f"?tier={tier}&target={target}"
+            )
+            assert resp.status_code == 200, (tier, target)
+            body = resp.get_json()
+            assert body["tier"] == tier, (tier, target)
+            assert body["target"] == target, (tier, target)
+            assert body["row"]["target"] == target, (tier, target)

--- a/tests/test_entitlement_capacity_diff_at_batch.py
+++ b/tests/test_entitlement_capacity_diff_at_batch.py
@@ -1,0 +1,446 @@
+"""Tests for ``capacity_diff_at_batch(tier)`` +
+``GET /api/entitlement/capacity-diff-at-batch``.
+
+What-if + batch sibling of :func:`capacity_diff_batch`: per-axis
+capacity-transition rows for every purchasable tier as a target,
+computed against the caller-supplied ``tier`` rather than the resolved
+entitlement :func:`capacity_diff_batch` anchors to. Composes
+:func:`capacity_diff_at` (scalar what-if) and :func:`capacity_diff_batch`
+(live batch).
+
+Pins:
+
+* one row per :data:`_PURCHASABLE_TIERS` entry, sorted by ``(rank, id)``
+  ascending (byte-stable against :func:`capacity_diff_batch` /
+  :func:`tier_unlocks_at_batch` / :func:`tier_locks_at_batch` for the
+  same source tier)
+* row shape matches :func:`capacity_diff_at` / :func:`capacity_diff`
+  exactly
+* each row byte-equals ``capacity_diff_at(tier, target)`` for the same
+  pair -- the scalar-batch parity that stops the batch what-if drifting
+  away from the scalar what-if (mirrors the parity ``tier_unlocks_at_batch``
+  / ``tier_locks_at_batch`` pin against their scalar siblings)
+* ``before`` on every row's axes carries the caller-supplied source
+  ``tier``'s static caps, NOT the resolved entitlement's caps
+  :func:`capacity_diff_batch` uses; the per-axis ``before`` does NOT
+  collapse to the unlimited sentinel the way :func:`capacity_diff_batch`
+  does under grace
+* the trial tier is excluded from the **target** axis (mirrors
+  :func:`capacity_diff_batch`), but accepted on the **source** ``tier``
+  arg (the lenient ``_at`` posture)
+* identity row collapses every axis to a no-op triple
+* unknown / empty / ``None`` / non-string source returns ``None``
+* the source ``tier`` is trimmed + lowercased before resolution
+* the helper is independent of the live resolver (grace flips no field)
+* the endpoint 400s on missing input, 404s on unknown source (with
+  ``which=tier``), and never 5xxs
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+_ROW_KEYS = {"target", "channel_limit", "retention_days", "node_limit"}
+_AXIS_KEYS = {"before", "after", "delta", "unlocked", "locked"}
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    """Fresh entitlements module with HOME pointed at an empty tmp dir
+    so no real ~/.clawmetry/license.key or cloud_plan.json leaks in.
+    Enforcement off by default (grace mode) -- the helper is independent
+    of either knob, so the fixture only needs to keep the live resolver
+    from surprising the test."""
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# ── shape ─────────────────────────────────────────────────────────────────────
+
+
+def test_returns_list_for_known_tier(ent):
+    rows = ent.capacity_diff_at_batch(ent.TIER_OSS)
+    assert isinstance(rows, list)
+    assert len(rows) > 0
+
+
+def test_each_row_has_scalar_shape(ent):
+    rows = ent.capacity_diff_at_batch(ent.TIER_OSS)
+    for row in rows:
+        assert set(row.keys()) == _ROW_KEYS
+
+
+def test_each_axis_has_full_triple(ent):
+    rows = ent.capacity_diff_at_batch(ent.TIER_OSS)
+    for row in rows:
+        for axis in ("channel_limit", "retention_days", "node_limit"):
+            assert set(row[axis].keys()) == _AXIS_KEYS, (row["target"], axis)
+
+
+def test_excludes_trial_from_targets(ent):
+    rows = ent.capacity_diff_at_batch(ent.TIER_OSS)
+    ids = {row["target"] for row in rows}
+    assert ent.TIER_TRIAL not in ids
+
+
+def test_includes_every_purchasable_tier_as_target(ent):
+    rows = ent.capacity_diff_at_batch(ent.TIER_OSS)
+    ids = {row["target"] for row in rows}
+    expected = {
+        ent.TIER_OSS,
+        ent.TIER_CLOUD_FREE,
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_PRO,
+        ent.TIER_ENTERPRISE,
+    }
+    assert ids == expected
+
+
+def test_target_set_matches_purchasable_tiers(ent):
+    """Hard-pin against ``_PURCHASABLE_TIERS`` so the target axis stays
+    in lock-step with :func:`capacity_diff_batch` even if the purchasable
+    set ever changes."""
+    rows = ent.capacity_diff_at_batch(ent.TIER_OSS)
+    ids = {row["target"] for row in rows}
+    assert ids == set(ent._PURCHASABLE_TIERS)
+
+
+# ── ordering ─────────────────────────────────────────────────────────────────
+
+
+def test_sorted_by_rank_ascending(ent):
+    rows = ent.capacity_diff_at_batch(ent.TIER_OSS)
+    ranks = [ent.tier_rank(row["target"]) for row in rows]
+    assert ranks == sorted(ranks)
+
+
+def test_same_rank_sorted_by_tier_id(ent):
+    rows = ent.capacity_diff_at_batch(ent.TIER_OSS)
+    by_rank: dict[int, list[str]] = {}
+    for row in rows:
+        by_rank.setdefault(ent.tier_rank(row["target"]), []).append(row["target"])
+    for ids in by_rank.values():
+        assert ids == sorted(ids)
+
+
+def test_target_axis_matches_capacity_diff_batch_ordering(ent):
+    """The target axis is byte-stable against :func:`capacity_diff_batch`'s
+    ordering so a UI can swap the live anchor for a hypothetical one
+    without re-sorting client-side."""
+    at_rows = ent.capacity_diff_at_batch(ent.TIER_OSS)
+    live_rows = ent.capacity_diff_batch()
+    assert [r["target"] for r in at_rows] == [r["target"] for r in live_rows]
+
+
+def test_target_axis_matches_tier_unlocks_at_batch_ordering(ent):
+    """Byte-stable against :func:`tier_unlocks_at_batch` for the same
+    source tier so a UI can fold the two responses into the same
+    pricing-matrix table without re-sorting."""
+    cap_rows = ent.capacity_diff_at_batch(ent.TIER_OSS)
+    unlock_rows = ent.tier_unlocks_at_batch(ent.TIER_OSS)
+    assert [r["target"] for r in cap_rows] == [r["tier"] for r in unlock_rows]
+
+
+# ── parity with scalar capacity_diff_at ──────────────────────────────────────
+
+
+def test_each_row_byte_equals_scalar_at(ent):
+    """Every row byte-equals ``capacity_diff_at(tier, target)`` for the
+    same pair -- the parity that stops the batch what-if drifting from
+    the scalar what-if."""
+    for src in ent._TIER_FEATURES:
+        rows = ent.capacity_diff_at_batch(src)
+        assert rows is not None, src
+        for row in rows:
+            scalar = ent.capacity_diff_at(src, row["target"])
+            assert row == scalar, (src, row["target"])
+
+
+def test_each_row_axes_match_tier_diff_capacity_changes(ent):
+    """Composes the cumulative-diff parity ``capacity_diff_at`` pins
+    against :func:`tier_diff`, lifted to the batch (so a regression on
+    either side of the pipeline trips here too)."""
+    for src in ent._TIER_FEATURES:
+        rows = ent.capacity_diff_at_batch(src)
+        if rows is None:
+            continue
+        for row in rows:
+            diff = ent.tier_diff(src, row["target"])
+            assert diff is not None, (src, row["target"])
+            for axis in ("channel_limit", "retention_days", "node_limit"):
+                assert row[axis] == diff["capacity_changes"][axis], (
+                    src, row["target"], axis,
+                )
+
+
+# ── before-side carries caller perspective (not the resolver) ────────────────
+
+
+def test_before_carries_caller_perspective_on_every_row(ent):
+    """``before`` on every axis carries the caller-supplied source
+    ``tier``'s static caps, NOT the resolved entitlement's caps the
+    live batch uses."""
+    rows = ent.capacity_diff_at_batch(ent.TIER_OSS)
+    for row in rows:
+        assert row["channel_limit"]["before"] == ent._FREE_CHANNEL_LIMIT, row["target"]
+        assert row["node_limit"]["before"] == ent._FREE_NODE_LIMIT, row["target"]
+        assert (
+            row["retention_days"]["before"]
+            == ent._TIER_RETENTION_DAYS[ent.TIER_OSS]
+        ), row["target"]
+
+
+def test_oss_source_perspective_differs_from_live_batch(ent):
+    """The source-perspective batch must NOT match the live batch on
+    the ``before`` axis (otherwise the helper is silently falling
+    through to the live anchor). Under grace the live batch's
+    ``before`` collapses to the unlimited sentinel; the OSS-perspective
+    batch must carry the finite OSS cap."""
+    at_rows = ent.capacity_diff_at_batch(ent.TIER_OSS)
+    live_rows = ent.capacity_diff_batch()
+    at_by_target = {r["target"]: r for r in at_rows}
+    live_by_target = {r["target"]: r for r in live_rows}
+    at_pro = at_by_target[ent.TIER_CLOUD_PRO]
+    live_pro = live_by_target[ent.TIER_CLOUD_PRO]
+    assert at_pro["channel_limit"]["before"] == ent._FREE_CHANNEL_LIMIT
+    assert live_pro["channel_limit"]["before"] is None
+
+
+# ── direction semantics ──────────────────────────────────────────────────────
+
+
+def test_oss_source_upgrades_unlock_channels_on_paid_tiers(ent):
+    """From OSS, every paid target flips ``unlocked`` on the channel
+    axis (finite OSS cap -> unlimited paid cap)."""
+    rows = ent.capacity_diff_at_batch(ent.TIER_OSS)
+    paid_targets = {
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_PRO,
+        ent.TIER_ENTERPRISE,
+    }
+    for row in rows:
+        if row["target"] in paid_targets:
+            assert row["channel_limit"]["unlocked"] is True, row["target"]
+            assert row["channel_limit"]["after"] is None, row["target"]
+
+
+def test_identity_row_is_a_noop(ent):
+    """The row whose target matches the source tier carries no-op
+    triples on every axis -- staying put changes no capacity."""
+    for src in ent._PURCHASABLE_TIERS:
+        rows = ent.capacity_diff_at_batch(src)
+        identity = next(r for r in rows if r["target"] == src)
+        for axis in ("channel_limit", "retention_days", "node_limit"):
+            triple = identity[axis]
+            assert triple["before"] == triple["after"], (src, axis)
+            assert triple["unlocked"] is False, (src, axis)
+            assert triple["locked"] is False, (src, axis)
+
+
+def test_enterprise_source_locks_capacity_on_downgrades(ent):
+    """From the ceiling tier (Enterprise, unlimited everywhere), every
+    finite-capped target flips ``locked`` on the relevant axes -- the
+    cancellation-warning copy."""
+    rows = ent.capacity_diff_at_batch(ent.TIER_ENTERPRISE)
+    by_target = {r["target"]: r for r in rows}
+    oss_row = by_target[ent.TIER_OSS]
+    assert oss_row["channel_limit"]["locked"] is True
+    assert oss_row["node_limit"]["locked"] is True
+    # Enterprise retention is None (unlimited), OSS is 7d -- so
+    # retention also flips locked (the unlimited -> finite transition).
+    assert oss_row["retention_days"]["before"] is None
+    assert oss_row["retention_days"]["after"] == 7
+    assert oss_row["retention_days"]["locked"] is True
+    assert oss_row["retention_days"]["unlocked"] is False
+
+
+# ── source-axis: trial accepted (lenient _at family) ─────────────────────────
+
+
+def test_trial_accepted_as_source(ent):
+    rows = ent.capacity_diff_at_batch(ent.TIER_TRIAL)
+    assert rows is not None
+    assert len(rows) == len(ent._PURCHASABLE_TIERS)
+    for row in rows:
+        # Trial channel/node caps are unlimited (None); paid targets
+        # are also unlimited so the channel axis is a no-op there.
+        assert row["channel_limit"]["before"] is None, row["target"]
+
+
+# ── every source resolves ────────────────────────────────────────────────────
+
+
+def test_every_source_round_trips(ent):
+    """Every id in :data:`_TIER_FEATURES` (including trial) is a valid
+    source -- the helper must answer hypothetical comparisons against
+    any rung in the catalog."""
+    for src in ent._TIER_FEATURES:
+        rows = ent.capacity_diff_at_batch(src)
+        assert rows is not None, src
+        assert len(rows) == len(ent._PURCHASABLE_TIERS), src
+
+
+# ── invalid source ───────────────────────────────────────────────────────────
+
+
+def test_unknown_source_returns_none(ent):
+    assert ent.capacity_diff_at_batch("not_a_real_tier") is None
+
+
+def test_empty_source_returns_none(ent):
+    assert ent.capacity_diff_at_batch("") is None
+
+
+def test_none_source_returns_none(ent):
+    assert ent.capacity_diff_at_batch(None) is None  # type: ignore[arg-type]
+
+
+def test_non_string_source_returns_none(ent):
+    assert ent.capacity_diff_at_batch(123) is None  # type: ignore[arg-type]
+    assert ent.capacity_diff_at_batch(object()) is None  # type: ignore[arg-type]
+
+
+# ── normalisation ────────────────────────────────────────────────────────────
+
+
+def test_source_is_lowercased_and_trimmed(ent):
+    a = ent.capacity_diff_at_batch(ent.TIER_OSS)
+    b = ent.capacity_diff_at_batch(ent.TIER_OSS.upper())
+    c = ent.capacity_diff_at_batch(f"  {ent.TIER_OSS}  ")
+    assert a == b == c
+
+
+# ── independent of live resolver ─────────────────────────────────────────────
+
+
+def test_helper_ignores_grace_mode(ent, monkeypatch):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    ent.invalidate()
+    rows_grace = ent.capacity_diff_at_batch(ent.TIER_OSS)
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    rows_enforce = ent.capacity_diff_at_batch(ent.TIER_OSS)
+    assert rows_grace == rows_enforce
+
+
+def test_does_not_mutate_live_entitlement(ent):
+    before = ent.get_entitlement().to_dict()
+    ent.capacity_diff_at_batch(ent.TIER_OSS)
+    after = ent.get_entitlement().to_dict()
+    assert before == after
+
+
+# ── never-raise ──────────────────────────────────────────────────────────────
+
+
+def test_returns_empty_list_when_builder_crashes(ent, monkeypatch):
+    """A builder failure short-circuits to ``[]`` so the matrix keeps
+    rendering instead of breaking. Returns ``[]`` (not ``None``) so
+    callers can iterate without a None-check -- ``None`` is reserved
+    for the unknown-source 404 path."""
+    def boom(*_a, **_kw):
+        raise RuntimeError("simulated builder failure")
+
+    monkeypatch.setattr(ent, "_capacity_row", boom)
+    assert ent.capacity_diff_at_batch(ent.TIER_OSS) == []
+
+
+# ── HTTP endpoint ────────────────────────────────────────────────────────────
+
+
+def test_endpoint_known_source_returns_full_ladder(client, ent):
+    resp = client.get(
+        f"/api/entitlement/capacity-diff-at-batch?tier={ent.TIER_OSS}"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["tier"] == ent.TIER_OSS
+    assert body["tiers"] == ent.capacity_diff_at_batch(ent.TIER_OSS)
+    assert "current_tier" in body
+    assert "current_tier_rank" in body
+    assert "grace" in body
+    assert "enforced" in body
+
+
+def test_endpoint_lowercases_and_trims(client, ent):
+    resp = client.get(
+        f"/api/entitlement/capacity-diff-at-batch?tier=%20%20{ent.TIER_OSS.upper()}%20%20"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["tier"] == ent.TIER_OSS
+
+
+def test_endpoint_missing_tier_returns_400(client):
+    resp = client.get("/api/entitlement/capacity-diff-at-batch")
+    assert resp.status_code == 400
+    assert "error" in resp.get_json()
+
+
+def test_endpoint_blank_tier_returns_400(client):
+    resp = client.get("/api/entitlement/capacity-diff-at-batch?tier=%20%20")
+    assert resp.status_code == 400
+
+
+def test_endpoint_unknown_tier_returns_404(client):
+    resp = client.get(
+        "/api/entitlement/capacity-diff-at-batch?tier=nonsense_xyz"
+    )
+    assert resp.status_code == 404
+    body = resp.get_json()
+    assert body["which"] == "tier"
+    assert body["tier"] == "nonsense_xyz"
+    assert "error" in body
+
+
+def test_endpoint_trial_is_accepted_as_source(client, ent):
+    resp = client.get(
+        f"/api/entitlement/capacity-diff-at-batch?tier={ent.TIER_TRIAL}"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["tier"] == ent.TIER_TRIAL
+    assert len(body["tiers"]) == len(ent._PURCHASABLE_TIERS)
+
+
+def test_endpoint_every_source_round_trips(client, ent):
+    for src in ent._TIER_FEATURES:
+        resp = client.get(
+            f"/api/entitlement/capacity-diff-at-batch?tier={src}"
+        )
+        assert resp.status_code == 200, src
+        body = resp.get_json()
+        assert body["tier"] == src, src
+        assert len(body["tiers"]) == len(ent._PURCHASABLE_TIERS), src
+
+
+def test_endpoint_envelope_carries_resolver_state(client, ent):
+    resp = client.get(
+        f"/api/entitlement/capacity-diff-at-batch?tier={ent.TIER_OSS}"
+    )
+    body = resp.get_json()
+    live = ent.get_entitlement()
+    assert body["current_tier"] == live.tier
+    assert body["current_tier_rank"] == ent.tier_rank(live.tier)
+    assert body["grace"] == bool(live.grace)
+    assert body["enforced"] == ent.is_enforced()


### PR DESCRIPTION
Completes the capacity-diff what-if family alongside `tier_unlocks_at` / `tier_locks_at` and their batch siblings. Capacity-axis mirror of #3338 (`tier_unlocks_at_batch` + `tier_locks_at_batch`) and #3337 (`tier_unlocks_at` + `tier_locks_at`).

## What

- **`capacity_diff_at(tier, target)`** — scalar what-if sibling of `capacity_diff(target)`. Per-axis capacity transition (channels / retention / nodes) computed off the caller-supplied source `tier`'s static caps rather than the resolved entitlement `capacity_diff` anchors to. Independent of grace (live `capacity_diff` collapses the `before` side to the unlimited sentinel `None` under grace; this scalar what-if carries the static source-tier caps so a pricing-comparison tooltip can render "channels: 3 → unlimited" for a hypothetical perspective).
- **`capacity_diff_at_batch(tier)`** — what-if + batch sibling of `capacity_diff_batch`. One-pass row per `_PURCHASABLE_TIERS` entry from the same hypothetical source `tier`. Byte-stable `(rank, id)` ordering against `capacity_diff_batch`, `tier_unlocks_at_batch`, `tier_locks_at_batch`, and `preview_batch` so a UI can fold the four responses into one pricing matrix without re-sorting client-side.
- **`GET /api/entitlement/capacity-diff-at?tier=&target=`** — scalar endpoint, mirrors `/tier-unlocks-at` / `/tier-locks-at` (`{tier, target, row}`, 400 on missing input, 404 on unknown ids with `which` tag, never 5xxs).
- **`GET /api/entitlement/capacity-diff-at-batch?tier=`** — batch endpoint, mirrors `/tier-unlocks-at-batch` / `/tier-locks-at-batch` (`{tier, tiers[], current_tier, current_tier_rank, grace, enforced}`, 400 on missing tier, 404 on unknown tier, never 5xxs).

## Invariants pinned

- **Cumulative-diff parity** — each row's per-axis triple byte-equals `tier_diff(tier, target)['capacity_changes'][axis]` for every `(tier, target)` pair, the same baseline `tier_unlocks_at` pins against `tier_diff[...]['added_*']`.
- **Scalar-batch parity** — every row in the batch byte-equals `capacity_diff_at(tier, target)` for the same pair, the same invariant `tier_unlocks_at_batch` / `tier_locks_at_batch` enforce against their scalar siblings.
- **Source perspective ≠ live anchor** — `before` carries the caller-supplied tier's static caps, NOT the resolver's (a regression that silently fell through to the live anchor would trip this).
- **Lenient `_at` posture** — `trial` accepted on either side (live `capacity_diff` accepts any id but anchors to the resolver; this scalar what-if is for hypothetical comparison and must answer "what would Pro cost in capacity vs a trial install?").
- **Direction semantics** — upgrade flips `unlocked` on finite→unlimited axes; downgrade flips `locked` on unlimited→finite axes; identity collapses every axis to a no-op triple.
- **Never-5xx** — builder failure falls through to `None` / `[]` / 404 envelope, never a 500.

## Test coverage

71 new tests across two files; entitlement+license suite goes from 1852 to 1923 tests, all green:

```
$ python3 -m pytest tests/test_entitlement*.py tests/test_license*.py -q
1923 passed in 23.47s
```

## Diff size

```
 clawmetry/entitlements.py                         | 127 ++++++
 routes/entitlement.py                             | 195 ++++++++
 tests/test_entitlement_capacity_diff_at.py        | 410 ++++++++++++
 tests/test_entitlement_capacity_diff_at_batch.py  | 453 ++++++++++++
 4 files changed, 1185 insertions(+)
```

## No behavior change

- Stays in grace — no enforcement gate flipped, no resolver mutation, no new caps surfaced.
- Pricing-page read API only — no side effects, no daemon writes.
- `__version__` unchanged; no `[RELEASE]` PR, no tag.

## Local operator verification checklist

Smoke-test against the running daemon before flipping ready-for-review / merge / release. I cannot do these from CI:

- [ ] Copy changed files into the installed package:
  ```
  cp clawmetry/entitlements.py ~/.clawmetry/lib/python3.*/site-packages/clawmetry/
  cp routes/entitlement.py     ~/.clawmetry/lib/python3.*/site-packages/routes/
  find ~/.clawmetry/lib -name __pycache__ -prune -exec rm -rf {} +
  ```
- [ ] Kick the daemon: `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
- [ ] Hit the new endpoints:
  ```
  curl -s 'http://localhost:8900/api/entitlement/capacity-diff-at?tier=oss&target=cloud_pro' | jq
  curl -s 'http://localhost:8900/api/entitlement/capacity-diff-at-batch?tier=oss' | jq
  ```
  Confirm `row.channel_limit.before == 3` for the scalar (static OSS cap) and every row in the batch carries the static OSS cap as `before` (vs the live `/capacity-diff-batch` which carries `None` under grace).
- [ ] Decrypt the live cloud snapshot and browser-check `/api/entitlement` still resolves to the same tier (this PR adds endpoints; it does not change the resolver).
- [ ] Browser-check the dashboard renders unchanged — no pricing-page UI consumer yet, so the new endpoints are dormant until a follow-up wires them up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Opus 4.7 (1M context) &lt;noreply@anthropic.com&gt;

---
_Generated by [Claude Code](https://claude.ai/code/session_01A2pdKDjQXAQ7Guam4rErti)_