### PR TITLE
fix: global emergency-stop endpoint + proxy enforcement (#3439)

### DIFF
--- a/clawmetry/proxy.py
+++ b/clawmetry/proxy.py
@@ -76,6 +76,7 @@ PROXY_DB_FILE = CONFIG_DIR / "proxy.db"
 PROXY_PID_FILE = CONFIG_DIR / "proxy.pid"
 PROXY_LOG_FILE = CONFIG_DIR / "proxy.log"
 _HITL_DIR = CONFIG_DIR / "hitl"
+_ESTOP_FLAG = _HITL_DIR / "emergency_stop"
 
 
 # Auto-backoff escalation ladder (#2818): minutes of cool-off by repeat count.
@@ -134,6 +135,17 @@ def _is_session_hitl_paused(session_id: str) -> bool:
     # after _BACKOFF_RESET_SECS of quiet). _prune_backoff_pauses removes
     # long-expired files in the maintenance loop.
     return False
+
+
+def _is_emergency_stopped() -> bool:
+    """Return True if the global emergency stop flag is active (#3439).
+
+    Written by POST /api/emergency-stop in routes/alerts.py and removed by
+    POST /api/emergency-stop/clear. File-based so the proxy and Flask processes
+    share state across process boundaries without IPC. A missing or corrupt
+    flag file is treated as inactive (fail-open: don't block when safe).
+    """
+    return _ESTOP_FLAG.exists()
 
 
 def _prune_backoff_pauses() -> int:
@@ -2385,6 +2397,28 @@ def create_proxy_app(config: ProxyConfig = None) -> "Flask":
                 )
                 logger.warning(f"Velocity exceeded: {spike_reason}")
                 return _error_response(429, "velocity_exceeded", spike_reason, provider)
+
+            # ── Global emergency stop (#3439) ──────────────────────────────
+            # Checked before per-session HITL so a global halt can't be
+            # bypassed by creating a new session that lacks a pause file.
+            if _is_emergency_stopped():
+                with _stats_lock:
+                    _stats["blocked"] += 1
+                db.record_event(
+                    "emergency_stop",
+                    "Request blocked: global emergency stop is active",
+                    severity="critical",
+                    details={"model": model, "session_id": session_id},
+                )
+                logger.warning(
+                    "Request blocked for session '%s': emergency stop active", session_id
+                )
+                return _error_response(
+                    503,
+                    "emergency_stop",
+                    "Emergency stop is active. Resume via POST /api/emergency-stop/clear.",
+                    provider,
+                )
 
             # ── HITL / auto-backoff pause check ────────────────────────────
             # Honors both legacy operator pauses (manual resume) and auto-backoff

--- a/routes/alerts.py
+++ b/routes/alerts.py
@@ -39,6 +39,7 @@ zero behaviour change.
 import json
 import os
 import time
+from pathlib import Path
 
 from flask import Blueprint, jsonify, request
 from clawmetry.config import is_local_store_read_enabled
@@ -448,6 +449,50 @@ def api_budget_resume_gateway():
     _audit("gateway.resume", actor=_actor(), target="gateway",
            result="resumed", source="dashboard")
     return jsonify({"ok": True, "paused": False})
+
+
+# ── Emergency stop (issue #3439) ──────────────────────────────────────────
+# Global halt: writes a flag file that proxy.py reads on every request.
+# File-based (matching the HITL pause pattern) so the proxy and Flask
+# processes share state without IPC even across restarts.
+
+_ESTOP_FLAG = Path.home() / ".clawmetry" / "hitl" / "emergency_stop"
+
+
+@bp_budget.route("/api/emergency-stop/status", methods=["GET"])
+def api_emergency_stop_status():
+    """Return whether the global emergency stop is currently active."""
+    active = _ESTOP_FLAG.exists()
+    activated_at = None
+    if active:
+        try:
+            activated_at = json.loads(_ESTOP_FLAG.read_text()).get("activated_at")
+        except Exception:  # noqa: BLE001 — missing/corrupt flag: report active, no ts
+            pass
+    return jsonify({"active": active, "activated_at": activated_at})
+
+
+@bp_budget.route("/api/emergency-stop", methods=["POST"])
+def api_emergency_stop():
+    """Activate global emergency stop — all proxy requests return 503 immediately."""
+    _ESTOP_FLAG.parent.mkdir(parents=True, exist_ok=True)
+    meta = {"activated_at": time.time(), "actor": _actor()}
+    _ESTOP_FLAG.write_text(json.dumps(meta))
+    _audit("emergency_stop.activate", actor=_actor(), target="all_sessions",
+           result="stopped", source="dashboard")
+    return jsonify({"ok": True, "active": True, "activated_at": meta["activated_at"]})
+
+
+@bp_budget.route("/api/emergency-stop/clear", methods=["POST"])
+def api_emergency_stop_clear():
+    """Deactivate emergency stop — proxy resumes forwarding requests."""
+    try:
+        _ESTOP_FLAG.unlink(missing_ok=True)
+    except OSError:
+        pass
+    _audit("emergency_stop.clear", actor=_actor(), target="all_sessions",
+           result="cleared", source="dashboard")
+    return jsonify({"ok": True, "active": False})
 
 
 @bp_budget.route("/api/budget/is-over-cap")


### PR DESCRIPTION
Closes #3439

## Summary

- Adds `POST /api/emergency-stop` — activates a global halt by writing `~/.clawmetry/hitl/emergency_stop` (JSON `{activated_at, actor}`)
- Adds `POST /api/emergency-stop/clear` — removes the flag file, proxy resumes forwarding
- Adds `GET /api/emergency-stop/status` — returns `{active, activated_at}` for dashboard polling
- Modifies `clawmetry/proxy.py` to check the flag **before** the per-session HITL check on every forwarded request; returns 503 `emergency_stop` when active

## Approach

File-based flag (same pattern as HITL legacy operator pause) so the proxy process and Flask process share state without IPC, and the stopped state survives daemon restarts by design.

The emergency-stop check fires before per-session HITL so a global halt can't be circumvented by opening a new session that lacks a pause file.

## Test plan

- `python3 -m pytest tests/test_proxy_enforcement.py -v` — all 32 existing tests pass, no regressions
- Manual: `POST /api/emergency-stop` → flag file created → next proxy request returns 503; `POST /api/emergency-stop/clear` → flag removed → requests resume

---
_Generated by [Claude Code](https://claude.ai/code/session_01NB7sqJGn5MGDX7rQWqpogc)_