### PR TITLE
feat(entitlement): channel_spec + /api/entitlement/channel-spec

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -5356,6 +5356,49 @@ def channel_catalog() -> list[dict]:
     return [_channel_spec_row(ent, ch) for ch in sorted(ALL_CHANNELS)]
 
 
+def channel_spec(channel: str) -> dict | None:
+    """Scalar sibling of :func:`channel_catalog`: return the single
+    catalogue row for ``channel`` (case-insensitive, trimmed), or
+    ``None`` for empty / unknown ids.
+
+    Channel-axis analogue of :func:`feature_spec` / :func:`runtime_spec`
+    -- fills the scalar slot on the channel ``spec`` family so a
+    channel-detail page or a "which channels does this account have
+    turned on" tooltip can hydrate against ONE channel in ONE round-trip
+    instead of fetching the whole :func:`channel_catalog` and filtering
+    client-side. Row shape is byte-identical to a row returned by
+    :func:`channel_catalog` for the same id -- a parity test pins this so
+    the scalar and bulk accessors cannot drift.
+
+    Every chat channel is FREE at every tier (the ``channels`` capacity
+    axis governs how many concurrent channels each plan admits, not
+    which adapters unlock), so the row always comes back
+    ``free=True`` / ``allowed=True`` / ``locked=False`` /
+    ``entitled=True`` regardless of the resolved tier. That posture is
+    inherited from :func:`_channel_spec_row`; the parity test pins it
+    against the catalog sibling.
+
+    Never raises: on resolver failure the row is still built against the
+    OSS-free fallback (matches the catalog's never-crash contract).
+    """
+    try:
+        ch = (channel or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if not ch or ch not in ALL_CHANNELS:
+        return None
+    try:
+        ent = get_entitlement()
+    except Exception as exc:
+        logger.warning("entitlements: channel_spec falling back to grace: %s", exc)
+        ent = _oss_free()
+    try:
+        return _channel_spec_row(ent, ch)
+    except Exception as exc:
+        logger.warning("entitlements: channel_spec row build failed: %s", exc)
+        return None
+
+
 def channel_catalog_at(tier: str) -> list[dict] | None:
     """What-if sibling of :func:`channel_catalog`: catalogue rows for the
     chat-channel axis with every row computed as if the install were on

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -3825,6 +3825,48 @@ def api_entitlement_runtime_spec():
         return jsonify({"error": "runtime-spec failed"}), 500
 
 
+@bp_entitlement.route("/api/entitlement/channel-spec")
+def api_entitlement_channel_spec():
+    """``GET /api/entitlement/channel-spec?channel=<id>`` -- scalar sibling
+    of ``/api/entitlement/channel-catalog``: the full catalogue row for one
+    chat-channel adapter id in one shot, matching exactly one row from
+    :func:`entitlements.channel_catalog`.
+
+    Channel-axis analogue of ``/feature-spec`` / ``/runtime-spec`` -- lets
+    a channel-detail page or a "which channels does this account have on"
+    tooltip hydrate against one channel without fetching the whole
+    catalogue and filtering client-side. Because every chat channel is
+    FREE at every tier (the ``channels`` capacity axis governs how many
+    concurrent channels each plan admits, not which adapters unlock), the
+    returned row is always ``free=True`` / ``allowed=True`` /
+    ``locked=False`` / ``entitled=True`` regardless of the resolved tier.
+
+    - **400** when ``channel=`` is missing / blank
+    - **404** when the id (after whitespace + case normalisation) is not
+      in :data:`entitlements.ALL_CHANNELS`
+    - **Never 5xxs**: the helper internally falls back to the OSS-free
+      shape on resolver failure, so the endpoint still returns 200 with a
+      valid row.
+    """
+    raw = request.args.get("channel")
+    channel = (raw or "").strip().lower()
+    if not channel:
+        return jsonify({"error": "missing channel"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        body = _ent.channel_spec(channel)
+        if body is None:
+            return (
+                jsonify({"error": "unknown channel", "channel": channel}),
+                404,
+            )
+        return jsonify(body)
+    except Exception as exc:
+        logger.warning("api_entitlement_channel_spec: error: %s", exc)
+        return jsonify({"error": "channel-spec failed"}), 500
+
+
 @bp_entitlement.route("/api/entitlement/feature-spec-batch")
 def api_entitlement_feature_spec_batch():
     """``GET /api/entitlement/feature-spec-batch?features=a,b,c`` -- plural

--- a/tests/test_entitlement_channel_spec.py
+++ b/tests/test_entitlement_channel_spec.py
@@ -1,0 +1,286 @@
+"""Tests for ``channel_spec(channel)`` and ``GET
+/api/entitlement/channel-spec``.
+
+``channel_spec`` is the scalar sibling of ``channel_catalog()`` -- the row
+shape a channel-detail page or "which channels does this account have
+turned on" tooltip hydrates against in one round-trip instead of fetching
+the full catalogue and filtering client-side.
+
+Pins:
+
+* the row shape matches a row from ``channel_catalog()`` exactly (so the
+  scalar and bulk accessors cannot drift)
+* every id in ``ALL_CHANNELS`` round-trips through ``channel_spec``
+* unknown / empty / ``None`` / non-string ids return ``None``
+* the input is trimmed + lowercased before resolution
+* every channel is FREE at every tier (the ``channels`` capacity axis
+  governs capacity, not adapter unlock), so grace vs enforce yields a
+  byte-identical row
+* the endpoint 400s on a missing arg, 404s on an unknown id, and never
+  5xxs (a resolver crash still returns a catalogue row built against the
+  OSS-free fallback)
+"""
+from __future__ import annotations
+
+import importlib
+import json
+
+import pytest
+
+
+_SPEC_KEYS = {
+    "id",
+    "label",
+    "free",
+    "tier",
+    "allowed",
+    "locked",
+    "entitled",
+}
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    """Fresh entitlements module with HOME pointed at an empty tmp dir so no
+    real ~/.clawmetry/license.key or cloud_plan.json leaks in. Enforcement off
+    by default (grace mode)."""
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from flask import Flask
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# ── shape ─────────────────────────────────────────────────────────────────────
+
+
+def test_spec_row_keys_match_catalog_row(ent):
+    """A row from ``channel_spec`` carries the same keys as a
+    ``channel_catalog()`` row -- defends against a rename on one side
+    silently shipping a half-renamed payload to the UI."""
+    cat_keys = set(ent.channel_catalog()[0].keys())
+    assert cat_keys == _SPEC_KEYS
+    ch = next(iter(ent.ALL_CHANNELS))
+    spec = ent.channel_spec(ch)
+    assert spec is not None
+    assert set(spec.keys()) == _SPEC_KEYS
+
+
+def test_spec_parity_with_every_catalog_row(ent):
+    """For every row in the catalogue, the scalar accessor returns the
+    same dict. Pins the scalar/bulk no-drift contract."""
+    cat_by_id = {row["id"]: row for row in ent.channel_catalog()}
+    assert set(cat_by_id.keys()) == set(ent.ALL_CHANNELS)
+    for ch, row in cat_by_id.items():
+        assert ent.channel_spec(ch) == row, ch
+
+
+# ── round-trip ────────────────────────────────────────────────────────────────
+
+
+def test_every_known_channel_round_trips(ent):
+    for ch in ent.ALL_CHANNELS:
+        spec = ent.channel_spec(ch)
+        assert spec is not None, ch
+        assert spec["id"] == ch
+
+
+def test_unknown_channel_returns_none(ent):
+    assert ent.channel_spec("not_a_real_channel") is None
+
+
+def test_empty_returns_none(ent):
+    assert ent.channel_spec("") is None
+
+
+def test_whitespace_only_returns_none(ent):
+    assert ent.channel_spec("   ") is None
+
+
+def test_none_returns_none(ent):
+    assert ent.channel_spec(None) is None
+
+
+def test_non_string_returns_none(ent):
+    # Defensive: a stray int / list / dict / object from a malformed caller
+    # must not crash.
+    assert ent.channel_spec(123) is None
+    assert ent.channel_spec(1.5) is None
+    assert ent.channel_spec(["telegram"]) is None
+    assert ent.channel_spec({"id": "telegram"}) is None
+    assert ent.channel_spec(object()) is None
+
+
+def test_input_is_lowercased_and_trimmed(ent):
+    ch = next(iter(ent.ALL_CHANNELS))
+    assert ent.channel_spec(ch.upper()) == ent.channel_spec(ch)
+    assert ent.channel_spec(f"  {ch}  ") == ent.channel_spec(ch)
+    assert ent.channel_spec(f"\t{ch.upper()}\n") == ent.channel_spec(ch)
+
+
+# ── always-free invariant ─────────────────────────────────────────────────────
+
+
+def test_every_channel_is_always_free(ent):
+    """Every chat channel is FREE at every tier -- the ``channels``
+    capacity axis governs how many concurrent channels each plan admits,
+    not which adapters unlock."""
+    for ch in ent.ALL_CHANNELS:
+        row = ent.channel_spec(ch)
+        assert row["free"] is True, ch
+        assert row["tier"] == "free", ch
+        assert row["allowed"] is True, ch
+        assert row["locked"] is False, ch
+        assert row["entitled"] is True, ch
+
+
+# ── label carriage ────────────────────────────────────────────────────────────
+
+
+def test_label_matches_channel_label_helper(ent):
+    for ch in ent.ALL_CHANNELS:
+        row = ent.channel_spec(ch)
+        assert row["label"] == ent.channel_label(ch), ch
+
+
+# ── grace vs enforce ──────────────────────────────────────────────────────────
+
+
+def test_grace_locks_nothing(ent):
+    for ch in ent.ALL_CHANNELS:
+        row = ent.channel_spec(ch)
+        assert row["allowed"] is True, ch
+        assert row["locked"] is False, ch
+
+
+def test_enforce_oss_still_unlocks_every_channel(ent, monkeypatch):
+    """Every chat channel is FREE at every tier -- enforcement is a
+    no-op on the channel axis, so the row is byte-identical to grace."""
+    grace_rows = {ch: ent.channel_spec(ch) for ch in ent.ALL_CHANNELS}
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    for ch in ent.ALL_CHANNELS:
+        assert ent.channel_spec(ch) == grace_rows[ch], ch
+
+
+def test_enforce_cloud_pro_yields_identical_row(ent, monkeypatch, tmp_path):
+    grace_rows = {ch: ent.channel_spec(ch) for ch in ent.ALL_CHANNELS}
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    cache = tmp_path / ".clawmetry" / "cloud_plan.json"
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    cache.write_text(json.dumps({"plan": "cloud_pro"}))
+    ent.invalidate()
+    for ch in ent.ALL_CHANNELS:
+        assert ent.channel_spec(ch) == grace_rows[ch], ch
+
+
+# ── never-raise ───────────────────────────────────────────────────────────────
+
+
+def test_never_raises_when_resolver_crashes(ent, monkeypatch):
+    """A blown resolver still returns the catalogue row built against
+    the OSS-free fallback -- matches the never-crash contract on
+    ``channel_catalog()``."""
+
+    def boom(*_a, **_kw):
+        raise RuntimeError("simulated resolver failure")
+
+    monkeypatch.setattr(ent, "get_entitlement", boom)
+    ch = next(iter(ent.ALL_CHANNELS))
+    row = ent.channel_spec(ch)
+    assert row is not None
+    assert row["id"] == ch
+    assert row["free"] is True
+
+
+# ── HTTP endpoint ─────────────────────────────────────────────────────────────
+
+
+def test_endpoint_known_channel_returns_row(client, ent):
+    ch = next(iter(ent.ALL_CHANNELS))
+    resp = client.get(f"/api/entitlement/channel-spec?channel={ch}")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body == ent.channel_spec(ch)
+
+
+def test_endpoint_lowercases_and_trims(client, ent):
+    ch = next(iter(ent.ALL_CHANNELS))
+    resp = client.get(
+        f"/api/entitlement/channel-spec?channel=%20%20{ch.upper()}%20%20"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["id"] == ch
+
+
+def test_endpoint_missing_arg_returns_400(client):
+    resp = client.get("/api/entitlement/channel-spec")
+    assert resp.status_code == 400
+    assert "error" in resp.get_json()
+
+
+def test_endpoint_blank_arg_returns_400(client):
+    resp = client.get("/api/entitlement/channel-spec?channel=%20%20")
+    assert resp.status_code == 400
+
+
+def test_endpoint_unknown_channel_returns_404(client):
+    resp = client.get("/api/entitlement/channel-spec?channel=nonsense_xyz")
+    assert resp.status_code == 404
+    body = resp.get_json()
+    assert body["channel"] == "nonsense_xyz"
+    assert "error" in body
+
+
+def test_endpoint_every_known_channel_round_trips(client, ent):
+    for ch in ent.ALL_CHANNELS:
+        resp = client.get(f"/api/entitlement/channel-spec?channel={ch}")
+        assert resp.status_code == 200, ch
+        body = resp.get_json()
+        assert body["id"] == ch, ch
+
+
+def test_endpoint_body_byte_equals_catalog_row(client, ent):
+    """The endpoint body must byte-equal the corresponding row in
+    ``/api/entitlement/channel-catalog`` -- pins the scalar/bulk
+    no-drift contract on the wire."""
+    cat_resp = client.get("/api/entitlement/channel-catalog")
+    assert cat_resp.status_code == 200
+    cat_by_id = {row["id"]: row for row in cat_resp.get_json()["channels"]}
+    for ch in ent.ALL_CHANNELS:
+        resp = client.get(f"/api/entitlement/channel-spec?channel={ch}")
+        assert resp.status_code == 200, ch
+        assert resp.get_json() == cat_by_id[ch], ch
+
+
+def test_endpoint_returns_grace_row_even_when_resolver_crashes(
+    client, ent, monkeypatch
+):
+    """``channel_spec`` catches resolver failures internally and falls
+    back to the OSS-free row, so the endpoint must return 200 + a
+    valid catalogue row even when ``get_entitlement`` explodes."""
+
+    def boom(*_a, **_kw):
+        raise RuntimeError("simulated resolver failure")
+
+    monkeypatch.setattr(ent, "get_entitlement", boom)
+    ch = next(iter(ent.ALL_CHANNELS))
+    resp = client.get(f"/api/entitlement/channel-spec?channel={ch}")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["id"] == ch
+    assert body["free"] is True


### PR DESCRIPTION
## Summary

- Fills the scalar `""` slot on the channel-axis `spec` family alongside `feature_spec` / `runtime_spec` / `tier_spec` — a channel-detail page or "which channels does this account have turned on" tooltip can now hydrate against ONE channel in ONE round-trip instead of fetching the whole `channel_catalog()` and filtering client-side.
- Row shape is byte-identical to a row from `channel_catalog()` — a parity test pins this on both the helper and the wire. Because every chat channel is FREE at every tier (the `channels` capacity axis governs how many concurrent channels each plan admits, not which adapters unlock), grace vs enforce yields byte-identical rows; enforcement is a no-op on the channel axis, also pinned.

Independent of the open PR #3562 (`channel_catalog_at_path`) — that's the `_at_path` slot on the channel-catalog family; this is the `""` slot on the channel-**spec** family. New helper sits between `channel_catalog` and `channel_catalog_at` in `clawmetry/entitlements.py`; new route sits between `/runtime-spec` and `/feature-spec-batch` in `routes/entitlement.py`.

## Helper

```python
def channel_spec(channel: str) -> dict | None
```

Row shape matches `channel_catalog()` exactly: `{id, label, free, tier, allowed, locked, entitled}`. Posture matches the sibling scalar helpers: input is whitespace-stripped + lowercased; unknown / empty / `None` / non-string ids return `None` (never raises). On resolver failure the row is still built against the OSS-free fallback, matching the catalog's never-crash contract.

## Route

```
GET /api/entitlement/channel-spec?channel=<id>
```

- **400** when `channel=` is missing / blank
- **404** when the id (after normalisation) is not in `ALL_CHANNELS`
- **Never 5xxs** — a resolver crash falls back to the OSS-free row so a detail page keeps rendering.

Body byte-equals the corresponding row in `/api/entitlement/channel-catalog` — pinned on the wire.

## Tests

23 new tests in `tests/test_entitlement_channel_spec.py` covering:

- helper: row-key set matches `channel_catalog()` row exactly (`{id, label, free, tier, allowed, locked, entitled}`)
- helper: byte-parity vs `channel_catalog()` row for every id in `ALL_CHANNELS`
- helper: every known channel round-trips
- helper: unknown / empty / whitespace-only / `None` / non-string (int / float / list / dict / object) inputs return `None`, never raise
- helper: case + whitespace normalisation on input
- helper: always-free invariant — every row is `free=True` / `tier="free"` / `allowed=True` / `locked=False` / `entitled=True`
- helper: `label` byte-equals `channel_label(ch)` for every id
- helper: grace vs enforce byte-parity across every channel (both OSS-enforce and Cloud-Pro-enforce)
- helper: resolver-crash short-circuits to the OSS-free fallback row
- HTTP: happy path returns 200 with the byte-parity row
- HTTP: case + whitespace normalisation on the wire
- HTTP: 400 on missing / blank arg, 404 on unknown id (with `channel` echoed)
- HTTP: every known channel round-trips via the endpoint
- HTTP: body byte-equals the corresponding row in `/api/entitlement/channel-catalog`
- HTTP: never-5xx contract when the inner resolver crashes

```
23 passed in 0.84s
```

Sibling channel-catalog + feature_spec families still green: **201 passed** across the touched surface, no regressions.

## Test plan

- [x] `python3 -m py_compile clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_channel_spec.py` — clean
- [x] `python3 -m pytest tests/test_entitlement_channel_spec.py -x -q` — 23 passed
- [x] `python3 -m pytest tests/test_entitlement_channel_catalog.py tests/test_entitlement_channel_catalog_at.py tests/test_entitlement_channel_catalog_path.py tests/test_entitlement_channel_catalog_path_batch.py tests/test_entitlement_feature_spec.py tests/test_entitlement_channel_spec.py -q` — 201 passed
- [x] `ruff check clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_channel_spec.py` — clean
- [x] `python3 -c "import ast; ast.parse(open('dashboard.py').read())"` — clean
- [ ] Spot-check every channel round-trips on the wire: `for ch in $(curl -sS http://localhost:8900/api/entitlement/channel-catalog | jq -r '.channels[].id'); do curl -sS "http://localhost:8900/api/entitlement/channel-spec?channel=$ch" | jq -e '.id'; done`
- [ ] Spot-check body parity: `/api/entitlement/channel-spec?channel=telegram` byte-equals the `telegram` row inside `/api/entitlement/channel-catalog`
- [ ] Spot-check 400 / 404: `curl -sS -o /dev/null -w '%{http_code}\n' 'http://localhost:8900/api/entitlement/channel-spec'` → `400`; `curl -sS -o /dev/null -w '%{http_code}\n' 'http://localhost:8900/api/entitlement/channel-spec?channel=nonsense'` → `404`

## Local operator verification checklist

(Required because this remote session has no access to the live daemon, `~/.openclaw`, the live cloud snapshot, or a browser.)

- [ ] Pull the branch locally: `git fetch origin feat/entitlement-channel-spec && git checkout feat/entitlement-channel-spec`
- [ ] Copy changed files into the live install:
  - `cp clawmetry/entitlements.py ~/.clawmetry/lib/python*/site-packages/clawmetry/entitlements.py`
  - `cp routes/entitlement.py ~/.clawmetry/lib/python*/site-packages/routes/entitlement.py`
- [ ] Clear caches: `find ~/.clawmetry/lib -name __pycache__ -type d -exec rm -rf {} +`
- [ ] Restart the daemon: `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
- [ ] Hit the new endpoint:
  - `curl -sS 'http://localhost:8900/api/entitlement/channel-spec?channel=telegram' | jq`
  - `curl -sS 'http://localhost:8900/api/entitlement/channel-spec?channel=%20%20WHATSAPP%20%20' | jq '.id'` → `"whatsapp"`
  - `curl -sS -o /dev/null -w '%{http_code}\n' 'http://localhost:8900/api/entitlement/channel-spec'` → `400`
  - `curl -sS -o /dev/null -w '%{http_code}\n' 'http://localhost:8900/api/entitlement/channel-spec?channel=nonsense_xyz'` → `404`
- [ ] Confirm every row has `free=true` / `tier="free"` / `allowed=true` / `locked=false` / `entitled=true`
- [ ] Confirm byte-parity vs `/channel-catalog`:
  - `curl -sS 'http://localhost:8900/api/entitlement/channel-catalog' | jq '.channels[] | select(.id=="telegram")' > /tmp/a.json`
  - `curl -sS 'http://localhost:8900/api/entitlement/channel-spec?channel=telegram' | jq | diff - /tmp/a.json` → empty diff
- [ ] Decrypt the live cloud snapshot client-side and confirm the pricing / entitlement UI (if any) still renders — no behaviour change intended (grace mode preserved; no enforcement gate added)
- [ ] Promote out of draft when the above checks pass; do not merge until then

Posture: **grace mode preserved**. No behaviour change to any existing endpoint, no enforce gate flipped, no `__version__` bump, no release tag. The next-phase work (cloud-side entitlement minting, `clawmetry-pro` package download, enterprise SSO) needs the private `clawmetry-cloud` / `clawmetry-pro` repos and is out of scope for this remote session.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01163AUKnrHijcBe1XzQiSA5)_