### PR TITLE
feat(entitlement): preview_path_batch helper + POST endpoint (backs the pre-merged test suite)

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -8450,3 +8450,123 @@ def tier_locks_path_batch(
             }
         )
     return {"tiers": rows, "unknown": unknown}
+
+
+def preview_path_batch(from_tier: str, to_tiers) -> dict | None:
+    """Batch sibling of :func:`preview_path`: per-rung cumulative
+    ``Entitlement.to_dict`` snapshots for a caller-supplied subset of
+    destination tiers all walked from a single ``from_tier`` in ONE
+    round-trip.
+
+    Composes :func:`preview_path` (scalar single-destination cumulative
+    path) and :func:`preview_batch` (batch cumulative-state at every
+    purchasable rung) -- same per-rung body as the scalar path helper (a
+    full :func:`preview` row per intermediate rung), same
+    multi-destination axis as :func:`tier_path_batch` /
+    :func:`tier_spec_path_batch` / :func:`capacity_diff_path_batch`. Lets
+    an upgrade-walkthrough surface render "from my current rung, here
+    are the 3 tiers I'm considering -- show me the resulting Entitlement
+    snapshot at every rung walked to each" off ONE call instead of N
+    calls to :func:`preview_path`. Cumulative-state member of the
+    path-batch grid alongside :func:`tier_path_batch` (all-slices
+    marginal), :func:`tier_spec_path_batch` (spec envelope),
+    :func:`capacity_diff_path_batch` (capacity slice),
+    :func:`tier_unlocks_path_batch` (grants slice) and
+    :func:`tier_locks_path_batch` (losses slice).
+
+    Per-destination row shape::
+
+        {
+          "to":         "<tier id>",
+          "to_label":   "...",
+          "to_rank":    <int>,
+          "direction":  "upgrade" | "downgrade" | "lateral" | "identity",
+          "path":       [<preview row>, ...],
+        }
+
+    Each ``path`` row is byte-identical to a row from :func:`preview_path`
+    for the same ``(from_tier, to)`` pair -- the same
+    ``_PURCHASABLE_TIERS`` filter + sort + destination-sibling exclusion
+    the sibling path-batch helpers use. Per-row body is the full
+    :func:`preview` cumulative snapshot (``source="preview"``,
+    ``grace=False``). Rung walks are destination-specific (the rung set
+    depends on ``to``), so per-destination ``path`` lengths can
+    legitimately differ -- matching :func:`tier_spec_path_batch` /
+    :func:`capacity_diff_path_batch` / :func:`tier_path_batch`'s
+    posture.
+
+    Shape::
+
+        {
+          "tiers": [
+            {"to": "<id>", "to_label": ..., "to_rank": ..., "direction": ..., "path": [...]},
+            ...
+          ],
+          "unknown": ["bogus_id", ...],
+        }
+
+    Supplied destination ids are normalised (whitespace stripped,
+    lowercased, duplicates dropped, first-seen order preserved). Unknown
+    ids are echoed in ``unknown[]`` instead of short-circuiting -- a
+    partially-bad caller still gets paths back for the valid ids
+    alongside a list of what was dropped, matching every other
+    ``*_path_batch`` sibling's posture. ``trial`` IS accepted as a
+    destination (excluded from the walked intermediate rungs the way
+    :func:`preview_path` already excludes it, but a valid endpoint via
+    the lateral / identity branches).
+
+    Returns ``None`` for empty / unknown ``from_tier`` (caller renders
+    "unknown tier" / 404).
+
+    Resolver-independent: delegates per-destination to
+    :func:`preview_path`, which walks the static per-tier maps via
+    :func:`_preview_row` -- so grace vs enforce yields byte-identical
+    rows. Never raises: per-destination failures short-circuit that id
+    into ``unknown[]`` and the rest of the batch keeps building.
+    """
+    try:
+        f = (from_tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if f not in _TIER_FEATURES:
+        return None
+    candidates = _normalise_csv(to_tiers)
+    rows: list[dict] = []
+    unknown: list[str] = []
+    from_rank = _TIER_RANK.get(f, -1)
+    for tid in candidates:
+        if tid not in _TIER_FEATURES:
+            unknown.append(tid)
+            continue
+        try:
+            path = preview_path(f, tid)
+        except Exception as exc:
+            logger.warning(
+                "entitlements: preview_path_batch row %r failed: %s",
+                tid,
+                exc,
+            )
+            unknown.append(tid)
+            continue
+        if path is None:
+            unknown.append(tid)
+            continue
+        to_rank = _TIER_RANK.get(tid, -1)
+        if f == tid:
+            direction = "identity"
+        elif from_rank == to_rank:
+            direction = "lateral"
+        elif to_rank > from_rank:
+            direction = "upgrade"
+        else:
+            direction = "downgrade"
+        rows.append(
+            {
+                "to": tid,
+                "to_label": tier_label(tid),
+                "to_rank": to_rank,
+                "direction": direction,
+                "path": path,
+            }
+        )
+    return {"tiers": rows, "unknown": unknown}

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -8527,3 +8527,144 @@ def api_entitlement_tier_path_batch():
                 "unknown": [],
             }
         )
+
+
+@bp_entitlement.route("/api/entitlement/preview-path-batch", methods=["POST"])
+def api_entitlement_preview_path_batch():
+    """``POST /api/entitlement/preview-path-batch`` -- batch sibling of
+    ``/api/entitlement/preview-path``.
+
+    Where ``/preview-path`` walks the cumulative-state rungs between
+    ONE ``(from, to)`` pair, this walks the cumulative-state rungs
+    between ONE ``from`` and N candidate ``to`` tiers in ONE round-trip
+    -- the cumulative-state member of the path-batch grid alongside
+    ``/tier-path-batch`` (all-slices marginal),
+    ``/tier-spec-path-batch`` (spec envelope),
+    ``/capacity-diff-path-batch`` (capacity slice),
+    ``/tier-unlocks-path-batch`` (grants slice) and
+    ``/tier-locks-path-batch`` (losses slice).
+
+    Use case: an upgrade-walkthrough surface hydrates the per-rung
+    ``Entitlement`` snapshot to every candidate destination off ONE
+    call instead of N calls to ``/preview-path``. Per-destination path
+    lengths can legitimately differ (the rungs walked depend on the
+    destination), matching every other ``*_path_batch`` sibling's
+    posture.
+
+    Request body::
+
+        {
+          "from": "<tier id>",
+          "to":   ["<tier id>", ...]
+        }
+
+    Response shape::
+
+        {
+          "from":         "<tier id>",
+          "from_label":   "...",
+          "from_rank":    <int>,
+          "tiers": [
+            {
+              "to":        "<tier id>",
+              "to_label":  "...",
+              "to_rank":   <int>,
+              "direction": "upgrade" | "downgrade" | "lateral" | "identity",
+              "path":      [<preview row>, ...],
+            },
+            ...
+          ],
+          "unknown":       ["bogus_id", ...],
+          "current_tier":  "<tier id>",
+          "grace":         <bool>,
+          "enforced":      <bool>,
+        }
+
+    Each row in ``tiers[].path`` is byte-identical to a row from
+    ``/preview-path?from=<from>&to=<to>``. Supplied destination ids are
+    normalised (whitespace stripped, lowercased, duplicates dropped,
+    first-seen order preserved). Unknown destination ids do NOT 404 the
+    call -- they are echoed in ``unknown[]`` so a partially-bad caller
+    still gets paths back for the valid ids.
+
+    - **400** when ``from`` is missing / blank, or ``to`` is missing /
+      empty
+    - **404** when ``from`` is unknown (body carries ``which: "from"``)
+    - **200** with bucketed unknowns for unknown destination ids --
+      does NOT 404 the call, matching every other batch sibling
+    - **Never 5xxs**: a synthesis failure short-circuits to an envelope
+      with empty rows so the matrix keeps rendering.
+
+    POST rather than GET because ``to`` is a list of tier ids that may
+    grow past a comfortable query-string length; the sibling
+    ``/tier-path-batch`` uses GET+CSV where the list is expected to
+    stay small. Both response envelopes carry the same shape so a
+    single UI walker can consume either family.
+    """
+    body = request.get_json(silent=True) or {}
+    try:
+        f_raw = body.get("from")
+        f = str(f_raw or "").strip().lower()
+    except Exception:
+        f = ""
+    if not f:
+        return jsonify({"error": "missing from"}), 400
+    to_raw = body.get("to")
+    if to_raw is None or (isinstance(to_raw, (list, tuple)) and not to_raw):
+        return jsonify({"error": "missing or empty to"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        if f not in _ent._TIER_FEATURES:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "from", "from": f}
+                ),
+                404,
+            )
+        try:
+            candidates = [str(t) for t in (to_raw or [])]
+        except TypeError:
+            return jsonify({"error": "to must be a list"}), 400
+        batch = _ent.preview_path_batch(f, candidates)
+        if batch is None:
+            batch = {"tiers": [], "unknown": []}
+        try:
+            ent = _ent.get_entitlement()
+            current_tier = getattr(ent, "tier", "oss") or "oss"
+            grace = bool(getattr(ent, "grace", True))
+        except Exception:
+            current_tier = "oss"
+            grace = True
+        try:
+            enforced = bool(_ent.is_enforced())
+        except Exception:
+            enforced = False
+        return jsonify(
+            {
+                "from": f,
+                "from_label": _ent.tier_label(f),
+                "from_rank": _ent.tier_rank(f),
+                "tiers": batch.get("tiers", []),
+                "unknown": batch.get("unknown", []),
+                "current_tier": current_tier,
+                "grace": grace,
+                "enforced": enforced,
+            }
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_preview_path_batch: error: %s", exc
+        )
+        return jsonify(
+            {
+                "from": f,
+                "from_label": None,
+                "from_rank": -1,
+                "tiers": [],
+                "unknown": [],
+                "current_tier": "oss",
+                "grace": True,
+                "enforced": False,
+            }
+        )

--- a/tests/test_entitlement_preview_path_batch_helper.py
+++ b/tests/test_entitlement_preview_path_batch_helper.py
@@ -1,0 +1,395 @@
+"""Real-behavior tests for ``clawmetry.entitlements.preview_path_batch``
+and its POST endpoint ``/api/entitlement/preview-path-batch``.
+
+Companion to ``test_entitlement_preview_path_batch.py`` (which patches
+the entitlements module with a lightweight stub). Where that suite pins
+the endpoint contract shape, this suite pins the real helper's behavior
+against the actual tier catalogue -- parity with the scalar
+:func:`preview_path`, direction geometry, input normalisation, unknown
+id bucketing, grace-vs-enforce byte parity, and never-raises posture.
+
+Batch sibling of :func:`preview_path`: where the scalar path helper
+walks one ``(from, to)`` pair, the batch walks N candidate destinations
+from one source in ONE round-trip. Each per-destination ``path`` must
+be byte-identical to the matching scalar :func:`preview_path` payload
+for the same ``(from, to)`` pair -- the parity test below pins this so
+the scalar and batch path helpers cannot drift.
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+
+_ITEM_KEYS = {"to", "to_label", "to_rank", "direction", "path"}
+
+_ENVELOPE_KEYS = {
+    "from",
+    "from_label",
+    "from_rank",
+    "tiers",
+    "unknown",
+    "current_tier",
+    "grace",
+    "enforced",
+}
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from flask import Flask
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# ── helper-level: shape ──────────────────────────────────────────────────────
+
+
+def test_helper_returns_dict_shape(ent):
+    out = ent.preview_path_batch(
+        ent.TIER_OSS, [ent.TIER_CLOUD_STARTER, ent.TIER_ENTERPRISE]
+    )
+    assert isinstance(out, dict)
+    assert set(out.keys()) == {"tiers", "unknown"}
+    assert isinstance(out["tiers"], list)
+    assert isinstance(out["unknown"], list)
+
+
+def test_helper_each_item_carries_row_envelope(ent):
+    out = ent.preview_path_batch(
+        ent.TIER_OSS, [ent.TIER_CLOUD_STARTER, ent.TIER_ENTERPRISE]
+    )
+    for item in out["tiers"]:
+        assert set(item.keys()) == _ITEM_KEYS
+        assert isinstance(item["to"], str)
+        assert isinstance(item["to_label"], str)
+        assert isinstance(item["to_rank"], int)
+        assert item["direction"] in {
+            "upgrade",
+            "downgrade",
+            "lateral",
+            "identity",
+        }
+        assert isinstance(item["path"], list)
+
+
+def test_helper_each_row_is_full_preview_snapshot(ent):
+    """Every per-rung row is a full :func:`preview` snapshot -- shape
+    parity with :func:`preview_path`, which is itself byte-equal to
+    :func:`preview` per rung."""
+    out = ent.preview_path_batch(ent.TIER_OSS, [ent.TIER_ENTERPRISE])
+    item = out["tiers"][0]
+    assert item["path"], "expected at least one rung in the path"
+    scalar_shape = set(ent.preview(ent.TIER_CLOUD_STARTER).keys())
+    for row in item["path"]:
+        assert set(row.keys()) == scalar_shape
+        assert row.get("source") == "preview"
+        assert row.get("grace") is False
+
+
+# ── helper-level: parity with scalar ─────────────────────────────────────────
+
+
+def test_helper_per_item_path_byte_equal_to_scalar(ent):
+    """Pin: per-destination ``path`` is byte-identical to the scalar
+    :func:`preview_path` payload for the same ``(from, to)`` pair."""
+    candidates = [
+        ent.TIER_CLOUD_FREE,
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_ENTERPRISE,
+    ]
+    out = ent.preview_path_batch(ent.TIER_OSS, candidates)
+    by_id = {item["to"]: item["path"] for item in out["tiers"]}
+    for tid in candidates:
+        scalar = ent.preview_path(ent.TIER_OSS, tid)
+        assert by_id[tid] == scalar
+
+
+def test_helper_per_item_direction_matches_rank_geometry(ent):
+    candidates = [
+        ent.TIER_OSS,
+        ent.TIER_CLOUD_FREE,
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_PRO,
+        ent.TIER_ENTERPRISE,
+    ]
+    out = ent.preview_path_batch(ent.TIER_CLOUD_STARTER, candidates)
+    by_id = {item["to"]: item for item in out["tiers"]}
+    src_rank = ent.tier_rank(ent.TIER_CLOUD_STARTER)
+    for tid in candidates:
+        tgt_rank = ent.tier_rank(tid)
+        if tid == ent.TIER_CLOUD_STARTER:
+            expected = "identity"
+        elif src_rank == tgt_rank:
+            expected = "lateral"
+        elif tgt_rank > src_rank:
+            expected = "upgrade"
+        else:
+            expected = "downgrade"
+        assert by_id[tid]["direction"] == expected
+
+
+# ── helper-level: input normalisation ────────────────────────────────────────
+
+
+def test_helper_supply_order_preserved(ent):
+    out = ent.preview_path_batch(
+        ent.TIER_OSS,
+        [ent.TIER_ENTERPRISE, ent.TIER_CLOUD_PRO, ent.TIER_CLOUD_STARTER],
+    )
+    assert [item["to"] for item in out["tiers"]] == [
+        ent.TIER_ENTERPRISE,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_CLOUD_STARTER,
+    ]
+
+
+def test_helper_normalises_input(ent):
+    out = ent.preview_path_batch(
+        ent.TIER_OSS,
+        [
+            "  CLOUD_PRO  ",
+            "cloud_starter",
+            "cloud_pro",
+            "",
+        ],
+    )
+    assert [item["to"] for item in out["tiers"]] == [
+        "cloud_pro",
+        "cloud_starter",
+    ]
+
+
+def test_helper_unknown_destination_ids_echoed(ent):
+    out = ent.preview_path_batch(
+        ent.TIER_OSS,
+        [ent.TIER_CLOUD_PRO, "bogus_tier", "still_bogus"],
+    )
+    assert [item["to"] for item in out["tiers"]] == [ent.TIER_CLOUD_PRO]
+    assert set(out["unknown"]) == {"bogus_tier", "still_bogus"}
+
+
+# ── helper-level: direction branches ─────────────────────────────────────────
+
+
+def test_helper_identity_yields_empty_path(ent):
+    out = ent.preview_path_batch(
+        ent.TIER_CLOUD_PRO, [ent.TIER_CLOUD_PRO, ent.TIER_ENTERPRISE]
+    )
+    by_id = {item["to"]: item for item in out["tiers"]}
+    assert by_id[ent.TIER_CLOUD_PRO]["direction"] == "identity"
+    assert by_id[ent.TIER_CLOUD_PRO]["path"] == []
+    assert by_id[ent.TIER_ENTERPRISE]["direction"] == "upgrade"
+
+
+def test_helper_upgrade_walks_intermediate_rungs(ent):
+    out = ent.preview_path_batch(ent.TIER_OSS, [ent.TIER_ENTERPRISE])
+    item = out["tiers"][0]
+    assert item["direction"] == "upgrade"
+    rungs = [row["tier"] for row in item["path"]]
+    assert rungs[-1] == ent.TIER_ENTERPRISE
+    assert ent.TIER_OSS not in rungs
+
+
+def test_helper_downgrade_walks_descending(ent):
+    out = ent.preview_path_batch(ent.TIER_ENTERPRISE, [ent.TIER_OSS])
+    item = out["tiers"][0]
+    assert item["direction"] == "downgrade"
+    ranks = [ent.tier_rank(row["tier"]) for row in item["path"]]
+    assert ranks == sorted(ranks, reverse=True)
+
+
+def test_helper_trial_destination_accepted(ent):
+    out = ent.preview_path_batch(ent.TIER_OSS, [ent.TIER_TRIAL])
+    assert out["unknown"] == []
+    assert [item["to"] for item in out["tiers"]] == [ent.TIER_TRIAL]
+
+
+# ── helper-level: error / edge cases ─────────────────────────────────────────
+
+
+def test_helper_unknown_from_tier_returns_none(ent):
+    assert ent.preview_path_batch("not_a_tier", [ent.TIER_ENTERPRISE]) is None
+
+
+def test_helper_empty_destinations_yields_empty_envelope(ent):
+    out = ent.preview_path_batch(ent.TIER_OSS, [])
+    assert out == {"tiers": [], "unknown": []}
+
+
+def test_helper_garbage_inputs_never_raise(ent):
+    assert ent.preview_path_batch("", []) is None
+    assert ent.preview_path_batch(None, None) is None  # type: ignore[arg-type]
+    assert ent.preview_path_batch("  ", "  ") is None
+
+
+def test_helper_grace_and_enforce_yield_identical_output(ent, monkeypatch):
+    candidates = [ent.TIER_CLOUD_STARTER, ent.TIER_ENTERPRISE]
+    grace = ent.preview_path_batch(ent.TIER_OSS, candidates)
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    enforced = ent.preview_path_batch(ent.TIER_OSS, candidates)
+    assert grace == enforced
+
+
+def test_helper_row_failure_short_circuits_item(ent, monkeypatch):
+    """A per-destination failure pushes that id into ``unknown[]``
+    while the rest of the batch keeps building."""
+    real = ent.preview_path
+
+    def fake(f, t):
+        if t == ent.TIER_CLOUD_PRO:
+            raise RuntimeError("boom")
+        return real(f, t)
+
+    monkeypatch.setattr(ent, "preview_path", fake)
+    out = ent.preview_path_batch(
+        ent.TIER_OSS, [ent.TIER_CLOUD_PRO, ent.TIER_ENTERPRISE]
+    )
+    assert [item["to"] for item in out["tiers"]] == [ent.TIER_ENTERPRISE]
+    assert ent.TIER_CLOUD_PRO in out["unknown"]
+
+
+# ── HTTP: POST /api/entitlement/preview-path-batch ───────────────────────────
+
+
+def test_api_400_on_missing_from(client):
+    r = client.post(
+        "/api/entitlement/preview-path-batch",
+        json={"to": ["enterprise"]},
+    )
+    assert r.status_code == 400
+
+
+def test_api_400_on_missing_to(client):
+    r = client.post(
+        "/api/entitlement/preview-path-batch",
+        json={"from": "oss"},
+    )
+    assert r.status_code == 400
+
+
+def test_api_400_on_empty_to(client):
+    r = client.post(
+        "/api/entitlement/preview-path-batch",
+        json={"from": "oss", "to": []},
+    )
+    assert r.status_code == 400
+
+
+def test_api_404_on_unknown_from_tier(client):
+    r = client.post(
+        "/api/entitlement/preview-path-batch",
+        json={"from": "not_a_tier", "to": ["enterprise"]},
+    )
+    assert r.status_code == 404
+    body = r.get_json()
+    assert body["which"] == "from"
+
+
+def test_api_200_with_unknown_destination_bucketed(client, ent):
+    r = client.post(
+        "/api/entitlement/preview-path-batch",
+        json={"from": ent.TIER_OSS, "to": [ent.TIER_CLOUD_PRO, "bogus_tier"]},
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert [item["to"] for item in body["tiers"]] == [ent.TIER_CLOUD_PRO]
+    assert body["unknown"] == ["bogus_tier"]
+
+
+def test_api_happy_path_response_envelope(client, ent):
+    r = client.post(
+        "/api/entitlement/preview-path-batch",
+        json={
+            "from": ent.TIER_OSS,
+            "to": [ent.TIER_CLOUD_STARTER, ent.TIER_ENTERPRISE],
+        },
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert set(body.keys()) == _ENVELOPE_KEYS
+    assert body["from"] == ent.TIER_OSS
+    assert isinstance(body["from_label"], str)
+    assert body["from_rank"] == ent.tier_rank(ent.TIER_OSS)
+    assert isinstance(body["current_tier"], str)
+    assert isinstance(body["grace"], bool)
+    assert isinstance(body["enforced"], bool)
+    tos = [item["to"] for item in body["tiers"]]
+    assert tos == [ent.TIER_CLOUD_STARTER, ent.TIER_ENTERPRISE]
+    for item in body["tiers"]:
+        assert item["direction"] == "upgrade"
+
+
+def test_api_identity_branch(client, ent):
+    r = client.post(
+        "/api/entitlement/preview-path-batch",
+        json={"from": ent.TIER_CLOUD_PRO, "to": [ent.TIER_CLOUD_PRO]},
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["tiers"][0]["direction"] == "identity"
+    assert body["tiers"][0]["path"] == []
+
+
+def test_api_per_item_path_matches_scalar_route(client, ent):
+    """HTTP parity: each per-destination ``path`` is byte-identical to
+    the scalar ``/preview-path?from=&to=`` payload for the same
+    ``(from, to)`` pair."""
+    candidates = [
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_ENTERPRISE,
+    ]
+    batch = client.post(
+        "/api/entitlement/preview-path-batch",
+        json={"from": ent.TIER_OSS, "to": candidates},
+    ).get_json()
+    by_id = {item["to"]: item["path"] for item in batch["tiers"]}
+    for tid in candidates:
+        scalar = client.get(
+            f"/api/entitlement/preview-path?from={ent.TIER_OSS}&to={tid}"
+        ).get_json()
+        assert by_id[tid] == scalar["path"]
+
+
+def test_api_never_5xxs_on_helper_failure(client, ent, monkeypatch):
+    def boom(*args, **kwargs):
+        raise RuntimeError("synthesis failure")
+
+    monkeypatch.setattr(ent, "preview_path_batch", boom)
+    r = client.post(
+        "/api/entitlement/preview-path-batch",
+        json={"from": ent.TIER_OSS, "to": [ent.TIER_ENTERPRISE]},
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["tiers"] == []
+    assert body["unknown"] == []
+
+
+def test_api_400_on_non_json_body(client):
+    r = client.post(
+        "/api/entitlement/preview-path-batch",
+        data="not json",
+        content_type="text/plain",
+    )
+    assert r.status_code == 400


### PR DESCRIPTION
## Summary

Fixes 8 pre-existing failures in `tests/test_entitlement_preview_path_batch.py::TestPreviewPathBatchEndpoint`. The test file was merged in #3413 but the implementation was dropped from the diff — `preview_path_batch` and `POST /api/entitlement/preview-path-batch` are still missing from `origin/main`, so the endpoint tests 404 out. This PR lands the helper + endpoint the tests were written against.

Batch sibling of `preview_path`: walks per-rung cumulative `Entitlement.to_dict` snapshots from ONE `from_tier` to N candidate destinations in a single round-trip. Cumulative-state member of the path-batch grid alongside `tier_path_batch` (all-slices marginal), `tier_spec_path_batch` (spec envelope), `capacity_diff_path_batch` (capacity slice), `tier_unlocks_path_batch` (grants slice) and `tier_locks_path_batch` (losses slice).

## API

```
POST /api/entitlement/preview-path-batch
Content-Type: application/json

{ "from": "<tier id>", "to": ["<tier id>", ...] }
```

Response envelope:

```json
{
  "from":         "<tier id>",
  "from_label":   "...",
  "from_rank":    0,
  "tiers": [
    {
      "to":        "<tier id>",
      "to_label":  "...",
      "to_rank":   0,
      "direction": "upgrade" | "downgrade" | "lateral" | "identity",
      "path":      [<preview row>, ...]
    }
  ],
  "unknown":       ["bogus_id", ...],
  "current_tier":  "<tier id>",
  "grace":         true,
  "enforced":      false
}
```

HTTP semantics match the sibling batch endpoints:

- **400** when `from` is missing / blank or `to` is missing / empty
- **404** when `from` is unknown (body carries `which: "from"`)
- **200** with bucketed `unknown[]` for unknown destination ids — does NOT 404 the call, matching every other batch sibling's posture
- **Never 5xxs**: a synthesis failure short-circuits to the empty-rows envelope so the matrix keeps rendering

POST rather than GET because `to` is a list of tier ids that may grow past a comfortable query-string length; the sibling `/tier-path-batch` uses GET+CSV where the list stays small. Both response envelopes share the same shape so a single UI walker can consume either family.

Per-destination `path` is byte-identical to the scalar `/preview-path?from=&to=` payload for the same `(from, to)` pair — parity-pinned by the new real-behavior tests so scalar and batch cannot drift.

## Files

| File | Change |
|---|---|
| `clawmetry/entitlements.py` | +120 — new `preview_path_batch(from_tier, to_tiers)` helper |
| `routes/entitlement.py` | +141 — new POST endpoint wrapping the helper |
| `tests/test_entitlement_preview_path_batch_helper.py` | +NEW — 27 real-behavior tests |

## Test plan

- [x] `python3 -m pytest tests/test_entitlement_preview_path_batch.py -q` → **19 passed** (was 8 failing on origin/main)
- [x] `python3 -m pytest tests/test_entitlement_preview_path_batch_helper.py -q` → **27 passed** (new real-behavior suite)
- [x] Sibling regression sweep: `tests/test_entitlement_preview_path.py`, `tests/test_entitlement_tier_path_batch.py`, `tests/test_entitlement_tier_spec_path_batch.py`, `tests/test_blueprint_uniqueness.py`, `tests/test_license.py` → **133 passed** (no regressions)
- [x] Full entitlement/license/blueprint/preview sweep: **3085 passed**, 1 pre-existing failure (`test_license_pubkey.py::test_fingerprint_is_whitespace_independent`) confirmed to reproduce on `origin/main` without this branch's changes
- [x] `ruff check clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_preview_path_batch_helper.py` → All checks passed
- [x] `python3 -m py_compile` on all three changed files
- [ ] CI green on this PR

Coverage:

- per-destination `path` byte-equal to the scalar `preview_path` payload (helper + HTTP)
- per-rung row carries the singular `preview` shape (`source="preview"`, `grace=False`)
- per-destination `direction` derived from rank geometry, agreeing with the scalar endpoint
- input normalisation (whitespace stripped, lowercased, duplicates dropped, first-seen order preserved)
- unknown destination ids echoed in `unknown[]` instead of 404'ing the call
- identity / lateral / upgrade / downgrade branches
- trial accepted as a destination endpoint
- unknown / empty / garbage `from_tier` returns `None` (helper) / 400 / 404 (HTTP)
- per-destination failure short-circuits that id into `unknown[]` while the rest of the batch keeps building
- HTTP 400 on missing / empty input, 404 on unknown source tier, never 5xx on row failure
- grace vs enforce yields byte-identical rows (resolver-independent: walks the static per-tier maps via `_preview_row`)

## Local operator verification checklist

This remote fire cannot reach the local machine, the running daemon, `~/.openclaw`, the live cloud snapshot, or a browser. The following must be done by the local operator before flipping to ready-for-review:

- [ ] `git fetch origin && git checkout feat/entitlement-preview-path-batch-post-endpoint`
- [ ] Copy changed files into the installed package:
      `cp clawmetry/entitlements.py ~/.clawmetry/lib/python*/site-packages/clawmetry/`
      `cp routes/entitlement.py ~/.clawmetry/lib/python*/site-packages/routes/`
- [ ] Clear bytecode: `find ~/.clawmetry/lib -name __pycache__ -type d -exec rm -rf {} +`
- [ ] Kick the daemon: `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
- [ ] Smoke-check the happy path:
      `curl -s -X POST 'http://localhost:8900/api/entitlement/preview-path-batch' -H 'Content-Type: application/json' -d '{"from":"oss","to":["cloud_starter","cloud_pro","enterprise"]}' | jq`
      expect 200, three rows with `direction: "upgrade"`, each row's `path` byte-identical to `GET /api/entitlement/preview-path?from=oss&to=<to>` `.path`.
- [ ] Pin unknown-id bucketing:
      `curl -s -X POST 'http://localhost:8900/api/entitlement/preview-path-batch' -H 'Content-Type: application/json' -d '{"from":"oss","to":["cloud_pro","bogus_tier"]}' | jq` — expect 200, one tier row + `unknown: ["bogus_tier"]`.
- [ ] Verify error contract:
      `curl -s -o /dev/null -w "%{http_code}\n" -X POST 'http://localhost:8900/api/entitlement/preview-path-batch' -H 'Content-Type: application/json' -d '{"to":["oss"]}'` — expect 400
      `curl -s -o /dev/null -w "%{http_code}\n" -X POST 'http://localhost:8900/api/entitlement/preview-path-batch' -H 'Content-Type: application/json' -d '{"from":"oss"}'` — expect 400
      `curl -s -o /dev/null -w "%{http_code}\n" -X POST 'http://localhost:8900/api/entitlement/preview-path-batch' -H 'Content-Type: application/json' -d '{"from":"not_a_tier","to":["oss"]}'` — expect 404 with `which: "from"`
- [ ] Identity branch:
      `curl -s -X POST 'http://localhost:8900/api/entitlement/preview-path-batch' -H 'Content-Type: application/json' -d '{"from":"pro","to":["pro"]}' | jq '.tiers[0]'` — expect `direction: "identity"`, `path: []`.
- [ ] `/api/entitlement` still resolves to the OSS-free grace envelope (no behaviour change in grace mode).
- [ ] Decrypt the live cloud snapshot, browser-check — no UI surface consumes this endpoint yet (it's a backend addition behind a parity guarantee), so the dashboard should look unchanged in grace mode.

This PR stays in **grace mode**: no behaviour change to any existing endpoint, no enforce gate flipped, no `__version__` bump, no release tag. The next-phase work (P3/P4/P6 — cloud-side entitlement minting, `clawmetry-pro` package download, enterprise SSO) needs the private `clawmetry-cloud` / `clawmetry-pro` repos and is out of scope for this remote session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01UdEqQWCMJ7g2dRWc1AU23M)_