### PR TITLE
feat(entitlement): next/previous_tier_channel_spec_batch + 2 endpoints

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -1117,6 +1117,132 @@ class Entitlement:
             )
             return None
 
+    def next_tier_channel_spec_batch(self, channels) -> dict:
+        """Channel-axis twin of :meth:`next_tier_feature_spec_batch` /
+        :meth:`next_tier_runtime_spec_batch` -- per-channel
+        :func:`channel_spec_at`-shape rows for N chat channels evaluated
+        on the rung above the resolved entitlement in ONE round-trip.
+
+        Batch sibling of :meth:`next_tier_channel_spec` and
+        current-relative sibling of the tier-parameterised
+        ``next_tier_channel_spec_at_batch`` (not yet on this axis --
+        arrives after this landing). Convenience for one call that walks
+        every supplied channel against ``self.next_purchasable_tier()``
+        instead of N calls to :meth:`next_tier_channel_spec`. Each row
+        is byte-identical to :meth:`next_tier_channel_spec(channel)` for
+        the same channel -- pinned by parity tests so the scalar and
+        batch accessors cannot drift.
+
+        Per-channel row shape::
+
+            {"channel": "<id>", "row": <channel_spec_at row> | None}
+
+        Supplied channel ids are normalised via :func:`_normalise_csv`
+        (whitespace stripped, lowercased, duplicates dropped, first-seen
+        order preserved). Unknown ids are echoed in ``unknown[]`` rather
+        than short-circuiting -- a partially-bad caller still gets rows
+        back for the valid ids alongside a list of what was dropped,
+        matching :meth:`next_tier_feature_spec_batch` /
+        :meth:`next_tier_runtime_spec_batch`.
+
+        Anchored on :meth:`next_purchasable_tier` (source-aware -- picks
+        the ``cloud_*`` sibling when :attr:`source` is ``"cloud"``, the
+        self-hosted sibling otherwise), matching :meth:`next_tier_spec`
+        / :meth:`next_tier_channel_spec`. At the resolver's ceiling
+        every ``row`` collapses to ``None`` while per-channel envelope
+        entries still render so the matrix's row count stays stable.
+
+        Every chat channel is FREE at every tier (see
+        :func:`channel_spec_at`), so whenever ``row`` is not ``None`` it
+        comes back ``free=True`` / ``locked=False`` / ``entitled=True``
+        regardless of the target rung. That parity IS the answer: an
+        upgrade-preview panel walking a channel picker can render "all
+        supplied chat channels included at every plan" off ONE call
+        without hard-coding that posture client-side. Pinned by tests.
+
+        Never raises: a per-channel builder failure short-circuits that
+        channel into ``unknown[]`` and the rest of the batch keeps
+        building.
+        """
+        chans = _normalise_csv(channels)
+        try:
+            target = self.next_purchasable_tier()
+        except Exception as exc:
+            logger.warning(
+                "entitlements: next_tier_channel_spec_batch target resolve failed: %s",
+                exc,
+            )
+            target = None
+        rows: list[dict] = []
+        unknown: list[str] = []
+        for cid in chans:
+            if cid not in ALL_CHANNELS:
+                unknown.append(cid)
+                continue
+            try:
+                row = channel_spec_at(target, cid) if target else None
+            except Exception as exc:
+                logger.warning(
+                    "entitlements: next_tier_channel_spec_batch row %r failed: %s",
+                    cid,
+                    exc,
+                )
+                unknown.append(cid)
+                continue
+            rows.append({"channel": cid, "row": row})
+        return {"channels": rows, "unknown": unknown}
+
+    def previous_tier_channel_spec_batch(self, channels) -> dict:
+        """Source-anchored mirror of
+        :meth:`next_tier_channel_spec_batch` -- batch sibling of
+        :meth:`previous_tier_channel_spec` walking N chat channels
+        against the rung BELOW the resolved entitlement in ONE round-
+        trip.
+
+        Same per-channel row shape and same normalisation /
+        ``unknown[]``-bucket posture as
+        :meth:`next_tier_channel_spec_batch`. At the resolver's floor
+        every ``row`` is ``None`` while per-channel envelope entries
+        still render so the downgrade-confirmation surface's row count
+        stays stable.
+
+        Each ``row`` is byte-identical to
+        :meth:`previous_tier_channel_spec(channel)` for the same
+        channel. The always-free invariant from
+        :func:`channel_spec_at` holds here too -- whenever ``row`` is
+        not ``None`` it comes back ``free=True`` / ``locked=False`` /
+        ``entitled=True``.
+
+        Never raises.
+        """
+        chans = _normalise_csv(channels)
+        try:
+            target = self.previous_purchasable_tier()
+        except Exception as exc:
+            logger.warning(
+                "entitlements: previous_tier_channel_spec_batch target resolve failed: %s",
+                exc,
+            )
+            target = None
+        rows: list[dict] = []
+        unknown: list[str] = []
+        for cid in chans:
+            if cid not in ALL_CHANNELS:
+                unknown.append(cid)
+                continue
+            try:
+                row = channel_spec_at(target, cid) if target else None
+            except Exception as exc:
+                logger.warning(
+                    "entitlements: previous_tier_channel_spec_batch row %r failed: %s",
+                    cid,
+                    exc,
+                )
+                unknown.append(cid)
+                continue
+            rows.append({"channel": cid, "row": row})
+        return {"channels": rows, "unknown": unknown}
+
     def next_tier_feature_spec_batch(self, features) -> dict:
         """Batch sibling of :meth:`next_tier_feature_spec`: per-feature
         :func:`feature_spec_at`-shape rows for N features evaluated on
@@ -2426,6 +2552,34 @@ def previous_tier_runtime_spec_batch(runtimes) -> dict:
             exc,
         )
         return {"runtimes": [], "unknown": []}
+
+
+def next_tier_channel_spec_batch(channels) -> dict:
+    """Module-level :meth:`Entitlement.next_tier_channel_spec_batch`
+    against the resolved entitlement. Never raises: a resolver failure
+    short-circuits to an envelope with ``channels=[]`` / ``unknown=[]``
+    so a paywall matrix keeps rendering."""
+    try:
+        return get_entitlement().next_tier_channel_spec_batch(channels)
+    except Exception as exc:
+        logger.warning(
+            "entitlements: next_tier_channel_spec_batch (module) failed: %s",
+            exc,
+        )
+        return {"channels": [], "unknown": []}
+
+
+def previous_tier_channel_spec_batch(channels) -> dict:
+    """Module-level :meth:`Entitlement.previous_tier_channel_spec_batch`
+    against the resolved entitlement. Never raises."""
+    try:
+        return get_entitlement().previous_tier_channel_spec_batch(channels)
+    except Exception as exc:
+        logger.warning(
+            "entitlements: previous_tier_channel_spec_batch (module) failed: %s",
+            exc,
+        )
+        return {"channels": [], "unknown": []}
 
 
 def next_tier_lock_reason(item, *, kind: str | None = None) -> str | None:

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -8258,6 +8258,135 @@ def api_entitlement_previous_tier_runtime_spec_batch():
         return jsonify(_next_prev_tier_axis_spec_batch_grace_body("runtimes"))
 
 
+@bp_entitlement.route("/api/entitlement/next-tier-channel-spec-batch")
+def api_entitlement_next_tier_channel_spec_batch():
+    """``GET /api/entitlement/next-tier-channel-spec-batch?channels=a,b,c``
+    -- channel-axis mirror of ``/next-tier-feature-spec-batch`` and
+    ``/next-tier-runtime-spec-batch``; batch sibling of
+    ``/next-tier-channel-spec``.
+
+    Where ``/next-tier-channel-spec`` projects ONE channel onto the rung
+    above the resolved entitlement, this projects N channels onto that
+    same rung in ONE round-trip. Pairs with ``/next-tier-channel-spec``
+    the same way ``/channel-spec-at-batch`` pairs with
+    ``/channel-spec-at``: scalar what-if -> batch what-if -- but source-
+    aware (anchored on the resolved entitlement's
+    ``next_purchasable_tier``) rather than caller-supplied ``tier=``.
+
+    Use case: an upgrade-preview panel walking a channel picker of N
+    chat adapters and asking "do these unlock at MY next rung?" without
+    threading the current tier through the query args or first fetching
+    ``/next-tier-channel-spec`` N times.
+
+    Each row in ``channels[].row`` is byte-identical to the body of
+    ``/next-tier-channel-spec?channel=<id>`` ``.row`` -- pinned by
+    parity tests so the scalar and batch accessors cannot drift.
+    Supplied channel ids are normalised (whitespace stripped,
+    lowercased, duplicates dropped, first-seen order preserved).
+    Unknown ids do not 404 the call -- they are echoed in ``unknown[]``
+    so a partially-bad caller still gets rows back for the valid ids,
+    matching the feature/runtime siblings.
+
+    At the ceiling (resolved entitlement already at enterprise -- no
+    rung above) every per-channel ``row`` is ``null`` while ``target``
+    / ``target_label`` / ``target_rank`` collapse to ``null``; the
+    surface stays 200 so callers can render "you're at the top" copy
+    without a status-code branch.
+
+    Every chat channel is FREE at every tier, so whenever ``row`` is
+    not ``null`` it comes back ``free=True`` / ``locked=False`` /
+    ``entitled=True`` -- pricing tooltips can render "chat channels
+    included at every plan" off ONE call.
+
+    Response shape mirrors ``/next-tier-feature-spec-batch`` with
+    ``"channels"`` in place of ``"features"`` and a per-row
+    ``"channel"`` key in place of ``"feature"``.
+
+    - **400** when ``channels=`` is missing / empty after normalisation
+    - **Never 5xxs**: a resolver failure short-circuits to the grace-
+      shape envelope with empty rows so the matrix keeps rendering.
+    """
+    try:
+        channels = _parse_csv_arg("channels")
+        if not channels:
+            return jsonify({"error": "supply channels=<csv>"}), 400
+        from clawmetry import entitlements as _ent
+
+        ent = _ent.get_entitlement()
+        target = ent.next_purchasable_tier()
+        batch = ent.next_tier_channel_spec_batch(channels)
+        return jsonify(
+            {
+                "current_tier": ent.tier,
+                "current_tier_label": _ent.tier_label(ent.tier),
+                "current_tier_rank": _ent.tier_rank(ent.tier),
+                "target": target,
+                "target_label": _ent.tier_label(target) if target else None,
+                "target_rank": _ent.tier_rank(target) if target else None,
+                "channels": batch.get("channels", []),
+                "unknown": batch.get("unknown", []),
+                "grace": bool(ent.grace),
+                "enforced": _ent.is_enforced(),
+            }
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_next_tier_channel_spec_batch: error: %s", exc
+        )
+        return jsonify(_next_prev_tier_axis_spec_batch_grace_body("channels"))
+
+
+@bp_entitlement.route("/api/entitlement/previous-tier-channel-spec-batch")
+def api_entitlement_previous_tier_channel_spec_batch():
+    """``GET /api/entitlement/previous-tier-channel-spec-batch
+    ?channels=a,b,c`` -- symmetric downgrade-side companion of
+    ``/next-tier-channel-spec-batch``.
+
+    Same envelope as ``/next-tier-channel-spec-batch``; ``target`` and
+    every per-channel ``row`` collapse to ``null`` at the floor
+    (resolved entitlement at ``oss`` / ``cloud_free`` -- no rung
+    below).
+
+    Each row in ``channels[].row`` is byte-identical to
+    ``/previous-tier-channel-spec?channel=<id>`` ``.row``.
+
+    The channel-axis always-free invariant holds here too: whenever
+    ``row`` is not ``null`` it comes back ``free=True`` /
+    ``locked=False`` / ``entitled=True``.
+
+    - **400** when ``channels=`` is missing / empty after normalisation
+    - **Never 5xxs**: grace-shape envelope on resolver failure.
+    """
+    try:
+        channels = _parse_csv_arg("channels")
+        if not channels:
+            return jsonify({"error": "supply channels=<csv>"}), 400
+        from clawmetry import entitlements as _ent
+
+        ent = _ent.get_entitlement()
+        target = ent.previous_purchasable_tier()
+        batch = ent.previous_tier_channel_spec_batch(channels)
+        return jsonify(
+            {
+                "current_tier": ent.tier,
+                "current_tier_label": _ent.tier_label(ent.tier),
+                "current_tier_rank": _ent.tier_rank(ent.tier),
+                "target": target,
+                "target_label": _ent.tier_label(target) if target else None,
+                "target_rank": _ent.tier_rank(target) if target else None,
+                "channels": batch.get("channels", []),
+                "unknown": batch.get("unknown", []),
+                "grace": bool(ent.grace),
+                "enforced": _ent.is_enforced(),
+            }
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_previous_tier_channel_spec_batch: error: %s", exc
+        )
+        return jsonify(_next_prev_tier_axis_spec_batch_grace_body("channels"))
+
+
 def _next_prev_lock_reason_grace_body(key: str, kind: str) -> dict:
     """Fallback envelope shared by the bare next/previous lock-reason
     routes. Keeps the shape identical to the happy path so a resolver

--- a/tests/test_entitlement_next_prev_tier_channel_spec_batch.py
+++ b/tests/test_entitlement_next_prev_tier_channel_spec_batch.py
@@ -1,0 +1,549 @@
+"""Tests for the bare (source-aware) directional channel-axis batch
+projections ``Entitlement.next_tier_channel_spec_batch`` /
+``Entitlement.previous_tier_channel_spec_batch``, their module-level
+convenience wrappers, and the two companion
+``/api/entitlement/{next,previous}-tier-channel-spec-batch`` endpoints.
+
+Channel-axis twin of the feature/runtime pair covered by
+``test_entitlement_next_prev_tier_feature_runtime_spec_batch.py``. Where
+those project N features / runtimes onto the rung above (or below) the
+resolved entitlement in ONE round-trip, these project N chat channels.
+Batch sibling of the scalar bare channel projection
+(``next/previous_tier_channel_spec``, merged in #3602).
+
+The channel-axis invariant is stronger than the feature/runtime axes:
+every chat channel is FREE at every tier (see :func:`channel_spec_at`),
+so whenever ``row`` is not ``None`` it comes back ``free=True`` /
+``locked=False`` / ``entitled=True`` regardless of the target rung. That
+parity IS the answer -- an upgrade-preview panel walking a channel picker
+can render "all supplied chat channels included at every plan" off ONE
+call. These tests pin that invariant on both the helper and the endpoint.
+
+Pins covered here:
+
+* per-row byte-equality with the scalar bare sibling
+  ``next/previous_tier_channel_spec(channel)`` across every purchasable
+  source
+* ceiling / floor produces per-row ``row=null`` with envelope entries
+  still rendered so the matrix keeps a stable row count
+* trial-as-source resolves next -> enterprise, previous -> cloud_starter
+  (matches sibling scalar family)
+* input normalisation (whitespace, lowercase, duplicate drop, first-seen
+  order preserved)
+* unknown ids bucketed in ``unknown[]`` alongside valid rows rather than
+  short-circuiting
+* always-free invariant: every non-null row reports ``free=True`` /
+  ``locked=False`` / ``entitled=True`` at every rung
+* grace vs enforce yields byte-identical bodies (catalogue-derived)
+* module-level wrappers match the bound method on the resolved
+  entitlement
+* helpers never raise on synthesised resolver failure; module-level
+  wrappers fall back to an empty envelope
+* HTTP 400 / 200 error envelopes on both endpoints (missing csv,
+  never-5xx grace fallback)
+* endpoint rows byte-match the helper on the live perspective
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+_ROW_KEYS = {"channel", "row"}
+_ENVELOPE_KEYS = {
+    "current_tier",
+    "current_tier_label",
+    "current_tier_rank",
+    "target",
+    "target_label",
+    "target_rank",
+    "channels",
+    "unknown",
+    "grace",
+    "enforced",
+}
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+def _some_channels(ent):
+    # A short deterministic slice of channels so the batch has non-trivial
+    # content to parity-check.
+    return list(ent.ALL_CHANNELS[:3])
+
+
+# ── Entitlement.next_tier_channel_spec_batch ────────────────────────────────
+
+
+def test_next_tier_channel_spec_batch_parity_with_scalar(ent):
+    # Each row must byte-equal next_tier_channel_spec(channel) so the scalar
+    # and batch accessors cannot drift.
+    channels = _some_channels(ent)
+    for tier in (
+        ent.TIER_OSS,
+        ent.TIER_CLOUD_FREE,
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_PRO,
+    ):
+        e = ent._build(tier, "test")
+        body = e.next_tier_channel_spec_batch(channels)
+        assert set(body.keys()) == {"channels", "unknown"}
+        assert body["unknown"] == []
+        assert [row["channel"] for row in body["channels"]] == channels
+        for row in body["channels"]:
+            assert set(row.keys()) == _ROW_KEYS
+            assert row["row"] == e.next_tier_channel_spec(row["channel"])
+
+
+def test_next_tier_channel_spec_batch_at_ceiling(ent):
+    # Enterprise has no rung above -- every row should be null but the
+    # per-channel entries still render so the row count stays stable.
+    e = ent._build(ent.TIER_ENTERPRISE, "license")
+    channels = _some_channels(ent)
+    body = e.next_tier_channel_spec_batch(channels)
+    assert [row["channel"] for row in body["channels"]] == channels
+    assert all(row["row"] is None for row in body["channels"])
+    assert body["unknown"] == []
+
+
+def test_next_tier_channel_spec_batch_normalises_input(ent):
+    # Duplicates dropped, whitespace stripped, case-lowered, first-seen order
+    # preserved -- shared _normalise_csv posture.
+    channels = _some_channels(ent)
+    e = ent._build(ent.TIER_CLOUD_STARTER, "cloud")
+    raw = f"  {channels[0].upper()}  ,{channels[1]},{channels[0]},, "
+    body = e.next_tier_channel_spec_batch(raw)
+    assert [row["channel"] for row in body["channels"]] == channels[:2]
+    assert body["unknown"] == []
+
+
+def test_next_tier_channel_spec_batch_unknown_ids_bucketed(ent):
+    e = ent._build(ent.TIER_CLOUD_STARTER, "cloud")
+    channels = _some_channels(ent)
+    body = e.next_tier_channel_spec_batch(
+        [channels[0], "no_such_channel", channels[1]]
+    )
+    assert [row["channel"] for row in body["channels"]] == channels[:2]
+    assert body["unknown"] == ["no_such_channel"]
+
+
+def test_next_tier_channel_spec_batch_empty_csv(ent):
+    e = ent._build(ent.TIER_CLOUD_STARTER, "cloud")
+    body = e.next_tier_channel_spec_batch("")
+    assert body == {"channels": [], "unknown": []}
+
+
+def test_next_tier_channel_spec_batch_never_raises(ent, monkeypatch):
+    # If next_purchasable_tier blows up, the helper must swallow and return
+    # rows with row=null so the matrix keeps rendering.
+    e = ent._oss_free()
+    monkeypatch.setattr(
+        type(e),
+        "next_purchasable_tier",
+        lambda self: (_ for _ in ()).throw(RuntimeError("synthetic")),
+    )
+    channels = _some_channels(ent)
+    body = e.next_tier_channel_spec_batch(channels)
+    assert [row["channel"] for row in body["channels"]] == channels
+    assert all(row["row"] is None for row in body["channels"])
+
+
+def test_next_tier_channel_spec_batch_always_free_invariant(ent):
+    # Every non-null row must come back free=True / locked=False /
+    # entitled=True regardless of the target rung -- pins the channel-axis
+    # promise that the batch surface can rely on.
+    channels = list(ent.ALL_CHANNELS)
+    for tier in (
+        ent.TIER_OSS,
+        ent.TIER_CLOUD_FREE,
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_PRO,
+    ):
+        e = ent._build(tier, "test")
+        body = e.next_tier_channel_spec_batch(channels)
+        for row in body["channels"]:
+            if row["row"] is None:
+                continue
+            assert row["row"]["free"] is True
+            assert row["row"]["locked"] is False
+            assert row["row"]["entitled"] is True
+
+
+def test_next_tier_channel_spec_batch_all_channels_covered(ent):
+    # Handing the full catalogue must return every channel in supply order
+    # with no unknowns dropped.
+    channels = list(ent.ALL_CHANNELS)
+    e = ent._build(ent.TIER_CLOUD_STARTER, "cloud")
+    body = e.next_tier_channel_spec_batch(channels)
+    assert [row["channel"] for row in body["channels"]] == channels
+    assert body["unknown"] == []
+
+
+# ── Entitlement.previous_tier_channel_spec_batch ────────────────────────────
+
+
+def test_previous_tier_channel_spec_batch_parity_with_scalar(ent):
+    channels = _some_channels(ent)
+    for tier in (
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_PRO,
+        ent.TIER_ENTERPRISE,
+    ):
+        e = ent._build(tier, "test")
+        body = e.previous_tier_channel_spec_batch(channels)
+        assert set(body.keys()) == {"channels", "unknown"}
+        for row in body["channels"]:
+            assert set(row.keys()) == _ROW_KEYS
+            assert row["row"] == e.previous_tier_channel_spec(row["channel"])
+
+
+def test_previous_tier_channel_spec_batch_at_floor(ent):
+    # OSS / cloud_free -- nothing below to step down to.
+    for tier in (ent.TIER_OSS, ent.TIER_CLOUD_FREE):
+        e = ent._build(tier, "test")
+        channels = _some_channels(ent)
+        body = e.previous_tier_channel_spec_batch(channels)
+        assert [row["channel"] for row in body["channels"]] == channels
+        assert all(row["row"] is None for row in body["channels"])
+
+
+def test_previous_tier_channel_spec_batch_never_raises(ent, monkeypatch):
+    e = ent._build(ent.TIER_ENTERPRISE, "license")
+    monkeypatch.setattr(
+        type(e),
+        "previous_purchasable_tier",
+        lambda self: (_ for _ in ()).throw(RuntimeError("synthetic")),
+    )
+    channels = _some_channels(ent)
+    body = e.previous_tier_channel_spec_batch(channels)
+    assert [row["channel"] for row in body["channels"]] == channels
+    assert all(row["row"] is None for row in body["channels"])
+
+
+def test_previous_tier_channel_spec_batch_always_free_invariant(ent):
+    channels = list(ent.ALL_CHANNELS)
+    for tier in (
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_PRO,
+        ent.TIER_ENTERPRISE,
+    ):
+        e = ent._build(tier, "test")
+        body = e.previous_tier_channel_spec_batch(channels)
+        for row in body["channels"]:
+            if row["row"] is None:
+                continue
+            assert row["row"]["free"] is True
+            assert row["row"]["locked"] is False
+            assert row["row"]["entitled"] is True
+
+
+def test_previous_tier_channel_spec_batch_normalises_input(ent):
+    channels = _some_channels(ent)
+    e = ent._build(ent.TIER_CLOUD_PRO, "cloud")
+    raw = f"  {channels[0].upper()}  ,{channels[1]},{channels[0]},, "
+    body = e.previous_tier_channel_spec_batch(raw)
+    assert [row["channel"] for row in body["channels"]] == channels[:2]
+    assert body["unknown"] == []
+
+
+def test_previous_tier_channel_spec_batch_unknown_ids_bucketed(ent):
+    e = ent._build(ent.TIER_CLOUD_PRO, "cloud")
+    channels = _some_channels(ent)
+    body = e.previous_tier_channel_spec_batch(
+        [channels[0], "no_such_channel", channels[1]]
+    )
+    assert [row["channel"] for row in body["channels"]] == channels[:2]
+    assert body["unknown"] == ["no_such_channel"]
+
+
+# ── trial source resolution ─────────────────────────────────────────────────
+
+
+def test_trial_next_batch_resolves_to_enterprise(ent):
+    # Trial's next purchasable is enterprise (matches next_tier_spec).
+    e = ent._build(ent.TIER_TRIAL, "cloud")
+    channels = _some_channels(ent)
+    body = e.next_tier_channel_spec_batch(channels)
+    for row in body["channels"]:
+        expected = ent.channel_spec_at(ent.TIER_ENTERPRISE, row["channel"])
+        assert row["row"] == expected
+
+
+def test_trial_previous_batch_resolves_to_starter(ent):
+    e = ent._build(ent.TIER_TRIAL, "cloud")
+    channels = _some_channels(ent)
+    body = e.previous_tier_channel_spec_batch(channels)
+    for row in body["channels"]:
+        expected = ent.channel_spec_at(ent.TIER_CLOUD_STARTER, row["channel"])
+        assert row["row"] == expected
+
+
+# ── grace vs enforce ────────────────────────────────────────────────────────
+
+
+def test_grace_vs_enforce_next_batch_identical(ent, monkeypatch):
+    channels = _some_channels(ent)
+    e = ent._build(ent.TIER_CLOUD_STARTER, "cloud")
+    grace_body = e.next_tier_channel_spec_batch(channels)
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    importlib.reload(ent)
+    ent.invalidate()
+    e2 = ent._build(ent.TIER_CLOUD_STARTER, "cloud")
+    enforce_body = e2.next_tier_channel_spec_batch(channels)
+    assert enforce_body == grace_body
+
+
+def test_grace_vs_enforce_previous_batch_identical(ent, monkeypatch):
+    channels = _some_channels(ent)
+    e = ent._build(ent.TIER_CLOUD_PRO, "cloud")
+    grace_body = e.previous_tier_channel_spec_batch(channels)
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    importlib.reload(ent)
+    ent.invalidate()
+    e2 = ent._build(ent.TIER_CLOUD_PRO, "cloud")
+    enforce_body = e2.previous_tier_channel_spec_batch(channels)
+    assert enforce_body == grace_body
+
+
+# ── module-level wrappers ───────────────────────────────────────────────────
+
+
+def test_module_level_next_channel_batch_matches_method(ent):
+    channels = _some_channels(ent)
+    assert ent.next_tier_channel_spec_batch(channels) == (
+        ent.get_entitlement().next_tier_channel_spec_batch(channels)
+    )
+
+
+def test_module_level_previous_channel_batch_matches_method(ent):
+    channels = _some_channels(ent)
+    assert ent.previous_tier_channel_spec_batch(channels) == (
+        ent.get_entitlement().previous_tier_channel_spec_batch(channels)
+    )
+
+
+def test_module_level_next_channel_batch_never_raises(ent, monkeypatch):
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "get_entitlement", boom)
+    channels = _some_channels(ent)
+    assert ent.next_tier_channel_spec_batch(channels) == {
+        "channels": [],
+        "unknown": [],
+    }
+
+
+def test_module_level_previous_channel_batch_never_raises(ent, monkeypatch):
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "get_entitlement", boom)
+    channels = _some_channels(ent)
+    assert ent.previous_tier_channel_spec_batch(channels) == {
+        "channels": [],
+        "unknown": [],
+    }
+
+
+# ── /api/entitlement/next-tier-channel-spec-batch endpoint ──────────────────
+
+
+def test_endpoint_next_channel_batch_default_oss(client, ent):
+    channels = _some_channels(ent)
+    rv = client.get(
+        "/api/entitlement/next-tier-channel-spec-batch?channels="
+        + ",".join(channels)
+    )
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert set(body.keys()) == _ENVELOPE_KEYS
+    assert body["current_tier"] == ent.TIER_OSS
+    assert body["current_tier_label"] == ent.tier_label(ent.TIER_OSS)
+    assert body["current_tier_rank"] == ent.tier_rank(ent.TIER_OSS)
+    assert body["target"] == ent.TIER_CLOUD_STARTER
+    assert body["target_label"] == ent.tier_label(ent.TIER_CLOUD_STARTER)
+    assert body["target_rank"] == ent.tier_rank(ent.TIER_CLOUD_STARTER)
+    assert [row["channel"] for row in body["channels"]] == channels
+    assert body["unknown"] == []
+    assert body["grace"] is True
+    assert body["enforced"] is False
+
+
+def test_endpoint_next_channel_batch_row_matches_helper(client, ent):
+    channels = _some_channels(ent)
+    rv = client.get(
+        "/api/entitlement/next-tier-channel-spec-batch?channels="
+        + ",".join(channels)
+    )
+    body = rv.get_json()
+    helper = ent.next_tier_channel_spec_batch(channels)
+    assert body["channels"] == helper["channels"]
+    assert body["unknown"] == helper["unknown"]
+
+
+def test_endpoint_next_channel_batch_row_matches_scalar(client, ent):
+    # Endpoint row must byte-match /next-tier-channel-spec?channel=<id> .row
+    # for the same channel -- pins the scalar/batch parity through HTTP.
+    channels = _some_channels(ent)
+    rv_batch = client.get(
+        "/api/entitlement/next-tier-channel-spec-batch?channels="
+        + ",".join(channels)
+    ).get_json()
+    for row in rv_batch["channels"]:
+        rv_scalar = client.get(
+            f"/api/entitlement/next-tier-channel-spec?channel={row['channel']}"
+        ).get_json()
+        assert row["row"] == rv_scalar["row"]
+
+
+def test_endpoint_next_channel_batch_missing_csv(client):
+    rv = client.get("/api/entitlement/next-tier-channel-spec-batch")
+    assert rv.status_code == 400
+    assert rv.get_json()["error"] == "supply channels=<csv>"
+
+
+def test_endpoint_next_channel_batch_empty_csv(client):
+    rv = client.get(
+        "/api/entitlement/next-tier-channel-spec-batch?channels=,"
+    )
+    assert rv.status_code == 400
+
+
+def test_endpoint_next_channel_batch_unknown_bucketed(client, ent):
+    channels = _some_channels(ent)
+    rv = client.get(
+        "/api/entitlement/next-tier-channel-spec-batch?channels="
+        + ",".join([channels[0], "no_such_channel", channels[1]])
+    )
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert [row["channel"] for row in body["channels"]] == channels[:2]
+    assert body["unknown"] == ["no_such_channel"]
+
+
+def test_endpoint_next_channel_batch_always_free_invariant(client, ent):
+    channels = list(ent.ALL_CHANNELS)
+    rv = client.get(
+        "/api/entitlement/next-tier-channel-spec-batch?channels="
+        + ",".join(channels)
+    )
+    body = rv.get_json()
+    for row in body["channels"]:
+        if row["row"] is None:
+            continue
+        assert row["row"]["free"] is True
+        assert row["row"]["locked"] is False
+        assert row["row"]["entitled"] is True
+
+
+def test_endpoint_next_channel_batch_never_5xxs(client, ent, monkeypatch):
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "get_entitlement", boom)
+    channels = _some_channels(ent)
+    rv = client.get(
+        "/api/entitlement/next-tier-channel-spec-batch?channels="
+        + ",".join(channels)
+    )
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert set(body.keys()) == _ENVELOPE_KEYS
+    assert body["current_tier"] == "oss"
+    assert body["channels"] == []
+    assert body["unknown"] == []
+    assert body["target"] is None
+
+
+# ── /api/entitlement/previous-tier-channel-spec-batch endpoint ──────────────
+
+
+def test_endpoint_previous_channel_batch_default_oss_floor(client, ent):
+    channels = _some_channels(ent)
+    rv = client.get(
+        "/api/entitlement/previous-tier-channel-spec-batch?channels="
+        + ",".join(channels)
+    )
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert set(body.keys()) == _ENVELOPE_KEYS
+    assert body["current_tier"] == ent.TIER_OSS
+    # OSS is the floor -- target and every row is null.
+    assert body["target"] is None
+    assert body["target_label"] is None
+    assert body["target_rank"] is None
+    assert all(row["row"] is None for row in body["channels"])
+    assert [row["channel"] for row in body["channels"]] == channels
+
+
+def test_endpoint_previous_channel_batch_row_matches_scalar(client, ent):
+    channels = _some_channels(ent)
+    rv_batch = client.get(
+        "/api/entitlement/previous-tier-channel-spec-batch?channels="
+        + ",".join(channels)
+    ).get_json()
+    for row in rv_batch["channels"]:
+        rv_scalar = client.get(
+            "/api/entitlement/previous-tier-channel-spec"
+            f"?channel={row['channel']}"
+        ).get_json()
+        assert row["row"] == rv_scalar["row"]
+
+
+def test_endpoint_previous_channel_batch_missing_csv(client):
+    rv = client.get("/api/entitlement/previous-tier-channel-spec-batch")
+    assert rv.status_code == 400
+
+
+def test_endpoint_previous_channel_batch_unknown_bucketed(client, ent):
+    channels = _some_channels(ent)
+    rv = client.get(
+        "/api/entitlement/previous-tier-channel-spec-batch?channels="
+        + ",".join([channels[0], "no_such_channel", channels[1]])
+    )
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert [row["channel"] for row in body["channels"]] == channels[:2]
+    assert body["unknown"] == ["no_such_channel"]
+
+
+def test_endpoint_previous_channel_batch_never_5xxs(client, ent, monkeypatch):
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "get_entitlement", boom)
+    channels = _some_channels(ent)
+    rv = client.get(
+        "/api/entitlement/previous-tier-channel-spec-batch?channels="
+        + ",".join(channels)
+    )
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert set(body.keys()) == _ENVELOPE_KEYS
+    assert body["channels"] == []


### PR DESCRIPTION
## Summary

- Channel-axis batch companion of the just-merged `next_tier_channel_spec(channel)` (#3602) and channel-axis twin of the feature/runtime batch siblings.
- New methods `Entitlement.next_tier_channel_spec_batch(channels)` / `previous_tier_channel_spec_batch(channels)` in `clawmetry/entitlements.py` -- walk N chat channels against `self.next_purchasable_tier()` / `self.previous_purchasable_tier()` in ONE round-trip. Per-row shape `{"channel": <id>, "row": <channel_spec_at row> | None}` mirrors the feature/runtime siblings.
- Module-level wrappers `entitlements.next_tier_channel_spec_batch` / `previous_tier_channel_spec_batch` against the resolved entitlement, matching the sibling helpers.
- New endpoints `GET /api/entitlement/next-tier-channel-spec-batch?channels=a,b,c` and `GET /api/entitlement/previous-tier-channel-spec-batch?channels=a,b,c` in `routes/entitlement.py` -- envelope mirrors `/next-tier-{feature,runtime}-spec-batch` with `"channels"` in place of `"features"` / `"runtimes"`.
- 35 new tests in `tests/test_entitlement_next_prev_tier_channel_spec_batch.py` pinning: per-source byte-parity with the scalar sibling `next/previous_tier_channel_spec(channel)`, ceiling/floor -> `row=null` (envelope entries still render so the row count stays stable), trial-as-source resolution (next -> enterprise, previous -> cloud_starter), input normalisation (whitespace / case / dedup / first-seen order), unknown-id bucketing, always-free invariant on every non-null row, grace vs enforce parity, module-level <-> method agreement, endpoint envelope keys, endpoint row byte-match with the helper AND with the scalar `/next-tier-channel-spec` endpoint, 400 on missing csv, never-5xx grace fallback.

Every chat channel is FREE at every tier, so every non-null row comes back `free=True` / `locked=False` / `entitled=True` regardless of the target rung. That parity IS the answer: an upgrade-preview panel walking a channel picker can render "all supplied chat channels included at every plan" off ONE call without hard-coding that posture client-side. The invariant is pinned in the tests on both the helper and the endpoint.

**Zero behaviour change on existing surfaces.** Read-only, additive endpoints. Enforcement posture unchanged (helpers defer to `channel_spec_at`, which is catalogue-derived; grace vs enforce yields byte-identical rows, pinned).

Independent of #3603 (that PR adds the no-arg `next_tier_channel_catalog()` / `previous_tier_channel_catalog()` catalog projections; this PR adds the batch scalar). No merge-order dependency.

## Test plan

- [x] `python -m py_compile clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_next_prev_tier_channel_spec_batch.py`
- [x] `python -m pytest tests/test_entitlement_next_prev_tier_channel_spec_batch.py -q` -- 35 passed
- [x] Regression check: sibling scalar / batch / catalog test files (`test_entitlement_next_prev_tier_channel_spec`, `test_entitlement_next_prev_tier_feature_runtime_spec_batch`, `test_entitlement_channel_spec`, `test_entitlement_channel_spec_batch`, `test_entitlement_channel_spec_at`, `test_entitlement_channel_catalog`, `test_entitlement_channel_catalog_at`) -- 225 passed
- [ ] CI matrix (Ubuntu / macOS / Windows x Python 3.9 / 3.11) green on this branch

### Local operator verification checklist

The automated agent cannot reach the local daemon, `~/.openclaw`, the live cloud snapshot, or a browser. Please run:

- [ ] Copy changed files into the installed package:
  ```
  cp clawmetry/entitlements.py ~/.clawmetry/lib/python3.*/site-packages/clawmetry/
  cp routes/entitlement.py    ~/.clawmetry/lib/python3.*/site-packages/routes/
  find ~/.clawmetry/lib/python3.*/site-packages/{clawmetry,routes} -name __pycache__ -exec rm -rf {} +
  ```
- [ ] Restart the daemon so it re-imports:
  ```
  launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync
  ```
- [ ] Hit the new endpoints and confirm the envelope keys:
  ```
  curl -s 'http://localhost:8900/api/entitlement/next-tier-channel-spec-batch?channels=telegram,signal,discord' | jq 'keys'
  curl -s 'http://localhost:8900/api/entitlement/previous-tier-channel-spec-batch?channels=telegram,signal,discord' | jq 'keys'
  ```
  Expect `["channels","current_tier","current_tier_label","current_tier_rank","enforced","grace","target","target_label","target_rank","unknown"]` on both.
- [ ] Confirm the always-free invariant reaches every non-null row:
  ```
  curl -s 'http://localhost:8900/api/entitlement/next-tier-channel-spec-batch?channels=telegram,signal,discord' \
    | jq '[.channels[].row | select(. != null) | {free,locked,entitled}] | unique'
  ```
  Expect `[{"entitled":true,"free":true,"locked":false}]` (single element -- all rows agree).
- [ ] Confirm scalar/batch no-drift on the live perspective:
  ```
  diff <(curl -s '.../next-tier-channel-spec-batch?channels=telegram' | jq '.channels[0].row') \
       <(curl -s '.../next-tier-channel-spec?channel=telegram' | jq '.row')
  ```
  Expect no diff.
- [ ] Decrypt the live cloud snapshot in the browser and confirm no paywall / channel-picker surface regressed (nothing on the live UI calls these endpoints yet -- they are additive infrastructure).
- [ ] After local sanity: convert this draft to ready-for-review, then merge on the operator's own release cadence. This PR does **not** bump `__version__` and is **not** a `[RELEASE]` PR -- the follow-up `[RELEASE]` PR carrying this commit is the operator's call.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GHTqQh3ykgpX3JBJgEAq5f)_