### PR TITLE
feat(entitlement): runtime_spec_at_path + runtime_spec_at_path_batch + 2 endpoints

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -9403,6 +9403,105 @@ def runtime_spec_path_batch(
     return {"runtimes": rows, "unknown": unknown}
 
 
+def runtime_spec_at_path(
+    perspective_tier: str, from_tier: str, to_tier: str, runtime: str
+) -> list[dict] | None:
+    """Perspective-validated what-if wrapper around :func:`runtime_spec_path`.
+
+    Runtime-axis twin of :func:`feature_spec_at_path`; fills the
+    ``_at_path`` slot of the ``runtime_spec`` family, matching the
+    already-shipping ``preview_at_path`` / ``tier_catalog_at_path``
+    pattern on the ``preview`` / ``tier_catalog`` axes. The perspective
+    is validated (empty / unknown ids short-circuit to ``None``) but
+    does NOT shape the rows -- the body is byte-identical to
+    :func:`runtime_spec_path` for every ``(from, to, runtime)`` triple,
+    so a paywall walkthrough UI can call
+    ``X_at_path(perspective, from, to, ...)`` uniformly across the
+    whole ``_at_path`` family without worrying that the perspective is
+    silently changing which rungs get walked.
+
+    Pins a parity test so the scalar ``_at_path`` can never drift from
+    :func:`runtime_spec_path` (which itself walks per-rung via
+    :func:`runtime_spec_at`).
+
+    Endpoint semantics match :func:`runtime_spec_path`: perspective,
+    from and to accept any id in :data:`_TIER_FEATURES` (``trial``
+    accepted, excluded from the walked intermediate rungs, valid
+    endpoint via the lateral / identity branch). ``runtime`` accepts
+    any id in :data:`ALL_RUNTIMES` after canonicalisation via
+    :func:`canonical_runtime` (``claude-code`` -> ``claude_code``).
+
+    Never raises: a delegation failure logs a warning and returns
+    ``None`` so a paywall surface keeps rendering instead of breaking.
+    """
+    try:
+        p = (perspective_tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if not p or p not in _TIER_FEATURES:
+        return None
+    try:
+        return runtime_spec_path(from_tier, to_tier, runtime)
+    except Exception as exc:
+        logger.warning("entitlements: runtime_spec_at_path failed: %s", exc)
+        return None
+
+
+def runtime_spec_at_path_batch(
+    perspective_tier: str, from_tier: str, to_tier: str, runtimes
+) -> dict | None:
+    """Perspective-validated what-if wrapper around
+    :func:`runtime_spec_path_batch`.
+
+    Fixed-perspective, fixed-from, fixed-to, multi-runtime companion of
+    :func:`runtime_spec_at_path`. Fills the ``_at_path_batch`` slot of
+    the ``runtime_spec`` family, matching the already-shipping
+    ``preview_at_path_batch`` / ``tier_catalog_at_path_batch`` pattern
+    on the ``preview`` / ``tier_catalog`` axes, and pairs one-to-one
+    with :func:`feature_spec_at_path_batch` on the ``feature_spec`` axis.
+
+    Per-runtime body byte-identical to :func:`runtime_spec_path_batch`
+    for the same ``(from, to, runtimes)`` triple -- scalar / batch
+    no-drift contract (the batch delegates to the same underlying
+    :func:`runtime_spec_path` per runtime that the scalar
+    :func:`runtime_spec_at_path` delegates to).
+
+    Shape mirrors :func:`runtime_spec_path_batch`::
+
+        {
+          "runtimes": [{"runtime": "<canonical id>", "path": [...]}, ...],
+          "unknown":  ["bogus_id", ...],
+        }
+
+    Supplied runtime ids are canonicalised via
+    :func:`canonical_runtime` (``claude-code`` -> ``claude_code``) and
+    aliases that collapse to a canonical id already in the response are
+    silently de-duplicated. Unknown ids are echoed in ``unknown[]``
+    carrying the supplied alias (not the canonical id) so the caller
+    can correlate against what was sent, matching every other
+    ``*_path_batch`` sibling's posture.
+
+    Returns ``None`` for empty / unknown ``perspective_tier`` /
+    ``from_tier`` / ``to_tier`` (caller renders "unknown tier" / 404).
+    Never raises: per-runtime failures short-circuit that id into
+    ``unknown[]``; a top-level delegation failure short-circuits to
+    ``None``.
+    """
+    try:
+        p = (perspective_tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if not p or p not in _TIER_FEATURES:
+        return None
+    try:
+        return runtime_spec_path_batch(from_tier, to_tier, runtimes)
+    except Exception as exc:
+        logger.warning(
+            "entitlements: runtime_spec_at_path_batch failed: %s", exc
+        )
+        return None
+
+
 def tier_catalog_path_batch(from_tier: str, to_tiers) -> dict | None:
     """Batch sibling of :func:`tier_catalog_path`: per-rung tier-ladder
     path rows for a caller-supplied subset of destination tiers all

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -10289,6 +10289,318 @@ def api_entitlement_runtime_spec_path_batch():
         )
 
 
+@bp_entitlement.route("/api/entitlement/runtime-spec-at-path")
+def api_entitlement_runtime_spec_at_path():
+    """``GET /api/entitlement/runtime-spec-at-path?tier=<perspective>
+    &from=<id>&to=<id>&runtime=<id>`` -- perspective-validated what-if
+    sibling of ``/api/entitlement/runtime-spec-path``.
+
+    Runtime-axis twin of ``/feature-spec-at-path``; fills the
+    ``_at_path`` slot of the ``runtime-spec`` family, matching the
+    already-shipping ``preview_at_path`` / ``tier_catalog_at_path``
+    pattern on the ``preview`` / ``tier_catalog`` axes. The perspective
+    is validated (400 on missing, 404 on unknown) but does NOT shape
+    the ``path`` rows -- the body is byte-identical to
+    ``/runtime-spec-path?from=<from>&to=<to>&runtime=<runtime>`` for
+    every perspective. Pinned by parity tests so the ``_at_path`` and
+    ``_path`` endpoints cannot drift.
+
+    Accepts runtime aliases (``claude-code`` -> ``claude_code``) via
+    :func:`clawmetry.entitlements.canonical_runtime` so the URL surface
+    matches what callers already pass to ``/api/entitlement/required-tier``.
+
+    Response shape (mirrors ``/runtime-spec-path`` plus a
+    ``perspective_tier`` echo and the standard ``_at*`` resolver-context
+    tail so a paywall matrix UI can render "at Cloud Pro this runtime
+    unlocks at Starter" without a second call to ``/entitlement``)::
+
+        {
+          "perspective_tier":      "<id>",
+          "perspective_tier_rank": <int>,
+          "from":                  "<tier id>",
+          "from_label":            "...",
+          "from_rank":             <int>,
+          "to":                    "<tier id>",
+          "to_label":              "...",
+          "to_rank":               <int>,
+          "direction":             "upgrade" | "downgrade" | "lateral" | "identity",
+          "runtime":               "<canonical runtime id>",
+          "path":                  [<runtime_spec_path row>, ...],
+          "current_tier":          "...",
+          "current_tier_rank":     <int>,
+          "grace":                 <bool>,
+          "enforced":              <bool>,
+        }
+
+    - **400** when ``tier=``, ``from=``, ``to=`` or ``runtime=`` is
+      missing / blank
+    - **404** when any id is unknown (body carries
+      ``which: "tier" | "from" | "to" | "runtime"`` so the caller can
+      point at the offender)
+    - **Never 5xxs**: a resolver failure short-circuits to the grace-
+      shape envelope with the perspective echoed so the UI keeps
+      rendering.
+    """
+    raw_tier = request.args.get("tier")
+    tier_in = (raw_tier or "").strip().lower()
+    if not tier_in:
+        return jsonify({"error": "missing tier"}), 400
+    f = (request.args.get("from") or "").strip().lower()
+    t = (request.args.get("to") or "").strip().lower()
+    if not f:
+        return jsonify({"error": "missing from"}), 400
+    if not t:
+        return jsonify({"error": "missing to"}), 400
+    rt_raw = (request.args.get("runtime") or "").strip()
+    if not rt_raw:
+        return jsonify({"error": "missing runtime"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        if tier_in not in _ent._TIER_FEATURES:
+            return (
+                jsonify(
+                    {
+                        "error": "unknown tier",
+                        "which": "tier",
+                        "tier": tier_in,
+                    }
+                ),
+                404,
+            )
+        if f not in _ent._TIER_FEATURES:
+            return (
+                jsonify(
+                    {"error": "unknown from", "which": "from", "from": f}
+                ),
+                404,
+            )
+        if t not in _ent._TIER_FEATURES:
+            return (
+                jsonify({"error": "unknown to", "which": "to", "to": t}),
+                404,
+            )
+        rt = _ent.canonical_runtime(rt_raw)
+        if not rt or rt not in _ent.ALL_RUNTIMES:
+            return (
+                jsonify(
+                    {
+                        "error": "unknown runtime",
+                        "which": "runtime",
+                        "runtime": rt or rt_raw.lower(),
+                    }
+                ),
+                404,
+            )
+        path = _ent.runtime_spec_at_path(tier_in, f, t, rt_raw)
+        if path is None:
+            path = []
+        from_rank = _ent.tier_rank(f)
+        to_rank = _ent.tier_rank(t)
+        if f == t:
+            direction = "identity"
+        elif from_rank == to_rank:
+            direction = "lateral"
+        elif to_rank > from_rank:
+            direction = "upgrade"
+        else:
+            direction = "downgrade"
+        ent = _ent.get_entitlement()
+        return jsonify(
+            {
+                "perspective_tier": tier_in,
+                "perspective_tier_rank": _ent.tier_rank(tier_in),
+                "from": f,
+                "from_label": _ent.tier_label(f),
+                "from_rank": from_rank,
+                "to": t,
+                "to_label": _ent.tier_label(t),
+                "to_rank": to_rank,
+                "direction": direction,
+                "runtime": rt,
+                "path": path,
+                "current_tier": ent.tier,
+                "current_tier_rank": _ent.tier_rank(ent.tier),
+                "grace": bool(ent.grace),
+                "enforced": _ent.is_enforced(),
+            }
+        )
+    except Exception as exc:
+        logger.warning("api_entitlement_runtime_spec_at_path: error: %s", exc)
+        return jsonify(
+            {
+                "perspective_tier": tier_in,
+                "perspective_tier_rank": 0,
+                "from": f,
+                "from_label": None,
+                "from_rank": -1,
+                "to": t,
+                "to_label": None,
+                "to_rank": -1,
+                "direction": "identity" if f == t else "upgrade",
+                "runtime": rt_raw.lower(),
+                "path": [],
+                "current_tier": "oss",
+                "current_tier_rank": 0,
+                "grace": True,
+                "enforced": False,
+            }
+        )
+
+
+@bp_entitlement.route("/api/entitlement/runtime-spec-at-path-batch")
+def api_entitlement_runtime_spec_at_path_batch():
+    """``GET /api/entitlement/runtime-spec-at-path-batch?tier=<perspective>
+    &from=<id>&to=<id>&runtimes=a,b,c`` -- perspective-validated what-if
+    batch sibling of ``/api/entitlement/runtime-spec-path-batch``.
+
+    Fills the ``_at_path_batch`` slot of the ``runtime-spec`` family;
+    fixed-perspective, fixed-from, fixed-to, multi-runtime companion of
+    ``/runtime-spec-at-path``. Per-runtime body byte-identical to
+    ``/runtime-spec-path-batch`` for the same ``(from, to, runtimes)``
+    triple -- scalar / batch no-drift contract.
+
+    Aliases are canonicalised the same way ``/runtime-spec-path`` does
+    (``claude-code`` -> ``claude_code``), and aliases that collapse to
+    a canonical id already in the response are silently de-duplicated
+    so the row count matches the unique-canonical-id count. Unknown
+    ids do NOT 404 the call -- they are echoed in ``unknown[]``
+    carrying the supplied alias (not the canonical id) so the caller
+    can correlate against what was sent.
+
+    Response shape (mirrors ``/runtime-spec-path-batch`` plus a
+    ``perspective_tier`` echo and the standard ``_at*`` resolver-context
+    tail)::
+
+        {
+          "perspective_tier":      "<id>",
+          "perspective_tier_rank": <int>,
+          "from":                  "<tier id>",
+          "from_label":            "...",
+          "from_rank":             <int>,
+          "to":                    "<tier id>",
+          "to_label":              "...",
+          "to_rank":               <int>,
+          "direction":             "upgrade" | "downgrade" | "lateral" | "identity",
+          "runtimes": [
+            {"runtime": "<canonical id>", "path": [<augmented row>, ...]},
+            ...
+          ],
+          "unknown":               ["bogus_id", ...],
+          "current_tier":          "...",
+          "current_tier_rank":     <int>,
+          "grace":                 <bool>,
+          "enforced":              <bool>,
+        }
+
+    - **400** when ``tier=``, ``from=``, ``to=`` is missing / blank, or
+      ``runtimes=`` is missing / empty after normalisation
+    - **404** when any tier id is unknown (body carries
+      ``which: "tier" | "from" | "to"``)
+    - Unknown runtime ids do NOT 404 the call -- they are echoed in
+      ``unknown[]`` so a partially-bad caller still gets paths back for
+      the valid ids alongside a list of what was dropped, matching
+      every other ``*_path_batch`` sibling's posture.
+    - **Never 5xxs**: a synthesis failure short-circuits to a grace-
+      shape envelope with the perspective echoed.
+    """
+    raw_tier = request.args.get("tier")
+    tier_in = (raw_tier or "").strip().lower()
+    if not tier_in:
+        return jsonify({"error": "missing tier"}), 400
+    f = (request.args.get("from") or "").strip().lower()
+    t = (request.args.get("to") or "").strip().lower()
+    if not f:
+        return jsonify({"error": "missing from"}), 400
+    if not t:
+        return jsonify({"error": "missing to"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        if tier_in not in _ent._TIER_FEATURES:
+            return (
+                jsonify(
+                    {
+                        "error": "unknown tier",
+                        "which": "tier",
+                        "tier": tier_in,
+                    }
+                ),
+                404,
+            )
+        if f not in _ent._TIER_FEATURES:
+            return (
+                jsonify(
+                    {"error": "unknown from", "which": "from", "from": f}
+                ),
+                404,
+            )
+        if t not in _ent._TIER_FEATURES:
+            return (
+                jsonify({"error": "unknown to", "which": "to", "to": t}),
+                404,
+            )
+        runtimes = _parse_csv_arg("runtimes")
+        if not runtimes:
+            return jsonify({"error": "supply runtimes=<csv>"}), 400
+        batch = _ent.runtime_spec_at_path_batch(tier_in, f, t, runtimes)
+        if batch is None:
+            batch = {"runtimes": [], "unknown": []}
+        from_rank = _ent.tier_rank(f)
+        to_rank = _ent.tier_rank(t)
+        if f == t:
+            direction = "identity"
+        elif from_rank == to_rank:
+            direction = "lateral"
+        elif to_rank > from_rank:
+            direction = "upgrade"
+        else:
+            direction = "downgrade"
+        ent = _ent.get_entitlement()
+        return jsonify(
+            {
+                "perspective_tier": tier_in,
+                "perspective_tier_rank": _ent.tier_rank(tier_in),
+                "from": f,
+                "from_label": _ent.tier_label(f),
+                "from_rank": from_rank,
+                "to": t,
+                "to_label": _ent.tier_label(t),
+                "to_rank": to_rank,
+                "direction": direction,
+                "runtimes": batch.get("runtimes", []),
+                "unknown": batch.get("unknown", []),
+                "current_tier": ent.tier,
+                "current_tier_rank": _ent.tier_rank(ent.tier),
+                "grace": bool(ent.grace),
+                "enforced": _ent.is_enforced(),
+            }
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_runtime_spec_at_path_batch: error: %s", exc
+        )
+        return jsonify(
+            {
+                "perspective_tier": tier_in,
+                "perspective_tier_rank": 0,
+                "from": f,
+                "from_label": None,
+                "from_rank": -1,
+                "to": t,
+                "to_label": None,
+                "to_rank": -1,
+                "direction": "identity" if f == t else "upgrade",
+                "runtimes": [],
+                "unknown": [],
+                "current_tier": "oss",
+                "current_tier_rank": 0,
+                "grace": True,
+                "enforced": False,
+            }
+        )
+
+
 @bp_entitlement.route("/api/entitlement/lock-reason-path-batch")
 def api_entitlement_lock_reason_path_batch():
     """``GET /api/entitlement/lock-reason-path-batch?from=<id>&to=<id>

--- a/tests/test_entitlement_runtime_spec_at_path.py
+++ b/tests/test_entitlement_runtime_spec_at_path.py
@@ -1,0 +1,847 @@
+"""Tests for
+``clawmetry.entitlements.runtime_spec_at_path(perspective, from, to, runtime)``
++ ``runtime_spec_at_path_batch(perspective, from, to, runtimes)`` + the
+``GET /api/entitlement/runtime-spec-at-path`` and ``GET
+/api/entitlement/runtime-spec-at-path-batch`` endpoints.
+
+Runtime-axis twin of :func:`feature_spec_at_path` /
+:func:`feature_spec_at_path_batch`: perspective is validated but does
+NOT shape the ``path`` rows, so an upgrade-walkthrough surface can call
+``X_at_path(perspective, from, to, ...)`` uniformly across the whole
+``_at_path`` family (alongside ``preview_at_path`` and
+``tier_catalog_at_path``).
+
+Pins:
+
+* body byte-parity with :func:`runtime_spec_path` for every
+  ``(perspective, from, to, runtime)`` quadruple; perspective
+  invariance (rows byte-identical across shifting perspective for the
+  same ``(from, to, runtime)``)
+* per-rung path row byte-equals :func:`runtime_spec_at(rung, runtime)`
+  after dropping the three ``rung*`` keys (delegated from
+  :func:`runtime_spec_path`, pinned by
+  ``test_entitlement_runtime_spec_path``)
+* batch per-runtime ``path`` byte-equals scalar
+  :func:`runtime_spec_at_path(perspective, from, to, runtime)`
+* runtime alias (``claude-code``) resolves to ``claude_code`` (scalar
+  and batch)
+* unknown perspective / from / to short-circuit to ``None`` (scalar
+  and batch); scalar unknown runtime -> ``None``; batch unknown
+  runtime -> bucketed into ``unknown[]``
+* case + whitespace normalisation on all four ids
+* trial accepted as perspective + endpoint (lateral / identity branch)
+* grace vs enforce identical rows (delegates to
+  :func:`runtime_spec_path` which walks static per-tier maps)
+* API surface: 400 on missing / blank / empty args, 404 with ``which``
+  bucketing on unknown tier ids, 404 with ``which: "runtime"`` on
+  unknown runtime for the scalar, unknown runtimes echoed into
+  ``unknown[]`` on the batch endpoint (never 404), 200 envelope with
+  ``perspective_tier`` echo + standard ``_at*`` resolver-context tail
+  on the happy path
+* endpoint never 5xxs on resolver crash
+"""
+from __future__ import annotations
+
+import importlib
+from itertools import product
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+ALL_TIERS = (
+    "oss",
+    "cloud_free",
+    "trial",
+    "cloud_starter",
+    "cloud_pro",
+    "pro",
+    "enterprise",
+)
+
+# Mix of free (``openclaw``) and paid (``claude_code``, ``codex``,
+# ``cursor``) so the parity sweep touches both the always-allowed and
+# the rung-flip branches.
+SAMPLE_RUNTIMES = (
+    "openclaw",
+    "claude_code",
+    "codex",
+    "cursor",
+    "hermes",
+)
+
+_RUNG_KEYS = {"rung", "rung_label", "rung_rank"}
+
+_SCALAR_ENVELOPE_KEYS = {
+    "perspective_tier",
+    "perspective_tier_rank",
+    "from",
+    "from_label",
+    "from_rank",
+    "to",
+    "to_label",
+    "to_rank",
+    "direction",
+    "runtime",
+    "path",
+    "current_tier",
+    "current_tier_rank",
+    "grace",
+    "enforced",
+}
+
+_BATCH_ENVELOPE_KEYS = {
+    "perspective_tier",
+    "perspective_tier_rank",
+    "from",
+    "from_label",
+    "from_rank",
+    "to",
+    "to_label",
+    "to_rank",
+    "direction",
+    "runtimes",
+    "unknown",
+    "current_tier",
+    "current_tier_rank",
+    "grace",
+    "enforced",
+}
+
+
+# ── scalar helper: shape + invariants ────────────────────────────────────────
+
+
+def test_scalar_returns_list(ent):
+    path = ent.runtime_spec_at_path(
+        "cloud_pro", "oss", "enterprise", "claude_code"
+    )
+    assert isinstance(path, list)
+    assert len(path) >= 1
+
+
+def test_scalar_body_byte_parity_with_runtime_spec_path(ent):
+    """Perspective must NOT shape the rows -- delegation to
+    :func:`runtime_spec_path` is byte-identical for every perspective."""
+    for perspective, f, t, rt in product(
+        ALL_TIERS, ALL_TIERS, ALL_TIERS, SAMPLE_RUNTIMES
+    ):
+        at_path = ent.runtime_spec_at_path(perspective, f, t, rt)
+        direct = ent.runtime_spec_path(f, t, rt)
+        assert at_path == direct, (perspective, f, t, rt)
+
+
+def test_scalar_perspective_invariance(ent):
+    """Rows must be byte-identical across every perspective for the same
+    ``(from, to, runtime)`` triple."""
+    for f, t, rt in product(
+        ("oss", "cloud_free"), ("enterprise", "pro"), SAMPLE_RUNTIMES
+    ):
+        rows_by_perspective = [
+            ent.runtime_spec_at_path(p, f, t, rt) for p in ALL_TIERS
+        ]
+        first = rows_by_perspective[0]
+        for other in rows_by_perspective[1:]:
+            assert other == first
+
+
+def test_scalar_per_rung_byte_equality_with_runtime_spec_at(ent):
+    """Dropping the three ``rung*`` keys from a path row yields exact
+    byte-equality with :func:`runtime_spec_at(rung, runtime)` -- a
+    property inherited from :func:`runtime_spec_path`."""
+    path = ent.runtime_spec_at_path(
+        "cloud_pro", "oss", "enterprise", "claude_code"
+    )
+    for row in path:
+        body = {k: v for k, v in row.items() if k not in _RUNG_KEYS}
+        direct = ent.runtime_spec_at(row["rung"], "claude_code")
+        assert body == direct
+
+
+def test_scalar_identity_returns_empty_path(ent):
+    path = ent.runtime_spec_at_path(
+        "cloud_pro", "cloud_pro", "cloud_pro", "claude_code"
+    )
+    assert path == []
+
+
+def test_scalar_lateral_returns_single_row(ent):
+    # cloud_pro and pro share a rank; lateral returns a single-row path.
+    path = ent.runtime_spec_at_path("oss", "cloud_pro", "pro", "claude_code")
+    assert isinstance(path, list)
+    assert len(path) == 1
+    assert path[0]["rung"] == "pro"
+
+
+def test_scalar_upgrade_ranks_monotonic(ent):
+    path = ent.runtime_spec_at_path("oss", "oss", "enterprise", "claude_code")
+    ranks = [r["rung_rank"] for r in path]
+    assert ranks == sorted(ranks)
+
+
+def test_scalar_downgrade_ranks_monotonic(ent):
+    path = ent.runtime_spec_at_path("oss", "enterprise", "oss", "claude_code")
+    ranks = [r["rung_rank"] for r in path]
+    assert ranks == sorted(ranks, reverse=True)
+
+
+def test_scalar_trial_accepted_as_perspective(ent):
+    path = ent.runtime_spec_at_path(
+        "trial", "oss", "enterprise", "claude_code"
+    )
+    assert isinstance(path, list)
+
+
+def test_scalar_trial_accepted_as_endpoint_identity(ent):
+    path = ent.runtime_spec_at_path("cloud_pro", "trial", "trial", "claude_code")
+    assert path == []
+
+
+def test_scalar_alias_resolves_to_canonical(ent):
+    # ``claude-code`` -> ``claude_code`` at the delegated
+    # :func:`runtime_spec_path` layer; perspective wrapper never shapes
+    # the ``runtime`` field on the row.
+    aliased = ent.runtime_spec_at_path(
+        "cloud_pro", "oss", "enterprise", "claude-code"
+    )
+    canonical = ent.runtime_spec_at_path(
+        "cloud_pro", "oss", "enterprise", "claude_code"
+    )
+    assert aliased == canonical
+
+
+def test_scalar_free_runtime_allowed_at_every_rung(ent):
+    path = ent.runtime_spec_at_path("oss", "oss", "enterprise", "openclaw")
+    assert path
+    for row in path:
+        assert row["allowed"] is True
+
+
+def test_scalar_paid_runtime_flips_along_path(ent):
+    path = ent.runtime_spec_at_path("oss", "oss", "enterprise", "claude_code")
+    assert path
+    allowed_flags = [row["allowed"] for row in path]
+    # Somewhere along the ladder the paid runtime becomes allowed.
+    assert False in allowed_flags or True in allowed_flags
+    assert any(flag is True for flag in allowed_flags)
+
+
+def test_scalar_unknown_perspective_returns_none(ent):
+    assert ent.runtime_spec_at_path(
+        "bogus", "oss", "enterprise", "claude_code"
+    ) is None
+
+
+def test_scalar_unknown_from_returns_none(ent):
+    assert ent.runtime_spec_at_path(
+        "cloud_pro", "bogus", "enterprise", "claude_code"
+    ) is None
+
+
+def test_scalar_unknown_to_returns_none(ent):
+    assert ent.runtime_spec_at_path(
+        "cloud_pro", "oss", "bogus", "claude_code"
+    ) is None
+
+
+def test_scalar_unknown_runtime_returns_none(ent):
+    assert ent.runtime_spec_at_path(
+        "cloud_pro", "oss", "enterprise", "no_such_runtime"
+    ) is None
+
+
+def test_scalar_none_inputs_return_none(ent):
+    assert ent.runtime_spec_at_path(None, "oss", "enterprise", "claude_code") is None
+    assert ent.runtime_spec_at_path("cloud_pro", None, "enterprise", "claude_code") is None
+    assert ent.runtime_spec_at_path("cloud_pro", "oss", None, "claude_code") is None
+    assert ent.runtime_spec_at_path("cloud_pro", "oss", "enterprise", None) is None
+
+
+def test_scalar_whitespace_and_case_normalisation(ent):
+    padded = ent.runtime_spec_at_path(
+        "  Cloud_Pro  ", "  OSS  ", "  ENTERPRISE  ", "  Claude-Code  "
+    )
+    canonical = ent.runtime_spec_at_path(
+        "cloud_pro", "oss", "enterprise", "claude_code"
+    )
+    assert padded == canonical
+
+
+def test_scalar_never_raises_on_weird_types(ent):
+    for weird in (b"bytes", 123, 4.5, ["oss"], {"tier": "oss"}):
+        # None of these should raise -- they should all short-circuit
+        # to ``None``.
+        assert ent.runtime_spec_at_path(weird, "oss", "enterprise", "claude_code") is None
+
+
+def test_scalar_grace_vs_enforce_byte_identical(ent, monkeypatch):
+    import clawmetry.entitlements as e
+
+    grace_path = ent.runtime_spec_at_path(
+        "cloud_pro", "oss", "enterprise", "claude_code"
+    )
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    importlib.reload(e)
+    e.invalidate()
+    try:
+        enforced_path = e.runtime_spec_at_path(
+            "cloud_pro", "oss", "enterprise", "claude_code"
+        )
+        assert enforced_path == grace_path
+    finally:
+        monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+        importlib.reload(e)
+        e.invalidate()
+
+
+# ── batch helper: shape + invariants ─────────────────────────────────────────
+
+
+def test_batch_returns_envelope(ent):
+    batch = ent.runtime_spec_at_path_batch(
+        "cloud_pro", "oss", "enterprise", ["claude_code", "codex"]
+    )
+    assert set(batch.keys()) == {"runtimes", "unknown"}
+    assert isinstance(batch["runtimes"], list)
+    assert isinstance(batch["unknown"], list)
+    assert len(batch["runtimes"]) == 2
+    assert {r["runtime"] for r in batch["runtimes"]} == {"claude_code", "codex"}
+
+
+def test_batch_body_byte_parity_with_runtime_spec_path_batch(ent):
+    for perspective in ALL_TIERS:
+        batch = ent.runtime_spec_at_path_batch(
+            perspective, "oss", "enterprise", list(SAMPLE_RUNTIMES)
+        )
+        direct = ent.runtime_spec_path_batch(
+            "oss", "enterprise", list(SAMPLE_RUNTIMES)
+        )
+        assert batch == direct, perspective
+
+
+def test_batch_perspective_invariance(ent):
+    batches = [
+        ent.runtime_spec_at_path_batch(
+            p, "oss", "enterprise", list(SAMPLE_RUNTIMES)
+        )
+        for p in ALL_TIERS
+    ]
+    first = batches[0]
+    for other in batches[1:]:
+        assert other == first
+
+
+def test_batch_per_row_matches_scalar(ent):
+    batch = ent.runtime_spec_at_path_batch(
+        "cloud_pro", "oss", "enterprise", list(SAMPLE_RUNTIMES)
+    )
+    for row in batch["runtimes"]:
+        scalar = ent.runtime_spec_at_path(
+            "cloud_pro", "oss", "enterprise", row["runtime"]
+        )
+        assert row["path"] == scalar
+
+
+def test_batch_unknown_runtime_bucketed(ent):
+    batch = ent.runtime_spec_at_path_batch(
+        "cloud_pro",
+        "oss",
+        "enterprise",
+        ["claude_code", "no_such_runtime", "codex"],
+    )
+    assert {r["runtime"] for r in batch["runtimes"]} == {"claude_code", "codex"}
+    assert batch["unknown"] == ["no_such_runtime"]
+
+
+def test_batch_all_unknown_returns_empty_rows_and_unknown_list(ent):
+    batch = ent.runtime_spec_at_path_batch(
+        "cloud_pro", "oss", "enterprise", ["bogus1", "bogus2"]
+    )
+    assert batch["runtimes"] == []
+    assert batch["unknown"] == ["bogus1", "bogus2"]
+
+
+def test_batch_alias_canonicalised(ent):
+    batch = ent.runtime_spec_at_path_batch(
+        "cloud_pro", "oss", "enterprise", ["claude-code"]
+    )
+    assert [r["runtime"] for r in batch["runtimes"]] == ["claude_code"]
+    assert batch["unknown"] == []
+
+
+def test_batch_alias_dedup(ent):
+    batch = ent.runtime_spec_at_path_batch(
+        "cloud_pro", "oss", "enterprise", ["claude-code", "claude_code"]
+    )
+    assert [r["runtime"] for r in batch["runtimes"]] == ["claude_code"]
+
+
+def test_batch_unknown_perspective_returns_none(ent):
+    assert ent.runtime_spec_at_path_batch(
+        "bogus", "oss", "enterprise", ["claude_code"]
+    ) is None
+
+
+def test_batch_unknown_from_returns_none(ent):
+    assert ent.runtime_spec_at_path_batch(
+        "cloud_pro", "bogus", "enterprise", ["claude_code"]
+    ) is None
+
+
+def test_batch_unknown_to_returns_none(ent):
+    assert ent.runtime_spec_at_path_batch(
+        "cloud_pro", "oss", "bogus", ["claude_code"]
+    ) is None
+
+
+def test_batch_trial_accepted_as_perspective(ent):
+    batch = ent.runtime_spec_at_path_batch(
+        "trial", "oss", "enterprise", ["claude_code"]
+    )
+    assert batch is not None
+    assert [r["runtime"] for r in batch["runtimes"]] == ["claude_code"]
+
+
+def test_batch_whitespace_and_case_normalisation(ent):
+    padded = ent.runtime_spec_at_path_batch(
+        "  Cloud_Pro  ",
+        "  OSS  ",
+        "  ENTERPRISE  ",
+        ["  Claude-Code  ", "codex"],
+    )
+    canonical = ent.runtime_spec_at_path_batch(
+        "cloud_pro", "oss", "enterprise", ["claude_code", "codex"]
+    )
+    assert padded == canonical
+
+
+def test_batch_grace_vs_enforce_byte_identical(ent, monkeypatch):
+    import clawmetry.entitlements as e
+
+    grace_batch = ent.runtime_spec_at_path_batch(
+        "cloud_pro", "oss", "enterprise", list(SAMPLE_RUNTIMES)
+    )
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    importlib.reload(e)
+    e.invalidate()
+    try:
+        enforced_batch = e.runtime_spec_at_path_batch(
+            "cloud_pro", "oss", "enterprise", list(SAMPLE_RUNTIMES)
+        )
+        assert enforced_batch == grace_batch
+    finally:
+        monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+        importlib.reload(e)
+        e.invalidate()
+
+
+def test_batch_per_runtime_crash_short_circuits_to_unknown(ent, monkeypatch):
+    def boom(from_tier, to_tier, runtime):
+        raise RuntimeError("simulated per-runtime failure")
+
+    monkeypatch.setattr(ent, "runtime_spec_path", boom)
+    batch = ent.runtime_spec_at_path_batch(
+        "cloud_pro", "oss", "enterprise", ["claude_code", "codex"]
+    )
+    # runtime_spec_path_batch delegates per-runtime to runtime_spec_path,
+    # so every runtime should end up in ``unknown[]`` with the raw alias.
+    assert batch["runtimes"] == []
+    assert set(batch["unknown"]) == {"claude_code", "codex"}
+
+
+# ── HTTP scalar endpoint ─────────────────────────────────────────────────────
+
+
+def test_http_scalar_envelope_shape(client, ent):
+    r = client.get(
+        "/api/entitlement/runtime-spec-at-path"
+        "?tier=cloud_pro&from=oss&to=enterprise&runtime=claude_code"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert set(body.keys()) == _SCALAR_ENVELOPE_KEYS
+
+
+def test_http_scalar_missing_tier_400(client):
+    r = client.get(
+        "/api/entitlement/runtime-spec-at-path?from=oss&to=enterprise&runtime=claude_code"
+    )
+    assert r.status_code == 400
+    assert r.get_json() == {"error": "missing tier"}
+
+
+def test_http_scalar_missing_from_400(client):
+    r = client.get(
+        "/api/entitlement/runtime-spec-at-path?tier=cloud_pro&to=enterprise&runtime=claude_code"
+    )
+    assert r.status_code == 400
+    assert r.get_json() == {"error": "missing from"}
+
+
+def test_http_scalar_missing_to_400(client):
+    r = client.get(
+        "/api/entitlement/runtime-spec-at-path?tier=cloud_pro&from=oss&runtime=claude_code"
+    )
+    assert r.status_code == 400
+    assert r.get_json() == {"error": "missing to"}
+
+
+def test_http_scalar_missing_runtime_400(client):
+    r = client.get(
+        "/api/entitlement/runtime-spec-at-path?tier=cloud_pro&from=oss&to=enterprise"
+    )
+    assert r.status_code == 400
+    assert r.get_json() == {"error": "missing runtime"}
+
+
+def test_http_scalar_unknown_tier_404_which_tier(client):
+    r = client.get(
+        "/api/entitlement/runtime-spec-at-path"
+        "?tier=bogus&from=oss&to=enterprise&runtime=claude_code"
+    )
+    assert r.status_code == 404
+    body = r.get_json()
+    assert body["which"] == "tier"
+    assert body["tier"] == "bogus"
+
+
+def test_http_scalar_unknown_from_404_which_from(client):
+    r = client.get(
+        "/api/entitlement/runtime-spec-at-path"
+        "?tier=cloud_pro&from=bogus&to=enterprise&runtime=claude_code"
+    )
+    assert r.status_code == 404
+    body = r.get_json()
+    assert body["which"] == "from"
+    assert body["from"] == "bogus"
+
+
+def test_http_scalar_unknown_to_404_which_to(client):
+    r = client.get(
+        "/api/entitlement/runtime-spec-at-path"
+        "?tier=cloud_pro&from=oss&to=bogus&runtime=claude_code"
+    )
+    assert r.status_code == 404
+    body = r.get_json()
+    assert body["which"] == "to"
+    assert body["to"] == "bogus"
+
+
+def test_http_scalar_unknown_runtime_404_which_runtime(client):
+    r = client.get(
+        "/api/entitlement/runtime-spec-at-path"
+        "?tier=cloud_pro&from=oss&to=enterprise&runtime=no_such_runtime"
+    )
+    assert r.status_code == 404
+    body = r.get_json()
+    assert body["which"] == "runtime"
+    assert body["runtime"] == "no_such_runtime"
+
+
+def test_http_scalar_identity_path_empty(client):
+    r = client.get(
+        "/api/entitlement/runtime-spec-at-path"
+        "?tier=cloud_pro&from=cloud_pro&to=cloud_pro&runtime=claude_code"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["direction"] == "identity"
+    assert body["path"] == []
+
+
+def test_http_scalar_downgrade_direction(client):
+    r = client.get(
+        "/api/entitlement/runtime-spec-at-path"
+        "?tier=cloud_pro&from=enterprise&to=oss&runtime=claude_code"
+    )
+    assert r.status_code == 200
+    assert r.get_json()["direction"] == "downgrade"
+
+
+def test_http_scalar_trial_accepted(client):
+    r = client.get(
+        "/api/entitlement/runtime-spec-at-path"
+        "?tier=trial&from=oss&to=enterprise&runtime=claude_code"
+    )
+    assert r.status_code == 200
+    assert r.get_json()["perspective_tier"] == "trial"
+
+
+def test_http_scalar_alias_canonicalised(client):
+    r = client.get(
+        "/api/entitlement/runtime-spec-at-path"
+        "?tier=cloud_pro&from=oss&to=enterprise&runtime=claude-code"
+    )
+    assert r.status_code == 200
+    assert r.get_json()["runtime"] == "claude_code"
+
+
+def test_http_scalar_whitespace_and_case_normalisation(client):
+    r = client.get(
+        "/api/entitlement/runtime-spec-at-path"
+        "?tier=%20Cloud_Pro%20&from=%20OSS%20&to=%20ENTERPRISE%20&runtime=%20Claude-Code%20"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["perspective_tier"] == "cloud_pro"
+    assert body["from"] == "oss"
+    assert body["to"] == "enterprise"
+    assert body["runtime"] == "claude_code"
+
+
+def test_http_scalar_path_byte_parity_with_runtime_spec_path(client):
+    at = client.get(
+        "/api/entitlement/runtime-spec-at-path"
+        "?tier=cloud_pro&from=oss&to=enterprise&runtime=claude_code"
+    ).get_json()
+    direct = client.get(
+        "/api/entitlement/runtime-spec-path"
+        "?from=oss&to=enterprise&runtime=claude_code"
+    ).get_json()
+    assert at["path"] == direct["path"]
+
+
+def test_http_scalar_perspective_invariance(client):
+    paths = []
+    for p in ALL_TIERS:
+        body = client.get(
+            "/api/entitlement/runtime-spec-at-path"
+            f"?tier={p}&from=oss&to=enterprise&runtime=claude_code"
+        ).get_json()
+        paths.append(body["path"])
+    first = paths[0]
+    for other in paths[1:]:
+        assert other == first
+
+
+def test_http_scalar_never_5xxs_on_resolver_crash(client, monkeypatch):
+    from clawmetry import entitlements as _ent
+
+    def boom(*a, **k):
+        raise RuntimeError("simulated")
+
+    monkeypatch.setattr(_ent, "runtime_spec_at_path", boom)
+    r = client.get(
+        "/api/entitlement/runtime-spec-at-path"
+        "?tier=cloud_pro&from=oss&to=enterprise&runtime=claude_code"
+    )
+    # Grace envelope short-circuit -- 200 with an empty path, not 500.
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["perspective_tier"] == "cloud_pro"
+    assert body["path"] == []
+    assert body["grace"] is True
+
+
+# ── HTTP batch endpoint ──────────────────────────────────────────────────────
+
+
+def test_http_batch_envelope_shape(client):
+    r = client.get(
+        "/api/entitlement/runtime-spec-at-path-batch"
+        "?tier=cloud_pro&from=oss&to=enterprise&runtimes=claude_code,codex"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert set(body.keys()) == _BATCH_ENVELOPE_KEYS
+
+
+def test_http_batch_missing_tier_400(client):
+    r = client.get(
+        "/api/entitlement/runtime-spec-at-path-batch"
+        "?from=oss&to=enterprise&runtimes=claude_code"
+    )
+    assert r.status_code == 400
+
+
+def test_http_batch_missing_from_400(client):
+    r = client.get(
+        "/api/entitlement/runtime-spec-at-path-batch"
+        "?tier=cloud_pro&to=enterprise&runtimes=claude_code"
+    )
+    assert r.status_code == 400
+
+
+def test_http_batch_missing_to_400(client):
+    r = client.get(
+        "/api/entitlement/runtime-spec-at-path-batch"
+        "?tier=cloud_pro&from=oss&runtimes=claude_code"
+    )
+    assert r.status_code == 400
+
+
+def test_http_batch_missing_runtimes_400(client):
+    r = client.get(
+        "/api/entitlement/runtime-spec-at-path-batch"
+        "?tier=cloud_pro&from=oss&to=enterprise"
+    )
+    assert r.status_code == 400
+
+
+def test_http_batch_empty_runtimes_400(client):
+    r = client.get(
+        "/api/entitlement/runtime-spec-at-path-batch"
+        "?tier=cloud_pro&from=oss&to=enterprise&runtimes=  ,  ,"
+    )
+    assert r.status_code == 400
+
+
+def test_http_batch_unknown_tier_which_bucketed(client):
+    for which, params in (
+        ("tier", "tier=bogus&from=oss&to=enterprise"),
+        ("from", "tier=cloud_pro&from=bogus&to=enterprise"),
+        ("to", "tier=cloud_pro&from=oss&to=bogus"),
+    ):
+        r = client.get(
+            "/api/entitlement/runtime-spec-at-path-batch"
+            f"?{params}&runtimes=claude_code"
+        )
+        assert r.status_code == 404
+        body = r.get_json()
+        assert body["which"] == which
+
+
+def test_http_batch_happy_path(client):
+    r = client.get(
+        "/api/entitlement/runtime-spec-at-path-batch"
+        "?tier=cloud_pro&from=oss&to=enterprise&runtimes=claude_code,codex,openclaw"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["direction"] == "upgrade"
+    assert {r["runtime"] for r in body["runtimes"]} == {
+        "claude_code",
+        "codex",
+        "openclaw",
+    }
+    assert body["unknown"] == []
+
+
+def test_http_batch_partial_unknown_runtime_bucketed_200(client):
+    r = client.get(
+        "/api/entitlement/runtime-spec-at-path-batch"
+        "?tier=cloud_pro&from=oss&to=enterprise"
+        "&runtimes=claude_code,no_such_runtime,codex"
+    )
+    # 200, not 404 -- unknown runtime ids do NOT short-circuit the batch.
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["unknown"] == ["no_such_runtime"]
+    assert {r["runtime"] for r in body["runtimes"]} == {"claude_code", "codex"}
+
+
+def test_http_batch_alias_canonicalised(client):
+    r = client.get(
+        "/api/entitlement/runtime-spec-at-path-batch"
+        "?tier=cloud_pro&from=oss&to=enterprise&runtimes=claude-code,codex"
+    )
+    body = r.get_json()
+    assert {r["runtime"] for r in body["runtimes"]} == {"claude_code", "codex"}
+
+
+def test_http_batch_alias_dedup(client):
+    r = client.get(
+        "/api/entitlement/runtime-spec-at-path-batch"
+        "?tier=cloud_pro&from=oss&to=enterprise&runtimes=claude-code,claude_code"
+    )
+    body = r.get_json()
+    assert [r["runtime"] for r in body["runtimes"]] == ["claude_code"]
+
+
+def test_http_batch_multi_runtime(client):
+    r = client.get(
+        "/api/entitlement/runtime-spec-at-path-batch"
+        "?tier=cloud_pro&from=oss&to=enterprise"
+        "&runtimes=claude_code,codex,cursor,hermes,openclaw"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert len(body["runtimes"]) == 5
+
+
+def test_http_batch_body_parity_with_runtime_spec_path_batch(client):
+    at = client.get(
+        "/api/entitlement/runtime-spec-at-path-batch"
+        "?tier=cloud_pro&from=oss&to=enterprise&runtimes=claude_code,codex"
+    ).get_json()
+    direct = client.get(
+        "/api/entitlement/runtime-spec-path-batch"
+        "?from=oss&to=enterprise&runtimes=claude_code,codex"
+    ).get_json()
+    assert at["runtimes"] == direct["runtimes"]
+
+
+def test_http_batch_perspective_invariance(client):
+    rows = []
+    for p in ALL_TIERS:
+        body = client.get(
+            "/api/entitlement/runtime-spec-at-path-batch"
+            f"?tier={p}&from=oss&to=enterprise&runtimes=claude_code,codex"
+        ).get_json()
+        rows.append(body["runtimes"])
+    first = rows[0]
+    for other in rows[1:]:
+        assert other == first
+
+
+def test_http_batch_trial_accepted(client):
+    r = client.get(
+        "/api/entitlement/runtime-spec-at-path-batch"
+        "?tier=trial&from=oss&to=enterprise&runtimes=claude_code"
+    )
+    assert r.status_code == 200
+    assert r.get_json()["perspective_tier"] == "trial"
+
+
+def test_http_batch_whitespace_and_case_normalisation(client):
+    r = client.get(
+        "/api/entitlement/runtime-spec-at-path-batch"
+        "?tier=%20Cloud_Pro%20&from=%20OSS%20&to=%20ENTERPRISE%20"
+        "&runtimes=%20Claude-Code%20,%20Codex%20"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["perspective_tier"] == "cloud_pro"
+    assert body["from"] == "oss"
+    assert body["to"] == "enterprise"
+    assert {r["runtime"] for r in body["runtimes"]} == {"claude_code", "codex"}
+
+
+def test_http_batch_never_5xxs_on_resolver_crash(client, monkeypatch):
+    from clawmetry import entitlements as _ent
+
+    def boom(*a, **k):
+        raise RuntimeError("simulated")
+
+    monkeypatch.setattr(_ent, "runtime_spec_at_path_batch", boom)
+    r = client.get(
+        "/api/entitlement/runtime-spec-at-path-batch"
+        "?tier=cloud_pro&from=oss&to=enterprise&runtimes=claude_code"
+    )
+    # Grace envelope -- 200 with empty runtimes list, not 500.
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["perspective_tier"] == "cloud_pro"
+    assert body["runtimes"] == []
+    assert body["grace"] is True


### PR DESCRIPTION
## Summary

Runtime-axis twin of the open `feature_spec_at_path` PR (#3520). Fills the `_at_path` / `_at_path_batch` slot for the `runtime_spec` family, matching the already-merged `preview_at_path` / `tier_catalog_at_path` pattern on the `preview` / `tier_catalog` axes: perspective is validated but does NOT shape the rows, so an upgrade-walkthrough surface can call `X_at_path(perspective, from, to, ...)` uniformly across the whole `_at_path` family.

- Module-level `runtime_spec_at_path(perspective_tier, from_tier, to_tier, runtime)` -- scalar what-if path. Body byte-identical to `runtime_spec_path(from_tier, to_tier, runtime)` for every perspective. Pinned by parity tests so the singular can never drift from `runtime_spec_path` (which itself walks per-rung via `runtime_spec_at`). Trial accepted as perspective (lenient posture matching every other `_at` helper); endpoint acceptance mirrors `runtime_spec_path` (any id in `_TIER_FEATURES`, including `trial` via the lateral / identity branch). Accepts runtime aliases (`claude-code` → `claude_code`) via `canonical_runtime`.
- Module-level `runtime_spec_at_path_batch(perspective_tier, from_tier, to_tier, runtimes)` -- fixed-perspective, fixed-from, fixed-to, multi-runtime companion. Per-runtime body byte-identical to `runtime_spec_path_batch(from_tier, to_tier, runtimes)` for the same targets (scalar / batch no-drift contract). Alias dedup is handled by the delegated `runtime_spec_path_batch`.
- `GET /api/entitlement/runtime-spec-at-path?tier=&from=&to=&runtime=` -- 400 on missing / blank input, 404 on unknown perspective / from / to / runtime (body carries `which: "tier" | "from" | "to" | "runtime"` so the caller can point at the offender), never 5xxs on resolver crash. Response envelope: `perspective_tier` + `perspective_tier_rank` echo, the same `from` / `from_label` / `from_rank` / `to` / `to_label` / `to_rank` / `direction` / `runtime` / `path` fields as `/runtime-spec-path`, plus the standard `_at*` resolver-context tail (`current_tier` / `current_tier_rank` / `grace` / `enforced`).
- `GET /api/entitlement/runtime-spec-at-path-batch?tier=&from=&to=&runtimes=a,b,c` -- envelope mirrors `/runtime-spec-path-batch` plus `perspective_tier` / `perspective_tier_rank` echo and the resolver-context tail. Unknown runtime ids are echoed in `unknown[]` instead of short-circuiting so a partially-bad caller still gets paths back for the valid ids, matching every other `*_path_batch` sibling's posture.

Fills the runtime-spec-family gap in the `_at_path` / `_at_path_batch` slot:

| helper                          | slot                       | status         |
|---------------------------------|----------------------------|----------------|
| `runtime_spec`                  | scalar (current)           | already merged |
| `runtime_spec_batch`            | batch (current)            | already merged |
| `runtime_spec_at`               | scalar (hypothetical)      | already merged |
| `runtime_spec_at_batch`         | batch (hypothetical)       | already merged |
| `runtime_spec_path`             | path (current)             | already merged |
| `runtime_spec_path_batch`       | batch path (current)       | already merged |
| `runtime_spec_at_path`          | path (hypothetical)        | **this PR**    |
| `runtime_spec_at_path_batch`    | batch path (hypothetical)  | **this PR**    |

Posture matches the rest of the `_at` family:

- Perspective + runtime ids normalised (whitespace stripped, lowercased, aliases canonicalised via `canonical_runtime`, duplicates dropped, first-seen order preserved on the batch).
- Unknown runtime ids echoed in `unknown[]` on the batch endpoint instead of short-circuiting -- a partially-bad caller still gets paths back for the valid ids alongside a list of what was dropped.
- `trial` IS accepted as perspective (any id in `_TIER_FEATURES`) and as endpoint (via `runtime_spec_path`'s lateral / identity branch).
- Per-rung path row is the `runtime_spec_at(rung, runtime)` body augmented with the three `rung*` keys -- inherited via delegation to `runtime_spec_path`.
- Resolver-independent: delegates to `runtime_spec_path` / `runtime_spec_path_batch`, which walk the static per-tier maps, so grace vs enforce yields byte-identical rows.
- Never raises: per-runtime crash short-circuits that id into `unknown[]`; endpoint resolver failure short-circuits to a grace-shape envelope (no 5xx).

**Grace-only, read-only**: no gate enforced, no behaviour change against the currently-resolved entitlement -- these are new read-only endpoints.

## Test plan

- [x] `python3 -m py_compile clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_runtime_spec_at_path.py` -- clean
- [x] `ruff check clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_runtime_spec_at_path.py` -- all checks passed
- [x] `python3 -m pytest tests/test_entitlement_runtime_spec_at_path.py -q` -- **70 passed**
- [x] Adjacent regression sweep -- **145 passed** across `test_entitlement_runtime_spec_at`, `test_entitlement_runtime_spec_path`, `test_entitlement_preview_at_path`, `test_entitlement_api`.

### Coverage in `tests/test_entitlement_runtime_spec_at_path.py`

- **scalar helper**: shape; body byte-parity with `runtime_spec_path(from, to, runtime)` across every `(perspective, from, to, runtime)` combination in `ALL_TIERS × ALL_TIERS × ALL_TIERS × SAMPLE_RUNTIMES`; perspective invariance; per-rung row byte-equals `runtime_spec_at(rung, runtime)` after dropping the three `rung*` keys; alias resolution (`claude-code` → `claude_code`); free runtime (`openclaw`) allowed at every rung; paid runtime (`claude_code`) rung-flip; identity → `[]`; lateral → single-row path; upgrade / downgrade ranks monotonic; trial accepted as perspective + endpoint; unknown perspective / from / to / runtime → `None`; `None` inputs → `None`; case + whitespace normalisation; never-raises on weird input types (bytes / ints / floats / lists / dicts); grace vs enforce byte-identical.
- **batch helper**: envelope `{runtimes, unknown}` shape; body byte-parity with `runtime_spec_path_batch(from, to, runtimes)` for every perspective; batch-level perspective invariance; each `runtimes[].path` equals scalar `runtime_spec_at_path(perspective, from, to, runtime)`; unknown runtimes bucketed in `unknown[]`; all-unknown case → `{"runtimes": [], "unknown": [...]}`; alias canonicalisation + dedup; unknown perspective / from / to → `None`; trial accepted as perspective; case + whitespace normalisation; grace vs enforce byte-identical; per-runtime row crash short-circuits into `unknown[]` (monkeypatched delegate crash).
- **HTTP scalar (`/runtime-spec-at-path`)**: 15-key envelope shape; 400 on missing `tier` / `from` / `to` / `runtime`; 404 with `which: "tier" | "from" | "to" | "runtime"` on unknown ids; 200 happy path; trial accepted as perspective; identity path empty; downgrade direction; alias canonicalised in the echoed `runtime` field; case + whitespace normalisation via URL-encoded query; `path` body-parity with `/runtime-spec-path`; perspective-invariance across every perspective; never 5xxs on resolver crash.
- **HTTP batch (`/runtime-spec-at-path-batch`)**: 15-key envelope shape; 400 on missing `tier` / `from` / `to` and missing / empty `runtimes` list; 404 with `which` bucketing on unknown tier ids; 200 happy path; unknown runtime ids bucketed into `unknown[]` (200, not 404); alias canonicalisation; alias dedup; multi-runtime; `runtimes[]` body-parity with `/runtime-spec-path-batch`; perspective invariance across every perspective; trial accepted as perspective; whitespace / casing normalisation; never 5xxs on resolver crash.

## Local operator verification checklist

The public-repo agent cannot exercise the live daemon, cloud snapshot, or browser. Please copy the changed files into your locally-installed clawmetry site-packages and verify against the real daemon before flipping ready-for-review:

```bash
# 1. Copy the changed files into the installed package
SP="$HOME/.clawmetry/lib/python$(python3 -c 'import sys;print(f"{sys.version_info.major}.{sys.version_info.minor}")')/site-packages/clawmetry"
cp clawmetry/entitlements.py "$SP/entitlements.py"
# routes/ isn't inside the package; on the default layout it lands at
# $HOME/.clawmetry/lib/python*/site-packages/routes/entitlement.py
find "$HOME/.clawmetry" -name entitlement.py -path '*routes*' -exec cp routes/entitlement.py {} \;

# 2. Purge stale bytecode so the new module actually loads
find "$HOME/.clawmetry" -type d -name __pycache__ -exec rm -rf {} +

# 3. Bounce the sync daemon so it re-imports
launchctl kickstart -k "gui/$(id -u)/com.clawmetry.sync"

# 4. Hit the new scalar endpoint (happy path)
curl -s 'http://localhost:8900/api/entitlement/runtime-spec-at-path?tier=cloud_pro&from=oss&to=enterprise&runtime=claude_code' | jq
# Expect: 200 with {perspective_tier: "cloud_pro", from: "oss", to: "enterprise", direction: "upgrade", runtime: "claude_code", path: [...], ...}

# 5. Alias canonicalised
curl -s 'http://localhost:8900/api/entitlement/runtime-spec-at-path?tier=cloud_pro&from=oss&to=enterprise&runtime=claude-code' | jq '.runtime'
# Expect: "claude_code"

# 6. Trial accepted as perspective
curl -s 'http://localhost:8900/api/entitlement/runtime-spec-at-path?tier=trial&from=oss&to=enterprise&runtime=claude_code' | jq '.perspective_tier'
# Expect: "trial"

# 7. Error paths
curl -si 'http://localhost:8900/api/entitlement/runtime-spec-at-path?from=oss&to=enterprise&runtime=claude_code' | head -1
# Expect: HTTP/1.1 400 (missing tier)
curl -si 'http://localhost:8900/api/entitlement/runtime-spec-at-path?tier=cloud_pro&to=enterprise&runtime=claude_code' | head -1
# Expect: HTTP/1.1 400 (missing from)
curl -si 'http://localhost:8900/api/entitlement/runtime-spec-at-path?tier=cloud_pro&from=oss&runtime=claude_code' | head -1
# Expect: HTTP/1.1 400 (missing to)
curl -si 'http://localhost:8900/api/entitlement/runtime-spec-at-path?tier=cloud_pro&from=oss&to=enterprise' | head -1
# Expect: HTTP/1.1 400 (missing runtime)
curl -s  'http://localhost:8900/api/entitlement/runtime-spec-at-path?tier=bogus&from=oss&to=enterprise&runtime=claude_code'      | jq '.which'
# Expect: "tier"
curl -s  'http://localhost:8900/api/entitlement/runtime-spec-at-path?tier=cloud_pro&from=bogus&to=enterprise&runtime=claude_code' | jq '.which'
# Expect: "from"
curl -s  'http://localhost:8900/api/entitlement/runtime-spec-at-path?tier=cloud_pro&from=oss&to=bogus&runtime=claude_code'        | jq '.which'
# Expect: "to"
curl -s  'http://localhost:8900/api/entitlement/runtime-spec-at-path?tier=cloud_pro&from=oss&to=enterprise&runtime=no_such_runtime' | jq '.which'
# Expect: "runtime"

# 8. Batch happy path
curl -s 'http://localhost:8900/api/entitlement/runtime-spec-at-path-batch?tier=cloud_pro&from=oss&to=enterprise&runtimes=claude_code,codex,openclaw' | jq
# Expect: 200 with envelope {perspective_tier, from, to, runtimes[3], unknown: [], current_tier, grace, enforced}

# 9. Partial-unknown runtime bucketing (200, not 404)
curl -s 'http://localhost:8900/api/entitlement/runtime-spec-at-path-batch?tier=cloud_pro&from=oss&to=enterprise&runtimes=claude_code,no_such_runtime,codex' | jq '.unknown'
# Expect: ["no_such_runtime"]

# 10. Alias canonicalisation + dedup
curl -s 'http://localhost:8900/api/entitlement/runtime-spec-at-path-batch?tier=cloud_pro&from=oss&to=enterprise&runtimes=claude-code,claude_code' | jq '.runtimes | map(.runtime)'
# Expect: ["claude_code"]

# 11. Perspective invariance (rows identical across shifting perspective)
for p in oss cloud_free cloud_starter cloud_pro pro enterprise trial; do
  diff \
    <(curl -s "http://localhost:8900/api/entitlement/runtime-spec-at-path-batch?tier=$p&from=oss&to=enterprise&runtimes=claude_code,codex" | jq '.runtimes') \
    <(curl -s "http://localhost:8900/api/entitlement/runtime-spec-at-path-batch?tier=cloud_pro&from=oss&to=enterprise&runtimes=claude_code,codex" | jq '.runtimes') \
  && echo "$p: perspective-invariant OK"
done
# Expect: "perspective-invariant OK" for every perspective.

# 12. Parity with /runtime-spec-path-batch (which the batch delegates to)
diff \
  <(curl -s 'http://localhost:8900/api/entitlement/runtime-spec-at-path-batch?tier=cloud_pro&from=oss&to=enterprise&runtimes=claude_code,codex' | jq '.runtimes') \
  <(curl -s 'http://localhost:8900/api/entitlement/runtime-spec-path-batch?from=oss&to=enterprise&runtimes=claude_code,codex' | jq '.runtimes') \
&& echo "runtimes[] byte-parity with runtime-spec-path-batch OK"

# 13. Decrypt the live cloud snapshot in the browser + sanity-check no
# regressions on the existing /runtime-spec, /runtime-spec-at,
# /runtime-spec-batch, /runtime-spec-at-batch, /runtime-spec-path,
# /runtime-spec-path-batch endpoints.
```

If everything looks right, flip to ready-for-review and merge in the normal flow. Only the local operator has access to the live daemon and snapshot for step 13, which is why this PR stays draft until then.

Non-overlapping with open PR #3520 (`feature_spec_at_path` / `feature_spec_at_path_batch`): both PRs fill the same `_at_path` / `_at_path_batch` slot on distinct axes (`feature_spec` vs `runtime_spec`). New helpers here land right before `tier_catalog_path_batch` (the runtime-family region of `entitlements.py`) rather than at the very end of the file where #3520 lands its helpers, so the rebase-conflict surface between the two PRs is minimised — they touch different regions.

The next-phase work (P3 / P4 / P6 -- cloud-side entitlement minting, `clawmetry-pro` package download, enterprise SSO) needs the private `clawmetry-cloud` / `clawmetry-pro` repos and is out of scope for this remote session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013X5nXSV6BYbR1McD54bAwM)_