### PR TITLE
feat(entitlement): tier_diff_at + /api/entitlement/tier-diff-at

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -6554,6 +6554,69 @@ def tier_diff_at_batch(tier: str) -> list[dict] | None:
         return []
 
 
+def tier_diff_at(
+    perspective: str, from_tier: str, to_tier: str
+) -> dict | None:
+    """Hypothetical-perspective sibling of :func:`tier_diff`: full marginal
+    diff between two tiers, scoped by a caller-supplied ``perspective`` tier.
+
+    Same relationship to :func:`tier_diff` that :func:`tier_path_at` has to
+    :func:`tier_path`: the ``perspective`` argument tells the helper which
+    resolver / plan the caller is answering from so an ``_at`` endpoint URL
+    can be uniform across the whole ``_at`` family (every ``_at`` sibling
+    accepts a ``tier=<perspective>`` query arg), even though the underlying
+    diff is inherently perspective-independent -- ``tier_diff`` is already
+    arbitrary-endpoint, so the row shape does not depend on where the caller
+    is standing.
+
+    Perspective is validated against :data:`_TIER_ORDER` (including
+    :data:`TIER_TRIAL`) but does NOT shape rows -- the diff is anchored to
+    ``from_tier`` / ``to_tier``, exactly the way :func:`tier_path_at` and
+    the ``_at_path`` family anchor to their ``from`` / ``to`` endpoints.
+    A parity test pins ``tier_diff_at(p, f, t) == tier_diff(f, t)`` for
+    every ``p`` in :data:`_TIER_ORDER` so the ``_at`` prefix cannot
+    silently drift into shaping rows.
+
+    Scalar what-if companion of the existing ``_at_batch`` /
+    ``_at_path`` / ``_at_path_batch`` siblings in the ``tier_diff`` family:
+    :func:`tier_diff_at_batch` walks every purchasable target for one
+    source ``tier``; :func:`tier_path_at` and its batch walk the per-rung
+    marginal diff along a ``from -> to`` segment; this scalar closes the
+    ``_at`` slot so a pricing-comparison tooltip can hit the same helper
+    for "A vs B under perspective P" as the other ``_at`` scalars
+    (:func:`capacity_diff_at`, :func:`tier_unlocks_at`,
+    :func:`tier_locks_at`) surface.
+
+    Per-row shape delegates to :func:`tier_diff` -- ``from``, ``from_label``,
+    ``from_rank``, ``to``, ``to_label``, ``to_rank``, ``direction``,
+    ``added_features``, ``lost_features``, ``added_runtimes``,
+    ``lost_runtimes``, ``capacity_changes``. Identity (``from == to``)
+    collapses to ``direction="identity"`` with empty marginal lists and
+    no-op capacity triples, matching the singular helper's identity
+    branch.
+
+    Returns ``None`` for empty / unknown ``perspective`` / ``from_tier`` /
+    ``to_tier`` ids (caller renders "unknown tier" / 404). Decoupled from
+    the resolved entitlement (delegates to :func:`tier_diff`, which walks
+    the static per-tier maps), so grace vs enforce yields byte-identical
+    rows.
+
+    Never raises: a builder failure short-circuits to ``None`` so a
+    pricing-comparison tooltip stays mute instead of breaking.
+    """
+    try:
+        p = (perspective or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if not p or p not in _TIER_ORDER:
+        return None
+    try:
+        return tier_diff(from_tier, to_tier)
+    except Exception as exc:
+        logger.warning("entitlements: tier_diff_at failed: %s", exc)
+        return None
+
+
 def _next_purchasable_tier_after(tier: str) -> str | None:
     """Pure helper: next strictly-higher-rank entry in
     :data:`_PURCHASABLE_TIERS` after ``tier``, ties broken by the order

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -856,6 +856,128 @@ def api_entitlement_capacity_diff_at_batch():
         )
 
 
+@bp_entitlement.route("/api/entitlement/tier-diff-at")
+def api_entitlement_tier_diff_at():
+    """``GET /api/entitlement/tier-diff-at?tier=<perspective>&from=<from>
+    &to=<to>`` -- arbitrary-endpoint diff between two tiers, rendered
+    from a hypothetical ``perspective_tier``.
+
+    What-if sibling of ``/tier-diff``: same payload shape, plus a
+    ``perspective_tier`` echo so a pricing-comparison tooltip surface
+    can call ``X_at(perspective, from, to)`` uniformly across the whole
+    ``_at`` scalar family (alongside ``/capacity-diff-at``,
+    ``/tier-unlocks-at``, ``/tier-locks-at``, ``/tier-catalog-at`` and
+    the ``_at_path`` walk siblings). Closes the ``_at`` slot of the
+    ``tier_diff`` family alongside the existing ``/tier-diff-at-batch``
+    (walk every purchasable target from one source) and the
+    ``/tier-path-at`` walk-shape sibling in the open ``tier_path_at``
+    PR.
+
+    Body posture matches ``/tier-catalog-at-path``: perspective is
+    validated against :data:`_TIER_ORDER` (including :data:`TIER_TRIAL`)
+    but does NOT shape rows -- the diff is anchored to ``from`` /
+    ``to``. A parity test pins the response body against
+    ``/tier-diff?from=<from>&to=<to>`` for every valid perspective so
+    the ``_at`` prefix cannot silently drift into shaping rows.
+
+    Response body extends the ``/tier-diff`` shape with three extra
+    fields at the top so a consumer can echo the perspective in a
+    "Comparing A vs B from perspective P" tooltip without a second
+    round-trip::
+
+        {
+          "perspective_tier":      "<tier id>",
+          "perspective_tier_rank": <int>,
+          "perspective_tier_label":"...",
+          "from":                  "<tier id>",
+          "from_label":            "...",
+          "from_rank":             <int>,
+          "to":                    "<tier id>",
+          "to_label":              "...",
+          "to_rank":               <int>,
+          "direction":             "upgrade" | "downgrade" | "lateral" | "identity",
+          "added_features":        [...],
+          "lost_features":         [...],
+          "added_runtimes":        [...],
+          "lost_runtimes":         [...],
+          "capacity_changes":      {...},
+        }
+
+    - **400** when ``tier=``, ``from=`` or ``to=`` is missing / blank.
+    - **404** when any id is unknown (body carries ``which: "tier" |
+      "from" | "to"`` so the caller can point at the offender).
+    - **200** on the happy path with the shape above.
+    - Never 5xxs: a resolver failure short-circuits to 404 so a
+      pricing-comparison tooltip keeps rendering instead of breaking.
+    """
+    p = (request.args.get("tier") or "").strip().lower()
+    f = (request.args.get("from") or "").strip().lower()
+    t = (request.args.get("to") or "").strip().lower()
+    if not p:
+        return jsonify({"error": "missing tier"}), 400
+    if not f:
+        return jsonify({"error": "missing from"}), 400
+    if not t:
+        return jsonify({"error": "missing to"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        if p not in _ent._TIER_ORDER:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "tier", "tier": p}
+                ),
+                404,
+            )
+        if f not in _ent._TIER_FEATURES:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "from", "from": f}
+                ),
+                404,
+            )
+        if t not in _ent._TIER_FEATURES:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "to", "to": t}
+                ),
+                404,
+            )
+        body = _ent.tier_diff_at(p, f, t)
+        if body is None:
+            return (
+                jsonify(
+                    {
+                        "error": "unknown tier",
+                        "tier": p,
+                        "from": f,
+                        "to": t,
+                    }
+                ),
+                404,
+            )
+        out = {
+            "perspective_tier": p,
+            "perspective_tier_rank": _ent.tier_rank(p),
+            "perspective_tier_label": _ent.tier_label(p),
+        }
+        out.update(body)
+        return jsonify(out)
+    except Exception as exc:
+        logger.warning("api_entitlement_tier_diff_at: error: %s", exc)
+        return (
+            jsonify(
+                {
+                    "error": "unknown tier",
+                    "tier": p,
+                    "from": f,
+                    "to": t,
+                }
+            ),
+            404,
+        )
+
+
 @bp_entitlement.route("/api/entitlement/tier-diff-at-batch")
 def api_entitlement_tier_diff_at_batch():
     """``GET /api/entitlement/tier-diff-at-batch?tier=<source>`` --

--- a/tests/test_entitlement_tier_diff_at.py
+++ b/tests/test_entitlement_tier_diff_at.py
@@ -1,0 +1,462 @@
+"""Tests for ``clawmetry.entitlements.tier_diff_at(perspective, from, to)``
++ the ``GET /api/entitlement/tier-diff-at`` endpoint.
+
+Fills the ``_at`` scalar slot of the ``tier_diff`` family alongside the
+existing ``tier_diff`` (arbitrary-endpoint diff) and ``tier_diff_at_batch``
+(what-if + batch fan-out over every purchasable target). Same relationship
+to :func:`tier_diff` that :func:`tier_path_at` has to :func:`tier_path`:
+the ``perspective`` argument is a URL-uniform slot so an ``_at`` scalar
+tooltip can call ``X_at(perspective, from, to)`` uniformly across
+:func:`capacity_diff_at` / :func:`tier_unlocks_at` / :func:`tier_locks_at`
+/ ``tier_diff_at``, even though ``tier_diff`` is already arbitrary-
+endpoint and the underlying diff is inherently perspective-independent.
+
+Pins:
+
+* full payload shape (from/to, direction tag, added/lost lists,
+  capacity_changes dict) delegated byte-identically to :func:`tier_diff`
+* perspective validated against :data:`_TIER_ORDER` but does NOT shape
+  rows -- ``tier_diff_at(p, f, t) == tier_diff(f, t)`` for every ``p``
+  in :data:`_TIER_ORDER` (parity invariant)
+* whitespace / case normalisation on all three ids
+* ``trial`` accepted as perspective (matches every other ``_at`` sibling)
+  AND as ``from`` / ``to`` (matches :func:`tier_diff`)
+* identity ``(from == to)`` collapses to ``direction="identity"`` with
+  empty marginal lists
+* swap-the-endpoints invariant is preserved through the ``_at`` prefix:
+  ``tier_diff_at(p, X, Y)['added_features']`` byte-equals
+  ``tier_diff_at(p, Y, X)['lost_features']`` for every valid ``p``
+* unknown perspective / from / to returns ``None`` (and ``404`` on the
+  endpoint with a ``which: "tier" | "from" | "to"`` marker)
+* never raises: a builder failure short-circuits to ``None``
+* grace vs enforce yields byte-identical rows (decoupled from resolver)
+* API surface: 400 on missing args, 404 on unknown ids with the
+  ``which`` marker, 200 on a happy path with the perspective echo on
+  top of the ``/tier-diff`` shape
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+_EXPECTED_TIER_DIFF_KEYS = {
+    "from",
+    "from_label",
+    "from_rank",
+    "to",
+    "to_label",
+    "to_rank",
+    "direction",
+    "added_features",
+    "lost_features",
+    "added_runtimes",
+    "lost_runtimes",
+    "capacity_changes",
+}
+
+_EXTRA_AT_KEYS = {
+    "perspective_tier",
+    "perspective_tier_rank",
+    "perspective_tier_label",
+}
+
+
+# ── shape ────────────────────────────────────────────────────────────────────
+
+
+def test_tier_diff_at_shape(ent):
+    body = ent.tier_diff_at(ent.TIER_TRIAL, ent.TIER_OSS, ent.TIER_CLOUD_PRO)
+    assert body is not None
+    assert set(body.keys()) == _EXPECTED_TIER_DIFF_KEYS
+    assert body["from"] == ent.TIER_OSS
+    assert body["to"] == ent.TIER_CLOUD_PRO
+    assert body["direction"] == "upgrade"
+
+
+def test_tier_diff_at_returns_dict_for_identity(ent):
+    body = ent.tier_diff_at(
+        ent.TIER_TRIAL, ent.TIER_CLOUD_PRO, ent.TIER_CLOUD_PRO
+    )
+    assert body is not None
+    assert body["direction"] == "identity"
+    assert body["added_features"] == []
+    assert body["lost_features"] == []
+    assert body["added_runtimes"] == []
+    assert body["lost_runtimes"] == []
+
+
+# ── parity vs tier_diff ──────────────────────────────────────────────────────
+
+
+def test_tier_diff_at_parity_across_every_perspective(ent):
+    """The core invariant: perspective is validated but does not shape
+    rows. For every ``p`` in :data:`_TIER_ORDER`,
+    ``tier_diff_at(p, f, t) == tier_diff(f, t)`` byte-for-byte.
+    """
+    for p in ent._TIER_ORDER:
+        for f in ent._TIER_FEATURES:
+            for t in ent._TIER_FEATURES:
+                assert ent.tier_diff_at(p, f, t) == ent.tier_diff(f, t), (
+                    p,
+                    f,
+                    t,
+                )
+
+
+def test_tier_diff_at_matches_scalar_diff_for_representative_pairs(ent):
+    for f, t in [
+        (ent.TIER_OSS, ent.TIER_CLOUD_PRO),
+        (ent.TIER_CLOUD_PRO, ent.TIER_OSS),
+        (ent.TIER_OSS, ent.TIER_ENTERPRISE),
+        (ent.TIER_ENTERPRISE, ent.TIER_OSS),
+        (ent.TIER_CLOUD_PRO, ent.TIER_PRO),  # lateral (same rank 2)
+        (ent.TIER_CLOUD_PRO, ent.TIER_CLOUD_PRO),  # identity
+        (ent.TIER_TRIAL, ent.TIER_CLOUD_PRO),
+    ]:
+        assert ent.tier_diff_at(
+            ent.TIER_CLOUD_STARTER, f, t
+        ) == ent.tier_diff(f, t)
+
+
+# ── swap-endpoints invariant preserved through _at ──────────────────────────
+
+
+def test_tier_diff_at_swap_endpoints_invariant(ent):
+    """The set-identity ``added_*`` mirrors swapped ``lost_*`` invariant
+    that :func:`tier_diff` pins holds through the ``_at`` prefix.
+    """
+    for p in ent._TIER_ORDER:
+        forward = ent.tier_diff_at(p, ent.TIER_OSS, ent.TIER_CLOUD_PRO)
+        reverse = ent.tier_diff_at(p, ent.TIER_CLOUD_PRO, ent.TIER_OSS)
+        assert forward["added_features"] == reverse["lost_features"]
+        assert forward["lost_features"] == reverse["added_features"]
+        assert forward["added_runtimes"] == reverse["lost_runtimes"]
+        assert forward["lost_runtimes"] == reverse["added_runtimes"]
+
+
+# ── direction tag ────────────────────────────────────────────────────────────
+
+
+def test_tier_diff_at_direction_upgrade(ent):
+    body = ent.tier_diff_at(ent.TIER_TRIAL, ent.TIER_OSS, ent.TIER_CLOUD_PRO)
+    assert body["direction"] == "upgrade"
+
+
+def test_tier_diff_at_direction_downgrade(ent):
+    body = ent.tier_diff_at(ent.TIER_TRIAL, ent.TIER_CLOUD_PRO, ent.TIER_OSS)
+    assert body["direction"] == "downgrade"
+
+
+def test_tier_diff_at_direction_lateral(ent):
+    body = ent.tier_diff_at(
+        ent.TIER_TRIAL, ent.TIER_CLOUD_PRO, ent.TIER_PRO
+    )
+    assert body["direction"] == "lateral"
+
+
+def test_tier_diff_at_direction_identity(ent):
+    body = ent.tier_diff_at(
+        ent.TIER_TRIAL, ent.TIER_CLOUD_PRO, ent.TIER_CLOUD_PRO
+    )
+    assert body["direction"] == "identity"
+
+
+# ── whitespace / case normalisation ─────────────────────────────────────────
+
+
+def test_tier_diff_at_normalises_perspective(ent):
+    body = ent.tier_diff_at("  Trial  ", ent.TIER_OSS, ent.TIER_CLOUD_PRO)
+    assert body is not None
+    assert body == ent.tier_diff(ent.TIER_OSS, ent.TIER_CLOUD_PRO)
+
+
+def test_tier_diff_at_normalises_from(ent):
+    body = ent.tier_diff_at(ent.TIER_TRIAL, " OSS ", ent.TIER_CLOUD_PRO)
+    assert body is not None
+    assert body["from"] == ent.TIER_OSS
+
+
+def test_tier_diff_at_normalises_to(ent):
+    body = ent.tier_diff_at(ent.TIER_TRIAL, ent.TIER_OSS, " Cloud_Pro ")
+    assert body is not None
+    assert body["to"] == ent.TIER_CLOUD_PRO
+
+
+# ── trial acceptance ────────────────────────────────────────────────────────
+
+
+def test_tier_diff_at_accepts_trial_as_perspective(ent):
+    body = ent.tier_diff_at(ent.TIER_TRIAL, ent.TIER_OSS, ent.TIER_CLOUD_PRO)
+    assert body is not None
+
+
+def test_tier_diff_at_accepts_trial_as_from(ent):
+    body = ent.tier_diff_at(
+        ent.TIER_CLOUD_PRO, ent.TIER_TRIAL, ent.TIER_ENTERPRISE
+    )
+    assert body is not None
+    assert body["from"] == ent.TIER_TRIAL
+
+
+def test_tier_diff_at_accepts_trial_as_to(ent):
+    body = ent.tier_diff_at(
+        ent.TIER_CLOUD_PRO, ent.TIER_OSS, ent.TIER_TRIAL
+    )
+    assert body is not None
+    assert body["to"] == ent.TIER_TRIAL
+
+
+# ── unknown / bad inputs ────────────────────────────────────────────────────
+
+
+def test_tier_diff_at_unknown_perspective(ent):
+    assert (
+        ent.tier_diff_at("bogus", ent.TIER_OSS, ent.TIER_CLOUD_PRO) is None
+    )
+
+
+def test_tier_diff_at_empty_perspective(ent):
+    assert ent.tier_diff_at("", ent.TIER_OSS, ent.TIER_CLOUD_PRO) is None
+
+
+def test_tier_diff_at_none_perspective(ent):
+    assert (
+        ent.tier_diff_at(None, ent.TIER_OSS, ent.TIER_CLOUD_PRO) is None
+    )
+
+
+def test_tier_diff_at_non_string_perspective(ent):
+    assert ent.tier_diff_at(123, ent.TIER_OSS, ent.TIER_CLOUD_PRO) is None
+
+
+def test_tier_diff_at_unknown_from(ent):
+    assert (
+        ent.tier_diff_at(ent.TIER_TRIAL, "bogus", ent.TIER_CLOUD_PRO)
+        is None
+    )
+
+
+def test_tier_diff_at_unknown_to(ent):
+    assert (
+        ent.tier_diff_at(ent.TIER_TRIAL, ent.TIER_OSS, "bogus") is None
+    )
+
+
+def test_tier_diff_at_empty_from(ent):
+    assert (
+        ent.tier_diff_at(ent.TIER_TRIAL, "", ent.TIER_CLOUD_PRO) is None
+    )
+
+
+def test_tier_diff_at_empty_to(ent):
+    assert ent.tier_diff_at(ent.TIER_TRIAL, ent.TIER_OSS, "") is None
+
+
+# ── grace vs enforce parity ─────────────────────────────────────────────────
+
+
+def test_tier_diff_at_byte_identical_across_grace_and_enforce(
+    ent, monkeypatch, tmp_path
+):
+    """The helper delegates to :func:`tier_diff`, which walks the static
+    per-tier maps. Grace vs enforce yields byte-identical rows.
+    """
+    grace_rows = {}
+    for p in ent._TIER_ORDER:
+        grace_rows[p] = ent.tier_diff_at(
+            p, ent.TIER_OSS, ent.TIER_CLOUD_PRO
+        )
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e2
+
+    importlib.reload(e2)
+    e2.invalidate()
+    try:
+        for p in e2._TIER_ORDER:
+            assert e2.tier_diff_at(
+                p, e2.TIER_OSS, e2.TIER_CLOUD_PRO
+            ) == grace_rows[p]
+    finally:
+        e2.invalidate()
+
+
+# ── never raises ────────────────────────────────────────────────────────────
+
+
+def test_tier_diff_at_never_raises_on_weird_inputs(ent):
+    for bad_p in [None, "", "bogus", 123, [], {}, object()]:
+        for bad_f in [None, "", "bogus", 123, [], {}]:
+            for bad_t in [None, "", "bogus", 123, [], {}]:
+                try:
+                    ent.tier_diff_at(bad_p, bad_f, bad_t)
+                except Exception as exc:  # pragma: no cover
+                    raise AssertionError(
+                        f"tier_diff_at raised on ({bad_p!r},"
+                        f" {bad_f!r}, {bad_t!r}): {exc}"
+                    )
+
+
+# ── API endpoint ────────────────────────────────────────────────────────────
+
+
+def test_endpoint_missing_tier_returns_400(client):
+    r = client.get("/api/entitlement/tier-diff-at?from=oss&to=cloud_pro")
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "missing tier"
+
+
+def test_endpoint_missing_from_returns_400(client):
+    r = client.get(
+        "/api/entitlement/tier-diff-at?tier=trial&to=cloud_pro"
+    )
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "missing from"
+
+
+def test_endpoint_missing_to_returns_400(client):
+    r = client.get("/api/entitlement/tier-diff-at?tier=trial&from=oss")
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "missing to"
+
+
+def test_endpoint_unknown_perspective_returns_404_with_which(client):
+    r = client.get(
+        "/api/entitlement/tier-diff-at?tier=bogus&from=oss&to=cloud_pro"
+    )
+    assert r.status_code == 404
+    body = r.get_json()
+    assert body["which"] == "tier"
+    assert body["tier"] == "bogus"
+
+
+def test_endpoint_unknown_from_returns_404_with_which(client):
+    r = client.get(
+        "/api/entitlement/tier-diff-at?tier=trial&from=bogus&to=cloud_pro"
+    )
+    assert r.status_code == 404
+    body = r.get_json()
+    assert body["which"] == "from"
+    assert body["from"] == "bogus"
+
+
+def test_endpoint_unknown_to_returns_404_with_which(client):
+    r = client.get(
+        "/api/entitlement/tier-diff-at?tier=trial&from=oss&to=bogus"
+    )
+    assert r.status_code == 404
+    body = r.get_json()
+    assert body["which"] == "to"
+    assert body["to"] == "bogus"
+
+
+def test_endpoint_happy_path_returns_200_with_perspective_echo(client):
+    r = client.get(
+        "/api/entitlement/tier-diff-at?tier=trial&from=oss&to=cloud_pro"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["perspective_tier"] == "trial"
+    assert body["perspective_tier_label"]
+    assert isinstance(body["perspective_tier_rank"], int)
+    assert body["from"] == "oss"
+    assert body["to"] == "cloud_pro"
+    assert body["direction"] == "upgrade"
+    assert isinstance(body["added_features"], list)
+    assert isinstance(body["capacity_changes"], dict)
+
+
+def test_endpoint_shape_matches_expected_keys(client):
+    r = client.get(
+        "/api/entitlement/tier-diff-at?tier=trial&from=oss&to=cloud_pro"
+    )
+    body = r.get_json()
+    assert (
+        set(body.keys())
+        == _EXPECTED_TIER_DIFF_KEYS | _EXTRA_AT_KEYS
+    )
+
+
+def test_endpoint_body_matches_tier_diff_endpoint_for_same_pair(client):
+    r_at = client.get(
+        "/api/entitlement/tier-diff-at?tier=trial&from=oss&to=cloud_pro"
+    ).get_json()
+    r_plain = client.get(
+        "/api/entitlement/tier-diff?from=oss&to=cloud_pro"
+    ).get_json()
+    for key in _EXPECTED_TIER_DIFF_KEYS:
+        assert r_at[key] == r_plain[key], key
+
+
+def test_endpoint_trial_perspective_accepted(client):
+    r = client.get(
+        "/api/entitlement/tier-diff-at?tier=trial&from=oss&to=enterprise"
+    )
+    assert r.status_code == 200
+    assert r.get_json()["perspective_tier"] == "trial"
+
+
+def test_endpoint_case_and_whitespace_normalisation(client):
+    r = client.get(
+        "/api/entitlement/tier-diff-at?tier=%20Trial%20&from=OSS"
+        "&to=%20cloud_pro%20"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["perspective_tier"] == "trial"
+    assert body["from"] == "oss"
+    assert body["to"] == "cloud_pro"
+
+
+def test_endpoint_identity_returns_empty_deltas(client):
+    r = client.get(
+        "/api/entitlement/tier-diff-at?tier=trial&from=cloud_pro"
+        "&to=cloud_pro"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["direction"] == "identity"
+    assert body["added_features"] == []
+    assert body["lost_features"] == []
+
+
+def test_endpoint_every_perspective_produces_200(client):
+    for p in [
+        "oss",
+        "cloud_free",
+        "trial",
+        "cloud_starter",
+        "cloud_pro",
+        "pro",
+        "enterprise",
+    ]:
+        r = client.get(
+            f"/api/entitlement/tier-diff-at?tier={p}"
+            "&from=oss&to=cloud_pro"
+        )
+        assert r.status_code == 200, (p, r.status_code, r.get_json())
+        assert r.get_json()["perspective_tier"] == p


### PR DESCRIPTION
## Summary

Fills the `_at` scalar slot of the `tier_diff` family — the last remaining unfilled `_at` slot alongside the existing arbitrary-endpoint `tier_diff` (scalar) and `tier_diff_at_batch` (walking fan-out over every purchasable target). Same relationship to `tier_diff` that `tier_path_at` (open in #3537) has to `tier_path`: perspective is validated against `_TIER_ORDER` but does NOT shape rows — `tier_diff_at(p, f, t) == tier_diff(f, t)` for every perspective `p` (parity-pinned in the test suite).

Lets a pricing-comparison tooltip surface call `X_at(perspective, from, to)` uniformly across `capacity_diff_at` / `tier_unlocks_at` / `tier_locks_at` / `tier_diff_at` off a single URL template, matching the `_at` scalar slot every other `tier_diff` family sibling already fills.

- Adds `tier_diff_at(perspective, from_tier, to_tier)` in `clawmetry/entitlements.py`, right after `tier_diff_at_batch`. Delegates to `tier_diff`; perspective validated against `_TIER_ORDER` (including `TIER_TRIAL`); whitespace / case normalised on all three ids; unknown ids short-circuit to `None`; never raises.
- Adds `GET /api/entitlement/tier-diff-at?tier=&from=&to=` in `routes/entitlement.py`, right before `/tier-diff-at-batch`.
  - **400** on missing arg
  - **404** with `which: "tier" | "from" | "to"` on unknown id (matches the `/tier-catalog-at-path` posture pinned by that endpoint's tests)
  - **200** with the `/tier-diff` shape plus `perspective_tier` / `perspective_tier_rank` / `perspective_tier_label` echoes on top so a "Comparing A vs B from perspective P" tooltip renders off one round-trip
  - Never 5xxs: a resolver failure short-circuits to 404 so a paywall surface keeps rendering.

Behavior-preserving; stays in grace. Additive endpoint; delegates to a helper that walks the static per-tier maps (via `tier_diff`), so grace vs enforce yields byte-identical rows (pinned in tests).

## Test plan

- [x] 38 new unit + endpoint tests in `tests/test_entitlement_tier_diff_at.py` — all pass locally (`pytest -q` → 38 passed)
- [x] Adjacent family regression sweep: `pytest tests/test_entitlement_tier_diff*.py tests/test_entitlement_tier_diff_at.py -q` → 162 passed
- [x] Full entitlement regression sweep: `pytest tests/ -k entitlement -q` → 4365 passed, 4 skipped (1 preexisting duckdb-dep error in `test_retention_prune.py` reproducible on `origin/main` — unrelated)
- [x] `ruff check clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_tier_diff_at.py` → All checks passed
- [x] `python3 -m py_compile` clean on all touched files
- [x] Parity pinned: for every perspective `p` in `_TIER_ORDER` (including `trial`) and every `(f, t)` pair in `_TIER_FEATURES`, `tier_diff_at(p, f, t) == tier_diff(f, t)` byte-for-byte
- [x] Swap-endpoints invariant preserved through the `_at` prefix: `tier_diff_at(p, X, Y)['added_features']` byte-equals `tier_diff_at(p, Y, X)['lost_features']` for every valid `p`
- [x] `trial` accepted as perspective (matches every other `_at` sibling) AND as `from` / `to` (matches `tier_diff`)
- [x] Whitespace / case normalisation on all three ids
- [x] Never-raises sweep over weird inputs (`None`, `int`, `list`, `dict`, `object()`, etc.)
- [x] Grace vs enforce yields byte-identical rows (pinned per-perspective)

## Local operator verification checklist

The autonomous fire that opened this PR has no access to the live daemon, the `~/.openclaw` workspace, the encrypted cloud snapshot, or a browser. The local operator needs to run these before flipping the PR to ready-for-review:

- [ ] Copy `clawmetry/entitlements.py`, `routes/entitlement.py`, `tests/test_entitlement_tier_diff_at.py` into `~/.clawmetry/lib/pythonX.Y/site-packages/clawmetry/` (or reinstall from source).
- [ ] Clear `__pycache__/` under the installed location so the new symbol is reloaded.
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` (or the equivalent daemon restart on Linux) to reload the route into the running dashboard.
- [ ] `curl 'http://localhost:8900/api/entitlement/tier-diff-at?tier=trial&from=oss&to=cloud_pro' | jq .` — verify `perspective_tier: "trial"`, `direction: "upgrade"`, populated `added_features` / `added_runtimes` / `capacity_changes` matching the resolved static per-tier maps.
- [ ] `curl 'http://localhost:8900/api/entitlement/tier-diff-at?tier=trial&from=cloud_pro&to=oss' | jq .` — verify `direction: "downgrade"`, populated `lost_features` / `lost_runtimes`.
- [ ] `curl 'http://localhost:8900/api/entitlement/tier-diff-at?tier=bogus&from=oss&to=cloud_pro'` — verify 404 with `which: "tier"`.
- [ ] `curl 'http://localhost:8900/api/entitlement/tier-diff-at?tier=trial&from=bogus&to=cloud_pro'` — verify 404 with `which: "from"`.
- [ ] `curl 'http://localhost:8900/api/entitlement/tier-diff-at?tier=trial&from=oss&to=bogus'` — verify 404 with `which: "to"`.
- [ ] Cross-check body parity: `diff <(curl -s '.../tier-diff-at?tier=trial&from=oss&to=cloud_pro' | jq 'del(.perspective_tier, .perspective_tier_rank, .perspective_tier_label)') <(curl -s '.../tier-diff?from=oss&to=cloud_pro' | jq .)` — should be empty (byte-identical minus perspective echoes).
- [ ] Decrypt the live cloud snapshot in-browser via the dashboard and confirm the endpoint renders cleanly against the real entitlement (no console errors, no 5xxs).
- [ ] Full `make test` (or targeted `pytest tests/test_entitlement_tier_diff_at.py`) in the operator's environment.

## Notes

- Branch off `origin/main`; no version bumps, no tag, no release. Draft PR only — the local operator handles verification, merge, and release per `FLYWHEEL.md`.
- Non-overlapping with the open `feat/entitlement-tier-path-at-and-batch` PR (#3537): that PR fills the `_at` slot of the `tier_path` family (walk shape); this PR fills the `_at` slot of the `tier_diff` family (scalar shape). No file overlap, no naming collision.
- The two helpers together will let a "Compare A vs B from perspective P" tooltip and a "walk A → B from perspective P" walkthrough surface hit their respective endpoints off one URL family.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q3Sk3N17Kw8Wq6CT5tMv3b)_