### PR TITLE
fix: surface cron on-exit schedule kind and detached-run marker on sessions

### DIFF
--- a/clawmetry/adapters/openclaw.py
+++ b/clawmetry/adapters/openclaw.py
@@ -1259,6 +1259,21 @@ class OpenClawAdapter(AgentAdapter):
             _cdcont = s.get("cronDeliveredContent") or s.get("deliveredContent")
             if _cdcont is not None:
                 extra["cronDeliveredContent"] = str(_cdcont)
+            # On-exit cron trigger kind (#3526): OpenClaw 2026.7.1 (#92037)
+            # stamps the schedule kind that triggered this session delivery
+            # ("on-exit", "every", "interval", "cron", …) so callers can
+            # distinguish exit-triggered runs from ordinary scheduled ones.
+            _csk = s.get("cronScheduleKind") or s.get("cronTriggerKind")
+            if _csk is not None:
+                extra["cronScheduleKind"] = str(_csk)
+            # Detached-run marker (#3526): OpenClaw 2026.7.1 (#98755) stamps
+            # cronDetachedRun on sessions that were spawned as a detached
+            # run (independent of the triggering session).
+            _cdr = s.get("cronDetachedRun")
+            if _cdr is None:
+                _cdr = s.get("cronDetached")
+            if _cdr is not None:
+                extra["cronDetachedRun"] = bool(_cdr)
             # GLM/Zhipu overload classification (#3343): PR #93241 classifies
             # Zhipu GLM overload as a distinct overload state for failover;
             # surface the tag so session views can indicate failover routing.

--- a/tests/test_obs_gap_openclaw_cron_on_exit_3526.py
+++ b/tests/test_obs_gap_openclaw_cron_on_exit_3526.py
@@ -1,0 +1,94 @@
+"""Regression tests for issue #3526.
+
+OpenClaw 2026.7.1 introduced event-driven cron runs (#92037, #98755):
+  - 'on-exit' schedule kind wakes an agent when a watched command exits
+  - session-targeted cron runs can detach from the triggering session
+
+The gateway stamps `cronScheduleKind` (e.g. "on-exit") and `cronDetachedRun`
+(bool) on sessions spawned by these cron types.  Before this fix,
+list_sessions() never read those fields, so on-exit/detached sessions were
+indistinguishable from ordinary cron deliveries.
+"""
+
+import clawmetry.adapters.openclaw as ocmod
+from clawmetry.adapters.openclaw import OpenClawAdapter
+
+
+class _FakeDash:
+    def __init__(self, extra_fields=None):
+        self._fields = extra_fields or {}
+
+    def _get_sessions(self):
+        record = {"sessionId": "sess-cron-exit"}
+        record.update(self._fields)
+        return [record]
+
+
+def test_list_sessions_surfaces_cron_schedule_kind(monkeypatch):
+    monkeypatch.setattr(
+        ocmod, "_d", lambda: _FakeDash({"cronScheduleKind": "on-exit"})
+    )
+    sessions = OpenClawAdapter().list_sessions(limit=10)
+    assert len(sessions) == 1
+    assert sessions[0].extra.get("cronScheduleKind") == "on-exit", (
+        "list_sessions() must surface cronScheduleKind from the gateway record"
+    )
+
+
+def test_list_sessions_surfaces_cron_trigger_kind_alias(monkeypatch):
+    """cronTriggerKind is accepted as an alias when cronScheduleKind is absent."""
+    monkeypatch.setattr(
+        ocmod, "_d", lambda: _FakeDash({"cronTriggerKind": "on-exit"})
+    )
+    sessions = OpenClawAdapter().list_sessions(limit=10)
+    assert sessions[0].extra.get("cronScheduleKind") == "on-exit", (
+        "cronTriggerKind alias must be accepted when cronScheduleKind is missing"
+    )
+
+
+def test_list_sessions_surfaces_cron_detached_run(monkeypatch):
+    monkeypatch.setattr(
+        ocmod, "_d", lambda: _FakeDash({"cronDetachedRun": True})
+    )
+    sessions = OpenClawAdapter().list_sessions(limit=10)
+    assert sessions[0].extra.get("cronDetachedRun") is True, (
+        "list_sessions() must surface cronDetachedRun from the gateway record"
+    )
+
+
+def test_list_sessions_surfaces_cron_detached_alias(monkeypatch):
+    """cronDetached is accepted as an alias when cronDetachedRun is absent."""
+    monkeypatch.setattr(
+        ocmod, "_d", lambda: _FakeDash({"cronDetached": True})
+    )
+    sessions = OpenClawAdapter().list_sessions(limit=10)
+    assert sessions[0].extra.get("cronDetachedRun") is True, (
+        "cronDetached alias must be accepted when cronDetachedRun is missing"
+    )
+
+
+def test_list_sessions_omits_fields_when_absent(monkeypatch):
+    """Extra keys must not appear for ordinary sessions without these fields."""
+    monkeypatch.setattr(
+        ocmod, "_d",
+        lambda: _FakeDash({"cronDeliveryTarget": True}),
+    )
+    sessions = OpenClawAdapter().list_sessions(limit=10)
+    assert "cronScheduleKind" not in sessions[0].extra, (
+        "cronScheduleKind must not appear when not in gateway record"
+    )
+    assert "cronDetachedRun" not in sessions[0].extra, (
+        "cronDetachedRun must not appear when not in gateway record"
+    )
+
+
+def test_list_sessions_coerces_detached_run_to_bool(monkeypatch):
+    """Non-bool truthy values must be coerced to bool."""
+    monkeypatch.setattr(
+        ocmod, "_d", lambda: _FakeDash({"cronDetachedRun": 1})
+    )
+    sessions = OpenClawAdapter().list_sessions(limit=10)
+    val = sessions[0].extra.get("cronDetachedRun")
+    assert val is True, (
+        "cronDetachedRun must be coerced to bool, got %r" % val
+    )


### PR DESCRIPTION
Closes #3526

## Summary

- `clawmetry/adapters/openclaw.py` — in `list_sessions()`, add two blocks after the existing `cronDeliveredContent` read: read `cronScheduleKind` (+ alias `cronTriggerKind`) and `cronDetachedRun` (+ alias `cronDetached`) from the gateway session record into `extra`. Same guard pattern as the surrounding `cronDelivery*` blocks. (~10 LOC)
- `tests/test_obs_gap_openclaw_cron_on_exit_3526.py` (new) — 6 tests covering: primary field names surface, alias fallbacks accepted, absent fields produce no key in extra, value coerced to bool. Pattern mirrors `test_obs_gap_openclaw_attach_3470.py`.

## Test plan

- [ ] `python3 -m pytest tests/test_obs_gap_openclaw_cron_on_exit_3526.py -v` — 6/6 pass
- [ ] `python3 -m pytest tests/test_obs_gap_openclaw_attach_3470.py -v` — 7/7 pass (no regression in adjacent cron delivery block)
- [ ] `python3 -m py_compile clawmetry/adapters/openclaw.py` — syntax clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hk4V72yseW2rGuSms7aJvy)_