### PR TITLE
fix: add GPT-5.6 family pricing to MODEL_OVERRIDES

### DIFF
--- a/clawmetry/providers_pricing.py
+++ b/clawmetry/providers_pricing.py
@@ -109,6 +109,11 @@ MODEL_OVERRIDES: dict[tuple[str, str], tuple[float, float]] = {
     ("openai", "o1-mini"): (3.00, 12.00),
     ("openai", "o1"): (15.00, 60.00),
     ("openai", "o3-mini"): (1.10, 4.40),
+    # GPT-5 family (gpt-5.4, gpt-5.6, …). Official prices not yet published —
+    # $10/$40 per 1M is a best-effort estimate; update once OpenAI confirms.
+    # gpt-5.6 entry beats the broad prefix via longest-prefix matching in _get_rates.
+    ("openai", "gpt-5"): (10.00, 40.00),
+    ("openai", "gpt-5.6"): (10.00, 40.00),
     ("gemini", "gemini-2.0-flash"): (0.10, 0.40),
     ("gemini", "gemini-1.5-pro"): (1.25, 5.00),
     ("gemini", "gemini-1.5-flash"): (0.075, 0.30),

--- a/tests/test_providers_pricing.py
+++ b/tests/test_providers_pricing.py
@@ -66,3 +66,12 @@ def test_unknown_provider_conservative_default():
 def test_local_models_are_free():
     assert _get_rates("ollama", "llama3.2:3b") == (0.0, 0.0)
     assert _get_rates("", "ollama/llama3.2") == (0.0, 0.0)
+
+
+def test_gpt5_6_priced_explicitly():
+    # GPT-5.x must not fall through to the gpt-4o baseline ($2.50/$10). #3502
+    assert _get_rates("openai", "gpt-5.6") == (10.00, 40.00)
+    assert _get_rates("openai", "gpt-5.4") == (10.00, 40.00)
+    assert _get_rates("openai", "gpt-5") == (10.00, 40.00)
+    # gpt-5.6 prefix wins over the broader gpt-5 prefix
+    assert _get_rates("openai", "gpt-5.6-turbo") == (10.00, 40.00)


### PR DESCRIPTION
Closes #3502

## What

`MODEL_OVERRIDES` in `clawmetry/providers_pricing.py` had no entry for the GPT-5.x model family, so any `gpt-5.4` / `gpt-5.6` session silently fell back to the gpt-4o baseline ($2.50/$10 per 1M) via `_get_rates()`, producing stale cost estimates for all GPT-5 usage.

## Changes

- **`clawmetry/providers_pricing.py`** — adds two `MODEL_OVERRIDES` entries:
  - `("openai", "gpt-5")` — broad family prefix; catches gpt-5, gpt-5.4, and any future gpt-5.x variants
  - `("openai", "gpt-5.6")` — specific entry for the subfamily named in the issue; wins over the broad prefix via the existing longest-prefix matching in `_get_rates()`
  - Estimated at $10/$40 per 1M (best-effort; comment notes it should be updated once OpenAI publishes official prices)
- **`tests/test_providers_pricing.py`** — adds `test_gpt5_6_priced_explicitly()` asserting gpt-5.6, gpt-5.4, and gpt-5 all resolve to the new entry rather than the gpt-4o baseline

## Test plan

- `python3 -m pytest tests/test_providers_pricing.py -v` → all 7 tests pass (including new `test_gpt5_6_priced_explicitly`)
- No change to `provider_for_model` needed — `"gpt" in m` already routes gpt-5.x to `openai` correctly

---
_Generated by [Claude Code](https://claude.ai/code/session_01HPcBPCGTMoGBC6s6e2NMbd)_