### PR TITLE
feat(approvals): GET /api/approvals + plaintext pending count in heartbeat

### DIFF
--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -7037,6 +7037,14 @@ def send_heartbeat(config: dict) -> bool:
             payload.setdefault("cache_pushes", []).extend(ap_pushes)
     except Exception as _ap_e2:
         log.debug("approvals cache_push build failed (continuing): %s", _ap_e2)
+    # Plaintext pending count so cloud can trigger push notifications without
+    # decrypting the encrypted cache blob above (issue #3303).
+    try:
+        _ap_ct = _pending_approvals_count(config)
+        if _ap_ct:
+            payload["pending_approvals_count"] = _ap_ct
+    except Exception as _ap_ct_e:
+        log.debug("pending_approvals_count failed (continuing): %s", _ap_ct_e)
     # Memory tab (epic #1032): proactively push the user's memory-file
     # snapshot so the cloud Node Detail → Memory tab paints from cache.
     # Without this push the cloud handler returns `{blob: None}` and the
@@ -9097,6 +9105,28 @@ def _build_approvals_cache_pushes(config: dict) -> list:
         "ttl_s":  APPROVALS_CACHE_TTL_SEC,
         "blob":   blob,
     }]
+
+
+def _pending_approvals_count(config: dict) -> int:
+    """Return count of pending approvals for this node's owner token.
+
+    Added as a plaintext top-level heartbeat field (issue #3303) so the cloud
+    can decide whether to push an FCM/APNs notification without decrypting the
+    E2E-encrypted cache blob. Returns 0 on any error (best-effort)."""
+    api_key = config.get("api_key", "")
+    if not api_key:
+        return 0
+    try:
+        from clawmetry import local_store
+        store = local_store.get_store(read_only=True)
+        rows = store.query_approvals(
+            owner_hash=_owner_hash_for_token(api_key),
+            status="pending",
+            limit=APPROVALS_CACHE_LIMIT,
+        )
+        return len(rows) if rows else 0
+    except Exception:
+        return 0
 
 
 # ── Phase 6: proactive cron-runs cache_push (issue #1640) ────────────────────

--- a/routes/policy.py
+++ b/routes/policy.py
@@ -52,6 +52,23 @@ def _coerce_rows(rows) -> list[dict]:
     return rows if isinstance(rows, list) else []
 
 
+def _arg_preview(args) -> str:
+    """Short single-line preview of tool-call arguments — never the full body."""
+    if args is None:
+        return ""
+    if isinstance(args, dict):
+        for k in ("command", "cmd", "tool", "path", "url"):
+            v = args.get(k)
+            if v:
+                return str(v)[:160]
+        try:
+            import json as _json
+            return _json.dumps(args, separators=(",", ":"))[:160]
+        except Exception:
+            return str(args)[:160]
+    return str(args)[:160]
+
+
 @bp_policy.route("/api/tool-policy")
 def api_tool_policy():
     """Per-agent effective sandbox mode + tool allow/deny.
@@ -123,29 +140,41 @@ def api_approvals_audit():
     return jsonify(_approvals_audit_payload(status=status, limit=limit))
 
 
+@bp_policy.route("/api/approvals")
+def api_approvals_queue():
+    """Pending approvals queue — compact format for mobile/remote clients.
+
+    Returns {approvals:[...], count:int, _source}. Each entry carries
+    action_token (the id a remote client uses to POST an approve/deny decision
+    to the cloud) plus a short args_preview so mobile UI can show context.
+
+    Query params: limit (<=100, default 50).
+    """
+    try:
+        limit = max(1, min(100, int(request.args.get("limit", 50))))
+    except (TypeError, ValueError):
+        limit = 50
+    rows = _coerce_rows(_ls_call("query_approvals", status="pending", limit=limit))
+    approvals = [
+        {
+            "id":                   r.get("id"),
+            "action_token":         r.get("id"),
+            "action":               r.get("action"),
+            "status":               r.get("status") or "pending",
+            "created_at":           r.get("created_at"),
+            "requestor_session_id": r.get("requestor_session_id"),
+            "args_preview":         _arg_preview(r.get("args")),
+        }
+        for r in rows
+    ]
+    return jsonify({"approvals": approvals, "count": len(approvals), "_source": "local_store"})
+
+
 def _approvals_audit_payload(status=None, limit=100):
     """Exec-approval decision audit payload, shared by the HTTP route and the
     cloud snapshot builder (trial-bug #22: the Policy tab audit was blank on the
     hosted dashboard). Returns {decisions, summary, _source}."""
     rows = _coerce_rows(_ls_call("query_approvals", status=status, limit=limit))
-
-    def _arg_preview(args) -> str:
-        """A short, single-line preview of the tool-call arguments — never the
-        full body (avoids snapshot/response bloat)."""
-        if args is None:
-            return ""
-        if isinstance(args, dict):
-            # exec-style calls usually carry a command; surface it first.
-            for k in ("command", "cmd", "tool", "path", "url"):
-                v = args.get(k)
-                if v:
-                    return str(v)[:160]
-            try:
-                import json as _json
-                return _json.dumps(args, separators=(",", ":"))[:160]
-            except Exception:
-                return str(args)[:160]
-        return str(args)[:160]
 
     decisions = []
     pending = approved = denied = simulated = 0


### PR DESCRIPTION
Closes #3303

## Summary

OSS API contract work for mobile lock screen approvals (#3303). No cloud changes needed here — FCM/APNs push infrastructure stays in clawmetry-cloud.

- **`routes/policy.py`** — Adds `GET /api/approvals` returning pending approvals in a compact, mobile-friendly format: `{approvals:[{id, action_token, action, status, created_at, requestor_session_id, args_preview}], count, _source}`. The `action_token` field is the approval `id` a remote client POSTs to the cloud to approve or deny. Extracts `_arg_preview` to module level so it can be shared by both `/api/approvals` and the existing `/api/approvals-audit`.

- **`clawmetry/sync.py`** — Adds `_pending_approvals_count(config)` helper and includes `pending_approvals_count` as a plaintext top-level field in the sync heartbeat. This lets the cloud check the count without decrypting the E2E-encrypted `cache_pushes` blob, so it can decide whether to send an FCM/APNs push notification within the 5s target window.

## Test plan

- `python3 -m py_compile routes/policy.py clawmetry/sync.py` — syntax clean ✓
- `python3 -m pytest tests/test_approvals_local_store.py tests/test_approvals_duckdb_watcher.py tests/test_policy_replay.py -v` — 29/30 pass; the 1 failure is a pre-existing cryptography library conflict in CI unrelated to this diff
- Manual: `GET /api/approvals` with no pending rows returns `{approvals:[], count:0, _source:"local_store"}`; with seeded pending rows returns compact list with `action_token` = `id`

---
_Generated by [Claude Code](https://claude.ai/code/session_01Esx599yZdVeUGbDVmZRgQw)_