### PR TITLE
feat(auto-update): releases reach the fleet in minutes, not days

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,6 +165,9 @@ CLAWMETRY_PROVIDER=local|turso         # Data backend (default: local)
 CLAWMETRY_INTERCEPT=1                  # Enable HTTP interceptor
 CLAWMETRY_FLEET_KEY=...               # Multi-node fleet auth key
 CLAWMETRY_FAMILY_SESSION_LIMIT=50      # Max sessions/runtime to ingest for Claude Code/Codex/Cursor/… (most-recent N; raise for deeper history)
+CLAWMETRY_UPDATE_CHECK_SECS=60         # Daemon PyPI update-check cadence (default 60s; fleet tracks the latest release within minutes)
+CLAWMETRY_AUTOUPDATE_MIN_AGE_HOURS=0   # Stability window before a silent install (default 0 = absolute latest; raise to be conservative)
+CLAWMETRY_AUTO_UPDATE=0                # Hard kill switch for unattended upgrades
 DEBUG=1                                # Enable debug logging
 ```
 

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -17652,18 +17652,21 @@ def run_daemon() -> None:
     except Exception as _e:
         log.warning(f"pro-entitlement watcher failed to start: {_e}")
 
-    # ── Opt-in auto-update worker ────────────────────────────────────────
-    # routes/update_check.py runs a background checker that self-updates ONLY
-    # when the `auto_update` config is on (default OFF → no behaviour change
-    # for anyone who hasn't opted in), via the same vetted pip+restart path as
-    # the manual "Update now". It was started only in the DASHBOARD process —
-    # but a headless / cloud-synced node runs only this daemon, so auto-update
-    # never fired where it's most needed. Start it here too (idempotent: the
-    # module guards against a double-started thread). Never blocks/raises.
+    # ── Auto-update worker (default ON for this daemon) ─────────────────
+    # routes/update_check.py self-updates via the same vetted pip+restart
+    # path as the manual "Update now". role="daemon" is LOAD-BEARING: the
+    # default-on policy only acts in the daemon role. This call site started
+    # the thread with no role for months, so every node whose plan sync
+    # never explicitly wrote auto_update (free / local-only installs) NEVER
+    # self-updated — the 2026-07-10 "my node is days stale" root cause. The
+    # daemon role also enables the fast check loop (every ~60s; we ship 20+
+    # releases a day) and the unsupervised re-exec restart. Never
+    # blocks/raises.
     try:
         from routes.update_check import start_update_check_thread as _start_uc
-        _start_uc()
-        log.info("update-check thread started (auto-update honours the opt-in flag)")
+        _start_uc(role="daemon")
+        log.info("update-check thread started (daemon role: default-on "
+                 "auto-update, fast check loop)")
     except Exception as _e:
         log.warning(f"update-check thread failed to start: {_e}")
 

--- a/routes/update_check.py
+++ b/routes/update_check.py
@@ -145,11 +145,14 @@ def _get_update_check_config():
         "check_on_startup": True,
         "check_daily": True,
         # Default ON (since 0.12.494): a detected newer release is installed
-        # automatically by the background worker. Rails: only the supervised
-        # sync-daemon process acts on the default (see _maybe_auto_update),
-        # releases must age CLAWMETRY_AUTOUPDATE_MIN_AGE_HOURS (48h) on PyPI
-        # first, CLAWMETRY_AUTO_UPDATE=0 is a hard kill switch, and the boot
-        # guard (clawmetry/update_guard.py) rolls back a crash-looping wheel.
+        # automatically by the background worker. Since 2026-07-10 the daemon
+        # checks every ~60s and tracks the ABSOLUTE latest (no age gate by
+        # default; CLAWMETRY_AUTOUPDATE_MIN_AGE_HOURS restores a window).
+        # Rails: only the daemon role acts on the default
+        # (see _maybe_auto_update), CLAWMETRY_AUTO_UPDATE=0 is a hard kill
+        # switch, failed targets back off CLAWMETRY_AUTOUPDATE_RETRY_SECS,
+        # and the boot guard (clawmetry/update_guard.py) rolls back a
+        # crash-looping wheel.
         # WHY default-on: 92% of active nodes were found running months-stale
         # daemons (2026-06-09 fleet audit) — every shipped fix reached almost
         # nobody, and the hosted dashboard rendered blank cards against old
@@ -259,11 +262,45 @@ def _should_show_update_banner(config, latest_check):
 def _autoupdate_min_age_hours() -> float:
     """Stability window (hours) a release must survive on PyPI before the
     daemon will silently install it. Env override:
-    ``CLAWMETRY_AUTOUPDATE_MIN_AGE_HOURS`` (default 48)."""
+    ``CLAWMETRY_AUTOUPDATE_MIN_AGE_HOURS``.
+
+    Default 0 (founder call 2026-07-10): ClawMetry ships 20+ releases a day
+    and users must never be expected to upgrade by hand, so the fleet tracks
+    the ABSOLUTE latest within minutes. The safety net for a bad wheel is
+    the boot rollback guard (``clawmetry/update_guard.py``), not a stale
+    window — the old 48h gate meant every shipped fix took two days to
+    reach anyone. Conservative operators can set the env to restore a
+    window; the aged-in selection logic still honors it."""
     try:
-        return float(os.environ.get("CLAWMETRY_AUTOUPDATE_MIN_AGE_HOURS", "48") or 48)
+        return float(os.environ.get("CLAWMETRY_AUTOUPDATE_MIN_AGE_HOURS", "0") or 0)
     except Exception:
-        return 48.0
+        return 0.0
+
+
+def _update_check_interval_secs() -> float:
+    """How often the DAEMON role polls PyPI for a new release. Env override:
+    ``CLAWMETRY_UPDATE_CHECK_SECS`` (default 60, clamped to [30, 86400]).
+
+    A 60s poll of PyPI's JSON endpoint is one tiny CDN-cached GET per node
+    per minute — negligible for both sides — and is what turns a release
+    into a fleet-wide upgrade within minutes instead of days. The dashboard
+    role keeps its gentler startup+daily banner cadence; only the daemon
+    (the process that actually installs) runs this fast loop."""
+    try:
+        v = float(os.environ.get("CLAWMETRY_UPDATE_CHECK_SECS", "60") or 60)
+    except Exception:
+        v = 60.0
+    return max(30.0, min(v, 86400.0))
+
+
+def _autoupdate_retry_secs() -> float:
+    """Backoff before re-attempting a version whose install FAILED. Without
+    this, the 60s check loop would re-run pip against a broken target every
+    minute. Env override: ``CLAWMETRY_AUTOUPDATE_RETRY_SECS`` (default 1800)."""
+    try:
+        return float(os.environ.get("CLAWMETRY_AUTOUPDATE_RETRY_SECS", "1800") or 1800)
+    except Exception:
+        return 1800.0
 
 
 def _newest_aged_in_version(releases, current, min_age_hours):
@@ -361,6 +398,43 @@ def _check_for_update():
 # before the restart lands. Reset on failure so the next check can retry.
 _auto_update_in_progress = False
 
+# version -> monotonic timestamp of its last FAILED install attempt. With the
+# 60s check loop a persistently-broken target would otherwise re-run pip every
+# minute; failed versions wait _autoupdate_retry_secs() before a retry.
+_failed_update_attempts: dict = {}
+
+
+def _exec_restart_disabled() -> bool:
+    """Kill switch for the unsupervised-daemon re-exec:
+    ``CLAWMETRY_AUTOUPDATE_EXEC_RESTART=0``."""
+    val = os.environ.get("CLAWMETRY_AUTOUPDATE_EXEC_RESTART", "").strip().lower()
+    return val in ("0", "false", "no", "off")
+
+
+def _schedule_exec_restart(delay_secs: float = 2.0) -> None:
+    """Re-exec the current process image so an UNSUPERVISED daemon (no
+    launchd/systemd to respawn it — containers, manual `python sync.py`,
+    kubectl-exec wrappers) actually starts running the wheel it just
+    installed instead of holding the old build in memory until someone
+    restarts it by hand. ``os.execv`` keeps the pid and argv, so whatever
+    started the process sees nothing change; the boot rollback guard
+    (clawmetry/update_guard.py) still protects against a crash-looping
+    wheel. Not used on Windows (execv semantics differ) — there the
+    install stays deferred to the next manual start."""
+    def _reexec():
+        try:
+            log.info("auto-update: re-exec restart (unsupervised daemon) "
+                     "argv=%s", sys.argv)
+            os.execv(sys.executable, [sys.executable] + sys.argv)
+        except Exception as exc:  # pragma: no cover — post-exec unreachable
+            global _auto_update_in_progress
+            _auto_update_in_progress = False
+            log.warning("auto-update: re-exec failed (%s); new version "
+                        "applies on next manual start", exc)
+    t = threading.Timer(delay_secs, _reexec)
+    t.daemon = True
+    t.start()
+
 
 def _maybe_auto_update(current, target, latest=None):
     """Install ``target`` (the newest aged-in release, chosen by
@@ -389,38 +463,85 @@ def _maybe_auto_update(current, target, latest=None):
         return
     if not target or not _version_gt(target, current):
         return
-    # An UNSUPERVISED daemon (no launchd plist / systemd unit — e.g. a manual
-    # `python -m clawmetry.sync` or Windows) still installs the new wheel but
-    # keeps running: exiting would stop ingest with nothing to respawn it.
-    # The new version applies on its next start.
+    # Failed-install backoff: with the 60s check loop, a target whose pip
+    # install failed must not be retried every minute.
+    _last_fail = _failed_update_attempts.get(str(target))
+    if _last_fail is not None and \
+            (time.monotonic() - _last_fail) < _autoupdate_retry_secs():
+        return
+    # An UNSUPERVISED daemon (no launchd plist / systemd unit — containers,
+    # kubectl-exec wrappers, a manual `python -m clawmetry.sync`) installs
+    # the wheel with restart=False, then re-execs its own process image so
+    # the new build actually starts running (previously it kept the old
+    # wheel in memory indefinitely — a containerized node stayed stale until
+    # someone bounced the pod by hand). Windows keeps the old
+    # install-and-defer behavior; the env kill switch restores it anywhere.
     restart = True
+    exec_restart = False
     if _process_role == "daemon" and not _daemon_supervised():
         restart = False
+        exec_restart = (not sys.platform.startswith("win")
+                        and not _exec_restart_disabled())
     _auto_update_in_progress = True
     log.info("auto-update: upgrading clawmetry v%s -> v%s (latest available v%s, "
-             "restart=%s)", current, target, latest or target, restart)
+             "restart=%s, exec_restart=%s)",
+             current, target, latest or target, restart, exec_restart)
     try:
         from routes.meta import perform_self_update
         payload, _status = perform_self_update(
             reason="auto", restart=restart, target_version=target)
         if not (isinstance(payload, dict) and payload.get("ok")):
-            log.warning("auto-update: upgrade failed, will retry next check: %s", payload)
+            log.warning("auto-update: upgrade failed, will retry in %.0fs: %s",
+                        _autoupdate_retry_secs(), payload)
+            _failed_update_attempts[str(target)] = time.monotonic()
+            if len(_failed_update_attempts) > 64:
+                _failed_update_attempts.pop(
+                    min(_failed_update_attempts, key=_failed_update_attempts.get),
+                    None,
+                )
             _auto_update_in_progress = False  # allow retry; no restart was scheduled
+            return
+        _failed_update_attempts.pop(str(target), None)
+        if exec_restart:
+            _schedule_exec_restart()
     except Exception as exc:
         log.warning("auto-update: error during upgrade: %s", exc)
+        _failed_update_attempts[str(target)] = time.monotonic()
         _auto_update_in_progress = False
 
 
 def _update_check_worker(stop_event):
-    """Background worker thread for periodic update checks."""
-    # Initial check on startup (after 60s delay)
-    time.sleep(60)
+    """Background worker thread for periodic update checks.
+
+    DAEMON role: poll PyPI every ``_update_check_interval_secs()`` (default
+    60s) and auto-install anything newer — ClawMetry ships 20+ releases a
+    day, so a release must reach the fleet in minutes, not on a daily-9AM
+    schedule (founder call 2026-07-10; the screenshot trigger was a hosted
+    feature telling a user their node would update "within about two days").
+
+    DASHBOARD role: unchanged gentle cadence — startup check + one banner
+    check per day after 9AM. The dashboard only shows the banner; the
+    daemon is the process that installs, and on the standard install its
+    fast loop keeps the shared check-history fresh for the banner anyway.
+    """
+    # Initial check on startup (after a boot-settle delay; interruptible).
+    if stop_event.wait(60):
+        return
 
     config = _get_update_check_config()
     if config.get("check_on_startup", True):
         _check_for_update()
 
-    # Daily checks
+    if _process_role == "daemon":
+        while not stop_event.is_set():
+            if stop_event.wait(_update_check_interval_secs()):
+                return
+            config = _get_update_check_config()
+            if config.get("enabled", True):
+                _check_for_update()
+        return
+
+    # Dashboard role: daily banner checks
     last_check_day = None
     while not stop_event.is_set():
         now = datetime.now(timezone.utc)

--- a/tests/test_auto_update.py
+++ b/tests/test_auto_update.py
@@ -60,7 +60,10 @@ def test_auto_update_on_upgrades_once(monkeypatch):
     assert calls == ["auto"], "must not re-trigger while a restart is pending"
 
 
-def test_auto_update_failure_allows_retry(monkeypatch):
+def test_auto_update_failure_allows_retry_after_backoff(monkeypatch):
+    """A failed install is retryable, but only after the failure backoff —
+    with the 60s check loop an immediately-retryable failure would re-run
+    pip against a broken target every minute."""
     uc = _uc()
     _as_daemon(uc, monkeypatch)
     monkeypatch.setattr(uc, "_get_update_check_config", lambda: {"auto_update": True})
@@ -68,9 +71,20 @@ def test_auto_update_failure_allows_retry(monkeypatch):
     _mock_self_update(monkeypatch, calls, ok=False)
     uc._maybe_auto_update("0.12.1", "0.12.2")
     assert calls == ["auto"]
-    # The upgrade failed (no restart scheduled) → the next check may retry.
+    # Within the backoff window the same target is NOT retried.
     uc._maybe_auto_update("0.12.1", "0.12.2")
-    assert calls == ["auto", "auto"], "a failed auto-update must be retryable"
+    assert calls == ["auto"], "failed target must back off, not retry every check"
+    # A DIFFERENT (newer) target is not blocked by the failed one's backoff.
+    uc._maybe_auto_update("0.12.1", "0.12.3")
+    assert calls == ["auto", "auto"], "a new target must not inherit the backoff"
+    # Once the backoff expires, the original target is retryable again.
+    import time as _t
+    uc._failed_update_attempts["0.12.2"] = (
+        _t.monotonic() - uc._autoupdate_retry_secs() - 1
+    )
+    uc._maybe_auto_update("0.12.1", "0.12.2")
+    assert calls == ["auto", "auto", "auto"], \
+        "a failed auto-update must be retryable after the backoff"
 
 
 def test_auto_update_in_allowed_config_keys(monkeypatch):

--- a/tests/test_auto_update_fast_loop.py
+++ b/tests/test_auto_update_fast_loop.py
@@ -1,0 +1,212 @@
+"""Fast auto-update (founder call 2026-07-10): a release must reach the
+fleet in MINUTES, not days. ClawMetry ships 20+ releases a day.
+
+Covers the four changes, each revert-proven red on the old code:
+
+  1. The daemon role polls every ``CLAWMETRY_UPDATE_CHECK_SECS`` (default
+     60s, clamped) instead of once a day after 9AM.
+  2. The silent-install age gate defaults to 0 (track the absolute latest;
+     ``CLAWMETRY_AUTOUPDATE_MIN_AGE_HOURS`` restores a window; the boot
+     rollback guard is the safety net for a bad wheel).
+  3. The sync daemon starts the checker with role="daemon" — the LOAD-
+     BEARING wiring that was missing: without it the default-on policy
+     never acted on free/local-only nodes (no plan sync ever wrote the
+     auto_update flag), which is why "auto-update" felt like it didn't
+     exist.
+  4. An UNSUPERVISED daemon (containers, kubectl-exec wrappers) re-execs
+     its own process image after installing, instead of holding the old
+     wheel in memory until someone bounces it by hand. Gated: daemon role
+     only, not Windows, ``CLAWMETRY_AUTOUPDATE_EXEC_RESTART=0`` kill switch.
+"""
+from __future__ import annotations
+
+import importlib
+import os
+import re
+
+
+def _uc():
+    import routes.update_check as uc
+    return importlib.reload(uc)
+
+
+# ── 1. check cadence ─────────────────────────────────────────────────────────
+
+
+def test_check_interval_default_and_env(monkeypatch):
+    uc = _uc()
+    monkeypatch.delenv("CLAWMETRY_UPDATE_CHECK_SECS", raising=False)
+    assert uc._update_check_interval_secs() == 60.0
+    monkeypatch.setenv("CLAWMETRY_UPDATE_CHECK_SECS", "300")
+    assert uc._update_check_interval_secs() == 300.0
+    # Clamps: never hammer PyPI sub-30s, never exceed a day.
+    monkeypatch.setenv("CLAWMETRY_UPDATE_CHECK_SECS", "1")
+    assert uc._update_check_interval_secs() == 30.0
+    monkeypatch.setenv("CLAWMETRY_UPDATE_CHECK_SECS", "999999999")
+    assert uc._update_check_interval_secs() == 86400.0
+    monkeypatch.setenv("CLAWMETRY_UPDATE_CHECK_SECS", "junk")
+    assert uc._update_check_interval_secs() == 60.0
+
+
+def test_daemon_worker_checks_every_interval(monkeypatch):
+    """The daemon-role worker must call _check_for_update once per interval
+    tick — not once per day. We drive the loop with a stub stop_event whose
+    wait() returns False (timeout) a few times, then True (stop)."""
+    uc = _uc()
+    uc._process_role = "daemon"
+    monkeypatch.setattr(uc, "_get_update_check_config",
+                        lambda: {"enabled": True, "check_on_startup": False})
+    checks = []
+    monkeypatch.setattr(uc, "_check_for_update", lambda: checks.append(1))
+
+    class _Ev:
+        def __init__(self, ticks):
+            self.ticks = ticks
+            self.waits = []
+
+        def wait(self, timeout=None):
+            self.waits.append(timeout)
+            self.ticks -= 1
+            return self.ticks < 0  # False (timed out) N times, then stop
+
+        def is_set(self):
+            return self.ticks < 0
+
+    ev = _Ev(ticks=4)  # 1 boot-settle wait + 3 interval ticks
+    uc._update_check_worker(ev)
+    assert len(checks) == 3, f"expected one check per tick, got {len(checks)}"
+    # Every post-boot wait uses the fast interval, not 3600s / daily gating.
+    assert all(w == uc._update_check_interval_secs() for w in ev.waits[1:]), ev.waits
+
+
+def test_dashboard_worker_keeps_daily_cadence(monkeypatch):
+    """The dashboard role must NOT inherit the fast loop (it only shows the
+    banner; per-minute PyPI polls belong to the installing daemon only)."""
+    uc = _uc()
+    uc._process_role = "dashboard"
+    monkeypatch.setattr(uc, "_get_update_check_config",
+                        lambda: {"enabled": True, "check_on_startup": False,
+                                 "check_daily": True})
+    checks = []
+    monkeypatch.setattr(uc, "_check_for_update", lambda: checks.append(1))
+
+    class _Ev:
+        def __init__(self, ticks):
+            self.ticks = ticks
+            self.waits = []
+
+        def wait(self, timeout=None):
+            self.waits.append(timeout)
+            self.ticks -= 1
+            return self.ticks < 0
+
+        def is_set(self):
+            return self.ticks < 0
+
+    ev = _Ev(ticks=3)
+    uc._update_check_worker(ev)
+    # Daily loop waits an hour between wakeups; at most one check fires.
+    assert 3600 in ev.waits, ev.waits
+    assert len(checks) <= 1
+
+
+# ── 2. age gate default 0 ────────────────────────────────────────────────────
+
+
+def test_min_age_defaults_to_zero_env_restores_window(monkeypatch):
+    uc = _uc()
+    monkeypatch.delenv("CLAWMETRY_AUTOUPDATE_MIN_AGE_HOURS", raising=False)
+    assert uc._autoupdate_min_age_hours() == 0.0
+    monkeypatch.setenv("CLAWMETRY_AUTOUPDATE_MIN_AGE_HOURS", "48")
+    assert uc._autoupdate_min_age_hours() == 48.0
+
+
+def test_zero_age_targets_absolute_latest():
+    """With no age gate, a release published seconds ago is the target."""
+    uc = _uc()
+    from datetime import datetime, timedelta, timezone
+    just_now = (datetime.now(timezone.utc) - timedelta(seconds=30)).isoformat()
+    releases = {
+        "0.12.550": [{"upload_time_iso_8601": just_now}],
+    }
+    assert uc._newest_aged_in_version(releases, "0.12.549", 0) == "0.12.550"
+    # The old 48h default would have returned None here.
+    assert uc._newest_aged_in_version(releases, "0.12.549", 48) is None
+
+
+# ── 3. daemon role wiring in sync.py ─────────────────────────────────────────
+
+
+def test_sync_daemon_starts_checker_with_daemon_role():
+    """clawmetry/sync.py must pass role="daemon" — without it the default-on
+    auto-update policy never acts (the 2026-07-10 stale-fleet root cause)."""
+    here = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    src = open(os.path.join(here, "clawmetry", "sync.py"), encoding="utf-8").read()
+    calls = re.findall(r"_start_uc\(([^)]*)\)", src)
+    assert calls, "sync.py no longer starts the update-check thread?"
+    for args in calls:
+        assert re.search(r"role\s*=\s*['\"]daemon['\"]", args), (
+            "sync.py starts the update checker WITHOUT role='daemon'; "
+            "default-on auto-update will silently never act: " + args
+        )
+
+
+# ── 4. unsupervised re-exec restart ──────────────────────────────────────────
+
+
+def _gate(monkeypatch, uc, supervised, platform="darwin", kill=None):
+    monkeypatch.delenv("CLAWMETRY_AUTO_UPDATE", raising=False)
+    if kill is None:
+        monkeypatch.delenv("CLAWMETRY_AUTOUPDATE_EXEC_RESTART", raising=False)
+    else:
+        monkeypatch.setenv("CLAWMETRY_AUTOUPDATE_EXEC_RESTART", kill)
+    uc._process_role = "daemon"
+    monkeypatch.setattr(uc, "_daemon_supervised", lambda: supervised)
+    monkeypatch.setattr(uc, "_get_update_check_config",
+                        lambda: {"auto_update": True})
+    monkeypatch.setattr(uc.sys, "platform", platform)
+    restarts = []
+    execs = []
+    monkeypatch.setattr(uc, "_schedule_exec_restart",
+                        lambda *a, **k: execs.append(1))
+    import routes.meta as meta
+    monkeypatch.setattr(
+        meta, "perform_self_update",
+        lambda reason="auto", restart=True, target_version=None: (
+            restarts.append(restart),
+            ({"ok": True, "old_version": "0.12.1", "new_version": "0.12.2"}, 200),
+        )[1],
+    )
+    return restarts, execs
+
+
+def test_unsupervised_daemon_reexecs_after_install(monkeypatch):
+    uc = _uc()
+    restarts, execs = _gate(monkeypatch, uc, supervised=False)
+    uc._maybe_auto_update("0.12.1", "0.12.2")
+    assert restarts == [False], "unsupervised installs must not Timer-exit"
+    assert execs == [1], "unsupervised daemon must re-exec onto the new wheel"
+
+
+def test_supervised_daemon_uses_normal_restart(monkeypatch):
+    uc = _uc()
+    restarts, execs = _gate(monkeypatch, uc, supervised=True)
+    uc._maybe_auto_update("0.12.1", "0.12.2")
+    assert restarts == [True]
+    assert execs == [], "supervised daemons restart via their supervisor"
+
+
+def test_exec_restart_skipped_on_windows(monkeypatch):
+    uc = _uc()
+    restarts, execs = _gate(monkeypatch, uc, supervised=False, platform="win32")
+    uc._maybe_auto_update("0.12.1", "0.12.2")
+    assert restarts == [False]
+    assert execs == [], "no execv semantics on Windows; defer to next start"
+
+
+def test_exec_restart_kill_switch(monkeypatch):
+    uc = _uc()
+    restarts, execs = _gate(monkeypatch, uc, supervised=False, kill="0")
+    uc._maybe_auto_update("0.12.1", "0.12.2")
+    assert restarts == [False]
+    assert execs == [], "CLAWMETRY_AUTOUPDATE_EXEC_RESTART=0 must disable re-exec"


### PR DESCRIPTION
## Why

We ship 20+ releases a day; the founder found a node telling him it would self-update "within about two days". Auto-update was (a) checking once a day, (b) gated behind a 48h release-age window, and (c) — the real killer — **never active at all on free/local-only nodes**: `sync.py` started the checker without `role=\"daemon\"`, so the default-on policy from 0.12.494 only acted where a plan sync had explicitly written the `auto_update` flag.

## What

1. **Role wiring fix** (root cause): `sync.py` now starts the checker with `role=\"daemon\"`. Source-level guard test.
2. **60s check loop** for the daemon role (`CLAWMETRY_UPDATE_CHECK_SECS`, clamped [30, 86400]); dashboard keeps startup+daily banner cadence.
3. **Age gate default 0** (was 48h): fleet tracks the absolute latest; `update_guard.py` boot rollback is the bad-wheel safety net; env restores a window.
4. **Unsupervised daemons re-exec** (`os.execv`) after install — containers/kubectl-exec nodes no longer run stale wheels in memory forever. Windows defers as before; `CLAWMETRY_AUTOUPDATE_EXEC_RESTART=0` disables.
5. Failed-target backoff (default 30 min) so the fast loop never hammers pip on a broken target.

## Verification

- 28 tests green; 10 new guards revert-proven (8/10 red on un-fixed code).
- Post-release E2E planned: roll this node's daemon to the new version, then watch it self-update to the NEXT release hands-off within ~2 minutes (will report in the release chain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)