### PR TITLE
feat(entitlement): channel_spec_batch + /api/entitlement/channel-spec-batch

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -5399,6 +5399,61 @@ def channel_spec(channel: str) -> dict | None:
         return None
 
 
+def channel_spec_batch(channels) -> dict:
+    """Plural sibling of :func:`channel_spec`: return spec rows for a
+    caller-supplied subset of chat-channel ids in one pass.
+
+    Mirrors :func:`feature_spec_batch` / :func:`runtime_spec_batch` for the
+    chat-channel axis. Lets a channel-picker or "which of these adapters
+    does this account have on" tooltip hydrate the N visible rows off
+    **one** round-trip instead of N calls to
+    ``/api/entitlement/channel-spec``. Each returned row is byte-identical
+    to a row from :func:`channel_catalog` for the same id -- a parity test
+    pins this so the scalar / bulk / batch accessors cannot drift.
+
+    Shape::
+
+        {
+          "channels": [<spec_row>, ...],   # one per known supplied id, in supply order
+          "unknown":  ["bogus_id", ...],   # supplied ids not in ALL_CHANNELS, in supply order
+        }
+
+    Supplied ids are normalised via :func:`_normalise_csv` (whitespace
+    stripped, lowercased, duplicates dropped while preserving first-seen
+    order) so the response is stable across repeated calls. Empty input
+    returns ``{"channels": [], "unknown": []}`` -- the HTTP wrapper turns
+    that into a 400, this helper does not raise.
+
+    Every chat channel is FREE at every tier (the ``channels`` capacity
+    axis governs how many concurrent channels each plan admits, not which
+    adapters unlock), so every row reports ``free=True`` /
+    ``allowed=True`` / ``locked=False`` / ``entitled=True`` regardless of
+    the resolved tier -- grace vs enforce yields byte-identical rows.
+    Never raises: a resolver failure short-circuits to the OSS-free
+    fallback so the matrix keeps rendering.
+    """
+    chans = _normalise_csv(channels)
+    try:
+        ent = get_entitlement()
+    except Exception as exc:
+        logger.warning("entitlements: channel_spec_batch falling back to grace: %s", exc)
+        ent = _oss_free()
+    rows: list[dict] = []
+    unknown: list[str] = []
+    for cid in chans:
+        if cid in ALL_CHANNELS:
+            try:
+                rows.append(_channel_spec_row(ent, cid))
+            except Exception as exc:
+                logger.warning(
+                    "entitlements: channel_spec_batch row %r failed: %s", cid, exc
+                )
+                unknown.append(cid)
+        else:
+            unknown.append(cid)
+    return {"channels": rows, "unknown": unknown}
+
+
 def channel_catalog_at(tier: str) -> list[dict] | None:
     """What-if sibling of :func:`channel_catalog`: catalogue rows for the
     chat-channel axis with every row computed as if the install were on

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -3867,6 +3867,78 @@ def api_entitlement_channel_spec():
         return jsonify({"error": "channel-spec failed"}), 500
 
 
+@bp_entitlement.route("/api/entitlement/channel-spec-batch")
+def api_entitlement_channel_spec_batch():
+    """``GET /api/entitlement/channel-spec-batch?channels=a,b,c`` -- plural
+    sibling of ``/api/entitlement/channel-spec``.
+
+    Returns the full catalogue spec row for every supplied chat-channel id
+    in one round-trip. Mirrors :func:`api_entitlement_feature_spec_batch` /
+    :func:`api_entitlement_runtime_spec_batch` for the chat-channel axis;
+    together they let a Settings or paywall matrix UI hydrate the per-row
+    state ("lock badge + required tier + entitled flag") for a viewport's
+    worth of features + runtimes + channels off THREE calls instead of N +
+    M + K.
+
+    Each ``channels[]`` entry is byte-identical to a row from
+    :func:`entitlements.channel_catalog` -- a parity test pins this so the
+    scalar / bulk / batch accessors cannot drift. Supplied ids are
+    normalised (whitespace stripped, lowercased, duplicates dropped while
+    preserving first-seen order). Unknown ids do not 404 the call -- they
+    are echoed in ``unknown[]`` so a partially-bad caller still gets rows
+    back for the valid ids alongside a list of what was dropped.
+
+    Because every chat channel is FREE at every tier (the ``channels``
+    capacity axis governs how many concurrent channels each plan admits,
+    not which adapters unlock), every returned row is ``free=True`` /
+    ``allowed=True`` / ``locked=False`` / ``entitled=True`` regardless of
+    the resolved tier.
+
+    Response shape::
+
+        {
+          "channels":          [<spec_row>, ...],
+          "unknown":           ["bogus_id", ...],
+          "current_tier":      "...",
+          "current_tier_rank": <int>,
+          "grace":             <bool>,
+          "enforced":          <bool>,
+        }
+
+    - **400** when ``channels=`` is missing or empty after normalisation
+    - **Never 5xxs**: a resolver crash short-circuits to the OSS-free
+      shape (empty rows, ``current_tier=oss``, ``grace=true``).
+    """
+    try:
+        channels = _parse_csv_arg("channels")
+        if not channels:
+            return (
+                jsonify({"error": "supply channels=<csv>"}),
+                400,
+            )
+        from clawmetry import entitlements as _ent
+
+        batch = _ent.channel_spec_batch(channels)
+        ent = _ent.get_entitlement()
+        batch["current_tier"] = ent.tier
+        batch["current_tier_rank"] = _ent.tier_rank(ent.tier)
+        batch["grace"] = bool(ent.grace)
+        batch["enforced"] = _ent.is_enforced()
+        return jsonify(batch)
+    except Exception as exc:
+        logger.warning("api_entitlement_channel_spec_batch: error: %s", exc)
+        return jsonify(
+            {
+                "channels": [],
+                "unknown": [],
+                "current_tier": "oss",
+                "current_tier_rank": 0,
+                "grace": True,
+                "enforced": False,
+            }
+        )
+
+
 @bp_entitlement.route("/api/entitlement/feature-spec-batch")
 def api_entitlement_feature_spec_batch():
     """``GET /api/entitlement/feature-spec-batch?features=a,b,c`` -- plural

--- a/tests/test_entitlement_channel_spec_batch.py
+++ b/tests/test_entitlement_channel_spec_batch.py
@@ -1,0 +1,317 @@
+"""Tests for ``channel_spec_batch(channels)`` and ``GET
+/api/entitlement/channel-spec-batch``.
+
+``channel_spec_batch`` is the plural / caller-subset sibling of
+``channel_spec`` on the chat-channel axis -- the batch accessor a paywall
+matrix UI hydrates the N rows it is about to render off in ONE round-trip
+instead of N calls to ``/api/entitlement/channel-spec``. Each returned
+row must be byte-identical to the corresponding row from
+``channel_catalog()`` so the scalar / bulk / batch accessors cannot
+drift; the parity tests below pin that.
+
+Coverage:
+
+* row shape matches ``channel_catalog`` (and matches the scalar
+  ``channel_spec`` row for the same id)
+* input is normalised (whitespace stripped, lowercased, duplicates
+  dropped, first-seen order preserved)
+* unknown ids are echoed in ``unknown[]`` instead of 404'ing the call
+* every chat channel is FREE at every tier, so grace vs enforce yields
+  byte-identical rows and no row is ever ``locked`` regardless of the
+  resolved tier
+* the helper never raises -- a resolver crash short-circuits to the
+  OSS-free fallback so the matrix keeps rendering
+* the HTTP endpoint 400s on missing / empty input, never 5xxs on a
+  resolver crash, and carries the standard ``grace`` / ``enforced`` /
+  ``current_tier`` / ``current_tier_rank`` envelope fields
+"""
+from __future__ import annotations
+
+import importlib
+import json
+
+import pytest
+
+
+_CHANNEL_SPEC_KEYS = {
+    "id",
+    "label",
+    "free",
+    "tier",
+    "allowed",
+    "locked",
+    "entitled",
+}
+
+_ENVELOPE_KEYS = {"current_tier", "current_tier_rank", "grace", "enforced"}
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    """Fresh entitlements module with HOME pointed at an empty tmp dir so no
+    real ~/.clawmetry/license.key or cloud_plan.json leaks in. Enforcement off
+    by default (grace mode)."""
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from flask import Flask
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# ── helper: shape + parity ────────────────────────────────────────────────────
+
+
+def test_batch_empty_input_returns_empty_envelope(ent):
+    assert ent.channel_spec_batch([]) == {"channels": [], "unknown": []}
+
+
+def test_batch_none_input_returns_empty_envelope(ent):
+    assert ent.channel_spec_batch(None) == {"channels": [], "unknown": []}
+
+
+def test_batch_row_shape_matches_catalog(ent):
+    ch = next(iter(ent.ALL_CHANNELS))
+    body = ent.channel_spec_batch([ch])
+    assert len(body["channels"]) == 1
+    assert set(body["channels"][0].keys()) == _CHANNEL_SPEC_KEYS
+
+
+def test_batch_every_row_matches_channel_spec_exactly(ent):
+    ids = sorted(ent.ALL_CHANNELS)
+    body = ent.channel_spec_batch(ids)
+    rows_by_id = {row["id"]: row for row in body["channels"]}
+    assert set(rows_by_id) == set(ids)
+    for cid in ids:
+        assert rows_by_id[cid] == ent.channel_spec(cid), cid
+
+
+def test_batch_rows_match_channel_catalog(ent):
+    """Pin scalar / bulk / batch no-drift: every batch row is byte-identical
+    to the same row from ``channel_catalog()``."""
+    cat_by_id = {row["id"]: row for row in ent.channel_catalog()}
+    ids = list(cat_by_id)
+    body = ent.channel_spec_batch(ids)
+    assert body["unknown"] == []
+    for row in body["channels"]:
+        assert row == cat_by_id[row["id"]], row["id"]
+
+
+# ── helper: normalisation ────────────────────────────────────────────────────
+
+
+def test_batch_supply_order_preserved(ent):
+    ids = list(ent.ALL_CHANNELS)[:3]
+    body = ent.channel_spec_batch(list(reversed(ids)))
+    assert [r["id"] for r in body["channels"]] == list(reversed(ids))
+
+
+def test_batch_string_csv_input(ent):
+    ids = list(ent.ALL_CHANNELS)[:3]
+    csv = ",".join(ids)
+    body = ent.channel_spec_batch(csv)
+    assert [r["id"] for r in body["channels"]] == ids
+
+
+def test_batch_whitespace_and_case_normalised(ent):
+    ch = next(iter(ent.ALL_CHANNELS))
+    body = ent.channel_spec_batch([f"  {ch.upper()}  "])
+    assert [r["id"] for r in body["channels"]] == [ch]
+
+
+def test_batch_duplicates_dropped_first_seen_wins(ent):
+    ids = list(ent.ALL_CHANNELS)[:2]
+    a, b = ids
+    body = ent.channel_spec_batch([a, a, b, a])
+    assert [r["id"] for r in body["channels"]] == [a, b]
+
+
+def test_batch_unknown_ids_echoed_in_unknown(ent):
+    ch = next(iter(ent.ALL_CHANNELS))
+    body = ent.channel_spec_batch([ch, "nope_xyz", "also_bogus"])
+    assert [r["id"] for r in body["channels"]] == [ch]
+    assert body["unknown"] == ["nope_xyz", "also_bogus"]
+
+
+def test_batch_unknown_only_returns_empty_channels(ent):
+    body = ent.channel_spec_batch(["nope_xyz", "also_bogus"])
+    assert body["channels"] == []
+    assert body["unknown"] == ["nope_xyz", "also_bogus"]
+
+
+# ── helper: always-free invariant ────────────────────────────────────────────
+
+
+def test_batch_every_channel_is_always_free(ent):
+    body = ent.channel_spec_batch(sorted(ent.ALL_CHANNELS))
+    assert len(body["channels"]) == len(ent.ALL_CHANNELS)
+    for row in body["channels"]:
+        assert row["free"] is True, row["id"]
+        assert row["tier"] == "free", row["id"]
+        assert row["allowed"] is True, row["id"]
+        assert row["locked"] is False, row["id"]
+        assert row["entitled"] is True, row["id"]
+
+
+def test_batch_grace_locks_nothing(ent):
+    body = ent.channel_spec_batch(sorted(ent.ALL_CHANNELS))
+    assert all(r["locked"] is False for r in body["channels"])
+    assert all(r["allowed"] is True for r in body["channels"])
+
+
+def test_batch_enforce_oss_still_unlocks_every_channel(ent, monkeypatch):
+    """Enforcement is a no-op on the channel axis, so a batch under
+    enforce-mode is byte-identical to a batch under grace."""
+    ids = sorted(ent.ALL_CHANNELS)
+    grace_body = ent.channel_spec_batch(ids)
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    enforced_body = ent.channel_spec_batch(ids)
+    assert enforced_body["channels"] == grace_body["channels"]
+    assert enforced_body["unknown"] == grace_body["unknown"]
+
+
+def test_batch_enforce_cloud_pro_yields_identical_rows(ent, monkeypatch, tmp_path):
+    ids = sorted(ent.ALL_CHANNELS)
+    grace_body = ent.channel_spec_batch(ids)
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    cache = tmp_path / ".clawmetry" / "cloud_plan.json"
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    cache.write_text(json.dumps({"plan": "cloud_pro"}))
+    ent.invalidate()
+    enforced_body = ent.channel_spec_batch(ids)
+    assert enforced_body["channels"] == grace_body["channels"]
+
+
+# ── helper: never-raise ──────────────────────────────────────────────────────
+
+
+def test_batch_never_raises_when_resolver_crashes(ent, monkeypatch):
+    def boom(*_a, **_kw):
+        raise RuntimeError("simulated resolver failure")
+
+    monkeypatch.setattr(ent, "get_entitlement", boom)
+    ch = next(iter(ent.ALL_CHANNELS))
+    body = ent.channel_spec_batch([ch])
+    assert len(body["channels"]) == 1
+    row = body["channels"][0]
+    assert row["id"] == ch
+    # Every channel is free under the OSS-free fallback -- matches the
+    # never-crash contract on ``channel_catalog()`` / ``channel_spec``.
+    assert row["free"] is True
+    assert row["locked"] is False
+
+
+# ── HTTP endpoint ────────────────────────────────────────────────────────────
+
+
+def test_endpoint_returns_rows_and_envelope(client, ent):
+    ids = list(ent.ALL_CHANNELS)[:2]
+    csv = ",".join(ids)
+    resp = client.get(f"/api/entitlement/channel-spec-batch?channels={csv}")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert _ENVELOPE_KEYS <= set(body.keys())
+    assert [r["id"] for r in body["channels"]] == ids
+    assert body["unknown"] == []
+    assert body["grace"] is True
+    assert body["enforced"] is False
+
+
+def test_endpoint_missing_arg_returns_400(client):
+    resp = client.get("/api/entitlement/channel-spec-batch")
+    assert resp.status_code == 400
+    assert "error" in resp.get_json()
+
+
+def test_endpoint_blank_arg_returns_400(client):
+    resp = client.get("/api/entitlement/channel-spec-batch?channels=%20%20,%20")
+    assert resp.status_code == 400
+
+
+def test_endpoint_unknown_only_returns_200(client):
+    """Unknown ids alone do not 400 -- they normalise to a non-empty list
+    so the helper runs and returns ``unknown=[...]`` with empty channels."""
+    resp = client.get(
+        "/api/entitlement/channel-spec-batch?channels=not_a_channel,also_bogus"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["channels"] == []
+    assert body["unknown"] == ["not_a_channel", "also_bogus"]
+
+
+def test_endpoint_lowercases_and_dedupes(client, ent):
+    ch = next(iter(ent.ALL_CHANNELS))
+    resp = client.get(
+        f"/api/entitlement/channel-spec-batch?channels={ch.upper()},{ch}"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert [r["id"] for r in body["channels"]] == [ch]
+
+
+def test_endpoint_every_known_channel_round_trips(client, ent):
+    csv = ",".join(sorted(ent.ALL_CHANNELS))
+    resp = client.get(f"/api/entitlement/channel-spec-batch?channels={csv}")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert set(r["id"] for r in body["channels"]) == set(ent.ALL_CHANNELS)
+    assert body["unknown"] == []
+
+
+def test_endpoint_body_channels_byte_equal_catalog_rows(client, ent):
+    """The endpoint body must byte-equal the corresponding rows in
+    ``/api/entitlement/channel-catalog`` -- pins the scalar / bulk /
+    batch no-drift contract on the wire."""
+    cat_resp = client.get("/api/entitlement/channel-catalog")
+    assert cat_resp.status_code == 200
+    cat_by_id = {row["id"]: row for row in cat_resp.get_json()["channels"]}
+    csv = ",".join(sorted(cat_by_id))
+    resp = client.get(f"/api/entitlement/channel-spec-batch?channels={csv}")
+    assert resp.status_code == 200
+    for row in resp.get_json()["channels"]:
+        assert row == cat_by_id[row["id"]], row["id"]
+
+
+def test_endpoint_envelope_carries_resolved_tier(client, ent, monkeypatch, tmp_path):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    cache = tmp_path / ".clawmetry" / "cloud_plan.json"
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    cache.write_text(json.dumps({"plan": "cloud_pro"}))
+    ent.invalidate()
+    ch = next(iter(ent.ALL_CHANNELS))
+    resp = client.get(f"/api/entitlement/channel-spec-batch?channels={ch}")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["current_tier"] == ent.TIER_CLOUD_PRO
+    assert body["current_tier_rank"] == ent.tier_rank(ent.TIER_CLOUD_PRO)
+    assert body["grace"] is False
+    assert body["enforced"] is True
+
+
+def test_endpoint_never_5xxs_when_resolver_crashes(client, ent, monkeypatch):
+    def boom(*_a, **_kw):
+        raise RuntimeError("simulated resolver failure")
+
+    monkeypatch.setattr(ent, "get_entitlement", boom)
+    ch = next(iter(ent.ALL_CHANNELS))
+    resp = client.get(f"/api/entitlement/channel-spec-batch?channels={ch}")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    # Endpoint short-circuits to the OSS-free envelope on resolver failure.
+    assert body["current_tier"] == "oss"
+    assert body["grace"] is True
+    assert body["enforced"] is False


### PR DESCRIPTION
## Summary

Adds the **plural sibling of `channel_spec`** on the chat-channel axis so a paywall matrix / channel-picker UI can hydrate the N visible rows off ONE round-trip instead of N calls to `/api/entitlement/channel-spec`.

Mirrors the existing `feature_spec_batch` / `runtime_spec_batch` pair for the channel axis; together the three batch endpoints let a Settings-style UI hydrate every axis off THREE calls instead of N + M + K.

### What's new

- **`clawmetry/entitlements.py`** — `channel_spec_batch(channels) -> dict` — plural sibling of `channel_spec`. Each returned row is byte-identical to a row from `channel_catalog()` for the same id, and to the scalar `channel_spec` row for the same id — parity tests pin this so the scalar / bulk / batch accessors cannot drift.
- **`routes/entitlement.py`** — `GET /api/entitlement/channel-spec-batch?channels=a,b,c` on `bp_entitlement`. Envelope carries `current_tier` / `current_tier_rank` / `grace` / `enforced` matching sibling batch endpoints.
- **`tests/test_entitlement_channel_spec_batch.py`** — 25 tests, all green.

### Contract (matches the existing `_spec_batch` pattern)

- Supplied ids are normalised via `_normalise_csv` — whitespace stripped, lowercased, duplicates dropped, first-seen order preserved
- Unknown ids are echoed in `unknown[]` instead of 404'ing the call, so a partially-bad caller still gets rows back for the valid ids
- Endpoint `400`s on missing / empty input
- Endpoint **never `5xx`s** on a resolver crash — short-circuits to the OSS-free envelope
- Every chat channel is FREE at every tier (the `channels` capacity axis governs how many concurrent channels each plan admits, not which adapters unlock), so every row reports `free=True` / `allowed=True` / `locked=False` / `entitled=True` regardless of the resolved tier — grace vs enforce yields byte-identical rows
- **Zero behaviour change while grace mode is on (default until enforcement flips)**

### Response shape

```json
{
  "channels":          [<spec_row>, ...],
  "unknown":           ["bogus_id", ...],
  "current_tier":      "...",
  "current_tier_rank": 0,
  "grace":             true,
  "enforced":          false
}
```

### Test coverage (25 tests)

- Row shape + parity with `channel_catalog` and `channel_spec`
- Input normalisation (order, whitespace, case, dedup, csv string, unknown echo)
- Always-free invariant + grace / enforce-OSS / enforce-cloud_pro all yield byte-identical rows
- Never-raise on resolver crash
- HTTP: 200 with envelope, 400 on missing/blank, 200 on unknown-only, byte-equal round-trip against `/api/entitlement/channel-catalog`, envelope carries resolved tier, never 5xxs when resolver crashes

## Test plan

- [x] `python -m pytest tests/test_entitlement_channel_spec_batch.py -v` — 25/25 pass locally
- [x] `python -m pytest tests/test_entitlement_channel_spec.py tests/test_entitlement_spec_batch.py tests/test_entitlement_channel_catalog.py` — 88/88 pass (no neighbour regressions)
- [x] `python -m py_compile clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_channel_spec_batch.py` — clean
- [x] Broader entitlement suite: 4,813 passed, 4 skipped in the sandbox (3 pre-existing collection errors are `cryptography` / `_cffi_backend` env issues in the sandbox, unrelated to this diff — will re-verify in CI)

## Local operator verification checklist

I cannot reach the local daemon, `~/.openclaw`, the live cloud snapshot, or a browser from this environment. Once CI is green, please:

- [ ] Copy the changed files into `~/.clawmetry/lib/pythonX.Y/site-packages/clawmetry/` (and the new `routes/entitlement.py` into the package's `routes/` dir)
- [ ] Clear `__pycache__/` under those two paths
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` to restart the daemon
- [ ] `curl -s http://localhost:8900/api/entitlement/channel-spec-batch?channels=telegram,signal,whatsapp | jq` — confirm 3 rows + envelope + `unknown: []`
- [ ] `curl -s http://localhost:8900/api/entitlement/channel-spec-batch?channels=telegram,not_a_channel | jq` — confirm 1 row + `unknown: ["not_a_channel"]`
- [ ] `curl -s -o /dev/null -w "%{http_code}\n" http://localhost:8900/api/entitlement/channel-spec-batch` — expect 400
- [ ] Decrypt the live cloud snapshot, spot-check that nothing else regressed
- [ ] Browser-check the Settings / paywall-matrix view still hydrates cleanly

Kept as **DRAFT** — the operator handles local-daemon verification, live-cloud verification, release, and merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TNa4Lo9bsNeMfAcdhZgcSx)_