### PR TITLE
feat(ar): Agent Resources data layer — two DuckDB tables + 5 CRUD methods

### DIFF
--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -472,6 +472,35 @@ _DDL = [
     )
     """,
     "CREATE INDEX IF NOT EXISTS idx_alert_rules_owner ON alert_rules(owner_hash, enabled)",
+    # Agent Resources (AR) framework — issue #1713. Data layer only; the
+    # evaluator, API routes, and UI follow in subsequent PRs once the
+    # Greenlight checklist decisions (tab name, confirmation modal, tier CTA)
+    # are signed off.
+    """
+    CREATE TABLE IF NOT EXISTS agent_resources_rules (
+        id               VARCHAR PRIMARY KEY,
+        enabled          BOOLEAN NOT NULL DEFAULT TRUE,
+        name             VARCHAR NOT NULL,
+        trigger_type     VARCHAR NOT NULL,
+        threshold        REAL,
+        window_seconds   INTEGER,
+        action_type      VARCHAR NOT NULL,
+        cooldown_seconds INTEGER NOT NULL DEFAULT 300,
+        created_at       BIGINT NOT NULL
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS agent_resources_history (
+        id           VARCHAR PRIMARY KEY,
+        rule_id      VARCHAR NOT NULL,
+        session_id   VARCHAR,
+        triggered_at BIGINT NOT NULL,
+        action_type  VARCHAR NOT NULL,
+        detail_json  VARCHAR
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_ar_history_rule ON agent_resources_history(rule_id)",
+    "CREATE INDEX IF NOT EXISTS idx_ar_history_session ON agent_resources_history(session_id, triggered_at)",
     # Shared by OpenClaw subagents + Claude Code Task tool.
     """
     CREATE TABLE IF NOT EXISTS subagents (
@@ -3003,6 +3032,82 @@ class LocalStore:
         with self._write_lock:
             self._conn.execute("DELETE FROM alert_rules WHERE id = ?", [rid])
         return 1
+
+    # ── Agent Resources rules + history (issue #1713) ────────────────────
+
+    def persist_ar_rule(self, rule: dict) -> None:
+        """Upsert one Agent Resources rule. Required: ``id``, ``name``,
+        ``trigger_type``, ``action_type``, ``created_at``."""
+        rid = rule.get("id")
+        if not rid:
+            raise ValueError("agent_resources rule must include 'id'")
+        enabled = rule.get("enabled")
+        enabled = True if enabled is None else bool(enabled)
+        with self._write_lock:
+            self._conn.execute("""
+                INSERT INTO agent_resources_rules (
+                    id, enabled, name, trigger_type, threshold,
+                    window_seconds, action_type, cooldown_seconds, created_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT (id) DO UPDATE SET
+                    enabled          = excluded.enabled,
+                    name             = COALESCE(excluded.name, agent_resources_rules.name),
+                    trigger_type     = COALESCE(excluded.trigger_type, agent_resources_rules.trigger_type),
+                    threshold        = excluded.threshold,
+                    window_seconds   = excluded.window_seconds,
+                    action_type      = COALESCE(excluded.action_type, agent_resources_rules.action_type),
+                    cooldown_seconds = excluded.cooldown_seconds
+            """, [
+                str(rid),
+                enabled,
+                rule.get("name", ""),
+                rule.get("trigger_type", ""),
+                rule.get("threshold"),
+                rule.get("window_seconds"),
+                rule.get("action_type", ""),
+                int(rule.get("cooldown_seconds") or 300),
+                int(rule.get("created_at") or 0),
+            ])
+
+    def delete_ar_rule(self, rule_id: str) -> int:
+        """Delete one Agent Resources rule by id. Returns 1 on delete, 0 when missing."""
+        if not rule_id:
+            return 0
+        rid = str(rule_id)
+        rows_before = self._fetch(
+            "SELECT 1 FROM agent_resources_rules WHERE id = ? LIMIT 1", [rid]
+        )
+        if not rows_before:
+            return 0
+        with self._write_lock:
+            self._conn.execute("DELETE FROM agent_resources_rules WHERE id = ?", [rid])
+        return 1
+
+    def log_ar_history(self, entry: dict) -> None:
+        """Append one Agent Resources history row. Required: ``id``,
+        ``rule_id``, ``triggered_at``, ``action_type``.
+
+        ``detail_json`` may be a dict/list (serialised to JSON) or a string."""
+        eid = entry.get("id")
+        if not eid:
+            raise ValueError("agent_resources_history entry must include 'id'")
+        detail = entry.get("detail_json")
+        if isinstance(detail, (dict, list)):
+            detail = json.dumps(detail)
+        with self._write_lock:
+            self._conn.execute("""
+                INSERT INTO agent_resources_history (
+                    id, rule_id, session_id, triggered_at, action_type, detail_json
+                ) VALUES (?, ?, ?, ?, ?, ?)
+                ON CONFLICT (id) DO NOTHING
+            """, [
+                str(eid),
+                str(entry.get("rule_id", "")),
+                entry.get("session_id"),
+                int(entry.get("triggered_at") or 0),
+                str(entry.get("action_type", "")),
+                detail,
+            ])
 
     # ── Per-agent budgets (issue #951) ───────────────────────────────────
 
@@ -7350,6 +7455,69 @@ class LocalStore:
                         d["condition_json"] = text
                 except UnicodeDecodeError:
                     d["condition_json"] = None
+            out.append(d)
+        return out
+
+    def list_ar_rules(
+        self,
+        *,
+        enabled_only: bool = False,
+        limit: int = 200,
+    ) -> list[dict]:
+        """Read Agent Resources rules, newest first."""
+        clauses: list[str] = []
+        params: list = []
+        if enabled_only:
+            clauses.append("enabled = TRUE")
+        where = ("WHERE " + " AND ".join(clauses)) if clauses else ""
+        sql = f"""
+            SELECT id, enabled, name, trigger_type, threshold,
+                   window_seconds, action_type, cooldown_seconds, created_at
+            FROM agent_resources_rules
+            {where}
+            ORDER BY created_at DESC NULLS LAST, id
+            LIMIT ?
+        """
+        params.append(int(limit))
+        cols = ["id", "enabled", "name", "trigger_type", "threshold",
+                "window_seconds", "action_type", "cooldown_seconds", "created_at"]
+        return [dict(zip(cols, r)) for r in self._fetch(sql, params)]
+
+    def query_ar_history(
+        self,
+        *,
+        session_id: str | None = None,
+        rule_id: str | None = None,
+        limit: int = 50,
+    ) -> list[dict]:
+        """Read Agent Resources history rows, most recent first."""
+        clauses: list[str] = []
+        params: list = []
+        if session_id:
+            clauses.append("session_id = ?")
+            params.append(session_id)
+        if rule_id:
+            clauses.append("rule_id = ?")
+            params.append(rule_id)
+        where = ("WHERE " + " AND ".join(clauses)) if clauses else ""
+        sql = f"""
+            SELECT id, rule_id, session_id, triggered_at, action_type, detail_json
+            FROM agent_resources_history
+            {where}
+            ORDER BY triggered_at DESC NULLS LAST, id
+            LIMIT ?
+        """
+        params.append(int(limit))
+        cols = ["id", "rule_id", "session_id", "triggered_at", "action_type", "detail_json"]
+        out: list[dict] = []
+        for r in self._fetch(sql, params):
+            d = dict(zip(cols, r))
+            raw = d.get("detail_json")
+            if raw:
+                try:
+                    d["detail_json"] = json.loads(raw)
+                except (ValueError, TypeError):
+                    pass
             out.append(d)
         return out
 

--- a/routes/local_query.py
+++ b/routes/local_query.py
@@ -796,6 +796,13 @@ _DAEMON_METHODS = frozenset({
     # to silently fall back to direct DuckDB open on multi-process installs).
     "query_authority_violations",
     "query_session_authority_counts",
+    # Issue #1713 — Agent Resources (AR) framework data layer. Routed through
+    # the daemon proxy so the dashboard process never grabs the DuckDB writer lock.
+    "persist_ar_rule",
+    "delete_ar_rule",
+    "log_ar_history",
+    "list_ar_rules",
+    "query_ar_history",
 })
 
 

--- a/tests/test_ar_framework.py
+++ b/tests/test_ar_framework.py
@@ -1,0 +1,172 @@
+"""Data-layer tests for the Agent Resources (AR) framework — issue #1713.
+
+Covers the two new DuckDB tables (agent_resources_rules, agent_resources_history)
+and the five CRUD methods added to LocalStore, plus _DAEMON_METHODS membership
+for the daemon proxy allowlist.
+"""
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+import time
+
+import pytest
+
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+
+# ── Fixtures ───────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def fresh_store(tmp_path, monkeypatch):
+    """Fresh DuckDB-backed LocalStore for each test. Yields (module, store)."""
+    monkeypatch.setenv(
+        "CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "ar_test.duckdb")
+    )
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_BATCH", "1")
+
+    sys.modules.pop("clawmetry.local_store", None)
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+
+    store = ls.get_store()
+    yield ls, store
+
+    try:
+        store.stop(flush=False)
+    except Exception:
+        pass
+
+
+def _rule(rule_id: str = "r-001", **kwargs) -> dict:
+    return {
+        "id": rule_id,
+        "name": "Stop burnout",
+        "trigger_type": "forward_progress",
+        "threshold": 0.0,
+        "window_seconds": 300,
+        "action_type": "alert_only",
+        "cooldown_seconds": 300,
+        "created_at": int(time.time()),
+        **kwargs,
+    }
+
+
+def _entry(entry_id: str = "h-001", rule_id: str = "r-001", **kwargs) -> dict:
+    return {
+        "id": entry_id,
+        "rule_id": rule_id,
+        "session_id": "sess-abc",
+        "triggered_at": int(time.time()),
+        "action_type": "alert_only",
+        **kwargs,
+    }
+
+
+# ── Tables exist after LocalStore init ────────────────────────────────────
+
+
+def test_ar_tables_exist(fresh_store):
+    ls, store = fresh_store
+    rows = store._fetch(
+        "SELECT table_name FROM information_schema.tables "
+        "WHERE table_name IN ('agent_resources_rules', 'agent_resources_history') "
+        "ORDER BY table_name",
+        [],
+    )
+    names = {r[0] for r in rows}
+    assert "agent_resources_rules" in names
+    assert "agent_resources_history" in names
+
+
+# ── Rules round-trip ──────────────────────────────────────────────────────
+
+
+def test_persist_and_list_ar_rule(fresh_store):
+    ls, store = fresh_store
+    store.persist_ar_rule(_rule("r-001", name="Stop burnout", enabled=True))
+    rows = store.list_ar_rules()
+    assert len(rows) == 1
+    r = rows[0]
+    assert r["id"] == "r-001"
+    assert r["name"] == "Stop burnout"
+    assert r["trigger_type"] == "forward_progress"
+    assert r["action_type"] == "alert_only"
+    assert r["enabled"] is True
+
+
+def test_delete_ar_rule(fresh_store):
+    ls, store = fresh_store
+    store.persist_ar_rule(_rule("r-del"))
+    assert store.delete_ar_rule("r-del") == 1
+    assert store.delete_ar_rule("r-del") == 0
+    assert store.list_ar_rules() == []
+
+
+def test_list_ar_rules_enabled_only_filter(fresh_store):
+    ls, store = fresh_store
+    store.persist_ar_rule(_rule("r-on", enabled=True))
+    store.persist_ar_rule(_rule("r-off", enabled=False))
+    all_rows = store.list_ar_rules()
+    assert len(all_rows) == 2
+    enabled_rows = store.list_ar_rules(enabled_only=True)
+    assert len(enabled_rows) == 1
+    assert enabled_rows[0]["id"] == "r-on"
+
+
+# ── History round-trip ────────────────────────────────────────────────────
+
+
+def test_log_and_query_ar_history(fresh_store):
+    ls, store = fresh_store
+    store.persist_ar_rule(_rule("r-001"))
+    store.log_ar_history(_entry("h-001", rule_id="r-001", session_id="sess-abc"))
+    rows = store.query_ar_history()
+    assert len(rows) == 1
+    h = rows[0]
+    assert h["id"] == "h-001"
+    assert h["rule_id"] == "r-001"
+    assert h["session_id"] == "sess-abc"
+    assert h["action_type"] == "alert_only"
+
+
+def test_query_ar_history_detail_json_decoded(fresh_store):
+    ls, store = fresh_store
+    store.persist_ar_rule(_rule())
+    store.log_ar_history(_entry(detail_json={"tokens": 50000, "metric": 0.0}))
+    rows = store.query_ar_history()
+    assert isinstance(rows[0]["detail_json"], dict)
+    assert rows[0]["detail_json"]["tokens"] == 50000
+
+
+def test_query_ar_history_session_filter(fresh_store):
+    ls, store = fresh_store
+    store.persist_ar_rule(_rule())
+    store.log_ar_history(_entry("h-a", session_id="sess-A"))
+    store.log_ar_history(_entry("h-b", session_id="sess-B"))
+    rows = store.query_ar_history(session_id="sess-A")
+    assert len(rows) == 1
+    assert rows[0]["id"] == "h-a"
+
+
+# ── DAEMON_METHODS allowlist ───────────────────────────────────────────────
+
+
+def test_ar_methods_in_daemon_methods():
+    sys.modules.pop("routes.local_query", None)
+    import routes.local_query as lq
+    importlib.reload(lq)
+    expected = {
+        "persist_ar_rule",
+        "delete_ar_rule",
+        "log_ar_history",
+        "list_ar_rules",
+        "query_ar_history",
+    }
+    assert expected.issubset(lq._DAEMON_METHODS)


### PR DESCRIPTION
## Summary

Closes #1713

Ships the data layer for the Agent Resources (AR) framework — the prerequisite that all future evaluator, API, and UI work depends on. Does **not** touch any UI, gating logic, or tab naming (those need Greenlight sign-off first).

- **`clawmetry/local_store.py`**: Appends `agent_resources_rules` and `agent_resources_history` tables to `_SCHEMA` (new tables only — zero migrations). Adds five CRUD methods following the `alert_rules` pattern: `persist_ar_rule`, `delete_ar_rule`, `log_ar_history`, `list_ar_rules`, `query_ar_history`.
- **`routes/local_query.py`**: All five methods added to `_DAEMON_METHODS` so the dashboard process can reach them through the daemon proxy without grabbing the DuckDB writer lock.
- **`tests/test_ar_framework.py`** (new): 8 unit tests covering table existence after `LocalStore()` init, rule and history round-trips, `enabled_only` filter, and `_DAEMON_METHODS` membership.

## Test plan

- `python3 -m pytest tests/test_ar_framework.py -v` — all 8 tests pass
- `python3 -m py_compile clawmetry/local_store.py routes/local_query.py` — syntax clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wm1zLvyPyEdd1NP1exbEVi)_