### PR TITLE
fix: mirror harness tools-present gate in _nemoclaw_tool_catalog_state()

### DIFF
--- a/clawmetry/adapters/openclaw.py
+++ b/clawmetry/adapters/openclaw.py
@@ -797,7 +797,9 @@ def _scan_openclaw_selection_runtime() -> tuple[bool, bool, bool]:
     return patched, native_base, native_enforcement
 
 
-def _nemoclaw_tool_catalog_state() -> Optional[bool]:
+def _nemoclaw_tool_catalog_state(
+    tools_present: Optional[bool] = None,
+) -> Optional[bool]:
     """Whether the NemoClaw compact tool-catalog wrapper is active for this
     runtime (#2683).
 
@@ -812,14 +814,28 @@ def _nemoclaw_tool_catalog_state() -> Optional[bool]:
     (the patch marker is present in the openclaw dist, or the env var is
     explicitly set); returns ``None`` on plain OpenClaw so we never assert a
     catalog state that doesn't exist. Never raises.
+
+    Args:
+        tools_present: When the caller knows whether the turn/session had any
+            registered tools, pass ``True`` or ``False`` to mirror the
+            tools-count half of the harness gate
+            (``effectiveTools.length > 0 || clientTools?.length > 0``,
+            #3432).  ``None`` (default) skips the tools-present check and
+            falls back to the env-var-only gate — safe when the caller cannot
+            determine tool count.
     """
     env = os.environ.get("NEMOCLAW_TOOL_CATALOG")
     patched, _native, _native_enf = _scan_openclaw_selection_runtime()
     if not patched and env is None:
         # No NemoClaw signal at all -> don't claim a catalog state.
         return None
-    # Mirror the harness gate exactly: enabled unless explicitly "0".
-    return env != "0"
+    # Mirror the harness gate exactly: disabled when env var is "0" OR when
+    # the caller knows no tools were registered for this turn/session (#3432).
+    if env == "0":
+        return False
+    if tools_present is False:
+        return False
+    return True
 
 
 def _openclaw_tool_catalog_kind() -> Optional[str]:
@@ -989,10 +1005,6 @@ class OpenClawAdapter(AgentAdapter):
         except Exception as exc:
             logger.warning(f"OpenClaw list_sessions() failed: {exc}")
             return []
-        # Runtime-level NemoClaw tool-catalog state (#2683): whether the
-        # compact tool-catalog wrapper is active for this install. None on
-        # plain OpenClaw (no NemoClaw signal) — we don't stamp a state then.
-        _tc_enabled = _nemoclaw_tool_catalog_state()
         # Catalog provenance (#2732): "nemoclaw" or "native" when either
         # signal is present, so native-tool-search OpenClaw builds are no
         # longer indistinguishable from "no catalog at all".
@@ -1006,6 +1018,18 @@ class OpenClawAdapter(AgentAdapter):
                 "contextTokens": s.get("contextTokens"),
                 "agentId": s.get("agent") or "main",
             }
+            # Runtime-level NemoClaw tool-catalog state (#2683 / #3432): mirror
+            # the full harness gate — env var AND tools-present. Derive
+            # tools_present from whichever tool-count alias the session record
+            # carries; fall back to None (unknown) when absent so existing
+            # gateway records that lack the field keep today's behaviour.
+            _raw_tc = (
+                s.get("toolCallCount")
+                or s.get("totalToolCalls")
+                or s.get("toolCount")
+            )
+            _tools_present = bool(_raw_tc) if _raw_tc is not None else None
+            _tc_enabled = _nemoclaw_tool_catalog_state(tools_present=_tools_present)
             if _tc_enabled is not None:
                 extra["nemoclawToolCatalogEnabled"] = _tc_enabled
             if _tc_kind is not None:

--- a/tests/test_openclaw_tool_catalog_kind.py
+++ b/tests/test_openclaw_tool_catalog_kind.py
@@ -164,3 +164,52 @@ def test_env_var_without_dist_marker_keeps_state_but_no_kind(monkeypatch, tmp_pa
     assert oc._nemoclaw_tool_catalog_state() is True
     # But there's no on-disk wrapper, so no provenance to stamp.
     assert oc._openclaw_tool_catalog_kind() is None
+
+
+# ── tools-present gate (#3432) ────────────────────────────────────────────────
+
+
+def test_tools_present_false_with_patch_returns_false(monkeypatch, tmp_path):
+    # Harness gate: catalog inactive when no tools registered, even if patched.
+    home = _make_dist(tmp_path, PATCH_MARKER)
+    monkeypatch.setenv("OPENCLAW_HOME", str(home))
+    assert oc._nemoclaw_tool_catalog_state(tools_present=False) is False
+
+
+def test_tools_present_none_with_patch_returns_true(monkeypatch, tmp_path):
+    # tools_present=None (unknown) must not change the existing contract.
+    home = _make_dist(tmp_path, PATCH_MARKER)
+    monkeypatch.setenv("OPENCLAW_HOME", str(home))
+    assert oc._nemoclaw_tool_catalog_state(tools_present=None) is True
+
+
+def test_tools_present_true_with_patch_returns_true(monkeypatch, tmp_path):
+    home = _make_dist(tmp_path, PATCH_MARKER)
+    monkeypatch.setenv("OPENCLAW_HOME", str(home))
+    assert oc._nemoclaw_tool_catalog_state(tools_present=True) is True
+
+
+def test_tools_present_false_with_env_only_returns_false(monkeypatch, tmp_path):
+    # Env-var-only (no patch marker) + zero tools → catalog inactive.
+    home = tmp_path / ".openclaw"
+    home.mkdir()
+    monkeypatch.setenv("OPENCLAW_HOME", str(home))
+    monkeypatch.setenv("NEMOCLAW_TOOL_CATALOG", "1")
+    assert oc._nemoclaw_tool_catalog_state(tools_present=False) is False
+
+
+def test_tools_present_false_no_nemoclaw_signal_still_none(monkeypatch, tmp_path):
+    # When there is no NemoClaw signal at all, tools_present is irrelevant —
+    # the function must return None (plain OpenClaw).
+    home = tmp_path / ".openclaw"
+    home.mkdir()
+    monkeypatch.setenv("OPENCLAW_HOME", str(home))
+    assert oc._nemoclaw_tool_catalog_state(tools_present=False) is None
+
+
+def test_env_var_zero_takes_precedence_over_tools_present(monkeypatch, tmp_path):
+    # NEMOCLAW_TOOL_CATALOG=0 disables regardless of tools_present value.
+    home = _make_dist(tmp_path, PATCH_MARKER)
+    monkeypatch.setenv("OPENCLAW_HOME", str(home))
+    monkeypatch.setenv("NEMOCLAW_TOOL_CATALOG", "0")
+    assert oc._nemoclaw_tool_catalog_state(tools_present=True) is False


### PR DESCRIPTION
Closes #3432

## What's wrong

The harness computes `nemoClawToolCatalogEnabled` as:
```js
process.env.NEMOCLAW_TOOL_CATALOG !== "0"
  && (effectiveTools.length > 0 || (clientTools?.length ?? 0) > 0)
```

`_nemoclaw_tool_catalog_state()` only mirrored the env-var half — so sessions where zero tools were registered were reported as `nemoclawToolCatalogEnabled: true` even though the harness left the catalog inactive for those turns.

## What changes

- **`clawmetry/adapters/openclaw.py`** — adds `tools_present: Optional[bool] = None` to `_nemoclaw_tool_catalog_state()`. When `False`, returns `False` regardless of the env var (catalog can't activate without tools). Moves the call into the `list_sessions()` per-session loop and derives `tools_present` from `s.get("toolCallCount") / totalToolCalls / toolCount`; defaults to `None` when the field is absent so existing gateway sessions that don't carry a tool-count keep their current behaviour.
- **`tests/test_openclaw_tool_catalog_kind.py`** — 6 new cases covering `tools_present=False/None/True` with patch, env-var-only, no NemoClaw signal, and env-var=0 override.

## Test plan

- `python3 -m pytest tests/test_openclaw_tool_catalog_kind.py -v` — all 18 tests pass (12 existing + 6 new)
- `python3 -m py_compile clawmetry/adapters/openclaw.py` — syntax clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01M2VU1gNrqLHVCorJwEKAbH)_