### PR TITLE
feat(entitlement): lock_reason_at_path + lock_reason_at_path_batch + endpoints

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -11958,3 +11958,137 @@ def feature_catalog_at_path_batch(
             "entitlements: feature_catalog_at_path_batch failed: %s", exc
         )
         return None
+
+
+def lock_reason_at_path(
+    perspective_tier: str,
+    from_tier: str,
+    to_tier: str,
+    item,
+    *,
+    kind: str | None = None,
+) -> list[dict] | None:
+    """Perspective-validated what-if wrapper around :func:`lock_reason_path`.
+
+    Fills the ``_at_path`` slot of the ``lock_reason`` family, matching the
+    already-shipping ``feature_spec_at_path`` / ``runtime_spec_at_path`` /
+    ``tier_spec_at_path`` / ``feature_catalog_at_path`` /
+    ``runtime_catalog_at_path`` / ``tier_catalog_at_path`` /
+    ``capacity_diff_at_path`` / ``preview_at_path`` pattern on the eight
+    other axes -- so every ``*_path`` helper now has a perspective-validated
+    ``_at_path`` sibling and a paywall walkthrough UI can call
+    ``X_at_path(perspective, from, to, ...)`` uniformly across the whole
+    ``_at_path`` family without special-casing the lock-reason axis.
+
+    The perspective is validated (empty / unknown ids short-circuit to
+    ``None``) but does NOT shape the rows -- the body is byte-identical to
+    :func:`lock_reason_path` for every ``(from, to, item, kind)`` tuple.
+    Pins a parity test so the scalar ``_at_path`` can never drift from
+    :func:`lock_reason_path` (which itself walks per-rung by synthesising
+    a fresh :class:`Entitlement` with ``grace=False``).
+
+    Endpoint semantics match :func:`lock_reason_path`: perspective, from
+    and to accept any id in :data:`_TIER_FEATURES` (``trial`` accepted,
+    excluded from the walked intermediate rungs, valid endpoint via the
+    lateral / identity branch). ``item`` is either a feature id (auto-
+    detected when ``kind`` is None and the id is in :data:`ALL_FEATURES`),
+    a runtime id (auto-detected via :func:`canonical_runtime` on
+    :data:`ALL_RUNTIMES`), or a positive integer capacity value with
+    ``kind`` set explicitly to ``"channels"`` / ``"retention_days"`` /
+    ``"nodes"``.
+
+    Never raises: a delegation failure logs a warning and returns
+    ``None`` so a paywall surface keeps rendering instead of breaking.
+    """
+    try:
+        p = (perspective_tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if not p or p not in _TIER_FEATURES:
+        return None
+    try:
+        return lock_reason_path(from_tier, to_tier, item, kind=kind)
+    except Exception as exc:
+        logger.warning("entitlements: lock_reason_at_path failed: %s", exc)
+        return None
+
+
+def lock_reason_at_path_batch(
+    perspective_tier: str,
+    from_tier: str,
+    to_tier: str,
+    *,
+    features=None,
+    runtimes=None,
+    channels: int | None = None,
+    retention_days: int | None = None,
+    nodes: int | None = None,
+) -> dict | None:
+    """Perspective-validated what-if wrapper around
+    :func:`lock_reason_path_batch`.
+
+    Fixed-perspective, fixed-from, fixed-to, multi-axis companion of
+    :func:`lock_reason_at_path`. Fills the ``_at_path_batch`` slot of
+    the ``lock_reason`` family, matching the already-shipping
+    ``feature_spec_at_path_batch`` / ``runtime_spec_at_path_batch`` /
+    ``tier_spec_at_path_batch`` / ``feature_catalog_at_path_batch`` /
+    ``runtime_catalog_at_path_batch`` / ``tier_catalog_at_path_batch`` /
+    ``capacity_diff_at_path_batch`` / ``preview_at_path_batch`` pattern.
+
+    Per-axis body byte-identical to :func:`lock_reason_path_batch` for
+    the same ``(from, to, features, runtimes, channels, retention_days,
+    nodes)`` tuple -- scalar / batch no-drift contract (the batch
+    delegates to the same underlying :func:`lock_reason_path` per item
+    that the scalar :func:`lock_reason_at_path` delegates to).
+
+    Shape mirrors :func:`lock_reason_path_batch`::
+
+        {
+          "features": [{"key": "<id>", "path": [...]}, ...],
+          "runtimes": [{"key": "<canonical id>", "path": [...]}, ...],
+          "channels":       {"key": "<n>", "path": [...]} | None,
+          "retention_days": {"key": "<n>", "path": [...]} | None,
+          "nodes":          {"key": "<n>", "path": [...]} | None,
+          "unknown": {"features": [...], "runtimes": [...]},
+        }
+
+    Supplied feature / runtime ids are normalised via
+    :func:`_normalise_csv` (whitespace stripped, lowercased, duplicates
+    dropped, first-seen order preserved). Runtime aliases are
+    canonicalised (``claude-code`` -> ``claude_code``). Unknown ids
+    are echoed in ``unknown.features`` / ``unknown.runtimes`` instead
+    of short-circuiting -- a partially-bad caller still gets paths back
+    for the valid ids alongside a list of what was dropped, matching
+    every other ``*_path_batch`` sibling's posture.
+
+    Capacity axes use ``None`` as the "axis not supplied" sentinel:
+    ``retention_days=None`` here means *unset*, NOT *unlimited* --
+    matches :func:`lock_reason_path_batch`. A non-positive / non-int
+    capacity value yields a ``None`` axis row.
+
+    Returns ``None`` for empty / unknown ``perspective_tier`` /
+    ``from_tier`` / ``to_tier`` (caller renders "unknown tier" / 404).
+    Never raises: a top-level delegation failure short-circuits to
+    ``None``.
+    """
+    try:
+        p = (perspective_tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if not p or p not in _TIER_FEATURES:
+        return None
+    try:
+        return lock_reason_path_batch(
+            from_tier,
+            to_tier,
+            features=features,
+            runtimes=runtimes,
+            channels=channels,
+            retention_days=retention_days,
+            nodes=nodes,
+        )
+    except Exception as exc:
+        logger.warning(
+            "entitlements: lock_reason_at_path_batch failed: %s", exc
+        )
+        return None

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -13935,3 +13935,514 @@ def api_entitlement_runtime_catalog_at_path_batch():
                 "enforced": False,
             }
         )
+
+
+@bp_entitlement.route("/api/entitlement/lock-reason-at-path")
+def api_entitlement_lock_reason_at_path():
+    """``GET /api/entitlement/lock-reason-at-path?tier=<perspective>
+    &from=<id>&to=<id>&<axis>=<id>`` -- perspective-validated what-if
+    sibling of ``/api/entitlement/lock-reason-path``.
+
+    Fills the ``_at_path`` slot of the ``lock-reason`` family, matching
+    the already-shipping ``feature-spec-at-path`` /
+    ``runtime-spec-at-path`` / ``tier-spec-at-path`` /
+    ``feature-catalog-at-path`` / ``runtime-catalog-at-path`` /
+    ``tier-catalog-at-path`` / ``capacity-diff-at-path`` /
+    ``preview-at-path`` pattern on the eight other axes -- so every
+    ``*-path`` endpoint now has a perspective-validated ``_at_path``
+    sibling and a paywall walkthrough UI can call
+    ``.../X-at-path?tier=<perspective>&from=<f>&to=<t>&...`` uniformly
+    across the whole ``_at_path`` family without special-casing the
+    lock-reason axis.
+
+    The perspective is validated (400 on missing, 404 on unknown) but
+    does NOT shape the ``path`` rows -- the body is byte-identical to
+    ``/lock-reason-path?from=<f>&to=<t>&<axis>=<id>`` for every
+    perspective. Pinned by parity tests so the ``_at_path`` and
+    ``_path`` endpoints cannot drift.
+
+    Exactly one of ``feature=`` / ``runtime=`` / ``channels=`` /
+    ``retention_days=`` / ``nodes=`` must be supplied -- the same axis
+    dispatcher as ``/lock-reason-path``. Runtime aliases
+    (``claude-code`` -> ``claude_code``) are canonicalised via
+    :func:`clawmetry.entitlements.canonical_runtime`.
+
+    Response shape (mirrors ``/lock-reason-path`` plus a
+    ``perspective_tier`` echo and the standard ``_at*`` resolver-context
+    tail so a paywall matrix UI can render "at Cloud Pro this lock-row
+    unlocks at Starter" without a second call to ``/entitlement``)::
+
+        {
+          "perspective_tier":      "<id>",
+          "perspective_tier_rank": <int>,
+          "from":                  "<tier id>",
+          "from_label":            "...",
+          "from_rank":             <int>,
+          "to":                    "<tier id>",
+          "to_label":              "...",
+          "to_rank":               <int>,
+          "direction":             "upgrade" | "downgrade" | "lateral" | "identity",
+          "key":                   "<echoed item id>",
+          "kind":                  "feature" | "runtime" | "channels" |
+                                   "retention_days" | "nodes",
+          "path":                  [<lock_reason_path row>, ...],
+          "current_tier":          "...",
+          "current_tier_rank":     <int>,
+          "grace":                 <bool>,
+          "enforced":              <bool>,
+        }
+
+    - **400** when ``tier=``, ``from=`` or ``to=`` is missing / blank,
+      when no axis is supplied, or when more than one axis is supplied
+    - **404** when any tier id is unknown (body carries
+      ``which: "tier" | "from" | "to"``), or when a feature / runtime
+      id is unknown, or when a capacity value is missing / non-int /
+      non-positive
+    - **Never 5xxs**: a resolver failure short-circuits to the grace-
+      shape envelope with the perspective echoed.
+    """
+    raw_tier = request.args.get("tier")
+    tier_in = (raw_tier or "").strip().lower()
+    if not tier_in:
+        return jsonify({"error": "missing tier"}), 400
+    f = (request.args.get("from") or "").strip().lower()
+    t = (request.args.get("to") or "").strip().lower()
+    if not f:
+        return jsonify({"error": "missing from"}), 400
+    if not t:
+        return jsonify({"error": "missing to"}), 400
+
+    feature = (request.args.get("feature") or "").strip().lower()
+    runtime_in = (request.args.get("runtime") or "").strip().lower()
+    (
+        channels_present,
+        channels_ok,
+        channels_n,
+        channels_raw,
+    ) = _parse_capacity_arg("channels")
+    (
+        retention_present,
+        retention_ok,
+        retention_n,
+        retention_raw,
+    ) = _parse_capacity_arg("retention_days")
+    (
+        nodes_present,
+        nodes_ok,
+        nodes_n,
+        nodes_raw,
+    ) = _parse_capacity_arg("nodes")
+
+    supplied = [
+        bool(feature),
+        bool(runtime_in),
+        channels_present,
+        retention_present,
+        nodes_present,
+    ]
+    n_supplied = sum(1 for s in supplied if s)
+    if n_supplied == 0:
+        return (
+            jsonify(
+                {
+                    "error": (
+                        "supply exactly one of feature=<id>, runtime=<id>, "
+                        "channels=<int>, retention_days=<int>, or "
+                        "nodes=<int>"
+                    )
+                }
+            ),
+            400,
+        )
+    if n_supplied > 1:
+        return (
+            jsonify(
+                {
+                    "error": (
+                        "supply only one of feature=, runtime=, channels=, "
+                        "retention_days=, or nodes="
+                    )
+                }
+            ),
+            400,
+        )
+
+    try:
+        from clawmetry import entitlements as _ent
+
+        if tier_in not in _ent._TIER_FEATURES:
+            return (
+                jsonify(
+                    {
+                        "error": "unknown tier",
+                        "which": "tier",
+                        "tier": tier_in,
+                    }
+                ),
+                404,
+            )
+        if f not in _ent._TIER_FEATURES:
+            return (
+                jsonify(
+                    {"error": "unknown from", "which": "from", "from": f}
+                ),
+                404,
+            )
+        if t not in _ent._TIER_FEATURES:
+            return (
+                jsonify({"error": "unknown to", "which": "to", "to": t}),
+                404,
+            )
+
+        if feature:
+            item, kind, echoed_key = feature, "feature", feature
+        elif runtime_in:
+            canon = _ent.canonical_runtime(runtime_in)
+            item, kind, echoed_key = (
+                canon or runtime_in,
+                "runtime",
+                canon or runtime_in,
+            )
+        elif channels_present:
+            if not channels_ok:
+                return (
+                    jsonify(
+                        {
+                            "error": "unknown tier or item",
+                            "which": "item",
+                            "from": f,
+                            "to": t,
+                            "key": channels_raw,
+                            "kind": "channels",
+                        }
+                    ),
+                    404,
+                )
+            item, kind, echoed_key = (
+                str(channels_n),
+                "channels",
+                str(channels_n),
+            )
+        elif retention_present:
+            if not retention_ok:
+                return (
+                    jsonify(
+                        {
+                            "error": "unknown tier or item",
+                            "which": "item",
+                            "from": f,
+                            "to": t,
+                            "key": retention_raw,
+                            "kind": "retention_days",
+                        }
+                    ),
+                    404,
+                )
+            item, kind, echoed_key = (
+                str(retention_n),
+                "retention_days",
+                str(retention_n),
+            )
+        else:
+            if not nodes_ok:
+                return (
+                    jsonify(
+                        {
+                            "error": "unknown tier or item",
+                            "which": "item",
+                            "from": f,
+                            "to": t,
+                            "key": nodes_raw,
+                            "kind": "nodes",
+                        }
+                    ),
+                    404,
+                )
+            item, kind, echoed_key = str(nodes_n), "nodes", str(nodes_n)
+
+        path = _ent.lock_reason_at_path(tier_in, f, t, item, kind=kind)
+        if path is None:
+            return (
+                jsonify(
+                    {
+                        "error": "unknown tier or item",
+                        "which": "item",
+                        "from": f,
+                        "to": t,
+                        "key": echoed_key,
+                        "kind": kind,
+                    }
+                ),
+                404,
+            )
+        from_rank = _ent.tier_rank(f)
+        to_rank = _ent.tier_rank(t)
+        if f == t:
+            direction = "identity"
+        elif from_rank == to_rank:
+            direction = "lateral"
+        elif to_rank > from_rank:
+            direction = "upgrade"
+        else:
+            direction = "downgrade"
+        ent = _ent.get_entitlement()
+        return jsonify(
+            {
+                "perspective_tier": tier_in,
+                "perspective_tier_rank": _ent.tier_rank(tier_in),
+                "from": f,
+                "from_label": _ent.tier_label(f),
+                "from_rank": from_rank,
+                "to": t,
+                "to_label": _ent.tier_label(t),
+                "to_rank": to_rank,
+                "direction": direction,
+                "key": echoed_key,
+                "kind": kind,
+                "path": path,
+                "current_tier": ent.tier,
+                "current_tier_rank": _ent.tier_rank(ent.tier),
+                "grace": bool(ent.grace),
+                "enforced": _ent.is_enforced(),
+            }
+        )
+    except Exception as exc:
+        logger.warning("api_entitlement_lock_reason_at_path: error: %s", exc)
+        if feature:
+            echoed_key, kind = feature, "feature"
+        elif runtime_in:
+            echoed_key, kind = runtime_in, "runtime"
+        elif channels_present:
+            echoed_key, kind = channels_raw, "channels"
+        elif retention_present:
+            echoed_key, kind = retention_raw, "retention_days"
+        else:
+            echoed_key, kind = nodes_raw, "nodes"
+        return jsonify(
+            {
+                "perspective_tier": tier_in,
+                "perspective_tier_rank": 0,
+                "from": f,
+                "from_label": None,
+                "from_rank": -1,
+                "to": t,
+                "to_label": None,
+                "to_rank": -1,
+                "direction": "identity" if f == t else "upgrade",
+                "key": echoed_key,
+                "kind": kind,
+                "path": [],
+                "current_tier": "oss",
+                "current_tier_rank": 0,
+                "grace": True,
+                "enforced": False,
+            }
+        )
+
+
+@bp_entitlement.route("/api/entitlement/lock-reason-at-path-batch")
+def api_entitlement_lock_reason_at_path_batch():
+    """``GET /api/entitlement/lock-reason-at-path-batch?tier=<perspective>
+    &from=<id>&to=<id>&features=a,b,c&runtimes=x,y&channels=N
+    &retention_days=K&nodes=M`` -- perspective-validated what-if batch
+    sibling of ``/api/entitlement/lock-reason-path-batch``.
+
+    Fills the ``_at_path_batch`` slot of the ``lock-reason`` family;
+    fixed-perspective, fixed-from, fixed-to, multi-axis companion of
+    ``/lock-reason-at-path``. Per-axis body byte-identical to
+    ``/lock-reason-path-batch`` for the same ``(from, to, features,
+    runtimes, channels, retention_days, nodes)`` tuple -- scalar / batch
+    no-drift contract.
+
+    At least one of ``features=`` / ``runtimes=`` / ``channels=`` /
+    ``retention_days=`` / ``nodes=`` must be supplied (matches
+    ``/lock-reason-path-batch``); supply as many as you like. Runtime
+    aliases are canonicalised (``claude-code`` -> ``claude_code``) and
+    aliases that collapse to a canonical id already in the response are
+    silently de-duplicated. Unknown ids do NOT 404 the call -- they are
+    echoed in ``unknown.features`` / ``unknown.runtimes`` carrying the
+    supplied alias.
+
+    Response shape (mirrors ``/lock-reason-path-batch`` plus a
+    ``perspective_tier`` echo and the standard ``_at*`` resolver-context
+    tail)::
+
+        {
+          "perspective_tier":      "<id>",
+          "perspective_tier_rank": <int>,
+          "from":                  "<tier id>",
+          "from_label":            "...",
+          "from_rank":             <int>,
+          "to":                    "<tier id>",
+          "to_label":              "...",
+          "to_rank":               <int>,
+          "direction":             "upgrade" | "downgrade" | "lateral" | "identity",
+          "features": [{"key": "<id>", "path": [...]}, ...],
+          "runtimes": [{"key": "<canonical id>", "path": [...]}, ...],
+          "channels":       {"key": "<n>", "path": [...]} | None,
+          "retention_days": {"key": "<n>", "path": [...]} | None,
+          "nodes":          {"key": "<n>", "path": [...]} | None,
+          "unknown": {"features": [...], "runtimes": [...]},
+          "current_tier":          "...",
+          "current_tier_rank":     <int>,
+          "grace":                 <bool>,
+          "enforced":              <bool>,
+        }
+
+    - **400** when ``tier=`` / ``from=`` / ``to=`` is missing / blank,
+      or when no axis is supplied
+    - **404** when any tier id is unknown (body carries
+      ``which: "tier" | "from" | "to"``)
+    - Unknown feature / runtime ids do NOT 404 the call -- they are
+      echoed in ``unknown[]`` so a partially-bad caller still gets paths
+      back for the valid ids alongside a list of what was dropped
+    - **Never 5xxs**: a synthesis failure short-circuits to a grace-
+      shape envelope with the perspective echoed.
+    """
+    raw_tier = request.args.get("tier")
+    tier_in = (raw_tier or "").strip().lower()
+    if not tier_in:
+        return jsonify({"error": "missing tier"}), 400
+    f = (request.args.get("from") or "").strip().lower()
+    t = (request.args.get("to") or "").strip().lower()
+    if not f:
+        return jsonify({"error": "missing from"}), 400
+    if not t:
+        return jsonify({"error": "missing to"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        if tier_in not in _ent._TIER_FEATURES:
+            return (
+                jsonify(
+                    {
+                        "error": "unknown tier",
+                        "which": "tier",
+                        "tier": tier_in,
+                    }
+                ),
+                404,
+            )
+        if f not in _ent._TIER_FEATURES:
+            return (
+                jsonify(
+                    {"error": "unknown from", "which": "from", "from": f}
+                ),
+                404,
+            )
+        if t not in _ent._TIER_FEATURES:
+            return (
+                jsonify({"error": "unknown to", "which": "to", "to": t}),
+                404,
+            )
+
+        features = _parse_csv_arg("features")
+        runtimes = _parse_csv_arg("runtimes")
+        (_, channels_ok, channels_n, _) = _parse_capacity_arg("channels")
+        (_, retention_ok, retention_n, _) = _parse_capacity_arg(
+            "retention_days"
+        )
+        (_, nodes_ok, nodes_n, _) = _parse_capacity_arg("nodes")
+
+        if (
+            not features
+            and not runtimes
+            and not channels_ok
+            and not retention_ok
+            and not nodes_ok
+        ):
+            return (
+                jsonify(
+                    {
+                        "error": (
+                            "supply at least one of features=<csv>, "
+                            "runtimes=<csv>, channels=<int>, "
+                            "retention_days=<int>, or nodes=<int>"
+                        )
+                    }
+                ),
+                400,
+            )
+
+        batch = _ent.lock_reason_at_path_batch(
+            tier_in,
+            f,
+            t,
+            features=features or None,
+            runtimes=runtimes or None,
+            channels=channels_n if channels_ok else None,
+            retention_days=retention_n if retention_ok else None,
+            nodes=nodes_n if nodes_ok else None,
+        )
+        if batch is None:
+            batch = {
+                "features": [],
+                "runtimes": [],
+                "channels": None,
+                "retention_days": None,
+                "nodes": None,
+                "unknown": {"features": [], "runtimes": []},
+            }
+        from_rank = _ent.tier_rank(f)
+        to_rank = _ent.tier_rank(t)
+        if f == t:
+            direction = "identity"
+        elif from_rank == to_rank:
+            direction = "lateral"
+        elif to_rank > from_rank:
+            direction = "upgrade"
+        else:
+            direction = "downgrade"
+        ent = _ent.get_entitlement()
+        return jsonify(
+            {
+                "perspective_tier": tier_in,
+                "perspective_tier_rank": _ent.tier_rank(tier_in),
+                "from": f,
+                "from_label": _ent.tier_label(f),
+                "from_rank": from_rank,
+                "to": t,
+                "to_label": _ent.tier_label(t),
+                "to_rank": to_rank,
+                "direction": direction,
+                "features": batch.get("features", []),
+                "runtimes": batch.get("runtimes", []),
+                "channels": batch.get("channels"),
+                "retention_days": batch.get("retention_days"),
+                "nodes": batch.get("nodes"),
+                "unknown": batch.get(
+                    "unknown", {"features": [], "runtimes": []}
+                ),
+                "current_tier": ent.tier,
+                "current_tier_rank": _ent.tier_rank(ent.tier),
+                "grace": bool(ent.grace),
+                "enforced": _ent.is_enforced(),
+            }
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_lock_reason_at_path_batch: error: %s", exc
+        )
+        return jsonify(
+            {
+                "perspective_tier": tier_in,
+                "perspective_tier_rank": 0,
+                "from": f,
+                "from_label": None,
+                "from_rank": -1,
+                "to": t,
+                "to_label": None,
+                "to_rank": -1,
+                "direction": "identity" if f == t else "upgrade",
+                "features": [],
+                "runtimes": [],
+                "channels": None,
+                "retention_days": None,
+                "nodes": None,
+                "unknown": {"features": [], "runtimes": []},
+                "current_tier": "oss",
+                "current_tier_rank": 0,
+                "grace": True,
+                "enforced": False,
+            }
+        )

--- a/tests/test_entitlement_lock_reason_at_path.py
+++ b/tests/test_entitlement_lock_reason_at_path.py
@@ -1,0 +1,803 @@
+"""Tests for
+``clawmetry.entitlements.lock_reason_at_path(perspective, from, to, item, kind)``
++ ``lock_reason_at_path_batch(perspective, from, to, ...)`` + the ``GET
+/api/entitlement/lock-reason-at-path`` and ``GET
+/api/entitlement/lock-reason-at-path-batch`` endpoints.
+
+Perspective-validated what-if wrapper around ``lock_reason_path`` /
+``lock_reason_path_batch``. Fills the ``_at_path`` /
+``_at_path_batch`` slot of the ``lock_reason`` family, matching the
+already-shipping ``feature_spec_at_path`` / ``runtime_spec_at_path`` /
+``tier_spec_at_path`` / ``feature_catalog_at_path`` /
+``runtime_catalog_at_path`` / ``tier_catalog_at_path`` /
+``capacity_diff_at_path`` / ``preview_at_path`` pattern on the eight
+other axes -- so every ``*_path`` helper now has a perspective-
+validated ``_at_path`` sibling.
+
+Pins:
+
+* scalar body byte-parity with :func:`lock_reason_path` for every
+  ``(perspective, from, to, item, kind)`` quintuple (perspective must
+  NOT shape the rows)
+* batch per-axis ``path`` byte-identical to
+  :func:`lock_reason_path_batch` for the same
+  ``(from, to, features, runtimes, channels, retention_days, nodes)``
+* perspective invariance (rows byte-identical across shifting
+  perspective for the same downstream args) on all 5 axes
+* unknown / empty perspective -> ``None`` (scalar and batch);
+  delegates identical short-circuit posture to
+  :func:`lock_reason_path` on unknown from / to / item
+* runtime alias (``claude-code``) canonicalises to ``claude_code`` on
+  the scalar and echoes into either ``runtimes[]`` or ``unknown[]`` in
+  the batch
+* trial accepted as perspective + endpoint (lateral / identity branch)
+* grace vs enforce identical rows (helper synthesises a fresh
+  ``Entitlement`` per rung with ``grace=False`` regardless of the live
+  resolver state)
+* never raises: a delegation failure logs a warning and returns
+  ``None`` / short-circuits into ``unknown[]``
+* API: 400 on missing tier / from / to / no axis / multi-axis (scalar
+  only); 404 on unknown tier ids (with ``which`` bucketing); 404 on
+  unknown feature / runtime / capacity for the scalar; unknown feature
+  / runtime IDs echoed in ``unknown[]`` for the batch (never 404s);
+  200 envelope carries ``perspective_tier`` echo + standard ``_at*``
+  resolver-context tail (``current_tier``, ``current_tier_rank``,
+  ``grace``, ``enforced``)
+* endpoint never 5xxs on a resolver crash
+"""
+from __future__ import annotations
+
+import importlib
+from itertools import product
+
+import pytest
+from flask import Flask
+
+
+ALL_TIERS = (
+    "oss",
+    "cloud_free",
+    "trial",
+    "cloud_starter",
+    "cloud_pro",
+    "pro",
+    "enterprise",
+)
+
+_RUNG_KEYS = {"rung", "rung_label", "rung_rank"}
+_ROW_KEYS = {
+    "key",
+    "kind",
+    "reason",
+    "locked",
+    "allowed",
+    "required_tier",
+    "required_tier_label",
+    "required_tier_rank",
+}
+
+_SCALAR_ENVELOPE_KEYS = {
+    "perspective_tier",
+    "perspective_tier_rank",
+    "from",
+    "from_label",
+    "from_rank",
+    "to",
+    "to_label",
+    "to_rank",
+    "direction",
+    "key",
+    "kind",
+    "path",
+    "current_tier",
+    "current_tier_rank",
+    "grace",
+    "enforced",
+}
+
+_BATCH_ENVELOPE_KEYS = {
+    "perspective_tier",
+    "perspective_tier_rank",
+    "from",
+    "from_label",
+    "from_rank",
+    "to",
+    "to_label",
+    "to_rank",
+    "direction",
+    "features",
+    "runtimes",
+    "channels",
+    "retention_days",
+    "nodes",
+    "unknown",
+    "current_tier",
+    "current_tier_rank",
+    "grace",
+    "enforced",
+}
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+def _pick_paid_feature(ent) -> str:
+    return sorted(ent.PAID_FEATURES)[0]
+
+
+def _pick_paid_runtime(ent) -> str:
+    return sorted(ent.PAID_RUNTIMES)[0]
+
+
+# ── scalar helper: shape ─────────────────────────────────────────────────────
+
+
+def test_scalar_returns_list(ent):
+    path = ent.lock_reason_at_path(
+        "cloud_pro", "oss", "enterprise", _pick_paid_feature(ent),
+        kind="feature",
+    )
+    assert isinstance(path, list)
+    assert len(path) >= 1
+
+
+def test_scalar_each_row_carries_rung_and_lock_keys(ent):
+    path = ent.lock_reason_at_path(
+        "cloud_pro", "oss", "enterprise", _pick_paid_feature(ent),
+        kind="feature",
+    )
+    for row in path:
+        assert set(row).issuperset(_RUNG_KEYS)
+        assert set(row).issuperset(_ROW_KEYS)
+        assert row["rung_label"] == ent.tier_label(row["rung"])
+        assert row["rung_rank"] == ent.tier_rank(row["rung"])
+
+
+# ── scalar helper: body byte-parity with lock_reason_path ────────────────────
+
+
+def test_scalar_body_byte_parity_with_lock_reason_path_feature(ent):
+    """Perspective must NOT shape the rows."""
+    feat = _pick_paid_feature(ent)
+    for perspective, f, t in product(ALL_TIERS, ALL_TIERS, ALL_TIERS):
+        at_path = ent.lock_reason_at_path(
+            perspective, f, t, feat, kind="feature"
+        )
+        base = ent.lock_reason_path(f, t, feat, kind="feature")
+        assert at_path == base, (perspective, f, t)
+
+
+def test_scalar_body_byte_parity_with_lock_reason_path_runtime(ent):
+    rt = _pick_paid_runtime(ent)
+    for perspective, f, t in product(ALL_TIERS, ALL_TIERS, ALL_TIERS):
+        at_path = ent.lock_reason_at_path(
+            perspective, f, t, rt, kind="runtime"
+        )
+        base = ent.lock_reason_path(f, t, rt, kind="runtime")
+        assert at_path == base, (perspective, f, t)
+
+
+@pytest.mark.parametrize(
+    "kind,value",
+    [
+        ("channels", 25),
+        ("retention_days", 365),
+        ("nodes", 50),
+    ],
+)
+def test_scalar_body_byte_parity_capacity_axes(ent, kind, value):
+    for perspective, f, t in product(ALL_TIERS, ALL_TIERS, ALL_TIERS):
+        at_path = ent.lock_reason_at_path(
+            perspective, f, t, value, kind=kind
+        )
+        base = ent.lock_reason_path(f, t, value, kind=kind)
+        assert at_path == base, (perspective, kind, f, t)
+
+
+def test_scalar_perspective_invariance_free_runtime(ent):
+    """A free runtime (``openclaw``) is allowed at every rung; perspective
+    still shouldn't move any bytes."""
+    for perspective in ALL_TIERS:
+        rows = ent.lock_reason_at_path(
+            perspective, "oss", "enterprise", "openclaw", kind="runtime"
+        )
+        base = ent.lock_reason_path(
+            "oss", "enterprise", "openclaw", kind="runtime"
+        )
+        assert rows == base
+
+
+def test_scalar_perspective_kind_none_auto_dispatches(ent):
+    """`kind=None` auto-detects feature vs runtime just like the delegate."""
+    feat = _pick_paid_feature(ent)
+    rt = _pick_paid_runtime(ent)
+    for perspective in ALL_TIERS:
+        f_out = ent.lock_reason_at_path(perspective, "oss", "enterprise", feat)
+        r_out = ent.lock_reason_at_path(perspective, "oss", "enterprise", rt)
+        assert f_out == ent.lock_reason_path(
+            "oss", "enterprise", feat, kind="feature"
+        )
+        assert r_out == ent.lock_reason_path(
+            "oss", "enterprise", rt, kind="runtime"
+        )
+
+
+def test_scalar_runtime_alias_normalises(ent):
+    canon = ent.lock_reason_at_path(
+        "cloud_pro", "oss", "enterprise", "claude_code", kind="runtime"
+    )
+    alias = ent.lock_reason_at_path(
+        "cloud_pro", "oss", "enterprise", "claude-code", kind="runtime"
+    )
+    assert canon == alias
+
+
+# ── scalar helper: perspective validation ────────────────────────────────────
+
+
+@pytest.mark.parametrize("bad", ["", "   ", "bogus", "not_a_tier", None])
+def test_scalar_unknown_perspective_returns_none(ent, bad):
+    out = ent.lock_reason_at_path(
+        bad, "oss", "enterprise", _pick_paid_feature(ent), kind="feature"
+    )
+    assert out is None
+
+
+def test_scalar_perspective_whitespace_case_normalised(ent):
+    a = ent.lock_reason_at_path(
+        "  Cloud_Pro  ", "oss", "enterprise",
+        _pick_paid_feature(ent), kind="feature",
+    )
+    b = ent.lock_reason_at_path(
+        "cloud_pro", "oss", "enterprise",
+        _pick_paid_feature(ent), kind="feature",
+    )
+    assert a == b
+
+
+def test_scalar_unknown_from_or_to_short_circuits(ent):
+    """Perspective-valid but tier ids unknown -> ``None`` (delegated)."""
+    assert (
+        ent.lock_reason_at_path(
+            "cloud_pro", "bogus", "enterprise",
+            _pick_paid_feature(ent), kind="feature",
+        )
+        is None
+    )
+    assert (
+        ent.lock_reason_at_path(
+            "cloud_pro", "oss", "bogus",
+            _pick_paid_feature(ent), kind="feature",
+        )
+        is None
+    )
+
+
+def test_scalar_unknown_item_short_circuits(ent):
+    """Perspective-valid but item id unknown -> ``None`` (delegated)."""
+    out = ent.lock_reason_at_path(
+        "cloud_pro", "oss", "enterprise", "bogus_id", kind="feature"
+    )
+    assert out is None
+
+
+def test_scalar_trial_perspective_accepted(ent):
+    """``trial`` is a valid perspective / from / to (matches delegate)."""
+    out = ent.lock_reason_at_path(
+        "trial", "trial", "trial",
+        _pick_paid_feature(ent), kind="feature",
+    )
+    assert out == []
+
+
+def test_scalar_never_raises_on_delegate_crash(ent, monkeypatch):
+    def _boom(*a, **kw):
+        raise RuntimeError("kaboom")
+
+    monkeypatch.setattr(ent, "lock_reason_path", _boom)
+    out = ent.lock_reason_at_path(
+        "cloud_pro", "oss", "enterprise",
+        _pick_paid_feature(ent), kind="feature",
+    )
+    assert out is None
+
+
+# ── scalar helper: grace vs enforce ──────────────────────────────────────────
+
+
+def test_scalar_grace_vs_enforce_identical_rows(ent, monkeypatch):
+    feat = _pick_paid_feature(ent)
+    grace_rows = ent.lock_reason_at_path(
+        "cloud_pro", "oss", "enterprise", feat, kind="feature"
+    )
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    enforce_rows = ent.lock_reason_at_path(
+        "cloud_pro", "oss", "enterprise", feat, kind="feature"
+    )
+    assert grace_rows == enforce_rows
+
+
+# ── batch helper: shape + parity ─────────────────────────────────────────────
+
+
+def test_batch_returns_dict_with_5_axes_plus_unknown(ent):
+    out = ent.lock_reason_at_path_batch(
+        "cloud_pro",
+        "oss",
+        "enterprise",
+        features=[_pick_paid_feature(ent)],
+        runtimes=[_pick_paid_runtime(ent)],
+        channels=99,
+        retention_days=365,
+        nodes=50,
+    )
+    assert isinstance(out, dict)
+    assert set(out.keys()) == {
+        "features",
+        "runtimes",
+        "channels",
+        "retention_days",
+        "nodes",
+        "unknown",
+    }
+    assert isinstance(out["features"], list)
+    assert isinstance(out["runtimes"], list)
+    assert isinstance(out["unknown"], dict)
+    assert set(out["unknown"].keys()) == {"features", "runtimes"}
+
+
+def test_batch_body_byte_parity_with_lock_reason_path_batch(ent):
+    for perspective in ALL_TIERS:
+        got = ent.lock_reason_at_path_batch(
+            perspective,
+            "oss",
+            "enterprise",
+            features=[_pick_paid_feature(ent), "custom_alerts"],
+            runtimes=[_pick_paid_runtime(ent), "openclaw", "claude-code"],
+            channels=99,
+            retention_days=365,
+            nodes=50,
+        )
+        base = ent.lock_reason_path_batch(
+            "oss",
+            "enterprise",
+            features=[_pick_paid_feature(ent), "custom_alerts"],
+            runtimes=[_pick_paid_runtime(ent), "openclaw", "claude-code"],
+            channels=99,
+            retention_days=365,
+            nodes=50,
+        )
+        assert got == base, perspective
+
+
+def test_batch_unknown_ids_echoed_not_404(ent):
+    out = ent.lock_reason_at_path_batch(
+        "cloud_pro",
+        "oss",
+        "enterprise",
+        features=[_pick_paid_feature(ent), "bogus_feat"],
+        runtimes=["bogus_runtime"],
+    )
+    assert any(row["key"] == _pick_paid_feature(ent) for row in out["features"])
+    assert "bogus_feat" in out["unknown"]["features"]
+    assert "bogus_runtime" in out["unknown"]["runtimes"]
+
+
+def test_batch_alias_canonicalises_and_dedupes(ent):
+    out = ent.lock_reason_at_path_batch(
+        "cloud_pro",
+        "oss",
+        "enterprise",
+        runtimes=["claude-code", "claude_code"],
+    )
+    ids = [row["key"] for row in out["runtimes"]]
+    assert ids.count("claude_code") == 1
+
+
+@pytest.mark.parametrize("bad", ["", "   ", "bogus", None])
+def test_batch_unknown_perspective_returns_none(ent, bad):
+    out = ent.lock_reason_at_path_batch(
+        bad,
+        "oss",
+        "enterprise",
+        features=[_pick_paid_feature(ent)],
+    )
+    assert out is None
+
+
+def test_batch_unknown_from_or_to_short_circuits(ent):
+    for bad in [("bogus", "enterprise"), ("oss", "bogus")]:
+        out = ent.lock_reason_at_path_batch(
+            "cloud_pro",
+            bad[0],
+            bad[1],
+            features=[_pick_paid_feature(ent)],
+        )
+        assert out is None
+
+
+def test_batch_never_raises_on_delegate_crash(ent, monkeypatch):
+    def _boom(*a, **kw):
+        raise RuntimeError("kaboom")
+
+    monkeypatch.setattr(ent, "lock_reason_path_batch", _boom)
+    out = ent.lock_reason_at_path_batch(
+        "cloud_pro",
+        "oss",
+        "enterprise",
+        features=[_pick_paid_feature(ent)],
+    )
+    assert out is None
+
+
+def test_batch_grace_vs_enforce_identical_rows(ent, monkeypatch):
+    kwargs = dict(
+        perspective_tier="cloud_pro",
+        from_tier="oss",
+        to_tier="enterprise",
+        features=[_pick_paid_feature(ent)],
+    )
+    grace = ent.lock_reason_at_path_batch(
+        kwargs["perspective_tier"],
+        kwargs["from_tier"],
+        kwargs["to_tier"],
+        features=kwargs["features"],
+    )
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    enforced = ent.lock_reason_at_path_batch(
+        kwargs["perspective_tier"],
+        kwargs["from_tier"],
+        kwargs["to_tier"],
+        features=kwargs["features"],
+    )
+    assert grace == enforced
+
+
+# ── HTTP scalar: 400 / 404 rules ─────────────────────────────────────────────
+
+
+def test_http_scalar_missing_tier_is_400(client, ent):
+    r = client.get(
+        "/api/entitlement/lock-reason-at-path"
+        f"?from=oss&to=enterprise&feature={_pick_paid_feature(ent)}"
+    )
+    assert r.status_code == 400
+    assert "tier" in r.get_json().get("error", "").lower()
+
+
+def test_http_scalar_missing_from_is_400(client, ent):
+    r = client.get(
+        "/api/entitlement/lock-reason-at-path"
+        f"?tier=cloud_pro&to=enterprise&feature={_pick_paid_feature(ent)}"
+    )
+    assert r.status_code == 400
+    assert "from" in r.get_json().get("error", "").lower()
+
+
+def test_http_scalar_missing_to_is_400(client, ent):
+    r = client.get(
+        "/api/entitlement/lock-reason-at-path"
+        f"?tier=cloud_pro&from=oss&feature={_pick_paid_feature(ent)}"
+    )
+    assert r.status_code == 400
+    assert "to" in r.get_json().get("error", "").lower()
+
+
+def test_http_scalar_no_axis_is_400(client):
+    r = client.get(
+        "/api/entitlement/lock-reason-at-path?tier=cloud_pro&from=oss&to=enterprise"
+    )
+    assert r.status_code == 400
+    body = r.get_json()["error"]
+    assert "supply exactly one" in body
+
+
+def test_http_scalar_multi_axis_is_400(client, ent):
+    r = client.get(
+        "/api/entitlement/lock-reason-at-path"
+        f"?tier=cloud_pro&from=oss&to=enterprise&feature={_pick_paid_feature(ent)}"
+        "&channels=5"
+    )
+    assert r.status_code == 400
+    assert "only one" in r.get_json()["error"]
+
+
+def test_http_scalar_unknown_tier_is_404_with_which(client, ent):
+    r = client.get(
+        "/api/entitlement/lock-reason-at-path"
+        f"?tier=bogus&from=oss&to=enterprise&feature={_pick_paid_feature(ent)}"
+    )
+    assert r.status_code == 404
+    body = r.get_json()
+    assert body["which"] == "tier"
+    assert body["tier"] == "bogus"
+
+
+def test_http_scalar_unknown_from_is_404_with_which(client, ent):
+    r = client.get(
+        "/api/entitlement/lock-reason-at-path"
+        f"?tier=cloud_pro&from=bogus&to=enterprise&feature={_pick_paid_feature(ent)}"
+    )
+    assert r.status_code == 404
+    body = r.get_json()
+    assert body["which"] == "from"
+
+
+def test_http_scalar_unknown_to_is_404_with_which(client, ent):
+    r = client.get(
+        "/api/entitlement/lock-reason-at-path"
+        f"?tier=cloud_pro&from=oss&to=bogus&feature={_pick_paid_feature(ent)}"
+    )
+    assert r.status_code == 404
+    body = r.get_json()
+    assert body["which"] == "to"
+
+
+def test_http_scalar_unknown_feature_is_404(client):
+    r = client.get(
+        "/api/entitlement/lock-reason-at-path"
+        "?tier=cloud_pro&from=oss&to=enterprise&feature=bogus"
+    )
+    assert r.status_code == 404
+
+
+def test_http_scalar_unknown_runtime_is_404(client):
+    r = client.get(
+        "/api/entitlement/lock-reason-at-path"
+        "?tier=cloud_pro&from=oss&to=enterprise&runtime=bogus"
+    )
+    assert r.status_code == 404
+
+
+def test_http_scalar_bad_capacity_is_404(client):
+    r = client.get(
+        "/api/entitlement/lock-reason-at-path"
+        "?tier=cloud_pro&from=oss&to=enterprise&channels=abc"
+    )
+    assert r.status_code == 404
+    body = r.get_json()
+    assert body["kind"] == "channels"
+
+
+# ── HTTP scalar: happy path ──────────────────────────────────────────────────
+
+
+def test_http_scalar_happy_path_envelope(client, ent):
+    feat = _pick_paid_feature(ent)
+    r = client.get(
+        "/api/entitlement/lock-reason-at-path"
+        f"?tier=cloud_pro&from=oss&to=enterprise&feature={feat}"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert set(body.keys()) == _SCALAR_ENVELOPE_KEYS
+    assert body["perspective_tier"] == "cloud_pro"
+    assert body["perspective_tier_rank"] == ent.tier_rank("cloud_pro")
+    assert body["from"] == "oss"
+    assert body["to"] == "enterprise"
+    assert body["key"] == feat
+    assert body["kind"] == "feature"
+    assert body["direction"] == "upgrade"
+    assert isinstance(body["path"], list)
+    assert len(body["path"]) >= 1
+
+
+def test_http_scalar_body_path_byte_parity_with_lock_reason_path(client, ent):
+    feat = _pick_paid_feature(ent)
+    r_at = client.get(
+        "/api/entitlement/lock-reason-at-path"
+        f"?tier=cloud_pro&from=oss&to=enterprise&feature={feat}"
+    ).get_json()
+    r_base = client.get(
+        "/api/entitlement/lock-reason-path"
+        f"?from=oss&to=enterprise&feature={feat}"
+    ).get_json()
+    assert r_at["path"] == r_base["path"]
+
+
+def test_http_scalar_runtime_alias_echoes_canonical(client):
+    r = client.get(
+        "/api/entitlement/lock-reason-at-path"
+        "?tier=cloud_pro&from=oss&to=enterprise&runtime=claude-code"
+    )
+    assert r.status_code == 200
+    assert r.get_json()["key"] == "claude_code"
+
+
+def test_http_scalar_identity_returns_empty_path(client, ent):
+    feat = _pick_paid_feature(ent)
+    r = client.get(
+        "/api/entitlement/lock-reason-at-path"
+        f"?tier=cloud_pro&from=enterprise&to=enterprise&feature={feat}"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["direction"] == "identity"
+    assert body["path"] == []
+
+
+def test_http_scalar_never_5xx_on_resolver_crash(client, ent, monkeypatch):
+    def _boom(*a, **kw):
+        raise RuntimeError("kaboom")
+
+    monkeypatch.setattr(ent, "lock_reason_at_path", _boom)
+    r = client.get(
+        "/api/entitlement/lock-reason-at-path"
+        f"?tier=cloud_pro&from=oss&to=enterprise&feature={_pick_paid_feature(ent)}"
+    )
+    assert r.status_code < 500
+
+
+# ── HTTP batch ───────────────────────────────────────────────────────────────
+
+
+def test_http_batch_missing_tier_is_400(client, ent):
+    r = client.get(
+        "/api/entitlement/lock-reason-at-path-batch"
+        f"?from=oss&to=enterprise&features={_pick_paid_feature(ent)}"
+    )
+    assert r.status_code == 400
+
+
+def test_http_batch_missing_from_or_to_is_400(client, ent):
+    r = client.get(
+        "/api/entitlement/lock-reason-at-path-batch"
+        f"?tier=cloud_pro&to=enterprise&features={_pick_paid_feature(ent)}"
+    )
+    assert r.status_code == 400
+    r = client.get(
+        "/api/entitlement/lock-reason-at-path-batch"
+        f"?tier=cloud_pro&from=oss&features={_pick_paid_feature(ent)}"
+    )
+    assert r.status_code == 400
+
+
+def test_http_batch_no_axis_is_400(client):
+    r = client.get(
+        "/api/entitlement/lock-reason-at-path-batch"
+        "?tier=cloud_pro&from=oss&to=enterprise"
+    )
+    assert r.status_code == 400
+    assert "supply at least one" in r.get_json()["error"]
+
+
+def test_http_batch_unknown_tier_is_404_with_which(client, ent):
+    r = client.get(
+        "/api/entitlement/lock-reason-at-path-batch"
+        f"?tier=bogus&from=oss&to=enterprise&features={_pick_paid_feature(ent)}"
+    )
+    assert r.status_code == 404
+    body = r.get_json()
+    assert body["which"] == "tier"
+
+
+def test_http_batch_unknown_from_is_404_with_which(client, ent):
+    r = client.get(
+        "/api/entitlement/lock-reason-at-path-batch"
+        f"?tier=cloud_pro&from=bogus&to=enterprise&features={_pick_paid_feature(ent)}"
+    )
+    assert r.status_code == 404
+    assert r.get_json()["which"] == "from"
+
+
+def test_http_batch_unknown_to_is_404_with_which(client, ent):
+    r = client.get(
+        "/api/entitlement/lock-reason-at-path-batch"
+        f"?tier=cloud_pro&from=oss&to=bogus&features={_pick_paid_feature(ent)}"
+    )
+    assert r.status_code == 404
+    assert r.get_json()["which"] == "to"
+
+
+def test_http_batch_happy_path_envelope(client, ent):
+    feat = _pick_paid_feature(ent)
+    r = client.get(
+        "/api/entitlement/lock-reason-at-path-batch"
+        f"?tier=cloud_pro&from=oss&to=enterprise&features={feat}"
+        f"&runtimes={_pick_paid_runtime(ent)}"
+        "&channels=99&retention_days=365&nodes=50"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert set(body.keys()) == _BATCH_ENVELOPE_KEYS
+    assert body["perspective_tier"] == "cloud_pro"
+    assert body["perspective_tier_rank"] == ent.tier_rank("cloud_pro")
+    assert body["direction"] == "upgrade"
+    assert len(body["features"]) == 1
+    assert len(body["runtimes"]) == 1
+    assert body["channels"] is not None
+    assert body["retention_days"] is not None
+    assert body["nodes"] is not None
+    assert body["unknown"] == {"features": [], "runtimes": []}
+
+
+def test_http_batch_body_byte_parity_with_lock_reason_path_batch(client, ent):
+    """Per-axis body must be byte-identical to /lock-reason-path-batch."""
+    feat = _pick_paid_feature(ent)
+    query = (
+        f"from=oss&to=enterprise&features={feat},custom_alerts"
+        f"&runtimes={_pick_paid_runtime(ent)},openclaw,claude-code"
+        "&channels=99&retention_days=365&nodes=50"
+    )
+    at = client.get(
+        f"/api/entitlement/lock-reason-at-path-batch?tier=cloud_pro&{query}"
+    ).get_json()
+    base = client.get(
+        f"/api/entitlement/lock-reason-path-batch?{query}"
+    ).get_json()
+    for key in ("features", "runtimes", "channels", "retention_days", "nodes", "unknown"):
+        assert at[key] == base[key], key
+
+
+def test_http_batch_unknown_ids_echoed_not_404(client, ent):
+    feat = _pick_paid_feature(ent)
+    r = client.get(
+        "/api/entitlement/lock-reason-at-path-batch"
+        f"?tier=cloud_pro&from=oss&to=enterprise&features={feat},bogus_feat"
+        "&runtimes=bogus_runtime"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert "bogus_feat" in body["unknown"]["features"]
+    assert "bogus_runtime" in body["unknown"]["runtimes"]
+
+
+def test_http_batch_runtime_alias_dedupes(client, ent):
+    r = client.get(
+        "/api/entitlement/lock-reason-at-path-batch"
+        "?tier=cloud_pro&from=oss&to=enterprise&runtimes=claude-code,claude_code"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    canon_ids = [row["key"] for row in body["runtimes"]]
+    assert canon_ids.count("claude_code") == 1
+
+
+def test_http_batch_identity_yields_empty_paths(client, ent):
+    feat = _pick_paid_feature(ent)
+    r = client.get(
+        "/api/entitlement/lock-reason-at-path-batch"
+        f"?tier=cloud_pro&from=enterprise&to=enterprise&features={feat}"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["direction"] == "identity"
+    for row in body["features"]:
+        assert row["path"] == []
+
+
+def test_http_batch_never_5xx_on_resolver_crash(client, ent, monkeypatch):
+    def _boom(*a, **kw):
+        raise RuntimeError("kaboom")
+
+    monkeypatch.setattr(ent, "lock_reason_at_path_batch", _boom)
+    r = client.get(
+        "/api/entitlement/lock-reason-at-path-batch"
+        f"?tier=cloud_pro&from=oss&to=enterprise&features={_pick_paid_feature(ent)}"
+    )
+    assert r.status_code < 500
+    body = r.get_json()
+    # Grace-shape envelope: perspective echoed, empty rows, grace=True.
+    assert body["perspective_tier"] == "cloud_pro"
+    assert body["features"] == []
+    assert body["grace"] is True


### PR DESCRIPTION
## Summary

- Fills the last remaining `_at_path` slot in the entitlement API. Every other axis (`feature_spec`, `runtime_spec`, `tier_spec`, `feature_catalog`, `runtime_catalog`, `tier_catalog`, `capacity_diff`, `preview`) already has a perspective-validated `_at_path` scalar + batch wrapper; the `lock_reason` axis was the odd one out. This PR closes that gap so a paywall walkthrough surface can call `X_at_path(perspective, from, to, ...)` uniformly across the whole family without special-casing the lock-reason axis.
- Purely additive read-only helpers on new URL surfaces. No behaviour change to any existing endpoint; ships in GRACE mode.

### Helpers added (`clawmetry/entitlements.py`)

```python
lock_reason_at_path(perspective, from_tier, to_tier, item, *, kind=None) -> list[dict] | None
lock_reason_at_path_batch(
    perspective, from_tier, to_tier, *,
    features=None, runtimes=None,
    channels=None, retention_days=None, nodes=None,
) -> dict | None
```

Perspective is validated (empty / unknown → `None`) but does **NOT** shape the rows — body is byte-identical to `lock_reason_path` / `lock_reason_path_batch` for the same downstream tuple. Pinned by a full perspective-invariance sweep across all 5 axes.

### Endpoints added (`routes/entitlement.py`)

- `GET /api/entitlement/lock-reason-at-path?tier=<perspective>&from=<f>&to=<t>&<axis>=<id>`
- `GET /api/entitlement/lock-reason-at-path-batch?tier=<perspective>&from=<f>&to=<t>&features=a,b&runtimes=x,y&channels=N&retention_days=K&nodes=M`

Standard `_at*` envelope (`perspective_tier` echo + resolver-context tail: `current_tier`, `current_tier_rank`, `grace`, `enforced`).

- **400** on missing `tier` / `from` / `to` / no axis / multi-axis (scalar)
- **404** with `which` bucketing on unknown tier ids
- **404** on unknown feature / runtime / bad capacity for the scalar
- Unknown feature / runtime IDs **echoed** in `unknown[]` on the batch (never 404s), matching every other `*_path_batch` sibling
- **Never 5xxs** — a delegation failure short-circuits to a grace-shape envelope with the perspective echoed

## Test plan

- [x] 60 new tests in `tests/test_entitlement_lock_reason_at_path.py` covering:
  - Perspective invariance across all 5 axes (features, runtimes, channels, retention_days, nodes)
  - Scalar / batch body byte-parity with the `lock_reason_path` / `lock_reason_path_batch` delegates
  - Runtime alias canonicalisation + dedupe (`claude-code` → `claude_code`)
  - Grace vs enforce byte-identity (delegate synthesises fresh `Entitlement(grace=False)` per rung)
  - `kind=None` auto-dispatch (feature vs runtime)
  - `trial` accepted as perspective + endpoint (lateral / identity branch)
  - Never-raises on delegate crash
  - HTTP 400 posture: missing `tier` / `from` / `to` / no axis / multi-axis
  - HTTP 404 posture: unknown `tier` / `from` / `to` (with `which` bucketing), unknown feature / runtime / bad capacity
  - Happy-path envelope shape (`_SCALAR_ENVELOPE_KEYS` / `_BATCH_ENVELOPE_KEYS`)
  - HTTP-level byte parity vs `/lock-reason-path` and `/lock-reason-path-batch`
  - Never-5xx behaviour on a resolver crash
- [x] `python3 -m py_compile clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_lock_reason_at_path.py` — clean
- [x] `ruff check clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_lock_reason_at_path.py` — All checks passed
- [x] `pytest -k entitlement` — 4220 passed, 4 skipped, zero entitlement failures (one unrelated `test_retention_prune` collection error caused by `duckdb` not being installed in this environment)

## Local operator verification checklist

The scheduled remote agent that opened this PR has no access to `~/.openclaw`, the running daemon, the browser, or the live cloud snapshot — the checks below need the operator's local box:

- [ ] Copy the two changed files into the installed package location:
      ```
      cp clawmetry/entitlements.py ~/.clawmetry/lib/python3.*/site-packages/clawmetry/
      cp routes/entitlement.py     ~/.clawmetry/lib/python3.*/site-packages/routes/
      ```
- [ ] Clear stale bytecode: `find ~/.clawmetry/lib -name __pycache__ -exec rm -rf {} +`
- [ ] Restart the sync daemon: `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
- [ ] Hit each new endpoint against the live daemon and inspect the envelope:
      ```
      curl -s "http://localhost:8900/api/entitlement/lock-reason-at-path?tier=cloud_pro&from=oss&to=enterprise&feature=custom_alerts" | jq
      curl -s "http://localhost:8900/api/entitlement/lock-reason-at-path?tier=cloud_pro&from=oss&to=enterprise&runtime=claude-code" | jq
      curl -s "http://localhost:8900/api/entitlement/lock-reason-at-path?tier=cloud_pro&from=oss&to=enterprise&channels=99" | jq
      curl -s "``http://localhost:8900/api/entitlement/lock-reason-at-path-batch?tier=cloud_pro&from=oss&to=enterprise&features=custom_alerts,fleet&runtimes=claude-code,codex&channels=99&retention_days=365&nodes=50"`` | jq
      ```
- [ ] Confirm scalar `_at_path` byte-parity with `_path`:
      ```
      curl -s ".../lock-reason-at-path?tier=cloud_pro&from=oss&to=enterprise&feature=custom_alerts" | jq '.path' > /tmp/at.json
      curl -s ".../lock-reason-path?from=oss&to=enterprise&feature=custom_alerts"                    | jq '.path' > /tmp/base.json
      diff /tmp/at.json /tmp/base.json  # should be empty
      ```
- [ ] Confirm batch `_at_path_batch` byte-parity with `_path_batch` across all 5 axes (features / runtimes / channels / retention_days / nodes).
- [ ] Confirm perspective invariance: shift `tier=oss` → `tier=enterprise` → `tier=trial` for the same `(from, to, feature)` and diff the `path` blob — every perspective yields identical rows.
- [ ] Confirm unknown-tier 404: `tier=bogus`, `from=bogus`, `to=bogus` each land at 404 with the right `which` bucketing.
- [ ] Confirm batch unknown-id echo: pass `features=custom_alerts,bogus_feat&runtimes=bogus_runtime` and check that `bogus_feat` / `bogus_runtime` land in `unknown[]` while the valid ids still return paths.
- [ ] Browser-check: decrypt the live cloud snapshot, load the dashboard, verify no regression on any entitlement-driven surface (paywall CTA, pricing-comparison matrix, upgrade tooltip) — these are additive read-only URLs so there should be zero visual delta.
- [ ] All existing `/api/entitlement/*` endpoints continue to return the same shapes (no behaviour change to anything already shipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LEeB5yCUzrVt7ZyQUr51yd)_