### PR TITLE
fix(adapter): extract fast-mode cutoff metadata from sessions and events

### DIFF
--- a/clawmetry/adapters/openclaw.py
+++ b/clawmetry/adapters/openclaw.py
@@ -960,6 +960,27 @@ class OpenClawAdapter(AgentAdapter):
             _fm = s.get("fastMode") if s.get("fastMode") is not None else s.get("isFastMode")
             if _fm is not None:
                 extra["fastMode"] = bool(_fm)
+            # Fast-mode fallback/cutoff metadata (#3341): PR #85104 also emits
+            # cutoff state, reason, transition count, delivery mode, and fallback
+            # model for sessions where fast-mode reverts to normal mode.
+            _fmc = s.get("fastModeCutoff")
+            if _fmc is not None:
+                extra["fastModeCutoff"] = bool(_fmc)
+            _fmc_reason = s.get("fastModeCutoffReason") or s.get("cutoffReason")
+            if _fmc_reason is not None:
+                extra["fastModeCutoffReason"] = _fmc_reason
+            _fmc_count = s.get("fastModeTransitionCount") or s.get("transitionCount")
+            if _fmc_count is not None:
+                try:
+                    extra["fastModeTransitionCount"] = int(_fmc_count)
+                except (TypeError, ValueError):
+                    pass
+            _fmc_mode = s.get("fastModeDeliveryMode") or s.get("deliveryMode")
+            if _fmc_mode is not None:
+                extra["fastModeDeliveryMode"] = _fmc_mode
+            _fm_fallback = s.get("fallbackModel") or s.get("fastModeFallbackModel")
+            if _fm_fallback is not None:
+                extra["fallbackModel"] = _fm_fallback
             # /think reasoning-level tier (#3324): PR #94067 stores the active
             # level (light/medium/deep) on session records; surface when present.
             _think_level = s.get("thinkLevel") or s.get("reasoningLevel")
@@ -1141,6 +1162,27 @@ class OpenClawAdapter(AgentAdapter):
                                 if _fmval is not None:
                                     extra["fastMode"] = bool(_fmval)
                                     break
+                            # Fast-mode fallback/cutoff metadata (#3341): PR #85104
+                            # also emits cutoff state on event blobs; extract reason,
+                            # transition count, delivery mode, and fallback model.
+                            _fmc = obj.get("fastModeCutoff")
+                            if _fmc is not None:
+                                extra["fastModeCutoff"] = bool(_fmc)
+                            _fmc_reason = obj.get("fastModeCutoffReason") or obj.get("cutoffReason")
+                            if _fmc_reason is not None:
+                                extra["fastModeCutoffReason"] = _fmc_reason
+                            _fmc_count = obj.get("fastModeTransitionCount") or obj.get("transitionCount")
+                            if _fmc_count is not None:
+                                try:
+                                    extra["fastModeTransitionCount"] = int(_fmc_count)
+                                except (TypeError, ValueError):
+                                    pass
+                            _fmc_mode = obj.get("fastModeDeliveryMode") or obj.get("deliveryMode")
+                            if _fmc_mode is not None:
+                                extra["fastModeDeliveryMode"] = _fmc_mode
+                            _fm_fallback = obj.get("fallbackModel") or obj.get("fastModeFallbackModel")
+                            if _fm_fallback is not None:
+                                extra["fallbackModel"] = _fm_fallback
                             # /think reasoning-level tier (#3324): PR #94067 stores
                             # the active level (light/medium/deep) on model-turn
                             # records; try camelCase then snake_case.


### PR DESCRIPTION
Closes #3341

## Summary

- openclaw PR #85104 extended fast-mode with bounded fallback semantics, adding five new fields to session and event records: `fastModeCutoff` (bool), `fastModeCutoffReason` (string), `fastModeTransitionCount` (int), `fastModeDeliveryMode` (string), and `fallbackModel` (string)
- The adapter already read `fastMode`/`isFastMode`/`talkFastMode` but silently dropped all five new fields
- This PR extends both the session-record extraction block (~line 960) and the event-blob extraction block (~line 1162) to also extract the five new fields, using the same `if _val is not None: extra[key] = val` guard pattern as the surrounding code

## Test plan

- [ ] Verify `python3 -m py_compile clawmetry/adapters/openclaw.py` passes (no syntax errors)
- [ ] On a build of openclaw that emits `fastModeCutoff`/`fastModeCutoffReason` etc., confirm these keys appear in session `extra` dicts returned by the adapter
- [ ] On older openclaw builds that don't emit these fields, confirm no regression — all five extractions are optional guards that no-op when the key is absent

---
_Generated by [Claude Code](https://claude.ai/code/session_013w8k9rwPnz1NW5GpXu1Cd2)_