### PR TITLE
feat(entitlement): next/previous_tier_spec + _at + endpoints

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -783,6 +783,66 @@ class Entitlement:
             logger.warning("entitlements: previous_tier_locks failed: %s", exc)
             return None
 
+    def next_tier_spec(self) -> dict | None:
+        """One-rung-up full :func:`tier_spec_at`-shape descriptor.
+
+        Convenience for ``tier_spec_at(self.tier, self.next_purchasable_tier())``
+        so a pricing-table cell or upgrade-CTA card can render the full
+        tier-row (``id``, ``label``, ``is_paid``, ``is_current``, ``rank``,
+        ``unlocks_paid_runtimes``, ``retention_days``, ``channel_limit``,
+        ``node_limit``, ``features``, ``runtimes``) for the rung above
+        current off ONE entitlement round-trip, alongside :meth:`next_tier_diff`
+        (full ``upgrade_diff`` row), :meth:`next_tier_unlocks` (marginal
+        grants), :meth:`next_tier_locks` (marginal losses), and
+        :meth:`next_tier_capacity_diff` (capacity-only marginal).
+
+        Delegates to :func:`tier_spec_at` (not :func:`tier_spec`) so the
+        ``is_current`` field is anchored on ``self.tier`` rather than the
+        live resolver -- and since the target is by definition strictly
+        above ``self.tier``, ``is_current`` is always ``False`` on the
+        returned row. Returns ``None`` at the resolver's ceiling (no next
+        purchasable rung) and never raises: a resolver failure short-
+        circuits to ``None`` so the CTA surface keeps rendering instead
+        of 500-ing.
+        """
+        try:
+            target = self.next_purchasable_tier()
+            if target is None:
+                return None
+            return tier_spec_at(self.tier, target)
+        except Exception as exc:
+            logger.warning("entitlements: next_tier_spec failed: %s", exc)
+            return None
+
+    def previous_tier_spec(self) -> dict | None:
+        """One-rung-down full :func:`tier_spec_at`-shape descriptor.
+
+        Symmetric companion to :meth:`next_tier_spec`. Convenience for
+        ``tier_spec_at(self.tier, self.previous_purchasable_tier())`` --
+        the full row of the rung immediately below current, useful on a
+        downgrade-confirmation card alongside :meth:`previous_tier_diff`
+        (full ``downgrade_diff`` row), :meth:`previous_tier_unlocks` (what
+        that rung first granted), :meth:`previous_tier_locks` (what that
+        rung first lost), and :meth:`previous_tier_capacity_diff`
+        (capacity-only marginal).
+
+        Delegates to :func:`tier_spec_at` so the ``is_current`` field is
+        anchored on ``self.tier`` rather than the live resolver -- and
+        since the target is by definition strictly below ``self.tier``,
+        ``is_current`` is always ``False`` on the returned row. Returns
+        ``None`` at the resolver's floor (no previous purchasable rung)
+        and never raises -- a resolver failure short-circuits to ``None``
+        so the confirmation surface keeps rendering instead of 500-ing.
+        """
+        try:
+            target = self.previous_purchasable_tier()
+            if target is None:
+                return None
+            return tier_spec_at(self.tier, target)
+        except Exception as exc:
+            logger.warning("entitlements: previous_tier_spec failed: %s", exc)
+            return None
+
     def grace_remaining_days(self) -> int | None:
         at = enforce_at_epoch()
         if at is None:
@@ -1486,6 +1546,26 @@ def previous_tier_locks() -> dict | None:
         return get_entitlement().previous_tier_locks()
     except Exception as exc:
         logger.warning("entitlements: previous_tier_locks (module) failed: %s", exc)
+        return None
+
+
+def next_tier_spec() -> dict | None:
+    """Module-level :meth:`Entitlement.next_tier_spec` against the resolved
+    entitlement. Never raises."""
+    try:
+        return get_entitlement().next_tier_spec()
+    except Exception as exc:
+        logger.warning("entitlements: next_tier_spec (module) failed: %s", exc)
+        return None
+
+
+def previous_tier_spec() -> dict | None:
+    """Module-level :meth:`Entitlement.previous_tier_spec` against the
+    resolved entitlement. Never raises."""
+    try:
+        return get_entitlement().previous_tier_spec()
+    except Exception as exc:
+        logger.warning("entitlements: previous_tier_spec (module) failed: %s", exc)
         return None
 
 
@@ -6091,3 +6171,96 @@ def previous_tier_capacity_diff_at_batch() -> list[dict]:
             exc,
         )
         return []
+
+
+def next_tier_spec_at(tier: str) -> dict | None:
+    """Scalar what-if sibling of :meth:`Entitlement.next_tier_spec`:
+    full :func:`tier_spec_at`-shape descriptor of the rung above the
+    caller-supplied ``tier``, with ``is_current`` computed as if the
+    install were on ``tier``.
+
+    Source-anchored equivalent of :meth:`Entitlement.next_tier_spec`,
+    which pins the perspective to the resolved entitlement. Convenience
+    for ``tier_spec_at(tier, _next_purchasable_tier_after(tier))`` so a
+    pricing-table cell can render the full tier-row of the rung above
+    any hypothetical source rung without first asking the resolver and
+    without monkey-patching the entitlement context. Pairs with
+    :func:`next_tier_diff_at` (full ``upgrade_diff`` payload),
+    :func:`next_tier_unlocks_at` / :func:`next_tier_locks_at` (the
+    marginal-grant / marginal-loss views), and
+    :func:`next_tier_capacity_diff_at` (capacity-only) on the same
+    hypothetical pricing-matrix cell.
+
+    The returned row matches :func:`tier_spec_at(tier, target)` for the
+    resolved ``target = _next_purchasable_tier_after(tier)`` exactly --
+    a parity test pins this so the scalar accessors cannot drift. The
+    ``is_current`` field is always ``False`` (target is by definition
+    strictly above source, so it cannot equal it).
+
+    Accepts any id in :data:`_TIER_ORDER` (including :data:`TIER_TRIAL`)
+    -- the lenient ``_at`` posture, matching the other ``next_*_at``
+    helpers.
+
+    Returns ``None`` for empty / unknown ``tier`` and at the ceiling
+    (no rung strictly above -- enterprise as source). Never raises:
+    a builder failure short-circuits to ``None`` so the CTA surface
+    stays mute instead of breaking.
+    """
+    try:
+        src = (tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if not src or src not in _TIER_ORDER:
+        return None
+    try:
+        target = _next_purchasable_tier_after(src)
+        if target is None:
+            return None
+        return tier_spec_at(src, target)
+    except Exception as exc:
+        logger.warning("entitlements: next_tier_spec_at failed: %s", exc)
+        return None
+
+
+def previous_tier_spec_at(tier: str) -> dict | None:
+    """Scalar what-if sibling of :meth:`Entitlement.previous_tier_spec`:
+    full :func:`tier_spec_at`-shape descriptor of the rung below the
+    caller-supplied ``tier``, with ``is_current`` computed as if the
+    install were on ``tier``.
+
+    Source-anchored mirror of :func:`next_tier_spec_at` and downgrade-
+    side counterpart of the live :meth:`Entitlement.previous_tier_spec`
+    (which pins the perspective to the resolved entitlement).
+    Convenience for ``tier_spec_at(tier, _previous_purchasable_tier_before(tier))``
+    so a downgrade-confirmation card or pricing-comparison cell can
+    render the full tier-row of the rung below any hypothetical source
+    rung without first asking the resolver.
+
+    Like :func:`next_tier_spec_at` the row matches
+    :func:`tier_spec_at(tier, target)` for the resolved
+    ``target = _previous_purchasable_tier_before(tier)`` exactly, and
+    the ``is_current`` field is always ``False`` (target is by definition
+    strictly below source, so it cannot equal it).
+
+    Accepts any id in :data:`_TIER_ORDER` (including :data:`TIER_TRIAL`)
+    -- the lenient ``_at`` posture.
+
+    Returns ``None`` for empty / unknown ``tier`` and at the floor
+    (oss / cloud_free as source -- no rung strictly below). Never
+    raises: a builder failure short-circuits to ``None`` so the
+    confirmation surface stays mute instead of breaking.
+    """
+    try:
+        src = (tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if not src or src not in _TIER_ORDER:
+        return None
+    try:
+        target = _previous_purchasable_tier_before(src)
+        if target is None:
+            return None
+        return tier_spec_at(src, target)
+    except Exception as exc:
+        logger.warning("entitlements: previous_tier_spec_at failed: %s", exc)
+        return None

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -5647,3 +5647,255 @@ def api_entitlement_previous_tier_capacity_diff_at_batch():
                 "enforced": False,
             }
         )
+
+
+@bp_entitlement.route("/api/entitlement/next-tier-spec")
+def api_entitlement_next_tier_spec():
+    """``GET /api/entitlement/next-tier-spec`` -- full
+    :func:`clawmetry.entitlements.tier_spec` descriptor for the rung
+    immediately above the resolved entitlement.
+
+    Current-relative convenience for
+    ``/api/entitlement/tier-spec?tier=<next_purchasable_tier>``; the
+    upgrade-CTA companion to ``/api/entitlement/next-tier-diff``
+    (full ``upgrade_diff`` shape), ``/next-tier-unlocks`` (marginal
+    grants), ``/next-tier-locks`` (marginal losses), and
+    ``/next-tier-capacity-diff`` (capacity-only). Returns
+    ``{"spec": null, ...}`` at the ceiling (no rung above to upgrade
+    to). Never 5xxs: a resolver failure short-circuits to the
+    grace-shape envelope so the dashboard CTA keeps rendering
+    instead of disappearing.
+    """
+    try:
+        from clawmetry import entitlements as _ent
+
+        ent = _ent.get_entitlement()
+        body = ent.next_tier_spec()
+        return jsonify(
+            {
+                "current_tier": ent.tier,
+                "current_tier_label": _ent.tier_label(ent.tier),
+                "current_tier_rank": _ent.tier_rank(ent.tier),
+                "spec": body,
+                "grace": bool(ent.grace),
+                "enforced": _ent.is_enforced(),
+            }
+        )
+    except Exception as exc:
+        logger.warning("api_entitlement_next_tier_spec: error: %s", exc)
+        return jsonify(
+            {
+                "current_tier": "oss",
+                "current_tier_label": "OSS",
+                "current_tier_rank": 0,
+                "spec": None,
+                "grace": True,
+                "enforced": False,
+            }
+        )
+
+
+@bp_entitlement.route("/api/entitlement/previous-tier-spec")
+def api_entitlement_previous_tier_spec():
+    """``GET /api/entitlement/previous-tier-spec`` -- full
+    :func:`clawmetry.entitlements.tier_spec` descriptor for the rung
+    immediately below the resolved entitlement.
+
+    Symmetric companion to ``/api/entitlement/next-tier-spec`` -- the
+    full tier-row of the rung below current, useful on a downgrade-
+    confirmation card alongside ``/previous-tier-diff``,
+    ``/previous-tier-unlocks``, ``/previous-tier-locks``, and
+    ``/previous-tier-capacity-diff``. ``spec`` collapses to ``null`` at
+    the floor (no rung below). Never 5xxs: a resolver failure
+    short-circuits to the grace-shape envelope so the confirmation
+    surface keeps rendering instead of disappearing.
+    """
+    try:
+        from clawmetry import entitlements as _ent
+
+        ent = _ent.get_entitlement()
+        body = ent.previous_tier_spec()
+        return jsonify(
+            {
+                "current_tier": ent.tier,
+                "current_tier_label": _ent.tier_label(ent.tier),
+                "current_tier_rank": _ent.tier_rank(ent.tier),
+                "spec": body,
+                "grace": bool(ent.grace),
+                "enforced": _ent.is_enforced(),
+            }
+        )
+    except Exception as exc:
+        logger.warning("api_entitlement_previous_tier_spec: error: %s", exc)
+        return jsonify(
+            {
+                "current_tier": "oss",
+                "current_tier_label": "OSS",
+                "current_tier_rank": 0,
+                "spec": None,
+                "grace": True,
+                "enforced": False,
+            }
+        )
+
+
+@bp_entitlement.route("/api/entitlement/next-tier-spec-at")
+def api_entitlement_next_tier_spec_at():
+    """``GET /api/entitlement/next-tier-spec-at?tier=<source>`` -- scalar
+    what-if sibling of ``/api/entitlement/next-tier-spec``: full
+    :func:`clawmetry.entitlements.tier_spec_at`-shape descriptor of the
+    rung above the caller-supplied ``tier``.
+
+    Lets a pricing page render the "full descriptor of the rung above X"
+    upgrade-CTA cell for any hypothetical ``X`` without first asking the
+    resolver -- the scalar what-if the live ``/next-tier-spec`` endpoint
+    surfaces against the resolved entitlement, parameterised over the
+    source.
+
+    Response shape::
+
+        {
+          "tier":           "<source tier id>",
+          "tier_label":     "<source label>",
+          "tier_rank":      <source rank>,
+          "target":         "<next-above tier id>" | null,
+          "target_label":   "<next-above label>" | null,
+          "target_rank":    <next-above rank> | null,
+          "row":            {<tier_spec_at row>} | null,
+        }
+
+    The inner ``row`` matches the live ``/tier-spec-at?tier=<source>
+    &target=<next-above>`` row exactly -- catalogue-derived fields
+    (``id``, ``label``, ``is_paid``, ``rank``, ``unlocks_paid_runtimes``,
+    ``retention_days``, ``channel_limit``, ``node_limit``, ``features``,
+    ``runtimes``) come straight from the static per-tier maps; the
+    ``is_current`` boolean is always ``False`` (target is by definition
+    strictly above source).
+
+    Accepts any tier id in :data:`entitlements._TIER_ORDER` (including
+    ``trial``), matching the other ``_at`` family endpoints. ``target``
+    / ``row`` collapse to ``null`` at the ceiling (no rung strictly
+    above the source) -- the surface stays 200 with a populated
+    envelope so callers can render "you're at the top" copy without
+    a status-code branch.
+
+    - **400** when ``tier=`` is missing / blank
+    - **404** when ``tier`` is unknown. The body carries ``which`` so a
+      caller can render the right "unknown ..." message.
+    - **Never 5xxs**: builder failure short-circuits to ``row=null``
+      on the same 200 envelope so the CTA surface stays mute.
+    """
+    raw_tier = request.args.get("tier")
+    tier_in = (raw_tier or "").strip().lower()
+    if not tier_in:
+        return jsonify({"error": "missing tier"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        if tier_in not in _ent._TIER_ORDER:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "tier", "tier": tier_in}
+                ),
+                404,
+            )
+        target = _ent._next_purchasable_tier_after(tier_in)
+        row = _ent.next_tier_spec_at(tier_in)
+        return jsonify(
+            {
+                "tier": tier_in,
+                "tier_label": _ent.tier_label(tier_in),
+                "tier_rank": _ent.tier_rank(tier_in),
+                "target": target,
+                "target_label": _ent.tier_label(target) if target else None,
+                "target_rank": _ent.tier_rank(target) if target else None,
+                "row": row,
+            }
+        )
+    except Exception as exc:
+        logger.warning("api_entitlement_next_tier_spec_at: error: %s", exc)
+        return jsonify(
+            {
+                "tier": tier_in,
+                "tier_label": None,
+                "tier_rank": -1,
+                "target": None,
+                "target_label": None,
+                "target_rank": None,
+                "row": None,
+            }
+        )
+
+
+@bp_entitlement.route("/api/entitlement/previous-tier-spec-at")
+def api_entitlement_previous_tier_spec_at():
+    """``GET /api/entitlement/previous-tier-spec-at?tier=<source>`` --
+    scalar what-if sibling of ``/api/entitlement/previous-tier-spec``:
+    full :func:`clawmetry.entitlements.tier_spec_at`-shape descriptor of
+    the rung below the caller-supplied ``tier``.
+
+    Source-anchored mirror of ``/next-tier-spec-at`` and downgrade-side
+    counterpart of the live ``/previous-tier-spec`` (source pinned to
+    the resolver). Lets a pricing page render the "full descriptor of
+    the rung below X" downgrade-confirmation detail cell for any
+    hypothetical ``X`` without asking the resolver.
+
+    Response shape matches ``/next-tier-spec-at`` byte-for-byte
+    (``tier``, ``tier_label``, ``tier_rank``, ``target``, ``target_label``,
+    ``target_rank``, ``row``). Inner ``row`` matches
+    ``/tier-spec-at?tier=<source>&target=<previous-below>`` exactly; the
+    ``is_current`` boolean is always ``False`` (target is by definition
+    strictly below source).
+
+    Accepts any tier id in :data:`entitlements._TIER_ORDER` (including
+    ``trial``). ``target`` / ``row`` collapse to ``null`` at the floor
+    (no rung strictly below the source -- ``oss`` / ``cloud_free`` as
+    source) -- the surface stays 200 with a populated envelope so
+    callers can render "you're at the floor" copy without a status-
+    code branch.
+
+    - **400** when ``tier=`` is missing / blank
+    - **404** when ``tier`` is unknown.
+    - **Never 5xxs**: builder failure short-circuits to ``row=null``
+      on the same 200 envelope.
+    """
+    raw_tier = request.args.get("tier")
+    tier_in = (raw_tier or "").strip().lower()
+    if not tier_in:
+        return jsonify({"error": "missing tier"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        if tier_in not in _ent._TIER_ORDER:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "tier", "tier": tier_in}
+                ),
+                404,
+            )
+        target = _ent._previous_purchasable_tier_before(tier_in)
+        row = _ent.previous_tier_spec_at(tier_in)
+        return jsonify(
+            {
+                "tier": tier_in,
+                "tier_label": _ent.tier_label(tier_in),
+                "tier_rank": _ent.tier_rank(tier_in),
+                "target": target,
+                "target_label": _ent.tier_label(target) if target else None,
+                "target_rank": _ent.tier_rank(target) if target else None,
+                "row": row,
+            }
+        )
+    except Exception as exc:
+        logger.warning("api_entitlement_previous_tier_spec_at: error: %s", exc)
+        return jsonify(
+            {
+                "tier": tier_in,
+                "tier_label": None,
+                "tier_rank": -1,
+                "target": None,
+                "target_label": None,
+                "target_rank": None,
+                "row": None,
+            }
+        )

--- a/tests/test_entitlement_next_prev_tier_spec.py
+++ b/tests/test_entitlement_next_prev_tier_spec.py
@@ -1,0 +1,701 @@
+"""Tests for ``Entitlement.next_tier_spec`` / ``previous_tier_spec``, the
+module-level convenience helpers, the scalar what-if
+``next_tier_spec_at`` / ``previous_tier_spec_at`` helpers, and the four
+companion ``/api/entitlement/{next,previous}-tier-spec[-at]`` endpoints.
+
+Full :func:`tier_spec`-shape descriptor lens of the
+``{next,previous}_tier_{diff,unlocks,locks,capacity_diff}`` family that
+already exists: where those helpers return marginal step / capacity rows
+between the resolved entitlement (or a hypothetical source ``_at``) and
+the rung one above / below, these helpers return the FULL tier-row
+descriptor of the rung above / below in :func:`tier_spec` shape (``id``,
+``label``, ``is_paid``, ``is_current``, ``rank``,
+``unlocks_paid_runtimes``, ``retention_days``, ``channel_limit``,
+``node_limit``, ``features``, ``runtimes``) so a pricing-table cell can
+hydrate the rung-above / rung-below column off ONE round-trip without
+fetching the full catalogue and filtering client-side.
+
+Pins covered here:
+
+* method-vs-tier_spec identity for next/previous across every
+  purchasable source -- the convenience cannot drift from the explicit
+  ``tier_spec(self.next_purchasable_tier())`` composition
+* ``next_tier_spec_at(tier)`` byte-equals
+  ``tier_spec_at(tier, _next_purchasable_tier_after(tier))`` and the
+  symmetric pin for previous
+* ``is_current`` is always ``False`` on the returned row -- the target
+  is by definition strictly above / below the source
+* ceiling / floor returns ``None`` (Enterprise has no next, OSS /
+  cloud_free has no previous)
+* trial-as-source resolves the same way the sibling ``_at`` families
+  do: next -> enterprise, previous -> cloud_starter
+* unknown / empty / ``None`` / non-string source on the ``_at`` helpers
+  returns ``None``
+* grace vs enforce yields the same body (catalogue-derived, not gated)
+* the helpers never raise -- a resolver failure short-circuits to
+  ``None`` so the CTA surface keeps rendering
+* the four API endpoints never 5xx: scalar endpoints surface a 200
+  envelope with ``spec=null`` at the ceiling / floor; ``_at`` endpoints
+  400 on missing input, 404 on unknown ids, and 200 with ``row=null``
+  at the ceiling / floor; a synthesised resolver failure yields the
+  grace-shape envelope on every surface
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+_SPEC_KEYS = {
+    "id",
+    "label",
+    "is_paid",
+    "is_current",
+    "rank",
+    "unlocks_paid_runtimes",
+    "retention_days",
+    "channel_limit",
+    "node_limit",
+    "features",
+    "runtimes",
+}
+
+_AT_ENVELOPE_KEYS = {
+    "tier",
+    "tier_label",
+    "tier_rank",
+    "target",
+    "target_label",
+    "target_rank",
+    "row",
+}
+
+_SCALAR_ENVELOPE_KEYS = {
+    "current_tier",
+    "current_tier_label",
+    "current_tier_rank",
+    "spec",
+    "grace",
+    "enforced",
+}
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# ── Entitlement.next_tier_spec ───────────────────────────────────────────────
+
+
+def test_next_tier_spec_matches_tier_spec_at(ent):
+    # next_tier_spec() is a convenience for
+    # tier_spec_at(self.tier, next_purchasable_tier()) -- they must be
+    # byte-equal across every purchasable source so a caller can use the
+    # singular helper interchangeably. Delegates to tier_spec_at (not
+    # tier_spec) so is_current is anchored on self.tier rather than the
+    # live resolver -- the helper is self-anchored, not resolver-anchored.
+    for tier in (
+        ent.TIER_OSS,
+        ent.TIER_CLOUD_FREE,
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_PRO,
+    ):
+        e = ent._build(tier, "test")
+        nxt = e.next_purchasable_tier()
+        assert nxt is not None
+        assert e.next_tier_spec() == ent.tier_spec_at(tier, nxt)
+
+
+def test_next_tier_spec_returns_none_at_ceiling(ent):
+    # Enterprise sits at the top of the purchasable ladder -- no rung above
+    # to upgrade to, so the convenience returns None just like
+    # next_purchasable_tier().
+    e = ent._build(ent.TIER_ENTERPRISE, "license")
+    assert e.next_purchasable_tier() is None
+    assert e.next_tier_spec() is None
+
+
+def test_next_tier_spec_shape(ent):
+    # The row must carry the full tier_spec shape so a pricing-cell can
+    # hydrate every column without a second round-trip.
+    e = ent._build(ent.TIER_CLOUD_STARTER, "cloud")
+    body = e.next_tier_spec()
+    assert body is not None
+    assert set(body.keys()) == _SPEC_KEYS
+    assert body["id"] == ent.TIER_CLOUD_PRO
+    assert body["label"] == ent.tier_label(ent.TIER_CLOUD_PRO)
+    # tier_spec carries the position-in-_TIER_ORDER rank, not the ladder
+    # tier_rank value -- pin against the source-of-truth field.
+    assert body["rank"] == ent._TIER_ORDER.index(ent.TIER_CLOUD_PRO)
+    assert body["features"] == sorted(body["features"])
+    assert body["runtimes"] == sorted(body["runtimes"])
+
+
+def test_next_tier_spec_is_current_always_false(ent):
+    # By definition the target is strictly above the source -- it can never
+    # equal current, so is_current must always be False.
+    for tier in (
+        ent.TIER_OSS,
+        ent.TIER_CLOUD_FREE,
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_PRO,
+    ):
+        e = ent._build(tier, "test")
+        body = e.next_tier_spec()
+        assert body is not None
+        assert body["is_current"] is False
+
+
+def test_next_tier_spec_never_raises_on_resolver_failure(ent, monkeypatch):
+    # If next_purchasable_tier blows up, the helper must swallow and return
+    # None so the dashboard CTA keeps rendering rather than 500-ing.
+    e = ent._oss_free()
+    monkeypatch.setattr(
+        type(e),
+        "next_purchasable_tier",
+        lambda self: (_ for _ in ()).throw(RuntimeError("synthetic")),
+    )
+    assert e.next_tier_spec() is None
+
+
+# ── Entitlement.previous_tier_spec ───────────────────────────────────────────
+
+
+def test_previous_tier_spec_matches_tier_spec_at(ent):
+    # Symmetric to next_tier_spec: previous_tier_spec() must be byte-equal
+    # to tier_spec_at(self.tier, previous_purchasable_tier()).
+    for tier in (
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_PRO,
+        ent.TIER_ENTERPRISE,
+    ):
+        e = ent._build(tier, "test")
+        prev = e.previous_purchasable_tier()
+        assert prev is not None
+        assert e.previous_tier_spec() == ent.tier_spec_at(tier, prev)
+
+
+def test_previous_tier_spec_returns_none_at_floor(ent):
+    # OSS and cloud_free both sit at rank 0 -- no rung below to step down to,
+    # so the helper returns None mirroring previous_purchasable_tier().
+    for tier in (ent.TIER_OSS, ent.TIER_CLOUD_FREE):
+        e = ent._build(tier, "test")
+        assert e.previous_purchasable_tier() is None
+        assert e.previous_tier_spec() is None
+
+
+def test_previous_tier_spec_shape(ent):
+    e = ent._build(ent.TIER_CLOUD_PRO, "cloud")
+    body = e.previous_tier_spec()
+    assert body is not None
+    assert set(body.keys()) == _SPEC_KEYS
+    assert body["id"] == ent.TIER_CLOUD_STARTER
+    assert body["label"] == ent.tier_label(ent.TIER_CLOUD_STARTER)
+
+
+def test_previous_tier_spec_is_current_always_false(ent):
+    # By definition the target is strictly below source -- can never equal
+    # current.
+    for tier in (
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_PRO,
+        ent.TIER_ENTERPRISE,
+    ):
+        e = ent._build(tier, "test")
+        body = e.previous_tier_spec()
+        assert body is not None
+        assert body["is_current"] is False
+
+
+def test_previous_tier_spec_never_raises_on_resolver_failure(ent, monkeypatch):
+    e = ent._build(ent.TIER_ENTERPRISE, "license")
+    monkeypatch.setattr(
+        type(e),
+        "previous_purchasable_tier",
+        lambda self: (_ for _ in ()).throw(RuntimeError("synthetic")),
+    )
+    assert e.previous_tier_spec() is None
+
+
+# ── trial source resolution ──────────────────────────────────────────────────
+
+
+def test_trial_next_spec_resolves_to_enterprise(ent):
+    # Trial sits at rank 2 alongside cloud_pro / self-hosted pro, so the next
+    # strictly-higher purchasable rung is enterprise (rank 3).
+    e = ent._build(ent.TIER_TRIAL, "cloud")
+    body = e.next_tier_spec()
+    assert body is not None
+    assert body["id"] == ent.TIER_ENTERPRISE
+
+
+def test_trial_previous_spec_resolves_to_starter(ent):
+    # Trial steps down to rank 1 (starter) -- the highest rank strictly below
+    # trial's rank 2.
+    e = ent._build(ent.TIER_TRIAL, "cloud")
+    body = e.previous_tier_spec()
+    assert body is not None
+    assert body["id"] == ent.TIER_CLOUD_STARTER
+
+
+# ── grace vs enforce ─────────────────────────────────────────────────────────
+
+
+def test_grace_and_enforce_yield_same_spec(ent, monkeypatch):
+    # These helpers are catalogue-derived (off the static per-tier maps),
+    # not gated -- so flipping enforce on must not change the body.
+    e = ent._build(ent.TIER_CLOUD_STARTER, "cloud")
+    grace_body = e.next_tier_spec()
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    importlib.reload(ent)
+    ent.invalidate()
+    e2 = ent._build(ent.TIER_CLOUD_STARTER, "cloud")
+    enforce_body = e2.next_tier_spec()
+    assert enforce_body == grace_body
+
+
+# ── module-level helpers ─────────────────────────────────────────────────────
+
+
+def test_module_level_next_helper_matches_method(ent):
+    # The bare module-level helper resolves the current entitlement and
+    # delegates, so it must agree with the bound method.
+    assert ent.next_tier_spec() == ent.get_entitlement().next_tier_spec()
+
+
+def test_module_level_previous_helper_matches_method(ent):
+    assert (
+        ent.previous_tier_spec() == ent.get_entitlement().previous_tier_spec()
+    )
+
+
+def test_module_level_next_helper_never_raises(monkeypatch, ent):
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "get_entitlement", boom)
+    assert ent.next_tier_spec() is None
+
+
+def test_module_level_previous_helper_never_raises(monkeypatch, ent):
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "get_entitlement", boom)
+    assert ent.previous_tier_spec() is None
+
+
+# ── next_tier_spec_at scalar what-if ─────────────────────────────────────────
+
+
+def test_next_tier_spec_at_matches_explicit_composition(ent):
+    # The convenience is just tier_spec_at(tier, _next_purchasable_tier_after(tier))
+    # -- pin the equivalence across every source in _TIER_ORDER so the scalar
+    # accessor cannot drift from the explicit composition.
+    for tier in ent._TIER_ORDER:
+        target = ent._next_purchasable_tier_after(tier)
+        if target is None:
+            assert ent.next_tier_spec_at(tier) is None
+        else:
+            assert ent.next_tier_spec_at(tier) == ent.tier_spec_at(tier, target)
+
+
+def test_next_tier_spec_at_ceiling_returns_none(ent):
+    # enterprise sits at the source-side ceiling -- nothing strictly above.
+    assert ent.next_tier_spec_at(ent.TIER_ENTERPRISE) is None
+
+
+def test_next_tier_spec_at_shape(ent):
+    body = ent.next_tier_spec_at(ent.TIER_CLOUD_STARTER)
+    assert body is not None
+    assert set(body.keys()) == _SPEC_KEYS
+    assert body["id"] == ent.TIER_CLOUD_PRO
+    assert body["is_current"] is False
+
+
+def test_next_tier_spec_at_is_current_always_false(ent):
+    # The target is by definition strictly above source -- is_current can
+    # never be True on the returned row.
+    for tier in ent._TIER_ORDER:
+        body = ent.next_tier_spec_at(tier)
+        if body is not None:
+            assert body["is_current"] is False
+
+
+def test_next_tier_spec_at_trial_resolves_to_enterprise(ent):
+    body = ent.next_tier_spec_at(ent.TIER_TRIAL)
+    assert body is not None
+    assert body["id"] == ent.TIER_ENTERPRISE
+
+
+def test_next_tier_spec_at_unknown_inputs(ent):
+    # Defensive null-paths -- empty / unknown / None / non-string all
+    # collapse to None rather than raising.
+    assert ent.next_tier_spec_at("") is None
+    assert ent.next_tier_spec_at("nope") is None
+    assert ent.next_tier_spec_at(None) is None  # type: ignore[arg-type]
+    assert ent.next_tier_spec_at(123) is None  # type: ignore[arg-type]
+
+
+def test_next_tier_spec_at_independent_of_resolver(ent, monkeypatch):
+    # The _at family walks the static catalogue, not the gated resolver --
+    # so a synthetic resolver failure must not affect the answer.
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "get_entitlement", boom)
+    body = ent.next_tier_spec_at(ent.TIER_CLOUD_STARTER)
+    assert body is not None
+    assert body["id"] == ent.TIER_CLOUD_PRO
+
+
+def test_next_tier_spec_at_grace_vs_enforce(ent, monkeypatch):
+    grace = ent.next_tier_spec_at(ent.TIER_CLOUD_STARTER)
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    importlib.reload(ent)
+    ent.invalidate()
+    enforce = ent.next_tier_spec_at(ent.TIER_CLOUD_STARTER)
+    assert grace == enforce
+
+
+# ── previous_tier_spec_at scalar what-if ─────────────────────────────────────
+
+
+def test_previous_tier_spec_at_matches_explicit_composition(ent):
+    for tier in ent._TIER_ORDER:
+        target = ent._previous_purchasable_tier_before(tier)
+        if target is None:
+            assert ent.previous_tier_spec_at(tier) is None
+        else:
+            assert ent.previous_tier_spec_at(tier) == ent.tier_spec_at(
+                tier, target
+            )
+
+
+def test_previous_tier_spec_at_floor_returns_none(ent):
+    # OSS and cloud_free both sit at the source-side floor.
+    for tier in (ent.TIER_OSS, ent.TIER_CLOUD_FREE):
+        assert ent.previous_tier_spec_at(tier) is None
+
+
+def test_previous_tier_spec_at_shape(ent):
+    body = ent.previous_tier_spec_at(ent.TIER_CLOUD_PRO)
+    assert body is not None
+    assert set(body.keys()) == _SPEC_KEYS
+    assert body["id"] == ent.TIER_CLOUD_STARTER
+    assert body["is_current"] is False
+
+
+def test_previous_tier_spec_at_is_current_always_false(ent):
+    for tier in ent._TIER_ORDER:
+        body = ent.previous_tier_spec_at(tier)
+        if body is not None:
+            assert body["is_current"] is False
+
+
+def test_previous_tier_spec_at_trial_resolves_to_starter(ent):
+    body = ent.previous_tier_spec_at(ent.TIER_TRIAL)
+    assert body is not None
+    assert body["id"] == ent.TIER_CLOUD_STARTER
+
+
+def test_previous_tier_spec_at_unknown_inputs(ent):
+    assert ent.previous_tier_spec_at("") is None
+    assert ent.previous_tier_spec_at("nope") is None
+    assert ent.previous_tier_spec_at(None) is None  # type: ignore[arg-type]
+    assert ent.previous_tier_spec_at(123) is None  # type: ignore[arg-type]
+
+
+def test_previous_tier_spec_at_grace_vs_enforce(ent, monkeypatch):
+    grace = ent.previous_tier_spec_at(ent.TIER_CLOUD_PRO)
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    importlib.reload(ent)
+    ent.invalidate()
+    enforce = ent.previous_tier_spec_at(ent.TIER_CLOUD_PRO)
+    assert grace == enforce
+
+
+# ── /api/entitlement/next-tier-spec endpoint ────────────────────────────────
+
+
+def test_next_tier_spec_endpoint_oss_default(client, ent):
+    rv = client.get("/api/entitlement/next-tier-spec")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert set(body.keys()) == _SCALAR_ENVELOPE_KEYS
+    assert body["current_tier"] == ent.TIER_OSS
+    assert body["current_tier_label"] == ent.tier_label(ent.TIER_OSS)
+    assert body["current_tier_rank"] == ent.tier_rank(ent.TIER_OSS)
+    assert body["spec"] is not None
+    assert body["spec"]["id"] == ent.TIER_CLOUD_STARTER
+    assert body["spec"]["is_current"] is False
+    assert body["grace"] is True
+    assert body["enforced"] is False
+
+
+def test_next_tier_spec_endpoint_never_raises(client, ent, monkeypatch):
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "get_entitlement", boom)
+    rv = client.get("/api/entitlement/next-tier-spec")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["spec"] is None
+    assert body["current_tier"] == "oss"
+
+
+def test_next_tier_spec_endpoint_row_matches_helper(client, ent):
+    # The body's spec row must byte-equal the underlying helper for the
+    # live resolved entitlement -- pin the equivalence so callers can
+    # swap between the bound endpoint and the helper without copy drift.
+    rv = client.get("/api/entitlement/next-tier-spec")
+    body = rv.get_json()
+    assert body["spec"] == ent.next_tier_spec()
+
+
+# ── /api/entitlement/previous-tier-spec endpoint ────────────────────────────
+
+
+def test_previous_tier_spec_endpoint_oss_default_floor(client, ent):
+    rv = client.get("/api/entitlement/previous-tier-spec")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert set(body.keys()) == _SCALAR_ENVELOPE_KEYS
+    assert body["current_tier"] == ent.TIER_OSS
+    # OSS is the floor; nothing below to step down to.
+    assert body["spec"] is None
+
+
+def test_previous_tier_spec_endpoint_never_raises(client, ent, monkeypatch):
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "get_entitlement", boom)
+    rv = client.get("/api/entitlement/previous-tier-spec")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["spec"] is None
+    assert body["current_tier"] == "oss"
+
+
+# ── /api/entitlement/next-tier-spec-at endpoint ─────────────────────────────
+
+
+def test_next_tier_spec_at_endpoint_starter_source(client, ent):
+    rv = client.get(
+        "/api/entitlement/next-tier-spec-at",
+        query_string={"tier": ent.TIER_CLOUD_STARTER},
+    )
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert set(body.keys()) == _AT_ENVELOPE_KEYS
+    assert body["tier"] == ent.TIER_CLOUD_STARTER
+    assert body["tier_label"] == ent.tier_label(ent.TIER_CLOUD_STARTER)
+    assert body["tier_rank"] == ent.tier_rank(ent.TIER_CLOUD_STARTER)
+    assert body["target"] == ent.TIER_CLOUD_PRO
+    assert body["target_label"] == ent.tier_label(ent.TIER_CLOUD_PRO)
+    assert body["target_rank"] == ent.tier_rank(ent.TIER_CLOUD_PRO)
+    assert body["row"] is not None
+    assert body["row"]["id"] == ent.TIER_CLOUD_PRO
+    assert body["row"]["is_current"] is False
+
+
+def test_next_tier_spec_at_endpoint_ceiling_returns_null_row(client, ent):
+    rv = client.get(
+        "/api/entitlement/next-tier-spec-at",
+        query_string={"tier": ent.TIER_ENTERPRISE},
+    )
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["target"] is None
+    assert body["target_label"] is None
+    assert body["target_rank"] is None
+    assert body["row"] is None
+
+
+def test_next_tier_spec_at_endpoint_missing_tier_400(client):
+    rv = client.get("/api/entitlement/next-tier-spec-at")
+    assert rv.status_code == 400
+    assert rv.get_json() == {"error": "missing tier"}
+
+
+def test_next_tier_spec_at_endpoint_blank_tier_400(client):
+    rv = client.get(
+        "/api/entitlement/next-tier-spec-at", query_string={"tier": "   "}
+    )
+    assert rv.status_code == 400
+
+
+def test_next_tier_spec_at_endpoint_unknown_tier_404(client):
+    rv = client.get(
+        "/api/entitlement/next-tier-spec-at",
+        query_string={"tier": "nope"},
+    )
+    assert rv.status_code == 404
+    body = rv.get_json()
+    assert body["error"] == "unknown tier"
+    assert body["which"] == "tier"
+    assert body["tier"] == "nope"
+
+
+def test_next_tier_spec_at_endpoint_never_raises(client, ent, monkeypatch):
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "_next_purchasable_tier_after", boom)
+    rv = client.get(
+        "/api/entitlement/next-tier-spec-at",
+        query_string={"tier": ent.TIER_CLOUD_STARTER},
+    )
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["row"] is None
+    assert body["target"] is None
+
+
+def test_next_tier_spec_at_endpoint_row_matches_helper(client, ent):
+    # Endpoint row byte-equals the underlying helper for any valid source.
+    for tier in (
+        ent.TIER_OSS,
+        ent.TIER_CLOUD_FREE,
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_PRO,
+        ent.TIER_TRIAL,
+    ):
+        rv = client.get(
+            "/api/entitlement/next-tier-spec-at", query_string={"tier": tier}
+        )
+        assert rv.status_code == 200
+        body = rv.get_json()
+        assert body["row"] == ent.next_tier_spec_at(tier)
+
+
+# ── /api/entitlement/previous-tier-spec-at endpoint ─────────────────────────
+
+
+def test_previous_tier_spec_at_endpoint_pro_source(client, ent):
+    rv = client.get(
+        "/api/entitlement/previous-tier-spec-at",
+        query_string={"tier": ent.TIER_CLOUD_PRO},
+    )
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert set(body.keys()) == _AT_ENVELOPE_KEYS
+    assert body["tier"] == ent.TIER_CLOUD_PRO
+    assert body["target"] == ent.TIER_CLOUD_STARTER
+    assert body["row"] is not None
+    assert body["row"]["id"] == ent.TIER_CLOUD_STARTER
+    assert body["row"]["is_current"] is False
+
+
+def test_previous_tier_spec_at_endpoint_floor_returns_null_row(client, ent):
+    for tier in (ent.TIER_OSS, ent.TIER_CLOUD_FREE):
+        rv = client.get(
+            "/api/entitlement/previous-tier-spec-at",
+            query_string={"tier": tier},
+        )
+        assert rv.status_code == 200
+        body = rv.get_json()
+        assert body["target"] is None
+        assert body["row"] is None
+
+
+def test_previous_tier_spec_at_endpoint_missing_tier_400(client):
+    rv = client.get("/api/entitlement/previous-tier-spec-at")
+    assert rv.status_code == 400
+
+
+def test_previous_tier_spec_at_endpoint_unknown_tier_404(client):
+    rv = client.get(
+        "/api/entitlement/previous-tier-spec-at",
+        query_string={"tier": "nope"},
+    )
+    assert rv.status_code == 404
+
+
+def test_previous_tier_spec_at_endpoint_never_raises(client, ent, monkeypatch):
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "_previous_purchasable_tier_before", boom)
+    rv = client.get(
+        "/api/entitlement/previous-tier-spec-at",
+        query_string={"tier": ent.TIER_CLOUD_PRO},
+    )
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["row"] is None
+    assert body["target"] is None
+
+
+def test_previous_tier_spec_at_endpoint_row_matches_helper(client, ent):
+    for tier in (
+        ent.TIER_OSS,
+        ent.TIER_CLOUD_FREE,
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_PRO,
+        ent.TIER_ENTERPRISE,
+        ent.TIER_TRIAL,
+    ):
+        rv = client.get(
+            "/api/entitlement/previous-tier-spec-at",
+            query_string={"tier": tier},
+        )
+        assert rv.status_code == 200
+        body = rv.get_json()
+        assert body["row"] == ent.previous_tier_spec_at(tier)
+
+
+# ── cross-helper parity (rank-unambiguous sources only) ─────────────────────
+#
+# The live ``Entitlement.previous_purchasable_tier`` applies a cloud-vs-
+# self-hosted tie-break against the resolved source, while
+# ``_previous_purchasable_tier_before`` (used by the ``_at`` family) elides
+# that preference and breaks ties by declaration order. They therefore
+# diverge for sources whose rank cluster is ambiguous (e.g. enterprise's
+# previous can land on cloud_pro or pro). Only assert parity for sources
+# whose target rank carries a single candidate.
+
+
+def test_next_spec_scalar_equals_at_unambiguous(ent):
+    # Sources whose target rank carries a single purchasable candidate --
+    # the scalar live posture and the static _at posture must agree.
+    # oss -> cloud_starter (rank 1), cloud_free -> cloud_starter, and
+    # cloud_starter -> rank-2 cluster (ambiguous, skip).
+    for tier in (ent.TIER_OSS, ent.TIER_CLOUD_FREE):
+        e = ent._build(tier, "test")
+        assert e.next_tier_spec() == ent.next_tier_spec_at(tier)
+
+
+def test_previous_spec_scalar_equals_at_unambiguous(ent):
+    # cloud_starter -> rank 0 cluster (oss / cloud_free both candidates),
+    # rank-2 sources -> rank 1 (unambiguous: cloud_starter).
+    for tier in (ent.TIER_CLOUD_PRO, ent.TIER_PRO):
+        e = ent._build(tier, "test")
+        assert e.previous_tier_spec() == ent.previous_tier_spec_at(tier)


### PR DESCRIPTION
## Summary

- Adds the full `tier_spec`-shape descriptor lens of the `{next,previous}_tier_{diff,unlocks,locks,capacity_diff}` family that landed in #3354 / #3358 / #3359 / #3361 / #3362.
- New helpers in `clawmetry/entitlements.py`: `Entitlement.next_tier_spec` / `previous_tier_spec` (self-anchored — delegate to `tier_spec_at(self.tier, target)` rather than `tier_spec(target)` so `is_current` binds to `self.tier` rather than the live resolver), module-level wrappers, and scalar what-if `next_tier_spec_at(tier)` / `previous_tier_spec_at(tier)` mirroring the existing `_at` family.
- Four new `GET` endpoints in `routes/entitlement.py`: `/api/entitlement/next-tier-spec`, `/api/entitlement/previous-tier-spec`, `/api/entitlement/next-tier-spec-at`, `/api/entitlement/previous-tier-spec-at`.
- 52 new tests pinning method-vs-`tier_spec_at` identity, ceiling/floor `None` collapse, `is_current=False` invariant, trial source resolution, unknown/empty/`None`/non-string defensive paths, grace==enforce equivalence, never-raise on synthesised resolver failure, and the four HTTP envelopes (400 on missing `tier=`, 404 on unknown tier id, 200 + `row=null` at ceiling/floor, never 5xx). Sibling regression suite (2374 entitlement tests) still passes.

Behaviour is purely additive — the existing surface is untouched; the new helpers/endpoints fill a gap so a pricing-table cell can hydrate the full rung-above / rung-below column off ONE round-trip alongside the existing diff/unlocks/locks/capacity rows.

## Test plan

- [x] `python3 -m pytest tests/test_entitlement_next_prev_tier_spec.py` — 52/52 pass
- [x] `python3 -m pytest tests/test_entitlement*.py tests/test_entitlements*.py` — 2374/2374 pass (no regressions in the sibling helper suite)
- [x] `python3 -m py_compile clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_next_prev_tier_spec.py` — clean
- [x] `ruff check clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_next_prev_tier_spec.py` — clean
- [ ] CI matrix (Ubuntu/macOS/Windows × Python 3.9/3.11) green on push

## Local operator verification checklist

This OSS-grind PR is authored remotely; the running daemon, `~/.openclaw`, and the live cloud snapshot aren't reachable from this environment. Operator-side verification:

- [ ] `cp clawmetry/entitlements.py routes/entitlement.py ~/.clawmetry/lib/python3.*/site-packages/clawmetry/` (or your install prefix)
- [ ] `find ~/.clawmetry -name __pycache__ -type d -exec rm -rf {} +`
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
- [ ] `curl -s http://localhost:8900/api/entitlement/next-tier-spec | jq` — returns 200 with `current_tier`, `current_tier_label`, `current_tier_rank`, `spec`, `grace`, `enforced`; on an OSS-free install `spec.id == "cloud_starter"` and `spec.is_current == false`
- [ ] `curl -s http://localhost:8900/api/entitlement/previous-tier-spec | jq` — returns 200 with `spec: null` (OSS is the floor)
- [ ] `curl -s 'http://localhost:8900/api/entitlement/next-tier-spec-at?tier=cloud_starter' | jq` — returns 200 with `target=cloud_pro`, populated `row`, `row.is_current=false`
- [ ] `curl -s 'http://localhost:8900/api/entitlement/previous-tier-spec-at?tier=enterprise' | jq` — returns 200 with `target` from the rank-2 cluster, populated `row`
- [ ] `curl -s 'http://localhost:8900/api/entitlement/next-tier-spec-at?tier=nope' | jq` — returns 404 `{"error": "unknown tier", "which": "tier", "tier": "nope"}`
- [ ] `curl -s 'http://localhost:8900/api/entitlement/next-tier-spec-at' | jq` — returns 400 `{"error": "missing tier"}`
- [ ] Decrypt the live cloud snapshot client-side in the browser and confirm the entitlement diagnostic surface still renders unchanged (no behavioural drift — this PR is additive)
- [ ] Operator drives the `[RELEASE]` PR + PyPI publish + cloud deploy + cross-browser/headed verify

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01VPF2MTWMwpQsXfyPDLdw5V)_