### PR TITLE
fix: surface Docker daemon liveness in detect() meta (#3390)

### DIFF
--- a/clawmetry/adapters/openclaw.py
+++ b/clawmetry/adapters/openclaw.py
@@ -101,6 +101,25 @@ def _gateway_live() -> bool:
         return False
 
 
+def _is_docker_runtime_down() -> Optional[bool]:
+    """True when Docker daemon is present but not responding, False when
+    healthy, None when docker CLI is absent (not a Docker-backed environment).
+    Never raises.
+    """
+    try:
+        import shutil as _sh
+        if not _sh.which("docker"):
+            return None
+        import subprocess as _sp
+        rc = _sp.run(
+            ["docker", "info"],
+            capture_output=True, timeout=3,
+        ).returncode
+        return rc != 0
+    except Exception:
+        return None
+
+
 def _real_install(sessions_dir: str) -> bool:
     """A genuine OpenClaw install signal, NOT the bare ~/.openclaw dir that
     ClawMetry itself creates as a scratch workspace. Any one of: the openclaw
@@ -917,6 +936,13 @@ class OpenClawAdapter(AgentAdapter):
             # Only meaningful — and safe to query — when the gateway is live.
             if running:
                 meta.update(_gateway_plugin_health())
+            # Docker runtime health (#3390): the NemoClaw harness treats Docker
+            # daemon liveness as a distinct signal from gateway liveness. Only
+            # written when docker CLI is present so non-Docker environments are
+            # unaffected.
+            _docker_down = _is_docker_runtime_down()
+            if _docker_down is not None:
+                meta["dockerRuntimeDown"] = _docker_down
             return DetectResult(
                 name=self.name,
                 display_name=self.display_name,

--- a/tests/test_obs_gap_nemoclaw_docker_runtime_3390.py
+++ b/tests/test_obs_gap_nemoclaw_docker_runtime_3390.py
@@ -1,0 +1,35 @@
+"""Tests for #3390 -- _is_docker_runtime_down surfaces Docker daemon health
+into DetectResult.meta as dockerRuntimeDown.
+"""
+import shutil
+import subprocess
+
+from clawmetry.adapters.openclaw import _is_docker_runtime_down
+
+
+def test_docker_down_when_info_fails(monkeypatch):
+    monkeypatch.setattr(shutil, "which", lambda _cmd: "/usr/bin/docker")
+    fake = type("R", (), {"returncode": 1})()
+    monkeypatch.setattr(subprocess, "run", lambda *a, **kw: fake)
+    assert _is_docker_runtime_down() is True
+
+
+def test_docker_healthy(monkeypatch):
+    monkeypatch.setattr(shutil, "which", lambda _cmd: "/usr/bin/docker")
+    fake = type("R", (), {"returncode": 0})()
+    monkeypatch.setattr(subprocess, "run", lambda *a, **kw: fake)
+    assert _is_docker_runtime_down() is False
+
+
+def test_docker_absent_returns_none(monkeypatch):
+    monkeypatch.setattr(shutil, "which", lambda _cmd: None)
+    assert _is_docker_runtime_down() is None
+
+
+def test_docker_exception_returns_none(monkeypatch):
+    monkeypatch.setattr(shutil, "which", lambda _cmd: "/usr/bin/docker")
+    monkeypatch.setattr(
+        subprocess, "run",
+        lambda *a, **kw: (_ for _ in ()).throw(OSError("timeout")),
+    )
+    assert _is_docker_runtime_down() is None


### PR DESCRIPTION
Closes #3390

## Summary
- Add `_is_docker_runtime_down()` in `clawmetry/adapters/openclaw.py`: runs `docker info`, returns `True` (down) / `False` (healthy) / `None` (docker CLI absent — non-Docker env, key stays out of meta)
- Call it in `OpenClawAdapter.detect()` and write `meta["dockerRuntimeDown"]` when non-None, making Docker daemon state independently visible from gateway liveness
- New test file `tests/test_obs_gap_nemoclaw_docker_runtime_3390.py` with 4 tests: daemon down, daemon healthy, docker absent, subprocess exception

## Test plan
- `python3 -m pytest tests/test_obs_gap_nemoclaw_docker_runtime_3390.py -v` — 4/4 pass
- `python3 -m py_compile clawmetry/adapters/openclaw.py` — syntax clean
- Non-Docker environments: `shutil.which("docker")` returns None → `dockerRuntimeDown` key is absent from meta, no behavior change

---
_Generated by [Claude Code](https://claude.ai/code/session_01BaXMQYRvYTNMd3DAR2BjhC)_