### PR TITLE
fix(process-control): locale-independent ps start-time reading (non-English macOS)

### DIFF
--- a/clawmetry/process_control.py
+++ b/clawmetry/process_control.py
@@ -218,6 +218,11 @@ def _ctime_epoch_candidates(s: str) -> Set[int]:
     non-UTC host the two strings for the same instant never match textually, so
     we parse to epochs under both interpretations and let the caller intersect.
     An unparseable string yields an empty set (the guard then fails closed).
+
+    The ``%a %b`` names here are English: safe, because ``_run`` forces the C
+    locale on every ``ps`` invocation (see ``_c_locale_env``), so ``lstart``
+    output is English even on a non-English-locale host, and claude_code's
+    recorded ``procStart`` ctime is always English too.
     """
     import calendar
     import datetime as _dt
@@ -312,11 +317,41 @@ def verify_pid(pid: int, recorded_start: Any = None) -> Tuple[bool, str]:
 # ──────────────────────────────────────────────────────────────────────────
 # Shell fallbacks (used only when psutil is absent)
 # ──────────────────────────────────────────────────────────────────────────
+def _c_locale_env() -> Dict[str, str]:
+    """A copy of ``os.environ`` with the C locale forced (``LC_ALL=C``) and
+    every other locale variable stripped (``LANG``, ``LANGUAGE``, ``LC_*``).
+
+    Why: the no-psutil pid-reuse guard parses ``ps -o lstart=`` output with
+    English month/day abbreviations (``_ctime_epoch_candidates`` uses
+    ``%a %b``). On a non-English-locale host, ``ps`` localizes those names
+    (e.g. "Do 2. Jul ..." on a German Mac), the parse fails, and the guard
+    fails CLOSED: kill/pause/resume refuse for those users. Forcing the C
+    locale on the SUBPROCESS makes every ps/lsof invocation emit stable
+    English output regardless of the user's locale, so the existing parser
+    always works. POSIX gives ``LC_ALL`` precedence over all other locale
+    vars; stripping the rest is belt-and-braces for tools that consult
+    ``LANG``/``LANGUAGE`` directly.
+    """
+    env = {
+        k: v
+        for k, v in os.environ.items()
+        if k not in ("LANG", "LANGUAGE") and not k.startswith("LC_")
+    }
+    env["LC_ALL"] = "C"
+    return env
+
+
 def _run(cmd: List[str], timeout: float = 10) -> Optional[str]:
-    """Run a short command, return stdout or None. Never raises, always bounded."""
+    """Run a short command, return stdout or None. Never raises, always bounded.
+
+    The child always runs under the C locale (``_c_locale_env``) so output we
+    parse — notably ``ps -o lstart=`` for the pid-reuse guard — is
+    locale-independent.
+    """
     try:
         proc = subprocess.run(
-            cmd, capture_output=True, text=True, timeout=timeout
+            cmd, capture_output=True, text=True, timeout=timeout,
+            env=_c_locale_env(),
         )
         if proc.returncode != 0 and not proc.stdout:
             return None

--- a/tests/test_process_control.py
+++ b/tests/test_process_control.py
@@ -496,3 +496,85 @@ def test_pause_does_not_freeze_group_sharing_orchestrator():
             orch.wait(timeout=5)
         except Exception:
             pass
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# locale-independent ps start-time reading (non-English macOS, no psutil)
+# ──────────────────────────────────────────────────────────────────────────
+_EN_LSTART = "Thu Jul  2 04:26:55 2026"       # C-locale `ps -o lstart=`
+_DE_LSTART = "Do  2. Jul 04:26:55 2026"       # German-locale `ps -o lstart=`
+
+
+def _is_c_locale_env(env) -> bool:
+    """True when the subprocess env forces the C locale the way _run must."""
+    if not env or env.get("LC_ALL") != "C":
+        return False
+    if "LANG" in env or "LANGUAGE" in env:
+        return False
+    return not any(k.startswith("LC_") and k != "LC_ALL" for k in env)
+
+
+def _fake_localized_ps(cmd, **kwargs):
+    """Simulate `ps -o lstart=` on a German-locale host: localized month/day
+    names UNLESS the caller forces the C locale via the subprocess env."""
+    assert "lstart=" in cmd, f"unexpected subprocess call in test: {cmd}"
+    out = _EN_LSTART if _is_c_locale_env(kwargs.get("env")) else _DE_LSTART
+    return subprocess.CompletedProcess(cmd, 0, stdout=out + "\n", stderr="")
+
+
+def test_guard_verifies_on_non_english_locale_host(monkeypatch):
+    """THE regression (follow-up to the TZ fix): on a non-English-locale Mac
+    without psutil, `ps -o lstart=` prints localized month/day names, the
+    ctime parse (%a %b) failed, and the guard failed CLOSED, so kill/pause/
+    resume refused for those users. _run now forces LC_ALL=C on the ps
+    subprocess, so lstart is always English and the guard verifies.
+
+    Revert-proof: without the _run env fix the fake ps below returns the
+    German rendering, _ctime_epoch_candidates yields no candidates, and
+    verify_pid refuses (RED); with the fix it sees English and verifies."""
+    monkeypatch.setattr(pc, "_psutil", None)
+    monkeypatch.setattr(pc, "_IS_MACOS", True)
+    monkeypatch.setattr(pc, "_IS_LINUX", False)
+    # The host is a German-locale machine.
+    monkeypatch.setenv("LANG", "de_DE.UTF-8")
+    monkeypatch.setenv("LC_TIME", "de_DE.UTF-8")
+    monkeypatch.setattr(pc.subprocess, "run", _fake_localized_ps)
+    # claude_code records procStart as an English ctime regardless of locale.
+    ok, reason = pc.verify_pid(os.getpid(), recorded_start=_EN_LSTART)
+    assert ok is True, reason
+    assert reason in ("verified", "verified_tz_normalized")
+
+
+def test_run_forces_c_locale_on_subprocess(monkeypatch):
+    """_run must pass an env that forces the C locale and strips every other
+    locale variable, while preserving the rest of the environment (PATH)."""
+    captured = {}
+
+    def spy(cmd, **kwargs):
+        captured.update(kwargs)
+        return subprocess.CompletedProcess(cmd, 0, stdout="x\n", stderr="")
+
+    monkeypatch.setenv("LANG", "fr_FR.UTF-8")
+    monkeypatch.setenv("LC_TIME", "fr_FR.UTF-8")
+    monkeypatch.setenv("LANGUAGE", "fr")
+    monkeypatch.setattr(pc.subprocess, "run", spy)
+    assert pc._run(["ps", "-o", "lstart=", "-p", "1"]) == "x\n"
+    env = captured.get("env")
+    assert _is_c_locale_env(env), f"subprocess env does not force C locale: {env}"
+    assert "PATH" in env  # non-locale environment is preserved
+
+
+def test_guard_still_fails_closed_on_unparseable_ps_output(monkeypatch):
+    """Fail-closed semantics survive the locale fix: if ps emits something
+    genuinely unparseable even under the C locale, the guard must refuse."""
+    monkeypatch.setattr(pc, "_psutil", None)
+    monkeypatch.setattr(pc, "_IS_MACOS", True)
+    monkeypatch.setattr(pc, "_IS_LINUX", False)
+
+    def broken_ps(cmd, **kwargs):
+        return subprocess.CompletedProcess(cmd, 0, stdout="not a date\n", stderr="")
+
+    monkeypatch.setattr(pc.subprocess, "run", broken_ps)
+    ok, reason = pc.verify_pid(os.getpid(), recorded_start=_EN_LSTART)
+    assert ok is False
+    assert reason.startswith("start_mismatch"), reason


### PR DESCRIPTION
## Why

Follow-up gap from #3477 (0.12.540). The pid-reuse guard for claude_code pause/kill/resume parses `ps -o lstart=` output via `strptime` with `%a %b` (English month/day abbreviations, `_ctime_epoch_candidates`). On a **non-English-locale Mac without psutil**, `ps` emits localized month/day names (e.g. `Do  2. Jul 04:26:55 2026` on a German Mac), the parse fails, no epoch candidates are produced, and the guard fails CLOSED: kill/pause/resume refuse (safe, but broken) for those users.

## What

Force the C locale on the **subprocess**, not the parser: `_run()` (the single choke point every `ps`/`lsof` call goes through) now passes `env=_c_locale_env()`, a copy of `os.environ` with `LC_ALL=C` set and `LANG`/`LANGUAGE`/`LC_*` stripped. `lstart` output is then always English, so the existing strptime always works. POSIX gives `LC_ALL` precedence over all other locale vars; stripping the rest is belt-and-braces for tools that consult `LANG` directly.

- Fail-closed semantics for genuinely unparseable output are unchanged (empty candidate set still refuses).
- Considered the `ps -o etime=` belt-and-braces candidate; skipped it as the env fix fully removes the locale dependency at the source and keeps the change minimal. The Python-side strptime itself uses the C locale unless someone calls `locale.setlocale`, which nothing in the daemon does.
- No behavior change on Linux (`/proc` path) or when psutil is present (epoch path); C-locale env on `ps`/`lsof` is harmless there.

## Guard tests (same PR, revert-proven)

`tests/test_process_control.py`:
- `test_guard_verifies_on_non_english_locale_host`: fake `ps` that returns the German lstart rendering UNLESS the subprocess env forces the C locale; asserts `verify_pid` verifies on a simulated German-locale host.
- `test_run_forces_c_locale_on_subprocess`: asserts `_run` passes `LC_ALL=C` with all other locale vars stripped and PATH preserved.
- `test_guard_still_fails_closed_on_unparseable_ps_output`: garbage ps output still refuses (`start_mismatch`).

**Revert-proof executed locally:** reverted the `process_control.py` fix -> `test_guard_verifies_on_non_english_locale_host` and `test_run_forces_c_locale_on_subprocess` FAILED (red); restored -> all green.

## Verification

- `pytest tests/test_process_control.py tests/test_sync_process_control_dispatch.py` -> 30 passed locally (macOS).
- Real-world sanity on this Mac: `LANG=de_DE.UTF-8 LC_ALL=de_DE.UTF-8 python3 -c ...` -> `pc._run(['ps','-o','lstart=','-p',<pid>])` returned English `Fri Jul  3 07:37:02 2026` (C locale forced on the child despite the German parent env).

🤖 Generated with [Claude Code](https://claude.com/claude-code)