### PR TITLE
feat(entitlement): {upgrade,downgrade}_path_at_batch + 2 endpoints

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -3602,6 +3602,185 @@ def downgrade_path_at(tier: str) -> list[dict] | None:
         return []
 
 
+def upgrade_path_at_batch(tiers) -> dict:
+    """Batch what-if sibling of :func:`upgrade_path_at`: ordered
+    marginal-unlock ladder ABOVE each caller-supplied source tier in ONE
+    round-trip.
+
+    Composes :func:`upgrade_path_at` across the perspective-tier axis
+    the same way :func:`tier_catalog_at_batch` composes
+    :func:`tier_catalog_at` and :func:`feature_catalog_at_batch` composes
+    :func:`feature_catalog_at`. Lets a pricing-comparison matrix UI
+    ("show me the upgrade ladder from OSS, Cloud Starter, Cloud Pro, and
+    Enterprise -- side by side") hydrate every column off ONE call
+    instead of N calls to :func:`upgrade_path_at`.
+
+    Per-source row shape::
+
+        {
+          "tier":       "<id>",
+          "tier_label": "...",
+          "tier_rank":  <int>,
+          "path":       [<upgrade_path_at row>, ...],
+        }
+
+    Each ``path`` list is byte-identical to the list
+    :func:`upgrade_path_at` returns for the same source tier -- pinned
+    by a parity test so the scalar and batch what-if upgrade-path
+    helpers cannot drift.
+
+    Shape::
+
+        {
+          "tiers": [
+            {"tier": "<id>", "tier_label": ..., "tier_rank": ..., "path": [...]},
+            ...
+          ],
+          "unknown": ["bogus_id", ...],
+        }
+
+    Supplied tier ids are normalised via :func:`_normalise_csv`
+    (whitespace stripped, lowercased, duplicates dropped, first-seen
+    order preserved). Unknown ids are echoed in ``unknown[]`` instead of
+    short-circuiting -- a partially-bad caller still gets rows back for
+    the valid ids alongside a list of what was dropped, matching every
+    other ``_at_batch`` sibling's posture. ``trial`` IS accepted (it
+    lives in :data:`_TIER_ORDER` and the scalar helper resolves it).
+
+    A source at the ceiling of the purchasable ladder (Enterprise)
+    still yields a valid row with an empty ``path`` list -- the ceiling
+    is NOT ``unknown``. Only ids not in :data:`_TIER_ORDER` (or where
+    the scalar returns ``None``) land in ``unknown[]``.
+
+    Empty / ``None`` input returns ``{"tiers": [], "unknown": []}`` --
+    the HTTP wrapper turns that into a 400, this helper does not raise.
+
+    Resolver-independent: delegates per-tier to :func:`upgrade_path_at`,
+    which folds :func:`tier_unlocks` (catalogue-derived) over each
+    strictly-higher rung -- so grace vs enforce yields byte-identical
+    rows. Never raises: a per-tier failure short-circuits that id into
+    ``unknown[]`` and the rest of the batch keeps building.
+    """
+    ids = _normalise_csv(tiers)
+    rows: list[dict] = []
+    unknown: list[str] = []
+    for tid in ids:
+        if tid not in _TIER_ORDER:
+            unknown.append(tid)
+            continue
+        try:
+            path = upgrade_path_at(tid)
+        except Exception as exc:
+            logger.warning(
+                "entitlements: upgrade_path_at_batch row %r failed: %s",
+                tid,
+                exc,
+            )
+            unknown.append(tid)
+            continue
+        if path is None:
+            unknown.append(tid)
+            continue
+        rows.append(
+            {
+                "tier": tid,
+                "tier_label": tier_label(tid),
+                "tier_rank": _TIER_RANK.get(tid, -1),
+                "path": path,
+            }
+        )
+    return {"tiers": rows, "unknown": unknown}
+
+
+def downgrade_path_at_batch(tiers) -> dict:
+    """Batch what-if sibling of :func:`downgrade_path_at`: ordered
+    cumulative-loss ladder BELOW each caller-supplied source tier in
+    ONE round-trip.
+
+    Direction-flipped twin of :func:`upgrade_path_at_batch`: where the
+    upgrade batch hydrates the marginal-unlock ladder strictly above
+    each source, this hydrates the cumulative-loss ladder strictly
+    below each source. Same envelope, same per-source row shape, same
+    unknown-bucketing posture -- only the inner ``path`` list changes
+    direction.
+
+    Per-source row shape::
+
+        {
+          "tier":       "<id>",
+          "tier_label": "...",
+          "tier_rank":  <int>,
+          "path":       [<downgrade_path_at row>, ...],
+        }
+
+    Each ``path`` list is byte-identical to the list
+    :func:`downgrade_path_at` returns for the same source tier --
+    pinned by a parity test so the scalar and batch what-if
+    downgrade-path helpers cannot drift.
+
+    Shape::
+
+        {
+          "tiers": [
+            {"tier": "<id>", "tier_label": ..., "tier_rank": ..., "path": [...]},
+            ...
+          ],
+          "unknown": ["bogus_id", ...],
+        }
+
+    Supplied tier ids are normalised via :func:`_normalise_csv`
+    (whitespace stripped, lowercased, duplicates dropped, first-seen
+    order preserved). Unknown ids are echoed in ``unknown[]`` instead
+    of short-circuiting. ``trial`` IS accepted.
+
+    A source at the floor of the purchasable ladder (``oss`` /
+    ``cloud_free``) still yields a valid row with an empty ``path``
+    list -- the floor is NOT ``unknown``. Only ids not in
+    :data:`_TIER_ORDER` (or where the scalar returns ``None``) land in
+    ``unknown[]``.
+
+    Empty / ``None`` input returns ``{"tiers": [], "unknown": []}`` --
+    the HTTP wrapper turns that into a 400, this helper does not
+    raise.
+
+    Resolver-independent: delegates per-tier to
+    :func:`downgrade_path_at`, which folds :func:`tier_diff`
+    (catalogue-derived) over each strictly-lower rung -- so grace vs
+    enforce yields byte-identical rows. Never raises: a per-tier
+    failure short-circuits that id into ``unknown[]`` and the rest of
+    the batch keeps building.
+    """
+    ids = _normalise_csv(tiers)
+    rows: list[dict] = []
+    unknown: list[str] = []
+    for tid in ids:
+        if tid not in _TIER_ORDER:
+            unknown.append(tid)
+            continue
+        try:
+            path = downgrade_path_at(tid)
+        except Exception as exc:
+            logger.warning(
+                "entitlements: downgrade_path_at_batch row %r failed: %s",
+                tid,
+                exc,
+            )
+            unknown.append(tid)
+            continue
+        if path is None:
+            unknown.append(tid)
+            continue
+        rows.append(
+            {
+                "tier": tid,
+                "tier_label": tier_label(tid),
+                "tier_rank": _TIER_RANK.get(tid, -1),
+                "path": path,
+            }
+        )
+    return {"tiers": rows, "unknown": unknown}
+
+
 def resolution_diagnostic() -> dict:
     out: dict = {
         "license_path": _LICENSE_PATH,

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -2031,6 +2031,186 @@ def api_entitlement_downgrade_path_at():
         )
 
 
+@bp_entitlement.route("/api/entitlement/upgrade-path-at-batch")
+def api_entitlement_upgrade_path_at_batch():
+    """``GET /api/entitlement/upgrade-path-at-batch?tiers=a,b,c`` -- batch
+    what-if sibling of ``/api/entitlement/upgrade-path-at``.
+
+    Where ``/upgrade-path-at`` hydrates the marginal-unlock ladder above
+    ONE hypothetical source tier, this hydrates it for N hypothetical
+    sources in ONE round-trip. Pairs with ``/upgrade-path-at`` the same
+    way ``/tier-catalog-at-batch`` pairs with ``/tier-catalog-at``:
+    scalar what-if -> matrix what-if across the perspective-tier axis.
+
+    Use case: a pricing-comparison matrix UI ("show me the upgrade
+    ladder as if I were on OSS vs Cloud Starter vs Cloud Pro vs
+    Enterprise -- side by side") hydrates every column off ONE call
+    instead of N calls to ``/upgrade-path-at``.
+
+    Each ``tiers[].path`` list is byte-identical to the body of
+    ``/upgrade-path-at?tier=<tier>`` (its ``path`` field) for the same
+    source tier -- pinned by parity tests so the scalar and batch
+    what-if upgrade-path helpers cannot drift. Supplied tier ids are
+    normalised (whitespace stripped, lowercased, duplicates dropped,
+    first-seen order preserved). Unknown ids do not 404 the call --
+    they are echoed in ``unknown[]`` so a partially-bad caller still
+    gets rows back for the valid ids alongside a list of what was
+    dropped, matching every other ``_at_batch`` sibling's posture.
+
+    A source at the ceiling of the purchasable ladder (Enterprise)
+    still yields a valid row with an empty ``path`` list -- the
+    ceiling is NOT ``unknown``. Only ids not in :data:`_TIER_ORDER`
+    (or where the scalar returns ``None``) land in ``unknown[]``.
+
+    Response shape::
+
+        {
+          "tiers": [
+            {
+              "tier":       "<id>",
+              "tier_label": "...",
+              "tier_rank":  <int>,
+              "path":       [<upgrade-path-at row>, ...],
+            },
+            ...
+          ],
+          "unknown":    ["bogus_id", ...],
+          "current_tier":      "...",
+          "current_tier_rank": <int>,
+          "grace":             <bool>,
+          "enforced":          <bool>,
+        }
+
+    - **400** when ``tiers=`` is missing / empty after normalisation
+    - **200** with bucketed unknowns for unknown tier ids -- does NOT
+      404 the call, matching every other batch sibling
+    - **Never 5xxs**: a synthesis failure short-circuits to an envelope
+      with empty rows so the matrix keeps rendering.
+    """
+    tiers = _parse_csv_arg("tiers")
+    if not tiers:
+        return jsonify({"error": "supply tiers=<csv>"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        batch = _ent.upgrade_path_at_batch(tiers)
+        ent = _ent.get_entitlement()
+        return jsonify(
+            {
+                "tiers": batch.get("tiers", []),
+                "unknown": batch.get("unknown", []),
+                "current_tier": ent.tier,
+                "current_tier_rank": _ent.tier_rank(ent.tier),
+                "grace": bool(ent.grace),
+                "enforced": _ent.is_enforced(),
+            }
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_upgrade_path_at_batch: error: %s", exc
+        )
+        return jsonify(
+            {
+                "tiers": [],
+                "unknown": [],
+                "current_tier": "oss",
+                "current_tier_rank": 0,
+                "grace": True,
+                "enforced": False,
+            }
+        )
+
+
+@bp_entitlement.route("/api/entitlement/downgrade-path-at-batch")
+def api_entitlement_downgrade_path_at_batch():
+    """``GET /api/entitlement/downgrade-path-at-batch?tiers=a,b,c`` --
+    batch what-if sibling of ``/api/entitlement/downgrade-path-at``.
+
+    Direction-flipped twin of ``/api/entitlement/upgrade-path-at-batch``:
+    where the upgrade batch hydrates the marginal-unlock ladder strictly
+    above each source, this hydrates the cumulative-loss ladder strictly
+    below each source. Same envelope, same per-source row shape, same
+    unknown-bucketing posture -- only the inner ``path`` list changes
+    direction.
+
+    Use case: a "compare from tier X" downgrade-warning matrix UI ("show
+    me the cumulative-loss ladder as if I were on OSS vs Cloud Starter
+    vs Cloud Pro vs Enterprise -- side by side") hydrates every column
+    off ONE call instead of N calls to ``/downgrade-path-at``.
+
+    Each ``tiers[].path`` list is byte-identical to the body of
+    ``/downgrade-path-at?tier=<tier>`` (its ``path`` field) for the same
+    source tier -- pinned by parity tests so the scalar and batch
+    what-if downgrade-path helpers cannot drift. Supplied tier ids are
+    normalised (whitespace stripped, lowercased, duplicates dropped,
+    first-seen order preserved). Unknown ids do not 404 the call --
+    they are echoed in ``unknown[]``.
+
+    A source at the floor of the purchasable ladder (``oss`` /
+    ``cloud_free``) still yields a valid row with an empty ``path``
+    list -- the floor is NOT ``unknown``. Only ids not in
+    :data:`_TIER_ORDER` (or where the scalar returns ``None``) land in
+    ``unknown[]``.
+
+    Response shape::
+
+        {
+          "tiers": [
+            {
+              "tier":       "<id>",
+              "tier_label": "...",
+              "tier_rank":  <int>,
+              "path":       [<downgrade-path-at row>, ...],
+            },
+            ...
+          ],
+          "unknown":    ["bogus_id", ...],
+          "current_tier":      "...",
+          "current_tier_rank": <int>,
+          "grace":             <bool>,
+          "enforced":          <bool>,
+        }
+
+    - **400** when ``tiers=`` is missing / empty after normalisation
+    - **200** with bucketed unknowns for unknown tier ids -- does NOT
+      404 the call, matching every other batch sibling
+    - **Never 5xxs**: a synthesis failure short-circuits to an envelope
+      with empty rows so the matrix keeps rendering.
+    """
+    tiers = _parse_csv_arg("tiers")
+    if not tiers:
+        return jsonify({"error": "supply tiers=<csv>"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        batch = _ent.downgrade_path_at_batch(tiers)
+        ent = _ent.get_entitlement()
+        return jsonify(
+            {
+                "tiers": batch.get("tiers", []),
+                "unknown": batch.get("unknown", []),
+                "current_tier": ent.tier,
+                "current_tier_rank": _ent.tier_rank(ent.tier),
+                "grace": bool(ent.grace),
+                "enforced": _ent.is_enforced(),
+            }
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_downgrade_path_at_batch: error: %s", exc
+        )
+        return jsonify(
+            {
+                "tiers": [],
+                "unknown": [],
+                "current_tier": "oss",
+                "current_tier_rank": 0,
+                "grace": True,
+                "enforced": False,
+            }
+        )
+
+
 _CAPACITY_PARAMS = ("channels", "retention_days", "nodes")
 
 

--- a/tests/test_entitlement_upgrade_downgrade_path_at_batch.py
+++ b/tests/test_entitlement_upgrade_downgrade_path_at_batch.py
@@ -1,0 +1,555 @@
+"""Tests for ``upgrade_path_at_batch(tiers)`` /
+``downgrade_path_at_batch(tiers)`` + the companion
+``/api/entitlement/{upgrade,downgrade}-path-at-batch`` endpoints.
+
+Perspective-tier-batched siblings of the scalar
+:func:`upgrade_path_at` / :func:`downgrade_path_at` what-ifs. Where
+each scalar hydrates the ordered marginal-unlock (or cumulative-loss)
+ladder from ONE hypothetical source, the batch hydrates the same
+ladder for N hypothetical sources off a single round-trip -- the same
+axis :func:`tier_catalog_at_batch` batches on.
+
+Each returned ``tiers[].path`` list must be byte-identical to the
+scalar's return for the same source tier so the scalar and batch
+what-if path helpers cannot drift -- pinned by the parity tests
+below.
+
+Coverage (both helpers + both endpoints):
+
+* per-source row shape (``tier`` / ``tier_label`` / ``tier_rank`` /
+  ``path``) matches the outer envelope of the sibling ``_at_batch``
+  family
+* every tier in ``_TIER_ORDER`` (including ``trial``) round-trips
+* input is normalised (whitespace stripped, lowercased, duplicates
+  dropped, first-seen order preserved) -- same as ``_normalise_csv``
+* unknown ids are echoed in ``unknown[]`` instead of short-circuiting;
+  ceiling / floor sources are NOT ``unknown`` -- they yield a valid
+  row with an empty ``path`` list
+* the helper never raises -- a per-tier scalar crash / ``None``
+  short-circuits that id into ``unknown[]`` so the matrix keeps
+  rendering
+* the HTTP endpoint 400s on missing / empty input, echoes unknown
+  ids at 200, carries the standard envelope (``current_tier`` /
+  ``current_tier_rank`` / ``grace`` / ``enforced``), and never 5xxs
+  on a resolver crash
+* grace vs enforce yields byte-identical bodies (catalogue-derived)
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+
+_OUTER_ROW_KEYS = {"tier", "tier_label", "tier_rank", "path"}
+
+_ENVELOPE_KEYS = {
+    "tiers",
+    "unknown",
+    "current_tier",
+    "current_tier_rank",
+    "grace",
+    "enforced",
+}
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    """Fresh entitlements module with HOME pointed at an empty tmp dir so
+    no real ~/.clawmetry/license.key or cloud_plan.json leaks in.
+    Enforcement off by default (grace mode); the batch helpers are
+    catalogue-derived and independent of either knob, but the fixture
+    avoids live-resolver surprises."""
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from flask import Flask
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# ── helper: input handling (both) ────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("fn", ["upgrade_path_at_batch", "downgrade_path_at_batch"])
+def test_empty_input_returns_empty_envelope(ent, fn):
+    assert getattr(ent, fn)([]) == {"tiers": [], "unknown": []}
+
+
+@pytest.mark.parametrize("fn", ["upgrade_path_at_batch", "downgrade_path_at_batch"])
+def test_none_input_returns_empty_envelope(ent, fn):
+    assert getattr(ent, fn)(None) == {"tiers": [], "unknown": []}
+
+
+@pytest.mark.parametrize("fn", ["upgrade_path_at_batch", "downgrade_path_at_batch"])
+def test_string_csv_input(ent, fn):
+    body = getattr(ent, fn)(
+        f"{ent.TIER_CLOUD_STARTER},{ent.TIER_CLOUD_PRO}"
+    )
+    assert [row["tier"] for row in body["tiers"]] == [
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+    ]
+
+
+@pytest.mark.parametrize("fn", ["upgrade_path_at_batch", "downgrade_path_at_batch"])
+def test_supply_order_preserved(ent, fn):
+    body = getattr(ent, fn)(
+        [ent.TIER_CLOUD_PRO, ent.TIER_OSS, ent.TIER_ENTERPRISE]
+    )
+    assert [row["tier"] for row in body["tiers"]] == [
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_OSS,
+        ent.TIER_ENTERPRISE,
+    ]
+
+
+@pytest.mark.parametrize("fn", ["upgrade_path_at_batch", "downgrade_path_at_batch"])
+def test_whitespace_and_case_normalised(ent, fn):
+    body = getattr(ent, fn)(
+        ["  CLOUD_PRO  ", ent.TIER_CLOUD_STARTER.upper()]
+    )
+    assert [row["tier"] for row in body["tiers"]] == [
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_CLOUD_STARTER,
+    ]
+
+
+@pytest.mark.parametrize("fn", ["upgrade_path_at_batch", "downgrade_path_at_batch"])
+def test_duplicates_dropped_first_seen_wins(ent, fn):
+    body = getattr(ent, fn)(
+        [
+            ent.TIER_CLOUD_PRO,
+            ent.TIER_CLOUD_PRO,
+            ent.TIER_CLOUD_STARTER,
+            ent.TIER_CLOUD_PRO,
+        ]
+    )
+    assert [row["tier"] for row in body["tiers"]] == [
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_CLOUD_STARTER,
+    ]
+
+
+@pytest.mark.parametrize("fn", ["upgrade_path_at_batch", "downgrade_path_at_batch"])
+def test_unknown_ids_echoed_in_unknown(ent, fn):
+    body = getattr(ent, fn)(
+        [ent.TIER_CLOUD_PRO, "nope_tier", "also_bogus"]
+    )
+    assert [row["tier"] for row in body["tiers"]] == [ent.TIER_CLOUD_PRO]
+    assert body["unknown"] == ["nope_tier", "also_bogus"]
+
+
+@pytest.mark.parametrize("fn", ["upgrade_path_at_batch", "downgrade_path_at_batch"])
+def test_unknown_only_returns_empty_tiers(ent, fn):
+    body = getattr(ent, fn)(["nope_tier", "also_bogus"])
+    assert body == {"tiers": [], "unknown": ["nope_tier", "also_bogus"]}
+
+
+@pytest.mark.parametrize("fn", ["upgrade_path_at_batch", "downgrade_path_at_batch"])
+def test_non_iterable_input_falls_back_to_empty(ent, fn):
+    """``_normalise_csv`` returns ``[]`` for non-iterable inputs (int,
+    object, etc.) so the batch collapses to an empty envelope rather
+    than raising."""
+    assert getattr(ent, fn)(12345) == {"tiers": [], "unknown": []}
+    assert getattr(ent, fn)(object()) == {"tiers": [], "unknown": []}
+
+
+@pytest.mark.parametrize("fn", ["upgrade_path_at_batch", "downgrade_path_at_batch"])
+def test_trial_source_accepted(ent, fn):
+    body = getattr(ent, fn)([ent.TIER_TRIAL])
+    assert [row["tier"] for row in body["tiers"]] == [ent.TIER_TRIAL]
+    assert body["unknown"] == []
+
+
+# ── helper: shape + parity ───────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("fn", ["upgrade_path_at_batch", "downgrade_path_at_batch"])
+def test_row_shape_matches_outer_envelope(ent, fn):
+    body = getattr(ent, fn)([ent.TIER_CLOUD_PRO])
+    assert len(body["tiers"]) == 1
+    row = body["tiers"][0]
+    assert set(row.keys()) == _OUTER_ROW_KEYS
+    assert isinstance(row["path"], list)
+
+
+def test_upgrade_batch_matches_scalar_exactly(ent):
+    """Pin scalar / batch no-drift: every batch source's ``path`` list
+    byte-equals the scalar ``upgrade_path_at`` list for the same source
+    across the full tier order (including ``trial``)."""
+    body = ent.upgrade_path_at_batch(list(ent._TIER_ORDER))
+    by_tier = {row["tier"]: row for row in body["tiers"]}
+    assert set(by_tier) == set(ent._TIER_ORDER)
+    for tid in ent._TIER_ORDER:
+        assert by_tier[tid]["path"] == ent.upgrade_path_at(tid), tid
+
+
+def test_downgrade_batch_matches_scalar_exactly(ent):
+    """Pin scalar / batch no-drift: every batch source's ``path`` list
+    byte-equals the scalar ``downgrade_path_at`` list for the same
+    source across the full tier order (including ``trial``)."""
+    body = ent.downgrade_path_at_batch(list(ent._TIER_ORDER))
+    by_tier = {row["tier"]: row for row in body["tiers"]}
+    assert set(by_tier) == set(ent._TIER_ORDER)
+    for tid in ent._TIER_ORDER:
+        assert by_tier[tid]["path"] == ent.downgrade_path_at(tid), tid
+
+
+@pytest.mark.parametrize("fn", ["upgrade_path_at_batch", "downgrade_path_at_batch"])
+def test_tier_metadata_matches_scalar(ent, fn):
+    body = getattr(ent, fn)([ent.TIER_CLOUD_PRO])
+    row = body["tiers"][0]
+    assert row["tier_label"] == ent.tier_label(ent.TIER_CLOUD_PRO)
+    assert row["tier_rank"] == ent.tier_rank(ent.TIER_CLOUD_PRO)
+
+
+@pytest.mark.parametrize("fn", ["upgrade_path_at_batch", "downgrade_path_at_batch"])
+def test_every_tier_in_order_resolves(ent, fn):
+    body = getattr(ent, fn)(list(ent._TIER_ORDER))
+    assert len(body["tiers"]) == len(ent._TIER_ORDER)
+    assert body["unknown"] == []
+
+
+# ── helper: ceiling / floor rows (not unknown) ───────────────────────────────
+
+
+def test_upgrade_ceiling_yields_empty_path_not_unknown(ent):
+    """Enterprise is the ceiling of the purchasable ladder -- there is
+    nothing strictly higher-rank to walk. The scalar returns ``[]``, not
+    ``None``, so the batch must include a valid row (not bucket it into
+    ``unknown[]``)."""
+    body = ent.upgrade_path_at_batch([ent.TIER_ENTERPRISE])
+    assert body["unknown"] == []
+    assert len(body["tiers"]) == 1
+    assert body["tiers"][0]["tier"] == ent.TIER_ENTERPRISE
+    assert body["tiers"][0]["path"] == []
+
+
+def test_downgrade_floor_yields_empty_path_not_unknown(ent):
+    """``oss`` and ``cloud_free`` sit at the floor of the purchasable
+    ladder -- nothing strictly below to walk. The scalar returns ``[]``,
+    not ``None``, so the batch must include valid rows for both."""
+    body = ent.downgrade_path_at_batch([ent.TIER_OSS, ent.TIER_CLOUD_FREE])
+    assert body["unknown"] == []
+    tiers = {row["tier"]: row["path"] for row in body["tiers"]}
+    assert tiers[ent.TIER_OSS] == []
+    assert tiers[ent.TIER_CLOUD_FREE] == []
+
+
+def test_upgrade_mid_ladder_row_shape(ent):
+    """A mid-ladder source (``cloud_starter``) walks strictly-higher-
+    rank purchasable tiers. Each inner row is the shape
+    ``tier_unlocks`` returns."""
+    body = ent.upgrade_path_at_batch([ent.TIER_CLOUD_STARTER])
+    inner = body["tiers"][0]["path"]
+    assert inner, "starter is not the ceiling -- expected non-empty path"
+    expected_keys = {
+        "tier",
+        "tier_label",
+        "tier_rank",
+        "previous_tier",
+        "previous_tier_label",
+        "previous_tier_rank",
+        "features",
+        "runtimes",
+    }
+    for row in inner:
+        assert set(row.keys()) == expected_keys
+
+
+def test_downgrade_mid_ladder_row_shape(ent):
+    """A mid-ladder source (``cloud_pro``) walks strictly-lower-rank
+    purchasable tiers. Each inner row carries the destination metadata
+    + the walk's source echo + cumulative ``lost_*`` lists."""
+    body = ent.downgrade_path_at_batch([ent.TIER_CLOUD_PRO])
+    inner = body["tiers"][0]["path"]
+    assert inner, "cloud_pro is not the floor -- expected non-empty path"
+    expected_keys = {
+        "target",
+        "target_label",
+        "target_rank",
+        "current_tier",
+        "current_tier_label",
+        "current_tier_rank",
+        "lost_features",
+        "lost_runtimes",
+    }
+    for row in inner:
+        assert set(row.keys()) == expected_keys
+        assert row["current_tier"] == ent.TIER_CLOUD_PRO
+
+
+# ── helper: resolver-independence ────────────────────────────────────────────
+
+
+def test_upgrade_grace_vs_enforce_byte_identical(ent, monkeypatch):
+    """Enforcement is a live-resolver knob; the batch what-if helper is
+    catalogue-derived and must produce byte-identical bodies."""
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    ent.invalidate()
+    grace = ent.upgrade_path_at_batch(list(ent._TIER_ORDER))
+
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    enforced = ent.upgrade_path_at_batch(list(ent._TIER_ORDER))
+    assert grace == enforced
+
+
+def test_downgrade_grace_vs_enforce_byte_identical(ent, monkeypatch):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    ent.invalidate()
+    grace = ent.downgrade_path_at_batch(list(ent._TIER_ORDER))
+
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    enforced = ent.downgrade_path_at_batch(list(ent._TIER_ORDER))
+    assert grace == enforced
+
+
+# ── helper: never-raise ──────────────────────────────────────────────────────
+
+
+def test_upgrade_never_raises_when_scalar_helper_crashes(ent, monkeypatch):
+    """A per-tier scalar crash must short-circuit that id into
+    ``unknown[]`` and the rest of the batch keeps building."""
+    real = ent.upgrade_path_at
+
+    def flaky(t):
+        if t == ent.TIER_CLOUD_PRO:
+            raise RuntimeError("simulated scalar crash")
+        return real(t)
+
+    monkeypatch.setattr(ent, "upgrade_path_at", flaky)
+    body = ent.upgrade_path_at_batch(
+        [ent.TIER_OSS, ent.TIER_CLOUD_PRO, ent.TIER_ENTERPRISE]
+    )
+    assert [row["tier"] for row in body["tiers"]] == [
+        ent.TIER_OSS,
+        ent.TIER_ENTERPRISE,
+    ]
+    assert body["unknown"] == [ent.TIER_CLOUD_PRO]
+
+
+def test_downgrade_never_raises_when_scalar_helper_crashes(ent, monkeypatch):
+    real = ent.downgrade_path_at
+
+    def flaky(t):
+        if t == ent.TIER_CLOUD_PRO:
+            raise RuntimeError("simulated scalar crash")
+        return real(t)
+
+    monkeypatch.setattr(ent, "downgrade_path_at", flaky)
+    body = ent.downgrade_path_at_batch(
+        [ent.TIER_OSS, ent.TIER_CLOUD_PRO, ent.TIER_ENTERPRISE]
+    )
+    assert [row["tier"] for row in body["tiers"]] == [
+        ent.TIER_OSS,
+        ent.TIER_ENTERPRISE,
+    ]
+    assert body["unknown"] == [ent.TIER_CLOUD_PRO]
+
+
+def test_upgrade_never_raises_when_scalar_returns_none(ent, monkeypatch):
+    """A per-tier scalar ``None`` return must land the id in
+    ``unknown[]`` without raising."""
+    real = ent.upgrade_path_at
+
+    def none_pro(t):
+        if t == ent.TIER_CLOUD_PRO:
+            return None
+        return real(t)
+
+    monkeypatch.setattr(ent, "upgrade_path_at", none_pro)
+    body = ent.upgrade_path_at_batch(
+        [ent.TIER_OSS, ent.TIER_CLOUD_PRO, ent.TIER_ENTERPRISE]
+    )
+    assert [row["tier"] for row in body["tiers"]] == [
+        ent.TIER_OSS,
+        ent.TIER_ENTERPRISE,
+    ]
+    assert body["unknown"] == [ent.TIER_CLOUD_PRO]
+
+
+def test_downgrade_never_raises_when_scalar_returns_none(ent, monkeypatch):
+    real = ent.downgrade_path_at
+
+    def none_pro(t):
+        if t == ent.TIER_CLOUD_PRO:
+            return None
+        return real(t)
+
+    monkeypatch.setattr(ent, "downgrade_path_at", none_pro)
+    body = ent.downgrade_path_at_batch(
+        [ent.TIER_OSS, ent.TIER_CLOUD_PRO, ent.TIER_ENTERPRISE]
+    )
+    assert [row["tier"] for row in body["tiers"]] == [
+        ent.TIER_OSS,
+        ent.TIER_ENTERPRISE,
+    ]
+    assert body["unknown"] == [ent.TIER_CLOUD_PRO]
+
+
+# ── HTTP endpoint: happy path ────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "path,helper_name",
+    [
+        ("upgrade-path-at-batch", "upgrade_path_at"),
+        ("downgrade-path-at-batch", "downgrade_path_at"),
+    ],
+)
+def test_endpoint_known_tiers_returns_rows(client, ent, path, helper_name):
+    resp = client.get(
+        f"/api/entitlement/{path}"
+        f"?tiers={ent.TIER_CLOUD_STARTER},{ent.TIER_CLOUD_PRO}"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert _ENVELOPE_KEYS.issubset(set(body.keys()))
+    assert [row["tier"] for row in body["tiers"]] == [
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+    ]
+    # Each row's path matches the scalar helper for the same source --
+    # pinned so scalar and batch cannot drift at the transport layer.
+    helper = getattr(ent, helper_name)
+    for row in body["tiers"]:
+        assert row["path"] == helper(row["tier"]), row["tier"]
+
+
+@pytest.mark.parametrize(
+    "path", ["upgrade-path-at-batch", "downgrade-path-at-batch"]
+)
+def test_endpoint_missing_arg_returns_400(client, path):
+    resp = client.get(f"/api/entitlement/{path}")
+    assert resp.status_code == 400
+    assert "error" in resp.get_json()
+
+
+@pytest.mark.parametrize(
+    "path", ["upgrade-path-at-batch", "downgrade-path-at-batch"]
+)
+def test_endpoint_blank_arg_returns_400(client, path):
+    resp = client.get(f"/api/entitlement/{path}?tiers=%20%20")
+    assert resp.status_code == 400
+
+
+@pytest.mark.parametrize(
+    "path", ["upgrade-path-at-batch", "downgrade-path-at-batch"]
+)
+def test_endpoint_unknown_ids_echoed_at_200(client, ent, path):
+    resp = client.get(
+        f"/api/entitlement/{path}"
+        f"?tiers={ent.TIER_CLOUD_PRO},nope_tier,also_bogus"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert [row["tier"] for row in body["tiers"]] == [ent.TIER_CLOUD_PRO]
+    assert body["unknown"] == ["nope_tier", "also_bogus"]
+
+
+@pytest.mark.parametrize(
+    "path", ["upgrade-path-at-batch", "downgrade-path-at-batch"]
+)
+def test_endpoint_lowercases_and_trims(client, ent, path):
+    resp = client.get(
+        f"/api/entitlement/{path}"
+        f"?tiers=%20%20{ent.TIER_CLOUD_PRO.upper()}%20%20"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert [row["tier"] for row in body["tiers"]] == [ent.TIER_CLOUD_PRO]
+
+
+@pytest.mark.parametrize(
+    "path", ["upgrade-path-at-batch", "downgrade-path-at-batch"]
+)
+def test_endpoint_every_tier_in_order_round_trips(client, ent, path):
+    tiers = ",".join(ent._TIER_ORDER)
+    resp = client.get(f"/api/entitlement/{path}?tiers={tiers}")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert len(body["tiers"]) == len(ent._TIER_ORDER)
+    assert body["unknown"] == []
+
+
+@pytest.mark.parametrize(
+    "path", ["upgrade-path-at-batch", "downgrade-path-at-batch"]
+)
+def test_endpoint_envelope_carries_current_tier_and_grace_flags(
+    client, ent, path
+):
+    resp = client.get(
+        f"/api/entitlement/{path}?tiers={ent.TIER_CLOUD_PRO}"
+    )
+    body = resp.get_json()
+    live = ent.get_entitlement()
+    assert body["current_tier"] == live.tier
+    assert body["current_tier_rank"] == ent.tier_rank(live.tier)
+    assert body["grace"] == bool(live.grace)
+    assert body["enforced"] == ent.is_enforced()
+
+
+@pytest.mark.parametrize(
+    "path", ["upgrade-path-at-batch", "downgrade-path-at-batch"]
+)
+def test_endpoint_never_5xx_on_resolver_crash(client, ent, monkeypatch, path):
+    def boom(*_a, **_kw):
+        raise RuntimeError("simulated resolver crash")
+
+    monkeypatch.setattr(ent, "get_entitlement", boom)
+    resp = client.get(
+        f"/api/entitlement/{path}?tiers={ent.TIER_CLOUD_PRO}"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["tiers"] == []
+    assert body["grace"] is True
+    assert body["enforced"] is False
+
+
+@pytest.mark.parametrize(
+    "path", ["upgrade-path-at-batch", "downgrade-path-at-batch"]
+)
+def test_endpoint_unknown_only_returns_200_empty_rows(client, path):
+    resp = client.get(
+        f"/api/entitlement/{path}?tiers=nope_tier,also_bogus"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["tiers"] == []
+    assert body["unknown"] == ["nope_tier", "also_bogus"]
+
+
+def test_endpoint_upgrade_ceiling_row_included_not_unknown(client, ent):
+    resp = client.get(
+        f"/api/entitlement/upgrade-path-at-batch?tiers={ent.TIER_ENTERPRISE}"
+    )
+    body = resp.get_json()
+    assert body["unknown"] == []
+    assert len(body["tiers"]) == 1
+    assert body["tiers"][0]["path"] == []
+
+
+def test_endpoint_downgrade_floor_row_included_not_unknown(client, ent):
+    resp = client.get(
+        f"/api/entitlement/downgrade-path-at-batch?tiers={ent.TIER_OSS}"
+    )
+    body = resp.get_json()
+    assert body["unknown"] == []
+    assert len(body["tiers"]) == 1
+    assert body["tiers"][0]["path"] == []


### PR DESCRIPTION
## Summary

Perspective-tier-batched siblings of the scalar `upgrade_path_at` / `downgrade_path_at` what-ifs (both already merged): hydrate the marginal-unlock (up) / cumulative-loss (down) ladder from N hypothetical sources in ONE round-trip, so a pricing-comparison matrix UI can render every column off ONE call instead of N calls to the scalar helper. Fills the `_at_batch` member of the `{upgrade,downgrade}_path` family that `tier_catalog_at_batch` (#3495) already established for the tier-catalog axis.

- Module-level `upgrade_path_at_batch(tiers)` / `downgrade_path_at_batch(tiers)` -- per-source row is `{tier, tier_label, tier_rank, path}`. Each inner `path` list is byte-identical to the scalar helper for the same source -- pinned by parity tests so scalar and batch cannot drift.
- `GET /api/entitlement/upgrade-path-at-batch?tiers=a,b,c`
  `GET /api/entitlement/downgrade-path-at-batch?tiers=a,b,c`
  mirroring the `/tier-catalog-at-batch` envelope shape: `{tiers, unknown, current_tier, current_tier_rank, grace, enforced}`.

Fills the perspective-tier `_at_batch` axis of the `{upgrade,downgrade}_path` family:

| helper                       | inner list                        | status        |
|------------------------------|-----------------------------------|---------------|
| `upgrade_path`               | `[tier_unlocks row]`              | merged        |
| `upgrade_path_at`            | `[tier_unlocks row]`              | merged        |
| `upgrade_path_at_batch`      | per-source `[upgrade_path_at]`    | **this PR**   |
| `downgrade_path`             | `[downgrade row]`                 | merged        |
| `downgrade_path_at`          | `[downgrade row]`                 | merged        |
| `downgrade_path_at_batch`    | per-source `[downgrade_path_at]`  | **this PR**   |

Posture matches the rest of the `_at_batch` family (mirrors `tier_catalog_at_batch`, `feature_catalog_at_batch`, `runtime_catalog_at_batch`):
- ids normalised via `_normalise_csv` (whitespace stripped, lowercased, duplicates dropped, first-seen order preserved)
- unknown ids echoed in `unknown[]` instead of short-circuiting -- a partially-bad caller still gets rows back for the valid ids alongside a list of what was dropped
- ceiling / floor sources yield a valid row with an empty `path: []` (only ids not in `_TIER_ORDER`, or scalar-`None` returns, land in `unknown[]`)
- `trial` IS accepted (lives in `_TIER_ORDER`; the scalar resolves it)
- resolver-independent: catalogue-derived, so grace vs enforce yields byte-identical rows
- never raises: a per-tier crash short-circuits that id into `unknown[]`; endpoint resolver failure short-circuits to a grace-shape envelope (no 5xx)

**Grace-only, read-only**: no gate enforced, no behavior change against the currently-resolved entitlement -- these are new read-only endpoints.

## Test plan

- [x] `python3 -m py_compile clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_upgrade_downgrade_path_at_batch.py` -- clean
- [x] `ruff check clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_upgrade_downgrade_path_at_batch.py` -- all checks passed
- [x] `python3 -m pytest tests/test_entitlement_upgrade_downgrade_path_at_batch.py -q` -- **58 passed**
- [x] Adjacent regression sweep -- 158 passed across `test_entitlement_tier_catalog_at_batch`, `test_entitlement_upgrade_path`, `test_entitlement_upgrade_path_at`, `test_entitlement_downgrade_path`, `test_entitlement_downgrade_path_at`, `test_entitlement_api`

### Coverage in `tests/test_entitlement_upgrade_downgrade_path_at_batch.py`

Both helpers + both endpoints are covered by parametrised tests:

- helper input handling: empty / `None` / csv string / iterable / non-iterable fallback / whitespace / casing / duplicate dedupe / order preservation / unknown-echo / `trial` accepted
- helper shape + parity: per-source row keys `{tier, tier_label, tier_rank, path}`; byte-parity with scalar `upgrade_path_at` / `downgrade_path_at` for every source in `_TIER_ORDER`; mid-ladder inner row shapes (upgrade rows match `tier_unlocks`, downgrade rows match `downgrade_path_at` field-for-field)
- helper ceiling / floor rows: `enterprise` in upgrade batch and `oss` / `cloud_free` in downgrade batch yield a valid row with `path: []` -- NOT `unknown`
- helper resolver-independence: grace vs enforce byte-identical
- helper never-raise: per-tier scalar crash → id lands in `unknown[]`; scalar `None` return → id lands in `unknown[]`
- HTTP: `_ENVELOPE_KEYS` shape, source echo, row parity with scalar `/upgrade-path-at` / `/downgrade-path-at`, 400 on missing / blank, 200 with bucketed unknowns, whitespace / casing normalised, envelope carries live `current_tier` + grace flags, never-5xxs on resolver failure, ceiling / floor rows still echoed at HTTP layer

## Local operator verification checklist

The public-repo agent cannot exercise the live daemon, cloud snapshot, or browser. Please copy the changed files into your locally-installed clawmetry site-packages and verify against the real daemon before flipping ready-for-review:

```bash
# 1. Copy the changed files into the installed package
SP="$HOME/.clawmetry/lib/python$(python3 -c 'import sys;print(f"{sys.version_info.major}.{sys.version_info.minor}")')/site-packages/clawmetry"
cp clawmetry/entitlements.py "$SP/entitlements.py"
# routes/ isn't inside the package; on the default layout it lands at
# $HOME/.clawmetry/lib/python*/site-packages/routes/entitlement.py
find "$HOME/.clawmetry" -name entitlement.py -path '*routes*' -exec cp routes/entitlement.py {} \;

# 2. Purge stale bytecode so the new module actually loads
find "$HOME/.clawmetry" -type d -name __pycache__ -exec rm -rf {} +

# 3. Bounce the sync daemon so it re-imports
launchctl kickstart -k "gui/$(id -u)/com.clawmetry.sync"

# 4. Hit the new endpoints (happy path)
curl -s 'http://localhost:8900/api/entitlement/upgrade-path-at-batch?tiers=oss,cloud_starter,cloud_pro,enterprise' | jq
curl -s 'http://localhost:8900/api/entitlement/downgrade-path-at-batch?tiers=oss,cloud_starter,cloud_pro,enterprise' | jq
# Expect: 200 with envelope {tiers, unknown, current_tier, current_tier_rank, grace, enforced}.
# Four per-source rows for each; the enterprise row in the UPGRADE batch has
# path: []; the oss row in the DOWNGRADE batch has path: []; neither lands
# in unknown[].

# 5. Parity with the live scalar sibling for every rung
for path in upgrade-path-at-batch downgrade-path-at-batch; do
  scalar_path="${path%-batch}"
  curl -s "http://localhost:8900/api/entitlement/${path}?tiers=oss,cloud_starter,cloud_pro,enterprise" \
    | jq -r '.tiers[] | .tier' \
    | while read rung; do
        diff \
          <(curl -s "http://localhost:8900/api/entitlement/${path}?tiers=$rung" | jq '.tiers[0].path') \
          <(curl -s "http://localhost:8900/api/entitlement/${scalar_path}?tier=$rung" | jq '.path') \
        && echo "$path rung $rung: parity OK"
      done
done
# Expect: "parity OK" for every rung; no diffs.

# 6. Direction round-trip
diff \
  <(curl -s 'http://localhost:8900/api/entitlement/upgrade-path-at-batch?tiers=cloud_starter' | jq '.tiers[0].path | map(.tier)') \
  <(curl -s 'http://localhost:8900/api/entitlement/upgrade-path-at?tier=cloud_starter' | jq '.path | map(.tier)')
# Expect: empty diff -- upgrade rows list higher-rank tiers strictly above cloud_starter.

# 7. Error paths
curl -si 'http://localhost:8900/api/entitlement/upgrade-path-at-batch' | head -1
# Expect: HTTP/1.1 400
curl -s 'http://localhost:8900/api/entitlement/upgrade-path-at-batch?tiers=cloud_pro,nope_tier' | jq '.unknown'
# Expect: ["nope_tier"] -- 200, not 404
curl -si 'http://localhost:8900/api/entitlement/downgrade-path-at-batch?tiers=%20%20' | head -1
# Expect: HTTP/1.1 400

# 8. Decrypt the live cloud snapshot in the browser + sanity-check no
# regressions on the existing /upgrade-path-at, /downgrade-path-at,
# and /tier-catalog-at-batch endpoints.
```

If everything looks right, flip to ready-for-review and merge in the normal flow. Only the local operator has access to the live daemon and snapshot for step 8, which is why this PR stays draft until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019HTNG62GDrcK6qFNpXXgtM)_