### PR TITLE
feat(entitlement): next/previous_tier_channel_spec_at_batch + 2 endpoints

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -12304,6 +12304,156 @@ def previous_tier_runtime_spec_at_batch(tier: str, runtimes) -> dict | None:
     return {"runtimes": rows, "unknown": unknown}
 
 
+def next_tier_channel_spec_at_batch(tier: str, channels) -> dict | None:
+    """Channel-axis twin of :func:`next_tier_feature_spec_at_batch` /
+    :func:`next_tier_runtime_spec_at_batch` -- batch sibling of
+    :func:`next_tier_channel_spec_at` walking N chat channels against
+    the rung ABOVE the caller-supplied ``tier`` in ONE round-trip.
+
+    Composes :func:`next_tier_channel_spec_at` (scalar projection) and
+    :func:`channel_spec_at_batch` (batch what-if) -- same target
+    (`_next_purchasable_tier_after(tier)`) as the scalar, same per-
+    channel envelope shape as the feature / runtime siblings. Lets a
+    paywall "does THIS column of chat channels unlock at my next rung?"
+    pricing-comparison surface render every channel off ONE call
+    instead of N calls to :func:`next_tier_channel_spec_at`.
+
+    Per-channel row shape::
+
+        {"channel": "<id>", "row": <channel_spec_at row> | None}
+
+    Each ``row`` is byte-identical to
+    :func:`next_tier_channel_spec_at(tier, channel)` (which itself
+    equals :func:`channel_spec_at(target, channel)` byte-for-byte at
+    the resolved target) -- pinned by parity tests so the scalar and
+    batch accessors cannot drift. At the ceiling (enterprise as source,
+    no rung above) every ``row`` is ``None`` while the per-channel
+    envelope entries still render so the matrix's row count stays
+    stable.
+
+    Shape::
+
+        {
+          "channels": [
+            {"channel": "<id>", "row": <row> | None},
+            ...
+          ],
+          "unknown": ["bogus_id", ...],
+        }
+
+    Supplied channel ids are normalised via :func:`_normalise_csv`
+    (whitespace stripped, lowercased, duplicates dropped, first-seen
+    order preserved). Unknown ids are echoed in ``unknown[]`` rather
+    than short-circuiting -- a partially-bad caller still gets rows
+    back for the valid ids alongside a list of what was dropped,
+    matching :func:`next_tier_feature_spec_at_batch` /
+    :func:`next_tier_runtime_spec_at_batch`.
+
+    Every chat channel is FREE at every tier (see
+    :func:`channel_spec_at`), so whenever ``row`` is not ``None`` it
+    comes back ``free=True`` / ``locked=False`` / ``entitled=True``
+    regardless of the target rung. That parity IS the answer: the
+    pricing surface can render "chat channel included at every plan"
+    off ONE call without hard-coding that posture client-side.
+
+    Returns ``None`` for empty / unknown ``tier`` (caller renders
+    "unknown tier" / 404). Resolver-independent: delegates to
+    :func:`channel_spec_at` against the synthesised hypothetical
+    entitlement -- grace vs enforce yields byte-identical rows. Never
+    raises: a per-channel failure short-circuits that channel into
+    ``unknown[]`` and the rest of the batch keeps building.
+    """
+    try:
+        src = (tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if not src or src not in _TIER_ORDER:
+        return None
+    chans = _normalise_csv(channels)
+    try:
+        target = _next_purchasable_tier_after(src)
+    except Exception as exc:
+        logger.warning(
+            "entitlements: next_tier_channel_spec_at_batch target resolve failed: %s",
+            exc,
+        )
+        target = None
+    rows: list[dict] = []
+    unknown: list[str] = []
+    for cid in chans:
+        if cid not in ALL_CHANNELS:
+            unknown.append(cid)
+            continue
+        try:
+            row = channel_spec_at(target, cid) if target else None
+        except Exception as exc:
+            logger.warning(
+                "entitlements: next_tier_channel_spec_at_batch row %r failed: %s",
+                cid,
+                exc,
+            )
+            unknown.append(cid)
+            continue
+        rows.append({"channel": cid, "row": row})
+    return {"channels": rows, "unknown": unknown}
+
+
+def previous_tier_channel_spec_at_batch(tier: str, channels) -> dict | None:
+    """Source-anchored mirror of :func:`next_tier_channel_spec_at_batch`
+    -- batch sibling of :func:`previous_tier_channel_spec_at` walking N
+    chat channels against the rung BELOW the caller-supplied ``tier``
+    in ONE round-trip.
+
+    Same per-channel row shape and same normalisation / unknown-bucket
+    posture as :func:`next_tier_channel_spec_at_batch`. At the floor
+    (``oss`` / ``cloud_free`` as source, no rung below) every ``row``
+    is ``None`` while per-channel envelope entries still render so the
+    downgrade-confirmation surface's row count stays stable.
+
+    Each ``row`` is byte-identical to
+    :func:`previous_tier_channel_spec_at(tier, channel)` (which itself
+    equals :func:`channel_spec_at(target, channel)` byte-for-byte at
+    the resolved target). Channel-axis always-free invariant applies
+    here as well: whenever ``row`` is not ``None`` it comes back
+    ``free=True`` / ``locked=False`` / ``entitled=True``.
+
+    Returns ``None`` for empty / unknown ``tier``. Never raises.
+    """
+    try:
+        src = (tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if not src or src not in _TIER_ORDER:
+        return None
+    chans = _normalise_csv(channels)
+    try:
+        target = _previous_purchasable_tier_before(src)
+    except Exception as exc:
+        logger.warning(
+            "entitlements: previous_tier_channel_spec_at_batch target resolve failed: %s",
+            exc,
+        )
+        target = None
+    rows: list[dict] = []
+    unknown: list[str] = []
+    for cid in chans:
+        if cid not in ALL_CHANNELS:
+            unknown.append(cid)
+            continue
+        try:
+            row = channel_spec_at(target, cid) if target else None
+        except Exception as exc:
+            logger.warning(
+                "entitlements: previous_tier_channel_spec_at_batch row %r failed: %s",
+                cid,
+                exc,
+            )
+            unknown.append(cid)
+            continue
+        rows.append({"channel": cid, "row": row})
+    return {"channels": rows, "unknown": unknown}
+
+
 def tier_path_batch(from_tier: str, to_tiers) -> dict | None:
     """Batch sibling of :func:`tier_path`: per-rung marginal ``tier_diff``
     rows for a caller-supplied subset of destination tiers all walked

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -14038,6 +14038,167 @@ def api_entitlement_previous_tier_runtime_spec_at_batch():
     return _next_prev_tier_runtime_spec_at_batch("previous")
 
 
+def _next_prev_tier_channel_spec_at_batch(
+    direction: str,
+):
+    """Shared helper for the two ``/api/entitlement/{next,previous}-tier-
+    channel-spec-at-batch`` handlers.
+
+    Channel-axis twin of :func:`_next_prev_tier_feature_spec_at_batch`
+    / :func:`_next_prev_tier_runtime_spec_at_batch`. ``direction``
+    selects the rung helper (``next`` / ``previous``). Returned
+    envelope shape is identical for both directions so the paywall
+    surface can swap one URL for the other without re-deriving the row
+    schema.
+    """
+    raw_tier = request.args.get("tier")
+    tier_in = (raw_tier or "").strip().lower()
+    if not tier_in:
+        return jsonify({"error": "missing tier"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        if tier_in not in _ent._TIER_ORDER:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "tier", "tier": tier_in}
+                ),
+                404,
+            )
+        channels = _parse_csv_arg("channels")
+        if not channels:
+            return jsonify({"error": "supply channels=<csv>"}), 400
+        if direction == "next":
+            target = _ent._next_purchasable_tier_after(tier_in)
+            batch = _ent.next_tier_channel_spec_at_batch(tier_in, channels)
+        else:
+            target = _ent._previous_purchasable_tier_before(tier_in)
+            batch = _ent.previous_tier_channel_spec_at_batch(tier_in, channels)
+        if batch is None:
+            batch = {"channels": [], "unknown": []}
+        return jsonify(
+            {
+                "tier": tier_in,
+                "tier_label": _ent.tier_label(tier_in),
+                "tier_rank": _ent.tier_rank(tier_in),
+                "target": target,
+                "target_label": _ent.tier_label(target) if target else None,
+                "target_rank": _ent.tier_rank(target) if target else None,
+                "channels": batch.get("channels", []),
+                "unknown": batch.get("unknown", []),
+            }
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_%s_tier_channel_spec_at_batch: error: %s",
+            direction,
+            exc,
+        )
+        return jsonify(
+            {
+                "tier": tier_in,
+                "tier_label": None,
+                "tier_rank": -1,
+                "target": None,
+                "target_label": None,
+                "target_rank": None,
+                "channels": [],
+                "unknown": [],
+            }
+        )
+
+
+@bp_entitlement.route("/api/entitlement/next-tier-channel-spec-at-batch")
+def api_entitlement_next_tier_channel_spec_at_batch():
+    """``GET /api/entitlement/next-tier-channel-spec-at-batch?tier=<source>
+    &channels=a,b,c`` -- channel-axis twin of
+    ``/api/entitlement/next-tier-feature-spec-at-batch`` /
+    ``/api/entitlement/next-tier-runtime-spec-at-batch`` and batch
+    sibling of ``/api/entitlement/next-tier-channel-spec-at``.
+
+    Where ``/next-tier-channel-spec-at`` projects ONE chat channel
+    onto the rung above the caller-supplied source, this projects N
+    channels onto that same rung in ONE round-trip. Pairs with
+    ``/next-tier-channel-spec-at`` the same way
+    ``/channel-spec-at-batch`` pairs with ``/channel-spec-at``: scalar
+    what-if -> batch what-if.
+
+    Use case: a pricing-comparison "here are the 6 chat channels I
+    care about -- what do they look like at my next rung?" surface
+    hydrates every channel off ONE call instead of N calls to
+    ``/next-tier-channel-spec-at``.
+
+    Each row in ``channels[].row`` is byte-identical to the body of
+    ``/next-tier-channel-spec-at?tier=<source>&channel=<id>`` ``.row``
+    -- pinned by parity tests so the scalar and batch accessors cannot
+    drift. Supplied channel ids are normalised (whitespace stripped,
+    lowercased, duplicates dropped, first-seen order preserved).
+    Unknown ids do not 404 the call -- they are echoed in
+    ``unknown[]`` so a partially-bad caller still gets rows back for
+    the valid ids.
+
+    Every chat channel is FREE at every tier (see
+    ``/channel-spec-at``), so whenever ``row`` is not ``null`` it
+    comes back ``free=true`` / ``locked=false`` / ``entitled=true``
+    regardless of the target rung -- the surface can render "chat
+    channel included at every plan" off ONE call without hard-coding
+    that posture client-side.
+
+    At the ceiling (enterprise as source, no rung above) every per-
+    channel ``row`` is ``null`` while the envelope's ``target`` /
+    ``target_label`` / ``target_rank`` collapse to ``null`` -- the
+    surface stays 200 so callers can render "you're at the top" copy
+    without a status-code branch.
+
+    Response shape::
+
+        {
+          "tier":         "<source tier id>",
+          "tier_label":   "<source label>",
+          "tier_rank":    <source rank>,
+          "target":       "<next-above tier id>" | null,
+          "target_label": "<next-above label>" | null,
+          "target_rank":  <next-above rank> | null,
+          "channels": [
+            {"channel": "<id>", "row": {<channel_spec_at row>} | null},
+            ...
+          ],
+          "unknown": ["bogus_id", ...],
+        }
+
+    - **400** when ``tier=`` is missing / blank, or ``channels=`` is
+      missing / empty after normalisation
+    - **404** when ``tier`` is unknown (body carries ``which: "tier"``)
+    - **Never 5xxs**: a synthesis failure short-circuits to an envelope
+      with empty rows so the matrix keeps rendering.
+    """
+    return _next_prev_tier_channel_spec_at_batch("next")
+
+
+@bp_entitlement.route("/api/entitlement/previous-tier-channel-spec-at-batch")
+def api_entitlement_previous_tier_channel_spec_at_batch():
+    """``GET /api/entitlement/previous-tier-channel-spec-at-batch
+    ?tier=<source>&channels=a,b,c`` -- source-anchored mirror of
+    ``/api/entitlement/next-tier-channel-spec-at-batch`` and batch
+    sibling of ``/api/entitlement/previous-tier-channel-spec-at``.
+
+    Lets a downgrade-confirmation card render "here are the N chat
+    channels I care about -- do they still unlock one rung down?" off
+    ONE round-trip instead of N calls to
+    ``/previous-tier-channel-spec-at``.
+
+    Each row in ``channels[].row`` is byte-identical to the body of
+    ``/previous-tier-channel-spec-at?tier=<source>&channel=<id>``
+    ``.row``. At the floor (``oss`` / ``cloud_free`` as source) every
+    per-channel ``row`` is ``null`` while ``target`` / ``target_label``
+    / ``target_rank`` collapse to ``null``.
+
+    Response shape, validation, and never-5xx posture are identical to
+    ``/next-tier-channel-spec-at-batch``.
+    """
+    return _next_prev_tier_channel_spec_at_batch("previous")
+
+
 @bp_entitlement.route("/api/entitlement/capacity-diff-path-batch")
 def api_entitlement_capacity_diff_path_batch():
     """``GET /api/entitlement/capacity-diff-path-batch?from=<id>&to=a,b,c``

--- a/tests/test_entitlement_next_prev_tier_channel_spec_at_batch.py
+++ b/tests/test_entitlement_next_prev_tier_channel_spec_at_batch.py
@@ -1,0 +1,448 @@
+"""Tests for the two batch siblings of
+:func:`clawmetry.entitlements.next_tier_channel_spec_at` /
+:func:`previous_tier_channel_spec_at`, and the two companion
+``/api/entitlement/{next,previous}-tier-channel-spec-at-batch``
+endpoints.
+
+Channel-axis twin of the four
+:func:`{next,previous}_tier_{feature,runtime}_spec_at_batch` helpers.
+Where the scalar projections walk ONE chat channel onto the rung
+above/below a source tier, the batch siblings walk N channels onto
+that same rung in ONE round-trip. They compose:
+
+* :func:`next_tier_channel_spec_at` (scalar projection) +
+  :func:`channel_spec_at_batch` (batch what-if) ->
+  :func:`next_tier_channel_spec_at_batch`
+* :func:`previous_tier_channel_spec_at` +
+  :func:`channel_spec_at_batch` ->
+  :func:`previous_tier_channel_spec_at_batch`
+
+Pins covered here:
+
+* per-row byte-equality with the scalar sibling for every valid
+  (source, channel) pair across every purchasable source tier
+  (parity)
+* channel-axis always-free invariant: whenever ``row`` is not
+  ``None`` it comes back ``free=True`` / ``locked=False`` /
+  ``entitled=True``
+* ceiling (enterprise as source for ``next_*``) / floor
+  (``oss`` / ``cloud_free`` as source for ``previous_*``) yields
+  ``row=None`` for every valid channel -- envelope rows still render
+* trial-as-source resolves the same way the sibling ``_at`` families do
+  (next -> enterprise, previous -> cloud_starter)
+* unknown / empty / whitespace / case-insensitive id handling
+* unknown ids echo into ``unknown[]`` rather than 404'ing the call
+* normalisation is whitespace-stripped, lowercased, first-seen order
+  preserved, duplicate-dropped (matches ``_normalise_csv``)
+* grace vs enforce yields the same body (catalogue-derived, not gated)
+* the helpers never raise -- a per-row builder failure short-circuits
+  that row into ``unknown[]`` rather than 500-ing
+* the two API endpoints never 5xx: 400 on missing input, 404 on
+  unknown tier, 200 with ``row=null`` rows at ceiling/floor; an
+  internal failure yields the same 200 envelope shape
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+_ENVELOPE_KEYS = {
+    "tier",
+    "tier_label",
+    "tier_rank",
+    "target",
+    "target_label",
+    "target_rank",
+    "channels",
+    "unknown",
+}
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+def _sample_channels(ent, n: int = 3) -> list[str]:
+    """Return up to ``n`` chat-channel ids in a deterministic order."""
+    return sorted(ent.ALL_CHANNELS)[:n]
+
+
+# ── next_tier_channel_spec_at_batch (helper) ────────────────────────────────
+
+
+def test_next_channel_batch_row_byte_equals_scalar(ent):
+    # Per-row body equals next_tier_channel_spec_at(src, channel)
+    # byte-for-byte across every purchasable source for every channel.
+    # Pins so the batch accessor cannot drift from the scalar projection.
+    chans = sorted(ent.ALL_CHANNELS)
+    for src in ent._PURCHASABLE_TIERS:
+        body = ent.next_tier_channel_spec_at_batch(src, chans)
+        assert body is not None
+        assert body["unknown"] == []
+        assert [r["channel"] for r in body["channels"]] == chans
+        for row in body["channels"]:
+            assert row["row"] == ent.next_tier_channel_spec_at(src, row["channel"])
+
+
+def test_next_channel_batch_returns_row_null_at_ceiling(ent):
+    # Enterprise is the top of the purchasable ladder -- no rung above.
+    # Every valid channel must surface as a row with row=None so the
+    # matrix's row count stays stable (the surface can still render
+    # "you're at the top").
+    chans = sorted(ent.ALL_CHANNELS)
+    body = ent.next_tier_channel_spec_at_batch(ent.TIER_ENTERPRISE, chans)
+    assert body is not None
+    assert body["unknown"] == []
+    assert [r["channel"] for r in body["channels"]] == chans
+    assert all(r["row"] is None for r in body["channels"])
+
+
+def test_next_channel_batch_trial_resolves_to_enterprise(ent):
+    ch = _sample_channels(ent, 1)[0]
+    body = ent.next_tier_channel_spec_at_batch(ent.TIER_TRIAL, [ch])
+    assert body is not None
+    assert body["channels"] == [
+        {
+            "channel": ch,
+            "row": ent.channel_spec_at(ent.TIER_ENTERPRISE, ch),
+        }
+    ]
+
+
+def test_next_channel_batch_unknown_inputs_short_circuit(ent):
+    # Empty / None / unknown tier -> helper returns None (HTTP wrapper
+    # turns into 400 / 404). Unknown channel ids are bucketed into
+    # ``unknown[]``.
+    ch = _sample_channels(ent, 1)[0]
+    assert ent.next_tier_channel_spec_at_batch("", [ch]) is None
+    assert ent.next_tier_channel_spec_at_batch(None, [ch]) is None
+    assert ent.next_tier_channel_spec_at_batch("bogus", [ch]) is None
+    body = ent.next_tier_channel_spec_at_batch(
+        ent.TIER_CLOUD_STARTER, [ch, "no_such_channel", "also_bogus"]
+    )
+    assert body is not None
+    assert [r["channel"] for r in body["channels"]] == [ch]
+    assert body["unknown"] == ["no_such_channel", "also_bogus"]
+
+
+def test_next_channel_batch_normalises_input(ent):
+    # Whitespace stripped, lowercased, duplicates dropped, first-seen
+    # order preserved -- matches _normalise_csv.
+    ch = _sample_channels(ent, 1)[0]
+    body = ent.next_tier_channel_spec_at_batch(
+        ent.TIER_CLOUD_STARTER,
+        [f" {ch.upper()} ", ch, "", ch.upper()],
+    )
+    assert body is not None
+    assert [r["channel"] for r in body["channels"]] == [ch]
+    assert body["unknown"] == []
+
+
+def test_next_channel_batch_empty_channels_returns_empty_rows(ent):
+    # An empty caller-supplied list returns {channels: [], unknown: []}
+    # -- the HTTP layer turns that into a 400, the helper itself does
+    # not raise.
+    body = ent.next_tier_channel_spec_at_batch(ent.TIER_CLOUD_STARTER, [])
+    assert body == {"channels": [], "unknown": []}
+
+
+def test_next_channel_batch_always_free_when_row_present(ent):
+    # Channel-axis always-free invariant: whenever ``row`` is not None
+    # it comes back ``free=True`` / ``locked=False`` / ``entitled=True``
+    # regardless of the source or target rung.
+    chans = sorted(ent.ALL_CHANNELS)
+    for src in ent._PURCHASABLE_TIERS:
+        body = ent.next_tier_channel_spec_at_batch(src, chans)
+        assert body is not None
+        for entry in body["channels"]:
+            row = entry["row"]
+            if row is None:
+                continue
+            assert row.get("free") is True
+            assert row.get("locked") is False
+            assert row.get("entitled") is True
+
+
+def test_next_channel_batch_grace_and_enforce_match(ent, monkeypatch):
+    chans = sorted(ent.ALL_CHANNELS)
+    grace = ent.next_tier_channel_spec_at_batch(ent.TIER_CLOUD_STARTER, chans)
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    importlib.reload(ent)
+    ent.invalidate()
+    enforce = ent.next_tier_channel_spec_at_batch(ent.TIER_CLOUD_STARTER, chans)
+    assert enforce == grace
+
+
+def test_next_channel_batch_row_failure_buckets_into_unknown(ent, monkeypatch):
+    # A synthesised failure in channel_spec_at short-circuits that row
+    # into ``unknown[]`` and the rest of the batch keeps building.
+    chans = _sample_channels(ent, 2)
+    boom, keep = chans[0], chans[1]
+    real_spec_at = ent.channel_spec_at
+
+    def fake_spec_at(tier, channel):
+        if channel == boom:
+            raise RuntimeError("synthetic")
+        return real_spec_at(tier, channel)
+
+    monkeypatch.setattr(ent, "channel_spec_at", fake_spec_at)
+    body = ent.next_tier_channel_spec_at_batch(
+        ent.TIER_CLOUD_STARTER, [boom, keep]
+    )
+    assert body is not None
+    assert [r["channel"] for r in body["channels"]] == [keep]
+    assert body["unknown"] == [boom]
+
+
+# ── previous_tier_channel_spec_at_batch (helper) ────────────────────────────
+
+
+def test_previous_channel_batch_row_byte_equals_scalar(ent):
+    chans = sorted(ent.ALL_CHANNELS)
+    for src in ent._PURCHASABLE_TIERS:
+        body = ent.previous_tier_channel_spec_at_batch(src, chans)
+        assert body is not None
+        for row in body["channels"]:
+            assert row["row"] == ent.previous_tier_channel_spec_at(
+                src, row["channel"]
+            )
+
+
+def test_previous_channel_batch_returns_row_null_at_floor(ent):
+    chans = sorted(ent.ALL_CHANNELS)
+    for src in (ent.TIER_OSS, ent.TIER_CLOUD_FREE):
+        body = ent.previous_tier_channel_spec_at_batch(src, chans)
+        assert body is not None
+        assert [r["channel"] for r in body["channels"]] == chans
+        assert all(r["row"] is None for r in body["channels"])
+
+
+def test_previous_channel_batch_trial_resolves_to_starter(ent):
+    ch = _sample_channels(ent, 1)[0]
+    body = ent.previous_tier_channel_spec_at_batch(ent.TIER_TRIAL, [ch])
+    assert body is not None
+    assert body["channels"] == [
+        {
+            "channel": ch,
+            "row": ent.channel_spec_at(ent.TIER_CLOUD_STARTER, ch),
+        }
+    ]
+
+
+def test_previous_channel_batch_unknown_inputs_short_circuit(ent):
+    ch = _sample_channels(ent, 1)[0]
+    assert (
+        ent.previous_tier_channel_spec_at_batch("", [ch]) is None
+    )
+    assert (
+        ent.previous_tier_channel_spec_at_batch("bogus", [ch]) is None
+    )
+    body = ent.previous_tier_channel_spec_at_batch(
+        ent.TIER_CLOUD_PRO, [ch, "no_such_channel"]
+    )
+    assert body is not None
+    assert [r["channel"] for r in body["channels"]] == [ch]
+    assert body["unknown"] == ["no_such_channel"]
+
+
+def test_previous_channel_batch_always_free_when_row_present(ent):
+    chans = sorted(ent.ALL_CHANNELS)
+    for src in ent._PURCHASABLE_TIERS:
+        body = ent.previous_tier_channel_spec_at_batch(src, chans)
+        assert body is not None
+        for entry in body["channels"]:
+            row = entry["row"]
+            if row is None:
+                continue
+            assert row.get("free") is True
+            assert row.get("locked") is False
+            assert row.get("entitled") is True
+
+
+# ── /api/entitlement/next-tier-channel-spec-at-batch ────────────────────────
+
+
+def test_api_next_channel_batch_happy_path(client, ent):
+    chans = _sample_channels(ent, 2)
+    csv = ",".join(chans)
+    resp = client.get(
+        "/api/entitlement/next-tier-channel-spec-at-batch"
+        f"?tier=cloud_starter&channels={csv}"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert set(body.keys()) == _ENVELOPE_KEYS
+    assert body["tier"] == ent.TIER_CLOUD_STARTER
+    assert body["target"] == ent.TIER_CLOUD_PRO
+    assert body["target_rank"] == ent.tier_rank(ent.TIER_CLOUD_PRO)
+    # Every per-channel row matches /next-tier-channel-spec-at .row
+    for row in body["channels"]:
+        scalar = client.get(
+            "/api/entitlement/next-tier-channel-spec-at"
+            f"?tier=cloud_starter&channel={row['channel']}"
+        ).get_json()
+        assert row["row"] == scalar["row"]
+
+
+def test_api_next_channel_batch_at_ceiling_returns_200_with_null_rows(
+    client, ent
+):
+    chans = _sample_channels(ent, 2)
+    csv = ",".join(chans)
+    resp = client.get(
+        "/api/entitlement/next-tier-channel-spec-at-batch"
+        f"?tier=enterprise&channels={csv}"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["target"] is None
+    assert body["target_label"] is None
+    assert body["target_rank"] is None
+    assert [r["channel"] for r in body["channels"]] == chans
+    assert all(r["row"] is None for r in body["channels"])
+
+
+def test_api_next_channel_batch_400_missing_tier(client, ent):
+    ch = _sample_channels(ent, 1)[0]
+    resp = client.get(
+        f"/api/entitlement/next-tier-channel-spec-at-batch?channels={ch}"
+    )
+    assert resp.status_code == 400
+
+
+def test_api_next_channel_batch_400_missing_channels(client):
+    resp = client.get(
+        "/api/entitlement/next-tier-channel-spec-at-batch?tier=cloud_starter"
+    )
+    assert resp.status_code == 400
+
+
+def test_api_next_channel_batch_400_empty_channels(client):
+    # ``channels=,,,`` normalises to an empty list -> 400.
+    resp = client.get(
+        "/api/entitlement/next-tier-channel-spec-at-batch"
+        "?tier=cloud_starter&channels=,,,"
+    )
+    assert resp.status_code == 400
+
+
+def test_api_next_channel_batch_404_unknown_tier(client, ent):
+    ch = _sample_channels(ent, 1)[0]
+    resp = client.get(
+        "/api/entitlement/next-tier-channel-spec-at-batch"
+        f"?tier=bogus&channels={ch}"
+    )
+    assert resp.status_code == 404
+    body = resp.get_json()
+    assert body.get("which") == "tier"
+
+
+def test_api_next_channel_batch_unknown_channel_bucketed_200(client, ent):
+    # An unknown channel does not 404 the call -- it lands in unknown[].
+    ch = _sample_channels(ent, 1)[0]
+    resp = client.get(
+        "/api/entitlement/next-tier-channel-spec-at-batch"
+        f"?tier=cloud_starter&channels={ch},no_such_channel"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert [r["channel"] for r in body["channels"]] == [ch]
+    assert body["unknown"] == ["no_such_channel"]
+
+
+def test_api_next_channel_batch_normalises_query_arg(client, ent):
+    # Whitespace + uppercase + duplicate dropping happens at the route
+    # layer via _parse_csv_arg before the helper sees the list.
+    chans = _sample_channels(ent, 2)
+    a, b = chans[0], chans[1]
+    resp = client.get(
+        "/api/entitlement/next-tier-channel-spec-at-batch"
+        f"?tier=cloud_starter&channels= {a.upper()} ,{a},{b.upper()}"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert [r["channel"] for r in body["channels"]] == [a, b]
+
+
+# ── /api/entitlement/previous-tier-channel-spec-at-batch ────────────────────
+
+
+def test_api_previous_channel_batch_happy_path(client, ent):
+    chans = _sample_channels(ent, 2)
+    csv = ",".join(chans)
+    resp = client.get(
+        "/api/entitlement/previous-tier-channel-spec-at-batch"
+        f"?tier=cloud_pro&channels={csv}"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert set(body.keys()) == _ENVELOPE_KEYS
+    assert body["tier"] == ent.TIER_CLOUD_PRO
+    assert body["target"] == ent.TIER_CLOUD_STARTER
+    for row in body["channels"]:
+        scalar = client.get(
+            "/api/entitlement/previous-tier-channel-spec-at"
+            f"?tier=cloud_pro&channel={row['channel']}"
+        ).get_json()
+        assert row["row"] == scalar["row"]
+
+
+def test_api_previous_channel_batch_at_floor_returns_200_with_null_rows(
+    client, ent
+):
+    chans = _sample_channels(ent, 2)
+    csv = ",".join(chans)
+    for src in (ent.TIER_OSS, ent.TIER_CLOUD_FREE):
+        resp = client.get(
+            "/api/entitlement/previous-tier-channel-spec-at-batch"
+            f"?tier={src}&channels={csv}"
+        )
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body["tier"] == src
+        assert body["target"] is None
+        assert all(r["row"] is None for r in body["channels"])
+
+
+def test_api_previous_channel_batch_400s_and_404s(client, ent):
+    ch = _sample_channels(ent, 1)[0]
+    assert (
+        client.get(
+            "/api/entitlement/previous-tier-channel-spec-at-batch"
+            f"?channels={ch}"
+        ).status_code
+        == 400
+    )
+    assert (
+        client.get(
+            "/api/entitlement/previous-tier-channel-spec-at-batch?tier=cloud_pro"
+        ).status_code
+        == 400
+    )
+    assert (
+        client.get(
+            "/api/entitlement/previous-tier-channel-spec-at-batch"
+            f"?tier=bogus&channels={ch}"
+        ).status_code
+        == 404
+    )


### PR DESCRIPTION
## Summary

Channel-axis twin of `next/previous_tier_{feature,runtime}_spec_at_batch` — batch siblings of `next/previous_tier_channel_spec_at` walking N chat channels against the rung above/below a caller-supplied source tier in ONE round-trip.

Adds:

- module-level `next_tier_channel_spec_at_batch(tier, channels)` / `previous_tier_channel_spec_at_batch(tier, channels)` in `clawmetry/entitlements.py`
- `GET /api/entitlement/next-tier-channel-spec-at-batch?tier=<src>&channels=a,b,c`
- `GET /api/entitlement/previous-tier-channel-spec-at-batch?tier=<src>&channels=a,b,c`
- `tests/test_entitlement_next_prev_tier_channel_spec_at_batch.py` (25 tests: helper parity, ceiling/floor, trial resolution, normalisation, always-free invariant, grace vs enforce parity, never-raise, endpoint 400/404/200 contract)

Response envelope matches `next-tier-{feature,runtime}-spec-at-batch` with `channels` in place of `features`/`runtimes` and per-row `{"channel": id, "row": row|null}`. At the ceiling (`enterprise` as source for `next_*`) / floor (`oss` / `cloud_free` as source for `previous_*`) every per-channel `row` is `null` while `target` / `target_label` / `target_rank` collapse to `null` — the surface stays 200 so callers can render the "you're at the top / floor" copy without a status-code branch.

Channel-axis always-free invariant preserved: whenever `row` is not `null` it comes back `free=true` / `locked=false` / `entitled=true` regardless of the target rung — pinned by tests.

400 on missing/blank `tier` or `channels`; 404 on unknown tier (body carries `which: "tier"`); never 5xxs. Unknown channel ids are echoed in `unknown[]` rather than short-circuiting the call.

No behaviour change to any existing endpoint. Zero-config default remains grace mode.

## Test plan

- [x] `python -m py_compile` on `clawmetry/entitlements.py`, `routes/entitlement.py`, and the new test file
- [x] `pytest tests/test_entitlement_next_prev_tier_channel_spec_at_batch.py` — 25/25 pass
- [x] `pytest -k "entitlement and channel and batch"` — 343/343 pass (existing channel-batch suites unaffected)
- [x] `pytest tests/test_entitlement_next_prev_tier_feature_runtime_spec_at_batch.py tests/test_entitlement_channel_spec_at_batch.py tests/test_entitlements.py` — 154/154 pass (nearest neighbours)

## Local operator verification checklist (I can't do these remotely)

- [ ] Copy `clawmetry/entitlements.py`, `routes/entitlement.py`, and `tests/test_entitlement_next_prev_tier_channel_spec_at_batch.py` into `~/.clawmetry/lib/pythonX.Y/site-packages/clawmetry/` (mirror the layout — `routes/entitlement.py` sits at repo root, not under the `clawmetry/` package)
- [ ] Clear stale `__pycache__/` dirs alongside the touched files
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` to reload the daemon
- [ ] `curl -s 'http://localhost:8900/api/entitlement/next-tier-channel-spec-at-batch?tier=cloud_starter&channels=telegram,signal' | jq` — confirm shape, per-row `channel_spec_at` parity, `target: "cloud_pro"`
- [ ] Repeat with `tier=enterprise` → every `row` is `null`, `target` is `null`, still 200
- [ ] Repeat with `previous-tier-channel-spec-at-batch?tier=cloud_pro&channels=telegram,signal` → `target: "cloud_starter"`
- [ ] Decrypt the live cloud snapshot in the browser and confirm any paywall matrix on the channel axis still hydrates from the existing per-item endpoints unchanged (no regression)
- [ ] Cross-check with `pytest tests/test_entitlement_next_prev_tier_channel_spec_at_batch.py -v` locally where `duckdb` / `requests` are installed
- [ ] Ship via the normal `[RELEASE]` PR pipeline once satisfied

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LrGh2a37gnPAjzw7bcNjMD

---
_Generated by [Claude Code](https://claude.ai/code/session_01LrGh2a37gnPAjzw7bcNjMD)_