### PR TITLE
feat(approvals): drive OpenClaw's native pre-exec gate from active policies

### DIFF
--- a/clawmetry/approvals.py
+++ b/clawmetry/approvals.py
@@ -1153,6 +1153,103 @@ def watch_iteration(api_key: str, node_id: str,
     return processed
 
 
+# ── OpenClaw native exec-approval gate (2026-07-08) ─────────────────────────
+# ClawMetry's own watcher is REACTIVE: it sees a tool_call only after the
+# transcript records it, so a destructive `rm -rf` on an OpenClaw agent has
+# already run by the time a policy could match (confirmed live 2026-07-08:
+# rm -rf executed, dir gone, no approval fired — OpenClaw never emitted a
+# matchable tool_call event either). The real fix is OpenClaw's OWN
+# pre-execution gate: `openclaw exec-policy preset cautious` sets
+# security=allowlist / ask=on-miss / askFallback=deny, so a non-allowlisted
+# exec PAUSES before running and is denied if unanswered.
+#
+# We drive it from the daemon (not a cloud→host call): the daemon already
+# runs inside the OpenClaw box and already fetches the cloud policies every
+# 2s. When an enabled require-approval policy that covers exec is present we
+# apply `cautious`; when none are, we restore `yolo` — but only when WE were
+# the one who changed it (tracked in a small state file), so we never clobber
+# a posture the operator set by hand. Best-effort; never raises into the loop.
+_EXEC_POLICY_STATE = Path.home() / ".clawmetry" / "exec_policy_applied"
+
+
+def _openclaw_env_and_bin():
+    """Resolve the `openclaw` binary with an augmented PATH (the daemon runs
+    under a minimal launchd/systemd PATH where node-shim CLIs aren't found —
+    same gotcha cli.py handles). Returns (bin_path, env) or (None, env)."""
+    import shutil
+    extra = ["/usr/local/bin", "/opt/homebrew/bin",
+             os.path.expanduser("~/.local/bin"), "/usr/bin"]
+    env = os.environ.copy()
+    env["PATH"] = ":".join(extra) + ":" + env.get("PATH", "")
+    return shutil.which("openclaw", path=env["PATH"]), env
+
+
+def _policies_want_exec_gate(policies) -> bool:
+    """True when any active policy asks for approval on a shell/exec command.
+    These are exactly the presets the UI ships (rm_rf, force_push, db, sudo,
+    package installs, network, system-config) plus the tool-agnostic secrets
+    rule — all `require_approval` and all covering `exec` (tool 'exec' or '')."""
+    for p in policies or []:
+        if not isinstance(p, dict):
+            continue
+        if (p.get("action") or "require_approval") != "require_approval":
+            continue
+        tool = (p.get("tool") or "").lower()
+        if tool in ("", "exec", "shell", "bash"):
+            return True
+    return False
+
+
+def _apply_openclaw_exec_preset(preset: str) -> bool:
+    """Run `openclaw exec-policy preset <preset>` locally. Returns True on a
+    clean apply. Never raises."""
+    import subprocess
+    ocbin, env = _openclaw_env_and_bin()
+    if not ocbin:
+        return False
+    try:
+        r = subprocess.run([ocbin, "exec-policy", "preset", preset, "--json"],
+                           capture_output=True, text=True, timeout=60, env=env)
+        if r.returncode != 0:
+            log.warning("openclaw exec-policy preset %s failed: %s",
+                        preset, (r.stderr or "")[-300:])
+            return False
+        log.info("openclaw exec-policy → %s (native pre-exec gate)", preset)
+        return True
+    except Exception as e:
+        log.warning("openclaw exec-policy preset %s error: %s", preset, e)
+        return False
+
+
+def sync_openclaw_exec_policy(policies) -> None:
+    """Align OpenClaw's native exec-approval posture with the active policies.
+    Only touches OpenClaw when the desired posture CHANGES, and only restores
+    `yolo` if a prior run was the one that set `cautious` (state file), so a
+    hand-configured posture is never clobbered. No-op when openclaw isn't on
+    this host."""
+    ocbin, _ = _openclaw_env_and_bin()
+    if not ocbin:
+        return  # not an OpenClaw box — nothing to gate
+    want = "cautious" if _policies_want_exec_gate(policies) else "yolo"
+    try:
+        prev = _EXEC_POLICY_STATE.read_text().strip() if _EXEC_POLICY_STATE.exists() else ""
+    except Exception:
+        prev = ""
+    if want == prev:
+        return  # already in the posture we last applied
+    # Guard the restore: only relax to yolo if WE previously set cautious.
+    # (Fresh install with no gate wanted + no prior state → don't force yolo
+    # onto an operator who may have set deny-all by hand.)
+    if want == "yolo" and prev != "cautious":
+        return
+    if _apply_openclaw_exec_preset(want):
+        try:
+            _EXEC_POLICY_STATE.parent.mkdir(parents=True, exist_ok=True)
+            _EXEC_POLICY_STATE.write_text(want)
+        except Exception:
+            pass
+
+
 def watcher_loop(api_key: str, node_id: str,
                  interval_sec: float = 2.0, stop_event: Optional[threading.Event] = None):
     """Long-running loop. Reloads policies on disk every iteration so users
@@ -1174,6 +1271,13 @@ def watcher_loop(api_key: str, node_id: str,
             return
         try:
             policies = load_policies(api_key=api_key)
+            # Drive OpenClaw's native pre-execution gate from the same policy
+            # set (the reactive watcher below can't PREVENT a command, only
+            # catch it after the fact — see sync_openclaw_exec_policy).
+            try:
+                sync_openclaw_exec_policy(policies)
+            except Exception as _pe:
+                log.debug("exec-policy sync skipped: %s", _pe)
             n = watch_iteration(api_key, node_id, policies=policies)
             if n:
                 log.debug(f"approvals: scanned {n} new toolCalls")

--- a/tests/test_openclaw_exec_policy_gate.py
+++ b/tests/test_openclaw_exec_policy_gate.py
@@ -1,0 +1,94 @@
+"""Daemon drives OpenClaw's native exec-approval gate from the active policies.
+
+ClawMetry's own watcher is reactive (can't prevent a command). When a
+require-approval policy covering exec is active, the daemon applies
+`openclaw exec-policy preset cautious` (pre-execution gate); when none are,
+it restores `yolo` — but only if it was the one that set cautious, so a
+hand-set posture is never clobbered. No-op off an OpenClaw host.
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+from clawmetry import approvals  # noqa: E402
+
+
+def _wire(monkeypatch, tmp_path, has_openclaw=True, prev=None):
+    state = tmp_path / "exec_policy_applied"
+    if prev is not None:
+        state.write_text(prev)
+    monkeypatch.setattr(approvals, "_EXEC_POLICY_STATE", state)
+    monkeypatch.setattr(approvals, "_openclaw_env_and_bin",
+                        lambda: (("/usr/local/bin/openclaw" if has_openclaw else None), {}))
+    applied = []
+    monkeypatch.setattr(approvals, "_apply_openclaw_exec_preset",
+                        lambda preset: (applied.append(preset), True)[1])
+    return applied, state
+
+
+RM = {"action": "require_approval", "tool": "exec",
+      "pattern": r"rm\s+-rf", "enabled": True}
+SECRETS = {"action": "require_approval", "tool": "",
+           "pattern": r"\.env", "enabled": True}
+
+
+def test_enable_applies_cautious(monkeypatch, tmp_path):
+    applied, state = _wire(monkeypatch, tmp_path)
+    approvals.sync_openclaw_exec_policy([RM])
+    assert applied == ["cautious"]
+    assert state.read_text() == "cautious"
+
+
+def test_secrets_rule_tool_agnostic_still_gates(monkeypatch, tmp_path):
+    applied, _ = _wire(monkeypatch, tmp_path)
+    approvals.sync_openclaw_exec_policy([SECRETS])
+    assert applied == ["cautious"]
+
+
+def test_no_reapply_when_already_cautious(monkeypatch, tmp_path):
+    applied, _ = _wire(monkeypatch, tmp_path, prev="cautious")
+    approvals.sync_openclaw_exec_policy([RM])
+    assert applied == []  # idempotent — desired == last applied
+
+
+def test_disable_restores_yolo_only_if_we_set_cautious(monkeypatch, tmp_path):
+    applied, state = _wire(monkeypatch, tmp_path, prev="cautious")
+    approvals.sync_openclaw_exec_policy([])  # all rules off
+    assert applied == ["yolo"]
+    assert state.read_text() == "yolo"
+
+
+def test_disable_does_not_force_yolo_on_handset_posture(monkeypatch, tmp_path):
+    # No prior state (operator may have set deny-all by hand) → never relax.
+    applied, _ = _wire(monkeypatch, tmp_path, prev=None)
+    approvals.sync_openclaw_exec_policy([])
+    assert applied == []
+
+
+def test_noop_off_openclaw_host(monkeypatch, tmp_path):
+    applied, _ = _wire(monkeypatch, tmp_path, has_openclaw=False)
+    approvals.sync_openclaw_exec_policy([RM])
+    assert applied == []
+
+
+def test_disabled_policy_does_not_gate(monkeypatch, tmp_path):
+    applied, _ = _wire(monkeypatch, tmp_path)
+    # A cloud policy row that is present but disabled must not trigger the gate.
+    # (load_policies already filters enabled; _policies_want_exec_gate keys off
+    # action/tool, so we assert the want-detector directly for a non-exec tool.)
+    approvals.sync_openclaw_exec_policy([{"action": "require_approval",
+                                          "tool": "browser", "enabled": True}])
+    assert applied == []  # browser-only rule doesn't imply an exec gate
+
+
+def test_want_detector():
+    assert approvals._policies_want_exec_gate([RM]) is True
+    assert approvals._policies_want_exec_gate([SECRETS]) is True
+    assert approvals._policies_want_exec_gate([]) is False
+    assert approvals._policies_want_exec_gate(
+        [{"action": "monitor", "tool": "exec"}]) is False  # monitor != gate


### PR DESCRIPTION
## Why

The Approvals protection-rule toggles are **inert on OpenClaw agents**. Proven live (2026-07-08): enabled "Block destructive deletes", told a hosted OpenClaw agent to `rm -rf` a sentinel dir → the dir was **deleted**, no approval ever fired. Two reasons: (1) ClawMetry's own watcher is *reactive* — it matches a `tool_call` only after the transcript records it, by which point the command already ran; and (2) OpenClaw didn't even emit a matchable `tool_call` event on that path. So the rules could neither prevent nor catch the command.

## What

OpenClaw ships its own **pre-execution** gate (`openclaw exec-policy`, verified against the pinned 2026.6.11 binary). The daemon — which already fetches the cloud policies every 2s and runs *inside* the OpenClaw box — now drives it:

- Any enabled `require_approval` policy covering exec (the rm_rf / force_push / db / sudo / package / network / system presets, plus the tool-agnostic secrets rule) → `openclaw exec-policy preset cautious` (`security=allowlist, ask=on-miss, askFallback=deny`): a non-allowlisted exec **pauses before running** and is denied if unanswered.
- No such policy → restore `yolo`, **but only if we were the one that set cautious** (state file), so a hand-set posture (e.g. `deny-all`) is never clobbered.
- Idempotent (acts only on posture change), guarded (no-op off an OpenClaw host; augmented PATH for the node-shim CLI), best-effort (never raises into the watcher loop).

No cloud→host cross-call: the toggle writes a cloud policy (existing), the daemon reads it and actuates locally. Ships to every OpenClaw node (hosted + self-hosted) via the normal release.

## Verification

- **Live controlled A/B on a hosted OpenClaw node**: the *same* `rm -rf` that deleted a sentinel dir under `yolo` was **prevented** under `cautious` (dir + `keep.txt` survived). Confirmed the daemon writes `defaults: {security: allowlist, ask: on-miss, askFallback: deny}`.
- **Unit tests 8/8** (`tests/test_openclaw_exec_policy_gate.py`): enable→cautious, disable→yolo-only-if-we-set-it, idempotent no-reapply, secrets rule (tool-agnostic) gates, no-op off OpenClaw, monitor≠gate, want-detector. (The 7 `test_approvals_local_store` failures are pre-existing on clean `origin/main` — environmental, unrelated.)

## Follow-up (v1 scope = auto-deny, founder call)

A gated command currently waits for the ask timeout, then `askFallback` denies it. Phase 2: forward the pause to a human (a channel / the ClawMetry approvals inbox) so it can be **approved**, not just denied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)