### PR TITLE
fix(install): runtime-neutral installer banner (not OpenClaw-only)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -12,7 +12,7 @@ DIM='\033[2m'
 NC='\033[0m'
 
 echo ""
-echo -e "  ${BOLD}🦞 ClawMetry${NC}  ${DIM}AI Observability for OpenClaw${NC}"
+echo -e "  ${BOLD}🦞 ClawMetry${NC}  ${DIM}Observability for your AI agents${NC}"
 echo -e "  $(printf '%.0s─' {1..50})"
 echo ""
 


### PR DESCRIPTION
## Why
The `curl -fsSL https://clawmetry.com/install.sh | bash` banner read **"AI Observability for OpenClaw"** (founder screenshot). That violates the multi-runtime non-negotiable (ClawMetry observes 12 runtimes, OpenClaw is one of them) and it is the very first thing a new user sees.

`clawmetry.com/install.sh` is served by the landing app fetching **this file raw from `main` with `no-cache`** (`app.py:/install.sh`), so editing this file fixes the live banner the moment it merges, with no release or deploy.

## Change
Banner now reads **"Observability for your AI agents"** (clean and runtime-neutral; "AI Observability for AI Agents" doubles the "AI").

`bash -n install.sh` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)