### PR TITLE
e2e(c6): health check audits all 6 required checks, not just 4

### DIFF
--- a/.github/workflows/c6-health.yml
+++ b/.github/workflows/c6-health.yml
@@ -58,6 +58,8 @@ jobs:
           }
 
           # All 3 repos and their required checks.
+          # This list must stay in sync with REQUIRED_CHECKS in
+          # scripts/apply_required_status_checks.py.
           # github.token reads clawmetry/main directly.
           # For clawmetry-cloud and clawmetry-landing we try the public
           # /branches/main endpoint; cross-repo reads may return UNKNOWN
@@ -66,6 +68,8 @@ jobs:
               "clawmetry": [
                   "OSS golden path (wheel + OpenClaw + 9 tabs)",
                   "Cross-repo handoff (C4)",
+                  "MOAT Keystone (13-endpoint bar)",
+                  "E2E Browser Tests (critical subset)",
               ],
               "clawmetry-cloud": [
                   "Cloud golden-path browser E2E",
@@ -230,7 +234,14 @@ jobs:
                   "- `pat_token` = paste the token from Step 1\n"
                   "- Click **Run workflow** -- closes all 3 repos in one run\n\n"
                   "Or from a terminal (~30s): `bash scripts/close-c6.sh` (uses existing gh CLI session)\n\n"
-                  "C1/C2/C3/C4/C5/C7 have been green for 7+ days. C6 is the sole remaining blocker."
+                  "C1/C2/C3/C4/C5/C7 have been green for 7+ days. C6 is the sole remaining blocker.\n\n"
+                  "Required checks that will be configured (all 6):\n"
+                  "- `clawmetry`: OSS golden path (wheel + OpenClaw + 9 tabs)\n"
+                  "- `clawmetry`: Cross-repo handoff (C4)\n"
+                  "- `clawmetry`: MOAT Keystone (13-endpoint bar)\n"
+                  "- `clawmetry`: E2E Browser Tests (critical subset)\n"
+                  "- `clawmetry-cloud`: Cloud golden-path browser E2E\n"
+                  "- `clawmetry-landing`: Landing golden path (C3)"
               )
 
           result_obj = post_comment(body)


### PR DESCRIPTION
## Summary

The daily `c6-health.yml` audit had a correctness gap: it only checked 2 of the 4 required status checks for `clawmetry/main`. If someone manually added those 2 checks to branch protection, the health check would post "ALL 3 repos confirmed GREEN" to tracking issue #2146 while `MOAT Keystone (13-endpoint bar)` and `E2E Browser Tests (critical subset)` were still missing.

`apply_required_status_checks.py` (and `close-c6.sh`) correctly add all 6 checks. The health audit now matches that full set.

## What changed

`ALL_CHECKS["clawmetry"]` in `.github/workflows/c6-health.yml`: added the 2 missing entries:
- `MOAT Keystone (13-endpoint bar)` -- `ci.yml` `moat-keystone` job, hard gate on every PR
- `E2E Browser Tests (critical subset)` -- `ci.yml` `e2e-critical` job, 32-tab auth-overlay sweep

The failure comment body also now lists all 6 required checks explicitly so it matches what the apply workflow will configure.

## Acceptance test

After merge, the next daily run of `c6-health.yml` (or a manual `workflow_dispatch`) will:
- Read `clawmetry/main` branch protection
- Report UNPROTECTED/MISSING for all 4 clawmetry checks until C6 is applied
- Only post GREEN when all 6 checks are confirmed across all 3 repos

No false positive GREEN is possible from a partial apply.

## Tracking

vivekchand/clawmetry#2146 (C6)

---
_Generated by [Claude Code](https://claude.ai/code/session_017n6JANF76thY3c8wE7EZ3h)_