### PR TITLE
feat(entitlement): tier_locks_path_batch + /api/entitlement/tier-locks-path-batch

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -7989,3 +7989,240 @@ def capacity_diff_path_batch(
             }
         )
     return {"tiers": rows, "unknown": unknown}
+
+
+def tier_unlocks_path_batch(
+    from_tier: str, to_tiers
+) -> dict | None:
+    """Batch sibling of :func:`tier_unlocks_path`: per-rung marginal-
+    unlocks rows for a caller-supplied subset of destination tiers all
+    walked from a single ``from_tier`` in ONE round-trip.
+
+    Multi-destination twin of :func:`capacity_diff_path_batch` (same
+    fan-out shape, unlocks-only per-rung body) and unlocks-only sibling
+    of :func:`tier_spec_path_batch` (same multi-destination axis,
+    marginal-grant body instead of full per-rung spec). Lets an
+    upgrade-comparison surface render "from my current rung, here are
+    the 3 tiers I'm considering -- show me the newly-unlocked features
+    + runtimes at every rung climbed to reach each" off ONE call
+    instead of N calls to :func:`tier_unlocks_path`.
+
+    Per-destination row shape::
+
+        {
+          "to":         "<tier id>",
+          "to_label":   "...",
+          "to_rank":    <int>,
+          "direction":  "upgrade" | "downgrade" | "lateral" | "identity",
+          "path":       [<tier_unlocks_path row>, ...],
+        }
+
+    Each ``path`` row is byte-identical to a row from
+    :func:`tier_unlocks_path` for the same ``(from_tier, to)`` pair --
+    a parity test pins this so the scalar and batch path helpers
+    cannot drift. The walked rungs are destination-specific (the
+    path's rung set depends on ``to``), so per-destination ``path``
+    lengths can legitimately differ -- this matches
+    :func:`capacity_diff_path_batch` and :func:`tier_spec_path_batch`'s
+    posture and differs from :func:`feature_spec_path_batch` /
+    :func:`runtime_spec_path_batch` whose rungs are axis-id-agnostic.
+
+    Shape::
+
+        {
+          "tiers": [
+            {"to": "<id>", "to_label": ..., "to_rank": ..., "direction": ..., "path": [...]},
+            ...
+          ],
+          "unknown": ["bogus_id", ...],
+        }
+
+    Supplied destination ids are normalised via :func:`_normalise_csv`
+    (whitespace stripped, lowercased, duplicates dropped, first-seen
+    order preserved). Unknown ids are echoed in ``unknown[]`` instead
+    of short-circuiting -- a partially-bad caller still gets paths
+    back for the valid ids alongside a list of what was dropped,
+    matching :func:`capacity_diff_path_batch` /
+    :func:`tier_spec_path_batch` / :func:`feature_spec_path_batch` /
+    :func:`runtime_spec_path_batch`'s posture. ``trial`` IS accepted
+    as a destination (it is excluded from the walked intermediate
+    rungs the way :func:`tier_unlocks_path` already excludes it, but
+    is a valid endpoint via the lateral / identity branches).
+
+    Returns ``None`` for empty / unknown ``from_tier`` (caller renders
+    "unknown tier" / 404).
+
+    Resolver-independent: delegates per-destination to
+    :func:`tier_unlocks_path`, which walks the static
+    :data:`_PURCHASABLE_TIERS` ladder and folds per-rung marginal
+    grants via :func:`_unlocks_row` -- so grace vs enforce yields
+    byte-identical rows. Never raises: per-destination failures
+    short-circuit that id into ``unknown[]`` and the rest of the
+    batch keeps building.
+    """
+    try:
+        f = (from_tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if f not in _TIER_FEATURES:
+        return None
+    candidates = _normalise_csv(to_tiers)
+    rows: list[dict] = []
+    unknown: list[str] = []
+    from_rank = _TIER_RANK.get(f, -1)
+    for tid in candidates:
+        if tid not in _TIER_FEATURES:
+            unknown.append(tid)
+            continue
+        try:
+            path = tier_unlocks_path(f, tid)
+        except Exception as exc:
+            logger.warning(
+                "entitlements: tier_unlocks_path_batch row %r failed: %s",
+                tid,
+                exc,
+            )
+            unknown.append(tid)
+            continue
+        if path is None:
+            unknown.append(tid)
+            continue
+        to_rank = _TIER_RANK.get(tid, -1)
+        if f == tid:
+            direction = "identity"
+        elif from_rank == to_rank:
+            direction = "lateral"
+        elif to_rank > from_rank:
+            direction = "upgrade"
+        else:
+            direction = "downgrade"
+        rows.append(
+            {
+                "to": tid,
+                "to_label": tier_label(tid),
+                "to_rank": to_rank,
+                "direction": direction,
+                "path": path,
+            }
+        )
+    return {"tiers": rows, "unknown": unknown}
+
+
+def tier_locks_path_batch(
+    from_tier: str, to_tiers
+) -> dict | None:
+    """Batch sibling of :func:`tier_locks_path`: per-rung marginal-locks
+    rows for a caller-supplied subset of destination tiers all walked
+    from a single ``from_tier`` in ONE round-trip.
+
+    Marginal-loss mirror of :func:`tier_unlocks_path_batch` and multi-
+    destination twin of :func:`capacity_diff_path_batch` (same fan-out
+    shape, locks-only per-rung body) / :func:`tier_spec_path_batch`
+    (same multi-destination axis, marginal-loss body instead of full
+    per-rung spec). Lets a downgrade-walkthrough surface render "from
+    my current rung, here are the 3 tiers I'm considering dropping to
+    -- show me the newly-lost features + runtimes at every rung walked
+    to reach each" off ONE call instead of N calls to
+    :func:`tier_locks_path`.
+
+    Per-destination row shape::
+
+        {
+          "to":         "<tier id>",
+          "to_label":   "...",
+          "to_rank":    <int>,
+          "direction":  "upgrade" | "downgrade" | "lateral" | "identity",
+          "path":       [<tier_locks_path row>, ...],
+        }
+
+    Each ``path`` row is byte-identical to a row from
+    :func:`tier_locks_path` for the same ``(from_tier, to)`` pair --
+    a parity test pins this so the scalar and batch path helpers
+    cannot drift. The walked rungs are destination-specific (the
+    path's rung set depends on ``to``), so per-destination ``path``
+    lengths can legitimately differ -- this matches
+    :func:`tier_unlocks_path_batch`, :func:`capacity_diff_path_batch`
+    and :func:`tier_spec_path_batch`'s posture and differs from
+    :func:`feature_spec_path_batch` / :func:`runtime_spec_path_batch`
+    whose rungs are axis-id-agnostic.
+
+    Shape::
+
+        {
+          "tiers": [
+            {"to": "<id>", "to_label": ..., "to_rank": ..., "direction": ..., "path": [...]},
+            ...
+          ],
+          "unknown": ["bogus_id", ...],
+        }
+
+    Supplied destination ids are normalised via :func:`_normalise_csv`
+    (whitespace stripped, lowercased, duplicates dropped, first-seen
+    order preserved). Unknown ids are echoed in ``unknown[]`` instead
+    of short-circuiting -- a partially-bad caller still gets paths
+    back for the valid ids alongside a list of what was dropped,
+    matching :func:`tier_unlocks_path_batch` /
+    :func:`capacity_diff_path_batch` / :func:`tier_spec_path_batch` /
+    :func:`feature_spec_path_batch` / :func:`runtime_spec_path_batch`'s
+    posture. ``trial`` IS accepted as a destination (it is excluded
+    from the walked intermediate rungs the way :func:`tier_locks_path`
+    already excludes it, but is a valid endpoint via the lateral /
+    identity branches).
+
+    Returns ``None`` for empty / unknown ``from_tier`` (caller renders
+    "unknown tier" / 404).
+
+    Resolver-independent: delegates per-destination to
+    :func:`tier_locks_path`, which walks the static
+    :data:`_PURCHASABLE_TIERS` ladder and folds per-rung marginal
+    losses via :func:`_locks_row` -- so grace vs enforce yields
+    byte-identical rows. Never raises: per-destination failures
+    short-circuit that id into ``unknown[]`` and the rest of the
+    batch keeps building.
+    """
+    try:
+        f = (from_tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if f not in _TIER_FEATURES:
+        return None
+    candidates = _normalise_csv(to_tiers)
+    rows: list[dict] = []
+    unknown: list[str] = []
+    from_rank = _TIER_RANK.get(f, -1)
+    for tid in candidates:
+        if tid not in _TIER_FEATURES:
+            unknown.append(tid)
+            continue
+        try:
+            path = tier_locks_path(f, tid)
+        except Exception as exc:
+            logger.warning(
+                "entitlements: tier_locks_path_batch row %r failed: %s",
+                tid,
+                exc,
+            )
+            unknown.append(tid)
+            continue
+        if path is None:
+            unknown.append(tid)
+            continue
+        to_rank = _TIER_RANK.get(tid, -1)
+        if f == tid:
+            direction = "identity"
+        elif from_rank == to_rank:
+            direction = "lateral"
+        elif to_rank > from_rank:
+            direction = "upgrade"
+        else:
+            direction = "downgrade"
+        rows.append(
+            {
+                "to": tid,
+                "to_label": tier_label(tid),
+                "to_rank": to_rank,
+                "direction": direction,
+                "path": path,
+            }
+        )
+    return {"tiers": rows, "unknown": unknown}

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -7899,3 +7899,217 @@ def api_entitlement_capacity_diff_path_batch():
                 "unknown": [],
             }
         )
+
+
+@bp_entitlement.route("/api/entitlement/tier-unlocks-path-batch")
+def api_entitlement_tier_unlocks_path_batch():
+    """``GET /api/entitlement/tier-unlocks-path-batch?from=<id>&to=a,b,c``
+    -- batch sibling of ``/api/entitlement/tier-unlocks-path``.
+
+    Where ``/tier-unlocks-path`` walks the rungs between ONE
+    ``(from, to)`` pair, this walks the rungs between ONE ``from`` and
+    N candidate ``to`` tiers in ONE round-trip. Pairs with
+    ``/tier-unlocks-path`` the same way ``/capacity-diff-path-batch``
+    pairs with ``/capacity-diff-path``: scalar -> matrix in one call.
+    Multi-destination twin of ``/capacity-diff-path-batch`` (same
+    fan-out shape, marginal-unlocks per-rung body) and unlocks-only
+    sibling of ``/tier-spec-path-batch`` (same multi-destination axis,
+    marginal-grant body instead of full per-rung spec).
+
+    Use case: an upgrade-comparison "from my current rung, here are
+    the 3 tiers I'm considering -- show me the newly-unlocked features
+    + runtimes at every rung climbed to reach each" surface hydrates
+    the per-rung marginal unlocks to every candidate off ONE call
+    instead of N calls to ``/tier-unlocks-path``. Same-rank siblings
+    strictly between the endpoints are included for each
+    per-destination path; same-rank siblings of each destination are
+    excluded so the per-destination path terminates exactly at its own
+    ``to``. Per-destination path lengths can legitimately differ (the
+    rungs walked depend on the destination), matching
+    ``/capacity-diff-path-batch`` and ``/tier-spec-path-batch``'s
+    posture.
+
+    Each row in ``tiers[].path`` is byte-identical to a row from
+    ``/tier-unlocks-path?from=<from>&to=<to>`` -- pinned by the parity
+    tests so the scalar and batch path accessors cannot drift.
+    Supplied destination ids are normalised (whitespace stripped,
+    lowercased, duplicates dropped, first-seen order preserved).
+    Unknown ids do not 404 the call -- they are echoed in
+    ``unknown[]`` so a partially-bad caller still gets paths back for
+    the valid ids.
+
+    Response shape::
+
+        {
+          "from":       "<tier id>",
+          "from_label": "...",
+          "from_rank":  <int>,
+          "tiers": [
+            {
+              "to":        "<tier id>",
+              "to_label":  "...",
+              "to_rank":   <int>,
+              "direction": "upgrade" | "downgrade" | "lateral" | "identity",
+              "path":      [<tier-unlocks row>, ...],
+            },
+            ...
+          ],
+          "unknown":    ["bogus_id", ...],
+        }
+
+    - **400** when ``from=`` is missing / blank, or ``to=`` is missing
+      / empty after normalisation
+    - **404** when ``from`` is unknown (body carries ``which: "tier"``)
+    - **200** with bucketed unknowns for unknown destination ids --
+      does NOT 404 the call, matching every other batch sibling
+    - **Never 5xxs**: a synthesis failure short-circuits to an envelope
+      with empty rows so the matrix keeps rendering.
+    """
+    f = (request.args.get("from") or "").strip().lower()
+    if not f:
+        return jsonify({"error": "missing from"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        if f not in _ent._TIER_ORDER:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "tier", "tier": f}
+                ),
+                404,
+            )
+        targets = _parse_csv_arg("to")
+        if not targets:
+            return jsonify({"error": "supply to=<csv>"}), 400
+        batch = _ent.tier_unlocks_path_batch(f, targets)
+        if batch is None:
+            batch = {"tiers": [], "unknown": []}
+        return jsonify(
+            {
+                "from": f,
+                "from_label": _ent.tier_label(f),
+                "from_rank": _ent.tier_rank(f),
+                "tiers": batch.get("tiers", []),
+                "unknown": batch.get("unknown", []),
+            }
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_tier_unlocks_path_batch: error: %s", exc
+        )
+        return jsonify(
+            {
+                "from": f,
+                "from_label": None,
+                "from_rank": -1,
+                "tiers": [],
+                "unknown": [],
+            }
+        )
+
+
+@bp_entitlement.route("/api/entitlement/tier-locks-path-batch")
+def api_entitlement_tier_locks_path_batch():
+    """``GET /api/entitlement/tier-locks-path-batch?from=<id>&to=a,b,c``
+    -- batch sibling of ``/api/entitlement/tier-locks-path``.
+
+    Where ``/tier-locks-path`` walks the rungs between ONE
+    ``(from, to)`` pair, this walks the rungs between ONE ``from`` and
+    N candidate ``to`` tiers in ONE round-trip. Pairs with
+    ``/tier-locks-path`` the same way ``/tier-unlocks-path-batch``
+    pairs with ``/tier-unlocks-path``: scalar -> matrix in one call.
+    Marginal-loss mirror of ``/tier-unlocks-path-batch`` (same multi-
+    destination axis, locks body instead of unlocks body) and locks-
+    only sibling of ``/tier-spec-path-batch`` (same fan-out shape,
+    marginal-loss body instead of full per-rung spec).
+
+    Use case: a downgrade-walkthrough "from my current rung, here are
+    the 3 tiers I'm considering dropping to -- show me the newly-lost
+    features + runtimes at every rung walked to reach each" surface
+    hydrates the per-rung marginal losses to every candidate off ONE
+    call instead of N calls to ``/tier-locks-path``. Same-rank
+    siblings strictly between the endpoints are included for each
+    per-destination path; same-rank siblings of each destination are
+    excluded so the per-destination path terminates exactly at its own
+    ``to``. Per-destination path lengths can legitimately differ (the
+    rungs walked depend on the destination), matching
+    ``/tier-unlocks-path-batch`` and ``/tier-spec-path-batch``'s
+    posture.
+
+    Each row in ``tiers[].path`` is byte-identical to a row from
+    ``/tier-locks-path?from=<from>&to=<to>`` -- pinned by the parity
+    tests so the scalar and batch path accessors cannot drift.
+    Supplied destination ids are normalised (whitespace stripped,
+    lowercased, duplicates dropped, first-seen order preserved).
+    Unknown ids do not 404 the call -- they are echoed in
+    ``unknown[]`` so a partially-bad caller still gets paths back for
+    the valid ids.
+
+    Response shape::
+
+        {
+          "from":       "<tier id>",
+          "from_label": "...",
+          "from_rank":  <int>,
+          "tiers": [
+            {
+              "to":        "<tier id>",
+              "to_label":  "...",
+              "to_rank":   <int>,
+              "direction": "upgrade" | "downgrade" | "lateral" | "identity",
+              "path":      [<tier-locks row>, ...],
+            },
+            ...
+          ],
+          "unknown":    ["bogus_id", ...],
+        }
+
+    - **400** when ``from=`` is missing / blank, or ``to=`` is missing
+      / empty after normalisation
+    - **404** when ``from`` is unknown (body carries ``which: "tier"``)
+    - **200** with bucketed unknowns for unknown destination ids --
+      does NOT 404 the call, matching every other batch sibling
+    - **Never 5xxs**: a synthesis failure short-circuits to an envelope
+      with empty rows so the matrix keeps rendering.
+    """
+    f = (request.args.get("from") or "").strip().lower()
+    if not f:
+        return jsonify({"error": "missing from"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        if f not in _ent._TIER_ORDER:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "tier", "tier": f}
+                ),
+                404,
+            )
+        targets = _parse_csv_arg("to")
+        if not targets:
+            return jsonify({"error": "supply to=<csv>"}), 400
+        batch = _ent.tier_locks_path_batch(f, targets)
+        if batch is None:
+            batch = {"tiers": [], "unknown": []}
+        return jsonify(
+            {
+                "from": f,
+                "from_label": _ent.tier_label(f),
+                "from_rank": _ent.tier_rank(f),
+                "tiers": batch.get("tiers", []),
+                "unknown": batch.get("unknown", []),
+            }
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_tier_locks_path_batch: error: %s", exc
+        )
+        return jsonify(
+            {
+                "from": f,
+                "from_label": None,
+                "from_rank": -1,
+                "tiers": [],
+                "unknown": [],
+            }
+        )

--- a/tests/test_entitlement_tier_locks_path_batch.py
+++ b/tests/test_entitlement_tier_locks_path_batch.py
@@ -1,0 +1,539 @@
+"""Tests for ``tier_locks_path_batch(from_tier, to_tiers)`` plus its
+HTTP endpoint ``/api/entitlement/tier-locks-path-batch``.
+
+Batch sibling of ``tier_locks_path``: where the scalar path helper
+walks one ``(from, to)`` pair, the batch helper walks N candidate
+destinations from one source in ONE round-trip. Marginal-loss mirror
+of :func:`tier_unlocks_path_batch` and multi-destination twin of
+:func:`capacity_diff_path_batch` (same fan-out shape, marginal-locks
+per-rung body) / :func:`tier_spec_path_batch` (same multi-destination
+axis, marginal-loss body instead of full per-rung spec).
+
+Each per-destination ``path`` must be byte-identical to the matching
+scalar :func:`tier_locks_path` payload for the same ``(from, to)``
+pair -- pinned by the parity tests below so the scalar and batch path
+accessors cannot drift.
+
+Coverage:
+
+* per-destination ``path`` byte-equal to the scalar
+  :func:`tier_locks_path` payload
+* per-row body matches the singular :func:`tier_locks` row shape
+  (``tier``, ``tier_label``, ``tier_rank``, ``next_tier``,
+  ``next_tier_label``, ``next_tier_rank``, ``lost_features``,
+  ``lost_runtimes``)
+* ``next_tier`` is path-chained (the previous step in the walked path,
+  never ``None`` on any path row) -- matches the scalar helper's one
+  semantic difference vs :func:`tier_locks`
+* per-rung chain continuous on the tier axis
+  (``row[i]['tier'] == row[i+1]['next_tier']``) on every per-
+  destination path
+* per-destination ``direction`` derived from the same ranks the scalar
+  endpoint uses
+* batch envelope mirrors ``/tier-locks-path``'s envelope on the source
+  side (``from`` / ``from_label`` / ``from_rank``) and carries
+  ``tiers`` + ``unknown``
+* input normalised (whitespace stripped, lowercased, duplicates dropped,
+  first-seen order preserved)
+* unknown destination ids echoed in ``unknown[]`` instead of 404'ing
+  the call (matching every other batch sibling)
+* identity ``from == to`` yields a per-destination entry whose ``path``
+  is ``[]``
+* lateral (same rank) yields a one-row per-destination ``path``
+* upgrade / downgrade direction labelled correctly; upgrade rows carry
+  empty lost lists but still walk the rungs
+* trial accepted as a destination (lateral / identity endpoint only --
+  excluded from intermediate rungs, same as the scalar helper)
+* unknown / empty / garbage ``from_tier`` returns ``None`` (helper) /
+  400 / 404 (HTTP)
+* helpers never raise -- a per-destination failure short-circuits that
+  id into ``unknown[]`` and the rest of the batch keeps building
+* HTTP endpoint 400 on missing / empty input, 404 on unknown source
+  tier, never 5xx on a row failure
+* grace vs enforce yields identical rows (resolver-independent)
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+_ROW_KEYS = {
+    "tier",
+    "tier_label",
+    "tier_rank",
+    "next_tier",
+    "next_tier_label",
+    "next_tier_rank",
+    "lost_features",
+    "lost_runtimes",
+}
+
+_ITEM_KEYS = {"to", "to_label", "to_rank", "direction", "path"}
+
+_ENVELOPE_KEYS = {
+    "from",
+    "from_label",
+    "from_rank",
+    "tiers",
+    "unknown",
+}
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# ── helper-level: shape ──────────────────────────────────────────────────────
+
+
+def test_helper_returns_dict_shape(ent):
+    out = ent.tier_locks_path_batch(
+        ent.TIER_ENTERPRISE, [ent.TIER_CLOUD_PRO, ent.TIER_OSS]
+    )
+    assert isinstance(out, dict)
+    assert set(out.keys()) == {"tiers", "unknown"}
+    assert isinstance(out["tiers"], list)
+    assert isinstance(out["unknown"], list)
+
+
+def test_helper_each_item_carries_full_envelope(ent):
+    out = ent.tier_locks_path_batch(
+        ent.TIER_ENTERPRISE, [ent.TIER_CLOUD_PRO, ent.TIER_OSS]
+    )
+    for item in out["tiers"]:
+        assert set(item.keys()) == _ITEM_KEYS
+        assert isinstance(item["to"], str)
+        assert isinstance(item["to_label"], str)
+        assert isinstance(item["to_rank"], int)
+        assert item["direction"] in {
+            "upgrade",
+            "downgrade",
+            "lateral",
+            "identity",
+        }
+        assert isinstance(item["path"], list)
+
+
+def test_helper_per_row_matches_tier_locks_schema(ent):
+    """Per-row body must match the singular :func:`tier_locks` row
+    shape exactly."""
+    out = ent.tier_locks_path_batch(
+        ent.TIER_ENTERPRISE, [ent.TIER_OSS]
+    )
+    for row in out["tiers"][0]["path"]:
+        assert set(row.keys()) == _ROW_KEYS
+        assert isinstance(row["lost_features"], list)
+        assert isinstance(row["lost_runtimes"], list)
+
+
+def test_helper_next_tier_fields_never_none_on_path(ent):
+    """Path-chained source guarantees ``next_tier`` (+ label/rank) are
+    concrete on every path row -- the one semantic difference vs the
+    singular :func:`tier_locks` (which can carry ``None`` at the
+    ceiling)."""
+    out = ent.tier_locks_path_batch(
+        ent.TIER_ENTERPRISE, [ent.TIER_CLOUD_STARTER, ent.TIER_OSS]
+    )
+    for item in out["tiers"]:
+        for row in item["path"]:
+            assert row["next_tier"] is not None
+            assert row["next_tier_label"] is not None
+            assert row["next_tier_rank"] is not None
+
+
+def test_helper_chain_continuous_on_tier_axis(ent):
+    """``row[i]['tier'] == row[i+1]['next_tier']`` on every per-
+    destination path -- the path-chained invariant the scalar helper
+    enforces."""
+    out = ent.tier_locks_path_batch(
+        ent.TIER_ENTERPRISE, [ent.TIER_CLOUD_STARTER, ent.TIER_OSS]
+    )
+    for item in out["tiers"]:
+        path = item["path"]
+        for i in range(len(path) - 1):
+            assert path[i]["tier"] == path[i + 1]["next_tier"]
+
+
+# ── helper-level: parity with scalar ─────────────────────────────────────────
+
+
+def test_helper_per_item_path_byte_equal_to_scalar(ent):
+    """Pin: per-destination ``path`` is byte-identical to the scalar
+    :func:`tier_locks_path` payload for the same ``(from, to)`` pair."""
+    candidates = [
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_FREE,
+        ent.TIER_OSS,
+    ]
+    out = ent.tier_locks_path_batch(ent.TIER_ENTERPRISE, candidates)
+    by_id = {item["to"]: item["path"] for item in out["tiers"]}
+    for tid in candidates:
+        scalar = ent.tier_locks_path(ent.TIER_ENTERPRISE, tid)
+        assert by_id[tid] == scalar
+
+
+def test_helper_per_item_direction_matches_rank_geometry(ent):
+    """Per-destination ``direction`` is derived from rank geometry and
+    must agree with the scalar endpoint's derivation."""
+    candidates = [
+        ent.TIER_OSS,
+        ent.TIER_CLOUD_FREE,
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_PRO,
+        ent.TIER_ENTERPRISE,
+    ]
+    out = ent.tier_locks_path_batch(ent.TIER_CLOUD_STARTER, candidates)
+    by_id = {item["to"]: item for item in out["tiers"]}
+    src_rank = ent.tier_rank(ent.TIER_CLOUD_STARTER)
+    for tid in candidates:
+        tgt_rank = ent.tier_rank(tid)
+        if tid == ent.TIER_CLOUD_STARTER:
+            expected = "identity"
+        elif src_rank == tgt_rank:
+            expected = "lateral"
+        elif tgt_rank > src_rank:
+            expected = "upgrade"
+        else:
+            expected = "downgrade"
+        assert by_id[tid]["direction"] == expected
+
+
+# ── helper-level: input normalisation ────────────────────────────────────────
+
+
+def test_helper_supply_order_preserved(ent):
+    out = ent.tier_locks_path_batch(
+        ent.TIER_ENTERPRISE,
+        [ent.TIER_OSS, ent.TIER_CLOUD_STARTER, ent.TIER_CLOUD_PRO],
+    )
+    assert [item["to"] for item in out["tiers"]] == [
+        ent.TIER_OSS,
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+    ]
+
+
+def test_helper_normalises_input(ent):
+    out = ent.tier_locks_path_batch(
+        ent.TIER_ENTERPRISE,
+        [
+            "  CLOUD_PRO  ",
+            "cloud_starter",
+            "cloud_pro",
+            "",
+        ],
+    )
+    assert [item["to"] for item in out["tiers"]] == [
+        "cloud_pro",
+        "cloud_starter",
+    ]
+
+
+def test_helper_unknown_destination_ids_echoed(ent):
+    out = ent.tier_locks_path_batch(
+        ent.TIER_ENTERPRISE,
+        [ent.TIER_CLOUD_PRO, "bogus_tier", "still_bogus"],
+    )
+    assert [item["to"] for item in out["tiers"]] == [ent.TIER_CLOUD_PRO]
+    assert set(out["unknown"]) == {"bogus_tier", "still_bogus"}
+
+
+# ── helper-level: direction branches ─────────────────────────────────────────
+
+
+def test_helper_identity_yields_empty_path(ent):
+    out = ent.tier_locks_path_batch(
+        ent.TIER_CLOUD_PRO, [ent.TIER_CLOUD_PRO, ent.TIER_OSS]
+    )
+    by_id = {item["to"]: item for item in out["tiers"]}
+    assert by_id[ent.TIER_CLOUD_PRO]["direction"] == "identity"
+    assert by_id[ent.TIER_CLOUD_PRO]["path"] == []
+    assert by_id[ent.TIER_OSS]["direction"] == "downgrade"
+
+
+def test_helper_lateral_yields_one_row_path(ent):
+    out = ent.tier_locks_path_batch(
+        ent.TIER_CLOUD_PRO, [ent.TIER_PRO]
+    )
+    assert len(out["tiers"]) == 1
+    item = out["tiers"][0]
+    assert item["direction"] == "lateral"
+    assert len(item["path"]) == 1
+
+
+def test_helper_downgrade_walks_descending_rungs(ent):
+    out = ent.tier_locks_path_batch(ent.TIER_ENTERPRISE, [ent.TIER_OSS])
+    item = out["tiers"][0]
+    assert item["direction"] == "downgrade"
+    tiers = [row["tier"] for row in item["path"]]
+    assert tiers[-1] == ent.TIER_OSS
+    assert ent.TIER_ENTERPRISE not in tiers
+    ranks = [ent.tier_rank(t) for t in tiers]
+    assert ranks == sorted(ranks, reverse=True)
+
+
+def test_helper_upgrade_walks_ascending(ent):
+    out = ent.tier_locks_path_batch(ent.TIER_OSS, [ent.TIER_ENTERPRISE])
+    item = out["tiers"][0]
+    assert item["direction"] == "upgrade"
+    tiers = [row["tier"] for row in item["path"]]
+    ranks = [ent.tier_rank(t) for t in tiers]
+    assert ranks == sorted(ranks)
+
+
+def test_helper_upgrade_rows_carry_empty_losses(ent):
+    """Ascending walks still walk the rungs (so a UI keyed off rung
+    shape keeps working) but every row carries empty loss lists --
+    you gain things on an upgrade, you don't lose them. Matches the
+    scalar helper's posture."""
+    out = ent.tier_locks_path_batch(ent.TIER_OSS, [ent.TIER_ENTERPRISE])
+    for row in out["tiers"][0]["path"]:
+        assert row["lost_features"] == []
+        assert row["lost_runtimes"] == []
+
+
+def test_helper_downgrade_folds_to_cumulative_diff(ent):
+    """Folding ``lost_features`` / ``lost_runtimes`` across a
+    descending path reconstructs the cumulative
+    ``tier_diff(from, to)['lost_*']`` sets -- the path-chained source
+    guarantees this."""
+    src, dst = ent.TIER_ENTERPRISE, ent.TIER_OSS
+    out = ent.tier_locks_path_batch(src, [dst])
+    path = out["tiers"][0]["path"]
+    folded_features = set()
+    folded_runtimes = set()
+    for row in path:
+        folded_features |= set(row["lost_features"])
+        folded_runtimes |= set(row["lost_runtimes"])
+    diff = ent.tier_diff(src, dst)
+    assert folded_features == set(diff["lost_features"])
+    assert folded_runtimes == set(diff["lost_runtimes"])
+
+
+# ── helper-level: trial endpoint ─────────────────────────────────────────────
+
+
+def test_helper_trial_destination_accepted(ent):
+    """``trial`` is a valid endpoint (matching :func:`tier_locks_path`
+    semantics) even though it is excluded from the walked intermediate
+    rungs."""
+    out = ent.tier_locks_path_batch(ent.TIER_ENTERPRISE, [ent.TIER_TRIAL])
+    assert out["unknown"] == []
+    assert [item["to"] for item in out["tiers"]] == [ent.TIER_TRIAL]
+
+
+# ── helper-level: error / edge cases ─────────────────────────────────────────
+
+
+def test_helper_unknown_from_tier_returns_none(ent):
+    assert (
+        ent.tier_locks_path_batch("not_a_tier", [ent.TIER_OSS])
+        is None
+    )
+
+
+def test_helper_empty_destinations_yields_empty_envelope(ent):
+    out = ent.tier_locks_path_batch(ent.TIER_ENTERPRISE, [])
+    assert out == {"tiers": [], "unknown": []}
+
+
+def test_helper_garbage_inputs_never_raise(ent):
+    assert ent.tier_locks_path_batch("", []) is None
+    assert ent.tier_locks_path_batch(None, None) is None  # type: ignore[arg-type]
+    assert ent.tier_locks_path_batch("  ", "  ") is None
+
+
+def test_helper_grace_and_enforce_yield_identical_output(ent, monkeypatch):
+    candidates = [ent.TIER_CLOUD_STARTER, ent.TIER_OSS]
+    grace = ent.tier_locks_path_batch(ent.TIER_ENTERPRISE, candidates)
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    enforced = ent.tier_locks_path_batch(ent.TIER_ENTERPRISE, candidates)
+    assert grace == enforced
+
+
+def test_helper_row_failure_short_circuits_item(ent, monkeypatch):
+    """A per-destination failure pushes that id into ``unknown[]`` while
+    the rest of the batch keeps building."""
+    real = ent.tier_locks_path
+
+    def fake(f, t):
+        if t == ent.TIER_CLOUD_PRO:
+            raise RuntimeError("boom")
+        return real(f, t)
+
+    monkeypatch.setattr(ent, "tier_locks_path", fake)
+    out = ent.tier_locks_path_batch(
+        ent.TIER_ENTERPRISE, [ent.TIER_CLOUD_PRO, ent.TIER_OSS]
+    )
+    assert [item["to"] for item in out["tiers"]] == [ent.TIER_OSS]
+    assert ent.TIER_CLOUD_PRO in out["unknown"]
+
+
+# ── HTTP: /api/entitlement/tier-locks-path-batch ─────────────────────────────
+
+
+def test_api_400_on_missing_from(client):
+    r = client.get(
+        "/api/entitlement/tier-locks-path-batch?to=cloud_pro,oss"
+    )
+    assert r.status_code == 400
+
+
+def test_api_400_on_missing_to(client):
+    r = client.get("/api/entitlement/tier-locks-path-batch?from=enterprise")
+    assert r.status_code == 400
+    body = r.get_json()
+    assert body["error"] == "supply to=<csv>"
+
+
+def test_api_400_on_empty_to(client):
+    r = client.get(
+        "/api/entitlement/tier-locks-path-batch?from=enterprise&to=,,"
+    )
+    assert r.status_code == 400
+
+
+def test_api_404_on_unknown_from_tier(client):
+    r = client.get(
+        "/api/entitlement/tier-locks-path-batch?from=not_a_tier&to=oss"
+    )
+    assert r.status_code == 404
+    body = r.get_json()
+    assert body["which"] == "tier"
+
+
+def test_api_200_with_unknown_destination_bucketed(client, ent):
+    r = client.get(
+        f"/api/entitlement/tier-locks-path-batch?from={ent.TIER_ENTERPRISE}"
+        f"&to={ent.TIER_CLOUD_PRO},bogus_tier"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert [item["to"] for item in body["tiers"]] == [ent.TIER_CLOUD_PRO]
+    assert body["unknown"] == ["bogus_tier"]
+
+
+def test_api_happy_path_descending(client, ent):
+    r = client.get(
+        f"/api/entitlement/tier-locks-path-batch?from={ent.TIER_ENTERPRISE}"
+        f"&to={ent.TIER_CLOUD_PRO},{ent.TIER_OSS}"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert set(body.keys()) == _ENVELOPE_KEYS
+    assert body["from"] == ent.TIER_ENTERPRISE
+    assert isinstance(body["from_label"], str)
+    assert body["from_rank"] == ent.tier_rank(ent.TIER_ENTERPRISE)
+    tos = [item["to"] for item in body["tiers"]]
+    assert tos == [ent.TIER_CLOUD_PRO, ent.TIER_OSS]
+    for item in body["tiers"]:
+        assert item["direction"] == "downgrade"
+        assert item["path"][-1]["tier"] == item["to"]
+
+
+def test_api_identity_branch(client, ent):
+    r = client.get(
+        f"/api/entitlement/tier-locks-path-batch"
+        f"?from={ent.TIER_CLOUD_PRO}&to={ent.TIER_CLOUD_PRO}"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["tiers"][0]["direction"] == "identity"
+    assert body["tiers"][0]["path"] == []
+
+
+def test_api_lateral_branch(client, ent):
+    r = client.get(
+        f"/api/entitlement/tier-locks-path-batch"
+        f"?from={ent.TIER_CLOUD_PRO}&to={ent.TIER_PRO}"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["tiers"][0]["direction"] == "lateral"
+    assert len(body["tiers"][0]["path"]) == 1
+
+
+def test_api_upgrade_branch(client, ent):
+    r = client.get(
+        f"/api/entitlement/tier-locks-path-batch"
+        f"?from={ent.TIER_OSS}&to={ent.TIER_ENTERPRISE}"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["tiers"][0]["direction"] == "upgrade"
+
+
+def test_api_per_item_path_matches_scalar_route(client, ent):
+    """HTTP parity: each per-destination ``path`` is byte-identical to
+    the scalar ``/tier-locks-path?from=&to=`` ``path`` payload for the
+    same ``(from, to)`` pair."""
+    candidates = [
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_OSS,
+    ]
+    batch = client.get(
+        f"/api/entitlement/tier-locks-path-batch?from={ent.TIER_ENTERPRISE}"
+        f"&to={','.join(candidates)}"
+    ).get_json()
+    for item in batch["tiers"]:
+        scalar = client.get(
+            f"/api/entitlement/tier-locks-path?from={ent.TIER_ENTERPRISE}"
+            f"&to={item['to']}"
+        ).get_json()
+        assert item["path"] == scalar["path"]
+        assert item["direction"] == scalar["direction"]
+        assert item["to_label"] == scalar["to_label"]
+        assert item["to_rank"] == scalar["to_rank"]
+
+
+def test_api_input_normalised(client, ent):
+    r = client.get(
+        f"/api/entitlement/tier-locks-path-batch?from={ent.TIER_ENTERPRISE}"
+        f"&to=  CLOUD_PRO  ,cloud_starter,cloud_pro,"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert [item["to"] for item in body["tiers"]] == [
+        "cloud_pro",
+        "cloud_starter",
+    ]
+
+
+def test_api_grace_and_enforce_yield_identical_body(
+    client, ent, monkeypatch
+):
+    grace = client.get(
+        f"/api/entitlement/tier-locks-path-batch?from={ent.TIER_ENTERPRISE}"
+        f"&to={ent.TIER_CLOUD_STARTER},{ent.TIER_OSS}"
+    ).get_json()
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    enforced = client.get(
+        f"/api/entitlement/tier-locks-path-batch?from={ent.TIER_ENTERPRISE}"
+        f"&to={ent.TIER_CLOUD_STARTER},{ent.TIER_OSS}"
+    ).get_json()
+    assert grace == enforced


### PR DESCRIPTION
## Summary

- New helper `tier_locks_path_batch(from_tier, to_tiers) -> {tiers, unknown}` in `clawmetry/entitlements.py` — marginal-loss mirror of `tier_unlocks_path_batch` and locks-only sibling of `tier_spec_path_batch`. Walks the rungs between ONE `from` and N candidate `to` tiers in ONE round-trip; each per-rung row is byte-identical to the scalar `tier_locks_path` payload for the same `(from, to)` pair (parity-pinned).
- New endpoint `GET /api/entitlement/tier-locks-path-batch?from=<id>&to=a,b,c` in `routes/entitlement.py` wrapping the helper.
- Use case: a downgrade-walkthrough surface renders "from my current rung, here are the 3 tiers I'm considering dropping to — show me the newly-lost features + runtimes at every rung walked to reach each" off one call instead of N.

## Test plan

- [x] `python3 -m pytest tests/test_entitlement_tier_locks_path_batch.py` — 34/34 pass
- [x] `python3 -m pytest tests/test_entitlement_tier_locks_path.py tests/test_entitlement_spec_path_batch.py` — sibling tests still 82/82 pass (no regression)
- [x] `python3 -m py_compile clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_tier_locks_path_batch.py` clean
- [x] `ruff check` clean on the three touched files

Coverage:

- per-destination `path` byte-equal to the scalar `tier_locks_path` payload
- per-row body matches the singular `tier_locks` row shape (`tier`, `tier_label`, `tier_rank`, `next_tier`, `next_tier_label`, `next_tier_rank`, `lost_features`, `lost_runtimes`)
- `next_tier` is path-chained (the previous step in the walked path, never `None` on any path row)
- per-rung chain continuous on the tier axis (`row[i]['tier'] == row[i+1]['next_tier']`)
- per-destination `direction` derived from rank geometry, agreeing with scalar
- input normalisation: whitespace stripped, lowercased, duplicates dropped, first-seen order preserved
- unknown destination ids echoed in `unknown[]` instead of 404'ing the call
- identity / lateral / upgrade / downgrade branches; upgrade rows carry empty loss lists
- descending fold across `lost_features` / `lost_runtimes` reconstructs `tier_diff(from, to)['lost_*']`
- trial accepted as a destination (lateral / identity endpoint only)
- unknown / empty / garbage `from_tier` returns `None` (helper) / 400 / 404 (HTTP)
- per-destination failure short-circuits that id into `unknown[]` without breaking the rest of the batch
- HTTP 400 on missing / empty input, 404 on unknown source tier, never 5xxs
- grace vs enforce yields identical rows (resolver-independent)

## Local operator verification checklist

Remote agent has no host access; the operator runs these on the live install:

- [ ] Copy changed files into `~/.clawmetry/lib/python<X>.<Y>/site-packages/clawmetry/` (mirror `clawmetry/entitlements.py`, `routes/entitlement.py`, new test).
- [ ] Clear `__pycache__` next to each replaced file.
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` to restart the daemon and the dashboard.
- [ ] `curl -s 'http://localhost:8900/api/entitlement/tier-locks-path-batch?from=enterprise&to=cloud_pro,cloud_starter,oss' | jq` — expect 200, three rows with `direction: "downgrade"`, each row's `path` byte-identical to `GET /api/entitlement/tier-locks-path?from=enterprise&to=<that to>`.
- [ ] `curl -s 'http://localhost:8900/api/entitlement/tier-locks-path-batch?from=enterprise&to=cloud_pro,bogus_tier' | jq` — expect 200, one tier row + `unknown: ["bogus_tier"]`.
- [ ] `curl -s -o /dev/null -w "%{http_code}\n" 'http://localhost:8900/api/entitlement/tier-locks-path-batch?to=oss'` — expect 400.
- [ ] `curl -s -o /dev/null -w "%{http_code}\n" 'http://localhost:8900/api/entitlement/tier-locks-path-batch?from=not_a_tier&to=oss'` — expect 404 (`which: "tier"`).
- [ ] Decrypt the live cloud snapshot, browser-check (no UI surfaces consume this endpoint yet — it's a backend addition behind a parity guarantee, so the dashboard should look unchanged in grace mode).
- [ ] `/api/entitlement` still resolves to the OSS-free grace envelope (no behaviour change in grace mode).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NBApYBNRd1oHfKJVkcjT4E

---
_Generated by [Claude Code](https://claude.ai/code/session_01NBApYBNRd1oHfKJVkcjT4E)_