### PR TITLE
fix: move hashlib import above SQLite/flat-file conditional in sync_crons

### DIFF
--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -9738,11 +9738,11 @@ def sync_crons(config: dict, state: dict, paths: dict) -> int:
             return 0
 
     try:
+        import hashlib
         if _sqlite_jobs is not None:
             jobs = _sqlite_jobs
             h, file_unchanged = "", False
         else:
-            import hashlib
             raw = open(cron_file, "rb").read()
             h = hashlib.md5(raw).hexdigest()
             file_unchanged = h == last_hash


### PR DESCRIPTION
When `sync_crons` falls back to `_load_jobs_from_state_sqlite()` (the new OpenClaw v2026.6.5+ path from #3428), the `hashlib` import was nested inside the flat-file `else` branch. The dedup logic later references `hashlib.sha1()` unconditionally, which causes:

```
WARNING Cron sync error: cannot access local variable 'hashlib' where it is not associated with a value
```

...on every sync cycle when `state/openclaw.sqlite` is the data source. Cron runs sync fine — only the job list sync is affected.

**Fix:** Move `import hashlib` above the `if/else` so both paths can use it.

**Before:**
```python
if _sqlite_jobs is not None:
    jobs = _sqlite_jobs
    h, file_unchanged = "", False
else:
    import hashlib
```

**After:**
```python
import hashlib
if _sqlite_jobs is not None:
    jobs = _sqlite_jobs
    h, file_unchanged = "", False
else:
```