### PR TITLE
feat: reports tab - markdown + embedded DuckDB SQL

### DIFF
--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -2837,6 +2837,16 @@ def _cmd_mcp(args) -> None:
     run()
 
 
+def _cmd_reports(args) -> None:
+    """Open the reports browser (refs #1005)."""
+    import webbrowser
+    port = getattr(args, "port", None) or 8900
+    url = f"http://localhost:{port}/reports/"
+    print(f"Opening {url} …")
+    print("(Make sure `clawmetry` is running. Write .md files to ~/.clawmetry/reports/.)")
+    webbrowser.open(url)
+
+
 def _cmd_eval(args) -> None:
     """Run a golden eval suite (Phase 2 evals, refs #1619).
 
@@ -3760,6 +3770,15 @@ def main() -> None:
         "--loop-detection", choices=["on", "off"], help="Toggle loop detection"
     )
 
+    # reports — open the reports browser (refs #1005)
+    p_reports = sub.add_parser(
+        "reports",
+        help="Open the reports browser (renders ~/.clawmetry/reports/*.md + DuckDB SQL)",
+    )
+    p_reports.add_argument(
+        "--port", type=int, default=8900, help="Dashboard port (default: 8900)"
+    )
+
     # eval — run a golden test suite (Phase 2 evals, refs #1619)
     p_eval = sub.add_parser(
         "eval",
@@ -3919,6 +3938,7 @@ def main() -> None:
         "sync",
         "status",
         "proxy",
+        "reports",
         "eval",
         "mcp",
         "update",
@@ -3951,6 +3971,8 @@ def main() -> None:
             _cmd_status(args)
         elif args.cmd == "proxy":
             _cmd_proxy(args)
+        elif args.cmd == "reports":
+            _cmd_reports(args)
         elif args.cmd == "eval":
             _cmd_eval(args)
         elif args.cmd == "mcp":

--- a/dashboard.py
+++ b/dashboard.py
@@ -125,6 +125,7 @@ from routes.insights import bp_insights
 from routes.review import bp_review
 from routes.evals import bp_evals
 from routes.dives import bp_dives
+from routes.reports import bp_reports
 from routes.scheduler import bp_scheduler
 from routes.policy import bp_policy
 from routes.turn_anatomy import bp_turn_anatomy
@@ -11585,6 +11586,7 @@ def detect_config(args=None):
     app.register_blueprint(bp_plugins)
     app.register_blueprint(bp_local_query)
     app.register_blueprint(bp_dives)
+    app.register_blueprint(bp_reports)
     app.register_blueprint(bp_scheduler)
     app.register_blueprint(bp_policy)
     app.register_blueprint(bp_turn_anatomy)

--- a/routes/reports.py
+++ b/routes/reports.py
@@ -22,7 +22,7 @@ _MAX_SQL_LEN = 2_000
 _BLOCK_RE = re.compile(r"<!--\s*duckdb:\s*(.*?)\s*-->", re.DOTALL | re.IGNORECASE)
 
 
-# ── Storage ───────────────────────────────────────────────────────────────────
+# ── Storage ─────────────────────────────────────────────────────────────────────────────
 
 
 def _reports_dir() -> str:
@@ -31,11 +31,11 @@ def _reports_dir() -> str:
     return d
 
 
-# ── Query helpers ─────────────────────────────────────────────────────────────
+# ── Query helpers ────────────────────────────────────────────────────────────────────────
 
 
 def _run_sql(sql: str) -> tuple[list[dict], str | None]:
-    """Run SQL via daemon proxy → direct store fallback. Returns (rows, error)."""
+    """Run SQL via daemon proxy, falling back to direct store. Returns (rows, error)."""
     sql = sql.strip()
     if len(sql) > _MAX_SQL_LEN:
         return [], f"SQL block too long (max {_MAX_SQL_LEN} chars)"
@@ -46,7 +46,7 @@ def _run_sql(sql: str) -> tuple[list[dict], str | None]:
             return [], f"SQL rejected: {reason}"
     except Exception as e:
         return [], f"SQL validator unavailable: {e}"
-    # Daemon proxy first — avoids contending on the DuckDB writer lock
+    # Daemon proxy first - avoids contending on the DuckDB writer lock
     try:
         from routes.local_query import local_store_via_daemon
         rows = local_store_via_daemon("raw_select_safe", sql=sql)
@@ -63,7 +63,7 @@ def _run_sql(sql: str) -> tuple[list[dict], str | None]:
         return [], str(e)[:200]
 
 
-# ── Rendering ─────────────────────────────────────────────────────────────────
+# ── Rendering ───────────────────────────────────────────────────────────────────────────
 
 
 def _rows_to_html_table(rows: list[dict]) -> str:
@@ -86,7 +86,7 @@ def _rows_to_html_table(rows: list[dict]) -> str:
 
 
 def _md_to_html(text: str) -> str:
-    """Minimal markdown → HTML for report prose (no SQL blocks remain here)."""
+    """Minimal markdown to HTML for report prose (no SQL blocks remain here)."""
     lines = text.split("\n")
     out: list[str] = []
     in_code = False
@@ -141,7 +141,7 @@ h3{font-size:1rem;margin-top:1.25rem}
 
 
 def _render_page(slug: str, md_content: str) -> str:
-    """Render a report .md file → full HTML page (SQL blocks replaced with tables)."""
+    """Render a report .md file to a full HTML page (SQL blocks replaced with tables)."""
     parts: list[str] = []
     last_end = 0
     for m in _BLOCK_RE.finditer(md_content):
@@ -162,7 +162,7 @@ def _render_page(slug: str, md_content: str) -> str:
     return (
         f"<!DOCTYPE html>\n<html lang=\"en\">\n<head>\n"
         f"<meta charset=\"utf-8\">\n"
-        f"<title>{html.escape(slug)} — ClawMetry Reports</title>\n"
+        f"<title>{html.escape(slug)} - ClawMetry Reports</title>\n"
         f"<style>{_CSS}</style>\n</head>\n<body>\n{body}\n</body>\n</html>"
     )
 
@@ -171,12 +171,12 @@ def _safe_slug(raw: str) -> str:
     return re.sub(r"[^A-Za-z0-9_\-]", "", raw)
 
 
-# ── Endpoints ─────────────────────────────────────────────────────────────────
+# ── Endpoints ─────────────────────────────────────────────────────────────────────────────
 
 
 @bp_reports.route("/api/reports")
 def api_reports_list():
-    """GET /api/reports → {reports: [{slug, title}]}"""
+    """GET /api/reports returns {reports: [{slug, title}]}"""
     try:
         d = _reports_dir()
         items = []
@@ -202,7 +202,7 @@ def api_reports_list():
 
 @bp_reports.route("/reports/")
 def reports_index():
-    """GET /reports/ → HTML index listing all reports."""
+    """GET /reports/ returns an HTML index listing all reports."""
     data = api_reports_list().get_json(force=True) or {}
     items = data.get("reports", [])
     if not items:
@@ -222,7 +222,7 @@ def reports_index():
         body = f"<h1>Reports</h1><ul>{links}</ul>"
     page = (
         f"<!DOCTYPE html><html lang=\"en\"><head><meta charset=\"utf-8\">"
-        f"<title>Reports — ClawMetry</title><style>{_CSS}</style></head>"
+        f"<title>ClawMetry Reports</title><style>{_CSS}</style></head>"
         f"<body>{body}</body></html>"
     )
     return Response(page, content_type="text/html; charset=utf-8")
@@ -230,7 +230,7 @@ def reports_index():
 
 @bp_reports.route("/reports/<slug>")
 def reports_render(slug: str):
-    """GET /reports/<slug> → rendered HTML report."""
+    """GET /reports/<slug> returns a rendered HTML report."""
     slug = _safe_slug(slug)
     if not slug:
         return Response("Invalid report name.", status=400)
@@ -247,7 +247,7 @@ def reports_render(slug: str):
 
 @bp_reports.route("/reports/<slug>/export.csv")
 def reports_export_csv(slug: str):
-    """GET /reports/<slug>/export.csv?block=<n> → CSV of SQL block n."""
+    """GET /reports/<slug>/export.csv?block=<n> returns CSV of SQL block n."""
     slug = _safe_slug(slug)
     if not slug:
         return Response("Invalid report name.", status=400)

--- a/routes/reports.py
+++ b/routes/reports.py
@@ -1,0 +1,283 @@
+"""routes/reports.py — ClawMetry Reports: markdown + embedded DuckDB SQL.
+
+Write .md files to ~/.clawmetry/reports/. Embed SQL with:
+    <!-- duckdb: SELECT count(*) FROM sessions -->
+Navigate to /reports/<slug> to see them rendered as HTML tables.
+
+Issue: https://github.com/vivekchand/clawmetry/issues/1005
+"""
+from __future__ import annotations
+
+import csv
+import html
+import io
+import os
+import re
+
+from flask import Blueprint, Response, jsonify, request
+
+bp_reports = Blueprint("reports", __name__)
+
+_MAX_SQL_LEN = 2_000
+_BLOCK_RE = re.compile(r"<!--\s*duckdb:\s*(.*?)\s*-->", re.DOTALL | re.IGNORECASE)
+
+
+# ── Storage ───────────────────────────────────────────────────────────────────
+
+
+def _reports_dir() -> str:
+    d = os.path.expanduser("~/.clawmetry/reports")
+    os.makedirs(d, exist_ok=True)
+    return d
+
+
+# ── Query helpers ─────────────────────────────────────────────────────────────
+
+
+def _run_sql(sql: str) -> tuple[list[dict], str | None]:
+    """Run SQL via daemon proxy → direct store fallback. Returns (rows, error)."""
+    sql = sql.strip()
+    if len(sql) > _MAX_SQL_LEN:
+        return [], f"SQL block too long (max {_MAX_SQL_LEN} chars)"
+    try:
+        from clawmetry.dives_sql_safety import validate_sql
+        ok, reason = validate_sql(sql)
+        if not ok:
+            return [], f"SQL rejected: {reason}"
+    except Exception as e:
+        return [], f"SQL validator unavailable: {e}"
+    # Daemon proxy first — avoids contending on the DuckDB writer lock
+    try:
+        from routes.local_query import local_store_via_daemon
+        rows = local_store_via_daemon("raw_select_safe", sql=sql)
+        if rows is not None:
+            return rows, None
+    except Exception:
+        pass
+    # Fall back to direct store (dev mode / unit tests)
+    try:
+        from clawmetry import local_store
+        store = local_store.get_store(read_only=True)
+        return store.raw_select_safe(sql=sql), None
+    except Exception as e:
+        return [], str(e)[:200]
+
+
+# ── Rendering ─────────────────────────────────────────────────────────────────
+
+
+def _rows_to_html_table(rows: list[dict]) -> str:
+    if not rows:
+        return '<p class="cm-rpt-empty">No results.</p>'
+    cols = list(rows[0].keys())
+    parts = ['<div class="cm-rpt-wrap"><table class="cm-rpt-tbl">']
+    parts.append("<thead><tr>")
+    for c in cols:
+        parts.append(f"<th>{html.escape(str(c))}</th>")
+    parts.append("</tr></thead><tbody>")
+    for row in rows:
+        parts.append("<tr>")
+        for c in cols:
+            v = row.get(c)
+            parts.append(f"<td>{html.escape('' if v is None else str(v))}</td>")
+        parts.append("</tr>")
+    parts.append("</tbody></table></div>")
+    return "".join(parts)
+
+
+def _md_to_html(text: str) -> str:
+    """Minimal markdown → HTML for report prose (no SQL blocks remain here)."""
+    lines = text.split("\n")
+    out: list[str] = []
+    in_code = False
+    for line in lines:
+        if line.startswith("```"):
+            if in_code:
+                out.append("</code></pre>")
+                in_code = False
+            else:
+                lang = html.escape(line[3:].strip())
+                out.append(f'<pre class="cm-rpt-code"><code class="language-{lang}">')
+                in_code = True
+            continue
+        if in_code:
+            out.append(html.escape(line) + "\n")
+            continue
+        if line.startswith("### "):
+            out.append(f"<h3>{html.escape(line[4:])}</h3>")
+        elif line.startswith("## "):
+            out.append(f"<h2>{html.escape(line[3:])}</h2>")
+        elif line.startswith("# "):
+            out.append(f"<h1>{html.escape(line[2:])}</h1>")
+        elif line.startswith(("- ", "* ")):
+            out.append(f"<li>{html.escape(line[2:])}</li>")
+        elif line.strip() == "":
+            out.append("")
+        else:
+            escaped = html.escape(line)
+            escaped = re.sub(r"\*\*(.+?)\*\*", r"<strong>\1</strong>", escaped)
+            escaped = re.sub(r"\*(.+?)\*", r"<em>\1</em>", escaped)
+            out.append(f"<p>{escaped}</p>")
+    return "\n".join(out)
+
+
+_CSS = """
+body{font-family:system-ui,sans-serif;max-width:900px;margin:2rem auto;padding:0 1rem;
+  color:#1a1a1a;line-height:1.6}
+a{color:#2563eb}
+.cm-rpt-wrap{overflow-x:auto;margin:1rem 0}
+.cm-rpt-tbl{border-collapse:collapse;width:100%;font-size:.875rem}
+.cm-rpt-tbl th,.cm-rpt-tbl td{border:1px solid #d1d5db;padding:.4rem .75rem;text-align:left}
+.cm-rpt-tbl th{background:#f3f4f6;font-weight:600}
+.cm-rpt-tbl tr:hover td{background:#f9fafb}
+.cm-rpt-empty{color:#6b7280;font-style:italic}
+.cm-rpt-err{color:#dc2626;font-style:italic}
+.cm-rpt-code{background:#f3f4f6;padding:1rem;overflow-x:auto;border-radius:.375rem;
+  font-size:.875rem}
+h1{font-size:1.75rem;margin-top:0}
+h2{font-size:1.25rem;margin-top:1.5rem}
+h3{font-size:1rem;margin-top:1.25rem}
+"""
+
+
+def _render_page(slug: str, md_content: str) -> str:
+    """Render a report .md file → full HTML page (SQL blocks replaced with tables)."""
+    parts: list[str] = []
+    last_end = 0
+    for m in _BLOCK_RE.finditer(md_content):
+        segment = md_content[last_end : m.start()]
+        if segment.strip():
+            parts.append(_md_to_html(segment))
+        sql = m.group(1).strip()
+        rows, err = _run_sql(sql)
+        if err:
+            parts.append(f'<div class="cm-rpt-err">Query error: {html.escape(err)}</div>')
+        else:
+            parts.append(_rows_to_html_table(rows))
+        last_end = m.end()
+    remaining = md_content[last_end:]
+    if remaining.strip():
+        parts.append(_md_to_html(remaining))
+    body = "\n".join(parts)
+    return (
+        f"<!DOCTYPE html>\n<html lang=\"en\">\n<head>\n"
+        f"<meta charset=\"utf-8\">\n"
+        f"<title>{html.escape(slug)} — ClawMetry Reports</title>\n"
+        f"<style>{_CSS}</style>\n</head>\n<body>\n{body}\n</body>\n</html>"
+    )
+
+
+def _safe_slug(raw: str) -> str:
+    return re.sub(r"[^A-Za-z0-9_\-]", "", raw)
+
+
+# ── Endpoints ─────────────────────────────────────────────────────────────────
+
+
+@bp_reports.route("/api/reports")
+def api_reports_list():
+    """GET /api/reports → {reports: [{slug, title}]}"""
+    try:
+        d = _reports_dir()
+        items = []
+        for fname in sorted(os.listdir(d)):
+            if not fname.endswith(".md"):
+                continue
+            slug = fname[:-3]
+            title = slug
+            try:
+                with open(os.path.join(d, fname), encoding="utf-8", errors="replace") as fh:
+                    for line in fh:
+                        stripped = line.strip().lstrip("# ").strip()
+                        if stripped:
+                            title = stripped
+                            break
+            except Exception:
+                pass
+            items.append({"slug": slug, "title": title})
+        return jsonify({"reports": items})
+    except Exception as e:
+        return jsonify({"reports": [], "error": str(e)}), 200
+
+
+@bp_reports.route("/reports/")
+def reports_index():
+    """GET /reports/ → HTML index listing all reports."""
+    data = api_reports_list().get_json(force=True) or {}
+    items = data.get("reports", [])
+    if not items:
+        body = (
+            "<h1>No reports yet</h1>"
+            "<p>Create a <code>.md</code> file in "
+            "<code>~/.clawmetry/reports/</code> with embedded SQL blocks:</p>"
+            "<pre>&lt;!-- duckdb: SELECT count(*) FROM sessions --&gt;</pre>"
+            "<p>Then refresh this page.</p>"
+        )
+    else:
+        links = "".join(
+            f'<li><a href="/reports/{html.escape(r["slug"])}">'
+            f'{html.escape(r["title"])}</a></li>'
+            for r in items
+        )
+        body = f"<h1>Reports</h1><ul>{links}</ul>"
+    page = (
+        f"<!DOCTYPE html><html lang=\"en\"><head><meta charset=\"utf-8\">"
+        f"<title>Reports — ClawMetry</title><style>{_CSS}</style></head>"
+        f"<body>{body}</body></html>"
+    )
+    return Response(page, content_type="text/html; charset=utf-8")
+
+
+@bp_reports.route("/reports/<slug>")
+def reports_render(slug: str):
+    """GET /reports/<slug> → rendered HTML report."""
+    slug = _safe_slug(slug)
+    if not slug:
+        return Response("Invalid report name.", status=400)
+    path = os.path.join(_reports_dir(), f"{slug}.md")
+    if not os.path.isfile(path):
+        return Response(f"Report '{slug}' not found.", status=404, content_type="text/plain")
+    try:
+        with open(path, encoding="utf-8", errors="replace") as fh:
+            content = fh.read()
+    except Exception as e:
+        return Response(f"Cannot read report: {e}", status=500, content_type="text/plain")
+    return Response(_render_page(slug, content), content_type="text/html; charset=utf-8")
+
+
+@bp_reports.route("/reports/<slug>/export.csv")
+def reports_export_csv(slug: str):
+    """GET /reports/<slug>/export.csv?block=<n> → CSV of SQL block n."""
+    slug = _safe_slug(slug)
+    if not slug:
+        return Response("Invalid report name.", status=400)
+    try:
+        block_idx = int(request.args.get("block", "0"))
+    except (TypeError, ValueError):
+        return Response("'block' must be an integer", status=400)
+    path = os.path.join(_reports_dir(), f"{slug}.md")
+    if not os.path.isfile(path):
+        return Response(f"Report '{slug}' not found.", status=404)
+    with open(path, encoding="utf-8", errors="replace") as fh:
+        content = fh.read()
+    blocks = _BLOCK_RE.findall(content)
+    if block_idx >= len(blocks):
+        return Response(
+            f"Block {block_idx} not found (report has {len(blocks)} block(s)).",
+            status=404,
+        )
+    rows, err = _run_sql(blocks[block_idx].strip())
+    if err:
+        return Response(f"Query error: {err}", status=400)
+    if not rows:
+        return Response("", content_type="text/csv")
+    buf = io.StringIO()
+    writer = csv.DictWriter(buf, fieldnames=list(rows[0].keys()))
+    writer.writeheader()
+    writer.writerows(rows)
+    fname = f"{slug}-block{block_idx}.csv"
+    return Response(
+        buf.getvalue(),
+        content_type="text/csv",
+        headers={"Content-Disposition": f'attachment; filename="{fname}"'},
+    )

--- a/tests/test_reports_blueprint.py
+++ b/tests/test_reports_blueprint.py
@@ -1,0 +1,220 @@
+"""Unit tests for routes/reports.py (issue #1005).
+
+Tests the blueprint endpoints and helper functions without requiring a running
+DuckDB — the SQL execution is mocked out.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+# Make sure project root is on the path
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+class TestMdToHtml(unittest.TestCase):
+    def setUp(self):
+        from routes.reports import _md_to_html
+        self.md_to_html = _md_to_html
+
+    def test_h1(self):
+        self.assertIn("<h1>Hello</h1>", self.md_to_html("# Hello"))
+
+    def test_h2(self):
+        self.assertIn("<h2>World</h2>", self.md_to_html("## World"))
+
+    def test_h3(self):
+        self.assertIn("<h3>Foo</h3>", self.md_to_html("### Foo"))
+
+    def test_paragraph(self):
+        self.assertIn("<p>Just text</p>", self.md_to_html("Just text"))
+
+    def test_bold(self):
+        result = self.md_to_html("**bold**")
+        self.assertIn("<strong>bold</strong>", result)
+
+    def test_italic(self):
+        result = self.md_to_html("*italic*")
+        self.assertIn("<em>italic</em>", result)
+
+    def test_list_item(self):
+        self.assertIn("<li>item</li>", self.md_to_html("- item"))
+
+    def test_escapes_html(self):
+        result = self.md_to_html("a <script> tag")
+        self.assertNotIn("<script>", result)
+        self.assertIn("&lt;script&gt;", result)
+
+    def test_code_fence(self):
+        md = "```sql\nSELECT 1\n```"
+        result = self.md_to_html(md)
+        self.assertIn("<pre", result)
+        self.assertIn("SELECT 1", result)
+
+
+class TestRowsToTable(unittest.TestCase):
+    def setUp(self):
+        from routes.reports import _rows_to_html_table
+        self.rows_to_table = _rows_to_html_table
+
+    def test_empty(self):
+        result = self.rows_to_table([])
+        self.assertIn("No results", result)
+
+    def test_single_row(self):
+        result = self.rows_to_table([{"count": 42, "name": "foo"}])
+        self.assertIn("<th>count</th>", result)
+        self.assertIn("<td>42</td>", result)
+        self.assertIn("<td>foo</td>", result)
+
+    def test_none_value(self):
+        result = self.rows_to_table([{"col": None}])
+        self.assertIn("<td></td>", result)
+
+    def test_escapes_values(self):
+        result = self.rows_to_table([{"col": "<script>xss</script>"}])
+        self.assertNotIn("<script>", result)
+        self.assertIn("&lt;script&gt;", result)
+
+
+class TestRunSql(unittest.TestCase):
+    def test_rejects_long_sql(self):
+        from routes.reports import _run_sql
+        rows, err = _run_sql("SELECT 1  " + "x" * 2001)
+        self.assertIsNotNone(err)
+        self.assertIn("too long", err)
+
+    def test_rejects_drop(self):
+        from routes.reports import _run_sql
+        rows, err = _run_sql("DROP TABLE sessions")
+        self.assertIsNotNone(err)
+        self.assertEqual(rows, [])
+
+    def test_accepts_select_via_mock(self):
+        from routes.reports import _run_sql
+        with patch("routes.reports.local_store_via_daemon", return_value=None, create=True):
+            with patch("routes.reports._run_sql") as mock_run:
+                mock_run.return_value = ([{"n": 1}], None)
+                rows, err = mock_run("SELECT 1 AS n")
+        self.assertIsNone(err)
+        self.assertEqual(rows[0]["n"], 1)
+
+
+class TestSafeSlug(unittest.TestCase):
+    def test_clean_slug(self):
+        from routes.reports import _safe_slug
+        self.assertEqual(_safe_slug("my-report_v2"), "my-report_v2")
+
+    def test_strips_traversal(self):
+        from routes.reports import _safe_slug
+        self.assertEqual(_safe_slug("../../etc/passwd"), "etcpasswd")
+
+    def test_strips_spaces(self):
+        from routes.reports import _safe_slug
+        self.assertEqual(_safe_slug("my report"), "myreport")
+
+
+class TestBlueprintEndpoints(unittest.TestCase):
+    def setUp(self):
+        from flask import Flask
+        from routes.reports import bp_reports
+        app = Flask(__name__)
+        app.register_blueprint(bp_reports)
+        app.config["TESTING"] = True
+        self.client = app.test_client()
+        self.tmpdir = tempfile.mkdtemp()
+
+    def _patch_reports_dir(self):
+        return patch("routes.reports._reports_dir", return_value=self.tmpdir)
+
+    def test_api_reports_empty(self):
+        with self._patch_reports_dir():
+            r = self.client.get("/api/reports")
+        self.assertEqual(r.status_code, 200)
+        data = r.get_json()
+        self.assertEqual(data["reports"], [])
+
+    def test_api_reports_lists_md_files(self):
+        with open(os.path.join(self.tmpdir, "myreport.md"), "w") as f:
+            f.write("# My Report\n\nSome content")
+        with self._patch_reports_dir():
+            r = self.client.get("/api/reports")
+        data = r.get_json()
+        self.assertEqual(len(data["reports"]), 1)
+        self.assertEqual(data["reports"][0]["slug"], "myreport")
+        self.assertEqual(data["reports"][0]["title"], "My Report")
+
+    def test_reports_index_empty(self):
+        with self._patch_reports_dir():
+            r = self.client.get("/reports/")
+        self.assertEqual(r.status_code, 200)
+        self.assertIn(b"No reports yet", r.data)
+
+    def test_reports_404_for_missing(self):
+        with self._patch_reports_dir():
+            r = self.client.get("/reports/nonexistent")
+        self.assertEqual(r.status_code, 404)
+
+    def test_reports_render_prose(self):
+        with open(os.path.join(self.tmpdir, "demo.md"), "w") as f:
+            f.write("# Demo\n\nHello world.")
+        with self._patch_reports_dir():
+            with patch("routes.reports._run_sql", return_value=([], None)):
+                r = self.client.get("/reports/demo")
+        self.assertEqual(r.status_code, 200)
+        self.assertIn(b"<h1>Demo</h1>", r.data)
+        self.assertIn(b"Hello world.", r.data)
+
+    def test_reports_render_sql_block(self):
+        with open(os.path.join(self.tmpdir, "qry.md"), "w") as f:
+            f.write("# Q\n<!-- duckdb: SELECT count(*) AS n FROM sessions -->\n")
+        with self._patch_reports_dir():
+            with patch("routes.reports._run_sql", return_value=([{"n": 5}], None)):
+                r = self.client.get("/reports/qry")
+        self.assertEqual(r.status_code, 200)
+        self.assertIn(b"<th>n</th>", r.data)
+        self.assertIn(b"<td>5</td>", r.data)
+
+    def test_reports_render_sql_error(self):
+        with open(os.path.join(self.tmpdir, "bad.md"), "w") as f:
+            f.write("<!-- duckdb: SELECT x FROM nonexistent -->")
+        with self._patch_reports_dir():
+            with patch("routes.reports._run_sql", return_value=([], "Table not found")):
+                r = self.client.get("/reports/bad")
+        self.assertEqual(r.status_code, 200)
+        self.assertIn(b"Table not found", r.data)
+
+    def test_export_csv_missing_report(self):
+        with self._patch_reports_dir():
+            r = self.client.get("/reports/ghost/export.csv")
+        self.assertEqual(r.status_code, 404)
+
+    def test_export_csv_block_out_of_range(self):
+        with open(os.path.join(self.tmpdir, "one.md"), "w") as f:
+            f.write("<!-- duckdb: SELECT 1 -->\n")
+        with self._patch_reports_dir():
+            r = self.client.get("/reports/one/export.csv?block=5")
+        self.assertEqual(r.status_code, 404)
+
+    def test_export_csv_returns_csv(self):
+        with open(os.path.join(self.tmpdir, "data.md"), "w") as f:
+            f.write("<!-- duckdb: SELECT 1 AS n -->\n")
+        with self._patch_reports_dir():
+            with patch("routes.reports._run_sql", return_value=([{"n": 1}, {"n": 2}], None)):
+                r = self.client.get("/reports/data/export.csv?block=0")
+        self.assertEqual(r.status_code, 200)
+        self.assertIn(b"n\r\n", r.data)
+        self.assertIn(b"1\r\n", r.data)
+
+    def test_bad_slug_returns_400(self):
+        with self._patch_reports_dir():
+            r = self.client.get("/reports/   /export.csv")
+        # Flask routing won't match a path with spaces; either 404 or 400 is fine
+        self.assertIn(r.status_code, (400, 404))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #1005

## Summary

- **New `routes/reports.py`** (`bp_reports` Blueprint): Users write `.md` files in `~/.clawmetry/reports/` and embed live DuckDB queries with `<!-- duckdb: SELECT ... -->` comment blocks. Three endpoints: `GET /api/reports` (list), `GET /reports/<slug>` (rendered HTML page), `GET /reports/<slug>/export.csv?block=<n>` (CSV export of any SQL block). SQL runs through `raw_select_safe` via the daemon proxy — no writer-lock contention.
- **`dashboard.py`**: imports and registers `bp_reports`.
- **`clawmetry/cli.py`**: adds `clawmetry reports [--port N]` subcommand that opens `/reports/` in the browser.
- **`tests/test_reports_blueprint.py`**: 30 unit tests (all green) covering markdown rendering, HTML escaping, SQL rejection, all four endpoints, and CSV export. No DuckDB required to run them.

Skips the Evidence.dev / Node.js approach from the original issue — that violates CLAUDE.md's no-build-step, no-npm rules. Pure-Python alternative with zero new pip dependencies.

## Test plan

- `python3 -m pytest tests/test_reports_blueprint.py -v` → 30/30 pass
- Create `~/.clawmetry/reports/demo.md`, visit `http://localhost:8900/reports/demo`
- Add `<!-- duckdb: SELECT count(*) FROM sessions -->` block, confirm table renders
- Visit `/reports/demo/export.csv?block=0`, confirm CSV download

---
_Generated by [Claude Code](https://claude.ai/code/session_014K6zmUQgKbPqeQj1xdbyu4)_