### PR TITLE
feat(adapter): surface cronDeliveryTarget marker on openclaw sessions (#3342)

### DIFF
--- a/clawmetry/adapters/openclaw.py
+++ b/clawmetry/adapters/openclaw.py
@@ -971,6 +971,16 @@ class OpenClawAdapter(AgentAdapter):
             _idt = s.get("target") or s.get("identityTarget")
             if _idt is not None:
                 extra["identityTarget"] = _idt
+            # Cron delivery awareness (#3342): PR #93580 stamps a
+            # cronDeliveryTarget marker on sessions that are delivery targets
+            # of a cron job so they can be correlated with the originating
+            # cron. Without this, cron-triggered sessions are indistinguishable
+            # from direct sessions in the dashboard.
+            _cdt = s.get("cronDeliveryTarget")
+            if _cdt is None:
+                _cdt = s.get("isCronDeliveryTarget") or s.get("cronTarget")
+            if _cdt is not None:
+                extra["cronDeliveryTarget"] = bool(_cdt)
             tok_total = int(s.get("totalTokens") or 0)
             tok_in = int(s.get("inputTokens") or 0)
             tok_out = int(s.get("outputTokens") or 0)


### PR DESCRIPTION
## Summary

OpenClaw PR #93580 stamps a `cronDeliveryTarget` bool on sessions that are delivery targets of a cron job, so the cron and the session can be correlated. The ClawMetry openclaw adapter was already reading `fastMode`, `thinkLevel`, and `identityTarget` from session records, but silently dropped this field — making cron-triggered sessions indistinguishable from direct sessions in the dashboard.

## Changes

- `clawmetry/adapters/openclaw.py`: in `list_sessions()`, after the existing `identityTarget` extraction, read `cronDeliveryTarget` (with fallback aliases `isCronDeliveryTarget` / `cronTarget`) and store it as `extra["cronDeliveryTarget"]` (bool). Follows the same optional-guard pattern as every adjacent field — no-ops when the key is absent on older OpenClaw builds.

## Test plan

- [ ] `python3 -c 'import ast; ast.parse(open("clawmetry/adapters/openclaw.py").read())'` passes (syntax clean)
- [ ] On an OpenClaw build that emits `cronDeliveryTarget: true`, confirm cron-triggered sessions carry `cronDeliveryTarget: true` in their `extra` dict
- [ ] On older builds without the field, confirm no regression — the guard no-ops

## Bot meta
<!-- bot-autofix -->
Draft PR opened autonomously based on the plan in #3342. Marked draft for human review — mark Ready for Review once happy.

Closes #3342

---
_Generated by [Claude Code](https://claude.ai/code/session_01MPRJ7aW35Ws5KnRHaNjZAc)_