### PR TITLE
feat(entitlement): next/previous_tier_{feature,runtime}_spec_at_batch + 4 endpoints

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -7491,3 +7491,275 @@ def lock_reason_path_batch(
             "runtimes": unknown_runtimes,
         },
     }
+
+
+def next_tier_feature_spec_at_batch(tier: str, features) -> dict | None:
+    """Batch sibling of :func:`next_tier_feature_spec_at`: per-feature
+    ``feature_spec_at``-shape rows evaluated on the rung above the caller-
+    supplied source ``tier`` for N features in ONE round-trip.
+
+    Composes :func:`next_tier_feature_spec_at` (scalar projection) and
+    :func:`feature_spec_at_batch` (batch what-if) -- same target
+    (`_next_purchasable_tier_after(tier)`) as the scalar, same per-feature
+    shape as the batch helper. Lets a paywall "does THIS column of
+    features unlock at my next rung?" pricing-comparison surface render
+    every feature off ONE call instead of N calls to
+    :func:`next_tier_feature_spec_at`.
+
+    Per-feature row shape::
+
+        {"feature": "<id>", "row": <feature_spec_at row> | None}
+
+    Each ``row`` is byte-identical to
+    :func:`next_tier_feature_spec_at(tier, feature)` (which itself equals
+    :func:`feature_spec_at(target, feature)` byte-for-byte at the
+    resolved target) -- pinned by parity tests so the scalar and batch
+    accessors cannot drift. At the ceiling (enterprise as source, no rung
+    above) every ``row`` is ``None`` while the per-feature envelope
+    entries still render so the matrix's row count stays stable.
+
+    Shape::
+
+        {
+          "features": [
+            {"feature": "<id>", "row": <row> | None},
+            ...
+          ],
+          "unknown": ["bogus_id", ...],
+        }
+
+    Supplied feature ids are normalised via :func:`_normalise_csv`
+    (whitespace stripped, lowercased, duplicates dropped, first-seen
+    order preserved). Unknown ids are echoed in ``unknown[]`` rather
+    than short-circuiting -- a partially-bad caller still gets rows
+    back for the valid ids alongside a list of what was dropped,
+    matching :func:`feature_spec_at_batch`'s posture.
+
+    Returns ``None`` for empty / unknown ``tier`` (caller renders
+    "unknown tier" / 404). Resolver-independent: delegates to
+    :func:`feature_spec_at` against the synthesised hypothetical
+    entitlement -- grace vs enforce yields byte-identical rows. Never
+    raises: a per-feature failure short-circuits that feature into
+    ``unknown[]`` and the rest of the batch keeps building.
+    """
+    try:
+        src = (tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if not src or src not in _TIER_ORDER:
+        return None
+    feats = _normalise_csv(features)
+    try:
+        target = _next_purchasable_tier_after(src)
+    except Exception as exc:
+        logger.warning(
+            "entitlements: next_tier_feature_spec_at_batch target resolve failed: %s",
+            exc,
+        )
+        target = None
+    rows: list[dict] = []
+    unknown: list[str] = []
+    for fid in feats:
+        if fid not in ALL_FEATURES:
+            unknown.append(fid)
+            continue
+        try:
+            row = feature_spec_at(target, fid) if target else None
+        except Exception as exc:
+            logger.warning(
+                "entitlements: next_tier_feature_spec_at_batch row %r failed: %s",
+                fid,
+                exc,
+            )
+            unknown.append(fid)
+            continue
+        rows.append({"feature": fid, "row": row})
+    return {"features": rows, "unknown": unknown}
+
+
+def previous_tier_feature_spec_at_batch(tier: str, features) -> dict | None:
+    """Source-anchored mirror of :func:`next_tier_feature_spec_at_batch`
+    -- batch sibling of :func:`previous_tier_feature_spec_at` walking N
+    features against the rung BELOW the caller-supplied ``tier`` in ONE
+    round-trip.
+
+    Same per-feature row shape and same normalisation / unknown-bucket
+    posture as :func:`next_tier_feature_spec_at_batch`. At the floor
+    (``oss`` / ``cloud_free`` as source, no rung below) every ``row`` is
+    ``None`` while per-feature entries still render so the downgrade-
+    confirmation surface's row count stays stable.
+
+    Each ``row`` is byte-identical to
+    :func:`previous_tier_feature_spec_at(tier, feature)` (which itself
+    equals :func:`feature_spec_at(target, feature)` byte-for-byte at the
+    resolved target).
+
+    Returns ``None`` for empty / unknown ``tier``. Never raises.
+    """
+    try:
+        src = (tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if not src or src not in _TIER_ORDER:
+        return None
+    feats = _normalise_csv(features)
+    try:
+        target = _previous_purchasable_tier_before(src)
+    except Exception as exc:
+        logger.warning(
+            "entitlements: previous_tier_feature_spec_at_batch target resolve failed: %s",
+            exc,
+        )
+        target = None
+    rows: list[dict] = []
+    unknown: list[str] = []
+    for fid in feats:
+        if fid not in ALL_FEATURES:
+            unknown.append(fid)
+            continue
+        try:
+            row = feature_spec_at(target, fid) if target else None
+        except Exception as exc:
+            logger.warning(
+                "entitlements: previous_tier_feature_spec_at_batch row %r failed: %s",
+                fid,
+                exc,
+            )
+            unknown.append(fid)
+            continue
+        rows.append({"feature": fid, "row": row})
+    return {"features": rows, "unknown": unknown}
+
+
+def next_tier_runtime_spec_at_batch(tier: str, runtimes) -> dict | None:
+    """Runtime-axis twin of :func:`next_tier_feature_spec_at_batch` --
+    batch sibling of :func:`next_tier_runtime_spec_at` walking N runtimes
+    against the rung ABOVE the caller-supplied ``tier`` in ONE
+    round-trip.
+
+    Per-runtime row shape::
+
+        {"runtime": "<canonical id>", "row": <runtime_spec_at row> | None}
+
+    Each ``row`` is byte-identical to
+    :func:`next_tier_runtime_spec_at(tier, runtime)`. Aliases are
+    canonicalised via :func:`canonical_runtime` (``claude-code`` ->
+    ``claude_code``) and aliases that collapse to a canonical id already
+    in the response are silently de-duplicated -- same behaviour as
+    :func:`runtime_spec_at_batch`. The per-row ``runtime`` value carries
+    the canonical id, never the supplied alias.
+
+    At the ceiling every ``row`` is ``None`` while the per-runtime
+    envelope entries still render so the matrix's row count stays
+    stable.
+
+    Shape::
+
+        {
+          "runtimes": [
+            {"runtime": "<canonical id>", "row": <row> | None},
+            ...
+          ],
+          "unknown": ["bogus_id", ...],
+        }
+
+    Returns ``None`` for empty / unknown ``tier``. Never raises: per-
+    runtime failures short-circuit that runtime into ``unknown[]``
+    (carrying the supplied alias, not the canonical id, so the caller
+    can correlate against what was sent) and the rest of the batch keeps
+    building.
+    """
+    try:
+        src = (tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if not src or src not in _TIER_ORDER:
+        return None
+    rts = _normalise_csv(runtimes)
+    try:
+        target = _next_purchasable_tier_after(src)
+    except Exception as exc:
+        logger.warning(
+            "entitlements: next_tier_runtime_spec_at_batch target resolve failed: %s",
+            exc,
+        )
+        target = None
+    rows: list[dict] = []
+    unknown: list[str] = []
+    seen: set[str] = set()
+    for raw in rts:
+        canon = canonical_runtime(raw)
+        if not canon or canon not in ALL_RUNTIMES:
+            unknown.append(raw)
+            continue
+        if canon in seen:
+            continue
+        try:
+            row = runtime_spec_at(target, canon) if target else None
+        except Exception as exc:
+            logger.warning(
+                "entitlements: next_tier_runtime_spec_at_batch row %r failed: %s",
+                raw,
+                exc,
+            )
+            unknown.append(raw)
+            continue
+        seen.add(canon)
+        rows.append({"runtime": canon, "row": row})
+    return {"runtimes": rows, "unknown": unknown}
+
+
+def previous_tier_runtime_spec_at_batch(tier: str, runtimes) -> dict | None:
+    """Source-anchored mirror of :func:`next_tier_runtime_spec_at_batch`
+    -- batch sibling of :func:`previous_tier_runtime_spec_at` walking N
+    runtimes against the rung BELOW the caller-supplied ``tier`` in ONE
+    round-trip.
+
+    Same per-runtime row shape, alias canonicalisation, alias collapse,
+    and ``unknown[]``-carries-supplied-alias posture as
+    :func:`next_tier_runtime_spec_at_batch`. At the floor every ``row``
+    is ``None`` while per-runtime entries still render.
+
+    Each ``row`` is byte-identical to
+    :func:`previous_tier_runtime_spec_at(tier, runtime)`.
+
+    Returns ``None`` for empty / unknown ``tier``. Never raises.
+    """
+    try:
+        src = (tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if not src or src not in _TIER_ORDER:
+        return None
+    rts = _normalise_csv(runtimes)
+    try:
+        target = _previous_purchasable_tier_before(src)
+    except Exception as exc:
+        logger.warning(
+            "entitlements: previous_tier_runtime_spec_at_batch target resolve failed: %s",
+            exc,
+        )
+        target = None
+    rows: list[dict] = []
+    unknown: list[str] = []
+    seen: set[str] = set()
+    for raw in rts:
+        canon = canonical_runtime(raw)
+        if not canon or canon not in ALL_RUNTIMES:
+            unknown.append(raw)
+            continue
+        if canon in seen:
+            continue
+        try:
+            row = runtime_spec_at(target, canon) if target else None
+        except Exception as exc:
+            logger.warning(
+                "entitlements: previous_tier_runtime_spec_at_batch row %r failed: %s",
+                raw,
+                exc,
+            )
+            unknown.append(raw)
+            continue
+        seen.add(canon)
+        rows.append({"runtime": canon, "row": row})
+    return {"runtimes": rows, "unknown": unknown}

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -7427,3 +7427,268 @@ def api_entitlement_lock_reason_path_batch():
                 "unknown": {"features": [], "runtimes": []},
             }
         )
+
+
+def _next_prev_tier_feature_spec_at_batch(
+    direction: str,
+):
+    """Shared helper for the two ``/api/entitlement/{next,previous}-tier-
+    feature-spec-at-batch`` handlers.
+
+    ``direction`` selects the rung helper (``next`` / ``previous``).
+    Returned envelope shape is identical for both directions so the
+    paywall surface can swap one URL for the other without re-deriving
+    the row schema.
+    """
+    raw_tier = request.args.get("tier")
+    tier_in = (raw_tier or "").strip().lower()
+    if not tier_in:
+        return jsonify({"error": "missing tier"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        if tier_in not in _ent._TIER_ORDER:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "tier", "tier": tier_in}
+                ),
+                404,
+            )
+        features = _parse_csv_arg("features")
+        if not features:
+            return jsonify({"error": "supply features=<csv>"}), 400
+        if direction == "next":
+            target = _ent._next_purchasable_tier_after(tier_in)
+            batch = _ent.next_tier_feature_spec_at_batch(tier_in, features)
+        else:
+            target = _ent._previous_purchasable_tier_before(tier_in)
+            batch = _ent.previous_tier_feature_spec_at_batch(tier_in, features)
+        if batch is None:
+            batch = {"features": [], "unknown": []}
+        return jsonify(
+            {
+                "tier": tier_in,
+                "tier_label": _ent.tier_label(tier_in),
+                "tier_rank": _ent.tier_rank(tier_in),
+                "target": target,
+                "target_label": _ent.tier_label(target) if target else None,
+                "target_rank": _ent.tier_rank(target) if target else None,
+                "features": batch.get("features", []),
+                "unknown": batch.get("unknown", []),
+            }
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_%s_tier_feature_spec_at_batch: error: %s",
+            direction,
+            exc,
+        )
+        return jsonify(
+            {
+                "tier": tier_in,
+                "tier_label": None,
+                "tier_rank": -1,
+                "target": None,
+                "target_label": None,
+                "target_rank": None,
+                "features": [],
+                "unknown": [],
+            }
+        )
+
+
+def _next_prev_tier_runtime_spec_at_batch(
+    direction: str,
+):
+    """Runtime-axis twin of :func:`_next_prev_tier_feature_spec_at_batch`.
+    Aliases are canonicalised one layer below in the helper -- this
+    wrapper just shuttles the supplied CSV through ``_parse_csv_arg``
+    and lets the helper de-duplicate, mirroring ``/runtime-spec-path-
+    batch``.
+    """
+    raw_tier = request.args.get("tier")
+    tier_in = (raw_tier or "").strip().lower()
+    if not tier_in:
+        return jsonify({"error": "missing tier"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        if tier_in not in _ent._TIER_ORDER:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "tier", "tier": tier_in}
+                ),
+                404,
+            )
+        runtimes = _parse_csv_arg("runtimes")
+        if not runtimes:
+            return jsonify({"error": "supply runtimes=<csv>"}), 400
+        if direction == "next":
+            target = _ent._next_purchasable_tier_after(tier_in)
+            batch = _ent.next_tier_runtime_spec_at_batch(tier_in, runtimes)
+        else:
+            target = _ent._previous_purchasable_tier_before(tier_in)
+            batch = _ent.previous_tier_runtime_spec_at_batch(tier_in, runtimes)
+        if batch is None:
+            batch = {"runtimes": [], "unknown": []}
+        return jsonify(
+            {
+                "tier": tier_in,
+                "tier_label": _ent.tier_label(tier_in),
+                "tier_rank": _ent.tier_rank(tier_in),
+                "target": target,
+                "target_label": _ent.tier_label(target) if target else None,
+                "target_rank": _ent.tier_rank(target) if target else None,
+                "runtimes": batch.get("runtimes", []),
+                "unknown": batch.get("unknown", []),
+            }
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_%s_tier_runtime_spec_at_batch: error: %s",
+            direction,
+            exc,
+        )
+        return jsonify(
+            {
+                "tier": tier_in,
+                "tier_label": None,
+                "tier_rank": -1,
+                "target": None,
+                "target_label": None,
+                "target_rank": None,
+                "runtimes": [],
+                "unknown": [],
+            }
+        )
+
+
+@bp_entitlement.route("/api/entitlement/next-tier-feature-spec-at-batch")
+def api_entitlement_next_tier_feature_spec_at_batch():
+    """``GET /api/entitlement/next-tier-feature-spec-at-batch?tier=<source>
+    &features=a,b,c`` -- batch sibling of
+    ``/api/entitlement/next-tier-feature-spec-at``.
+
+    Where ``/next-tier-feature-spec-at`` projects ONE feature onto the
+    rung above the caller-supplied source, this projects N features
+    onto that same rung in ONE round-trip. Pairs with
+    ``/next-tier-feature-spec-at`` the same way
+    ``/feature-spec-at-batch`` pairs with ``/feature-spec-at``: scalar
+    what-if -> batch what-if.
+
+    Use case: a pricing-comparison "here are the 6 features I care
+    about -- what do they look like at my next rung?" surface hydrates
+    every feature off ONE call instead of N calls to
+    ``/next-tier-feature-spec-at``.
+
+    Each row in ``features[].row`` is byte-identical to the body of
+    ``/next-tier-feature-spec-at?tier=<source>&feature=<id>`` ``.row``
+    -- pinned by parity tests so the scalar and batch accessors cannot
+    drift. Supplied feature ids are normalised (whitespace stripped,
+    lowercased, duplicates dropped, first-seen order preserved). Unknown
+    ids do not 404 the call -- they are echoed in ``unknown[]`` so a
+    partially-bad caller still gets rows back for the valid ids.
+
+    At the ceiling (enterprise as source, no rung above) every per-
+    feature ``row`` is ``null`` while the envelope's ``target`` /
+    ``target_label`` / ``target_rank`` collapse to ``null`` -- the
+    surface stays 200 so callers can render "you're at the top" copy
+    without a status-code branch.
+
+    Response shape::
+
+        {
+          "tier":         "<source tier id>",
+          "tier_label":   "<source label>",
+          "tier_rank":    <source rank>,
+          "target":       "<next-above tier id>" | null,
+          "target_label": "<next-above label>" | null,
+          "target_rank":  <next-above rank> | null,
+          "features": [
+            {"feature": "<id>", "row": {<feature_spec_at row>} | null},
+            ...
+          ],
+          "unknown": ["bogus_id", ...],
+        }
+
+    - **400** when ``tier=`` is missing / blank, or ``features=`` is
+      missing / empty after normalisation
+    - **404** when ``tier`` is unknown (body carries ``which: "tier"``)
+    - **Never 5xxs**: a synthesis failure short-circuits to an envelope
+      with empty rows so the matrix keeps rendering.
+    """
+    return _next_prev_tier_feature_spec_at_batch("next")
+
+
+@bp_entitlement.route("/api/entitlement/previous-tier-feature-spec-at-batch")
+def api_entitlement_previous_tier_feature_spec_at_batch():
+    """``GET /api/entitlement/previous-tier-feature-spec-at-batch
+    ?tier=<source>&features=a,b,c`` -- source-anchored mirror of
+    ``/api/entitlement/next-tier-feature-spec-at-batch`` and batch
+    sibling of ``/api/entitlement/previous-tier-feature-spec-at``.
+
+    Lets a downgrade-confirmation card render "here are the N features
+    I care about -- do they still unlock one rung down?" off ONE round-
+    trip instead of N calls to ``/previous-tier-feature-spec-at``.
+
+    Each row in ``features[].row`` is byte-identical to the body of
+    ``/previous-tier-feature-spec-at?tier=<source>&feature=<id>``
+    ``.row``. At the floor (``oss`` / ``cloud_free`` as source) every
+    per-feature ``row`` is ``null`` while ``target`` / ``target_label``
+    / ``target_rank`` collapse to ``null``.
+
+    Response shape, validation, and never-5xx posture are identical to
+    ``/next-tier-feature-spec-at-batch``.
+    """
+    return _next_prev_tier_feature_spec_at_batch("previous")
+
+
+@bp_entitlement.route("/api/entitlement/next-tier-runtime-spec-at-batch")
+def api_entitlement_next_tier_runtime_spec_at_batch():
+    """``GET /api/entitlement/next-tier-runtime-spec-at-batch?tier=<source>
+    &runtimes=a,b,c`` -- runtime-axis twin of
+    ``/api/entitlement/next-tier-feature-spec-at-batch``.
+
+    Aliases are canonicalised the same way ``/next-tier-runtime-spec-at``
+    already does (``claude-code`` -> ``claude_code``), and aliases that
+    collapse to a canonical id already in the response are silently
+    de-duplicated so the row count matches the unique-canonical-id
+    count.
+
+    Each row in ``runtimes[].row`` is byte-identical to the body of
+    ``/next-tier-runtime-spec-at?tier=<source>&runtime=<id>`` ``.row``.
+    Unknown ids do not 404 the call -- they are echoed in ``unknown[]``
+    carrying the supplied alias so the caller can correlate against
+    what was sent.
+
+    At the ceiling every per-runtime ``row`` is ``null`` while
+    ``target`` / ``target_label`` / ``target_rank`` collapse to
+    ``null``.
+
+    Response shape mirrors ``/next-tier-feature-spec-at-batch`` with
+    ``"runtimes"`` in place of ``"features"`` and a per-row
+    ``"runtime"`` key (canonical id) in place of ``"feature"``.
+
+    - **400** when ``tier=`` is missing or ``runtimes=`` is missing /
+      empty after normalisation
+    - **404** when ``tier`` is unknown
+    - **Never 5xxs**.
+    """
+    return _next_prev_tier_runtime_spec_at_batch("next")
+
+
+@bp_entitlement.route("/api/entitlement/previous-tier-runtime-spec-at-batch")
+def api_entitlement_previous_tier_runtime_spec_at_batch():
+    """``GET /api/entitlement/previous-tier-runtime-spec-at-batch
+    ?tier=<source>&runtimes=a,b,c`` -- source-anchored mirror of
+    ``/api/entitlement/next-tier-runtime-spec-at-batch`` and batch
+    sibling of ``/api/entitlement/previous-tier-runtime-spec-at``.
+
+    Each row in ``runtimes[].row`` is byte-identical to the body of
+    ``/previous-tier-runtime-spec-at?tier=<source>&runtime=<id>``
+    ``.row``. At the floor every per-runtime ``row`` is ``null``.
+
+    Response shape, alias handling, validation, and never-5xx posture
+    are identical to ``/next-tier-runtime-spec-at-batch``.
+    """
+    return _next_prev_tier_runtime_spec_at_batch("previous")

--- a/tests/test_entitlement_next_prev_tier_feature_runtime_spec_at_batch.py
+++ b/tests/test_entitlement_next_prev_tier_feature_runtime_spec_at_batch.py
@@ -1,0 +1,666 @@
+"""Tests for the four batch siblings of
+:func:`clawmetry.entitlements.next_tier_feature_spec_at` /
+:func:`previous_tier_feature_spec_at` /
+:func:`next_tier_runtime_spec_at` /
+:func:`previous_tier_runtime_spec_at`, and the four companion
+``/api/entitlement/{next,previous}-tier-{feature,runtime}-spec-at-batch``
+endpoints.
+
+Where the scalar projections walk ONE feature/runtime onto the rung
+above/below a source tier, the batch siblings walk N items onto that
+same rung in ONE round-trip. They compose:
+
+* :func:`next_tier_feature_spec_at` (scalar projection) +
+  :func:`feature_spec_at_batch` (batch what-if) ->
+  :func:`next_tier_feature_spec_at_batch`
+
+* :func:`feature_spec_path_batch` (batch path) ->
+  :func:`next_tier_feature_spec_at_batch` (batch what-if)
+
+Pins covered here:
+
+* per-row byte-equality with the scalar sibling for every valid
+  (source, item) pair across every purchasable source tier (parity)
+* item-agnostic target resolution: every per-item row resolves
+  ``feature_spec_at(target, item)`` (or ``None`` at ceiling/floor)
+* ceiling (enterprise as source for ``next_*``) / floor
+  (``oss`` / ``cloud_free`` as source for ``previous_*``) yields
+  ``row=None`` for every valid item -- envelope rows still render
+* trial-as-source resolves the same way the sibling ``_at`` families do
+  (next -> enterprise, previous -> cloud_starter)
+* unknown / empty / whitespace / case-insensitive id handling
+* runtime alias resolution (``claude-code`` -> ``claude_code``) on
+  helper and API, alias-to-canonical collapse de-duplicates
+* unknown ids echo into ``unknown[]`` (carrying the supplied alias for
+  the runtime axis, the lowercased id for the feature axis) rather
+  than 404'ing the call
+* normalisation is whitespace-stripped, lowercased, first-seen order
+  preserved, duplicate-dropped (matches ``_normalise_csv``)
+* grace vs enforce yields the same body (catalogue-derived, not gated)
+* the helpers never raise -- a per-row builder failure short-circuits
+  that row into ``unknown[]`` rather than 500-ing
+* the four API endpoints never 5xx: 400 on missing input, 404 on
+  unknown tier, 200 with ``row=null`` rows at ceiling/floor; an
+  internal failure yields the same 200 envelope shape
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+_ENVELOPE_FEATURE_KEYS = {
+    "tier",
+    "tier_label",
+    "tier_rank",
+    "target",
+    "target_label",
+    "target_rank",
+    "features",
+    "unknown",
+}
+
+_ENVELOPE_RUNTIME_KEYS = {
+    "tier",
+    "tier_label",
+    "tier_rank",
+    "target",
+    "target_label",
+    "target_rank",
+    "runtimes",
+    "unknown",
+}
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# ── next_tier_feature_spec_at_batch (helper) ─────────────────────────────────
+
+
+def test_next_feature_batch_row_byte_equals_scalar(ent):
+    # Per-row body equals next_tier_feature_spec_at(src, feature) byte-for-byte
+    # across every purchasable source for every feature. Pins so the batch
+    # accessor cannot drift from the scalar projection.
+    feats = sorted(ent.ALL_FEATURES)
+    for src in ent._PURCHASABLE_TIERS:
+        body = ent.next_tier_feature_spec_at_batch(src, feats)
+        assert body is not None
+        assert body["unknown"] == []
+        for row in body["features"]:
+            assert row["row"] == ent.next_tier_feature_spec_at(src, row["feature"])
+
+
+def test_next_feature_batch_returns_row_null_at_ceiling(ent):
+    # Enterprise is the top of the purchasable ladder -- no rung above. Every
+    # valid feature must surface as a row with row=None so the matrix's row
+    # count stays stable (the surface can still render "you're at the top").
+    feats = sorted(ent.ALL_FEATURES)
+    body = ent.next_tier_feature_spec_at_batch(ent.TIER_ENTERPRISE, feats)
+    assert body is not None
+    assert body["unknown"] == []
+    assert [r["feature"] for r in body["features"]] == feats
+    assert all(r["row"] is None for r in body["features"])
+
+
+def test_next_feature_batch_trial_resolves_to_enterprise(ent):
+    body = ent.next_tier_feature_spec_at_batch(ent.TIER_TRIAL, ["custom_alerts"])
+    assert body is not None
+    assert body["features"] == [
+        {
+            "feature": "custom_alerts",
+            "row": ent.feature_spec_at(ent.TIER_ENTERPRISE, "custom_alerts"),
+        }
+    ]
+
+
+def test_next_feature_batch_unknown_inputs_short_circuit(ent):
+    # Empty / None / unknown tier -> helper returns None (HTTP wrapper turns
+    # into 400 / 404). Unknown feature ids are bucketed into unknown[].
+    assert ent.next_tier_feature_spec_at_batch("", ["custom_alerts"]) is None
+    assert ent.next_tier_feature_spec_at_batch(None, ["custom_alerts"]) is None
+    assert ent.next_tier_feature_spec_at_batch("bogus", ["custom_alerts"]) is None
+    body = ent.next_tier_feature_spec_at_batch(
+        ent.TIER_CLOUD_STARTER, ["custom_alerts", "no_such", "also_bogus"]
+    )
+    assert body is not None
+    assert [r["feature"] for r in body["features"]] == ["custom_alerts"]
+    assert body["unknown"] == ["no_such", "also_bogus"]
+
+
+def test_next_feature_batch_normalises_input(ent):
+    # Whitespace stripped, lowercased, duplicates dropped, first-seen order
+    # preserved -- matches _normalise_csv.
+    body = ent.next_tier_feature_spec_at_batch(
+        ent.TIER_CLOUD_STARTER,
+        [" CUSTOM_ALERTS ", "custom_alerts", "", "CUSTOM_ALERTS"],
+    )
+    assert body is not None
+    assert [r["feature"] for r in body["features"]] == ["custom_alerts"]
+    assert body["unknown"] == []
+
+
+def test_next_feature_batch_empty_features_returns_empty_rows(ent):
+    # An empty caller-supplied list returns {features: [], unknown: []} --
+    # the HTTP layer turns that into a 400, the helper itself does not raise.
+    body = ent.next_tier_feature_spec_at_batch(ent.TIER_CLOUD_STARTER, [])
+    assert body == {"features": [], "unknown": []}
+
+
+def test_next_feature_batch_grace_and_enforce_match(ent, monkeypatch):
+    feats = sorted(ent.ALL_FEATURES)
+    grace = ent.next_tier_feature_spec_at_batch(ent.TIER_CLOUD_STARTER, feats)
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    importlib.reload(ent)
+    ent.invalidate()
+    enforce = ent.next_tier_feature_spec_at_batch(ent.TIER_CLOUD_STARTER, feats)
+    assert enforce == grace
+
+
+def test_next_feature_batch_row_failure_buckets_into_unknown(ent, monkeypatch):
+    # A synthesised failure in feature_spec_at short-circuits that row into
+    # unknown[] and the rest of the batch keeps building.
+    real_spec_at = ent.feature_spec_at
+
+    def fake_spec_at(tier, feature):
+        if feature == "custom_alerts":
+            raise RuntimeError("synthetic")
+        return real_spec_at(tier, feature)
+
+    monkeypatch.setattr(ent, "feature_spec_at", fake_spec_at)
+    body = ent.next_tier_feature_spec_at_batch(
+        ent.TIER_CLOUD_STARTER, ["custom_alerts", "sso"]
+    )
+    assert body is not None
+    assert [r["feature"] for r in body["features"]] == ["sso"]
+    assert body["unknown"] == ["custom_alerts"]
+
+
+# ── previous_tier_feature_spec_at_batch (helper) ─────────────────────────────
+
+
+def test_previous_feature_batch_row_byte_equals_scalar(ent):
+    feats = sorted(ent.ALL_FEATURES)
+    for src in ent._PURCHASABLE_TIERS:
+        body = ent.previous_tier_feature_spec_at_batch(src, feats)
+        assert body is not None
+        for row in body["features"]:
+            assert row["row"] == ent.previous_tier_feature_spec_at(
+                src, row["feature"]
+            )
+
+
+def test_previous_feature_batch_returns_row_null_at_floor(ent):
+    feats = sorted(ent.ALL_FEATURES)
+    for src in (ent.TIER_OSS, ent.TIER_CLOUD_FREE):
+        body = ent.previous_tier_feature_spec_at_batch(src, feats)
+        assert body is not None
+        assert [r["feature"] for r in body["features"]] == feats
+        assert all(r["row"] is None for r in body["features"])
+
+
+def test_previous_feature_batch_trial_resolves_to_starter(ent):
+    body = ent.previous_tier_feature_spec_at_batch(
+        ent.TIER_TRIAL, ["custom_alerts"]
+    )
+    assert body is not None
+    assert body["features"] == [
+        {
+            "feature": "custom_alerts",
+            "row": ent.feature_spec_at(ent.TIER_CLOUD_STARTER, "custom_alerts"),
+        }
+    ]
+
+
+def test_previous_feature_batch_unknown_inputs_short_circuit(ent):
+    assert (
+        ent.previous_tier_feature_spec_at_batch("", ["custom_alerts"]) is None
+    )
+    assert (
+        ent.previous_tier_feature_spec_at_batch("bogus", ["custom_alerts"])
+        is None
+    )
+    body = ent.previous_tier_feature_spec_at_batch(
+        ent.TIER_CLOUD_PRO, ["custom_alerts", "no_such"]
+    )
+    assert body is not None
+    assert [r["feature"] for r in body["features"]] == ["custom_alerts"]
+    assert body["unknown"] == ["no_such"]
+
+
+# ── next_tier_runtime_spec_at_batch (helper) ─────────────────────────────────
+
+
+def test_next_runtime_batch_row_byte_equals_scalar(ent):
+    rts = sorted(ent.ALL_RUNTIMES)
+    for src in ent._PURCHASABLE_TIERS:
+        body = ent.next_tier_runtime_spec_at_batch(src, rts)
+        assert body is not None
+        assert body["unknown"] == []
+        for row in body["runtimes"]:
+            assert row["row"] == ent.next_tier_runtime_spec_at(src, row["runtime"])
+
+
+def test_next_runtime_batch_returns_row_null_at_ceiling(ent):
+    rts = sorted(ent.ALL_RUNTIMES)
+    body = ent.next_tier_runtime_spec_at_batch(ent.TIER_ENTERPRISE, rts)
+    assert body is not None
+    assert [r["runtime"] for r in body["runtimes"]] == rts
+    assert all(r["row"] is None for r in body["runtimes"])
+
+
+def test_next_runtime_batch_alias_canonicalises(ent):
+    # ``claude-code`` aliases to ``claude_code``; per-row ``runtime`` carries
+    # the canonical id and supplying both spellings collapses to ONE row.
+    body = ent.next_tier_runtime_spec_at_batch(
+        ent.TIER_CLOUD_STARTER, ["claude-code", "CLAUDE_CODE", " claude_code "]
+    )
+    assert body is not None
+    assert [r["runtime"] for r in body["runtimes"]] == ["claude_code"]
+    assert body["runtimes"][0]["row"] == ent.runtime_spec_at(
+        ent.TIER_CLOUD_PRO, "claude_code"
+    )
+
+
+def test_next_runtime_batch_unknown_alias_bucketed_with_supplied_value(ent):
+    body = ent.next_tier_runtime_spec_at_batch(
+        ent.TIER_CLOUD_STARTER, ["claude_code", "bogus-runtime"]
+    )
+    assert body is not None
+    assert [r["runtime"] for r in body["runtimes"]] == ["claude_code"]
+    # ``_normalise_csv`` lower-cases its input before the helper sees it, so the
+    # alias surfaces in ``unknown[]`` as the lowercased form, matching the
+    # ``runtime_spec_at_batch`` posture.
+    assert body["unknown"] == ["bogus-runtime"]
+
+
+def test_next_runtime_batch_unknown_tier_returns_none(ent):
+    assert ent.next_tier_runtime_spec_at_batch("", ["claude_code"]) is None
+    assert ent.next_tier_runtime_spec_at_batch("bogus", ["claude_code"]) is None
+
+
+def test_next_runtime_batch_grace_and_enforce_match(ent, monkeypatch):
+    rts = sorted(ent.ALL_RUNTIMES)
+    grace = ent.next_tier_runtime_spec_at_batch(ent.TIER_CLOUD_STARTER, rts)
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    importlib.reload(ent)
+    ent.invalidate()
+    enforce = ent.next_tier_runtime_spec_at_batch(ent.TIER_CLOUD_STARTER, rts)
+    assert enforce == grace
+
+
+def test_next_runtime_batch_row_failure_buckets_into_unknown(ent, monkeypatch):
+    real_spec_at = ent.runtime_spec_at
+
+    def fake_spec_at(tier, runtime):
+        if runtime == "claude_code":
+            raise RuntimeError("synthetic")
+        return real_spec_at(tier, runtime)
+
+    monkeypatch.setattr(ent, "runtime_spec_at", fake_spec_at)
+    body = ent.next_tier_runtime_spec_at_batch(
+        ent.TIER_CLOUD_STARTER, ["claude_code", "openclaw"]
+    )
+    assert body is not None
+    assert [r["runtime"] for r in body["runtimes"]] == ["openclaw"]
+    assert body["unknown"] == ["claude_code"]
+
+
+# ── previous_tier_runtime_spec_at_batch (helper) ─────────────────────────────
+
+
+def test_previous_runtime_batch_row_byte_equals_scalar(ent):
+    rts = sorted(ent.ALL_RUNTIMES)
+    for src in ent._PURCHASABLE_TIERS:
+        body = ent.previous_tier_runtime_spec_at_batch(src, rts)
+        assert body is not None
+        for row in body["runtimes"]:
+            assert row["row"] == ent.previous_tier_runtime_spec_at(
+                src, row["runtime"]
+            )
+
+
+def test_previous_runtime_batch_returns_row_null_at_floor(ent):
+    rts = sorted(ent.ALL_RUNTIMES)
+    for src in (ent.TIER_OSS, ent.TIER_CLOUD_FREE):
+        body = ent.previous_tier_runtime_spec_at_batch(src, rts)
+        assert body is not None
+        assert [r["runtime"] for r in body["runtimes"]] == rts
+        assert all(r["row"] is None for r in body["runtimes"])
+
+
+def test_previous_runtime_batch_alias_canonicalises(ent):
+    body = ent.previous_tier_runtime_spec_at_batch(
+        ent.TIER_CLOUD_PRO, ["claude-code", "claude_code"]
+    )
+    assert body is not None
+    assert [r["runtime"] for r in body["runtimes"]] == ["claude_code"]
+
+
+# ── /api/entitlement/next-tier-feature-spec-at-batch ─────────────────────────
+
+
+def test_api_next_feature_batch_happy_path(client, ent):
+    resp = client.get(
+        "/api/entitlement/next-tier-feature-spec-at-batch"
+        "?tier=cloud_starter&features=custom_alerts,sso"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert set(body.keys()) == _ENVELOPE_FEATURE_KEYS
+    assert body["tier"] == ent.TIER_CLOUD_STARTER
+    assert body["target"] == ent.TIER_CLOUD_PRO
+    assert body["target_rank"] == ent.tier_rank(ent.TIER_CLOUD_PRO)
+    # Every per-feature row matches the scalar /next-tier-feature-spec-at .row
+    for row in body["features"]:
+        scalar = client.get(
+            f"/api/entitlement/next-tier-feature-spec-at"
+            f"?tier=cloud_starter&feature={row['feature']}"
+        ).get_json()
+        assert row["row"] == scalar["row"]
+
+
+def test_api_next_feature_batch_at_ceiling_returns_200_with_null_rows(
+    client, ent
+):
+    resp = client.get(
+        "/api/entitlement/next-tier-feature-spec-at-batch"
+        "?tier=enterprise&features=custom_alerts,sso"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["target"] is None
+    assert body["target_label"] is None
+    assert body["target_rank"] is None
+    assert [r["feature"] for r in body["features"]] == ["custom_alerts", "sso"]
+    assert all(r["row"] is None for r in body["features"])
+
+
+def test_api_next_feature_batch_400_missing_tier(client):
+    resp = client.get(
+        "/api/entitlement/next-tier-feature-spec-at-batch?features=custom_alerts"
+    )
+    assert resp.status_code == 400
+
+
+def test_api_next_feature_batch_400_missing_features(client):
+    resp = client.get(
+        "/api/entitlement/next-tier-feature-spec-at-batch?tier=cloud_starter"
+    )
+    assert resp.status_code == 400
+
+
+def test_api_next_feature_batch_400_empty_features(client):
+    # ``features=,,,`` normalises to an empty list -> 400.
+    resp = client.get(
+        "/api/entitlement/next-tier-feature-spec-at-batch?tier=cloud_starter&features=,,,"
+    )
+    assert resp.status_code == 400
+
+
+def test_api_next_feature_batch_404_unknown_tier(client):
+    resp = client.get(
+        "/api/entitlement/next-tier-feature-spec-at-batch"
+        "?tier=bogus&features=custom_alerts"
+    )
+    assert resp.status_code == 404
+    body = resp.get_json()
+    assert body.get("which") == "tier"
+
+
+def test_api_next_feature_batch_unknown_feature_bucketed_200(client, ent):
+    # An unknown feature does not 404 the call -- it lands in unknown[].
+    resp = client.get(
+        "/api/entitlement/next-tier-feature-spec-at-batch"
+        "?tier=cloud_starter&features=custom_alerts,no_such"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert [r["feature"] for r in body["features"]] == ["custom_alerts"]
+    assert body["unknown"] == ["no_such"]
+
+
+def test_api_next_feature_batch_normalises_query_arg(client, ent):
+    # Whitespace + uppercase + duplicate dropping happens at the route layer
+    # via _parse_csv_arg before the helper sees the list.
+    resp = client.get(
+        "/api/entitlement/next-tier-feature-spec-at-batch"
+        "?tier=cloud_starter&features= CUSTOM_ALERTS ,custom_alerts,SSO"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert [r["feature"] for r in body["features"]] == ["custom_alerts", "sso"]
+
+
+# ── /api/entitlement/previous-tier-feature-spec-at-batch ─────────────────────
+
+
+def test_api_previous_feature_batch_happy_path(client, ent):
+    resp = client.get(
+        "/api/entitlement/previous-tier-feature-spec-at-batch"
+        "?tier=cloud_pro&features=custom_alerts,sso"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert set(body.keys()) == _ENVELOPE_FEATURE_KEYS
+    assert body["tier"] == ent.TIER_CLOUD_PRO
+    assert body["target"] == ent.TIER_CLOUD_STARTER
+    for row in body["features"]:
+        scalar = client.get(
+            f"/api/entitlement/previous-tier-feature-spec-at"
+            f"?tier=cloud_pro&feature={row['feature']}"
+        ).get_json()
+        assert row["row"] == scalar["row"]
+
+
+def test_api_previous_feature_batch_at_floor_returns_200_with_null_rows(
+    client, ent
+):
+    for src in (ent.TIER_OSS, ent.TIER_CLOUD_FREE):
+        resp = client.get(
+            f"/api/entitlement/previous-tier-feature-spec-at-batch"
+            f"?tier={src}&features=custom_alerts,sso"
+        )
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body["tier"] == src
+        assert body["target"] is None
+        assert all(r["row"] is None for r in body["features"])
+
+
+def test_api_previous_feature_batch_400s_and_404s(client):
+    assert (
+        client.get(
+            "/api/entitlement/previous-tier-feature-spec-at-batch?features=custom_alerts"
+        ).status_code
+        == 400
+    )
+    assert (
+        client.get(
+            "/api/entitlement/previous-tier-feature-spec-at-batch?tier=cloud_pro"
+        ).status_code
+        == 400
+    )
+    assert (
+        client.get(
+            "/api/entitlement/previous-tier-feature-spec-at-batch?tier=bogus&features=custom_alerts"
+        ).status_code
+        == 404
+    )
+
+
+# ── /api/entitlement/next-tier-runtime-spec-at-batch ─────────────────────────
+
+
+def test_api_next_runtime_batch_happy_path(client, ent):
+    resp = client.get(
+        "/api/entitlement/next-tier-runtime-spec-at-batch"
+        "?tier=cloud_starter&runtimes=claude_code,openclaw"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert set(body.keys()) == _ENVELOPE_RUNTIME_KEYS
+    assert body["tier"] == ent.TIER_CLOUD_STARTER
+    assert body["target"] == ent.TIER_CLOUD_PRO
+    for row in body["runtimes"]:
+        scalar = client.get(
+            f"/api/entitlement/next-tier-runtime-spec-at"
+            f"?tier=cloud_starter&runtime={row['runtime']}"
+        ).get_json()
+        assert row["row"] == scalar["row"]
+
+
+def test_api_next_runtime_batch_alias_normalises_and_collapses(client, ent):
+    # ``claude-code`` aliases to ``claude_code``; both spellings collapse to
+    # ONE row with the canonical id, matching /runtime-spec-at-batch.
+    resp = client.get(
+        "/api/entitlement/next-tier-runtime-spec-at-batch"
+        "?tier=cloud_starter&runtimes=claude-code,claude_code"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert [r["runtime"] for r in body["runtimes"]] == ["claude_code"]
+
+
+def test_api_next_runtime_batch_at_ceiling_returns_200_with_null_rows(
+    client, ent
+):
+    resp = client.get(
+        "/api/entitlement/next-tier-runtime-spec-at-batch"
+        "?tier=enterprise&runtimes=claude_code,openclaw"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["target"] is None
+    assert [r["runtime"] for r in body["runtimes"]] == ["claude_code", "openclaw"]
+    assert all(r["row"] is None for r in body["runtimes"])
+
+
+def test_api_next_runtime_batch_unknown_runtime_bucketed_200(client, ent):
+    resp = client.get(
+        "/api/entitlement/next-tier-runtime-spec-at-batch"
+        "?tier=cloud_starter&runtimes=claude_code,bogus-rt"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert [r["runtime"] for r in body["runtimes"]] == ["claude_code"]
+    assert body["unknown"] == ["bogus-rt"]
+
+
+def test_api_next_runtime_batch_400s_and_404s(client):
+    assert (
+        client.get(
+            "/api/entitlement/next-tier-runtime-spec-at-batch?runtimes=claude_code"
+        ).status_code
+        == 400
+    )
+    assert (
+        client.get(
+            "/api/entitlement/next-tier-runtime-spec-at-batch?tier=cloud_starter"
+        ).status_code
+        == 400
+    )
+    assert (
+        client.get(
+            "/api/entitlement/next-tier-runtime-spec-at-batch?tier=bogus&runtimes=claude_code"
+        ).status_code
+        == 404
+    )
+
+
+# ── /api/entitlement/previous-tier-runtime-spec-at-batch ─────────────────────
+
+
+def test_api_previous_runtime_batch_happy_path(client, ent):
+    resp = client.get(
+        "/api/entitlement/previous-tier-runtime-spec-at-batch"
+        "?tier=cloud_pro&runtimes=claude_code,openclaw"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert set(body.keys()) == _ENVELOPE_RUNTIME_KEYS
+    assert body["target"] == ent.TIER_CLOUD_STARTER
+    for row in body["runtimes"]:
+        scalar = client.get(
+            f"/api/entitlement/previous-tier-runtime-spec-at"
+            f"?tier=cloud_pro&runtime={row['runtime']}"
+        ).get_json()
+        assert row["row"] == scalar["row"]
+
+
+def test_api_previous_runtime_batch_at_floor_returns_200_with_null_rows(
+    client, ent
+):
+    for src in (ent.TIER_OSS, ent.TIER_CLOUD_FREE):
+        resp = client.get(
+            f"/api/entitlement/previous-tier-runtime-spec-at-batch"
+            f"?tier={src}&runtimes=claude_code,openclaw"
+        )
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body["target"] is None
+        assert all(r["row"] is None for r in body["runtimes"])
+
+
+def test_api_previous_runtime_batch_400s_and_404s(client):
+    assert (
+        client.get(
+            "/api/entitlement/previous-tier-runtime-spec-at-batch?runtimes=claude_code"
+        ).status_code
+        == 400
+    )
+    assert (
+        client.get(
+            "/api/entitlement/previous-tier-runtime-spec-at-batch?tier=cloud_pro"
+        ).status_code
+        == 400
+    )
+    assert (
+        client.get(
+            "/api/entitlement/previous-tier-runtime-spec-at-batch?tier=bogus&runtimes=claude_code"
+        ).status_code
+        == 404
+    )
+
+
+# ── cross-axis parity with the path-batch sibling ────────────────────────────
+
+
+def test_next_feature_batch_first_row_matches_path_batch_first_rung(ent):
+    # The first rung of /feature-spec-path-batch from src -> next purchasable
+    # equals the body of /next-tier-feature-spec-at-batch from src. Pins the
+    # path-vs-what-if relationship at the boundary so the two batch helpers
+    # cannot drift.
+    src = ent.TIER_CLOUD_STARTER
+    target = ent._next_purchasable_tier_after(src)
+    feats = ["custom_alerts", "sso"]
+    at_batch = ent.next_tier_feature_spec_at_batch(src, feats)
+    path_batch = ent.feature_spec_path_batch(src, target, feats)
+    assert at_batch is not None
+    assert path_batch is not None
+    # path_batch[features][i].path is a list of rung augmented rows from src
+    # to target; the LAST rung is the target itself (because feature_spec_path
+    # walks rungs strictly between from and to and includes the target row).
+    # Each at_batch row equals feature_spec_at(target, feature).
+    for at_row in at_batch["features"]:
+        assert at_row["row"] == ent.feature_spec_at(target, at_row["feature"])


### PR DESCRIPTION
## Summary

- Batch siblings of the four scalar what-if projections added in PR #3387 (`next/previous_tier_{feature,runtime}_spec_at`). Where the scalar walks ONE item against the rung above/below a source tier, the batch sibling walks N items against that same rung in ONE round-trip.
- Pairs with the scalar projections the same way `feature_spec_at_batch` pairs with `feature_spec_at`: scalar what-if → batch what-if. A paywall "here are the N items I care about — what do they look like at my next/previous rung?" surface hydrates every item off ONE call instead of N calls.
- Per-row body is byte-identical to the scalar sibling (parity-pinned). At ceiling/floor every `row` is `null` while per-item envelope entries still render so the matrix's row count stays stable.

## Helpers

```python
def next_tier_feature_spec_at_batch(tier: str, features) -> dict | None
def previous_tier_feature_spec_at_batch(tier: str, features) -> dict | None
def next_tier_runtime_spec_at_batch(tier: str, runtimes) -> dict | None
def previous_tier_runtime_spec_at_batch(tier: str, runtimes) -> dict | None
```

Returned shape (feature axis; runtime axis swaps `features`↔`runtimes` and `feature`↔`runtime`):

```
{
  "features": [{"feature": "<id>", "row": <feature_spec_at row> | None}, ...],
  "unknown":  ["bogus_id", ...],
}
```

- Feature/runtime ids normalised via `_normalise_csv` (whitespace stripped, lowercased, duplicates dropped, first-seen order preserved); runtime aliases canonicalised (`claude-code` → `claude_code`) and collapsed against already-supplied canonical ids.
- Unknown ids echoed in `unknown[]` (supplied alias for runtime axis, lowercased id for feature axis) instead of short-circuiting.
- At ceiling (enterprise as source for `next_*`) / floor (`oss` / `cloud_free` as source for `previous_*`) every per-item `row` is `None`; the envelope still carries one entry per valid item so the matrix stays a stable shape.
- Grace vs enforce yields byte-identical bodies (catalogue-derived).
- Helpers never raise: a per-row builder failure short-circuits that item into `unknown[]` and the rest of the batch keeps building.

## Routes

```
GET /api/entitlement/next-tier-feature-spec-at-batch?tier=&features=a,b,c
GET /api/entitlement/previous-tier-feature-spec-at-batch?tier=&features=a,b,c
GET /api/entitlement/next-tier-runtime-spec-at-batch?tier=&runtimes=a,b,c
GET /api/entitlement/previous-tier-runtime-spec-at-batch?tier=&runtimes=a,b,c
```

Envelope shape (mirrors the scalar `/next-tier-feature-spec-at` envelope plus the per-item array + `unknown[]`):

```
{
  "tier":         "<source>",
  "tier_label":   "...",
  "tier_rank":    <int>,
  "target":       "<next/prev tier>" | null,
  "target_label": "..." | null,
  "target_rank":  <int>  | null,
  "features":     [{"feature": "<id>", "row": {<spec row>} | null}, ...],
  "unknown":      ["bogus_id", ...],
}
```

- **400** on missing `tier=` or empty `features=` / `runtimes=` after normalisation
- **404** on unknown `tier` (body carries `which: "tier"`)
- **200** with bucketed unknowns for unknown item ids — does NOT 404 the call, matching every other batch sibling
- **Never 5xxs**: a synthesis failure short-circuits to the same envelope shape with empty rows so the matrix keeps rendering.

## Tests

42 new tests in `tests/test_entitlement_next_prev_tier_feature_runtime_spec_at_batch.py` covering:

- per-row byte-equality with the scalar `next/previous_tier_{feature,runtime}_spec_at` across every purchasable source for every feature / runtime (parity)
- ceiling (enterprise as source for `next_*`) / floor (`oss` / `cloud_free` as source for `previous_*`) yields `row=null` for every valid item, envelope rows still rendered
- trial-as-source resolves the same way the sibling `_at` families do (next → enterprise, previous → cloud_starter)
- unknown / empty / whitespace / case-insensitive id handling
- runtime alias canonicalisation + alias-to-canonical collapse de-duplicates
- input normalisation (whitespace, lowercase, duplicate drop, first-seen order)
- grace vs enforce byte-parity
- builder-failure-per-row short-circuits into `unknown[]` instead of 500'ing
- HTTP 400 / 404 / 200 paths for all four endpoints
- cross-axis parity with `feature_spec_path_batch` first rung

```
42 passed in 0.81s
```

The 241 sibling tests (`test_entitlement_next_prev_tier_feature_runtime_spec_at`, `test_entitlement_spec_path_batch`, `test_entitlement_feature_spec_at`, `test_entitlement_runtime_spec_at`, `test_entitlement_spec_at_batch`, `test_entitlement_next_prev_tier_spec_at_batch`) all still pass.

## Test plan

- [ ] `python -m pytest tests/test_entitlement_next_prev_tier_feature_runtime_spec_at_batch.py -v`
- [ ] Spot-check parity: `/api/entitlement/next-tier-feature-spec-at-batch?tier=cloud_starter&features=custom_alerts` `features[0].row` matches `/api/entitlement/next-tier-feature-spec-at?tier=cloud_starter&feature=custom_alerts` `.row`
- [ ] Spot-check alias collapse: `/api/entitlement/next-tier-runtime-spec-at-batch?tier=cloud_starter&runtimes=claude-code,claude_code` returns ONE row with `runtime: "claude_code"`
- [ ] Spot-check ceiling: `/api/entitlement/next-tier-feature-spec-at-batch?tier=enterprise&features=custom_alerts,sso` returns 200 with `target: null` and both `row` values `null`

## Local operator verification checklist

(Required because this remote session has no access to the live daemon, `~/.openclaw`, the cloud snapshot, or a browser.)

- [ ] Pull the branch locally: `git fetch origin feat/entitlement-next-prev-tier-feature-runtime-spec-at-batch && git checkout feat/entitlement-next-prev-tier-feature-runtime-spec-at-batch`
- [ ] Copy changed files into the live install:
  - `cp clawmetry/entitlements.py ~/.clawmetry/lib/python*/site-packages/clawmetry/entitlements.py`
  - `cp routes/entitlement.py ~/.clawmetry/lib/python*/site-packages/routes/entitlement.py`
- [ ] Clear caches: `find ~/.clawmetry/lib -name __pycache__ -type d -exec rm -rf {} +`
- [ ] Restart the daemon: `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
- [ ] Hit the new endpoints:
  - `curl -s 'http://localhost:8900/api/entitlement/next-tier-feature-spec-at-batch?tier=cloud_starter&features=custom_alerts,sso' | jq`
  - `curl -s 'http://localhost:8900/api/entitlement/previous-tier-feature-spec-at-batch?tier=cloud_pro&features=custom_alerts,sso' | jq`
  - `curl -s 'http://localhost:8900/api/entitlement/next-tier-runtime-spec-at-batch?tier=cloud_starter&runtimes=claude-code,openclaw' | jq`
  - `curl -s 'http://localhost:8900/api/entitlement/previous-tier-runtime-spec-at-batch?tier=cloud_pro&runtimes=claude_code,openclaw' | jq`
- [ ] Confirm the body has `tier` / `tier_label` / `tier_rank` / `target` / `target_label` / `target_rank` plus `features|runtimes[]` + `unknown[]`
- [ ] Decrypt the live cloud snapshot client-side and browser-check that nothing regressed on the entitlement UI
- [ ] Promote out of draft when satisfied

This PR stays in **grace mode**: no behaviour change to any existing endpoint, no enforce gate flipped, no `__version__` bump, no release tag. The next-phase work (cloud-side entitlement minting, `clawmetry-pro` package download, enterprise SSO) needs the private `clawmetry-cloud` / `clawmetry-pro` repos and is out of scope for this remote session.

Pairs cleanly with open PR #3395 (`lock_reason_path_batch`) on the same direction-of-iteration: scalar projection → batch sibling. Non-overlapping diff (this PR appends to `entitlements.py` + `routes/entitlement.py` after the runtime_spec_path_batch helper / route that #3395 builds against, but does not touch the lock_reason_path helpers it adds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015Q25g1fdQcGJuZnQM2Ld8P)_