### PR TITLE
feat(entitlement): next_tier_unlocks_at + next_tier_locks_at + endpoints (scalar what-if)

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -4906,3 +4906,144 @@ def tier_diff_at_batch(tier: str) -> list[dict] | None:
     except Exception as exc:
         logger.warning("entitlements: tier_diff_at_batch failed: %s", exc)
         return []
+
+
+def _next_purchasable_tier_after(tier: str) -> str | None:
+    """Pure helper: next strictly-higher-rank entry in
+    :data:`_PURCHASABLE_TIERS` after ``tier``, ties broken by the order
+    of declaration in :data:`_PURCHASABLE_TIERS`.
+
+    Mirrors :meth:`Entitlement.next_purchasable_tier` but takes a
+    caller-supplied source tier instead of resolving the live
+    entitlement -- the source-anchored pure stepper the ``_at`` family
+    needs so its scalar what-if helpers do not depend on the resolver.
+
+    The tie-break (rank-only, declaration-order otherwise) intentionally
+    elides the cloud-vs-self-hosted preference the live method applies:
+    the ``_at`` family is for hypothetical comparison and should be
+    deterministic on the static catalogue, not driven by which install
+    flavour the resolver is currently in.
+
+    Accepts any id in :data:`_TIER_ORDER` (including :data:`TIER_TRIAL`,
+    rank 2 -- "next strictly above trial" resolves to enterprise,
+    matching how :meth:`Entitlement.next_purchasable_tier` walks past
+    same-rank trial when called from a trial entitlement).
+
+    Returns ``None`` for empty / unknown ``tier`` and at the ceiling
+    (enterprise -- nothing strictly above). Never raises.
+    """
+    try:
+        src = (tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if not src or src not in _TIER_ORDER:
+        return None
+    try:
+        src_rank = _TIER_RANK.get(src, -1)
+        for cand in _PURCHASABLE_TIERS:
+            if _TIER_RANK.get(cand, -1) > src_rank:
+                return cand
+        return None
+    except Exception as exc:
+        logger.warning("entitlements: _next_purchasable_tier_after failed: %s", exc)
+        return None
+
+
+def next_tier_unlocks_at(tier: str) -> dict | None:
+    """Scalar what-if sibling of :meth:`Entitlement.next_tier_unlocks`:
+    marginal unlocks row at the rung above the caller-supplied ``tier``,
+    in :func:`tier_unlocks` shape.
+
+    Convenience for ``tier_unlocks(_next_purchasable_tier_after(tier))``
+    -- the source-anchored equivalent of the live method, so a pricing
+    page can render "what's new at the next rung above X" for any X
+    without first having to ask the resolver and without monkey-patching
+    the entitlement context. Pairs with :func:`next_tier_locks_at` (the
+    marginal-loss view of the same rung) on a hypothetical pricing
+    matrix cell.
+
+    Row shape matches :func:`tier_unlocks` exactly -- ``tier``,
+    ``tier_label``, ``tier_rank``, ``previous_tier``, ``previous_tier_label``,
+    ``previous_tier_rank``, ``features``, ``runtimes``. The row IS the
+    tier-property row of the rung above (its ``previous_tier`` is that
+    rung's natural next-lower purchasable, NOT the caller-supplied
+    ``tier``) -- the same posture :meth:`Entitlement.next_tier_unlocks`
+    surfaces via the live resolver. Callers who want the source-anchored
+    ``previous_tier`` should use :func:`tier_unlocks_at` directly with
+    the explicit ``(tier, target)`` pair.
+
+    Accepts any id in :data:`_TIER_ORDER` (including :data:`TIER_TRIAL`)
+    -- the lenient ``_at`` posture, since the source is hypothetical
+    and may legitimately answer "what would step Trial -> Enterprise
+    unlock?".
+
+    Returns ``None`` for empty / unknown ``tier`` and at the ceiling
+    (no rung strictly above). Never raises: a builder failure short-
+    circuits to ``None`` so the CTA surface stays mute instead of
+    breaking.
+    """
+    try:
+        src = (tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if not src or src not in _TIER_ORDER:
+        return None
+    try:
+        target = _next_purchasable_tier_after(src)
+        if target is None:
+            return None
+        return tier_unlocks(target)
+    except Exception as exc:
+        logger.warning("entitlements: next_tier_unlocks_at failed: %s", exc)
+        return None
+
+
+def next_tier_locks_at(tier: str) -> dict | None:
+    """Scalar what-if sibling of :meth:`Entitlement.next_tier_locks`:
+    marginal locks row at the rung above the caller-supplied ``tier``,
+    in :func:`tier_locks` shape.
+
+    Marginal-loss mirror of :func:`next_tier_unlocks_at` and pairs
+    with :meth:`Entitlement.next_tier_locks` (live, source pinned to
+    the resolver) the same way :func:`tier_locks_at` pairs with
+    :func:`tier_locks`. Convenience for
+    ``tier_locks(_next_purchasable_tier_after(tier))`` -- the source-
+    anchored equivalent of the live method, so a pricing page can
+    render "what does the rung above X first lose vs the rung above
+    IT" for any X without first asking the resolver.
+
+    Row shape matches :func:`tier_locks` exactly -- ``tier``,
+    ``tier_label``, ``tier_rank``, ``next_tier``, ``next_tier_label``,
+    ``next_tier_rank``, ``lost_features``, ``lost_runtimes``. The row
+    IS the tier-property row of the rung above (its ``next_tier`` is
+    that rung's natural next-higher purchasable, NOT the caller-
+    supplied ``tier``) -- the same posture
+    :meth:`Entitlement.next_tier_locks` surfaces via the live resolver.
+
+    Accepts any id in :data:`_TIER_ORDER` (including :data:`TIER_TRIAL`)
+    -- the lenient ``_at`` posture.
+
+    Returns ``None`` for empty / unknown ``tier`` and at the ceiling
+    (no rung strictly above). At the rung where the next-above IS the
+    ladder ceiling (enterprise as ``_next_purchasable_tier_after``'s
+    answer) the returned row carries ``next_tier=None`` and empty
+    ``lost_*`` lists -- :func:`tier_locks` shape for "this rung has no
+    rung above to step down from", not ``None``.
+
+    Never raises: a builder failure short-circuits to ``None`` so the
+    CTA surface stays mute instead of breaking.
+    """
+    try:
+        src = (tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if not src or src not in _TIER_ORDER:
+        return None
+    try:
+        target = _next_purchasable_tier_after(src)
+        if target is None:
+            return None
+        return tier_locks(target)
+    except Exception as exc:
+        logger.warning("entitlements: next_tier_locks_at failed: %s", exc)
+        return None

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -4350,3 +4350,181 @@ def api_license_deactivate():
     except Exception as exc:
         logger.warning("api_license_deactivate: error: %s", exc)
         return jsonify({"ok": False, "error": str(exc)}), 500
+
+
+@bp_entitlement.route("/api/entitlement/next-tier-unlocks-at")
+def api_entitlement_next_tier_unlocks_at():
+    """``GET /api/entitlement/next-tier-unlocks-at?tier=<source>`` --
+    scalar what-if sibling of ``/api/entitlement/next-tier-unlocks``:
+    marginal unlocks row at the rung above the caller-supplied
+    ``tier``, in :func:`clawmetry.entitlements.tier_unlocks` shape.
+
+    Lets a pricing page render the "what's new at the next rung above
+    X" upgrade-CTA cell for any hypothetical ``X`` without first asking
+    the resolver and without monkey-patching the entitlement context --
+    the scalar what-if the live ``/next-tier-unlocks`` endpoint surfaces
+    against the resolved entitlement, parameterised over the source.
+
+    Response shape::
+
+        {
+          "tier":           "<source tier id>",
+          "tier_label":     "<source label>",
+          "tier_rank":      <source rank>,
+          "target":         "<next-above tier id>" | null,
+          "target_label":   "<next-above label>" | null,
+          "target_rank":    <next-above rank> | null,
+          "row":            {<tier_unlocks row>} | null,
+        }
+
+    The inner ``row`` matches the live ``/next-tier-unlocks`` ``locks``-
+    style row shape (``tier``, ``tier_label``, ``tier_rank``,
+    ``previous_tier``, ``previous_tier_label``, ``previous_tier_rank``,
+    ``features``, ``runtimes``). The row IS the tier-property row of
+    the rung above (its ``previous_tier`` is that rung's natural next-
+    lower purchasable, NOT the caller-supplied ``tier``) -- the same
+    posture the live endpoint surfaces. Callers who want the source-
+    anchored ``previous_tier`` should use ``/tier-unlocks-at`` with the
+    explicit ``(tier, target)`` pair.
+
+    Accepts any tier id in :data:`entitlements._TIER_ORDER` (including
+    ``trial``), matching the other ``_at`` family endpoints. ``target``
+    / ``row`` collapse to ``null`` at the ceiling (no rung strictly
+    above the source) -- the surface stays 200 with a populated
+    envelope so callers can render "you're at the top" copy without
+    a status-code branch.
+
+    - **400** when ``tier=`` is missing / blank
+    - **404** when ``tier`` is unknown. The body carries ``which`` so a
+      caller can render the right "unknown ..." message.
+    - **Never 5xxs**: builder failure short-circuits to ``row=null``
+      on the same 200 envelope so the CTA surface stays mute.
+    """
+    raw_tier = request.args.get("tier")
+    tier_in = (raw_tier or "").strip().lower()
+    if not tier_in:
+        return jsonify({"error": "missing tier"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        if tier_in not in _ent._TIER_ORDER:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "tier", "tier": tier_in}
+                ),
+                404,
+            )
+        target = _ent._next_purchasable_tier_after(tier_in)
+        row = _ent.next_tier_unlocks_at(tier_in)
+        return jsonify(
+            {
+                "tier": tier_in,
+                "tier_label": _ent.tier_label(tier_in),
+                "tier_rank": _ent.tier_rank(tier_in),
+                "target": target,
+                "target_label": _ent.tier_label(target) if target else None,
+                "target_rank": _ent.tier_rank(target) if target else None,
+                "row": row,
+            }
+        )
+    except Exception as exc:
+        logger.warning("api_entitlement_next_tier_unlocks_at: error: %s", exc)
+        return jsonify(
+            {
+                "tier": tier_in,
+                "tier_label": None,
+                "tier_rank": -1,
+                "target": None,
+                "target_label": None,
+                "target_rank": None,
+                "row": None,
+            }
+        )
+
+
+@bp_entitlement.route("/api/entitlement/next-tier-locks-at")
+def api_entitlement_next_tier_locks_at():
+    """``GET /api/entitlement/next-tier-locks-at?tier=<source>`` --
+    scalar what-if sibling of ``/api/entitlement/next-tier-locks``:
+    marginal locks row at the rung above the caller-supplied ``tier``,
+    in :func:`clawmetry.entitlements.tier_locks` shape.
+
+    Marginal-loss mirror of ``/next-tier-unlocks-at`` and pairs with
+    the live ``/next-tier-locks`` (source pinned to the resolver) the
+    same way ``/tier-locks-at`` pairs with ``/tier-locks``. Lets a
+    pricing page render the "what does the rung above X first lose vs
+    the rung above IT" detail cell for any hypothetical ``X`` without
+    asking the resolver.
+
+    Response shape::
+
+        {
+          "tier":           "<source tier id>",
+          "tier_label":     "<source label>",
+          "tier_rank":      <source rank>,
+          "target":         "<next-above tier id>" | null,
+          "target_label":   "<next-above label>" | null,
+          "target_rank":    <next-above rank> | null,
+          "row":            {<tier_locks row>} | null,
+        }
+
+    The inner ``row`` matches the live ``/next-tier-locks`` ``locks``
+    row shape (``tier``, ``tier_label``, ``tier_rank``, ``next_tier``,
+    ``next_tier_label``, ``next_tier_rank``, ``lost_features``,
+    ``lost_runtimes``). At the rung where the next-above IS the ladder
+    ceiling (enterprise), the row's ``next_tier`` is ``null`` and the
+    ``lost_*`` lists collapse to ``[]`` -- :func:`tier_locks` shape
+    for "this rung has no rung above to step down from", not ``null``
+    on the envelope.
+
+    Accepts any tier id in :data:`entitlements._TIER_ORDER` (including
+    ``trial``). ``target`` / ``row`` collapse to ``null`` at the
+    source-side ceiling (enterprise as source -- no rung strictly
+    above) -- the surface stays 200 with a populated envelope.
+
+    - **400** when ``tier=`` is missing / blank
+    - **404** when ``tier`` is unknown. The body carries ``which`` so
+      a caller can render the right "unknown ..." message.
+    - **Never 5xxs**: builder failure short-circuits to ``row=null``
+      on the same 200 envelope so the CTA surface stays mute.
+    """
+    raw_tier = request.args.get("tier")
+    tier_in = (raw_tier or "").strip().lower()
+    if not tier_in:
+        return jsonify({"error": "missing tier"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        if tier_in not in _ent._TIER_ORDER:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "tier", "tier": tier_in}
+                ),
+                404,
+            )
+        target = _ent._next_purchasable_tier_after(tier_in)
+        row = _ent.next_tier_locks_at(tier_in)
+        return jsonify(
+            {
+                "tier": tier_in,
+                "tier_label": _ent.tier_label(tier_in),
+                "tier_rank": _ent.tier_rank(tier_in),
+                "target": target,
+                "target_label": _ent.tier_label(target) if target else None,
+                "target_rank": _ent.tier_rank(target) if target else None,
+                "row": row,
+            }
+        )
+    except Exception as exc:
+        logger.warning("api_entitlement_next_tier_locks_at: error: %s", exc)
+        return jsonify(
+            {
+                "tier": tier_in,
+                "tier_label": None,
+                "tier_rank": -1,
+                "target": None,
+                "target_label": None,
+                "target_rank": None,
+                "row": None,
+            }
+        )

--- a/tests/test_entitlement_next_tier_at.py
+++ b/tests/test_entitlement_next_tier_at.py
@@ -1,0 +1,506 @@
+"""Tests for ``next_tier_unlocks_at`` / ``next_tier_locks_at`` --
+scalar what-if siblings of the live :meth:`Entitlement.next_tier_unlocks`
+/ :meth:`Entitlement.next_tier_locks` instance methods, plus the
+companion ``/api/entitlement/next-tier-{unlocks,locks}-at?tier=<src>``
+endpoints and the private :func:`_next_purchasable_tier_after`
+stepper they share.
+
+These helpers let a pricing-comparison UI render "what's new / what's
+lost at the next rung above X" for any hypothetical ``X`` without
+first asking the resolver or monkey-patching the entitlement context
+-- the source-anchored counterpart of the live methods that pin the
+source to the resolved entitlement.
+
+Pins covered here:
+
+* helper :func:`_next_purchasable_tier_after` walks the static
+  :data:`_PURCHASABLE_TIERS` rank ladder identically for every source
+  tier -- ceiling returns ``None``, lenient on :data:`TIER_TRIAL`
+* ``next_tier_unlocks_at(tier)`` byte-equals
+  ``tier_unlocks(_next_purchasable_tier_after(tier))`` across every
+  valid source -- the convenience cannot drift from the explicit
+  composition
+* same identity for ``next_tier_locks_at`` against :func:`tier_locks`
+* at the ceiling (no rung strictly above source) both helpers return
+  ``None`` -- mirrors the live :meth:`Entitlement.next_tier_unlocks`
+  / :meth:`Entitlement.next_tier_locks` behaviour
+* at the source rung whose next-above IS enterprise, the locks row
+  collapses to empty ``lost_*`` lists with ``next_tier=null`` (the
+  ladder ceiling's :func:`tier_locks` posture) -- a populated row,
+  not ``None``
+* trial-as-source resolves the same way :meth:`Entitlement.next_purchasable_tier`
+  does for a trial entitlement: strictly-higher rank == enterprise
+* grace vs enforce yields the same body (the ``_at`` family walks the
+  static catalogue, not the gated resolver)
+* unknown / empty / ``None`` / non-string source returns ``None``
+* the API surface 400s on missing input, 404s on unknown ids (with
+  ``which``), surfaces 200 envelopes at the ceiling with ``row=null``,
+  and never 5xxs
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    """Fresh entitlements module with HOME pointed at an empty tmp dir
+    so no real ~/.clawmetry/license.key or cloud_plan.json leaks in.
+    Enforcement off by default (grace mode) -- both helpers are
+    catalogue-derived and independent of the resolver, so the fixture
+    only needs to make sure the live resolver does not surprise the
+    test."""
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+_UNLOCKS_KEYS = {
+    "tier",
+    "tier_label",
+    "tier_rank",
+    "previous_tier",
+    "previous_tier_label",
+    "previous_tier_rank",
+    "features",
+    "runtimes",
+}
+
+_LOCKS_KEYS = {
+    "tier",
+    "tier_label",
+    "tier_rank",
+    "next_tier",
+    "next_tier_label",
+    "next_tier_rank",
+    "lost_features",
+    "lost_runtimes",
+}
+
+_ENVELOPE_KEYS = {
+    "tier",
+    "tier_label",
+    "tier_rank",
+    "target",
+    "target_label",
+    "target_rank",
+    "row",
+}
+
+
+# ── _next_purchasable_tier_after ─────────────────────────────────────────────
+
+
+def test_next_after_walks_to_strictly_higher_rank(ent):
+    # The stepper picks the first entry in _PURCHASABLE_TIERS with a
+    # strictly higher rank. Pinned per known source so a reshuffle of
+    # the static ladder cannot silently change the answer.
+    expected = {
+        ent.TIER_OSS: ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_FREE: ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_STARTER: ent.TIER_CLOUD_PRO,
+        ent.TIER_CLOUD_PRO: ent.TIER_ENTERPRISE,
+        ent.TIER_PRO: ent.TIER_ENTERPRISE,
+        ent.TIER_TRIAL: ent.TIER_ENTERPRISE,
+    }
+    for src, exp in expected.items():
+        assert ent._next_purchasable_tier_after(src) == exp, src
+
+
+def test_next_after_returns_none_at_ceiling(ent):
+    # Enterprise sits at the top of the purchasable ladder -- nothing
+    # strictly above.
+    assert ent._next_purchasable_tier_after(ent.TIER_ENTERPRISE) is None
+
+
+@pytest.mark.parametrize("bad", ["", "  ", None, 0, 1.5, "BOGUS", "bogus"])
+def test_next_after_returns_none_on_bad_input(ent, bad):
+    assert ent._next_purchasable_tier_after(bad) is None
+
+
+def test_next_after_trims_and_lowercases(ent):
+    # Same canonicalisation the rest of the _at family applies.
+    assert ent._next_purchasable_tier_after("  OSS  ") == ent.TIER_CLOUD_STARTER
+
+
+def test_next_after_independent_of_resolver(ent, monkeypatch):
+    # The stepper must not call get_entitlement at any point -- if it
+    # does, swapping it to raise would make the helper return None.
+    def boom(*_, **__):
+        raise RuntimeError("resolver must not be reached")
+
+    monkeypatch.setattr(ent, "get_entitlement", boom)
+    assert ent._next_purchasable_tier_after(ent.TIER_OSS) == ent.TIER_CLOUD_STARTER
+
+
+def test_next_after_never_raises(monkeypatch, ent):
+    # Synthetic _TIER_RANK failure -- the helper must swallow and
+    # return None rather than propagate.
+    monkeypatch.setattr(
+        ent,
+        "_TIER_RANK",
+        type("Boom", (), {"get": lambda *_, **__: (_ for _ in ()).throw(RuntimeError())})(),
+    )
+    assert ent._next_purchasable_tier_after(ent.TIER_OSS) is None
+
+
+# ── next_tier_unlocks_at ─────────────────────────────────────────────────────
+
+
+def test_next_tier_unlocks_at_matches_explicit_composition(ent):
+    # The convenience is tier_unlocks(_next_purchasable_tier_after(tier)).
+    # Byte-equal across every source so callers can swap between the
+    # singular helper and the explicit composition without drift.
+    for src in (
+        ent.TIER_OSS,
+        ent.TIER_CLOUD_FREE,
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_PRO,
+        ent.TIER_TRIAL,
+    ):
+        nxt = ent._next_purchasable_tier_after(src)
+        assert nxt is not None, src
+        assert ent.next_tier_unlocks_at(src) == ent.tier_unlocks(nxt), src
+
+
+def test_next_tier_unlocks_at_returns_none_at_ceiling(ent):
+    # Enterprise has no rung above -> None, mirroring the live method.
+    assert ent.next_tier_unlocks_at(ent.TIER_ENTERPRISE) is None
+
+
+def test_next_tier_unlocks_at_row_shape(ent):
+    body = ent.next_tier_unlocks_at(ent.TIER_CLOUD_STARTER)
+    assert body is not None
+    assert set(body.keys()) == _UNLOCKS_KEYS
+    assert body["tier"] == ent.TIER_CLOUD_PRO
+    assert body["tier_label"] == ent.tier_label(ent.TIER_CLOUD_PRO)
+    assert body["tier_rank"] == ent.tier_rank(ent.TIER_CLOUD_PRO)
+    # tier_unlocks sets previous_tier to target's natural next-lower
+    # purchasable -- NOT the caller-supplied source -- so this carries
+    # cloud_starter (the natural floor below cloud_pro), which here
+    # happens to coincide with the source.
+    assert body["previous_tier"] is not None
+    assert body["features"] == sorted(body["features"])
+    assert body["runtimes"] == sorted(body["runtimes"])
+
+
+@pytest.mark.parametrize("bad", ["", "  ", None, 0, 1.5, "BOGUS", "bogus"])
+def test_next_tier_unlocks_at_returns_none_on_bad_input(ent, bad):
+    assert ent.next_tier_unlocks_at(bad) is None
+
+
+def test_next_tier_unlocks_at_trims_and_lowercases(ent):
+    assert ent.next_tier_unlocks_at("  OSS  ") == ent.tier_unlocks(
+        ent.TIER_CLOUD_STARTER
+    )
+
+
+def test_next_tier_unlocks_at_trial_source_resolves_to_enterprise(ent):
+    # Trial sits at rank 2, so the next strictly-higher purchasable
+    # rung is enterprise -- matches the live method's posture when
+    # called from a trial entitlement.
+    body = ent.next_tier_unlocks_at(ent.TIER_TRIAL)
+    assert body is not None
+    assert body["tier"] == ent.TIER_ENTERPRISE
+
+
+def test_next_tier_unlocks_at_grace_and_enforce_match(ent, monkeypatch):
+    # Catalogue-derived (off the static per-tier grants) -- flipping
+    # enforcement on must not change the body.
+    grace = ent.next_tier_unlocks_at(ent.TIER_CLOUD_STARTER)
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    importlib.reload(ent)
+    ent.invalidate()
+    enforce = ent.next_tier_unlocks_at(ent.TIER_CLOUD_STARTER)
+    assert enforce == grace
+
+
+def test_next_tier_unlocks_at_never_raises(ent, monkeypatch):
+    monkeypatch.setattr(
+        ent,
+        "tier_unlocks",
+        lambda *_: (_ for _ in ()).throw(RuntimeError("synthetic")),
+    )
+    assert ent.next_tier_unlocks_at(ent.TIER_OSS) is None
+
+
+def test_next_tier_unlocks_at_independent_of_resolver(ent, monkeypatch):
+    # The whole point of the _at variant: it does not need the
+    # resolver. Swap get_entitlement to raise and the helper must
+    # still return a non-None body.
+    def boom(*_, **__):
+        raise RuntimeError("resolver must not be reached")
+
+    monkeypatch.setattr(ent, "get_entitlement", boom)
+    body = ent.next_tier_unlocks_at(ent.TIER_OSS)
+    assert body is not None
+    assert body["tier"] == ent.TIER_CLOUD_STARTER
+
+
+# ── next_tier_locks_at ───────────────────────────────────────────────────────
+
+
+def test_next_tier_locks_at_matches_explicit_composition(ent):
+    for src in (
+        ent.TIER_OSS,
+        ent.TIER_CLOUD_FREE,
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_PRO,
+        ent.TIER_TRIAL,
+    ):
+        nxt = ent._next_purchasable_tier_after(src)
+        assert nxt is not None, src
+        assert ent.next_tier_locks_at(src) == ent.tier_locks(nxt), src
+
+
+def test_next_tier_locks_at_returns_none_at_ceiling(ent):
+    assert ent.next_tier_locks_at(ent.TIER_ENTERPRISE) is None
+
+
+def test_next_tier_locks_at_row_shape(ent):
+    body = ent.next_tier_locks_at(ent.TIER_CLOUD_STARTER)
+    assert body is not None
+    assert set(body.keys()) == _LOCKS_KEYS
+    assert body["tier"] == ent.TIER_CLOUD_PRO
+    assert body["lost_features"] == sorted(body["lost_features"])
+    assert body["lost_runtimes"] == sorted(body["lost_runtimes"])
+
+
+def test_next_tier_locks_at_pro_collapses_to_empty_at_ceiling(ent):
+    # Pro -> next is Enterprise -- the ladder ceiling. tier_locks(ENT)
+    # carries next_tier=None and empty lost_* lists. The convenience
+    # must surface that populated row, not None.
+    body = ent.next_tier_locks_at(ent.TIER_PRO)
+    assert body is not None
+    assert body["tier"] == ent.TIER_ENTERPRISE
+    assert body["next_tier"] is None
+    assert body["lost_features"] == []
+    assert body["lost_runtimes"] == []
+
+
+def test_next_tier_locks_at_cloud_pro_collapses_to_empty_at_ceiling(ent):
+    # cloud_pro -> next is Enterprise (same ceiling) -- identical
+    # collapse, even though cloud_pro and pro both sit at rank 2.
+    body = ent.next_tier_locks_at(ent.TIER_CLOUD_PRO)
+    assert body is not None
+    assert body["tier"] == ent.TIER_ENTERPRISE
+    assert body["next_tier"] is None
+    assert body["lost_features"] == []
+    assert body["lost_runtimes"] == []
+
+
+@pytest.mark.parametrize("bad", ["", "  ", None, 0, 1.5, "BOGUS", "bogus"])
+def test_next_tier_locks_at_returns_none_on_bad_input(ent, bad):
+    assert ent.next_tier_locks_at(bad) is None
+
+
+def test_next_tier_locks_at_trims_and_lowercases(ent):
+    assert ent.next_tier_locks_at("  OSS  ") == ent.tier_locks(
+        ent.TIER_CLOUD_STARTER
+    )
+
+
+def test_next_tier_locks_at_trial_source_resolves_to_enterprise(ent):
+    body = ent.next_tier_locks_at(ent.TIER_TRIAL)
+    assert body is not None
+    assert body["tier"] == ent.TIER_ENTERPRISE
+
+
+def test_next_tier_locks_at_grace_and_enforce_match(ent, monkeypatch):
+    grace = ent.next_tier_locks_at(ent.TIER_CLOUD_STARTER)
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    importlib.reload(ent)
+    ent.invalidate()
+    enforce = ent.next_tier_locks_at(ent.TIER_CLOUD_STARTER)
+    assert enforce == grace
+
+
+def test_next_tier_locks_at_never_raises(ent, monkeypatch):
+    monkeypatch.setattr(
+        ent,
+        "tier_locks",
+        lambda *_: (_ for _ in ()).throw(RuntimeError("synthetic")),
+    )
+    assert ent.next_tier_locks_at(ent.TIER_OSS) is None
+
+
+def test_next_tier_locks_at_independent_of_resolver(ent, monkeypatch):
+    def boom(*_, **__):
+        raise RuntimeError("resolver must not be reached")
+
+    monkeypatch.setattr(ent, "get_entitlement", boom)
+    body = ent.next_tier_locks_at(ent.TIER_OSS)
+    assert body is not None
+    assert body["tier"] == ent.TIER_CLOUD_STARTER
+
+
+# ── API: /api/entitlement/next-tier-unlocks-at ──────────────────────────────
+
+
+def test_next_tier_unlocks_at_endpoint_oss_default(client, ent):
+    rv = client.get("/api/entitlement/next-tier-unlocks-at?tier=oss")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert set(body.keys()) == _ENVELOPE_KEYS
+    assert body["tier"] == ent.TIER_OSS
+    assert body["tier_label"] == ent.tier_label(ent.TIER_OSS)
+    assert body["tier_rank"] == ent.tier_rank(ent.TIER_OSS)
+    assert body["target"] == ent.TIER_CLOUD_STARTER
+    assert body["target_label"] == ent.tier_label(ent.TIER_CLOUD_STARTER)
+    assert body["target_rank"] == ent.tier_rank(ent.TIER_CLOUD_STARTER)
+    assert body["row"] == ent.tier_unlocks(ent.TIER_CLOUD_STARTER)
+
+
+def test_next_tier_unlocks_at_endpoint_enterprise_ceiling(client, ent):
+    rv = client.get("/api/entitlement/next-tier-unlocks-at?tier=enterprise")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert set(body.keys()) == _ENVELOPE_KEYS
+    assert body["tier"] == ent.TIER_ENTERPRISE
+    assert body["target"] is None
+    assert body["target_label"] is None
+    assert body["target_rank"] is None
+    assert body["row"] is None
+
+
+def test_next_tier_unlocks_at_endpoint_trial(client, ent):
+    rv = client.get("/api/entitlement/next-tier-unlocks-at?tier=trial")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["target"] == ent.TIER_ENTERPRISE
+    assert body["row"] == ent.tier_unlocks(ent.TIER_ENTERPRISE)
+
+
+def test_next_tier_unlocks_at_endpoint_missing_tier(client):
+    rv = client.get("/api/entitlement/next-tier-unlocks-at")
+    assert rv.status_code == 400
+    assert rv.get_json()["error"] == "missing tier"
+
+
+def test_next_tier_unlocks_at_endpoint_blank_tier(client):
+    rv = client.get("/api/entitlement/next-tier-unlocks-at?tier=%20%20")
+    assert rv.status_code == 400
+
+
+def test_next_tier_unlocks_at_endpoint_unknown_tier(client):
+    rv = client.get("/api/entitlement/next-tier-unlocks-at?tier=bogus")
+    assert rv.status_code == 404
+    body = rv.get_json()
+    assert body["error"] == "unknown tier"
+    assert body["which"] == "tier"
+
+
+def test_next_tier_unlocks_at_endpoint_trims_and_lowercases(client, ent):
+    rv = client.get("/api/entitlement/next-tier-unlocks-at?tier=%20%20OSS%20%20")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["tier"] == ent.TIER_OSS
+    assert body["target"] == ent.TIER_CLOUD_STARTER
+
+
+def test_next_tier_unlocks_at_endpoint_never_raises(client, ent, monkeypatch):
+    # Synthesise a builder failure and assert the envelope still
+    # returns 200 with row=null so the dashboard doesn't break.
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "next_tier_unlocks_at", boom)
+    monkeypatch.setattr(ent, "_next_purchasable_tier_after", boom)
+    rv = client.get("/api/entitlement/next-tier-unlocks-at?tier=oss")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["row"] is None
+    assert body["target"] is None
+
+
+# ── API: /api/entitlement/next-tier-locks-at ─────────────────────────────────
+
+
+def test_next_tier_locks_at_endpoint_oss_default(client, ent):
+    rv = client.get("/api/entitlement/next-tier-locks-at?tier=oss")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert set(body.keys()) == _ENVELOPE_KEYS
+    assert body["tier"] == ent.TIER_OSS
+    assert body["target"] == ent.TIER_CLOUD_STARTER
+    assert body["row"] == ent.tier_locks(ent.TIER_CLOUD_STARTER)
+
+
+def test_next_tier_locks_at_endpoint_enterprise_ceiling(client, ent):
+    rv = client.get("/api/entitlement/next-tier-locks-at?tier=enterprise")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["tier"] == ent.TIER_ENTERPRISE
+    assert body["target"] is None
+    assert body["row"] is None
+
+
+def test_next_tier_locks_at_endpoint_pro_collapses_to_empty(client, ent):
+    # pro -> next is enterprise (ceiling). The row carries the empty
+    # collapse, not null on the envelope.
+    rv = client.get("/api/entitlement/next-tier-locks-at?tier=pro")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["target"] == ent.TIER_ENTERPRISE
+    assert body["row"] is not None
+    assert body["row"]["next_tier"] is None
+    assert body["row"]["lost_features"] == []
+    assert body["row"]["lost_runtimes"] == []
+
+
+def test_next_tier_locks_at_endpoint_missing_tier(client):
+    rv = client.get("/api/entitlement/next-tier-locks-at")
+    assert rv.status_code == 400
+
+
+def test_next_tier_locks_at_endpoint_unknown_tier(client):
+    rv = client.get("/api/entitlement/next-tier-locks-at?tier=bogus")
+    assert rv.status_code == 404
+    body = rv.get_json()
+    assert body["error"] == "unknown tier"
+    assert body["which"] == "tier"
+
+
+def test_next_tier_locks_at_endpoint_never_raises(client, ent, monkeypatch):
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "next_tier_locks_at", boom)
+    monkeypatch.setattr(ent, "_next_purchasable_tier_after", boom)
+    rv = client.get("/api/entitlement/next-tier-locks-at?tier=oss")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["row"] is None
+    assert body["target"] is None
+
+
+def test_endpoints_row_matches_helper(client, ent):
+    # End-to-end parity: the endpoint body's row byte-equals the
+    # module-level helper for the same source.
+    unlocks_rv = client.get("/api/entitlement/next-tier-unlocks-at?tier=cloud_starter")
+    assert unlocks_rv.get_json()["row"] == ent.next_tier_unlocks_at(
+        ent.TIER_CLOUD_STARTER
+    )
+    locks_rv = client.get("/api/entitlement/next-tier-locks-at?tier=cloud_starter")
+    assert locks_rv.get_json()["row"] == ent.next_tier_locks_at(
+        ent.TIER_CLOUD_STARTER
+    )


### PR DESCRIPTION
## Summary

Adds the scalar what-if siblings of `Entitlement.next_tier_unlocks` / `.next_tier_locks`: the marginal unlocks / locks rows at the rung above a **caller-supplied** source tier, computed without going through the resolver. Source-anchored counterpart of the live methods that pin the source to the resolved entitlement.

Lets a pricing-comparison UI render the "what's new / what's lost at the next rung above X" cells for any hypothetical X off one round-trip, without first hitting `/api/entitlement` and without monkey-patching the entitlement context.

## What's added

**`clawmetry/entitlements.py`** (3 new module-level helpers)
- `_next_purchasable_tier_after(tier)` — pure stepper that walks the static `_PURCHASABLE_TIERS` rank ladder from any source tier (lenient on `trial`, ceiling returns `None`). Independent of the resolver — `get_entitlement` is never called.
- `next_tier_unlocks_at(tier)` — convenience for `tier_unlocks(_next_purchasable_tier_after(tier))`.
- `next_tier_locks_at(tier)` — convenience for `tier_locks(_next_purchasable_tier_after(tier))`.

Each helper byte-equals the explicit composition above (parity pinned in the test suite).

**`routes/entitlement.py`** (2 new endpoints, both keyed off `?tier=<source>`)
- `GET /api/entitlement/next-tier-unlocks-at?tier=<src>` — returns `{tier, tier_label, tier_rank, target, target_label, target_rank, row}` with `row` matching the `tier_unlocks` shape (or `null` at the ceiling / on builder failure).
- `GET /api/entitlement/next-tier-locks-at?tier=<src>` — symmetric for the marginal-loss view; at the rung whose next-above IS the ladder ceiling the row carries `next_tier=null` and empty `lost_*` lists (the `tier_locks` posture for "no rung above to step down from"), not `null` on the envelope.

Both endpoints: 400 on missing/blank input, 404 on unknown tier (with `which`), 200 with `row=null` at the source-side ceiling, never 5xxs.

## Behaviour

Stays in **GRACE** — no enforcement change. The helpers are catalogue-derived (off the static per-tier maps), independent of the resolver, and a parity test pins that flipping `CLAWMETRY_ENFORCE` on does not change the body.

## Tests

59 unit + endpoint tests in `tests/test_entitlement_next_tier_at.py`:

- stepper parity per source (OSS → cloud_starter, cloud_starter → cloud_pro, cloud_pro/pro/trial → enterprise, enterprise → None)
- ceiling None returns + bad-input handling for the stepper and both helpers
- `next_tier_{unlocks,locks}_at(tier) == tier_{unlocks,locks}(_next_purchasable_tier_after(tier))` byte-identity across every valid source
- row-shape pins (`tier_unlocks` and `tier_locks` exact key sets, sorted lists)
- enterprise-at-ceiling collapse (`next_tier=None`, `lost_*=[]`) — for both pro→ent and cloud_pro→ent
- trial-source resolution → enterprise (matches the live method's posture when called from a trial entitlement)
- grace-vs-enforce parity (catalogue-derived)
- resolver independence (`get_entitlement` raising must not break the helpers)
- never-raise on `tier_unlocks` / `tier_locks` / stepper builder failure
- API 400/missing, 404/unknown, 200/ceiling envelope, end-to-end row byte-parity with the module helpers

Lint clean (`ruff check`), all 59 tests pass, sibling entitlement tests still pass.

## Local operator verification checklist

I cannot reach the operator's machine, the running daemon, the live cloud snapshot, or a browser from this PR. After review:

- [ ] Copy the changed files (`clawmetry/entitlements.py`, `routes/entitlement.py`, `tests/test_entitlement_next_tier_at.py`) into `~/.clawmetry/lib/python3.X/site-packages/clawmetry/` (and the matching `routes/` + `tests/` directories where the daemon reads them).
- [ ] Clear the `__pycache__` directories under the install path.
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` to restart the sync daemon picking up the new module.
- [ ] `curl -s http://localhost:8900/api/entitlement/next-tier-unlocks-at?tier=oss | jq` — expect `target=cloud_starter`, `row.tier=cloud_starter`, `row.features` non-empty.
- [ ] `curl -s http://localhost:8900/api/entitlement/next-tier-locks-at?tier=pro | jq` — expect `target=enterprise`, `row.tier=enterprise`, `row.next_tier=null`, `row.lost_features=[]`, `row.lost_runtimes=[]` (ceiling collapse).
- [ ] `curl -s http://localhost:8900/api/entitlement/next-tier-unlocks-at?tier=enterprise | jq` — expect `target=null`, `row=null`, status 200.
- [ ] `curl -s -o /dev/null -w '%{http_code}\n' http://localhost:8900/api/entitlement/next-tier-unlocks-at` — expect `400`.
- [ ] `curl -s -o /dev/null -w '%{http_code}\n' http://localhost:8900/api/entitlement/next-tier-locks-at?tier=bogus` — expect `404`.
- [ ] Decrypt the live cloud snapshot and confirm nothing new leaks (these are pure GET endpoints; no snapshot-shape change).
- [ ] Browser-check `/dashboard` — no console errors, no regression in any panel that currently consumes the entitlement API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01MSFfTK956ATgTUut5CoCTj)_