### PR TITLE
feat(entitlement): tier_unlocks/locks_at_path + _at_path_batch + 4 endpoints

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -12092,3 +12092,255 @@ def lock_reason_at_path_batch(
             "entitlements: lock_reason_at_path_batch failed: %s", exc
         )
         return None
+
+
+def tier_unlocks_at_path(
+    perspective_tier: str, from_tier: str, to_tier: str
+) -> list[dict] | None:
+    """What-if sibling of :func:`tier_unlocks_path`: per-rung marginal-
+    unlocks path between ``from_tier`` and ``to_tier`` rendered from a
+    hypothetical ``perspective_tier``.
+
+    Fills the ``_at_path`` slot for the ``tier_unlocks`` family alongside
+    :func:`tier_unlocks` (scalar current), :func:`tier_unlocks_at`
+    (scalar what-if), :func:`tier_unlocks_at_batch` (batch what-if),
+    :func:`tier_unlocks_path` (path current) and
+    :func:`tier_unlocks_path_batch` (batch path) so a pricing-comparison
+    walkthrough surface can call ``X_at_path(perspective, from, to)``
+    uniformly across the whole ``_at_path`` slot. Unlocks-only twin of
+    :func:`capacity_diff_at_path` -- same rung walk, marginal-unlocks
+    rows instead of capacity rows.
+
+    Body posture matches every other ``_at_path`` sibling
+    (:func:`capacity_diff_at_path` / :func:`tier_catalog_at_path` /
+    :func:`preview_at_path`): perspective is validated against
+    :data:`_TIER_ORDER` but does NOT shape rows. Each row is byte-
+    identical to a row from :func:`tier_unlocks_path` for the same
+    ``(from_tier, to_tier)`` pair -- pinned by parity tests so the
+    what-if path helper cannot drift from the current-perspective sibling
+    that also backs :func:`tier_unlocks_path_batch`.
+
+    Perspective acceptance is lenient (matches :func:`tier_unlocks_at`
+    and every other ``_at`` helper): any id in :data:`_TIER_ORDER` is
+    accepted, including :data:`TIER_TRIAL`. Endpoint acceptance mirrors
+    :func:`tier_unlocks_path`: both ``from_tier`` and ``to_tier``
+    accept any id in :data:`_TIER_FEATURES` (trial is a valid endpoint
+    via the lateral / identity branch even though the walked
+    intermediate rungs exclude it -- it is not purchasable).
+
+    Returns ``None`` when any of the three ids is unknown; empty list
+    for identity (``from == to``); single-row path for lateral
+    (same-rank, different id). Resolver-independent: delegates to
+    :func:`tier_unlocks_path`, which walks the static
+    :data:`_PURCHASABLE_TIERS` ladder and folds per-rung marginal
+    grants via :func:`_unlocks_row`, so grace vs enforce yields byte-
+    identical rows -- same property the rest of the ``_at_path`` family
+    guarantees.
+
+    Never raises: a delegate failure logs a warning and returns
+    ``None`` so an upgrade-walkthrough surface keeps rendering instead
+    of breaking.
+    """
+    try:
+        p = (perspective_tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if p not in _TIER_ORDER:
+        return None
+    try:
+        return tier_unlocks_path(from_tier, to_tier)
+    except Exception as exc:
+        logger.warning(
+            "entitlements: tier_unlocks_at_path failed: %s", exc
+        )
+        return None
+
+
+def tier_locks_at_path(
+    perspective_tier: str, from_tier: str, to_tier: str
+) -> list[dict] | None:
+    """What-if sibling of :func:`tier_locks_path`: per-rung marginal-
+    locks path between ``from_tier`` and ``to_tier`` rendered from a
+    hypothetical ``perspective_tier``.
+
+    Marginal-loss mirror of :func:`tier_unlocks_at_path`; fills the
+    ``_at_path`` slot for the ``tier_locks`` family alongside
+    :func:`tier_locks` / :func:`tier_locks_at` /
+    :func:`tier_locks_at_batch` / :func:`tier_locks_path` /
+    :func:`tier_locks_path_batch`. Locks-only twin of
+    :func:`capacity_diff_at_path` -- same rung walk, marginal-losses
+    rows instead of capacity rows.
+
+    Body posture matches every other ``_at_path`` sibling: perspective
+    is validated against :data:`_TIER_ORDER` but does NOT shape rows.
+    Each row is byte-identical to a row from :func:`tier_locks_path`
+    for the same ``(from_tier, to_tier)`` pair -- pinned by parity
+    tests so the what-if path helper cannot drift from the current-
+    perspective sibling that also backs :func:`tier_locks_path_batch`.
+
+    Perspective acceptance is lenient (any id in :data:`_TIER_ORDER`,
+    including :data:`TIER_TRIAL`). Endpoint acceptance mirrors
+    :func:`tier_locks_path`: both ``from_tier`` and ``to_tier`` accept
+    any id in :data:`_TIER_FEATURES`.
+
+    Returns ``None`` when any of the three ids is unknown; empty list
+    for identity (``from == to``); single-row path for lateral
+    (same-rank, different id). Resolver-independent: delegates to
+    :func:`tier_locks_path`, so grace vs enforce yields byte-identical
+    rows.
+
+    Never raises: a delegate failure logs a warning and returns
+    ``None`` so a downgrade-walkthrough surface keeps rendering instead
+    of breaking.
+    """
+    try:
+        p = (perspective_tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if p not in _TIER_ORDER:
+        return None
+    try:
+        return tier_locks_path(from_tier, to_tier)
+    except Exception as exc:
+        logger.warning(
+            "entitlements: tier_locks_at_path failed: %s", exc
+        )
+        return None
+
+
+def tier_unlocks_at_path_batch(
+    perspective_tier: str, from_tier: str, to_tiers
+) -> dict | None:
+    """Batch sibling of :func:`tier_unlocks_at_path`: per-rung marginal-
+    unlocks paths for a caller-supplied subset of destination tiers all
+    walked from a single ``from_tier`` from a hypothetical
+    ``perspective_tier`` in ONE round-trip.
+
+    Composes :func:`tier_unlocks_at_path` (scalar what-if path) and
+    :func:`tier_unlocks_path_batch` (multi-destination current-
+    perspective path). Fills the ``_at_path_batch`` slot for the
+    ``tier_unlocks`` family alongside :func:`tier_unlocks_at` /
+    :func:`tier_unlocks_at_batch` / :func:`tier_unlocks_at_path` so a
+    pricing-comparison walkthrough surface can call
+    ``X_at_path_batch(perspective, from, to_tiers)`` uniformly across
+    the whole ``_at_path_batch`` family (matches
+    :func:`capacity_diff_at_path_batch` /
+    :func:`feature_catalog_at_path_batch` /
+    :func:`runtime_catalog_at_path_batch` /
+    :func:`tier_catalog_at_path_batch` /
+    :func:`feature_spec_at_path_batch` /
+    :func:`runtime_spec_at_path_batch` /
+    :func:`tier_spec_at_path_batch` /
+    :func:`preview_at_path_batch` /
+    :func:`lock_reason_at_path_batch`).
+
+    Per-destination row shape mirrors :func:`tier_unlocks_path_batch`::
+
+        {
+          "to":         "<tier id>",
+          "to_label":   "...",
+          "to_rank":    <int>,
+          "direction":  "upgrade" | "downgrade" | "lateral" | "identity",
+          "path":       [<tier_unlocks_path row>, ...],
+        }
+
+    Envelope::
+
+        {
+          "tiers":   [<row>, ...],
+          "unknown": ["bogus_id", ...],
+        }
+
+    Body posture matches :func:`tier_unlocks_at_path`: perspective is
+    validated against :data:`_TIER_ORDER` but does NOT shape rows. Each
+    row is byte-identical to a row from
+    :func:`tier_unlocks_path_batch` for the same
+    ``(from_tier, to_tiers)`` pair -- pinned by parity tests so the
+    batch what-if path helper cannot drift from the current-perspective
+    sibling.
+
+    Supplied destination ids are normalised via :func:`_normalise_csv`
+    (whitespace stripped, lowercased, duplicates dropped, first-seen
+    order preserved). Unknown destination ids land in ``unknown[]``
+    instead of short-circuiting the batch, matching every other
+    ``*_path_batch`` sibling's posture. ``trial`` IS accepted as a
+    destination via the lateral / identity branches, matching
+    :func:`tier_unlocks_path_batch`.
+
+    Returns ``None`` for empty / unknown ``perspective_tier`` or
+    ``from_tier`` (caller renders "unknown tier" / 404). Never raises:
+    a per-destination failure short-circuits that id into ``unknown[]``
+    and the rest of the batch keeps building.
+    """
+    try:
+        p = (perspective_tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if p not in _TIER_ORDER:
+        return None
+    try:
+        return tier_unlocks_path_batch(from_tier, to_tiers)
+    except Exception as exc:
+        logger.warning(
+            "entitlements: tier_unlocks_at_path_batch failed: %s", exc
+        )
+        return None
+
+
+def tier_locks_at_path_batch(
+    perspective_tier: str, from_tier: str, to_tiers
+) -> dict | None:
+    """Batch sibling of :func:`tier_locks_at_path`: per-rung marginal-
+    locks paths for a caller-supplied subset of destination tiers all
+    walked from a single ``from_tier`` from a hypothetical
+    ``perspective_tier`` in ONE round-trip.
+
+    Marginal-loss mirror of :func:`tier_unlocks_at_path_batch`.
+    Composes :func:`tier_locks_at_path` (scalar what-if path) and
+    :func:`tier_locks_path_batch` (multi-destination current-
+    perspective path). Fills the ``_at_path_batch`` slot for the
+    ``tier_locks`` family alongside :func:`tier_locks_at` /
+    :func:`tier_locks_at_batch` / :func:`tier_locks_at_path` so a
+    downgrade-walkthrough surface can call
+    ``X_at_path_batch(perspective, from, to_tiers)`` uniformly across
+    the whole ``_at_path_batch`` family.
+
+    Per-destination row shape mirrors :func:`tier_locks_path_batch`::
+
+        {
+          "to":         "<tier id>",
+          "to_label":   "...",
+          "to_rank":    <int>,
+          "direction":  "upgrade" | "downgrade" | "lateral" | "identity",
+          "path":       [<tier_locks_path row>, ...],
+        }
+
+    Body posture matches :func:`tier_locks_at_path`: perspective is
+    validated against :data:`_TIER_ORDER` but does NOT shape rows. Each
+    row is byte-identical to a row from
+    :func:`tier_locks_path_batch` for the same
+    ``(from_tier, to_tiers)`` pair -- pinned by parity tests so the
+    batch what-if path helper cannot drift from the current-perspective
+    sibling.
+
+    Supplied destination ids are normalised via :func:`_normalise_csv`.
+    Unknown destination ids land in ``unknown[]`` instead of short-
+    circuiting. ``trial`` IS accepted as a destination via the lateral
+    / identity branches.
+
+    Returns ``None`` for empty / unknown ``perspective_tier`` or
+    ``from_tier``. Never raises.
+    """
+    try:
+        p = (perspective_tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if p not in _TIER_ORDER:
+        return None
+    try:
+        return tier_locks_path_batch(from_tier, to_tiers)
+    except Exception as exc:
+        logger.warning(
+            "entitlements: tier_locks_at_path_batch failed: %s", exc
+        )
+        return None

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -14446,3 +14446,524 @@ def api_entitlement_lock_reason_at_path_batch():
                 "enforced": False,
             }
         )
+
+
+@bp_entitlement.route("/api/entitlement/tier-unlocks-at-path")
+def api_entitlement_tier_unlocks_at_path():
+    """``GET /api/entitlement/tier-unlocks-at-path?tier=<perspective>
+    &from=<from>&to=<to>`` -- arbitrary-endpoint stepwise marginal-
+    unlocks path between any two tiers, rendered from a hypothetical
+    ``perspective_tier``.
+
+    What-if sibling of ``/tier-unlocks-path``: same rung walk, same
+    per-rung marginal-unlocks body, plus a ``perspective_tier`` echo
+    so a pricing-comparison walkthrough surface can call
+    ``X_at_path(perspective, from, to)`` uniformly across the whole
+    ``_at_path`` slot of the ``tier_unlocks`` family (alongside
+    ``/tier-unlocks-at`` and ``/tier-unlocks-at-batch``, which fill the
+    scalar-what-if and batch-what-if slots). Unlocks-only mirror of
+    ``/capacity-diff-at-path`` -- same posture, marginal-unlocks rows
+    instead of capacity rows.
+
+    Body posture matches ``/tier-unlocks-at`` and every other
+    ``_at_path`` sibling: perspective is validated but does not shape
+    the rows. Each row in ``path`` is byte-identical to a row from
+    ``/tier-unlocks-path?from=<from>&to=<to>`` -- pinned by parity
+    tests. Perspective acceptance is lenient: ``trial`` IS accepted
+    (matching every other ``_at`` sibling).
+
+    Response shape::
+
+        {
+          "perspective_tier":      "<tier id>",
+          "perspective_tier_rank": <int>,
+          "from":                  "<tier id>",
+          "from_label":            "...",
+          "from_rank":             <int>,
+          "to":                    "<tier id>",
+          "to_label":              "...",
+          "to_rank":               <int>,
+          "direction":             "upgrade" | "downgrade" | "lateral" | "identity",
+          "path":                  [<tier-unlocks-path row>, ...],
+          "current_tier":          "<tier id>",
+          "current_tier_rank":     <int>,
+          "grace":                 <bool>,
+          "enforced":              <bool>,
+        }
+
+    - **400** when ``tier=``, ``from=`` or ``to=`` is missing / blank
+    - **404** when any id is unknown (body carries ``which: "tier" |
+      "from" | "to"`` so the caller can point at the offender)
+    - **Never 5xxs**: a resolver failure short-circuits to 404 so an
+      upgrade-comparison surface keeps rendering instead of breaking.
+    """
+    p = (request.args.get("tier") or "").strip().lower()
+    f = (request.args.get("from") or "").strip().lower()
+    t = (request.args.get("to") or "").strip().lower()
+    if not p:
+        return jsonify({"error": "missing tier"}), 400
+    if not f:
+        return jsonify({"error": "missing from"}), 400
+    if not t:
+        return jsonify({"error": "missing to"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        if p not in _ent._TIER_ORDER:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "tier", "tier": p}
+                ),
+                404,
+            )
+        if f not in _ent._TIER_FEATURES:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "from", "from": f}
+                ),
+                404,
+            )
+        if t not in _ent._TIER_FEATURES:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "to", "to": t}
+                ),
+                404,
+            )
+        path = _ent.tier_unlocks_at_path(p, f, t)
+        if path is None:
+            return (
+                jsonify(
+                    {
+                        "error": "unknown tier",
+                        "tier": p,
+                        "from": f,
+                        "to": t,
+                    }
+                ),
+                404,
+            )
+        from_rank = _ent.tier_rank(f)
+        to_rank = _ent.tier_rank(t)
+        if f == t:
+            direction = "identity"
+        elif from_rank == to_rank:
+            direction = "lateral"
+        elif to_rank > from_rank:
+            direction = "upgrade"
+        else:
+            direction = "downgrade"
+        try:
+            ent = _ent.get_entitlement()
+            current_tier = getattr(ent, "tier", "oss") or "oss"
+            grace = bool(getattr(ent, "grace", True))
+        except Exception:
+            current_tier = "oss"
+            grace = True
+        try:
+            enforced = bool(_ent.is_enforced())
+        except Exception:
+            enforced = False
+        return jsonify(
+            {
+                "perspective_tier": p,
+                "perspective_tier_rank": _ent.tier_rank(p),
+                "from": f,
+                "from_label": _ent.tier_label(f),
+                "from_rank": from_rank,
+                "to": t,
+                "to_label": _ent.tier_label(t),
+                "to_rank": to_rank,
+                "direction": direction,
+                "path": path,
+                "current_tier": current_tier,
+                "current_tier_rank": _ent.tier_rank(current_tier),
+                "grace": grace,
+                "enforced": enforced,
+            }
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_tier_unlocks_at_path: error: %s", exc
+        )
+        return (
+            jsonify(
+                {
+                    "error": "unknown tier",
+                    "tier": p,
+                    "from": f,
+                    "to": t,
+                }
+            ),
+            404,
+        )
+
+
+@bp_entitlement.route("/api/entitlement/tier-locks-at-path")
+def api_entitlement_tier_locks_at_path():
+    """``GET /api/entitlement/tier-locks-at-path?tier=<perspective>
+    &from=<from>&to=<to>`` -- arbitrary-endpoint stepwise marginal-
+    locks path between any two tiers, rendered from a hypothetical
+    ``perspective_tier``.
+
+    Marginal-loss mirror of ``/tier-unlocks-at-path``. What-if sibling
+    of ``/tier-locks-path``: same rung walk, same per-rung marginal-
+    losses body, plus a ``perspective_tier`` echo. Locks-only mirror
+    of ``/capacity-diff-at-path``.
+
+    Body posture matches ``/tier-locks-at``: perspective is validated
+    but does not shape the rows. Each row in ``path`` is byte-
+    identical to a row from ``/tier-locks-path?from=<from>&to=<to>``
+    -- pinned by parity tests. Perspective acceptance is lenient:
+    ``trial`` IS accepted.
+
+    Response shape mirrors ``/tier-unlocks-at-path`` with ``path`` rows
+    carrying ``lost_features`` / ``lost_runtimes`` instead of
+    ``features`` / ``runtimes``.
+
+    - **400** when ``tier=``, ``from=`` or ``to=`` is missing / blank
+    - **404** when any id is unknown (body carries ``which: "tier" |
+      "from" | "to"``)
+    - **Never 5xxs**: a resolver failure short-circuits to 404 so a
+      downgrade-warning surface keeps rendering instead of breaking.
+    """
+    p = (request.args.get("tier") or "").strip().lower()
+    f = (request.args.get("from") or "").strip().lower()
+    t = (request.args.get("to") or "").strip().lower()
+    if not p:
+        return jsonify({"error": "missing tier"}), 400
+    if not f:
+        return jsonify({"error": "missing from"}), 400
+    if not t:
+        return jsonify({"error": "missing to"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        if p not in _ent._TIER_ORDER:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "tier", "tier": p}
+                ),
+                404,
+            )
+        if f not in _ent._TIER_FEATURES:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "from", "from": f}
+                ),
+                404,
+            )
+        if t not in _ent._TIER_FEATURES:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "to", "to": t}
+                ),
+                404,
+            )
+        path = _ent.tier_locks_at_path(p, f, t)
+        if path is None:
+            return (
+                jsonify(
+                    {
+                        "error": "unknown tier",
+                        "tier": p,
+                        "from": f,
+                        "to": t,
+                    }
+                ),
+                404,
+            )
+        from_rank = _ent.tier_rank(f)
+        to_rank = _ent.tier_rank(t)
+        if f == t:
+            direction = "identity"
+        elif from_rank == to_rank:
+            direction = "lateral"
+        elif to_rank > from_rank:
+            direction = "upgrade"
+        else:
+            direction = "downgrade"
+        try:
+            ent = _ent.get_entitlement()
+            current_tier = getattr(ent, "tier", "oss") or "oss"
+            grace = bool(getattr(ent, "grace", True))
+        except Exception:
+            current_tier = "oss"
+            grace = True
+        try:
+            enforced = bool(_ent.is_enforced())
+        except Exception:
+            enforced = False
+        return jsonify(
+            {
+                "perspective_tier": p,
+                "perspective_tier_rank": _ent.tier_rank(p),
+                "from": f,
+                "from_label": _ent.tier_label(f),
+                "from_rank": from_rank,
+                "to": t,
+                "to_label": _ent.tier_label(t),
+                "to_rank": to_rank,
+                "direction": direction,
+                "path": path,
+                "current_tier": current_tier,
+                "current_tier_rank": _ent.tier_rank(current_tier),
+                "grace": grace,
+                "enforced": enforced,
+            }
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_tier_locks_at_path: error: %s", exc
+        )
+        return (
+            jsonify(
+                {
+                    "error": "unknown tier",
+                    "tier": p,
+                    "from": f,
+                    "to": t,
+                }
+            ),
+            404,
+        )
+
+
+@bp_entitlement.route("/api/entitlement/tier-unlocks-at-path-batch")
+def api_entitlement_tier_unlocks_at_path_batch():
+    """``GET /api/entitlement/tier-unlocks-at-path-batch?tier=<perspective>
+    &from=<from>&to=a,b,c`` -- batch sibling of
+    ``/tier-unlocks-at-path``.
+
+    Where ``/tier-unlocks-at-path`` walks the marginal-unlocks rungs
+    between ONE ``(from, to)`` pair from a hypothetical
+    ``perspective_tier``, this walks ONE ``from`` to N candidate ``to``
+    tiers in ONE round-trip from the same hypothetical perspective --
+    the batch what-if sibling of ``/tier-unlocks-path-batch``, filling
+    the ``_at_path_batch`` slot for the ``tier_unlocks`` family.
+    Multi-destination cousin of ``/capacity-diff-at-path-batch`` (same
+    fan-out shape, marginal-unlocks body instead of capacity body).
+
+    Body posture matches ``/tier-unlocks-at``: perspective is validated
+    but does not shape rows. Each row in ``tiers[].path`` is byte-
+    identical to a row from ``/tier-unlocks-path-batch`` for the same
+    ``(from, to)`` pair. Perspective acceptance is lenient: ``trial``
+    IS accepted (matching every other ``_at`` sibling).
+
+    Response shape (mirrors ``/tier-unlocks-path-batch`` plus the
+    ``perspective_tier`` echo and the resolver-context tail every
+    ``_at*`` endpoint carries)::
+
+        {
+          "perspective_tier":      "<tier id>",
+          "perspective_tier_rank": <int>,
+          "from":                  "<tier id>",
+          "from_label":            "...",
+          "from_rank":             <int>,
+          "tiers": [
+            {
+              "to":        "<tier id>",
+              "to_label":  "...",
+              "to_rank":   <int>,
+              "direction": "upgrade" | "downgrade" | "lateral" | "identity",
+              "path":      [<tier-unlocks-path row>, ...],
+            },
+            ...
+          ],
+          "unknown":               ["bogus_id", ...],
+          "current_tier":          "<tier id>",
+          "current_tier_rank":     <int>,
+          "grace":                 <bool>,
+          "enforced":              <bool>,
+        }
+
+    Supplied destination ids are normalised (whitespace stripped,
+    lowercased, duplicates dropped, first-seen order preserved).
+    Unknown destination ids do NOT 404 the call -- they are echoed in
+    ``unknown[]``, matching every other ``*_path_batch`` sibling's
+    posture.
+
+    - **400** when ``tier=`` or ``from=`` is missing / blank, or ``to=``
+      is missing / empty after normalisation
+    - **404** when ``tier`` or ``from`` is unknown (body carries
+      ``which: "tier" | "from"``)
+    - **200** with bucketed unknowns for unknown destination ids
+    - **Never 5xxs**: a synthesis failure short-circuits to an envelope
+      with empty rows so the matrix keeps rendering.
+    """
+    p = (request.args.get("tier") or "").strip().lower()
+    f = (request.args.get("from") or "").strip().lower()
+    if not p:
+        return jsonify({"error": "missing tier"}), 400
+    if not f:
+        return jsonify({"error": "missing from"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        if p not in _ent._TIER_ORDER:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "tier", "tier": p}
+                ),
+                404,
+            )
+        if f not in _ent._TIER_FEATURES:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "from", "from": f}
+                ),
+                404,
+            )
+        targets = _parse_csv_arg("to")
+        if not targets:
+            return jsonify({"error": "supply to=<csv>"}), 400
+        batch = _ent.tier_unlocks_at_path_batch(p, f, targets)
+        if batch is None:
+            batch = {"tiers": [], "unknown": []}
+        try:
+            ent = _ent.get_entitlement()
+            current_tier = getattr(ent, "tier", "oss") or "oss"
+            grace = bool(getattr(ent, "grace", True))
+        except Exception:
+            current_tier = "oss"
+            grace = True
+        try:
+            enforced = bool(_ent.is_enforced())
+        except Exception:
+            enforced = False
+        return jsonify(
+            {
+                "perspective_tier": p,
+                "perspective_tier_rank": _ent.tier_rank(p),
+                "from": f,
+                "from_label": _ent.tier_label(f),
+                "from_rank": _ent.tier_rank(f),
+                "tiers": batch.get("tiers", []),
+                "unknown": batch.get("unknown", []),
+                "current_tier": current_tier,
+                "current_tier_rank": _ent.tier_rank(current_tier),
+                "grace": grace,
+                "enforced": enforced,
+            }
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_tier_unlocks_at_path_batch: error: %s", exc
+        )
+        return jsonify(
+            {
+                "perspective_tier": p,
+                "perspective_tier_rank": 0,
+                "from": f,
+                "from_label": None,
+                "from_rank": -1,
+                "tiers": [],
+                "unknown": [],
+                "current_tier": "oss",
+                "current_tier_rank": 0,
+                "grace": True,
+                "enforced": False,
+            }
+        )
+
+
+@bp_entitlement.route("/api/entitlement/tier-locks-at-path-batch")
+def api_entitlement_tier_locks_at_path_batch():
+    """``GET /api/entitlement/tier-locks-at-path-batch?tier=<perspective>
+    &from=<from>&to=a,b,c`` -- batch sibling of
+    ``/tier-locks-at-path``.
+
+    Marginal-loss mirror of ``/tier-unlocks-at-path-batch``. Batch
+    what-if sibling of ``/tier-locks-path-batch``. Locks-only cousin
+    of ``/capacity-diff-at-path-batch``.
+
+    Body posture matches ``/tier-locks-at``: perspective is validated
+    but does not shape rows. Each row in ``tiers[].path`` is byte-
+    identical to a row from ``/tier-locks-path-batch``. Perspective
+    acceptance is lenient: ``trial`` IS accepted.
+
+    Response shape mirrors ``/tier-unlocks-at-path-batch`` with
+    per-rung ``path`` rows carrying ``lost_features`` /
+    ``lost_runtimes`` instead of ``features`` / ``runtimes``.
+
+    - **400** when ``tier=`` or ``from=`` is missing / blank, or ``to=``
+      is missing / empty after normalisation
+    - **404** when ``tier`` or ``from`` is unknown (body carries
+      ``which: "tier" | "from"``)
+    - **200** with bucketed unknowns for unknown destination ids
+    - **Never 5xxs**.
+    """
+    p = (request.args.get("tier") or "").strip().lower()
+    f = (request.args.get("from") or "").strip().lower()
+    if not p:
+        return jsonify({"error": "missing tier"}), 400
+    if not f:
+        return jsonify({"error": "missing from"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        if p not in _ent._TIER_ORDER:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "tier", "tier": p}
+                ),
+                404,
+            )
+        if f not in _ent._TIER_FEATURES:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "from", "from": f}
+                ),
+                404,
+            )
+        targets = _parse_csv_arg("to")
+        if not targets:
+            return jsonify({"error": "supply to=<csv>"}), 400
+        batch = _ent.tier_locks_at_path_batch(p, f, targets)
+        if batch is None:
+            batch = {"tiers": [], "unknown": []}
+        try:
+            ent = _ent.get_entitlement()
+            current_tier = getattr(ent, "tier", "oss") or "oss"
+            grace = bool(getattr(ent, "grace", True))
+        except Exception:
+            current_tier = "oss"
+            grace = True
+        try:
+            enforced = bool(_ent.is_enforced())
+        except Exception:
+            enforced = False
+        return jsonify(
+            {
+                "perspective_tier": p,
+                "perspective_tier_rank": _ent.tier_rank(p),
+                "from": f,
+                "from_label": _ent.tier_label(f),
+                "from_rank": _ent.tier_rank(f),
+                "tiers": batch.get("tiers", []),
+                "unknown": batch.get("unknown", []),
+                "current_tier": current_tier,
+                "current_tier_rank": _ent.tier_rank(current_tier),
+                "grace": grace,
+                "enforced": enforced,
+            }
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_tier_locks_at_path_batch: error: %s", exc
+        )
+        return jsonify(
+            {
+                "perspective_tier": p,
+                "perspective_tier_rank": 0,
+                "from": f,
+                "from_label": None,
+                "from_rank": -1,
+                "tiers": [],
+                "unknown": [],
+                "current_tier": "oss",
+                "current_tier_rank": 0,
+                "grace": True,
+                "enforced": False,
+            }
+        )

--- a/tests/test_entitlement_tier_unlocks_locks_at_path.py
+++ b/tests/test_entitlement_tier_unlocks_locks_at_path.py
@@ -1,0 +1,766 @@
+"""Tests for ``tier_unlocks_at_path`` / ``tier_locks_at_path`` +
+``tier_unlocks_at_path_batch`` / ``tier_locks_at_path_batch`` and their
+four HTTP endpoints.
+
+Path-shaped what-if siblings of :func:`tier_unlocks_path` /
+:func:`tier_locks_path` -- render the per-rung marginal-unlocks /
+marginal-locks path between two tiers from a hypothetical
+``perspective_tier`` in ONE round-trip. Fills the ``_at_path`` /
+``_at_path_batch`` slots for the ``tier_unlocks`` / ``tier_locks``
+families so a pricing-comparison walkthrough surface can call
+``X_at_path(perspective, from, to)`` uniformly across every
+``_at_path`` family member (matches the already-shipping
+``capacity_diff_at_path`` / ``tier_catalog_at_path`` /
+``feature_catalog_at_path`` / ``preview_at_path`` /
+``feature_spec_at_path`` / ``runtime_spec_at_path`` /
+``tier_spec_at_path`` / ``lock_reason_at_path`` pattern).
+
+Pins:
+
+* per-rung ``path`` byte-identical to :func:`tier_unlocks_path` /
+  :func:`tier_locks_path` for every perspective -- the perspective is
+  validated but does NOT shape the rows (parity with every other
+  ``_at_path`` helper).
+* batch ``tiers[].path`` byte-identical to
+  :func:`tier_unlocks_path_batch` / :func:`tier_locks_path_batch` for
+  every perspective.
+* ``trial`` accepted as perspective and as endpoint / destination.
+* case + whitespace normalisation on perspective, from, to.
+* helper is decoupled from the resolver -- grace vs enforce yields
+  byte-identical rows.
+* unknown / empty / garbage ids return ``None`` and never raise; a
+  per-destination failure short-circuits that id into ``unknown[]``.
+* HTTP scalar: 400 on missing args, 404 with
+  ``which: "tier" | "from" | "to"`` on unknown ids, 200 with the
+  standard resolver-context tail every ``_at*`` endpoint carries.
+* HTTP batch: 400 on missing tier / from / empty to, 404 with
+  ``which: "tier" | "from"`` on unknown perspective / source, 200
+  with bucketed ``unknown[]`` on partially-bad destination lists,
+  never 5xxs on a synthesis failure.
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+
+_SCALAR_ENVELOPE_KEYS = {
+    "perspective_tier",
+    "perspective_tier_rank",
+    "from",
+    "from_label",
+    "from_rank",
+    "to",
+    "to_label",
+    "to_rank",
+    "direction",
+    "path",
+    "current_tier",
+    "current_tier_rank",
+    "grace",
+    "enforced",
+}
+_BATCH_ENVELOPE_KEYS = {
+    "perspective_tier",
+    "perspective_tier_rank",
+    "from",
+    "from_label",
+    "from_rank",
+    "tiers",
+    "unknown",
+    "current_tier",
+    "current_tier_rank",
+    "grace",
+    "enforced",
+}
+_BATCH_ITEM_KEYS = {"to", "to_label", "to_rank", "direction", "path"}
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def enforced(monkeypatch, tmp_path):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from flask import Flask
+
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+def _perspectives(mod):
+    """Every id the ``_at`` family accepts as a perspective."""
+    return [
+        mod.TIER_OSS,
+        mod.TIER_CLOUD_FREE,
+        mod.TIER_TRIAL,
+        mod.TIER_CLOUD_STARTER,
+        mod.TIER_CLOUD_PRO,
+        mod.TIER_PRO,
+        mod.TIER_ENTERPRISE,
+    ]
+
+
+# ─── tier_unlocks_at_path: helper ─────────────────────────────────────────────
+
+
+def test_unlocks_helper_returns_list(ent):
+    out = ent.tier_unlocks_at_path(
+        ent.TIER_CLOUD_PRO, ent.TIER_OSS, ent.TIER_ENTERPRISE
+    )
+    assert isinstance(out, list)
+    assert len(out) >= 1
+
+
+def test_unlocks_helper_perspective_does_not_shape_rows(ent):
+    """Every perspective yields the byte-identical rows the scalar path
+    helper would return -- the perspective is validated but does NOT
+    shape rows (parity with every other ``_at_path`` helper)."""
+    scalar = ent.tier_unlocks_path(ent.TIER_OSS, ent.TIER_ENTERPRISE)
+    for p in _perspectives(ent):
+        assert ent.tier_unlocks_at_path(p, ent.TIER_OSS, ent.TIER_ENTERPRISE) == scalar
+
+
+def test_unlocks_helper_trial_accepted_as_perspective(ent):
+    assert ent.tier_unlocks_at_path(
+        ent.TIER_TRIAL, ent.TIER_OSS, ent.TIER_CLOUD_PRO
+    ) == ent.tier_unlocks_path(ent.TIER_OSS, ent.TIER_CLOUD_PRO)
+
+
+def test_unlocks_helper_trial_accepted_as_endpoint(ent):
+    out = ent.tier_unlocks_at_path(
+        ent.TIER_CLOUD_PRO, ent.TIER_OSS, ent.TIER_TRIAL
+    )
+    assert out is not None
+
+
+def test_unlocks_helper_case_and_whitespace_normalised(ent):
+    a = ent.tier_unlocks_at_path("  CLOUD_PRO  ", "  OSS  ", "  ENTERPRISE  ")
+    b = ent.tier_unlocks_path(ent.TIER_OSS, ent.TIER_ENTERPRISE)
+    assert a == b
+
+
+def test_unlocks_helper_identity_returns_empty_list(ent):
+    assert ent.tier_unlocks_at_path(
+        ent.TIER_CLOUD_PRO, ent.TIER_CLOUD_PRO, ent.TIER_CLOUD_PRO
+    ) == []
+
+
+def test_unlocks_helper_lateral_returns_single_row(ent):
+    out = ent.tier_unlocks_at_path(
+        ent.TIER_OSS, ent.TIER_CLOUD_PRO, ent.TIER_PRO
+    )
+    assert isinstance(out, list)
+    assert len(out) == 1
+
+
+def test_unlocks_helper_bad_perspective_returns_none(ent):
+    assert ent.tier_unlocks_at_path(
+        "bogus", ent.TIER_OSS, ent.TIER_ENTERPRISE
+    ) is None
+
+
+def test_unlocks_helper_bad_from_returns_none(ent):
+    assert ent.tier_unlocks_at_path(
+        ent.TIER_CLOUD_PRO, "bogus", ent.TIER_ENTERPRISE
+    ) is None
+
+
+def test_unlocks_helper_bad_to_returns_none(ent):
+    assert ent.tier_unlocks_at_path(
+        ent.TIER_CLOUD_PRO, ent.TIER_OSS, "bogus"
+    ) is None
+
+
+def test_unlocks_helper_garbage_never_raises(ent):
+    assert ent.tier_unlocks_at_path(None, None, None) is None  # type: ignore[arg-type]
+    assert ent.tier_unlocks_at_path("", "", "") is None
+    assert ent.tier_unlocks_at_path("  ", "  ", "  ") is None
+
+
+def test_unlocks_helper_grace_and_enforce_yield_identical(ent, enforced):
+    for perspective in _perspectives(ent):
+        assert ent.tier_unlocks_at_path(
+            perspective, ent.TIER_OSS, ent.TIER_ENTERPRISE
+        ) == enforced.tier_unlocks_at_path(
+            perspective, ent.TIER_OSS, ent.TIER_ENTERPRISE
+        )
+
+
+def test_unlocks_helper_delegate_failure_returns_none(ent, monkeypatch):
+    def fake(*_a, **_k):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(ent, "tier_unlocks_path", fake)
+    assert ent.tier_unlocks_at_path(
+        ent.TIER_CLOUD_PRO, ent.TIER_OSS, ent.TIER_ENTERPRISE
+    ) is None
+
+
+# ─── tier_locks_at_path: helper ───────────────────────────────────────────────
+
+
+def test_locks_helper_perspective_does_not_shape_rows(ent):
+    scalar = ent.tier_locks_path(ent.TIER_ENTERPRISE, ent.TIER_OSS)
+    for p in _perspectives(ent):
+        assert ent.tier_locks_at_path(p, ent.TIER_ENTERPRISE, ent.TIER_OSS) == scalar
+
+
+def test_locks_helper_trial_accepted_as_perspective(ent):
+    assert ent.tier_locks_at_path(
+        ent.TIER_TRIAL, ent.TIER_ENTERPRISE, ent.TIER_OSS
+    ) == ent.tier_locks_path(ent.TIER_ENTERPRISE, ent.TIER_OSS)
+
+
+def test_locks_helper_identity_returns_empty_list(ent):
+    assert ent.tier_locks_at_path(
+        ent.TIER_CLOUD_PRO, ent.TIER_CLOUD_PRO, ent.TIER_CLOUD_PRO
+    ) == []
+
+
+def test_locks_helper_bad_perspective_returns_none(ent):
+    assert ent.tier_locks_at_path(
+        "bogus", ent.TIER_ENTERPRISE, ent.TIER_OSS
+    ) is None
+
+
+def test_locks_helper_garbage_never_raises(ent):
+    assert ent.tier_locks_at_path(None, None, None) is None  # type: ignore[arg-type]
+    assert ent.tier_locks_at_path("", "", "") is None
+
+
+def test_locks_helper_grace_and_enforce_yield_identical(ent, enforced):
+    for perspective in _perspectives(ent):
+        assert ent.tier_locks_at_path(
+            perspective, ent.TIER_ENTERPRISE, ent.TIER_OSS
+        ) == enforced.tier_locks_at_path(
+            perspective, ent.TIER_ENTERPRISE, ent.TIER_OSS
+        )
+
+
+def test_locks_helper_delegate_failure_returns_none(ent, monkeypatch):
+    def fake(*_a, **_k):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(ent, "tier_locks_path", fake)
+    assert ent.tier_locks_at_path(
+        ent.TIER_CLOUD_PRO, ent.TIER_ENTERPRISE, ent.TIER_OSS
+    ) is None
+
+
+# ─── tier_unlocks_at_path_batch: helper ───────────────────────────────────────
+
+
+def test_unlocks_batch_helper_returns_envelope(ent):
+    out = ent.tier_unlocks_at_path_batch(
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_OSS,
+        [ent.TIER_CLOUD_STARTER, ent.TIER_CLOUD_PRO, ent.TIER_ENTERPRISE],
+    )
+    assert isinstance(out, dict)
+    assert set(out.keys()) == {"tiers", "unknown"}
+    for row in out["tiers"]:
+        assert set(row.keys()) == _BATCH_ITEM_KEYS
+
+
+def test_unlocks_batch_helper_byte_equal_to_scalar_batch(ent):
+    """Each row in the batch what-if envelope is byte-identical to the
+    matching current-perspective batch envelope -- the perspective does
+    not shape rows."""
+    targets = [ent.TIER_CLOUD_STARTER, ent.TIER_CLOUD_PRO, ent.TIER_ENTERPRISE]
+    scalar_batch = ent.tier_unlocks_path_batch(ent.TIER_OSS, targets)
+    for p in _perspectives(ent):
+        assert ent.tier_unlocks_at_path_batch(p, ent.TIER_OSS, targets) == scalar_batch
+
+
+def test_unlocks_batch_helper_unknown_id_bucketed(ent):
+    out = ent.tier_unlocks_at_path_batch(
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_OSS,
+        [ent.TIER_CLOUD_STARTER, "bogus_id"],
+    )
+    assert [row["to"] for row in out["tiers"]] == [ent.TIER_CLOUD_STARTER]
+    assert out["unknown"] == ["bogus_id"]
+
+
+def test_unlocks_batch_helper_bad_perspective_returns_none(ent):
+    assert ent.tier_unlocks_at_path_batch(
+        "bogus", ent.TIER_OSS, [ent.TIER_ENTERPRISE]
+    ) is None
+
+
+def test_unlocks_batch_helper_bad_from_returns_none(ent):
+    """A bad ``from_tier`` propagates via the scalar delegate."""
+    assert ent.tier_unlocks_at_path_batch(
+        ent.TIER_CLOUD_PRO, "bogus", [ent.TIER_ENTERPRISE]
+    ) is None
+
+
+def test_unlocks_batch_helper_garbage_never_raises(ent):
+    assert ent.tier_unlocks_at_path_batch(None, None, None) is None  # type: ignore[arg-type]
+    assert ent.tier_unlocks_at_path_batch("", "", []) is None
+
+
+def test_unlocks_batch_helper_delegate_failure_returns_none(ent, monkeypatch):
+    def fake(*_a, **_k):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(ent, "tier_unlocks_path_batch", fake)
+    assert ent.tier_unlocks_at_path_batch(
+        ent.TIER_CLOUD_PRO, ent.TIER_OSS, [ent.TIER_ENTERPRISE]
+    ) is None
+
+
+def test_unlocks_batch_helper_grace_and_enforce_identical(ent, enforced):
+    targets = [ent.TIER_CLOUD_STARTER, ent.TIER_CLOUD_PRO, ent.TIER_ENTERPRISE]
+    for perspective in _perspectives(ent):
+        assert ent.tier_unlocks_at_path_batch(
+            perspective, ent.TIER_OSS, targets
+        ) == enforced.tier_unlocks_at_path_batch(
+            perspective, ent.TIER_OSS, targets
+        )
+
+
+# ─── tier_locks_at_path_batch: helper ─────────────────────────────────────────
+
+
+def test_locks_batch_helper_byte_equal_to_scalar_batch(ent):
+    targets = [ent.TIER_PRO, ent.TIER_CLOUD_STARTER, ent.TIER_OSS]
+    scalar_batch = ent.tier_locks_path_batch(ent.TIER_ENTERPRISE, targets)
+    for p in _perspectives(ent):
+        assert ent.tier_locks_at_path_batch(
+            p, ent.TIER_ENTERPRISE, targets
+        ) == scalar_batch
+
+
+def test_locks_batch_helper_unknown_id_bucketed(ent):
+    out = ent.tier_locks_at_path_batch(
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_ENTERPRISE,
+        [ent.TIER_OSS, "bogus_id"],
+    )
+    assert [row["to"] for row in out["tiers"]] == [ent.TIER_OSS]
+    assert out["unknown"] == ["bogus_id"]
+
+
+def test_locks_batch_helper_bad_perspective_returns_none(ent):
+    assert ent.tier_locks_at_path_batch(
+        "bogus", ent.TIER_ENTERPRISE, [ent.TIER_OSS]
+    ) is None
+
+
+def test_locks_batch_helper_delegate_failure_returns_none(ent, monkeypatch):
+    def fake(*_a, **_k):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(ent, "tier_locks_path_batch", fake)
+    assert ent.tier_locks_at_path_batch(
+        ent.TIER_CLOUD_PRO, ent.TIER_ENTERPRISE, [ent.TIER_OSS]
+    ) is None
+
+
+# ─── HTTP /api/entitlement/tier-unlocks-at-path ───────────────────────────────
+
+
+def test_http_unlocks_envelope_keys(client, ent):
+    r = client.get(
+        "/api/entitlement/tier-unlocks-at-path"
+        f"?tier={ent.TIER_CLOUD_PRO}"
+        f"&from={ent.TIER_OSS}"
+        f"&to={ent.TIER_ENTERPRISE}"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert set(body.keys()) == _SCALAR_ENVELOPE_KEYS
+
+
+def test_http_unlocks_path_matches_helper(client, ent):
+    r = client.get(
+        "/api/entitlement/tier-unlocks-at-path"
+        f"?tier={ent.TIER_CLOUD_PRO}"
+        f"&from={ent.TIER_OSS}"
+        f"&to={ent.TIER_ENTERPRISE}"
+    )
+    body = r.get_json()
+    assert body["path"] == ent.tier_unlocks_at_path(
+        ent.TIER_CLOUD_PRO, ent.TIER_OSS, ent.TIER_ENTERPRISE
+    )
+
+
+def test_http_unlocks_direction_upgrade(client, ent):
+    r = client.get(
+        "/api/entitlement/tier-unlocks-at-path"
+        f"?tier={ent.TIER_CLOUD_PRO}"
+        f"&from={ent.TIER_OSS}"
+        f"&to={ent.TIER_ENTERPRISE}"
+    )
+    assert r.get_json()["direction"] == "upgrade"
+
+
+def test_http_unlocks_direction_identity(client, ent):
+    r = client.get(
+        "/api/entitlement/tier-unlocks-at-path"
+        f"?tier={ent.TIER_OSS}"
+        f"&from={ent.TIER_CLOUD_PRO}"
+        f"&to={ent.TIER_CLOUD_PRO}"
+    )
+    body = r.get_json()
+    assert body["direction"] == "identity"
+    assert body["path"] == []
+
+
+def test_http_unlocks_missing_tier_400(client):
+    r = client.get(
+        "/api/entitlement/tier-unlocks-at-path?from=oss&to=enterprise"
+    )
+    assert r.status_code == 400
+
+
+def test_http_unlocks_missing_from_400(client, ent):
+    r = client.get(
+        "/api/entitlement/tier-unlocks-at-path"
+        f"?tier={ent.TIER_CLOUD_PRO}&to={ent.TIER_ENTERPRISE}"
+    )
+    assert r.status_code == 400
+
+
+def test_http_unlocks_missing_to_400(client, ent):
+    r = client.get(
+        "/api/entitlement/tier-unlocks-at-path"
+        f"?tier={ent.TIER_CLOUD_PRO}&from={ent.TIER_OSS}"
+    )
+    assert r.status_code == 400
+
+
+def test_http_unlocks_bad_perspective_404(client, ent):
+    r = client.get(
+        "/api/entitlement/tier-unlocks-at-path"
+        f"?tier=bogus&from={ent.TIER_OSS}&to={ent.TIER_ENTERPRISE}"
+    )
+    assert r.status_code == 404
+    assert r.get_json()["which"] == "tier"
+
+
+def test_http_unlocks_bad_from_404(client, ent):
+    r = client.get(
+        "/api/entitlement/tier-unlocks-at-path"
+        f"?tier={ent.TIER_CLOUD_PRO}&from=bogus&to={ent.TIER_ENTERPRISE}"
+    )
+    assert r.status_code == 404
+    assert r.get_json()["which"] == "from"
+
+
+def test_http_unlocks_bad_to_404(client, ent):
+    r = client.get(
+        "/api/entitlement/tier-unlocks-at-path"
+        f"?tier={ent.TIER_CLOUD_PRO}&from={ent.TIER_OSS}&to=bogus"
+    )
+    assert r.status_code == 404
+    assert r.get_json()["which"] == "to"
+
+
+def test_http_unlocks_trial_perspective_accepted(client, ent):
+    r = client.get(
+        "/api/entitlement/tier-unlocks-at-path"
+        f"?tier={ent.TIER_TRIAL}&from={ent.TIER_OSS}&to={ent.TIER_ENTERPRISE}"
+    )
+    assert r.status_code == 200
+
+
+def test_http_unlocks_never_5xx_on_helper_failure(client, ent, monkeypatch):
+    def fake(*_a, **_k):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(ent, "tier_unlocks_at_path", fake)
+    r = client.get(
+        "/api/entitlement/tier-unlocks-at-path"
+        f"?tier={ent.TIER_CLOUD_PRO}&from={ent.TIER_OSS}&to={ent.TIER_ENTERPRISE}"
+    )
+    assert r.status_code < 500
+
+
+# ─── HTTP /api/entitlement/tier-locks-at-path ─────────────────────────────────
+
+
+def test_http_locks_envelope_keys(client, ent):
+    r = client.get(
+        "/api/entitlement/tier-locks-at-path"
+        f"?tier={ent.TIER_CLOUD_PRO}"
+        f"&from={ent.TIER_ENTERPRISE}"
+        f"&to={ent.TIER_OSS}"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert set(body.keys()) == _SCALAR_ENVELOPE_KEYS
+
+
+def test_http_locks_path_matches_helper(client, ent):
+    r = client.get(
+        "/api/entitlement/tier-locks-at-path"
+        f"?tier={ent.TIER_CLOUD_PRO}"
+        f"&from={ent.TIER_ENTERPRISE}"
+        f"&to={ent.TIER_OSS}"
+    )
+    assert r.get_json()["path"] == ent.tier_locks_at_path(
+        ent.TIER_CLOUD_PRO, ent.TIER_ENTERPRISE, ent.TIER_OSS
+    )
+
+
+def test_http_locks_direction_downgrade(client, ent):
+    r = client.get(
+        "/api/entitlement/tier-locks-at-path"
+        f"?tier={ent.TIER_CLOUD_PRO}"
+        f"&from={ent.TIER_ENTERPRISE}"
+        f"&to={ent.TIER_OSS}"
+    )
+    assert r.get_json()["direction"] == "downgrade"
+
+
+def test_http_locks_missing_args_400(client, ent):
+    for qs in (
+        "",
+        f"?tier={ent.TIER_CLOUD_PRO}",
+        f"?from={ent.TIER_ENTERPRISE}",
+        f"?tier={ent.TIER_CLOUD_PRO}&from={ent.TIER_ENTERPRISE}",
+        f"?tier={ent.TIER_CLOUD_PRO}&to={ent.TIER_OSS}",
+    ):
+        r = client.get(f"/api/entitlement/tier-locks-at-path{qs}")
+        assert r.status_code == 400, qs
+
+
+def test_http_locks_bad_ids_404(client, ent):
+    r = client.get(
+        "/api/entitlement/tier-locks-at-path"
+        f"?tier=bogus&from={ent.TIER_ENTERPRISE}&to={ent.TIER_OSS}"
+    )
+    assert r.status_code == 404
+    assert r.get_json()["which"] == "tier"
+
+
+def test_http_locks_never_5xx_on_helper_failure(client, ent, monkeypatch):
+    def fake(*_a, **_k):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(ent, "tier_locks_at_path", fake)
+    r = client.get(
+        "/api/entitlement/tier-locks-at-path"
+        f"?tier={ent.TIER_CLOUD_PRO}&from={ent.TIER_ENTERPRISE}&to={ent.TIER_OSS}"
+    )
+    assert r.status_code < 500
+
+
+# ─── HTTP /api/entitlement/tier-unlocks-at-path-batch ─────────────────────────
+
+
+def test_http_unlocks_batch_envelope_keys(client, ent):
+    r = client.get(
+        "/api/entitlement/tier-unlocks-at-path-batch"
+        f"?tier={ent.TIER_CLOUD_PRO}"
+        f"&from={ent.TIER_OSS}"
+        f"&to={ent.TIER_CLOUD_STARTER},{ent.TIER_ENTERPRISE}"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert set(body.keys()) == _BATCH_ENVELOPE_KEYS
+
+
+def test_http_unlocks_batch_body_matches_helper(client, ent):
+    r = client.get(
+        "/api/entitlement/tier-unlocks-at-path-batch"
+        f"?tier={ent.TIER_CLOUD_PRO}"
+        f"&from={ent.TIER_OSS}"
+        f"&to={ent.TIER_CLOUD_STARTER},{ent.TIER_CLOUD_PRO},{ent.TIER_ENTERPRISE}"
+    )
+    body = r.get_json()
+    helper = ent.tier_unlocks_at_path_batch(
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_OSS,
+        [ent.TIER_CLOUD_STARTER, ent.TIER_CLOUD_PRO, ent.TIER_ENTERPRISE],
+    )
+    assert body["tiers"] == helper["tiers"]
+    assert body["unknown"] == helper["unknown"]
+
+
+def test_http_unlocks_batch_missing_tier_400(client, ent):
+    r = client.get(
+        "/api/entitlement/tier-unlocks-at-path-batch"
+        f"?from={ent.TIER_OSS}&to={ent.TIER_ENTERPRISE}"
+    )
+    assert r.status_code == 400
+
+
+def test_http_unlocks_batch_missing_from_400(client, ent):
+    r = client.get(
+        "/api/entitlement/tier-unlocks-at-path-batch"
+        f"?tier={ent.TIER_CLOUD_PRO}&to={ent.TIER_ENTERPRISE}"
+    )
+    assert r.status_code == 400
+
+
+def test_http_unlocks_batch_empty_to_400(client, ent):
+    r = client.get(
+        "/api/entitlement/tier-unlocks-at-path-batch"
+        f"?tier={ent.TIER_CLOUD_PRO}&from={ent.TIER_OSS}"
+    )
+    assert r.status_code == 400
+
+
+def test_http_unlocks_batch_bad_perspective_404(client, ent):
+    r = client.get(
+        "/api/entitlement/tier-unlocks-at-path-batch"
+        f"?tier=bogus&from={ent.TIER_OSS}&to={ent.TIER_ENTERPRISE}"
+    )
+    assert r.status_code == 404
+    assert r.get_json()["which"] == "tier"
+
+
+def test_http_unlocks_batch_bad_from_404(client, ent):
+    r = client.get(
+        "/api/entitlement/tier-unlocks-at-path-batch"
+        f"?tier={ent.TIER_CLOUD_PRO}&from=bogus&to={ent.TIER_ENTERPRISE}"
+    )
+    assert r.status_code == 404
+    assert r.get_json()["which"] == "from"
+
+
+def test_http_unlocks_batch_unknown_to_bucketed_200(client, ent):
+    r = client.get(
+        "/api/entitlement/tier-unlocks-at-path-batch"
+        f"?tier={ent.TIER_CLOUD_PRO}"
+        f"&from={ent.TIER_OSS}"
+        f"&to={ent.TIER_CLOUD_STARTER},bogus_id"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert [row["to"] for row in body["tiers"]] == [ent.TIER_CLOUD_STARTER]
+    assert body["unknown"] == ["bogus_id"]
+
+
+def test_http_unlocks_batch_never_5xx_on_helper_failure(client, ent, monkeypatch):
+    def fake(*_a, **_k):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(ent, "tier_unlocks_at_path_batch", fake)
+    r = client.get(
+        "/api/entitlement/tier-unlocks-at-path-batch"
+        f"?tier={ent.TIER_CLOUD_PRO}&from={ent.TIER_OSS}&to={ent.TIER_ENTERPRISE}"
+    )
+    assert r.status_code < 500
+
+
+def test_http_unlocks_batch_trial_accepted(client, ent):
+    r = client.get(
+        "/api/entitlement/tier-unlocks-at-path-batch"
+        f"?tier={ent.TIER_TRIAL}"
+        f"&from={ent.TIER_OSS}"
+        f"&to={ent.TIER_ENTERPRISE},{ent.TIER_TRIAL}"
+    )
+    assert r.status_code == 200
+
+
+# ─── HTTP /api/entitlement/tier-locks-at-path-batch ───────────────────────────
+
+
+def test_http_locks_batch_envelope_keys(client, ent):
+    r = client.get(
+        "/api/entitlement/tier-locks-at-path-batch"
+        f"?tier={ent.TIER_CLOUD_PRO}"
+        f"&from={ent.TIER_ENTERPRISE}"
+        f"&to={ent.TIER_PRO},{ent.TIER_OSS}"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert set(body.keys()) == _BATCH_ENVELOPE_KEYS
+
+
+def test_http_locks_batch_body_matches_helper(client, ent):
+    r = client.get(
+        "/api/entitlement/tier-locks-at-path-batch"
+        f"?tier={ent.TIER_CLOUD_PRO}"
+        f"&from={ent.TIER_ENTERPRISE}"
+        f"&to={ent.TIER_PRO},{ent.TIER_CLOUD_STARTER},{ent.TIER_OSS}"
+    )
+    body = r.get_json()
+    helper = ent.tier_locks_at_path_batch(
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_ENTERPRISE,
+        [ent.TIER_PRO, ent.TIER_CLOUD_STARTER, ent.TIER_OSS],
+    )
+    assert body["tiers"] == helper["tiers"]
+    assert body["unknown"] == helper["unknown"]
+
+
+def test_http_locks_batch_missing_args_400(client, ent):
+    for qs in (
+        "",
+        f"?tier={ent.TIER_CLOUD_PRO}",
+        f"?from={ent.TIER_ENTERPRISE}",
+        f"?tier={ent.TIER_CLOUD_PRO}&from={ent.TIER_ENTERPRISE}",
+    ):
+        r = client.get(f"/api/entitlement/tier-locks-at-path-batch{qs}")
+        assert r.status_code == 400, qs
+
+
+def test_http_locks_batch_bad_ids_404(client, ent):
+    r = client.get(
+        "/api/entitlement/tier-locks-at-path-batch"
+        f"?tier=bogus&from={ent.TIER_ENTERPRISE}&to={ent.TIER_OSS}"
+    )
+    assert r.status_code == 404
+    assert r.get_json()["which"] == "tier"
+
+    r = client.get(
+        "/api/entitlement/tier-locks-at-path-batch"
+        f"?tier={ent.TIER_CLOUD_PRO}&from=bogus&to={ent.TIER_OSS}"
+    )
+    assert r.status_code == 404
+    assert r.get_json()["which"] == "from"
+
+
+def test_http_locks_batch_unknown_to_bucketed_200(client, ent):
+    r = client.get(
+        "/api/entitlement/tier-locks-at-path-batch"
+        f"?tier={ent.TIER_CLOUD_PRO}"
+        f"&from={ent.TIER_ENTERPRISE}"
+        f"&to={ent.TIER_OSS},bogus_id"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert [row["to"] for row in body["tiers"]] == [ent.TIER_OSS]
+    assert body["unknown"] == ["bogus_id"]
+
+
+def test_http_locks_batch_never_5xx_on_helper_failure(client, ent, monkeypatch):
+    def fake(*_a, **_k):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(ent, "tier_locks_at_path_batch", fake)
+    r = client.get(
+        "/api/entitlement/tier-locks-at-path-batch"
+        f"?tier={ent.TIER_CLOUD_PRO}&from={ent.TIER_ENTERPRISE}&to={ent.TIER_OSS}"
+    )
+    assert r.status_code < 500


### PR DESCRIPTION
## Summary

Fills the missing `_at_path` / `_at_path_batch` slot for the `tier_unlocks` / `tier_locks` families. Every neighbouring family (`capacity_diff`, `tier_catalog`, `feature_catalog`, `feature_spec`, `runtime_spec`, `tier_spec`, `preview`, `lock_reason`) already ships those slots — this PR closes the gap for the two remaining families so a pricing-comparison walkthrough surface can call `X_at_path(perspective, from, to)` uniformly across the whole family.

- Adds `tier_unlocks_at_path(perspective, from, to)` + `tier_locks_at_path(perspective, from, to)` in `clawmetry/entitlements.py`. Both delegate to the existing scalar `tier_unlocks_path` / `tier_locks_path` — perspective is validated against `_TIER_ORDER` but does NOT shape rows (matches the existing `capacity_diff_at_path` posture).
- Adds `tier_unlocks_at_path_batch(perspective, from, to_tiers)` + `tier_locks_at_path_batch(perspective, from, to_tiers)` — multi-destination fan-out, per-destination `path` byte-identical to `tier_unlocks_path_batch` / `tier_locks_path_batch` for the same `(from, to_tiers)` tuple (pinned by parity tests).
- Adds 4 GET endpoints in `routes/entitlement.py`:
  - `/api/entitlement/tier-unlocks-at-path?tier=&from=&to=`
  - `/api/entitlement/tier-locks-at-path?tier=&from=&to=`
  - `/api/entitlement/tier-unlocks-at-path-batch?tier=&from=&to=csv`
  - `/api/entitlement/tier-locks-at-path-batch?tier=&from=&to=csv`

Same posture as the neighbouring `capacity_diff_at_path` / `_batch` endpoints: **400** on missing arg, **404** with `which: "tier" | "from" | "to"` on unknown id, **200** with bucketed `unknown[]` on partially-bad destination lists. Never 5xxs: a resolver failure short-circuits so an upgrade-comparison / downgrade-walkthrough surface keeps rendering.

Behavior-preserving; stays in grace. Endpoints are additive and delegate to helpers already on main. Grace vs enforce yields byte-identical rows (pinned in tests).

## Test plan

- [x] 66 new unit + endpoint tests in `tests/test_entitlement_tier_unlocks_locks_at_path.py` — all pass locally
- [x] `python3 -m pytest tests/test_entitlement_tier_unlocks_locks_at_path.py -q` → 66 passed
- [x] Regression sweep: `python3 -m pytest tests/test_entitlement_*.py -q` → 4040 passed
- [x] Adjacent path-family tests still pass (`test_entitlement_tier_unlocks_path.py`, `test_entitlement_tier_locks_path.py`, `test_entitlement_tier_unlocks_path_batch.py`, `test_entitlement_capacity_diff_at_path.py`)
- [x] `ruff check` clean on all touched files
- [x] `python3 -m py_compile` clean on all touched files
- [x] Parity pinned: for every perspective `p` in `_TIER_ORDER` (including `trial`), `tier_unlocks_at_path(p, f, t) == tier_unlocks_path(f, t)` and the same for locks — the batch variants pin against `tier_unlocks_path_batch` / `tier_locks_path_batch`.
- [x] `trial` accepted as perspective and as endpoint (matches every other `_at` sibling).
- [x] Whitespace / case normalisation on all three ids.
- [x] Grace vs enforce yields byte-identical rows (pinned per-perspective).

## Local operator verification checklist

The autonomous fire that opened this PR has no access to the live daemon, the `~/.openclaw` workspace, the encrypted cloud snapshot, or a browser. The local operator needs to run these before flipping the PR to ready-for-review:

- [ ] Copy `clawmetry/entitlements.py`, `routes/entitlement.py`, `tests/test_entitlement_tier_unlocks_locks_at_path.py` into `~/.clawmetry/lib/pythonX.Y/site-packages/clawmetry/` (or reinstall from source).
- [ ] Clear `__pycache__/` under the installed location so the new symbols are reloaded.
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` (or the equivalent daemon restart on Linux) to reload the routes into the running dashboard.
- [ ] `curl 'http://localhost:8900/api/entitlement/tier-unlocks-at-path?tier=cloud_pro&from=oss&to=enterprise' | jq .` — verify `path` populated with real `features` / `runtimes`, `direction:"upgrade"`, and grace context matches the resolved entitlement.
- [ ] `curl 'http://localhost:8900/api/entitlement/tier-locks-at-path?tier=cloud_pro&from=enterprise&to=oss' | jq .` — verify `path` populated with real `lost_features` / `lost_runtimes`, `direction:"downgrade"`.
- [ ] `curl 'http://localhost:8900/api/entitlement/tier-unlocks-at-path-batch?tier=cloud_pro&from=oss&to=cloud_starter,cloud_pro,enterprise,bogus' | jq .` — verify per-destination `path` rows populated and `unknown:["bogus"]`.
- [ ] `curl 'http://localhost:8900/api/entitlement/tier-locks-at-path-batch?tier=cloud_pro&from=enterprise&to=pro,cloud_starter,oss' | jq .` — verify per-destination `lost_features` / `lost_runtimes` populated.
- [ ] Decrypt the live cloud snapshot in-browser via the dashboard and confirm the endpoints render cleanly against the real entitlement (no console errors, no 5xxs, `_source` unchanged).
- [ ] Full `make test` (or targeted `pytest tests/test_entitlement_tier_unlocks_locks_at_path.py`) in the operator's environment.

## Notes

- Branch off `origin/main`; no version bumps, no tag, no release. Draft PR only — the local operator handles verification, merge, and release per `FLYWHEEL.md`.
- Rendered rows are byte-identical to the underlying `tier_unlocks_path` / `tier_locks_path` (scalar) and `tier_unlocks_path_batch` / `tier_locks_path_batch` (batch) helpers, so any pricing-comparison client hydrating against the current-perspective variant can swap to the what-if variant by supplying a `tier=<perspective>` arg without any row-shape changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MoM7ZpLtia3i7q44xUADNc)_