### PR TITLE
feat(entitlement): min_tier_for_all_at + affordable_tiers_at + endpoints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,6 +167,33 @@ jobs:
             tests/test_openclaw_detection_real.py \
             -q
 
+  # ── Entitlement API test suite (~2700 hermetic tests) ─────────────────────
+  # Covers every helper in clawmetry/entitlements.py and every endpoint
+  # under routes/entitlement.py via Flask test client. No live server, no
+  # gateway, no network. Runtime ~60s. HARD-FAIL: no continue-on-error.
+  entitlement-tests:
+    name: Entitlement API tests
+    needs: lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          cache: pip
+      - name: Install dependencies
+        run: pip install flask waitress cryptography duckdb pytest requests psutil
+      - name: Run entitlement test suite
+        run: |
+          python3 -m pytest \
+            tests/test_entitlement*.py \
+            tests/test_entitlements*.py \
+            tests/test_required_tier_canonical.py \
+            tests/test_tier_catalog.py \
+            tests/test_tier_cli.py \
+            -q
+
   # ── Compression / cache-safety eval (Tier-1, deterministic) ──────────────
   # Issue #2844 (epic #2837): port Headroom's eval rigor so we can claim
   # "compression-safe" with proof. This Tier-1 gate is pure-Python and spends

--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -4580,6 +4580,154 @@ def affordable_tiers(
         return None
 
 
+def min_tier_for_all_at(
+    perspective_tier: str,
+    *,
+    features=None,
+    runtimes=None,
+    channels: int | None = None,
+    retention_days: int | None = None,
+    nodes: int | None = None,
+) -> str | None:
+    """Hypothetical-perspective sibling of :func:`min_tier_for_all`: cheapest
+    *purchasable* tier admitting **all** supplied constraints, scoped by a
+    caller-supplied ``perspective_tier``.
+
+    Same relationship to :func:`min_tier_for_all` that the ``_at`` scalars
+    in the ``tier_unlocks`` / ``tier_locks`` / ``capacity_diff`` families
+    have to their current-perspective siblings: the ``perspective_tier``
+    argument tells the helper which resolver / plan the caller is
+    answering from so an ``_at`` endpoint URL can be uniform across the
+    whole ``_at`` family (every ``_at`` sibling accepts a
+    ``tier=<perspective>`` query arg), even though the underlying floor
+    is inherently perspective-independent -- :func:`min_tier_for_all`
+    walks the static per-tier caps, so the answer does not depend on
+    where the caller is standing.
+
+    Perspective is validated against :data:`_TIER_ORDER` (including
+    :data:`TIER_TRIAL`) but does NOT shape the result -- the floor is
+    anchored to the constraint bundle, exactly the way the ``_at_path``
+    family anchors to its ``from`` / ``to`` endpoints. A parity test
+    pins ``min_tier_for_all_at(p, ...) == min_tier_for_all(...)`` for
+    every ``p`` in :data:`_TIER_ORDER` so the ``_at`` prefix cannot
+    silently drift into shaping the answer.
+
+    Scalar what-if companion of :func:`affordable_tiers_at` (which
+    returns the full list of qualifying tiers from the same
+    perspective). Fills the ``_at`` slot for the aggregate
+    constraint-bundle family alongside the per-axis ``min_tier_for_*``
+    singulars, so a pricing-comparison tooltip can call
+    ``X_at(perspective, ...)`` uniformly across every ``_at`` scalar
+    (:func:`capacity_diff_at`, :func:`tier_unlocks_at`,
+    :func:`tier_locks_at`) surface.
+
+    Semantics mirror :func:`min_tier_for_all` exactly:
+
+    * No constraints supplied -- returns ``None`` (matches the "nothing
+      asked" posture of the delegate).
+    * Any axis collapses to ``None`` (empty iterable / non-int / all-
+      unknown items) -- that axis contributes nothing.
+    * All axes collapse to ``None`` -- returns ``None``.
+    * Otherwise -- the highest-rank tier across the per-axis answers.
+    * ``retention_days=None`` here means *unset*, NOT *unlimited* --
+      matches :func:`min_tier_for_all`.
+
+    Returns ``None`` for empty / unknown ``perspective_tier`` (caller
+    renders "unknown tier" / 404). Decoupled from the resolved
+    entitlement (delegates to :func:`min_tier_for_all`, which walks the
+    static per-tier caps), so grace vs enforce yields byte-identical
+    answers.
+
+    Never raises: a builder failure short-circuits to ``None`` so a
+    pricing-comparison tooltip stays mute instead of breaking.
+    """
+    try:
+        p = (perspective_tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if not p or p not in _TIER_ORDER:
+        return None
+    try:
+        return min_tier_for_all(
+            features=features,
+            runtimes=runtimes,
+            channels=channels,
+            retention_days=retention_days,
+            nodes=nodes,
+        )
+    except Exception as exc:
+        logger.warning("entitlements: min_tier_for_all_at failed: %s", exc)
+        return None
+
+
+def affordable_tiers_at(
+    perspective_tier: str,
+    *,
+    features=None,
+    runtimes=None,
+    channels: int | None = None,
+    retention_days: int | None = None,
+    nodes: int | None = None,
+) -> list[dict] | None:
+    """Hypothetical-perspective sibling of :func:`affordable_tiers`: every
+    *purchasable* tier admitting **all** supplied constraints, ordered by
+    rank ascending, scoped by a caller-supplied ``perspective_tier``.
+
+    Plural what-if companion of :func:`min_tier_for_all_at` (which
+    returns only the floor). Same arg shape, same per-axis ``None`` "not
+    supplied" sentinels, same never-raise contract. Lets a pricing-page
+    walkthrough render "if I were on Starter, this bundle would qualify
+    for Pro and Enterprise" off ONE round-trip instead of switching the
+    resolver.
+
+    Perspective is validated against :data:`_TIER_ORDER` (including
+    :data:`TIER_TRIAL`) but does NOT shape rows -- the qualifying-tier
+    list is anchored to the constraint bundle, matching the
+    perspective-independent posture of :func:`min_tier_for_all_at` and
+    the rest of the ``_at`` family. A parity test pins
+    ``affordable_tiers_at(p, ...) == affordable_tiers(...)`` for every
+    ``p`` in :data:`_TIER_ORDER` so the ``_at`` prefix cannot silently
+    drift into shaping rows.
+
+    Row schema and ordering mirror :func:`affordable_tiers` exactly:
+    ``tier`` / ``tier_label`` / ``tier_rank`` / ``is_minimum`` per row,
+    ``tier_rank`` ascending with same-rank ties broken alphabetically
+    for byte-stable output.
+
+    Semantics mirror :func:`affordable_tiers`:
+
+    * No constraints supplied -- returns ``None``.
+    * All axes collapse to ``None`` -- returns ``None``.
+    * Otherwise -- the full list of purchasable tiers with rank ``>=``
+      the floor (``TIER_TRIAL`` is intentionally excluded, matching
+      every other path/batch helper).
+    * Never raises.
+
+    Returns ``None`` for empty / unknown ``perspective_tier`` (caller
+    renders "unknown tier" / 404). Decoupled from the resolved
+    entitlement (delegates to :func:`affordable_tiers`), so grace vs
+    enforce yields byte-identical lists.
+    """
+    try:
+        p = (perspective_tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if not p or p not in _TIER_ORDER:
+        return None
+    try:
+        return affordable_tiers(
+            features=features,
+            runtimes=runtimes,
+            channels=channels,
+            retention_days=retention_days,
+            nodes=nodes,
+        )
+    except Exception as exc:
+        logger.warning("entitlements: affordable_tiers_at failed: %s", exc)
+        return None
+
+
+
 def _min_tier_row(key, kind: str) -> dict:
     """Per-item cheapest-tier row for :func:`min_tier_batch`.
 

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -4728,6 +4728,315 @@ def api_entitlement_affordable_tiers():
         )
 
 
+@bp_entitlement.route("/api/entitlement/required-tier-at")
+def api_entitlement_required_tier_at():
+    """``GET /api/entitlement/required-tier-at?tier=<perspective>
+    &features=a,b,c&runtimes=x,y&channels=N&retention_days=K&nodes=M`` --
+    hypothetical-perspective sibling of ``/api/entitlement/required-tier-batch``.
+
+    Wraps :func:`entitlements.min_tier_for_all_at` so a pricing-comparison
+    tooltip can render "if I were on Starter, this bundle would need Pro"
+    off ONE round-trip without first switching the resolver. Fills the
+    ``_at`` slot for the aggregate constraint-bundle family alongside the
+    per-axis ``_at`` scalars (``/capacity-diff-at``, ``/tier-unlocks-at``,
+    ``/tier-locks-at``) so a caller can call ``X_at`` uniformly across the
+    whole ``_at`` scalar family.
+
+    Perspective is validated against :data:`entitlements._TIER_ORDER`
+    (including ``trial``) but does NOT shape the result -- the floor is
+    anchored to the constraint bundle, matching every other ``_at``
+    helper. A parity contract pinned in the test suite guarantees that
+    per-row output byte-equals ``/api/entitlement/required-tier-batch`` for
+    the same bundle regardless of perspective; the response layers
+    ``perspective_tier`` / ``perspective_tier_rank`` /
+    ``upgrade_required_from_perspective`` on top so a caller can render
+    "from <perspective> this needs Pro" copy off one call.
+
+    Args are byte-identical to ``/required-tier-batch`` except for the
+    additional ``tier=`` perspective arg: at least one of ``features=`` /
+    ``runtimes=`` / ``channels=`` / ``retention_days=`` / ``nodes=`` must
+    be supplied (non-empty / parseable after normalisation). Same CSV
+    normalisation, same capacity-axis parsing, same ``None`` = "not
+    supplied" sentinel (so ``retention_days=`` blank is "unset", NOT
+    the "unlimited" sentinel that would mis-route to Enterprise).
+
+    - **400** when ``tier=`` is missing / blank, OR when no constraint
+      axis is supplied.
+    - **404** when ``tier`` is unknown. The body carries ``which=tier``
+      so a caller can render the right "unknown tier" message.
+    - **Never 5xxs**: a resolver failure yields the OSS-free shape so the
+      pricing tooltip keeps rendering.
+    """
+    raw_tier = request.args.get("tier")
+    tier_in = (raw_tier or "").strip().lower()
+    if not tier_in:
+        return jsonify({"error": "missing tier"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        if tier_in not in _ent._TIER_ORDER:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "tier", "tier": tier_in}
+                ),
+                404,
+            )
+
+        features = _parse_csv_arg("features")
+        runtimes = _parse_csv_arg("runtimes")
+        (_, channels_ok, channels_n, _) = _parse_capacity_arg("channels")
+        (_, retention_ok, retention_n, _) = _parse_capacity_arg(
+            "retention_days",
+        )
+        (_, nodes_ok, nodes_n, _) = _parse_capacity_arg("nodes")
+
+        if (
+            not features
+            and not runtimes
+            and not channels_ok
+            and not retention_ok
+            and not nodes_ok
+        ):
+            return (
+                jsonify(
+                    {
+                        "error": (
+                            "supply at least one of features=<csv>, "
+                            "runtimes=<csv>, channels=<int>, "
+                            "retention_days=<int>, or nodes=<int>"
+                        )
+                    }
+                ),
+                400,
+            )
+
+        required = _ent.min_tier_for_all_at(
+            tier_in,
+            features=features or None,
+            runtimes=runtimes or None,
+            channels=channels_n if channels_ok else None,
+            retention_days=retention_n if retention_ok else None,
+            nodes=nodes_n if nodes_ok else None,
+        )
+
+        ent = _ent.get_entitlement()
+        cur_rank = _ent.tier_rank(ent.tier)
+        persp_rank = _ent.tier_rank(tier_in)
+        req_rank = _ent.tier_rank(required) if required else -1
+        required_label = _ent.tier_label(required) if required else None
+
+        return jsonify(
+            {
+                "perspective_tier": tier_in,
+                "perspective_tier_label": _ent.tier_label(tier_in),
+                "perspective_tier_rank": persp_rank,
+                "features": features,
+                "runtimes": runtimes,
+                "channels": channels_n if channels_ok else None,
+                "retention_days": retention_n if retention_ok else None,
+                "nodes": nodes_n if nodes_ok else None,
+                "required_tier": required,
+                "required_tier_label": required_label,
+                "required_tier_rank": req_rank,
+                "current_tier": ent.tier,
+                "current_tier_rank": cur_rank,
+                "upgrade_required_from_perspective": (
+                    bool(required) and req_rank > persp_rank
+                ),
+                "upgrade_required_from_current": (
+                    bool(required) and req_rank > cur_rank
+                ),
+                "grace": bool(ent.grace),
+                "enforced": _ent.is_enforced(),
+            }
+        )
+    except Exception as exc:
+        logger.warning("api_entitlement_required_tier_at: error: %s", exc)
+        (_, channels_ok, channels_n, _) = _parse_capacity_arg("channels")
+        (_, retention_ok, retention_n, _) = _parse_capacity_arg("retention_days")
+        (_, nodes_ok, nodes_n, _) = _parse_capacity_arg("nodes")
+        return jsonify(
+            {
+                "perspective_tier": tier_in,
+                "perspective_tier_label": None,
+                "perspective_tier_rank": -1,
+                "features": _parse_csv_arg("features"),
+                "runtimes": _parse_csv_arg("runtimes"),
+                "channels": channels_n if channels_ok else None,
+                "retention_days": retention_n if retention_ok else None,
+                "nodes": nodes_n if nodes_ok else None,
+                "required_tier": None,
+                "required_tier_label": None,
+                "required_tier_rank": -1,
+                "current_tier": "oss",
+                "current_tier_rank": 0,
+                "upgrade_required_from_perspective": False,
+                "upgrade_required_from_current": False,
+                "grace": True,
+                "enforced": False,
+            }
+        )
+
+
+@bp_entitlement.route("/api/entitlement/affordable-tiers-at")
+def api_entitlement_affordable_tiers_at():
+    """``GET /api/entitlement/affordable-tiers-at?tier=<perspective>
+    &features=a,b,c&runtimes=x,y&channels=N&retention_days=K&nodes=M`` --
+    hypothetical-perspective sibling of ``/api/entitlement/affordable-tiers``.
+
+    Wraps :func:`entitlements.affordable_tiers_at` so a pricing-page
+    walkthrough can render "if I were on Starter, this bundle would
+    qualify for Pro and Enterprise" off ONE round-trip without first
+    switching the resolver. Plural what-if companion of
+    ``/required-tier-at`` (which returns only the floor).
+
+    Perspective is validated against :data:`entitlements._TIER_ORDER`
+    (including ``trial``) but does NOT shape rows -- the qualifying-tier
+    list is anchored to the constraint bundle. A parity contract pinned
+    in the test suite guarantees per-row output byte-equals
+    ``/api/entitlement/affordable-tiers`` for the same bundle regardless
+    of perspective; the response layers ``perspective_tier`` /
+    ``is_at_or_better_than_perspective`` on top so a walkthrough surface
+    can render "from <perspective> these tiers qualify" copy off one
+    call, alongside the existing ``is_current`` /
+    ``is_current_or_better`` current-resolver flags.
+
+    Args are byte-identical to ``/affordable-tiers`` except for the
+    additional ``tier=`` perspective arg. Same CSV normalisation, same
+    capacity-axis parsing, same ``None`` = "not supplied" sentinel.
+
+    - **400** when ``tier=`` is missing / blank, OR when no constraint
+      axis is supplied.
+    - **404** when ``tier`` is unknown. The body carries ``which=tier``
+      so a caller can render the right "unknown tier" message.
+    - **Never 5xxs**: a resolver failure yields the OSS-free shape
+      (empty tier list) so the pricing walkthrough keeps rendering.
+    """
+    raw_tier = request.args.get("tier")
+    tier_in = (raw_tier or "").strip().lower()
+    if not tier_in:
+        return jsonify({"error": "missing tier"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        if tier_in not in _ent._TIER_ORDER:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "tier", "tier": tier_in}
+                ),
+                404,
+            )
+
+        features = _parse_csv_arg("features")
+        runtimes = _parse_csv_arg("runtimes")
+        (_, channels_ok, channels_n, _) = _parse_capacity_arg("channels")
+        (_, retention_ok, retention_n, _) = _parse_capacity_arg(
+            "retention_days",
+        )
+        (_, nodes_ok, nodes_n, _) = _parse_capacity_arg("nodes")
+
+        if (
+            not features
+            and not runtimes
+            and not channels_ok
+            and not retention_ok
+            and not nodes_ok
+        ):
+            return (
+                jsonify(
+                    {
+                        "error": (
+                            "supply at least one of features=<csv>, "
+                            "runtimes=<csv>, channels=<int>, "
+                            "retention_days=<int>, or nodes=<int>"
+                        )
+                    }
+                ),
+                400,
+            )
+
+        ent = _ent.get_entitlement()
+        rows = _ent.affordable_tiers_at(
+            tier_in,
+            features=features or None,
+            runtimes=runtimes or None,
+            channels=channels_n if channels_ok else None,
+            retention_days=retention_n if retention_ok else None,
+            nodes=nodes_n if nodes_ok else None,
+        ) or []
+
+        cur_tier = ent.tier
+        cur_rank = _ent.tier_rank(cur_tier)
+        persp_rank = _ent.tier_rank(tier_in)
+        minimum_tier = rows[0]["tier"] if rows else None
+        minimum_label = rows[0]["tier_label"] if rows else None
+        minimum_rank = rows[0]["tier_rank"] if rows else -1
+
+        augmented: list[dict] = []
+        for row in rows:
+            augmented.append(
+                {
+                    "tier": row["tier"],
+                    "tier_label": row["tier_label"],
+                    "tier_rank": row["tier_rank"],
+                    "is_minimum": row["is_minimum"],
+                    "is_current": row["tier"] == cur_tier,
+                    "is_current_or_better": row["tier_rank"] >= cur_rank,
+                    "is_perspective": row["tier"] == tier_in,
+                    "is_at_or_better_than_perspective": (
+                        row["tier_rank"] >= persp_rank
+                    ),
+                }
+            )
+
+        return jsonify(
+            {
+                "perspective_tier": tier_in,
+                "perspective_tier_label": _ent.tier_label(tier_in),
+                "perspective_tier_rank": persp_rank,
+                "features": features,
+                "runtimes": runtimes,
+                "channels": channels_n if channels_ok else None,
+                "retention_days": retention_n if retention_ok else None,
+                "nodes": nodes_n if nodes_ok else None,
+                "current_tier": cur_tier,
+                "current_tier_rank": cur_rank,
+                "minimum_tier": minimum_tier,
+                "minimum_tier_label": minimum_label,
+                "minimum_tier_rank": minimum_rank,
+                "tiers": augmented,
+                "grace": bool(ent.grace),
+                "enforced": _ent.is_enforced(),
+            }
+        )
+    except Exception as exc:
+        logger.warning("api_entitlement_affordable_tiers_at: error: %s", exc)
+        (_, channels_ok, channels_n, _) = _parse_capacity_arg("channels")
+        (_, retention_ok, retention_n, _) = _parse_capacity_arg("retention_days")
+        (_, nodes_ok, nodes_n, _) = _parse_capacity_arg("nodes")
+        return jsonify(
+            {
+                "perspective_tier": tier_in,
+                "perspective_tier_label": None,
+                "perspective_tier_rank": -1,
+                "features": _parse_csv_arg("features"),
+                "runtimes": _parse_csv_arg("runtimes"),
+                "channels": channels_n if channels_ok else None,
+                "retention_days": retention_n if retention_ok else None,
+                "nodes": nodes_n if nodes_ok else None,
+                "current_tier": "oss",
+                "current_tier_rank": 0,
+                "minimum_tier": None,
+                "minimum_tier_label": None,
+                "minimum_tier_rank": -1,
+                "tiers": [],
+                "grace": True,
+                "enforced": False,
+            }
+        )
+
+
+
 @bp_entitlement.route("/api/entitlement/min-tier")
 def api_entitlement_min_tier():
     """``GET /api/entitlement/min-tier?<axis>=<value>`` -- cheapest purchasable

--- a/tests/test_entitlement_required_tier_at_affordable_tiers_at.py
+++ b/tests/test_entitlement_required_tier_at_affordable_tiers_at.py
@@ -1,0 +1,722 @@
+"""Tests for the ``_at`` (hypothetical-perspective) siblings of the
+aggregate constraint-bundle helpers:
+
+* :func:`clawmetry.entitlements.min_tier_for_all_at`
+* :func:`clawmetry.entitlements.affordable_tiers_at`
+
+and their HTTP wrappers:
+
+* ``GET /api/entitlement/required-tier-at``
+* ``GET /api/entitlement/affordable-tiers-at``
+
+These fill the ``_at`` slot for the aggregate constraint-bundle family
+alongside the per-axis ``_at`` scalars (``capacity_diff_at``,
+``tier_unlocks_at``, ``tier_locks_at``, ``tier_diff_at_batch``) so a
+pricing-comparison tooltip can call ``X_at(perspective, ...)`` uniformly
+across the whole ``_at`` scalar family.
+
+The core invariant pinned in this file is the **parity contract**: for
+every perspective in :data:`_TIER_ORDER`, the ``_at`` sibling returns
+byte-identical results to the current-perspective helper for the same
+constraint bundle. Perspective is validated but does NOT shape the
+answer -- a future regression that leaks the perspective into the
+computation breaks loudly here instead of silently in the UI.
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# ── min_tier_for_all_at: perspective validation ───────────────────────────
+
+
+def test_min_tier_for_all_at_missing_perspective_returns_none(ent):
+    assert ent.min_tier_for_all_at("", features=["fleet"]) is None
+    assert ent.min_tier_for_all_at(None, features=["fleet"]) is None
+
+
+def test_min_tier_for_all_at_unknown_perspective_returns_none(ent):
+    assert ent.min_tier_for_all_at("nope", features=["fleet"]) is None
+    assert ent.min_tier_for_all_at("cloud", features=["fleet"]) is None
+
+
+def test_min_tier_for_all_at_accepts_trial_perspective(ent):
+    """Perspective validation mirrors every other ``_at`` helper: trial is
+    a legitimate perspective even though it is not purchasable."""
+    assert ent.min_tier_for_all_at(
+        ent.TIER_TRIAL, features=["fleet"]
+    ) == ent.TIER_CLOUD_STARTER
+
+
+def test_min_tier_for_all_at_accepts_every_tier_in_tier_order(ent):
+    """Every id in _TIER_ORDER must be accepted as a perspective."""
+    for p in ent._TIER_ORDER:
+        out = ent.min_tier_for_all_at(p, features=["fleet"])
+        assert out == ent.TIER_CLOUD_STARTER, p
+
+
+def test_min_tier_for_all_at_perspective_case_insensitive(ent):
+    """Whitespace + case are normalised on the perspective."""
+    a = ent.min_tier_for_all_at("  Cloud_Pro  ", features=["fleet"])
+    b = ent.min_tier_for_all_at(ent.TIER_CLOUD_PRO, features=["fleet"])
+    assert a == b
+
+
+# ── min_tier_for_all_at: parity vs current-perspective sibling ────────────
+
+
+def test_min_tier_for_all_at_parity_features(ent):
+    """Byte-identical to :func:`min_tier_for_all` for every perspective."""
+    for p in ent._TIER_ORDER:
+        at = ent.min_tier_for_all_at(p, features=["fleet"])
+        cur = ent.min_tier_for_all(features=["fleet"])
+        assert at == cur, p
+
+
+def test_min_tier_for_all_at_parity_across_axes(ent):
+    """Parity holds across every axis combination."""
+    cases = (
+        {"features": ["fleet"]},
+        {"features": ["otel_export"]},
+        {"features": ["sso"]},
+        {"features": ["fleet", "otel_export"]},
+        {"runtimes": ["claude_code"]},
+        {"channels": 10},
+        {"retention_days": 60},
+        {"retention_days": 365},
+        {"nodes": 3},
+        {"features": ["fleet"], "retention_days": 365},
+        {"features": ["fleet"], "runtimes": ["claude_code"], "channels": 5},
+    )
+    for p in ent._TIER_ORDER:
+        for inputs in cases:
+            at = ent.min_tier_for_all_at(p, **inputs)
+            cur = ent.min_tier_for_all(**inputs)
+            assert at == cur, (p, inputs)
+
+
+def test_min_tier_for_all_at_no_constraints_returns_none(ent):
+    """No constraints supplied -- returns ``None`` even with a valid
+    perspective."""
+    assert ent.min_tier_for_all_at(ent.TIER_CLOUD_PRO) is None
+
+
+def test_min_tier_for_all_at_retention_none_means_unset(ent):
+    """``retention_days=None`` is *unset*, NOT *unlimited* (which would
+    mis-route to Enterprise). Matches :func:`min_tier_for_all`."""
+    out = ent.min_tier_for_all_at(
+        ent.TIER_CLOUD_STARTER, features=["fleet"], retention_days=None
+    )
+    assert out == ent.TIER_CLOUD_STARTER
+
+
+def test_min_tier_for_all_at_most_constraining_axis_wins(ent):
+    """fleet -> Starter (rank 1); sso -> Enterprise (rank 3). The aggregate
+    floor must be Enterprise regardless of perspective."""
+    out = ent.min_tier_for_all_at(
+        ent.TIER_OSS, features=["fleet", "sso"]
+    )
+    assert out == ent.TIER_ENTERPRISE
+
+
+# ── min_tier_for_all_at: contract guarantees ──────────────────────────────
+
+
+def test_min_tier_for_all_at_never_raises_on_garbage(ent):
+    """Non-iterables, exotic types on the constraint axes -- helper must
+    collapse to ``None`` instead of bubbling up an exception."""
+    p = ent.TIER_CLOUD_STARTER
+    assert ent.min_tier_for_all_at(p, features=42) is None
+    assert ent.min_tier_for_all_at(p, runtimes=object()) is None
+    assert ent.min_tier_for_all_at(p, channels="not a number") is None
+
+
+def test_min_tier_for_all_at_never_raises_on_perspective_type(ent):
+    """Perspective must accept anything without crashing."""
+    assert ent.min_tier_for_all_at(42, features=["fleet"]) is None
+    assert ent.min_tier_for_all_at(object(), features=["fleet"]) is None
+    assert ent.min_tier_for_all_at([], features=["fleet"]) is None
+
+
+def test_min_tier_for_all_at_grace_enforce_identity(monkeypatch, ent):
+    """Decoupled from the resolved entitlement: grace vs enforce yields
+    identical answers."""
+    grace_out = ent.min_tier_for_all_at(
+        ent.TIER_CLOUD_STARTER, features=["fleet"]
+    )
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    importlib.reload(ent)
+    ent.invalidate()
+    enforce_out = ent.min_tier_for_all_at(
+        ent.TIER_CLOUD_STARTER, features=["fleet"]
+    )
+    assert grace_out == enforce_out
+
+
+# ── affordable_tiers_at: perspective validation ───────────────────────────
+
+
+def test_affordable_tiers_at_missing_perspective_returns_none(ent):
+    assert ent.affordable_tiers_at("", features=["fleet"]) is None
+    assert ent.affordable_tiers_at(None, features=["fleet"]) is None
+
+
+def test_affordable_tiers_at_unknown_perspective_returns_none(ent):
+    assert ent.affordable_tiers_at("nope", features=["fleet"]) is None
+
+
+def test_affordable_tiers_at_accepts_trial_perspective(ent):
+    out = ent.affordable_tiers_at(ent.TIER_TRIAL, features=["fleet"])
+    assert out is not None
+    assert out[0]["tier"] == ent.TIER_CLOUD_STARTER
+
+
+def test_affordable_tiers_at_accepts_every_tier_in_tier_order(ent):
+    for p in ent._TIER_ORDER:
+        out = ent.affordable_tiers_at(p, features=["fleet"])
+        assert out is not None, p
+        assert out[0]["tier"] == ent.TIER_CLOUD_STARTER, p
+
+
+# ── affordable_tiers_at: parity vs current-perspective sibling ────────────
+
+
+def test_affordable_tiers_at_parity_features(ent):
+    """Byte-identical to :func:`affordable_tiers` for every perspective."""
+    for p in ent._TIER_ORDER:
+        at = ent.affordable_tiers_at(p, features=["fleet"])
+        cur = ent.affordable_tiers(features=["fleet"])
+        assert at == cur, p
+
+
+def test_affordable_tiers_at_parity_across_axes(ent):
+    cases = (
+        {"features": ["fleet"]},
+        {"features": ["otel_export"]},
+        {"features": ["sso"]},
+        {"features": ["fleet", "otel_export"]},
+        {"runtimes": ["claude_code"]},
+        {"channels": 10},
+        {"retention_days": 60},
+        {"retention_days": 365},
+        {"nodes": 3},
+        {"features": ["fleet"], "retention_days": 365},
+    )
+    for p in ent._TIER_ORDER:
+        for inputs in cases:
+            at = ent.affordable_tiers_at(p, **inputs)
+            cur = ent.affordable_tiers(**inputs)
+            assert at == cur, (p, inputs)
+
+
+def test_affordable_tiers_at_no_constraints_returns_none(ent):
+    assert ent.affordable_tiers_at(ent.TIER_CLOUD_PRO) is None
+
+
+def test_affordable_tiers_at_row_schema(ent):
+    """Row schema mirrors :func:`affordable_tiers` byte-for-byte."""
+    out = ent.affordable_tiers_at(ent.TIER_CLOUD_STARTER, features=["fleet"])
+    expected_keys = {"tier", "tier_label", "tier_rank", "is_minimum"}
+    for row in out:
+        assert set(row.keys()) == expected_keys, row
+
+
+def test_affordable_tiers_at_trial_never_in_results(ent):
+    """``TIER_TRIAL`` is never a purchasable row regardless of perspective."""
+    for p in ent._TIER_ORDER:
+        for inputs in (
+            {"features": ["fleet"]},
+            {"channels": 10},
+            {"retention_days": 60},
+            {"nodes": 3},
+        ):
+            out = ent.affordable_tiers_at(p, **inputs)
+            if out is None:
+                continue
+            assert all(r["tier"] != ent.TIER_TRIAL for r in out), (p, inputs)
+
+
+def test_affordable_tiers_at_first_row_matches_min_tier_for_all_at(ent):
+    """``affordable_tiers_at[0].tier`` == ``min_tier_for_all_at`` for the
+    same perspective + args -- the plural can't disagree with the singular."""
+    cases = (
+        {"features": ["fleet"]},
+        {"features": ["otel_export"]},
+        {"runtimes": ["claude_code"]},
+        {"channels": 10},
+        {"retention_days": 60},
+        {"features": ["fleet"], "retention_days": 365},
+    )
+    for p in ent._TIER_ORDER:
+        for inputs in cases:
+            floor = ent.min_tier_for_all_at(p, **inputs)
+            out = ent.affordable_tiers_at(p, **inputs)
+            if floor is None:
+                assert out is None, (p, inputs)
+                continue
+            assert out is not None and out[0]["tier"] == floor, (p, inputs)
+
+
+def test_affordable_tiers_at_grace_enforce_identity(monkeypatch, ent):
+    grace_out = ent.affordable_tiers_at(
+        ent.TIER_CLOUD_STARTER, features=["fleet"]
+    )
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    importlib.reload(ent)
+    ent.invalidate()
+    enforce_out = ent.affordable_tiers_at(
+        ent.TIER_CLOUD_STARTER, features=["fleet"]
+    )
+    assert grace_out == enforce_out
+
+
+def test_affordable_tiers_at_never_raises_on_garbage(ent):
+    p = ent.TIER_CLOUD_STARTER
+    assert ent.affordable_tiers_at(p, features=42) is None
+    assert ent.affordable_tiers_at(p, runtimes=object()) is None
+    assert ent.affordable_tiers_at(p, channels="not a number") is None
+
+
+def test_affordable_tiers_at_never_raises_on_perspective_type(ent):
+    assert ent.affordable_tiers_at(42, features=["fleet"]) is None
+    assert ent.affordable_tiers_at(object(), features=["fleet"]) is None
+
+
+# ── API: /api/entitlement/required-tier-at ────────────────────────────────
+
+
+def test_api_required_tier_at_missing_tier_returns_400(client):
+    r = client.get("/api/entitlement/required-tier-at?features=fleet")
+    assert r.status_code == 400
+    body = r.get_json()
+    assert "error" in body
+
+
+def test_api_required_tier_at_unknown_tier_returns_404(client):
+    r = client.get(
+        "/api/entitlement/required-tier-at?tier=nope&features=fleet"
+    )
+    assert r.status_code == 404
+    body = r.get_json()
+    assert body["which"] == "tier"
+
+
+def test_api_required_tier_at_missing_all_axes_returns_400(client, ent):
+    r = client.get(
+        "/api/entitlement/required-tier-at?tier=" + ent.TIER_CLOUD_PRO
+    )
+    assert r.status_code == 400
+    body = r.get_json()
+    assert "error" in body
+
+
+def test_api_required_tier_at_happy_path(client, ent):
+    r = client.get(
+        "/api/entitlement/required-tier-at?tier="
+        + ent.TIER_CLOUD_STARTER
+        + "&features=fleet"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["perspective_tier"] == ent.TIER_CLOUD_STARTER
+    assert body["perspective_tier_rank"] == ent.tier_rank(
+        ent.TIER_CLOUD_STARTER
+    )
+    assert body["required_tier"] == ent.TIER_CLOUD_STARTER
+    assert body["required_tier_label"] == ent.tier_label(
+        ent.TIER_CLOUD_STARTER
+    )
+    assert body["required_tier_rank"] == ent.tier_rank(
+        ent.TIER_CLOUD_STARTER
+    )
+
+
+def test_api_required_tier_at_envelope_keys(client, ent):
+    r = client.get(
+        "/api/entitlement/required-tier-at?tier="
+        + ent.TIER_CLOUD_STARTER
+        + "&features=fleet"
+    )
+    body = r.get_json()
+    expected = {
+        "perspective_tier",
+        "perspective_tier_label",
+        "perspective_tier_rank",
+        "features",
+        "runtimes",
+        "channels",
+        "retention_days",
+        "nodes",
+        "required_tier",
+        "required_tier_label",
+        "required_tier_rank",
+        "current_tier",
+        "current_tier_rank",
+        "upgrade_required_from_perspective",
+        "upgrade_required_from_current",
+        "grace",
+        "enforced",
+    }
+    assert expected <= set(body.keys())
+
+
+def test_api_required_tier_at_upgrade_flags_from_oss_perspective(
+    client, ent
+):
+    r = client.get(
+        "/api/entitlement/required-tier-at?tier="
+        + ent.TIER_OSS
+        + "&features=fleet"
+    )
+    body = r.get_json()
+    assert body["upgrade_required_from_perspective"] is True
+
+
+def test_api_required_tier_at_upgrade_flags_from_enterprise_perspective(
+    client, ent
+):
+    r = client.get(
+        "/api/entitlement/required-tier-at?tier="
+        + ent.TIER_ENTERPRISE
+        + "&features=fleet"
+    )
+    body = r.get_json()
+    assert body["upgrade_required_from_perspective"] is False
+
+
+def test_api_required_tier_at_byte_equal_floor_regardless_of_perspective(
+    client, ent
+):
+    """The floor is anchored to the constraint bundle, NOT the perspective."""
+    q = "&features=fleet,otel_export&nodes=2&retention_days=45"
+    floors = []
+    for p in (
+        ent.TIER_OSS,
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_ENTERPRISE,
+    ):
+        r = client.get(
+            "/api/entitlement/required-tier-at?tier=" + p + q
+        )
+        floors.append(r.get_json()["required_tier"])
+    assert len(set(floors)) == 1, floors
+
+
+def test_api_required_tier_at_parity_vs_required_tier_batch(client, ent):
+    """Perspective-independent parity: the ``_at`` floor matches
+    ``/required-tier-batch`` for the same bundle."""
+    q = "features=fleet,otel_export&nodes=2&retention_days=45"
+    a = client.get(
+        "/api/entitlement/required-tier-at?tier="
+        + ent.TIER_CLOUD_STARTER
+        + "&"
+        + q
+    ).get_json()
+    b = client.get("/api/entitlement/required-tier-batch?" + q).get_json()
+    assert a["required_tier"] == b["required_tier"]
+    assert a["required_tier_rank"] == b["required_tier_rank"]
+
+
+def test_api_required_tier_at_unparseable_capacity_falls_through(client, ent):
+    r = client.get(
+        "/api/entitlement/required-tier-at?tier="
+        + ent.TIER_CLOUD_STARTER
+        + "&features=fleet&channels=xx"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["channels"] is None
+    assert body["features"] == ["fleet"]
+
+
+def test_api_required_tier_at_csv_normalisation(client, ent):
+    r = client.get(
+        "/api/entitlement/required-tier-at?tier="
+        + ent.TIER_CLOUD_STARTER
+        + "&features=fleet,FLEET,,fleet"
+    )
+    body = r.get_json()
+    assert body["features"] == ["fleet"]
+
+
+def test_api_required_tier_at_accepts_trial_perspective(client, ent):
+    r = client.get(
+        "/api/entitlement/required-tier-at?tier="
+        + ent.TIER_TRIAL
+        + "&features=fleet"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["perspective_tier"] == ent.TIER_TRIAL
+
+
+def test_api_required_tier_at_perspective_whitespace_normalised(client, ent):
+    r = client.get(
+        "/api/entitlement/required-tier-at?tier=%20cloud_pro%20"
+        "&features=fleet"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["perspective_tier"] == ent.TIER_CLOUD_PRO
+
+
+# ── API: /api/entitlement/affordable-tiers-at ─────────────────────────────
+
+
+def test_api_affordable_tiers_at_missing_tier_returns_400(client):
+    r = client.get("/api/entitlement/affordable-tiers-at?features=fleet")
+    assert r.status_code == 400
+
+
+def test_api_affordable_tiers_at_unknown_tier_returns_404(client):
+    r = client.get(
+        "/api/entitlement/affordable-tiers-at?tier=nope&features=fleet"
+    )
+    assert r.status_code == 404
+    body = r.get_json()
+    assert body["which"] == "tier"
+
+
+def test_api_affordable_tiers_at_missing_all_axes_returns_400(client, ent):
+    r = client.get(
+        "/api/entitlement/affordable-tiers-at?tier=" + ent.TIER_CLOUD_PRO
+    )
+    assert r.status_code == 400
+
+
+def test_api_affordable_tiers_at_happy_path(client, ent):
+    r = client.get(
+        "/api/entitlement/affordable-tiers-at?tier="
+        + ent.TIER_CLOUD_STARTER
+        + "&features=fleet"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["perspective_tier"] == ent.TIER_CLOUD_STARTER
+    assert body["minimum_tier"] == ent.TIER_CLOUD_STARTER
+    assert body["tiers"][0]["tier"] == ent.TIER_CLOUD_STARTER
+    assert body["tiers"][0]["is_minimum"] is True
+
+
+def test_api_affordable_tiers_at_row_keys(client, ent):
+    r = client.get(
+        "/api/entitlement/affordable-tiers-at?tier="
+        + ent.TIER_CLOUD_STARTER
+        + "&features=fleet"
+    )
+    body = r.get_json()
+    row_keys = {
+        "tier",
+        "tier_label",
+        "tier_rank",
+        "is_minimum",
+        "is_current",
+        "is_current_or_better",
+        "is_perspective",
+        "is_at_or_better_than_perspective",
+    }
+    for row in body["tiers"]:
+        assert set(row.keys()) == row_keys, row
+
+
+def test_api_affordable_tiers_at_envelope_keys(client, ent):
+    r = client.get(
+        "/api/entitlement/affordable-tiers-at?tier="
+        + ent.TIER_CLOUD_STARTER
+        + "&features=fleet"
+    )
+    body = r.get_json()
+    expected = {
+        "perspective_tier",
+        "perspective_tier_label",
+        "perspective_tier_rank",
+        "features",
+        "runtimes",
+        "channels",
+        "retention_days",
+        "nodes",
+        "current_tier",
+        "current_tier_rank",
+        "minimum_tier",
+        "minimum_tier_label",
+        "minimum_tier_rank",
+        "tiers",
+        "grace",
+        "enforced",
+    }
+    assert expected <= set(body.keys())
+
+
+def test_api_affordable_tiers_at_is_perspective_marks_row(client, ent):
+    r = client.get(
+        "/api/entitlement/affordable-tiers-at?tier="
+        + ent.TIER_CLOUD_PRO
+        + "&features=fleet"
+    )
+    body = r.get_json()
+    flagged = [row for row in body["tiers"] if row["is_perspective"]]
+    assert len(flagged) == 1
+    assert flagged[0]["tier"] == ent.TIER_CLOUD_PRO
+
+
+def test_api_affordable_tiers_at_at_or_better_from_perspective(client, ent):
+    """``is_at_or_better_than_perspective`` must line up with rank
+    comparison against the perspective."""
+    r = client.get(
+        "/api/entitlement/affordable-tiers-at?tier="
+        + ent.TIER_CLOUD_PRO
+        + "&features=sessions"
+    )
+    body = r.get_json()
+    persp_rank = body["perspective_tier_rank"]
+    for row in body["tiers"]:
+        assert row["is_at_or_better_than_perspective"] == (
+            row["tier_rank"] >= persp_rank
+        ), row
+
+
+def test_api_affordable_tiers_at_tiers_bytewise_equal_across_perspectives(
+    client, ent
+):
+    """The row LIST (minus the ``is_perspective`` /
+    ``is_at_or_better_than_perspective`` flags) is anchored to the bundle,
+    not the perspective."""
+    q = "&features=fleet"
+    lists = []
+    for p in (
+        ent.TIER_OSS,
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_ENTERPRISE,
+    ):
+        r = client.get(
+            "/api/entitlement/affordable-tiers-at?tier=" + p + q
+        )
+        body = r.get_json()
+        stripped = [
+            {
+                "tier": row["tier"],
+                "tier_label": row["tier_label"],
+                "tier_rank": row["tier_rank"],
+                "is_minimum": row["is_minimum"],
+            }
+            for row in body["tiers"]
+        ]
+        lists.append(stripped)
+    for lst in lists[1:]:
+        assert lst == lists[0]
+
+
+def test_api_affordable_tiers_at_parity_vs_affordable_tiers(client, ent):
+    """The stripped tier list must byte-equal ``/affordable-tiers`` for the
+    same bundle regardless of perspective."""
+    q = "features=fleet,otel_export&nodes=2&retention_days=45"
+    a = client.get(
+        "/api/entitlement/affordable-tiers-at?tier="
+        + ent.TIER_CLOUD_STARTER
+        + "&"
+        + q
+    ).get_json()
+    b = client.get("/api/entitlement/affordable-tiers?" + q).get_json()
+    a_stripped = [
+        {
+            "tier": r["tier"],
+            "tier_label": r["tier_label"],
+            "tier_rank": r["tier_rank"],
+            "is_minimum": r["is_minimum"],
+        }
+        for r in a["tiers"]
+    ]
+    b_stripped = [
+        {
+            "tier": r["tier"],
+            "tier_label": r["tier_label"],
+            "tier_rank": r["tier_rank"],
+            "is_minimum": r["is_minimum"],
+        }
+        for r in b["tiers"]
+    ]
+    assert a_stripped == b_stripped
+    assert a["minimum_tier"] == b["minimum_tier"]
+
+
+def test_api_affordable_tiers_at_capacity_axes_happy_path(client, ent):
+    r = client.get(
+        "/api/entitlement/affordable-tiers-at?tier="
+        + ent.TIER_CLOUD_PRO
+        + "&channels=10&retention_days=60&nodes=2"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["channels"] == 10
+    assert body["retention_days"] == 60
+    assert body["nodes"] == 2
+    assert body["minimum_tier"] is not None
+    assert body["tiers"]
+
+
+def test_api_affordable_tiers_at_never_crashes_on_garbage(client, ent):
+    for q in (
+        "features=,,,&runtimes=,,",
+        "channels=NaN&retention_days=&nodes=",
+        "features=%00bad%01",
+    ):
+        r = client.get(
+            "/api/entitlement/affordable-tiers-at?tier="
+            + ent.TIER_CLOUD_STARTER
+            + "&"
+            + q
+        )
+        # 200 (envelope) or 400 (no axis) -- never 5xx.
+        assert r.status_code in (200, 400), (q, r.status_code)
+
+
+def test_api_required_tier_at_never_crashes_on_garbage(client, ent):
+    for q in (
+        "features=,,,&runtimes=,,",
+        "channels=NaN&retention_days=&nodes=",
+        "features=%00bad%01",
+    ):
+        r = client.get(
+            "/api/entitlement/required-tier-at?tier="
+            + ent.TIER_CLOUD_STARTER
+            + "&"
+            + q
+        )
+        assert r.status_code in (200, 400), (q, r.status_code)
+
+
+def test_api_affordable_tiers_at_accepts_trial_perspective(client, ent):
+    r = client.get(
+        "/api/entitlement/affordable-tiers-at?tier="
+        + ent.TIER_TRIAL
+        + "&features=fleet"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["perspective_tier"] == ent.TIER_TRIAL


### PR DESCRIPTION
## Summary

- Fills the `_at` (hypothetical-perspective) slot for the aggregate constraint-bundle family (`min_tier_for_all` / `affordable_tiers`) alongside the per-axis `_at` scalars (`capacity_diff_at`, `tier_unlocks_at`, `tier_locks_at`, `tier_diff_at_batch`) so a pricing-comparison surface can call `X_at(perspective, ...)` uniformly across the whole `_at` scalar family.
- Adds `clawmetry.entitlements.min_tier_for_all_at(perspective, *, features, runtimes, channels, retention_days, nodes) -> str | None` — what-if wrapper around `min_tier_for_all`. Perspective is validated against `_TIER_ORDER` (trial accepted) but does NOT shape the answer; pinned by parity tests so the `_at` prefix cannot silently drift into the computation.
- Adds `clawmetry.entitlements.affordable_tiers_at(...)` — plural what-if companion; same row schema and ordering as `affordable_tiers`, same trial-excluded posture.
- Adds `GET /api/entitlement/required-tier-at` and `GET /api/entitlement/affordable-tiers-at`. Envelopes carry `perspective_tier` + rank and (for `/required-tier-at`) `upgrade_required_from_perspective` / `upgrade_required_from_current`; the affordable-tiers rows layer `is_perspective` + `is_at_or_better_than_perspective` on top of the existing `is_current` flags.
- Both endpoints follow the family posture: **400** on missing `tier=` or no constraint axis, **404** on unknown `tier` (body carries `which=tier`), never 5xx (OSS-free shape on any resolver failure).

## Test plan

- [x] `python -m py_compile` — `clawmetry/entitlements.py`, `routes/entitlement.py`, `tests/test_entitlement_required_tier_at_affordable_tiers_at.py`, `dashboard.py`
- [x] `ruff check clawmetry/entitlements.py routes/entitlement.py tests/…` — all checks passed
- [x] 53 new tests in `tests/test_entitlement_required_tier_at_affordable_tiers_at.py` — parity vs `min_tier_for_all` / `affordable_tiers` for every id in `_TIER_ORDER` across every axis combination, perspective validation (trial accepted, unknown → None/404, whitespace/case normalised, non-str inputs never raise), grace/enforce identity, API envelope + row shape, byte-equal-across-perspectives invariant.
- [x] Adjacent suites still green: `test_entitlement_affordable_tiers.py` (40 tests), `test_entitlement_capacity_diff_at.py` + `test_entitlement_next_prev_tier_capacity_diff_at.py` + `test_entitlement_required_tier_capacity.py` (140 tests).
- [ ] CI matrix (Ubuntu / macOS / Windows × Py 3.9 / 3.11) green on this branch.

## Local operator verification checklist

I can't reach the live daemon or cloud snapshot from this environment; these steps run on your box before flipping the PR out of draft:

- [ ] Copy changed files into `~/.clawmetry/lib/python3.11/site-packages/clawmetry/` (`entitlements.py` only) and the running `routes/` sibling; clear `__pycache__/` under both.
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` to reload the daemon.
- [ ] Local sanity:
  - `curl -sS 'http://localhost:8900/api/entitlement/required-tier-at?tier=cloud_starter&features=fleet' | jq`
  - `curl -sS 'http://localhost:8900/api/entitlement/required-tier-at?tier=cloud_pro&features=sso' | jq .upgrade_required_from_perspective`
  - `curl -sS 'http://localhost:8900/api/entitlement/affordable-tiers-at?tier=cloud_pro&features=fleet' | jq '.tiers[] | {tier, is_perspective, is_at_or_better_than_perspective}'`
  - `curl -sSi 'http://localhost:8900/api/entitlement/required-tier-at?tier=nope&features=fleet' | head -5` → expect `404` with `"which":"tier"`
  - `curl -sSi 'http://localhost:8900/api/entitlement/required-tier-at?features=fleet' | head -5` → expect `400 missing tier`
  - `curl -sSi 'http://localhost:8900/api/entitlement/affordable-tiers-at?tier=cloud_starter' | head -5` → expect `400 supply at least one of …`
- [ ] Decrypt the live cloud snapshot in the browser (the ClawMetry web console) and confirm the two new endpoints return the same `required_tier` / `minimum_tier` as `/required-tier-batch` and `/affordable-tiers` for the same bundle (perspective-independence contract).
- [ ] Grace posture preserved — response `grace: true` unless the daemon has flipped to enforce; nothing new is gated.

Draft only. Not a release. No `__version__` bump. No enforcement flip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B4QrSmrXfQfXhqRCWH2QYj

---
_Generated by [Claude Code](https://claude.ai/code/session_01B4QrSmrXfQfXhqRCWH2QYj)_