### PR TITLE
feat(entitlement): channel_catalog_at_path + /api/entitlement/channel-catalog-at-path

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -12717,6 +12717,78 @@ def feature_catalog_at_path_batch(
         return None
 
 
+def channel_catalog_at_path(
+    perspective_tier: str, from_tier: str, to_tier: str
+) -> list[dict] | None:
+    """Channel-axis twin of :func:`feature_catalog_at_path` /
+    :func:`runtime_catalog_at_path`: per-rung channel-catalog path
+    between ``from_tier`` and ``to_tier`` rendered from a hypothetical
+    ``perspective_tier``.
+
+    Path-shaped companion to :func:`channel_catalog_at`: where
+    ``channel_catalog_at`` renders the full channel catalogue at ONE
+    hypothetical rung, ``channel_catalog_at_path`` walks the full rung
+    path between two endpoints. Fills the ``_at_path`` slot for the
+    channel-catalog family alongside :func:`channel_catalog`
+    (scalar current), :func:`channel_catalog_at` (scalar what-if),
+    :func:`channel_catalog_at_batch` (batch what-if), and
+    :func:`channel_catalog_path` (path current) so a pricing-
+    comparison walkthrough surface can call
+    ``X_at_path(perspective, from, to)`` uniformly across the whole
+    ``_at_path`` family (feature / runtime / channel / tier).
+
+    Body posture matches :func:`tier_catalog_at_path` /
+    :func:`feature_catalog_at_path` / :func:`runtime_catalog_at_path`:
+    perspective is validated against :data:`_TIER_ORDER` but does NOT
+    shape the rows. The per-rung body is byte-identical to a row from
+    :func:`channel_catalog_path` for the same ``(from_tier, to_tier)``
+    pair -- pinned by parity tests so the what-if path helper cannot
+    drift from the current-perspective sibling.
+
+    Because every chat-channel adapter is FREE at every tier (the
+    ``channels`` capacity axis governs how many concurrent channels
+    each plan admits, not which adapters unlock), each rung's inner
+    ``channels`` list is byte-identical to :func:`channel_catalog`.
+    The always-free invariant is inherited from the delegate; parity
+    tests here pin it against the scalar path helper so the scalar-
+    and what-if- surfaces cannot drift.
+
+    Perspective acceptance is lenient (matches
+    :func:`channel_catalog_at` and every other ``_at`` helper): any id
+    in :data:`_TIER_ORDER` is accepted, including :data:`TIER_TRIAL`.
+    Endpoint acceptance mirrors :func:`channel_catalog_path`: both
+    ``from_tier`` and ``to_tier`` accept any id in
+    :data:`_TIER_FEATURES` (trial is a valid endpoint via the lateral
+    / identity branch even though the walked intermediate rungs
+    exclude it -- it is not purchasable).
+
+    Returns ``None`` when any of the three ids is unknown; empty list
+    for identity (``from == to``). Resolver-independent: delegates to
+    :func:`channel_catalog_path`, which walks per-rung via
+    :func:`_channel_spec_row` over freshly-synthesised hypothetical
+    :class:`Entitlement` objects, so grace vs enforce yields byte-
+    identical rows -- same property the rest of the ``_path`` family
+    guarantees.
+
+    Never raises: a delegate failure logs a warning and returns
+    ``None`` so an upgrade-walkthrough surface keeps rendering instead
+    of breaking.
+    """
+    try:
+        p = (perspective_tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if p not in _TIER_ORDER:
+        return None
+    try:
+        return channel_catalog_path(from_tier, to_tier)
+    except Exception as exc:
+        logger.warning(
+            "entitlements: channel_catalog_at_path failed: %s", exc
+        )
+        return None
+
+
 def lock_reason_at_path(
     perspective_tier: str,
     from_tier: str,

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -14665,6 +14665,165 @@ def api_entitlement_runtime_catalog_at_path_batch():
         )
 
 
+@bp_entitlement.route("/api/entitlement/channel-catalog-at-path")
+def api_entitlement_channel_catalog_at_path():
+    """``GET /api/entitlement/channel-catalog-at-path?tier=<perspective>
+    &from=<from>&to=<to>`` -- arbitrary-endpoint stepwise channel-catalog
+    path between any two tiers, rendered from a hypothetical
+    ``perspective_tier``.
+
+    What-if sibling of ``/channel-catalog-path``: same rung walk, same
+    per-rung body, plus a ``perspective_tier`` echo so a pricing-
+    comparison walkthrough surface can call
+    ``X_at_path(perspective, from, to)`` uniformly across the whole
+    ``_at_path`` slot of the channel-catalog family (alongside
+    ``/channel-catalog-at`` and ``/channel-catalog-at-batch``, which
+    fill the scalar-what-if and batch-what-if slots). Family-complete
+    twin of ``/feature-catalog-at-path`` / ``/runtime-catalog-at-path``
+    / ``/tier-catalog-at-path``.
+
+    Body posture matches ``/channel-catalog-at``: perspective is
+    validated but does not shape the rows. Each row in ``path`` is
+    byte-identical to a row from
+    ``/channel-catalog-path?from=<from>&to=<to>`` -- pinned by parity
+    tests. Perspective acceptance is lenient: ``trial`` IS accepted
+    (matching every other ``_at`` sibling).
+
+    Because every chat-channel adapter is FREE at every tier (the
+    ``channels`` capacity axis governs how many concurrent channels
+    each plan admits, not which adapters unlock), each rung's inner
+    ``channels`` list is byte-identical to ``/channel-catalog`` --
+    inherited from the delegate, pinned by parity tests so a
+    walkthrough UI can render the channel column off the same
+    row-renderer as the feature and runtime columns.
+
+    Response shape::
+
+        {
+          "perspective_tier":      "<tier id>",
+          "perspective_tier_rank": <int>,
+          "from":                  "<tier id>",
+          "from_label":            "...",
+          "from_rank":             <int>,
+          "to":                    "<tier id>",
+          "to_label":              "...",
+          "to_rank":               <int>,
+          "direction":             "upgrade" | "downgrade" | "lateral" | "identity",
+          "path":                  [<channel-catalog-path row>, ...],
+          "current_tier":          "<tier id>",
+          "current_tier_rank":     <int>,
+          "grace":                 <bool>,
+          "enforced":              <bool>,
+        }
+
+    - **400** when ``tier=``, ``from=`` or ``to=`` is missing / blank
+    - **404** when any id is unknown (body carries ``which: "tier" |
+      "from" | "to"`` so the caller can point at the offender)
+    - **Never 5xxs**: a resolver failure short-circuits to 404 so an
+      upgrade-walkthrough surface keeps rendering instead of breaking.
+    """
+    p = (request.args.get("tier") or "").strip().lower()
+    f = (request.args.get("from") or "").strip().lower()
+    t = (request.args.get("to") or "").strip().lower()
+    if not p:
+        return jsonify({"error": "missing tier"}), 400
+    if not f:
+        return jsonify({"error": "missing from"}), 400
+    if not t:
+        return jsonify({"error": "missing to"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        if p not in _ent._TIER_ORDER:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "tier", "tier": p}
+                ),
+                404,
+            )
+        if f not in _ent._TIER_FEATURES:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "from", "from": f}
+                ),
+                404,
+            )
+        if t not in _ent._TIER_FEATURES:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "to", "to": t}
+                ),
+                404,
+            )
+        path = _ent.channel_catalog_at_path(p, f, t)
+        if path is None:
+            return (
+                jsonify(
+                    {
+                        "error": "unknown tier",
+                        "tier": p,
+                        "from": f,
+                        "to": t,
+                    }
+                ),
+                404,
+            )
+        from_rank = _ent.tier_rank(f)
+        to_rank = _ent.tier_rank(t)
+        if f == t:
+            direction = "identity"
+        elif from_rank == to_rank:
+            direction = "lateral"
+        elif to_rank > from_rank:
+            direction = "upgrade"
+        else:
+            direction = "downgrade"
+        try:
+            ent = _ent.get_entitlement()
+            current_tier = getattr(ent, "tier", "oss") or "oss"
+            grace = bool(getattr(ent, "grace", True))
+        except Exception:
+            current_tier = "oss"
+            grace = True
+        try:
+            enforced = bool(_ent.is_enforced())
+        except Exception:
+            enforced = False
+        return jsonify(
+            {
+                "perspective_tier": p,
+                "perspective_tier_rank": _ent.tier_rank(p),
+                "from": f,
+                "from_label": _ent.tier_label(f),
+                "from_rank": from_rank,
+                "to": t,
+                "to_label": _ent.tier_label(t),
+                "to_rank": to_rank,
+                "direction": direction,
+                "path": path,
+                "current_tier": current_tier,
+                "current_tier_rank": _ent.tier_rank(current_tier),
+                "grace": grace,
+                "enforced": enforced,
+            }
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_channel_catalog_at_path: error: %s", exc
+        )
+        return (
+            jsonify(
+                {
+                    "error": "unknown tier",
+                    "tier": p,
+                    "from": f,
+                    "to": t,
+                }
+            ),
+            404,
+        )
+
+
 @bp_entitlement.route("/api/entitlement/lock-reason-at-path")
 def api_entitlement_lock_reason_at_path():
     """``GET /api/entitlement/lock-reason-at-path?tier=<perspective>

--- a/tests/test_entitlement_channel_catalog_at_path.py
+++ b/tests/test_entitlement_channel_catalog_at_path.py
@@ -1,0 +1,534 @@
+"""Tests for ``clawmetry.entitlements.channel_catalog_at_path`` +
+its HTTP endpoint ``GET /api/entitlement/channel-catalog-at-path``.
+
+Path-shaped what-if sibling of :func:`channel_catalog_path`: renders
+the FULL per-rung channel-catalog path between two tiers from a
+hypothetical ``perspective_tier`` in ONE round-trip. Fills the
+``_at_path`` slot for the channel-catalog family (alongside
+:func:`channel_catalog_at` and :func:`channel_catalog_at_batch` which
+fill the scalar-what-if and batch-what-if slots) so a pricing-
+comparison walkthrough surface can call
+``X_at_path(perspective, from, to)`` uniformly across every
+``_at_path`` family member on all four axes (feature / runtime /
+channel / tier).
+
+Pins:
+
+* body byte-identical to :func:`channel_catalog_path` for every
+  perspective -- the perspective is validated but does NOT shape the
+  rows (parity with every other ``_at_path`` helper the
+  ``feature_catalog_at_path`` / ``runtime_catalog_at_path`` /
+  ``tier_catalog_at_path`` family ships).
+* per-rung row shape carries the same 4 keys as
+  :func:`channel_catalog_path` (``tier``, ``tier_label``,
+  ``tier_rank``, ``channels``); each inner ``channels`` list byte-
+  equals :func:`channel_catalog()` -- the "channels are always free
+  at every tier" invariant is inherited from the delegate and pinned
+  here so the ``_at`` / ``_at_path`` / ``_at_batch`` /
+  ``_at_path_batch`` channel-catalog surfaces cannot drift.
+* ``trial`` accepted as perspective and as endpoint (matching every
+  other ``_at`` sibling's lenient posture, unlike
+  :func:`channel_catalog_path` which excludes trial from the walked
+  intermediate rungs but accepts it as an endpoint via the lateral /
+  identity branches).
+* case + whitespace normalisation on perspective, from, to.
+* helper is decoupled from the resolver -- grace vs enforce yields
+  byte-identical rows.
+* unknown / empty / garbage ids return ``None`` and never raise;
+  a delegate crash short-circuits to ``None`` and logs a warning.
+* API: 400 on missing args, 404 with ``which: "tier" | "from" |
+  "to"`` on unknown ids, 200 with the standard resolver-context tail
+  every ``_at*`` endpoint carries.
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+
+_ROW_KEYS = {"tier", "tier_label", "tier_rank", "channels"}
+_SCALAR_ENVELOPE_KEYS = {
+    "perspective_tier",
+    "perspective_tier_rank",
+    "from",
+    "from_label",
+    "from_rank",
+    "to",
+    "to_label",
+    "to_rank",
+    "direction",
+    "path",
+    "current_tier",
+    "current_tier_rank",
+    "grace",
+    "enforced",
+}
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def enforced(monkeypatch, tmp_path):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from flask import Flask
+
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+def _all_tiers(mod):
+    return [
+        mod.TIER_OSS,
+        mod.TIER_CLOUD_FREE,
+        mod.TIER_TRIAL,
+        mod.TIER_CLOUD_STARTER,
+        mod.TIER_CLOUD_PRO,
+        mod.TIER_PRO,
+        mod.TIER_ENTERPRISE,
+    ]
+
+
+# ── helper: shape + happy path ───────────────────────────────────────────
+
+
+def test_helper_returns_list(ent):
+    path = ent.channel_catalog_at_path(
+        ent.TIER_CLOUD_PRO, ent.TIER_OSS, ent.TIER_ENTERPRISE
+    )
+    assert isinstance(path, list)
+    assert len(path) >= 1
+
+
+def test_helper_each_row_has_expected_shape(ent):
+    path = ent.channel_catalog_at_path(
+        ent.TIER_CLOUD_PRO, ent.TIER_OSS, ent.TIER_ENTERPRISE
+    )
+    for row in path:
+        assert isinstance(row, dict)
+        assert set(row.keys()) == _ROW_KEYS
+        assert isinstance(row["tier"], str)
+        assert isinstance(row["tier_label"], str)
+        assert isinstance(row["tier_rank"], int)
+        assert isinstance(row["channels"], list)
+
+
+def test_helper_identity_yields_empty(ent):
+    for tid in _all_tiers(ent):
+        assert ent.channel_catalog_at_path(ent.TIER_CLOUD_PRO, tid, tid) == []
+
+
+def test_helper_lateral_yields_single_row(ent):
+    """Lateral (same rank, different id) yields a one-row path."""
+    path = ent.channel_catalog_at_path(
+        ent.TIER_CLOUD_STARTER, ent.TIER_CLOUD_PRO, ent.TIER_PRO
+    )
+    assert isinstance(path, list)
+    assert len(path) == 1
+    assert path[0]["tier"] == ent.TIER_PRO
+
+
+def test_helper_upgrade_direction_walks_rungs(ent):
+    path = ent.channel_catalog_at_path(
+        ent.TIER_CLOUD_PRO, ent.TIER_OSS, ent.TIER_ENTERPRISE
+    )
+    ranks = [r["tier_rank"] for r in path]
+    assert ranks == sorted(ranks)
+
+
+def test_helper_downgrade_direction_walks_rungs(ent):
+    path = ent.channel_catalog_at_path(
+        ent.TIER_CLOUD_PRO, ent.TIER_ENTERPRISE, ent.TIER_OSS
+    )
+    ranks = [r["tier_rank"] for r in path]
+    assert ranks == sorted(ranks, reverse=True)
+
+
+# ── helper: byte-parity with channel_catalog_path ────────────────────────
+
+
+def test_helper_body_parity_with_channel_catalog_path(ent):
+    """Body byte-identical to ``channel_catalog_path(from, to)`` for every
+    ``(perspective, from, to)`` triple in ``ALL_TIERS × ALL_TIERS ×
+    ALL_TIERS`` -- the perspective is validated but does NOT shape rows.
+    """
+    tiers = _all_tiers(ent)
+    for p in tiers:
+        for f in tiers:
+            for t in tiers:
+                got = ent.channel_catalog_at_path(p, f, t)
+                want = ent.channel_catalog_path(f, t)
+                assert got == want, (p, f, t)
+
+
+def test_helper_perspective_invariance(ent):
+    """Two different perspectives yield byte-identical rows."""
+    tiers = _all_tiers(ent)
+    for f in tiers:
+        for t in tiers:
+            a = ent.channel_catalog_at_path(ent.TIER_OSS, f, t)
+            b = ent.channel_catalog_at_path(ent.TIER_ENTERPRISE, f, t)
+            assert a == b, (f, t)
+
+
+def test_helper_per_rung_channels_matches_channel_catalog(ent):
+    """Each per-rung ``channels`` list byte-equals ``channel_catalog()``
+    (the "channels always free at every tier" invariant, inherited
+    from :func:`channel_catalog_path`)."""
+    baseline = ent.channel_catalog()
+    path = ent.channel_catalog_at_path(
+        ent.TIER_CLOUD_PRO, ent.TIER_OSS, ent.TIER_ENTERPRISE
+    )
+    assert path
+    for row in path:
+        assert row["channels"] == baseline
+
+
+def test_helper_channel_list_invariant_across_all_walks(ent):
+    """Every rung across every walk carries the same channels list."""
+    baseline = ent.channel_catalog()
+    tiers = _all_tiers(ent)
+    for p in tiers:
+        for f in tiers:
+            for t in tiers:
+                path = ent.channel_catalog_at_path(p, f, t)
+                if not path:
+                    continue
+                for row in path:
+                    assert row["channels"] == baseline
+
+
+# ── helper: trial + endpoint acceptance ──────────────────────────────────
+
+
+def test_helper_trial_accepted_as_perspective(ent):
+    """Perspective acceptance is lenient: trial IS accepted."""
+    got = ent.channel_catalog_at_path(
+        ent.TIER_TRIAL, ent.TIER_OSS, ent.TIER_ENTERPRISE
+    )
+    assert isinstance(got, list)
+    assert got == ent.channel_catalog_path(ent.TIER_OSS, ent.TIER_ENTERPRISE)
+
+
+def test_helper_trial_accepted_as_endpoint(ent):
+    """Trial IS accepted as from or to via the lateral / identity branch."""
+    got = ent.channel_catalog_at_path(
+        ent.TIER_CLOUD_PRO, ent.TIER_TRIAL, ent.TIER_TRIAL
+    )
+    assert got == []
+    lateral = ent.channel_catalog_at_path(
+        ent.TIER_CLOUD_PRO, ent.TIER_TRIAL, ent.TIER_CLOUD_FREE
+    )
+    assert isinstance(lateral, list)
+
+
+# ── helper: unknown / normalisation / robustness ─────────────────────────
+
+
+def test_helper_unknown_perspective_returns_none(ent):
+    assert ent.channel_catalog_at_path("bogus", ent.TIER_OSS, ent.TIER_ENTERPRISE) is None
+
+
+def test_helper_unknown_from_returns_none(ent):
+    assert ent.channel_catalog_at_path(ent.TIER_CLOUD_PRO, "bogus", ent.TIER_ENTERPRISE) is None
+
+
+def test_helper_unknown_to_returns_none(ent):
+    assert ent.channel_catalog_at_path(ent.TIER_CLOUD_PRO, ent.TIER_OSS, "bogus") is None
+
+
+def test_helper_none_perspective_returns_none(ent):
+    assert ent.channel_catalog_at_path(None, ent.TIER_OSS, ent.TIER_ENTERPRISE) is None
+
+
+def test_helper_empty_perspective_returns_none(ent):
+    assert ent.channel_catalog_at_path("", ent.TIER_OSS, ent.TIER_ENTERPRISE) is None
+    assert ent.channel_catalog_at_path("   ", ent.TIER_OSS, ent.TIER_ENTERPRISE) is None
+
+
+def test_helper_case_and_whitespace_normalised(ent):
+    """Case + whitespace on perspective, from, to are all normalised."""
+    got = ent.channel_catalog_at_path(
+        "  Cloud_Pro  ", "  OSS  ", "  ENTERPRISE  "
+    )
+    want = ent.channel_catalog_at_path(
+        ent.TIER_CLOUD_PRO, ent.TIER_OSS, ent.TIER_ENTERPRISE
+    )
+    assert got == want
+
+
+def test_helper_never_raises_on_weird_types(ent):
+    """Garbage inputs return None, never raise."""
+    for bad_p in (123, 4.5, [], {}, object()):
+        assert ent.channel_catalog_at_path(bad_p, ent.TIER_OSS, ent.TIER_ENTERPRISE) is None
+
+
+def test_helper_grace_vs_enforce_identical(ent, enforced):
+    """Grace vs enforce yields byte-identical rows."""
+    tiers = _all_tiers(ent)
+    for p in tiers:
+        for f in tiers:
+            for t in tiers:
+                a = ent.channel_catalog_at_path(p, f, t)
+                b = enforced.channel_catalog_at_path(p, f, t)
+                assert a == b, (p, f, t)
+
+
+def test_helper_delegate_crash_returns_none(ent, monkeypatch):
+    """A crash inside :func:`channel_catalog_path` short-circuits to
+    ``None`` instead of propagating."""
+    def _boom(*args, **kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(ent, "channel_catalog_path", _boom)
+    got = ent.channel_catalog_at_path(
+        ent.TIER_CLOUD_PRO, ent.TIER_OSS, ent.TIER_ENTERPRISE
+    )
+    assert got is None
+
+
+# ── HTTP scalar ──────────────────────────────────────────────────────────
+
+
+def test_http_happy_path(client, ent):
+    r = client.get(
+        "/api/entitlement/channel-catalog-at-path"
+        f"?tier={ent.TIER_CLOUD_PRO}&from={ent.TIER_OSS}&to={ent.TIER_ENTERPRISE}"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert set(body.keys()) == _SCALAR_ENVELOPE_KEYS
+    assert body["perspective_tier"] == ent.TIER_CLOUD_PRO
+    assert body["from"] == ent.TIER_OSS
+    assert body["to"] == ent.TIER_ENTERPRISE
+    assert body["direction"] == "upgrade"
+    assert isinstance(body["path"], list)
+    assert body["path"]
+    for row in body["path"]:
+        assert set(row.keys()) == _ROW_KEYS
+
+
+def test_http_missing_tier_400(client):
+    r = client.get("/api/entitlement/channel-catalog-at-path?from=oss&to=enterprise")
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "missing tier"
+
+
+def test_http_missing_from_400(client):
+    r = client.get("/api/entitlement/channel-catalog-at-path?tier=cloud_pro&to=enterprise")
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "missing from"
+
+
+def test_http_missing_to_400(client):
+    r = client.get("/api/entitlement/channel-catalog-at-path?tier=cloud_pro&from=oss")
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "missing to"
+
+
+def test_http_unknown_tier_which_key(client):
+    r = client.get(
+        "/api/entitlement/channel-catalog-at-path?tier=bogus&from=oss&to=enterprise"
+    )
+    assert r.status_code == 404
+    body = r.get_json()
+    assert body["error"] == "unknown tier"
+    assert body["which"] == "tier"
+    assert body["tier"] == "bogus"
+
+
+def test_http_unknown_from_which_key(client):
+    r = client.get(
+        "/api/entitlement/channel-catalog-at-path?tier=cloud_pro&from=bogus&to=enterprise"
+    )
+    assert r.status_code == 404
+    body = r.get_json()
+    assert body["error"] == "unknown tier"
+    assert body["which"] == "from"
+    assert body["from"] == "bogus"
+
+
+def test_http_unknown_to_which_key(client):
+    r = client.get(
+        "/api/entitlement/channel-catalog-at-path?tier=cloud_pro&from=oss&to=bogus"
+    )
+    assert r.status_code == 404
+    body = r.get_json()
+    assert body["error"] == "unknown tier"
+    assert body["which"] == "to"
+    assert body["to"] == "bogus"
+
+
+def test_http_trial_accepted_as_perspective(client, ent):
+    r = client.get(
+        "/api/entitlement/channel-catalog-at-path"
+        f"?tier={ent.TIER_TRIAL}&from={ent.TIER_OSS}&to={ent.TIER_ENTERPRISE}"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["perspective_tier"] == ent.TIER_TRIAL
+
+
+def test_http_identity_path_empty(client):
+    r = client.get(
+        "/api/entitlement/channel-catalog-at-path?tier=cloud_pro&from=oss&to=oss"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["direction"] == "identity"
+    assert body["path"] == []
+
+
+def test_http_downgrade_direction(client):
+    r = client.get(
+        "/api/entitlement/channel-catalog-at-path"
+        "?tier=cloud_pro&from=enterprise&to=oss"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["direction"] == "downgrade"
+    ranks = [row["tier_rank"] for row in body["path"]]
+    assert ranks == sorted(ranks, reverse=True)
+
+
+def test_http_lateral_direction(client):
+    r = client.get(
+        "/api/entitlement/channel-catalog-at-path"
+        "?tier=cloud_starter&from=cloud_pro&to=pro"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["direction"] == "lateral"
+    assert len(body["path"]) == 1
+
+
+def test_http_case_and_whitespace_normalised(client, ent):
+    r = client.get(
+        "/api/entitlement/channel-catalog-at-path"
+        "?tier=%20Cloud_Pro%20&from=%20OSS%20&to=%20ENTERPRISE%20"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["perspective_tier"] == ent.TIER_CLOUD_PRO
+    assert body["from"] == ent.TIER_OSS
+    assert body["to"] == ent.TIER_ENTERPRISE
+
+
+def test_http_body_parity_with_channel_catalog_path(client, ent):
+    """Wire body's ``path`` byte-equals ``/channel-catalog-path?from&to``
+    for the same ``(from, to)`` pair."""
+    r_at = client.get(
+        "/api/entitlement/channel-catalog-at-path"
+        f"?tier={ent.TIER_CLOUD_PRO}&from={ent.TIER_OSS}&to={ent.TIER_ENTERPRISE}"
+    )
+    r_bare = client.get(
+        "/api/entitlement/channel-catalog-path"
+        f"?from={ent.TIER_OSS}&to={ent.TIER_ENTERPRISE}"
+    )
+    assert r_at.status_code == 200
+    assert r_bare.status_code == 200
+    assert r_at.get_json()["path"] == r_bare.get_json()["path"]
+
+
+def test_http_perspective_invariance(client, ent):
+    """Wire body's ``path`` is byte-identical across two perspectives."""
+    r_a = client.get(
+        "/api/entitlement/channel-catalog-at-path"
+        f"?tier={ent.TIER_OSS}&from={ent.TIER_OSS}&to={ent.TIER_ENTERPRISE}"
+    )
+    r_b = client.get(
+        "/api/entitlement/channel-catalog-at-path"
+        f"?tier={ent.TIER_ENTERPRISE}&from={ent.TIER_OSS}&to={ent.TIER_ENTERPRISE}"
+    )
+    assert r_a.status_code == 200
+    assert r_b.status_code == 200
+    assert r_a.get_json()["path"] == r_b.get_json()["path"]
+
+
+def test_http_channel_list_invariant_across_rungs(client, ent):
+    """Every rung's ``channels`` list is byte-equal to
+    ``/channel-catalog`` (the "channels are always free" invariant
+    inherited from the delegate)."""
+    r = client.get(
+        "/api/entitlement/channel-catalog-at-path"
+        f"?tier={ent.TIER_CLOUD_PRO}&from={ent.TIER_OSS}&to={ent.TIER_ENTERPRISE}"
+    )
+    r_bare = client.get("/api/entitlement/channel-catalog")
+    assert r.status_code == 200
+    assert r_bare.status_code == 200
+    baseline = r_bare.get_json()["channels"]
+    for row in r.get_json()["path"]:
+        assert row["channels"] == baseline
+
+
+def test_http_carries_resolver_context_tail(client, ent):
+    r = client.get(
+        "/api/entitlement/channel-catalog-at-path"
+        f"?tier={ent.TIER_CLOUD_PRO}&from={ent.TIER_OSS}&to={ent.TIER_ENTERPRISE}"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert "current_tier" in body
+    assert "current_tier_rank" in body
+    assert isinstance(body["grace"], bool)
+    assert isinstance(body["enforced"], bool)
+
+
+def test_http_never_5xx_on_delegate_crash(client, ent, monkeypatch):
+    """A crash inside the helper short-circuits to 404, not 5xx."""
+    def _boom(*args, **kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(ent, "channel_catalog_at_path", _boom)
+    r = client.get(
+        "/api/entitlement/channel-catalog-at-path"
+        f"?tier={ent.TIER_CLOUD_PRO}&from={ent.TIER_OSS}&to={ent.TIER_ENTERPRISE}"
+    )
+    assert r.status_code == 404
+
+
+def test_http_grace_vs_enforce_identical(client, ent, enforced):
+    """Wire body's ``path`` is byte-identical across grace / enforce."""
+    r_a = client.get(
+        "/api/entitlement/channel-catalog-at-path"
+        f"?tier={ent.TIER_CLOUD_PRO}&from={ent.TIER_OSS}&to={ent.TIER_ENTERPRISE}"
+    )
+    assert r_a.status_code == 200
+
+    from flask import Flask
+    from routes.entitlement import bp_entitlement
+
+    app_e = Flask(__name__)
+    app_e.register_blueprint(bp_entitlement)
+    client_e = app_e.test_client()
+    r_b = client_e.get(
+        "/api/entitlement/channel-catalog-at-path"
+        f"?tier={enforced.TIER_CLOUD_PRO}&from={enforced.TIER_OSS}"
+        f"&to={enforced.TIER_ENTERPRISE}"
+    )
+    assert r_b.status_code == 200
+    assert r_a.get_json()["path"] == r_b.get_json()["path"]


### PR DESCRIPTION
## Summary

- Channel-axis twin of `feature_catalog_at_path` / `runtime_catalog_at_path` / `tier_catalog_at_path`: per-rung channel-catalog path between two tiers rendered from a hypothetical `perspective_tier` in ONE round-trip. Fills the `_at_path` slot for the channel-catalog family alongside `channel_catalog_at` (scalar what-if), `channel_catalog_at_batch` (batch what-if), and `channel_catalog_path` (path current) so a pricing-comparison walkthrough surface can call `X_at_path(perspective, from, to)` uniformly across every `_at_path` family member on all four axes (feature / runtime / channel / tier).
- Because every chat-channel adapter is FREE at every tier (the `channels` capacity axis governs how many concurrent channels each plan admits, not which adapters unlock), each rung's inner `channels` list is byte-identical to `channel_catalog()`. The always-free invariant is inherited from `channel_catalog_path`; parity tests here pin it against the current-perspective sibling so the scalar-, path-, what-if-, and batch- channel surfaces cannot drift.

Non-overlapping with the open draft PR #3561 (`channel_catalog_path_batch`) — that's the `_path_batch` slot on the channel-catalog family; this PR is the `_at_path` slot. New helper sits between `feature_catalog_at_path_batch` and `lock_reason_at_path` in `clawmetry/entitlements.py`; new route sits between `/runtime-catalog-at-path-batch` and `/lock-reason-at-path` in `routes/entitlement.py`.

## Helper

```python
def channel_catalog_at_path(
    perspective_tier: str, from_tier: str, to_tier: str
) -> list[dict] | None
```

Per-rung row shape matches `channel_catalog_path` (`tier`, `tier_label`, `tier_rank`, `channels`). Body posture matches the sibling `_at_path` helpers: `perspective_tier` is validated against `_TIER_ORDER` but does NOT shape the rows — the delegate `channel_catalog_path(from, to)` supplies the walk. Returns `None` when any of the three ids is unknown; empty list on identity (`from == to`). `trial` accepted as perspective and as endpoint (matching every other `_at` sibling's lenient posture). Grace vs enforce yields byte-identical rows. Never raises: a delegate crash logs a warning and returns `None`.

## Route

```
GET /api/entitlement/channel-catalog-at-path?tier=<perspective>&from=<from>&to=<to>
```

Envelope carries the standard `_at_path` shape:

```
{
  "perspective_tier":      "<tier id>",
  "perspective_tier_rank": <int>,
  "from":                  "<tier id>",
  "from_label":            "...",
  "from_rank":             <int>,
  "to":                    "<tier id>",
  "to_label":              "...",
  "to_rank":               <int>,
  "direction":             "upgrade" | "downgrade" | "lateral" | "identity",
  "path":                  [<channel-catalog-path row>, ...],
  "current_tier":          "<tier id>",
  "current_tier_rank":     <int>,
  "grace":                 <bool>,
  "enforced":              <bool>,
}
```

- **400** on missing `tier=` / `from=` / `to=`.
- **404** with `which: "tier" | "from" | "to"` on unknown ids.
- **Never 5xxs**: a resolver failure short-circuits to 404 so an upgrade-walkthrough surface keeps rendering instead of breaking.

## Tests

39 new tests in `tests/test_entitlement_channel_catalog_at_path.py` covering:

- helper: row shape, identity → `[]`, lateral → single-row, upgrade / downgrade rung monotonicity
- helper: byte-parity vs `channel_catalog_path(from, to)` across every `(perspective, from, to)` triple in `ALL_TIERS × ALL_TIERS × ALL_TIERS`
- helper: perspective invariance (two different perspectives yield identical rows)
- helper: per-rung `channels` list byte-equals `channel_catalog()` (always-free invariant)
- helper: `trial` accepted as perspective and endpoint
- helper: unknown / None / empty / whitespace-only inputs return `None`
- helper: case + whitespace normalisation on perspective, from, to
- helper: garbage types (int, float, list, dict, object) return `None`, never raise
- helper: grace vs enforce byte-parity across every triple
- helper: delegate crash short-circuits to `None`
- HTTP: happy path envelope key set, 400 on missing args, 404 with `which` on unknown ids
- HTTP: `trial` perspective accepted, identity / downgrade / lateral direction branches
- HTTP: case + whitespace normalisation on wire
- HTTP: `path` byte-equals `/channel-catalog-path` path for the same `(from, to)` pair
- HTTP: perspective invariance on wire
- HTTP: rung-invariant `channels` byte-equals `/channel-catalog` `channels`
- HTTP: resolver-context tail carried (`current_tier`, `grace`, `enforced`)
- HTTP: never-5xx contract when the inner helper crashes
- HTTP: grace vs enforce body parity

```
39 passed in 1.18s
```

Sibling family (`channel_catalog`, `channel_catalog_at`, `channel_catalog_path`, and every `_at_path` scalar on the feature / runtime / tier axes) still green: **329 passed** across the touched surface, no regressions.

## Test plan

- [x] `python3 -m py_compile clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_channel_catalog_at_path.py` — clean
- [x] `python3 -m pytest tests/test_entitlement_channel_catalog_at_path.py -x -q` — 39 passed
- [x] `python3 -m pytest tests/test_entitlement_channel_catalog.py tests/test_entitlement_channel_catalog_at.py tests/test_entitlement_channel_catalog_path.py tests/test_entitlement_channel_catalog_at_path.py tests/test_entitlement_feature_catalog_at_path.py tests/test_entitlement_runtime_catalog_at_path.py tests/test_entitlement_tier_catalog_at_path.py -q` — 329 passed
- [x] `ruff check clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_channel_catalog_at_path.py` — clean
- [x] `python3 -c "import ast; ast.parse(open('dashboard.py').read())"` — clean
- [ ] Spot-check body parity: `/api/entitlement/channel-catalog-at-path?tier=cloud_pro&from=oss&to=enterprise` `.path` matches `/api/entitlement/channel-catalog-path?from=oss&to=enterprise` `.path`
- [ ] Spot-check perspective invariance: same `(from, to)` with different `tier=` returns identical `path[]`
- [ ] Spot-check always-free invariant: every per-rung `channels[]` list is byte-equal to `/api/entitlement/channel-catalog` `.channels`

## Local operator verification checklist

(Required because this remote session has no access to the live daemon, `~/.openclaw`, the live cloud snapshot, or a browser.)

- [ ] Pull the branch locally: `git fetch origin feat/entitlement-channel-catalog-at-path && git checkout feat/entitlement-channel-catalog-at-path`
- [ ] Copy changed files into the live install:
  - `cp clawmetry/entitlements.py ~/.clawmetry/lib/python*/site-packages/clawmetry/entitlements.py`
  - `cp routes/entitlement.py ~/.clawmetry/lib/python*/site-packages/routes/entitlement.py`
- [ ] Clear caches: `find ~/.clawmetry/lib -name __pycache__ -type d -exec rm -rf {} +`
- [ ] Restart the daemon: `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
- [ ] Hit the new endpoint:
  - `curl -sS 'http://localhost:8900/api/entitlement/channel-catalog-at-path?tier=cloud_pro&from=oss&to=enterprise' | jq`
  - `curl -sS 'http://localhost:8900/api/entitlement/channel-catalog-at-path?tier=cloud_pro&from=enterprise&to=oss' | jq '.direction'` → `"downgrade"`
  - `curl -sS 'http://localhost:8900/api/entitlement/channel-catalog-at-path?tier=cloud_starter&from=cloud_pro&to=pro' | jq '.direction'` → `"lateral"`
  - `curl -sS 'http://localhost:8900/api/entitlement/channel-catalog-at-path?tier=trial&from=oss&to=enterprise' | jq '.perspective_tier'` → `"trial"`
- [ ] Confirm the body carries `perspective_tier` / `perspective_tier_rank` / `from` / `from_label` / `from_rank` / `to` / `to_label` / `to_rank` / `direction` / `path[]` + resolver tail (`current_tier` / `current_tier_rank` / `grace` / `enforced`)
- [ ] Confirm channel-list invariance across rungs (channels are always free):
  - `curl -sS 'http://localhost:8900/api/entitlement/channel-catalog-at-path?tier=cloud_pro&from=oss&to=enterprise' | jq '.path | map(.channels) | unique | length'` → `1`
- [ ] Confirm perspective invariance:
  - `curl -sS 'http://localhost:8900/api/entitlement/channel-catalog-at-path?tier=oss&from=oss&to=enterprise' | jq .path > /tmp/a.json`
  - `curl -sS 'http://localhost:8900/api/entitlement/channel-catalog-at-path?tier=enterprise&from=oss&to=enterprise' | jq .path | diff - /tmp/a.json` → empty diff
- [ ] Decrypt the live cloud snapshot client-side and confirm the pricing / entitlement UI (if any) still renders — no behaviour change intended (grace mode preserved; no enforcement gate added)
- [ ] Promote out of draft when the above checks pass; do not merge until then

Posture: **grace mode preserved**. No behaviour change to any existing endpoint, no enforce gate flipped, no `__version__` bump, no release tag. The next-phase work (cloud-side entitlement minting, `clawmetry-pro` package download, enterprise SSO) needs the private `clawmetry-cloud` / `clawmetry-pro` repos and is out of scope for this remote session.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PEvZVzngWyQs1urtyWP1Fu

---
_Generated by [Claude Code](https://claude.ai/code/session_01PEvZVzngWyQs1urtyWP1Fu)_