### PR TITLE
fix(cost): attribute rollups by session-id prefix (family spend was booked as openclaw)

### DIFF
--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -180,7 +180,7 @@ def _on_disk_bytes() -> int:
         pass
     return total
 
-SCHEMA_VERSION = 10
+SCHEMA_VERSION = 11
 
 # ── Two-layer schema (multi-agent) ──────────────────────────────────────────
 #
@@ -1786,6 +1786,32 @@ class LocalStore:
                     except Exception as exc:
                         log.exception(
                             "local store: v7 dedup migration FAILED — schema "
+                            "version will NOT be stamped; next boot will retry"
+                        )
+                        migration_failed = True
+                        _migration_err = str(exc)
+                if not migration_failed and current < 11:
+                    # v10 -> v11: rollup runtime RE-ATTRIBUTION. The v3 event
+                    # mapper stamped agent_type='openclaw' on family-runtime
+                    # events, so every claude_code/codex/... token rolled up
+                    # under openclaw (openclaw week/month showed the node-wide
+                    # spend; the family runtimes showed $0 despite a non-zero
+                    # today). _rollup_deltas now attributes by the session-id
+                    # prefix, so wiping the rollups here lets the standard
+                    # startup backfill (backfill_rollups, right after
+                    # _migrate) rebuild all three tables correctly from the
+                    # stored events + sessions.
+                    try:
+                        self._conn.execute("DELETE FROM rollup_model_daily")
+                        self._conn.execute("DELETE FROM rollup_runtime_daily")
+                        self._conn.execute("DELETE FROM rollup_session")
+                        log.info(
+                            "local store: v11 wiped rollup tables for runtime "
+                            "re-attribution; startup backfill rebuilds them"
+                        )
+                    except Exception as exc:
+                        log.exception(
+                            "local store: v11 rollup wipe FAILED — schema "
                             "version will NOT be stamped; next boot will retry"
                         )
                         migration_failed = True
@@ -5125,7 +5151,7 @@ class LocalStore:
                 while True:
                     cur = self._conn.execute(
                         """
-                        SELECT rowid, agent_type, ts, data,
+                        SELECT rowid, agent_type, session_id, ts, data,
                                cost_usd, token_count, model
                         FROM events WHERE rowid > ?
                         ORDER BY rowid LIMIT ?
@@ -5137,7 +5163,7 @@ class LocalStore:
                         break
                     last_rowid = rows[-1][0]
                     pairs = []
-                    for (_rid, atype, ts, blob, cost, tokens, model) in rows:
+                    for (_rid, atype, sid, ts, blob, cost, tokens, model) in rows:
                         data = None
                         if blob is not None:
                             try:
@@ -5153,7 +5179,7 @@ class LocalStore:
                         # top-level keys win inside _extract_event_usage, so
                         # only the in/out/cache splits are re-read from data.
                         pseudo = {
-                            "agent_type": atype, "ts": ts,
+                            "agent_type": atype, "session_id": sid, "ts": ts,
                             "cost_usd": cost, "token_count": tokens,
                             "model": model,
                             "data": data if isinstance(data, dict) else None,
@@ -10792,7 +10818,20 @@ def _rollup_deltas(
         day = _event_day(e.get("ts"))
         if day is None:
             continue
-        runtime = str(e.get("agent_type") or "openclaw")
+        # Runtime attribution: the session-id PREFIX is the canonical runtime
+        # key (mirrors _runtime_of_session / _runtime_session_id_clause) and
+        # WINS over the stored agent_type. The v3 event mapper used to stamp
+        # agent_type='openclaw' on family-runtime events, so a month of
+        # claude_code spend rolled up under openclaw while claude_code's own
+        # week/month showed $0 (founder report 2026-07-02). Prefix-less events
+        # (bare OpenClaw ids, nemoclaw's stamped rows) keep agent_type.
+        runtime = None
+        _sid = str(e.get("session_id") or "")
+        _ci = _sid.find(":")
+        if _ci > 0 and _sid[:_ci].lower() in _NON_OPENCLAW_RUNTIME_PREFIXES:
+            runtime = _sid[:_ci].lower()
+        if not runtime:
+            runtime = str(e.get("agent_type") or "openclaw")
         tokens = int(u["tokens"] or 0)
         cost = float(u["cost"] or 0.0)
         rk = (day, runtime)

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -2992,6 +2992,7 @@ def _parse_v3_event(
     obj: dict,
     session_id: str,
     node_id: str,
+    agent_type: str = "openclaw",
 ) -> dict | None:
     """Map ONE v3 underscore-schema event to a normalised local-store row.
 
@@ -3216,7 +3217,11 @@ def _parse_v3_event(
 
     return {
         "id": str(eid),
-        "agent_type": "openclaw",
+        # The runtime this batch belongs to. Hardcoding "openclaw" here was
+        # the rollup mis-attribution bug: family adapters route their
+        # v3-schema transcripts through this mapper, so a month of
+        # claude_code spend was booked as openclaw (2026-07-02).
+        "agent_type": agent_type,
         "node_id": node_id,
         "agent_id": obj.get("agent_id") or "main",
         "session_id": session_id,
@@ -3278,7 +3283,7 @@ def _local_ingest_session_batch(
         # the trajectory parser (which would stamp event_type="message"
         # etc. and re-introduce the bug).
         if _is_v3_event(obj):
-            row = _parse_v3_event(obj, session_id, node_id)
+            row = _parse_v3_event(obj, session_id, node_id, agent_type)
             if row is not None:
                 rows.append(row)
             continue

--- a/tests/test_rollup_runtime_attribution.py
+++ b/tests/test_rollup_runtime_attribution.py
@@ -1,0 +1,161 @@
+"""Guards for rollup runtime attribution (founder report 2026-07-02).
+
+The bug: the v3 event mapper stamped agent_type='openclaw' on family-runtime
+events, and _rollup_deltas trusted agent_type. Result: EVERY claude_code token
+rolled up under openclaw (rollup_runtime_daily held ONLY openclaw rows: 9.45M
+tokens / $2,048 over 31d on the founder node, with today's "openclaw" row
+exactly equal to Claude Code's real day), so on the Cost tab OpenClaw showed
+the node-wide week/month while Claude Code showed today=$103 but week/month=$0.
+
+The fix, three layers, all guarded here:
+  1. _rollup_deltas attributes by the SESSION-ID PREFIX (the canonical runtime
+     key, mirrors _runtime_of_session) and only falls back to agent_type.
+  2. The rollup backfill feeds session_id through, so a force rebuild repairs
+     mis-attributed history from the stored events.
+  3. schema v11 wipes the rollups once so the startup backfill rebuilds them;
+     _parse_v3_event (sync.py) threads the real agent_type for new events.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import re
+from datetime import datetime, timedelta
+
+import pytest
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_SYNC = os.path.join(_HERE, "..", "clawmetry", "sync.py")
+_LS = os.path.join(_HERE, "..", "clawmetry", "local_store.py")
+
+
+@pytest.fixture
+def fresh_store(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "3600")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_BATCH", "100000")
+    monkeypatch.setenv(
+        "CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "attribution.duckdb")
+    )
+    import clawmetry.local_store as ls
+    ls = importlib.reload(ls)
+    store = ls.LocalStore()
+    try:
+        yield ls, store
+    finally:
+        try:
+            store.stop(flush=False)
+        except Exception:
+            pass
+
+
+def _ts(offset_days: int = 0) -> str:
+    return (datetime.now() - timedelta(days=offset_days)).strftime(
+        "%Y-%m-%dT12:00:00"
+    )
+
+
+def _ev(eid, session_id, agent_type, cost, tokens):
+    return {
+        "id": eid, "node_id": "n1", "agent_type": agent_type,
+        "session_id": session_id, "event_type": "assistant",
+        "ts": _ts(0), "data": {}, "cost_usd": cost,
+        "token_count": tokens, "model": "claude-opus-4-8",
+    }
+
+
+def test_rollup_deltas_prefix_wins_over_wrong_agent_type(fresh_store):
+    """THE regression: a claude_code:* event stamped agent_type='openclaw'
+    must roll up under claude_code."""
+    ls, _ = fresh_store
+    pairs = []
+    for e in (
+        _ev("e1", "claude_code:abc", "openclaw", 1.5, 100),
+        _ev("e2", "bare-openclaw-session", "openclaw", 0.5, 10),
+        _ev("e3", "nemo-session", "nemoclaw", 0.25, 5),
+        _ev("e4", "no-type-session", None, 0.1, 1),
+    ):
+        pairs.append((e, ls._extract_event_usage(e)))
+    _, runtime_d = ls._rollup_deltas(pairs)
+    by_rt = {rt: vals for (day, rt), vals in runtime_d.items()}
+    assert by_rt["claude_code"] == [100, 1.5], (
+        "claude_code:* events must attribute to claude_code even when the "
+        "stored agent_type says openclaw (the v3-mapper stamp bug)"
+    )
+    assert by_rt["openclaw"] == [11, 0.6], (
+        "prefix-less events keep agent_type / default to openclaw"
+    )
+    assert by_rt["nemoclaw"] == [5, 0.25], "nemoclaw stamped rows must survive"
+
+
+def test_live_ingest_attributes_by_prefix(fresh_store):
+    """End-to-end through ingest_events -> incremental rollup upsert."""
+    _, store = fresh_store
+    store.ingest(_ev("e10", "claude_code:xyz", "openclaw", 2.0, 200))
+    store.ingest(_ev("e11", "claude_code:xyz", "openclaw", 3.0, 300))
+    store.flush()
+    rows = store.query_rollup_runtime_daily()
+    by_rt = {}
+    for r in rows:
+        acc = by_rt.setdefault(r["runtime"], [0, 0.0])
+        acc[0] += int(r["tokens"] or 0)
+        acc[1] += float(r["cost_usd"] or 0.0)
+    assert by_rt.get("claude_code", [0, 0])[0] == 500
+    assert round(by_rt.get("claude_code", [0, 0])[1], 2) == 5.0
+    assert by_rt.get("openclaw", [0, 0])[0] == 0, (
+        "no claude_code spend may leak into the openclaw bucket"
+    )
+
+
+def test_force_backfill_repairs_polluted_history(fresh_store):
+    """The v11 repair path: events stored with the WRONG agent_type (and a
+    polluted rollup) re-attribute correctly on backfill_rollups(force=True),
+    because the backfill now reads session_id."""
+    _, store = fresh_store
+    store.ingest(_ev("e20", "claude_code:old", "openclaw", 4.0, 400))
+    store.flush()
+    # Simulate the historical pollution: hand-write a wrong rollup row.
+    with store._write_lock:
+        store._conn.execute("DELETE FROM rollup_runtime_daily")
+        store._conn.execute(
+            "INSERT INTO rollup_runtime_daily "
+            "(day, runtime, tokens, cost_usd, sessions, active_sessions) "
+            "VALUES (CAST(? AS DATE), 'openclaw', 400, 4.0, 0, 0)",
+            [_ts(0)[:10]],
+        )
+    out = store.backfill_rollups(force=True)
+    assert not out.get("skipped"), out
+    rows = store.query_rollup_runtime_daily()
+    by_rt = {}
+    for r in rows:
+        acc = by_rt.setdefault(r["runtime"], [0, 0.0])
+        acc[0] += int(r["tokens"] or 0)
+        acc[1] += float(r["cost_usd"] or 0.0)
+    assert by_rt.get("claude_code", [0, 0])[0] == 400, (
+        "force backfill must re-attribute mis-stamped history via session_id"
+    )
+    assert by_rt.get("openclaw", [0, 0])[0] == 0
+
+
+def test_schema_v11_wipe_migration_present():
+    src = open(_LS, encoding="utf-8").read()
+    assert "SCHEMA_VERSION = 11" in src
+    m = re.search(r"if not migration_failed and current < 11:.*?DELETE FROM rollup_runtime_daily",
+                  src, re.S)
+    assert m, "the v11 rollup-wipe migration must exist (repairs shipped stores)"
+
+
+def test_v3_mapper_threads_agent_type():
+    src = open(_SYNC, encoding="utf-8").read()
+    assert re.search(
+        r"def _parse_v3_event\(\s*obj: dict,\s*session_id: str,\s*node_id: str,\s*agent_type: str = \"openclaw\",",
+        src,
+    ), "_parse_v3_event must accept the batch agent_type"
+    assert "_parse_v3_event(obj, session_id, node_id, agent_type)" in src, (
+        "_local_ingest_session_batch must pass its agent_type through"
+    )
+    m = re.search(r"def _parse_v3_event.*?return \{.*?\"agent_type\": (\S+),", src, re.S)
+    assert m and m.group(1) == "agent_type", (
+        "the mapper's returned row must use the agent_type param, not a "
+        "hardcoded 'openclaw'"
+    )


### PR DESCRIPTION
## Why
Founder report: the Cost tab per runtime was wildly wrong - OpenClaw showed week $200 / month $2,005 (its real lifetime is $4.37) while Claude Code showed today $103 but week/month $0.00, an impossible shape.

## Root cause (verified against the live store)
`sync.py::_parse_v3_event` hardcoded `agent_type='openclaw'`; family adapters route their transcripts through it; `_rollup_deltas` trusted `agent_type`. Result: `rollup_runtime_daily` held ONLY openclaw rows (9.45M tokens / $2,048 over 31d - "openclaw's" today row was exactly Claude Code's real day), and that table feeds the Cost tab's week/month slices.

## Fix (three layers)
1. `_rollup_deltas` attributes by the **session-id prefix** (the canonical runtime key, mirrors `_runtime_of_session`), falling back to `agent_type` for prefix-less ids (bare OpenClaw, nemoclaw's stamped rows).
2. The rollup backfill selects + feeds `session_id` through, so a force rebuild repairs mis-stamped history.
3. **Schema v11**: one-time wipe of the rollup tables; the standard startup backfill rebuilds them re-attributed. Forward: `_parse_v3_event` threads the real batch `agent_type`.

## Verification (real data, live)
- Ran on the founder's actual store (daemon file-copy + kickstart): 26K events re-attributed. Rollup now: claude_code **$2,057.84 / 9.39M tokens**, openclaw **$4.37 / 111K** - openclaw and qwen_code match their Agents-roster lifetimes exactly.
- Live cloud Cost tab: Claude Code $120 today / $213 week / $2,019 month (consistent); OpenClaw $0 / $4.37 / $4.37. Screenshots in the run.
- `tests/test_rollup_runtime_attribution.py`: 5 guards (unit, live-ingest E2E, force-backfill repair, v11 presence, v3-mapper threading), attribution guard revert-proven. Full rollup family (25 tests) green; the parity test is unaffected (prefix-less corpus).
