### PR TITLE
feat(entitlement): next/previous_tier_spec_at_batch + endpoints

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -6264,3 +6264,183 @@ def previous_tier_spec_at(tier: str) -> dict | None:
     except Exception as exc:
         logger.warning("entitlements: previous_tier_spec_at failed: %s", exc)
         return None
+
+
+def _spec_at_envelope(source: str, target: str | None) -> dict:
+    """Private builder for the ``{next,previous}_tier_spec_at_batch`` rows.
+
+    Spec-shaped sibling of :func:`_diff_at_envelope` and
+    :func:`_capacity_diff_at_envelope`: where those builders carry the
+    full :func:`tier_diff` row / capacity-only :func:`capacity_diff_at`
+    row pinned on both endpoints, this one carries the cumulative
+    :func:`tier_spec_at` row (the ``{id, label, is_paid, is_current,
+    rank, unlocks_paid_runtimes, retention_days, channel_limit,
+    node_limit, features, runtimes}`` shape ``tier_spec_at`` publishes)
+    pinned on both ``source`` and ``target``.
+
+    Envelope shape matches the diff / capacity ``_at`` envelopes
+    byte-for-byte on the source / target metadata so a UI can fold the
+    four batches into one pricing-comparison matrix without re-keying::
+
+        ``{tier, tier_label, tier_rank, target, target_label, target_rank, row}``
+
+    ``row`` collapses to ``None`` at the ladder ceiling / floor of the
+    source axis (``target is None``) and on a :func:`tier_spec_at`
+    builder failure, matching the diff / capacity envelopes. Never
+    raises -- every fallback collapses to a fully-populated envelope
+    with ``row=None`` so the batch keeps the per-source row visible
+    even when its per-pair spec row could not be built.
+    """
+    src = (source or "").strip().lower()
+    row: dict | None = None
+    if target is not None:
+        try:
+            row = tier_spec_at(src, target)
+        except Exception as exc:
+            logger.warning(
+                "entitlements: _spec_at_envelope builder failed for %s->%s: %s",
+                src,
+                target,
+                exc,
+            )
+            row = None
+    return {
+        "tier": src,
+        "tier_label": tier_label(src) if src in _TIER_ORDER else None,
+        "tier_rank": tier_rank(src) if src in _TIER_ORDER else -1,
+        "target": target,
+        "target_label": tier_label(target) if target else None,
+        "target_rank": tier_rank(target) if target else None,
+        "row": row,
+    }
+
+
+def next_tier_spec_at_batch() -> list[dict]:
+    """Batch sibling of :func:`next_tier_spec_at`: one
+    ``next-tier-spec-at`` envelope per purchasable source tier, in one
+    pass.
+
+    Spec-shaped sibling of :func:`next_tier_diff_at_batch` (full
+    :func:`tier_diff` payload), :func:`next_tier_unlocks_at_batch`
+    (marginal grants), :func:`next_tier_locks_at_batch` (marginal
+    losses), and :func:`next_tier_capacity_diff_at_batch` (capacity-only
+    diff). Where the diff batches answer "what *changes* at the rung
+    above each rung", this batch answers "what does the rung above each
+    rung *look like*" -- the cumulative :func:`tier_spec_at` row
+    (``id``, ``label``, ``is_paid``, ``is_current``, ``rank``,
+    ``unlocks_paid_runtimes``, ``retention_days``, ``channel_limit``,
+    ``node_limit``, ``features``, ``runtimes``) so a pricing-comparison
+    matrix UI can render the "full descriptor of the rung above each
+    rung" upgrade-CTA column off **one** round-trip instead of N calls
+    to :func:`next_tier_spec_at`.
+
+    Each envelope is byte-equal to the scalar
+    ``/api/entitlement/next-tier-spec-at?tier=<source>`` response body
+    for the same source (sans the resolver-context fields the route
+    adds around the helper output) -- a parity test pins this so the
+    batch what-if cannot drift from the scalar what-if (the same
+    invariant :func:`next_tier_diff_at_batch` enforces against
+    :func:`next_tier_diff_at`).
+
+    Envelopes are sorted by source ``(tier_rank, tier_id)`` ascending
+    -- byte-stable against :func:`next_tier_diff_at_batch` /
+    :func:`next_tier_unlocks_at_batch` / :func:`next_tier_locks_at_batch`
+    / :func:`next_tier_capacity_diff_at_batch` so a UI can fold the
+    five responses into one matrix without re-sorting client-side.
+    Same-rank sibling tiers (``cloud_pro`` / ``pro`` both at rank 2)
+    are both returned.
+
+    Source list is :data:`_PURCHASABLE_TIERS` (trial excluded),
+    matching the other ``next_*_at_batch`` siblings. The source-side
+    ceiling (``enterprise`` as source -- no rung strictly above)
+    surfaces with ``target=None`` and ``row=None`` rather than being
+    dropped, so the matrix keeps a row for every purchasable rung.
+
+    Each populated ``row``'s ``is_current`` field is always ``False``
+    (target is by definition strictly above source, so it cannot equal
+    it) -- mirrors :func:`next_tier_spec_at`.
+
+    Decoupled from the resolved entitlement (walks the static
+    catalogue), so grace vs enforce yields identical rows.
+
+    Never raises: a per-source builder failure collapses to
+    ``row=None`` on the populated envelope so the surrounding envelope
+    stays visible; an unexpected top-level failure short-circuits to
+    ``[]`` so the matrix keeps rendering instead of breaking.
+    """
+    try:
+        out: list[dict] = []
+        ordered = sorted(
+            _PURCHASABLE_TIERS, key=lambda t: (_TIER_RANK.get(t, -1), t)
+        )
+        for tid in ordered:
+            target = _next_purchasable_tier_after(tid)
+            out.append(_spec_at_envelope(tid, target))
+        return out
+    except Exception as exc:
+        logger.warning("entitlements: next_tier_spec_at_batch failed: %s", exc)
+        return []
+
+
+def previous_tier_spec_at_batch() -> list[dict]:
+    """Batch sibling of :func:`previous_tier_spec_at`: one
+    ``previous-tier-spec-at`` envelope per purchasable source tier, in
+    one pass.
+
+    Source-anchored downgrade-side mirror of
+    :func:`next_tier_spec_at_batch` and spec-shaped sibling of
+    :func:`previous_tier_diff_at_batch`,
+    :func:`previous_tier_unlocks_at_batch`,
+    :func:`previous_tier_locks_at_batch`, and
+    :func:`previous_tier_capacity_diff_at_batch`. Lets a pricing-
+    comparison matrix UI render the "full descriptor of the rung below
+    each rung" downgrade-confirmation column off **one** round-trip
+    instead of N calls to :func:`previous_tier_spec_at`.
+
+    Each envelope is byte-equal to the scalar
+    ``/api/entitlement/previous-tier-spec-at?tier=<source>`` response
+    body for the same source (sans the resolver-context fields the
+    route adds around the helper output) -- a parity test pins this so
+    the batch what-if cannot drift from the scalar what-if.
+
+    Envelopes are sorted by source ``(tier_rank, tier_id)`` ascending
+    -- byte-stable against :func:`previous_tier_diff_at_batch` /
+    :func:`previous_tier_unlocks_at_batch` /
+    :func:`previous_tier_locks_at_batch` /
+    :func:`previous_tier_capacity_diff_at_batch` so a UI can fold the
+    five responses into one matrix without re-sorting client-side.
+    Same-rank sibling tiers are both returned.
+
+    Source list is :data:`_PURCHASABLE_TIERS` (trial excluded),
+    matching the other ``previous_*_at_batch`` siblings. The
+    source-side floor (``oss`` / ``cloud_free`` as source -- no rung
+    strictly below) surfaces with ``target=None`` and ``row=None``
+    rather than being dropped, so the matrix keeps a row for every
+    purchasable rung.
+
+    Each populated ``row``'s ``is_current`` field is always ``False``
+    (target is by definition strictly below source) -- mirrors
+    :func:`previous_tier_spec_at`.
+
+    Decoupled from the resolved entitlement (walks the static
+    catalogue), so grace vs enforce yields identical rows.
+
+    Never raises: a per-source builder failure collapses to
+    ``row=None`` on the populated envelope so the surrounding envelope
+    stays visible; an unexpected top-level failure short-circuits to
+    ``[]`` so the matrix keeps rendering instead of breaking.
+    """
+    try:
+        out: list[dict] = []
+        ordered = sorted(
+            _PURCHASABLE_TIERS, key=lambda t: (_TIER_RANK.get(t, -1), t)
+        )
+        for tid in ordered:
+            target = _previous_purchasable_tier_before(tid)
+            out.append(_spec_at_envelope(tid, target))
+        return out
+    except Exception as exc:
+        logger.warning(
+            "entitlements: previous_tier_spec_at_batch failed: %s", exc
+        )
+        return []

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -5899,3 +5899,147 @@ def api_entitlement_previous_tier_spec_at():
                 "row": None,
             }
         )
+
+
+@bp_entitlement.route("/api/entitlement/next-tier-spec-at-batch")
+def api_entitlement_next_tier_spec_at_batch():
+    """``GET /api/entitlement/next-tier-spec-at-batch`` -- batch sibling
+    of ``/api/entitlement/next-tier-spec-at``: one ``next-tier-spec-at``
+    envelope per purchasable source tier, in one round-trip.
+
+    Spec-shaped sibling of ``/api/entitlement/next-tier-diff-at-batch``,
+    ``/next-tier-unlocks-at-batch``, ``/next-tier-locks-at-batch``, and
+    ``/next-tier-capacity-diff-at-batch``. Lets a pricing-comparison
+    matrix UI render the "full descriptor of the rung above each rung"
+    upgrade-CTA column off **one** call instead of N calls to
+    ``/next-tier-spec-at``.
+
+    No query params. The source list is :data:`entitlements._PURCHASABLE_TIERS`
+    (trial excluded), matching the live ``/tier-diff-batch`` endpoint
+    and the sibling diff / unlocks / locks / capacity ``_at_batch``
+    endpoints, so the five batches fold into the same pricing-page
+    table byte-for-byte on the source axis.
+
+    Response shape::
+
+        {
+          "tiers":             [<envelope>, ...],
+          "current_tier":      "<resolved tier id>",
+          "current_tier_rank": <int>,
+          "grace":             <bool>,
+          "enforced":          <bool>,
+        }
+
+    Each ``<envelope>`` matches
+    ``/api/entitlement/next-tier-spec-at?tier=<source>`` for that
+    source exactly (``tier``, ``tier_label``, ``tier_rank``,
+    ``target``, ``target_label``, ``target_rank``, ``row``). The
+    ``row`` carries the :func:`tier_spec_at` row pinned on both
+    endpoints; ``is_current`` is always ``False`` on populated rows
+    (target is strictly above source). At the source-side ceiling
+    (``enterprise`` as source) the envelope carries ``target=null``
+    and ``row=null`` rather than being dropped.
+
+    - **Never 5xxs**: a resolver failure yields an empty ``tiers``
+      list and the grace-shape envelope so the matrix keeps rendering.
+    """
+    try:
+        from clawmetry import entitlements as _ent
+
+        rows = _ent.next_tier_spec_at_batch() or []
+        ent = _ent.get_entitlement()
+        return jsonify(
+            {
+                "tiers": rows,
+                "current_tier": ent.tier,
+                "current_tier_rank": _ent.tier_rank(ent.tier),
+                "grace": bool(ent.grace),
+                "enforced": _ent.is_enforced(),
+            }
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_next_tier_spec_at_batch: error: %s", exc
+        )
+        return jsonify(
+            {
+                "tiers": [],
+                "current_tier": "oss",
+                "current_tier_rank": 0,
+                "grace": True,
+                "enforced": False,
+            }
+        )
+
+
+@bp_entitlement.route("/api/entitlement/previous-tier-spec-at-batch")
+def api_entitlement_previous_tier_spec_at_batch():
+    """``GET /api/entitlement/previous-tier-spec-at-batch`` -- batch
+    sibling of ``/api/entitlement/previous-tier-spec-at``: one
+    ``previous-tier-spec-at`` envelope per purchasable source tier, in
+    one round-trip.
+
+    Source-anchored downgrade-side mirror of
+    ``/api/entitlement/next-tier-spec-at-batch`` and spec-shaped
+    sibling of ``/previous-tier-diff-at-batch``,
+    ``/previous-tier-unlocks-at-batch``,
+    ``/previous-tier-locks-at-batch``, and
+    ``/previous-tier-capacity-diff-at-batch``. Lets a pricing-
+    comparison matrix UI render the "full descriptor of the rung below
+    each rung" downgrade-confirmation column off **one** call instead
+    of N calls to ``/previous-tier-spec-at``.
+
+    No query params. The source list is :data:`entitlements._PURCHASABLE_TIERS`
+    (trial excluded), matching the sibling ``_at_batch`` endpoints, so
+    the five batches fold into the same pricing-page table byte-for-
+    byte on the source axis.
+
+    Response shape::
+
+        {
+          "tiers":             [<envelope>, ...],
+          "current_tier":      "<resolved tier id>",
+          "current_tier_rank": <int>,
+          "grace":             <bool>,
+          "enforced":          <bool>,
+        }
+
+    Each ``<envelope>`` matches
+    ``/api/entitlement/previous-tier-spec-at?tier=<source>`` for that
+    source exactly. The ``row`` carries the :func:`tier_spec_at` row
+    pinned on both endpoints; ``is_current`` is always ``False`` on
+    populated rows (target is strictly below source). At the
+    source-side floor (``oss`` / ``cloud_free`` as source) the
+    envelope carries ``target=null`` and ``row=null`` rather than
+    being dropped.
+
+    - **Never 5xxs**: a resolver failure yields an empty ``tiers``
+      list and the grace-shape envelope so the matrix keeps rendering.
+    """
+    try:
+        from clawmetry import entitlements as _ent
+
+        rows = _ent.previous_tier_spec_at_batch() or []
+        ent = _ent.get_entitlement()
+        return jsonify(
+            {
+                "tiers": rows,
+                "current_tier": ent.tier,
+                "current_tier_rank": _ent.tier_rank(ent.tier),
+                "grace": bool(ent.grace),
+                "enforced": _ent.is_enforced(),
+            }
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_previous_tier_spec_at_batch: error: %s", exc
+        )
+        return jsonify(
+            {
+                "tiers": [],
+                "current_tier": "oss",
+                "current_tier_rank": 0,
+                "grace": True,
+                "enforced": False,
+            }
+        )

--- a/tests/test_entitlement_next_prev_tier_spec_at_batch.py
+++ b/tests/test_entitlement_next_prev_tier_spec_at_batch.py
@@ -1,0 +1,541 @@
+"""Tests for ``next_tier_spec_at_batch`` /
+``previous_tier_spec_at_batch`` and the companion
+``/api/entitlement/{next,previous}-tier-spec-at-batch`` endpoints,
+plus the private :func:`_spec_at_envelope` builder the batches share.
+
+Batch siblings of the scalar
+``{next,previous}_tier_spec_at`` what-ifs that landed alongside the
+live ``next_tier_spec`` / ``previous_tier_spec`` accessors. Where the
+scalar what-ifs answer "what does the rung above / below ``tier``
+look like" one source at a time, the batch siblings return the same
+envelope for every entry in :data:`_PURCHASABLE_TIERS` in one pass --
+the spec-shaped member of the ``{next,previous}_tier_*_at_batch``
+family alongside the diff / unlocks / locks / capacity siblings.
+
+Pins covered here:
+
+* :func:`_spec_at_envelope` composes source / target metadata with
+  the per-pair :func:`tier_spec_at` row in the same envelope shape
+  :func:`_diff_at_envelope` / :func:`_capacity_diff_at_envelope`
+  publish -- ``tier``, ``tier_label``, ``tier_rank``, ``target``,
+  ``target_label``, ``target_rank``, ``row``
+* both batches return one envelope per entry in
+  :data:`_PURCHASABLE_TIERS`, sorted by ``(tier_rank, tier_id)``
+* every batch envelope byte-equals the scalar endpoint body for the
+  same source -- the batch-vs-scalar parity that stops the batch
+  what-if drifting from the scalar what-if
+* cross-batch parity with the diff / unlocks / locks / capacity
+  ``_at_batch`` siblings: the source axis (envelope ``tier`` /
+  ``tier_label`` / ``tier_rank`` and ordering) byte-equals each
+  sibling so a UI can fold all five batches into one matrix
+* at the source-side ceiling (``enterprise`` for next) / floor
+  (``oss`` / ``cloud_free`` for previous) the envelope carries
+  ``target=null`` and ``row=null`` rather than being dropped
+* trial is excluded from the source axis (mirrors the sibling
+  batches)
+* on populated rows the inner ``row.is_current`` is always ``False``
+  (target is strictly above / below source by construction)
+* the helpers never raise: a per-source builder failure collapses
+  to ``row=null`` on the populated envelope; a top-level failure
+  short-circuits to ``[]``
+* grace vs enforce yields identical rows (the helpers walk the
+  static catalogue, not the gated resolver)
+* the API endpoints never 5xx: a resolver failure yields an empty
+  ``tiers`` list and a grace-shape envelope
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+_ENVELOPE_KEYS = {
+    "tier",
+    "tier_label",
+    "tier_rank",
+    "target",
+    "target_label",
+    "target_rank",
+    "row",
+}
+
+_SPEC_ROW_KEYS = {
+    "id",
+    "label",
+    "is_paid",
+    "is_current",
+    "rank",
+    "unlocks_paid_runtimes",
+    "retention_days",
+    "channel_limit",
+    "node_limit",
+    "features",
+    "runtimes",
+}
+
+_BATCH_RESPONSE_KEYS = {
+    "tiers",
+    "current_tier",
+    "current_tier_rank",
+    "grace",
+    "enforced",
+}
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    """Fresh entitlements module with HOME pointed at an empty tmp dir
+    so no real ~/.clawmetry/license.key or cloud_plan.json leaks in.
+    Enforcement off by default (grace mode) -- the spec ``_at`` family
+    is catalogue-derived and independent of the resolver, so the
+    fixture only needs to keep the live resolver from surprising the
+    test."""
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# ── _spec_at_envelope ────────────────────────────────────────────────────────
+
+
+def test_spec_envelope_shape_for_known_pair(ent):
+    env = ent._spec_at_envelope(ent.TIER_OSS, ent.TIER_CLOUD_STARTER)
+    assert set(env.keys()) == _ENVELOPE_KEYS
+    assert env["tier"] == ent.TIER_OSS
+    assert env["tier_label"] == ent.tier_label(ent.TIER_OSS)
+    assert env["tier_rank"] == ent.tier_rank(ent.TIER_OSS)
+    assert env["target"] == ent.TIER_CLOUD_STARTER
+    assert env["target_label"] == ent.tier_label(ent.TIER_CLOUD_STARTER)
+    assert env["target_rank"] == ent.tier_rank(ent.TIER_CLOUD_STARTER)
+    assert env["row"] == ent.tier_spec_at(
+        ent.TIER_OSS, ent.TIER_CLOUD_STARTER
+    )
+
+
+def test_spec_envelope_none_target_collapses_row(ent):
+    env = ent._spec_at_envelope(ent.TIER_ENTERPRISE, None)
+    assert env["tier"] == ent.TIER_ENTERPRISE
+    assert env["tier_label"] == ent.tier_label(ent.TIER_ENTERPRISE)
+    assert env["target"] is None
+    assert env["target_label"] is None
+    assert env["target_rank"] is None
+    assert env["row"] is None
+
+
+def test_spec_envelope_unknown_source_keeps_envelope_populated(ent):
+    env = ent._spec_at_envelope("bogus", ent.TIER_CLOUD_STARTER)
+    assert set(env.keys()) == _ENVELOPE_KEYS
+    # tier_spec_at returns None on unknown source -- the envelope
+    # surfaces row=None but keeps target metadata so the batch row
+    # stays visible.
+    assert env["tier_label"] is None
+    assert env["tier_rank"] == -1
+    assert env["target"] == ent.TIER_CLOUD_STARTER
+    assert env["row"] is None
+
+
+def test_spec_envelope_trims_and_lowercases(ent):
+    env = ent._spec_at_envelope("  OSS  ", ent.TIER_CLOUD_STARTER)
+    assert env["tier"] == ent.TIER_OSS
+    assert env["target"] == ent.TIER_CLOUD_STARTER
+    assert env["row"] == ent.tier_spec_at(
+        ent.TIER_OSS, ent.TIER_CLOUD_STARTER
+    )
+
+
+def test_spec_envelope_swallows_builder_exception(ent, monkeypatch):
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "tier_spec_at", boom)
+    env = ent._spec_at_envelope(ent.TIER_OSS, ent.TIER_CLOUD_STARTER)
+    assert env["target"] == ent.TIER_CLOUD_STARTER
+    assert env["row"] is None
+
+
+# ── next_tier_spec_at_batch ──────────────────────────────────────────────────
+
+
+def test_next_spec_batch_returns_list_for_every_purchasable_source(ent):
+    rows = ent.next_tier_spec_at_batch()
+    assert isinstance(rows, list)
+    assert len(rows) == len(ent._PURCHASABLE_TIERS)
+
+
+def test_next_spec_batch_each_envelope_has_envelope_shape(ent):
+    for env in ent.next_tier_spec_at_batch():
+        assert set(env.keys()) == _ENVELOPE_KEYS
+
+
+def test_next_spec_batch_source_axis_matches_purchasable(ent):
+    rows = ent.next_tier_spec_at_batch()
+    sources = {env["tier"] for env in rows}
+    assert sources == set(ent._PURCHASABLE_TIERS)
+
+
+def test_next_spec_batch_excludes_trial_from_sources(ent):
+    sources = {env["tier"] for env in ent.next_tier_spec_at_batch()}
+    assert ent.TIER_TRIAL not in sources
+
+
+def test_next_spec_batch_sorted_by_rank_then_id(ent):
+    rows = ent.next_tier_spec_at_batch()
+    keys = [(env["tier_rank"], env["tier"]) for env in rows]
+    assert keys == sorted(keys)
+
+
+def test_next_spec_batch_enterprise_source_ceiling_collapses(ent):
+    rows = ent.next_tier_spec_at_batch()
+    ent_row = next(env for env in rows if env["tier"] == ent.TIER_ENTERPRISE)
+    assert ent_row["target"] is None
+    assert ent_row["target_label"] is None
+    assert ent_row["target_rank"] is None
+    assert ent_row["row"] is None
+
+
+def test_next_spec_batch_populated_rows_have_spec_row_shape(ent):
+    for env in ent.next_tier_spec_at_batch():
+        if env["row"] is None:
+            continue
+        assert set(env["row"].keys()) == _SPEC_ROW_KEYS
+        # row.id is byte-equal to envelope.target on every populated
+        # row -- the spec descriptor identifies the target tier so the
+        # envelope's two slots must agree.
+        assert env["row"]["id"] == env["target"]
+
+
+def test_next_spec_batch_populated_rows_have_is_current_false(ent):
+    # Target is strictly above source by construction, so it can never
+    # equal it -- ``is_current`` is therefore always False on populated
+    # rows. Mirrors :func:`next_tier_spec_at`.
+    for env in ent.next_tier_spec_at_batch():
+        if env["row"] is None:
+            continue
+        assert env["row"]["is_current"] is False
+
+
+def test_next_spec_batch_matches_scalar_helper_per_source(ent):
+    for env in ent.next_tier_spec_at_batch():
+        assert env["row"] == ent.next_tier_spec_at(env["tier"])
+
+
+def test_next_spec_batch_source_axis_matches_diff_batch(ent):
+    # The five ``_at_batch`` siblings (diff / unlocks / locks /
+    # capacity / spec) MUST agree on the source axis -- envelope
+    # ``tier``, ``tier_label``, ``tier_rank`` and ordering -- so a UI
+    # can fold the five responses into one matrix without re-keying.
+    spec = ent.next_tier_spec_at_batch()
+    diff = ent.next_tier_diff_at_batch()
+    cap = ent.next_tier_capacity_diff_at_batch()
+    unl = ent.next_tier_unlocks_at_batch()
+    lck = ent.next_tier_locks_at_batch()
+    spec_keys = [(env["tier_rank"], env["tier"]) for env in spec]
+    for sibling in (diff, cap, unl, lck):
+        sibling_keys = [(env["tier_rank"], env["tier"]) for env in sibling]
+        assert sibling_keys == spec_keys
+
+
+def test_next_spec_batch_target_axis_matches_diff_batch(ent):
+    # The target a UI lands on at each rung MUST agree across the
+    # ``_at_batch`` siblings -- otherwise spec / diff would render
+    # different upgrade rungs in the same matrix row.
+    spec = {env["tier"]: env for env in ent.next_tier_spec_at_batch()}
+    diff = {env["tier"]: env for env in ent.next_tier_diff_at_batch()}
+    assert set(spec.keys()) == set(diff.keys())
+    for tier in spec:
+        assert spec[tier]["target"] == diff[tier]["target"], tier
+        assert spec[tier]["target_rank"] == diff[tier]["target_rank"], tier
+        assert spec[tier]["target_label"] == diff[tier]["target_label"], tier
+
+
+def test_next_spec_batch_grace_and_enforce_match(ent, monkeypatch):
+    grace = ent.next_tier_spec_at_batch()
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    importlib.reload(ent)
+    ent.invalidate()
+    enforce = ent.next_tier_spec_at_batch()
+    assert enforce == grace
+
+
+def test_next_spec_batch_top_level_failure_short_circuits_to_empty(
+    ent, monkeypatch
+):
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "_PURCHASABLE_TIERS", boom)
+    assert ent.next_tier_spec_at_batch() == []
+
+
+def test_next_spec_batch_per_row_failure_collapses_to_row_null(
+    ent, monkeypatch
+):
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "tier_spec_at", boom)
+    rows = ent.next_tier_spec_at_batch()
+    assert rows
+    for env in rows:
+        assert set(env.keys()) == _ENVELOPE_KEYS
+        assert env["row"] is None
+
+
+def test_next_spec_batch_independent_of_resolver(ent, monkeypatch):
+    def boom(*_, **__):
+        raise RuntimeError("resolver must not be reached")
+
+    monkeypatch.setattr(ent, "get_entitlement", boom)
+    rows = ent.next_tier_spec_at_batch()
+    assert len(rows) == len(ent._PURCHASABLE_TIERS)
+
+
+# ── previous_tier_spec_at_batch ──────────────────────────────────────────────
+
+
+def test_prev_spec_batch_returns_list_for_every_purchasable_source(ent):
+    rows = ent.previous_tier_spec_at_batch()
+    assert isinstance(rows, list)
+    assert len(rows) == len(ent._PURCHASABLE_TIERS)
+
+
+def test_prev_spec_batch_each_envelope_has_envelope_shape(ent):
+    for env in ent.previous_tier_spec_at_batch():
+        assert set(env.keys()) == _ENVELOPE_KEYS
+
+
+def test_prev_spec_batch_source_axis_matches_purchasable(ent):
+    rows = ent.previous_tier_spec_at_batch()
+    sources = {env["tier"] for env in rows}
+    assert sources == set(ent._PURCHASABLE_TIERS)
+
+
+def test_prev_spec_batch_excludes_trial_from_sources(ent):
+    sources = {env["tier"] for env in ent.previous_tier_spec_at_batch()}
+    assert ent.TIER_TRIAL not in sources
+
+
+def test_prev_spec_batch_sorted_by_rank_then_id(ent):
+    rows = ent.previous_tier_spec_at_batch()
+    keys = [(env["tier_rank"], env["tier"]) for env in rows]
+    assert keys == sorted(keys)
+
+
+def test_prev_spec_batch_floor_sources_collapse(ent):
+    rows = {env["tier"]: env for env in ent.previous_tier_spec_at_batch()}
+    for floor in (ent.TIER_OSS, ent.TIER_CLOUD_FREE):
+        env = rows[floor]
+        assert env["target"] is None
+        assert env["target_label"] is None
+        assert env["target_rank"] is None
+        assert env["row"] is None
+
+
+def test_prev_spec_batch_populated_rows_have_spec_row_shape(ent):
+    for env in ent.previous_tier_spec_at_batch():
+        if env["row"] is None:
+            continue
+        assert set(env["row"].keys()) == _SPEC_ROW_KEYS
+        assert env["row"]["id"] == env["target"]
+
+
+def test_prev_spec_batch_populated_rows_have_is_current_false(ent):
+    for env in ent.previous_tier_spec_at_batch():
+        if env["row"] is None:
+            continue
+        assert env["row"]["is_current"] is False
+
+
+def test_prev_spec_batch_matches_scalar_helper_per_source(ent):
+    for env in ent.previous_tier_spec_at_batch():
+        assert env["row"] == ent.previous_tier_spec_at(env["tier"])
+
+
+def test_prev_spec_batch_source_axis_matches_diff_batch(ent):
+    spec = ent.previous_tier_spec_at_batch()
+    diff = ent.previous_tier_diff_at_batch()
+    cap = ent.previous_tier_capacity_diff_at_batch()
+    unl = ent.previous_tier_unlocks_at_batch()
+    lck = ent.previous_tier_locks_at_batch()
+    spec_keys = [(env["tier_rank"], env["tier"]) for env in spec]
+    for sibling in (diff, cap, unl, lck):
+        sibling_keys = [(env["tier_rank"], env["tier"]) for env in sibling]
+        assert sibling_keys == spec_keys
+
+
+def test_prev_spec_batch_target_axis_matches_diff_batch(ent):
+    spec = {env["tier"]: env for env in ent.previous_tier_spec_at_batch()}
+    diff = {env["tier"]: env for env in ent.previous_tier_diff_at_batch()}
+    assert set(spec.keys()) == set(diff.keys())
+    for tier in spec:
+        assert spec[tier]["target"] == diff[tier]["target"], tier
+        assert spec[tier]["target_rank"] == diff[tier]["target_rank"], tier
+        assert spec[tier]["target_label"] == diff[tier]["target_label"], tier
+
+
+def test_prev_spec_batch_grace_and_enforce_match(ent, monkeypatch):
+    grace = ent.previous_tier_spec_at_batch()
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    importlib.reload(ent)
+    ent.invalidate()
+    enforce = ent.previous_tier_spec_at_batch()
+    assert enforce == grace
+
+
+def test_prev_spec_batch_top_level_failure_short_circuits_to_empty(
+    ent, monkeypatch
+):
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "_PURCHASABLE_TIERS", boom)
+    assert ent.previous_tier_spec_at_batch() == []
+
+
+def test_prev_spec_batch_per_row_failure_collapses_to_row_null(
+    ent, monkeypatch
+):
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "tier_spec_at", boom)
+    rows = ent.previous_tier_spec_at_batch()
+    assert rows
+    for env in rows:
+        assert set(env.keys()) == _ENVELOPE_KEYS
+        assert env["row"] is None
+
+
+def test_prev_spec_batch_independent_of_resolver(ent, monkeypatch):
+    def boom(*_, **__):
+        raise RuntimeError("resolver must not be reached")
+
+    monkeypatch.setattr(ent, "get_entitlement", boom)
+    rows = ent.previous_tier_spec_at_batch()
+    assert len(rows) == len(ent._PURCHASABLE_TIERS)
+
+
+# ── API: /api/entitlement/next-tier-spec-at-batch ────────────────────────────
+
+
+def test_next_spec_batch_endpoint_returns_envelopes(client, ent):
+    rv = client.get("/api/entitlement/next-tier-spec-at-batch")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert set(body.keys()) == _BATCH_RESPONSE_KEYS
+    assert isinstance(body["tiers"], list)
+    assert len(body["tiers"]) == len(ent._PURCHASABLE_TIERS)
+    for env in body["tiers"]:
+        assert set(env.keys()) == _ENVELOPE_KEYS
+
+
+def test_next_spec_batch_endpoint_resolver_context(client, ent):
+    rv = client.get("/api/entitlement/next-tier-spec-at-batch")
+    body = rv.get_json()
+    resolved = ent.get_entitlement()
+    assert body["current_tier"] == resolved.tier
+    assert body["current_tier_rank"] == ent.tier_rank(resolved.tier)
+    assert body["grace"] == bool(resolved.grace)
+    assert body["enforced"] == ent.is_enforced()
+
+
+def test_next_spec_batch_endpoint_matches_helper(client, ent):
+    rv = client.get("/api/entitlement/next-tier-spec-at-batch")
+    assert rv.get_json()["tiers"] == ent.next_tier_spec_at_batch()
+
+
+def test_next_spec_batch_endpoint_matches_scalar_per_source(client, ent):
+    batch = client.get(
+        "/api/entitlement/next-tier-spec-at-batch"
+    ).get_json()["tiers"]
+    by_tier = {env["tier"]: env for env in batch}
+    for src in ent._PURCHASABLE_TIERS:
+        scalar = client.get(
+            f"/api/entitlement/next-tier-spec-at?tier={src}"
+        ).get_json()
+        assert by_tier[src] == scalar
+
+
+def test_next_spec_batch_endpoint_never_raises(client, ent, monkeypatch):
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "next_tier_spec_at_batch", boom)
+    rv = client.get("/api/entitlement/next-tier-spec-at-batch")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["tiers"] == []
+    assert body["current_tier"] == "oss"
+    assert body["current_tier_rank"] == 0
+    assert body["grace"] is True
+    assert body["enforced"] is False
+
+
+# ── API: /api/entitlement/previous-tier-spec-at-batch ────────────────────────
+
+
+def test_prev_spec_batch_endpoint_returns_envelopes(client, ent):
+    rv = client.get("/api/entitlement/previous-tier-spec-at-batch")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert set(body.keys()) == _BATCH_RESPONSE_KEYS
+    assert isinstance(body["tiers"], list)
+    assert len(body["tiers"]) == len(ent._PURCHASABLE_TIERS)
+
+
+def test_prev_spec_batch_endpoint_resolver_context(client, ent):
+    rv = client.get("/api/entitlement/previous-tier-spec-at-batch")
+    body = rv.get_json()
+    resolved = ent.get_entitlement()
+    assert body["current_tier"] == resolved.tier
+    assert body["current_tier_rank"] == ent.tier_rank(resolved.tier)
+    assert body["grace"] == bool(resolved.grace)
+    assert body["enforced"] == ent.is_enforced()
+
+
+def test_prev_spec_batch_endpoint_matches_helper(client, ent):
+    rv = client.get("/api/entitlement/previous-tier-spec-at-batch")
+    assert rv.get_json()["tiers"] == ent.previous_tier_spec_at_batch()
+
+
+def test_prev_spec_batch_endpoint_matches_scalar_per_source(client, ent):
+    batch = client.get(
+        "/api/entitlement/previous-tier-spec-at-batch"
+    ).get_json()["tiers"]
+    by_tier = {env["tier"]: env for env in batch}
+    for src in ent._PURCHASABLE_TIERS:
+        scalar = client.get(
+            f"/api/entitlement/previous-tier-spec-at?tier={src}"
+        ).get_json()
+        assert by_tier[src] == scalar
+
+
+def test_prev_spec_batch_endpoint_never_raises(client, ent, monkeypatch):
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "previous_tier_spec_at_batch", boom)
+    rv = client.get("/api/entitlement/previous-tier-spec-at-batch")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["tiers"] == []
+    assert body["current_tier"] == "oss"
+    assert body["current_tier_rank"] == 0
+    assert body["grace"] is True
+    assert body["enforced"] is False


### PR DESCRIPTION
## Summary

- Adds the spec-shaped batch siblings to the `*_at_batch` family — `next_tier_spec_at_batch()` / `previous_tier_spec_at_batch()` and the matching `GET /api/entitlement/{next,previous}-tier-spec-at-batch` endpoints. Each returns one envelope per purchasable source tier where `row` is the full `tier_spec_at` descriptor of the rung above (next) or below (previous) that source.
- Shares the seven-key envelope shape (`tier`, `tier_label`, `tier_rank`, `target`, `target_label`, `target_rank`, `row`) with the four sibling `_at_batch` surfaces (diff / unlocks / locks / capacity), so a pricing-comparison matrix UI can fold all five batches into one row per rung off **one** round-trip per surface instead of N calls to the scalar `_at` what-ifs.
- Catalogue-only / decoupled from the resolved entitlement: grace vs enforce yield identical rows. Behaviour of the live resolver and existing endpoints is unchanged.

## What this fills

The `next_tier_spec_at` / `previous_tier_spec_at` scalar what-ifs landed in #3371. The four other axes of the `_at_batch` family already exist:

| axis | scalar `_at` | batch `_at_batch` |
| --- | --- | --- |
| diff | ✅ | ✅ |
| unlocks | ✅ | ✅ |
| locks | ✅ | ✅ |
| capacity | ✅ | ✅ |
| **spec** | ✅ | ❌ → ✅ (this PR) |

So the spec batch siblings were the only remaining gap on the `_at_batch` matrix axis.

## Files

- `clawmetry/entitlements.py` (+180)
  - `_spec_at_envelope(source, target)` — private envelope builder, mirror of `_diff_at_envelope` / `_capacity_diff_at_envelope`
  - `next_tier_spec_at_batch()` / `previous_tier_spec_at_batch()`
- `routes/entitlement.py` (+144)
  - `GET /api/entitlement/next-tier-spec-at-batch`
  - `GET /api/entitlement/previous-tier-spec-at-batch`
- `tests/test_entitlement_next_prev_tier_spec_at_batch.py` (+45 tests, all passing)

## Test plan

- [x] `python3 -m pytest tests/test_entitlement_next_prev_tier_spec_at_batch.py` → **45 passed**
- [x] `python3 -m pytest tests/ -k entitlement` → **2428 passed** (3 pre-existing collection errors unrelated to this PR: missing `duckdb` module in CI image for `test_license.py::test_activate_then_entitlement_resolves_pro`, `test_license_audit.py::test_deactivate_clears_entitlement_cache`, `test_retention_prune.py::test_entitlement_retention_value_drives_prune`)
- [x] `ruff check clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_next_prev_tier_spec_at_batch.py` → clean
- [x] `python3 -m py_compile` on changed files → clean

Pins covered (per test file):

- `_spec_at_envelope` envelope shape (7 keys), `target=None` collapses `row`, unknown source keeps envelope populated with `row=None`, trims/lowercases, swallows builder exception
- Both batches return one envelope per `_PURCHASABLE_TIERS` source, sorted by `(tier_rank, tier_id)`, trial excluded
- Ceiling (`enterprise` as source for next) / floor (`oss` / `cloud_free` as source for previous) collapses to `target=None`, `row=None`
- Populated rows carry full `tier_spec_at` row shape (11 keys); `is_current` always `False`
- **Cross-batch parity**: source axis (`tier`/`tier_label`/`tier_rank` + order) byte-equals all four sibling `_at_batch` surfaces; target axis byte-equals `*_diff_at_batch`
- Scalar-vs-batch byte parity per source (the same invariant the diff / capacity batches enforce against their scalar what-ifs)
- Grace == enforce (catalogue-derived, not resolver-derived)
- Top-level exception → `[]`; per-row builder exception → `row=None` on populated envelope
- Endpoints: 200 with batch-response shape (`tiers`, `current_tier`, `current_tier_rank`, `grace`, `enforced`); resolver-context fields; helper / scalar parity; never-5xx fallback to grace-shape envelope with `tiers=[]`

## Local operator verification checklist

The session that opened this PR has no access to the live daemon, `~/.openclaw`, or the cloud snapshot. To verify before flipping out of draft:

- [ ] Copy `clawmetry/entitlements.py`, `routes/entitlement.py`, and the new test file into `~/.clawmetry/lib/python3.X/site-packages/clawmetry/` (and matching `routes/`)
- [ ] Clear `__pycache__` under the install prefix
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` to bounce the daemon
- [ ] `curl -s http://localhost:8900/api/entitlement/next-tier-spec-at-batch | jq` — confirm seven-key envelopes, sorted by `(tier_rank, tier_id)`, `enterprise` row collapsed to `row=null`, every other populated row has `is_current: false`
- [ ] `curl -s http://localhost:8900/api/entitlement/previous-tier-spec-at-batch | jq` — same shape, `oss` / `cloud_free` rows collapsed
- [ ] Sanity-check folding the five `_at_batch` surfaces in JS (`next-tier-{diff,unlocks,locks,capacity-diff,spec}-at-batch`): the rows should align on `tier` and `target` byte-for-byte
- [ ] Decrypt the live cloud snapshot and confirm no new fields appear in transit (catalogue-only helpers; should round-trip identically)
- [ ] Browser check: `/api/entitlement` unchanged, pricing-page placeholder still renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jfaad4b35guZkLJGWc2xYZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jfaad4b35guZkLJGWc2xYZ)_