### PR TITLE
fix: map short-form 'input'/'output' usage keys in openclaw adapter

### DIFF
--- a/clawmetry/adapters/openclaw.py
+++ b/clawmetry/adapters/openclaw.py
@@ -1272,8 +1272,8 @@ class OpenClawAdapter(AgentAdapter):
                             usage = src.get("usage") if isinstance(src.get("usage"), dict) else {}
                             if usage:
                                 for dst, *keys in [
-                                    ("inputTokens", "input_tokens", "inputTokens"),
-                                    ("outputTokens", "output_tokens", "outputTokens"),
+                                    ("inputTokens", "input_tokens", "inputTokens", "input"),
+                                    ("outputTokens", "output_tokens", "outputTokens", "output"),
                                     ("cacheReadTokens", "cache_read_input_tokens", "cacheReadInputTokens", "cacheRead"),
                                     ("cacheWriteTokens", "cache_creation_input_tokens", "cacheCreationInputTokens", "cacheWrite"),
                                     ("totalTokens", "totalTokens", "total_tokens"),
@@ -1516,8 +1516,8 @@ class OpenClawAdapter(AgentAdapter):
                     continue
                 model = msg.get("model") or ""
                 usage = msg.get("usage") or {}
-                tok_in = int(usage.get("input_tokens") or usage.get("inputTokens") or 0)
-                tok_out = int(usage.get("output_tokens") or usage.get("outputTokens") or 0)
+                tok_in = int(usage.get("input_tokens") or usage.get("inputTokens") or usage.get("input") or 0)
+                tok_out = int(usage.get("output_tokens") or usage.get("outputTokens") or usage.get("output") or 0)
                 # Reasoning/thinking tokens (#2876) are billed but not part of
                 # input/output; fold them into token_count so LLM-span cost
                 # totals are not systematically under-reported.
@@ -1729,8 +1729,8 @@ class OpenClawAdapter(AgentAdapter):
                 comp_usage = obj.get("usage")
                 if isinstance(comp_usage, dict):
                     tok_total = int(comp_usage.get("totalTokens") or comp_usage.get("total_tokens") or 0)
-                    tok_in = int(comp_usage.get("input_tokens") or comp_usage.get("inputTokens") or 0)
-                    tok_out = int(comp_usage.get("output_tokens") or comp_usage.get("outputTokens") or 0)
+                    tok_in = int(comp_usage.get("input_tokens") or comp_usage.get("inputTokens") or comp_usage.get("input") or 0)
+                    tok_out = int(comp_usage.get("output_tokens") or comp_usage.get("outputTokens") or comp_usage.get("output") or 0)
                     effective = tok_total or (tok_in + tok_out)
                     if effective:
                         comp_attrs["compaction.usage.total_tokens"] = effective


### PR DESCRIPTION
Closes #3364

## Summary

- Plugin-SDK events from `completeSimple()` emit `{ input, output, cacheRead, cacheWrite, totalTokens }` but the adapter only checked `input_tokens`/`inputTokens` and `output_tokens`/`outputTokens`, so those events landed with zero token counts in `Event.extra` and in OTel spans.
- Adds `"input"` and `"output"` as final fallback keys in three spots in `clawmetry/adapters/openclaw.py`: the `list_events()` usage for-loop, the `_build_spans_from_events()` assistant-turn usage extraction, and the compaction-block usage extraction.
- `local_store.py` already included these short-form keys (`line ~11017`); this brings the adapter into parity with the store layer.

## Test plan

- [ ] Ingest a session that uses `completeSimple()` (plugin-SDK path) — confirm `Event.extra.inputTokens` / `Event.extra.outputTokens` are non-zero.
- [ ] Ingest a session with the standard `input_tokens`/`output_tokens` shape — confirm values unchanged (longer-form keys still win via first-match order in the for-loop).
- [ ] `python3 -m py_compile clawmetry/adapters/openclaw.py` passes (checked).

---
_Generated by [Claude Code](https://claude.ai/code/session_01DV2W42cqppSzoAdiohtKfo)_