### PR TITLE
feat(entitlement): next/previous_tier_{feature,runtime}_spec_at + endpoints

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -6446,6 +6446,196 @@ def previous_tier_spec_at_batch() -> list[dict]:
         return []
 
 
+def next_tier_feature_spec_at(tier: str, feature: str) -> dict | None:
+    """Scalar what-if sibling of :func:`next_tier_spec_at` projected onto a
+    SINGLE feature: the :func:`feature_spec_at`-shape catalogue row for
+    ``feature`` evaluated on the rung above the caller-supplied ``tier``.
+
+    Feature-axis projection of :func:`next_tier_spec_at` (full tier-row
+    descriptor of the rung above the source) and feature-side mirror of
+    :func:`next_tier_runtime_spec_at`. Convenience for
+    ``feature_spec_at(_next_purchasable_tier_after(tier), feature)`` so a
+    pricing-table cell can ask "does THIS feature unlock at my next
+    rung?" off ONE round-trip without first walking the catalogue or
+    asking the resolver. Pairs with :func:`previous_tier_feature_spec_at`
+    on the downgrade side and with :func:`next_tier_runtime_spec_at` /
+    :func:`previous_tier_runtime_spec_at` on the runtime axis.
+
+    The returned row matches :func:`feature_spec_at(target, feature)` for
+    the resolved ``target = _next_purchasable_tier_after(tier)`` exactly
+    -- a parity test pins this so the scalar projection cannot drift
+    from the full-row sibling.
+
+    Accepts any id in :data:`_TIER_ORDER` for ``tier`` (including
+    :data:`TIER_TRIAL`) -- the lenient ``_at`` posture, matching the
+    other ``next_*_at`` helpers.
+
+    Returns ``None`` for empty / unknown ``tier`` or ``feature`` and at
+    the ceiling (no rung strictly above -- enterprise as source). Never
+    raises: a builder failure short-circuits to ``None`` so the CTA
+    surface stays mute instead of breaking.
+    """
+    try:
+        src = (tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if not src or src not in _TIER_ORDER:
+        return None
+    try:
+        f = (feature or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if not f or f not in ALL_FEATURES:
+        return None
+    try:
+        target = _next_purchasable_tier_after(src)
+        if target is None:
+            return None
+        return feature_spec_at(target, f)
+    except Exception as exc:
+        logger.warning("entitlements: next_tier_feature_spec_at failed: %s", exc)
+        return None
+
+
+def previous_tier_feature_spec_at(tier: str, feature: str) -> dict | None:
+    """Scalar what-if sibling of :func:`previous_tier_spec_at` projected
+    onto a SINGLE feature: the :func:`feature_spec_at`-shape catalogue
+    row for ``feature`` evaluated on the rung below the caller-supplied
+    ``tier``.
+
+    Source-anchored mirror of :func:`next_tier_feature_spec_at` and
+    downgrade-confirmation counterpart on the feature axis. Convenience
+    for ``feature_spec_at(_previous_purchasable_tier_before(tier),
+    feature)`` so a downgrade-confirmation card can ask "does THIS
+    feature still unlock at my previous rung?" off ONE round-trip
+    without re-walking the catalogue.
+
+    Like :func:`next_tier_feature_spec_at` the row matches
+    :func:`feature_spec_at(target, feature)` for the resolved
+    ``target = _previous_purchasable_tier_before(tier)`` exactly.
+
+    Accepts any id in :data:`_TIER_ORDER` (including :data:`TIER_TRIAL`)
+    -- the lenient ``_at`` posture.
+
+    Returns ``None`` for empty / unknown ``tier`` or ``feature`` and at
+    the floor (``oss`` / ``cloud_free`` as source -- no rung strictly
+    below). Never raises: a builder failure short-circuits to ``None``
+    so the confirmation surface stays mute instead of breaking.
+    """
+    try:
+        src = (tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if not src or src not in _TIER_ORDER:
+        return None
+    try:
+        f = (feature or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if not f or f not in ALL_FEATURES:
+        return None
+    try:
+        target = _previous_purchasable_tier_before(src)
+        if target is None:
+            return None
+        return feature_spec_at(target, f)
+    except Exception as exc:
+        logger.warning(
+            "entitlements: previous_tier_feature_spec_at failed: %s", exc
+        )
+        return None
+
+
+def next_tier_runtime_spec_at(tier: str, runtime: str) -> dict | None:
+    """Scalar what-if sibling of :func:`next_tier_spec_at` projected onto a
+    SINGLE runtime: the :func:`runtime_spec_at`-shape catalogue row for
+    ``runtime`` evaluated on the rung above the caller-supplied ``tier``.
+
+    Runtime-axis projection of :func:`next_tier_spec_at` and runtime-side
+    mirror of :func:`next_tier_feature_spec_at`. Convenience for
+    ``runtime_spec_at(_next_purchasable_tier_after(tier), runtime)`` so a
+    pricing-table cell can ask "does THIS runtime unlock at my next
+    rung?" off ONE round-trip without first walking the catalogue.
+
+    Accepts aliases (``claude-code`` -> ``claude_code``) via
+    :func:`canonical_runtime` so the URL surface matches what callers
+    already pass to ``/api/entitlement/required-tier`` and
+    ``/runtime-spec-at``.
+
+    The returned row matches :func:`runtime_spec_at(target, runtime)`
+    for the resolved ``target = _next_purchasable_tier_after(tier)``
+    exactly -- a parity test pins this so the scalar projection cannot
+    drift from the full-row sibling.
+
+    Accepts any id in :data:`_TIER_ORDER` for ``tier`` (including
+    :data:`TIER_TRIAL`).
+
+    Returns ``None`` for empty / unknown ``tier`` or ``runtime`` and at
+    the ceiling (no rung strictly above). Never raises.
+    """
+    try:
+        src = (tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if not src or src not in _TIER_ORDER:
+        return None
+    rt = canonical_runtime(runtime)
+    if not rt or rt not in ALL_RUNTIMES:
+        return None
+    try:
+        target = _next_purchasable_tier_after(src)
+        if target is None:
+            return None
+        return runtime_spec_at(target, rt)
+    except Exception as exc:
+        logger.warning("entitlements: next_tier_runtime_spec_at failed: %s", exc)
+        return None
+
+
+def previous_tier_runtime_spec_at(tier: str, runtime: str) -> dict | None:
+    """Scalar what-if sibling of :func:`previous_tier_spec_at` projected
+    onto a SINGLE runtime: the :func:`runtime_spec_at`-shape catalogue
+    row for ``runtime`` evaluated on the rung below the caller-supplied
+    ``tier``.
+
+    Source-anchored mirror of :func:`next_tier_runtime_spec_at` and
+    downgrade-confirmation counterpart on the runtime axis. Convenience
+    for ``runtime_spec_at(_previous_purchasable_tier_before(tier),
+    runtime)``.
+
+    Accepts aliases (``claude-code`` -> ``claude_code``) via
+    :func:`canonical_runtime`.
+
+    Like :func:`next_tier_runtime_spec_at` the row matches
+    :func:`runtime_spec_at(target, runtime)` for the resolved
+    ``target = _previous_purchasable_tier_before(tier)`` exactly.
+
+    Accepts any id in :data:`_TIER_ORDER` (including :data:`TIER_TRIAL`).
+
+    Returns ``None`` for empty / unknown ``tier`` or ``runtime`` and at
+    the floor (``oss`` / ``cloud_free`` as source). Never raises.
+    """
+    try:
+        src = (tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if not src or src not in _TIER_ORDER:
+        return None
+    rt = canonical_runtime(runtime)
+    if not rt or rt not in ALL_RUNTIMES:
+        return None
+    try:
+        target = _previous_purchasable_tier_before(src)
+        if target is None:
+            return None
+        return runtime_spec_at(target, rt)
+    except Exception as exc:
+        logger.warning(
+            "entitlements: previous_tier_runtime_spec_at failed: %s", exc
+        )
+        return None
+
+
 def tier_spec_path(from_tier: str, to_tier: str) -> list[dict] | None:
     """Arbitrary-endpoint stepwise spec-shaped path between two tiers.
 

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -6168,3 +6168,395 @@ def api_entitlement_tier_spec_path():
             jsonify({"error": "unknown tier", "from": f, "to": t}),
             404,
         )
+
+
+@bp_entitlement.route("/api/entitlement/next-tier-feature-spec-at")
+def api_entitlement_next_tier_feature_spec_at():
+    """``GET /api/entitlement/next-tier-feature-spec-at?tier=<source>&feature=<id>``
+    -- scalar what-if sibling of ``/api/entitlement/next-tier-spec-at``
+    projected onto a SINGLE feature: the
+    :func:`clawmetry.entitlements.feature_spec_at`-shape catalogue row for
+    ``feature`` evaluated on the rung above the caller-supplied ``tier``.
+
+    Feature-axis projection of ``/next-tier-spec-at`` (full tier-row
+    descriptor of the rung above the source) and feature-side mirror of
+    ``/next-tier-runtime-spec-at``. Lets a paywall "does THIS feature
+    unlock at my next rung?" tooltip hydrate off ONE round-trip instead
+    of fetching the full ``/feature-catalog-at`` at the next rung and
+    filtering client-side.
+
+    Response shape::
+
+        {
+          "tier":           "<source tier id>",
+          "tier_label":     "<source label>",
+          "tier_rank":      <source rank>,
+          "feature":        "<feature id>",
+          "target":         "<next-above tier id>" | null,
+          "target_label":   "<next-above label>" | null,
+          "target_rank":    <next-above rank> | null,
+          "row":            {<feature_spec_at row>} | null,
+        }
+
+    The inner ``row`` matches
+    ``/feature-spec-at?tier=<target>&feature=<feature>`` byte-for-byte
+    when ``target`` is populated -- a parity test pins this so the
+    projection cannot drift from the full-row sibling.
+
+    Accepts any tier id in :data:`entitlements._TIER_ORDER` (including
+    ``trial``). ``target`` / ``row`` collapse to ``null`` at the ceiling
+    (no rung strictly above the source -- enterprise as source) -- the
+    surface stays 200 with a populated envelope so callers can render
+    "you're at the top" copy without a status-code branch.
+
+    - **400** when ``tier=`` or ``feature=`` is missing / blank
+    - **404** when ``tier`` is unknown or ``feature`` is unknown (not in
+      :data:`ALL_FEATURES`). The body carries ``which`` so a caller can
+      render the right "unknown ..." message.
+    - **Never 5xxs**: builder failure short-circuits to ``row=null`` on
+      the same 200 envelope so the paywall surface stays mute.
+    """
+    raw_tier = request.args.get("tier")
+    tier_in = (raw_tier or "").strip().lower()
+    if not tier_in:
+        return jsonify({"error": "missing tier"}), 400
+    raw_feature = request.args.get("feature")
+    feature = (raw_feature or "").strip().lower()
+    if not feature:
+        return jsonify({"error": "missing feature"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        if tier_in not in _ent._TIER_ORDER:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "tier", "tier": tier_in}
+                ),
+                404,
+            )
+        if feature not in _ent.ALL_FEATURES:
+            return (
+                jsonify(
+                    {
+                        "error": "unknown feature",
+                        "which": "feature",
+                        "feature": feature,
+                    }
+                ),
+                404,
+            )
+        target = _ent._next_purchasable_tier_after(tier_in)
+        row = _ent.next_tier_feature_spec_at(tier_in, feature)
+        return jsonify(
+            {
+                "tier": tier_in,
+                "tier_label": _ent.tier_label(tier_in),
+                "tier_rank": _ent.tier_rank(tier_in),
+                "feature": feature,
+                "target": target,
+                "target_label": _ent.tier_label(target) if target else None,
+                "target_rank": _ent.tier_rank(target) if target else None,
+                "row": row,
+            }
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_next_tier_feature_spec_at: error: %s", exc
+        )
+        return jsonify(
+            {
+                "tier": tier_in,
+                "tier_label": None,
+                "tier_rank": -1,
+                "feature": feature,
+                "target": None,
+                "target_label": None,
+                "target_rank": None,
+                "row": None,
+            }
+        )
+
+
+@bp_entitlement.route("/api/entitlement/previous-tier-feature-spec-at")
+def api_entitlement_previous_tier_feature_spec_at():
+    """``GET /api/entitlement/previous-tier-feature-spec-at?tier=<source>&feature=<id>``
+    -- scalar what-if sibling of
+    ``/api/entitlement/previous-tier-spec-at`` projected onto a SINGLE
+    feature: the :func:`clawmetry.entitlements.feature_spec_at`-shape
+    catalogue row for ``feature`` evaluated on the rung below the
+    caller-supplied ``tier``.
+
+    Source-anchored mirror of ``/next-tier-feature-spec-at`` and
+    downgrade-confirmation counterpart on the feature axis. Lets a
+    downgrade-confirmation card render "does THIS feature still unlock
+    one rung down?" without re-walking the catalogue.
+
+    Response shape matches ``/next-tier-feature-spec-at`` byte-for-byte
+    (``tier``, ``tier_label``, ``tier_rank``, ``feature``, ``target``,
+    ``target_label``, ``target_rank``, ``row``). Inner ``row`` matches
+    ``/feature-spec-at?tier=<target>&feature=<feature>`` byte-for-byte
+    when ``target`` is populated.
+
+    Accepts any tier id in :data:`entitlements._TIER_ORDER` (including
+    ``trial``). ``target`` / ``row`` collapse to ``null`` at the floor
+    (``oss`` / ``cloud_free`` as source).
+
+    - **400** when ``tier=`` or ``feature=`` is missing / blank
+    - **404** when ``tier`` is unknown or ``feature`` is unknown.
+    - **Never 5xxs**: builder failure short-circuits to ``row=null`` on
+      the same 200 envelope.
+    """
+    raw_tier = request.args.get("tier")
+    tier_in = (raw_tier or "").strip().lower()
+    if not tier_in:
+        return jsonify({"error": "missing tier"}), 400
+    raw_feature = request.args.get("feature")
+    feature = (raw_feature or "").strip().lower()
+    if not feature:
+        return jsonify({"error": "missing feature"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        if tier_in not in _ent._TIER_ORDER:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "tier", "tier": tier_in}
+                ),
+                404,
+            )
+        if feature not in _ent.ALL_FEATURES:
+            return (
+                jsonify(
+                    {
+                        "error": "unknown feature",
+                        "which": "feature",
+                        "feature": feature,
+                    }
+                ),
+                404,
+            )
+        target = _ent._previous_purchasable_tier_before(tier_in)
+        row = _ent.previous_tier_feature_spec_at(tier_in, feature)
+        return jsonify(
+            {
+                "tier": tier_in,
+                "tier_label": _ent.tier_label(tier_in),
+                "tier_rank": _ent.tier_rank(tier_in),
+                "feature": feature,
+                "target": target,
+                "target_label": _ent.tier_label(target) if target else None,
+                "target_rank": _ent.tier_rank(target) if target else None,
+                "row": row,
+            }
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_previous_tier_feature_spec_at: error: %s", exc
+        )
+        return jsonify(
+            {
+                "tier": tier_in,
+                "tier_label": None,
+                "tier_rank": -1,
+                "feature": feature,
+                "target": None,
+                "target_label": None,
+                "target_rank": None,
+                "row": None,
+            }
+        )
+
+
+@bp_entitlement.route("/api/entitlement/next-tier-runtime-spec-at")
+def api_entitlement_next_tier_runtime_spec_at():
+    """``GET /api/entitlement/next-tier-runtime-spec-at?tier=<source>&runtime=<id>``
+    -- scalar what-if sibling of ``/api/entitlement/next-tier-spec-at``
+    projected onto a SINGLE runtime: the
+    :func:`clawmetry.entitlements.runtime_spec_at`-shape catalogue row
+    for ``runtime`` evaluated on the rung above the caller-supplied
+    ``tier``.
+
+    Runtime-axis projection of ``/next-tier-spec-at`` (full tier-row
+    descriptor of the rung above the source) and runtime-side mirror of
+    ``/next-tier-feature-spec-at``. Accepts aliases (``claude-code`` ->
+    ``claude_code``) via :func:`entitlements.canonical_runtime` so the
+    URL surface matches what callers already pass to
+    ``/api/entitlement/required-tier`` and ``/runtime-spec-at``.
+
+    Response shape::
+
+        {
+          "tier":           "<source tier id>",
+          "tier_label":     "<source label>",
+          "tier_rank":      <source rank>,
+          "runtime":        "<canonical runtime id>",
+          "target":         "<next-above tier id>" | null,
+          "target_label":   "<next-above label>" | null,
+          "target_rank":    <next-above rank> | null,
+          "row":            {<runtime_spec_at row>} | null,
+        }
+
+    The inner ``row`` matches
+    ``/runtime-spec-at?tier=<target>&runtime=<runtime>`` byte-for-byte
+    when ``target`` is populated.
+
+    Accepts any tier id in :data:`entitlements._TIER_ORDER` (including
+    ``trial``). ``target`` / ``row`` collapse to ``null`` at the
+    ceiling.
+
+    - **400** when ``tier=`` or ``runtime=`` is missing / blank
+    - **404** when ``tier`` is unknown or ``runtime`` (after alias
+      canonicalisation) is unknown (not in :data:`ALL_RUNTIMES`).
+    - **Never 5xxs**: builder failure short-circuits to ``row=null`` on
+      the same 200 envelope.
+    """
+    raw_tier = request.args.get("tier")
+    tier_in = (raw_tier or "").strip().lower()
+    if not tier_in:
+        return jsonify({"error": "missing tier"}), 400
+    raw_runtime = request.args.get("runtime")
+    runtime_in = (raw_runtime or "").strip().lower()
+    if not runtime_in:
+        return jsonify({"error": "missing runtime"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        if tier_in not in _ent._TIER_ORDER:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "tier", "tier": tier_in}
+                ),
+                404,
+            )
+        rt = _ent.canonical_runtime(runtime_in)
+        if not rt or rt not in _ent.ALL_RUNTIMES:
+            return (
+                jsonify(
+                    {
+                        "error": "unknown runtime",
+                        "which": "runtime",
+                        "runtime": runtime_in,
+                    }
+                ),
+                404,
+            )
+        target = _ent._next_purchasable_tier_after(tier_in)
+        row = _ent.next_tier_runtime_spec_at(tier_in, rt)
+        return jsonify(
+            {
+                "tier": tier_in,
+                "tier_label": _ent.tier_label(tier_in),
+                "tier_rank": _ent.tier_rank(tier_in),
+                "runtime": rt,
+                "target": target,
+                "target_label": _ent.tier_label(target) if target else None,
+                "target_rank": _ent.tier_rank(target) if target else None,
+                "row": row,
+            }
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_next_tier_runtime_spec_at: error: %s", exc
+        )
+        return jsonify(
+            {
+                "tier": tier_in,
+                "tier_label": None,
+                "tier_rank": -1,
+                "runtime": runtime_in,
+                "target": None,
+                "target_label": None,
+                "target_rank": None,
+                "row": None,
+            }
+        )
+
+
+@bp_entitlement.route("/api/entitlement/previous-tier-runtime-spec-at")
+def api_entitlement_previous_tier_runtime_spec_at():
+    """``GET /api/entitlement/previous-tier-runtime-spec-at?tier=<source>&runtime=<id>``
+    -- scalar what-if sibling of
+    ``/api/entitlement/previous-tier-spec-at`` projected onto a SINGLE
+    runtime: the :func:`clawmetry.entitlements.runtime_spec_at`-shape
+    catalogue row for ``runtime`` evaluated on the rung below the
+    caller-supplied ``tier``.
+
+    Source-anchored mirror of ``/next-tier-runtime-spec-at`` and
+    downgrade-confirmation counterpart on the runtime axis. Accepts
+    aliases (``claude-code`` -> ``claude_code``) via
+    :func:`entitlements.canonical_runtime`.
+
+    Response shape matches ``/next-tier-runtime-spec-at`` byte-for-byte
+    (``tier``, ``tier_label``, ``tier_rank``, ``runtime``, ``target``,
+    ``target_label``, ``target_rank``, ``row``). Inner ``row`` matches
+    ``/runtime-spec-at?tier=<target>&runtime=<runtime>`` byte-for-byte
+    when ``target`` is populated.
+
+    Accepts any tier id in :data:`entitlements._TIER_ORDER` (including
+    ``trial``). ``target`` / ``row`` collapse to ``null`` at the floor.
+
+    - **400** when ``tier=`` or ``runtime=`` is missing / blank
+    - **404** when ``tier`` is unknown or ``runtime`` is unknown.
+    - **Never 5xxs**: builder failure short-circuits to ``row=null`` on
+      the same 200 envelope.
+    """
+    raw_tier = request.args.get("tier")
+    tier_in = (raw_tier or "").strip().lower()
+    if not tier_in:
+        return jsonify({"error": "missing tier"}), 400
+    raw_runtime = request.args.get("runtime")
+    runtime_in = (raw_runtime or "").strip().lower()
+    if not runtime_in:
+        return jsonify({"error": "missing runtime"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        if tier_in not in _ent._TIER_ORDER:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "tier", "tier": tier_in}
+                ),
+                404,
+            )
+        rt = _ent.canonical_runtime(runtime_in)
+        if not rt or rt not in _ent.ALL_RUNTIMES:
+            return (
+                jsonify(
+                    {
+                        "error": "unknown runtime",
+                        "which": "runtime",
+                        "runtime": runtime_in,
+                    }
+                ),
+                404,
+            )
+        target = _ent._previous_purchasable_tier_before(tier_in)
+        row = _ent.previous_tier_runtime_spec_at(tier_in, rt)
+        return jsonify(
+            {
+                "tier": tier_in,
+                "tier_label": _ent.tier_label(tier_in),
+                "tier_rank": _ent.tier_rank(tier_in),
+                "runtime": rt,
+                "target": target,
+                "target_label": _ent.tier_label(target) if target else None,
+                "target_rank": _ent.tier_rank(target) if target else None,
+                "row": row,
+            }
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_previous_tier_runtime_spec_at: error: %s", exc
+        )
+        return jsonify(
+            {
+                "tier": tier_in,
+                "tier_label": None,
+                "tier_rank": -1,
+                "runtime": runtime_in,
+                "target": None,
+                "target_label": None,
+                "target_rank": None,
+                "row": None,
+            }
+        )

--- a/tests/test_entitlement_next_prev_tier_feature_runtime_spec_at.py
+++ b/tests/test_entitlement_next_prev_tier_feature_runtime_spec_at.py
@@ -1,0 +1,617 @@
+"""Tests for the four directional scalar what-if helpers projecting
+:func:`clawmetry.entitlements.next_tier_spec_at` /
+:func:`previous_tier_spec_at` onto a single feature or runtime, and the
+four companion ``/api/entitlement/{next,previous}-tier-{feature,runtime}-spec-at``
+endpoints.
+
+These helpers fill the per-axis directional gap between:
+
+* :func:`feature_spec_at` / :func:`runtime_spec_at` -- scalar what-if of
+  ONE feature/runtime at a caller-supplied target tier
+* :func:`next_tier_spec_at` / :func:`previous_tier_spec_at` -- full
+  tier-row descriptor of the rung above/below a caller-supplied source
+
+The new helpers compose those: ``feature_spec_at`` /
+``runtime_spec_at`` evaluated at the rung above/below the source. Lets a
+paywall "does THIS feature/runtime unlock at my next rung?" tooltip
+hydrate off ONE round-trip without re-walking the catalogue or asking
+the resolver.
+
+Pins covered here:
+
+* per-rung byte-equality with :func:`feature_spec_at` /
+  :func:`runtime_spec_at` at the resolved next/previous purchasable
+  target (parity)
+* ``next``/``previous`` align with :func:`_next_purchasable_tier_after`
+  / :func:`_previous_purchasable_tier_before` so the helpers cannot
+  drift from the rung-walker shared with the other ``next_*_at`` family
+* ceiling (enterprise as source) / floor (oss / cloud_free as source)
+  returns ``None`` from the helper, and the API surfaces 200 with
+  ``row=null`` + ``target=null`` so the surface keeps rendering
+* trial-as-source resolves the same way the sibling ``_at`` families
+  do: next -> enterprise, previous -> cloud_starter
+* unknown / empty / whitespace / case-insensitive id handling
+* runtime alias resolution (``claude-code`` -> ``claude_code``) on
+  helper and API
+* grace vs enforce yields the same body (catalogue-derived, not gated)
+* the helpers never raise -- a builder failure short-circuits to
+  ``None`` so the CTA surface keeps rendering rather than 500-ing
+* the four API endpoints never 5xx: 400 on missing input, 404 on
+  unknown ids, 200 with ``row=null`` at the ceiling / floor; an
+  internal failure yields the same 200 envelope shape
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+_AT_ENVELOPE_FEATURE_KEYS = {
+    "tier",
+    "tier_label",
+    "tier_rank",
+    "feature",
+    "target",
+    "target_label",
+    "target_rank",
+    "row",
+}
+
+_AT_ENVELOPE_RUNTIME_KEYS = {
+    "tier",
+    "tier_label",
+    "tier_rank",
+    "runtime",
+    "target",
+    "target_label",
+    "target_rank",
+    "row",
+}
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# ── next_tier_feature_spec_at ────────────────────────────────────────────────
+
+
+def test_next_tier_feature_spec_at_byte_equals_feature_spec_at(ent):
+    # Helper is convenience for feature_spec_at(_next_purchasable_tier_after(tier), feature).
+    # The two must be byte-equal across every purchasable source for every
+    # feature -- pinning so the projection cannot drift from the full-row
+    # sibling.
+    for src in ent._PURCHASABLE_TIERS:
+        target = ent._next_purchasable_tier_after(src)
+        if target is None:
+            continue
+        for feature in sorted(ent.ALL_FEATURES):
+            assert ent.next_tier_feature_spec_at(src, feature) == ent.feature_spec_at(
+                target, feature
+            )
+
+
+def test_next_tier_feature_spec_at_returns_none_at_ceiling(ent):
+    # Enterprise sits at the top of the purchasable ladder -- no rung above,
+    # so the helper returns None for every feature.
+    assert ent._next_purchasable_tier_after(ent.TIER_ENTERPRISE) is None
+    for feature in sorted(ent.ALL_FEATURES):
+        assert ent.next_tier_feature_spec_at(ent.TIER_ENTERPRISE, feature) is None
+
+
+def test_next_tier_feature_spec_at_trial_resolves_to_enterprise(ent):
+    # Trial sits at rank 2 alongside cloud_pro / self-hosted pro -- the next
+    # strictly-higher purchasable rung is enterprise (rank 3). Pinning so the
+    # lenient _at posture matches the sibling ``next_*_at`` helpers.
+    assert ent._next_purchasable_tier_after(ent.TIER_TRIAL) == ent.TIER_ENTERPRISE
+    body = ent.next_tier_feature_spec_at(ent.TIER_TRIAL, "custom_alerts")
+    assert body is not None
+    assert body == ent.feature_spec_at(ent.TIER_ENTERPRISE, "custom_alerts")
+
+
+def test_next_tier_feature_spec_at_unknown_inputs_return_none(ent):
+    # The helper must not raise on garbage input -- empty/None/case/whitespace
+    # mismatch must all short-circuit to None.
+    assert ent.next_tier_feature_spec_at("", "custom_alerts") is None
+    assert ent.next_tier_feature_spec_at(None, "custom_alerts") is None
+    assert ent.next_tier_feature_spec_at("bogus_tier", "custom_alerts") is None
+    assert ent.next_tier_feature_spec_at(ent.TIER_CLOUD_STARTER, "") is None
+    assert ent.next_tier_feature_spec_at(ent.TIER_CLOUD_STARTER, None) is None
+    assert ent.next_tier_feature_spec_at(ent.TIER_CLOUD_STARTER, "no_such_feature") is None
+
+
+def test_next_tier_feature_spec_at_whitespace_and_case_insensitive(ent):
+    # Whitespace + case normalisation must match the sibling _at helpers --
+    # caller-supplied input is normalised before lookup.
+    canon = ent.next_tier_feature_spec_at(ent.TIER_CLOUD_STARTER, "custom_alerts")
+    assert canon is not None
+    assert (
+        ent.next_tier_feature_spec_at(" CLOUD_STARTER ", " CUSTOM_ALERTS ") == canon
+    )
+
+
+def test_next_tier_feature_spec_at_grace_and_enforce_match(ent, monkeypatch):
+    # The row is catalogue-derived (off the static per-tier maps), so flipping
+    # enforce on must not change the body.
+    grace_body = ent.next_tier_feature_spec_at(
+        ent.TIER_CLOUD_STARTER, "custom_alerts"
+    )
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    importlib.reload(ent)
+    ent.invalidate()
+    enforce_body = ent.next_tier_feature_spec_at(
+        ent.TIER_CLOUD_STARTER, "custom_alerts"
+    )
+    assert enforce_body == grace_body
+
+
+def test_next_tier_feature_spec_at_never_raises_on_builder_failure(
+    ent, monkeypatch
+):
+    # A synthesised failure in the underlying feature_spec_at must short-
+    # circuit to None so the CTA surface stays mute rather than 500-ing.
+    monkeypatch.setattr(
+        ent,
+        "feature_spec_at",
+        lambda *a, **k: (_ for _ in ()).throw(RuntimeError("synthetic")),
+    )
+    assert (
+        ent.next_tier_feature_spec_at(ent.TIER_CLOUD_STARTER, "custom_alerts")
+        is None
+    )
+
+
+# ── previous_tier_feature_spec_at ────────────────────────────────────────────
+
+
+def test_previous_tier_feature_spec_at_byte_equals_feature_spec_at(ent):
+    for src in ent._PURCHASABLE_TIERS:
+        target = ent._previous_purchasable_tier_before(src)
+        if target is None:
+            continue
+        for feature in sorted(ent.ALL_FEATURES):
+            assert ent.previous_tier_feature_spec_at(
+                src, feature
+            ) == ent.feature_spec_at(target, feature)
+
+
+def test_previous_tier_feature_spec_at_returns_none_at_floor(ent):
+    # OSS and cloud_free both sit at rank 0 -- no rung below to step down to,
+    # so the helper returns None for every feature on either source.
+    for src in (ent.TIER_OSS, ent.TIER_CLOUD_FREE):
+        assert ent._previous_purchasable_tier_before(src) is None
+        for feature in sorted(ent.ALL_FEATURES):
+            assert ent.previous_tier_feature_spec_at(src, feature) is None
+
+
+def test_previous_tier_feature_spec_at_trial_resolves_to_starter(ent):
+    # Trial steps down to rank 1 (starter).
+    assert ent._previous_purchasable_tier_before(ent.TIER_TRIAL) == ent.TIER_CLOUD_STARTER
+    body = ent.previous_tier_feature_spec_at(ent.TIER_TRIAL, "custom_alerts")
+    assert body is not None
+    assert body == ent.feature_spec_at(ent.TIER_CLOUD_STARTER, "custom_alerts")
+
+
+def test_previous_tier_feature_spec_at_unknown_inputs_return_none(ent):
+    assert ent.previous_tier_feature_spec_at("", "custom_alerts") is None
+    assert ent.previous_tier_feature_spec_at(None, "custom_alerts") is None
+    assert ent.previous_tier_feature_spec_at("bogus", "custom_alerts") is None
+    assert ent.previous_tier_feature_spec_at(ent.TIER_CLOUD_PRO, "") is None
+    assert ent.previous_tier_feature_spec_at(ent.TIER_CLOUD_PRO, None) is None
+    assert ent.previous_tier_feature_spec_at(ent.TIER_CLOUD_PRO, "no_such") is None
+
+
+def test_previous_tier_feature_spec_at_never_raises_on_builder_failure(
+    ent, monkeypatch
+):
+    monkeypatch.setattr(
+        ent,
+        "feature_spec_at",
+        lambda *a, **k: (_ for _ in ()).throw(RuntimeError("synthetic")),
+    )
+    assert (
+        ent.previous_tier_feature_spec_at(ent.TIER_CLOUD_PRO, "custom_alerts")
+        is None
+    )
+
+
+# ── next_tier_runtime_spec_at ────────────────────────────────────────────────
+
+
+def test_next_tier_runtime_spec_at_byte_equals_runtime_spec_at(ent):
+    for src in ent._PURCHASABLE_TIERS:
+        target = ent._next_purchasable_tier_after(src)
+        if target is None:
+            continue
+        for runtime in sorted(ent.ALL_RUNTIMES):
+            assert ent.next_tier_runtime_spec_at(
+                src, runtime
+            ) == ent.runtime_spec_at(target, runtime)
+
+
+def test_next_tier_runtime_spec_at_returns_none_at_ceiling(ent):
+    for runtime in sorted(ent.ALL_RUNTIMES):
+        assert ent.next_tier_runtime_spec_at(ent.TIER_ENTERPRISE, runtime) is None
+
+
+def test_next_tier_runtime_spec_at_alias_resolution(ent):
+    # ``claude-code`` aliases to ``claude_code`` -- the helper must
+    # canonicalise so both spellings yield byte-equal output, matching the
+    # sibling /runtime-spec-at posture.
+    canon = ent.next_tier_runtime_spec_at(ent.TIER_CLOUD_STARTER, "claude_code")
+    assert canon is not None
+    assert (
+        ent.next_tier_runtime_spec_at(ent.TIER_CLOUD_STARTER, "claude-code")
+        == canon
+    )
+    assert (
+        ent.next_tier_runtime_spec_at(ent.TIER_CLOUD_STARTER, " CLAUDE-CODE ")
+        == canon
+    )
+
+
+def test_next_tier_runtime_spec_at_unknown_inputs_return_none(ent):
+    assert ent.next_tier_runtime_spec_at("", "claude_code") is None
+    assert ent.next_tier_runtime_spec_at(None, "claude_code") is None
+    assert ent.next_tier_runtime_spec_at("bogus", "claude_code") is None
+    assert ent.next_tier_runtime_spec_at(ent.TIER_CLOUD_STARTER, "") is None
+    assert ent.next_tier_runtime_spec_at(ent.TIER_CLOUD_STARTER, None) is None
+    assert ent.next_tier_runtime_spec_at(ent.TIER_CLOUD_STARTER, "no_such") is None
+
+
+def test_next_tier_runtime_spec_at_grace_and_enforce_match(ent, monkeypatch):
+    grace_body = ent.next_tier_runtime_spec_at(
+        ent.TIER_CLOUD_STARTER, "claude_code"
+    )
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    importlib.reload(ent)
+    ent.invalidate()
+    enforce_body = ent.next_tier_runtime_spec_at(
+        ent.TIER_CLOUD_STARTER, "claude_code"
+    )
+    assert enforce_body == grace_body
+
+
+def test_next_tier_runtime_spec_at_never_raises_on_builder_failure(
+    ent, monkeypatch
+):
+    monkeypatch.setattr(
+        ent,
+        "runtime_spec_at",
+        lambda *a, **k: (_ for _ in ()).throw(RuntimeError("synthetic")),
+    )
+    assert (
+        ent.next_tier_runtime_spec_at(ent.TIER_CLOUD_STARTER, "claude_code")
+        is None
+    )
+
+
+# ── previous_tier_runtime_spec_at ────────────────────────────────────────────
+
+
+def test_previous_tier_runtime_spec_at_byte_equals_runtime_spec_at(ent):
+    for src in ent._PURCHASABLE_TIERS:
+        target = ent._previous_purchasable_tier_before(src)
+        if target is None:
+            continue
+        for runtime in sorted(ent.ALL_RUNTIMES):
+            assert ent.previous_tier_runtime_spec_at(
+                src, runtime
+            ) == ent.runtime_spec_at(target, runtime)
+
+
+def test_previous_tier_runtime_spec_at_returns_none_at_floor(ent):
+    for src in (ent.TIER_OSS, ent.TIER_CLOUD_FREE):
+        for runtime in sorted(ent.ALL_RUNTIMES):
+            assert ent.previous_tier_runtime_spec_at(src, runtime) is None
+
+
+def test_previous_tier_runtime_spec_at_alias_resolution(ent):
+    canon = ent.previous_tier_runtime_spec_at(ent.TIER_CLOUD_PRO, "claude_code")
+    assert canon is not None
+    assert (
+        ent.previous_tier_runtime_spec_at(ent.TIER_CLOUD_PRO, "claude-code") == canon
+    )
+
+
+def test_previous_tier_runtime_spec_at_never_raises_on_builder_failure(
+    ent, monkeypatch
+):
+    monkeypatch.setattr(
+        ent,
+        "runtime_spec_at",
+        lambda *a, **k: (_ for _ in ()).throw(RuntimeError("synthetic")),
+    )
+    assert (
+        ent.previous_tier_runtime_spec_at(ent.TIER_CLOUD_PRO, "claude_code")
+        is None
+    )
+
+
+# ── /api/entitlement/next-tier-feature-spec-at ───────────────────────────────
+
+
+def test_api_next_tier_feature_spec_at_happy_path(client, ent):
+    resp = client.get(
+        "/api/entitlement/next-tier-feature-spec-at?tier=cloud_starter&feature=custom_alerts"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert set(body.keys()) == _AT_ENVELOPE_FEATURE_KEYS
+    assert body["tier"] == ent.TIER_CLOUD_STARTER
+    assert body["feature"] == "custom_alerts"
+    assert body["target"] == ent.TIER_CLOUD_PRO
+    assert body["target_rank"] == ent.tier_rank(ent.TIER_CLOUD_PRO)
+    assert body["row"] == ent.feature_spec_at(ent.TIER_CLOUD_PRO, "custom_alerts")
+
+
+def test_api_next_tier_feature_spec_at_at_ceiling_returns_200_with_null_row(
+    client, ent
+):
+    resp = client.get(
+        "/api/entitlement/next-tier-feature-spec-at?tier=enterprise&feature=custom_alerts"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["tier"] == ent.TIER_ENTERPRISE
+    assert body["target"] is None
+    assert body["target_label"] is None
+    assert body["target_rank"] is None
+    assert body["row"] is None
+
+
+def test_api_next_tier_feature_spec_at_400_missing_tier(client):
+    resp = client.get(
+        "/api/entitlement/next-tier-feature-spec-at?feature=custom_alerts"
+    )
+    assert resp.status_code == 400
+
+
+def test_api_next_tier_feature_spec_at_400_missing_feature(client):
+    resp = client.get(
+        "/api/entitlement/next-tier-feature-spec-at?tier=cloud_starter"
+    )
+    assert resp.status_code == 400
+
+
+def test_api_next_tier_feature_spec_at_404_unknown_tier(client):
+    resp = client.get(
+        "/api/entitlement/next-tier-feature-spec-at?tier=bogus&feature=custom_alerts"
+    )
+    assert resp.status_code == 404
+    body = resp.get_json()
+    assert body.get("which") == "tier"
+
+
+def test_api_next_tier_feature_spec_at_404_unknown_feature(client):
+    resp = client.get(
+        "/api/entitlement/next-tier-feature-spec-at?tier=cloud_starter&feature=no_such"
+    )
+    assert resp.status_code == 404
+    body = resp.get_json()
+    assert body.get("which") == "feature"
+
+
+def test_api_next_tier_feature_spec_at_trial_endpoint(client, ent):
+    resp = client.get(
+        "/api/entitlement/next-tier-feature-spec-at?tier=trial&feature=custom_alerts"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["target"] == ent.TIER_ENTERPRISE
+    assert body["row"] == ent.feature_spec_at(ent.TIER_ENTERPRISE, "custom_alerts")
+
+
+# ── /api/entitlement/previous-tier-feature-spec-at ───────────────────────────
+
+
+def test_api_previous_tier_feature_spec_at_happy_path(client, ent):
+    resp = client.get(
+        "/api/entitlement/previous-tier-feature-spec-at?tier=cloud_pro&feature=custom_alerts"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert set(body.keys()) == _AT_ENVELOPE_FEATURE_KEYS
+    assert body["tier"] == ent.TIER_CLOUD_PRO
+    assert body["feature"] == "custom_alerts"
+    assert body["target"] == ent.TIER_CLOUD_STARTER
+    assert body["row"] == ent.feature_spec_at(
+        ent.TIER_CLOUD_STARTER, "custom_alerts"
+    )
+
+
+def test_api_previous_tier_feature_spec_at_at_floor_returns_200_with_null_row(
+    client, ent
+):
+    for src in (ent.TIER_OSS, ent.TIER_CLOUD_FREE):
+        resp = client.get(
+            f"/api/entitlement/previous-tier-feature-spec-at?tier={src}&feature=custom_alerts"
+        )
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body["tier"] == src
+        assert body["target"] is None
+        assert body["row"] is None
+
+
+def test_api_previous_tier_feature_spec_at_400s_and_404s(client):
+    assert (
+        client.get(
+            "/api/entitlement/previous-tier-feature-spec-at?feature=custom_alerts"
+        ).status_code
+        == 400
+    )
+    assert (
+        client.get(
+            "/api/entitlement/previous-tier-feature-spec-at?tier=cloud_pro"
+        ).status_code
+        == 400
+    )
+    assert (
+        client.get(
+            "/api/entitlement/previous-tier-feature-spec-at?tier=bogus&feature=custom_alerts"
+        ).status_code
+        == 404
+    )
+    assert (
+        client.get(
+            "/api/entitlement/previous-tier-feature-spec-at?tier=cloud_pro&feature=no_such"
+        ).status_code
+        == 404
+    )
+
+
+# ── /api/entitlement/next-tier-runtime-spec-at ───────────────────────────────
+
+
+def test_api_next_tier_runtime_spec_at_happy_path(client, ent):
+    resp = client.get(
+        "/api/entitlement/next-tier-runtime-spec-at?tier=cloud_starter&runtime=claude_code"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert set(body.keys()) == _AT_ENVELOPE_RUNTIME_KEYS
+    assert body["tier"] == ent.TIER_CLOUD_STARTER
+    assert body["runtime"] == "claude_code"
+    assert body["target"] == ent.TIER_CLOUD_PRO
+    assert body["row"] == ent.runtime_spec_at(ent.TIER_CLOUD_PRO, "claude_code")
+
+
+def test_api_next_tier_runtime_spec_at_alias_normalises(client, ent):
+    # The route accepts ``claude-code`` and echoes the canonical id in the
+    # envelope so a UI consuming the response sees the same id regardless of
+    # the spelling sent in.
+    resp = client.get(
+        "/api/entitlement/next-tier-runtime-spec-at?tier=cloud_starter&runtime=claude-code"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["runtime"] == "claude_code"
+    assert body["row"] == ent.runtime_spec_at(ent.TIER_CLOUD_PRO, "claude_code")
+
+
+def test_api_next_tier_runtime_spec_at_at_ceiling_returns_200_with_null_row(
+    client, ent
+):
+    resp = client.get(
+        "/api/entitlement/next-tier-runtime-spec-at?tier=enterprise&runtime=claude_code"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["tier"] == ent.TIER_ENTERPRISE
+    assert body["target"] is None
+    assert body["row"] is None
+
+
+def test_api_next_tier_runtime_spec_at_400s_and_404s(client):
+    assert (
+        client.get(
+            "/api/entitlement/next-tier-runtime-spec-at?runtime=claude_code"
+        ).status_code
+        == 400
+    )
+    assert (
+        client.get(
+            "/api/entitlement/next-tier-runtime-spec-at?tier=cloud_starter"
+        ).status_code
+        == 400
+    )
+    assert (
+        client.get(
+            "/api/entitlement/next-tier-runtime-spec-at?tier=bogus&runtime=claude_code"
+        ).status_code
+        == 404
+    )
+    assert (
+        client.get(
+            "/api/entitlement/next-tier-runtime-spec-at?tier=cloud_starter&runtime=no_such"
+        ).status_code
+        == 404
+    )
+
+
+# ── /api/entitlement/previous-tier-runtime-spec-at ───────────────────────────
+
+
+def test_api_previous_tier_runtime_spec_at_happy_path(client, ent):
+    resp = client.get(
+        "/api/entitlement/previous-tier-runtime-spec-at?tier=cloud_pro&runtime=claude_code"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert set(body.keys()) == _AT_ENVELOPE_RUNTIME_KEYS
+    assert body["tier"] == ent.TIER_CLOUD_PRO
+    assert body["runtime"] == "claude_code"
+    assert body["target"] == ent.TIER_CLOUD_STARTER
+    assert body["row"] == ent.runtime_spec_at(
+        ent.TIER_CLOUD_STARTER, "claude_code"
+    )
+
+
+def test_api_previous_tier_runtime_spec_at_at_floor_returns_200_with_null_row(
+    client, ent
+):
+    for src in (ent.TIER_OSS, ent.TIER_CLOUD_FREE):
+        resp = client.get(
+            f"/api/entitlement/previous-tier-runtime-spec-at?tier={src}&runtime=claude_code"
+        )
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body["tier"] == src
+        assert body["target"] is None
+        assert body["row"] is None
+
+
+def test_api_previous_tier_runtime_spec_at_alias_normalises(client, ent):
+    resp = client.get(
+        "/api/entitlement/previous-tier-runtime-spec-at?tier=cloud_pro&runtime=claude-code"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["runtime"] == "claude_code"
+
+
+def test_api_previous_tier_runtime_spec_at_400s_and_404s(client):
+    assert (
+        client.get(
+            "/api/entitlement/previous-tier-runtime-spec-at?runtime=claude_code"
+        ).status_code
+        == 400
+    )
+    assert (
+        client.get(
+            "/api/entitlement/previous-tier-runtime-spec-at?tier=cloud_pro"
+        ).status_code
+        == 400
+    )
+    assert (
+        client.get(
+            "/api/entitlement/previous-tier-runtime-spec-at?tier=bogus&runtime=claude_code"
+        ).status_code
+        == 404
+    )
+    assert (
+        client.get(
+            "/api/entitlement/previous-tier-runtime-spec-at?tier=cloud_pro&runtime=no_such"
+        ).status_code
+        == 404
+    )


### PR DESCRIPTION
## Summary

Adds the per-feature and per-runtime members of the directional scalar `_at` family — `next_tier_feature_spec_at(tier, feature)` + `previous_tier_feature_spec_at(tier, feature)` + `next_tier_runtime_spec_at(tier, runtime)` + `previous_tier_runtime_spec_at(tier, runtime)`, plus their four `GET /api/entitlement/{next,previous}-tier-{feature,runtime}-spec-at` endpoints.

These fill the per-axis directional gap between the two existing families:

- `feature_spec_at` / `runtime_spec_at` — scalar what-if of ONE feature/runtime at a caller-supplied target tier
- `next_tier_spec_at` / `previous_tier_spec_at` — full tier-row descriptor of the rung above/below a caller-supplied source

The new helpers compose those: `feature_spec_at` / `runtime_spec_at` evaluated at the rung above/below the source. Lets a paywall **"does THIS feature/runtime unlock at my next rung?"** tooltip hydrate off ONE round-trip without re-walking the catalogue or asking the resolver — the projection of the rung-direction lens (`next_tier_spec_at`) onto the per-axis lens (`feature_spec_at` / `runtime_spec_at`).

### Shape

Feature axis:

```
{
  "tier":         "<source tier id>",
  "tier_label":   "<source label>",
  "tier_rank":    <source rank>,
  "feature":      "<feature id>",
  "target":       "<next/previous tier id>" | null,
  "target_label": "<...>" | null,
  "target_rank":  <int> | null,
  "row":          {<feature_spec_at row>} | null
}
```

Runtime axis: identical with `feature` swapped for `runtime` (canonicalised via `canonical_runtime`).

Inner `row` matches `/feature-spec-at?tier=<target>&feature=<feature>` (or the runtime equivalent) byte-for-byte when `target` is populated — a parity test pins this so the projection cannot drift from the full-row sibling.

### Posture

- Resolver-independent: walks the static per-tier maps via `feature_spec_at` / `runtime_spec_at`, so grace vs enforce yields byte-identical rows.
- Runtime helpers + routes accept aliases (`claude-code` → `claude_code`) via `canonical_runtime`, matching the existing `/runtime-spec-at` posture and the new `_path` helpers in #3378.
- Lenient `_at` posture on `tier`: any id in `_TIER_ORDER` is accepted (including `trial` — resolves next → `enterprise`, previous → `cloud_starter` to match the sibling `_at` families).
- Never raises: helper logs a warning and returns `None` on builder failure; routes catch and return the 200 envelope with `row=null` so the paywall surface keeps rendering without a status-code branch.
- Ceiling (enterprise as source) / floor (oss / cloud_free as source) → helper returns `None`; route returns 200 with `target=null` + `row=null`.

### Tests

40 new unit + route tests covering:

- per-rung byte-equality with `feature_spec_at(_next_purchasable_tier_after(tier), feature)` and the three symmetries (parity)
- `next` / `previous` align with `_next_purchasable_tier_after` / `_previous_purchasable_tier_before` so the helpers cannot drift from the rung-walker shared with the other `next_*_at` family
- ceiling / floor / trial source resolution
- unknown / empty / whitespace / case-insensitive id handling
- runtime alias resolution (`claude-code` → `claude_code`) on helper and API
- grace vs enforce body equality (helper is catalogue-derived, not gated)
- never-raises on synthesised builder failure (helper → `None`, route → 200 envelope)
- API surface: 400 on missing args, 404 on unknown ids (with `which` discriminator), 200 envelope on happy path, alias echo returns canonical id, ceiling/floor row collapse to `null`

All 40 new tests pass; full local entitlement + license suite (2618 tests) green. `ruff` clean on every file in the diff.

### Scope

Pure feature-add — no helper signatures or existing route shapes change. Resolver semantics untouched. No frontend changes; this is an API-only addition for a future paywall surface. No version bump, no `[RELEASE]` PR. Disjoint from the open `_path`-family PR #3378 (different axis: directional scalar, not path-walking).

## Test plan

- [x] `python3 -m pytest tests/test_entitlement_next_prev_tier_feature_runtime_spec_at.py -q` — 40 passed
- [x] `python3 -m pytest tests/test_entitlement*.py tests/test_entitlements*.py tests/test_license*.py -q` — 2618 passed
- [x] `ruff check clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_next_prev_tier_feature_runtime_spec_at.py` — clean
- [ ] Local-operator verification on the running daemon (see checklist below)

---

### Local operator verification checklist

I cannot reach the running daemon, `~/.openclaw`, or the live cloud snapshot from this environment. Before flipping the PR ready-for-review and merging, please:

1. Pull `feat/entitlement-next-prev-tier-feature-runtime-spec-at` locally and copy the changed files into the installed site-packages location:
   ```sh
   cp clawmetry/entitlements.py ~/.clawmetry/lib/python*/site-packages/clawmetry/entitlements.py
   cp routes/entitlement.py     ~/.clawmetry/lib/python*/site-packages/routes/entitlement.py
   ```
2. Clear `__pycache__` under `~/.clawmetry/lib/python*/site-packages/{clawmetry,routes}/` so the new bytecode is picked up.
3. Restart the daemon: `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`.
4. Smoke the four new endpoints against your live install:
   ```sh
   # feature axis — happy path
   curl -s 'http://localhost:8900/api/entitlement/next-tier-feature-spec-at?tier=cloud_starter&feature=custom_alerts' \
     | jq '.tier, .target, .row.allowed'
   curl -s 'http://localhost:8900/api/entitlement/previous-tier-feature-spec-at?tier=cloud_pro&feature=custom_alerts' \
     | jq '.tier, .target, .row.allowed'

   # ceiling / floor — 200 with row=null
   curl -s 'http://localhost:8900/api/entitlement/next-tier-feature-spec-at?tier=enterprise&feature=custom_alerts' \
     | jq '.target, .row'         # null, null
   curl -s 'http://localhost:8900/api/entitlement/previous-tier-feature-spec-at?tier=oss&feature=custom_alerts' \
     | jq '.target, .row'         # null, null

   # runtime axis + alias
   curl -s 'http://localhost:8900/api/entitlement/next-tier-runtime-spec-at?tier=cloud_starter&runtime=claude-code' \
     | jq '.runtime, .target, .row.allowed'   # claude_code echoed canonical

   # error envelopes
   curl -s 'http://localhost:8900/api/entitlement/next-tier-feature-spec-at?tier=cloud_starter' \
     -o /dev/null -w '%{http_code}\n'    # expect 400
   curl -s 'http://localhost:8900/api/entitlement/next-tier-feature-spec-at?tier=bogus&feature=custom_alerts' \
     -o /dev/null -w '%{http_code}\n'    # expect 404
   curl -s 'http://localhost:8900/api/entitlement/next-tier-runtime-spec-at?tier=cloud_starter&runtime=no_such' \
     -o /dev/null -w '%{http_code}\n'    # expect 404
   ```
5. Confirm `/api/entitlement` and the existing `_at` endpoints (`/feature-spec-at`, `/runtime-spec-at`, `/next-tier-spec-at`, `/previous-tier-spec-at`) still return the same payloads they did pre-change.
6. Decrypt the live cloud snapshot in the browser and re-verify the entitlement panel renders unchanged (no UI consumes the new endpoints yet — this is a pure additive surface).

---

Generated with [Claude Code](https://claude.com/claude-code).

---
_Generated by [Claude Code](https://claude.ai/code/session_01CUdRCS2Nu6qmYkWmdzXzVt)_