### PR TITLE
feat(entitlement): tier_spec_at_batch + /api/entitlement/tier-spec-at-batch

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -4528,6 +4528,91 @@ def runtime_spec_at_batch(tier: str, runtimes) -> dict | None:
     return {"runtimes": rows, "unknown": unknown}
 
 
+def tier_spec_at_batch(tier: str, targets) -> dict | None:
+    """What-if + batch sibling of :func:`tier_spec_at`: return single-tier
+    descriptor rows for a caller-supplied subset of target tiers, all
+    computed from the perspective of a fixed hypothetical ``tier``.
+
+    Fixed-source multi-target companion to :func:`tier_spec_at` (scalar
+    what-if scalar) and cross-tier axis of :func:`feature_spec_at_batch` /
+    :func:`runtime_spec_at_batch` (which fix the source and batch across
+    the feature / runtime axis). Also the caller-supplied-targets sibling
+    of :func:`next_tier_spec_at_batch` /
+    :func:`previous_tier_spec_at_batch` (which walk the ladder from the
+    resolved tier and pin the destination to the adjacent purchasable
+    rung). Lets a pricing-comparison matrix UI ("from my perspective
+    tier, show me the descriptor rows for OSS, Cloud Starter, Cloud Pro,
+    Enterprise") hydrate every column off ONE round-trip instead of N
+    calls to :func:`tier_spec_at`.
+
+    Per-row body is byte-identical to :func:`tier_spec_at(tier, target)`
+    for the same ``target`` -- a parity test pins this so the scalar and
+    batch what-if accessors cannot drift. Only the ``is_current`` boolean
+    varies row by row (``True`` iff ``target == tier``); every other
+    catalogue-derived field comes straight from the static per-tier maps.
+
+    Shape (mirrors :func:`feature_catalog_at_batch` /
+    :func:`runtime_catalog_at_batch`'s ``{tiers, unknown}`` envelope --
+    the ``tiers`` axis IS the batch axis here, so the envelope key stays
+    ``tiers`` even though every row IS a tier)::
+
+        {
+          "tiers": [<tier_spec_at row>, ...],   # one per known target, first-seen order
+          "unknown": ["bogus_id", ...],         # supplied ids not in _TIER_ORDER
+        }
+
+    Returns ``None`` for empty / unknown perspective ``tier`` (caller
+    renders "unknown tier" / 404). Supplied target ids are normalised via
+    :func:`_normalise_csv` (whitespace stripped, lowercased, duplicates
+    dropped, first-seen order preserved). Unknown ids are echoed in
+    ``unknown[]`` instead of short-circuiting -- a partially-bad caller
+    still gets rows back for the valid ids alongside a list of what was
+    dropped, matching :func:`feature_spec_at_batch` /
+    :func:`runtime_spec_at_batch` /
+    :func:`feature_catalog_at_batch` /
+    :func:`runtime_catalog_at_batch`'s posture. ``trial`` IS accepted as
+    both perspective and target (it lives in :data:`_TIER_ORDER` and the
+    scalar helper resolves it).
+
+    Empty / ``None`` targets returns ``{"tiers": [], "unknown": []}`` --
+    the HTTP wrapper turns that into a 400, this helper does not raise.
+
+    Resolver-independent: delegates per-row to :func:`tier_spec_at`,
+    which reads only the static per-tier maps -- so grace vs enforce
+    yields byte-identical rows. Never raises: a per-row failure
+    short-circuits that id into ``unknown[]`` and the rest of the batch
+    keeps building.
+    """
+    try:
+        t = (tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if not t or t not in _TIER_ORDER:
+        return None
+    ids = _normalise_csv(targets)
+    rows: list[dict] = []
+    unknown: list[str] = []
+    for tid in ids:
+        if tid not in _TIER_ORDER:
+            unknown.append(tid)
+            continue
+        try:
+            row = tier_spec_at(t, tid)
+        except Exception as exc:
+            logger.warning(
+                "entitlements: tier_spec_at_batch row %r failed: %s",
+                tid,
+                exc,
+            )
+            unknown.append(tid)
+            continue
+        if row is None:
+            unknown.append(tid)
+            continue
+        rows.append(row)
+    return {"tiers": rows, "unknown": unknown}
+
+
 def lock_reason_at(
     perspective_tier: str, item: str, *, kind: str | None = None
 ) -> str | None:

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -3156,6 +3156,104 @@ def api_entitlement_runtime_spec_batch():
         )
 
 
+@bp_entitlement.route("/api/entitlement/tier-spec-at-batch")
+def api_entitlement_tier_spec_at_batch():
+    """``GET /api/entitlement/tier-spec-at-batch?tier=<perspective>
+    &targets=a,b,c`` -- what-if + batch sibling of
+    ``/api/entitlement/tier-spec-at``.
+
+    Where ``/tier-spec-at`` hydrates ONE tier descriptor from a
+    hypothetical perspective, this hydrates N descriptor rows for a
+    caller-supplied subset of target tiers off a single round-trip.
+    Fixed-source multi-target companion of ``/tier-spec-at`` and
+    tier-axis sibling of ``/feature-spec-at-batch`` /
+    ``/runtime-spec-at-batch`` (which fix the source and batch across
+    the feature / runtime axis instead).
+
+    Use case: a pricing-comparison matrix UI ("from my perspective tier,
+    render the descriptor rows for OSS, Cloud Starter, Cloud Pro and
+    Enterprise") hydrates every column off ONE call instead of N calls
+    to ``/tier-spec-at``.
+
+    Each ``tiers[]`` entry is byte-identical to a row from
+    :func:`entitlements.tier_spec_at` for the same ``target`` -- pinned
+    by the parity tests so the scalar / batch what-if accessors cannot
+    drift. Supplied ids are normalised (whitespace stripped, lowercased,
+    duplicates dropped, first-seen order preserved). Unknown ids do not
+    404 the call -- they are echoed in ``unknown[]`` so a partially-bad
+    caller still gets rows back for the valid ids alongside a list of
+    what was dropped.
+
+    Response shape (mirrors ``/feature-spec-at-batch`` /
+    ``/runtime-spec-at-batch`` plus a ``perspective_tier`` echo)::
+
+        {
+          "tiers":                 [<tier_spec_at row>, ...],
+          "unknown":               ["bogus_id", ...],
+          "perspective_tier":      "...",
+          "perspective_tier_rank": <int>,
+          "current_tier":          "...",
+          "current_tier_rank":     <int>,
+          "grace":                 <bool>,
+          "enforced":              <bool>,
+        }
+
+    - **400** when ``tier=`` is missing / blank or ``targets=`` is
+      missing / empty after normalisation
+    - **404** when ``tier`` is unknown (body carries ``which: "tier"``)
+    - **Never 5xxs**: a resolver failure short-circuits to the OSS-free
+      shape (empty rows, ``current_tier=oss``, ``grace=true``) with the
+      perspective tier echoed so the UI keeps rendering.
+    """
+    raw_tier = request.args.get("tier")
+    tier_in = (raw_tier or "").strip().lower()
+    if not tier_in:
+        return jsonify({"error": "missing tier"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        if tier_in not in _ent._TIER_ORDER:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "tier", "tier": tier_in}
+                ),
+                404,
+            )
+        targets = _parse_csv_arg("targets")
+        if not targets:
+            return (
+                jsonify({"error": "supply targets=<csv>"}),
+                400,
+            )
+        batch = _ent.tier_spec_at_batch(tier_in, targets)
+        if batch is None:
+            batch = {"tiers": [], "unknown": []}
+        ent = _ent.get_entitlement()
+        batch["perspective_tier"] = tier_in
+        batch["perspective_tier_rank"] = _ent.tier_rank(tier_in)
+        batch["current_tier"] = ent.tier
+        batch["current_tier_rank"] = _ent.tier_rank(ent.tier)
+        batch["grace"] = bool(ent.grace)
+        batch["enforced"] = _ent.is_enforced()
+        return jsonify(batch)
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_tier_spec_at_batch: error: %s", exc
+        )
+        return jsonify(
+            {
+                "tiers": [],
+                "unknown": [],
+                "perspective_tier": tier_in,
+                "perspective_tier_rank": 0,
+                "current_tier": "oss",
+                "current_tier_rank": 0,
+                "grace": True,
+                "enforced": False,
+            }
+        )
+
+
 @bp_entitlement.route("/api/entitlement/feature-spec-at-batch")
 def api_entitlement_feature_spec_at_batch():
     """``GET /api/entitlement/feature-spec-at-batch?tier=<perspective>

--- a/tests/test_entitlement_tier_spec_at_batch.py
+++ b/tests/test_entitlement_tier_spec_at_batch.py
@@ -1,0 +1,424 @@
+"""Tests for ``tier_spec_at_batch(tier, targets)`` + ``GET
+/api/entitlement/tier-spec-at-batch``.
+
+What-if + batch sibling of :func:`tier_spec_at`: single-tier descriptor
+rows for a caller-supplied subset of target tiers, all computed from the
+perspective of one fixed hypothetical ``tier``. Fixed-source multi-target
+companion to :func:`tier_spec_at` and tier-axis sibling of
+:func:`feature_spec_at_batch` / :func:`runtime_spec_at_batch` (which
+fix the source and batch over the feature / runtime axis).
+
+Pins:
+
+* per-row body is byte-identical to :func:`tier_spec_at(tier, target)`
+  for the same target (scalar/batch no-drift contract) -- a parity test
+  enumerates every (tier, target) pair
+* only ``is_current`` varies row by row (``True`` iff the row's ``id``
+  equals the perspective tier); every other field stays catalogue-derived
+* input is normalised (whitespace stripped, lowercased, duplicates
+  dropped, first-seen order preserved)
+* unknown ids are echoed in ``unknown[]`` instead of short-circuiting
+* unknown / blank / ``None`` / non-string perspective ``tier`` returns
+  ``None`` (helper) / 400 (missing / blank) / 404 (unknown)
+* ``trial`` is accepted as both perspective and target -- lenient ``_at``
+  posture matching :func:`tier_spec_at` and :func:`feature_spec_at_batch`
+* the helper is independent of the live resolver: switching enforcement
+  or pointing HOME at a license cache does not change the rows the
+  what-if surface returns
+* the endpoint 400s on missing / empty input, 404s on unknown perspective
+  tier, never 5xxs on a resolver crash, and carries the standard
+  ``grace`` / ``enforced`` / ``current_tier`` / ``current_tier_rank``
+  envelope plus ``perspective_tier`` / ``perspective_tier_rank``.
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+
+_ROW_KEYS = {
+    "id",
+    "label",
+    "is_paid",
+    "is_current",
+    "rank",
+    "unlocks_paid_runtimes",
+    "retention_days",
+    "channel_limit",
+    "node_limit",
+    "features",
+    "runtimes",
+}
+
+_ENVELOPE_KEYS = {
+    "perspective_tier",
+    "perspective_tier_rank",
+    "current_tier",
+    "current_tier_rank",
+    "grace",
+    "enforced",
+}
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    """Fresh entitlements module with HOME pointed at an empty tmp dir
+    so no real ~/.clawmetry/license.key or cloud_plan.json leaks in.
+    Enforcement off by default -- ``tier_spec_at_batch`` is independent
+    of either knob, so the fixture only needs to keep the live resolver
+    from surprising the test."""
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from flask import Flask
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# ── perspective tier handling ────────────────────────────────────────────────
+
+
+def test_unknown_perspective_tier_returns_none(ent):
+    assert ent.tier_spec_at_batch("bogus", ["oss"]) is None
+
+
+def test_blank_perspective_tier_returns_none(ent):
+    assert ent.tier_spec_at_batch("", ["oss"]) is None
+    assert ent.tier_spec_at_batch("   ", ["oss"]) is None
+
+
+def test_none_perspective_tier_returns_none(ent):
+    assert ent.tier_spec_at_batch(None, ["oss"]) is None
+
+
+def test_int_perspective_tier_returns_none(ent):
+    assert ent.tier_spec_at_batch(0, ["oss"]) is None
+
+
+def test_perspective_tier_whitespace_and_case_normalised(ent):
+    got = ent.tier_spec_at_batch("  CLOUD_PRO  ", ["cloud_pro"])
+    assert got is not None
+    assert got["tiers"][0]["id"] == "cloud_pro"
+    assert got["tiers"][0]["is_current"] is True
+
+
+def test_trial_accepted_as_perspective(ent):
+    got = ent.tier_spec_at_batch(ent.TIER_TRIAL, [ent.TIER_TRIAL])
+    assert got is not None
+    assert got["tiers"][0]["id"] == ent.TIER_TRIAL
+    assert got["tiers"][0]["is_current"] is True
+
+
+# ── targets input handling ───────────────────────────────────────────────────
+
+
+def test_empty_targets_returns_empty_envelope(ent):
+    got = ent.tier_spec_at_batch("cloud_pro", [])
+    assert got == {"tiers": [], "unknown": []}
+
+
+def test_none_targets_returns_empty_envelope(ent):
+    got = ent.tier_spec_at_batch("cloud_pro", None)
+    assert got == {"tiers": [], "unknown": []}
+
+
+def test_targets_string_csv_input(ent):
+    got = ent.tier_spec_at_batch(
+        "cloud_pro", "oss,cloud_starter,cloud_pro"
+    )
+    assert got is not None
+    assert [row["id"] for row in got["tiers"]] == [
+        "oss",
+        "cloud_starter",
+        "cloud_pro",
+    ]
+
+
+def test_targets_whitespace_and_case_normalised(ent):
+    got = ent.tier_spec_at_batch(
+        "cloud_pro", ["  OSS ", "Cloud_Pro"]
+    )
+    assert got is not None
+    assert [row["id"] for row in got["tiers"]] == ["oss", "cloud_pro"]
+
+
+def test_targets_duplicates_dropped_first_seen_wins(ent):
+    got = ent.tier_spec_at_batch(
+        "cloud_pro", ["oss", "cloud_pro", "oss", "cloud_pro"]
+    )
+    assert got is not None
+    assert [row["id"] for row in got["tiers"]] == ["oss", "cloud_pro"]
+
+
+def test_targets_supply_order_preserved(ent):
+    got = ent.tier_spec_at_batch(
+        "cloud_pro", ["cloud_pro", "oss", "enterprise", "cloud_starter"]
+    )
+    assert got is not None
+    assert [row["id"] for row in got["tiers"]] == [
+        "cloud_pro",
+        "oss",
+        "enterprise",
+        "cloud_starter",
+    ]
+
+
+def test_targets_unknown_ids_echoed_in_unknown(ent):
+    got = ent.tier_spec_at_batch(
+        "cloud_pro", ["oss", "bogus", "cloud_pro", "also_bogus"]
+    )
+    assert got is not None
+    assert [row["id"] for row in got["tiers"]] == ["oss", "cloud_pro"]
+    assert got["unknown"] == ["bogus", "also_bogus"]
+
+
+def test_targets_unknown_only_returns_empty_tiers(ent):
+    got = ent.tier_spec_at_batch("cloud_pro", ["bogus", "also_bogus"])
+    assert got is not None
+    assert got["tiers"] == []
+    assert got["unknown"] == ["bogus", "also_bogus"]
+
+
+def test_trial_accepted_as_target(ent):
+    got = ent.tier_spec_at_batch("cloud_pro", [ent.TIER_TRIAL])
+    assert got is not None
+    assert got["tiers"][0]["id"] == ent.TIER_TRIAL
+
+
+# ── row shape + parity ───────────────────────────────────────────────────────
+
+
+def test_row_shape_matches_tier_spec_at(ent):
+    got = ent.tier_spec_at_batch("cloud_pro", ["oss", "cloud_pro"])
+    assert got is not None
+    for row in got["tiers"]:
+        assert set(row.keys()) == _ROW_KEYS
+
+
+def test_row_parity_with_scalar_tier_spec_at(ent):
+    """For every (tier, target) pair, the batch row is byte-identical
+    to the scalar. Pins the scalar/batch no-drift contract."""
+    for tier in ent._TIER_ORDER:
+        got = ent.tier_spec_at_batch(tier, list(ent._TIER_ORDER))
+        assert got is not None
+        rows_by_id = {row["id"]: row for row in got["tiers"]}
+        for target in ent._TIER_ORDER:
+            assert rows_by_id[target] == ent.tier_spec_at(tier, target), (
+                tier,
+                target,
+            )
+
+
+def test_row_parity_with_tier_catalog_at(ent):
+    """Each returned row also matches the corresponding row in
+    :func:`tier_catalog_at` -- three-way parity (scalar / bulk / batch)."""
+    for tier in ent._TIER_ORDER:
+        got = ent.tier_spec_at_batch(tier, list(ent._TIER_ORDER))
+        assert got is not None
+        catalog_by_id = {row["id"]: row for row in ent.tier_catalog_at(tier)}
+        for row in got["tiers"]:
+            assert row == catalog_by_id[row["id"]], (tier, row["id"])
+
+
+def test_is_current_flips_with_perspective(ent):
+    """``is_current`` is True iff the row's id equals the perspective
+    tier, so shifting the perspective shifts which row (if any) carries
+    the flag."""
+    got = ent.tier_spec_at_batch(
+        "cloud_pro", ["oss", "cloud_starter", "cloud_pro", "enterprise"]
+    )
+    assert got is not None
+    flags = {row["id"]: row["is_current"] for row in got["tiers"]}
+    assert flags == {
+        "oss": False,
+        "cloud_starter": False,
+        "cloud_pro": True,
+        "enterprise": False,
+    }
+
+
+def test_is_current_absent_when_perspective_not_in_targets(ent):
+    got = ent.tier_spec_at_batch(
+        "cloud_pro", ["oss", "cloud_starter", "enterprise"]
+    )
+    assert got is not None
+    assert all(row["is_current"] is False for row in got["tiers"])
+
+
+# ── resolver independence ────────────────────────────────────────────────────
+
+
+def test_resolver_independent_across_enforcement(ent, monkeypatch):
+    """Grace vs enforce yields byte-identical rows -- ``tier_spec_at``
+    reads the static per-tier maps, not the live resolver, so the batch
+    inherits that property."""
+    grace = ent.tier_spec_at_batch(
+        "cloud_pro", ["oss", "cloud_pro", "enterprise"]
+    )
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    enforced = ent.tier_spec_at_batch(
+        "cloud_pro", ["oss", "cloud_pro", "enterprise"]
+    )
+    assert grace == enforced
+
+
+def test_never_raises_when_scalar_crashes(ent, monkeypatch):
+    """A per-row failure short-circuits that id into ``unknown[]`` and
+    the rest of the batch keeps building."""
+    orig = ent.tier_spec_at
+
+    def _boom(tier, target):
+        if target == "cloud_pro":
+            raise RuntimeError("boom")
+        return orig(tier, target)
+
+    monkeypatch.setattr(ent, "tier_spec_at", _boom)
+    got = ent.tier_spec_at_batch(
+        "enterprise", ["oss", "cloud_pro", "enterprise"]
+    )
+    assert got is not None
+    assert [row["id"] for row in got["tiers"]] == ["oss", "enterprise"]
+    assert got["unknown"] == ["cloud_pro"]
+
+
+# ── HTTP endpoint ────────────────────────────────────────────────────────────
+
+
+def test_endpoint_returns_rows_and_envelope(client, ent):
+    resp = client.get(
+        "/api/entitlement/tier-spec-at-batch"
+        "?tier=cloud_pro&targets=oss,cloud_pro,enterprise"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert [row["id"] for row in body["tiers"]] == [
+        "oss",
+        "cloud_pro",
+        "enterprise",
+    ]
+    assert body["unknown"] == []
+    assert _ENVELOPE_KEYS.issubset(body.keys())
+    assert body["perspective_tier"] == "cloud_pro"
+    assert body["perspective_tier_rank"] == ent.tier_rank("cloud_pro")
+
+
+def test_endpoint_perspective_flips_is_current(client, ent):
+    resp = client.get(
+        "/api/entitlement/tier-spec-at-batch"
+        "?tier=enterprise&targets=oss,cloud_pro,enterprise"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    flags = {row["id"]: row["is_current"] for row in body["tiers"]}
+    assert flags == {
+        "oss": False,
+        "cloud_pro": False,
+        "enterprise": True,
+    }
+
+
+def test_endpoint_missing_tier_returns_400(client, ent):
+    resp = client.get("/api/entitlement/tier-spec-at-batch?targets=oss")
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "missing tier"
+
+
+def test_endpoint_blank_tier_returns_400(client, ent):
+    resp = client.get(
+        "/api/entitlement/tier-spec-at-batch?tier=%20%20&targets=oss"
+    )
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "missing tier"
+
+
+def test_endpoint_unknown_tier_returns_404(client, ent):
+    resp = client.get(
+        "/api/entitlement/tier-spec-at-batch?tier=bogus&targets=oss"
+    )
+    assert resp.status_code == 404
+    body = resp.get_json()
+    assert body["error"] == "unknown tier"
+    assert body["which"] == "tier"
+    assert body["tier"] == "bogus"
+
+
+def test_endpoint_missing_targets_returns_400(client, ent):
+    resp = client.get("/api/entitlement/tier-spec-at-batch?tier=cloud_pro")
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "supply targets=<csv>"
+
+
+def test_endpoint_blank_targets_returns_400(client, ent):
+    resp = client.get(
+        "/api/entitlement/tier-spec-at-batch?tier=cloud_pro&targets=,,,"
+    )
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "supply targets=<csv>"
+
+
+def test_endpoint_unknown_only_returns_200(client, ent):
+    resp = client.get(
+        "/api/entitlement/tier-spec-at-batch"
+        "?tier=cloud_pro&targets=bogus,also_bogus"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["tiers"] == []
+    assert body["unknown"] == ["bogus", "also_bogus"]
+    assert body["perspective_tier"] == "cloud_pro"
+
+
+def test_endpoint_lowercases_tier_and_targets(client, ent):
+    resp = client.get(
+        "/api/entitlement/tier-spec-at-batch"
+        "?tier=CLOUD_PRO&targets=OSS,Cloud_Pro"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["perspective_tier"] == "cloud_pro"
+    assert [row["id"] for row in body["tiers"]] == ["oss", "cloud_pro"]
+
+
+def test_endpoint_envelope_carries_current_tier(client, ent):
+    resp = client.get(
+        "/api/entitlement/tier-spec-at-batch?tier=cloud_pro&targets=oss"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    resolved = ent.get_entitlement()
+    assert body["current_tier"] == resolved.tier
+    assert body["current_tier_rank"] == ent.tier_rank(resolved.tier)
+    assert body["grace"] is bool(resolved.grace)
+    assert body["enforced"] == ent.is_enforced()
+
+
+def test_endpoint_never_5xxs_when_resolver_crashes(client, ent, monkeypatch):
+    def _boom(*_a, **_kw):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(ent, "tier_spec_at_batch", _boom)
+    resp = client.get(
+        "/api/entitlement/tier-spec-at-batch?tier=cloud_pro&targets=oss"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["tiers"] == []
+    assert body["unknown"] == []
+    assert body["perspective_tier"] == "cloud_pro"
+    assert body["current_tier"] == "oss"
+    assert body["grace"] is True
+    assert body["enforced"] is False


### PR DESCRIPTION
## Summary

- Adds `tier_spec_at_batch(tier, targets)` — the caller-supplied-targets batch what-if sibling of `tier_spec_at`, filling the last docstring-referenced-but-unimplemented helper in the what-if scalar family.
- Adds `GET /api/entitlement/tier-spec-at-batch?tier=<perspective>&targets=<csv>` wrapping the helper on `bp_entitlement`.
- Fixed-source multi-target companion of `tier_spec_at` (scalar) and tier-axis sibling of `feature_spec_at_batch` / `runtime_spec_at_batch` (which fix the source and batch across the feature / runtime axis). Lets a pricing-comparison matrix UI hydrate N tier descriptor columns off ONE round-trip instead of N calls to `/tier-spec-at`.

Per-row body is byte-identical to `tier_spec_at(tier, target)` for the same target (three-way parity vs `tier_catalog_at`); only `is_current` varies row-by-row (True iff `target == tier`). `{tiers, unknown}` envelope mirrors `feature_catalog_at_batch` / `runtime_catalog_at_batch`. Input normalised via `_normalise_csv`; unknown ids are echoed instead of short-circuiting. `trial` accepted as both perspective and target. Resolver-independent; never raises.

Endpoint 400s on missing tier/targets, 404s on unknown perspective tier (with `which: "tier"`), never 5xxs on a resolver crash; response carries the standard `grace` / `enforced` / `current_tier` / `current_tier_rank` envelope plus a `perspective_tier` echo.

## Test plan

- [x] `ruff check clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_tier_spec_at_batch.py` — clean
- [x] `python -m py_compile` on all changed files — clean
- [x] 33 new tests (`tests/test_entitlement_tier_spec_at_batch.py`) covering row shape, three-way scalar/bulk/batch parity across every `(tier, target)` pair, `is_current` perspective-flip semantics, input normalisation, unknown-id echo, trial acceptance, resolver independence across enforcement, per-row crash isolation, plus the full HTTP envelope + 400/404/never-5xx contract — all pass
- [x] Neighbouring `test_entitlement_spec_at_batch.py`, `test_entitlement_catalog_at_batch.py`, `test_entitlement_feature_spec_at.py`, `test_entitlement_runtime_spec_at.py` — 153/153 pass, no regressions

## Local operator verification checklist

Because the CI runner cannot reach the operator's live daemon / cloud snapshot / browser, please run these before flipping the PR to ready-for-review:

- [ ] Copy `clawmetry/entitlements.py` + `routes/entitlement.py` into `~/.clawmetry/lib/python3.X/site-packages/clawmetry/` (and the sibling `routes/`), clear `__pycache__/`, then `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` and `com.clawmetry.dashboard`.
- [ ] `curl -sS 'http://localhost:8900/api/entitlement/tier-spec-at-batch?tier=cloud_pro&targets=oss,cloud_starter,cloud_pro,enterprise' | jq` — expect 4 rows with `is_current` set only on `cloud_pro`; `perspective_tier`, `perspective_tier_rank`, `current_tier`, `grace`, `enforced` populated.
- [ ] `curl -sS 'http://localhost:8900/api/entitlement/tier-spec-at-batch?tier=cloud_pro&targets=bogus,oss' | jq` — expect one `oss` row plus `"unknown": ["bogus"]`, status 200.
- [ ] `curl -sS -o /dev/null -w '%{http_code}\n' 'http://localhost:8900/api/entitlement/tier-spec-at-batch?tier=cloud_pro'` → 400. `?tier=bogus&targets=oss` → 404. `?targets=oss` → 400.
- [ ] Decrypt the live cloud snapshot and confirm the same call returns a matching payload against the cloud-backed data provider.
- [ ] Spot-check in the browser dashboard that no existing pricing / matrix widget regressed (this is a purely additive endpoint; nothing else in the UI calls it yet).
- [ ] Keep the resolver in GRACE — this PR adds no gate and does not enforce anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ubj9wMqnctx9vwPWbCVwHf)_