### PR TITLE
fix(plan): re-check the cloud plan on every status + heartbeat so an upgrade syncs paid runtimes immediately

### DIFF
--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -1733,6 +1733,21 @@ def _cmd_status(args) -> None:
             print("  Cloud sync:  ✅  Connected")
             print(f"  API key:     {masked_api}")
             _acct_email, _acct_plan = _resolve_account_email(api_key)
+            # Self-heal the local plan cache from the LIVE account. The runtime
+            # entitlement gate below (and the daemon + dashboard) read
+            # ~/.clawmetry/cloud_plan.json, which only the daemon refreshes on a
+            # heartbeat. If the daemon is down, or hasn't heartbeated since the
+            # user upgraded (free -> trial/pro), that cache is stale and status
+            # contradicts itself ("trial" in the header, "FREE plan" in the gate).
+            # Mirroring the live plan here makes the gate reflect the real plan
+            # immediately and seeds the entitlement resolver so paid runtimes
+            # flip on without waiting for the daemon. Best-effort; never raises.
+            if _acct_plan:
+                try:
+                    from clawmetry.sync import _persist_cloud_plan_to_disk as _pcp
+                    _pcp(_acct_plan)
+                except Exception:
+                    pass
             if _acct_email:
                 _plan_suffix = f"  ({_acct_plan})" if _acct_plan else ""
                 _acct_note = "  ⚠ temporary, not linked" if _is_placeholder_account(_acct_email) else ""

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -1209,6 +1209,24 @@ def _persist_cloud_plan_to_disk(plan: str | None, trial_days_left=None) -> None:
     tier = _HEARTBEAT_PLAN_TO_TIER.get(str(plan or "").strip().lower())
     # Entitled plan → keep this node current automatically (opt-out + 48h rail).
     _sync_auto_update_with_plan(tier)
+    # Idempotent reconcile: this is now called on EVERY heartbeat (not just on a
+    # plan change), so short-circuit when the on-disk cache already reflects this
+    # tier. We compare only the ``plan`` field (the entitlement-relevant part) so
+    # the trial ``expiry`` countdown doesn't churn a write + entitlement
+    # invalidation every cycle. Only an actual tier transition re-writes + flips
+    # the resolver, so paid runtimes start syncing the moment the plan upgrades.
+    try:
+        _existing_plan = None
+        if os.path.isfile(_CLOUD_PLAN_CACHE_PATH):
+            with open(_CLOUD_PLAN_CACHE_PATH, encoding="utf-8") as _fh:
+                _existing_plan = (json.load(_fh) or {}).get("plan")
+        if tier is None:
+            if _existing_plan is None and not os.path.isfile(_CLOUD_PLAN_CACHE_PATH):
+                return  # already absent; nothing to reconcile
+        elif _existing_plan == tier:
+            return  # cache already matches the live tier; no write, no invalidate
+    except Exception:
+        pass  # any read trouble -> fall through and (re)write below
     try:
         if tier is None:
             if os.path.isfile(_CLOUD_PLAN_CACHE_PATH):
@@ -1252,7 +1270,13 @@ def _update_trial_state(resp: dict) -> None:
         _TRIAL_STATE["trial_days_left"] = resp.get("trial_days_left")
     if resp.get("upgrade_url"):
         _TRIAL_STATE["upgrade_url"] = resp["upgrade_url"]
-    if _TRIAL_STATE.get("plan") != prev_plan or _TRIAL_STATE.get("trial_days_left") != prev_days:
+    # Reconcile the on-disk plan cache on EVERY heartbeat (the founder ask:
+    # "check & start sync at every heartbeat, for which plan it is in"). The
+    # call is idempotent (a no-op when the cache already matches the live tier),
+    # so this is cheap, but it self-heals a cache that drifted for any reason
+    # (deleted file, a daemon that started while free then the plan upgraded,
+    # etc.) and flips paid runtimes on the moment the plan becomes entitled.
+    if "plan" in resp or "trial_days_left" in resp:
         _persist_cloud_plan_to_disk(
             _TRIAL_STATE.get("plan"), _TRIAL_STATE.get("trial_days_left")
         )

--- a/tests/test_sync_cloud_plan_cache.py
+++ b/tests/test_sync_cloud_plan_cache.py
@@ -135,18 +135,20 @@ def test_update_trial_state_clears_cache_on_expiry(sync):
     assert not os.path.isfile(sync._CLOUD_PLAN_CACHE_PATH)
 
 
-def test_update_trial_state_skips_persist_when_plan_unchanged(sync, monkeypatch):
+def test_update_trial_state_reconciles_persist_each_heartbeat(sync, monkeypatch):
+    """Every heartbeat carrying a plan now RECONCILES the cache (calls persist),
+    so a stale/drifted cache self-heals. Redundant disk writes are avoided
+    inside _persist_cloud_plan_to_disk itself, which is idempotent (see
+    test_persist_is_idempotent_when_tier_unchanged), NOT by skipping the call."""
     calls = {"n": 0}
 
     def _spy(plan, trial_days_left=None):
         calls["n"] += 1
 
-    sync._update_trial_state({"sync_allowed": True, "plan": "pro"})
     monkeypatch.setattr(sync, "_persist_cloud_plan_to_disk", _spy)
-    # Same plan repeated → no extra disk writes.
     sync._update_trial_state({"sync_allowed": True, "plan": "pro"})
     sync._update_trial_state({"sync_allowed": True, "plan": "pro"})
-    assert calls["n"] == 0
+    assert calls["n"] == 2  # reconciles each heartbeat; persist no-ops when unchanged
 
 
 # ── integration: dashboard sees the cloud plan after persist ────────────────
@@ -178,3 +180,58 @@ def test_entitlements_falls_back_to_oss_after_trial_expiry(sync, monkeypatch):
     en = e.get_entitlement(force=True)
     assert en.tier == e.TIER_OSS
     assert en.allows_runtime("claude_code") is False
+
+
+# ── reconcile-every-heartbeat + idempotency (founder ask 2026-06-30) ─────────
+
+def test_persist_is_idempotent_when_tier_unchanged(sync, monkeypatch):
+    """Calling _persist with the same tier twice must not re-write the file or
+    re-invalidate entitlements (it now runs on every heartbeat)."""
+    import clawmetry.entitlements as e
+    calls = {"n": 0}
+    monkeypatch.setattr(e, "invalidate", lambda *a, **k: calls.__setitem__("n", calls["n"] + 1))
+
+    sync._persist_cloud_plan_to_disk("trial")
+    assert calls["n"] == 1
+    mtime1 = os.path.getmtime(sync._CLOUD_PLAN_CACHE_PATH)
+    plan1 = json.loads(open(sync._CLOUD_PLAN_CACHE_PATH).read())["plan"]
+    assert plan1 == "trial"
+
+    time.sleep(0.02)
+    sync._persist_cloud_plan_to_disk("trial")  # same tier -> no-op
+    assert calls["n"] == 1, "must NOT re-invalidate when the tier is unchanged"
+    assert os.path.getmtime(sync._CLOUD_PLAN_CACHE_PATH) == mtime1, "must NOT re-write"
+
+
+def test_persist_rewrites_on_tier_change(sync, monkeypatch):
+    import clawmetry.entitlements as e
+    calls = {"n": 0}
+    monkeypatch.setattr(e, "invalidate", lambda *a, **k: calls.__setitem__("n", calls["n"] + 1))
+    sync._persist_cloud_plan_to_disk("free")
+    assert json.loads(open(sync._CLOUD_PLAN_CACHE_PATH).read())["plan"] == "cloud_free"
+    sync._persist_cloud_plan_to_disk("pro")  # upgrade -> rewrite + invalidate
+    assert json.loads(open(sync._CLOUD_PLAN_CACHE_PATH).read())["plan"] == "cloud_pro"
+    assert calls["n"] == 2
+
+
+def test_update_trial_state_reconciles_when_cache_drifts(sync):
+    """The reconcile fires every heartbeat: even when _TRIAL_STATE['plan']
+    didn't 'change', a deleted/stale cache is re-written from the live plan.
+    This is the user's case: daemon cached free, account upgraded, the cache
+    must self-heal on the next heartbeat."""
+    sync._TRIAL_STATE["plan"] = "trial"  # state already thinks trial (no "change")
+    if os.path.isfile(sync._CLOUD_PLAN_CACHE_PATH):
+        os.remove(sync._CLOUD_PLAN_CACHE_PATH)
+    # A heartbeat carrying the plan -> reconcile rewrites the missing cache.
+    sync._update_trial_state({"sync_allowed": True, "plan": "trial", "trial_days_left": 6})
+    assert os.path.isfile(sync._CLOUD_PLAN_CACHE_PATH)
+    assert json.loads(open(sync._CLOUD_PLAN_CACHE_PATH).read())["plan"] == "trial"
+
+
+def test_update_trial_state_upgrade_free_to_trial_flips_cache(sync):
+    """free -> trial within one heartbeat writes the entitled tier so paid
+    runtimes flip on without a daemon restart."""
+    sync._update_trial_state({"sync_allowed": True, "plan": "free"})
+    assert json.loads(open(sync._CLOUD_PLAN_CACHE_PATH).read())["plan"] == "cloud_free"
+    sync._update_trial_state({"sync_allowed": True, "plan": "trial", "trial_days_left": 7})
+    assert json.loads(open(sync._CLOUD_PLAN_CACHE_PATH).read())["plan"] == "trial"


### PR DESCRIPTION
## The bug
A node that linked while **FREE** and then upgraded to **Trial/Pro** showed a self-contradictory `clawmetry status`: the header read the **live** plan (`(trial)`) but the runtimes section read the daemon's cached `~/.clawmetry/cloud_plan.json` (stale `free`), so Claude Code / Codex / etc. showed "detected, NOT syncing" even on a trial. The cache is only refreshed by the daemon on a heartbeat, so with the daemon down (or pre-upgrade) it stayed stale. Reported from a Hostinger VPS.

## The fix (matches the ask: "check & start sync at every heartbeat, for which plan it is in")
- **`clawmetry status`** now mirrors the **live** account plan into `cloud_plan.json` (reusing the daemon's `_persist_cloud_plan_to_disk` mapping). The gate, the entitlement resolver, and the daemon all read this cache, so paid runtimes flip to entitled immediately, even with the daemon down. Offline falls back to the cached plan.
- **The daemon reconciles the plan cache on EVERY heartbeat**, not just on a change. `_persist_cloud_plan_to_disk` is now **idempotent** (no-op when the cache already matches the live tier), so it's cheap, but self-heals a cache that drifted for any reason and flips paid runtimes on the moment the plan upgrades, with no daemon restart.

## Tests
`tests/test_sync_cloud_plan_cache.py` +4: idempotent-when-unchanged (no re-write / no re-invalidate), rewrite-on-tier-change, reconcile-when-cache-drifts (deleted cache + unchanged state -> re-written), free->trial flips the cache. Updated the old `skip-when-unchanged` test to the new reconcile reality. Existing entitlement + CLI tests green.

Note: the daemon must still be **running** to actually upload paid-runtime data; this makes the plan *detection* correct + immediate. `clawmetry status` already surfaces "Daemon: Not running" with the `clawmetry sync --restart` hint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)