### PR TITLE
feat(audit-log): add audit_log DuckDB table + /api/audit-log endpoint (#3306)

### DIFF
--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -637,6 +637,25 @@ _DDL = [
     """,
     "CREATE INDEX IF NOT EXISTS idx_security_events_ts      ON security_events(ts)",
     "CREATE INDEX IF NOT EXISTS idx_security_events_session ON security_events(session_id, ts)",
+    # Issue #3306 — operator audit log. Persistent record of human actions
+    # (approve, deny, kill_session, config_change, etc.) for the OSS data layer
+    # that the cloud relay reads. Auth / RBAC enforcement is cloud-side; this
+    # table is the append-only source-of-truth for the local operator trail.
+    # Idempotent (CREATE TABLE IF NOT EXISTS).
+    """
+    CREATE TABLE IF NOT EXISTS audit_log (
+        id         VARCHAR PRIMARY KEY,
+        ts         VARCHAR NOT NULL,
+        actor      VARCHAR,
+        action     VARCHAR NOT NULL,
+        target     VARCHAR,
+        session_id VARCHAR,
+        result     VARCHAR
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_audit_log_ts     ON audit_log(ts)",
+    "CREATE INDEX IF NOT EXISTS idx_audit_log_actor  ON audit_log(actor, ts)",
+    "CREATE INDEX IF NOT EXISTS idx_audit_log_action ON audit_log(action, ts)",
     # Issue #2201 — asset registry. Evidence + review layer that turns
     # individual agent discoveries (Self-Evolve findings, useful prompts,
     # improved skills) into reviewable, reusable assets without auto-promoting
@@ -7466,6 +7485,68 @@ class LocalStore:
         """
         params.append(int(limit))
         cols = ["id", "ts", "type", "severity", "session_id", "rule_id", "description", "snippet"]
+        return [dict(zip(cols, r)) for r in self._fetch(sql, params)]
+
+    # ------------------------------------------------------------------
+    # Audit log (#3306) — persistent operator action trail
+    # ------------------------------------------------------------------
+
+    def ingest_audit_log_entry(self, entry: dict[str, Any]) -> None:
+        """Upsert one audit-log entry. Required: ``id``, ``action``."""
+        eid = entry.get("id")
+        if not eid:
+            raise ValueError("audit log entry must include 'id'")
+        ts = entry.get("ts") or datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S")
+        with self._write_lock:
+            self._conn.execute("""
+                INSERT INTO audit_log (id, ts, actor, action, target, session_id, result)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT (id) DO UPDATE SET
+                    result = COALESCE(excluded.result, audit_log.result)
+            """, [
+                str(eid),
+                ts,
+                entry.get("actor"),
+                entry.get("action", ""),
+                entry.get("target"),
+                entry.get("session_id"),
+                entry.get("result"),
+            ])
+
+    def query_audit_log(
+        self,
+        *,
+        actor: str | None = None,
+        action: str | None = None,
+        session_id: str | None = None,
+        since: str | None = None,
+        limit: int = 200,
+    ) -> list[dict[str, Any]]:
+        """Read audit-log entries, most-recent first."""
+        clauses: list[str] = []
+        params: list[Any] = []
+        if actor:
+            clauses.append("actor = ?")
+            params.append(actor)
+        if action:
+            clauses.append("action = ?")
+            params.append(action)
+        if session_id:
+            clauses.append("session_id = ?")
+            params.append(session_id)
+        if since:
+            clauses.append("ts >= ?")
+            params.append(since)
+        where = ("WHERE " + " AND ".join(clauses)) if clauses else ""
+        sql = f"""
+            SELECT id, ts, actor, action, target, session_id, result
+            FROM audit_log
+            {where}
+            ORDER BY ts DESC, id
+            LIMIT ?
+        """
+        params.append(int(limit))
+        cols = ["id", "ts", "actor", "action", "target", "session_id", "result"]
         return [dict(zip(cols, r)) for r in self._fetch(sql, params)]
 
     def query_nemoclaw_metrics(

--- a/routes/health.py
+++ b/routes/health.py
@@ -3544,3 +3544,55 @@ def api_security_threats_history():
             rows = []
 
     return jsonify({"threats": rows or [], "total": len(rows or [])})
+
+
+@bp_health.route("/api/audit-log")
+def api_audit_log():
+    """Return operator audit-log entries from DuckDB (#3306).
+
+    Records human actions (approve, deny, kill_session, config_change, etc.)
+    written via ``ingest_audit_log_entry``. Auth / RBAC enforcement is
+    cloud-side; this endpoint is the OSS read surface.
+
+    Query params:
+      actor      — filter by actor identity
+      action     — filter by action type
+      session_id — narrow to one session
+      since      — ISO timestamp lower bound
+      limit      — max rows (default 200)
+    """
+    actor = (request.args.get("actor") or "").strip() or None
+    action = (request.args.get("action") or "").strip() or None
+    session_id = (request.args.get("session_id") or "").strip() or None
+    since = (request.args.get("since") or "").strip() or None
+    try:
+        limit = max(1, min(1000, int(request.args.get("limit", 200))))
+    except (TypeError, ValueError):
+        limit = 200
+
+    rows = None
+    if is_local_store_read_enabled():
+        try:
+            from routes.local_query import local_store_via_daemon
+            rows = local_store_via_daemon(
+                "query_audit_log",
+                actor=actor,
+                action=action,
+                session_id=session_id,
+                since=since,
+                limit=limit,
+            )
+        except Exception:
+            rows = None
+
+    if rows is None:
+        try:
+            from clawmetry import local_store as _ls
+            rows = _ls.get_store().query_audit_log(
+                actor=actor, action=action, session_id=session_id,
+                since=since, limit=limit,
+            )
+        except Exception:
+            rows = []
+
+    return jsonify({"entries": rows or [], "total": len(rows or [])})

--- a/routes/local_query.py
+++ b/routes/local_query.py
@@ -782,6 +782,11 @@ _DAEMON_METHODS = frozenset({
     # proxy so the dashboard process never opens DuckDB writable.
     "ingest_security_event",
     "query_security_events",
+    # Issue #3306 — audit log read path. ingest_ is called from operator
+    # actions; query_ serves /api/audit-log. Both routed through the daemon
+    # proxy so the dashboard process never opens DuckDB writable.
+    "ingest_audit_log_entry",
+    "query_audit_log",
 })
 
 


### PR DESCRIPTION
## Summary

Adds the OSS data-layer slice of the team-features audit log from #3306. Operators now have a persistent, queryable record of human actions (approvals, kills, config changes) in DuckDB that survives daemon restarts and is relay-able to the cloud. Auth / RBAC enforcement and cloud-side team management are explicitly out of scope here.

## Changes

- **`clawmetry/local_store.py`** — `audit_log` DuckDB table (`id`, `ts`, `actor`, `action`, `target`, `session_id`, `result`) with three indexes; idempotent `CREATE TABLE IF NOT EXISTS`. Adds `ingest_audit_log_entry(entry)` (upsert, mirrors `ingest_security_event`) and `query_audit_log(*, actor, action, session_id, since, limit)` (read, mirrors `query_authority_violations`).
- **`routes/local_query.py`** — registers `ingest_audit_log_entry` and `query_audit_log` in `_DAEMON_METHODS` so reads route through the daemon proxy without contending on the DuckDB writer lock.
- **`routes/health.py`** — `GET /api/audit-log` on `bp_health`: daemon-proxy first, direct-store fallback; supports `actor`, `action`, `session_id`, `since`, `limit` query params. Returns `{"entries": [...], "total": N}`.

## Test plan

- [ ] `python3 -c 'import ast; ast.parse(open("clawmetry/local_store.py").read())'` — syntax OK
- [ ] `python3 -c 'import ast; ast.parse(open("routes/health.py").read())'` — syntax OK
- [ ] `GET /api/audit-log?limit=10` on a fresh store → `{"entries": [], "total": 0}`
- [ ] After wiring an operator action to call `ingest_audit_log_entry`, verify the entry appears in `/api/audit-log`

## Bot meta
<!-- bot-autofix -->
Draft PR opened autonomously based on the plan in #3306. Marked draft for human review — mark Ready for Review once happy.

Closes #3306

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q6XUbJrk1dYiaSbBwWsez8)_