### PR TITLE
fix(crons): surface on-exit trigger and detached-run metadata

### DIFF
--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -9821,6 +9821,11 @@ def sync_crons(config: dict, state: dict, paths: dict) -> int:
                     "lastDurationMs": job_state.get("lastDurationMs"),
                     "lastError": job_state.get("lastError"),
                     "consecutiveFailures": job_state.get("consecutiveFailures"),
+                    # on-exit trigger / detached-run metadata (openclaw #92037 / #98755)
+                    "watchedCommand":  job_state.get("watchedCommand"),
+                    "lastExitCode":    job_state.get("lastExitCode") or job_state.get("exitCode"),
+                    "targetSessionId": job_state.get("targetSessionId"),
+                    "detachedAt":      job_state.get("detachedAt"),
                 },
             }
 
@@ -9873,6 +9878,11 @@ def sync_crons(config: dict, state: dict, paths: dict) -> int:
                     "lastDurationMs":      job_state.get("lastDurationMs"),
                     "lastError":           job_state.get("lastError"),
                     "consecutiveFailures": job_state.get("consecutiveFailures"),
+                    # on-exit trigger / detached-run metadata (openclaw #92037 / #98755)
+                    "watchedCommand":      job_state.get("watchedCommand"),
+                    "lastExitCode":        job_state.get("lastExitCode") or job_state.get("exitCode"),
+                    "targetSessionId":     job_state.get("targetSessionId"),
+                    "detachedAt":          job_state.get("detachedAt"),
                 })
             except Exception as _e:
                 log.debug("local_store: ingest_cron failed for %s: %s",

--- a/routes/crons.py
+++ b/routes/crons.py
@@ -158,6 +158,8 @@ def _row_to_cron_job(row):
     for k in (
         "lastDurationMs", "consecutiveFailures", "lastError",
         "runHistory", "lastCostUsd",
+        # on-exit trigger / detached-run metadata (openclaw #92037 / #98755)
+        "watchedCommand", "lastExitCode", "targetSessionId", "detachedAt",
     ):
         if k in extras:
             state_extras[k] = extras[k]
@@ -192,7 +194,8 @@ def _row_to_cron_job(row):
     for k, v in extras.items():
         if k not in {"createdAtMs", "schedule", "lastDurationMs",
                      "consecutiveFailures", "lastError", "runHistory",
-                     "lastCostUsd"}:
+                     "lastCostUsd",
+                     "watchedCommand", "lastExitCode", "targetSessionId", "detachedAt"}:
             job.setdefault(k, v)
     return job
 
@@ -1343,10 +1346,16 @@ def _project_intentions(jobs, days: int, include_disabled: bool, max_events: int
             while t <= window_end_ms and len(firings) < 100:
                 firings.append(t)
                 t += every_ms
+        elif sched_kind == "on-exit":
+            # Event-triggered: fires when the watched command exits; no
+            # predictable next-run time. Use nextRunAtMs when the gateway
+            # provides one, otherwise pin to window_end so the job still
+            # appears in the timeline.
+            firings.append(int(next_run_ms) if next_run_ms else window_end_ms)
         elif next_run_ms and now_ms <= next_run_ms <= window_end_ms:
             firings.append(int(next_run_ms))
         for ts in firings:
-            intentions.append({
+            entry = {
                 "jobId":           job_id,
                 "name":            job_name,
                 "scheduledForMs":  ts,
@@ -1355,7 +1364,13 @@ def _project_intentions(jobs, days: int, include_disabled: bool, max_events: int
                 "lastRunAtMs":     last_run_ms,
                 "isRecentlyAdded": is_recently_added,
                 "enabled":         enabled,
-            })
+            }
+            if sched_kind == "on-exit":
+                for k in ("watchedCommand", "lastExitCode", "targetSessionId", "detachedAt"):
+                    v = state.get(k)
+                    if v is not None:
+                        entry[k] = v
+            intentions.append(entry)
             if len(intentions) >= max_events:
                 break
         if len(intentions) >= max_events:

--- a/tests/test_crons_local_store.py
+++ b/tests/test_crons_local_store.py
@@ -334,3 +334,70 @@ def test_cron_health_disabled_without_env_flag(no_flag_app):
     _seed_two_crons(ls.get_store())
     body = app.test_client().get("/api/cron-health").get_json()
     assert body.get("_source") != "local_store"
+
+
+# ── on-exit / detached-run metadata (issue #3501) ──────────────────────────
+
+
+def _seed_on_exit_cron(store):
+    """Insert an on-exit cron with trigger + detach metadata."""
+    import time
+    now_ms = int(time.time() * 1000)
+    store.ingest_cron({
+        "cron_id": "watch-build",
+        "name": "Watch Build Exit",
+        "schedule": '{"kind":"on-exit"}',
+        "enabled": True,
+        "last_run_at": "",
+        "last_status": "success",
+        "next_run_at": "",
+        "createdAtMs": now_ms - 3600000,
+        "lastDurationMs": 800,
+        # on-exit trigger / detached-run fields
+        "watchedCommand": "make build",
+        "lastExitCode": 0,
+        "targetSessionId": "sess-abc123",
+        "detachedAt": now_ms - 60000,
+    })
+
+
+def test_on_exit_cron_metadata_in_jobs_response(fast_path_app):
+    """on-exit trigger fields must round-trip through _row_to_cron_job into
+    job.state (issue #3501 — Gap 1)."""
+    app, ls, _cr = fast_path_app
+    _seed_on_exit_cron(ls.get_store())
+
+    body = app.test_client().get("/api/crons").get_json()
+    assert body.get("_source") == "local_store"
+    jobs = body.get("jobs", [])
+    by_id = {j["id"]: j for j in jobs}
+    assert "watch-build" in by_id, f"on-exit job missing from response: {list(by_id)}"
+
+    job = by_id["watch-build"]
+    state = job.get("state", {})
+    assert state.get("watchedCommand") == "make build", f"watchedCommand missing from state: {state}"
+    assert state.get("lastExitCode") == 0, f"lastExitCode missing from state: {state}"
+    assert state.get("targetSessionId") == "sess-abc123", f"targetSessionId missing from state: {state}"
+    assert state.get("detachedAt") is not None, f"detachedAt missing from state: {state}"
+    # Must NOT also appear at the top level (carry-through excluded them)
+    assert "watchedCommand" not in job, f"watchedCommand leaked to top-level: {job}"
+
+
+def test_on_exit_cron_appears_in_agent_intentions(fast_path_app):
+    """on-exit cron with no nextRunAtMs must still appear in /api/agent-intentions
+    (issue #3501 — Gap 2). The job is surfaced at window_end so it's visible."""
+    app, ls, _cr = fast_path_app
+    _seed_on_exit_cron(ls.get_store())
+
+    body = app.test_client().get("/api/agent-intentions").get_json()
+    intentions = body.get("intentions", [])
+    on_exit_entries = [i for i in intentions if i.get("jobId") == "watch-build"]
+    assert on_exit_entries, (
+        f"on-exit job 'watch-build' missing from intentions; got jobIds: "
+        f"{[i.get('jobId') for i in intentions]}"
+    )
+    entry = on_exit_entries[0]
+    assert entry.get("scheduleKind") == "on-exit"
+    # Trigger metadata must be forwarded into the intention entry
+    assert entry.get("watchedCommand") == "make build", f"watchedCommand missing from intention: {entry}"
+    assert entry.get("lastExitCode") == 0, f"lastExitCode missing from intention: {entry}"


### PR DESCRIPTION
Closes #3501

## Summary

- **`clawmetry/sync.py`**: Forward `watchedCommand`, `lastExitCode`, `targetSessionId`, `detachedAt` from `job_state` in both the cloud `event_data["state"]` dict and the local DuckDB `ingest_cron()` write-through, so the new on-exit/detach fields are actually stored.
- **`routes/crons.py` `_row_to_cron_job()`**: Add the four on-exit fields to the `state_extras` allow-list (they now land in `job.state`) and to the carry-through exclusion set (preventing top-level duplication).
- **`routes/crons.py` `_project_intentions()`**: Add an explicit `on-exit` branch so event-triggered jobs appear in `/api/agent-intentions` even when `nextRunAtMs` is zero — pinned to `window_end_ms` when no firm time is available, with trigger metadata forwarded into each intention entry.

## Test plan

- `python3 -m pytest tests/test_crons_local_store.py -v` — all 13 tests pass (11 existing + 2 new)
  - `test_on_exit_cron_metadata_in_jobs_response` — on-exit fields round-trip into `job.state` via `/api/crons`
  - `test_on_exit_cron_appears_in_agent_intentions` — on-exit job surfaces in `/api/agent-intentions` with correct `scheduleKind` and trigger context
- `python3 -m py_compile routes/crons.py clawmetry/sync.py` — syntax clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01NFf822EYeJCaRwuBUnWVwE)_