### PR TITLE
feat(entitlement): bare {feature,runtime,tier}-catalog endpoints

### DIFF
--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -155,6 +155,26 @@ is the single source of truth -- handlers never re-derive tier logic here.
                                          row or feature tooltip needs).
   GET  /api/runtimes                  -- the full runtime catalog.
   GET  /api/tiers                     -- the full tier ladder with per-tier metadata.
+  GET  /api/entitlement/feature-catalog  -- bare sibling of
+                                         ``/feature-catalog-at``: the resolved
+                                         feature catalogue wrapped in the same
+                                         ``{tier, features, grace, enforced}``
+                                         envelope the ``-at`` sibling uses, so
+                                         a client hydrating every catalog
+                                         variant (bare, ``-at``,
+                                         ``-at-batch``, ``-path``, ...) can do
+                                         it off one prefix instead of mixing
+                                         ``/api/features`` with
+                                         ``/api/entitlement/feature-catalog-at``.
+  GET  /api/entitlement/runtime-catalog  -- bare sibling of
+                                         ``/runtime-catalog-at`` for the
+                                         runtime axis; same envelope shape.
+  GET  /api/entitlement/tier-catalog  -- bare sibling of
+                                         ``/tier-catalog-at`` for the tier
+                                         ladder; same envelope shape (with
+                                         the resolved tier mirrored into the
+                                         ``tier`` key to match the ``-at``
+                                         sibling).
   GET  /api/entitlement/tier-spec     -- scalar sibling of ``/api/tiers``:
                                          full per-tier descriptor for one
                                          ``tier=`` key (label, rank,
@@ -15486,6 +15506,153 @@ def api_entitlement_tier_path_at_batch():
                 "unknown": [],
                 "current_tier": "oss",
                 "current_tier_rank": 0,
+                "grace": True,
+                "enforced": False,
+            }
+        )
+
+
+@bp_entitlement.route("/api/entitlement/feature-catalog")
+def api_entitlement_feature_catalog():
+    """``GET /api/entitlement/feature-catalog`` -- bare sibling of
+    ``/api/entitlement/feature-catalog-at``: returns the full feature
+    catalogue for the *resolved* entitlement, wrapped with the same
+    envelope keys the ``-at`` sibling uses so a pricing UI can swap
+    between "current" and "hypothetical" without reshaping.
+
+    Same rows as ``/api/features``; this alias lives under
+    ``/api/entitlement/`` so a client hydrating every catalog variant
+    (bare, ``-at``, ``-at-batch``, ``-path``, ...) can do it off one
+    prefix instead of mixing ``/api/features`` with
+    ``/api/entitlement/feature-catalog-at``.
+
+    Response shape::
+
+        {
+          "tier":     "<resolved tier id>",
+          "features": [<catalog_row>, ...],   # from feature_catalog()
+          "grace":    <bool>,                 # resolver is in grace mode
+          "enforced": <bool>,                 # negation of grace, for symmetry
+        }
+
+    - **Never 5xxs**: helper failures short-circuit to the OSS-free
+      envelope so the pricing UI keeps rendering.
+    """
+    try:
+        from clawmetry import entitlements as _ent
+
+        ent = _ent.get_entitlement()
+        return jsonify(
+            {
+                "tier": ent.tier,
+                "features": _ent.feature_catalog(),
+                "grace": ent.grace,
+                "enforced": not ent.grace,
+            }
+        )
+    except Exception as exc:
+        logger.warning("api_entitlement_feature_catalog: error: %s", exc)
+        return jsonify(
+            {
+                "tier": "oss",
+                "features": [],
+                "grace": True,
+                "enforced": False,
+            }
+        )
+
+
+@bp_entitlement.route("/api/entitlement/runtime-catalog")
+def api_entitlement_runtime_catalog():
+    """``GET /api/entitlement/runtime-catalog`` -- bare sibling of
+    ``/api/entitlement/runtime-catalog-at``: returns the full runtime
+    catalogue for the *resolved* entitlement, wrapped with the same
+    envelope keys the ``-at`` sibling uses so a pricing UI can swap
+    between "current" and "hypothetical" without reshaping.
+
+    Same rows as ``/api/runtimes``; this alias lives under
+    ``/api/entitlement/`` so a client hydrating every catalog variant
+    can do it off one prefix.
+
+    Response shape::
+
+        {
+          "tier":     "<resolved tier id>",
+          "runtimes": [<catalog_row>, ...],   # from runtime_catalog()
+          "grace":    <bool>,
+          "enforced": <bool>,
+        }
+
+    - **Never 5xxs**: helper failures short-circuit to the OSS-free
+      envelope so the pricing UI keeps rendering.
+    """
+    try:
+        from clawmetry import entitlements as _ent
+
+        ent = _ent.get_entitlement()
+        return jsonify(
+            {
+                "tier": ent.tier,
+                "runtimes": _ent.runtime_catalog(),
+                "grace": ent.grace,
+                "enforced": not ent.grace,
+            }
+        )
+    except Exception as exc:
+        logger.warning("api_entitlement_runtime_catalog: error: %s", exc)
+        return jsonify(
+            {
+                "tier": "oss",
+                "runtimes": [],
+                "grace": True,
+                "enforced": False,
+            }
+        )
+
+
+@bp_entitlement.route("/api/entitlement/tier-catalog")
+def api_entitlement_tier_catalog():
+    """``GET /api/entitlement/tier-catalog`` -- bare sibling of
+    ``/api/entitlement/tier-catalog-at``: returns the full tier ladder
+    for the *resolved* entitlement, wrapped with the same envelope
+    keys the ``-at`` sibling uses so a pricing UI can swap between
+    "current" and "hypothetical" without reshaping.
+
+    Same rows as ``/api/tiers`` (with ``current`` mirrored into
+    ``tier`` to match the ``-at`` sibling); this alias lives under
+    ``/api/entitlement/`` so a client hydrating every catalog variant
+    can do it off one prefix.
+
+    Response shape::
+
+        {
+          "tier":     "<resolved tier id>",   # matches _at sibling key
+          "tiers":    [<catalog_row>, ...],   # from tier_catalog()
+          "grace":    <bool>,
+          "enforced": <bool>,
+        }
+
+    - **Never 5xxs**: helper failures short-circuit to the OSS-floor
+      envelope so the pricing UI keeps rendering.
+    """
+    try:
+        from clawmetry import entitlements as _ent
+
+        ent = _ent.get_entitlement()
+        return jsonify(
+            {
+                "tier": ent.tier,
+                "tiers": _ent.tier_catalog(),
+                "grace": ent.grace,
+                "enforced": not ent.grace,
+            }
+        )
+    except Exception as exc:
+        logger.warning("api_entitlement_tier_catalog: error: %s", exc)
+        return jsonify(
+            {
+                "tier": "oss",
+                "tiers": [],
                 "grace": True,
                 "enforced": False,
             }

--- a/tests/test_entitlement_bare_catalog.py
+++ b/tests/test_entitlement_bare_catalog.py
@@ -1,0 +1,290 @@
+"""Tests for the bare ``/api/entitlement/{feature,runtime,tier}-catalog``
+endpoints.
+
+These are the bare siblings of the ``*-catalog-at`` what-if endpoints.
+Where ``-catalog-at?tier=X`` hydrates the catalogue as if the install
+were on tier ``X``, the bare form hydrates it for the *resolved*
+entitlement. Both share the same ``{tier, features/runtimes/tiers,
+grace, enforced}`` envelope so a pricing UI can swap between "current"
+and "hypothetical" without reshaping.
+
+The bare catalogs are already served under the legacy
+``/api/features``, ``/api/runtimes``, ``/api/tiers`` URLs; these tests
+pin the new aliases under ``/api/entitlement/`` and defend the
+never-5xx contract.
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    """Fresh entitlements module with HOME pointed at an empty tmp dir so no
+    real ``~/.clawmetry/license.key`` or ``cloud_plan.json`` leaks in.
+    Enforcement off by default -- grace mode is the current shipping default
+    and the bare catalog must render correctly in it."""
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# ── feature-catalog ────────────────────────────────────────────────────────────
+
+
+def test_feature_catalog_200(client):
+    resp = client.get("/api/entitlement/feature-catalog")
+    assert resp.status_code == 200
+
+
+def test_feature_catalog_envelope_shape(client):
+    body = client.get("/api/entitlement/feature-catalog").get_json()
+    assert set(body.keys()) == {"tier", "features", "grace", "enforced"}
+    assert isinstance(body["features"], list)
+    assert isinstance(body["tier"], str)
+    assert isinstance(body["grace"], bool)
+    assert isinstance(body["enforced"], bool)
+
+
+def test_feature_catalog_grace_and_enforced_are_negations(client):
+    body = client.get("/api/entitlement/feature-catalog").get_json()
+    assert body["grace"] is not body["enforced"]
+
+
+def test_feature_catalog_tier_matches_resolved(client, ent):
+    body = client.get("/api/entitlement/feature-catalog").get_json()
+    assert body["tier"] == ent.get_entitlement().tier
+
+
+def test_feature_catalog_rows_match_helper(client, ent):
+    """Byte-parity with :func:`feature_catalog` -- a pricing UI reading
+    the bare endpoint must see the same rows the helper produces."""
+    body = client.get("/api/entitlement/feature-catalog").get_json()
+    assert body["features"] == ent.feature_catalog()
+
+
+def test_feature_catalog_covers_every_feature(client, ent):
+    body = client.get("/api/entitlement/feature-catalog").get_json()
+    assert len(body["features"]) == len(ent.ALL_FEATURES)
+    ids = {row["id"] for row in body["features"]}
+    assert ids == set(ent.ALL_FEATURES)
+
+
+def test_feature_catalog_never_5xxs_on_helper_failure(client, ent, monkeypatch):
+    """The endpoint must not 500 when the helper explodes. It falls back
+    to the OSS-free envelope so the pricing UI keeps rendering."""
+
+    def boom(*_a, **_kw):
+        raise RuntimeError("simulated helper failure")
+
+    monkeypatch.setattr(ent, "feature_catalog", boom)
+    resp = client.get("/api/entitlement/feature-catalog")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["features"] == []
+    assert body["grace"] is True
+    assert body["enforced"] is False
+
+
+# ── runtime-catalog ────────────────────────────────────────────────────────────
+
+
+def test_runtime_catalog_200(client):
+    resp = client.get("/api/entitlement/runtime-catalog")
+    assert resp.status_code == 200
+
+
+def test_runtime_catalog_envelope_shape(client):
+    body = client.get("/api/entitlement/runtime-catalog").get_json()
+    assert set(body.keys()) == {"tier", "runtimes", "grace", "enforced"}
+    assert isinstance(body["runtimes"], list)
+
+
+def test_runtime_catalog_grace_and_enforced_are_negations(client):
+    body = client.get("/api/entitlement/runtime-catalog").get_json()
+    assert body["grace"] is not body["enforced"]
+
+
+def test_runtime_catalog_tier_matches_resolved(client, ent):
+    body = client.get("/api/entitlement/runtime-catalog").get_json()
+    assert body["tier"] == ent.get_entitlement().tier
+
+
+def test_runtime_catalog_rows_match_helper(client, ent):
+    body = client.get("/api/entitlement/runtime-catalog").get_json()
+    assert body["runtimes"] == ent.runtime_catalog()
+
+
+def test_runtime_catalog_lists_free_before_paid(client, ent):
+    """Ordering contract: free runtimes come before paid runtimes (matches
+    :func:`runtime_catalog`)."""
+    rows = client.get("/api/entitlement/runtime-catalog").get_json()["runtimes"]
+    ids = [row["id"] for row in rows]
+    free_positions = [ids.index(r) for r in ent.FREE_RUNTIMES if r in ids]
+    paid_positions = [ids.index(r) for r in ent.PAID_RUNTIMES if r in ids]
+    if free_positions and paid_positions:
+        assert max(free_positions) < min(paid_positions)
+
+
+def test_runtime_catalog_never_5xxs_on_helper_failure(client, ent, monkeypatch):
+    def boom(*_a, **_kw):
+        raise RuntimeError("simulated helper failure")
+
+    monkeypatch.setattr(ent, "runtime_catalog", boom)
+    resp = client.get("/api/entitlement/runtime-catalog")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["runtimes"] == []
+    assert body["grace"] is True
+    assert body["enforced"] is False
+
+
+# ── tier-catalog ───────────────────────────────────────────────────────────────
+
+
+def test_tier_catalog_200(client):
+    resp = client.get("/api/entitlement/tier-catalog")
+    assert resp.status_code == 200
+
+
+def test_tier_catalog_envelope_shape(client):
+    body = client.get("/api/entitlement/tier-catalog").get_json()
+    assert set(body.keys()) == {"tier", "tiers", "grace", "enforced"}
+    assert isinstance(body["tiers"], list)
+
+
+def test_tier_catalog_grace_and_enforced_are_negations(client):
+    body = client.get("/api/entitlement/tier-catalog").get_json()
+    assert body["grace"] is not body["enforced"]
+
+
+def test_tier_catalog_tier_matches_resolved(client, ent):
+    body = client.get("/api/entitlement/tier-catalog").get_json()
+    assert body["tier"] == ent.get_entitlement().tier
+
+
+def test_tier_catalog_rows_match_helper(client, ent):
+    body = client.get("/api/entitlement/tier-catalog").get_json()
+    assert body["tiers"] == ent.tier_catalog()
+
+
+def test_tier_catalog_is_current_lines_up_with_tier_field(client):
+    """The rung marked ``is_current=True`` in ``tiers`` must be the one
+    identified by the top-level ``tier`` field -- otherwise a UI would
+    highlight one row and label the header with a different tier id."""
+    body = client.get("/api/entitlement/tier-catalog").get_json()
+    current_rows = [r for r in body["tiers"] if r.get("is_current")]
+    assert len(current_rows) == 1
+    assert current_rows[0]["id"] == body["tier"]
+
+
+def test_tier_catalog_covers_every_known_tier(client, ent):
+    body = client.get("/api/entitlement/tier-catalog").get_json()
+    ids = [row["id"] for row in body["tiers"]]
+    assert ids == list(ent._TIER_ORDER)
+
+
+def test_tier_catalog_never_5xxs_on_helper_failure(client, ent, monkeypatch):
+    def boom(*_a, **_kw):
+        raise RuntimeError("simulated helper failure")
+
+    monkeypatch.setattr(ent, "tier_catalog", boom)
+    resp = client.get("/api/entitlement/tier-catalog")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["tiers"] == []
+    assert body["grace"] is True
+    assert body["enforced"] is False
+
+
+# ── parity with `-at` sibling ──────────────────────────────────────────────────
+
+
+def test_feature_catalog_bare_parity_with_at_at_resolved_tier(client, ent):
+    """The bare endpoint at the resolved tier and the ``-at`` endpoint
+    parameterised with the resolved tier must return the same rows (only
+    the envelope differs: the bare form adds ``grace`` / ``enforced``,
+    the ``-at`` form echoes the requested ``tier``). Pins the "swap
+    without reshaping" promise: rows are one-to-one."""
+    resolved = ent.get_entitlement().tier
+    bare = client.get("/api/entitlement/feature-catalog").get_json()
+    atr = client.get(
+        f"/api/entitlement/feature-catalog-at?tier={resolved}"
+    ).get_json()
+    bare_ids = [r["id"] for r in bare["features"]]
+    at_ids = [r["id"] for r in atr["features"]]
+    assert bare_ids == at_ids
+
+
+def test_runtime_catalog_bare_parity_with_at_at_resolved_tier(client, ent):
+    resolved = ent.get_entitlement().tier
+    bare = client.get("/api/entitlement/runtime-catalog").get_json()
+    atr = client.get(
+        f"/api/entitlement/runtime-catalog-at?tier={resolved}"
+    ).get_json()
+    bare_ids = [r["id"] for r in bare["runtimes"]]
+    at_ids = [r["id"] for r in atr["runtimes"]]
+    assert bare_ids == at_ids
+
+
+def test_tier_catalog_bare_parity_with_at_at_resolved_tier(client, ent):
+    """Rows from the bare tier-catalog and the ``-at`` sibling at the
+    resolved tier must match exactly -- the ``-at`` sibling's whole
+    point is that its rows are byte-identical to :func:`tier_catalog`
+    when the perspective is the live resolved tier."""
+    resolved = ent.get_entitlement().tier
+    bare = client.get("/api/entitlement/tier-catalog").get_json()
+    atr = client.get(
+        f"/api/entitlement/tier-catalog-at?tier={resolved}"
+    ).get_json()
+    assert bare["tiers"] == atr["tiers"]
+
+
+# ── legacy alias parity ────────────────────────────────────────────────────────
+
+
+def test_feature_catalog_matches_legacy_features_endpoint(client):
+    """The bare ``/api/entitlement/feature-catalog`` must return the same
+    catalogue rows as the legacy ``/api/features`` alias -- the two
+    surfaces share a helper and must not drift."""
+    bare = client.get("/api/entitlement/feature-catalog").get_json()
+    legacy = client.get("/api/features").get_json()
+    assert bare["features"] == legacy["features"]
+    assert bare["grace"] == legacy["grace"]
+    assert bare["enforced"] == legacy["enforced"]
+
+
+def test_runtime_catalog_matches_legacy_runtimes_endpoint(client):
+    bare = client.get("/api/entitlement/runtime-catalog").get_json()
+    legacy = client.get("/api/runtimes").get_json()
+    assert bare["runtimes"] == legacy["runtimes"]
+    assert bare["grace"] == legacy["grace"]
+    assert bare["enforced"] == legacy["enforced"]
+
+
+def test_tier_catalog_matches_legacy_tiers_endpoint(client):
+    """Rows must match ``/api/tiers``; the bare endpoint just renames
+    ``current`` to ``tier`` for symmetry with the ``-at`` sibling."""
+    bare = client.get("/api/entitlement/tier-catalog").get_json()
+    legacy = client.get("/api/tiers").get_json()
+    assert bare["tiers"] == legacy["tiers"]
+    assert bare["tier"] == legacy["current"]
+    assert bare["grace"] == legacy["grace"]
+    assert bare["enforced"] == legacy["enforced"]


### PR DESCRIPTION
## Summary
- Add three bare catalog endpoints on `bp_entitlement` so the whole catalog family lives under one prefix: `GET /api/entitlement/{feature,runtime,tier}-catalog`.
- Each returns the same `{tier, features/runtimes/tiers, grace, enforced}` envelope its `-at` sibling uses, so a pricing UI can swap between the current-resolved catalog and any hypothetical `-at?tier=X` view without reshaping.
- Rows are byte-identical to the existing `/api/features`, `/api/runtimes`, `/api/tiers` legacy aliases (which keep working); this just moves the catalog into the `/api/entitlement/` namespace next to the `-at`, `-at-batch`, `-path`, `-at-path`, ... siblings.
- No gate flips: `grace=True` / `enforced=False` remain the resolved default until the operator flips enforcement.

## Test plan
- [x] `python -m pytest tests/test_entitlement_bare_catalog.py` — 28 new tests, all pass (envelope shape, row parity with helpers and legacy aliases, `is_current` lines up with the top-level `tier`, never-5xx contract via monkeypatched helper failures, cross-parity with each `-at` sibling at the resolved tier).
- [x] `python -m pytest tests/test_entitlement_feature_catalog_at.py tests/test_entitlement_runtime_catalog_at.py tests/test_entitlement_tier_catalog_at.py tests/test_entitlements_feature_catalog.py tests/test_tier_catalog.py tests/test_entitlement_api.py` — 181 tests, all green (no regression in the existing catalog / entitlement-api surface).
- [x] `ruff check routes/entitlement.py tests/test_entitlement_bare_catalog.py` — clean.
- [x] `python -m py_compile routes/entitlement.py tests/test_entitlement_bare_catalog.py` — clean.

## Local operator verification checklist
This session runs from a cloned repo without access to the user's laptop, live daemon, `~/.openclaw`, or the cloud snapshot — the operator finishes the loop:

- [ ] Copy the changed files onto the running install:
  ```
  cp routes/entitlement.py ~/.clawmetry/lib/python*/site-packages/routes/entitlement.py
  cp tests/test_entitlement_bare_catalog.py ~/.clawmetry/lib/python*/site-packages/tests/  # optional
  find ~/.clawmetry/lib/python*/site-packages/routes -name __pycache__ -exec rm -rf {} +
  ```
- [ ] Bounce the sync daemon: `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`.
- [ ] Hit each new endpoint and confirm the envelope:
  ```
  curl -s http://localhost:8900/api/entitlement/feature-catalog | jq 'keys, .tier, .grace, .enforced, (.features | length)'
  curl -s http://localhost:8900/api/entitlement/runtime-catalog | jq 'keys, .tier, (.runtimes | length)'
  curl -s http://localhost:8900/api/entitlement/tier-catalog    | jq 'keys, .tier, (.tiers | length), [.tiers[] | select(.is_current) | .id]'
  ```
  All three should return `grace=true`, `enforced=false` today, with a non-empty catalog and the `tier` field matching `/api/entitlement | jq .tier`.
- [ ] Legacy-alias parity (should be byte-identical row lists):
  ```
  diff <(curl -s http://localhost:8900/api/features   | jq .features) <(curl -s http://localhost:8900/api/entitlement/feature-catalog | jq .features)
  diff <(curl -s http://localhost:8900/api/runtimes   | jq .runtimes) <(curl -s http://localhost:8900/api/entitlement/runtime-catalog | jq .runtimes)
  diff <(curl -s http://localhost:8900/api/tiers      | jq .tiers)    <(curl -s http://localhost:8900/api/entitlement/tier-catalog    | jq .tiers)
  ```
- [ ] Decrypt the live cloud snapshot and browser-check the pricing/catalog page (I can't do this remotely).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LaPwjc9zQ8mCj9vybmFBKY

---
_Generated by [Claude Code](https://claude.ai/code/session_01LaPwjc9zQ8mCj9vybmFBKY)_