### PR TITLE
feat(entitlement): feature_spec_path + runtime_spec_path + endpoints

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -6557,3 +6557,223 @@ def tier_spec_path(from_tier: str, to_tier: str) -> list[dict] | None:
     except Exception as exc:
         logger.warning("entitlements: tier_spec_path failed: %s", exc)
         return None
+
+
+def feature_spec_path(
+    from_tier: str, to_tier: str, feature: str
+) -> list[dict] | None:
+    """Arbitrary-endpoint stepwise single-feature spec path between two tiers.
+
+    Single-feature sibling of :func:`tier_spec_path` (full slim spec per
+    rung) and perspective-walked sibling of :func:`feature_spec_at`. Lets a
+    paywall "how does THIS one feature unlock as I climb the ladder" UI
+    render every rung's ``allowed`` / ``locked`` / ``entitled`` status off
+    ONE round-trip without fetching the full :func:`feature_catalog_at` at
+    every rung.
+
+    Walks the same ``_PURCHASABLE_TIERS`` rungs by the same sort key and
+    same destination-sibling exclusion as :func:`tier_path`,
+    :func:`tier_spec_path`, :func:`capacity_diff_path`,
+    :func:`tier_unlocks_path`, :func:`tier_locks_path` and
+    :func:`preview_path` -- rung-for-rung byte-stable against the six
+    existing ``_path`` helpers, so a UI that walks one helper's rows can
+    line them up index-for-index with another helper's rows without
+    re-deriving the rung sequence.
+
+    Per-rung row shape: each row is the :func:`feature_spec_at` body
+    (``id``, ``label``, ``tier``, ``tiers``, ``free``, ``allowed``,
+    ``locked``, ``entitled``, ``alias``) augmented with three rung-
+    identification keys -- ``rung``, ``rung_label``, ``rung_rank`` --
+    naming the perspective tier the row was computed at. Dropping the
+    three ``rung*`` keys yields exact byte-equality with
+    :func:`feature_spec_at(rung, feature)` -- a parity test pins this so
+    the scalar what-if and the path what-if cannot drift. The static
+    feature-property fields (``id``, ``label``, ``tier``, ``tiers``,
+    ``free``, ``alias``) stay constant across all rows; only the
+    perspective-dependent fields (``allowed``, ``locked``, ``entitled``)
+    vary rung by rung -- the visible "unlock boundary" the UI renders.
+
+    Direction semantics mirror :func:`tier_spec_path` / :func:`tier_path`:
+
+    * ``upgrade`` (ascending) -- rows climb rung by rung from the rung
+      above ``from_tier`` toward ``to_tier``; the natural "what does this
+      feature look like at each rung I'd climb through" walkthrough.
+    * ``downgrade`` (descending) -- rows shrink rung by rung; the
+      cancellation-walkthrough counterpart showing when the feature
+      becomes locked again.
+    * ``lateral`` (same rank, different id) -- single-row path; row
+      carries the spec at ``to_tier``.
+    * ``identity`` (``from == to``) -- empty path; no rungs to walk.
+
+    Endpoint semantics match :func:`tier_path` / :func:`tier_spec_path`:
+    both tier ids accept any entry in :data:`_TIER_FEATURES` (including
+    :data:`TIER_TRIAL`, which is not purchasable -- excluded from the
+    walked intermediate rungs but a valid endpoint via the lateral
+    branch). Unknown tier or feature ids on either side short-circuit to
+    ``None``.
+
+    Resolver-independent: walks the static per-tier maps via
+    :func:`feature_spec_at` so grace vs enforce yields byte-identical
+    rows -- same property the rest of the ``_path`` family guarantees.
+
+    Never raises: a resolver failure logs a warning and returns ``None``
+    so a paywall surface keeps rendering instead of breaking.
+    """
+    try:
+        f = (from_tier or "").strip().lower()
+        t = (to_tier or "").strip().lower()
+        if f not in _TIER_FEATURES or t not in _TIER_FEATURES:
+            return None
+        fid = (feature or "").strip().lower()
+        if not fid or fid not in ALL_FEATURES:
+            return None
+        if f == t:
+            return []
+        from_rank = _TIER_RANK.get(f, -1)
+        to_rank = _TIER_RANK.get(t, -1)
+
+        def _row(rung: str) -> dict | None:
+            body = feature_spec_at(rung, fid)
+            if body is None:
+                return None
+            return {
+                "rung": rung,
+                "rung_label": tier_label(rung),
+                "rung_rank": _TIER_RANK.get(rung, -1),
+                **body,
+            }
+
+        if from_rank == to_rank:
+            row = _row(t)
+            return [row] if row is not None else []
+        ascending = to_rank > from_rank
+        if ascending:
+            ordered = sorted(
+                _PURCHASABLE_TIERS,
+                key=lambda x: (_TIER_RANK.get(x, -1), x),
+            )
+        else:
+            ordered = sorted(
+                _PURCHASABLE_TIERS,
+                key=lambda x: (-_TIER_RANK.get(x, -1), x),
+            )
+        path: list[dict] = []
+        for tid in ordered:
+            r = _TIER_RANK.get(tid, -1)
+            if ascending:
+                if r <= from_rank or r > to_rank:
+                    continue
+            else:
+                if r >= from_rank or r < to_rank:
+                    continue
+            if r == to_rank and tid != t:
+                continue
+            row = _row(tid)
+            if row is not None:
+                path.append(row)
+        return path
+    except Exception as exc:
+        logger.warning("entitlements: feature_spec_path failed: %s", exc)
+        return None
+
+
+def runtime_spec_path(
+    from_tier: str, to_tier: str, runtime: str
+) -> list[dict] | None:
+    """Arbitrary-endpoint stepwise single-runtime spec path between two tiers.
+
+    Runtime-axis twin of :func:`feature_spec_path` -- the single-runtime
+    sibling of :func:`tier_spec_path` and perspective-walked sibling of
+    :func:`runtime_spec_at`. Lets a paywall "how does THIS one runtime
+    unlock as I climb the ladder" UI render every rung's ``allowed`` /
+    ``locked`` / ``entitled`` status off ONE round-trip without fetching
+    the full :func:`runtime_catalog_at` at every rung.
+
+    Accepts runtime aliases (``claude-code`` -> ``claude_code``) via
+    :func:`canonical_runtime` so the URL surface matches what callers
+    already pass to ``/api/entitlement/required-tier``.
+
+    Walks the same ``_PURCHASABLE_TIERS`` rungs by the same sort key and
+    same destination-sibling exclusion as the rest of the ``_path``
+    family -- rung-for-rung byte-stable against
+    :func:`feature_spec_path`, :func:`tier_path`, :func:`tier_spec_path`,
+    :func:`capacity_diff_path`, :func:`tier_unlocks_path`,
+    :func:`tier_locks_path` and :func:`preview_path`.
+
+    Per-rung row shape: each row is the :func:`runtime_spec_at` body
+    (``id``, ``label``, ``free``, ``tier``, ``tiers``, ``allowed``,
+    ``locked``, ``entitled``) augmented with three rung-identification
+    keys -- ``rung``, ``rung_label``, ``rung_rank`` -- naming the
+    perspective tier the row was computed at. Dropping the three
+    ``rung*`` keys yields exact byte-equality with
+    :func:`runtime_spec_at(rung, runtime)` -- a parity test pins this so
+    the scalar what-if and the path what-if cannot drift.
+
+    Direction semantics mirror :func:`feature_spec_path` /
+    :func:`tier_spec_path`. Endpoint semantics match :func:`tier_path`:
+    both tier ids accept any entry in :data:`_TIER_FEATURES`. Unknown
+    tier or runtime ids short-circuit to ``None``. Empty / whitespace
+    runtime short-circuits to ``None``.
+
+    Resolver-independent: walks the static per-tier maps via
+    :func:`runtime_spec_at` so grace vs enforce yields byte-identical
+    rows.
+
+    Never raises: a resolver failure logs a warning and returns ``None``.
+    """
+    try:
+        f = (from_tier or "").strip().lower()
+        t = (to_tier or "").strip().lower()
+        if f not in _TIER_FEATURES or t not in _TIER_FEATURES:
+            return None
+        rt = canonical_runtime(runtime)
+        if not rt or rt not in ALL_RUNTIMES:
+            return None
+        if f == t:
+            return []
+        from_rank = _TIER_RANK.get(f, -1)
+        to_rank = _TIER_RANK.get(t, -1)
+
+        def _row(rung: str) -> dict | None:
+            body = runtime_spec_at(rung, rt)
+            if body is None:
+                return None
+            return {
+                "rung": rung,
+                "rung_label": tier_label(rung),
+                "rung_rank": _TIER_RANK.get(rung, -1),
+                **body,
+            }
+
+        if from_rank == to_rank:
+            row = _row(t)
+            return [row] if row is not None else []
+        ascending = to_rank > from_rank
+        if ascending:
+            ordered = sorted(
+                _PURCHASABLE_TIERS,
+                key=lambda x: (_TIER_RANK.get(x, -1), x),
+            )
+        else:
+            ordered = sorted(
+                _PURCHASABLE_TIERS,
+                key=lambda x: (-_TIER_RANK.get(x, -1), x),
+            )
+        path: list[dict] = []
+        for tid in ordered:
+            r = _TIER_RANK.get(tid, -1)
+            if ascending:
+                if r <= from_rank or r > to_rank:
+                    continue
+            else:
+                if r >= from_rank or r < to_rank:
+                    continue
+            if r == to_rank and tid != t:
+                continue
+            row = _row(tid)
+            if row is not None:
+                path.append(row)
+        return path
+    except Exception as exc:
+        logger.warning("entitlements: runtime_spec_path failed: %s", exc)
+        return None

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -6168,3 +6168,212 @@ def api_entitlement_tier_spec_path():
             jsonify({"error": "unknown tier", "from": f, "to": t}),
             404,
         )
+
+
+@bp_entitlement.route("/api/entitlement/feature-spec-path")
+def api_entitlement_feature_spec_path():
+    """``GET /api/entitlement/feature-spec-path?from=<id>&to=<id>&feature=<id>``
+
+    Arbitrary-endpoint stepwise single-feature spec path between any two
+    tiers; the single-feature sibling of ``/tier-spec-path`` (full slim
+    spec per rung) and the perspective-walked sibling of
+    ``/feature-spec-at``. Lets a paywall surface render every rung's
+    ``allowed`` / ``locked`` / ``entitled`` status for a SINGLE feature
+    off ONE round-trip without fetching the full
+    ``/feature-catalog-at`` at every rung.
+
+    Rung walk is byte-stable against ``/tier-path``,
+    ``/capacity-diff-path``, ``/tier-unlocks-path``,
+    ``/tier-locks-path``, ``/preview-path`` and ``/tier-spec-path``
+    (same ``_PURCHASABLE_TIERS`` filter + same sort + same destination-
+    sibling exclusion), so the seven paths line up rung-for-rung.
+
+    Each row in ``path`` is the ``/feature-spec-at?tier=<rung>&feature=<feature>``
+    body augmented with three rung-identification keys -- ``rung``,
+    ``rung_label``, ``rung_rank`` -- naming the perspective tier the
+    row was computed at. Dropping the three ``rung*`` keys yields exact
+    byte-equality with ``/feature-spec-at?tier=<rung>&feature=<feature>``
+    (a parity test pins this).
+
+    Response shape::
+
+        {
+          "from":       "<tier id>",
+          "from_label": "...",
+          "from_rank":  <int>,
+          "to":         "<tier id>",
+          "to_label":   "...",
+          "to_rank":    <int>,
+          "direction":  "upgrade" | "downgrade" | "lateral" | "identity",
+          "feature":    "<feature id>",
+          "path":       [<augmented feature-spec-at row>, ...],
+        }
+
+    Direction semantics:
+
+    * ``upgrade`` (ascending) -- rows climb rung by rung from the rung
+      above ``from`` toward ``to``.
+    * ``downgrade`` (descending) -- rows shrink rung by rung.
+    * ``lateral`` (same rank, different id) -- single-row path; row
+      carries the spec at ``to``.
+    * ``identity`` (``from == to``) -- empty path; no rungs to walk.
+
+    Same-rank siblings strictly between the endpoints are both included;
+    same-rank siblings of the destination are excluded so the path
+    terminates exactly at ``to``. ``400`` when ``from=``, ``to=`` or
+    ``feature=`` is missing; ``404`` when any id is unknown. ``trial``
+    IS accepted as an endpoint -- it is excluded from the walked
+    intermediate rungs (not purchasable) but is a valid endpoint via
+    the lateral branch. Never 5xxs: a resolver failure short-circuits
+    to ``404`` so a paywall surface keeps rendering instead of
+    breaking.
+    """
+    f = (request.args.get("from") or "").strip().lower()
+    t = (request.args.get("to") or "").strip().lower()
+    feat = (request.args.get("feature") or "").strip().lower()
+    if not f or not t:
+        return jsonify({"error": "missing from or to"}), 400
+    if not feat:
+        return jsonify({"error": "missing feature"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        path = _ent.feature_spec_path(f, t, feat)
+        if path is None:
+            return (
+                jsonify(
+                    {
+                        "error": "unknown tier or feature",
+                        "from": f,
+                        "to": t,
+                        "feature": feat,
+                    }
+                ),
+                404,
+            )
+        from_rank = _ent.tier_rank(f)
+        to_rank = _ent.tier_rank(t)
+        if f == t:
+            direction = "identity"
+        elif from_rank == to_rank:
+            direction = "lateral"
+        elif to_rank > from_rank:
+            direction = "upgrade"
+        else:
+            direction = "downgrade"
+        return jsonify(
+            {
+                "from": f,
+                "from_label": _ent.tier_label(f),
+                "from_rank": from_rank,
+                "to": t,
+                "to_label": _ent.tier_label(t),
+                "to_rank": to_rank,
+                "direction": direction,
+                "feature": feat,
+                "path": path,
+            }
+        )
+    except Exception as exc:
+        logger.warning("api_entitlement_feature_spec_path: error: %s", exc)
+        return (
+            jsonify(
+                {
+                    "error": "unknown tier or feature",
+                    "from": f,
+                    "to": t,
+                    "feature": feat,
+                }
+            ),
+            404,
+        )
+
+
+@bp_entitlement.route("/api/entitlement/runtime-spec-path")
+def api_entitlement_runtime_spec_path():
+    """``GET /api/entitlement/runtime-spec-path?from=<id>&to=<id>&runtime=<id>``
+
+    Runtime-axis twin of ``/feature-spec-path`` -- the single-runtime
+    sibling of ``/tier-spec-path`` and perspective-walked sibling of
+    ``/runtime-spec-at``. Lets a paywall surface render every rung's
+    ``allowed`` / ``locked`` / ``entitled`` status for a SINGLE runtime
+    off ONE round-trip without fetching the full
+    ``/runtime-catalog-at`` at every rung.
+
+    Accepts runtime aliases (``claude-code`` -> ``claude_code``) via
+    :func:`clawmetry.entitlements.canonical_runtime` so the URL surface
+    matches what callers already pass to
+    ``/api/entitlement/required-tier``.
+
+    Rung walk is byte-stable against the other ``_path`` helpers. Each
+    row in ``path`` is the ``/runtime-spec-at?tier=<rung>&runtime=<runtime>``
+    body augmented with the ``rung`` / ``rung_label`` / ``rung_rank``
+    keys; dropping the three ``rung*`` keys yields exact byte-equality
+    with the singular ``/runtime-spec-at`` (a parity test pins this).
+
+    Response shape mirrors ``/feature-spec-path`` with ``"runtime"`` in
+    place of ``"feature"`` in the envelope.
+
+    ``400`` when ``from=``, ``to=`` or ``runtime=`` is missing; ``404``
+    when any id is unknown. Never 5xxs.
+    """
+    f = (request.args.get("from") or "").strip().lower()
+    t = (request.args.get("to") or "").strip().lower()
+    rt_raw = (request.args.get("runtime") or "").strip()
+    if not f or not t:
+        return jsonify({"error": "missing from or to"}), 400
+    if not rt_raw:
+        return jsonify({"error": "missing runtime"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        rt = _ent.canonical_runtime(rt_raw)
+        path = _ent.runtime_spec_path(f, t, rt_raw)
+        if path is None:
+            return (
+                jsonify(
+                    {
+                        "error": "unknown tier or runtime",
+                        "from": f,
+                        "to": t,
+                        "runtime": rt or rt_raw.lower(),
+                    }
+                ),
+                404,
+            )
+        from_rank = _ent.tier_rank(f)
+        to_rank = _ent.tier_rank(t)
+        if f == t:
+            direction = "identity"
+        elif from_rank == to_rank:
+            direction = "lateral"
+        elif to_rank > from_rank:
+            direction = "upgrade"
+        else:
+            direction = "downgrade"
+        return jsonify(
+            {
+                "from": f,
+                "from_label": _ent.tier_label(f),
+                "from_rank": from_rank,
+                "to": t,
+                "to_label": _ent.tier_label(t),
+                "to_rank": to_rank,
+                "direction": direction,
+                "runtime": rt or rt_raw.lower(),
+                "path": path,
+            }
+        )
+    except Exception as exc:
+        logger.warning("api_entitlement_runtime_spec_path: error: %s", exc)
+        return (
+            jsonify(
+                {
+                    "error": "unknown tier or runtime",
+                    "from": f,
+                    "to": t,
+                    "runtime": rt_raw.lower(),
+                }
+            ),
+            404,
+        )

--- a/tests/test_entitlement_feature_spec_path.py
+++ b/tests/test_entitlement_feature_spec_path.py
@@ -1,0 +1,433 @@
+"""Tests for ``clawmetry.entitlements.feature_spec_path(from, to, feature)``
++ the ``GET /api/entitlement/feature-spec-path`` endpoint.
+
+Single-feature sibling of :func:`tier_spec_path` (full slim spec per
+rung) and perspective-walked sibling of :func:`feature_spec_at`. Lets a
+paywall "how does THIS one feature unlock as I climb the ladder" UI
+render every rung's ``allowed`` / ``locked`` / ``entitled`` status off
+ONE round-trip without fetching the full :func:`feature_catalog_at` at
+every rung.
+
+Pins:
+
+* rung walk byte-stable against :func:`tier_path`,
+  :func:`tier_spec_path`, :func:`capacity_diff_path`,
+  :func:`tier_unlocks_path`, :func:`tier_locks_path` and
+  :func:`preview_path` (same ``_PURCHASABLE_TIERS`` filter + same sort
+  + same destination-sibling exclusion)
+* per-rung row carries the singular :func:`feature_spec_at` body PLUS
+  the three rung-identification keys (``rung``, ``rung_label``,
+  ``rung_rank``); dropping the three ``rung*`` keys yields exact
+  byte-equality with :func:`feature_spec_at(rung, feature)`
+* static feature-property keys (``id``, ``label``, ``tier``, ``tiers``,
+  ``free``, ``alias``) stay constant across all rows
+* paid-feature unlock boundary visible: ``allowed`` flips from
+  ``False`` to ``True`` at the rung where the feature's min tier is
+  reached
+* free feature surfaces ``allowed=True`` at every rung
+* enterprise-only feature stays ``allowed=False`` until the enterprise
+  rung
+* identity returns ``[]``
+* lateral (same rank, different id) returns a single-row path
+* trial accepted as an endpoint (lateral branch for ``to=trial``;
+  ``from=trial`` walks intermediate rungs above)
+* unknown / empty / garbage tier or feature ids return ``None`` and
+  never raise
+* grace vs enforce yields identical rows (helper walks the static
+  per-tier maps via :func:`feature_spec_at`)
+* API surface: 400 on missing args, 404 on unknown ids, 200 envelope
+  on happy path (incl. direction tag and ``feature`` echo)
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+_ENVELOPE_KEYS = {
+    "from",
+    "from_label",
+    "from_rank",
+    "to",
+    "to_label",
+    "to_rank",
+    "direction",
+    "feature",
+    "path",
+}
+
+_RUNG_KEYS = {"rung", "rung_label", "rung_rank"}
+
+
+# ── helper-level: shape + invariants ─────────────────────────────────────────
+
+
+def test_returns_list(ent):
+    path = ent.feature_spec_path(ent.TIER_OSS, ent.TIER_ENTERPRISE, "custom_alerts")
+    assert isinstance(path, list)
+    assert len(path) >= 1
+
+
+def test_each_row_carries_rung_keys(ent):
+    path = ent.feature_spec_path(ent.TIER_OSS, ent.TIER_ENTERPRISE, "custom_alerts")
+    for row in path:
+        assert set(row).issuperset(_RUNG_KEYS)
+        assert row["rung_label"] == ent.tier_label(row["rung"])
+        assert row["rung_rank"] == ent.tier_rank(row["rung"])
+
+
+def test_per_rung_byte_equality_with_singular_feature_spec_at(ent):
+    """Dropping the three ``rung*`` keys from a path row yields exact
+    byte-equality with :func:`feature_spec_at(rung, feature)`."""
+    path = ent.feature_spec_path(ent.TIER_OSS, ent.TIER_ENTERPRISE, "custom_alerts")
+    for row in path:
+        body = {k: v for k, v in row.items() if k not in _RUNG_KEYS}
+        direct = ent.feature_spec_at(row["rung"], "custom_alerts")
+        assert body == direct
+
+
+def test_static_feature_property_keys_constant_across_rungs(ent):
+    """``id``, ``label``, ``tier``, ``tiers``, ``free``, ``alias`` are
+    feature-properties -- they must NOT vary rung by rung. Only the
+    perspective-dependent fields (``allowed``, ``locked``, ``entitled``)
+    can move."""
+    path = ent.feature_spec_path(ent.TIER_OSS, ent.TIER_ENTERPRISE, "custom_alerts")
+    static = {"id", "label", "tier", "tiers", "free", "alias"}
+    first = {k: path[0][k] for k in static}
+    for row in path[1:]:
+        assert {k: row[k] for k in static} == first
+
+
+def test_first_row_is_first_step_above_from(ent):
+    path = ent.feature_spec_path(ent.TIER_OSS, ent.TIER_ENTERPRISE, "custom_alerts")
+    assert path[0]["rung"] == ent.TIER_CLOUD_STARTER
+
+
+def test_last_row_is_destination(ent):
+    path = ent.feature_spec_path(ent.TIER_OSS, ent.TIER_ENTERPRISE, "custom_alerts")
+    assert path[-1]["rung"] == ent.TIER_ENTERPRISE
+
+
+def test_rung_walk_byte_stable_against_tier_spec_path(ent):
+    """Rung ids must match :func:`tier_spec_path`'s rung ``id`` field
+    byte-for-byte -- same ``_PURCHASABLE_TIERS`` filter + same sort +
+    same destination-sibling exclusion."""
+    for f, t in (
+        (ent.TIER_OSS, ent.TIER_ENTERPRISE),
+        (ent.TIER_CLOUD_FREE, ent.TIER_PRO),
+        (ent.TIER_OSS, ent.TIER_CLOUD_PRO),
+        (ent.TIER_ENTERPRISE, ent.TIER_OSS),
+        (ent.TIER_PRO, ent.TIER_CLOUD_FREE),
+        (ent.TIER_TRIAL, ent.TIER_ENTERPRISE),
+    ):
+        feat_rungs = [
+            r["rung"] for r in ent.feature_spec_path(f, t, "custom_alerts")
+        ]
+        spec_rungs = [r["id"] for r in ent.tier_spec_path(f, t)]
+        assert feat_rungs == spec_rungs
+
+
+def test_rung_walk_byte_stable_against_tier_path(ent):
+    for f, t in (
+        (ent.TIER_OSS, ent.TIER_ENTERPRISE),
+        (ent.TIER_ENTERPRISE, ent.TIER_OSS),
+        (ent.TIER_TRIAL, ent.TIER_ENTERPRISE),
+    ):
+        feat_rungs = [
+            r["rung"] for r in ent.feature_spec_path(f, t, "custom_alerts")
+        ]
+        diff_rungs = [r["to"] for r in ent.tier_path(f, t)]
+        assert feat_rungs == diff_rungs
+
+
+def test_rung_walk_invariant_across_features(ent):
+    """The walked rung sequence is feature-agnostic -- swapping the
+    feature must not move the rungs."""
+    a = [
+        r["rung"]
+        for r in ent.feature_spec_path(
+            ent.TIER_OSS, ent.TIER_ENTERPRISE, "custom_alerts"
+        )
+    ]
+    b = [
+        r["rung"]
+        for r in ent.feature_spec_path(
+            ent.TIER_OSS, ent.TIER_ENTERPRISE, "sessions"
+        )
+    ]
+    c = [
+        r["rung"]
+        for r in ent.feature_spec_path(
+            ent.TIER_OSS, ent.TIER_ENTERPRISE, "siem_export"
+        )
+    ]
+    assert a == b == c
+
+
+def test_paid_feature_unlock_boundary_visible(ent):
+    """``custom_alerts`` is a Pro-only feature -- ``allowed`` must
+    flip from ``False`` to ``True`` exactly at the cloud_pro rung."""
+    path = ent.feature_spec_path(ent.TIER_OSS, ent.TIER_ENTERPRISE, "custom_alerts")
+    by_rung = {row["rung"]: row for row in path}
+    # cloud_starter rank 1: not yet unlocked
+    assert by_rung[ent.TIER_CLOUD_STARTER]["allowed"] is False
+    assert by_rung[ent.TIER_CLOUD_STARTER]["locked"] is True
+    # cloud_pro / pro / enterprise: unlocked
+    for rung in (ent.TIER_CLOUD_PRO, ent.TIER_PRO, ent.TIER_ENTERPRISE):
+        assert by_rung[rung]["allowed"] is True
+        assert by_rung[rung]["locked"] is False
+        assert by_rung[rung]["entitled"] is True
+
+
+def test_free_feature_allowed_at_every_rung(ent):
+    """``sessions`` is a free feature -- ``allowed`` must be ``True``
+    at every walked rung."""
+    path = ent.feature_spec_path(ent.TIER_OSS, ent.TIER_ENTERPRISE, "sessions")
+    for row in path:
+        assert row["allowed"] is True
+        assert row["locked"] is False
+        assert row["entitled"] is True
+        assert row["free"] is True
+
+
+def test_enterprise_only_feature_locked_until_enterprise(ent):
+    """``siem_export`` is enterprise-only -- ``allowed`` must stay
+    ``False`` at every rung below enterprise and ``True`` at
+    enterprise."""
+    path = ent.feature_spec_path(ent.TIER_OSS, ent.TIER_ENTERPRISE, "siem_export")
+    by_rung = {row["rung"]: row for row in path}
+    for rung in (ent.TIER_CLOUD_STARTER, ent.TIER_CLOUD_PRO, ent.TIER_PRO):
+        assert by_rung[rung]["allowed"] is False
+    assert by_rung[ent.TIER_ENTERPRISE]["allowed"] is True
+
+
+def test_ascending_walk_is_non_decreasing_in_rank(ent):
+    path = ent.feature_spec_path(ent.TIER_OSS, ent.TIER_ENTERPRISE, "custom_alerts")
+    walk_ranks = [row["rung_rank"] for row in path]
+    assert walk_ranks == sorted(walk_ranks)
+
+
+def test_descending_walk_is_non_increasing_in_rank(ent):
+    path = ent.feature_spec_path(ent.TIER_ENTERPRISE, ent.TIER_OSS, "custom_alerts")
+    walk_ranks = [row["rung_rank"] for row in path]
+    assert walk_ranks == sorted(walk_ranks, reverse=True)
+
+
+def test_path_terminates_at_to_not_a_sibling(ent):
+    """``pro`` and ``cloud_pro`` share rank 2 -- the path must end
+    exactly at ``pro`` and exclude the same-rank sibling."""
+    rungs = [
+        r["rung"]
+        for r in ent.feature_spec_path(ent.TIER_OSS, ent.TIER_PRO, "custom_alerts")
+    ]
+    assert rungs[-1] == ent.TIER_PRO
+    assert ent.TIER_CLOUD_PRO not in rungs
+
+
+def test_identity_returns_empty(ent):
+    for tid in (
+        ent.TIER_OSS,
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_PRO,
+        ent.TIER_ENTERPRISE,
+    ):
+        assert ent.feature_spec_path(tid, tid, "custom_alerts") == []
+
+
+def test_lateral_single_row(ent):
+    """``cloud_pro`` and ``pro`` share rank 2 -- lateral branch yields
+    a one-row path."""
+    path = ent.feature_spec_path(ent.TIER_CLOUD_PRO, ent.TIER_PRO, "custom_alerts")
+    assert len(path) == 1
+    assert path[0]["rung"] == ent.TIER_PRO
+
+
+def test_trial_endpoint_via_lateral(ent):
+    path = ent.feature_spec_path(ent.TIER_CLOUD_PRO, ent.TIER_TRIAL, "custom_alerts")
+    assert len(path) == 1
+    assert path[0]["rung"] == ent.TIER_TRIAL
+
+
+def test_trial_excluded_from_walked_intermediate_rungs(ent):
+    path = ent.feature_spec_path(ent.TIER_OSS, ent.TIER_ENTERPRISE, "custom_alerts")
+    for row in path:
+        assert row["rung"] != ent.TIER_TRIAL
+
+
+def test_unknown_tier_returns_none(ent):
+    assert (
+        ent.feature_spec_path("not_a_tier", ent.TIER_ENTERPRISE, "custom_alerts")
+        is None
+    )
+    assert (
+        ent.feature_spec_path(ent.TIER_OSS, "still_not", "custom_alerts") is None
+    )
+
+
+def test_unknown_feature_returns_none(ent):
+    assert (
+        ent.feature_spec_path(ent.TIER_OSS, ent.TIER_ENTERPRISE, "not_a_feature")
+        is None
+    )
+    assert ent.feature_spec_path(ent.TIER_OSS, ent.TIER_ENTERPRISE, "") is None
+
+
+def test_empty_and_garbage_inputs_never_raise(ent):
+    assert ent.feature_spec_path("", "", "") is None
+    assert ent.feature_spec_path(None, None, None) is None  # type: ignore[arg-type]
+    assert ent.feature_spec_path("  ", "  ", "  ") is None
+    assert ent.feature_spec_path(123, 456, 789) is None  # type: ignore[arg-type]
+
+
+def test_case_and_whitespace_normalised(ent):
+    a = ent.feature_spec_path(ent.TIER_OSS, ent.TIER_ENTERPRISE, "custom_alerts")
+    b = ent.feature_spec_path("  OSS ", " ENTERPRISE  ", "  CUSTOM_ALERTS ")
+    assert a == b
+
+
+def test_grace_and_enforce_yield_identical_rows(ent, monkeypatch):
+    grace_rows = ent.feature_spec_path(
+        ent.TIER_OSS, ent.TIER_ENTERPRISE, "custom_alerts"
+    )
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    enforced_rows = ent.feature_spec_path(
+        ent.TIER_OSS, ent.TIER_ENTERPRISE, "custom_alerts"
+    )
+    assert grace_rows == enforced_rows
+
+
+def test_resolver_failure_returns_none(ent, monkeypatch):
+    monkeypatch.setattr(
+        ent,
+        "feature_spec_at",
+        lambda _t, _f: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
+    result = ent.feature_spec_path(
+        ent.TIER_OSS, ent.TIER_ENTERPRISE, "custom_alerts"
+    )
+    assert result is None
+
+
+# ── API surface ──────────────────────────────────────────────────────────────
+
+
+def test_api_400_on_missing_from(client):
+    r = client.get("/api/entitlement/feature-spec-path?to=cloud_pro&feature=sessions")
+    assert r.status_code == 400
+
+
+def test_api_400_on_missing_to(client):
+    r = client.get("/api/entitlement/feature-spec-path?from=oss&feature=sessions")
+    assert r.status_code == 400
+
+
+def test_api_400_on_missing_feature(client):
+    r = client.get("/api/entitlement/feature-spec-path?from=oss&to=enterprise")
+    assert r.status_code == 400
+    body = r.get_json()
+    assert body["error"] == "missing feature"
+
+
+def test_api_404_on_unknown_tier(client):
+    r = client.get(
+        "/api/entitlement/feature-spec-path?from=oss&to=not_a_tier&feature=sessions"
+    )
+    assert r.status_code == 404
+    body = r.get_json()
+    assert body["error"] == "unknown tier or feature"
+
+
+def test_api_404_on_unknown_feature(client):
+    r = client.get(
+        "/api/entitlement/feature-spec-path?from=oss&to=enterprise&feature=bogus"
+    )
+    assert r.status_code == 404
+
+
+def test_api_happy_path_ascending(client, ent):
+    r = client.get(
+        f"/api/entitlement/feature-spec-path?from={ent.TIER_OSS}"
+        f"&to={ent.TIER_ENTERPRISE}&feature=custom_alerts"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert set(body.keys()) == _ENVELOPE_KEYS
+    assert body["from"] == ent.TIER_OSS
+    assert body["to"] == ent.TIER_ENTERPRISE
+    assert body["feature"] == "custom_alerts"
+    assert body["direction"] == "upgrade"
+    assert isinstance(body["path"], list) and body["path"]
+    assert body["path"][-1]["rung"] == ent.TIER_ENTERPRISE
+
+
+def test_api_happy_path_descending(client, ent):
+    r = client.get(
+        f"/api/entitlement/feature-spec-path?from={ent.TIER_ENTERPRISE}"
+        f"&to={ent.TIER_OSS}&feature=custom_alerts"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["direction"] == "downgrade"
+    assert body["path"][-1]["rung"] == ent.TIER_OSS
+
+
+def test_api_identity_empty_path(client, ent):
+    r = client.get(
+        f"/api/entitlement/feature-spec-path?from={ent.TIER_CLOUD_PRO}"
+        f"&to={ent.TIER_CLOUD_PRO}&feature=custom_alerts"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["direction"] == "identity"
+    assert body["path"] == []
+
+
+def test_api_lateral_single_row(client, ent):
+    r = client.get(
+        f"/api/entitlement/feature-spec-path?from={ent.TIER_CLOUD_PRO}"
+        f"&to={ent.TIER_PRO}&feature=custom_alerts"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["direction"] == "lateral"
+    assert len(body["path"]) == 1
+    assert body["path"][0]["rung"] == ent.TIER_PRO
+
+
+def test_api_rungs_match_tier_spec_path_route(client, ent):
+    """API-level byte-equality: rung ids from ``/feature-spec-path``
+    match rung ids from ``/tier-spec-path``."""
+    a = client.get(
+        f"/api/entitlement/feature-spec-path?from={ent.TIER_OSS}"
+        f"&to={ent.TIER_ENTERPRISE}&feature=custom_alerts"
+    ).get_json()
+    b = client.get(
+        f"/api/entitlement/tier-spec-path?from={ent.TIER_OSS}"
+        f"&to={ent.TIER_ENTERPRISE}"
+    ).get_json()
+    assert [r["rung"] for r in a["path"]] == [r["id"] for r in b["path"]]

--- a/tests/test_entitlement_runtime_spec_path.py
+++ b/tests/test_entitlement_runtime_spec_path.py
@@ -1,0 +1,422 @@
+"""Tests for ``clawmetry.entitlements.runtime_spec_path(from, to, runtime)``
++ the ``GET /api/entitlement/runtime-spec-path`` endpoint.
+
+Runtime-axis twin of :func:`feature_spec_path` -- the single-runtime
+sibling of :func:`tier_spec_path` and perspective-walked sibling of
+:func:`runtime_spec_at`. Lets a paywall "how does THIS one runtime
+unlock as I climb the ladder" UI render every rung's ``allowed`` /
+``locked`` / ``entitled`` status off ONE round-trip without fetching
+the full :func:`runtime_catalog_at` at every rung.
+
+Pins:
+
+* rung walk byte-stable against :func:`tier_path`,
+  :func:`tier_spec_path`, :func:`feature_spec_path`,
+  :func:`capacity_diff_path`, :func:`tier_unlocks_path`,
+  :func:`tier_locks_path` and :func:`preview_path`
+* per-rung row carries the singular :func:`runtime_spec_at` body PLUS
+  the three rung-identification keys (``rung``, ``rung_label``,
+  ``rung_rank``); dropping the three ``rung*`` keys yields exact
+  byte-equality with :func:`runtime_spec_at(rung, runtime)`
+* free runtime (``openclaw``) surfaces ``allowed=True`` at every rung
+* paid runtime (``claude_code``) flips from ``False`` to ``True`` at
+  the rung where the runtime becomes allowed
+* runtime alias (``claude-code``) resolves to ``claude_code``
+* identity returns ``[]``
+* lateral (same rank, different id) returns a single-row path
+* trial accepted as an endpoint (lateral branch for ``to=trial``;
+  ``from=trial`` walks intermediate rungs above)
+* unknown / empty / garbage tier or runtime ids return ``None`` and
+  never raise
+* grace vs enforce yields identical rows (helper walks the static
+  per-tier maps via :func:`runtime_spec_at`)
+* API surface: 400 on missing args, 404 on unknown ids, 200 envelope
+  on happy path (incl. direction tag and ``runtime`` echo with the
+  canonical id, not the alias)
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+_ENVELOPE_KEYS = {
+    "from",
+    "from_label",
+    "from_rank",
+    "to",
+    "to_label",
+    "to_rank",
+    "direction",
+    "runtime",
+    "path",
+}
+
+_RUNG_KEYS = {"rung", "rung_label", "rung_rank"}
+
+
+# ── helper-level: shape + invariants ─────────────────────────────────────────
+
+
+def test_returns_list(ent):
+    path = ent.runtime_spec_path(ent.TIER_OSS, ent.TIER_ENTERPRISE, "claude_code")
+    assert isinstance(path, list)
+    assert len(path) >= 1
+
+
+def test_each_row_carries_rung_keys(ent):
+    path = ent.runtime_spec_path(ent.TIER_OSS, ent.TIER_ENTERPRISE, "claude_code")
+    for row in path:
+        assert set(row).issuperset(_RUNG_KEYS)
+        assert row["rung_label"] == ent.tier_label(row["rung"])
+        assert row["rung_rank"] == ent.tier_rank(row["rung"])
+
+
+def test_per_rung_byte_equality_with_singular_runtime_spec_at(ent):
+    """Dropping the three ``rung*`` keys yields exact byte-equality with
+    :func:`runtime_spec_at(rung, runtime)`."""
+    path = ent.runtime_spec_path(ent.TIER_OSS, ent.TIER_ENTERPRISE, "claude_code")
+    for row in path:
+        body = {k: v for k, v in row.items() if k not in _RUNG_KEYS}
+        direct = ent.runtime_spec_at(row["rung"], "claude_code")
+        assert body == direct
+
+
+def test_static_runtime_property_keys_constant_across_rungs(ent):
+    path = ent.runtime_spec_path(ent.TIER_OSS, ent.TIER_ENTERPRISE, "claude_code")
+    static = {"id", "label", "tier", "tiers", "free"}
+    first = {k: path[0][k] for k in static}
+    for row in path[1:]:
+        assert {k: row[k] for k in static} == first
+
+
+def test_rung_walk_byte_stable_against_tier_spec_path(ent):
+    for f, t in (
+        (ent.TIER_OSS, ent.TIER_ENTERPRISE),
+        (ent.TIER_CLOUD_FREE, ent.TIER_PRO),
+        (ent.TIER_ENTERPRISE, ent.TIER_OSS),
+        (ent.TIER_TRIAL, ent.TIER_ENTERPRISE),
+    ):
+        rt_rungs = [
+            r["rung"] for r in ent.runtime_spec_path(f, t, "claude_code")
+        ]
+        spec_rungs = [r["id"] for r in ent.tier_spec_path(f, t)]
+        assert rt_rungs == spec_rungs
+
+
+def test_rung_walk_byte_stable_against_feature_spec_path(ent):
+    """Cross-axis byte-stability: feature_spec_path and
+    runtime_spec_path must walk the same rungs."""
+    for f, t in (
+        (ent.TIER_OSS, ent.TIER_ENTERPRISE),
+        (ent.TIER_ENTERPRISE, ent.TIER_OSS),
+    ):
+        rt_rungs = [
+            r["rung"] for r in ent.runtime_spec_path(f, t, "claude_code")
+        ]
+        feat_rungs = [
+            r["rung"] for r in ent.feature_spec_path(f, t, "custom_alerts")
+        ]
+        assert rt_rungs == feat_rungs
+
+
+def test_rung_walk_invariant_across_runtimes(ent):
+    """The walked rung sequence is runtime-agnostic -- swapping the
+    runtime must not move the rungs."""
+    a = [
+        r["rung"]
+        for r in ent.runtime_spec_path(
+            ent.TIER_OSS, ent.TIER_ENTERPRISE, "claude_code"
+        )
+    ]
+    b = [
+        r["rung"]
+        for r in ent.runtime_spec_path(
+            ent.TIER_OSS, ent.TIER_ENTERPRISE, "openclaw"
+        )
+    ]
+    c = [
+        r["rung"]
+        for r in ent.runtime_spec_path(
+            ent.TIER_OSS, ent.TIER_ENTERPRISE, "codex"
+        )
+    ]
+    assert a == b == c
+
+
+def test_free_runtime_allowed_at_every_rung(ent):
+    """``openclaw`` is in :data:`FREE_RUNTIMES` -- ``allowed`` must be
+    ``True`` at every walked rung."""
+    path = ent.runtime_spec_path(ent.TIER_OSS, ent.TIER_ENTERPRISE, "openclaw")
+    for row in path:
+        assert row["allowed"] is True
+        assert row["locked"] is False
+        assert row["entitled"] is True
+        assert row["free"] is True
+
+
+def test_paid_runtime_unlock_boundary_visible(ent):
+    """``claude_code`` is a paid runtime -- ``allowed`` is ``False`` at
+    the free / oss rung and ``True`` at every purchasable rung that
+    unlocks paid runtimes (cloud_starter, cloud_pro, pro, enterprise)."""
+    path = ent.runtime_spec_path(ent.TIER_OSS, ent.TIER_ENTERPRISE, "claude_code")
+    for row in path:
+        if row["rung"] in (ent.TIER_OSS, ent.TIER_CLOUD_FREE):
+            assert row["allowed"] is False
+        else:
+            assert row["allowed"] is True
+
+
+def test_runtime_alias_resolves(ent):
+    """``claude-code`` (alias) must resolve to ``claude_code`` and
+    produce a path byte-identical to the canonical id."""
+    aliased = ent.runtime_spec_path(
+        ent.TIER_OSS, ent.TIER_ENTERPRISE, "claude-code"
+    )
+    canonical = ent.runtime_spec_path(
+        ent.TIER_OSS, ent.TIER_ENTERPRISE, "claude_code"
+    )
+    assert aliased == canonical
+
+
+def test_ascending_walk_is_non_decreasing_in_rank(ent):
+    path = ent.runtime_spec_path(ent.TIER_OSS, ent.TIER_ENTERPRISE, "claude_code")
+    walk_ranks = [row["rung_rank"] for row in path]
+    assert walk_ranks == sorted(walk_ranks)
+
+
+def test_descending_walk_is_non_increasing_in_rank(ent):
+    path = ent.runtime_spec_path(ent.TIER_ENTERPRISE, ent.TIER_OSS, "claude_code")
+    walk_ranks = [row["rung_rank"] for row in path]
+    assert walk_ranks == sorted(walk_ranks, reverse=True)
+
+
+def test_path_terminates_at_to_not_a_sibling(ent):
+    rungs = [
+        r["rung"]
+        for r in ent.runtime_spec_path(ent.TIER_OSS, ent.TIER_PRO, "claude_code")
+    ]
+    assert rungs[-1] == ent.TIER_PRO
+    assert ent.TIER_CLOUD_PRO not in rungs
+
+
+def test_identity_returns_empty(ent):
+    for tid in (
+        ent.TIER_OSS,
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_PRO,
+        ent.TIER_ENTERPRISE,
+    ):
+        assert ent.runtime_spec_path(tid, tid, "claude_code") == []
+
+
+def test_lateral_single_row(ent):
+    path = ent.runtime_spec_path(ent.TIER_CLOUD_PRO, ent.TIER_PRO, "claude_code")
+    assert len(path) == 1
+    assert path[0]["rung"] == ent.TIER_PRO
+
+
+def test_trial_endpoint_via_lateral(ent):
+    path = ent.runtime_spec_path(ent.TIER_CLOUD_PRO, ent.TIER_TRIAL, "claude_code")
+    assert len(path) == 1
+    assert path[0]["rung"] == ent.TIER_TRIAL
+
+
+def test_trial_excluded_from_walked_intermediate_rungs(ent):
+    path = ent.runtime_spec_path(ent.TIER_OSS, ent.TIER_ENTERPRISE, "claude_code")
+    for row in path:
+        assert row["rung"] != ent.TIER_TRIAL
+
+
+def test_unknown_tier_returns_none(ent):
+    assert (
+        ent.runtime_spec_path("not_a_tier", ent.TIER_ENTERPRISE, "claude_code")
+        is None
+    )
+    assert (
+        ent.runtime_spec_path(ent.TIER_OSS, "still_not", "claude_code") is None
+    )
+
+
+def test_unknown_runtime_returns_none(ent):
+    assert (
+        ent.runtime_spec_path(ent.TIER_OSS, ent.TIER_ENTERPRISE, "not_a_runtime")
+        is None
+    )
+    assert ent.runtime_spec_path(ent.TIER_OSS, ent.TIER_ENTERPRISE, "") is None
+
+
+def test_empty_and_garbage_inputs_never_raise(ent):
+    assert ent.runtime_spec_path("", "", "") is None
+    assert ent.runtime_spec_path(None, None, None) is None  # type: ignore[arg-type]
+    assert ent.runtime_spec_path("  ", "  ", "  ") is None
+    assert ent.runtime_spec_path(123, 456, 789) is None  # type: ignore[arg-type]
+
+
+def test_case_and_whitespace_normalised(ent):
+    a = ent.runtime_spec_path(ent.TIER_OSS, ent.TIER_ENTERPRISE, "claude_code")
+    b = ent.runtime_spec_path("  OSS ", " ENTERPRISE  ", "  CLAUDE_CODE ")
+    assert a == b
+
+
+def test_grace_and_enforce_yield_identical_rows(ent, monkeypatch):
+    grace_rows = ent.runtime_spec_path(
+        ent.TIER_OSS, ent.TIER_ENTERPRISE, "claude_code"
+    )
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    enforced_rows = ent.runtime_spec_path(
+        ent.TIER_OSS, ent.TIER_ENTERPRISE, "claude_code"
+    )
+    assert grace_rows == enforced_rows
+
+
+def test_resolver_failure_returns_none(ent, monkeypatch):
+    monkeypatch.setattr(
+        ent,
+        "runtime_spec_at",
+        lambda _t, _r: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
+    result = ent.runtime_spec_path(
+        ent.TIER_OSS, ent.TIER_ENTERPRISE, "claude_code"
+    )
+    assert result is None
+
+
+# ── API surface ──────────────────────────────────────────────────────────────
+
+
+def test_api_400_on_missing_from(client):
+    r = client.get(
+        "/api/entitlement/runtime-spec-path?to=cloud_pro&runtime=claude_code"
+    )
+    assert r.status_code == 400
+
+
+def test_api_400_on_missing_to(client):
+    r = client.get(
+        "/api/entitlement/runtime-spec-path?from=oss&runtime=claude_code"
+    )
+    assert r.status_code == 400
+
+
+def test_api_400_on_missing_runtime(client):
+    r = client.get("/api/entitlement/runtime-spec-path?from=oss&to=enterprise")
+    assert r.status_code == 400
+    body = r.get_json()
+    assert body["error"] == "missing runtime"
+
+
+def test_api_404_on_unknown_tier(client):
+    r = client.get(
+        "/api/entitlement/runtime-spec-path?from=oss&to=not_a_tier&runtime=claude_code"
+    )
+    assert r.status_code == 404
+    body = r.get_json()
+    assert body["error"] == "unknown tier or runtime"
+
+
+def test_api_404_on_unknown_runtime(client):
+    r = client.get(
+        "/api/entitlement/runtime-spec-path?from=oss&to=enterprise&runtime=bogus"
+    )
+    assert r.status_code == 404
+
+
+def test_api_happy_path_ascending(client, ent):
+    r = client.get(
+        f"/api/entitlement/runtime-spec-path?from={ent.TIER_OSS}"
+        f"&to={ent.TIER_ENTERPRISE}&runtime=claude_code"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert set(body.keys()) == _ENVELOPE_KEYS
+    assert body["from"] == ent.TIER_OSS
+    assert body["to"] == ent.TIER_ENTERPRISE
+    assert body["runtime"] == "claude_code"
+    assert body["direction"] == "upgrade"
+    assert isinstance(body["path"], list) and body["path"]
+    assert body["path"][-1]["rung"] == ent.TIER_ENTERPRISE
+
+
+def test_api_happy_path_descending(client, ent):
+    r = client.get(
+        f"/api/entitlement/runtime-spec-path?from={ent.TIER_ENTERPRISE}"
+        f"&to={ent.TIER_OSS}&runtime=claude_code"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["direction"] == "downgrade"
+    assert body["path"][-1]["rung"] == ent.TIER_OSS
+
+
+def test_api_identity_empty_path(client, ent):
+    r = client.get(
+        f"/api/entitlement/runtime-spec-path?from={ent.TIER_CLOUD_PRO}"
+        f"&to={ent.TIER_CLOUD_PRO}&runtime=claude_code"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["direction"] == "identity"
+    assert body["path"] == []
+
+
+def test_api_lateral_single_row(client, ent):
+    r = client.get(
+        f"/api/entitlement/runtime-spec-path?from={ent.TIER_CLOUD_PRO}"
+        f"&to={ent.TIER_PRO}&runtime=claude_code"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["direction"] == "lateral"
+    assert len(body["path"]) == 1
+    assert body["path"][0]["rung"] == ent.TIER_PRO
+
+
+def test_api_alias_echoes_canonical_id(client, ent):
+    """``runtime=claude-code`` (alias) must echo the canonical
+    ``claude_code`` in the envelope -- mirrors the
+    ``/api/entitlement/required-tier`` and ``/runtime-spec-at`` behaviour."""
+    r = client.get(
+        f"/api/entitlement/runtime-spec-path?from={ent.TIER_OSS}"
+        f"&to={ent.TIER_ENTERPRISE}&runtime=claude-code"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["runtime"] == "claude_code"
+
+
+def test_api_rungs_match_tier_spec_path_route(client, ent):
+    a = client.get(
+        f"/api/entitlement/runtime-spec-path?from={ent.TIER_OSS}"
+        f"&to={ent.TIER_ENTERPRISE}&runtime=claude_code"
+    ).get_json()
+    b = client.get(
+        f"/api/entitlement/tier-spec-path?from={ent.TIER_OSS}"
+        f"&to={ent.TIER_ENTERPRISE}"
+    ).get_json()
+    assert [r["rung"] for r in a["path"]] == [r["id"] for r in b["path"]]


### PR DESCRIPTION
## Summary

Adds the per-feature and per-runtime members of the `_path` family — `feature_spec_path(from, to, feature)` + `GET /api/entitlement/feature-spec-path` and `runtime_spec_path(from, to, runtime)` + `GET /api/entitlement/runtime-spec-path` — extending the six existing `_path` helpers (`tier_path`, `capacity_diff_path`, `tier_unlocks_path`, `tier_locks_path`, `preview_path`, `tier_spec_path`) onto the single-feature and single-runtime axes.

### What they do

Both walk the same `_PURCHASABLE_TIERS` rungs by the same sort key + destination-sibling exclusion as the rest of the `_path` family — byte-stable rung-for-rung against the existing six — and at each rung return the singular `feature_spec_at(rung, feature)` / `runtime_spec_at(rung, runtime)` body augmented with three rung-identification keys (`rung`, `rung_label`, `rung_rank`) so each row identifies the perspective tier it was computed at.

Dropping the three `rung*` keys from any path row yields exact byte-equality with the singular `feature_spec_at` / `runtime_spec_at` row (parity tests pin this so the scalar what-if and the path what-if cannot drift).

Lets a paywall **"how does THIS one feature/runtime unlock as I climb the ladder"** UI render every rung's `allowed` / `locked` / `entitled` status off ONE round-trip without fetching the full `/feature-catalog-at` (or `/runtime-catalog-at`) at every rung. The static feature-/runtime-property keys (`id`, `label`, `tier`, `tiers`, `free`, `alias`) stay constant across all rows; only the perspective-dependent fields (`allowed`, `locked`, `entitled`) vary rung by rung — the visible "unlock boundary" the UI renders.

### Shape

```
{
  "from":       "<tier id>",
  "from_label": "...",
  "from_rank":  <int>,
  "to":         "<tier id>",
  "to_label":   "...",
  "to_rank":    <int>,
  "direction":  "upgrade" | "downgrade" | "lateral" | "identity",
  "feature":    "<feature id>",          // or "runtime" on the runtime route
  "path":       [<augmented spec row>, ...]
}
```

Per-rung row: every key from `/feature-spec-at?tier=<rung>&feature=<feature>` (or `/runtime-spec-at?tier=<rung>&runtime=<runtime>`) PLUS `rung`, `rung_label`, `rung_rank`.

### Posture

- Resolver-independent: walks the static per-tier maps via `feature_spec_at` / `runtime_spec_at`, so grace vs enforce yields byte-identical rows.
- Runtime route accepts aliases (`claude-code` → `claude_code`) via `canonical_runtime` so the URL surface matches `/api/entitlement/required-tier` and `/runtime-spec-at`.
- Never raises: helper logs a warning and returns `None` on resolver failure; routes catch and return 404 on unknown ids, 400 on missing args.
- `trial` accepted as an endpoint (excluded from walked intermediate rungs since it is not purchasable; valid via the lateral branch).

### Tests

69 new unit + route tests across two files covering:

- per-rung byte-equality with the singular `feature_spec_at` / `runtime_spec_at` (after dropping `rung*` keys)
- rung walk byte-stable against `tier_spec_path` / `tier_path` (so the seven paths line up rung-for-rung)
- static feature-/runtime-property keys constant across rungs
- unlock boundary visible: free feature/runtime `allowed=True` everywhere; paid feature flips at its min-tier rung; enterprise-only feature stays locked until enterprise; paid runtime flips at the first purchasable rung that unlocks paid runtimes
- runtime alias resolves to canonical id (byte-equal paths)
- identity / lateral / upgrade / downgrade branches
- same-rank sibling exclusion at destination
- trial endpoint via the lateral branch
- unknown / empty / garbage tier or feature/runtime ids → `None` (never raises)
- whitespace + case normalisation
- grace vs enforce row equality
- resolver-failure swallow → `None`
- API surface: 400 on missing args, 404 on unknown ids, 200 envelope on happy path, API alias echo returns canonical id, route rung-for-rung parity against `/tier-spec-path`

All 69 new tests pass; full local entitlement+license suite (2606 tests) green except for one pre-existing `test_license_pubkey.py::test_fingerprint_is_whitespace_independent` failure unrelated to this PR (reproduces on `main` with no edits). `ruff` clean on every file in the diff.

### Scope

Pure feature-add — no helper signatures or existing route shapes change. Resolver semantics untouched (helpers do not consult the resolver). No frontend changes; this is an API-only addition for a future paywall surface. No version bump, no `[RELEASE]` PR.

## Test plan

- [x] `python3 -m pytest tests/test_entitlement_feature_spec_path.py tests/test_entitlement_runtime_spec_path.py -q` — 69 passed
- [x] `python3 -m pytest tests/test_entitlement*.py tests/test_entitlements*.py tests/test_license*.py -q` — 2606 passed, 1 pre-existing failure
- [x] `ruff check clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_feature_spec_path.py tests/test_entitlement_runtime_spec_path.py` — All checks passed
- [ ] Local-operator verification on the running daemon (see checklist below)

---

### Local operator verification checklist

I cannot reach the running daemon, `~/.openclaw`, or the live cloud snapshot from this environment. Before flipping the PR ready-for-review and merging, please:

1. Pull `feat/entitlement-feature-runtime-spec-path` locally and copy the changed files into the installed site-packages location:
   ```sh
   cp clawmetry/entitlements.py ~/.clawmetry/lib/python*/site-packages/clawmetry/entitlements.py
   cp routes/entitlement.py ~/.clawmetry/lib/python*/site-packages/routes/entitlement.py
   ```
2. Clear `__pycache__` under `~/.clawmetry/lib/python*/site-packages/{clawmetry,routes}/` so the new bytecode is picked up.
3. Restart the daemon: `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`.
4. Smoke the new endpoints against your live install:
   ```sh
   curl -s 'http://localhost:8900/api/entitlement/feature-spec-path?from=oss&to=enterprise&feature=custom_alerts' \
     | jq '.direction, [.path[] | {rung, allowed, locked, entitled}]'
   curl -s 'http://localhost:8900/api/entitlement/feature-spec-path?from=oss&to=enterprise&feature=siem_export' \
     | jq '[.path[] | {rung, allowed}]'
   curl -s 'http://localhost:8900/api/entitlement/runtime-spec-path?from=oss&to=enterprise&runtime=claude_code' \
     | jq '.direction, [.path[] | {rung, allowed, locked, entitled}]'
   curl -s 'http://localhost:8900/api/entitlement/runtime-spec-path?from=oss&to=enterprise&runtime=claude-code' \
     | jq '.runtime'   # should print "claude_code" (alias normalised)
   curl -s 'http://localhost:8900/api/entitlement/feature-spec-path?from=oss&to=enterprise' \
     -o /dev/null -w '%{http_code}\n'   # expect 400 (missing feature)
   curl -s 'http://localhost:8900/api/entitlement/feature-spec-path?from=oss&to=enterprise&feature=bogus' \
     -o /dev/null -w '%{http_code}\n'   # expect 404
   curl -s 'http://localhost:8900/api/entitlement/runtime-spec-path?from=oss&to=not_a_tier&runtime=claude_code' \
     -o /dev/null -w '%{http_code}\n'   # expect 404
   ```
5. Confirm `/api/entitlement` and the existing `_path` endpoints (`/tier-path`, `/preview-path`, `/capacity-diff-path`, `/tier-unlocks-path`, `/tier-locks-path`, `/tier-spec-path`) still return the same payloads they did pre-change.
6. Decrypt the live cloud snapshot in the browser and re-verify the entitlement panel renders unchanged (no UI consumes the new endpoints yet — this is a pure additive surface).

---

Generated with [Claude Code](https://claude.com/claude-code).

---
_Generated by [Claude Code](https://claude.ai/code/session_01MSJKEV9Cd2DrLxfbNXJVRf)_