### PR TITLE
feat(entitlement): next/previous_tier_lock_reason_batch + 2 endpoints

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -1289,6 +1289,151 @@ class Entitlement:
             )
             return None
 
+    def next_tier_lock_reason_batch(
+        self,
+        *,
+        features=None,
+        runtimes=None,
+        channels: int | None = None,
+        retention_days: int | None = None,
+        nodes: int | None = None,
+    ) -> dict:
+        """Batch sibling of :meth:`next_tier_lock_reason`: per-item lock-
+        reason rows for every supplied item across all 5 axes, evaluated
+        on the rung above the resolved entitlement in ONE round-trip.
+
+        Current-relative sibling of
+        :func:`next_tier_lock_reason_at_batch` (which takes an explicit
+        source ``tier``) and lock-reason-axis batch companion of
+        :meth:`next_tier_feature_spec_batch` /
+        :meth:`next_tier_runtime_spec_batch`. Body is byte-identical to
+        :func:`lock_reasons_at_batch(target, ...)` for the resolved
+        ``target = self.next_purchasable_tier()`` -- pinned by parity
+        tests so the source-aware batch here and the source-agnostic
+        ``_at_batch`` sibling cannot drift from the full matrix helper.
+
+        Anchored on :meth:`next_purchasable_tier` (source-aware -- picks
+        the ``cloud_*`` sibling when :attr:`source` is ``"cloud"``, the
+        self-hosted sibling otherwise), matching
+        :meth:`next_tier_feature_spec_batch`. The ``_at_batch`` variant
+        walks the source-agnostic :func:`_next_purchasable_tier_after`
+        instead -- both resolve to the same rung for every source except
+        at the free/starter boundary where source-aware and source-
+        agnostic diverge.
+
+        Shape (byte-identical to :func:`lock_reasons_at_batch`)::
+
+            {
+              "features":       [<row>, ...],
+              "runtimes":       [<row>, ...],
+              "channels":       <row> | None,
+              "retention_days": <row> | None,
+              "nodes":          <row> | None,
+            }
+
+        Each ``<row>`` carries the same 8 keys :func:`_lock_row` emits
+        (``key``, ``kind``, ``reason``, ``locked``, ``allowed``,
+        ``required_tier``, ``required_tier_label``,
+        ``required_tier_rank``).
+
+        At the resolver's ceiling (no rung above) rows still render for
+        every supplied item with ``reason=None`` / ``locked=False`` /
+        ``allowed=True`` so the matrix's row count stays stable and the
+        caller doesn't need a special shape branch -- same posture as
+        :func:`next_tier_lock_reason_at_batch`.
+
+        Never raises: a resolver failure short-circuits to the grace-
+        shape rows so the paywall matrix keeps rendering.
+        """
+        try:
+            target = self.next_purchasable_tier()
+        except Exception as exc:
+            logger.warning(
+                "entitlements: next_tier_lock_reason_batch target resolve failed: %s",
+                exc,
+            )
+            target = None
+        if target is None:
+            return _empty_lock_reasons_at_batch(
+                features, runtimes, channels, retention_days, nodes
+            )
+        try:
+            out = lock_reasons_at_batch(
+                target,
+                features=features,
+                runtimes=runtimes,
+                channels=channels,
+                retention_days=retention_days,
+                nodes=nodes,
+            )
+        except Exception as exc:
+            logger.warning(
+                "entitlements: next_tier_lock_reason_batch failed: %s", exc
+            )
+            out = None
+        if out is None:
+            return _empty_lock_reasons_at_batch(
+                features, runtimes, channels, retention_days, nodes
+            )
+        return out
+
+    def previous_tier_lock_reason_batch(
+        self,
+        *,
+        features=None,
+        runtimes=None,
+        channels: int | None = None,
+        retention_days: int | None = None,
+        nodes: int | None = None,
+    ) -> dict:
+        """Symmetric downgrade-side companion of
+        :meth:`next_tier_lock_reason_batch`: per-item lock-reason rows
+        evaluated on the rung below the resolved entitlement.
+
+        Anchored on :meth:`previous_purchasable_tier` (source-aware),
+        matching :meth:`previous_tier_feature_spec_batch`.
+
+        Response shape matches :meth:`next_tier_lock_reason_batch`
+        byte-for-byte. At the floor (resolved entitlement at ``oss`` /
+        ``cloud_free`` -- no rung below) rows still render for every
+        supplied item with ``reason=None`` / ``locked=False`` /
+        ``allowed=True`` so the row count stays stable.
+
+        Never raises.
+        """
+        try:
+            target = self.previous_purchasable_tier()
+        except Exception as exc:
+            logger.warning(
+                "entitlements: previous_tier_lock_reason_batch target resolve failed: %s",
+                exc,
+            )
+            target = None
+        if target is None:
+            return _empty_lock_reasons_at_batch(
+                features, runtimes, channels, retention_days, nodes
+            )
+        try:
+            out = lock_reasons_at_batch(
+                target,
+                features=features,
+                runtimes=runtimes,
+                channels=channels,
+                retention_days=retention_days,
+                nodes=nodes,
+            )
+        except Exception as exc:
+            logger.warning(
+                "entitlements: previous_tier_lock_reason_batch failed: %s",
+                exc,
+            )
+            out = None
+        if out is None:
+            return _empty_lock_reasons_at_batch(
+                features, runtimes, channels, retention_days, nodes
+            )
+        return out
+
     def grace_remaining_days(self) -> int | None:
         at = enforce_at_epoch()
         if at is None:
@@ -2141,6 +2286,64 @@ def previous_tier_lock_reason(
             "entitlements: previous_tier_lock_reason (module) failed: %s", exc
         )
         return None
+
+
+def next_tier_lock_reason_batch(
+    *,
+    features=None,
+    runtimes=None,
+    channels: int | None = None,
+    retention_days: int | None = None,
+    nodes: int | None = None,
+) -> dict:
+    """Module-level :meth:`Entitlement.next_tier_lock_reason_batch`
+    against the resolved entitlement. Never raises: a resolver failure
+    short-circuits to the grace-shape 5-axis envelope so a paywall
+    matrix keeps rendering."""
+    try:
+        return get_entitlement().next_tier_lock_reason_batch(
+            features=features,
+            runtimes=runtimes,
+            channels=channels,
+            retention_days=retention_days,
+            nodes=nodes,
+        )
+    except Exception as exc:
+        logger.warning(
+            "entitlements: next_tier_lock_reason_batch (module) failed: %s",
+            exc,
+        )
+        return _empty_lock_reasons_at_batch(
+            features, runtimes, channels, retention_days, nodes
+        )
+
+
+def previous_tier_lock_reason_batch(
+    *,
+    features=None,
+    runtimes=None,
+    channels: int | None = None,
+    retention_days: int | None = None,
+    nodes: int | None = None,
+) -> dict:
+    """Module-level :meth:`Entitlement.previous_tier_lock_reason_batch`
+    against the resolved entitlement. Never raises."""
+    try:
+        return get_entitlement().previous_tier_lock_reason_batch(
+            features=features,
+            runtimes=runtimes,
+            channels=channels,
+            retention_days=retention_days,
+            nodes=nodes,
+        )
+    except Exception as exc:
+        logger.warning(
+            "entitlements: previous_tier_lock_reason_batch (module) failed: %s",
+            exc,
+        )
+        return _empty_lock_reasons_at_batch(
+            features, runtimes, channels, retention_days, nodes
+        )
 
 
 def capacity_diff(target_tier: str) -> dict:

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -10527,3 +10527,230 @@ def api_entitlement_previous_tier_diff():
         logger.warning("api_entitlement_previous_tier_diff: error: %s", exc)
         return jsonify({"current_tier": "oss", "current_tier_label": "OSS",
                         "current_tier_rank": 0, "row": None, "grace": True, "enforced": False})
+
+
+def _next_prev_lock_reason_batch_grace_body() -> dict:
+    """Fallback envelope for the resolved-tier lock-reason batch routes.
+    Shape mirrors the happy path (5-axis empty rows + tier / target
+    echo) so a resolver failure never breaks a paywall matrix client-
+    side."""
+    return {
+        "features": [],
+        "runtimes": [],
+        "channels": None,
+        "retention_days": None,
+        "nodes": None,
+        "current_tier": "oss",
+        "current_tier_label": "OSS",
+        "current_tier_rank": 0,
+        "target": None,
+        "target_label": None,
+        "target_rank": None,
+        "grace": True,
+        "enforced": False,
+    }
+
+
+def _next_prev_lock_reason_batch(direction: str):
+    """Shared handler body for
+    ``/api/entitlement/{next,previous}-tier-lock-reason-batch``.
+
+    Current-relative sibling of the ``_next_prev_lock_reason_at_batch``
+    handler -- takes no ``tier=`` (the source is the resolved
+    entitlement) and walks
+    :meth:`Entitlement.next_tier_lock_reason_batch` /
+    :meth:`Entitlement.previous_tier_lock_reason_batch` instead of the
+    source-parameterised ``_at_batch`` module helpers, matching the
+    pattern of ``/next-tier-feature-spec-batch`` vs
+    ``/next-tier-feature-spec-at-batch``.
+
+    Mirrors the axis-parsing contract of the ``_at_batch`` handler (at
+    least one of ``features=`` / ``runtimes=`` / ``channels=`` /
+    ``retention_days=`` / ``nodes=``). Body is byte-identical to
+    ``/lock-reasons-at-batch?tier=<target>&...`` for the resolved
+    ``target = ent.next_purchasable_tier()`` (or
+    ``previous_purchasable_tier()``), same as
+    ``/next-tier-lock-reason-at-batch`` is byte-identical for
+    caller-supplied ``tier``. ``target`` collapses to ``null`` at the
+    rung edge (ceiling for ``next``, floor for ``previous``) while
+    every supplied item still renders a grace-shape row so the paywall
+    matrix's row count stays stable.
+
+    ``direction`` is ``"next"`` or ``"previous"``. Never 5xxs: resolver
+    failure short-circuits to the grace-shape envelope so the paywall
+    surface stays mute.
+    """
+    log_name = f"api_entitlement_{direction}_tier_lock_reason_batch"
+    try:
+        from clawmetry import entitlements as _ent
+
+        features = _parse_csv_arg("features")
+        runtimes = _parse_csv_arg("runtimes")
+        (_, channels_ok, channels_n, _) = _parse_capacity_arg("channels")
+        (_, retention_ok, retention_n, _) = _parse_capacity_arg(
+            "retention_days"
+        )
+        (_, nodes_ok, nodes_n, _) = _parse_capacity_arg("nodes")
+
+        if (
+            not features
+            and not runtimes
+            and not channels_ok
+            and not retention_ok
+            and not nodes_ok
+        ):
+            return (
+                jsonify(
+                    {
+                        "error": (
+                            "supply at least one of features=<csv>, "
+                            "runtimes=<csv>, channels=<int>, "
+                            "retention_days=<int>, or nodes=<int>"
+                        )
+                    }
+                ),
+                400,
+            )
+
+        ent = _ent.get_entitlement()
+        if direction == "next":
+            target = ent.next_purchasable_tier()
+            batch = ent.next_tier_lock_reason_batch(
+                features=features or None,
+                runtimes=runtimes or None,
+                channels=channels_n if channels_ok else None,
+                retention_days=retention_n if retention_ok else None,
+                nodes=nodes_n if nodes_ok else None,
+            )
+        else:
+            target = ent.previous_purchasable_tier()
+            batch = ent.previous_tier_lock_reason_batch(
+                features=features or None,
+                runtimes=runtimes or None,
+                channels=channels_n if channels_ok else None,
+                retention_days=retention_n if retention_ok else None,
+                nodes=nodes_n if nodes_ok else None,
+            )
+        if batch is None:
+            batch = {
+                "features": [],
+                "runtimes": [],
+                "channels": None,
+                "retention_days": None,
+                "nodes": None,
+            }
+        batch["current_tier"] = ent.tier
+        batch["current_tier_label"] = _ent.tier_label(ent.tier)
+        batch["current_tier_rank"] = _ent.tier_rank(ent.tier)
+        batch["target"] = target
+        batch["target_label"] = _ent.tier_label(target) if target else None
+        batch["target_rank"] = _ent.tier_rank(target) if target else None
+        batch["grace"] = bool(ent.grace)
+        batch["enforced"] = _ent.is_enforced()
+        return jsonify(batch)
+    except Exception as exc:
+        logger.warning("%s: error: %s", log_name, exc)
+        return jsonify(_next_prev_lock_reason_batch_grace_body())
+
+
+@bp_entitlement.route("/api/entitlement/next-tier-lock-reason-batch")
+def api_entitlement_next_tier_lock_reason_batch():
+    """``GET /api/entitlement/next-tier-lock-reason-batch?features=a,b
+    &runtimes=x,y&channels=N&retention_days=K&nodes=M`` -- current-
+    relative sibling of
+    ``/api/entitlement/next-tier-lock-reason-at-batch`` and batch
+    sibling of ``/api/entitlement/next-tier-lock-reason``.
+
+    Where ``/next-tier-lock-reason`` returns ONE lock sentence for ONE
+    item at the rung above the resolved entitlement, this returns per-
+    item rows for every supplied item across all 5 axes in ONE round-
+    trip. Pairs with ``/next-tier-lock-reason`` the same way
+    ``/lock-reasons-batch`` pairs with ``/lock-reason``: scalar ->
+    matrix in one call. Fills the lock-reason-axis batch member of the
+    resolved-tier ``next_*_batch`` family alongside
+    ``/next-tier-feature-spec-batch`` and
+    ``/next-tier-runtime-spec-batch``.
+
+    Use case: a paywall "does THIS column of features / runtimes /
+    capacity axes unlock at MY next rung?" matrix surface hydrates
+    every row off ONE call instead of N calls to
+    ``/next-tier-lock-reason`` per axis, without threading the current
+    tier through the query args.
+
+    Body is byte-identical to
+    ``/next-tier-lock-reason-at-batch?tier=<current>&...`` for every
+    source EXCEPT at the free/starter boundary where source-aware
+    (``ent.next_purchasable_tier()``) and source-agnostic
+    (``_next_purchasable_tier_after(tier)``) diverge -- matches
+    ``/next-tier-feature-spec-batch`` vs
+    ``/next-tier-feature-spec-at-batch``. Pinned by parity tests so
+    the two batch surfaces cannot drift outside that boundary.
+
+    At least one of ``features=`` / ``runtimes=`` / ``channels=`` /
+    ``retention_days=`` / ``nodes=`` must be supplied; supply as many
+    as you like. ``features=`` / ``runtimes=`` take comma-separated
+    tokens (whitespace + duplicates are normalised away; unknown ids
+    contribute a grace-shape row). The three capacity axes take a
+    single int each; blank / non-int values are treated as "not
+    supplied".
+
+    Response shape::
+
+        {
+          "features":       [<row>, ...],
+          "runtimes":       [<row>, ...],
+          "channels":       <row> | None,
+          "retention_days": <row> | None,
+          "nodes":          <row> | None,
+          "current_tier":       "<resolved tier id>",
+          "current_tier_label": "<resolved label>",
+          "current_tier_rank":  <resolved rank>,
+          "target":             "<next-above tier id>" | null,
+          "target_label":       "<next-above label>" | null,
+          "target_rank":        <next-above rank> | null,
+          "grace":              <bool>,
+          "enforced":           <bool>,
+        }
+
+    Each ``<row>`` carries ``key``, ``kind``, ``reason``, ``locked``,
+    ``allowed``, ``required_tier``, ``required_tier_label``,
+    ``required_tier_rank`` -- the same 8 keys ``/lock-reasons-batch``
+    returns.
+
+    At the ceiling (resolved entitlement already at enterprise -- no
+    rung above) ``target`` is ``null`` and rows still render for every
+    supplied item with ``reason=null`` / ``locked=false`` /
+    ``allowed=true`` so callers can render "you're at the top" copy
+    without a status-code branch.
+
+    - **400** when no axis is supplied
+    - **Never 5xxs**: resolver failure short-circuits to the grace-
+      shape envelope with ``target=null`` so the paywall surface stays
+      mute.
+    """
+    return _next_prev_lock_reason_batch("next")
+
+
+@bp_entitlement.route("/api/entitlement/previous-tier-lock-reason-batch")
+def api_entitlement_previous_tier_lock_reason_batch():
+    """``GET /api/entitlement/previous-tier-lock-reason-batch?features=a,b
+    &runtimes=x,y&channels=N&retention_days=K&nodes=M`` -- symmetric
+    downgrade-side companion of ``/next-tier-lock-reason-batch``.
+
+    Same envelope as ``/next-tier-lock-reason-batch``. ``target``
+    collapses to ``null`` at the floor (resolved entitlement at
+    ``oss`` / ``cloud_free`` -- no rung below) while every supplied
+    item still renders a grace-shape row so the downgrade-confirmation
+    matrix's row count stays stable.
+
+    Body is byte-identical to
+    ``/previous-tier-lock-reason-at-batch?tier=<current>&...`` for
+    every source except at the free/starter boundary where source-
+    aware and source-agnostic diverge -- matches
+    ``/previous-tier-feature-spec-batch`` vs
+    ``/previous-tier-feature-spec-at-batch``.
+
+    - **400** when no axis is supplied
+    - **Never 5xxs**: grace-shape envelope on resolver failure.
+    """
+    return _next_prev_lock_reason_batch("previous")

--- a/tests/test_entitlement_next_prev_tier_lock_reason_batch.py
+++ b/tests/test_entitlement_next_prev_tier_lock_reason_batch.py
@@ -1,0 +1,567 @@
+"""Tests for the bare (source-aware) directional 5-axis batch
+projections ``Entitlement.next_tier_lock_reason_batch`` /
+``Entitlement.previous_tier_lock_reason_batch``, their module-level
+convenience wrappers, and the two companion
+``/api/entitlement/{next,previous}-tier-lock-reason-batch`` endpoints.
+
+Batch sibling of the scalar bare projection
+``Entitlement.next_tier_lock_reason`` / ``previous_tier_lock_reason``
+(single item, resolved current tier) and current-relative sibling of
+the tier-parameterised
+``next_tier_lock_reason_at_batch`` / ``previous_tier_lock_reason_at_batch``
+family (5-axis matrix what-if, arbitrary source tier). Where the scalar
+bare projection walks ONE item against ``self.next_purchasable_tier()``,
+this batch sibling walks N items across all 5 axes against that same
+rung in ONE round-trip -- source-aware target resolution (picks
+``cloud_*`` when ``source == "cloud"``, self-hosted otherwise).
+
+Fills the lock-reason-axis batch member of the resolved-tier
+``next_*_batch`` / ``previous_*_batch`` family alongside the existing:
+
+* :meth:`Entitlement.next_tier_feature_spec_batch` /
+  :meth:`Entitlement.previous_tier_feature_spec_batch`
+* :meth:`Entitlement.next_tier_runtime_spec_batch` /
+  :meth:`Entitlement.previous_tier_runtime_spec_batch`
+
+Pins covered here:
+
+* per-rung byte-equality with :func:`lock_reasons_at_batch` at the
+  resolved next / previous purchasable target (parity, all five axes)
+* per-rung byte-equality with the source-agnostic
+  :func:`next_tier_lock_reason_at_batch` /
+  :func:`previous_tier_lock_reason_at_batch` sibling for every source
+  where source-aware and source-agnostic resolve to the same rung
+* ceiling (enterprise as source) / floor (oss / cloud_free as source)
+  still emit per-item rows with ``reason=null`` / ``locked=false`` /
+  ``allowed=true`` so the matrix's row count stays stable (no shape
+  branch for edge tiers)
+* trial-as-source resolves the same way the sibling ``_batch``
+  families do: next -> enterprise, previous -> starter
+* capacity axes (``channels`` / ``retention_days`` / ``nodes``) route
+  through the batch helper's kwarg surface just like
+  :func:`lock_reasons_at_batch`
+* grace vs enforce yields byte-identical bodies (catalogue-derived)
+* module-level wrappers match the bound method on the resolved
+  entitlement, and fall back to the grace-shape 5-axis envelope on a
+  synthesised resolver failure
+* helpers never raise -- a builder failure short-circuits to grace-
+  shape rows so the matrix keeps rendering rather than 500-ing
+* the two API endpoints never 5xx: 400 on no-axis, 200 with grace-
+  shape rows at the ceiling / floor; an internal failure yields the
+  same 200 envelope shape
+* the endpoint response is byte-identical to the helper body plus a
+  ``current_tier`` / ``target`` echo -- parity pin so the two batch
+  surfaces cannot drift
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+_ROW_KEYS = {
+    "key",
+    "kind",
+    "reason",
+    "locked",
+    "allowed",
+    "required_tier",
+    "required_tier_label",
+    "required_tier_rank",
+}
+
+_HELPER_BATCH_KEYS = {
+    "features",
+    "runtimes",
+    "channels",
+    "retention_days",
+    "nodes",
+}
+
+_API_ENVELOPE_KEYS = {
+    "features",
+    "runtimes",
+    "channels",
+    "retention_days",
+    "nodes",
+    "current_tier",
+    "current_tier_label",
+    "current_tier_rank",
+    "target",
+    "target_label",
+    "target_rank",
+    "grace",
+    "enforced",
+}
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+def _some_features(ent):
+    # A short deterministic slice of features so the batch has non-trivial
+    # content to parity-check.
+    return sorted(ent.ALL_FEATURES)[:3]
+
+
+def _some_runtimes(ent):
+    return sorted(ent.ALL_RUNTIMES)[:3]
+
+
+# ── Entitlement.next_tier_lock_reason_batch: shape ──────────────────────────
+
+
+def test_next_helper_returns_dict_with_axis_keys(ent):
+    e = ent._build(ent.TIER_OSS, "test")
+    out = e.next_tier_lock_reason_batch(features=_some_features(ent))
+    assert isinstance(out, dict)
+    assert set(out.keys()) == _HELPER_BATCH_KEYS
+
+
+def test_next_helper_features_row_shape(ent):
+    e = ent._build(ent.TIER_OSS, "test")
+    features = _some_features(ent)
+    out = e.next_tier_lock_reason_batch(features=features)
+    assert isinstance(out["features"], list)
+    assert len(out["features"]) == len(features)
+    for row in out["features"]:
+        assert set(row.keys()) == _ROW_KEYS
+
+
+def test_next_helper_every_purchasable_tier_returns_dict(ent):
+    features = _some_features(ent)
+    for tier in ent._TIER_ORDER:
+        e = ent._build(tier, "test")
+        out = e.next_tier_lock_reason_batch(features=features)
+        assert isinstance(out, dict), tier
+        assert set(out.keys()) == _HELPER_BATCH_KEYS
+
+
+# ── byte-parity with lock_reasons_at_batch at the resolved target ───────────
+
+
+def test_next_helper_body_equals_lock_reasons_at_batch_target(ent):
+    features = _some_features(ent)
+    runtimes = _some_runtimes(ent)
+    for tier in ent._TIER_ORDER:
+        e = ent._build(tier, "test")
+        target = e.next_purchasable_tier()
+        got = e.next_tier_lock_reason_batch(
+            features=features,
+            runtimes=runtimes,
+            channels=5,
+            retention_days=30,
+            nodes=3,
+        )
+        if target is None:
+            # Ceiling -> grace-shape rows for every supplied item.
+            for row in got["features"] + got["runtimes"]:
+                assert row["reason"] is None
+                assert row["locked"] is False
+                assert row["allowed"] is True
+            assert got["channels"] is not None
+            assert got["retention_days"] is not None
+            assert got["nodes"] is not None
+        else:
+            assert got == ent.lock_reasons_at_batch(
+                target,
+                features=features,
+                runtimes=runtimes,
+                channels=5,
+                retention_days=30,
+                nodes=3,
+            )
+
+
+def test_previous_helper_body_equals_lock_reasons_at_batch_target(ent):
+    features = _some_features(ent)
+    runtimes = _some_runtimes(ent)
+    for tier in ent._TIER_ORDER:
+        e = ent._build(tier, "test")
+        target = e.previous_purchasable_tier()
+        got = e.previous_tier_lock_reason_batch(
+            features=features,
+            runtimes=runtimes,
+        )
+        if target is None:
+            for row in got["features"] + got["runtimes"]:
+                assert row["reason"] is None
+                assert row["locked"] is False
+                assert row["allowed"] is True
+        else:
+            assert got == ent.lock_reasons_at_batch(
+                target,
+                features=features,
+                runtimes=runtimes,
+            )
+
+
+# ── parity with the source-agnostic _at_batch sibling ───────────────────────
+
+
+def test_next_helper_matches_at_batch_when_target_matches(ent):
+    features = _some_features(ent)
+    runtimes = _some_runtimes(ent)
+    for tier in ent._TIER_ORDER:
+        # Skip trial (source-aware vs source-agnostic can pick different
+        # rungs at the free/starter boundary; parity holds when both
+        # resolvers agree).
+        e = ent._build(tier, "test")
+        aware = e.next_purchasable_tier()
+        agnostic = ent._next_purchasable_tier_after(tier)
+        if aware != agnostic:
+            continue
+        bare = e.next_tier_lock_reason_batch(
+            features=features, runtimes=runtimes
+        )
+        at = ent.next_tier_lock_reason_at_batch(
+            tier, features=features, runtimes=runtimes
+        )
+        assert bare == at, tier
+
+
+def test_previous_helper_matches_at_batch_when_target_matches(ent):
+    features = _some_features(ent)
+    runtimes = _some_runtimes(ent)
+    for tier in ent._TIER_ORDER:
+        e = ent._build(tier, "test")
+        aware = e.previous_purchasable_tier()
+        agnostic = ent._previous_purchasable_tier_before(tier)
+        if aware != agnostic:
+            continue
+        bare = e.previous_tier_lock_reason_batch(
+            features=features, runtimes=runtimes
+        )
+        at = ent.previous_tier_lock_reason_at_batch(
+            tier, features=features, runtimes=runtimes
+        )
+        assert bare == at, tier
+
+
+# ── ceiling / floor ─────────────────────────────────────────────────────────
+
+
+def test_next_helper_at_ceiling_returns_grace_rows(ent):
+    e = ent._build(ent.TIER_ENTERPRISE, "license")
+    assert e.next_purchasable_tier() is None
+    features = _some_features(ent)
+    out = e.next_tier_lock_reason_batch(features=features)
+    assert [row["key"] for row in out["features"]] == features
+    for row in out["features"]:
+        assert row["reason"] is None
+        assert row["locked"] is False
+        assert row["allowed"] is True
+
+
+def test_previous_helper_at_floor_returns_grace_rows(ent):
+    for tier in (ent.TIER_OSS, ent.TIER_CLOUD_FREE):
+        e = ent._build(tier, "test")
+        assert e.previous_purchasable_tier() is None
+        features = _some_features(ent)
+        out = e.previous_tier_lock_reason_batch(features=features)
+        assert [row["key"] for row in out["features"]] == features
+        for row in out["features"]:
+            assert row["reason"] is None
+            assert row["locked"] is False
+            assert row["allowed"] is True
+
+
+# ── trial source resolution ─────────────────────────────────────────────────
+
+
+def test_trial_next_batch_resolves_to_enterprise(ent):
+    features = _some_features(ent)
+    e = ent._build(ent.TIER_TRIAL, "cloud")
+    got = e.next_tier_lock_reason_batch(features=features)
+    assert got == ent.lock_reasons_at_batch(
+        ent.TIER_ENTERPRISE, features=features
+    )
+
+
+def test_trial_previous_batch_resolves_to_starter(ent):
+    features = _some_features(ent)
+    e = ent._build(ent.TIER_TRIAL, "cloud")
+    got = e.previous_tier_lock_reason_batch(features=features)
+    assert got == ent.lock_reasons_at_batch(
+        ent.TIER_CLOUD_STARTER, features=features
+    )
+
+
+# ── capacity axes ───────────────────────────────────────────────────────────
+
+
+def test_next_helper_capacity_axes_present(ent):
+    e = ent._build(ent.TIER_CLOUD_STARTER, "cloud")
+    out = e.next_tier_lock_reason_batch(
+        channels=10, retention_days=60, nodes=5
+    )
+    assert out["channels"] is not None
+    assert out["retention_days"] is not None
+    assert out["nodes"] is not None
+    assert set(out["channels"].keys()) == _ROW_KEYS
+    assert set(out["retention_days"].keys()) == _ROW_KEYS
+    assert set(out["nodes"].keys()) == _ROW_KEYS
+
+
+def test_next_helper_capacity_axes_none_when_not_supplied(ent):
+    e = ent._build(ent.TIER_CLOUD_STARTER, "cloud")
+    out = e.next_tier_lock_reason_batch(features=_some_features(ent))
+    assert out["channels"] is None
+    assert out["retention_days"] is None
+    assert out["nodes"] is None
+
+
+# ── grace vs enforce ────────────────────────────────────────────────────────
+
+
+def test_grace_vs_enforce_batch_identical(ent, monkeypatch):
+    features = _some_features(ent)
+    runtimes = _some_runtimes(ent)
+    e = ent._build(ent.TIER_CLOUD_STARTER, "cloud")
+    grace_body = e.next_tier_lock_reason_batch(
+        features=features, runtimes=runtimes
+    )
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    importlib.reload(ent)
+    ent.invalidate()
+    e2 = ent._build(ent.TIER_CLOUD_STARTER, "cloud")
+    enforce_body = e2.next_tier_lock_reason_batch(
+        features=features, runtimes=runtimes
+    )
+    assert enforce_body == grace_body
+
+
+# ── never raises on resolver failure ────────────────────────────────────────
+
+
+def test_next_helper_never_raises_on_resolver_failure(ent, monkeypatch):
+    e = ent._build(ent.TIER_CLOUD_STARTER, "cloud")
+    monkeypatch.setattr(
+        type(e),
+        "next_purchasable_tier",
+        lambda self: (_ for _ in ()).throw(RuntimeError("synthetic")),
+    )
+    features = _some_features(ent)
+    out = e.next_tier_lock_reason_batch(features=features)
+    # Fell through to _empty_lock_reasons_at_batch -> grace-shape rows.
+    for row in out["features"]:
+        assert row["reason"] is None
+        assert row["locked"] is False
+        assert row["allowed"] is True
+
+
+def test_previous_helper_never_raises_on_resolver_failure(ent, monkeypatch):
+    e = ent._build(ent.TIER_ENTERPRISE, "license")
+    monkeypatch.setattr(
+        type(e),
+        "previous_purchasable_tier",
+        lambda self: (_ for _ in ()).throw(RuntimeError("synthetic")),
+    )
+    features = _some_features(ent)
+    out = e.previous_tier_lock_reason_batch(features=features)
+    for row in out["features"]:
+        assert row["reason"] is None
+        assert row["locked"] is False
+        assert row["allowed"] is True
+
+
+# ── module-level wrappers ───────────────────────────────────────────────────
+
+
+def test_module_level_next_batch_matches_method(ent):
+    features = _some_features(ent)
+    assert ent.next_tier_lock_reason_batch(features=features) == (
+        ent.get_entitlement().next_tier_lock_reason_batch(features=features)
+    )
+
+
+def test_module_level_previous_batch_matches_method(ent):
+    features = _some_features(ent)
+    assert ent.previous_tier_lock_reason_batch(features=features) == (
+        ent.get_entitlement().previous_tier_lock_reason_batch(
+            features=features
+        )
+    )
+
+
+def test_module_level_next_batch_never_raises(ent, monkeypatch):
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "get_entitlement", boom)
+    features = _some_features(ent)
+    out = ent.next_tier_lock_reason_batch(features=features)
+    # Falls back to _empty_lock_reasons_at_batch -> grace-shape rows.
+    assert set(out.keys()) == _HELPER_BATCH_KEYS
+    for row in out["features"]:
+        assert row["reason"] is None
+        assert row["locked"] is False
+        assert row["allowed"] is True
+
+
+def test_module_level_previous_batch_never_raises(ent, monkeypatch):
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "get_entitlement", boom)
+    features = _some_features(ent)
+    out = ent.previous_tier_lock_reason_batch(features=features)
+    assert set(out.keys()) == _HELPER_BATCH_KEYS
+    for row in out["features"]:
+        assert row["reason"] is None
+        assert row["locked"] is False
+        assert row["allowed"] is True
+
+
+# ── /api/entitlement/next-tier-lock-reason-batch endpoint ───────────────────
+
+
+def test_endpoint_next_batch_default_oss(client, ent):
+    features = _some_features(ent)
+    rv = client.get(
+        "/api/entitlement/next-tier-lock-reason-batch?features="
+        + ",".join(features)
+    )
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert set(body.keys()) == _API_ENVELOPE_KEYS
+    assert body["current_tier"] == ent.TIER_OSS
+    assert body["current_tier_label"] == ent.tier_label(ent.TIER_OSS)
+    assert body["current_tier_rank"] == ent.tier_rank(ent.TIER_OSS)
+    assert body["target"] == ent.TIER_CLOUD_STARTER
+    assert body["target_label"] == ent.tier_label(ent.TIER_CLOUD_STARTER)
+    assert body["target_rank"] == ent.tier_rank(ent.TIER_CLOUD_STARTER)
+    assert [row["key"] for row in body["features"]] == features
+    assert body["grace"] is True
+    assert body["enforced"] is False
+
+
+def test_endpoint_next_batch_body_matches_helper(client, ent):
+    features = _some_features(ent)
+    runtimes = _some_runtimes(ent)
+    rv = client.get(
+        "/api/entitlement/next-tier-lock-reason-batch?features="
+        + ",".join(features)
+        + "&runtimes="
+        + ",".join(runtimes)
+        + "&channels=5&retention_days=30&nodes=3"
+    )
+    assert rv.status_code == 200
+    body = rv.get_json()
+    helper = ent.next_tier_lock_reason_batch(
+        features=features,
+        runtimes=runtimes,
+        channels=5,
+        retention_days=30,
+        nodes=3,
+    )
+    for axis in ("features", "runtimes", "channels", "retention_days", "nodes"):
+        assert body[axis] == helper[axis], axis
+
+
+def test_endpoint_next_batch_missing_axis_returns_400(client):
+    rv = client.get("/api/entitlement/next-tier-lock-reason-batch")
+    assert rv.status_code == 400
+    err = rv.get_json()["error"]
+    assert "features" in err
+    assert "runtimes" in err
+    assert "channels" in err
+
+
+def test_endpoint_next_batch_empty_csv_and_no_capacity_returns_400(client):
+    rv = client.get(
+        "/api/entitlement/next-tier-lock-reason-batch?features=&runtimes=,"
+    )
+    assert rv.status_code == 400
+
+
+def test_endpoint_next_batch_capacity_only_returns_200(client, ent):
+    rv = client.get(
+        "/api/entitlement/next-tier-lock-reason-batch?channels=5"
+    )
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["features"] == []
+    assert body["runtimes"] == []
+    assert body["channels"] is not None
+    assert body["retention_days"] is None
+    assert body["nodes"] is None
+
+
+# ── /api/entitlement/previous-tier-lock-reason-batch endpoint ───────────────
+
+
+def test_endpoint_previous_batch_at_floor(client, ent):
+    features = _some_features(ent)
+    rv = client.get(
+        "/api/entitlement/previous-tier-lock-reason-batch?features="
+        + ",".join(features)
+    )
+    assert rv.status_code == 200
+    body = rv.get_json()
+    # Default resolved tier is OSS -> no rung below.
+    assert body["current_tier"] == ent.TIER_OSS
+    assert body["target"] is None
+    assert body["target_label"] is None
+    assert body["target_rank"] is None
+    # But per-feature rows still render so the matrix's row count stays
+    # stable.
+    assert [row["key"] for row in body["features"]] == features
+    for row in body["features"]:
+        assert row["reason"] is None
+        assert row["locked"] is False
+        assert row["allowed"] is True
+
+
+def test_endpoint_previous_batch_missing_axis_returns_400(client):
+    rv = client.get("/api/entitlement/previous-tier-lock-reason-batch")
+    assert rv.status_code == 400
+
+
+def test_endpoint_previous_batch_body_matches_helper(client, ent):
+    features = _some_features(ent)
+    rv = client.get(
+        "/api/entitlement/previous-tier-lock-reason-batch?features="
+        + ",".join(features)
+    )
+    body = rv.get_json()
+    helper = ent.previous_tier_lock_reason_batch(features=features)
+    assert body["features"] == helper["features"]
+    assert body["runtimes"] == helper["runtimes"]
+
+
+def test_endpoint_never_5xx_on_internal_failure(client, monkeypatch):
+    import clawmetry.entitlements as ent
+
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "get_entitlement", boom)
+    rv = client.get(
+        "/api/entitlement/next-tier-lock-reason-batch?features=x"
+    )
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert set(body.keys()) == _API_ENVELOPE_KEYS
+    assert body["grace"] is True
+    assert body["enforced"] is False


### PR DESCRIPTION
## Summary

Adds current-relative (source-aware) 5-axis batch siblings of the scalar bare projections `next_tier_lock_reason` / `previous_tier_lock_reason` (merged in #3457) and the tier-parameterised `next_tier_lock_reason_at_batch` / `previous_tier_lock_reason_at_batch` family:

- `Entitlement.next_tier_lock_reason_batch(*, features, runtimes, channels, retention_days, nodes)` — walks all 5 axes against `self.next_purchasable_tier()` in one round-trip
- `Entitlement.previous_tier_lock_reason_batch(...)` — symmetric downgrade-side
- module-level convenience wrappers on both
- `GET /api/entitlement/next-tier-lock-reason-batch`
- `GET /api/entitlement/previous-tier-lock-reason-batch`

Fills the lock-reason-axis batch member of the resolved-tier `next_*_batch` / `previous_*_batch` family alongside `next/previous_tier_{feature,runtime}_spec_batch` (merged in #3467). Where the scalar bare projection `Entitlement.next_tier_lock_reason(item)` walks ONE item against the resolved next rung, this walks N items across all 5 axes against that same rung — same source-aware target resolution.

Response body is byte-identical to `lock_reasons_at_batch(target, ...)` for the resolved `target = ent.next_purchasable_tier()` (or `previous_purchasable_tier()`), and byte-identical to the `..._at_batch` sibling for every source outside the free/starter boundary where source-aware and source-agnostic diverge. Pinned by parity tests so the two batch surfaces cannot drift.

Ceiling (enterprise resolved) / floor (oss / cloud_free resolved) still emit per-item rows with `reason=null` / `locked=false` / `allowed=true` so a paywall matrix's row count stays stable — no shape branch for edge tiers.

Grace-only: no behavior change against the currently-resolved entitlement; helpers walk the same `_empty_lock_reasons_at_batch` grace-shape fallback the `_at_batch` sibling already uses. Never 5xxs: resolver failure short-circuits to the grace-shape envelope so paywall surfaces stay mute.

## Test plan

- [x] `python3 -m py_compile clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_next_prev_tier_lock_reason_batch.py` — clean
- [x] `ruff check clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_next_prev_tier_lock_reason_batch.py` — clean (pre-existing lint issues in `routes/usage.py` / `routes/channels.py` are unrelated to this diff)
- [x] `python3 -m pytest tests/test_entitlement_next_prev_tier_lock_reason_batch.py -q` — 29 passed
- [x] Adjacent tests still green: `tests/test_entitlement_next_prev_tier_lock_reason{,_at,_at_batch}.py`, `tests/test_entitlement_lock_reasons_at_batch.py`, `tests/test_entitlement_next_prev_tier_feature_runtime_spec_batch.py` — 192 passed
- [x] Broader entitlement API tests still green: `tests/test_entitlement_api{,_nodes,_lock_reason,_lock_reason_capacity}.py`, `tests/test_entitlement_lock_reason_batch.py`, `tests/test_entitlement_lock_reason_at.py` — 160 passed

### Coverage in `tests/test_entitlement_next_prev_tier_lock_reason_batch.py`

- Helper class-method shape (5-axis dict, `_lock_row` 8-key rows)
- Byte-parity with `lock_reasons_at_batch(target, ...)` at the resolved next / previous purchasable target across every tier in `_TIER_ORDER`
- Byte-parity with `next_tier_lock_reason_at_batch(tier, ...)` / `previous_tier_lock_reason_at_batch(tier, ...)` for every source where source-aware == source-agnostic
- Ceiling (enterprise) → `target=null` + grace-shape rows for every axis
- Floor (oss / cloud_free) → `target=null` + grace-shape rows for every axis
- Trial-as-source: next → enterprise, previous → cloud_starter (same as sibling `_batch` families)
- Capacity axes (`channels` / `retention_days` / `nodes`) routed through the kwarg surface + `None` sentinel when not supplied
- Grace vs enforce → byte-identical bodies (catalogue-derived)
- Module-level wrappers match the bound method on the resolved entitlement
- Helpers never raise on synthesised `next_purchasable_tier` failure — grace-shape fallback via `_empty_lock_reasons_at_batch`
- Module wrappers never raise on synthesised `get_entitlement` failure
- HTTP endpoints: `_API_ENVELOPE_KEYS` shape, 400 on no-axis, 400 on empty-csv-and-no-capacity, 200 when only a capacity axis is supplied, byte-parity with helper body, never-5xxs on internal failure (200 with grace envelope)

## Local operator verification checklist

The public-repo agent cannot exercise the live daemon, cloud snapshot, or browser. Please copy the two changed source files into your locally-installed clawmetry site-packages and verify against the real daemon before flipping ready-for-review:

```bash
# 1. Copy the new/changed files into the installed package
SP="$HOME/.clawmetry/lib/python$(python3 -c 'import sys;print(f"{sys.version_info.major}.{sys.version_info.minor}")')/site-packages/clawmetry"
cp clawmetry/entitlements.py "$SP/entitlements.py"
# routes/ isn't inside the package — copy to wherever your install lays it out;
# on the default layout it's at $HOME/.clawmetry/lib/python*/site-packages/routes/entitlement.py
find "$HOME/.clawmetry" -name entitlement.py -path '*routes*' -exec cp routes/entitlement.py {} \;

# 2. Purge stale bytecode so the new module actually loads
find "$HOME/.clawmetry" -type d -name __pycache__ -exec rm -rf {} +

# 3. Bounce the sync daemon so it re-imports
launchctl kickstart -k "gui/$(id -u)/com.clawmetry.sync"

# 4. Hit the new endpoints
curl -s 'http://localhost:8900/api/entitlement/next-tier-lock-reason-batch?features=custom_alerts&runtimes=claude_code&channels=5' | jq
curl -s 'http://localhost:8900/api/entitlement/previous-tier-lock-reason-batch?features=custom_alerts' | jq
# Expect: 200 with the shape documented in the endpoint docstrings; features/runtimes rows carry
# 8 keys each; target/target_label/target_rank echo the source-aware next / previous rung.

# 5. Parity with the source-agnostic _at_batch sibling for non-boundary sources
CUR=$(curl -s http://localhost:8900/api/entitlement | jq -r .tier)
diff \
  <(curl -s "http://localhost:8900/api/entitlement/next-tier-lock-reason-batch?features=custom_alerts" \
      | jq 'del(.current_tier,.current_tier_label,.current_tier_rank)') \
  <(curl -s "http://localhost:8900/api/entitlement/next-tier-lock-reason-at-batch?tier=$CUR&features=custom_alerts" \
      | jq 'del(.tier,.tier_label,.tier_rank,.current_tier,.current_tier_rank)')
# Expect: empty diff for any source where source-aware and source-agnostic resolve to the same rung
# (i.e. everything except the free/starter boundary).

# 6. Decrypt the live cloud snapshot in the browser + eyeball the paywall matrix surface
# — no client changes here, but sanity-check no regressions on the existing
# /next-tier-lock-reason and /next-tier-lock-reason-at-batch endpoints.
```

If everything looks right, flip to ready-for-review and merge in the normal flow. Only the local operator has access to the live daemon and snapshot for step 6, which is why this PR stays draft until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qomjd1USVrr9AcrL1CTVnF


---
_Generated by [Claude Code](https://claude.ai/code/session_01Qomjd1USVrr9AcrL1CTVnF)_