### PR TITLE
feat(entitlement): previous_tier_unlocks_at_batch + previous_tier_locks_at_batch + endpoints

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -1,3 +1,4 @@
+"""
 clawmetry/entitlements.py — open-core entitlement resolution.
 
 Single source of truth for "what is this install allowed to do". Everything

--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -1,4 +1,3 @@
-"""
 clawmetry/entitlements.py — open-core entitlement resolution.
 
 Single source of truth for "what is this install allowed to do". Everything
@@ -5333,4 +5332,159 @@ def next_tier_locks_at_batch() -> list[dict]:
         return out
     except Exception as exc:
         logger.warning("entitlements: next_tier_locks_at_batch failed: %s", exc)
+        return []
+
+
+def _previous_at_envelope(source: str, builder) -> dict:
+    """Private builder for the ``previous_tier_*_at_batch`` rows.
+
+    Mirror of :func:`_next_at_envelope` (next-tier batch) pivoted to the
+    rung *below* the source. Resolves
+    ``target = _previous_purchasable_tier_before(source)`` and pairs the
+    source/target tier metadata with the row produced by ``builder``
+    (one of :func:`tier_unlocks` / :func:`tier_locks`) into the same
+    envelope shape the scalar ``/previous-tier-*-at`` endpoints surface:
+
+        ``{tier, tier_label, tier_rank, target, target_label, target_rank, row}``
+
+    ``row`` collapses to ``None`` at the floor of the source axis (oss
+    / cloud_free -- no rung strictly below), matching the scalar
+    helpers. A builder failure short-circuits to ``row=None`` on the
+    populated envelope so the batch keeps the per-source row visible
+    instead of dropping it -- the same posture
+    :func:`tier_unlocks_at_batch` / :func:`tier_locks_at_batch` apply
+    to their per-row failures.
+
+    Never raises: every fallback collapses to a fully-populated
+    envelope with ``row=None`` so a pricing-matrix UI can render the
+    source rung even when its target row could not be built.
+    """
+    src = (source or "").strip().lower()
+    target = _previous_purchasable_tier_before(src) if src in _TIER_ORDER else None
+    row: dict | None = None
+    if target is not None:
+        try:
+            row = builder(target)
+        except Exception as exc:
+            logger.warning(
+                "entitlements: _previous_at_envelope builder failed for %s: %s",
+                target,
+                exc,
+            )
+            row = None
+    return {
+        "tier": src,
+        "tier_label": tier_label(src) if src in _TIER_ORDER else None,
+        "tier_rank": tier_rank(src) if src in _TIER_ORDER else -1,
+        "target": target,
+        "target_label": tier_label(target) if target else None,
+        "target_rank": tier_rank(target) if target else None,
+        "row": row,
+    }
+
+
+def previous_tier_unlocks_at_batch() -> list[dict]:
+    """Batch sibling of :func:`previous_tier_unlocks_at`: one
+    ``previous-tier-unlocks-at`` envelope per purchasable source tier,
+    in one pass.
+
+    Source-anchored downgrade-side mirror of
+    :func:`next_tier_unlocks_at_batch`. Composes
+    :func:`previous_tier_unlocks_at` (scalar what-if) and
+    :func:`tier_unlocks_batch` (live batch): same envelope shape per
+    row as the scalar ``/api/entitlement/previous-tier-unlocks-at``
+    endpoint surfaces, same source axis as :func:`tier_unlocks_batch`.
+    Lets a pricing-comparison matrix UI render the "what would still
+    be granted at the rung below each rung" downgrade-CTA column off
+    **one** round-trip instead of N calls to
+    :func:`previous_tier_unlocks_at`.
+
+    Each envelope is byte-equal to the scalar
+    ``/api/entitlement/previous-tier-unlocks-at?tier=<source>``
+    response body for the same source (sans the resolver-context
+    fields the route adds around the helper output) -- a parity test
+    pins this so the batch what-if cannot drift from the scalar
+    what-if (the same invariant :func:`tier_unlocks_at_batch` enforces
+    against :func:`tier_unlocks_at`).
+
+    Envelopes are sorted by source ``(tier_rank, tier_id)`` ascending
+    -- byte-stable against :func:`tier_unlocks_batch`'s ordering and
+    against :func:`previous_tier_locks_at_batch` for the same source so
+    a UI can fold the two responses into a downgrade-CTA column without
+    re-sorting client-side. Same-rank sibling tiers (``cloud_pro`` /
+    ``pro`` both at rank 2) are both returned.
+
+    Source list is :data:`_PURCHASABLE_TIERS` (trial excluded),
+    matching :func:`tier_unlocks_batch`. The source-side floor
+    (``oss`` / ``cloud_free`` as source -- no rung strictly below)
+    surfaces with ``target=None`` and ``row=None`` rather than being
+    dropped, so the matrix keeps a row for every purchasable rung.
+
+    Never raises: a per-source builder failure collapses to
+    ``row=None`` on the populated envelope so the surrounding envelope
+    stays visible; an unexpected top-level failure short-circuits to
+    ``[]`` so the matrix keeps rendering instead of breaking.
+    """
+    try:
+        out: list[dict] = []
+        ordered = sorted(
+            _PURCHASABLE_TIERS, key=lambda t: (_TIER_RANK.get(t, -1), t)
+        )
+        for tid in ordered:
+            out.append(_previous_at_envelope(tid, tier_unlocks))
+        return out
+    except Exception as exc:
+        logger.warning("entitlements: previous_tier_unlocks_at_batch failed: %s", exc)
+        return []
+
+
+def previous_tier_locks_at_batch() -> list[dict]:
+    """Batch sibling of :func:`previous_tier_locks_at`: one
+    ``previous-tier-locks-at`` envelope per purchasable source tier,
+    in one pass.
+
+    Marginal-loss mirror of :func:`previous_tier_unlocks_at_batch` and
+    pairs with :func:`tier_locks_batch` the same way
+    :func:`previous_tier_unlocks_at_batch` pairs with
+    :func:`tier_unlocks_batch` -- the downgrade-warning column on the
+    same matrix the previous-unlocks batch renders the downgrade-CTA
+    column for, pivoted around the natural next-below rung for each
+    source.
+
+    Each envelope is byte-equal to the scalar
+    ``/api/entitlement/previous-tier-locks-at?tier=<source>`` response
+    body for the same source (sans the resolver-context fields the
+    route adds around the helper output) -- a parity test pins this so
+    the batch what-if cannot drift from the scalar what-if.
+
+    Envelopes are sorted by source ``(tier_rank, tier_id)`` ascending
+    -- byte-stable against :func:`previous_tier_unlocks_at_batch` for
+    the same source so a UI can fold the two responses into a
+    downgrade-CTA + downgrade-warning matrix without re-sorting
+    client-side.
+
+    Source list is :data:`_PURCHASABLE_TIERS` (trial excluded). The
+    source-side floor (``oss`` / ``cloud_free`` as source -- no rung
+    strictly below) surfaces with ``target=None`` and ``row=None``.
+
+    At a source rung whose next-below IS the ladder floor
+    (``cloud_starter`` -> ``oss``) the row carries populated
+    ``lost_features`` / ``lost_runtimes`` lists -- :func:`tier_locks`
+    shape against the floor's next-above rung -- NOT ``None`` on the
+    envelope.
+
+    Never raises: a per-source builder failure collapses to
+    ``row=None`` on the populated envelope; an unexpected top-level
+    failure short-circuits to ``[]``.
+    """
+    try:
+        out: list[dict] = []
+        ordered = sorted(
+            _PURCHASABLE_TIERS, key=lambda t: (_TIER_RANK.get(t, -1), t)
+        )
+        for tid in ordered:
+            out.append(_previous_at_envelope(tid, tier_locks))
+        return out
+    except Exception as exc:
+        logger.warning("entitlements: previous_tier_locks_at_batch failed: %s", exc)
         return []

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -1,3 +1,4 @@
+"""
 routes/entitlement.py -- ``bp_entitlement``.
 
 Exposes the resolved open-core entitlement so the frontend knows which

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -1,4 +1,3 @@
-"""
 routes/entitlement.py -- ``bp_entitlement``.
 
 Exposes the resolved open-core entitlement so the frontend knows which
@@ -4830,6 +4829,146 @@ def api_entitlement_next_tier_locks_at_batch():
     except Exception as exc:
         logger.warning(
             "api_entitlement_next_tier_locks_at_batch: error: %s", exc
+        )
+        return jsonify(
+            {
+                "tiers": [],
+                "current_tier": "oss",
+                "current_tier_rank": 0,
+                "grace": True,
+                "enforced": False,
+            }
+        )
+
+
+@bp_entitlement.route("/api/entitlement/previous-tier-unlocks-at-batch")
+def api_entitlement_previous_tier_unlocks_at_batch():
+    """``GET /api/entitlement/previous-tier-unlocks-at-batch`` -- batch
+    sibling of ``/api/entitlement/previous-tier-unlocks-at``: one
+    ``previous-tier-unlocks-at`` envelope per purchasable source tier,
+    in one round-trip.
+
+    Source-anchored downgrade-side mirror of
+    ``/api/entitlement/next-tier-unlocks-at-batch``. Composes the
+    scalar what-if (``/previous-tier-unlocks-at``) and the live batch
+    (``/tier-unlocks-batch``) -- same envelope shape per row as the
+    scalar what-if, same source axis as the live batch. Lets a
+    pricing-comparison matrix UI render the "what would still be
+    granted at the rung below each rung" downgrade-CTA column off
+    **one** call instead of N calls to ``/previous-tier-unlocks-at``.
+
+    No query params. The source list is :data:`entitlements._PURCHASABLE_TIERS`
+    (trial excluded), matching the live ``/tier-unlocks-batch``
+    endpoint, so the envelopes fold into the same pricing-page table
+    byte-for-byte on the source axis.
+
+    Response shape::
+
+        {
+          "tiers":             [<envelope>, ...],
+          "current_tier":      "<resolved tier id>",
+          "current_tier_rank": <int>,
+          "grace":             <bool>,
+          "enforced":          <bool>,
+        }
+
+    Each ``<envelope>`` matches ``/api/entitlement/previous-tier-unlocks-at?tier=<source>``
+    for that source exactly (``tier``, ``tier_label``, ``tier_rank``,
+    ``target``, ``target_label``, ``target_rank``, ``row``). At the
+    source-side floor (``oss`` / ``cloud_free`` as source -- no rung
+    strictly below) the envelope carries ``target=null`` and
+    ``row=null`` rather than being dropped, so the matrix keeps a row
+    for every purchasable rung.
+
+    - **Never 5xxs**: a resolver failure yields an empty ``tiers``
+      list and the grace-shape envelope so the matrix keeps rendering.
+    """
+    try:
+        from clawmetry import entitlements as _ent
+
+        rows = _ent.previous_tier_unlocks_at_batch() or []
+        ent = _ent.get_entitlement()
+        return jsonify(
+            {
+                "tiers": rows,
+                "current_tier": ent.tier,
+                "current_tier_rank": _ent.tier_rank(ent.tier),
+                "grace": bool(ent.grace),
+                "enforced": _ent.is_enforced(),
+            }
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_previous_tier_unlocks_at_batch: error: %s", exc
+        )
+        return jsonify(
+            {
+                "tiers": [],
+                "current_tier": "oss",
+                "current_tier_rank": 0,
+                "grace": True,
+                "enforced": False,
+            }
+        )
+
+
+@bp_entitlement.route("/api/entitlement/previous-tier-locks-at-batch")
+def api_entitlement_previous_tier_locks_at_batch():
+    """``GET /api/entitlement/previous-tier-locks-at-batch`` -- batch
+    sibling of ``/api/entitlement/previous-tier-locks-at``: one
+    ``previous-tier-locks-at`` envelope per purchasable source tier,
+    in one round-trip.
+
+    Marginal-loss mirror of ``/previous-tier-unlocks-at-batch`` and
+    pairs with ``/tier-locks-batch`` the same way
+    ``/previous-tier-unlocks-at-batch`` pairs with
+    ``/tier-unlocks-batch``. Pair the two ``previous-*-at-batch``
+    endpoints to render the downgrade-CTA + downgrade-warning columns
+    of a "below each rung" pricing matrix in two round-trips.
+
+    No query params. The source list is :data:`entitlements._PURCHASABLE_TIERS`
+    (trial excluded), matching the live ``/tier-locks-batch`` endpoint.
+
+    Response shape::
+
+        {
+          "tiers":             [<envelope>, ...],
+          "current_tier":      "<resolved tier id>",
+          "current_tier_rank": <int>,
+          "grace":             <bool>,
+          "enforced":          <bool>,
+        }
+
+    Each ``<envelope>`` matches ``/api/entitlement/previous-tier-locks-at?tier=<source>``
+    for that source exactly (``tier``, ``tier_label``, ``tier_rank``,
+    ``target``, ``target_label``, ``target_rank``, ``row``). At the
+    source-side floor (``oss`` / ``cloud_free`` as source) the
+    envelope carries ``target=null`` and ``row=null``. At a source
+    rung whose next-below IS the ladder floor (``cloud_starter`` ->
+    ``oss``) the row carries populated ``lost_features`` /
+    ``lost_runtimes`` lists -- :func:`tier_locks` shape against the
+    floor's next-above rung -- NOT ``null`` on the envelope.
+
+    - **Never 5xxs**: a resolver failure yields an empty ``tiers``
+      list and the grace-shape envelope so the matrix keeps rendering.
+    """
+    try:
+        from clawmetry import entitlements as _ent
+
+        rows = _ent.previous_tier_locks_at_batch() or []
+        ent = _ent.get_entitlement()
+        return jsonify(
+            {
+                "tiers": rows,
+                "current_tier": ent.tier,
+                "current_tier_rank": _ent.tier_rank(ent.tier),
+                "grace": bool(ent.grace),
+                "enforced": _ent.is_enforced(),
+            }
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_previous_tier_locks_at_batch: error: %s", exc
         )
         return jsonify(
             {

--- a/tests/test_entitlement_previous_tier_at_batch.py
+++ b/tests/test_entitlement_previous_tier_at_batch.py
@@ -1,0 +1,663 @@
+"""Tests for ``previous_tier_unlocks_at_batch`` /
+``previous_tier_locks_at_batch`` -- batch siblings of the scalar
+:func:`previous_tier_unlocks_at` / :func:`previous_tier_locks_at`
+what-ifs, plus the companion
+``/api/entitlement/previous-tier-{unlocks,locks}-at-batch`` endpoints
+and the private :func:`_previous_at_envelope` builder they share.
+
+Downgrade-side mirror of the next-tier batch siblings: where the
+next-tier ``_at_batch`` family answers "what would the rung above each
+rung first unlock / first lose", this family answers "what would the
+rung below each rung still grant / first lose at that rung". Together
+they cover both directions of the per-source pricing-comparison matrix
+in two round-trips per direction.
+
+Pins covered here:
+
+* helper :func:`_previous_at_envelope` composes the source/target
+  metadata with the per-target row in the same envelope shape the
+  scalar endpoints surface -- ``tier``, ``tier_label``, ``tier_rank``,
+  ``target``, ``target_label``, ``target_rank``, ``row``
+* ``previous_tier_unlocks_at_batch()`` returns one envelope per entry
+  in :data:`_PURCHASABLE_TIERS`, sorted by ``(tier_rank, tier_id)``
+* same shape / ordering for ``previous_tier_locks_at_batch``
+* every envelope byte-equals the body that the scalar
+  ``/api/entitlement/previous-tier-{unlocks,locks}-at?tier=<src>``
+  endpoint returns for the same source -- the batch-vs-scalar parity
+  that stops the batch what-if drifting from the scalar what-if
+* at the source-side floor (``oss`` / ``cloud_free`` as source) the
+  envelope carries ``target=null`` and ``row=null`` rather than being
+  dropped
+* at a source rung whose next-below IS the ladder floor
+  (``cloud_starter`` -> ``oss``) the locks row carries populated
+  ``lost_features`` / ``lost_runtimes`` lists -- :func:`tier_locks`
+  shape against the floor's next-above rung -- NOT ``null`` on the
+  envelope
+* trial is excluded from the source axis (mirrors
+  :func:`tier_unlocks_batch`)
+* grace vs enforce yields the same body (the ``_at`` family walks the
+  static catalogue, not the gated resolver)
+* the helpers never raise: builder failure on a single source
+  collapses to ``row=null`` on the populated envelope; a top-level
+  failure short-circuits to ``[]``
+* the API endpoints never 5xx: a resolver failure yields an empty
+  ``tiers`` list and a grace-shape envelope
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+_UNLOCKS_KEYS = {
+    "tier",
+    "tier_label",
+    "tier_rank",
+    "previous_tier",
+    "previous_tier_label",
+    "previous_tier_rank",
+    "features",
+    "runtimes",
+}
+
+_LOCKS_KEYS = {
+    "tier",
+    "tier_label",
+    "tier_rank",
+    "next_tier",
+    "next_tier_label",
+    "next_tier_rank",
+    "lost_features",
+    "lost_runtimes",
+}
+
+_ENVELOPE_KEYS = {
+    "tier",
+    "tier_label",
+    "tier_rank",
+    "target",
+    "target_label",
+    "target_rank",
+    "row",
+}
+
+_BATCH_RESPONSE_KEYS = {
+    "tiers",
+    "current_tier",
+    "current_tier_rank",
+    "grace",
+    "enforced",
+}
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    """Fresh entitlements module with HOME pointed at an empty tmp dir
+    so no real ~/.clawmetry/license.key or cloud_plan.json leaks in.
+    Enforcement off by default (grace mode) -- both batch helpers are
+    catalogue-derived and independent of the resolver, so the fixture
+    only needs to keep the live resolver from surprising the test."""
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# -- _previous_at_envelope ---------------------------------------------------
+
+
+def test_envelope_builder_shape_for_known_source(ent):
+    env = ent._previous_at_envelope(ent.TIER_CLOUD_STARTER, ent.tier_unlocks)
+    assert set(env.keys()) == _ENVELOPE_KEYS
+    assert env["tier"] == ent.TIER_CLOUD_STARTER
+    assert env["tier_label"] == ent.tier_label(ent.TIER_CLOUD_STARTER)
+    assert env["tier_rank"] == ent.tier_rank(ent.TIER_CLOUD_STARTER)
+    target = ent._previous_purchasable_tier_before(ent.TIER_CLOUD_STARTER)
+    assert env["target"] == target
+    assert env["target_label"] == ent.tier_label(target)
+    assert env["target_rank"] == ent.tier_rank(target)
+    assert env["row"] == ent.tier_unlocks(target)
+
+
+def test_envelope_builder_locks_branch(ent):
+    env = ent._previous_at_envelope(ent.TIER_CLOUD_PRO, ent.tier_locks)
+    assert set(env.keys()) == _ENVELOPE_KEYS
+    target = ent._previous_purchasable_tier_before(ent.TIER_CLOUD_PRO)
+    assert env["target"] == target
+    assert env["row"] == ent.tier_locks(target)
+
+
+def test_envelope_builder_floor_collapses_target_and_row(ent):
+    env = ent._previous_at_envelope(ent.TIER_OSS, ent.tier_unlocks)
+    assert env["tier"] == ent.TIER_OSS
+    assert env["target"] is None
+    assert env["target_label"] is None
+    assert env["target_rank"] is None
+    assert env["row"] is None
+
+
+def test_envelope_builder_cloud_free_floor_also_collapses(ent):
+    env = ent._previous_at_envelope(ent.TIER_CLOUD_FREE, ent.tier_locks)
+    assert env["tier"] == ent.TIER_CLOUD_FREE
+    assert env["target"] is None
+    assert env["row"] is None
+
+
+def test_envelope_builder_unknown_source_keeps_envelope_populated(ent):
+    env = ent._previous_at_envelope("bogus", ent.tier_unlocks)
+    assert set(env.keys()) == _ENVELOPE_KEYS
+    assert env["target"] is None
+    assert env["row"] is None
+
+
+def test_envelope_builder_trims_and_lowercases(ent):
+    env = ent._previous_at_envelope("  CLOUD_STARTER  ", ent.tier_unlocks)
+    assert env["tier"] == ent.TIER_CLOUD_STARTER
+    assert env["target"] == ent._previous_purchasable_tier_before(
+        ent.TIER_CLOUD_STARTER
+    )
+
+
+def test_envelope_builder_swallows_builder_exception(ent):
+    def boom(_target):
+        raise RuntimeError("synthetic")
+
+    env = ent._previous_at_envelope(ent.TIER_CLOUD_STARTER, boom)
+    assert env["target"] == ent._previous_purchasable_tier_before(
+        ent.TIER_CLOUD_STARTER
+    )
+    assert env["row"] is None
+
+
+# -- previous_tier_unlocks_at_batch ------------------------------------------
+
+
+def test_unlocks_batch_returns_list_for_every_purchasable_source(ent):
+    rows = ent.previous_tier_unlocks_at_batch()
+    assert isinstance(rows, list)
+    assert len(rows) == len(ent._PURCHASABLE_TIERS)
+
+
+def test_unlocks_batch_each_envelope_has_envelope_shape(ent):
+    rows = ent.previous_tier_unlocks_at_batch()
+    for env in rows:
+        assert set(env.keys()) == _ENVELOPE_KEYS
+
+
+def test_unlocks_batch_source_axis_matches_purchasable(ent):
+    rows = ent.previous_tier_unlocks_at_batch()
+    sources = {env["tier"] for env in rows}
+    assert sources == set(ent._PURCHASABLE_TIERS)
+
+
+def test_unlocks_batch_excludes_trial_from_sources(ent):
+    rows = ent.previous_tier_unlocks_at_batch()
+    assert ent.TIER_TRIAL not in {env["tier"] for env in rows}
+
+
+def test_unlocks_batch_sorted_by_rank_then_id(ent):
+    rows = ent.previous_tier_unlocks_at_batch()
+    keys = [(env["tier_rank"], env["tier"]) for env in rows]
+    assert keys == sorted(keys)
+
+
+def test_unlocks_batch_ordering_matches_tier_unlocks_batch(ent):
+    """The source axis is byte-stable against
+    :func:`tier_unlocks_batch`'s ordering so the two responses fold
+    into the same pricing-page table without re-sorting client-side."""
+    at_rows = ent.previous_tier_unlocks_at_batch()
+    live_rows = ent.tier_unlocks_batch()
+    assert [r["tier"] for r in at_rows] == [r["tier"] for r in live_rows]
+
+
+def test_unlocks_batch_ordering_matches_locks_batch(ent):
+    """The two ``previous-*-at_batch`` siblings emit the source axis in
+    the same order so the unlocks/locks columns line up row-for-row."""
+    unlocks = ent.previous_tier_unlocks_at_batch()
+    locks = ent.previous_tier_locks_at_batch()
+    assert [r["tier"] for r in unlocks] == [r["tier"] for r in locks]
+
+
+def test_unlocks_batch_each_envelope_byte_equals_scalar_helper(ent):
+    """Every envelope byte-equals the body the scalar
+    :func:`previous_tier_unlocks_at` helper produces for the same
+    source -- the parity that stops the batch what-if drifting from the
+    scalar what-if."""
+    rows = ent.previous_tier_unlocks_at_batch()
+    for env in rows:
+        scalar_row = ent.previous_tier_unlocks_at(env["tier"])
+        assert env["row"] == scalar_row, env["tier"]
+
+
+def test_unlocks_batch_target_resolves_via_previous_purchasable_before(ent):
+    rows = ent.previous_tier_unlocks_at_batch()
+    for env in rows:
+        assert env["target"] == ent._previous_purchasable_tier_before(env["tier"])
+
+
+def test_unlocks_batch_target_metadata_consistent(ent):
+    rows = ent.previous_tier_unlocks_at_batch()
+    for env in rows:
+        if env["target"] is None:
+            assert env["target_label"] is None
+            assert env["target_rank"] is None
+        else:
+            assert env["target_label"] == ent.tier_label(env["target"])
+            assert env["target_rank"] == ent.tier_rank(env["target"])
+
+
+def test_unlocks_batch_oss_source_collapses_to_null(ent):
+    rows = ent.previous_tier_unlocks_at_batch()
+    oss = next(env for env in rows if env["tier"] == ent.TIER_OSS)
+    assert oss["target"] is None
+    assert oss["target_label"] is None
+    assert oss["target_rank"] is None
+    assert oss["row"] is None
+
+
+def test_unlocks_batch_cloud_free_source_collapses_to_null(ent):
+    rows = ent.previous_tier_unlocks_at_batch()
+    cf = next(env for env in rows if env["tier"] == ent.TIER_CLOUD_FREE)
+    assert cf["target"] is None
+    assert cf["row"] is None
+
+
+def test_unlocks_batch_each_row_matches_unlocks_keys_when_populated(ent):
+    rows = ent.previous_tier_unlocks_at_batch()
+    for env in rows:
+        if env["row"] is not None:
+            assert set(env["row"].keys()) == _UNLOCKS_KEYS
+
+
+def test_unlocks_batch_enterprise_source_has_populated_row(ent):
+    """enterprise -> previous is the highest rank below 3 -- a paid
+    rung (cloud_pro or pro). The row must be populated, not null."""
+    rows = ent.previous_tier_unlocks_at_batch()
+    ent_row = next(env for env in rows if env["tier"] == ent.TIER_ENTERPRISE)
+    assert ent_row["target"] is not None
+    assert ent_row["row"] is not None
+    assert set(ent_row["row"].keys()) == _UNLOCKS_KEYS
+
+
+def test_unlocks_batch_grace_and_enforce_match(ent, monkeypatch):
+    grace = ent.previous_tier_unlocks_at_batch()
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    importlib.reload(ent)
+    ent.invalidate()
+    enforce = ent.previous_tier_unlocks_at_batch()
+    assert enforce == grace
+
+
+def test_unlocks_batch_independent_of_resolver(ent, monkeypatch):
+    def boom(*_, **__):
+        raise RuntimeError("resolver must not be reached")
+
+    monkeypatch.setattr(ent, "get_entitlement", boom)
+    rows = ent.previous_tier_unlocks_at_batch()
+    assert len(rows) == len(ent._PURCHASABLE_TIERS)
+
+
+def test_unlocks_batch_does_not_mutate_live_entitlement(ent):
+    before = ent.get_entitlement().to_dict()
+    ent.previous_tier_unlocks_at_batch()
+    after = ent.get_entitlement().to_dict()
+    assert before == after
+
+
+def test_unlocks_batch_returns_empty_on_top_level_failure(ent, monkeypatch):
+    """A top-level failure short-circuits to ``[]`` so the matrix keeps
+    rendering instead of breaking."""
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "_PURCHASABLE_TIERS", property(boom))
+    out = ent.previous_tier_unlocks_at_batch()
+    assert out == []
+
+
+def test_unlocks_batch_per_source_failure_collapses_row_only(ent, monkeypatch):
+    """A per-source builder failure collapses to ``row=null`` on the
+    populated envelope -- the source rung stays visible in the matrix."""
+    def boom(_t):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "tier_unlocks", boom)
+    rows = ent.previous_tier_unlocks_at_batch()
+    assert len(rows) == len(ent._PURCHASABLE_TIERS)
+    for env in rows:
+        assert env["row"] is None
+        if env["tier"] not in (ent.TIER_OSS, ent.TIER_CLOUD_FREE):
+            assert env["target"] is not None
+
+
+# -- previous_tier_locks_at_batch --------------------------------------------
+
+
+def test_locks_batch_returns_list_for_every_purchasable_source(ent):
+    rows = ent.previous_tier_locks_at_batch()
+    assert isinstance(rows, list)
+    assert len(rows) == len(ent._PURCHASABLE_TIERS)
+
+
+def test_locks_batch_each_envelope_has_envelope_shape(ent):
+    rows = ent.previous_tier_locks_at_batch()
+    for env in rows:
+        assert set(env.keys()) == _ENVELOPE_KEYS
+
+
+def test_locks_batch_source_axis_matches_purchasable(ent):
+    rows = ent.previous_tier_locks_at_batch()
+    sources = {env["tier"] for env in rows}
+    assert sources == set(ent._PURCHASABLE_TIERS)
+
+
+def test_locks_batch_excludes_trial_from_sources(ent):
+    rows = ent.previous_tier_locks_at_batch()
+    assert ent.TIER_TRIAL not in {env["tier"] for env in rows}
+
+
+def test_locks_batch_sorted_by_rank_then_id(ent):
+    rows = ent.previous_tier_locks_at_batch()
+    keys = [(env["tier_rank"], env["tier"]) for env in rows]
+    assert keys == sorted(keys)
+
+
+def test_locks_batch_ordering_matches_tier_locks_batch(ent):
+    at_rows = ent.previous_tier_locks_at_batch()
+    live_rows = ent.tier_locks_batch()
+    assert [r["tier"] for r in at_rows] == [r["tier"] for r in live_rows]
+
+
+def test_locks_batch_each_envelope_byte_equals_scalar_helper(ent):
+    rows = ent.previous_tier_locks_at_batch()
+    for env in rows:
+        scalar_row = ent.previous_tier_locks_at(env["tier"])
+        assert env["row"] == scalar_row, env["tier"]
+
+
+def test_locks_batch_target_resolves_via_previous_purchasable_before(ent):
+    rows = ent.previous_tier_locks_at_batch()
+    for env in rows:
+        assert env["target"] == ent._previous_purchasable_tier_before(env["tier"])
+
+
+def test_locks_batch_oss_source_collapses_to_null(ent):
+    rows = ent.previous_tier_locks_at_batch()
+    oss = next(env for env in rows if env["tier"] == ent.TIER_OSS)
+    assert oss["target"] is None
+    assert oss["row"] is None
+
+
+def test_locks_batch_cloud_free_source_collapses_to_null(ent):
+    rows = ent.previous_tier_locks_at_batch()
+    cf = next(env for env in rows if env["tier"] == ent.TIER_CLOUD_FREE)
+    assert cf["target"] is None
+    assert cf["row"] is None
+
+
+def test_locks_batch_cloud_starter_source_row_points_to_floor(ent):
+    """cloud_starter -> previous is the floor (oss or cloud_free).
+    tier_locks(floor) carries next_tier = floor's natural next-above
+    rung (cloud_starter itself) and populated lost_* lists. The
+    envelope must surface that populated row, not None on the
+    envelope."""
+    rows = ent.previous_tier_locks_at_batch()
+    cs = next(env for env in rows if env["tier"] == ent.TIER_CLOUD_STARTER)
+    assert cs["target"] in (ent.TIER_OSS, ent.TIER_CLOUD_FREE)
+    assert cs["row"] is not None
+    assert cs["row"]["next_tier"] == ent.TIER_CLOUD_STARTER
+
+
+def test_locks_batch_each_row_matches_locks_keys_when_populated(ent):
+    rows = ent.previous_tier_locks_at_batch()
+    for env in rows:
+        if env["row"] is not None:
+            assert set(env["row"].keys()) == _LOCKS_KEYS
+
+
+def test_locks_batch_enterprise_source_row_populated(ent):
+    """enterprise -> previous is a paid rung (cloud_pro or pro). The
+    row must be populated, not null."""
+    rows = ent.previous_tier_locks_at_batch()
+    ent_row = next(env for env in rows if env["tier"] == ent.TIER_ENTERPRISE)
+    assert ent_row["target"] is not None
+    assert ent_row["row"] is not None
+
+
+def test_locks_batch_grace_and_enforce_match(ent, monkeypatch):
+    grace = ent.previous_tier_locks_at_batch()
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    importlib.reload(ent)
+    ent.invalidate()
+    enforce = ent.previous_tier_locks_at_batch()
+    assert enforce == grace
+
+
+def test_locks_batch_independent_of_resolver(ent, monkeypatch):
+    def boom(*_, **__):
+        raise RuntimeError("resolver must not be reached")
+
+    monkeypatch.setattr(ent, "get_entitlement", boom)
+    rows = ent.previous_tier_locks_at_batch()
+    assert len(rows) == len(ent._PURCHASABLE_TIERS)
+
+
+def test_locks_batch_returns_empty_on_top_level_failure(ent, monkeypatch):
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "_PURCHASABLE_TIERS", property(boom))
+    out = ent.previous_tier_locks_at_batch()
+    assert out == []
+
+
+# -- API: /api/entitlement/previous-tier-unlocks-at-batch -------------------
+
+
+def test_unlocks_endpoint_returns_full_ladder(client, ent):
+    rv = client.get("/api/entitlement/previous-tier-unlocks-at-batch")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert set(body.keys()) == _BATCH_RESPONSE_KEYS
+    assert body["tiers"] == ent.previous_tier_unlocks_at_batch()
+    assert len(body["tiers"]) == len(ent._PURCHASABLE_TIERS)
+
+
+def test_unlocks_endpoint_envelope_shape(client, ent):
+    rv = client.get("/api/entitlement/previous-tier-unlocks-at-batch")
+    body = rv.get_json()
+    for env in body["tiers"]:
+        assert set(env.keys()) == _ENVELOPE_KEYS
+
+
+def test_unlocks_endpoint_cloud_starter_envelope_matches_scalar(client, ent):
+    """The cloud_starter envelope in the batch byte-equals the body the
+    scalar ``/previous-tier-unlocks-at?tier=cloud_starter`` endpoint
+    returns (sans the resolver-context fields the batch wrapper adds)."""
+    batch_rv = client.get("/api/entitlement/previous-tier-unlocks-at-batch")
+    scalar_rv = client.get(
+        "/api/entitlement/previous-tier-unlocks-at?tier=cloud_starter"
+    )
+    batch_cs = next(
+        env
+        for env in batch_rv.get_json()["tiers"]
+        if env["tier"] == ent.TIER_CLOUD_STARTER
+    )
+    assert batch_cs == scalar_rv.get_json()
+
+
+def test_unlocks_endpoint_resolver_context_present(client, ent):
+    rv = client.get("/api/entitlement/previous-tier-unlocks-at-batch")
+    body = rv.get_json()
+    live = ent.get_entitlement()
+    assert body["current_tier"] == live.tier
+    assert body["current_tier_rank"] == ent.tier_rank(live.tier)
+    assert body["grace"] == bool(live.grace)
+    assert body["enforced"] == ent.is_enforced()
+
+
+def test_unlocks_endpoint_oss_envelope_collapses(client, ent):
+    rv = client.get("/api/entitlement/previous-tier-unlocks-at-batch")
+    body = rv.get_json()
+    oss = next(env for env in body["tiers"] if env["tier"] == ent.TIER_OSS)
+    assert oss["target"] is None
+    assert oss["row"] is None
+
+
+def test_unlocks_endpoint_never_5xxs(client, ent, monkeypatch):
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "previous_tier_unlocks_at_batch", boom)
+    monkeypatch.setattr(ent, "get_entitlement", boom)
+    rv = client.get("/api/entitlement/previous-tier-unlocks-at-batch")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["tiers"] == []
+    assert body["current_tier"] == "oss"
+    assert body["grace"] is True
+    assert body["enforced"] is False
+
+
+def test_unlocks_endpoint_ignores_extra_query_args(client, ent):
+    """The endpoint takes no params -- extra args are silently ignored
+    rather than 400'd."""
+    rv = client.get(
+        "/api/entitlement/previous-tier-unlocks-at-batch?tier=oss&foo=bar"
+    )
+    assert rv.status_code == 200
+
+
+# -- API: /api/entitlement/previous-tier-locks-at-batch ---------------------
+
+
+def test_locks_endpoint_returns_full_ladder(client, ent):
+    rv = client.get("/api/entitlement/previous-tier-locks-at-batch")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert set(body.keys()) == _BATCH_RESPONSE_KEYS
+    assert body["tiers"] == ent.previous_tier_locks_at_batch()
+    assert len(body["tiers"]) == len(ent._PURCHASABLE_TIERS)
+
+
+def test_locks_endpoint_envelope_shape(client, ent):
+    rv = client.get("/api/entitlement/previous-tier-locks-at-batch")
+    body = rv.get_json()
+    for env in body["tiers"]:
+        assert set(env.keys()) == _ENVELOPE_KEYS
+
+
+def test_locks_endpoint_cloud_starter_envelope_matches_scalar(client, ent):
+    batch_rv = client.get("/api/entitlement/previous-tier-locks-at-batch")
+    scalar_rv = client.get(
+        "/api/entitlement/previous-tier-locks-at?tier=cloud_starter"
+    )
+    batch_cs = next(
+        env
+        for env in batch_rv.get_json()["tiers"]
+        if env["tier"] == ent.TIER_CLOUD_STARTER
+    )
+    assert batch_cs == scalar_rv.get_json()
+
+
+def test_locks_endpoint_resolver_context_present(client, ent):
+    rv = client.get("/api/entitlement/previous-tier-locks-at-batch")
+    body = rv.get_json()
+    live = ent.get_entitlement()
+    assert body["current_tier"] == live.tier
+    assert body["current_tier_rank"] == ent.tier_rank(live.tier)
+    assert body["grace"] == bool(live.grace)
+    assert body["enforced"] == ent.is_enforced()
+
+
+def test_locks_endpoint_oss_envelope_collapses(client, ent):
+    rv = client.get("/api/entitlement/previous-tier-locks-at-batch")
+    body = rv.get_json()
+    oss = next(env for env in body["tiers"] if env["tier"] == ent.TIER_OSS)
+    assert oss["target"] is None
+    assert oss["row"] is None
+
+
+def test_locks_endpoint_cloud_starter_row_populated(client, ent):
+    rv = client.get("/api/entitlement/previous-tier-locks-at-batch")
+    body = rv.get_json()
+    cs = next(env for env in body["tiers"] if env["tier"] == ent.TIER_CLOUD_STARTER)
+    assert cs["target"] in (ent.TIER_OSS, ent.TIER_CLOUD_FREE)
+    assert cs["row"] is not None
+    assert cs["row"]["next_tier"] == ent.TIER_CLOUD_STARTER
+
+
+def test_locks_endpoint_never_5xxs(client, ent, monkeypatch):
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "previous_tier_locks_at_batch", boom)
+    monkeypatch.setattr(ent, "get_entitlement", boom)
+    rv = client.get("/api/entitlement/previous-tier-locks-at-batch")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["tiers"] == []
+    assert body["current_tier"] == "oss"
+    assert body["grace"] is True
+    assert body["enforced"] is False
+
+
+def test_locks_endpoint_ignores_extra_query_args(client, ent):
+    rv = client.get(
+        "/api/entitlement/previous-tier-locks-at-batch?tier=oss&foo=bar"
+    )
+    assert rv.status_code == 200
+
+
+# -- cross-endpoint: source axis lines up -----------------------------------
+
+
+def test_endpoints_source_axis_aligned(client, ent):
+    """The unlocks/locks batch endpoints emit the source axis in the
+    same order so a UI can fold them into a single matrix row-for-row
+    without re-sorting."""
+    unlocks = client.get(
+        "/api/entitlement/previous-tier-unlocks-at-batch"
+    ).get_json()
+    locks = client.get(
+        "/api/entitlement/previous-tier-locks-at-batch"
+    ).get_json()
+    assert [r["tier"] for r in unlocks["tiers"]] == [
+        r["tier"] for r in locks["tiers"]
+    ]
+
+
+def test_endpoints_each_scalar_source_byte_equal(client, ent):
+    """End-to-end parity: every batched envelope byte-equals what the
+    scalar endpoint would return for the same source."""
+    unlocks_body = client.get(
+        "/api/entitlement/previous-tier-unlocks-at-batch"
+    ).get_json()
+    locks_body = client.get(
+        "/api/entitlement/previous-tier-locks-at-batch"
+    ).get_json()
+    for env in unlocks_body["tiers"]:
+        scalar = client.get(
+            f"/api/entitlement/previous-tier-unlocks-at?tier={env['tier']}"
+        ).get_json()
+        assert env == scalar, env["tier"]
+    for env in locks_body["tiers"]:
+        scalar = client.get(
+            f"/api/entitlement/previous-tier-locks-at?tier={env['tier']}"
+        ).get_json()
+        assert env == scalar, env["tier"]


### PR DESCRIPTION
## Summary

Downgrade-side batch siblings of the source-anchored `previous_tier_unlocks_at` / `previous_tier_locks_at` scalar what-ifs that landed in #3353. Mirrors the next-tier batch shape #3354 establishes for the upgrade direction: adds the `previous_tier_unlocks_at_batch()` / `previous_tier_locks_at_batch()` module helpers, the private `_previous_at_envelope(source, builder)` builder they share, and the two companion `GET /api/entitlement/previous-tier-{unlocks,locks}-at-batch` endpoints. Lets a pricing-comparison matrix UI render the "what's still granted / what's first lost at the rung **below** each rung" downgrade-CTA column off **one** round-trip instead of N calls to the scalar `/previous-tier-{unlocks,locks}-at` endpoint -- the batch counterpart of the scalar what-ifs that landed in #3353, pivoted around the natural next-below rung for each source.

- `clawmetry/entitlements.py`
  - `_previous_at_envelope(source, builder)` -- private builder that pairs source/target tier metadata with the row produced by `tier_unlocks` or `tier_locks` into the scalar-endpoint envelope shape (`tier`, `tier_label`, `tier_rank`, `target`, `target_label`, `target_rank`, `row`). At the source-side floor (`oss` / `cloud_free` as source) target/row collapse to `None`; a per-target builder failure collapses to `row=None` on the populated envelope so the row stays visible in the matrix.
  - `previous_tier_unlocks_at_batch()` / `previous_tier_locks_at_batch()` -- module helpers iterating over `_PURCHASABLE_TIERS` as source, composing the envelope per source via `_previous_at_envelope` with `tier_unlocks` / `tier_locks` respectively. Rows sorted by `(tier_rank, tier_id)` ascending so they fold byte-stable into the same matrix as `tier_unlocks_batch` / `tier_locks_batch`. Independent of the resolver, never raise -- a top-level failure short-circuits to `[]`.
- `routes/entitlement.py`
  - `GET /api/entitlement/previous-tier-unlocks-at-batch` and `GET /api/entitlement/previous-tier-locks-at-batch` -- no query params, return `{tiers, current_tier, current_tier_rank, grace, enforced}` where each `tiers[i]` byte-equals the scalar `/previous-tier-{unlocks,locks}-at?tier=` body for that source. **Never 5xxs**: resolver failure collapses to `tiers=[]` and a grace-shape envelope.
- `tests/test_entitlement_previous_tier_at_batch.py` -- **59 tests** pinning helper semantics, batch/scalar parity (every batched envelope byte-equals the scalar helper and the scalar endpoint for the same source), source-axis ordering byte-stable against `tier_unlocks_batch` / `tier_locks_batch` and across the unlocks/locks siblings, floor/collapse posture (`oss` / `cloud_free` as source collapse to `target=null` / `row=null`), populated-row posture at `cloud_starter` (target is the floor, `row.next_tier=cloud_starter`, populated `lost_*` lists), grace==enforce parity, resolver-independence, never-raise, and the full API surface.

No behaviour change to any existing surface -- pure additions on read-only `GET` endpoints. Both helpers/routes default to mute (`[]` / populated envelope with `row=null`) on every fallback path so the dashboard never breaks.

Lands on top of #3353 (scalar `previous_tier_*_at`) and is parallel to #3354 (next-tier batch sibling). Either order of merge works -- the two batch siblings touch different append points and there is no helper overlap (`_previous_at_envelope` and `_next_at_envelope` are independent).

## Test plan

- [x] `python3 -m pytest tests/test_entitlement_previous_tier_at_batch.py` -- **59 passed**
- [x] `python3 -m pytest tests/ -k entitlement` (excluding pre-existing duckdb-import collection errors / e2e suite) -- **2095 passed, 4 skipped** (full entitlement suite green, including the sibling `test_entitlement_previous_tier_at.py` and `test_entitlement_tier_unlocks_at_batch.py` to confirm no regression)
- [x] `python3 -m py_compile clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_previous_tier_at_batch.py` -- clean
- [x] `ruff check` on the three changed files -- **All checks passed!**

### Local operator verification checklist

(I can't reach the live daemon / cloud snapshot / browser from this run -- this is the on-host path for the operator before flipping the PR ready-for-review.)

- [ ] Copy `clawmetry/entitlements.py`, `routes/entitlement.py`, `tests/test_entitlement_previous_tier_at_batch.py` into `~/.clawmetry/lib/python3.X/site-packages/clawmetry/` (and `~/.clawmetry/lib/python3.X/site-packages/routes/`).
- [ ] Clear `__pycache__/` under those dirs.
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
- [ ] `curl -s http://localhost:8900/api/entitlement/previous-tier-unlocks-at-batch | jq '.tiers | length'` -> matches `len(_PURCHASABLE_TIERS)` (6 today)
- [ ] `curl -s http://localhost:8900/api/entitlement/previous-tier-unlocks-at-batch | jq '.tiers[] | select(.tier=="cloud_starter")'` -> envelope with `target` in (`oss`, `cloud_free`), populated `row` byte-equal to the scalar `/previous-tier-unlocks-at?tier=cloud_starter` body
- [ ] `curl -s http://localhost:8900/api/entitlement/previous-tier-unlocks-at-batch | jq '.tiers[] | select(.tier=="oss")'` -> `target=null`, `row=null` (source-side floor collapse)
- [ ] `curl -s http://localhost:8900/api/entitlement/previous-tier-locks-at-batch | jq '.tiers[] | select(.tier=="cloud_starter")'` -> populated `row` with `row.next_tier=="cloud_starter"` (floor's natural next-above rung)
- [ ] `curl -s http://localhost:8900/api/entitlement/previous-tier-locks-at-batch | jq '.current_tier, .grace, .enforced'` -> matches the live resolver state surfaced on the sibling endpoints
- [ ] Browser sanity: dashboard still loads, no console errors, no regressions to the existing `/previous-tier-*-at` CTA surface.
- [ ] Decrypt the live cloud snapshot client-side; the new endpoints are not part of the snapshot payload, but confirm overall snapshot integrity unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01KDLTyhLND4PpzhVvVA36m8)_