### PR TITLE
feat(entitlement): feature/runtime_catalog_at_batch + endpoints

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -3986,6 +3986,158 @@ def runtime_catalog_at(tier: str) -> list[dict] | None:
     return out
 
 
+def feature_catalog_at_batch(tiers) -> dict:
+    """Batch what-if sibling of :func:`feature_catalog_at`: full feature
+    catalog rows for a caller-supplied set of hypothetical tiers in ONE
+    round-trip.
+
+    Composes :func:`feature_catalog_at` (scalar what-if catalog) and
+    :func:`feature_spec_at_batch` (batch what-if scalar) -- same per-row
+    body as the scalar catalog helper, batched across the perspective-
+    tier axis instead of the feature-id axis. Lets a pricing-comparison
+    matrix UI ("show me the full feature catalog at OSS vs Cloud Starter
+    vs Cloud Pro vs Enterprise") hydrate every column off ONE call
+    instead of N calls to :func:`feature_catalog_at`.
+
+    Per-tier row shape::
+
+        {
+          "tier":       "<id>",
+          "tier_label": "...",
+          "tier_rank":  <int>,
+          "features":   [<feature_catalog_at row>, ...],
+        }
+
+    Each ``features`` list is byte-identical to the list
+    :func:`feature_catalog_at` returns for the same tier -- a parity
+    test pins this so the scalar and batch what-if catalog helpers
+    cannot drift.
+
+    Shape::
+
+        {
+          "tiers": [
+            {"tier": "<id>", "tier_label": ..., "tier_rank": ..., "features": [...]},
+            ...
+          ],
+          "unknown": ["bogus_id", ...],
+        }
+
+    Supplied tier ids are normalised via :func:`_normalise_csv`
+    (whitespace stripped, lowercased, duplicates dropped, first-seen
+    order preserved). Unknown ids are echoed in ``unknown[]`` instead of
+    short-circuiting -- a partially-bad caller still gets rows back for
+    the valid ids alongside a list of what was dropped, matching
+    :func:`feature_spec_at_batch`'s posture. ``trial`` IS accepted (it
+    lives in :data:`_TIER_ORDER` and the scalar helper resolves it).
+
+    Empty / ``None`` input returns ``{"tiers": [], "unknown": []}`` --
+    the HTTP wrapper turns that into a 400, this helper does not raise.
+
+    Resolver-independent: delegates per-tier to
+    :func:`feature_catalog_at`, which synthesises a fresh
+    :class:`Entitlement` per rung -- so grace vs enforce yields
+    byte-identical rows. Never raises: a per-tier failure short-circuits
+    that id into ``unknown[]`` and the rest of the batch keeps building.
+    """
+    ids = _normalise_csv(tiers)
+    rows: list[dict] = []
+    unknown: list[str] = []
+    for tid in ids:
+        if tid not in _TIER_ORDER:
+            unknown.append(tid)
+            continue
+        try:
+            catalog = feature_catalog_at(tid)
+        except Exception as exc:
+            logger.warning(
+                "entitlements: feature_catalog_at_batch row %r failed: %s",
+                tid,
+                exc,
+            )
+            unknown.append(tid)
+            continue
+        if catalog is None:
+            unknown.append(tid)
+            continue
+        rows.append(
+            {
+                "tier": tid,
+                "tier_label": tier_label(tid),
+                "tier_rank": _TIER_RANK.get(tid, -1),
+                "features": catalog,
+            }
+        )
+    return {"tiers": rows, "unknown": unknown}
+
+
+def runtime_catalog_at_batch(tiers) -> dict:
+    """Runtime-axis twin of :func:`feature_catalog_at_batch`: full runtime
+    catalog rows for a caller-supplied set of hypothetical tiers in ONE
+    round-trip.
+
+    Pairs with :func:`feature_catalog_at_batch` the same way
+    :func:`runtime_catalog_at` pairs with :func:`feature_catalog_at`.
+    Together they let a pricing-comparison matrix UI hydrate every
+    feature + runtime column at every hypothetical rung off TWO calls
+    instead of 2 * N calls to the scalar what-if catalog helpers.
+
+    Per-tier row shape::
+
+        {
+          "tier":       "<id>",
+          "tier_label": "...",
+          "tier_rank":  <int>,
+          "runtimes":   [<runtime_catalog_at row>, ...],
+        }
+
+    Each ``runtimes`` list is byte-identical to the list
+    :func:`runtime_catalog_at` returns for the same tier -- a parity
+    test pins this so the scalar and batch what-if catalog helpers
+    cannot drift.
+
+    Shape mirrors :func:`feature_catalog_at_batch` (top-level ``tiers``
+    array + ``unknown`` echo). Supplied ids are normalised via
+    :func:`_normalise_csv`; unknown ids are echoed instead of short-
+    circuiting the batch. ``trial`` is accepted.
+
+    Resolver-independent: delegates per-tier to
+    :func:`runtime_catalog_at`, which synthesises a fresh
+    :class:`Entitlement` per rung -- so grace vs enforce yields
+    byte-identical rows. Never raises: per-tier failures short-circuit
+    that id into ``unknown[]`` and the rest of the batch keeps building.
+    """
+    ids = _normalise_csv(tiers)
+    rows: list[dict] = []
+    unknown: list[str] = []
+    for tid in ids:
+        if tid not in _TIER_ORDER:
+            unknown.append(tid)
+            continue
+        try:
+            catalog = runtime_catalog_at(tid)
+        except Exception as exc:
+            logger.warning(
+                "entitlements: runtime_catalog_at_batch row %r failed: %s",
+                tid,
+                exc,
+            )
+            unknown.append(tid)
+            continue
+        if catalog is None:
+            unknown.append(tid)
+            continue
+        rows.append(
+            {
+                "tier": tid,
+                "tier_label": tier_label(tid),
+                "tier_rank": _TIER_RANK.get(tid, -1),
+                "runtimes": catalog,
+            }
+        )
+    return {"tiers": rows, "unknown": unknown}
+
+
 def tier_spec(tier: str) -> dict | None:
     """Scalar variant of :func:`tier_catalog`: full descriptor for a single
     tier in one shot.

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -2610,6 +2610,149 @@ def api_entitlement_tier_catalog_at():
         return jsonify({"error": "tier-catalog-at failed"}), 500
 
 
+@bp_entitlement.route("/api/entitlement/feature-catalog-at-batch")
+def api_entitlement_feature_catalog_at_batch():
+    """``GET /api/entitlement/feature-catalog-at-batch?tiers=a,b,c`` --
+    batch what-if sibling of ``/api/entitlement/feature-catalog-at``.
+
+    Where ``/feature-catalog-at`` hydrates the full feature catalog for
+    ONE hypothetical tier, this hydrates it for N hypothetical tiers in
+    ONE round-trip. Pairs with ``/feature-catalog-at`` the same way
+    ``/feature-spec-at-batch`` pairs with ``/feature-spec-at``: scalar
+    what-if -> matrix what-if across the perspective-tier axis rather
+    than the feature-id axis.
+
+    Use case: a pricing-comparison matrix UI ("show me the full feature
+    catalog at OSS vs Cloud Starter vs Cloud Pro vs Enterprise")
+    hydrates every column off ONE call instead of N calls to
+    ``/feature-catalog-at``.
+
+    Each ``tiers[].features`` list is byte-identical to the body of
+    ``/feature-catalog-at?tier=<tier>`` for the same tier -- pinned by
+    the parity tests so the scalar and batch what-if catalog helpers
+    cannot drift. Supplied tier ids are normalised (whitespace
+    stripped, lowercased, duplicates dropped, first-seen order
+    preserved). Unknown ids do not 404 the call -- they are echoed in
+    ``unknown[]`` so a partially-bad caller still gets rows back for
+    the valid ids alongside a list of what was dropped, matching every
+    other ``_at_batch`` sibling's posture.
+
+    Response shape::
+
+        {
+          "tiers": [
+            {
+              "tier":       "<id>",
+              "tier_label": "...",
+              "tier_rank":  <int>,
+              "features":   [<feature-catalog-at row>, ...],
+            },
+            ...
+          ],
+          "unknown":    ["bogus_id", ...],
+          "current_tier":      "...",
+          "current_tier_rank": <int>,
+          "grace":             <bool>,
+          "enforced":          <bool>,
+        }
+
+    - **400** when ``tiers=`` is missing / empty after normalisation
+    - **200** with bucketed unknowns for unknown tier ids -- does NOT
+      404 the call, matching every other batch sibling
+    - **Never 5xxs**: a synthesis failure short-circuits to an envelope
+      with empty rows so the matrix keeps rendering.
+    """
+    tiers = _parse_csv_arg("tiers")
+    if not tiers:
+        return jsonify({"error": "supply tiers=<csv>"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        batch = _ent.feature_catalog_at_batch(tiers)
+        ent = _ent.get_entitlement()
+        return jsonify(
+            {
+                "tiers": batch.get("tiers", []),
+                "unknown": batch.get("unknown", []),
+                "current_tier": ent.tier,
+                "current_tier_rank": _ent.tier_rank(ent.tier),
+                "grace": bool(ent.grace),
+                "enforced": _ent.is_enforced(),
+            }
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_feature_catalog_at_batch: error: %s", exc
+        )
+        return jsonify(
+            {
+                "tiers": [],
+                "unknown": [],
+                "current_tier": "oss",
+                "current_tier_rank": 0,
+                "grace": True,
+                "enforced": False,
+            }
+        )
+
+
+@bp_entitlement.route("/api/entitlement/runtime-catalog-at-batch")
+def api_entitlement_runtime_catalog_at_batch():
+    """``GET /api/entitlement/runtime-catalog-at-batch?tiers=a,b,c`` --
+    batch what-if sibling of ``/api/entitlement/runtime-catalog-at``.
+
+    Runtime-axis twin of ``/feature-catalog-at-batch``: same shape, same
+    normalisation semantics, same unknown-echo posture. Together the
+    two batches let a pricing-comparison matrix UI hydrate every
+    feature + runtime column at every hypothetical rung off TWO calls
+    instead of 2 * N calls to the scalar what-if catalog endpoints.
+
+    Each ``tiers[].runtimes`` list is byte-identical to the body of
+    ``/runtime-catalog-at?tier=<tier>`` for the same tier -- pinned by
+    the parity tests.
+
+    Response shape mirrors ``/feature-catalog-at-batch`` with
+    ``features`` renamed to ``runtimes``.
+
+    - **400** when ``tiers=`` is missing / empty after normalisation
+    - **200** with bucketed unknowns for unknown tier ids
+    - **Never 5xxs**: a synthesis failure short-circuits to an envelope
+      with empty rows so the matrix keeps rendering.
+    """
+    tiers = _parse_csv_arg("tiers")
+    if not tiers:
+        return jsonify({"error": "supply tiers=<csv>"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        batch = _ent.runtime_catalog_at_batch(tiers)
+        ent = _ent.get_entitlement()
+        return jsonify(
+            {
+                "tiers": batch.get("tiers", []),
+                "unknown": batch.get("unknown", []),
+                "current_tier": ent.tier,
+                "current_tier_rank": _ent.tier_rank(ent.tier),
+                "grace": bool(ent.grace),
+                "enforced": _ent.is_enforced(),
+            }
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_runtime_catalog_at_batch: error: %s", exc
+        )
+        return jsonify(
+            {
+                "tiers": [],
+                "unknown": [],
+                "current_tier": "oss",
+                "current_tier_rank": 0,
+                "grace": True,
+                "enforced": False,
+            }
+        )
+
+
 @bp_entitlement.route("/api/entitlement/tier-spec-at")
 def api_entitlement_tier_spec_at():
     """``GET /api/entitlement/tier-spec-at?tier=<id>&target=<id>`` -- scalar

--- a/tests/test_entitlement_catalog_at_batch.py
+++ b/tests/test_entitlement_catalog_at_batch.py
@@ -1,0 +1,580 @@
+"""Tests for ``feature_catalog_at_batch(tiers)`` /
+``runtime_catalog_at_batch(tiers)`` plus their HTTP endpoints.
+
+These are the batch what-if siblings of ``feature_catalog_at`` /
+``runtime_catalog_at``: where the scalar what-if catalog hydrates the
+full catalog at ONE hypothetical tier, the batch what-if catalog
+hydrates the same catalog at N hypothetical tiers off a single
+round-trip -- the perspective-tier axis is batched instead of the
+feature/runtime id axis.
+
+Each returned ``tiers[].features`` / ``tiers[].runtimes`` list must be
+byte-identical to the corresponding scalar catalog helper's return for
+the same tier, so the scalar / batch what-if catalog accessors cannot
+drift -- pinned by the parity tests below.
+
+Coverage:
+
+* per-tier row shape matches the scalar catalog (parity pin)
+* every tier in ``_TIER_ORDER`` (including ``trial``) round-trips through
+  the batch
+* input is normalised (whitespace stripped, lowercased, duplicates
+  dropped, first-seen order preserved) -- same as ``_normalise_csv``
+* unknown ids are echoed in ``unknown[]`` instead of short-circuiting
+* the helpers never raise -- a synthesis failure short-circuits to
+  ``unknown[]`` so the matrix keeps rendering
+* the HTTP endpoints 400 on missing / empty input, echo unknown ids at
+  200, carry the standard envelope (``current_tier`` /
+  ``current_tier_rank`` / ``grace`` / ``enforced``), and never 5xx on a
+  resolver crash
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+
+_FEATURE_ROW_KEYS = {
+    "id",
+    "label",
+    "tier",
+    "tiers",
+    "free",
+    "allowed",
+    "locked",
+    "entitled",
+    "alias",
+}
+
+_RUNTIME_ROW_KEYS = {
+    "id",
+    "label",
+    "free",
+    "tier",
+    "tiers",
+    "allowed",
+    "locked",
+    "entitled",
+}
+
+_TIER_ROW_KEYS = {"tier", "tier_label", "tier_rank"}
+
+_ENVELOPE_KEYS = {
+    "tiers",
+    "unknown",
+    "current_tier",
+    "current_tier_rank",
+    "grace",
+    "enforced",
+}
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    """Fresh entitlements module with HOME pointed at an empty tmp dir so no
+    real ~/.clawmetry/license.key or cloud_plan.json leaks in. Enforcement
+    off by default (grace mode); the helpers still synthesise a non-grace
+    hypothetical entitlement per requested tier so the ``locked`` flags
+    actually reflect the per-tier grant."""
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from flask import Flask
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# ── feature_catalog_at_batch helper: input handling ──────────────────────────
+
+
+def test_feature_batch_empty_input_returns_empty_envelope(ent):
+    assert ent.feature_catalog_at_batch([]) == {"tiers": [], "unknown": []}
+
+
+def test_feature_batch_none_input_returns_empty_envelope(ent):
+    assert ent.feature_catalog_at_batch(None) == {"tiers": [], "unknown": []}
+
+
+def test_feature_batch_string_csv_input(ent):
+    body = ent.feature_catalog_at_batch(
+        f"{ent.TIER_CLOUD_STARTER},{ent.TIER_CLOUD_PRO}"
+    )
+    assert [row["tier"] for row in body["tiers"]] == [
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+    ]
+
+
+def test_feature_batch_supply_order_preserved(ent):
+    body = ent.feature_catalog_at_batch(
+        [ent.TIER_CLOUD_PRO, ent.TIER_OSS, ent.TIER_ENTERPRISE]
+    )
+    assert [row["tier"] for row in body["tiers"]] == [
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_OSS,
+        ent.TIER_ENTERPRISE,
+    ]
+
+
+def test_feature_batch_whitespace_and_case_normalised(ent):
+    body = ent.feature_catalog_at_batch(
+        ["  CLOUD_PRO  ", ent.TIER_CLOUD_STARTER.upper()]
+    )
+    assert [row["tier"] for row in body["tiers"]] == [
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_CLOUD_STARTER,
+    ]
+
+
+def test_feature_batch_duplicates_dropped_first_seen_wins(ent):
+    body = ent.feature_catalog_at_batch(
+        [
+            ent.TIER_CLOUD_PRO,
+            ent.TIER_CLOUD_PRO,
+            ent.TIER_CLOUD_STARTER,
+            ent.TIER_CLOUD_PRO,
+        ]
+    )
+    assert [row["tier"] for row in body["tiers"]] == [
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_CLOUD_STARTER,
+    ]
+
+
+def test_feature_batch_unknown_ids_echoed_in_unknown(ent):
+    body = ent.feature_catalog_at_batch(
+        [ent.TIER_CLOUD_PRO, "nope_tier", "also_bogus"]
+    )
+    assert [row["tier"] for row in body["tiers"]] == [ent.TIER_CLOUD_PRO]
+    assert body["unknown"] == ["nope_tier", "also_bogus"]
+
+
+def test_feature_batch_unknown_only_returns_empty_tiers(ent):
+    body = ent.feature_catalog_at_batch(["nope_tier", "also_bogus"])
+    assert body == {"tiers": [], "unknown": ["nope_tier", "also_bogus"]}
+
+
+def test_feature_batch_non_iterable_input_falls_back_to_empty(ent):
+    # ``_normalise_csv`` returns ``[]`` for non-iterable inputs (int,
+    # object, etc.) so the batch collapses to an empty envelope rather
+    # than raising.
+    assert ent.feature_catalog_at_batch(12345) == {
+        "tiers": [],
+        "unknown": [],
+    }
+    assert ent.feature_catalog_at_batch(object()) == {
+        "tiers": [],
+        "unknown": [],
+    }
+
+
+# ── feature_catalog_at_batch helper: shape + parity ──────────────────────────
+
+
+def test_feature_batch_row_shape_matches_scalar(ent):
+    body = ent.feature_catalog_at_batch([ent.TIER_CLOUD_PRO])
+    assert len(body["tiers"]) == 1
+    row = body["tiers"][0]
+    assert _TIER_ROW_KEYS.issubset(set(row.keys()))
+    assert "features" in row
+    assert set(row["features"][0].keys()) == _FEATURE_ROW_KEYS
+
+
+def test_feature_batch_features_list_matches_scalar_exactly(ent):
+    """Pin scalar / batch no-drift: every batch tier's ``features`` list
+    equals the scalar ``feature_catalog_at`` list for the same tier."""
+    body = ent.feature_catalog_at_batch(list(ent._TIER_ORDER))
+    by_tier = {row["tier"]: row for row in body["tiers"]}
+    assert set(by_tier) == set(ent._TIER_ORDER)
+    for tid in ent._TIER_ORDER:
+        assert by_tier[tid]["features"] == ent.feature_catalog_at(tid), tid
+
+
+def test_feature_batch_tier_metadata_matches_scalar(ent):
+    body = ent.feature_catalog_at_batch([ent.TIER_CLOUD_PRO])
+    row = body["tiers"][0]
+    assert row["tier_label"] == ent.tier_label(ent.TIER_CLOUD_PRO)
+    assert row["tier_rank"] == ent.tier_rank(ent.TIER_CLOUD_PRO)
+
+
+def test_feature_batch_every_tier_in_order_resolves(ent):
+    body = ent.feature_catalog_at_batch(list(ent._TIER_ORDER))
+    assert len(body["tiers"]) == len(ent._TIER_ORDER)
+    assert body["unknown"] == []
+    for row in body["tiers"]:
+        assert len(row["features"]) == len(ent.ALL_FEATURES)
+
+
+# ── feature_catalog_at_batch helper: perspective shifts ──────────────────────
+
+
+def test_feature_batch_perspective_shift_locks_at_oss_unlocks_at_pro(ent):
+    """Same feature id resolves to locked at OSS and unlocked at Cloud Pro
+    within the same batch response -- the whole point of the helper."""
+    fid = next(iter(ent.STARTER_FEATURES))
+    body = ent.feature_catalog_at_batch([ent.TIER_OSS, ent.TIER_CLOUD_PRO])
+    by_tier = {row["tier"]: row for row in body["tiers"]}
+    at_oss = {r["id"]: r for r in by_tier[ent.TIER_OSS]["features"]}
+    at_pro = {r["id"]: r for r in by_tier[ent.TIER_CLOUD_PRO]["features"]}
+    assert at_oss[fid]["locked"] is True
+    assert at_oss[fid]["allowed"] is False
+    assert at_pro[fid]["locked"] is False
+    assert at_pro[fid]["allowed"] is True
+
+
+def test_feature_batch_free_features_always_allowed(ent):
+    fid = next(iter(ent.FREE_FEATURES))
+    body = ent.feature_catalog_at_batch(list(ent._TIER_ORDER))
+    for row in body["tiers"]:
+        by_id = {r["id"]: r for r in row["features"]}
+        assert by_id[fid]["allowed"] is True, row["tier"]
+        assert by_id[fid]["locked"] is False, row["tier"]
+
+
+def test_feature_batch_enterprise_unlocks_everything(ent):
+    body = ent.feature_catalog_at_batch([ent.TIER_ENTERPRISE])
+    for r in body["tiers"][0]["features"]:
+        assert r["allowed"] is True, r["id"]
+        assert r["locked"] is False, r["id"]
+
+
+# ── feature_catalog_at_batch helper: never-raise ─────────────────────────────
+
+
+def test_feature_batch_never_raises_when_scalar_helper_crashes(ent, monkeypatch):
+    """A per-tier scalar helper crash must short-circuit that id into
+    ``unknown[]`` and the rest of the batch keeps building -- matches
+    every other ``_at_batch`` sibling's posture."""
+    real = ent.feature_catalog_at
+
+    def flaky(t):
+        if t == ent.TIER_CLOUD_PRO:
+            raise RuntimeError("simulated scalar crash")
+        return real(t)
+
+    monkeypatch.setattr(ent, "feature_catalog_at", flaky)
+    body = ent.feature_catalog_at_batch(
+        [ent.TIER_OSS, ent.TIER_CLOUD_PRO, ent.TIER_ENTERPRISE]
+    )
+    assert [row["tier"] for row in body["tiers"]] == [
+        ent.TIER_OSS,
+        ent.TIER_ENTERPRISE,
+    ]
+    assert body["unknown"] == [ent.TIER_CLOUD_PRO]
+
+
+# ── feature_catalog_at_batch helper: resolver-independent ────────────────────
+
+
+def test_feature_batch_grace_vs_enforce_byte_identical(ent, monkeypatch):
+    """Enforcement is a live-resolver knob; the batch what-if helper builds
+    a fresh hypothetical Entitlement per tier and must be independent."""
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    ent.invalidate()
+    grace = ent.feature_catalog_at_batch(list(ent._TIER_ORDER))
+
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    enforced = ent.feature_catalog_at_batch(list(ent._TIER_ORDER))
+    assert grace == enforced
+
+
+# ── runtime_catalog_at_batch helper: shape + parity ──────────────────────────
+
+
+def test_runtime_batch_empty_input_returns_empty_envelope(ent):
+    assert ent.runtime_catalog_at_batch([]) == {"tiers": [], "unknown": []}
+
+
+def test_runtime_batch_none_input_returns_empty_envelope(ent):
+    assert ent.runtime_catalog_at_batch(None) == {"tiers": [], "unknown": []}
+
+
+def test_runtime_batch_row_shape_matches_scalar(ent):
+    body = ent.runtime_catalog_at_batch([ent.TIER_CLOUD_PRO])
+    row = body["tiers"][0]
+    assert _TIER_ROW_KEYS.issubset(set(row.keys()))
+    assert "runtimes" in row
+    assert set(row["runtimes"][0].keys()) == _RUNTIME_ROW_KEYS
+
+
+def test_runtime_batch_runtimes_list_matches_scalar_exactly(ent):
+    body = ent.runtime_catalog_at_batch(list(ent._TIER_ORDER))
+    by_tier = {row["tier"]: row for row in body["tiers"]}
+    assert set(by_tier) == set(ent._TIER_ORDER)
+    for tid in ent._TIER_ORDER:
+        assert by_tier[tid]["runtimes"] == ent.runtime_catalog_at(tid), tid
+
+
+def test_runtime_batch_every_tier_in_order_resolves(ent):
+    body = ent.runtime_catalog_at_batch(list(ent._TIER_ORDER))
+    assert len(body["tiers"]) == len(ent._TIER_ORDER)
+    assert body["unknown"] == []
+    for row in body["tiers"]:
+        assert len(row["runtimes"]) == len(ent.ALL_RUNTIMES)
+
+
+# ── runtime_catalog_at_batch helper: normalisation ───────────────────────────
+
+
+def test_runtime_batch_supply_order_preserved(ent):
+    body = ent.runtime_catalog_at_batch(
+        [ent.TIER_ENTERPRISE, ent.TIER_OSS, ent.TIER_CLOUD_PRO]
+    )
+    assert [row["tier"] for row in body["tiers"]] == [
+        ent.TIER_ENTERPRISE,
+        ent.TIER_OSS,
+        ent.TIER_CLOUD_PRO,
+    ]
+
+
+def test_runtime_batch_whitespace_and_case_normalised(ent):
+    body = ent.runtime_catalog_at_batch(["  OSS  ", "CLOUD_PRO"])
+    assert [row["tier"] for row in body["tiers"]] == [
+        ent.TIER_OSS,
+        ent.TIER_CLOUD_PRO,
+    ]
+
+
+def test_runtime_batch_duplicates_dropped_first_seen_wins(ent):
+    body = ent.runtime_catalog_at_batch(
+        [ent.TIER_CLOUD_PRO, ent.TIER_CLOUD_PRO, ent.TIER_OSS]
+    )
+    assert [row["tier"] for row in body["tiers"]] == [
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_OSS,
+    ]
+
+
+def test_runtime_batch_unknown_ids_echoed_in_unknown(ent):
+    body = ent.runtime_catalog_at_batch(
+        [ent.TIER_CLOUD_PRO, "nope_tier"]
+    )
+    assert [row["tier"] for row in body["tiers"]] == [ent.TIER_CLOUD_PRO]
+    assert body["unknown"] == ["nope_tier"]
+
+
+# ── runtime_catalog_at_batch helper: perspective shifts ──────────────────────
+
+
+def test_runtime_batch_paid_runtime_locked_at_oss_allowed_at_pro(ent):
+    rt = next(iter(ent.PAID_RUNTIMES))
+    body = ent.runtime_catalog_at_batch([ent.TIER_OSS, ent.TIER_CLOUD_PRO])
+    by_tier = {row["tier"]: row for row in body["tiers"]}
+    at_oss = {r["id"]: r for r in by_tier[ent.TIER_OSS]["runtimes"]}
+    at_pro = {r["id"]: r for r in by_tier[ent.TIER_CLOUD_PRO]["runtimes"]}
+    assert at_oss[rt]["locked"] is True
+    assert at_oss[rt]["allowed"] is False
+    assert at_pro[rt]["locked"] is False
+    assert at_pro[rt]["allowed"] is True
+
+
+def test_runtime_batch_free_runtimes_always_allowed(ent):
+    body = ent.runtime_catalog_at_batch(list(ent._TIER_ORDER))
+    for row in body["tiers"]:
+        by_id = {r["id"]: r for r in row["runtimes"]}
+        for rt in ent.FREE_RUNTIMES:
+            assert by_id[rt]["allowed"] is True, (row["tier"], rt)
+            assert by_id[rt]["locked"] is False, (row["tier"], rt)
+
+
+# ── runtime_catalog_at_batch helper: never-raise ─────────────────────────────
+
+
+def test_runtime_batch_never_raises_when_scalar_helper_crashes(ent, monkeypatch):
+    real = ent.runtime_catalog_at
+
+    def flaky(t):
+        if t == ent.TIER_CLOUD_STARTER:
+            raise RuntimeError("simulated scalar crash")
+        return real(t)
+
+    monkeypatch.setattr(ent, "runtime_catalog_at", flaky)
+    body = ent.runtime_catalog_at_batch(
+        [ent.TIER_OSS, ent.TIER_CLOUD_STARTER, ent.TIER_CLOUD_PRO]
+    )
+    assert [row["tier"] for row in body["tiers"]] == [
+        ent.TIER_OSS,
+        ent.TIER_CLOUD_PRO,
+    ]
+    assert body["unknown"] == [ent.TIER_CLOUD_STARTER]
+
+
+# ── HTTP endpoint: feature-catalog-at-batch ──────────────────────────────────
+
+
+def test_endpoint_feature_batch_known_tiers_returns_rows(client, ent):
+    resp = client.get(
+        f"/api/entitlement/feature-catalog-at-batch"
+        f"?tiers={ent.TIER_CLOUD_STARTER},{ent.TIER_CLOUD_PRO}"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert _ENVELOPE_KEYS.issubset(set(body.keys()))
+    assert [row["tier"] for row in body["tiers"]] == [
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+    ]
+    # Every row's features list matches the scalar catalog endpoint for
+    # the same tier -- pinned so scalar and batch cannot drift.
+    for row in body["tiers"]:
+        scalar = client.get(
+            f"/api/entitlement/feature-catalog-at?tier={row['tier']}"
+        ).get_json()
+        assert row["features"] == scalar["features"], row["tier"]
+
+
+def test_endpoint_feature_batch_missing_arg_returns_400(client):
+    resp = client.get("/api/entitlement/feature-catalog-at-batch")
+    assert resp.status_code == 400
+    assert "error" in resp.get_json()
+
+
+def test_endpoint_feature_batch_blank_arg_returns_400(client):
+    resp = client.get(
+        "/api/entitlement/feature-catalog-at-batch?tiers=%20%20"
+    )
+    assert resp.status_code == 400
+
+
+def test_endpoint_feature_batch_unknown_ids_echoed_at_200(client, ent):
+    resp = client.get(
+        f"/api/entitlement/feature-catalog-at-batch"
+        f"?tiers={ent.TIER_CLOUD_PRO},nope_tier,also_bogus"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert [row["tier"] for row in body["tiers"]] == [ent.TIER_CLOUD_PRO]
+    assert body["unknown"] == ["nope_tier", "also_bogus"]
+
+
+def test_endpoint_feature_batch_lowercases_and_trims(client, ent):
+    resp = client.get(
+        f"/api/entitlement/feature-catalog-at-batch"
+        f"?tiers=%20%20{ent.TIER_CLOUD_PRO.upper()}%20%20"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert [row["tier"] for row in body["tiers"]] == [ent.TIER_CLOUD_PRO]
+
+
+def test_endpoint_feature_batch_every_tier_in_order_round_trips(client, ent):
+    tiers = ",".join(ent._TIER_ORDER)
+    resp = client.get(
+        f"/api/entitlement/feature-catalog-at-batch?tiers={tiers}"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert len(body["tiers"]) == len(ent._TIER_ORDER)
+    assert body["unknown"] == []
+
+
+def test_endpoint_feature_batch_never_5xx_on_resolver_crash(client, ent, monkeypatch):
+    def boom(*_a, **_kw):
+        raise RuntimeError("simulated resolver crash")
+
+    monkeypatch.setattr(ent, "get_entitlement", boom)
+    resp = client.get(
+        f"/api/entitlement/feature-catalog-at-batch?tiers={ent.TIER_CLOUD_PRO}"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["tiers"] == []
+    assert body["grace"] is True
+    assert body["enforced"] is False
+
+
+# ── HTTP endpoint: runtime-catalog-at-batch ──────────────────────────────────
+
+
+def test_endpoint_runtime_batch_known_tiers_returns_rows(client, ent):
+    resp = client.get(
+        f"/api/entitlement/runtime-catalog-at-batch"
+        f"?tiers={ent.TIER_CLOUD_STARTER},{ent.TIER_CLOUD_PRO}"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert _ENVELOPE_KEYS.issubset(set(body.keys()))
+    assert [row["tier"] for row in body["tiers"]] == [
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+    ]
+    for row in body["tiers"]:
+        scalar = client.get(
+            f"/api/entitlement/runtime-catalog-at?tier={row['tier']}"
+        ).get_json()
+        assert row["runtimes"] == scalar["runtimes"], row["tier"]
+
+
+def test_endpoint_runtime_batch_missing_arg_returns_400(client):
+    resp = client.get("/api/entitlement/runtime-catalog-at-batch")
+    assert resp.status_code == 400
+
+
+def test_endpoint_runtime_batch_blank_arg_returns_400(client):
+    resp = client.get(
+        "/api/entitlement/runtime-catalog-at-batch?tiers=%20%20"
+    )
+    assert resp.status_code == 400
+
+
+def test_endpoint_runtime_batch_unknown_ids_echoed_at_200(client, ent):
+    resp = client.get(
+        f"/api/entitlement/runtime-catalog-at-batch"
+        f"?tiers={ent.TIER_CLOUD_PRO},nope_tier"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert [row["tier"] for row in body["tiers"]] == [ent.TIER_CLOUD_PRO]
+    assert body["unknown"] == ["nope_tier"]
+
+
+def test_endpoint_runtime_batch_every_tier_in_order_round_trips(client, ent):
+    tiers = ",".join(ent._TIER_ORDER)
+    resp = client.get(
+        f"/api/entitlement/runtime-catalog-at-batch?tiers={tiers}"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert len(body["tiers"]) == len(ent._TIER_ORDER)
+    assert body["unknown"] == []
+
+
+def test_endpoint_runtime_batch_never_5xx_on_resolver_crash(client, ent, monkeypatch):
+    def boom(*_a, **_kw):
+        raise RuntimeError("simulated resolver crash")
+
+    monkeypatch.setattr(ent, "get_entitlement", boom)
+    resp = client.get(
+        f"/api/entitlement/runtime-catalog-at-batch?tiers={ent.TIER_CLOUD_PRO}"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["tiers"] == []
+    assert body["grace"] is True
+    assert body["enforced"] is False
+
+
+def test_endpoint_envelope_carries_current_tier_and_grace_flags(client, ent):
+    resp = client.get(
+        f"/api/entitlement/feature-catalog-at-batch?tiers={ent.TIER_CLOUD_PRO}"
+    )
+    body = resp.get_json()
+    live = ent.get_entitlement()
+    assert body["current_tier"] == live.tier
+    assert body["current_tier_rank"] == ent.tier_rank(live.tier)
+    assert body["grace"] == bool(live.grace)
+    assert body["enforced"] == ent.is_enforced()


### PR DESCRIPTION
## Summary

- Adds `feature_catalog_at_batch(tiers)` and `runtime_catalog_at_batch(tiers)` in `clawmetry/entitlements.py` -- the batch what-if siblings of the scalar `feature_catalog_at` / `runtime_catalog_at` helpers.
- Adds `GET /api/entitlement/feature-catalog-at-batch` + `GET /api/entitlement/runtime-catalog-at-batch` in `routes/entitlement.py` carrying the standard `current_tier` / `current_tier_rank` / `grace` / `enforced` envelope + per-tier rows (`{tier, tier_label, tier_rank, features | runtimes}`) + `unknown[]`.
- Fills the last gap in the what-if catalog family: `feature_catalog_at` / `runtime_catalog_at` / `tier_catalog_at` all have scalar `_at` helpers; feature and runtime were still missing a batch sibling. This pair lets a pricing-comparison matrix UI hydrate every feature + runtime column at every hypothetical rung off TWO calls instead of 2 * N calls to the scalar catalog endpoints (`/feature-catalog-at?tier=<t>` / `/runtime-catalog-at?tier=<t>`).
- Resolver-independent (walks the static per-tier grants via the scalar `feature_catalog_at` / `runtime_catalog_at`, grace == enforce byte-identical); never raises (per-tier failures land in `unknown[]`, the rest of the batch keeps building).

## Test plan

- [x] `python3 -m py_compile clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_catalog_at_batch.py`
- [x] `python3 -m pytest tests/test_entitlement_catalog_at_batch.py -x -q` → **44 passed**
- [x] `python3 -m pytest tests/ -k entitlement -q` → **3087 passed, 4 skipped** (only error is unrelated `test_retention_prune` blocked on the container missing `duckdb`; pre-existing in this env, matches the pattern in the last three merged entitlement PRs)
- [x] `make lint` shows zero new findings on the three files this PR touches (the 209 pre-existing warnings in `dashboard.py` are untouched)

### Helper-level pins

- [x] per-tier `features` / `runtimes` list is byte-identical to `feature_catalog_at(tier)` / `runtime_catalog_at(tier)` for the same tier
- [x] every tier in `_TIER_ORDER` (including `trial`) round-trips through the batch
- [x] per-tier metadata (`tier_label`, `tier_rank`) matches the scalar `tier_label()` / `tier_rank()` helpers
- [x] supply order preserved through normalisation; duplicates collapse; whitespace + case folded
- [x] unknown tier ids echoed in `unknown[]` (no short-circuit on partial-bad input)
- [x] empty / `None` input returns `{"tiers": [], "unknown": []}` (the HTTP wrapper turns that into a 400, the helper does not)
- [x] non-iterable input (int, `object()`) collapses to the empty envelope rather than raising
- [x] perspective shift works: a paid feature/runtime is `locked` at OSS and `allowed` at Cloud Pro in the same batch response
- [x] free features/runtimes stay allowed at every tier
- [x] grace vs enforce yields byte-identical output
- [x] per-tier scalar-helper failure short-circuits that id into `unknown[]`; rest of the batch keeps building

### HTTP-level pins

- [x] 400 on missing / empty `tiers=` after normalisation
- [x] 200 with bucketed `unknown[]` on partial-bad input (no 404)
- [x] 200 envelope carries `current_tier` / `current_tier_rank` / `grace` / `enforced` alongside `tiers` / `unknown`
- [x] per-tier `features` / `runtimes` matches the body of `GET /feature-catalog-at?tier=<t>` / `GET /runtime-catalog-at?tier=<t>` byte-for-byte
- [x] never 5xxs — a resolver crash short-circuits to an empty-rows envelope with `grace: true, enforced: false`

### Local operator verification checklist (cannot run remotely)

The remote agent has no access to your local daemon, `~/.openclaw`, or the cloud snapshot, so the following are for the local operator before flipping the PR off-draft:

- [ ] Copy `clawmetry/entitlements.py` + `routes/entitlement.py` (and optionally `tests/test_entitlement_catalog_at_batch.py`) into `~/.clawmetry/lib/python3.*/site-packages/clawmetry/` and `~/.clawmetry/lib/python3.*/site-packages/routes/`
- [ ] Clear `__pycache__` under both paths (`find ~/.clawmetry/lib -name __pycache__ -exec rm -rf {} +`)
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
- [ ] `curl -s 'http://localhost:8900/api/entitlement/feature-catalog-at-batch?tiers=oss,cloud_starter,cloud_pro,enterprise' | jq '.tiers | length'` returns `4`
- [ ] `curl -s 'http://localhost:8900/api/entitlement/feature-catalog-at-batch?tiers=oss,bogus_tier' | jq '.unknown'` returns `["bogus_tier"]`
- [ ] `curl -s 'http://localhost:8900/api/entitlement/runtime-catalog-at-batch?tiers=cloud_pro' | jq '.tiers[0].runtimes | length'` returns the runtime count
- [ ] Cross-check that per-tier `features` matches the scalar route response (`/api/entitlement/feature-catalog-at?tier=cloud_pro`) byte-for-byte
- [ ] `curl -s 'http://localhost:8900/api/entitlement/feature-catalog-at-batch'` (no `tiers=`) returns HTTP 400
- [ ] Decrypt the live cloud snapshot in-browser and confirm the dashboard renders normally (no behaviour change expected — this PR adds endpoints, doesn't touch existing surfaces)
- [ ] Flip the draft → ready-for-review (the remote agent intentionally leaves it draft)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RpaMiKowsYHj5EJckem6QF)_