### PR TITLE
fix: capture cron-configured agent-turn model on sessions

### DIFF
--- a/clawmetry/adapters/openclaw.py
+++ b/clawmetry/adapters/openclaw.py
@@ -1349,6 +1349,17 @@ class OpenClawAdapter(AgentAdapter):
                 _cdr = s.get("cronDetached")
             if _cdr is not None:
                 extra["cronDetachedRun"] = bool(_cdr)
+            # Cron-configured agent-turn model (#3552): OpenClaw PR #95341
+            # stamps the model selected (or defaulted) for the cron job that
+            # triggered this session so usage can be attributed per scheduled
+            # job.  Key name varies across harness builds; try all known forms.
+            _cm = (
+                s.get("cronModel")
+                or s.get("cronAgentModel")
+                or s.get("cronConfiguredModel")
+            )
+            if _cm is not None:
+                extra["cronModel"] = str(_cm)
             # GLM/Zhipu overload classification (#3343): PR #93241 classifies
             # Zhipu GLM overload as a distinct overload state for failover;
             # surface the tag so session views can indicate failover routing.


### PR DESCRIPTION
Closes #3552

## Summary

- `list_sessions()` in `clawmetry/adapters/openclaw.py` already extracts a rich set of cron session extras, but never reads the agent-turn model stamped by OpenClaw PR #95341 (`cronModel` / `cronAgentModel` / `cronConfiguredModel`).
- Adds a single extraction block after `cronDetachedRun`, following the exact same defensive fallback pattern used for all other cron extras.
- Pure additive change: no existing logic is altered, no new dependencies, absent on pre-PR-#95341 installs → no-op.

## Test plan

- [ ] With a cron-triggered session that carries `cronModel` in its record, confirm `extra["cronModel"]` is populated in the adapter output.
- [ ] With a pre-#95341 session (no `cronModel` key), confirm no regression — field is simply absent from extras.
- [ ] `python3 -c "import ast; ast.parse(open('clawmetry/adapters/openclaw.py').read())"` → passes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CqPBRx3j12c96pLfxjPJ3a)_