### PR TITLE
feat(entitlement): tier_spec_path_batch + /api/entitlement/tier-spec-path-batch

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -7152,6 +7152,123 @@ def lock_reason_path(
         return None
 
 
+def tier_spec_path_batch(from_tier: str, to_tiers) -> dict | None:
+    """Batch sibling of :func:`tier_spec_path`: per-destination spec-shaped
+    paths from ONE source tier to N candidate destination tiers walked in
+    ONE round-trip.
+
+    Multi-destination axis mirrors :func:`tier_spec_at_batch` (fixed-source
+    what-if matrix over many targets) the same way
+    :func:`feature_spec_path_batch` mirrors :func:`feature_spec_at_batch`:
+    scalar -> matrix in one call along the destination axis. Lets a
+    pricing-comparison "from my current rung, here are the 3 tiers I'm
+    considering" surface hydrate every per-rung row for every candidate off
+    ONE call instead of N calls to :func:`tier_spec_path`.
+
+    Per-destination row shape::
+
+        {
+          "to":         "<id>",
+          "to_label":   "...",
+          "to_rank":    <int>,
+          "direction":  "upgrade" | "downgrade" | "lateral" | "identity",
+          "path":       [<tier_spec_at row>, ...],
+        }
+
+    Each ``path`` list is byte-identical to :func:`tier_spec_path` for the
+    same ``(from_tier, to)`` pair -- a parity test pins this so the scalar
+    and batch path helpers cannot drift. Per-destination ``path`` lengths
+    can legitimately differ -- the rungs walked depend on the destination,
+    unlike :func:`feature_spec_path_batch` whose rungs are feature-agnostic
+    across the supplied feature set.
+
+    ``direction`` is derived from the same rank geometry
+    :func:`tier_spec_path` uses (identity / lateral / upgrade / downgrade),
+    so a UI rendering scalar-shaped rows needs zero new shape code to
+    render rows off this batch.
+
+    Shape::
+
+        {
+          "tiers": [
+            {"to": "<id>", "to_label": "...", "to_rank": <int>,
+             "direction": "upgrade" | "downgrade" | "lateral" | "identity",
+             "path": [<row>, ...]},
+            ...
+          ],
+          "unknown": ["bogus_id", ...],
+        }
+
+    Destination ids are normalised via :func:`_normalise_csv` (whitespace
+    stripped, lowercased, duplicates dropped, first-seen order preserved).
+    :data:`TIER_TRIAL` IS a valid destination -- it resolves via the
+    identity / lateral branch the way :func:`tier_spec_path` already
+    handles it, and is excluded from the walked intermediate rungs the
+    same way. Unknown destination ids are echoed in ``unknown[]`` instead
+    of short-circuiting -- a partially-bad caller still gets paths back
+    for the valid ids alongside a list of what was dropped, matching
+    :func:`feature_spec_path_batch`'s posture.
+
+    Returns ``None`` for empty / unknown ``from_tier`` (caller renders
+    "unknown tier" / 404). An empty destination list yields
+    ``{"tiers": [], "unknown": []}``.
+
+    Resolver-independent: delegates per-destination to
+    :func:`tier_spec_path`, which walks the static per-tier maps via
+    :func:`tier_spec_at` -- so grace vs enforce yields byte-identical
+    rows.
+
+    Never raises: a per-destination builder failure short-circuits that
+    id into ``unknown[]`` and the rest of the batch keeps building.
+    """
+    try:
+        f = (from_tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if f not in _TIER_FEATURES:
+        return None
+    tos = _normalise_csv(to_tiers)
+    from_rank = _TIER_RANK.get(f, -1)
+    rows: list[dict] = []
+    unknown: list[str] = []
+    for tid in tos:
+        if tid not in _TIER_FEATURES:
+            unknown.append(tid)
+            continue
+        try:
+            path = tier_spec_path(f, tid)
+        except Exception as exc:
+            logger.warning(
+                "entitlements: tier_spec_path_batch row %r failed: %s",
+                tid,
+                exc,
+            )
+            unknown.append(tid)
+            continue
+        if path is None:
+            unknown.append(tid)
+            continue
+        to_rank = _TIER_RANK.get(tid, -1)
+        if f == tid:
+            direction = "identity"
+        elif from_rank == to_rank:
+            direction = "lateral"
+        elif to_rank > from_rank:
+            direction = "upgrade"
+        else:
+            direction = "downgrade"
+        rows.append(
+            {
+                "to": tid,
+                "to_label": tier_label(tid),
+                "to_rank": to_rank,
+                "direction": direction,
+                "path": path,
+            }
+        )
+    return {"tiers": rows, "unknown": unknown}
+
+
 def feature_spec_path_batch(
     from_tier: str, to_tier: str, features
 ) -> dict | None:

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -7028,6 +7028,102 @@ def api_entitlement_previous_tier_runtime_spec_at():
         )
 
 
+@bp_entitlement.route("/api/entitlement/tier-spec-path-batch")
+def api_entitlement_tier_spec_path_batch():
+    """``GET /api/entitlement/tier-spec-path-batch?from=<id>&to=a,b,c`` --
+    batch sibling of ``/api/entitlement/tier-spec-path``.
+
+    Where ``/tier-spec-path`` walks the rungs between ONE ``(from, to)``
+    pair, this walks them between ONE source and N candidate destinations
+    in ONE round-trip. Multi-destination axis mirrors
+    ``/tier-spec-at-batch`` (same axis, one-rung-at-a-time -> all-rungs-
+    at-a-time) the same way ``/feature-spec-path-batch`` mirrors
+    ``/feature-spec-at-batch``: scalar -> matrix in one call along the
+    destination axis.
+
+    Use case: a pricing-comparison "from my current rung, here are the 3
+    tiers I'm considering" surface hydrates every per-rung row for every
+    candidate off ONE call instead of N calls to ``/tier-spec-path``. Per-
+    destination ``path`` rows are byte-identical to the scalar
+    ``/tier-spec-path?from=<from>&to=<to>`` payload for the same
+    ``(from, to)`` pair, so a UI that already renders scalar-shaped rows
+    needs zero new shape code to render rows off this batch.
+
+    Response shape::
+
+        {
+          "from":       "<tier id>",
+          "from_label": "...",
+          "from_rank":  <int>,
+          "tiers": [
+            {"to": "<id>", "to_label": "...", "to_rank": <int>,
+             "direction": "upgrade" | "downgrade" | "lateral" | "identity",
+             "path": [<tier-spec-at row>, ...]},
+            ...
+          ],
+          "unknown":    ["bogus_id", ...],
+        }
+
+    Per-destination ``path`` lengths can legitimately differ -- the rungs
+    walked depend on the destination, unlike ``/feature-spec-path-batch``
+    whose rungs are feature-agnostic across the supplied feature set.
+    Destination ids are normalised (whitespace stripped, lowercased,
+    duplicates dropped, first-seen order preserved). ``trial`` IS a valid
+    destination (identity / lateral branch); it is excluded from the
+    walked intermediate rungs the way ``/tier-spec-path`` already
+    excludes it. Unknown destination ids do NOT 404 the call -- they are
+    echoed in ``unknown[]`` so a partially-bad caller still gets paths
+    back for the valid ids.
+
+    - **400** when ``from=`` is missing / blank, or ``to=`` is missing /
+      empty after normalisation
+    - **404** when ``from`` is unknown (body carries ``which: "tier"``)
+    - **Never 5xxs**: a synthesis failure short-circuits to an envelope
+      with empty rows so the matrix keeps rendering.
+    """
+    f = (request.args.get("from") or "").strip().lower()
+    if not f:
+        return jsonify({"error": "missing from"}), 400
+    tos = _parse_csv_arg("to")
+    if not tos:
+        return jsonify({"error": "supply to=<csv>"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        if f not in _ent._TIER_ORDER:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "tier", "tier": f}
+                ),
+                404,
+            )
+        batch = _ent.tier_spec_path_batch(f, tos)
+        if batch is None:
+            batch = {"tiers": [], "unknown": []}
+        return jsonify(
+            {
+                "from": f,
+                "from_label": _ent.tier_label(f),
+                "from_rank": _ent.tier_rank(f),
+                "tiers": batch.get("tiers", []),
+                "unknown": batch.get("unknown", []),
+            }
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_tier_spec_path_batch: error: %s", exc
+        )
+        return jsonify(
+            {
+                "from": f,
+                "from_label": None,
+                "from_rank": -1,
+                "tiers": [],
+                "unknown": [],
+            }
+        )
+
+
 @bp_entitlement.route("/api/entitlement/feature-spec-path-batch")
 def api_entitlement_feature_spec_path_batch():
     """``GET /api/entitlement/feature-spec-path-batch?from=<id>&to=<id>

--- a/tests/test_entitlement_tier_spec_path_batch.py
+++ b/tests/test_entitlement_tier_spec_path_batch.py
@@ -1,0 +1,483 @@
+"""Tests for ``clawmetry.entitlements.tier_spec_path_batch(from, to_tiers)``
++ the ``GET /api/entitlement/tier-spec-path-batch`` endpoint.
+
+Batch sibling of :func:`tier_spec_path` (walks the rungs between ONE
+``(from, to)`` pair). This helper walks the rungs between ONE source and
+N candidate destinations in ONE round-trip. Multi-destination axis
+mirrors :func:`tier_spec_at_batch` (fixed-source what-if matrix over many
+targets) the same way :func:`feature_spec_path_batch` mirrors
+:func:`feature_spec_at_batch`.
+
+Pins:
+
+* per-destination ``path`` list byte-equals the scalar
+  :func:`tier_spec_path` helper for the same ``(from, to)`` pair
+* per-destination ``direction`` derived from the same rank geometry the
+  scalar ``/tier-spec-path`` endpoint uses (identity / lateral / upgrade /
+  downgrade), matching the scalar branch it takes for the same pair
+* per-destination ``to_label`` / ``to_rank`` byte-equal :func:`tier_label`
+  / :func:`tier_rank` for the same id
+* supply order preserved through input normalisation
+  (whitespace stripped, lowercased, duplicates dropped, first-seen order
+  preserved)
+* unknown destination ids echoed in ``unknown[]`` -- helper does not
+  short-circuit on partially-bad callers
+* all four direction branches surface: identity / lateral / upgrade /
+  downgrade
+* trial IS accepted as a destination (identity + lateral branches);
+  excluded from walked intermediate rungs the way :func:`tier_spec_path`
+  already excludes it
+* per-destination row-failure short-circuits that id into ``unknown[]``
+  instead of raising
+* grace vs enforce yields byte-identical helper output (walks the static
+  per-tier maps via :func:`tier_spec_at`)
+* empty / unknown ``from_tier`` returns ``None``; garbage inputs never
+  raise
+* empty destinations returns ``{"tiers": [], "unknown": []}``
+* HTTP: 400 on missing / empty ``from`` or ``to``, 404 on unknown ``from``,
+  200 with bucketed unknowns for destination ids; envelope keys pinned
+* HTTP per-destination ``path`` byte-equals the scalar
+  ``/api/entitlement/tier-spec-path`` payload's ``path``
+* HTTP grace-vs-enforce body parity
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+_ENVELOPE_KEYS = {
+    "from",
+    "from_label",
+    "from_rank",
+    "tiers",
+    "unknown",
+}
+_ROW_KEYS = {
+    "to",
+    "to_label",
+    "to_rank",
+    "direction",
+    "path",
+}
+
+
+# ── helper-level: shape + invariants ─────────────────────────────────────────
+
+
+def test_returns_dict_with_tiers_and_unknown(ent):
+    out = ent.tier_spec_path_batch(
+        ent.TIER_OSS, [ent.TIER_CLOUD_PRO, ent.TIER_ENTERPRISE]
+    )
+    assert isinstance(out, dict)
+    assert set(out.keys()) == {"tiers", "unknown"}
+    assert isinstance(out["tiers"], list)
+    assert isinstance(out["unknown"], list)
+    assert len(out["tiers"]) == 2
+    assert out["unknown"] == []
+
+
+def test_each_row_has_the_row_key_set(ent):
+    out = ent.tier_spec_path_batch(
+        ent.TIER_OSS, [ent.TIER_CLOUD_STARTER, ent.TIER_ENTERPRISE]
+    )
+    for row in out["tiers"]:
+        assert set(row.keys()) == _ROW_KEYS
+
+
+def test_per_destination_path_byte_equals_scalar(ent):
+    """``path`` for each destination must be byte-identical to the scalar
+    :func:`tier_spec_path(from, to)` payload for the same ``(from, to)``
+    pair -- the parity pin so scalar and batch cannot drift."""
+    f = ent.TIER_OSS
+    tos = [
+        ent.TIER_CLOUD_FREE,
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_PRO,
+        ent.TIER_ENTERPRISE,
+        ent.TIER_TRIAL,
+    ]
+    out = ent.tier_spec_path_batch(f, tos)
+    by_to = {row["to"]: row for row in out["tiers"]}
+    for tid in tos:
+        assert by_to[tid]["path"] == ent.tier_spec_path(f, tid)
+
+
+def test_per_destination_to_label_and_to_rank_match_helpers(ent):
+    out = ent.tier_spec_path_batch(
+        ent.TIER_OSS,
+        [ent.TIER_CLOUD_PRO, ent.TIER_PRO, ent.TIER_ENTERPRISE],
+    )
+    for row in out["tiers"]:
+        assert row["to_label"] == ent.tier_label(row["to"])
+        assert row["to_rank"] == ent.tier_rank(row["to"])
+
+
+def test_direction_identity_when_to_equals_from(ent):
+    out = ent.tier_spec_path_batch(ent.TIER_CLOUD_PRO, [ent.TIER_CLOUD_PRO])
+    assert out["tiers"][0]["direction"] == "identity"
+    assert out["tiers"][0]["path"] == []
+
+
+def test_direction_lateral_when_same_rank_different_id(ent):
+    # cloud_pro and pro both at collapsed rank 2
+    out = ent.tier_spec_path_batch(ent.TIER_CLOUD_PRO, [ent.TIER_PRO])
+    assert out["tiers"][0]["direction"] == "lateral"
+    assert len(out["tiers"][0]["path"]) == 1
+    assert out["tiers"][0]["path"][0]["id"] == ent.TIER_PRO
+
+
+def test_direction_upgrade_when_to_rank_above_from(ent):
+    out = ent.tier_spec_path_batch(ent.TIER_OSS, [ent.TIER_ENTERPRISE])
+    assert out["tiers"][0]["direction"] == "upgrade"
+    assert out["tiers"][0]["path"][-1]["id"] == ent.TIER_ENTERPRISE
+
+
+def test_direction_downgrade_when_to_rank_below_from(ent):
+    out = ent.tier_spec_path_batch(ent.TIER_ENTERPRISE, [ent.TIER_OSS])
+    assert out["tiers"][0]["direction"] == "downgrade"
+    assert out["tiers"][0]["path"][-1]["id"] == ent.TIER_OSS
+
+
+def test_all_four_direction_branches_in_one_batch(ent):
+    """One batch surfaces all four direction branches at once -- pins the
+    per-destination geometry against the pairwise scalar mapping."""
+    f = ent.TIER_CLOUD_PRO
+    out = ent.tier_spec_path_batch(
+        f,
+        [
+            ent.TIER_CLOUD_PRO,  # identity
+            ent.TIER_PRO,  # lateral (both rank 2)
+            ent.TIER_ENTERPRISE,  # upgrade
+            ent.TIER_OSS,  # downgrade
+        ],
+    )
+    by_to = {row["to"]: row["direction"] for row in out["tiers"]}
+    assert by_to[ent.TIER_CLOUD_PRO] == "identity"
+    assert by_to[ent.TIER_PRO] == "lateral"
+    assert by_to[ent.TIER_ENTERPRISE] == "upgrade"
+    assert by_to[ent.TIER_OSS] == "downgrade"
+
+
+def test_supply_order_preserved(ent):
+    tos = [
+        ent.TIER_ENTERPRISE,
+        ent.TIER_CLOUD_FREE,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_CLOUD_STARTER,
+    ]
+    out = ent.tier_spec_path_batch(ent.TIER_OSS, tos)
+    assert [row["to"] for row in out["tiers"]] == tos
+
+
+def test_whitespace_case_and_duplicates_normalised(ent):
+    tos = [
+        "  ENTERPRISE  ",
+        "cloud_pro",
+        "ENTERPRISE",  # duplicate after normalisation
+        "  Cloud_Pro ",  # another duplicate
+        "cloud_starter",
+    ]
+    out = ent.tier_spec_path_batch(ent.TIER_OSS, tos)
+    assert [row["to"] for row in out["tiers"]] == [
+        ent.TIER_ENTERPRISE,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_CLOUD_STARTER,
+    ]
+
+
+def test_unknown_destinations_bucketed_not_short_circuiting(ent):
+    out = ent.tier_spec_path_batch(
+        ent.TIER_OSS,
+        [
+            ent.TIER_CLOUD_PRO,
+            "not_a_tier",
+            ent.TIER_ENTERPRISE,
+            "still_not_a_tier",
+        ],
+    )
+    assert [row["to"] for row in out["tiers"]] == [
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_ENTERPRISE,
+    ]
+    assert out["unknown"] == ["not_a_tier", "still_not_a_tier"]
+
+
+def test_empty_destinations_returns_empty_envelope(ent):
+    out = ent.tier_spec_path_batch(ent.TIER_OSS, [])
+    assert out == {"tiers": [], "unknown": []}
+    assert ent.tier_spec_path_batch(ent.TIER_OSS, "") == {
+        "tiers": [],
+        "unknown": [],
+    }
+    assert ent.tier_spec_path_batch(ent.TIER_OSS, None) == {
+        "tiers": [],
+        "unknown": [],
+    }
+
+
+def test_none_or_unknown_from_tier_returns_none(ent):
+    assert ent.tier_spec_path_batch("", [ent.TIER_CLOUD_PRO]) is None
+    assert ent.tier_spec_path_batch(None, [ent.TIER_CLOUD_PRO]) is None
+    assert ent.tier_spec_path_batch("  ", [ent.TIER_CLOUD_PRO]) is None
+    assert (
+        ent.tier_spec_path_batch("not_a_tier", [ent.TIER_CLOUD_PRO])
+        is None
+    )
+
+
+def test_garbage_from_tier_never_raises(ent):
+    assert ent.tier_spec_path_batch(123, [ent.TIER_CLOUD_PRO]) is None
+    assert ent.tier_spec_path_batch([], [ent.TIER_CLOUD_PRO]) is None
+    assert ent.tier_spec_path_batch({}, [ent.TIER_CLOUD_PRO]) is None
+
+
+def test_trial_accepted_as_destination_via_lateral(ent):
+    """cloud_pro and trial both at collapsed rank 2 -- trial resolves via
+    the lateral branch as a single-row path."""
+    out = ent.tier_spec_path_batch(ent.TIER_CLOUD_PRO, [ent.TIER_TRIAL])
+    assert out["unknown"] == []
+    row = out["tiers"][0]
+    assert row["direction"] == "lateral"
+    assert len(row["path"]) == 1
+    assert row["path"][0]["id"] == ent.TIER_TRIAL
+
+
+def test_trial_as_source_still_walks(ent):
+    """trial IS a valid source -- the walker crosses into the rank above."""
+    out = ent.tier_spec_path_batch(ent.TIER_TRIAL, [ent.TIER_ENTERPRISE])
+    assert out["unknown"] == []
+    row = out["tiers"][0]
+    assert row["direction"] == "upgrade"
+    assert row["path"][-1]["id"] == ent.TIER_ENTERPRISE
+
+
+def test_trial_excluded_from_walked_intermediate_rungs(ent):
+    """trial is not purchasable -- it must never appear as an intermediate
+    rung between two purchasable endpoints, in the batch response the
+    same way it never appears in the scalar."""
+    out = ent.tier_spec_path_batch(ent.TIER_OSS, [ent.TIER_ENTERPRISE])
+    for rung in out["tiers"][0]["path"]:
+        assert rung["id"] != ent.TIER_TRIAL
+
+
+def test_grace_and_enforce_yield_identical_batch(ent, monkeypatch):
+    """The helper is decoupled from the resolved entitlement -- flipping
+    enforce on must NOT change any row. Pins the resolver-independence
+    property the whole ``_path`` family shares."""
+    tos = [
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_PRO,
+        ent.TIER_ENTERPRISE,
+    ]
+    grace = ent.tier_spec_path_batch(ent.TIER_OSS, tos)
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    enforced = ent.tier_spec_path_batch(ent.TIER_OSS, tos)
+    assert grace == enforced
+
+
+def test_per_destination_failure_bucketed_not_5xxd(ent, monkeypatch):
+    """When the underlying scalar helper raises for a single destination,
+    that id must short-circuit into ``unknown[]`` while the rest of the
+    batch keeps building -- pins the never-raise batch posture."""
+    real = ent.tier_spec_path
+
+    def blow_up_on_pro(f, t):
+        if t == ent.TIER_PRO:
+            raise RuntimeError("boom")
+        return real(f, t)
+
+    monkeypatch.setattr(ent, "tier_spec_path", blow_up_on_pro)
+    out = ent.tier_spec_path_batch(
+        ent.TIER_OSS,
+        [ent.TIER_CLOUD_PRO, ent.TIER_PRO, ent.TIER_ENTERPRISE],
+    )
+    assert [row["to"] for row in out["tiers"]] == [
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_ENTERPRISE,
+    ]
+    assert ent.TIER_PRO in out["unknown"]
+
+
+def test_per_destination_none_bucketed(ent, monkeypatch):
+    """When the scalar helper returns ``None`` for a destination, that id
+    is bucketed into ``unknown[]`` instead of appearing as a
+    ``path: None`` row."""
+
+    def none_on_pro(f, t):
+        if t == ent.TIER_PRO:
+            return None
+        # Fall through to a real call.
+        return ent.tier_spec_at(f, t) and [ent.tier_spec_at(f, t)]
+
+    monkeypatch.setattr(ent, "tier_spec_path", none_on_pro)
+    out = ent.tier_spec_path_batch(
+        ent.TIER_OSS, [ent.TIER_CLOUD_PRO, ent.TIER_PRO]
+    )
+    assert ent.TIER_PRO in out["unknown"]
+    tos = [row["to"] for row in out["tiers"]]
+    assert ent.TIER_PRO not in tos
+
+
+# ── API surface ──────────────────────────────────────────────────────────────
+
+
+def test_api_400_on_missing_from(client):
+    r = client.get("/api/entitlement/tier-spec-path-batch")
+    assert r.status_code == 400
+
+
+def test_api_400_on_missing_to(client, ent):
+    r = client.get(
+        f"/api/entitlement/tier-spec-path-batch?from={ent.TIER_OSS}"
+    )
+    assert r.status_code == 400
+    r2 = client.get(
+        f"/api/entitlement/tier-spec-path-batch?from={ent.TIER_OSS}&to="
+    )
+    assert r2.status_code == 400
+
+
+def test_api_404_on_unknown_from(client, ent):
+    r = client.get(
+        f"/api/entitlement/tier-spec-path-batch?from=not_a_tier"
+        f"&to={ent.TIER_CLOUD_PRO}"
+    )
+    assert r.status_code == 404
+    body = r.get_json()
+    assert body["error"] == "unknown tier"
+    assert body["which"] == "tier"
+    assert body["tier"] == "not_a_tier"
+
+
+def test_api_happy_path_envelope(client, ent):
+    r = client.get(
+        f"/api/entitlement/tier-spec-path-batch?from={ent.TIER_OSS}"
+        f"&to={ent.TIER_CLOUD_STARTER},{ent.TIER_CLOUD_PRO},{ent.TIER_ENTERPRISE}"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert set(body.keys()) == _ENVELOPE_KEYS
+    assert body["from"] == ent.TIER_OSS
+    assert body["from_label"] == ent.tier_label(ent.TIER_OSS)
+    assert body["from_rank"] == ent.tier_rank(ent.TIER_OSS)
+    assert isinstance(body["tiers"], list)
+    assert len(body["tiers"]) == 3
+    for row in body["tiers"]:
+        assert set(row.keys()) == _ROW_KEYS
+    assert body["unknown"] == []
+
+
+def test_api_bucketed_unknowns_do_not_404(client, ent):
+    r = client.get(
+        f"/api/entitlement/tier-spec-path-batch?from={ent.TIER_OSS}"
+        f"&to={ent.TIER_CLOUD_PRO},bogus_tier"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert [row["to"] for row in body["tiers"]] == [ent.TIER_CLOUD_PRO]
+    assert body["unknown"] == ["bogus_tier"]
+
+
+def test_api_direction_branches_end_to_end(client, ent):
+    """Each destination in a single request should carry the same
+    direction the scalar ``/tier-spec-path`` endpoint returns for the
+    same pair."""
+    r = client.get(
+        f"/api/entitlement/tier-spec-path-batch?from={ent.TIER_CLOUD_PRO}"
+        f"&to={ent.TIER_CLOUD_PRO},{ent.TIER_PRO},{ent.TIER_ENTERPRISE},{ent.TIER_OSS}"
+    )
+    assert r.status_code == 200
+    by_to = {row["to"]: row["direction"] for row in r.get_json()["tiers"]}
+    assert by_to[ent.TIER_CLOUD_PRO] == "identity"
+    assert by_to[ent.TIER_PRO] == "lateral"
+    assert by_to[ent.TIER_ENTERPRISE] == "upgrade"
+    assert by_to[ent.TIER_OSS] == "downgrade"
+
+
+def test_api_per_destination_path_byte_equals_scalar_route(client, ent):
+    """The per-destination ``path`` in the batch response must be
+    byte-identical to the scalar ``/tier-spec-path?from=&to=`` payload's
+    ``path`` for the same pair."""
+    f = ent.TIER_OSS
+    tos = [ent.TIER_CLOUD_STARTER, ent.TIER_CLOUD_PRO, ent.TIER_ENTERPRISE]
+    batch = client.get(
+        f"/api/entitlement/tier-spec-path-batch?from={f}"
+        f"&to={','.join(tos)}"
+    ).get_json()
+    by_to = {row["to"]: row for row in batch["tiers"]}
+    for tid in tos:
+        scalar = client.get(
+            f"/api/entitlement/tier-spec-path?from={f}&to={tid}"
+        ).get_json()
+        assert by_to[tid]["path"] == scalar["path"]
+        assert by_to[tid]["direction"] == scalar["direction"]
+        assert by_to[tid]["to_label"] == scalar["to_label"]
+        assert by_to[tid]["to_rank"] == scalar["to_rank"]
+
+
+def test_api_supply_order_preserved(client, ent):
+    tos = [
+        ent.TIER_ENTERPRISE,
+        ent.TIER_CLOUD_FREE,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_CLOUD_STARTER,
+    ]
+    body = client.get(
+        f"/api/entitlement/tier-spec-path-batch?from={ent.TIER_OSS}"
+        f"&to={','.join(tos)}"
+    ).get_json()
+    assert [row["to"] for row in body["tiers"]] == tos
+
+
+def test_api_grace_vs_enforce_body_parity(client, ent, monkeypatch):
+    tos = [ent.TIER_CLOUD_PRO, ent.TIER_PRO, ent.TIER_ENTERPRISE]
+    grace_body = client.get(
+        f"/api/entitlement/tier-spec-path-batch?from={ent.TIER_OSS}"
+        f"&to={','.join(tos)}"
+    ).get_json()
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    enforced_body = client.get(
+        f"/api/entitlement/tier-spec-path-batch?from={ent.TIER_OSS}"
+        f"&to={','.join(tos)}"
+    ).get_json()
+    assert grace_body == enforced_body
+
+
+def test_api_trial_endpoints_accepted(client, ent):
+    r = client.get(
+        f"/api/entitlement/tier-spec-path-batch?from={ent.TIER_TRIAL}"
+        f"&to={ent.TIER_ENTERPRISE},{ent.TIER_CLOUD_PRO}"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["from"] == ent.TIER_TRIAL
+    tos = [row["to"] for row in body["tiers"]]
+    assert ent.TIER_ENTERPRISE in tos
+    assert ent.TIER_CLOUD_PRO in tos


### PR DESCRIPTION
## Summary

- Batch sibling of `tier_spec_path` (walks the rungs between ONE `(from, to)` pair). Where the scalar walks the rungs between one source and one destination, this batch sibling walks them between ONE source and N candidate destinations in ONE round-trip.
- Multi-destination axis mirrors `tier_spec_at_batch` (fixed-source what-if matrix over many targets) the same way `feature_spec_path_batch` mirrors `feature_spec_at_batch`: scalar → matrix in one call along the destination axis. A pricing-comparison "from my current rung, here are the tiers I'm considering" surface hydrates every per-rung row for every candidate off ONE call instead of N calls to `/tier-spec-path`.
- Per-destination `path` rows are byte-identical to the scalar `/tier-spec-path?from=&to=` payload for the same `(from, to)` pair (parity-pinned in tests).

> Fresh implementation of the surface planned in the previously-merged #3402 -- the helper + endpoint were not present on `main` when this branch was cut, so this PR re-lands the helper + route + tests. Non-overlapping with open PRs #3555 (channel_catalog_path) and #3549 (channel_catalog_at + batch): the new helper sits just above `feature_spec_path_batch` in `clawmetry/entitlements.py` and the new route just above `/feature-spec-path-batch` in `routes/entitlement.py`, on a different axis from both open branches.

## Helper

```python
def tier_spec_path_batch(from_tier: str, to_tiers) -> dict | None
```

Returned shape:

```
{
  "tiers": [
    {"to": "<id>", "to_label": "...", "to_rank": <int>,
     "direction": "upgrade" | "downgrade" | "lateral" | "identity",
     "path": [<tier_spec_at row>, ...]},
    ...
  ],
  "unknown": ["bogus_id", ...],
}
```

- Destination ids normalised via `_normalise_csv` (whitespace stripped, lowercased, duplicates dropped, first-seen order preserved).
- Per-destination `direction` derived from the same rank geometry the scalar `/tier-spec-path` endpoint uses -- so a UI rendering scalar-shaped rows needs zero new shape code to render rows off this batch.
- Per-destination `path` lengths can legitimately differ -- the rungs walked depend on the destination, unlike `feature_spec_path_batch` whose rungs are feature-agnostic across the supplied feature set.
- `trial` IS a valid destination (identity / lateral branch); excluded from walked intermediate rungs the way `tier_spec_path` already excludes it.
- Unknown destination ids echoed in `unknown[]` instead of short-circuiting.
- Helper never raises: a per-destination builder failure short-circuits that id into `unknown[]` and the rest of the batch keeps building.
- Empty / unknown `from_tier` returns `None`; empty destinations returns `{"tiers": [], "unknown": []}`.
- Resolver-independent: delegates per-destination to `tier_spec_path`, which walks the static per-tier maps via `tier_spec_at` -- so grace vs enforce yields byte-identical rows.

## Route

```
GET /api/entitlement/tier-spec-path-batch?from=<id>&to=a,b,c
```

Envelope shape:

```
{
  "from":       "<id>",
  "from_label": "...",
  "from_rank":  <int>,
  "tiers":      [<per-destination row>, ...],
  "unknown":    ["bogus_id", ...],
}
```

- **400** when `from=` is missing/blank, or `to=` is missing/empty after normalisation
- **404** when `from` is unknown (body carries `which: "tier"`)
- **200** with bucketed unknowns for unknown destination ids -- does NOT 404 the call, matching every other batch sibling
- **Never 5xxs**: a synthesis failure short-circuits to an envelope with empty rows so the matrix keeps rendering

## Tests

31 new tests in `tests/test_entitlement_tier_spec_path_batch.py` covering:

- helper dict shape + per-row key set
- per-destination `path` byte-equality with the scalar `tier_spec_path` helper (parity)
- per-row `to_label` / `to_rank` byte-parity with `tier_label` / `tier_rank`
- all four direction branches (identity / lateral / upgrade / downgrade) in a single batch
- supply-order preservation
- whitespace + case + duplicate normalisation
- unknown destination bucketing
- empty / None / unknown `from_tier` returning `None`
- empty destinations returning `{"tiers": [], "unknown": []}`
- garbage inputs never raise
- `trial` as destination (via lateral) + as source (via upgrade) + excluded from walked intermediate rungs
- grace vs enforce byte-parity
- per-destination row failure short-circuiting to `unknown[]`
- per-destination `None` short-circuiting to `unknown[]`
- HTTP 400 on missing `from` or `to`, 404 on unknown `from`, envelope key set, bucketed unknowns at 200
- HTTP per-destination `path` + `direction` + `to_label` + `to_rank` byte-equality with the scalar `/tier-spec-path` route
- HTTP supply-order preservation, grace vs enforce body parity, trial endpoints accepted

```
31 passed in 0.45s
```

Sibling family (`tier_spec_path`, `tier_spec_at`, `tier_spec`, `next_prev_tier_spec`, `next_prev_tier_spec_at_batch`) still green: 228 passed. Wider `entitlement_(feature|runtime|tier)_spec_path`-family sweep: 139 passed, 4 skipped -- no regressions. The 7 pre-existing collection errors (`test_duckdb_relay_integration.py`, `test_e2e.py`, `test_spans_otlp_edge_cases.py`, etc.) reproduce on `origin/main` before this branch (missing `duckdb` / `google.protobuf` at import time) and are unrelated.

## Test plan

- [x] `python3 -m py_compile clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_tier_spec_path_batch.py` -- clean
- [x] `python3 -m pytest tests/test_entitlement_tier_spec_path_batch.py -x -q` -- 31 passed
- [x] `python3 -m pytest tests/test_entitlement_tier_spec_path.py tests/test_entitlement_tier_spec_at.py tests/test_entitlement_tier_spec.py tests/test_entitlement_next_prev_tier_spec.py tests/test_entitlement_next_prev_tier_spec_at_batch.py tests/test_entitlement_tier_spec_path_batch.py -q` -- 228 passed
- [x] `ruff check clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_tier_spec_path_batch.py` -- clean
- [x] `python3 -m py_compile dashboard.py` -- clean
- [ ] Spot-check parity: `/api/entitlement/tier-spec-path-batch?from=oss&to=cloud_pro` `tiers[0].path` matches `/api/entitlement/tier-spec-path?from=oss&to=cloud_pro` `.path`
- [ ] Spot-check direction: `/api/entitlement/tier-spec-path-batch?from=cloud_starter&to=cloud_pro,pro,oss` returns three entries with `direction` of `upgrade`, `upgrade`, `downgrade` respectively
- [ ] Spot-check unknown bucketing: `/api/entitlement/tier-spec-path-batch?from=oss&to=cloud_pro,bogus_tier` returns 200 with one row in `tiers` and `["bogus_tier"]` in `unknown`

## Local operator verification checklist

(Required because this remote session has no access to the live daemon, `~/.openclaw`, the live cloud snapshot, or a browser.)

- [ ] Pull the branch locally: `git fetch origin feat/entitlement-tier-spec-path-batch-2 && git checkout feat/entitlement-tier-spec-path-batch-2`
- [ ] Copy changed files into the live install:
  - `cp clawmetry/entitlements.py ~/.clawmetry/lib/python*/site-packages/clawmetry/entitlements.py`
  - `cp routes/entitlement.py ~/.clawmetry/lib/python*/site-packages/routes/entitlement.py`
- [ ] Clear caches: `find ~/.clawmetry/lib -name __pycache__ -type d -exec rm -rf {} +`
- [ ] Restart the daemon: `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
- [ ] Hit the new endpoint:
  - `curl -sS 'http://localhost:8900/api/entitlement/tier-spec-path-batch?from=oss&to=cloud_starter,cloud_pro,enterprise' | jq`
  - `curl -sS 'http://localhost:8900/api/entitlement/tier-spec-path-batch?from=enterprise&to=oss' | jq '.tiers[0].direction'` → `"downgrade"`
  - `curl -sS 'http://localhost:8900/api/entitlement/tier-spec-path-batch?from=cloud_pro&to=pro' | jq '.tiers[0].direction'` → `"lateral"`
  - `curl -sS 'http://localhost:8900/api/entitlement/tier-spec-path-batch?from=oss&to=cloud_pro,bogus_tier' | jq` → 200 with `bogus_tier` in `unknown[]`
- [ ] Confirm the body carries `from` / `from_label` / `from_rank` plus `tiers[]` (with per-row `to` / `to_label` / `to_rank` / `direction` / `path`) + `unknown[]`
- [ ] Decrypt the live cloud snapshot client-side and confirm the pricing / entitlement UI (if any) still renders -- no behaviour change intended (grace mode preserved; no enforcement gate added)
- [ ] Promote out of draft when the above checks pass; do not merge until then

Posture: **grace mode preserved**. No behaviour change to any existing endpoint, no enforce gate flipped, no `__version__` bump, no release tag. The next-phase work (cloud-side entitlement minting, `clawmetry-pro` package download, enterprise SSO) needs the private `clawmetry-cloud` / `clawmetry-pro` repos and is out of scope for this remote session.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NaMXJ9Q5Z3Dwo231bUVfGi)_