### PR TITLE
fix: filter nemoclaw-onboard-warmup-* phantom sessions from dashboard

### DIFF
--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -8259,6 +8259,9 @@ class LocalStore:
             "WHERE parent_session_id IS NOT NULL AND parent_session_id != ''"
             ")"
         )
+        # Filter NemoClaw harness warm-up sessions that were written during
+        # harness onboarding — they are not real agent sessions (#3366).
+        clauses.append("s.session_id NOT LIKE 'nemoclaw-onboard-warmup-%'")
         where = ("WHERE " + " AND ".join(clauses)) if clauses else ""
         # ``sessions.message_count`` is only populated by the typed-session
         # ingest path (sync.py + claude_code adapter). The OpenClaw events

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -2330,6 +2330,10 @@ def sync_sandbox_sessions_openshell(config: dict, state: dict) -> int:
             continue
 
         for fname in fnames:
+            # Warmup sessions (nemoclaw-onboard-warmup-*) are harness
+            # onboarding artefacts — skip so they never reach DuckDB (#3366).
+            if fname.startswith("nemoclaw-onboard-warmup-"):
+                continue
             cursor_key = f"{sb_name}/{fname}"
             last_line = cursors.get(cursor_key, 0)
             try:


### PR DESCRIPTION
Closes #3366

## What

NemoClaw harness writes warmup sessions (`nemoclaw-onboard-warmup-*`) to the session store during onboarding. ClawMetry was ingesting these without filtering, so phantom sessions appeared in the dashboard alongside real agent conversations.

## Changes

- **`clawmetry/sync.py`**: Skip `.jsonl` files whose name starts with `nemoclaw-onboard-warmup-` during the NemoClaw sandbox session sync loop — warmup sessions never enter DuckDB going forward.
- **`clawmetry/local_store.py`**: Add `s.session_id NOT LIKE 'nemoclaw-onboard-warmup-%'` to the `WHERE` clause in `query_sessions_table()` — filters any warmup sessions already stored before this fix lands.

## Test plan

- `python3 -m py_compile clawmetry/sync.py clawmetry/local_store.py` — syntax clean ✓
- With a nemoclaw sandbox that has `nemoclaw-onboard-warmup-1.jsonl`: confirm sync loop skips the file and no `nemoclaw-onboard-warmup-1` row appears in the `sessions` table.
- Existing sessions (non-warmup) unaffected — the prefix filter is specific enough to not match real session UUIDs.

---
_Generated by [Claude Code](https://claude.ai/code/session_011rbNMjBmRtQZAUQ9YnDdPn)_