### PR TITLE
feat(brain): time axis on the density chart + clickable datetime pickers

### DIFF
--- a/clawmetry/static/css/dashboard.css
+++ b/clawmetry/static/css/dashboard.css
@@ -133,6 +133,15 @@
   .time-btn { padding: 4px 12px; border-radius: 6px; background: var(--bg-secondary); border: 1px solid var(--border-primary); color: var(--text-tertiary); cursor: pointer; font-size: 12px; font-weight: 600; transition: all 0.2s; }
   .time-btn:hover { background: var(--bg-hover); color: var(--text-secondary); }
   .time-btn.active { background: var(--bg-accent); color: #fff; border-color: var(--bg-accent); }
+  /* Brain custom-range datetime inputs. color-scheme drives the palette of
+     the native calendar popup AND the picker indicator icon: without the
+     dark override Chrome paints a near-black icon on the dark input
+     background, so the picker looks like it does not exist. Clicking
+     anywhere in the field opens the popup via _brainOpenPicker (app.js). */
+  input.brain-dtl { color-scheme: light; cursor: pointer; }
+  [data-theme="dark"] input.brain-dtl { color-scheme: dark; }
+  input.brain-dtl::-webkit-calendar-picker-indicator { cursor: pointer; opacity: 0.75; }
+  input.brain-dtl::-webkit-calendar-picker-indicator:hover { opacity: 1; }
 
   .page { display: none; padding: 16px 20px; max-width: 1200px; margin: 0 auto; }
   #page-flow { padding: 0; max-width: 100%; }

--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -4332,6 +4332,16 @@ function toggleBrainCustomRange(el) {
   }
 }
 
+function _brainOpenPicker(inp) {
+  // Open the native calendar popup on a click anywhere in the field, not
+  // just the tiny indicator icon (which is easy to miss on the dark theme).
+  // showPicker needs a user gesture and does not exist on Safari, so any
+  // failure is non-fatal: the field still accepts typed input.
+  try {
+    if (inp && typeof inp.showPicker === 'function') inp.showPicker();
+  } catch (e) {}
+}
+
 function applyBrainCustomRange() {
   var from = document.getElementById('brain-range-from');
   var to = document.getElementById('brain-range-to');
@@ -5696,8 +5706,8 @@ function renderBrainChart(events) {
   var ctx = canvas.getContext('2d');
   var W = canvas.parentElement ? canvas.parentElement.offsetWidth : (canvas.offsetWidth || 800);
   canvas.width = W;
-  canvas.height = 80;
-  ctx.clearRect(0, 0, W, 80);
+  canvas.height = 100; // 80px bars + 20px time axis strip
+  ctx.clearRect(0, 0, W, 100);
 
   // Adaptive window: pick the shortest window that contains the events so the
   // chart actually renders bars instead of an empty 60-min background. The
@@ -5767,6 +5777,64 @@ function renderBrainChart(events) {
     });
   }
   ctx.globalAlpha = 1;
+
+  // Time axis: label the window the bars actually span, in local wall time.
+  // The window is derived (adaptive in Live mode, explicit in history mode),
+  // so without labels the same bars could mean "last hour" or "last day".
+  var axis = _brainAxisTicks(now - numBuckets * bucketMs, now, W);
+  var _axCs = null;
+  try { _axCs = getComputedStyle(document.body); } catch (e) {}
+  var _axVar = function(name, fb) {
+    var v = _axCs && _axCs.getPropertyValue(name);
+    return (v && v.trim()) || fb;
+  };
+  ctx.strokeStyle = _axVar('--border-primary', '#273243');
+  ctx.lineWidth = 1;
+  ctx.beginPath();
+  ctx.moveTo(0, 80.5);
+  ctx.lineTo(W, 80.5);
+  axis.ticks.forEach(function(tk) {
+    var x = Math.round(tk.frac * W) + 0.5;
+    ctx.moveTo(Math.min(x, W - 0.5), 80.5);
+    ctx.lineTo(Math.min(x, W - 0.5), 84.5);
+  });
+  ctx.stroke();
+  ctx.fillStyle = _axVar('--text-faint', '#98a2b3');
+  ctx.font = '10px -apple-system, "Segoe UI", sans-serif';
+  ctx.textBaseline = 'alphabetic';
+  axis.ticks.forEach(function(tk, ti) {
+    ctx.textAlign = ti === 0 ? 'left' : (ti === axis.ticks.length - 1 ? 'right' : 'center');
+    ctx.fillText(tk.label, tk.frac * W + (ti === 0 ? 1 : (ti === axis.ticks.length - 1 ? -1 : 0)), 96);
+  });
+}
+
+// Tick positions + labels for the density chart's time axis. Pure function
+// (unit-tested via the extraction pattern in tests/test_brain_axis_ticks.js).
+// Returns {withDate, ticks: [{frac, label}]} where frac is 0..1 across the
+// chart width. Labels include the day/month whenever the window is longer
+// than ~20h or crosses midnight, so "03:00" can't be mistaken for today.
+function _brainAxisTicks(startMs, endMs, width) {
+  var span = endMs - startMs;
+  if (!isFinite(span) || span <= 0 || !(width > 0)) return { withDate: false, ticks: [] };
+  var withDate = span > 72000000 ||
+    (new Date(startMs).toDateString() !== new Date(endMs).toDateString());
+  // Date-bearing labels are ~2x wider; space ticks so labels never collide.
+  var n = Math.max(2, Math.min(withDate ? 5 : 7, Math.floor(width / (withDate ? 170 : 110)) + 1));
+  var ticks = [];
+  for (var i = 0; i < n; i++) {
+    var frac = i / (n - 1);
+    var t = new Date(startMs + span * frac);
+    var label;
+    try {
+      label = withDate
+        ? t.toLocaleString([], { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })
+        : t.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+    } catch (e) {
+      label = t.toISOString().slice(11, 16);
+    }
+    ticks.push({ frac: frac, label: label });
+  }
+  return { withDate: withDate, ticks: ticks };
 }
 
 // ── Brain Graph (neural-net visualization, refs #53) ──────────────────────

--- a/clawmetry/templates/tabs/brain.html
+++ b/clawmetry/templates/tabs/brain.html
@@ -141,9 +141,9 @@
       </div>
       <div id="brain-custom-range" style="display:none;align-items:center;gap:6px;flex-wrap:wrap;margin-bottom:8px;font-size:11px;color:var(--text-muted);">
         <span data-i18n="brain.range_from">From</span>
-        <input type="datetime-local" id="brain-range-from" step="60" style="padding:4px 6px;background:var(--bg-primary);border:1px solid var(--border);border-radius:6px;color:var(--text-primary);font-size:11px;font-family:inherit;">
+        <input type="datetime-local" class="brain-dtl" id="brain-range-from" step="60" onclick="_brainOpenPicker(this)" style="padding:4px 6px;background:var(--bg-primary);border:1px solid var(--border);border-radius:6px;color:var(--text-primary);font-size:11px;font-family:inherit;">
         <span data-i18n="brain.range_to">to</span>
-        <input type="datetime-local" id="brain-range-to" step="60" style="padding:4px 6px;background:var(--bg-primary);border:1px solid var(--border);border-radius:6px;color:var(--text-primary);font-size:11px;font-family:inherit;">
+        <input type="datetime-local" class="brain-dtl" id="brain-range-to" step="60" onclick="_brainOpenPicker(this)" style="padding:4px 6px;background:var(--bg-primary);border:1px solid var(--border);border-radius:6px;color:var(--text-primary);font-size:11px;font-family:inherit;">
         <button class="refresh-btn" onclick="applyBrainCustomRange()" style="font-weight:600;" data-i18n="brain.range_apply">Show this window</button>
       </div>
       <div id="brain-history-banner" style="display:none;align-items:center;gap:8px;flex-wrap:wrap;background:rgba(245,158,11,0.08);border:1px solid rgba(245,158,11,0.35);border-radius:6px;padding:6px 10px;margin-bottom:8px;font-size:12px;color:#f59e0b;">
@@ -151,7 +151,7 @@
         <span id="brain-history-banner-status" style="color:var(--text-muted);font-size:11px;"></span>
         <button class="refresh-btn" onclick="setBrainTimeRange('live')" style="margin-left:auto;font-weight:600;" data-i18n="brain.back_to_live">● Back to live</button>
       </div>
-      <canvas id="brain-density-chart" height="60" style="width:100%;display:block;"></canvas>
+      <canvas id="brain-density-chart" height="100" style="width:100%;display:block;"></canvas>
     </div>
     <!-- Sessions-at-risk card (issue #2008): surfaces the existing
          /api/outcomes/impact endpoint in a visible UI summary. Hidden when

--- a/tests/test_brain_axis_ticks.js
+++ b/tests/test_brain_axis_ticks.js
@@ -1,0 +1,98 @@
+// Unit tests for the Brain density chart's time axis (_brainAxisTicks).
+//
+// The density chart's window is DERIVED (adaptive in Live mode, explicit in
+// history mode), so without axis labels the same bars could mean "last hour"
+// or "last day". _brainAxisTicks is the pure helper that decides tick
+// positions, label format, and when labels must carry the date (window
+// longer than ~20h or crossing midnight) so "03:00" can't be mistaken for
+// today.
+//
+// Extraction pattern mirrors test_brain_time_range.js: pull the shipped
+// function out of app.js via regex + vm so the test always tracks the real
+// source, no bundler needed.
+
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const APP_JS = path.join(__dirname, '..', 'clawmetry', 'static', 'js', 'app.js');
+const src = fs.readFileSync(APP_JS, 'utf8');
+
+let passed = 0;
+let failed = 0;
+
+function eq(actual, expected, label) {
+  if (actual === expected) { passed++; console.log('  ok   ' + label); }
+  else {
+    failed++;
+    console.log('  FAIL ' + label);
+    console.log('       expected: ' + JSON.stringify(expected));
+    console.log('       actual:   ' + JSON.stringify(actual));
+  }
+}
+
+function truthy(v, label) {
+  if (v) { passed++; console.log('  ok   ' + label); }
+  else { failed++; console.log('  FAIL ' + label + ' (got falsy)'); }
+}
+
+function extractFunction(name) {
+  const re = new RegExp('^function ' + name + '\\b[\\s\\S]*?^\\}', 'm');
+  const m = src.match(re);
+  if (!m) throw new Error('could not find function ' + name + ' in app.js');
+  return m[0];
+}
+
+const sandbox = {};
+vm.createContext(sandbox);
+vm.runInContext(extractFunction('_brainAxisTicks'), sandbox);
+const _brainAxisTicks = sandbox._brainAxisTicks;
+
+// Local-time constructors keep the midnight-crossing cases deterministic in
+// any TZ the CI matrix runs in (toDateString compares local days).
+const noonStart = new Date(2026, 6, 10, 12, 0).getTime();
+
+console.log('time-only window (1h, same local day)');
+{
+  const r = _brainAxisTicks(noonStart, noonStart + 3600000, 800);
+  eq(r.withDate, false, 'same-day 1h window needs no date in labels');
+  eq(r.ticks.length, 7, '800px time-only chart gets 7 ticks');
+  eq(r.ticks[0].frac, 0, 'first tick sits at the window start');
+  eq(r.ticks[r.ticks.length - 1].frac, 1, 'last tick sits at the window end');
+  let monotonic = true;
+  for (let i = 1; i < r.ticks.length; i++) {
+    if (!(r.ticks[i].frac > r.ticks[i - 1].frac)) monotonic = false;
+  }
+  truthy(monotonic, 'tick fractions strictly increase');
+  truthy(r.ticks.every(function (t) { return typeof t.label === 'string' && t.label.length > 0; }),
+    'every tick carries a non-empty label');
+}
+
+console.log('date-bearing windows');
+{
+  const day = _brainAxisTicks(noonStart, noonStart + 86400000, 800);
+  eq(day.withDate, true, '24h window puts the date in labels');
+  eq(day.ticks.length, 5, 'date-bearing labels are wider: 800px gets 5 ticks');
+
+  const midnight = new Date(2026, 6, 10, 23, 30).getTime();
+  const cross = _brainAxisTicks(midnight, midnight + 3600000, 800);
+  eq(cross.withDate, true, 'a 1h window crossing midnight still shows the date');
+}
+
+console.log('narrow charts and degenerate input');
+{
+  const narrow = _brainAxisTicks(noonStart, noonStart + 3600000, 120);
+  eq(narrow.ticks.length, 2, 'a narrow chart keeps at least start + end ticks');
+
+  eq(_brainAxisTicks(noonStart, noonStart, 800).ticks.length, 0, 'zero span yields no ticks');
+  eq(_brainAxisTicks(noonStart + 10, noonStart, 800).ticks.length, 0, 'negative span yields no ticks');
+  eq(_brainAxisTicks(noonStart, noonStart + 3600000, 0).ticks.length, 0, 'zero width yields no ticks');
+  eq(_brainAxisTicks(NaN, noonStart, 800).ticks.length, 0, 'NaN bounds yield no ticks');
+}
+
+console.log('');
+if (failed) {
+  console.log('FAIL: ' + failed + ' assertion(s) failed, ' + passed + ' passed');
+  process.exit(1);
+}
+console.log('PASS: all ' + passed + ' assertions passed');

--- a/tests/test_brain_axis_ticks_js.py
+++ b/tests/test_brain_axis_ticks_js.py
@@ -1,0 +1,44 @@
+"""Runner for the Node-based Brain density-chart time-axis unit tests.
+
+``tests/test_brain_axis_ticks.js`` extracts ``_brainAxisTicks`` from the
+shipped app.js (vm + regex, same pattern as test_brain_time_range) and
+asserts:
+
+  1. Tick fractions span exactly 0..1 and strictly increase, so labels line
+     up with the bucketed bars.
+  2. Labels carry the date whenever the window is longer than ~20h OR
+     crosses local midnight ("03:00" must not read as today), and stay
+     time-only otherwise.
+  3. Date-bearing labels get fewer, wider-spaced ticks so they never
+     collide; degenerate input (zero/negative span, zero width, NaN)
+     yields no ticks instead of throwing mid-render.
+
+Skipped (not failed) when ``node`` is not on PATH.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+
+import pytest
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_JS_TEST = os.path.join(_HERE, "test_brain_axis_ticks.js")
+
+
+@pytest.mark.skipif(
+    shutil.which("node") is None,
+    reason="node not on PATH; JS unit tests only run when Node is available",
+)
+def test_brain_axis_ticks_js_suite() -> None:
+    proc = subprocess.run(
+        ["node", _JS_TEST],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    output = (proc.stdout or "") + (proc.stderr or "")
+    assert proc.returncode == 0, "brain axis-ticks JS tests failed:\n" + output
+    assert "PASS" in output, "no PASS line in output:\n" + output


### PR DESCRIPTION
## What

Two Activity-tab (Brain) usability asks from the founder:

1. **Density chart now has a time axis.** The chart's window is derived (adaptive 1h/6h/24h in Live mode, explicit in history mode), so the same bars could mean "last hour" or "last day". A new pure helper `_brainAxisTicks` draws tick marks + labels for the exact window the bars span, in local wall time. Labels include the day/month whenever the window is longer than ~20h or crosses midnight, so "03:00" can't be mistaken for today. Date-bearing labels get fewer, wider-spaced ticks so they never collide.

2. **Custom-range datetime inputs are now real pickers.** On the dark theme Chrome painted a near-black `::-webkit-calendar-picker-indicator` on the dark input (invisible), and only that tiny icon opened the calendar. `color-scheme` now follows `[data-theme]`, the indicator is styled/hoverable, and `_brainOpenPicker` opens the native popup on a click anywhere in the field via `showPicker()` (needs a user gesture; absent on Safari, where the field still accepts typed input, so failures are non-fatal).

## Verification

- `tests/test_brain_axis_ticks.js` (extraction pattern, 14 assertions) + pytest wrapper `tests/test_brain_axis_ticks_js.py`, same shape as `test_brain_time_range`.
- **Revert-proof:** the guard is red against origin/main's app.js (helper absent, extraction throws) and green after this change.
- Existing `tests/test_brain_time_range.js` still passes (15/15); `make lint-js` clean.
- Rendered in Chrome against a dev dashboard on repo HEAD: Live mode shows time-only labels spanning the actual adaptive window; a 48h custom window shows date-bearing labels (8 Jul → 10 Jul); the axis renders even when the window has zero events; picker icons visible on the dark theme.

🤖 Generated with [Claude Code](https://claude.com/claude-code)