### PR TITLE
feat(entitlement): /next-tier-diff + /previous-tier-diff endpoints

### DIFF
--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -10467,3 +10467,63 @@ def api_entitlement_previous_tier_capacity_diff():
                 "enforced": False,
             }
         )
+
+@bp_entitlement.route("/api/entitlement/next-tier-diff")
+def api_entitlement_next_tier_diff():
+    """GET /api/entitlement/next-tier-diff -- marginal
+    :func:`clawmetry.entitlements.upgrade_diff` row from the resolved
+    entitlement to the rung immediately above.
+
+    Current-relative convenience for
+    ``/api/entitlement/upgrade-diff?target=<next_purchasable_tier>``; the
+    upgrade-CTA companion to ``/api/entitlement/next-tier-unlocks``
+    (same marginal, ``tier_unlocks`` shape), ``/next-tier-locks``
+    (marginal losses), and ``/next-tier-spec`` (full tier row). ``row``
+    collapses to ``null`` at the ceiling (resolved entitlement already at
+    enterprise -- no rung above to upgrade to). Never 5xxs: a resolver
+    failure short-circuits to the grace-shape envelope so the dashboard
+    CTA keeps rendering instead of disappearing.
+    """
+    try:
+        from clawmetry import entitlements as _ent
+        ent = _ent.get_entitlement()
+        body = ent.next_tier_diff()
+        return jsonify({
+            "current_tier": ent.tier,
+            "current_tier_label": _ent.tier_label(ent.tier),
+            "current_tier_rank": _ent.tier_rank(ent.tier),
+            "row": body,
+            "grace": bool(ent.grace),
+            "enforced": _ent.is_enforced(),
+        })
+    except Exception as exc:
+        logger.warning("api_entitlement_next_tier_diff: error: %s", exc)
+        return jsonify({"current_tier": "oss", "current_tier_label": "OSS",
+                        "current_tier_rank": 0, "row": None, "grace": True, "enforced": False})
+
+
+@bp_entitlement.route("/api/entitlement/previous-tier-diff")
+def api_entitlement_previous_tier_diff():
+    """GET /api/entitlement/previous-tier-diff -- marginal
+    :func:`clawmetry.entitlements.downgrade_diff` row from the resolved
+    entitlement to the rung immediately below.
+
+    Symmetric companion to ``/api/entitlement/next-tier-diff``. ``row``
+    collapses to ``null`` at the floor. Never 5xxs.
+    """
+    try:
+        from clawmetry import entitlements as _ent
+        ent = _ent.get_entitlement()
+        body = ent.previous_tier_diff()
+        return jsonify({
+            "current_tier": ent.tier,
+            "current_tier_label": _ent.tier_label(ent.tier),
+            "current_tier_rank": _ent.tier_rank(ent.tier),
+            "row": body,
+            "grace": bool(ent.grace),
+            "enforced": _ent.is_enforced(),
+        })
+    except Exception as exc:
+        logger.warning("api_entitlement_previous_tier_diff: error: %s", exc)
+        return jsonify({"current_tier": "oss", "current_tier_label": "OSS",
+                        "current_tier_rank": 0, "row": None, "grace": True, "enforced": False})

--- a/tests/test_entitlement_next_prev_tier_diff.py
+++ b/tests/test_entitlement_next_prev_tier_diff.py
@@ -1,0 +1,308 @@
+"""Tests for the bare ``/api/entitlement/{next,previous}-tier-diff``
+endpoints -- the stand-alone sibling of ``/next-tier-unlocks`` /
+``/next-tier-locks`` / ``/next-tier-spec`` for the marginal
+``upgrade_diff`` / ``downgrade_diff`` row.
+
+``Entitlement.next_tier_diff`` / ``previous_tier_diff`` (the instance
+methods) and the module-level ``next_tier_diff()`` / ``previous_tier_diff()``
+convenience wrappers already ship. ``/api/entitlement`` already surfaces
+these bodies inline under ``next_tier_diff`` / ``prev_tier_diff``. What
+was missing were the dedicated ``GET /api/entitlement/next-tier-diff`` and
+``GET /api/entitlement/previous-tier-diff`` endpoints -- the sibling
+docstrings on ``/next-tier-spec`` and ``/next-tier-unlocks`` reference them
+as if they existed.
+
+These tests pin:
+
+* endpoint envelope shape (6 stable keys) matches the sibling
+  ``/next-tier-unlocks`` / ``/next-tier-locks`` / ``/next-tier-spec``
+  envelopes so the four bare directional routes stay interchangeable
+  from a UI layout point of view
+* endpoint ``row`` byte-parity with the resolved
+  ``Entitlement.next_tier_diff`` / ``previous_tier_diff`` bound method
+  so the endpoint cannot drift from the helper
+* endpoint ``row`` byte-parity with the module-level
+  ``next_tier_diff()`` / ``previous_tier_diff()`` helper for the same
+  reason
+* endpoint ``row`` byte-parity with the existing inline slot on
+  ``/api/entitlement`` (``next_tier_diff`` / ``prev_tier_diff``) so the
+  two surfaces agree on the same body
+* ceiling (Enterprise for ``next``) and floor (OSS / cloud_free for
+  ``previous``) collapse ``row`` to ``null``; envelope metadata stays
+  populated so the CTA surface keeps rendering
+* trial-source resolution matches the sibling directional endpoints
+  (next -> enterprise, previous -> cloud_starter)
+* grace vs enforce yields byte-identical bodies (catalogue-derived)
+* never-5xx: a synthesised resolver failure returns 200 with the
+  grace-shape envelope
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+_ENVELOPE_KEYS = {
+    "current_tier",
+    "current_tier_label",
+    "current_tier_rank",
+    "row",
+    "grace",
+    "enforced",
+}
+
+_UPGRADE_ROW_KEYS = {"target", "added_features", "added_runtimes"}
+_DOWNGRADE_ROW_KEYS = {"target", "lost_features", "lost_runtimes"}
+
+
+# ── /api/entitlement/next-tier-diff ──────────────────────────────────────────
+
+
+def test_next_tier_diff_endpoint_oss_default(client, ent):
+    rv = client.get("/api/entitlement/next-tier-diff")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert set(body.keys()) == _ENVELOPE_KEYS
+    assert body["current_tier"] == ent.TIER_OSS
+    assert body["current_tier_label"] == ent.tier_label(ent.TIER_OSS)
+    assert body["current_tier_rank"] == ent.tier_rank(ent.TIER_OSS)
+    assert body["row"] is not None
+    assert set(body["row"].keys()) == _UPGRADE_ROW_KEYS
+    # OSS -> next purchasable rung is cloud_starter (rank 1).
+    assert body["row"]["target"] == ent.TIER_CLOUD_STARTER
+    assert body["grace"] is True
+    assert body["enforced"] is False
+
+
+def test_next_tier_diff_endpoint_row_matches_bound_method(client, ent):
+    rv = client.get("/api/entitlement/next-tier-diff")
+    body = rv.get_json()
+    assert body["row"] == ent.get_entitlement().next_tier_diff()
+
+
+def test_next_tier_diff_endpoint_row_matches_module_helper(client, ent):
+    rv = client.get("/api/entitlement/next-tier-diff")
+    body = rv.get_json()
+    assert body["row"] == ent.next_tier_diff()
+
+
+def test_next_tier_diff_endpoint_row_matches_entitlement_inline_slot(
+    client, ent
+):
+    # /api/entitlement already surfaces next_tier_diff inline under the
+    # `next_tier_diff` key. The stand-alone endpoint's `row` slot must
+    # agree byte-for-byte so both surfaces stay in sync.
+    ent_body = client.get("/api/entitlement").get_json()
+    dedicated = client.get("/api/entitlement/next-tier-diff").get_json()
+    assert dedicated["row"] == ent_body.get("next_tier_diff")
+
+
+def test_next_tier_diff_endpoint_row_at_ceiling(client, ent, monkeypatch):
+    # Pin an enterprise-tier entitlement and confirm the endpoint reports
+    # `row=null` with the envelope metadata still populated so a CTA can
+    # render "you're at the top" copy.
+    e = ent._build(ent.TIER_ENTERPRISE, "license")
+    monkeypatch.setattr(ent, "get_entitlement", lambda force=False: e)
+    rv = client.get("/api/entitlement/next-tier-diff")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["current_tier"] == ent.TIER_ENTERPRISE
+    assert body["current_tier_label"] == ent.tier_label(ent.TIER_ENTERPRISE)
+    assert body["current_tier_rank"] == ent.tier_rank(ent.TIER_ENTERPRISE)
+    assert body["row"] is None
+
+
+def test_next_tier_diff_endpoint_trial_resolves_to_enterprise(
+    client, ent, monkeypatch
+):
+    # Trial sits at rank 2, so the next strictly-higher purchasable rung
+    # is enterprise -- matches the sibling next-tier-unlocks/locks/spec
+    # behaviour.
+    e = ent._build(ent.TIER_TRIAL, "cloud")
+    monkeypatch.setattr(ent, "get_entitlement", lambda force=False: e)
+    body = client.get("/api/entitlement/next-tier-diff").get_json()
+    assert body["row"] is not None
+    assert body["row"]["target"] == ent.TIER_ENTERPRISE
+
+
+def test_next_tier_diff_endpoint_never_raises(client, ent, monkeypatch):
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "get_entitlement", boom)
+    rv = client.get("/api/entitlement/next-tier-diff")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert set(body.keys()) == _ENVELOPE_KEYS
+    assert body["current_tier"] == "oss"
+    assert body["current_tier_label"] == "OSS"
+    assert body["current_tier_rank"] == 0
+    assert body["row"] is None
+    assert body["grace"] is True
+    assert body["enforced"] is False
+
+
+# ── /api/entitlement/previous-tier-diff ──────────────────────────────────────
+
+
+def test_previous_tier_diff_endpoint_oss_default_floor(client, ent):
+    # OSS sits at rank 0 -- no rung below -- so the row collapses to
+    # null while the envelope metadata stays populated.
+    rv = client.get("/api/entitlement/previous-tier-diff")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert set(body.keys()) == _ENVELOPE_KEYS
+    assert body["current_tier"] == ent.TIER_OSS
+    assert body["row"] is None
+    assert body["grace"] is True
+
+
+def test_previous_tier_diff_endpoint_row_matches_bound_method(
+    client, ent, monkeypatch
+):
+    e = ent._build(ent.TIER_CLOUD_PRO, "cloud")
+    monkeypatch.setattr(ent, "get_entitlement", lambda force=False: e)
+    rv = client.get("/api/entitlement/previous-tier-diff")
+    body = rv.get_json()
+    assert body["row"] == e.previous_tier_diff()
+    assert set(body["row"].keys()) == _DOWNGRADE_ROW_KEYS
+    assert body["row"]["target"] == ent.TIER_CLOUD_STARTER
+
+
+def test_previous_tier_diff_endpoint_row_matches_module_helper(
+    client, ent, monkeypatch
+):
+    e = ent._build(ent.TIER_CLOUD_PRO, "cloud")
+    monkeypatch.setattr(ent, "get_entitlement", lambda force=False: e)
+    rv = client.get("/api/entitlement/previous-tier-diff")
+    body = rv.get_json()
+    assert body["row"] == ent.previous_tier_diff()
+
+
+def test_previous_tier_diff_endpoint_row_matches_entitlement_inline_slot(
+    client, ent, monkeypatch
+):
+    e = ent._build(ent.TIER_CLOUD_PRO, "cloud")
+    monkeypatch.setattr(ent, "get_entitlement", lambda force=False: e)
+    ent_body = client.get("/api/entitlement").get_json()
+    dedicated = client.get("/api/entitlement/previous-tier-diff").get_json()
+    assert dedicated["row"] == ent_body.get("prev_tier_diff")
+
+
+def test_previous_tier_diff_endpoint_cloud_free_floor(
+    client, ent, monkeypatch
+):
+    # cloud_free is a same-rank sibling of OSS at rank 0, so it also has
+    # no rung strictly below -- the row collapses to null just like OSS.
+    e = ent._build(ent.TIER_CLOUD_FREE, "cloud")
+    monkeypatch.setattr(ent, "get_entitlement", lambda force=False: e)
+    body = client.get("/api/entitlement/previous-tier-diff").get_json()
+    assert body["current_tier"] == ent.TIER_CLOUD_FREE
+    assert body["row"] is None
+
+
+def test_previous_tier_diff_endpoint_trial_resolves_to_starter(
+    client, ent, monkeypatch
+):
+    # Trial steps down to rank 1 (starter) -- matches the sibling
+    # previous-tier-unlocks/locks/spec behaviour.
+    e = ent._build(ent.TIER_TRIAL, "cloud")
+    monkeypatch.setattr(ent, "get_entitlement", lambda force=False: e)
+    body = client.get("/api/entitlement/previous-tier-diff").get_json()
+    assert body["row"] is not None
+    assert body["row"]["target"] == ent.TIER_CLOUD_STARTER
+
+
+def test_previous_tier_diff_endpoint_never_raises(client, ent, monkeypatch):
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "get_entitlement", boom)
+    rv = client.get("/api/entitlement/previous-tier-diff")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert set(body.keys()) == _ENVELOPE_KEYS
+    assert body["row"] is None
+    assert body["current_tier"] == "oss"
+    assert body["grace"] is True
+    assert body["enforced"] is False
+
+
+# ── grace vs enforce parity ─────────────────────────────────────────────────
+
+
+def test_next_tier_diff_endpoint_grace_matches_enforce(
+    client, ent, monkeypatch
+):
+    # The helper is catalogue-derived (off upgrade_diff on the static
+    # per-tier grants), not gated -- so flipping enforce on must not
+    # change the row body.
+    e = ent._build(ent.TIER_CLOUD_STARTER, "cloud")
+    monkeypatch.setattr(ent, "get_entitlement", lambda force=False: e)
+    grace_body = client.get("/api/entitlement/next-tier-diff").get_json()
+
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    importlib.reload(ent)
+    ent.invalidate()
+    # Rebuild the entitlement under enforce and re-pin the resolver so we
+    # compare identical resolved contexts (only enforce flag differs).
+    e2 = ent._build(ent.TIER_CLOUD_STARTER, "cloud")
+    monkeypatch.setattr(ent, "get_entitlement", lambda force=False: e2)
+    # And rebuild the client so the fresh module is picked up.
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    enforce_body = (
+        app.test_client().get("/api/entitlement/next-tier-diff").get_json()
+    )
+    assert enforce_body["row"] == grace_body["row"]
+
+
+# ── sibling family parity ───────────────────────────────────────────────────
+
+
+def test_next_tier_diff_envelope_shape_matches_sibling_family(client, ent):
+    # The four bare directional endpoints (diff/unlocks/locks/spec) share
+    # a common envelope shape so a UI can lay them out on a single card
+    # without conditional key handling. Pin that they carry the same
+    # metadata keys around the payload slot.
+    diff = client.get("/api/entitlement/next-tier-diff").get_json()
+    unlocks = client.get("/api/entitlement/next-tier-unlocks").get_json()
+    common = {
+        "current_tier",
+        "current_tier_label",
+        "current_tier_rank",
+        "grace",
+        "enforced",
+    }
+    assert common.issubset(diff.keys())
+    assert common.issubset(unlocks.keys())
+    # Payload slot differs by name (row vs unlocks) but the surrounding
+    # metadata must byte-equal so a shared header component can render
+    # both bodies.
+    for key in common:
+        assert diff[key] == unlocks[key]


### PR DESCRIPTION
## Summary

- Wires the two bare-directional HTTP endpoints for the marginal `upgrade_diff` / `downgrade_diff` row: `GET /api/entitlement/next-tier-diff` and `GET /api/entitlement/previous-tier-diff`.
- The `Entitlement.next_tier_diff` / `previous_tier_diff` instance methods (`entitlements.py:662` / `:672`) and the module-level `next_tier_diff()` / `previous_tier_diff()` wrappers (`entitlements.py:1628` / `:1636`) already ship. `/api/entitlement` also already surfaces both bodies inline under `next_tier_diff` / `prev_tier_diff`. What was missing were the dedicated stand-alone routes — sibling docstrings on `/next-tier-unlocks` (`routes/entitlement.py:1391`) and `/next-tier-spec` (`routes/entitlement.py:5943`) reference them as companions.
- Fills the bare-directional slot alongside the source-parameterised `_at` variants (`/next-tier-diff-at`, `/previous-tier-diff-at`) and the batch variants (`/next-tier-diff-at-batch`, `/previous-tier-diff-at-batch`) that already ship. The diff family now has the same three-endpoint shape as the unlocks / locks / spec families.

| bare directional (this PR) | source-parameterised `_at` (already ships) | source-parameterised `_at_batch` (already ships) |
|---|---|---|
| `/next-tier-diff` | `/next-tier-diff-at` | `/next-tier-diff-at-batch` |
| `/previous-tier-diff` | `/previous-tier-diff-at` | `/previous-tier-diff-at-batch` |

## Endpoints

Envelope shape matches the sibling bare-directional endpoints (`/next-tier-unlocks`, `/next-tier-locks`, `/next-tier-spec`) byte-for-byte around the payload slot so a shared header component can render all four bodies interchangeably:

```json
{
  "current_tier":       "<resolved tier id>",
  "current_tier_label": "<resolved label>",
  "current_tier_rank":  0,
  "row":                {"target": "<tier>", "added_features": [], "added_runtimes": []} | null,
  "grace":              true,
  "enforced":           false
}
```

`row` collapses to `null` at the ceiling (Enterprise for `/next-tier-diff`) and at the floor (OSS / cloud_free for `/previous-tier-diff`). The envelope stays populated so callers never lose `current_tier` / `grace` / `enforced` metadata.

`/previous-tier-diff` returns `{"target": ..., "lost_features": [...], "lost_runtimes": [...]}` in `row` — the `downgrade_diff` shape — mirroring the `next` direction's `upgrade_diff` shape.

Never 5xxs: a resolver failure short-circuits to the grace-shape envelope with `row=null`.

## Relationship to the existing inline slot

`/api/entitlement` already surfaces `next_tier_diff` / `prev_tier_diff` inline in its main body (added in an earlier PR that made the CTA render in one round-trip). The two new endpoints carry the same row on their `row` slot — this PR adds the stand-alone sibling shape so callers that want only the diff row don't have to pull the full entitlement envelope, matching the pattern of `/next-tier-unlocks` / `/next-tier-locks` / `/next-tier-spec`. Byte-parity between the two surfaces is pinned by a test.

## Tests

16 new tests in `tests/test_entitlement_next_prev_tier_diff.py`:

- envelope shape (6 stable keys)
- endpoint `row` byte-parity with the resolved `Entitlement.next_tier_diff` / `previous_tier_diff` bound method
- endpoint `row` byte-parity with the module-level `next_tier_diff()` / `previous_tier_diff()` helper
- endpoint `row` byte-parity with the existing inline slot on `/api/entitlement` (`next_tier_diff` / `prev_tier_diff`) — cross-surface pin
- ceiling (`enterprise` for next) / floor (`oss` and `cloud_free` for previous) → `row=null`, envelope still populated
- trial-source resolution: next → `enterprise`, previous → `cloud_starter` (matches sibling directional families)
- grace vs enforce yields byte-identical bodies (catalogue-derived)
- never-5xx on synthesised resolver failure — returns 200 grace envelope with `row=null`
- shared-envelope byte-parity vs the sibling `/next-tier-unlocks` endpoint (common metadata keys agree)

```
16 passed in 0.67s
```

Sibling suites unaffected: `test_entitlement_next_prev_tier_unlocks.py` + `test_entitlement_next_prev_tier_locks.py` + `test_entitlement_next_prev_tier_spec.py` + `test_entitlement_tier_diff.py` — **122 passed**.

`python3 -m ruff check routes/entitlement.py tests/test_entitlement_next_prev_tier_diff.py` — clean.
`python3 -m py_compile` on both changed files — clean.

## Test plan

- [x] `python3 -m pytest tests/test_entitlement_next_prev_tier_diff.py -v` — 16 passed
- [x] `python3 -m pytest tests/test_entitlement_next_prev_tier_unlocks.py tests/test_entitlement_next_prev_tier_locks.py tests/test_entitlement_next_prev_tier_spec.py tests/test_entitlement_tier_diff.py` — 122 passed
- [x] `python3 -m ruff check routes/entitlement.py tests/test_entitlement_next_prev_tier_diff.py` — clean
- [x] `python3 -m py_compile` on both changed files
- [ ] CI green
- [ ] Local operator: verify against the running daemon (see checklist below)

## Scope

Pure feature-add — no helper signatures or existing route shapes change. Resolver semantics untouched. No frontend consumer wired up yet; this is an API-only surface for future paywall / upgrade-CTA tooltips. Grace-mode change only: no gate flipped, no `__version__` bump, no `[RELEASE]` PR.

Disjoint from open PR #3480 (bare `/next-tier-capacity-diff` — capacity axis), #3467 (bare batch `next/previous_tier_{feature,runtime}_spec_batch` — feature/runtime axis) and #3457 (bare `next/previous_tier_lock_reason` — lock-reason axis). Different axis: full `upgrade_diff` / `downgrade_diff` row vs capacity slice vs feature/runtime spec vs lock sentence.

## Local operator verification checklist

I cannot reach the running daemon, `~/.openclaw`, the live cloud snapshot, or a browser from this session. Please walk the last mile on a real install:

1. Pull the branch: `git fetch origin feat/entitlement-next-prev-tier-diff && git checkout feat/entitlement-next-prev-tier-diff`
2. Copy changed files into the live install:
   - `cp routes/entitlement.py ~/.clawmetry/lib/python*/site-packages/routes/entitlement.py`
3. Clear caches: `find ~/.clawmetry/lib -name __pycache__ -type d -exec rm -rf {} +`
4. Restart the daemon: `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
5. Smoke the new endpoints against the live install:
   ```sh
   # happy path
   curl -s 'http://localhost:8900/api/entitlement/next-tier-diff' | jq
   curl -s 'http://localhost:8900/api/entitlement/previous-tier-diff' | jq
   ```
6. Confirm the body has `current_tier` / `current_tier_label` / `current_tier_rank` / `row` / `grace` / `enforced`.
7. Byte-parity spot check: `/next-tier-diff` `.row` matches `/api/entitlement` `.next_tier_diff` (same helper on both surfaces). Same for the `previous` direction against `.prev_tier_diff`.
8. Ceiling / floor: if the operator's entitlement is at Enterprise, `/next-tier-diff` should return `row=null` with a populated envelope. If at OSS or cloud_free, `/previous-tier-diff` should return `row=null` with a populated envelope.
9. Confirm `/api/entitlement`, the sibling `/next-tier-unlocks` / `/next-tier-locks` / `/next-tier-spec` bare endpoints, and the source-parameterised `/next-tier-diff-at` / `/next-tier-diff-at-batch` endpoints still return the same payloads they did pre-change.
10. Decrypt the live cloud snapshot and browser-check the dashboard for any regression (no UI consumes the new endpoints yet — this is a pure additive surface).

Keep this PR **draft**. Do not mark Ready for Review, do not edit `__version__`, do not open a `[RELEASE]` PR, do not enforce any gate. Once the operator has run the checklist, mark Ready for Review and proceed with the normal `[RELEASE]` loop.

---

Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_013nZT42zSk8vhZ9r4SgdhrB)_