### PR TITLE
feat(entitlement): next/previous_tier_lock_reason_at_batch + 2 endpoints

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -8098,6 +8098,236 @@ def tier_path_batch(from_tier: str, to_tiers) -> dict | None:
     return {"tiers": rows, "unknown": unknown}
 
 
+def _empty_lock_reasons_at_batch(features, runtimes, channels, retention_days, nodes):
+    """Grace-shape sibling of :func:`lock_reasons_at_batch` used when the
+    resolved target tier is ``None`` (ceiling for ``next``, floor for
+    ``previous``). Preserves the 5-axis shape and per-item row counts so
+    a paywall matrix UI never sees a shape-change at the edges -- every
+    row carries ``reason=None`` / ``locked=False`` / ``allowed=True``.
+    """
+    feats = _normalise_csv(features)
+    rts_norm = _normalise_csv(runtimes)
+    seen_rt: set[str] = set()
+    rt_rows: list[dict] = []
+    for raw in rts_norm:
+        canon = canonical_runtime(raw) or raw
+        if canon in seen_rt:
+            continue
+        seen_rt.add(canon)
+        rt_rows.append(
+            {
+                "key": canon,
+                "kind": "runtime",
+                "reason": None,
+                "locked": False,
+                "allowed": True,
+                "required_tier": None,
+                "required_tier_label": None,
+                "required_tier_rank": -1,
+            }
+        )
+    feat_rows = [
+        {
+            "key": fid,
+            "kind": "feature",
+            "reason": None,
+            "locked": False,
+            "allowed": True,
+            "required_tier": None,
+            "required_tier_label": None,
+            "required_tier_rank": -1,
+        }
+        for fid in feats
+    ]
+
+    def _cap_row(kind: str, raw) -> dict | None:
+        if raw is None:
+            return None
+        try:
+            n = int(raw)
+            key = str(n)
+        except (TypeError, ValueError):
+            key = str(raw)
+        return {
+            "key": key,
+            "kind": kind,
+            "reason": None,
+            "locked": False,
+            "allowed": True,
+            "required_tier": None,
+            "required_tier_label": None,
+            "required_tier_rank": -1,
+        }
+
+    return {
+        "features": feat_rows,
+        "runtimes": rt_rows,
+        "channels": _cap_row("channels", channels),
+        "retention_days": _cap_row("retention_days", retention_days),
+        "nodes": _cap_row("nodes", nodes),
+    }
+
+
+def next_tier_lock_reason_at_batch(
+    tier: str,
+    *,
+    features=None,
+    runtimes=None,
+    channels: int | None = None,
+    retention_days: int | None = None,
+    nodes: int | None = None,
+) -> dict | None:
+    """Batch sibling of :func:`next_tier_lock_reason_at`: per-item lock-
+    reason rows for every supplied item across all 5 axes, evaluated on
+    the rung above the caller-supplied source ``tier`` in ONE round-trip.
+
+    Composes :func:`next_tier_lock_reason_at` (scalar projection) and
+    :func:`lock_reasons_at_batch` (5-axis matrix what-if) -- same target
+    (``_next_purchasable_tier_after(tier)``) as the scalar, same
+    per-item row shape as the batch helper. Lets a paywall "does THIS
+    column of items unlock at my next rung?" matrix surface render every
+    row off ONE call instead of N calls to
+    :func:`next_tier_lock_reason_at` per axis.
+
+    Body is byte-identical to
+    :func:`lock_reasons_at_batch(target, ...)` for the resolved
+    ``target = _next_purchasable_tier_after(tier)`` -- pinned by parity
+    tests so the scalar what-if and batch what-if cannot drift from the
+    full helper.
+
+    Shape (byte-identical to :func:`lock_reasons_at_batch`)::
+
+        {
+          "features":       [<row>, ...],
+          "runtimes":       [<row>, ...],
+          "channels":       <row> | None,
+          "retention_days": <row> | None,
+          "nodes":          <row> | None,
+        }
+
+    Each ``<row>`` carries the same 8 keys :func:`_lock_row` emits
+    (``key``, ``kind``, ``reason``, ``locked``, ``allowed``,
+    ``required_tier``, ``required_tier_label``, ``required_tier_rank``).
+
+    At the ceiling (enterprise as source, no rung above) rows still
+    render for every supplied item with ``reason=None`` /
+    ``locked=False`` / ``allowed=True`` so the matrix's row count stays
+    stable and the caller doesn't need a special shape branch.
+
+    Accepts any tier id in :data:`_TIER_ORDER` (including
+    :data:`TIER_TRIAL`) -- the lenient ``_at`` posture. Returns ``None``
+    for empty / unknown ``tier`` (caller renders "unknown tier" / 404).
+
+    Resolver-independent: delegates to :func:`lock_reasons_at_batch`
+    against the synthesised hypothetical entitlement -- grace vs enforce
+    yields byte-identical rows. Never raises: a per-axis failure short-
+    circuits to the grace-shape rows so the matrix keeps rendering.
+    """
+    try:
+        src = (tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if not src or src not in _TIER_ORDER:
+        return None
+    try:
+        target = _next_purchasable_tier_after(src)
+    except Exception as exc:
+        logger.warning(
+            "entitlements: next_tier_lock_reason_at_batch target resolve failed: %s",
+            exc,
+        )
+        target = None
+    if target is None:
+        return _empty_lock_reasons_at_batch(
+            features, runtimes, channels, retention_days, nodes
+        )
+    try:
+        out = lock_reasons_at_batch(
+            target,
+            features=features,
+            runtimes=runtimes,
+            channels=channels,
+            retention_days=retention_days,
+            nodes=nodes,
+        )
+    except Exception as exc:
+        logger.warning(
+            "entitlements: next_tier_lock_reason_at_batch failed: %s", exc
+        )
+        out = None
+    if out is None:
+        return _empty_lock_reasons_at_batch(
+            features, runtimes, channels, retention_days, nodes
+        )
+    return out
+
+
+def previous_tier_lock_reason_at_batch(
+    tier: str,
+    *,
+    features=None,
+    runtimes=None,
+    channels: int | None = None,
+    retention_days: int | None = None,
+    nodes: int | None = None,
+) -> dict | None:
+    """Source-anchored mirror of :func:`next_tier_lock_reason_at_batch`
+    -- batch sibling of :func:`previous_tier_lock_reason_at` sweeping N
+    items across all 5 axes against the rung BELOW the caller-supplied
+    ``tier`` in ONE round-trip.
+
+    Same per-item row shape and 5-axis envelope as
+    :func:`next_tier_lock_reason_at_batch`. At the floor (``oss`` /
+    ``cloud_free`` as source, no rung below) rows still render for every
+    supplied item with ``reason=None`` / ``locked=False`` /
+    ``allowed=True`` so the downgrade-confirmation matrix's row count
+    stays stable.
+
+    Body is byte-identical to
+    :func:`lock_reasons_at_batch(target, ...)` for the resolved
+    ``target = _previous_purchasable_tier_before(tier)``.
+
+    Returns ``None`` for empty / unknown ``tier``. Never raises.
+    """
+    try:
+        src = (tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if not src or src not in _TIER_ORDER:
+        return None
+    try:
+        target = _previous_purchasable_tier_before(src)
+    except Exception as exc:
+        logger.warning(
+            "entitlements: previous_tier_lock_reason_at_batch target resolve failed: %s",
+            exc,
+        )
+        target = None
+    if target is None:
+        return _empty_lock_reasons_at_batch(
+            features, runtimes, channels, retention_days, nodes
+        )
+    try:
+        out = lock_reasons_at_batch(
+            target,
+            features=features,
+            runtimes=runtimes,
+            channels=channels,
+            retention_days=retention_days,
+            nodes=nodes,
+        )
+    except Exception as exc:
+        logger.warning(
+            "entitlements: previous_tier_lock_reason_at_batch failed: %s", exc
+        )
+        out = None
+    if out is None:
+        return _empty_lock_reasons_at_batch(
+            features, runtimes, channels, retention_days, nodes
+        )
+    return out
+
+
 def capacity_diff_path_batch(
     from_tier: str, to_tiers
 ) -> dict | None:

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -7334,6 +7334,224 @@ def api_entitlement_previous_tier_lock_reason_at():
     return _next_prev_lock_reason_at("previous")
 
 
+def _next_prev_lock_reason_at_batch(direction: str):
+    """Shared body for the ``/next-tier-lock-reason-at-batch`` and
+    ``/previous-tier-lock-reason-at-batch`` endpoints. ``direction`` is
+    ``"next"`` or ``"previous"``.
+    """
+    log_name = f"api_entitlement_{direction}_tier_lock_reason_at_batch"
+    raw_tier = request.args.get("tier")
+    tier_in = (raw_tier or "").strip().lower()
+    if not tier_in:
+        return jsonify({"error": "missing tier"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        if tier_in not in _ent._TIER_ORDER:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "tier", "tier": tier_in}
+                ),
+                404,
+            )
+
+        features = _parse_csv_arg("features")
+        runtimes = _parse_csv_arg("runtimes")
+        (_, channels_ok, channels_n, _) = _parse_capacity_arg("channels")
+        (_, retention_ok, retention_n, _) = _parse_capacity_arg(
+            "retention_days"
+        )
+        (_, nodes_ok, nodes_n, _) = _parse_capacity_arg("nodes")
+
+        if (
+            not features
+            and not runtimes
+            and not channels_ok
+            and not retention_ok
+            and not nodes_ok
+        ):
+            return (
+                jsonify(
+                    {
+                        "error": (
+                            "supply at least one of features=<csv>, "
+                            "runtimes=<csv>, channels=<int>, "
+                            "retention_days=<int>, or nodes=<int>"
+                        )
+                    }
+                ),
+                400,
+            )
+
+        if direction == "next":
+            target = _ent._next_purchasable_tier_after(tier_in)
+            batch = _ent.next_tier_lock_reason_at_batch(
+                tier_in,
+                features=features or None,
+                runtimes=runtimes or None,
+                channels=channels_n if channels_ok else None,
+                retention_days=retention_n if retention_ok else None,
+                nodes=nodes_n if nodes_ok else None,
+            )
+        else:
+            target = _ent._previous_purchasable_tier_before(tier_in)
+            batch = _ent.previous_tier_lock_reason_at_batch(
+                tier_in,
+                features=features or None,
+                runtimes=runtimes or None,
+                channels=channels_n if channels_ok else None,
+                retention_days=retention_n if retention_ok else None,
+                nodes=nodes_n if nodes_ok else None,
+            )
+        if batch is None:
+            batch = {
+                "features": [],
+                "runtimes": [],
+                "channels": None,
+                "retention_days": None,
+                "nodes": None,
+            }
+        ent = _ent.get_entitlement()
+        batch["tier"] = tier_in
+        batch["tier_label"] = _ent.tier_label(tier_in)
+        batch["tier_rank"] = _ent.tier_rank(tier_in)
+        batch["target"] = target
+        batch["target_label"] = _ent.tier_label(target) if target else None
+        batch["target_rank"] = _ent.tier_rank(target) if target else None
+        batch["current_tier"] = ent.tier
+        batch["current_tier_rank"] = _ent.tier_rank(ent.tier)
+        batch["grace"] = bool(ent.grace)
+        batch["enforced"] = _ent.is_enforced()
+        return jsonify(batch)
+    except Exception as exc:
+        logger.warning("%s: error: %s", log_name, exc)
+        return jsonify(
+            {
+                "features": [],
+                "runtimes": [],
+                "channels": None,
+                "retention_days": None,
+                "nodes": None,
+                "tier": tier_in,
+                "tier_label": None,
+                "tier_rank": -1,
+                "target": None,
+                "target_label": None,
+                "target_rank": None,
+                "current_tier": "oss",
+                "current_tier_rank": 0,
+                "grace": True,
+                "enforced": False,
+            }
+        )
+
+
+@bp_entitlement.route("/api/entitlement/next-tier-lock-reason-at-batch")
+def api_entitlement_next_tier_lock_reason_at_batch():
+    """``GET /api/entitlement/next-tier-lock-reason-at-batch?tier=<source>
+    &features=a,b&runtimes=x,y&channels=N&retention_days=K&nodes=M`` --
+    batch sibling of ``/api/entitlement/next-tier-lock-reason-at``.
+
+    Where ``/next-tier-lock-reason-at`` returns ONE lock sentence for
+    ONE item at the rung above ``tier``, this returns per-item rows for
+    every supplied item across all 5 axes in ONE round-trip. Pairs with
+    ``/next-tier-lock-reason-at`` the same way
+    ``/lock-reasons-at-batch`` pairs with ``/lock-reason-at``: scalar ->
+    matrix in one call. Fills the lock-reason-axis batch member of the
+    ``next_*_at_batch`` family alongside
+    ``/next-tier-feature-spec-at-batch`` and
+    ``/next-tier-runtime-spec-at-batch``.
+
+    Use case: a paywall "does THIS column of features / runtimes /
+    capacity axes unlock at my next rung?" matrix surface hydrates every
+    row off ONE call instead of N calls to ``/next-tier-lock-reason-at``
+    per axis.
+
+    Body is byte-identical to
+    ``/lock-reasons-at-batch?tier=<target>&...`` for the resolved
+    ``target = _next_purchasable_tier_after(tier)`` plus a ``tier`` /
+    ``target`` echo -- a parity test pins this so the two batch surfaces
+    cannot drift.
+
+    At least one of ``features=`` / ``runtimes=`` / ``channels=`` /
+    ``retention_days=`` / ``nodes=`` must be supplied (matches
+    ``/lock-reasons-at-batch``); supply as many as you like.
+    ``features=`` / ``runtimes=`` take comma-separated tokens
+    (whitespace + duplicates are normalised away; unknown ids contribute
+    a grace-shape row). The three capacity axes take a single int each;
+    blank / non-int values are treated as "not supplied".
+
+    Response shape::
+
+        {
+          "features":       [<row>, ...],
+          "runtimes":       [<row>, ...],
+          "channels":       <row> | None,
+          "retention_days": <row> | None,
+          "nodes":          <row> | None,
+          "tier":                 "<source tier id>",
+          "tier_label":           "<source label>",
+          "tier_rank":            <source rank>,
+          "target":               "<next-above tier id>" | null,
+          "target_label":         "<next-above label>" | null,
+          "target_rank":          <next-above rank> | null,
+          "current_tier":         "<live resolved tier>",
+          "current_tier_rank":    <int>,
+          "grace":                <bool>,
+          "enforced":             <bool>,
+        }
+
+    Each ``<row>`` carries ``key``, ``kind``, ``reason``, ``locked``,
+    ``allowed``, ``required_tier``, ``required_tier_label``,
+    ``required_tier_rank`` -- the same 8 keys ``/lock-reasons-at-batch``
+    returns.
+
+    Accepts any tier id in :data:`entitlements._TIER_ORDER` (including
+    ``trial``). At the ceiling (enterprise as source) ``target`` is
+    ``null`` and rows still render for every supplied item with
+    ``reason=null`` / ``locked=false`` / ``allowed=true`` so callers can
+    render "you're at the top" copy without a status-code branch.
+
+    - **400** when ``tier=`` is missing / blank or no axis is supplied
+    - **404** when ``tier`` is unknown (body carries ``which: "tier"``)
+    - **Never 5xxs**: builder failure short-circuits to the grace-shape
+      envelope with ``target=null`` so the paywall surface stays mute.
+    """
+    return _next_prev_lock_reason_at_batch("next")
+
+
+@bp_entitlement.route("/api/entitlement/previous-tier-lock-reason-at-batch")
+def api_entitlement_previous_tier_lock_reason_at_batch():
+    """``GET /api/entitlement/previous-tier-lock-reason-at-batch?tier=<source>
+    &features=a,b&runtimes=x,y&channels=N&retention_days=K&nodes=M`` --
+    batch sibling of ``/api/entitlement/previous-tier-lock-reason-at``.
+
+    Source-anchored mirror of ``/next-tier-lock-reason-at-batch`` and
+    downgrade-confirmation counterpart on the lock-reason axis. Lets a
+    downgrade-confirmation matrix surface render "what lock sentences
+    would surface for THIS column of items if I drop one rung?" without
+    recomputing the target tier client-side.
+
+    Response shape matches ``/next-tier-lock-reason-at-batch`` byte-for-
+    byte (``features``, ``runtimes``, ``channels``, ``retention_days``,
+    ``nodes``, ``tier``, ``tier_label``, ``tier_rank``, ``target``,
+    ``target_label``, ``target_rank``, ``current_tier``,
+    ``current_tier_rank``, ``grace``, ``enforced``). Body is
+    byte-identical to ``/lock-reasons-at-batch?tier=<target>&...`` for
+    the resolved
+    ``target = _previous_purchasable_tier_before(tier)``.
+
+    Accepts any tier id in :data:`entitlements._TIER_ORDER` (including
+    ``trial``). At the floor (``oss`` / ``cloud_free`` as source)
+    ``target`` is ``null`` and rows still render for every supplied item
+    with ``reason=null`` / ``locked=false`` / ``allowed=true``.
+
+    - **400** when ``tier=`` is missing / blank or no axis is supplied
+    - **404** when ``tier`` is unknown (body carries ``which: "tier"``)
+    - **Never 5xxs**: builder failure short-circuits to the grace-shape
+      envelope with ``target=null``.
+    """
+    return _next_prev_lock_reason_at_batch("previous")
 
 
 @bp_entitlement.route("/api/entitlement/tier-spec-path-batch")

--- a/tests/test_entitlement_next_prev_tier_lock_reason_at_batch.py
+++ b/tests/test_entitlement_next_prev_tier_lock_reason_at_batch.py
@@ -1,0 +1,724 @@
+"""Tests for the two directional batch what-if helpers projecting
+:func:`clawmetry.entitlements.lock_reasons_at_batch` onto the rung
+above / below a caller-supplied source tier, and the two companion
+``/api/entitlement/{next,previous}-tier-lock-reason-at-batch``
+endpoints.
+
+These helpers fill the batch member of the ``next_*_at_batch`` /
+``previous_*_at_batch`` family on the lock-reason axis, alongside
+the existing:
+
+* :func:`next_tier_feature_spec_at_batch` /
+  :func:`previous_tier_feature_spec_at_batch`
+* :func:`next_tier_runtime_spec_at_batch` /
+  :func:`previous_tier_runtime_spec_at_batch`
+* :func:`next_tier_spec_at_batch` / :func:`previous_tier_spec_at_batch`
+* :func:`next_tier_capacity_diff_at_batch` /
+  :func:`previous_tier_capacity_diff_at_batch`
+* :func:`next_tier_locks_at_batch` / :func:`next_tier_unlocks_at_batch`
+  (and the ``previous_`` twins)
+
+The new helpers compose:
+:func:`next_tier_lock_reason_at` (scalar projection) +
+:func:`lock_reasons_at_batch` (5-axis matrix what-if) -- same target as
+the scalar, same 5-axis row shape as the batch helper. Lets a paywall
+"does THIS column of features / runtimes / capacity axes unlock at my
+next / previous rung?" matrix surface render every row off ONE call
+instead of N calls to :func:`next_tier_lock_reason_at` per axis.
+
+Pins covered here:
+
+* per-rung byte-equality with :func:`lock_reasons_at_batch` at the
+  resolved next / previous purchasable target (parity, all five axes)
+* ``next`` / ``previous`` align with
+  :func:`_next_purchasable_tier_after` /
+  :func:`_previous_purchasable_tier_before` so the batch helpers cannot
+  drift from the rung-walker shared with the other ``next_*_at_batch``
+  family
+* ceiling (enterprise as source) / floor (oss / cloud_free as source)
+  still emit per-item rows with ``reason=null`` / ``locked=false`` /
+  ``allowed=true`` so the matrix's row count stays stable (no shape
+  branch for edge tiers)
+* trial-as-source resolves the same way the sibling ``_at_batch``
+  families do: next -> enterprise, previous -> cloud_starter
+* unknown / empty / whitespace / case-insensitive id handling
+* runtime alias resolution (``claude-code`` -> ``claude_code``)
+  produces canonical ``key`` values in the returned rows
+* capacity axes (``channels`` / ``retention_days`` / ``nodes``) route
+  through the batch helper's kwarg surface just like
+  :func:`lock_reasons_at_batch`
+* grace vs enforce yields the same body (catalogue-derived, not gated)
+* the helpers never raise -- a builder failure short-circuits to
+  grace-shape rows so the matrix keeps rendering rather than 500-ing
+* the two API endpoints never 5xx: 400 on missing input / no-axis,
+  404 on unknown tier, 200 with grace-shape rows at the ceiling /
+  floor; an internal failure yields the same 200 envelope shape
+* the endpoint response is byte-identical to
+  ``/lock-reasons-at-batch?tier=<target>&...`` for the resolved target,
+  plus a ``tier`` / ``target`` echo -- parity pin so the two batch
+  surfaces cannot drift
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+_ROW_KEYS = {
+    "key",
+    "kind",
+    "reason",
+    "locked",
+    "allowed",
+    "required_tier",
+    "required_tier_label",
+    "required_tier_rank",
+}
+
+_HELPER_BATCH_KEYS = {
+    "features",
+    "runtimes",
+    "channels",
+    "retention_days",
+    "nodes",
+}
+
+_API_EXTRA_KEYS = {
+    "tier",
+    "tier_label",
+    "tier_rank",
+    "target",
+    "target_label",
+    "target_rank",
+    "current_tier",
+    "current_tier_rank",
+    "grace",
+    "enforced",
+}
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# ── next_tier_lock_reason_at_batch: helper shape ────────────────────────────
+
+
+def test_next_helper_returns_dict_with_axis_keys(ent):
+    fid = next(iter(ent.FREE_FEATURES))
+    out = ent.next_tier_lock_reason_at_batch(ent.TIER_OSS, features=[fid])
+    assert isinstance(out, dict)
+    assert set(out.keys()) == _HELPER_BATCH_KEYS
+
+
+def test_next_helper_features_row_shape(ent):
+    fid = next(iter(ent.FREE_FEATURES))
+    out = ent.next_tier_lock_reason_at_batch(ent.TIER_OSS, features=[fid])
+    assert isinstance(out["features"], list)
+    assert len(out["features"]) == 1
+    assert set(out["features"][0].keys()) == _ROW_KEYS
+
+
+def test_next_helper_every_purchasable_tier_returns_dict(ent):
+    paid_universe = (
+        ent.STARTER_FEATURES | ent.PRO_ONLY_FEATURES | ent.ENTERPRISE_FEATURES
+    )
+    fid = next(iter(paid_universe))
+    for tier in ent._TIER_ORDER:
+        out = ent.next_tier_lock_reason_at_batch(tier, features=[fid])
+        assert isinstance(out, dict), tier
+        assert set(out.keys()) == _HELPER_BATCH_KEYS
+
+
+# ── next helper: invalid source tier ────────────────────────────────────────
+
+
+def test_next_helper_unknown_tier_returns_none(ent):
+    fid = next(iter(ent.FREE_FEATURES))
+    assert (
+        ent.next_tier_lock_reason_at_batch("not_a_real_tier", features=[fid])
+        is None
+    )
+
+
+def test_next_helper_empty_tier_returns_none(ent):
+    fid = next(iter(ent.FREE_FEATURES))
+    assert ent.next_tier_lock_reason_at_batch("", features=[fid]) is None
+
+
+def test_next_helper_none_tier_returns_none(ent):
+    fid = next(iter(ent.FREE_FEATURES))
+    assert ent.next_tier_lock_reason_at_batch(None, features=[fid]) is None
+
+
+def test_next_helper_non_string_tier_returns_none(ent):
+    fid = next(iter(ent.FREE_FEATURES))
+    assert ent.next_tier_lock_reason_at_batch(123, features=[fid]) is None
+
+
+# ── next helper: byte-parity with lock_reasons_at_batch at target ───────────
+
+
+def test_next_helper_byte_equal_to_lock_reasons_at_batch_at_target(ent):
+    """The batch what-if projection must be byte-identical to the full
+    :func:`lock_reasons_at_batch` payload at the resolved target for
+    every purchasable source tier. Parity pin so the projection cannot
+    drift from the full helper.
+    """
+    fid = next(iter(ent.PRO_ONLY_FEATURES))
+    rt = next(iter(ent.PAID_RUNTIMES))
+    for src in ent._PURCHASABLE_TIERS:
+        target = ent._next_purchasable_tier_after(src)
+        if target is None:
+            continue
+        projected = ent.next_tier_lock_reason_at_batch(
+            src,
+            features=[fid],
+            runtimes=[rt],
+            channels=50,
+            retention_days=365,
+            nodes=10,
+        )
+        direct = ent.lock_reasons_at_batch(
+            target,
+            features=[fid],
+            runtimes=[rt],
+            channels=50,
+            retention_days=365,
+            nodes=10,
+        )
+        assert projected == direct, src
+
+
+def test_next_helper_scalar_matches_row_reason(ent):
+    """Row ``reason`` for a feature in the batch must byte-equal the
+    scalar :func:`next_tier_lock_reason_at` sibling for the same input.
+    """
+    fid = next(iter(ent.PRO_ONLY_FEATURES))
+    for src in ent._PURCHASABLE_TIERS:
+        batch = ent.next_tier_lock_reason_at_batch(src, features=[fid])
+        scalar = ent.next_tier_lock_reason_at(src, fid, kind="feature")
+        assert batch["features"][0]["reason"] == scalar, src
+
+
+# ── next helper: rows at rung above unlock paid items ───────────────────────
+
+
+def test_paid_feature_locked_from_oss_next_rung_is_starter(ent):
+    """From OSS the next purchasable rung is Starter -- Pro-only
+    features should still be locked there."""
+    fid = next(iter(ent.PRO_ONLY_FEATURES))
+    out = ent.next_tier_lock_reason_at_batch(ent.TIER_OSS, features=[fid])
+    row = out["features"][0]
+    assert row["locked"] is True
+    assert row["allowed"] is False
+    assert isinstance(row["reason"], str) and row["reason"]
+
+
+def test_paid_feature_unlocked_from_starter_next_rung_is_pro(ent):
+    """From Starter the next purchasable rung is Pro -- Pro-only
+    features should be unlocked there."""
+    fid = next(iter(ent.PRO_ONLY_FEATURES))
+    out = ent.next_tier_lock_reason_at_batch(
+        ent.TIER_CLOUD_STARTER, features=[fid]
+    )
+    row = out["features"][0]
+    assert row["locked"] is False
+    assert row["allowed"] is True
+    assert row["reason"] is None
+
+
+# ── next helper: runtime + alias canonicalisation ───────────────────────────
+
+
+def test_next_helper_paid_runtime_locked_from_oss_next_rung(ent):
+    rt = next(iter(ent.PAID_RUNTIMES))
+    out = ent.next_tier_lock_reason_at_batch(ent.TIER_OSS, runtimes=[rt])
+    row = out["runtimes"][0]
+    assert row["locked"] is False
+    assert row["allowed"] is True
+
+
+def test_next_helper_runtime_alias_preserved_like_parent(ent):
+    """Aliased runtime ids are echoed back verbatim in the row ``key``
+    -- matching :func:`lock_reasons_at_batch`'s no-canonicalisation
+    posture (the sibling ``next_tier_runtime_spec_at_batch`` canonicalises
+    because it delegates to :func:`runtime_spec_at`; this helper
+    delegates to :func:`lock_reasons_at_batch` which does not). Pin so
+    the two batch surfaces cannot silently diverge on alias handling."""
+    if ent.canonical_runtime("claude-code") != "claude_code":
+        pytest.skip("claude-code alias not present")
+    out = ent.next_tier_lock_reason_at_batch(
+        ent.TIER_OSS, runtimes=["claude-code"]
+    )
+    row = out["runtimes"][0]
+    direct = ent.lock_reasons_at_batch(
+        ent._next_purchasable_tier_after(ent.TIER_OSS),
+        runtimes=["claude-code"],
+    )
+    assert row["key"] == direct["runtimes"][0]["key"]
+
+
+# ── next helper: capacity axes ──────────────────────────────────────────────
+
+
+def test_next_helper_capacity_axes_default_to_none(ent):
+    fid = next(iter(ent.FREE_FEATURES))
+    out = ent.next_tier_lock_reason_at_batch(ent.TIER_OSS, features=[fid])
+    assert out["channels"] is None
+    assert out["retention_days"] is None
+    assert out["nodes"] is None
+
+
+def test_next_helper_nodes_axis_carries_capacity_row(ent):
+    out = ent.next_tier_lock_reason_at_batch(ent.TIER_OSS, nodes=100)
+    row = out["nodes"]
+    assert row is not None
+    assert row["kind"] == "nodes"
+
+
+def test_next_helper_channels_axis_carries_capacity_row(ent):
+    out = ent.next_tier_lock_reason_at_batch(ent.TIER_OSS, channels=50)
+    row = out["channels"]
+    assert row is not None
+    assert row["kind"] == "channels"
+
+
+def test_next_helper_retention_axis_carries_capacity_row(ent):
+    out = ent.next_tier_lock_reason_at_batch(
+        ent.TIER_OSS, retention_days=365
+    )
+    row = out["retention_days"]
+    assert row is not None
+    assert row["kind"] == "retention_days"
+
+
+# ── next helper: ceiling posture ────────────────────────────────────────────
+
+
+def test_next_helper_at_ceiling_emits_grace_rows(ent):
+    """Enterprise as source has no rung above; rows must still render
+    with ``reason=null`` / ``locked=false`` / ``allowed=true``."""
+    assert ent._next_purchasable_tier_after(ent.TIER_ENTERPRISE) is None
+    fid = next(iter(ent.PRO_ONLY_FEATURES))
+    rt = next(iter(ent.PAID_RUNTIMES))
+    out = ent.next_tier_lock_reason_at_batch(
+        ent.TIER_ENTERPRISE,
+        features=[fid],
+        runtimes=[rt],
+        nodes=100,
+    )
+    assert isinstance(out, dict)
+    assert set(out.keys()) == _HELPER_BATCH_KEYS
+    assert len(out["features"]) == 1
+    assert out["features"][0]["locked"] is False
+    assert out["features"][0]["reason"] is None
+    assert out["features"][0]["allowed"] is True
+    assert out["runtimes"][0]["locked"] is False
+    assert out["runtimes"][0]["reason"] is None
+    assert out["nodes"]["locked"] is False
+    assert out["nodes"]["reason"] is None
+
+
+# ── next helper: trial-as-source resolves to enterprise ─────────────────────
+
+
+def test_next_helper_trial_source_resolves_to_enterprise(ent):
+    assert (
+        ent._next_purchasable_tier_after(ent.TIER_TRIAL) == ent.TIER_ENTERPRISE
+    )
+    fid = next(iter(ent.PRO_ONLY_FEATURES))
+    projected = ent.next_tier_lock_reason_at_batch(
+        ent.TIER_TRIAL, features=[fid]
+    )
+    direct = ent.lock_reasons_at_batch(ent.TIER_ENTERPRISE, features=[fid])
+    assert projected == direct
+
+
+# ── next helper: whitespace / case-insensitive ──────────────────────────────
+
+
+def test_next_helper_whitespace_and_case_insensitive(ent):
+    fid = next(iter(ent.PRO_ONLY_FEATURES))
+    canon = ent.next_tier_lock_reason_at_batch(ent.TIER_OSS, features=[fid])
+    other = ent.next_tier_lock_reason_at_batch(" OSS ", features=[fid])
+    assert canon == other
+
+
+# ── next helper: independent of the live resolver ───────────────────────────
+
+
+def test_next_helper_grace_and_enforce_match(ent, monkeypatch):
+    fid = next(iter(ent.PRO_ONLY_FEATURES))
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    grace = ent.next_tier_lock_reason_at_batch(ent.TIER_OSS, features=[fid])
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    enforced = ent.next_tier_lock_reason_at_batch(
+        ent.TIER_OSS, features=[fid]
+    )
+    assert grace == enforced
+
+
+# ── next helper: never raises on garbage input ──────────────────────────────
+
+
+def test_next_helper_never_raises_on_garbage_features(ent):
+    out = ent.next_tier_lock_reason_at_batch(
+        ent.TIER_OSS,
+        features=["", None, "valid_id"],  # type: ignore[list-item]
+    )
+    assert isinstance(out, dict)
+    assert isinstance(out["features"], list)
+
+
+def test_next_helper_empty_inputs_returns_empty_lists(ent):
+    out = ent.next_tier_lock_reason_at_batch(ent.TIER_OSS)
+    assert out["features"] == []
+    assert out["runtimes"] == []
+    assert out["channels"] is None
+    assert out["retention_days"] is None
+    assert out["nodes"] is None
+
+
+# ── previous_tier_lock_reason_at_batch: helper shape ────────────────────────
+
+
+def test_previous_helper_returns_dict_with_axis_keys(ent):
+    fid = next(iter(ent.FREE_FEATURES))
+    out = ent.previous_tier_lock_reason_at_batch(
+        ent.TIER_CLOUD_PRO, features=[fid]
+    )
+    assert isinstance(out, dict)
+    assert set(out.keys()) == _HELPER_BATCH_KEYS
+
+
+def test_previous_helper_unknown_tier_returns_none(ent):
+    fid = next(iter(ent.FREE_FEATURES))
+    assert (
+        ent.previous_tier_lock_reason_at_batch("bogus", features=[fid])
+        is None
+    )
+
+
+def test_previous_helper_empty_tier_returns_none(ent):
+    fid = next(iter(ent.FREE_FEATURES))
+    assert ent.previous_tier_lock_reason_at_batch("", features=[fid]) is None
+
+
+# ── previous helper: byte-parity at target ──────────────────────────────────
+
+
+def test_previous_helper_byte_equal_to_lock_reasons_at_batch_at_target(ent):
+    fid = next(iter(ent.PRO_ONLY_FEATURES))
+    rt = next(iter(ent.PAID_RUNTIMES))
+    for src in ent._PURCHASABLE_TIERS:
+        target = ent._previous_purchasable_tier_before(src)
+        if target is None:
+            continue
+        projected = ent.previous_tier_lock_reason_at_batch(
+            src,
+            features=[fid],
+            runtimes=[rt],
+            channels=50,
+            retention_days=365,
+            nodes=10,
+        )
+        direct = ent.lock_reasons_at_batch(
+            target,
+            features=[fid],
+            runtimes=[rt],
+            channels=50,
+            retention_days=365,
+            nodes=10,
+        )
+        assert projected == direct, src
+
+
+def test_previous_helper_scalar_matches_row_reason(ent):
+    fid = next(iter(ent.PRO_ONLY_FEATURES))
+    for src in ent._PURCHASABLE_TIERS:
+        batch = ent.previous_tier_lock_reason_at_batch(src, features=[fid])
+        scalar = ent.previous_tier_lock_reason_at(src, fid, kind="feature")
+        assert batch["features"][0]["reason"] == scalar, src
+
+
+# ── previous helper: floor posture ──────────────────────────────────────────
+
+
+def test_previous_helper_at_floor_emits_grace_rows(ent):
+    """OSS as source has no rung below; rows must still render."""
+    assert ent._previous_purchasable_tier_before(ent.TIER_OSS) is None
+    fid = next(iter(ent.PRO_ONLY_FEATURES))
+    rt = next(iter(ent.PAID_RUNTIMES))
+    out = ent.previous_tier_lock_reason_at_batch(
+        ent.TIER_OSS,
+        features=[fid],
+        runtimes=[rt],
+        nodes=100,
+    )
+    assert isinstance(out, dict)
+    assert set(out.keys()) == _HELPER_BATCH_KEYS
+    assert len(out["features"]) == 1
+    assert out["features"][0]["locked"] is False
+    assert out["features"][0]["reason"] is None
+    assert out["runtimes"][0]["locked"] is False
+    assert out["nodes"]["locked"] is False
+
+
+def test_previous_helper_trial_source_resolves_below_pro(ent):
+    """Trial sits at rank 2 alongside Pro; the strictly-lower
+    purchasable rung is Starter."""
+    target = ent._previous_purchasable_tier_before(ent.TIER_TRIAL)
+    assert target == ent.TIER_CLOUD_STARTER
+    fid = next(iter(ent.PRO_ONLY_FEATURES))
+    projected = ent.previous_tier_lock_reason_at_batch(
+        ent.TIER_TRIAL, features=[fid]
+    )
+    direct = ent.lock_reasons_at_batch(ent.TIER_CLOUD_STARTER, features=[fid])
+    assert projected == direct
+
+
+def test_previous_helper_grace_and_enforce_match(ent, monkeypatch):
+    fid = next(iter(ent.PRO_ONLY_FEATURES))
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    grace = ent.previous_tier_lock_reason_at_batch(
+        ent.TIER_CLOUD_PRO, features=[fid]
+    )
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    enforced = ent.previous_tier_lock_reason_at_batch(
+        ent.TIER_CLOUD_PRO, features=[fid]
+    )
+    assert grace == enforced
+
+
+# ── directional independence (next vs previous) ─────────────────────────────
+
+
+def test_next_vs_previous_disagree_for_pro_only_from_starter(ent):
+    """From Starter, ``next`` steps up to Pro (Pro-only unlocks) and
+    ``previous`` steps down to Free (still locked). The two directions
+    must resolve to different targets and different lock outcomes."""
+    fid = next(iter(ent.PRO_ONLY_FEATURES))
+    up = ent.next_tier_lock_reason_at_batch(
+        ent.TIER_CLOUD_STARTER, features=[fid]
+    )
+    down = ent.previous_tier_lock_reason_at_batch(
+        ent.TIER_CLOUD_STARTER, features=[fid]
+    )
+    assert up["features"][0]["locked"] is False
+    assert down["features"][0]["locked"] is True
+
+
+# ── endpoint: error contract ────────────────────────────────────────────────
+
+
+def test_next_endpoint_missing_tier_400(client):
+    r = client.get(
+        "/api/entitlement/next-tier-lock-reason-at-batch?features=custom_alerts"
+    )
+    assert r.status_code == 400
+    body = r.get_json()
+    assert "error" in body
+
+
+def test_previous_endpoint_missing_tier_400(client):
+    r = client.get(
+        "/api/entitlement/previous-tier-lock-reason-at-batch?features=custom_alerts"
+    )
+    assert r.status_code == 400
+    body = r.get_json()
+    assert "error" in body
+
+
+def test_next_endpoint_blank_tier_400(client):
+    r = client.get(
+        "/api/entitlement/next-tier-lock-reason-at-batch?tier=&features=custom_alerts"
+    )
+    assert r.status_code == 400
+
+
+def test_previous_endpoint_blank_tier_400(client):
+    r = client.get(
+        "/api/entitlement/previous-tier-lock-reason-at-batch?tier=&features=custom_alerts"
+    )
+    assert r.status_code == 400
+
+
+def test_next_endpoint_unknown_tier_404(client):
+    r = client.get(
+        "/api/entitlement/next-tier-lock-reason-at-batch?tier=nonsense&features=custom_alerts"
+    )
+    assert r.status_code == 404
+    body = r.get_json()
+    assert body.get("which") == "tier"
+    assert body.get("tier") == "nonsense"
+
+
+def test_previous_endpoint_unknown_tier_404(client):
+    r = client.get(
+        "/api/entitlement/previous-tier-lock-reason-at-batch?tier=nonsense&features=custom_alerts"
+    )
+    assert r.status_code == 404
+    body = r.get_json()
+    assert body.get("which") == "tier"
+
+
+def test_next_endpoint_no_axis_400(client, ent):
+    r = client.get(
+        f"/api/entitlement/next-tier-lock-reason-at-batch?tier={ent.TIER_OSS}"
+    )
+    assert r.status_code == 400
+    body = r.get_json()
+    assert "error" in body
+
+
+def test_previous_endpoint_no_axis_400(client, ent):
+    r = client.get(
+        f"/api/entitlement/previous-tier-lock-reason-at-batch?tier={ent.TIER_CLOUD_PRO}"
+    )
+    assert r.status_code == 400
+
+
+# ── endpoint: happy path + shape ────────────────────────────────────────────
+
+
+def test_next_endpoint_returns_full_envelope(client, ent):
+    r = client.get(
+        "/api/entitlement/next-tier-lock-reason-at-batch?tier="
+        + ent.TIER_OSS
+        + "&features=custom_alerts&runtimes=claude_code&nodes=100"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert set(body.keys()) >= (_HELPER_BATCH_KEYS | _API_EXTRA_KEYS)
+    assert body["tier"] == ent.TIER_OSS
+    assert body["target"] == ent._next_purchasable_tier_after(ent.TIER_OSS)
+    assert isinstance(body["features"], list)
+    assert isinstance(body["runtimes"], list)
+
+
+def test_previous_endpoint_returns_full_envelope(client, ent):
+    r = client.get(
+        "/api/entitlement/previous-tier-lock-reason-at-batch?tier="
+        + ent.TIER_CLOUD_PRO
+        + "&features=custom_alerts&nodes=10"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert set(body.keys()) >= (_HELPER_BATCH_KEYS | _API_EXTRA_KEYS)
+    assert body["tier"] == ent.TIER_CLOUD_PRO
+    assert body["target"] == ent._previous_purchasable_tier_before(
+        ent.TIER_CLOUD_PRO
+    )
+
+
+def test_next_endpoint_at_ceiling_target_null(client, ent):
+    r = client.get(
+        "/api/entitlement/next-tier-lock-reason-at-batch?tier="
+        + ent.TIER_ENTERPRISE
+        + "&features=custom_alerts"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["target"] is None
+    assert body["target_label"] is None
+    assert body["target_rank"] is None
+    assert body["features"][0]["locked"] is False
+    assert body["features"][0]["reason"] is None
+
+
+def test_previous_endpoint_at_floor_target_null(client, ent):
+    r = client.get(
+        "/api/entitlement/previous-tier-lock-reason-at-batch?tier="
+        + ent.TIER_OSS
+        + "&features=custom_alerts"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["target"] is None
+    assert body["target_label"] is None
+    assert body["features"][0]["locked"] is False
+
+
+# ── endpoint: byte parity with /lock-reasons-at-batch at target ─────────────
+
+
+def test_next_endpoint_body_byte_equal_to_lock_reasons_at_batch(client, ent):
+    """The batch-what-if endpoint body (minus the ``tier`` / ``target``
+    echo keys) must be byte-identical to the direct
+    ``/lock-reasons-at-batch?tier=<target>&...`` call. Parity pin so
+    the two batch surfaces cannot drift.
+    """
+    target = ent._next_purchasable_tier_after(ent.TIER_CLOUD_STARTER)
+    assert target is not None
+    r1 = client.get(
+        "/api/entitlement/next-tier-lock-reason-at-batch?tier="
+        + ent.TIER_CLOUD_STARTER
+        + "&features=custom_alerts&nodes=10"
+    )
+    r2 = client.get(
+        "/api/entitlement/lock-reasons-at-batch?tier="
+        + target
+        + "&features=custom_alerts&nodes=10"
+    )
+    assert r1.status_code == r2.status_code == 200
+    b1 = r1.get_json()
+    b2 = r2.get_json()
+    for k in _HELPER_BATCH_KEYS:
+        assert b1[k] == b2[k], k
+
+
+def test_previous_endpoint_body_byte_equal_to_lock_reasons_at_batch(
+    client, ent
+):
+    target = ent._previous_purchasable_tier_before(ent.TIER_CLOUD_PRO)
+    assert target is not None
+    r1 = client.get(
+        "/api/entitlement/previous-tier-lock-reason-at-batch?tier="
+        + ent.TIER_CLOUD_PRO
+        + "&features=custom_alerts&nodes=10"
+    )
+    r2 = client.get(
+        "/api/entitlement/lock-reasons-at-batch?tier="
+        + target
+        + "&features=custom_alerts&nodes=10"
+    )
+    assert r1.status_code == r2.status_code == 200
+    b1 = r1.get_json()
+    b2 = r2.get_json()
+    for k in _HELPER_BATCH_KEYS:
+        assert b1[k] == b2[k], k
+
+
+# ── endpoint: blueprint uniqueness ──────────────────────────────────────────
+
+
+def test_endpoints_registered_on_blueprint():
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    rules = {r.rule for r in app.url_map.iter_rules()}
+    assert "/api/entitlement/next-tier-lock-reason-at-batch" in rules
+    assert "/api/entitlement/previous-tier-lock-reason-at-batch" in rules


### PR DESCRIPTION
## Summary

- New helpers `next_tier_lock_reason_at_batch(tier, *, features, runtimes, channels, retention_days, nodes)` and `previous_tier_lock_reason_at_batch(...)` in `clawmetry/entitlements.py` — batch siblings of the scalar `next_tier_lock_reason_at` / `previous_tier_lock_reason_at`. Sweep the 5-axis lock-reason matrix at the resolved next/previous purchasable rung in ONE round-trip; body is byte-identical to `lock_reasons_at_batch(target, ...)` for the resolved `target = _next_purchasable_tier_after(tier)` / `_previous_purchasable_tier_before(tier)`, pinned at both the helper and HTTP layers.
- New endpoints `GET /api/entitlement/next-tier-lock-reason-at-batch` and `GET /api/entitlement/previous-tier-lock-reason-at-batch` in `routes/entitlement.py`.

Fills the lock-reason-axis batch member of the `next_*_at_batch` / `previous_*_at_batch` family alongside the existing feature-spec / runtime-spec / spec / capacity-diff / unlocks / locks siblings:

| helper                              | scalar | `_at` | `_at_batch` |
|-------------------------------------|:------:|:-----:|:-----------:|
| `tier_feature_spec`                 |   ✅   |   ✅  |     ✅      |
| `tier_runtime_spec`                 |   ✅   |   ✅  |     ✅      |
| `tier_spec`                         |   ✅   |   ✅  |     ✅      |
| `tier_capacity_diff`                |   ✅   |   ✅  |     ✅      |
| `tier_unlocks` / `tier_locks`       |   ✅   |   ✅  |     ✅      |
| `tier_lock_reason` (next/prev only) |   —    |   ✅  |   **NEW**   |

Use case: a paywall "does THIS column of features / runtimes / capacity axes unlock at my next rung?" matrix surface hydrates every row off ONE call instead of N calls to `/next-tier-lock-reason-at` per axis. The `previous_` twin powers the downgrade-confirmation matrix.

## API

```
GET /api/entitlement/next-tier-lock-reason-at-batch
    ?tier=<source>&features=a,b&runtimes=x,y&channels=N&retention_days=K&nodes=M
GET /api/entitlement/previous-tier-lock-reason-at-batch
    (same params)
```

Response shape (mirrors `/lock-reasons-at-batch` plus `tier` / `target` echo):

```json
{
  "features":       [<row>, ...],
  "runtimes":       [<row>, ...],
  "channels":       {...} | null,
  "retention_days": {...} | null,
  "nodes":          {...} | null,
  "tier":              "<source tier id>",
  "tier_label":        "...",
  "tier_rank":         0,
  "target":            "<next-above tier id>" | null,
  "target_label":      "..." | null,
  "target_rank":       0 | null,
  "current_tier":      "<live resolved tier>",
  "current_tier_rank": 0,
  "grace":             true,
  "enforced":          false
}
```

Each `<row>` carries the same 8 keys as `/lock-reasons-at-batch`: `key`, `kind`, `reason`, `locked`, `allowed`, `required_tier`, `required_tier_label`, `required_tier_rank`.

HTTP semantics match the sibling batch endpoints:

- **400** when `tier=` is missing / blank or no axis is supplied
- **404** when `tier` is unknown (body carries `which: "tier"`)
- **200** at the ceiling (enterprise as source) / floor (oss / cloud_free as source) with `target=null` and rows still rendering with `reason=null` / `locked=false` / `allowed=true` — so a matrix UI never sees a shape-change at the edges and doesn't need a status-code branch
- **Never 5xxs**: a builder failure short-circuits to the grace-shape envelope with `target=null`

Body is byte-identical to `/lock-reasons-at-batch?tier=<target>&...` for the resolved target — pinned at the HTTP layer so the two batch surfaces cannot silently diverge. Trial-as-source resolves the same way the sibling `_at_batch` families do (next → enterprise, previous → cloud_starter). Resolver-independent: grace vs enforce yields byte-identical rows since the batch delegates to `lock_reasons_at_batch` over the static per-tier maps. No behaviour change to any existing endpoint, no `__version__` bump, no enforce gate flipped.

## Files

| File | Change |
|---|---|
| `clawmetry/entitlements.py` | +230 — `next_tier_lock_reason_at_batch`, `previous_tier_lock_reason_at_batch`, shared `_empty_lock_reasons_at_batch` edge-tier grace-shape builder |
| `routes/entitlement.py` | +218 — 2 endpoints + shared `_next_prev_lock_reason_at_batch` body |
| `tests/test_entitlement_next_prev_tier_lock_reason_at_batch.py` | +NEW — 47 tests: helper shape, byte parity with `lock_reasons_at_batch` at target (helper + HTTP), scalar-vs-batch row parity, ceiling / floor grace posture, trial-as-source, alias-preservation parity with parent, capacity-axis routing, grace-vs-enforce parity, error contract, blueprint uniqueness |

## Test plan

- [x] `python -m pytest tests/test_entitlement_next_prev_tier_lock_reason_at_batch.py -x -q` → **47 passed** in 0.72s
- [x] Sibling regression sweep: `tests/test_entitlement_next_prev_tier_lock_reason_at.py`, `tests/test_entitlement_lock_reasons_at_batch.py`, `tests/test_entitlement_lock_reason_at.py`, `tests/test_blueprint_uniqueness.py` → **119 passed** in 2.39s (no regressions)
- [x] Broader `entitlement` sweep: 2973 passed, pre-existing failures in `test_entitlement_preview_path_batch.py` / `test_license.py` / `test_retention_prune.py` reproduce on `origin/main` without this branch's changes (unrelated to this PR)
- [x] `ruff check clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_next_prev_tier_lock_reason_at_batch.py` → All checks passed!
- [x] `python -m py_compile` on all three changed files
- [ ] CI green on this PR

## Local operator verification checklist

This remote fire cannot reach the local machine, the running daemon, `~/.openclaw`, the live cloud snapshot, or a browser. The following must be done by the local operator before flipping to ready-for-review:

- [ ] `git fetch origin && git checkout feat/entitlement-next-prev-tier-lock-reason-at-batch`
- [ ] Copy changed files into the installed package:
      `cp clawmetry/entitlements.py ~/.clawmetry/lib/python*/site-packages/clawmetry/`
      `cp routes/entitlement.py ~/.clawmetry/lib/python*/site-packages/routes/`
- [ ] Clear bytecode: `find ~/.clawmetry/lib -name __pycache__ -type d -exec rm -rf {} +`
- [ ] Kick the daemon: `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
- [ ] Smoke-check the happy path:
      `curl -s 'http://localhost:8900/api/entitlement/next-tier-lock-reason-at-batch?tier=oss&features=custom_alerts&runtimes=claude_code&nodes=100' | jq`
      expect 200, `target` populated, `features[0].locked=true` (custom_alerts still locked at Starter), `runtimes[0].locked=false` (claude_code unlocks at Starter), `nodes` row rendered.
- [ ] Pin scalar-vs-batch row parity in the live install:
      `curl -s 'http://localhost:8900/api/entitlement/next-tier-lock-reason-at-batch?tier=oss&features=custom_alerts' | jq '.features[0].reason'`
      byte-equal to
      `curl -s 'http://localhost:8900/api/entitlement/next-tier-lock-reason-at?tier=oss&feature=custom_alerts' | jq '.reason'`.
- [ ] Pin batch-vs-lock-reasons-at-batch parity in the live install (with `target = _next_purchasable_tier_after('cloud_starter')`):
      `curl -s 'http://localhost:8900/api/entitlement/next-tier-lock-reason-at-batch?tier=cloud_starter&features=custom_alerts&nodes=10' | jq '{features,runtimes,channels,retention_days,nodes}'`
      byte-equal to
      `curl -s 'http://localhost:8900/api/entitlement/lock-reasons-at-batch?tier=cloud_pro&features=custom_alerts&nodes=10' | jq '{features,runtimes,channels,retention_days,nodes}'`.
- [ ] Verify error contract:
      `curl -i 'http://localhost:8900/api/entitlement/next-tier-lock-reason-at-batch?features=custom_alerts'` → 400
      `curl -i 'http://localhost:8900/api/entitlement/next-tier-lock-reason-at-batch?tier=oss'` → 400
      `curl -i 'http://localhost:8900/api/entitlement/next-tier-lock-reason-at-batch?tier=nonsense&features=custom_alerts'` → 404 with `which: "tier"`
- [ ] Verify ceiling / floor grace posture:
      `curl -s 'http://localhost:8900/api/entitlement/next-tier-lock-reason-at-batch?tier=enterprise&features=custom_alerts&nodes=100' | jq '{target,features,nodes}'` → `target=null`, rows rendered with `reason=null` / `locked=false`.
      `curl -s 'http://localhost:8900/api/entitlement/previous-tier-lock-reason-at-batch?tier=oss&features=custom_alerts' | jq '{target,features}'` → `target=null`, rows rendered with `reason=null` / `locked=false`.
- [ ] `/api/entitlement` still resolves to the OSS-free grace envelope (no behaviour change in grace mode).
- [ ] Decrypt the live cloud snapshot, browser-check — no UI surface consumes this endpoint yet (it's a backend addition behind a parity guarantee), so the dashboard should look unchanged in grace mode.

This PR stays in **grace mode**: no behaviour change to any existing endpoint, no enforce gate flipped, no `__version__` bump, no release tag. The next-phase work (P3/P4/P6 — cloud-side entitlement minting, `clawmetry-pro` package download, enterprise SSO) needs the private `clawmetry-cloud` / `clawmetry-pro` repos and is out of scope for this remote session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CbS86adjY4nvyVMzsn3hJo)_