### PR TITLE
fix: surface gateway host/system status fields on DetectResult.meta

### DIFF
--- a/clawmetry/adapters/openclaw.py
+++ b/clawmetry/adapters/openclaw.py
@@ -1116,6 +1116,90 @@ def _gateway_plugin_health() -> dict:
         return {}
 
 
+def _gateway_host_status() -> dict:
+    """Host/system fields from the OpenClaw gateway.status RPC (#3551).
+
+    As of harness CHANGELOG #100478 the gateway.status response includes
+    host name, network address, OS, runtime, uptime, CPU, memory, and disk
+    details alongside the existing ``plugins`` list.
+
+    Returns a dict with whichever fields are present:
+    - ``"gatewayHostName"``       — machine hostname
+    - ``"gatewayNetworkAddress"`` — primary network address / IP
+    - ``"gatewayHostOS"``         — OS name or platform string
+    - ``"gatewayHostRuntime"``    — runtime identifier (e.g. Node version)
+    - ``"gatewayHostUptime"``     — uptime in seconds
+    - ``"gatewayHostCPU"``        — CPU usage value or dict
+    - ``"gatewayHostMemory"``     — memory info (bytes or dict)
+    - ``"gatewayHostDisk"``       — disk info (bytes or dict)
+
+    Returns ``{}`` when the RPC is unavailable or the response carries no
+    host fields. Never raises.
+    """
+    try:
+        d = _d()
+        rpc = getattr(d, "_gw_ws_rpc", None)
+        if rpc is None:
+            return {}
+        payload = rpc("gateway.status")
+        if not isinstance(payload, dict):
+            return {}
+        result: dict = {}
+        host_name = (
+            payload.get("hostName")
+            or payload.get("host_name")
+            or payload.get("hostname")
+            or payload.get("host")
+        )
+        if host_name:
+            result["gatewayHostName"] = str(host_name)
+        address = (
+            payload.get("networkAddress")
+            or payload.get("network_address")
+            or payload.get("address")
+            or payload.get("ip")
+        )
+        if address:
+            result["gatewayNetworkAddress"] = str(address)
+        os_val = payload.get("os") or payload.get("platform")
+        if os_val:
+            result["gatewayHostOS"] = str(os_val)
+        runtime = (
+            payload.get("runtime")
+            or payload.get("nodeVersion")
+            or payload.get("node_version")
+        )
+        if runtime:
+            result["gatewayHostRuntime"] = str(runtime)
+        uptime = (
+            payload.get("uptime")
+            or payload.get("uptimeSeconds")
+            or payload.get("uptime_seconds")
+        )
+        if uptime is not None:
+            result["gatewayHostUptime"] = uptime
+        cpu = payload.get("cpu") or payload.get("cpuUsage") or payload.get("cpu_usage")
+        if cpu is not None:
+            result["gatewayHostCPU"] = cpu
+        memory = (
+            payload.get("memory")
+            or payload.get("memoryUsage")
+            or payload.get("memory_usage")
+        )
+        if memory is not None:
+            result["gatewayHostMemory"] = memory
+        disk = (
+            payload.get("disk")
+            or payload.get("diskUsage")
+            or payload.get("disk_usage")
+        )
+        if disk is not None:
+            result["gatewayHostDisk"] = disk
+        return result
+    except Exception:
+        return {}
+
+
 class OpenClawAdapter(AgentAdapter):
     name = "openclaw"
     display_name = "OpenClaw"
@@ -1186,6 +1270,9 @@ class OpenClawAdapter(AgentAdapter):
             # Only meaningful — and safe to query — when the gateway is live.
             if running:
                 meta.update(_gateway_plugin_health())
+                # Gateway host/system status (#3551): host name, OS, runtime,
+                # uptime, CPU, memory, disk from the same gateway.status RPC.
+                meta.update(_gateway_host_status())
             # Docker runtime health (#3390): the NemoClaw harness treats Docker
             # daemon liveness as a distinct signal from gateway liveness. Only
             # written when docker CLI is present so non-Docker environments are

--- a/tests/test_obs_gap_openclaw_gateway_host_status_3551.py
+++ b/tests/test_obs_gap_openclaw_gateway_host_status_3551.py
@@ -1,0 +1,111 @@
+"""Tests for issue #3551 — openclaw: gateway host/system status fields.
+
+Verifies that _gateway_host_status() extracts host/system fields from the
+gateway.status RPC response and surfaces them on DetectResult.meta.
+
+Fingerprint: hgap-dd7ff7ab07 (used to dedupe — keep it in the body).
+"""
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+
+
+def _make_mock_dashboard(rpc_return):
+    """Return a minimal mock dashboard module with _gw_ws_rpc wired up."""
+    mod = types.ModuleType("dashboard")
+    mod._gw_ws_rpc = lambda method, params=None: rpc_return
+    sys.modules["dashboard"] = mod
+    return mod
+
+
+def _reload_adapter():
+    import clawmetry.adapters.openclaw as oc_mod
+    importlib.reload(oc_mod)
+    return oc_mod
+
+
+def test_all_host_fields_present():
+    """All eight host/system fields are extracted when the RPC returns them."""
+    _make_mock_dashboard({
+        "plugins": [],
+        "hostName": "gateway-host.local",
+        "networkAddress": "192.168.1.50",
+        "os": "linux",
+        "runtime": "node/20.11.0",
+        "uptime": 7200,
+        "cpu": 8.5,
+        "memory": {"total": 16777216000, "used": 4294967296},
+        "disk": {"total": 107374182400, "used": 21474836480},
+    })
+    oc = _reload_adapter()
+    result = oc._gateway_host_status()
+    assert result["gatewayHostName"] == "gateway-host.local"
+    assert result["gatewayNetworkAddress"] == "192.168.1.50"
+    assert result["gatewayHostOS"] == "linux"
+    assert result["gatewayHostRuntime"] == "node/20.11.0"
+    assert result["gatewayHostUptime"] == 7200
+    assert result["gatewayHostCPU"] == 8.5
+    assert result["gatewayHostMemory"] == {"total": 16777216000, "used": 4294967296}
+    assert result["gatewayHostDisk"] == {"total": 107374182400, "used": 21474836480}
+
+
+def test_partial_fields_only_present_keys_returned():
+    """Only fields that are non-None/non-empty are included in the result."""
+    _make_mock_dashboard({
+        "hostname": "partial-host",
+        "os": "darwin",
+    })
+    oc = _reload_adapter()
+    result = oc._gateway_host_status()
+    assert result.get("gatewayHostName") == "partial-host"
+    assert result.get("gatewayHostOS") == "darwin"
+    assert "gatewayNetworkAddress" not in result
+    assert "gatewayHostRuntime" not in result
+    assert "gatewayHostUptime" not in result
+    assert "gatewayHostCPU" not in result
+    assert "gatewayHostMemory" not in result
+    assert "gatewayHostDisk" not in result
+
+
+def test_rpc_returns_none_gives_empty_dict():
+    """When the gateway RPC returns None (gateway down), return {}."""
+    _make_mock_dashboard(None)
+    oc = _reload_adapter()
+    result = oc._gateway_host_status()
+    assert result == {}
+
+
+def test_no_host_fields_in_response_gives_empty_dict():
+    """A gateway.status response with only plugins and no host fields → {}."""
+    _make_mock_dashboard({
+        "plugins": [
+            {"name": "telegram", "state": "loaded", "type": "channel"},
+        ]
+    })
+    oc = _reload_adapter()
+    result = oc._gateway_host_status()
+    assert result == {}
+
+
+def test_fallback_key_variants_resolved():
+    """Fallback key names (host_name, network_address, node_version) are tried."""
+    _make_mock_dashboard({
+        "host_name": "fallback-host",
+        "network_address": "10.0.0.1",
+        "node_version": "v18.20.0",
+        "uptime_seconds": 3600,
+        "cpu_usage": 15.2,
+        "memory_usage": {"total": 8589934592, "used": 2147483648},
+        "disk_usage": {"total": 53687091200, "used": 10737418240},
+    })
+    oc = _reload_adapter()
+    result = oc._gateway_host_status()
+    assert result.get("gatewayHostName") == "fallback-host"
+    assert result.get("gatewayNetworkAddress") == "10.0.0.1"
+    assert result.get("gatewayHostRuntime") == "v18.20.0"
+    assert result.get("gatewayHostUptime") == 3600
+    assert result.get("gatewayHostCPU") == 15.2
+    assert result.get("gatewayHostMemory") == {"total": 8589934592, "used": 2147483648}
+    assert result.get("gatewayHostDisk") == {"total": 53687091200, "used": 10737418240}


### PR DESCRIPTION
Closes #3551

## Summary
- `_gateway_plugin_health()` already calls `rpc('gateway.status')` but discards host name, OS, runtime, uptime, CPU, memory, and disk fields returned on the same response since harness CHANGELOG #100478
- Adds `_gateway_host_status()` in `clawmetry/adapters/openclaw.py` — same RPC-call pattern, reads host/system fields with common key fallbacks (`hostName`/`host_name`/`hostname`, `os`/`platform`, `uptimeSeconds`/`uptime_seconds`, etc.), surfaces them as `gatewayHostName`, `gatewayNetworkAddress`, `gatewayHostOS`, `gatewayHostRuntime`, `gatewayHostUptime`, `gatewayHostCPU`, `gatewayHostMemory`, `gatewayHostDisk` on `DetectResult.meta`
- Wired into `detect()` alongside existing `_gateway_plugin_health()` call (only when gateway is running)

## Test plan
- `python3 -m pytest tests/test_obs_gap_openclaw_gateway_host_status_3551.py -v` — 5 new tests pass (all-fields, partial-fields, RPC-down, no-host-fields, fallback key variants)
- `python3 -m pytest tests/test_obs_gap_openclaw_gateway_plugin_health_3200.py -v` — 4/5 pass; the one pre-existing failure (`test_loaded_errored_disabled_summary`) already fails on `main` before this PR due to a separate double-brace bug in `_gateway_plugin_health()` — not introduced here

---
_Generated by [Claude Code](https://claude.ai/code/session_017sDJ3P7cUERRsHX6PC7qYz)_