### PR TITLE
fix(brain): full chat replies in the feed - de-dup v3 text + roomier caps

### DIFF
--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -7435,7 +7435,10 @@ def _cap_brain_event_size(ev):
             return ev
     except (TypeError, ValueError):
         return ev
-    for limit in (400, 250, 150, 80):
+    # Gentle ladder: a chat message that overshoots the ceiling by a few
+    # bytes (unicode escapes, long model ids) should lose a sentence, not
+    # collapse from 1200 chars straight to 400 (the old first rung).
+    for limit in (1000, 700, 400, 250, 150, 80):
         ev = _truncate_brain_payload(ev, cap=limit)
         try:
             if len(json.dumps(ev, separators=(",", ":"))) <= _BRAIN_EVENT_CAP:
@@ -7509,6 +7512,19 @@ def _rows_to_brain_events(rows: list) -> list:
             # cloud renderer AND the device parser already understand.
             v3msg = _v3_chat_message(data)
             if v3msg is not None:
+                # LEAN blob event: the v3 row stores the same text up to
+                # three times (completionText, assistantTexts[0], the nested
+                # data.* copy) and the message block adds a fourth — that
+                # quadrupling blew the 1500-byte _BRAIN_EVENT_CAP, so
+                # _cap_brain_event_size squeezed every string to 150 chars
+                # and the cloud feed showed a stub of the reply (live-hit
+                # 2026-07-08). The blob's only readers are transformEvents
+                # (cloud) and brain_event_to_row (device), both of which
+                # read message.content — drop the duplicates so the actual
+                # text gets nearly the whole per-event budget.
+                data = {k: v for k, v in data.items()
+                        if k not in ("completionText", "assistantTexts",
+                                     "finalPromptText", "toolMetas", "data")}
                 data = {**data, "type": "message", "message": v3msg}
             if enrich:
                 # Enrichment wins — the JSONL payload often carries the
@@ -7525,7 +7541,13 @@ def _rows_to_brain_events(rows: list) -> list:
                 data.setdefault("type", r.get("event_type"))
             # Bound the per-event size so a burst of big tool outputs can't push
             # the blob past the device's 128 KB buffer (the "feed locked" cause).
-            data = _truncate_brain_payload(data)
+            # Chat messages get a roomier per-string cap: the lean event's only
+            # big string is the message text itself, and cutting a reply at the
+            # default 600 reads as a bug in the feed. _cap_brain_event_size
+            # still enforces the hard 1500-byte ceiling either way, so the
+            # device-buffer math is unchanged.
+            data = _truncate_brain_payload(
+                data, cap=1200 if v3msg is not None else None)
             # Stamp the CANONICAL session id from the row's top-level session_id
             # column (the BARE uuid, dropping the ``runtime:`` namespace) so
             # per-session feeds (desk device + cloud Brain filtering) attribute

--- a/tests/test_brain_v3_chat_events.py
+++ b/tests/test_brain_v3_chat_events.py
@@ -104,6 +104,37 @@ def test_plumbing_rows_stay_hidden():
         assert sync._brain_row_renderable(row) is False, row["event_type"]
 
 
+def test_long_reply_survives_the_event_cap():
+    """The v3 row stores the same text up to three times and the message
+    block adds a fourth; that quadrupling blew the 1500-byte event ceiling
+    and _cap_brain_event_size squeezed the reply to a 150-char stub in the
+    cloud feed (live-hit 2026-07-08: a health-check reply cut at
+    '~2 minutes at check ti…'). The blob event must be de-duplicated so a
+    realistic ~900-char reply arrives (near-)intact."""
+    text = ("Hey - I just came online. I checked system health first. "
+            "System health: OK overall. " + "Detail line about the system. " * 27)
+    assert 850 <= len(text) <= 1000
+    row = {"id": "e9", "session_id": "openclaw:main",
+           "event_type": "model.completed", "ts": "2026-07-08T07:00:00Z",
+           "data": {"_v3_type": "message", "completionText": text,
+                    "assistantTexts": [text],
+                    "data": {"completionText": text, "assistantTexts": [text]},
+                    "modelId": "gpt-5.5", "provider": "openai",
+                    "timestamp": "2026-07-08T07:00:00Z", "stopReason": "stop"}}
+    out = sync._rows_to_brain_events([row])
+    assert len(out) == 1
+    ev = out[0]
+    got = ev["message"]["content"][0]["text"]
+    # full text survives (not a 150-char stub, not the 600 default cap)
+    assert got == text
+    # the duplicates are gone from the blob event
+    for k in ("completionText", "assistantTexts", "data"):
+        assert k not in ev
+    # and the hard device ceiling still holds
+    import json as _json
+    assert len(_json.dumps(ev, separators=(",", ":"))) <= sync._BRAIN_EVENT_CAP
+
+
 def test_blob_carries_transform_events_contract():
     """The pushed blob must hold the {type:'message', message:{role,content[]}}
     shape the cloud transformEvents role-branches render — its empty-detail


### PR DESCRIPTION
## Why

The cloud Activity feed showed only a ~150-char stub of each agent reply (a health-check message cut at "~2 minutes at check ti…") while the openclaw dashboard showed the full message.

Root cause: the v3 row stores the same reply text up to three times (`completionText`, `assistantTexts[0]`, the nested `data.*` copy), and #3581's synthesized `message` block added a fourth. That quadrupling blew the 1500-byte per-event ceiling (`_BRAIN_EVENT_CAP`, sized for the desk device's 128 KB receive buffer), so `_cap_brain_event_size`'s tighten loop squeezed every string to 150 chars.

## What

- **Lean blob events for v3 chat rows**: the duplicate text fields are dropped from the blob copy — its only readers (cloud `transformEvents`, device `brain_event_to_row`) read `message.content` — so the actual text gets nearly the whole per-event budget.
- **Chat messages get a 1200-char per-string cap** (default stays 600 for everything else). The hard 1500-byte event ceiling is UNCHANGED, so the device-buffer math (50 × 1.5 KB ≈ 75 KB plaintext) is untouched.
- **Gentler tighten ladder** (1000, 700 rungs added): a borderline event loses a sentence, not two-thirds of the message.

## Verification

- New `test_long_reply_survives_the_event_cap`: a realistic ~900-char reply must arrive intact, duplicates gone, event ≤ ceiling. Proven RED on the un-fixed code, GREEN with the fix (7/7 in the file).
- Neighboring brain suites (`cache_push`, `channel_events`, `history_v3_event_detail`): IDENTICAL failure sets with and without the change on my machine (environmental; CI's clean env is the gate).
- Post-release: hosted nodes now auto-update the daemon, so this reaches them within ~6h of PyPI with no image rebuild; will verify on a live node's Activity tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)