### PR TITLE
fix(auto-update): restart BOTH the dashboard and the daemon onto the new wheel

### DIFF
--- a/routes/meta.py
+++ b/routes/meta.py
@@ -452,19 +452,57 @@ def perform_self_update(reason: str = "manual", restart: bool = True,
         import os as _os
         import platform as _pl
 
+        # BOTH long-running processes must restart onto the new wheel or one
+        # keeps serving the old build from memory (the classic "daemon
+        # updated but the dashboard UI is stale" gotcha — see
+        # feedback_restart_both_processes_after_upgrade.md; found again live
+        # 2026-07-10 when the daemon self-updated to 0.12.552 while the
+        # dashboard kept 0.12.549 in memory). Ordering is load-bearing:
+        # `kickstart -k` on our OWN service kills us mid-function, so kick
+        # the OTHER service(s) first and restart ourselves last via _exit
+        # (the supervisor respawns us).
+        try:
+            from routes.update_check import _process_role as _role
+        except Exception:
+            _role = "dashboard"
+        _own = ("com.clawmetry.sync" if _role == "daemon"
+                else "com.clawmetry.dashboard")
         if _pl.system() == "Darwin":
+            uid = None
             try:
                 uid = _os.getuid()
-                _sp.run(
-                    ["launchctl", "kickstart", "-k",
-                     f"gui/{uid}/com.clawmetry.sync"],
-                    timeout=5,
-                    stdout=_sp.DEVNULL,
-                    stderr=_sp.DEVNULL,
-                    check=False,
-                )
             except Exception:
-                pass  # daemon may not be running; dashboard restart is enough
+                pass
+            for _svc in ("com.clawmetry.dashboard", "com.clawmetry.sync"):
+                if _svc == _own or uid is None:
+                    continue
+                try:
+                    _sp.run(
+                        ["launchctl", "kickstart", "-k", f"gui/{uid}/{_svc}"],
+                        timeout=5,
+                        stdout=_sp.DEVNULL,
+                        stderr=_sp.DEVNULL,
+                        check=False,
+                    )
+                except Exception:
+                    pass  # service may not exist; self-restart still happens
+        elif _pl.system() == "Linux":
+            _own_unit = ("clawmetry-sync.service" if _role == "daemon"
+                         else "clawmetry-dashboard.service")
+            for _unit in ("clawmetry-dashboard.service",
+                          "clawmetry-sync.service"):
+                if _unit == _own_unit:
+                    continue
+                try:
+                    _sp.run(
+                        ["systemctl", "--user", "restart", _unit],
+                        timeout=5,
+                        stdout=_sp.DEVNULL,
+                        stderr=_sp.DEVNULL,
+                        check=False,
+                    )
+                except Exception:
+                    pass
         _os._exit(0)
 
     _ulog.info("self-update (%s): upgraded v%s -> v%s; restarting in 2s",

--- a/tests/test_auto_update_fast_loop.py
+++ b/tests/test_auto_update_fast_loop.py
@@ -238,3 +238,24 @@ def test_status_endpoint_reports_updater_posture(monkeypatch):
     assert upd["check_interval_secs"] == 60.0
     assert upd["min_age_hours"] == 0.0
     assert upd["env_disabled"] is False
+
+
+# ── 6. both processes restart onto the new wheel ─────────────────────────────
+
+
+def test_self_update_restart_covers_both_processes():
+    """perform_self_update's restart must kick BOTH long-running services
+    (dashboard + sync), other-service-first: kickstart -k of our OWN service
+    kills the process mid-function, so self restarts last via _exit. Found
+    live 2026-07-10: the daemon self-updated to 0.12.552 while the dashboard
+    kept serving 0.12.549 from memory."""
+    here = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    src = open(os.path.join(here, "routes", "meta.py"), encoding="utf-8").read()
+    body = src.split("def _restart():", 1)[1].split("_ulog.info", 1)[0]
+    assert "com.clawmetry.dashboard" in body, \
+        "restart must also kick the dashboard service (stale-UI-in-memory bug)"
+    assert "com.clawmetry.sync" in body
+    assert "_process_role" in body, \
+        "restart must be role-aware so it never kickstart-kills itself first"
+    assert "clawmetry-dashboard.service" in body and \
+           "clawmetry-sync.service" in body, "Linux units must be covered too"


### PR DESCRIPTION
The 0.12.552 hands-off verification surfaced this: the daemon restarted itself onto the new wheel but the local dashboard kept serving 0.12.549 from memory (the auto path never kicked it). The restart helper is now role-aware and kicks the other service first, self last via _exit. Source-level guard included; suite 26/26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)