### PR TITLE
fix(i18n): real Unicode instead of emoji/arrow entities (unbreaks red test on main)

### DIFF
--- a/clawmetry/templates/partials/banners.html
+++ b/clawmetry/templates/partials/banners.html
@@ -2,9 +2,9 @@
 <div id="cm-device-pill" style="display:none; justify-content:center; align-items:center; padding:8px 16px; background:#0b0d12; border-bottom:1px solid rgba(124,140,255,0.18);">
   <a href="https://clawmetry.com/device" target="_blank" rel="noopener" style="display:inline-flex; align-items:center; gap:8px; padding:6px 15px; border-radius:999px; background:rgba(124,140,255,0.12); border:1px solid rgba(124,140,255,0.4); color:#a5b4ff; font-size:13px; font-weight:600; text-decoration:none;">
     <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="flex-shrink:0;"><rect x="2" y="3" width="20" height="14" rx="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg>
-    New: the ClawMetry desk device, $49 launch &rarr;
+    New: the ClawMetry desk device, $49 launch →
   </a>
-  <button onclick="dismissDevicePill()" title="Dismiss" aria-label="Dismiss" style="background:transparent; border:none; color:#6b7280; cursor:pointer; margin-left:10px; font-size:18px; line-height:1; padding:0 4px;">&times;</button>
+  <button onclick="dismissDevicePill()" title="Dismiss" aria-label="Dismiss" style="background:transparent; border:none; color:#6b7280; cursor:pointer; margin-left:10px; font-size:18px; line-height:1; padding:0 4px;">×</button>
 </div>
 <script>
 function dismissDevicePill(){ try{ localStorage.setItem('cm_device_pill_dismissed','1'); }catch(e){} var p=document.getElementById('cm-device-pill'); if(p) p.style.display='none'; }

--- a/clawmetry/templates/partials/overlays.html
+++ b/clawmetry/templates/partials/overlays.html
@@ -5,7 +5,7 @@
   <div style="background:var(--bg-primary);border:1px solid var(--border-primary);border-radius:12px;padding:20px;max-width:640px;width:90%;max-height:80vh;display:flex;flex-direction:column;gap:12px;overflow-y:auto;">
     <div style="display:flex;justify-content:space-between;align-items:center;">
       <h3 style="margin:0;font-size:14px;font-weight:700;color:var(--text-primary);">Evals (LLM judge)</h3>
-      <button onclick="closeEvalRubricModal()" style="background:transparent;border:none;color:var(--text-muted);font-size:18px;cursor:pointer;">&times;</button>
+      <button onclick="closeEvalRubricModal()" style="background:transparent;border:none;color:var(--text-muted);font-size:18px;cursor:pointer;">×</button>
     </div>
     <div style="border:1px solid var(--border-primary);border-radius:8px;padding:12px;display:flex;flex-direction:column;gap:8px;background:var(--bg-secondary);">
       <div style="display:flex;justify-content:space-between;align-items:center;">

--- a/clawmetry/templates/tabs/harness.html
+++ b/clawmetry/templates/tabs/harness.html
@@ -4,7 +4,7 @@
     <div style="font-size:13px;color:var(--muted,#888);">
       What this runtime uniquely exposes — beyond the generic tabs.
     </div>
-    <button onclick="loadHarness()" style="margin-left:auto;" class="btn-ghost" title="Refresh">&#8635;</button>
+    <button onclick="loadHarness()" style="margin-left:auto;" class="btn-ghost" title="Refresh">↻</button>
   </div>
   <!-- renderHarnessPanel() fills this from the selected runtime's template -->
   <div id="harness-container" class="card" style="padding:16px;">Loading harness view…</div>

--- a/clawmetry/templates/tabs/overview.html
+++ b/clawmetry/templates/tabs/overview.html
@@ -27,11 +27,11 @@
   <div id="activity-today-strip" style="display:none;background:var(--bg-secondary);border:1px solid var(--border-primary);border-radius:10px;padding:10px 16px;margin-bottom:10px;box-shadow:var(--card-shadow);">
     <div style="display:flex;gap:18px;flex-wrap:wrap;align-items:center;">
       <span style="font-size:11px;font-weight:700;color:var(--text-muted);text-transform:uppercase;letter-spacing:1.2px;">Today</span>
-      <span style="font-size:13px;color:var(--text-secondary);">&#128296; <b id="at-tool-calls" style="color:var(--text-primary);">0</b> tool calls</span>
-      <span style="font-size:13px;color:var(--text-secondary);">&#9889; <b id="at-exec-calls" style="color:var(--text-primary);">0</b> exec</span>
-      <span style="font-size:13px;color:var(--text-secondary);">&#127760; <b id="at-browser-actions" style="color:var(--text-primary);">0</b> browser</span>
-      <span style="font-size:13px;color:var(--text-secondary);">&#128172; <b id="at-messages" style="color:var(--text-primary);">0</b> messages</span>
-      <span style="font-size:13px;color:var(--text-secondary);">&#128295; <b id="at-unique-tools" style="color:var(--text-primary);">0</b> unique tools</span>
+      <span style="font-size:13px;color:var(--text-secondary);">🔨 <b id="at-tool-calls" style="color:var(--text-primary);">0</b> tool calls</span>
+      <span style="font-size:13px;color:var(--text-secondary);">⚡ <b id="at-exec-calls" style="color:var(--text-primary);">0</b> exec</span>
+      <span style="font-size:13px;color:var(--text-secondary);">🌐 <b id="at-browser-actions" style="color:var(--text-primary);">0</b> browser</span>
+      <span style="font-size:13px;color:var(--text-secondary);">💬 <b id="at-messages" style="color:var(--text-primary);">0</b> messages</span>
+      <span style="font-size:13px;color:var(--text-secondary);">🔧 <b id="at-unique-tools" style="color:var(--text-primary);">0</b> unique tools</span>
     </div>
   </div>
 
@@ -68,7 +68,7 @@
       <div id="eval-regression-line" style="font-size:12px;color:var(--text-muted);margin-top:6px;"></div>
     </div>
     <!-- QW7: setup lives behind a small gear icon; the title keeps the old label. -->
-    <button onclick="openEvalRubricModal()" title="Judge key &amp; rubric" data-i18n-title="overview.eval_setup" aria-label="Judge key &amp; rubric" style="background:var(--button-bg);color:var(--text-secondary);border:1px solid var(--border-primary);border-radius:8px;padding:6px 10px;font-size:14px;font-weight:600;cursor:pointer;white-space:nowrap;">&#9881;</button>
+    <button onclick="openEvalRubricModal()" title="Judge key &amp; rubric" data-i18n-title="overview.eval_setup" aria-label="Judge key &amp; rubric" style="background:var(--button-bg);color:var(--text-secondary);border:1px solid var(--border-primary);border-radius:8px;padding:6px 10px;font-size:14px;font-weight:600;cursor:pointer;white-space:nowrap;">⚙</button>
   </div>
 
   <!-- Named evaluator library. Brands ClawMetry's shipped quality / reliability
@@ -77,7 +77,7 @@
        catalogue is static data /api/evaluators returns with or without a store. -->
   <div id="evaluators-card" style="background:var(--bg-secondary);border:2px solid var(--border-primary);border-radius:12px;padding:18px 22px;margin-bottom:14px;box-shadow:var(--card-shadow);">
     <div style="display:flex;align-items:baseline;justify-content:space-between;gap:12px;flex-wrap:wrap;margin-bottom:4px;">
-      <div style="font-size:13px;font-weight:700;color:var(--text-muted);text-transform:uppercase;letter-spacing:1.5px;">&#128300; <span data-i18n="evaluators.title">Evaluators on your agent</span></div>
+      <div style="font-size:13px;font-weight:700;color:var(--text-muted);text-transform:uppercase;letter-spacing:1.5px;">🔬 <span data-i18n="evaluators.title">Evaluators on your agent</span></div>
       <div id="evaluators-count" style="font-size:11px;color:var(--text-muted);"></div>
     </div>
     <div style="font-size:12px;color:var(--text-muted);margin-bottom:12px;" data-i18n="evaluators.subtitle">Named checks ClawMetry runs to tell you if your agent is doing good work. Each one answers a plain question.</div>


### PR DESCRIPTION
tests/test_i18n_no_raw_codes.py::test_no_emoji_entities_in_templates has been failing on main for 4 templates (overview, harness, banners, overlays): emoji/arrow HTML entities render literally in SVG/textContent contexts. Converted exactly the flagged entities to real Unicode (named arrows + decimal >= U+2000; &mdash; deliberately untouched, no em-dashes introduced, verified in the diff). 72/72 tests in the file pass; dashboard boots and serves the glyphs.