### PR TITLE
feat(obs): surface ClawHub promo offers in _clawrouter_detect() (#3570)

### DIFF
--- a/clawmetry/adapters/openclaw.py
+++ b/clawmetry/adapters/openclaw.py
@@ -218,6 +218,36 @@ def _clawrouter_detect() -> dict:
     except (OSError, ValueError, KeyError):
         pass
 
+    # Promos file: ClawHub promotional model offers (#3570, openclaw#100236)
+    promos_path = os.path.join(home, "promos.json")
+    try:
+        with open(promos_path, encoding="utf-8") as _fh:
+            promos_data = _json.load(_fh)
+        # List-of-claims format: {"claimedPromos": [...]} or {"claims": [...]}
+        claims = (
+            promos_data.get("claimedPromos")
+            or promos_data.get("claims")
+            or promos_data.get("activeClaims")
+            or []
+        )
+        if isinstance(claims, list) and claims:
+            active = [c for c in claims if isinstance(c, dict) and c.get("active", True)]
+            if active:
+                out["clawRouterPromoActive"] = True
+                out["clawRouterPromoCount"] = len(active)
+                first_model = active[0].get("modelRef") or active[0].get("model")
+                if first_model:
+                    out["clawRouterPromoModel"] = str(first_model)
+        elif isinstance(promos_data.get("active"), bool):
+            # Single-promo format: {"active": true, "modelRef": "...", ...}
+            if promos_data["active"]:
+                out["clawRouterPromoActive"] = True
+                promo_model = promos_data.get("modelRef") or promos_data.get("model")
+                if promo_model:
+                    out["clawRouterPromoModel"] = str(promo_model)
+    except (OSError, ValueError, KeyError):
+        pass
+
     return out
 
 

--- a/tests/test_obs_gap_openclaw_clawrouter_3570.py
+++ b/tests/test_obs_gap_openclaw_clawrouter_3570.py
@@ -1,0 +1,114 @@
+"""Tests for issue #3570 — openclaw: ClawHub promotional model offers not surfaced.
+
+Verifies that _clawrouter_detect() reads promos.json from
+~/.openclaw/clawrouter/ (or OPENCLAW_CLAWROUTER_HOME) and surfaces
+active promo state, count, and model ref alongside the existing config/quota data.
+
+Fingerprint: hgap-966f276123
+"""
+from __future__ import annotations
+
+import importlib
+import json
+import os
+
+
+def _reload_adapter():
+    import clawmetry.adapters.openclaw as oc_mod
+    importlib.reload(oc_mod)
+    return oc_mod
+
+
+def test_active_list_format_promos_surfaced(tmp_path):
+    """List-format promos with active claims: all keys surfaced."""
+    cr_home = tmp_path / "clawrouter"
+    cr_home.mkdir()
+    promos = {
+        "claimedPromos": [
+            {"id": "promo-abc", "modelRef": "claude-sonnet-5", "active": True},
+            {"id": "promo-xyz", "modelRef": "gpt-4o", "active": True},
+        ]
+    }
+    (cr_home / "promos.json").write_text(json.dumps(promos))
+    os.environ["OPENCLAW_CLAWROUTER_HOME"] = str(cr_home)
+    try:
+        oc = _reload_adapter()
+        result = oc._clawrouter_detect()
+    finally:
+        del os.environ["OPENCLAW_CLAWROUTER_HOME"]
+
+    assert result["clawRouterPromoActive"] is True
+    assert result["clawRouterPromoCount"] == 2
+    assert result["clawRouterPromoModel"] == "claude-sonnet-5"
+
+
+def test_no_promos_file_no_promo_keys(tmp_path):
+    """Missing promos.json: no promo keys in result (no regression)."""
+    cr_home = tmp_path / "clawrouter"
+    cr_home.mkdir()
+    # Write config so the function has something to return
+    (cr_home / "config.json").write_text(json.dumps({"enabled": True}))
+    os.environ["OPENCLAW_CLAWROUTER_HOME"] = str(cr_home)
+    try:
+        oc = _reload_adapter()
+        result = oc._clawrouter_detect()
+    finally:
+        del os.environ["OPENCLAW_CLAWROUTER_HOME"]
+
+    assert "clawRouterPromoActive" not in result
+    assert "clawRouterPromoCount" not in result
+    assert "clawRouterPromoModel" not in result
+    assert result.get("clawRouterEnabled") is True
+
+
+def test_malformed_promos_json_silently_skipped(tmp_path):
+    """Malformed promos.json is silently ignored; other data still extracted."""
+    cr_home = tmp_path / "clawrouter"
+    cr_home.mkdir()
+    (cr_home / "config.json").write_text(json.dumps({"enabled": True, "version": "0.3.1"}))
+    (cr_home / "promos.json").write_text("not-valid-json{{{")
+    os.environ["OPENCLAW_CLAWROUTER_HOME"] = str(cr_home)
+    try:
+        oc = _reload_adapter()
+        result = oc._clawrouter_detect()
+    finally:
+        del os.environ["OPENCLAW_CLAWROUTER_HOME"]
+
+    assert "clawRouterPromoActive" not in result
+    assert result["clawRouterEnabled"] is True
+    assert result["clawRouterVersion"] == "0.3.1"
+
+
+def test_single_promo_active_format(tmp_path):
+    """Single-promo format with active=True: flag and model surfaced."""
+    cr_home = tmp_path / "clawrouter"
+    cr_home.mkdir()
+    promos = {"active": True, "modelRef": "gemini-2.5-pro", "promoId": "clawhub-summer"}
+    (cr_home / "promos.json").write_text(json.dumps(promos))
+    os.environ["OPENCLAW_CLAWROUTER_HOME"] = str(cr_home)
+    try:
+        oc = _reload_adapter()
+        result = oc._clawrouter_detect()
+    finally:
+        del os.environ["OPENCLAW_CLAWROUTER_HOME"]
+
+    assert result["clawRouterPromoActive"] is True
+    assert result["clawRouterPromoModel"] == "gemini-2.5-pro"
+    assert "clawRouterPromoCount" not in result
+
+
+def test_single_promo_inactive_not_surfaced(tmp_path):
+    """Single-promo format with active=False: no promo keys emitted."""
+    cr_home = tmp_path / "clawrouter"
+    cr_home.mkdir()
+    promos = {"active": False, "modelRef": "claude-sonnet-5", "promoId": "clawhub-old"}
+    (cr_home / "promos.json").write_text(json.dumps(promos))
+    os.environ["OPENCLAW_CLAWROUTER_HOME"] = str(cr_home)
+    try:
+        oc = _reload_adapter()
+        result = oc._clawrouter_detect()
+    finally:
+        del os.environ["OPENCLAW_CLAWROUTER_HOME"]
+
+    assert "clawRouterPromoActive" not in result
+    assert "clawRouterPromoModel" not in result


### PR DESCRIPTION
## Summary

`_clawrouter_detect()` already reads `config.json` and `quota.json` from `~/.openclaw/clawrouter/`, but never checked `promos.json` — so claimed ClawHub promotional model offers were completely invisible to the dashboard. This PR adds the third file read using the identical `try/except (OSError, ValueError, KeyError)` pattern, so missing or malformed promo files are silently ignored with zero regression.

## Changes

- **`clawmetry/adapters/openclaw.py`** — after the quota block in `_clawrouter_detect()`, read `promos.json` from the ClawRouter home dir. Handles two observed JSON shapes: list-of-claims (`claimedPromos`/`claims`/`activeClaims` array) and single-promo (`active` bool + `modelRef`). Emits `clawRouterPromoActive` (bool), `clawRouterPromoCount` (int, list format only), and `clawRouterPromoModel` (str, first active model ref). ~25 lines.
- **`tests/test_obs_gap_openclaw_clawrouter_3570.py`** — 5 new tests following the exact pattern of `test_obs_gap_openclaw_clawrouter_3524.py`: active list-format promo, missing file (no regression), malformed JSON (no regression), single-promo active, single-promo inactive. All 10 tests (new + existing #3524) pass.

## Test plan

- [ ] `python -m pytest tests/test_obs_gap_openclaw_clawrouter_3570.py tests/test_obs_gap_openclaw_clawrouter_3524.py -v` → 10/10 passed
- [ ] `python -m py_compile clawmetry/adapters/openclaw.py` → syntax clean

## Bot meta

<!-- bot-autofix -->
Draft PR opened autonomously based on the plan in #3570. Marked draft for human review — mark Ready for Review once happy.

**Scope note:** This PR surfaces the promo observability signal. Adjusting cost calculation to apply promo discount rates is deferred — the exact discount schema isn't documented in the audit fingerprint yet.

Closes #3570

---
_Generated by [Claude Code](https://claude.ai/code/session_01KAjz7wfhkXLbjPE2tdhhfZ)_