### PR TITLE
feat(entitlement): next/previous_tier_lock_reason_at + 2 endpoints

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -6636,6 +6636,105 @@ def previous_tier_runtime_spec_at(tier: str, runtime: str) -> dict | None:
         return None
 
 
+def next_tier_lock_reason_at(
+    tier: str, item, *, kind: str | None = None
+) -> str | None:
+    """Scalar what-if sibling of :func:`lock_reason_at` projected onto the
+    rung above the caller-supplied ``tier``.
+
+    Lock-reason-axis projection of :func:`next_tier_spec_at` and
+    lock-reason sibling of :func:`next_tier_feature_spec_at` /
+    :func:`next_tier_runtime_spec_at` -- where those return the catalog
+    row at the rung above, this returns the human-readable lock sentence
+    the paywall surface would render. Convenience for
+    ``lock_reason_at(_next_purchasable_tier_after(tier), item, kind=kind)``
+    so a paywall "what does the lock copy for THIS item look like at my
+    next rung?" tooltip hydrates off ONE round-trip without the caller
+    walking the ladder or asking the resolver.
+
+    The returned string matches :func:`lock_reason_at(target, item, kind=kind)`
+    for the resolved ``target = _next_purchasable_tier_after(tier)``
+    exactly -- a parity test pins this so the projection cannot drift
+    from the full helper.
+
+    ``kind`` follows :meth:`Entitlement.lock_reason`: ``"feature"`` /
+    ``"runtime"`` / ``"channels"`` / ``"retention_days"`` / ``"nodes"``
+    explicitly; ``None`` lets the inner method infer ``feature`` vs
+    ``runtime`` from the id (capacity axes can't be inferred, so pass
+    ``kind=`` for those).
+
+    Accepts any id in :data:`_TIER_ORDER` for ``tier`` (including
+    :data:`TIER_TRIAL`) -- the lenient ``_at`` posture, matching the
+    other ``next_*_at`` helpers.
+
+    Returns ``None`` for empty / unknown ``tier``, at the ceiling (no
+    rung strictly above -- enterprise as source), and for any item the
+    inner method considers unlockable at the resolved target (free
+    features / runtimes, empty keys, malformed capacity counts). Never
+    raises: a builder failure short-circuits to ``None`` so the CTA
+    surface stays mute instead of breaking.
+    """
+    try:
+        src = (tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if not src or src not in _TIER_ORDER:
+        return None
+    try:
+        target = _next_purchasable_tier_after(src)
+        if target is None:
+            return None
+        return lock_reason_at(target, item, kind=kind)
+    except Exception as exc:
+        logger.warning(
+            "entitlements: next_tier_lock_reason_at failed: %s", exc
+        )
+        return None
+
+
+def previous_tier_lock_reason_at(
+    tier: str, item, *, kind: str | None = None
+) -> str | None:
+    """Scalar what-if sibling of :func:`lock_reason_at` projected onto the
+    rung below the caller-supplied ``tier``.
+
+    Source-anchored mirror of :func:`next_tier_lock_reason_at` and
+    downgrade-confirmation counterpart on the lock-reason axis.
+    Convenience for ``lock_reason_at(_previous_purchasable_tier_before(tier),
+    item, kind=kind)`` so a downgrade-confirmation card can ask "what
+    lock sentence would surface if I drop one rung?" without recomputing
+    the target tier client-side.
+
+    Like :func:`next_tier_lock_reason_at` the returned string matches
+    :func:`lock_reason_at(target, item, kind=kind)` for the resolved
+    ``target = _previous_purchasable_tier_before(tier)`` exactly.
+
+    Accepts any id in :data:`_TIER_ORDER` (including :data:`TIER_TRIAL`)
+    -- the lenient ``_at`` posture.
+
+    Returns ``None`` for empty / unknown ``tier``, at the floor (``oss``
+    / ``cloud_free`` as source -- no rung strictly below), and for any
+    item the inner method considers unlockable at the resolved target.
+    Never raises.
+    """
+    try:
+        src = (tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if not src or src not in _TIER_ORDER:
+        return None
+    try:
+        target = _previous_purchasable_tier_before(src)
+        if target is None:
+            return None
+        return lock_reason_at(target, item, kind=kind)
+    except Exception as exc:
+        logger.warning(
+            "entitlements: previous_tier_lock_reason_at failed: %s", exc
+        )
+        return None
+
+
 def tier_spec_path(from_tier: str, to_tier: str) -> list[dict] | None:
     """Arbitrary-endpoint stepwise spec-shaped path between two tiers.
 

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -7028,6 +7028,314 @@ def api_entitlement_previous_tier_runtime_spec_at():
         )
 
 
+
+
+def _next_prev_lock_reason_at(direction: str):
+    """Shared handler body for ``/{next,previous}-tier-lock-reason-at``.
+
+    Mirrors the axis-parsing contract of ``/api/entitlement/lock-reason-at``
+    (exactly one of ``feature=`` / ``runtime=`` / ``channels=`` /
+    ``retention_days=`` / ``nodes=``) and the ceiling/floor envelope shape of
+    ``/next-tier-feature-spec-at`` / ``/previous-tier-feature-spec-at``
+    (``target`` / ``target_label`` / ``target_rank`` collapse to ``null``
+    at the rung edge, lock fields collapse to the grace-shape unlocked
+    row so the surface keeps rendering).
+
+    ``direction`` is ``"next"`` or ``"previous"``: picks
+    :func:`entitlements._next_purchasable_tier_after` vs
+    :func:`entitlements._previous_purchasable_tier_before` and the matching
+    log-name. Never 5xxs: synthesis failure short-circuits to the
+    grace-shape envelope with ``target=null`` so the paywall surface stays
+    mute.
+    """
+    raw_tier = request.args.get("tier")
+    tier_in = (raw_tier or "").strip().lower()
+    if not tier_in:
+        return jsonify({"error": "missing tier"}), 400
+    log_name = f"api_entitlement_{direction}_tier_lock_reason_at"
+    try:
+        from clawmetry import entitlements as _ent
+
+        if tier_in not in _ent._TIER_ORDER:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "tier", "tier": tier_in}
+                ),
+                404,
+            )
+        feature = (request.args.get("feature") or "").strip().lower()
+        runtime_in = (request.args.get("runtime") or "").strip().lower()
+        (
+            channels_present,
+            channels_ok,
+            channels_n,
+            channels_raw,
+        ) = _parse_capacity_arg("channels")
+        (
+            retention_present,
+            retention_ok,
+            retention_n,
+            retention_raw,
+        ) = _parse_capacity_arg("retention_days")
+        (
+            nodes_present,
+            nodes_ok,
+            nodes_n,
+            nodes_raw,
+        ) = _parse_capacity_arg("nodes")
+
+        supplied = [
+            bool(feature),
+            bool(runtime_in),
+            channels_present,
+            retention_present,
+            nodes_present,
+        ]
+        n_supplied = sum(1 for s in supplied if s)
+        if n_supplied == 0:
+            return (
+                jsonify(
+                    {
+                        "error": (
+                            "supply exactly one of feature=<id>, runtime=<id>, "
+                            "channels=<int>, retention_days=<int>, or "
+                            "nodes=<int>"
+                        )
+                    }
+                ),
+                400,
+            )
+        if n_supplied > 1:
+            return (
+                jsonify(
+                    {
+                        "error": (
+                            "supply only one of feature=, runtime=, channels=, "
+                            "retention_days=, or nodes="
+                        )
+                    }
+                ),
+                400,
+            )
+
+        if direction == "next":
+            target = _ent._next_purchasable_tier_after(tier_in)
+            walk = _ent.next_tier_lock_reason_at
+        else:
+            target = _ent._previous_purchasable_tier_before(tier_in)
+            walk = _ent.previous_tier_lock_reason_at
+
+        if feature:
+            key, kind = feature, "feature"
+            required = _ent.min_tier_for_feature(feature)
+            reason = walk(tier_in, feature, kind=kind) if target else None
+            allowed = reason is None
+        elif runtime_in:
+            rt = _ent.canonical_runtime(runtime_in)
+            key, kind = rt or runtime_in, "runtime"
+            required = _ent.min_tier_for_runtime(rt) if rt else None
+            reason = (
+                walk(tier_in, rt or runtime_in, kind=kind) if target else None
+            )
+            allowed = reason is None
+        elif channels_present:
+            key, kind = channels_raw, "channels"
+            if channels_ok and target:
+                required = _ent.min_tier_for_channel_count(channels_n)
+                reason = walk(tier_in, str(channels_n), kind=kind)
+                allowed = reason is None
+            else:
+                required = (
+                    _ent.min_tier_for_channel_count(channels_n)
+                    if channels_ok
+                    else None
+                )
+                reason = None
+                allowed = True
+        elif retention_present:
+            key, kind = retention_raw, "retention_days"
+            if retention_ok and target:
+                required = _ent.min_tier_for_retention_window(retention_n)
+                reason = walk(tier_in, str(retention_n), kind=kind)
+                allowed = reason is None
+            else:
+                required = (
+                    _ent.min_tier_for_retention_window(retention_n)
+                    if retention_ok
+                    else None
+                )
+                reason = None
+                allowed = True
+        else:
+            key, kind = nodes_raw, "nodes"
+            if nodes_ok and target:
+                required = _ent.min_tier_for_node_count(nodes_n)
+                reason = walk(tier_in, str(nodes_n), kind=kind)
+                allowed = reason is None
+            else:
+                required = (
+                    _ent.min_tier_for_node_count(nodes_n)
+                    if nodes_ok
+                    else None
+                )
+                reason = None
+                allowed = True
+
+        cur_rank = _ent.tier_rank(tier_in)
+        req_rank = _ent.tier_rank(required) if required else -1
+        required_label = _ent.tier_label(required) if required else None
+        return jsonify(
+            {
+                "tier": tier_in,
+                "tier_label": _ent.tier_label(tier_in),
+                "tier_rank": cur_rank,
+                "key": key,
+                "kind": kind,
+                "target": target,
+                "target_label": _ent.tier_label(target) if target else None,
+                "target_rank": (
+                    _ent.tier_rank(target) if target else None
+                ),
+                "reason": reason,
+                "locked": reason is not None,
+                "allowed": allowed,
+                "required_tier": required,
+                "required_tier_label": required_label,
+                "required_tier_rank": req_rank,
+                "upgrade_required": bool(required) and req_rank > cur_rank,
+            }
+        )
+    except Exception as exc:
+        logger.warning("%s: error: %s", log_name, exc)
+        feature = (request.args.get("feature") or "").strip().lower()
+        runtime_in = (request.args.get("runtime") or "").strip().lower()
+        channels_raw = (request.args.get("channels") or "").strip()
+        retention_raw = (request.args.get("retention_days") or "").strip()
+        nodes_raw = (request.args.get("nodes") or "").strip()
+        if feature:
+            key, kind = feature, "feature"
+        elif runtime_in:
+            key, kind = runtime_in, "runtime"
+        elif channels_raw:
+            key, kind = channels_raw, "channels"
+        elif retention_raw:
+            key, kind = retention_raw, "retention_days"
+        elif nodes_raw:
+            key, kind = nodes_raw, "nodes"
+        else:
+            key, kind = "", ""
+        return jsonify(
+            {
+                "tier": tier_in,
+                "tier_label": None,
+                "tier_rank": -1,
+                "key": key,
+                "kind": kind,
+                "target": None,
+                "target_label": None,
+                "target_rank": None,
+                "reason": None,
+                "locked": False,
+                "allowed": True,
+                "required_tier": None,
+                "required_tier_label": None,
+                "required_tier_rank": -1,
+                "upgrade_required": False,
+            }
+        )
+
+
+@bp_entitlement.route("/api/entitlement/next-tier-lock-reason-at")
+def api_entitlement_next_tier_lock_reason_at():
+    """``GET /api/entitlement/next-tier-lock-reason-at?tier=<source>&<axis>=<id>``
+    -- scalar what-if sibling of ``/api/entitlement/lock-reason-at``
+    projected onto the rung above the caller-supplied ``tier``.
+
+    Lock-reason-axis projection of ``/next-tier-spec-at`` and lock-reason
+    sibling of ``/next-tier-feature-spec-at`` / ``/next-tier-runtime-spec-at``
+    -- where those return the catalog row at the rung above, this returns
+    the lock sentence the paywall surface would render there. Lets a
+    paywall "what's the lock copy for THIS item at my next rung?"
+    tooltip hydrate off ONE round-trip without the caller computing the
+    target tier.
+
+    Exactly one of ``feature=`` / ``runtime=`` / ``channels=`` /
+    ``retention_days=`` / ``nodes=`` must be supplied. Response shape::
+
+        {
+          "tier":                 "<source tier id>",
+          "tier_label":           "<source label>",
+          "tier_rank":            <source rank>,
+          "key":                  "<id-as-passed>",
+          "kind":                 "feature|runtime|channels|retention_days|nodes",
+          "target":               "<next-above tier id>" | null,
+          "target_label":         "<next-above label>" | null,
+          "target_rank":          <next-above rank> | null,
+          "reason":               "<lock sentence>" | null,
+          "locked":               <bool>,
+          "allowed":              <bool>,
+          "required_tier":        "<min purchasable tier>" | null,
+          "required_tier_label":  "<label>" | null,
+          "required_tier_rank":   <rank>,
+          "upgrade_required":     <bool>,
+        }
+
+    The ``reason`` field matches
+    ``/lock-reason-at?tier=<target>&<axis>=<id>`` byte-for-byte when
+    ``target`` is populated -- a parity test pins this so the projection
+    cannot drift from the full ``/lock-reason-at`` sibling.
+
+    Accepts any tier id in :data:`entitlements._TIER_ORDER` (including
+    ``trial``). ``target`` / ``reason`` collapse to ``null`` (with
+    ``locked=false`` / ``allowed=true``) at the ceiling -- the surface
+    stays 200 with a populated envelope so callers can render "you're at
+    the top" copy without a status-code branch.
+
+    - **400** when ``tier=`` is missing / blank, when no axis is
+      supplied, or when more than one axis is supplied
+    - **404** when ``tier`` is unknown (body carries ``which: "tier"``)
+    - **Never 5xxs**: builder failure short-circuits to the grace-shape
+      envelope with ``target=null`` so the paywall surface stays mute.
+    """
+    return _next_prev_lock_reason_at("next")
+
+
+@bp_entitlement.route("/api/entitlement/previous-tier-lock-reason-at")
+def api_entitlement_previous_tier_lock_reason_at():
+    """``GET /api/entitlement/previous-tier-lock-reason-at?tier=<source>&<axis>=<id>``
+    -- scalar what-if sibling of ``/api/entitlement/lock-reason-at``
+    projected onto the rung below the caller-supplied ``tier``.
+
+    Source-anchored mirror of ``/next-tier-lock-reason-at`` and
+    downgrade-confirmation counterpart on the lock-reason axis. Lets a
+    downgrade-confirmation card render "what lock sentence would surface
+    for THIS item if I drop one rung?" without recomputing the target
+    tier.
+
+    Response shape matches ``/next-tier-lock-reason-at`` byte-for-byte
+    (``tier``, ``tier_label``, ``tier_rank``, ``key``, ``kind``,
+    ``target``, ``target_label``, ``target_rank``, ``reason``,
+    ``locked``, ``allowed``, ``required_tier``, ``required_tier_label``,
+    ``required_tier_rank``, ``upgrade_required``). The ``reason`` field
+    matches ``/lock-reason-at?tier=<target>&<axis>=<id>`` byte-for-byte
+    when ``target`` is populated.
+
+    Accepts any tier id in :data:`entitlements._TIER_ORDER` (including
+    ``trial``). ``target`` / ``reason`` collapse to ``null`` (with
+    ``locked=false`` / ``allowed=true``) at the floor (``oss`` /
+    ``cloud_free`` as source).
+
+    - **400** when ``tier=`` is missing / blank, when no axis is
+      supplied, or when more than one axis is supplied
+    - **404** when ``tier`` is unknown (body carries ``which: "tier"``)
+    - **Never 5xxs**: builder failure short-circuits to the grace-shape
+      envelope with ``target=null``.
+    """
+    return _next_prev_lock_reason_at("previous")
+
+
+
+
 @bp_entitlement.route("/api/entitlement/tier-spec-path-batch")
 def api_entitlement_tier_spec_path_batch():
     """``GET /api/entitlement/tier-spec-path-batch?from=<id>&to=a,b,c``

--- a/tests/test_entitlement_next_prev_tier_lock_reason_at.py
+++ b/tests/test_entitlement_next_prev_tier_lock_reason_at.py
@@ -1,0 +1,514 @@
+"""Tests for the two directional scalar what-if helpers projecting
+:func:`clawmetry.entitlements.lock_reason_at` onto the rung above /
+below a caller-supplied source tier, and the two companion
+``/api/entitlement/{next,previous}-tier-lock-reason-at`` endpoints.
+
+These helpers fill the per-axis directional gap between:
+
+* :func:`lock_reason_at` -- scalar what-if of ONE lock-row at a
+  caller-supplied target tier
+* :func:`next_tier_spec_at` / :func:`previous_tier_spec_at` -- full
+  tier-row descriptor of the rung above/below a caller-supplied source
+
+The new helpers compose those: ``lock_reason_at`` evaluated at the rung
+above/below the source. Lets a paywall "what does the lock copy for
+THIS item look like at my next rung?" tooltip hydrate off ONE round-trip
+without re-walking the catalogue or asking the resolver. Pairs with
+:func:`next_tier_feature_spec_at` / :func:`previous_tier_runtime_spec_at`
+on the catalog-row side -- where those return the row, this returns the
+human-readable sentence the paywall surface renders.
+
+Pins covered here:
+
+* per-rung byte-equality with :func:`lock_reason_at` at the resolved
+  next/previous purchasable target (parity, all five axes)
+* ``next``/``previous`` align with :func:`_next_purchasable_tier_after` /
+  :func:`_previous_purchasable_tier_before` so the helpers cannot drift
+  from the rung-walker shared with the other ``next_*_at`` family
+* ceiling (enterprise as source) / floor (oss / cloud_free as source)
+  returns ``None`` from the helper, and the API surfaces 200 with
+  ``reason=null`` + ``locked=false`` + ``target=null`` so the surface
+  keeps rendering
+* trial-as-source resolves the same way the sibling ``_at`` families do:
+  next -> enterprise, previous -> cloud_starter
+* unknown / empty / whitespace / case-insensitive id handling
+* runtime alias resolution (``claude-code`` -> ``claude_code``)
+* capacity axes (``channels`` / ``retention_days`` / ``nodes``) route
+  through the ``kind=`` keyword path just like :func:`lock_reason_at`
+* grace vs enforce yields the same body (catalogue-derived, not gated)
+* the helpers never raise -- a builder failure short-circuits to
+  ``None`` so the CTA surface keeps rendering rather than 500-ing
+* the two API endpoints never 5xx: 400 on missing input / multi-axis,
+  404 on unknown tier, 200 with ``reason=null`` at the ceiling / floor;
+  an internal failure yields the same 200 envelope shape
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+_ENVELOPE_KEYS = {
+    "tier",
+    "tier_label",
+    "tier_rank",
+    "key",
+    "kind",
+    "target",
+    "target_label",
+    "target_rank",
+    "reason",
+    "locked",
+    "allowed",
+    "required_tier",
+    "required_tier_label",
+    "required_tier_rank",
+    "upgrade_required",
+}
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# ── next_tier_lock_reason_at ────────────────────────────────────────────────
+
+
+def test_next_tier_lock_reason_at_byte_equals_lock_reason_at_for_features(ent):
+    # Helper is convenience for lock_reason_at(_next_purchasable_tier_after(tier), feature).
+    # The two must be byte-equal across every purchasable source for every
+    # feature -- pinning so the projection cannot drift from the full helper.
+    for src in ent._PURCHASABLE_TIERS:
+        target = ent._next_purchasable_tier_after(src)
+        if target is None:
+            continue
+        for feature in sorted(ent.ALL_FEATURES):
+            assert ent.next_tier_lock_reason_at(
+                src, feature, kind="feature"
+            ) == ent.lock_reason_at(target, feature, kind="feature")
+
+
+def test_next_tier_lock_reason_at_byte_equals_lock_reason_at_for_runtimes(ent):
+    for src in ent._PURCHASABLE_TIERS:
+        target = ent._next_purchasable_tier_after(src)
+        if target is None:
+            continue
+        for runtime in sorted(ent.ALL_RUNTIMES):
+            assert ent.next_tier_lock_reason_at(
+                src, runtime, kind="runtime"
+            ) == ent.lock_reason_at(target, runtime, kind="runtime")
+
+
+def test_next_tier_lock_reason_at_byte_equals_lock_reason_at_for_capacity(ent):
+    # Capacity axes must route through ``kind=`` the same way lock_reason_at does.
+    for src in ent._PURCHASABLE_TIERS:
+        target = ent._next_purchasable_tier_after(src)
+        if target is None:
+            continue
+        for kind, count in (
+            ("channels", 50),
+            ("retention_days", 365),
+            ("nodes", 10),
+        ):
+            assert ent.next_tier_lock_reason_at(
+                src, str(count), kind=kind
+            ) == ent.lock_reason_at(target, str(count), kind=kind)
+
+
+def test_next_tier_lock_reason_at_returns_none_at_ceiling(ent):
+    # Enterprise sits at the top of the purchasable ladder -- no rung above,
+    # so the helper returns None for every item.
+    assert ent._next_purchasable_tier_after(ent.TIER_ENTERPRISE) is None
+    for feature in sorted(ent.ALL_FEATURES):
+        assert (
+            ent.next_tier_lock_reason_at(
+                ent.TIER_ENTERPRISE, feature, kind="feature"
+            )
+            is None
+        )
+
+
+def test_next_tier_lock_reason_at_trial_resolves_to_enterprise(ent):
+    # Trial sits at rank 2 alongside cloud_pro -- the next strictly-higher
+    # purchasable rung is enterprise. Lenient _at posture pin.
+    assert ent._next_purchasable_tier_after(ent.TIER_TRIAL) == ent.TIER_ENTERPRISE
+    # An OSS-locked feature unlocks at enterprise, so the helper returns None
+    # (no lock-reason -- it's allowed there).
+    body = ent.next_tier_lock_reason_at(
+        ent.TIER_TRIAL, "custom_alerts", kind="feature"
+    )
+    assert body == ent.lock_reason_at(
+        ent.TIER_ENTERPRISE, "custom_alerts", kind="feature"
+    )
+
+
+def test_next_tier_lock_reason_at_inference_from_id(ent):
+    # ``kind=None`` lets the inner method infer feature vs runtime from the id.
+    target = ent._next_purchasable_tier_after(ent.TIER_OSS)
+    sample_feature = next(iter(ent.ALL_FEATURES))
+    sample_runtime = next(iter(ent.ALL_RUNTIMES))
+    assert ent.next_tier_lock_reason_at(
+        ent.TIER_OSS, sample_feature
+    ) == ent.lock_reason_at(target, sample_feature)
+    assert ent.next_tier_lock_reason_at(
+        ent.TIER_OSS, sample_runtime
+    ) == ent.lock_reason_at(target, sample_runtime)
+
+
+def test_next_tier_lock_reason_at_unknown_inputs_return_none(ent):
+    # The helper must not raise on garbage input.
+    assert ent.next_tier_lock_reason_at("", "custom_alerts") is None
+    assert ent.next_tier_lock_reason_at(None, "custom_alerts") is None
+    assert ent.next_tier_lock_reason_at("bogus_tier", "custom_alerts") is None
+
+
+def test_next_tier_lock_reason_at_whitespace_and_case_insensitive(ent):
+    canon = ent.next_tier_lock_reason_at(
+        ent.TIER_OSS, "custom_alerts", kind="feature"
+    )
+    assert (
+        ent.next_tier_lock_reason_at(" OSS ", " CUSTOM_ALERTS ", kind="feature")
+        == canon
+    )
+
+
+def test_next_tier_lock_reason_at_grace_and_enforce_match(ent, monkeypatch):
+    # The string is catalogue-derived (off the static per-tier maps), so
+    # flipping enforce on must not change the body.
+    grace_body = ent.next_tier_lock_reason_at(
+        ent.TIER_OSS, "custom_alerts", kind="feature"
+    )
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    importlib.reload(ent)
+    ent.invalidate()
+    enforce_body = ent.next_tier_lock_reason_at(
+        ent.TIER_OSS, "custom_alerts", kind="feature"
+    )
+    assert enforce_body == grace_body
+
+
+def test_next_tier_lock_reason_at_never_raises_on_builder_failure(
+    ent, monkeypatch
+):
+    # A synthesised failure in the underlying lock_reason_at must short-
+    # circuit to None so the CTA surface stays mute rather than 500-ing.
+    monkeypatch.setattr(
+        ent,
+        "lock_reason_at",
+        lambda *a, **k: (_ for _ in ()).throw(RuntimeError("synthetic")),
+    )
+    assert (
+        ent.next_tier_lock_reason_at(
+            ent.TIER_CLOUD_STARTER, "custom_alerts", kind="feature"
+        )
+        is None
+    )
+
+
+# ── previous_tier_lock_reason_at ────────────────────────────────────────────
+
+
+def test_previous_tier_lock_reason_at_byte_equals_lock_reason_at_for_features(ent):
+    for src in ent._PURCHASABLE_TIERS:
+        target = ent._previous_purchasable_tier_before(src)
+        if target is None:
+            continue
+        for feature in sorted(ent.ALL_FEATURES):
+            assert ent.previous_tier_lock_reason_at(
+                src, feature, kind="feature"
+            ) == ent.lock_reason_at(target, feature, kind="feature")
+
+
+def test_previous_tier_lock_reason_at_byte_equals_lock_reason_at_for_runtimes(ent):
+    for src in ent._PURCHASABLE_TIERS:
+        target = ent._previous_purchasable_tier_before(src)
+        if target is None:
+            continue
+        for runtime in sorted(ent.ALL_RUNTIMES):
+            assert ent.previous_tier_lock_reason_at(
+                src, runtime, kind="runtime"
+            ) == ent.lock_reason_at(target, runtime, kind="runtime")
+
+
+def test_previous_tier_lock_reason_at_returns_none_at_floor(ent):
+    # OSS and cloud_free both sit at rank 0 -- no rung below to step down to.
+    for src in (ent.TIER_OSS, ent.TIER_CLOUD_FREE):
+        assert ent._previous_purchasable_tier_before(src) is None
+        for feature in sorted(ent.ALL_FEATURES):
+            assert (
+                ent.previous_tier_lock_reason_at(src, feature, kind="feature")
+                is None
+            )
+
+
+def test_previous_tier_lock_reason_at_trial_resolves_to_starter(ent):
+    # Trial steps down to rank 1 (starter).
+    assert (
+        ent._previous_purchasable_tier_before(ent.TIER_TRIAL)
+        == ent.TIER_CLOUD_STARTER
+    )
+    body = ent.previous_tier_lock_reason_at(
+        ent.TIER_TRIAL, "custom_alerts", kind="feature"
+    )
+    assert body == ent.lock_reason_at(
+        ent.TIER_CLOUD_STARTER, "custom_alerts", kind="feature"
+    )
+
+
+def test_previous_tier_lock_reason_at_unknown_inputs_return_none(ent):
+    assert ent.previous_tier_lock_reason_at("", "custom_alerts") is None
+    assert ent.previous_tier_lock_reason_at(None, "custom_alerts") is None
+    assert ent.previous_tier_lock_reason_at("bogus", "custom_alerts") is None
+
+
+def test_previous_tier_lock_reason_at_never_raises_on_builder_failure(
+    ent, monkeypatch
+):
+    monkeypatch.setattr(
+        ent,
+        "lock_reason_at",
+        lambda *a, **k: (_ for _ in ()).throw(RuntimeError("synthetic")),
+    )
+    assert (
+        ent.previous_tier_lock_reason_at(
+            ent.TIER_CLOUD_PRO, "custom_alerts", kind="feature"
+        )
+        is None
+    )
+
+
+# ── /api/entitlement/next-tier-lock-reason-at ───────────────────────────────
+
+
+def test_api_next_tier_lock_reason_at_happy_path_feature(client, ent):
+    resp = client.get(
+        "/api/entitlement/next-tier-lock-reason-at?tier=cloud_starter&feature=custom_alerts"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert set(body.keys()) == _ENVELOPE_KEYS
+    assert body["tier"] == ent.TIER_CLOUD_STARTER
+    assert body["kind"] == "feature"
+    assert body["key"] == "custom_alerts"
+    assert body["target"] == ent.TIER_CLOUD_PRO
+    assert body["target_rank"] == ent.tier_rank(ent.TIER_CLOUD_PRO)
+    assert body["reason"] == ent.lock_reason_at(
+        ent.TIER_CLOUD_PRO, "custom_alerts", kind="feature"
+    )
+
+
+def test_api_next_tier_lock_reason_at_happy_path_runtime(client, ent):
+    sample = next(iter(ent.ALL_RUNTIMES))
+    resp = client.get(
+        f"/api/entitlement/next-tier-lock-reason-at?tier=oss&runtime={sample}"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["kind"] == "runtime"
+    target = ent._next_purchasable_tier_after(ent.TIER_OSS)
+    assert body["target"] == target
+    assert body["reason"] == ent.lock_reason_at(
+        target, sample, kind="runtime"
+    )
+
+
+def test_api_next_tier_lock_reason_at_alias_normalises(client, ent):
+    # ``claude-code`` aliases to ``claude_code``.
+    resp = client.get(
+        "/api/entitlement/next-tier-lock-reason-at?tier=oss&runtime=claude-code"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["key"] == "claude_code"
+    assert body["kind"] == "runtime"
+
+
+def test_api_next_tier_lock_reason_at_capacity_axes(client, ent):
+    for axis, val in (
+        ("channels", "50"),
+        ("retention_days", "365"),
+        ("nodes", "10"),
+    ):
+        resp = client.get(
+            f"/api/entitlement/next-tier-lock-reason-at?tier=oss&{axis}={val}"
+        )
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body["kind"] == axis
+        assert body["key"] == val
+
+
+def test_api_next_tier_lock_reason_at_at_ceiling_returns_200_with_null(
+    client, ent
+):
+    resp = client.get(
+        "/api/entitlement/next-tier-lock-reason-at?tier=enterprise&feature=custom_alerts"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["tier"] == ent.TIER_ENTERPRISE
+    assert body["target"] is None
+    assert body["target_label"] is None
+    assert body["target_rank"] is None
+    assert body["reason"] is None
+    assert body["locked"] is False
+    assert body["allowed"] is True
+
+
+def test_api_next_tier_lock_reason_at_400_missing_tier(client):
+    resp = client.get(
+        "/api/entitlement/next-tier-lock-reason-at?feature=custom_alerts"
+    )
+    assert resp.status_code == 400
+
+
+def test_api_next_tier_lock_reason_at_400_missing_axis(client):
+    resp = client.get(
+        "/api/entitlement/next-tier-lock-reason-at?tier=cloud_starter"
+    )
+    assert resp.status_code == 400
+
+
+def test_api_next_tier_lock_reason_at_400_multi_axis(client):
+    resp = client.get(
+        "/api/entitlement/next-tier-lock-reason-at?tier=cloud_starter"
+        "&feature=custom_alerts&runtime=claude_code"
+    )
+    assert resp.status_code == 400
+
+
+def test_api_next_tier_lock_reason_at_404_unknown_tier(client):
+    resp = client.get(
+        "/api/entitlement/next-tier-lock-reason-at?tier=bogus&feature=custom_alerts"
+    )
+    assert resp.status_code == 404
+    body = resp.get_json()
+    assert body.get("which") == "tier"
+
+
+def test_api_next_tier_lock_reason_at_trial_endpoint(client, ent):
+    resp = client.get(
+        "/api/entitlement/next-tier-lock-reason-at?tier=trial&feature=custom_alerts"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["target"] == ent.TIER_ENTERPRISE
+    assert body["reason"] == ent.lock_reason_at(
+        ent.TIER_ENTERPRISE, "custom_alerts", kind="feature"
+    )
+
+
+# ── /api/entitlement/previous-tier-lock-reason-at ───────────────────────────
+
+
+def test_api_previous_tier_lock_reason_at_happy_path(client, ent):
+    resp = client.get(
+        "/api/entitlement/previous-tier-lock-reason-at?tier=cloud_pro&feature=custom_alerts"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert set(body.keys()) == _ENVELOPE_KEYS
+    assert body["tier"] == ent.TIER_CLOUD_PRO
+    assert body["target"] == ent.TIER_CLOUD_STARTER
+    assert body["reason"] == ent.lock_reason_at(
+        ent.TIER_CLOUD_STARTER, "custom_alerts", kind="feature"
+    )
+
+
+def test_api_previous_tier_lock_reason_at_at_floor_returns_200_with_null(
+    client, ent
+):
+    for src in (ent.TIER_OSS, ent.TIER_CLOUD_FREE):
+        resp = client.get(
+            f"/api/entitlement/previous-tier-lock-reason-at?tier={src}&feature=custom_alerts"
+        )
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body["tier"] == src
+        assert body["target"] is None
+        assert body["reason"] is None
+        assert body["locked"] is False
+
+
+def test_api_previous_tier_lock_reason_at_400s_and_404s(client):
+    assert (
+        client.get(
+            "/api/entitlement/previous-tier-lock-reason-at?feature=custom_alerts"
+        ).status_code
+        == 400
+    )
+    assert (
+        client.get(
+            "/api/entitlement/previous-tier-lock-reason-at?tier=cloud_pro"
+        ).status_code
+        == 400
+    )
+    assert (
+        client.get(
+            "/api/entitlement/previous-tier-lock-reason-at?tier=cloud_pro"
+            "&feature=custom_alerts&runtime=claude_code"
+        ).status_code
+        == 400
+    )
+    assert (
+        client.get(
+            "/api/entitlement/previous-tier-lock-reason-at?tier=bogus&feature=custom_alerts"
+        ).status_code
+        == 404
+    )
+
+
+def test_api_previous_tier_lock_reason_at_capacity_axis(client, ent):
+    resp = client.get(
+        "/api/entitlement/previous-tier-lock-reason-at?tier=cloud_pro&nodes=10"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["kind"] == "nodes"
+    assert body["key"] == "10"
+
+
+def test_api_endpoints_never_5xx_on_internal_failure(client, ent, monkeypatch):
+    # If the underlying helper raises, the wrapper must still return 200
+    # with the grace-shape envelope so the surface stays mute.
+    monkeypatch.setattr(
+        ent,
+        "_next_purchasable_tier_after",
+        lambda *a, **k: (_ for _ in ()).throw(RuntimeError("synthetic")),
+    )
+    monkeypatch.setattr(
+        ent,
+        "_previous_purchasable_tier_before",
+        lambda *a, **k: (_ for _ in ()).throw(RuntimeError("synthetic")),
+    )
+    for endpoint in (
+        "/api/entitlement/next-tier-lock-reason-at?tier=cloud_starter&feature=custom_alerts",
+        "/api/entitlement/previous-tier-lock-reason-at?tier=cloud_pro&feature=custom_alerts",
+    ):
+        resp = client.get(endpoint)
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert set(body.keys()) == _ENVELOPE_KEYS
+        assert body["target"] is None
+        assert body["reason"] is None
+        assert body["locked"] is False
+        assert body["allowed"] is True


### PR DESCRIPTION
## Summary

Adds the two directional scalar what-if helpers projecting `lock_reason_at` onto the rung above / below a caller-supplied source tier, plus the two companion `/api/entitlement/{next,previous}-tier-lock-reason-at` endpoints. Closes the per-axis directional gap on the lock-reason side: the catalog-row family already has `next_tier_feature_spec_at` / `previous_tier_feature_spec_at` / `next_tier_runtime_spec_at` / `previous_tier_runtime_spec_at` (landed in #3387). This PR adds the lock-sentence counterpart so the paywall surface can preview the lock copy at the rung above/below in one round-trip — without the caller computing the rung or re-walking the catalogue.

Composition is the natural one given the existing helper grid:

| helper                              | scalar | batch | `_at` | `next_*_at` | `previous_*_at` |
|-------------------------------------|:------:|:-----:|:-----:|:-----------:|:---------------:|
| `lock_reason`                       |   ✅   |  ✅   |  ✅   |  **NEW**    |    **NEW**      |
| `feature_spec` / `runtime_spec`     |   ✅   |  ✅   |  ✅   |    ✅       |      ✅         |
| `tier_spec`                         |   ✅   |  ✅   |  ✅   |    ✅       |      ✅         |

## API

```
GET /api/entitlement/next-tier-lock-reason-at?tier=<source>&<axis>=<id>
GET /api/entitlement/previous-tier-lock-reason-at?tier=<source>&<axis>=<id>
```

Exactly one of `feature=` / `runtime=` / `channels=` / `retention_days=` / `nodes=` must be supplied — same five-axis contract as `/lock-reason-at`. Response envelope mirrors the `/next-tier-feature-spec-at` shape:

```json
{
  "tier":                 "<source tier id>",
  "tier_label":           "<source label>",
  "tier_rank":            <source rank>,
  "key":                  "<id-as-passed>",
  "kind":                 "feature|runtime|channels|retention_days|nodes",
  "target":               "<next-above tier id>" | null,
  "target_label":         "<next-above label>" | null,
  "target_rank":          <next-above rank> | null,
  "reason":               "<lock sentence>" | null,
  "locked":               <bool>,
  "allowed":              <bool>,
  "required_tier":        "<min purchasable tier>" | null,
  "required_tier_label":  "<label>" | null,
  "required_tier_rank":   <rank>,
  "upgrade_required":     <bool>
}
```

The inner `reason` matches `/lock-reason-at?tier=<target>&<axis>=<id>` byte-for-byte when `target` is populated — a parity test pins this so the projection cannot drift from the full helper.

Accepts any tier id in `_TIER_ORDER` (including `trial`). At the ceiling (`enterprise` as source on `next`) / floor (`oss` / `cloud_free` as source on `previous`), `target` / `reason` collapse to `null` with `locked=false` / `allowed=true` on a 200 — the surface keeps rendering "you're at the top / bottom" copy without a status-code branch.

- **400** when `tier=` is missing / blank, when no axis is supplied, or when more than one axis is supplied
- **404** when `tier` is unknown (body carries `which: "tier"`)
- **Never 5xxs**: builder failure short-circuits to the grace-shape envelope with `target=null`

The two routes share a `_next_prev_lock_reason_at(direction)` helper so the five-axis parsing, ceiling/floor handling, and fallback envelope are written once rather than twice.

## Files

| File | Lines | Change |
|---|---|---|
| `clawmetry/entitlements.py` | +99 | `next_tier_lock_reason_at` / `previous_tier_lock_reason_at` helpers |
| `routes/entitlement.py` | +304 | `_next_prev_lock_reason_at` shared body + 2 thin route wrappers |
| `tests/test_entitlement_next_prev_tier_lock_reason_at.py` | +514 | 31 tests pinning helpers, endpoints, parity, ceiling/floor, never-raise, never-5xx, capacity axes, runtime alias |

Read-only catalog-like accessor on top of the static tier maps — no behaviour gate flips and no live entitlement is consulted, so this is safe to wire into pricing-page tooltips even during grace mode. No `__version__` bump, no UI wired.

## Test plan

- [x] `python -m pytest tests/test_entitlement_next_prev_tier_lock_reason_at.py -x -q` → **31 passed** in 0.75s
- [x] Adjacent regression sweep: `test_entitlement_lock_reason_at.py`, `test_entitlement_lock_reason.py`, `test_entitlement_lock_reason_capacity.py`, `test_entitlement_lock_reason_nodes.py`, `test_entitlement_lock_reason_batch.py`, `test_entitlement_lock_reasons_at_batch.py`, `test_entitlement_next_prev_tier_feature_runtime_spec_at.py` → **195 passed** in 2.57s
- [x] Full `-k entitlement` sweep (excluding `duckdb`-blocked collection files in the autonomous CI image) → **2709 passed** (the one error is `test_retention_prune.py` which needs the optional `duckdb` extra, unrelated to this change)
- [x] `ruff check clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_next_prev_tier_lock_reason_at.py` → **All checks passed!**
- [x] `python -m py_compile` on all three changed files

## Local operator verification checklist

The autonomous fire cannot touch the user's machine, the running daemon, `~/.openclaw`, the live cloud snapshot, or a browser. The following must be done by the local operator before flipping to ready-for-review:

- [ ] Copy changed files into the installed package:
      `cp clawmetry/entitlements.py ~/.clawmetry/lib/python*/site-packages/clawmetry/`
      `cp routes/entitlement.py ~/.clawmetry/lib/python*/site-packages/routes/`
- [ ] Clear bytecode: `find ~/.clawmetry/lib -name __pycache__ -exec rm -rf {} +`
- [ ] Kick the daemon: `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
- [ ] Hit the new endpoints across all five axes:
      `curl -s 'http://localhost:8900/api/entitlement/next-tier-lock-reason-at?tier=cloud_starter&feature=custom_alerts' | jq`
      `curl -s 'http://localhost:8900/api/entitlement/previous-tier-lock-reason-at?tier=cloud_pro&feature=custom_alerts' | jq`
      `curl -s 'http://localhost:8900/api/entitlement/next-tier-lock-reason-at?tier=oss&runtime=claude-code' | jq` (alias must normalise)
      `curl -s 'http://localhost:8900/api/entitlement/next-tier-lock-reason-at?tier=oss&nodes=10' | jq`
      `curl -s 'http://localhost:8900/api/entitlement/previous-tier-lock-reason-at?tier=cloud_pro&retention_days=365' | jq`
- [ ] Confirm `target` echoes the resolved next/previous purchasable rung and `reason` matches what `/lock-reason-at?tier=<target>&<axis>=<id>` returns
- [ ] Confirm ceiling: `curl -s '.../next-tier-lock-reason-at?tier=enterprise&feature=custom_alerts'` → 200 with `target=null`, `reason=null`, `locked=false`
- [ ] Confirm floor: `curl -s '.../previous-tier-lock-reason-at?tier=oss&feature=custom_alerts'` → 200 with `target=null`, `reason=null`, `locked=false`
- [ ] Verify error contract: `curl -i '.../next-tier-lock-reason-at?feature=custom_alerts'` → 400; `?tier=cloud_starter` → 400; `?tier=cloud_starter&feature=a&runtime=b` → 400; `?tier=nonsense&feature=a` → 404 with `which: "tier"`
- [ ] Decrypt the live cloud snapshot and browser-check that no existing tooltip / paywall surface regressed (these endpoints are unconsumed, so the check is purely defensive)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_017mp1T8XuQVqq2S6HbQSGzy)_