### PR TITLE
feat(entitlement): next_tier_locks + previous_tier_locks + endpoints

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -719,6 +719,70 @@ class Entitlement:
             logger.warning("entitlements: previous_tier_unlocks failed: %s", exc)
             return None
 
+    def next_tier_locks(self) -> dict | None:
+        """One-rung-up locks row in :func:`tier_locks` shape.
+
+        Marginal-loss companion to :meth:`next_tier_unlocks` and the fourth
+        member of the ``next_tier_*`` family alongside :meth:`next_tier_diff`
+        (full ``upgrade_diff`` shape), :meth:`next_tier_unlocks` (marginal
+        grants in ``tier_unlocks`` shape), and :meth:`next_tier_capacity_diff`
+        (capacity-only marginal).
+
+        Convenience for ``tier_locks(self.next_purchasable_tier())`` -- the
+        marginal-locks row of the rung immediately above current as a
+        tier-property (``lost_features`` / ``lost_runtimes`` are what that
+        rung first loses vs the rung above *it*, NOT vs the caller). Useful
+        as a symmetric detail row alongside :meth:`next_tier_unlocks` on a
+        pricing-table cell so the rung above carries both its first-grant
+        and first-loss copy off ONE entitlement round-trip; collapses to
+        empty loss lists at the ladder's ceiling (Enterprise's
+        :func:`tier_locks` row has no rung above to step down from).
+
+        Returns ``None`` at the resolver's ceiling (no next purchasable
+        rung to look up) and never raises -- a resolver failure
+        short-circuits to ``None`` so the CTA surface keeps rendering
+        instead of 500-ing.
+        """
+        try:
+            target = self.next_purchasable_tier()
+            if target is None:
+                return None
+            return tier_locks(target)
+        except Exception as exc:
+            logger.warning("entitlements: next_tier_locks failed: %s", exc)
+            return None
+
+    def previous_tier_locks(self) -> dict | None:
+        """One-rung-down locks row in :func:`tier_locks` shape.
+
+        Symmetric companion to :meth:`previous_tier_unlocks` -- where the
+        unlocks form returns the rung-below's *first-grant* row (a tier
+        property), this returns the rung-below's *first-loss* row.
+
+        Convenience for ``tier_locks(self.previous_purchasable_tier())``;
+        the row's ``lost_features`` / ``lost_runtimes`` are what the rung
+        below first loses vs the rung above it -- and since "the rung
+        above" the previous purchasable tier is *exactly the caller's
+        current tier* in the simple single-step downgrade case, this
+        row's loss lists byte-equal the caller's marginal loss when
+        stepping down by one rung. Pair with :meth:`previous_tier_diff`
+        (which carries the same marginal in ``downgrade_diff`` shape) on
+        a step-down confirmation card.
+
+        Returns ``None`` at the resolver's floor (no previous purchasable
+        rung to look up) and never raises -- a resolver failure
+        short-circuits to ``None`` so the confirmation surface keeps
+        rendering instead of 500-ing.
+        """
+        try:
+            target = self.previous_purchasable_tier()
+            if target is None:
+                return None
+            return tier_locks(target)
+        except Exception as exc:
+            logger.warning("entitlements: previous_tier_locks failed: %s", exc)
+            return None
+
     def grace_remaining_days(self) -> int | None:
         at = enforce_at_epoch()
         if at is None:
@@ -967,6 +1031,8 @@ class Entitlement:
             "prev_tier_capacity_diff": self.previous_tier_capacity_diff(),
             "next_tier_unlocks": self.next_tier_unlocks(),
             "prev_tier_unlocks": self.previous_tier_unlocks(),
+            "next_tier_locks": self.next_tier_locks(),
+            "prev_tier_locks": self.previous_tier_locks(),
         }
 
 
@@ -1400,6 +1466,26 @@ def previous_tier_unlocks() -> dict | None:
         return get_entitlement().previous_tier_unlocks()
     except Exception as exc:
         logger.warning("entitlements: previous_tier_unlocks (module) failed: %s", exc)
+        return None
+
+
+def next_tier_locks() -> dict | None:
+    """Module-level :meth:`Entitlement.next_tier_locks` against the resolved
+    entitlement. Never raises."""
+    try:
+        return get_entitlement().next_tier_locks()
+    except Exception as exc:
+        logger.warning("entitlements: next_tier_locks (module) failed: %s", exc)
+        return None
+
+
+def previous_tier_locks() -> dict | None:
+    """Module-level :meth:`Entitlement.previous_tier_locks` against the
+    resolved entitlement. Never raises."""
+    try:
+        return get_entitlement().previous_tier_locks()
+    except Exception as exc:
+        logger.warning("entitlements: previous_tier_locks (module) failed: %s", exc)
         return None
 
 

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -1427,6 +1427,96 @@ def api_entitlement_previous_tier_unlocks():
         )
 
 
+@bp_entitlement.route("/api/entitlement/next-tier-locks")
+def api_entitlement_next_tier_locks():
+    """``GET /api/entitlement/next-tier-locks`` -- marginal locks row for the
+    rung immediately above the resolved entitlement, in
+    :func:`clawmetry.entitlements.tier_locks` shape (``tier``,
+    ``tier_label``, ``tier_rank``, ``next_tier``, ``next_tier_label``,
+    ``next_tier_rank``, ``lost_features``, ``lost_runtimes``).
+
+    Symmetric companion to ``/api/entitlement/next-tier-unlocks``: that
+    endpoint carries the rung-above's first-grant row, this carries its
+    first-loss row -- a pricing-table cell can render both off ONE
+    entitlement round-trip. ``locks`` is ``null`` at the ladder's
+    ceiling (no rung above). Never 5xxs: a resolver failure
+    short-circuits to the grace-shape envelope so the dashboard CTA
+    keeps rendering instead of disappearing.
+    """
+    try:
+        from clawmetry import entitlements as _ent
+
+        ent = _ent.get_entitlement()
+        body = ent.next_tier_locks()
+        return jsonify(
+            {
+                "current_tier": ent.tier,
+                "current_tier_label": _ent.tier_label(ent.tier),
+                "current_tier_rank": _ent.tier_rank(ent.tier),
+                "locks": body,
+                "grace": bool(ent.grace),
+                "enforced": _ent.is_enforced(),
+            }
+        )
+    except Exception as exc:
+        logger.warning("api_entitlement_next_tier_locks: error: %s", exc)
+        return jsonify(
+            {
+                "current_tier": "oss",
+                "current_tier_label": "OSS",
+                "current_tier_rank": 0,
+                "locks": None,
+                "grace": True,
+                "enforced": False,
+            }
+        )
+
+
+@bp_entitlement.route("/api/entitlement/previous-tier-locks")
+def api_entitlement_previous_tier_locks():
+    """``GET /api/entitlement/previous-tier-locks`` -- marginal locks row for
+    the rung immediately below the resolved entitlement, in
+    :func:`clawmetry.entitlements.tier_locks` shape.
+
+    The step-down confirmation detail row paired with
+    ``/api/entitlement/previous-tier-diff`` (which carries the same
+    marginal in ``downgrade_diff`` shape). ``lost_features`` /
+    ``lost_runtimes`` here are what the rung below first loses vs the
+    rung above it -- and since "the rung above" the previous purchasable
+    tier *is* the caller's current tier in the simple single-step
+    downgrade case, these lists byte-equal the caller's marginal loss
+    when stepping down by one rung. ``locks`` is ``null`` at the
+    ladder's floor (no rung below). Never 5xxs.
+    """
+    try:
+        from clawmetry import entitlements as _ent
+
+        ent = _ent.get_entitlement()
+        body = ent.previous_tier_locks()
+        return jsonify(
+            {
+                "current_tier": ent.tier,
+                "current_tier_label": _ent.tier_label(ent.tier),
+                "current_tier_rank": _ent.tier_rank(ent.tier),
+                "locks": body,
+                "grace": bool(ent.grace),
+                "enforced": _ent.is_enforced(),
+            }
+        )
+    except Exception as exc:
+        logger.warning("api_entitlement_previous_tier_locks: error: %s", exc)
+        return jsonify(
+            {
+                "current_tier": "oss",
+                "current_tier_label": "OSS",
+                "current_tier_rank": 0,
+                "locks": None,
+                "grace": True,
+                "enforced": False,
+            }
+        )
+
+
 @bp_entitlement.route("/api/entitlement/tier-locks")
 def api_entitlement_tier_locks():
     """``GET /api/entitlement/tier-locks?tier=<id>`` -- marginal locks for

--- a/tests/test_entitlement_next_prev_tier_locks.py
+++ b/tests/test_entitlement_next_prev_tier_locks.py
@@ -1,0 +1,386 @@
+"""Tests for ``Entitlement.next_tier_locks`` / ``previous_tier_locks``, the
+module-level convenience helpers, the ``to_dict`` surface, and the companion
+``/api/entitlement/{next,previous}-tier-locks`` endpoints.
+
+The dashboard's downgrade confirmation card currently composes the marginal-
+loss payload client-side by hitting ``/api/entitlement/tier-locks?tier=<prev>``
+after a ``/api/entitlement`` round-trip; these helpers expose the same row in
+one call so the card can render off a single fetch. Marginal-loss companion to
+the existing ``next_tier_unlocks`` / ``previous_tier_unlocks`` family (same
+shape, ``lost_*`` lists instead of ``features`` / ``runtimes`` grants), and
+the fourth member of the ``next_tier_*`` / ``previous_tier_*`` family
+alongside ``next_tier_diff`` (full ``upgrade_diff`` shape),
+``next_tier_unlocks`` (marginal grant), and ``next_tier_capacity_diff``
+(capacity-only marginal) -- the slot the family was missing before this PR.
+
+Pins covered here:
+
+* method-vs-tier_locks identity for next/previous
+* method-vs-module-level helper identity
+* tier_locks shape (8 stable keys, sorted lists, label/rank metadata)
+* ceiling / floor behaviour (Enterprise has no next, OSS/cloud_free has no
+  previous) -- returns ``None``
+* enterprise-as-next collapses the rows ``lost_*`` lists to empty (Enterprise
+  is the ladder ceiling, its tier_locks row has no rung above to step down
+  from)
+* set-identity invariant: previous_tier_locks's ``lost_*`` byte-equal the
+  caller's marginal loss from ``downgrade_diff(previous_tier)`` -- so the row
+  IS the "if I drop one rung, what would I lose" answer
+* grace vs enforce yields the same body (catalogue-derived, not gated)
+* trial source resolves to enterprise as next (rank 2 -> rank 3) and to the
+  same-rank-cluster sibling for previous
+* to_dict carries the two new fields with the expected null/body shape per
+  tier
+* API surface: 200 always (no 5xx), locks=null at the floor/ceiling,
+  current_* tier metadata included, never-raise envelope on a synthetic
+  resolver failure
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+_LOCKS_KEYS = {
+    "tier",
+    "tier_label",
+    "tier_rank",
+    "next_tier",
+    "next_tier_label",
+    "next_tier_rank",
+    "lost_features",
+    "lost_runtimes",
+}
+
+
+# ── Entitlement.next_tier_locks ──────────────────────────────────────────────
+
+
+def test_next_tier_locks_matches_tier_locks_of_next(ent):
+    # next_tier_locks() is a convenience for tier_locks(next_purchasable_tier())
+    # -- they must be byte-equal across every purchasable tier so a caller can
+    # use the singular helper interchangeably.
+    for tier in (
+        ent.TIER_OSS,
+        ent.TIER_CLOUD_FREE,
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_PRO,
+    ):
+        e = ent._build(tier, "test")
+        nxt = e.next_purchasable_tier()
+        assert nxt is not None
+        assert e.next_tier_locks() == ent.tier_locks(nxt)
+
+
+def test_next_tier_locks_returns_none_at_ceiling(ent):
+    # Enterprise sits at the top of the purchasable ladder -- no rung above to
+    # upgrade to, so the convenience returns None just like
+    # next_purchasable_tier().
+    e = ent._build(ent.TIER_ENTERPRISE, "license")
+    assert e.next_purchasable_tier() is None
+    assert e.next_tier_locks() is None
+
+
+def test_next_tier_locks_shape(ent):
+    # The row must carry the full tier_locks shape so the CTA can render
+    # labels + rank without a second round-trip.
+    e = ent._build(ent.TIER_CLOUD_STARTER, "cloud")
+    body = e.next_tier_locks()
+    assert body is not None
+    assert set(body.keys()) == _LOCKS_KEYS
+    assert body["tier"] == ent.TIER_CLOUD_PRO
+    assert body["tier_label"] == ent.tier_label(ent.TIER_CLOUD_PRO)
+    assert body["tier_rank"] == ent.tier_rank(ent.TIER_CLOUD_PRO)
+    assert body["lost_features"] == sorted(body["lost_features"])
+    assert body["lost_runtimes"] == sorted(body["lost_runtimes"])
+
+
+def test_next_tier_locks_enterprise_collapses_to_empty_when_caller_is_pro(ent):
+    # Pro's next purchasable rung is Enterprise (the ceiling). tier_locks(ENT)
+    # carries Enterprise as the destination of a step-down from the rung above
+    # it -- but there IS no rung above Enterprise, so next_tier=None and the
+    # lost_* lists collapse to []. The convenience must surface that shape, not
+    # 500 or short-circuit to None.
+    e = ent._build(ent.TIER_PRO, "license")
+    nxt = e.next_purchasable_tier()
+    assert nxt == ent.TIER_ENTERPRISE
+    body = e.next_tier_locks()
+    assert body is not None
+    assert body["tier"] == ent.TIER_ENTERPRISE
+    assert body["next_tier"] is None
+    assert body["lost_features"] == []
+    assert body["lost_runtimes"] == []
+
+
+def test_next_tier_locks_never_raises_on_resolver_failure(ent, monkeypatch):
+    # If next_purchasable_tier blows up, the helper must swallow and return
+    # None so the dashboard CTA keeps rendering rather than 500-ing.
+    e = ent._oss_free()
+    monkeypatch.setattr(
+        type(e),
+        "next_purchasable_tier",
+        lambda self: (_ for _ in ()).throw(RuntimeError("synthetic")),
+    )
+    assert e.next_tier_locks() is None
+
+
+# ── Entitlement.previous_tier_locks ──────────────────────────────────────────
+
+
+def test_previous_tier_locks_matches_tier_locks_of_previous(ent):
+    # Symmetric to next_tier_locks: previous_tier_locks() must be byte-equal to
+    # tier_locks(previous_purchasable_tier()).
+    for tier in (
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_PRO,
+        ent.TIER_ENTERPRISE,
+    ):
+        e = ent._build(tier, "test")
+        prev = e.previous_purchasable_tier()
+        assert prev is not None
+        assert e.previous_tier_locks() == ent.tier_locks(prev)
+
+
+def test_previous_tier_locks_returns_none_at_floor(ent):
+    # OSS and cloud_free both sit at rank 0 -- no rung below to step down to,
+    # so the helper returns None mirroring previous_purchasable_tier().
+    for tier in (ent.TIER_OSS, ent.TIER_CLOUD_FREE):
+        e = ent._build(tier, "test")
+        assert e.previous_purchasable_tier() is None
+        assert e.previous_tier_locks() is None
+
+
+def test_previous_tier_locks_shape(ent):
+    e = ent._build(ent.TIER_CLOUD_PRO, "cloud")
+    body = e.previous_tier_locks()
+    assert body is not None
+    assert set(body.keys()) == _LOCKS_KEYS
+    assert body["tier"] == ent.TIER_CLOUD_STARTER
+    assert body["tier_label"] == ent.tier_label(ent.TIER_CLOUD_STARTER)
+
+
+def test_previous_tier_locks_loss_matches_downgrade_by_one_rung(ent):
+    # The whole point of previous_tier_locks: the row's lost_* lists represent
+    # exactly what the caller would lose by stepping down one rung. Pin the
+    # set-identity against the caller's own downgrade_diff(previous_tier)
+    # across every tier with a previous rung so a future reshuffle of the
+    # tier grant sets can't silently desync the convenience from the explicit
+    # downgrade view.
+    for tier in (
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_PRO,
+        ent.TIER_ENTERPRISE,
+    ):
+        e = ent._build(tier, "test")
+        prev = e.previous_purchasable_tier()
+        assert prev is not None
+        diff = e.downgrade_diff(prev)
+        body = e.previous_tier_locks()
+        assert body is not None
+        assert body["lost_features"] == diff["lost_features"]
+        assert body["lost_runtimes"] == diff["lost_runtimes"]
+
+
+def test_previous_tier_locks_never_raises_on_resolver_failure(ent, monkeypatch):
+    e = ent._build(ent.TIER_ENTERPRISE, "license")
+    monkeypatch.setattr(
+        type(e),
+        "previous_purchasable_tier",
+        lambda self: (_ for _ in ()).throw(RuntimeError("synthetic")),
+    )
+    assert e.previous_tier_locks() is None
+
+
+# ── trial source resolution ──────────────────────────────────────────────────
+
+
+def test_trial_next_locks_resolves_to_enterprise(ent):
+    # Trial sits at rank 2 alongside cloud_pro / self-hosted pro, so the next
+    # strictly-higher purchasable rung is enterprise (rank 3).
+    e = ent._build(ent.TIER_TRIAL, "cloud")
+    body = e.next_tier_locks()
+    assert body is not None
+    assert body["tier"] == ent.TIER_ENTERPRISE
+
+
+def test_trial_previous_locks_resolves_to_starter(ent):
+    # Trial steps down to rank 1 (starter) -- the highest rank strictly below
+    # trial's rank 2.
+    e = ent._build(ent.TIER_TRIAL, "cloud")
+    body = e.previous_tier_locks()
+    assert body is not None
+    assert body["tier"] == ent.TIER_CLOUD_STARTER
+
+
+# ── grace vs enforce ─────────────────────────────────────────────────────────
+
+
+def test_grace_and_enforce_yield_same_locks(ent, monkeypatch):
+    # These helpers are catalogue-derived (off the static per-tier grants),
+    # not gated -- so flipping enforce on must not change the body.
+    e = ent._build(ent.TIER_CLOUD_STARTER, "cloud")
+    grace_body = e.next_tier_locks()
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    importlib.reload(ent)
+    ent.invalidate()
+    e2 = ent._build(ent.TIER_CLOUD_STARTER, "cloud")
+    enforce_body = e2.next_tier_locks()
+    assert enforce_body == grace_body
+
+
+# ── module-level helpers ─────────────────────────────────────────────────────
+
+
+def test_module_level_next_helper_matches_method(ent):
+    # The bare module-level helper resolves the current entitlement and
+    # delegates, so it must agree with the bound method.
+    assert ent.next_tier_locks() == ent.get_entitlement().next_tier_locks()
+
+
+def test_module_level_previous_helper_matches_method(ent):
+    assert (
+        ent.previous_tier_locks() == ent.get_entitlement().previous_tier_locks()
+    )
+
+
+def test_module_level_next_helper_never_raises(monkeypatch, ent):
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "get_entitlement", boom)
+    assert ent.next_tier_locks() is None
+
+
+def test_module_level_previous_helper_never_raises(monkeypatch, ent):
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "get_entitlement", boom)
+    assert ent.previous_tier_locks() is None
+
+
+# ── to_dict carries the new fields ───────────────────────────────────────────
+
+
+def test_to_dict_carries_next_tier_locks(ent):
+    body = ent._oss_free().to_dict()
+    assert "next_tier_locks" in body
+    # OSS has a next rung -> the field is a non-null row.
+    assert body["next_tier_locks"] is not None
+    assert body["next_tier_locks"]["tier"] == ent.TIER_CLOUD_STARTER
+
+
+def test_to_dict_carries_prev_tier_locks(ent):
+    body = ent._build(ent.TIER_CLOUD_PRO, "cloud").to_dict()
+    assert "prev_tier_locks" in body
+    assert body["prev_tier_locks"] is not None
+    assert body["prev_tier_locks"]["tier"] == ent.TIER_CLOUD_STARTER
+
+
+def test_to_dict_next_locks_null_at_ceiling(ent):
+    body = ent._build(ent.TIER_ENTERPRISE, "license").to_dict()
+    assert body["next_tier_locks"] is None
+
+
+def test_to_dict_prev_locks_null_at_floor(ent):
+    body = ent._oss_free().to_dict()
+    assert body["prev_tier_locks"] is None
+
+
+# ── API surface ──────────────────────────────────────────────────────────────
+
+
+_ENVELOPE_KEYS = {
+    "current_tier",
+    "current_tier_label",
+    "current_tier_rank",
+    "locks",
+    "grace",
+    "enforced",
+}
+
+
+def test_next_tier_locks_endpoint_oss_default(client, ent):
+    rv = client.get("/api/entitlement/next-tier-locks")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert set(body.keys()) == _ENVELOPE_KEYS
+    assert body["current_tier"] == ent.TIER_OSS
+    assert body["current_tier_label"] == ent.tier_label(ent.TIER_OSS)
+    assert body["current_tier_rank"] == ent.tier_rank(ent.TIER_OSS)
+    assert body["locks"] is not None
+    assert body["locks"]["tier"] == ent.TIER_CLOUD_STARTER
+    assert body["grace"] is True
+    assert body["enforced"] is False
+
+
+def test_previous_tier_locks_endpoint_oss_default_floor(client, ent):
+    rv = client.get("/api/entitlement/previous-tier-locks")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert set(body.keys()) == _ENVELOPE_KEYS
+    assert body["current_tier"] == ent.TIER_OSS
+    # OSS is the floor; nothing below to step down to.
+    assert body["locks"] is None
+
+
+def test_next_tier_locks_endpoint_never_raises(client, ent, monkeypatch):
+    # Synthesise a resolver failure and assert the envelope still returns 200
+    # with the grace-shape body so the dashboard doesn't break on a flaky
+    # entitlement read.
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "get_entitlement", boom)
+    rv = client.get("/api/entitlement/next-tier-locks")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["locks"] is None
+    assert body["current_tier"] == "oss"
+
+
+def test_previous_tier_locks_endpoint_never_raises(client, ent, monkeypatch):
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "get_entitlement", boom)
+    rv = client.get("/api/entitlement/previous-tier-locks")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["locks"] is None
+    assert body["current_tier"] == "oss"
+
+
+def test_endpoint_locks_row_matches_tier_locks(client, ent):
+    # The body's locks row must byte-equal what /tier-locks?tier=<next>
+    # returns directly -- pin the equivalence so callers can swap between the
+    # two endpoints without copy drift.
+    rv = client.get("/api/entitlement/next-tier-locks")
+    body = rv.get_json()
+    assert body["locks"] == ent.tier_locks(ent.TIER_CLOUD_STARTER)


### PR DESCRIPTION
## Summary

Fills the missing fourth member of the `next_tier_*` / `previous_tier_*` family. Before this PR:

| family slot | next | previous |
|---|---|---|
| full diff | `next_tier_diff` (upgrade_diff shape) | `previous_tier_diff` (downgrade_diff shape) |
| marginal grants | `next_tier_unlocks` | `previous_tier_unlocks` |
| capacity-only | `next_tier_capacity_diff` | `previous_tier_capacity_diff` |
| **marginal losses** | **MISSING** | **MISSING** |

The marginal-loss row is the slot a step-down confirmation card wants alongside `previous_tier_diff` and the symmetric one a pricing-table cell wants alongside `next_tier_unlocks`. Until now the dashboard had to fetch `/api/entitlement/tier-locks?tier=<prev>` after a `/api/entitlement` round-trip; this PR exposes the same row off **one** fetch.

## Changes

- **`Entitlement.next_tier_locks()`** / **`Entitlement.previous_tier_locks()`** — mirror the existing `*_tier_unlocks` methods (delegate to `tier_locks(next/previous_purchasable_tier())`, swallow resolver failures, return `None` at floor/ceiling).
- Module-level **`next_tier_locks()`** / **`previous_tier_locks()`** wrappers matching the existing convention.
- **`Entitlement.to_dict()`** gains `next_tier_locks` + `prev_tier_locks` fields so the resolved-entitlement payload carries both immediately (no separate round-trip needed).
- New endpoints **`GET /api/entitlement/next-tier-locks`** and **`GET /api/entitlement/previous-tier-locks`** on `bp_entitlement`, matching the envelope of `/next-tier-unlocks` exactly: `current_tier`, `current_tier_label`, `current_tier_rank`, `locks`, `grace`, `enforced`.
- **26 unit + endpoint tests** in `tests/test_entitlement_next_prev_tier_locks.py`.

## Pinned invariants

- **method-vs-tier_locks identity**: `next_tier_locks()` byte-equals `tier_locks(next_purchasable_tier())` across every purchasable source tier (and same for `previous_tier_locks`), so the convenience can be swapped for the singular helper without copy drift.
- **module-level vs bound-method identity**: `entitlements.next_tier_locks() == get_entitlement().next_tier_locks()`.
- **downgrade-diff set-identity** (the whole point of `previous_tier_locks`): `previous_tier_locks()['lost_*']` byte-equals `self.downgrade_diff(previous_purchasable_tier())['lost_*']` for every tier with a previous rung — so the row IS the "if I drop one rung, what would I lose" answer, pinned against the explicit downgrade view so a future reshuffle of the per-tier grant sets can't silently desync the two.
- **ceiling/floor**: `next_tier_locks()` returns `None` at Enterprise (no rung above); `previous_tier_locks()` returns `None` at OSS / cloud_free (no rung below).
- **enterprise-as-next-purchasable** (caller at Pro): row carries Enterprise as `tier`, `next_tier=None`, and `lost_*` collapse to `[]` — Enterprise is the ladder ceiling so its `tier_locks` row has no rung above to step down from. The convenience surfaces that shape rather than 500-ing or short-circuiting to `None`.
- **trial source**: resolves to Enterprise as next (rank 2 → rank 3) and to Cloud Starter as previous (rank 2 → rank 1), matching the `tier_unlocks` family's trial semantics.
- **grace vs enforce yield same body** (catalogue-derived, not gated): flipping `CLAWMETRY_ENFORCE` on must not change the response.
- **`to_dict` carries both fields** with the expected null/body shape per tier (OSS gets non-null `next_tier_locks` + null `prev_tier_locks`; Enterprise the inverse).
- **API surface**: 200 always (no 5xx), `locks=null` at floor/ceiling, full `current_*` tier metadata included, never-raise envelope on a synthetic resolver failure (drops back to `oss` grace shape so the dashboard CTA keeps rendering).

## Posture

- Ships in **GRACE** — no `__version__` bump, no release tag, no enforcement changes. Zero behavior change.
- Helpers + endpoints follow house style (graceful fallback + logged warning, never crash). No new dependencies.
- Lint clean: `ruff check clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_next_prev_tier_locks.py` passes.
- 2000 entitlement+license tests pass locally (sole unrelated collection error is `tests/test_retention_prune.py` missing `duckdb` — pre-existing).

## Local operator verification checklist

The agent cannot reach the live daemon / cloud snapshot / browser, so the operator drives the final loop:

- [ ] `cp clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_next_prev_tier_locks.py ~/.clawmetry/lib/python*/site-packages/clawmetry/` (and matching `routes/` / `tests/` paths)
- [ ] `find ~/.clawmetry -name __pycache__ -exec rm -rf {} +`
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
- [ ] `curl -sS http://localhost:8900/api/entitlement/next-tier-locks | jq '.locks.tier, .locks.lost_runtimes'` (default OSS install → expect `cloud_starter` + the runtimes that disappear at Starter, paid-runtime cluster, etc.)
- [ ] `curl -sS http://localhost:8900/api/entitlement/previous-tier-locks | jq '.locks'` (default OSS install → expect `null`, OSS is the floor)
- [ ] `curl -sS http://localhost:8900/api/entitlement | jq '.next_tier_locks.tier, .prev_tier_locks'` — confirm `to_dict` carries the two new fields with the right floor/ceiling nulls
- [ ] Decrypt the live cloud snapshot and confirm both endpoints surface there with the same shape
- [ ] Browser-check the entitlement / paywall surface (if any consumes these endpoints) for the new symmetric locks rows
- [ ] Once green, flip the PR out of Draft and merge via the usual `[RELEASE]` path

---
_Generated by [Claude Code](https://claude.ai/code/session_01JgxNDtybjyBV97i4t2tXME)_