### PR TITLE
fix(c6-health): use prot-is-None to detect cross-repo read limit

### DIFF
--- a/.github/workflows/c6-health.yml
+++ b/.github/workflows/c6-health.yml
@@ -115,7 +115,8 @@ jobs:
                                  (may be empty if required checks are not yet
                                  configured -- outer loop detects "missing")
                 'unknown'     -- branch is protected but detail not readable
-                                 (cross-repo GITHUB_TOKEN limit on public repos)
+                                 (cross-repo GITHUB_TOKEN limit on public repos:
+                                 /branches/main returns protection=None)
                 'unprotected' -- branch has no protection configured
                 'error'       -- API error / repo not reachable
               """
@@ -124,26 +125,15 @@ jobs:
                   return set(), "error"
               if not data.get("protected"):
                   return set(), "unprotected"
-              prot = (data.get("protection") or {})
-              rsc = prot.get("required_status_checks") or {}
-              contexts = set(rsc.get("contexts", []))
-              if not contexts:
-                  # Protected but contexts empty or not visible in /branches/main.
-                  # GITHUB_TOKEN may return a partial protection object (e.g.
-                  # when the branch was recently protected without required checks,
-                  # or when token lacks admin scope for the full detail).
-                  # Try the dedicated endpoint: GITHUB_TOKEN with push access on
-                  # the host repo can read this; cross-repo reads return 403.
-                  detail, detail_err = api_get(
-                      f"/repos/{OWNER}/{repo}/branches/main/protection/required_status_checks"
-                  )
-                  if detail is not None:
-                      # Readable -- return actual contexts (may be empty = confirmed
-                      # no required checks configured; outer loop marks as "missing").
-                      return set(detail.get("contexts", [])), "ok"
-                  # Could not read via dedicated endpoint (cross-repo 403 or no
-                  # protection at all on that path) -- genuinely unknown.
+              # "protection" key present in response = token can read details.
+              # Returns None when cross-repo read limits apply (public repos,
+              # different owner scope). Empty contexts in a readable dict is
+              # definitive: branch is protected but no required checks yet.
+              prot = data.get("protection")
+              if prot is None:
                   return set(), "unknown"
+              rsc = (prot.get("required_status_checks") or {})
+              contexts = set(rsc.get("contexts", []))
               return contexts, "ok"
 
           # Audit all repos.
@@ -261,7 +251,8 @@ jobs:
 
           result_obj = post_comment(body)
           print(f"Posted: {result_obj['html_url']}")
-          # Exit 1 when clawmetry checks are confirmed missing (we can always read this).
-          # Exit 0 for unknown (can't verify cross-repo) to avoid spurious red badges.
+          # Exit 1 when any repo has confirmed missing/unprotected checks
+          # (detectable without admin scope). Exit 0 only for unknown
+          # (cross-repo read limit) to avoid spurious red CI badges.
           sys.exit(1 if has_confirmed_missing else 0)
           PYEOF


### PR DESCRIPTION
## Summary

- **Root cause**: `c6-health.yml` scheduled run at 10:11 UTC 2026-07-10 was a false positive -- the workflow exited 0 (green) even though clawmetry/main is still missing 4 required E2E checks (C6 is RED). The false positive caused by today's partial fix (b02e6b3) which tried the dedicated admin endpoint (`/branches/main/protection/required_status_checks`) as a fallback. That endpoint requires admin scope; `permissions: contents: read` always gets a 403, so `detail=None`, status returned as `"unknown"`, and the outer loop exits 0 instead of 1.

- **Fix**: Use `data.get("protection")` return value to distinguish the two cases:
  - `prot is None` -- token cannot read protection details (cross-repo limit). Return `"unknown"` (exit 0, avoid false red badge).
  - `prot` is a dict -- token CAN read details. An empty `contexts` set is now definitive: branch is protected but no required checks configured. Outer loop marks it `"missing"` and exits 1.

- **No change** to the outer audit logic, issue comment format, or exit-code semantics. The only change is inside `read_protection()` -- removes the admin-endpoint fallback, adds the `prot is None` guard.

## How to verify

After merge, wait for the 09:00 UTC scheduled run (or trigger manually via Actions > C6 daily health check). The run should:
1. Exit 1 (red badge) because clawmetry/main still has 4 checks missing
2. Post a comment to #2146 with `MISSING` status for clawmetry

## C6 status

C6 still requires manual admin action from @vivekchand (this PR only fixes the health-check reporter):

1. [Create fine-grained PAT](https://github.com/settings/personal-access-tokens/new?name=clawmetry-c6) with Administration read+write on clawmetry, clawmetry-cloud, clawmetry-landing
2. [Actions > Apply required E2E status checks > Run workflow](https://github.com/vivekchand/clawmetry/actions/workflows/apply-required-checks.yml) with `confirm=APPLY` and the PAT

C1/C2/C3/C4/C5/C7 are green. C6 is the sole remaining gap.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EA1CzpwJ89SsvamNuvje1D)_