### PR TITLE
feat(entitlement): tier_catalog_path + /tier-catalog-path endpoint

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -8439,6 +8439,112 @@ def runtime_catalog_path(from_tier: str, to_tier: str) -> list[dict] | None:
         return None
 
 
+def tier_catalog_path(from_tier: str, to_tier: str) -> list[dict] | None:
+    """Arbitrary-endpoint stepwise tier-catalog path between two tiers.
+
+    Tier-axis twin of :func:`feature_catalog_path` and
+    :func:`runtime_catalog_path`: the FULL tier ladder at every rung
+    between any two tiers off ONE round-trip, with each rung's inner
+    ``tiers`` list carrying the ladder from the perspective of that
+    rung (``is_current`` pinned on the rung id). Lets an upgrade-
+    walkthrough UI render the full pricing ladder at every step
+    between two tiers without first calling :func:`tier_path` to get
+    the rung list and then N calls to :func:`tier_catalog_at`.
+
+    Pairs with :func:`feature_catalog_path` / :func:`runtime_catalog_path`
+    the same way :func:`tier_catalog_at` pairs with
+    :func:`feature_catalog_at` / :func:`runtime_catalog_at`. Together
+    the three ``_catalog_path`` helpers let an upgrade-walkthrough UI
+    render every tier + feature + runtime column at every rung off
+    THREE calls instead of first calling :func:`tier_path` and then
+    3 * N calls to the scalar what-if catalog helpers.
+
+    Per-rung row shape mirrors :func:`feature_catalog_path` /
+    :func:`runtime_catalog_path` with ``features`` / ``runtimes``
+    renamed to ``tiers``::
+
+        {
+          "tier":       "<rung id>",
+          "tier_label": "...",
+          "tier_rank":  <int>,
+          "tiers":      [<tier_catalog_at row>, ...],
+        }
+
+    Each rung's inner ``tiers`` list byte-equals
+    :func:`tier_catalog_at` for the same rung id -- a parity test
+    pins this so the scalar and path what-if tier-ladder surfaces
+    cannot drift.
+
+    Walk semantics, direction semantics, endpoint semantics and
+    resolver-independence all match :func:`feature_catalog_path` --
+    see that helper's docstring. Rung walk is byte-stable against
+    :func:`tier_path`, :func:`tier_spec_path`,
+    :func:`capacity_diff_path`, :func:`tier_unlocks_path`,
+    :func:`tier_locks_path`, :func:`preview_path`,
+    :func:`feature_spec_path`, :func:`runtime_spec_path`,
+    :func:`feature_catalog_path` and :func:`runtime_catalog_path`
+    (same ``_PURCHASABLE_TIERS`` filter + same sort key + same
+    destination-sibling exclusion), so the paths line up rung-for-rung.
+
+    Never raises: a resolver failure logs a warning and returns
+    ``None`` so a pricing-page surface keeps rendering instead of
+    breaking.
+    """
+    try:
+        f = (from_tier or "").strip().lower()
+        t = (to_tier or "").strip().lower()
+        if f not in _TIER_FEATURES or t not in _TIER_FEATURES:
+            return None
+        if f == t:
+            return []
+        from_rank = _TIER_RANK.get(f, -1)
+        to_rank = _TIER_RANK.get(t, -1)
+
+        def _row(rung: str) -> dict | None:
+            catalog = tier_catalog_at(rung)
+            if catalog is None:
+                return None
+            return {
+                "tier": rung,
+                "tier_label": tier_label(rung),
+                "tier_rank": _TIER_RANK.get(rung, -1),
+                "tiers": catalog,
+            }
+
+        if from_rank == to_rank:
+            row = _row(t)
+            return [row] if row is not None else []
+        ascending = to_rank > from_rank
+        if ascending:
+            ordered = sorted(
+                _PURCHASABLE_TIERS,
+                key=lambda x: (_TIER_RANK.get(x, -1), x),
+            )
+        else:
+            ordered = sorted(
+                _PURCHASABLE_TIERS,
+                key=lambda x: (-_TIER_RANK.get(x, -1), x),
+            )
+        path: list[dict] = []
+        for tid in ordered:
+            r = _TIER_RANK.get(tid, -1)
+            if ascending:
+                if r <= from_rank or r > to_rank:
+                    continue
+            else:
+                if r >= from_rank or r < to_rank:
+                    continue
+            if r == to_rank and tid != t:
+                continue
+            row = _row(tid)
+            if row is not None:
+                path.append(row)
+        return path
+    except Exception as exc:
+        logger.warning("entitlements: tier_catalog_path failed: %s", exc)
+        return None
+
+
 def lock_reason_path(
     from_tier: str, to_tier: str, item, *, kind: str | None = None
 ) -> list[dict] | None:

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -227,6 +227,21 @@ is the single source of truth -- handlers never re-derive tier logic here.
                                          instead of first walking
                                          ``/tier-path`` and then hydrating
                                          each rung individually.
+  GET  /api/entitlement/tier-catalog-path -- tier-axis twin of
+                                         ``/feature-catalog-path`` /
+                                         ``/runtime-catalog-path``. Each row
+                                         is a ``/tier-catalog-at`` payload at
+                                         ``rung=<tier>`` so an upgrade-
+                                         walkthrough surface hydrates the
+                                         full pricing ladder at every rung
+                                         between two tiers off one round-
+                                         trip. Together the three
+                                         ``_catalog_path`` endpoints render
+                                         every tier + feature + runtime
+                                         column at every rung off three calls
+                                         instead of walking ``/tier-path``
+                                         and hydrating each rung
+                                         individually.
 """
 
 from __future__ import annotations
@@ -7807,6 +7822,98 @@ def api_entitlement_runtime_catalog_path():
     except Exception as exc:
         logger.warning(
             "api_entitlement_runtime_catalog_path: error: %s", exc
+        )
+        return (
+            jsonify({"error": "unknown tier", "from": f, "to": t}),
+            404,
+        )
+
+
+@bp_entitlement.route("/api/entitlement/tier-catalog-path")
+def api_entitlement_tier_catalog_path():
+    """``GET /api/entitlement/tier-catalog-path?from=<id>&to=<id>`` --
+    tier-axis twin of ``/feature-catalog-path`` and
+    ``/runtime-catalog-path``: the FULL tier ladder at every rung
+    between any two tiers off ONE round-trip, with each rung's inner
+    ``tiers`` list carrying the ladder from the perspective of that
+    rung (``is_current`` pinned on the rung id).
+
+    Pairs with the two sibling ``_catalog_path`` endpoints the same
+    way ``/tier-catalog-at`` pairs with ``/feature-catalog-at`` /
+    ``/runtime-catalog-at``. Together the three ``_catalog_path``
+    endpoints let an upgrade-walkthrough UI render every tier +
+    feature + runtime column at every rung off THREE calls instead
+    of first calling ``/tier-path`` and then 3 * N calls to the
+    scalar what-if catalog endpoints.
+
+    Each row in ``path`` mirrors the ``/feature-catalog-path`` /
+    ``/runtime-catalog-path`` row shape with ``features`` /
+    ``runtimes`` renamed to ``tiers`` (``tier``, ``tier_label``,
+    ``tier_rank``, ``tiers``); the inner ``tiers`` list byte-equals
+    ``/tier-catalog-at?tier=<rung>`` for the same rung -- pinned by
+    the parity tests so the scalar and path what-if tier-ladder
+    surfaces cannot drift.
+
+    Response shape::
+
+        {
+          "from":       "<tier id>",
+          "from_label": "...",
+          "from_rank":  <int>,
+          "to":         "<tier id>",
+          "to_label":   "...",
+          "to_rank":    <int>,
+          "direction":  "upgrade" | "downgrade" | "lateral" | "identity",
+          "path":       [<per-rung row>, ...],
+        }
+
+    Rung walk, direction semantics and error posture match
+    ``/feature-catalog-path`` (byte-stable against the rest of the
+    ``_path`` family). ``400`` when ``from=`` or ``to=`` is missing;
+    ``404`` when either id is unknown. ``trial`` IS accepted as an
+    endpoint -- excluded from the walked intermediate rungs (not
+    purchasable) but valid via the lateral branch. Never 5xxs: a
+    resolver failure short-circuits to ``404`` so a pricing-page
+    surface keeps rendering.
+    """
+    f = (request.args.get("from") or "").strip().lower()
+    t = (request.args.get("to") or "").strip().lower()
+    if not f or not t:
+        return jsonify({"error": "missing from or to"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        path = _ent.tier_catalog_path(f, t)
+        if path is None:
+            return (
+                jsonify({"error": "unknown tier", "from": f, "to": t}),
+                404,
+            )
+        from_rank = _ent.tier_rank(f)
+        to_rank = _ent.tier_rank(t)
+        if f == t:
+            direction = "identity"
+        elif from_rank == to_rank:
+            direction = "lateral"
+        elif to_rank > from_rank:
+            direction = "upgrade"
+        else:
+            direction = "downgrade"
+        return jsonify(
+            {
+                "from": f,
+                "from_label": _ent.tier_label(f),
+                "from_rank": from_rank,
+                "to": t,
+                "to_label": _ent.tier_label(t),
+                "to_rank": to_rank,
+                "direction": direction,
+                "path": path,
+            }
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_tier_catalog_path: error: %s", exc
         )
         return (
             jsonify({"error": "unknown tier", "from": f, "to": t}),

--- a/tests/test_entitlement_tier_catalog_path.py
+++ b/tests/test_entitlement_tier_catalog_path.py
@@ -1,0 +1,427 @@
+"""Tests for ``clawmetry.entitlements.tier_catalog_path(from, to)`` + the
+``GET /api/entitlement/tier-catalog-path`` endpoint.
+
+Tier-axis twin of :func:`feature_catalog_path` /
+:func:`runtime_catalog_path`: where the two sibling ``_catalog_path``
+helpers hydrate the feature / runtime catalog at every rung between two
+tiers off ONE round-trip, this hydrates the FULL TIER LADDER at every
+rung -- each rung's inner ``tiers`` list carrying the ladder from the
+perspective of that rung.
+
+Pins:
+
+* per-rung row shape matches the sibling ``_catalog_path`` helpers
+  (``tier``, ``tier_label``, ``tier_rank``, ``tiers``) -- byte-stable
+  across the family
+* each ``tiers`` list byte-equals :func:`tier_catalog_at` for the
+  same rung -- pinned so the scalar and path what-if surfaces cannot
+  drift
+* rung walk byte-equals :func:`tier_path` on the destination axis and
+  :func:`feature_catalog_path` / :func:`runtime_catalog_path` on the
+  perspective axis -- the ``_path`` family stays in lock-step
+* identity (``from == to``) -> ``[]``; lateral (same rank, different
+  id) -> single-row path; ``trial`` accepted as an endpoint (excluded
+  from the walked rungs but valid via the lateral branch)
+* helper is decoupled from the resolver -- grace vs enforce yields
+  the same rows
+* unknown / empty / garbage ids return ``None`` and never raise; a
+  synthesised failure in the inner row builder short-circuits to
+  ``None``
+* API: 400 on missing args, 404 on unknown ids, 200 with the standard
+  ``_path`` envelope on the happy path; 404 (not 5xx) when the inner
+  helper blows up
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def enforced(monkeypatch, tmp_path):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+_ROW_KEYS = {"tier", "tier_label", "tier_rank", "tiers"}
+_ENVELOPE_KEYS = {
+    "from",
+    "from_label",
+    "from_rank",
+    "to",
+    "to_label",
+    "to_rank",
+    "direction",
+    "path",
+}
+
+
+# ── helper: shape + per-row contract ─────────────────────────────────────
+
+
+def test_returns_list(ent):
+    path = ent.tier_catalog_path(ent.TIER_OSS, ent.TIER_ENTERPRISE)
+    assert isinstance(path, list)
+    assert len(path) >= 1
+
+
+def test_each_row_matches_expected_shape(ent):
+    path = ent.tier_catalog_path(ent.TIER_OSS, ent.TIER_ENTERPRISE)
+    for row in path:
+        assert isinstance(row, dict)
+        assert set(row.keys()) == _ROW_KEYS
+        assert isinstance(row["tiers"], list)
+        assert row["tiers"]  # never empty
+
+
+def test_last_rung_is_destination(ent):
+    path = ent.tier_catalog_path(ent.TIER_OSS, ent.TIER_ENTERPRISE)
+    assert path[-1]["tier"] == ent.TIER_ENTERPRISE
+    assert path[-1]["tier_label"] == ent.tier_label(ent.TIER_ENTERPRISE)
+    assert path[-1]["tier_rank"] == ent._TIER_RANK[ent.TIER_ENTERPRISE]
+
+
+# ── byte-parity with the scalar what-if tier-ladder helper ──────────────
+
+
+def test_tiers_list_byte_equals_tier_catalog_at(ent):
+    """Each rung's inner ``tiers`` list is what :func:`tier_catalog_at`
+    returns for the same rung -- the scalar and path what-if tier-ladder
+    surfaces cannot drift."""
+    path = ent.tier_catalog_path(ent.TIER_OSS, ent.TIER_ENTERPRISE)
+    for row in path:
+        assert row["tiers"] == ent.tier_catalog_at(row["tier"])
+
+
+def test_inner_tiers_is_current_pinned_on_rung(ent):
+    """The perspective shifts rung-by-rung: exactly one entry in each
+    inner ``tiers`` list has ``is_current=True`` and it is the rung id."""
+    path = ent.tier_catalog_path(ent.TIER_OSS, ent.TIER_ENTERPRISE)
+    for row in path:
+        current = [t for t in row["tiers"] if t["is_current"]]
+        assert len(current) == 1
+        assert current[0]["id"] == row["tier"]
+
+
+# ── rung walk parity with the rest of the _path family ───────────────────
+
+
+def test_rung_walk_byte_equal_to_tier_path(ent):
+    catalog = ent.tier_catalog_path(ent.TIER_OSS, ent.TIER_ENTERPRISE)
+    full = ent.tier_path(ent.TIER_OSS, ent.TIER_ENTERPRISE)
+    assert [r["tier"] for r in catalog] == [r["to"] for r in full]
+
+
+def test_rung_walk_byte_equal_to_tier_spec_path(ent):
+    catalog = ent.tier_catalog_path(ent.TIER_OSS, ent.TIER_ENTERPRISE)
+    spec = ent.tier_spec_path(ent.TIER_OSS, ent.TIER_ENTERPRISE)
+    assert [r["tier"] for r in catalog] == [r["id"] for r in spec]
+
+
+def test_rung_walk_byte_equal_to_feature_catalog_path(ent):
+    """The three ``_catalog_path`` helpers must share the same rung
+    sequence so a UI can line them up index-for-index."""
+    catalog = ent.tier_catalog_path(ent.TIER_OSS, ent.TIER_ENTERPRISE)
+    feature = ent.feature_catalog_path(ent.TIER_OSS, ent.TIER_ENTERPRISE)
+    runtime = ent.runtime_catalog_path(ent.TIER_OSS, ent.TIER_ENTERPRISE)
+    assert [r["tier"] for r in catalog] == [r["tier"] for r in feature]
+    assert [r["tier"] for r in catalog] == [r["tier"] for r in runtime]
+
+
+def test_path_terminates_at_to_not_a_sibling(ent):
+    """``pro`` and ``cloud_pro`` share rank 2; asking for ``pro`` must
+    end exactly at ``pro`` and EXCLUDE the same-rank sibling
+    ``cloud_pro`` from the final rung -- same rule as ``tier_path``."""
+    tiers = [
+        r["tier"]
+        for r in ent.tier_catalog_path(ent.TIER_OSS, ent.TIER_PRO)
+    ]
+    assert tiers[-1] == ent.TIER_PRO
+    assert tiers.count(ent.TIER_PRO) == 1
+    assert ent.TIER_CLOUD_PRO not in tiers
+
+
+def test_same_rank_siblings_between_endpoints_both_included(ent):
+    tiers = [
+        r["tier"]
+        for r in ent.tier_catalog_path(ent.TIER_OSS, ent.TIER_ENTERPRISE)
+    ]
+    assert ent.TIER_CLOUD_PRO in tiers
+    assert ent.TIER_PRO in tiers
+    assert tiers[-1] == ent.TIER_ENTERPRISE
+
+
+# ── identity / lateral / adjacent ────────────────────────────────────────
+
+
+def test_identity_returns_empty(ent):
+    for tid in (
+        ent.TIER_OSS,
+        ent.TIER_CLOUD_FREE,
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_PRO,
+        ent.TIER_ENTERPRISE,
+        ent.TIER_TRIAL,
+    ):
+        assert ent.tier_catalog_path(tid, tid) == []
+
+
+def test_lateral_is_single_row(ent):
+    path = ent.tier_catalog_path(ent.TIER_CLOUD_PRO, ent.TIER_PRO)
+    assert len(path) == 1
+    assert path[0]["tier"] == ent.TIER_PRO
+    assert path[0]["tiers"] == ent.tier_catalog_at(ent.TIER_PRO)
+
+
+def test_oss_to_cloud_free_lateral(ent):
+    path = ent.tier_catalog_path(ent.TIER_OSS, ent.TIER_CLOUD_FREE)
+    assert len(path) == 1
+    assert path[0]["tier"] == ent.TIER_CLOUD_FREE
+
+
+def test_adjacent_step_is_one_row(ent):
+    path = ent.tier_catalog_path(ent.TIER_OSS, ent.TIER_CLOUD_STARTER)
+    assert len(path) == 1
+    assert path[0]["tier"] == ent.TIER_CLOUD_STARTER
+
+
+# ── descending mirror ───────────────────────────────────────────────────
+
+
+def test_descending_path_terminates_at_to(ent):
+    path = ent.tier_catalog_path(ent.TIER_ENTERPRISE, ent.TIER_OSS)
+    assert path[-1]["tier"] == ent.TIER_OSS
+    # closest-to-from rung first
+    assert (
+        ent._TIER_RANK[path[0]["tier"]]
+        < ent._TIER_RANK[ent.TIER_ENTERPRISE]
+    )
+
+
+def test_descending_terminates_at_explicit_floor(ent):
+    """Asking for ``oss`` must NOT also include ``cloud_free`` (the
+    other rank-0 sibling) as a terminal rung."""
+    tiers = [
+        r["tier"]
+        for r in ent.tier_catalog_path(ent.TIER_ENTERPRISE, ent.TIER_OSS)
+    ]
+    assert tiers[-1] == ent.TIER_OSS
+    assert tiers.count(ent.TIER_OSS) == 1
+
+
+# ── trial endpoint ───────────────────────────────────────────────────────
+
+
+def test_trial_excluded_from_walked_rungs_but_valid_endpoint(ent):
+    """``trial`` is not purchasable -- it must never appear as a stop on
+    a path between purchasable tiers, but resolves as an endpoint."""
+    path = ent.tier_catalog_path(ent.TIER_OSS, ent.TIER_ENTERPRISE)
+    for row in path:
+        assert row["tier"] != ent.TIER_TRIAL
+    upward = ent.tier_catalog_path(ent.TIER_TRIAL, ent.TIER_ENTERPRISE)
+    assert upward is not None
+    assert upward[-1]["tier"] == ent.TIER_ENTERPRISE
+    downward = ent.tier_catalog_path(ent.TIER_TRIAL, ent.TIER_OSS)
+    assert downward is not None
+    assert downward[-1]["tier"] == ent.TIER_OSS
+
+
+# ── decoupled from the resolver ──────────────────────────────────────────
+
+
+def test_grace_and_enforce_yield_identical_rows(ent, enforced):
+    grace_rows = ent.tier_catalog_path(ent.TIER_OSS, ent.TIER_ENTERPRISE)
+    enforced_rows = enforced.tier_catalog_path(
+        enforced.TIER_OSS, enforced.TIER_ENTERPRISE
+    )
+    assert grace_rows == enforced_rows
+
+
+# ── unknown / garbage inputs never raise ─────────────────────────────────
+
+
+def test_unknown_tiers_return_none(ent):
+    assert (
+        ent.tier_catalog_path("not_a_tier", ent.TIER_ENTERPRISE) is None
+    )
+    assert (
+        ent.tier_catalog_path(ent.TIER_OSS, "still_not_a_tier") is None
+    )
+    assert ent.tier_catalog_path("a", "b") is None
+
+
+def test_empty_and_garbage_inputs_never_raise(ent):
+    assert ent.tier_catalog_path("", "") is None
+    assert ent.tier_catalog_path(None, None) is None  # type: ignore[arg-type]
+    assert ent.tier_catalog_path("  ", "  ") is None
+    assert ent.tier_catalog_path(123, 456) is None  # type: ignore[arg-type]
+
+
+def test_case_and_whitespace_normalised(ent):
+    a = ent.tier_catalog_path(ent.TIER_OSS, ent.TIER_ENTERPRISE)
+    b = ent.tier_catalog_path("  OSS ", " ENTERPRISE  ")
+    assert a == b
+
+
+def test_helper_swallows_resolver_failure(monkeypatch, ent):
+    """If the inner catalog builder blows up, the helper must short-
+    circuit to ``None`` (logged-warning + graceful fallback contract)."""
+
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "tier_catalog_at", boom)
+    assert (
+        ent.tier_catalog_path(ent.TIER_OSS, ent.TIER_ENTERPRISE) is None
+    )
+
+
+# ── API surface ──────────────────────────────────────────────────────────
+
+
+def test_api_400_on_missing_args(client):
+    assert (
+        client.get("/api/entitlement/tier-catalog-path").status_code
+        == 400
+    )
+    assert (
+        client.get(
+            "/api/entitlement/tier-catalog-path?from=oss"
+        ).status_code
+        == 400
+    )
+    assert (
+        client.get(
+            "/api/entitlement/tier-catalog-path?to=cloud_pro"
+        ).status_code
+        == 400
+    )
+
+
+def test_api_404_on_unknown_tier(client):
+    r = client.get(
+        "/api/entitlement/tier-catalog-path?from=oss&to=not_a_tier"
+    )
+    assert r.status_code == 404
+    body = r.get_json()
+    assert body["error"] == "unknown tier"
+    assert body["to"] == "not_a_tier"
+
+
+def test_api_happy_path_ascending(client, ent):
+    r = client.get(
+        "/api/entitlement/tier-catalog-path"
+        f"?from={ent.TIER_OSS}&to={ent.TIER_ENTERPRISE}"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert set(body.keys()) == _ENVELOPE_KEYS
+    assert body["from"] == ent.TIER_OSS
+    assert body["to"] == ent.TIER_ENTERPRISE
+    assert body["direction"] == "upgrade"
+    assert isinstance(body["path"], list) and body["path"]
+    assert body["path"][-1]["tier"] == ent.TIER_ENTERPRISE
+
+
+def test_api_happy_path_descending(client, ent):
+    r = client.get(
+        "/api/entitlement/tier-catalog-path"
+        f"?from={ent.TIER_ENTERPRISE}&to={ent.TIER_OSS}"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["direction"] == "downgrade"
+    assert body["path"][-1]["tier"] == ent.TIER_OSS
+
+
+def test_api_identity_empty_path(client, ent):
+    r = client.get(
+        "/api/entitlement/tier-catalog-path"
+        f"?from={ent.TIER_CLOUD_PRO}&to={ent.TIER_CLOUD_PRO}"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["direction"] == "identity"
+    assert body["path"] == []
+
+
+def test_api_lateral_single_row(client, ent):
+    r = client.get(
+        "/api/entitlement/tier-catalog-path"
+        f"?from={ent.TIER_CLOUD_PRO}&to={ent.TIER_PRO}"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["direction"] == "lateral"
+    assert len(body["path"]) == 1
+    assert body["path"][0]["tier"] == ent.TIER_PRO
+
+
+def test_api_trial_endpoint_accepted(client, ent):
+    r = client.get(
+        "/api/entitlement/tier-catalog-path"
+        f"?from={ent.TIER_TRIAL}&to={ent.TIER_ENTERPRISE}"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["from"] == ent.TIER_TRIAL
+    assert body["path"][-1]["tier"] == ent.TIER_ENTERPRISE
+
+
+def test_api_path_byte_equals_helper(client, ent):
+    r = client.get(
+        "/api/entitlement/tier-catalog-path"
+        f"?from={ent.TIER_OSS}&to={ent.TIER_ENTERPRISE}"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["path"] == ent.tier_catalog_path(
+        ent.TIER_OSS, ent.TIER_ENTERPRISE
+    )
+
+
+def test_api_404_on_resolver_failure(monkeypatch, client):
+    """Force the resolver path used by the route to blow up; the route
+    must short-circuit to a 404 envelope instead of leaking a 500."""
+    import clawmetry.entitlements as _ent
+
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(_ent, "tier_catalog_path", boom)
+    r = client.get(
+        "/api/entitlement/tier-catalog-path?from=oss&to=enterprise"
+    )
+    assert r.status_code == 404
+    body = r.get_json()
+    assert body["error"] == "unknown tier"


### PR DESCRIPTION
## Summary

Tier-axis twin of `feature_catalog_path` / `runtime_catalog_path` (both merged): where the two sibling `_catalog_path` helpers hydrate the feature / runtime catalog at every rung between two tiers off one round-trip, this hydrates the FULL TIER LADDER at every rung -- each rung's inner `tiers` list carrying the ladder from the perspective of that rung.

- Module-level `tier_catalog_path(from_tier, to_tier)` -- per-rung row is `{tier, tier_label, tier_rank, tiers: [...]}`. Each inner `tiers` list is byte-identical to `tier_catalog_at(rung)` for the same rung -- pinned by a parity test so the scalar and path what-if tier-ladder surfaces cannot drift.
- `GET /api/entitlement/tier-catalog-path?from=<id>&to=<id>` mirroring the `/feature-catalog-path` / `/runtime-catalog-path` envelope: `{from, from_label, from_rank, to, to_label, to_rank, direction, path}` with `direction` in `{upgrade, downgrade, lateral, identity}`.

Fills the tier-axis member of the resolver-independent `_catalog_path` family:

| helper                       | inner list        | status        |
|------------------------------|-------------------|---------------|
| `feature_catalog_path`       | `[features]`      | merged        |
| `runtime_catalog_path`       | `[runtimes]`      | merged        |
| `tier_catalog_path`          | `[tier ladder]`   | **this PR**   |

The `_catalog_path` posture matches the rest of the family:
- walks the same `_PURCHASABLE_TIERS` rungs by the same sort + same destination-sibling exclusion as `tier_path`, `tier_spec_path`, `capacity_diff_path`, `tier_unlocks_path`, `tier_locks_path`, `preview_path`, `feature_spec_path`, `runtime_spec_path`, `feature_catalog_path`, `runtime_catalog_path` -- rung-for-rung byte-stable, so a UI that walks one helper's rows can line them up index-for-index with another helper's rows
- `identity` (`from == to`) -> empty path; `lateral` (same rank, different id) -> single-row path with the row at `to`; `upgrade` / `downgrade` walk cumulatively toward the destination
- `trial` IS accepted as an endpoint (excluded from walked intermediate rungs but valid via the lateral branch)
- resolver-independent: delegates per-rung to `tier_catalog_at`, so grace vs enforce yields byte-identical rows
- never raises: a per-rung crash logs a warning and short-circuits to `None`; the HTTP wrapper's own resolver failure short-circuits to a 404 envelope (no 5xx)

**Grace-only, read-only**: no gate enforced, no behavior change against the currently-resolved entitlement -- this is a new read-only endpoint.

Together the three `_catalog_path` endpoints let an upgrade-walkthrough UI render every tier + feature + runtime column at every rung off THREE calls instead of first calling `/tier-path` and then 3 * N calls to the scalar what-if catalog endpoints.

## Test plan

- [x] `python3 -m py_compile clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_tier_catalog_path.py` -- clean
- [x] `ruff check clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_tier_catalog_path.py` -- all checks passed
- [x] `python3 -m pytest tests/test_entitlement_tier_catalog_path.py -q` -- **31 passed**
- [x] Adjacent regression sweep -- 150 passed across `test_entitlement_feature_catalog_path`, `test_entitlement_runtime_catalog_path`, `test_entitlement_tier_catalog_at`, `test_entitlement_api`, `test_entitlement_feature_catalog_at`

### Coverage in `tests/test_entitlement_tier_catalog_path.py`

- helper: shape (`_ROW_KEYS`, `tiers` list non-empty), last rung is destination
- helper: byte-parity with `tier_catalog_at` on the perspective axis (each rung's inner `tiers` list byte-equals `tier_catalog_at(rung)`)
- helper: `is_current` perspective shift (exactly one `is_current=True` per rung's inner ladder, pinned on the rung id)
- helper: rung walk parity vs `tier_path`, `tier_spec_path`, `feature_catalog_path`, `runtime_catalog_path`
- helper: same-rank destination-sibling exclusion (`pro` / `cloud_pro` case), same-rank between-endpoint inclusion
- helper: identity (`from == to`) -> `[]` for every tier including `trial`; lateral single-row (`cloud_pro -> pro`, `oss -> cloud_free`); adjacent single-row (`oss -> cloud_starter`)
- helper: descending mirror (terminates at explicit floor `oss`, does not include `cloud_free`)
- helper: `trial` endpoint accepted (excluded from walked rungs but valid as endpoint upward + downward)
- helper: resolver-independence (grace vs enforce byte-identical)
- helper: never-raise on unknown / empty / whitespace / non-string / mixed-case input; synthesised inner-builder crash short-circuits to `None`
- HTTP: 400 on missing args, 404 on unknown tier, 200 with `_ENVELOPE_KEYS` shape on ascending / descending / identity / lateral / trial-endpoint, `path` byte-equals helper, resolver-failure short-circuits to 404 (never 5xx)

## Local operator verification checklist

The public-repo agent cannot exercise the live daemon, cloud snapshot, or browser. Please copy the changed files into your locally-installed clawmetry site-packages and verify against the real daemon before flipping ready-for-review:

```bash
# 1. Copy the changed files into the installed package
SP="$HOME/.clawmetry/lib/python$(python3 -c 'import sys;print(f"{sys.version_info.major}.{sys.version_info.minor}")')/site-packages/clawmetry"
cp clawmetry/entitlements.py "$SP/entitlements.py"
# routes/ isn't inside the package; on the default layout it lands at
# $HOME/.clawmetry/lib/python*/site-packages/routes/entitlement.py
find "$HOME/.clawmetry" -name entitlement.py -path '*routes*' -exec cp routes/entitlement.py {} \;

# 2. Purge stale bytecode so the new module actually loads
find "$HOME/.clawmetry" -type d -name __pycache__ -exec rm -rf {} +

# 3. Bounce the sync daemon so it re-imports
launchctl kickstart -k "gui/$(id -u)/com.clawmetry.sync"

# 4. Hit the new endpoint (ascending)
curl -s 'http://localhost:8900/api/entitlement/tier-catalog-path?from=oss&to=enterprise' | jq
# Expect: 200 with envelope {from, from_label, from_rank, to, to_label, to_rank, direction, path}.
# direction == "upgrade"; path is a non-empty list; path[-1].tier == "enterprise";
# every path[i].tiers list has length equal to the full _TIER_ORDER ladder (7)
# and exactly one entry with is_current=true (path[i].tier).

# 5. Parity with the live scalar sibling for every rung
curl -s 'http://localhost:8900/api/entitlement/tier-catalog-path?from=oss&to=enterprise' \
  | jq -r '.path[] | .tier' \
  | while read rung; do
      diff \
        <(curl -s 'http://localhost:8900/api/entitlement/tier-catalog-path?from=oss&to=enterprise' | jq ".path[] | select(.tier==\"$rung\") | .tiers") \
        <(curl -s "http://localhost:8900/api/entitlement/tier-catalog-at?tier=$rung" | jq '.tiers') \
      && echo "rung $rung: parity OK"
    done
# Expect: "parity OK" for every rung; no diffs.

# 6. Rung-walk parity with the sibling _catalog_path endpoints
diff \
  <(curl -s 'http://localhost:8900/api/entitlement/tier-catalog-path?from=oss&to=enterprise' | jq '[.path[].tier]') \
  <(curl -s 'http://localhost:8900/api/entitlement/feature-catalog-path?from=oss&to=enterprise' | jq '[.path[].tier]')
# Expect: empty diff.
diff \
  <(curl -s 'http://localhost:8900/api/entitlement/tier-catalog-path?from=oss&to=enterprise' | jq '[.path[].tier]') \
  <(curl -s 'http://localhost:8900/api/entitlement/runtime-catalog-path?from=oss&to=enterprise' | jq '[.path[].tier]')
# Expect: empty diff.

# 7. Direction branches
curl -s 'http://localhost:8900/api/entitlement/tier-catalog-path?from=enterprise&to=oss' | jq '.direction'   # "downgrade"
curl -s 'http://localhost:8900/api/entitlement/tier-catalog-path?from=cloud_pro&to=pro' | jq '.direction'    # "lateral"
curl -s 'http://localhost:8900/api/entitlement/tier-catalog-path?from=cloud_pro&to=cloud_pro' | jq '.'       # direction=="identity", path==[]

# 8. Error paths
curl -si 'http://localhost:8900/api/entitlement/tier-catalog-path' | head -1
# Expect: HTTP/1.1 400
curl -si 'http://localhost:8900/api/entitlement/tier-catalog-path?from=oss&to=nope_tier' | head -1
# Expect: HTTP/1.1 404

# 9. Decrypt the live cloud snapshot in the browser + sanity-check no
# regressions on the existing /feature-catalog-path, /runtime-catalog-path,
# and /tier-catalog-at endpoints.
```

If everything looks right, flip to ready-for-review and merge in the normal flow. Only the local operator has access to the live daemon and snapshot for step 9, which is why this PR stays draft until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JVKeBG7rbGXVjsnWQbaRxd)_