### PR TITLE
feat(entitlement): feature_spec_at_path + feature_spec_at_path_batch + 2 endpoints

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -11270,3 +11270,97 @@ def runtime_catalog_path_batch(
             }
         )
     return {"tiers": rows, "unknown": unknown}
+
+
+def feature_spec_at_path(
+    perspective_tier: str, from_tier: str, to_tier: str, feature: str
+) -> list[dict] | None:
+    """Perspective-validated what-if wrapper around :func:`feature_spec_path`.
+
+    Fills the ``_at_path`` slot of the ``feature_spec`` family, matching the
+    already-shipping ``preview_at_path`` / ``tier_catalog_at_path`` pattern
+    on the ``preview`` / ``tier_catalog`` axes. The perspective is
+    validated (empty / unknown ids short-circuit to ``None``) but does
+    NOT shape the rows -- the body is byte-identical to
+    :func:`feature_spec_path` for every ``(from, to, feature)`` triple,
+    so a pricing-comparison walkthrough UI can call
+    ``X_at_path(perspective, from, to, feature)`` uniformly across the
+    whole ``_at_path`` family without worrying that the perspective is
+    silently changing which rungs get walked.
+
+    Pins a parity test so the scalar ``_at_path`` can never drift from
+    :func:`feature_spec_path` (which itself walks per-rung via
+    :func:`feature_spec_at`).
+
+    Endpoint semantics match :func:`feature_spec_path`: perspective, from
+    and to accept any id in :data:`_TIER_FEATURES` (``trial`` accepted,
+    excluded from the walked intermediate rungs, valid endpoint via the
+    lateral / identity branch). ``feature`` accepts any id in
+    :data:`ALL_FEATURES`.
+
+    Never raises: a delegation failure logs a warning and returns
+    ``None`` so a paywall surface keeps rendering instead of breaking.
+    """
+    try:
+        p = (perspective_tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if not p or p not in _TIER_FEATURES:
+        return None
+    try:
+        return feature_spec_path(from_tier, to_tier, feature)
+    except Exception as exc:
+        logger.warning("entitlements: feature_spec_at_path failed: %s", exc)
+        return None
+
+
+def feature_spec_at_path_batch(
+    perspective_tier: str, from_tier: str, to_tier: str, features
+) -> dict | None:
+    """Perspective-validated what-if wrapper around
+    :func:`feature_spec_path_batch`.
+
+    Fixed-perspective, fixed-from, fixed-to, multi-feature companion of
+    :func:`feature_spec_at_path`. Fills the ``_at_path_batch`` slot of
+    the ``feature_spec`` family, matching the already-shipping
+    ``preview_at_path_batch`` / ``tier_catalog_at_path_batch`` pattern.
+
+    Per-feature body byte-identical to :func:`feature_spec_path_batch`
+    for the same ``(from, to, features)`` triple -- scalar / batch
+    no-drift contract (the batch delegates to the same underlying
+    :func:`feature_spec_path` per feature that the scalar
+    :func:`feature_spec_at_path` delegates to).
+
+    Shape mirrors :func:`feature_spec_path_batch`::
+
+        {
+          "features": [{"feature": "<id>", "path": [...]}, ...],
+          "unknown":  ["bogus_id", ...],
+        }
+
+    Supplied feature ids are normalised via :func:`_normalise_csv`
+    (whitespace stripped, lowercased, duplicates dropped, first-seen
+    order preserved). Unknown ids are echoed in ``unknown[]`` instead of
+    short-circuiting -- a partially-bad caller still gets paths back for
+    the valid ids alongside a list of what was dropped, matching every
+    other ``*_path_batch`` sibling's posture.
+
+    Returns ``None`` for empty / unknown ``perspective_tier`` /
+    ``from_tier`` / ``to_tier`` (caller renders "unknown tier" / 404).
+    Never raises: per-feature failures short-circuit that feature into
+    ``unknown[]``; a top-level delegation failure short-circuits to
+    ``None``.
+    """
+    try:
+        p = (perspective_tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if not p or p not in _TIER_FEATURES:
+        return None
+    try:
+        return feature_spec_path_batch(from_tier, to_tier, features)
+    except Exception as exc:
+        logger.warning(
+            "entitlements: feature_spec_at_path_batch failed: %s", exc
+        )
+        return None

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -12192,3 +12192,301 @@ def api_entitlement_preview_at_path_batch():
                 "enforced": False,
             }
         )
+
+
+@bp_entitlement.route("/api/entitlement/feature-spec-at-path")
+def api_entitlement_feature_spec_at_path():
+    """``GET /api/entitlement/feature-spec-at-path?tier=<perspective>
+    &from=<id>&to=<id>&feature=<id>`` -- perspective-validated what-if
+    sibling of ``/api/entitlement/feature-spec-path``.
+
+    Fills the ``_at_path`` slot of the ``feature-spec`` family, matching
+    the already-shipping ``preview_at_path`` / ``tier_catalog_at_path``
+    pattern on the ``preview`` / ``tier_catalog`` axes. The perspective
+    is validated (400 on missing, 404 on unknown) but does NOT shape the
+    ``path`` rows -- the body is byte-identical to
+    ``/feature-spec-path?from=<from>&to=<to>&feature=<feature>`` for
+    every perspective. Pinned by parity tests so the ``_at_path`` and
+    ``_path`` endpoints cannot drift.
+
+    Response shape (mirrors ``/feature-spec-path`` plus a
+    ``perspective_tier`` echo and the standard ``_at*`` resolver-context
+    tail so a paywall matrix UI can render "at Cloud Pro this feature
+    unlocks at Starter" without a second call to ``/entitlement``)::
+
+        {
+          "perspective_tier":      "<id>",
+          "perspective_tier_rank": <int>,
+          "from":                  "<tier id>",
+          "from_label":            "...",
+          "from_rank":             <int>,
+          "to":                    "<tier id>",
+          "to_label":              "...",
+          "to_rank":               <int>,
+          "direction":             "upgrade" | "downgrade" | "lateral" | "identity",
+          "feature":               "<feature id>",
+          "path":                  [<feature_spec_path row>, ...],
+          "current_tier":          "...",
+          "current_tier_rank":     <int>,
+          "grace":                 <bool>,
+          "enforced":              <bool>,
+        }
+
+    - **400** when ``tier=``, ``from=``, ``to=`` or ``feature=`` is
+      missing / blank
+    - **404** when any id is unknown (body carries
+      ``which: "tier" | "from" | "to" | "feature"`` so the caller can
+      point at the offender)
+    - **Never 5xxs**: a resolver failure short-circuits to the grace-
+      shape envelope with the perspective echoed so the UI keeps
+      rendering.
+    """
+    raw_tier = request.args.get("tier")
+    tier_in = (raw_tier or "").strip().lower()
+    if not tier_in:
+        return jsonify({"error": "missing tier"}), 400
+    f = (request.args.get("from") or "").strip().lower()
+    t = (request.args.get("to") or "").strip().lower()
+    if not f:
+        return jsonify({"error": "missing from"}), 400
+    if not t:
+        return jsonify({"error": "missing to"}), 400
+    feat = (request.args.get("feature") or "").strip().lower()
+    if not feat:
+        return jsonify({"error": "missing feature"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        if tier_in not in _ent._TIER_FEATURES:
+            return (
+                jsonify(
+                    {
+                        "error": "unknown tier",
+                        "which": "tier",
+                        "tier": tier_in,
+                    }
+                ),
+                404,
+            )
+        if f not in _ent._TIER_FEATURES:
+            return (
+                jsonify(
+                    {"error": "unknown from", "which": "from", "from": f}
+                ),
+                404,
+            )
+        if t not in _ent._TIER_FEATURES:
+            return (
+                jsonify({"error": "unknown to", "which": "to", "to": t}),
+                404,
+            )
+        if feat not in _ent.ALL_FEATURES:
+            return (
+                jsonify(
+                    {
+                        "error": "unknown feature",
+                        "which": "feature",
+                        "feature": feat,
+                    }
+                ),
+                404,
+            )
+        path = _ent.feature_spec_at_path(tier_in, f, t, feat)
+        if path is None:
+            path = []
+        from_rank = _ent.tier_rank(f)
+        to_rank = _ent.tier_rank(t)
+        if f == t:
+            direction = "identity"
+        elif from_rank == to_rank:
+            direction = "lateral"
+        elif to_rank > from_rank:
+            direction = "upgrade"
+        else:
+            direction = "downgrade"
+        ent = _ent.get_entitlement()
+        return jsonify(
+            {
+                "perspective_tier": tier_in,
+                "perspective_tier_rank": _ent.tier_rank(tier_in),
+                "from": f,
+                "from_label": _ent.tier_label(f),
+                "from_rank": from_rank,
+                "to": t,
+                "to_label": _ent.tier_label(t),
+                "to_rank": to_rank,
+                "direction": direction,
+                "feature": feat,
+                "path": path,
+                "current_tier": ent.tier,
+                "current_tier_rank": _ent.tier_rank(ent.tier),
+                "grace": bool(ent.grace),
+                "enforced": _ent.is_enforced(),
+            }
+        )
+    except Exception as exc:
+        logger.warning("api_entitlement_feature_spec_at_path: error: %s", exc)
+        return jsonify(
+            {
+                "perspective_tier": tier_in,
+                "perspective_tier_rank": 0,
+                "from": f,
+                "from_label": None,
+                "from_rank": -1,
+                "to": t,
+                "to_label": None,
+                "to_rank": -1,
+                "direction": "identity" if f == t else "upgrade",
+                "feature": feat,
+                "path": [],
+                "current_tier": "oss",
+                "current_tier_rank": 0,
+                "grace": True,
+                "enforced": False,
+            }
+        )
+
+
+@bp_entitlement.route("/api/entitlement/feature-spec-at-path-batch")
+def api_entitlement_feature_spec_at_path_batch():
+    """``GET /api/entitlement/feature-spec-at-path-batch?tier=<perspective>
+    &from=<id>&to=<id>&features=a,b,c`` -- perspective-validated what-if
+    batch sibling of ``/api/entitlement/feature-spec-path-batch``.
+
+    Fills the ``_at_path_batch`` slot of the ``feature-spec`` family;
+    fixed-perspective, fixed-from, fixed-to, multi-feature companion of
+    ``/feature-spec-at-path``. Per-feature body byte-identical to
+    ``/feature-spec-path-batch`` for the same ``(from, to, features)``
+    triple -- scalar / batch no-drift contract.
+
+    Response shape (mirrors ``/feature-spec-path-batch`` plus a
+    ``perspective_tier`` echo and the standard ``_at*`` resolver-context
+    tail)::
+
+        {
+          "perspective_tier":      "<id>",
+          "perspective_tier_rank": <int>,
+          "from":                  "<tier id>",
+          "from_label":            "...",
+          "from_rank":             <int>,
+          "to":                    "<tier id>",
+          "to_label":              "...",
+          "to_rank":               <int>,
+          "direction":             "upgrade" | "downgrade" | "lateral" | "identity",
+          "features": [
+            {"feature": "<id>", "path": [<augmented row>, ...]},
+            ...
+          ],
+          "unknown":               ["bogus_id", ...],
+          "current_tier":          "...",
+          "current_tier_rank":     <int>,
+          "grace":                 <bool>,
+          "enforced":              <bool>,
+        }
+
+    - **400** when ``tier=``, ``from=``, ``to=`` is missing / blank, or
+      ``features=`` is missing / empty after normalisation
+    - **404** when any tier id is unknown (body carries
+      ``which: "tier" | "from" | "to"``)
+    - Unknown feature ids do NOT 404 the call -- they are echoed in
+      ``unknown[]`` so a partially-bad caller still gets paths back for
+      the valid ids alongside a list of what was dropped, matching
+      every other ``*_path_batch`` sibling's posture.
+    - **Never 5xxs**: a synthesis failure short-circuits to a grace-
+      shape envelope with the perspective echoed.
+    """
+    raw_tier = request.args.get("tier")
+    tier_in = (raw_tier or "").strip().lower()
+    if not tier_in:
+        return jsonify({"error": "missing tier"}), 400
+    f = (request.args.get("from") or "").strip().lower()
+    t = (request.args.get("to") or "").strip().lower()
+    if not f:
+        return jsonify({"error": "missing from"}), 400
+    if not t:
+        return jsonify({"error": "missing to"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        if tier_in not in _ent._TIER_FEATURES:
+            return (
+                jsonify(
+                    {
+                        "error": "unknown tier",
+                        "which": "tier",
+                        "tier": tier_in,
+                    }
+                ),
+                404,
+            )
+        if f not in _ent._TIER_FEATURES:
+            return (
+                jsonify(
+                    {"error": "unknown from", "which": "from", "from": f}
+                ),
+                404,
+            )
+        if t not in _ent._TIER_FEATURES:
+            return (
+                jsonify({"error": "unknown to", "which": "to", "to": t}),
+                404,
+            )
+        features = _parse_csv_arg("features")
+        if not features:
+            return jsonify({"error": "supply features=<csv>"}), 400
+        batch = _ent.feature_spec_at_path_batch(tier_in, f, t, features)
+        if batch is None:
+            batch = {"features": [], "unknown": []}
+        from_rank = _ent.tier_rank(f)
+        to_rank = _ent.tier_rank(t)
+        if f == t:
+            direction = "identity"
+        elif from_rank == to_rank:
+            direction = "lateral"
+        elif to_rank > from_rank:
+            direction = "upgrade"
+        else:
+            direction = "downgrade"
+        ent = _ent.get_entitlement()
+        return jsonify(
+            {
+                "perspective_tier": tier_in,
+                "perspective_tier_rank": _ent.tier_rank(tier_in),
+                "from": f,
+                "from_label": _ent.tier_label(f),
+                "from_rank": from_rank,
+                "to": t,
+                "to_label": _ent.tier_label(t),
+                "to_rank": to_rank,
+                "direction": direction,
+                "features": batch.get("features", []),
+                "unknown": batch.get("unknown", []),
+                "current_tier": ent.tier,
+                "current_tier_rank": _ent.tier_rank(ent.tier),
+                "grace": bool(ent.grace),
+                "enforced": _ent.is_enforced(),
+            }
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_feature_spec_at_path_batch: error: %s", exc
+        )
+        return jsonify(
+            {
+                "perspective_tier": tier_in,
+                "perspective_tier_rank": 0,
+                "from": f,
+                "from_label": None,
+                "from_rank": -1,
+                "to": t,
+                "to_label": None,
+                "to_rank": -1,
+                "direction": "identity" if f == t else "upgrade",
+                "features": [],
+                "unknown": [],
+                "current_tier": "oss",
+                "current_tier_rank": 0,
+                "grace": True,
+                "enforced": False,
+            }
+        )

--- a/tests/test_entitlement_feature_spec_at_path.py
+++ b/tests/test_entitlement_feature_spec_at_path.py
@@ -1,0 +1,748 @@
+"""Tests for
+``clawmetry.entitlements.feature_spec_at_path(perspective, from, to, feature)``
++ ``feature_spec_at_path_batch(perspective, from, to, features)`` + the
+``GET /api/entitlement/feature-spec-at-path`` and ``GET
+/api/entitlement/feature-spec-at-path-batch`` endpoints.
+
+Perspective-validated what-if sibling of :func:`feature_spec_path` /
+:func:`feature_spec_path_batch`: perspective is validated but does NOT
+shape the ``path`` rows, so an upgrade-walkthrough surface can call
+``X_at_path(perspective, from, to, ...)`` uniformly across the whole
+``_at_path`` family (alongside ``preview_at_path`` and
+``tier_catalog_at_path``).
+
+Pins:
+
+* body byte-parity with :func:`feature_spec_path` for every
+  ``(perspective, from, to, feature)`` triple; perspective invariance
+  (rows byte-identical across shifting perspective for the same
+  ``(from, to, feature)``)
+* per-rung path row byte-equals :func:`feature_spec_at(rung, feature)`
+  after dropping the three ``rung*`` keys (delegated from
+  :func:`feature_spec_path`, pinned by
+  ``test_entitlement_feature_spec_path``)
+* batch per-feature ``path`` byte-equals scalar
+  :func:`feature_spec_at_path(perspective, from, to, feature)`
+* unknown perspective / from / to / feature → ``None`` (scalar); batch
+  short-circuits to ``None`` on unknown perspective / from / to and
+  buckets unknown features into ``unknown[]``
+* case + whitespace normalisation on all four ids
+* trial accepted as perspective + endpoint (lateral / identity branch)
+* grace vs enforce identical rows (delegates to
+  :func:`feature_spec_path` which walks static per-tier maps)
+* API surface: 400 on missing / blank / empty args, 404 with ``which``
+  bucketing on unknown tier ids, unknown feature ids echoed into
+  ``unknown[]`` on the batch endpoint (never 404), 200 envelope with
+  ``perspective_tier`` echo + standard ``_at*`` resolver-context tail
+  on the happy path
+* endpoint never 5xxs on resolver crash
+"""
+from __future__ import annotations
+
+import importlib
+from itertools import product
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+ALL_TIERS = (
+    "oss",
+    "cloud_free",
+    "trial",
+    "cloud_starter",
+    "cloud_pro",
+    "pro",
+    "enterprise",
+)
+
+SAMPLE_FEATURES = (
+    "sessions",
+    "custom_alerts",
+    "fleet",
+    "sso",
+    "anomaly_detection",
+)
+
+_RUNG_KEYS = {"rung", "rung_label", "rung_rank"}
+
+_SCALAR_ENVELOPE_KEYS = {
+    "perspective_tier",
+    "perspective_tier_rank",
+    "from",
+    "from_label",
+    "from_rank",
+    "to",
+    "to_label",
+    "to_rank",
+    "direction",
+    "feature",
+    "path",
+    "current_tier",
+    "current_tier_rank",
+    "grace",
+    "enforced",
+}
+
+_BATCH_ENVELOPE_KEYS = {
+    "perspective_tier",
+    "perspective_tier_rank",
+    "from",
+    "from_label",
+    "from_rank",
+    "to",
+    "to_label",
+    "to_rank",
+    "direction",
+    "features",
+    "unknown",
+    "current_tier",
+    "current_tier_rank",
+    "grace",
+    "enforced",
+}
+
+
+# ── scalar helper: shape + invariants ────────────────────────────────────────
+
+
+def test_scalar_returns_list(ent):
+    path = ent.feature_spec_at_path(
+        "cloud_pro", "oss", "enterprise", "custom_alerts"
+    )
+    assert isinstance(path, list)
+    assert len(path) >= 1
+
+
+def test_scalar_body_byte_parity_with_feature_spec_path(ent):
+    """Perspective must NOT shape the rows -- delegation to
+    :func:`feature_spec_path` is byte-identical for every perspective."""
+    for perspective, f, t, feat in product(
+        ALL_TIERS, ALL_TIERS, ALL_TIERS, SAMPLE_FEATURES
+    ):
+        at_path = ent.feature_spec_at_path(perspective, f, t, feat)
+        direct = ent.feature_spec_path(f, t, feat)
+        assert at_path == direct, (perspective, f, t, feat)
+
+
+def test_scalar_perspective_invariance(ent):
+    """Rows must be byte-identical across every perspective for the same
+    ``(from, to, feature)`` triple."""
+    for f, t, feat in product(("oss", "cloud_free"), ("enterprise", "pro"), SAMPLE_FEATURES):
+        rows_by_perspective = [
+            ent.feature_spec_at_path(p, f, t, feat) for p in ALL_TIERS
+        ]
+        first = rows_by_perspective[0]
+        for other in rows_by_perspective[1:]:
+            assert other == first
+
+
+def test_scalar_per_rung_byte_equality_with_feature_spec_at(ent):
+    """Dropping the three ``rung*`` keys from a path row yields exact
+    byte-equality with :func:`feature_spec_at(rung, feature)` -- a
+    property inherited from :func:`feature_spec_path`."""
+    path = ent.feature_spec_at_path(
+        "cloud_pro", "oss", "enterprise", "custom_alerts"
+    )
+    for row in path:
+        body = {k: v for k, v in row.items() if k not in _RUNG_KEYS}
+        direct = ent.feature_spec_at(row["rung"], "custom_alerts")
+        assert body == direct
+
+
+def test_scalar_identity_returns_empty_path(ent):
+    path = ent.feature_spec_at_path("cloud_pro", "cloud_pro", "cloud_pro", "custom_alerts")
+    assert path == []
+
+
+def test_scalar_lateral_returns_single_row(ent):
+    # cloud_pro and pro share a rank; lateral returns a single-row path.
+    path = ent.feature_spec_at_path("oss", "cloud_pro", "pro", "custom_alerts")
+    assert isinstance(path, list)
+    assert len(path) == 1
+    assert path[0]["rung"] == "pro"
+
+
+def test_scalar_upgrade_ranks_monotonic(ent):
+    path = ent.feature_spec_at_path("oss", "oss", "enterprise", "custom_alerts")
+    ranks = [r["rung_rank"] for r in path]
+    assert ranks == sorted(ranks)
+
+
+def test_scalar_downgrade_ranks_monotonic(ent):
+    path = ent.feature_spec_at_path("oss", "enterprise", "oss", "custom_alerts")
+    ranks = [r["rung_rank"] for r in path]
+    assert ranks == sorted(ranks, reverse=True)
+
+
+def test_scalar_trial_accepted_as_perspective(ent):
+    path = ent.feature_spec_at_path("trial", "oss", "enterprise", "custom_alerts")
+    assert path == ent.feature_spec_path("oss", "enterprise", "custom_alerts")
+
+
+def test_scalar_trial_accepted_as_endpoint(ent):
+    # trial as `to` is a valid lateral / identity endpoint via feature_spec_path.
+    lat = ent.feature_spec_at_path("cloud_pro", "cloud_free", "trial", "custom_alerts")
+    assert lat == ent.feature_spec_path("cloud_free", "trial", "custom_alerts")
+
+
+def test_scalar_unknown_perspective_returns_none(ent):
+    assert (
+        ent.feature_spec_at_path("bogus", "oss", "enterprise", "custom_alerts")
+        is None
+    )
+
+
+def test_scalar_unknown_from_returns_none(ent):
+    assert (
+        ent.feature_spec_at_path("cloud_pro", "bogus", "enterprise", "custom_alerts")
+        is None
+    )
+
+
+def test_scalar_unknown_to_returns_none(ent):
+    assert (
+        ent.feature_spec_at_path("cloud_pro", "oss", "bogus", "custom_alerts")
+        is None
+    )
+
+
+def test_scalar_unknown_feature_returns_none(ent):
+    assert (
+        ent.feature_spec_at_path("cloud_pro", "oss", "enterprise", "no_such_feat")
+        is None
+    )
+
+
+def test_scalar_none_inputs_return_none(ent):
+    assert ent.feature_spec_at_path(None, "oss", "enterprise", "custom_alerts") is None
+    assert ent.feature_spec_at_path("cloud_pro", None, "enterprise", "custom_alerts") is None
+    assert ent.feature_spec_at_path("cloud_pro", "oss", None, "custom_alerts") is None
+    assert ent.feature_spec_at_path("cloud_pro", "oss", "enterprise", None) is None
+
+
+def test_scalar_case_and_whitespace_normalised(ent):
+    a = ent.feature_spec_at_path(
+        "  Cloud_PRO ", " oss ", " ENTERPRISE\t", " custom_alerts "
+    )
+    b = ent.feature_spec_at_path(
+        "cloud_pro", "oss", "enterprise", "custom_alerts"
+    )
+    assert a == b
+
+
+def test_scalar_never_raises_on_weird_types(ent):
+    for weird in (b"bytes", 42, 3.14, [], {}):
+        assert ent.feature_spec_at_path(weird, "oss", "enterprise", "custom_alerts") is None
+        assert ent.feature_spec_at_path("cloud_pro", weird, "enterprise", "custom_alerts") is None
+        assert ent.feature_spec_at_path("cloud_pro", "oss", weird, "custom_alerts") is None
+        assert ent.feature_spec_at_path("cloud_pro", "oss", "enterprise", weird) is None
+
+
+def test_scalar_grace_vs_enforce_identical(ent, monkeypatch):
+    grace = ent.feature_spec_at_path(
+        "cloud_pro", "oss", "enterprise", "custom_alerts"
+    )
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    enforced = ent.feature_spec_at_path(
+        "cloud_pro", "oss", "enterprise", "custom_alerts"
+    )
+    assert grace == enforced
+
+
+# ── batch helper: shape + invariants ─────────────────────────────────────────
+
+
+def test_batch_returns_dict_shape(ent):
+    batch = ent.feature_spec_at_path_batch(
+        "cloud_pro", "oss", "enterprise", ["custom_alerts", "sso"]
+    )
+    assert isinstance(batch, dict)
+    assert set(batch.keys()) == {"features", "unknown"}
+    assert isinstance(batch["features"], list)
+    assert isinstance(batch["unknown"], list)
+
+
+def test_batch_body_byte_parity_with_feature_spec_path_batch(ent):
+    """Per-feature body must be byte-identical to
+    :func:`feature_spec_path_batch` for every perspective."""
+    features = ["custom_alerts", "sso", "fleet"]
+    for perspective, f, t in product(ALL_TIERS, ("oss", "cloud_free"), ("enterprise", "pro")):
+        at_batch = ent.feature_spec_at_path_batch(perspective, f, t, features)
+        direct = ent.feature_spec_path_batch(f, t, features)
+        assert at_batch == direct, (perspective, f, t)
+
+
+def test_batch_perspective_invariance(ent):
+    """Envelope byte-identical across every perspective for the same
+    ``(from, to, features)`` triple."""
+    features = ["custom_alerts", "sso"]
+    envelopes = [
+        ent.feature_spec_at_path_batch(p, "oss", "enterprise", features)
+        for p in ALL_TIERS
+    ]
+    first = envelopes[0]
+    for other in envelopes[1:]:
+        assert other == first
+
+
+def test_batch_row_path_equals_scalar_at_path(ent):
+    """Each ``features[].path`` byte-equals scalar
+    :func:`feature_spec_at_path(perspective, from, to, feature)`."""
+    features = ["custom_alerts", "sso"]
+    batch = ent.feature_spec_at_path_batch(
+        "cloud_pro", "oss", "enterprise", features
+    )
+    for entry in batch["features"]:
+        fid = entry["feature"]
+        scalar = ent.feature_spec_at_path(
+            "cloud_pro", "oss", "enterprise", fid
+        )
+        assert entry["path"] == scalar
+
+
+def test_batch_unknown_features_bucketed(ent):
+    batch = ent.feature_spec_at_path_batch(
+        "cloud_pro", "oss", "enterprise", ["custom_alerts", "no_such_feat", "sso"]
+    )
+    assert [e["feature"] for e in batch["features"]] == ["custom_alerts", "sso"]
+    assert batch["unknown"] == ["no_such_feat"]
+
+
+def test_batch_all_unknown_features(ent):
+    batch = ent.feature_spec_at_path_batch(
+        "cloud_pro", "oss", "enterprise", ["nope1", "nope2"]
+    )
+    assert batch == {"features": [], "unknown": ["nope1", "nope2"]}
+
+
+def test_batch_unknown_perspective_returns_none(ent):
+    assert (
+        ent.feature_spec_at_path_batch(
+            "bogus", "oss", "enterprise", ["custom_alerts"]
+        )
+        is None
+    )
+
+
+def test_batch_unknown_from_returns_none(ent):
+    assert (
+        ent.feature_spec_at_path_batch(
+            "cloud_pro", "bogus", "enterprise", ["custom_alerts"]
+        )
+        is None
+    )
+
+
+def test_batch_unknown_to_returns_none(ent):
+    assert (
+        ent.feature_spec_at_path_batch(
+            "cloud_pro", "oss", "bogus", ["custom_alerts"]
+        )
+        is None
+    )
+
+
+def test_batch_trial_accepted_as_perspective(ent):
+    batch = ent.feature_spec_at_path_batch(
+        "trial", "oss", "enterprise", ["custom_alerts", "sso"]
+    )
+    assert batch == ent.feature_spec_path_batch("oss", "enterprise", ["custom_alerts", "sso"])
+
+
+def test_batch_case_and_whitespace_normalised(ent):
+    a = ent.feature_spec_at_path_batch(
+        "  Cloud_PRO ", " oss ", " ENTERPRISE ", ["custom_alerts", "SSO"]
+    )
+    b = ent.feature_spec_at_path_batch(
+        "cloud_pro", "oss", "enterprise", ["custom_alerts", "sso"]
+    )
+    assert a == b
+
+
+def test_batch_grace_vs_enforce_identical(ent, monkeypatch):
+    grace = ent.feature_spec_at_path_batch(
+        "cloud_pro", "oss", "enterprise", ["custom_alerts", "sso"]
+    )
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    enforced = ent.feature_spec_at_path_batch(
+        "cloud_pro", "oss", "enterprise", ["custom_alerts", "sso"]
+    )
+    assert grace == enforced
+
+
+def test_batch_per_feature_crash_shorts_into_unknown(ent, monkeypatch):
+    """A per-feature delegation crash must short-circuit into
+    ``unknown[]`` -- the rest of the batch keeps building."""
+
+    real = ent.feature_spec_path
+
+    def _boom(f, t, feat):
+        if feat == "sso":
+            raise RuntimeError("boom")
+        return real(f, t, feat)
+
+    monkeypatch.setattr(ent, "feature_spec_path", _boom)
+    batch = ent.feature_spec_at_path_batch(
+        "cloud_pro", "oss", "enterprise", ["custom_alerts", "sso", "fleet"]
+    )
+    assert [e["feature"] for e in batch["features"]] == ["custom_alerts", "fleet"]
+    assert batch["unknown"] == ["sso"]
+
+
+# ── HTTP scalar: /api/entitlement/feature-spec-at-path ────────────────────────
+
+
+def test_http_scalar_envelope_shape(client):
+    r = client.get(
+        "/api/entitlement/feature-spec-at-path"
+        "?tier=cloud_pro&from=oss&to=enterprise&feature=custom_alerts"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert set(body.keys()) == _SCALAR_ENVELOPE_KEYS
+    assert body["perspective_tier"] == "cloud_pro"
+    assert body["from"] == "oss"
+    assert body["to"] == "enterprise"
+    assert body["direction"] == "upgrade"
+    assert body["feature"] == "custom_alerts"
+    assert isinstance(body["path"], list) and body["path"]
+
+
+def test_http_scalar_missing_tier(client):
+    r = client.get(
+        "/api/entitlement/feature-spec-at-path?from=oss&to=enterprise&feature=custom_alerts"
+    )
+    assert r.status_code == 400
+
+
+def test_http_scalar_missing_from(client):
+    r = client.get(
+        "/api/entitlement/feature-spec-at-path?tier=cloud_pro&to=enterprise&feature=custom_alerts"
+    )
+    assert r.status_code == 400
+
+
+def test_http_scalar_missing_to(client):
+    r = client.get(
+        "/api/entitlement/feature-spec-at-path?tier=cloud_pro&from=oss&feature=custom_alerts"
+    )
+    assert r.status_code == 400
+
+
+def test_http_scalar_missing_feature(client):
+    r = client.get(
+        "/api/entitlement/feature-spec-at-path?tier=cloud_pro&from=oss&to=enterprise"
+    )
+    assert r.status_code == 400
+
+
+def test_http_scalar_unknown_tier_404_which_tier(client):
+    r = client.get(
+        "/api/entitlement/feature-spec-at-path"
+        "?tier=bogus&from=oss&to=enterprise&feature=custom_alerts"
+    )
+    assert r.status_code == 404
+    body = r.get_json()
+    assert body["which"] == "tier"
+    assert body["tier"] == "bogus"
+
+
+def test_http_scalar_unknown_from_404_which_from(client):
+    r = client.get(
+        "/api/entitlement/feature-spec-at-path"
+        "?tier=cloud_pro&from=bogus&to=enterprise&feature=custom_alerts"
+    )
+    assert r.status_code == 404
+    assert r.get_json()["which"] == "from"
+
+
+def test_http_scalar_unknown_to_404_which_to(client):
+    r = client.get(
+        "/api/entitlement/feature-spec-at-path"
+        "?tier=cloud_pro&from=oss&to=bogus&feature=custom_alerts"
+    )
+    assert r.status_code == 404
+    assert r.get_json()["which"] == "to"
+
+
+def test_http_scalar_unknown_feature_404_which_feature(client):
+    r = client.get(
+        "/api/entitlement/feature-spec-at-path"
+        "?tier=cloud_pro&from=oss&to=enterprise&feature=no_such_feat"
+    )
+    assert r.status_code == 404
+    body = r.get_json()
+    assert body["which"] == "feature"
+    assert body["feature"] == "no_such_feat"
+
+
+def test_http_scalar_trial_accepted_as_perspective(client):
+    r = client.get(
+        "/api/entitlement/feature-spec-at-path"
+        "?tier=trial&from=oss&to=enterprise&feature=custom_alerts"
+    )
+    assert r.status_code == 200
+    assert r.get_json()["perspective_tier"] == "trial"
+
+
+def test_http_scalar_identity_empty_path(client):
+    r = client.get(
+        "/api/entitlement/feature-spec-at-path"
+        "?tier=cloud_pro&from=cloud_pro&to=cloud_pro&feature=custom_alerts"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["direction"] == "identity"
+    assert body["path"] == []
+
+
+def test_http_scalar_downgrade_direction(client):
+    r = client.get(
+        "/api/entitlement/feature-spec-at-path"
+        "?tier=cloud_pro&from=enterprise&to=oss&feature=custom_alerts"
+    )
+    assert r.status_code == 200
+    assert r.get_json()["direction"] == "downgrade"
+
+
+def test_http_scalar_case_whitespace_normalised(client):
+    r = client.get(
+        "/api/entitlement/feature-spec-at-path"
+        "?tier=%20Cloud_PRO%20&from=%20OSS%20&to=%20ENTERPRISE%20&feature=%20custom_alerts%20"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["perspective_tier"] == "cloud_pro"
+    assert body["from"] == "oss"
+    assert body["to"] == "enterprise"
+    assert body["feature"] == "custom_alerts"
+
+
+def test_http_scalar_path_parity_with_feature_spec_path(client):
+    """``path`` in the ``_at_path`` envelope must byte-equal ``path`` in
+    ``/feature-spec-path`` for the same ``(from, to, feature)``."""
+    r_at = client.get(
+        "/api/entitlement/feature-spec-at-path"
+        "?tier=cloud_pro&from=oss&to=enterprise&feature=custom_alerts"
+    )
+    r_base = client.get(
+        "/api/entitlement/feature-spec-path"
+        "?from=oss&to=enterprise&feature=custom_alerts"
+    )
+    assert r_at.get_json()["path"] == r_base.get_json()["path"]
+
+
+def test_http_scalar_perspective_invariance(client):
+    baseline = client.get(
+        "/api/entitlement/feature-spec-at-path"
+        "?tier=cloud_pro&from=oss&to=enterprise&feature=custom_alerts"
+    ).get_json()["path"]
+    for p in ALL_TIERS:
+        got = client.get(
+            f"/api/entitlement/feature-spec-at-path?tier={p}&from=oss&to=enterprise&feature=custom_alerts"
+        ).get_json()["path"]
+        assert got == baseline, p
+
+
+# ── HTTP batch: /api/entitlement/feature-spec-at-path-batch ──────────────────
+
+
+def test_http_batch_envelope_shape(client):
+    r = client.get(
+        "/api/entitlement/feature-spec-at-path-batch"
+        "?tier=cloud_pro&from=oss&to=enterprise&features=custom_alerts,sso,fleet"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert set(body.keys()) == _BATCH_ENVELOPE_KEYS
+    assert body["perspective_tier"] == "cloud_pro"
+    assert body["direction"] == "upgrade"
+    assert [e["feature"] for e in body["features"]] == ["custom_alerts", "sso", "fleet"]
+    assert body["unknown"] == []
+
+
+def test_http_batch_missing_tier(client):
+    r = client.get(
+        "/api/entitlement/feature-spec-at-path-batch"
+        "?from=oss&to=enterprise&features=custom_alerts"
+    )
+    assert r.status_code == 400
+
+
+def test_http_batch_missing_from(client):
+    r = client.get(
+        "/api/entitlement/feature-spec-at-path-batch"
+        "?tier=cloud_pro&to=enterprise&features=custom_alerts"
+    )
+    assert r.status_code == 400
+
+
+def test_http_batch_missing_to(client):
+    r = client.get(
+        "/api/entitlement/feature-spec-at-path-batch"
+        "?tier=cloud_pro&from=oss&features=custom_alerts"
+    )
+    assert r.status_code == 400
+
+
+def test_http_batch_missing_features_400(client):
+    r = client.get(
+        "/api/entitlement/feature-spec-at-path-batch"
+        "?tier=cloud_pro&from=oss&to=enterprise"
+    )
+    assert r.status_code == 400
+
+
+def test_http_batch_empty_features_400(client):
+    r = client.get(
+        "/api/entitlement/feature-spec-at-path-batch"
+        "?tier=cloud_pro&from=oss&to=enterprise&features="
+    )
+    assert r.status_code == 400
+
+
+def test_http_batch_unknown_tier_404_which_tier(client):
+    r = client.get(
+        "/api/entitlement/feature-spec-at-path-batch"
+        "?tier=bogus&from=oss&to=enterprise&features=custom_alerts"
+    )
+    assert r.status_code == 404
+    assert r.get_json()["which"] == "tier"
+
+
+def test_http_batch_unknown_from_404_which_from(client):
+    r = client.get(
+        "/api/entitlement/feature-spec-at-path-batch"
+        "?tier=cloud_pro&from=bogus&to=enterprise&features=custom_alerts"
+    )
+    assert r.status_code == 404
+    assert r.get_json()["which"] == "from"
+
+
+def test_http_batch_unknown_to_404_which_to(client):
+    r = client.get(
+        "/api/entitlement/feature-spec-at-path-batch"
+        "?tier=cloud_pro&from=oss&to=bogus&features=custom_alerts"
+    )
+    assert r.status_code == 404
+    assert r.get_json()["which"] == "to"
+
+
+def test_http_batch_unknown_feature_bucketed_not_404(client):
+    r = client.get(
+        "/api/entitlement/feature-spec-at-path-batch"
+        "?tier=cloud_pro&from=oss&to=enterprise&features=custom_alerts,no_such_feat,sso"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert [e["feature"] for e in body["features"]] == ["custom_alerts", "sso"]
+    assert body["unknown"] == ["no_such_feat"]
+
+
+def test_http_batch_features_parity_with_feature_spec_path_batch(client):
+    """``features[]`` in the ``_at_path_batch`` envelope must byte-equal
+    ``features[]`` in ``/feature-spec-path-batch`` for the same
+    ``(from, to, features)``."""
+    r_at = client.get(
+        "/api/entitlement/feature-spec-at-path-batch"
+        "?tier=cloud_pro&from=oss&to=enterprise&features=custom_alerts,sso"
+    )
+    r_base = client.get(
+        "/api/entitlement/feature-spec-path-batch"
+        "?from=oss&to=enterprise&features=custom_alerts,sso"
+    )
+    assert r_at.get_json()["features"] == r_base.get_json()["features"]
+
+
+def test_http_batch_perspective_invariance(client):
+    baseline = client.get(
+        "/api/entitlement/feature-spec-at-path-batch"
+        "?tier=cloud_pro&from=oss&to=enterprise&features=custom_alerts,sso"
+    ).get_json()["features"]
+    for p in ALL_TIERS:
+        got = client.get(
+            f"/api/entitlement/feature-spec-at-path-batch?tier={p}&from=oss&to=enterprise&features=custom_alerts,sso"
+        ).get_json()["features"]
+        assert got == baseline, p
+
+
+def test_http_batch_trial_accepted_as_perspective(client):
+    r = client.get(
+        "/api/entitlement/feature-spec-at-path-batch"
+        "?tier=trial&from=oss&to=enterprise&features=custom_alerts,sso"
+    )
+    assert r.status_code == 200
+    assert r.get_json()["perspective_tier"] == "trial"
+
+
+def test_http_batch_case_whitespace_normalised(client):
+    r = client.get(
+        "/api/entitlement/feature-spec-at-path-batch"
+        "?tier=%20Cloud_PRO%20&from=%20OSS%20&to=%20ENTERPRISE%20"
+        "&features=%20custom_alerts%20,%20SSO%20"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["perspective_tier"] == "cloud_pro"
+    assert body["from"] == "oss"
+    assert body["to"] == "enterprise"
+    assert [e["feature"] for e in body["features"]] == ["custom_alerts", "sso"]
+
+
+def test_http_batch_never_5xxs_on_resolver_crash(client, monkeypatch, ent):
+    monkeypatch.setattr(
+        ent,
+        "feature_spec_at_path_batch",
+        lambda *_a, **_k: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
+    r = client.get(
+        "/api/entitlement/feature-spec-at-path-batch"
+        "?tier=cloud_pro&from=oss&to=enterprise&features=custom_alerts,sso"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["perspective_tier"] == "cloud_pro"
+    assert body["features"] == []
+    assert body["unknown"] == []
+    assert body["grace"] is True
+
+
+def test_http_scalar_never_5xxs_on_resolver_crash(client, monkeypatch, ent):
+    monkeypatch.setattr(
+        ent,
+        "feature_spec_at_path",
+        lambda *_a, **_k: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
+    r = client.get(
+        "/api/entitlement/feature-spec-at-path"
+        "?tier=cloud_pro&from=oss&to=enterprise&feature=custom_alerts"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["perspective_tier"] == "cloud_pro"
+    assert body["path"] == []
+    assert body["grace"] is True


### PR DESCRIPTION
## Summary

Fills the `_at_path` / `_at_path_batch` slot for the feature-spec family. Perspective-validated what-if sibling of the already-merged `feature_spec_path` / `feature_spec_path_batch`: perspective is validated but does NOT shape the rows, so an upgrade-walkthrough surface can call `X_at_path(perspective, from, to, ...)` uniformly across the whole `_at_path` family alongside `preview_at_path` (open PR #3511) and `tier_catalog_at_path` (open PR #3518).

- Module-level `feature_spec_at_path(perspective_tier, from_tier, to_tier, feature)` -- scalar what-if path. Body byte-identical to `feature_spec_path(from_tier, to_tier, feature)` for every perspective. Pinned by parity tests so the singular can never drift from `feature_spec_path` (which itself walks per-rung via `feature_spec_at`). Trial accepted as perspective (lenient posture matching every other `_at` helper); endpoint acceptance mirrors `feature_spec_path` (any id in `_TIER_FEATURES`, including `trial` via the lateral / identity branch).
- Module-level `feature_spec_at_path_batch(perspective_tier, from_tier, to_tier, features)` -- fixed-perspective, fixed-from, fixed-to, multi-feature companion. Per-feature body byte-identical to `feature_spec_path_batch(from_tier, to_tier, features)` for the same targets (scalar / batch no-drift contract).
- `GET /api/entitlement/feature-spec-at-path?tier=&from=&to=&feature=` -- 400 on missing / blank input, 404 on unknown perspective / from / to / feature (body carries `which: "tier" | "from" | "to" | "feature"` so the caller can point at the offender), never 5xxs on resolver crash. Response envelope: `perspective_tier` + `perspective_tier_rank` echo, the same `from` / `from_label` / `from_rank` / `to` / `to_label` / `to_rank` / `direction` / `feature` / `path` fields as `/feature-spec-path`, plus the standard `_at*` resolver-context tail (`current_tier` / `current_tier_rank` / `grace` / `enforced`).
- `GET /api/entitlement/feature-spec-at-path-batch?tier=&from=&to=&features=a,b,c` -- envelope mirrors `/feature-spec-path-batch` plus `perspective_tier` / `perspective_tier_rank` echo and the resolver-context tail. GET+CSV shape matches sibling `/feature-spec-path-batch` (rest of the `feature-spec` family already uses GET+CSV; keeps the family internally consistent). Unknown feature ids are echoed in `unknown[]` instead of short-circuiting so a partially-bad caller still gets paths back for the valid ids, matching every other `*_path_batch` sibling's posture.

Fills the feature-spec-family gap in the `_at_path` / `_at_path_batch` slot:

| helper                          | slot                       | status         |
|---------------------------------|----------------------------|----------------|
| `feature_spec`                  | scalar (current)           | already merged |
| `feature_spec_batch`            | batch (current)            | already merged |
| `feature_spec_at`               | scalar (hypothetical)      | already merged |
| `feature_spec_at_batch`         | batch (hypothetical)       | already merged |
| `feature_spec_path`             | path (current)             | already merged |
| `feature_spec_path_batch`       | batch path (current)       | already merged |
| `feature_spec_at_path`          | path (hypothetical)        | **this PR**    |
| `feature_spec_at_path_batch`    | batch path (hypothetical)  | **this PR**    |

Posture matches the rest of the `_at` family:

- Perspective + feature ids normalised (whitespace stripped, lowercased, duplicates dropped, first-seen order preserved on the batch).
- Unknown feature ids echoed in `unknown[]` on the batch endpoint instead of short-circuiting -- a partially-bad caller still gets paths back for the valid ids alongside a list of what was dropped.
- `trial` IS accepted as perspective (any id in `_TIER_FEATURES`) and as endpoint (via `feature_spec_path`'s lateral / identity branch).
- Per-rung path row is the `feature_spec_at(rung, feature)` body augmented with the three `rung*` keys -- inherited via delegation to `feature_spec_path`.
- Resolver-independent: delegates to `feature_spec_path` / `feature_spec_path_batch`, which walk the static per-tier maps, so grace vs enforce yields byte-identical rows.
- Never raises: per-feature crash short-circuits that id into `unknown[]`; endpoint resolver failure short-circuits to a grace-shape envelope (no 5xx).

**Grace-only, read-only**: no gate enforced, no behaviour change against the currently-resolved entitlement -- these are new read-only endpoints.

## Test plan

- [x] `python3 -m py_compile clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_feature_spec_at_path.py` -- clean
- [x] `ruff check clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_feature_spec_at_path.py` -- all checks passed
- [x] `python3 -m pytest tests/test_entitlement_feature_spec_at_path.py -q` -- **62 passed**
- [x] Adjacent regression sweep -- **133 passed** across `test_entitlement_feature_spec_at`, `test_entitlement_feature_spec_path`, `test_entitlement_preview_path`, `test_entitlement_api`.

### Coverage in `tests/test_entitlement_feature_spec_at_path.py`

- **scalar helper**: shape; body byte-parity with `feature_spec_path(from, to, feature)` across every `(perspective, from, to, feature)` combination in `ALL_TIERS × ALL_TIERS × ALL_TIERS × SAMPLE_FEATURES`; perspective invariance (byte-identical rows across shifting perspective); per-rung row byte-equals `feature_spec_at(rung, feature)` after dropping the three `rung*` keys; identity → `[]`; lateral → single-row path; upgrade / downgrade ranks monotonic; trial accepted as perspective + endpoint; unknown perspective / from / to / feature → `None`; `None` inputs → `None`; case + whitespace normalisation; never-raises on weird input types (bytes / ints / floats / lists / dicts); grace vs enforce byte-identical.
- **batch helper**: envelope `{features, unknown}` shape; body byte-parity with `feature_spec_path_batch(from, to, features)` for every perspective; batch-level perspective invariance; each `features[].path` equals scalar `feature_spec_at_path(perspective, from, to, feature)`; unknown features bucketed in `unknown[]`; all-unknown case → `{"features": [], "unknown": [...]}`; unknown perspective / from / to → `None`; trial accepted as perspective; case + whitespace normalisation; grace vs enforce byte-identical; per-feature row crash short-circuits into `unknown[]` (monkeypatched delegate crash).
- **HTTP scalar (`/feature-spec-at-path`)**: 15-key envelope shape; 400 on missing `tier` / `from` / `to` / `feature`; 404 with `which: "tier" | "from" | "to" | "feature"` on unknown ids; 200 happy path; trial accepted as perspective; identity path empty; downgrade direction; case + whitespace normalisation via URL-encoded query; `path` body-parity with `/feature-spec-path`; perspective-invariance across every perspective; never 5xxs on resolver crash.
- **HTTP batch (`/feature-spec-at-path-batch`)**: 15-key envelope shape; 400 on missing `tier` / `from` / `to` and missing / empty `features` list; 404 with `which` bucketing on unknown tier ids; 200 happy path; unknown feature ids bucketed into `unknown[]` (200, not 404); multi-feature; `features[]` body-parity with `/feature-spec-path-batch`; perspective invariance across every perspective; trial accepted as perspective; whitespace / casing normalisation; never 5xxs on resolver crash.

## Local operator verification checklist

The public-repo agent cannot exercise the live daemon, cloud snapshot, or browser. Please copy the changed files into your locally-installed clawmetry site-packages and verify against the real daemon before flipping ready-for-review:

```bash
# 1. Copy the changed files into the installed package
SP="$HOME/.clawmetry/lib/python$(python3 -c 'import sys;print(f"{sys.version_info.major}.{sys.version_info.minor}")')/site-packages/clawmetry"
cp clawmetry/entitlements.py "$SP/entitlements.py"
# routes/ isn't inside the package; on the default layout it lands at
# $HOME/.clawmetry/lib/python*/site-packages/routes/entitlement.py
find "$HOME/.clawmetry" -name entitlement.py -path '*routes*' -exec cp routes/entitlement.py {} \;

# 2. Purge stale bytecode so the new module actually loads
find "$HOME/.clawmetry" -type d -name __pycache__ -exec rm -rf {} +

# 3. Bounce the sync daemon so it re-imports
launchctl kickstart -k "gui/$(id -u)/com.clawmetry.sync"

# 4. Hit the new scalar endpoint (happy path)
curl -s 'http://localhost:8900/api/entitlement/feature-spec-at-path?tier=cloud_pro&from=oss&to=enterprise&feature=custom_alerts' | jq
# Expect: 200 with {perspective_tier: "cloud_pro", from: "oss", to: "enterprise", direction: "upgrade", feature: "custom_alerts", path: [...], ...}

# 5. Trial accepted as perspective
curl -s 'http://localhost:8900/api/entitlement/feature-spec-at-path?tier=trial&from=oss&to=enterprise&feature=custom_alerts' | jq '.perspective_tier'
# Expect: "trial"

# 6. Error paths
curl -si 'http://localhost:8900/api/entitlement/feature-spec-at-path?from=oss&to=enterprise&feature=custom_alerts' | head -1
# Expect: HTTP/1.1 400 (missing tier)
curl -si 'http://localhost:8900/api/entitlement/feature-spec-at-path?tier=cloud_pro&to=enterprise&feature=custom_alerts' | head -1
# Expect: HTTP/1.1 400 (missing from)
curl -si 'http://localhost:8900/api/entitlement/feature-spec-at-path?tier=cloud_pro&from=oss&feature=custom_alerts' | head -1
# Expect: HTTP/1.1 400 (missing to)
curl -si 'http://localhost:8900/api/entitlement/feature-spec-at-path?tier=cloud_pro&from=oss&to=enterprise' | head -1
# Expect: HTTP/1.1 400 (missing feature)
curl -s  'http://localhost:8900/api/entitlement/feature-spec-at-path?tier=bogus&from=oss&to=enterprise&feature=custom_alerts'      | jq '.which'
# Expect: "tier"
curl -s  'http://localhost:8900/api/entitlement/feature-spec-at-path?tier=cloud_pro&from=bogus&to=enterprise&feature=custom_alerts' | jq '.which'
# Expect: "from"
curl -s  'http://localhost:8900/api/entitlement/feature-spec-at-path?tier=cloud_pro&from=oss&to=bogus&feature=custom_alerts'        | jq '.which'
# Expect: "to"
curl -s  'http://localhost:8900/api/entitlement/feature-spec-at-path?tier=cloud_pro&from=oss&to=enterprise&feature=no_such_feat'    | jq '.which'
# Expect: "feature"

# 7. Batch happy path
curl -s 'http://localhost:8900/api/entitlement/feature-spec-at-path-batch?tier=cloud_pro&from=oss&to=enterprise&features=custom_alerts,sso,fleet' | jq
# Expect: 200 with envelope {perspective_tier, from, to, features[3], unknown: [], current_tier, grace, enforced}

# 8. Partial-unknown feature bucketing (200, not 404)
curl -s 'http://localhost:8900/api/entitlement/feature-spec-at-path-batch?tier=cloud_pro&from=oss&to=enterprise&features=custom_alerts,no_such_feat,sso' | jq '.unknown'
# Expect: ["no_such_feat"]

# 9. Perspective invariance (rows identical across shifting perspective)
for p in oss cloud_free cloud_starter cloud_pro pro enterprise trial; do
  diff \
    <(curl -s "http://localhost:8900/api/entitlement/feature-spec-at-path-batch?tier=$p&from=oss&to=enterprise&features=custom_alerts,sso" | jq '.features') \
    <(curl -s "http://localhost:8900/api/entitlement/feature-spec-at-path-batch?tier=cloud_pro&from=oss&to=enterprise&features=custom_alerts,sso" | jq '.features') \
  && echo "$p: perspective-invariant OK"
done
# Expect: "perspective-invariant OK" for every perspective.

# 10. Parity with /feature-spec-path-batch (which the batch delegates to)
diff \
  <(curl -s 'http://localhost:8900/api/entitlement/feature-spec-at-path-batch?tier=cloud_pro&from=oss&to=enterprise&features=custom_alerts,sso' | jq '.features') \
  <(curl -s 'http://localhost:8900/api/entitlement/feature-spec-path-batch?from=oss&to=enterprise&features=custom_alerts,sso' | jq '.features') \
&& echo "features[] byte-parity with feature-spec-path-batch OK"

# 11. Decrypt the live cloud snapshot in the browser + sanity-check no
# regressions on the existing /feature-spec, /feature-spec-at, /feature-spec-batch,
# /feature-spec-at-batch, /feature-spec-path, /feature-spec-path-batch endpoints.
```

If everything looks right, flip to ready-for-review and merge in the normal flow. Only the local operator has access to the live daemon and snapshot for step 11, which is why this PR stays draft until then.

Non-overlapping with open PR #3511 (`preview_at_path` / `preview_at_path_batch`) and open PR #3518 (`tier_catalog_at_path` / `tier_catalog_at_path_batch`): all three fill the same `_at_path` slot on distinct axes (`preview` / `tier_catalog` / `feature_spec`). New helpers land at the very end of `entitlements.py` (after `runtime_catalog_path_batch`) and new routes at the end of `routes/entitlement.py` (after `_next_prev_lock_reason_batch`) -- both a clearly separate surface from #3511 (which lives in the `preview` family region) and #3518 (which lives in the `tier_catalog` family region).

The next-phase work (P3 / P4 / P6 -- cloud-side entitlement minting, `clawmetry-pro` package download, enterprise SSO) needs the private `clawmetry-cloud` / `clawmetry-pro` repos and is out of scope for this remote session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012LHa1wBhfNbv9zupxZPJoN)_