### PR TITLE
feat(entitlement): preview_at + preview_at_batch + 2 endpoints

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -2678,6 +2678,143 @@ def _preview_row(tier: str) -> dict | None:
         return None
 
 
+def preview_at(perspective_tier: str, target_tier: str) -> dict | None:
+    """What-if sibling of :func:`preview`: the full
+    :meth:`Entitlement.to_dict` snapshot at ``target_tier`` rendered from
+    the perspective of a hypothetical ``perspective_tier``.
+
+    Fills the ``_at`` slot in the preview family alongside
+    :func:`tier_spec_at`, :func:`feature_spec_at`, :func:`runtime_spec_at`,
+    :func:`capacity_diff_at`, :func:`tier_unlocks_at`, :func:`tier_locks_at`
+    and :func:`lock_reason_at`. Byte-identical to the internal
+    :func:`_preview_row(target_tier)` -- the cumulative preview state is
+    catalogue-derived so it does not depend on the perspective -- but
+    exposes the perspective-aware naming a pricing-comparison UI wants
+    when it uniformly calls ``X_at(perspective, target)`` across the
+    whole ``_at`` family off ONE request shape.
+
+    Unlike singular :func:`preview` (which returns ``None`` for the
+    non-purchasable :data:`TIER_TRIAL`), ``preview_at`` accepts trial as a
+    target and returns the trial preview row -- the lenient ``_at``
+    posture matching :func:`tier_spec_at` / :func:`feature_spec_at` /
+    :func:`runtime_spec_at`. The perspective tier is validated but does
+    not shape the returned row (byte-parity with :func:`_preview_row`
+    holds for every perspective / target combination).
+
+    Callers pair the result with :func:`tier_diff` /
+    :func:`tier_unlocks_at` / :func:`capacity_diff_at` to render "from
+    your perspective X, tier Y looks like this and the delta is Z"
+    walkthroughs off a uniform API.
+
+    Row shape matches :func:`preview` / :func:`_preview_row` /
+    :func:`preview_batch` / :func:`preview_path` exactly (full
+    :meth:`Entitlement.to_dict` with ``source="preview"`` and
+    ``grace=False`` so concrete per-tier capacity surfaces).
+
+    Returns ``None`` for empty / unknown perspective or target ids
+    (either side ``not in _TIER_ORDER`` / ``_TIER_FEATURES``
+    short-circuits). Resolver-independent: reads only the static per-tier
+    maps, so grace vs enforce yields byte-identical rows. Never raises: a
+    builder failure logs a warning and returns ``None``.
+    """
+    try:
+        p = (perspective_tier or "").strip().lower()
+        t = (target_tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if not p or p not in _TIER_ORDER:
+        return None
+    if not t or t not in _TIER_FEATURES:
+        return None
+    try:
+        return _preview_row(t)
+    except Exception as exc:
+        logger.warning("entitlements: preview_at failed: %s", exc)
+        return None
+
+
+def preview_at_batch(perspective_tier: str, targets) -> dict | None:
+    """What-if + batch sibling of :func:`preview_at`: return the full
+    :meth:`Entitlement.to_dict` snapshot rows for a caller-supplied subset
+    of target tiers, all computed from the perspective of one fixed
+    hypothetical ``perspective_tier``.
+
+    Fixed-perspective multi-target companion to :func:`preview_at`
+    (scalar what-if scalar) and caller-supplied-targets sibling of
+    :func:`preview_batch` (which walks :data:`_PURCHASABLE_TIERS`
+    unconditionally). Fills the ``_at_batch`` slot in the preview family
+    alongside :func:`tier_spec_at_batch`, :func:`feature_spec_at_batch`,
+    :func:`runtime_spec_at_batch`. Lets a pricing-comparison matrix UI
+    ("from my perspective tier, render the cumulative-state row for
+    OSS, Cloud Starter, Cloud Pro and Enterprise") hydrate every column
+    off ONE round-trip instead of N calls to :func:`preview_at`.
+
+    Per-row body is byte-identical to :func:`preview_at(perspective,
+    target)` for the same target (which is byte-identical to
+    :func:`_preview_row(target)`) -- a parity test pins this so the
+    scalar and batch what-if accessors cannot drift.
+
+    Shape (mirrors :func:`tier_spec_at_batch` / :func:`feature_spec_at_batch`
+    / :func:`runtime_spec_at_batch` ``{tiers, unknown}`` envelope --
+    the ``tiers`` axis IS the batch axis here, so the envelope key stays
+    ``tiers`` even though every row IS a tier)::
+
+        {
+          "tiers": [<preview_at row>, ...],   # one per known target, first-seen order
+          "unknown": ["bogus_id", ...],        # supplied ids not in _TIER_FEATURES
+        }
+
+    Returns ``None`` for empty / unknown perspective ``perspective_tier``
+    (caller renders "unknown tier" / 404). Supplied target ids are
+    normalised via :func:`_normalise_csv` (whitespace stripped,
+    lowercased, duplicates dropped, first-seen order preserved).
+    Unknown ids are echoed in ``unknown[]`` instead of short-circuiting
+    -- a partially-bad caller still gets rows back for the valid ids
+    alongside a list of what was dropped, matching
+    :func:`tier_spec_at_batch` / :func:`feature_spec_at_batch` /
+    :func:`runtime_spec_at_batch`. ``trial`` IS accepted as both
+    perspective (any id in :data:`_TIER_ORDER`) and target (any id in
+    :data:`_TIER_FEATURES`, which is a superset of
+    :data:`_PURCHASABLE_TIERS` -- includes trial).
+
+    Empty / ``None`` targets returns ``{"tiers": [], "unknown": []}``
+    -- the HTTP wrapper turns that into a 400, this helper does not
+    raise.
+
+    Resolver-independent: delegates per-row to :func:`_preview_row`,
+    which reads only the static per-tier maps -- so grace vs enforce
+    yields byte-identical rows. Never raises: a per-row failure
+    short-circuits that id into ``unknown[]`` and the rest of the batch
+    keeps building.
+    """
+    try:
+        p = (perspective_tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if not p or p not in _TIER_ORDER:
+        return None
+    ids = _normalise_csv(targets)
+    rows: list[dict] = []
+    unknown: list[str] = []
+    for tid in ids:
+        if tid not in _TIER_FEATURES:
+            unknown.append(tid)
+            continue
+        try:
+            row = _preview_row(tid)
+        except Exception as exc:
+            logger.warning(
+                "entitlements: preview_at_batch row %r failed: %s", tid, exc
+            )
+            unknown.append(tid)
+            continue
+        if row is None:
+            unknown.append(tid)
+            continue
+        rows.append(row)
+    return {"tiers": rows, "unknown": unknown}
+
+
 def preview_path(from_tier: str, to_tier: str) -> list[dict] | None:
     """Arbitrary-endpoint stepwise cumulative-state path between two tiers.
 

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -1126,6 +1126,193 @@ def api_entitlement_preview_batch():
         )
 
 
+@bp_entitlement.route("/api/entitlement/preview-at")
+def api_entitlement_preview_at():
+    """``GET /api/entitlement/preview-at?tier=<perspective>&target=<id>`` --
+    what-if sibling of ``/api/entitlement/preview``: the full
+    :meth:`Entitlement.to_dict` snapshot at ``target`` rendered from the
+    perspective of a hypothetical ``tier``.
+
+    Fills the ``_at`` slot in the preview family alongside
+    ``/api/entitlement/tier-spec-at``,
+    ``/api/entitlement/feature-spec-at``,
+    ``/api/entitlement/runtime-spec-at``,
+    ``/api/entitlement/capacity-diff-at``,
+    ``/api/entitlement/tier-unlocks-at``,
+    ``/api/entitlement/tier-locks-at`` and
+    ``/api/entitlement/lock-reason-at``. Lets a pricing-comparison
+    tooltip hydrate one cumulative-state row from a hypothetical
+    perspective in ONE round-trip using the uniform
+    ``X_at(perspective, target)`` request shape the rest of the ``_at``
+    family already exposes.
+
+    Unlike ``/api/entitlement/preview`` (which 404s the non-purchasable
+    :data:`TIER_TRIAL`), ``/preview-at`` accepts trial as a target and
+    returns the trial preview row -- lenient ``_at`` posture matching
+    ``/tier-spec-at`` / ``/feature-spec-at`` / ``/runtime-spec-at``. The
+    perspective tier is validated but does not shape the returned row
+    (byte-parity with :func:`entitlements._preview_row` holds for every
+    perspective / target combination).
+
+    Row shape matches ``/api/entitlement/preview`` exactly -- the full
+    ``Entitlement.to_dict`` payload with ``source="preview"`` and
+    ``grace=False`` so concrete per-tier capacity surfaces.
+
+    - **400** when ``tier=`` or ``target=`` is missing / blank
+    - **404** when ``tier`` is not in :data:`entitlements._TIER_ORDER`
+      or ``target`` is not in :data:`entitlements._TIER_FEATURES`; the
+      body carries ``which`` so a caller can render the right
+      "unknown ..." message
+    - **Never 5xxs**: the helper reads only the static per-tier maps, so
+      a resolver failure short-circuits to ``404`` instead of 500
+    """
+    raw_tier = request.args.get("tier")
+    tier = (raw_tier or "").strip().lower()
+    if not tier:
+        return jsonify({"error": "missing tier"}), 400
+    raw_target = request.args.get("target")
+    target = (raw_target or "").strip().lower()
+    if not target:
+        return jsonify({"error": "missing target"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        if tier not in _ent._TIER_ORDER:
+            return (
+                jsonify({"error": "unknown tier", "which": "tier", "tier": tier}),
+                404,
+            )
+        if target not in _ent._TIER_FEATURES:
+            return (
+                jsonify(
+                    {
+                        "error": "unknown target",
+                        "which": "target",
+                        "target": target,
+                    }
+                ),
+                404,
+            )
+        body = _ent.preview_at(tier, target)
+        if body is None:
+            return (
+                jsonify(
+                    {
+                        "error": "preview-at failed",
+                        "tier": tier,
+                        "target": target,
+                    }
+                ),
+                404,
+            )
+        return jsonify({"tier": tier, "target": target, "preview": body})
+    except Exception as exc:
+        logger.warning("api_entitlement_preview_at: error: %s", exc)
+        return jsonify({"error": "preview-at failed"}), 500
+
+
+@bp_entitlement.route("/api/entitlement/preview-at-batch")
+def api_entitlement_preview_at_batch():
+    """``GET /api/entitlement/preview-at-batch?tier=<perspective>
+    &targets=a,b,c`` -- what-if + batch sibling of
+    ``/api/entitlement/preview-at``.
+
+    Where ``/preview-at`` hydrates ONE cumulative-state row from a
+    hypothetical perspective, this hydrates N rows for a caller-supplied
+    subset of target tiers off a single round-trip. Fixed-perspective
+    multi-target companion of ``/preview-at`` and
+    caller-supplied-targets sibling of ``/preview-batch`` (which walks
+    :data:`_PURCHASABLE_TIERS` unconditionally). Fills the ``_at_batch``
+    slot alongside ``/api/entitlement/tier-spec-at-batch``,
+    ``/api/entitlement/feature-spec-at-batch``,
+    ``/api/entitlement/runtime-spec-at-batch``.
+
+    Use case: a pricing-comparison matrix UI ("from my perspective tier,
+    render the cumulative-state row for OSS, Cloud Starter, Cloud Pro
+    and Enterprise") hydrates every column off ONE call instead of N
+    calls to ``/preview-at``.
+
+    Each ``tiers[]`` entry is byte-identical to a row from
+    :func:`entitlements.preview_at` (and therefore
+    :func:`entitlements._preview_row`) for the same target -- pinned by
+    the parity tests so the scalar / batch what-if accessors cannot
+    drift. Supplied ids are normalised (whitespace stripped, lowercased,
+    duplicates dropped, first-seen order preserved). Unknown ids do not
+    404 the call -- they are echoed in ``unknown[]`` so a partially-bad
+    caller still gets rows back for the valid ids alongside a list of
+    what was dropped.
+
+    Response shape (mirrors ``/tier-spec-at-batch`` /
+    ``/feature-spec-at-batch`` / ``/runtime-spec-at-batch`` plus a
+    ``perspective_tier`` echo)::
+
+        {
+          "tiers":                 [<preview_at row>, ...],
+          "unknown":               ["bogus_id", ...],
+          "perspective_tier":      "...",
+          "perspective_tier_rank": <int>,
+          "current_tier":          "...",
+          "current_tier_rank":     <int>,
+          "grace":                 <bool>,
+          "enforced":              <bool>,
+        }
+
+    - **400** when ``tier=`` is missing / blank or ``targets=`` is
+      missing / empty after normalisation
+    - **404** when ``tier`` is unknown (body carries ``which: "tier"``)
+    - **Never 5xxs**: a resolver failure short-circuits to the OSS-free
+      shape (empty rows, ``current_tier=oss``, ``grace=true``) with the
+      perspective tier echoed so the UI keeps rendering.
+    """
+    raw_tier = request.args.get("tier")
+    tier_in = (raw_tier or "").strip().lower()
+    if not tier_in:
+        return jsonify({"error": "missing tier"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        if tier_in not in _ent._TIER_ORDER:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "tier", "tier": tier_in}
+                ),
+                404,
+            )
+        targets = _parse_csv_arg("targets")
+        if not targets:
+            return (
+                jsonify({"error": "supply targets=<csv>"}),
+                400,
+            )
+        batch = _ent.preview_at_batch(tier_in, targets)
+        if batch is None:
+            batch = {"tiers": [], "unknown": []}
+        ent = _ent.get_entitlement()
+        batch["perspective_tier"] = tier_in
+        batch["perspective_tier_rank"] = _ent.tier_rank(tier_in)
+        batch["current_tier"] = ent.tier
+        batch["current_tier_rank"] = _ent.tier_rank(ent.tier)
+        batch["grace"] = bool(ent.grace)
+        batch["enforced"] = _ent.is_enforced()
+        return jsonify(batch)
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_preview_at_batch: error: %s", exc
+        )
+        return jsonify(
+            {
+                "tiers": [],
+                "unknown": [],
+                "perspective_tier": tier_in,
+                "perspective_tier_rank": 0,
+                "current_tier": "oss",
+                "current_tier_rank": 0,
+                "grace": True,
+                "enforced": False,
+            }
+        )
+
+
 @bp_entitlement.route("/api/entitlement/preview-path")
 def api_entitlement_preview_path():
     """``GET /api/entitlement/preview-path?from=<id>&to=<id>`` --

--- a/tests/test_entitlement_preview_at.py
+++ b/tests/test_entitlement_preview_at.py
@@ -1,0 +1,648 @@
+"""Tests for ``clawmetry.entitlements.preview_at`` +
+``clawmetry.entitlements.preview_at_batch`` + the matching
+``/api/entitlement/preview-at`` and ``/api/entitlement/preview-at-batch``
+endpoints.
+
+What-if sibling of :func:`preview` / :func:`preview_batch`: rendering the
+full :meth:`Entitlement.to_dict` snapshot at a target tier from the
+perspective of a hypothetical source tier. Fills the ``_at`` /
+``_at_batch`` slots in the preview family alongside
+:func:`tier_spec_at` / :func:`tier_spec_at_batch`,
+:func:`feature_spec_at` / :func:`feature_spec_at_batch`,
+:func:`runtime_spec_at` / :func:`runtime_spec_at_batch` so a
+pricing-comparison UI can call ``X_at(perspective, target)`` uniformly
+across the whole ``_at`` family.
+
+Pins:
+
+  - scalar body is byte-identical to :func:`_preview_row(target)` for
+    every perspective (the perspective is validated but does not shape
+    the row); pinned so the singular preview_at can never drift from
+    the private row builder that also backs :func:`preview_path` /
+    :func:`preview_path_batch`
+  - each batch row body is byte-identical to
+    :func:`preview_at(perspective, target)` for the same target (and
+    therefore also byte-identical to :func:`_preview_row(target)`) --
+    the scalar / batch no-drift contract
+  - full :meth:`Entitlement.to_dict` shape with ``source="preview"``
+    and ``grace=False`` so concrete per-tier capacity surfaces (a
+    grace-mode preview would zero those out)
+  - ``trial`` IS accepted as both perspective and target (lenient
+    ``_at`` posture matching :func:`tier_spec_at`) -- unlike singular
+    :func:`preview` which rejects trial
+  - inputs normalised (whitespace stripped, lowercased, duplicates
+    dropped, first-seen order preserved)
+  - unknown target ids echoed in ``unknown[]`` instead of
+    short-circuiting; unknown perspective ``tier`` returns ``None``
+    (helper) / 400 (missing / blank) / 404 (unknown)
+  - resolver-independent -- grace vs enforce yields byte-identical rows
+  - never raises -- a per-row failure short-circuits that id into
+    ``unknown[]`` and the rest of the batch keeps building; the
+    endpoint always returns a 200 with the grace envelope on resolver
+    crash so the pricing-page UI keeps rendering
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+
+_ENVELOPE_KEYS = {
+    "perspective_tier",
+    "perspective_tier_rank",
+    "current_tier",
+    "current_tier_rank",
+    "grace",
+    "enforced",
+}
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    """Fresh entitlements module with HOME pointed at an empty tmp dir
+    so no real ~/.clawmetry/license.key or cloud_plan.json leaks in.
+    Enforcement off by default -- ``preview_at`` is independent of
+    either knob, so the fixture only needs to keep the live resolver
+    from surprising the test."""
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from flask import Flask
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# ── scalar helper: perspective handling ──────────────────────────────────────
+
+
+def test_scalar_unknown_perspective_returns_none(ent):
+    assert ent.preview_at("bogus", "cloud_pro") is None
+
+
+def test_scalar_blank_perspective_returns_none(ent):
+    assert ent.preview_at("", "cloud_pro") is None
+    assert ent.preview_at("   ", "cloud_pro") is None
+
+
+def test_scalar_none_perspective_returns_none(ent):
+    assert ent.preview_at(None, "cloud_pro") is None
+
+
+def test_scalar_int_perspective_returns_none(ent):
+    assert ent.preview_at(0, "cloud_pro") is None
+
+
+def test_scalar_perspective_whitespace_and_case_normalised(ent):
+    got = ent.preview_at("  CLOUD_PRO  ", "cloud_pro")
+    assert got is not None
+    assert got["tier"] == "cloud_pro"
+
+
+def test_scalar_trial_accepted_as_perspective(ent):
+    got = ent.preview_at(ent.TIER_TRIAL, "cloud_pro")
+    assert got is not None
+    assert got["tier"] == "cloud_pro"
+
+
+# ── scalar helper: target handling ───────────────────────────────────────────
+
+
+def test_scalar_unknown_target_returns_none(ent):
+    assert ent.preview_at("cloud_pro", "bogus") is None
+
+
+def test_scalar_blank_target_returns_none(ent):
+    assert ent.preview_at("cloud_pro", "") is None
+    assert ent.preview_at("cloud_pro", "   ") is None
+
+
+def test_scalar_none_target_returns_none(ent):
+    assert ent.preview_at("cloud_pro", None) is None
+
+
+def test_scalar_trial_accepted_as_target(ent):
+    """Unlike :func:`preview` (which rejects trial), :func:`preview_at`
+    accepts trial as a target -- lenient ``_at`` posture."""
+    got = ent.preview_at("cloud_pro", ent.TIER_TRIAL)
+    assert got is not None
+    assert got["tier"] == ent.TIER_TRIAL
+
+
+def test_scalar_target_whitespace_and_case_normalised(ent):
+    got = ent.preview_at("cloud_pro", "  CLOUD_PRO  ")
+    assert got is not None
+    assert got["tier"] == "cloud_pro"
+
+
+# ── scalar helper: row shape + parity ────────────────────────────────────────
+
+
+def test_scalar_row_shape_matches_preview_batch(ent):
+    """The scalar row shape matches every row in
+    :func:`preview_batch` byte-for-byte -- same
+    ``Entitlement.to_dict`` shape, ``source="preview"``,
+    ``grace=False``."""
+    expected = set(ent._build(ent.TIER_CLOUD_PRO, "preview").to_dict().keys())
+    row = ent.preview_at("cloud_pro", "cloud_pro")
+    assert row is not None
+    assert set(row.keys()) == expected
+
+
+def test_scalar_parity_with_preview_row_across_all_perspectives(ent):
+    """For every (perspective, target) pair, the scalar row is
+    byte-identical to :func:`_preview_row(target)` -- the perspective is
+    validated but does not shape the row. Pins the scalar-and-private-row
+    no-drift contract."""
+    for perspective in ent._TIER_ORDER:
+        for target in ent._TIER_ORDER:
+            assert ent.preview_at(perspective, target) == ent._preview_row(
+                target
+            ), (perspective, target)
+
+
+def test_scalar_source_is_preview(ent):
+    """Every scalar row carries ``source="preview"`` so a UI never
+    mistakes it for a live entitlement."""
+    for perspective in ent._TIER_ORDER:
+        for target in ent._TIER_ORDER:
+            row = ent.preview_at(perspective, target)
+            assert row is not None
+            assert row["source"] == "preview"
+
+
+def test_scalar_grace_is_false(ent):
+    """Every scalar row carries ``grace=False`` so per-tier capacity
+    surfaces -- a grace-mode preview would zero those out."""
+    for perspective in ent._TIER_ORDER:
+        for target in ent._TIER_ORDER:
+            row = ent.preview_at(perspective, target)
+            assert row is not None
+            assert row["grace"] is False
+            assert row["enforced"] is True
+
+
+def test_scalar_perspective_does_not_shape_row(ent):
+    """The perspective is validated but the returned row is identical
+    across all perspectives -- byte-parity with :func:`_preview_row`."""
+    baseline = ent.preview_at("oss", "cloud_pro")
+    for perspective in ent._TIER_ORDER:
+        assert ent.preview_at(perspective, "cloud_pro") == baseline, perspective
+
+
+# ── batch helper: perspective handling ───────────────────────────────────────
+
+
+def test_batch_unknown_perspective_returns_none(ent):
+    assert ent.preview_at_batch("bogus", ["oss"]) is None
+
+
+def test_batch_blank_perspective_returns_none(ent):
+    assert ent.preview_at_batch("", ["oss"]) is None
+    assert ent.preview_at_batch("   ", ["oss"]) is None
+
+
+def test_batch_none_perspective_returns_none(ent):
+    assert ent.preview_at_batch(None, ["oss"]) is None
+
+
+def test_batch_int_perspective_returns_none(ent):
+    assert ent.preview_at_batch(0, ["oss"]) is None
+
+
+def test_batch_perspective_whitespace_and_case_normalised(ent):
+    got = ent.preview_at_batch("  CLOUD_PRO  ", ["cloud_pro"])
+    assert got is not None
+    assert got["tiers"][0]["tier"] == "cloud_pro"
+
+
+def test_batch_trial_accepted_as_perspective(ent):
+    got = ent.preview_at_batch(ent.TIER_TRIAL, [ent.TIER_TRIAL])
+    assert got is not None
+    assert got["tiers"][0]["tier"] == ent.TIER_TRIAL
+
+
+# ── batch helper: targets input handling ─────────────────────────────────────
+
+
+def test_batch_empty_targets_returns_empty_envelope(ent):
+    got = ent.preview_at_batch("cloud_pro", [])
+    assert got == {"tiers": [], "unknown": []}
+
+
+def test_batch_none_targets_returns_empty_envelope(ent):
+    got = ent.preview_at_batch("cloud_pro", None)
+    assert got == {"tiers": [], "unknown": []}
+
+
+def test_batch_targets_string_csv_input(ent):
+    got = ent.preview_at_batch(
+        "cloud_pro", "oss,cloud_starter,cloud_pro"
+    )
+    assert got is not None
+    assert [row["tier"] for row in got["tiers"]] == [
+        "oss",
+        "cloud_starter",
+        "cloud_pro",
+    ]
+
+
+def test_batch_targets_whitespace_and_case_normalised(ent):
+    got = ent.preview_at_batch("cloud_pro", ["  OSS ", "Cloud_Pro"])
+    assert got is not None
+    assert [row["tier"] for row in got["tiers"]] == ["oss", "cloud_pro"]
+
+
+def test_batch_targets_duplicates_dropped_first_seen_wins(ent):
+    got = ent.preview_at_batch(
+        "cloud_pro", ["oss", "cloud_pro", "oss", "cloud_pro"]
+    )
+    assert got is not None
+    assert [row["tier"] for row in got["tiers"]] == ["oss", "cloud_pro"]
+
+
+def test_batch_targets_supply_order_preserved(ent):
+    got = ent.preview_at_batch(
+        "cloud_pro", ["cloud_pro", "oss", "enterprise", "cloud_starter"]
+    )
+    assert got is not None
+    assert [row["tier"] for row in got["tiers"]] == [
+        "cloud_pro",
+        "oss",
+        "enterprise",
+        "cloud_starter",
+    ]
+
+
+def test_batch_targets_unknown_ids_echoed_in_unknown(ent):
+    got = ent.preview_at_batch(
+        "cloud_pro", ["oss", "bogus", "cloud_pro", "also_bogus"]
+    )
+    assert got is not None
+    assert [row["tier"] for row in got["tiers"]] == ["oss", "cloud_pro"]
+    assert got["unknown"] == ["bogus", "also_bogus"]
+
+
+def test_batch_targets_unknown_only_returns_empty_tiers(ent):
+    got = ent.preview_at_batch("cloud_pro", ["bogus", "also_bogus"])
+    assert got is not None
+    assert got["tiers"] == []
+    assert got["unknown"] == ["bogus", "also_bogus"]
+
+
+def test_batch_trial_accepted_as_target(ent):
+    """Lenient ``_at`` posture matching :func:`preview_at` -- trial is
+    a valid target even though ``preview_batch`` excludes it."""
+    got = ent.preview_at_batch("cloud_pro", [ent.TIER_TRIAL])
+    assert got is not None
+    assert got["tiers"][0]["tier"] == ent.TIER_TRIAL
+
+
+# ── batch helper: row shape + parity ─────────────────────────────────────────
+
+
+def test_batch_row_shape_matches_to_dict(ent):
+    expected = set(ent._build(ent.TIER_CLOUD_PRO, "preview").to_dict().keys())
+    got = ent.preview_at_batch(
+        "cloud_pro", ["oss", "cloud_pro", "enterprise"]
+    )
+    assert got is not None
+    for row in got["tiers"]:
+        assert set(row.keys()) == expected
+
+
+def test_batch_parity_with_scalar_preview_at(ent):
+    """For every (perspective, target) pair, the batch row is
+    byte-identical to the scalar :func:`preview_at`. Pins the
+    scalar/batch no-drift contract."""
+    for perspective in ent._TIER_ORDER:
+        got = ent.preview_at_batch(perspective, list(ent._TIER_ORDER))
+        assert got is not None
+        rows_by_id = {row["tier"]: row for row in got["tiers"]}
+        for target in ent._TIER_ORDER:
+            assert rows_by_id[target] == ent.preview_at(
+                perspective, target
+            ), (perspective, target)
+
+
+def test_batch_parity_with_preview_row(ent):
+    """Each returned row also matches :func:`_preview_row(target)` --
+    three-way parity (scalar / private / batch), pinning the same
+    invariant :func:`preview_path` / :func:`preview_path_batch` rely on."""
+    for perspective in ent._TIER_ORDER:
+        got = ent.preview_at_batch(perspective, list(ent._TIER_ORDER))
+        assert got is not None
+        for row in got["tiers"]:
+            assert row == ent._preview_row(row["tier"]), (
+                perspective,
+                row["tier"],
+            )
+
+
+def test_batch_source_is_preview(ent):
+    got = ent.preview_at_batch("cloud_pro", list(ent._TIER_ORDER))
+    assert got is not None
+    for row in got["tiers"]:
+        assert row["source"] == "preview"
+
+
+def test_batch_grace_is_false(ent):
+    got = ent.preview_at_batch("cloud_pro", list(ent._TIER_ORDER))
+    assert got is not None
+    for row in got["tiers"]:
+        assert row["grace"] is False
+        assert row["enforced"] is True
+
+
+def test_batch_perspective_does_not_shape_rows(ent):
+    """Same targets across shifting perspective yields byte-identical
+    tiers[] -- confirms the perspective is validated only, not folded
+    into the row body."""
+    baseline = ent.preview_at_batch(
+        "oss", ["oss", "cloud_pro", "enterprise"]
+    )
+    for perspective in ent._TIER_ORDER:
+        got = ent.preview_at_batch(
+            perspective, ["oss", "cloud_pro", "enterprise"]
+        )
+        assert got == baseline, perspective
+
+
+# ── resolver independence ────────────────────────────────────────────────────
+
+
+def test_scalar_resolver_independent_across_enforcement(ent, monkeypatch):
+    grace = ent.preview_at("cloud_pro", "cloud_pro")
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    enforced = ent.preview_at("cloud_pro", "cloud_pro")
+    assert grace == enforced
+
+
+def test_batch_resolver_independent_across_enforcement(ent, monkeypatch):
+    grace = ent.preview_at_batch(
+        "cloud_pro", ["oss", "cloud_pro", "enterprise"]
+    )
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    enforced = ent.preview_at_batch(
+        "cloud_pro", ["oss", "cloud_pro", "enterprise"]
+    )
+    assert grace == enforced
+
+
+# ── never-raises ─────────────────────────────────────────────────────────────
+
+
+def test_batch_never_raises_when_row_builder_crashes(ent, monkeypatch):
+    """A per-row failure short-circuits that id into ``unknown[]`` and
+    the rest of the batch keeps building."""
+    orig = ent._preview_row
+
+    def _boom(tier):
+        if tier == "cloud_pro":
+            raise RuntimeError("boom")
+        return orig(tier)
+
+    monkeypatch.setattr(ent, "_preview_row", _boom)
+    got = ent.preview_at_batch(
+        "enterprise", ["oss", "cloud_pro", "enterprise"]
+    )
+    assert got is not None
+    assert [row["tier"] for row in got["tiers"]] == ["oss", "enterprise"]
+    assert got["unknown"] == ["cloud_pro"]
+
+
+# ── HTTP endpoint: /preview-at ───────────────────────────────────────────────
+
+
+def test_endpoint_scalar_returns_row(client, ent):
+    resp = client.get(
+        "/api/entitlement/preview-at?tier=cloud_pro&target=cloud_pro"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["tier"] == "cloud_pro"
+    assert body["target"] == "cloud_pro"
+    assert body["preview"]["tier"] == "cloud_pro"
+
+
+def test_endpoint_scalar_target_trial_accepted(client, ent):
+    resp = client.get(
+        "/api/entitlement/preview-at?tier=cloud_pro&target=trial"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["preview"]["tier"] == ent.TIER_TRIAL
+
+
+def test_endpoint_scalar_missing_tier_returns_400(client, ent):
+    resp = client.get("/api/entitlement/preview-at?target=cloud_pro")
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "missing tier"
+
+
+def test_endpoint_scalar_missing_target_returns_400(client, ent):
+    resp = client.get("/api/entitlement/preview-at?tier=cloud_pro")
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "missing target"
+
+
+def test_endpoint_scalar_unknown_tier_returns_404(client, ent):
+    resp = client.get(
+        "/api/entitlement/preview-at?tier=bogus&target=cloud_pro"
+    )
+    assert resp.status_code == 404
+    body = resp.get_json()
+    assert body["error"] == "unknown tier"
+    assert body["which"] == "tier"
+    assert body["tier"] == "bogus"
+
+
+def test_endpoint_scalar_unknown_target_returns_404(client, ent):
+    resp = client.get(
+        "/api/entitlement/preview-at?tier=cloud_pro&target=bogus"
+    )
+    assert resp.status_code == 404
+    body = resp.get_json()
+    assert body["error"] == "unknown target"
+    assert body["which"] == "target"
+    assert body["target"] == "bogus"
+
+
+def test_endpoint_scalar_lowercases_and_trims(client, ent):
+    resp = client.get(
+        "/api/entitlement/preview-at?tier=%20CLOUD_PRO%20&target=%20CLOUD_PRO%20"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["tier"] == "cloud_pro"
+    assert body["target"] == "cloud_pro"
+
+
+def test_endpoint_scalar_parity_with_helper(client, ent):
+    for perspective in ent._TIER_ORDER:
+        for target in ent._TIER_ORDER:
+            resp = client.get(
+                f"/api/entitlement/preview-at"
+                f"?tier={perspective}&target={target}"
+            )
+            assert resp.status_code == 200, (perspective, target)
+            assert resp.get_json()["preview"] == ent.preview_at(
+                perspective, target
+            ), (perspective, target)
+
+
+# ── HTTP endpoint: /preview-at-batch ─────────────────────────────────────────
+
+
+def test_endpoint_batch_returns_rows_and_envelope(client, ent):
+    resp = client.get(
+        "/api/entitlement/preview-at-batch"
+        "?tier=cloud_pro&targets=oss,cloud_pro,enterprise"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert [row["tier"] for row in body["tiers"]] == [
+        "oss",
+        "cloud_pro",
+        "enterprise",
+    ]
+    assert body["unknown"] == []
+    assert _ENVELOPE_KEYS.issubset(body.keys())
+    assert body["perspective_tier"] == "cloud_pro"
+    assert body["perspective_tier_rank"] == ent.tier_rank("cloud_pro")
+
+
+def test_endpoint_batch_missing_tier_returns_400(client, ent):
+    resp = client.get(
+        "/api/entitlement/preview-at-batch?targets=oss"
+    )
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "missing tier"
+
+
+def test_endpoint_batch_blank_tier_returns_400(client, ent):
+    resp = client.get(
+        "/api/entitlement/preview-at-batch?tier=%20%20&targets=oss"
+    )
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "missing tier"
+
+
+def test_endpoint_batch_unknown_tier_returns_404(client, ent):
+    resp = client.get(
+        "/api/entitlement/preview-at-batch?tier=bogus&targets=oss"
+    )
+    assert resp.status_code == 404
+    body = resp.get_json()
+    assert body["error"] == "unknown tier"
+    assert body["which"] == "tier"
+    assert body["tier"] == "bogus"
+
+
+def test_endpoint_batch_missing_targets_returns_400(client, ent):
+    resp = client.get(
+        "/api/entitlement/preview-at-batch?tier=cloud_pro"
+    )
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "supply targets=<csv>"
+
+
+def test_endpoint_batch_blank_targets_returns_400(client, ent):
+    resp = client.get(
+        "/api/entitlement/preview-at-batch?tier=cloud_pro&targets=,,,"
+    )
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "supply targets=<csv>"
+
+
+def test_endpoint_batch_unknown_only_returns_200(client, ent):
+    resp = client.get(
+        "/api/entitlement/preview-at-batch"
+        "?tier=cloud_pro&targets=bogus,also_bogus"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["tiers"] == []
+    assert body["unknown"] == ["bogus", "also_bogus"]
+    assert body["perspective_tier"] == "cloud_pro"
+
+
+def test_endpoint_batch_lowercases_tier_and_targets(client, ent):
+    resp = client.get(
+        "/api/entitlement/preview-at-batch"
+        "?tier=CLOUD_PRO&targets=OSS,Cloud_Pro"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["perspective_tier"] == "cloud_pro"
+    assert [row["tier"] for row in body["tiers"]] == ["oss", "cloud_pro"]
+
+
+def test_endpoint_batch_envelope_carries_current_tier(client, ent):
+    resp = client.get(
+        "/api/entitlement/preview-at-batch?tier=cloud_pro&targets=oss"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    resolved = ent.get_entitlement()
+    assert body["current_tier"] == resolved.tier
+    assert body["current_tier_rank"] == ent.tier_rank(resolved.tier)
+    assert body["grace"] is bool(resolved.grace)
+    assert body["enforced"] == ent.is_enforced()
+
+
+def test_endpoint_batch_trial_accepted_as_target(client, ent):
+    resp = client.get(
+        "/api/entitlement/preview-at-batch?tier=cloud_pro&targets=trial"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["tiers"][0]["tier"] == ent.TIER_TRIAL
+
+
+def test_endpoint_batch_row_parity_with_helper(client, ent):
+    resp = client.get(
+        "/api/entitlement/preview-at-batch"
+        "?tier=cloud_pro&targets=oss,cloud_starter,cloud_pro,enterprise"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    helper = ent.preview_at_batch(
+        "cloud_pro", ["oss", "cloud_starter", "cloud_pro", "enterprise"]
+    )
+    assert body["tiers"] == helper["tiers"]
+    assert body["unknown"] == helper["unknown"]
+
+
+def test_endpoint_batch_never_5xxs_when_resolver_crashes(
+    client, ent, monkeypatch
+):
+    def _boom(*_a, **_kw):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(ent, "preview_at_batch", _boom)
+    resp = client.get(
+        "/api/entitlement/preview-at-batch?tier=cloud_pro&targets=oss"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["tiers"] == []
+    assert body["unknown"] == []
+    assert body["perspective_tier"] == "cloud_pro"
+    assert body["current_tier"] == "oss"
+    assert body["grace"] is True
+    assert body["enforced"] is False


### PR DESCRIPTION
## Summary

What-if sibling of `preview` / `preview_batch`: renders the full `Entitlement.to_dict` cumulative-state snapshot at a target tier from the perspective of a hypothetical `perspective_tier`. Fills the `_at` / `_at_batch` slots in the preview family alongside `tier_spec_at` / `tier_spec_at_batch`, `feature_spec_at` / `feature_spec_at_batch`, `runtime_spec_at` / `runtime_spec_at_batch` so a pricing-comparison UI can call `X_at(perspective, target)` uniformly across the whole `_at` family off ONE request shape.

- Module-level `preview_at(perspective_tier, target_tier)` -- scalar body is byte-identical to `_preview_row(target)` for every perspective (the perspective is validated but does not shape the row). Pinned by parity tests so the singular can never drift from the private row builder that also backs `preview_path` / `preview_path_batch`.
- Module-level `preview_at_batch(perspective_tier, targets)` -- fixed-perspective multi-target companion, `{tiers, unknown}` envelope. Per-row body byte-identical to `preview_at(perspective, target)` for the same target (scalar / batch no-drift contract).
- `GET /api/entitlement/preview-at?tier=<perspective>&target=<id>` -- 400 on missing / blank input, 404 on unknown perspective (`which: "tier"`) or unknown target (`which: "target"`), never 5xxs on resolver crash.
- `GET /api/entitlement/preview-at-batch?tier=<perspective>&targets=a,b,c` -- envelope mirrors `/tier-spec-at-batch`: `{tiers, unknown, perspective_tier, perspective_tier_rank, current_tier, current_tier_rank, grace, enforced}`. Unknown target ids are echoed in `unknown[]` instead of short-circuiting so a partially-bad caller still gets rows back for the valid ids.

Fills the preview-family gap in the `_at` / `_at_batch` slot:

| helper                | slot                | status          |
|-----------------------|---------------------|-----------------|
| `preview`             | scalar (current)    | already merged  |
| `preview_batch`       | batch (current)     | already merged  |
| `preview_path`        | path                | already merged  |
| `preview_path_batch`  | path batch          | already merged  |
| `preview_at`          | scalar (hypothetical) | **this PR**   |
| `preview_at_batch`    | batch (hypothetical) | **this PR**    |

Posture matches the rest of the `_at` family (mirrors `tier_spec_at` / `tier_spec_at_batch`):

- Perspective + target ids normalised via `_normalise_csv` on the batch (whitespace stripped, lowercased, duplicates dropped, first-seen order preserved).
- Unknown target ids echoed in `unknown[]` instead of short-circuiting -- a partially-bad caller still gets rows back for the valid ids alongside a list of what was dropped.
- `trial` IS accepted as both perspective (any id in `_TIER_ORDER`) and target (any id in `_TIER_FEATURES`, which is a superset of `_PURCHASABLE_TIERS`). Singular `preview` rejects trial; `preview_at` accepts it -- the lenient `_at` posture matching every other `_at` helper.
- Row body carries `source="preview"` and `grace=False` so concrete per-tier capacity (`channel_limit`, `retention_days`, `node_limit`) surfaces. A grace-mode preview would zero those out and defeat the purpose.
- Resolver-independent: catalogue-derived, so grace vs enforce yields byte-identical rows.
- Never raises: a per-target crash short-circuits that id into `unknown[]`; endpoint resolver failure short-circuits to a grace-shape envelope (no 5xx).

**Grace-only, read-only**: no gate enforced, no behaviour change against the currently-resolved entitlement -- these are new read-only endpoints.

## Test plan

- [x] `python3 -m py_compile clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_preview_at.py` -- clean
- [x] `ruff check clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_preview_at.py` -- all checks passed
- [x] `python3 -m pytest tests/test_entitlement_preview_at.py -q` -- **60 passed**
- [x] Adjacent regression sweep -- **196 passed** across `test_entitlement_preview`, `test_entitlement_preview_batch`, `test_entitlement_preview_path`, `test_entitlement_preview_path_batch`, `test_entitlement_preview_path_batch_helper`, `test_entitlement_tier_spec_at_batch`, `test_entitlement_api`.

### Coverage in `tests/test_entitlement_preview_at.py`

Helper + endpoint covered by parametrised tests:

- scalar shape: full `Entitlement.to_dict` keyset with `source="preview"` and `grace=False`; byte-parity with `_preview_row(target)` across every `(perspective, target)` pair in `_TIER_ORDER × _TIER_ORDER`; perspective does not shape the row (byte-identical rows across shifting perspective).
- batch shape: `{tiers, unknown}` envelope; per-row keyset matches `Entitlement.to_dict`; per-row byte-parity with `preview_at(perspective, target)` and transitive parity with `_preview_row(target)`; source echo and grace=False stay pinned; perspective does not shape rows (batch-level byte-parity across shifting perspective).
- input handling: perspective + target whitespace / casing normalised; duplicates dropped; supply-order preserved; unknown target ids echoed in `unknown[]`; unknown-only returns `{"tiers": [], "unknown": [...]}`; `trial` accepted as both perspective and target.
- resolver-independence: grace vs enforce byte-identical for both scalar and batch.
- never-raise: per-row `_preview_row` crash short-circuits that id into `unknown[]` and the rest of the batch keeps building.
- HTTP scalar (`/preview-at`): row returned; 400 on missing / blank `tier` or `target`; 404 on unknown `tier` (body carries `which: "tier"`) or unknown `target` (body carries `which: "target"`); 200 with the trial row when target=`trial`; input lowercased / trimmed; body-parity with helper across every `(perspective, target)` pair.
- HTTP batch (`/preview-at-batch`): `_ENVELOPE_KEYS` shape (`{perspective_tier, perspective_tier_rank, current_tier, current_tier_rank, grace, enforced}`); source echo; per-row body-parity with helper; 400 on missing / blank `tier` / missing / blank `targets`; 404 on unknown source tier (body carries `which: "tier"`); 200 with bucketed unknowns for unknown target ids; input normalised; `trial` accepted as target; never-5xxs on a `preview_at_batch` monkeypatched crash (falls back to grace-shape envelope with `perspective_tier` echoed).

## Local operator verification checklist

The public-repo agent cannot exercise the live daemon, cloud snapshot, or browser. Please copy the changed files into your locally-installed clawmetry site-packages and verify against the real daemon before flipping ready-for-review:

```bash
# 1. Copy the changed files into the installed package
SP="$HOME/.clawmetry/lib/python$(python3 -c 'import sys;print(f"{sys.version_info.major}.{sys.version_info.minor}")')/site-packages/clawmetry"
cp clawmetry/entitlements.py "$SP/entitlements.py"
# routes/ isn't inside the package; on the default layout it lands at
# $HOME/.clawmetry/lib/python*/site-packages/routes/entitlement.py
find "$HOME/.clawmetry" -name entitlement.py -path '*routes*' -exec cp routes/entitlement.py {} \;

# 2. Purge stale bytecode so the new module actually loads
find "$HOME/.clawmetry" -type d -name __pycache__ -exec rm -rf {} +

# 3. Bounce the sync daemon so it re-imports
launchctl kickstart -k "gui/$(id -u)/com.clawmetry.sync"

# 4. Hit the new scalar endpoint (happy path)
curl -s 'http://localhost:8900/api/entitlement/preview-at?tier=cloud_pro&target=cloud_pro' | jq
# Expect: 200 with {tier, target, preview: {...full Entitlement.to_dict at cloud_pro...}}

# 5. Trial-as-target accepted (unlike /preview which 404s on trial)
curl -s 'http://localhost:8900/api/entitlement/preview-at?tier=cloud_pro&target=trial' | jq '.preview.tier'
# Expect: "trial"
curl -si 'http://localhost:8900/api/entitlement/preview?tier=trial' | head -1
# Expect: HTTP/1.1 404 (baseline -- /preview rejects trial)

# 6. Batch happy path
curl -s 'http://localhost:8900/api/entitlement/preview-at-batch?tier=cloud_pro&targets=oss,cloud_starter,cloud_pro,enterprise' | jq
# Expect: 200 with envelope {tiers[4], unknown: [], perspective_tier, perspective_tier_rank, current_tier, current_tier_rank, grace, enforced}

# 7. Parity with the live scalar sibling for every target
for tid in oss cloud_starter cloud_pro enterprise trial; do
  diff \
    <(curl -s "http://localhost:8900/api/entitlement/preview-at-batch?tier=cloud_pro&targets=$tid" | jq '.tiers[0]') \
    <(curl -s "http://localhost:8900/api/entitlement/preview-at?tier=cloud_pro&target=$tid"     | jq '.preview') \
  && echo "$tid: parity OK"
done
# Expect: "parity OK" for every target; no diffs.

# 8. Perspective does not shape rows (byte-parity across perspectives)
for p in oss cloud_starter cloud_pro enterprise trial; do
  diff \
    <(curl -s "http://localhost:8900/api/entitlement/preview-at-batch?tier=$p&targets=oss,cloud_pro,enterprise"        | jq '.tiers') \
    <(curl -s "http://localhost:8900/api/entitlement/preview-at-batch?tier=cloud_pro&targets=oss,cloud_pro,enterprise" | jq '.tiers') \
  && echo "$p: perspective-invariant OK"
done
# Expect: "perspective-invariant OK" for every perspective.

# 9. Error paths
curl -si 'http://localhost:8900/api/entitlement/preview-at' | head -1
# Expect: HTTP/1.1 400 (missing tier)
curl -si 'http://localhost:8900/api/entitlement/preview-at?tier=cloud_pro' | head -1
# Expect: HTTP/1.1 400 (missing target)
curl -si 'http://localhost:8900/api/entitlement/preview-at?tier=bogus&target=cloud_pro' | head -1
# Expect: HTTP/1.1 404 (unknown tier)
curl -si 'http://localhost:8900/api/entitlement/preview-at?tier=cloud_pro&target=bogus' | head -1
# Expect: HTTP/1.1 404 (unknown target)
curl -si 'http://localhost:8900/api/entitlement/preview-at-batch?tier=cloud_pro' | head -1
# Expect: HTTP/1.1 400 (missing targets)
curl -s  'http://localhost:8900/api/entitlement/preview-at-batch?tier=cloud_pro&targets=cloud_pro,nope_tier' | jq '.unknown'
# Expect: ["nope_tier"] -- 200, not 404

# 10. Decrypt the live cloud snapshot in the browser + sanity-check no
# regressions on the existing /preview, /preview-batch, /preview-path,
# /preview-path-batch, /tier-spec-at, /tier-spec-at-batch,
# /feature-spec-at, /feature-spec-at-batch endpoints.
```

If everything looks right, flip to ready-for-review and merge in the normal flow. Only the local operator has access to the live daemon and snapshot for step 10, which is why this PR stays draft until then.

Non-overlapping with open PR #3506 (`tier_catalog_path_batch`): this PR appends new helpers immediately after `_preview_row` and before `preview_path` in `entitlements.py`, and new routes between `/preview-batch` and `/preview-path` in `routes/entitlement.py` -- both a clearly separate surface from #3506, which lives near the tier-catalog-path scalar helper.

The next-phase work (P3 / P4 / P6 -- cloud-side entitlement minting, `clawmetry-pro` package download, enterprise SSO) needs the private `clawmetry-cloud` / `clawmetry-pro` repos and is out of scope for this remote session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01X3tXzwNABjV6XFYdEjKWaD)_