### PR TITLE
fix: surface cron-level model field in /api/crons response (#3568)

### DIFF
--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -9814,6 +9814,7 @@ def sync_crons(config: dict, state: dict, paths: dict) -> int:
                 "expr": expr,
                 "schedule": sched,
                 "task": (j.get("task") or "")[:200],
+                "model": j.get("model", ""),
                 "state": {
                     "lastStatus": job_state.get("lastStatus"),
                     "lastRunAtMs": job_state.get("lastRunAtMs"),
@@ -9875,6 +9876,7 @@ def sync_crons(config: dict, state: dict, paths: dict) -> int:
                     "next_run_at": str(job_state.get("nextRunAtMs") or ""),
                     # All other freeform fields go into the BLOB
                     "task":        (j.get("task") or "")[:500],
+                    "model":       j.get("model"),
                     "lastDurationMs":      job_state.get("lastDurationMs"),
                     "lastError":           job_state.get("lastError"),
                     "consecutiveFailures": job_state.get("consecutiveFailures"),

--- a/tests/test_crons_local_store.py
+++ b/tests/test_crons_local_store.py
@@ -401,3 +401,71 @@ def test_on_exit_cron_appears_in_agent_intentions(fast_path_app):
     # Trigger metadata must be forwarded into the intention entry
     assert entry.get("watchedCommand") == "make build", f"watchedCommand missing from intention: {entry}"
     assert entry.get("lastExitCode") == 0, f"lastExitCode missing from intention: {entry}"
+
+
+# ── cron-level model field (issue #3568) ───────────────────────────────────
+
+
+def test_cron_model_field_surfaced_in_jobs_response(fast_path_app):
+    """Cron jobs with a per-job model field must carry it through the DuckDB
+    fast path so the dashboard can display the configured agent-turn model
+    (OpenClaw Control UI Quick Create — harness gap #3568)."""
+    import time
+    from datetime import datetime, timezone, timedelta
+
+    app, ls, _cr = fast_path_app
+    now = datetime.now(timezone.utc)
+    recent_iso = (now - timedelta(seconds=30)).isoformat()
+    next_iso = (now + timedelta(minutes=5)).isoformat()
+
+    ls.get_store().ingest_cron({
+        "cron_id":     "model-cron",
+        "name":        "Model-pinned job",
+        "schedule":    '{"kind":"cron","expr":"0 9 * * 1-5"}',
+        "enabled":     True,
+        "last_run_at": recent_iso,
+        "last_status": "success",
+        "next_run_at": next_iso,
+        "createdAtMs": int(time.time() * 1000) - 3600000,
+        "model":       "claude-haiku-4-5-20251001",
+    })
+
+    body = app.test_client().get("/api/crons").get_json()
+    jobs = body.get("jobs", [])
+    matched = [j for j in jobs if j.get("id") == "model-cron"]
+    assert matched, f"model-cron not found in response; got ids: {[j.get('id') for j in jobs]}"
+    assert matched[0].get("model") == "claude-haiku-4-5-20251001", (
+        f"model field missing or wrong in cron job; job dict: {matched[0]}"
+    )
+
+
+def test_cron_without_model_field_unaffected(fast_path_app):
+    """Crons ingested without a model field must not gain a spurious 'model' key
+    (None values are filtered by setdefault in _row_to_cron_job)."""
+    import time
+    from datetime import datetime, timezone, timedelta
+
+    app, ls, _cr = fast_path_app
+    now = datetime.now(timezone.utc)
+    recent_iso = (now - timedelta(seconds=30)).isoformat()
+    next_iso = (now + timedelta(minutes=5)).isoformat()
+
+    ls.get_store().ingest_cron({
+        "cron_id":     "no-model-cron",
+        "name":        "No-model job",
+        "schedule":    '{"kind":"every","everyMs":3600000}',
+        "enabled":     True,
+        "last_run_at": recent_iso,
+        "last_status": "success",
+        "next_run_at": next_iso,
+        "createdAtMs": int(time.time() * 1000) - 3600000,
+    })
+
+    body = app.test_client().get("/api/crons").get_json()
+    jobs = body.get("jobs", [])
+    matched = [j for j in jobs if j.get("id") == "no-model-cron"]
+    assert matched, f"no-model-cron not in response"
+    # model key should be absent (None is not set via setdefault)
+    assert "model" not in matched[0] or matched[0].get("model") is None, (
+        f"unexpected model value in cron without model field: {matched[0]}"
+    )


### PR DESCRIPTION
Closes #3568

## What

When OpenClaw's `jobs.json` includes a per-cron `model` field (the agent-turn model chosen in Control UI Quick Create), `sync_crons` was not forwarding it to `ingest_cron`. The field never landed in the DuckDB `data` BLOB, so the `/api/crons` response omitted the model.

## Changes

- **`clawmetry/sync.py`** — Added `"model": j.get("model", "")` to the `event_data` dict (cloud sync) and `"model": j.get("model")` to the `ingest_cron` call (DuckDB fast path). The existing plumbing (`ingest_cron → data BLOB → _row_to_cron_job → job dict`) already carries through any key not in the explicit column set — no other changes needed.
- **`tests/test_crons_local_store.py`** — Two new tests: one asserting `model` appears in the `/api/crons` response when ingested, one confirming existing crons without a `model` field are unaffected.

## Test plan

- `pytest tests/test_crons_local_store.py -v` — all 15 tests pass (13 pre-existing + 2 new)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Eq4HPJfD2daucMVhP8zRfd)_