### PR TITLE
fix(nemoclaw): surface full OCSF audit trail in sandbox security summary (#3616)

### DIFF
--- a/clawmetry/adapters/openclaw.py
+++ b/clawmetry/adapters/openclaw.py
@@ -481,33 +481,52 @@ def _openshell_sandbox_logs(name: str, count: int = 20) -> list:
 
 
 def _sandbox_egress_denied_count(name: str, count: int = 100) -> dict:
-    """Count DNS-backed HTTPS fail-closed denial events in recent sandbox OCSF logs.
+    """Summarise OCSF audit events from recent sandbox logs (#3616).
 
     Fetches the <count> most-recent OCSF audit events for sandbox <name> and
-    counts those with verdict=='deny' that carry a network-egress context:
-    either an OCSF network-activity class_uid (4001-4004) or the presence of
-    endpoint fields (dst_endpoint / src_endpoint) that imply a connection
-    attempt.  Returns {"egressDeniedCount": N} when N>0 so callers can
-    .update() a sandbox entry dict directly; returns {} otherwise -- identical
-    to the _openshell_sandbox_ocsf_enabled() contract.  Never raises.
+    classifies every event into one of three buckets:
+
+    - Network-egress denied  (class_uid 4001-4004 or endpoint fields, verdict==deny)
+      → ``egressDeniedCount``
+    - Network-egress allowed (class_uid 4001-4004 or endpoint fields, verdict==allow)
+      → ``egressAllowedCount``
+    - Non-network audit      (process-activity, file-activity, auth events, …)
+      → ``processFileAuthAuditCount``
+
+    Each key is omitted when its count is zero, preserving the .update()-friendly
+    contract used by callers.  Never raises.
     """
     _NETWORK_CLASS_UIDS = frozenset([4001, 4002, 4003, 4004])
     try:
         events = _openshell_sandbox_logs(name, count=count)
         denied = 0
+        allowed = 0
+        non_network = 0
         for evt in events:
             if not isinstance(evt, dict):
                 continue
-            if evt.get("verdict") != "deny":
-                continue
             class_uid = evt.get("class_uid")
-            if class_uid in _NETWORK_CLASS_UIDS:
-                denied += 1
-            elif "dst_endpoint" in evt or "src_endpoint" in evt:
-                denied += 1
+            is_network = (
+                class_uid in _NETWORK_CLASS_UIDS
+                or "dst_endpoint" in evt
+                or "src_endpoint" in evt
+            )
+            if is_network:
+                verdict = evt.get("verdict")
+                if verdict == "deny":
+                    denied += 1
+                elif verdict == "allow":
+                    allowed += 1
+            else:
+                non_network += 1
+        result: dict = {}
         if denied:
-            return {"egressDeniedCount": denied}
-        return {}
+            result["egressDeniedCount"] = denied
+        if allowed:
+            result["egressAllowedCount"] = allowed
+        if non_network:
+            result["processFileAuthAuditCount"] = non_network
+        return result
     except Exception:
         return {}
 

--- a/tests/test_obs_gap_nemoclaw_dns_fail_closed_3471.py
+++ b/tests/test_obs_gap_nemoclaw_dns_fail_closed_3471.py
@@ -1,6 +1,8 @@
-"""Tests for #3471: DNS-backed HTTPS fail-closed denial events surfaced as a
-distinct security signal (egressDeniedCount per sandbox, dnsFailClosedCount /
-networkEgressDenied on DetectResult.meta).
+"""Tests for #3471 and #3616.
+
+#3471: DNS-backed HTTPS fail-closed denial events surfaced as egressDeniedCount.
+#3616: The full OCSF audit stream is now classified — allowed connections and
+non-network (process/file/auth) events are no longer discarded.
 """
 import json
 import shutil
@@ -27,7 +29,7 @@ def _make_run(events_by_sandbox):
 
 
 def test_deny_with_network_class_uid_counted(monkeypatch):
-    """verdict=='deny' + network-activity class_uid (4001-4004) is counted."""
+    """Network deny events contribute egressDeniedCount; allow events add egressAllowedCount."""
     monkeypatch.setattr(shutil, "which", lambda _: "/usr/bin/openshell")
     events = [
         {"uid": "a1", "verdict": "deny", "class_uid": 4003},
@@ -36,11 +38,11 @@ def test_deny_with_network_class_uid_counted(monkeypatch):
     ]
     monkeypatch.setattr(subprocess, "run", _make_run({"alpha": events}))
     result = _sandbox_egress_denied_count("alpha")
-    assert result == {"egressDeniedCount": 2}
+    assert result == {"egressDeniedCount": 2, "egressAllowedCount": 1}
 
 
 def test_deny_with_dst_endpoint_counted(monkeypatch):
-    """verdict=='deny' + dst_endpoint is counted even without class_uid."""
+    """verdict=='deny' + dst_endpoint / src_endpoint is counted as network-egress denied."""
     monkeypatch.setattr(shutil, "which", lambda _: "/usr/bin/openshell")
     events = [
         {"uid": "b1", "verdict": "deny", "dst_endpoint": {"ip": "1.2.3.4", "port": 443}},
@@ -51,30 +53,31 @@ def test_deny_with_dst_endpoint_counted(monkeypatch):
     assert result == {"egressDeniedCount": 2}
 
 
-def test_no_denials_returns_empty(monkeypatch):
-    """All allow-verdict events yield {} (key absent, not zero)."""
+def test_network_allow_surfaced_as_egress_allowed(monkeypatch):
+    """Allowed network connections (previously dropped) now produce egressAllowedCount."""
     monkeypatch.setattr(shutil, "which", lambda _: "/usr/bin/openshell")
     events = [
         {"uid": "c1", "verdict": "allow", "class_uid": 4003},
+        # no verdict → not counted in either network bucket
         {"uid": "c2", "class_uid": 4003},
     ]
     monkeypatch.setattr(subprocess, "run", _make_run({"gamma": events}))
     result = _sandbox_egress_denied_count("gamma")
-    assert result == {}
+    assert result == {"egressAllowedCount": 1}
 
 
-def test_non_network_deny_not_counted(monkeypatch):
-    """verdict=='deny' without network class_uid or endpoint fields is skipped."""
+def test_non_network_events_counted_as_process_file_auth(monkeypatch):
+    """Process/file/auth OCSF events (previously discarded) populate processFileAuthAuditCount."""
     monkeypatch.setattr(shutil, "which", lambda _: "/usr/bin/openshell")
     events = [
-        # class_uid 5001 is File System Activity — not network-egress
+        # class_uid 5001 is File System Activity
         {"uid": "d1", "verdict": "deny", "class_uid": 5001},
-        # no class_uid, no endpoint fields
+        # no class_uid, no endpoint fields → non-network
         {"uid": "d2", "verdict": "deny"},
     ]
     monkeypatch.setattr(subprocess, "run", _make_run({"delta": events}))
     result = _sandbox_egress_denied_count("delta")
-    assert result == {}
+    assert result == {"processFileAuthAuditCount": 2}
 
 
 def test_openshell_absent_returns_empty(monkeypatch):
@@ -82,3 +85,42 @@ def test_openshell_absent_returns_empty(monkeypatch):
     monkeypatch.setattr(shutil, "which", lambda _: None)
     result = _sandbox_egress_denied_count("epsilon")
     assert result == {}
+
+
+def test_mixed_event_stream_all_buckets(monkeypatch):
+    """A realistic mixed stream populates all three counters (#3616)."""
+    monkeypatch.setattr(shutil, "which", lambda _: "/usr/bin/openshell")
+    events = [
+        # network denies
+        {"uid": "m1", "verdict": "deny",  "class_uid": 4001},
+        {"uid": "m2", "verdict": "deny",  "class_uid": 4002},
+        # network allow
+        {"uid": "m3", "verdict": "allow", "class_uid": 4003},
+        # process activity (class_uid outside network range)
+        {"uid": "m4", "verdict": "allow", "class_uid": 1007, "actor": {"process": {"pid": 42}}},
+        # auth event
+        {"uid": "m5", "class_uid": 3001, "actor": {"user": {"name": "sandbox-agent"}}},
+        # file activity deny (no endpoint → non-network)
+        {"uid": "m6", "verdict": "deny",  "class_uid": 5001, "file": {"path": "/etc/passwd"}},
+    ]
+    monkeypatch.setattr(subprocess, "run", _make_run({"mixed": events}))
+    result = _sandbox_egress_denied_count("mixed")
+    assert result == {
+        "egressDeniedCount": 2,
+        "egressAllowedCount": 1,
+        "processFileAuthAuditCount": 3,
+    }
+
+
+def test_only_non_network_events_no_egress_keys(monkeypatch):
+    """When all events are non-network only processFileAuthAuditCount is set."""
+    monkeypatch.setattr(shutil, "which", lambda _: "/usr/bin/openshell")
+    events = [
+        {"uid": "p1", "class_uid": 3001},
+        {"uid": "p2", "class_uid": 1007},
+    ]
+    monkeypatch.setattr(subprocess, "run", _make_run({"proc": events}))
+    result = _sandbox_egress_denied_count("proc")
+    assert result == {"processFileAuthAuditCount": 2}
+    assert "egressDeniedCount" not in result
+    assert "egressAllowedCount" not in result


### PR DESCRIPTION
## Summary

`_sandbox_egress_denied_count()` in `clawmetry/adapters/openclaw.py` already fetches the full OCSF JSON audit stream from NemoClaw sandboxes — but only preserved a single integer (`egressDeniedCount`) by discarding everything except network-class events with `verdict=="deny"`. Allowed connections, process-execution events, file-activity events, and auth events were all silently dropped, leaving the dashboard with one integer instead of the rich audit picture the harness already emits.

## Changes

- **`clawmetry/adapters/openclaw.py`** — `_sandbox_egress_denied_count()` now classifies every OCSF event into one of three counters:
  - `egressDeniedCount` — network events (`class_uid` 4001-4004 or `dst_endpoint`/`src_endpoint`) with `verdict=="deny"` (unchanged behaviour, backwards compatible)
  - `egressAllowedCount` — network events with `verdict=="allow"` (previously dropped)
  - `processFileAuthAuditCount` — non-network events (process/file/auth class_uid; previously dropped)
  
  Each key is omitted when its count is zero, preserving the `.update()`-friendly contract all callers rely on.

- **`tests/test_obs_gap_nemoclaw_dns_fail_closed_3471.py`** — three existing tests updated to expect the new keys where applicable; two new tests added: one for a realistic mixed-event stream exercising all three counters, one verifying non-network-only streams produce no egress keys.

## Test plan

- [x] `python3 -m pytest tests/test_obs_gap_nemoclaw_dns_fail_closed_3471.py -v` — 7 passed
- [x] Broader OCSF suite: `tests/test_obs_gap_nemoclaw_ocsf_3274.py`, `_3299.py`, `_3389.py` — 31 passed total, no regressions
- [ ] Verify sandbox security section in the NemoClaw dashboard tab shows the new counters when a live NemoClaw deployment has process/file/auth events

## Bot meta
<!-- bot-autofix -->
Draft PR opened autonomously based on the plan in #3616. Marked draft for human review — mark Ready for Review once happy.

Closes #3616

---
_Generated by [Claude Code](https://claude.ai/code/session_0138Vc9DMhhAy8y8vWLrQ9aU)_