### PR TITLE
feat(entitlement): tier_catalog_at_batch + /tier-catalog-at-batch endpoint

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -4826,6 +4826,92 @@ def tier_catalog_at(tier: str) -> list[dict] | None:
     return out
 
 
+def tier_catalog_at_batch(tiers) -> dict:
+    """Batch what-if sibling of :func:`tier_catalog_at`: full tier-catalog
+    rows for a caller-supplied set of hypothetical source tiers in ONE
+    round-trip.
+
+    Composes :func:`tier_catalog_at` across the perspective-tier axis the
+    same way :func:`feature_catalog_at_batch` composes
+    :func:`feature_catalog_at` and :func:`runtime_catalog_at_batch`
+    composes :func:`runtime_catalog_at`. Lets a pricing-comparison matrix
+    UI ("show me the tier ladder as if the install were on OSS, Cloud
+    Starter, Cloud Pro, and Enterprise -- side by side") hydrate every
+    column off ONE call instead of N calls to :func:`tier_catalog_at`.
+
+    Per-source row shape::
+
+        {
+          "tier":       "<id>",
+          "tier_label": "...",
+          "tier_rank":  <int>,
+          "tiers":      [<tier_catalog_at row>, ...],
+        }
+
+    Each ``tiers`` list is byte-identical to the list
+    :func:`tier_catalog_at` returns for the same source tier -- pinned by
+    a parity test so the scalar and batch what-if catalog helpers cannot
+    drift.
+
+    Shape::
+
+        {
+          "tiers": [
+            {"tier": "<id>", "tier_label": ..., "tier_rank": ..., "tiers": [...]},
+            ...
+          ],
+          "unknown": ["bogus_id", ...],
+        }
+
+    Supplied tier ids are normalised via :func:`_normalise_csv`
+    (whitespace stripped, lowercased, duplicates dropped, first-seen
+    order preserved). Unknown ids are echoed in ``unknown[]`` instead of
+    short-circuiting -- a partially-bad caller still gets rows back for
+    the valid ids alongside a list of what was dropped, matching
+    :func:`feature_catalog_at_batch` /
+    :func:`runtime_catalog_at_batch`'s posture. ``trial`` IS accepted
+    (it lives in :data:`_TIER_ORDER` and the scalar helper resolves it).
+
+    Empty / ``None`` input returns ``{"tiers": [], "unknown": []}`` --
+    the HTTP wrapper turns that into a 400, this helper does not raise.
+
+    Resolver-independent: delegates per-tier to :func:`tier_catalog_at`,
+    which only walks the static per-tier maps (no fresh
+    :class:`Entitlement` synthesis needed) -- so grace vs enforce yields
+    byte-identical rows. Never raises: a per-tier failure short-circuits
+    that id into ``unknown[]`` and the rest of the batch keeps building.
+    """
+    ids = _normalise_csv(tiers)
+    rows: list[dict] = []
+    unknown: list[str] = []
+    for tid in ids:
+        if tid not in _TIER_ORDER:
+            unknown.append(tid)
+            continue
+        try:
+            catalog = tier_catalog_at(tid)
+        except Exception as exc:
+            logger.warning(
+                "entitlements: tier_catalog_at_batch row %r failed: %s",
+                tid,
+                exc,
+            )
+            unknown.append(tid)
+            continue
+        if catalog is None:
+            unknown.append(tid)
+            continue
+        rows.append(
+            {
+                "tier": tid,
+                "tier_label": tier_label(tid),
+                "tier_rank": _TIER_RANK.get(tid, -1),
+                "tiers": catalog,
+            }
+        )
+    return {"tiers": rows, "unknown": unknown}
+
+
 def tier_spec_at(tier: str, target: str) -> dict | None:
     """Scalar what-if sibling of :func:`tier_catalog_at`: the single tier
     descriptor for ``target`` with ``is_current`` computed as if the install

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -178,6 +178,19 @@ is the single source of truth -- handlers never re-derive tier logic here.
                                          hypothetical "current tier"
                                          without first switching the live
                                          resolver.
+  GET  /api/entitlement/tier-catalog-at-batch -- batch what-if sibling
+                                         of ``/tier-catalog-at``: full tier
+                                         ladders for N hypothetical source
+                                         tiers (``?tiers=a,b,c``) off ONE
+                                         call, each with ``is_current``
+                                         flipped to its own source. Mirrors
+                                         ``/feature-catalog-at-batch`` and
+                                         ``/runtime-catalog-at-batch`` on the
+                                         tier axis so a pricing-comparison
+                                         matrix UI can render the ladder
+                                         side-by-side from every hypothetical
+                                         perspective off ONE round-trip
+                                         instead of N calls.
   GET  /api/entitlement/tier-spec-at  -- scalar what-if sibling of
                                          ``/tier-catalog-at``: the single
                                          tier descriptor for ``target=`` with
@@ -2628,6 +2641,94 @@ def api_entitlement_tier_catalog_at():
     except Exception as exc:
         logger.warning("api_entitlement_tier_catalog_at: error: %s", exc)
         return jsonify({"error": "tier-catalog-at failed"}), 500
+
+
+@bp_entitlement.route("/api/entitlement/tier-catalog-at-batch")
+def api_entitlement_tier_catalog_at_batch():
+    """``GET /api/entitlement/tier-catalog-at-batch?tiers=a,b,c`` -- batch
+    what-if sibling of ``/api/entitlement/tier-catalog-at``.
+
+    Where ``/tier-catalog-at`` hydrates the full tier ladder for ONE
+    hypothetical source tier (with ``is_current`` flipped to that
+    source), this hydrates it for N hypothetical sources in ONE
+    round-trip. Pairs with ``/tier-catalog-at`` the same way
+    ``/feature-catalog-at-batch`` pairs with ``/feature-catalog-at`` and
+    ``/runtime-catalog-at-batch`` pairs with ``/runtime-catalog-at``:
+    scalar what-if -> matrix what-if across the perspective-tier axis
+    rather than the feature-id / runtime-id axis.
+
+    Use case: a pricing-comparison matrix UI ("show me the tier ladder
+    as if I were on OSS vs Cloud Starter vs Cloud Pro vs Enterprise --
+    side by side") hydrates every column off ONE call instead of N
+    calls to ``/tier-catalog-at``.
+
+    Each ``tiers[].tiers`` list is byte-identical to the body of
+    ``/tier-catalog-at?tier=<tier>`` for the same source tier -- pinned
+    by parity tests so the scalar and batch what-if catalog helpers
+    cannot drift. Supplied tier ids are normalised (whitespace
+    stripped, lowercased, duplicates dropped, first-seen order
+    preserved). Unknown ids do not 404 the call -- they are echoed in
+    ``unknown[]`` so a partially-bad caller still gets rows back for
+    the valid ids alongside a list of what was dropped, matching every
+    other ``_at_batch`` sibling's posture.
+
+    Response shape::
+
+        {
+          "tiers": [
+            {
+              "tier":       "<id>",
+              "tier_label": "...",
+              "tier_rank":  <int>,
+              "tiers":      [<tier-catalog-at row>, ...],
+            },
+            ...
+          ],
+          "unknown":    ["bogus_id", ...],
+          "current_tier":      "...",
+          "current_tier_rank": <int>,
+          "grace":             <bool>,
+          "enforced":          <bool>,
+        }
+
+    - **400** when ``tiers=`` is missing / empty after normalisation
+    - **200** with bucketed unknowns for unknown tier ids -- does NOT
+      404 the call, matching every other batch sibling
+    - **Never 5xxs**: a synthesis failure short-circuits to an envelope
+      with empty rows so the matrix keeps rendering.
+    """
+    tiers = _parse_csv_arg("tiers")
+    if not tiers:
+        return jsonify({"error": "supply tiers=<csv>"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        batch = _ent.tier_catalog_at_batch(tiers)
+        ent = _ent.get_entitlement()
+        return jsonify(
+            {
+                "tiers": batch.get("tiers", []),
+                "unknown": batch.get("unknown", []),
+                "current_tier": ent.tier,
+                "current_tier_rank": _ent.tier_rank(ent.tier),
+                "grace": bool(ent.grace),
+                "enforced": _ent.is_enforced(),
+            }
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_tier_catalog_at_batch: error: %s", exc
+        )
+        return jsonify(
+            {
+                "tiers": [],
+                "unknown": [],
+                "current_tier": "oss",
+                "current_tier_rank": 0,
+                "grace": True,
+                "enforced": False,
+            }
+        )
 
 
 @bp_entitlement.route("/api/entitlement/feature-catalog-at-batch")

--- a/tests/test_entitlement_tier_catalog_at_batch.py
+++ b/tests/test_entitlement_tier_catalog_at_batch.py
@@ -1,0 +1,418 @@
+"""Tests for ``tier_catalog_at_batch(tiers)`` +
+``GET /api/entitlement/tier-catalog-at-batch``.
+
+Tier-axis twin of ``feature_catalog_at_batch`` /
+``runtime_catalog_at_batch``: where the scalar ``tier_catalog_at``
+hydrates the full tier ladder for ONE hypothetical source (with
+``is_current`` flipped to that source), the batch what-if catalog
+hydrates the same ladder for N hypothetical sources off a single
+round-trip -- the perspective-tier axis is batched.
+
+Each returned ``tiers[].tiers`` list must be byte-identical to the
+scalar ``tier_catalog_at`` return for the same source tier, so the
+scalar / batch what-if catalog accessors cannot drift -- pinned by
+the parity tests below.
+
+Coverage:
+
+* per-source row shape matches the scalar catalog (parity pin)
+* every tier in ``_TIER_ORDER`` (including ``trial``) round-trips
+* input is normalised (whitespace stripped, lowercased, duplicates
+  dropped, first-seen order preserved) -- same as ``_normalise_csv``
+* unknown ids are echoed in ``unknown[]`` instead of short-circuiting
+* the helper never raises -- a per-tier crash short-circuits that id
+  into ``unknown[]`` so the matrix keeps rendering
+* the HTTP endpoint 400s on missing / empty input, echoes unknown ids
+  at 200, carries the standard envelope (``current_tier`` /
+  ``current_tier_rank`` / ``grace`` / ``enforced``), and never 5xxs
+  on a resolver crash
+* grace vs enforce yields byte-identical bodies (catalogue-derived)
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+
+_ROW_KEYS = {
+    "id",
+    "label",
+    "is_paid",
+    "is_current",
+    "rank",
+    "unlocks_paid_runtimes",
+    "retention_days",
+    "channel_limit",
+    "node_limit",
+    "features",
+    "runtimes",
+}
+
+_OUTER_ROW_KEYS = {"tier", "tier_label", "tier_rank", "tiers"}
+
+_ENVELOPE_KEYS = {
+    "tiers",
+    "unknown",
+    "current_tier",
+    "current_tier_rank",
+    "grace",
+    "enforced",
+}
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    """Fresh entitlements module with HOME pointed at an empty tmp dir so
+    no real ~/.clawmetry/license.key or cloud_plan.json leaks in.
+    Enforcement off by default (grace mode); the helper is catalogue-
+    derived and independent of either knob, but the fixture avoids
+    live-resolver surprises."""
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from flask import Flask
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# ── helper: input handling ───────────────────────────────────────────────────
+
+
+def test_empty_input_returns_empty_envelope(ent):
+    assert ent.tier_catalog_at_batch([]) == {"tiers": [], "unknown": []}
+
+
+def test_none_input_returns_empty_envelope(ent):
+    assert ent.tier_catalog_at_batch(None) == {"tiers": [], "unknown": []}
+
+
+def test_string_csv_input(ent):
+    body = ent.tier_catalog_at_batch(
+        f"{ent.TIER_CLOUD_STARTER},{ent.TIER_CLOUD_PRO}"
+    )
+    assert [row["tier"] for row in body["tiers"]] == [
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+    ]
+
+
+def test_supply_order_preserved(ent):
+    body = ent.tier_catalog_at_batch(
+        [ent.TIER_CLOUD_PRO, ent.TIER_OSS, ent.TIER_ENTERPRISE]
+    )
+    assert [row["tier"] for row in body["tiers"]] == [
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_OSS,
+        ent.TIER_ENTERPRISE,
+    ]
+
+
+def test_whitespace_and_case_normalised(ent):
+    body = ent.tier_catalog_at_batch(
+        ["  CLOUD_PRO  ", ent.TIER_CLOUD_STARTER.upper()]
+    )
+    assert [row["tier"] for row in body["tiers"]] == [
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_CLOUD_STARTER,
+    ]
+
+
+def test_duplicates_dropped_first_seen_wins(ent):
+    body = ent.tier_catalog_at_batch(
+        [
+            ent.TIER_CLOUD_PRO,
+            ent.TIER_CLOUD_PRO,
+            ent.TIER_CLOUD_STARTER,
+            ent.TIER_CLOUD_PRO,
+        ]
+    )
+    assert [row["tier"] for row in body["tiers"]] == [
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_CLOUD_STARTER,
+    ]
+
+
+def test_unknown_ids_echoed_in_unknown(ent):
+    body = ent.tier_catalog_at_batch(
+        [ent.TIER_CLOUD_PRO, "nope_tier", "also_bogus"]
+    )
+    assert [row["tier"] for row in body["tiers"]] == [ent.TIER_CLOUD_PRO]
+    assert body["unknown"] == ["nope_tier", "also_bogus"]
+
+
+def test_unknown_only_returns_empty_tiers(ent):
+    body = ent.tier_catalog_at_batch(["nope_tier", "also_bogus"])
+    assert body == {"tiers": [], "unknown": ["nope_tier", "also_bogus"]}
+
+
+def test_non_iterable_input_falls_back_to_empty(ent):
+    # ``_normalise_csv`` returns ``[]`` for non-iterable inputs (int,
+    # object, etc.) so the batch collapses to an empty envelope rather
+    # than raising.
+    assert ent.tier_catalog_at_batch(12345) == {
+        "tiers": [],
+        "unknown": [],
+    }
+    assert ent.tier_catalog_at_batch(object()) == {
+        "tiers": [],
+        "unknown": [],
+    }
+
+
+def test_trial_source_accepted(ent):
+    body = ent.tier_catalog_at_batch([ent.TIER_TRIAL])
+    assert [row["tier"] for row in body["tiers"]] == [ent.TIER_TRIAL]
+    assert body["unknown"] == []
+
+
+# ── helper: shape + parity ───────────────────────────────────────────────────
+
+
+def test_row_shape_matches_scalar(ent):
+    body = ent.tier_catalog_at_batch([ent.TIER_CLOUD_PRO])
+    assert len(body["tiers"]) == 1
+    row = body["tiers"][0]
+    assert set(row.keys()) == _OUTER_ROW_KEYS
+    assert isinstance(row["tiers"], list)
+    assert set(row["tiers"][0].keys()) == _ROW_KEYS
+
+
+def test_ladder_matches_scalar_exactly(ent):
+    """Pin scalar / batch no-drift: every batch source's ``tiers`` list
+    equals the scalar ``tier_catalog_at`` list for the same source."""
+    body = ent.tier_catalog_at_batch(list(ent._TIER_ORDER))
+    by_tier = {row["tier"]: row for row in body["tiers"]}
+    assert set(by_tier) == set(ent._TIER_ORDER)
+    for tid in ent._TIER_ORDER:
+        assert by_tier[tid]["tiers"] == ent.tier_catalog_at(tid), tid
+
+
+def test_tier_metadata_matches_scalar(ent):
+    body = ent.tier_catalog_at_batch([ent.TIER_CLOUD_PRO])
+    row = body["tiers"][0]
+    assert row["tier_label"] == ent.tier_label(ent.TIER_CLOUD_PRO)
+    assert row["tier_rank"] == ent.tier_rank(ent.TIER_CLOUD_PRO)
+
+
+def test_every_tier_in_order_resolves(ent):
+    body = ent.tier_catalog_at_batch(list(ent._TIER_ORDER))
+    assert len(body["tiers"]) == len(ent._TIER_ORDER)
+    assert body["unknown"] == []
+    for row in body["tiers"]:
+        assert len(row["tiers"]) == len(ent._TIER_ORDER)
+
+
+# ── helper: perspective shifts ───────────────────────────────────────────────
+
+
+def test_is_current_flips_per_source(ent):
+    """Same batch response carries ``is_current=True`` on exactly one
+    row per source -- the requested source -- and False everywhere
+    else."""
+    sources = [ent.TIER_OSS, ent.TIER_CLOUD_PRO, ent.TIER_ENTERPRISE]
+    body = ent.tier_catalog_at_batch(sources)
+    by_tier = {row["tier"]: row for row in body["tiers"]}
+    for source in sources:
+        rows = by_tier[source]["tiers"]
+        current = [r for r in rows if r["is_current"]]
+        assert len(current) == 1, source
+        assert current[0]["id"] == source, source
+        for r in rows:
+            if r["id"] != source:
+                assert r["is_current"] is False, (source, r["id"])
+
+
+def test_non_is_current_fields_invariant_across_sources(ent):
+    """Every catalogue-derived field on a tier row is stable across the
+    source axis -- only ``is_current`` shifts. Any drift means a
+    resolution-dependent field leaked into the catalog somehow."""
+    body = ent.tier_catalog_at_batch(list(ent._TIER_ORDER))
+    by_source = {row["tier"]: row["tiers"] for row in body["tiers"]}
+    baseline_by_id = {r["id"]: r for r in by_source[ent.TIER_OSS]}
+    invariant = _ROW_KEYS - {"is_current"}
+    for source, rows in by_source.items():
+        for r in rows:
+            base = baseline_by_id[r["id"]]
+            for key in invariant:
+                assert r[key] == base[key], (source, r["id"], key)
+
+
+# ── helper: resolver-independence ────────────────────────────────────────────
+
+
+def test_grace_vs_enforce_byte_identical(ent, monkeypatch):
+    """Enforcement is a live-resolver knob; the batch what-if helper
+    is catalogue-derived and must produce byte-identical bodies."""
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    ent.invalidate()
+    grace = ent.tier_catalog_at_batch(list(ent._TIER_ORDER))
+
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    enforced = ent.tier_catalog_at_batch(list(ent._TIER_ORDER))
+    assert grace == enforced
+
+
+# ── helper: never-raise ──────────────────────────────────────────────────────
+
+
+def test_never_raises_when_scalar_helper_crashes(ent, monkeypatch):
+    """A per-tier scalar helper crash must short-circuit that id into
+    ``unknown[]`` and the rest of the batch keeps building -- matches
+    every other ``_at_batch`` sibling's posture."""
+    real = ent.tier_catalog_at
+
+    def flaky(t):
+        if t == ent.TIER_CLOUD_PRO:
+            raise RuntimeError("simulated scalar crash")
+        return real(t)
+
+    monkeypatch.setattr(ent, "tier_catalog_at", flaky)
+    body = ent.tier_catalog_at_batch(
+        [ent.TIER_OSS, ent.TIER_CLOUD_PRO, ent.TIER_ENTERPRISE]
+    )
+    assert [row["tier"] for row in body["tiers"]] == [
+        ent.TIER_OSS,
+        ent.TIER_ENTERPRISE,
+    ]
+    assert body["unknown"] == [ent.TIER_CLOUD_PRO]
+
+
+def test_never_raises_when_scalar_returns_none(ent, monkeypatch):
+    """A per-tier scalar ``None`` return must land the id in
+    ``unknown[]`` without raising."""
+    real = ent.tier_catalog_at
+
+    def none_pro(t):
+        if t == ent.TIER_CLOUD_PRO:
+            return None
+        return real(t)
+
+    monkeypatch.setattr(ent, "tier_catalog_at", none_pro)
+    body = ent.tier_catalog_at_batch(
+        [ent.TIER_OSS, ent.TIER_CLOUD_PRO, ent.TIER_ENTERPRISE]
+    )
+    assert [row["tier"] for row in body["tiers"]] == [
+        ent.TIER_OSS,
+        ent.TIER_ENTERPRISE,
+    ]
+    assert body["unknown"] == [ent.TIER_CLOUD_PRO]
+
+
+# ── HTTP endpoint: happy path ────────────────────────────────────────────────
+
+
+def test_endpoint_known_tiers_returns_rows(client, ent):
+    resp = client.get(
+        f"/api/entitlement/tier-catalog-at-batch"
+        f"?tiers={ent.TIER_CLOUD_STARTER},{ent.TIER_CLOUD_PRO}"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert _ENVELOPE_KEYS.issubset(set(body.keys()))
+    assert [row["tier"] for row in body["tiers"]] == [
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+    ]
+    # Each row's ladder matches the scalar catalog endpoint for the
+    # same source -- pinned so scalar and batch cannot drift.
+    for row in body["tiers"]:
+        scalar = client.get(
+            f"/api/entitlement/tier-catalog-at?tier={row['tier']}"
+        ).get_json()
+        assert row["tiers"] == scalar["tiers"], row["tier"]
+
+
+def test_endpoint_missing_arg_returns_400(client):
+    resp = client.get("/api/entitlement/tier-catalog-at-batch")
+    assert resp.status_code == 400
+    assert "error" in resp.get_json()
+
+
+def test_endpoint_blank_arg_returns_400(client):
+    resp = client.get(
+        "/api/entitlement/tier-catalog-at-batch?tiers=%20%20"
+    )
+    assert resp.status_code == 400
+
+
+def test_endpoint_unknown_ids_echoed_at_200(client, ent):
+    resp = client.get(
+        f"/api/entitlement/tier-catalog-at-batch"
+        f"?tiers={ent.TIER_CLOUD_PRO},nope_tier,also_bogus"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert [row["tier"] for row in body["tiers"]] == [ent.TIER_CLOUD_PRO]
+    assert body["unknown"] == ["nope_tier", "also_bogus"]
+
+
+def test_endpoint_lowercases_and_trims(client, ent):
+    resp = client.get(
+        f"/api/entitlement/tier-catalog-at-batch"
+        f"?tiers=%20%20{ent.TIER_CLOUD_PRO.upper()}%20%20"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert [row["tier"] for row in body["tiers"]] == [ent.TIER_CLOUD_PRO]
+
+
+def test_endpoint_every_tier_in_order_round_trips(client, ent):
+    tiers = ",".join(ent._TIER_ORDER)
+    resp = client.get(
+        f"/api/entitlement/tier-catalog-at-batch?tiers={tiers}"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert len(body["tiers"]) == len(ent._TIER_ORDER)
+    assert body["unknown"] == []
+
+
+def test_endpoint_envelope_carries_current_tier_and_grace_flags(client, ent):
+    resp = client.get(
+        f"/api/entitlement/tier-catalog-at-batch?tiers={ent.TIER_CLOUD_PRO}"
+    )
+    body = resp.get_json()
+    live = ent.get_entitlement()
+    assert body["current_tier"] == live.tier
+    assert body["current_tier_rank"] == ent.tier_rank(live.tier)
+    assert body["grace"] == bool(live.grace)
+    assert body["enforced"] == ent.is_enforced()
+
+
+def test_endpoint_never_5xx_on_resolver_crash(client, ent, monkeypatch):
+    def boom(*_a, **_kw):
+        raise RuntimeError("simulated resolver crash")
+
+    monkeypatch.setattr(ent, "get_entitlement", boom)
+    resp = client.get(
+        f"/api/entitlement/tier-catalog-at-batch?tiers={ent.TIER_CLOUD_PRO}"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["tiers"] == []
+    assert body["grace"] is True
+    assert body["enforced"] is False
+
+
+def test_endpoint_unknown_only_returns_200_empty_rows(client, ent):
+    resp = client.get(
+        "/api/entitlement/tier-catalog-at-batch?tiers=nope_tier,also_bogus"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["tiers"] == []
+    assert body["unknown"] == ["nope_tier", "also_bogus"]


### PR DESCRIPTION
## Summary

Tier-axis twin of `feature_catalog_at_batch` / `runtime_catalog_at_batch` (both merged): where the scalar `tier_catalog_at` hydrates the full tier ladder for ONE hypothetical source, this hydrates it for N hypothetical sources off one round-trip.

- `Entitlement`-module-level `tier_catalog_at_batch(tiers)` -- per-source row is `{tier, tier_label, tier_rank, tiers: [<tier_catalog_at row>, ...]}`. Each inner `tiers` list is byte-identical to `tier_catalog_at(<source>)` for the same tier -- pinned by a parity test so scalar and batch cannot drift.
- `GET /api/entitlement/tier-catalog-at-batch?tiers=a,b,c` mirroring the `/feature-catalog-at-batch` / `/runtime-catalog-at-batch` envelope: `{tiers, unknown, current_tier, current_tier_rank, grace, enforced}`.

Fills the tier-axis member of the resolver-independent `_at_batch` catalog family:

| helper                          | inner list         | status        |
|---------------------------------|--------------------|---------------|
| `feature_catalog_at_batch`      | `[features]`       | merged        |
| `runtime_catalog_at_batch`      | `[runtimes]`       | merged        |
| `tier_catalog_at_batch`         | `[tier catalog]`   | **this PR**   |

The `_at_batch` posture matches the rest of the family:
- ids normalised via `_normalise_csv` (whitespace stripped, lowercased, duplicates dropped, first-seen order preserved)
- unknown ids echoed in `unknown[]` instead of short-circuiting -- a partially-bad caller still gets rows back for the valid ids
- `trial` IS accepted (it lives in `_TIER_ORDER` and the scalar helper resolves it)
- empty / `None` input yields `{tiers: [], unknown: []}` at the helper; the HTTP wrapper turns that into a 400
- resolver-independent: catalogue-derived, so grace vs enforce is byte-identical
- never raises: per-tier crash short-circuits that id to `unknown[]`; endpoint resolver failure short-circuits to a grace-shape envelope (no 5xx)

**Grace-only, read-only**: no gate enforced, no behavior change against the currently-resolved entitlement -- this is a new read-only endpoint.

## Test plan

- [x] `python3 -m py_compile clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_tier_catalog_at_batch.py` -- clean
- [x] `ruff check clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_tier_catalog_at_batch.py` -- all checks passed
- [x] `python3 -m pytest tests/test_entitlement_tier_catalog_at_batch.py -q` -- 28 passed
- [x] Adjacent regression sweep -- 276 passed across `test_entitlement_catalog_at_batch`, `test_entitlement_tier_catalog_at`, `test_entitlement_feature_catalog_at`, `test_entitlement_runtime_catalog_at`, `test_entitlement_api`, `test_entitlement_tier_spec_at`, `test_entitlement_tier_spec_at_batch`, `test_entitlement_catalog_path_batch`

### Coverage in `tests/test_entitlement_tier_catalog_at_batch.py`

- helper: input handling (empty / None / csv string / iterable / non-iterable fallback / whitespace / casing / duplicate dedupe / order preservation / unknown-echo / trial accepted)
- helper: shape + parity (`_OUTER_ROW_KEYS`, inner `tier_catalog_at` row shape, byte-parity with scalar `tier_catalog_at` for every source in `_TIER_ORDER`, ladder length pinned)
- helper: perspective shifts (`is_current` flips per source, exactly one True per ladder; every other catalogue-derived field is invariant across sources)
- helper: resolver-independence (grace vs enforce byte-identical)
- helper: never-raise (per-tier scalar crash → id lands in `unknown[]`; scalar `None` return → id lands in `unknown[]`)
- HTTP: `_ENVELOPE_KEYS` shape, source echo, row parity with `/tier-catalog-at`, 400 on missing / blank, 200 with bucketed unknowns, whitespace / casing normalised, envelope carries live `current_tier`, never-5xxs on resolver failure, unknown-only 200 with empty rows

## Local operator verification checklist

The public-repo agent cannot exercise the live daemon, cloud snapshot, or browser. Please copy the changed files into your locally-installed clawmetry site-packages and verify against the real daemon before flipping ready-for-review:

```bash
# 1. Copy the changed files into the installed package
SP="$HOME/.clawmetry/lib/python$(python3 -c 'import sys;print(f"{sys.version_info.major}.{sys.version_info.minor}")')/site-packages/clawmetry"
cp clawmetry/entitlements.py "$SP/entitlements.py"
# routes/ isn't inside the package; on the default layout it lands at
# $HOME/.clawmetry/lib/python*/site-packages/routes/entitlement.py
find "$HOME/.clawmetry" -name entitlement.py -path '*routes*' -exec cp routes/entitlement.py {} \;

# 2. Purge stale bytecode so the new module actually loads
find "$HOME/.clawmetry" -type d -name __pycache__ -exec rm -rf {} +

# 3. Bounce the sync daemon so it re-imports
launchctl kickstart -k "gui/$(id -u)/com.clawmetry.sync"

# 4. Hit the new endpoint
curl -s 'http://localhost:8900/api/entitlement/tier-catalog-at-batch?tiers=oss,cloud_starter,cloud_pro,enterprise' | jq
# Expect: 200 with the envelope shape documented in the endpoint docstring.
# Four per-source rows, each with an inner tiers[] list of length 7 (the full
# _TIER_ORDER ladder) and is_current=True on exactly the requested source.

# 5. Parity with the live sibling for source == current
CUR=$(curl -s http://localhost:8900/api/entitlement | jq -r .tier)
diff \
  <(curl -s "http://localhost:8900/api/entitlement/tier-catalog-at-batch?tiers=$CUR" | jq '.tiers[0].tiers') \
  <(curl -s "http://localhost:8900/api/entitlement/tier-catalog-at?tier=$CUR" | jq '.tiers')
# Expect: empty diff.

# 6. Error paths
curl -si 'http://localhost:8900/api/entitlement/tier-catalog-at-batch' | head -1
# Expect: HTTP/1.1 400
curl -s 'http://localhost:8900/api/entitlement/tier-catalog-at-batch?tiers=cloud_pro,nope_tier' | jq '.unknown'
# Expect: ["nope_tier"] -- 200, not 404

# 7. Decrypt the live cloud snapshot in the browser + sanity-check no
# regressions on the existing /tier-catalog-at, /feature-catalog-at-batch,
# and /runtime-catalog-at-batch endpoints.
```

If everything looks right, flip to ready-for-review and merge in the normal flow. Only the local operator has access to the live daemon and snapshot for step 7, which is why this PR stays draft until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016AVqLijKAAZ87EBNFtUsGy

---
_Generated by [Claude Code](https://claude.ai/code/session_016AVqLijKAAZ87EBNFtUsGy)_