### PR TITLE
feat(entitlement): next/previous_tier_{feature,runtime}_spec_at_batch + 4 endpoints

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -7314,3 +7314,249 @@ def runtime_spec_path_batch(
         seen.add(canon)
         rows.append({"runtime": canon, "path": path})
     return {"runtimes": rows, "unknown": unknown}
+
+
+def next_tier_feature_spec_at_batch(tier: str, features) -> dict | None:
+    """Batch sibling of :func:`next_tier_feature_spec_at`: per-feature
+    ``feature_spec_at``-shape catalogue rows for the rung above ``tier``,
+    over a caller-supplied subset of feature ids in ONE round-trip.
+
+    Feature-axis + batch projection of :func:`next_tier_spec_at` (full
+    tier-row descriptor of the rung above the source) and feature-side
+    mirror of :func:`next_tier_runtime_spec_at_batch`. Composes
+    :func:`next_tier_feature_spec_at` (scalar what-if) and
+    :func:`feature_spec_at_batch` (batch what-if): same rung-above
+    resolution as the scalar, same per-feature shape as the batch.
+
+    Lets a pricing-comparison "does each of THESE 6 features unlock at
+    my next rung?" surface hydrate the visible cells off ONE call
+    instead of N calls to :func:`next_tier_feature_spec_at`, without the
+    caller having to first resolve ``_next_purchasable_tier_after`` and
+    then thread it through :func:`feature_spec_at_batch`.
+
+    Per-feature row shape matches :func:`feature_spec_at` exactly (the
+    same key set :func:`_feature_spec_row` emits). Each row is
+    byte-identical to a row from
+    :func:`feature_spec_at_batch(target, [feature])` for the resolved
+    ``target = _next_purchasable_tier_after(tier)`` -- so a parity test
+    can pin the scalar what-if and the batch what-if against each other.
+
+    Shape::
+
+        {
+          "target":   "<next-above tier id>" | None,
+          "features": [<feature_spec_at row>, ...],
+          "unknown":  ["bogus_id", ...],
+        }
+
+    ``target`` echoes the resolved rung above ``tier`` (``None`` at the
+    ceiling -- enterprise as source). At the ceiling ``features`` is
+    empty because there is no rung to project onto -- the surface stays
+    populated so callers can render "you're at the top" copy without a
+    status-code branch. Supplied feature ids are normalised via
+    :func:`_normalise_csv` (whitespace stripped, lowercased, duplicates
+    dropped, first-seen order preserved). Unknown ids are echoed in
+    ``unknown[]`` instead of short-circuiting -- a partially-bad caller
+    still gets rows back for the valid ids alongside a list of what was
+    dropped, matching :func:`feature_spec_at_batch`'s posture.
+
+    Accepts any tier id in :data:`_TIER_ORDER` (including
+    :data:`TIER_TRIAL`) -- the lenient ``_at`` posture, matching the
+    scalar sibling.
+
+    Returns ``None`` for empty / unknown ``tier`` (caller renders
+    "unknown tier" / 404). Never raises: a synthesis failure
+    short-circuits to the OSS-free fallback so the matrix keeps
+    rendering; a per-row failure lands in ``unknown[]`` alongside the
+    caller-supplied id.
+    """
+    try:
+        src = (tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if not src or src not in _TIER_ORDER:
+        return None
+    try:
+        target = _next_purchasable_tier_after(src)
+    except Exception as exc:
+        logger.warning(
+            "entitlements: next_tier_feature_spec_at_batch resolve failed: %s",
+            exc,
+        )
+        target = None
+    feats = _normalise_csv(features)
+    if target is None:
+        unknown = [fid for fid in feats if fid not in ALL_FEATURES]
+        return {"target": None, "features": [], "unknown": unknown}
+    batch = feature_spec_at_batch(target, feats)
+    if batch is None:
+        return {"target": target, "features": [], "unknown": []}
+    return {
+        "target": target,
+        "features": batch.get("features", []),
+        "unknown": batch.get("unknown", []),
+    }
+
+
+def previous_tier_feature_spec_at_batch(
+    tier: str, features
+) -> dict | None:
+    """Batch sibling of :func:`previous_tier_feature_spec_at`: per-feature
+    ``feature_spec_at``-shape catalogue rows for the rung below ``tier``,
+    over a caller-supplied subset of feature ids in ONE round-trip.
+
+    Source-anchored mirror of :func:`next_tier_feature_spec_at_batch`
+    and downgrade-confirmation counterpart on the feature axis. Lets a
+    downgrade-confirmation card render "does each of THESE 6 features
+    still unlock at my previous rung?" off ONE call instead of N calls
+    to :func:`previous_tier_feature_spec_at`.
+
+    Shape matches :func:`next_tier_feature_spec_at_batch` byte-for-byte
+    (``target``, ``features``, ``unknown``). ``target`` collapses to
+    ``None`` at the floor (``oss`` / ``cloud_free`` as source -- no rung
+    strictly below); ``features`` is empty in that branch.
+
+    Never raises: a synthesis failure short-circuits to the OSS-free
+    fallback so the surface keeps rendering; a per-row failure lands in
+    ``unknown[]``.
+    """
+    try:
+        src = (tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if not src or src not in _TIER_ORDER:
+        return None
+    try:
+        target = _previous_purchasable_tier_before(src)
+    except Exception as exc:
+        logger.warning(
+            "entitlements: previous_tier_feature_spec_at_batch resolve failed: %s",
+            exc,
+        )
+        target = None
+    feats = _normalise_csv(features)
+    if target is None:
+        unknown = [fid for fid in feats if fid not in ALL_FEATURES]
+        return {"target": None, "features": [], "unknown": unknown}
+    batch = feature_spec_at_batch(target, feats)
+    if batch is None:
+        return {"target": target, "features": [], "unknown": []}
+    return {
+        "target": target,
+        "features": batch.get("features", []),
+        "unknown": batch.get("unknown", []),
+    }
+
+
+def next_tier_runtime_spec_at_batch(tier: str, runtimes) -> dict | None:
+    """Batch sibling of :func:`next_tier_runtime_spec_at`: per-runtime
+    ``runtime_spec_at``-shape catalogue rows for the rung above
+    ``tier``, over a caller-supplied subset of runtime ids in ONE
+    round-trip.
+
+    Runtime-axis twin of :func:`next_tier_feature_spec_at_batch` and
+    batch sibling of :func:`next_tier_runtime_spec_at`. Aliases are
+    canonicalised via :func:`canonical_runtime` (``claude-code`` ->
+    ``claude_code``) and aliases that collapse to a canonical id
+    already in the response are silently de-duplicated -- same
+    behaviour as :func:`runtime_spec_at_batch`.
+
+    Each row is byte-identical to a row from
+    :func:`runtime_spec_at_batch(target, [runtime])` for the resolved
+    ``target = _next_purchasable_tier_after(tier)``. Per-row shape
+    matches :func:`runtime_spec_at`; the per-row ``runtime`` value
+    carries the canonical id, never the supplied alias.
+
+    Shape::
+
+        {
+          "target":   "<next-above tier id>" | None,
+          "runtimes": [<runtime_spec_at row>, ...],
+          "unknown":  ["bogus_id", ...],
+        }
+
+    Returns ``None`` for empty / unknown ``tier``. At the ceiling
+    ``target`` / ``runtimes`` collapse the same way
+    :func:`next_tier_feature_spec_at_batch` does. Never raises.
+    """
+    try:
+        src = (tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if not src or src not in _TIER_ORDER:
+        return None
+    try:
+        target = _next_purchasable_tier_after(src)
+    except Exception as exc:
+        logger.warning(
+            "entitlements: next_tier_runtime_spec_at_batch resolve failed: %s",
+            exc,
+        )
+        target = None
+    rts = _normalise_csv(runtimes)
+    if target is None:
+        unknown = [
+            raw
+            for raw in rts
+            if not canonical_runtime(raw)
+            or canonical_runtime(raw) not in ALL_RUNTIMES
+        ]
+        return {"target": None, "runtimes": [], "unknown": unknown}
+    batch = runtime_spec_at_batch(target, rts)
+    if batch is None:
+        return {"target": target, "runtimes": [], "unknown": []}
+    return {
+        "target": target,
+        "runtimes": batch.get("runtimes", []),
+        "unknown": batch.get("unknown", []),
+    }
+
+
+def previous_tier_runtime_spec_at_batch(
+    tier: str, runtimes
+) -> dict | None:
+    """Batch sibling of :func:`previous_tier_runtime_spec_at`: per-runtime
+    ``runtime_spec_at``-shape catalogue rows for the rung below
+    ``tier``, over a caller-supplied subset of runtime ids in ONE
+    round-trip.
+
+    Source-anchored mirror of :func:`next_tier_runtime_spec_at_batch`
+    and downgrade-confirmation counterpart on the runtime axis. Shape
+    matches :func:`next_tier_runtime_spec_at_batch` byte-for-byte
+    (``target``, ``runtimes``, ``unknown``). ``target`` collapses to
+    ``None`` at the floor; ``runtimes`` is empty in that branch.
+
+    Never raises: a synthesis failure short-circuits to the OSS-free
+    fallback so the surface keeps rendering.
+    """
+    try:
+        src = (tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if not src or src not in _TIER_ORDER:
+        return None
+    try:
+        target = _previous_purchasable_tier_before(src)
+    except Exception as exc:
+        logger.warning(
+            "entitlements: previous_tier_runtime_spec_at_batch resolve failed: %s",
+            exc,
+        )
+        target = None
+    rts = _normalise_csv(runtimes)
+    if target is None:
+        unknown = [
+            raw
+            for raw in rts
+            if not canonical_runtime(raw)
+            or canonical_runtime(raw) not in ALL_RUNTIMES
+        ]
+        return {"target": None, "runtimes": [], "unknown": unknown}
+    batch = runtime_spec_at_batch(target, rts)
+    if batch is None:
+        return {"target": target, "runtimes": [], "unknown": []}
+    return {
+        "target": target,
+        "runtimes": batch.get("runtimes", []),
+        "unknown": batch.get("unknown", []),
+    }

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -7243,3 +7243,334 @@ def api_entitlement_runtime_spec_path_batch():
                 "unknown": [],
             }
         )
+
+
+@bp_entitlement.route("/api/entitlement/next-tier-feature-spec-at-batch")
+def api_entitlement_next_tier_feature_spec_at_batch():
+    """``GET /api/entitlement/next-tier-feature-spec-at-batch?tier=<source>
+    &features=a,b,c`` -- batch sibling of
+    ``/api/entitlement/next-tier-feature-spec-at``.
+
+    Where ``/next-tier-feature-spec-at`` projects the rung above
+    ``tier`` onto ONE feature, this walks N features onto the same
+    rung-above in ONE round-trip. Pairs with
+    ``/next-tier-feature-spec-at`` the same way
+    ``/feature-spec-at-batch`` pairs with ``/feature-spec-at``: scalar
+    -> matrix in one call.
+
+    Use case: a paywall "does each of THESE 6 features unlock at my
+    next rung?" surface hydrates the visible cells off ONE call instead
+    of N calls to ``/next-tier-feature-spec-at``.
+
+    Each row in ``features[]`` is byte-identical to a row from
+    ``/feature-spec-at-batch?tier=<target>&features=<...>`` for the
+    resolved ``target = _next_purchasable_tier_after(tier)`` -- pinned
+    by the parity tests so the scalar what-if and the batch what-if
+    cannot drift. Supplied feature ids are normalised (whitespace
+    stripped, lowercased, duplicates dropped, first-seen order
+    preserved). Unknown ids do not 404 the call -- they are echoed in
+    ``unknown[]`` so a partially-bad caller still gets rows back for
+    the valid ids.
+
+    Response shape::
+
+        {
+          "tier":         "<source tier id>",
+          "tier_label":   "<source label>",
+          "tier_rank":    <source rank>,
+          "target":       "<next-above tier id>" | null,
+          "target_label": "<next-above label>" | null,
+          "target_rank":  <next-above rank> | null,
+          "features":     [<feature_spec_at row>, ...],
+          "unknown":      ["bogus_id", ...],
+        }
+
+    ``target`` / ``target_label`` / ``target_rank`` collapse to
+    ``null`` at the ceiling (no rung strictly above the source --
+    enterprise as source); ``features`` is empty in that branch. The
+    surface stays 200 so callers can render "you're at the top" copy
+    without a status-code branch.
+
+    - **400** when ``tier=`` or ``features=`` is missing / blank / empty
+      after normalisation
+    - **404** when ``tier`` is unknown (body carries ``which: "tier"``)
+    - **Never 5xxs**: a synthesis failure short-circuits to the
+      grace-shape envelope so the surface keeps rendering.
+    """
+    raw_tier = request.args.get("tier")
+    tier_in = (raw_tier or "").strip().lower()
+    if not tier_in:
+        return jsonify({"error": "missing tier"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        if tier_in not in _ent._TIER_ORDER:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "tier", "tier": tier_in}
+                ),
+                404,
+            )
+        features = _parse_csv_arg("features")
+        if not features:
+            return jsonify({"error": "supply features=<csv>"}), 400
+        batch = _ent.next_tier_feature_spec_at_batch(tier_in, features)
+        if batch is None:
+            batch = {"target": None, "features": [], "unknown": []}
+        target = batch.get("target")
+        return jsonify(
+            {
+                "tier": tier_in,
+                "tier_label": _ent.tier_label(tier_in),
+                "tier_rank": _ent.tier_rank(tier_in),
+                "target": target,
+                "target_label": _ent.tier_label(target) if target else None,
+                "target_rank": _ent.tier_rank(target) if target else None,
+                "features": batch.get("features", []),
+                "unknown": batch.get("unknown", []),
+            }
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_next_tier_feature_spec_at_batch: error: %s", exc
+        )
+        return jsonify(
+            {
+                "tier": tier_in,
+                "tier_label": None,
+                "tier_rank": -1,
+                "target": None,
+                "target_label": None,
+                "target_rank": None,
+                "features": [],
+                "unknown": [],
+            }
+        )
+
+
+@bp_entitlement.route("/api/entitlement/previous-tier-feature-spec-at-batch")
+def api_entitlement_previous_tier_feature_spec_at_batch():
+    """``GET /api/entitlement/previous-tier-feature-spec-at-batch?tier=<source>
+    &features=a,b,c`` -- batch sibling of
+    ``/api/entitlement/previous-tier-feature-spec-at``.
+
+    Source-anchored mirror of
+    ``/next-tier-feature-spec-at-batch`` and downgrade-confirmation
+    counterpart on the feature axis. Lets a downgrade-confirmation
+    card render "does each of THESE 6 features still unlock one rung
+    down?" off ONE call instead of N calls to
+    ``/previous-tier-feature-spec-at``.
+
+    Response shape matches ``/next-tier-feature-spec-at-batch``
+    byte-for-byte (``tier``, ``tier_label``, ``tier_rank``, ``target``,
+    ``target_label``, ``target_rank``, ``features``, ``unknown``).
+    ``target`` collapses to ``null`` at the floor (``oss`` /
+    ``cloud_free`` as source); ``features`` is empty in that branch.
+
+    - **400** when ``tier=`` or ``features=`` is missing / blank / empty
+      after normalisation
+    - **404** when ``tier`` is unknown.
+    - **Never 5xxs**.
+    """
+    raw_tier = request.args.get("tier")
+    tier_in = (raw_tier or "").strip().lower()
+    if not tier_in:
+        return jsonify({"error": "missing tier"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        if tier_in not in _ent._TIER_ORDER:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "tier", "tier": tier_in}
+                ),
+                404,
+            )
+        features = _parse_csv_arg("features")
+        if not features:
+            return jsonify({"error": "supply features=<csv>"}), 400
+        batch = _ent.previous_tier_feature_spec_at_batch(tier_in, features)
+        if batch is None:
+            batch = {"target": None, "features": [], "unknown": []}
+        target = batch.get("target")
+        return jsonify(
+            {
+                "tier": tier_in,
+                "tier_label": _ent.tier_label(tier_in),
+                "tier_rank": _ent.tier_rank(tier_in),
+                "target": target,
+                "target_label": _ent.tier_label(target) if target else None,
+                "target_rank": _ent.tier_rank(target) if target else None,
+                "features": batch.get("features", []),
+                "unknown": batch.get("unknown", []),
+            }
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_previous_tier_feature_spec_at_batch: error: %s",
+            exc,
+        )
+        return jsonify(
+            {
+                "tier": tier_in,
+                "tier_label": None,
+                "tier_rank": -1,
+                "target": None,
+                "target_label": None,
+                "target_rank": None,
+                "features": [],
+                "unknown": [],
+            }
+        )
+
+
+@bp_entitlement.route("/api/entitlement/next-tier-runtime-spec-at-batch")
+def api_entitlement_next_tier_runtime_spec_at_batch():
+    """``GET /api/entitlement/next-tier-runtime-spec-at-batch?tier=<source>
+    &runtimes=a,b,c`` -- batch sibling of
+    ``/api/entitlement/next-tier-runtime-spec-at``.
+
+    Runtime-axis twin of ``/next-tier-feature-spec-at-batch``.
+    Aliases are canonicalised (``claude-code`` -> ``claude_code``) and
+    aliases that collapse to a canonical id already in the response
+    are silently de-duplicated so the row count matches the
+    unique-canonical-id count.
+
+    Each row in ``runtimes[]`` is byte-identical to a row from
+    ``/runtime-spec-at-batch?tier=<target>&runtimes=<...>`` for the
+    resolved ``target = _next_purchasable_tier_after(tier)``. Unknown
+    ids do not 404 the call -- they are echoed in ``unknown[]``
+    carrying the supplied alias so the caller can correlate against
+    what was sent.
+
+    Response shape mirrors ``/next-tier-feature-spec-at-batch`` with
+    ``"runtimes"`` in place of ``"features"``.
+
+    - **400** when ``tier=`` or ``runtimes=`` is missing / blank / empty
+      after normalisation
+    - **404** when ``tier`` is unknown.
+    - **Never 5xxs**.
+    """
+    raw_tier = request.args.get("tier")
+    tier_in = (raw_tier or "").strip().lower()
+    if not tier_in:
+        return jsonify({"error": "missing tier"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        if tier_in not in _ent._TIER_ORDER:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "tier", "tier": tier_in}
+                ),
+                404,
+            )
+        runtimes = _parse_csv_arg("runtimes")
+        if not runtimes:
+            return jsonify({"error": "supply runtimes=<csv>"}), 400
+        batch = _ent.next_tier_runtime_spec_at_batch(tier_in, runtimes)
+        if batch is None:
+            batch = {"target": None, "runtimes": [], "unknown": []}
+        target = batch.get("target")
+        return jsonify(
+            {
+                "tier": tier_in,
+                "tier_label": _ent.tier_label(tier_in),
+                "tier_rank": _ent.tier_rank(tier_in),
+                "target": target,
+                "target_label": _ent.tier_label(target) if target else None,
+                "target_rank": _ent.tier_rank(target) if target else None,
+                "runtimes": batch.get("runtimes", []),
+                "unknown": batch.get("unknown", []),
+            }
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_next_tier_runtime_spec_at_batch: error: %s", exc
+        )
+        return jsonify(
+            {
+                "tier": tier_in,
+                "tier_label": None,
+                "tier_rank": -1,
+                "target": None,
+                "target_label": None,
+                "target_rank": None,
+                "runtimes": [],
+                "unknown": [],
+            }
+        )
+
+
+@bp_entitlement.route("/api/entitlement/previous-tier-runtime-spec-at-batch")
+def api_entitlement_previous_tier_runtime_spec_at_batch():
+    """``GET /api/entitlement/previous-tier-runtime-spec-at-batch?tier=<source>
+    &runtimes=a,b,c`` -- batch sibling of
+    ``/api/entitlement/previous-tier-runtime-spec-at``.
+
+    Source-anchored mirror of
+    ``/next-tier-runtime-spec-at-batch`` and downgrade-confirmation
+    counterpart on the runtime axis. Aliases are canonicalised the
+    same way ``/next-tier-runtime-spec-at-batch`` already does.
+
+    Response shape matches ``/next-tier-runtime-spec-at-batch``
+    byte-for-byte (``tier``, ``tier_label``, ``tier_rank``, ``target``,
+    ``target_label``, ``target_rank``, ``runtimes``, ``unknown``).
+    ``target`` collapses to ``null`` at the floor; ``runtimes`` is
+    empty in that branch.
+
+    - **400** when ``tier=`` or ``runtimes=`` is missing / blank / empty
+      after normalisation
+    - **404** when ``tier`` is unknown.
+    - **Never 5xxs**.
+    """
+    raw_tier = request.args.get("tier")
+    tier_in = (raw_tier or "").strip().lower()
+    if not tier_in:
+        return jsonify({"error": "missing tier"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        if tier_in not in _ent._TIER_ORDER:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "tier", "tier": tier_in}
+                ),
+                404,
+            )
+        runtimes = _parse_csv_arg("runtimes")
+        if not runtimes:
+            return jsonify({"error": "supply runtimes=<csv>"}), 400
+        batch = _ent.previous_tier_runtime_spec_at_batch(tier_in, runtimes)
+        if batch is None:
+            batch = {"target": None, "runtimes": [], "unknown": []}
+        target = batch.get("target")
+        return jsonify(
+            {
+                "tier": tier_in,
+                "tier_label": _ent.tier_label(tier_in),
+                "tier_rank": _ent.tier_rank(tier_in),
+                "target": target,
+                "target_label": _ent.tier_label(target) if target else None,
+                "target_rank": _ent.tier_rank(target) if target else None,
+                "runtimes": batch.get("runtimes", []),
+                "unknown": batch.get("unknown", []),
+            }
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_previous_tier_runtime_spec_at_batch: error: %s",
+            exc,
+        )
+        return jsonify(
+            {
+                "tier": tier_in,
+                "tier_label": None,
+                "tier_rank": -1,
+                "target": None,
+                "target_label": None,
+                "target_rank": None,
+                "runtimes": [],
+                "unknown": [],
+            }
+        )

--- a/tests/test_entitlement_next_prev_tier_feat_runtime_spec_at_batch.py
+++ b/tests/test_entitlement_next_prev_tier_feat_runtime_spec_at_batch.py
@@ -1,0 +1,554 @@
+"""Tests for ``next_tier_feature_spec_at_batch`` /
+``previous_tier_feature_spec_at_batch`` /
+``next_tier_runtime_spec_at_batch`` /
+``previous_tier_runtime_spec_at_batch`` and the four companion
+``/api/entitlement/{next,previous}-tier-{feature,runtime}-spec-at-batch``
+endpoints.
+
+Batch siblings of the scalar
+``{next,previous}_tier_{feature,runtime}_spec_at`` what-ifs.  Where each
+scalar what-if projects the rung above / below the source onto ONE
+feature / runtime id, the batch siblings project onto N ids in ONE
+round-trip -- the feature / runtime axis analogue of
+``{next,previous}_tier_spec_at_batch`` (which walks the full spec-row
+descriptor at every purchasable source).
+
+Pins covered here:
+
+* each row in ``features[]`` / ``runtimes[]`` byte-equals the scalar
+  ``feature_spec_at`` / ``runtime_spec_at`` row for the resolved
+  ``target = _{next,previous}_purchasable_tier_after/before(tier)`` --
+  the batch-vs-scalar parity that stops the batch what-if drifting from
+  the scalar what-if
+* each row byte-equals the row from
+  ``feature_spec_at_batch(target, [id])`` /
+  ``runtime_spec_at_batch(target, [id])`` for the same target -- pin
+  against the perspective-tier batch helper
+* the batch also byte-equals ``next_tier_feature_spec_at(tier, id)`` /
+  ``next_tier_runtime_spec_at(tier, id)`` per row -- so the scalar
+  ``next`` / ``previous`` what-if projections and the batch ``next`` /
+  ``previous`` what-if projections cannot drift
+* ``target`` echoes the resolved rung above / below the source; at the
+  source-side ceiling / floor ``target`` collapses to ``None`` and
+  ``features[]`` / ``runtimes[]`` is empty (surface stays populated
+  instead of being dropped)
+* supplied ids are normalised via ``_normalise_csv`` (trim / lowercase /
+  duplicate drop / first-seen order); unknown ids echo into
+  ``unknown[]`` instead of short-circuiting
+* runtime aliases canonicalise (``claude-code`` -> ``claude_code``) and
+  collapse against already-supplied canonical ids without emitting two
+  rows
+* unknown / blank ``tier`` returns ``None`` (helper) / 400 / 404 (HTTP)
+* the helpers never raise: a top-level failure short-circuits to
+  ``{"target": None, "features": [], "unknown": []}``
+* grace vs enforce yields identical rows (the batch is catalogue-derived
+  through the scalar sibling, not the gated resolver)
+* the four HTTP endpoints 400 on missing / empty input, 404 on unknown
+  tier, and never 5xx on a resolver crash
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+_FEATURE_ROW_KEYS = {
+    "id",
+    "label",
+    "tier",
+    "tiers",
+    "free",
+    "allowed",
+    "locked",
+    "entitled",
+    "alias",
+}
+
+_RUNTIME_ROW_KEYS = {
+    "id",
+    "label",
+    "free",
+    "tier",
+    "tiers",
+    "allowed",
+    "locked",
+    "entitled",
+}
+
+_ENVELOPE_KEYS = {
+    "tier",
+    "tier_label",
+    "tier_rank",
+    "target",
+    "target_label",
+    "target_rank",
+    "features",
+    "unknown",
+}
+
+_RUNTIME_ENVELOPE_KEYS = {
+    "tier",
+    "tier_label",
+    "tier_rank",
+    "target",
+    "target_label",
+    "target_rank",
+    "runtimes",
+    "unknown",
+}
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    """Fresh entitlements module with HOME pointed at an empty tmp dir
+    so no real ~/.clawmetry/license.key or cloud_plan.json leaks in.
+    Enforcement off by default (grace mode); the batch is catalogue-
+    derived through the scalar sibling, so the fixture only needs to
+    keep the live resolver from surprising the test."""
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# ── next_tier_feature_spec_at_batch: tier + input handling ───────────────────
+
+
+def test_next_feat_batch_unknown_tier_returns_none(ent):
+    assert ent.next_tier_feature_spec_at_batch("bogus", ["sessions"]) is None
+
+
+def test_next_feat_batch_blank_tier_returns_none(ent):
+    assert ent.next_tier_feature_spec_at_batch("", ["sessions"]) is None
+    assert ent.next_tier_feature_spec_at_batch("  ", ["sessions"]) is None
+
+
+def test_next_feat_batch_none_tier_returns_none(ent):
+    assert ent.next_tier_feature_spec_at_batch(None, ["sessions"]) is None
+
+
+def test_next_feat_batch_int_tier_returns_none(ent):
+    assert ent.next_tier_feature_spec_at_batch(42, ["sessions"]) is None
+
+
+def test_next_feat_batch_trims_and_lowercases_tier(ent):
+    # `_at` posture: any tier id in ``_TIER_ORDER`` accepted, including
+    # trial.  Whitespace + case handled leniently.
+    same = ent.next_tier_feature_spec_at_batch(
+        "  OSS  ", list(ent.FREE_FEATURES)[:1]
+    )
+    canon = ent.next_tier_feature_spec_at_batch(
+        ent.TIER_OSS, list(ent.FREE_FEATURES)[:1]
+    )
+    assert same == canon
+
+
+# ── next_tier_feature_spec_at_batch: envelope shape + parity ─────────────────
+
+
+def test_next_feat_batch_envelope_shape_from_oss(ent):
+    body = ent.next_tier_feature_spec_at_batch(
+        ent.TIER_OSS, list(ent.FREE_FEATURES)[:1]
+    )
+    assert body is not None
+    assert set(body.keys()) == {"target", "features", "unknown"}
+    assert body["target"] == ent._next_purchasable_tier_after(ent.TIER_OSS)
+
+
+def test_next_feat_batch_row_shape_matches_feature_spec_at(ent):
+    fid = next(iter(ent.FREE_FEATURES))
+    body = ent.next_tier_feature_spec_at_batch(ent.TIER_OSS, [fid])
+    assert body["features"], "expected at least one row above OSS"
+    for row in body["features"]:
+        assert set(row.keys()) == _FEATURE_ROW_KEYS
+
+
+def test_next_feat_batch_parity_with_scalar_next_tier_feature_spec_at(ent):
+    """Pin batch-vs-scalar no-drift on the ``next`` axis: every batch
+    row equals ``next_tier_feature_spec_at(tier, id)`` for the same
+    (source, feature) pair.
+    """
+    ids = sorted(ent.ALL_FEATURES)
+    body = ent.next_tier_feature_spec_at_batch(ent.TIER_OSS, ids)
+    rows_by_id = {row["id"]: row for row in body["features"]}
+    for fid in ids:
+        scalar = ent.next_tier_feature_spec_at(ent.TIER_OSS, fid)
+        if scalar is None:
+            continue
+        assert rows_by_id.get(fid) == scalar, fid
+
+
+def test_next_feat_batch_parity_with_feature_spec_at_batch_on_target(ent):
+    """Pin the batch what-if against the perspective-tier batch: the
+    rows must match ``feature_spec_at_batch(target, ids)`` for the
+    resolved ``target = _next_purchasable_tier_after(tier)``.
+    """
+    ids = sorted(ent.ALL_FEATURES)
+    body = ent.next_tier_feature_spec_at_batch(ent.TIER_OSS, ids)
+    target = ent._next_purchasable_tier_after(ent.TIER_OSS)
+    reference = ent.feature_spec_at_batch(target, ids)
+    assert body["features"] == reference["features"]
+    assert body["unknown"] == reference["unknown"]
+
+
+def test_next_feat_batch_normalises_ids(ent):
+    fid = next(iter(ent.FREE_FEATURES))
+    body = ent.next_tier_feature_spec_at_batch(
+        ent.TIER_OSS, [f"  {fid.upper()}  ", fid, fid]
+    )
+    # duplicates dropped, first-seen order preserved -> one row.
+    assert len(body["features"]) == 1
+    assert body["features"][0]["id"] == fid
+
+
+def test_next_feat_batch_unknown_ids_echo_into_unknown(ent):
+    fid = next(iter(ent.FREE_FEATURES))
+    body = ent.next_tier_feature_spec_at_batch(
+        ent.TIER_OSS, [fid, "totally_bogus_feature"]
+    )
+    assert "totally_bogus_feature" in body["unknown"]
+    assert any(row["id"] == fid for row in body["features"])
+
+
+def test_next_feat_batch_ceiling_collapses(ent):
+    # Enterprise as source -> no rung strictly above.  target=None,
+    # features=[] -- the envelope stays populated so callers can
+    # render "you're at the top" without a status-code branch.
+    body = ent.next_tier_feature_spec_at_batch(
+        ent.TIER_ENTERPRISE, list(ent.FREE_FEATURES)[:1]
+    )
+    assert body == {"target": None, "features": [], "unknown": []}
+
+
+def test_next_feat_batch_ceiling_still_reports_unknown_ids(ent):
+    # Ceiling branch reports genuine unknown ids so a partially-bad
+    # caller can still learn what would have been dropped one rung
+    # earlier -- helps a UI debug the caller-supplied list even at the
+    # top of the ladder.
+    body = ent.next_tier_feature_spec_at_batch(
+        ent.TIER_ENTERPRISE, ["totally_bogus_feature"]
+    )
+    assert body["target"] is None
+    assert body["features"] == []
+    assert "totally_bogus_feature" in body["unknown"]
+
+
+def test_next_feat_batch_grace_matches_enforce(ent, monkeypatch):
+    ids = sorted(ent.ALL_FEATURES)
+    grace = ent.next_tier_feature_spec_at_batch(ent.TIER_OSS, ids)
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    importlib.reload(ent)
+    ent.invalidate()
+    enforce = ent.next_tier_feature_spec_at_batch(ent.TIER_OSS, ids)
+    assert enforce == grace
+
+
+def test_next_feat_batch_swallows_resolver_exception(ent, monkeypatch):
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "_next_purchasable_tier_after", boom)
+    body = ent.next_tier_feature_spec_at_batch(
+        ent.TIER_OSS, ["totally_bogus"]
+    )
+    # Resolver crash collapses to the "target=None" branch, envelope
+    # keeps rendering, unknown ids still surface.
+    assert body["target"] is None
+    assert body["features"] == []
+    assert "totally_bogus" in body["unknown"]
+
+
+# ── previous_tier_feature_spec_at_batch ──────────────────────────────────────
+
+
+def test_prev_feat_batch_floor_collapses(ent):
+    body = ent.previous_tier_feature_spec_at_batch(
+        ent.TIER_OSS, list(ent.FREE_FEATURES)[:1]
+    )
+    assert body == {"target": None, "features": [], "unknown": []}
+
+
+def test_prev_feat_batch_parity_with_scalar(ent):
+    ids = sorted(ent.ALL_FEATURES)
+    body = ent.previous_tier_feature_spec_at_batch(ent.TIER_ENTERPRISE, ids)
+    rows_by_id = {row["id"]: row for row in body["features"]}
+    for fid in ids:
+        scalar = ent.previous_tier_feature_spec_at(ent.TIER_ENTERPRISE, fid)
+        if scalar is None:
+            continue
+        assert rows_by_id.get(fid) == scalar, fid
+
+
+def test_prev_feat_batch_parity_with_feature_spec_at_batch_on_target(ent):
+    ids = sorted(ent.ALL_FEATURES)
+    body = ent.previous_tier_feature_spec_at_batch(ent.TIER_ENTERPRISE, ids)
+    target = ent._previous_purchasable_tier_before(ent.TIER_ENTERPRISE)
+    reference = ent.feature_spec_at_batch(target, ids)
+    assert body["features"] == reference["features"]
+    assert body["unknown"] == reference["unknown"]
+
+
+# ── next_tier_runtime_spec_at_batch ──────────────────────────────────────────
+
+
+def test_next_rt_batch_unknown_tier_returns_none(ent):
+    assert ent.next_tier_runtime_spec_at_batch("bogus", ["openclaw"]) is None
+
+
+def test_next_rt_batch_row_shape_matches_runtime_spec_at(ent):
+    body = ent.next_tier_runtime_spec_at_batch(ent.TIER_OSS, ["openclaw"])
+    assert body["runtimes"], "expected at least one row above OSS"
+    for row in body["runtimes"]:
+        assert set(row.keys()) == _RUNTIME_ROW_KEYS
+
+
+def test_next_rt_batch_parity_with_scalar_next_tier_runtime_spec_at(ent):
+    rts = sorted(ent.ALL_RUNTIMES)
+    body = ent.next_tier_runtime_spec_at_batch(ent.TIER_OSS, rts)
+    rows_by_id = {row["id"]: row for row in body["runtimes"]}
+    for rt in rts:
+        scalar = ent.next_tier_runtime_spec_at(ent.TIER_OSS, rt)
+        if scalar is None:
+            continue
+        assert rows_by_id.get(rt) == scalar, rt
+
+
+def test_next_rt_batch_parity_with_runtime_spec_at_batch_on_target(ent):
+    rts = sorted(ent.ALL_RUNTIMES)
+    body = ent.next_tier_runtime_spec_at_batch(ent.TIER_OSS, rts)
+    target = ent._next_purchasable_tier_after(ent.TIER_OSS)
+    reference = ent.runtime_spec_at_batch(target, rts)
+    assert body["runtimes"] == reference["runtimes"]
+    assert body["unknown"] == reference["unknown"]
+
+
+def test_next_rt_batch_aliases_canonicalise_and_dedupe(ent):
+    # ``claude-code`` (alias) + ``claude_code`` (canonical) collapse to
+    # one row on the canonical id.
+    rt_paid = next(iter(ent.PAID_RUNTIMES))  # e.g. "claude_code"
+    aliased = rt_paid.replace("_", "-")
+    body = ent.next_tier_runtime_spec_at_batch(
+        ent.TIER_OSS, [aliased, rt_paid]
+    )
+    matching = [row for row in body["runtimes"] if row["id"] == rt_paid]
+    assert len(matching) == 1
+
+
+def test_next_rt_batch_ceiling_collapses(ent):
+    body = ent.next_tier_runtime_spec_at_batch(
+        ent.TIER_ENTERPRISE, ["openclaw"]
+    )
+    assert body == {"target": None, "runtimes": [], "unknown": []}
+
+
+def test_next_rt_batch_unknown_alias_echoes_into_unknown_at_ceiling(ent):
+    body = ent.next_tier_runtime_spec_at_batch(
+        ent.TIER_ENTERPRISE, ["totally-bogus-runtime"]
+    )
+    assert body["target"] is None
+    assert body["runtimes"] == []
+    assert "totally-bogus-runtime" in body["unknown"]
+
+
+# ── previous_tier_runtime_spec_at_batch ──────────────────────────────────────
+
+
+def test_prev_rt_batch_floor_collapses(ent):
+    body = ent.previous_tier_runtime_spec_at_batch(
+        ent.TIER_OSS, ["openclaw"]
+    )
+    assert body == {"target": None, "runtimes": [], "unknown": []}
+
+
+def test_prev_rt_batch_parity_with_scalar(ent):
+    rts = sorted(ent.ALL_RUNTIMES)
+    body = ent.previous_tier_runtime_spec_at_batch(ent.TIER_ENTERPRISE, rts)
+    rows_by_id = {row["id"]: row for row in body["runtimes"]}
+    for rt in rts:
+        scalar = ent.previous_tier_runtime_spec_at(ent.TIER_ENTERPRISE, rt)
+        if scalar is None:
+            continue
+        assert rows_by_id.get(rt) == scalar, rt
+
+
+# ── HTTP: next-tier-feature-spec-at-batch ────────────────────────────────────
+
+
+def test_http_next_feat_batch_missing_tier_400(client):
+    resp = client.get("/api/entitlement/next-tier-feature-spec-at-batch")
+    assert resp.status_code == 400
+
+
+def test_http_next_feat_batch_blank_tier_400(client):
+    resp = client.get(
+        "/api/entitlement/next-tier-feature-spec-at-batch?tier=%20"
+    )
+    assert resp.status_code == 400
+
+
+def test_http_next_feat_batch_missing_features_400(client):
+    resp = client.get(
+        "/api/entitlement/next-tier-feature-spec-at-batch?tier=oss"
+    )
+    assert resp.status_code == 400
+
+
+def test_http_next_feat_batch_unknown_tier_404(client):
+    resp = client.get(
+        "/api/entitlement/next-tier-feature-spec-at-batch"
+        "?tier=bogus&features=sessions"
+    )
+    assert resp.status_code == 404
+    body = resp.get_json()
+    assert body["which"] == "tier"
+
+
+def test_http_next_feat_batch_envelope_shape(ent, client):
+    fid = next(iter(ent.FREE_FEATURES))
+    resp = client.get(
+        f"/api/entitlement/next-tier-feature-spec-at-batch"
+        f"?tier=oss&features={fid}"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert set(body.keys()) == _ENVELOPE_KEYS
+    assert body["tier"] == ent.TIER_OSS
+    assert body["target"] == ent._next_purchasable_tier_after(ent.TIER_OSS)
+
+
+def test_http_next_feat_batch_ceiling_200_with_null_target(client):
+    resp = client.get(
+        "/api/entitlement/next-tier-feature-spec-at-batch"
+        "?tier=enterprise&features=sessions"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["target"] is None
+    assert body["target_label"] is None
+    assert body["target_rank"] is None
+    assert body["features"] == []
+
+
+def test_http_next_feat_batch_never_5xxs_on_helper_exception(
+    ent, client, monkeypatch
+):
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "next_tier_feature_spec_at_batch", boom)
+    fid = next(iter(ent.FREE_FEATURES))
+    resp = client.get(
+        f"/api/entitlement/next-tier-feature-spec-at-batch"
+        f"?tier=oss&features={fid}"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["features"] == []
+    assert body["unknown"] == []
+
+
+# ── HTTP: previous-tier-feature-spec-at-batch ────────────────────────────────
+
+
+def test_http_prev_feat_batch_missing_features_400(client):
+    resp = client.get(
+        "/api/entitlement/previous-tier-feature-spec-at-batch?tier=enterprise"
+    )
+    assert resp.status_code == 400
+
+
+def test_http_prev_feat_batch_unknown_tier_404(client):
+    resp = client.get(
+        "/api/entitlement/previous-tier-feature-spec-at-batch"
+        "?tier=bogus&features=sessions"
+    )
+    assert resp.status_code == 404
+
+
+def test_http_prev_feat_batch_floor_200_with_null_target(client):
+    resp = client.get(
+        "/api/entitlement/previous-tier-feature-spec-at-batch"
+        "?tier=oss&features=sessions"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["target"] is None
+    assert body["features"] == []
+
+
+# ── HTTP: next-tier-runtime-spec-at-batch ────────────────────────────────────
+
+
+def test_http_next_rt_batch_missing_runtimes_400(client):
+    resp = client.get(
+        "/api/entitlement/next-tier-runtime-spec-at-batch?tier=oss"
+    )
+    assert resp.status_code == 400
+
+
+def test_http_next_rt_batch_unknown_tier_404(client):
+    resp = client.get(
+        "/api/entitlement/next-tier-runtime-spec-at-batch"
+        "?tier=bogus&runtimes=openclaw"
+    )
+    assert resp.status_code == 404
+
+
+def test_http_next_rt_batch_envelope_shape(ent, client):
+    resp = client.get(
+        "/api/entitlement/next-tier-runtime-spec-at-batch"
+        "?tier=oss&runtimes=openclaw"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert set(body.keys()) == _RUNTIME_ENVELOPE_KEYS
+    assert body["tier"] == ent.TIER_OSS
+    assert body["target"] == ent._next_purchasable_tier_after(ent.TIER_OSS)
+
+
+def test_http_next_rt_batch_ceiling_200_with_null_target(client):
+    resp = client.get(
+        "/api/entitlement/next-tier-runtime-spec-at-batch"
+        "?tier=enterprise&runtimes=openclaw"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["target"] is None
+    assert body["runtimes"] == []
+
+
+# ── HTTP: previous-tier-runtime-spec-at-batch ────────────────────────────────
+
+
+def test_http_prev_rt_batch_floor_200_with_null_target(client):
+    resp = client.get(
+        "/api/entitlement/previous-tier-runtime-spec-at-batch"
+        "?tier=oss&runtimes=openclaw"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["target"] is None
+    assert body["runtimes"] == []
+
+
+def test_http_prev_rt_batch_unknown_tier_404(client):
+    resp = client.get(
+        "/api/entitlement/previous-tier-runtime-spec-at-batch"
+        "?tier=bogus&runtimes=openclaw"
+    )
+    assert resp.status_code == 404


### PR DESCRIPTION
## Summary

- Adds the batch siblings of the scalar `next/previous_tier_{feature,runtime}_spec_at` what-ifs (added in #3387): four helpers `{next,previous}_tier_{feature,runtime}_spec_at_batch(tier, ids)` in `clawmetry/entitlements.py`, plus the four companion `GET /api/entitlement/{next,previous}-tier-{feature,runtime}-spec-at-batch` endpoints in `routes/entitlement.py`.
- Where each scalar what-if projects the rung above / below the source onto ONE feature / runtime id, the batch variants project onto N ids in ONE round-trip — the feature / runtime axis analogue of `{next,previous}_tier_spec_at_batch` (which walks the full spec-row descriptor at every purchasable source).
- Purely additive read-only helpers on new URL surfaces. No behaviour change to any existing endpoint; ships in GRACE mode.

### Response envelope

```json
{
  "tier":         "<source>",
  "tier_label":   "<label>",
  "tier_rank":    N,
  "target":       "<rung above/below>" | null,
  "target_label": "<label>" | null,
  "target_rank":  M | null,
  "features"|"runtimes": [<spec_at row>, ...],
  "unknown":      ["bogus_id", ...]
}
```

Each row is byte-identical to a row from `feature_spec_at_batch(target, [id])` / `runtime_spec_at_batch(target, [id])` for the resolved rung — pinned by parity tests. At the source-side ceiling / floor `target` collapses to `null` and rows is empty; the surface stays 200 so callers can render "you're at the top" copy without a status-code branch. Runtime aliases (`claude-code` → `claude_code`) canonicalise and de-duplicate. Unknown ids echo into `unknown[]` rather than 404'ing the whole call.

## Test plan

- [x] 43 new tests in `tests/test_entitlement_next_prev_tier_feat_runtime_spec_at_batch.py` covering:
  - Row-shape parity with the scalar `next/previous_tier_{feature,runtime}_spec_at` sibling
  - Row-shape parity with `{feature,runtime}_spec_at_batch(target, ids)` for the resolved rung
  - Ceiling / floor collapse posture (`target=null`, rows=[])
  - Alias canonicalisation + dedupe on the runtime axis
  - Unknown-id echo handling (feature + runtime axes)
  - Resolver-crash resilience (never raises; helper collapses to grace shape)
  - Grace vs enforce yields identical rows (catalogue-derived)
  - HTTP: 400 on missing / empty `tier=` / `features=` / `runtimes=`, 404 on unknown tier, never 5xx on a helper exception
- [x] `python3 -m py_compile` clean on all changed files
- [x] `pytest -k entitlement` — 2721 passed, 4 skipped, 0 entitlement failures (one unrelated `test_retention_prune` error caused by `duckdb` not being installed in this environment)

## Local operator verification checklist

The scheduled remote agent that opened this PR has no access to `~/.openclaw`, the running daemon, the browser, or the live cloud snapshot — the checks below need the operator's local box:

- [ ] Copy the three changed files into the installed package location:
      ```
      cp clawmetry/entitlements.py ~/.clawmetry/lib/python3.*/site-packages/clawmetry/
      cp routes/entitlement.py     ~/.clawmetry/lib/python3.*/site-packages/routes/
      ```
- [ ] Clear stale bytecode: `find ~/.clawmetry/lib -name __pycache__ -exec rm -rf {} +`
- [ ] Restart the sync daemon: `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
- [ ] Hit each new endpoint against the live daemon and inspect the envelope:
      ```
      curl -s "http://localhost:8900/api/entitlement/next-tier-feature-spec-at-batch?tier=oss&features=sessions,subagents" | jq
      curl -s "http://localhost:8900/api/entitlement/previous-tier-feature-spec-at-batch?tier=enterprise&features=sessions,fleet" | jq
      curl -s "http://localhost:8900/api/entitlement/next-tier-runtime-spec-at-batch?tier=oss&runtimes=openclaw,claude-code" | jq
      curl -s "http://localhost:8900/api/entitlement/previous-tier-runtime-spec-at-batch?tier=enterprise&runtimes=openclaw,claude_code" | jq
      ```
- [ ] Confirm ceiling / floor collapse posture: `curl -s ".../next-tier-feature-spec-at-batch?tier=enterprise&features=sessions"` → `target=null`, `features=[]`, 200 (not 4xx / 5xx)
- [ ] Confirm scalar / batch parity for the `next` axis on OSS source:
      ```
      curl -s ".../next-tier-feature-spec-at?tier=oss&feature=sessions" | jq '.row' > /tmp/scalar.json
      curl -s ".../next-tier-feature-spec-at-batch?tier=oss&features=sessions" | jq '.features[0]' > /tmp/batch.json
      diff /tmp/scalar.json /tmp/batch.json  # should be empty
      ```
- [ ] Browser-check: decrypt the live cloud snapshot, load the dashboard, verify no regression on any entitlement-driven surface (paywall CTA, pricing-comparison matrix, upgrade tooltip) since these are additive read-only URLs.
- [ ] All existing `/api/entitlement/*` endpoints continue to return the same shapes (no behaviour change to anything already shipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C1vHG2SyQAB1jGhPbvz86b

---
_Generated by [Claude Code](https://claude.ai/code/session_01C1vHG2SyQAB1jGhPbvz86b)_