### PR TITLE
docs: fix stale version, line counts, and architecture claims

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -271,7 +271,7 @@ Secured with `CLAWMETRY_FLEET_KEY` — nodes must provide the API key to registe
 ## Technical Details
 
 ### Modular Blueprint Architecture
-ClawMetry is a Flask app organised as a small core (`dashboard.py`, ~15,000 lines) plus a `routes/` package of feature-scoped Blueprints (sessions, channels, components, usage, health, brain, infra, overview, crons, meta, alerts, fleet_history, nemoclaw). Shared helpers and the embedded HTML/CSS/JS templates still live in `dashboard.py`; route handlers reach them via a late `import dashboard as _d`.
+ClawMetry is a Flask app organised as a small core (`dashboard.py`, ~19,000 lines) plus a `routes/` package of feature-scoped Blueprints (sessions, channels, components, usage, health, brain, infra, overview, crons, meta, alerts, fleet_history, nemoclaw). Shared helpers live in `dashboard.py`; the live UI is served from `clawmetry/static/` + `clawmetry/templates/`. Route handlers reach shared helpers via a late `import dashboard as _d`.
 
 This layout keeps the install story simple while letting each feature evolve in its own module:
 - Easy to install (`pip install clawmetry`)
@@ -279,7 +279,7 @@ This layout keeps the install story simple while letting each feature evolve in 
 - Easy to deploy (pure-Python, no build step)
 - Portable (runs on a Raspberry Pi)
 
-The HTML/CSS/JS dashboard is embedded as template strings inside `dashboard.py`.
+The HTML/CSS/JS dashboard is served from `clawmetry/static/css/dashboard.css`, `clawmetry/static/js/app.js`, and `clawmetry/templates/tabs/*.html` — not embedded inline in `dashboard.py`.
 
 ### Event Data Source Contract
 OSS API routes that serve event-derived dashboard data must tag their JSON
@@ -300,7 +300,7 @@ event-data response omits `_source` or reports anything other than
 ### Dependencies
 Minimal by design:
 - **Flask** — Web server
-- **No database** — reads OpenClaw's files directly
+- **DuckDB** — local store; the sync daemon ingests all events and owns the writer lock; the dashboard reads through the daemon proxy (`/__local_query__/`)
 - **Optional**: `opentelemetry-proto` for OTLP support
 - **Optional**: `history.py` for time-series storage (SQLite-based)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,10 +54,10 @@ All HTTP endpoints live here, organised by feature. Each module owns one or more
 | `local_server.py` | ~200 | Daemon-hosted localhost query server (`/__local_query__/<method>`) so the dashboard/sync read DuckDB without grabbing the writer lock |
 | `proxy.py` | ~2,600 | Enforcement proxy — budget limits, loop detection, model routing (port 4100) |
 | `interceptor.py` | ~630 | Zero-config HTTP monkey-patching for LLM cost tracking (patches httpx/requests) |
-| `providers_pricing.py` | ~134 | Multi-provider pricing table (Anthropic, OpenAI, Google, OpenRouter, etc.) |
-| `config.py` | ~80 | Configuration dataclass |
-| `extensions.py` | ~109 | Plugin/hook system |
-| `track.py` | ~39 | Zero-config interceptor shorthand |
+| `providers_pricing.py` | ~390 | Multi-provider pricing table (Anthropic, OpenAI, Google, OpenRouter, etc.) |
+| `config.py` | ~200 | Configuration dataclass |
+| `extensions.py` | ~180 | Plugin/hook system |
+| `track.py` | ~60 | Zero-config interceptor shorthand |
 | `providers/` | — | Pluggable data provider layer (LocalDataProvider, TursoDataProvider) |
 
 ### Config & Build
@@ -146,7 +146,7 @@ Tests use `CLAWMETRY_URL` and `CLAWMETRY_TOKEN` env vars. Test matrix in CI: 3 O
 ## Deploy
 - **PyPI**: `pip install clawmetry && clawmetry`
 - **Docker**: `docker build -t clawmetry . && docker run -p 8900:8900 -v ~/.openclaw:/root/.openclaw:ro clawmetry`
-- **Current version**: `0.12.525` (in `dashboard.py` `__version__`)
+- **Current version**: `0.12.544` (in `dashboard.py` `__version__`)
 
 ## CI/CD (GitHub Actions)
 - `ci.yml` — Lint + test matrix on push/PR


### PR DESCRIPTION
Closes #3573

Fixes the 11 stale documentation claims found in the weekly docs-drift audit.

## Changes

- **CLAUDE.md** — 5 fixes:
  - Version `0.12.525` → `0.12.544` (verified against `__version__` in `dashboard.py`)
  - Line counts for `providers_pricing.py` (134→390), `config.py` (80→200), `extensions.py` (109→180), `track.py` (39→60) — all verified with `wc -l`

- **ARCHITECTURE.md** — 4 fixes:
  - `dashboard.py` size `~15,000` → `~19,000` lines
  - Two paragraphs that described the frontend as "embedded as template strings inside `dashboard.py`" — corrected to reference `clawmetry/static/` + `clawmetry/templates/`
  - "No database" dependency bullet replaced with accurate DuckDB description

## Test plan

- `make lint` — 210 pre-existing Python lint errors unchanged; markdown files unaffected
- All claimed facts re-verified against live codebase (`wc -l`, `grep __version__`, directory listing)

---
_Generated by [Claude Code](https://claude.ai/code/session_01C794fEaaC9CxkhoMkzbksb)_