### PR TITLE
fix(auto-update): propagation-lag failures retry in about 2 minutes, not 30

### DIFF
--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -1181,8 +1181,8 @@ def _sync_auto_update_with_plan(tier: str | None) -> None:
             _succ({"auto_update": True})
             log.info(
                 "auto-update enabled for entitled plan (%s) — this node will keep "
-                "itself current (48h stability window). Opt out any time with "
-                "CLAWMETRY_AUTO_UPDATE=0.", tier,
+                "itself current within minutes of each release. Opt out any time "
+                "with CLAWMETRY_AUTO_UPDATE=0.", tier,
             )
     except Exception as exc:
         log.debug("auto-update plan sync skipped: %s", exc)

--- a/routes/update_check.py
+++ b/routes/update_check.py
@@ -398,10 +398,40 @@ def _check_for_update():
 # before the restart lands. Reset on failure so the next check can retry.
 _auto_update_in_progress = False
 
-# version -> monotonic timestamp of its last FAILED install attempt. With the
-# 60s check loop a persistently-broken target would otherwise re-run pip every
-# minute; failed versions wait _autoupdate_retry_secs() before a retry.
+# version -> monotonic DEADLINE before which a FAILED install must not be
+# retried. With the 60s check loop a persistently-broken target would
+# otherwise re-run pip every minute. The deadline length depends on WHY the
+# install failed — see _retry_backoff_for_error.
 _failed_update_attempts: dict = {}
+
+# pip stderr signatures of "the release exists but this mirror hasn't seen it
+# yet" — the PyPI simple-index/CDN propagation race. The JSON API (which the
+# checker polls) routinely advertises a version 1-3 minutes before pip can
+# install it. Caught live 2026-07-10: the very first fast-loop update attempt
+# hit this and backed off a full 30 minutes for what was a 2-minute lag.
+_PROPAGATION_ERR_SIGNS = (
+    "No matching distribution",
+    "Could not find a version",
+)
+
+
+def _propagation_retry_secs() -> float:
+    """Short retry for index-propagation failures. Env override:
+    ``CLAWMETRY_AUTOUPDATE_PROPAGATION_RETRY_SECS`` (default 120)."""
+    try:
+        return float(os.environ.get(
+            "CLAWMETRY_AUTOUPDATE_PROPAGATION_RETRY_SECS", "120") or 120)
+    except Exception:
+        return 120.0
+
+
+def _retry_backoff_for_error(error_text: str) -> float:
+    """Backoff for a failed install: propagation lag retries in ~2 minutes,
+    anything else (a genuinely broken target / env) waits the full backoff."""
+    txt = str(error_text or "")
+    if any(sig in txt for sig in _PROPAGATION_ERR_SIGNS):
+        return _propagation_retry_secs()
+    return _autoupdate_retry_secs()
 
 
 def _exec_restart_disabled() -> bool:
@@ -464,10 +494,10 @@ def _maybe_auto_update(current, target, latest=None):
     if not target or not _version_gt(target, current):
         return
     # Failed-install backoff: with the 60s check loop, a target whose pip
-    # install failed must not be retried every minute.
-    _last_fail = _failed_update_attempts.get(str(target))
-    if _last_fail is not None and \
-            (time.monotonic() - _last_fail) < _autoupdate_retry_secs():
+    # install failed must not be retried every minute. The stored value is
+    # the DEADLINE (propagation lag ~2 min, real failures 30 min).
+    _retry_at = _failed_update_attempts.get(str(target))
+    if _retry_at is not None and time.monotonic() < _retry_at:
         return
     # An UNSUPERVISED daemon (no launchd plist / systemd unit — containers,
     # kubectl-exec wrappers, a manual `python -m clawmetry.sync`) installs
@@ -491,9 +521,11 @@ def _maybe_auto_update(current, target, latest=None):
         payload, _status = perform_self_update(
             reason="auto", restart=restart, target_version=target)
         if not (isinstance(payload, dict) and payload.get("ok")):
+            _err = payload.get("error", "") if isinstance(payload, dict) else ""
+            _backoff = _retry_backoff_for_error(_err)
             log.warning("auto-update: upgrade failed, will retry in %.0fs: %s",
-                        _autoupdate_retry_secs(), payload)
-            _failed_update_attempts[str(target)] = time.monotonic()
+                        _backoff, payload)
+            _failed_update_attempts[str(target)] = time.monotonic() + _backoff
             if len(_failed_update_attempts) > 64:
                 _failed_update_attempts.pop(
                     min(_failed_update_attempts, key=_failed_update_attempts.get),
@@ -506,7 +538,9 @@ def _maybe_auto_update(current, target, latest=None):
             _schedule_exec_restart()
     except Exception as exc:
         log.warning("auto-update: error during upgrade: %s", exc)
-        _failed_update_attempts[str(target)] = time.monotonic()
+        _failed_update_attempts[str(target)] = (
+            time.monotonic() + _autoupdate_retry_secs()
+        )
         _auto_update_in_progress = False
 
 

--- a/tests/test_auto_update.py
+++ b/tests/test_auto_update.py
@@ -77,14 +77,51 @@ def test_auto_update_failure_allows_retry_after_backoff(monkeypatch):
     # A DIFFERENT (newer) target is not blocked by the failed one's backoff.
     uc._maybe_auto_update("0.12.1", "0.12.3")
     assert calls == ["auto", "auto"], "a new target must not inherit the backoff"
-    # Once the backoff expires, the original target is retryable again.
+    # Once the backoff deadline passes, the original target is retryable.
     import time as _t
-    uc._failed_update_attempts["0.12.2"] = (
-        _t.monotonic() - uc._autoupdate_retry_secs() - 1
-    )
+    uc._failed_update_attempts["0.12.2"] = _t.monotonic() - 1
     uc._maybe_auto_update("0.12.1", "0.12.2")
     assert calls == ["auto", "auto", "auto"], \
         "a failed auto-update must be retryable after the backoff"
+
+
+def test_propagation_lag_gets_short_backoff(monkeypatch):
+    """'No matching distribution' is the PyPI simple-index propagation race
+    (the JSON API advertises a release 1-3 minutes before pip can install
+    it) — it must retry in ~2 minutes, NOT the full broken-target backoff.
+    Caught live 2026-07-10: the very first fast-loop update attempt hit this
+    and sat out a 30-minute backoff for a 2-minute lag."""
+    import time as _t
+    import routes.meta as meta
+    uc = _uc()
+    _as_daemon(uc, monkeypatch)
+    monkeypatch.setattr(uc, "_get_update_check_config", lambda: {"auto_update": True})
+
+    def _fake(reason="manual", restart=True, target_version=None):
+        return ({"ok": False,
+                 "error": "pip exit 1: No matching distribution found for "
+                          "clawmetry==0.12.551"}, 500)
+
+    monkeypatch.setattr(meta, "perform_self_update", _fake)
+    t0 = _t.monotonic()
+    uc._maybe_auto_update("0.12.550", "0.12.551")
+    deadline = uc._failed_update_attempts.get("0.12.551")
+    assert deadline is not None
+    wait = deadline - t0
+    assert wait <= uc._propagation_retry_secs() + 5, (
+        f"propagation lag backed off {wait:.0f}s; must be ~"
+        f"{uc._propagation_retry_secs():.0f}s, not the broken-target backoff"
+    )
+    # A non-propagation failure still gets the long backoff.
+    def _fake_broken(reason="manual", restart=True, target_version=None):
+        return ({"ok": False, "error": "pip exit 1: some real build error"}, 500)
+
+    monkeypatch.setattr(meta, "perform_self_update", _fake_broken)
+    uc._maybe_auto_update("0.12.550", "0.12.552")
+    deadline2 = uc._failed_update_attempts.get("0.12.552")
+    assert deadline2 is not None
+    assert (deadline2 - _t.monotonic()) > uc._propagation_retry_secs() + 60, \
+        "a real install failure must keep the long backoff"
 
 
 def test_auto_update_in_allowed_config_keys(monkeypatch):


### PR DESCRIPTION
The live hands-off verification of #3624 caught this immediately: the daemon's first fast-loop update attempt hit the PyPI simple-index propagation race and sat out the full 30-minute broken-target backoff for what is a 1-3 minute lag. Distribution-not-found errors now retry in ~120s (env-tunable); real failures keep the long backoff. Revert-proven guard included (suite 30/30).

🤖 Generated with [Claude Code](https://claude.com/claude-code)