### PR TITLE
fix(security): surface DNS-backed HTTPS fail-closed denial events as a distinct signal

### DIFF
--- a/clawmetry/adapters/openclaw.py
+++ b/clawmetry/adapters/openclaw.py
@@ -358,6 +358,38 @@ def _openshell_sandbox_logs(name: str, count: int = 20) -> list:
         return []
 
 
+def _sandbox_egress_denied_count(name: str, count: int = 100) -> dict:
+    """Count DNS-backed HTTPS fail-closed denial events in recent sandbox OCSF logs.
+
+    Fetches the <count> most-recent OCSF audit events for sandbox <name> and
+    counts those with verdict=='deny' that carry a network-egress context:
+    either an OCSF network-activity class_uid (4001-4004) or the presence of
+    endpoint fields (dst_endpoint / src_endpoint) that imply a connection
+    attempt.  Returns {"egressDeniedCount": N} when N>0 so callers can
+    .update() a sandbox entry dict directly; returns {} otherwise -- identical
+    to the _openshell_sandbox_ocsf_enabled() contract.  Never raises.
+    """
+    _NETWORK_CLASS_UIDS = frozenset([4001, 4002, 4003, 4004])
+    try:
+        events = _openshell_sandbox_logs(name, count=count)
+        denied = 0
+        for evt in events:
+            if not isinstance(evt, dict):
+                continue
+            if evt.get("verdict") != "deny":
+                continue
+            class_uid = evt.get("class_uid")
+            if class_uid in _NETWORK_CLASS_UIDS:
+                denied += 1
+            elif "dst_endpoint" in evt or "src_endpoint" in evt:
+                denied += 1
+        if denied:
+            return {"egressDeniedCount": denied}
+        return {}
+    except Exception:
+        return {}
+
+
 def _openshell_sandbox_logs_tail(name: str):
     """Spawn ``openshell logs <name> --source all --tail`` as a long-lived child
     process and return the ``subprocess.Popen`` handle.
@@ -453,6 +485,7 @@ def _sandbox_inference_configs() -> list:
                 }
                 entry.update(_openshell_sandbox_phase_policy(name))
                 entry.update(_openshell_sandbox_ocsf_enabled(name))
+                entry.update(_sandbox_egress_denied_count(name))
                 if json_runtime_kind and "sandboxRuntimeKind" not in entry:
                     entry["sandboxRuntimeKind"] = json_runtime_kind
                 out.append(entry)
@@ -479,6 +512,7 @@ def _sandbox_inference_configs() -> list:
             }
             entry.update(_openshell_sandbox_phase_policy(name))
             entry.update(_openshell_sandbox_ocsf_enabled(name))
+            entry.update(_sandbox_egress_denied_count(name))
             if json_runtime_kind and "sandboxRuntimeKind" not in entry:
                 entry["sandboxRuntimeKind"] = json_runtime_kind
             out.append(entry)
@@ -997,6 +1031,15 @@ class OpenClawAdapter(AgentAdapter):
             _sb_configs = _sandbox_inference_configs()
             if _sb_configs:
                 meta["sandboxInferenceConfigs"] = _sb_configs
+            # DNS-backed HTTPS fail-closed enforcement (#3471): aggregate denial
+            # events across all known sandboxes.  Only written when >0 denials
+            # so absence of the key on plain OpenClaw installs is unambiguous.
+            _dns_denied_total = sum(
+                c.get("egressDeniedCount", 0) for c in _sb_configs
+            ) if _sb_configs else 0
+            if _dns_denied_total:
+                meta["dnsFailClosedCount"] = _dns_denied_total
+                meta["networkEgressDenied"] = True
             # Agents manifest (#3185): agent roster + per-agent sandbox/config
             # from ~/.nemoclaw/agents.yaml (written by harness onboarding,
             # commit 01e5525).

--- a/tests/test_obs_gap_nemoclaw_dns_fail_closed_3471.py
+++ b/tests/test_obs_gap_nemoclaw_dns_fail_closed_3471.py
@@ -1,0 +1,84 @@
+"""Tests for #3471: DNS-backed HTTPS fail-closed denial events surfaced as a
+distinct security signal (egressDeniedCount per sandbox, dnsFailClosedCount /
+networkEgressDenied on DetectResult.meta).
+"""
+import json
+import shutil
+import subprocess
+
+import pytest
+
+from clawmetry.adapters.openclaw import _sandbox_egress_denied_count
+
+
+# ---------------------------------------------------------------------------
+# _sandbox_egress_denied_count
+# ---------------------------------------------------------------------------
+
+def _make_run(events_by_sandbox):
+    """Return a fake subprocess.run that serves OCSF events as JSON lines."""
+    def fake_run(cmd, **kw):
+        name = cmd[2]  # ["openshell", "logs", <name>, ...]
+        if cmd[1] == "settings":
+            return type("R", (), {"stdout": ""})()
+        lines = "\n".join(json.dumps(e) for e in events_by_sandbox.get(name, []))
+        return type("R", (), {"stdout": lines})()
+    return fake_run
+
+
+def test_deny_with_network_class_uid_counted(monkeypatch):
+    """verdict=='deny' + network-activity class_uid (4001-4004) is counted."""
+    monkeypatch.setattr(shutil, "which", lambda _: "/usr/bin/openshell")
+    events = [
+        {"uid": "a1", "verdict": "deny", "class_uid": 4003},
+        {"uid": "a2", "verdict": "deny", "class_uid": 4001},
+        {"uid": "a3", "verdict": "allow", "class_uid": 4003},
+    ]
+    monkeypatch.setattr(subprocess, "run", _make_run({"alpha": events}))
+    result = _sandbox_egress_denied_count("alpha")
+    assert result == {"egressDeniedCount": 2}
+
+
+def test_deny_with_dst_endpoint_counted(monkeypatch):
+    """verdict=='deny' + dst_endpoint is counted even without class_uid."""
+    monkeypatch.setattr(shutil, "which", lambda _: "/usr/bin/openshell")
+    events = [
+        {"uid": "b1", "verdict": "deny", "dst_endpoint": {"ip": "1.2.3.4", "port": 443}},
+        {"uid": "b2", "verdict": "deny", "src_endpoint": {"ip": "10.0.0.1"}},
+    ]
+    monkeypatch.setattr(subprocess, "run", _make_run({"beta": events}))
+    result = _sandbox_egress_denied_count("beta")
+    assert result == {"egressDeniedCount": 2}
+
+
+def test_no_denials_returns_empty(monkeypatch):
+    """All allow-verdict events yield {} (key absent, not zero)."""
+    monkeypatch.setattr(shutil, "which", lambda _: "/usr/bin/openshell")
+    events = [
+        {"uid": "c1", "verdict": "allow", "class_uid": 4003},
+        {"uid": "c2", "class_uid": 4003},
+    ]
+    monkeypatch.setattr(subprocess, "run", _make_run({"gamma": events}))
+    result = _sandbox_egress_denied_count("gamma")
+    assert result == {}
+
+
+def test_non_network_deny_not_counted(monkeypatch):
+    """verdict=='deny' without network class_uid or endpoint fields is skipped."""
+    monkeypatch.setattr(shutil, "which", lambda _: "/usr/bin/openshell")
+    events = [
+        # class_uid 5001 is File System Activity — not network-egress
+        {"uid": "d1", "verdict": "deny", "class_uid": 5001},
+        # no class_uid, no endpoint fields
+        {"uid": "d2", "verdict": "deny"},
+    ]
+    monkeypatch.setattr(subprocess, "run", _make_run({"delta": events}))
+    result = _sandbox_egress_denied_count("delta")
+    assert result == {}
+
+
+def test_openshell_absent_returns_empty(monkeypatch):
+    """No openshell binary -> {} without raising."""
+    monkeypatch.setattr(shutil, "which", lambda _: None)
+    result = _sandbox_egress_denied_count("epsilon")
+    assert result == {}


### PR DESCRIPTION
Closes #3471

## Summary

- Adds `_sandbox_egress_denied_count(name)` helper in `clawmetry/adapters/openclaw.py` that fetches recent OCSF audit events and counts those with `verdict=='deny'` carrying a network-egress context (`class_uid` 4001–4004 or `dst_endpoint`/`src_endpoint` fields)
- Wires it into both code paths of `_sandbox_inference_configs()` so each sandbox entry gains `egressDeniedCount` when denial events are present
- Aggregates across sandboxes in `detect()` and surfaces `meta["dnsFailClosedCount"]` + `meta["networkEgressDenied"] = True` — the signal is now queryable from the dashboard and alert pipeline

## Test plan

- `python3 -m pytest tests/test_obs_gap_nemoclaw_dns_fail_closed_3471.py -v` — 5 tests covering: deny+class_uid counted, deny+dst_endpoint counted, all-allow yields `{}`, non-network deny skipped, openshell-absent short-circuits safely
- `python3 -m py_compile clawmetry/adapters/openclaw.py` — clean
- No regressions in existing sandbox OCSF tests (`test_obs_gap_nemoclaw_ocsf_3299.py`, `test_obs_gap_nemoclaw_ocsf_3274.py`, `test_obs_gap_nemoclaw_ocsf_3389.py`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QgShuaANZNr9HqhjBwwiGA)_