### PR TITLE
feat(entitlement): tier_spec_path + /api/entitlement/tier-spec-path

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -6444,3 +6444,116 @@ def previous_tier_spec_at_batch() -> list[dict]:
             "entitlements: previous_tier_spec_at_batch failed: %s", exc
         )
         return []
+
+
+def tier_spec_path(from_tier: str, to_tier: str) -> list[dict] | None:
+    """Arbitrary-endpoint stepwise spec-shaped path between two tiers.
+
+    Spec-shaped sibling of :func:`tier_path` (full ``tier_diff`` per
+    rung), :func:`capacity_diff_path` (capacity-only per rung),
+    :func:`tier_unlocks_path` (marginal grants per rung),
+    :func:`tier_locks_path` (marginal losses per rung), and
+    :func:`preview_path` (cumulative ``Entitlement.to_dict`` per rung)
+    -- the spec-shaped member of the ``_path`` family, the path-shaped
+    sibling of :func:`tier_spec_at_batch` (which is a fixed-source what-
+    if matrix over many targets) and the bulk what-if cousin of
+    :func:`tier_spec_at`. Lets a pricing-comparison "compare A vs B"
+    surface render the slim catalogue-shaped descriptor
+    (``id``, ``label``, ``is_paid``, ``is_current``, ``rank``,
+    ``unlocks_paid_runtimes``, ``retention_days``, ``channel_limit``,
+    ``node_limit``, ``features``, ``runtimes``) at every rung between
+    any two tiers off ONE round-trip, without folding marketing fields
+    (``is_paid``, ``label``, ``unlocks_paid_runtimes``) back in from a
+    separate ``/tier-catalog`` lookup the way a ``/preview-path`` row
+    forces.
+
+    Per-rung row shape matches :func:`tier_spec_at` exactly -- the same
+    key set with ``is_current`` always ``False`` on walked rungs
+    (``from_tier`` is excluded from the walked set, so the rung-equals-
+    from-tier perspective never appears) -- so a UI that already
+    renders a ``/tier-spec-at`` row needs zero new shape code to render
+    a per-rung row off this path. A parity test pins this so the
+    scalar what-if and path what-if cannot drift.
+
+    Walk semantics mirror :func:`tier_path` / :func:`capacity_diff_path`
+    / :func:`tier_unlocks_path` / :func:`tier_locks_path` /
+    :func:`preview_path` byte-for-byte (same ``_PURCHASABLE_TIERS``
+    filter + same sort key + same destination-sibling exclusion), so
+    the rung ``id`` ids from this helper line up rung-for-rung against
+    the rung ``tier`` ids from those five helpers -- the six paths
+    walk the same rungs in the same order. Same-rank siblings strictly
+    between the endpoints are both included (matching :func:`tier_path`
+    's ladder shape); same-rank siblings of the destination are
+    excluded so the path terminates exactly at ``to_tier`` and not at
+    one of its rank peers.
+
+    Direction semantics (all rows share the same cumulative spec
+    shape; only the sequence changes):
+
+    * ``upgrade`` (ascending) -- rows climb cumulatively from the rung
+      above ``from_tier`` toward ``to_tier``; the natural "what does
+      each rung above me look like" walkthrough.
+    * ``downgrade`` (descending) -- rows shrink cumulatively rung by
+      rung; the cancellation-walkthrough counterpart.
+    * ``lateral`` (same rank, different id) -- single-row path; row
+      carries the cumulative spec at ``to_tier``.
+    * ``identity`` (``from == to``) -- empty path; no rungs to walk.
+
+    Endpoint semantics match :func:`tier_path` / :func:`tier_diff`:
+    both ids accept any entry in :data:`_TIER_FEATURES` (including
+    :data:`TIER_TRIAL`, which is not purchasable -- it is excluded
+    from the walked intermediate rungs but is a valid endpoint via the
+    lateral branch). Unknown ids on either side short-circuit to
+    ``None``.
+
+    Resolver-independent: walks the static per-tier maps via
+    :func:`tier_spec_at` (which pins ``is_current`` to the hypothetical
+    perspective of ``from_tier``, not the live resolved entitlement),
+    so flipping enforce on yields byte-identical rows -- same property
+    the rest of the ``_path`` family guarantees.
+
+    Never raises: a resolver failure logs a warning and returns
+    ``None`` so a pricing-page surface keeps rendering instead of
+    breaking.
+    """
+    try:
+        f = (from_tier or "").strip().lower()
+        t = (to_tier or "").strip().lower()
+        if f not in _TIER_FEATURES or t not in _TIER_FEATURES:
+            return None
+        if f == t:
+            return []
+        from_rank = _TIER_RANK.get(f, -1)
+        to_rank = _TIER_RANK.get(t, -1)
+        if from_rank == to_rank:
+            row = tier_spec_at(f, t)
+            return [row] if row is not None else []
+        ascending = to_rank > from_rank
+        if ascending:
+            ordered = sorted(
+                _PURCHASABLE_TIERS,
+                key=lambda x: (_TIER_RANK.get(x, -1), x),
+            )
+        else:
+            ordered = sorted(
+                _PURCHASABLE_TIERS,
+                key=lambda x: (-_TIER_RANK.get(x, -1), x),
+            )
+        path: list[dict] = []
+        for tid in ordered:
+            r = _TIER_RANK.get(tid, -1)
+            if ascending:
+                if r <= from_rank or r > to_rank:
+                    continue
+            else:
+                if r >= from_rank or r < to_rank:
+                    continue
+            if r == to_rank and tid != t:
+                continue
+            row = tier_spec_at(f, tid)
+            if row is not None:
+                path.append(row)
+        return path
+    except Exception as exc:
+        logger.warning("entitlements: tier_spec_path failed: %s", exc)
+        return None

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -188,6 +188,25 @@ is the single source of truth -- handlers never re-derive tier logic here.
                                          hypothetical perspective in one
                                          round-trip instead of fetching the
                                          full ``/tier-catalog-at`` payload.
+  GET  /api/entitlement/tier-spec-path -- arbitrary-endpoint stepwise spec-
+                                         shaped path between any two tiers
+                                         (``?from=&to=``); path-shaped
+                                         sibling of ``/tier-spec-at-batch``
+                                         and spec-shaped sibling of
+                                         ``/tier-path`` / ``/capacity-diff-
+                                         path`` / ``/tier-unlocks-path`` /
+                                         ``/tier-locks-path`` / ``/preview-
+                                         path``. Each row is a
+                                         ``tier_spec_at`` row pinned on
+                                         ``from=`` for ``target=<rung>``, so
+                                         the marketing-shaped descriptor
+                                         (``label``, ``is_paid``,
+                                         ``unlocks_paid_runtimes``,
+                                         ``retention_days``,
+                                         ``channel_limit``, ``node_limit``,
+                                         ``features``, ``runtimes``) hydrates
+                                         at every rung between two tiers
+                                         off one round-trip.
 """
 
 from __future__ import annotations
@@ -6042,4 +6061,110 @@ def api_entitlement_previous_tier_spec_at_batch():
                 "grace": True,
                 "enforced": False,
             }
+        )
+
+
+@bp_entitlement.route("/api/entitlement/tier-spec-path")
+def api_entitlement_tier_spec_path():
+    """``GET /api/entitlement/tier-spec-path?from=<id>&to=<id>`` --
+    arbitrary-endpoint stepwise spec-shaped path between any two
+    tiers; the spec-shaped sibling of ``/tier-path`` (full
+    ``tier_diff`` per rung), ``/capacity-diff-path`` (capacity-only per
+    rung), ``/tier-unlocks-path`` (marginal grants per rung),
+    ``/tier-locks-path`` (marginal losses per rung) and
+    ``/preview-path`` (cumulative ``Entitlement.to_dict`` per rung) --
+    the spec-shaped member of the ``_path`` family, the path-shaped
+    sibling of ``/tier-spec-at-batch`` and the bulk what-if cousin of
+    ``/tier-spec-at``. Lets a pricing-comparison "compare A vs B"
+    surface render the slim catalogue-shaped descriptor (``label``,
+    ``is_paid``, ``unlocks_paid_runtimes``, ``retention_days``,
+    ``channel_limit``, ``node_limit``, ``features``, ``runtimes``) at
+    every rung between any two tiers off ONE round-trip, without
+    folding marketing fields back in from a separate
+    ``/tier-catalog`` lookup the way a ``/preview-path`` row forces.
+
+    Each row in ``path`` matches the ``/tier-spec-at?tier=<from>&target=<rung>``
+    payload exactly -- the same key set with ``is_current=False`` on
+    every walked rung (``from`` is excluded from the walked rungs) --
+    so a UI that already renders ``/tier-spec-at`` needs zero new
+    shape code to render a per-rung row off this path. Rung walk is
+    byte-stable against ``/tier-path``, ``/capacity-diff-path``,
+    ``/tier-unlocks-path``, ``/tier-locks-path`` and ``/preview-path``
+    (same ``_PURCHASABLE_TIERS`` filter + same sort + same
+    destination-sibling exclusion), so the six paths line up rung-for-
+    rung.
+
+    Response shape::
+
+        {
+          "from":       "<tier id>",
+          "from_label": "...",
+          "from_rank":  <int>,
+          "to":         "<tier id>",
+          "to_label":   "...",
+          "to_rank":    <int>,
+          "direction":  "upgrade" | "downgrade" | "lateral" | "identity",
+          "path":       [<tier-spec-at row>, ...],
+        }
+
+    Direction semantics:
+
+    * ``upgrade`` (ascending) -- rows climb cumulatively rung by rung
+      from the rung above ``from`` toward ``to``.
+    * ``downgrade`` (descending) -- rows shrink cumulatively rung by
+      rung; the cancellation-walkthrough counterpart.
+    * ``lateral`` (same rank, different id) -- single-row path; row
+      carries the cumulative spec at ``to``.
+    * ``identity`` (``from == to``) -- empty path; no rungs to walk.
+
+    Same-rank siblings strictly between the endpoints are both
+    included; same-rank siblings of the destination are excluded so
+    the path terminates exactly at ``to``. ``400`` when ``from=`` or
+    ``to=`` is missing; ``404`` when either id is unknown. ``trial``
+    IS accepted as an endpoint -- it is excluded from the walked
+    intermediate rungs (not purchasable) but is a valid endpoint via
+    the lateral branch. Never 5xxs: a resolver failure short-circuits
+    to ``404`` so a pricing-comparison surface keeps rendering
+    instead of breaking.
+    """
+    f = (request.args.get("from") or "").strip().lower()
+    t = (request.args.get("to") or "").strip().lower()
+    if not f or not t:
+        return jsonify({"error": "missing from or to"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        path = _ent.tier_spec_path(f, t)
+        if path is None:
+            return (
+                jsonify({"error": "unknown tier", "from": f, "to": t}),
+                404,
+            )
+        from_rank = _ent.tier_rank(f)
+        to_rank = _ent.tier_rank(t)
+        if f == t:
+            direction = "identity"
+        elif from_rank == to_rank:
+            direction = "lateral"
+        elif to_rank > from_rank:
+            direction = "upgrade"
+        else:
+            direction = "downgrade"
+        return jsonify(
+            {
+                "from": f,
+                "from_label": _ent.tier_label(f),
+                "from_rank": from_rank,
+                "to": t,
+                "to_label": _ent.tier_label(t),
+                "to_rank": to_rank,
+                "direction": direction,
+                "path": path,
+            }
+        )
+    except Exception as exc:
+        logger.warning("api_entitlement_tier_spec_path: error: %s", exc)
+        return (
+            jsonify({"error": "unknown tier", "from": f, "to": t}),
+            404,
         )

--- a/tests/test_entitlement_tier_spec_path.py
+++ b/tests/test_entitlement_tier_spec_path.py
@@ -1,0 +1,531 @@
+"""Tests for ``clawmetry.entitlements.tier_spec_path(from, to)`` + the
+``GET /api/entitlement/tier-spec-path`` endpoint.
+
+Spec-shaped sibling of :func:`tier_path` (full ``tier_diff`` per rung),
+:func:`capacity_diff_path` (capacity-only per rung),
+:func:`tier_unlocks_path` (marginal grants per rung),
+:func:`tier_locks_path` (marginal losses per rung), and
+:func:`preview_path` (cumulative ``Entitlement.to_dict`` per rung) -- the
+spec-shaped member of the ``_path`` family, the path-shaped sibling of
+:func:`tier_spec_at_batch` (fixed-source what-if matrix) and the bulk
+what-if cousin of :func:`tier_spec_at`. Lets a pricing-comparison
+"compare A vs B" surface render the slim catalogue-shaped descriptor
+(``id``, ``label``, ``is_paid``, ``is_current``, ``rank``,
+``unlocks_paid_runtimes``, ``retention_days``, ``channel_limit``,
+``node_limit``, ``features``, ``runtimes``) at every rung between any
+two tiers off ONE round-trip, without folding marketing fields
+(``is_paid``, ``label``, ``unlocks_paid_runtimes``) back in from a
+separate ``/tier-catalog`` lookup the way a ``/preview-path`` row
+forces.
+
+Pins:
+
+* row shape matches singular :func:`tier_spec_at` schema down to the
+  key set
+* every walked row carries ``is_current=False`` (``from`` is excluded
+  from the walked rungs)
+* rung walk is byte-stable against :func:`tier_path`,
+  :func:`capacity_diff_path`, :func:`tier_unlocks_path`,
+  :func:`tier_locks_path` and :func:`preview_path` (same
+  ``_PURCHASABLE_TIERS`` filter + same sort + same destination-sibling
+  exclusion); confirmed by extracting the rung ``id`` ids and lining
+  them up against ``tier`` / ``to`` / ``target`` keys on the other
+  five paths
+* ascending walk reaches ``to_tier`` at the final rung; rung ``id``
+  ids walk strictly upward in rank
+* descending walk reaches ``to_tier`` at the final rung; rung ``id``
+  ids walk strictly downward in rank
+* per-rung byte-equality with the singular :func:`tier_spec_at`
+  helper pinned on ``(from_tier, rung_id)`` for every rung in the walk
+* the path's terminal row byte-equals ``tier_spec_at(from, to)``
+  whenever the destination is purchasable; for ``to=trial`` the
+  lateral branch produces a single-row path with the trial spec shape
+* identity (``from == to``) returns an empty path
+* lateral (same rank, different id) returns a single-row path
+* trial accepted as an endpoint -- excluded from walked intermediate
+  rungs (lateral endpoint pinned for ``to=trial``; intermediate-walk
+  paths with ``from=trial`` cross into the rung above)
+* unknown / empty / garbage ids return ``None`` and never raise
+* grace vs enforce yields identical rows (helper is decoupled from the
+  resolved entitlement; it walks the static per-tier maps via
+  :func:`tier_spec_at`)
+* API surface: 400 on missing args, 404 on unknown ids, 200 with the
+  envelope shape on the happy path (incl. direction tag)
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+_ENVELOPE_KEYS = {
+    "from",
+    "from_label",
+    "from_rank",
+    "to",
+    "to_label",
+    "to_rank",
+    "direction",
+    "path",
+}
+
+
+# ── helper-level: shape + invariants ─────────────────────────────────────────
+
+
+def test_returns_list(ent):
+    path = ent.tier_spec_path(ent.TIER_OSS, ent.TIER_ENTERPRISE)
+    assert isinstance(path, list)
+    assert len(path) >= 1
+
+
+def test_each_row_matches_tier_spec_at_schema(ent):
+    """Per-rung row shape must byte-match the singular
+    :func:`tier_spec_at` row schema -- so a UI that already renders a
+    ``/tier-spec-at`` row needs zero new shape code to render a per-rung
+    row off this path."""
+    path = ent.tier_spec_path(ent.TIER_OSS, ent.TIER_ENTERPRISE)
+    reference_keys = set(
+        ent.tier_spec_at(ent.TIER_OSS, ent.TIER_CLOUD_PRO).keys()
+    )
+    assert reference_keys  # sanity
+    for row in path:
+        assert isinstance(row, dict)
+        assert set(row.keys()) == reference_keys
+
+
+def test_every_walked_row_carries_is_current_false(ent):
+    """``from`` is excluded from the walked rungs, so the
+    rung-equals-from-tier perspective never appears -- every walked
+    row must surface with ``is_current=False``."""
+    for f, t in (
+        (ent.TIER_OSS, ent.TIER_ENTERPRISE),
+        (ent.TIER_CLOUD_FREE, ent.TIER_PRO),
+        (ent.TIER_ENTERPRISE, ent.TIER_OSS),
+        (ent.TIER_PRO, ent.TIER_CLOUD_FREE),
+    ):
+        for row in ent.tier_spec_path(f, t):
+            assert row["is_current"] is False
+
+
+def test_first_row_is_first_step_above_from(ent):
+    """Ascending walk from oss (rank 0) toward enterprise: the first
+    row's ``id`` must be the first purchasable rung strictly above
+    rank 0 -- cloud_starter at rank 1."""
+    path = ent.tier_spec_path(ent.TIER_OSS, ent.TIER_ENTERPRISE)
+    assert path[0]["id"] == ent.TIER_CLOUD_STARTER
+
+
+def test_last_row_is_destination(ent):
+    path = ent.tier_spec_path(ent.TIER_OSS, ent.TIER_ENTERPRISE)
+    assert path[-1]["id"] == ent.TIER_ENTERPRISE
+
+
+def test_rung_walk_byte_stable_against_tier_path(ent):
+    """The set of rung ``id`` ids must match :func:`tier_path`'s rung
+    ``to`` ids byte-for-byte -- same ``_PURCHASABLE_TIERS`` filter +
+    same sort + same destination-sibling exclusion."""
+    for f, t in (
+        (ent.TIER_OSS, ent.TIER_ENTERPRISE),
+        (ent.TIER_CLOUD_FREE, ent.TIER_PRO),
+        (ent.TIER_OSS, ent.TIER_CLOUD_PRO),
+        (ent.TIER_ENTERPRISE, ent.TIER_OSS),
+        (ent.TIER_PRO, ent.TIER_CLOUD_FREE),
+        (ent.TIER_TRIAL, ent.TIER_ENTERPRISE),
+    ):
+        spec_rungs = [r["id"] for r in ent.tier_spec_path(f, t)]
+        diff_rungs = [r["to"] for r in ent.tier_path(f, t)]
+        assert spec_rungs == diff_rungs
+
+
+def test_rung_walk_byte_stable_against_capacity_diff_path(ent):
+    """And byte-stable against :func:`capacity_diff_path` -- the five
+    other path helpers must line up rung-for-rung against this one."""
+    for f, t in (
+        (ent.TIER_OSS, ent.TIER_ENTERPRISE),
+        (ent.TIER_CLOUD_FREE, ent.TIER_PRO),
+        (ent.TIER_ENTERPRISE, ent.TIER_OSS),
+        (ent.TIER_TRIAL, ent.TIER_ENTERPRISE),
+    ):
+        spec_rungs = [r["id"] for r in ent.tier_spec_path(f, t)]
+        cap_rungs = [r["target"] for r in ent.capacity_diff_path(f, t)]
+        assert spec_rungs == cap_rungs
+
+
+def test_rung_walk_byte_stable_against_tier_unlocks_path(ent):
+    """And byte-stable against :func:`tier_unlocks_path`."""
+    for f, t in (
+        (ent.TIER_OSS, ent.TIER_ENTERPRISE),
+        (ent.TIER_CLOUD_FREE, ent.TIER_PRO),
+        (ent.TIER_ENTERPRISE, ent.TIER_OSS),
+        (ent.TIER_TRIAL, ent.TIER_ENTERPRISE),
+    ):
+        spec_rungs = [r["id"] for r in ent.tier_spec_path(f, t)]
+        unlocks_rungs = [r["tier"] for r in ent.tier_unlocks_path(f, t)]
+        assert spec_rungs == unlocks_rungs
+
+
+def test_rung_walk_byte_stable_against_tier_locks_path(ent):
+    """And byte-stable against :func:`tier_locks_path`."""
+    for f, t in (
+        (ent.TIER_OSS, ent.TIER_ENTERPRISE),
+        (ent.TIER_CLOUD_FREE, ent.TIER_PRO),
+        (ent.TIER_ENTERPRISE, ent.TIER_OSS),
+        (ent.TIER_TRIAL, ent.TIER_ENTERPRISE),
+    ):
+        spec_rungs = [r["id"] for r in ent.tier_spec_path(f, t)]
+        locks_rungs = [r["tier"] for r in ent.tier_locks_path(f, t)]
+        assert spec_rungs == locks_rungs
+
+
+def test_rung_walk_byte_stable_against_preview_path(ent):
+    """And byte-stable against :func:`preview_path` -- all six paths
+    line up rung-for-rung."""
+    for f, t in (
+        (ent.TIER_OSS, ent.TIER_ENTERPRISE),
+        (ent.TIER_CLOUD_FREE, ent.TIER_PRO),
+        (ent.TIER_ENTERPRISE, ent.TIER_OSS),
+        (ent.TIER_TRIAL, ent.TIER_ENTERPRISE),
+    ):
+        spec_rungs = [r["id"] for r in ent.tier_spec_path(f, t)]
+        preview_rungs = [r["tier"] for r in ent.preview_path(f, t)]
+        assert spec_rungs == preview_rungs
+
+
+def test_ascending_walk_is_non_decreasing_in_rank(ent):
+    """Ascending walk: rungs may share a collapsed rank only at the
+    destination's rank (cloud_pro and pro both at collapsed rank 2 in
+    a oss->enterprise walk); the sequence is non-decreasing overall.
+    Pinned against :func:`tier_rank` (collapsed ``_TIER_RANK``), the
+    same comparator the walker uses -- the published ``rank`` field
+    on the row is the strict ``_TIER_ORDER`` ordinal and does not
+    preserve walk monotonicity for same-collapsed-rank siblings."""
+    path = ent.tier_spec_path(ent.TIER_OSS, ent.TIER_ENTERPRISE)
+    walk_ranks = [ent.tier_rank(r["id"]) for r in path]
+    assert walk_ranks == sorted(walk_ranks)
+
+
+def test_descending_walk_is_non_increasing_in_rank(ent):
+    """Descending walk: pinned against :func:`tier_rank` (collapsed
+    ``_TIER_RANK``) for the same reason as the ascending sibling."""
+    path = ent.tier_spec_path(ent.TIER_ENTERPRISE, ent.TIER_OSS)
+    walk_ranks = [ent.tier_rank(r["id"]) for r in path]
+    assert walk_ranks == sorted(walk_ranks, reverse=True)
+
+
+def test_path_terminates_at_to_not_a_sibling(ent):
+    """``pro`` and ``cloud_pro`` share rank 2; asking for ``pro`` must
+    end exactly at ``pro`` and EXCLUDE the same-rank sibling
+    ``cloud_pro`` from the final rung -- same rule as the rest of the
+    ``_path`` family."""
+    rungs = [r["id"] for r in ent.tier_spec_path(ent.TIER_OSS, ent.TIER_PRO)]
+    assert rungs[-1] == ent.TIER_PRO
+    assert rungs.count(ent.TIER_PRO) == 1
+    assert ent.TIER_CLOUD_PRO not in rungs
+
+
+def test_same_rank_siblings_between_endpoints_both_included(ent):
+    """Walking oss -> enterprise: rank-2 siblings ``cloud_pro`` AND
+    ``pro`` both appear because they sit strictly *between* rank-0
+    start and rank-3 destination."""
+    rungs = [
+        r["id"]
+        for r in ent.tier_spec_path(ent.TIER_OSS, ent.TIER_ENTERPRISE)
+    ]
+    assert ent.TIER_CLOUD_PRO in rungs
+    assert ent.TIER_PRO in rungs
+    assert rungs[-1] == ent.TIER_ENTERPRISE
+
+
+def test_per_rung_byte_equality_with_singular_tier_spec_at(ent):
+    """Each rung's row must byte-equal :func:`tier_spec_at(from, rung)`
+    -- the path is a sequence of singular what-if specs pinned on
+    ``from``, not a re-derivation."""
+    f = ent.TIER_OSS
+    path = ent.tier_spec_path(f, ent.TIER_ENTERPRISE)
+    for row in path:
+        direct = ent.tier_spec_at(f, row["id"])
+        assert row == direct
+
+
+def test_terminal_row_byte_equals_tier_spec_at_of_to(ent):
+    """When the destination is purchasable the final rung must
+    byte-equal :func:`tier_spec_at(from, to)`."""
+    f = ent.TIER_OSS
+    for to in (
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_PRO,
+        ent.TIER_ENTERPRISE,
+    ):
+        path = ent.tier_spec_path(f, to)
+        assert path[-1] == ent.tier_spec_at(f, to)
+
+
+def test_terminal_row_for_trial_endpoint_via_lateral(ent):
+    """The walked-rungs filter excludes trial as an intermediate, but
+    the lateral branch can pin trial as a destination -- the row
+    surfaces via :func:`tier_spec_at` directly and carries the trial
+    spec shape."""
+    path = ent.tier_spec_path(ent.TIER_CLOUD_PRO, ent.TIER_TRIAL)
+    assert len(path) == 1
+    row = path[0]
+    assert row["id"] == ent.TIER_TRIAL
+    assert row == ent.tier_spec_at(ent.TIER_CLOUD_PRO, ent.TIER_TRIAL)
+
+
+def test_identity_returns_empty(ent):
+    for tid in (
+        ent.TIER_OSS,
+        ent.TIER_CLOUD_FREE,
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_PRO,
+        ent.TIER_ENTERPRISE,
+        ent.TIER_TRIAL,
+    ):
+        assert ent.tier_spec_path(tid, tid) == []
+
+
+def test_lateral_single_row(ent):
+    path = ent.tier_spec_path(ent.TIER_CLOUD_PRO, ent.TIER_PRO)
+    assert len(path) == 1
+    row = path[0]
+    assert row["id"] == ent.TIER_PRO
+
+
+def test_oss_to_cloud_free_lateral_single_row(ent):
+    """Both rank 0 -- lateral single-row path landing on cloud_free."""
+    path = ent.tier_spec_path(ent.TIER_OSS, ent.TIER_CLOUD_FREE)
+    assert len(path) == 1
+    assert path[0]["id"] == ent.TIER_CLOUD_FREE
+
+
+def test_adjacent_step_is_one_row(ent):
+    """oss (rank 0) -> cloud_starter (rank 1) is a single rank-up step."""
+    path = ent.tier_spec_path(ent.TIER_OSS, ent.TIER_CLOUD_STARTER)
+    assert len(path) == 1
+    assert path[0]["id"] == ent.TIER_CLOUD_STARTER
+
+
+def test_trial_excluded_from_walked_intermediate_rungs(ent):
+    """``trial`` is not purchasable -- it must never appear as an
+    *intermediate* rung on a walk between purchasable endpoints."""
+    path = ent.tier_spec_path(ent.TIER_OSS, ent.TIER_ENTERPRISE)
+    for row in path:
+        assert row["id"] != ent.TIER_TRIAL
+
+
+def test_trial_endpoint_still_resolves(ent):
+    """``trial`` IS a valid endpoint -- as the source (via the
+    cross-rank branch landing at enterprise) or as the destination
+    (via the lateral branch)."""
+    upward = ent.tier_spec_path(ent.TIER_TRIAL, ent.TIER_ENTERPRISE)
+    assert upward is not None
+    assert upward[-1]["id"] == ent.TIER_ENTERPRISE
+    downward = ent.tier_spec_path(ent.TIER_CLOUD_PRO, ent.TIER_TRIAL)
+    assert downward is not None
+    assert downward[-1]["id"] == ent.TIER_TRIAL
+
+
+def test_unknown_tiers_return_none(ent):
+    assert ent.tier_spec_path("not_a_tier", ent.TIER_ENTERPRISE) is None
+    assert ent.tier_spec_path(ent.TIER_OSS, "still_not_a_tier") is None
+    assert ent.tier_spec_path("a", "b") is None
+
+
+def test_empty_and_garbage_inputs_never_raise(ent):
+    assert ent.tier_spec_path("", "") is None
+    assert ent.tier_spec_path(None, None) is None  # type: ignore[arg-type]
+    assert ent.tier_spec_path("  ", "  ") is None
+    assert ent.tier_spec_path(123, 456) is None  # type: ignore[arg-type]
+
+
+def test_case_and_whitespace_normalised(ent):
+    a = ent.tier_spec_path(ent.TIER_OSS, ent.TIER_ENTERPRISE)
+    b = ent.tier_spec_path("  OSS ", " ENTERPRISE  ")
+    assert a == b
+
+
+def test_grace_and_enforce_yield_identical_rows(ent, monkeypatch):
+    """The helper is decoupled from the resolved entitlement -- it
+    walks the static per-tier maps via :func:`tier_spec_at` so
+    flipping enforce on must NOT change any row. Pins the
+    resolver-independence property the whole ``_path`` family shares."""
+    grace_rows = ent.tier_spec_path(ent.TIER_OSS, ent.TIER_ENTERPRISE)
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    enforced_rows = ent.tier_spec_path(ent.TIER_OSS, ent.TIER_ENTERPRISE)
+    assert grace_rows == enforced_rows
+
+
+def test_resolver_failure_returns_none(ent, monkeypatch):
+    """A blown per-rung builder must not 5xx -- the wrapper swallows
+    and returns ``None`` so a pricing surface keeps rendering."""
+    monkeypatch.setattr(
+        ent,
+        "tier_spec_at",
+        lambda _f, _t: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
+    result = ent.tier_spec_path(ent.TIER_OSS, ent.TIER_ENTERPRISE)
+    assert result is None
+
+
+# ── API surface ──────────────────────────────────────────────────────────────
+
+
+def test_api_400_on_missing_args(client):
+    assert client.get("/api/entitlement/tier-spec-path").status_code == 400
+    assert (
+        client.get("/api/entitlement/tier-spec-path?from=oss").status_code == 400
+    )
+    assert (
+        client.get("/api/entitlement/tier-spec-path?to=cloud_pro").status_code
+        == 400
+    )
+
+
+def test_api_404_on_unknown_tier(client):
+    r = client.get("/api/entitlement/tier-spec-path?from=oss&to=not_a_tier")
+    assert r.status_code == 404
+    body = r.get_json()
+    assert body["error"] == "unknown tier"
+    assert body["to"] == "not_a_tier"
+
+
+def test_api_happy_path_ascending(client, ent):
+    r = client.get(
+        f"/api/entitlement/tier-spec-path?from={ent.TIER_OSS}&to={ent.TIER_ENTERPRISE}"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert set(body.keys()) == _ENVELOPE_KEYS
+    assert body["from"] == ent.TIER_OSS
+    assert body["to"] == ent.TIER_ENTERPRISE
+    assert body["direction"] == "upgrade"
+    assert isinstance(body["path"], list) and body["path"]
+    assert body["path"][-1]["id"] == ent.TIER_ENTERPRISE
+    reference_keys = set(
+        ent.tier_spec_at(ent.TIER_OSS, ent.TIER_CLOUD_PRO).keys()
+    )
+    for row in body["path"]:
+        assert set(row.keys()) == reference_keys
+        assert row["is_current"] is False
+
+
+def test_api_happy_path_descending(client, ent):
+    r = client.get(
+        f"/api/entitlement/tier-spec-path?from={ent.TIER_ENTERPRISE}&to={ent.TIER_OSS}"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["direction"] == "downgrade"
+    assert body["path"][-1]["id"] == ent.TIER_OSS
+    walk_ranks = [ent.tier_rank(row["id"]) for row in body["path"]]
+    assert walk_ranks == sorted(walk_ranks, reverse=True)
+
+
+def test_api_identity_empty_path(client, ent):
+    r = client.get(
+        f"/api/entitlement/tier-spec-path?from={ent.TIER_CLOUD_PRO}&to={ent.TIER_CLOUD_PRO}"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["direction"] == "identity"
+    assert body["path"] == []
+
+
+def test_api_lateral_single_row(client, ent):
+    r = client.get(
+        f"/api/entitlement/tier-spec-path?from={ent.TIER_CLOUD_PRO}&to={ent.TIER_PRO}"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["direction"] == "lateral"
+    assert len(body["path"]) == 1
+    assert body["path"][0]["id"] == ent.TIER_PRO
+
+
+def test_api_trial_endpoint_accepted(client, ent):
+    r = client.get(
+        f"/api/entitlement/tier-spec-path?from={ent.TIER_TRIAL}&to={ent.TIER_ENTERPRISE}"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["from"] == ent.TIER_TRIAL
+    assert body["path"][-1]["id"] == ent.TIER_ENTERPRISE
+
+
+def test_api_trial_destination_via_lateral(client, ent):
+    """``to=trial`` resolves via the lateral branch (cloud_pro and
+    trial share rank 2)."""
+    r = client.get(
+        f"/api/entitlement/tier-spec-path?from={ent.TIER_CLOUD_PRO}&to={ent.TIER_TRIAL}"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["direction"] == "lateral"
+    assert len(body["path"]) == 1
+    assert body["path"][0]["id"] == ent.TIER_TRIAL
+
+
+def test_api_rungs_match_tier_path_route(client, ent):
+    """API-level byte-equality: rung ``id`` ids from
+    ``/tier-spec-path`` match rung ``to`` ids from ``/tier-path``."""
+    a = client.get(
+        f"/api/entitlement/tier-spec-path?from={ent.TIER_OSS}&to={ent.TIER_ENTERPRISE}"
+    ).get_json()
+    b = client.get(
+        f"/api/entitlement/tier-path?from={ent.TIER_OSS}&to={ent.TIER_ENTERPRISE}"
+    ).get_json()
+    assert [r["id"] for r in a["path"]] == [r["to"] for r in b["path"]]
+
+
+def test_api_rungs_match_preview_path_route(client, ent):
+    """And against ``/preview-path`` rung-for-rung."""
+    a = client.get(
+        f"/api/entitlement/tier-spec-path?from={ent.TIER_OSS}&to={ent.TIER_ENTERPRISE}"
+    ).get_json()
+    b = client.get(
+        f"/api/entitlement/preview-path?from={ent.TIER_OSS}&to={ent.TIER_ENTERPRISE}"
+    ).get_json()
+    assert [r["id"] for r in a["path"]] == [r["tier"] for r in b["path"]]
+
+
+def test_api_per_rung_byte_equality_with_tier_spec_at_endpoint(client, ent):
+    """Each rung's row must byte-equal the ``spec`` field of the
+    singular ``/tier-spec-at?tier=<from>&target=<rung>`` endpoint for
+    that rung -- the route returns a sequence of singular what-if
+    specs, not a re-derivation."""
+    f = ent.TIER_OSS
+    body = client.get(
+        f"/api/entitlement/tier-spec-path?from={f}&to={ent.TIER_ENTERPRISE}"
+    ).get_json()
+    for row in body["path"]:
+        ref = client.get(
+            f"/api/entitlement/tier-spec-at?tier={f}&target={row['id']}"
+        ).get_json()
+        assert ref["spec"] == row


### PR DESCRIPTION
## Summary

Adds the spec-shaped sixth member of the `_path` family — `tier_spec_path(from, to)` plus `GET /api/entitlement/tier-spec-path` — closing the spec axis on the path matrix. The five existing path helpers (`tier_path`, `capacity_diff_path`, `tier_unlocks_path`, `tier_locks_path`, `preview_path`) cover the diff / capacity / grants / losses / cumulative-entitlement shapes; this PR adds the slim catalogue-shaped spec view to the same walker.

### What it does

Walks the same `_PURCHASABLE_TIERS` rungs by the same sort key + destination-sibling exclusion as the rest of the `_path` family — byte-stable rung-for-rung against the other five paths — and at each rung returns the `tier_spec_at(from, rung)` row (the slim catalogue-shaped descriptor with `id`, `label`, `is_paid`, `is_current`, `rank`, `unlocks_paid_runtimes`, `retention_days`, `channel_limit`, `node_limit`, `features`, `runtimes`).

Lets a pricing-comparison "compare A vs B" surface hydrate the marketing-shaped per-rung descriptor in one round-trip, without folding marketing fields (`is_paid`, `label`, `unlocks_paid_runtimes`) back in from a separate `/tier-catalog` lookup the way a `/preview-path` row forces.

### Shape

```
{
  "from": "<tier id>",
  "from_label": "...",
  "from_rank": <int>,
  "to": "<tier id>",
  "to_label": "...",
  "to_rank": <int>,
  "direction": "upgrade" | "downgrade" | "lateral" | "identity",
  "path": [<tier-spec-at row>, ...]
}
```

Per-rung row matches `/tier-spec-at?tier=<from>&target=<rung>` byte-for-byte (parity test pins this).

### Posture

- Resolver-independent: walks the static per-tier maps via `tier_spec_at`, so grace vs enforce yields byte-identical rows.
- Never raises: helper logs a warning and returns `None` on resolver failure; route catches and returns 404 on unknown ids, 400 on missing args.
- `trial` accepted as an endpoint (excluded from walked intermediate rungs since it is not purchasable; valid via the lateral branch).

### Tests

39 unit + route tests covering:

- row shape parity with singular `tier_spec_at`
- every walked row carries `is_current=False` (from-tier excluded from walked rungs)
- rung walk byte-stable rung-for-rung against the five existing `_path` helpers
- identity / lateral / upgrade / downgrade branches
- same-rank sibling inclusion rules
- per-rung byte-equality with singular `tier_spec_at(from, rung)`
- terminal-row byte-equality with `tier_spec_at(from, to)` for purchasable destinations
- trial endpoint via the lateral branch
- unknown / empty / garbage ids → `None` (never raises)
- whitespace + case normalisation
- grace vs enforce row equality
- resolver-failure swallow → `None`
- API surface: 400 on missing args, 404 on unknown ids, 200 envelope on happy path, route rung-for-rung parity against `/tier-path` + `/preview-path`

Plus the full path-family neighborhood smoke (134 tests across `tier_path` / `preview_path` / `tier_spec_at` / `tier_spec_path`) passes locally.

### Scope

Pure feature-add — no helper signatures or existing route shapes change. Resolver semantics untouched (helper does not consult the resolver). No frontend changes; this is an API-only addition for a future pricing-comparison surface.

---

### Local operator verification checklist

I cannot reach the running daemon, `~/.openclaw`, or the live cloud snapshot from this environment. Before flipping the PR ready-for-review and merging, please:

1. Pull `feat/entitlement-tier-spec-path` locally and copy the three changed files into the installed site-packages location:
   ```sh
   cp clawmetry/entitlements.py ~/.clawmetry/lib/python*/site-packages/clawmetry/entitlements.py
   cp routes/entitlement.py ~/.clawmetry/lib/python*/site-packages/routes/entitlement.py
   ```
2. Clear `__pycache__` under `~/.clawmetry/lib/python*/site-packages/{clawmetry,routes}/` so the new bytecode is picked up.
3. Restart the daemon: `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`.
4. Smoke the new endpoint against your live install:
   ```sh
   curl -s 'http://localhost:8900/api/entitlement/tier-spec-path?from=oss&to=enterprise' | jq '.direction, .path[].id'
   curl -s 'http://localhost:8900/api/entitlement/tier-spec-path?from=oss&to=oss' | jq '.direction, .path'
   curl -s 'http://localhost:8900/api/entitlement/tier-spec-path?from=enterprise&to=oss' | jq '.direction, .path[].id'
   curl -s 'http://localhost:8900/api/entitlement/tier-spec-path?from=oss' -o /dev/null -w '%{http_code}\n'  # expect 400
   curl -s 'http://localhost:8900/api/entitlement/tier-spec-path?from=oss&to=bogus' -o /dev/null -w '%{http_code}\n'  # expect 404
   ```
5. Confirm `/api/entitlement` and existing `_path` endpoints (`/tier-path`, `/preview-path`, `/capacity-diff-path`, `/tier-unlocks-path`, `/tier-locks-path`) still return the same payloads they did pre-change.
6. Decrypt the live cloud snapshot in the browser and re-verify the entitlement panel renders unchanged (no UI consumes the new endpoint yet — this is a pure additive surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_014zNTbsw552iL7W3k7158QR)_