### PR TITLE
e2e(c6): add @mention to daily C6 reminder so it generates a GitHub notification

### DIFF
--- a/.github/workflows/c6-health.yml
+++ b/.github/workflows/c6-health.yml
@@ -4,8 +4,8 @@ name: C6 daily health check (branch-protection audit)
 # configured on clawmetry/main (github.token cannot read state on
 # clawmetry-cloud or clawmetry-landing -- those must be verified manually).
 #
-# On failure: posts a reminder comment to tracking issue #2146 at most
-# once per calendar day. On success: posts a GREEN confirmation.
+# On failure: posts a @vivekchand mention + reminder to tracking issue #2146
+# at most once per calendar day. On success: posts a GREEN confirmation.
 #
 # To close C6:
 #   1. Actions > "Apply required E2E status checks (C6 -- one-shot)" >
@@ -124,7 +124,7 @@ jobs:
               checks_block = "".join(f"  - `{c}`\n" for c in missing)
               body = (
                   f"{MARKER}\n"
-                  f"**C6 health check {today_utc}:"
+                  f"@vivekchand **C6 health check {today_utc}:"
                   f" {len(missing)}/2 required checks not yet configured on clawmetry/main.**\n\n"
                   f"Missing:\n{checks_block}\n"
                   "**Close C6 now (browser only, no local setup):**\n"


### PR DESCRIPTION
## Summary

The `c6-health.yml` daily health check has posted 8 identical comments to issue #2146 (2026-06-30 through 2026-07-07) without generating any GitHub notification, because the comment body never `@mentioned` the repo owner.

**Change:** prepend `@vivekchand` to the comment body in the missing-checks case.

GitHub `@mentions` from `github-actions[bot]` generate email and bell notifications for the mentioned user. This ensures the daily C6 reminder actually breaks through to the inbox rather than silently accumulating in a thread nobody is watching.

## What changed

- `.github/workflows/c6-health.yml`: one line changed in the `body` string for the `if missing:` branch.

```diff
-                  f"{MARKER}\n"
-                  f"**C6 health check {today_utc}:"
+                  f"{MARKER}\n"
+                  f"@vivekchand **C6 health check {today_utc}:"
```

No logic change. Only the missing-checks comment body is affected. The GREEN confirmation body is unchanged (no @mention needed once C6 is closed).

## Context

- 6/7 E2E criteria are GREEN for 7+ days (C1/C2/C3/C4/C5/C7).
- C6 (required-status-checks) is the sole blocker.
- Closing C6 requires one admin action: run `bash scripts/close-c6.sh` or trigger the `Apply required E2E status checks (C6 -- one-shot)` workflow with a fine-grained PAT.
- Tracking: #2146

---
_Generated by [Claude Code](https://claude.ai/code/session_019g1U6y6utP5LeKAzfTSzML)_