### PR TITLE
feat(entitlement): previous_tier_unlocks_at + previous_tier_locks_at + endpoints (scalar what-if)

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -5047,3 +5047,141 @@ def next_tier_locks_at(tier: str) -> dict | None:
     except Exception as exc:
         logger.warning("entitlements: next_tier_locks_at failed: %s", exc)
         return None
+
+
+def _previous_purchasable_tier_before(tier: str) -> str | None:
+    """Pure helper: next strictly-lower-rank entry in
+    :data:`_PURCHASABLE_TIERS` before ``tier``, picking the *highest*
+    rank strictly below the source and breaking same-rank ties by the
+    order of declaration in :data:`_PURCHASABLE_TIERS`.
+
+    Source-anchored mirror of :func:`_next_purchasable_tier_after`. The
+    live :meth:`Entitlement.previous_purchasable_tier` applies a cloud-
+    vs-self-hosted tie-break against the resolved entitlement's
+    ``source``; this helper intentionally elides that preference for
+    the same reason :func:`_next_purchasable_tier_after` does -- the
+    ``_at`` family is for hypothetical comparison and must be
+    deterministic on the static catalogue, not driven by which install
+    flavour the resolver is currently in.
+
+    Accepts any id in :data:`_TIER_ORDER` (including :data:`TIER_TRIAL`,
+    rank 2 -- "next strictly below trial" resolves to cloud_starter,
+    rank 1). Returns ``None`` for empty / unknown ``tier`` and at the
+    floor (oss / cloud_free -- nothing strictly below). Never raises.
+    """
+    try:
+        src = (tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if not src or src not in _TIER_ORDER:
+        return None
+    try:
+        src_rank = _TIER_RANK.get(src, -1)
+        lower_ranks = [
+            r for r in (_TIER_RANK.get(t, -1) for t in _PURCHASABLE_TIERS)
+            if 0 <= r < src_rank
+        ]
+        if not lower_ranks:
+            return None
+        target_rank = max(lower_ranks)
+        for cand in _PURCHASABLE_TIERS:
+            if _TIER_RANK.get(cand, -1) == target_rank:
+                return cand
+        return None
+    except Exception as exc:
+        logger.warning("entitlements: _previous_purchasable_tier_before failed: %s", exc)
+        return None
+
+
+def previous_tier_unlocks_at(tier: str) -> dict | None:
+    """Scalar what-if sibling of :meth:`Entitlement.previous_tier_unlocks`:
+    marginal unlocks row at the rung below the caller-supplied ``tier``,
+    in :func:`tier_unlocks` shape.
+
+    Source-anchored mirror of :func:`next_tier_unlocks_at`. Convenience
+    for ``tier_unlocks(_previous_purchasable_tier_before(tier))`` -- the
+    source-anchored equivalent of the live method, so a downgrade-CTA
+    or pricing-comparison page can render "what would still be granted
+    at the rung below X" for any hypothetical ``X`` without first
+    asking the resolver and without monkey-patching the entitlement
+    context. Pairs with :func:`previous_tier_locks_at` (the marginal-
+    loss view of the same rung) on a hypothetical pricing matrix cell.
+
+    Row shape matches :func:`tier_unlocks` exactly -- ``tier``,
+    ``tier_label``, ``tier_rank``, ``previous_tier``,
+    ``previous_tier_label``, ``previous_tier_rank``, ``features``,
+    ``runtimes``. The row IS the tier-property row of the rung below
+    (its ``previous_tier`` is that rung's natural next-lower
+    purchasable, NOT the caller-supplied ``tier``) -- the same posture
+    :meth:`Entitlement.previous_tier_unlocks` surfaces via the live
+    resolver. Callers who want the source-anchored ``previous_tier``
+    should use :func:`tier_unlocks_at` directly with the explicit
+    ``(tier, target)`` pair.
+
+    Accepts any id in :data:`_TIER_ORDER` (including :data:`TIER_TRIAL`)
+    -- the lenient ``_at`` posture.
+
+    Returns ``None`` for empty / unknown ``tier`` and at the floor
+    (oss / cloud_free -- no rung strictly below). Never raises: a
+    builder failure short-circuits to ``None`` so the CTA surface stays
+    mute instead of breaking.
+    """
+    try:
+        src = (tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if not src or src not in _TIER_ORDER:
+        return None
+    try:
+        target = _previous_purchasable_tier_before(src)
+        if target is None:
+            return None
+        return tier_unlocks(target)
+    except Exception as exc:
+        logger.warning("entitlements: previous_tier_unlocks_at failed: %s", exc)
+        return None
+
+
+def previous_tier_locks_at(tier: str) -> dict | None:
+    """Scalar what-if sibling of :meth:`Entitlement.previous_tier_locks`:
+    marginal locks row at the rung below the caller-supplied ``tier``,
+    in :func:`tier_locks` shape.
+
+    Marginal-loss mirror of :func:`previous_tier_unlocks_at` and pairs
+    with :meth:`Entitlement.previous_tier_locks` (live, source pinned to
+    the resolver) the same way :func:`tier_locks_at` pairs with
+    :func:`tier_locks`. Convenience for
+    ``tier_locks(_previous_purchasable_tier_before(tier))`` -- the
+    source-anchored equivalent of the live method, so a pricing page
+    can render "what does the rung below X first lose vs the rung
+    above IT" for any hypothetical ``X`` without asking the resolver.
+
+    Row shape matches :func:`tier_locks` exactly -- ``tier``,
+    ``tier_label``, ``tier_rank``, ``next_tier``, ``next_tier_label``,
+    ``next_tier_rank``, ``lost_features``, ``lost_runtimes``. The row IS
+    the tier-property row of the rung below (its ``next_tier`` is that
+    rung's natural next-higher purchasable, NOT the caller-supplied
+    ``tier``).
+
+    Accepts any id in :data:`_TIER_ORDER` (including :data:`TIER_TRIAL`)
+    -- the lenient ``_at`` posture.
+
+    Returns ``None`` for empty / unknown ``tier`` and at the floor
+    (oss / cloud_free -- no rung strictly below). Never raises: a
+    builder failure short-circuits to ``None`` so the CTA surface stays
+    mute instead of breaking.
+    """
+    try:
+        src = (tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if not src or src not in _TIER_ORDER:
+        return None
+    try:
+        target = _previous_purchasable_tier_before(src)
+        if target is None:
+            return None
+        return tier_locks(target)
+    except Exception as exc:
+        logger.warning("entitlements: previous_tier_locks_at failed: %s", exc)
+        return None

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -4528,3 +4528,177 @@ def api_entitlement_next_tier_locks_at():
                 "row": None,
             }
         )
+
+
+@bp_entitlement.route("/api/entitlement/previous-tier-unlocks-at")
+def api_entitlement_previous_tier_unlocks_at():
+    """``GET /api/entitlement/previous-tier-unlocks-at?tier=<source>`` --
+    scalar what-if sibling of ``/api/entitlement/previous-tier-unlocks``:
+    marginal unlocks row at the rung below the caller-supplied
+    ``tier``, in :func:`clawmetry.entitlements.tier_unlocks` shape.
+
+    Source-anchored mirror of ``/api/entitlement/next-tier-unlocks-at``
+    and downgrade-side counterpart of the live
+    ``/api/entitlement/previous-tier-unlocks`` endpoint. Lets a pricing
+    page render the "what would still be granted at the rung below X"
+    downgrade-CTA cell for any hypothetical ``X`` without first asking
+    the resolver and without monkey-patching the entitlement context.
+
+    Response shape::
+
+        {
+          "tier":           "<source tier id>",
+          "tier_label":     "<source label>",
+          "tier_rank":      <source rank>,
+          "target":         "<rung-below tier id>" | null,
+          "target_label":   "<rung-below label>" | null,
+          "target_rank":    <rung-below rank> | null,
+          "row":            {<tier_unlocks row>} | null,
+        }
+
+    The inner ``row`` matches the live ``/previous-tier-unlocks`` row
+    shape (``tier``, ``tier_label``, ``tier_rank``, ``previous_tier``,
+    ``previous_tier_label``, ``previous_tier_rank``, ``features``,
+    ``runtimes``). The row IS the tier-property row of the rung below
+    (its ``previous_tier`` is that rung's natural next-lower
+    purchasable, NOT the caller-supplied ``tier``). Callers who want
+    the source-anchored ``previous_tier`` should use ``/tier-unlocks-at``
+    with the explicit ``(tier, target)`` pair.
+
+    Accepts any tier id in :data:`entitlements._TIER_ORDER` (including
+    ``trial``), matching the other ``_at`` family endpoints. ``target``
+    / ``row`` collapse to ``null`` at the floor (no rung strictly below
+    the source -- oss / cloud_free) -- the surface stays 200 with a
+    populated envelope so callers can render "you're at the bottom"
+    copy without a status-code branch.
+
+    - **400** when ``tier=`` is missing / blank
+    - **404** when ``tier`` is unknown. The body carries ``which`` so a
+      caller can render the right "unknown ..." message.
+    - **Never 5xxs**: builder failure short-circuits to ``row=null``
+      on the same 200 envelope so the CTA surface stays mute.
+    """
+    raw_tier = request.args.get("tier")
+    tier_in = (raw_tier or "").strip().lower()
+    if not tier_in:
+        return jsonify({"error": "missing tier"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        if tier_in not in _ent._TIER_ORDER:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "tier", "tier": tier_in}
+                ),
+                404,
+            )
+        target = _ent._previous_purchasable_tier_before(tier_in)
+        row = _ent.previous_tier_unlocks_at(tier_in)
+        return jsonify(
+            {
+                "tier": tier_in,
+                "tier_label": _ent.tier_label(tier_in),
+                "tier_rank": _ent.tier_rank(tier_in),
+                "target": target,
+                "target_label": _ent.tier_label(target) if target else None,
+                "target_rank": _ent.tier_rank(target) if target else None,
+                "row": row,
+            }
+        )
+    except Exception as exc:
+        logger.warning("api_entitlement_previous_tier_unlocks_at: error: %s", exc)
+        return jsonify(
+            {
+                "tier": tier_in,
+                "tier_label": None,
+                "tier_rank": -1,
+                "target": None,
+                "target_label": None,
+                "target_rank": None,
+                "row": None,
+            }
+        )
+
+
+@bp_entitlement.route("/api/entitlement/previous-tier-locks-at")
+def api_entitlement_previous_tier_locks_at():
+    """``GET /api/entitlement/previous-tier-locks-at?tier=<source>`` --
+    scalar what-if sibling of ``/api/entitlement/previous-tier-locks``:
+    marginal locks row at the rung below the caller-supplied ``tier``,
+    in :func:`clawmetry.entitlements.tier_locks` shape.
+
+    Source-anchored mirror of ``/api/entitlement/next-tier-locks-at``.
+    Marginal-loss companion to ``/previous-tier-unlocks-at`` on a
+    hypothetical pricing matrix cell -- where the unlocks form shows
+    "what the rung below still grants" the locks form shows "what the
+    rung below first loses vs the rung above IT".
+
+    Response shape::
+
+        {
+          "tier":           "<source tier id>",
+          "tier_label":     "<source label>",
+          "tier_rank":      <source rank>,
+          "target":         "<rung-below tier id>" | null,
+          "target_label":   "<rung-below label>" | null,
+          "target_rank":    <rung-below rank> | null,
+          "row":            {<tier_locks row>} | null,
+        }
+
+    The inner ``row`` matches the live ``/previous-tier-locks`` row
+    shape (``tier``, ``tier_label``, ``tier_rank``, ``next_tier``,
+    ``next_tier_label``, ``next_tier_rank``, ``lost_features``,
+    ``lost_runtimes``). The row's ``next_tier`` is the rung-below's
+    natural next-higher purchasable, NOT the caller-supplied source.
+
+    Accepts any tier id in :data:`entitlements._TIER_ORDER` (including
+    ``trial``). ``target`` / ``row`` collapse to ``null`` at the floor
+    (no rung strictly below the source -- oss / cloud_free) -- the
+    surface stays 200 with a populated envelope.
+
+    - **400** when ``tier=`` is missing / blank
+    - **404** when ``tier`` is unknown. The body carries ``which`` so a
+      caller can render the right "unknown ..." message.
+    - **Never 5xxs**: builder failure short-circuits to ``row=null``
+      on the same 200 envelope so the CTA surface stays mute.
+    """
+    raw_tier = request.args.get("tier")
+    tier_in = (raw_tier or "").strip().lower()
+    if not tier_in:
+        return jsonify({"error": "missing tier"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        if tier_in not in _ent._TIER_ORDER:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "tier", "tier": tier_in}
+                ),
+                404,
+            )
+        target = _ent._previous_purchasable_tier_before(tier_in)
+        row = _ent.previous_tier_locks_at(tier_in)
+        return jsonify(
+            {
+                "tier": tier_in,
+                "tier_label": _ent.tier_label(tier_in),
+                "tier_rank": _ent.tier_rank(tier_in),
+                "target": target,
+                "target_label": _ent.tier_label(target) if target else None,
+                "target_rank": _ent.tier_rank(target) if target else None,
+                "row": row,
+            }
+        )
+    except Exception as exc:
+        logger.warning("api_entitlement_previous_tier_locks_at: error: %s", exc)
+        return jsonify(
+            {
+                "tier": tier_in,
+                "tier_label": None,
+                "tier_rank": -1,
+                "target": None,
+                "target_label": None,
+                "target_rank": None,
+                "row": None,
+            }
+        )

--- a/tests/test_entitlement_previous_tier_at.py
+++ b/tests/test_entitlement_previous_tier_at.py
@@ -1,0 +1,533 @@
+"""Tests for ``previous_tier_unlocks_at`` / ``previous_tier_locks_at`` --
+scalar what-if siblings of the live :meth:`Entitlement.previous_tier_unlocks`
+/ :meth:`Entitlement.previous_tier_locks` instance methods, plus the
+companion ``/api/entitlement/previous-tier-{unlocks,locks}-at?tier=<src>``
+endpoints and the private :func:`_previous_purchasable_tier_before`
+stepper they share.
+
+These helpers let a pricing-comparison UI render "what would still be
+granted / first lose at the rung below X" for any hypothetical ``X``
+without first asking the resolver or monkey-patching the entitlement
+context -- the source-anchored counterpart of the live methods that
+pin the source to the resolved entitlement.
+
+Pins covered here:
+
+* helper :func:`_previous_purchasable_tier_before` walks the static
+  :data:`_PURCHASABLE_TIERS` rank ladder identically for every source
+  tier -- floor returns ``None``, lenient on :data:`TIER_TRIAL`, and
+  intentionally elides the cloud-vs-self-hosted preference the live
+  :meth:`Entitlement.previous_purchasable_tier` applies (the ``_at``
+  family is deterministic on the static catalogue)
+* ``previous_tier_unlocks_at(tier)`` byte-equals
+  ``tier_unlocks(_previous_purchasable_tier_before(tier))`` across
+  every valid source -- the convenience cannot drift from the explicit
+  composition
+* same identity for ``previous_tier_locks_at`` against :func:`tier_locks`
+* at the floor (no rung strictly below source -- oss / cloud_free)
+  both helpers return ``None`` -- mirrors the live
+  :meth:`Entitlement.previous_tier_unlocks` /
+  :meth:`Entitlement.previous_tier_locks` behaviour
+* trial-as-source resolves to the highest rank strictly below 2 ==
+  cloud_starter (rank 1) -- the same rung the next-after-cloud-starter
+  step lands on, walked in reverse
+* grace vs enforce yields the same body (the ``_at`` family walks the
+  static catalogue, not the gated resolver)
+* unknown / empty / ``None`` / non-string source returns ``None``
+* the API surface 400s on missing input, 404s on unknown ids (with
+  ``which``), surfaces 200 envelopes at the floor with ``row=null``,
+  and never 5xxs
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    """Fresh entitlements module with HOME pointed at an empty tmp dir
+    so no real ~/.clawmetry/license.key or cloud_plan.json leaks in.
+    Enforcement off by default (grace mode) -- both helpers are
+    catalogue-derived and independent of the resolver, so the fixture
+    only needs to make sure the live resolver does not surprise the
+    test."""
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+_UNLOCKS_KEYS = {
+    "tier",
+    "tier_label",
+    "tier_rank",
+    "previous_tier",
+    "previous_tier_label",
+    "previous_tier_rank",
+    "features",
+    "runtimes",
+}
+
+_LOCKS_KEYS = {
+    "tier",
+    "tier_label",
+    "tier_rank",
+    "next_tier",
+    "next_tier_label",
+    "next_tier_rank",
+    "lost_features",
+    "lost_runtimes",
+}
+
+_ENVELOPE_KEYS = {
+    "tier",
+    "tier_label",
+    "tier_rank",
+    "target",
+    "target_label",
+    "target_rank",
+    "row",
+}
+
+
+# ── _previous_purchasable_tier_before ───────────────────────────────────────
+
+
+def test_previous_before_walks_to_highest_strictly_lower_rank(ent):
+    # The stepper picks the highest rank strictly below source, then
+    # the first entry in _PURCHASABLE_TIERS at that rank. Pinned per
+    # known source so a reshuffle of the static ladder cannot silently
+    # change the answer.
+    expected = {
+        ent.TIER_CLOUD_STARTER: ent.TIER_OSS,
+        ent.TIER_TRIAL: ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO: ent.TIER_CLOUD_STARTER,
+        ent.TIER_PRO: ent.TIER_CLOUD_STARTER,
+        ent.TIER_ENTERPRISE: ent.TIER_CLOUD_PRO,
+    }
+    for src, exp in expected.items():
+        assert ent._previous_purchasable_tier_before(src) == exp, src
+
+
+def test_previous_before_returns_none_at_floor(ent):
+    # oss and cloud_free both sit at rank 0 -- nothing strictly below.
+    assert ent._previous_purchasable_tier_before(ent.TIER_OSS) is None
+    assert ent._previous_purchasable_tier_before(ent.TIER_CLOUD_FREE) is None
+
+
+@pytest.mark.parametrize("bad", ["", "  ", None, 0, 1.5, "BOGUS", "bogus"])
+def test_previous_before_returns_none_on_bad_input(ent, bad):
+    assert ent._previous_purchasable_tier_before(bad) is None
+
+
+def test_previous_before_trims_and_lowercases(ent):
+    # Same canonicalisation the rest of the _at family applies.
+    assert (
+        ent._previous_purchasable_tier_before("  CLOUD_STARTER  ")
+        == ent.TIER_OSS
+    )
+
+
+def test_previous_before_independent_of_resolver(ent, monkeypatch):
+    # The stepper must not call get_entitlement at any point -- if it
+    # does, swapping it to raise would make the helper return None.
+    def boom(*_, **__):
+        raise RuntimeError("resolver must not be reached")
+
+    monkeypatch.setattr(ent, "get_entitlement", boom)
+    assert (
+        ent._previous_purchasable_tier_before(ent.TIER_CLOUD_STARTER)
+        == ent.TIER_OSS
+    )
+
+
+def test_previous_before_elides_cloud_vs_self_hosted_preference(ent):
+    # The live Entitlement.previous_purchasable_tier applies a cloud-
+    # vs-self-hosted tie-break against the resolved source -- the _at
+    # stepper intentionally does NOT (declaration-order tie-break),
+    # since the source is hypothetical. Enterprise's strictly-lower
+    # cluster is rank 2 == {cloud_pro, pro}; _PURCHASABLE_TIERS declares
+    # cloud_pro before pro, so the helper deterministically picks
+    # cloud_pro regardless of how the resolver is currently sourced.
+    assert (
+        ent._previous_purchasable_tier_before(ent.TIER_ENTERPRISE)
+        == ent.TIER_CLOUD_PRO
+    )
+
+
+def test_previous_before_never_raises(monkeypatch, ent):
+    # Synthetic _TIER_RANK failure -- the helper must swallow and
+    # return None rather than propagate.
+    monkeypatch.setattr(
+        ent,
+        "_TIER_RANK",
+        type("Boom", (), {"get": lambda *_, **__: (_ for _ in ()).throw(RuntimeError())})(),
+    )
+    assert (
+        ent._previous_purchasable_tier_before(ent.TIER_CLOUD_STARTER) is None
+    )
+
+
+# ── previous_tier_unlocks_at ────────────────────────────────────────────────
+
+
+def test_previous_tier_unlocks_at_matches_explicit_composition(ent):
+    # The convenience is tier_unlocks(_previous_purchasable_tier_before(tier)).
+    # Byte-equal across every source above the floor so callers can swap
+    # between the singular helper and the explicit composition without
+    # drift.
+    for src in (
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_TRIAL,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_PRO,
+        ent.TIER_ENTERPRISE,
+    ):
+        prv = ent._previous_purchasable_tier_before(src)
+        assert prv is not None, src
+        assert ent.previous_tier_unlocks_at(src) == ent.tier_unlocks(prv), src
+
+
+def test_previous_tier_unlocks_at_returns_none_at_floor(ent):
+    # oss / cloud_free have no rung below -> None, mirroring the live
+    # method.
+    assert ent.previous_tier_unlocks_at(ent.TIER_OSS) is None
+    assert ent.previous_tier_unlocks_at(ent.TIER_CLOUD_FREE) is None
+
+
+def test_previous_tier_unlocks_at_row_shape(ent):
+    body = ent.previous_tier_unlocks_at(ent.TIER_CLOUD_PRO)
+    assert body is not None
+    assert set(body.keys()) == _UNLOCKS_KEYS
+    assert body["tier"] == ent.TIER_CLOUD_STARTER
+    assert body["tier_label"] == ent.tier_label(ent.TIER_CLOUD_STARTER)
+    assert body["tier_rank"] == ent.tier_rank(ent.TIER_CLOUD_STARTER)
+    # tier_unlocks sets previous_tier to target's natural next-lower
+    # purchasable -- NOT the caller-supplied source -- so this carries
+    # the rung below cloud_starter, not cloud_pro.
+    assert body["features"] == sorted(body["features"])
+    assert body["runtimes"] == sorted(body["runtimes"])
+
+
+@pytest.mark.parametrize("bad", ["", "  ", None, 0, 1.5, "BOGUS", "bogus"])
+def test_previous_tier_unlocks_at_returns_none_on_bad_input(ent, bad):
+    assert ent.previous_tier_unlocks_at(bad) is None
+
+
+def test_previous_tier_unlocks_at_trims_and_lowercases(ent):
+    assert ent.previous_tier_unlocks_at("  CLOUD_STARTER  ") == ent.tier_unlocks(
+        ent.TIER_OSS
+    )
+
+
+def test_previous_tier_unlocks_at_trial_source_resolves_to_cloud_starter(ent):
+    # Trial sits at rank 2, so the highest strictly-lower purchasable
+    # rung is cloud_starter (rank 1).
+    body = ent.previous_tier_unlocks_at(ent.TIER_TRIAL)
+    assert body is not None
+    assert body["tier"] == ent.TIER_CLOUD_STARTER
+
+
+def test_previous_tier_unlocks_at_grace_and_enforce_match(ent, monkeypatch):
+    # Catalogue-derived (off the static per-tier grants) -- flipping
+    # enforcement on must not change the body.
+    grace = ent.previous_tier_unlocks_at(ent.TIER_CLOUD_PRO)
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    importlib.reload(ent)
+    ent.invalidate()
+    enforce = ent.previous_tier_unlocks_at(ent.TIER_CLOUD_PRO)
+    assert enforce == grace
+
+
+def test_previous_tier_unlocks_at_never_raises(ent, monkeypatch):
+    monkeypatch.setattr(
+        ent,
+        "tier_unlocks",
+        lambda *_: (_ for _ in ()).throw(RuntimeError("synthetic")),
+    )
+    assert ent.previous_tier_unlocks_at(ent.TIER_CLOUD_PRO) is None
+
+
+def test_previous_tier_unlocks_at_independent_of_resolver(ent, monkeypatch):
+    # The whole point of the _at variant: it does not need the
+    # resolver. Swap get_entitlement to raise and the helper must
+    # still return a non-None body above the floor.
+    def boom(*_, **__):
+        raise RuntimeError("resolver must not be reached")
+
+    monkeypatch.setattr(ent, "get_entitlement", boom)
+    body = ent.previous_tier_unlocks_at(ent.TIER_CLOUD_STARTER)
+    assert body is not None
+    assert body["tier"] == ent.TIER_OSS
+
+
+# ── previous_tier_locks_at ──────────────────────────────────────────────────
+
+
+def test_previous_tier_locks_at_matches_explicit_composition(ent):
+    for src in (
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_TRIAL,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_PRO,
+        ent.TIER_ENTERPRISE,
+    ):
+        prv = ent._previous_purchasable_tier_before(src)
+        assert prv is not None, src
+        assert ent.previous_tier_locks_at(src) == ent.tier_locks(prv), src
+
+
+def test_previous_tier_locks_at_returns_none_at_floor(ent):
+    assert ent.previous_tier_locks_at(ent.TIER_OSS) is None
+    assert ent.previous_tier_locks_at(ent.TIER_CLOUD_FREE) is None
+
+
+def test_previous_tier_locks_at_row_shape(ent):
+    body = ent.previous_tier_locks_at(ent.TIER_CLOUD_PRO)
+    assert body is not None
+    assert set(body.keys()) == _LOCKS_KEYS
+    assert body["tier"] == ent.TIER_CLOUD_STARTER
+    assert body["lost_features"] == sorted(body["lost_features"])
+    assert body["lost_runtimes"] == sorted(body["lost_runtimes"])
+
+
+@pytest.mark.parametrize("bad", ["", "  ", None, 0, 1.5, "BOGUS", "bogus"])
+def test_previous_tier_locks_at_returns_none_on_bad_input(ent, bad):
+    assert ent.previous_tier_locks_at(bad) is None
+
+
+def test_previous_tier_locks_at_trims_and_lowercases(ent):
+    assert ent.previous_tier_locks_at("  CLOUD_STARTER  ") == ent.tier_locks(
+        ent.TIER_OSS
+    )
+
+
+def test_previous_tier_locks_at_trial_source_resolves_to_cloud_starter(ent):
+    body = ent.previous_tier_locks_at(ent.TIER_TRIAL)
+    assert body is not None
+    assert body["tier"] == ent.TIER_CLOUD_STARTER
+
+
+def test_previous_tier_locks_at_grace_and_enforce_match(ent, monkeypatch):
+    grace = ent.previous_tier_locks_at(ent.TIER_CLOUD_PRO)
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    importlib.reload(ent)
+    ent.invalidate()
+    enforce = ent.previous_tier_locks_at(ent.TIER_CLOUD_PRO)
+    assert enforce == grace
+
+
+def test_previous_tier_locks_at_never_raises(ent, monkeypatch):
+    monkeypatch.setattr(
+        ent,
+        "tier_locks",
+        lambda *_: (_ for _ in ()).throw(RuntimeError("synthetic")),
+    )
+    assert ent.previous_tier_locks_at(ent.TIER_CLOUD_PRO) is None
+
+
+def test_previous_tier_locks_at_independent_of_resolver(ent, monkeypatch):
+    def boom(*_, **__):
+        raise RuntimeError("resolver must not be reached")
+
+    monkeypatch.setattr(ent, "get_entitlement", boom)
+    body = ent.previous_tier_locks_at(ent.TIER_CLOUD_STARTER)
+    assert body is not None
+    assert body["tier"] == ent.TIER_OSS
+
+
+# ── API: /api/entitlement/previous-tier-unlocks-at ──────────────────────────
+
+
+def test_previous_tier_unlocks_at_endpoint_cloud_starter_default(client, ent):
+    rv = client.get("/api/entitlement/previous-tier-unlocks-at?tier=cloud_starter")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert set(body.keys()) == _ENVELOPE_KEYS
+    assert body["tier"] == ent.TIER_CLOUD_STARTER
+    assert body["tier_label"] == ent.tier_label(ent.TIER_CLOUD_STARTER)
+    assert body["tier_rank"] == ent.tier_rank(ent.TIER_CLOUD_STARTER)
+    assert body["target"] == ent.TIER_OSS
+    assert body["target_label"] == ent.tier_label(ent.TIER_OSS)
+    assert body["target_rank"] == ent.tier_rank(ent.TIER_OSS)
+    assert body["row"] == ent.tier_unlocks(ent.TIER_OSS)
+
+
+def test_previous_tier_unlocks_at_endpoint_oss_floor(client, ent):
+    rv = client.get("/api/entitlement/previous-tier-unlocks-at?tier=oss")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert set(body.keys()) == _ENVELOPE_KEYS
+    assert body["tier"] == ent.TIER_OSS
+    assert body["target"] is None
+    assert body["target_label"] is None
+    assert body["target_rank"] is None
+    assert body["row"] is None
+
+
+def test_previous_tier_unlocks_at_endpoint_cloud_free_floor(client, ent):
+    rv = client.get("/api/entitlement/previous-tier-unlocks-at?tier=cloud_free")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["tier"] == ent.TIER_CLOUD_FREE
+    assert body["target"] is None
+    assert body["row"] is None
+
+
+def test_previous_tier_unlocks_at_endpoint_trial(client, ent):
+    rv = client.get("/api/entitlement/previous-tier-unlocks-at?tier=trial")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["target"] == ent.TIER_CLOUD_STARTER
+    assert body["row"] == ent.tier_unlocks(ent.TIER_CLOUD_STARTER)
+
+
+def test_previous_tier_unlocks_at_endpoint_enterprise(client, ent):
+    # Enterprise -> highest-rank-below is rank 2 == {cloud_pro, pro};
+    # declaration order in _PURCHASABLE_TIERS picks cloud_pro.
+    rv = client.get("/api/entitlement/previous-tier-unlocks-at?tier=enterprise")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["target"] == ent.TIER_CLOUD_PRO
+    assert body["row"] == ent.tier_unlocks(ent.TIER_CLOUD_PRO)
+
+
+def test_previous_tier_unlocks_at_endpoint_missing_tier(client):
+    rv = client.get("/api/entitlement/previous-tier-unlocks-at")
+    assert rv.status_code == 400
+    assert rv.get_json()["error"] == "missing tier"
+
+
+def test_previous_tier_unlocks_at_endpoint_blank_tier(client):
+    rv = client.get("/api/entitlement/previous-tier-unlocks-at?tier=%20%20")
+    assert rv.status_code == 400
+
+
+def test_previous_tier_unlocks_at_endpoint_unknown_tier(client):
+    rv = client.get("/api/entitlement/previous-tier-unlocks-at?tier=bogus")
+    assert rv.status_code == 404
+    body = rv.get_json()
+    assert body["error"] == "unknown tier"
+    assert body["which"] == "tier"
+
+
+def test_previous_tier_unlocks_at_endpoint_trims_and_lowercases(client, ent):
+    rv = client.get(
+        "/api/entitlement/previous-tier-unlocks-at?tier=%20%20CLOUD_STARTER%20%20"
+    )
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["tier"] == ent.TIER_CLOUD_STARTER
+    assert body["target"] == ent.TIER_OSS
+
+
+def test_previous_tier_unlocks_at_endpoint_never_raises(client, ent, monkeypatch):
+    # Synthesise a builder failure and assert the envelope still
+    # returns 200 with row=null so the dashboard doesn't break.
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "previous_tier_unlocks_at", boom)
+    monkeypatch.setattr(ent, "_previous_purchasable_tier_before", boom)
+    rv = client.get("/api/entitlement/previous-tier-unlocks-at?tier=cloud_starter")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["row"] is None
+    assert body["target"] is None
+
+
+# ── API: /api/entitlement/previous-tier-locks-at ────────────────────────────
+
+
+def test_previous_tier_locks_at_endpoint_cloud_starter_default(client, ent):
+    rv = client.get("/api/entitlement/previous-tier-locks-at?tier=cloud_starter")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert set(body.keys()) == _ENVELOPE_KEYS
+    assert body["tier"] == ent.TIER_CLOUD_STARTER
+    assert body["target"] == ent.TIER_OSS
+    assert body["row"] == ent.tier_locks(ent.TIER_OSS)
+
+
+def test_previous_tier_locks_at_endpoint_oss_floor(client, ent):
+    rv = client.get("/api/entitlement/previous-tier-locks-at?tier=oss")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["tier"] == ent.TIER_OSS
+    assert body["target"] is None
+    assert body["row"] is None
+
+
+def test_previous_tier_locks_at_endpoint_cloud_free_floor(client, ent):
+    rv = client.get("/api/entitlement/previous-tier-locks-at?tier=cloud_free")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["target"] is None
+    assert body["row"] is None
+
+
+def test_previous_tier_locks_at_endpoint_trial(client, ent):
+    rv = client.get("/api/entitlement/previous-tier-locks-at?tier=trial")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["target"] == ent.TIER_CLOUD_STARTER
+    assert body["row"] == ent.tier_locks(ent.TIER_CLOUD_STARTER)
+
+
+def test_previous_tier_locks_at_endpoint_missing_tier(client):
+    rv = client.get("/api/entitlement/previous-tier-locks-at")
+    assert rv.status_code == 400
+
+
+def test_previous_tier_locks_at_endpoint_unknown_tier(client):
+    rv = client.get("/api/entitlement/previous-tier-locks-at?tier=bogus")
+    assert rv.status_code == 404
+    body = rv.get_json()
+    assert body["error"] == "unknown tier"
+    assert body["which"] == "tier"
+
+
+def test_previous_tier_locks_at_endpoint_never_raises(client, ent, monkeypatch):
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "previous_tier_locks_at", boom)
+    monkeypatch.setattr(ent, "_previous_purchasable_tier_before", boom)
+    rv = client.get("/api/entitlement/previous-tier-locks-at?tier=cloud_starter")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["row"] is None
+    assert body["target"] is None
+
+
+def test_endpoints_row_matches_helper(client, ent):
+    # End-to-end parity: the endpoint body's row byte-equals the
+    # module-level helper for the same source.
+    unlocks_rv = client.get(
+        "/api/entitlement/previous-tier-unlocks-at?tier=cloud_pro"
+    )
+    assert unlocks_rv.get_json()["row"] == ent.previous_tier_unlocks_at(
+        ent.TIER_CLOUD_PRO
+    )
+    locks_rv = client.get(
+        "/api/entitlement/previous-tier-locks-at?tier=cloud_pro"
+    )
+    assert locks_rv.get_json()["row"] == ent.previous_tier_locks_at(
+        ent.TIER_CLOUD_PRO
+    )


### PR DESCRIPTION
## Summary

Downgrade-side mirror of the `next_tier_*_at` family that landed in #3351. Adds the source-anchored `previous_tier_unlocks_at` / `previous_tier_locks_at` scalar what-if helpers, the private `_previous_purchasable_tier_before` stepper they share, and the two companion `GET /api/entitlement/previous-tier-{unlocks,locks}-at?tier=<src>` endpoints. Lets a pricing-comparison UI render "what's still granted / what's first lost at the rung below X" for any hypothetical X without first asking the resolver — the source-anchored counterpart of the live `Entitlement.previous_tier_unlocks` / `Entitlement.previous_tier_locks` methods that pin the source to the resolved entitlement.

- `clawmetry/entitlements.py`
  - `_previous_purchasable_tier_before(tier)` — pure stepper walking `_PURCHASABLE_TIERS` to the highest rank strictly below source; declaration-order tie-break, intentionally elides the cloud-vs-self-hosted preference the live `Entitlement.previous_purchasable_tier` applies (the `_at` family is deterministic on the static catalogue, not driven by which install flavour the resolver is in).
  - `previous_tier_unlocks_at(tier)` / `previous_tier_locks_at(tier)` — module helpers returning the marginal `tier_unlocks` / `tier_locks` row at the rung below `tier`. Independent of the resolver, never raise, return `None` at the floor (`oss` / `cloud_free`).
- `routes/entitlement.py`
  - `GET /api/entitlement/previous-tier-unlocks-at?tier=<src>` and `GET /api/entitlement/previous-tier-locks-at?tier=<src>` — same envelope shape (`tier`, `tier_label`, `tier_rank`, `target`, `target_label`, `target_rank`, `row`) as the next-direction endpoints. **400** on missing/blank tier, **404** on unknown id with `which`, populated 200 envelope with `row=null` at the floor, never 5xxs (builder failure collapses to `row=null`).
- `tests/test_entitlement_previous_tier_at.py` — **61 tests** pinning helper semantics, composition identity (`previous_tier_unlocks_at` byte-equals `tier_unlocks(_previous_purchasable_tier_before(...))`), floor behaviour, trial-as-source resolving to `cloud_starter` (rank 1), grace==enforce parity, resolver-independence, never-raise, and the full API surface.

No behaviour change to any existing surface — pure additions on read-only `GET` endpoints, both helpers/routes default to mute (`null` / 200 envelope) on every fallback path so the dashboard never breaks.

## Test plan

- [x] `python3 -m pytest tests/test_entitlement_previous_tier_at.py` — **61 passed**
- [x] `python3 -m pytest tests/ -k entitlement` excluding `test_e2e.py` — **2039 passed, 2 skipped** (full entitlement suite green, including the sibling `test_entitlement_next_tier_at.py` to confirm no regression)
- [x] `python3 -m py_compile clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_previous_tier_at.py` — clean
- [x] `ruff check` on the three changed files — **All checks passed!** (the pre-existing 207 errors in `dashboard.py` are unrelated to this diff)

### Local operator verification checklist

(I can't reach the live daemon / cloud snapshot / browser from this run — this is the on-host path for the operator before flipping the PR ready-for-review.)

- [ ] Copy `clawmetry/entitlements.py`, `routes/entitlement.py`, `tests/test_entitlement_previous_tier_at.py` into `~/.clawmetry/lib/python3.X/site-packages/clawmetry/` (and `~/.clawmetry/lib/python3.X/site-packages/routes/`).
- [ ] Clear `__pycache__/` under those dirs.
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
- [ ] `curl -s http://localhost:8900/api/entitlement/previous-tier-unlocks-at?tier=cloud_starter | jq .` → envelope with `target=oss`, populated `row`
- [ ] `curl -s http://localhost:8900/api/entitlement/previous-tier-unlocks-at?tier=oss | jq .` → 200 envelope with `target=null`, `row=null` (floor collapse)
- [ ] `curl -s "http://localhost:8900/api/entitlement/previous-tier-locks-at?tier=enterprise" | jq .` → `target=cloud_pro`, populated `row`
- [ ] `curl -s "http://localhost:8900/api/entitlement/previous-tier-locks-at?tier=bogus"` → **404** with `{"error":"unknown tier","which":"tier"}`
- [ ] `curl -s "http://localhost:8900/api/entitlement/previous-tier-unlocks-at"` → **400** `{"error":"missing tier"}`
- [ ] Browser sanity: dashboard still loads, no console errors, no regressions to the existing `/next-tier-*-at` CTA surface.
- [ ] Decrypt the live cloud snapshot client-side; the new endpoints are not part of the snapshot payload, but confirm overall snapshot integrity unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01P6vPkK8Dkdw4swWbx1rZos)_