### PR TITLE
feat(entitlement): upgrade_path_at + downgrade_path_at + 2 endpoints

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -3249,6 +3249,156 @@ def downgrade_path() -> list[dict]:
         return []
 
 
+def upgrade_path_at(tier: str) -> list[dict] | None:
+    """Source-anchored what-if sibling of :func:`upgrade_path`: ordered
+    marginal-unlock ladder from the caller-supplied ``tier`` upward.
+
+    Where :func:`upgrade_path` pins the walk's starting point to the
+    resolved entitlement, this walks strictly above the caller-supplied
+    ``tier`` -- the same what-if pattern :func:`next_tier_spec_at` /
+    :func:`next_tier_unlocks_at` / :func:`next_tier_diff_at` apply to
+    the scalar rung above. Lets a "compare from tier X" pricing wizard
+    render the sequenced upgrade ladder for any hypothetical source
+    without monkey-patching the entitlement context.
+
+    Row shape matches :func:`upgrade_path` byte-for-byte -- each row is
+    :func:`tier_unlocks` for the destination rung, whose ``previous_tier``
+    is that rung's natural next-lower purchasable (NOT the caller-
+    supplied ``tier``). Callers that want a source-anchored
+    ``previous_tier`` echo should compose :func:`tier_unlocks_at`
+    directly. Same-rank siblings of the ceiling are both included; same-
+    rank siblings of the source are excluded (only strictly-higher-rank
+    rungs walk), matching :func:`upgrade_path` and :func:`tier_path`.
+
+    Accepts any id in :data:`_TIER_ORDER` (including :data:`TIER_TRIAL`)
+    -- the lenient ``_at`` posture, matching the other ``*_at`` helpers.
+    Byte-parity contract: when ``tier`` equals the resolved entitlement's
+    tier, ``upgrade_path_at(tier)`` is byte-identical to
+    :func:`upgrade_path` (pinned by tests so the scalar and what-if
+    accessors cannot drift).
+
+    Returns ``None`` for empty / unknown ``tier``, and an empty list at
+    the ceiling (enterprise -- nothing strictly above). Never raises:
+    a builder failure short-circuits to ``[]`` so a pricing-wizard
+    surface keeps rendering instead of breaking.
+    """
+    try:
+        src = (tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if not src or src not in _TIER_ORDER:
+        return None
+    try:
+        src_rank = _TIER_RANK.get(src, -1)
+        ordered = sorted(
+            _PURCHASABLE_TIERS,
+            key=lambda t: (_TIER_RANK.get(t, -1), t),
+        )
+        path: list[dict] = []
+        for tid in ordered:
+            cand_rank = _TIER_RANK.get(tid, -1)
+            if cand_rank <= src_rank:
+                continue
+            row = tier_unlocks(tid)
+            if row is not None:
+                path.append(row)
+        return path
+    except Exception as exc:
+        logger.warning("entitlements: upgrade_path_at failed: %s", exc)
+        return []
+
+
+def downgrade_path_at(tier: str) -> list[dict] | None:
+    """Source-anchored what-if sibling of :func:`downgrade_path`: ordered
+    cumulative-loss ladder from the caller-supplied ``tier`` downward.
+
+    Direction-flipped mirror of :func:`upgrade_path_at` and source-
+    anchored equivalent of :func:`downgrade_path` (which pins the walk's
+    starting point to the resolved entitlement). Convenience for a
+    "compare from tier X" downgrade-warning surface: renders "if a caller
+    on ``tier`` dropped to each rung below, here's what they'd lose"
+    without monkey-patching the entitlement context.
+
+    Row shape matches :func:`downgrade_path` field-for-field, with the
+    what-if source substituted for the live resolver in ``current_tier`` /
+    ``current_tier_label`` / ``current_tier_rank`` (the field names are
+    retained for byte-shape parity with :func:`downgrade_path`, and mean
+    "the source of the walk" in the ``_at`` variant)::
+
+        {
+          "target":             "<tier id>",
+          "target_label":       "<display>",
+          "target_rank":        <int>,
+          "current_tier":       "<source tier id>",
+          "current_tier_label": "<display>",
+          "current_tier_rank":  <int>,
+          "lost_features":      [...],
+          "lost_runtimes":      [...],
+        }
+
+    Cumulative not marginal, matching :func:`downgrade_path`:
+    ``lost_features`` / ``lost_runtimes`` on each row reflect the *full*
+    delta between ``tier`` and that row's destination -- so the lists
+    strictly grow as the path descends. The deltas are computed from the
+    catalogue against ``tier`` directly (via :func:`tier_diff`), NOT via
+    the resolver's :meth:`Entitlement.downgrade_diff`, so a caller with a
+    resolved entitlement wider than the catalogue's static grant (e.g. an
+    enterprise entitlement mid-tier walk) still gets a stable what-if
+    answer.
+
+    Accepts any id in :data:`_TIER_ORDER` (including :data:`TIER_TRIAL`)
+    -- the lenient ``_at`` posture. Byte-parity contract: when ``tier``
+    equals the resolved entitlement's tier AND the caller's entitlement
+    is a plain catalogue tier (no bespoke feature/runtime overrides),
+    ``downgrade_path_at(tier)`` is byte-identical to
+    :func:`downgrade_path` (pinned by tests so the scalar and what-if
+    accessors cannot drift on catalogue-shaped entitlements).
+
+    Rows are sorted by ``(-tier_rank, tier_id)`` so the closest-to-source
+    rung sits first, matching :func:`downgrade_path`.
+
+    Returns ``None`` for empty / unknown ``tier``, and an empty list at
+    the floor (oss / cloud_free -- no rung strictly below). Never raises:
+    a builder failure short-circuits to ``[]`` so a downgrade-warning
+    surface keeps rendering instead of breaking.
+    """
+    try:
+        src = (tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if not src or src not in _TIER_ORDER:
+        return None
+    try:
+        src_rank = _TIER_RANK.get(src, -1)
+        src_label = tier_label(src)
+        ordered = sorted(
+            _PURCHASABLE_TIERS,
+            key=lambda t: (-_TIER_RANK.get(t, -1), t),
+        )
+        path: list[dict] = []
+        for tid in ordered:
+            cand_rank = _TIER_RANK.get(tid, -1)
+            if cand_rank < 0 or cand_rank >= src_rank:
+                continue
+            diff = tier_diff(src, tid) or {}
+            path.append(
+                {
+                    "target": tid,
+                    "target_label": tier_label(tid),
+                    "target_rank": cand_rank,
+                    "current_tier": src,
+                    "current_tier_label": src_label,
+                    "current_tier_rank": src_rank,
+                    "lost_features": list(diff.get("lost_features") or []),
+                    "lost_runtimes": list(diff.get("lost_runtimes") or []),
+                }
+            )
+        return path
+    except Exception as exc:
+        logger.warning("entitlements: downgrade_path_at failed: %s", exc)
+        return []
+
+
 def resolution_diagnostic() -> dict:
     out: dict = {
         "license_path": _LICENSE_PATH,

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -1864,6 +1864,160 @@ def api_entitlement_downgrade_path():
         )
 
 
+@bp_entitlement.route("/api/entitlement/upgrade-path-at")
+def api_entitlement_upgrade_path_at():
+    """``GET /api/entitlement/upgrade-path-at?tier=<source>`` -- scalar
+    what-if sibling of ``/api/entitlement/upgrade-path``: ordered
+    marginal-unlock ladder from the caller-supplied ``tier`` upward.
+
+    Source-anchored equivalent of ``/upgrade-path`` (which pins the
+    walk's starting point to the resolver) -- the ``_at`` sibling in
+    the ladder-walk family alongside ``/next-tier-spec-at``,
+    ``/next-tier-unlocks-at``, ``/next-tier-locks-at``,
+    ``/next-tier-diff-at`` and ``/next-tier-capacity-diff-at``.
+    Lets a pricing-page "from tier X" wizard render the full upgrade
+    ladder for any hypothetical source rung without first switching
+    the resolver.
+
+    Response shape mirrors ``/upgrade-path`` with the ``current_tier`` /
+    ``current_tier_rank`` echo replaced by the caller-supplied ``tier``::
+
+        {
+          "tier":              "<source>",
+          "tier_label":        "<display>",
+          "tier_rank":         <int>,
+          "path":              [<row>, ...],
+          "current_tier":      "<resolved tier>",
+          "current_tier_rank": <int>,
+          "grace":             <bool>,
+          "enforced":          <bool>,
+        }
+
+    Each ``<row>`` matches ``/api/entitlement/tier-unlocks`` exactly
+    (``tier``, ``tier_label``, ``tier_rank``, ``previous_tier``, ...),
+    byte-identical to the corresponding row in ``/upgrade-path`` when
+    ``tier`` equals the resolved entitlement -- pinned by parity tests so
+    the source-anchored and live variants cannot drift.
+
+    Missing / empty ``tier`` -> 400. Unknown ``tier`` -> 404. Enterprise
+    source -> 200 with ``path: []`` (already at the top). Never 5xxs: a
+    resolver failure yields the grace-shape envelope so the wizard keeps
+    rendering.
+    """
+    tier = (request.args.get("tier") or "").strip().lower()
+    if not tier:
+        return jsonify({"error": "tier query parameter is required"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        if tier not in _ent._TIER_ORDER:
+            return jsonify({"error": "unknown tier", "tier": tier}), 404
+        path = _ent.upgrade_path_at(tier) or []
+        ent = _ent.get_entitlement()
+        return jsonify(
+            {
+                "tier": tier,
+                "tier_label": _ent.tier_label(tier),
+                "tier_rank": _ent.tier_rank(tier),
+                "path": path,
+                "current_tier": ent.tier,
+                "current_tier_rank": _ent.tier_rank(ent.tier),
+                "grace": bool(ent.grace),
+                "enforced": _ent.is_enforced(),
+            }
+        )
+    except Exception as exc:
+        logger.warning("api_entitlement_upgrade_path_at: error: %s", exc)
+        return jsonify(
+            {
+                "tier": tier,
+                "tier_label": tier,
+                "tier_rank": -1,
+                "path": [],
+                "current_tier": "oss",
+                "current_tier_rank": 0,
+                "grace": True,
+                "enforced": False,
+            }
+        )
+
+
+@bp_entitlement.route("/api/entitlement/downgrade-path-at")
+def api_entitlement_downgrade_path_at():
+    """``GET /api/entitlement/downgrade-path-at?tier=<source>`` -- scalar
+    what-if sibling of ``/api/entitlement/downgrade-path``: ordered
+    cumulative-loss ladder from the caller-supplied ``tier`` downward.
+
+    Source-anchored mirror of ``/api/entitlement/upgrade-path-at`` and
+    downgrade-side counterpart of the live ``/downgrade-path`` (source
+    pinned to the resolver). Lets a "compare from tier X" downgrade-
+    warning surface render every rung's loss list for any hypothetical
+    source without first asking the resolver.
+
+    Response shape mirrors ``/downgrade-path`` with the ``current_tier`` /
+    ``current_tier_rank`` echo replaced by the caller-supplied ``tier``::
+
+        {
+          "tier":              "<source>",
+          "tier_label":        "<display>",
+          "tier_rank":         <int>,
+          "path":              [<row>, ...],
+          "current_tier":      "<resolved tier>",
+          "current_tier_rank": <int>,
+          "grace":             <bool>,
+          "enforced":          <bool>,
+        }
+
+    Each ``<row>`` carries the destination tier metadata + the walk's
+    source echo (``current_tier`` / ``current_tier_label`` /
+    ``current_tier_rank`` retain their :func:`downgrade_path` names for
+    byte-shape parity, and carry the ``_at`` source in this variant) +
+    ``lost_features`` / ``lost_runtimes`` cumulative over the gap (see
+    :func:`clawmetry.entitlements.downgrade_path_at`).
+
+    Missing / empty ``tier`` -> 400. Unknown ``tier`` -> 404. Floor
+    source (oss / cloud_free) -> 200 with ``path: []`` (no rung strictly
+    below). Never 5xxs: a resolver failure yields the grace-shape
+    envelope so the surface keeps rendering.
+    """
+    tier = (request.args.get("tier") or "").strip().lower()
+    if not tier:
+        return jsonify({"error": "tier query parameter is required"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        if tier not in _ent._TIER_ORDER:
+            return jsonify({"error": "unknown tier", "tier": tier}), 404
+        path = _ent.downgrade_path_at(tier) or []
+        ent = _ent.get_entitlement()
+        return jsonify(
+            {
+                "tier": tier,
+                "tier_label": _ent.tier_label(tier),
+                "tier_rank": _ent.tier_rank(tier),
+                "path": path,
+                "current_tier": ent.tier,
+                "current_tier_rank": _ent.tier_rank(ent.tier),
+                "grace": bool(ent.grace),
+                "enforced": _ent.is_enforced(),
+            }
+        )
+    except Exception as exc:
+        logger.warning("api_entitlement_downgrade_path_at: error: %s", exc)
+        return jsonify(
+            {
+                "tier": tier,
+                "tier_label": tier,
+                "tier_rank": -1,
+                "path": [],
+                "current_tier": "oss",
+                "current_tier_rank": 0,
+                "grace": True,
+                "enforced": False,
+            }
+        )
+
+
 _CAPACITY_PARAMS = ("channels", "retention_days", "nodes")
 
 

--- a/tests/test_entitlement_downgrade_path_at.py
+++ b/tests/test_entitlement_downgrade_path_at.py
@@ -1,0 +1,309 @@
+"""Tests for ``clawmetry.entitlements.downgrade_path_at`` +
+``GET /api/entitlement/downgrade-path-at``.
+
+Source-anchored what-if sibling of :mod:`test_entitlement_downgrade_path`:
+walks strictly below a caller-supplied hypothetical ``tier`` and returns
+the cumulative-loss row for each rung. Pins the per-source ladder + row
+shape + parity contract with the live :func:`downgrade_path` so a
+"compare from tier X" downgrade-warning surface keeps rendering when
+``_PURCHASABLE_TIERS`` / ``_TIER_RANK`` / ``_TIER_FEATURES`` shift
+underneath it.
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+def _force_tier(monkeypatch, ent, tier: str):
+    synthetic = ent._build(tier, source="test")
+
+    def _stub(force: bool = False):  # noqa: ARG001
+        return synthetic
+
+    monkeypatch.setattr(ent, "get_entitlement", _stub)
+
+
+# -- shape -----------------------------------------------------------------
+
+
+def test_returns_list_for_known_source(ent):
+    assert isinstance(ent.downgrade_path_at(ent.TIER_ENTERPRISE), list)
+
+
+def test_each_row_shape(ent):
+    path = ent.downgrade_path_at(ent.TIER_ENTERPRISE)
+    expected_keys = {
+        "target",
+        "target_label",
+        "target_rank",
+        "current_tier",
+        "current_tier_label",
+        "current_tier_rank",
+        "lost_features",
+        "lost_runtimes",
+    }
+    for row in path:
+        assert set(row.keys()) == expected_keys
+
+
+def test_source_echo_matches_caller_supplied(ent):
+    # current_tier / current_tier_label / current_tier_rank echo the
+    # caller-supplied `_at` source (not the resolver) so a per-row consumer
+    # can label the "from" side of the transition.
+    path = ent.downgrade_path_at(ent.TIER_PRO)
+    for row in path:
+        assert row["current_tier"] == ent.TIER_PRO
+        assert row["current_tier_label"] == ent.tier_label(ent.TIER_PRO)
+        assert row["current_tier_rank"] == ent.tier_rank(ent.TIER_PRO)
+
+
+# -- per-source ladder -----------------------------------------------------
+
+
+def test_floor_source_is_empty(ent):
+    assert ent.downgrade_path_at(ent.TIER_OSS) == []
+    assert ent.downgrade_path_at(ent.TIER_CLOUD_FREE) == []
+
+
+def test_starter_source_has_only_floor_pair(ent):
+    tiers = [r["target"] for r in ent.downgrade_path_at(ent.TIER_CLOUD_STARTER)]
+    # rank 0 siblings, sorted by id ascending after the -rank sort.
+    assert set(tiers) == {ent.TIER_OSS, ent.TIER_CLOUD_FREE}
+
+
+def test_pro_source_walks_all_rungs_below(ent):
+    tiers = [r["target"] for r in ent.downgrade_path_at(ent.TIER_PRO)]
+    # Descending: rank 1 (starter) first, then rank 0 pair.
+    # `pro` is rank 2 -- same-rank siblings (cloud_pro) are excluded.
+    assert tiers[0] == ent.TIER_CLOUD_STARTER
+    assert set(tiers[1:]) == {ent.TIER_OSS, ent.TIER_CLOUD_FREE}
+
+
+def test_enterprise_source_full_lower_ladder(ent):
+    tiers = [r["target"] for r in ent.downgrade_path_at(ent.TIER_ENTERPRISE)]
+    # Descending: rank 2 pair (cloud_pro then pro), rank 1, rank 0 pair.
+    assert tiers[0] == ent.TIER_CLOUD_PRO
+    assert tiers[1] == ent.TIER_PRO
+    assert tiers[2] == ent.TIER_CLOUD_STARTER
+    assert set(tiers[3:]) == {ent.TIER_OSS, ent.TIER_CLOUD_FREE}
+
+
+def test_trial_source_walks_below(ent):
+    # Trial (rank 2) -- strictly-below walk lands on rank 1 (starter) then
+    # rank 0 pair. Same-rank siblings (pro / cloud_pro) excluded.
+    tiers = [r["target"] for r in ent.downgrade_path_at(ent.TIER_TRIAL)]
+    assert tiers[0] == ent.TIER_CLOUD_STARTER
+    assert set(tiers[1:]) == {ent.TIER_OSS, ent.TIER_CLOUD_FREE}
+
+
+# -- cumulative shape ------------------------------------------------------
+
+
+def test_lost_lists_monotonically_grow(ent):
+    # Cumulative: each further-down rung's loss list is a superset of the
+    # closer rung's.
+    path = ent.downgrade_path_at(ent.TIER_ENTERPRISE)
+    for a, b in zip(path, path[1:]):
+        assert set(a["lost_features"]) <= set(b["lost_features"])
+        assert set(a["lost_runtimes"]) <= set(b["lost_runtimes"])
+
+
+def test_lost_lists_sorted(ent):
+    path = ent.downgrade_path_at(ent.TIER_ENTERPRISE)
+    for row in path:
+        assert row["lost_features"] == sorted(row["lost_features"])
+        assert row["lost_runtimes"] == sorted(row["lost_runtimes"])
+
+
+def test_lost_lists_match_tier_diff(ent):
+    # Each row's cumulative loss list matches tier_diff(source, target)
+    # -- the _at variant uses tier_diff to stay catalogue-anchored.
+    src = ent.TIER_ENTERPRISE
+    for row in ent.downgrade_path_at(src):
+        diff = ent.tier_diff(src, row["target"])
+        assert diff is not None
+        assert row["lost_features"] == list(diff["lost_features"])
+        assert row["lost_runtimes"] == list(diff["lost_runtimes"])
+
+
+# -- parity with live downgrade_path ---------------------------------------
+
+
+def test_at_source_matches_live_when_source_equals_current(monkeypatch, ent):
+    # For a plain-catalogue current tier (no runtime overrides), the
+    # `_at` variant is byte-identical to the live path.
+    for tier in (
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_PRO,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_ENTERPRISE,
+    ):
+        _force_tier(monkeypatch, ent, tier)
+        assert ent.downgrade_path_at(tier) == ent.downgrade_path(), tier
+
+
+# -- ordering / stability --------------------------------------------------
+
+
+def test_ordered_by_neg_rank_then_tier_id(ent):
+    path = ent.downgrade_path_at(ent.TIER_ENTERPRISE)
+    ranks = [row["target_rank"] for row in path]
+    assert ranks == sorted(ranks, reverse=True)
+    # Same-rank cluster (rank 0): cloud_free < oss lexicographically.
+    rank0 = [row["target"] for row in path if row["target_rank"] == 0]
+    assert rank0 == sorted(rank0)
+
+
+def test_stable_across_calls(ent):
+    a = ent.downgrade_path_at(ent.TIER_ENTERPRISE)
+    b = ent.downgrade_path_at(ent.TIER_ENTERPRISE)
+    c = ent.downgrade_path_at(ent.TIER_ENTERPRISE)
+    assert a == b == c
+
+
+def test_trial_never_in_path(ent):
+    # Trial is a promotional grant, not purchasable. Downgrade CTA must
+    # never route to it.
+    for src in (ent.TIER_ENTERPRISE, ent.TIER_PRO, ent.TIER_CLOUD_STARTER):
+        ids = {r["target"] for r in ent.downgrade_path_at(src)}
+        assert ent.TIER_TRIAL not in ids
+
+
+# -- lenient _at posture ---------------------------------------------------
+
+
+def test_unknown_tier_returns_none(ent):
+    assert ent.downgrade_path_at("nope") is None
+    assert ent.downgrade_path_at("") is None
+    assert ent.downgrade_path_at(None) is None  # type: ignore[arg-type]
+
+
+def test_whitespace_and_casing_normalised(ent):
+    a = ent.downgrade_path_at("  ENTERPRISE  ")
+    b = ent.downgrade_path_at(ent.TIER_ENTERPRISE)
+    assert a == b
+
+
+# -- safety ----------------------------------------------------------------
+
+
+def test_never_raises_on_builder_failure(monkeypatch, ent):
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "tier_diff", boom)
+    assert ent.downgrade_path_at(ent.TIER_ENTERPRISE) == []
+
+
+def test_does_not_mutate_live_entitlement(ent):
+    before = ent.get_entitlement().to_dict()
+    ent.downgrade_path_at(ent.TIER_ENTERPRISE)
+    after = ent.get_entitlement().to_dict()
+    assert before == after
+
+
+# -- API surface -----------------------------------------------------------
+
+
+def test_api_envelope_shape(client, ent):
+    rv = client.get(
+        f"/api/entitlement/downgrade-path-at?tier={ent.TIER_ENTERPRISE}",
+    )
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert set(body.keys()) == {
+        "tier",
+        "tier_label",
+        "tier_rank",
+        "path",
+        "current_tier",
+        "current_tier_rank",
+        "grace",
+        "enforced",
+    }
+
+
+def test_api_enterprise_source_full_lower_ladder(client, ent):
+    rv = client.get(
+        f"/api/entitlement/downgrade-path-at?tier={ent.TIER_ENTERPRISE}",
+    )
+    body = rv.get_json()
+    assert body["tier"] == ent.TIER_ENTERPRISE
+    tiers = [row["target"] for row in body["path"]]
+    assert tiers[0] == ent.TIER_CLOUD_PRO
+
+
+def test_api_floor_source_empty(client, ent):
+    rv = client.get(f"/api/entitlement/downgrade-path-at?tier={ent.TIER_OSS}")
+    body = rv.get_json()
+    assert body["tier"] == ent.TIER_OSS
+    assert body["path"] == []
+
+
+def test_api_body_parity_with_live_downgrade_path(client, ent, monkeypatch):
+    # For a plain-catalogue current tier, the `path` array is
+    # byte-identical to the live endpoint's `path`.
+    _force_tier(monkeypatch, ent, ent.TIER_ENTERPRISE)
+    at = client.get(
+        f"/api/entitlement/downgrade-path-at?tier={ent.TIER_ENTERPRISE}",
+    ).get_json()
+    live = client.get("/api/entitlement/downgrade-path").get_json()
+    assert at["path"] == live["path"]
+
+
+def test_api_missing_tier_400(client):
+    rv = client.get("/api/entitlement/downgrade-path-at")
+    assert rv.status_code == 400
+    assert "error" in rv.get_json()
+
+
+def test_api_empty_tier_400(client):
+    rv = client.get("/api/entitlement/downgrade-path-at?tier=")
+    assert rv.status_code == 400
+
+
+def test_api_unknown_tier_404(client):
+    rv = client.get("/api/entitlement/downgrade-path-at?tier=nope")
+    assert rv.status_code == 404
+    body = rv.get_json()
+    assert body["error"] == "unknown tier"
+    assert body["tier"] == "nope"
+
+
+def test_api_never_5xxs_on_resolver_failure(client, ent, monkeypatch):
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "get_entitlement", boom)
+    rv = client.get(
+        f"/api/entitlement/downgrade-path-at?tier={ent.TIER_ENTERPRISE}",
+    )
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["path"] == []
+    assert body["grace"] is True
+    assert body["enforced"] is False

--- a/tests/test_entitlement_upgrade_path_at.py
+++ b/tests/test_entitlement_upgrade_path_at.py
@@ -1,0 +1,306 @@
+"""Tests for ``clawmetry.entitlements.upgrade_path_at`` +
+``GET /api/entitlement/upgrade-path-at``.
+
+Source-anchored what-if sibling of :mod:`test_entitlement_upgrade_path`:
+where the live variant pins the walk's start to the resolver, this one
+walks strictly above a caller-supplied hypothetical ``tier``. Pins the
+per-source ladder + per-row shape + parity contract with the live
+:func:`upgrade_path` so a pricing-wizard "compare from tier X" surface
+keeps rendering when ``_PURCHASABLE_TIERS`` / ``_TIER_RANK`` shift
+underneath it.
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+def _force_tier(monkeypatch, ent, tier: str):
+    synthetic = ent._build(tier, source="test")
+
+    def _stub(force: bool = False):  # noqa: ARG001
+        return synthetic
+
+    monkeypatch.setattr(ent, "get_entitlement", _stub)
+
+
+# -- shape -----------------------------------------------------------------
+
+
+def test_returns_list_for_known_source(ent):
+    path = ent.upgrade_path_at(ent.TIER_OSS)
+    assert isinstance(path, list)
+
+
+def test_each_row_matches_tier_unlocks_shape(ent):
+    path = ent.upgrade_path_at(ent.TIER_OSS)
+    expected_keys = {
+        "tier",
+        "tier_label",
+        "tier_rank",
+        "previous_tier",
+        "previous_tier_label",
+        "previous_tier_rank",
+        "features",
+        "runtimes",
+    }
+    for row in path:
+        assert set(row.keys()) == expected_keys
+
+
+def test_rows_byte_equal_to_singular_tier_unlocks(ent):
+    # Row equality with the singular endpoint -- the _at helper is a pure
+    # source-anchored plural sibling, not a divergent path.
+    path = ent.upgrade_path_at(ent.TIER_OSS)
+    for row in path:
+        assert row == ent.tier_unlocks(row["tier"])
+
+
+# -- per-source ladder -----------------------------------------------------
+
+
+def test_oss_source_full_upper_ladder(ent):
+    tiers = [row["tier"] for row in ent.upgrade_path_at(ent.TIER_OSS)]
+    assert tiers == [
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_PRO,
+        ent.TIER_ENTERPRISE,
+    ]
+
+
+def test_cloud_free_source_matches_oss_source(ent):
+    # Both are rank 0, so ladder above is identical.
+    a = [r["tier"] for r in ent.upgrade_path_at(ent.TIER_CLOUD_FREE)]
+    b = [r["tier"] for r in ent.upgrade_path_at(ent.TIER_OSS)]
+    assert a == b
+
+
+def test_starter_source_drops_starter_and_below(ent):
+    tiers = [row["tier"] for row in ent.upgrade_path_at(ent.TIER_CLOUD_STARTER)]
+    assert tiers == [
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_PRO,
+        ent.TIER_ENTERPRISE,
+    ]
+
+
+def test_cloud_pro_source_is_enterprise_only(ent):
+    # Same-rank siblings (rank 2 pro / cloud_pro) excluded, only strictly
+    # above (enterprise) remains.
+    assert [r["tier"] for r in ent.upgrade_path_at(ent.TIER_CLOUD_PRO)] == [
+        ent.TIER_ENTERPRISE,
+    ]
+
+
+def test_self_hosted_pro_source_mirrors_cloud_pro(ent):
+    assert [r["tier"] for r in ent.upgrade_path_at(ent.TIER_PRO)] == [
+        ent.TIER_ENTERPRISE,
+    ]
+
+
+def test_enterprise_source_is_empty(ent):
+    assert ent.upgrade_path_at(ent.TIER_ENTERPRISE) == []
+
+
+def test_trial_source_walks_past_same_rank(ent):
+    # Trial is rank 2, same as pro / cloud_pro. Strictly-above walk should
+    # skip same-rank siblings and only land on enterprise.
+    assert [r["tier"] for r in ent.upgrade_path_at(ent.TIER_TRIAL)] == [
+        ent.TIER_ENTERPRISE,
+    ]
+
+
+# -- parity with live upgrade_path -----------------------------------------
+
+
+def test_at_source_matches_live_when_source_equals_current(ent):
+    # Byte-parity: for any resolved current tier, upgrade_path_at(current)
+    # returns the same rows as the live upgrade_path().
+    live = ent.upgrade_path()
+    at = ent.upgrade_path_at(ent.TIER_OSS)  # fixture resolves to OSS
+    assert at == live
+
+
+def test_at_source_parity_across_forced_tiers(monkeypatch, ent):
+    for tier in (
+        ent.TIER_OSS,
+        ent.TIER_CLOUD_FREE,
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_PRO,
+        ent.TIER_ENTERPRISE,
+    ):
+        _force_tier(monkeypatch, ent, tier)
+        assert ent.upgrade_path_at(tier) == ent.upgrade_path(), tier
+
+
+# -- ordering / stability --------------------------------------------------
+
+
+def test_ordered_by_rank_then_tier_id(ent):
+    path = ent.upgrade_path_at(ent.TIER_OSS)
+    ranks = [row["tier_rank"] for row in path]
+    assert ranks == sorted(ranks)
+    rank2 = [row["tier"] for row in path if row["tier_rank"] == 2]
+    assert rank2 == sorted(rank2)
+
+
+def test_stable_across_calls(ent):
+    a = ent.upgrade_path_at(ent.TIER_OSS)
+    b = ent.upgrade_path_at(ent.TIER_OSS)
+    c = ent.upgrade_path_at(ent.TIER_OSS)
+    assert a == b == c
+
+
+def test_trial_never_in_path(ent):
+    for src in (ent.TIER_OSS, ent.TIER_CLOUD_STARTER, ent.TIER_PRO):
+        ids = {row["tier"] for row in ent.upgrade_path_at(src)}
+        assert ent.TIER_TRIAL not in ids
+
+
+# -- lenient _at posture ---------------------------------------------------
+
+
+def test_unknown_tier_returns_none(ent):
+    assert ent.upgrade_path_at("nope") is None
+    assert ent.upgrade_path_at("") is None
+    assert ent.upgrade_path_at(None) is None  # type: ignore[arg-type]
+
+
+def test_whitespace_and_casing_normalised(ent):
+    assert ent.upgrade_path_at("  OSS  ") == ent.upgrade_path_at(ent.TIER_OSS)
+
+
+# -- safety ----------------------------------------------------------------
+
+
+def test_never_raises_on_builder_failure(monkeypatch, ent):
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "tier_unlocks", boom)
+    assert ent.upgrade_path_at(ent.TIER_OSS) == []
+
+
+def test_does_not_mutate_live_entitlement(ent):
+    before = ent.get_entitlement().to_dict()
+    ent.upgrade_path_at(ent.TIER_PRO)
+    after = ent.get_entitlement().to_dict()
+    assert before == after
+
+
+# -- API surface -----------------------------------------------------------
+
+
+def test_api_envelope_shape(client, ent):
+    rv = client.get(f"/api/entitlement/upgrade-path-at?tier={ent.TIER_OSS}")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert set(body.keys()) == {
+        "tier",
+        "tier_label",
+        "tier_rank",
+        "path",
+        "current_tier",
+        "current_tier_rank",
+        "grace",
+        "enforced",
+    }
+
+
+def test_api_oss_source_full_ladder(client, ent):
+    rv = client.get(f"/api/entitlement/upgrade-path-at?tier={ent.TIER_OSS}")
+    body = rv.get_json()
+    assert body["tier"] == ent.TIER_OSS
+    assert body["tier_rank"] == 0
+    tiers = [row["tier"] for row in body["path"]]
+    assert tiers == [
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_PRO,
+        ent.TIER_ENTERPRISE,
+    ]
+
+
+def test_api_row_parity_with_singular_endpoint(client, ent):
+    rv = client.get(f"/api/entitlement/upgrade-path-at?tier={ent.TIER_OSS}")
+    body = rv.get_json()
+    for row in body["path"]:
+        single = client.get(
+            f"/api/entitlement/tier-unlocks?tier={row['tier']}",
+        ).get_json()
+        assert row == single
+
+
+def test_api_body_parity_with_live_upgrade_path(client, ent):
+    # Envelopes differ (extra tier / tier_label / tier_rank echo), but the
+    # `path` array is byte-identical when source == current.
+    at = client.get(
+        f"/api/entitlement/upgrade-path-at?tier={ent.TIER_OSS}",
+    ).get_json()
+    live = client.get("/api/entitlement/upgrade-path").get_json()
+    assert at["path"] == live["path"]
+
+
+def test_api_enterprise_source_is_empty(client, ent):
+    rv = client.get(f"/api/entitlement/upgrade-path-at?tier={ent.TIER_ENTERPRISE}")
+    body = rv.get_json()
+    assert body["tier"] == ent.TIER_ENTERPRISE
+    assert body["path"] == []
+
+
+def test_api_missing_tier_400(client):
+    rv = client.get("/api/entitlement/upgrade-path-at")
+    assert rv.status_code == 400
+    body = rv.get_json()
+    assert "error" in body
+
+
+def test_api_empty_tier_400(client):
+    rv = client.get("/api/entitlement/upgrade-path-at?tier=")
+    assert rv.status_code == 400
+
+
+def test_api_unknown_tier_404(client):
+    rv = client.get("/api/entitlement/upgrade-path-at?tier=nope")
+    assert rv.status_code == 404
+    body = rv.get_json()
+    assert body["error"] == "unknown tier"
+    assert body["tier"] == "nope"
+
+
+def test_api_never_5xxs_on_resolver_failure(client, ent, monkeypatch):
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "get_entitlement", boom)
+    rv = client.get(f"/api/entitlement/upgrade-path-at?tier={ent.TIER_OSS}")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["path"] == []
+    assert body["grace"] is True
+    assert body["enforced"] is False


### PR DESCRIPTION
## Summary

Adds source-anchored what-if siblings of the currently current-relative-only `upgrade_path()` / `downgrade_path()` -- the `_at` members of the ladder-walk family alongside `next_tier_spec_at`, `next_tier_unlocks_at`, `next_tier_diff_at`, and `next_tier_capacity_diff_at` (which already have source-anchored variants at the *scalar* rung level; this fills in the *ladder* level).

- `Entitlement` module-level `upgrade_path_at(tier)` — ordered marginal-unlock ladder from a caller-supplied source; row shape matches `upgrade_path()` byte-for-byte (each row is `tier_unlocks(destination)`). Byte-identical to `upgrade_path()` when `tier` equals the resolved entitlement's tier.
- `downgrade_path_at(tier)` — ordered cumulative-loss ladder from a caller-supplied source. Deltas are computed from the catalogue via `tier_diff(source, target)` (not via the resolver's `Entitlement.downgrade_diff`), so a caller with a resolved entitlement wider than the catalogue's static grant still gets a stable what-if answer. Byte-identical to `downgrade_path()` on plain-catalogue current tiers.
- `GET /api/entitlement/upgrade-path-at?tier=<source>`
- `GET /api/entitlement/downgrade-path-at?tier=<source>`

Both endpoints echo the source in `tier` / `tier_label` / `tier_rank` at the envelope level and keep the `current_tier` / `current_tier_rank` fields (mirroring the live siblings) so a consumer that already parses `/upgrade-path` / `/downgrade-path` can point at the `_at` variant with only the query param change.

The `_at` posture matches the rest of the family:
- accepts any id in `_TIER_ORDER` (including `TIER_TRIAL` — hypothetical, unreachable via the purchasable-only helpers)
- whitespace / casing normalised
- unknown / empty `tier` → helper returns `None`, endpoint returns 400 (empty) or 404 (unknown)
- ceiling (enterprise) source → `upgrade_path_at` returns `[]`; floor (oss / cloud_free) source → `downgrade_path_at` returns `[]`
- never raises: resolver / builder failure short-circuits to `[]` on the helper and to the grace-shape envelope on the endpoint

**Grace-only**: pure catalogue projection. Zero behavior change against the currently-resolved entitlement — these are new read-only endpoints, no gate is enforced.

## Test plan

- [x] `python3 -m py_compile clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_upgrade_path_at.py tests/test_entitlement_downgrade_path_at.py` — clean
- [x] `ruff check clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_upgrade_path_at.py tests/test_entitlement_downgrade_path_at.py` — all checks passed
- [x] `python3 -m pytest tests/test_entitlement_upgrade_path_at.py tests/test_entitlement_downgrade_path_at.py -q` — 55 passed
- [x] Adjacent regression sweep — 235 passed across `test_entitlement_upgrade_path`, `test_entitlement_downgrade_path`, `test_entitlement_api`, `test_entitlement_next_prev_tier_diff{,_at}`, `test_entitlement_lock_reason_at`, `test_entitlement_api_lock_reason`, `test_entitlement_capacity_diff`, `test_entitlement_next_prev_tier_capacity_diff{,_at}`

### Coverage in `tests/test_entitlement_upgrade_path_at.py`

- Row shape / `tier_unlocks` byte-parity
- Per-source ladder (OSS, Cloud Free, Starter, Cloud Pro, self-hosted Pro, Enterprise, Trial)
- Byte-parity with live `upgrade_path()` across every resolved source
- Ordering by `(rank, tier_id)`, stability across calls, trial never in path
- Lenient `_at` posture (whitespace / casing, unknown → `None`)
- Safety: never raises on builder failure, does not mutate live entitlement
- HTTP: envelope shape, source echo, row parity with `/tier-unlocks`, body parity with `/upgrade-path`, 400 on missing, 400 on empty, 404 on unknown, never-5xxs on resolver failure

### Coverage in `tests/test_entitlement_downgrade_path_at.py`

- Row shape (8 keys), source echo populates `current_tier` / `current_tier_label` / `current_tier_rank` with the `_at` source
- Per-source ladder (floor, Starter, self-hosted Pro, Enterprise, Trial)
- Cumulative-loss monotonicity, sorted lost lists, per-row match with `tier_diff(source, target)`
- Byte-parity with live `downgrade_path()` on catalogue-shaped forced tiers
- Ordering by `(-rank, tier_id)`, stability, trial never in path
- Lenient `_at` posture, safety, HTTP envelope + parity + error paths

## Local operator verification checklist

The public-repo agent can't exercise the live daemon, cloud snapshot, or browser. Please copy the changed files into your locally-installed clawmetry site-packages and verify against the real daemon before flipping ready-for-review:

```bash
# 1. Copy the changed files into the installed package
SP="$HOME/.clawmetry/lib/python$(python3 -c 'import sys;print(f"{sys.version_info.major}.{sys.version_info.minor}")')/site-packages/clawmetry"
cp clawmetry/entitlements.py "$SP/entitlements.py"
# routes/ isn't inside the package; on the default layout it lands at
# $HOME/.clawmetry/lib/python*/site-packages/routes/entitlement.py
find "$HOME/.clawmetry" -name entitlement.py -path '*routes*' -exec cp routes/entitlement.py {} \;

# 2. Purge stale bytecode so the new module actually loads
find "$HOME/.clawmetry" -type d -name __pycache__ -exec rm -rf {} +

# 3. Bounce the sync daemon so it re-imports
launchctl kickstart -k "gui/$(id -u)/com.clawmetry.sync"

# 4. Hit the new endpoints
curl -s 'http://localhost:8900/api/entitlement/upgrade-path-at?tier=oss' | jq
curl -s 'http://localhost:8900/api/entitlement/downgrade-path-at?tier=enterprise' | jq
# Expect: 200 with the envelope shape documented in the endpoint docstrings.
# upgrade-path-at from OSS -> 4-row path (starter, cloud_pro, pro, enterprise).
# downgrade-path-at from Enterprise -> 5-row path (cloud_pro, pro, starter, oss+cloud_free).

# 5. Parity with the live sibling for source == current
CUR=$(curl -s http://localhost:8900/api/entitlement | jq -r .tier)
diff \
  <(curl -s "http://localhost:8900/api/entitlement/upgrade-path-at?tier=$CUR" | jq '.path') \
  <(curl -s "http://localhost:8900/api/entitlement/upgrade-path" | jq '.path')
# Expect: empty diff.

diff \
  <(curl -s "http://localhost:8900/api/entitlement/downgrade-path-at?tier=$CUR" | jq '.path') \
  <(curl -s "http://localhost:8900/api/entitlement/downgrade-path" | jq '.path')
# Expect: empty diff for plain-catalogue current tiers.

# 6. Error paths
curl -si 'http://localhost:8900/api/entitlement/upgrade-path-at' | head -1
# Expect: HTTP/1.1 400
curl -si 'http://localhost:8900/api/entitlement/downgrade-path-at?tier=nope' | head -1
# Expect: HTTP/1.1 404

# 7. Decrypt the live cloud snapshot in the browser + sanity-check no
# regressions on the existing /upgrade-path and /downgrade-path endpoints.
```

If everything looks right, flip to ready-for-review and merge in the normal flow. Only the local operator has access to the live daemon and snapshot for step 7, which is why this PR stays draft until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tvz7ovXRLGxj5tQWGVo6H


---
_Generated by [Claude Code](https://claude.ai/code/session_011Tvz7ovXRLGxj5tQWGVo6H)_