### PR TITLE
feat(entitlement): tier_catalog_at_path + tier_catalog_at_path_batch + 2 endpoints

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -9390,6 +9390,132 @@ def tier_catalog_path_batch(from_tier: str, to_tiers) -> dict | None:
     return {"tiers": rows, "unknown": unknown}
 
 
+def tier_catalog_at_path(
+    perspective_tier: str, from_tier: str, to_tier: str
+) -> list[dict] | None:
+    """What-if sibling of :func:`tier_catalog_path`: per-rung tier ladder
+    path between ``from_tier`` and ``to_tier`` rendered from a
+    hypothetical ``perspective_tier``.
+
+    Path-shaped companion to :func:`tier_catalog_at`: where
+    ``tier_catalog_at`` renders the full ladder at ONE hypothetical rung,
+    ``tier_catalog_at_path`` walks the full rung path between two
+    endpoints. Fills the ``_at_path`` slot for the tier-catalog family
+    alongside :func:`tier_catalog` (scalar current), :func:`tier_catalog_at`
+    (scalar what-if), :func:`tier_catalog_at_batch` (batch what-if),
+    :func:`tier_catalog_path` (path current) and
+    :func:`tier_catalog_path_batch` (batch path) so a pricing-comparison
+    walkthrough surface can call ``X_at_path(perspective, from, to)``
+    uniformly across the whole ``_at_path`` family.
+
+    Body posture matches :func:`preview_at_path` /
+    :func:`preview_at`: perspective is validated against
+    :data:`_TIER_ORDER` but does NOT shape the rows. The per-rung body
+    is byte-identical to a row from :func:`tier_catalog_path` for the
+    same ``(from_tier, to_tier)`` pair -- pinned by parity tests so the
+    what-if path helper cannot drift from the current-perspective
+    sibling that also backs :func:`tier_catalog_path_batch`.
+
+    Perspective acceptance is lenient (matches :func:`tier_catalog_at`
+    and every other ``_at`` helper): any id in :data:`_TIER_ORDER` is
+    accepted, including :data:`TIER_TRIAL`. Endpoint acceptance mirrors
+    :func:`tier_catalog_path`: both ``from_tier`` and ``to_tier`` accept
+    any id in :data:`_TIER_FEATURES` (trial is a valid endpoint via the
+    lateral / identity branch even though the walked intermediate rungs
+    exclude it -- it is not purchasable).
+
+    Returns ``None`` when any of the three ids is unknown; empty list
+    for identity (``from == to``). Resolver-independent: delegates to
+    :func:`tier_catalog_path`, which walks the static per-tier maps via
+    :func:`tier_catalog_at`, so grace vs enforce yields byte-identical
+    rows -- same property the rest of the ``_path`` family guarantees.
+
+    Never raises: a delegate failure logs a warning and returns
+    ``None`` so an upgrade-walkthrough surface keeps rendering instead
+    of breaking.
+    """
+    try:
+        p = (perspective_tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if p not in _TIER_ORDER:
+        return None
+    try:
+        return tier_catalog_path(from_tier, to_tier)
+    except Exception as exc:
+        logger.warning("entitlements: tier_catalog_at_path failed: %s", exc)
+        return None
+
+
+def tier_catalog_at_path_batch(
+    perspective_tier: str, from_tier: str, to_tiers
+) -> dict | None:
+    """Batch sibling of :func:`tier_catalog_at_path`: per-rung tier-
+    ladder path rows for a caller-supplied subset of destination tiers
+    all walked from a single ``from_tier`` from a hypothetical
+    ``perspective_tier`` in ONE round-trip.
+
+    Composes :func:`tier_catalog_at_path` (scalar what-if path) and
+    :func:`tier_catalog_path_batch` (multi-destination current-
+    perspective path). Fills the ``_at_path_batch`` slot for the tier-
+    catalog family alongside :func:`tier_catalog_at` /
+    :func:`tier_catalog_at_batch` / :func:`tier_catalog_at_path` so a
+    pricing-comparison walkthrough surface can call
+    ``X_at_path_batch(perspective, from, to_tiers)`` uniformly across
+    the whole ``_at_path_batch`` family.
+
+    Per-destination row shape mirrors :func:`tier_catalog_path_batch`::
+
+        {
+          "to":         "<tier id>",
+          "to_label":   "...",
+          "to_rank":    <int>,
+          "direction":  "upgrade" | "downgrade" | "lateral" | "identity",
+          "path":       [<tier_catalog_path row>, ...],
+        }
+
+    Envelope::
+
+        {
+          "tiers":   [<row>, ...],
+          "unknown": ["bogus_id", ...],
+        }
+
+    Body posture matches :func:`tier_catalog_at_path`: perspective is
+    validated against :data:`_TIER_ORDER` but does NOT shape rows. Each
+    row is byte-identical to a row from :func:`tier_catalog_path_batch`
+    for the same ``(from_tier, to_tiers)`` pair -- pinned by parity
+    tests so the batch what-if path helper cannot drift from the
+    current-perspective sibling.
+
+    Supplied destination ids are normalised via :func:`_normalise_csv`
+    (whitespace stripped, lowercased, duplicates dropped, first-seen
+    order preserved). Unknown destination ids land in ``unknown[]``
+    instead of short-circuiting the batch, matching every other
+    ``*_path_batch`` sibling's posture. ``trial`` IS accepted as a
+    destination via the lateral / identity branches, matching
+    :func:`tier_catalog_path_batch`.
+
+    Returns ``None`` for empty / unknown ``perspective_tier`` or
+    ``from_tier`` (caller renders "unknown tier" / 404). Never raises:
+    a per-destination failure short-circuits that id into ``unknown[]``
+    and the rest of the batch keeps building.
+    """
+    try:
+        p = (perspective_tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if p not in _TIER_ORDER:
+        return None
+    try:
+        return tier_catalog_path_batch(from_tier, to_tiers)
+    except Exception as exc:
+        logger.warning(
+            "entitlements: tier_catalog_at_path_batch failed: %s", exc
+        )
+        return None
+
+
 def lock_reason_path_batch(
     from_tier: str,
     to_tier: str,

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -9598,6 +9598,293 @@ def api_entitlement_tier_catalog_path_batch():
         )
 
 
+@bp_entitlement.route("/api/entitlement/tier-catalog-at-path")
+def api_entitlement_tier_catalog_at_path():
+    """``GET /api/entitlement/tier-catalog-at-path?tier=<perspective>
+    &from=<from>&to=<to>`` -- arbitrary-endpoint stepwise tier-ladder
+    path between any two tiers, rendered from a hypothetical
+    ``perspective_tier``.
+
+    What-if sibling of ``/tier-catalog-path``: same rung walk, same per-
+    rung body, plus a ``perspective_tier`` echo so a pricing-comparison
+    walkthrough surface can call ``X_at_path(perspective, from, to)``
+    uniformly across the whole ``_at_path`` slot of the tier-catalog
+    family (alongside ``/tier-catalog-at`` and ``/tier-catalog-at-batch``,
+    which fill the scalar-what-if and batch-what-if slots).
+
+    Body posture matches ``/tier-catalog-at``: perspective is validated
+    but does not shape the rows. Each row in ``path`` is byte-identical
+    to a row from ``/tier-catalog-path?from=<from>&to=<to>`` -- pinned
+    by parity tests. Perspective acceptance is lenient: ``trial`` IS
+    accepted (matching every other ``_at`` sibling).
+
+    Response shape::
+
+        {
+          "perspective_tier":      "<tier id>",
+          "perspective_tier_rank": <int>,
+          "from":                  "<tier id>",
+          "from_label":            "...",
+          "from_rank":             <int>,
+          "to":                    "<tier id>",
+          "to_label":              "...",
+          "to_rank":               <int>,
+          "direction":             "upgrade" | "downgrade" | "lateral" | "identity",
+          "path":                  [<tier-catalog-path row>, ...],
+          "current_tier":          "<tier id>",
+          "current_tier_rank":     <int>,
+          "grace":                 <bool>,
+          "enforced":              <bool>,
+        }
+
+    - **400** when ``tier=``, ``from=`` or ``to=`` is missing / blank
+    - **404** when any id is unknown (body carries ``which: "tier" |
+      "from" | "to"`` so the caller can point at the offender)
+    - **Never 5xxs**: a resolver failure short-circuits to 404 so an
+      upgrade-walkthrough surface keeps rendering instead of breaking.
+    """
+    p = (request.args.get("tier") or "").strip().lower()
+    f = (request.args.get("from") or "").strip().lower()
+    t = (request.args.get("to") or "").strip().lower()
+    if not p:
+        return jsonify({"error": "missing tier"}), 400
+    if not f:
+        return jsonify({"error": "missing from"}), 400
+    if not t:
+        return jsonify({"error": "missing to"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        if p not in _ent._TIER_ORDER:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "tier", "tier": p}
+                ),
+                404,
+            )
+        if f not in _ent._TIER_FEATURES:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "from", "from": f}
+                ),
+                404,
+            )
+        if t not in _ent._TIER_FEATURES:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "to", "to": t}
+                ),
+                404,
+            )
+        path = _ent.tier_catalog_at_path(p, f, t)
+        if path is None:
+            return (
+                jsonify(
+                    {
+                        "error": "unknown tier",
+                        "tier": p,
+                        "from": f,
+                        "to": t,
+                    }
+                ),
+                404,
+            )
+        from_rank = _ent.tier_rank(f)
+        to_rank = _ent.tier_rank(t)
+        if f == t:
+            direction = "identity"
+        elif from_rank == to_rank:
+            direction = "lateral"
+        elif to_rank > from_rank:
+            direction = "upgrade"
+        else:
+            direction = "downgrade"
+        try:
+            ent = _ent.get_entitlement()
+            current_tier = getattr(ent, "tier", "oss") or "oss"
+            grace = bool(getattr(ent, "grace", True))
+        except Exception:
+            current_tier = "oss"
+            grace = True
+        try:
+            enforced = bool(_ent.is_enforced())
+        except Exception:
+            enforced = False
+        return jsonify(
+            {
+                "perspective_tier": p,
+                "perspective_tier_rank": _ent.tier_rank(p),
+                "from": f,
+                "from_label": _ent.tier_label(f),
+                "from_rank": from_rank,
+                "to": t,
+                "to_label": _ent.tier_label(t),
+                "to_rank": to_rank,
+                "direction": direction,
+                "path": path,
+                "current_tier": current_tier,
+                "current_tier_rank": _ent.tier_rank(current_tier),
+                "grace": grace,
+                "enforced": enforced,
+            }
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_tier_catalog_at_path: error: %s", exc
+        )
+        return (
+            jsonify(
+                {
+                    "error": "unknown tier",
+                    "tier": p,
+                    "from": f,
+                    "to": t,
+                }
+            ),
+            404,
+        )
+
+
+@bp_entitlement.route("/api/entitlement/tier-catalog-at-path-batch")
+def api_entitlement_tier_catalog_at_path_batch():
+    """``GET /api/entitlement/tier-catalog-at-path-batch?tier=<perspective>
+    &from=<from>&to=a,b,c`` -- batch sibling of ``/tier-catalog-at-path``.
+
+    Where ``/tier-catalog-at-path`` walks the tier-ladder rungs between
+    ONE ``(from, to)`` pair from a hypothetical ``perspective_tier``,
+    this walks ONE ``from`` to N candidate ``to`` tiers in ONE round-
+    trip from the same hypothetical perspective -- the batch what-if
+    sibling of ``/tier-catalog-path-batch``, filling the
+    ``_at_path_batch`` slot for the tier-catalog family.
+
+    Body posture matches ``/tier-catalog-at``: perspective is validated
+    but does not shape rows. Each row in ``tiers[].path`` is byte-
+    identical to a row from ``/tier-catalog-path-batch`` for the same
+    ``(from, to)`` pair. Perspective acceptance is lenient: ``trial``
+    IS accepted (matching every other ``_at`` sibling). The GET+CSV
+    query surface matches the ``/tier-catalog-path-batch`` sibling
+    rather than the POST+JSON ``/preview-at-path-batch`` shape -- keeps
+    the tier-catalog family internally consistent.
+
+    Response shape (mirrors ``/tier-catalog-path-batch`` plus the
+    ``perspective_tier`` echo and the resolver-context tail every
+    ``_at*`` endpoint carries)::
+
+        {
+          "perspective_tier":      "<tier id>",
+          "perspective_tier_rank": <int>,
+          "from":                  "<tier id>",
+          "from_label":            "...",
+          "from_rank":             <int>,
+          "tiers": [
+            {
+              "to":        "<tier id>",
+              "to_label":  "...",
+              "to_rank":   <int>,
+              "direction": "upgrade" | "downgrade" | "lateral" | "identity",
+              "path":      [<tier-catalog-path row>, ...],
+            },
+            ...
+          ],
+          "unknown":               ["bogus_id", ...],
+          "current_tier":          "<tier id>",
+          "current_tier_rank":     <int>,
+          "grace":                 <bool>,
+          "enforced":              <bool>,
+        }
+
+    Supplied destination ids are normalised (whitespace stripped,
+    lowercased, duplicates dropped, first-seen order preserved).
+    Unknown destination ids do NOT 404 the call -- they are echoed in
+    ``unknown[]`` so a partially-bad caller still gets paths back for
+    the valid ids alongside a list of what was dropped, matching every
+    other ``*_path_batch`` sibling's posture.
+
+    - **400** when ``tier=`` or ``from=`` is missing / blank, or ``to=``
+      is missing / empty after normalisation
+    - **404** when ``tier`` or ``from`` is unknown (body carries
+      ``which: "tier" | "from"``)
+    - **200** with bucketed unknowns for unknown destination ids -- does
+      NOT 404 the call
+    - **Never 5xxs**: a synthesis failure short-circuits to an envelope
+      with empty rows so the matrix keeps rendering.
+    """
+    p = (request.args.get("tier") or "").strip().lower()
+    f = (request.args.get("from") or "").strip().lower()
+    if not p:
+        return jsonify({"error": "missing tier"}), 400
+    if not f:
+        return jsonify({"error": "missing from"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        if p not in _ent._TIER_ORDER:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "tier", "tier": p}
+                ),
+                404,
+            )
+        if f not in _ent._TIER_FEATURES:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "from", "from": f}
+                ),
+                404,
+            )
+        targets = _parse_csv_arg("to")
+        if not targets:
+            return jsonify({"error": "supply to=<csv>"}), 400
+        batch = _ent.tier_catalog_at_path_batch(p, f, targets)
+        if batch is None:
+            batch = {"tiers": [], "unknown": []}
+        try:
+            ent = _ent.get_entitlement()
+            current_tier = getattr(ent, "tier", "oss") or "oss"
+            grace = bool(getattr(ent, "grace", True))
+        except Exception:
+            current_tier = "oss"
+            grace = True
+        try:
+            enforced = bool(_ent.is_enforced())
+        except Exception:
+            enforced = False
+        return jsonify(
+            {
+                "perspective_tier": p,
+                "perspective_tier_rank": _ent.tier_rank(p),
+                "from": f,
+                "from_label": _ent.tier_label(f),
+                "from_rank": _ent.tier_rank(f),
+                "tiers": batch.get("tiers", []),
+                "unknown": batch.get("unknown", []),
+                "current_tier": current_tier,
+                "current_tier_rank": _ent.tier_rank(current_tier),
+                "grace": grace,
+                "enforced": enforced,
+            }
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_tier_catalog_at_path_batch: error: %s", exc
+        )
+        return jsonify(
+            {
+                "perspective_tier": p,
+                "perspective_tier_rank": 0,
+                "from": f,
+                "from_label": None,
+                "from_rank": -1,
+                "tiers": [],
+                "unknown": [],
+                "current_tier": "oss",
+                "current_tier_rank": 0,
+                "grace": True,
+                "enforced": False,
+            }
+        )
+
+
 @bp_entitlement.route("/api/entitlement/feature-spec-path-batch")
 def api_entitlement_feature_spec_path_batch():
     """``GET /api/entitlement/feature-spec-path-batch?from=<id>&to=<id>

--- a/tests/test_entitlement_tier_catalog_at_path.py
+++ b/tests/test_entitlement_tier_catalog_at_path.py
@@ -1,0 +1,813 @@
+"""Tests for ``clawmetry.entitlements.tier_catalog_at_path`` +
+``tier_catalog_at_path_batch`` and their two HTTP endpoints
+``GET /api/entitlement/tier-catalog-at-path`` +
+``GET /api/entitlement/tier-catalog-at-path-batch``.
+
+Path-shaped what-if sibling of :func:`tier_catalog_path` /
+:func:`tier_catalog_path_batch`: renders the FULL per-rung tier-ladder
+path between two tiers from a hypothetical ``perspective_tier`` in ONE
+round-trip. Fills the ``_at_path`` / ``_at_path_batch`` slots for the
+tier-catalog family so a pricing-comparison walkthrough surface can
+call ``X_at_path(perspective, from, to)`` uniformly across every
+``_at_path`` family member.
+
+Pins:
+
+* body byte-identical to :func:`tier_catalog_path` /
+  :func:`tier_catalog_path_batch` for every perspective -- the
+  perspective is validated but does NOT shape the rows (parity with
+  every other ``_at_path`` helper the ``preview_at_path`` family
+  ships).
+* per-rung row shape carries the same 4 keys as
+  :func:`tier_catalog_path` (``tier``, ``tier_label``, ``tier_rank``,
+  ``tiers``); each inner ``tiers`` list byte-equals
+  :func:`tier_catalog_at(rung)` for the same rung, so the ``_at`` /
+  ``_at_path`` / ``_at_batch`` / ``_at_path_batch`` catalog surfaces
+  cannot drift from each other.
+* ``trial`` accepted as perspective and as destination (matching
+  every other ``_at`` sibling's lenient posture, unlike
+  :func:`tier_catalog_path` which excludes trial from the walked
+  intermediate rungs but accepts it as an endpoint via the lateral /
+  identity branches).
+* case + whitespace normalisation on perspective, from, to.
+* helper is decoupled from the resolver -- grace vs enforce yields
+  byte-identical rows.
+* unknown / empty / garbage ids return ``None`` and never raise; a
+  per-destination failure short-circuits that id into ``unknown[]``
+  and the rest of the batch keeps building.
+* API scalar: 400 on missing args, 404 with ``which: "tier" | "from" |
+  "to"`` on unknown ids, 200 with the standard resolver-context tail
+  every ``_at*`` endpoint carries.
+* API batch: 400 on missing tier / from / empty to, 404 with
+  ``which: "tier" | "from"`` on unknown perspective / source, 200 with
+  bucketed ``unknown[]`` on partially-bad destination lists, never
+  5xxs on a synthesis failure.
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+
+_ROW_KEYS = {"tier", "tier_label", "tier_rank", "tiers"}
+_ITEM_KEYS = {"to", "to_label", "to_rank", "direction", "path"}
+_SCALAR_ENVELOPE_KEYS = {
+    "perspective_tier",
+    "perspective_tier_rank",
+    "from",
+    "from_label",
+    "from_rank",
+    "to",
+    "to_label",
+    "to_rank",
+    "direction",
+    "path",
+    "current_tier",
+    "current_tier_rank",
+    "grace",
+    "enforced",
+}
+_BATCH_ENVELOPE_KEYS = {
+    "perspective_tier",
+    "perspective_tier_rank",
+    "from",
+    "from_label",
+    "from_rank",
+    "tiers",
+    "unknown",
+    "current_tier",
+    "current_tier_rank",
+    "grace",
+    "enforced",
+}
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def enforced(monkeypatch, tmp_path):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from flask import Flask
+
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+def _all_tiers(mod):
+    return [
+        mod.TIER_OSS,
+        mod.TIER_CLOUD_FREE,
+        mod.TIER_TRIAL,
+        mod.TIER_CLOUD_STARTER,
+        mod.TIER_CLOUD_PRO,
+        mod.TIER_PRO,
+        mod.TIER_ENTERPRISE,
+    ]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# scalar helper: shape + happy path
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_scalar_returns_list(ent):
+    path = ent.tier_catalog_at_path(
+        ent.TIER_CLOUD_PRO, ent.TIER_OSS, ent.TIER_ENTERPRISE
+    )
+    assert isinstance(path, list)
+    assert len(path) >= 1
+
+
+def test_scalar_each_row_has_expected_shape(ent):
+    path = ent.tier_catalog_at_path(
+        ent.TIER_CLOUD_PRO, ent.TIER_OSS, ent.TIER_ENTERPRISE
+    )
+    for row in path:
+        assert isinstance(row, dict)
+        assert set(row.keys()) == _ROW_KEYS
+        assert isinstance(row["tier"], str)
+        assert isinstance(row["tier_label"], str)
+        assert isinstance(row["tier_rank"], int)
+        assert isinstance(row["tiers"], list)
+
+
+def test_scalar_identity_yields_empty(ent):
+    for tid in _all_tiers(ent):
+        assert (
+            ent.tier_catalog_at_path(ent.TIER_CLOUD_PRO, tid, tid) == []
+        )
+
+
+def test_scalar_lateral_yields_single_row(ent):
+    """Lateral (same rank, different id) yields a one-row path."""
+    # cloud_pro / self-hosted pro share rank 2 -- lateral endpoints.
+    path = ent.tier_catalog_at_path(
+        ent.TIER_CLOUD_STARTER, ent.TIER_CLOUD_PRO, ent.TIER_PRO
+    )
+    assert isinstance(path, list)
+    assert len(path) == 1
+    assert path[0]["tier"] == ent.TIER_PRO
+
+
+def test_scalar_upgrade_direction_walks_rungs(ent):
+    path = ent.tier_catalog_at_path(
+        ent.TIER_CLOUD_PRO, ent.TIER_OSS, ent.TIER_ENTERPRISE
+    )
+    ranks = [r["tier_rank"] for r in path]
+    assert ranks == sorted(ranks)
+
+
+def test_scalar_downgrade_direction_walks_rungs(ent):
+    path = ent.tier_catalog_at_path(
+        ent.TIER_CLOUD_PRO, ent.TIER_ENTERPRISE, ent.TIER_OSS
+    )
+    ranks = [r["tier_rank"] for r in path]
+    assert ranks == sorted(ranks, reverse=True)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# scalar helper: byte-parity with tier_catalog_path
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_scalar_body_parity_with_tier_catalog_path(ent):
+    """Body byte-identical to ``tier_catalog_path(from, to)`` for every
+    ``(perspective, from, to)`` triple in ``ALL_TIERS × ALL_TIERS ×
+    ALL_TIERS``. Perspective validates but does NOT shape rows."""
+    tiers = _all_tiers(ent)
+    for p in tiers:
+        for f in tiers:
+            for t in tiers:
+                got = ent.tier_catalog_at_path(p, f, t)
+                want = ent.tier_catalog_path(f, t)
+                assert got == want, (
+                    f"body drift for perspective={p} from={f} to={t}: "
+                    f"{got!r} != {want!r}"
+                )
+
+
+def test_scalar_perspective_invariance(ent):
+    """Shifting perspective across every id in ``_TIER_ORDER`` yields
+    byte-identical rows for the same ``(from, to)`` pair."""
+    baseline = ent.tier_catalog_at_path(
+        ent.TIER_CLOUD_PRO, ent.TIER_OSS, ent.TIER_ENTERPRISE
+    )
+    for p in _all_tiers(ent):
+        assert ent.tier_catalog_at_path(
+            p, ent.TIER_OSS, ent.TIER_ENTERPRISE
+        ) == baseline, f"perspective {p} drifted from cloud_pro baseline"
+
+
+def test_scalar_per_rung_body_matches_tier_catalog_at(ent):
+    """Each per-rung ``tiers`` list byte-equals
+    :func:`tier_catalog_at` for the same rung id -- pinned so the
+    scalar and path what-if tier-ladder surfaces cannot drift."""
+    path = ent.tier_catalog_at_path(
+        ent.TIER_CLOUD_PRO, ent.TIER_OSS, ent.TIER_ENTERPRISE
+    )
+    for row in path:
+        assert row["tiers"] == ent.tier_catalog_at(row["tier"])
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# scalar helper: input handling / error posture
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_scalar_trial_accepted_as_perspective(ent):
+    """Trial IS accepted as perspective (lenient ``_at`` posture)
+    -- matches every other ``_at`` helper."""
+    got = ent.tier_catalog_at_path(
+        ent.TIER_TRIAL, ent.TIER_OSS, ent.TIER_ENTERPRISE
+    )
+    want = ent.tier_catalog_path(ent.TIER_OSS, ent.TIER_ENTERPRISE)
+    assert got == want
+
+
+def test_scalar_trial_accepted_as_endpoint(ent):
+    """Trial IS accepted as ``to`` / ``from`` via the lateral / identity
+    branches (matches :func:`tier_catalog_path`)."""
+    got = ent.tier_catalog_at_path(
+        ent.TIER_CLOUD_PRO, ent.TIER_CLOUD_PRO, ent.TIER_TRIAL
+    )
+    # cloud_pro and trial share rank 2 -- lateral, single-row path.
+    assert isinstance(got, list)
+    assert len(got) == 1
+    assert got[0]["tier"] == ent.TIER_TRIAL
+
+
+def test_scalar_unknown_perspective_returns_none(ent):
+    assert ent.tier_catalog_at_path(
+        "bogus_tier", ent.TIER_OSS, ent.TIER_ENTERPRISE
+    ) is None
+
+
+def test_scalar_unknown_from_returns_none(ent):
+    assert ent.tier_catalog_at_path(
+        ent.TIER_CLOUD_PRO, "bogus_tier", ent.TIER_ENTERPRISE
+    ) is None
+
+
+def test_scalar_unknown_to_returns_none(ent):
+    assert ent.tier_catalog_at_path(
+        ent.TIER_CLOUD_PRO, ent.TIER_OSS, "bogus_tier"
+    ) is None
+
+
+def test_scalar_none_perspective_returns_none(ent):
+    assert ent.tier_catalog_at_path(
+        None, ent.TIER_OSS, ent.TIER_ENTERPRISE
+    ) is None
+
+
+def test_scalar_empty_perspective_returns_none(ent):
+    assert ent.tier_catalog_at_path(
+        "", ent.TIER_OSS, ent.TIER_ENTERPRISE
+    ) is None
+
+
+def test_scalar_case_and_whitespace_normalised(ent):
+    got = ent.tier_catalog_at_path(
+        "  Cloud_Pro  ", "  OSS  ", "  ENTERPRISE  "
+    )
+    want = ent.tier_catalog_path(ent.TIER_OSS, ent.TIER_ENTERPRISE)
+    assert got == want
+
+
+def test_scalar_never_raises_on_weird_types(ent):
+    """A per-destination crash short-circuits to ``None`` rather than
+    surfacing an exception -- the delegate is wrapped in try/except."""
+    for bad in (b"bytes", 12345, 3.14, object()):
+        assert ent.tier_catalog_at_path(
+            bad, ent.TIER_OSS, ent.TIER_ENTERPRISE
+        ) is None
+
+
+def test_scalar_grace_vs_enforce_identical(ent, enforced):
+    """Helper is resolver-independent -- grace and enforce yield the
+    same rows."""
+    grace_rows = ent.tier_catalog_at_path(
+        ent.TIER_CLOUD_PRO, ent.TIER_OSS, ent.TIER_ENTERPRISE
+    )
+    enforce_rows = enforced.tier_catalog_at_path(
+        enforced.TIER_CLOUD_PRO, enforced.TIER_OSS, enforced.TIER_ENTERPRISE
+    )
+    assert grace_rows == enforce_rows
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# batch helper: shape + happy path
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_batch_returns_dict_shape(ent):
+    out = ent.tier_catalog_at_path_batch(
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_OSS,
+        [ent.TIER_CLOUD_STARTER, ent.TIER_ENTERPRISE],
+    )
+    assert isinstance(out, dict)
+    assert set(out.keys()) == {"tiers", "unknown"}
+    assert isinstance(out["tiers"], list)
+    assert isinstance(out["unknown"], list)
+
+
+def test_batch_each_item_has_expected_shape(ent):
+    out = ent.tier_catalog_at_path_batch(
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_OSS,
+        [ent.TIER_CLOUD_STARTER, ent.TIER_ENTERPRISE],
+    )
+    for item in out["tiers"]:
+        assert set(item.keys()) == _ITEM_KEYS
+        assert item["direction"] in {
+            "upgrade",
+            "downgrade",
+            "lateral",
+            "identity",
+        }
+
+
+def test_batch_body_parity_with_tier_catalog_path_batch(ent):
+    """For every perspective, batch body byte-equals
+    :func:`tier_catalog_path_batch(from, to_tiers)` for the same
+    ``(from, to_tiers)``."""
+    tiers = _all_tiers(ent)
+    dests = [
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_ENTERPRISE,
+        ent.TIER_TRIAL,
+    ]
+    for p in tiers:
+        for f in tiers:
+            got = ent.tier_catalog_at_path_batch(p, f, dests)
+            want = ent.tier_catalog_path_batch(f, dests)
+            assert got == want, (
+                f"batch body drift for perspective={p} from={f}"
+            )
+
+
+def test_batch_perspective_invariance(ent):
+    dests = [ent.TIER_CLOUD_PRO, ent.TIER_ENTERPRISE]
+    baseline = ent.tier_catalog_at_path_batch(
+        ent.TIER_CLOUD_PRO, ent.TIER_OSS, dests
+    )
+    for p in _all_tiers(ent):
+        assert ent.tier_catalog_at_path_batch(
+            p, ent.TIER_OSS, dests
+        ) == baseline
+
+
+def test_batch_scalar_parity(ent):
+    """Each ``tiers[].path`` byte-equals the scalar
+    :func:`tier_catalog_at_path(perspective, from, tid)` for the same
+    id -- the scalar/batch no-drift contract."""
+    p = ent.TIER_CLOUD_PRO
+    f = ent.TIER_OSS
+    dests = [ent.TIER_CLOUD_STARTER, ent.TIER_CLOUD_PRO, ent.TIER_ENTERPRISE]
+    out = ent.tier_catalog_at_path_batch(p, f, dests)
+    by_id = {row["to"]: row for row in out["tiers"]}
+    for tid in dests:
+        assert (
+            by_id[tid]["path"]
+            == ent.tier_catalog_at_path(p, f, tid)
+        )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# batch helper: input handling / error posture
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_batch_unknown_perspective_returns_none(ent):
+    assert ent.tier_catalog_at_path_batch(
+        "bogus_tier", ent.TIER_OSS, [ent.TIER_ENTERPRISE]
+    ) is None
+
+
+def test_batch_unknown_from_returns_none(ent):
+    assert ent.tier_catalog_at_path_batch(
+        ent.TIER_CLOUD_PRO, "bogus_tier", [ent.TIER_ENTERPRISE]
+    ) is None
+
+
+def test_batch_none_perspective_returns_none(ent):
+    assert ent.tier_catalog_at_path_batch(
+        None, ent.TIER_OSS, [ent.TIER_ENTERPRISE]
+    ) is None
+
+
+def test_batch_unknown_destinations_bucketed(ent):
+    out = ent.tier_catalog_at_path_batch(
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_OSS,
+        [ent.TIER_ENTERPRISE, "bogus_id"],
+    )
+    assert [row["to"] for row in out["tiers"]] == [ent.TIER_ENTERPRISE]
+    assert out["unknown"] == ["bogus_id"]
+
+
+def test_batch_all_unknown_destinations_empty_tiers(ent):
+    out = ent.tier_catalog_at_path_batch(
+        ent.TIER_CLOUD_PRO, ent.TIER_OSS, ["bogus_a", "bogus_b"]
+    )
+    assert out == {"tiers": [], "unknown": ["bogus_a", "bogus_b"]}
+
+
+def test_batch_trial_accepted_as_destination(ent):
+    out = ent.tier_catalog_at_path_batch(
+        ent.TIER_CLOUD_PRO, ent.TIER_CLOUD_PRO, [ent.TIER_TRIAL]
+    )
+    assert out["unknown"] == []
+    assert [row["to"] for row in out["tiers"]] == [ent.TIER_TRIAL]
+
+
+def test_batch_normalises_destinations(ent):
+    got = ent.tier_catalog_at_path_batch(
+        "  cloud_pro  ",
+        "  OSS  ",
+        ["  Enterprise  ", "ENTERPRISE", "cloud_pro"],
+    )
+    want = ent.tier_catalog_at_path_batch(
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_OSS,
+        [ent.TIER_ENTERPRISE, ent.TIER_CLOUD_PRO],
+    )
+    assert got == want
+
+
+def test_batch_grace_vs_enforce_identical(ent, enforced):
+    dests = [ent.TIER_CLOUD_PRO, ent.TIER_ENTERPRISE]
+    grace_out = ent.tier_catalog_at_path_batch(
+        ent.TIER_CLOUD_PRO, ent.TIER_OSS, dests
+    )
+    enforce_out = enforced.tier_catalog_at_path_batch(
+        enforced.TIER_CLOUD_PRO, enforced.TIER_OSS, dests
+    )
+    assert grace_out == enforce_out
+
+
+def test_batch_never_raises_on_row_crash(ent, monkeypatch):
+    """A per-destination ``tier_catalog_path`` crash short-circuits that
+    id into ``unknown[]`` rather than surfacing an exception."""
+    real = ent.tier_catalog_path
+
+    def _boom(f, t):
+        if t == ent.TIER_ENTERPRISE:
+            raise RuntimeError("boom")
+        return real(f, t)
+
+    monkeypatch.setattr(ent, "tier_catalog_path", _boom)
+    out = ent.tier_catalog_at_path_batch(
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_OSS,
+        [ent.TIER_CLOUD_STARTER, ent.TIER_ENTERPRISE],
+    )
+    assert ent.TIER_ENTERPRISE in out["unknown"]
+    assert [row["to"] for row in out["tiers"]] == [ent.TIER_CLOUD_STARTER]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# HTTP scalar: /tier-catalog-at-path
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_http_scalar_happy_path(client, ent):
+    r = client.get(
+        "/api/entitlement/tier-catalog-at-path"
+        "?tier=cloud_pro&from=oss&to=enterprise"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert set(body.keys()) == _SCALAR_ENVELOPE_KEYS
+    assert body["perspective_tier"] == "cloud_pro"
+    assert body["from"] == "oss"
+    assert body["to"] == "enterprise"
+    assert body["direction"] == "upgrade"
+    assert isinstance(body["path"], list)
+    assert body["path"] == ent.tier_catalog_at_path(
+        ent.TIER_CLOUD_PRO, ent.TIER_OSS, ent.TIER_ENTERPRISE
+    )
+
+
+def test_http_scalar_missing_tier_400(client):
+    r = client.get(
+        "/api/entitlement/tier-catalog-at-path"
+        "?from=oss&to=enterprise"
+    )
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "missing tier"
+
+
+def test_http_scalar_missing_from_400(client):
+    r = client.get(
+        "/api/entitlement/tier-catalog-at-path"
+        "?tier=cloud_pro&to=enterprise"
+    )
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "missing from"
+
+
+def test_http_scalar_missing_to_400(client):
+    r = client.get(
+        "/api/entitlement/tier-catalog-at-path"
+        "?tier=cloud_pro&from=oss"
+    )
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "missing to"
+
+
+def test_http_scalar_unknown_tier_which_key(client):
+    r = client.get(
+        "/api/entitlement/tier-catalog-at-path"
+        "?tier=bogus&from=oss&to=enterprise"
+    )
+    assert r.status_code == 404
+    body = r.get_json()
+    assert body["which"] == "tier"
+
+
+def test_http_scalar_unknown_from_which_key(client):
+    r = client.get(
+        "/api/entitlement/tier-catalog-at-path"
+        "?tier=cloud_pro&from=bogus&to=enterprise"
+    )
+    assert r.status_code == 404
+    body = r.get_json()
+    assert body["which"] == "from"
+
+
+def test_http_scalar_unknown_to_which_key(client):
+    r = client.get(
+        "/api/entitlement/tier-catalog-at-path"
+        "?tier=cloud_pro&from=oss&to=bogus"
+    )
+    assert r.status_code == 404
+    body = r.get_json()
+    assert body["which"] == "to"
+
+
+def test_http_scalar_trial_accepted_as_perspective(client, ent):
+    r = client.get(
+        "/api/entitlement/tier-catalog-at-path"
+        "?tier=trial&from=oss&to=enterprise"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["perspective_tier"] == "trial"
+    assert body["path"] == ent.tier_catalog_path(
+        ent.TIER_OSS, ent.TIER_ENTERPRISE
+    )
+
+
+def test_http_scalar_identity_path_empty(client):
+    r = client.get(
+        "/api/entitlement/tier-catalog-at-path"
+        "?tier=cloud_pro&from=enterprise&to=enterprise"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["direction"] == "identity"
+    assert body["path"] == []
+
+
+def test_http_scalar_downgrade_direction(client):
+    r = client.get(
+        "/api/entitlement/tier-catalog-at-path"
+        "?tier=cloud_pro&from=enterprise&to=oss"
+    )
+    assert r.status_code == 200
+    assert r.get_json()["direction"] == "downgrade"
+
+
+def test_http_scalar_case_and_whitespace_normalised(client, ent):
+    r = client.get(
+        "/api/entitlement/tier-catalog-at-path"
+        "?tier=%20Cloud_Pro%20&from=%20OSS%20&to=%20ENTERPRISE%20"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["perspective_tier"] == "cloud_pro"
+    assert body["from"] == "oss"
+    assert body["to"] == "enterprise"
+
+
+def test_http_scalar_body_parity_with_tier_catalog_path(client, ent):
+    """``path`` byte-parity with ``/tier-catalog-path?from=&to=``
+    (the current-perspective sibling)."""
+    r_at = client.get(
+        "/api/entitlement/tier-catalog-at-path"
+        "?tier=cloud_pro&from=oss&to=enterprise"
+    )
+    r_path = client.get(
+        "/api/entitlement/tier-catalog-path?from=oss&to=enterprise"
+    )
+    assert r_at.status_code == 200
+    assert r_path.status_code == 200
+    assert r_at.get_json()["path"] == r_path.get_json()["path"]
+
+
+def test_http_scalar_perspective_invariance(client, ent):
+    baseline = client.get(
+        "/api/entitlement/tier-catalog-at-path"
+        "?tier=cloud_pro&from=oss&to=enterprise"
+    ).get_json()["path"]
+    for p in ("oss", "cloud_free", "trial", "cloud_starter", "pro", "enterprise"):
+        got = client.get(
+            f"/api/entitlement/tier-catalog-at-path"
+            f"?tier={p}&from=oss&to=enterprise"
+        ).get_json()["path"]
+        assert got == baseline, f"perspective {p} drifted from cloud_pro"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# HTTP batch: /tier-catalog-at-path-batch
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_http_batch_happy_path(client, ent):
+    r = client.get(
+        "/api/entitlement/tier-catalog-at-path-batch"
+        "?tier=cloud_pro&from=oss&to=cloud_starter,cloud_pro,enterprise"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert set(body.keys()) == _BATCH_ENVELOPE_KEYS
+    assert body["perspective_tier"] == "cloud_pro"
+    assert body["from"] == "oss"
+    assert [row["to"] for row in body["tiers"]] == [
+        "cloud_starter",
+        "cloud_pro",
+        "enterprise",
+    ]
+    assert body["unknown"] == []
+
+
+def test_http_batch_missing_tier_400(client):
+    r = client.get(
+        "/api/entitlement/tier-catalog-at-path-batch"
+        "?from=oss&to=enterprise"
+    )
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "missing tier"
+
+
+def test_http_batch_missing_from_400(client):
+    r = client.get(
+        "/api/entitlement/tier-catalog-at-path-batch"
+        "?tier=cloud_pro&to=enterprise"
+    )
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "missing from"
+
+
+def test_http_batch_missing_to_400(client):
+    r = client.get(
+        "/api/entitlement/tier-catalog-at-path-batch"
+        "?tier=cloud_pro&from=oss"
+    )
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "supply to=<csv>"
+
+
+def test_http_batch_empty_to_400(client):
+    """An empty ``to`` list normalises to zero targets and 400s."""
+    r = client.get(
+        "/api/entitlement/tier-catalog-at-path-batch"
+        "?tier=cloud_pro&from=oss&to="
+    )
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "supply to=<csv>"
+
+
+def test_http_batch_unknown_tier_which_key(client):
+    r = client.get(
+        "/api/entitlement/tier-catalog-at-path-batch"
+        "?tier=bogus&from=oss&to=enterprise"
+    )
+    assert r.status_code == 404
+    body = r.get_json()
+    assert body["which"] == "tier"
+
+
+def test_http_batch_unknown_from_which_key(client):
+    r = client.get(
+        "/api/entitlement/tier-catalog-at-path-batch"
+        "?tier=cloud_pro&from=bogus&to=enterprise"
+    )
+    assert r.status_code == 404
+    body = r.get_json()
+    assert body["which"] == "from"
+
+
+def test_http_batch_partial_unknown_bucketed(client):
+    r = client.get(
+        "/api/entitlement/tier-catalog-at-path-batch"
+        "?tier=cloud_pro&from=oss&to=enterprise,nope_tier"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert [row["to"] for row in body["tiers"]] == ["enterprise"]
+    assert body["unknown"] == ["nope_tier"]
+
+
+def test_http_batch_multi_destination(client, ent):
+    r = client.get(
+        "/api/entitlement/tier-catalog-at-path-batch"
+        "?tier=cloud_pro&from=oss"
+        "&to=cloud_starter,cloud_pro,enterprise,pro"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert [row["to"] for row in body["tiers"]] == [
+        "cloud_starter",
+        "cloud_pro",
+        "enterprise",
+        "pro",
+    ]
+    assert body["unknown"] == []
+
+
+def test_http_batch_body_parity_with_tier_catalog_path_batch(client):
+    """``tiers[]`` byte-parity with ``/tier-catalog-path-batch`` (the
+    current-perspective sibling) for the same ``(from, to)``."""
+    r_at = client.get(
+        "/api/entitlement/tier-catalog-at-path-batch"
+        "?tier=cloud_pro&from=oss&to=cloud_pro,enterprise"
+    )
+    r_path = client.get(
+        "/api/entitlement/tier-catalog-path-batch"
+        "?from=oss&to=cloud_pro,enterprise"
+    )
+    assert r_at.status_code == 200
+    assert r_path.status_code == 200
+    assert r_at.get_json()["tiers"] == r_path.get_json()["tiers"]
+
+
+def test_http_batch_perspective_invariance(client):
+    """``tiers[]`` byte-identical across shifting perspective."""
+    baseline = client.get(
+        "/api/entitlement/tier-catalog-at-path-batch"
+        "?tier=cloud_pro&from=oss&to=cloud_pro,enterprise"
+    ).get_json()["tiers"]
+    for p in ("oss", "cloud_free", "trial", "cloud_starter", "pro", "enterprise"):
+        got = client.get(
+            f"/api/entitlement/tier-catalog-at-path-batch"
+            f"?tier={p}&from=oss&to=cloud_pro,enterprise"
+        ).get_json()["tiers"]
+        assert got == baseline, f"perspective {p} drifted from cloud_pro"
+
+
+def test_http_batch_trial_accepted_as_both_perspective_and_destination(
+    client, ent
+):
+    r = client.get(
+        "/api/entitlement/tier-catalog-at-path-batch"
+        "?tier=trial&from=oss&to=trial,enterprise"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["perspective_tier"] == "trial"
+    assert body["unknown"] == []
+    assert set(row["to"] for row in body["tiers"]) == {"trial", "enterprise"}
+
+
+def test_http_batch_case_and_whitespace_normalised(client):
+    r = client.get(
+        "/api/entitlement/tier-catalog-at-path-batch"
+        "?tier=%20Cloud_Pro%20&from=%20OSS%20"
+        "&to=%20Enterprise%20,ENTERPRISE,cloud_pro"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["perspective_tier"] == "cloud_pro"
+    assert body["from"] == "oss"
+    # duplicates dropped, whitespace stripped, first-seen order preserved.
+    assert [row["to"] for row in body["tiers"]] == ["enterprise", "cloud_pro"]
+    assert body["unknown"] == []


### PR DESCRIPTION
## Summary

Fills the `_at_path` / `_at_path_batch` slot for the tier-catalog family. Path-shaped what-if sibling of the already-merged `tier_catalog_path` (#3499) / `tier_catalog_path_batch` (#3506): both are pricing-comparison walkthrough accessors where the perspective is validated but does NOT shape the rows, so an upgrade-walkthrough surface can call `X_at_path(perspective, from, to)` uniformly across the whole `_at_path` family.

- Module-level `tier_catalog_at_path(perspective_tier, from_tier, to_tier)` -- scalar what-if path. Body byte-identical to `tier_catalog_path(from_tier, to_tier)` for every perspective. Pinned by parity tests so the singular can never drift from `tier_catalog_path` (which also backs `tier_catalog_path_batch`). Trial accepted as perspective (lenient posture matching every other `_at` helper); endpoint acceptance mirrors `tier_catalog_path` (any id in `_TIER_FEATURES`, including `trial` via the lateral / identity branch).
- Module-level `tier_catalog_at_path_batch(perspective_tier, from_tier, to_tiers)` -- fixed-perspective, fixed-from, multi-to companion. Per-row body byte-identical to `tier_catalog_path_batch(from_tier, to_tiers)` for the same targets (scalar / batch no-drift contract).
- `GET /api/entitlement/tier-catalog-at-path?tier=&from=&to=` -- 400 on missing / blank input, 404 on unknown perspective / from / to (body carries `which: "tier" | "from" | "to"` so the caller can point at the offender), never 5xxs on resolver crash. Response envelope: `perspective_tier` + `perspective_tier_rank` echo, the same `from` / `from_label` / `from_rank` / `to` / `to_label` / `to_rank` / `direction` / `path` fields as `/tier-catalog-path`, plus the standard `_at*` resolver-context tail (`current_tier` / `current_tier_rank` / `grace` / `enforced`).
- `GET /api/entitlement/tier-catalog-at-path-batch?tier=&from=&to=a,b,c` -- envelope mirrors `/tier-catalog-path-batch` plus `perspective_tier` / `perspective_tier_rank` echo and the resolver-context tail. GET+CSV shape matches sibling `/tier-catalog-path-batch` rather than the POST+JSON `/preview-at-path-batch` shape -- keeps the tier-catalog family internally consistent. Unknown destination ids are echoed in `unknown[]` instead of short-circuiting so a partially-bad caller still gets paths back for the valid ids, matching every other `*_path_batch` sibling's posture.

Fills the tier-catalog-family gap in the `_at_path` / `_at_path_batch` slot:

| helper                        | slot                       | status         |
|-------------------------------|----------------------------|----------------|
| `tier_catalog`                | scalar (current)           | already merged |
| `tier_catalog_at`             | scalar (hypothetical)      | already merged |
| `tier_catalog_at_batch`       | batch (hypothetical)       | already merged (#3495) |
| `tier_catalog_path`           | path (current)             | already merged (#3499) |
| `tier_catalog_path_batch`     | batch path (current)       | already merged (#3506) |
| `tier_catalog_at_path`        | path (hypothetical)        | **this PR**    |
| `tier_catalog_at_path_batch`  | batch path (hypothetical)  | **this PR**    |

Posture matches the rest of the `_at` family:

- Perspective + destination ids normalised (whitespace stripped, lowercased, duplicates dropped, first-seen order preserved on the batch).
- Unknown destination ids echoed in `unknown[]` instead of short-circuiting -- a partially-bad caller still gets paths back for the valid ids alongside a list of what was dropped.
- `trial` IS accepted as both perspective (any id in `_TIER_ORDER`) and endpoint (any id in `_TIER_FEATURES`), matching every other `_at*` helper.
- Per-rung row body carries the same 4-key shape as `tier_catalog_path` (`tier`, `tier_label`, `tier_rank`, `tiers`); each inner `tiers` list byte-equals `tier_catalog_at(rung)` for the same rung, so the `_at` / `_at_path` / `_at_batch` / `_at_path_batch` catalog surfaces cannot drift from each other.
- Resolver-independent: delegates to `tier_catalog_path` / `tier_catalog_path_batch`, which walk the static per-tier maps, so grace vs enforce yields byte-identical rows.
- Never raises: per-destination crash short-circuits that id into `unknown[]`; endpoint resolver failure short-circuits to a grace-shape envelope (no 5xx).

**Grace-only, read-only**: no gate enforced, no behaviour change against the currently-resolved entitlement -- these are new read-only endpoints.

## Test plan

- [x] `python3 -m py_compile clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_tier_catalog_at_path.py` -- clean
- [x] `ruff check clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_tier_catalog_at_path.py` -- all checks passed
- [x] `python3 -m pytest tests/test_entitlement_tier_catalog_at_path.py -q` -- **59 passed**
- [x] Adjacent regression sweep -- **190 passed** across `test_entitlement_tier_catalog_path`, `test_entitlement_tier_catalog_path_batch`, `test_entitlement_tier_catalog_at`, `test_entitlement_tier_catalog_at_batch`, `test_entitlement_api`.

### Coverage in `tests/test_entitlement_tier_catalog_at_path.py`

- **scalar helper**: shape; body byte-parity with `tier_catalog_path(from, to)` across every `(perspective, from, to)` triple in `ALL_TIERS × ALL_TIERS × ALL_TIERS`; perspective invariance (byte-identical rows across shifting perspective for the same `(from, to)`); per-rung `tiers` list byte-equals `tier_catalog_at(rung)` for the same rung; trial accepted as perspective + endpoint; identity → `[]`; lateral → single-row path; upgrade / downgrade ranks monotonic; unknown perspective / from / to → `None`; `None` inputs → `None`; case + whitespace normalisation; never-raises on weird input types (bytes / ints / floats); grace vs enforce byte-identical.
- **batch helper**: envelope `{tiers, unknown}` shape; body byte-parity with `tier_catalog_path_batch(from, to_tiers)` for every perspective; batch-level perspective invariance; each `tiers[].path` equals scalar `tier_catalog_at_path(perspective, from, tid)`; unknown destinations bucketed in `unknown[]`; all-unknown case → `{"tiers": [], "unknown": [...]}`; trial accepted as destination; perspective / from whitespace / casing normalised; grace vs enforce byte-identical; per-destination row crash short-circuits into `unknown[]` (monkeypatched delegate crash).
- **HTTP scalar (`/tier-catalog-at-path`)**: 14-key envelope shape; 400 on missing `tier` / `from` / `to`; 404 with `which: "tier" | "from" | "to"` on unknown ids; 200 happy path; trial accepted as perspective; identity path empty; downgrade direction; case + whitespace normalisation via URL-encoded query; `path` body-parity with `/tier-catalog-path`; perspective-invariance across every perspective.
- **HTTP batch (`/tier-catalog-at-path-batch`)**: 11-key envelope shape; 400 on missing `tier` / `from` and empty `to` list; 404 with `which` bucketing on unknown perspective / from; 200 happy path; partial-unknown bucketing; multi-destination; `tiers[]` body-parity with `/tier-catalog-path-batch`; perspective invariance across every perspective; trial accepted as both perspective and destination; whitespace / casing normalisation.

## Local operator verification checklist

The public-repo agent cannot exercise the live daemon, cloud snapshot, or browser. Please copy the changed files into your locally-installed clawmetry site-packages and verify against the real daemon before flipping ready-for-review:

```bash
# 1. Copy the changed files into the installed package
SP="$HOME/.clawmetry/lib/python$(python3 -c 'import sys;print(f"{sys.version_info.major}.{sys.version_info.minor}")')/site-packages/clawmetry"
cp clawmetry/entitlements.py "$SP/entitlements.py"
# routes/ isn't inside the package; on the default layout it lands at
# $HOME/.clawmetry/lib/python*/site-packages/routes/entitlement.py
find "$HOME/.clawmetry" -name entitlement.py -path '*routes*' -exec cp routes/entitlement.py {} \;

# 2. Purge stale bytecode so the new module actually loads
find "$HOME/.clawmetry" -type d -name __pycache__ -exec rm -rf {} +

# 3. Bounce the sync daemon so it re-imports
launchctl kickstart -k "gui/$(id -u)/com.clawmetry.sync"

# 4. Hit the new scalar endpoint (happy path)
curl -s 'http://localhost:8900/api/entitlement/tier-catalog-at-path?tier=cloud_pro&from=oss&to=enterprise' | jq
# Expect: 200 with {perspective_tier: "cloud_pro", from: "oss", to: "enterprise", direction: "upgrade", path: [...], ...}

# 5. Trial accepted as perspective
curl -s 'http://localhost:8900/api/entitlement/tier-catalog-at-path?tier=trial&from=oss&to=enterprise' | jq '.perspective_tier'
# Expect: "trial"

# 6. Error paths
curl -si 'http://localhost:8900/api/entitlement/tier-catalog-at-path?from=oss&to=enterprise' | head -1
# Expect: HTTP/1.1 400 (missing tier)
curl -si 'http://localhost:8900/api/entitlement/tier-catalog-at-path?tier=cloud_pro&to=enterprise' | head -1
# Expect: HTTP/1.1 400 (missing from)
curl -si 'http://localhost:8900/api/entitlement/tier-catalog-at-path?tier=cloud_pro&from=oss' | head -1
# Expect: HTTP/1.1 400 (missing to)
curl -s  'http://localhost:8900/api/entitlement/tier-catalog-at-path?tier=bogus&from=oss&to=enterprise'      | jq '.which'
# Expect: "tier"
curl -s  'http://localhost:8900/api/entitlement/tier-catalog-at-path?tier=cloud_pro&from=bogus&to=enterprise' | jq '.which'
# Expect: "from"
curl -s  'http://localhost:8900/api/entitlement/tier-catalog-at-path?tier=cloud_pro&from=oss&to=bogus'        | jq '.which'
# Expect: "to"

# 7. Batch happy path
curl -s 'http://localhost:8900/api/entitlement/tier-catalog-at-path-batch?tier=cloud_pro&from=oss&to=cloud_starter,cloud_pro,enterprise' | jq
# Expect: 200 with envelope {perspective_tier, from, tiers[3], unknown: [], current_tier, grace, enforced}

# 8. Partial-unknown bucketing
curl -s 'http://localhost:8900/api/entitlement/tier-catalog-at-path-batch?tier=cloud_pro&from=oss&to=enterprise,nope_tier' | jq '.unknown'
# Expect: ["nope_tier"] -- 200, not 404

# 9. Perspective invariance (rows identical across shifting perspective)
for p in oss cloud_free cloud_starter cloud_pro pro enterprise trial; do
  diff \
    <(curl -s "http://localhost:8900/api/entitlement/tier-catalog-at-path-batch?tier=$p&from=oss&to=cloud_pro,enterprise" | jq '.tiers') \
    <(curl -s "http://localhost:8900/api/entitlement/tier-catalog-at-path-batch?tier=cloud_pro&from=oss&to=cloud_pro,enterprise" | jq '.tiers') \
  && echo "$p: perspective-invariant OK"
done
# Expect: "perspective-invariant OK" for every perspective.

# 10. Parity with /tier-catalog-path-batch (which the batch delegates to)
diff \
  <(curl -s 'http://localhost:8900/api/entitlement/tier-catalog-at-path-batch?tier=cloud_pro&from=oss&to=cloud_pro,enterprise' | jq '.tiers') \
  <(curl -s 'http://localhost:8900/api/entitlement/tier-catalog-path-batch?from=oss&to=cloud_pro,enterprise' | jq '.tiers') \
&& echo "tiers[] byte-parity with tier-catalog-path-batch OK"

# 11. Decrypt the live cloud snapshot in the browser + sanity-check no
# regressions on the existing /tier-catalog, /tier-catalog-at,
# /tier-catalog-at-batch, /tier-catalog-path, /tier-catalog-path-batch
# endpoints.
```

If everything looks right, flip to ready-for-review and merge in the normal flow. Only the local operator has access to the live daemon and snapshot for step 11, which is why this PR stays draft until then.

Non-overlapping with open PR #3509 (`preview_at` / `preview_at_batch`) and open PR #3511 (`preview_at_path` / `preview_at_path_batch`): both open PRs target the `preview` family; this PR appends to the tier-catalog family so the helper and route diffs land in distinct file regions.

The next-phase work (P3 / P4 / P6 -- cloud-side entitlement minting, `clawmetry-pro` package download, enterprise SSO) needs the private `clawmetry-cloud` / `clawmetry-pro` repos and is out of scope for this remote session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011NQuU3gBVyt23zKiNW8hD7)_