### PR TITLE
feat(entitlement): channel_catalog_path + /api/entitlement/channel-catalog-path

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -9369,6 +9369,119 @@ def runtime_catalog_path(from_tier: str, to_tier: str) -> list[dict] | None:
         return None
 
 
+def channel_catalog_path(from_tier: str, to_tier: str) -> list[dict] | None:
+    """Arbitrary-endpoint stepwise channel-catalog path between two tiers.
+
+    Channel-axis twin of :func:`feature_catalog_path` and
+    :func:`runtime_catalog_path`: the full chat-channel catalogue at every
+    rung between any two tiers off ONE round-trip. Lets an upgrade-
+    walkthrough UI render the "which channels ship at every tier" column
+    alongside the feature and runtime columns without first calling
+    :func:`tier_path` and then N calls to :func:`channel_catalog`.
+
+    Per-rung row shape mirrors :func:`feature_catalog_path` /
+    :func:`runtime_catalog_path` with ``features`` / ``runtimes`` renamed
+    to ``channels``::
+
+        {
+          "tier":       "<id>",
+          "tier_label": "...",
+          "tier_rank":  <int>,
+          "channels":   [<channel_catalog row>, ...],
+        }
+
+    Every chat-channel adapter is FREE at every tier (the ``channels``
+    capacity axis governs how many concurrent channels each plan admits,
+    not which adapters unlock), so each rung's inner ``channels`` list is
+    byte-identical to :func:`channel_catalog` -- a parity test pins this
+    so the bare and path what-if channel surfaces cannot drift. Rows are
+    synthesised via :func:`_channel_spec_row` against a per-rung
+    :func:`_hypothetical_entitlement` so the helper stays resolver-
+    independent (grace vs enforce yields byte-identical rows), matching
+    the rest of the ``_path`` family.
+
+    Walk semantics, direction semantics and endpoint semantics match
+    :func:`feature_catalog_path` -- see that helper's docstring. Rung
+    walk is byte-stable against :func:`tier_path`,
+    :func:`tier_spec_path`, :func:`feature_spec_path`,
+    :func:`runtime_spec_path`, :func:`feature_catalog_path`,
+    :func:`runtime_catalog_path` and :func:`tier_catalog_path` (same
+    ``_PURCHASABLE_TIERS`` filter + same sort key + same destination-
+    sibling exclusion), so the paths line up rung-for-rung.
+
+    Never raises: a resolver failure logs a warning and returns ``None``
+    so a pricing-page surface keeps rendering instead of breaking.
+    """
+    try:
+        f = (from_tier or "").strip().lower()
+        t = (to_tier or "").strip().lower()
+        if f not in _TIER_FEATURES or t not in _TIER_FEATURES:
+            return None
+        if f == t:
+            return []
+        from_rank = _TIER_RANK.get(f, -1)
+        to_rank = _TIER_RANK.get(t, -1)
+
+        def _row(rung: str) -> dict | None:
+            try:
+                ent = _hypothetical_entitlement(rung)
+            except Exception as exc:
+                logger.warning(
+                    "entitlements: channel_catalog_path rung %r synth failed: %s",
+                    rung,
+                    exc,
+                )
+                return None
+            try:
+                channels = [_channel_spec_row(ent, ch) for ch in sorted(ALL_CHANNELS)]
+            except Exception as exc:
+                logger.warning(
+                    "entitlements: channel_catalog_path rung %r row build failed: %s",
+                    rung,
+                    exc,
+                )
+                return None
+            return {
+                "tier": rung,
+                "tier_label": tier_label(rung),
+                "tier_rank": _TIER_RANK.get(rung, -1),
+                "channels": channels,
+            }
+
+        if from_rank == to_rank:
+            row = _row(t)
+            return [row] if row is not None else []
+        ascending = to_rank > from_rank
+        if ascending:
+            ordered = sorted(
+                _PURCHASABLE_TIERS,
+                key=lambda x: (_TIER_RANK.get(x, -1), x),
+            )
+        else:
+            ordered = sorted(
+                _PURCHASABLE_TIERS,
+                key=lambda x: (-_TIER_RANK.get(x, -1), x),
+            )
+        path: list[dict] = []
+        for tid in ordered:
+            r = _TIER_RANK.get(tid, -1)
+            if ascending:
+                if r <= from_rank or r > to_rank:
+                    continue
+            else:
+                if r >= from_rank or r < to_rank:
+                    continue
+            if r == to_rank and tid != t:
+                continue
+            row = _row(tid)
+            if row is not None:
+                path.append(row)
+        return path
+    except Exception as exc:
+        logger.warning("entitlements: channel_catalog_path failed: %s", exc)
+        return None
+
+
 def tier_catalog_path(from_tier: str, to_tier: str) -> list[dict] | None:
     """Arbitrary-endpoint stepwise tier-catalog path between two tiers.
 

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -8952,6 +8952,79 @@ def api_entitlement_runtime_catalog_path():
         )
 
 
+@bp_entitlement.route("/api/entitlement/channel-catalog-path")
+def api_entitlement_channel_catalog_path():
+    """``GET /api/entitlement/channel-catalog-path?from=<id>&to=<id>`` --
+    channel-axis twin of ``/feature-catalog-path`` and
+    ``/runtime-catalog-path``: the full chat-channel catalogue at every
+    rung between any two tiers off ONE round-trip.
+
+    Pairs with ``/feature-catalog-path`` and ``/runtime-catalog-path``
+    the same way ``/channel-catalog`` pairs with ``/feature-catalog``
+    and ``/runtime-catalog``. Together the three ``_catalog_path``
+    endpoints let an upgrade-walkthrough UI render every feature +
+    runtime + channel column at every rung off THREE calls instead of
+    first calling ``/tier-path`` and then N * 3 calls to the scalar
+    catalog endpoints.
+
+    Each row in ``path`` mirrors the ``/feature-catalog-path`` /
+    ``/runtime-catalog-path`` row shape with ``features`` / ``runtimes``
+    renamed to ``channels`` (``tier``, ``tier_label``, ``tier_rank``,
+    ``channels``); the ``channels`` list byte-equals
+    ``/channel-catalog`` for every rung -- pinned by the parity tests
+    (every chat-channel adapter is FREE at every tier, so the catalogue
+    is invariant across the rung walk).
+
+    Rung walk, direction semantics and error posture match
+    ``/feature-catalog-path`` (byte-stable against the rest of the
+    ``_path`` family). Never 5xxs: a resolver failure short-circuits to
+    ``404`` so a pricing-page surface keeps rendering.
+    """
+    f = (request.args.get("from") or "").strip().lower()
+    t = (request.args.get("to") or "").strip().lower()
+    if not f or not t:
+        return jsonify({"error": "missing from or to"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        path = _ent.channel_catalog_path(f, t)
+        if path is None:
+            return (
+                jsonify({"error": "unknown tier", "from": f, "to": t}),
+                404,
+            )
+        from_rank = _ent.tier_rank(f)
+        to_rank = _ent.tier_rank(t)
+        if f == t:
+            direction = "identity"
+        elif from_rank == to_rank:
+            direction = "lateral"
+        elif to_rank > from_rank:
+            direction = "upgrade"
+        else:
+            direction = "downgrade"
+        return jsonify(
+            {
+                "from": f,
+                "from_label": _ent.tier_label(f),
+                "from_rank": from_rank,
+                "to": t,
+                "to_label": _ent.tier_label(t),
+                "to_rank": to_rank,
+                "direction": direction,
+                "path": path,
+            }
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_channel_catalog_path: error: %s", exc
+        )
+        return (
+            jsonify({"error": "unknown tier", "from": f, "to": t}),
+            404,
+        )
+
+
 @bp_entitlement.route("/api/entitlement/tier-catalog-path")
 def api_entitlement_tier_catalog_path():
     """``GET /api/entitlement/tier-catalog-path?from=<id>&to=<id>`` --

--- a/tests/test_entitlement_channel_catalog_path.py
+++ b/tests/test_entitlement_channel_catalog_path.py
@@ -1,0 +1,492 @@
+"""Tests for ``clawmetry.entitlements.channel_catalog_path(from, to)`` + the
+``GET /api/entitlement/channel-catalog-path`` endpoint.
+
+Channel-axis twin of :func:`feature_catalog_path` and
+:func:`runtime_catalog_path`: the full chat-channel catalogue at every
+rung between two tiers off ONE round-trip. Because every chat-channel
+adapter is FREE at every tier (the ``channels`` capacity axis governs
+how many concurrent channels each plan admits, not which adapters
+unlock), each rung's inner ``channels`` list is byte-identical to
+:func:`channel_catalog`. The path helper is worth having anyway: a
+pricing-comparison UI that renders feature and runtime columns off
+``/feature-catalog-path`` and ``/runtime-catalog-path`` should be able
+to render the channel column off a matching sibling instead of
+hard-coding "channels don't vary by tier" client-side.
+
+Pins:
+
+* per-rung row shape matches :func:`feature_catalog_path` /
+  :func:`runtime_catalog_path` with ``features`` / ``runtimes``
+  renamed to ``channels`` (``tier``, ``tier_label``, ``tier_rank``,
+  ``channels``) -- byte-stable so a UI can render all three columns
+  off one row-renderer
+* each ``channels`` list byte-equals :func:`channel_catalog` for
+  every rung -- the "channels are always free" invariant is baked
+  in and never drifts
+* rung walk byte-equals :func:`tier_path` on the destination axis
+  and :func:`feature_catalog_path` / :func:`runtime_catalog_path` /
+  :func:`tier_catalog_path` on the perspective axis -- the
+  ``_path`` family stays in lock-step
+* identity (``from == to``) -> ``[]``; lateral (same rank,
+  different id) -> single-row path; ``trial`` accepted as an
+  endpoint (excluded from the walked rungs but valid via the
+  lateral branch)
+* helper is decoupled from the resolver -- grace vs enforce yields
+  the same rows
+* unknown / empty / garbage ids return ``None`` and never raise; a
+  synthesised failure in the inner row builder short-circuits to
+  ``None``
+* API: 400 on missing args, 404 on unknown ids, 200 with the
+  standard ``_path`` envelope on the happy path; 404 (not 5xx)
+  when the inner helper blows up
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def enforced(monkeypatch, tmp_path):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+_ROW_KEYS = {"tier", "tier_label", "tier_rank", "channels"}
+_ENVELOPE_KEYS = {
+    "from",
+    "from_label",
+    "from_rank",
+    "to",
+    "to_label",
+    "to_rank",
+    "direction",
+    "path",
+}
+
+
+# ── helper: shape + per-row contract ─────────────────────────────────────
+
+
+def test_returns_list(ent):
+    path = ent.channel_catalog_path(ent.TIER_OSS, ent.TIER_ENTERPRISE)
+    assert isinstance(path, list)
+    assert len(path) >= 1
+
+
+def test_each_row_matches_catalog_path_row_shape(ent):
+    path = ent.channel_catalog_path(ent.TIER_OSS, ent.TIER_ENTERPRISE)
+    for row in path:
+        assert isinstance(row, dict)
+        assert set(row.keys()) == _ROW_KEYS
+        assert isinstance(row["channels"], list)
+        assert row["tier_rank"] == ent._TIER_RANK[row["tier"]]
+        assert row["tier_label"] == ent.tier_label(row["tier"])
+
+
+def test_last_rung_is_destination(ent):
+    path = ent.channel_catalog_path(ent.TIER_OSS, ent.TIER_ENTERPRISE)
+    assert path[-1]["tier"] == ent.TIER_ENTERPRISE
+    assert path[-1]["tier_label"] == ent.tier_label(ent.TIER_ENTERPRISE)
+    assert path[-1]["tier_rank"] == ent._TIER_RANK[ent.TIER_ENTERPRISE]
+
+
+# ── byte-parity with the bare channel catalog ────────────────────────────
+
+
+def test_channels_list_byte_equals_channel_catalog_every_rung(ent):
+    """Each rung's ``channels`` list is byte-identical to
+    :func:`channel_catalog` -- channels are always free, so the
+    catalogue is invariant across the rung walk. Pinned so a future
+    _at helper cannot drift and quietly re-gate the channel axis
+    behind a tier."""
+    baseline = ent.channel_catalog()
+    path = ent.channel_catalog_path(ent.TIER_OSS, ent.TIER_ENTERPRISE)
+    for row in path:
+        assert row["channels"] == baseline
+
+
+def test_every_channel_row_reports_free_at_every_rung(ent):
+    """Belt-and-braces: even if a future tier flip pretended to gate
+    the channel axis, every row reported by this helper must still
+    surface ``free=True`` / ``allowed=True`` / ``locked=False`` /
+    ``entitled=True`` -- otherwise the "channels are always free"
+    posture has been broken."""
+    path = ent.channel_catalog_path(ent.TIER_OSS, ent.TIER_ENTERPRISE)
+    for row in path:
+        for ch in row["channels"]:
+            assert ch["free"] is True
+            assert ch["allowed"] is True
+            assert ch["locked"] is False
+            assert ch["entitled"] is True
+            assert ch["tier"] == "free"
+
+
+def test_channels_list_sorted_alphabetically(ent):
+    path = ent.channel_catalog_path(ent.TIER_OSS, ent.TIER_ENTERPRISE)
+    for row in path:
+        ids = [c["id"] for c in row["channels"]]
+        assert ids == sorted(ids)
+
+
+def test_channels_list_covers_all_channels(ent):
+    path = ent.channel_catalog_path(ent.TIER_OSS, ent.TIER_ENTERPRISE)
+    expected = set(ent.ALL_CHANNELS)
+    for row in path:
+        assert {c["id"] for c in row["channels"]} == expected
+
+
+# ── rung walk parity with the rest of the _path family ───────────────────
+
+
+def test_rung_walk_byte_equal_to_tier_path(ent):
+    catalog = ent.channel_catalog_path(ent.TIER_OSS, ent.TIER_ENTERPRISE)
+    full = ent.tier_path(ent.TIER_OSS, ent.TIER_ENTERPRISE)
+    assert [r["tier"] for r in catalog] == [r["to"] for r in full]
+
+
+def test_rung_walk_byte_equal_to_feature_catalog_path(ent):
+    channels = ent.channel_catalog_path(ent.TIER_OSS, ent.TIER_ENTERPRISE)
+    features = ent.feature_catalog_path(ent.TIER_OSS, ent.TIER_ENTERPRISE)
+    assert [r["tier"] for r in channels] == [r["tier"] for r in features]
+
+
+def test_rung_walk_byte_equal_to_runtime_catalog_path(ent):
+    channels = ent.channel_catalog_path(ent.TIER_OSS, ent.TIER_ENTERPRISE)
+    runtimes = ent.runtime_catalog_path(ent.TIER_OSS, ent.TIER_ENTERPRISE)
+    assert [r["tier"] for r in channels] == [r["tier"] for r in runtimes]
+
+
+def test_rung_walk_byte_equal_to_tier_catalog_path(ent):
+    channels = ent.channel_catalog_path(ent.TIER_OSS, ent.TIER_ENTERPRISE)
+    tiers = ent.tier_catalog_path(ent.TIER_OSS, ent.TIER_ENTERPRISE)
+    assert [r["tier"] for r in channels] == [r["tier"] for r in tiers]
+
+
+def test_path_terminates_at_to_not_a_sibling(ent):
+    """``pro`` and ``cloud_pro`` share rank 2; asking for ``pro`` must
+    end exactly at ``pro`` and EXCLUDE the same-rank sibling
+    ``cloud_pro`` from the final rung -- same rule as ``tier_path``."""
+    tiers = [
+        r["tier"]
+        for r in ent.channel_catalog_path(ent.TIER_OSS, ent.TIER_PRO)
+    ]
+    assert tiers[-1] == ent.TIER_PRO
+    assert tiers.count(ent.TIER_PRO) == 1
+    assert ent.TIER_CLOUD_PRO not in tiers
+
+
+def test_same_rank_siblings_between_endpoints_both_included(ent):
+    tiers = [
+        r["tier"]
+        for r in ent.channel_catalog_path(ent.TIER_OSS, ent.TIER_ENTERPRISE)
+    ]
+    assert ent.TIER_CLOUD_PRO in tiers
+    assert ent.TIER_PRO in tiers
+    assert tiers[-1] == ent.TIER_ENTERPRISE
+
+
+# ── identity / lateral / adjacent ────────────────────────────────────────
+
+
+def test_identity_returns_empty(ent):
+    for tid in (
+        ent.TIER_OSS,
+        ent.TIER_CLOUD_FREE,
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_PRO,
+        ent.TIER_ENTERPRISE,
+        ent.TIER_TRIAL,
+    ):
+        assert ent.channel_catalog_path(tid, tid) == []
+
+
+def test_lateral_is_single_row(ent):
+    path = ent.channel_catalog_path(ent.TIER_CLOUD_PRO, ent.TIER_PRO)
+    assert len(path) == 1
+    assert path[0]["tier"] == ent.TIER_PRO
+    assert path[0]["channels"] == ent.channel_catalog()
+
+
+def test_oss_to_cloud_free_lateral(ent):
+    path = ent.channel_catalog_path(ent.TIER_OSS, ent.TIER_CLOUD_FREE)
+    assert len(path) == 1
+    assert path[0]["tier"] == ent.TIER_CLOUD_FREE
+
+
+def test_adjacent_step_is_one_row(ent):
+    path = ent.channel_catalog_path(ent.TIER_OSS, ent.TIER_CLOUD_STARTER)
+    assert len(path) == 1
+    assert path[0]["tier"] == ent.TIER_CLOUD_STARTER
+
+
+# ── descending mirror ───────────────────────────────────────────────────
+
+
+def test_descending_path_terminates_at_to(ent):
+    path = ent.channel_catalog_path(ent.TIER_ENTERPRISE, ent.TIER_OSS)
+    assert path[-1]["tier"] == ent.TIER_OSS
+    # closest-to-from rung first
+    assert (
+        ent._TIER_RANK[path[0]["tier"]]
+        < ent._TIER_RANK[ent.TIER_ENTERPRISE]
+    )
+
+
+def test_descending_terminates_at_explicit_floor(ent):
+    """Asking for ``oss`` must NOT also include ``cloud_free`` (the
+    other rank-0 sibling) as a terminal rung."""
+    tiers = [
+        r["tier"]
+        for r in ent.channel_catalog_path(ent.TIER_ENTERPRISE, ent.TIER_OSS)
+    ]
+    assert tiers[-1] == ent.TIER_OSS
+    assert tiers.count(ent.TIER_OSS) == 1
+
+
+# ── trial endpoint ───────────────────────────────────────────────────────
+
+
+def test_trial_excluded_from_walked_rungs_but_valid_endpoint(ent):
+    """``trial`` is not purchasable -- it must never appear as a stop on
+    a path between purchasable tiers, but resolves as an endpoint."""
+    path = ent.channel_catalog_path(ent.TIER_OSS, ent.TIER_ENTERPRISE)
+    for row in path:
+        assert row["tier"] != ent.TIER_TRIAL
+    upward = ent.channel_catalog_path(ent.TIER_TRIAL, ent.TIER_ENTERPRISE)
+    assert upward is not None
+    assert upward[-1]["tier"] == ent.TIER_ENTERPRISE
+    downward = ent.channel_catalog_path(ent.TIER_TRIAL, ent.TIER_OSS)
+    assert downward is not None
+    assert downward[-1]["tier"] == ent.TIER_OSS
+
+
+# ── decoupled from the resolver ──────────────────────────────────────────
+
+
+def test_grace_and_enforce_yield_identical_rows(ent, enforced):
+    grace_rows = ent.channel_catalog_path(ent.TIER_OSS, ent.TIER_ENTERPRISE)
+    enforced_rows = enforced.channel_catalog_path(
+        enforced.TIER_OSS, enforced.TIER_ENTERPRISE
+    )
+    assert grace_rows == enforced_rows
+
+
+# ── unknown / garbage inputs never raise ─────────────────────────────────
+
+
+def test_unknown_tiers_return_none(ent):
+    assert (
+        ent.channel_catalog_path("not_a_tier", ent.TIER_ENTERPRISE) is None
+    )
+    assert (
+        ent.channel_catalog_path(ent.TIER_OSS, "still_not_a_tier") is None
+    )
+    assert ent.channel_catalog_path("a", "b") is None
+
+
+def test_empty_and_garbage_inputs_never_raise(ent):
+    assert ent.channel_catalog_path("", "") is None
+    assert ent.channel_catalog_path(None, None) is None  # type: ignore[arg-type]
+    assert ent.channel_catalog_path("  ", "  ") is None
+    assert ent.channel_catalog_path(123, 456) is None  # type: ignore[arg-type]
+
+
+def test_case_and_whitespace_normalised(ent):
+    a = ent.channel_catalog_path(ent.TIER_OSS, ent.TIER_ENTERPRISE)
+    b = ent.channel_catalog_path("  OSS ", " ENTERPRISE  ")
+    assert a == b
+
+
+def test_helper_swallows_synthesis_failure(monkeypatch, ent):
+    """If the per-rung entitlement synthesiser blows up, the helper must
+    short-circuit gracefully -- either dropping the poisoned rung or
+    logging + returning ``None`` -- and must never raise (logged-
+    warning + graceful fallback contract)."""
+
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "_hypothetical_entitlement", boom)
+    # Must not raise, and must not return anything with a poisoned row.
+    result = ent.channel_catalog_path(ent.TIER_OSS, ent.TIER_ENTERPRISE)
+    assert result is None or result == []
+
+
+def test_helper_swallows_row_builder_failure(monkeypatch, ent):
+    """If the per-channel row builder itself blows up, the helper must
+    also short-circuit to ``None`` / empty rather than leaking."""
+
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "_channel_spec_row", boom)
+    result = ent.channel_catalog_path(ent.TIER_OSS, ent.TIER_ENTERPRISE)
+    assert result is None or result == []
+
+
+# ── API surface ──────────────────────────────────────────────────────────
+
+
+def test_api_400_on_missing_args(client):
+    assert (
+        client.get("/api/entitlement/channel-catalog-path").status_code
+        == 400
+    )
+    assert (
+        client.get(
+            "/api/entitlement/channel-catalog-path?from=oss"
+        ).status_code
+        == 400
+    )
+    assert (
+        client.get(
+            "/api/entitlement/channel-catalog-path?to=cloud_pro"
+        ).status_code
+        == 400
+    )
+
+
+def test_api_404_on_unknown_tier(client):
+    r = client.get(
+        "/api/entitlement/channel-catalog-path?from=oss&to=not_a_tier"
+    )
+    assert r.status_code == 404
+    body = r.get_json()
+    assert body["error"] == "unknown tier"
+    assert body["to"] == "not_a_tier"
+
+
+def test_api_happy_path_ascending(client, ent):
+    r = client.get(
+        "/api/entitlement/channel-catalog-path"
+        f"?from={ent.TIER_OSS}&to={ent.TIER_ENTERPRISE}"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert set(body.keys()) == _ENVELOPE_KEYS
+    assert body["from"] == ent.TIER_OSS
+    assert body["to"] == ent.TIER_ENTERPRISE
+    assert body["direction"] == "upgrade"
+    assert isinstance(body["path"], list) and body["path"]
+    assert body["path"][-1]["tier"] == ent.TIER_ENTERPRISE
+
+
+def test_api_happy_path_descending(client, ent):
+    r = client.get(
+        "/api/entitlement/channel-catalog-path"
+        f"?from={ent.TIER_ENTERPRISE}&to={ent.TIER_OSS}"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["direction"] == "downgrade"
+    assert body["path"][-1]["tier"] == ent.TIER_OSS
+
+
+def test_api_identity_empty_path(client, ent):
+    r = client.get(
+        "/api/entitlement/channel-catalog-path"
+        f"?from={ent.TIER_CLOUD_PRO}&to={ent.TIER_CLOUD_PRO}"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["direction"] == "identity"
+    assert body["path"] == []
+
+
+def test_api_lateral_single_row(client, ent):
+    r = client.get(
+        "/api/entitlement/channel-catalog-path"
+        f"?from={ent.TIER_CLOUD_PRO}&to={ent.TIER_PRO}"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["direction"] == "lateral"
+    assert len(body["path"]) == 1
+    assert body["path"][0]["tier"] == ent.TIER_PRO
+
+
+def test_api_trial_endpoint_accepted(client, ent):
+    r = client.get(
+        "/api/entitlement/channel-catalog-path"
+        f"?from={ent.TIER_TRIAL}&to={ent.TIER_ENTERPRISE}"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["from"] == ent.TIER_TRIAL
+    assert body["path"][-1]["tier"] == ent.TIER_ENTERPRISE
+
+
+def test_api_path_byte_equals_helper(client, ent):
+    r = client.get(
+        "/api/entitlement/channel-catalog-path"
+        f"?from={ent.TIER_OSS}&to={ent.TIER_ENTERPRISE}"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["path"] == ent.channel_catalog_path(
+        ent.TIER_OSS, ent.TIER_ENTERPRISE
+    )
+
+
+def test_api_envelope_channels_lists_match_channel_catalog(client, ent):
+    """Cross-check the wire envelope's per-rung ``channels`` list against
+    ``/api/entitlement/channel-catalog`` -- the two channel-axis
+    surfaces stay in lock-step."""
+    r = client.get(
+        "/api/entitlement/channel-catalog-path"
+        f"?from={ent.TIER_OSS}&to={ent.TIER_ENTERPRISE}"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    baseline = client.get("/api/entitlement/channel-catalog").get_json()
+    baseline_channels = baseline["channels"]
+    for row in body["path"]:
+        assert row["channels"] == baseline_channels
+
+
+def test_api_404_on_resolver_failure(monkeypatch, client):
+    """Force the resolver path used by the route to blow up; the route
+    must short-circuit to a 404 envelope instead of leaking a 500."""
+    import clawmetry.entitlements as _ent
+
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(_ent, "channel_catalog_path", boom)
+    r = client.get(
+        "/api/entitlement/channel-catalog-path?from=oss&to=enterprise"
+    )
+    assert r.status_code == 404
+    body = r.get_json()
+    assert body["error"] == "unknown tier"


### PR DESCRIPTION
## Summary

- Channel-axis twin of `feature_catalog_path` / `runtime_catalog_path` / `tier_catalog_path`: the full chat-channel catalogue at every rung between two tiers off ONE round-trip. Lets an upgrade-walkthrough UI render every feature + runtime + channel column at every rung off THREE calls instead of first calling `/tier-path` and then N * 3 calls to the scalar catalog endpoints.
- Because every chat-channel adapter is FREE at every tier (the `channels` capacity axis governs how many concurrent channels each plan admits, not which adapters unlock), each rung's inner `channels` list is byte-identical to `channel_catalog()`. Pinned by parity tests so a future `_at` helper cannot drift and quietly re-gate the channel axis behind a tier.
- New helper in `clawmetry/entitlements.py`:
  - `channel_catalog_path(from_tier, to_tier)` — placed between `runtime_catalog_path` and `tier_catalog_path`. Per-rung rows are synthesised via `_hypothetical_entitlement` + `_channel_spec_row` so the helper stays resolver-independent (grace vs enforce yields byte-identical rows). Rung walk uses the same `_PURCHASABLE_TIERS` filter + sort key + destination-sibling exclusion as the rest of the `_path` family, so paths line up rung-for-rung against `tier_path` / `feature_catalog_path` / `runtime_catalog_path` / `tier_catalog_path`. Never raises: synthesis / row-builder failures drop the rung and log a warning; a top-level failure logs + returns `None`.
- New endpoint in `routes/entitlement.py`:
  - `GET /api/entitlement/channel-catalog-path?from=<id>&to=<id>` — placed between the runtime and tier siblings. 400 on missing args, 404 on unknown ids, 200 with the standard `_path` envelope (`from` / `from_label` / `from_rank` / `to` / `to_label` / `to_rank` / `direction` / `path`) on the happy path. 404 (not 5xx) on inner failure.
- 36 new tests in `tests/test_entitlement_channel_catalog_path.py` covering row shape, per-rung `channels`-list byte-parity vs `channel_catalog`, always-free posture at every rung, sort + coverage of `ALL_CHANNELS`, rung-walk byte-stability against `tier_path` + `feature_catalog_path` + `runtime_catalog_path` + `tier_catalog_path`, identity + lateral + adjacent + descending walks, `trial` endpoint, grace-vs-enforce parity, input normalisation / never-raise on synthesis + row-builder failure, and HTTP surface (400 + 404 + happy path + envelope keys + wire byte-parity vs `/api/entitlement/channel-catalog` + 404-on-500).

Posture: grace-mode preserved. No enforcement gate added — this is a read-only what-if surface for a pricing-comparison UI.

## Test plan

- [x] `python -m py_compile clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_channel_catalog_path.py` — clean.
- [x] `python -m pytest tests/test_entitlement_channel_catalog_path.py -x -q` — 36 passed.
- [x] `python -m pytest tests/test_entitlement_channel_catalog.py tests/test_entitlement_channel_catalog_path.py tests/test_entitlement_feature_catalog_path.py tests/test_entitlement_runtime_catalog_path.py tests/test_entitlement_tier_catalog_path.py tests/test_entitlement_tier_catalog_path_batch.py -q` — 187 passed (no regressions across the sibling `_path` family or the channel-catalog root).
- [x] `ruff check clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_channel_catalog_path.py` — clean.
- [x] `python -c "import ast; ast.parse(open('dashboard.py').read())"` — clean.

## Local operator verification checklist

Because this fire runs remotely with no access to the local daemon, `~/.openclaw`, the live cloud snapshot, or a browser, please verify against a live install:

- [ ] Copy the changed files into your site-packages: `cp clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_channel_catalog_path.py ~/.clawmetry/lib/python*/site-packages/` (adjust paths to your local layout).
- [ ] Clear `__pycache__` under the ClawMetry site-packages: `find ~/.clawmetry -name __pycache__ -exec rm -rf {} + 2>/dev/null || true`.
- [ ] Restart the daemon: `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`.
- [ ] Hit the new endpoint against a resolved install and confirm the envelope shape:
  - `curl -sS 'http://localhost:8900/api/entitlement/channel-catalog-path?from=oss&to=enterprise' | jq '{from, to, direction, rungs: (.path | length), rows: (.path[0].channels | length)}'`
  - `curl -sS 'http://localhost:8900/api/entitlement/channel-catalog-path?from=enterprise&to=oss' | jq '.direction'` → `"downgrade"`.
  - `curl -sS 'http://localhost:8900/api/entitlement/channel-catalog-path?from=cloud_pro&to=pro' | jq '{direction, rungs: (.path | length)}'` → `"lateral"` / `1`.
- [ ] Confirm channel-list invariance across rungs (channels are always free):
  - `curl -sS 'http://localhost:8900/api/entitlement/channel-catalog-path?from=oss&to=enterprise' | jq '.path | map(.channels) | unique | length'` → `1`.
  - `curl -sS 'http://localhost:8900/api/entitlement/channel-catalog' | jq '.channels' > /tmp/cc.json && curl -sS 'http://localhost:8900/api/entitlement/channel-catalog-path?from=oss&to=enterprise' | jq '.path[-1].channels' | diff - /tmp/cc.json` → empty diff.
- [ ] 400 on missing args, 404 on unknown ids:
  - `curl -sS -o /dev/null -w '%{http_code}\n' http://localhost:8900/api/entitlement/channel-catalog-path` → `400`
  - `curl -sS -o /dev/null -w '%{http_code}\n' 'http://localhost:8900/api/entitlement/channel-catalog-path?from=oss&to=nonsense'` → `404`
- [ ] Decrypt the live cloud snapshot in the browser and confirm the pricing / upgrade-walkthrough UI (if any) still renders — no behaviour change intended (grace mode preserved; no enforcement gate added).
- [ ] Draft PR is intentional: do not mark ready-for-review until the above checks pass on your machine.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NVDuLhXG31MmGXuZFJ1RHE)_