### PR TITLE
feat(usage): surface smart-routing savings in /api/usage

### DIFF
--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -7549,6 +7549,76 @@ class LocalStore:
         cols = ["id", "ts", "actor", "action", "target", "session_id", "result"]
         return [dict(zip(cols, r)) for r in self._fetch(sql, params)]
 
+    def query_routing_savings(
+        self,
+        *,
+        days: int = 30,
+    ) -> dict[str, Any]:
+        """Aggregate smart-routing savings from ``auto_downgraded`` proxy events.
+
+        Returns ``{total_savings_usd, total_substitutions, by_pair}`` where
+        ``by_pair`` is a list of ``{from_model, to_model, count, saved_usd}``
+        sorted by saved_usd descending. Drives the routing-attribution fields
+        added to ``/api/usage`` (issue #3438).
+        """
+        from datetime import datetime, timedelta, timezone
+        try:
+            d = max(1, min(365, int(days)))
+        except (TypeError, ValueError):
+            d = 30
+        since = (datetime.now(timezone.utc) - timedelta(days=d)).isoformat(timespec="seconds")
+        sql = """
+            SELECT data
+            FROM events
+            WHERE event_type = 'auto_downgraded'
+              AND ts >= ?
+        """
+        rows = self._fetch(sql, [since])
+
+        total_savings = 0.0
+        total_count = 0
+        pair_stats: dict[tuple, dict] = {}
+
+        for (raw,) in rows:
+            if raw is None:
+                continue
+            try:
+                raw = _ccr.maybe_decompress(raw)
+                text = raw.decode("utf-8") if isinstance(raw, (bytes, bytearray)) else raw
+                data = json.loads(text) if text else {}
+            except (ValueError, TypeError, UnicodeDecodeError):
+                continue
+            if not isinstance(data, dict):
+                continue
+
+            from_model = str(data.get("from_model") or "")
+            to_model = str(data.get("to_model") or "")
+            saved = float(data.get("estimated_saved_usd") or 0.0)
+
+            total_savings += saved
+            total_count += 1
+
+            key = (from_model, to_model)
+            if key not in pair_stats:
+                pair_stats[key] = {
+                    "from_model": from_model,
+                    "to_model": to_model,
+                    "count": 0,
+                    "saved_usd": 0.0,
+                }
+            pair_stats[key]["count"] += 1
+            pair_stats[key]["saved_usd"] += saved
+
+        by_pair = sorted(pair_stats.values(), key=lambda x: -x["saved_usd"])
+        for p in by_pair:
+            p["saved_usd"] = round(p["saved_usd"], 6)
+
+        return {
+            "total_savings_usd": round(total_savings, 6),
+            "total_substitutions": total_count,
+            "by_pair": by_pair,
+        }
+
     def query_nemoclaw_metrics(
         self,
         *,

--- a/routes/local_query.py
+++ b/routes/local_query.py
@@ -787,6 +787,10 @@ _DAEMON_METHODS = frozenset({
     # proxy so the dashboard process never opens DuckDB writable.
     "ingest_audit_log_entry",
     "query_audit_log",
+    # Issue #3438 — smart model routing savings attribution. Read-only
+    # aggregation of auto_downgraded events; routed through the daemon
+    # proxy so the dashboard process never opens DuckDB writable.
+    "query_routing_savings",
 })
 
 

--- a/routes/usage.py
+++ b/routes/usage.py
@@ -352,6 +352,11 @@ def _try_local_store_usage(runtime: Optional[str] = None):
         if v > 0
     ]
 
+    # Issue #3438: routing savings attribution. Reads auto_downgraded events
+    # written by the proxy into DuckDB and surfaces per-pair savings so the
+    # usage tab can show "X substitutions saved $Y this month."
+    routing_data = _ls_call("query_routing_savings") or {}
+
     return {
         "source": "local_store",
         "_source": "local_store",
@@ -371,6 +376,8 @@ def _try_local_store_usage(runtime: Optional[str] = None):
         "anomalySessionIds": [],
         "trend": {},
         "warnings": [],
+        "routing_savings_usd": round(float(routing_data.get("total_savings_usd") or 0.0), 6),
+        "routing_substitutions": routing_data.get("by_pair") or [],
     }
 
 

--- a/tests/test_proxy_routing_usage.py
+++ b/tests/test_proxy_routing_usage.py
@@ -1,0 +1,202 @@
+"""Tests for issue #3438 — smart model routing savings attribution in /api/usage.
+
+Verifies that:
+1. query_routing_savings() aggregates auto_downgraded events correctly.
+2. Per-(from_model, to_model) pair stats are accurate.
+3. Empty workspace returns zero-valued result, not an exception.
+4. _try_local_store_usage() includes routing_savings_usd and
+   routing_substitutions in its return dict.
+"""
+
+from __future__ import annotations
+
+import importlib
+import uuid
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# Use a timestamp that is always within a 30-day window from today
+# (2026-06 is within 30 days of 2026-07-01, the current date).
+_RECENT_TS = "2026-06-25T10:00:00"
+_OLD_TS = "2020-01-01T00:00:00"
+
+
+def _seed_routing_events(store, events):
+    """Ingest a list of auto_downgraded event payloads into the store and flush."""
+    for ev in events:
+        store.ingest({
+            "id": uuid.uuid4().hex,
+            "node_id": "node-1",
+            "agent_id": "clawmetry-proxy",
+            "agent_type": "openclaw",
+            "event_type": "auto_downgraded",
+            "ts": ev.get("ts", _RECENT_TS),
+            "session_id": ev.get("session_id", "sess-1"),
+            "data": {
+                "from_model": ev["from_model"],
+                "to_model": ev["to_model"],
+                "estimated_saved_usd": ev["estimated_saved_usd"],
+                "reason": ev.get("reason", "short-no-tools"),
+            },
+        })
+    # ingest() queues in the ring buffer; flush to DuckDB before querying.
+    store._flush_now()
+
+
+# ---------------------------------------------------------------------------
+# Fixture
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def store(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_READ", "1")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_BATCH", "5")
+
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+
+    s = ls.get_store()
+    yield s
+    try:
+        s.stop(flush=True)
+    except Exception:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: query_routing_savings()
+# ---------------------------------------------------------------------------
+
+def test_empty_store_returns_zero(store):
+    result = store.query_routing_savings(days=30)
+    assert result["total_savings_usd"] == 0.0
+    assert result["total_substitutions"] == 0
+    assert result["by_pair"] == []
+
+
+def test_single_substitution(store):
+    _seed_routing_events(store, [
+        {"from_model": "claude-opus-4-8", "to_model": "claude-haiku-4-5",
+         "estimated_saved_usd": 0.005},
+    ])
+    result = store.query_routing_savings(days=30)
+    assert result["total_substitutions"] == 1
+    assert abs(result["total_savings_usd"] - 0.005) < 1e-9
+    assert len(result["by_pair"]) == 1
+    pair = result["by_pair"][0]
+    assert pair["from_model"] == "claude-opus-4-8"
+    assert pair["to_model"] == "claude-haiku-4-5"
+    assert pair["count"] == 1
+    assert abs(pair["saved_usd"] - 0.005) < 1e-9
+
+
+def test_multiple_substitutions_same_pair(store):
+    _seed_routing_events(store, [
+        {"from_model": "claude-opus-4-8", "to_model": "claude-haiku-4-5",
+         "estimated_saved_usd": 0.003},
+        {"from_model": "claude-opus-4-8", "to_model": "claude-haiku-4-5",
+         "estimated_saved_usd": 0.007},
+    ])
+    result = store.query_routing_savings(days=30)
+    assert result["total_substitutions"] == 2
+    assert abs(result["total_savings_usd"] - 0.01) < 1e-9
+    assert len(result["by_pair"]) == 1
+    assert result["by_pair"][0]["count"] == 2
+
+
+def test_multiple_pairs_sorted_by_savings(store):
+    _seed_routing_events(store, [
+        {"from_model": "gpt-4o", "to_model": "gpt-4o-mini",
+         "estimated_saved_usd": 0.001},
+        {"from_model": "claude-opus-4-8", "to_model": "claude-haiku-4-5",
+         "estimated_saved_usd": 0.010},
+    ])
+    result = store.query_routing_savings(days=30)
+    assert result["total_substitutions"] == 2
+    # Highest-savings pair must come first
+    assert result["by_pair"][0]["from_model"] == "claude-opus-4-8"
+    assert result["by_pair"][1]["from_model"] == "gpt-4o"
+
+
+def test_days_window_excludes_old_events(store):
+    _seed_routing_events(store, [
+        {"from_model": "claude-opus-4-8", "to_model": "claude-haiku-4-5",
+         "estimated_saved_usd": 0.005, "ts": _OLD_TS},
+    ])
+    result = store.query_routing_savings(days=30)
+    assert result["total_substitutions"] == 0
+    assert result["total_savings_usd"] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Integration test: _try_local_store_usage() exposes routing fields
+# ---------------------------------------------------------------------------
+
+def test_usage_fast_path_includes_routing_fields(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "u.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_READ", "1")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_BATCH", "5")
+
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    import routes.usage as ru
+    importlib.reload(ru)
+
+    s = ls.get_store()
+    try:
+        # Seed enough cost events to satisfy the fast-path (needs aggregates or events).
+        for i in range(6):
+            s.ingest({
+                "id": uuid.uuid4().hex,
+                "node_id": "node-1",
+                "agent_id": "agent-1",
+                "agent_type": "openclaw",
+                "event_type": "model.completed",
+                "ts": _RECENT_TS,
+                "session_id": "sess-1",
+                "cost_usd": 0.01,
+                "token_count": 500,
+            })
+        # The 6th ingest triggers auto-flush (FLUSH_BATCH=5 -> flushes at 5).
+        # Also seed one routing event.
+        s.ingest({
+            "id": uuid.uuid4().hex,
+            "node_id": "node-1",
+            "agent_id": "clawmetry-proxy",
+            "agent_type": "openclaw",
+            "event_type": "auto_downgraded",
+            "ts": _RECENT_TS,
+            "session_id": "sess-1",
+            "data": {
+                "from_model": "claude-opus-4-8",
+                "to_model": "claude-haiku-4-5",
+                "estimated_saved_usd": 0.008,
+                "reason": "short-no-tools",
+            },
+        })
+        s._flush_now()
+
+        result = ru._try_local_store_usage()
+        assert result is not None, "_try_local_store_usage() returned None with seeded data"
+        assert "routing_savings_usd" in result, "routing_savings_usd missing from /api/usage response"
+        assert "routing_substitutions" in result, "routing_substitutions missing from /api/usage response"
+        assert isinstance(result["routing_savings_usd"], float)
+        assert isinstance(result["routing_substitutions"], list)
+    finally:
+        try:
+            s.stop(flush=True)
+        except Exception:
+            pass
+
+
+if __name__ == "__main__":
+    import pytest as _pytest
+    _pytest.main([__file__, "-v"])


### PR DESCRIPTION
Closes #3438

## Summary

The `AutoRouter` proxy already writes `auto_downgraded` events to DuckDB with `estimated_saved_usd` on every model substitution, but `/api/usage` never exposed them — users had no way to see how much routing saved them.

- **`clawmetry/local_store.py`**: new `query_routing_savings(days=30)` method — queries `events` for `event_type='auto_downgraded'`, parses data BLOB, sums `estimated_saved_usd`, groups by `(from_model → to_model)` pair sorted by savings descending
- **`routes/local_query.py`**: registers `query_routing_savings` in `_DAEMON_METHODS` so the dashboard reads through the daemon proxy without contending on the DuckDB writer lock (same pattern as all other query methods)
- **`routes/usage.py`**: calls `query_routing_savings` in `_try_local_store_usage()` and adds `routing_savings_usd` (float) and `routing_substitutions` (list of `{from_model, to_model, count, saved_usd}`) to the `/api/usage` response

## Test plan

- `python3 -m pytest tests/test_proxy_routing_usage.py -v` — 6 new tests: empty workspace returns zeros, single substitution, multi-event aggregation, multi-pair sort by savings, old-event window exclusion, integration test asserting `/api/usage` response includes both new fields
- `python3 -m pytest tests/test_version_health_local_store.py -v` — 9 existing tests all pass (no regressions in local_store or health routes)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bw55H2owiLVE2Cfv3Q2TB1)_