### PR TITLE
feat(entitlement): channel_spec_at_batch + /api/entitlement/channel-spec-at-batch

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -5628,6 +5628,85 @@ def channel_catalog_at_batch(tiers) -> dict:
     return {"tiers": rows, "unknown": unknown}
 
 
+def channel_spec_at_batch(tier: str, channels) -> dict | None:
+    """What-if + batch sibling of :func:`channel_spec_batch`: return spec
+    rows for a caller-supplied subset of chat-channel ids, with ``allowed``
+    / ``locked`` / ``entitled`` computed as if the install were on
+    ``tier``.
+
+    Composes :func:`channel_spec_at` (scalar what-if) and
+    :func:`channel_spec_batch` (live batch) -- same shape as the batch
+    helper, same hypothetical perspective as the ``_at`` helper. Channel-
+    axis analogue of :func:`feature_spec_at_batch` /
+    :func:`runtime_spec_at_batch`; together they let a pricing-comparison
+    matrix UI ("here are the N channels I want to render at Cloud Pro")
+    hydrate a viewport's worth of feature + runtime + channel rows at a
+    hypothetical tier off THREE calls instead of N + M + K.
+
+    Each returned row is byte-identical to a row from
+    :func:`channel_catalog_at` for the same perspective ``tier`` -- a
+    parity test pins this so the scalar what-if
+    (:func:`channel_spec_at`), bulk what-if (:func:`channel_catalog_at`),
+    and batch what-if accessors cannot drift. And because every chat
+    channel is FREE at every tier (the ``channels`` capacity axis governs
+    how many concurrent channels each plan admits, not which adapters
+    unlock), each row is ALSO byte-identical to the LIVE
+    :func:`channel_spec` row for the same id regardless of the
+    perspective tier -- pinned by the parity tests below.
+
+    Shape::
+
+        {
+          "channels": [<spec_row>, ...],   # one per known supplied id, in supply order
+          "unknown":  ["bogus_id", ...],   # supplied ids not in ALL_CHANNELS, in supply order
+        }
+
+    Returns ``None`` for empty / unknown ``tier`` (caller renders
+    "unknown tier" / 404). Supplied channel ids are normalised via
+    :func:`_normalise_csv` (whitespace stripped, lowercased, duplicates
+    dropped, first-seen order preserved); an empty channel list returns
+    ``{"channels": [], "unknown": []}`` -- the HTTP wrapper turns that
+    into a 400, this helper does not raise.
+
+    Resolver-independent: synthesises a fresh :class:`Entitlement` at the
+    perspective tier via :func:`_hypothetical_entitlement`, so grace vs
+    enforce yields byte-identical rows. Never raises: a synthesis
+    failure short-circuits to the OSS-free fallback and a per-channel
+    row build failure drops the id into ``unknown[]`` so the rest of the
+    batch keeps rendering.
+    """
+    try:
+        t = (tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if not t or t not in _TIER_ORDER:
+        return None
+    chans = _normalise_csv(channels)
+    try:
+        ent = _hypothetical_entitlement(t)
+    except Exception as exc:
+        logger.warning(
+            "entitlements: channel_spec_at_batch falling back to OSS-free: %s", exc
+        )
+        ent = _oss_free()
+    rows: list[dict] = []
+    unknown: list[str] = []
+    for cid in chans:
+        if cid in ALL_CHANNELS:
+            try:
+                rows.append(_channel_spec_row(ent, cid))
+            except Exception as exc:
+                logger.warning(
+                    "entitlements: channel_spec_at_batch row %r failed: %s",
+                    cid,
+                    exc,
+                )
+                unknown.append(cid)
+        else:
+            unknown.append(cid)
+    return {"channels": rows, "unknown": unknown}
+
+
 def feature_spec(feature: str) -> dict | None:
     """Scalar sibling of :func:`feature_catalog`: return the single
     catalogue row for ``feature`` (case-insensitive, trimmed), or

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -4015,6 +4015,106 @@ def api_entitlement_channel_spec_at():
         return jsonify({"error": "channel-spec-at failed"}), 500
 
 
+@bp_entitlement.route("/api/entitlement/channel-spec-at-batch")
+def api_entitlement_channel_spec_at_batch():
+    """``GET /api/entitlement/channel-spec-at-batch?tier=<perspective>
+    &channels=a,b,c`` -- what-if + batch sibling of
+    ``/api/entitlement/channel-spec-batch``.
+
+    Where ``/channel-spec-batch`` returns batch rows against the LIVE
+    resolved entitlement, this returns them against a HYPOTHETICAL
+    ``perspective_tier``. Pairs with ``/channel-spec-at`` the same way
+    ``/channel-spec-batch`` pairs with ``/channel-spec``: scalar -> matrix
+    in one round-trip. Channel-axis twin of ``/feature-spec-at-batch`` /
+    ``/runtime-spec-at-batch`` -- together they let a pricing-comparison
+    matrix UI hydrate a viewport's worth of feature + runtime + channel
+    rows at a hypothetical tier off THREE calls instead of N + M + K.
+
+    Each ``channels[]`` entry is byte-identical to a row from
+    :func:`entitlements.channel_catalog_at` at the same perspective tier
+    -- pinned by the parity tests so the scalar / bulk / batch what-if
+    accessors cannot drift. And because every chat channel is FREE at
+    every tier (the ``channels`` capacity axis governs how many
+    concurrent channels each plan admits, not which adapters unlock),
+    each row is ALSO byte-identical to the LIVE ``/channel-spec`` row
+    for the same id regardless of the perspective tier.
+
+    Supplied ids are normalised (whitespace stripped, lowercased,
+    duplicates dropped, first-seen order preserved). Unknown ids do not
+    404 the call -- they are echoed in ``unknown[]`` so a partially-bad
+    caller still gets rows back for the valid ids alongside a list of
+    what was dropped.
+
+    Response shape (mirrors ``/channel-spec-batch`` plus a
+    ``perspective_tier`` echo for caller round-trip safety)::
+
+        {
+          "channels":              [<spec_row>, ...],
+          "unknown":               ["bogus_id", ...],
+          "perspective_tier":      "...",
+          "perspective_tier_rank": <int>,
+          "current_tier":          "...",
+          "current_tier_rank":     <int>,
+          "grace":                 <bool>,
+          "enforced":              <bool>,
+        }
+
+    - **400** when ``tier=`` is missing / blank or ``channels=`` is
+      missing / empty after normalisation
+    - **404** when ``tier`` is unknown (body carries ``which: "tier"``)
+    - **Never 5xxs**: a synthesis failure short-circuits to the OSS-free
+      shape (empty rows, ``current_tier=oss``, ``grace=true``) with the
+      perspective tier echoed so the UI keeps rendering.
+    """
+    raw_tier = request.args.get("tier")
+    tier_in = (raw_tier or "").strip().lower()
+    if not tier_in:
+        return jsonify({"error": "missing tier"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        if tier_in not in _ent._TIER_ORDER:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "tier", "tier": tier_in}
+                ),
+                404,
+            )
+        channels = _parse_csv_arg("channels")
+        if not channels:
+            return (
+                jsonify({"error": "supply channels=<csv>"}),
+                400,
+            )
+        batch = _ent.channel_spec_at_batch(tier_in, channels)
+        if batch is None:
+            batch = {"channels": [], "unknown": []}
+        ent = _ent.get_entitlement()
+        batch["perspective_tier"] = tier_in
+        batch["perspective_tier_rank"] = _ent.tier_rank(tier_in)
+        batch["current_tier"] = ent.tier
+        batch["current_tier_rank"] = _ent.tier_rank(ent.tier)
+        batch["grace"] = bool(ent.grace)
+        batch["enforced"] = _ent.is_enforced()
+        return jsonify(batch)
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_channel_spec_at_batch: error: %s", exc
+        )
+        return jsonify(
+            {
+                "channels": [],
+                "unknown": [],
+                "perspective_tier": tier_in,
+                "perspective_tier_rank": 0,
+                "current_tier": "oss",
+                "current_tier_rank": 0,
+                "grace": True,
+                "enforced": False,
+            }
+        )
+
+
 @bp_entitlement.route("/api/entitlement/feature-spec-batch")
 def api_entitlement_feature_spec_batch():
     """``GET /api/entitlement/feature-spec-batch?features=a,b,c`` -- plural

--- a/tests/test_entitlement_channel_spec_at_batch.py
+++ b/tests/test_entitlement_channel_spec_at_batch.py
@@ -1,0 +1,539 @@
+"""Tests for ``channel_spec_at_batch(tier, channels)`` + ``GET
+/api/entitlement/channel-spec-at-batch``.
+
+What-if + batch sibling of :func:`channel_spec_batch`: return spec rows
+for a caller-supplied subset of chat-channel ids, with ``allowed`` /
+``locked`` / ``entitled`` computed as if the install were on ``tier``.
+Channel-axis twin of :func:`feature_spec_at_batch` /
+:func:`runtime_spec_at_batch`.
+
+Pins:
+
+* row shape matches a row from ``channel_catalog_at(tier)`` EXACTLY (so
+  the scalar what-if / bulk what-if / batch what-if accessors cannot
+  drift on the channel axis) -- parity test enumerates every
+  ``(tier, channel)`` pair
+* the row for a given channel is byte-identical to the LIVE
+  ``channel_spec(channel)`` and to ``channel_spec_batch([channel])``
+  regardless of the perspective tier -- the always-free invariant on the
+  channel axis (the ``channels`` capacity axis governs how many
+  concurrent channels each plan admits, not which adapters unlock)
+* the row is also byte-identical to ``channel_spec_at(tier, channel)``
+  for the same ``(tier, channel)`` pair -- pins the scalar / batch
+  what-if no-drift contract
+* input is normalised (whitespace stripped, lowercased, duplicates
+  dropped, first-seen order preserved)
+* unknown channel ids are echoed in ``unknown[]`` instead of 404'ing
+* unknown / empty / ``None`` / non-string tier ids return ``None``
+* every row is ``free=True`` / ``allowed=True`` / ``locked=False`` /
+  ``entitled=True`` regardless of the perspective tier
+* the helper is independent of the live resolver: switching enforcement
+  or pointing HOME at a license cache does not change the rows the
+  what-if surface returns
+* never raises -- a synthesis failure short-circuits to the OSS-free
+  fallback and a per-channel row build failure drops the id into
+  ``unknown[]`` so the rest of the batch keeps rendering
+* the endpoint 400s on missing / blank ``tier`` or ``channels``, 404s
+  on unknown tier (with ``which: "tier"``), carries the standard
+  ``perspective_tier`` / ``current_tier`` / ``grace`` / ``enforced``
+  envelope, and never 5xxs on a resolver crash
+"""
+from __future__ import annotations
+
+import importlib
+import json
+
+import pytest
+from flask import Flask
+
+
+_CHANNEL_SPEC_KEYS = {
+    "id",
+    "label",
+    "free",
+    "tier",
+    "allowed",
+    "locked",
+    "entitled",
+}
+
+_ENVELOPE_KEYS = {
+    "perspective_tier",
+    "perspective_tier_rank",
+    "current_tier",
+    "current_tier_rank",
+    "grace",
+    "enforced",
+}
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    """Fresh entitlements module with HOME pointed at an empty tmp dir
+    so no real ~/.clawmetry/license.key or cloud_plan.json leaks in.
+    Enforcement off by default (grace mode) -- ``channel_spec_at_batch``
+    is independent of either knob, so the fixture only needs to make
+    sure the live resolver does not surprise the test."""
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# ── helper: empty / bogus tier ────────────────────────────────────────────────
+
+
+def test_unknown_tier_returns_none(ent):
+    ch = next(iter(ent.ALL_CHANNELS))
+    assert ent.channel_spec_at_batch("not_a_real_tier", [ch]) is None
+
+
+def test_empty_tier_returns_none(ent):
+    ch = next(iter(ent.ALL_CHANNELS))
+    assert ent.channel_spec_at_batch("", [ch]) is None
+
+
+def test_none_tier_returns_none(ent):
+    ch = next(iter(ent.ALL_CHANNELS))
+    assert ent.channel_spec_at_batch(None, [ch]) is None
+
+
+def test_non_string_tier_returns_none(ent):
+    ch = next(iter(ent.ALL_CHANNELS))
+    assert ent.channel_spec_at_batch(123, [ch]) is None
+    assert ent.channel_spec_at_batch(object(), [ch]) is None
+
+
+# ── helper: empty channel list ────────────────────────────────────────────────
+
+
+def test_empty_channels_returns_empty_envelope(ent):
+    assert ent.channel_spec_at_batch(ent.TIER_CLOUD_PRO, []) == {
+        "channels": [],
+        "unknown": [],
+    }
+
+
+def test_none_channels_returns_empty_envelope(ent):
+    assert ent.channel_spec_at_batch(ent.TIER_CLOUD_PRO, None) == {
+        "channels": [],
+        "unknown": [],
+    }
+
+
+# ── helper: shape + parity ────────────────────────────────────────────────────
+
+
+def test_row_shape_matches_catalog_at_row(ent):
+    ch = next(iter(ent.ALL_CHANNELS))
+    body = ent.channel_spec_at_batch(ent.TIER_CLOUD_PRO, [ch])
+    assert len(body["channels"]) == 1
+    assert set(body["channels"][0].keys()) == _CHANNEL_SPEC_KEYS
+
+
+def test_parity_with_catalog_at_every_pair(ent):
+    """For every (tier, channel) pair, the batch what-if accessor
+    returns the same dict as the bulk what-if accessor. Pins the
+    scalar/bulk/batch no-drift contract on the channel axis."""
+    for tier in ent._TIER_ORDER:
+        bulk_by_id = {row["id"]: row for row in ent.channel_catalog_at(tier)}
+        ids = sorted(bulk_by_id)
+        body = ent.channel_spec_at_batch(tier, ids)
+        rows_by_id = {row["id"]: row for row in body["channels"]}
+        assert set(rows_by_id) == set(ids), tier
+        for cid in ids:
+            assert rows_by_id[cid] == bulk_by_id[cid], (tier, cid)
+
+
+def test_parity_with_scalar_channel_spec_at_every_pair(ent):
+    """Pins ``channel_spec_at_batch(tier, [ch])[0]`` == ``channel_spec_at(tier, ch)``
+    for every ``(tier, ch)`` -- scalar / batch no-drift contract."""
+    for tier in ent._TIER_ORDER:
+        for ch in ent.ALL_CHANNELS:
+            body = ent.channel_spec_at_batch(tier, [ch])
+            assert body["channels"] == [ent.channel_spec_at(tier, ch)], (tier, ch)
+
+
+def test_parity_with_live_channel_spec(ent):
+    """Because every chat channel is FREE at every tier, the batch
+    what-if row must byte-equal the LIVE :func:`channel_spec` row for
+    the same id at every perspective tier -- the always-free posture is
+    the whole point of the channel axis, and this test pins it end to
+    end across the ``at_batch`` surface."""
+    ids = sorted(ent.ALL_CHANNELS)
+    live = {cid: ent.channel_spec(cid) for cid in ids}
+    for tier in ent._TIER_ORDER:
+        body = ent.channel_spec_at_batch(tier, ids)
+        rows_by_id = {row["id"]: row for row in body["channels"]}
+        for cid in ids:
+            assert rows_by_id[cid] == live[cid], (tier, cid)
+
+
+def test_parity_with_channel_spec_batch(ent):
+    """Because every chat channel is FREE at every tier, the batch
+    what-if body must byte-equal the LIVE :func:`channel_spec_batch`
+    body for the same ids at every perspective tier."""
+    ids = sorted(ent.ALL_CHANNELS)
+    live = ent.channel_spec_batch(ids)
+    for tier in ent._TIER_ORDER:
+        body = ent.channel_spec_at_batch(tier, ids)
+        assert body["channels"] == live["channels"], tier
+        assert body["unknown"] == live["unknown"], tier
+
+
+# ── input normalisation ───────────────────────────────────────────────────────
+
+
+def test_tier_is_lowercased_and_trimmed(ent):
+    ch = next(iter(ent.ALL_CHANNELS))
+    a = ent.channel_spec_at_batch(ent.TIER_CLOUD_PRO, [ch])
+    b = ent.channel_spec_at_batch(ent.TIER_CLOUD_PRO.upper(), [ch])
+    c = ent.channel_spec_at_batch(f"  {ent.TIER_CLOUD_PRO}  ", [ch])
+    assert a == b == c
+
+
+def test_channels_are_lowercased_and_trimmed(ent):
+    ch = next(iter(ent.ALL_CHANNELS))
+    a = ent.channel_spec_at_batch(ent.TIER_CLOUD_PRO, [ch])
+    b = ent.channel_spec_at_batch(ent.TIER_CLOUD_PRO, [ch.upper()])
+    c = ent.channel_spec_at_batch(ent.TIER_CLOUD_PRO, [f"  {ch}  "])
+    assert a == b == c
+
+
+def test_supply_order_preserved(ent):
+    ids = list(sorted(ent.ALL_CHANNELS))
+    reversed_ids = list(reversed(ids))
+    body = ent.channel_spec_at_batch(ent.TIER_CLOUD_PRO, reversed_ids)
+    assert [row["id"] for row in body["channels"]] == reversed_ids
+
+
+def test_duplicates_dropped_first_seen_wins(ent):
+    ids = list(sorted(ent.ALL_CHANNELS))
+    if len(ids) < 2:
+        pytest.skip("need >=2 channels")
+    supply = [ids[0], ids[1], ids[0], ids[1]]
+    body = ent.channel_spec_at_batch(ent.TIER_CLOUD_PRO, supply)
+    assert [row["id"] for row in body["channels"]] == [ids[0], ids[1]]
+
+
+# ── unknown ids echoed ───────────────────────────────────────────────────────
+
+
+def test_unknown_channels_echoed(ent):
+    ch = next(iter(ent.ALL_CHANNELS))
+    body = ent.channel_spec_at_batch(
+        ent.TIER_CLOUD_PRO, [ch, "not_a_channel", "also_not"]
+    )
+    assert [row["id"] for row in body["channels"]] == [ch]
+    assert body["unknown"] == ["not_a_channel", "also_not"]
+
+
+def test_only_unknown_channels_returns_empty_rows(ent):
+    body = ent.channel_spec_at_batch(
+        ent.TIER_CLOUD_PRO, ["bogus_a", "bogus_b"]
+    )
+    assert body["channels"] == []
+    assert body["unknown"] == ["bogus_a", "bogus_b"]
+
+
+# ── always-free invariant ────────────────────────────────────────────────────
+
+
+def test_every_row_is_always_free(ent):
+    """Every chat channel is FREE at every tier, so every row must come
+    back ``free`` / ``allowed`` / ``entitled`` and never ``locked`` --
+    regardless of the perspective tier or the resolver's current
+    posture."""
+    ids = sorted(ent.ALL_CHANNELS)
+    for tier in ent._TIER_ORDER:
+        body = ent.channel_spec_at_batch(tier, ids)
+        for row in body["channels"]:
+            assert row["free"] is True, (tier, row["id"])
+            assert row["tier"] == "free", (tier, row["id"])
+            assert row["allowed"] is True, (tier, row["id"])
+            assert row["locked"] is False, (tier, row["id"])
+            assert row["entitled"] is True, (tier, row["id"])
+
+
+# ── independent of live resolver ──────────────────────────────────────────────
+
+
+def test_helper_ignores_grace_mode(ent, monkeypatch):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    ent.invalidate()
+    ch = next(iter(ent.ALL_CHANNELS))
+    body = ent.channel_spec_at_batch(ent.TIER_OSS, [ch])
+    assert body["channels"][0]["allowed"] is True
+    assert body["channels"][0]["locked"] is False
+    assert body["channels"][0]["entitled"] is True
+
+
+def test_helper_ignores_cloud_plan_cache(ent, monkeypatch, tmp_path):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    cache = tmp_path / ".clawmetry" / "cloud_plan.json"
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    cache.write_text(json.dumps({"plan": "cloud_pro"}))
+    ent.invalidate()
+    ch = next(iter(ent.ALL_CHANNELS))
+    body = ent.channel_spec_at_batch(ent.TIER_OSS, [ch])
+    assert body["channels"][0]["allowed"] is True
+    assert body["channels"][0]["locked"] is False
+    assert body["channels"][0]["entitled"] is True
+
+
+# ── never-raise ───────────────────────────────────────────────────────────────
+
+
+def test_never_raises_when_get_entitlement_crashes(ent, monkeypatch):
+    """The helper builds its own hypothetical Entitlement and does not
+    consult :func:`get_entitlement`, so a blown resolver must not
+    affect the result. Pins the never-raise contract anyway."""
+
+    def boom(*_a, **_kw):
+        raise RuntimeError("simulated resolver failure")
+
+    monkeypatch.setattr(ent, "get_entitlement", boom)
+    ids = sorted(ent.ALL_CHANNELS)
+    body = ent.channel_spec_at_batch(ent.TIER_CLOUD_PRO, ids)
+    assert body is not None
+    assert len(body["channels"]) == len(ids)
+    for row in body["channels"]:
+        assert row["free"] is True
+        assert row["locked"] is False
+
+
+def test_row_build_failure_drops_id_into_unknown(ent, monkeypatch):
+    """A per-channel row build failure drops the id into ``unknown[]``
+    so the rest of the batch keeps rendering. Pins the batch's never-
+    raise + partial-response contract on the channel axis."""
+    ids = sorted(ent.ALL_CHANNELS)
+    victim = ids[0]
+    real = ent._channel_spec_row
+
+    def selective(entobj, ch):
+        if ch == victim:
+            raise RuntimeError("simulated per-channel row build failure")
+        return real(entobj, ch)
+
+    monkeypatch.setattr(ent, "_channel_spec_row", selective)
+    body = ent.channel_spec_at_batch(ent.TIER_CLOUD_PRO, ids)
+    row_ids = {row["id"] for row in body["channels"]}
+    assert victim not in row_ids
+    assert victim in body["unknown"]
+    assert len(row_ids) == len(ids) - 1
+
+
+def test_synthesis_failure_still_returns_rows(ent, monkeypatch):
+    """A ``_hypothetical_entitlement`` crash short-circuits to the
+    OSS-free fallback so the matrix keeps rendering."""
+
+    def boom(*_a, **_kw):
+        raise RuntimeError("simulated synthesis failure")
+
+    monkeypatch.setattr(ent, "_hypothetical_entitlement", boom)
+    ids = sorted(ent.ALL_CHANNELS)
+    body = ent.channel_spec_at_batch(ent.TIER_CLOUD_PRO, ids)
+    assert body is not None
+    assert len(body["channels"]) == len(ids)
+    # Every chat channel is FREE at every tier, so the fallback rows are
+    # byte-identical to the intended rows.
+    for row in body["channels"]:
+        assert row["free"] is True
+        assert row["locked"] is False
+
+
+# ── HTTP endpoint ─────────────────────────────────────────────────────────────
+
+
+def test_endpoint_known_pair_returns_rows(client, ent):
+    ch = next(iter(ent.ALL_CHANNELS))
+    resp = client.get(
+        f"/api/entitlement/channel-spec-at-batch?tier={ent.TIER_CLOUD_PRO}"
+        f"&channels={ch}"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["perspective_tier"] == ent.TIER_CLOUD_PRO
+    assert body["perspective_tier_rank"] == ent.tier_rank(ent.TIER_CLOUD_PRO)
+    assert body["channels"] == [ent.channel_spec_at(ent.TIER_CLOUD_PRO, ch)]
+    assert body["unknown"] == []
+    for key in _ENVELOPE_KEYS:
+        assert key in body, key
+
+
+def test_endpoint_lowercases_and_trims(client, ent):
+    ch = next(iter(ent.ALL_CHANNELS))
+    resp = client.get(
+        f"/api/entitlement/channel-spec-at-batch"
+        f"?tier=%20%20{ent.TIER_CLOUD_PRO.upper()}%20%20"
+        f"&channels=%20%20{ch.upper()}%20%20"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["perspective_tier"] == ent.TIER_CLOUD_PRO
+    assert [row["id"] for row in body["channels"]] == [ch]
+
+
+def test_endpoint_missing_tier_returns_400(client, ent):
+    ch = next(iter(ent.ALL_CHANNELS))
+    resp = client.get(
+        f"/api/entitlement/channel-spec-at-batch?channels={ch}"
+    )
+    assert resp.status_code == 400
+    assert "error" in resp.get_json()
+
+
+def test_endpoint_blank_tier_returns_400(client, ent):
+    ch = next(iter(ent.ALL_CHANNELS))
+    resp = client.get(
+        f"/api/entitlement/channel-spec-at-batch?tier=%20%20&channels={ch}"
+    )
+    assert resp.status_code == 400
+
+
+def test_endpoint_missing_channels_returns_400(client, ent):
+    resp = client.get(
+        f"/api/entitlement/channel-spec-at-batch?tier={ent.TIER_CLOUD_PRO}"
+    )
+    assert resp.status_code == 400
+    assert "error" in resp.get_json()
+
+
+def test_endpoint_blank_channels_returns_400(client, ent):
+    resp = client.get(
+        f"/api/entitlement/channel-spec-at-batch?tier={ent.TIER_CLOUD_PRO}"
+        f"&channels=%20%20"
+    )
+    assert resp.status_code == 400
+
+
+def test_endpoint_unknown_tier_returns_404(client, ent):
+    ch = next(iter(ent.ALL_CHANNELS))
+    resp = client.get(
+        f"/api/entitlement/channel-spec-at-batch?tier=nonsense_xyz"
+        f"&channels={ch}"
+    )
+    assert resp.status_code == 404
+    body = resp.get_json()
+    assert body["tier"] == "nonsense_xyz"
+    assert body["which"] == "tier"
+    assert "error" in body
+
+
+def test_endpoint_unknown_channels_echoed(client, ent):
+    ch = next(iter(ent.ALL_CHANNELS))
+    resp = client.get(
+        f"/api/entitlement/channel-spec-at-batch?tier={ent.TIER_CLOUD_PRO}"
+        f"&channels={ch},not_a_channel"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert [row["id"] for row in body["channels"]] == [ch]
+    assert body["unknown"] == ["not_a_channel"]
+
+
+def test_endpoint_every_pair_round_trips(client, ent):
+    ids = ",".join(sorted(ent.ALL_CHANNELS))
+    for tier in ent._TIER_ORDER:
+        resp = client.get(
+            f"/api/entitlement/channel-spec-at-batch?tier={tier}"
+            f"&channels={ids}"
+        )
+        assert resp.status_code == 200, tier
+        body = resp.get_json()
+        assert body["perspective_tier"] == tier, tier
+        assert len(body["channels"]) == len(ent.ALL_CHANNELS), tier
+        assert body["unknown"] == [], tier
+
+
+def test_endpoint_byte_equal_channel_catalog_at(client, ent):
+    """The endpoint's ``channels[]`` must byte-equal the corresponding
+    rows in ``/api/entitlement/channel-catalog-at`` at the same
+    perspective tier -- pins the scalar / bulk / batch no-drift contract
+    on the wire."""
+    tier = ent.TIER_CLOUD_PRO
+    cat_resp = client.get(
+        f"/api/entitlement/channel-catalog-at?tier={tier}"
+    )
+    assert cat_resp.status_code == 200
+    cat_by_id = {row["id"]: row for row in cat_resp.get_json()["channels"]}
+    ids = ",".join(sorted(cat_by_id))
+    resp = client.get(
+        f"/api/entitlement/channel-spec-at-batch?tier={tier}&channels={ids}"
+    )
+    assert resp.status_code == 200
+    rows_by_id = {row["id"]: row for row in resp.get_json()["channels"]}
+    assert set(rows_by_id) == set(cat_by_id)
+    for cid, row in rows_by_id.items():
+        assert row == cat_by_id[cid], cid
+
+
+def test_endpoint_byte_equal_channel_spec_batch(client, ent):
+    """Because every chat channel is FREE at every tier, the endpoint's
+    ``channels[]`` must byte-equal the LIVE ``/channel-spec-batch``
+    body's ``channels[]`` at every perspective tier."""
+    ids = ",".join(sorted(ent.ALL_CHANNELS))
+    live = client.get(
+        f"/api/entitlement/channel-spec-batch?channels={ids}"
+    ).get_json()
+    for tier in ent._TIER_ORDER:
+        resp = client.get(
+            f"/api/entitlement/channel-spec-at-batch?tier={tier}"
+            f"&channels={ids}"
+        )
+        assert resp.status_code == 200, tier
+        assert resp.get_json()["channels"] == live["channels"], tier
+
+
+def test_endpoint_never_5xxs_when_resolver_crashes(client, ent, monkeypatch):
+    """A ``get_entitlement`` crash inside the handler (used for the
+    envelope's ``current_tier`` / ``grace`` / ``enforced`` fields)
+    short-circuits to the OSS-free fallback shape -- empty rows,
+    ``current_tier=oss``, ``grace=true``, ``enforced=false`` -- with the
+    perspective tier echoed so the UI keeps rendering. Mirrors
+    ``/feature-spec-at-batch`` / ``/runtime-spec-at-batch``."""
+
+    def boom(*_a, **_kw):
+        raise RuntimeError("simulated resolver failure")
+
+    monkeypatch.setattr(ent, "get_entitlement", boom)
+    ch = next(iter(ent.ALL_CHANNELS))
+    resp = client.get(
+        f"/api/entitlement/channel-spec-at-batch?tier={ent.TIER_CLOUD_PRO}"
+        f"&channels={ch}"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["perspective_tier"] == ent.TIER_CLOUD_PRO
+    assert body["channels"] == []
+    assert body["unknown"] == []
+    assert body["current_tier"] == "oss"
+    assert body["current_tier_rank"] == 0
+    assert body["grace"] is True
+    assert body["enforced"] is False
+
+
+def test_endpoint_carries_envelope_flags(client, ent):
+    ch = next(iter(ent.ALL_CHANNELS))
+    resp = client.get(
+        f"/api/entitlement/channel-spec-at-batch?tier={ent.TIER_CLOUD_PRO}"
+        f"&channels={ch}"
+    )
+    body = resp.get_json()
+    assert isinstance(body["current_tier"], str)
+    assert isinstance(body["current_tier_rank"], int)
+    assert isinstance(body["grace"], bool)
+    assert isinstance(body["enforced"], bool)


### PR DESCRIPTION
## Summary

Fills the **channel-axis batch-what-if slot**: the plural sibling of `channel_spec_at` (PR merged as #3566) and the what-if sibling of `channel_spec_batch` (#3565). Channel-axis twin of `feature_spec_at_batch` / `runtime_spec_at_batch` — together the three let a pricing-comparison matrix UI hydrate a viewport's worth of feature + runtime + channel rows at a hypothetical tier off **THREE** calls instead of N + M + K.

### What's new

- **`clawmetry/entitlements.py`** — `channel_spec_at_batch(tier, channels) -> dict | None`. Returns `None` on unknown tier; an empty channel list returns the empty envelope (the HTTP wrapper turns that into a 400). Rows synthesised via the existing `_hypothetical_entitlement` + `_channel_spec_row` primitives (same pattern `feature_spec_at_batch` / `runtime_spec_at_batch` use), so the helper is resolver-independent — grace vs enforce yields byte-identical rows.
- **`routes/entitlement.py`** — `GET /api/entitlement/channel-spec-at-batch?tier=<perspective>&channels=a,b,c` on `bp_entitlement`. `400` on missing / blank `tier` or `channels`, `404` with `which="tier"` on unknown tier, standard `perspective_tier` / `perspective_tier_rank` / `current_tier` / `current_tier_rank` / `grace` / `enforced` envelope. Never 5xxs — a resolver crash short-circuits to the OSS-free fallback shape (empty rows, `current_tier="oss"`, `grace=true`, `enforced=false`) with the perspective tier echoed so the UI keeps rendering.
- **`tests/test_entitlement_channel_spec_at_batch.py`** — 36 tests, all green.

### Contract (matches the existing `_at_batch` pattern)

- All args are normalised (whitespace stripped, lowercased, duplicates dropped, first-seen order preserved)
- Unknown channel ids are echoed in `unknown[]` instead of 404'ing
- Every chat channel is FREE at every tier, so every returned row reports `free=True` / `allowed=True` / `locked=False` / `entitled=True` regardless of the perspective tier — grace vs enforce yields byte-identical rows
- Per-row byte-equality with `channel_catalog_at(tier)` row, `channel_spec_at(tier, channel)`, LIVE `channel_spec(channel)`, and LIVE `channel_spec_batch([channel])` — parity tests pin all four so the scalar / bulk / batch what-if accessors cannot drift
- Per-channel row build failure drops the id into `unknown[]`; synthesis failure short-circuits to the OSS-free fallback so the matrix keeps rendering
- **Zero behaviour change while grace mode is on (default until enforcement flips)**

### Response shape

```json
{
  "channels": [
    { "id": "telegram", "label": "Telegram", "free": true, "tier": "free",
      "allowed": true, "locked": false, "entitled": true },
    ...
  ],
  "unknown":               ["bogus_id", ...],
  "perspective_tier":      "cloud_pro",
  "perspective_tier_rank": 2,
  "current_tier":          "oss",
  "current_tier_rank":     0,
  "grace":                 true,
  "enforced":              false
}
```

### Test coverage (36 tests)

- Row shape matches `channel_catalog_at` row exactly (parity across every `(tier, channel)` pair)
- Per-row byte-equality with scalar `channel_spec_at(tier, channel)`
- Per-row byte-equality with LIVE `channel_spec(channel)` and `channel_spec_batch` at every perspective tier (always-free invariant)
- Row shape carriage (`id`, `label`, `free`, `tier`, `allowed`, `locked`, `entitled`)
- Unknown / empty / `None` / non-string tier → `None`; empty / `None` channel list → empty envelope
- Input normalisation: tier + channels lowercased / trimmed, duplicates dropped (first-seen wins), supply order preserved
- Unknown channel ids echoed in `unknown[]` rather than 404'ing
- Every row always-free / -allowed / -entitled / not-locked at every perspective tier
- Resolver-independence: switching enforcement or seeding `~/.clawmetry/cloud_plan.json` cannot alter the returned rows
- Never-raise: `get_entitlement` crash, `_hypothetical_entitlement` crash, and per-channel `_channel_spec_row` crash all leave a well-formed body
- HTTP: `200` with envelope, `400` on missing / blank `tier` or `channels`, `404` with `which="tier"` on unknown tier, unknown channels echoed in `unknown[]`, byte-equal round-trip against `/channel-catalog-at` and `/channel-spec-batch`, never 5xxs on resolver crash

## Test plan

- [x] `python -m pytest tests/test_entitlement_channel_spec_at_batch.py -v` — 36/36 pass locally
- [x] `python -m pytest tests/test_entitlement*.py -q` — 4868/4868 pass (no neighbour regressions)
- [x] `python -m py_compile clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_channel_spec_at_batch.py` — clean

## Local operator verification checklist

I cannot reach the local daemon, `~/.openclaw`, the live cloud snapshot, or a browser from this environment. Once CI is green, please:

- [ ] Copy the changed files into `~/.clawmetry/lib/pythonX.Y/site-packages/clawmetry/entitlements.py` and `.../routes/entitlement.py`
- [ ] Copy the new test into the package's `tests/` dir
- [ ] Clear `__pycache__/` under those paths
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` to restart the daemon
- [ ] `curl -s "http://localhost:8900/api/entitlement/channel-spec-at-batch?tier=cloud_pro&channels=telegram,signal,discord" | jq` — confirm `{perspective_tier:"cloud_pro", channels:[...3 rows...], unknown:[], ...}` with each row `free=true` / `allowed=true` / `locked=false`
- [ ] `curl -s "http://localhost:8900/api/entitlement/channel-spec-at-batch?tier=oss&channels=telegram,bogus_x,signal" | jq '.channels|length,.unknown'` — expect `2` and `["bogus_x"]`
- [ ] `curl -s -o /dev/null -w "%{http_code}\n" "http://localhost:8900/api/entitlement/channel-spec-at-batch?channels=telegram"` — expect `400`
- [ ] `curl -s -o /dev/null -w "%{http_code}\n" "http://localhost:8900/api/entitlement/channel-spec-at-batch?tier=cloud_pro"` — expect `400`
- [ ] `curl -s -o /dev/null -w "%{http_code}\n" "http://localhost:8900/api/entitlement/channel-spec-at-batch?tier=bogus&channels=telegram"` — expect `404`
- [ ] Byte-equal round-trip: `diff <(curl -s ".../channel-catalog-at?tier=cloud_pro" | jq '.channels|sort_by(.id)') <(curl -s ".../channel-spec-at-batch?tier=cloud_pro&channels=$(...all channel ids csv...)" | jq '.channels|sort_by(.id)')` — should be empty
- [ ] Byte-equal parity: same as above vs `/channel-spec-batch?channels=<csv>` (always-free invariant across the channel axis)
- [ ] Decrypt the live cloud snapshot, spot-check that nothing else regressed
- [ ] Browser-check the paywall matrix / channel-picker view still hydrates cleanly

Kept as **DRAFT** — the operator handles local-daemon verification, live-cloud verification, release, and merge.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BbWoEpybxtXa5bnjXAMJkn)_