### PR TITLE
fix(process-control): TZ-safe pid-reuse guard for claude_code pause/kill (macOS, no psutil)

### DIFF
--- a/clawmetry/process_control.py
+++ b/clawmetry/process_control.py
@@ -27,7 +27,11 @@ The descendant walk handles a real gotcha found in recon: in-flight tool shells
 launched by a Node CLI are frequently *detached session leaders* with their OWN
 process-group id (``tty=??``). A single ``kill(-pgid, sig)`` against the parent's
 group misses them. So we enumerate the descendant tree by ``ppid`` (BFS) and
-signal each DISTINCT process group we find.
+signal each DISTINCT process group we find — but only groups OWNED EXCLUSIVELY
+by the session's tree. A pgid shared with outsiders (e.g. a parent orchestrator
+that spawned the CLI without a new session, or our own daemon) is never signaled
+wholesale; the session's pids in it are signaled individually instead. Freezing
+a shared group froze the calling orchestrator during mobile E2E (2026-07-02).
 
 cursor is explicitly UNSUPPORTED for per-session signals: one IDE process holds
 all sessions, so signaling it would freeze every session and the editor. We
@@ -157,6 +161,9 @@ def _proc_start_token(pid: int) -> Optional[str]:
         # recorded by claude_code is an ISO/epoch with sub-second jitter we must
         # not let trip the guard.
         return f"epoch:{int(round(epoch))}"
+    # NOTE: an ``lstart:``/``raw:`` token is NOT directly comparable to an
+    # ``epoch:`` token (or to a ctime string rendered in a different timezone);
+    # verify_pid additionally runs _start_tokens_equivalent to bridge the forms.
     if _IS_MACOS:
         out = _run(["ps", "-o", "lstart=", "-p", str(int(pid))], timeout=5)
         if out is not None:
@@ -202,6 +209,61 @@ def _normalize_recorded_start(recorded: Any) -> Optional[str]:
         return f"raw:{s}"
 
 
+def _ctime_epoch_candidates(s: str) -> Set[int]:
+    """Epoch candidates for a ctime-style string ("Thu Jul  2 04:26:55 2026")
+    under BOTH a UTC and a local-time interpretation.
+
+    claude_code writes ``procStart`` as a ctime string rendered in UTC, while
+    macOS ``ps -o lstart=`` prints the process start in LOCAL time. On any
+    non-UTC host the two strings for the same instant never match textually, so
+    we parse to epochs under both interpretations and let the caller intersect.
+    An unparseable string yields an empty set (the guard then fails closed).
+    """
+    import calendar
+    import datetime as _dt
+
+    out: Set[int] = set()
+    try:
+        # Collapse ctime's day-of-month double space so strptime is happy.
+        dt = _dt.datetime.strptime(
+            " ".join(str(s).split()), "%a %b %d %H:%M:%S %Y"
+        )
+    except Exception:  # noqa: BLE001
+        return out
+    tt = dt.timetuple()
+    out.add(int(calendar.timegm(tt)))  # UTC interpretation
+    try:
+        out.add(int(time.mktime(tt)))  # local-time interpretation
+    except Exception:  # noqa: BLE001 - mktime can overflow on exotic dates
+        pass
+    return out
+
+
+def _start_tokens_equivalent(want: str, have: str, tol: int = 3) -> bool:
+    """True when two start-time tokens plausibly denote the SAME instant even
+    though their string forms differ (``epoch:`` vs ``lstart:`` vs ``raw:``
+    ctime, UTC vs local timezone).
+
+    ``tol`` covers lstart's 1s resolution plus sub-second rounding. Tokens that
+    cannot be reduced to at least one epoch candidate never match, so the
+    pid-reuse guard still fails closed on garbage.
+    """
+
+    def cands(tok: str) -> Set[int]:
+        tok = (tok or "").strip()
+        if tok.startswith("epoch:"):
+            try:
+                return {int(round(float(tok[6:])))}
+            except ValueError:
+                return set()
+        if tok.startswith(("lstart:", "raw:")):
+            return _ctime_epoch_candidates(tok.split(":", 1)[1])
+        return set()
+
+    a, b = cands(want), cands(have)
+    return any(abs(x - y) <= tol for x in a for y in b)
+
+
 def is_alive(pid: int) -> bool:
     """True iff ``pid`` is a live process we can address. Never raises."""
     if pid is None or pid <= 0:
@@ -239,6 +301,11 @@ def verify_pid(pid: int, recorded_start: Any = None) -> Tuple[bool, str]:
         return True, "recorded_start_unparseable_but_alive"
     if want == have:
         return True, "verified"
+    if _start_tokens_equivalent(want, have):
+        # Same instant, different renderings: claude_code records procStart as
+        # a UTC ctime string while macOS `ps -o lstart=` prints local time, so
+        # on a non-UTC Mac without psutil the raw tokens NEVER compare equal.
+        return True, "verified_tz_normalized"
     return False, f"start_mismatch(recorded={want},live={have})"
 
 
@@ -413,6 +480,29 @@ def _distinct_pgids(pids: List[int]) -> List[int]:
     return out
 
 
+def _pgid_member_map() -> Dict[int, Set[int]]:
+    """Map pgid -> set of member pids across the WHOLE process table (via ps).
+
+    Used to decide whether a process group is owned exclusively by a session's
+    tree before group-signaling it. Empty / missing entries mean membership is
+    UNKNOWN; callers must treat unknown as shared and signal per-pid instead.
+    """
+    members: Dict[int, Set[int]] = {}
+    for cpid, _ppid, pgid in _all_procs_ps():
+        if pgid > 0:
+            members.setdefault(pgid, set()).add(cpid)
+    return members
+
+
+def _own_pgid() -> int:
+    """The calling process's own pgid (-1 if unreadable). We must never
+    group-signal our own group: SIGSTOP would freeze the daemon itself."""
+    try:
+        return os.getpgrp()
+    except Exception:  # noqa: BLE001
+        return -1
+
+
 # ──────────────────────────────────────────────────────────────────────────
 # Signal helpers
 # ──────────────────────────────────────────────────────────────────────────
@@ -514,25 +604,37 @@ def pause(pid: int, runtime: str = "") -> Dict[str, Any]:
         return _result(False, "pause", pid, runtime, "pid_not_alive")
 
     pids = process_set(pid)  # children first, parent last
+    pid_set = set(pids)
     pgids = _distinct_pgids(pids)
+    members = _pgid_member_map()
+    own = _own_pgid()
     stopped_pgids: List[int] = []
+    shared_pgids: List[int] = []
     for g in pgids:
+        mem = members.get(g)
+        # Group-signal ONLY a pgid owned exclusively by the session's tree. A
+        # group shared with outsiders (e.g. a parent orchestrator that spawned
+        # the CLI without a new session), our own group, or a group whose
+        # membership we cannot determine must never be frozen wholesale:
+        # SIGSTOP-ing a shared group froze the calling orchestrator during
+        # mobile E2E (2026-07-02). Session pids in it are stopped per-pid below.
+        if g == own or not mem or (mem - pid_set):
+            shared_pgids.append(g)
+            continue
         if _signal_pid(-g, signal.SIGSTOP):
             stopped_pgids.append(g)
-    # Belt-and-braces: also SIGSTOP any individual pid whose pgid we couldn't
-    # resolve (e.g. ps lacked pgid), so nothing in the tree escapes the freeze.
-    covered = set()
-    for g in pgids:
-        for p in pids:
-            if _pgid_of(p) == g:
-                covered.add(p)
+    # Per-pid coverage for everything not frozen via an exclusive group: session
+    # pids inside shared groups, plus pids whose pgid we couldn't resolve.
+    covered: Set[int] = set()
+    for g in stopped_pgids:
+        covered |= members.get(g, set())
     for p in pids:
         if p not in covered and is_alive(p):
             _signal_pid(p, signal.SIGSTOP)
     ok = bool(stopped_pgids) or bool(pids)
     return _result(ok, "pause", pid, runtime,
                    "paused" if ok else "nothing_to_pause",
-                   pgids=stopped_pgids, pids=pids)
+                   pgids=stopped_pgids, pids=pids, shared_pgids=shared_pgids)
 
 
 def resume(pid: int, runtime: str = "") -> Dict[str, Any]:
@@ -544,13 +646,21 @@ def resume(pid: int, runtime: str = "") -> Dict[str, Any]:
     # Note: a SIGSTOP'd process IS still alive (os.kill(pid,0) succeeds), so the
     # alive check here is meaningful.
     pids = process_set(pid)
+    pid_set = set(pids)
     pgids = _distinct_pgids(pids)
+    members = _pgid_member_map()
+    own = _own_pgid()
     resumed_pgids: List[int] = []
     for g in reversed(pgids):  # parent group first
+        mem = members.get(g)
+        if g == own or not mem or (mem - pid_set):
+            # Shared / unknown-membership group (mirror of pause): never
+            # group-signal it; the per-pid SIGCONT below wakes the session pids.
+            continue
         if _signal_pid(-g, signal.SIGCONT):
             resumed_pgids.append(g)
     for p in reversed(pids):
-        # Cover any pid whose pgid wasn't resolvable.
+        # Cover shared groups and any pid whose pgid wasn't resolvable.
         _signal_pid(p, signal.SIGCONT)
     ok = bool(resumed_pgids) or bool(pids)
     return _result(ok, "resume", pid, runtime,
@@ -608,10 +718,18 @@ def claude_code_session_map() -> Dict[str, Dict[str, Any]]:
             pid = int(pid)
         except (TypeError, ValueError):
             continue
+        # Prefer startedAt (an epoch, timezone-unambiguous) over procStart (a
+        # ctime string claude_code renders in UTC, which cannot be compared
+        # textually against local-time `ps -o lstart=` output on non-UTC hosts).
+        start: Any = rec.get("startedAt")
+        if isinstance(start, bool) or not isinstance(start, (int, float)) or start <= 0:
+            start = None
+        elif start > 1e12:  # epoch in milliseconds
+            start = start / 1000.0
         out[str(sid)] = {
             "pid": pid,
             "cwd": rec.get("cwd"),
-            "procStart": rec.get("procStart"),
+            "procStart": start if start is not None else rec.get("procStart"),
             "status": rec.get("status"),
             "version": rec.get("version"),
         }

--- a/tests/test_process_control.py
+++ b/tests/test_process_control.py
@@ -339,3 +339,160 @@ def test_stop_turn_sends_sigint(spawned):
     # Default SIGINT handler raises KeyboardInterrupt -> the child exits. Reap.
     assert _reaped(p), res
     assert p.returncode is not None
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# TZ-safe start-time guard (macOS-without-psutil bug, found in mobile E2E)
+# ──────────────────────────────────────────────────────────────────────────
+@pytest.fixture
+def berlin_tz():
+    """Run the test in a non-UTC timezone (Europe/Berlin) so the UTC-vs-local
+    ctime rendering skew actually manifests, then restore the original TZ."""
+    if not hasattr(time, "tzset"):
+        pytest.skip("time.tzset required (POSIX only)")
+    old = os.environ.get("TZ")
+    os.environ["TZ"] = "Europe/Berlin"
+    time.tzset()
+    yield
+    if old is None:
+        os.environ.pop("TZ", None)
+    else:
+        os.environ["TZ"] = old
+    time.tzset()
+
+
+def test_verify_pid_tz_normalized_ctime(berlin_tz, monkeypatch):
+    """THE regression: claude_code records procStart as a UTC ctime string,
+    while macOS `ps -o lstart=` (the no-psutil fallback) prints LOCAL time.
+    On any non-UTC Mac the raw tokens can never be equal, so the pid-reuse
+    guard refused every pause/kill/resume. Same instant must now verify."""
+    epoch = 1751430415  # fixed instant (2026-07-02, DST active in Berlin)
+    recorded = time.asctime(time.gmtime(epoch))            # what claude_code writes
+    live = "lstart:" + time.asctime(time.localtime(epoch))  # what ps prints
+    assert recorded not in live  # sanity: the strings really do differ in Berlin
+    monkeypatch.setattr(pc, "_proc_start_token", lambda _pid: live)
+    ok, reason = pc.verify_pid(os.getpid(), recorded_start=recorded)
+    assert ok is True, reason
+    assert reason == "verified_tz_normalized"
+
+
+def test_verify_pid_tz_guard_still_refuses_different_start(berlin_tz, monkeypatch):
+    """A genuinely different process start (offset that is NOT a whole timezone
+    offset) must still REFUSE — the TZ bridge must not weaken the reuse guard."""
+    epoch = 1751430415
+    recorded = time.asctime(time.gmtime(epoch))
+    live = "lstart:" + time.asctime(time.localtime(epoch - 12345))
+    monkeypatch.setattr(pc, "_proc_start_token", lambda _pid: live)
+    ok, reason = pc.verify_pid(os.getpid(), recorded_start=recorded)
+    assert ok is False
+    assert reason.startswith("start_mismatch"), reason
+
+
+def test_start_tokens_unparseable_fail_closed():
+    # Garbage on either side yields no epoch candidates -> never equivalent.
+    assert pc._start_tokens_equivalent("raw:garbage", "lstart:also garbage") is False
+    assert pc._start_tokens_equivalent("", "") is False
+    assert pc._start_tokens_equivalent("epoch:notanumber", "epoch:123") is False
+    # Plain epoch tokens still compare within tolerance.
+    assert pc._start_tokens_equivalent("epoch:1000", "epoch:1002") is True
+    assert pc._start_tokens_equivalent("epoch:1000", "epoch:1010") is False
+
+
+def test_claude_session_map_prefers_started_at_epoch(tmp_path, monkeypatch):
+    """When claude_code provides startedAt (epoch ms, timezone-unambiguous) the
+    map must prefer it over the ambiguous procStart ctime string."""
+    import json
+
+    sessions_dir = tmp_path / "sessions"
+    sessions_dir.mkdir()
+    (sessions_dir / "12345.json").write_text(json.dumps({
+        "pid": 12345,
+        "sessionId": "sid-startedat",
+        "startedAt": 1751430415123,  # ms
+        "procStart": "Thu Jul  2 04:26:55 2026",
+        "status": "running",
+    }))
+    (sessions_dir / "12346.json").write_text(json.dumps({
+        "pid": 12346,
+        "sessionId": "sid-ctime-only",
+        "procStart": "Thu Jul  2 04:26:55 2026",
+        "status": "running",
+    }))
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path))
+    m = pc.claude_code_session_map()
+    assert m["sid-startedat"]["procStart"] == pytest.approx(1751430415.123)
+    # Without startedAt the ctime string still flows through (TZ bridge handles it).
+    assert m["sid-ctime-only"]["procStart"] == "Thu Jul  2 04:26:55 2026"
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# pause must not freeze a process group shared with the caller
+# ──────────────────────────────────────────────────────────────────────────
+def _read_until(proc, marker: str, timeout: float) -> str:
+    """Accumulate proc.stdout (non-blocking) until ``marker`` appears or the
+    deadline passes. Bounded; never hangs the test runner."""
+    import select
+
+    fd = proc.stdout.fileno()
+    buf = ""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if marker in buf:
+            return buf
+        r, _, _ = select.select([fd], [], [], 0.1)
+        if r:
+            chunk = os.read(fd, 4096)
+            if not chunk:
+                break
+            buf += chunk.decode("utf-8", "replace")
+    return buf
+
+
+@posix_only
+def test_pause_does_not_freeze_group_sharing_orchestrator():
+    """Second mobile-E2E finding: pause() SIGSTOP'd the target's whole process
+    GROUP, freezing a parent orchestrator that shared the group. An orchestrator
+    that spawns the agent WITHOUT a new session (same pgid) must survive its own
+    pause() call; the child must still stop."""
+    repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    script = (
+        "import os, subprocess, sys, time\n"
+        f"sys.path.insert(0, {repo_root!r})\n"
+        "import clawmetry.process_control as pc\n"
+        "# child shares OUR pgid (no start_new_session) — the E2E topology\n"
+        "child = subprocess.Popen([sys.executable, '-c', 'import time; time.sleep(120)'])\n"
+        "time.sleep(0.3)\n"
+        "print('CHILD', child.pid, flush=True)\n"
+        "res = pc.pause(child.pid)\n"
+        "print('SURVIVED', res.get('ok'), flush=True)\n"
+        "time.sleep(120)\n"
+    )
+    orch = subprocess.Popen(
+        [sys.executable, "-c", script],
+        start_new_session=True,  # isolate from pytest's own group
+        stdout=subprocess.PIPE,
+    )
+    try:
+        out = _read_until(orch, "SURVIVED", timeout=15.0)
+        assert "CHILD " in out, f"orchestrator never spawned a child: {out!r}"
+        child_pid = int(out.split("CHILD", 1)[1].split()[0])
+        # Un-fixed code SIGSTOPs the shared group, freezing the orchestrator
+        # mid-call, so SURVIVED never prints and its state goes to T.
+        assert "SURVIVED" in out, (
+            f"orchestrator froze during its own pause() call "
+            f"(state={_proc_state(orch.pid)!r}, out={out!r})"
+        )
+        assert _proc_state(orch.pid) != "T", "orchestrator was SIGSTOP'd"
+        # The actual target must still be frozen.
+        assert _wait_state(child_pid, "T", timeout=3.0) == "T"
+    finally:
+        # Wake + tear down the whole orchestrator group (covers the child too).
+        for sig_ in (signal.SIGCONT, signal.SIGKILL):
+            try:
+                os.killpg(os.getpgid(orch.pid), sig_)
+            except Exception:
+                pass
+        try:
+            orch.wait(timeout=5)
+        except Exception:
+            pass


### PR DESCRIPTION
## The bug (found during mobile-app E2E, 2026-07-02, verified live)

On macOS **without psutil**, the pid-reuse guard in `clawmetry/process_control.py` could NEVER pass for claude_code sessions:

- claude_code writes `procStart` into `~/.claude/sessions/<pid>.json` as a **ctime string rendered in UTC** (e.g. `Thu Jul  2 04:26:55 2026`).
- The guard compares it against the live process start from `ps -o lstart=`, which prints **local time**, and the two sides carry mismatched token prefixes (`raw:` vs `lstart:`).
- On any non-UTC Mac the strings can never be equal, so `verify_pid` always returned `start_mismatch` and pause/kill/resume from the web dashboard, the desk device, and the new mobile apps **silently no-oped**.

A hotfix was validated on the discovering machine's installed daemon; this PR upstreams a clean version.

## The fix

1. **Prefer `startedAt`** (epoch ms, timezone-unambiguous) over `procStart` when building the claude_code session map.
2. **TZ-normalized token equivalence**: when tokens differ textually, `_start_tokens_equivalent` reduces both sides to UTC-epoch candidates (`epoch:` parsed directly; `lstart:`/`raw:` ctime parsed under BOTH a UTC and a local-time interpretation) and accepts a match within a 3s tolerance (`verified_tz_normalized`), covering lstart's 1s resolution.
3. **Safety intent preserved (fail closed)**: an unparseable token yields zero epoch candidates, so garbage still refuses with `start_mismatch`, exactly as before. A genuinely different process start still refuses (covered by a test using a non-TZ-multiple offset so cross-interpretation ambiguity cannot false-match).

## Second E2E finding: pause froze a group-sharing orchestrator (fixed here, safely contained)

`pause()` SIGSTOP'd every distinct process **group** in the descendant tree. When a parent orchestrator spawned the agent without a new session (shared pgid), the group signal froze the orchestrator too (observed live during E2E). Fix is contained to `pause()`/`resume()`:

- Group-signal only pgids whose full membership (from the process table) is **exclusively** inside the session's tree; never the caller's own pgid; unknown membership counts as shared.
- Session pids inside shared groups are SIGSTOP/SIGCONT'd **individually** (SIGSTOP is uncatchable, so the target still freezes), so coverage of the session tree is unchanged while outsiders are never signaled.

## Revert-proof (guard ships in the same PR)

The 5 new tests were run against the **un-fixed** module (`git stash` the fix, run, restore): **4 failed red**, including:

- `test_verify_pid_tz_normalized_ctime`: reproduces the exact failure with `TZ=Europe/Berlin` + `time.tzset()`, a UTC ctime procStart vs a local-TZ lstart for the same instant; red on old code (`start_mismatch`), green on fixed (`verified_tz_normalized`).
- `test_pause_does_not_freeze_group_sharing_orchestrator`: on old code the orchestrator froze mid-`pause()` call (`state='T'`, never printed its survival marker); green on fixed.
- `test_claude_session_map_prefers_started_at_epoch`, `test_start_tokens_unparseable_fail_closed`: red on old code.
- `test_verify_pid_tz_guard_still_refuses_different_start` (negative safety test) passes on both, as intended.

After restoring the fix: full `tests/test_process_control.py` + `tests/test_sync_process_control_dispatch.py` suites pass (27 passed) on Python 3.9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)