### PR TITLE
feat(entitlement): tier_catalog + /api/entitlement/tier-catalog

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -65,6 +65,49 @@ _PAID_TIERS = frozenset(
     {TIER_TRIAL, TIER_CLOUD_STARTER, TIER_CLOUD_PRO, TIER_PRO, TIER_ENTERPRISE}
 )
 
+# Display labels for every known tier. The frontend pricing/upgrade card and
+# the locked-runtime tooltip both read these so the API and the UI agree on
+# what to call each tier in human copy. Falls back to a Title-cased id when a
+# label is missing so an unknown tier still renders with *something*.
+TIER_LABELS = {
+    TIER_OSS: "OSS",
+    TIER_CLOUD_FREE: "Cloud Free",
+    TIER_TRIAL: "Trial",
+    TIER_CLOUD_STARTER: "Cloud Starter",
+    TIER_CLOUD_PRO: "Cloud Pro",
+    TIER_PRO: "Pro (Self-hosted)",
+    TIER_ENTERPRISE: "Enterprise",
+}
+
+# Stable ladder rank for every known tier — lower-rank tier is strictly "less
+# than" a higher-rank tier on the open-core ladder. Same-rank entries are
+# cloud/self-hosted siblings of the equivalent tier (rank 0 = Free, rank 1 =
+# Starter, rank 2 = Pro/Trial, rank 3 = Enterprise). The pricing-comparison
+# UI uses this to sort tiers deterministically; the gate never decides on
+# rank alone — feature/runtime grants do.
+_TIER_RANK = {
+    TIER_OSS: 0,
+    TIER_CLOUD_FREE: 0,
+    TIER_CLOUD_STARTER: 1,
+    TIER_TRIAL: 2,
+    TIER_CLOUD_PRO: 2,
+    TIER_PRO: 2,
+    TIER_ENTERPRISE: 3,
+}
+
+# Deterministic listing order for the catalog: ladder ascending, with
+# cloud/self-hosted siblings clustered. Pinned so the UI dropdown is
+# byte-stable across releases — adding a new tier MUST add a row here.
+_TIER_ORDER = (
+    TIER_OSS,
+    TIER_CLOUD_FREE,
+    TIER_CLOUD_STARTER,
+    TIER_TRIAL,
+    TIER_CLOUD_PRO,
+    TIER_PRO,
+    TIER_ENTERPRISE,
+)
+
 # ── Runtime catalogue ───────────────────────────────────────────────────────
 # FREE: the OpenClaw and NVIDIA NemoClaw runtimes. NeMo *governance* (policy
 # enforcement) is a separate free feature; ``nemoclaw`` here is the agent
@@ -464,6 +507,95 @@ def runtime_catalog() -> list[dict]:
                 "free": False,
                 "allowed": allowed,
                 "locked": not allowed,
+            }
+        )
+    return out
+
+
+def tier_label(tier: str) -> str:
+    """Human-readable label for ``tier``. Falls back to a Title-cased id when
+    unknown so an unknown tier still renders with *something*. Mirrors
+    :func:`runtime_label` for the tier ladder. Never raises -- non-string
+    input returns ``""``."""
+    try:
+        tid = (tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return ""
+    if not tid:
+        return ""
+    return TIER_LABELS.get(tid, tid.replace("_", " ").title())
+
+
+def tier_rank(tier: str) -> int:
+    """Stable ladder rank for ``tier``. Returns ``-1`` for empty / unknown.
+
+    Same-rank entries (e.g. ``cloud_pro`` and ``pro``) are cloud/self-hosted
+    siblings of one another and not strictly ordered against each other. The
+    pricing UI uses ``(rank, id)`` to sort; never use the rank alone to decide
+    a gate — feature/runtime membership is the source of truth. Never raises
+    -- non-string input returns ``-1``.
+    """
+    try:
+        tid = (tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return -1
+    if not tid:
+        return -1
+    return _TIER_RANK.get(tid, -1)
+
+
+def tier_catalog() -> list[dict]:
+    """The full tier ladder with the entitlement-derived ``current`` flag set
+    on the row matching the resolved tier. Single source of truth the pricing
+    page reads to render *every* tier in the ladder — including ones the
+    install isn't on — so the upgrade-CTA card has data without monkey-
+    patching the entitlement context.
+
+    Each entry::
+
+        {
+          "id":              "<tier>",         # canonical key
+          "label":           "<Display>",      # falls back to title-cased id
+          "rank":            <int>,            # 0 = Free, 3 = Enterprise
+          "paid":            True | False,     # _PAID_TIERS membership
+          "current":         True | False,     # matches the resolved tier
+          "features":        ["..."],          # sorted, includes free
+          "runtimes":        ["..."],          # sorted, includes free
+          "retention_days":  <int> | null,     # null = unlimited / custom
+        }
+
+    Ordering: :data:`_TIER_ORDER` — ladder ascending, cloud/self-hosted
+    siblings clustered. Pinned so the UI is byte-stable across releases.
+
+    Never raises; on any resolution error every row is reported with
+    ``current=False`` and the OSS-free row is still surfaced first so the UI
+    has something safe to render. The catalog is catalogue-derived (off the
+    static per-tier grants) — flipping enforcement on does NOT change the
+    body. Only the ``current`` flag depends on the resolver.
+    """
+    try:
+        ent = get_entitlement()
+        current = (ent.tier or "").strip().lower()
+    except Exception as exc:
+        logger.warning("entitlements: tier_catalog falling back to grace: %s", exc)
+        current = TIER_OSS
+    out: list[dict] = []
+    for tid in _TIER_ORDER:
+        paid_feats = _TIER_FEATURES.get(tid, frozenset())
+        feats = sorted(FREE_FEATURES | paid_feats)
+        runtimes = sorted(
+            FREE_RUNTIMES | PAID_RUNTIMES if tid in _TIER_PAID_RUNTIMES else FREE_RUNTIMES
+        )
+        out.append(
+            {
+                "id": tid,
+                "label": tier_label(tid),
+                "rank": tier_rank(tid),
+                "paid": tid in _PAID_TIERS,
+                "current": tid == current,
+                "features": feats,
+                "runtimes": runtimes,
+                "retention_days": _TIER_RETENTION_DAYS.get(tid, 7),
             }
         )
     return out

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -113,6 +113,65 @@ def api_runtimes():
         )
 
 
+@bp_entitlement.route("/api/entitlement/tier-catalog")
+def api_entitlement_tier_catalog():
+    """Return the full tier ladder with each tier's features, runtimes,
+    retention and a ``current`` flag set on the resolved tier.
+
+    Companion to :func:`api_runtimes` (per-runtime locked/free flags) — the
+    pricing page reads this to render an upgrade-CTA card off ONE round-trip
+    instead of stitching per-feature gate calls together. Catalogue-derived:
+    flipping enforcement on does NOT change the body. Only the ``current``
+    flag depends on the resolver.
+
+    Shape::
+
+        {
+          "tiers": [
+            {
+              "id":              "<tier>",
+              "label":           "<Display>",
+              "rank":            <int>,
+              "paid":            true | false,
+              "current":         true | false,
+              "features":        ["..."],
+              "runtimes":        ["..."],
+              "retention_days":  <int> | null
+            },
+            ...
+          ],
+          "current":  "<resolved tier id>",
+          "grace":    true | false,   # mirrors /api/entitlement.grace
+          "enforced": true | false
+        }
+
+    Side-effect-free and never-raise: any resolution error falls back to an
+    OSS-free shape so the UI still has something safe to render.
+    """
+    try:
+        from clawmetry import entitlements as _ent
+
+        ent = _ent.get_entitlement()
+        return jsonify(
+            {
+                "tiers": _ent.tier_catalog(),
+                "current": ent.tier,
+                "grace": ent.grace,
+                "enforced": not ent.grace,
+            }
+        )
+    except Exception as exc:
+        logger.warning("api_entitlement_tier_catalog: falling back to OSS-free: %s", exc)
+        return jsonify(
+            {
+                "tiers": [],
+                "current": "oss",
+                "grace": True,
+                "enforced": False,
+            }
+        )
+
+
 @bp_entitlement.route("/api/license/status")
 def api_license_status():
     """Return the current self-hosted license info as JSON.

--- a/tests/test_entitlement_tier_catalog.py
+++ b/tests/test_entitlement_tier_catalog.py
@@ -1,0 +1,309 @@
+"""Tests for ``tier_label`` / ``tier_rank`` / ``tier_catalog`` -- the
+deterministic per-tier ladder helpers the pricing-comparison UI reads
+to render every tier in the open-core ladder off ONE round-trip, plus
+the companion ``/api/entitlement/tier-catalog`` endpoint.
+
+Pins covered here:
+
+* :data:`TIER_LABELS` has a display string for every tier in
+  :data:`_TIER_ORDER` -- the UI never has to fall back to the raw id
+* :func:`tier_label` falls back to a Title-cased id for unknown tiers
+  so an unknown tier still renders with something
+* :func:`tier_rank` returns -1 for unknown / empty / non-string input
+  and never raises on garbage
+* :func:`tier_catalog` walks :data:`_TIER_ORDER` in declaration order
+  -- pinned per known id so a reshuffle of the static ladder cannot
+  silently change the dropdown
+* every catalog row carries the same eight keys -- shape lock
+* free-tier rows (OSS / Cloud Free) carry only the free runtimes;
+  paid-tier rows carry FREE_RUNTIMES ∪ PAID_RUNTIMES
+* every catalog row's ``features`` includes the full :data:`FREE_FEATURES`
+  set on top of the per-tier paid grants (free features are always on)
+* the ``current`` flag flips on exactly the row matching the resolved
+  entitlement's tier; the rest are False
+* catalog is catalogue-derived -- flipping ``CLAWMETRY_ENFORCE`` on
+  does NOT change the per-tier rows (only the ``current`` flag depends
+  on the resolver)
+* helpers never raise on garbage input
+* the API endpoint surfaces the same body with ``current`` / ``grace``
+  / ``enforced`` envelope flags
+* a resolver failure short-circuits to an OSS-free envelope, never 5xx
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    """Fresh entitlements module with HOME pointed at an empty tmp dir so no
+    real ~/.clawmetry/license.key or cloud_plan.json leaks in. Enforcement
+    off by default (grace mode) -- the catalog is catalogue-derived and
+    independent of the resolver, so the fixture only needs to keep the live
+    resolver from surprising the test."""
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+_ROW_KEYS = {
+    "id",
+    "label",
+    "rank",
+    "paid",
+    "current",
+    "features",
+    "runtimes",
+    "retention_days",
+}
+
+_ENVELOPE_KEYS = {"tiers", "current", "grace", "enforced"}
+
+
+# ── TIER_LABELS / tier_label ────────────────────────────────────────────────
+
+
+def test_tier_labels_cover_every_known_tier(ent):
+    # The frontend pricing card never falls back to the raw id for any tier
+    # the install ships with knowing about.
+    for tid in ent._TIER_ORDER:
+        assert tid in ent.TIER_LABELS, tid
+        assert ent.TIER_LABELS[tid].strip() != "", tid
+
+
+def test_tier_label_returns_known_label(ent):
+    assert ent.tier_label(ent.TIER_OSS) == "OSS"
+    assert ent.tier_label(ent.TIER_ENTERPRISE) == "Enterprise"
+    assert ent.tier_label(ent.TIER_CLOUD_PRO) == "Cloud Pro"
+
+
+def test_tier_label_trims_and_lowercases(ent):
+    assert ent.tier_label("  OSS  ") == "OSS"
+    assert ent.tier_label("ENTERPRISE") == "Enterprise"
+
+
+def test_tier_label_falls_back_for_unknown(ent):
+    # Title-cased id with underscores -> spaces, so the UI gets *something*.
+    assert ent.tier_label("custom_plan") == "Custom Plan"
+
+
+@pytest.mark.parametrize("bad", ["", "  ", None])
+def test_tier_label_blank_returns_empty(ent, bad):
+    assert ent.tier_label(bad) == ""
+
+
+# ── tier_rank ────────────────────────────────────────────────────────────────
+
+
+def test_tier_rank_values(ent):
+    # Pinned ladder so a reshuffle of the static ranks cannot silently
+    # change the pricing sort order.
+    assert ent.tier_rank(ent.TIER_OSS) == 0
+    assert ent.tier_rank(ent.TIER_CLOUD_FREE) == 0
+    assert ent.tier_rank(ent.TIER_CLOUD_STARTER) == 1
+    assert ent.tier_rank(ent.TIER_TRIAL) == 2
+    assert ent.tier_rank(ent.TIER_CLOUD_PRO) == 2
+    assert ent.tier_rank(ent.TIER_PRO) == 2
+    assert ent.tier_rank(ent.TIER_ENTERPRISE) == 3
+
+
+def test_tier_rank_trims_and_lowercases(ent):
+    assert ent.tier_rank("  OSS  ") == 0
+
+
+@pytest.mark.parametrize("bad", ["", "  ", None, "bogus", "BOGUS"])
+def test_tier_rank_returns_minus_one_on_bad_input(ent, bad):
+    assert ent.tier_rank(bad) == -1
+
+
+def test_tier_rank_never_raises_on_garbage(ent):
+    # Non-string input must not propagate the AttributeError -- the
+    # gate-adjacent helpers all use the trim/lower idiom defensively.
+    assert ent.tier_rank(0) == -1
+    assert ent.tier_rank(1.5) == -1
+
+
+# ── tier_catalog ─────────────────────────────────────────────────────────────
+
+
+def test_catalog_walks_static_order(ent):
+    cat = ent.tier_catalog()
+    assert [row["id"] for row in cat] == list(ent._TIER_ORDER)
+
+
+def test_catalog_row_shape(ent):
+    for row in ent.tier_catalog():
+        assert set(row.keys()) == _ROW_KEYS, row["id"]
+        assert isinstance(row["features"], list)
+        assert isinstance(row["runtimes"], list)
+        assert isinstance(row["paid"], bool)
+        assert isinstance(row["current"], bool)
+
+
+def test_catalog_features_sorted_and_include_free(ent):
+    for row in ent.tier_catalog():
+        # Sorted determinism so the dashboard JSON is byte-stable.
+        assert row["features"] == sorted(row["features"]), row["id"]
+        # Free features are always on -- a row missing them would be a
+        # silent regression that flipped /api/entitlement.allows_feature
+        # for some baseline cap.
+        assert frozenset(ent.FREE_FEATURES).issubset(row["features"]), row["id"]
+
+
+def test_catalog_runtimes_sorted(ent):
+    for row in ent.tier_catalog():
+        assert row["runtimes"] == sorted(row["runtimes"]), row["id"]
+
+
+def test_catalog_free_rows_only_have_free_runtimes(ent):
+    rows_by_id = {row["id"]: row for row in ent.tier_catalog()}
+    for tid in (ent.TIER_OSS, ent.TIER_CLOUD_FREE):
+        assert rows_by_id[tid]["runtimes"] == sorted(ent.FREE_RUNTIMES)
+        assert rows_by_id[tid]["paid"] is False
+
+
+def test_catalog_paid_rows_have_all_runtimes(ent):
+    rows_by_id = {row["id"]: row for row in ent.tier_catalog()}
+    for tid in (
+        ent.TIER_TRIAL,
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_PRO,
+        ent.TIER_ENTERPRISE,
+    ):
+        assert rows_by_id[tid]["runtimes"] == sorted(ent.ALL_RUNTIMES), tid
+        assert rows_by_id[tid]["paid"] is True
+
+
+def test_catalog_paid_flag_matches_paid_tiers(ent):
+    for row in ent.tier_catalog():
+        assert row["paid"] is (row["id"] in ent._PAID_TIERS), row["id"]
+
+
+def test_catalog_retention_days_per_tier(ent):
+    rows_by_id = {row["id"]: row for row in ent.tier_catalog()}
+    assert rows_by_id[ent.TIER_OSS]["retention_days"] == 7
+    assert rows_by_id[ent.TIER_CLOUD_FREE]["retention_days"] == 7
+    assert rows_by_id[ent.TIER_CLOUD_STARTER]["retention_days"] == 30
+    assert rows_by_id[ent.TIER_TRIAL]["retention_days"] == 30
+    assert rows_by_id[ent.TIER_CLOUD_PRO]["retention_days"] == 90
+    assert rows_by_id[ent.TIER_PRO]["retention_days"] == 90
+    assert rows_by_id[ent.TIER_ENTERPRISE]["retention_days"] is None
+
+
+def test_catalog_current_flag_marks_oss_on_oss_install(ent):
+    cat = ent.tier_catalog()
+    current_rows = [row for row in cat if row["current"]]
+    # OSS-free fallback -> exactly one row carries current=True.
+    assert len(current_rows) == 1
+    assert current_rows[0]["id"] == ent.TIER_OSS
+
+
+def test_catalog_current_flag_follows_resolved_tier(ent, monkeypatch):
+    # Swap the resolver to a higher tier and the flag must move with it.
+    monkeypatch.setattr(
+        ent,
+        "get_entitlement",
+        lambda *_, **__: ent._build(ent.TIER_CLOUD_PRO, "cloud", node_limit=5),
+    )
+    cat = ent.tier_catalog()
+    current_rows = [row for row in cat if row["current"]]
+    assert len(current_rows) == 1
+    assert current_rows[0]["id"] == ent.TIER_CLOUD_PRO
+
+
+def test_catalog_rows_identical_under_grace_and_enforce(ent, monkeypatch):
+    # Catalogue-derived -- only the `current` flag depends on the resolver,
+    # never the per-tier features/runtimes/retention slice.
+    grace_rows = [
+        {k: v for k, v in row.items() if k != "current"} for row in ent.tier_catalog()
+    ]
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    importlib.reload(ent)
+    ent.invalidate()
+    enforce_rows = [
+        {k: v for k, v in row.items() if k != "current"} for row in ent.tier_catalog()
+    ]
+    assert enforce_rows == grace_rows
+
+
+def test_catalog_never_raises_when_resolver_fails(ent, monkeypatch):
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "get_entitlement", boom)
+    # Catalog still surfaces every tier; current flag collapses to OSS.
+    cat = ent.tier_catalog()
+    assert [row["id"] for row in cat] == list(ent._TIER_ORDER)
+    current_rows = [row for row in cat if row["current"]]
+    assert len(current_rows) == 1
+    assert current_rows[0]["id"] == ent.TIER_OSS
+
+
+# ── API: /api/entitlement/tier-catalog ──────────────────────────────────────
+
+
+def test_tier_catalog_endpoint_envelope(client, ent):
+    rv = client.get("/api/entitlement/tier-catalog")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert set(body.keys()) == _ENVELOPE_KEYS
+    assert body["current"] == ent.TIER_OSS
+    assert body["grace"] is True
+    assert body["enforced"] is False
+    # Same body as the module-level helper.
+    assert body["tiers"] == ent.tier_catalog()
+
+
+def test_tier_catalog_endpoint_rows_match_helper(client, ent):
+    rv = client.get("/api/entitlement/tier-catalog")
+    rows = rv.get_json()["tiers"]
+    assert [row["id"] for row in rows] == list(ent._TIER_ORDER)
+    for row in rows:
+        assert set(row.keys()) == _ROW_KEYS
+
+
+def test_tier_catalog_endpoint_never_raises_on_resolver_failure(client, ent, monkeypatch):
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "get_entitlement", boom)
+    monkeypatch.setattr(ent, "tier_catalog", boom)
+    rv = client.get("/api/entitlement/tier-catalog")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert set(body.keys()) == _ENVELOPE_KEYS
+    assert body["tiers"] == []
+    assert body["current"] == "oss"
+    assert body["grace"] is True
+    assert body["enforced"] is False
+
+
+def test_tier_catalog_endpoint_enforced_envelope(client, ent, monkeypatch):
+    # Pretend enforcement is on -- the envelope flips grace/enforced but the
+    # per-row body still matches the helper.
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    importlib.reload(ent)
+    ent.invalidate()
+    rv = client.get("/api/entitlement/tier-catalog")
+    body = rv.get_json()
+    assert body["grace"] is False
+    assert body["enforced"] is True
+    assert body["tiers"] == ent.tier_catalog()


### PR DESCRIPTION
## Summary

Adds the deterministic per-tier ladder helpers (`tier_label`, `tier_rank`, `tier_catalog`) and a `GET /api/entitlement/tier-catalog` endpoint so the dashboard can render every tier in the open-core ladder off **one** round-trip. Companion to the existing `runtime_catalog()` / `/api/runtimes` — together they cover both axes the upgrade-CTA card needs without monkey-patching the entitlement context or making N per-feature gate calls.

**No behaviour change.** Catalogue-derived (off the static per-tier grants); the gate stays in GRACE. Only the `current` flag depends on the resolver.

## Changes

### `clawmetry/entitlements.py`
- `TIER_LABELS` — display label for every known tier.
- `_TIER_RANK` — stable ladder rank (0 = Free, 1 = Starter, 2 = Pro/Trial, 3 = Enterprise). Cloud/self-hosted siblings share a rank.
- `_TIER_ORDER` — pinned declaration order for byte-stable UI rendering.
- `tier_label(tier)` — Title-cased id fallback for unknown ids; defensive against non-string input.
- `tier_rank(tier)` — `-1` for empty/unknown; defensive against non-string input.
- `tier_catalog()` — `list[dict]` over `_TIER_ORDER` with `id`, `label`, `rank`, `paid`, `current`, `features` (sorted, free always on top of paid grants), `runtimes` (sorted), `retention_days`. Never raises.

### `routes/entitlement.py`
- `GET /api/entitlement/tier-catalog` — envelope `{tiers, current, grace, enforced}`. Falls back to an OSS-free shape on any resolver failure (never 5xxs).

### `tests/test_entitlement_tier_catalog.py`
31 tests pinning:
- Every `_TIER_ORDER` id has a `TIER_LABELS` entry.
- `tier_label` / `tier_rank` garbage-safety (empty / None / non-string).
- Catalog walks `_TIER_ORDER` in declaration order; row shape lock (8 keys).
- Free-tier rows carry only `FREE_RUNTIMES`; paid-tier rows carry `ALL_RUNTIMES`.
- Per-tier retention pinned to what `/pricing` promises.
- `current` flag follows the resolver; collapses to OSS on resolver failure.
- Body is byte-stable across `CLAWMETRY_ENFORCE=0` vs `=1` (only the `current` flag depends on the resolver).
- Endpoint envelope shape lock, resolver-failure fallback shape.

## Test plan

- [x] `ruff check clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_tier_catalog.py` → clean.
- [x] `python3 -m pytest tests/test_entitlement_tier_catalog.py` → 31 passed.
- [x] `python3 -m pytest tests/test_entitlements*.py tests/test_entitlement_api.py` → 41 passed (no regressions on existing entitlement tests).
- [x] In-process smoke: `Flask().register_blueprint(bp_entitlement).test_client().get('/api/entitlement/tier-catalog')` → 200 with the expected ladder.

## Local operator verification checklist

The bot can't reach the running daemon or the live cloud snapshot, so the human operator should:

1. Copy the three changed files into the installed package:
   ```
   cp clawmetry/entitlements.py routes/entitlement.py ~/.clawmetry/lib/pythonX.Y/site-packages/clawmetry/
   cp routes/entitlement.py ~/.clawmetry/lib/pythonX.Y/site-packages/routes/
   ```
2. Clear `__pycache__` under both dirs.
3. `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` to bounce the daemon.
4. Hit `curl -s http://localhost:8900/api/entitlement/tier-catalog | jq` and confirm:
   - 7 rows in `_TIER_ORDER`.
   - `current == "oss"`, `grace == true`, `enforced == false`.
   - The OSS row carries every free feature and only `nemoclaw` + `openclaw`; Enterprise carries all features + every runtime.
5. Decrypt the live cloud snapshot in the browser and confirm `/api/entitlement` (unchanged) still surfaces the OSS-free shape — the new endpoint is additive and should not have moved anything.
6. Browser-check the dashboard renders normally (no JS calls the new endpoint yet; this PR only ships the API surface).

## Notes for the operator

- This PR is **DRAFT** — please drive the local-daemon verification, live-cloud verification, and the `[RELEASE]` PR yourself. The bot does not touch `__version__`, tags, or releases.
- The CLI / `clawmetry activate` / `clawmetry license` surface is untouched. Phase 3/4/6 work (cloud-side license issuance, closed-source `clawmetry-pro` package, enterprise SSO/SIEM) lives in the private `clawmetry-cloud` repo the bot has no access to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_98034b73-851c-5868-8b3f-d81924d18c88

---
_Generated by [Claude Code](https://claude.ai/code/session_011hSuyrcvAeCUdVbXLY7Us1)_