### PR TITLE
feat(entitlement): next/previous_tier_capacity_diff_at + endpoints

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -5801,3 +5801,293 @@ def previous_tier_diff_at_batch() -> list[dict]:
             "entitlements: previous_tier_diff_at_batch failed: %s", exc
         )
         return []
+
+
+def next_tier_capacity_diff_at(tier: str) -> dict | None:
+    """Scalar what-if sibling of :meth:`Entitlement.next_tier_capacity_diff`:
+    per-axis capacity transition (channels / retention / nodes) from the
+    caller-supplied ``tier`` to the rung above it.
+
+    Capacity-only narrow lens of :func:`next_tier_diff_at` -- the latter
+    returns the FULL :func:`tier_diff` payload (``added_*`` + ``lost_*``
+    + ``capacity_changes`` + ``direction``) for the same step; this
+    helper returns only the capacity slice (the
+    ``{target, channel_limit, retention_days, node_limit}`` shape
+    :func:`capacity_diff` / :func:`capacity_diff_at` already publish).
+    Source-anchored equivalent of the live
+    :meth:`Entitlement.next_tier_capacity_diff` instance method which
+    pins the source to the resolved entitlement -- convenience for
+    ``capacity_diff_at(tier, _next_purchasable_tier_after(tier))`` so a
+    capacity-only tooltip on a pricing-comparison cell can render the
+    upgrade-side capacity delta for any hypothetical source rung off
+    **one** round-trip, without first hitting ``/api/entitlement`` and
+    without monkey-patching the entitlement context.
+
+    Row shape matches :func:`capacity_diff_at` exactly -- ``target``,
+    ``channel_limit``, ``retention_days``, ``node_limit`` where each
+    capacity axis is the ``{before, after, delta, unlocked, locked}``
+    triple :func:`_capacity_transition` builds. ``before`` comes off the
+    static per-tier caps anchored at the caller-supplied ``tier`` (NOT
+    the resolved entitlement), so the helper is independent of grace
+    mode and the per-axis caps do NOT collapse to the unlimited sentinel
+    the way live :func:`capacity_diff` does under grace -- the ``_at``
+    posture is "if I were at A, what's the capacity at the next rung",
+    not "from where I am now".
+
+    Each row is byte-identical to ``capacity_diff_at(tier,
+    _next_purchasable_tier_after(tier))`` for the same source -- pinned
+    in the test suite so the singular helper cannot drift from the
+    explicit composition.
+
+    Accepts any id in :data:`_TIER_ORDER` (including :data:`TIER_TRIAL`)
+    -- the lenient ``_at`` posture, since the source is hypothetical
+    and may legitimately answer "what would step Trial -> Enterprise
+    cost in capacity?".
+
+    Returns ``None`` for empty / unknown ``tier`` and at the ceiling
+    (no rung strictly above -- enterprise as source). Never raises: a
+    builder failure short-circuits to ``None`` so the tooltip surface
+    stays mute instead of breaking.
+    """
+    try:
+        src = (tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if not src or src not in _TIER_ORDER:
+        return None
+    try:
+        target = _next_purchasable_tier_after(src)
+        if target is None:
+            return None
+        return capacity_diff_at(src, target)
+    except Exception as exc:
+        logger.warning(
+            "entitlements: next_tier_capacity_diff_at failed: %s", exc
+        )
+        return None
+
+
+def previous_tier_capacity_diff_at(tier: str) -> dict | None:
+    """Scalar what-if sibling of
+    :meth:`Entitlement.previous_tier_capacity_diff`: per-axis capacity
+    transition from the caller-supplied ``tier`` to the rung below it.
+
+    Capacity-only narrow lens of :func:`previous_tier_diff_at` and
+    source-anchored downgrade-side mirror of
+    :func:`next_tier_capacity_diff_at`. Convenience for
+    ``capacity_diff_at(tier, _previous_purchasable_tier_before(tier))``
+    so a downgrade-confirmation tooltip can render the step-down
+    capacity delta for any hypothetical source rung off **one** round-
+    trip, without first hitting ``/api/entitlement``.
+
+    Row shape matches :func:`capacity_diff_at` exactly. Like
+    :func:`next_tier_capacity_diff_at` the ``before`` side comes off
+    the static per-tier caps anchored at the caller-supplied ``tier``
+    (NOT the resolved entitlement) -- the helper is independent of
+    grace mode and never returns the unlimited sentinel.
+
+    Each row is byte-identical to ``capacity_diff_at(tier,
+    _previous_purchasable_tier_before(tier))`` for the same source --
+    pinned in the test suite so the singular helper cannot drift from
+    the explicit composition.
+
+    Accepts any id in :data:`_TIER_ORDER` (including :data:`TIER_TRIAL`)
+    -- the lenient ``_at`` posture.
+
+    Returns ``None`` for empty / unknown ``tier`` and at the floor
+    (no rung strictly below -- oss / cloud_free as source). Never
+    raises: a builder failure short-circuits to ``None``.
+    """
+    try:
+        src = (tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if not src or src not in _TIER_ORDER:
+        return None
+    try:
+        target = _previous_purchasable_tier_before(src)
+        if target is None:
+            return None
+        return capacity_diff_at(src, target)
+    except Exception as exc:
+        logger.warning(
+            "entitlements: previous_tier_capacity_diff_at failed: %s", exc
+        )
+        return None
+
+
+def _capacity_diff_at_envelope(source: str, target: str | None) -> dict:
+    """Private builder for the ``{next,previous}_tier_capacity_diff_at_batch``
+    rows.
+
+    Capacity-only narrow-lens mirror of :func:`_diff_at_envelope`:
+    where that builder carries the full :func:`tier_diff` row, this
+    one carries the capacity-only :func:`_capacity_row` shape
+    (``target``, ``channel_limit``, ``retention_days``, ``node_limit``)
+    pinned on both ``source`` and ``target``.
+
+    Envelope shape matches :func:`_diff_at_envelope` byte-for-byte on
+    the source/target metadata so a UI can fold the diff batch and the
+    capacity batch into one pricing-comparison matrix without
+    re-keying::
+
+        ``{tier, tier_label, tier_rank, target, target_label, target_rank, row}``
+
+    ``row`` collapses to ``None`` at the ladder ceiling / floor of the
+    source axis (``target is None``) and on a builder failure,
+    matching the diff envelope's posture. Never raises -- every
+    fallback collapses to a fully-populated envelope with ``row=None``
+    so the batch keeps the per-source row visible even when its
+    per-pair capacity row could not be built.
+    """
+    src = (source or "").strip().lower()
+    row: dict | None = None
+    if target is not None:
+        try:
+            row = capacity_diff_at(src, target)
+        except Exception as exc:
+            logger.warning(
+                "entitlements: _capacity_diff_at_envelope builder failed for %s->%s: %s",
+                src,
+                target,
+                exc,
+            )
+            row = None
+    return {
+        "tier": src,
+        "tier_label": tier_label(src) if src in _TIER_ORDER else None,
+        "tier_rank": tier_rank(src) if src in _TIER_ORDER else -1,
+        "target": target,
+        "target_label": tier_label(target) if target else None,
+        "target_rank": tier_rank(target) if target else None,
+        "row": row,
+    }
+
+
+def next_tier_capacity_diff_at_batch() -> list[dict]:
+    """Batch sibling of :func:`next_tier_capacity_diff_at`: one
+    ``next-tier-capacity-diff-at`` envelope per purchasable source
+    tier, in one pass.
+
+    Capacity-only narrow-lens mirror of :func:`next_tier_diff_at_batch`:
+    where that batch returns the full :func:`tier_diff` payload for
+    each ``source -> next-above-source`` pair, this batch returns only
+    the capacity slice (the ``{target, channel_limit, retention_days,
+    node_limit}`` shape :func:`capacity_diff_at` publishes). Lets a
+    pricing-comparison matrix UI render the "capacity at the rung
+    above each rung" upgrade tooltip column off **one** round-trip
+    instead of N calls to :func:`next_tier_capacity_diff_at`.
+
+    Each envelope is byte-equal to the scalar
+    ``/api/entitlement/next-tier-capacity-diff-at?tier=<source>``
+    response body for the same source (sans the resolver-context
+    fields the route adds around the helper output) -- a parity test
+    pins this so the batch what-if cannot drift from the scalar
+    what-if (the same invariant :func:`next_tier_diff_at_batch`
+    enforces against :func:`next_tier_diff_at`).
+
+    Per-slice parity with :func:`next_tier_diff_at_batch`: each
+    envelope's ``row`` byte-equals the corresponding diff batch
+    envelope's ``row.capacity_changes`` for the same source -- pinned
+    so the capacity batch cannot silently desync from the full diff
+    batch as the catalogue evolves.
+
+    Envelopes are sorted by source ``(tier_rank, tier_id)`` ascending
+    -- byte-stable against :func:`next_tier_diff_at_batch` /
+    :func:`next_tier_unlocks_at_batch` / :func:`next_tier_locks_at_batch`
+    so a UI can fold the four responses into one matrix without
+    re-sorting client-side. Same-rank sibling tiers (``cloud_pro`` /
+    ``pro`` both at rank 2) are both returned.
+
+    Source list is :data:`_PURCHASABLE_TIERS` (trial excluded),
+    matching :func:`next_tier_diff_at_batch`. The source-side ceiling
+    (``enterprise`` as source -- no rung strictly above) surfaces with
+    ``target=None`` and ``row=None`` rather than being dropped, so the
+    matrix keeps a row for every purchasable rung.
+
+    Decoupled from the resolved entitlement (walks the static
+    catalogue), so grace vs enforce yields identical rows.
+
+    Never raises: a per-source builder failure collapses to
+    ``row=None`` on the populated envelope so the surrounding envelope
+    stays visible; an unexpected top-level failure short-circuits to
+    ``[]`` so the matrix keeps rendering instead of breaking.
+    """
+    try:
+        out: list[dict] = []
+        ordered = sorted(
+            _PURCHASABLE_TIERS, key=lambda t: (_TIER_RANK.get(t, -1), t)
+        )
+        for tid in ordered:
+            target = _next_purchasable_tier_after(tid)
+            out.append(_capacity_diff_at_envelope(tid, target))
+        return out
+    except Exception as exc:
+        logger.warning(
+            "entitlements: next_tier_capacity_diff_at_batch failed: %s", exc
+        )
+        return []
+
+
+def previous_tier_capacity_diff_at_batch() -> list[dict]:
+    """Batch sibling of :func:`previous_tier_capacity_diff_at`: one
+    ``previous-tier-capacity-diff-at`` envelope per purchasable source
+    tier, in one pass.
+
+    Source-anchored downgrade-side mirror of
+    :func:`next_tier_capacity_diff_at_batch` and capacity-only narrow
+    lens of :func:`previous_tier_diff_at_batch`. Lets a pricing-
+    comparison matrix UI render the "capacity at the rung below each
+    rung" downgrade tooltip column off **one** round-trip instead of N
+    calls to :func:`previous_tier_capacity_diff_at`.
+
+    Each envelope is byte-equal to the scalar
+    ``/api/entitlement/previous-tier-capacity-diff-at?tier=<source>``
+    response body for the same source (sans the resolver-context
+    fields the route adds around the helper output) -- a parity test
+    pins this so the batch what-if cannot drift from the scalar
+    what-if.
+
+    Per-slice parity with :func:`previous_tier_diff_at_batch`: each
+    envelope's ``row`` byte-equals the corresponding diff batch
+    envelope's ``row.capacity_changes`` for the same source -- pinned
+    so the capacity batch cannot silently desync from the full diff
+    batch.
+
+    Envelopes are sorted by source ``(tier_rank, tier_id)`` ascending
+    -- byte-stable against :func:`previous_tier_diff_at_batch` /
+    :func:`previous_tier_unlocks_at_batch` /
+    :func:`previous_tier_locks_at_batch` so a UI can fold the four
+    responses into one matrix without re-sorting client-side. Same-
+    rank sibling tiers are both returned.
+
+    Source list is :data:`_PURCHASABLE_TIERS` (trial excluded),
+    matching :func:`previous_tier_diff_at_batch`. The source-side
+    floor (``oss`` / ``cloud_free`` as source -- no rung strictly
+    below) surfaces with ``target=None`` and ``row=None`` rather than
+    being dropped, so the matrix keeps a row for every purchasable
+    rung.
+
+    Decoupled from the resolved entitlement (walks the static
+    catalogue), so grace vs enforce yields identical rows.
+
+    Never raises: a per-source builder failure collapses to
+    ``row=None`` on the populated envelope so the surrounding envelope
+    stays visible; an unexpected top-level failure short-circuits to
+    ``[]`` so the matrix keeps rendering instead of breaking.
+    """
+    try:
+        out: list[dict] = []
+        ordered = sorted(
+            _PURCHASABLE_TIERS, key=lambda t: (_TIER_RANK.get(t, -1), t)
+        )
+        for tid in ordered:
+            target = _previous_purchasable_tier_before(tid)
+            out.append(_capacity_diff_at_envelope(tid, target))
+        return out
+    except Exception as exc:
+        logger.warning(
+            "entitlements: previous_tier_capacity_diff_at_batch failed: %s",
+            exc,
+        )
+        return []

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -5327,3 +5327,323 @@ def api_entitlement_previous_tier_diff_at_batch():
                 "enforced": False,
             }
         )
+
+
+@bp_entitlement.route("/api/entitlement/next-tier-capacity-diff-at")
+def api_entitlement_next_tier_capacity_diff_at():
+    """``GET /api/entitlement/next-tier-capacity-diff-at?tier=<source>`` --
+    scalar what-if sibling of the live
+    ``Entitlement.next_tier_capacity_diff``: per-axis capacity
+    transition from the caller-supplied ``tier`` to the rung above it.
+
+    Capacity-only narrow lens of
+    ``/api/entitlement/next-tier-diff-at`` -- the latter returns the
+    full :func:`tier_diff` payload for the same step; this endpoint
+    returns only the capacity slice
+    (``{target, channel_limit, retention_days, node_limit}``) so a
+    capacity-only tooltip on a pricing-comparison cell can render the
+    upgrade-side capacity delta for any hypothetical source rung off
+    **one** round-trip.
+
+    Response shape::
+
+        {
+          "tier":           "<source tier id>",
+          "tier_label":     "<source label>",
+          "tier_rank":      <source rank>,
+          "target":         "<next-above tier id>" | null,
+          "target_label":   "<next-above label>" | null,
+          "target_rank":    <next-above rank> | null,
+          "row":            {<capacity_diff_at row>} | null,
+        }
+
+    ``row`` is byte-equal to
+    ``/api/entitlement/next-tier-diff-at?tier=<source>``'s
+    ``row.capacity_changes`` for the same source (modulo the outer
+    :func:`_capacity_row` ``target`` key the diff row does not carry).
+    The ``before`` side of each axis comes off the static per-tier
+    caps anchored at the caller-supplied ``tier`` (NOT the resolved
+    entitlement), so the endpoint is independent of grace mode.
+
+    Accepts any tier id in :data:`entitlements._TIER_ORDER` (including
+    ``trial``), matching the other ``_at`` family endpoints. ``target``
+    / ``row`` collapse to ``null`` at the ceiling (no rung strictly
+    above the source -- enterprise as source) -- the surface stays 200
+    with a populated envelope so callers can render "you're at the top"
+    copy without a status-code branch.
+
+    - **400** when ``tier=`` is missing / blank
+    - **404** when ``tier`` is unknown. The body carries ``which`` so a
+      caller can render the right "unknown ..." message.
+    - **Never 5xxs**: builder failure short-circuits to ``row=null``
+      on the same 200 envelope so the tooltip surface stays mute.
+    """
+    raw_tier = request.args.get("tier")
+    tier_in = (raw_tier or "").strip().lower()
+    if not tier_in:
+        return jsonify({"error": "missing tier"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        if tier_in not in _ent._TIER_ORDER:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "tier", "tier": tier_in}
+                ),
+                404,
+            )
+        target = _ent._next_purchasable_tier_after(tier_in)
+        row = _ent.next_tier_capacity_diff_at(tier_in)
+        return jsonify(
+            {
+                "tier": tier_in,
+                "tier_label": _ent.tier_label(tier_in),
+                "tier_rank": _ent.tier_rank(tier_in),
+                "target": target,
+                "target_label": _ent.tier_label(target) if target else None,
+                "target_rank": _ent.tier_rank(target) if target else None,
+                "row": row,
+            }
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_next_tier_capacity_diff_at: error: %s", exc
+        )
+        return jsonify(
+            {
+                "tier": tier_in,
+                "tier_label": None,
+                "tier_rank": -1,
+                "target": None,
+                "target_label": None,
+                "target_rank": None,
+                "row": None,
+            }
+        )
+
+
+@bp_entitlement.route("/api/entitlement/previous-tier-capacity-diff-at")
+def api_entitlement_previous_tier_capacity_diff_at():
+    """``GET /api/entitlement/previous-tier-capacity-diff-at?tier=<source>``
+    -- scalar what-if sibling of the live
+    ``Entitlement.previous_tier_capacity_diff``: per-axis capacity
+    transition from the caller-supplied ``tier`` to the rung below it.
+
+    Source-anchored downgrade-side mirror of
+    ``/api/entitlement/next-tier-capacity-diff-at`` and capacity-only
+    narrow lens of ``/api/entitlement/previous-tier-diff-at``. Lets a
+    downgrade-confirmation tooltip render the step-down capacity
+    delta for any hypothetical source rung off **one** round-trip.
+
+    Response shape::
+
+        {
+          "tier":           "<source tier id>",
+          "tier_label":     "<source label>",
+          "tier_rank":      <source rank>,
+          "target":         "<rung-below tier id>" | null,
+          "target_label":   "<rung-below label>" | null,
+          "target_rank":    <rung-below rank> | null,
+          "row":            {<capacity_diff_at row>} | null,
+        }
+
+    ``row`` is byte-equal to
+    ``/api/entitlement/previous-tier-diff-at?tier=<source>``'s
+    ``row.capacity_changes`` for the same source (modulo the outer
+    :func:`_capacity_row` ``target`` key the diff row does not carry).
+
+    Accepts any tier id in :data:`entitlements._TIER_ORDER` (including
+    ``trial``), matching the other ``_at`` family endpoints. ``target``
+    / ``row`` collapse to ``null`` at the floor (no rung strictly
+    below the source -- oss / cloud_free) -- the surface stays 200
+    with a populated envelope so callers can render "you're at the
+    bottom" copy without a status-code branch.
+
+    - **400** when ``tier=`` is missing / blank
+    - **404** when ``tier`` is unknown. The body carries ``which`` so a
+      caller can render the right "unknown ..." message.
+    - **Never 5xxs**: builder failure short-circuits to ``row=null``
+      on the same 200 envelope so the tooltip surface stays mute.
+    """
+    raw_tier = request.args.get("tier")
+    tier_in = (raw_tier or "").strip().lower()
+    if not tier_in:
+        return jsonify({"error": "missing tier"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        if tier_in not in _ent._TIER_ORDER:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "tier", "tier": tier_in}
+                ),
+                404,
+            )
+        target = _ent._previous_purchasable_tier_before(tier_in)
+        row = _ent.previous_tier_capacity_diff_at(tier_in)
+        return jsonify(
+            {
+                "tier": tier_in,
+                "tier_label": _ent.tier_label(tier_in),
+                "tier_rank": _ent.tier_rank(tier_in),
+                "target": target,
+                "target_label": _ent.tier_label(target) if target else None,
+                "target_rank": _ent.tier_rank(target) if target else None,
+                "row": row,
+            }
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_previous_tier_capacity_diff_at: error: %s", exc
+        )
+        return jsonify(
+            {
+                "tier": tier_in,
+                "tier_label": None,
+                "tier_rank": -1,
+                "target": None,
+                "target_label": None,
+                "target_rank": None,
+                "row": None,
+            }
+        )
+
+
+@bp_entitlement.route("/api/entitlement/next-tier-capacity-diff-at-batch")
+def api_entitlement_next_tier_capacity_diff_at_batch():
+    """``GET /api/entitlement/next-tier-capacity-diff-at-batch`` --
+    batch sibling of ``/api/entitlement/next-tier-capacity-diff-at``:
+    one ``next-tier-capacity-diff-at`` envelope per purchasable source
+    tier, in one round-trip.
+
+    Capacity-only narrow lens of
+    ``/api/entitlement/next-tier-diff-at-batch``. Lets a pricing-
+    comparison matrix UI render the "capacity at the rung above each
+    rung" upgrade-tooltip column off **one** call instead of N calls
+    to ``/next-tier-capacity-diff-at``.
+
+    No query params. The source list is :data:`entitlements._PURCHASABLE_TIERS`
+    (trial excluded), matching the live ``/tier-diff-batch`` endpoint
+    and the sibling diff / unlocks / locks ``_at_batch`` endpoints, so
+    the four batches fold into the same pricing-page table byte-for-
+    byte on the source axis.
+
+    Response shape::
+
+        {
+          "tiers":             [<envelope>, ...],
+          "current_tier":      "<resolved tier id>",
+          "current_tier_rank": <int>,
+          "grace":             <bool>,
+          "enforced":          <bool>,
+        }
+
+    Each ``<envelope>`` matches
+    ``/api/entitlement/next-tier-capacity-diff-at?tier=<source>`` for
+    that source exactly (``tier``, ``tier_label``, ``tier_rank``,
+    ``target``, ``target_label``, ``target_rank``, ``row``). The
+    ``row`` carries the :func:`capacity_diff_at` row pinned on both
+    endpoints. At the source-side ceiling (``enterprise`` as source --
+    no rung strictly above) the envelope carries ``target=null`` and
+    ``row=null`` rather than being dropped, so the matrix keeps a row
+    for every purchasable rung.
+
+    - **Never 5xxs**: a resolver failure yields an empty ``tiers``
+      list and the grace-shape envelope so the matrix keeps rendering.
+    """
+    try:
+        from clawmetry import entitlements as _ent
+
+        rows = _ent.next_tier_capacity_diff_at_batch() or []
+        ent = _ent.get_entitlement()
+        return jsonify(
+            {
+                "tiers": rows,
+                "current_tier": ent.tier,
+                "current_tier_rank": _ent.tier_rank(ent.tier),
+                "grace": bool(ent.grace),
+                "enforced": _ent.is_enforced(),
+            }
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_next_tier_capacity_diff_at_batch: error: %s", exc
+        )
+        return jsonify(
+            {
+                "tiers": [],
+                "current_tier": "oss",
+                "current_tier_rank": 0,
+                "grace": True,
+                "enforced": False,
+            }
+        )
+
+
+@bp_entitlement.route("/api/entitlement/previous-tier-capacity-diff-at-batch")
+def api_entitlement_previous_tier_capacity_diff_at_batch():
+    """``GET /api/entitlement/previous-tier-capacity-diff-at-batch`` --
+    batch sibling of ``/api/entitlement/previous-tier-capacity-diff-at``:
+    one ``previous-tier-capacity-diff-at`` envelope per purchasable
+    source tier, in one round-trip.
+
+    Source-anchored downgrade-side mirror of
+    ``/api/entitlement/next-tier-capacity-diff-at-batch`` and capacity-
+    only narrow lens of
+    ``/api/entitlement/previous-tier-diff-at-batch``. Lets a pricing-
+    comparison matrix UI render the "capacity at the rung below each
+    rung" downgrade-tooltip column off **one** call instead of N calls
+    to ``/previous-tier-capacity-diff-at``.
+
+    No query params. The source list is :data:`entitlements._PURCHASABLE_TIERS`
+    (trial excluded), matching the live ``/tier-diff-batch`` endpoint
+    and the sibling diff / unlocks / locks ``_at_batch`` endpoints.
+
+    Response shape::
+
+        {
+          "tiers":             [<envelope>, ...],
+          "current_tier":      "<resolved tier id>",
+          "current_tier_rank": <int>,
+          "grace":             <bool>,
+          "enforced":          <bool>,
+        }
+
+    Each ``<envelope>`` matches
+    ``/api/entitlement/previous-tier-capacity-diff-at?tier=<source>``
+    for that source exactly. At the source-side floor (``oss`` /
+    ``cloud_free`` as source -- no rung strictly below) the envelope
+    carries ``target=null`` and ``row=null`` rather than being
+    dropped, so the matrix keeps a row for every purchasable rung.
+
+    - **Never 5xxs**: a resolver failure yields an empty ``tiers``
+      list and the grace-shape envelope so the matrix keeps rendering.
+    """
+    try:
+        from clawmetry import entitlements as _ent
+
+        rows = _ent.previous_tier_capacity_diff_at_batch() or []
+        ent = _ent.get_entitlement()
+        return jsonify(
+            {
+                "tiers": rows,
+                "current_tier": ent.tier,
+                "current_tier_rank": _ent.tier_rank(ent.tier),
+                "grace": bool(ent.grace),
+                "enforced": _ent.is_enforced(),
+            }
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_previous_tier_capacity_diff_at_batch: error: %s",
+            exc,
+        )
+        return jsonify(
+            {
+                "tiers": [],
+                "current_tier": "oss",
+                "current_tier_rank": 0,
+                "grace": True,
+                "enforced": False,
+            }
+        )

--- a/tests/test_entitlement_next_prev_tier_capacity_diff_at.py
+++ b/tests/test_entitlement_next_prev_tier_capacity_diff_at.py
@@ -1,0 +1,828 @@
+"""Tests for ``next_tier_capacity_diff_at`` /
+``previous_tier_capacity_diff_at`` (scalar what-ifs) and their
+``_at_batch`` siblings, plus the companion
+``/api/entitlement/{next,previous}-tier-capacity-diff-at[-batch]``
+endpoints and the private :func:`_capacity_diff_at_envelope` builder
+the batches share.
+
+Capacity-only narrow lens of the
+``{next,previous}_tier_diff_at[_batch]`` family that landed in
+#3359 / #3361: where those helpers return the full :func:`tier_diff`
+payload (``added_*`` + ``lost_*`` + ``capacity_changes`` +
+``direction``) for each ``source -> next/prev-of-source`` pair, these
+helpers return only the capacity slice (the
+``{target, channel_limit, retention_days, node_limit}`` shape
+:func:`capacity_diff_at` publishes) so a capacity-only tooltip on a
+pricing-comparison cell can render the upgrade- / downgrade-side
+capacity delta for any hypothetical source rung off **one** round-trip,
+without first hitting ``/api/entitlement`` and without monkey-patching
+the entitlement context.
+
+Pins covered here:
+
+* ``next_tier_capacity_diff_at(tier)`` byte-equals
+  ``capacity_diff_at(tier, _next_purchasable_tier_after(tier))`` across
+  every valid source -- the convenience cannot drift from the explicit
+  composition
+* same identity for ``previous_tier_capacity_diff_at`` against
+  ``_previous_purchasable_tier_before``
+* at the ceiling / floor (no rung strictly above / below source) both
+  scalar helpers return ``None``
+* trial-as-source resolves the same way the diff ``_at`` family does:
+  next -> enterprise, previous -> cloud_starter
+* unknown / empty / ``None`` / non-string source returns ``None``
+* grace vs enforce yields the same body (the ``_at`` family walks the
+  static catalogue, not the gated resolver)
+* :func:`_capacity_diff_at_envelope` composes source / target metadata
+  with the per-pair :func:`capacity_diff_at` row in the same envelope
+  shape :func:`_diff_at_envelope` publishes -- ``tier``, ``tier_label``,
+  ``tier_rank``, ``target``, ``target_label``, ``target_rank``, ``row``
+* both batches return one envelope per entry in
+  :data:`_PURCHASABLE_TIERS`, sorted by ``(tier_rank, tier_id)``
+* every batch envelope byte-equals the scalar endpoint body for the
+  same source -- the batch-vs-scalar parity that stops the batch
+  what-if drifting from the scalar what-if
+* per-slice parity with the full ``_at_batch`` diff siblings: each
+  envelope's ``row`` capacity-axis triples byte-equal the corresponding
+  diff batch envelope's ``row.capacity_changes`` slot for the same
+  source, so the four ``_at_batch`` surfaces (diff / unlocks / locks /
+  capacity) never silently desync
+* at the source-side ceiling (``enterprise`` for next) / floor
+  (``oss`` / ``cloud_free`` for previous) the envelope carries
+  ``target=null`` and ``row=null`` rather than being dropped
+* trial is excluded from the source axis (mirrors the diff batch)
+* the helpers never raise: a per-source builder failure collapses to
+  ``row=null`` on the populated envelope; a top-level failure
+  short-circuits to ``[]``
+* the API endpoints never 5xx: a resolver failure yields an empty
+  ``tiers`` list and a grace-shape envelope; scalar endpoints 400 on
+  missing input, 404 on unknown ids, and 200 with ``row=null`` at the
+  ceiling / floor
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+_CAPACITY_ROW_KEYS = {
+    "target",
+    "channel_limit",
+    "retention_days",
+    "node_limit",
+}
+
+_AXIS_KEYS = {"before", "after", "delta", "unlocked", "locked"}
+
+_ENVELOPE_KEYS = {
+    "tier",
+    "tier_label",
+    "tier_rank",
+    "target",
+    "target_label",
+    "target_rank",
+    "row",
+}
+
+_BATCH_RESPONSE_KEYS = {
+    "tiers",
+    "current_tier",
+    "current_tier_rank",
+    "grace",
+    "enforced",
+}
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    """Fresh entitlements module with HOME pointed at an empty tmp dir
+    so no real ~/.clawmetry/license.key or cloud_plan.json leaks in.
+    Enforcement off by default (grace mode) -- the capacity-diff ``_at``
+    family is catalogue-derived and independent of the resolver, so the
+    fixture only needs to keep the live resolver from surprising the
+    test."""
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# ── next_tier_capacity_diff_at ───────────────────────────────────────────────
+
+
+def test_next_capacity_at_matches_explicit_composition(ent):
+    for src in (
+        ent.TIER_OSS,
+        ent.TIER_CLOUD_FREE,
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_PRO,
+        ent.TIER_TRIAL,
+    ):
+        nxt = ent._next_purchasable_tier_after(src)
+        assert nxt is not None, src
+        assert ent.next_tier_capacity_diff_at(src) == ent.capacity_diff_at(
+            src, nxt
+        ), src
+
+
+def test_next_capacity_at_returns_none_at_ceiling(ent):
+    assert ent.next_tier_capacity_diff_at(ent.TIER_ENTERPRISE) is None
+
+
+def test_next_capacity_at_row_shape(ent):
+    body = ent.next_tier_capacity_diff_at(ent.TIER_OSS)
+    assert body is not None
+    assert set(body.keys()) == _CAPACITY_ROW_KEYS
+    assert body["target"] == ent.TIER_CLOUD_STARTER
+    for axis in ("channel_limit", "retention_days", "node_limit"):
+        assert set(body[axis].keys()) == _AXIS_KEYS
+
+
+@pytest.mark.parametrize("bad", ["", "  ", None, 0, 1.5, "BOGUS", "bogus"])
+def test_next_capacity_at_returns_none_on_bad_input(ent, bad):
+    assert ent.next_tier_capacity_diff_at(bad) is None
+
+
+def test_next_capacity_at_trims_and_lowercases(ent):
+    assert ent.next_tier_capacity_diff_at(
+        "  OSS  "
+    ) == ent.capacity_diff_at(ent.TIER_OSS, ent.TIER_CLOUD_STARTER)
+
+
+def test_next_capacity_at_trial_source_resolves_to_enterprise(ent):
+    body = ent.next_tier_capacity_diff_at(ent.TIER_TRIAL)
+    assert body is not None
+    assert body["target"] == ent.TIER_ENTERPRISE
+
+
+def test_next_capacity_at_grace_and_enforce_match(ent, monkeypatch):
+    grace = ent.next_tier_capacity_diff_at(ent.TIER_CLOUD_STARTER)
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    importlib.reload(ent)
+    ent.invalidate()
+    enforce = ent.next_tier_capacity_diff_at(ent.TIER_CLOUD_STARTER)
+    assert enforce == grace
+
+
+def test_next_capacity_at_never_raises(ent, monkeypatch):
+    monkeypatch.setattr(
+        ent,
+        "capacity_diff_at",
+        lambda *_: (_ for _ in ()).throw(RuntimeError("synthetic")),
+    )
+    assert ent.next_tier_capacity_diff_at(ent.TIER_OSS) is None
+
+
+def test_next_capacity_at_independent_of_resolver(ent, monkeypatch):
+    def boom(*_, **__):
+        raise RuntimeError("resolver must not be reached")
+
+    monkeypatch.setattr(ent, "get_entitlement", boom)
+    body = ent.next_tier_capacity_diff_at(ent.TIER_OSS)
+    assert body is not None
+    assert body["target"] == ent.TIER_CLOUD_STARTER
+
+
+def test_next_capacity_at_matches_diff_capacity_changes(ent):
+    # The capacity slice MUST byte-equal the matching axis triples from
+    # the full diff for the same source/target pair -- otherwise a UI
+    # consuming both surfaces will render inconsistent capacity
+    # numbers. Pinned to stop a drift between the two helpers.
+    for src in (
+        ent.TIER_OSS,
+        ent.TIER_CLOUD_FREE,
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_PRO,
+        ent.TIER_TRIAL,
+    ):
+        cap = ent.next_tier_capacity_diff_at(src)
+        diff = ent.next_tier_diff_at(src)
+        assert cap is not None and diff is not None, src
+        for axis in ("channel_limit", "retention_days", "node_limit"):
+            assert cap[axis] == diff["capacity_changes"][axis], (src, axis)
+
+
+# ── previous_tier_capacity_diff_at ───────────────────────────────────────────
+
+
+def test_prev_capacity_at_matches_explicit_composition(ent):
+    for src in (
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_PRO,
+        ent.TIER_ENTERPRISE,
+        ent.TIER_TRIAL,
+    ):
+        prv = ent._previous_purchasable_tier_before(src)
+        assert prv is not None, src
+        assert ent.previous_tier_capacity_diff_at(src) == ent.capacity_diff_at(
+            src, prv
+        ), src
+
+
+def test_prev_capacity_at_returns_none_at_floor(ent):
+    assert ent.previous_tier_capacity_diff_at(ent.TIER_OSS) is None
+    assert ent.previous_tier_capacity_diff_at(ent.TIER_CLOUD_FREE) is None
+
+
+def test_prev_capacity_at_row_shape(ent):
+    body = ent.previous_tier_capacity_diff_at(ent.TIER_ENTERPRISE)
+    assert body is not None
+    assert set(body.keys()) == _CAPACITY_ROW_KEYS
+    assert body["target"] == ent.TIER_CLOUD_PRO
+    for axis in ("channel_limit", "retention_days", "node_limit"):
+        assert set(body[axis].keys()) == _AXIS_KEYS
+
+
+@pytest.mark.parametrize("bad", ["", "  ", None, 0, 1.5, "BOGUS", "bogus"])
+def test_prev_capacity_at_returns_none_on_bad_input(ent, bad):
+    assert ent.previous_tier_capacity_diff_at(bad) is None
+
+
+def test_prev_capacity_at_trims_and_lowercases(ent):
+    assert ent.previous_tier_capacity_diff_at(
+        "  CLOUD_STARTER  "
+    ) == ent.capacity_diff_at(ent.TIER_CLOUD_STARTER, ent.TIER_OSS)
+
+
+def test_prev_capacity_at_trial_source_resolves_to_cloud_starter(ent):
+    body = ent.previous_tier_capacity_diff_at(ent.TIER_TRIAL)
+    assert body is not None
+    assert body["target"] == ent.TIER_CLOUD_STARTER
+
+
+def test_prev_capacity_at_grace_and_enforce_match(ent, monkeypatch):
+    grace = ent.previous_tier_capacity_diff_at(ent.TIER_CLOUD_PRO)
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    importlib.reload(ent)
+    ent.invalidate()
+    enforce = ent.previous_tier_capacity_diff_at(ent.TIER_CLOUD_PRO)
+    assert enforce == grace
+
+
+def test_prev_capacity_at_never_raises(ent, monkeypatch):
+    monkeypatch.setattr(
+        ent,
+        "capacity_diff_at",
+        lambda *_: (_ for _ in ()).throw(RuntimeError("synthetic")),
+    )
+    assert ent.previous_tier_capacity_diff_at(ent.TIER_ENTERPRISE) is None
+
+
+def test_prev_capacity_at_independent_of_resolver(ent, monkeypatch):
+    def boom(*_, **__):
+        raise RuntimeError("resolver must not be reached")
+
+    monkeypatch.setattr(ent, "get_entitlement", boom)
+    body = ent.previous_tier_capacity_diff_at(ent.TIER_ENTERPRISE)
+    assert body is not None
+    assert body["target"] == ent.TIER_CLOUD_PRO
+
+
+def test_prev_capacity_at_matches_diff_capacity_changes(ent):
+    for src in (
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_PRO,
+        ent.TIER_ENTERPRISE,
+        ent.TIER_TRIAL,
+    ):
+        cap = ent.previous_tier_capacity_diff_at(src)
+        diff = ent.previous_tier_diff_at(src)
+        assert cap is not None and diff is not None, src
+        for axis in ("channel_limit", "retention_days", "node_limit"):
+            assert cap[axis] == diff["capacity_changes"][axis], (src, axis)
+
+
+# ── _capacity_diff_at_envelope ───────────────────────────────────────────────
+
+
+def test_capacity_envelope_shape_for_known_pair(ent):
+    env = ent._capacity_diff_at_envelope(ent.TIER_OSS, ent.TIER_CLOUD_STARTER)
+    assert set(env.keys()) == _ENVELOPE_KEYS
+    assert env["tier"] == ent.TIER_OSS
+    assert env["tier_label"] == ent.tier_label(ent.TIER_OSS)
+    assert env["tier_rank"] == ent.tier_rank(ent.TIER_OSS)
+    assert env["target"] == ent.TIER_CLOUD_STARTER
+    assert env["target_label"] == ent.tier_label(ent.TIER_CLOUD_STARTER)
+    assert env["target_rank"] == ent.tier_rank(ent.TIER_CLOUD_STARTER)
+    assert env["row"] == ent.capacity_diff_at(
+        ent.TIER_OSS, ent.TIER_CLOUD_STARTER
+    )
+
+
+def test_capacity_envelope_none_target_collapses_row(ent):
+    env = ent._capacity_diff_at_envelope(ent.TIER_ENTERPRISE, None)
+    assert env["tier"] == ent.TIER_ENTERPRISE
+    assert env["tier_label"] == ent.tier_label(ent.TIER_ENTERPRISE)
+    assert env["target"] is None
+    assert env["target_label"] is None
+    assert env["target_rank"] is None
+    assert env["row"] is None
+
+
+def test_capacity_envelope_unknown_source_keeps_envelope_populated(ent):
+    env = ent._capacity_diff_at_envelope("bogus", ent.TIER_CLOUD_STARTER)
+    assert set(env.keys()) == _ENVELOPE_KEYS
+    # capacity_diff_at returns None on unknown source -- the envelope
+    # surfaces row=None but keeps target metadata so the batch row
+    # stays visible.
+    assert env["tier_label"] is None
+    assert env["tier_rank"] == -1
+    assert env["target"] == ent.TIER_CLOUD_STARTER
+    assert env["row"] is None
+
+
+def test_capacity_envelope_trims_and_lowercases(ent):
+    env = ent._capacity_diff_at_envelope("  OSS  ", ent.TIER_CLOUD_STARTER)
+    assert env["tier"] == ent.TIER_OSS
+    assert env["target"] == ent.TIER_CLOUD_STARTER
+    assert env["row"] == ent.capacity_diff_at(
+        ent.TIER_OSS, ent.TIER_CLOUD_STARTER
+    )
+
+
+def test_capacity_envelope_swallows_builder_exception(ent, monkeypatch):
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "capacity_diff_at", boom)
+    env = ent._capacity_diff_at_envelope(ent.TIER_OSS, ent.TIER_CLOUD_STARTER)
+    assert env["target"] == ent.TIER_CLOUD_STARTER
+    assert env["row"] is None
+
+
+# ── next_tier_capacity_diff_at_batch ─────────────────────────────────────────
+
+
+def test_next_capacity_batch_returns_list_for_every_purchasable_source(ent):
+    rows = ent.next_tier_capacity_diff_at_batch()
+    assert isinstance(rows, list)
+    assert len(rows) == len(ent._PURCHASABLE_TIERS)
+
+
+def test_next_capacity_batch_each_envelope_has_envelope_shape(ent):
+    for env in ent.next_tier_capacity_diff_at_batch():
+        assert set(env.keys()) == _ENVELOPE_KEYS
+
+
+def test_next_capacity_batch_source_axis_matches_purchasable(ent):
+    rows = ent.next_tier_capacity_diff_at_batch()
+    sources = {env["tier"] for env in rows}
+    assert sources == set(ent._PURCHASABLE_TIERS)
+
+
+def test_next_capacity_batch_excludes_trial_from_sources(ent):
+    sources = {env["tier"] for env in ent.next_tier_capacity_diff_at_batch()}
+    assert ent.TIER_TRIAL not in sources
+
+
+def test_next_capacity_batch_sorted_by_rank_then_id(ent):
+    rows = ent.next_tier_capacity_diff_at_batch()
+    keys = [(env["tier_rank"], env["tier"]) for env in rows]
+    assert keys == sorted(keys)
+
+
+def test_next_capacity_batch_enterprise_source_ceiling_collapses(ent):
+    rows = ent.next_tier_capacity_diff_at_batch()
+    ent_row = next(env for env in rows if env["tier"] == ent.TIER_ENTERPRISE)
+    assert ent_row["target"] is None
+    assert ent_row["target_label"] is None
+    assert ent_row["target_rank"] is None
+    assert ent_row["row"] is None
+
+
+def test_next_capacity_batch_populated_rows_have_capacity_row_shape(ent):
+    for env in ent.next_tier_capacity_diff_at_batch():
+        if env["row"] is None:
+            continue
+        assert set(env["row"].keys()) == _CAPACITY_ROW_KEYS
+        # row.target is byte-equal to envelope.target on every
+        # populated row -- the same pin the diff batch's row.from
+        # holds against envelope.tier.
+        assert env["row"]["target"] == env["target"]
+
+
+def test_next_capacity_batch_matches_scalar_helper_per_source(ent):
+    for env in ent.next_tier_capacity_diff_at_batch():
+        assert env["row"] == ent.next_tier_capacity_diff_at(env["tier"])
+
+
+def test_next_capacity_batch_matches_diff_batch_capacity_changes(ent):
+    # The capacity batch row's per-axis triples MUST byte-equal the
+    # diff batch row's ``capacity_changes`` slot for the same source --
+    # the cross-surface invariant that stops the two ``_at_batch``
+    # surfaces from silently disagreeing on the same pair.
+    cap = {env["tier"]: env for env in ent.next_tier_capacity_diff_at_batch()}
+    diff = {env["tier"]: env for env in ent.next_tier_diff_at_batch()}
+    assert set(cap.keys()) == set(diff.keys())
+    for tier in cap:
+        c = cap[tier]["row"]
+        d = diff[tier]["row"]
+        if c is None:
+            assert d is None
+            continue
+        for axis in ("channel_limit", "retention_days", "node_limit"):
+            assert c[axis] == d["capacity_changes"][axis], (tier, axis)
+
+
+def test_next_capacity_batch_grace_and_enforce_match(ent, monkeypatch):
+    grace = ent.next_tier_capacity_diff_at_batch()
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    importlib.reload(ent)
+    ent.invalidate()
+    enforce = ent.next_tier_capacity_diff_at_batch()
+    assert enforce == grace
+
+
+def test_next_capacity_batch_top_level_failure_short_circuits_to_empty(
+    ent, monkeypatch
+):
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "_PURCHASABLE_TIERS", boom)
+    assert ent.next_tier_capacity_diff_at_batch() == []
+
+
+def test_next_capacity_batch_per_row_failure_collapses_to_row_null(
+    ent, monkeypatch
+):
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "capacity_diff_at", boom)
+    rows = ent.next_tier_capacity_diff_at_batch()
+    assert rows
+    for env in rows:
+        assert set(env.keys()) == _ENVELOPE_KEYS
+        assert env["row"] is None
+
+
+def test_next_capacity_batch_independent_of_resolver(ent, monkeypatch):
+    def boom(*_, **__):
+        raise RuntimeError("resolver must not be reached")
+
+    monkeypatch.setattr(ent, "get_entitlement", boom)
+    rows = ent.next_tier_capacity_diff_at_batch()
+    assert len(rows) == len(ent._PURCHASABLE_TIERS)
+
+
+# ── previous_tier_capacity_diff_at_batch ─────────────────────────────────────
+
+
+def test_prev_capacity_batch_returns_list_for_every_purchasable_source(ent):
+    rows = ent.previous_tier_capacity_diff_at_batch()
+    assert isinstance(rows, list)
+    assert len(rows) == len(ent._PURCHASABLE_TIERS)
+
+
+def test_prev_capacity_batch_each_envelope_has_envelope_shape(ent):
+    for env in ent.previous_tier_capacity_diff_at_batch():
+        assert set(env.keys()) == _ENVELOPE_KEYS
+
+
+def test_prev_capacity_batch_source_axis_matches_purchasable(ent):
+    rows = ent.previous_tier_capacity_diff_at_batch()
+    sources = {env["tier"] for env in rows}
+    assert sources == set(ent._PURCHASABLE_TIERS)
+
+
+def test_prev_capacity_batch_excludes_trial_from_sources(ent):
+    sources = {
+        env["tier"] for env in ent.previous_tier_capacity_diff_at_batch()
+    }
+    assert ent.TIER_TRIAL not in sources
+
+
+def test_prev_capacity_batch_sorted_by_rank_then_id(ent):
+    rows = ent.previous_tier_capacity_diff_at_batch()
+    keys = [(env["tier_rank"], env["tier"]) for env in rows]
+    assert keys == sorted(keys)
+
+
+def test_prev_capacity_batch_floor_sources_collapse(ent):
+    rows = {env["tier"]: env for env in ent.previous_tier_capacity_diff_at_batch()}
+    for floor in (ent.TIER_OSS, ent.TIER_CLOUD_FREE):
+        env = rows[floor]
+        assert env["target"] is None
+        assert env["target_label"] is None
+        assert env["target_rank"] is None
+        assert env["row"] is None
+
+
+def test_prev_capacity_batch_populated_rows_have_capacity_row_shape(ent):
+    for env in ent.previous_tier_capacity_diff_at_batch():
+        if env["row"] is None:
+            continue
+        assert set(env["row"].keys()) == _CAPACITY_ROW_KEYS
+        assert env["row"]["target"] == env["target"]
+
+
+def test_prev_capacity_batch_matches_scalar_helper_per_source(ent):
+    for env in ent.previous_tier_capacity_diff_at_batch():
+        assert env["row"] == ent.previous_tier_capacity_diff_at(env["tier"])
+
+
+def test_prev_capacity_batch_matches_diff_batch_capacity_changes(ent):
+    cap = {
+        env["tier"]: env for env in ent.previous_tier_capacity_diff_at_batch()
+    }
+    diff = {env["tier"]: env for env in ent.previous_tier_diff_at_batch()}
+    assert set(cap.keys()) == set(diff.keys())
+    for tier in cap:
+        c = cap[tier]["row"]
+        d = diff[tier]["row"]
+        if c is None:
+            assert d is None
+            continue
+        for axis in ("channel_limit", "retention_days", "node_limit"):
+            assert c[axis] == d["capacity_changes"][axis], (tier, axis)
+
+
+def test_prev_capacity_batch_grace_and_enforce_match(ent, monkeypatch):
+    grace = ent.previous_tier_capacity_diff_at_batch()
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    importlib.reload(ent)
+    ent.invalidate()
+    enforce = ent.previous_tier_capacity_diff_at_batch()
+    assert enforce == grace
+
+
+def test_prev_capacity_batch_top_level_failure_short_circuits_to_empty(
+    ent, monkeypatch
+):
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "_PURCHASABLE_TIERS", boom)
+    assert ent.previous_tier_capacity_diff_at_batch() == []
+
+
+def test_prev_capacity_batch_per_row_failure_collapses_to_row_null(
+    ent, monkeypatch
+):
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "capacity_diff_at", boom)
+    rows = ent.previous_tier_capacity_diff_at_batch()
+    assert rows
+    for env in rows:
+        assert set(env.keys()) == _ENVELOPE_KEYS
+        assert env["row"] is None
+
+
+def test_prev_capacity_batch_independent_of_resolver(ent, monkeypatch):
+    def boom(*_, **__):
+        raise RuntimeError("resolver must not be reached")
+
+    monkeypatch.setattr(ent, "get_entitlement", boom)
+    rows = ent.previous_tier_capacity_diff_at_batch()
+    assert len(rows) == len(ent._PURCHASABLE_TIERS)
+
+
+# ── API: /api/entitlement/next-tier-capacity-diff-at ─────────────────────────
+
+
+def test_next_capacity_at_endpoint_returns_envelope(client, ent):
+    rv = client.get(
+        f"/api/entitlement/next-tier-capacity-diff-at?tier={ent.TIER_OSS}"
+    )
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert set(body.keys()) == _ENVELOPE_KEYS
+    assert body["tier"] == ent.TIER_OSS
+    assert body["target"] == ent.TIER_CLOUD_STARTER
+    assert body["row"] == ent.next_tier_capacity_diff_at(ent.TIER_OSS)
+
+
+def test_next_capacity_at_endpoint_missing_tier_400(client):
+    rv = client.get("/api/entitlement/next-tier-capacity-diff-at")
+    assert rv.status_code == 400
+    assert rv.get_json() == {"error": "missing tier"}
+
+
+def test_next_capacity_at_endpoint_unknown_tier_404(client):
+    rv = client.get(
+        "/api/entitlement/next-tier-capacity-diff-at?tier=bogus"
+    )
+    assert rv.status_code == 404
+    body = rv.get_json()
+    assert body["error"] == "unknown tier"
+    assert body["which"] == "tier"
+    assert body["tier"] == "bogus"
+
+
+def test_next_capacity_at_endpoint_ceiling_surfaces_null_target(client, ent):
+    rv = client.get(
+        f"/api/entitlement/next-tier-capacity-diff-at?tier={ent.TIER_ENTERPRISE}"
+    )
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["tier"] == ent.TIER_ENTERPRISE
+    assert body["target"] is None
+    assert body["target_label"] is None
+    assert body["target_rank"] is None
+    assert body["row"] is None
+
+
+def test_next_capacity_at_endpoint_trims_and_lowercases(client, ent):
+    rv = client.get(
+        "/api/entitlement/next-tier-capacity-diff-at?tier=%20%20OSS%20%20"
+    )
+    assert rv.status_code == 200
+    assert rv.get_json()["tier"] == ent.TIER_OSS
+
+
+def test_next_capacity_at_endpoint_never_raises(client, ent, monkeypatch):
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "next_tier_capacity_diff_at", boom)
+    rv = client.get(
+        f"/api/entitlement/next-tier-capacity-diff-at?tier={ent.TIER_OSS}"
+    )
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["tier"] == ent.TIER_OSS
+    assert body["row"] is None
+
+
+# ── API: /api/entitlement/previous-tier-capacity-diff-at ─────────────────────
+
+
+def test_prev_capacity_at_endpoint_returns_envelope(client, ent):
+    rv = client.get(
+        f"/api/entitlement/previous-tier-capacity-diff-at?tier={ent.TIER_ENTERPRISE}"
+    )
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert set(body.keys()) == _ENVELOPE_KEYS
+    assert body["tier"] == ent.TIER_ENTERPRISE
+    assert body["target"] == ent.TIER_CLOUD_PRO
+    assert body["row"] == ent.previous_tier_capacity_diff_at(
+        ent.TIER_ENTERPRISE
+    )
+
+
+def test_prev_capacity_at_endpoint_missing_tier_400(client):
+    rv = client.get("/api/entitlement/previous-tier-capacity-diff-at")
+    assert rv.status_code == 400
+
+
+def test_prev_capacity_at_endpoint_unknown_tier_404(client):
+    rv = client.get(
+        "/api/entitlement/previous-tier-capacity-diff-at?tier=bogus"
+    )
+    assert rv.status_code == 404
+
+
+def test_prev_capacity_at_endpoint_floor_surfaces_null_target(client, ent):
+    rv = client.get(
+        f"/api/entitlement/previous-tier-capacity-diff-at?tier={ent.TIER_OSS}"
+    )
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["tier"] == ent.TIER_OSS
+    assert body["target"] is None
+    assert body["row"] is None
+
+
+def test_prev_capacity_at_endpoint_never_raises(client, ent, monkeypatch):
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "previous_tier_capacity_diff_at", boom)
+    rv = client.get(
+        f"/api/entitlement/previous-tier-capacity-diff-at?tier={ent.TIER_ENTERPRISE}"
+    )
+    assert rv.status_code == 200
+    assert rv.get_json()["row"] is None
+
+
+# ── API: /api/entitlement/next-tier-capacity-diff-at-batch ───────────────────
+
+
+def test_next_capacity_batch_endpoint_returns_envelopes(client, ent):
+    rv = client.get("/api/entitlement/next-tier-capacity-diff-at-batch")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert set(body.keys()) == _BATCH_RESPONSE_KEYS
+    assert isinstance(body["tiers"], list)
+    assert len(body["tiers"]) == len(ent._PURCHASABLE_TIERS)
+    for env in body["tiers"]:
+        assert set(env.keys()) == _ENVELOPE_KEYS
+
+
+def test_next_capacity_batch_endpoint_resolver_context(client, ent):
+    rv = client.get("/api/entitlement/next-tier-capacity-diff-at-batch")
+    body = rv.get_json()
+    resolved = ent.get_entitlement()
+    assert body["current_tier"] == resolved.tier
+    assert body["current_tier_rank"] == ent.tier_rank(resolved.tier)
+    assert body["grace"] == bool(resolved.grace)
+    assert body["enforced"] == ent.is_enforced()
+
+
+def test_next_capacity_batch_endpoint_matches_helper(client, ent):
+    rv = client.get("/api/entitlement/next-tier-capacity-diff-at-batch")
+    assert rv.get_json()["tiers"] == ent.next_tier_capacity_diff_at_batch()
+
+
+def test_next_capacity_batch_endpoint_matches_scalar_per_source(client, ent):
+    batch = client.get(
+        "/api/entitlement/next-tier-capacity-diff-at-batch"
+    ).get_json()["tiers"]
+    by_tier = {env["tier"]: env for env in batch}
+    for src in ent._PURCHASABLE_TIERS:
+        scalar = client.get(
+            f"/api/entitlement/next-tier-capacity-diff-at?tier={src}"
+        ).get_json()
+        assert by_tier[src] == scalar
+
+
+def test_next_capacity_batch_endpoint_never_raises(client, ent, monkeypatch):
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "next_tier_capacity_diff_at_batch", boom)
+    rv = client.get("/api/entitlement/next-tier-capacity-diff-at-batch")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["tiers"] == []
+    assert body["current_tier"] == "oss"
+    assert body["current_tier_rank"] == 0
+    assert body["grace"] is True
+    assert body["enforced"] is False
+
+
+# ── API: /api/entitlement/previous-tier-capacity-diff-at-batch ───────────────
+
+
+def test_prev_capacity_batch_endpoint_returns_envelopes(client, ent):
+    rv = client.get("/api/entitlement/previous-tier-capacity-diff-at-batch")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert set(body.keys()) == _BATCH_RESPONSE_KEYS
+    assert isinstance(body["tiers"], list)
+    assert len(body["tiers"]) == len(ent._PURCHASABLE_TIERS)
+
+
+def test_prev_capacity_batch_endpoint_resolver_context(client, ent):
+    rv = client.get("/api/entitlement/previous-tier-capacity-diff-at-batch")
+    body = rv.get_json()
+    resolved = ent.get_entitlement()
+    assert body["current_tier"] == resolved.tier
+    assert body["current_tier_rank"] == ent.tier_rank(resolved.tier)
+    assert body["grace"] == bool(resolved.grace)
+    assert body["enforced"] == ent.is_enforced()
+
+
+def test_prev_capacity_batch_endpoint_matches_helper(client, ent):
+    rv = client.get("/api/entitlement/previous-tier-capacity-diff-at-batch")
+    assert rv.get_json()["tiers"] == ent.previous_tier_capacity_diff_at_batch()
+
+
+def test_prev_capacity_batch_endpoint_matches_scalar_per_source(client, ent):
+    batch = client.get(
+        "/api/entitlement/previous-tier-capacity-diff-at-batch"
+    ).get_json()["tiers"]
+    by_tier = {env["tier"]: env for env in batch}
+    for src in ent._PURCHASABLE_TIERS:
+        scalar = client.get(
+            f"/api/entitlement/previous-tier-capacity-diff-at?tier={src}"
+        ).get_json()
+        assert by_tier[src] == scalar
+
+
+def test_prev_capacity_batch_endpoint_never_raises(client, ent, monkeypatch):
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "previous_tier_capacity_diff_at_batch", boom)
+    rv = client.get("/api/entitlement/previous-tier-capacity-diff-at-batch")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["tiers"] == []
+    assert body["current_tier"] == "oss"
+    assert body["current_tier_rank"] == 0
+    assert body["grace"] is True
+    assert body["enforced"] is False


### PR DESCRIPTION
## Summary

Capacity-only narrow lens of the `next/previous_tier_diff_at[_batch]` family that landed in #3359 / #3361: for each `source -> next/prev-of-source` pair return only the capacity slice (the `{target, channel_limit, retention_days, node_limit}` shape `capacity_diff_at` publishes) so a capacity-only tooltip on a pricing-comparison cell can render the upgrade- / downgrade-side capacity delta for any hypothetical source rung off one round-trip, without first hitting `/api/entitlement` and without monkey-patching the entitlement context.

- New helpers in `clawmetry/entitlements.py`:
  - `next_tier_capacity_diff_at(tier)` -> `dict | None`
  - `previous_tier_capacity_diff_at(tier)` -> `dict | None`
  - `_capacity_diff_at_envelope(source, target)` -> `dict` (shared private builder; capacity-only mirror of `_diff_at_envelope`)
  - `next_tier_capacity_diff_at_batch()` -> `list[dict]`
  - `previous_tier_capacity_diff_at_batch()` -> `list[dict]`
- New routes in `routes/entitlement.py`:
  - `GET /api/entitlement/next-tier-capacity-diff-at?tier=<source>`
  - `GET /api/entitlement/previous-tier-capacity-diff-at?tier=<source>`
  - `GET /api/entitlement/next-tier-capacity-diff-at-batch`
  - `GET /api/entitlement/previous-tier-capacity-diff-at-batch`
- New test file `tests/test_entitlement_next_prev_tier_capacity_diff_at.py` (84 tests, all passing).

Each batch envelope is byte-equal to the matching scalar endpoint body for the same source (sans resolver-context). Each row's per-axis triples (`channel_limit`, `retention_days`, `node_limit`) byte-equal the corresponding `next/previous_tier_diff_at_batch` envelope's `row.capacity_changes` slot for the same source -- the cross-surface invariant that stops the capacity batch from silently drifting from the full diff batch as the catalogue evolves. Envelope sort order matches the diff / unlocks / locks `_at_batch` siblings so a UI can fold the four responses into one pricing-comparison matrix without re-sorting client-side.

## Invariants pinned

- `next_tier_capacity_diff_at(tier)` byte-equals `capacity_diff_at(tier, _next_purchasable_tier_after(tier))` across every valid source — the convenience cannot drift from the explicit composition. Same for the `previous_*` direction against `_previous_purchasable_tier_before`.
- At the ceiling (no rung strictly above) / floor (no rung strictly below) both scalar helpers return `None`.
- Trial-as-source resolves the same way the diff `_at` family does: next -> enterprise, previous -> cloud_starter.
- Per-axis triples (`channel_limit`, `retention_days`, `node_limit`) byte-equal the corresponding `next/previous_tier_diff_at` body's `capacity_changes` slot for the same source — pinned at both the scalar layer and the batch layer.
- Batch envelope sort order, source-axis exclusion of trial, and source-side ceiling/floor `target=null` + `row=null` posture all match the diff / unlocks / locks `_at_batch` siblings byte-for-byte on the envelope metadata.
- Grace vs enforce yields the same body (catalogue-derived, decoupled from the resolver).
- Helpers never raise: per-source builder failure collapses to `row=null`; top-level failure short-circuits to `[]`.
- Endpoints never 5xx: a resolver failure yields an empty `tiers` list with the grace-shape envelope; scalar endpoints 400 on missing input, 404 on unknown ids, and 200 with `row=null` at the ceiling / floor.

## Tests

`tests/test_entitlement_next_prev_tier_capacity_diff_at.py` — 84 tests, all passing. Covers helper shape, parity with explicit composition, parity with the diff family's `capacity_changes` slot, ceiling / floor collapse, source-endpoint pin, source axis, ordering, grace/enforce equivalence, never-raises (both per-row builder failure and top-level failure), resolver-independence, and the corresponding HTTP envelopes + matches-scalar-per-source + never-5xx checks.

Sibling regression — re-ran `test_entitlement_next_prev_tier_diff_at`, `test_entitlement_next_prev_tier_diff_at_batch`, `test_entitlement_capacity_diff_at`, `test_entitlement_capacity_diff_at_batch`, `test_entitlement_next_prev_tier_locks`, `test_entitlement_next_prev_tier_unlocks` → 217 passed.

`ruff check` clean on the three changed files.

## Local operator verification checklist

Cannot be done from this PR's CI; needs the local daemon + cloud snapshot:

- [ ] Copy changed files (`clawmetry/entitlements.py`, `routes/entitlement.py`, `tests/test_entitlement_next_prev_tier_capacity_diff_at.py`) into `~/.clawmetry/lib/pythonX.Y/site-packages/clawmetry/` (and `routes/`, `tests/`) and clear `__pycache__`.
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` to bounce the daemon.
- [ ] `curl localhost:8900/api/entitlement/next-tier-capacity-diff-at-batch` and confirm 200 + one envelope per purchasable tier, sorted by `(tier_rank, tier_id)`. Enterprise envelope should have `target=null` and `row=null`.
- [ ] Same for `/api/entitlement/previous-tier-capacity-diff-at-batch` — OSS / cloud_free envelopes should have `target=null` and `row=null`; populated envelopes should carry `row.channel_limit/retention_days/node_limit` axis triples.
- [ ] `curl 'localhost:8900/api/entitlement/next-tier-capacity-diff-at?tier=oss'` and confirm `row.target == cloud_starter`. 400 on missing `tier=`, 404 on unknown `tier=bogus`, 200 with `row=null` on `tier=enterprise`.
- [ ] Spot-check parity: for any source, the batch envelope should byte-equal the scalar `/api/entitlement/next-tier-capacity-diff-at?tier=<src>` body, and each axis triple should byte-equal the matching `next-tier-diff-at?tier=<src>` body's `row.capacity_changes.<axis>`.
- [ ] Decrypt the live cloud snapshot in the browser and confirm the dashboard still renders (these are additive endpoints — no UI consumer yet, no regression risk).

DRAFT only — please review and merge yourself.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012BeP9awtHxjcPbWJkbSv5s

---
_Generated by [Claude Code](https://claude.ai/code/session_012BeP9awtHxjcPbWJkbSv5s)_