### PR TITLE
fix: surface ClawRouter provider plugin in OpenClawAdapter (#3524)

### DIFF
--- a/clawmetry/adapters/openclaw.py
+++ b/clawmetry/adapters/openclaw.py
@@ -153,6 +153,74 @@ def _openclaw_doctor_findings() -> list:
         return []
 
 
+def _clawrouter_detect() -> dict:
+    """Detect the ClawRouter bundled provider plugin (OpenClaw 2026.7.1, #99658).
+
+    ClawRouter adds credential-scoped dynamic model discovery,
+    OpenAI-compatible + native Anthropic/Gemini transports, and managed
+    budget/quota reporting across OpenClaw usage surfaces. Config and quota
+    data are written to ``~/.openclaw/clawrouter/`` by the harness onboarding
+    step (override with ``OPENCLAW_CLAWROUTER_HOME``).
+
+    Returns a dict with zero or more of:
+    - ``clawRouterEnabled`` (bool)
+    - ``clawRouterVersion`` (str)
+    - ``clawRouterTransports`` (list[str])
+    - ``clawRouterModels`` (list[str])
+    - ``clawRouterBudgetUsd`` (float) — aggregate managed budget in USD
+    - ``clawRouterQuotaCredentials`` (int) — number of credential scopes
+
+    Returns ``{}`` when the plugin is absent (pre-2026.7.1 or unconfigured).
+    Read-only, never raises.
+    """
+    import json as _json
+
+    home = os.environ.get("OPENCLAW_CLAWROUTER_HOME") or os.path.expanduser(
+        os.path.join("~", ".openclaw", "clawrouter"))
+    config_path = os.path.join(home, "config.json")
+    quota_path = os.path.join(home, "quota.json")
+
+    out: dict = {}
+
+    # Main config: enabled flag, version, transport list, model catalog
+    try:
+        with open(config_path, encoding="utf-8") as _fh:
+            cfg = _json.load(_fh)
+        out["clawRouterEnabled"] = bool(cfg.get("enabled", True))
+        version = cfg.get("version") or cfg.get("pluginVersion")
+        if version:
+            out["clawRouterVersion"] = str(version)
+        transports = cfg.get("transports") or cfg.get("transport") or []
+        if isinstance(transports, list) and transports:
+            out["clawRouterTransports"] = [str(t) for t in transports if t]
+        models = cfg.get("models") or cfg.get("modelCatalog") or []
+        if isinstance(models, list) and models:
+            out["clawRouterModels"] = [
+                str(m.get("name") or m) if isinstance(m, dict) else str(m)
+                for m in models if m
+            ]
+    except (OSError, ValueError, KeyError):
+        pass
+
+    # Quota file: aggregate managed budget + credential-scope count
+    try:
+        with open(quota_path, encoding="utf-8") as _fh:
+            quota = _json.load(_fh)
+        budget = quota.get("totalBudgetUsd") or quota.get("budgetUsd")
+        if budget is not None:
+            try:
+                out["clawRouterBudgetUsd"] = float(budget)
+            except (TypeError, ValueError):
+                pass
+        creds = quota.get("credentials") or quota.get("credentialScopes") or []
+        if isinstance(creds, list) and creds:
+            out["clawRouterQuotaCredentials"] = len(creds)
+    except (OSError, ValueError, KeyError):
+        pass
+
+    return out
+
+
 def _real_install(sessions_dir: str) -> bool:
     """A genuine OpenClaw install signal, NOT the bare ~/.openclaw dir that
     ClawMetry itself creates as a scratch workspace. Any one of: the openclaw
@@ -1132,6 +1200,13 @@ class OpenClawAdapter(AgentAdapter):
             _doctor = _openclaw_doctor_findings()
             if _doctor:
                 meta["doctorFindings"] = _doctor
+            # ClawRouter bundled provider plugin (#3524, OpenClaw 2026.7.1
+            # #99658). Credential-scoped dynamic model discovery, multi-transport
+            # routing, and managed budget/quota reporting across OpenClaw usage
+            # surfaces. Returns {} on pre-2026.7.1 installs.
+            _cr = _clawrouter_detect()
+            if _cr:
+                meta.update(_cr)
             return DetectResult(
                 name=self.name,
                 display_name=self.display_name,

--- a/tests/test_obs_gap_openclaw_clawrouter_3524.py
+++ b/tests/test_obs_gap_openclaw_clawrouter_3524.py
@@ -1,0 +1,128 @@
+"""Tests for issue #3524 — openclaw: ClawRouter provider plugin not surfaced.
+
+Verifies that _clawrouter_detect() reads config.json and quota.json from
+~/.openclaw/clawrouter/ (or OPENCLAW_CLAWROUTER_HOME) and surfaces
+credential-scoped model catalog, transport list, and budget/quota data.
+
+Fingerprint: hgap-90b7f3ec9b
+"""
+from __future__ import annotations
+
+import importlib
+import json
+import os
+
+
+def _reload_adapter():
+    import clawmetry.adapters.openclaw as oc_mod
+    importlib.reload(oc_mod)
+    return oc_mod
+
+
+def test_config_and_quota_both_present(tmp_path):
+    """Full config + quota: all keys surfaced."""
+    cr_home = tmp_path / "clawrouter"
+    cr_home.mkdir()
+    config = {
+        "enabled": True,
+        "version": "0.3.1",
+        "transports": ["openai-compatible", "anthropic-native", "gemini-native"],
+        "models": [
+            {"name": "claude-sonnet-5"},
+            {"name": "gpt-4o"},
+            "gemini-2.5-pro",
+        ],
+    }
+    quota = {
+        "totalBudgetUsd": 50.0,
+        "credentials": [{"id": "cred-a"}, {"id": "cred-b"}],
+    }
+    (cr_home / "config.json").write_text(json.dumps(config))
+    (cr_home / "quota.json").write_text(json.dumps(quota))
+
+    os.environ["OPENCLAW_CLAWROUTER_HOME"] = str(cr_home)
+    try:
+        oc = _reload_adapter()
+        result = oc._clawrouter_detect()
+    finally:
+        del os.environ["OPENCLAW_CLAWROUTER_HOME"]
+
+    assert result["clawRouterEnabled"] is True
+    assert result["clawRouterVersion"] == "0.3.1"
+    assert result["clawRouterTransports"] == [
+        "openai-compatible", "anthropic-native", "gemini-native"
+    ]
+    assert result["clawRouterModels"] == ["claude-sonnet-5", "gpt-4o", "gemini-2.5-pro"]
+    assert result["clawRouterBudgetUsd"] == 50.0
+    assert result["clawRouterQuotaCredentials"] == 2
+
+
+def test_absent_home_returns_empty_dict():
+    """No ~/.openclaw/clawrouter/ → returns {} (plugin not installed)."""
+    os.environ["OPENCLAW_CLAWROUTER_HOME"] = "/nonexistent/path/clawrouter"
+    try:
+        oc = _reload_adapter()
+        result = oc._clawrouter_detect()
+    finally:
+        del os.environ["OPENCLAW_CLAWROUTER_HOME"]
+    assert result == {}
+
+
+def test_config_only_no_quota(tmp_path):
+    """Config present but no quota file: config keys extracted, no budget keys."""
+    cr_home = tmp_path / "clawrouter"
+    cr_home.mkdir()
+    (cr_home / "config.json").write_text(json.dumps({
+        "enabled": False,
+        "transports": ["openai-compatible"],
+    }))
+    os.environ["OPENCLAW_CLAWROUTER_HOME"] = str(cr_home)
+    try:
+        oc = _reload_adapter()
+        result = oc._clawrouter_detect()
+    finally:
+        del os.environ["OPENCLAW_CLAWROUTER_HOME"]
+    assert result["clawRouterEnabled"] is False
+    assert result["clawRouterTransports"] == ["openai-compatible"]
+    assert "clawRouterBudgetUsd" not in result
+    assert "clawRouterQuotaCredentials" not in result
+
+
+def test_malformed_config_json_quota_still_read(tmp_path):
+    """Malformed config.json is silently skipped; quota data still extracted."""
+    cr_home = tmp_path / "clawrouter"
+    cr_home.mkdir()
+    (cr_home / "config.json").write_text("not-valid-json{{{")
+    (cr_home / "quota.json").write_text(json.dumps({
+        "budgetUsd": 10.5,
+        "credentialScopes": [{"id": "cred-x"}],
+    }))
+    os.environ["OPENCLAW_CLAWROUTER_HOME"] = str(cr_home)
+    try:
+        oc = _reload_adapter()
+        result = oc._clawrouter_detect()
+    finally:
+        del os.environ["OPENCLAW_CLAWROUTER_HOME"]
+    assert "clawRouterEnabled" not in result
+    assert result["clawRouterBudgetUsd"] == 10.5
+    assert result["clawRouterQuotaCredentials"] == 1
+
+
+def test_empty_models_and_transports_not_surfaced(tmp_path):
+    """Empty lists for models/transports are omitted from the result."""
+    cr_home = tmp_path / "clawrouter"
+    cr_home.mkdir()
+    (cr_home / "config.json").write_text(json.dumps({
+        "enabled": True,
+        "transports": [],
+        "models": [],
+    }))
+    os.environ["OPENCLAW_CLAWROUTER_HOME"] = str(cr_home)
+    try:
+        oc = _reload_adapter()
+        result = oc._clawrouter_detect()
+    finally:
+        del os.environ["OPENCLAW_CLAWROUTER_HOME"]
+    assert result.get("clawRouterEnabled") is True
+    assert "clawRouterTransports" not in result
+    assert "clawRouterModels" not in result


### PR DESCRIPTION
Closes #3524

## Summary

- Add `_clawrouter_detect()` helper in `clawmetry/adapters/openclaw.py` that reads `~/.openclaw/clawrouter/config.json` (enabled flag, version, transport list, model catalog) and `quota.json` (aggregate budget USD, credential-scope count) and merges the result into `DetectResult.meta`.
- Wire it into `detect()` after doctor-findings, following the same pattern as `_model_router_fingerprint` / `_sandbox_inference_configs`.
- 5 new tests in `tests/test_obs_gap_openclaw_clawrouter_3524.py` covering full config+quota, absent home, config-only, malformed config, and empty lists.

## Test plan

- `python -m pytest tests/test_obs_gap_openclaw_clawrouter_3524.py -v` — all 5 pass
- `python -m py_compile clawmetry/adapters/openclaw.py` — syntax clean
- Pre-2026.7.1 installs without `~/.openclaw/clawrouter/`: helper returns `{}`, `meta` unchanged (safe no-op)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VC1RZdhtGxEehzXune58qu)_