### PR TITLE
feat(entitlement): channel_catalog + /api/entitlement/channel-catalog

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -107,6 +107,66 @@ RUNTIME_LABELS = {
     "nanoclaw": "NanoClaw",
 }
 
+# Canonical list of chat-channel adapters observable by ClawMetry, in the
+# same order the sync daemon walks them (``clawmetry/sync.py``
+# ``_CHANNEL_DIRS``). Every channel is FREE -- there is no paid-channel
+# tier -- so :func:`channel_catalog` renders every row unlocked; the
+# ``channels`` capacity axis (``min_tier_for_channel_count``) governs how
+# many concurrent channels each plan admits, not which adapters unlock.
+#
+# Kept in lockstep with ``clawmetry.sync._CHANNEL_DIRS`` by a pin test in
+# ``tests/test_entitlement_channel_catalog.py`` -- adding a new adapter
+# means updating BOTH lists in the same PR; the pin fails loudly otherwise.
+ALL_CHANNELS: tuple[str, ...] = (
+    "telegram",
+    "signal",
+    "whatsapp",
+    "discord",
+    "slack",
+    "irc",
+    "imessage",
+    "webchat",
+    "googlechat",
+    "msteams",
+    "bluebubbles",
+    "matrix",
+    "mattermost",
+    "line",
+    "nostr",
+    "twitch",
+    "feishu",
+    "zalo",
+    "tlon",
+    "synologychat",
+    "nextcloudtalk",
+)
+
+# Display labels for every known chat-channel adapter. Fallback for an
+# unknown id is a title-cased echo of the id (see :func:`channel_label`).
+CHANNEL_LABELS = {
+    "telegram": "Telegram",
+    "signal": "Signal",
+    "whatsapp": "WhatsApp",
+    "discord": "Discord",
+    "slack": "Slack",
+    "irc": "IRC",
+    "imessage": "iMessage",
+    "webchat": "WebChat",
+    "googlechat": "Google Chat",
+    "msteams": "Microsoft Teams",
+    "bluebubbles": "BlueBubbles",
+    "matrix": "Matrix",
+    "mattermost": "Mattermost",
+    "line": "LINE",
+    "nostr": "Nostr",
+    "twitch": "Twitch",
+    "feishu": "Feishu",
+    "zalo": "Zalo",
+    "tlon": "Tlon",
+    "synologychat": "Synology Chat",
+    "nextcloudtalk": "Nextcloud Talk",
+}
+
 _TIER_ORDER = (
     TIER_OSS,
     TIER_CLOUD_FREE,
@@ -5079,6 +5139,73 @@ def runtime_catalog() -> list[dict]:
     for rt in sorted(PAID_RUNTIMES):
         out.append(_runtime_spec_row(ent, rt))
     return out
+
+
+def channel_label(channel: str) -> str:
+    """Display label for a chat-channel adapter id.
+
+    Falls back to a title-cased echo of the id when the id is unknown so a
+    "brand-new adapter shipped in sync.py but not yet in
+    :data:`CHANNEL_LABELS`" doesn't render as a blank cell in a pricing
+    matrix. Whitespace-trimmed and lowercased, matching
+    :func:`feature_label` / :func:`runtime_label`.
+    """
+    try:
+        ch = (channel or "").strip().lower()
+    except (AttributeError, TypeError):
+        return ""
+    if not ch:
+        return ""
+    label = CHANNEL_LABELS.get(ch)
+    if label:
+        return label
+    return ch.replace("_", " ").title()
+
+
+def _channel_spec_row(ent: "Entitlement", ch: str) -> dict:
+    """Build the single channel row shape that :func:`channel_catalog`
+    returns. Every chat channel is FREE (there is no paid-channel tier --
+    the ``channels`` capacity axis governs how many concurrent channels
+    each plan admits, not which adapters unlock), so ``free`` / ``allowed``
+    / ``entitled`` are always ``True`` and ``locked`` is always ``False``.
+    Centralised so a future scalar / batch sibling cannot drift from the
+    catalogue rows.
+    """
+    return {
+        "id": ch,
+        "label": channel_label(ch),
+        "free": True,
+        "tier": "free",
+        "allowed": True,
+        "locked": False,
+        "entitled": True,
+    }
+
+
+def channel_catalog() -> list[dict]:
+    """Full catalogue of chat-channel adapters observable by ClawMetry.
+
+    Sibling of :func:`feature_catalog` / :func:`runtime_catalog` for the
+    channel axis. One row per id in :data:`ALL_CHANNELS`, sorted
+    alphabetically so a pricing UI can render a stable table across
+    releases. Every row is unlocked -- there is no paid-channel tier --
+    which lets a pricing page render "all 21 chat channels included in
+    every plan" off a single call instead of hard-coding the adapter list
+    client-side.
+
+    Grace vs enforce yields byte-identical rows (nothing to gate). Never
+    raises: resolver failure short-circuits to the OSS-free fallback so
+    the catalogue keeps rendering; a poisoned label lookup is contained
+    inside the row builder.
+    """
+    try:
+        ent = get_entitlement()
+    except Exception as exc:
+        logger.warning(
+            "entitlements: channel_catalog falling back to grace: %s", exc
+        )
+        ent = _oss_free()
+    return [_channel_spec_row(ent, ch) for ch in sorted(ALL_CHANNELS)]
 
 
 def feature_spec(feature: str) -> dict | None:

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -15707,6 +15707,59 @@ def api_entitlement_runtime_catalog():
         )
 
 
+@bp_entitlement.route("/api/entitlement/channel-catalog")
+def api_entitlement_channel_catalog():
+    """``GET /api/entitlement/channel-catalog`` -- catalogue sibling of
+    :func:`api_entitlement_feature_catalog` /
+    :func:`api_entitlement_runtime_catalog` for the chat-channel axis.
+
+    Returns every chat-channel adapter ClawMetry can observe (see
+    :data:`clawmetry.entitlements.ALL_CHANNELS`, kept in lockstep with
+    ``clawmetry.sync._CHANNEL_DIRS``). Every row is unlocked -- there is
+    no paid-channel tier; the ``channels`` capacity axis
+    (:func:`min_tier_for_channel_count` and the ``channels=`` arg on the
+    aggregate helpers) governs *how many* concurrent channels each plan
+    admits, not *which* adapters unlock. That posture lets a pricing page
+    render "all N chat channels included in every plan" off one call
+    instead of hard-coding the adapter list client-side.
+
+    Response shape mirrors ``/api/entitlement/feature-catalog`` and
+    ``/api/entitlement/runtime-catalog``::
+
+        {
+          "tier":     "<resolved tier id>",
+          "channels": [<catalog_row>, ...],   # from channel_catalog()
+          "grace":    <bool>,
+          "enforced": <bool>,
+        }
+
+    - **Never 5xxs**: helper failures short-circuit to the OSS-free
+      envelope so the pricing UI keeps rendering.
+    """
+    try:
+        from clawmetry import entitlements as _ent
+
+        ent = _ent.get_entitlement()
+        return jsonify(
+            {
+                "tier": ent.tier,
+                "channels": _ent.channel_catalog(),
+                "grace": ent.grace,
+                "enforced": not ent.grace,
+            }
+        )
+    except Exception as exc:
+        logger.warning("api_entitlement_channel_catalog: error: %s", exc)
+        return jsonify(
+            {
+                "tier": "oss",
+                "channels": [],
+                "grace": True,
+                "enforced": False,
+            }
+        )
+
+
 @bp_entitlement.route("/api/entitlement/tier-catalog")
 def api_entitlement_tier_catalog():
     """``GET /api/entitlement/tier-catalog`` -- bare sibling of

--- a/tests/test_entitlement_channel_catalog.py
+++ b/tests/test_entitlement_channel_catalog.py
@@ -1,0 +1,264 @@
+"""Tests for the channel-axis catalogue helpers and endpoint:
+
+* :data:`clawmetry.entitlements.ALL_CHANNELS`
+* :data:`clawmetry.entitlements.CHANNEL_LABELS`
+* :func:`clawmetry.entitlements.channel_label`
+* :func:`clawmetry.entitlements.channel_catalog`
+* ``GET /api/entitlement/channel-catalog``
+
+The channel axis has no paid-channel tier -- every chat-channel adapter is
+FREE, and the ``channels`` capacity axis
+(:func:`min_tier_for_channel_count` + the ``channels=`` arg on the
+aggregate helpers) governs how many concurrent channels each plan admits.
+So the catalogue is purely enumerative: one row per adapter, all
+unlocked. The tests below defend that posture, the sort order, the
+never-5xx contract, and pin :data:`ALL_CHANNELS` in lockstep with
+``clawmetry.sync._CHANNEL_DIRS`` so a new adapter can't ship in the
+daemon without also being catalogued.
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# ── ALL_CHANNELS / CHANNEL_LABELS ─────────────────────────────────────────
+
+
+def test_all_channels_is_a_tuple_of_strings(ent):
+    assert isinstance(ent.ALL_CHANNELS, tuple)
+    assert all(isinstance(ch, str) and ch for ch in ent.ALL_CHANNELS)
+
+
+def test_all_channels_has_no_duplicates(ent):
+    assert len(set(ent.ALL_CHANNELS)) == len(ent.ALL_CHANNELS)
+
+
+def test_all_channels_is_nonempty(ent):
+    assert len(ent.ALL_CHANNELS) >= 1
+
+
+def test_channel_labels_covers_every_channel(ent):
+    """Every id in :data:`ALL_CHANNELS` must have a curated label.
+
+    :func:`channel_label` falls back to a title-cased echo, so a missing
+    label doesn't render as a blank cell; but a curated label is the
+    stronger guarantee -- the catalogue should never leak an id-shaped
+    "Msteams" into a pricing page when the vendor spells it "Microsoft
+    Teams".
+    """
+    missing = [ch for ch in ent.ALL_CHANNELS if ch not in ent.CHANNEL_LABELS]
+    assert not missing, f"channels without a curated label: {missing}"
+
+
+def test_all_channels_matches_sync_channel_dirs(ent):
+    """Pin :data:`ALL_CHANNELS` to ``clawmetry.sync._CHANNEL_DIRS``.
+
+    Adding a new chat-channel adapter is a two-place edit today (the
+    daemon walks ``_CHANNEL_DIRS``, the catalogue reads
+    :data:`ALL_CHANNELS`); this pin fails loudly the moment the two lists
+    drift so a new adapter can't ship in the daemon without also being
+    catalogued (which would silently hide it from the pricing UI).
+    """
+    from clawmetry import sync as _sync
+
+    assert set(ent.ALL_CHANNELS) == set(_sync._CHANNEL_DIRS)
+
+
+# ── channel_label ─────────────────────────────────────────────────────────
+
+
+def test_channel_label_returns_curated_label(ent):
+    assert ent.channel_label("telegram") == "Telegram"
+    assert ent.channel_label("whatsapp") == "WhatsApp"
+    assert ent.channel_label("imessage") == "iMessage"
+
+
+def test_channel_label_case_insensitive_and_trimmed(ent):
+    assert ent.channel_label("  TELEGRAM  ") == "Telegram"
+    assert ent.channel_label("Telegram") == "Telegram"
+
+
+def test_channel_label_unknown_falls_back_to_title_case_echo(ent):
+    """Unknown ids don't crash and don't render as a blank cell."""
+    assert ent.channel_label("brand_new_adapter") == "Brand New Adapter"
+
+
+def test_channel_label_empty_and_none_return_empty_string(ent):
+    assert ent.channel_label("") == ""
+    assert ent.channel_label(None) == ""
+
+
+def test_channel_label_never_raises_on_garbage(ent):
+    assert ent.channel_label(42) == ""
+    assert ent.channel_label(object()) == ""
+
+
+# ── channel_catalog helper ────────────────────────────────────────────────
+
+
+def test_channel_catalog_returns_a_list(ent):
+    out = ent.channel_catalog()
+    assert isinstance(out, list)
+
+
+def test_channel_catalog_has_one_row_per_channel(ent):
+    rows = ent.channel_catalog()
+    assert len(rows) == len(ent.ALL_CHANNELS)
+
+
+def test_channel_catalog_row_ids_match_all_channels(ent):
+    ids = {row["id"] for row in ent.channel_catalog()}
+    assert ids == set(ent.ALL_CHANNELS)
+
+
+def test_channel_catalog_is_sorted_alphabetically(ent):
+    """Row order must be stable across releases so a pricing table doesn't
+    reshuffle on redeploy."""
+    ids = [row["id"] for row in ent.channel_catalog()]
+    assert ids == sorted(ent.ALL_CHANNELS)
+
+
+def test_channel_catalog_row_schema(ent):
+    """Row keys mirror :func:`_runtime_spec_row` for free runtimes so a
+    matrix UI can render the two catalogues with one row-renderer."""
+    expected = {"id", "label", "free", "tier", "allowed", "locked", "entitled"}
+    for row in ent.channel_catalog():
+        assert set(row.keys()) == expected, row
+
+
+def test_channel_catalog_every_row_is_free(ent):
+    """There is no paid-channel tier: every row must be free / unlocked /
+    allowed / entitled."""
+    for row in ent.channel_catalog():
+        assert row["free"] is True, row
+        assert row["tier"] == "free", row
+        assert row["allowed"] is True, row
+        assert row["locked"] is False, row
+        assert row["entitled"] is True, row
+
+
+def test_channel_catalog_labels_come_from_channel_label_helper(ent):
+    for row in ent.channel_catalog():
+        assert row["label"] == ent.channel_label(row["id"])
+
+
+def test_channel_catalog_never_raises_on_resolver_failure(ent, monkeypatch):
+    """A crashing resolver must not propagate: the catalogue falls back
+    to the OSS-free entitlement so the UI keeps rendering."""
+
+    def boom(*_a, **_kw):
+        raise RuntimeError("simulated resolver failure")
+
+    monkeypatch.setattr(ent, "get_entitlement", boom)
+    rows = ent.channel_catalog()
+    assert len(rows) == len(ent.ALL_CHANNELS)
+    for row in rows:
+        assert row["free"] is True
+
+
+def test_channel_catalog_grace_and_enforce_are_identical(ent, monkeypatch):
+    """Every row is free, so flipping enforcement changes nothing."""
+    grace = ent.channel_catalog()
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    importlib.reload(ent)
+    ent.invalidate()
+    enforce = ent.channel_catalog()
+    assert grace == enforce
+
+
+# ── API: /api/entitlement/channel-catalog ─────────────────────────────────
+
+
+def test_channel_catalog_endpoint_200(client):
+    resp = client.get("/api/entitlement/channel-catalog")
+    assert resp.status_code == 200
+
+
+def test_channel_catalog_endpoint_envelope_shape(client):
+    body = client.get("/api/entitlement/channel-catalog").get_json()
+    assert set(body.keys()) == {"tier", "channels", "grace", "enforced"}
+    assert isinstance(body["channels"], list)
+    assert isinstance(body["tier"], str)
+    assert isinstance(body["grace"], bool)
+    assert isinstance(body["enforced"], bool)
+
+
+def test_channel_catalog_endpoint_grace_and_enforced_are_negations(client):
+    body = client.get("/api/entitlement/channel-catalog").get_json()
+    assert body["grace"] is not body["enforced"]
+
+
+def test_channel_catalog_endpoint_tier_matches_resolved(client, ent):
+    body = client.get("/api/entitlement/channel-catalog").get_json()
+    assert body["tier"] == ent.get_entitlement().tier
+
+
+def test_channel_catalog_endpoint_rows_match_helper(client, ent):
+    """Byte-parity with :func:`channel_catalog` so the endpoint can't
+    drift from the helper a CLI wrapper might call directly."""
+    body = client.get("/api/entitlement/channel-catalog").get_json()
+    assert body["channels"] == ent.channel_catalog()
+
+
+def test_channel_catalog_endpoint_covers_every_channel(client, ent):
+    body = client.get("/api/entitlement/channel-catalog").get_json()
+    ids = {row["id"] for row in body["channels"]}
+    assert ids == set(ent.ALL_CHANNELS)
+
+
+def test_channel_catalog_endpoint_never_5xxs_on_helper_failure(
+    client, ent, monkeypatch
+):
+    """A crashing helper must not 500 the endpoint. Falls back to the
+    OSS-free envelope so the pricing UI keeps rendering."""
+
+    def boom(*_a, **_kw):
+        raise RuntimeError("simulated helper failure")
+
+    monkeypatch.setattr(ent, "channel_catalog", boom)
+    resp = client.get("/api/entitlement/channel-catalog")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["channels"] == []
+    assert body["grace"] is True
+    assert body["enforced"] is False
+
+
+def test_channel_catalog_endpoint_never_5xxs_on_resolver_failure(
+    client, ent, monkeypatch
+):
+    def boom(*_a, **_kw):
+        raise RuntimeError("simulated resolver failure")
+
+    monkeypatch.setattr(ent, "get_entitlement", boom)
+    resp = client.get("/api/entitlement/channel-catalog")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["tier"] == "oss"
+    assert body["channels"] == []
+    assert body["grace"] is True
+    assert body["enforced"] is False


### PR DESCRIPTION
## Summary

Fills the last catalogue-axis slot alongside `feature_catalog` and `runtime_catalog`. The chat-channel axis had no `_catalog()` helper — this PR adds one so a pricing UI can enumerate every observable adapter off a single call instead of hard-coding the list client-side.

- `ALL_CHANNELS` + `CHANNEL_LABELS` + `channel_label()` in `clawmetry/entitlements.py`. Canonical tuple of the 21 chat-channel adapters (pinned in lockstep with `clawmetry.sync._CHANNEL_DIRS` by a test — a new adapter shipped in the daemon without also being catalogued fails loudly here instead of silently hiding from the pricing UI). `channel_label()` falls back to a title-cased echo when the id is uncatalogued, so a brand-new adapter still renders.
- `channel_catalog()` in `clawmetry/entitlements.py`. One row per adapter, sorted alphabetically for stable ordering across releases. Row schema mirrors `_runtime_spec_row` for free runtimes (`{id, label, free, tier, allowed, locked, entitled}`) so a matrix UI can render the runtimes and channels catalogues with one row-renderer. Never raises: resolver failure short-circuits to the OSS-free fallback.
- `GET /api/entitlement/channel-catalog` in `routes/entitlement.py`. Envelope matches the bare feature/runtime/tier catalog endpoints (`{tier, channels, grace, enforced}`); never 5xxs — falls back to the OSS-free envelope on resolver or helper failure so the pricing UI keeps rendering.

**Posture.** Every channel is FREE. There is no paid-channel tier — the `channels` capacity axis (`min_tier_for_channel_count` + the `channels=` arg on the aggregate helpers) governs how many concurrent channels each plan admits, not which adapters unlock. Grace vs enforce yields byte-identical rows.

Non-overlapping with the in-flight `min_tier_for_all_at` / `affordable_tiers_at` work (#3547) — that PR extends the aggregate-constraint family; this one fills the per-axis catalogue family.

## Test plan

- [x] `python -m py_compile` — `clawmetry/entitlements.py`, `routes/entitlement.py`, `tests/test_entitlement_channel_catalog.py`
- [x] `ruff check` on all three files — all checks passed
- [x] 27 new tests in `tests/test_entitlement_channel_catalog.py` — constant shape, label fallback, sort order, row schema, `sync._CHANNEL_DIRS` pin, resolver-failure never-raise, endpoint envelope + never-5xx
- [x] Adjacent suite still green: `test_entitlement_bare_catalog.py` (28), `test_entitlement_feature_catalog_at.py`, `test_entitlement_runtime_catalog_at.py` — 55 + 49 catalog-family tests pass together
- [ ] CI matrix (Ubuntu / macOS / Windows × Py 3.9 / 3.11) green on this branch

## Local operator verification checklist

I can't reach the live daemon or cloud snapshot from this environment; these steps run on your box before flipping the PR out of draft:

- [ ] Copy the changed files into `~/.clawmetry/lib/python3.11/site-packages/clawmetry/` (`entitlements.py`) and the running `routes/` sibling; clear `__pycache__/` under both.
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` to reload the daemon.
- [ ] Local sanity:
  - `curl -sS 'http://localhost:8900/api/entitlement/channel-catalog' | jq '.channels | length'` → expect the same count as `len(sync._CHANNEL_DIRS)`
  - `curl -sS 'http://localhost:8900/api/entitlement/channel-catalog' | jq '.channels[0]'` → expect `{id, label, free:true, tier:"free", allowed:true, locked:false, entitled:true}`
  - `curl -sS 'http://localhost:8900/api/entitlement/channel-catalog' | jq '[.channels[] | select(.locked==true)] | length'` → expect `0`
  - `curl -sS 'http://localhost:8900/api/entitlement/channel-catalog' | jq '.grace'` → expect `true` (grace posture preserved).
- [ ] Decrypt the live cloud snapshot in the browser (the ClawMetry web console) and confirm the same catalogue renders identically to the local response.
- [ ] Grace posture preserved — response `grace: true` unless the daemon has flipped to enforce; nothing new is gated.

Draft only. Not a release. No `__version__` bump. No enforcement flip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TD4dRiQ95jsGMia2ffAnAT

---
_Generated by [Claude Code](https://claude.ai/code/session_01TD4dRiQ95jsGMia2ffAnAT)_