### PR TITLE
fix(approvals): enforce deny-kill for family runtimes + close watcher watermark race

### DIFF
--- a/clawmetry/approvals.py
+++ b/clawmetry/approvals.py
@@ -6,7 +6,10 @@ tool calls that match a user-defined approval policy. When a match fires:
   1. POST the request to ClawMetry cloud (`/api/approvals/request`)
   2. Notify a human (cloud handles delivery — Slack/email/browser link)
   3. Poll cloud (`/api/approvals/<id>`) every 3 s up to policy.timeout
-  4. On `denied` → call gateway `sessions_kill(session_id)` to abort the agent
+  4. On `denied` → abort the agent: gateway `sessions_kill(session_id)` for
+     OpenClaw sessions, the pid-based `process_control.kill_session` engine
+     (same one the Stop button uses) for family runtimes
+     (claude_code/codex/goose/opencode/aider — ids like `claude_code:UUID`)
   5. On `timeout` → apply policy.on_timeout (default: deny → kill)
   6. On `approved` → no-op, the action proceeds
 
@@ -31,9 +34,11 @@ Backward-compat NOTE (PRD vivekchand/clawmetry-cloud#779, audit P0 #6):
 
 Design notes:
   * Stateless watcher — restartable any time, resumes from a single
-    ``approvals_last_check_ts`` watermark persisted in
-    ``~/.clawmetry/sync-state.json``. The watermark survives daemon
-    restarts, so already-decided approvals are not re-evaluated.
+    ``approvals_last_ingest_ms`` watermark (the events table's INGEST
+    stamp, not the event ts — see the watermark-race note above
+    ``watch_iteration``) persisted in ``~/.clawmetry/sync-state.json``.
+    The watermark survives daemon restarts, so already-decided approvals
+    are not re-evaluated.
   * One in-flight approval per (session, tool_call_id). Multiple matches
     on the same call collapse into one request — important so a session
     that matches both "rm" AND "outside-tmp" policies doesn't get
@@ -452,10 +457,45 @@ def _poll_decision(api_key: str, approval_id: str, timeout_s: int) -> str:
     return last_status if last_status != "pending" else "timeout"
 
 
-def _kill_session(session_id: Optional[str]) -> bool:
-    """Best-effort kill of an OpenClaw session via the gateway WebSocket RPC."""
-    if not session_id:
-        return False
+def _session_runtime(session_id: str) -> str:
+    """Runtime of a session id (its ``<runtime>:`` prefix, else openclaw).
+
+    Prefers ``sync._runtime_of_session`` (the canonical prefix map) and falls
+    back to a plain prefix parse so this module keeps working if sync isn't
+    importable (pure-OSS unit tests)."""
+    try:
+        from clawmetry.sync import _runtime_of_session
+        return _runtime_of_session(session_id)
+    except Exception:
+        sid = session_id or ""
+        i = sid.find(":")
+        if i > 0:
+            return sid[:i].lower()
+        return "openclaw"
+
+
+def _session_cwd_hint(session_id: str) -> str:
+    """Best-effort working-directory hint for cwd-resolved runtimes
+    (codex/goose/opencode/aider). Family adapters store the agent's cwd in
+    the event ``workspace_id`` column when known; claude_code doesn't need
+    it (per-pid session map). Never raises; '' when unknown."""
+    try:
+        from clawmetry import local_store
+        store = local_store.get_store(read_only=True)
+        for r in store.query_events(session_id=session_id, limit=1):
+            ws = r.get("workspace_id")
+            if isinstance(ws, str) and (
+                ws.startswith("/") or ws.startswith("~")
+                or (len(ws) > 2 and ws[1] == ":")
+            ):
+                return ws
+    except Exception:
+        pass
+    return ""
+
+
+def _gateway_kill_session(session_id: str) -> bool:
+    """Kill an OpenClaw session via the gateway WebSocket RPC."""
     try:
         # Late import to avoid pulling Flask into the daemon. helpers/gateway
         # is the OSS package's gateway WS client.
@@ -482,14 +522,67 @@ def _kill_session(session_id: Optional[str]) -> bool:
             try:
                 r = rpc(method, {"sessionId": session_id})
                 if r is not None:
-                    log.info(f"killed session {session_id} via {method}")
+                    log.info(f"killed session {session_id} via gateway {method}")
                     return True
             except Exception:
                 continue
         return False
     except Exception as e:
-        log.warning(f"kill_session({session_id}) failed: {e}")
+        log.warning(f"gateway kill_session({session_id}) failed: {e}")
         return False
+
+
+def _process_control_kill(session_id: str, runtime: str) -> bool:
+    """Kill a family-runtime session via the SAME pid-based engine the
+    Stop button uses (``clawmetry/process_control.py``): resolve the session
+    to its live pid (pid-reuse guarded), SIGTERM, escalate to SIGKILL of the
+    descendant tree. Never raises."""
+    try:
+        from clawmetry import process_control as _pc
+    except Exception as e:
+        log.warning(f"process_control unavailable for kill of {session_id}: {e}")
+        return False
+    # The store keys family sessions as '<runtime>:<bare-id>'; the process
+    # maps (e.g. ~/.claude/sessions/<pid>.json) key by the BARE id.
+    bare = (session_id or "").rsplit(":", 1)[-1]
+    cwd = _session_cwd_hint(session_id)
+    try:
+        res = _pc.kill_session(runtime, bare, cwd) or {}
+    except Exception as e:
+        log.warning(f"process_control kill_session({session_id}) raised: {e}")
+        return False
+    if res.get("ok"):
+        log.info(f"killed session {session_id} via process_control "
+                 f"(pid={res.get('pid')}, detail={res.get('detail')})")
+        return True
+    log.warning(f"process_control kill failed for {session_id}: "
+                f"{res.get('detail') or res.get('reason') or 'unknown'}")
+    return False
+
+
+def _kill_session(session_id: Optional[str]) -> bool:
+    """Best-effort kill of a denied session, runtime-aware.
+
+    * OpenClaw sessions -> gateway WebSocket RPC (the historical path).
+    * Family runtimes (claude_code / codex / goose / opencode / aider / ...,
+      session ids like ``claude_code:UUID``) -> the pid-based
+      ``process_control.kill_session`` engine the Stop button uses. The
+      gateway does not know these sessions, so before 2026-07-02 a DENY
+      logged ``killed=False`` and the denied agent KEPT RUNNING (live repro:
+      approval 7d202307907a4f12bd8af5aa17c62c76).
+
+    Fail-safe: if the primary mechanism fails we try the other one, and if
+    neither works we return False (callers log the warning)."""
+    if not session_id:
+        return False
+    runtime = _session_runtime(session_id)
+    if runtime != "openclaw":
+        if _process_control_kill(session_id, runtime):
+            return True
+        # Last resort: some wrapped setups register the session with the
+        # gateway anyway. Harmless when it doesn't.
+        return _gateway_kill_session(session_id)
+    return _gateway_kill_session(session_id)
 
 
 # ── Public entry point: process one toolCall event ────────────────────────
@@ -656,33 +749,50 @@ def process_tool_call(api_key: str, node_id: str, session_id: Optional[str],
 
 # ── Watcher: scan unified DuckDB event store for new toolCalls ────────────
 #
-# The watermark is the most recent event ts (ISO-8601 string) we've examined
-# AND completely processed. Persisted in ``~/.clawmetry/sync-state.json``
-# under the key ``approvals_last_check_ts`` so a daemon restart doesn't
-# re-evaluate already-decided approvals.
+# The watermark is the most recent INGEST stamp (``events.created_at``,
+# epoch-ms set at INSERT time) we've examined AND completely processed.
+# Persisted in ``~/.clawmetry/sync-state.json`` under
+# ``approvals_last_ingest_ms`` so a daemon restart doesn't re-evaluate
+# already-decided approvals.
 #
-# We deliberately store/compare ``ts`` as a string. Every adapter ingests its
-# event timestamps as strings (see ``clawmetry/local_store.py`` schema) and
-# DuckDB's ``ORDER BY ts`` sort is lexicographic on that VARCHAR column.
-# Lexicographic sort on properly-padded ISO-8601 timestamps is the same as
-# chronological — that's the whole point of the format. Mixing in a numeric
-# epoch would break the comparison.
+# Why ingest time and NOT the event's own ``ts`` (the pre-2026-07-02
+# design): family adapters (claude_code / codex / cursor / ...) can ingest a
+# session MINUTES after its events' timestamps (live repro: a brand-new
+# project dir ingested ~4 min late). By then newer events had already
+# advanced a ts-based watermark past them, so those tool calls were NEVER
+# evaluated — approval-gated actions silently sailed through. ``created_at``
+# is monotone with insertion (up to a few seconds of flush-retry skew,
+# covered by ``_INGEST_LOOKBACK_MS`` below), so a cursor on it sees every
+# row when it LANDS, no matter how stale its ``ts`` is.
 
 # In-memory mirror of the persisted watermark, primed lazily on first
-# iteration. ``None`` → not yet read from disk.
+# iteration. ``last_ingest_ms is None`` → not yet read from disk.
 #
-# ``last_check_ts`` is an ISO-8601 timestamp string. We query
-# ``query_events(since=last_check_ts)`` which uses ``ts >= since``
-# (inclusive). To prevent an event whose ``ts`` exactly equals
-# ``last_check_ts`` from being re-processed on every iteration, we also
-# track ``seen_ids_at_boundary`` — the set of event ids we've already
-# dispatched at the current watermark ts. The set is reset whenever the
-# watermark advances to a strictly newer ts.
+# ``seen_recent_ids`` maps event id -> created_at (ms) for every row we've
+# already dispatched whose stamp is still within the lookback window. The
+# window re-scan (``created_at >= watermark - lookback``) exists to catch
+# rows whose stamp predates their COMMIT (ring rows are stamped before the
+# writer lock is taken; flush retries add seconds); this set is what makes
+# that re-scan dispatch each row exactly once. Pruned every iteration to
+# ids still inside the window, so it stays bounded.
 _state: dict = {
-    "last_check_ts": None,        # Optional[str]
-    "seen_ids_at_boundary": set(),  # set[str]
+    "last_ingest_ms": None,     # Optional[int]  (epoch-ms, ingest stamp)
+    "seen_recent_ids": {},      # dict[str, int]  event id -> created_at ms
 }
 _state_lock = threading.Lock()
+
+# How far behind the ingest watermark each iteration re-scans (with id-level
+# dedup) to absorb created_at-stamp-vs-commit skew. Flush retries cap out
+# around ~3 s; 60 s is a generous, still-bounded margin.
+_INGEST_LOOKBACK_MS = int(os.environ.get(
+    "CLAWMETRY_APPROVALS_INGEST_LOOKBACK_MS", "60000") or 60000)
+# Keyset pages fetched per iteration (500 rows each). Bounds one iteration's
+# work; anything beyond is picked up by the next 2 s poll.
+_MAX_PAGES_PER_ITERATION = 4
+# Hard caps on the dedup set (in-memory / persisted) so a pathological burst
+# can't bloat memory or the on-disk state file.
+_SEEN_IDS_MEM_CAP = 20000
+_SEEN_IDS_DISK_CAP = 5000
 
 # Issue #1343 Phase 2 — event-driven kick.
 #
@@ -714,12 +824,14 @@ def watcher_kick():
 # doesn't have to learn a second file. We use the same key namespace the
 # sync daemon uses (separate top-level key, no collision).
 _STATE_PATH = Path.home() / ".clawmetry" / "sync-state.json"
-_STATE_KEY = "approvals_last_check_ts"
-# Companion key: the set of event ids we've already dispatched at the
-# watermark ts. Persisted alongside the watermark so a daemon restart
-# doesn't replay a boundary event that's already been processed (the
-# events table's ``ts >= since`` filter is inclusive).
-_STATE_KEY_SEEN = "approvals_seen_ids_at_boundary"
+# Ingest-time (created_at, epoch-ms) watermark. Replaces the legacy
+# ``approvals_last_check_ts`` event-ts watermark (see the watermark-race
+# note above); a stale legacy key in the file is simply ignored.
+_STATE_KEY = "approvals_last_ingest_ms"
+# Companion key: event id -> created_at (ms) for rows already dispatched
+# inside the lookback window. Persisted alongside the watermark so a daemon
+# restart doesn't replay a window row that's already been processed.
+_STATE_KEY_SEEN = "approvals_seen_ingest_ids"
 
 # Recognised "this content block is a tool invocation" types. Both flavours
 # coexist in the wild because adapters mirror their underlying agent's wire
@@ -742,34 +854,39 @@ _TOOL_BLOCK_TYPES = ("toolCall", "tool_use")
 _TOOL_EVENT_TYPES = ("message", "assistant", "tool_call")
 
 
-def _read_persisted_watermark() -> tuple[Optional[str], set[str]]:
-    """Read the persisted watermark + boundary-id set from sync-state.json.
+def _read_persisted_watermark() -> "tuple[Optional[int], dict[str, int]]":
+    """Read the persisted ingest watermark + dispatched-id map from
+    sync-state.json.
 
-    Returns ``(ts, seen_ids)``. ``ts`` is None if the file or key is missing
-    or unreadable; ``seen_ids`` is empty in the same cases. Never raises —
-    a corrupt state file must not stop the watcher from running, only
-    forces a one-time replay."""
+    Returns ``(watermark_ms, seen_ids)``. ``watermark_ms`` is None if the
+    file or key is missing or unreadable; ``seen_ids`` is empty in the same
+    cases. Never raises — a corrupt state file must not stop the watcher
+    from running, only forces a one-time re-anchor."""
     try:
         if not _STATE_PATH.exists():
-            return None, set()
+            return None, {}
         with _STATE_PATH.open("r", encoding="utf-8") as fh:
             blob = json.load(fh)
         v = blob.get(_STATE_KEY)
-        ts = v if isinstance(v, str) and v else None
-        ids_raw = blob.get(_STATE_KEY_SEEN) or []
-        ids = {s for s in ids_raw if isinstance(s, str)}
-        return ts, ids
+        wm = int(v) if isinstance(v, (int, float)) and v > 0 else None
+        ids_raw = blob.get(_STATE_KEY_SEEN) or {}
+        ids: dict[str, int] = {}
+        if isinstance(ids_raw, dict):
+            for k, c in ids_raw.items():
+                if isinstance(k, str) and isinstance(c, (int, float)):
+                    ids[k] = int(c)
+        return wm, ids
     except Exception as e:
         log.debug(f"approvals: could not read watermark from {_STATE_PATH}: {e}")
-        return None, set()
+        return None, {}
 
 
-def _persist_watermark(ts: str, seen_ids: set[str]) -> None:
-    """Atomically update the watermark + boundary-id set in sync-state.json.
-    Reads the existing blob (so we don't clobber sibling keys owned by
-    sync.py) and writes back. Never raises — losing one watermark write
-    means at most a re-replay on the next restart, which is benign because
-    ``_in_flight`` deduplicates."""
+def _persist_watermark(watermark_ms: int, seen_ids: "dict[str, int]") -> None:
+    """Atomically update the ingest watermark + dispatched-id map in
+    sync-state.json. Reads the existing blob (so we don't clobber sibling
+    keys owned by sync.py) and writes back. Never raises — losing one
+    watermark write means at most a re-replay on the next restart, which is
+    benign because the persisted id map + ``_in_flight`` deduplicate."""
     try:
         _STATE_PATH.parent.mkdir(parents=True, exist_ok=True)
         blob: dict = {}
@@ -779,11 +896,15 @@ def _persist_watermark(ts: str, seen_ids: set[str]) -> None:
                     blob = json.load(fh) or {}
             except Exception:
                 blob = {}
-        blob[_STATE_KEY] = ts
-        # Cap the persisted set: a single ts shouldn't accumulate more than
-        # a few dozen ids in practice, but a buggy adapter could spam the
-        # same ts. 1000 is generous and bounds the on-disk size.
-        blob[_STATE_KEY_SEEN] = sorted(seen_ids)[:1000]
+        blob[_STATE_KEY] = int(watermark_ms)
+        # Cap the persisted map (newest stamps win) so a burst can't bloat
+        # the on-disk state file.
+        if len(seen_ids) > _SEEN_IDS_DISK_CAP:
+            keep = sorted(seen_ids.items(), key=lambda kv: kv[1],
+                          reverse=True)[:_SEEN_IDS_DISK_CAP]
+            blob[_STATE_KEY_SEEN] = dict(keep)
+        else:
+            blob[_STATE_KEY_SEEN] = dict(seen_ids)
         tmp_path = _STATE_PATH.with_suffix(".json.tmp")
         with tmp_path.open("w", encoding="utf-8") as fh:
             json.dump(blob, fh, indent=2)
@@ -871,16 +992,14 @@ def _extract_tool_blocks(row: dict) -> list[tuple[str, str, dict]]:
     return out
 
 
-def _query_new_events(since: Optional[str], limit: int) -> list[dict]:
-    """Fetch candidate event rows from the local store since ``since`` (ts).
+def _query_new_events(created_after: int, after_id: Optional[str],
+                      limit: int) -> list[dict]:
+    """Fetch candidate event rows from the local store by INGEST order.
 
-    ``query_events`` accepts only one ``event_type`` filter at a time, but
-    different adapters ingest the same conceptual "assistant turn" event
-    under different ``event_type`` strings (OpenClaw uses ``"message"``;
-    some Anthropic-shape adapters use ``"assistant"``; the family adapters
-    emit one ``"tool_call"`` row per invocation). Issue one query per type
-    in ``_TOOL_EVENT_TYPES`` and merge. Cost is negligible — all are
-    indexed by ``idx_events_type_ts``.
+    One indexed keyset query covers all of ``_TOOL_EVENT_TYPES`` (the
+    conceptual "assistant turn" lands under ``"message"`` / ``"assistant"``
+    / one ``"tool_call"`` row per invocation depending on the adapter).
+    Rows come back oldest-ingested first with their ``created_at`` stamp.
     """
     from clawmetry import local_store
     try:
@@ -891,26 +1010,30 @@ def _query_new_events(since: Optional[str], limit: int) -> list[dict]:
         # than crash the loop.
         log.debug(f"approvals: local_store unavailable ({e})")
         return []
-    rows: list[dict] = []
-    for et in _TOOL_EVENT_TYPES:
-        try:
-            rows.extend(store.query_events(event_type=et, since=since, limit=limit))
-        except Exception as e:
-            log.debug(f"approvals: query_events({et}) failed: {e}")
-    return rows
+    try:
+        return store.query_events_by_ingest(
+            created_after=created_after, after_id=after_id,
+            event_types=_TOOL_EVENT_TYPES, limit=limit)
+    except Exception as e:
+        log.debug(f"approvals: query_events_by_ingest failed: {e}")
+        return []
 
 
 def watch_iteration(api_key: str, node_id: str,
                     policies: Optional[list[dict]] = None) -> int:
-    """One pass over the unified event store. Returns count of toolCalls
-    dispatched to ``process_tool_call`` (each in its own thread).
+    """One pass over the unified event store, in INGEST order. Returns the
+    count of toolCalls dispatched to ``process_tool_call`` (each in its own
+    thread).
 
-    Re-entrancy: the watermark moves forward only AFTER all matching rows
-    in this pass have been spawned. ``query_events(since=…)`` uses ``ts >=
-    since`` (inclusive), so on the next iteration we may re-see the row at
-    the boundary timestamp; the per-tool-call dedup in ``process_tool_call``
-    (``_in_flight`` keyed by tool_call_id) absorbs the duplicate without a
-    second cloud round-trip.
+    The cursor is ``events.created_at`` (insert stamp), NOT the event's own
+    ``ts`` — a family session ingested minutes after its events' timestamps
+    is still evaluated (the 2026-07-02 watermark race). Each iteration
+    re-scans a bounded lookback window behind the watermark (indexed, never
+    a full-table scan) to absorb stamp-vs-commit skew; ``seen_recent_ids``
+    guarantees each row is dispatched exactly once across polls AND daemon
+    restarts (it is persisted with the watermark). ``process_tool_call``'s
+    ``_in_flight`` map dedups at the (session, tool_call_id) level as the
+    final belt-and-braces, so an already-decided approval is never re-fired.
     """
     if policies is None:
         policies = load_policies()
@@ -920,89 +1043,95 @@ def watch_iteration(api_key: str, node_id: str,
     # Lazy-prime the watermark from disk on first iteration. Subsequent
     # iterations use the in-memory copy.
     with _state_lock:
-        if _state["last_check_ts"] is None:
-            persisted_ts, persisted_ids = _read_persisted_watermark()
-            # First-ever start: anchor to "now" so we don't replay the entire
-            # event history on a fresh install. ISO-8601 with "Z" suffix to
-            # match the format adapters emit.
-            if persisted_ts is None:
-                persisted_ts = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
-                _persist_watermark(persisted_ts, set())
-            _state["last_check_ts"] = persisted_ts
-            _state["seen_ids_at_boundary"] = persisted_ids
-        since = _state["last_check_ts"]
-        seen_at_boundary: set[str] = set(_state["seen_ids_at_boundary"])
-
-    # ``limit=500`` matches the PRD spec. At 2 s polling cadence that's a
-    # 250 toolCalls/sec ceiling, well above any realistic agent throughput.
-    rows = _query_new_events(since=since, limit=500)
-    if not rows:
-        return 0
+        if _state["last_ingest_ms"] is None:
+            persisted_ms, persisted_ids = _read_persisted_watermark()
+            # First-ever start (or upgrade from the legacy ts watermark):
+            # anchor to "now" so we don't replay the entire event history.
+            # The lookback window below still covers anything ingested in
+            # the last minute (e.g. during a daemon restart).
+            if persisted_ms is None:
+                persisted_ms = int(time.time() * 1000)
+                _persist_watermark(persisted_ms, {})
+            _state["last_ingest_ms"] = persisted_ms
+            _state["seen_recent_ids"] = persisted_ids
+        watermark = int(_state["last_ingest_ms"])
+        seen: dict = dict(_state["seen_recent_ids"])
 
     processed = 0
-    max_seen_ts = since
-    new_seen_at_boundary: set[str] = set(seen_at_boundary)
-    for row in rows:
-        ts = row.get("ts")
-        eid = row.get("id")
-        # Skip rows we've already dispatched at the boundary. ``query_events``
-        # is inclusive on ``since`` (ts >= since), so without this filter we'd
-        # re-fire on every poll for any event whose ts equals our watermark.
-        if isinstance(ts, str) and ts == since and eid in seen_at_boundary:
-            continue
-        if isinstance(ts, str) and (max_seen_ts is None or ts > max_seen_ts):
-            max_seen_ts = ts
-        sid = row.get("session_id") or ""
-        row_blocks = _extract_tool_blocks(row)
-        # Even if a row had no toolCall blocks we still mark it as "seen at
-        # this boundary" — otherwise the next poll would keep re-extracting
-        # the same plain assistant message until a later event nudges the
-        # watermark forward.
-        if isinstance(ts, str) and ts == since and isinstance(eid, str):
-            new_seen_at_boundary.add(eid)
-        for tool_call_id, tool_name, args in row_blocks:
-            if not tool_name:
-                # No tool name → no policy can match. Skip rather than
-                # bother process_tool_call.
+    max_ingest = watermark
+    saw_rows = False
+    # Window start: a bounded lookback behind the watermark. Rows in the
+    # window we already dispatched are skipped via ``seen``; rows that
+    # committed late (stamp older than the watermark) are caught here.
+    cursor_ca = max(0, watermark - _INGEST_LOOKBACK_MS)
+    cursor_id: Optional[str] = None  # None → inclusive window start
+    for _page in range(_MAX_PAGES_PER_ITERATION):
+        # ``limit=500`` per page matches the PRD spec; the page cap bounds
+        # one iteration's work (the next 2 s poll picks up the rest).
+        rows = _query_new_events(created_after=cursor_ca, after_id=cursor_id,
+                                 limit=500)
+        if not rows:
+            break
+        saw_rows = True
+        for row in rows:
+            eid = str(row.get("id") or "")
+            ca = row.get("created_at")
+            ca = int(ca) if isinstance(ca, (int, float)) else watermark
+            if ca > max_ingest:
+                max_ingest = ca
+            # Exactly-once inside the lookback window: skip rows already
+            # dispatched on a previous poll (or before a daemon restart —
+            # the map is persisted alongside the watermark).
+            if eid and eid in seen:
                 continue
-            # Run in a background thread so a long approval timeout
-            # doesn't stall the watcher loop.
-            t = threading.Thread(
-                target=process_tool_call,
-                args=(api_key, node_id, sid, tool_call_id, tool_name,
-                      args if isinstance(args, dict) else {}, policies),
-                daemon=True,
-            )
-            t.start()
-            processed += 1
+            # Mark every examined row (even without toolCall blocks) so the
+            # window re-scan never re-extracts it.
+            if eid:
+                seen[eid] = ca
+            sid = row.get("session_id") or ""
+            for tool_call_id, tool_name, args in _extract_tool_blocks(row):
+                if not tool_name:
+                    # No tool name → no policy can match. Skip rather than
+                    # bother process_tool_call.
+                    continue
+                # Run in a background thread so a long approval timeout
+                # doesn't stall the watcher loop.
+                t = threading.Thread(
+                    target=process_tool_call,
+                    args=(api_key, node_id, sid, tool_call_id, tool_name,
+                          args if isinstance(args, dict) else {}, policies),
+                    daemon=True,
+                )
+                t.start()
+                processed += 1
+        if len(rows) < 500:
+            break
+        # Strict keyset continuation from the last row — pages always make
+        # progress even when hundreds of rows share one millisecond stamp
+        # (a single flush batch does).
+        last = rows[-1]
+        last_ca = last.get("created_at")
+        cursor_ca = int(last_ca) if isinstance(last_ca, (int, float)) else cursor_ca
+        cursor_id = str(last.get("id") or "")
 
-    # Advance the watermark and persist. We move it forward whether or not
-    # any toolCalls fired — the goal is to avoid re-scanning rows whose
-    # timestamp is already in our rear-view mirror, even when none of them
-    # were assistant-with-toolCall events. When the watermark advances to a
-    # strictly newer ts, the boundary-id set is reset (those older events
-    # are now in the rear-view and can't be re-seen with ts >= since).
-    advanced = isinstance(max_seen_ts, str) and max_seen_ts != since
+    if not saw_rows:
+        return 0
+
+    # Advance the watermark, prune the dedup map to the new lookback window
+    # (older rows can never be re-fetched), and persist. Cheap (single small
+    # JSON file); a daemon crash mid-poll loses at most this iteration's
+    # rows, which the persisted map + ``_in_flight`` absorb on replay.
+    cutoff = max_ingest - _INGEST_LOOKBACK_MS
+    seen = {i: c for i, c in seen.items() if c >= cutoff}
+    if len(seen) > _SEEN_IDS_MEM_CAP:
+        seen = dict(sorted(seen.items(), key=lambda kv: kv[1],
+                           reverse=True)[:_SEEN_IDS_MEM_CAP])
     with _state_lock:
-        if advanced:
-            _state["last_check_ts"] = max_seen_ts
-            # Anything at the new boundary ts is captured here — repopulate
-            # from this iteration's rows so we don't redispatch them on the
-            # next poll (still within the inclusive ``ts >= since`` window).
-            _state["seen_ids_at_boundary"] = {
-                str(r.get("id")) for r in rows
-                if isinstance(r.get("ts"), str) and r.get("ts") == max_seen_ts
-                and r.get("id") is not None
-            }
-        else:
-            _state["seen_ids_at_boundary"] = new_seen_at_boundary
-        snapshot_ts = _state["last_check_ts"]
-        snapshot_ids = set(_state["seen_ids_at_boundary"])
-    # Persist on every successful iteration. Cheap (single small JSON file)
-    # and means a daemon crash mid-poll loses at most the events from this
-    # iteration — bounded by limit=500.
-    if isinstance(snapshot_ts, str):
-        _persist_watermark(snapshot_ts, snapshot_ids)
+        _state["last_ingest_ms"] = max_ingest
+        _state["seen_recent_ids"] = seen
+        snapshot_ms = int(_state["last_ingest_ms"])
+        snapshot_ids = dict(_state["seen_recent_ids"])
+    _persist_watermark(snapshot_ms, snapshot_ids)
 
     return processed
 

--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -225,6 +225,12 @@ _DDL = [
     # query that wants to scan a single session's timeline by event_type
     # without hitting the full ts index.
     "CREATE INDEX IF NOT EXISTS idx_events_session_ts_type ON events(session_id, ts, event_type)",
+    # Ingest-order scans: the approvals watcher advances its watermark on
+    # created_at (the INSERT stamp) rather than the event's own ts, so a
+    # session ingested minutes after its events' timestamps is still
+    # evaluated (the 2026-07-02 watermark race). Without this index every
+    # watcher poll would be a full-table scan on created_at.
+    "CREATE INDEX IF NOT EXISTS idx_events_created_at ON events(created_at)",
     """
     CREATE TABLE IF NOT EXISTS sessions (
         agent_type      VARCHAR NOT NULL DEFAULT 'openclaw',
@@ -5546,6 +5552,61 @@ class LocalStore:
         """
         params.append(int(limit))
         return [_row_to_event(r, _EVENT_COLS) for r in self._fetch(sql, params)]
+
+    def query_events_by_ingest(
+        self,
+        *,
+        created_after: int,
+        after_id: str | None = None,
+        event_types: "tuple[str, ...] | list[str]" = (),
+        limit: int = 500,
+    ) -> list[dict[str, Any]]:
+        """Read events by INGEST order (``created_at``, epoch-ms stamped at
+        insert time) instead of the event's own ``ts``.
+
+        This is the approvals-watcher cursor primitive: family adapters
+        (claude_code / codex / cursor / ...) can ingest a session MINUTES
+        after its events' timestamps, so a ``ts``-based watermark that other
+        events already advanced skips those rows forever (the 2026-07-02
+        approvals watermark race). ``created_at`` is monotone with insertion
+        (up to flush-retry skew of a few seconds), so a cursor on it sees
+        every row exactly when it lands regardless of how stale its ``ts`` is.
+
+        Semantics:
+          * ``after_id is None``  -> ``created_at >= created_after`` (inclusive
+            window start, for a bounded lookback re-scan).
+          * ``after_id`` given    -> strict keyset continuation:
+            ``created_at > created_after OR (created_at = created_after AND
+            id > after_id)`` so callers can page forward even when many rows
+            share one millisecond stamp (a single flush batch does).
+
+        Rows come back oldest-ingested first (``created_at ASC, id ASC``) and
+        include the ``created_at`` column. Uses ``idx_events_created_at`` —
+        never a full-table scan.
+        """
+        clauses: list[str] = []
+        params: list[Any] = []
+        if after_id is None:
+            clauses.append("created_at >= ?")
+            params.append(int(created_after))
+        else:
+            clauses.append("(created_at > ? OR (created_at = ? AND id > ?))")
+            params.extend([int(created_after), int(created_after), str(after_id)])
+        if event_types:
+            placeholders = ",".join("?" for _ in event_types)
+            clauses.append(f"event_type IN ({placeholders})")
+            params.extend(str(t) for t in event_types)
+        sql = f"""
+            SELECT id, agent_type, node_id, agent_id, session_id, workspace_id,
+                   event_type, ts, data, cost_usd, token_count, model, created_at
+            FROM events
+            WHERE {' AND '.join(clauses)}
+            ORDER BY created_at ASC, id ASC
+            LIMIT ?
+        """
+        params.append(int(limit))
+        cols = _EVENT_COLS + ["created_at"]
+        return [_row_to_event(r, cols) for r in self._fetch(sql, params)]
 
     # ── Issue #2200: integrity hash chain ────────────────────────────────────
 

--- a/tests/test_approvals_deny_kill.py
+++ b/tests/test_approvals_deny_kill.py
@@ -1,0 +1,155 @@
+"""Guard tests for the 2026-07-02 deny-kill enforcement gap.
+
+Live repro: approval ``7d202307907a4f12bd8af5aa17c62c76`` was DENIED from the
+mobile app, the daemon logged ``denied, killed=False``, and the claude_code
+canary KEPT RUNNING. Root cause: ``approvals._kill_session`` only attempted
+the OpenClaw gateway RPC (``sessions_kill``/...), which does not know
+family-runtime sessions (ids like ``claude_code:UUID``), so a deny never
+enforced anything for claude_code / codex / goose / opencode / aider.
+
+The fix routes family-runtime denies through the SAME pid-based engine the
+Stop button uses (``clawmetry/process_control.kill_session``), keeping the
+gateway path for OpenClaw. These tests are revert-proof: on the pre-fix
+code the process_control spy is never invoked and ``killed`` stays False.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import uuid
+
+import pytest
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+import clawmetry.approvals as ap  # noqa: E402
+import clawmetry.process_control as pc  # noqa: E402
+
+
+_FAMILY_SID = "claude_code:11111111-2222-3333-4444-555555555555"
+_BARE_SID = "11111111-2222-3333-4444-555555555555"
+
+
+@pytest.fixture
+def spies(monkeypatch):
+    """Spy on both kill mechanisms; neither touches a real process or the
+    network. ``raising=False`` keeps the fixture importable on pre-fix code
+    (which lacks ``_gateway_kill_session``) so a revert shows up as a RED
+    assertion, not a fixture error."""
+    calls = {"pc": [], "gw": [], "gw_ret": False, "pc_ok": True}
+
+    def _fake_pc_kill(runtime, session_id="", cwd="", mode="kill"):
+        calls["pc"].append((runtime, session_id, cwd, mode))
+        if calls["pc_ok"]:
+            return {"ok": True, "action": "graceful_kill", "pid": 4242,
+                    "runtime": runtime, "detail": "terminated"}
+        return {"ok": False, "action": "graceful_kill", "pid": None,
+                "runtime": runtime, "detail": "session_not_in_claude_map"}
+
+    def _fake_gw_kill(session_id):
+        calls["gw"].append(session_id)
+        return calls["gw_ret"]
+
+    monkeypatch.setattr(pc, "kill_session", _fake_pc_kill)
+    monkeypatch.setattr(ap, "_gateway_kill_session", _fake_gw_kill,
+                        raising=False)
+    # Keep the cwd lookup away from any real DuckDB store.
+    monkeypatch.setattr(ap, "_session_cwd_hint", lambda sid: "",
+                        raising=False)
+    return calls
+
+
+# ── unit: _kill_session routing ───────────────────────────────────────────
+
+
+def test_deny_kill_family_runtime_uses_process_control(spies):
+    """BUG 1 GUARD: a family-runtime session id must route to the pid-based
+    process_control kill (the Stop-button engine), with the runtime prefix
+    stripped for the process-map lookup. Pre-fix code only tried the gateway
+    and returned False."""
+    assert ap._kill_session(_FAMILY_SID) is True
+    assert spies["pc"] == [("claude_code", _BARE_SID, "", "kill")]
+    # process_control succeeded, so the gateway is never consulted.
+    assert spies["gw"] == []
+
+
+def test_deny_kill_openclaw_still_uses_gateway(spies):
+    """OpenClaw sessions (no family prefix) keep the historical gateway RPC
+    path and never go near process_control."""
+    spies["gw_ret"] = True
+    assert ap._kill_session("bare-openclaw-session-uuid") is True
+    assert spies["gw"] == ["bare-openclaw-session-uuid"]
+    assert spies["pc"] == []
+
+
+def test_deny_kill_family_failure_falls_back_then_fails_safe(spies):
+    """If the pid kill cannot resolve the session, we try the gateway as a
+    last resort and return False when neither works (the caller keeps the
+    existing killed=False warning behaviour)."""
+    spies["pc_ok"] = False
+    assert ap._kill_session(_FAMILY_SID) is False
+    assert len(spies["pc"]) == 1
+    assert spies["gw"] == [_FAMILY_SID]
+
+
+def test_deny_kill_codex_prefix_routes_to_process_control(spies):
+    """The routing is runtime-generic (prefix-driven), not claude_code
+    specific."""
+    assert ap._kill_session("codex:abc-123") is True
+    assert spies["pc"][0][0] == "codex"
+    assert spies["pc"][0][1] == "abc-123"
+
+
+def test_deny_kill_empty_session_is_noop(spies):
+    assert ap._kill_session(None) is False
+    assert ap._kill_session("") is False
+    assert spies["pc"] == [] and spies["gw"] == []
+
+
+# ── end to end: a DENIED approval on a family session enforces the kill ──
+
+
+def test_denied_approval_kills_family_session(monkeypatch, spies):
+    """Full ``process_tool_call`` flow with the cloud round-trip mocked to
+    DENY: the result must report ``killed=True`` and the process_control spy
+    must have fired for the family runtime. This is the exact live-repro
+    shape (deny from the phone, claude_code session)."""
+    monkeypatch.setattr(ap, "_post_approval_request", lambda *a, **k: {"ok": True})
+    monkeypatch.setattr(ap, "_poll_decision", lambda *a, **k: "denied")
+
+    # Keep DuckDB + the audit producer out of the unit.
+    class _StoreStub:
+        def ingest_approval(self, approval):
+            pass
+
+        def update_approval_decision(self, *a, **k):
+            pass
+
+    import clawmetry.local_store as _ls
+    monkeypatch.setattr(_ls, "get_store", lambda *a, **k: _StoreStub())
+    import clawmetry.audit as _audit
+    monkeypatch.setattr(_audit, "audit_event", lambda *a, **k: None,
+                        raising=False)
+
+    policy = ap._compile_policy({
+        "name": "deny-canary",
+        "match": {"tool": "exec", "command_regex": r"rm\s+-rf"},
+        "timeout": 1,
+    })
+    assert policy is not None
+
+    result = ap.process_tool_call(
+        api_key="test-key", node_id="node-1", session_id=_FAMILY_SID,
+        tool_call_id=uuid.uuid4().hex, tool_name="Bash",
+        args={"command": "rm -rf /tmp/canary"}, policies=[policy])
+
+    assert result["decision"] == "denied"
+    assert result["killed"] is True, (
+        "denied family-runtime approval must actually kill the session "
+        "(pre-fix: gateway-only path logged killed=False and the agent "
+        "kept running)")
+    assert spies["pc"] and spies["pc"][0][0] == "claude_code"
+    assert spies["pc"][0][1] == _BARE_SID

--- a/tests/test_approvals_duckdb_watcher.py
+++ b/tests/test_approvals_duckdb_watcher.py
@@ -53,6 +53,14 @@ def _ts(seconds_offset: float = 0.0) -> str:
     return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(t))
 
 
+def _anchor_watermark(ap, seconds_ago: float = 10.0) -> None:
+    """Prime the in-memory INGEST watermark to 'a moment ago' so rows the
+    test is about to ingest (created_at = now) are all visible, without the
+    first-iteration anchor-to-now racing the ingest."""
+    ap._state["last_ingest_ms"] = int((time.time() - seconds_ago) * 1000)
+    ap._state["seen_recent_ids"] = {}
+
+
 def _msg_event(eid: str, sid: str, ts: str, *,
                agent_type: str = "openclaw",
                role: str = "assistant",
@@ -113,8 +121,8 @@ def watcher(tmp_path, monkeypatch):
     state_path = tmp_path / "sync-state.json"
     monkeypatch.setattr(ap, "_STATE_PATH", state_path)
     # Force the in-memory watermark mirror to re-prime from disk.
-    ap._state["last_check_ts"] = None
-    ap._state["seen_ids_at_boundary"] = set()
+    ap._state["last_ingest_ms"] = None
+    ap._state["seen_recent_ids"] = {}
 
     # Capture every process_tool_call invocation. Replace it on the module
     # and turn off the threading.Thread spawn so assertions are
@@ -188,7 +196,7 @@ def test_watcher_dispatches_three_toolcalls(watcher):
     store = ls.get_store()
 
     # Anchor watermark to "before the test events" so they're all visible.
-    ap._state["last_check_ts"] = _ts(-10)
+    _anchor_watermark(ap)
 
     for i in range(3):
         store.ingest(_msg_event(
@@ -222,10 +230,11 @@ def test_watcher_dispatches_three_toolcalls(watcher):
 
 def test_watcher_does_not_redispatch_on_second_pass(watcher):
     """One event → first watch_iteration fires once → second pass sees
-    nothing new (watermark advanced past the row's ts)."""
+    nothing new (ingest watermark advanced past the row and its id is
+    in the dispatched-id map for the lookback window)."""
     ap, ls, captured, policies, _ = watcher
     store = ls.get_store()
-    ap._state["last_check_ts"] = _ts(-10)
+    _anchor_watermark(ap)
 
     store.ingest(_msg_event(
         eid="ev-once", sid="sess-once", ts=_ts(0),
@@ -251,7 +260,7 @@ def test_watcher_skips_messages_without_toolcall(watcher):
     only the message that carries a toolCall block does."""
     ap, ls, captured, policies, _ = watcher
     store = ls.get_store()
-    ap._state["last_check_ts"] = _ts(-10)
+    _anchor_watermark(ap)
 
     # No-toolCall: just a text block.
     store.ingest(_msg_event(
@@ -280,7 +289,7 @@ def test_watcher_processes_non_openclaw_adapter(watcher):
     PRD acceptance: the watcher is adapter-agnostic now."""
     ap, ls, captured, policies, _ = watcher
     store = ls.get_store()
-    ap._state["last_check_ts"] = _ts(-10)
+    _anchor_watermark(ap)
 
     store.ingest(_msg_event(
         eid="ev-hermes", sid="sess-hermes", ts=_ts(0),
@@ -311,7 +320,7 @@ def test_watermark_survives_daemon_restart(watcher, monkeypatch):
     and skip the already-processed event — no double-fire."""
     ap, ls, captured, policies, state_path = watcher
     store = ls.get_store()
-    ap._state["last_check_ts"] = _ts(-10)
+    _anchor_watermark(ap)
 
     store.ingest(_msg_event(
         eid="ev-pre-restart", sid="sess-X", ts=_ts(0),
@@ -327,8 +336,8 @@ def test_watermark_survives_daemon_restart(watcher, monkeypatch):
     # store + on-disk watermark intact. The next iteration must reload the
     # watermark from disk and NOT re-fire on the same event.
     captured.clear()
-    ap._state["last_check_ts"] = None
-    ap._state["seen_ids_at_boundary"] = set()
+    ap._state["last_ingest_ms"] = None
+    ap._state["seen_recent_ids"] = {}
 
     n2 = ap.watch_iteration("k", "n", policies=policies)
     assert n2 == 0, "post-restart pass must not redispatch the already-seen event"
@@ -339,4 +348,63 @@ def test_watermark_survives_daemon_restart(watcher, monkeypatch):
     with state_path.open() as fh:
         blob = _j.load(fh)
     assert blob.get(ap._STATE_KEY) is not None
-    assert ap._state["last_check_ts"] == blob[ap._STATE_KEY]
+    assert ap._state["last_ingest_ms"] == blob[ap._STATE_KEY]
+
+
+# ── 6. BUG 2 GUARD: late-ingested events (2026-07-02 watermark race) ──────
+
+
+def test_late_ingested_event_with_stale_ts_still_evaluated(watcher):
+    """An event whose INGESTION lags its ``ts`` beyond the watermark must
+    still be evaluated exactly once.
+
+    Live repro 2026-07-02: family adapters ingested a brand-new project dir
+    ~4 minutes after its events' timestamps; newer events had already
+    advanced the (then ts-based) watermark past them, so those tool calls
+    were NEVER evaluated and approval-gated actions sailed through. The
+    watcher now cursors on ``events.created_at`` (the ingest stamp), so a
+    stale-``ts`` row is picked up the moment it lands.
+
+    Revert-proof: on the pre-fix ts-watermark code, step 2's row (ts far
+    behind the watermark) is never fetched and the assertion goes RED."""
+    ap, ls, captured, policies, _ = watcher
+    store = ls.get_store()
+    _anchor_watermark(ap)
+
+    # 1. A live event advances the watermark.
+    store.ingest(_msg_event(
+        eid="ev-live", sid="sess-live", ts=_ts(1000),
+        content=[_toolcall_block("bash", {"cmd": "echo live"},
+                                 blk_id="tc-live")],
+    ))
+    store._flush_now()
+    assert ap.watch_iteration("k", "n", policies=policies) == 1
+    assert captured[-1]["tool_call_id"] == "tc-live"
+
+    # 2. NOW a session is ingested whose event ts is far BEHIND the
+    # already-advanced watermark (the minutes-late family ingest). It must
+    # still be dispatched.
+    store.ingest(_msg_event(
+        eid="ev-late", sid="claude_code:sess-late", ts=_ts(0),
+        agent_type="claude_code",
+        content=[_toolcall_block("bash", {"cmd": "rm -rf /tmp/x"},
+                                 blk_id="tc-late")],
+    ))
+    store._flush_now()
+    n = ap.watch_iteration("k", "n", policies=policies)
+    assert n == 1, ("late-ingested event with a stale ts must still be "
+                    "evaluated (pre-fix ts-watermark skipped it forever)")
+    assert captured[-1]["tool_call_id"] == "tc-late"
+    assert captured[-1]["session_id"] == "claude_code:sess-late"
+
+    # 3. Exactly once: further passes must not re-dispatch either row.
+    assert ap.watch_iteration("k", "n", policies=policies) == 0
+    assert len(captured) == 2
+
+    # 4. ... including across a daemon restart (the dedup map is persisted
+    # with the watermark, and the late row is still inside the lookback
+    # window).
+    ap._state["last_ingest_ms"] = None
+    ap._state["seen_recent_ids"] = {}
+    assert ap.watch_iteration("k", "n", policies=policies) == 0
+    assert len(captured) == 2

--- a/tests/test_policy_replay.py
+++ b/tests/test_policy_replay.py
@@ -219,13 +219,14 @@ def test_watcher_queries_tool_call_event_type(monkeypatch):
     seen: list = []
 
     class _QStub:
-        def query_events(self, *, event_type=None, since=None, limit=0):
-            seen.append(event_type)
+        def query_events_by_ingest(self, *, created_after=0, after_id=None,
+                                   event_types=(), limit=0):
+            seen.extend(event_types)
             return []
 
     import clawmetry.local_store as _ls
     monkeypatch.setattr(_ls, "get_store", lambda *a, **k: _QStub())
-    approvals._query_new_events(None, 10)
+    approvals._query_new_events(0, None, 10)
     assert set(seen) == {"message", "assistant", "tool_call"}
 
 


### PR DESCRIPTION
## Why

Two real enforcement gaps in the approvals engine, both found 2026-07-02 by a live approval E2E driven from the mobile app on the founder node:

**Bug 1: approval DENY did not kill family-runtime sessions.** `clawmetry/approvals.py::_kill_session` only attempted the OpenClaw gateway RPC (`sessions_kill`/`session_kill`/`kill_session`). For family runtimes (session ids like `claude_code:UUID`) the gateway does not know the session, so `killed=False` and the denied agent KEPT RUNNING. Live repro: approval `7d202307907a4f12bd8af5aa17c62c76` denied from the phone; the daemon logged `denied, killed=False`; the claude_code canary survived until manually killed.

**Bug 2: watcher watermark race skipped late-ingested sessions.** `watch_iteration` advanced a single event-`ts` watermark (`approvals_last_check_ts` in `~/.clawmetry/sync-state.json`). Family adapters can ingest a session MINUTES after its events' timestamps (live repro: a brand-new project dir ingested ~4 min late); by then newer events had advanced the watermark past them, so those tool calls were never evaluated and approval-gated actions silently sailed through.

## What

**Bug 1 fix** (`clawmetry/approvals.py`):
- `_kill_session` is now runtime-aware: family runtimes route through the SAME pid-based engine the Stop button uses, `process_control.kill_session` (pid-reuse guarded, SIGTERM then SIGKILL of the descendant tree), with the runtime prefix stripped for the process-map lookup and a best-effort cwd hint from the event `workspace_id` for the cwd-resolved runtimes.
- OpenClaw keeps the existing gateway RPC path unchanged (factored into `_gateway_kill_session`).
- Logs which mechanism fired. Fail-safe: a failed pid kill falls back to a gateway attempt; if neither works the existing `killed=False` warning behavior is preserved.

**Bug 2 fix** (`clawmetry/approvals.py` + `clawmetry/local_store.py`):
- Watermark now tracks INGESTION time (`events.created_at`, the epoch-ms insert stamp) instead of the event's own `ts`, persisted as `approvals_last_ingest_ms`. A session ingested minutes late is seen the moment its rows land, regardless of how stale its `ts` is.
- New `LocalStore.query_events_by_ingest(created_after, after_id, event_types, limit)` keyset query + `idx_events_created_at` index (added via `CREATE INDEX IF NOT EXISTS`, so existing DBs migrate on next open). Ordered `created_at ASC, id ASC`; strict keyset continuation makes progress even when hundreds of rows share one millisecond stamp (a single flush batch does).
- Bounded 60s lookback window (`CLAWMETRY_APPROVALS_INGEST_LOOKBACK_MS`) absorbs stamp-vs-commit skew (ring rows are stamped before the writer lock; flush retries add seconds). A persisted dispatched-id map makes the window re-scan exactly-once across polls AND daemon restarts; `process_tool_call`'s `_in_flight` map stays as the final (session, tool_call_id) dedup, so already-decided approvals are never re-fired.
- CPU budget (FLYWHEEL 1e): every query is indexed and bounded (max 4 pages x 500 rows per 2s iteration, window re-scan limited to 60s of rows). No full-table rescans. The id map is pruned every iteration and hard-capped (20k mem / 5k disk).

## Guards (same PR, revert-proven)

Ran the guards against the UN-fixed code (`git stash` of `clawmetry/approvals.py` + `clawmetry/local_store.py`, tests kept): **11 red**. Restored the fix: **64 green** across `test_approvals_deny_kill.py`, `test_approvals_duckdb_watcher.py`, `test_policy_replay.py`, `test_approvals_local_store.py`, `test_process_control.py`, `test_sync_process_control_dispatch.py`.

1. **Deny-kill guard** (`tests/test_approvals_deny_kill.py`): a deny on a family-runtime session invokes the `process_control.kill_session` path (spy) with the bare session id; OpenClaw still routes to the gateway; pid-kill failure falls back and fails safe; and the full `process_tool_call` deny flow asserts `killed=True` (pre-fix: gateway-only path returned `killed=False`).
2. **Watermark-race guard** (`test_late_ingested_event_with_stale_ts_still_evaluated`): an event whose ingestion lags its `ts` beyond the already-advanced watermark is still evaluated EXACTLY once, including across a simulated daemon restart (persisted dedup map). Red on the pre-fix ts-watermark code.

## Verification

- Full-chain smoke in one process (temp DuckDB, cloud round-trip mocked to `denied`, `process_control.kill_session` spied): ingested a family `tool_call` row whose `ts` was 10 minutes old against a fresher watermark; the watcher picked it up, the policy fired, and the result was `denied, killed=True` via `process_control('claude_code', 'dead-beef')`; a second iteration dispatched 0.
- `make lint` AST check green; `py_compile` green on both changed modules.
- Note: `tests/test_audit_producers.py::test_apply_approval_decision_records_audit` flakes when run after `test_policy_replay.py` in the same pytest process. Verified pre-existing on clean `origin/main` (same red), unrelated to this change.

No daemon-facing API changes: `watcher_loop` / `watch_iteration` / `watcher_kick` signatures unchanged; legacy `approvals_last_check_ts` key in `sync-state.json` is simply ignored (one-time re-anchor to now, with the lookback window covering the restart gap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)