### PR TITLE
feat(oauth): headless paste-code sign-in for clawmetry connect (CLI half)

### DIFF
--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -283,20 +283,78 @@ def _stop_existing_daemon() -> None:
         LOG_FILE.write_text("")
 
 
-def _oauth_browser_login(provider: str) -> str:
-    """Browser-bridge OAuth for `clawmetry connect`.
+def _is_headless() -> bool:
+    """True when webbrowser.open() almost certainly can't reach a GUI on THIS host.
 
-    Spins up a one-shot loopback server on 127.0.0.1, opens the cloud OAuth flow
-    with cli_port=<our port>, and captures the cm_ key that the callback redirects
-    back to loopback. Returns "" on timeout/error so the caller falls back to email
-    OTP. The key only ever travels over 127.0.0.1 — nothing is exposed off-host.
+    Used only to ORDER the auth flows, never as a hard gate: the headless path is
+    an interactive paste prompt (not a timed wait), so a wrong guess can never
+    hang the CLI. macOS/Windows always have a usable browser. On Linux, no
+    DISPLAY/WAYLAND or an SSH session means the browser would open on a DIFFERENT
+    machine (the loopback callback can't reach this box). CLAWMETRY_NO_BROWSER=1
+    forces it (for users who know their box, and for the live test).
+    """
+    if os.environ.get("CLAWMETRY_NO_BROWSER") == "1":
+        return True
+    if sys.platform in ("darwin", "win32"):
+        return False
+    no_display = not os.environ.get("DISPLAY") and not os.environ.get("WAYLAND_DISPLAY")
+    ssh = bool(os.environ.get("SSH_CONNECTION") or os.environ.get("SSH_TTY") or os.environ.get("SSH_CLIENT"))
+    return no_display or ssh
+
+
+def _oauth_browser_login(provider: str, input_fn=input, api_call=None) -> str:
+    """OAuth sign-in for `clawmetry connect` (GitHub / Google).
+
+    Desktop: a one-shot 127.0.0.1 loopback server captures the cm_ key the cloud
+    callback redirects back (the key never leaves 127.0.0.1). Headless/remote
+    (SSH/VPS, no GUI): the loopback can't be reached by a browser on another
+    machine, so we use a Claude-Code-style paste-code path instead. The CLI
+    generates a PKCE verifier (kept in memory; only its SHA256 challenge leaves
+    the process), the cloud shows a short single-use code, the user pastes it,
+    and the CLI redeems code+verifier at /api/oauth/cli/exchange over INGEST_URL.
+    Returns "" on timeout/skip/error so the caller falls back to email OTP.
     """
     import http.server
     import urllib.parse
     import webbrowser
     import time as _time
+    import secrets as _secrets
+    import hashlib as _hashlib
+    import base64 as _base64
 
     app_base = os.environ.get("CLAWMETRY_APP_BASE", "https://app.clawmetry.com").rstrip("/")
+
+    # PKCE: the verifier stays in CLI memory only; only its SHA256 (the
+    # challenge) ever leaves this process, in the start URL.
+    verifier = _base64.urlsafe_b64encode(_secrets.token_bytes(32)).rstrip(b"=").decode()
+    challenge = _base64.urlsafe_b64encode(
+        _hashlib.sha256(verifier.encode()).digest()).rstrip(b"=").decode()
+
+    def _paste_path() -> str:
+        """Headless paste-code path. No loopback; redeem over INGEST_URL."""
+        url = f"{app_base}/api/oauth/{provider}/start?cli_paste=1&cc={challenge}"
+        print(f"\n  Browser didn't open? Use the url below to sign in with {provider.title()}:\n  {url}\n")
+        try:
+            webbrowser.open(url)  # best-effort; no-ops on a headless box
+        except Exception:
+            pass
+        code = input_fn("  Paste code here if prompted > ").strip()
+        if not code or api_call is None:
+            return ""
+        resp = api_call("/api/oauth/cli/exchange", {"code": code, "verifier": verifier})
+        if isinstance(resp, dict) and str(resp.get("api_key", "")).startswith("cm_"):
+            print("  Account created. Welcome to ClawMetry." if resp.get("is_new")
+                  else "  Welcome back.")
+            return resp["api_key"]
+        err = (resp or {}).get("error", "that code did not work") if isinstance(resp, dict) else "network error"
+        print(f"  Sign-in could not be completed ({err}).")
+        return ""
+
+    # Headless/remote: skip loopback entirely and use the interactive paste path.
+    if _is_headless():
+        return _paste_path()
+
+    # Desktop: one-shot loopback fast-path.
     captured = {}
 
     class _Handler(http.server.BaseHTTPRequestHandler):
@@ -304,7 +362,7 @@ def _oauth_browser_login(provider: str) -> str:
             params = urllib.parse.parse_qs(urllib.parse.urlparse(self.path).query)
             captured["token"] = (params.get("token") or [""])[0]
             ok = captured["token"].startswith("cm_")
-            msg = ("You're connected — return to your terminal."
+            msg = ("You're connected. Return to your terminal."
                    if ok else "Sign-in failed. Return to your terminal and use email instead.")
             self.send_response(200)
             self.send_header("Content-Type", "text/html; charset=utf-8")
@@ -323,11 +381,12 @@ def _oauth_browser_login(provider: str) -> str:
     try:
         srv = http.server.HTTPServer(("127.0.0.1", 0), _Handler)
     except OSError:
-        return ""
+        # Can't bind loopback -> fall through to the paste path rather than fail.
+        return _paste_path()
     port = srv.server_address[1]
     url = f"{app_base}/api/oauth/{provider}/start?cli_port={port}"
-    print(f"\n  🌐 Opening your browser to sign in with {provider.title()}…")
-    print(f"  If it doesn't open, paste this into your browser:\n  {url}\n")
+    print(f"\n  Opening your browser to sign in with {provider.title()}.")
+    print(f"  Browser didn't open? Use the url below to sign in:\n  {url}\n")
     try:
         webbrowser.open(url)
     except Exception:
@@ -379,14 +438,17 @@ def _get_api_key_interactive() -> str:
 
     print()
     print("  Sign in with:")
-    print("    [1] GitHub      [2] Google      (opens your browser)")
+    print("    [1] GitHub      [2] Google")
     print("    …or type your email to get a 6-digit code.")
     entry = _input("  > ").strip()
 
-    # Browser-bridge OAuth (GitHub / Google). Falls back to email on failure.
+    # OAuth (GitHub / Google). Desktop uses a loopback browser hand-off; a
+    # headless/remote box (SSH/VPS) uses a paste-code path. Falls back to email
+    # on failure. _input is /dev/tty-aware (piped installs) and _api_call talks
+    # to INGEST_URL, both required by the headless exchange.
     _provider = {"1": "github", "github": "github", "2": "google", "google": "google"}.get(entry.lower())
     if _provider:
-        _key = _oauth_browser_login(_provider)
+        _key = _oauth_browser_login(_provider, input_fn=_input, api_call=_api_call)
         if _key:
             return _key
         print("  Couldn't complete browser sign-in. Let's use email instead.")

--- a/tests/test_oauth_headless.py
+++ b/tests/test_oauth_headless.py
@@ -1,0 +1,127 @@
+"""Headless OAuth paste-code path for `clawmetry connect`.
+
+The loopback OAuth callback can't reach a CLI on a remote/headless box (the
+browser opens on the user's laptop). These pin the headless paste-code fork:
+the CLI must use cli_paste mode (not cli_port), redeem via api_call, and never
+hang on a timed wait. Desktop loopback must stay unchanged.
+"""
+import itertools
+
+import pytest
+
+import clawmetry.cli as cli
+
+
+# ── _is_headless ────────────────────────────────────────────────────────────
+
+def test_is_headless_forced(monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_NO_BROWSER", "1")
+    assert cli._is_headless() is True
+
+
+def test_is_headless_false_on_mac(monkeypatch):
+    monkeypatch.delenv("CLAWMETRY_NO_BROWSER", raising=False)
+    monkeypatch.setattr(cli.sys, "platform", "darwin")
+    assert cli._is_headless() is False
+
+
+def test_is_headless_true_on_linux_ssh(monkeypatch):
+    monkeypatch.delenv("CLAWMETRY_NO_BROWSER", raising=False)
+    monkeypatch.setattr(cli.sys, "platform", "linux")
+    monkeypatch.setenv("SSH_CONNECTION", "1.2.3.4 5 6.7.8.9 22")
+    monkeypatch.setenv("DISPLAY", ":0")  # SSH still counts even with a display
+    assert cli._is_headless() is True
+
+
+def test_is_headless_true_on_linux_no_display(monkeypatch):
+    monkeypatch.delenv("CLAWMETRY_NO_BROWSER", raising=False)
+    monkeypatch.delenv("SSH_CONNECTION", raising=False)
+    monkeypatch.delenv("SSH_TTY", raising=False)
+    monkeypatch.delenv("SSH_CLIENT", raising=False)
+    monkeypatch.setattr(cli.sys, "platform", "linux")
+    monkeypatch.delenv("DISPLAY", raising=False)
+    monkeypatch.delenv("WAYLAND_DISPLAY", raising=False)
+    assert cli._is_headless() is True
+
+
+# ── headless paste path ─────────────────────────────────────────────────────
+
+def test_headless_paste_returns_key_uses_cli_paste(monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_NO_BROWSER", "1")
+    opened = {}
+    monkeypatch.setattr("webbrowser.open", lambda u: opened.setdefault("url", u))
+    exchanged = {}
+
+    def _api(path, body):
+        exchanged["path"] = path
+        exchanged["body"] = body
+        return {"ok": True, "api_key": "cm_headlesskey0001", "is_new": True}
+
+    key = cli._oauth_browser_login("google", input_fn=lambda _p: "PASTECODE", api_call=_api)
+    assert key == "cm_headlesskey0001"
+    assert "cli_paste=1" in opened["url"] and "cc=" in opened["url"]
+    assert "cli_port" not in opened["url"]
+    assert exchanged["path"] == "/api/oauth/cli/exchange"
+    assert exchanged["body"]["code"] == "PASTECODE"
+    # The verifier sent to exchange must hash to the challenge in the URL (PKCE).
+    import hashlib, base64, urllib.parse as up
+    cc = up.parse_qs(opened["url"].split("?", 1)[1])["cc"][0]
+    v = exchanged["body"]["verifier"]
+    recomputed = base64.urlsafe_b64encode(hashlib.sha256(v.encode()).digest()).rstrip(b"=").decode()
+    assert recomputed == cc
+
+
+def test_headless_empty_paste_returns_empty(monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_NO_BROWSER", "1")
+    monkeypatch.setattr("webbrowser.open", lambda u: None)
+    key = cli._oauth_browser_login("github", input_fn=lambda _p: "", api_call=lambda p, b: {})
+    assert key == ""  # empty paste -> caller drops to email OTP
+
+
+def test_headless_bad_code_returns_empty(monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_NO_BROWSER", "1")
+    monkeypatch.setattr("webbrowser.open", lambda u: None)
+    key = cli._oauth_browser_login(
+        "github", input_fn=lambda _p: "WRONG",
+        api_call=lambda p, b: {"ok": False, "error": "invalid or used code"})
+    assert key == ""
+
+
+# ── desktop loopback unchanged ──────────────────────────────────────────────
+
+def test_desktop_uses_cli_port_not_paste(monkeypatch):
+    monkeypatch.delenv("CLAWMETRY_NO_BROWSER", raising=False)
+    monkeypatch.setattr(cli, "_is_headless", lambda: False)
+    opened = {}
+    monkeypatch.setattr("webbrowser.open", lambda u: opened.setdefault("url", u))
+    # Make the loopback wait exit immediately (no 180s hang, no token captured).
+    ticks = itertools.chain([0.0], itertools.repeat(1e9))
+    monkeypatch.setattr("time.time", lambda: next(ticks))
+    key = cli._oauth_browser_login("google", input_fn=lambda _p: "", api_call=lambda p, b: {})
+    assert key == ""  # no token captured -> falls back to email
+    assert "cli_port=" in opened["url"]
+    assert "cli_paste" not in opened["url"]
+
+
+def test_loopback_bind_failure_falls_to_paste(monkeypatch):
+    monkeypatch.delenv("CLAWMETRY_NO_BROWSER", raising=False)
+    monkeypatch.setattr(cli, "_is_headless", lambda: False)
+    import http.server
+
+    def _boom(*a, **k):
+        raise OSError("cannot bind")
+
+    monkeypatch.setattr(http.server, "HTTPServer", _boom)
+    opened = {}
+    monkeypatch.setattr("webbrowser.open", lambda u: opened.setdefault("url", u))
+    key = cli._oauth_browser_login(
+        "google", input_fn=lambda _p: "CODE",
+        api_call=lambda p, b: {"api_key": "cm_fallbackkey", "is_new": False})
+    assert key == "cm_fallbackkey"
+    assert "cli_paste=1" in opened["url"]  # fell through to the paste path
+
+
+def test_no_emdash_in_oauth_copy():
+    import inspect
+    src = inspect.getsource(cli._oauth_browser_login)
+    assert "—" not in src and "–" not in src


### PR DESCRIPTION
## The bug
On a headless/remote box (SSH into a Hostinger VPS), `clawmetry connect` -> Google/GitHub opens the browser on the user's **laptop**, and the OAuth loopback callback redirects to the **laptop's** `127.0.0.1`, never reaching the remote CLI. It hangs ~180s then drops to email OTP. Reported live.

## The fix (CLI half)
A Claude-Code-style **paste-code** path:
- **`_is_headless()`**: macOS/Windows -> False; Linux with no `DISPLAY`/`WAYLAND_DISPLAY` or an SSH session -> True; `CLAWMETRY_NO_BROWSER=1` forces it. Used only to **order** the flows, never as a hard gate (the headless path is an interactive prompt, not a timed wait, so a wrong guess can't hang).
- **`_oauth_browser_login` forks**: desktop keeps the one-shot **loopback** (`cli_port`, unchanged contract); headless generates a **PKCE verifier** (kept in memory; only the SHA256 challenge leaves via `cli_paste=1&cc=`), prints the URL + `Paste code here if prompted >`, and redeems `code+verifier` at `/api/oauth/cli/exchange` over `INGEST_URL`. Also falls through to paste if the loopback can't bind.
- Caller passes the `/dev/tty`-aware `_input` + `_api_call` so the prompt works under piped installs and the exchange hits the right host.

## Ordering
Depends on the cloud `/api/oauth/cli/exchange` endpoint (clawmetry-cloud #1705), so this **ships after that deploys**. Old-CLI x new-cloud and new-CLI x old-cloud both degrade gracefully to email OTP.

## Tests
`tests/test_oauth_headless.py` (10): `_is_headless` matrix, headless returns key via `cli_paste` (with a PKCE round-trip check), empty/bad paste -> `''`, desktop still uses `cli_port`, loopback-bind-failure -> paste, no-em-dash. Existing `test_cli*.py` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)