### PR TITLE
feat(entitlement): channel_spec_path_batch + /api/entitlement/channel-spec-path-batch

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -10088,6 +10088,98 @@ def channel_spec_path(
         return None
 
 
+def channel_spec_path_batch(
+    from_tier: str, to_tier: str, channels
+) -> dict | None:
+    """Batch sibling of :func:`channel_spec_path`: per-rung single-channel
+    spec rows for a caller-supplied subset of channel ids walked between
+    two tiers in ONE round-trip.
+
+    Channel-axis twin of :func:`feature_spec_path_batch` and
+    :func:`runtime_spec_path_batch`. Composes :func:`channel_spec_path`
+    (scalar single-channel path) and :func:`channel_spec_at_batch`
+    (batch what-if scalar) -- same rung walk as the path helper, same
+    per-channel shape as the batch helper. Lets a paywall / channel-
+    picker "compare A vs B, here are the 6 channels I care about"
+    surface render every rung for every channel off ONE call instead of
+    N calls to :func:`channel_spec_path`.
+
+    Per-channel row shape::
+
+        {"channel": "<id>", "path": [<channel_spec_path row>, ...]}
+
+    Each ``path`` row is byte-identical to a row from
+    :func:`channel_spec_path` for the same ``(from, to, channel)``
+    triple -- a parity test pins this so the scalar and batch path
+    helpers cannot drift. The rungs walked are channel-agnostic (every
+    chat-channel adapter is FREE at every tier so the rung walk of
+    :func:`channel_spec_path` is invariant across channel ids), so
+    every per-channel ``path`` has the same length and rung sequence --
+    matches :func:`feature_spec_path_batch`'s
+    ``rung_walk_invariant_across_features`` pin on the feature axis.
+
+    Shape::
+
+        {
+          "channels": [
+            {"channel": "<id>", "path": [<augmented row>, ...]},
+            ...
+          ],
+          "unknown": ["bogus_id", ...],
+        }
+
+    Supplied channel ids are normalised via :func:`_normalise_csv`
+    (whitespace stripped, lowercased, duplicates dropped, first-seen
+    order preserved). Unknown ids are echoed in ``unknown[]`` instead of
+    short-circuiting -- a partially-bad caller still gets paths back for
+    the valid ids alongside a list of what was dropped, matching
+    :func:`channel_spec_at_batch` /
+    :func:`feature_spec_path_batch` /
+    :func:`runtime_spec_path_batch`'s posture.
+
+    Returns ``None`` for empty / unknown ``from_tier`` / ``to_tier``
+    (caller renders "unknown tier" / 404). Identity ``from == to`` yields
+    ``{"channels": [...empty path per channel...], "unknown": [...]}``
+    matching the singular helper's identity branch.
+
+    Resolver-independent: delegates per-channel to
+    :func:`channel_spec_path`, which walks the static per-tier maps via
+    :func:`_channel_spec_row` -- so grace vs enforce yields byte-
+    identical rows. Never raises: per-channel failures short-circuit
+    that channel into ``unknown[]`` and the rest of the batch keeps
+    building.
+    """
+    try:
+        f = (from_tier or "").strip().lower()
+        t = (to_tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if f not in _TIER_FEATURES or t not in _TIER_FEATURES:
+        return None
+    chans = _normalise_csv(channels)
+    rows: list[dict] = []
+    unknown: list[str] = []
+    for cid in chans:
+        if cid not in ALL_CHANNELS:
+            unknown.append(cid)
+            continue
+        try:
+            path = channel_spec_path(f, t, cid)
+        except Exception as exc:
+            logger.warning(
+                "entitlements: channel_spec_path_batch row %r failed: %s",
+                cid,
+                exc,
+            )
+            unknown.append(cid)
+            continue
+        if path is None:
+            unknown.append(cid)
+            continue
+        rows.append({"channel": cid, "path": path})
+    return {"channels": rows, "unknown": unknown}
+
+
 def tier_catalog_path(from_tier: str, to_tier: str) -> list[dict] | None:
     """Arbitrary-endpoint stepwise tier-catalog path between two tiers.
 

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -9603,6 +9603,129 @@ def api_entitlement_channel_spec_at_path():
         )
 
 
+@bp_entitlement.route("/api/entitlement/channel-spec-path-batch")
+def api_entitlement_channel_spec_path_batch():
+    """``GET /api/entitlement/channel-spec-path-batch?from=<id>&to=<id>
+    &channels=a,b,c`` -- batch sibling of
+    ``/api/entitlement/channel-spec-path``.
+
+    Where ``/channel-spec-path`` walks ONE channel across the rungs
+    between two tiers, this walks N channels across the same rungs in
+    ONE round-trip. Channel-axis twin of ``/feature-spec-path-batch``
+    and ``/runtime-spec-path-batch``. Pairs with ``/channel-spec-path``
+    the same way ``/feature-spec-path-batch`` pairs with
+    ``/feature-spec-path``: scalar -> matrix in one call.
+
+    Use case: a paywall / channel-picker "compare A vs B, here are the
+    6 channels I care about" surface hydrates every rung for every
+    channel off ONE call instead of N calls to ``/channel-spec-path``.
+    Rung walk is channel-agnostic (every chat-channel adapter is FREE
+    at every tier), so all per-channel paths share the same length and
+    rung sequence -- the client can render the matrix as
+    rows = channels x cols = rungs without re-deriving the column
+    headers per channel.
+
+    Each row in ``channels[].path`` is byte-identical to a row from
+    ``/channel-spec-path?from=<from>&to=<to>&channel=<id>`` -- pinned
+    by the parity tests so the scalar and batch path accessors cannot
+    drift. Supplied channel ids are normalised (whitespace stripped,
+    lowercased, duplicates dropped, first-seen order preserved).
+    Unknown ids do not 404 the call -- they are echoed in ``unknown[]``
+    so a partially-bad caller still gets paths back for the valid ids.
+
+    Response shape::
+
+        {
+          "from":       "<tier id>",
+          "from_label": "...",
+          "from_rank":  <int>,
+          "to":         "<tier id>",
+          "to_label":   "...",
+          "to_rank":    <int>,
+          "direction":  "upgrade" | "downgrade" | "lateral" | "identity",
+          "channels": [
+            {"channel": "<id>", "path": [<augmented row>, ...]},
+            ...
+          ],
+          "unknown":    ["bogus_id", ...],
+        }
+
+    - **400** when ``from=``, ``to=`` is missing / blank, or ``channels=``
+      is missing / empty after normalisation
+    - **404** when ``from`` or ``to`` is unknown (body carries
+      ``which: "tier"``)
+    - **Never 5xxs**: a synthesis failure short-circuits to an envelope
+      with empty rows so the matrix keeps rendering.
+    """
+    f = (request.args.get("from") or "").strip().lower()
+    t = (request.args.get("to") or "").strip().lower()
+    if not f or not t:
+        return jsonify({"error": "missing from or to"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        if f not in _ent._TIER_ORDER:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "tier", "tier": f}
+                ),
+                404,
+            )
+        if t not in _ent._TIER_ORDER:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "tier", "tier": t}
+                ),
+                404,
+            )
+        channels = _parse_csv_arg("channels")
+        if not channels:
+            return jsonify({"error": "supply channels=<csv>"}), 400
+        batch = _ent.channel_spec_path_batch(f, t, channels)
+        if batch is None:
+            batch = {"channels": [], "unknown": []}
+        from_rank = _ent.tier_rank(f)
+        to_rank = _ent.tier_rank(t)
+        if f == t:
+            direction = "identity"
+        elif from_rank == to_rank:
+            direction = "lateral"
+        elif to_rank > from_rank:
+            direction = "upgrade"
+        else:
+            direction = "downgrade"
+        return jsonify(
+            {
+                "from": f,
+                "from_label": _ent.tier_label(f),
+                "from_rank": from_rank,
+                "to": t,
+                "to_label": _ent.tier_label(t),
+                "to_rank": to_rank,
+                "direction": direction,
+                "channels": batch.get("channels", []),
+                "unknown": batch.get("unknown", []),
+            }
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_channel_spec_path_batch: error: %s", exc
+        )
+        return jsonify(
+            {
+                "from": f,
+                "from_label": None,
+                "from_rank": -1,
+                "to": t,
+                "to_label": None,
+                "to_rank": -1,
+                "direction": "identity" if f == t else "upgrade",
+                "channels": [],
+                "unknown": [],
+            }
+        )
+
+
 @bp_entitlement.route("/api/entitlement/tier-catalog-path")
 def api_entitlement_tier_catalog_path():
     """``GET /api/entitlement/tier-catalog-path?from=<id>&to=<id>`` --

--- a/tests/test_entitlement_channel_spec_path_batch.py
+++ b/tests/test_entitlement_channel_spec_path_batch.py
@@ -1,0 +1,585 @@
+"""Tests for ``clawmetry.entitlements.channel_spec_path_batch(from, to,
+channels)`` + the ``GET /api/entitlement/channel-spec-path-batch``
+endpoint.
+
+Channel-axis batch sibling of :func:`channel_spec_path` -- twin of
+:func:`feature_spec_path_batch` and :func:`runtime_spec_path_batch` on
+the channel axis. Where the scalar path helper walks ONE channel across
+the rungs between two tiers, this helper walks N channels across the
+same rungs in ONE round-trip.
+
+Each per-item ``path`` must be byte-identical to the matching scalar
+:func:`channel_spec_path` payload for the same ``(from, to, channel)``
+triple -- pinned below so the scalar and batch path accessors cannot
+drift.
+
+Coverage:
+
+* per-item ``path`` byte-equal to the scalar
+  :func:`channel_spec_path` payload for every supplied channel
+* rung walk identical across items in the same batch (rungs are
+  channel-agnostic because every chat-channel adapter is FREE at every
+  tier)
+* batch envelope mirrors ``/channel-spec-path`` (from / from_label /
+  from_rank / to / to_label / to_rank / direction) plus ``channels`` +
+  ``unknown``
+* input normalised (whitespace stripped, lowercased, duplicates
+  dropped, first-seen order preserved)
+* unknown ids echoed in ``unknown[]`` instead of 404'ing the call
+* identity ``from == to`` yields an envelope with one entry per
+  supplied id whose ``path`` is ``[]``
+* lateral (same rank, different id) yields one-row paths per supplied
+  id
+* every row remains ``free=True`` / ``allowed=True`` / ``locked=False``
+  / ``entitled=True`` (every channel is FREE at every tier)
+* unknown / empty / garbage tier returns ``None`` (helper) / 400 / 404
+  (HTTP)
+* helper never raises -- a row failure short-circuits that channel
+  into ``unknown[]`` and the rest of the batch keeps building
+* HTTP endpoint 400 on missing / empty input, 404 on unknown tier,
+  never 5xx on a row failure
+* grace vs enforce yields byte-identical rows
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+_ITEM_KEYS = {"channel", "path"}
+_RUNG_KEYS = {"rung", "rung_label", "rung_rank"}
+_SPEC_KEYS = {"id", "label", "free", "tier", "allowed", "locked", "entitled"}
+_ENVELOPE_KEYS = {
+    "from",
+    "from_label",
+    "from_rank",
+    "to",
+    "to_label",
+    "to_rank",
+    "direction",
+    "channels",
+    "unknown",
+}
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# ── helper-level: shape ──────────────────────────────────────────────────────
+
+
+def test_helper_returns_dict_shape(ent):
+    out = ent.channel_spec_path_batch(
+        ent.TIER_OSS, ent.TIER_ENTERPRISE, ["telegram", "signal"]
+    )
+    assert isinstance(out, dict)
+    assert set(out.keys()) == {"channels", "unknown"}
+    assert isinstance(out["channels"], list)
+    assert isinstance(out["unknown"], list)
+
+
+def test_helper_each_item_carries_channel_and_path(ent):
+    out = ent.channel_spec_path_batch(
+        ent.TIER_OSS, ent.TIER_ENTERPRISE, ["telegram", "signal"]
+    )
+    for item in out["channels"]:
+        assert set(item.keys()) == _ITEM_KEYS
+        assert isinstance(item["channel"], str)
+        assert isinstance(item["path"], list)
+
+
+def test_helper_each_path_row_has_rung_and_spec_keys(ent):
+    out = ent.channel_spec_path_batch(
+        ent.TIER_OSS, ent.TIER_ENTERPRISE, ["telegram", "signal"]
+    )
+    for item in out["channels"]:
+        for row in item["path"]:
+            assert set(row).issuperset(_RUNG_KEYS)
+            assert set(row).issuperset(_SPEC_KEYS)
+
+
+# ── parity + invariance pins ─────────────────────────────────────────────────
+
+
+def test_helper_per_item_path_byte_equal_to_scalar(ent):
+    """Pin: per-item ``path`` is byte-identical to the scalar
+    :func:`channel_spec_path` payload for the same triple."""
+    chans = ["telegram", "signal", "discord", "slack"]
+    out = ent.channel_spec_path_batch(
+        ent.TIER_OSS, ent.TIER_ENTERPRISE, chans
+    )
+    by_id = {item["channel"]: item["path"] for item in out["channels"]}
+    for cid in chans:
+        scalar = ent.channel_spec_path(
+            ent.TIER_OSS, ent.TIER_ENTERPRISE, cid
+        )
+        assert by_id[cid] == scalar
+
+
+def test_helper_rung_walk_channel_agnostic(ent):
+    """The walked rung sequence is channel-agnostic -- all per-item
+    paths in the batch share the same rung sequence (every channel is
+    FREE at every tier so the walk is invariant)."""
+    out = ent.channel_spec_path_batch(
+        ent.TIER_OSS,
+        ent.TIER_ENTERPRISE,
+        ["telegram", "signal", "discord"],
+    )
+    rung_sequences = [
+        [row["rung"] for row in item["path"]] for item in out["channels"]
+    ]
+    assert len(rung_sequences) == 3
+    assert rung_sequences[0] == rung_sequences[1] == rung_sequences[2]
+
+
+def test_helper_every_row_free_and_allowed(ent):
+    """Every chat-channel adapter is FREE at every tier -- so every row
+    at every rung reports ``free=True`` / ``allowed=True`` /
+    ``locked=False`` / ``entitled=True``, regardless of direction."""
+    for endpoints in (
+        (ent.TIER_OSS, ent.TIER_ENTERPRISE),
+        (ent.TIER_ENTERPRISE, ent.TIER_OSS),
+    ):
+        out = ent.channel_spec_path_batch(
+            endpoints[0], endpoints[1], ["telegram", "slack", "discord"]
+        )
+        for item in out["channels"]:
+            for row in item["path"]:
+                assert row["free"] is True
+                assert row["allowed"] is True
+                assert row["locked"] is False
+                assert row["entitled"] is True
+
+
+# ── input normalisation ──────────────────────────────────────────────────────
+
+
+def test_helper_supply_order_preserved(ent):
+    out = ent.channel_spec_path_batch(
+        ent.TIER_OSS,
+        ent.TIER_ENTERPRISE,
+        ["signal", "telegram", "discord"],
+    )
+    assert [item["channel"] for item in out["channels"]] == [
+        "signal",
+        "telegram",
+        "discord",
+    ]
+
+
+def test_helper_normalises_input(ent):
+    out = ent.channel_spec_path_batch(
+        ent.TIER_OSS,
+        ent.TIER_ENTERPRISE,
+        ["  TELEGRAM  ", "signal", "telegram", ""],
+    )
+    assert [item["channel"] for item in out["channels"]] == [
+        "telegram",
+        "signal",
+    ]
+
+
+def test_helper_normalises_tier_input(ent):
+    out = ent.channel_spec_path_batch(
+        "  OSS  ", "  ENTERPRISE  ", ["telegram"]
+    )
+    assert out is not None
+    assert [item["channel"] for item in out["channels"]] == ["telegram"]
+
+
+# ── unknown-id handling ──────────────────────────────────────────────────────
+
+
+def test_helper_unknown_ids_echoed(ent):
+    out = ent.channel_spec_path_batch(
+        ent.TIER_OSS,
+        ent.TIER_ENTERPRISE,
+        ["telegram", "bogus_channel", "still_bogus"],
+    )
+    assert [item["channel"] for item in out["channels"]] == ["telegram"]
+    assert set(out["unknown"]) == {"bogus_channel", "still_bogus"}
+
+
+def test_helper_all_unknown_ids_yields_empty_channels(ent):
+    out = ent.channel_spec_path_batch(
+        ent.TIER_OSS, ent.TIER_ENTERPRISE, ["bogus_1", "bogus_2"]
+    )
+    assert out == {
+        "channels": [],
+        "unknown": ["bogus_1", "bogus_2"],
+    }
+
+
+# ── direction branches ──────────────────────────────────────────────────────
+
+
+def test_helper_identity_yields_empty_paths(ent):
+    out = ent.channel_spec_path_batch(
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_CLOUD_PRO,
+        ["telegram", "signal"],
+    )
+    assert out["unknown"] == []
+    for item in out["channels"]:
+        assert item["path"] == []
+
+
+def test_helper_lateral_yields_one_row_paths(ent):
+    out = ent.channel_spec_path_batch(
+        ent.TIER_CLOUD_PRO, ent.TIER_PRO, ["telegram", "signal"]
+    )
+    for item in out["channels"]:
+        assert len(item["path"]) == 1
+        assert item["path"][0]["rung"] == ent.TIER_PRO
+
+
+def test_helper_downgrade_walks_descending(ent):
+    out = ent.channel_spec_path_batch(
+        ent.TIER_ENTERPRISE, ent.TIER_OSS, ["telegram"]
+    )
+    assert out is not None
+    for item in out["channels"]:
+        ranks = [row["rung_rank"] for row in item["path"]]
+        assert ranks == sorted(ranks, reverse=True)
+
+
+def test_helper_upgrade_walks_ascending(ent):
+    out = ent.channel_spec_path_batch(
+        ent.TIER_OSS, ent.TIER_ENTERPRISE, ["telegram"]
+    )
+    assert out is not None
+    for item in out["channels"]:
+        ranks = [row["rung_rank"] for row in item["path"]]
+        assert ranks == sorted(ranks)
+
+
+def test_helper_trial_accepted_as_endpoint(ent):
+    """`trial` is not purchasable but IS a valid endpoint via the
+    lateral / identity branches -- matches the scalar helper's posture."""
+    out = ent.channel_spec_path_batch(
+        ent.TIER_TRIAL, ent.TIER_TRIAL, ["telegram"]
+    )
+    assert out is not None
+    assert out["channels"][0]["path"] == []
+
+
+# ── error / edge branches ────────────────────────────────────────────────────
+
+
+def test_helper_unknown_from_tier_returns_none(ent):
+    assert (
+        ent.channel_spec_path_batch(
+            "not_a_tier", ent.TIER_ENTERPRISE, ["telegram"]
+        )
+        is None
+    )
+
+
+def test_helper_unknown_to_tier_returns_none(ent):
+    assert (
+        ent.channel_spec_path_batch(
+            ent.TIER_OSS, "not_a_tier", ["telegram"]
+        )
+        is None
+    )
+
+
+def test_helper_empty_channels_yields_empty_envelope(ent):
+    out = ent.channel_spec_path_batch(
+        ent.TIER_OSS, ent.TIER_ENTERPRISE, []
+    )
+    assert out == {"channels": [], "unknown": []}
+
+
+def test_helper_garbage_inputs_never_raise(ent):
+    assert ent.channel_spec_path_batch("", "", []) is None
+    assert ent.channel_spec_path_batch(None, None, None) is None  # type: ignore[arg-type]
+    assert ent.channel_spec_path_batch("  ", "  ", "  ") is None
+    assert (
+        ent.channel_spec_path_batch(
+            ent.TIER_OSS, ent.TIER_ENTERPRISE, 42
+        )
+        == {"channels": [], "unknown": []}
+    )
+
+
+def test_helper_row_failure_short_circuits_item(ent, monkeypatch):
+    """A per-item failure pushes that id into ``unknown[]`` while the
+    rest of the batch keeps building."""
+    real = ent.channel_spec_path
+
+    def fake(f, t, cid):
+        if cid == "telegram":
+            raise RuntimeError("boom")
+        return real(f, t, cid)
+
+    monkeypatch.setattr(ent, "channel_spec_path", fake)
+    out = ent.channel_spec_path_batch(
+        ent.TIER_OSS,
+        ent.TIER_ENTERPRISE,
+        ["telegram", "signal"],
+    )
+    assert [item["channel"] for item in out["channels"]] == ["signal"]
+    assert "telegram" in out["unknown"]
+
+
+def test_helper_row_returning_none_pushes_to_unknown(ent, monkeypatch):
+    real = ent.channel_spec_path
+
+    def fake(f, t, cid):
+        if cid == "signal":
+            return None
+        return real(f, t, cid)
+
+    monkeypatch.setattr(ent, "channel_spec_path", fake)
+    out = ent.channel_spec_path_batch(
+        ent.TIER_OSS,
+        ent.TIER_ENTERPRISE,
+        ["telegram", "signal"],
+    )
+    assert [item["channel"] for item in out["channels"]] == ["telegram"]
+    assert "signal" in out["unknown"]
+
+
+def test_helper_grace_and_enforce_yield_identical_output(ent, monkeypatch):
+    chans = ["telegram", "signal", "discord"]
+    grace = ent.channel_spec_path_batch(
+        ent.TIER_OSS, ent.TIER_ENTERPRISE, chans
+    )
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    enforced = ent.channel_spec_path_batch(
+        ent.TIER_OSS, ent.TIER_ENTERPRISE, chans
+    )
+    assert grace == enforced
+
+
+# ── HTTP: /api/entitlement/channel-spec-path-batch ───────────────────────────
+
+
+def test_api_400_on_missing_from(client):
+    r = client.get(
+        "/api/entitlement/channel-spec-path-batch"
+        "?to=enterprise&channels=telegram"
+    )
+    assert r.status_code == 400
+
+
+def test_api_400_on_missing_to(client):
+    r = client.get(
+        "/api/entitlement/channel-spec-path-batch?from=oss&channels=telegram"
+    )
+    assert r.status_code == 400
+
+
+def test_api_400_on_missing_channels(client):
+    r = client.get(
+        "/api/entitlement/channel-spec-path-batch?from=oss&to=enterprise"
+    )
+    assert r.status_code == 400
+    body = r.get_json()
+    assert body["error"] == "supply channels=<csv>"
+
+
+def test_api_400_on_empty_channels(client):
+    r = client.get(
+        "/api/entitlement/channel-spec-path-batch"
+        "?from=oss&to=enterprise&channels="
+    )
+    assert r.status_code == 400
+
+
+def test_api_404_on_unknown_from_tier(client):
+    r = client.get(
+        "/api/entitlement/channel-spec-path-batch"
+        "?from=not_a_tier&to=enterprise&channels=telegram"
+    )
+    assert r.status_code == 404
+    body = r.get_json()
+    assert body.get("which") == "tier"
+
+
+def test_api_404_on_unknown_to_tier(client):
+    r = client.get(
+        "/api/entitlement/channel-spec-path-batch"
+        "?from=oss&to=not_a_tier&channels=telegram"
+    )
+    assert r.status_code == 404
+    body = r.get_json()
+    assert body.get("which") == "tier"
+
+
+def test_api_happy_path_ascending(client, ent):
+    r = client.get(
+        f"/api/entitlement/channel-spec-path-batch?from={ent.TIER_OSS}"
+        f"&to={ent.TIER_ENTERPRISE}&channels=telegram,signal"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert set(body.keys()) == _ENVELOPE_KEYS
+    assert body["from"] == ent.TIER_OSS
+    assert body["to"] == ent.TIER_ENTERPRISE
+    assert body["direction"] == "upgrade"
+    assert [item["channel"] for item in body["channels"]] == [
+        "telegram",
+        "signal",
+    ]
+    for item in body["channels"]:
+        assert item["path"][-1]["rung"] == ent.TIER_ENTERPRISE
+
+
+def test_api_direction_downgrade(client, ent):
+    r = client.get(
+        f"/api/entitlement/channel-spec-path-batch?from={ent.TIER_ENTERPRISE}"
+        f"&to={ent.TIER_OSS}&channels=telegram"
+    )
+    body = r.get_json()
+    assert body["direction"] == "downgrade"
+
+
+def test_api_direction_lateral(client, ent):
+    r = client.get(
+        f"/api/entitlement/channel-spec-path-batch?from={ent.TIER_CLOUD_PRO}"
+        f"&to={ent.TIER_PRO}&channels=telegram"
+    )
+    body = r.get_json()
+    assert body["direction"] == "lateral"
+    for item in body["channels"]:
+        assert len(item["path"]) == 1
+        assert item["path"][0]["rung"] == ent.TIER_PRO
+
+
+def test_api_direction_identity(client, ent):
+    r = client.get(
+        f"/api/entitlement/channel-spec-path-batch?from={ent.TIER_CLOUD_PRO}"
+        f"&to={ent.TIER_CLOUD_PRO}&channels=telegram,signal"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["direction"] == "identity"
+    for item in body["channels"]:
+        assert item["path"] == []
+
+
+def test_api_unknown_id_echoed(client, ent):
+    r = client.get(
+        f"/api/entitlement/channel-spec-path-batch?from={ent.TIER_OSS}"
+        f"&to={ent.TIER_ENTERPRISE}&channels=telegram,bogus_channel"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert [item["channel"] for item in body["channels"]] == ["telegram"]
+    assert body["unknown"] == ["bogus_channel"]
+
+
+def test_api_normalises_channels(client, ent):
+    r = client.get(
+        f"/api/entitlement/channel-spec-path-batch?from={ent.TIER_OSS}"
+        f"&to={ent.TIER_ENTERPRISE}&channels=%20TELEGRAM%20,signal,telegram"
+    )
+    body = r.get_json()
+    assert [item["channel"] for item in body["channels"]] == [
+        "telegram",
+        "signal",
+    ]
+
+
+def test_api_trial_accepted_as_endpoint(client, ent):
+    r = client.get(
+        f"/api/entitlement/channel-spec-path-batch?from={ent.TIER_TRIAL}"
+        f"&to={ent.TIER_TRIAL}&channels=telegram"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["direction"] == "identity"
+    assert body["channels"][0]["path"] == []
+
+
+def test_api_per_item_path_matches_scalar_route(client, ent):
+    """Pin: per-item ``path`` in the batch response byte-equals the scalar
+    ``/api/entitlement/channel-spec-path`` response for the same triple."""
+    batch = client.get(
+        f"/api/entitlement/channel-spec-path-batch?from={ent.TIER_OSS}"
+        f"&to={ent.TIER_ENTERPRISE}&channels=telegram,signal,discord"
+    ).get_json()
+    for item in batch["channels"]:
+        scalar = client.get(
+            f"/api/entitlement/channel-spec-path?from={ent.TIER_OSS}"
+            f"&to={ent.TIER_ENTERPRISE}&channel={item['channel']}"
+        ).get_json()
+        assert item["path"] == scalar["path"]
+
+
+def test_api_never_5xx_on_helper_failure(client, ent, monkeypatch):
+    """If ``channel_spec_path_batch`` raises deep in the helper, the
+    endpoint must fall back to an empty envelope instead of 5xxing."""
+    import clawmetry.entitlements as _ent
+
+    def boom(*a, **k):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(_ent, "channel_spec_path_batch", boom)
+    r = client.get(
+        f"/api/entitlement/channel-spec-path-batch?from={ent.TIER_OSS}"
+        f"&to={ent.TIER_ENTERPRISE}&channels=telegram"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["channels"] == []
+    assert body["unknown"] == []
+
+
+def test_api_row_failure_short_circuits_item(client, ent, monkeypatch):
+    """A helper-level per-channel failure lands the channel in
+    ``unknown[]`` while the rest of the batch keeps building -- the
+    endpoint should render this without dropping to 5xx."""
+    import clawmetry.entitlements as _ent
+
+    real = _ent.channel_spec_path
+
+    def fake(f, t, cid):
+        if cid == "signal":
+            raise RuntimeError("boom")
+        return real(f, t, cid)
+
+    monkeypatch.setattr(_ent, "channel_spec_path", fake)
+    r = client.get(
+        f"/api/entitlement/channel-spec-path-batch?from={ent.TIER_OSS}"
+        f"&to={ent.TIER_ENTERPRISE}&channels=telegram,signal"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert [item["channel"] for item in body["channels"]] == ["telegram"]
+    assert "signal" in body["unknown"]
+
+
+def test_api_envelope_ranks_populated(client, ent):
+    r = client.get(
+        f"/api/entitlement/channel-spec-path-batch?from={ent.TIER_OSS}"
+        f"&to={ent.TIER_ENTERPRISE}&channels=telegram"
+    )
+    body = r.get_json()
+    assert isinstance(body["from_rank"], int) and body["from_rank"] >= 0
+    assert isinstance(body["to_rank"], int) and body["to_rank"] >= 0
+    assert body["from_label"] == ent.tier_label(ent.TIER_OSS)
+    assert body["to_label"] == ent.tier_label(ent.TIER_ENTERPRISE)


### PR DESCRIPTION
## Summary

Fills the **channel-axis `_path_batch` slot**: the batch sibling of
`channel_spec_path` (#3567) and channel-axis twin of
`feature_spec_path_batch` / `runtime_spec_path_batch`. Where the scalar
path helper walks ONE channel across the rungs between two tiers, this
walks N channels across the same rungs in ONE round-trip. Lets a
paywall / channel-picker "compare A vs B, here are the 6 channels I
care about" surface hydrate every rung for every channel off ONE call
instead of N calls to `/channel-spec-path`.

### What's new

- **`clawmetry/entitlements.py`** — `channel_spec_path_batch(from_tier, to_tier, channels) -> dict | None` returning `{"channels": [{"channel": id, "path": [...]}], "unknown": [...]}`. Delegates per-channel to `channel_spec_path` so per-item `path` is byte-identical to the scalar helper for the same `(from, to, channel)` triple. Never raises: a per-channel failure short-circuits that id into `unknown[]` and the rest of the batch keeps building.
- **`routes/entitlement.py`** — `GET /api/entitlement/channel-spec-path-batch?from=&to=&channels=a,b,c` on `bp_entitlement`. `400` on missing / blank `from` / `to` / `channels`; `404` with `which="tier"` on unknown `from` / `to`. Standard envelope with `direction` tag (`upgrade` / `downgrade` / `lateral` / `identity`). Never 5xxs — a helper crash short-circuits to an empty envelope so the matrix keeps rendering.
- **`tests/test_entitlement_channel_spec_path_batch.py`** — 40 tests, all green.

### Contract (matches the existing `_path_batch` pattern)

- Per-item `path` byte-identical to `channel_spec_path(from, to, channel)` for every supplied triple — pinned by the scalar-parity sweep.
- Rung walk is channel-agnostic (every chat-channel adapter is FREE at every tier), so all per-channel paths in a batch share the same length and rung sequence.
- Every row remains `free=True` / `allowed=True` / `locked=False` / `entitled=True` — pinned across every supplied channel.
- Supplied channel ids are normalised via `_normalise_csv` (whitespace stripped, lowercased, duplicates dropped, first-seen order preserved). Unknown ids land in `unknown[]` instead of short-circuiting.
- Identity `from == to` yields empty paths per channel; lateral yields one-row paths at `to`.
- Grace vs enforce yields byte-identical rows.
- **Zero behaviour change while grace mode is on (default until enforcement flips).**

### Response shape

```json
{
  "from":       "oss",
  "from_label": "Open Source",
  "from_rank":  0,
  "to":         "enterprise",
  "to_label":   "Enterprise",
  "to_rank":    6,
  "direction":  "upgrade",
  "channels": [
    {"channel": "telegram", "path": [ {"rung": "cloud_free", "rung_label": "…", "rung_rank": 1, "id": "telegram", "label": "Telegram", "free": true, "tier": "free", "allowed": true, "locked": false, "entitled": true}, … ]},
    {"channel": "signal",   "path": [ … ]}
  ],
  "unknown":    ["bogus_channel"]
}
```

### Test coverage (40 tests)

- Helper: envelope shape, per-item keys, per-row rung + spec keys, byte-parity with scalar `channel_spec_path`, rung walk channel-agnostic, every row `free` / `allowed` / `entitled` / not-`locked`
- Input normalisation: whitespace / case / duplicates / supply-order preservation on the channels list; whitespace + case on tier ids
- Unknown-id handling: mixed known + unknown echoed; all-unknown yields empty `channels[]`
- Direction branches: identity / lateral / upgrade (ascending ranks) / downgrade (descending ranks); trial accepted as endpoint
- Error / edge: unknown `from` / `to` → `None`; empty `channels=[]` yields empty envelope; garbage / non-iterable inputs never raise
- Helper never-raise: per-channel `RuntimeError` and per-channel `None` return both push the id to `unknown[]` while the rest of the batch keeps building
- Grace vs enforce byte-identical
- HTTP: `400` on each missing arg + empty `channels=`, `404` on unknown `from` / `to` (with `which: "tier"`), `200` envelope shape, per-item route parity with `/channel-spec-path`, direction branches, whitespace + case normalisation, trial accepted as endpoint, never-5xx on helper failure, per-row failure short-circuit visible through HTTP, ranks + labels populated

## Test plan

- [x] `python -m pytest tests/test_entitlement_channel_spec_path_batch.py -v` — 40/40 pass locally
- [x] `python -m pytest tests/test_entitlement_channel_spec_path.py tests/test_entitlement_spec_path_batch.py tests/test_entitlement_channel_catalog_path_batch.py -q` — 129/129 pass (no neighbour regressions)
- [x] `python -m pytest tests/test_blueprint_uniqueness.py -q` — 2/2 pass
- [x] `ruff check clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_channel_spec_path_batch.py` — clean
- [x] `python -m py_compile clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_channel_spec_path_batch.py` — clean

## Local operator verification checklist

I cannot reach the local daemon, `~/.openclaw`, the live cloud snapshot, or a browser from this environment. Once CI is green, please:

- [ ] Copy the changed files into `~/.clawmetry/lib/pythonX.Y/site-packages/clawmetry/entitlements.py` and `.../routes/entitlement.py`
- [ ] Copy the new test into the package's `tests/` dir
- [ ] Clear `__pycache__/` under those paths
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` to restart the daemon
- [ ] `curl -s "http://localhost:8900/api/entitlement/channel-spec-path-batch?from=oss&to=enterprise&channels=telegram,signal,discord" | jq` — confirm `{from:"oss", to:"enterprise", direction:"upgrade", channels:[{channel:"telegram", path:[...]}, {channel:"signal", path:[...]}, {channel:"discord", path:[...]}], unknown:[]}` with each row `free=true` / `allowed=true` / `locked=false`
- [ ] `curl -s "http://localhost:8900/api/entitlement/channel-spec-path-batch?from=cloud_pro&to=cloud_pro&channels=telegram,signal" | jq '.direction, [.channels[].path]'` — expect `"identity"` and `[[], []]`
- [ ] `curl -s -o /dev/null -w "%{http_code}\n" "http://localhost:8900/api/entitlement/channel-spec-path-batch?to=enterprise&channels=telegram"` — expect `400`
- [ ] `curl -s -o /dev/null -w "%{http_code}\n" "http://localhost:8900/api/entitlement/channel-spec-path-batch?from=oss&to=enterprise"` — expect `400`
- [ ] `curl -s -o /dev/null -w "%{http_code}\n" "http://localhost:8900/api/entitlement/channel-spec-path-batch?from=bogus&to=enterprise&channels=telegram"` — expect `404`
- [ ] Unknown channel echoed, not 404'd: `curl -s "http://localhost:8900/api/entitlement/channel-spec-path-batch?from=oss&to=enterprise&channels=telegram,no_such_channel" | jq '{channels: [.channels[].channel], unknown}'` — expect `{channels:["telegram"], unknown:["no_such_channel"]}`
- [ ] Byte-equal per-channel round-trip: for each `ch` in `telegram,signal`, `diff <(curl -s ".../channel-spec-path?from=oss&to=enterprise&channel=$ch" | jq '.path') <(curl -s ".../channel-spec-path-batch?from=oss&to=enterprise&channels=telegram,signal" | jq --arg ch "$ch" '.channels[] | select(.channel==$ch) | .path')` — should be empty
- [ ] Decrypt the live cloud snapshot, spot-check that nothing else regressed
- [ ] Browser-check the paywall matrix / channel-picker view still hydrates cleanly

Kept as **DRAFT** — the operator handles local-daemon verification, live-cloud verification, release, and merge.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XicLhn9YPQf7ZoPSdXDCEF)_