### PR TITLE
feat(entitlement): next_tier_diff_at + previous_tier_diff_at + endpoints

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -5489,3 +5489,115 @@ def previous_tier_locks_at_batch() -> list[dict]:
     except Exception as exc:
         logger.warning("entitlements: previous_tier_locks_at_batch failed: %s", exc)
         return []
+
+
+def next_tier_diff_at(tier: str) -> dict | None:
+    """Scalar what-if sibling of :meth:`Entitlement.next_tier_diff`:
+    full :func:`tier_diff` row from the caller-supplied ``tier`` to the
+    next rung above it.
+
+    Source-anchored equivalent of :meth:`Entitlement.next_tier_diff`,
+    which pins ``from`` to the resolved entitlement. Convenience for
+    ``tier_diff(tier, _next_purchasable_tier_after(tier))`` so a pricing-
+    comparison or upgrade-CTA card can render the full upgrade payload
+    (``added_*``, ``lost_*``, ``capacity_changes``, ``direction``) for
+    any hypothetical source rung without first asking the resolver and
+    without monkey-patching the entitlement context. Pairs with
+    :func:`next_tier_unlocks_at` / :func:`next_tier_locks_at` (the
+    marginal-grant / marginal-loss views of the same step) on a
+    hypothetical pricing matrix cell.
+
+    Unlike :func:`next_tier_unlocks_at` -- which surfaces the target's
+    own ``tier_unlocks`` row (target-anchored, ``previous_tier`` is the
+    target's natural next-lower purchasable, NOT the caller-supplied
+    source) -- this helper pins **both** endpoints, so the row's
+    ``from`` is byte-equal to the caller-supplied ``tier``. That mirrors
+    the live :meth:`Entitlement.next_tier_diff` posture
+    (``upgrade_diff(self.tier, next_purchasable_tier())``) and is the
+    natural shape for a two-endpoint diff.
+
+    Row shape matches :func:`tier_diff` exactly -- ``from``,
+    ``from_label``, ``from_rank``, ``to``, ``to_label``, ``to_rank``,
+    ``direction``, ``added_features``, ``lost_features``,
+    ``added_runtimes``, ``lost_runtimes``, ``capacity_changes``.
+    ``direction`` is always ``"upgrade"`` for any purchasable source
+    that has a strictly-higher rung above (the floor-to-step is always
+    an upgrade); from ``trial`` (rank 2) ``direction`` is ``"upgrade"``
+    too since the next strictly-higher purchasable resolves to
+    enterprise (rank 3).
+
+    Accepts any id in :data:`_TIER_ORDER` (including :data:`TIER_TRIAL`)
+    -- the lenient ``_at`` posture, since the source is hypothetical
+    and may legitimately answer "what would step Trial -> Enterprise
+    diff to?".
+
+    Returns ``None`` for empty / unknown ``tier`` and at the ceiling
+    (no rung strictly above). Never raises: a builder failure short-
+    circuits to ``None`` so the CTA surface stays mute instead of
+    breaking.
+    """
+    try:
+        src = (tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if not src or src not in _TIER_ORDER:
+        return None
+    try:
+        target = _next_purchasable_tier_after(src)
+        if target is None:
+            return None
+        return tier_diff(src, target)
+    except Exception as exc:
+        logger.warning("entitlements: next_tier_diff_at failed: %s", exc)
+        return None
+
+
+def previous_tier_diff_at(tier: str) -> dict | None:
+    """Scalar what-if sibling of :meth:`Entitlement.previous_tier_diff`:
+    full :func:`tier_diff` row from the caller-supplied ``tier`` to the
+    next rung below it.
+
+    Source-anchored mirror of :func:`next_tier_diff_at` and downgrade-
+    side counterpart of the live :meth:`Entitlement.previous_tier_diff`
+    (which pins ``from`` to the resolved entitlement). Convenience for
+    ``tier_diff(tier, _previous_purchasable_tier_before(tier))`` so a
+    downgrade-confirmation card or pricing-comparison cell can render
+    the full step-down payload for any hypothetical source rung without
+    first asking the resolver.
+
+    Like :func:`next_tier_diff_at` (and unlike
+    :func:`previous_tier_unlocks_at`, which surfaces the target's own
+    ``tier_unlocks`` row), this helper pins **both** endpoints, so the
+    row's ``from`` is byte-equal to the caller-supplied ``tier``. That
+    mirrors the live :meth:`Entitlement.previous_tier_diff` posture
+    (``downgrade_diff(self.tier, previous_purchasable_tier())``) and
+    is the natural shape for a two-endpoint diff.
+
+    Row shape matches :func:`tier_diff` exactly. ``direction`` is
+    always ``"downgrade"`` for any purchasable source that has a
+    strictly-lower rung below; from ``trial`` (rank 2) ``direction``
+    is ``"downgrade"`` since the next strictly-lower purchasable
+    resolves to cloud_starter (rank 1).
+
+    Accepts any id in :data:`_TIER_ORDER` (including :data:`TIER_TRIAL`)
+    -- the lenient ``_at`` posture.
+
+    Returns ``None`` for empty / unknown ``tier`` and at the floor
+    (oss / cloud_free -- no rung strictly below). Never raises: a
+    builder failure short-circuits to ``None`` so the CTA surface stays
+    mute instead of breaking.
+    """
+    try:
+        src = (tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if not src or src not in _TIER_ORDER:
+        return None
+    try:
+        target = _previous_purchasable_tier_before(src)
+        if target is None:
+            return None
+        return tier_diff(src, target)
+    except Exception as exc:
+        logger.warning("entitlements: previous_tier_diff_at failed: %s", exc)
+        return None

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -4980,3 +4980,192 @@ def api_entitlement_previous_tier_locks_at_batch():
                 "enforced": False,
             }
         )
+
+
+@bp_entitlement.route("/api/entitlement/next-tier-diff-at")
+def api_entitlement_next_tier_diff_at():
+    """``GET /api/entitlement/next-tier-diff-at?tier=<source>`` --
+    scalar what-if sibling of the live ``Entitlement.next_tier_diff``:
+    full :func:`clawmetry.entitlements.tier_diff` row from the caller-
+    supplied ``tier`` to the rung above it.
+
+    Lets a pricing-comparison or upgrade-CTA card render the full
+    upgrade payload (``added_*``, ``lost_*``, ``capacity_changes``,
+    ``direction``) for any hypothetical source rung off **one** round-
+    trip, without first hitting ``/api/entitlement`` and without
+    monkey-patching the entitlement context. Pairs with
+    ``/api/entitlement/next-tier-unlocks-at`` and
+    ``/api/entitlement/next-tier-locks-at`` (the marginal-grant /
+    marginal-loss views of the same step) on a hypothetical pricing
+    matrix cell.
+
+    Response shape::
+
+        {
+          "tier":           "<source tier id>",
+          "tier_label":     "<source label>",
+          "tier_rank":      <source rank>,
+          "target":         "<next-above tier id>" | null,
+          "target_label":   "<next-above label>" | null,
+          "target_rank":    <next-above rank> | null,
+          "row":            {<tier_diff row>} | null,
+        }
+
+    Unlike ``/api/entitlement/next-tier-unlocks-at`` -- which surfaces
+    the target's own ``tier_unlocks`` row (target-anchored,
+    ``previous_tier`` is the target's natural next-lower purchasable,
+    NOT the caller-supplied source) -- this endpoint pins **both**
+    endpoints, so ``row.from`` is byte-equal to ``tier``. That mirrors
+    the live ``Entitlement.next_tier_diff`` posture and is the natural
+    shape for a two-endpoint diff. ``row.direction`` is always
+    ``"upgrade"`` for any purchasable source that has a strictly-higher
+    rung above; from ``trial`` ``row.direction`` is ``"upgrade"`` too
+    (next strictly-higher purchasable resolves to enterprise).
+
+    Accepts any tier id in :data:`entitlements._TIER_ORDER` (including
+    ``trial``), matching the other ``_at`` family endpoints. ``target``
+    / ``row`` collapse to ``null`` at the ceiling (no rung strictly
+    above the source -- enterprise as source) -- the surface stays 200
+    with a populated envelope so callers can render "you're at the top"
+    copy without a status-code branch.
+
+    - **400** when ``tier=`` is missing / blank
+    - **404** when ``tier`` is unknown. The body carries ``which`` so a
+      caller can render the right "unknown ..." message.
+    - **Never 5xxs**: builder failure short-circuits to ``row=null``
+      on the same 200 envelope so the CTA surface stays mute.
+    """
+    raw_tier = request.args.get("tier")
+    tier_in = (raw_tier or "").strip().lower()
+    if not tier_in:
+        return jsonify({"error": "missing tier"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        if tier_in not in _ent._TIER_ORDER:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "tier", "tier": tier_in}
+                ),
+                404,
+            )
+        target = _ent._next_purchasable_tier_after(tier_in)
+        row = _ent.next_tier_diff_at(tier_in)
+        return jsonify(
+            {
+                "tier": tier_in,
+                "tier_label": _ent.tier_label(tier_in),
+                "tier_rank": _ent.tier_rank(tier_in),
+                "target": target,
+                "target_label": _ent.tier_label(target) if target else None,
+                "target_rank": _ent.tier_rank(target) if target else None,
+                "row": row,
+            }
+        )
+    except Exception as exc:
+        logger.warning("api_entitlement_next_tier_diff_at: error: %s", exc)
+        return jsonify(
+            {
+                "tier": tier_in,
+                "tier_label": None,
+                "tier_rank": -1,
+                "target": None,
+                "target_label": None,
+                "target_rank": None,
+                "row": None,
+            }
+        )
+
+
+@bp_entitlement.route("/api/entitlement/previous-tier-diff-at")
+def api_entitlement_previous_tier_diff_at():
+    """``GET /api/entitlement/previous-tier-diff-at?tier=<source>`` --
+    scalar what-if sibling of the live
+    ``Entitlement.previous_tier_diff``: full
+    :func:`clawmetry.entitlements.tier_diff` row from the caller-
+    supplied ``tier`` to the rung below it.
+
+    Source-anchored mirror of ``/api/entitlement/next-tier-diff-at``
+    and downgrade-side counterpart of the live
+    ``Entitlement.previous_tier_diff``. Lets a downgrade-confirmation
+    card or pricing-comparison cell render the full step-down payload
+    for any hypothetical source rung off **one** round-trip.
+
+    Response shape::
+
+        {
+          "tier":           "<source tier id>",
+          "tier_label":     "<source label>",
+          "tier_rank":      <source rank>,
+          "target":         "<rung-below tier id>" | null,
+          "target_label":   "<rung-below label>" | null,
+          "target_rank":    <rung-below rank> | null,
+          "row":            {<tier_diff row>} | null,
+        }
+
+    Like ``/api/entitlement/next-tier-diff-at`` (and unlike
+    ``/api/entitlement/previous-tier-unlocks-at`` which surfaces the
+    target's own ``tier_unlocks`` row), this endpoint pins **both**
+    endpoints, so ``row.from`` is byte-equal to ``tier``. That mirrors
+    the live ``Entitlement.previous_tier_diff`` posture and is the
+    natural shape for a two-endpoint diff. ``row.direction`` is always
+    ``"downgrade"`` for any purchasable source that has a strictly-
+    lower rung below; from ``trial`` ``row.direction`` is
+    ``"downgrade"`` (next strictly-lower purchasable resolves to
+    cloud_starter).
+
+    Accepts any tier id in :data:`entitlements._TIER_ORDER` (including
+    ``trial``), matching the other ``_at`` family endpoints. ``target``
+    / ``row`` collapse to ``null`` at the floor (no rung strictly
+    below the source -- oss / cloud_free) -- the surface stays 200
+    with a populated envelope so callers can render "you're at the
+    bottom" copy without a status-code branch.
+
+    - **400** when ``tier=`` is missing / blank
+    - **404** when ``tier`` is unknown. The body carries ``which`` so a
+      caller can render the right "unknown ..." message.
+    - **Never 5xxs**: builder failure short-circuits to ``row=null``
+      on the same 200 envelope so the CTA surface stays mute.
+    """
+    raw_tier = request.args.get("tier")
+    tier_in = (raw_tier or "").strip().lower()
+    if not tier_in:
+        return jsonify({"error": "missing tier"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        if tier_in not in _ent._TIER_ORDER:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "tier", "tier": tier_in}
+                ),
+                404,
+            )
+        target = _ent._previous_purchasable_tier_before(tier_in)
+        row = _ent.previous_tier_diff_at(tier_in)
+        return jsonify(
+            {
+                "tier": tier_in,
+                "tier_label": _ent.tier_label(tier_in),
+                "tier_rank": _ent.tier_rank(tier_in),
+                "target": target,
+                "target_label": _ent.tier_label(target) if target else None,
+                "target_rank": _ent.tier_rank(target) if target else None,
+                "row": row,
+            }
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_previous_tier_diff_at: error: %s", exc
+        )
+        return jsonify(
+            {
+                "tier": tier_in,
+                "tier_label": None,
+                "tier_rank": -1,
+                "target": None,
+                "target_label": None,
+                "target_rank": None,
+                "row": None,
+            }
+        )

--- a/tests/test_entitlement_next_prev_tier_diff_at.py
+++ b/tests/test_entitlement_next_prev_tier_diff_at.py
@@ -1,0 +1,592 @@
+"""Tests for ``next_tier_diff_at`` / ``previous_tier_diff_at`` -- scalar
+what-if siblings of the live ``Entitlement.next_tier_diff`` /
+``Entitlement.previous_tier_diff`` instance methods, plus the companion
+``/api/entitlement/{next,previous}-tier-diff-at?tier=<src>`` endpoints.
+
+These helpers let a pricing-comparison UI render the full ``tier_diff``
+payload (``added_*``, ``lost_*``, ``capacity_changes``, ``direction``)
+for the rung above / below any hypothetical source rung off **one**
+round-trip, without first hitting ``/api/entitlement`` and without
+monkey-patching the entitlement context -- the source-anchored
+counterpart of the live methods that pin ``from`` to the resolved
+entitlement.
+
+Unlike ``next_tier_unlocks_at`` / ``previous_tier_unlocks_at`` -- which
+surface the target's own ``tier_unlocks`` row (target-anchored,
+``previous_tier`` is the target's natural next-lower purchasable, NOT
+the caller-supplied source) -- these helpers pin **both** endpoints, so
+``row["from"]`` is byte-equal to the caller-supplied ``tier``. That
+mirrors the live ``Entitlement.{next,previous}_tier_diff`` posture and
+is the natural shape for a two-endpoint diff.
+
+Pins covered here:
+
+* ``next_tier_diff_at(tier)`` byte-equals
+  ``tier_diff(tier, _next_purchasable_tier_after(tier))`` across every
+  valid source -- the convenience cannot drift from the explicit
+  composition
+* same identity for ``previous_tier_diff_at`` against
+  ``_previous_purchasable_tier_before``
+* the row's ``from`` is byte-equal to the caller-supplied source -- the
+  key differentiator vs the unlocks/locks ``_at`` family
+* ``direction`` is always ``"upgrade"`` for the next-direction helper
+  (any purchasable source has only strictly-higher rungs above) and
+  ``"downgrade"`` for the previous-direction helper
+* at the ceiling / floor (no rung strictly above / below source) both
+  helpers return ``None``
+* trial-as-source resolves the same way the unlocks/locks ``_at``
+  family does: next -> enterprise, previous -> cloud_starter
+* grace vs enforce yields the same body (the ``_at`` family walks the
+  static catalogue, not the gated resolver)
+* unknown / empty / ``None`` / non-string source returns ``None``
+* the API surface 400s on missing input, 404s on unknown ids (with
+  ``which``), surfaces 200 envelopes at the ceiling / floor with
+  ``row=null``, and never 5xxs
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    """Fresh entitlements module with HOME pointed at an empty tmp dir
+    so no real ~/.clawmetry/license.key or cloud_plan.json leaks in.
+    Enforcement off by default (grace mode) -- both helpers are
+    catalogue-derived and independent of the resolver, so the fixture
+    only needs to make sure the live resolver does not surprise the
+    test."""
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+_DIFF_KEYS = {
+    "from",
+    "from_label",
+    "from_rank",
+    "to",
+    "to_label",
+    "to_rank",
+    "direction",
+    "added_features",
+    "lost_features",
+    "added_runtimes",
+    "lost_runtimes",
+    "capacity_changes",
+}
+
+_ENVELOPE_KEYS = {
+    "tier",
+    "tier_label",
+    "tier_rank",
+    "target",
+    "target_label",
+    "target_rank",
+    "row",
+}
+
+
+# ── next_tier_diff_at ────────────────────────────────────────────────────────
+
+
+def test_next_tier_diff_at_matches_explicit_composition(ent):
+    # The convenience is tier_diff(tier, _next_purchasable_tier_after(tier)).
+    # Byte-equal across every source so callers can swap between the
+    # singular helper and the explicit composition without drift.
+    for src in (
+        ent.TIER_OSS,
+        ent.TIER_CLOUD_FREE,
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_PRO,
+        ent.TIER_TRIAL,
+    ):
+        nxt = ent._next_purchasable_tier_after(src)
+        assert nxt is not None, src
+        assert ent.next_tier_diff_at(src) == ent.tier_diff(src, nxt), src
+
+
+def test_next_tier_diff_at_returns_none_at_ceiling(ent):
+    # Enterprise has no rung above -> None, mirroring the live method.
+    assert ent.next_tier_diff_at(ent.TIER_ENTERPRISE) is None
+
+
+def test_next_tier_diff_at_row_shape(ent):
+    body = ent.next_tier_diff_at(ent.TIER_OSS)
+    assert body is not None
+    assert set(body.keys()) == _DIFF_KEYS
+    # The from endpoint IS the caller-supplied source -- this is the
+    # key differentiator vs next_tier_unlocks_at which pins only the
+    # target.
+    assert body["from"] == ent.TIER_OSS
+    assert body["from_label"] == ent.tier_label(ent.TIER_OSS)
+    assert body["from_rank"] == ent.tier_rank(ent.TIER_OSS)
+    assert body["to"] == ent.TIER_CLOUD_STARTER
+    assert body["to_label"] == ent.tier_label(ent.TIER_CLOUD_STARTER)
+    assert body["to_rank"] == ent.tier_rank(ent.TIER_CLOUD_STARTER)
+    assert body["direction"] == "upgrade"
+    assert body["added_features"] == sorted(body["added_features"])
+    assert body["lost_features"] == sorted(body["lost_features"])
+    assert body["added_runtimes"] == sorted(body["added_runtimes"])
+    assert body["lost_runtimes"] == sorted(body["lost_runtimes"])
+    # capacity_changes carries the three documented keys.
+    assert set(body["capacity_changes"].keys()) == {
+        "channel_limit",
+        "retention_days",
+        "node_limit",
+    }
+
+
+def test_next_tier_diff_at_pins_source_endpoint(ent):
+    # The row's from endpoint is byte-equal to the caller-supplied
+    # source across every purchasable rung -- the contract that lets a
+    # downstream consumer use the row as-is for a "From X To Y"
+    # pricing-comparison card without rewriting from.
+    for src in (
+        ent.TIER_OSS,
+        ent.TIER_CLOUD_FREE,
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_PRO,
+        ent.TIER_TRIAL,
+    ):
+        body = ent.next_tier_diff_at(src)
+        assert body is not None, src
+        assert body["from"] == src, src
+
+
+def test_next_tier_diff_at_direction_is_upgrade_for_every_purchasable_source(ent):
+    # Every purchasable source has only strictly-higher rungs above
+    # (the stepper picks strictly higher rank). So direction is
+    # always "upgrade" -- never "lateral" / "identity" / "downgrade".
+    for src in (
+        ent.TIER_OSS,
+        ent.TIER_CLOUD_FREE,
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_PRO,
+        ent.TIER_TRIAL,
+    ):
+        body = ent.next_tier_diff_at(src)
+        assert body is not None, src
+        assert body["direction"] == "upgrade", src
+
+
+@pytest.mark.parametrize("bad", ["", "  ", None, 0, 1.5, "BOGUS", "bogus"])
+def test_next_tier_diff_at_returns_none_on_bad_input(ent, bad):
+    assert ent.next_tier_diff_at(bad) is None
+
+
+def test_next_tier_diff_at_trims_and_lowercases(ent):
+    assert ent.next_tier_diff_at("  OSS  ") == ent.tier_diff(
+        ent.TIER_OSS, ent.TIER_CLOUD_STARTER
+    )
+
+
+def test_next_tier_diff_at_trial_source_resolves_to_enterprise(ent):
+    # Trial sits at rank 2, so the next strictly-higher purchasable
+    # rung is enterprise -- matches the live method's posture when
+    # called from a trial entitlement, and the unlocks/locks family's
+    # trial semantics.
+    body = ent.next_tier_diff_at(ent.TIER_TRIAL)
+    assert body is not None
+    assert body["from"] == ent.TIER_TRIAL
+    assert body["to"] == ent.TIER_ENTERPRISE
+    assert body["direction"] == "upgrade"
+
+
+def test_next_tier_diff_at_grace_and_enforce_match(ent, monkeypatch):
+    # Catalogue-derived (off the static per-tier grants) -- flipping
+    # enforcement on must not change the body.
+    grace = ent.next_tier_diff_at(ent.TIER_CLOUD_STARTER)
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    importlib.reload(ent)
+    ent.invalidate()
+    enforce = ent.next_tier_diff_at(ent.TIER_CLOUD_STARTER)
+    assert enforce == grace
+
+
+def test_next_tier_diff_at_never_raises(ent, monkeypatch):
+    monkeypatch.setattr(
+        ent,
+        "tier_diff",
+        lambda *_: (_ for _ in ()).throw(RuntimeError("synthetic")),
+    )
+    assert ent.next_tier_diff_at(ent.TIER_OSS) is None
+
+
+def test_next_tier_diff_at_independent_of_resolver(ent, monkeypatch):
+    # The whole point of the _at variant: it does not need the
+    # resolver. Swap get_entitlement to raise and the helper must
+    # still return a non-None body.
+    def boom(*_, **__):
+        raise RuntimeError("resolver must not be reached")
+
+    monkeypatch.setattr(ent, "get_entitlement", boom)
+    body = ent.next_tier_diff_at(ent.TIER_OSS)
+    assert body is not None
+    assert body["from"] == ent.TIER_OSS
+    assert body["to"] == ent.TIER_CLOUD_STARTER
+
+
+# ── previous_tier_diff_at ────────────────────────────────────────────────────
+
+
+def test_previous_tier_diff_at_matches_explicit_composition(ent):
+    for src in (
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_PRO,
+        ent.TIER_ENTERPRISE,
+        ent.TIER_TRIAL,
+    ):
+        prv = ent._previous_purchasable_tier_before(src)
+        assert prv is not None, src
+        assert ent.previous_tier_diff_at(src) == ent.tier_diff(src, prv), src
+
+
+def test_previous_tier_diff_at_returns_none_at_floor(ent):
+    # OSS and cloud_free both have nothing strictly below.
+    assert ent.previous_tier_diff_at(ent.TIER_OSS) is None
+    assert ent.previous_tier_diff_at(ent.TIER_CLOUD_FREE) is None
+
+
+def test_previous_tier_diff_at_row_shape(ent):
+    body = ent.previous_tier_diff_at(ent.TIER_ENTERPRISE)
+    assert body is not None
+    assert set(body.keys()) == _DIFF_KEYS
+    assert body["from"] == ent.TIER_ENTERPRISE
+    assert body["from_label"] == ent.tier_label(ent.TIER_ENTERPRISE)
+    assert body["from_rank"] == ent.tier_rank(ent.TIER_ENTERPRISE)
+    # Enterprise's previous_purchasable_tier_before is cloud_pro (the
+    # first rank-2 entry in declaration order).
+    assert body["to"] == ent.TIER_CLOUD_PRO
+    assert body["direction"] == "downgrade"
+    assert body["added_features"] == sorted(body["added_features"])
+    assert body["lost_features"] == sorted(body["lost_features"])
+    assert body["added_runtimes"] == sorted(body["added_runtimes"])
+    assert body["lost_runtimes"] == sorted(body["lost_runtimes"])
+    assert set(body["capacity_changes"].keys()) == {
+        "channel_limit",
+        "retention_days",
+        "node_limit",
+    }
+
+
+def test_previous_tier_diff_at_pins_source_endpoint(ent):
+    # Same source-endpoint pin as next_tier_diff_at, downgrade side.
+    for src in (
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_PRO,
+        ent.TIER_ENTERPRISE,
+        ent.TIER_TRIAL,
+    ):
+        body = ent.previous_tier_diff_at(src)
+        assert body is not None, src
+        assert body["from"] == src, src
+
+
+def test_previous_tier_diff_at_direction_is_downgrade_for_every_source_with_a_floor(
+    ent,
+):
+    # Every source that has a strictly-lower rung below resolves to
+    # direction="downgrade". Pinned per known source.
+    for src in (
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_PRO,
+        ent.TIER_ENTERPRISE,
+        ent.TIER_TRIAL,
+    ):
+        body = ent.previous_tier_diff_at(src)
+        assert body is not None, src
+        assert body["direction"] == "downgrade", src
+
+
+@pytest.mark.parametrize("bad", ["", "  ", None, 0, 1.5, "BOGUS", "bogus"])
+def test_previous_tier_diff_at_returns_none_on_bad_input(ent, bad):
+    assert ent.previous_tier_diff_at(bad) is None
+
+
+def test_previous_tier_diff_at_trims_and_lowercases(ent):
+    assert ent.previous_tier_diff_at("  CLOUD_STARTER  ") == ent.tier_diff(
+        ent.TIER_CLOUD_STARTER, ent.TIER_OSS
+    )
+
+
+def test_previous_tier_diff_at_trial_source_resolves_to_cloud_starter(ent):
+    # Trial sits at rank 2, so the next strictly-lower purchasable
+    # rung is cloud_starter (rank 1) -- matches the live method's
+    # posture and the unlocks/locks family's trial semantics.
+    body = ent.previous_tier_diff_at(ent.TIER_TRIAL)
+    assert body is not None
+    assert body["from"] == ent.TIER_TRIAL
+    assert body["to"] == ent.TIER_CLOUD_STARTER
+    assert body["direction"] == "downgrade"
+
+
+def test_previous_tier_diff_at_grace_and_enforce_match(ent, monkeypatch):
+    grace = ent.previous_tier_diff_at(ent.TIER_CLOUD_PRO)
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    importlib.reload(ent)
+    ent.invalidate()
+    enforce = ent.previous_tier_diff_at(ent.TIER_CLOUD_PRO)
+    assert enforce == grace
+
+
+def test_previous_tier_diff_at_never_raises(ent, monkeypatch):
+    monkeypatch.setattr(
+        ent,
+        "tier_diff",
+        lambda *_: (_ for _ in ()).throw(RuntimeError("synthetic")),
+    )
+    assert ent.previous_tier_diff_at(ent.TIER_ENTERPRISE) is None
+
+
+def test_previous_tier_diff_at_independent_of_resolver(ent, monkeypatch):
+    def boom(*_, **__):
+        raise RuntimeError("resolver must not be reached")
+
+    monkeypatch.setattr(ent, "get_entitlement", boom)
+    body = ent.previous_tier_diff_at(ent.TIER_ENTERPRISE)
+    assert body is not None
+    assert body["from"] == ent.TIER_ENTERPRISE
+    assert body["to"] == ent.TIER_CLOUD_PRO
+
+
+# ── set-identity vs tier_diff swap ───────────────────────────────────────────
+
+
+def test_diff_at_pair_swap_identity(ent):
+    # tier_diff(X, Y)["added_*"] byte-equals tier_diff(Y, X)["lost_*"]
+    # for any pair. The _at convenience must inherit that invariant
+    # against the corresponding helper composition, so a UI can flip
+    # direction without re-fetching.
+    for src in (
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_PRO,
+    ):
+        up = ent.next_tier_diff_at(src)
+        # The reverse: from the rung above, downgrade back to source.
+        nxt = ent._next_purchasable_tier_after(src)
+        down = ent.tier_diff(nxt, src)
+        assert up is not None and down is not None
+        assert up["added_features"] == down["lost_features"]
+        assert up["lost_features"] == down["added_features"]
+        assert up["added_runtimes"] == down["lost_runtimes"]
+        assert up["lost_runtimes"] == down["added_runtimes"]
+
+
+# ── API: /api/entitlement/next-tier-diff-at ──────────────────────────────────
+
+
+def test_next_tier_diff_at_endpoint_oss_default(client, ent):
+    rv = client.get("/api/entitlement/next-tier-diff-at?tier=oss")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert set(body.keys()) == _ENVELOPE_KEYS
+    assert body["tier"] == ent.TIER_OSS
+    assert body["tier_label"] == ent.tier_label(ent.TIER_OSS)
+    assert body["tier_rank"] == ent.tier_rank(ent.TIER_OSS)
+    assert body["target"] == ent.TIER_CLOUD_STARTER
+    assert body["target_label"] == ent.tier_label(ent.TIER_CLOUD_STARTER)
+    assert body["target_rank"] == ent.tier_rank(ent.TIER_CLOUD_STARTER)
+    assert body["row"] == ent.tier_diff(ent.TIER_OSS, ent.TIER_CLOUD_STARTER)
+
+
+def test_next_tier_diff_at_endpoint_row_from_pins_source(client, ent):
+    # Pinned at the endpoint surface too -- a UI consuming the body
+    # directly without re-checking can rely on row.from == query tier.
+    rv = client.get(
+        "/api/entitlement/next-tier-diff-at?tier=cloud_starter"
+    )
+    body = rv.get_json()
+    assert body["row"]["from"] == ent.TIER_CLOUD_STARTER
+    assert body["row"]["direction"] == "upgrade"
+
+
+def test_next_tier_diff_at_endpoint_enterprise_ceiling(client, ent):
+    rv = client.get("/api/entitlement/next-tier-diff-at?tier=enterprise")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert set(body.keys()) == _ENVELOPE_KEYS
+    assert body["tier"] == ent.TIER_ENTERPRISE
+    assert body["target"] is None
+    assert body["target_label"] is None
+    assert body["target_rank"] is None
+    assert body["row"] is None
+
+
+def test_next_tier_diff_at_endpoint_trial(client, ent):
+    rv = client.get("/api/entitlement/next-tier-diff-at?tier=trial")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["target"] == ent.TIER_ENTERPRISE
+    assert body["row"] == ent.tier_diff(ent.TIER_TRIAL, ent.TIER_ENTERPRISE)
+
+
+def test_next_tier_diff_at_endpoint_missing_tier(client):
+    rv = client.get("/api/entitlement/next-tier-diff-at")
+    assert rv.status_code == 400
+    assert rv.get_json()["error"] == "missing tier"
+
+
+def test_next_tier_diff_at_endpoint_blank_tier(client):
+    rv = client.get("/api/entitlement/next-tier-diff-at?tier=%20%20")
+    assert rv.status_code == 400
+
+
+def test_next_tier_diff_at_endpoint_unknown_tier(client):
+    rv = client.get("/api/entitlement/next-tier-diff-at?tier=bogus")
+    assert rv.status_code == 404
+    body = rv.get_json()
+    assert body["error"] == "unknown tier"
+    assert body["which"] == "tier"
+
+
+def test_next_tier_diff_at_endpoint_trims_and_lowercases(client, ent):
+    rv = client.get(
+        "/api/entitlement/next-tier-diff-at?tier=%20%20OSS%20%20"
+    )
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["tier"] == ent.TIER_OSS
+    assert body["target"] == ent.TIER_CLOUD_STARTER
+
+
+def test_next_tier_diff_at_endpoint_never_raises(client, ent, monkeypatch):
+    # Synthesise a builder failure and assert the envelope still
+    # returns 200 with row=null so the dashboard doesn't break.
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "next_tier_diff_at", boom)
+    monkeypatch.setattr(ent, "_next_purchasable_tier_after", boom)
+    rv = client.get("/api/entitlement/next-tier-diff-at?tier=oss")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["row"] is None
+    assert body["target"] is None
+
+
+# ── API: /api/entitlement/previous-tier-diff-at ──────────────────────────────
+
+
+def test_previous_tier_diff_at_endpoint_enterprise_default(client, ent):
+    rv = client.get(
+        "/api/entitlement/previous-tier-diff-at?tier=enterprise"
+    )
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert set(body.keys()) == _ENVELOPE_KEYS
+    assert body["tier"] == ent.TIER_ENTERPRISE
+    assert body["target"] == ent.TIER_CLOUD_PRO
+    assert body["row"] == ent.tier_diff(
+        ent.TIER_ENTERPRISE, ent.TIER_CLOUD_PRO
+    )
+
+
+def test_previous_tier_diff_at_endpoint_row_from_pins_source(client, ent):
+    rv = client.get(
+        "/api/entitlement/previous-tier-diff-at?tier=cloud_starter"
+    )
+    body = rv.get_json()
+    assert body["row"]["from"] == ent.TIER_CLOUD_STARTER
+    assert body["row"]["direction"] == "downgrade"
+
+
+def test_previous_tier_diff_at_endpoint_oss_floor(client, ent):
+    rv = client.get("/api/entitlement/previous-tier-diff-at?tier=oss")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["tier"] == ent.TIER_OSS
+    assert body["target"] is None
+    assert body["target_label"] is None
+    assert body["target_rank"] is None
+    assert body["row"] is None
+
+
+def test_previous_tier_diff_at_endpoint_cloud_free_floor(client, ent):
+    rv = client.get(
+        "/api/entitlement/previous-tier-diff-at?tier=cloud_free"
+    )
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["target"] is None
+    assert body["row"] is None
+
+
+def test_previous_tier_diff_at_endpoint_trial(client, ent):
+    rv = client.get("/api/entitlement/previous-tier-diff-at?tier=trial")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["target"] == ent.TIER_CLOUD_STARTER
+    assert body["row"] == ent.tier_diff(ent.TIER_TRIAL, ent.TIER_CLOUD_STARTER)
+
+
+def test_previous_tier_diff_at_endpoint_missing_tier(client):
+    rv = client.get("/api/entitlement/previous-tier-diff-at")
+    assert rv.status_code == 400
+
+
+def test_previous_tier_diff_at_endpoint_unknown_tier(client):
+    rv = client.get("/api/entitlement/previous-tier-diff-at?tier=bogus")
+    assert rv.status_code == 404
+    body = rv.get_json()
+    assert body["error"] == "unknown tier"
+    assert body["which"] == "tier"
+
+
+def test_previous_tier_diff_at_endpoint_never_raises(
+    client, ent, monkeypatch
+):
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "previous_tier_diff_at", boom)
+    monkeypatch.setattr(ent, "_previous_purchasable_tier_before", boom)
+    rv = client.get("/api/entitlement/previous-tier-diff-at?tier=enterprise")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["row"] is None
+    assert body["target"] is None
+
+
+# ── end-to-end parity ────────────────────────────────────────────────────────
+
+
+def test_endpoints_row_matches_helper(client, ent):
+    # End-to-end parity: the endpoint body's row byte-equals the
+    # module-level helper for the same source, on both directions.
+    next_rv = client.get(
+        "/api/entitlement/next-tier-diff-at?tier=cloud_starter"
+    )
+    assert next_rv.get_json()["row"] == ent.next_tier_diff_at(
+        ent.TIER_CLOUD_STARTER
+    )
+    prev_rv = client.get(
+        "/api/entitlement/previous-tier-diff-at?tier=cloud_pro"
+    )
+    assert prev_rv.get_json()["row"] == ent.previous_tier_diff_at(
+        ent.TIER_CLOUD_PRO
+    )


### PR DESCRIPTION
## Summary

Source-anchored what-if siblings of `Entitlement.next_tier_diff` / `Entitlement.previous_tier_diff`: the full `tier_diff` row from the caller-supplied source to the rung above / below, computed without going through the resolver. The full-diff counterpart of the next/previous `*_unlocks_at` / `*_locks_at` scalar family (#3351 / #3353), pinning **both** endpoints so `row["from"]` is byte-equal to the caller-supplied source -- the natural shape for a two-endpoint diff and the same posture the live `next_tier_diff` / `previous_tier_diff` methods use against the resolved entitlement.

Lets a pricing-comparison or upgrade/downgrade-CTA card render the full upgrade payload (`added_*`, `lost_*`, `capacity_changes`, `direction`) for any hypothetical source rung off **one** round-trip, without first hitting `/api/entitlement` and without monkey-patching the entitlement context.

- `clawmetry/entitlements.py`
  - `next_tier_diff_at(tier)` -- convenience for `tier_diff(tier, _next_purchasable_tier_after(tier))`.
  - `previous_tier_diff_at(tier)` -- convenience for `tier_diff(tier, _previous_purchasable_tier_before(tier))`.
  - Both independent of the resolver, never raise, return `None` at the ceiling / floor (no rung above / below).
- `routes/entitlement.py`
  - `GET /api/entitlement/next-tier-diff-at?tier=<src>`
  - `GET /api/entitlement/previous-tier-diff-at?tier=<src>`
  - Same envelope shape as `/next-tier-unlocks-at` (`tier`, `tier_label`, `tier_rank`, `target`, `target_label`, `target_rank`, `row`). **400** on missing/blank, **404** on unknown id with `which`, populated 200 envelope with `row=null` at the source-side ceiling / floor. **Never 5xxs**: builder failure collapses to `row=null`.
- `tests/test_entitlement_next_prev_tier_diff_at.py` -- **53 tests** pinning:
  - helper semantics (both helpers byte-equal the explicit `tier_diff(src, stepper(src))` composition across every valid source -- the convenience cannot drift from the explicit composition)
  - the `row["from"] == source` pin -- the key differentiator vs the unlocks/locks `_at` family which surfaces target-anchored rows
  - direction-axis: `"upgrade"` for the next-direction helper across every source with a rung above; `"downgrade"` for the previous-direction helper across every source with a rung below
  - ceiling / floor `None` collapse (enterprise as source for next, oss / cloud_free as source for previous)
  - trial-as-source semantics (next -> enterprise, previous -> cloud_starter, matching the existing `_at` family)
  - swap-the-endpoints set-identity vs `tier_diff` (every `_at` upgrade row's `added_*` byte-equals the reverse `tier_diff(target, source)` `lost_*`)
  - grace == enforce parity (catalogue-derived)
  - resolver-independence (swap `get_entitlement` to raise -> helpers still return non-None bodies)
  - never-raise on `tier_diff` / stepper builder failure
  - full API surface: 200 default, 200 ceiling/floor envelope with `row=null`, 200 trial source, 400 on missing/blank input, 404 on unknown ids, trims + lowercases input, never 5xxs even when both the helper and the stepper raise

No behaviour change to any existing surface -- pure additions on read-only `GET` endpoints. Both helpers / routes default to mute (`None` / 200 envelope with `row=null`) on every fallback path so the dashboard never breaks. Stays in **GRACE**.

Lands as the full-diff slot of the existing `_at` family alongside #3351 (`next_tier_*_at` scalar), #3353 (`previous_tier_*_at` scalar), #3354 (`next_tier_*_at_batch`), and #3358 (`previous_tier_*_at_batch`).

## Test plan

- [x] `python3 -m pytest tests/test_entitlement_next_prev_tier_diff_at.py` -- **53 passed**
- [x] `python3 -m pytest tests/ -k entitlement` (excluding pre-existing duckdb-import collection errors / e2e suite) -- **2206 passed, 4 skipped** (full entitlement suite green, including sibling `_at` / `_at_batch` / `tier_diff` suites)
- [x] `python3 -m py_compile clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_next_prev_tier_diff_at.py` -- clean
- [x] `ruff check` on the three changed files -- **All checks passed!**

### Local operator verification checklist

(I can't reach the live daemon / cloud snapshot / browser from this run -- this is the on-host path for the operator before flipping the PR ready-for-review.)

- [ ] Copy `clawmetry/entitlements.py`, `routes/entitlement.py`, `tests/test_entitlement_next_prev_tier_diff_at.py` into `~/.clawmetry/lib/python3.X/site-packages/clawmetry/` (and `~/.clawmetry/lib/python3.X/site-packages/routes/`).
- [ ] Clear `__pycache__/` under those dirs.
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
- [ ] `curl -s 'http://localhost:8900/api/entitlement/next-tier-diff-at?tier=oss' | jq '.row.from, .row.to, .row.direction'` -> `"oss"`, `"cloud_starter"`, `"upgrade"`
- [ ] `curl -s 'http://localhost:8900/api/entitlement/next-tier-diff-at?tier=enterprise' | jq '.target, .row'` -> `null`, `null` (source-side ceiling collapse)
- [ ] `curl -s 'http://localhost:8900/api/entitlement/previous-tier-diff-at?tier=enterprise' | jq '.row.from, .row.to, .row.direction'` -> `"enterprise"`, `"cloud_pro"`, `"downgrade"`
- [ ] `curl -s 'http://localhost:8900/api/entitlement/previous-tier-diff-at?tier=oss' | jq '.target, .row'` -> `null`, `null` (source-side floor collapse)
- [ ] `curl -s 'http://localhost:8900/api/entitlement/next-tier-diff-at?tier=trial' | jq '.row.to'` -> `"enterprise"`
- [ ] `curl -s 'http://localhost:8900/api/entitlement/previous-tier-diff-at?tier=trial' | jq '.row.to'` -> `"cloud_starter"`
- [ ] `curl -sS -o /dev/null -w '%{http_code}\n' 'http://localhost:8900/api/entitlement/next-tier-diff-at'` -> `400`
- [ ] `curl -sS -o /dev/null -w '%{http_code}\n' 'http://localhost:8900/api/entitlement/previous-tier-diff-at?tier=bogus'` -> `404`
- [ ] Browser sanity: dashboard still loads, no console errors, no regressions to the existing `/next-tier-*-at` / `/previous-tier-*-at` CTA surface.
- [ ] Decrypt the live cloud snapshot client-side; the new endpoints are not part of the snapshot payload, but confirm overall snapshot integrity unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01URkUoBjY34UieCbptkNHYo)_