### PR TITLE
fix: gateway plugin-health silently emptied by double-brace typo (#3615)

### DIFF
--- a/clawmetry/adapters/openclaw.py
+++ b/clawmetry/adapters/openclaw.py
@@ -1161,7 +1161,7 @@ def _gateway_plugin_health() -> dict:
             ptype = entry.get("type") or entry.get("kind") or None
             if not name or not state:
                 continue
-            plugins.append({"name": name, "state": state, **({{"type": ptype}} if ptype else {})})
+            plugins.append({"name": name, "state": state, **({"type": ptype} if ptype else {})})
             summary[state] = summary.get(state, 0) + 1
         if not plugins:
             return {}


### PR DESCRIPTION
Closes #3615

## What broke

`clawmetry/adapters/openclaw.py:1164` had a double-brace typo:

```python
# before — {{"type": ptype}} is a Python *set* literal, not a dict
plugins.append({"name": name, "state": state, **({{"type": ptype}} if ptype else {})})
```

In Python `{expr}` is a set literal, so `{{"type": ptype}}` tries to put an unhashable `dict` into a set → `TypeError`. The `except Exception: return {}` at line 1169 swallowed the crash, causing `gatewayPluginHealth` and `gatewayPluginHealthSummary` to return completely empty on any gateway.status response where at least one plugin carries a truthy `type` field (present since harness 2026.6.9).

## Fix (1 line)

```python
# after — single-brace dict, correct dict unpacking
plugins.append({"name": name, "state": state, **({"type": ptype} if ptype else {})})
```

## Test plan

- `python3 -c "import ast; ast.parse(open('clawmetry/adapters/openclaw.py').read()); print('OK')"` → OK
- Manual logic verified: entry with `ptype="channel"` produces `{"name":…,"state":…,"type":"channel"}`; entry with `ptype=None` omits the key — both match intended behaviour.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CnswvfeeQtVewAAEHqNYAf)_