### PR TITLE
fix: preserve fastMode 'auto' string state in openclaw adapter

### DIFF
--- a/clawmetry/adapters/openclaw.py
+++ b/clawmetry/adapters/openclaw.py
@@ -959,7 +959,7 @@ class OpenClawAdapter(AgentAdapter):
             # Fast-mode state (#3322): PR #85104 added fastMode to session records.
             _fm = s.get("fastMode") if s.get("fastMode") is not None else s.get("isFastMode")
             if _fm is not None:
-                extra["fastMode"] = bool(_fm)
+                extra["fastMode"] = _fm if isinstance(_fm, str) else bool(_fm)
             # Fast-mode fallback/cutoff metadata (#3341): PR #85104 also emits
             # cutoff state, reason, transition count, delivery mode, and fallback
             # model for sessions where fast-mode reverts to normal mode.
@@ -1187,7 +1187,7 @@ class OpenClawAdapter(AgentAdapter):
                             for _fmkey in ("fastMode", "isFastMode", "talkFastMode"):
                                 _fmval = obj.get(_fmkey)
                                 if _fmval is not None:
-                                    extra["fastMode"] = bool(_fmval)
+                                    extra["fastMode"] = _fmval if isinstance(_fmval, str) else bool(_fmval)
                                     break
                             # Fast-mode fallback/cutoff metadata (#3341): PR #85104
                             # also emits cutoff state on event blobs; extract reason,


### PR DESCRIPTION
Closes #3355

## What

OpenClaw PR #85104 changed `fastMode` from a boolean to a three-state string enum (`'auto'`/`'on'`/`'off'`). ClawMetry's `OpenClawAdapter` was still calling `bool(fastMode)` at both extraction sites, coercing `'auto'` → `True` and making auto-fast sessions indistinguishable from explicitly-enabled ones.

## Changes

- `clawmetry/adapters/openclaw.py` — two one-liner fixes:
  - `list_sessions()` (line 962): `bool(_fm)` → `_fm if isinstance(_fm, str) else bool(_fm)`
  - `list_events()` (line 1190): same guard inside the `for _fmkey in (...)` loop

Legacy bool/int values continue to coerce via `bool()` for backward compat. `fastModeCutoff` is a true boolean and is unchanged.

## Test plan

- Verify a session with `/fast auto` now shows `fastMode: "auto"` (not `true`) in `/api/sessions` and brain-feed events.
- Verify a session with `/fast on` still shows `fastMode: true` (legacy bool path).
- Verify a session with `/fast off` still shows `fastMode: false`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AFT6QuEy7xaq5FngKUVtek)_