### PR TITLE
fix: approval watcher starves rows after 2,000-row page cap (#3558)

### DIFF
--- a/clawmetry/approvals.py
+++ b/clawmetry/approvals.py
@@ -778,6 +778,7 @@ def process_tool_call(api_key: str, node_id: str, session_id: Optional[str],
 _state: dict = {
     "last_ingest_ms": None,     # Optional[int]  (epoch-ms, ingest stamp)
     "seen_recent_ids": {},      # dict[str, int]  event id -> created_at ms
+    "resume_cursor": None,      # Optional[tuple[int, Optional[str]]] — keyset after page cap
 }
 _state_lock = threading.Lock()
 
@@ -1056,15 +1057,20 @@ def watch_iteration(api_key: str, node_id: str,
             _state["seen_recent_ids"] = persisted_ids
         watermark = int(_state["last_ingest_ms"])
         seen: dict = dict(_state["seen_recent_ids"])
+        resume_cursor = _state.get("resume_cursor")
 
     processed = 0
     max_ingest = watermark
     saw_rows = False
-    # Window start: a bounded lookback behind the watermark. Rows in the
-    # window we already dispatched are skipped via ``seen``; rows that
-    # committed late (stamp older than the watermark) are caught here.
-    cursor_ca = max(0, watermark - _INGEST_LOOKBACK_MS)
-    cursor_id: Optional[str] = None  # None → inclusive window start
+    # If the previous iteration hit the page cap, resume from where it stopped
+    # so we advance past row 2,000 instead of rescanning the same first 2,000
+    # rows forever (see #3558).  Otherwise start from the lookback window.
+    if resume_cursor is not None:
+        cursor_ca, cursor_id = resume_cursor
+    else:
+        cursor_ca = max(0, watermark - _INGEST_LOOKBACK_MS)
+        cursor_id = None
+    hit_page_cap = False
     for _page in range(_MAX_PAGES_PER_ITERATION):
         # ``limit=500`` per page matches the PRD spec; the page cap bounds
         # one iteration's work (the next 2 s poll picks up the rest).
@@ -1113,8 +1119,18 @@ def watch_iteration(api_key: str, node_id: str,
         last_ca = last.get("created_at")
         cursor_ca = int(last_ca) if isinstance(last_ca, (int, float)) else cursor_ca
         cursor_id = str(last.get("id") or "")
+    else:
+        # All pages exhausted without a short final page: save the keyset
+        # cursor so the next iteration resumes here instead of restarting
+        # from the lookback window (#3558 page-cap starvation fix).
+        hit_page_cap = True
 
     if not saw_rows:
+        # Nothing to scan.  Clear any stale resume cursor so the next
+        # iteration doesn't try to pick up mid-way through an empty window.
+        if resume_cursor is not None:
+            with _state_lock:
+                _state["resume_cursor"] = None
         return 0
 
     # Advance the watermark, prune the dedup map to the new lookback window
@@ -1129,6 +1145,7 @@ def watch_iteration(api_key: str, node_id: str,
     with _state_lock:
         _state["last_ingest_ms"] = max_ingest
         _state["seen_recent_ids"] = seen
+        _state["resume_cursor"] = (cursor_ca, cursor_id) if hit_page_cap else None
         snapshot_ms = int(_state["last_ingest_ms"])
         snapshot_ids = dict(_state["seen_recent_ids"])
     _persist_watermark(snapshot_ms, snapshot_ids)

--- a/tests/test_approvals_duckdb_watcher.py
+++ b/tests/test_approvals_duckdb_watcher.py
@@ -408,3 +408,80 @@ def test_late_ingested_event_with_stale_ts_still_evaluated(watcher):
     ap._state["seen_recent_ids"] = {}
     assert ap.watch_iteration("k", "n", policies=policies) == 0
     assert len(captured) == 2
+
+
+# ── 7. page-cap cursor resumes past 2,000 rows (#3558) ───────────────────
+
+
+def test_page_cap_cursor_resumes_past_2000_rows(watcher, monkeypatch):
+    """When more than _MAX_PAGES_PER_ITERATION * 500 rows exist in the
+    lookback window, subsequent iterations must resume from the saved keyset
+    cursor rather than restarting from the window start.
+
+    Pre-fix: every poll refetched the same first 2,000 rows, all of which hit
+    seen_recent_ids and were skipped, so the watcher never advanced to row
+    2,001+.  Any approval-gated tool call in the starved suffix was silently
+    dropped forever.  Regression guard for vivekchand/clawmetry#3558.
+    """
+    ap, ls, captured, policies, _ = watcher
+
+    n_rows = ap._MAX_PAGES_PER_ITERATION * 500 + 1  # 2,001 rows
+    now_ms = 2_000_000_000_000
+
+    # All rows share the same created_at; the keyset (created_at, id) drives
+    # ordering.  The toolCall block lives only in the final row (index 2000)
+    # so we can prove the watcher eventually reaches it.
+    rows = []
+    for i in range(n_rows):
+        content = []
+        if i == n_rows - 1:
+            content = [_toolcall_block("bash", {"cmd": "rm -rf /"},
+                                       blk_id="tc-starved")]
+        rows.append({
+            "id": f"e{i:04d}",
+            "session_id": "sess-pagecap",
+            "event_type": "message",
+            "created_at": now_ms,
+            "data": {
+                "type": "message",
+                "message": {"role": "assistant", "content": content},
+            },
+        })
+
+    def _stub_query(created_after, after_id, limit):
+        eligible = [
+            r for r in rows
+            if r["created_at"] > created_after
+            or (r["created_at"] == created_after
+                and (after_id is None or r["id"] > after_id))
+        ]
+        return eligible[:limit]
+
+    monkeypatch.setattr(ap, "_query_new_events", _stub_query)
+    monkeypatch.setattr(ap, "_persist_watermark", lambda *_: None)
+
+    # Prime watermark so the lookback window covers all rows.
+    ap._state["last_ingest_ms"] = now_ms - 1
+    ap._state["seen_recent_ids"] = {}
+    ap._state["resume_cursor"] = None
+
+    # Iteration 1: consumes the first 2,000 rows (4 full pages).  The
+    # toolCall at index 2,000 has not been reached yet.
+    ap.watch_iteration("k", "n", policies=policies)
+    assert ap._state.get("resume_cursor") is not None, (
+        "page cap must store a resume cursor so the next iteration continues"
+    )
+    assert len(captured) == 0, "toolCall is beyond the page cap — not yet dispatched"
+
+    # Iteration 2: resumes from the saved cursor and reaches the final row.
+    ap.watch_iteration("k", "n", policies=policies)
+    assert len(captured) == 1, "toolCall in the starved row must be dispatched exactly once"
+    assert captured[0]["tool_call_id"] == "tc-starved"
+    assert ap._state.get("resume_cursor") is None, (
+        "cursor must be cleared after a short final page"
+    )
+
+    # Iteration 3: idempotent — nothing new dispatched.
+    captured.clear()
+    ap.watch_iteration("k", "n", policies=policies)
+    assert len(captured) == 0, "already-seen rows must not be re-dispatched"


### PR DESCRIPTION
Closes #3558

## What was broken

`watch_iteration()` in `clawmetry/approvals.py` resets its keyset cursor to `watermark - _INGEST_LOOKBACK_MS` on every call. When the lookback window held more than `_MAX_PAGES_PER_ITERATION × 500 = 2,000` rows, every poll re-fetched the same first 2,000 rows, had all of them deduplicated by `seen_recent_ids`, hit the page cap again, and never advanced to row 2,001+. Approval-gated tool calls in the starved suffix were silently dropped forever.

## Fix

- **`clawmetry/approvals.py`** — add a `"resume_cursor"` field to the module-level `_state` dict. In `watch_iteration()`, if a prior iteration hit the page cap the new `for…else` branch saves `(cursor_ca, cursor_id)` to `_state["resume_cursor"]`. The next call reads it and starts the scan from there rather than the window start. The cursor is cleared on a short final page or an empty window, keeping the normal (< 2,000 row) path unchanged.

- **`tests/test_approvals_duckdb_watcher.py`** — add `test_page_cap_cursor_resumes_past_2000_rows`: stubs `_query_new_events` with 2,001 in-memory rows (a toolCall only in the final row), runs three `watch_iteration()` calls, asserts the toolCall is dispatched exactly once on iteration 2, and verifies the cursor is set then cleared correctly.

## Test plan

- All 7 tests in `tests/test_approvals_duckdb_watcher.py` pass, including the new regression test.
- No changes to watermark, `seen_recent_ids`, or `_persist_watermark` — those are unaffected.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EVEwmMBPSEZuYie5rMNrBW)_