### PR TITLE
feat(entitlement): tier_path_batch + /api/entitlement/tier-path-batch

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -7973,6 +7973,131 @@ def previous_tier_runtime_spec_at_batch(tier: str, runtimes) -> dict | None:
     return {"runtimes": rows, "unknown": unknown}
 
 
+def tier_path_batch(from_tier: str, to_tiers) -> dict | None:
+    """Batch sibling of :func:`tier_path`: per-rung marginal ``tier_diff``
+    rows for a caller-supplied subset of destination tiers all walked
+    from a single ``from_tier`` in ONE round-trip.
+
+    Composes :func:`tier_path` (scalar single-destination path) and
+    :func:`tier_diff_at_batch` (batch what-if scalar) -- same per-rung
+    body as the path helper (a full marginal :func:`tier_diff` payload
+    between consecutive rungs), same multi-destination axis as the
+    other ``*_path_batch`` siblings. Lets a pricing-comparison "from my
+    current rung, here are the 3 tiers I'm considering -- show me the
+    full marginal step diff (added + lost features, added + lost
+    runtimes, capacity changes) at every rung walked to each" surface
+    render every rung for every candidate destination off ONE call
+    instead of N calls to :func:`tier_path`. Pairs with the existing
+    path-batch grid (``tier_spec_path_batch``, ``capacity_diff_path_
+    batch``, ``tier_unlocks_path_batch``, ``tier_locks_path_batch``,
+    ``preview_path_batch``) as the all-slices-in-one-row member -- each
+    per-rung row carries every marginal slice in one body so a UI that
+    already renders a ``/tier-diff`` row can render a per-rung body
+    here with zero new shape code.
+
+    Per-destination row shape::
+
+        {
+          "to":         "<tier id>",
+          "to_label":   "...",
+          "to_rank":    <int>,
+          "direction":  "upgrade" | "downgrade" | "lateral" | "identity",
+          "path":       [<tier_diff row>, ...],
+        }
+
+    Each ``path`` row is byte-identical to a row from :func:`tier_path`
+    for the same ``(from_tier, to)`` pair -- a parity test pins this so
+    the scalar and batch path helpers cannot drift. Per-row body is the
+    full :func:`tier_diff` envelope (``from`` / ``from_label`` /
+    ``from_rank`` / ``to`` / ``to_label`` / ``to_rank`` / ``direction``
+    / ``added_features`` / ``lost_features`` / ``added_runtimes`` /
+    ``lost_runtimes`` / ``capacity_changes``), and the per-step ``from``
+    chains across the path: ``row[i]["to"] == row[i+1]["from"]``. The
+    walked rungs are destination-specific (the path's rung set depends
+    on ``to``), so per-destination ``path`` lengths can legitimately
+    differ -- matching :func:`tier_spec_path_batch` /
+    :func:`capacity_diff_path_batch`'s posture and differing from
+    :func:`feature_spec_path_batch` / :func:`runtime_spec_path_batch`
+    whose rungs are axis-id-agnostic.
+
+    Shape::
+
+        {
+          "tiers": [
+            {"to": "<id>", "to_label": ..., "to_rank": ..., "direction": ..., "path": [...]},
+            ...
+          ],
+          "unknown": ["bogus_id", ...],
+        }
+
+    Supplied destination ids are normalised via :func:`_normalise_csv`
+    (whitespace stripped, lowercased, duplicates dropped, first-seen
+    order preserved). Unknown ids are echoed in ``unknown[]`` instead
+    of short-circuiting -- a partially-bad caller still gets paths
+    back for the valid ids alongside a list of what was dropped,
+    matching :func:`tier_spec_path_batch` /
+    :func:`capacity_diff_path_batch`'s posture. ``trial`` IS accepted
+    as a destination (it is excluded from the walked intermediate
+    rungs the way :func:`tier_path` already excludes it, but is a
+    valid endpoint via the lateral / identity branches).
+
+    Returns ``None`` for empty / unknown ``from_tier`` (caller renders
+    "unknown tier" / 404).
+
+    Resolver-independent: delegates per-destination to :func:`tier_path`,
+    which walks the static per-tier maps via :func:`tier_diff` -- so
+    grace vs enforce yields byte-identical rows. Never raises: per-
+    destination failures short-circuit that id into ``unknown[]`` and
+    the rest of the batch keeps building.
+    """
+    try:
+        f = (from_tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if f not in _TIER_FEATURES:
+        return None
+    candidates = _normalise_csv(to_tiers)
+    rows: list[dict] = []
+    unknown: list[str] = []
+    from_rank = _TIER_RANK.get(f, -1)
+    for tid in candidates:
+        if tid not in _TIER_FEATURES:
+            unknown.append(tid)
+            continue
+        try:
+            path = tier_path(f, tid)
+        except Exception as exc:
+            logger.warning(
+                "entitlements: tier_path_batch row %r failed: %s",
+                tid,
+                exc,
+            )
+            unknown.append(tid)
+            continue
+        if path is None:
+            unknown.append(tid)
+            continue
+        to_rank = _TIER_RANK.get(tid, -1)
+        if f == tid:
+            direction = "identity"
+        elif from_rank == to_rank:
+            direction = "lateral"
+        elif to_rank > from_rank:
+            direction = "upgrade"
+        else:
+            direction = "downgrade"
+        rows.append(
+            {
+                "to": tid,
+                "to_label": tier_label(tid),
+                "to_rank": to_rank,
+                "direction": direction,
+                "path": path,
+            }
+        )
+    return {"tiers": rows, "unknown": unknown}
+
+
 def capacity_diff_path_batch(
     from_tier: str, to_tiers
 ) -> dict | None:

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -8421,3 +8421,109 @@ def api_entitlement_tier_locks_path_batch():
                 "unknown": [],
             }
         )
+
+
+
+
+@bp_entitlement.route("/api/entitlement/tier-path-batch")
+def api_entitlement_tier_path_batch():
+    """``GET /api/entitlement/tier-path-batch?from=<id>&to=a,b,c`` --
+    batch sibling of ``/api/entitlement/tier-path``.
+
+    Where ``/tier-path`` walks the rungs between ONE ``(from, to)``
+    pair, this walks the rungs between ONE ``from`` and N candidate
+    ``to`` tiers in ONE round-trip. Pairs with ``/tier-path`` the same
+    way ``/tier-spec-path-batch`` pairs with ``/tier-spec-path``:
+    scalar -> matrix in one call. All-slices member of the path-batch
+    grid -- carries the full marginal ``tier_diff`` per rung (added +
+    lost features, added + lost runtimes, capacity changes) rather
+    than a single slice the way ``/tier-unlocks-path-batch`` /
+    ``/tier-locks-path-batch`` / ``/capacity-diff-path-batch`` do.
+
+    Use case: a pricing-comparison "from my current rung, here are the
+    3 tiers I'm considering" surface hydrates the per-rung full
+    marginal step diff to every candidate off ONE call instead of N
+    calls to ``/tier-path``. Same-rank siblings strictly between the
+    endpoints are included for each per-destination path; same-rank
+    siblings of each destination are excluded so the per-destination
+    path terminates exactly at its own ``to``. Per-destination path
+    lengths can legitimately differ (the rungs walked depend on the
+    destination), matching ``/tier-spec-path-batch`` /
+    ``/capacity-diff-path-batch``'s posture.
+
+    Each row in ``tiers[].path`` is byte-identical to a row from
+    ``/tier-path?from=<from>&to=<to>`` -- pinned by the parity tests
+    so the scalar and batch path accessors cannot drift. Supplied
+    destination ids are normalised (whitespace stripped, lowercased,
+    duplicates dropped, first-seen order preserved). Unknown ids do
+    not 404 the call -- they are echoed in ``unknown[]`` so a
+    partially-bad caller still gets paths back for the valid ids.
+
+    Response shape::
+
+        {
+          "from":       "<tier id>",
+          "from_label": "...",
+          "from_rank":  <int>,
+          "tiers": [
+            {
+              "to":        "<tier id>",
+              "to_label":  "...",
+              "to_rank":   <int>,
+              "direction": "upgrade" | "downgrade" | "lateral" | "identity",
+              "path":      [<tier_diff row>, ...],
+            },
+            ...
+          ],
+          "unknown":    ["bogus_id", ...],
+        }
+
+    - **400** when ``from=`` is missing / blank, or ``to=`` is missing
+      / empty after normalisation
+    - **404** when ``from`` is unknown (body carries ``which: "tier"``)
+    - **200** with bucketed unknowns for unknown destination ids --
+      does NOT 404 the call, matching every other batch sibling
+    - **Never 5xxs**: a synthesis failure short-circuits to an envelope
+      with empty rows so the matrix keeps rendering.
+    """
+    f = (request.args.get("from") or "").strip().lower()
+    if not f:
+        return jsonify({"error": "missing from"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        if f not in _ent._TIER_ORDER:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "tier", "tier": f}
+                ),
+                404,
+            )
+        targets = _parse_csv_arg("to")
+        if not targets:
+            return jsonify({"error": "supply to=<csv>"}), 400
+        batch = _ent.tier_path_batch(f, targets)
+        if batch is None:
+            batch = {"tiers": [], "unknown": []}
+        return jsonify(
+            {
+                "from": f,
+                "from_label": _ent.tier_label(f),
+                "from_rank": _ent.tier_rank(f),
+                "tiers": batch.get("tiers", []),
+                "unknown": batch.get("unknown", []),
+            }
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_tier_path_batch: error: %s", exc
+        )
+        return jsonify(
+            {
+                "from": f,
+                "from_label": None,
+                "from_rank": -1,
+                "tiers": [],
+                "unknown": [],
+            }
+        )

--- a/tests/test_entitlement_tier_path_batch.py
+++ b/tests/test_entitlement_tier_path_batch.py
@@ -1,0 +1,505 @@
+"""Tests for ``tier_path_batch(from_tier, to_tiers)`` plus its HTTP
+endpoint ``/api/entitlement/tier-path-batch``.
+
+This is the batch sibling of ``tier_path``: where the scalar path
+helper walks one ``(from, to)`` pair, the batch helper walks N
+candidate destinations from one source in ONE round-trip. Each row
+in a per-destination ``path`` is a full marginal :func:`tier_diff`
+payload between consecutive rungs -- so the batch carries every slice
+(``added_features`` + ``lost_features`` + ``added_runtimes`` +
+``lost_runtimes`` + ``capacity_changes``) in one body, unlike the
+slice-only path-batch siblings (unlocks / locks / capacity).
+
+Each per-destination ``path`` must be byte-identical to the matching
+scalar :func:`tier_path` payload for the same ``(from, to)`` pair --
+pinned by the parity tests below so the scalar and batch path
+accessors cannot drift.
+
+Coverage:
+
+* per-destination ``path`` byte-equal to the scalar ``tier_path``
+  payload
+* per-destination ``direction`` derived from the same ranks the scalar
+  endpoint uses
+* batch envelope mirrors ``/tier-path``'s envelope on the source side
+  (``from`` / ``from_label`` / ``from_rank``) and carries ``tiers`` +
+  ``unknown``
+* per-row body is a full ``tier_diff`` envelope (every key present)
+  and the per-step ``from`` chains: ``row[i]["to"] == row[i+1]["from"]``
+* input normalised (whitespace stripped, lowercased, duplicates dropped,
+  first-seen order preserved)
+* unknown destination ids echoed in ``unknown[]`` instead of 404'ing
+  the call (matching every other batch sibling)
+* identity ``from == to`` yields a per-destination entry whose ``path``
+  is ``[]``
+* lateral (same rank) yields a one-row per-destination ``path``
+* upgrade / downgrade direction labelled correctly
+* unknown / empty / garbage ``from_tier`` returns ``None`` (helper) /
+  400 / 404 (HTTP)
+* helpers never raise -- a per-destination failure short-circuits that
+  id into ``unknown[]`` and the rest of the batch keeps building
+* HTTP endpoint 400 on missing / empty input, 404 on unknown source
+  tier, never 5xx on a row failure
+* grace vs enforce yields identical rows
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+
+_DIFF_KEYS = {
+    "from",
+    "from_label",
+    "from_rank",
+    "to",
+    "to_label",
+    "to_rank",
+    "direction",
+    "added_features",
+    "lost_features",
+    "added_runtimes",
+    "lost_runtimes",
+    "capacity_changes",
+}
+
+_ITEM_KEYS = {"to", "to_label", "to_rank", "direction", "path"}
+
+_ENVELOPE_KEYS = {
+    "from",
+    "from_label",
+    "from_rank",
+    "tiers",
+    "unknown",
+}
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from flask import Flask
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# ── helper-level: shape ──────────────────────────────────────────────────────
+
+
+def test_helper_returns_dict_shape(ent):
+    out = ent.tier_path_batch(
+        ent.TIER_OSS, [ent.TIER_CLOUD_STARTER, ent.TIER_ENTERPRISE]
+    )
+    assert isinstance(out, dict)
+    assert set(out.keys()) == {"tiers", "unknown"}
+    assert isinstance(out["tiers"], list)
+    assert isinstance(out["unknown"], list)
+
+
+def test_helper_each_item_carries_full_envelope(ent):
+    out = ent.tier_path_batch(
+        ent.TIER_OSS, [ent.TIER_CLOUD_STARTER, ent.TIER_ENTERPRISE]
+    )
+    for item in out["tiers"]:
+        assert set(item.keys()) == _ITEM_KEYS
+        assert isinstance(item["to"], str)
+        assert isinstance(item["to_label"], str)
+        assert isinstance(item["to_rank"], int)
+        assert item["direction"] in {
+            "upgrade",
+            "downgrade",
+            "lateral",
+            "identity",
+        }
+        assert isinstance(item["path"], list)
+
+
+def test_helper_each_row_is_full_tier_diff_payload(ent):
+    out = ent.tier_path_batch(ent.TIER_OSS, [ent.TIER_ENTERPRISE])
+    item = out["tiers"][0]
+    assert item["path"], "expected at least one rung in the path"
+    for row in item["path"]:
+        assert set(row.keys()) == _DIFF_KEYS
+
+
+def test_helper_per_row_from_chains(ent):
+    """``row[i]["to"] == row[i+1]["from"]`` -- the marginal step diffs
+    chain across the path so a consumer can fold the rows to
+    reconstruct the cumulative diff."""
+    out = ent.tier_path_batch(ent.TIER_OSS, [ent.TIER_ENTERPRISE])
+    path = out["tiers"][0]["path"]
+    for i in range(len(path) - 1):
+        assert path[i]["to"] == path[i + 1]["from"]
+
+
+# ── helper-level: parity with scalar ─────────────────────────────────────────
+
+
+def test_helper_per_item_path_byte_equal_to_scalar(ent):
+    """Pin: per-destination ``path`` is byte-identical to the scalar
+    :func:`tier_path` payload for the same ``(from, to)`` pair."""
+    candidates = [
+        ent.TIER_CLOUD_FREE,
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_ENTERPRISE,
+    ]
+    out = ent.tier_path_batch(ent.TIER_OSS, candidates)
+    by_id = {item["to"]: item["path"] for item in out["tiers"]}
+    for tid in candidates:
+        scalar = ent.tier_path(ent.TIER_OSS, tid)
+        assert by_id[tid] == scalar
+
+
+def test_helper_per_item_direction_matches_rank_geometry(ent):
+    """Per-destination ``direction`` is derived from rank geometry and
+    must agree with the scalar endpoint's derivation."""
+    candidates = [
+        ent.TIER_OSS,
+        ent.TIER_CLOUD_FREE,
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_PRO,
+        ent.TIER_ENTERPRISE,
+    ]
+    out = ent.tier_path_batch(ent.TIER_CLOUD_STARTER, candidates)
+    by_id = {item["to"]: item for item in out["tiers"]}
+    src_rank = ent.tier_rank(ent.TIER_CLOUD_STARTER)
+    for tid in candidates:
+        tgt_rank = ent.tier_rank(tid)
+        if tid == ent.TIER_CLOUD_STARTER:
+            expected = "identity"
+        elif src_rank == tgt_rank:
+            expected = "lateral"
+        elif tgt_rank > src_rank:
+            expected = "upgrade"
+        else:
+            expected = "downgrade"
+        assert by_id[tid]["direction"] == expected
+
+
+# ── helper-level: input normalisation ────────────────────────────────────────
+
+
+def test_helper_supply_order_preserved(ent):
+    out = ent.tier_path_batch(
+        ent.TIER_OSS,
+        [ent.TIER_ENTERPRISE, ent.TIER_CLOUD_PRO, ent.TIER_CLOUD_STARTER],
+    )
+    assert [item["to"] for item in out["tiers"]] == [
+        ent.TIER_ENTERPRISE,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_CLOUD_STARTER,
+    ]
+
+
+def test_helper_normalises_input(ent):
+    out = ent.tier_path_batch(
+        ent.TIER_OSS,
+        [
+            "  CLOUD_PRO  ",
+            "cloud_starter",
+            "cloud_pro",
+            "",
+        ],
+    )
+    assert [item["to"] for item in out["tiers"]] == [
+        "cloud_pro",
+        "cloud_starter",
+    ]
+
+
+def test_helper_unknown_destination_ids_echoed(ent):
+    out = ent.tier_path_batch(
+        ent.TIER_OSS,
+        [ent.TIER_CLOUD_PRO, "bogus_tier", "still_bogus"],
+    )
+    assert [item["to"] for item in out["tiers"]] == [ent.TIER_CLOUD_PRO]
+    assert set(out["unknown"]) == {"bogus_tier", "still_bogus"}
+
+
+# ── helper-level: direction branches ─────────────────────────────────────────
+
+
+def test_helper_identity_yields_empty_path(ent):
+    out = ent.tier_path_batch(
+        ent.TIER_CLOUD_PRO, [ent.TIER_CLOUD_PRO, ent.TIER_ENTERPRISE]
+    )
+    by_id = {item["to"]: item for item in out["tiers"]}
+    assert by_id[ent.TIER_CLOUD_PRO]["direction"] == "identity"
+    assert by_id[ent.TIER_CLOUD_PRO]["path"] == []
+    assert by_id[ent.TIER_ENTERPRISE]["direction"] == "upgrade"
+
+
+def test_helper_lateral_yields_one_row_path(ent):
+    out = ent.tier_path_batch(
+        ent.TIER_CLOUD_PRO, [ent.TIER_PRO]
+    )
+    assert len(out["tiers"]) == 1
+    item = out["tiers"][0]
+    assert item["direction"] == "lateral"
+    assert len(item["path"]) == 1
+    # the lateral one-row body is exactly tier_diff(from, to)
+    scalar = ent.tier_diff(ent.TIER_CLOUD_PRO, ent.TIER_PRO)
+    assert item["path"][0] == scalar
+
+
+def test_helper_upgrade_walks_intermediate_rungs(ent):
+    out = ent.tier_path_batch(ent.TIER_OSS, [ent.TIER_ENTERPRISE])
+    item = out["tiers"][0]
+    assert item["direction"] == "upgrade"
+    rungs = [row["to"] for row in item["path"]]
+    assert rungs[-1] == ent.TIER_ENTERPRISE
+    assert ent.TIER_OSS not in rungs
+
+
+def test_helper_downgrade_walks_descending(ent):
+    out = ent.tier_path_batch(ent.TIER_ENTERPRISE, [ent.TIER_OSS])
+    item = out["tiers"][0]
+    assert item["direction"] == "downgrade"
+    rungs = [row["to"] for row in item["path"]]
+    ranks = [ent.tier_rank(r) for r in rungs]
+    assert ranks == sorted(ranks, reverse=True)
+
+
+def test_helper_marginal_fold_reconstructs_cumulative_diff(ent):
+    """Folding ``added_features`` / ``added_runtimes`` across an
+    ascending path reconstructs the cumulative
+    ``tier_diff(from, to).added_*`` sets (mirrors the per-row
+    invariant pinned by :func:`tier_path`'s test)."""
+    out = ent.tier_path_batch(ent.TIER_OSS, [ent.TIER_ENTERPRISE])
+    item = out["tiers"][0]
+    folded_features: set[str] = set()
+    folded_runtimes: set[str] = set()
+    for row in item["path"]:
+        folded_features.update(row["added_features"])
+        folded_runtimes.update(row["added_runtimes"])
+    cumulative = ent.tier_diff(ent.TIER_OSS, ent.TIER_ENTERPRISE)
+    assert folded_features == set(cumulative["added_features"])
+    assert folded_runtimes == set(cumulative["added_runtimes"])
+
+
+# ── helper-level: trial endpoint ─────────────────────────────────────────────
+
+
+def test_helper_trial_destination_accepted(ent):
+    """``trial`` is a valid endpoint (matching :func:`tier_path`
+    semantics) even though it is excluded from the walked intermediate
+    rungs."""
+    out = ent.tier_path_batch(ent.TIER_OSS, [ent.TIER_TRIAL])
+    assert out["unknown"] == []
+    assert [item["to"] for item in out["tiers"]] == [ent.TIER_TRIAL]
+
+
+# ── helper-level: error / edge cases ─────────────────────────────────────────
+
+
+def test_helper_unknown_from_tier_returns_none(ent):
+    assert ent.tier_path_batch("not_a_tier", [ent.TIER_ENTERPRISE]) is None
+
+
+def test_helper_empty_destinations_yields_empty_envelope(ent):
+    out = ent.tier_path_batch(ent.TIER_OSS, [])
+    assert out == {"tiers": [], "unknown": []}
+
+
+def test_helper_garbage_inputs_never_raise(ent):
+    assert ent.tier_path_batch("", []) is None
+    assert ent.tier_path_batch(None, None) is None  # type: ignore[arg-type]
+    assert ent.tier_path_batch("  ", "  ") is None
+
+
+def test_helper_grace_and_enforce_yield_identical_output(ent, monkeypatch):
+    candidates = [ent.TIER_CLOUD_STARTER, ent.TIER_ENTERPRISE]
+    grace = ent.tier_path_batch(ent.TIER_OSS, candidates)
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    enforced = ent.tier_path_batch(ent.TIER_OSS, candidates)
+    assert grace == enforced
+
+
+def test_helper_row_failure_short_circuits_item(ent, monkeypatch):
+    """A per-destination failure pushes that id into ``unknown[]``
+    while the rest of the batch keeps building."""
+    real = ent.tier_path
+
+    def fake(f, t):
+        if t == ent.TIER_CLOUD_PRO:
+            raise RuntimeError("boom")
+        return real(f, t)
+
+    monkeypatch.setattr(ent, "tier_path", fake)
+    out = ent.tier_path_batch(
+        ent.TIER_OSS, [ent.TIER_CLOUD_PRO, ent.TIER_ENTERPRISE]
+    )
+    assert [item["to"] for item in out["tiers"]] == [ent.TIER_ENTERPRISE]
+    assert ent.TIER_CLOUD_PRO in out["unknown"]
+
+
+# ── HTTP: /api/entitlement/tier-path-batch ───────────────────────────────────
+
+
+def test_api_400_on_missing_from(client):
+    r = client.get(
+        "/api/entitlement/tier-path-batch?to=cloud_pro,enterprise"
+    )
+    assert r.status_code == 400
+
+
+def test_api_400_on_missing_to(client):
+    r = client.get("/api/entitlement/tier-path-batch?from=oss")
+    assert r.status_code == 400
+    body = r.get_json()
+    assert body["error"] == "supply to=<csv>"
+
+
+def test_api_400_on_empty_to(client):
+    r = client.get("/api/entitlement/tier-path-batch?from=oss&to=,,")
+    assert r.status_code == 400
+
+
+def test_api_404_on_unknown_from_tier(client):
+    r = client.get(
+        "/api/entitlement/tier-path-batch?from=not_a_tier&to=enterprise"
+    )
+    assert r.status_code == 404
+    body = r.get_json()
+    assert body["which"] == "tier"
+
+
+def test_api_200_with_unknown_destination_bucketed(client, ent):
+    r = client.get(
+        f"/api/entitlement/tier-path-batch?from={ent.TIER_OSS}"
+        f"&to={ent.TIER_CLOUD_PRO},bogus_tier"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert [item["to"] for item in body["tiers"]] == [ent.TIER_CLOUD_PRO]
+    assert body["unknown"] == ["bogus_tier"]
+
+
+def test_api_happy_path_ascending(client, ent):
+    r = client.get(
+        f"/api/entitlement/tier-path-batch?from={ent.TIER_OSS}"
+        f"&to={ent.TIER_CLOUD_STARTER},{ent.TIER_ENTERPRISE}"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert set(body.keys()) == _ENVELOPE_KEYS
+    assert body["from"] == ent.TIER_OSS
+    assert isinstance(body["from_label"], str)
+    assert body["from_rank"] == ent.tier_rank(ent.TIER_OSS)
+    tos = [item["to"] for item in body["tiers"]]
+    assert tos == [ent.TIER_CLOUD_STARTER, ent.TIER_ENTERPRISE]
+    for item in body["tiers"]:
+        assert item["direction"] == "upgrade"
+        assert item["path"][-1]["to"] == item["to"]
+
+
+def test_api_identity_branch(client, ent):
+    r = client.get(
+        f"/api/entitlement/tier-path-batch?from={ent.TIER_CLOUD_PRO}"
+        f"&to={ent.TIER_CLOUD_PRO}"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["tiers"][0]["direction"] == "identity"
+    assert body["tiers"][0]["path"] == []
+
+
+def test_api_lateral_branch(client, ent):
+    r = client.get(
+        f"/api/entitlement/tier-path-batch?from={ent.TIER_CLOUD_PRO}"
+        f"&to={ent.TIER_PRO}"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["tiers"][0]["direction"] == "lateral"
+    assert len(body["tiers"][0]["path"]) == 1
+
+
+def test_api_downgrade_branch(client, ent):
+    r = client.get(
+        f"/api/entitlement/tier-path-batch?from={ent.TIER_ENTERPRISE}"
+        f"&to={ent.TIER_OSS}"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["tiers"][0]["direction"] == "downgrade"
+
+
+def test_api_per_item_path_matches_scalar_route(client, ent):
+    """HTTP parity: each per-destination ``path`` is byte-identical to
+    the scalar ``/tier-path?from=&to=`` ``path`` payload for the same
+    ``(from, to)`` pair."""
+    candidates = [
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_ENTERPRISE,
+    ]
+    batch = client.get(
+        f"/api/entitlement/tier-path-batch?from={ent.TIER_OSS}"
+        f"&to={','.join(candidates)}"
+    ).get_json()
+    for item in batch["tiers"]:
+        scalar = client.get(
+            f"/api/entitlement/tier-path?from={ent.TIER_OSS}"
+            f"&to={item['to']}"
+        ).get_json()
+        assert item["path"] == scalar["path"]
+        assert item["direction"] == scalar["direction"]
+        assert item["to_label"] == scalar["to_label"]
+        assert item["to_rank"] == scalar["to_rank"]
+
+
+def test_api_input_normalised(client, ent):
+    r = client.get(
+        f"/api/entitlement/tier-path-batch?from={ent.TIER_OSS}"
+        f"&to=  CLOUD_PRO  ,cloud_starter,cloud_pro,"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert [item["to"] for item in body["tiers"]] == [
+        "cloud_pro",
+        "cloud_starter",
+    ]
+
+
+def test_api_grace_and_enforce_yield_identical_body(client, ent, monkeypatch):
+    grace = client.get(
+        f"/api/entitlement/tier-path-batch?from={ent.TIER_OSS}"
+        f"&to={ent.TIER_CLOUD_STARTER},{ent.TIER_ENTERPRISE}"
+    ).get_json()
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    enforced = client.get(
+        f"/api/entitlement/tier-path-batch?from={ent.TIER_OSS}"
+        f"&to={ent.TIER_CLOUD_STARTER},{ent.TIER_ENTERPRISE}"
+    ).get_json()
+    assert grace == enforced
+
+
+def test_api_envelope_carries_from_metadata(client, ent):
+    r = client.get(
+        f"/api/entitlement/tier-path-batch?from={ent.TIER_CLOUD_STARTER}"
+        f"&to={ent.TIER_ENTERPRISE}"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["from"] == ent.TIER_CLOUD_STARTER
+    assert body["from_label"] == ent.tier_label(ent.TIER_CLOUD_STARTER)
+    assert body["from_rank"] == ent.tier_rank(ent.TIER_CLOUD_STARTER)


### PR DESCRIPTION
## Summary

- New helper `tier_path_batch(from_tier, to_tiers) -> {tiers, unknown}` in `clawmetry/entitlements.py` — batch sibling of the existing scalar `tier_path`. Walks the rungs between ONE source tier and N candidate destinations in ONE round-trip; each per-destination `path` is byte-identical to the scalar `tier_path` payload for the same `(from, to)` pair (parity-pinned at both the helper and HTTP layers).
- New endpoint `GET /api/entitlement/tier-path-batch?from=&to=a,b,c` in `routes/entitlement.py` wrapping the helper.

This closes the gap on the all-slices member of the path-batch grid — the one row family that carries every marginal slice (`added_features` + `lost_features` + `added_runtimes` + `lost_runtimes` + `capacity_changes`) in a single per-rung body, complementing the existing slice-only siblings:

| helper                              | scalar | `_at` | `_at_batch` | `_path` | **`_path_batch`** |
|-------------------------------------|:------:|:-----:|:-----------:|:-------:|:-----------------:|
| `tier_path` (full marginal diff)    |   ✅   |   —   |     —       |    —    |   **NEW**         |
| `tier_spec_path`                    |   ✅   |   ✅  |     ✅      |   ✅    |     ✅            |
| `capacity_diff_path`                |   ✅   |   ✅  |     ✅      |   ✅    |     ✅            |
| `tier_unlocks_path` / `tier_locks_path` | ✅ |   ✅  |     ✅      |   ✅    |   ✅ (#3404 / #3405) |
| `preview_path`                      |   ✅   |   —   |     —       |   ✅    |   ✅ (#3413)      |
| `feature_spec_path` / `runtime_spec_path` | ✅ | ✅  |     ✅      |   ✅    |     ✅            |
| `lock_reason_path`                  |   ✅   |   ✅  |     ✅      |   ✅    |     ✅            |

Use case: a pricing-comparison "from my current rung, here are the 3 tiers I'm considering — show me the full marginal step diff (added + lost features, added + lost runtimes, capacity changes) at every rung walked to each" surface hydrates the matrix off ONE call instead of N calls to `/tier-path`.

## API

```
GET /api/entitlement/tier-path-batch?from=<id>&to=a,b,c
```

Response shape:

```json
{
  "from":       "<tier id>",
  "from_label": "...",
  "from_rank":  0,
  "tiers": [
    {
      "to":        "<tier id>",
      "to_label":  "...",
      "to_rank":   0,
      "direction": "upgrade|downgrade|lateral|identity",
      "path":      [{ ...tier_diff row... }, ...]
    }
  ],
  "unknown": ["bogus_id", ...]
}
```

Per-row body is the full `tier_diff` envelope (`from`/`from_label`/`from_rank`/`to`/`to_label`/`to_rank`/`direction`/`added_features`/`lost_features`/`added_runtimes`/`lost_runtimes`/`capacity_changes`), and the per-step `from` chains across the path so `row[i]["to"] == row[i+1]["from"]` and folding `added_features` / `added_runtimes` across an ascending path reconstructs `tier_diff(from, to).added_*` (pinned by a coverage test).

HTTP semantics match every other batch sibling:

- **400** when `from=` is missing / blank, or `to=` is missing / empty after normalisation
- **404** when `from` is unknown (body carries `which: "tier"`)
- **200** with bucketed `unknown[]` for unknown destination ids — does NOT 404 the call
- **Never 5xxs**: a synthesis failure short-circuits to an envelope with empty rows so the matrix keeps rendering

`trial` accepted as a destination (excluded from intermediate rungs, same as the scalar). Resolver-independent — grace vs enforce yields byte-identical rows since the walk delegates to `tier_path` / `tier_diff` over the static per-tier maps. No behaviour change to any existing endpoint, no `__version__` bump, no enforce gate flipped.

## Files

| File | Change |
|---|---|
| `clawmetry/entitlements.py` | +124 — `tier_path_batch` helper |
| `routes/entitlement.py` | +106 — `/api/entitlement/tier-path-batch` route |
| `tests/test_entitlement_tier_path_batch.py` | +504 — 33 tests: shape, scalar parity (helper + HTTP), direction branches, marginal-fold invariant, input normalisation, trial endpoint, error/edge cases, grace-vs-enforce parity, row-failure short-circuit, blueprint integration |

## Test plan

- [x] `python -m pytest tests/test_entitlement_tier_path_batch.py -x -q` → **33 passed** in 0.82s
- [x] Sibling regression sweep: `tests/test_entitlement_tier_path.py`, `tests/test_entitlement_tier_spec_path_batch.py`, `tests/test_entitlement_capacity_diff_path_batch.py` → **85 passed** in 1.68s
- [x] Broader `entitlement and path` sweep → **556 passed** in 10.57s (no regressions)
- [x] `python -m pytest tests/test_blueprint_uniqueness.py -q` → 2 passed (new route does not collide)
- [x] `ruff check clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_tier_path_batch.py` → All checks passed!
- [x] `python -m py_compile` on all three changed files
- [ ] CI green on this PR

## Local operator verification checklist

This remote fire cannot reach the local machine, the running daemon, `~/.openclaw`, the live cloud snapshot, or a browser. The following must be done by the local operator before flipping to ready-for-review:

- [ ] `git fetch origin && git checkout feat/entitlement-tier-path-batch`
- [ ] Copy changed files into the installed package:
      `cp clawmetry/entitlements.py ~/.clawmetry/lib/python*/site-packages/clawmetry/`
      `cp routes/entitlement.py ~/.clawmetry/lib/python*/site-packages/routes/`
- [ ] Clear bytecode: `find ~/.clawmetry/lib -name __pycache__ -type d -exec rm -rf {} +`
- [ ] Kick the daemon: `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
- [ ] Smoke-check the happy path:
      `curl -s 'http://localhost:8900/api/entitlement/tier-path-batch?from=oss&to=cloud_starter,cloud_pro,enterprise' | jq`
      expect 200, three rows with `direction: "upgrade"`, each `path[-1].to` equal to the row's `to`.
- [ ] Pin scalar parity in the live install:
      `curl -s 'http://localhost:8900/api/entitlement/tier-path-batch?from=oss&to=enterprise' | jq '.tiers[0].path'`
      byte-equal to
      `curl -s 'http://localhost:8900/api/entitlement/tier-path?from=oss&to=enterprise' | jq '.path'`.
- [ ] Verify error contract:
      `curl -i 'http://localhost:8900/api/entitlement/tier-path-batch?to=enterprise'` → 400
      `curl -i 'http://localhost:8900/api/entitlement/tier-path-batch?from=oss'` → 400 with `error: "supply to=<csv>"`
      `curl -i 'http://localhost:8900/api/entitlement/tier-path-batch?from=oss&to=,,'` → 400
      `curl -i 'http://localhost:8900/api/entitlement/tier-path-batch?from=not_a_tier&to=oss'` → 404 with `which: "tier"`
- [ ] Verify unknown-destination bucketing:
      `curl -s 'http://localhost:8900/api/entitlement/tier-path-batch?from=oss&to=cloud_pro,bogus_tier' | jq '.unknown'` echoes `["bogus_tier"]` with the valid row still present.
- [ ] `/api/entitlement` still resolves to the OSS-free grace envelope (no behaviour change in grace mode).
- [ ] Decrypt the live cloud snapshot, browser-check — no UI surface consumes this endpoint yet (it's a backend addition behind a parity guarantee), so the dashboard should look unchanged in grace mode.

This PR stays in **grace mode**: no behaviour change to any existing endpoint, no enforce gate flipped, no `__version__` bump, no release tag. The next-phase work (P3/P4/P6 — cloud-side entitlement minting, `clawmetry-pro` package download, enterprise SSO) needs the private `clawmetry-cloud` / `clawmetry-pro` repos and is out of scope for this remote session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01MSyxbAaUnQdGVXTZ1aYSF1)_