### PR TITLE
fix(cost): Cost tab stuck on Loading when trend is empty

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -12910,11 +12910,11 @@ async function loadUsage() {
       if (_uEmptyEl) _uEmptyEl.remove();
     }
 
-    // Display cost warnings
-    displayCostWarnings(data.warnings || []);
-    
-    // Display trend analysis
-    displayTrendAnalysis(data.trend || {}, data);
+    // Display cost warnings + trend. Wrapped so a render bug in either card
+    // cannot abort the rest of loadUsage and leave every card below stuck on
+    // "Loading…" (the Cost-tab-blank regression).
+    try { displayCostWarnings(data.warnings || []); } catch (_eCW) { console.error('displayCostWarnings failed', _eCW); }
+    try { displayTrendAnalysis(data.trend || {}, data); } catch (_eTA) { console.error('displayTrendAnalysis failed', _eTA); }
     // Bar chart — QW4: with no data at all, hide the whole section (title +
     // card) instead of an empty box; render as before when data exists.
     var _uDays = Array.isArray(data.days) ? data.days : [];
@@ -13764,8 +13764,12 @@ function displayCostWarnings(warnings) {
 
 function displayTrendAnalysis(trend, usageData) {
   var card = document.getElementById('trend-card');
-  if (!trend || trend.trend === 'insufficient_data') {
-    card.style.display = 'none';
+  // Guard an empty/partial trend object ({}), not just null. When /api/usage
+  // returns trend:{} (no history yet), trend.trend is undefined; reaching the
+  // `trend.trend.charAt(0)` below threw and, since this runs early inside
+  // loadUsage's try, aborted every Cost card after it (all stuck on "Loading…").
+  if (!trend || !trend.trend || trend.trend === 'insufficient_data') {
+    if (card) card.style.display = 'none';
     return;
   }
   

--- a/tests/test_cost_trend_guard.js
+++ b/tests/test_cost_trend_guard.js
@@ -1,0 +1,74 @@
+// Guard for the "Cost tab stuck on Loading…" regression (founder report
+// 2026-07-02, cloud + localhost).
+//
+// /api/usage returns trend:{} when there is not enough history yet. The old
+// guard `if (!trend || trend.trend === 'insufficient_data')` let an empty {}
+// through (it is truthy, and trend.trend is undefined), so the next line
+// `trend.trend.charAt(0)` threw. Because displayTrendAnalysis runs EARLY inside
+// loadUsage's try block, the throw aborted every Cost card after it and they all
+// stayed on "Loading…".
+//
+// We pull displayTrendAnalysis out of the shipped app.js via brace-matching +
+// vm (same approach as test_brain_sse_reconnect.js) and assert it never throws
+// on an empty/partial/null trend, and still renders a real trend.
+
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const APP_JS = path.join(__dirname, '..', 'clawmetry', 'static', 'js', 'app.js');
+const src = fs.readFileSync(APP_JS, 'utf8');
+
+// Extract `function displayTrendAnalysis(...) { ... }` by matching braces.
+const start = src.indexOf('function displayTrendAnalysis');
+if (start === -1) { console.error('FAIL: displayTrendAnalysis not found in app.js'); process.exit(1); }
+let i = src.indexOf('{', start);
+let depth = 0, end = -1;
+for (; i < src.length; i++) {
+  if (src[i] === '{') depth++;
+  else if (src[i] === '}') { depth--; if (depth === 0) { end = i + 1; break; } }
+}
+const fnSrc = src.slice(start, end);
+
+// Minimal DOM stub: getElementById returns a fake element with a style object
+// and a settable textContent so the function can run headlessly.
+function makeEl() { return { style: {}, textContent: '', innerHTML: '' }; }
+const els = {};
+const sandbox = {
+  document: { getElementById: function (id) { return (els[id] = els[id] || makeEl()); } },
+  console: console,
+};
+vm.createContext(sandbox);
+vm.runInContext(fnSrc + '\nthis.displayTrendAnalysis = displayTrendAnalysis;', sandbox);
+
+let passed = 0, failed = 0;
+function ok(name, fn) {
+  try { fn(); passed++; console.log('  ok - ' + name); }
+  catch (e) { failed++; console.error('  FAIL - ' + name + ': ' + e.message); }
+}
+
+ok('empty trend {} does not throw (the regression)', function () {
+  sandbox.displayTrendAnalysis({}, { month: 100, monthCost: 1 });
+});
+ok('empty trend {} hides the trend card', function () {
+  els['trend-card'] = makeEl();
+  sandbox.displayTrendAnalysis({}, {});
+  if (els['trend-card'].style.display !== 'none') throw new Error('card not hidden');
+});
+ok('null trend does not throw', function () {
+  sandbox.displayTrendAnalysis(null, {});
+});
+ok('insufficient_data hides the card', function () {
+  els['trend-card'] = makeEl();
+  sandbox.displayTrendAnalysis({ trend: 'insufficient_data' }, {});
+  if (els['trend-card'].style.display !== 'none') throw new Error('card not hidden');
+});
+ok('a real trend still renders a direction', function () {
+  els['trend-card'] = makeEl(); els['trend-direction'] = makeEl(); els['trend-prediction'] = makeEl();
+  sandbox.displayTrendAnalysis({ trend: 'increasing', dailyAvg: 1000, monthlyPrediction: 30000 },
+                               { month: 30000, monthCost: 3 });
+  if (!/Increasing/.test(els['trend-direction'].textContent)) throw new Error('direction not rendered');
+});
+
+console.log('\n' + passed + ' passed, ' + failed + ' failed');
+process.exit(failed ? 1 : 0);


### PR DESCRIPTION
## Why
Every Cost-tab card (Top Sessions by Cost, Cost By Plugin/Skill, Trace Clusters, Activity Heatmap, Cost Comparison) was stuck on "Loading..." forever, on both cloud and localhost.

## Root cause
`/api/usage` returns `trend:{}` until there is enough history. `displayTrendAnalysis`'s guard was `if (!trend || trend.trend === 'insufficient_data')`, which lets an empty `{}` through (truthy object; `trend.trend` is `undefined`), so the next line `trend.trend.charAt(0)` threw `TypeError: Cannot read properties of undefined (reading 'charAt')`. Since `displayTrendAnalysis` runs early inside `loadUsage`'s `try`, the throw aborted every card render after it, leaving them all on "Loading...".

## Fix
- Guard `!trend.trend` too, so an empty/partial trend hides the trend card and returns.
- Wrap `displayCostWarnings` + `displayTrendAnalysis` in `loadUsage` so a single card's render bug can never blank the whole Cost tab again.

## Verification
- Reproduced live on the reporting node: patched the guard in the running page, re-ran `loadUsage`, and every card rendered (chart, top-sessions table, trace clusters, plugin legend, cost comparison).
- `tests/test_cost_trend_guard.js` (vm-extracts `displayTrendAnalysis`, stubs DOM): 5 pass on fixed code; **revert-proven** (2 fail with the exact `charAt` error on the old guard).

## Shipping
Frontend fix. After merge + [RELEASE], localhost daemons auto-update; the cloud needs a Dockerfile pin bump to serve the new app.js (follow-up).
