### PR TITLE
feat(nemoclaw): discover terminal sandboxes from agents.yaml (#3503)

### DIFF
--- a/clawmetry/adapters/openclaw.py
+++ b/clawmetry/adapters/openclaw.py
@@ -518,6 +518,75 @@ def _sandbox_inference_configs() -> list:
             out.append(entry)
         except Exception:
             continue
+
+    # -- gap #3503: terminal/agent-execution sandboxes not in sandboxes.json --
+    # agents.yaml carries the *intent* roster; terminal-kind coding-agent
+    # sandboxes (e.g. deepagents-code) have no inference-routing entry and are
+    # invisible to the loop above. Discover them from agents.yaml and probe
+    # each with the openshell helpers so Phase/Policy/Runtime/OCSF/egress data
+    # reaches the dashboard exactly as it does for inference-routing sandboxes.
+    _seen = {e["sandbox"] for e in out}
+    try:
+        _home2 = os.environ.get("HOME") or os.path.expanduser("~")
+        _manifest = os.path.join(_home2, ".nemoclaw", "agents.yaml")
+        if os.path.isfile(_manifest):
+            with open(_manifest, "r", encoding="utf-8") as _fh:
+                _mc = _fh.read()
+            _agents: list = []
+            try:
+                import yaml as _yaml  # type: ignore[import]
+                _md = _yaml.safe_load(_mc)
+                if isinstance(_md, dict):
+                    _raw = _md.get("agents", [])
+                    if isinstance(_raw, list):
+                        _agents = [a for a in _raw if isinstance(a, dict)]
+                    elif isinstance(_raw, dict):
+                        _agents = [
+                            {"name": k, **(v if isinstance(v, dict) else {})}
+                            for k, v in _raw.items()
+                        ]
+                elif isinstance(_md, list):
+                    _agents = [a for a in _md if isinstance(a, dict)]
+            except ImportError:
+                # yaml unavailable: line-scan for sandbox:/name: entries
+                for _line in _mc.splitlines():
+                    _s = _line.strip()
+                    for _pfx in ("sandbox:", "- sandbox:"):
+                        if _s.startswith(_pfx):
+                            _v = _s[len(_pfx):].strip().strip("\"'")
+                            if _v:
+                                _agents.append({"sandbox": _v})
+                            break
+                    else:
+                        if _s.startswith("- name:"):
+                            _, _, _v2 = _s.partition(":")
+                            _v2 = _v2.strip().strip("\"'")
+                            if _v2:
+                                _agents.append({"name": _v2})
+            except Exception:
+                _agents = []
+            for _agent in _agents:
+                if not isinstance(_agent, dict):
+                    continue
+                _sb = (_agent.get("sandbox") or _agent.get("name") or "").strip()
+                if not _sb or _sb in _seen:
+                    continue
+                _seen.add(_sb)
+                _te: dict = {
+                    "sandbox": _sb,
+                    "isDefault": False,
+                    "provider": "terminal",
+                    "providerKey": "terminal",
+                    "primaryModelRef": "",
+                    "sandboxSource": "agents.yaml",
+                }
+                _te.update(_openshell_sandbox_phase_policy(_sb))
+                _te.update(_openshell_sandbox_ocsf_enabled(_sb))
+                _te.update(_sandbox_egress_denied_count(_sb))
+                out.append(_te)
+    except Exception:
+        pass
+
     return out
 
 

--- a/tests/test_obs_gap_nemoclaw_terminal_sandbox_3503.py
+++ b/tests/test_obs_gap_nemoclaw_terminal_sandbox_3503.py
@@ -1,0 +1,146 @@
+"""Tests for #3503 -- _sandbox_inference_configs discovers terminal/agent-execution
+sandboxes from agents.yaml that have no entry in sandboxes.json.
+"""
+import json
+import shutil
+import subprocess
+
+import pytest
+
+from clawmetry.adapters.openclaw import _sandbox_inference_configs
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+def _write_sandboxes_json(tmp_path, data):
+    nemo = tmp_path / ".nemoclaw"
+    nemo.mkdir(exist_ok=True)
+    (nemo / "sandboxes.json").write_text(json.dumps(data))
+
+
+def _write_agents_yaml(tmp_path, content):
+    nemo = tmp_path / ".nemoclaw"
+    nemo.mkdir(exist_ok=True)
+    (nemo / "agents.yaml").write_text(content)
+
+
+def _noop_openshell(*a, **kw):
+    """subprocess.run stub: returns an empty stdout so openshell helpers no-op."""
+    return type("R", (), {"stdout": ""})()
+
+
+# ---------------------------------------------------------------------------
+# 1. Terminal sandbox in agents.yaml but not in sandboxes.json → surfaced
+# ---------------------------------------------------------------------------
+
+def test_terminal_sandbox_from_agents_yaml_surfaces_in_output(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    # sandboxes.json has only an inference-routing sandbox
+    _write_sandboxes_json(tmp_path, {
+        "defaultSandbox": "inference-sb",
+        "sandboxes": {
+            "inference-sb": {"provider": "anthropic-prod", "model": "claude-opus-4-5"},
+        },
+    })
+    # agents.yaml declares a terminal sandbox absent from sandboxes.json
+    _write_agents_yaml(tmp_path, (
+        "agents:\n"
+        "  - name: deepagents-code\n"
+        "    sandbox: deepagents-code\n"
+        "    runtimeKind: terminal\n"
+    ))
+    # openshell absent — helpers no-op gracefully
+    monkeypatch.setattr(shutil, "which", lambda _cmd: None)
+
+    result = _sandbox_inference_configs()
+    sandboxes = {r["sandbox"]: r for r in result}
+
+    assert "inference-sb" in sandboxes
+    assert "deepagents-code" in sandboxes
+    te = sandboxes["deepagents-code"]
+    assert te["provider"] == "terminal"
+    assert te["providerKey"] == "terminal"
+    assert te["sandboxSource"] == "agents.yaml"
+    assert te["primaryModelRef"] == ""
+
+
+# ---------------------------------------------------------------------------
+# 2. Sandbox already in sandboxes.json must not be duplicated
+# ---------------------------------------------------------------------------
+
+def test_sandbox_in_sandboxes_json_not_duplicated(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    _write_sandboxes_json(tmp_path, {
+        "sandboxes": {
+            "shared-sb": {"provider": "openai-api", "model": "gpt-4o"},
+        },
+    })
+    # agents.yaml also lists the same sandbox name
+    _write_agents_yaml(tmp_path, (
+        "agents:\n"
+        "  - name: shared-sb\n"
+        "    sandbox: shared-sb\n"
+    ))
+    monkeypatch.setattr(shutil, "which", lambda _cmd: None)
+
+    result = _sandbox_inference_configs()
+    names = [r["sandbox"] for r in result]
+
+    # Must appear exactly once; the sandboxes.json entry wins (providerKey != "terminal")
+    assert names.count("shared-sb") == 1
+    assert result[0]["providerKey"] != "terminal"
+
+
+# ---------------------------------------------------------------------------
+# 3. openshell is probed for the terminal sandbox; Phase/Runtime propagate
+# ---------------------------------------------------------------------------
+
+def test_terminal_sandbox_openshell_probed_for_phase_and_runtime(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    _write_sandboxes_json(tmp_path, {"sandboxes": {}})
+    _write_agents_yaml(tmp_path, (
+        "agents:\n"
+        "  - name: deepagents-code\n"
+        "    sandbox: deepagents-code\n"
+    ))
+
+    calls = []
+
+    def fake_run(cmd, **kw):
+        calls.append(cmd)
+        if "get" in cmd:
+            return type("R", (), {"stdout": "Phase: Ready\nRuntime: terminal\n"})()
+        return type("R", (), {"stdout": ""})()
+
+    monkeypatch.setattr(shutil, "which", lambda _cmd: "/usr/bin/openshell")
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    result = _sandbox_inference_configs()
+    te = next(r for r in result if r["sandbox"] == "deepagents-code")
+
+    assert te["sandboxPhase"] == "Ready"
+    assert te["sandboxRuntimeKind"] == "terminal"
+    # openshell sandbox get was called with the right sandbox name
+    assert any("deepagents-code" in c for c in calls)
+
+
+# ---------------------------------------------------------------------------
+# 4. No agents.yaml → no extra entries (graceful no-op)
+# ---------------------------------------------------------------------------
+
+def test_no_agents_yaml_no_extra_sandboxes(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    _write_sandboxes_json(tmp_path, {
+        "sandboxes": {
+            "inference-sb": {"provider": "anthropic-prod", "model": "claude-3-5-sonnet"},
+        },
+    })
+    # no agents.yaml written
+    monkeypatch.setattr(shutil, "which", lambda _cmd: None)
+
+    result = _sandbox_inference_configs()
+    assert len(result) == 1
+    assert result[0]["sandbox"] == "inference-sb"
+    assert result[0].get("sandboxSource") != "agents.yaml"


### PR DESCRIPTION
## Summary

Terminal/agent-execution sandboxes (like `deepagents-code`) have no entry in `~/.nemoclaw/sandboxes.json` — they're pure execution environments with no inference-routing config. The existing `_sandbox_inference_configs()` only enumerated from `sandboxes.json`, so these sandboxes were invisible: Phase, Policy, Runtime classification, OCSF audit trail, and DNS-egress-denial counters were never surfaced even though `openshell sandbox get/logs <name>` fully supports them.

## Changes

- **`clawmetry/adapters/openclaw.py`**: After the `sandboxes.json` loop in `_sandbox_inference_configs()`, add a second discovery pass that reads `~/.nemoclaw/agents.yaml`, extracts each agent's `sandbox` field (falling back to `name`), skips any name already enumerated, and for each new terminal sandbox calls `_openshell_sandbox_phase_policy()` + `_openshell_sandbox_ocsf_enabled()` + `_sandbox_egress_denied_count()` — exactly the same three helpers used for inference-routing sandboxes. Entries are stamped `provider="terminal"`, `providerKey="terminal"`, `sandboxSource="agents.yaml"`. The whole block is wrapped in `try/except Exception: pass` so it never raises on plain OpenClaw or pre-onboarding NemoClaw installs.
- **`tests/test_obs_gap_nemoclaw_terminal_sandbox_3503.py`** (new): 4 tests covering: (1) terminal sandbox from agents.yaml surfaces with correct fields; (2) sandbox already in sandboxes.json is not duplicated; (3) openshell is called and Phase/Runtime propagate; (4) no agents.yaml → no extra entries.

## Test plan

- [x] `python3 -m pytest tests/test_obs_gap_nemoclaw_terminal_sandbox_3503.py -v` — 4 passed
- [x] `python3 -m pytest tests/test_obs_gap_nemoclaw_runtime_kind_3273.py tests/test_obs_gap_nemoclaw_sandbox_phase_3202.py tests/test_obs_gap_nemoclaw_ocsf_3274.py tests/test_obs_gap_nemoclaw_ollama_3201.py -q` — 79 passed, 0 regressions
- [x] `python3 -c 'import ast; ast.parse(open("clawmetry/adapters/openclaw.py").read())'` — syntax clean

## Bot meta
<!-- bot-autofix -->
Draft PR opened autonomously based on the plan in #3503. Marked draft for human review — mark Ready for Review once happy.

Closes #3503

---
_Generated by [Claude Code](https://claude.ai/code/session_01JxnuTWGEjVxGXpHYbECHk5)_