### PR TITLE
feat(entitlement): lock_reason_path + /api/entitlement/lock-reason-path

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -6777,3 +6777,186 @@ def runtime_spec_path(
     except Exception as exc:
         logger.warning("entitlements: runtime_spec_path failed: %s", exc)
         return None
+
+
+def lock_reason_path(
+    from_tier: str, to_tier: str, item, *, kind: str | None = None
+) -> list[dict] | None:
+    """Arbitrary-endpoint stepwise lock-row path between two tiers.
+
+    Single-item path-walking sibling of :func:`lock_reason_at` and
+    lock-row analogue of :func:`feature_spec_path` / :func:`runtime_spec_path`.
+    Lets a paywall "how does THIS one lock-row evolve as I climb the
+    ladder" UI render every rung's ``locked`` / ``allowed`` / ``reason``
+    string off ONE round-trip without fetching the full
+    :func:`lock_reasons_at_batch` payload at every rung.
+
+    Walks the same ``_PURCHASABLE_TIERS`` rungs by the same sort key and
+    same destination-sibling exclusion as :func:`tier_path`,
+    :func:`tier_spec_path`, :func:`capacity_diff_path`,
+    :func:`tier_unlocks_path`, :func:`tier_locks_path`, :func:`preview_path`,
+    :func:`feature_spec_path` and :func:`runtime_spec_path` -- rung-for-rung
+    byte-stable against the rest of the ``_path`` family, so a UI that
+    walks one helper's rows can line them up index-for-index with another
+    helper's rows without re-deriving the rung sequence.
+
+    Per-rung row shape: each row is the :func:`_lock_row` body (``key``,
+    ``kind``, ``reason``, ``locked``, ``allowed``, ``required_tier``,
+    ``required_tier_label``, ``required_tier_rank``) augmented with three
+    rung-identification keys -- ``rung``, ``rung_label``, ``rung_rank`` --
+    naming the perspective tier the row was computed at. Dropping the
+    three ``rung*`` keys yields exact byte-equality with a synthesised
+    ``lock_reasons_at_batch`` axis row at the same rung -- a parity test
+    pins this so the path what-if and the batch what-if cannot drift.
+
+    ``kind`` follows :meth:`Entitlement.lock_reason`: ``"feature"`` /
+    ``"runtime"`` / ``"channels"`` / ``"retention_days"`` / ``"nodes"``
+    explicitly; ``None`` lets the helper infer ``runtime`` vs ``feature``
+    from the id (capacity axes can't be inferred, so pass ``kind=`` for
+    those). Runtime ids are canonicalised (``claude-code`` ->
+    ``claude_code``) so the URL surface matches the rest of the
+    entitlement API.
+
+    Direction semantics mirror :func:`feature_spec_path` /
+    :func:`tier_spec_path`:
+
+    * ``upgrade`` (ascending) -- rows climb rung by rung from the rung
+      above ``from_tier`` toward ``to_tier``; the natural "what does this
+      lock-row look like at each rung I'd climb through" walkthrough.
+    * ``downgrade`` (descending) -- rows shrink rung by rung; the
+      cancellation-walkthrough counterpart showing when the item becomes
+      locked again.
+    * ``lateral`` (same rank, different id) -- single-row path; row
+      carries the lock-row at ``to_tier``.
+    * ``identity`` (``from == to``) -- empty path; no rungs to walk.
+
+    Endpoint semantics match :func:`tier_path` / :func:`feature_spec_path`:
+    both tier ids accept any entry in :data:`_TIER_FEATURES` (including
+    :data:`TIER_TRIAL`, which is not purchasable -- excluded from the
+    walked intermediate rungs but a valid endpoint via the lateral
+    branch). Unknown ids on either side short-circuit to ``None``.
+    Unknown / empty / non-positive capacity counts short-circuit to
+    ``None`` rather than emitting an "always allowed" row -- matches the
+    400 posture the route surfaces for malformed capacity input.
+
+    Resolver-independent: synthesises a fresh :class:`Entitlement` per
+    rung with ``grace=False`` and the per-tier capacity caps off
+    :data:`_TIER_NODE_LIMIT`, mirroring :func:`lock_reason_at` /
+    :func:`lock_reasons_at_batch` -- so grace vs enforce yields
+    byte-identical rows.
+
+    Never raises: a synthesis failure logs a warning and short-circuits
+    to ``None`` so a paywall surface keeps rendering instead of breaking.
+    """
+    try:
+        f = (from_tier or "").strip().lower()
+        t = (to_tier or "").strip().lower()
+        if f not in _TIER_FEATURES or t not in _TIER_FEATURES:
+            return None
+
+        try:
+            raw_item = "" if item is None else str(item).strip()
+        except Exception:
+            return None
+        if not raw_item:
+            return None
+        item_lc = raw_item.lower()
+
+        resolved_kind = kind
+        if resolved_kind is None:
+            if item_lc in ALL_RUNTIMES:
+                resolved_kind = "runtime"
+            elif item_lc in ALL_FEATURES:
+                resolved_kind = "feature"
+            else:
+                return None
+        if resolved_kind == "runtime":
+            canon = canonical_runtime(item_lc)
+            if not canon or canon not in ALL_RUNTIMES:
+                return None
+            row_key: str = canon
+        elif resolved_kind == "feature":
+            if item_lc not in ALL_FEATURES:
+                return None
+            row_key = item_lc
+        elif resolved_kind in ("channels", "retention_days", "nodes"):
+            try:
+                n = int(raw_item)
+            except (TypeError, ValueError):
+                return None
+            if n <= 0:
+                return None
+            row_key = str(n)
+        else:
+            return None
+
+        if f == t:
+            return []
+
+        from_rank = _TIER_RANK.get(f, -1)
+        to_rank = _TIER_RANK.get(t, -1)
+
+        def _synth(rung: str):
+            paid_feats = _TIER_FEATURES.get(rung, frozenset())
+            rts = (
+                (FREE_RUNTIMES | PAID_RUNTIMES)
+                if rung in _TIER_PAID_RUNTIMES
+                else FREE_RUNTIMES
+            )
+            return Entitlement(
+                tier=rung,
+                source="hypothetical",
+                node_limit=_TIER_NODE_LIMIT.get(rung, _FREE_NODE_LIMIT),
+                expiry=None,
+                features=FREE_FEATURES | paid_feats,
+                runtimes=rts,
+                grace=False,
+            )
+
+        def _row(rung: str) -> dict:
+            try:
+                ent = _synth(rung)
+            except Exception as exc:
+                logger.warning(
+                    "entitlements: lock_reason_path synth failed for %s: %s",
+                    rung,
+                    exc,
+                )
+                ent = _oss_free()
+            body = _lock_row(ent, row_key, resolved_kind)
+            return {
+                "rung": rung,
+                "rung_label": tier_label(rung),
+                "rung_rank": _TIER_RANK.get(rung, -1),
+                **body,
+            }
+
+        if from_rank == to_rank:
+            return [_row(t)]
+        ascending = to_rank > from_rank
+        if ascending:
+            ordered = sorted(
+                _PURCHASABLE_TIERS,
+                key=lambda x: (_TIER_RANK.get(x, -1), x),
+            )
+        else:
+            ordered = sorted(
+                _PURCHASABLE_TIERS,
+                key=lambda x: (-_TIER_RANK.get(x, -1), x),
+            )
+        path: list[dict] = []
+        for tid in ordered:
+            r = _TIER_RANK.get(tid, -1)
+            if ascending:
+                if r <= from_rank or r > to_rank:
+                    continue
+            else:
+                if r >= from_rank or r < to_rank:
+                    continue
+            if r == to_rank and tid != t:
+                continue
+            path.append(_row(tid))
+        return path
+    except Exception as exc:
+        logger.warning("entitlements: lock_reason_path failed: %s", exc)
+        return None

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -6377,3 +6377,260 @@ def api_entitlement_runtime_spec_path():
             ),
             404,
         )
+
+
+@bp_entitlement.route("/api/entitlement/lock-reason-path")
+def api_entitlement_lock_reason_path():
+    """``GET /api/entitlement/lock-reason-path?from=<id>&to=<id>&<axis>=<id>``
+
+    Arbitrary-endpoint stepwise lock-row path between any two tiers; the
+    lock-row analogue of ``/feature-spec-path`` / ``/runtime-spec-path``
+    and the path-walking sibling of ``/lock-reason-at``. Lets a paywall
+    surface render every rung's ``locked`` / ``allowed`` / ``reason``
+    sentence for a SINGLE item off ONE round-trip without fetching the
+    full ``/lock-reasons-at-batch`` payload at every rung.
+
+    Exactly one of ``feature=`` / ``runtime=`` / ``channels=`` /
+    ``retention_days=`` / ``nodes=`` must be supplied -- the same axis
+    dispatcher as ``/lock-reason`` and ``/lock-reason-at``.
+
+    Rung walk is byte-stable against ``/tier-path``,
+    ``/capacity-diff-path``, ``/tier-unlocks-path``,
+    ``/tier-locks-path``, ``/preview-path``, ``/tier-spec-path``,
+    ``/feature-spec-path`` and ``/runtime-spec-path`` (same
+    ``_PURCHASABLE_TIERS`` filter + same sort + same destination-sibling
+    exclusion), so the nine paths line up rung-for-rung.
+
+    Each row in ``path`` is the same 8-key lock-row shape ``/lock-reason``
+    / ``/lock-reason-at`` / ``/lock-reasons-at-batch`` already emit
+    (``key``, ``kind``, ``reason``, ``locked``, ``allowed``,
+    ``required_tier``, ``required_tier_label``, ``required_tier_rank``)
+    augmented with three rung-identification keys -- ``rung``,
+    ``rung_label``, ``rung_rank`` -- naming the perspective tier the row
+    was computed at. Dropping the three ``rung*`` keys yields exact
+    byte-equality with the corresponding axis row of
+    ``/lock-reasons-at-batch?perspective_tier=<rung>``.
+
+    Response shape::
+
+        {
+          "from":       "<tier id>",
+          "from_label": "...",
+          "from_rank":  <int>,
+          "to":         "<tier id>",
+          "to_label":   "...",
+          "to_rank":    <int>,
+          "direction":  "upgrade" | "downgrade" | "lateral" | "identity",
+          "key":        "<echoed item id>",
+          "kind":       "feature" | "runtime" | "channels" |
+                        "retention_days" | "nodes",
+          "path":       [<rung-augmented lock-row>, ...],
+        }
+
+    Direction semantics mirror ``/feature-spec-path``:
+
+    * ``upgrade`` (ascending) -- rows climb rung by rung from the rung
+      above ``from`` toward ``to``.
+    * ``downgrade`` (descending) -- rows shrink rung by rung.
+    * ``lateral`` (same rank, different id) -- single-row path; row
+      carries the lock-row at ``to``.
+    * ``identity`` (``from == to``) -- empty path; no rungs to walk.
+
+    Runtime ids accept aliases (``claude-code`` -> ``claude_code``) via
+    :func:`clawmetry.entitlements.canonical_runtime` so the URL surface
+    matches ``/api/entitlement/required-tier``.
+
+    ``400`` when ``from=`` / ``to=`` is missing, when no axis is
+    supplied, or when more than one axis is supplied. ``404`` when any
+    tier id is unknown, when a feature/runtime id is unknown, or when a
+    capacity value is missing / non-int / non-positive (the helper
+    short-circuits to ``None``). ``trial`` IS accepted as an endpoint --
+    it is excluded from the walked intermediate rungs (not purchasable)
+    but is a valid endpoint via the lateral branch. Never 5xxs: a
+    resolver failure short-circuits to ``404`` so a paywall surface
+    keeps rendering instead of breaking.
+    """
+    f = (request.args.get("from") or "").strip().lower()
+    t = (request.args.get("to") or "").strip().lower()
+    if not f or not t:
+        return jsonify({"error": "missing from or to"}), 400
+
+    feature = (request.args.get("feature") or "").strip().lower()
+    runtime_in = (request.args.get("runtime") or "").strip().lower()
+    (
+        channels_present,
+        channels_ok,
+        channels_n,
+        channels_raw,
+    ) = _parse_capacity_arg("channels")
+    (
+        retention_present,
+        retention_ok,
+        retention_n,
+        retention_raw,
+    ) = _parse_capacity_arg("retention_days")
+    (
+        nodes_present,
+        nodes_ok,
+        nodes_n,
+        nodes_raw,
+    ) = _parse_capacity_arg("nodes")
+
+    supplied = [
+        bool(feature),
+        bool(runtime_in),
+        channels_present,
+        retention_present,
+        nodes_present,
+    ]
+    n_supplied = sum(1 for s in supplied if s)
+    if n_supplied == 0:
+        return (
+            jsonify(
+                {
+                    "error": (
+                        "supply exactly one of feature=<id>, runtime=<id>, "
+                        "channels=<int>, retention_days=<int>, or "
+                        "nodes=<int>"
+                    )
+                }
+            ),
+            400,
+        )
+    if n_supplied > 1:
+        return (
+            jsonify(
+                {
+                    "error": (
+                        "supply only one of feature=, runtime=, channels=, "
+                        "retention_days=, or nodes="
+                    )
+                }
+            ),
+            400,
+        )
+
+    try:
+        from clawmetry import entitlements as _ent
+
+        if feature:
+            item, kind, echoed_key = feature, "feature", feature
+        elif runtime_in:
+            canon = _ent.canonical_runtime(runtime_in)
+            item, kind, echoed_key = (
+                canon or runtime_in,
+                "runtime",
+                canon or runtime_in,
+            )
+        elif channels_present:
+            if not channels_ok:
+                return (
+                    jsonify(
+                        {
+                            "error": "unknown tier or item",
+                            "from": f,
+                            "to": t,
+                            "key": channels_raw,
+                            "kind": "channels",
+                        }
+                    ),
+                    404,
+                )
+            item, kind, echoed_key = str(channels_n), "channels", str(channels_n)
+        elif retention_present:
+            if not retention_ok:
+                return (
+                    jsonify(
+                        {
+                            "error": "unknown tier or item",
+                            "from": f,
+                            "to": t,
+                            "key": retention_raw,
+                            "kind": "retention_days",
+                        }
+                    ),
+                    404,
+                )
+            item, kind, echoed_key = (
+                str(retention_n),
+                "retention_days",
+                str(retention_n),
+            )
+        else:
+            if not nodes_ok:
+                return (
+                    jsonify(
+                        {
+                            "error": "unknown tier or item",
+                            "from": f,
+                            "to": t,
+                            "key": nodes_raw,
+                            "kind": "nodes",
+                        }
+                    ),
+                    404,
+                )
+            item, kind, echoed_key = str(nodes_n), "nodes", str(nodes_n)
+
+        path = _ent.lock_reason_path(f, t, item, kind=kind)
+        if path is None:
+            return (
+                jsonify(
+                    {
+                        "error": "unknown tier or item",
+                        "from": f,
+                        "to": t,
+                        "key": echoed_key,
+                        "kind": kind,
+                    }
+                ),
+                404,
+            )
+        from_rank = _ent.tier_rank(f)
+        to_rank = _ent.tier_rank(t)
+        if f == t:
+            direction = "identity"
+        elif from_rank == to_rank:
+            direction = "lateral"
+        elif to_rank > from_rank:
+            direction = "upgrade"
+        else:
+            direction = "downgrade"
+        return jsonify(
+            {
+                "from": f,
+                "from_label": _ent.tier_label(f),
+                "from_rank": from_rank,
+                "to": t,
+                "to_label": _ent.tier_label(t),
+                "to_rank": to_rank,
+                "direction": direction,
+                "key": echoed_key,
+                "kind": kind,
+                "path": path,
+            }
+        )
+    except Exception as exc:
+        logger.warning("api_entitlement_lock_reason_path: error: %s", exc)
+        if feature:
+            echoed_key, kind = feature, "feature"
+        elif runtime_in:
+            echoed_key, kind = runtime_in, "runtime"
+        elif channels_present:
+            echoed_key, kind = channels_raw, "channels"
+        elif retention_present:
+            echoed_key, kind = retention_raw, "retention_days"
+        else:
+            echoed_key, kind = nodes_raw, "nodes"
+        return (
+            jsonify(
+                {
+                    "error": "unknown tier or item",
+                    "from": f,
+                    "to": t,
+                    "key": echoed_key,
+                    "kind": kind,
+                }
+            ),
+            404,
+        )

--- a/tests/test_entitlement_lock_reason_path.py
+++ b/tests/test_entitlement_lock_reason_path.py
@@ -1,0 +1,706 @@
+"""Tests for ``clawmetry.entitlements.lock_reason_path(from, to, item, kind)``
++ the ``GET /api/entitlement/lock-reason-path`` endpoint.
+
+Single-item path-walking sibling of :func:`lock_reason_at` and lock-row
+analogue of :func:`feature_spec_path` / :func:`runtime_spec_path`. Lets a
+paywall "how does THIS one lock-row evolve as I climb the ladder" UI
+render every rung's ``locked`` / ``allowed`` / ``reason`` sentence off
+ONE round-trip without fetching the full
+:func:`lock_reasons_at_batch` payload at every rung.
+
+Pins:
+
+* rung walk byte-stable against :func:`tier_path`,
+  :func:`tier_spec_path`, :func:`capacity_diff_path`,
+  :func:`tier_unlocks_path`, :func:`tier_locks_path`,
+  :func:`preview_path`, :func:`feature_spec_path` and
+  :func:`runtime_spec_path` (same ``_PURCHASABLE_TIERS`` filter + same
+  sort + same destination-sibling exclusion)
+* per-rung row carries the 8-key ``_lock_row`` body PLUS the three
+  rung-identification keys (``rung``, ``rung_label``, ``rung_rank``);
+  dropping the three ``rung*`` keys yields exact byte-equality with the
+  matching axis row of :func:`lock_reasons_at_batch` for the same rung
+* paid-feature unlock boundary visible: ``allowed`` flips from
+  ``False`` to ``True`` at the rung where the feature's min tier is
+  reached; ``reason`` flips from a sentence to ``None``
+* free feature surfaces ``allowed=True`` / ``reason=None`` at every
+  rung
+* enterprise-only feature stays ``allowed=False`` until the enterprise
+  rung
+* runtime alias normalisation (``claude-code`` -> ``claude_code``)
+* capacity axes (``channels`` / ``retention_days`` / ``nodes``)
+  resolve against the per-tier caps so e.g. 100 nodes at Enterprise is
+  unlocked, not locked
+* identity returns ``[]``; lateral returns a single-row path; trial
+  accepted as endpoint
+* unknown / empty / garbage tier / item ids return ``None`` and never
+  raise; non-positive / non-int capacity values return ``None``
+* grace vs enforce yields identical rows (helper synthesises a fresh
+  ``Entitlement`` per rung with ``grace=False`` regardless of the live
+  resolver state)
+* API surface: 400 on missing args / no axis / multi-axis; 404 on
+  unknown ids; 200 envelope on happy path; alias echo returns canonical
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+_ENVELOPE_KEYS = {
+    "from",
+    "from_label",
+    "from_rank",
+    "to",
+    "to_label",
+    "to_rank",
+    "direction",
+    "key",
+    "kind",
+    "path",
+}
+
+_RUNG_KEYS = {"rung", "rung_label", "rung_rank"}
+
+_ROW_KEYS = {
+    "key",
+    "kind",
+    "reason",
+    "locked",
+    "allowed",
+    "required_tier",
+    "required_tier_label",
+    "required_tier_rank",
+}
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# ── helper: shape + invariants ───────────────────────────────────────────────
+
+
+def test_returns_list(ent):
+    path = ent.lock_reason_path(
+        ent.TIER_OSS, ent.TIER_ENTERPRISE, "custom_alerts", kind="feature"
+    )
+    assert isinstance(path, list)
+    assert len(path) >= 1
+
+
+def test_each_row_carries_rung_and_lock_keys(ent):
+    path = ent.lock_reason_path(
+        ent.TIER_OSS, ent.TIER_ENTERPRISE, "custom_alerts", kind="feature"
+    )
+    for row in path:
+        assert set(row).issuperset(_RUNG_KEYS)
+        assert set(row).issuperset(_ROW_KEYS)
+        assert row["rung_label"] == ent.tier_label(row["rung"])
+        assert row["rung_rank"] == ent.tier_rank(row["rung"])
+
+
+def test_per_rung_byte_equality_with_lock_reasons_at_batch(ent):
+    """Dropping the three ``rung*`` keys from a path row yields exact
+    byte-equality with the matching axis row of
+    :func:`lock_reasons_at_batch` for the same perspective tier."""
+    path = ent.lock_reason_path(
+        ent.TIER_OSS, ent.TIER_ENTERPRISE, "custom_alerts", kind="feature"
+    )
+    for row in path:
+        body = {k: v for k, v in row.items() if k not in _RUNG_KEYS}
+        batch = ent.lock_reasons_at_batch(row["rung"], features=["custom_alerts"])
+        assert batch is not None
+        assert batch["features"] == [body]
+
+
+def test_runtime_axis_byte_equality_with_lock_reasons_at_batch(ent):
+    path = ent.lock_reason_path(
+        ent.TIER_OSS, ent.TIER_ENTERPRISE, "claude_code", kind="runtime"
+    )
+    for row in path:
+        body = {k: v for k, v in row.items() if k not in _RUNG_KEYS}
+        batch = ent.lock_reasons_at_batch(row["rung"], runtimes=["claude_code"])
+        assert batch is not None
+        assert batch["runtimes"] == [body]
+
+
+def test_static_lock_keys_constant_across_rungs_for_paid_feature(ent):
+    """The ``key`` / ``kind`` / ``required_tier`` keys describe the item
+    itself, not the perspective -- they must NOT vary rung by rung."""
+    path = ent.lock_reason_path(
+        ent.TIER_OSS, ent.TIER_ENTERPRISE, "custom_alerts", kind="feature"
+    )
+    static = {"key", "kind", "required_tier", "required_tier_label", "required_tier_rank"}
+    first = {k: path[0][k] for k in static}
+    for row in path[1:]:
+        assert {k: row[k] for k in static} == first
+
+
+def test_first_row_is_first_step_above_from(ent):
+    path = ent.lock_reason_path(
+        ent.TIER_OSS, ent.TIER_ENTERPRISE, "custom_alerts", kind="feature"
+    )
+    assert path[0]["rung"] == ent.TIER_CLOUD_STARTER
+
+
+def test_last_row_is_destination(ent):
+    path = ent.lock_reason_path(
+        ent.TIER_OSS, ent.TIER_ENTERPRISE, "custom_alerts", kind="feature"
+    )
+    assert path[-1]["rung"] == ent.TIER_ENTERPRISE
+
+
+def test_rung_walk_byte_stable_against_feature_spec_path(ent):
+    """Rung ids must match :func:`feature_spec_path`'s rung ids
+    byte-for-byte -- same ``_PURCHASABLE_TIERS`` filter + same sort +
+    same destination-sibling exclusion."""
+    for f, t in (
+        (ent.TIER_OSS, ent.TIER_ENTERPRISE),
+        (ent.TIER_CLOUD_FREE, ent.TIER_PRO),
+        (ent.TIER_OSS, ent.TIER_CLOUD_PRO),
+        (ent.TIER_ENTERPRISE, ent.TIER_OSS),
+        (ent.TIER_PRO, ent.TIER_CLOUD_FREE),
+        (ent.TIER_TRIAL, ent.TIER_ENTERPRISE),
+    ):
+        lock_rungs = [
+            r["rung"]
+            for r in ent.lock_reason_path(f, t, "custom_alerts", kind="feature")
+        ]
+        feat_rungs = [
+            r["rung"] for r in ent.feature_spec_path(f, t, "custom_alerts")
+        ]
+        assert lock_rungs == feat_rungs
+
+
+def test_rung_walk_byte_stable_against_tier_path(ent):
+    for f, t in (
+        (ent.TIER_OSS, ent.TIER_ENTERPRISE),
+        (ent.TIER_ENTERPRISE, ent.TIER_OSS),
+        (ent.TIER_TRIAL, ent.TIER_ENTERPRISE),
+    ):
+        lock_rungs = [
+            r["rung"]
+            for r in ent.lock_reason_path(f, t, "custom_alerts", kind="feature")
+        ]
+        diff_rungs = [r["to"] for r in ent.tier_path(f, t)]
+        assert lock_rungs == diff_rungs
+
+
+def test_rung_walk_invariant_across_items_and_axes(ent):
+    """The walked rung sequence is item- and axis-agnostic -- swapping
+    the feature / runtime / channels query must not move the rungs."""
+    a = [
+        r["rung"]
+        for r in ent.lock_reason_path(
+            ent.TIER_OSS, ent.TIER_ENTERPRISE, "custom_alerts", kind="feature"
+        )
+    ]
+    b = [
+        r["rung"]
+        for r in ent.lock_reason_path(
+            ent.TIER_OSS, ent.TIER_ENTERPRISE, "claude_code", kind="runtime"
+        )
+    ]
+    c = [
+        r["rung"]
+        for r in ent.lock_reason_path(
+            ent.TIER_OSS, ent.TIER_ENTERPRISE, "10", kind="channels"
+        )
+    ]
+    assert a == b == c
+
+
+# ── unlock boundary semantics ────────────────────────────────────────────────
+
+
+def test_paid_feature_unlock_boundary_visible(ent):
+    """``custom_alerts`` is a Pro-only feature -- ``allowed`` flips
+    from ``False`` to ``True`` exactly at the cloud_pro rung; ``reason``
+    flips from a sentence to ``None``."""
+    path = ent.lock_reason_path(
+        ent.TIER_OSS, ent.TIER_ENTERPRISE, "custom_alerts", kind="feature"
+    )
+    by_rung = {row["rung"]: row for row in path}
+    assert by_rung[ent.TIER_CLOUD_STARTER]["allowed"] is False
+    assert by_rung[ent.TIER_CLOUD_STARTER]["locked"] is True
+    assert isinstance(by_rung[ent.TIER_CLOUD_STARTER]["reason"], str)
+    for rung in (ent.TIER_CLOUD_PRO, ent.TIER_PRO, ent.TIER_ENTERPRISE):
+        assert by_rung[rung]["allowed"] is True
+        assert by_rung[rung]["locked"] is False
+        assert by_rung[rung]["reason"] is None
+
+
+def test_free_feature_allowed_at_every_rung(ent):
+    """``sessions`` is a free feature -- ``allowed`` is ``True`` and
+    ``reason`` is ``None`` at every walked rung."""
+    path = ent.lock_reason_path(
+        ent.TIER_OSS, ent.TIER_ENTERPRISE, "sessions", kind="feature"
+    )
+    for row in path:
+        assert row["allowed"] is True
+        assert row["locked"] is False
+        assert row["reason"] is None
+
+
+def test_enterprise_only_feature_locked_until_enterprise(ent):
+    path = ent.lock_reason_path(
+        ent.TIER_OSS, ent.TIER_ENTERPRISE, "siem_export", kind="feature"
+    )
+    by_rung = {row["rung"]: row for row in path}
+    for rung in (ent.TIER_CLOUD_STARTER, ent.TIER_CLOUD_PRO, ent.TIER_PRO):
+        assert by_rung[rung]["allowed"] is False
+        assert by_rung[rung]["locked"] is True
+    assert by_rung[ent.TIER_ENTERPRISE]["allowed"] is True
+    assert by_rung[ent.TIER_ENTERPRISE]["reason"] is None
+
+
+def test_free_runtime_allowed_at_every_rung(ent):
+    rt = next(iter(ent.FREE_RUNTIMES))
+    path = ent.lock_reason_path(
+        ent.TIER_OSS, ent.TIER_ENTERPRISE, rt, kind="runtime"
+    )
+    for row in path:
+        assert row["allowed"] is True
+        assert row["reason"] is None
+
+
+def test_paid_runtime_locked_below_starter(ent):
+    path = ent.lock_reason_path(
+        ent.TIER_OSS, ent.TIER_ENTERPRISE, "claude_code", kind="runtime"
+    )
+    by_rung = {row["rung"]: row for row in path}
+    for rung in (
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_PRO,
+        ent.TIER_ENTERPRISE,
+    ):
+        assert by_rung[rung]["allowed"] is True
+        assert by_rung[rung]["reason"] is None
+
+
+def test_runtime_alias_canonicalised_in_row_key(ent):
+    path = ent.lock_reason_path(
+        ent.TIER_OSS, ent.TIER_ENTERPRISE, "claude-code", kind="runtime"
+    )
+    assert path is not None and path
+    for row in path:
+        assert row["key"] == "claude_code"
+
+
+# ── capacity axes ────────────────────────────────────────────────────────────
+
+
+def test_channels_axis_unlock_boundary(ent):
+    """At Enterprise (unlimited channels), 100 channels is allowed; at
+    OSS the same count exceeds the free cap."""
+    path = ent.lock_reason_path(
+        ent.TIER_OSS, ent.TIER_ENTERPRISE, "100", kind="channels"
+    )
+    assert path is not None and path
+    # destination Enterprise must be allowed
+    last = path[-1]
+    assert last["rung"] == ent.TIER_ENTERPRISE
+    assert last["allowed"] is True
+    assert last["reason"] is None
+
+
+def test_nodes_axis_unlock_boundary(ent):
+    """At Enterprise (typically high node cap), 100 nodes is allowed
+    even though OSS caps at 1 node."""
+    path = ent.lock_reason_path(
+        ent.TIER_OSS, ent.TIER_ENTERPRISE, "100", kind="nodes"
+    )
+    assert path is not None and path
+    last = path[-1]
+    assert last["rung"] == ent.TIER_ENTERPRISE
+    assert last["allowed"] is True
+
+
+def test_capacity_non_positive_returns_none(ent):
+    assert (
+        ent.lock_reason_path(ent.TIER_OSS, ent.TIER_ENTERPRISE, "0", kind="channels")
+        is None
+    )
+    assert (
+        ent.lock_reason_path(ent.TIER_OSS, ent.TIER_ENTERPRISE, "-5", kind="nodes")
+        is None
+    )
+
+
+def test_capacity_non_int_returns_none(ent):
+    assert (
+        ent.lock_reason_path(
+            ent.TIER_OSS, ent.TIER_ENTERPRISE, "bogus", kind="channels"
+        )
+        is None
+    )
+
+
+# ── kind inference ───────────────────────────────────────────────────────────
+
+
+def test_kind_none_infers_feature(ent):
+    a = ent.lock_reason_path(
+        ent.TIER_OSS, ent.TIER_ENTERPRISE, "custom_alerts", kind=None
+    )
+    b = ent.lock_reason_path(
+        ent.TIER_OSS, ent.TIER_ENTERPRISE, "custom_alerts", kind="feature"
+    )
+    assert a == b
+
+
+def test_kind_none_infers_runtime(ent):
+    a = ent.lock_reason_path(
+        ent.TIER_OSS, ent.TIER_ENTERPRISE, "claude_code", kind=None
+    )
+    b = ent.lock_reason_path(
+        ent.TIER_OSS, ent.TIER_ENTERPRISE, "claude_code", kind="runtime"
+    )
+    assert a == b
+
+
+def test_kind_none_on_unknown_item_returns_none(ent):
+    assert (
+        ent.lock_reason_path(
+            ent.TIER_OSS, ent.TIER_ENTERPRISE, "not_a_real_item", kind=None
+        )
+        is None
+    )
+
+
+# ── direction semantics ──────────────────────────────────────────────────────
+
+
+def test_ascending_walk_is_non_decreasing_in_rank(ent):
+    path = ent.lock_reason_path(
+        ent.TIER_OSS, ent.TIER_ENTERPRISE, "custom_alerts", kind="feature"
+    )
+    ranks = [row["rung_rank"] for row in path]
+    assert ranks == sorted(ranks)
+
+
+def test_descending_walk_is_non_increasing_in_rank(ent):
+    path = ent.lock_reason_path(
+        ent.TIER_ENTERPRISE, ent.TIER_OSS, "custom_alerts", kind="feature"
+    )
+    ranks = [row["rung_rank"] for row in path]
+    assert ranks == sorted(ranks, reverse=True)
+
+
+def test_path_terminates_at_to_not_a_sibling(ent):
+    """``pro`` and ``cloud_pro`` share rank 2 -- the path must end at
+    ``pro`` and exclude the same-rank sibling."""
+    rungs = [
+        r["rung"]
+        for r in ent.lock_reason_path(
+            ent.TIER_OSS, ent.TIER_PRO, "custom_alerts", kind="feature"
+        )
+    ]
+    assert rungs[-1] == ent.TIER_PRO
+    assert ent.TIER_CLOUD_PRO not in rungs
+
+
+def test_identity_returns_empty(ent):
+    for tid in (
+        ent.TIER_OSS,
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_PRO,
+        ent.TIER_ENTERPRISE,
+    ):
+        assert (
+            ent.lock_reason_path(tid, tid, "custom_alerts", kind="feature") == []
+        )
+
+
+def test_lateral_single_row(ent):
+    path = ent.lock_reason_path(
+        ent.TIER_CLOUD_PRO, ent.TIER_PRO, "custom_alerts", kind="feature"
+    )
+    assert len(path) == 1
+    assert path[0]["rung"] == ent.TIER_PRO
+
+
+def test_trial_endpoint_via_lateral(ent):
+    path = ent.lock_reason_path(
+        ent.TIER_CLOUD_PRO, ent.TIER_TRIAL, "custom_alerts", kind="feature"
+    )
+    assert len(path) == 1
+    assert path[0]["rung"] == ent.TIER_TRIAL
+
+
+def test_trial_excluded_from_walked_intermediate_rungs(ent):
+    path = ent.lock_reason_path(
+        ent.TIER_OSS, ent.TIER_ENTERPRISE, "custom_alerts", kind="feature"
+    )
+    for row in path:
+        assert row["rung"] != ent.TIER_TRIAL
+
+
+# ── unknown / empty / garbage inputs ─────────────────────────────────────────
+
+
+def test_unknown_tier_returns_none(ent):
+    assert (
+        ent.lock_reason_path(
+            "not_a_tier", ent.TIER_ENTERPRISE, "custom_alerts", kind="feature"
+        )
+        is None
+    )
+    assert (
+        ent.lock_reason_path(
+            ent.TIER_OSS, "still_not", "custom_alerts", kind="feature"
+        )
+        is None
+    )
+
+
+def test_unknown_feature_returns_none(ent):
+    assert (
+        ent.lock_reason_path(
+            ent.TIER_OSS, ent.TIER_ENTERPRISE, "not_a_feature", kind="feature"
+        )
+        is None
+    )
+
+
+def test_unknown_runtime_returns_none(ent):
+    assert (
+        ent.lock_reason_path(
+            ent.TIER_OSS, ent.TIER_ENTERPRISE, "not_a_runtime", kind="runtime"
+        )
+        is None
+    )
+
+
+def test_unknown_kind_returns_none(ent):
+    assert (
+        ent.lock_reason_path(
+            ent.TIER_OSS, ent.TIER_ENTERPRISE, "custom_alerts", kind="bogus"
+        )
+        is None
+    )
+
+
+def test_empty_and_garbage_inputs_never_raise(ent):
+    assert ent.lock_reason_path("", "", "", kind="feature") is None
+    assert (
+        ent.lock_reason_path(None, None, None, kind=None)  # type: ignore[arg-type]
+        is None
+    )
+    assert ent.lock_reason_path("  ", "  ", "  ", kind="feature") is None
+    assert (
+        ent.lock_reason_path(123, 456, 789, kind="feature")  # type: ignore[arg-type]
+        is None
+    )
+
+
+def test_case_and_whitespace_normalised(ent):
+    a = ent.lock_reason_path(
+        ent.TIER_OSS, ent.TIER_ENTERPRISE, "custom_alerts", kind="feature"
+    )
+    b = ent.lock_reason_path(
+        "  OSS ", " ENTERPRISE  ", "  CUSTOM_ALERTS ", kind="feature"
+    )
+    assert a == b
+
+
+# ── resolver-independence ────────────────────────────────────────────────────
+
+
+def test_grace_and_enforce_yield_identical_rows(ent, monkeypatch):
+    grace_rows = ent.lock_reason_path(
+        ent.TIER_OSS, ent.TIER_ENTERPRISE, "custom_alerts", kind="feature"
+    )
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    enforced_rows = ent.lock_reason_path(
+        ent.TIER_OSS, ent.TIER_ENTERPRISE, "custom_alerts", kind="feature"
+    )
+    assert grace_rows == enforced_rows
+
+
+def test_synth_failure_returns_none(ent, monkeypatch):
+    """A synthesis failure inside the rung loop must short-circuit the
+    whole helper to ``None`` -- never 5xx, never partial rows."""
+    monkeypatch.setattr(
+        ent,
+        "_lock_row",
+        lambda *_a, **_kw: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
+    result = ent.lock_reason_path(
+        ent.TIER_OSS, ent.TIER_ENTERPRISE, "custom_alerts", kind="feature"
+    )
+    assert result is None
+
+
+# ── API surface ──────────────────────────────────────────────────────────────
+
+
+def test_api_400_on_missing_from(client):
+    r = client.get(
+        "/api/entitlement/lock-reason-path?to=cloud_pro&feature=custom_alerts"
+    )
+    assert r.status_code == 400
+
+
+def test_api_400_on_missing_to(client):
+    r = client.get(
+        "/api/entitlement/lock-reason-path?from=oss&feature=custom_alerts"
+    )
+    assert r.status_code == 400
+
+
+def test_api_400_on_no_axis(client):
+    r = client.get("/api/entitlement/lock-reason-path?from=oss&to=enterprise")
+    assert r.status_code == 400
+
+
+def test_api_400_on_multi_axis(client):
+    r = client.get(
+        "/api/entitlement/lock-reason-path?from=oss&to=enterprise"
+        "&feature=custom_alerts&runtime=claude_code"
+    )
+    assert r.status_code == 400
+
+
+def test_api_404_on_unknown_tier(client):
+    r = client.get(
+        "/api/entitlement/lock-reason-path?from=oss&to=not_a_tier"
+        "&feature=custom_alerts"
+    )
+    assert r.status_code == 404
+    assert r.get_json()["error"] == "unknown tier or item"
+
+
+def test_api_404_on_unknown_feature(client):
+    r = client.get(
+        "/api/entitlement/lock-reason-path?from=oss&to=enterprise&feature=bogus"
+    )
+    assert r.status_code == 404
+
+
+def test_api_404_on_unknown_runtime(client):
+    r = client.get(
+        "/api/entitlement/lock-reason-path?from=oss&to=enterprise&runtime=bogus"
+    )
+    assert r.status_code == 404
+
+
+def test_api_404_on_unparseable_capacity(client):
+    r = client.get(
+        "/api/entitlement/lock-reason-path?from=oss&to=enterprise&channels=bogus"
+    )
+    assert r.status_code == 404
+
+
+def test_api_happy_path_ascending(client, ent):
+    r = client.get(
+        f"/api/entitlement/lock-reason-path?from={ent.TIER_OSS}"
+        f"&to={ent.TIER_ENTERPRISE}&feature=custom_alerts"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert set(body.keys()) == _ENVELOPE_KEYS
+    assert body["from"] == ent.TIER_OSS
+    assert body["to"] == ent.TIER_ENTERPRISE
+    assert body["key"] == "custom_alerts"
+    assert body["kind"] == "feature"
+    assert body["direction"] == "upgrade"
+    assert isinstance(body["path"], list) and body["path"]
+    assert body["path"][-1]["rung"] == ent.TIER_ENTERPRISE
+
+
+def test_api_happy_path_descending(client, ent):
+    r = client.get(
+        f"/api/entitlement/lock-reason-path?from={ent.TIER_ENTERPRISE}"
+        f"&to={ent.TIER_OSS}&feature=custom_alerts"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["direction"] == "downgrade"
+    assert body["path"][-1]["rung"] == ent.TIER_OSS
+
+
+def test_api_identity_empty_path(client, ent):
+    r = client.get(
+        f"/api/entitlement/lock-reason-path?from={ent.TIER_CLOUD_PRO}"
+        f"&to={ent.TIER_CLOUD_PRO}&feature=custom_alerts"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["direction"] == "identity"
+    assert body["path"] == []
+
+
+def test_api_lateral_single_row(client, ent):
+    r = client.get(
+        f"/api/entitlement/lock-reason-path?from={ent.TIER_CLOUD_PRO}"
+        f"&to={ent.TIER_PRO}&feature=custom_alerts"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["direction"] == "lateral"
+    assert len(body["path"]) == 1
+    assert body["path"][0]["rung"] == ent.TIER_PRO
+
+
+def test_api_runtime_alias_echoed_canonical(client):
+    r = client.get(
+        "/api/entitlement/lock-reason-path?from=oss&to=enterprise"
+        "&runtime=claude-code"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["key"] == "claude_code"
+    assert body["kind"] == "runtime"
+    for row in body["path"]:
+        assert row["key"] == "claude_code"
+
+
+def test_api_channels_axis(client, ent):
+    r = client.get(
+        f"/api/entitlement/lock-reason-path?from={ent.TIER_OSS}"
+        f"&to={ent.TIER_ENTERPRISE}&channels=10"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["kind"] == "channels"
+    assert body["key"] == "10"
+    assert body["path"]
+
+
+def test_api_rungs_match_feature_spec_path_route(client, ent):
+    """API-level byte-equality: rung ids from ``/lock-reason-path`` match
+    rung ids from ``/feature-spec-path`` on the same axis-and-endpoint
+    bundle."""
+    a = client.get(
+        f"/api/entitlement/lock-reason-path?from={ent.TIER_OSS}"
+        f"&to={ent.TIER_ENTERPRISE}&feature=custom_alerts"
+    ).get_json()
+    b = client.get(
+        f"/api/entitlement/feature-spec-path?from={ent.TIER_OSS}"
+        f"&to={ent.TIER_ENTERPRISE}&feature=custom_alerts"
+    ).get_json()
+    assert [r["rung"] for r in a["path"]] == [r["rung"] for r in b["path"]]


### PR DESCRIPTION
## Summary

Fills the missing `_path` member of the lock-reason family: `lock_reason_path(from_tier, to_tier, item, kind=None)` + `GET /api/entitlement/lock-reason-path`. Lock-row analogue of `feature_spec_path` / `runtime_spec_path` and path-walking sibling of `lock_reason_at` — lets a paywall surface render the per-rung `locked` / `allowed` / `reason` sentence for a SINGLE item off one round-trip instead of one `/lock-reason-at` call per rung.

- **Helper** — walks `_PURCHASABLE_TIERS` between the two endpoints by the same sort + same destination-sibling exclusion as the eight existing `_path` helpers (`tier_path`, `tier_spec_path`, `capacity_diff_path`, `tier_unlocks_path`, `tier_locks_path`, `preview_path`, `feature_spec_path`, `runtime_spec_path`), so the nine paths line up rung-for-rung. Per-rung row is the 8-key `_lock_row` body plus three rung-id keys (`rung`, `rung_label`, `rung_rank`); dropping the `rung*` keys yields byte-equality with `lock_reasons_at_batch`'s axis row at the same rung — pinned in the test suite.
- **Axis dispatch** — `feature` / `runtime` / `channels` / `retention_days` / `nodes`, the same single-axis posture `/lock-reason` and `/lock-reason-at` already use. Runtime ids canonicalised (`claude-code` → `claude_code`).
- **Resolver-independent** — synthesises a fresh `Entitlement` per rung with `grace=False` and per-tier capacity caps off `_TIER_NODE_LIMIT`, so grace vs enforce yields byte-identical rows.
- **Never crashes** — unknown / empty / non-positive inputs short-circuit to `None`. The route 400s on missing args / no-axis / multi-axis, 404s on unknown ids or unparseable capacity, and never 5xxs.

### Response shape

```
{
  "from":       "<tier id>",
  "from_label": "...",
  "from_rank":  <int>,
  "to":         "<tier id>",
  "to_label":   "...",
  "to_rank":    <int>,
  "direction":  "upgrade" | "downgrade" | "lateral" | "identity",
  "key":        "<echoed item id>",
  "kind":       "feature" | "runtime" | "channels" | "retention_days" | "nodes",
  "path":       [<rung-augmented lock-row>, ...]
}
```

Each `path` row is `{rung, rung_label, rung_rank, key, kind, reason, locked, allowed, required_tier, required_tier_label, required_tier_rank}`.

### Scope

Pure additive helper + route. No existing function signature or route shape changes, no resolver semantics change, no frontend change, no `__version__` bump, no `[RELEASE]` tag. Disjoint from the open `_at`-family PR #3379 (different axis: path-walking, not directional scalar).

## Test plan

- [x] `python3 -m pytest tests/test_entitlement_lock_reason_path.py -q` — **53 passed**
- [x] `python3 -m pytest tests/test_entitlement_*.py tests/test_entitlements*.py tests/test_license*.py -q` — **2660 passed**
- [x] `ruff check clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_lock_reason_path.py` — clean
- [ ] Local-operator verification on the running daemon (see checklist below)

---

### Local operator verification checklist

I cannot reach the running daemon, `~/.openclaw`, or the live cloud snapshot from this environment. Before flipping ready-for-review and merging, please:

1. Pull `feat/entitlement-lock-reason-path` locally and copy the changed files into the installed site-packages location:
   ```sh
   cp clawmetry/entitlements.py ~/.clawmetry/lib/python*/site-packages/clawmetry/entitlements.py
   cp routes/entitlement.py     ~/.clawmetry/lib/python*/site-packages/routes/entitlement.py
   ```
2. Clear `__pycache__` under `~/.clawmetry/lib/python*/site-packages/{clawmetry,routes}/` so the new bytecode is picked up.
3. Restart the daemon: `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`.
4. Smoke the new endpoint against your live install:
   ```sh
   # feature axis — happy path
   curl -s 'http://localhost:8900/api/entitlement/lock-reason-path?from=oss&to=enterprise&feature=custom_alerts' \
     | jq '.direction, (.path | map({rung, allowed, reason}))'

   # cancellation walk (descending)
   curl -s 'http://localhost:8900/api/entitlement/lock-reason-path?from=enterprise&to=oss&feature=custom_alerts' \
     | jq '.direction, .path[-1].rung'   # "downgrade", "oss"

   # runtime axis + alias canonicalisation
   curl -s 'http://localhost:8900/api/entitlement/lock-reason-path?from=oss&to=enterprise&runtime=claude-code' \
     | jq '.key, .kind'                  # "claude_code", "runtime"

   # capacity axes
   curl -s 'http://localhost:8900/api/entitlement/lock-reason-path?from=oss&to=enterprise&channels=10' \
     | jq '.kind, (.path[-1] | {rung, allowed, reason})'

   # error envelopes
   curl -s 'http://localhost:8900/api/entitlement/lock-reason-path?feature=custom_alerts' \
     -o /dev/null -w '%{http_code}\n'    # expect 400 (missing from/to)
   curl -s 'http://localhost:8900/api/entitlement/lock-reason-path?from=oss&to=enterprise' \
     -o /dev/null -w '%{http_code}\n'    # expect 400 (no axis)
   curl -s 'http://localhost:8900/api/entitlement/lock-reason-path?from=oss&to=enterprise&feature=custom_alerts&runtime=claude_code' \
     -o /dev/null -w '%{http_code}\n'    # expect 400 (multi-axis)
   curl -s 'http://localhost:8900/api/entitlement/lock-reason-path?from=oss&to=bogus&feature=custom_alerts' \
     -o /dev/null -w '%{http_code}\n'    # expect 404 (unknown tier)
   curl -s 'http://localhost:8900/api/entitlement/lock-reason-path?from=oss&to=enterprise&feature=bogus' \
     -o /dev/null -w '%{http_code}\n'    # expect 404 (unknown feature)
   curl -s 'http://localhost:8900/api/entitlement/lock-reason-path?from=oss&to=enterprise&channels=bogus' \
     -o /dev/null -w '%{http_code}\n'    # expect 404 (unparseable capacity)
   ```
5. Confirm the existing `/api/entitlement`, `/lock-reason`, `/lock-reason-at`, `/lock-reason-batch`, `/lock-reasons-at-batch`, `/feature-spec-path`, `/runtime-spec-path` and `/tier-spec-path` endpoints still return the same payloads they did pre-change (no UI consumes the new endpoint yet — this is a pure additive surface).
6. Decrypt the live cloud snapshot in the browser and re-verify the entitlement panel renders unchanged.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01KURNnLuc7sq8GnkFMn9doq)_