### PR TITLE
fix(agents): pin + label the selected runtime's roster row (switcher legibility)

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -8671,12 +8671,23 @@ function _invRosterRow(a, rtFilter) {
   var work = (a.sessions || 0) + ((a.sessions === 1) ? ' conversation' : ' conversations');
   var model = a.primaryModel || '--';
   var highlight = (rtFilter !== 'all' && rt === rtFilter) ? ' inv-row-active' : '';
+  // When the row is only visible BECAUSE it is the selected runtime (it had no
+  // activity in 24h and would otherwise sit in the inactive fold), say so.
+  // Without this chip the roster looks like it shows different data on every
+  // switcher change (founder report 2026-07-02).
+  var selectedChip = '';
+  if (rtFilter !== 'all' && rt === rtFilter && !_invIsRecentlyActive(a, 'all')) {
+    selectedChip = ' <span class="inv-selected-chip" '
+      + 'title="' + t('inventory.selected_chip_tip', null, 'Shown because this runtime is selected in the switcher. No activity in the last 24h.') + '" '
+      + 'style="font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:0.5px;padding:2px 7px;border-radius:9px;background:rgba(99,102,241,0.15);border:1px solid rgba(99,102,241,0.4);color:#818cf8;vertical-align:middle;">'
+      + t('inventory.selected_chip', null, 'selected') + '</span>';
+  }
   var pencil = window.CLOUD_MODE
     ? ''
     : '<span class="inv-owner-pencil" title="Rename owner" onclick="event.stopPropagation();_invStartOwnerEdit(this,\'' + escHtml(rt) + '\')">&#9998;</span>';
   return ''
     + '<tr class="inv-row' + highlight + '" data-rt="' + escHtml(rt) + '" onclick="_invToggleRow(this,\'' + escHtml(rt) + '\')">'
-    +   '<td class="inv-c-agent"><span class="inv-dot" style="background:' + dot.color + '"></span>' + escHtml(label) + '</td>'
+    +   '<td class="inv-c-agent"><span class="inv-dot" style="background:' + dot.color + '"></span>' + escHtml(label) + selectedChip + '</td>'
     +   '<td class="inv-c-owner"><span class="inv-owner-chip" data-rt="' + escHtml(rt) + '"><span class="inv-owner-name">' + escHtml(owner) + '</span>' + pencil + '</span></td>'
     +   '<td class="inv-c-doing"><span class="inv-doing ' + doing.cls + '">' + doing.txt + '</span></td>'
     +   '<td class="inv-c-alive"><span class="inv-dot" style="background:' + dot.color + '"></span>'
@@ -8701,6 +8712,15 @@ function _invRenderRoster(inv) {
   // Never end up with an empty roster: if nothing is "active" right now, show
   // everything rather than an empty table.
   if (!active.length && inactive.length) { active = inactive; inactive = []; }
+  // Consistent ordering: the selected runtime is always the FIRST row. Without
+  // this the promoted row lands wherever the roster order puts it (OpenClaw
+  // above Claude Code, Hermes below), which reads as the list changing
+  // arbitrarily on every switcher change.
+  if (rtFilter !== 'all') {
+    active.sort(function (a, b) {
+      return (b.agentKey === rtFilter ? 1 : 0) - (a.agentKey === rtFilter ? 1 : 0);
+    });
+  }
   var rows = active.map(function (a) { return _invRosterRow(a, rtFilter); }).join('');
   var foldRows = '';
   if (inactive.length) {

--- a/clawmetry/static/locales/en.json
+++ b/clawmetry/static/locales/en.json
@@ -658,6 +658,8 @@
   "history.to": "to",
   "history.token_usage_over_time": "Token Usage Over Time",
   "i18n.language": "Language",
+  "inventory.selected_chip": "selected",
+  "inventory.selected_chip_tip": "Shown because this runtime is selected in the switcher. No activity in the last 24h.",
   "inventory.title": "Your agents",
   "inventory.story": "A calm, one-glance view of every agent on this machine: what it runs, what it costs, and whether it is alive.",
   "inventory.tile_alive": "Alive",

--- a/tests/test_inventory_selected_legibility.py
+++ b/tests/test_inventory_selected_legibility.py
@@ -1,0 +1,69 @@
+"""Guards for the Agents-roster legibility fix (founder report 2026-07-02).
+
+The roster is node-wide by design; the runtime switcher promotes the selected
+runtime's row out of the "Show N inactive" fold (_invIsRecentlyActive counts
+"is the selected runtime" as active). Two legibility bugs made that read as
+"the tab shows different data on every dropdown change":
+
+  1. the promoted row landed wherever roster order put it (OpenClaw above
+     Claude Code, Hermes below) - unstable ordering;
+  2. nothing explained WHY an idle runtime's row suddenly appeared.
+
+Fix: the selected runtime is always the FIRST row, and a "selected" chip (with
+a plain-words tooltip) marks a row that is only visible because it is selected.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_APP_JS = os.path.join(_HERE, "..", "clawmetry", "static", "js", "app.js")
+_EN_JSON = os.path.join(_HERE, "..", "clawmetry", "static", "locales", "en.json")
+
+
+def _read(path):
+    with open(path, encoding="utf-8") as fh:
+        return fh.read()
+
+
+def _fn(js, name):
+    start = js.find("function " + name)
+    assert start != -1, name + " missing"
+    nxt = js.find("\nfunction ", start + 1)
+    a = js.find("\nasync function ", start + 1)
+    ends = [x for x in (nxt, a) if x != -1]
+    return js[start:min(ends) if ends else start + 20000]
+
+
+def test_selected_runtime_pinned_first():
+    body = _fn(_read(_APP_JS), "_invRenderRoster")
+    assert "active.sort" in body and "agentKey === rtFilter" in body, (
+        "the selected runtime's row must be pinned to the top of the active "
+        "list - unstable ordering reads as the roster changing arbitrarily"
+    )
+
+
+def test_promoted_row_carries_selected_chip():
+    body = _fn(_read(_APP_JS), "_invRosterRow")
+    assert "inv-selected-chip" in body, "promoted row must carry the selected chip"
+    # The chip only marks rows visible BECAUSE they are selected (idle otherwise).
+    assert "_invIsRecentlyActive(a, 'all')" in body, (
+        "the chip must check activity WITHOUT the selected-runtime promotion "
+        "(rtFilter 'all'), so genuinely-active selected rows are not mislabeled"
+    )
+
+
+def test_promotion_rule_unchanged():
+    """The deliberate promotion itself stays (a selected runtime must be
+    visible), this fix only makes it legible."""
+    body = _fn(_read(_APP_JS), "_invIsRecentlyActive")
+    assert "a.agentKey === rtFilter" in body
+
+
+def test_i18n_keys():
+    en = json.load(open(_EN_JSON, encoding="utf-8"))
+    assert en.get("inventory.selected_chip") == "selected"
+    assert "inventory.selected_chip_tip" in en


### PR DESCRIPTION
## Why
Founder report: the Agents tab looked like it showed different data on every runtime-dropdown change (screenshots: claude_code -> 1 row/8 inactive; openclaw -> OpenClaw above Claude Code/7 inactive; hermes/qwen -> below Claude Code/7 inactive).

## Root cause
Not a data bug - the per-row numbers are identical across selections. The roster is node-wide by design, and `_invIsRecentlyActive` deliberately counts "is the selected runtime" as active so the selected row is visible instead of buried in the "Show N inactive" fold. But the promotion was illegible: unstable ordering (the promoted row landed wherever roster order put it) and no explanation of why an idle row appeared (and why the inactive count moved 8 -> 7).

## Fix (behavior kept, legibility added)
- The selected runtime's row is always the **first** row.
- A small **"selected"** chip with a plain-words tooltip marks a row that is visible only because it is selected (checked without the promotion, so genuinely-active selected rows are not mislabeled).

## Verification
- Live browser render with a founder-like roster: every selection pins the selected row first; the chip shows on idle-promoted rows (hermes/openclaw/qwen_code) and not on the genuinely-active claude_code. Screenshot in the run.
- `tests/test_inventory_selected_legibility.py` (4 guards; the sort guard revert-proven red -> green). `node --check` clean; en.json +2 keys (autotranslate syncs locales).
