### PR TITLE
feat(entitlement): accept channels/retention_days/nodes on /min-tier

### DIFF
--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -4710,14 +4710,27 @@ def api_entitlement_affordable_tiers():
 
 @bp_entitlement.route("/api/entitlement/min-tier")
 def api_entitlement_min_tier():
-    """``GET /api/entitlement/min-tier?feature=<f>`` or ``?runtime=<r>`` --
-    cheapest purchasable tier that unlocks the named feature or runtime.
+    """``GET /api/entitlement/min-tier?<axis>=<value>`` -- cheapest purchasable
+    tier that admits the supplied constraint on ONE of the five capacity axes
+    (``feature``, ``runtime``, ``channels``, ``retention_days``, ``nodes``).
+
+    Singular sibling of :func:`api_entitlement_min_tier_batch`, closing the
+    axis-symmetry gap: previously the singular endpoint accepted only
+    ``feature=`` / ``runtime=``, while the batch already accepted all five.
+    Same reverse-lookup contract as ``/required-tier`` (``feature``,
+    ``runtime``, ``channels``, ``retention_days``, ``nodes``), rendered as
+    the cheapest qualifying tier instead of the current-vs-required
+    upgrade view -- so a pricing-page cell rendering "N nodes -- Available
+    in Starter" can hit the same endpoint the feature / runtime lock
+    affordances already use, and per-row parity with the plural
+    ``/min-tier-batch`` shape is pinned in the test suite.
 
     Catalogue-derived, so the answer is identical in grace and enforce mode.
     Response shape::
 
         {
-          "key":        "feature" | "runtime",
+          "key":        "feature" | "runtime" | "channels"
+                        | "retention_days" | "nodes",
           "value":      "<input>",
           "free":       <bool>,           # true when min_tier == OSS
           "min_tier":   "<tier id>" | null,
@@ -4725,19 +4738,81 @@ def api_entitlement_min_tier():
           "tier_rank":  <int> | null,
         }
 
-    400 when neither ``feature`` nor ``runtime`` is supplied (or both are).
-    404 when the input id is unknown -- the caller can show a neutral
-    "not available" hint rather than pointing at a nonsense tier. Never 5xxs.
+    400 when zero or more than one axis is supplied, or when a capacity
+    axis value is non-int. 404 when the ``feature`` / ``runtime`` id is
+    unknown -- the caller can show a neutral "not available" hint rather
+    than pointing at a nonsense tier. Never 5xxs. The three capacity
+    axes never 404: any parseable int (including zero / negative --
+    which collapses to :data:`TIER_OSS` matching the helpers' contract)
+    resolves to a real tier, so the ``error`` key never appears on a
+    capacity response.
     """
     feature = (request.args.get("feature") or "").strip()
     runtime = (request.args.get("runtime") or "").strip().lower()
-    if bool(feature) == bool(runtime):
+    (
+        channels_present,
+        channels_ok,
+        channels_n,
+        channels_raw,
+    ) = _parse_capacity_arg("channels")
+    (
+        retention_present,
+        retention_ok,
+        retention_n,
+        retention_raw,
+    ) = _parse_capacity_arg("retention_days")
+    (
+        nodes_present,
+        nodes_ok,
+        nodes_n,
+        nodes_raw,
+    ) = _parse_capacity_arg("nodes")
+    supplied = [
+        bool(feature),
+        bool(runtime),
+        channels_present,
+        retention_present,
+        nodes_present,
+    ]
+    n_supplied = sum(1 for s in supplied if s)
+    if n_supplied == 0:
         return (
             jsonify(
                 {
-                    "error": "exactly one of feature= or runtime= is required",
+                    "error": (
+                        "supply exactly one of feature=<id>, runtime=<id>, "
+                        "channels=<int>, retention_days=<int>, or "
+                        "nodes=<int>"
+                    ),
                 }
             ),
+            400,
+        )
+    if n_supplied > 1:
+        return (
+            jsonify(
+                {
+                    "error": (
+                        "supply only one of feature=, runtime=, channels=, "
+                        "retention_days=, or nodes="
+                    ),
+                }
+            ),
+            400,
+        )
+    if channels_present and not channels_ok:
+        return (
+            jsonify({"error": "channels= must be an integer"}),
+            400,
+        )
+    if retention_present and not retention_ok:
+        return (
+            jsonify({"error": "retention_days= must be an integer"}),
+            400,
+        )
+    if nodes_present and not nodes_ok:
+        return (
+            jsonify({"error": "nodes= must be an integer"}),
             400,
         )
     try:
@@ -4747,10 +4822,22 @@ def api_entitlement_min_tier():
             min_t = _ent.min_tier_for_feature(feature)
             key, value = "feature", feature
             known = feature in _ent.ALL_FEATURES
-        else:
+        elif runtime:
             min_t = _ent.min_tier_for_runtime(runtime)
             key, value = "runtime", runtime
             known = runtime in _ent.ALL_RUNTIMES
+        elif channels_present:
+            min_t = _ent.min_tier_for_channel_count(channels_n)
+            key, value = "channels", str(channels_n)
+            known = True
+        elif retention_present:
+            min_t = _ent.min_tier_for_retention_window(retention_n)
+            key, value = "retention_days", str(retention_n)
+            known = True
+        else:
+            min_t = _ent.min_tier_for_node_count(nodes_n)
+            key, value = "nodes", str(nodes_n)
+            known = True
         if not known:
             return (
                 jsonify(
@@ -4778,10 +4865,20 @@ def api_entitlement_min_tier():
         )
     except Exception as exc:
         logger.warning("api_entitlement_min_tier: error: %s", exc)
+        if feature:
+            key, value = "feature", feature
+        elif runtime:
+            key, value = "runtime", runtime
+        elif channels_present:
+            key, value = "channels", channels_raw
+        elif retention_present:
+            key, value = "retention_days", retention_raw
+        else:
+            key, value = "nodes", nodes_raw
         return jsonify(
             {
-                "key": "feature" if feature else "runtime",
-                "value": feature or runtime,
+                "key": key,
+                "value": value,
                 "free": False,
                 "min_tier": None,
                 "tier_label": None,

--- a/tests/test_entitlement_min_tier_capacity.py
+++ b/tests/test_entitlement_min_tier_capacity.py
@@ -1,0 +1,407 @@
+"""Tests for the three capacity axes on ``/api/entitlement/min-tier``:
+``channels``, ``retention_days`` and ``nodes``.
+
+Previously the singular ``/min-tier`` endpoint accepted only ``feature=`` /
+``runtime=`` while its plural sibling ``/min-tier-batch`` already answered on
+all five axes. This module pins the closed-symmetry contract: the singular
+now delegates to the same three helpers the batch calls
+(``min_tier_for_channel_count`` / ``min_tier_for_retention_window`` /
+``min_tier_for_node_count``) and returns the same ``key`` / ``value`` /
+``free`` / ``min_tier`` / ``tier_label`` / ``tier_rank`` envelope the
+``feature`` / ``runtime`` branches return so callers don't have to reshape
+per axis.
+
+Invariants pinned here:
+
+* ``/min-tier?channels=<N>`` / ``retention_days=<N>`` / ``nodes=<N>`` return
+  the byte-identical envelope shape ``feature`` / ``runtime`` returns
+  (``key``, ``value``, ``free``, ``min_tier``, ``tier_label``, ``tier_rank``).
+* ``key`` names the axis (``"channels"`` / ``"retention_days"`` /
+  ``"nodes"``); ``value`` echoes the *parsed* integer input as a string so a
+  pricing-page cell can display it back verbatim.
+* Per-axis parity with the underlying helpers: each answer byte-equals
+  ``min_tier_for_<axis>(N)`` at the ``min_tier`` field.
+* Per-row parity with the plural ``/min-tier-batch`` sibling: for the same
+  input ``N`` on the same axis, ``/min-tier`` and the corresponding row of
+  ``/min-tier-batch`` land on the same ``min_tier``.
+* Non-integer capacity values 400 (matching ``/required-tier``'s parse
+  posture) rather than silently mis-routing.
+* Mixing axes (``feature=`` + ``channels=`` etc.) 400 -- exactly-one
+  constraint still applies across all five axes.
+* Zero / negative capacity collapses to ``TIER_OSS`` (matching the helpers'
+  grace-on-zero contract), so ``free=True`` -- the "trivially satisfied"
+  answer, not an error.
+* Catalogue-derived, so the answer is identical in grace and enforce mode.
+* Never 5xxs: a resolver failure collapses to the all-``None`` shape so the
+  pricing-page cell keeps rendering instead of breaking.
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# -- channels ---------------------------------------------------------------
+
+
+def test_channels_free_when_within_oss_cap(client, ent):
+    # OSS admits at least one channel -- min_tier collapses to OSS.
+    rv = client.get("/api/entitlement/min-tier?channels=1")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["key"] == "channels"
+    assert body["value"] == "1"
+    assert body["min_tier"] == ent.min_tier_for_channel_count(1)
+    assert body["free"] is (body["min_tier"] == ent.TIER_OSS)
+    assert body["tier_label"] == ent.tier_label(body["min_tier"])
+    assert body["tier_rank"] == ent.tier_rank(body["min_tier"])
+
+
+def test_channels_beyond_free_climbs_ladder(client, ent):
+    # A very large channel count should climb past OSS to a paid rung.
+    rv = client.get("/api/entitlement/min-tier?channels=1000")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    expected = ent.min_tier_for_channel_count(1000)
+    assert body["min_tier"] == expected
+    assert body["tier_rank"] == ent.tier_rank(expected)
+
+
+def test_channels_zero_collapses_to_oss(client, ent):
+    # Grace-on-zero contract: zero channels is trivially satisfied by OSS.
+    rv = client.get("/api/entitlement/min-tier?channels=0")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["min_tier"] == ent.TIER_OSS
+    assert body["free"] is True
+    assert body["value"] == "0"
+
+
+def test_channels_non_int_400(client):
+    rv = client.get("/api/entitlement/min-tier?channels=abc")
+    assert rv.status_code == 400
+    body = rv.get_json()
+    assert "channels" in (body.get("error") or "").lower()
+
+
+def test_channels_blank_400(client):
+    # A supplied-but-empty capacity axis is a parse failure, not "unset" --
+    # matches ``_parse_capacity_arg``'s ``present=True, ok=False`` shape.
+    rv = client.get("/api/entitlement/min-tier?channels=")
+    assert rv.status_code == 400
+
+
+# -- retention_days ---------------------------------------------------------
+
+
+def test_retention_days_finite_matches_helper(client, ent):
+    rv = client.get("/api/entitlement/min-tier?retention_days=30")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    expected = ent.min_tier_for_retention_window(30)
+    assert body["key"] == "retention_days"
+    assert body["value"] == "30"
+    assert body["min_tier"] == expected
+    assert body["tier_label"] == ent.tier_label(expected)
+    assert body["tier_rank"] == ent.tier_rank(expected)
+    assert body["free"] is (expected == ent.TIER_OSS)
+
+
+def test_retention_days_zero_collapses_to_oss(client, ent):
+    rv = client.get("/api/entitlement/min-tier?retention_days=0")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["min_tier"] == ent.TIER_OSS
+    assert body["free"] is True
+
+
+def test_retention_days_non_int_400(client):
+    rv = client.get("/api/entitlement/min-tier?retention_days=forever")
+    assert rv.status_code == 400
+    body = rv.get_json()
+    assert "retention_days" in (body.get("error") or "").lower()
+
+
+def test_retention_days_large_climbs_ladder(client, ent):
+    # A very long retention window should require Enterprise (the only tier
+    # with an unlimited cap).
+    rv = client.get("/api/entitlement/min-tier?retention_days=100000")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["min_tier"] == ent.TIER_ENTERPRISE
+
+
+# -- nodes ------------------------------------------------------------------
+
+
+def test_nodes_single_free(client, ent):
+    rv = client.get("/api/entitlement/min-tier?nodes=1")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    expected = ent.min_tier_for_node_count(1)
+    assert body["key"] == "nodes"
+    assert body["value"] == "1"
+    assert body["min_tier"] == expected
+    assert body["free"] is (expected == ent.TIER_OSS)
+
+
+def test_nodes_beyond_free_climbs_ladder(client, ent):
+    rv = client.get("/api/entitlement/min-tier?nodes=999")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    expected = ent.min_tier_for_node_count(999)
+    assert body["min_tier"] == expected
+    assert body["tier_rank"] == ent.tier_rank(expected)
+
+
+def test_nodes_zero_collapses_to_oss(client, ent):
+    rv = client.get("/api/entitlement/min-tier?nodes=0")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["min_tier"] == ent.TIER_OSS
+    assert body["free"] is True
+
+
+def test_nodes_non_int_400(client):
+    rv = client.get("/api/entitlement/min-tier?nodes=lots")
+    assert rv.status_code == 400
+    body = rv.get_json()
+    assert "nodes" in (body.get("error") or "").lower()
+
+
+# -- exactly-one across all five axes ---------------------------------------
+
+
+def test_no_axis_400(client):
+    rv = client.get("/api/entitlement/min-tier")
+    assert rv.status_code == 400
+
+
+def test_two_axes_across_kinds_400(client):
+    # feature + capacity axis mix.
+    rv = client.get(
+        "/api/entitlement/min-tier?feature=sessions&channels=5"
+    )
+    assert rv.status_code == 400
+    # runtime + capacity axis mix.
+    rv = client.get(
+        "/api/entitlement/min-tier?runtime=openclaw&nodes=3"
+    )
+    assert rv.status_code == 400
+    # Two capacity axes.
+    rv = client.get(
+        "/api/entitlement/min-tier?channels=5&retention_days=30"
+    )
+    assert rv.status_code == 400
+    rv = client.get(
+        "/api/entitlement/min-tier?channels=5&nodes=3"
+    )
+    assert rv.status_code == 400
+    rv = client.get(
+        "/api/entitlement/min-tier?retention_days=30&nodes=3"
+    )
+    assert rv.status_code == 400
+
+
+def test_three_axes_400(client):
+    rv = client.get(
+        "/api/entitlement/min-tier?channels=5&retention_days=30&nodes=3"
+    )
+    assert rv.status_code == 400
+
+
+# -- envelope shape parity across all five axes -----------------------------
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "/api/entitlement/min-tier?feature=sessions",
+        "/api/entitlement/min-tier?runtime=openclaw",
+        "/api/entitlement/min-tier?channels=5",
+        "/api/entitlement/min-tier?retention_days=30",
+        "/api/entitlement/min-tier?nodes=3",
+    ],
+)
+def test_envelope_shape_uniform_across_axes(client, url):
+    rv = client.get(url)
+    assert rv.status_code == 200
+    body = rv.get_json()
+    for k in ("key", "value", "free", "min_tier", "tier_label", "tier_rank"):
+        assert k in body, k
+
+
+# -- per-row parity with the plural /min-tier-batch sibling ----------------
+
+
+def _batch_row(batch_body, axis):
+    """Extract the row the plural batch returns for a given axis. Batch
+    exposes ``features`` / ``runtimes`` as lists (0/1 rows here) and the
+    three capacity axes as a scalar row-or-null."""
+    if axis == "features":
+        rows = batch_body.get("features") or []
+        return rows[0] if rows else None
+    if axis == "runtimes":
+        rows = batch_body.get("runtimes") or []
+        return rows[0] if rows else None
+    return batch_body.get(axis)
+
+
+def test_parity_channels_singular_vs_batch(client):
+    single = client.get("/api/entitlement/min-tier?channels=5").get_json()
+    batch = client.get("/api/entitlement/min-tier-batch?channels=5").get_json()
+    row = _batch_row(batch, "channels")
+    assert row is not None
+    assert single["min_tier"] == row["min_tier"]
+    assert single["free"] == row["free"]
+
+
+def test_parity_retention_days_singular_vs_batch(client):
+    single = client.get(
+        "/api/entitlement/min-tier?retention_days=45"
+    ).get_json()
+    batch = client.get(
+        "/api/entitlement/min-tier-batch?retention_days=45"
+    ).get_json()
+    row = _batch_row(batch, "retention_days")
+    assert row is not None
+    assert single["min_tier"] == row["min_tier"]
+    assert single["free"] == row["free"]
+
+
+def test_parity_nodes_singular_vs_batch(client):
+    single = client.get("/api/entitlement/min-tier?nodes=7").get_json()
+    batch = client.get("/api/entitlement/min-tier-batch?nodes=7").get_json()
+    row = _batch_row(batch, "nodes")
+    assert row is not None
+    assert single["min_tier"] == row["min_tier"]
+    assert single["free"] == row["free"]
+
+
+# -- feature / runtime backward compat --------------------------------------
+
+
+def test_backward_compat_feature_shape_unchanged(client, ent):
+    # Same request that shipped in the previous release still returns the
+    # historical shape -- extending the endpoint must not shift any existing
+    # response.
+    rv = client.get("/api/entitlement/min-tier?feature=sessions")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body == {
+        "key": "feature",
+        "value": "sessions",
+        "free": True,
+        "min_tier": ent.TIER_OSS,
+        "tier_label": "OSS",
+        "tier_rank": 0,
+    }
+
+
+def test_backward_compat_runtime_shape_unchanged(client, ent):
+    rv = client.get("/api/entitlement/min-tier?runtime=openclaw")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["key"] == "runtime"
+    assert body["value"] == "openclaw"
+    assert body["free"] is True
+    assert body["min_tier"] == ent.TIER_OSS
+
+
+def test_backward_compat_unknown_feature_still_404(client):
+    rv = client.get("/api/entitlement/min-tier?feature=nonsense_xyz")
+    assert rv.status_code == 404
+    body = rv.get_json()
+    assert body["error"] == "unknown"
+    assert body["min_tier"] is None
+
+
+def test_backward_compat_unknown_runtime_still_404(client):
+    rv = client.get("/api/entitlement/min-tier?runtime=nonsense_xyz")
+    assert rv.status_code == 404
+    body = rv.get_json()
+    assert body["error"] == "unknown"
+
+
+# -- never-5xx across the three new axes -----------------------------------
+
+
+def test_never_5xx_on_channels_helper_failure(client, ent, monkeypatch):
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "min_tier_for_channel_count", boom)
+    rv = client.get("/api/entitlement/min-tier?channels=5")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["min_tier"] is None
+    assert body["key"] == "channels"
+    assert body["value"] == "5"
+
+
+def test_never_5xx_on_retention_helper_failure(client, ent, monkeypatch):
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "min_tier_for_retention_window", boom)
+    rv = client.get("/api/entitlement/min-tier?retention_days=30")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["min_tier"] is None
+    assert body["key"] == "retention_days"
+
+
+def test_never_5xx_on_nodes_helper_failure(client, ent, monkeypatch):
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "min_tier_for_node_count", boom)
+    rv = client.get("/api/entitlement/min-tier?nodes=3")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["min_tier"] is None
+    assert body["key"] == "nodes"
+
+
+# -- enforce mode: same answer as grace ------------------------------------
+
+
+def test_capacity_answer_identical_in_enforce_mode(client, ent, monkeypatch):
+    # The three helpers walk the static ``_PURCHASABLE_TIERS`` ladder, so the
+    # answer must not depend on whether the resolver is in grace or enforce.
+    grace_bodies = [
+        client.get(f"/api/entitlement/min-tier?{q}").get_json()
+        for q in ("channels=5", "retention_days=30", "nodes=3")
+    ]
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    enforce_bodies = [
+        client.get(f"/api/entitlement/min-tier?{q}").get_json()
+        for q in ("channels=5", "retention_days=30", "nodes=3")
+    ]
+    for g, e in zip(grace_bodies, enforce_bodies):
+        assert g["min_tier"] == e["min_tier"]
+        assert g["free"] == e["free"]


### PR DESCRIPTION
## Summary
- Closes the axis-symmetry gap between `/api/entitlement/min-tier` (feature/runtime only) and its plural sibling `/min-tier-batch` (all five axes). A pricing-page cell rendering "N nodes — Available in Starter" can now hit the singular endpoint the way the feature / runtime lock affordances already do, instead of reaching for the batch endpoint or reinventing the ladder walk client-side.
- Extend the singular to accept `channels=<int>`, `retention_days=<int>`, and `nodes=<int>` alongside the existing `feature=<id>` / `runtime=<id>`. Each new axis delegates to the matching `min_tier_for_*` helper that already exists (`min_tier_for_channel_count` / `min_tier_for_retention_window` / `min_tier_for_node_count` — the same three functions `/min-tier-batch` and `/required-tier` already delegate to).
- Response envelope is uniform across all five axes: `key` names the axis, `value` echoes the parsed input, and `free` / `min_tier` / `tier_label` / `tier_rank` match the pre-existing feature / runtime shape.
- Exactly-one enforcement extended across all five axes; non-int capacity 400s (matching `/required-tier`'s parse posture) rather than silently mis-routing. Zero / negative capacity collapses to `TIER_OSS` (grace-on-zero contract).
- Catalogue-derived, so the answer is identical in grace and enforce mode. Never 5xxs on resolver failure — collapses to the all-`None` shape so the pricing-page cell keeps rendering. No gate flips: `grace=True` / `enforced=False` remain the resolved default.

## Backward compatibility
- The pre-existing `feature=<id>` / `runtime=<id>` response shape is byte-stable — pinned by two new equality tests (`test_backward_compat_feature_shape_unchanged` / `test_backward_compat_runtime_shape_unchanged`) and by the pre-existing `tests/test_entitlement_min_tier.py` continuing to pass unchanged.
- `404` for unknown feature / runtime id preserved, including the `"error": "unknown"` field.
- No changes to `/min-tier-batch` or any other endpoint.

## Test plan
- [x] `python -m pytest tests/test_entitlement_min_tier_capacity.py` — **32 new tests, all pass** (per-axis parity with helpers, singular-vs-batch parity, envelope-shape uniformity across all five axes, backward-compat equality on feature / runtime shapes, exactly-one enforcement across every 2-and-3-axis combination, non-int 400, zero-collapses-to-OSS, never-5xx-on-helper-failure for each capacity axis, grace-vs-enforce identity).
- [x] `python -m pytest tests/test_entitlement_min_tier.py tests/test_entitlement_min_tier_batch.py tests/test_entitlements_min_tier.py tests/test_entitlements_min_tier_batch.py tests/test_entitlements_min_tier_capacity.py tests/test_entitlements_min_tier_nodes.py` — 158 tests, all green (no regression in the singular, batch, or backing-helper coverage).
- [x] `python -m pytest tests/ -k entitlement` — 4495 tests green (one collection error in `test_retention_prune.py` is a pre-existing `duckdb` missing-dep in this sandbox, unrelated to this change).
- [x] `python -m py_compile routes/entitlement.py tests/test_entitlement_min_tier_capacity.py` — clean.

## Local operator verification checklist
This session runs from a cloned repo without access to the user's laptop, live daemon, `~/.openclaw`, or the cloud snapshot — the operator finishes the loop:

- [ ] Copy the changed files onto the running install:
  ```
  cp routes/entitlement.py ~/.clawmetry/lib/python*/site-packages/routes/entitlement.py
  cp tests/test_entitlement_min_tier_capacity.py ~/.clawmetry/lib/python*/site-packages/tests/  # optional
  find ~/.clawmetry/lib/python*/site-packages/routes -name __pycache__ -exec rm -rf {} +
  ```
- [ ] Bounce the sync daemon: `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`.
- [ ] Hit the singular endpoint on each new axis and confirm the envelope:
  ```
  curl -s 'http://localhost:8900/api/entitlement/min-tier?channels=5'      | jq
  curl -s 'http://localhost:8900/api/entitlement/min-tier?retention_days=30' | jq
  curl -s 'http://localhost:8900/api/entitlement/min-tier?nodes=3'         | jq
  ```
  All three should return `200` with a body containing `{key, value, free, min_tier, tier_label, tier_rank}`.
- [ ] Confirm backward-compat on the feature / runtime axes:
  ```
  curl -s 'http://localhost:8900/api/entitlement/min-tier?feature=sessions' | jq
  curl -s 'http://localhost:8900/api/entitlement/min-tier?runtime=openclaw' | jq
  ```
  Both should still return the same shape they did before this change.
- [ ] Per-row parity vs `/min-tier-batch`:
  ```
  diff <(curl -s 'http://localhost:8900/api/entitlement/min-tier?channels=5' | jq .min_tier) \
       <(curl -s 'http://localhost:8900/api/entitlement/min-tier-batch?channels=5' | jq .channels.min_tier)
  ```
  Should print nothing (byte-equal). Repeat for `retention_days=45` and `nodes=7`.
- [ ] Confirm the 400 branches:
  ```
  curl -s -o /dev/null -w '%{http_code}\n' 'http://localhost:8900/api/entitlement/min-tier?channels=abc'   # 400
  curl -s -o /dev/null -w '%{http_code}\n' 'http://localhost:8900/api/entitlement/min-tier?feature=sessions&channels=5'  # 400
  ```
- [ ] Decrypt the live cloud snapshot and browser-check any pricing / paywall / lock-affordance surface that hits `/api/entitlement/min-tier` (I can't do this remotely).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code


---
_Generated by [Claude Code](https://claude.ai/code/session_019cMHSxsz8qxQ3zNNrQ15uY)_