### PR TITLE
feat(openclaw): surface Talk/Voice Call session fields on list_sessions() (#3553)

### DIFF
--- a/clawmetry/adapters/openclaw.py
+++ b/clawmetry/adapters/openclaw.py
@@ -1240,6 +1240,7 @@ class OpenClawAdapter(AgentAdapter):
         for s in raw[:limit]:
             updated_ms = s.get("updatedAt") or 0
             started_at = (updated_ms / 1000.0) if updated_ms else 0.0
+            _sk = (s.get("kind") or "").lower()
             extra = {
                 "kind": s.get("kind") or "direct",
                 "contextTokens": s.get("contextTokens"),
@@ -1424,6 +1425,41 @@ class OpenClawAdapter(AgentAdapter):
                     extra["utilityModelCostUsd"] = float(_um_cost)
                 except (TypeError, ValueError):
                     pass
+            # Talk/Voice Call session fields (#3553): OpenClaw 'Control UI Talk
+            # controls' (harness PR #97170/#97738) stamps transcription-provider,
+            # transport, voice model, and VAD config on talk-kind sessions.
+            # Extract with multi-alias fallbacks for resilience across harness
+            # versions; guard on _sk so non-voice sessions are unaffected.
+            if _sk in ("talk", "voice", "realtime", "voice_call", "talk_call"):
+                _tp = (
+                    s.get("transcriptionProvider")
+                    or s.get("talkTranscriptionProvider")
+                    or s.get("speechProvider")
+                )
+                if _tp is not None:
+                    extra["transcriptionProvider"] = str(_tp)
+                _tt = (
+                    s.get("talkTransport")
+                    or s.get("voiceTransport")
+                    or s.get("transport")
+                )
+                if _tt is not None:
+                    extra["talkTransport"] = str(_tt)
+                _vm = (
+                    s.get("voiceModel")
+                    or s.get("talkVoiceModel")
+                    or s.get("realtimeModel")
+                    or s.get("talkModel")
+                )
+                if _vm is not None:
+                    extra["voiceModel"] = str(_vm)
+                _vad = (
+                    s.get("vadMode")
+                    or s.get("talkVadMode")
+                    or s.get("vadTimingMode")
+                )
+                if _vad is not None:
+                    extra["vadMode"] = str(_vad)
             tok_total = int(s.get("totalTokens") or 0)
             tok_in = int(s.get("inputTokens") or 0)
             tok_out = int(s.get("outputTokens") or 0)
@@ -1441,7 +1477,7 @@ class OpenClawAdapter(AgentAdapter):
                     id=s.get("sessionId") or s.get("key") or "",
                     display_name=s.get("displayName") or "",
                     model=s.get("model") or "",
-                    source=s.get("channel") or "",
+                    source=s.get("channel") or (_sk if _sk in ("talk", "voice", "realtime") else "") or "",
                     started_at=started_at,
                     total_tokens=tok_total,
                     input_tokens=tok_in,

--- a/dashboard.py
+++ b/dashboard.py
@@ -16479,6 +16479,10 @@ def _get_sessions():
                         "contextTokens", 200000
                     ),
                     "kind": s.get("kind", "direct"),
+                    "transcriptionProvider": s.get("transcriptionProvider") or s.get("talkTranscriptionProvider") or s.get("speechProvider") or "",
+                    "talkTransport": s.get("talkTransport") or s.get("voiceTransport") or "",
+                    "voiceModel": s.get("voiceModel") or s.get("realtimeModel") or s.get("talkModel") or "",
+                    "vadMode": s.get("vadMode") or s.get("talkVadMode") or "",
                     "agent": s.get("agentId", "main"),
                     "parentId": s.get("parentSessionId") or s.get("parentId") or s.get("spawnedBy") or s.get("parentKey") or None,
                     "endedAt": s.get("endedAtMs") or s.get("endedAt"),

--- a/tests/test_obs_gap_talk_sandbox.py
+++ b/tests/test_obs_gap_talk_sandbox.py
@@ -708,3 +708,88 @@ def test_sandbox_inference_configs_managed_default(tmp_path, monkeypatch):
     assert r["inferenceApi"] == "openai-completions"
     assert r["inferenceCompat"] == "openai"
     assert r["isDefault"] is True
+
+
+# -- #3553 Talk/Voice Call session fields in list_sessions() -----------------
+
+import types
+
+
+def _make_fake_dash(sessions):
+    """Return a minimal stand-in for the dashboard module used by _d()."""
+    return types.SimpleNamespace(_get_sessions=lambda: sessions)
+
+
+def test_list_sessions_voice_kind_sets_source_and_extra(monkeypatch):
+    """kind='talk' session: source falls back to 'talk'; all 4 voice fields land in extra."""
+    import clawmetry.adapters.openclaw as oc_mod
+    raw = [{
+        "kind": "talk",
+        "sessionId": "voice-sess-1",
+        "displayName": "Voice call",
+        "model": "gpt-4o-realtime-preview",
+        "channel": "",
+        "updatedAt": 1750000000000,
+        "totalTokens": 800,
+        "inputTokens": 300,
+        "outputTokens": 500,
+        "transcriptionProvider": "openai",
+        "talkTransport": "webrtc",
+        "voiceModel": "gpt-4o-realtime-preview",
+        "vadMode": "server",
+    }]
+    monkeypatch.setattr(oc_mod, "_d", lambda: _make_fake_dash(raw))
+    sessions = oc_mod.OpenClawAdapter().list_sessions()
+    assert len(sessions) == 1
+    s = sessions[0]
+    assert s.source == "talk"
+    assert s.extra["kind"] == "talk"
+    assert s.extra["transcriptionProvider"] == "openai"
+    assert s.extra["talkTransport"] == "webrtc"
+    assert s.extra["voiceModel"] == "gpt-4o-realtime-preview"
+    assert s.extra["vadMode"] == "server"
+
+
+def test_list_sessions_voice_channel_takes_priority(monkeypatch):
+    """When channel is set on a talk session, source uses channel not kind."""
+    import clawmetry.adapters.openclaw as oc_mod
+    raw = [{
+        "kind": "talk",
+        "sessionId": "voice-sess-2",
+        "displayName": "Voice via channel",
+        "model": "gpt-4o-realtime-preview",
+        "channel": "realtime",
+        "updatedAt": 1750000000000,
+        "totalTokens": 0,
+        "inputTokens": 0,
+        "outputTokens": 0,
+    }]
+    monkeypatch.setattr(oc_mod, "_d", lambda: _make_fake_dash(raw))
+    sessions = oc_mod.OpenClawAdapter().list_sessions()
+    assert len(sessions) == 1
+    assert sessions[0].source == "realtime"
+
+
+def test_list_sessions_non_voice_no_voice_keys(monkeypatch):
+    """A standard chat session (kind='direct') must not get any voice extra keys."""
+    import clawmetry.adapters.openclaw as oc_mod
+    raw = [{
+        "kind": "direct",
+        "sessionId": "chat-sess-1",
+        "displayName": "Chat session",
+        "model": "claude-opus-4",
+        "channel": "main",
+        "updatedAt": 1750000000000,
+        "totalTokens": 200,
+        "inputTokens": 100,
+        "outputTokens": 100,
+    }]
+    monkeypatch.setattr(oc_mod, "_d", lambda: _make_fake_dash(raw))
+    sessions = oc_mod.OpenClawAdapter().list_sessions()
+    assert len(sessions) == 1
+    s = sessions[0]
+    assert s.source == "main"
+    assert "transcriptionProvider" not in s.extra
+    assert "talkTransport" not in s.extra
+    assert "voiceModel" not in s.extra
+    assert "vadMode" not in s.extra


### PR DESCRIPTION
## Summary

Gateway sessions with `kind='talk'`, `'voice'`, or `'realtime'` carry transcription-provider resolution, transport mode, voice model, and VAD config — but `list_sessions()` was silently discarding all four fields and always setting `source` from `channel` with no voice fallback, leaving voice/talk sessions invisible to any session-filter caller.

This fix is scoped to the two places that map the raw gateway record to the `Session` shape: the OpenClaw adapter and the `_get_sessions()` helper in `dashboard.py`.

## Changes

- **`clawmetry/adapters/openclaw.py`** — compute `_sk` (lowercase kind) once per loop iteration; add a `if _sk in ("talk", "voice", "realtime", "voice_call", "talk_call"):` block after the `utilityModelCostUsd` extraction that reads `transcriptionProvider`/`talkTranscriptionProvider`/`speechProvider`, `talkTransport`/`voiceTransport`, `voiceModel`/`realtimeModel`/`talkModel`, `vadMode`/`talkVadMode` with multi-alias fallbacks; update `source=` to fall back to `_sk` when `channel` is empty and the session is a voice kind
- **`dashboard.py`** — add four pass-through fields (`transcriptionProvider`, `talkTransport`, `voiceModel`, `vadMode`) to the `_get_sessions()` session dict so the adapter can read them from the raw gateway RPC response
- **`tests/test_obs_gap_talk_sandbox.py`** — 3 new unit tests: full voice fields → correct `source` + `extra`; channel-present takes priority over kind; non-voice session gets no voice keys

## Test plan

- [x] `python3 -m pytest tests/test_obs_gap_talk_sandbox.py::test_list_sessions_voice_kind_sets_source_and_extra tests/test_obs_gap_talk_sandbox.py::test_list_sessions_voice_channel_takes_priority tests/test_obs_gap_talk_sandbox.py::test_list_sessions_non_voice_no_voice_keys -v` — 3/3 pass
- [x] `python3 -m pytest tests/test_obs_gap_talk_sandbox.py -v` — 37 pass, 1 pre-existing failure (`test_list_sessions_maps_parent_id` fails on main without Flask installed — not introduced here)
- [x] `python3 -c "import ast; ast.parse(open('clawmetry/adapters/openclaw.py').read())"` — syntax clean
- [x] `python3 -c "import ast; ast.parse(open('dashboard.py').read())"` — syntax clean
- [ ] On an OpenClaw install with an active Talk session: verify `list_sessions()` returns `source='talk'` and `extra["transcriptionProvider"]` is populated

## Bot meta

<!-- bot-autofix -->
Draft PR opened autonomously based on the plan in #3553. Marked draft for human review — mark Ready for Review once happy.

Closes #3553

---
_Generated by [Claude Code](https://claude.ai/code/session_01VfUGu7bWo4zVjXZVDB8wm6)_