### PR TITLE
fix: merge /tmp/gateway.log for container-runtime NemoClaw sandbox logs

### DIFF
--- a/clawmetry/adapters/openclaw.py
+++ b/clawmetry/adapters/openclaw.py
@@ -394,9 +394,13 @@ def _openshell_sandbox_logs(name: str, count: int = 20) -> list:
     """Retrieve OCSF JSON audit log lines for a NemoClaw sandbox.
 
     Arms OCSF output first (idempotent settings set), then calls
-    ``openshell logs <name> -n <count> --source all``.  Returns a list of
-    parsed OCSF event dicts; silently drops non-JSON lines.  Never raises;
-    returns ``[]`` when openshell is absent or any call fails.
+    ``openshell logs <name> -n <count> --source all``.  For container-backed
+    (non-terminal) sandboxes also merges the last ``count`` lines from the
+    OpenClaw gateway log at ``/tmp/gateway.log`` (override with
+    ``OPENSHELL_GATEWAY_LOG``), matching the harness's two-source merge in
+    ``showSandboxLogsWithDeps`` (#3571).  Returns a list of parsed OCSF event
+    dicts; silently drops non-JSON lines.  Never raises; returns ``[]`` when
+    openshell is absent or any call fails.
     """
     try:
         import shutil as _sh
@@ -420,6 +424,26 @@ def _openshell_sandbox_logs(name: str, count: int = 20) -> list:
             try:
                 events.append(json.loads(line))
             except Exception:
+                pass
+        # For container-backed (non-terminal) sandboxes the harness also tails
+        # /tmp/gateway.log (asserted in test/sandbox-logs-terminal.test.ts).
+        # Read runtime kind via the existing phase-policy helper and merge when
+        # the sandbox is not terminal-kind.
+        phase_info = _openshell_sandbox_phase_policy(name)
+        if phase_info.get("sandboxRuntimeKind", "").lower() != "terminal":
+            _gw_log = os.environ.get("OPENSHELL_GATEWAY_LOG", "/tmp/gateway.log")
+            try:
+                with open(_gw_log, "r", encoding="utf-8", errors="replace") as _gf:
+                    _gw_lines = _gf.readlines()[-count:]
+                for _gw_line in _gw_lines:
+                    _gw_line = _gw_line.strip()
+                    if not _gw_line:
+                        continue
+                    try:
+                        events.append(json.loads(_gw_line))
+                    except Exception:
+                        pass
+            except OSError:
                 pass
         return events
     except Exception:

--- a/tests/test_obs_gap_nemoclaw_gateway_log_3571.py
+++ b/tests/test_obs_gap_nemoclaw_gateway_log_3571.py
@@ -1,0 +1,172 @@
+"""Tests for #3571 — NemoClaw: sandbox gateway log stream (/tmp/gateway.log)
+merged for container-runtime sandboxes.
+
+Verifies that _openshell_sandbox_logs() reads /tmp/gateway.log (env-overrideable
+via OPENSHELL_GATEWAY_LOG) and appends its parsed JSON lines for non-terminal
+sandboxes, matching the harness's showSandboxLogsWithDeps two-source merge.
+
+Fingerprint: hgap-08cd94533a
+"""
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+
+import pytest
+
+from clawmetry.adapters.openclaw import _openshell_sandbox_logs
+
+
+def _fake_run_factory(*, ocsf_stdout="", runtime_kind="container"):
+    """Return a fake subprocess.run that serves openshell mock responses."""
+    def fake_run(cmd, **kw):
+        cmd_words = [str(c) for c in cmd]
+        if "sandbox" in cmd_words and "get" in cmd_words:
+            return type("R", (), {"stdout": f"Runtime: {runtime_kind}\n"})()
+        if "logs" in cmd_words and "--source" in cmd_words:
+            return type("R", (), {"stdout": ocsf_stdout})()
+        return type("R", (), {"stdout": ""})()
+    return fake_run
+
+
+def test_container_sandbox_includes_gateway_log(monkeypatch, tmp_path):
+    """Container-runtime sandbox: gateway.log JSON lines appended to OCSF events."""
+    monkeypatch.setattr(shutil, "which", lambda _: "/usr/bin/openshell")
+
+    ocsf_event = {"uid": "ocsf-1", "activity": "exec"}
+    gw_event = {"ts": 1700000001, "method": "tts.speak", "source": "gateway"}
+
+    gw_log = tmp_path / "gateway.log"
+    gw_log.write_text(json.dumps(gw_event) + "\n")
+    monkeypatch.setenv("OPENSHELL_GATEWAY_LOG", str(gw_log))
+
+    monkeypatch.setattr(
+        subprocess, "run",
+        _fake_run_factory(ocsf_stdout=json.dumps(ocsf_event) + "\n", runtime_kind="container"),
+    )
+
+    result = _openshell_sandbox_logs("my-sandbox")
+    assert ocsf_event in result
+    assert gw_event in result
+
+
+def test_terminal_sandbox_excludes_gateway_log(monkeypatch, tmp_path):
+    """Terminal-runtime sandbox: gateway.log is never read (harness parity)."""
+    monkeypatch.setattr(shutil, "which", lambda _: "/usr/bin/openshell")
+
+    gw_event = {"ts": 1700000001, "method": "tts.speak"}
+    gw_log = tmp_path / "gateway.log"
+    gw_log.write_text(json.dumps(gw_event) + "\n")
+    monkeypatch.setenv("OPENSHELL_GATEWAY_LOG", str(gw_log))
+
+    monkeypatch.setattr(
+        subprocess, "run",
+        _fake_run_factory(runtime_kind="terminal"),
+    )
+
+    result = _openshell_sandbox_logs("term-sandbox")
+    assert gw_event not in result
+
+
+def test_container_sandbox_missing_gateway_log_silently_ignored(monkeypatch):
+    """Container sandbox with no gateway.log returns OCSF events only; no error."""
+    monkeypatch.setattr(shutil, "which", lambda _: "/usr/bin/openshell")
+    monkeypatch.setenv("OPENSHELL_GATEWAY_LOG", "/nonexistent/path/gateway.log")
+
+    ocsf_event = {"uid": "ocsf-1", "activity": "exec"}
+    monkeypatch.setattr(
+        subprocess, "run",
+        _fake_run_factory(ocsf_stdout=json.dumps(ocsf_event) + "\n", runtime_kind="docker"),
+    )
+
+    result = _openshell_sandbox_logs("docker-sandbox")
+    assert result == [ocsf_event]
+
+
+def test_container_sandbox_non_json_gateway_lines_dropped(monkeypatch, tmp_path):
+    """Non-JSON gateway.log lines are silently skipped; valid events still returned."""
+    monkeypatch.setattr(shutil, "which", lambda _: "/usr/bin/openshell")
+
+    valid_gw = {"ts": 1700000002, "msg": "gateway ok"}
+    gw_log = tmp_path / "gateway.log"
+    gw_log.write_text(
+        "not-json-line\n"
+        "[INFO] gateway started\n"
+        + json.dumps(valid_gw) + "\n"
+    )
+    monkeypatch.setenv("OPENSHELL_GATEWAY_LOG", str(gw_log))
+
+    monkeypatch.setattr(
+        subprocess, "run",
+        _fake_run_factory(runtime_kind="container"),
+    )
+
+    result = _openshell_sandbox_logs("my-sandbox")
+    assert valid_gw in result
+    assert len(result) == 1
+
+
+def test_gateway_log_count_limits_lines_read(monkeypatch, tmp_path):
+    """Only the last `count` lines of gateway.log are read."""
+    monkeypatch.setattr(shutil, "which", lambda _: "/usr/bin/openshell")
+
+    lines = [{"i": i} for i in range(10)]
+    gw_log = tmp_path / "gateway.log"
+    gw_log.write_text("\n".join(json.dumps(e) for e in lines) + "\n")
+    monkeypatch.setenv("OPENSHELL_GATEWAY_LOG", str(gw_log))
+
+    monkeypatch.setattr(
+        subprocess, "run",
+        _fake_run_factory(runtime_kind="container"),
+    )
+
+    result = _openshell_sandbox_logs("my-sandbox", count=3)
+    # Only the last 3 entries (i=7,8,9) should appear
+    assert {"i": 9} in result
+    assert {"i": 8} in result
+    assert {"i": 7} in result
+    assert {"i": 0} not in result
+
+
+def test_no_openshell_gateway_log_never_read(monkeypatch, tmp_path):
+    """When openshell is absent, gateway.log is never opened (early return)."""
+    monkeypatch.setattr(shutil, "which", lambda _: None)
+
+    opened = []
+
+    real_open = open
+
+    def patched_open(path, *a, **kw):
+        opened.append(path)
+        return real_open(path, *a, **kw)
+
+    gw_log = tmp_path / "gateway.log"
+    gw_log.write_text('{"ts": 123}\n')
+    monkeypatch.setenv("OPENSHELL_GATEWAY_LOG", str(gw_log))
+
+    result = _openshell_sandbox_logs("my-sandbox")
+    assert result == []
+    assert not any(str(gw_log) in str(p) for p in opened)
+
+
+def test_unknown_runtime_kind_includes_gateway_log(monkeypatch, tmp_path):
+    """Unknown/absent sandboxRuntimeKind defaults to non-terminal; gateway.log included."""
+    monkeypatch.setattr(shutil, "which", lambda _: "/usr/bin/openshell")
+
+    gw_event = {"ts": 1700000003, "msg": "startup"}
+    gw_log = tmp_path / "gateway.log"
+    gw_log.write_text(json.dumps(gw_event) + "\n")
+    monkeypatch.setenv("OPENSHELL_GATEWAY_LOG", str(gw_log))
+
+    def fake_run(cmd, **kw):
+        cmd_words = [str(c) for c in cmd]
+        if "sandbox" in cmd_words and "get" in cmd_words:
+            # No "Runtime:" line in output → sandboxRuntimeKind absent → ""
+            return type("R", (), {"stdout": "Phase: running\n"})()
+        return type("R", (), {"stdout": ""})()
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    result = _openshell_sandbox_logs("unknown-kind-sandbox")
+    assert gw_event in result


### PR DESCRIPTION
Closes #3571

## What

For non-terminal (container-backed) NemoClaw sandboxes, `_openshell_sandbox_logs()` now also reads the tail of `/tmp/gateway.log` and appends its parsed JSON lines to the OCSF event list — matching the harness's two-source merge in `showSandboxLogsWithDeps` (`test/sandbox-logs-terminal.test.ts` asserts this source is skipped only for `runtime.kind === 'terminal'`).

- **`clawmetry/adapters/openclaw.py`** — after collecting OCSF events, calls `_openshell_sandbox_phase_policy(name)` to get `sandboxRuntimeKind`. If the kind is anything other than `"terminal"`, reads the last `count` lines of `$OPENSHELL_GATEWAY_LOG` (default `/tmp/gateway.log`), parses JSON, and appends to events. ~20 lines.
- **`tests/test_obs_gap_nemoclaw_gateway_log_3571.py`** — 7 new tests: container sandbox includes gateway.log; terminal sandbox does not; missing file is silently ignored; non-JSON lines dropped; `count` limits lines read; openshell-absent short-circuits before any file I/O; unknown runtime kind defaults to non-terminal.

## Test plan

- `python -m pytest tests/test_obs_gap_nemoclaw_gateway_log_3571.py -v` → 7 passed
- `python -m pytest tests/test_obs_gap_nemoclaw_ocsf_3299.py tests/test_obs_gap_nemoclaw_ocsf_3389.py -v` → 14 passed (no regressions)
- `python -m py_compile clawmetry/adapters/openclaw.py` → syntax OK

---
_Generated by [Claude Code](https://claude.ai/code/session_012FXN2uCudPkyQhqRbXZu1z)_