### PR TITLE
fix: surface per-conversation capabilityProfile in Session.extra

### DIFF
--- a/clawmetry/adapters/openclaw.py
+++ b/clawmetry/adapters/openclaw.py
@@ -1155,6 +1155,15 @@ class OpenClawAdapter(AgentAdapter):
             _zai = s.get("zaiBaseUrl") or s.get("synthesizedModelBaseUrl") or s.get("glm5BaseUrl")
             if _zai is not None:
                 extra["zaiBaseUrl"] = _zai
+            # Per-conversation capability profile (#3469): PR #98536 adds
+            # capabilityProfile / conversationCapability to session records
+            # (OpenClaw harness 2026.7.1, "Safer scoped conversations").
+            _cap_profile = (
+                s.get("capabilityProfile")
+                or s.get("conversationCapability")
+            )
+            if _cap_profile is not None:
+                extra["capabilityProfile"] = _cap_profile
             tok_total = int(s.get("totalTokens") or 0)
             tok_in = int(s.get("inputTokens") or 0)
             tok_out = int(s.get("outputTokens") or 0)
@@ -1365,6 +1374,13 @@ class OpenClawAdapter(AgentAdapter):
                             _zai = obj.get("zaiBaseUrl") or obj.get("synthesizedModelBaseUrl") or obj.get("glm5BaseUrl")
                             if _zai is not None:
                                 extra["zaiBaseUrl"] = _zai
+                            # Per-conversation capability profile (#3469): PR #98536.
+                            _cap_profile = (
+                                obj.get("capabilityProfile")
+                                or obj.get("conversationCapability")
+                            )
+                            if _cap_profile is not None:
+                                extra["capabilityProfile"] = _cap_profile
                             # Normalized TTFR keys (#3054): also write ttfr_ms /
                             # slow_reply so callers that read the normalized form
                             # don't need to know the original key spellings.

--- a/dashboard.py
+++ b/dashboard.py
@@ -16487,6 +16487,7 @@ def _get_sessions():
                     "title": s.get("title") or "",
                     "costStatus": s.get("costStatus") or "",
                     "target": s.get("target") or s.get("identityTarget"),
+                    "capabilityProfile": s.get("capabilityProfile") or s.get("conversationCapability"),
                 }
             )
         _sessions_cache["data"] = sessions

--- a/tests/test_obs_gap_openclaw_capability_profile_3469.py
+++ b/tests/test_obs_gap_openclaw_capability_profile_3469.py
@@ -1,0 +1,86 @@
+"""Regression tests for issue #3469.
+
+OpenClaw PR #98536 (harness 2026.7.1, "Safer scoped conversations") added
+per-conversation capability profiles.  ClawMetry was not reading them:
+``list_sessions()`` never placed ``capabilityProfile`` in ``Session.extra``
+and ``list_events()`` did not extract it from the event data blob.
+"""
+
+import json
+
+from clawmetry.adapters.openclaw import OpenClawAdapter
+import clawmetry.adapters.openclaw as ocmod
+
+
+class _FakeDash:
+    def __init__(self, key="capabilityProfile", val="restricted"):
+        self._key = key
+        self._val = val
+
+    def _get_sessions(self):
+        return [{"sessionId": "sess-cap-1", self._key: self._val}]
+
+
+def test_list_sessions_surfaces_capability_profile(monkeypatch):
+    monkeypatch.setattr(ocmod, "_d", lambda: _FakeDash("capabilityProfile", "restricted"))
+    sessions = OpenClawAdapter().list_sessions(limit=10)
+    assert len(sessions) == 1
+    assert sessions[0].extra.get("capabilityProfile") == "restricted", (
+        "list_sessions() must propagate 'capabilityProfile' into Session.extra"
+    )
+
+
+def test_list_sessions_surfaces_conversation_capability_alias(monkeypatch):
+    monkeypatch.setattr(
+        ocmod, "_d", lambda: _FakeDash("conversationCapability", "scoped-read-only")
+    )
+    sessions = OpenClawAdapter().list_sessions(limit=10)
+    assert sessions[0].extra.get("capabilityProfile") == "scoped-read-only", (
+        "list_sessions() must also handle the 'conversationCapability' alias"
+    )
+
+
+def test_list_sessions_omits_capability_profile_when_absent(monkeypatch):
+    class _NoDash:
+        def _get_sessions(self):
+            return [{"sessionId": "sess-cap-2"}]
+
+    monkeypatch.setattr(ocmod, "_d", lambda: _NoDash())
+    sessions = OpenClawAdapter().list_sessions(limit=10)
+    assert "capabilityProfile" not in sessions[0].extra, (
+        "capabilityProfile must not appear in extra when the upstream record omits it"
+    )
+
+
+def test_list_events_surfaces_capability_profile(monkeypatch):
+    data = json.dumps({"capabilityProfile": "restricted"})
+
+    class _FakeStore:
+        def _fetch(self, sql, params):
+            # id, event_type, ts, model, token_count, data, agent_id, node_id
+            return [("e-cap-1", "message", "0", None, 0, data, "main", None)]
+
+    import clawmetry.local_store as ls
+    monkeypatch.setattr(ls, "get_store", lambda read_only=True: _FakeStore())
+
+    events = OpenClawAdapter().list_events("sess-cap-1", limit=10)
+    assert len(events) == 1
+    assert events[0].extra.get("capabilityProfile") == "restricted", (
+        "list_events() must extract 'capabilityProfile' from the data blob into extra"
+    )
+
+
+def test_list_events_surfaces_conversation_capability_alias(monkeypatch):
+    data = json.dumps({"conversationCapability": "scoped-read-only"})
+
+    class _FakeStore:
+        def _fetch(self, sql, params):
+            return [("e-cap-2", "message", "0", None, 0, data, "main", None)]
+
+    import clawmetry.local_store as ls
+    monkeypatch.setattr(ls, "get_store", lambda read_only=True: _FakeStore())
+
+    events = OpenClawAdapter().list_events("sess-cap-2", limit=10)
+    assert events[0].extra.get("capabilityProfile") == "scoped-read-only", (
+        "list_events() must also handle the 'conversationCapability' alias in the blob"
+    )


### PR DESCRIPTION
Closes #3469

## Summary

- **`clawmetry/adapters/openclaw.py`** — in `list_sessions()`, extract `capabilityProfile` (with `conversationCapability` as alias) from the gateway session dict into `Session.extra`, following the established `if _v is not None: extra[k] = _v` pattern. Same extraction added in `list_events()` for the event data blob.
- **`dashboard.py`** — in `_get_sessions()`, pass `capabilityProfile`/`conversationCapability` through the session normalization dict so `list_sessions()` can read it from `s`.
- **`tests/test_obs_gap_openclaw_capability_profile_3469.py`** (new) — 5 tests covering: field surfaces in `Session.extra` via both key spellings, absent when not present, and extracted from event data blob via both spellings.

## Test plan

- `python3 -m pytest tests/test_obs_gap_openclaw_capability_profile_3469.py -v` — 3 `list_sessions` tests pass locally; 2 `list_events` tests require `duckdb` (same pattern as all other `list_events` obs-gap tests in the repo, which pass in CI)
- `python3 -m py_compile clawmetry/adapters/openclaw.py dashboard.py` — syntax clean

---
_Generated by [Claude Code](https://claude.ai/code/session_018KB2xRmmyDNLH8uCznK4iA)_