### PR TITLE
feat(auto-update): expose effective updater posture on the status endpoint

### DIFF
--- a/routes/update_check.py
+++ b/routes/update_check.py
@@ -608,7 +608,15 @@ def api_update_check_config_post():
 
 @bp_update_check.route("/api/update-check/status", methods=["GET"])
 def api_update_check_status():
-    """Get the current update check status."""
+    """Get the current update check status.
+
+    ``updater`` describes THIS process's effective auto-update posture
+    (role, cadence, age gate, kill switch) so "is this node actually on
+    the fast update loop?" is answerable from the API instead of by
+    reading env vars and logs on the box. Note the dashboard process
+    reports role=dashboard; the installing fast loop lives in the sync
+    daemon (see the same endpoint there / the sync log line).
+    """
     config = _get_update_check_config()
     latest = _get_latest_update_check()
 
@@ -616,6 +624,15 @@ def api_update_check_status():
         "config": config,
         "latest_check": latest,
         "show_banner": _should_show_update_banner(config, latest),
+        "updater": {
+            "role": _process_role,
+            "check_interval_secs": (
+                _update_check_interval_secs()
+                if _process_role == "daemon" else None
+            ),
+            "min_age_hours": _autoupdate_min_age_hours(),
+            "env_disabled": _env_auto_update_disabled(),
+        },
     }
 
     return jsonify(result)

--- a/tests/test_auto_update_fast_loop.py
+++ b/tests/test_auto_update_fast_loop.py
@@ -210,3 +210,31 @@ def test_exec_restart_kill_switch(monkeypatch):
     uc._maybe_auto_update("0.12.1", "0.12.2")
     assert restarts == [False]
     assert execs == [], "CLAWMETRY_AUTOUPDATE_EXEC_RESTART=0 must disable re-exec"
+
+
+# ── 5. status endpoint introspection ─────────────────────────────────────────
+
+
+def test_status_endpoint_reports_updater_posture(monkeypatch):
+    """/api/update-check/status must expose the effective auto-update
+    posture (role, cadence, age gate, kill switch) so a stale node is
+    diagnosable from the API."""
+    from flask import Flask
+    uc = _uc()
+    uc._process_role = "daemon"
+    monkeypatch.delenv("CLAWMETRY_AUTO_UPDATE", raising=False)
+    monkeypatch.delenv("CLAWMETRY_UPDATE_CHECK_SECS", raising=False)
+    monkeypatch.delenv("CLAWMETRY_AUTOUPDATE_MIN_AGE_HOURS", raising=False)
+    monkeypatch.setattr(uc, "_get_update_check_config",
+                        lambda: {"enabled": True, "auto_update": True,
+                                 "dismissed_version": ""})
+    monkeypatch.setattr(uc, "_get_latest_update_check", lambda: None)
+    a = Flask(__name__)
+    a.register_blueprint(uc.bp_update_check)
+    body = a.test_client().get("/api/update-check/status").get_json()
+    upd = body.get("updater")
+    assert upd, "status response must carry the updater block"
+    assert upd["role"] == "daemon"
+    assert upd["check_interval_secs"] == 60.0
+    assert upd["min_age_hours"] == 0.0
+    assert upd["env_disabled"] is False


### PR DESCRIPTION
Adds an 'updater' block (role, check_interval_secs, min_age_hours, env_disabled) to /api/update-check/status so a stale node is diagnosable from the API. Guarded by a new endpoint test (11/11 suite green). This release also serves as the live hands-off verification of #3624: the founder node's daemon (0.12.550, fast loop confirmed in logs) must self-update to this version within minutes of PyPI publish with zero manual action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)