### PR TITLE
feat(entitlement): min_tier_batch + /api/entitlement/min-tier-batch

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -4580,6 +4580,196 @@ def affordable_tiers(
         return None
 
 
+def _min_tier_row(key, kind: str) -> dict:
+    """Per-item cheapest-tier row for :func:`min_tier_batch`.
+
+    Row-shape sibling of :func:`_lock_row` (which carries the current-
+    resolver locked / reason state per item): mirrors the same
+    ``key`` + ``kind`` + normalised value contract but carries the
+    reverse-lookup answer (``min_tier`` / ``free`` / label / rank)
+    instead of the current-resolver lock state, so a pricing-matrix
+    UI can render "each row's cheapest qualifying tier" off a batch
+    call. Kind semantics mirror :func:`_lock_row` exactly:
+
+    * ``"feature"`` / ``"runtime"`` -- ``key`` is a normalised id
+      (whitespace stripped, lowercased; runtimes additionally
+      canonicalised via :func:`canonical_runtime` so
+      ``claude-code`` -> ``claude_code``). Unknown ids get
+      ``min_tier=None`` / ``free=False`` / ``min_tier_label=None`` /
+      ``min_tier_rank=-1`` -- the caller distinguishes "unknown"
+      from "free" via the ``free`` flag.
+    * ``"channels"`` / ``"retention_days"`` / ``"nodes"`` -- ``key``
+      is int-parseable; non-int input collapses to the same all-None
+      shape. Retention passes the parsed int straight through, so
+      ``retention_days=<int>`` is treated as a finite request, not
+      the ``None`` unlimited sentinel (matches every other 5-axis
+      batch: this helper's ``None`` means "not supplied").
+
+    Never raises: any resolver failure short-circuits to the all-
+    ``None`` shape so the caller keeps rendering.
+    """
+    try:
+        if kind == "feature":
+            fid = str(key or "").strip().lower()
+            min_t = min_tier_for_feature(fid) if fid in ALL_FEATURES else None
+            key_out = fid
+        elif kind == "runtime":
+            raw = str(key or "").strip().lower()
+            rt = canonical_runtime(raw)
+            if rt and rt in ALL_RUNTIMES:
+                min_t = min_tier_for_runtime(rt)
+                key_out = rt
+            else:
+                min_t = None
+                key_out = raw
+        elif kind in ("channels", "retention_days", "nodes"):
+            try:
+                n = int(key)
+            except (TypeError, ValueError):
+                return {
+                    "key": str(key),
+                    "kind": kind,
+                    "free": False,
+                    "min_tier": None,
+                    "min_tier_label": None,
+                    "min_tier_rank": -1,
+                }
+            if kind == "channels":
+                min_t = min_tier_for_channel_count(n)
+            elif kind == "retention_days":
+                min_t = min_tier_for_retention_window(n)
+            else:
+                min_t = min_tier_for_node_count(n)
+            key_out = str(n)
+        else:
+            min_t = None
+            key_out = str(key)
+        return {
+            "key": key_out,
+            "kind": kind,
+            "free": min_t == TIER_OSS,
+            "min_tier": min_t,
+            "min_tier_label": tier_label(min_t) if min_t else None,
+            "min_tier_rank": tier_rank(min_t) if min_t else -1,
+        }
+    except Exception:
+        return {
+            "key": str(key),
+            "kind": kind,
+            "free": False,
+            "min_tier": None,
+            "min_tier_label": None,
+            "min_tier_rank": -1,
+        }
+
+
+def min_tier_batch(
+    *,
+    features=None,
+    runtimes=None,
+    channels: int | None = None,
+    retention_days: int | None = None,
+    nodes: int | None = None,
+) -> dict:
+    """Per-item cheapest qualifying tier for every supplied item across
+    all five capacity axes in one pass.
+
+    Per-item plural sibling of :func:`min_tier_for_feature` /
+    :func:`min_tier_for_runtime` / :func:`min_tier_for_channel_count` /
+    :func:`min_tier_for_retention_window` / :func:`min_tier_for_node_count`.
+    Where :func:`min_tier_for_all` / ``/api/entitlement/required-tier-batch``
+    collapse the answer to the single most-constraining tier (the floor
+    across all supplied constraints), this helper preserves the per-item
+    detail so a pricing-matrix UI ("each requested feature + runtime +
+    capacity row with its individual cheapest tier") renders off ONE
+    round-trip instead of N calls to ``/api/entitlement/min-tier``.
+
+    Envelope shape mirrors :func:`lock_reasons_batch` exactly (same
+    five-axis kwargs, same per-axis ``None`` "not supplied" sentinel,
+    same never-raise contract)::
+
+        {
+          "features":       [<row>, ...],
+          "runtimes":       [<row>, ...],
+          "channels":       <row> | None,
+          "retention_days": <row> | None,
+          "nodes":          <row> | None,
+        }
+
+    Each ``<row>`` carries ``key``, ``kind``, ``free`` (True iff
+    ``min_tier == TIER_OSS``), ``min_tier`` (``None`` for unknown /
+    unparseable input), ``min_tier_label`` and ``min_tier_rank``
+    (``-1`` when ``min_tier`` is ``None``).
+
+    Per-row parity is pinned in the test suite: for every feature
+    id ``f`` in :data:`ALL_FEATURES`,
+    ``min_tier_batch(features=[f])['features'][0]['min_tier']``
+    byte-equals :func:`min_tier_for_feature`; ditto for every id in
+    :data:`ALL_RUNTIMES` against :func:`min_tier_for_runtime`, and
+    for the three capacity axes against their singular helpers.
+
+    Feature ids are normalised via :func:`_normalise_csv` (whitespace
+    stripped, lowercased, duplicates dropped while preserving first-
+    seen order). Runtime ids additionally canonicalise via
+    :func:`canonical_runtime` so aliases (``claude-code`` ->
+    ``claude_code``) resolve the same way they do on the singular
+    ``/api/entitlement/min-tier?runtime=`` endpoint; duplicates that
+    collapse after canonicalisation only contribute one row.
+
+    Critically, ``retention_days=None`` here means *unset* -- NOT
+    *unlimited*. Same posture as :func:`min_tier_for_all` /
+    :func:`lock_reasons_batch`: asking for the unlimited-retention
+    tier is the singular :func:`min_tier_for_retention_window`
+    (``days=None``) call's job and would mis-route the batch to
+    Enterprise otherwise.
+
+    Decoupled from the resolved entitlement (walks the static per-
+    tier maps via the singular ``min_tier_for_*`` helpers), so grace
+    vs enforce yields byte-identical rows -- pinned in the test suite
+    via a grace / enforce reload roundtrip. Never raises: a per-row
+    failure short-circuits to the all-``None`` row shape so the
+    pricing UI keeps rendering.
+    """
+    try:
+        feats = _normalise_csv(features)
+        raw_rts = _normalise_csv(runtimes)
+        seen: set[str] = set()
+        rt_rows: list[dict] = []
+        for raw in raw_rts:
+            rt = canonical_runtime(raw)
+            key = rt if rt else raw
+            if key in seen:
+                continue
+            seen.add(key)
+            rt_rows.append(_min_tier_row(raw, "runtime"))
+        return {
+            "features": [_min_tier_row(f, "feature") for f in feats],
+            "runtimes": rt_rows,
+            "channels": (
+                _min_tier_row(channels, "channels")
+                if channels is not None
+                else None
+            ),
+            "retention_days": (
+                _min_tier_row(retention_days, "retention_days")
+                if retention_days is not None
+                else None
+            ),
+            "nodes": (
+                _min_tier_row(nodes, "nodes") if nodes is not None else None
+            ),
+        }
+    except Exception as exc:
+        logger.warning("entitlements: min_tier_batch failed: %s", exc)
+        return {
+            "features": [],
+            "runtimes": [],
+            "channels": None,
+            "retention_days": None,
+            "nodes": None,
+        }
+
+
 def lock_reason(item: str, *, kind: str | None = None) -> str | None:
     try:
         return get_entitlement().lock_reason(item, kind=kind)

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -4668,6 +4668,113 @@ def api_entitlement_min_tier():
         )
 
 
+@bp_entitlement.route("/api/entitlement/min-tier-batch")
+def api_entitlement_min_tier_batch():
+    """``GET /api/entitlement/min-tier-batch?features=a,b,c&runtimes=x,y
+    &channels=N&retention_days=K&nodes=M`` -- per-item plural sibling of
+    ``/api/entitlement/min-tier``.
+
+    Where ``/required-tier-batch`` aggregates the most-constraining axis
+    into one tier answer, this preserves the per-item detail so a
+    pricing-matrix UI ("show me each requested feature + runtime +
+    capacity row with its individual cheapest tier") renders off ONE
+    round-trip instead of N calls to ``/min-tier``. Wraps
+    :func:`clawmetry.entitlements.min_tier_batch` and appends the same
+    ``current_tier`` / ``grace`` / ``enforced`` envelope
+    ``/lock-reason-batch`` returns so a caller sees the same resolver
+    context alongside the per-item answers.
+
+    At least one of ``features=`` / ``runtimes=`` / ``channels=`` /
+    ``retention_days=`` / ``nodes=`` must be supplied (non-empty /
+    parseable after normalisation). ``features=`` / ``runtimes=`` take
+    comma-separated tokens (whitespace and duplicates are normalised
+    away; runtime aliases like ``claude-code`` canonicalise to
+    ``claude_code``; unknown ids contribute an all-``None`` row --
+    they do not error). The three capacity axes take a single int
+    each; a blank or non-int value is treated as "not supplied"
+    (matches the singular endpoint's never-crash posture rather than
+    mis-routing a typo to Enterprise). Never 5xxs: the grace-shape
+    envelope is returned on any resolver failure.
+
+    Response shape::
+
+        {
+          "features":       [<row>, ...],
+          "runtimes":       [<row>, ...],
+          "channels":       <row> | None,
+          "retention_days": <row> | None,
+          "nodes":          <row> | None,
+          "current_tier":       "...",
+          "current_tier_rank":  <int>,
+          "grace":              <bool>,
+          "enforced":           <bool>,
+        }
+
+    Each ``<row>`` carries ``key``, ``kind``, ``free``, ``min_tier``,
+    ``min_tier_label`` and ``min_tier_rank`` (``-1`` when
+    ``min_tier`` is ``None``). Per-row parity with the singular
+    ``/min-tier?feature=`` / ``?runtime=`` endpoint is pinned in the
+    test suite so the batch cannot silently drift from the scalar.
+    """
+    try:
+        from clawmetry import entitlements as _ent
+
+        features = _parse_csv_arg("features")
+        runtimes = _parse_csv_arg("runtimes")
+        (_, channels_ok, channels_n, _) = _parse_capacity_arg("channels")
+        (_, retention_ok, retention_n, _) = _parse_capacity_arg("retention_days")
+        (_, nodes_ok, nodes_n, _) = _parse_capacity_arg("nodes")
+
+        if (
+            not features
+            and not runtimes
+            and not channels_ok
+            and not retention_ok
+            and not nodes_ok
+        ):
+            return (
+                jsonify(
+                    {
+                        "error": (
+                            "supply at least one of features=<csv>, "
+                            "runtimes=<csv>, channels=<int>, "
+                            "retention_days=<int>, or nodes=<int>"
+                        )
+                    }
+                ),
+                400,
+            )
+
+        batch = _ent.min_tier_batch(
+            features=features or None,
+            runtimes=runtimes or None,
+            channels=channels_n if channels_ok else None,
+            retention_days=retention_n if retention_ok else None,
+            nodes=nodes_n if nodes_ok else None,
+        )
+        ent = _ent.get_entitlement()
+        batch["current_tier"] = ent.tier
+        batch["current_tier_rank"] = _ent.tier_rank(ent.tier)
+        batch["grace"] = bool(ent.grace)
+        batch["enforced"] = _ent.is_enforced()
+        return jsonify(batch)
+    except Exception as exc:
+        logger.warning("api_entitlement_min_tier_batch: error: %s", exc)
+        return jsonify(
+            {
+                "features": [],
+                "runtimes": [],
+                "channels": None,
+                "retention_days": None,
+                "nodes": None,
+                "current_tier": "oss",
+                "current_tier_rank": 0,
+                "grace": True,
+                "enforced": False,
+            }
+        )
+
+
 @bp_entitlement.route("/api/entitlement/lock-reason-batch")
 def api_entitlement_lock_reason_batch():
     """``GET /api/entitlement/lock-reason-batch?features=a,b,c&runtimes=x,y

--- a/tests/test_entitlement_min_tier_batch.py
+++ b/tests/test_entitlement_min_tier_batch.py
@@ -1,0 +1,435 @@
+"""Tests for ``clawmetry.entitlements.min_tier_batch`` and the
+``GET /api/entitlement/min-tier-batch`` endpoint.
+
+Per-item plural sibling of :func:`min_tier_for_feature` /
+:func:`min_tier_for_runtime` / :func:`min_tier_for_channel_count` /
+:func:`min_tier_for_retention_window` / :func:`min_tier_for_node_count`.
+Where :func:`min_tier_for_all` / ``/api/entitlement/required-tier-batch``
+collapse the answer to the single most-constraining tier, this surface
+preserves the per-item detail so a pricing-matrix UI ("show me each
+requested feature + runtime + capacity row with its individual cheapest
+tier") renders off ONE round-trip instead of N calls to
+``/api/entitlement/min-tier``.
+
+These tests pin:
+
+* full response shape (per-axis rows, envelope keys, row fields)
+* per-row parity with the singular ``min_tier_for_*`` helpers across
+  every feature id in :data:`ALL_FEATURES`, every runtime id in
+  :data:`ALL_RUNTIMES`, and the three capacity axes
+* runtime canonicalisation (``claude-code`` -> ``claude_code``)
+* dedup after canonicalisation
+* unknown ids contribute an all-``None`` row (rather than raising)
+* ``retention_days=None`` means unset, NOT unlimited
+* grace vs enforce yields byte-identical rows (helper is decoupled
+  from the resolver)
+* never-raises contract
+* API: 400 on no axis supplied, 200 with the batch shape + resolver
+  envelope on happy path
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+_EXPECTED_ROW_KEYS = {
+    "key",
+    "kind",
+    "free",
+    "min_tier",
+    "min_tier_label",
+    "min_tier_rank",
+}
+
+
+# ── min_tier_batch -- shape ─────────────────────────────────────────────────
+
+
+def test_helper_returns_envelope_with_five_axes(ent):
+    out = ent.min_tier_batch(
+        features=["fleet", "sso"],
+        runtimes=["claude_code"],
+        channels=5,
+        retention_days=30,
+        nodes=3,
+    )
+    assert set(out.keys()) == {
+        "features",
+        "runtimes",
+        "channels",
+        "retention_days",
+        "nodes",
+    }
+    assert isinstance(out["features"], list)
+    assert isinstance(out["runtimes"], list)
+    for axis in ("channels", "retention_days", "nodes"):
+        assert isinstance(out[axis], dict)
+
+
+def test_helper_row_shape(ent):
+    out = ent.min_tier_batch(features=["fleet"])
+    row = out["features"][0]
+    assert set(row.keys()) == _EXPECTED_ROW_KEYS
+    assert row["kind"] == "feature"
+
+
+def test_helper_no_inputs_returns_empty_shape(ent):
+    out = ent.min_tier_batch()
+    assert out["features"] == []
+    assert out["runtimes"] == []
+    assert out["channels"] is None
+    assert out["retention_days"] is None
+    assert out["nodes"] is None
+
+
+# ── min_tier_batch -- per-row parity with singular helpers ─────────────────
+
+
+def test_feature_rows_match_singular_helper(ent):
+    """Every feature id in ALL_FEATURES must have a batch row whose
+    min_tier is byte-identical to :func:`min_tier_for_feature`."""
+    for fid in sorted(ent.ALL_FEATURES):
+        out = ent.min_tier_batch(features=[fid])
+        assert len(out["features"]) == 1
+        row = out["features"][0]
+        assert row["key"] == fid
+        assert row["min_tier"] == ent.min_tier_for_feature(fid)
+        assert row["free"] is (row["min_tier"] == ent.TIER_OSS)
+        if row["min_tier"]:
+            assert row["min_tier_label"] == ent.tier_label(row["min_tier"])
+            assert row["min_tier_rank"] == ent.tier_rank(row["min_tier"])
+        else:
+            assert row["min_tier_label"] is None
+            assert row["min_tier_rank"] == -1
+
+
+def test_runtime_rows_match_singular_helper(ent):
+    for rt in sorted(ent.ALL_RUNTIMES):
+        out = ent.min_tier_batch(runtimes=[rt])
+        assert len(out["runtimes"]) == 1
+        row = out["runtimes"][0]
+        assert row["key"] == rt
+        assert row["min_tier"] == ent.min_tier_for_runtime(rt)
+        assert row["free"] is (row["min_tier"] == ent.TIER_OSS)
+
+
+def test_channels_row_matches_singular_helper(ent):
+    for n in (0, 1, 3, 5, 25, 100, 10000):
+        out = ent.min_tier_batch(channels=n)
+        assert out["channels"]["min_tier"] == ent.min_tier_for_channel_count(n)
+        assert out["channels"]["key"] == str(n)
+        assert out["channels"]["kind"] == "channels"
+
+
+def test_retention_row_matches_singular_helper(ent):
+    for days in (0, 1, 7, 30, 90, 365, 3650):
+        out = ent.min_tier_batch(retention_days=days)
+        assert out["retention_days"]["min_tier"] == (
+            ent.min_tier_for_retention_window(days)
+        )
+        assert out["retention_days"]["key"] == str(days)
+
+
+def test_nodes_row_matches_singular_helper(ent):
+    for n in (0, 1, 3, 5, 25, 100, 10000):
+        out = ent.min_tier_batch(nodes=n)
+        assert out["nodes"]["min_tier"] == ent.min_tier_for_node_count(n)
+        assert out["nodes"]["key"] == str(n)
+
+
+# ── min_tier_batch -- runtime canonicalisation + dedup ─────────────────────
+
+
+def test_runtime_alias_canonicalises(ent):
+    out = ent.min_tier_batch(runtimes=["claude-code"])
+    assert len(out["runtimes"]) == 1
+    assert out["runtimes"][0]["key"] == "claude_code"
+    assert out["runtimes"][0]["min_tier"] == ent.min_tier_for_runtime(
+        "claude_code"
+    )
+
+
+def test_runtime_alias_dedups_against_canonical(ent):
+    out = ent.min_tier_batch(runtimes=["claude-code", "claude_code"])
+    assert len(out["runtimes"]) == 1
+    assert out["runtimes"][0]["key"] == "claude_code"
+
+
+# ── min_tier_batch -- unknown ids ──────────────────────────────────────────
+
+
+def test_unknown_feature_returns_all_none_row(ent):
+    out = ent.min_tier_batch(features=["definitely_not_a_feature"])
+    assert len(out["features"]) == 1
+    row = out["features"][0]
+    assert row["key"] == "definitely_not_a_feature"
+    assert row["min_tier"] is None
+    assert row["free"] is False
+    assert row["min_tier_label"] is None
+    assert row["min_tier_rank"] == -1
+
+
+def test_unknown_runtime_returns_all_none_row(ent):
+    out = ent.min_tier_batch(runtimes=["definitely_not_a_runtime"])
+    assert len(out["runtimes"]) == 1
+    row = out["runtimes"][0]
+    assert row["min_tier"] is None
+    assert row["free"] is False
+
+
+def test_non_int_capacity_returns_all_none_row(ent):
+    out = ent.min_tier_batch(channels="oops")
+    assert out["channels"]["min_tier"] is None
+    assert out["channels"]["free"] is False
+    assert out["channels"]["min_tier_rank"] == -1
+
+
+# ── min_tier_batch -- input normalisation ─────────────────────────────────
+
+
+def test_features_are_lowercased_and_deduped(ent):
+    out = ent.min_tier_batch(features=["FLEET", " fleet ", "sso", "fleet"])
+    keys = [r["key"] for r in out["features"]]
+    assert keys == ["fleet", "sso"]
+
+
+def test_features_accepts_csv_string(ent):
+    out = ent.min_tier_batch(features="fleet,sso")
+    keys = [r["key"] for r in out["features"]]
+    assert keys == ["fleet", "sso"]
+
+
+# ── min_tier_batch -- unset vs unlimited ──────────────────────────────────
+
+
+def test_retention_none_means_unset_not_unlimited(ent):
+    """``retention_days=None`` here means axis-not-supplied, NOT the
+    unlimited sentinel that would mis-route to Enterprise."""
+    out = ent.min_tier_batch(retention_days=None)
+    assert out["retention_days"] is None
+
+
+def test_channels_none_means_unset(ent):
+    out = ent.min_tier_batch(channels=None)
+    assert out["channels"] is None
+
+
+def test_nodes_none_means_unset(ent):
+    out = ent.min_tier_batch(nodes=None)
+    assert out["nodes"] is None
+
+
+# ── min_tier_batch -- grace vs enforce parity ──────────────────────────────
+
+
+def test_grace_vs_enforce_yields_byte_identical_rows(monkeypatch, tmp_path):
+    """The helper walks the static per-tier maps via the singular
+    ``min_tier_for_*`` helpers, so grace vs enforce yields byte-identical
+    rows -- a pricing-page must render the same numbers on both sides of
+    the enforcement cutover."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    import clawmetry.entitlements as e_grace
+
+    importlib.reload(e_grace)
+    e_grace.invalidate()
+    grace_out = e_grace.min_tier_batch(
+        features=sorted(e_grace.ALL_FEATURES),
+        runtimes=sorted(e_grace.ALL_RUNTIMES),
+        channels=5,
+        retention_days=30,
+        nodes=3,
+    )
+    e_grace.invalidate()
+
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    import clawmetry.entitlements as e_enf
+
+    importlib.reload(e_enf)
+    e_enf.invalidate()
+    enf_out = e_enf.min_tier_batch(
+        features=sorted(e_enf.ALL_FEATURES),
+        runtimes=sorted(e_enf.ALL_RUNTIMES),
+        channels=5,
+        retention_days=30,
+        nodes=3,
+    )
+    e_enf.invalidate()
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+
+    assert grace_out == enf_out
+
+
+# ── min_tier_batch -- never raises ─────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "features,runtimes,channels,retention_days,nodes",
+    [
+        (None, None, None, None, None),
+        ([], [], None, None, None),
+        ([""], [""], None, None, None),
+        (["fleet", None, ""], ["claude_code"], "oops", "oops", "oops"),
+        (["FLEET"], ["CLAUDE-CODE"], -1, -1, -1),
+        (object(), object(), None, None, None),
+        ("fleet,sso", "claude_code,codex", 5, 30, 3),
+    ],
+)
+def test_helper_never_raises(ent, features, runtimes, channels, retention_days, nodes):
+    try:
+        out = ent.min_tier_batch(
+            features=features,
+            runtimes=runtimes,
+            channels=channels,
+            retention_days=retention_days,
+            nodes=nodes,
+        )
+    except Exception:  # pragma: no cover
+        pytest.fail("min_tier_batch must not raise")
+    assert set(out.keys()) == {
+        "features",
+        "runtimes",
+        "channels",
+        "retention_days",
+        "nodes",
+    }
+
+
+# ── /api/entitlement/min-tier-batch ────────────────────────────────────────
+
+
+def test_endpoint_400_on_no_axis(client):
+    r = client.get("/api/entitlement/min-tier-batch")
+    assert r.status_code == 400
+    body = r.get_json()
+    assert "error" in body
+
+
+def test_endpoint_happy_path_features(client):
+    r = client.get(
+        "/api/entitlement/min-tier-batch?features=fleet,sso"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert set(body.keys()) >= {
+        "features",
+        "runtimes",
+        "channels",
+        "retention_days",
+        "nodes",
+        "current_tier",
+        "current_tier_rank",
+        "grace",
+        "enforced",
+    }
+    assert [r["key"] for r in body["features"]] == ["fleet", "sso"]
+    assert body["runtimes"] == []
+    assert body["channels"] is None
+
+
+def test_endpoint_happy_path_all_axes(client):
+    r = client.get(
+        "/api/entitlement/min-tier-batch"
+        "?features=fleet"
+        "&runtimes=claude_code"
+        "&channels=5"
+        "&retention_days=30"
+        "&nodes=3"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["features"][0]["key"] == "fleet"
+    assert body["runtimes"][0]["key"] == "claude_code"
+    assert body["channels"]["key"] == "5"
+    assert body["retention_days"]["key"] == "30"
+    assert body["nodes"]["key"] == "3"
+
+
+def test_endpoint_runtime_alias_canonicalises(client):
+    r = client.get(
+        "/api/entitlement/min-tier-batch?runtimes=claude-code"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["runtimes"][0]["key"] == "claude_code"
+
+
+def test_endpoint_unknown_id_does_not_500(client):
+    r = client.get(
+        "/api/entitlement/min-tier-batch"
+        "?features=definitely_not_a_feature"
+        "&runtimes=definitely_not_a_runtime"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["features"][0]["min_tier"] is None
+    assert body["features"][0]["free"] is False
+    assert body["runtimes"][0]["min_tier"] is None
+
+
+def test_endpoint_non_int_capacity_treated_as_unsupplied(client):
+    """Blank / non-int capacity args must be treated as "not supplied"
+    (mirrors the singular endpoint's never-crash posture) rather than
+    mis-routing a typo to Enterprise."""
+    r = client.get(
+        "/api/entitlement/min-tier-batch"
+        "?features=fleet&channels=oops&retention_days=&nodes=oops"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["channels"] is None
+    assert body["retention_days"] is None
+    assert body["nodes"] is None
+
+
+def test_endpoint_per_row_parity_with_singular_min_tier(client, ent):
+    """Each batch row's ``min_tier`` must byte-equal the singular
+    ``/api/entitlement/min-tier?feature=<id>`` response for the same id.
+    Pins the batch against the scalar so they can never silently
+    drift."""
+    for fid in sorted(ent.ALL_FEATURES):
+        batch = client.get(
+            f"/api/entitlement/min-tier-batch?features={fid}"
+        ).get_json()
+        singular = client.get(
+            f"/api/entitlement/min-tier?feature={fid}"
+        ).get_json()
+        assert batch["features"][0]["min_tier"] == singular["min_tier"]
+        assert batch["features"][0]["free"] == singular["free"]
+
+
+def test_endpoint_carries_resolver_envelope(client, ent):
+    r = client.get(
+        "/api/entitlement/min-tier-batch?features=fleet"
+    )
+    body = r.get_json()
+    live = ent.get_entitlement()
+    assert body["current_tier"] == live.tier
+    assert body["current_tier_rank"] == ent.tier_rank(live.tier)
+    assert body["grace"] == bool(live.grace)
+    assert body["enforced"] == ent.is_enforced()


### PR DESCRIPTION
## Summary

Fills the per-item batch slot of the `min_tier_for_*` family. Where `min_tier_for_all` / `/api/entitlement/required-tier-batch` collapse the answer to the single most-constraining tier (the floor across all supplied constraints), this preserves the per-item detail so a pricing-matrix UI — "show me each requested feature + runtime + capacity row with its individual cheapest tier" — renders off ONE round-trip instead of N calls to `/api/entitlement/min-tier`.

Same relationship to `min_tier_for_feature` / `min_tier_for_runtime` / `min_tier_for_channel_count` / `min_tier_for_retention_window` / `min_tier_for_node_count` that `lock_reasons_batch` has to `lock_reason`: same 5-axis kwargs, same per-axis `None` "not supplied" sentinel, same never-raise contract, same envelope shape — but carrying the reverse-lookup answer (`min_tier` / `free` / label / rank) instead of the current-resolver lock state.

- Adds `_min_tier_row(key, kind)` in `clawmetry/entitlements.py` right after `affordable_tiers`. Row-shape sibling of `_lock_row` — mirrors the same `key` + `kind` + normalised value contract but carries the reverse-lookup answer instead of the resolver-relative lock state.
- Adds `min_tier_batch(*, features, runtimes, channels, retention_days, nodes)` right after `_min_tier_row`. Envelope mirrors `lock_reasons_batch` exactly. Runtime ids are canonicalised via `canonical_runtime` so aliases (`claude-code` → `claude_code`) resolve the same way they do on the singular `/min-tier?runtime=` endpoint; duplicates that collapse after canonicalisation only contribute one row. `retention_days=None` means *unset*, NOT *unlimited* (matches `min_tier_for_all` / `lock_reasons_batch`).
- Adds `GET /api/entitlement/min-tier-batch` in `routes/entitlement.py` right after `/api/entitlement/min-tier`, before `/api/entitlement/lock-reason-batch`.
  - **400** on no axis supplied
  - **200** with the batch shape plus the same `current_tier` / `current_tier_rank` / `grace` / `enforced` envelope `/lock-reason-batch` returns
  - Non-int capacity args treated as "not supplied" (matches the singular endpoint's never-crash posture rather than mis-routing a typo to Enterprise)
  - Never 5xxs: the grace-shape envelope is returned on any resolver failure.

Behaviour-preserving; stays in grace. Additive helper + endpoint; delegates to the singular `min_tier_for_*` helpers that walk the static per-tier maps, so grace vs enforce yields byte-identical rows (pinned in tests).

## Test plan

- [x] 34 new unit + endpoint tests in `tests/test_entitlement_min_tier_batch.py` — all pass locally (`pytest -q` → 34 passed in 0.63s)
- [x] Full entitlement regression sweep: `pytest tests/ -k "min_tier or entitlement" -q` → 4430 passed, 4 skipped (1 preexisting duckdb-dep error in `test_retention_prune.py` reproducible on `origin/main` — unrelated)
- [x] `ruff check clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_min_tier_batch.py` → All checks passed
- [x] `python3 -m py_compile` clean on all touched files
- [x] Per-row parity pinned: for every id `f` in `ALL_FEATURES`, `min_tier_batch(features=[f])['features'][0]['min_tier']` byte-equals `min_tier_for_feature(f)`; ditto for every id in `ALL_RUNTIMES` against `min_tier_for_runtime`, and for the three capacity axes against their singular helpers
- [x] Endpoint per-row parity pinned: `/min-tier-batch?features=<id>` batch row byte-equals `/min-tier?feature=<id>` singular row for every id in `ALL_FEATURES`
- [x] Runtime alias canonicalisation pinned: `min_tier_batch(runtimes=['claude-code'])` returns one row keyed `'claude_code'`
- [x] Alias dedup pinned: `min_tier_batch(runtimes=['claude-code', 'claude_code'])` returns one row
- [x] Unknown ids contribute an all-`None` row (`min_tier=None`, `free=False`, `min_tier_label=None`, `min_tier_rank=-1`) rather than raising
- [x] `retention_days=None` means unset (not unlimited) — pinned in helper and endpoint
- [x] Grace vs enforce yields byte-identical rows (pinned via a grace/enforce reload roundtrip)
- [x] Never-raises sweep over weird inputs (`None`, empty, non-iterable `object()`, mixed casing, etc.)

## Local operator verification checklist

The autonomous fire that opened this PR has no access to the live daemon, the `~/.openclaw` workspace, the encrypted cloud snapshot, or a browser. The local operator needs to run these before flipping the PR to ready-for-review:

- [ ] Copy `clawmetry/entitlements.py`, `routes/entitlement.py`, `tests/test_entitlement_min_tier_batch.py` into `~/.clawmetry/lib/pythonX.Y/site-packages/clawmetry/` (or reinstall from source).
- [ ] Clear `__pycache__/` under the installed location so the new symbol is reloaded.
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` (or the equivalent daemon restart on Linux) to reload the route into the running dashboard.
- [ ] `curl 'http://localhost:8900/api/entitlement/min-tier-batch?features=fleet,sso&runtimes=claude_code&channels=5&retention_days=30&nodes=3' | jq .` — verify per-axis rows populated with `key` / `kind` / `free` / `min_tier` / `min_tier_label` / `min_tier_rank`, plus the `current_tier` / `current_tier_rank` / `grace` / `enforced` envelope.
- [ ] `curl 'http://localhost:8900/api/entitlement/min-tier-batch?runtimes=claude-code' | jq .runtimes` — verify the alias canonicalises to `claude_code`.
- [ ] `curl 'http://localhost:8900/api/entitlement/min-tier-batch?features=definitely_not_a_feature' | jq .features` — verify the unknown id returns an all-`None` row (200, not 5xx).
- [ ] `curl 'http://localhost:8900/api/entitlement/min-tier-batch?features=fleet&channels=oops&retention_days=&nodes=oops' | jq .` — verify non-int capacity args are treated as "not supplied" (channels / retention_days / nodes all `null`), not mis-routed to Enterprise.
- [ ] `curl -w '\n%{http_code}\n' 'http://localhost:8900/api/entitlement/min-tier-batch'` — verify 400 on no axis supplied.
- [ ] Cross-check per-row parity: `diff <(curl -s '.../min-tier-batch?features=fleet' | jq '.features[0].min_tier') <(curl -s '.../min-tier?feature=fleet' | jq '.min_tier')` — should be empty (batch row byte-equals singular).
- [ ] Decrypt the live cloud snapshot in-browser via the dashboard and confirm the endpoint renders cleanly against the real entitlement (no console errors, no 5xxs).
- [ ] Full `make test` (or targeted `pytest tests/test_entitlement_min_tier_batch.py`) in the operator's environment.

## Notes

- Branch off `origin/main`; no version bumps, no tag, no release. Draft PR only — the local operator handles verification, merge, and release per `FLYWHEEL.md`.
- Non-overlapping with the open `feat/entitlement-tier-diff-at` PR (#3541): that PR fills the `_at` scalar slot of the `tier_diff` family; this PR fills the per-item batch slot of the `min_tier_for_*` family (distinct family, distinct file lines, no naming collision).
- Complements `/required-tier-batch` (aggregate — one required_tier for the whole 5-axis input) and `/lock-reason-batch` (per-item resolver-relative lock reasons). The three together give a pricing-matrix UI the aggregate floor, the per-row minima, and the per-row current-lock state off three parallel batches on the same 5-axis input shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015bp37q1RkVM1vAuvKBpqT5)_