### PR TITLE
fix: ingest openclaw doctor diagnostic findings (#3468)

### DIFF
--- a/clawmetry/adapters/openclaw.py
+++ b/clawmetry/adapters/openclaw.py
@@ -120,6 +120,39 @@ def _is_docker_runtime_down() -> Optional[bool]:
         return None
 
 
+def _openclaw_doctor_findings() -> list:
+    """Run ``openclaw doctor --json`` and return the list of structured
+    diagnostic findings (auth-profile, workspace, device-pairing,
+    channel-plugin, memory-provider, systemd-exhaustion, LAN-firewall).
+    Available since OpenClaw harness 2026.7.1 (#97125+). Returns [] when
+    openclaw is absent, the --json flag is unsupported, or output is not
+    valid JSON. Never raises.
+    """
+    try:
+        import shutil as _sh
+        if not _sh.which("openclaw"):
+            return []
+        import subprocess as _sp
+        res = _sp.run(
+            ["openclaw", "doctor", "--json"],
+            capture_output=True, text=True, timeout=15,
+        )
+        raw = (res.stdout or "").strip()
+        if not raw:
+            return []
+        import json as _json
+        data = _json.loads(raw)
+        if isinstance(data, list):
+            return data
+        if isinstance(data, dict):
+            for _key in ("findings", "results", "diagnostics"):
+                if isinstance(data.get(_key), list):
+                    return data[_key]
+        return []
+    except Exception:
+        return []
+
+
 def _real_install(sessions_dir: str) -> bool:
     """A genuine OpenClaw install signal, NOT the bare ~/.openclaw dir that
     ClawMetry itself creates as a scratch workspace. Any one of: the openclaw
@@ -980,6 +1013,13 @@ class OpenClawAdapter(AgentAdapter):
             _docker_down = _is_docker_runtime_down()
             if _docker_down is not None:
                 meta["dockerRuntimeDown"] = _docker_down
+            # Doctor findings (#3468): structured diagnostic findings from
+            # `openclaw doctor --json` (harness 2026.7.1). Categories:
+            # auth-profile, workspace, device-pairing, channel-plugin,
+            # memory-provider, systemd-exhaustion, Windows LAN-firewall.
+            _doctor = _openclaw_doctor_findings()
+            if _doctor:
+                meta["doctorFindings"] = _doctor
             return DetectResult(
                 name=self.name,
                 display_name=self.display_name,

--- a/routes/health.py
+++ b/routes/health.py
@@ -3596,3 +3596,22 @@ def api_audit_log():
             rows = []
 
     return jsonify({"entries": rows or [], "total": len(rows or [])})
+
+
+@bp_health.route("/api/doctor-findings")
+def api_doctor_findings():
+    """Return structured ``openclaw doctor`` diagnostic findings (#3468).
+
+    Runs ``openclaw doctor --json`` and surfaces the categorised findings
+    (auth-profile, workspace, device-pairing, channel-plugin, memory-provider,
+    systemd-exhaustion, Windows LAN-firewall) so the dashboard can show
+    misconfiguration alerts without the user having to run the CLI manually.
+    Returns ``{"findings": [], "count": 0}`` when openclaw is absent or the
+    harness version pre-dates the ``--json`` flag.
+    """
+    try:
+        from clawmetry.adapters.openclaw import _openclaw_doctor_findings
+        findings = _openclaw_doctor_findings()
+    except Exception:
+        findings = []
+    return jsonify({"findings": findings, "count": len(findings)})


### PR DESCRIPTION
Closes #3468

## Summary

- **`clawmetry/adapters/openclaw.py`** — adds `_openclaw_doctor_findings()` helper that runs `openclaw doctor --json` (harness 2026.7.1+) and parses the structured findings list. Wired into `detect()` as `meta["doctorFindings"]` when non-empty. Returns `[]` safely on older installs where `--json` is unsupported.
- **`routes/health.py`** — adds `GET /api/doctor-findings` endpoint that exposes the findings so the dashboard can surface auth-profile / workspace / device-pairing / channel-plugin / memory-provider / systemd-exhaustion / LAN-firewall alerts without requiring manual CLI use.

## Test plan

- `python3 -m py_compile clawmetry/adapters/openclaw.py routes/health.py` — both files compile clean
- `python3 -c "from clawmetry.adapters.openclaw import _openclaw_doctor_findings; assert isinstance(_openclaw_doctor_findings(), list)"` — helper returns `[]` gracefully when `openclaw` is absent (CI)
- `python3 -m pytest tests/test_obs_gap_talk_sandbox.py tests/test_openclaw_list_events.py tests/test_nemoclaw_runtime_adapter.py -q` — 71 passed, 2 pre-existing failures (test-interaction flake on main unrelated to this diff, confirmed by stash bisect)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KqgsirkbSMJDya4Vhv2Ec8)_