### PR TITLE
fix(approvals): kill exec-policy CLI process group on timeout + backoff failed applies

### DIFF
--- a/clawmetry/approvals.py
+++ b/clawmetry/approvals.py
@@ -1170,6 +1170,19 @@ def watch_iteration(api_key: str, node_id: str,
 # the one who changed it (tracked in a small state file), so we never clobber
 # a posture the operator set by hand. Best-effort; never raises into the loop.
 _EXEC_POLICY_STATE = Path.home() / ".clawmetry" / "exec_policy_applied"
+# Backoff between FAILED preset applies. Live-hit 2026-07-10 (agent-builder
+# shared-cpu-1x box): `openclaw` is a wrapper whose node child can outlive
+# the 60 s timeout on a busy 1-core host; subprocess.run's kill reaped only
+# the wrapper, the ~200 MB node grandchild survived as an orphan, and the
+# watcher retried every ~62 s forever (the state file is only written on
+# success) — one orphan per minute until the VM OOM/throttle-wedged. The
+# process-group kill in _apply_openclaw_exec_preset stops the leak; this
+# backoff stops the hot retry so a host that can't apply the preset degrades
+# to an occasional attempt instead of a permanent CPU tax.
+_EXEC_POLICY_APPLY_TIMEOUT_S = 60
+_EXEC_POLICY_BACKOFF_BASE_S = 300      # first retry 5 min after a failure
+_EXEC_POLICY_BACKOFF_MAX_S = 3600     # never back off longer than an hour
+_EXEC_POLICY_BACKOFF = {"fails": 0, "until": 0.0}
 
 
 def _openclaw_env_and_bin():
@@ -1202,17 +1215,34 @@ def _policies_want_exec_gate(policies) -> bool:
 
 def _apply_openclaw_exec_preset(preset: str) -> bool:
     """Run `openclaw exec-policy preset <preset>` locally. Returns True on a
-    clean apply. Never raises."""
+    clean apply. Never raises. The CLI runs in its own process group and the
+    whole GROUP is killed on timeout — `openclaw` is a wrapper whose node
+    child otherwise survives the wrapper's death as a CPU/RAM-burning orphan
+    (live-hit 2026-07-10, see _EXEC_POLICY_BACKOFF)."""
+    import signal
     import subprocess
     ocbin, env = _openclaw_env_and_bin()
     if not ocbin:
         return False
     try:
-        r = subprocess.run([ocbin, "exec-policy", "preset", preset, "--json"],
-                           capture_output=True, text=True, timeout=60, env=env)
-        if r.returncode != 0:
+        p = subprocess.Popen([ocbin, "exec-policy", "preset", preset, "--json"],
+                             stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                             text=True, env=env, start_new_session=True)
+        try:
+            _, err = p.communicate(timeout=_EXEC_POLICY_APPLY_TIMEOUT_S)
+        except subprocess.TimeoutExpired:
+            try:
+                os.killpg(p.pid, signal.SIGKILL)  # pgid == pid (new session)
+            except Exception:
+                p.kill()
+            p.wait(timeout=10)
+            log.warning("openclaw exec-policy preset %s timed out after %ss "
+                        "(process group killed)", preset,
+                        _EXEC_POLICY_APPLY_TIMEOUT_S)
+            return False
+        if p.returncode != 0:
             log.warning("openclaw exec-policy preset %s failed: %s",
-                        preset, (r.stderr or "")[-300:])
+                        preset, (err or "")[-300:])
             return False
         log.info("openclaw exec-policy → %s (native pre-exec gate)", preset)
         return True
@@ -1242,12 +1272,25 @@ def sync_openclaw_exec_policy(policies) -> None:
     # onto an operator who may have set deny-all by hand.)
     if want == "yolo" and prev != "cautious":
         return
+    now = time.time()
+    if now < _EXEC_POLICY_BACKOFF["until"]:
+        return  # last apply failed; wait out the backoff before retrying
     if _apply_openclaw_exec_preset(want):
+        _EXEC_POLICY_BACKOFF["fails"] = 0
+        _EXEC_POLICY_BACKOFF["until"] = 0.0
         try:
             _EXEC_POLICY_STATE.parent.mkdir(parents=True, exist_ok=True)
             _EXEC_POLICY_STATE.write_text(want)
         except Exception:
             pass
+    else:
+        _EXEC_POLICY_BACKOFF["fails"] += 1
+        delay = min(_EXEC_POLICY_BACKOFF_MAX_S,
+                    _EXEC_POLICY_BACKOFF_BASE_S
+                    * (2 ** (_EXEC_POLICY_BACKOFF["fails"] - 1)))
+        _EXEC_POLICY_BACKOFF["until"] = now + delay
+        log.warning("openclaw exec-policy apply failed (%d in a row); "
+                    "next retry in %ds", _EXEC_POLICY_BACKOFF["fails"], delay)
 
 
 def watcher_loop(api_key: str, node_id: str,

--- a/tests/test_openclaw_exec_policy_gate.py
+++ b/tests/test_openclaw_exec_policy_gate.py
@@ -23,6 +23,8 @@ def _wire(monkeypatch, tmp_path, has_openclaw=True, prev=None):
     if prev is not None:
         state.write_text(prev)
     monkeypatch.setattr(approvals, "_EXEC_POLICY_STATE", state)
+    monkeypatch.setattr(approvals, "_EXEC_POLICY_BACKOFF",
+                        {"fails": 0, "until": 0.0})
     monkeypatch.setattr(approvals, "_openclaw_env_and_bin",
                         lambda: (("/usr/local/bin/openclaw" if has_openclaw else None), {}))
     applied = []
@@ -84,6 +86,81 @@ def test_disabled_policy_does_not_gate(monkeypatch, tmp_path):
     approvals.sync_openclaw_exec_policy([{"action": "require_approval",
                                           "tool": "browser", "enabled": True}])
     assert applied == []  # browser-only rule doesn't imply an exec gate
+
+
+def test_failed_apply_backs_off_then_retries(monkeypatch, tmp_path):
+    # A host that can't complete the CLI (live-hit 2026-07-10: node child
+    # outliving the timeout on a 1-core box) must not retry every watcher
+    # iteration — that was one ~200MB orphan per minute until the VM wedged.
+    applied, state = _wire(monkeypatch, tmp_path)
+    monkeypatch.setattr(approvals, "_apply_openclaw_exec_preset",
+                        lambda preset: (applied.append(preset), False)[1])
+    t = {"now": 1000.0}
+    monkeypatch.setattr(approvals.time, "time", lambda: t["now"])
+    approvals.sync_openclaw_exec_policy([RM])
+    approvals.sync_openclaw_exec_policy([RM])  # inside backoff window
+    assert applied == ["cautious"]  # second call did not shell out
+    assert not state.exists()       # never written on failure
+    t["now"] += approvals._EXEC_POLICY_BACKOFF_BASE_S + 1
+    approvals.sync_openclaw_exec_policy([RM])  # backoff expired → retry
+    assert applied == ["cautious", "cautious"]
+
+
+def test_backoff_escalates_and_caps(monkeypatch, tmp_path):
+    applied, _ = _wire(monkeypatch, tmp_path)
+    monkeypatch.setattr(approvals, "_apply_openclaw_exec_preset",
+                        lambda preset: (applied.append(preset), False)[1])
+    t = {"now": 1000.0}
+    monkeypatch.setattr(approvals.time, "time", lambda: t["now"])
+    delays = []
+    for _ in range(6):
+        approvals.sync_openclaw_exec_policy([RM])
+        delays.append(approvals._EXEC_POLICY_BACKOFF["until"] - t["now"])
+        t["now"] = approvals._EXEC_POLICY_BACKOFF["until"] + 1
+    assert delays == [300, 600, 1200, 2400, 3600, 3600]  # 2x, capped at 1h
+
+
+def test_success_resets_backoff(monkeypatch, tmp_path):
+    applied, state = _wire(monkeypatch, tmp_path)
+    ok = {"v": False}
+    monkeypatch.setattr(approvals, "_apply_openclaw_exec_preset",
+                        lambda preset: (applied.append(preset), ok["v"])[1])
+    t = {"now": 1000.0}
+    monkeypatch.setattr(approvals.time, "time", lambda: t["now"])
+    approvals.sync_openclaw_exec_policy([RM])   # fails → backoff armed
+    assert approvals._EXEC_POLICY_BACKOFF["fails"] == 1
+    ok["v"] = True
+    t["now"] += approvals._EXEC_POLICY_BACKOFF_BASE_S + 1
+    approvals.sync_openclaw_exec_policy([RM])   # succeeds
+    assert state.read_text() == "cautious"
+    assert approvals._EXEC_POLICY_BACKOFF == {"fails": 0, "until": 0.0}
+
+
+def test_timeout_kills_whole_process_group(monkeypatch, tmp_path):
+    # `openclaw` is a wrapper: on timeout the node CHILD must die too, not
+    # just the wrapper (the orphan leak that wedged the VM, 2026-07-10).
+    import os
+    import time as _time
+    child_pid_file = tmp_path / "child.pid"
+    fake = tmp_path / "openclaw"
+    fake.write_text("#!/bin/bash\nsleep 300 &\necho $! > %s\nwait\n"
+                    % child_pid_file)
+    fake.chmod(0o755)
+    monkeypatch.setattr(approvals, "_openclaw_env_and_bin",
+                        lambda: (str(fake), dict(os.environ)))
+    monkeypatch.setattr(approvals, "_EXEC_POLICY_APPLY_TIMEOUT_S", 1)
+    assert approvals._apply_openclaw_exec_preset("cautious") is False
+    deadline = _time.time() + 5
+    child = int(child_pid_file.read_text().strip())
+    while _time.time() < deadline:
+        try:
+            os.kill(child, 0)
+        except ProcessLookupError:
+            break  # grandchild is gone — group kill worked
+        _time.sleep(0.1)
+    else:
+        os.kill(child, 9)  # cleanup before failing
+        raise AssertionError("grandchild survived the process-group kill")
 
 
 def test_want_detector():


### PR DESCRIPTION
## What happened

The daemon's OpenClaw exec-policy gate wedged a production agent-builder VM (2026-07-10, ~20:05 UTC boot → unresponsive by 20:32; reproduced again on the next boot).

Chain:
1. `sync_openclaw_exec_policy` shells `openclaw exec-policy preset cautious --json` with `subprocess.run(timeout=60)`.
2. On a busy shared-cpu-1x host the CLI (a full ~250MB node boot) doesn't finish in 60s.
3. `subprocess.run` kills only the **wrapper**; the node child survives as an orphan.
4. The state file is only written on success, so the watcher retries every ~62s forever → one ~200MB orphan per minute → RAM exhausted, Fly burst CPU drained, VM throttled to ~0.5% core, controller/dashboard dead.

## Fix

- `_apply_openclaw_exec_preset`: spawn with `start_new_session=True`, SIGKILL the **process group** on timeout.
- `sync_openclaw_exec_policy`: exponential backoff between failed applies (5 min doubling, capped at 1h) so a host that can't apply the preset degrades to an occasional attempt instead of a permanent CPU tax.

## Tests

4 new tests in `tests/test_openclaw_exec_policy_gate.py` (backoff arm/expiry, escalation+cap, reset-on-success, and a real process-group-kill test with a wrapper+grandchild script). 12/12 pass; other failing suites in `tests/` are pre-existing on main under local py3.9.

Release/publish left for maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)