### PR TITLE
feat(entitlement): next_tier_unlocks_at_batch + next_tier_locks_at_batch + endpoints

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -5185,3 +5185,152 @@ def previous_tier_locks_at(tier: str) -> dict | None:
     except Exception as exc:
         logger.warning("entitlements: previous_tier_locks_at failed: %s", exc)
         return None
+
+
+def _next_at_envelope(source: str, builder) -> dict:
+    """Private builder for the ``next_tier_*_at_batch`` rows.
+
+    Resolves ``target = _next_purchasable_tier_after(source)`` and pairs
+    the source/target tier metadata with the row produced by ``builder``
+    (one of :func:`tier_unlocks` / :func:`tier_locks`) into the same
+    envelope shape the scalar what-if endpoints surface:
+
+        ``{tier, tier_label, tier_rank, target, target_label, target_rank, row}``
+
+    ``row`` collapses to ``None`` at the source-side ceiling (source ==
+    enterprise -- no rung strictly above), matching the scalar helpers.
+    A builder failure short-circuits to ``row=None`` on the populated
+    envelope so the batch keeps the per-source row visible instead of
+    dropping it -- the same posture
+    :func:`tier_unlocks_at_batch` / :func:`tier_locks_at_batch` apply to
+    their per-row failures.
+
+    Never raises: every fallback collapses to a fully-populated envelope
+    with ``row=None`` so a pricing-matrix UI can render the source rung
+    even when its target row could not be built.
+    """
+    src = (source or "").strip().lower()
+    target = _next_purchasable_tier_after(src) if src in _TIER_ORDER else None
+    row: dict | None = None
+    if target is not None:
+        try:
+            row = builder(target)
+        except Exception as exc:
+            logger.warning(
+                "entitlements: _next_at_envelope builder failed for %s: %s",
+                target,
+                exc,
+            )
+            row = None
+    return {
+        "tier": src,
+        "tier_label": tier_label(src) if src in _TIER_ORDER else None,
+        "tier_rank": tier_rank(src) if src in _TIER_ORDER else -1,
+        "target": target,
+        "target_label": tier_label(target) if target else None,
+        "target_rank": tier_rank(target) if target else None,
+        "row": row,
+    }
+
+
+def next_tier_unlocks_at_batch() -> list[dict]:
+    """Batch sibling of :func:`next_tier_unlocks_at`: one
+    ``next-tier-unlocks-at`` envelope per purchasable source tier, in
+    one pass.
+
+    Composes :func:`next_tier_unlocks_at` (scalar what-if) and
+    :func:`tier_unlocks_batch` (live batch): same envelope shape per row
+    as the scalar ``/api/entitlement/next-tier-unlocks-at`` endpoint
+    surfaces, same source axis as :func:`tier_unlocks_batch`. Lets a
+    pricing-comparison matrix UI render the "what's new at the rung
+    above each rung" upgrade-CTA column off **one** round-trip instead
+    of N calls to :func:`next_tier_unlocks_at`.
+
+    Each envelope is byte-equal to the scalar
+    ``/api/entitlement/next-tier-unlocks-at?tier=<source>`` response
+    body for the same source (sans the resolver-context fields the
+    route adds around the helper output) -- a parity test pins this so
+    the batch what-if cannot drift from the scalar what-if (the same
+    invariant :func:`tier_unlocks_at_batch` enforces against
+    :func:`tier_unlocks_at`).
+
+    Envelopes are sorted by source ``(tier_rank, tier_id)`` ascending
+    -- byte-stable against :func:`tier_unlocks_batch`'s ordering and
+    against :func:`tier_locks_at_batch` for the same source so a UI can
+    fold the two responses into an upgrade-CTA column without re-sorting
+    client-side. Same-rank sibling tiers (``cloud_pro`` / ``pro`` both
+    at rank 2) are both returned.
+
+    Source list is :data:`_PURCHASABLE_TIERS` (trial excluded), matching
+    :func:`tier_unlocks_batch`. The source-side ceiling (enterprise as
+    source -- no rung strictly above) surfaces with ``target=None`` and
+    ``row=None`` rather than being dropped, so the matrix keeps a row
+    for every purchasable rung.
+
+    Never raises: a per-source builder failure collapses to
+    ``row=None`` on the populated envelope so the surrounding envelope
+    stays visible; an unexpected top-level failure short-circuits to
+    ``[]`` so the matrix keeps rendering instead of breaking.
+    """
+    try:
+        out: list[dict] = []
+        ordered = sorted(
+            _PURCHASABLE_TIERS, key=lambda t: (_TIER_RANK.get(t, -1), t)
+        )
+        for tid in ordered:
+            out.append(_next_at_envelope(tid, tier_unlocks))
+        return out
+    except Exception as exc:
+        logger.warning("entitlements: next_tier_unlocks_at_batch failed: %s", exc)
+        return []
+
+
+def next_tier_locks_at_batch() -> list[dict]:
+    """Batch sibling of :func:`next_tier_locks_at`: one
+    ``next-tier-locks-at`` envelope per purchasable source tier, in one
+    pass.
+
+    Marginal-loss mirror of :func:`next_tier_unlocks_at_batch` and pairs
+    with :func:`tier_locks_batch` the same way
+    :func:`next_tier_unlocks_at_batch` pairs with
+    :func:`tier_unlocks_batch` -- the downgrade-warning column on the
+    same matrix the unlocks batch renders the upgrade-CTA column for,
+    pivoted around the natural next-above rung for each source.
+
+    Each envelope is byte-equal to the scalar
+    ``/api/entitlement/next-tier-locks-at?tier=<source>`` response body
+    for the same source (sans the resolver-context fields the route
+    adds around the helper output) -- a parity test pins this so the
+    batch what-if cannot drift from the scalar what-if.
+
+    Envelopes are sorted by source ``(tier_rank, tier_id)`` ascending
+    -- byte-stable against :func:`next_tier_unlocks_at_batch` for the
+    same source so a UI can fold the two responses into an
+    upgrade-CTA + downgrade-warning matrix without re-sorting
+    client-side.
+
+    Source list is :data:`_PURCHASABLE_TIERS` (trial excluded). The
+    source-side ceiling (enterprise as source -- no rung strictly
+    above) surfaces with ``target=None`` and ``row=None``.
+
+    At a source rung whose next-above IS the ladder ceiling
+    (``cloud_pro`` / ``pro`` -> ``enterprise``) the row carries
+    ``next_tier=None`` and empty ``lost_*`` lists -- :func:`tier_locks`
+    shape for "the target has no rung above to step down from", NOT
+    ``None`` on the envelope.
+
+    Never raises: a per-source builder failure collapses to
+    ``row=None`` on the populated envelope; an unexpected top-level
+    failure short-circuits to ``[]``.
+    """
+    try:
+        out: list[dict] = []
+        ordered = sorted(
+            _PURCHASABLE_TIERS, key=lambda t: (_TIER_RANK.get(t, -1), t)
+        )
+        for tid in ordered:
+            out.append(_next_at_envelope(tid, tier_locks))
+        return out
+    except Exception as exc:
+        logger.warning("entitlements: next_tier_locks_at_batch failed: %s", exc)
+        return []

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -4702,3 +4702,141 @@ def api_entitlement_previous_tier_locks_at():
                 "row": None,
             }
         )
+
+
+@bp_entitlement.route("/api/entitlement/next-tier-unlocks-at-batch")
+def api_entitlement_next_tier_unlocks_at_batch():
+    """``GET /api/entitlement/next-tier-unlocks-at-batch`` -- batch
+    sibling of ``/api/entitlement/next-tier-unlocks-at``: one
+    ``next-tier-unlocks-at`` envelope per purchasable source tier, in
+    one round-trip.
+
+    Composes the scalar what-if (``/next-tier-unlocks-at``) and the
+    live batch (``/tier-unlocks-batch``) -- same envelope shape per row
+    as the scalar what-if, same source axis as the live batch. Lets a
+    pricing-comparison matrix UI render the "what's new at the rung
+    above each rung" upgrade-CTA column off **one** call instead of N
+    calls to ``/next-tier-unlocks-at``.
+
+    No query params. The source list is :data:`entitlements._PURCHASABLE_TIERS`
+    (trial excluded), matching the live ``/tier-unlocks-batch``
+    endpoint, so the envelopes fold into the same pricing-page table
+    byte-for-byte on the source axis.
+
+    Response shape::
+
+        {
+          "tiers":             [<envelope>, ...],
+          "current_tier":      "<resolved tier id>",
+          "current_tier_rank": <int>,
+          "grace":             <bool>,
+          "enforced":          <bool>,
+        }
+
+    Each ``<envelope>`` matches ``/api/entitlement/next-tier-unlocks-at?tier=<source>``
+    for that source exactly (``tier``, ``tier_label``, ``tier_rank``,
+    ``target``, ``target_label``, ``target_rank``, ``row``). At the
+    source-side ceiling (``enterprise`` as source -- no rung strictly
+    above) the envelope carries ``target=null`` and ``row=null`` rather
+    than being dropped, so the matrix keeps a row for every purchasable
+    rung.
+
+    - **Never 5xxs**: a resolver failure yields an empty ``tiers``
+      list and the grace-shape envelope so the matrix keeps rendering.
+    """
+    try:
+        from clawmetry import entitlements as _ent
+
+        rows = _ent.next_tier_unlocks_at_batch() or []
+        ent = _ent.get_entitlement()
+        return jsonify(
+            {
+                "tiers": rows,
+                "current_tier": ent.tier,
+                "current_tier_rank": _ent.tier_rank(ent.tier),
+                "grace": bool(ent.grace),
+                "enforced": _ent.is_enforced(),
+            }
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_next_tier_unlocks_at_batch: error: %s", exc
+        )
+        return jsonify(
+            {
+                "tiers": [],
+                "current_tier": "oss",
+                "current_tier_rank": 0,
+                "grace": True,
+                "enforced": False,
+            }
+        )
+
+
+@bp_entitlement.route("/api/entitlement/next-tier-locks-at-batch")
+def api_entitlement_next_tier_locks_at_batch():
+    """``GET /api/entitlement/next-tier-locks-at-batch`` -- batch
+    sibling of ``/api/entitlement/next-tier-locks-at``: one
+    ``next-tier-locks-at`` envelope per purchasable source tier, in one
+    round-trip.
+
+    Marginal-loss mirror of ``/next-tier-unlocks-at-batch`` and pairs
+    with ``/tier-locks-batch`` the same way
+    ``/next-tier-unlocks-at-batch`` pairs with ``/tier-unlocks-batch``.
+    Pair the two ``_at_batch`` endpoints to render the upgrade-CTA +
+    downgrade-warning columns of an "above each rung" pricing matrix
+    in two round-trips.
+
+    No query params. The source list is :data:`entitlements._PURCHASABLE_TIERS`
+    (trial excluded), matching the live ``/tier-locks-batch`` endpoint.
+
+    Response shape::
+
+        {
+          "tiers":             [<envelope>, ...],
+          "current_tier":      "<resolved tier id>",
+          "current_tier_rank": <int>,
+          "grace":             <bool>,
+          "enforced":          <bool>,
+        }
+
+    Each ``<envelope>`` matches ``/api/entitlement/next-tier-locks-at?tier=<source>``
+    for that source exactly (``tier``, ``tier_label``, ``tier_rank``,
+    ``target``, ``target_label``, ``target_rank``, ``row``). At the
+    source-side ceiling (``enterprise`` as source) the envelope
+    carries ``target=null`` and ``row=null``. At a source rung whose
+    next-above IS the ladder ceiling (``cloud_pro`` / ``pro`` ->
+    ``enterprise``) the row carries ``next_tier=null`` and empty
+    ``lost_*`` lists -- :func:`tier_locks` shape for "the target has no
+    rung above to step down from", NOT ``null`` on the envelope.
+
+    - **Never 5xxs**: a resolver failure yields an empty ``tiers``
+      list and the grace-shape envelope so the matrix keeps rendering.
+    """
+    try:
+        from clawmetry import entitlements as _ent
+
+        rows = _ent.next_tier_locks_at_batch() or []
+        ent = _ent.get_entitlement()
+        return jsonify(
+            {
+                "tiers": rows,
+                "current_tier": ent.tier,
+                "current_tier_rank": _ent.tier_rank(ent.tier),
+                "grace": bool(ent.grace),
+                "enforced": _ent.is_enforced(),
+            }
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_next_tier_locks_at_batch: error: %s", exc
+        )
+        return jsonify(
+            {
+                "tiers": [],
+                "current_tier": "oss",
+                "current_tier_rank": 0,
+                "grace": True,
+                "enforced": False,
+            }
+        )

--- a/tests/test_entitlement_next_tier_at_batch.py
+++ b/tests/test_entitlement_next_tier_at_batch.py
@@ -1,0 +1,630 @@
+"""Tests for ``next_tier_unlocks_at_batch`` /
+``next_tier_locks_at_batch`` -- batch siblings of the scalar
+:func:`next_tier_unlocks_at` / :func:`next_tier_locks_at` what-ifs,
+plus the companion
+``/api/entitlement/next-tier-{unlocks,locks}-at-batch`` endpoints and
+the private :func:`_next_at_envelope` builder they share.
+
+These helpers let a pricing-comparison matrix UI render the
+"what's new / what's lost at the rung above each rung" upgrade-CTA
+column off **one** round-trip instead of N calls to the scalar
+``/next-tier-{unlocks,locks}-at`` endpoint -- the batch counterpart of
+the scalar what-ifs that landed in #3351.
+
+Pins covered here:
+
+* helper :func:`_next_at_envelope` composes the source/target metadata
+  with the per-target row in the same envelope shape the scalar
+  endpoints surface -- ``tier``, ``tier_label``, ``tier_rank``,
+  ``target``, ``target_label``, ``target_rank``, ``row``
+* ``next_tier_unlocks_at_batch()`` returns one envelope per entry in
+  :data:`_PURCHASABLE_TIERS`, sorted by ``(tier_rank, tier_id)``
+* same shape / ordering for ``next_tier_locks_at_batch``
+* every envelope byte-equals the body that the scalar
+  ``/api/entitlement/next-tier-{unlocks,locks}-at?tier=<src>`` endpoint
+  returns for the same source -- the batch-vs-scalar parity that stops
+  the batch what-if drifting from the scalar what-if
+* at the source-side ceiling (``enterprise`` as source) the envelope
+  carries ``target=null`` and ``row=null`` rather than being dropped
+* at a source rung whose next-above IS the ladder ceiling
+  (``cloud_pro`` / ``pro`` -> ``enterprise``) the locks row carries
+  ``next_tier=null`` and empty ``lost_*`` lists -- :func:`tier_locks`
+  shape, NOT ``null`` on the envelope
+* trial is excluded from the source axis (mirrors
+  :func:`tier_unlocks_batch`)
+* grace vs enforce yields the same body (the ``_at`` family walks the
+  static catalogue, not the gated resolver)
+* the helpers never raise: builder failure on a single source collapses
+  to ``row=null`` on the populated envelope; a top-level failure
+  short-circuits to ``[]``
+* the API endpoints never 5xx: a resolver failure yields an empty
+  ``tiers`` list and a grace-shape envelope
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+_UNLOCKS_KEYS = {
+    "tier",
+    "tier_label",
+    "tier_rank",
+    "previous_tier",
+    "previous_tier_label",
+    "previous_tier_rank",
+    "features",
+    "runtimes",
+}
+
+_LOCKS_KEYS = {
+    "tier",
+    "tier_label",
+    "tier_rank",
+    "next_tier",
+    "next_tier_label",
+    "next_tier_rank",
+    "lost_features",
+    "lost_runtimes",
+}
+
+_ENVELOPE_KEYS = {
+    "tier",
+    "tier_label",
+    "tier_rank",
+    "target",
+    "target_label",
+    "target_rank",
+    "row",
+}
+
+_BATCH_RESPONSE_KEYS = {
+    "tiers",
+    "current_tier",
+    "current_tier_rank",
+    "grace",
+    "enforced",
+}
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    """Fresh entitlements module with HOME pointed at an empty tmp dir
+    so no real ~/.clawmetry/license.key or cloud_plan.json leaks in.
+    Enforcement off by default (grace mode) -- both batch helpers are
+    catalogue-derived and independent of the resolver, so the fixture
+    only needs to keep the live resolver from surprising the test."""
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# ── _next_at_envelope ────────────────────────────────────────────────────────
+
+
+def test_envelope_builder_shape_for_known_source(ent):
+    env = ent._next_at_envelope(ent.TIER_OSS, ent.tier_unlocks)
+    assert set(env.keys()) == _ENVELOPE_KEYS
+    assert env["tier"] == ent.TIER_OSS
+    assert env["tier_label"] == ent.tier_label(ent.TIER_OSS)
+    assert env["tier_rank"] == ent.tier_rank(ent.TIER_OSS)
+    assert env["target"] == ent.TIER_CLOUD_STARTER
+    assert env["target_label"] == ent.tier_label(ent.TIER_CLOUD_STARTER)
+    assert env["target_rank"] == ent.tier_rank(ent.TIER_CLOUD_STARTER)
+    assert env["row"] == ent.tier_unlocks(ent.TIER_CLOUD_STARTER)
+
+
+def test_envelope_builder_locks_branch(ent):
+    env = ent._next_at_envelope(ent.TIER_CLOUD_STARTER, ent.tier_locks)
+    assert set(env.keys()) == _ENVELOPE_KEYS
+    assert env["target"] == ent.TIER_CLOUD_PRO
+    assert env["row"] == ent.tier_locks(ent.TIER_CLOUD_PRO)
+
+
+def test_envelope_builder_ceiling_collapses_target_and_row(ent):
+    # Enterprise has no rung above -- target/row must collapse to null.
+    env = ent._next_at_envelope(ent.TIER_ENTERPRISE, ent.tier_unlocks)
+    assert env["tier"] == ent.TIER_ENTERPRISE
+    assert env["target"] is None
+    assert env["target_label"] is None
+    assert env["target_rank"] is None
+    assert env["row"] is None
+
+
+def test_envelope_builder_unknown_source_keeps_envelope_populated(ent):
+    # Unknown source surfaces a fully-shaped envelope with target/row
+    # null and the source-metadata best-effort -- the batch can keep
+    # the row visible without crashing.
+    env = ent._next_at_envelope("bogus", ent.tier_unlocks)
+    assert set(env.keys()) == _ENVELOPE_KEYS
+    assert env["target"] is None
+    assert env["row"] is None
+
+
+def test_envelope_builder_trims_and_lowercases(ent):
+    env = ent._next_at_envelope("  OSS  ", ent.tier_unlocks)
+    assert env["tier"] == ent.TIER_OSS
+    assert env["target"] == ent.TIER_CLOUD_STARTER
+
+
+def test_envelope_builder_swallows_builder_exception(ent):
+    # A per-target builder failure must collapse to row=null on the
+    # populated envelope rather than propagate.
+    def boom(_target):
+        raise RuntimeError("synthetic")
+
+    env = ent._next_at_envelope(ent.TIER_OSS, boom)
+    assert env["target"] == ent.TIER_CLOUD_STARTER
+    assert env["row"] is None
+
+
+# ── next_tier_unlocks_at_batch ───────────────────────────────────────────────
+
+
+def test_unlocks_batch_returns_list_for_every_purchasable_source(ent):
+    rows = ent.next_tier_unlocks_at_batch()
+    assert isinstance(rows, list)
+    assert len(rows) == len(ent._PURCHASABLE_TIERS)
+
+
+def test_unlocks_batch_each_envelope_has_envelope_shape(ent):
+    rows = ent.next_tier_unlocks_at_batch()
+    for env in rows:
+        assert set(env.keys()) == _ENVELOPE_KEYS
+
+
+def test_unlocks_batch_source_axis_matches_purchasable(ent):
+    rows = ent.next_tier_unlocks_at_batch()
+    sources = {env["tier"] for env in rows}
+    assert sources == set(ent._PURCHASABLE_TIERS)
+
+
+def test_unlocks_batch_excludes_trial_from_sources(ent):
+    rows = ent.next_tier_unlocks_at_batch()
+    assert ent.TIER_TRIAL not in {env["tier"] for env in rows}
+
+
+def test_unlocks_batch_sorted_by_rank_then_id(ent):
+    rows = ent.next_tier_unlocks_at_batch()
+    keys = [(env["tier_rank"], env["tier"]) for env in rows]
+    assert keys == sorted(keys)
+
+
+def test_unlocks_batch_ordering_matches_tier_unlocks_batch(ent):
+    """The source axis is byte-stable against
+    :func:`tier_unlocks_batch`'s ordering so the two responses fold
+    into the same pricing-page table without re-sorting client-side."""
+    at_rows = ent.next_tier_unlocks_at_batch()
+    live_rows = ent.tier_unlocks_batch()
+    assert [r["tier"] for r in at_rows] == [r["tier"] for r in live_rows]
+
+
+def test_unlocks_batch_ordering_matches_locks_batch(ent):
+    """The two ``_at_batch`` siblings emit the source axis in the same
+    order so the unlocks/locks columns line up row-for-row."""
+    unlocks = ent.next_tier_unlocks_at_batch()
+    locks = ent.next_tier_locks_at_batch()
+    assert [r["tier"] for r in unlocks] == [r["tier"] for r in locks]
+
+
+def test_unlocks_batch_each_envelope_byte_equals_scalar_helper(ent):
+    """Every envelope byte-equals the body the scalar
+    :func:`next_tier_unlocks_at` helper produces for the same source --
+    the parity that stops the batch what-if drifting from the scalar
+    what-if."""
+    rows = ent.next_tier_unlocks_at_batch()
+    for env in rows:
+        scalar_row = ent.next_tier_unlocks_at(env["tier"])
+        assert env["row"] == scalar_row, env["tier"]
+
+
+def test_unlocks_batch_target_resolves_via_next_purchasable_after(ent):
+    rows = ent.next_tier_unlocks_at_batch()
+    for env in rows:
+        assert env["target"] == ent._next_purchasable_tier_after(env["tier"])
+
+
+def test_unlocks_batch_target_metadata_consistent(ent):
+    rows = ent.next_tier_unlocks_at_batch()
+    for env in rows:
+        if env["target"] is None:
+            assert env["target_label"] is None
+            assert env["target_rank"] is None
+        else:
+            assert env["target_label"] == ent.tier_label(env["target"])
+            assert env["target_rank"] == ent.tier_rank(env["target"])
+
+
+def test_unlocks_batch_enterprise_source_collapses_to_null(ent):
+    rows = ent.next_tier_unlocks_at_batch()
+    enterprise = next(env for env in rows if env["tier"] == ent.TIER_ENTERPRISE)
+    assert enterprise["target"] is None
+    assert enterprise["target_label"] is None
+    assert enterprise["target_rank"] is None
+    assert enterprise["row"] is None
+
+
+def test_unlocks_batch_each_row_matches_unlocks_keys_when_populated(ent):
+    rows = ent.next_tier_unlocks_at_batch()
+    for env in rows:
+        if env["row"] is not None:
+            assert set(env["row"].keys()) == _UNLOCKS_KEYS
+
+
+def test_unlocks_batch_oss_source_has_cloud_starter_row(ent):
+    rows = ent.next_tier_unlocks_at_batch()
+    oss = next(env for env in rows if env["tier"] == ent.TIER_OSS)
+    assert oss["target"] == ent.TIER_CLOUD_STARTER
+    assert oss["row"] == ent.tier_unlocks(ent.TIER_CLOUD_STARTER)
+
+
+def test_unlocks_batch_grace_and_enforce_match(ent, monkeypatch):
+    grace = ent.next_tier_unlocks_at_batch()
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    importlib.reload(ent)
+    ent.invalidate()
+    enforce = ent.next_tier_unlocks_at_batch()
+    assert enforce == grace
+
+
+def test_unlocks_batch_independent_of_resolver(ent, monkeypatch):
+    def boom(*_, **__):
+        raise RuntimeError("resolver must not be reached")
+
+    monkeypatch.setattr(ent, "get_entitlement", boom)
+    rows = ent.next_tier_unlocks_at_batch()
+    assert len(rows) == len(ent._PURCHASABLE_TIERS)
+
+
+def test_unlocks_batch_does_not_mutate_live_entitlement(ent):
+    before = ent.get_entitlement().to_dict()
+    ent.next_tier_unlocks_at_batch()
+    after = ent.get_entitlement().to_dict()
+    assert before == after
+
+
+def test_unlocks_batch_returns_empty_on_top_level_failure(ent, monkeypatch):
+    """A top-level failure short-circuits to ``[]`` so the matrix keeps
+    rendering instead of breaking."""
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "_PURCHASABLE_TIERS", property(boom))
+    out = ent.next_tier_unlocks_at_batch()
+    assert out == []
+
+
+def test_unlocks_batch_per_source_failure_collapses_row_only(ent, monkeypatch):
+    """A per-source builder failure collapses to ``row=null`` on the
+    populated envelope -- the source rung stays visible in the matrix."""
+    def boom(_t):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "tier_unlocks", boom)
+    rows = ent.next_tier_unlocks_at_batch()
+    assert len(rows) == len(ent._PURCHASABLE_TIERS)
+    for env in rows:
+        assert env["row"] is None
+        # Source/target metadata stays populated except at the ceiling.
+        if env["tier"] != ent.TIER_ENTERPRISE:
+            assert env["target"] is not None
+
+
+# ── next_tier_locks_at_batch ─────────────────────────────────────────────────
+
+
+def test_locks_batch_returns_list_for_every_purchasable_source(ent):
+    rows = ent.next_tier_locks_at_batch()
+    assert isinstance(rows, list)
+    assert len(rows) == len(ent._PURCHASABLE_TIERS)
+
+
+def test_locks_batch_each_envelope_has_envelope_shape(ent):
+    rows = ent.next_tier_locks_at_batch()
+    for env in rows:
+        assert set(env.keys()) == _ENVELOPE_KEYS
+
+
+def test_locks_batch_source_axis_matches_purchasable(ent):
+    rows = ent.next_tier_locks_at_batch()
+    sources = {env["tier"] for env in rows}
+    assert sources == set(ent._PURCHASABLE_TIERS)
+
+
+def test_locks_batch_excludes_trial_from_sources(ent):
+    rows = ent.next_tier_locks_at_batch()
+    assert ent.TIER_TRIAL not in {env["tier"] for env in rows}
+
+
+def test_locks_batch_sorted_by_rank_then_id(ent):
+    rows = ent.next_tier_locks_at_batch()
+    keys = [(env["tier_rank"], env["tier"]) for env in rows]
+    assert keys == sorted(keys)
+
+
+def test_locks_batch_ordering_matches_tier_locks_batch(ent):
+    at_rows = ent.next_tier_locks_at_batch()
+    live_rows = ent.tier_locks_batch()
+    assert [r["tier"] for r in at_rows] == [r["tier"] for r in live_rows]
+
+
+def test_locks_batch_each_envelope_byte_equals_scalar_helper(ent):
+    rows = ent.next_tier_locks_at_batch()
+    for env in rows:
+        scalar_row = ent.next_tier_locks_at(env["tier"])
+        assert env["row"] == scalar_row, env["tier"]
+
+
+def test_locks_batch_target_resolves_via_next_purchasable_after(ent):
+    rows = ent.next_tier_locks_at_batch()
+    for env in rows:
+        assert env["target"] == ent._next_purchasable_tier_after(env["tier"])
+
+
+def test_locks_batch_enterprise_source_collapses_to_null(ent):
+    rows = ent.next_tier_locks_at_batch()
+    enterprise = next(env for env in rows if env["tier"] == ent.TIER_ENTERPRISE)
+    assert enterprise["target"] is None
+    assert enterprise["row"] is None
+
+
+def test_locks_batch_pro_source_row_collapses_lost_lists(ent):
+    """pro -> next is enterprise (ceiling). tier_locks(enterprise)
+    carries next_tier=None and empty lost_* lists. The envelope must
+    surface that populated row, not None on the envelope."""
+    rows = ent.next_tier_locks_at_batch()
+    pro = next(env for env in rows if env["tier"] == ent.TIER_PRO)
+    assert pro["target"] == ent.TIER_ENTERPRISE
+    assert pro["row"] is not None
+    assert pro["row"]["next_tier"] is None
+    assert pro["row"]["lost_features"] == []
+    assert pro["row"]["lost_runtimes"] == []
+
+
+def test_locks_batch_cloud_pro_source_row_collapses_lost_lists(ent):
+    """cloud_pro and pro both sit at rank 2 -> next is enterprise --
+    identical ceiling collapse on the row."""
+    rows = ent.next_tier_locks_at_batch()
+    cp = next(env for env in rows if env["tier"] == ent.TIER_CLOUD_PRO)
+    assert cp["target"] == ent.TIER_ENTERPRISE
+    assert cp["row"] is not None
+    assert cp["row"]["next_tier"] is None
+    assert cp["row"]["lost_features"] == []
+    assert cp["row"]["lost_runtimes"] == []
+
+
+def test_locks_batch_each_row_matches_locks_keys_when_populated(ent):
+    rows = ent.next_tier_locks_at_batch()
+    for env in rows:
+        if env["row"] is not None:
+            assert set(env["row"].keys()) == _LOCKS_KEYS
+
+
+def test_locks_batch_grace_and_enforce_match(ent, monkeypatch):
+    grace = ent.next_tier_locks_at_batch()
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    importlib.reload(ent)
+    ent.invalidate()
+    enforce = ent.next_tier_locks_at_batch()
+    assert enforce == grace
+
+
+def test_locks_batch_independent_of_resolver(ent, monkeypatch):
+    def boom(*_, **__):
+        raise RuntimeError("resolver must not be reached")
+
+    monkeypatch.setattr(ent, "get_entitlement", boom)
+    rows = ent.next_tier_locks_at_batch()
+    assert len(rows) == len(ent._PURCHASABLE_TIERS)
+
+
+def test_locks_batch_returns_empty_on_top_level_failure(ent, monkeypatch):
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "_PURCHASABLE_TIERS", property(boom))
+    out = ent.next_tier_locks_at_batch()
+    assert out == []
+
+
+# ── API: /api/entitlement/next-tier-unlocks-at-batch ────────────────────────
+
+
+def test_unlocks_endpoint_returns_full_ladder(client, ent):
+    rv = client.get("/api/entitlement/next-tier-unlocks-at-batch")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert set(body.keys()) == _BATCH_RESPONSE_KEYS
+    assert body["tiers"] == ent.next_tier_unlocks_at_batch()
+    assert len(body["tiers"]) == len(ent._PURCHASABLE_TIERS)
+
+
+def test_unlocks_endpoint_envelope_shape(client, ent):
+    rv = client.get("/api/entitlement/next-tier-unlocks-at-batch")
+    body = rv.get_json()
+    for env in body["tiers"]:
+        assert set(env.keys()) == _ENVELOPE_KEYS
+
+
+def test_unlocks_endpoint_oss_envelope_matches_scalar(client, ent):
+    """The OSS envelope in the batch byte-equals the body the scalar
+    ``/next-tier-unlocks-at?tier=oss`` endpoint returns (sans the
+    resolver-context fields the batch wrapper adds)."""
+    batch_rv = client.get("/api/entitlement/next-tier-unlocks-at-batch")
+    scalar_rv = client.get("/api/entitlement/next-tier-unlocks-at?tier=oss")
+    batch_oss = next(
+        env for env in batch_rv.get_json()["tiers"] if env["tier"] == ent.TIER_OSS
+    )
+    assert batch_oss == scalar_rv.get_json()
+
+
+def test_unlocks_endpoint_resolver_context_present(client, ent):
+    rv = client.get("/api/entitlement/next-tier-unlocks-at-batch")
+    body = rv.get_json()
+    live = ent.get_entitlement()
+    assert body["current_tier"] == live.tier
+    assert body["current_tier_rank"] == ent.tier_rank(live.tier)
+    assert body["grace"] == bool(live.grace)
+    assert body["enforced"] == ent.is_enforced()
+
+
+def test_unlocks_endpoint_enterprise_envelope_collapses(client, ent):
+    rv = client.get("/api/entitlement/next-tier-unlocks-at-batch")
+    body = rv.get_json()
+    enterprise = next(
+        env for env in body["tiers"] if env["tier"] == ent.TIER_ENTERPRISE
+    )
+    assert enterprise["target"] is None
+    assert enterprise["row"] is None
+
+
+def test_unlocks_endpoint_never_5xxs(client, ent, monkeypatch):
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "next_tier_unlocks_at_batch", boom)
+    monkeypatch.setattr(ent, "get_entitlement", boom)
+    rv = client.get("/api/entitlement/next-tier-unlocks-at-batch")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["tiers"] == []
+    assert body["current_tier"] == "oss"
+    assert body["grace"] is True
+    assert body["enforced"] is False
+
+
+def test_unlocks_endpoint_ignores_extra_query_args(client, ent):
+    """The endpoint takes no params -- extra args are silently ignored
+    rather than 400'd."""
+    rv = client.get("/api/entitlement/next-tier-unlocks-at-batch?tier=oss&foo=bar")
+    assert rv.status_code == 200
+
+
+# ── API: /api/entitlement/next-tier-locks-at-batch ──────────────────────────
+
+
+def test_locks_endpoint_returns_full_ladder(client, ent):
+    rv = client.get("/api/entitlement/next-tier-locks-at-batch")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert set(body.keys()) == _BATCH_RESPONSE_KEYS
+    assert body["tiers"] == ent.next_tier_locks_at_batch()
+    assert len(body["tiers"]) == len(ent._PURCHASABLE_TIERS)
+
+
+def test_locks_endpoint_envelope_shape(client, ent):
+    rv = client.get("/api/entitlement/next-tier-locks-at-batch")
+    body = rv.get_json()
+    for env in body["tiers"]:
+        assert set(env.keys()) == _ENVELOPE_KEYS
+
+
+def test_locks_endpoint_oss_envelope_matches_scalar(client, ent):
+    batch_rv = client.get("/api/entitlement/next-tier-locks-at-batch")
+    scalar_rv = client.get("/api/entitlement/next-tier-locks-at?tier=oss")
+    batch_oss = next(
+        env for env in batch_rv.get_json()["tiers"] if env["tier"] == ent.TIER_OSS
+    )
+    assert batch_oss == scalar_rv.get_json()
+
+
+def test_locks_endpoint_pro_row_collapses_lost_lists(client, ent):
+    rv = client.get("/api/entitlement/next-tier-locks-at-batch")
+    body = rv.get_json()
+    pro = next(env for env in body["tiers"] if env["tier"] == ent.TIER_PRO)
+    assert pro["target"] == ent.TIER_ENTERPRISE
+    assert pro["row"] is not None
+    assert pro["row"]["next_tier"] is None
+    assert pro["row"]["lost_features"] == []
+    assert pro["row"]["lost_runtimes"] == []
+
+
+def test_locks_endpoint_resolver_context_present(client, ent):
+    rv = client.get("/api/entitlement/next-tier-locks-at-batch")
+    body = rv.get_json()
+    live = ent.get_entitlement()
+    assert body["current_tier"] == live.tier
+    assert body["current_tier_rank"] == ent.tier_rank(live.tier)
+    assert body["grace"] == bool(live.grace)
+    assert body["enforced"] == ent.is_enforced()
+
+
+def test_locks_endpoint_enterprise_envelope_collapses(client, ent):
+    rv = client.get("/api/entitlement/next-tier-locks-at-batch")
+    body = rv.get_json()
+    enterprise = next(
+        env for env in body["tiers"] if env["tier"] == ent.TIER_ENTERPRISE
+    )
+    assert enterprise["target"] is None
+    assert enterprise["row"] is None
+
+
+def test_locks_endpoint_never_5xxs(client, ent, monkeypatch):
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "next_tier_locks_at_batch", boom)
+    monkeypatch.setattr(ent, "get_entitlement", boom)
+    rv = client.get("/api/entitlement/next-tier-locks-at-batch")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["tiers"] == []
+    assert body["current_tier"] == "oss"
+    assert body["grace"] is True
+    assert body["enforced"] is False
+
+
+def test_locks_endpoint_ignores_extra_query_args(client, ent):
+    rv = client.get("/api/entitlement/next-tier-locks-at-batch?tier=oss&foo=bar")
+    assert rv.status_code == 200
+
+
+# ── cross-endpoint: source axis lines up ─────────────────────────────────────
+
+
+def test_endpoints_source_axis_aligned(client, ent):
+    """The unlocks/locks batch endpoints emit the source axis in the
+    same order so a UI can fold them into a single matrix row-for-row
+    without re-sorting."""
+    unlocks = client.get("/api/entitlement/next-tier-unlocks-at-batch").get_json()
+    locks = client.get("/api/entitlement/next-tier-locks-at-batch").get_json()
+    assert [r["tier"] for r in unlocks["tiers"]] == [
+        r["tier"] for r in locks["tiers"]
+    ]
+
+
+def test_endpoints_each_scalar_source_byte_equal(client, ent):
+    """End-to-end parity: every batched envelope byte-equals what the
+    scalar endpoint would return for the same source."""
+    unlocks_body = client.get(
+        "/api/entitlement/next-tier-unlocks-at-batch"
+    ).get_json()
+    locks_body = client.get(
+        "/api/entitlement/next-tier-locks-at-batch"
+    ).get_json()
+    for env in unlocks_body["tiers"]:
+        scalar = client.get(
+            f"/api/entitlement/next-tier-unlocks-at?tier={env['tier']}"
+        ).get_json()
+        assert env == scalar, env["tier"]
+    for env in locks_body["tiers"]:
+        scalar = client.get(
+            f"/api/entitlement/next-tier-locks-at?tier={env['tier']}"
+        ).get_json()
+        assert env == scalar, env["tier"]


### PR DESCRIPTION
## Summary

Batch siblings of the source-anchored `next_tier_unlocks_at` / `next_tier_locks_at` scalar what-ifs that landed in #3351. Adds the `next_tier_unlocks_at_batch()` / `next_tier_locks_at_batch()` module helpers, the private `_next_at_envelope(source, builder)` builder they share, and the two companion `GET /api/entitlement/next-tier-{unlocks,locks}-at-batch` endpoints. Lets a pricing-comparison matrix UI render the "what's new / what's lost at the rung above each rung" upgrade-CTA column off **one** round-trip instead of N calls to the scalar `/next-tier-{unlocks,locks}-at` endpoint -- the batch counterpart of the scalar what-ifs, mirroring how `tier_unlocks_at_batch` / `tier_locks_at_batch` (#3338) pair with `tier_unlocks_at` / `tier_locks_at`.

- `clawmetry/entitlements.py`
  - `_next_at_envelope(source, builder)` -- private builder that pairs source/target tier metadata with the row produced by `tier_unlocks` or `tier_locks` into the scalar-endpoint envelope shape (`tier`, `tier_label`, `tier_rank`, `target`, `target_label`, `target_rank`, `row`). At the source-side ceiling (`enterprise` as source) target/row collapse to `None`; a per-target builder failure collapses to `row=None` on the populated envelope so the row stays visible in the matrix.
  - `next_tier_unlocks_at_batch()` / `next_tier_locks_at_batch()` -- module helpers iterating over `_PURCHASABLE_TIERS` as source, composing the envelope per source via `_next_at_envelope` with `tier_unlocks` / `tier_locks` respectively. Rows sorted by `(tier_rank, tier_id)` ascending so they fold byte-stable into the same matrix as `tier_unlocks_batch` / `tier_locks_batch`. Independent of the resolver, never raise -- a top-level failure short-circuits to `[]`.
- `routes/entitlement.py`
  - `GET /api/entitlement/next-tier-unlocks-at-batch` and `GET /api/entitlement/next-tier-locks-at-batch` -- no query params, return `{tiers, current_tier, current_tier_rank, grace, enforced}` where each `tiers[i]` byte-equals the scalar `/next-tier-{unlocks,locks}-at?tier=<source>` body for that source. **Never 5xxs**: resolver failure collapses to `tiers=[]` and a grace-shape envelope.
- `tests/test_entitlement_next_tier_at_batch.py` -- **56 tests** pinning helper semantics, batch/scalar parity (every batched envelope byte-equals the scalar helper and the scalar endpoint for the same source), source-axis ordering byte-stable against `tier_unlocks_batch` / `tier_locks_batch` and across the unlocks/locks siblings, ceiling/collapse posture (enterprise-as-source collapses to `target=null`/`row=null`; cloud_pro/pro-as-source collapse the `lost_*` lists but keep the row populated), grace==enforce parity, resolver-independence, never-raise, and the full API surface.

No behaviour change to any existing surface -- pure additions on read-only `GET` endpoints. Both helpers/routes default to mute (`[]` / populated envelope with `row=null`) on every fallback path so the dashboard never breaks.

## Test plan

- [x] `python3 -m pytest tests/test_entitlement_next_tier_at_batch.py` — **56 passed**
- [x] `python3 -m pytest tests/ -k entitlement` (excluding pre-existing duckdb-import collection errors / e2e suite) — **2094 passed, 4 skipped** (full entitlement suite green, including the sibling `test_entitlement_next_tier_at.py`, `test_entitlement_previous_tier_at.py`, and `test_entitlement_tier_unlocks_at_batch.py` to confirm no regression)
- [x] `python3 -m py_compile clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_next_tier_at_batch.py` — clean
- [x] `ruff check` on the three changed files — **All checks passed!**

### Local operator verification checklist

(I can't reach the live daemon / cloud snapshot / browser from this run — this is the on-host path for the operator before flipping the PR ready-for-review.)

- [ ] Copy `clawmetry/entitlements.py`, `routes/entitlement.py`, `tests/test_entitlement_next_tier_at_batch.py` into `~/.clawmetry/lib/python3.X/site-packages/clawmetry/` (and `~/.clawmetry/lib/python3.X/site-packages/routes/`).
- [ ] Clear `__pycache__/` under those dirs.
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
- [ ] `curl -s http://localhost:8900/api/entitlement/next-tier-unlocks-at-batch | jq '.tiers | length'` → matches `len(_PURCHASABLE_TIERS)` (6 today)
- [ ] `curl -s http://localhost:8900/api/entitlement/next-tier-unlocks-at-batch | jq '.tiers[] | select(.tier=="oss")'` → envelope with `target=cloud_starter`, populated `row` byte-equal to the scalar `/next-tier-unlocks-at?tier=oss` body
- [ ] `curl -s http://localhost:8900/api/entitlement/next-tier-unlocks-at-batch | jq '.tiers[] | select(.tier=="enterprise")'` → `target=null`, `row=null` (source-side ceiling collapse)
- [ ] `curl -s http://localhost:8900/api/entitlement/next-tier-locks-at-batch | jq '.tiers[] | select(.tier=="pro")'` → `target=enterprise`, `row.next_tier=null`, `row.lost_features=[]`, `row.lost_runtimes=[]` (target-ceiling collapse on populated row)
- [ ] `curl -s http://localhost:8900/api/entitlement/next-tier-locks-at-batch | jq '.current_tier, .grace, .enforced'` → matches the live resolver state surfaced on the sibling endpoints
- [ ] Browser sanity: dashboard still loads, no console errors, no regressions to the existing `/next-tier-*-at` CTA surface.
- [ ] Decrypt the live cloud snapshot client-side; the new endpoints are not part of the snapshot payload, but confirm overall snapshot integrity unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01KM7wke4kMfmJhypWCJX5rW)_