### PR TITLE
feat(entitlement): channel_spec_at_path + /api/entitlement/channel-spec-at-path

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -13279,6 +13279,65 @@ def channel_catalog_at_path(
         return None
 
 
+def channel_spec_at_path(
+    perspective_tier: str, from_tier: str, to_tier: str, channel: str
+) -> list[dict] | None:
+    """Perspective-validated what-if wrapper around :func:`channel_spec_path`.
+
+    Channel-axis twin of :func:`feature_spec_at_path` /
+    :func:`runtime_spec_at_path`; fills the ``_at_path`` slot of the
+    ``channel_spec`` family alongside :func:`channel_spec` (scalar
+    current), :func:`channel_spec_at` (scalar what-if),
+    :func:`channel_spec_batch` (batch current),
+    :func:`channel_spec_at_batch` (batch what-if), and
+    :func:`channel_spec_path` (path current) so a pricing-comparison
+    walkthrough surface can call ``X_at_path(perspective, from, to, ...)``
+    uniformly across the whole ``_at_path`` family (feature / runtime /
+    channel / tier).
+
+    The perspective is validated (empty / unknown ids short-circuit to
+    ``None``) but does NOT shape the rows -- the body is byte-identical
+    to :func:`channel_spec_path` for every ``(from, to, channel)``
+    triple. Pinned by parity tests so the scalar ``_at_path`` can never
+    drift from :func:`channel_spec_path` (which itself walks per-rung
+    via :func:`channel_spec_at`).
+
+    Because every chat-channel adapter is FREE at every tier (the
+    ``channels`` capacity axis governs how many concurrent channels
+    each plan admits, not which adapters unlock), each row's per-rung
+    body is byte-identical to the LIVE :func:`channel_spec` row after
+    dropping the three ``rung*`` keys. The always-free invariant is
+    inherited from the delegate; parity tests pin it.
+
+    Endpoint semantics match :func:`channel_spec_path`: perspective,
+    from and to accept any id in :data:`_TIER_FEATURES` (``trial``
+    accepted, excluded from the walked intermediate rungs, valid
+    endpoint via the lateral / identity branch). ``channel`` accepts
+    any id in :data:`ALL_CHANNELS`.
+
+    Resolver-independent: rows are synthesised via
+    :func:`_channel_spec_row` against per-rung
+    :func:`_hypothetical_entitlement` objects (delegated through
+    :func:`channel_spec_path`), so grace vs enforce yields byte-
+    identical rows -- same property the rest of the ``_path`` family
+    guarantees.
+
+    Never raises: a delegation failure logs a warning and returns
+    ``None`` so a paywall surface keeps rendering instead of breaking.
+    """
+    try:
+        p = (perspective_tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if not p or p not in _TIER_FEATURES:
+        return None
+    try:
+        return channel_spec_path(from_tier, to_tier, channel)
+    except Exception as exc:
+        logger.warning("entitlements: channel_spec_at_path failed: %s", exc)
+        return None
+
+
 def lock_reason_at_path(
     perspective_tier: str,
     from_tier: str,

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -9445,6 +9445,164 @@ def api_entitlement_channel_spec_path():
         )
 
 
+@bp_entitlement.route("/api/entitlement/channel-spec-at-path")
+def api_entitlement_channel_spec_at_path():
+    """``GET /api/entitlement/channel-spec-at-path?tier=<perspective>
+    &from=<id>&to=<id>&channel=<id>`` -- perspective-validated what-if
+    sibling of ``/api/entitlement/channel-spec-path``.
+
+    Channel-axis twin of ``/feature-spec-at-path`` /
+    ``/runtime-spec-at-path``; fills the ``_at_path`` slot of the
+    ``channel-spec`` family alongside ``/channel-spec`` (scalar
+    current), ``/channel-spec-at`` (scalar what-if),
+    ``/channel-spec-batch`` (batch current),
+    ``/channel-spec-at-batch`` (batch what-if), and
+    ``/channel-spec-path`` (path current). The perspective is validated
+    (400 on missing, 404 on unknown) but does NOT shape the ``path``
+    rows -- the body is byte-identical to
+    ``/channel-spec-path?from=<from>&to=<to>&channel=<channel>`` for
+    every perspective. Pinned by parity tests so the ``_at_path`` and
+    ``_path`` endpoints cannot drift.
+
+    Response shape (mirrors ``/channel-spec-path`` plus a
+    ``perspective_tier`` echo and the standard ``_at*`` resolver-
+    context tail so a paywall matrix UI can render "at Cloud Pro this
+    channel is free at every rung" without a second call to
+    ``/entitlement``)::
+
+        {
+          "perspective_tier":      "<id>",
+          "perspective_tier_rank": <int>,
+          "from":                  "<tier id>",
+          "from_label":            "...",
+          "from_rank":             <int>,
+          "to":                    "<tier id>",
+          "to_label":              "...",
+          "to_rank":               <int>,
+          "direction":             "upgrade" | "downgrade" | "lateral" | "identity",
+          "channel":               "<channel id>",
+          "path":                  [<channel_spec_path row>, ...],
+          "current_tier":          "...",
+          "current_tier_rank":     <int>,
+          "grace":                 <bool>,
+          "enforced":              <bool>,
+        }
+
+    - **400** when ``tier=``, ``from=``, ``to=`` or ``channel=`` is
+      missing / blank
+    - **404** when any id is unknown (body carries
+      ``which: "tier" | "from" | "to" | "channel"`` so the caller can
+      point at the offender)
+    - **Never 5xxs**: a resolver failure short-circuits to the grace-
+      shape envelope with the perspective echoed so the UI keeps
+      rendering.
+    """
+    raw_tier = request.args.get("tier")
+    tier_in = (raw_tier or "").strip().lower()
+    if not tier_in:
+        return jsonify({"error": "missing tier"}), 400
+    f = (request.args.get("from") or "").strip().lower()
+    t = (request.args.get("to") or "").strip().lower()
+    if not f:
+        return jsonify({"error": "missing from"}), 400
+    if not t:
+        return jsonify({"error": "missing to"}), 400
+    ch = (request.args.get("channel") or "").strip().lower()
+    if not ch:
+        return jsonify({"error": "missing channel"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        if tier_in not in _ent._TIER_FEATURES:
+            return (
+                jsonify(
+                    {
+                        "error": "unknown tier",
+                        "which": "tier",
+                        "tier": tier_in,
+                    }
+                ),
+                404,
+            )
+        if f not in _ent._TIER_FEATURES:
+            return (
+                jsonify(
+                    {"error": "unknown from", "which": "from", "from": f}
+                ),
+                404,
+            )
+        if t not in _ent._TIER_FEATURES:
+            return (
+                jsonify({"error": "unknown to", "which": "to", "to": t}),
+                404,
+            )
+        if ch not in _ent.ALL_CHANNELS:
+            return (
+                jsonify(
+                    {
+                        "error": "unknown channel",
+                        "which": "channel",
+                        "channel": ch,
+                    }
+                ),
+                404,
+            )
+        path = _ent.channel_spec_at_path(tier_in, f, t, ch)
+        if path is None:
+            path = []
+        from_rank = _ent.tier_rank(f)
+        to_rank = _ent.tier_rank(t)
+        if f == t:
+            direction = "identity"
+        elif from_rank == to_rank:
+            direction = "lateral"
+        elif to_rank > from_rank:
+            direction = "upgrade"
+        else:
+            direction = "downgrade"
+        ent = _ent.get_entitlement()
+        return jsonify(
+            {
+                "perspective_tier": tier_in,
+                "perspective_tier_rank": _ent.tier_rank(tier_in),
+                "from": f,
+                "from_label": _ent.tier_label(f),
+                "from_rank": from_rank,
+                "to": t,
+                "to_label": _ent.tier_label(t),
+                "to_rank": to_rank,
+                "direction": direction,
+                "channel": ch,
+                "path": path,
+                "current_tier": ent.tier,
+                "current_tier_rank": _ent.tier_rank(ent.tier),
+                "grace": bool(ent.grace),
+                "enforced": _ent.is_enforced(),
+            }
+        )
+    except Exception as exc:
+        logger.warning("api_entitlement_channel_spec_at_path: error: %s", exc)
+        return jsonify(
+            {
+                "perspective_tier": tier_in,
+                "perspective_tier_rank": 0,
+                "from": f,
+                "from_label": None,
+                "from_rank": -1,
+                "to": t,
+                "to_label": None,
+                "to_rank": -1,
+                "direction": "identity" if f == t else "upgrade",
+                "channel": ch,
+                "path": [],
+                "current_tier": "oss",
+                "current_tier_rank": 0,
+                "grace": True,
+                "enforced": False,
+            }
+        )
+
+
 @bp_entitlement.route("/api/entitlement/tier-catalog-path")
 def api_entitlement_tier_catalog_path():
     """``GET /api/entitlement/tier-catalog-path?from=<id>&to=<id>`` --

--- a/tests/test_entitlement_channel_spec_at_path.py
+++ b/tests/test_entitlement_channel_spec_at_path.py
@@ -1,0 +1,536 @@
+"""Tests for
+``clawmetry.entitlements.channel_spec_at_path(perspective, from, to, channel)``
++ the ``GET /api/entitlement/channel-spec-at-path`` endpoint.
+
+Channel-axis twin of :func:`feature_spec_at_path` /
+:func:`runtime_spec_at_path`: perspective is validated but does NOT
+shape the ``path`` rows, so an upgrade-walkthrough surface can call
+``X_at_path(perspective, from, to, ...)`` uniformly across the whole
+``_at_path`` family (alongside ``preview_at_path``,
+``tier_catalog_at_path``, ``channel_catalog_at_path``).
+
+Pins:
+
+* body byte-parity with :func:`channel_spec_path` for every
+  ``(perspective, from, to, channel)`` quadruple; perspective
+  invariance (rows byte-identical across shifting perspective for the
+  same ``(from, to, channel)``)
+* per-rung path row byte-equals :func:`channel_spec_at(rung, channel)`
+  after dropping the three ``rung*`` keys (delegated from
+  :func:`channel_spec_path`, pinned by
+  ``test_entitlement_channel_spec_path``)
+* always-free invariant: every chat-channel adapter is FREE at every
+  tier, so every path row reports ``free=True`` / ``allowed=True`` /
+  ``locked=False`` / ``entitled=True`` regardless of perspective
+* unknown perspective / from / to / channel short-circuit to ``None``
+* case + whitespace normalisation on all four ids
+* trial accepted as perspective + endpoint (lateral / identity branch)
+* grace vs enforce identical rows (delegates to
+  :func:`channel_spec_path` which walks static per-tier maps)
+* API surface: 400 on missing / blank args, 404 with ``which``
+  bucketing on unknown tier ids, 404 with ``which: "channel"`` on
+  unknown channel, 200 envelope with ``perspective_tier`` echo +
+  standard ``_at*`` resolver-context tail on the happy path
+* endpoint never 5xxs on resolver crash
+"""
+from __future__ import annotations
+
+import importlib
+from itertools import product
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+ALL_TIERS = (
+    "oss",
+    "cloud_free",
+    "trial",
+    "cloud_starter",
+    "cloud_pro",
+    "pro",
+    "enterprise",
+)
+
+# A representative slice of the 21 chat-channel adapters so the parity
+# sweep touches multiple ids without ballooning the product() cost.
+SAMPLE_CHANNELS = (
+    "telegram",
+    "signal",
+    "discord",
+    "whatsapp",
+    "imessage",
+)
+
+_RUNG_KEYS = {"rung", "rung_label", "rung_rank"}
+
+_SCALAR_ENVELOPE_KEYS = {
+    "perspective_tier",
+    "perspective_tier_rank",
+    "from",
+    "from_label",
+    "from_rank",
+    "to",
+    "to_label",
+    "to_rank",
+    "direction",
+    "channel",
+    "path",
+    "current_tier",
+    "current_tier_rank",
+    "grace",
+    "enforced",
+}
+
+
+# ── scalar helper: shape + invariants ────────────────────────────────────────
+
+
+def test_scalar_returns_list(ent):
+    path = ent.channel_spec_at_path(
+        "cloud_pro", "oss", "enterprise", "telegram"
+    )
+    assert isinstance(path, list)
+    assert len(path) >= 1
+
+
+def test_scalar_body_byte_parity_with_channel_spec_path(ent):
+    """Perspective must NOT shape the rows -- delegation to
+    :func:`channel_spec_path` is byte-identical for every perspective."""
+    for perspective, f, t, ch in product(
+        ALL_TIERS, ALL_TIERS, ALL_TIERS, SAMPLE_CHANNELS
+    ):
+        at_path = ent.channel_spec_at_path(perspective, f, t, ch)
+        direct = ent.channel_spec_path(f, t, ch)
+        assert at_path == direct, (perspective, f, t, ch)
+
+
+def test_scalar_perspective_invariance(ent):
+    """Rows must be byte-identical across every perspective for the same
+    ``(from, to, channel)`` triple."""
+    for f, t, ch in product(
+        ("oss", "cloud_free"), ("enterprise", "pro"), SAMPLE_CHANNELS
+    ):
+        rows_by_perspective = [
+            ent.channel_spec_at_path(p, f, t, ch) for p in ALL_TIERS
+        ]
+        first = rows_by_perspective[0]
+        for other in rows_by_perspective[1:]:
+            assert other == first
+
+
+def test_scalar_per_rung_byte_equality_with_channel_spec_at(ent):
+    """Dropping the three ``rung*`` keys from a path row yields exact
+    byte-equality with :func:`channel_spec_at(rung, channel)` -- a
+    property inherited from :func:`channel_spec_path`."""
+    path = ent.channel_spec_at_path(
+        "cloud_pro", "oss", "enterprise", "telegram"
+    )
+    for row in path:
+        body = {k: v for k, v in row.items() if k not in _RUNG_KEYS}
+        direct = ent.channel_spec_at(row["rung"], "telegram")
+        assert body == direct
+
+
+def test_scalar_per_rung_byte_equality_with_live_channel_spec(ent):
+    """Every channel is FREE at every tier, so each rung's body is
+    byte-identical to the LIVE :func:`channel_spec(channel)` row."""
+    live = ent.channel_spec("telegram")
+    path = ent.channel_spec_at_path(
+        "cloud_pro", "oss", "enterprise", "telegram"
+    )
+    for row in path:
+        body = {k: v for k, v in row.items() if k not in _RUNG_KEYS}
+        assert body == live
+
+
+def test_scalar_identity_returns_empty_path(ent):
+    path = ent.channel_spec_at_path(
+        "cloud_pro", "cloud_pro", "cloud_pro", "telegram"
+    )
+    assert path == []
+
+
+def test_scalar_lateral_returns_single_row(ent):
+    # cloud_pro and pro share a rank; lateral returns a single-row path.
+    path = ent.channel_spec_at_path("oss", "cloud_pro", "pro", "telegram")
+    assert isinstance(path, list)
+    assert len(path) == 1
+    assert path[0]["rung"] == "pro"
+
+
+def test_scalar_upgrade_ranks_monotonic(ent):
+    path = ent.channel_spec_at_path("oss", "oss", "enterprise", "telegram")
+    ranks = [r["rung_rank"] for r in path]
+    assert ranks == sorted(ranks)
+
+
+def test_scalar_downgrade_ranks_monotonic(ent):
+    path = ent.channel_spec_at_path("oss", "enterprise", "oss", "telegram")
+    ranks = [r["rung_rank"] for r in path]
+    assert ranks == sorted(ranks, reverse=True)
+
+
+def test_scalar_trial_accepted_as_perspective(ent):
+    path = ent.channel_spec_at_path(
+        "trial", "oss", "enterprise", "telegram"
+    )
+    assert isinstance(path, list)
+
+
+def test_scalar_trial_accepted_as_endpoint_identity(ent):
+    path = ent.channel_spec_at_path(
+        "cloud_pro", "trial", "trial", "telegram"
+    )
+    assert path == []
+
+
+def test_scalar_every_channel_free_at_every_rung(ent):
+    """Always-free invariant: every returned row must report
+    ``free=True`` / ``allowed=True`` / ``locked=False`` /
+    ``entitled=True`` at every rung, regardless of perspective."""
+    for perspective, ch in product(ALL_TIERS, SAMPLE_CHANNELS):
+        path = ent.channel_spec_at_path(perspective, "oss", "enterprise", ch)
+        assert path
+        for row in path:
+            assert row["free"] is True
+            assert row["allowed"] is True
+            assert row["locked"] is False
+            assert row["entitled"] is True
+
+
+def test_scalar_unknown_perspective_returns_none(ent):
+    assert ent.channel_spec_at_path(
+        "bogus", "oss", "enterprise", "telegram"
+    ) is None
+
+
+def test_scalar_unknown_from_returns_none(ent):
+    assert ent.channel_spec_at_path(
+        "cloud_pro", "bogus", "enterprise", "telegram"
+    ) is None
+
+
+def test_scalar_unknown_to_returns_none(ent):
+    assert ent.channel_spec_at_path(
+        "cloud_pro", "oss", "bogus", "telegram"
+    ) is None
+
+
+def test_scalar_unknown_channel_returns_none(ent):
+    assert ent.channel_spec_at_path(
+        "cloud_pro", "oss", "enterprise", "no_such_channel"
+    ) is None
+
+
+def test_scalar_none_inputs_return_none(ent):
+    assert ent.channel_spec_at_path(None, "oss", "enterprise", "telegram") is None
+    assert ent.channel_spec_at_path("cloud_pro", None, "enterprise", "telegram") is None
+    assert ent.channel_spec_at_path("cloud_pro", "oss", None, "telegram") is None
+    assert ent.channel_spec_at_path("cloud_pro", "oss", "enterprise", None) is None
+
+
+def test_scalar_blank_inputs_return_none(ent):
+    assert ent.channel_spec_at_path("", "oss", "enterprise", "telegram") is None
+    assert ent.channel_spec_at_path("   ", "oss", "enterprise", "telegram") is None
+
+
+def test_scalar_whitespace_and_case_normalisation(ent):
+    padded = ent.channel_spec_at_path(
+        "  Cloud_Pro  ", "  OSS  ", "  ENTERPRISE  ", "  Telegram  "
+    )
+    canonical = ent.channel_spec_at_path(
+        "cloud_pro", "oss", "enterprise", "telegram"
+    )
+    assert padded == canonical
+
+
+def test_scalar_never_raises_on_weird_types(ent):
+    for weird in (b"bytes", 123, 4.5, ["oss"], {"tier": "oss"}):
+        # None of these should raise -- they should all short-circuit
+        # to ``None``.
+        assert ent.channel_spec_at_path(
+            weird, "oss", "enterprise", "telegram"
+        ) is None
+
+
+def test_scalar_grace_vs_enforce_byte_identical(ent, monkeypatch):
+    import clawmetry.entitlements as e
+
+    grace_path = ent.channel_spec_at_path(
+        "cloud_pro", "oss", "enterprise", "telegram"
+    )
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    importlib.reload(e)
+    e.invalidate()
+    try:
+        enforced_path = e.channel_spec_at_path(
+            "cloud_pro", "oss", "enterprise", "telegram"
+        )
+        assert enforced_path == grace_path
+    finally:
+        monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+        importlib.reload(e)
+        e.invalidate()
+
+
+def test_scalar_delegate_crash_short_circuits_to_none(ent, monkeypatch):
+    def boom(from_tier, to_tier, channel):
+        raise RuntimeError("simulated delegate failure")
+
+    monkeypatch.setattr(ent, "channel_spec_path", boom)
+    assert ent.channel_spec_at_path(
+        "cloud_pro", "oss", "enterprise", "telegram"
+    ) is None
+
+
+# ── HTTP scalar endpoint ─────────────────────────────────────────────────────
+
+
+def test_http_envelope_shape(client, ent):
+    r = client.get(
+        "/api/entitlement/channel-spec-at-path"
+        "?tier=cloud_pro&from=oss&to=enterprise&channel=telegram"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert set(body.keys()) == _SCALAR_ENVELOPE_KEYS
+
+
+def test_http_missing_tier_400(client):
+    r = client.get(
+        "/api/entitlement/channel-spec-at-path"
+        "?from=oss&to=enterprise&channel=telegram"
+    )
+    assert r.status_code == 400
+    assert r.get_json() == {"error": "missing tier"}
+
+
+def test_http_missing_from_400(client):
+    r = client.get(
+        "/api/entitlement/channel-spec-at-path"
+        "?tier=cloud_pro&to=enterprise&channel=telegram"
+    )
+    assert r.status_code == 400
+    assert r.get_json() == {"error": "missing from"}
+
+
+def test_http_missing_to_400(client):
+    r = client.get(
+        "/api/entitlement/channel-spec-at-path"
+        "?tier=cloud_pro&from=oss&channel=telegram"
+    )
+    assert r.status_code == 400
+    assert r.get_json() == {"error": "missing to"}
+
+
+def test_http_missing_channel_400(client):
+    r = client.get(
+        "/api/entitlement/channel-spec-at-path"
+        "?tier=cloud_pro&from=oss&to=enterprise"
+    )
+    assert r.status_code == 400
+    assert r.get_json() == {"error": "missing channel"}
+
+
+def test_http_blank_tier_400(client):
+    r = client.get(
+        "/api/entitlement/channel-spec-at-path"
+        "?tier=%20%20&from=oss&to=enterprise&channel=telegram"
+    )
+    assert r.status_code == 400
+
+
+def test_http_unknown_tier_404_which_tier(client):
+    r = client.get(
+        "/api/entitlement/channel-spec-at-path"
+        "?tier=bogus&from=oss&to=enterprise&channel=telegram"
+    )
+    assert r.status_code == 404
+    body = r.get_json()
+    assert body["which"] == "tier"
+    assert body["tier"] == "bogus"
+
+
+def test_http_unknown_from_404_which_from(client):
+    r = client.get(
+        "/api/entitlement/channel-spec-at-path"
+        "?tier=cloud_pro&from=bogus&to=enterprise&channel=telegram"
+    )
+    assert r.status_code == 404
+    body = r.get_json()
+    assert body["which"] == "from"
+    assert body["from"] == "bogus"
+
+
+def test_http_unknown_to_404_which_to(client):
+    r = client.get(
+        "/api/entitlement/channel-spec-at-path"
+        "?tier=cloud_pro&from=oss&to=bogus&channel=telegram"
+    )
+    assert r.status_code == 404
+    body = r.get_json()
+    assert body["which"] == "to"
+    assert body["to"] == "bogus"
+
+
+def test_http_unknown_channel_404_which_channel(client):
+    r = client.get(
+        "/api/entitlement/channel-spec-at-path"
+        "?tier=cloud_pro&from=oss&to=enterprise&channel=no_such_channel"
+    )
+    assert r.status_code == 404
+    body = r.get_json()
+    assert body["which"] == "channel"
+    assert body["channel"] == "no_such_channel"
+
+
+def test_http_identity_path_empty(client):
+    r = client.get(
+        "/api/entitlement/channel-spec-at-path"
+        "?tier=cloud_pro&from=cloud_pro&to=cloud_pro&channel=telegram"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["direction"] == "identity"
+    assert body["path"] == []
+
+
+def test_http_upgrade_direction(client):
+    r = client.get(
+        "/api/entitlement/channel-spec-at-path"
+        "?tier=cloud_pro&from=oss&to=enterprise&channel=telegram"
+    )
+    assert r.status_code == 200
+    assert r.get_json()["direction"] == "upgrade"
+
+
+def test_http_downgrade_direction(client):
+    r = client.get(
+        "/api/entitlement/channel-spec-at-path"
+        "?tier=cloud_pro&from=enterprise&to=oss&channel=telegram"
+    )
+    assert r.status_code == 200
+    assert r.get_json()["direction"] == "downgrade"
+
+
+def test_http_lateral_direction(client):
+    r = client.get(
+        "/api/entitlement/channel-spec-at-path"
+        "?tier=oss&from=cloud_pro&to=pro&channel=telegram"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["direction"] == "lateral"
+    assert len(body["path"]) == 1
+
+
+def test_http_trial_accepted(client):
+    r = client.get(
+        "/api/entitlement/channel-spec-at-path"
+        "?tier=trial&from=oss&to=enterprise&channel=telegram"
+    )
+    assert r.status_code == 200
+    assert r.get_json()["perspective_tier"] == "trial"
+
+
+def test_http_whitespace_and_case_normalisation(client):
+    r = client.get(
+        "/api/entitlement/channel-spec-at-path"
+        "?tier=%20Cloud_Pro%20&from=%20OSS%20&to=%20ENTERPRISE%20&channel=%20Telegram%20"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["perspective_tier"] == "cloud_pro"
+    assert body["from"] == "oss"
+    assert body["to"] == "enterprise"
+    assert body["channel"] == "telegram"
+
+
+def test_http_path_byte_parity_with_channel_spec_path(client):
+    at = client.get(
+        "/api/entitlement/channel-spec-at-path"
+        "?tier=cloud_pro&from=oss&to=enterprise&channel=telegram"
+    ).get_json()
+    direct = client.get(
+        "/api/entitlement/channel-spec-path"
+        "?from=oss&to=enterprise&channel=telegram"
+    ).get_json()
+    assert at["path"] == direct["path"]
+
+
+def test_http_perspective_invariance(client):
+    paths = []
+    for p in ALL_TIERS:
+        body = client.get(
+            "/api/entitlement/channel-spec-at-path"
+            f"?tier={p}&from=oss&to=enterprise&channel=telegram"
+        ).get_json()
+        paths.append(body["path"])
+    first = paths[0]
+    for other in paths[1:]:
+        assert other == first
+
+
+def test_http_every_row_free_and_allowed(client):
+    body = client.get(
+        "/api/entitlement/channel-spec-at-path"
+        "?tier=cloud_pro&from=oss&to=enterprise&channel=telegram"
+    ).get_json()
+    for row in body["path"]:
+        assert row["free"] is True
+        assert row["allowed"] is True
+        assert row["locked"] is False
+        assert row["entitled"] is True
+
+
+def test_http_never_5xxs_on_resolver_crash(client, monkeypatch):
+    from clawmetry import entitlements as _ent
+
+    def boom(*a, **k):
+        raise RuntimeError("simulated")
+
+    monkeypatch.setattr(_ent, "channel_spec_at_path", boom)
+    r = client.get(
+        "/api/entitlement/channel-spec-at-path"
+        "?tier=cloud_pro&from=oss&to=enterprise&channel=telegram"
+    )
+    # Grace envelope short-circuit -- 200 with an empty path, not 500.
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["perspective_tier"] == "cloud_pro"
+    assert body["path"] == []
+    assert body["grace"] is True
+
+
+def test_http_ranks_and_labels_populated(client):
+    body = client.get(
+        "/api/entitlement/channel-spec-at-path"
+        "?tier=cloud_pro&from=oss&to=enterprise&channel=telegram"
+    ).get_json()
+    assert isinstance(body["perspective_tier_rank"], int)
+    assert isinstance(body["from_rank"], int)
+    assert isinstance(body["to_rank"], int)
+    assert body["from_label"]
+    assert body["to_label"]


### PR DESCRIPTION
## Summary

Fills the **channel-axis what-if-path slot**: the perspective-validated wrapper around `channel_spec_path` (#3567). Channel-axis twin of `feature_spec_at_path` / `runtime_spec_at_path`, path-cousin of the recently-shipped `channel_spec_at_batch` (#3574). Together with `feature_spec_at_path` and `runtime_spec_at_path`, this lets a paywall walkthrough UI call `X_at_path(perspective, from, to, …)` uniformly across every axis without special-casing which one is the channel row.

### What's new

- **`clawmetry/entitlements.py`** — `channel_spec_at_path(perspective_tier, from_tier, to_tier, channel) -> list[dict] | None`. Validates the perspective against `_TIER_FEATURES`; delegates to `channel_spec_path(from_tier, to_tier, channel)` so the returned path is byte-identical to the current-perspective sibling for every `(from, to, channel)` triple. Returns `None` on empty / unknown perspective; propagates delegate `None` on unknown `from` / `to` / `channel`. Never raises: a delegation failure logs a warning and returns `None`.
- **`routes/entitlement.py`** — `GET /api/entitlement/channel-spec-at-path?tier=<perspective>&from=<id>&to=<id>&channel=<id>` on `bp_entitlement`. `400` on missing / blank `tier` / `from` / `to` / `channel`; `404` with `which="tier"|"from"|"to"|"channel"` on unknown ids. Standard envelope with `perspective_tier` / `perspective_tier_rank` / `current_tier` / `current_tier_rank` / `grace` / `enforced` tail. Never 5xxs — a resolver crash short-circuits to the OSS-free grace envelope so the paywall keeps rendering.
- **`tests/test_entitlement_channel_spec_at_path.py`** — 43 tests, all green.

### Contract (matches the existing `_at_path` pattern)

- Perspective is validated but does **not** shape the rows — body byte-identical to `channel_spec_path(from, to, channel)` for every perspective, pinned by the parity sweep across `product(ALL_TIERS, ALL_TIERS, ALL_TIERS, SAMPLE_CHANNELS)`.
- Per-rung body byte-equals `channel_spec_at(rung, channel)` after dropping the three `rung*` keys.
- Every chat-channel adapter is FREE at every tier, so every path row reports `free=True` / `allowed=True` / `locked=False` / `entitled=True` — pinned across every `(perspective, channel)` pair.
- All four args are whitespace-trimmed and lower-cased.
- Grace vs enforce yields byte-identical rows.
- **Zero behaviour change while grace mode is on (default until enforcement flips).**

### Response shape

```json
{
  "perspective_tier":      "cloud_pro",
  "perspective_tier_rank": 4,
  "from":                  "oss",
  "from_label":            "Open Source",
  "from_rank":             0,
  "to":                    "enterprise",
  "to_label":              "Enterprise",
  "to_rank":               6,
  "direction":             "upgrade",
  "channel":               "telegram",
  "path":                  [ {"rung": "cloud_free", "rung_label": "…", "rung_rank": 1, "id": "telegram", "label": "Telegram", "free": true, "tier": "free", "allowed": true, "locked": false, "entitled": true}, … ],
  "current_tier":          "oss",
  "current_tier_rank":     0,
  "grace":                 true,
  "enforced":              false
}
```

### Test coverage (43 tests)

- Scalar body byte-parity with `channel_spec_path` across `product(ALL_TIERS, ALL_TIERS, ALL_TIERS, SAMPLE_CHANNELS)` (7×7×7×5 = 1715 quadruples)
- Per-rung byte-equality with `channel_spec_at(rung, channel)`
- Per-rung byte-equality with LIVE `channel_spec(channel)` (always-free invariant)
- Perspective invariance across every tier
- Identity / lateral / upgrade / downgrade direction branches; monotonic rung ranks
- Trial accepted as perspective and endpoint
- Every row `free` / `allowed` / `entitled` / not-`locked` across every `(perspective, channel)` pair
- Unknown / empty / `None` / non-string perspective / `from` / `to` / `channel` → `None`
- Whitespace + case normalisation on all four ids
- Never-raise on weird arg types; grace vs enforce byte-identical
- Delegate crash short-circuits scalar to `None`
- HTTP: `200` envelope shape, `400` on each missing arg + blank tier, `404` with `which` bucketing on unknown tier / from / to / channel, identity / lateral / upgrade / downgrade direction, trial accepted, whitespace + case normalisation, path byte-parity with `/channel-spec-path`, perspective invariance, every row free/allowed, never-5xxs on resolver crash, ranks + labels populated

## Test plan

- [x] `python -m pytest tests/test_entitlement_channel_spec_at_path.py -v` — 43/43 pass locally
- [x] `python -m pytest tests/test_entitlement_channel_spec*.py tests/test_entitlement_channel_catalog_at_path.py tests/test_entitlement_runtime_spec_at_path.py tests/test_entitlement_feature_spec_at_path.py -q` — 325/325 pass (no neighbour regressions)
- [x] `python -m py_compile clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_channel_spec_at_path.py` — clean

## Local operator verification checklist

I cannot reach the local daemon, `~/.openclaw`, the live cloud snapshot, or a browser from this environment. Once CI is green, please:

- [ ] Copy the changed files into `~/.clawmetry/lib/pythonX.Y/site-packages/clawmetry/entitlements.py` and `.../routes/entitlement.py`
- [ ] Copy the new test into the package's `tests/` dir
- [ ] Clear `__pycache__/` under those paths
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` to restart the daemon
- [ ] `curl -s "http://localhost:8900/api/entitlement/channel-spec-at-path?tier=cloud_pro&from=oss&to=enterprise&channel=telegram" | jq` — confirm `{perspective_tier:"cloud_pro", direction:"upgrade", path:[...], grace:true, ...}` with each row `free=true` / `allowed=true` / `locked=false`
- [ ] `curl -s "http://localhost:8900/api/entitlement/channel-spec-at-path?tier=cloud_pro&from=cloud_pro&to=cloud_pro&channel=telegram" | jq '.direction, .path'` — expect `"identity"` and `[]`
- [ ] `curl -s -o /dev/null -w "%{http_code}\n" "http://localhost:8900/api/entitlement/channel-spec-at-path?from=oss&to=enterprise&channel=telegram"` — expect `400`
- [ ] `curl -s -o /dev/null -w "%{http_code}\n" "http://localhost:8900/api/entitlement/channel-spec-at-path?tier=cloud_pro&from=oss&to=enterprise"` — expect `400`
- [ ] `curl -s -o /dev/null -w "%{http_code}\n" "http://localhost:8900/api/entitlement/channel-spec-at-path?tier=bogus&from=oss&to=enterprise&channel=telegram"` — expect `404`
- [ ] `curl -s -o /dev/null -w "%{http_code}\n" "http://localhost:8900/api/entitlement/channel-spec-at-path?tier=cloud_pro&from=oss&to=enterprise&channel=no_such_channel"` — expect `404`
- [ ] Byte-equal round-trip: `diff <(curl -s ".../channel-spec-path?from=oss&to=enterprise&channel=telegram" | jq '.path') <(curl -s ".../channel-spec-at-path?tier=cloud_pro&from=oss&to=enterprise&channel=telegram" | jq '.path')` — should be empty
- [ ] Decrypt the live cloud snapshot, spot-check that nothing else regressed
- [ ] Browser-check the paywall matrix / channel-picker view still hydrates cleanly

Kept as **DRAFT** — the operator handles local-daemon verification, live-cloud verification, release, and merge.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NcCF8hmxR1F9XuWJgWRA2c)_