### PR TITLE
fix: capture cron delivery outcome fields (success, failure reason, content)

### DIFF
--- a/clawmetry/adapters/openclaw.py
+++ b/clawmetry/adapters/openclaw.py
@@ -1002,6 +1002,24 @@ class OpenClawAdapter(AgentAdapter):
                 _cdt = s.get("isCronDeliveryTarget") or s.get("cronTarget")
             if _cdt is not None:
                 extra["cronDeliveryTarget"] = bool(_cdt)
+            # Cron delivery outcome (#3365): PR #93580 also stamps the delivery
+            # result (success/failure), failure reason, and delivered-content
+            # reference on the session so the next turn can see what happened.
+            _cds = s.get("cronDeliverySuccess")
+            if _cds is None:
+                _cds = s.get("cronDelivered") or s.get("deliverySuccess")
+            if _cds is not None:
+                extra["cronDeliverySuccess"] = bool(_cds)
+            _cdfr = (
+                s.get("cronDeliveryFailureReason")
+                or s.get("deliveryFailureReason")
+                or s.get("cronFailureReason")
+            )
+            if _cdfr is not None:
+                extra["cronDeliveryFailureReason"] = str(_cdfr)
+            _cdcont = s.get("cronDeliveredContent") or s.get("deliveredContent")
+            if _cdcont is not None:
+                extra["cronDeliveredContent"] = str(_cdcont)
             # GLM/Zhipu overload classification (#3343): PR #93241 classifies
             # Zhipu GLM overload as a distinct overload state for failover;
             # surface the tag so session views can indicate failover routing.


### PR DESCRIPTION
Closes #3365

## Summary

- OpenClaw PR #93580 added three delivery-outcome fields to scheduled-message sessions: success/failure state, failure reason, and delivered-content reference. ClawMetry was only capturing `cronDeliveryTarget` (bool).
- Adds alias-probed extraction for `cronDeliverySuccess`, `cronDeliveryFailureReason`, and `cronDeliveredContent` into the session `extra` dict in `clawmetry/adapters/openclaw.py`, following the exact same pattern used for every other optional harness field.
- All three fields are absent-safe: sessions without cron delivery context are unaffected.

## Test plan

- [ ] `python3 -m pytest tests/test_adapters.py tests/test_obs_gap_talk_sandbox.py -q` — 35+ tests pass, no regressions
- [ ] `python3 -m py_compile clawmetry/adapters/openclaw.py` — syntax clean
- [ ] On a session with `cronDeliveryTarget: true`, the `extra` dict now also carries `cronDeliverySuccess`, `cronDeliveryFailureReason` (on failure), and `cronDeliveredContent` (on success) when those fields are present in the JSONL record

---
_Generated by [Claude Code](https://claude.ai/code/session_015LBLcznwJbKb3VUwpJxBKo)_