### PR TITLE
[RELEASE] fix(gateway): repair double-brace set typo in _gateway_plugin_health (closes #3615)

### DIFF
--- a/clawmetry/adapters/openclaw.py
+++ b/clawmetry/adapters/openclaw.py
@@ -1161,7 +1161,7 @@ def _gateway_plugin_health() -> dict:
             ptype = entry.get("type") or entry.get("kind") or None
             if not name or not state:
                 continue
-            plugins.append({"name": name, "state": state, **({{"type": ptype}} if ptype else {})})
+            plugins.append({"name": name, "state": state, **({"type": ptype} if ptype else {})})
             summary[state] = summary.get(state, 0) + 1
         if not plugins:
             return {}


### PR DESCRIPTION
## Summary

- **Root cause:** `clawmetry/adapters/openclaw.py:1164` had `{{"type": ptype}}` — the double braces construct a *set* whose only element is the unhashable dict `{"type": ptype}`, raising `TypeError` immediately.
- The surrounding `except Exception: return {}` swallowed the error silently, so `gatewayPluginHealth` and `gatewayPluginHealthSummary` returned `{}` for every gateway response that contained at least one plugin with a `type` field — completely dropping plugin state (`loaded`/`errored`/`disabled`) for all plugins.
- **Fix:** single-brace dict literal `{"type": ptype}` — 1-character change per brace pair, one line.

Closes #3615.

## Test plan

- [x] `python3 -m py_compile clawmetry/adapters/openclaw.py` — syntax OK
- [x] Inline smoke-test: old code reproduces `TypeError: unhashable type: 'dict'`; new code returns correct `gatewayPluginHealth` list with `type` field populated and `gatewayPluginHealthSummary` accurate
- [ ] CI matrix (Ubuntu / macOS / Windows × Python 3.9 / 3.11)

### Before / after

```python
# Before (broken — set literal, TypeError on any plugin with type)
plugins.append({"name": name, "state": state, **({{"type": ptype}} if ptype else {})})

# After (correct — dict literal)
plugins.append({"name": name, "state": state, **({"type": ptype} if ptype else {})})
```

---
Linked PR: #3615

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LLhR6nViwDaxNzKJPzSPR8

---
_Generated by [Claude Code](https://claude.ai/code/session_01LLhR6nViwDaxNzKJPzSPR8)_