### PR TITLE
feat(entitlement): capacity_diff_path_batch + /api/entitlement/capacity-diff-path-batch

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -7872,3 +7872,120 @@ def previous_tier_runtime_spec_at_batch(tier: str, runtimes) -> dict | None:
         seen.add(canon)
         rows.append({"runtime": canon, "row": row})
     return {"runtimes": rows, "unknown": unknown}
+
+
+def capacity_diff_path_batch(
+    from_tier: str, to_tiers
+) -> dict | None:
+    """Batch sibling of :func:`capacity_diff_path`: per-rung capacity
+    transition rows for a caller-supplied subset of destination tiers
+    all walked from a single ``from_tier`` in ONE round-trip.
+
+    Composes :func:`capacity_diff_path` (scalar single-destination
+    capacity walk) and :func:`tier_spec_path_batch` (multi-destination
+    path batch) -- same per-rung capacity body as the path helper, same
+    multi-destination axis as the tier-spec batch helper. Lets a
+    capacity-only pricing-comparison "from my current rung, here are
+    the 3 tiers I'm considering -- show me the channels / retention /
+    nodes bumps to each" surface render every rung for every candidate
+    destination off ONE call instead of N calls to
+    :func:`capacity_diff_path`.
+
+    Per-destination row shape::
+
+        {
+          "to":         "<tier id>",
+          "to_label":   "...",
+          "to_rank":    <int>,
+          "direction":  "upgrade" | "downgrade" | "lateral" | "identity",
+          "path":       [<capacity_diff_path row>, ...],
+        }
+
+    Each ``path`` row is byte-identical to a row from
+    :func:`capacity_diff_path` for the same ``(from_tier, to)`` pair --
+    a parity test pins this so the scalar and batch path helpers
+    cannot drift. The walked rungs are destination-specific (the
+    path's rung set depends on ``to``), so per-destination ``path``
+    lengths can legitimately differ -- this matches
+    :func:`tier_spec_path_batch`'s posture and differs from
+    :func:`feature_spec_path_batch` / :func:`runtime_spec_path_batch`
+    whose rungs are axis-id-agnostic.
+
+    Shape::
+
+        {
+          "tiers": [
+            {"to": "<id>", "to_label": ..., "to_rank": ..., "direction": ..., "path": [...]},
+            ...
+          ],
+          "unknown": ["bogus_id", ...],
+        }
+
+    Supplied destination ids are normalised via :func:`_normalise_csv`
+    (whitespace stripped, lowercased, duplicates dropped, first-seen
+    order preserved). Unknown ids are echoed in ``unknown[]`` instead
+    of short-circuiting -- a partially-bad caller still gets paths
+    back for the valid ids alongside a list of what was dropped,
+    matching :func:`tier_spec_path_batch` /
+    :func:`feature_spec_path_batch` / :func:`runtime_spec_path_batch`'s
+    posture. ``trial`` IS accepted as a destination (it is excluded
+    from the walked intermediate rungs the way
+    :func:`capacity_diff_path` already excludes it, but is a valid
+    endpoint via the lateral / identity branches).
+
+    Returns ``None`` for empty / unknown ``from_tier`` (caller renders
+    "unknown tier" / 404).
+
+    Resolver-independent: delegates per-destination to
+    :func:`capacity_diff_path`, which walks the static per-tier caps
+    via :func:`_capacity_row` -- so grace vs enforce yields
+    byte-identical rows. Never raises: per-destination failures
+    short-circuit that id into ``unknown[]`` and the rest of the
+    batch keeps building.
+    """
+    try:
+        f = (from_tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if f not in _TIER_FEATURES:
+        return None
+    candidates = _normalise_csv(to_tiers)
+    rows: list[dict] = []
+    unknown: list[str] = []
+    from_rank = _TIER_RANK.get(f, -1)
+    for tid in candidates:
+        if tid not in _TIER_FEATURES:
+            unknown.append(tid)
+            continue
+        try:
+            path = capacity_diff_path(f, tid)
+        except Exception as exc:
+            logger.warning(
+                "entitlements: capacity_diff_path_batch row %r failed: %s",
+                tid,
+                exc,
+            )
+            unknown.append(tid)
+            continue
+        if path is None:
+            unknown.append(tid)
+            continue
+        to_rank = _TIER_RANK.get(tid, -1)
+        if f == tid:
+            direction = "identity"
+        elif from_rank == to_rank:
+            direction = "lateral"
+        elif to_rank > from_rank:
+            direction = "upgrade"
+        else:
+            direction = "downgrade"
+        rows.append(
+            {
+                "to": tid,
+                "to_label": tier_label(tid),
+                "to_rank": to_rank,
+                "direction": direction,
+                "path": path,
+            }
+        )
+    return {"tiers": rows, "unknown": unknown}

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -7795,3 +7795,107 @@ def api_entitlement_previous_tier_runtime_spec_at_batch():
     are identical to ``/next-tier-runtime-spec-at-batch``.
     """
     return _next_prev_tier_runtime_spec_at_batch("previous")
+
+
+@bp_entitlement.route("/api/entitlement/capacity-diff-path-batch")
+def api_entitlement_capacity_diff_path_batch():
+    """``GET /api/entitlement/capacity-diff-path-batch?from=<id>&to=a,b,c``
+    -- batch sibling of ``/api/entitlement/capacity-diff-path``.
+
+    Where ``/capacity-diff-path`` walks the rungs between ONE
+    ``(from, to)`` pair, this walks the rungs between ONE ``from`` and
+    N candidate ``to`` tiers in ONE round-trip. Pairs with
+    ``/capacity-diff-path`` the same way ``/tier-spec-path-batch``
+    pairs with ``/tier-spec-path``: scalar -> matrix in one call.
+    Mirrors the multi-destination axis of ``/tier-spec-path-batch`` --
+    same fan-out shape, capacity-only per-rung body.
+
+    Use case: a capacity-only pricing-comparison "from my current
+    rung, here are the 3 tiers I'm considering -- show me the
+    channels / retention / nodes bumps to each" surface hydrates the
+    per-rung capacity transitions to every candidate off ONE call
+    instead of N calls to ``/capacity-diff-path``. Same-rank siblings
+    strictly between the endpoints are included for each
+    per-destination path; same-rank siblings of each destination are
+    excluded so the per-destination path terminates exactly at its own
+    ``to``. Per-destination path lengths can legitimately differ (the
+    rungs walked depend on the destination), matching
+    ``/tier-spec-path-batch``'s posture.
+
+    Each row in ``tiers[].path`` is byte-identical to a row from
+    ``/capacity-diff-path?from=<from>&to=<to>`` -- pinned by the
+    parity tests so the scalar and batch path accessors cannot drift.
+    Supplied destination ids are normalised (whitespace stripped,
+    lowercased, duplicates dropped, first-seen order preserved).
+    Unknown ids do not 404 the call -- they are echoed in
+    ``unknown[]`` so a partially-bad caller still gets paths back for
+    the valid ids.
+
+    Response shape::
+
+        {
+          "from":       "<tier id>",
+          "from_label": "...",
+          "from_rank":  <int>,
+          "tiers": [
+            {
+              "to":        "<tier id>",
+              "to_label":  "...",
+              "to_rank":   <int>,
+              "direction": "upgrade" | "downgrade" | "lateral" | "identity",
+              "path":      [<capacity-diff row>, ...],
+            },
+            ...
+          ],
+          "unknown":    ["bogus_id", ...],
+        }
+
+    - **400** when ``from=`` is missing / blank, or ``to=`` is missing
+      / empty after normalisation
+    - **404** when ``from`` is unknown (body carries ``which: "tier"``)
+    - **200** with bucketed unknowns for unknown destination ids --
+      does NOT 404 the call, matching every other batch sibling
+    - **Never 5xxs**: a synthesis failure short-circuits to an envelope
+      with empty rows so the matrix keeps rendering.
+    """
+    f = (request.args.get("from") or "").strip().lower()
+    if not f:
+        return jsonify({"error": "missing from"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        if f not in _ent._TIER_ORDER:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "tier", "tier": f}
+                ),
+                404,
+            )
+        targets = _parse_csv_arg("to")
+        if not targets:
+            return jsonify({"error": "supply to=<csv>"}), 400
+        batch = _ent.capacity_diff_path_batch(f, targets)
+        if batch is None:
+            batch = {"tiers": [], "unknown": []}
+        return jsonify(
+            {
+                "from": f,
+                "from_label": _ent.tier_label(f),
+                "from_rank": _ent.tier_rank(f),
+                "tiers": batch.get("tiers", []),
+                "unknown": batch.get("unknown", []),
+            }
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_capacity_diff_path_batch: error: %s", exc
+        )
+        return jsonify(
+            {
+                "from": f,
+                "from_label": None,
+                "from_rank": -1,
+                "tiers": [],
+                "unknown": [],
+            }
+        )

--- a/tests/test_entitlement_capacity_diff_path_batch.py
+++ b/tests/test_entitlement_capacity_diff_path_batch.py
@@ -1,0 +1,479 @@
+"""Tests for ``capacity_diff_path_batch(from_tier, to_tiers)`` plus its
+HTTP endpoint ``/api/entitlement/capacity-diff-path-batch``.
+
+Batch sibling of ``capacity_diff_path``: where the scalar path helper
+walks one ``(from, to)`` pair, the batch helper walks N candidate
+destinations from one source in ONE round-trip. Multi-destination
+twin of :func:`tier_spec_path_batch` (same fan-out shape, capacity-only
+per-rung body).
+
+Each per-destination ``path`` must be byte-identical to the matching
+scalar :func:`capacity_diff_path` payload for the same ``(from, to)``
+pair -- pinned by the parity tests below so the scalar and batch path
+accessors cannot drift.
+
+Coverage:
+
+* per-destination ``path`` byte-equal to the scalar
+  :func:`capacity_diff_path` payload
+* per-row body matches the singular :func:`capacity_diff` shape
+  (``target``, ``channel_limit``, ``retention_days``, ``node_limit``)
+  with the full ``{before, after, delta, unlocked, locked}`` triple per
+  axis
+* per-destination ``direction`` derived from the same ranks the scalar
+  endpoint uses
+* batch envelope mirrors ``/capacity-diff-path``'s envelope on the
+  source side (``from`` / ``from_label`` / ``from_rank``) and carries
+  ``tiers`` + ``unknown``
+* input normalised (whitespace stripped, lowercased, duplicates dropped,
+  first-seen order preserved)
+* unknown destination ids echoed in ``unknown[]`` instead of 404'ing
+  the call (matching every other batch sibling)
+* identity ``from == to`` yields a per-destination entry whose ``path``
+  is ``[]``
+* lateral (same rank) yields a one-row per-destination ``path``
+* upgrade / downgrade direction labelled correctly
+* trial accepted as a destination (lateral / identity endpoint only --
+  excluded from intermediate rungs, same as the scalar helper)
+* unknown / empty / garbage ``from_tier`` returns ``None`` (helper) /
+  400 / 404 (HTTP)
+* helpers never raise -- a per-destination failure short-circuits that
+  id into ``unknown[]`` and the rest of the batch keeps building
+* HTTP endpoint 400 on missing / empty input, 404 on unknown source
+  tier, never 5xx on a row failure
+* grace vs enforce yields identical rows (resolver-independent)
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+_ROW_KEYS = {"target", "channel_limit", "retention_days", "node_limit"}
+_AXIS_KEYS = {"before", "after", "delta", "unlocked", "locked"}
+
+_ITEM_KEYS = {"to", "to_label", "to_rank", "direction", "path"}
+
+_ENVELOPE_KEYS = {
+    "from",
+    "from_label",
+    "from_rank",
+    "tiers",
+    "unknown",
+}
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# ── helper-level: shape ──────────────────────────────────────────────────────
+
+
+def test_helper_returns_dict_shape(ent):
+    out = ent.capacity_diff_path_batch(
+        ent.TIER_OSS, [ent.TIER_CLOUD_STARTER, ent.TIER_ENTERPRISE]
+    )
+    assert isinstance(out, dict)
+    assert set(out.keys()) == {"tiers", "unknown"}
+    assert isinstance(out["tiers"], list)
+    assert isinstance(out["unknown"], list)
+
+
+def test_helper_each_item_carries_full_envelope(ent):
+    out = ent.capacity_diff_path_batch(
+        ent.TIER_OSS, [ent.TIER_CLOUD_STARTER, ent.TIER_ENTERPRISE]
+    )
+    for item in out["tiers"]:
+        assert set(item.keys()) == _ITEM_KEYS
+        assert isinstance(item["to"], str)
+        assert isinstance(item["to_label"], str)
+        assert isinstance(item["to_rank"], int)
+        assert item["direction"] in {
+            "upgrade",
+            "downgrade",
+            "lateral",
+            "identity",
+        }
+        assert isinstance(item["path"], list)
+
+
+def test_helper_per_row_matches_capacity_diff_shape(ent):
+    """Per-row body must match the singular :func:`capacity_diff` shape
+    exactly -- ``target`` + the three capacity axes, each carrying the
+    ``{before, after, delta, unlocked, locked}`` triple."""
+    out = ent.capacity_diff_path_batch(
+        ent.TIER_OSS, [ent.TIER_ENTERPRISE]
+    )
+    for row in out["tiers"][0]["path"]:
+        assert set(row.keys()) == _ROW_KEYS
+        for axis in ("channel_limit", "retention_days", "node_limit"):
+            assert set(row[axis].keys()) == _AXIS_KEYS
+
+
+# ── helper-level: parity with scalar ─────────────────────────────────────────
+
+
+def test_helper_per_item_path_byte_equal_to_scalar(ent):
+    """Pin: per-destination ``path`` is byte-identical to the scalar
+    :func:`capacity_diff_path` payload for the same ``(from, to)`` pair."""
+    candidates = [
+        ent.TIER_CLOUD_FREE,
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_ENTERPRISE,
+    ]
+    out = ent.capacity_diff_path_batch(ent.TIER_OSS, candidates)
+    by_id = {item["to"]: item["path"] for item in out["tiers"]}
+    for tid in candidates:
+        scalar = ent.capacity_diff_path(ent.TIER_OSS, tid)
+        assert by_id[tid] == scalar
+
+
+def test_helper_per_item_direction_matches_rank_geometry(ent):
+    """Per-destination ``direction`` is derived from rank geometry and
+    must agree with the scalar endpoint's derivation."""
+    candidates = [
+        ent.TIER_OSS,
+        ent.TIER_CLOUD_FREE,
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_PRO,
+        ent.TIER_ENTERPRISE,
+    ]
+    out = ent.capacity_diff_path_batch(ent.TIER_CLOUD_STARTER, candidates)
+    by_id = {item["to"]: item for item in out["tiers"]}
+    src_rank = ent.tier_rank(ent.TIER_CLOUD_STARTER)
+    for tid in candidates:
+        tgt_rank = ent.tier_rank(tid)
+        if tid == ent.TIER_CLOUD_STARTER:
+            expected = "identity"
+        elif src_rank == tgt_rank:
+            expected = "lateral"
+        elif tgt_rank > src_rank:
+            expected = "upgrade"
+        else:
+            expected = "downgrade"
+        assert by_id[tid]["direction"] == expected
+
+
+# ── helper-level: input normalisation ────────────────────────────────────────
+
+
+def test_helper_supply_order_preserved(ent):
+    out = ent.capacity_diff_path_batch(
+        ent.TIER_OSS,
+        [ent.TIER_ENTERPRISE, ent.TIER_CLOUD_PRO, ent.TIER_CLOUD_STARTER],
+    )
+    assert [item["to"] for item in out["tiers"]] == [
+        ent.TIER_ENTERPRISE,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_CLOUD_STARTER,
+    ]
+
+
+def test_helper_normalises_input(ent):
+    out = ent.capacity_diff_path_batch(
+        ent.TIER_OSS,
+        [
+            "  CLOUD_PRO  ",
+            "cloud_starter",
+            "cloud_pro",
+            "",
+        ],
+    )
+    assert [item["to"] for item in out["tiers"]] == [
+        "cloud_pro",
+        "cloud_starter",
+    ]
+
+
+def test_helper_unknown_destination_ids_echoed(ent):
+    out = ent.capacity_diff_path_batch(
+        ent.TIER_OSS,
+        [ent.TIER_CLOUD_PRO, "bogus_tier", "still_bogus"],
+    )
+    assert [item["to"] for item in out["tiers"]] == [ent.TIER_CLOUD_PRO]
+    assert set(out["unknown"]) == {"bogus_tier", "still_bogus"}
+
+
+# ── helper-level: direction branches ─────────────────────────────────────────
+
+
+def test_helper_identity_yields_empty_path(ent):
+    out = ent.capacity_diff_path_batch(
+        ent.TIER_CLOUD_PRO, [ent.TIER_CLOUD_PRO, ent.TIER_ENTERPRISE]
+    )
+    by_id = {item["to"]: item for item in out["tiers"]}
+    assert by_id[ent.TIER_CLOUD_PRO]["direction"] == "identity"
+    assert by_id[ent.TIER_CLOUD_PRO]["path"] == []
+    assert by_id[ent.TIER_ENTERPRISE]["direction"] == "upgrade"
+
+
+def test_helper_lateral_yields_one_row_path(ent):
+    out = ent.capacity_diff_path_batch(
+        ent.TIER_CLOUD_PRO, [ent.TIER_PRO]
+    )
+    assert len(out["tiers"]) == 1
+    item = out["tiers"][0]
+    assert item["direction"] == "lateral"
+    assert len(item["path"]) == 1
+
+
+def test_helper_upgrade_walks_intermediate_rungs(ent):
+    out = ent.capacity_diff_path_batch(ent.TIER_OSS, [ent.TIER_ENTERPRISE])
+    item = out["tiers"][0]
+    assert item["direction"] == "upgrade"
+    targets = [row["target"] for row in item["path"]]
+    assert targets[-1] == ent.TIER_ENTERPRISE
+    assert ent.TIER_OSS not in targets
+
+
+def test_helper_downgrade_walks_descending(ent):
+    out = ent.capacity_diff_path_batch(ent.TIER_ENTERPRISE, [ent.TIER_OSS])
+    item = out["tiers"][0]
+    assert item["direction"] == "downgrade"
+    targets = [row["target"] for row in item["path"]]
+    ranks = [ent.tier_rank(r) for r in targets]
+    assert ranks == sorted(ranks, reverse=True)
+
+
+def test_helper_path_chain_is_continuous_per_axis(ent):
+    """row[i].axis.after == row[i+1].axis.before across every axis on
+    every per-destination path -- the fold-to-cumulative invariant the
+    scalar helper enforces."""
+    out = ent.capacity_diff_path_batch(
+        ent.TIER_OSS, [ent.TIER_CLOUD_PRO, ent.TIER_ENTERPRISE]
+    )
+    for item in out["tiers"]:
+        path = item["path"]
+        for i in range(len(path) - 1):
+            for axis in ("channel_limit", "retention_days", "node_limit"):
+                assert path[i][axis]["after"] == path[i + 1][axis]["before"]
+
+
+# ── helper-level: trial endpoint ─────────────────────────────────────────────
+
+
+def test_helper_trial_destination_accepted(ent):
+    """``trial`` is a valid endpoint (matching :func:`capacity_diff_path`
+    semantics) even though it is excluded from the walked intermediate
+    rungs."""
+    out = ent.capacity_diff_path_batch(ent.TIER_OSS, [ent.TIER_TRIAL])
+    assert out["unknown"] == []
+    assert [item["to"] for item in out["tiers"]] == [ent.TIER_TRIAL]
+
+
+# ── helper-level: error / edge cases ─────────────────────────────────────────
+
+
+def test_helper_unknown_from_tier_returns_none(ent):
+    assert (
+        ent.capacity_diff_path_batch("not_a_tier", [ent.TIER_ENTERPRISE])
+        is None
+    )
+
+
+def test_helper_empty_destinations_yields_empty_envelope(ent):
+    out = ent.capacity_diff_path_batch(ent.TIER_OSS, [])
+    assert out == {"tiers": [], "unknown": []}
+
+
+def test_helper_garbage_inputs_never_raise(ent):
+    assert ent.capacity_diff_path_batch("", []) is None
+    assert ent.capacity_diff_path_batch(None, None) is None  # type: ignore[arg-type]
+    assert ent.capacity_diff_path_batch("  ", "  ") is None
+
+
+def test_helper_grace_and_enforce_yield_identical_output(ent, monkeypatch):
+    candidates = [ent.TIER_CLOUD_STARTER, ent.TIER_ENTERPRISE]
+    grace = ent.capacity_diff_path_batch(ent.TIER_OSS, candidates)
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    enforced = ent.capacity_diff_path_batch(ent.TIER_OSS, candidates)
+    assert grace == enforced
+
+
+def test_helper_row_failure_short_circuits_item(ent, monkeypatch):
+    """A per-destination failure pushes that id into ``unknown[]`` while
+    the rest of the batch keeps building."""
+    real = ent.capacity_diff_path
+
+    def fake(f, t):
+        if t == ent.TIER_CLOUD_PRO:
+            raise RuntimeError("boom")
+        return real(f, t)
+
+    monkeypatch.setattr(ent, "capacity_diff_path", fake)
+    out = ent.capacity_diff_path_batch(
+        ent.TIER_OSS, [ent.TIER_CLOUD_PRO, ent.TIER_ENTERPRISE]
+    )
+    assert [item["to"] for item in out["tiers"]] == [ent.TIER_ENTERPRISE]
+    assert ent.TIER_CLOUD_PRO in out["unknown"]
+
+
+# ── HTTP: /api/entitlement/capacity-diff-path-batch ──────────────────────────
+
+
+def test_api_400_on_missing_from(client):
+    r = client.get(
+        "/api/entitlement/capacity-diff-path-batch?to=cloud_pro,enterprise"
+    )
+    assert r.status_code == 400
+
+
+def test_api_400_on_missing_to(client):
+    r = client.get("/api/entitlement/capacity-diff-path-batch?from=oss")
+    assert r.status_code == 400
+    body = r.get_json()
+    assert body["error"] == "supply to=<csv>"
+
+
+def test_api_400_on_empty_to(client):
+    r = client.get(
+        "/api/entitlement/capacity-diff-path-batch?from=oss&to=,,"
+    )
+    assert r.status_code == 400
+
+
+def test_api_404_on_unknown_from_tier(client):
+    r = client.get(
+        "/api/entitlement/capacity-diff-path-batch"
+        "?from=not_a_tier&to=enterprise"
+    )
+    assert r.status_code == 404
+    body = r.get_json()
+    assert body["which"] == "tier"
+
+
+def test_api_200_with_unknown_destination_bucketed(client, ent):
+    r = client.get(
+        f"/api/entitlement/capacity-diff-path-batch?from={ent.TIER_OSS}"
+        f"&to={ent.TIER_CLOUD_PRO},bogus_tier"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert [item["to"] for item in body["tiers"]] == [ent.TIER_CLOUD_PRO]
+    assert body["unknown"] == ["bogus_tier"]
+
+
+def test_api_happy_path_ascending(client, ent):
+    r = client.get(
+        f"/api/entitlement/capacity-diff-path-batch?from={ent.TIER_OSS}"
+        f"&to={ent.TIER_CLOUD_STARTER},{ent.TIER_ENTERPRISE}"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert set(body.keys()) == _ENVELOPE_KEYS
+    assert body["from"] == ent.TIER_OSS
+    assert isinstance(body["from_label"], str)
+    assert body["from_rank"] == ent.tier_rank(ent.TIER_OSS)
+    tos = [item["to"] for item in body["tiers"]]
+    assert tos == [ent.TIER_CLOUD_STARTER, ent.TIER_ENTERPRISE]
+    for item in body["tiers"]:
+        assert item["direction"] == "upgrade"
+        assert item["path"][-1]["target"] == item["to"]
+
+
+def test_api_identity_branch(client, ent):
+    r = client.get(
+        f"/api/entitlement/capacity-diff-path-batch"
+        f"?from={ent.TIER_CLOUD_PRO}&to={ent.TIER_CLOUD_PRO}"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["tiers"][0]["direction"] == "identity"
+    assert body["tiers"][0]["path"] == []
+
+
+def test_api_lateral_branch(client, ent):
+    r = client.get(
+        f"/api/entitlement/capacity-diff-path-batch"
+        f"?from={ent.TIER_CLOUD_PRO}&to={ent.TIER_PRO}"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["tiers"][0]["direction"] == "lateral"
+    assert len(body["tiers"][0]["path"]) == 1
+
+
+def test_api_downgrade_branch(client, ent):
+    r = client.get(
+        f"/api/entitlement/capacity-diff-path-batch"
+        f"?from={ent.TIER_ENTERPRISE}&to={ent.TIER_OSS}"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["tiers"][0]["direction"] == "downgrade"
+
+
+def test_api_per_item_path_matches_scalar_route(client, ent):
+    """HTTP parity: each per-destination ``path`` is byte-identical to
+    the scalar ``/capacity-diff-path?from=&to=`` ``path`` payload for
+    the same ``(from, to)`` pair."""
+    candidates = [
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_ENTERPRISE,
+    ]
+    batch = client.get(
+        f"/api/entitlement/capacity-diff-path-batch?from={ent.TIER_OSS}"
+        f"&to={','.join(candidates)}"
+    ).get_json()
+    for item in batch["tiers"]:
+        scalar = client.get(
+            f"/api/entitlement/capacity-diff-path?from={ent.TIER_OSS}"
+            f"&to={item['to']}"
+        ).get_json()
+        assert item["path"] == scalar["path"]
+        assert item["direction"] == scalar["direction"]
+        assert item["to_label"] == scalar["to_label"]
+        assert item["to_rank"] == scalar["to_rank"]
+
+
+def test_api_input_normalised(client, ent):
+    r = client.get(
+        f"/api/entitlement/capacity-diff-path-batch?from={ent.TIER_OSS}"
+        f"&to=  CLOUD_PRO  ,cloud_starter,cloud_pro,"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert [item["to"] for item in body["tiers"]] == [
+        "cloud_pro",
+        "cloud_starter",
+    ]
+
+
+def test_api_grace_and_enforce_yield_identical_body(
+    client, ent, monkeypatch
+):
+    grace = client.get(
+        f"/api/entitlement/capacity-diff-path-batch?from={ent.TIER_OSS}"
+        f"&to={ent.TIER_CLOUD_STARTER},{ent.TIER_ENTERPRISE}"
+    ).get_json()
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    enforced = client.get(
+        f"/api/entitlement/capacity-diff-path-batch?from={ent.TIER_OSS}"
+        f"&to={ent.TIER_CLOUD_STARTER},{ent.TIER_ENTERPRISE}"
+    ).get_json()
+    assert grace == enforced


### PR DESCRIPTION
## Summary

Adds a multi-destination batch sibling of `capacity_diff_path`: walks rungs from ONE source tier to N candidate destinations in ONE round-trip.

Composes `capacity_diff_path` (scalar single-destination capacity walk) and `tier_spec_path_batch` (multi-destination path batch, PR #3402) — same per-rung capacity body as the path helper, same fan-out shape as the tier-spec batch helper. Lets a capacity-only pricing-comparison "from my current rung, here are the 3 tiers I'm considering — show me the channels / retention / nodes bumps to each" surface render every rung for every candidate destination off ONE call instead of N calls to `/capacity-diff-path`.

## Shape

```
GET /api/entitlement/capacity-diff-path-batch?from=<id>&to=a,b,c

{
  "from":       "<tier id>",
  "from_label": "...",
  "from_rank":  <int>,
  "tiers": [
    {
      "to":        "<tier id>",
      "to_label":  "...",
      "to_rank":   <int>,
      "direction": "upgrade" | "downgrade" | "lateral" | "identity",
      "path":      [<capacity-diff row>, ...]   // target + channel_limit/retention_days/node_limit triples
    }
  ],
  "unknown":    ["bogus_id", ...]
}
```

Each `tiers[].path[]` row is byte-identical to a row from `/capacity-diff-path?from=<from>&to=<to>` for the same `(from, to)` pair — parity tests pin this so the scalar and batch path accessors cannot drift. Unknown destination ids are echoed in `unknown[]` instead of 404'ing the call, matching every other batch sibling.

## Behaviour

- **400** when `from=` is missing/blank, or `to=` is missing/empty after normalisation
- **404** when `from` is unknown (body carries `which: "tier"`)
- **200** with bucketed unknowns for unknown destination ids
- **Never 5xxs** — a synthesis failure short-circuits to an envelope with empty rows
- Resolver-independent: grace vs enforce yields byte-identical rows
- `trial` accepted as a destination (lateral/identity endpoint only — excluded from intermediate rungs, same as the scalar helper)

## Rollout

Stays in **grace mode** — no enforce gate flipped, no version bump. This is a read-only pricing-comparison helper; it does not gate any existing behaviour.

## Files

- `clawmetry/entitlements.py` — new `capacity_diff_path_batch(from_tier, to_tiers)` helper (117 lines, end of file alongside the other `*_path_batch` siblings)
- `routes/entitlement.py` — new `GET /api/entitlement/capacity-diff-path-batch` endpoint on `bp_entitlement` (104 lines, end of file alongside the other `*-path-batch` endpoints)
- `tests/test_entitlement_capacity_diff_path_batch.py` — 31 tests covering helper shape, per-row capacity contract, byte-equal parity with the scalar helper, direction branches (identity / lateral / upgrade / downgrade), input normalisation, unknown-id bucketing, path chain continuity per axis, grace/enforce parity, row-failure short-circuit, and the full HTTP surface (400/404/200 + envelope shape + scalar-route parity)

## Test plan

- `python -m pytest tests/test_entitlement_capacity_diff_path_batch.py` → 31 passed
- `python -m pytest tests/test_entitlement_capacity_diff_path.py tests/test_entitlement_tier_spec_path.py tests/test_entitlement_feature_spec_path.py tests/test_entitlement_runtime_spec_path.py tests/test_entitlements.py` → 217 passed (no regressions in scalar siblings)
- `ruff check clawmetry/entitlements.py` → clean

## Local operator verification checklist

This agent runs without access to the local daemon, `~/.openclaw`, the live cloud snapshot, or a browser. The local operator needs to:

- [ ] Copy changed files into `~/.clawmetry/lib/python*/site-packages/clawmetry/` and `~/.clawmetry/lib/python*/site-packages/routes/`
- [ ] Clear `__pycache__` under those dirs
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
- [ ] Hit `GET /api/entitlement/capacity-diff-path-batch?from=oss&to=cloud_starter,cloud_pro,enterprise` and confirm the `tiers[].path[]` rows match `GET /api/entitlement/capacity-diff-path?from=oss&to=<id>` for each id
- [ ] Confirm bucketed unknowns: `?from=oss&to=cloud_pro,bogus_tier` returns 200 with `unknown=["bogus_tier"]`
- [ ] Decrypt the live cloud snapshot and confirm the new endpoint is reachable
- [ ] Browser-check that any cloud-side capacity-comparison surface still renders (no regression — this is a NEW endpoint, no existing caller)
- [ ] Mark this PR ready-for-review once the above passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GuiAkVVjRifPj7PNLkbKaU

---
_Generated by [Claude Code](https://claude.ai/code/session_01GuiAkVVjRifPj7PNLkbKaU)_