### PR TITLE
feat(entitlement): channel_spec_at + /api/entitlement/channel-spec-at

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -5494,6 +5494,64 @@ def channel_catalog_at(tier: str) -> list[dict] | None:
     return [_channel_spec_row(ent, ch) for ch in sorted(ALL_CHANNELS)]
 
 
+def channel_spec_at(tier: str, channel: str) -> dict | None:
+    """Scalar what-if sibling of :func:`channel_catalog_at`: the single
+    catalogue row for ``channel`` computed as if the install were on
+    ``tier``.
+
+    Channel-axis analogue of :func:`feature_spec_at` /
+    :func:`runtime_spec_at`. Pairs with :func:`channel_spec` (scalar
+    against the LIVE resolved entitlement) the same way
+    :func:`channel_catalog_at` pairs with :func:`channel_catalog`. Lets a
+    pricing-comparison tooltip hydrate against ONE channel at a
+    hypothetical tier in one round-trip instead of fetching the full
+    :func:`channel_catalog_at` payload and filtering client-side.
+
+    The returned row matches a row from :func:`channel_catalog_at`
+    exactly (and, because every chat channel is free at every tier, is
+    byte-identical to the LIVE :func:`channel_spec` row for the same id)
+    -- a parity test pins this so the scalar and bulk what-if accessors
+    cannot drift.
+
+    Every chat channel is FREE at every tier (the ``channels`` capacity
+    axis governs how many concurrent channels each plan admits, not
+    which adapters unlock), so the row always comes back
+    ``free=True`` / ``allowed=True`` / ``locked=False`` /
+    ``entitled=True`` regardless of the perspective tier. That parity IS
+    the answer: the tooltip can render "channel included at every plan"
+    without having to hard-code that posture client-side.
+
+    Returns ``None`` for empty / unknown tier or channel ids (caller
+    renders "unknown tier" / "unknown channel" / 404). Never raises: a
+    synthesis failure short-circuits to the OSS-free fallback so the
+    row still renders.
+    """
+    try:
+        t = (tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if not t or t not in _TIER_ORDER:
+        return None
+    try:
+        ch = (channel or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if not ch or ch not in ALL_CHANNELS:
+        return None
+    try:
+        ent = _hypothetical_entitlement(t)
+    except Exception as exc:
+        logger.warning(
+            "entitlements: channel_spec_at falling back to OSS-free: %s", exc
+        )
+        ent = _oss_free()
+    try:
+        return _channel_spec_row(ent, ch)
+    except Exception as exc:
+        logger.warning("entitlements: channel_spec_at row build failed: %s", exc)
+        return None
+
+
 def channel_catalog_at_batch(tiers) -> dict:
     """Batch what-if sibling of :func:`channel_catalog_at`: channel
     catalogue rows for a caller-supplied set of hypothetical tiers in ONE

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -3939,6 +3939,82 @@ def api_entitlement_channel_spec_batch():
         )
 
 
+@bp_entitlement.route("/api/entitlement/channel-spec-at")
+def api_entitlement_channel_spec_at():
+    """``GET /api/entitlement/channel-spec-at?tier=<id>&channel=<id>`` --
+    scalar what-if sibling of ``/api/entitlement/channel-catalog-at``:
+    the single catalogue row for ``channel`` with ``allowed`` /
+    ``locked`` / ``entitled`` computed as if the install were on
+    ``tier``.
+
+    Channel-axis analogue of ``/feature-spec-at`` / ``/runtime-spec-at``
+    -- lets a pricing-comparison tooltip hydrate against ONE channel at
+    a hypothetical tier in one round-trip instead of fetching the full
+    ``/api/entitlement/channel-catalog-at`` payload and filtering
+    client-side. The returned row matches exactly one row from
+    :func:`entitlements.channel_catalog_at`.
+
+    Because every chat channel is FREE at every tier (the ``channels``
+    capacity axis governs how many concurrent channels each plan admits,
+    not which adapters unlock), the returned row is always
+    ``free=True`` / ``allowed=True`` / ``locked=False`` /
+    ``entitled=True`` regardless of the perspective tier.
+
+    - **400** when either ``tier=`` or ``channel=`` is missing / blank
+    - **404** when ``tier`` is unknown (not in
+      :data:`entitlements._TIER_ORDER`) or ``channel`` (after whitespace
+      + case normalisation) is unknown (not in
+      :data:`entitlements.ALL_CHANNELS`). The body carries ``which`` so a
+      caller can render the right "unknown ..." message.
+    - **Never 5xxs**: the helper internally falls back to the OSS-free
+      shape on resolver failure, so the endpoint still returns 200 with
+      a valid row.
+    """
+    raw_tier = request.args.get("tier")
+    tier = (raw_tier or "").strip().lower()
+    if not tier:
+        return jsonify({"error": "missing tier"}), 400
+    raw_channel = request.args.get("channel")
+    channel = (raw_channel or "").strip().lower()
+    if not channel:
+        return jsonify({"error": "missing channel"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        if tier not in _ent._TIER_ORDER:
+            return (
+                jsonify({"error": "unknown tier", "which": "tier", "tier": tier}),
+                404,
+            )
+        if channel not in _ent.ALL_CHANNELS:
+            return (
+                jsonify(
+                    {
+                        "error": "unknown channel",
+                        "which": "channel",
+                        "channel": channel,
+                    }
+                ),
+                404,
+            )
+        body = _ent.channel_spec_at(tier, channel)
+        if body is None:
+            return (
+                jsonify(
+                    {
+                        "error": "channel-spec-at failed",
+                        "tier": tier,
+                        "channel": channel,
+                    }
+                ),
+                404,
+            )
+        return jsonify({"tier": tier, "channel": channel, "spec": body})
+    except Exception as exc:
+        logger.warning("api_entitlement_channel_spec_at: error: %s", exc)
+        return jsonify({"error": "channel-spec-at failed"}), 500
+
+
 @bp_entitlement.route("/api/entitlement/feature-spec-batch")
 def api_entitlement_feature_spec_batch():
     """``GET /api/entitlement/feature-spec-batch?features=a,b,c`` -- plural

--- a/tests/test_entitlement_channel_spec_at.py
+++ b/tests/test_entitlement_channel_spec_at.py
@@ -1,0 +1,371 @@
+"""Tests for ``channel_spec_at(tier, channel)`` + ``GET
+/api/entitlement/channel-spec-at``.
+
+Scalar what-if sibling of :func:`channel_catalog_at`: one catalogue row
+for ``channel`` with ``allowed`` / ``locked`` / ``entitled`` computed as
+if the install were on ``tier``. Lets a pricing-comparison tooltip
+hydrate against ONE channel at a hypothetical tier in one round-trip
+without fetching the full ``channel_catalog_at`` payload.
+
+Pins:
+
+* the row shape matches a row from ``channel_catalog_at(tier)``
+  EXACTLY (so the scalar and bulk what-if accessors cannot drift) -- a
+  parity test enumerates every (tier, channel) pair
+* the row for a given channel is byte-identical to the LIVE
+  ``channel_spec(channel)`` row regardless of the perspective tier --
+  the always-free invariant on the channel axis (the ``channels``
+  capacity axis governs how many concurrent channels each plan admits,
+  not which adapters unlock)
+* every (tier, channel) pair in ``_TIER_ORDER`` x ``ALL_CHANNELS``
+  round-trips
+* unknown / empty / ``None`` / non-string tier ids return ``None``
+* unknown / empty / ``None`` / non-string channel ids return ``None``
+* both args are trimmed + lowercased before resolution
+* every row is ``free=True`` / ``allowed=True`` / ``locked=False`` /
+  ``entitled=True`` regardless of the perspective tier
+* the helper is independent of the live resolver: switching
+  enforcement or pointing HOME at a license cache does not change the
+  rows the what-if surface returns
+* the endpoint 400s on missing input, 404s on unknown ids (with
+  ``which`` so the caller can render the right "unknown ..." message),
+  and never 5xxs
+"""
+from __future__ import annotations
+
+import importlib
+import json
+
+import pytest
+from flask import Flask
+
+
+_ROW_KEYS = {
+    "id",
+    "label",
+    "free",
+    "tier",
+    "allowed",
+    "locked",
+    "entitled",
+}
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    """Fresh entitlements module with HOME pointed at an empty tmp dir
+    so no real ~/.clawmetry/license.key or cloud_plan.json leaks in.
+    Enforcement off by default (grace mode) -- ``channel_spec_at`` is
+    independent of either knob, so the fixture only needs to make sure
+    the live resolver does not surprise the test."""
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# ── shape ─────────────────────────────────────────────────────────────────────
+
+
+def test_row_shape_matches_catalog_at_row(ent):
+    ch = next(iter(ent.ALL_CHANNELS))
+    spec = ent.channel_spec_at(ent.TIER_CLOUD_PRO, ch)
+    assert spec is not None
+    assert set(spec.keys()) == _ROW_KEYS
+
+
+def test_parity_with_every_catalog_at_row(ent):
+    """For every (tier, channel) pair, the scalar what-if accessor
+    returns the same dict as the bulk what-if accessor. Pins the
+    scalar/bulk no-drift contract -- this is THE invariant the helper
+    exists to make hydratable in one round-trip."""
+    for tier in ent._TIER_ORDER:
+        bulk_by_id = {row["id"]: row for row in ent.channel_catalog_at(tier)}
+        for cid, row in bulk_by_id.items():
+            assert ent.channel_spec_at(tier, cid) == row, (tier, cid)
+
+
+def test_parity_with_live_channel_spec(ent):
+    """Because every chat channel is FREE at every tier, the scalar
+    what-if row must byte-equal the LIVE :func:`channel_spec` row for
+    the same id at every perspective tier -- the always-free posture is
+    the whole point of the channel axis, and this test pins it end to
+    end across the ``at`` surface."""
+    for ch in sorted(ent.ALL_CHANNELS):
+        live = ent.channel_spec(ch)
+        assert live is not None, ch
+        for tier in ent._TIER_ORDER:
+            assert ent.channel_spec_at(tier, ch) == live, (tier, ch)
+
+
+# ── round-trip ────────────────────────────────────────────────────────────────
+
+
+def test_every_pair_in_order_resolves(ent):
+    for tier in ent._TIER_ORDER:
+        for ch in ent.ALL_CHANNELS:
+            spec = ent.channel_spec_at(tier, ch)
+            assert spec is not None, (tier, ch)
+            assert spec["id"] == ch
+
+
+# ── invalid tier ──────────────────────────────────────────────────────────────
+
+
+def test_unknown_tier_returns_none(ent):
+    ch = next(iter(ent.ALL_CHANNELS))
+    assert ent.channel_spec_at("not_a_real_tier", ch) is None
+
+
+def test_empty_tier_returns_none(ent):
+    ch = next(iter(ent.ALL_CHANNELS))
+    assert ent.channel_spec_at("", ch) is None
+
+
+def test_none_tier_returns_none(ent):
+    ch = next(iter(ent.ALL_CHANNELS))
+    assert ent.channel_spec_at(None, ch) is None
+
+
+def test_non_string_tier_returns_none(ent):
+    ch = next(iter(ent.ALL_CHANNELS))
+    assert ent.channel_spec_at(123, ch) is None
+    assert ent.channel_spec_at(object(), ch) is None
+
+
+# ── invalid channel ───────────────────────────────────────────────────────────
+
+
+def test_unknown_channel_returns_none(ent):
+    assert ent.channel_spec_at(ent.TIER_CLOUD_PRO, "not_a_real_channel") is None
+
+
+def test_empty_channel_returns_none(ent):
+    assert ent.channel_spec_at(ent.TIER_CLOUD_PRO, "") is None
+
+
+def test_none_channel_returns_none(ent):
+    assert ent.channel_spec_at(ent.TIER_CLOUD_PRO, None) is None
+
+
+def test_non_string_channel_returns_none(ent):
+    assert ent.channel_spec_at(ent.TIER_CLOUD_PRO, 123) is None
+    assert ent.channel_spec_at(ent.TIER_CLOUD_PRO, object()) is None
+
+
+# ── normalisation ─────────────────────────────────────────────────────────────
+
+
+def test_inputs_are_lowercased_and_trimmed(ent):
+    ch = next(iter(ent.ALL_CHANNELS))
+    a = ent.channel_spec_at(ent.TIER_CLOUD_PRO, ch)
+    b = ent.channel_spec_at(ent.TIER_CLOUD_PRO.upper(), ch.upper())
+    c = ent.channel_spec_at(f"  {ent.TIER_CLOUD_PRO}  ", f"  {ch}  ")
+    assert a == b == c
+
+
+# ── always-free invariant ────────────────────────────────────────────────────
+
+
+def test_every_row_is_always_free(ent):
+    """Every chat channel is FREE at every tier (the ``channels``
+    capacity axis governs how many concurrent channels each plan
+    admits, not which adapters unlock), so every row must come back
+    ``free`` / ``allowed`` / ``entitled`` and never ``locked`` --
+    regardless of the perspective tier or the resolver's current
+    posture."""
+    for tier in ent._TIER_ORDER:
+        for ch in ent.ALL_CHANNELS:
+            row = ent.channel_spec_at(tier, ch)
+            assert row["free"] is True, (tier, ch)
+            assert row["tier"] == "free", (tier, ch)
+            assert row["allowed"] is True, (tier, ch)
+            assert row["locked"] is False, (tier, ch)
+            assert row["entitled"] is True, (tier, ch)
+
+
+# ── independent of live resolver ──────────────────────────────────────────────
+
+
+def test_helper_ignores_grace_mode(ent, monkeypatch):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    ent.invalidate()
+    ch = next(iter(ent.ALL_CHANNELS))
+    row = ent.channel_spec_at(ent.TIER_OSS, ch)
+    assert row["allowed"] is True
+    assert row["locked"] is False
+    assert row["entitled"] is True
+
+
+def test_helper_ignores_cloud_plan_cache(ent, monkeypatch, tmp_path):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    cache = tmp_path / ".clawmetry" / "cloud_plan.json"
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    cache.write_text(json.dumps({"plan": "cloud_pro"}))
+    ent.invalidate()
+    ch = next(iter(ent.ALL_CHANNELS))
+    row = ent.channel_spec_at(ent.TIER_OSS, ch)
+    assert row["allowed"] is True
+    assert row["locked"] is False
+    assert row["entitled"] is True
+
+
+# ── never-raise ───────────────────────────────────────────────────────────────
+
+
+def test_never_raises_when_get_entitlement_crashes(ent, monkeypatch):
+    """The helper builds its own hypothetical Entitlement and does not
+    consult :func:`get_entitlement`, so a blown resolver must not
+    affect the result. Pins the never-raise contract anyway."""
+
+    def boom(*_a, **_kw):
+        raise RuntimeError("simulated resolver failure")
+
+    monkeypatch.setattr(ent, "get_entitlement", boom)
+    ch = next(iter(ent.ALL_CHANNELS))
+    row = ent.channel_spec_at(ent.TIER_CLOUD_PRO, ch)
+    assert row is not None
+    assert row["id"] == ch
+    assert row["free"] is True
+    assert row["locked"] is False
+
+
+# ── HTTP endpoint ─────────────────────────────────────────────────────────────
+
+
+def test_endpoint_known_pair_returns_row(client, ent):
+    ch = next(iter(ent.ALL_CHANNELS))
+    resp = client.get(
+        f"/api/entitlement/channel-spec-at?tier={ent.TIER_CLOUD_PRO}&channel={ch}"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["tier"] == ent.TIER_CLOUD_PRO
+    assert body["channel"] == ch
+    assert body["spec"] == ent.channel_spec_at(ent.TIER_CLOUD_PRO, ch)
+
+
+def test_endpoint_lowercases_and_trims(client, ent):
+    ch = next(iter(ent.ALL_CHANNELS))
+    resp = client.get(
+        f"/api/entitlement/channel-spec-at?tier=%20%20{ent.TIER_CLOUD_PRO.upper()}%20%20"
+        f"&channel=%20%20{ch.upper()}%20%20"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["tier"] == ent.TIER_CLOUD_PRO
+    assert body["channel"] == ch
+
+
+def test_endpoint_missing_tier_returns_400(client, ent):
+    ch = next(iter(ent.ALL_CHANNELS))
+    resp = client.get(f"/api/entitlement/channel-spec-at?channel={ch}")
+    assert resp.status_code == 400
+    assert "error" in resp.get_json()
+
+
+def test_endpoint_blank_tier_returns_400(client, ent):
+    ch = next(iter(ent.ALL_CHANNELS))
+    resp = client.get(
+        f"/api/entitlement/channel-spec-at?tier=%20%20&channel={ch}"
+    )
+    assert resp.status_code == 400
+
+
+def test_endpoint_missing_channel_returns_400(client, ent):
+    resp = client.get(
+        f"/api/entitlement/channel-spec-at?tier={ent.TIER_CLOUD_PRO}"
+    )
+    assert resp.status_code == 400
+    assert "error" in resp.get_json()
+
+
+def test_endpoint_blank_channel_returns_400(client, ent):
+    resp = client.get(
+        f"/api/entitlement/channel-spec-at?tier={ent.TIER_CLOUD_PRO}&channel=%20%20"
+    )
+    assert resp.status_code == 400
+
+
+def test_endpoint_unknown_tier_returns_404(client, ent):
+    ch = next(iter(ent.ALL_CHANNELS))
+    resp = client.get(
+        f"/api/entitlement/channel-spec-at?tier=nonsense_xyz&channel={ch}"
+    )
+    assert resp.status_code == 404
+    body = resp.get_json()
+    assert body["tier"] == "nonsense_xyz"
+    assert body["which"] == "tier"
+    assert "error" in body
+
+
+def test_endpoint_unknown_channel_returns_404(client, ent):
+    resp = client.get(
+        f"/api/entitlement/channel-spec-at?tier={ent.TIER_CLOUD_PRO}"
+        "&channel=not_a_real_channel"
+    )
+    assert resp.status_code == 404
+    body = resp.get_json()
+    assert body["channel"] == "not_a_real_channel"
+    assert body["which"] == "channel"
+    assert "error" in body
+
+
+def test_endpoint_every_pair_in_order_round_trips(client, ent):
+    for tier in ent._TIER_ORDER:
+        for ch in ent.ALL_CHANNELS:
+            resp = client.get(
+                f"/api/entitlement/channel-spec-at?tier={tier}&channel={ch}"
+            )
+            assert resp.status_code == 200, (tier, ch)
+            body = resp.get_json()
+            assert body["tier"] == tier, (tier, ch)
+            assert body["channel"] == ch, (tier, ch)
+
+
+def test_endpoint_body_spec_byte_equal_catalog_at_row(client, ent):
+    """The endpoint body's ``spec`` field must byte-equal the
+    corresponding row in ``/api/entitlement/channel-catalog-at`` at the
+    same perspective tier -- pins the scalar / bulk no-drift contract
+    on the wire."""
+    tier = ent.TIER_CLOUD_PRO
+    cat_resp = client.get(
+        f"/api/entitlement/channel-catalog-at?tier={tier}"
+    )
+    assert cat_resp.status_code == 200
+    cat_by_id = {row["id"]: row for row in cat_resp.get_json()["channels"]}
+    for ch, row in cat_by_id.items():
+        resp = client.get(
+            f"/api/entitlement/channel-spec-at?tier={tier}&channel={ch}"
+        )
+        assert resp.status_code == 200, ch
+        assert resp.get_json()["spec"] == row, ch
+
+
+def test_endpoint_never_5xxs_when_resolver_crashes(client, ent, monkeypatch):
+    def boom(*_a, **_kw):
+        raise RuntimeError("simulated resolver failure")
+
+    monkeypatch.setattr(ent, "get_entitlement", boom)
+    ch = next(iter(ent.ALL_CHANNELS))
+    resp = client.get(
+        f"/api/entitlement/channel-spec-at?tier={ent.TIER_CLOUD_PRO}&channel={ch}"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["spec"]["id"] == ch
+    assert body["spec"]["free"] is True
+    assert body["spec"]["locked"] is False


### PR DESCRIPTION
## Summary

Adds the **scalar what-if sibling of `channel_catalog_at`** on the chat-channel axis — one catalogue row for a single channel id, with `allowed` / `locked` / `entitled` computed as if the install were on the supplied tier.

Channel-axis analogue of `feature_spec_at` / `runtime_spec_at`; fills the `spec_at` slot on the channel family (parallel to how #3563 filled `channel_spec` and how PR #3565 fills `channel_spec_batch`). Together with those, a pricing-comparison tooltip can hydrate ONE channel at a hypothetical tier in one round-trip instead of fetching the full `channel_catalog_at` payload and filtering client-side.

### What's new

- **`clawmetry/entitlements.py`** — `channel_spec_at(tier, channel) -> dict | None`. Row shape / ordering are byte-identical to a row from `channel_catalog_at(tier)` for the same id, and — because every chat channel is FREE at every tier (the `channels` capacity axis governs how many concurrent channels each plan admits, not which adapters unlock) — byte-identical to the LIVE `channel_spec(channel)` row regardless of the perspective tier. Parity tests pin both invariants.
- **`routes/entitlement.py`** — `GET /api/entitlement/channel-spec-at?tier=<id>&channel=<id>` on `bp_entitlement`. Response shape mirrors the `feature-spec-at` / `runtime-spec-at` endpoints: `{"tier": "...", "channel": "...", "spec": <catalog_at row>}`.
- **`tests/test_entitlement_channel_spec_at.py`** — 28 tests, all green.

### Contract (matches the existing `_spec_at` pattern)

- Both args are normalised (whitespace stripped, lowercased)
- `400` on missing / blank `tier=` or `channel=`
- `404` on unknown tier (not in `_TIER_ORDER`) or unknown channel (not in `ALL_CHANNELS`) — the body carries `which` so a caller can render the right "unknown ..." message
- Endpoint **never `5xx`s** on a resolver crash — the helper builds its own hypothetical `Entitlement`, and a synthesis failure short-circuits to the OSS-free fallback
- Every chat channel is FREE at every tier, so every returned row reports `free=True` / `allowed=True` / `locked=False` / `entitled=True` regardless of the resolved tier — grace vs enforce yields byte-identical rows
- **Zero behaviour change while grace mode is on (default until enforcement flips)**

### Response shape

```json
{
  "tier":    "cloud_pro",
  "channel": "telegram",
  "spec":    { "id": "telegram", "label": "Telegram", "free": true,
               "tier": "free", "allowed": true, "locked": false,
               "entitled": true }
}
```

### Test coverage (28 tests)

- Row shape + parity with every `channel_catalog_at(tier)` row (every `_TIER_ORDER` × `ALL_CHANNELS` pair)
- Parity with LIVE `channel_spec(channel)` at every perspective tier (always-free invariant)
- Round-trip: every (tier, channel) pair resolves
- Invalid tier: unknown / empty / None / non-string → `None`
- Invalid channel: unknown / empty / None / non-string → `None`
- Normalisation: whitespace + case fold on both args
- Every row is always `free=True` / `allowed=True` / `locked=False` / `entitled=True` across every (tier, channel) pair
- Independent of live resolver: grace-mode toggle and `cloud_plan.json` cache do not affect rows
- Never-raise on resolver crash
- HTTP: 200 with body, 400 on missing / blank tier or channel, 404 with `which` on unknown tier or channel, byte-equal round-trip against `/api/entitlement/channel-catalog-at`, envelope carries resolved tier + channel + spec, never 5xxs when resolver crashes

## Test plan

- [x] `python -m pytest tests/test_entitlement_channel_spec_at.py -v` — 28/28 pass locally
- [x] `python -m pytest tests/test_entitlement_channel_spec.py tests/test_entitlement_channel_catalog.py tests/test_entitlement_channel_catalog_at.py tests/test_entitlement_feature_spec_at.py tests/test_entitlement_runtime_spec_at.py tests/test_entitlement_api.py` — 187/187 pass (no neighbour regressions)
- [x] `python -m py_compile clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_channel_spec_at.py` — clean
- [x] Broader entitlement suite: 4,818 passed, 4 skipped in the sandbox (1 pre-existing collection error is a `duckdb` env issue in the sandbox, unrelated to this diff — will re-verify in CI)

## Local operator verification checklist

I cannot reach the local daemon, `~/.openclaw`, the live cloud snapshot, or a browser from this environment. Once CI is green, please:

- [ ] Copy the changed files into `~/.clawmetry/lib/pythonX.Y/site-packages/clawmetry/` (and the updated `routes/entitlement.py` into the package's `routes/` dir)
- [ ] Clear `__pycache__/` under those two paths
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` to restart the daemon
- [ ] `curl -s "http://localhost:8900/api/entitlement/channel-spec-at?tier=cloud_pro&channel=telegram" | jq` — confirm `{tier, channel, spec}` envelope with `spec.free=true`
- [ ] `curl -s "http://localhost:8900/api/entitlement/channel-spec-at?tier=oss&channel=telegram" | jq` — confirm same free row (channels are always free at every tier)
- [ ] `curl -s -o /dev/null -w "%{http_code}\n" "http://localhost:8900/api/entitlement/channel-spec-at?channel=telegram"` — expect 400
- [ ] `curl -s -o /dev/null -w "%{http_code}\n" "http://localhost:8900/api/entitlement/channel-spec-at?tier=cloud_pro"` — expect 400
- [ ] `curl -s -o /dev/null -w "%{http_code}\n" "http://localhost:8900/api/entitlement/channel-spec-at?tier=bogus&channel=telegram"` — expect 404
- [ ] `curl -s -o /dev/null -w "%{http_code}\n" "http://localhost:8900/api/entitlement/channel-spec-at?tier=cloud_pro&channel=not_a_channel"` — expect 404
- [ ] Byte-equal round-trip: `curl -s "http://localhost:8900/api/entitlement/channel-catalog-at?tier=cloud_pro" | jq '.channels[] | select(.id=="telegram")'` should equal `curl -s "http://localhost:8900/api/entitlement/channel-spec-at?tier=cloud_pro&channel=telegram" | jq .spec`
- [ ] Decrypt the live cloud snapshot, spot-check that nothing else regressed
- [ ] Browser-check the paywall matrix / channel-picker view still hydrates cleanly

Kept as **DRAFT** — the operator handles local-daemon verification, live-cloud verification, release, and merge.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018sZmvdGYqtdXgbae1V8ysx

---
_Generated by [Claude Code](https://claude.ai/code/session_018sZmvdGYqtdXgbae1V8ysx)_