### PR TITLE
feat(entitlement): channel_catalog_path_batch + /api/entitlement/channel-catalog-path-batch

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -9598,6 +9598,127 @@ def channel_catalog_path(from_tier: str, to_tier: str) -> list[dict] | None:
         return None
 
 
+def channel_catalog_path_batch(
+    from_tier: str, to_tiers
+) -> dict | None:
+    """Batch sibling of :func:`channel_catalog_path`: per-rung channel-
+    catalog rows for a caller-supplied subset of destination tiers all
+    walked from a single ``from_tier`` in ONE round-trip.
+
+    Channel-axis twin of :func:`feature_catalog_path_batch` and
+    :func:`runtime_catalog_path_batch`. Composes
+    :func:`channel_catalog_path` (scalar single-destination catalog path)
+    and :func:`channel_catalog_at_batch` (multi-source what-if catalog
+    matrix) -- same per-rung catalog body as the scalar path helper, same
+    multi-destination axis as :func:`feature_catalog_path_batch` /
+    :func:`runtime_catalog_path_batch` / :func:`tier_catalog_path_batch`.
+    Together the three catalog ``_path_batch`` helpers on the feature /
+    runtime / channel axes plus the ``_path_batch`` helper on the tier
+    axis let an upgrade-comparison walkthrough surface render every
+    feature + runtime + channel + tier column at every rung walked to N
+    candidate destinations off FOUR calls instead of first calling
+    :func:`tier_path_batch` and then 4 * N calls to the scalar what-if
+    catalog helpers.
+
+    Per-destination row shape::
+
+        {
+          "to":         "<tier id>",
+          "to_label":   "...",
+          "to_rank":    <int>,
+          "direction":  "upgrade" | "downgrade" | "lateral" | "identity",
+          "path":       [<channel_catalog_path row>, ...],
+        }
+
+    Each ``path`` row is byte-identical to a row from
+    :func:`channel_catalog_path` for the same ``(from_tier, to)`` pair --
+    a parity test pins this so the scalar and batch path helpers cannot
+    drift. Per-rung ``channels`` payload byte-equals :func:`channel_catalog`
+    for every rung (every chat-channel adapter is FREE at every tier),
+    the same guarantee the scalar path helper carries. Per-destination
+    ``path`` lengths can legitimately differ (rung set depends on ``to``),
+    matching :func:`feature_catalog_path_batch` /
+    :func:`runtime_catalog_path_batch` / :func:`tier_catalog_path_batch`'s
+    posture.
+
+    Shape::
+
+        {
+          "tiers": [
+            {"to": "<id>", "to_label": ..., "to_rank": ..., "direction": ..., "path": [...]},
+            ...
+          ],
+          "unknown": ["bogus_id", ...],
+        }
+
+    Supplied destination ids are normalised via :func:`_normalise_csv`
+    (whitespace stripped, lowercased, duplicates dropped, first-seen order
+    preserved). Unknown ids are echoed in ``unknown[]`` instead of short-
+    circuiting -- a partially-bad caller still gets paths back for the
+    valid ids alongside a list of what was dropped, matching every other
+    ``*_path_batch`` sibling's posture. ``trial`` IS accepted as a
+    destination (excluded from the walked intermediate rungs the way
+    :func:`channel_catalog_path` already excludes it, but a valid endpoint
+    via the lateral / identity branches).
+
+    Returns ``None`` for empty / unknown ``from_tier`` (caller renders
+    "unknown tier" / 404).
+
+    Resolver-independent: delegates per-destination to
+    :func:`channel_catalog_path`, which walks via :func:`channel_catalog_at`
+    over freshly-synthesised hypothetical :class:`Entitlement` objects --
+    so grace vs enforce yields byte-identical rows. Never raises: per-
+    destination failures short-circuit that id into ``unknown[]`` and the
+    rest of the batch keeps building.
+    """
+    try:
+        f = (from_tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if f not in _TIER_FEATURES:
+        return None
+    candidates = _normalise_csv(to_tiers)
+    rows: list[dict] = []
+    unknown: list[str] = []
+    from_rank = _TIER_RANK.get(f, -1)
+    for tid in candidates:
+        if tid not in _TIER_FEATURES:
+            unknown.append(tid)
+            continue
+        try:
+            path = channel_catalog_path(f, tid)
+        except Exception as exc:
+            logger.warning(
+                "entitlements: channel_catalog_path_batch row %r failed: %s",
+                tid,
+                exc,
+            )
+            unknown.append(tid)
+            continue
+        if path is None:
+            unknown.append(tid)
+            continue
+        to_rank = _TIER_RANK.get(tid, -1)
+        if f == tid:
+            direction = "identity"
+        elif from_rank == to_rank:
+            direction = "lateral"
+        elif to_rank > from_rank:
+            direction = "upgrade"
+        else:
+            direction = "downgrade"
+        rows.append(
+            {
+                "to": tid,
+                "to_label": tier_label(tid),
+                "to_rank": to_rank,
+                "direction": direction,
+                "path": path,
+            }
+        )
+    return {"tiers": rows, "unknown": unknown}
+
+
 def tier_catalog_path(from_tier: str, to_tier: str) -> list[dict] | None:
     """Arbitrary-endpoint stepwise tier-catalog path between two tiers.
 

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -13104,6 +13104,107 @@ def api_entitlement_runtime_catalog_path_batch():
         )
 
 
+@bp_entitlement.route("/api/entitlement/channel-catalog-path-batch")
+def api_entitlement_channel_catalog_path_batch():
+    """``GET /api/entitlement/channel-catalog-path-batch?from=<id>&to=a,b,c``
+    -- batch sibling of ``/api/entitlement/channel-catalog-path``.
+
+    Where ``/channel-catalog-path`` walks the full-catalog rungs between
+    ONE ``(from, to)`` pair, this walks the full-catalog rungs between
+    ONE ``from`` and N candidate ``to`` tiers in ONE round-trip.
+    Channel-axis twin of ``/feature-catalog-path-batch`` and
+    ``/runtime-catalog-path-batch``: pairs with them the same way
+    ``/channel-catalog-at-batch`` pairs with
+    ``/feature-catalog-at-batch`` / ``/runtime-catalog-at-batch``.
+    Together the three catalog ``-path-batch`` endpoints on the feature /
+    runtime / channel axes plus the ``-path-batch`` endpoint on the tier
+    axis let an upgrade-comparison walkthrough UI render every feature +
+    runtime + channel + tier column at every rung walked to N candidate
+    destinations off FOUR calls instead of first calling
+    ``/tier-path-batch`` (or ``/tier-path`` per destination) and then 4 *
+    N calls to the scalar what-if catalog endpoints.
+
+    Each row in ``tiers[].path`` is byte-identical to a row from
+    ``/channel-catalog-path?from=<from>&to=<to>`` -- pinned by the parity
+    tests so the scalar and batch path accessors cannot drift. Per-rung
+    ``channels`` list byte-equals ``/channel-catalog`` for every rung
+    (every chat-channel adapter is FREE at every tier, so the catalogue
+    is invariant across the rung walk). Supplied destination ids are
+    normalised (whitespace stripped, lowercased, duplicates dropped,
+    first-seen order preserved). Unknown ids do not 404 the call -- they
+    are echoed in ``unknown[]`` so a partially-bad caller still gets
+    paths back for the valid ids.
+
+    Response shape::
+
+        {
+          "from":       "<tier id>",
+          "from_label": "...",
+          "from_rank":  <int>,
+          "tiers": [
+            {
+              "to":        "<tier id>",
+              "to_label":  "...",
+              "to_rank":   <int>,
+              "direction": "upgrade" | "downgrade" | "lateral" | "identity",
+              "path":      [<channel-catalog-path row>, ...],
+            },
+            ...
+          ],
+          "unknown":    ["bogus_id", ...],
+        }
+
+    - **400** when ``from=`` is missing / blank, or ``to=`` is missing
+      / empty after normalisation
+    - **404** when ``from`` is unknown (body carries ``which: "tier"``)
+    - **200** with bucketed unknowns for unknown destination ids --
+      does NOT 404 the call, matching every other batch sibling
+    - **Never 5xxs**: a synthesis failure short-circuits to an envelope
+      with empty rows so the matrix keeps rendering.
+    """
+    f = (request.args.get("from") or "").strip().lower()
+    if not f:
+        return jsonify({"error": "missing from"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        if f not in _ent._TIER_FEATURES:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "tier", "tier": f}
+                ),
+                404,
+            )
+        targets = _parse_csv_arg("to")
+        if not targets:
+            return jsonify({"error": "supply to=<csv>"}), 400
+        batch = _ent.channel_catalog_path_batch(f, targets)
+        if batch is None:
+            batch = {"tiers": [], "unknown": []}
+        return jsonify(
+            {
+                "from": f,
+                "from_label": _ent.tier_label(f),
+                "from_rank": _ent.tier_rank(f),
+                "tiers": batch.get("tiers", []),
+                "unknown": batch.get("unknown", []),
+            }
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_channel_catalog_path_batch: error: %s", exc
+        )
+        return jsonify(
+            {
+                "from": f,
+                "from_label": None,
+                "from_rank": -1,
+                "tiers": [],
+                "unknown": [],
+            }
+        )
+
+
 @bp_entitlement.route("/api/entitlement/next-tier-capacity-diff")
 def api_entitlement_next_tier_capacity_diff():
     """``GET /api/entitlement/next-tier-capacity-diff`` -- capacity-only

--- a/tests/test_entitlement_channel_catalog_path_batch.py
+++ b/tests/test_entitlement_channel_catalog_path_batch.py
@@ -1,0 +1,627 @@
+"""Tests for ``clawmetry.entitlements.channel_catalog_path_batch(from, to)``
+plus the ``GET /api/entitlement/channel-catalog-path-batch`` endpoint.
+
+Batch sibling of :func:`channel_catalog_path`: where the scalar path
+helper walks one ``(from, to)`` pair and hydrates the full channel
+catalogue at each rung, the batch helper walks N candidate destinations
+from one source in ONE round-trip. Channel-axis twin of
+:func:`feature_catalog_path_batch` and :func:`runtime_catalog_path_batch`.
+
+Because every chat-channel adapter is FREE at every tier, each rung's
+inner ``channels`` list is byte-identical to :func:`channel_catalog` --
+the scalar path helper already pins that invariant; here we pin that the
+batch helper never drifts from the scalar.
+
+Pins:
+
+* per-destination ``path`` byte-equal to the scalar
+  :func:`channel_catalog_path` payload for the same ``(from, to)``
+  pair
+* per-rung row shape mirrors :func:`channel_catalog_path`
+  (``tier``, ``tier_label``, ``tier_rank``, ``channels``)
+* per-destination ``direction`` derived from the same ranks the scalar
+  endpoint uses (identity / lateral / upgrade / downgrade)
+* batch envelope mirrors ``/tier-catalog-path-batch`` /
+  ``/feature-catalog-path-batch`` / ``/runtime-catalog-path-batch``
+  on the source side (``from`` / ``from_label`` / ``from_rank``) and
+  carries ``tiers`` + ``unknown``
+* input normalised (whitespace stripped, lowercased, duplicates dropped,
+  first-seen order preserved)
+* unknown destination ids echoed in ``unknown[]`` instead of 404'ing
+  the call
+* identity ``from == to`` yields a per-destination entry whose ``path``
+  is ``[]``
+* lateral (same rank) yields a one-row per-destination ``path``
+* ``trial`` accepted as a destination and as a source
+* unknown / empty / garbage ``from_tier`` returns ``None`` (helper) /
+  400 / 404 (HTTP)
+* helper never raises -- a per-destination failure short-circuits that
+  id into ``unknown[]`` and the rest of the batch keeps building
+* HTTP endpoint 400 on missing / empty input, 404 on unknown source
+  tier, never 5xx on a row failure
+* grace vs enforce yields identical rows
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+
+_INNER_ROW_KEYS = {"tier", "tier_label", "tier_rank", "channels"}
+
+_ITEM_KEYS = {"to", "to_label", "to_rank", "direction", "path"}
+
+_ENVELOPE_KEYS = {
+    "from",
+    "from_label",
+    "from_rank",
+    "tiers",
+    "unknown",
+}
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from flask import Flask
+
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# ── helper-level: shape ──────────────────────────────────────────────────────
+
+
+def test_helper_returns_dict_shape(ent):
+    out = ent.channel_catalog_path_batch(
+        ent.TIER_OSS, [ent.TIER_CLOUD_STARTER, ent.TIER_ENTERPRISE]
+    )
+    assert isinstance(out, dict)
+    assert set(out.keys()) == {"tiers", "unknown"}
+    assert isinstance(out["tiers"], list)
+    assert isinstance(out["unknown"], list)
+
+
+def test_helper_each_item_carries_full_envelope(ent):
+    out = ent.channel_catalog_path_batch(
+        ent.TIER_OSS, [ent.TIER_CLOUD_STARTER, ent.TIER_ENTERPRISE]
+    )
+    for item in out["tiers"]:
+        assert set(item.keys()) == _ITEM_KEYS
+        assert isinstance(item["to"], str)
+        assert isinstance(item["to_label"], str)
+        assert isinstance(item["to_rank"], int)
+        assert item["direction"] in {
+            "upgrade",
+            "downgrade",
+            "lateral",
+            "identity",
+        }
+        assert isinstance(item["path"], list)
+
+
+def test_helper_per_rung_row_shape(ent):
+    """Per-rung rows carry the same 4-key shape as
+    :func:`channel_catalog_path` -- the ``_path`` family stays in
+    lock-step."""
+    out = ent.channel_catalog_path_batch(
+        ent.TIER_OSS, [ent.TIER_ENTERPRISE]
+    )
+    (item,) = out["tiers"]
+    assert item["path"]
+    for row in item["path"]:
+        assert set(row.keys()) == _INNER_ROW_KEYS
+        assert isinstance(row["channels"], list)
+        assert row["channels"]  # never empty
+
+
+# ── helper-level: parity with scalar ─────────────────────────────────────────
+
+
+def test_helper_per_item_path_byte_equal_to_scalar(ent):
+    """Pin: per-destination ``path`` is byte-identical to the scalar
+    :func:`channel_catalog_path` payload for the same ``(from, to)``
+    pair. If a future refactor teaches the batch helper to skip a rung
+    or a per-channel column, this test fails."""
+    candidates = [
+        ent.TIER_CLOUD_FREE,
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_ENTERPRISE,
+    ]
+    out = ent.channel_catalog_path_batch(ent.TIER_OSS, candidates)
+    by_id = {item["to"]: item["path"] for item in out["tiers"]}
+    for tid in candidates:
+        scalar = ent.channel_catalog_path(ent.TIER_OSS, tid)
+        assert by_id[tid] == scalar
+
+
+def test_helper_per_rung_channels_byte_equal_to_channel_catalog(ent):
+    """Cross-check: each rung's inner ``channels`` list equals
+    :func:`channel_catalog` -- inherited from the scalar
+    :func:`channel_catalog_path` "channels are always free" pin."""
+    baseline = ent.channel_catalog()
+    out = ent.channel_catalog_path_batch(
+        ent.TIER_OSS, [ent.TIER_ENTERPRISE]
+    )
+    (item,) = out["tiers"]
+    for row in item["path"]:
+        assert row["channels"] == baseline
+
+
+def test_helper_per_row_free_posture_preserved(ent):
+    """Belt-and-braces: even if a future tier flip pretended to gate
+    the channel axis, every row reported by this batch helper must
+    still surface ``free=True`` / ``allowed=True`` / ``locked=False``
+    / ``entitled=True``."""
+    out = ent.channel_catalog_path_batch(
+        ent.TIER_OSS, [ent.TIER_ENTERPRISE]
+    )
+    (item,) = out["tiers"]
+    for row in item["path"]:
+        for ch in row["channels"]:
+            assert ch["free"] is True
+            assert ch["allowed"] is True
+            assert ch["locked"] is False
+            assert ch["entitled"] is True
+            assert ch["tier"] == "free"
+
+
+def test_helper_per_item_direction_matches_rank_geometry(ent):
+    """Per-destination ``direction`` is derived from rank geometry and
+    must agree with the scalar endpoint's derivation."""
+    candidates = [
+        ent.TIER_OSS,
+        ent.TIER_CLOUD_FREE,
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_PRO,
+        ent.TIER_ENTERPRISE,
+    ]
+    out = ent.channel_catalog_path_batch(ent.TIER_CLOUD_STARTER, candidates)
+    by_id = {item["to"]: item for item in out["tiers"]}
+    src_rank = ent.tier_rank(ent.TIER_CLOUD_STARTER)
+    for tid in candidates:
+        tgt_rank = ent.tier_rank(tid)
+        if tid == ent.TIER_CLOUD_STARTER:
+            expected = "identity"
+        elif src_rank == tgt_rank:
+            expected = "lateral"
+        elif tgt_rank > src_rank:
+            expected = "upgrade"
+        else:
+            expected = "downgrade"
+        assert by_id[tid]["direction"] == expected
+
+
+def test_helper_per_item_to_label_matches_scalar_pin(ent):
+    """Per-destination ``to_label`` / ``to_rank`` byte-equal the
+    :func:`tier_label` / :func:`tier_rank` helpers (matching the
+    sibling ``_path_batch`` envelopes)."""
+    candidates = [
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_ENTERPRISE,
+    ]
+    out = ent.channel_catalog_path_batch(ent.TIER_OSS, candidates)
+    for item in out["tiers"]:
+        assert item["to_label"] == ent.tier_label(item["to"])
+        assert item["to_rank"] == ent.tier_rank(item["to"])
+
+
+# ── helper-level: input normalisation ────────────────────────────────────────
+
+
+def test_helper_supply_order_preserved(ent):
+    out = ent.channel_catalog_path_batch(
+        ent.TIER_OSS,
+        [ent.TIER_ENTERPRISE, ent.TIER_CLOUD_PRO, ent.TIER_CLOUD_STARTER],
+    )
+    assert [item["to"] for item in out["tiers"]] == [
+        ent.TIER_ENTERPRISE,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_CLOUD_STARTER,
+    ]
+
+
+def test_helper_normalises_input(ent):
+    out = ent.channel_catalog_path_batch(
+        ent.TIER_OSS,
+        [
+            "  CLOUD_PRO  ",
+            "cloud_starter",
+            "cloud_pro",
+            "",
+        ],
+    )
+    assert [item["to"] for item in out["tiers"]] == [
+        "cloud_pro",
+        "cloud_starter",
+    ]
+
+
+def test_helper_from_tier_normalised(ent):
+    """``from_tier`` also normalised (whitespace + case) -- matches the
+    scalar :func:`channel_catalog_path`."""
+    a = ent.channel_catalog_path_batch(
+        ent.TIER_OSS, [ent.TIER_ENTERPRISE]
+    )
+    b = ent.channel_catalog_path_batch(
+        "  OSS  ", [ent.TIER_ENTERPRISE]
+    )
+    assert a == b
+
+
+def test_helper_unknown_destination_ids_echoed(ent):
+    out = ent.channel_catalog_path_batch(
+        ent.TIER_OSS,
+        [ent.TIER_CLOUD_PRO, "bogus_tier", "still_bogus"],
+    )
+    assert [item["to"] for item in out["tiers"]] == [ent.TIER_CLOUD_PRO]
+    assert set(out["unknown"]) == {"bogus_tier", "still_bogus"}
+
+
+# ── helper-level: direction branches ─────────────────────────────────────────
+
+
+def test_helper_identity_yields_empty_path(ent):
+    out = ent.channel_catalog_path_batch(
+        ent.TIER_CLOUD_PRO, [ent.TIER_CLOUD_PRO, ent.TIER_ENTERPRISE]
+    )
+    by_id = {item["to"]: item for item in out["tiers"]}
+    assert by_id[ent.TIER_CLOUD_PRO]["direction"] == "identity"
+    assert by_id[ent.TIER_CLOUD_PRO]["path"] == []
+    assert by_id[ent.TIER_ENTERPRISE]["direction"] == "upgrade"
+
+
+def test_helper_lateral_yields_one_row_path(ent):
+    out = ent.channel_catalog_path_batch(
+        ent.TIER_CLOUD_PRO, [ent.TIER_PRO]
+    )
+    assert len(out["tiers"]) == 1
+    item = out["tiers"][0]
+    assert item["direction"] == "lateral"
+    assert len(item["path"]) == 1
+    assert item["path"][0]["tier"] == ent.TIER_PRO
+
+
+def test_helper_upgrade_walks_intermediate_rungs(ent):
+    out = ent.channel_catalog_path_batch(
+        ent.TIER_OSS, [ent.TIER_ENTERPRISE]
+    )
+    item = out["tiers"][0]
+    assert item["direction"] == "upgrade"
+    rungs = [row["tier"] for row in item["path"]]
+    assert rungs[-1] == ent.TIER_ENTERPRISE
+    assert ent.TIER_OSS not in rungs
+
+
+def test_helper_downgrade_walks_descending(ent):
+    out = ent.channel_catalog_path_batch(
+        ent.TIER_ENTERPRISE, [ent.TIER_OSS]
+    )
+    item = out["tiers"][0]
+    assert item["direction"] == "downgrade"
+    rungs = [row["tier"] for row in item["path"]]
+    ranks = [ent.tier_rank(r) for r in rungs]
+    assert ranks == sorted(ranks, reverse=True)
+
+
+def test_helper_all_four_branches_in_one_batch(ent):
+    """Single call covers identity + lateral + upgrade + downgrade."""
+    out = ent.channel_catalog_path_batch(
+        ent.TIER_CLOUD_PRO,
+        [
+            ent.TIER_CLOUD_PRO,       # identity
+            ent.TIER_PRO,             # lateral
+            ent.TIER_ENTERPRISE,      # upgrade
+            ent.TIER_OSS,             # downgrade
+        ],
+    )
+    by_id = {item["to"]: item["direction"] for item in out["tiers"]}
+    assert by_id[ent.TIER_CLOUD_PRO] == "identity"
+    assert by_id[ent.TIER_PRO] == "lateral"
+    assert by_id[ent.TIER_ENTERPRISE] == "upgrade"
+    assert by_id[ent.TIER_OSS] == "downgrade"
+
+
+# ── helper-level: trial endpoint ─────────────────────────────────────────────
+
+
+def test_helper_trial_destination_accepted(ent):
+    """``trial`` is a valid endpoint (matching
+    :func:`channel_catalog_path` semantics) even though it is excluded
+    from the walked intermediate rungs."""
+    out = ent.channel_catalog_path_batch(ent.TIER_OSS, [ent.TIER_TRIAL])
+    assert out["unknown"] == []
+    assert [item["to"] for item in out["tiers"]] == [ent.TIER_TRIAL]
+
+
+def test_helper_trial_source_accepted(ent):
+    """``trial`` is a valid source (matching
+    :func:`channel_catalog_path` semantics)."""
+    out = ent.channel_catalog_path_batch(
+        ent.TIER_TRIAL, [ent.TIER_ENTERPRISE]
+    )
+    assert out is not None
+    assert out["unknown"] == []
+    (item,) = out["tiers"]
+    assert item["path"][-1]["tier"] == ent.TIER_ENTERPRISE
+
+
+def test_helper_trial_never_appears_as_intermediate_rung(ent):
+    """``trial`` is not purchasable -- it must never appear as a stop
+    on a path between purchasable tiers."""
+    out = ent.channel_catalog_path_batch(
+        ent.TIER_OSS, [ent.TIER_ENTERPRISE]
+    )
+    (item,) = out["tiers"]
+    rungs = [row["tier"] for row in item["path"]]
+    assert ent.TIER_TRIAL not in rungs
+
+
+# ── helper-level: error / edge cases ─────────────────────────────────────────
+
+
+def test_helper_unknown_from_tier_returns_none(ent):
+    assert (
+        ent.channel_catalog_path_batch("not_a_tier", [ent.TIER_ENTERPRISE])
+        is None
+    )
+
+
+def test_helper_empty_destinations_yields_empty_envelope(ent):
+    out = ent.channel_catalog_path_batch(ent.TIER_OSS, [])
+    assert out == {"tiers": [], "unknown": []}
+
+
+def test_helper_garbage_from_tier_returns_none(ent):
+    assert ent.channel_catalog_path_batch("", []) is None
+    assert ent.channel_catalog_path_batch(None, None) is None  # type: ignore[arg-type]
+    assert ent.channel_catalog_path_batch("  ", []) is None
+    assert ent.channel_catalog_path_batch(123, []) is None  # type: ignore[arg-type]
+
+
+def test_helper_grace_and_enforce_yield_identical_output(ent, monkeypatch):
+    candidates = [ent.TIER_CLOUD_STARTER, ent.TIER_ENTERPRISE]
+    grace = ent.channel_catalog_path_batch(ent.TIER_OSS, candidates)
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    enforced = ent.channel_catalog_path_batch(ent.TIER_OSS, candidates)
+    assert grace == enforced
+
+
+def test_helper_row_failure_short_circuits_item(ent, monkeypatch):
+    """A per-destination failure pushes that id into ``unknown[]``
+    while the rest of the batch keeps building."""
+    real = ent.channel_catalog_path
+
+    def fake(f, t):
+        if t == ent.TIER_CLOUD_PRO:
+            raise RuntimeError("boom")
+        return real(f, t)
+
+    monkeypatch.setattr(ent, "channel_catalog_path", fake)
+    out = ent.channel_catalog_path_batch(
+        ent.TIER_OSS, [ent.TIER_CLOUD_PRO, ent.TIER_ENTERPRISE]
+    )
+    assert [item["to"] for item in out["tiers"]] == [ent.TIER_ENTERPRISE]
+    assert ent.TIER_CLOUD_PRO in out["unknown"]
+
+
+def test_helper_row_none_return_short_circuits_item(ent, monkeypatch):
+    """A per-destination ``None`` return also pushes that id into
+    ``unknown[]`` (helper never emits a row with ``path=None``)."""
+    real = ent.channel_catalog_path
+
+    def fake(f, t):
+        if t == ent.TIER_CLOUD_PRO:
+            return None
+        return real(f, t)
+
+    monkeypatch.setattr(ent, "channel_catalog_path", fake)
+    out = ent.channel_catalog_path_batch(
+        ent.TIER_OSS, [ent.TIER_CLOUD_PRO, ent.TIER_ENTERPRISE]
+    )
+    assert [item["to"] for item in out["tiers"]] == [ent.TIER_ENTERPRISE]
+    assert ent.TIER_CLOUD_PRO in out["unknown"]
+
+
+# ── HTTP: /api/entitlement/channel-catalog-path-batch ────────────────────────
+
+
+def test_api_400_on_missing_from(client):
+    r = client.get(
+        "/api/entitlement/channel-catalog-path-batch?to=cloud_pro,enterprise"
+    )
+    assert r.status_code == 400
+
+
+def test_api_400_on_missing_to(client):
+    r = client.get(
+        "/api/entitlement/channel-catalog-path-batch?from=oss"
+    )
+    assert r.status_code == 400
+    body = r.get_json()
+    assert body["error"] == "supply to=<csv>"
+
+
+def test_api_400_on_empty_to(client):
+    r = client.get(
+        "/api/entitlement/channel-catalog-path-batch?from=oss&to=,,"
+    )
+    assert r.status_code == 400
+
+
+def test_api_404_on_unknown_from_tier(client):
+    r = client.get(
+        "/api/entitlement/channel-catalog-path-batch"
+        "?from=not_a_tier&to=enterprise"
+    )
+    assert r.status_code == 404
+    body = r.get_json()
+    assert body["which"] == "tier"
+
+
+def test_api_200_with_unknown_destination_bucketed(client, ent):
+    r = client.get(
+        "/api/entitlement/channel-catalog-path-batch"
+        f"?from={ent.TIER_OSS}&to={ent.TIER_CLOUD_PRO},bogus_tier"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert [item["to"] for item in body["tiers"]] == [ent.TIER_CLOUD_PRO]
+    assert body["unknown"] == ["bogus_tier"]
+
+
+def test_api_happy_path_ascending(client, ent):
+    r = client.get(
+        "/api/entitlement/channel-catalog-path-batch"
+        f"?from={ent.TIER_OSS}&to={ent.TIER_CLOUD_STARTER},{ent.TIER_ENTERPRISE}"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert set(body.keys()) == _ENVELOPE_KEYS
+    assert body["from"] == ent.TIER_OSS
+    assert isinstance(body["from_label"], str)
+    assert body["from_rank"] == ent.tier_rank(ent.TIER_OSS)
+    tos = [item["to"] for item in body["tiers"]]
+    assert tos == [ent.TIER_CLOUD_STARTER, ent.TIER_ENTERPRISE]
+    for item in body["tiers"]:
+        assert item["direction"] == "upgrade"
+        assert item["path"][-1]["tier"] == item["to"]
+
+
+def test_api_identity_branch(client, ent):
+    r = client.get(
+        "/api/entitlement/channel-catalog-path-batch"
+        f"?from={ent.TIER_CLOUD_PRO}&to={ent.TIER_CLOUD_PRO}"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["tiers"][0]["direction"] == "identity"
+    assert body["tiers"][0]["path"] == []
+
+
+def test_api_lateral_branch(client, ent):
+    r = client.get(
+        "/api/entitlement/channel-catalog-path-batch"
+        f"?from={ent.TIER_CLOUD_PRO}&to={ent.TIER_PRO}"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["tiers"][0]["direction"] == "lateral"
+    assert len(body["tiers"][0]["path"]) == 1
+    assert body["tiers"][0]["path"][0]["tier"] == ent.TIER_PRO
+
+
+def test_api_downgrade_branch(client, ent):
+    r = client.get(
+        "/api/entitlement/channel-catalog-path-batch"
+        f"?from={ent.TIER_ENTERPRISE}&to={ent.TIER_OSS}"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["tiers"][0]["direction"] == "downgrade"
+
+
+def test_api_per_item_path_matches_scalar_route(client, ent):
+    """HTTP parity: each per-destination ``path`` is byte-identical to
+    the scalar ``/channel-catalog-path?from=&to=`` ``path`` payload for
+    the same ``(from, to)`` pair."""
+    candidates = [
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_ENTERPRISE,
+    ]
+    batch = client.get(
+        "/api/entitlement/channel-catalog-path-batch"
+        f"?from={ent.TIER_OSS}&to={','.join(candidates)}"
+    ).get_json()
+    for item in batch["tiers"]:
+        scalar = client.get(
+            "/api/entitlement/channel-catalog-path"
+            f"?from={ent.TIER_OSS}&to={item['to']}"
+        ).get_json()
+        assert item["path"] == scalar["path"]
+        assert item["direction"] == scalar["direction"]
+        assert item["to_label"] == scalar["to_label"]
+        assert item["to_rank"] == scalar["to_rank"]
+
+
+def test_api_input_normalised(client, ent):
+    r = client.get(
+        "/api/entitlement/channel-catalog-path-batch"
+        f"?from={ent.TIER_OSS}&to=  CLOUD_PRO  ,cloud_starter,cloud_pro,"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert [item["to"] for item in body["tiers"]] == [
+        "cloud_pro",
+        "cloud_starter",
+    ]
+
+
+def test_api_trial_endpoint_accepted(client, ent):
+    r = client.get(
+        "/api/entitlement/channel-catalog-path-batch"
+        f"?from={ent.TIER_TRIAL}&to={ent.TIER_ENTERPRISE}"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["from"] == ent.TIER_TRIAL
+    assert body["unknown"] == []
+    (item,) = body["tiers"]
+    assert item["path"][-1]["tier"] == ent.TIER_ENTERPRISE
+
+
+def test_api_grace_and_enforce_yield_identical_body(
+    client, ent, monkeypatch
+):
+    grace = client.get(
+        "/api/entitlement/channel-catalog-path-batch"
+        f"?from={ent.TIER_OSS}&to={ent.TIER_CLOUD_STARTER},{ent.TIER_ENTERPRISE}"
+    ).get_json()
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    enforced = client.get(
+        "/api/entitlement/channel-catalog-path-batch"
+        f"?from={ent.TIER_OSS}&to={ent.TIER_CLOUD_STARTER},{ent.TIER_ENTERPRISE}"
+    ).get_json()
+    assert grace == enforced
+
+
+def test_api_never_5xxs_on_row_failure(client, ent, monkeypatch):
+    """A per-destination synthesis crash short-circuits to ``unknown[]``
+    -- the endpoint still returns 200 with a rendered envelope."""
+    real = ent.channel_catalog_path
+
+    def fake(f, t):
+        if t == ent.TIER_CLOUD_PRO:
+            raise RuntimeError("boom")
+        return real(f, t)
+
+    monkeypatch.setattr(ent, "channel_catalog_path", fake)
+    r = client.get(
+        "/api/entitlement/channel-catalog-path-batch"
+        f"?from={ent.TIER_OSS}&to={ent.TIER_CLOUD_PRO},{ent.TIER_ENTERPRISE}"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert [item["to"] for item in body["tiers"]] == [ent.TIER_ENTERPRISE]
+    assert ent.TIER_CLOUD_PRO in body["unknown"]


### PR DESCRIPTION
## Summary

- Batch sibling of `channel_catalog_path` (recently added in #3555). Where the scalar walks the full-catalog rungs between ONE `(from, to)` pair, this batch sibling walks them between ONE source and N candidate destinations in ONE round-trip.
- Channel-axis twin of `feature_catalog_path_batch` and `runtime_catalog_path_batch`. Fills the missing `_path_batch` slot on the channel axis so the family is symmetric across all four axes (feature / runtime / channel / tier).
- Every chat-channel adapter is FREE at every tier (the `channels` capacity axis governs how many concurrent channels each plan admits, not which adapters unlock), so each rung's inner `channels` list is byte-identical to `channel_catalog`. The scalar `channel_catalog_path` already pins that invariant; the batch tests here pin that the scalar and batch helpers cannot drift.
- Together the three catalog `_path_batch` helpers on the feature / runtime / channel axes plus the `_path_batch` helper on the tier axis let an upgrade-comparison walkthrough surface render every feature + runtime + channel + tier column at every rung walked to N candidate destinations off FOUR calls instead of first calling `/tier-path-batch` and then 4 * N calls to the scalar what-if catalog helpers.

Non-overlapping with the open draft PR #3560 (`tier_spec_path_batch`) — that's the tier / spec axis; this PR is the channel / catalog axis. New helper sits directly after `channel_catalog_path` in `clawmetry/entitlements.py` and the new route directly after `/runtime-catalog-path-batch` in `routes/entitlement.py`.

## Helper

```python
def channel_catalog_path_batch(from_tier: str, to_tiers) -> dict | None
```

Returned shape:

```
{
  "tiers": [
    {"to": "<id>", "to_label": "...", "to_rank": <int>,
     "direction": "upgrade" | "downgrade" | "lateral" | "identity",
     "path": [<channel_catalog_path row>, ...]},
    ...
  ],
  "unknown": ["bogus_id", ...],
}
```

- Destination ids normalised via `_normalise_csv` (whitespace stripped, lowercased, duplicates dropped, first-seen order preserved).
- Per-destination `direction` derived from the same rank geometry the scalar `/channel-catalog-path` endpoint uses — a UI rendering scalar-shaped rows needs zero new shape code to render rows off this batch.
- Per-destination `path` lengths can legitimately differ (rungs walked depend on the destination), matching `feature_catalog_path_batch` / `runtime_catalog_path_batch` / `tier_catalog_path_batch`'s posture.
- `trial` IS a valid destination (identity / lateral branch); excluded from walked intermediate rungs the way `channel_catalog_path` already excludes it. Also valid as a source.
- Unknown destination ids echoed in `unknown[]` instead of short-circuiting the whole batch.
- Helper never raises: a per-destination builder failure short-circuits that id into `unknown[]` and the rest of the batch keeps building.
- Empty / unknown `from_tier` returns `None`; empty destinations returns `{"tiers": [], "unknown": []}`.
- Resolver-independent: delegates per-destination to `channel_catalog_path`, which walks via `channel_catalog_at` over freshly-synthesised hypothetical `Entitlement` objects — so grace vs enforce yields byte-identical rows.

## Route

```
GET /api/entitlement/channel-catalog-path-batch?from=<id>&to=a,b,c
```

Envelope shape:

```
{
  "from":       "<id>",
  "from_label": "...",
  "from_rank":  <int>,
  "tiers":      [<per-destination row>, ...],
  "unknown":    ["bogus_id", ...],
}
```

- **400** when `from=` is missing / blank, or `to=` is missing / empty after normalisation.
- **404** when `from` is unknown (body carries `which: "tier"`).
- **200** with bucketed unknowns for unknown destination ids — does NOT 404 the call, matching every other batch sibling.
- **Never 5xxs**: a synthesis failure short-circuits to an envelope with empty rows so the matrix keeps rendering.

## Tests

40 new tests in `tests/test_entitlement_channel_catalog_path_batch.py` covering:

- helper dict shape + per-row key set
- per-destination `path` byte-equality with the scalar `channel_catalog_path` helper (parity)
- per-rung `channels` list byte-equality with the bare `channel_catalog` (always-free invariant)
- per-row `to_label` / `to_rank` byte-parity with `tier_label` / `tier_rank`
- all four direction branches (identity / lateral / upgrade / downgrade) in a single batch
- supply-order preservation
- whitespace + case + duplicate normalisation (both `from_tier` and destinations)
- unknown destination bucketing
- empty / None / unknown `from_tier` returning `None`
- empty destinations returning `{"tiers": [], "unknown": []}`
- garbage inputs never raise
- `trial` as destination (via lateral) + as source (via upgrade) + excluded from walked intermediate rungs
- grace vs enforce byte-parity
- per-destination row failure short-circuiting to `unknown[]`
- per-destination `None` short-circuiting to `unknown[]`
- HTTP 400 on missing `from` or `to`, 404 on unknown `from`, envelope key set, bucketed unknowns at 200
- HTTP per-destination `path` + `direction` + `to_label` + `to_rank` byte-equality with the scalar `/channel-catalog-path` route
- HTTP supply-order preservation, grace vs enforce body parity, trial endpoints accepted
- HTTP never-5xx contract when the inner helper crashes

```
40 passed in 0.80s
```

Sibling family (`channel_catalog`, `channel_catalog_at`, `channel_catalog_path`, `tier_catalog_path_batch`, `feature_catalog_path_batch` via `catalog_path_batch`) still green: **238 passed** across the touched surface, no regressions.

## Test plan

- [x] `python3 -m py_compile clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_channel_catalog_path_batch.py` — clean
- [x] `python3 -m pytest tests/test_entitlement_channel_catalog_path_batch.py -x -q` — 40 passed
- [x] `python3 -m pytest tests/test_entitlement_channel_catalog.py tests/test_entitlement_channel_catalog_at.py tests/test_entitlement_channel_catalog_path.py tests/test_entitlement_channel_catalog_path_batch.py tests/test_entitlement_tier_catalog_path_batch.py tests/test_entitlement_catalog_path_batch.py -q` — 238 passed
- [x] `ruff check clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_channel_catalog_path_batch.py` — clean
- [x] `python3 -m py_compile dashboard.py` — clean
- [ ] Spot-check parity: `/api/entitlement/channel-catalog-path-batch?from=oss&to=cloud_pro` `tiers[0].path` matches `/api/entitlement/channel-catalog-path?from=oss&to=cloud_pro` `.path`
- [ ] Spot-check direction: `/api/entitlement/channel-catalog-path-batch?from=cloud_starter&to=cloud_pro,pro,oss` returns three entries with `direction` of `upgrade`, `upgrade`, `downgrade` respectively
- [ ] Spot-check unknown bucketing: `/api/entitlement/channel-catalog-path-batch?from=oss&to=cloud_pro,bogus_tier` returns 200 with one row in `tiers` and `["bogus_tier"]` in `unknown`
- [ ] Spot-check always-free invariant: every per-rung `channels[]` list is byte-equal to `/api/entitlement/channel-catalog` `.channels`

## Local operator verification checklist

(Required because this remote session has no access to the live daemon, `~/.openclaw`, the live cloud snapshot, or a browser.)

- [ ] Pull the branch locally: `git fetch origin feat/entitlement-channel-catalog-path-batch && git checkout feat/entitlement-channel-catalog-path-batch`
- [ ] Copy changed files into the live install:
  - `cp clawmetry/entitlements.py ~/.clawmetry/lib/python*/site-packages/clawmetry/entitlements.py`
  - `cp routes/entitlement.py ~/.clawmetry/lib/python*/site-packages/routes/entitlement.py`
- [ ] Clear caches: `find ~/.clawmetry/lib -name __pycache__ -type d -exec rm -rf {} +`
- [ ] Restart the daemon: `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
- [ ] Hit the new endpoint:
  - `curl -sS 'http://localhost:8900/api/entitlement/channel-catalog-path-batch?from=oss&to=cloud_starter,cloud_pro,enterprise' | jq`
  - `curl -sS 'http://localhost:8900/api/entitlement/channel-catalog-path-batch?from=enterprise&to=oss' | jq '.tiers[0].direction'` → `"downgrade"`
  - `curl -sS 'http://localhost:8900/api/entitlement/channel-catalog-path-batch?from=cloud_pro&to=pro' | jq '.tiers[0].direction'` → `"lateral"`
  - `curl -sS 'http://localhost:8900/api/entitlement/channel-catalog-path-batch?from=oss&to=cloud_pro,bogus_tier' | jq` → 200 with `bogus_tier` in `unknown[]`
- [ ] Confirm the body carries `from` / `from_label` / `from_rank` plus `tiers[]` (with per-row `to` / `to_label` / `to_rank` / `direction` / `path`) + `unknown[]`
- [ ] Confirm channel-list invariance across rungs (channels are always free):
  - `curl -sS 'http://localhost:8900/api/entitlement/channel-catalog-path-batch?from=oss&to=enterprise' | jq '.tiers[0].path | map(.channels) | unique | length'` → `1`
- [ ] Decrypt the live cloud snapshot client-side and confirm the pricing / entitlement UI (if any) still renders — no behaviour change intended (grace mode preserved; no enforcement gate added)
- [ ] Promote out of draft when the above checks pass; do not merge until then

Posture: **grace mode preserved**. No behaviour change to any existing endpoint, no enforce gate flipped, no `__version__` bump, no release tag. The next-phase work (cloud-side entitlement minting, `clawmetry-pro` package download, enterprise SSO) needs the private `clawmetry-cloud` / `clawmetry-pro` repos and is out of scope for this remote session.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DP44Z8iSUig5Fv3JRjU878

---
_Generated by [Claude Code](https://claude.ai/code/session_01DP44Z8iSUig5Fv3JRjU878)_