### PR TITLE
feat(onboard): always show the [1]/[2]/[3] options, even when already connected

### DIFF
--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -2137,11 +2137,14 @@ def _cmd_onboard(args) -> None:
     if _os.environ.get("CLAWMETRY_API_KEY") or _os.environ.get("CLAWMETRY_NODE_ID"):
         already_connected = True
 
+    # NOTE: we no longer early-return when already connected. `clawmetry onboard`
+    # is the setup wizard, so it ALWAYS shows the [1]/[2]/[3] options and lets the
+    # user switch how ClawMetry runs (e.g. cloud -> local, or add a license). When
+    # already connected, an empty Enter keeps the current setup (handled in the
+    # choice logic below) so re-running never silently changes anything.
     if already_connected:
-        print(f"\n  {GREEN(BOLD('Already connected to ClawMetry Cloud'))}")
-        _maybe_apply_nemoclaw_preset(_input, BOLD, CYAN, DIM)
-        print(f"  {DIM('Run  clawmetry status  to check sync health.')}\n")
-        return
+        print(f"\n  {GREEN(BOLD('Already connected to ClawMetry.'))}")
+        print(f"  {DIM('Pick an option below to change how ClawMetry runs, or press Enter to keep your current setup.')}")
 
     # Get version for banner
     try:
@@ -2151,7 +2154,8 @@ def _cmd_onboard(args) -> None:
         _ver = ""
     _ver_str = f" {_ver}" if _ver else ""
 
-    print(f"\n  {BOLD(f'ClawMetry{_ver_str} installed!')}")
+    if not already_connected:
+        print(f"\n  {BOLD(f'ClawMetry{_ver_str} installed!')}")
     print()
     print(f"  {BOLD('How do you want to run ClawMetry?')}")
     print()
@@ -2216,11 +2220,21 @@ def _cmd_onboard(args) -> None:
     elif getattr(args, "cloud", False):
         choice = "2"
     else:
+        # When already connected, the default on an empty Enter is "keep current
+        # setup" (return without changes) so re-running onboard never silently
+        # switches a connected user to local. A fresh install defaults to [1].
+        _prompt = ("  Choose an option, or press Enter to keep your current setup: "
+                   if already_connected else "  Choose [1]: ")
         try:
-            choice = _input("  Choose [1]: ").strip() or "1"
+            choice = _input(_prompt).strip()
         except (EOFError, KeyboardInterrupt):
-            choice = "1"
+            choice = ""
             print()
+        if not choice:
+            if already_connected:
+                print(f"\n  {DIM('Keeping your current setup. Run  clawmetry status  to check sync health.')}\n")
+                return
+            choice = "1"
 
     print()
 

--- a/tests/test_onboard_local_default.py
+++ b/tests/test_onboard_local_default.py
@@ -105,3 +105,43 @@ def test_empty_enter_defaults_to_local(onboard_env, monkeypatch):
     cli._cmd_onboard(_args())
     assert state["instant_register"] == 0
     assert marker.exists()
+
+
+# ── `clawmetry onboard` always shows the options (founder ask 2026-06-30) ────
+
+def _make_connected(home):
+    """Write a config that looks already-connected (has an api_key)."""
+    import json
+    (home / ".clawmetry").mkdir(parents=True, exist_ok=True)
+    (home / ".clawmetry" / "config.json").write_text(
+        json.dumps({"api_key": "cm_existing", "node_id": "n1"}))
+
+
+def test_already_connected_empty_enter_keeps_current(onboard_env, monkeypatch, tmp_path):
+    state, marker = onboard_env
+    _make_connected(tmp_path / "home")
+    # Empty Enter while already connected -> keep current, change nothing.
+    monkeypatch.setattr("builtins.input", lambda _p="": "")
+    cli._cmd_onboard(_args())
+    assert state["instant_register"] == 0
+    assert state["start_daemon"] == 0
+    assert not marker.exists(), "must NOT switch a connected user to local on empty Enter"
+
+
+def test_already_connected_shows_options_and_choice_1_goes_local(onboard_env, monkeypatch, tmp_path, capsys):
+    state, marker = onboard_env
+    _make_connected(tmp_path / "home")
+    monkeypatch.setattr("builtins.input", lambda _p="": "1")
+    cli._cmd_onboard(_args())
+    out = capsys.readouterr().out
+    assert "[1] Local only" in out and "[2] Cloud" in out and "[3] License key" in out
+    assert marker.exists(), "explicit [1] reconfigures a connected user to local"
+
+
+def test_already_connected_choice_2_reaches_cloud(onboard_env, monkeypatch, tmp_path):
+    state, _marker = onboard_env
+    _make_connected(tmp_path / "home")
+    answers = iter(["2", "n"])  # [2] Cloud, then "no existing account" -> instant register
+    monkeypatch.setattr("builtins.input", lambda _p="": next(answers))
+    cli._cmd_onboard(_args())
+    assert state["instant_register"] == 1


### PR DESCRIPTION
## Ask
`clawmetry onboard` should always show the Local / Cloud / License options.

## Problem
`onboard` early-returned with "Already connected to ClawMetry Cloud" and skipped the menu whenever a config with an `api_key` (or `CLAWMETRY_API_KEY`/`CLAWMETRY_NODE_ID`) existed. So a connected user couldn't re-run the wizard to switch how ClawMetry runs (e.g. cloud -> local, or add a license).

## Fix
`onboard` now **always** shows the 3-way menu. Safe re-run: when already connected, an empty Enter (or EOF) **keeps the current setup** and returns without changes, so re-running never silently switches a connected cloud user to local. Only an explicit `[1]`/`[2]`/`[3]` (or `--local`/`--cloud`/`CLAWMETRY_LOCAL_ONLY`) reconfigures. Fresh installs are unchanged (default `[1]`).

## Tests
`tests/test_onboard_local_default.py` +3: connected + Enter keeps current (no marker, no register); connected + `[1]` shows all options and writes the local marker; connected + `[2]` reaches cloud registration. Existing onboard + CLI tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)