### PR TITLE
fix(agent-graph): wire the loader in the live switchTab (Loading-forever bug)

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -1191,6 +1191,11 @@ function switchTab(name) {
   if (name === 'overview') loadAll();
   if (name === 'overview') { if (typeof _velocityPollTimer !== 'undefined' && _velocityPollTimer) clearInterval(_velocityPollTimer); if (typeof loadTokenVelocity === 'function') _velocityPollTimer = visibilitySetInterval(function() { if (!_cmIsOverviewTab()) return; loadTokenVelocity(); }, 30000); }
   if (name === 'usage') loadUsage();
+  // Agent Graph (#3315): the original wiring landed in the DEAD first
+  // DASHBOARD_HTML's inline switchTab in dashboard.py, so the loader never
+  // fired and the tab sat on its static "Loading..." forever (founder
+  // report 2026-07-02). The LIVE switchTab is this one.
+  if (name === 'agents') loadAgentGraph();
   if (name === 'skills') loadSkills();
   if (name === 'crons') loadCrons();
   if (name === 'memory') loadMemory();
@@ -22286,13 +22291,24 @@ function loadAgentGraph() {
   var now   = Math.floor(Date.now() / 1000);
   var since = now - win;
   fetch('/api/local/agent-graph?since=' + since + '&until=' + now)
-    .then(function(r) { return r.ok ? r.json() : {nodes: [], edges: []}; })
+    .then(function(r) {
+      // The cloud disables /api/local/* (no local DuckDB) with HTTP 410.
+      // Say so honestly instead of pretending there is no data.
+      if (r.status === 410) return {_cloud_disabled: true};
+      return r.ok ? r.json() : {nodes: [], edges: []};
+    })
     .then(function(data) {
+      if (data && data._cloud_disabled) {
+        statusEl.style.display = 'block';
+        statusEl.textContent = t('app.agent_graph_local_only', null,
+          'The agent graph is built from your local data store, so it is only available on the dashboard running on your machine (http://localhost:8900).');
+        return;
+      }
       statusEl.style.display = 'none';
       _renderAgentGraph(data.nodes || [], data.edges || []);
     })
     .catch(function() {
-      statusEl.textContent = 'Could not load agent graph — is the daemon running?';
+      statusEl.textContent = 'Could not load agent graph. Is the daemon running?';
     });
 }
 

--- a/clawmetry/static/locales/en.json
+++ b/clawmetry/static/locales/en.json
@@ -35,6 +35,7 @@
   "app.add_integration": "+ Add Integration",
   "app.add_new_webhook_to_workspace": "Add New Webhook to Workspace",
   "app.advisor": "Advisor",
+  "app.agent_graph_local_only": "The agent graph is built from your local data store, so it is only available on the dashboard running on your machine (http://localhost:8900).",
   "app.agent_runtime": "Agent Runtime",
   "app.agent_working": "⚙️ Agent working…",
   "app.ai_model": "AI Model",

--- a/dashboard.py
+++ b/dashboard.py
@@ -6712,7 +6712,10 @@ function switchTab(name) {
   if (name !== 'subagents' && _subagentsTimer) { clearInterval(_subagentsTimer); _subagentsTimer = null; }
   if (name === 'selfconfig') loadSelfConfig();
   if (name === 'review') loadReview();
-  if (name === 'agents') loadAgentGraph();
+  // NOTE: this is the DEAD first DASHBOARD_HTML - it never renders. The Agent
+  // Graph wiring was mistakenly added here by #3315 (so the tab sat on
+  // "Loading..." forever); the live wiring lives in static/js/app.js
+  // switchTab. Do not add tab wiring here.
 }
 
 // ── Review tab (issue #1615) ─────────────────────────────────────────────

--- a/tests/test_agent_graph_wiring.py
+++ b/tests/test_agent_graph_wiring.py
@@ -1,0 +1,67 @@
+"""Guards for the Agent Graph tab wiring (founder report 2026-07-02).
+
+The bug class: dashboard.py defines DASHBOARD_HTML twice and only the SECOND
+renders. #3315 added `if (name === 'agents') loadAgentGraph();` to the inline
+switchTab inside the DEAD first block, so the loader never fired and the tab
+sat on its static "Loading..." forever, on localhost and cloud alike.
+
+Guards:
+  1. The LIVE switchTab (static/js/app.js) wires every nav tab that has a
+     dedicated loader - specifically 'agents' -> loadAgentGraph.
+  2. Class-wide: any `if (name === '<tab>') load...()` wiring that exists ONLY
+     in dashboard.py (the dead inline switchTab) and not in app.js is flagged.
+  3. The loader renders an honest message on the cloud's 410 (disabled
+     /api/local/*) instead of pretending there is no data.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_DASH = os.path.join(_HERE, "..", "dashboard.py")
+_APP_JS = os.path.join(_HERE, "..", "clawmetry", "static", "js", "app.js")
+
+
+def _read(path):
+    with open(path, encoding="utf-8") as fh:
+        return fh.read()
+
+
+def test_live_switchtab_wires_agent_graph():
+    js = _read(_APP_JS)
+    assert re.search(r"if \(name === 'agents'\) loadAgentGraph\(\);", js), (
+        "app.js switchTab must call loadAgentGraph() for the 'agents' tab - "
+        "wiring it only in dashboard.py's dead inline switchTab leaves the tab "
+        "on 'Loading...' forever"
+    )
+
+
+def test_no_wiring_exists_only_in_dead_block():
+    """Class guard: every dead-block tab wiring must also exist in app.js."""
+    dash = _read(_DASH)
+    js = _read(_APP_JS)
+    dead_wirings = set(re.findall(r"if \(name === '([a-z-]+)'\) load\w+\(\);", dash))
+    live_wirings = set(re.findall(r"if \(name === '([a-z-]+)'\)", js))
+    # Tabs that exist only in the dead block AND are reachable from the live
+    # nav (data-tab present in the live DASHBOARD_HTML) are broken.
+    live_html_start = dash.rindex('<aside id="left-nav"')
+    nav = dash[live_html_start:dash.index("</aside>", live_html_start)]
+    nav_tabs = set(re.findall(r'data-tab="([a-z-]+)"', nav))
+    orphaned = (dead_wirings - live_wirings) & nav_tabs
+    assert not orphaned, (
+        f"tab loader(s) wired ONLY in the dead first DASHBOARD_HTML: {sorted(orphaned)} - "
+        "move the wiring to static/js/app.js switchTab or the tab never loads"
+    )
+
+
+def test_loader_handles_cloud_410_honestly():
+    js = _read(_APP_JS)
+    m = re.search(r"function loadAgentGraph\(\).*?\n\}", js, re.S)
+    assert m, "loadAgentGraph missing"
+    body = m.group(0)
+    assert "410" in body and "agent_graph_local_only" in body, (
+        "loadAgentGraph must show the honest local-only message on the cloud's "
+        "410, not an empty-data state"
+    )


### PR DESCRIPTION
## Why
The Agent Graph tab sat on "Loading..." forever, on localhost and app.clawmetry.com (founder screenshot).

## Root cause
dashboard.py defines DASHBOARD_HTML twice and only the SECOND renders. #3315 added the tab wiring (`if (name === 'agents') loadAgentGraph();`) to the inline switchTab inside the DEAD first block, so the loader never fired and the template's static "Loading..." never got replaced.

## Fix
- Wire `agents -> loadAgentGraph()` in the LIVE app.js switchTab; remove the dead-block line and leave a do-not-add-here note.
- Honest cloud state: the cloud disables `/api/local/*` with HTTP 410; the loader now explains the graph is local-only instead of showing a misleading empty state (i18n key `app.agent_graph_local_only`).

## Verification
- Browser-verified from this branch: clicking Agent Graph runs the loader (honest empty state on an empty store), a stubbed 410 renders the local-only message, drawer auto-reveal + nav highlight work.
- tests/test_agent_graph_wiring.py: wiring guard (revert-proven), a CLASS guard flagging any nav tab wired only in the dead block, and the 410 honest-state guard.
