### PR TITLE
fix: surface unauthorized_call_count in sessions list (#3443)

### DIFF
--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -7521,6 +7521,30 @@ class LocalStore:
                 "declared_tools", "allowed_tools"]
         return [dict(zip(cols, r)) for r in self._fetch(sql, params)]
 
+    def query_session_authority_counts(
+        self,
+        session_ids: "Iterable[str]",
+    ) -> "dict[str, int]":
+        """Return {session_id: violation_count} for the given session IDs.
+
+        Missing session IDs (no violations) are omitted from the result.
+        Empty input returns {} without touching the database.
+        """
+        try:
+            ids = [str(s) for s in session_ids if s]
+            if not ids:
+                return {}
+            placeholders = ", ".join(["?"] * len(ids))
+            sql = f"""
+                SELECT session_id, COUNT(*) AS cnt
+                FROM authority_violations
+                WHERE session_id IN ({placeholders})
+                GROUP BY session_id
+            """
+            return {r[0]: int(r[1]) for r in self._fetch(sql, ids)}
+        except Exception:
+            return {}
+
     def ingest_security_event(self, event: dict[str, Any]) -> None:
         """Upsert one security-threat event row. Required: ``id``."""
         eid = event.get("id")

--- a/routes/local_query.py
+++ b/routes/local_query.py
@@ -791,6 +791,11 @@ _DAEMON_METHODS = frozenset({
     # aggregation of auto_downgraded events; routed through the daemon
     # proxy so the dashboard process never opens DuckDB writable.
     "query_routing_savings",
+    # Issue #3443 — authority-violation counts per session. Also adds
+    # query_authority_violations which was missing (causing /api/authority-violations
+    # to silently fall back to direct DuckDB open on multi-process installs).
+    "query_authority_violations",
+    "query_session_authority_counts",
 })
 
 

--- a/routes/sessions.py
+++ b/routes/sessions.py
@@ -199,6 +199,36 @@ def _decorate_with_channel_context(sessions):
     return sessions
 
 
+def _decorate_with_authority_counts(sessions):
+    """Stamp ``unauthorized_call_count`` onto each session row from the
+    authority_violations table.  Always a no-op when the proxy is disabled
+    or the table is empty — stamps 0 in that case rather than omitting the key.
+    """
+    if not sessions:
+        return sessions
+    ids = [s.get("session_id") or s.get("sessionId") for s in sessions]
+    counts = {}
+    try:
+        from routes.local_query import local_store_via_daemon
+        result = local_store_via_daemon("query_session_authority_counts",
+                                        session_ids=ids)
+        if isinstance(result, dict):
+            counts = result
+    except Exception:
+        pass
+    if not counts:
+        try:
+            from clawmetry import local_store
+            store = local_store.get_store(read_only=True)
+            counts = store.query_session_authority_counts(ids)
+        except Exception:
+            counts = {}
+    for s in sessions:
+        sid = s.get("session_id") or s.get("sessionId")
+        s["unauthorized_call_count"] = counts.get(sid, 0)
+    return sessions
+
+
 def _session_last_active_epoch(s: dict):
     """Extract a unix-second timestamp for a session row, tolerant of the
     many shapes the gateway / local-store / JSONL paths produce.
@@ -286,6 +316,7 @@ def api_sessions():
     # subject without waiting for the full session-table cutover.
     if is_local_store_read_enabled():
         _decorate_with_channel_context(sessions)
+        _decorate_with_authority_counts(sessions)
     for s in sessions:
         if "session_type" not in s:
             s["session_type"] = _infer_session_type(s)
@@ -475,6 +506,7 @@ def _try_local_store_sessions():
     # Decorate with channel context from the typed openclaw_channels table.
     # No-op when the table is empty; overrides only blank fields when present.
     _decorate_with_channel_context(out)
+    _decorate_with_authority_counts(out)
     return {"sessions": out, "_source": "local_store"}
 
 
@@ -591,6 +623,7 @@ def _try_local_store_sessions_by_type(type_filter: str = ""):
     # channel=telegram (typed table) classifies as "user" even if the metadata
     # blob never carried a channel field.
     _decorate_with_channel_context(sessions)
+    _decorate_with_authority_counts(sessions)
     for s in sessions:
         # Honour explicit metadata.session_type when present; otherwise
         # classify with the same _infer_session_type() the legacy path uses.

--- a/routes/sessions.py
+++ b/routes/sessions.py
@@ -220,7 +220,7 @@ def _decorate_with_authority_counts(sessions):
         try:
             from clawmetry import local_store
             store = local_store.get_store(read_only=True)
-            counts = store.query_session_authority_counts(ids)
+            counts = store.query_session_authority_counts(ids) or {}
         except Exception:
             counts = {}
     for s in sessions:

--- a/tests/test_approvals_local_store.py
+++ b/tests/test_approvals_local_store.py
@@ -380,3 +380,70 @@ def test_dispatch_pending_queries_approval_decision_missing_id_is_noop(fast_path
     # Neither row was touched.
     for r in rows:
         assert r["status"] == "pending"
+
+
+# ── query_session_authority_counts ────────────────────────────────────────────
+
+
+def _seed_authority_violations(store):
+    """Insert two violations for session-A and one for session-B."""
+    for i, (sess, tool) in enumerate([
+        ("session-A", "write_file"),
+        ("session-A", "bash"),
+        ("session-B", "execute_command"),
+    ]):
+        store.ingest_authority_violation({
+            "id":             f"av-{i}",
+            "session_id":     sess,
+            "ts":             f"2026-07-04T10:0{i}:00",
+            "tool":           tool,
+            "violation_type": "tool_not_in_allowed_list",
+            "declared_tools": '["read_file"]',
+            "allowed_tools":  '["read_file"]',
+        })
+
+
+def test_authority_counts_returns_correct_counts(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH",
+                       str(tmp_path / "events.duckdb"))
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    store = ls.get_store()
+    try:
+        _seed_authority_violations(store)
+        counts = store.query_session_authority_counts(["session-A", "session-B"])
+        assert counts["session-A"] == 2
+        assert counts["session-B"] == 1
+    finally:
+        store.stop(flush=True)
+
+
+def test_authority_counts_missing_session_absent(tmp_path, monkeypatch):
+    """Sessions with no violations are absent from the result (callers treat
+    absence as 0 — mirroring the query_event_totals_by_session contract)."""
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH",
+                       str(tmp_path / "events.duckdb"))
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    store = ls.get_store()
+    try:
+        _seed_authority_violations(store)
+        counts = store.query_session_authority_counts(
+            ["session-A", "session-C"]  # session-C has no violations
+        )
+        assert counts["session-A"] == 2
+        assert "session-C" not in counts
+    finally:
+        store.stop(flush=True)
+
+
+def test_authority_counts_empty_input(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH",
+                       str(tmp_path / "events.duckdb"))
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    store = ls.get_store()
+    try:
+        assert store.query_session_authority_counts([]) == {}
+    finally:
+        store.stop(flush=True)


### PR DESCRIPTION
Closes #3443

## Summary

- **`clawmetry/local_store.py`** — adds `query_session_authority_counts(session_ids)` next to `query_authority_violations()`: a single `COUNT(*) GROUP BY session_id` query returning `{session_id: int}` for the given session IDs. Mirrors the shape of `query_event_totals_by_session()`.
- **`routes/local_query.py`** — adds `"query_authority_violations"` (was missing — `/api/authority-violations` silently fell back to a direct DuckDB open on multi-process installs, a contention risk) and `"query_session_authority_counts"` to `_DAEMON_METHODS`.
- **`routes/sessions.py`** — adds `_decorate_with_authority_counts(sessions)` helper (mirrors `_decorate_with_channel_context`) and wires it at all three session-list assembly paths (gateway/JSONL fallback, local-store fast path, by-type fast path). Always stamps `unauthorized_call_count: 0` when no violations exist — never omits the key.
- **`tests/test_approvals_local_store.py`** — 3 new tests: correct per-session counts (2 + 1), missing session is absent from the result, empty input short-circuits without hitting the DB.

## Test plan

- [ ] `python3 -m pytest tests/test_approvals_local_store.py -q` — all 3 new tests green (verified locally)
- [ ] Installs with the enforcement proxy disabled: `/api/sessions` returns `unauthorized_call_count: 0` on every session (safe default)
- [ ] Installs with proxy enabled: run a session that triggers a policy violation, confirm the session row shows `unauthorized_call_count: 1`

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VGxxtdjvngSYaVTYkHARTC)_