### PR TITLE
fix: expose runtimeKind in NemoClaw list_sessions/list_events

### DIFF
--- a/clawmetry/adapters/nemo.py
+++ b/clawmetry/adapters/nemo.py
@@ -958,7 +958,8 @@ class NemoClawAdapter(AgentAdapter):
             rows = store._fetch(
                 "SELECT session_id, MIN(ts) AS started, MAX(ts) AS ended, "
                 "COUNT(*) AS n_events, SUM(token_count) AS tokens, "
-                "SUM(cost_usd) AS cost FROM events "
+                "SUM(cost_usd) AS cost, ANY_VALUE(runtime_kind) AS runtime_kind "
+                "FROM events "
                 "WHERE agent_type = ? AND session_id IS NOT NULL "
                 "GROUP BY session_id ORDER BY started DESC LIMIT ?",
                 ["nemoclaw", int(limit)],
@@ -980,6 +981,10 @@ class NemoClawAdapter(AgentAdapter):
                 n_ev = int(r[3] or 0)
                 tokens = int(r[4] or 0)
                 cost = float(r[5] or 0.0)
+                rk = str(r[6]) if r[6] else ""
+                extra: dict = {}
+                if rk:
+                    extra["runtimeKind"] = rk
                 sessions.append(Session(
                     agent=self.name,
                     id=str(sid),
@@ -989,6 +994,7 @@ class NemoClawAdapter(AgentAdapter):
                     message_count=n_ev,
                     total_tokens=tokens,
                     cost_usd=cost,
+                    extra=extra,
                 ))
         except Exception as exc:
             logger.debug("nemoclaw list_sessions read failed: %s", exc)
@@ -1000,7 +1006,7 @@ class NemoClawAdapter(AgentAdapter):
             from clawmetry import local_store as _ls
             store = _ls.get_store(read_only=True)
             rows = store._fetch(
-                "SELECT id, event_type, ts, model, token_count, data "
+                "SELECT id, event_type, ts, model, token_count, data, runtime_kind "
                 "FROM events WHERE agent_type = ? AND session_id = ? "
                 "ORDER BY ts ASC LIMIT ?",
                 ["nemoclaw", str(session_id), int(limit)],
@@ -1014,6 +1020,8 @@ class NemoClawAdapter(AgentAdapter):
                 extra: dict = {}
                 if r[3]:
                     extra["model"] = r[3]
+                if r[6]:
+                    extra["runtimeKind"] = str(r[6])
                 raw_data = r[5]
                 if raw_data is not None and r[1] == "sandbox.audit_log":
                     try:

--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -213,7 +213,8 @@ _DDL = [
         model           VARCHAR,
         created_at      BIGINT NOT NULL,
         chain_prev_hash VARCHAR,
-        chain_hash      VARCHAR
+        chain_hash      VARCHAR,
+        runtime_kind    VARCHAR
     )
     """,
     "CREATE INDEX IF NOT EXISTS idx_events_ts          ON events(ts)",
@@ -1091,6 +1092,9 @@ _MIGRATIONS_V2 = [
     # existing rows and populated on new events when CLAWMETRY_INTEGRITY=1.
     ("events",   "chain_prev_hash",   "VARCHAR"),
     ("events",   "chain_hash",        "VARCHAR"),
+    # Issue #3367 — expose NemoClaw sandbox runtime kind (terminal vs docker)
+    # on session and event rows. Stamped at ingest time from sandbox config.
+    ("events",   "runtime_kind",      "VARCHAR"),
 ]
 
 # ── Integrity / hash-chain (Issue #2200) ────────────────────────────────────
@@ -4847,8 +4851,9 @@ class LocalStore:
                             """
                             INSERT OR IGNORE INTO events
                               (id, agent_type, node_id, agent_id, session_id, workspace_id,
-                               event_type, ts, data, cost_usd, token_count, model, created_at)
-                            VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)
+                               event_type, ts, data, cost_usd, token_count, model, created_at,
+                               runtime_kind)
+                            VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)
                             """,
                             rows,
                         )
@@ -10889,6 +10894,7 @@ def _event_to_row(e: dict[str, Any], usage: dict[str, Any] | None = None) -> tup
         int(tokens) if tokens is not None else None,
         model,
         int(time.time() * 1000),
+        e.get("runtime_kind") or None,
     )
 
 

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -2343,6 +2343,26 @@ def sync_sandbox_sessions_openshell(config: dict, state: dict) -> int:
     cursors: dict = state.setdefault("sandbox_session_cursors", {})
     total = 0
 
+    # Build sandbox→runtimeKind map once from sandboxes.json so we can stamp
+    # each ingested event without a subprocess call per event (#3367).
+    _sb_rk_map: dict = {}
+    try:
+        import os as _os
+        _reg = _os.path.join(_os.environ.get("HOME", ""), ".nemoclaw", "sandboxes.json")
+        with open(_reg) as _f:
+            _sb_data = json.load(_f)
+        for _n, _e in (_sb_data.get("sandboxes") or {}).items():
+            if isinstance(_e, dict):
+                _rk = (
+                    _e.get("runtimeKind")
+                    or (_e.get("runtime") or {}).get("kind")
+                    or ""
+                )
+                if _rk:
+                    _sb_rk_map[_n] = str(_rk)
+    except Exception:
+        pass
+
     for sb in sandboxes:
         if not isinstance(sb, dict):
             continue
@@ -2398,6 +2418,13 @@ def sync_sandbox_sessions_openshell(config: dict, state: dict) -> int:
                     if isinstance(obj, dict):
                         batch.append(obj)
                 if batch:
+                    # Stamp sandbox runtimeKind on each event so the adapter
+                    # can expose it in list_sessions/list_events (#3367).
+                    _rk = _sb_rk_map.get(sb_name, "")
+                    if _rk:
+                        for _ev in batch:
+                            if isinstance(_ev, dict):
+                                _ev["_nemo_rk"] = _rk
                     _flush_session_batch(batch, fname, api_key, enc_key, node_id, None,
                                          agent_type="nemoclaw")
                     total += len(batch)
@@ -3285,6 +3312,8 @@ def _local_ingest_session_batch(
         if _is_v3_event(obj):
             row = _parse_v3_event(obj, session_id, node_id, agent_type)
             if row is not None:
+                if obj.get("_nemo_rk"):
+                    row["runtime_kind"] = str(obj["_nemo_rk"])
                 rows.append(row)
             continue
 
@@ -3316,10 +3345,11 @@ def _local_ingest_session_batch(
         # ``tokens`` only appear in synthesised events (e.g. our own tests).
         # See MOAT_E2E_REPORT_2026-05-13 root-cause #4.
         cost_usd, token_count, model = _extract_cost_tokens_model(obj)
-        # Strip the internal _cc_source marker so it never reaches the
-        # stored ``data`` BLOB (it's a routing hint, not part of the event).
-        if obj.get("_cc_source"):
-            data_payload = {k: v for k, v in obj.items() if k != "_cc_source"}
+        # Strip private routing markers (_cc_source, _nemo_rk) so they never
+        # reach the stored data BLOB.
+        _private = {k for k in ("_cc_source", "_nemo_rk") if obj.get(k)}
+        if _private:
+            data_payload = {k: v for k, v in obj.items() if k not in _private}
         else:
             data_payload = obj
         rows.append({
@@ -3335,6 +3365,7 @@ def _local_ingest_session_batch(
             "cost_usd": cost_usd,
             "token_count": token_count,
             "model": model,
+            "runtime_kind": obj.get("_nemo_rk") or None,
         })
     if rows:
         store.ingest_many(rows)

--- a/tests/test_nemoclaw_runtime_adapter.py
+++ b/tests/test_nemoclaw_runtime_adapter.py
@@ -364,3 +364,60 @@ def test_detect_meta_includes_ollama_inference(isolated_store, monkeypatch):
     assert "ollama_inference" in meta
     assert "ollama_host" in meta["ollama_inference"]
     assert "ollama_host_mode" in meta["ollama_inference"]
+
+
+# ── runtime_kind (issue #3367) ─────────────────────────────────────────────
+
+
+def test_list_sessions_exposes_runtime_kind(isolated_store):
+    """list_sessions() returns runtimeKind in extra when runtime_kind column is populated."""
+    import uuid
+    store = isolated_store
+    store.ingest({
+        "id": str(uuid.uuid4()),
+        "node_id": "n1",
+        "agent_type": "nemoclaw",
+        "agent_id": "main",
+        "session_id": "rk-sess-terminal",
+        "event_type": "session.started",
+        "ts": "1700000000",
+        "runtime_kind": "terminal",
+    })
+    _wait_flush(store)
+    from clawmetry.adapters.nemo import NemoClawAdapter
+    sessions = NemoClawAdapter().list_sessions()
+    sess = next((s for s in sessions if s.id == "rk-sess-terminal"), None)
+    assert sess is not None
+    assert sess.extra.get("runtimeKind") == "terminal"
+
+
+def test_list_events_exposes_runtime_kind(isolated_store):
+    """list_events() returns runtimeKind in extra when runtime_kind column is populated."""
+    import uuid
+    store = isolated_store
+    store.ingest({
+        "id": str(uuid.uuid4()),
+        "node_id": "n1",
+        "agent_type": "nemoclaw",
+        "agent_id": "main",
+        "session_id": "rk-sess-docker",
+        "event_type": "tool.called",
+        "ts": "1700000001",
+        "runtime_kind": "docker",
+    })
+    _wait_flush(store)
+    from clawmetry.adapters.nemo import NemoClawAdapter
+    events = NemoClawAdapter().list_events("rk-sess-docker")
+    assert len(events) == 1
+    assert events[0].extra.get("runtimeKind") == "docker"
+
+
+def test_list_sessions_no_runtime_kind_when_absent(isolated_store):
+    """list_sessions() omits runtimeKind from extra when no runtime_kind was stored."""
+    _seed_nemoclaw_event(isolated_store, session_id="rk-sess-none")
+    _wait_flush(isolated_store)
+    from clawmetry.adapters.nemo import NemoClawAdapter
+    sessions = NemoClawAdapter().list_sessions()
+    sess = next((s for s in sessions if s.id == "rk-sess-none"), None)
+    assert sess is not None
+    assert "runtimeKind" not in sess.extra


### PR DESCRIPTION
## Summary

- Adds `runtime_kind VARCHAR` column to the `events` table (base DDL + `_MIGRATIONS_V2` for existing installs)
- `sync_sandbox_sessions_openshell` reads `sandboxes.json` to look up each sandbox's `runtimeKind`/`runtime.kind` and stamps it onto event dicts as `_nemo_rk` before ingesting
- `_local_ingest_session_batch` stores `_nemo_rk` into the new `runtime_kind` column (strips it from the `data` blob alongside `_cc_source`)
- `NemoClawAdapter.list_sessions()` and `list_events()` surface `runtimeKind` in `extra` when present

## Test plan

- [ ] `python3 -m pytest tests/test_nemoclaw_runtime_adapter.py -v` — all 21 tests pass (3 new tests cover the new behaviour)
- [ ] Existing NemoClaw sessions without `runtimeKind` continue to work (no `runtimeKind` key in `extra`)

Closes #3367

---
_Generated by [Claude Code](https://claude.ai/code/session_012Dkm1c26L1yFm4xhaek5wS)_