### PR TITLE
feat(entitlement): next/previous_tier_channel_catalog_at_batch + 2 endpoints

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -9846,6 +9846,218 @@ def previous_tier_channel_catalog_at(tier: str) -> list[dict] | None:
         return None
 
 
+def next_tier_channel_catalog_at_batch() -> list[dict]:
+    """Batch sibling of :func:`next_tier_channel_catalog_at`: one
+    envelope per purchasable source tier carrying the full
+    :func:`channel_catalog_at`-shape catalogue at the rung above each
+    source, in one pass.
+
+    Channel-axis catalog analogue of :func:`next_tier_spec_at_batch`
+    (full :func:`tier_spec_at` row per source), :func:`next_tier_diff_at_batch`
+    (marginal :func:`tier_diff` per source), and the sibling
+    :func:`next_tier_feature_spec_at_batch` / :func:`next_tier_runtime_spec_at_batch`
+    (scalar projection axis). Where the scalar
+    :func:`next_tier_channel_catalog_at` returns one source's channel
+    matrix at its next rung, this batch returns every purchasable
+    source's channel matrix at ITS next rung in ONE round-trip -- the
+    catalog-shaped, channel-axis member of the ``next_tier_*_at_batch``
+    family so a pricing-comparison matrix UI can render the full
+    "chat channels included at the rung above each rung" column off
+    one call instead of N calls to :func:`next_tier_channel_catalog_at`.
+
+    Per-envelope row shape byte-matches the scalar
+    ``/api/entitlement/next-tier-channel-catalog-at`` response body for
+    the same source (sans the resolver-context fields the outer route
+    adds around the helper output)::
+
+        {
+          "tier":         "<source tier id>",
+          "tier_label":   "...",
+          "tier_rank":    <int>,
+          "target":       "<next-above tier id>" | None,
+          "target_label": "..." | None,
+          "target_rank":  <int> | None,
+          "channels":     [<channel_catalog_at row>, ...],
+        }
+
+    Each populated ``channels`` list is byte-identical to
+    :func:`next_tier_channel_catalog_at(source)` (and, at the resolved
+    target, to :func:`channel_catalog_at(target)`) -- a parity test
+    pins this so the scalar and batch what-if catalog helpers cannot
+    drift. Envelopes are sorted by source ``(tier_rank, tier_id)``
+    ascending -- byte-stable against
+    :func:`next_tier_spec_at_batch` / :func:`next_tier_diff_at_batch`
+    / :func:`next_tier_unlocks_at_batch` / :func:`next_tier_locks_at_batch`
+    / :func:`next_tier_capacity_diff_at_batch` so a UI can fold the
+    six responses into one matrix without re-sorting client-side.
+    Same-rank sibling tiers (``cloud_pro`` / ``pro`` both at rank 2)
+    are both returned.
+
+    Source list is :data:`_PURCHASABLE_TIERS` (trial excluded),
+    matching the sibling ``next_*_at_batch`` helpers. The source-side
+    ceiling (``enterprise`` as source -- no rung strictly above)
+    surfaces with ``target=None`` and ``channels=[]`` rather than
+    being dropped, so the matrix keeps a row for every purchasable
+    rung.
+
+    Every chat channel is FREE at every tier (see
+    :func:`channel_catalog_at`), so every populated ``channels`` row
+    comes back ``free=True`` / ``allowed=True`` / ``locked=False`` /
+    ``entitled=True`` regardless of the source or target rung. That
+    parity IS the answer: the batch surface can render "all N chat
+    channels included at every plan" off ONE call without hard-coding
+    that posture client-side.
+
+    Decoupled from the resolved entitlement (walks the static
+    catalogue), so grace vs enforce yields identical envelopes.
+
+    Never raises: a per-source builder failure collapses to
+    ``channels=[]`` on the populated envelope so the surrounding
+    envelope stays visible; an unexpected top-level failure
+    short-circuits to ``[]`` so the matrix keeps rendering instead of
+    breaking.
+    """
+    try:
+        out: list[dict] = []
+        ordered = sorted(
+            _PURCHASABLE_TIERS, key=lambda t: (_TIER_RANK.get(t, -1), t)
+        )
+        for tid in ordered:
+            try:
+                target = _next_purchasable_tier_after(tid)
+            except Exception as exc:
+                logger.warning(
+                    "entitlements: next_tier_channel_catalog_at_batch target %r failed: %s",
+                    tid,
+                    exc,
+                )
+                target = None
+            channels: list[dict] = []
+            if target is not None:
+                try:
+                    channels = channel_catalog_at(target) or []
+                except Exception as exc:
+                    logger.warning(
+                        "entitlements: next_tier_channel_catalog_at_batch row %r failed: %s",
+                        tid,
+                        exc,
+                    )
+                    channels = []
+            out.append(
+                {
+                    "tier": tid,
+                    "tier_label": tier_label(tid),
+                    "tier_rank": tier_rank(tid),
+                    "target": target,
+                    "target_label": tier_label(target) if target else None,
+                    "target_rank": tier_rank(target) if target else None,
+                    "channels": channels,
+                }
+            )
+        return out
+    except Exception as exc:
+        logger.warning(
+            "entitlements: next_tier_channel_catalog_at_batch failed: %s", exc
+        )
+        return []
+
+
+def previous_tier_channel_catalog_at_batch() -> list[dict]:
+    """Batch sibling of :func:`previous_tier_channel_catalog_at`: one
+    envelope per purchasable source tier carrying the full
+    :func:`channel_catalog_at`-shape catalogue at the rung below each
+    source, in one pass.
+
+    Source-anchored downgrade-side mirror of
+    :func:`next_tier_channel_catalog_at_batch` and channel-axis catalog
+    analogue of :func:`previous_tier_spec_at_batch`. Lets a
+    downgrade-confirmation matrix UI render the "chat channels that
+    stay when I step down from each rung" column off **one** call
+    instead of N calls to :func:`previous_tier_channel_catalog_at`.
+
+    Per-envelope row shape byte-matches the scalar
+    ``/api/entitlement/previous-tier-channel-catalog-at`` response
+    body for the same source (sans the resolver-context fields the
+    outer route adds). Same envelope keys as
+    :func:`next_tier_channel_catalog_at_batch`: ``tier``,
+    ``tier_label``, ``tier_rank``, ``target``, ``target_label``,
+    ``target_rank``, ``channels``.
+
+    Each populated ``channels`` list is byte-identical to
+    :func:`previous_tier_channel_catalog_at(source)` (and, at the
+    resolved target, to :func:`channel_catalog_at(target)`) -- pinned
+    by parity tests so the scalar and batch what-if catalog helpers
+    cannot drift.
+
+    Envelopes are sorted by source ``(tier_rank, tier_id)`` ascending
+    -- byte-stable against the sibling ``previous_*_at_batch``
+    helpers so a UI can fold the responses into one matrix without
+    re-sorting client-side.
+
+    Source list is :data:`_PURCHASABLE_TIERS` (trial excluded). The
+    source-side floor (``oss`` / ``cloud_free`` as source -- no rung
+    strictly below) surfaces with ``target=None`` and ``channels=[]``
+    rather than being dropped, so the matrix keeps a row for every
+    purchasable rung.
+
+    Channel-axis always-free invariant applies here as well: every
+    populated ``channels`` row comes back ``free=True`` /
+    ``allowed=True`` / ``locked=False`` / ``entitled=True`` regardless
+    of the source or target rung.
+
+    Decoupled from the resolved entitlement (walks the static
+    catalogue), so grace vs enforce yields identical envelopes.
+
+    Never raises: a per-source builder failure collapses to
+    ``channels=[]`` on the populated envelope; an unexpected
+    top-level failure short-circuits to ``[]``.
+    """
+    try:
+        out: list[dict] = []
+        ordered = sorted(
+            _PURCHASABLE_TIERS, key=lambda t: (_TIER_RANK.get(t, -1), t)
+        )
+        for tid in ordered:
+            try:
+                target = _previous_purchasable_tier_before(tid)
+            except Exception as exc:
+                logger.warning(
+                    "entitlements: previous_tier_channel_catalog_at_batch target %r failed: %s",
+                    tid,
+                    exc,
+                )
+                target = None
+            channels: list[dict] = []
+            if target is not None:
+                try:
+                    channels = channel_catalog_at(target) or []
+                except Exception as exc:
+                    logger.warning(
+                        "entitlements: previous_tier_channel_catalog_at_batch row %r failed: %s",
+                        tid,
+                        exc,
+                    )
+                    channels = []
+            out.append(
+                {
+                    "tier": tid,
+                    "tier_label": tier_label(tid),
+                    "tier_rank": tier_rank(tid),
+                    "target": target,
+                    "target_label": tier_label(target) if target else None,
+                    "target_rank": tier_rank(target) if target else None,
+                    "channels": channels,
+                }
+            )
+        return out
+    except Exception as exc:
+        logger.warning(
+            "entitlements: previous_tier_channel_catalog_at_batch failed: %s",
+            exc,
+        )
+        return []
+
+
 def next_tier_feature_catalog_at(tier: str) -> list[dict] | None:
     """Source-anchored feature-axis catalog sibling of
     :func:`next_tier_spec_at`: the full :func:`feature_catalog_at`-shape

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -18729,6 +18729,154 @@ def api_entitlement_previous_tier_channel_catalog_at():
         )
 
 
+@bp_entitlement.route("/api/entitlement/next-tier-channel-catalog-at-batch")
+def api_entitlement_next_tier_channel_catalog_at_batch():
+    """``GET /api/entitlement/next-tier-channel-catalog-at-batch`` --
+    batch sibling of ``/api/entitlement/next-tier-channel-catalog-at``:
+    one ``next-tier-channel-catalog-at`` envelope per purchasable source
+    tier, in one round-trip.
+
+    Channel-axis catalog analogue of
+    ``/api/entitlement/next-tier-spec-at-batch`` (full
+    :func:`tier_spec_at` row per source),
+    ``/next-tier-diff-at-batch`` (marginal :func:`tier_diff` per
+    source), and the sibling ``/next-tier-feature-spec-at-batch`` /
+    ``/next-tier-runtime-spec-at-batch`` axes. Lets a pricing-
+    comparison matrix UI render the "chat channels included at the
+    rung above each rung" column off **one** call instead of N calls
+    to ``/next-tier-channel-catalog-at``.
+
+    No query params. The source list is
+    :data:`entitlements._PURCHASABLE_TIERS` (trial excluded), matching
+    the sibling ``_at_batch`` endpoints, so the batches fold into the
+    same pricing-page table byte-for-byte on the source axis.
+
+    Response shape::
+
+        {
+          "tiers":             [<envelope>, ...],
+          "current_tier":      "<resolved tier id>",
+          "current_tier_rank": <int>,
+          "grace":             <bool>,
+          "enforced":          <bool>,
+        }
+
+    Each ``<envelope>`` matches
+    ``/api/entitlement/next-tier-channel-catalog-at?tier=<source>`` for
+    that source exactly (``tier``, ``tier_label``, ``tier_rank``,
+    ``target``, ``target_label``, ``target_rank``, ``channels``). The
+    inner ``channels`` matches
+    ``/channel-catalog-at?tier=<target>`` byte-for-byte when
+    ``target`` is populated. At the source-side ceiling (``enterprise``
+    as source) the envelope carries ``target=null`` and
+    ``channels=[]`` rather than being dropped.
+
+    Every chat channel is FREE at every tier, so every populated
+    ``channels`` row comes back ``free=True`` / ``locked=False`` /
+    ``entitled=True`` regardless of the source or target rung -- the
+    pricing surface can render "all N chat channels included at every
+    plan" off ONE call without hard-coding the posture client-side.
+
+    - **Never 5xxs**: a resolver failure yields an empty ``tiers``
+      list and the grace-shape envelope so the matrix keeps rendering.
+    """
+    try:
+        from clawmetry import entitlements as _ent
+
+        rows = _ent.next_tier_channel_catalog_at_batch() or []
+        ent = _ent.get_entitlement()
+        return jsonify(
+            {
+                "tiers": rows,
+                "current_tier": ent.tier,
+                "current_tier_rank": _ent.tier_rank(ent.tier),
+                "grace": bool(ent.grace),
+                "enforced": _ent.is_enforced(),
+            }
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_next_tier_channel_catalog_at_batch: error: %s",
+            exc,
+        )
+        return jsonify(
+            {
+                "tiers": [],
+                "current_tier": "oss",
+                "current_tier_rank": 0,
+                "grace": True,
+                "enforced": False,
+            }
+        )
+
+
+@bp_entitlement.route("/api/entitlement/previous-tier-channel-catalog-at-batch")
+def api_entitlement_previous_tier_channel_catalog_at_batch():
+    """``GET /api/entitlement/previous-tier-channel-catalog-at-batch``
+    -- batch sibling of
+    ``/api/entitlement/previous-tier-channel-catalog-at``: one
+    ``previous-tier-channel-catalog-at`` envelope per purchasable source
+    tier, in one round-trip.
+
+    Source-anchored downgrade-side mirror of
+    ``/api/entitlement/next-tier-channel-catalog-at-batch`` and
+    channel-axis catalog analogue of
+    ``/api/entitlement/previous-tier-spec-at-batch``. Lets a
+    downgrade-confirmation matrix UI render the "chat channels that
+    stay when I step down from each rung" column off **one** call
+    instead of N calls to ``/previous-tier-channel-catalog-at``.
+
+    No query params. The source list is
+    :data:`entitlements._PURCHASABLE_TIERS` (trial excluded), matching
+    the sibling ``_at_batch`` endpoints, so the batches fold into the
+    same pricing-page table byte-for-byte on the source axis.
+
+    Response shape matches
+    ``/api/entitlement/next-tier-channel-catalog-at-batch`` byte-for-
+    byte (``tiers`` / ``current_tier`` / ``current_tier_rank`` /
+    ``grace`` / ``enforced``); each envelope in ``tiers`` matches
+    ``/api/entitlement/previous-tier-channel-catalog-at?tier=<source>``
+    for that source exactly. At the source-side floor (``oss`` /
+    ``cloud_free`` as source) the envelope carries ``target=null`` and
+    ``channels=[]`` rather than being dropped.
+
+    Channel-axis always-free invariant applies here as well: every
+    populated ``channels`` row comes back ``free=True`` /
+    ``locked=False`` / ``entitled=True``.
+
+    - **Never 5xxs**: a resolver failure yields an empty ``tiers``
+      list and the grace-shape envelope.
+    """
+    try:
+        from clawmetry import entitlements as _ent
+
+        rows = _ent.previous_tier_channel_catalog_at_batch() or []
+        ent = _ent.get_entitlement()
+        return jsonify(
+            {
+                "tiers": rows,
+                "current_tier": ent.tier,
+                "current_tier_rank": _ent.tier_rank(ent.tier),
+                "grace": bool(ent.grace),
+                "enforced": _ent.is_enforced(),
+            }
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_previous_tier_channel_catalog_at_batch: error: %s",
+            exc,
+        )
+        return jsonify(
+            {
+                "tiers": [],
+                "current_tier": "oss",
+                "current_tier_rank": 0,
+                "grace": True,
+                "enforced": False,
+            }
+        )
+
+
 @bp_entitlement.route("/api/entitlement/next-tier-feature-catalog-at")
 def api_entitlement_next_tier_feature_catalog_at():
     """``GET /api/entitlement/next-tier-feature-catalog-at?tier=<source>``

--- a/tests/test_entitlement_next_prev_tier_channel_catalog_at_batch.py
+++ b/tests/test_entitlement_next_prev_tier_channel_catalog_at_batch.py
@@ -1,0 +1,589 @@
+"""Tests for ``next_tier_channel_catalog_at_batch`` /
+``previous_tier_channel_catalog_at_batch`` and the companion
+``/api/entitlement/{next,previous}-tier-channel-catalog-at-batch`` endpoints.
+
+Batch siblings of the source-anchored scalar
+``{next,previous}_tier_channel_catalog_at`` (source-anchored channel-axis
+catalog helpers). Where the scalar helpers answer "give me the full
+channel matrix at the rung above / below THIS source", the batch
+siblings return the same envelope for every entry in
+:data:`_PURCHASABLE_TIERS` in one pass -- the catalog-shaped, channel-
+axis member of the ``{next,previous}_tier_*_at_batch`` family alongside
+the spec / diff / unlocks / locks / capacity siblings.
+
+Every chat channel is FREE at every tier (the ``channels`` capacity axis
+governs how many concurrent channels each plan admits, not which
+adapters unlock), so every populated ``channels`` row is byte-identical
+across every target rung: ``free=True`` / ``allowed=True`` /
+``locked=False`` / ``entitled=True``. That parity IS the answer: a
+pricing tooltip / upgrade panel can render "all N chat channels included
+at every plan" off ONE batch call without hard-coding the posture
+client-side. The invariant is pinned in the tests.
+
+Pins covered here:
+
+* both batches return one envelope per entry in
+  :data:`_PURCHASABLE_TIERS`, sorted by ``(tier_rank, tier_id)``
+* every batch envelope byte-matches the scalar endpoint body for the
+  same source -- the batch-vs-scalar parity that stops the batch
+  what-if drifting from the scalar what-if
+* per-envelope ``channels`` byte-equals the scalar helper for the same
+  source: ``env["channels"] == next_tier_channel_catalog_at(env["tier"])``
+* cross-batch parity with the spec / diff / unlocks / locks / capacity
+  ``_at_batch`` siblings: the source axis (envelope ``tier`` /
+  ``tier_label`` / ``tier_rank`` and ordering) byte-equals each sibling
+  so a UI can fold all six batches into one matrix
+* at the source-side ceiling (``enterprise`` for next) / floor (``oss``
+  / ``cloud_free`` for previous) the envelope carries ``target=null``
+  and ``channels=[]`` rather than being dropped
+* trial is excluded from the source axis (mirrors the sibling batches)
+* the always-free invariant reaches every row for every purchasable
+  source (row-key set matches ``channel_catalog_at``; every row is
+  ``free=True`` / ``allowed=True`` / ``locked=False`` /
+  ``entitled=True``)
+* per-envelope ``channels`` row count matches ``ALL_CHANNELS`` on every
+  populated envelope
+* per-envelope ``channels`` are sorted alphabetically (byte-identical
+  to the sibling ``channel_catalog_at`` sort)
+* grace vs enforce yields identical rows (the helpers walk the static
+  catalogue, not the gated resolver)
+* the helpers never raise: a per-source builder failure collapses to
+  ``channels=[]`` on the populated envelope; a top-level failure
+  short-circuits to ``[]``
+* the API endpoints never 5xx: a resolver failure yields an empty
+  ``tiers`` list and a grace-shape envelope
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+_ENVELOPE_KEYS = {
+    "tier",
+    "tier_label",
+    "tier_rank",
+    "target",
+    "target_label",
+    "target_rank",
+    "channels",
+}
+
+_ROW_KEYS = {"id", "label", "free", "tier", "allowed", "locked", "entitled"}
+
+_BATCH_RESPONSE_KEYS = {
+    "tiers",
+    "current_tier",
+    "current_tier_rank",
+    "grace",
+    "enforced",
+}
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    """Fresh entitlements module with HOME pointed at an empty tmp dir
+    so no real ~/.clawmetry/license.key or cloud_plan.json leaks in.
+    Enforcement off by default (grace mode) -- the channel catalog
+    ``_at_batch`` family is catalogue-derived and independent of the
+    resolver, so the fixture only needs to keep the live resolver from
+    surprising the test."""
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# ── next_tier_channel_catalog_at_batch ───────────────────────────────────────
+
+
+def test_next_catalog_batch_returns_list_for_every_purchasable_source(ent):
+    rows = ent.next_tier_channel_catalog_at_batch()
+    assert isinstance(rows, list)
+    assert len(rows) == len(ent._PURCHASABLE_TIERS)
+
+
+def test_next_catalog_batch_each_envelope_has_envelope_shape(ent):
+    for env in ent.next_tier_channel_catalog_at_batch():
+        assert set(env.keys()) == _ENVELOPE_KEYS
+
+
+def test_next_catalog_batch_source_axis_matches_purchasable(ent):
+    rows = ent.next_tier_channel_catalog_at_batch()
+    sources = {env["tier"] for env in rows}
+    assert sources == set(ent._PURCHASABLE_TIERS)
+
+
+def test_next_catalog_batch_excludes_trial_from_sources(ent):
+    sources = {env["tier"] for env in ent.next_tier_channel_catalog_at_batch()}
+    assert ent.TIER_TRIAL not in sources
+
+
+def test_next_catalog_batch_sorted_by_rank_then_id(ent):
+    rows = ent.next_tier_channel_catalog_at_batch()
+    keys = [(env["tier_rank"], env["tier"]) for env in rows]
+    assert keys == sorted(keys)
+
+
+def test_next_catalog_batch_enterprise_source_ceiling_collapses(ent):
+    rows = ent.next_tier_channel_catalog_at_batch()
+    ent_row = next(env for env in rows if env["tier"] == ent.TIER_ENTERPRISE)
+    assert ent_row["target"] is None
+    assert ent_row["target_label"] is None
+    assert ent_row["target_rank"] is None
+    assert ent_row["channels"] == []
+
+
+def test_next_catalog_batch_target_axis_is_next_purchasable(ent):
+    for env in ent.next_tier_channel_catalog_at_batch():
+        assert env["target"] == ent._next_purchasable_tier_after(env["tier"])
+
+
+def test_next_catalog_batch_populated_channels_have_row_shape(ent):
+    for env in ent.next_tier_channel_catalog_at_batch():
+        if not env["channels"]:
+            continue
+        for row in env["channels"]:
+            assert set(row.keys()) == _ROW_KEYS, row
+
+
+def test_next_catalog_batch_populated_channels_len_matches_all_channels(ent):
+    for env in ent.next_tier_channel_catalog_at_batch():
+        if env["target"] is None:
+            continue
+        assert len(env["channels"]) == len(ent.ALL_CHANNELS), env["tier"]
+        assert {row["id"] for row in env["channels"]} == set(ent.ALL_CHANNELS)
+
+
+def test_next_catalog_batch_populated_channels_sorted_alphabetically(ent):
+    for env in ent.next_tier_channel_catalog_at_batch():
+        if not env["channels"]:
+            continue
+        assert [row["id"] for row in env["channels"]] == sorted(
+            ent.ALL_CHANNELS
+        )
+
+
+def test_next_catalog_batch_always_free_invariant(ent):
+    # Every chat channel is FREE at every tier -- pinned on every
+    # populated envelope for every purchasable source.
+    for env in ent.next_tier_channel_catalog_at_batch():
+        for row in env["channels"]:
+            assert row["free"] is True, (env["tier"], row)
+            assert row["tier"] == "free", (env["tier"], row)
+            assert row["allowed"] is True, (env["tier"], row)
+            assert row["locked"] is False, (env["tier"], row)
+            assert row["entitled"] is True, (env["tier"], row)
+
+
+def test_next_catalog_batch_channels_byte_equal_scalar_helper(ent):
+    for env in ent.next_tier_channel_catalog_at_batch():
+        scalar = ent.next_tier_channel_catalog_at(env["tier"]) or []
+        assert env["channels"] == scalar, env["tier"]
+
+
+def test_next_catalog_batch_channels_byte_equal_channel_catalog_at_target(
+    ent,
+):
+    for env in ent.next_tier_channel_catalog_at_batch():
+        if env["target"] is None:
+            assert env["channels"] == []
+            continue
+        assert env["channels"] == ent.channel_catalog_at(env["target"])
+
+
+def test_next_catalog_batch_source_axis_matches_spec_batch(ent):
+    # The six ``_at_batch`` siblings (spec / diff / unlocks / locks /
+    # capacity / channel-catalog) MUST agree on the source axis --
+    # envelope ``tier`` / ``tier_label`` / ``tier_rank`` and ordering
+    # -- so a UI can fold the six responses into one matrix without
+    # re-keying.
+    catalog = ent.next_tier_channel_catalog_at_batch()
+    spec = ent.next_tier_spec_at_batch()
+    catalog_keys = [(env["tier_rank"], env["tier"]) for env in catalog]
+    spec_keys = [(env["tier_rank"], env["tier"]) for env in spec]
+    assert catalog_keys == spec_keys
+
+
+def test_next_catalog_batch_target_axis_matches_spec_batch(ent):
+    # The target a UI lands on at each rung MUST agree across the
+    # ``_at_batch`` siblings -- otherwise catalog / spec would render
+    # different upgrade rungs in the same matrix row.
+    catalog = {
+        env["tier"]: env for env in ent.next_tier_channel_catalog_at_batch()
+    }
+    spec = {env["tier"]: env for env in ent.next_tier_spec_at_batch()}
+    assert set(catalog.keys()) == set(spec.keys())
+    for tier in catalog:
+        assert catalog[tier]["target"] == spec[tier]["target"], tier
+        assert catalog[tier]["target_rank"] == spec[tier]["target_rank"], tier
+        assert (
+            catalog[tier]["target_label"] == spec[tier]["target_label"]
+        ), tier
+
+
+def test_next_catalog_batch_grace_and_enforce_match(ent, monkeypatch):
+    grace = ent.next_tier_channel_catalog_at_batch()
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    importlib.reload(ent)
+    ent.invalidate()
+    enforce = ent.next_tier_channel_catalog_at_batch()
+    assert enforce == grace
+
+
+def test_next_catalog_batch_top_level_failure_short_circuits_to_empty(
+    ent, monkeypatch
+):
+    class Boom:
+        def __iter__(self):
+            raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "_PURCHASABLE_TIERS", Boom())
+    assert ent.next_tier_channel_catalog_at_batch() == []
+
+
+def test_next_catalog_batch_per_row_failure_collapses_to_channels_empty(
+    ent, monkeypatch
+):
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "channel_catalog_at", boom)
+    rows = ent.next_tier_channel_catalog_at_batch()
+    assert rows
+    for env in rows:
+        assert set(env.keys()) == _ENVELOPE_KEYS
+        assert env["channels"] == []
+
+
+def test_next_catalog_batch_independent_of_resolver(ent, monkeypatch):
+    def boom(*_, **__):
+        raise RuntimeError("resolver must not be reached")
+
+    monkeypatch.setattr(ent, "get_entitlement", boom)
+    rows = ent.next_tier_channel_catalog_at_batch()
+    assert len(rows) == len(ent._PURCHASABLE_TIERS)
+
+
+# ── previous_tier_channel_catalog_at_batch ───────────────────────────────────
+
+
+def test_prev_catalog_batch_returns_list_for_every_purchasable_source(ent):
+    rows = ent.previous_tier_channel_catalog_at_batch()
+    assert isinstance(rows, list)
+    assert len(rows) == len(ent._PURCHASABLE_TIERS)
+
+
+def test_prev_catalog_batch_each_envelope_has_envelope_shape(ent):
+    for env in ent.previous_tier_channel_catalog_at_batch():
+        assert set(env.keys()) == _ENVELOPE_KEYS
+
+
+def test_prev_catalog_batch_source_axis_matches_purchasable(ent):
+    rows = ent.previous_tier_channel_catalog_at_batch()
+    sources = {env["tier"] for env in rows}
+    assert sources == set(ent._PURCHASABLE_TIERS)
+
+
+def test_prev_catalog_batch_excludes_trial_from_sources(ent):
+    sources = {
+        env["tier"] for env in ent.previous_tier_channel_catalog_at_batch()
+    }
+    assert ent.TIER_TRIAL not in sources
+
+
+def test_prev_catalog_batch_sorted_by_rank_then_id(ent):
+    rows = ent.previous_tier_channel_catalog_at_batch()
+    keys = [(env["tier_rank"], env["tier"]) for env in rows]
+    assert keys == sorted(keys)
+
+
+def test_prev_catalog_batch_floor_sources_collapse(ent):
+    rows = {env["tier"]: env for env in ent.previous_tier_channel_catalog_at_batch()}
+    for floor in (ent.TIER_OSS, ent.TIER_CLOUD_FREE):
+        env = rows[floor]
+        assert env["target"] is None
+        assert env["target_label"] is None
+        assert env["target_rank"] is None
+        assert env["channels"] == []
+
+
+def test_prev_catalog_batch_target_axis_is_previous_purchasable(ent):
+    for env in ent.previous_tier_channel_catalog_at_batch():
+        assert env["target"] == ent._previous_purchasable_tier_before(
+            env["tier"]
+        )
+
+
+def test_prev_catalog_batch_populated_channels_have_row_shape(ent):
+    for env in ent.previous_tier_channel_catalog_at_batch():
+        if not env["channels"]:
+            continue
+        for row in env["channels"]:
+            assert set(row.keys()) == _ROW_KEYS, row
+
+
+def test_prev_catalog_batch_populated_channels_len_matches_all_channels(ent):
+    for env in ent.previous_tier_channel_catalog_at_batch():
+        if env["target"] is None:
+            continue
+        assert len(env["channels"]) == len(ent.ALL_CHANNELS), env["tier"]
+        assert {row["id"] for row in env["channels"]} == set(ent.ALL_CHANNELS)
+
+
+def test_prev_catalog_batch_populated_channels_sorted_alphabetically(ent):
+    for env in ent.previous_tier_channel_catalog_at_batch():
+        if not env["channels"]:
+            continue
+        assert [row["id"] for row in env["channels"]] == sorted(
+            ent.ALL_CHANNELS
+        )
+
+
+def test_prev_catalog_batch_always_free_invariant(ent):
+    for env in ent.previous_tier_channel_catalog_at_batch():
+        for row in env["channels"]:
+            assert row["free"] is True, (env["tier"], row)
+            assert row["tier"] == "free", (env["tier"], row)
+            assert row["allowed"] is True, (env["tier"], row)
+            assert row["locked"] is False, (env["tier"], row)
+            assert row["entitled"] is True, (env["tier"], row)
+
+
+def test_prev_catalog_batch_channels_byte_equal_scalar_helper(ent):
+    for env in ent.previous_tier_channel_catalog_at_batch():
+        scalar = ent.previous_tier_channel_catalog_at(env["tier"]) or []
+        assert env["channels"] == scalar, env["tier"]
+
+
+def test_prev_catalog_batch_channels_byte_equal_channel_catalog_at_target(
+    ent,
+):
+    for env in ent.previous_tier_channel_catalog_at_batch():
+        if env["target"] is None:
+            assert env["channels"] == []
+            continue
+        assert env["channels"] == ent.channel_catalog_at(env["target"])
+
+
+def test_prev_catalog_batch_source_axis_matches_spec_batch(ent):
+    catalog = ent.previous_tier_channel_catalog_at_batch()
+    spec = ent.previous_tier_spec_at_batch()
+    catalog_keys = [(env["tier_rank"], env["tier"]) for env in catalog]
+    spec_keys = [(env["tier_rank"], env["tier"]) for env in spec]
+    assert catalog_keys == spec_keys
+
+
+def test_prev_catalog_batch_target_axis_matches_spec_batch(ent):
+    catalog = {
+        env["tier"]: env
+        for env in ent.previous_tier_channel_catalog_at_batch()
+    }
+    spec = {env["tier"]: env for env in ent.previous_tier_spec_at_batch()}
+    assert set(catalog.keys()) == set(spec.keys())
+    for tier in catalog:
+        assert catalog[tier]["target"] == spec[tier]["target"], tier
+        assert catalog[tier]["target_rank"] == spec[tier]["target_rank"], tier
+        assert (
+            catalog[tier]["target_label"] == spec[tier]["target_label"]
+        ), tier
+
+
+def test_prev_catalog_batch_grace_and_enforce_match(ent, monkeypatch):
+    grace = ent.previous_tier_channel_catalog_at_batch()
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    importlib.reload(ent)
+    ent.invalidate()
+    enforce = ent.previous_tier_channel_catalog_at_batch()
+    assert enforce == grace
+
+
+def test_prev_catalog_batch_top_level_failure_short_circuits_to_empty(
+    ent, monkeypatch
+):
+    class Boom:
+        def __iter__(self):
+            raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "_PURCHASABLE_TIERS", Boom())
+    assert ent.previous_tier_channel_catalog_at_batch() == []
+
+
+def test_prev_catalog_batch_per_row_failure_collapses_to_channels_empty(
+    ent, monkeypatch
+):
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "channel_catalog_at", boom)
+    rows = ent.previous_tier_channel_catalog_at_batch()
+    assert rows
+    for env in rows:
+        assert set(env.keys()) == _ENVELOPE_KEYS
+        assert env["channels"] == []
+
+
+def test_prev_catalog_batch_independent_of_resolver(ent, monkeypatch):
+    def boom(*_, **__):
+        raise RuntimeError("resolver must not be reached")
+
+    monkeypatch.setattr(ent, "get_entitlement", boom)
+    rows = ent.previous_tier_channel_catalog_at_batch()
+    assert len(rows) == len(ent._PURCHASABLE_TIERS)
+
+
+# ── API: /api/entitlement/next-tier-channel-catalog-at-batch ─────────────────
+
+
+def test_next_catalog_batch_endpoint_returns_envelopes(client, ent):
+    rv = client.get("/api/entitlement/next-tier-channel-catalog-at-batch")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert set(body.keys()) == _BATCH_RESPONSE_KEYS
+    assert isinstance(body["tiers"], list)
+    assert len(body["tiers"]) == len(ent._PURCHASABLE_TIERS)
+    for env in body["tiers"]:
+        assert set(env.keys()) == _ENVELOPE_KEYS
+
+
+def test_next_catalog_batch_endpoint_resolver_context(client, ent):
+    rv = client.get("/api/entitlement/next-tier-channel-catalog-at-batch")
+    body = rv.get_json()
+    resolved = ent.get_entitlement()
+    assert body["current_tier"] == resolved.tier
+    assert body["current_tier_rank"] == ent.tier_rank(resolved.tier)
+    assert body["grace"] == bool(resolved.grace)
+    assert body["enforced"] == ent.is_enforced()
+
+
+def test_next_catalog_batch_endpoint_matches_helper(client, ent):
+    rv = client.get("/api/entitlement/next-tier-channel-catalog-at-batch")
+    assert rv.get_json()["tiers"] == ent.next_tier_channel_catalog_at_batch()
+
+
+def test_next_catalog_batch_endpoint_matches_scalar_per_source(client, ent):
+    batch = client.get(
+        "/api/entitlement/next-tier-channel-catalog-at-batch"
+    ).get_json()["tiers"]
+    by_tier = {env["tier"]: env for env in batch}
+    for src in ent._PURCHASABLE_TIERS:
+        scalar = client.get(
+            f"/api/entitlement/next-tier-channel-catalog-at?tier={src}"
+        ).get_json()
+        assert by_tier[src] == scalar
+
+
+def test_next_catalog_batch_endpoint_always_free_invariant(client, ent):
+    body = client.get(
+        "/api/entitlement/next-tier-channel-catalog-at-batch"
+    ).get_json()
+    for env in body["tiers"]:
+        for row in env["channels"]:
+            assert row["free"] is True, (env["tier"], row)
+            assert row["locked"] is False, (env["tier"], row)
+            assert row["entitled"] is True, (env["tier"], row)
+
+
+def test_next_catalog_batch_endpoint_never_raises(client, ent, monkeypatch):
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "next_tier_channel_catalog_at_batch", boom)
+    rv = client.get("/api/entitlement/next-tier-channel-catalog-at-batch")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["tiers"] == []
+    assert body["current_tier"] == "oss"
+    assert body["current_tier_rank"] == 0
+    assert body["grace"] is True
+    assert body["enforced"] is False
+
+
+# ── API: /api/entitlement/previous-tier-channel-catalog-at-batch ─────────────
+
+
+def test_prev_catalog_batch_endpoint_returns_envelopes(client, ent):
+    rv = client.get(
+        "/api/entitlement/previous-tier-channel-catalog-at-batch"
+    )
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert set(body.keys()) == _BATCH_RESPONSE_KEYS
+    assert isinstance(body["tiers"], list)
+    assert len(body["tiers"]) == len(ent._PURCHASABLE_TIERS)
+
+
+def test_prev_catalog_batch_endpoint_resolver_context(client, ent):
+    rv = client.get(
+        "/api/entitlement/previous-tier-channel-catalog-at-batch"
+    )
+    body = rv.get_json()
+    resolved = ent.get_entitlement()
+    assert body["current_tier"] == resolved.tier
+    assert body["current_tier_rank"] == ent.tier_rank(resolved.tier)
+    assert body["grace"] == bool(resolved.grace)
+    assert body["enforced"] == ent.is_enforced()
+
+
+def test_prev_catalog_batch_endpoint_matches_helper(client, ent):
+    rv = client.get(
+        "/api/entitlement/previous-tier-channel-catalog-at-batch"
+    )
+    assert (
+        rv.get_json()["tiers"] == ent.previous_tier_channel_catalog_at_batch()
+    )
+
+
+def test_prev_catalog_batch_endpoint_matches_scalar_per_source(client, ent):
+    batch = client.get(
+        "/api/entitlement/previous-tier-channel-catalog-at-batch"
+    ).get_json()["tiers"]
+    by_tier = {env["tier"]: env for env in batch}
+    for src in ent._PURCHASABLE_TIERS:
+        scalar = client.get(
+            f"/api/entitlement/previous-tier-channel-catalog-at?tier={src}"
+        ).get_json()
+        assert by_tier[src] == scalar
+
+
+def test_prev_catalog_batch_endpoint_always_free_invariant(client, ent):
+    body = client.get(
+        "/api/entitlement/previous-tier-channel-catalog-at-batch"
+    ).get_json()
+    for env in body["tiers"]:
+        for row in env["channels"]:
+            assert row["free"] is True, (env["tier"], row)
+            assert row["locked"] is False, (env["tier"], row)
+            assert row["entitled"] is True, (env["tier"], row)
+
+
+def test_prev_catalog_batch_endpoint_never_raises(client, ent, monkeypatch):
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "previous_tier_channel_catalog_at_batch", boom)
+    rv = client.get(
+        "/api/entitlement/previous-tier-channel-catalog-at-batch"
+    )
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["tiers"] == []
+    assert body["current_tier"] == "oss"
+    assert body["current_tier_rank"] == 0
+    assert body["grace"] is True
+    assert body["enforced"] is False


### PR DESCRIPTION
## Summary

- Batch siblings of the source-anchored channel-axis catalog helpers (#3621) walking every purchasable source rung in one pass. Adds `next_tier_channel_catalog_at_batch` / `previous_tier_channel_catalog_at_batch` helpers and `GET /api/entitlement/next-tier-channel-catalog-at-batch` + `previous-tier-channel-catalog-at-batch` endpoints.
- Channel-axis catalog analogue of `next/previous_tier_spec_at_batch`. Per-envelope shape matches the source-anchored scalar endpoint (`tier` / `tier_label` / `tier_rank` / `target` / `target_label` / `target_rank` / `channels`); source axis is `_PURCHASABLE_TIERS` (trial excluded), sorted by `(tier_rank, tier_id)` — byte-stable against the sibling spec/diff/unlocks/locks/capacity `_at_batch` helpers so a UI can fold six batches into one pricing matrix without re-sorting client-side.
- Every chat channel is FREE at every tier, so every populated `channels` row comes back `free=True` / `locked=False` / `entitled=True` regardless of the target rung — the pricing surface renders "chat channel included at every plan" off ONE call without hard-coding the posture client-side. Pinned in the tests.

## Test plan

- [x] `python3 -m pytest tests/test_entitlement_next_prev_tier_channel_catalog_at_batch.py` — 50/50 green
- [x] Broader entitlement suite (`pytest -k entitlement`) still green: 5552 passed, 4 skipped (1 unrelated collection error, missing `duckdb` in sandbox)
- [x] `ruff check clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_next_prev_tier_channel_catalog_at_batch.py` — clean
- [x] `python3 -c "import ast; ast.parse(...)"` on both edited source files — OK
- [x] Live-flask sanity: `GET /api/entitlement/next-tier-channel-catalog-at-batch` → 200 with 6 envelopes (one per purchasable source), enterprise ceiling collapses to `target=null` / `channels=[]`; symmetric shape on the previous endpoint with `oss` / `cloud_free` collapsing.

## Coverage pinned by the new tests (50 total)

- Batch source axis matches `_PURCHASABLE_TIERS`, sorted `(tier_rank, tier_id)`, `trial` excluded
- Per-envelope `channels` byte-equals scalar `next/previous_tier_channel_catalog_at(source)` and (at target) `channel_catalog_at(target)`
- Ceiling / floor collapse (`target=null`, `channels=[]`) on `enterprise` / `oss` / `cloud_free`
- Cross-batch parity with `next/previous_tier_spec_at_batch` on both source and target axes
- Always-free invariant on every populated row for every purchasable source
- Row schema / row count matches `ALL_CHANNELS`, alphabetical sort
- Grace vs enforce byte-identical
- Top-level failure → `[]`; per-row builder failure → `channels=[]`; resolver-independence
- Endpoint envelope keys, endpoint-to-helper parity, endpoint-to-scalar-per-source parity, never-5xx envelope

## Local operator verification checklist

Since this fires from a remote container with no access to the local daemon, live cloud snapshot, or a browser, the local operator handles verification before flipping the PR to ready-for-review:

- [ ] Copy the changed files into `~/.clawmetry/lib/pythonX.Y/site-packages/clawmetry/` (or reinstall the wheel)
- [ ] Clear `__pycache__` (`find ~/.clawmetry -name __pycache__ -exec rm -rf {} +`)
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` (and `com.clawmetry.dashboard` if separate)
- [ ] `curl -s http://localhost:8900/api/entitlement/next-tier-channel-catalog-at-batch | jq .` — expect 6 envelopes, enterprise-as-source collapsed to `target=null` / `channels=[]`
- [ ] `curl -s http://localhost:8900/api/entitlement/previous-tier-channel-catalog-at-batch | jq .` — expect 6 envelopes, `oss` / `cloud_free` collapsed to `target=null` / `channels=[]`
- [ ] Decrypt the live cloud snapshot and confirm the pricing-preview panel that consumes the source-anchored channel catalog still renders identically at the resolved source rung (helper preserves scalar parity — no UX diff)
- [ ] Browser-check the pricing / upgrade / downgrade panels for any client-side crash on the new batch response shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YPshe4oo8Va698AbYtat1Z


---
_Generated by [Claude Code](https://claude.ai/code/session_01YPshe4oo8Va698AbYtat1Z)_