### PR TITLE
fix: skip ollama CLI fallback for non-loopback hosts

### DIFF
--- a/clawmetry/adapters/openclaw.py
+++ b/clawmetry/adapters/openclaw.py
@@ -183,11 +183,14 @@ def _resolve_minimax_base_url() -> str:
 def _list_ollama_models(host: str) -> list:
     """Return available Ollama model names. Never raises; returns [] on failure.
 
-    Tries GET {host}/api/tags first (same as the harness HTTP path), then falls
-    back to `ollama list` CLI (same fallback the harness uses). Both failures
-    are silenced so a missing/offline Ollama doesn't error detection.
+    Tries GET {host}/api/tags first (same as the harness HTTP path). For
+    loopback hosts only, also falls back to ``ollama list`` CLI on HTTP
+    failure — matching the harness's getOllamaModelOptions() which skips the
+    CLI fallback when OLLAMA_HOST_DOCKER_INTERNAL is set, so ollamaModels is
+    never populated from the local workstation daemon for Docker-internal hosts.
     """
     import urllib.request
+    from urllib.parse import urlparse
     try:
         url = host.rstrip("/") + "/api/tags"
         with urllib.request.urlopen(url, timeout=2) as resp:  # noqa: S310
@@ -195,6 +198,10 @@ def _list_ollama_models(host: str) -> list:
             return [m["name"] for m in data.get("models", []) if m.get("name")]
     except Exception:
         pass
+    # CLI fallback only for loopback hosts (#3391: harness parity)
+    _hostname = urlparse(host).hostname or ""
+    if _hostname not in ("localhost", "127.0.0.1", "::1"):
+        return []
     try:
         import subprocess
         result = subprocess.run(

--- a/tests/test_obs_gap_nemoclaw_ollama_3201.py
+++ b/tests/test_obs_gap_nemoclaw_ollama_3201.py
@@ -127,6 +127,29 @@ def test_list_ollama_models_returns_empty_on_both_failures(monkeypatch):
     assert _list_ollama_models("http://localhost:11434") == []
 
 
+def test_list_ollama_models_non_loopback_skips_cli_fallback(monkeypatch):
+    """Docker-internal host must not fall back to CLI on HTTP failure (#3391)."""
+    def _fail_urlopen(url, timeout=None):
+        raise urllib.error.URLError("refused")
+
+    monkeypatch.setattr("urllib.request.urlopen", _fail_urlopen)
+
+    import subprocess as _sp
+    cli_calls = []
+
+    def _spy_run(*a, **kw):
+        cli_calls.append(a)
+        class _Res:
+            stdout = "NAME\nllama3:latest\n"
+        return _Res()
+
+    monkeypatch.setattr(_sp, "run", _spy_run)
+
+    result = _list_ollama_models("http://172.17.0.1:11434")
+    assert result == [], "non-loopback host should return [] when HTTP fails"
+    assert cli_calls == [], "CLI must not be invoked for non-loopback Ollama hosts"
+
+
 # ---------------------------------------------------------------------------
 # _sandbox_inference_configs — Ollama sandbox
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #3391

## What changed

- `clawmetry/adapters/openclaw.py` — `_list_ollama_models()` now parses the hostname from the `host` URL before the CLI fallback. If the hostname is not `localhost`, `127.0.0.1`, or `::1`, it returns `[]` immediately instead of invoking `ollama list`.
- `tests/test_obs_gap_nemoclaw_ollama_3201.py` — adds `test_list_ollama_models_non_loopback_skips_cli_fallback` which asserts that a Docker-internal host (`172.17.0.1:11434`) never triggers `subprocess.run` when HTTP fails.

## Why

When `OLLAMA_HOST_DOCKER_INTERNAL` is set, the resolved Ollama host is non-loopback (e.g. `172.17.0.1:11434`). If the HTTP `/api/tags` request failed, the old code silently fell back to `ollama list` CLI — which queries the *local workstation* daemon, not the Docker-internal one. This caused `ollamaModels` to be populated with wrong model names.

The harness's `getOllamaModelOptions()` already handles this correctly: it skips the CLI fallback for non-loopback hosts. This PR brings ClawMetry in line with that behaviour.

## Test plan

- `python -m pytest tests/test_obs_gap_nemoclaw_ollama_3201.py -v` — all 16 tests pass (15 pre-existing + 1 new)
- Loopback behaviour (localhost/127.0.0.1) unchanged: CLI fallback still fires when HTTP fails

---
_Generated by [Claude Code](https://claude.ai/code/session_016HtV4wX9zGguz6XTcXgehn)_