### PR TITLE
feat(entitlement): feature/runtime_catalog_path_batch + endpoints

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -9244,3 +9244,224 @@ def preview_path_batch(from_tier: str, to_tiers) -> dict | None:
             }
         )
     return {"tiers": rows, "unknown": unknown}
+
+
+def feature_catalog_path_batch(
+    from_tier: str, to_tiers
+) -> dict | None:
+    """Batch sibling of :func:`feature_catalog_path`: per-rung feature-catalog
+    rows for a caller-supplied subset of destination tiers all walked from a
+    single ``from_tier`` in ONE round-trip.
+
+    Composes :func:`feature_catalog_path` (scalar single-destination catalog
+    path) and :func:`feature_catalog_at_batch` (multi-source what-if catalog
+    matrix) -- same per-rung catalog body as the scalar path helper, same
+    multi-destination axis as :func:`tier_spec_path_batch` /
+    :func:`capacity_diff_path_batch` / :func:`preview_path_batch`. Lets an
+    upgrade-comparison walkthrough surface render "from my current rung,
+    here are the 3 tiers I'm considering -- show me the full feature
+    catalogue at every rung walked to each" off ONE call instead of N calls
+    to :func:`feature_catalog_path`. Full-catalog member of the path-batch
+    grid alongside :func:`tier_path_batch` (all-slices marginal),
+    :func:`tier_spec_path_batch` (spec envelope),
+    :func:`capacity_diff_path_batch` (capacity slice),
+    :func:`tier_unlocks_path_batch` (grants slice),
+    :func:`tier_locks_path_batch` (losses slice) and
+    :func:`preview_path_batch` (cumulative snapshot).
+
+    Per-destination row shape::
+
+        {
+          "to":         "<tier id>",
+          "to_label":   "...",
+          "to_rank":    <int>,
+          "direction":  "upgrade" | "downgrade" | "lateral" | "identity",
+          "path":       [<feature_catalog_path row>, ...],
+        }
+
+    Each ``path`` row is byte-identical to a row from
+    :func:`feature_catalog_path` for the same ``(from_tier, to)`` pair --
+    a parity test pins this so the scalar and batch path helpers cannot
+    drift. Per-rung ``features`` payload byte-equals
+    :func:`feature_catalog_at` for the same rung, the same guarantee the
+    scalar path helper carries. The walked rungs are destination-specific
+    (the path's rung set depends on ``to``), so per-destination ``path``
+    lengths can legitimately differ -- matching :func:`tier_spec_path_batch`
+    / :func:`capacity_diff_path_batch` / :func:`preview_path_batch` /
+    :func:`tier_path_batch`'s posture and differing from
+    :func:`feature_spec_path_batch` / :func:`runtime_spec_path_batch` whose
+    rungs are axis-id-agnostic.
+
+    Shape::
+
+        {
+          "tiers": [
+            {"to": "<id>", "to_label": ..., "to_rank": ..., "direction": ..., "path": [...]},
+            ...
+          ],
+          "unknown": ["bogus_id", ...],
+        }
+
+    Supplied destination ids are normalised via :func:`_normalise_csv`
+    (whitespace stripped, lowercased, duplicates dropped, first-seen order
+    preserved). Unknown ids are echoed in ``unknown[]`` instead of short-
+    circuiting -- a partially-bad caller still gets paths back for the
+    valid ids alongside a list of what was dropped, matching every other
+    ``*_path_batch`` sibling's posture. ``trial`` IS accepted as a
+    destination (excluded from the walked intermediate rungs the way
+    :func:`feature_catalog_path` already excludes it, but a valid endpoint
+    via the lateral / identity branches).
+
+    Returns ``None`` for empty / unknown ``from_tier`` (caller renders
+    "unknown tier" / 404).
+
+    Resolver-independent: delegates per-destination to
+    :func:`feature_catalog_path`, which walks via :func:`feature_catalog_at`
+    over freshly-synthesised hypothetical :class:`Entitlement` objects --
+    so grace vs enforce yields byte-identical rows. Never raises: per-
+    destination failures short-circuit that id into ``unknown[]`` and the
+    rest of the batch keeps building.
+    """
+    try:
+        f = (from_tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if f not in _TIER_FEATURES:
+        return None
+    candidates = _normalise_csv(to_tiers)
+    rows: list[dict] = []
+    unknown: list[str] = []
+    from_rank = _TIER_RANK.get(f, -1)
+    for tid in candidates:
+        if tid not in _TIER_FEATURES:
+            unknown.append(tid)
+            continue
+        try:
+            path = feature_catalog_path(f, tid)
+        except Exception as exc:
+            logger.warning(
+                "entitlements: feature_catalog_path_batch row %r failed: %s",
+                tid,
+                exc,
+            )
+            unknown.append(tid)
+            continue
+        if path is None:
+            unknown.append(tid)
+            continue
+        to_rank = _TIER_RANK.get(tid, -1)
+        if f == tid:
+            direction = "identity"
+        elif from_rank == to_rank:
+            direction = "lateral"
+        elif to_rank > from_rank:
+            direction = "upgrade"
+        else:
+            direction = "downgrade"
+        rows.append(
+            {
+                "to": tid,
+                "to_label": tier_label(tid),
+                "to_rank": to_rank,
+                "direction": direction,
+                "path": path,
+            }
+        )
+    return {"tiers": rows, "unknown": unknown}
+
+
+def runtime_catalog_path_batch(
+    from_tier: str, to_tiers
+) -> dict | None:
+    """Runtime-axis twin of :func:`feature_catalog_path_batch`: per-rung
+    runtime-catalog rows for a caller-supplied subset of destination tiers
+    all walked from a single ``from_tier`` in ONE round-trip.
+
+    Pairs with :func:`feature_catalog_path_batch` the same way
+    :func:`runtime_catalog_at_batch` pairs with
+    :func:`feature_catalog_at_batch` and :func:`runtime_catalog_path` pairs
+    with :func:`feature_catalog_path`. Together the two batch path helpers
+    let an upgrade-comparison walkthrough surface render every feature +
+    runtime column at every rung walked to N candidate destinations off
+    TWO calls instead of first calling :func:`tier_path_batch` (or
+    :func:`tier_path` per destination) and then 2 * N calls to the scalar
+    what-if catalog helpers.
+
+    Per-destination row shape::
+
+        {
+          "to":         "<canonical tier id>",
+          "to_label":   "...",
+          "to_rank":    <int>,
+          "direction":  "upgrade" | "downgrade" | "lateral" | "identity",
+          "path":       [<runtime_catalog_path row>, ...],
+        }
+
+    Each ``path`` row is byte-identical to a row from
+    :func:`runtime_catalog_path` for the same ``(from_tier, to)`` pair --
+    pinned by the parity tests. Per-rung ``runtimes`` payload byte-equals
+    :func:`runtime_catalog_at` for the same rung. Per-destination ``path``
+    lengths can legitimately differ (rung set depends on ``to``), matching
+    :func:`feature_catalog_path_batch`'s posture.
+
+    Shape mirrors :func:`feature_catalog_path_batch` (top-level ``tiers``
+    array + ``unknown`` echo). Supplied ids are normalised via
+    :func:`_normalise_csv`; unknown ids are echoed instead of short-
+    circuiting the batch. ``trial`` is accepted as a destination.
+
+    Returns ``None`` for empty / unknown ``from_tier`` (caller renders
+    "unknown tier" / 404).
+
+    Resolver-independent: delegates per-destination to
+    :func:`runtime_catalog_path`, which walks via :func:`runtime_catalog_at`
+    over freshly-synthesised hypothetical :class:`Entitlement` objects --
+    so grace vs enforce yields byte-identical rows. Never raises: per-
+    destination failures short-circuit that id into ``unknown[]`` and the
+    rest of the batch keeps building.
+    """
+    try:
+        f = (from_tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if f not in _TIER_FEATURES:
+        return None
+    candidates = _normalise_csv(to_tiers)
+    rows: list[dict] = []
+    unknown: list[str] = []
+    from_rank = _TIER_RANK.get(f, -1)
+    for tid in candidates:
+        if tid not in _TIER_FEATURES:
+            unknown.append(tid)
+            continue
+        try:
+            path = runtime_catalog_path(f, tid)
+        except Exception as exc:
+            logger.warning(
+                "entitlements: runtime_catalog_path_batch row %r failed: %s",
+                tid,
+                exc,
+            )
+            unknown.append(tid)
+            continue
+        if path is None:
+            unknown.append(tid)
+            continue
+        to_rank = _TIER_RANK.get(tid, -1)
+        if f == tid:
+            direction = "identity"
+        elif from_rank == to_rank:
+            direction = "lateral"
+        elif to_rank > from_rank:
+            direction = "upgrade"
+        else:
+            direction = "downgrade"
+        rows.append(
+            {
+                "to": tid,
+                "to_label": tier_label(tid),
+                "to_rank": to_rank,
+                "direction": direction,
+                "path": path,
+            }
+        )
+    return {"tiers": rows, "unknown": unknown}

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -9317,3 +9317,178 @@ def api_entitlement_preview_path_batch():
                 "enforced": False,
             }
         )
+
+
+@bp_entitlement.route("/api/entitlement/feature-catalog-path-batch")
+def api_entitlement_feature_catalog_path_batch():
+    """``GET /api/entitlement/feature-catalog-path-batch?from=<id>&to=a,b,c``
+    -- batch sibling of ``/api/entitlement/feature-catalog-path``.
+
+    Where ``/feature-catalog-path`` walks the full-catalog rungs between
+    ONE ``(from, to)`` pair, this walks the full-catalog rungs between
+    ONE ``from`` and N candidate ``to`` tiers in ONE round-trip. Pairs
+    with ``/feature-catalog-path`` the same way
+    ``/capacity-diff-path-batch`` pairs with ``/capacity-diff-path``:
+    scalar -> matrix in one call. Full-catalog member of the path-batch
+    grid alongside ``/tier-path-batch`` (all-slices marginal),
+    ``/tier-spec-path-batch`` (spec envelope),
+    ``/capacity-diff-path-batch`` (capacity slice),
+    ``/tier-unlocks-path-batch`` (grants slice),
+    ``/tier-locks-path-batch`` (losses slice) and
+    ``/preview-path-batch`` (cumulative snapshot).
+
+    Use case: an upgrade-comparison walkthrough surface hydrates the
+    per-rung feature catalog to every candidate destination off ONE call
+    instead of N calls to ``/feature-catalog-path``. Same-rank siblings
+    strictly between the endpoints are included for each per-destination
+    path; same-rank siblings of each destination are excluded so the
+    per-destination path terminates exactly at its own ``to``. Per-
+    destination path lengths can legitimately differ (rungs walked
+    depend on the destination), matching ``/tier-spec-path-batch`` /
+    ``/capacity-diff-path-batch`` / ``/preview-path-batch``'s posture.
+
+    Each row in ``tiers[].path`` is byte-identical to a row from
+    ``/feature-catalog-path?from=<from>&to=<to>`` -- pinned by the parity
+    tests so the scalar and batch path accessors cannot drift. Supplied
+    destination ids are normalised (whitespace stripped, lowercased,
+    duplicates dropped, first-seen order preserved). Unknown ids do not
+    404 the call -- they are echoed in ``unknown[]`` so a partially-bad
+    caller still gets paths back for the valid ids.
+
+    Response shape::
+
+        {
+          "from":       "<tier id>",
+          "from_label": "...",
+          "from_rank":  <int>,
+          "tiers": [
+            {
+              "to":        "<tier id>",
+              "to_label":  "...",
+              "to_rank":   <int>,
+              "direction": "upgrade" | "downgrade" | "lateral" | "identity",
+              "path":      [<feature-catalog-at-batch row>, ...],
+            },
+            ...
+          ],
+          "unknown":    ["bogus_id", ...],
+        }
+
+    - **400** when ``from=`` is missing / blank, or ``to=`` is missing
+      / empty after normalisation
+    - **404** when ``from`` is unknown (body carries ``which: "tier"``)
+    - **200** with bucketed unknowns for unknown destination ids --
+      does NOT 404 the call, matching every other batch sibling
+    - **Never 5xxs**: a synthesis failure short-circuits to an envelope
+      with empty rows so the matrix keeps rendering.
+    """
+    f = (request.args.get("from") or "").strip().lower()
+    if not f:
+        return jsonify({"error": "missing from"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        if f not in _ent._TIER_FEATURES:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "tier", "tier": f}
+                ),
+                404,
+            )
+        targets = _parse_csv_arg("to")
+        if not targets:
+            return jsonify({"error": "supply to=<csv>"}), 400
+        batch = _ent.feature_catalog_path_batch(f, targets)
+        if batch is None:
+            batch = {"tiers": [], "unknown": []}
+        return jsonify(
+            {
+                "from": f,
+                "from_label": _ent.tier_label(f),
+                "from_rank": _ent.tier_rank(f),
+                "tiers": batch.get("tiers", []),
+                "unknown": batch.get("unknown", []),
+            }
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_feature_catalog_path_batch: error: %s", exc
+        )
+        return jsonify(
+            {
+                "from": f,
+                "from_label": None,
+                "from_rank": -1,
+                "tiers": [],
+                "unknown": [],
+            }
+        )
+
+
+@bp_entitlement.route("/api/entitlement/runtime-catalog-path-batch")
+def api_entitlement_runtime_catalog_path_batch():
+    """``GET /api/entitlement/runtime-catalog-path-batch?from=<id>&to=a,b,c``
+    -- runtime-axis twin of ``/feature-catalog-path-batch``.
+
+    Pairs with ``/feature-catalog-path-batch`` the same way
+    ``/runtime-catalog-at-batch`` pairs with
+    ``/feature-catalog-at-batch`` and ``/runtime-catalog-path`` pairs
+    with ``/feature-catalog-path``. Together the two batch path endpoints
+    let an upgrade-comparison walkthrough UI render every feature +
+    runtime column at every rung walked to N candidate destinations off
+    TWO calls instead of first calling ``/tier-path-batch`` (or
+    ``/tier-path`` per destination) and then 2 * N calls to the scalar
+    what-if catalog endpoints.
+
+    Each row in ``tiers[].path`` mirrors the ``/runtime-catalog-at-batch``
+    row shape (``tier``, ``tier_label``, ``tier_rank``, ``runtimes``); the
+    ``runtimes`` list byte-equals ``/runtime-catalog-at?tier=<rung>`` for
+    the same rung -- pinned by the parity tests. Supplied destination ids
+    are normalised (whitespace stripped, lowercased, duplicates dropped,
+    first-seen order preserved). Unknown ids do not 404 the call -- they
+    are echoed in ``unknown[]``.
+
+    Response shape, direction semantics and error posture match
+    ``/feature-catalog-path-batch`` exactly. Never 5xxs.
+    """
+    f = (request.args.get("from") or "").strip().lower()
+    if not f:
+        return jsonify({"error": "missing from"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        if f not in _ent._TIER_FEATURES:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "tier", "tier": f}
+                ),
+                404,
+            )
+        targets = _parse_csv_arg("to")
+        if not targets:
+            return jsonify({"error": "supply to=<csv>"}), 400
+        batch = _ent.runtime_catalog_path_batch(f, targets)
+        if batch is None:
+            batch = {"tiers": [], "unknown": []}
+        return jsonify(
+            {
+                "from": f,
+                "from_label": _ent.tier_label(f),
+                "from_rank": _ent.tier_rank(f),
+                "tiers": batch.get("tiers", []),
+                "unknown": batch.get("unknown", []),
+            }
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_runtime_catalog_path_batch: error: %s", exc
+        )
+        return jsonify(
+            {
+                "from": f,
+                "from_label": None,
+                "from_rank": -1,
+                "tiers": [],
+                "unknown": [],
+            }
+        )

--- a/tests/test_entitlement_catalog_path_batch.py
+++ b/tests/test_entitlement_catalog_path_batch.py
@@ -1,0 +1,751 @@
+"""Tests for ``clawmetry.entitlements.feature_catalog_path_batch`` +
+``runtime_catalog_path_batch`` and their HTTP endpoints
+``/api/entitlement/feature-catalog-path-batch`` +
+``/api/entitlement/runtime-catalog-path-batch``.
+
+Batch siblings of the scalar catalog-path helpers: where the scalar helper
+walks one ``(from, to)`` pair, the batch helper walks N candidate
+destinations from ONE source in ONE round-trip -- the full-catalog member
+of the path-batch grid alongside ``tier_path_batch``,
+``tier_spec_path_batch``, ``capacity_diff_path_batch``,
+``tier_unlocks_path_batch``, ``tier_locks_path_batch`` and
+``preview_path_batch``.
+
+Pins:
+
+* per-destination ``path`` byte-equal to the scalar
+  :func:`feature_catalog_path` / :func:`runtime_catalog_path` payload
+* per-rung ``features`` / ``runtimes`` list byte-equals
+  :func:`feature_catalog_at` / :func:`runtime_catalog_at` for the same
+  rung -- the scalar, at-batch and path-batch surfaces cannot drift
+* per-destination ``direction`` derived from rank geometry, matches the
+  scalar endpoint's derivation
+* batch envelope mirrors the scalar path envelope on the source side
+  (``from`` / ``from_label`` / ``from_rank``) and carries
+  ``tiers`` + ``unknown``
+* input normalised (whitespace stripped, lowercased, duplicates dropped,
+  first-seen order preserved)
+* unknown destination ids echoed in ``unknown[]`` instead of 404'ing
+* identity ``from == to`` yields a per-destination entry whose ``path``
+  is ``[]``; lateral (same rank) yields a one-row ``path``
+* trial accepted as a destination (lateral / identity endpoint only --
+  excluded from intermediate rungs, same as the scalar helper)
+* unknown / empty / garbage ``from_tier`` returns ``None`` (helper) /
+  400 / 404 (HTTP)
+* helpers never raise -- a per-destination failure short-circuits that
+  id into ``unknown[]`` and the rest of the batch keeps building
+* HTTP endpoint 400 on missing / empty input, 404 on unknown source
+  tier, never 5xx on a row failure
+* grace vs enforce yields identical rows (resolver-independent)
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+_ITEM_KEYS = {"to", "to_label", "to_rank", "direction", "path"}
+
+_ENVELOPE_KEYS = {
+    "from",
+    "from_label",
+    "from_rank",
+    "tiers",
+    "unknown",
+}
+
+_FEATURE_ROW_KEYS = {"tier", "tier_label", "tier_rank", "features"}
+_RUNTIME_ROW_KEYS = {"tier", "tier_label", "tier_rank", "runtimes"}
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# ── feature helper: shape ────────────────────────────────────────────────────
+
+
+def test_feature_helper_returns_dict_shape(ent):
+    out = ent.feature_catalog_path_batch(
+        ent.TIER_OSS, [ent.TIER_CLOUD_STARTER, ent.TIER_ENTERPRISE]
+    )
+    assert isinstance(out, dict)
+    assert set(out.keys()) == {"tiers", "unknown"}
+    assert isinstance(out["tiers"], list)
+    assert isinstance(out["unknown"], list)
+
+
+def test_feature_helper_each_item_carries_full_envelope(ent):
+    out = ent.feature_catalog_path_batch(
+        ent.TIER_OSS, [ent.TIER_CLOUD_STARTER, ent.TIER_ENTERPRISE]
+    )
+    for item in out["tiers"]:
+        assert set(item.keys()) == _ITEM_KEYS
+        assert isinstance(item["to"], str)
+        assert isinstance(item["to_label"], str)
+        assert isinstance(item["to_rank"], int)
+        assert item["direction"] in {
+            "upgrade",
+            "downgrade",
+            "lateral",
+            "identity",
+        }
+        assert isinstance(item["path"], list)
+
+
+def test_feature_helper_per_row_matches_catalog_row_shape(ent):
+    out = ent.feature_catalog_path_batch(
+        ent.TIER_OSS, [ent.TIER_ENTERPRISE]
+    )
+    for row in out["tiers"][0]["path"]:
+        assert set(row.keys()) == _FEATURE_ROW_KEYS
+        assert isinstance(row["features"], list)
+
+
+# ── feature helper: parity ───────────────────────────────────────────────────
+
+
+def test_feature_helper_per_item_path_byte_equal_to_scalar(ent):
+    """Pin: per-destination ``path`` is byte-identical to the scalar
+    :func:`feature_catalog_path` payload for the same ``(from, to)`` pair."""
+    candidates = [
+        ent.TIER_CLOUD_FREE,
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_ENTERPRISE,
+    ]
+    out = ent.feature_catalog_path_batch(ent.TIER_OSS, candidates)
+    by_id = {item["to"]: item["path"] for item in out["tiers"]}
+    for tid in candidates:
+        scalar = ent.feature_catalog_path(ent.TIER_OSS, tid)
+        assert by_id[tid] == scalar
+
+
+def test_feature_helper_per_rung_features_byte_equal_to_catalog_at(ent):
+    """Every rung's ``features`` list is what :func:`feature_catalog_at`
+    returns for the same tier -- the scalar / at-batch / path / path-batch
+    surfaces cannot drift."""
+    out = ent.feature_catalog_path_batch(
+        ent.TIER_OSS, [ent.TIER_CLOUD_PRO, ent.TIER_ENTERPRISE]
+    )
+    for item in out["tiers"]:
+        for row in item["path"]:
+            assert row["features"] == ent.feature_catalog_at(row["tier"])
+
+
+def test_feature_helper_per_item_direction_matches_rank_geometry(ent):
+    candidates = [
+        ent.TIER_OSS,
+        ent.TIER_CLOUD_FREE,
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_PRO,
+        ent.TIER_ENTERPRISE,
+    ]
+    out = ent.feature_catalog_path_batch(ent.TIER_CLOUD_STARTER, candidates)
+    by_id = {item["to"]: item for item in out["tiers"]}
+    src_rank = ent.tier_rank(ent.TIER_CLOUD_STARTER)
+    for tid in candidates:
+        tgt_rank = ent.tier_rank(tid)
+        if tid == ent.TIER_CLOUD_STARTER:
+            expected = "identity"
+        elif src_rank == tgt_rank:
+            expected = "lateral"
+        elif tgt_rank > src_rank:
+            expected = "upgrade"
+        else:
+            expected = "downgrade"
+        assert by_id[tid]["direction"] == expected
+
+
+# ── feature helper: input normalisation ──────────────────────────────────────
+
+
+def test_feature_helper_supply_order_preserved(ent):
+    out = ent.feature_catalog_path_batch(
+        ent.TIER_OSS,
+        [ent.TIER_ENTERPRISE, ent.TIER_CLOUD_PRO, ent.TIER_CLOUD_STARTER],
+    )
+    assert [item["to"] for item in out["tiers"]] == [
+        ent.TIER_ENTERPRISE,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_CLOUD_STARTER,
+    ]
+
+
+def test_feature_helper_normalises_input(ent):
+    out = ent.feature_catalog_path_batch(
+        ent.TIER_OSS,
+        [
+            "  CLOUD_PRO  ",
+            "cloud_starter",
+            "cloud_pro",
+            "",
+        ],
+    )
+    assert [item["to"] for item in out["tiers"]] == [
+        "cloud_pro",
+        "cloud_starter",
+    ]
+
+
+def test_feature_helper_unknown_destination_ids_echoed(ent):
+    out = ent.feature_catalog_path_batch(
+        ent.TIER_OSS,
+        [ent.TIER_CLOUD_PRO, "bogus_tier", "still_bogus"],
+    )
+    assert [item["to"] for item in out["tiers"]] == [ent.TIER_CLOUD_PRO]
+    assert set(out["unknown"]) == {"bogus_tier", "still_bogus"}
+
+
+# ── feature helper: direction branches ───────────────────────────────────────
+
+
+def test_feature_helper_identity_yields_empty_path(ent):
+    out = ent.feature_catalog_path_batch(
+        ent.TIER_CLOUD_PRO, [ent.TIER_CLOUD_PRO, ent.TIER_ENTERPRISE]
+    )
+    by_id = {item["to"]: item for item in out["tiers"]}
+    assert by_id[ent.TIER_CLOUD_PRO]["direction"] == "identity"
+    assert by_id[ent.TIER_CLOUD_PRO]["path"] == []
+    assert by_id[ent.TIER_ENTERPRISE]["direction"] == "upgrade"
+
+
+def test_feature_helper_lateral_yields_one_row_path(ent):
+    out = ent.feature_catalog_path_batch(
+        ent.TIER_CLOUD_PRO, [ent.TIER_PRO]
+    )
+    assert len(out["tiers"]) == 1
+    item = out["tiers"][0]
+    assert item["direction"] == "lateral"
+    assert len(item["path"]) == 1
+    assert item["path"][0]["tier"] == ent.TIER_PRO
+
+
+def test_feature_helper_upgrade_walks_intermediate_rungs(ent):
+    out = ent.feature_catalog_path_batch(
+        ent.TIER_OSS, [ent.TIER_ENTERPRISE]
+    )
+    item = out["tiers"][0]
+    assert item["direction"] == "upgrade"
+    tiers = [row["tier"] for row in item["path"]]
+    assert tiers[-1] == ent.TIER_ENTERPRISE
+    assert ent.TIER_OSS not in tiers
+
+
+def test_feature_helper_downgrade_walks_descending(ent):
+    out = ent.feature_catalog_path_batch(
+        ent.TIER_ENTERPRISE, [ent.TIER_OSS]
+    )
+    item = out["tiers"][0]
+    assert item["direction"] == "downgrade"
+    tiers = [row["tier"] for row in item["path"]]
+    ranks = [ent.tier_rank(t) for t in tiers]
+    assert ranks == sorted(ranks, reverse=True)
+    assert tiers[-1] == ent.TIER_OSS
+
+
+# ── feature helper: trial endpoint ───────────────────────────────────────────
+
+
+def test_feature_helper_trial_destination_accepted(ent):
+    """``trial`` is a valid endpoint (matching
+    :func:`feature_catalog_path` semantics) even though it is excluded
+    from the walked intermediate rungs."""
+    out = ent.feature_catalog_path_batch(ent.TIER_OSS, [ent.TIER_TRIAL])
+    assert out["unknown"] == []
+    assert [item["to"] for item in out["tiers"]] == [ent.TIER_TRIAL]
+
+
+# ── feature helper: error / edge cases ───────────────────────────────────────
+
+
+def test_feature_helper_unknown_from_tier_returns_none(ent):
+    assert (
+        ent.feature_catalog_path_batch(
+            "not_a_tier", [ent.TIER_ENTERPRISE]
+        )
+        is None
+    )
+
+
+def test_feature_helper_empty_destinations_yields_empty_envelope(ent):
+    out = ent.feature_catalog_path_batch(ent.TIER_OSS, [])
+    assert out == {"tiers": [], "unknown": []}
+
+
+def test_feature_helper_garbage_inputs_never_raise(ent):
+    assert ent.feature_catalog_path_batch("", []) is None
+    assert ent.feature_catalog_path_batch(None, None) is None  # type: ignore[arg-type]
+    assert ent.feature_catalog_path_batch("  ", "  ") is None
+
+
+def test_feature_helper_grace_and_enforce_yield_identical_output(
+    ent, monkeypatch
+):
+    candidates = [ent.TIER_CLOUD_STARTER, ent.TIER_ENTERPRISE]
+    grace = ent.feature_catalog_path_batch(ent.TIER_OSS, candidates)
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    enforced = ent.feature_catalog_path_batch(ent.TIER_OSS, candidates)
+    assert grace == enforced
+
+
+def test_feature_helper_row_failure_short_circuits_item(ent, monkeypatch):
+    """A per-destination failure pushes that id into ``unknown[]`` while
+    the rest of the batch keeps building."""
+    real = ent.feature_catalog_path
+
+    def fake(f, t):
+        if t == ent.TIER_CLOUD_PRO:
+            raise RuntimeError("boom")
+        return real(f, t)
+
+    monkeypatch.setattr(ent, "feature_catalog_path", fake)
+    out = ent.feature_catalog_path_batch(
+        ent.TIER_OSS, [ent.TIER_CLOUD_PRO, ent.TIER_ENTERPRISE]
+    )
+    assert [item["to"] for item in out["tiers"]] == [ent.TIER_ENTERPRISE]
+    assert ent.TIER_CLOUD_PRO in out["unknown"]
+
+
+# ── runtime helper: shape + parity ───────────────────────────────────────────
+
+
+def test_runtime_helper_returns_dict_shape(ent):
+    out = ent.runtime_catalog_path_batch(
+        ent.TIER_OSS, [ent.TIER_CLOUD_STARTER, ent.TIER_ENTERPRISE]
+    )
+    assert isinstance(out, dict)
+    assert set(out.keys()) == {"tiers", "unknown"}
+    assert isinstance(out["tiers"], list)
+    assert isinstance(out["unknown"], list)
+
+
+def test_runtime_helper_per_row_matches_catalog_row_shape(ent):
+    out = ent.runtime_catalog_path_batch(
+        ent.TIER_OSS, [ent.TIER_ENTERPRISE]
+    )
+    for row in out["tiers"][0]["path"]:
+        assert set(row.keys()) == _RUNTIME_ROW_KEYS
+        assert isinstance(row["runtimes"], list)
+
+
+def test_runtime_helper_per_item_path_byte_equal_to_scalar(ent):
+    candidates = [
+        ent.TIER_CLOUD_FREE,
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_ENTERPRISE,
+    ]
+    out = ent.runtime_catalog_path_batch(ent.TIER_OSS, candidates)
+    by_id = {item["to"]: item["path"] for item in out["tiers"]}
+    for tid in candidates:
+        scalar = ent.runtime_catalog_path(ent.TIER_OSS, tid)
+        assert by_id[tid] == scalar
+
+
+def test_runtime_helper_per_rung_runtimes_byte_equal_to_catalog_at(ent):
+    out = ent.runtime_catalog_path_batch(
+        ent.TIER_OSS, [ent.TIER_CLOUD_PRO, ent.TIER_ENTERPRISE]
+    )
+    for item in out["tiers"]:
+        for row in item["path"]:
+            assert row["runtimes"] == ent.runtime_catalog_at(row["tier"])
+
+
+def test_runtime_helper_identity_yields_empty_path(ent):
+    out = ent.runtime_catalog_path_batch(
+        ent.TIER_CLOUD_PRO, [ent.TIER_CLOUD_PRO]
+    )
+    assert out["tiers"][0]["direction"] == "identity"
+    assert out["tiers"][0]["path"] == []
+
+
+def test_runtime_helper_lateral_yields_one_row_path(ent):
+    out = ent.runtime_catalog_path_batch(
+        ent.TIER_CLOUD_PRO, [ent.TIER_PRO]
+    )
+    assert len(out["tiers"]) == 1
+    item = out["tiers"][0]
+    assert item["direction"] == "lateral"
+    assert len(item["path"]) == 1
+    assert item["path"][0]["tier"] == ent.TIER_PRO
+
+
+def test_runtime_helper_upgrade_and_downgrade_terminate_at_to(ent):
+    up = ent.runtime_catalog_path_batch(
+        ent.TIER_OSS, [ent.TIER_ENTERPRISE]
+    )
+    down = ent.runtime_catalog_path_batch(
+        ent.TIER_ENTERPRISE, [ent.TIER_OSS]
+    )
+    assert up["tiers"][0]["path"][-1]["tier"] == ent.TIER_ENTERPRISE
+    assert down["tiers"][0]["path"][-1]["tier"] == ent.TIER_OSS
+
+
+def test_runtime_helper_unknown_from_tier_returns_none(ent):
+    assert (
+        ent.runtime_catalog_path_batch(
+            "not_a_tier", [ent.TIER_ENTERPRISE]
+        )
+        is None
+    )
+
+
+def test_runtime_helper_unknown_destination_ids_echoed(ent):
+    out = ent.runtime_catalog_path_batch(
+        ent.TIER_OSS, [ent.TIER_CLOUD_PRO, "bogus_tier"]
+    )
+    assert [item["to"] for item in out["tiers"]] == [ent.TIER_CLOUD_PRO]
+    assert out["unknown"] == ["bogus_tier"]
+
+
+def test_runtime_helper_garbage_inputs_never_raise(ent):
+    assert ent.runtime_catalog_path_batch("", []) is None
+    assert ent.runtime_catalog_path_batch(None, None) is None  # type: ignore[arg-type]
+    assert ent.runtime_catalog_path_batch("  ", "  ") is None
+
+
+def test_runtime_helper_grace_and_enforce_yield_identical_output(
+    ent, monkeypatch
+):
+    candidates = [ent.TIER_CLOUD_STARTER, ent.TIER_ENTERPRISE]
+    grace = ent.runtime_catalog_path_batch(ent.TIER_OSS, candidates)
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    enforced = ent.runtime_catalog_path_batch(ent.TIER_OSS, candidates)
+    assert grace == enforced
+
+
+def test_runtime_helper_row_failure_short_circuits_item(ent, monkeypatch):
+    real = ent.runtime_catalog_path
+
+    def fake(f, t):
+        if t == ent.TIER_CLOUD_PRO:
+            raise RuntimeError("boom")
+        return real(f, t)
+
+    monkeypatch.setattr(ent, "runtime_catalog_path", fake)
+    out = ent.runtime_catalog_path_batch(
+        ent.TIER_OSS, [ent.TIER_CLOUD_PRO, ent.TIER_ENTERPRISE]
+    )
+    assert [item["to"] for item in out["tiers"]] == [ent.TIER_ENTERPRISE]
+    assert ent.TIER_CLOUD_PRO in out["unknown"]
+
+
+# ── HTTP: /api/entitlement/feature-catalog-path-batch ────────────────────────
+
+
+def test_feature_api_400_on_missing_from(client):
+    r = client.get(
+        "/api/entitlement/feature-catalog-path-batch?to=cloud_pro,enterprise"
+    )
+    assert r.status_code == 400
+
+
+def test_feature_api_400_on_missing_to(client):
+    r = client.get("/api/entitlement/feature-catalog-path-batch?from=oss")
+    assert r.status_code == 400
+    body = r.get_json()
+    assert body["error"] == "supply to=<csv>"
+
+
+def test_feature_api_400_on_empty_to(client):
+    r = client.get(
+        "/api/entitlement/feature-catalog-path-batch?from=oss&to=,,"
+    )
+    assert r.status_code == 400
+
+
+def test_feature_api_404_on_unknown_from_tier(client):
+    r = client.get(
+        "/api/entitlement/feature-catalog-path-batch"
+        "?from=not_a_tier&to=enterprise"
+    )
+    assert r.status_code == 404
+    body = r.get_json()
+    assert body["which"] == "tier"
+
+
+def test_feature_api_200_with_unknown_destination_bucketed(client, ent):
+    r = client.get(
+        "/api/entitlement/feature-catalog-path-batch"
+        f"?from={ent.TIER_OSS}&to={ent.TIER_CLOUD_PRO},bogus_tier"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert [item["to"] for item in body["tiers"]] == [ent.TIER_CLOUD_PRO]
+    assert body["unknown"] == ["bogus_tier"]
+
+
+def test_feature_api_happy_path_ascending(client, ent):
+    r = client.get(
+        "/api/entitlement/feature-catalog-path-batch"
+        f"?from={ent.TIER_OSS}"
+        f"&to={ent.TIER_CLOUD_STARTER},{ent.TIER_ENTERPRISE}"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert set(body.keys()) == _ENVELOPE_KEYS
+    assert body["from"] == ent.TIER_OSS
+    assert isinstance(body["from_label"], str)
+    assert body["from_rank"] == ent.tier_rank(ent.TIER_OSS)
+    tos = [item["to"] for item in body["tiers"]]
+    assert tos == [ent.TIER_CLOUD_STARTER, ent.TIER_ENTERPRISE]
+    for item in body["tiers"]:
+        assert item["direction"] == "upgrade"
+        assert item["path"][-1]["tier"] == item["to"]
+
+
+def test_feature_api_identity_branch(client, ent):
+    r = client.get(
+        "/api/entitlement/feature-catalog-path-batch"
+        f"?from={ent.TIER_CLOUD_PRO}&to={ent.TIER_CLOUD_PRO}"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["tiers"][0]["direction"] == "identity"
+    assert body["tiers"][0]["path"] == []
+
+
+def test_feature_api_lateral_branch(client, ent):
+    r = client.get(
+        "/api/entitlement/feature-catalog-path-batch"
+        f"?from={ent.TIER_CLOUD_PRO}&to={ent.TIER_PRO}"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["tiers"][0]["direction"] == "lateral"
+    assert len(body["tiers"][0]["path"]) == 1
+
+
+def test_feature_api_downgrade_branch(client, ent):
+    r = client.get(
+        "/api/entitlement/feature-catalog-path-batch"
+        f"?from={ent.TIER_ENTERPRISE}&to={ent.TIER_OSS}"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["tiers"][0]["direction"] == "downgrade"
+
+
+def test_feature_api_per_item_path_matches_scalar_route(client, ent):
+    """HTTP parity: each per-destination ``path`` is byte-identical to
+    the scalar ``/feature-catalog-path?from=&to=`` ``path`` payload for
+    the same ``(from, to)`` pair."""
+    candidates = [
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_ENTERPRISE,
+    ]
+    batch = client.get(
+        "/api/entitlement/feature-catalog-path-batch"
+        f"?from={ent.TIER_OSS}&to={','.join(candidates)}"
+    ).get_json()
+    for item in batch["tiers"]:
+        scalar = client.get(
+            "/api/entitlement/feature-catalog-path"
+            f"?from={ent.TIER_OSS}&to={item['to']}"
+        ).get_json()
+        assert item["path"] == scalar["path"]
+        assert item["direction"] == scalar["direction"]
+        assert item["to_label"] == scalar["to_label"]
+        assert item["to_rank"] == scalar["to_rank"]
+
+
+def test_feature_api_input_normalised(client, ent):
+    r = client.get(
+        "/api/entitlement/feature-catalog-path-batch"
+        f"?from={ent.TIER_OSS}"
+        "&to=  CLOUD_PRO  ,cloud_starter,cloud_pro,"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert [item["to"] for item in body["tiers"]] == [
+        "cloud_pro",
+        "cloud_starter",
+    ]
+
+
+def test_feature_api_grace_and_enforce_yield_identical_body(
+    client, ent, monkeypatch
+):
+    grace = client.get(
+        "/api/entitlement/feature-catalog-path-batch"
+        f"?from={ent.TIER_OSS}"
+        f"&to={ent.TIER_CLOUD_STARTER},{ent.TIER_ENTERPRISE}"
+    ).get_json()
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    enforced = client.get(
+        "/api/entitlement/feature-catalog-path-batch"
+        f"?from={ent.TIER_OSS}"
+        f"&to={ent.TIER_CLOUD_STARTER},{ent.TIER_ENTERPRISE}"
+    ).get_json()
+    assert grace == enforced
+
+
+def test_feature_api_never_5xx_on_helper_failure(client, monkeypatch, ent):
+    """Force the underlying helper to blow up; the route must degrade
+    gracefully to an empty envelope instead of leaking a 500."""
+    import clawmetry.entitlements as _ent
+
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(_ent, "feature_catalog_path_batch", boom)
+    r = client.get(
+        "/api/entitlement/feature-catalog-path-batch"
+        f"?from={ent.TIER_OSS}&to={ent.TIER_ENTERPRISE}"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["tiers"] == []
+    assert body["unknown"] == []
+
+
+# ── HTTP: /api/entitlement/runtime-catalog-path-batch ────────────────────────
+
+
+def test_runtime_api_400_on_missing_from(client):
+    r = client.get(
+        "/api/entitlement/runtime-catalog-path-batch?to=cloud_pro"
+    )
+    assert r.status_code == 400
+
+
+def test_runtime_api_400_on_missing_to(client):
+    r = client.get("/api/entitlement/runtime-catalog-path-batch?from=oss")
+    assert r.status_code == 400
+
+
+def test_runtime_api_404_on_unknown_from_tier(client):
+    r = client.get(
+        "/api/entitlement/runtime-catalog-path-batch"
+        "?from=not_a_tier&to=enterprise"
+    )
+    assert r.status_code == 404
+    body = r.get_json()
+    assert body["which"] == "tier"
+
+
+def test_runtime_api_200_with_unknown_destination_bucketed(client, ent):
+    r = client.get(
+        "/api/entitlement/runtime-catalog-path-batch"
+        f"?from={ent.TIER_OSS}&to={ent.TIER_CLOUD_PRO},bogus_tier"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert [item["to"] for item in body["tiers"]] == [ent.TIER_CLOUD_PRO]
+    assert body["unknown"] == ["bogus_tier"]
+
+
+def test_runtime_api_happy_path_ascending(client, ent):
+    r = client.get(
+        "/api/entitlement/runtime-catalog-path-batch"
+        f"?from={ent.TIER_OSS}"
+        f"&to={ent.TIER_CLOUD_STARTER},{ent.TIER_ENTERPRISE}"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert set(body.keys()) == _ENVELOPE_KEYS
+    assert body["from"] == ent.TIER_OSS
+    assert body["from_rank"] == ent.tier_rank(ent.TIER_OSS)
+    tos = [item["to"] for item in body["tiers"]]
+    assert tos == [ent.TIER_CLOUD_STARTER, ent.TIER_ENTERPRISE]
+    for item in body["tiers"]:
+        assert item["direction"] == "upgrade"
+        assert item["path"][-1]["tier"] == item["to"]
+
+
+def test_runtime_api_per_item_path_matches_scalar_route(client, ent):
+    """HTTP parity: each per-destination ``path`` is byte-identical to
+    the scalar ``/runtime-catalog-path?from=&to=`` ``path`` payload for
+    the same ``(from, to)`` pair."""
+    candidates = [
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_ENTERPRISE,
+    ]
+    batch = client.get(
+        "/api/entitlement/runtime-catalog-path-batch"
+        f"?from={ent.TIER_OSS}&to={','.join(candidates)}"
+    ).get_json()
+    for item in batch["tiers"]:
+        scalar = client.get(
+            "/api/entitlement/runtime-catalog-path"
+            f"?from={ent.TIER_OSS}&to={item['to']}"
+        ).get_json()
+        assert item["path"] == scalar["path"]
+        assert item["direction"] == scalar["direction"]
+        assert item["to_label"] == scalar["to_label"]
+        assert item["to_rank"] == scalar["to_rank"]
+
+
+def test_runtime_api_input_normalised(client, ent):
+    r = client.get(
+        "/api/entitlement/runtime-catalog-path-batch"
+        f"?from={ent.TIER_OSS}"
+        "&to=  CLOUD_PRO  ,cloud_starter,cloud_pro,"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert [item["to"] for item in body["tiers"]] == [
+        "cloud_pro",
+        "cloud_starter",
+    ]
+
+
+def test_runtime_api_grace_and_enforce_yield_identical_body(
+    client, ent, monkeypatch
+):
+    grace = client.get(
+        "/api/entitlement/runtime-catalog-path-batch"
+        f"?from={ent.TIER_OSS}"
+        f"&to={ent.TIER_CLOUD_STARTER},{ent.TIER_ENTERPRISE}"
+    ).get_json()
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    enforced = client.get(
+        "/api/entitlement/runtime-catalog-path-batch"
+        f"?from={ent.TIER_OSS}"
+        f"&to={ent.TIER_CLOUD_STARTER},{ent.TIER_ENTERPRISE}"
+    ).get_json()
+    assert grace == enforced
+
+
+def test_runtime_api_never_5xx_on_helper_failure(client, monkeypatch, ent):
+    import clawmetry.entitlements as _ent
+
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(_ent, "runtime_catalog_path_batch", boom)
+    r = client.get(
+        "/api/entitlement/runtime-catalog-path-batch"
+        f"?from={ent.TIER_OSS}&to={ent.TIER_ENTERPRISE}"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["tiers"] == []
+    assert body["unknown"] == []


### PR DESCRIPTION
## Summary

- Adds `feature_catalog_path_batch(from_tier, to_tiers)` + `runtime_catalog_path_batch(from_tier, to_tiers)` to `clawmetry/entitlements.py` — batch siblings of `feature_catalog_path` / `runtime_catalog_path`. Full-catalog member of the path-batch grid alongside `tier_path_batch`, `tier_spec_path_batch`, `capacity_diff_path_batch`, `tier_unlocks_path_batch`, `tier_locks_path_batch`, `preview_path_batch`.
- Wires them behind `GET /api/entitlement/feature-catalog-path-batch?from=<id>&to=a,b,c` and `GET /api/entitlement/runtime-catalog-path-batch?from=<id>&to=a,b,c` in `routes/entitlement.py`.
- 53 new tests in `tests/test_entitlement_catalog_path_batch.py` pinning shape, scalar-vs-batch byte-parity, direction geometry, input normalisation, unknown-id bucketing, identity/lateral/upgrade/downgrade branches, trial endpoint, resolver-independence, per-item failure isolation, HTTP 400 / 404 / never-5xx contracts.

Grace-mode change only — no behaviour change. Each per-destination `path` row is byte-identical to the scalar `feature_catalog_path` / `runtime_catalog_path` payload for the same `(from, to)` pair; per-rung `features` / `runtimes` payloads byte-equal `feature_catalog_at` / `runtime_catalog_at` for the same rung. Same posture as sibling `*_path_batch` helpers: `_normalise_csv` on inputs, unknown ids echoed in `unknown[]` instead of short-circuiting, `trial` accepted as endpoint, per-destination failures isolated to `unknown[]`, unknown/empty/garbage `from_tier` returns `None`, grace vs enforce yields identical rows.

## Test plan

- [x] `python -m pytest tests/test_entitlement_catalog_path_batch.py` — 53 passed
- [x] Regression: `tests/test_entitlement_feature_catalog_path.py`, `tests/test_entitlement_runtime_catalog_path.py`, `tests/test_entitlement_capacity_diff_path_batch.py`, `tests/test_entitlement_preview_path_batch.py` — 110 passed
- [x] `python -m py_compile clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_catalog_path_batch.py`
- [x] `python -m ruff check clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_catalog_path_batch.py` — clean
- [ ] Local operator: verify against the running daemon (see checklist below)

## Local operator verification checklist

Because this session runs in an ephemeral cloud container with no access to the local daemon, `~/.openclaw`, or a browser, the human operator needs to walk the last mile:

- [ ] Copy the three changed files into `~/.clawmetry/lib/python3.X/site-packages/clawmetry/` (and `routes/`, `tests/` if you keep them side-loaded) OR `pip install -e .` from the branch checkout
- [ ] Clear `__pycache__` under the install path
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` to bounce the daemon
- [ ] `curl -s 'http://localhost:8900/api/entitlement/feature-catalog-path-batch?from=oss&to=cloud_starter,cloud_pro,enterprise' | jq .` — expect `tiers[]` populated, `unknown[]` empty, per-item `path[-1].tier == to`
- [ ] `curl -s 'http://localhost:8900/api/entitlement/runtime-catalog-path-batch?from=oss&to=cloud_starter,cloud_pro,enterprise' | jq .` — same shape, `runtimes` per rung
- [ ] `curl -s 'http://localhost:8900/api/entitlement/feature-catalog-path-batch?from=oss&to=cloud_pro,bogus_tier' | jq '.unknown'` — expect `["bogus_tier"]`, does NOT 404
- [ ] `curl -s -o /dev/null -w '%{http_code}\n' 'http://localhost:8900/api/entitlement/feature-catalog-path-batch?from=oss'` — expect `400`
- [ ] `curl -s -o /dev/null -w '%{http_code}\n' 'http://localhost:8900/api/entitlement/runtime-catalog-path-batch?from=not_a_tier&to=enterprise'` — expect `404`
- [ ] Byte-parity spot check: for one `(from, to)` pair, diff `feature-catalog-path?from=&to=` `path` vs the matching `tiers[].path` from `feature-catalog-path-batch` — expect byte-equal
- [ ] Decrypt the live cloud snapshot and browser-check any pricing / upgrade surface hitting these endpoints still renders (grace mode — no behaviour change expected)

Once verified, flip out of draft. Please do not merge or tag/release from this PR — I'm following the "operator handles release" rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01S1eaS6tEwkgXgAGTfPjbMj)_