### PR TITLE
feat(entitlement): lock_reason_path_batch + /api/entitlement/lock-reason-path-batch

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -7314,3 +7314,180 @@ def runtime_spec_path_batch(
         seen.add(canon)
         rows.append({"runtime": canon, "path": path})
     return {"runtimes": rows, "unknown": unknown}
+
+
+def lock_reason_path_batch(
+    from_tier: str,
+    to_tier: str,
+    *,
+    features=None,
+    runtimes=None,
+    channels: int | None = None,
+    retention_days: int | None = None,
+    nodes: int | None = None,
+) -> dict | None:
+    """Multi-axis batch sibling of :func:`lock_reason_path`: per-item
+    stepwise lock-row paths between two tiers across all 5 axes in ONE
+    round-trip.
+
+    Pairs with :func:`lock_reason_path` the same way
+    :func:`lock_reasons_at_batch` pairs with :func:`lock_reason_at`:
+    scalar what-if -> matrix what-if. Lets a paywall comparison surface
+    ("here are the 6 features + 2 runtimes + my channel count + my
+    retention window, walk each one from OSS to Enterprise") render the
+    full matrix off ONE call instead of N calls to
+    :func:`lock_reason_path` per item.
+
+    Composes :func:`lock_reason_path` (scalar single-item path) and
+    :func:`lock_reasons_at_batch` (matrix what-if scalar) -- same rung
+    walk as the scalar path helper, same multi-axis envelope as the
+    matrix what-if helper. The two top-level capacity axes
+    (``channels`` / ``retention_days`` / ``nodes``) are *single-item*
+    just like :func:`lock_reasons_at_batch`, since each is a single
+    integer rather than a CSV.
+
+    Shape (mirrors :func:`lock_reasons_at_batch` plus per-row paths)::
+
+        {
+          "features": [{"key": "<id>", "path": [<augmented row>, ...]}, ...],
+          "runtimes": [{"key": "<canonical id>", "path": [...]}, ...],
+          "channels":       {"key": "<n>", "path": [...]} | None,
+          "retention_days": {"key": "<n>", "path": [...]} | None,
+          "nodes":          {"key": "<n>", "path": [...]} | None,
+          "unknown": {"features": [...], "runtimes": [...]},
+        }
+
+    Each ``path`` row is byte-identical to a row from
+    :func:`lock_reason_path` for the same ``(from, to, item, kind)``
+    tuple -- a parity test pins this so the scalar and batch path
+    helpers cannot drift. Rungs walked are item-agnostic (matches
+    :func:`feature_spec_path_batch` / :func:`runtime_spec_path_batch`),
+    so every per-item ``path`` has the same length and rung sequence.
+
+    Supplied feature/runtime ids are normalised via
+    :func:`_normalise_csv` (whitespace stripped, lowercased, duplicates
+    dropped, first-seen order preserved). Runtime aliases are
+    canonicalised via :func:`canonical_runtime` (``claude-code`` ->
+    ``claude_code``); aliases that collapse to a canonical id already
+    in the response are silently de-duplicated -- same behaviour as
+    :func:`runtime_spec_path_batch`. Unknown ids are echoed in
+    ``unknown.features`` / ``unknown.runtimes`` instead of
+    short-circuiting -- a partially-bad caller still gets paths back
+    for the valid ids alongside a list of what was dropped, matching
+    :func:`feature_spec_path_batch`'s posture.
+
+    Capacity axes use ``None`` as the "axis not supplied" sentinel:
+    ``retention_days=None`` here means *unset*, NOT *unlimited* --
+    matches :func:`lock_reasons_at_batch`. A non-positive / non-int
+    capacity value yields a ``None`` axis row (the scalar
+    :func:`lock_reason_path` short-circuits in that case).
+
+    Returns ``None`` for empty / unknown ``from_tier`` / ``to_tier``
+    (caller renders 404). Identity ``from == to`` yields a payload with
+    one entry per supplied id whose ``path`` is ``[]``, matching the
+    singular helper's identity branch.
+
+    Resolver-independent: delegates per-item to
+    :func:`lock_reason_path`, which synthesises a fresh
+    :class:`Entitlement` per rung with ``grace=False`` -- so grace vs
+    enforce yields byte-identical rows. Never raises: per-item failures
+    short-circuit that item into ``unknown[]`` and the rest of the
+    batch keeps building.
+    """
+    try:
+        f = (from_tier or "").strip().lower()
+        t = (to_tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if f not in _TIER_FEATURES or t not in _TIER_FEATURES:
+        return None
+
+    feats = _normalise_csv(features)
+    rts = _normalise_csv(runtimes)
+
+    feature_rows: list[dict] = []
+    runtime_rows: list[dict] = []
+    unknown_features: list[str] = []
+    unknown_runtimes: list[str] = []
+    seen_runtimes: set[str] = set()
+
+    for fid in feats:
+        if fid not in ALL_FEATURES:
+            unknown_features.append(fid)
+            continue
+        try:
+            path = lock_reason_path(f, t, fid, kind="feature")
+        except Exception as exc:
+            logger.warning(
+                "entitlements: lock_reason_path_batch feature %r failed: %s",
+                fid,
+                exc,
+            )
+            unknown_features.append(fid)
+            continue
+        if path is None:
+            unknown_features.append(fid)
+            continue
+        feature_rows.append({"key": fid, "path": path})
+
+    for raw in rts:
+        canon = canonical_runtime(raw)
+        if not canon or canon not in ALL_RUNTIMES:
+            unknown_runtimes.append(raw)
+            continue
+        if canon in seen_runtimes:
+            continue
+        try:
+            path = lock_reason_path(f, t, raw, kind="runtime")
+        except Exception as exc:
+            logger.warning(
+                "entitlements: lock_reason_path_batch runtime %r failed: %s",
+                raw,
+                exc,
+            )
+            unknown_runtimes.append(raw)
+            continue
+        if path is None:
+            unknown_runtimes.append(raw)
+            continue
+        seen_runtimes.add(canon)
+        runtime_rows.append({"runtime": canon, "path": path})
+
+    def _capacity(value, kind: str) -> dict | None:
+        if value is None:
+            return None
+        try:
+            n = int(value)
+        except (TypeError, ValueError):
+            return None
+        if n <= 0:
+            return None
+        try:
+            p = lock_reason_path(f, t, str(n), kind=kind)
+        except Exception as exc:
+            logger.warning(
+                "entitlements: lock_reason_path_batch %s %r failed: %s",
+                kind,
+                value,
+                exc,
+            )
+            return None
+        if p is None:
+            return None
+        return {"key": str(n), "path": p}
+
+    # Map runtime rows to the {"key", "path"} shape used by every
+    # other axis in this envelope; the canonical id lives in ``key``.
+    runtime_rows = [{"key": r["runtime"], "path": r["path"]} for r in runtime_rows]
+
+    return {
+        "features": feature_rows,
+        "runtimes": runtime_rows,
+        "channels": _capacity(channels, "channels"),
+        "retention_days": _capacity(retention_days, "retention_days"),
+        "nodes": _capacity(nodes, "nodes"),
+        "unknown": {
+            "features": unknown_features,
+            "runtimes": unknown_runtimes,
+        },
+    }

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -7243,3 +7243,187 @@ def api_entitlement_runtime_spec_path_batch():
                 "unknown": [],
             }
         )
+
+
+@bp_entitlement.route("/api/entitlement/lock-reason-path-batch")
+def api_entitlement_lock_reason_path_batch():
+    """``GET /api/entitlement/lock-reason-path-batch?from=<id>&to=<id>
+    &features=a,b,c&runtimes=x,y&channels=N&retention_days=K&nodes=M``
+    -- multi-axis batch sibling of
+    ``/api/entitlement/lock-reason-path``.
+
+    Where ``/lock-reason-path`` walks ONE item across the rungs between
+    two tiers, this walks N items across all 5 axes (features +
+    runtimes + 3 capacity axes) across the same rungs in ONE
+    round-trip. Pairs with ``/lock-reason-path`` the same way
+    ``/lock-reasons-at-batch`` pairs with ``/lock-reason-at``: scalar
+    what-if -> matrix what-if.
+
+    Use case: a paywall comparison surface ("here are the 6 features +
+    2 runtimes + my channel count + my retention window, walk each one
+    from OSS to Enterprise") hydrates the full matrix off ONE call
+    instead of N calls to ``/lock-reason-path`` per item. Rung walk is
+    item-agnostic, so all per-item paths share the same length and
+    rung sequence -- the client can render the matrix as rows = items
+    x cols = rungs without re-deriving the column headers per item.
+
+    At least one of ``features=`` / ``runtimes=`` / ``channels=`` /
+    ``retention_days=`` / ``nodes=`` must be supplied (matches
+    ``/lock-reasons-at-batch``); supply as many as you like.
+    ``features=`` / ``runtimes=`` take comma-separated tokens
+    (whitespace + duplicates are normalised away; unknown ids are
+    echoed in ``unknown[]`` instead of 404'ing the call). The three
+    capacity axes take a single int each; blank / non-int / non-
+    positive values render that axis as ``None`` (matches
+    ``/lock-reason-path``'s short-circuit posture).
+
+    Each row in ``features[].path`` / ``runtimes[].path`` /
+    ``channels.path`` / ``retention_days.path`` / ``nodes.path`` is
+    byte-identical to a row from ``/lock-reason-path?from=<from>
+    &to=<to>&<axis>=<id>`` -- pinned by the parity tests so the scalar
+    and batch path accessors cannot drift.
+
+    Response shape (mirrors ``/feature-spec-path-batch`` envelope plus
+    the 5-axis body from ``/lock-reasons-at-batch``)::
+
+        {
+          "from":       "<tier id>",
+          "from_label": "...",
+          "from_rank":  <int>,
+          "to":         "<tier id>",
+          "to_label":   "...",
+          "to_rank":    <int>,
+          "direction":  "upgrade" | "downgrade" | "lateral" | "identity",
+          "features": [{"key": "<id>", "path": [<augmented row>, ...]}, ...],
+          "runtimes": [{"key": "<canonical id>", "path": [...]}, ...],
+          "channels":       {"key": "<n>", "path": [...]} | None,
+          "retention_days": {"key": "<n>", "path": [...]} | None,
+          "nodes":          {"key": "<n>", "path": [...]} | None,
+          "unknown": {"features": [...], "runtimes": [...]},
+        }
+
+    - **400** when ``from=`` / ``to=`` is missing / blank, or no axis
+      is supplied
+    - **404** when ``from`` or ``to`` is unknown (body carries
+      ``which: "tier"``)
+    - **Never 5xxs**: a synthesis failure short-circuits to an envelope
+      with empty rows so the matrix keeps rendering.
+    """
+    f = (request.args.get("from") or "").strip().lower()
+    t = (request.args.get("to") or "").strip().lower()
+    if not f or not t:
+        return jsonify({"error": "missing from or to"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        if f not in _ent._TIER_ORDER:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "tier", "tier": f}
+                ),
+                404,
+            )
+        if t not in _ent._TIER_ORDER:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "tier", "tier": t}
+                ),
+                404,
+            )
+
+        features = _parse_csv_arg("features")
+        runtimes = _parse_csv_arg("runtimes")
+        (_, channels_ok, channels_n, _) = _parse_capacity_arg("channels")
+        (_, retention_ok, retention_n, _) = _parse_capacity_arg(
+            "retention_days"
+        )
+        (_, nodes_ok, nodes_n, _) = _parse_capacity_arg("nodes")
+
+        if (
+            not features
+            and not runtimes
+            and not channels_ok
+            and not retention_ok
+            and not nodes_ok
+        ):
+            return (
+                jsonify(
+                    {
+                        "error": (
+                            "supply at least one of features=<csv>, "
+                            "runtimes=<csv>, channels=<int>, "
+                            "retention_days=<int>, or nodes=<int>"
+                        )
+                    }
+                ),
+                400,
+            )
+
+        batch = _ent.lock_reason_path_batch(
+            f,
+            t,
+            features=features or None,
+            runtimes=runtimes or None,
+            channels=channels_n if channels_ok else None,
+            retention_days=retention_n if retention_ok else None,
+            nodes=nodes_n if nodes_ok else None,
+        )
+        if batch is None:
+            batch = {
+                "features": [],
+                "runtimes": [],
+                "channels": None,
+                "retention_days": None,
+                "nodes": None,
+                "unknown": {"features": [], "runtimes": []},
+            }
+        from_rank = _ent.tier_rank(f)
+        to_rank = _ent.tier_rank(t)
+        if f == t:
+            direction = "identity"
+        elif from_rank == to_rank:
+            direction = "lateral"
+        elif to_rank > from_rank:
+            direction = "upgrade"
+        else:
+            direction = "downgrade"
+        return jsonify(
+            {
+                "from": f,
+                "from_label": _ent.tier_label(f),
+                "from_rank": from_rank,
+                "to": t,
+                "to_label": _ent.tier_label(t),
+                "to_rank": to_rank,
+                "direction": direction,
+                "features": batch.get("features", []),
+                "runtimes": batch.get("runtimes", []),
+                "channels": batch.get("channels"),
+                "retention_days": batch.get("retention_days"),
+                "nodes": batch.get("nodes"),
+                "unknown": batch.get(
+                    "unknown", {"features": [], "runtimes": []}
+                ),
+            }
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_lock_reason_path_batch: error: %s", exc
+        )
+        return jsonify(
+            {
+                "from": f,
+                "from_label": None,
+                "from_rank": -1,
+                "to": t,
+                "to_label": None,
+                "to_rank": -1,
+                "direction": "identity" if f == t else "upgrade",
+                "features": [],
+                "runtimes": [],
+                "channels": None,
+                "retention_days": None,
+                "nodes": None,
+                "unknown": {"features": [], "runtimes": []},
+            }
+        )

--- a/tests/test_entitlement_lock_reason_path_batch.py
+++ b/tests/test_entitlement_lock_reason_path_batch.py
@@ -1,0 +1,490 @@
+"""Tests for ``clawmetry.entitlements.lock_reason_path_batch(...)`` +
+the ``GET /api/entitlement/lock-reason-path-batch`` endpoint.
+
+Multi-axis batch sibling of :func:`lock_reason_path`: where the scalar
+path helper walks ONE item across the rungs between two tiers, this
+walks N items across all 5 axes (features + runtimes + 3 capacity
+axes) in ONE round-trip. Pairs with :func:`lock_reason_path` the same
+way :func:`lock_reasons_at_batch` pairs with :func:`lock_reason_at`.
+
+Pins:
+
+* per-item ``path`` byte-identical to the scalar
+  :func:`lock_reason_path` payload for the same ``(from, to, item,
+  kind)`` tuple -- so the scalar and batch path helpers cannot drift
+* rung walk identical across items in the same batch (rungs are
+  item-agnostic, matches the ``feature_spec_path_batch`` /
+  ``runtime_spec_path_batch`` invariant)
+* envelope mirrors ``/feature-spec-path-batch`` (from / from_label /
+  from_rank / to / to_label / to_rank / direction) PLUS the 5-axis
+  body of :func:`lock_reasons_at_batch` (features / runtimes /
+  channels / retention_days / nodes) PLUS structured
+  ``unknown.features`` / ``unknown.runtimes``
+* feature/runtime input normalised (whitespace stripped, lowercased,
+  duplicates dropped, first-seen order preserved); runtime aliases
+  canonicalise and collapse against already-supplied canonical ids
+* unknown feature/runtime ids echoed in ``unknown[...]`` instead of
+  404'ing the call
+* capacity axes are single-item (single int each); ``None`` /
+  non-positive / non-int values render that axis as ``None``
+  short-circuit (matches :func:`lock_reason_path`)
+* identity ``from == to`` yields per-item paths of ``[]``
+* lateral (same rank, different id) yields one-row paths per item
+* helper never raises -- per-item failures short-circuit that item
+  into ``unknown[...]`` and the rest of the batch keeps building
+* HTTP endpoint: 400 on missing tier / no axis supplied; 404 on
+  unknown tier; never 5xxs on row failure
+* grace vs enforce yields byte-identical rows
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+_ENVELOPE_KEYS = {
+    "from",
+    "from_label",
+    "from_rank",
+    "to",
+    "to_label",
+    "to_rank",
+    "direction",
+    "features",
+    "runtimes",
+    "channels",
+    "retention_days",
+    "nodes",
+    "unknown",
+}
+
+_RUNG_KEYS = {"rung", "rung_label", "rung_rank"}
+_ROW_KEYS = {
+    "key",
+    "kind",
+    "reason",
+    "locked",
+    "allowed",
+    "required_tier",
+    "required_tier_label",
+    "required_tier_rank",
+}
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+def _pick_feature(ent, *, paid: bool) -> str:
+    pool = ent.PAID_FEATURES if paid else ent.FREE_FEATURES
+    return sorted(pool)[0]
+
+
+def _pick_paid_runtime(ent) -> str:
+    return sorted(ent.PAID_RUNTIMES)[0]
+
+
+# ── helper: envelope shape ──────────────────────────────────────────────────
+
+
+def test_helper_returns_dict_with_5_axes_plus_unknown(ent):
+    out = ent.lock_reason_path_batch(
+        ent.TIER_OSS,
+        ent.TIER_ENTERPRISE,
+        features=[_pick_feature(ent, paid=True)],
+        runtimes=[_pick_paid_runtime(ent)],
+        channels=99,
+        retention_days=365,
+        nodes=50,
+    )
+    assert isinstance(out, dict)
+    assert set(out.keys()) == {
+        "features",
+        "runtimes",
+        "channels",
+        "retention_days",
+        "nodes",
+        "unknown",
+    }
+    assert isinstance(out["features"], list)
+    assert isinstance(out["runtimes"], list)
+    assert isinstance(out["unknown"], dict)
+    assert set(out["unknown"].keys()) == {"features", "runtimes"}
+
+
+def test_helper_each_axis_item_carries_key_and_path(ent):
+    out = ent.lock_reason_path_batch(
+        ent.TIER_OSS,
+        ent.TIER_ENTERPRISE,
+        features=[_pick_feature(ent, paid=True)],
+        runtimes=[_pick_paid_runtime(ent)],
+        channels=99,
+        retention_days=365,
+        nodes=50,
+    )
+    for item in out["features"]:
+        assert set(item.keys()) == {"key", "path"}
+        assert isinstance(item["key"], str)
+        assert isinstance(item["path"], list)
+    for item in out["runtimes"]:
+        assert set(item.keys()) == {"key", "path"}
+    for axis in ("channels", "retention_days", "nodes"):
+        assert set(out[axis].keys()) == {"key", "path"}
+
+
+def test_helper_unsupplied_axes_default_to_empty_or_none(ent):
+    out = ent.lock_reason_path_batch(
+        ent.TIER_OSS, ent.TIER_ENTERPRISE, features=["custom_alerts"]
+    )
+    assert out["features"] != []
+    assert out["runtimes"] == []
+    assert out["channels"] is None
+    assert out["retention_days"] is None
+    assert out["nodes"] is None
+    assert out["unknown"] == {"features": [], "runtimes": []}
+
+
+# ── helper: parity with scalar lock_reason_path ─────────────────────────────
+
+
+def test_helper_feature_path_byte_equal_to_scalar(ent):
+    feats = sorted(ent.PAID_FEATURES)[:3]
+    out = ent.lock_reason_path_batch(
+        ent.TIER_OSS, ent.TIER_ENTERPRISE, features=feats
+    )
+    by_id = {item["key"]: item["path"] for item in out["features"]}
+    for fid in feats:
+        scalar = ent.lock_reason_path(
+            ent.TIER_OSS, ent.TIER_ENTERPRISE, fid, kind="feature"
+        )
+        assert by_id[fid] == scalar
+
+
+def test_helper_runtime_path_byte_equal_to_scalar(ent):
+    rts = sorted(ent.PAID_RUNTIMES)[:2]
+    out = ent.lock_reason_path_batch(
+        ent.TIER_OSS, ent.TIER_ENTERPRISE, runtimes=rts
+    )
+    by_id = {item["key"]: item["path"] for item in out["runtimes"]}
+    for rt in rts:
+        scalar = ent.lock_reason_path(
+            ent.TIER_OSS, ent.TIER_ENTERPRISE, rt, kind="runtime"
+        )
+        assert by_id[rt] == scalar
+
+
+@pytest.mark.parametrize(
+    "axis,value",
+    [
+        ("channels", 99),
+        ("retention_days", 365),
+        ("nodes", 50),
+    ],
+)
+def test_helper_capacity_path_byte_equal_to_scalar(ent, axis, value):
+    out = ent.lock_reason_path_batch(
+        ent.TIER_OSS, ent.TIER_ENTERPRISE, **{axis: value}
+    )
+    scalar = ent.lock_reason_path(
+        ent.TIER_OSS, ent.TIER_ENTERPRISE, str(value), kind=axis
+    )
+    assert out[axis] == {"key": str(value), "path": scalar}
+
+
+# ── helper: rung walk item-agnostic ─────────────────────────────────────────
+
+
+def test_helper_rung_walk_identical_across_items(ent):
+    feats = sorted(ent.PAID_FEATURES)[:2]
+    rts = sorted(ent.PAID_RUNTIMES)[:2]
+    out = ent.lock_reason_path_batch(
+        ent.TIER_OSS,
+        ent.TIER_ENTERPRISE,
+        features=feats,
+        runtimes=rts,
+        channels=99,
+        retention_days=365,
+        nodes=50,
+    )
+    sequences = []
+    for item in out["features"] + out["runtimes"]:
+        sequences.append([row["rung"] for row in item["path"]])
+    for axis in ("channels", "retention_days", "nodes"):
+        sequences.append([row["rung"] for row in out[axis]["path"]])
+    assert all(seq == sequences[0] for seq in sequences)
+    assert len(sequences[0]) >= 1
+
+
+def test_helper_each_path_row_carries_rung_and_lock_keys(ent):
+    out = ent.lock_reason_path_batch(
+        ent.TIER_OSS,
+        ent.TIER_ENTERPRISE,
+        features=["custom_alerts"],
+        runtimes=[_pick_paid_runtime(ent)],
+        channels=99,
+    )
+    for item in out["features"] + out["runtimes"]:
+        for row in item["path"]:
+            assert set(row).issuperset(_RUNG_KEYS)
+            assert set(row).issuperset(_ROW_KEYS)
+    for row in out["channels"]["path"]:
+        assert set(row).issuperset(_RUNG_KEYS)
+        assert set(row).issuperset(_ROW_KEYS)
+
+
+# ── helper: input normalisation + unknown bucketing ─────────────────────────
+
+
+def test_helper_normalises_feature_input(ent):
+    out = ent.lock_reason_path_batch(
+        ent.TIER_OSS,
+        ent.TIER_ENTERPRISE,
+        features=["  CUSTOM_ALERTS  ", "custom_alerts", ""],
+    )
+    assert [item["key"] for item in out["features"]] == ["custom_alerts"]
+
+
+def test_helper_canonicalises_runtime_aliases(ent):
+    # claude-code -> claude_code
+    out = ent.lock_reason_path_batch(
+        ent.TIER_OSS,
+        ent.TIER_ENTERPRISE,
+        runtimes=["claude-code", "claude_code"],
+    )
+    # Both inputs collapse to the same canonical id -> ONE row.
+    assert len(out["runtimes"]) == 1
+    assert out["runtimes"][0]["key"] == "claude_code"
+
+
+def test_helper_unknown_feature_ids_echo_in_unknown(ent):
+    out = ent.lock_reason_path_batch(
+        ent.TIER_OSS,
+        ent.TIER_ENTERPRISE,
+        features=["custom_alerts", "bogus_feat_id"],
+    )
+    assert [item["key"] for item in out["features"]] == ["custom_alerts"]
+    assert out["unknown"]["features"] == ["bogus_feat_id"]
+
+
+def test_helper_unknown_runtime_ids_echo_in_unknown(ent):
+    out = ent.lock_reason_path_batch(
+        ent.TIER_OSS,
+        ent.TIER_ENTERPRISE,
+        runtimes=[_pick_paid_runtime(ent), "bogus_runtime_alias"],
+    )
+    assert out["unknown"]["runtimes"] == ["bogus_runtime_alias"]
+
+
+def test_helper_supply_order_preserved_for_features(ent):
+    feats = sorted(ent.PAID_FEATURES)[:3]
+    reversed_feats = list(reversed(feats))
+    out = ent.lock_reason_path_batch(
+        ent.TIER_OSS, ent.TIER_ENTERPRISE, features=reversed_feats
+    )
+    assert [item["key"] for item in out["features"]] == reversed_feats
+
+
+# ── helper: capacity short-circuit ──────────────────────────────────────────
+
+
+@pytest.mark.parametrize("bad", [0, -1, None])
+def test_helper_capacity_short_circuit_on_bad_value(ent, bad):
+    out = ent.lock_reason_path_batch(
+        ent.TIER_OSS,
+        ent.TIER_ENTERPRISE,
+        features=["custom_alerts"],
+        channels=bad,
+    )
+    assert out["channels"] is None
+
+
+# ── helper: identity + lateral ──────────────────────────────────────────────
+
+
+def test_helper_identity_yields_empty_paths_per_item(ent):
+    out = ent.lock_reason_path_batch(
+        ent.TIER_OSS, ent.TIER_OSS, features=["custom_alerts", "sessions"]
+    )
+    for item in out["features"]:
+        assert item["path"] == []
+
+
+# ── helper: unknown / empty / garbage tier ──────────────────────────────────
+
+
+@pytest.mark.parametrize("bad", ["", "   ", "bogus_tier", None])
+def test_helper_unknown_from_tier_returns_none(ent, bad):
+    out = ent.lock_reason_path_batch(
+        bad, ent.TIER_ENTERPRISE, features=["custom_alerts"]
+    )
+    assert out is None
+
+
+@pytest.mark.parametrize("bad", ["", "   ", "bogus_tier", None])
+def test_helper_unknown_to_tier_returns_none(ent, bad):
+    out = ent.lock_reason_path_batch(
+        ent.TIER_OSS, bad, features=["custom_alerts"]
+    )
+    assert out is None
+
+
+# ── helper: grace vs enforce parity ─────────────────────────────────────────
+
+
+def test_helper_grace_vs_enforce_byte_identical(ent, monkeypatch):
+    base = ent.lock_reason_path_batch(
+        ent.TIER_OSS,
+        ent.TIER_ENTERPRISE,
+        features=["custom_alerts"],
+        runtimes=[_pick_paid_runtime(ent)],
+        channels=99,
+    )
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    enforced = ent.lock_reason_path_batch(
+        ent.TIER_OSS,
+        ent.TIER_ENTERPRISE,
+        features=["custom_alerts"],
+        runtimes=[_pick_paid_runtime(ent)],
+        channels=99,
+    )
+    assert base == enforced
+
+
+# ── HTTP: happy path ────────────────────────────────────────────────────────
+
+
+def test_api_returns_200_with_envelope(client, ent):
+    rt = _pick_paid_runtime(ent)
+    resp = client.get(
+        "/api/entitlement/lock-reason-path-batch"
+        f"?from=oss&to=enterprise&features=custom_alerts&runtimes={rt}"
+        "&channels=99&retention_days=365&nodes=50"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert set(body.keys()) == _ENVELOPE_KEYS
+    assert body["from"] == "oss"
+    assert body["to"] == "enterprise"
+    assert body["direction"] == "upgrade"
+    assert len(body["features"]) == 1
+    assert len(body["runtimes"]) == 1
+    assert body["channels"] is not None
+    assert body["retention_days"] is not None
+    assert body["nodes"] is not None
+    assert body["unknown"] == {"features": [], "runtimes": []}
+
+
+def test_api_runtime_alias_canonicalises(client):
+    resp = client.get(
+        "/api/entitlement/lock-reason-path-batch"
+        "?from=oss&to=enterprise&runtimes=claude-code"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert len(body["runtimes"]) == 1
+    assert body["runtimes"][0]["key"] == "claude_code"
+
+
+def test_api_unknown_feature_echoed_in_unknown_bucket(client):
+    resp = client.get(
+        "/api/entitlement/lock-reason-path-batch"
+        "?from=oss&to=enterprise&features=custom_alerts,bogus_id"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["unknown"]["features"] == ["bogus_id"]
+    assert [it["key"] for it in body["features"]] == ["custom_alerts"]
+
+
+def test_api_identity_yields_empty_per_item_paths(client):
+    resp = client.get(
+        "/api/entitlement/lock-reason-path-batch"
+        "?from=oss&to=oss&features=custom_alerts"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["direction"] == "identity"
+    assert body["features"][0]["path"] == []
+
+
+# ── HTTP: error paths ───────────────────────────────────────────────────────
+
+
+def test_api_400_on_missing_from(client):
+    resp = client.get(
+        "/api/entitlement/lock-reason-path-batch?to=enterprise"
+        "&features=custom_alerts"
+    )
+    assert resp.status_code == 400
+
+
+def test_api_400_on_missing_to(client):
+    resp = client.get(
+        "/api/entitlement/lock-reason-path-batch?from=oss"
+        "&features=custom_alerts"
+    )
+    assert resp.status_code == 400
+
+
+def test_api_400_on_no_axis_supplied(client):
+    resp = client.get(
+        "/api/entitlement/lock-reason-path-batch?from=oss&to=enterprise"
+    )
+    assert resp.status_code == 400
+
+
+def test_api_404_on_unknown_from_tier(client):
+    resp = client.get(
+        "/api/entitlement/lock-reason-path-batch"
+        "?from=bogus&to=enterprise&features=custom_alerts"
+    )
+    assert resp.status_code == 404
+    body = resp.get_json()
+    assert body["which"] == "tier"
+    assert body["tier"] == "bogus"
+
+
+def test_api_404_on_unknown_to_tier(client):
+    resp = client.get(
+        "/api/entitlement/lock-reason-path-batch"
+        "?from=oss&to=bogus&features=custom_alerts"
+    )
+    assert resp.status_code == 404
+
+
+# ── HTTP: parity with scalar /lock-reason-path ──────────────────────────────
+
+
+def test_api_feature_path_byte_equal_to_scalar_endpoint(client):
+    resp_batch = client.get(
+        "/api/entitlement/lock-reason-path-batch"
+        "?from=oss&to=enterprise&features=custom_alerts"
+    )
+    resp_scalar = client.get(
+        "/api/entitlement/lock-reason-path"
+        "?from=oss&to=enterprise&feature=custom_alerts"
+    )
+    assert resp_batch.status_code == 200 and resp_scalar.status_code == 200
+    batch_path = resp_batch.get_json()["features"][0]["path"]
+    scalar_path = resp_scalar.get_json()["path"]
+    assert batch_path == scalar_path


### PR DESCRIPTION
## Summary

Multi-axis batch sibling of `lock_reason_path`. Where the scalar path helper walks ONE item across the rungs between two tiers, this walks N items across all 5 axes (features + runtimes + 3 capacity axes) in ONE round-trip.

Pairs with `lock_reason_path` the same way `lock_reasons_at_batch` pairs with `lock_reason_at`: scalar what-if -> matrix what-if. A paywall comparison surface can render the full matrix off ONE call instead of N calls to `/lock-reason-path` per item.

## Helper

```python
def lock_reason_path_batch(
    from_tier: str,
    to_tier: str,
    *,
    features=None,
    runtimes=None,
    channels: int | None = None,
    retention_days: int | None = None,
    nodes: int | None = None,
) -> dict | None
```

Returned shape (mirrors `lock_reasons_at_batch` plus per-row paths):

```
{
  "features": [{"key": "<id>", "path": [<augmented row>, ...]}, ...],
  "runtimes": [{"key": "<canonical id>", "path": [...]}, ...],
  "channels":       {"key": "<n>", "path": [...]} | None,
  "retention_days": {"key": "<n>", "path": [...]} | None,
  "nodes":          {"key": "<n>", "path": [...]} | None,
  "unknown": {"features": [...], "runtimes": [...]},
}
```

Each per-item `path` is byte-identical to a row from the scalar `lock_reason_path` for the same `(from, to, item, kind)` tuple — pinned by the parity tests so the scalar and batch path helpers cannot drift. Rung walk is item-agnostic, so all per-item paths share the same length and rung sequence — the client can render the matrix as rows = items × cols = rungs without re-deriving the column headers per item.

## Route

`GET /api/entitlement/lock-reason-path-batch?from=<id>&to=<id>&features=a,b,c&runtimes=x,y&channels=N&retention_days=K&nodes=M`

Envelope mirrors `/feature-spec-path-batch` (from / from_label / from_rank / to / to_label / to_rank / direction) plus the 5-axis body of `/lock-reasons-at-batch` plus structured `unknown.features` / `unknown.runtimes`.

- Feature/runtime input normalised (whitespace stripped, lowercased, duplicates dropped, first-seen order preserved); runtime aliases canonicalised (`claude-code` → `claude_code`) and collapsed against already-supplied canonical ids
- Unknown ids echoed in `unknown[...]` instead of 404'ing the call
- Capacity axes single-item; `None` / non-positive / non-int values render that axis as `None` (matches `lock_reason_path`'s short-circuit posture)
- `400` on missing tier / no axis supplied; `404` on unknown tier; never 5xxs on row failure
- Grace vs enforce yields byte-identical rows (helper synthesises a fresh `Entitlement` per rung with `grace=False`)

## Tests

38 new tests in `tests/test_entitlement_lock_reason_path_batch.py` covering:

- envelope shape (5-axis body + structured unknown bucket)
- per-axis parity with scalar `lock_reason_path` (feature, runtime, capacity)
- item-agnostic rung walk (all per-item paths share the same rung sequence)
- per-row keys (the 8 `_lock_row` keys + 3 `rung*` keys)
- input normalisation + alias canonicalisation + alias collapse
- unknown feature/runtime id bucketing
- capacity short-circuit on bad value (0, -1, None)
- identity `from == to` yields empty per-item paths
- unknown / empty / garbage tier returns `None` (helper) / 400 / 404 (HTTP)
- grace vs enforce byte-parity
- HTTP 400 / 404 / 200 paths, alias canonicalisation surfacing at the HTTP layer, parity with the scalar `/lock-reason-path` endpoint

```
38 passed in 0.59s
```

The 158 sibling tests (`test_entitlement_lock_reason_path.py`, `test_entitlement_spec_path_batch.py`, `test_entitlement_lock_reasons_at_batch.py`, `test_entitlement_lock_reason_batch.py`) all still pass.

## Test plan

- [ ] `python -m pytest tests/test_entitlement_lock_reason_path_batch.py -v`
- [ ] Spot-check parity: `/api/entitlement/lock-reason-path-batch?from=oss&to=enterprise&features=custom_alerts` `features[0].path` matches `/api/entitlement/lock-reason-path?from=oss&to=enterprise&feature=custom_alerts` `.path`

## Local operator verification checklist

(Required because this remote session has no access to the live daemon, `~/.openclaw`, the cloud snapshot, or a browser.)

- [ ] Pull the branch locally: `git fetch origin feat/entitlement-lock-reason-path-batch && git checkout feat/entitlement-lock-reason-path-batch`
- [ ] Copy changed files into the live install:
  - `cp clawmetry/entitlements.py ~/.clawmetry/lib/python*/site-packages/clawmetry/entitlements.py`
  - `cp routes/entitlement.py ~/.clawmetry/lib/python*/site-packages/routes/entitlement.py`
- [ ] Clear caches: `find ~/.clawmetry/lib -name __pycache__ -type d -exec rm -rf {} +`
- [ ] Restart the daemon: `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
- [ ] Hit the new endpoint: `curl -s '``http://localhost:8900/api/entitlement/lock-reason-path-batch?from=oss&to=enterprise&features=custom_alerts,sessions&runtimes=claude-code&channels=99&retention_days=365&nodes=50'`` | jq`
- [ ] Confirm the body has the 5-axis structure + `unknown.features` / `unknown.runtimes` + matching `from_*` / `to_*` echo
- [ ] Decrypt the live cloud snapshot client-side and browser-check that nothing regressed on the entitlement UI
- [ ] Promote out of draft when satisfied

This PR stays in **grace mode**: no behaviour change to any existing endpoint, no enforce gate flipped, no `__version__` bump, no release tag. The next-phase work (P3/P4/P6 — cloud-side entitlement minting, `clawmetry-pro` package download, enterprise SSO) needs the private `clawmetry-cloud` / `clawmetry-pro` repos and is out of scope for this remote session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_018KnMVAi7fgEQjvEQjhHtRy)_