### PR TITLE
chore: remove dead stop_update_check_thread() (#3370)

### DIFF
--- a/routes/update_check.py
+++ b/routes/update_check.py
@@ -465,15 +465,6 @@ def start_update_check_thread(role=None):
     log.info("Update check thread started")
 
 
-def stop_update_check_thread():
-    """Stop the background update check thread."""
-    global _update_check_thread, _update_check_stop_event
-    if _update_check_stop_event:
-        _update_check_stop_event.set()
-    if _update_check_thread:
-        _update_check_thread.join(timeout=5)
-
-
 # ── API Endpoints ─────────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
Closes #3370

## Summary

- Removes `stop_update_check_thread()` from `routes/update_check.py` — confirmed zero callers anywhere in the repo (`grep -rn` found only the definition itself)
- `start_update_check_thread()` is correctly wired in `dashboard.py` and `sync.py`; the stop counterpart was never invoked, making it unreachable dead code flagged by three consecutive weekly dead-code patrols (#3120, #3237, #3370)
- No behavioural change: the update-check daemon thread is `daemon=True` and self-terminates with the process; the missing stop hook had no runtime effect

## Test plan

- `python3 -m py_compile routes/update_check.py` — passes
- Existing update-check tests continue to pass (thread lifecycle tests only verify `start_update_check_thread`; no test references the removed function)

---
_Generated by [Claude Code](https://claude.ai/code/session_017raUNDE5zYBC2kGofJ8yUc)_