### PR TITLE
fix: surface contextTokens per event in list_events() (#3614)

### DIFF
--- a/clawmetry/adapters/openclaw.py
+++ b/clawmetry/adapters/openclaw.py
@@ -1878,6 +1878,7 @@ class OpenClawAdapter(AgentAdapter):
                                     ("cacheReadTokens", "cache_read_input_tokens", "cacheReadInputTokens", "cacheRead"),
                                     ("cacheWriteTokens", "cache_creation_input_tokens", "cacheCreationInputTokens", "cacheWrite"),
                                     ("totalTokens", "totalTokens", "total_tokens"),
+                                    ("contextTokens", "contextTokens", "context_tokens"),
                                 ]:
                                     for k in keys:
                                         v = usage.get(k)

--- a/tests/test_openclaw_list_events.py
+++ b/tests/test_openclaw_list_events.py
@@ -640,3 +640,72 @@ def test_list_events_tags_top_level_catalog_tool_call(isolated_store):
     assert len(events) == 1
     ex = events[0].extra
     assert ex.get("isCatalogTool") is True
+
+
+def test_list_events_surfaces_context_tokens(isolated_store):
+    """Per-message contextTokens from usage lands in event.extra (#3614).
+
+    OpenClaw Control UI now shows context-window size per transcript turn.
+    list_events() must expose contextTokens from message.usage so callers
+    can display or alert on per-turn context utilisation.  Both camelCase
+    (contextTokens) and snake_case (context_tokens) key variants are accepted.
+    """
+    import uuid, time as _t
+    isolated_store.ingest({
+        "id": str(uuid.uuid4()),
+        "node_id": "agent+test-node",
+        "agent_id": "main",
+        "agent_type": "openclaw",
+        "session_id": "sess-CTX",
+        "event_type": "model.completed",
+        "ts": _t.time(),
+        "model": "claude-opus-4-7",
+        "token_count": 200,
+        "data": {
+            "type": "assistant",
+            "message": {
+                "model": "claude-opus-4-7",
+                "usage": {
+                    "input": 120,
+                    "output": 42,
+                    "contextTokens": 5000,
+                },
+            },
+        },
+    })
+    # snake_case variant
+    isolated_store.ingest({
+        "id": str(uuid.uuid4()),
+        "node_id": "agent+test-node",
+        "agent_id": "main",
+        "agent_type": "openclaw",
+        "session_id": "sess-CTX2",
+        "event_type": "model.completed",
+        "ts": _t.time(),
+        "model": "claude-opus-4-7",
+        "token_count": 100,
+        "data": {
+            "type": "assistant",
+            "message": {
+                "model": "claude-opus-4-7",
+                "usage": {
+                    "input": 60,
+                    "output": 20,
+                    "context_tokens": 8000,
+                },
+            },
+        },
+    })
+    _wait_flush(isolated_store)
+
+    from clawmetry.adapters.openclaw import OpenClawAdapter
+    events = OpenClawAdapter().list_events("sess-CTX")
+    assert len(events) == 1
+    ex = events[0].extra
+    assert ex.get("inputTokens") == 120
+    assert ex.get("outputTokens") == 42
+    assert ex.get("contextTokens") == 5000, "contextTokens must appear in extra for per-turn context-window tracking"
+
+    events2 = OpenClawAdapter().list_events("sess-CTX2")
+    assert len(events2) == 1
+    assert events2[0].extra.get("contextTokens") == 8000, "snake_case context_tokens must also map to contextTokens"


### PR DESCRIPTION
Closes #3614

## What

`list_events()` in `clawmetry/adapters/openclaw.py` already extracts `inputTokens`, `outputTokens`, cache split, `totalTokens`, and `reasoningTokens` from the `message.usage` blob stored in DuckDB — but it silently dropped `contextTokens` (the context-window size in effect at that turn). OpenClaw's Control UI now exposes this per-message, so ClawMetry was the odd one out.

## Changes

- **`clawmetry/adapters/openclaw.py`** — one entry added to the usage-field extraction loop in `list_events()`: `("contextTokens", "contextTokens", "context_tokens")`. Recognises both camelCase (`contextTokens`) and snake_case (`context_tokens`) key variants, exactly like the surrounding fields.
- **`tests/test_openclaw_list_events.py`** — `test_list_events_surfaces_context_tokens` tests both key variants using the same seed→flush→assert pattern as the existing `test_list_events_surfaces_cache_token_split`, `test_list_events_surfaces_reasoning_tokens`, etc.

## Test plan

```
python3 -m pytest tests/test_openclaw_list_events.py -v
# 21 passed (all existing tests green, new test passes)
```

Sessions from older OpenClaw (no `contextTokens` in usage) are unaffected — the field is simply absent from `Event.extra`.

---
_Generated by [Claude Code](https://claude.ai/code/session_013q6b2sjYZV4Xs5F4VC1YC9)_