### PR TITLE
feat(entitlement): next/previous_tier_feature/runtime_catalog_at_batch + 4 endpoints

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -10028,6 +10028,291 @@ def previous_tier_runtime_catalog_at(tier: str) -> list[dict] | None:
         return None
 
 
+def _feature_catalog_at_envelope(source: str, target: str | None) -> dict:
+    """Private builder for the ``{next,previous}_tier_feature_catalog_at_batch``
+    rows.
+
+    Feature-axis catalog mirror of :func:`_capacity_diff_at_envelope` and
+    :func:`_diff_at_envelope`: envelope shape matches the scalar
+    ``/api/entitlement/{next,previous}-tier-feature-catalog-at`` endpoint
+    (``tier``, ``tier_label``, ``tier_rank``, ``target``, ``target_label``,
+    ``target_rank``, ``features``) so a UI can fold the scalar and batch
+    responses without re-keying. ``features`` collapses to ``[]`` at the
+    ladder ceiling / floor of the source axis (``target is None``) and on
+    a builder failure -- the batch keeps the per-source envelope visible
+    even when its per-pair catalogue could not be built. Never raises --
+    every fallback yields a fully-populated envelope with ``features=[]``.
+    """
+    src = (source or "").strip().lower()
+    rows: list[dict] = []
+    if target is not None:
+        try:
+            rows = feature_catalog_at(target) or []
+        except Exception as exc:
+            logger.warning(
+                "entitlements: _feature_catalog_at_envelope builder failed for %s->%s: %s",
+                src,
+                target,
+                exc,
+            )
+            rows = []
+    return {
+        "tier": src,
+        "tier_label": tier_label(src) if src in _TIER_ORDER else None,
+        "tier_rank": tier_rank(src) if src in _TIER_ORDER else -1,
+        "target": target,
+        "target_label": tier_label(target) if target else None,
+        "target_rank": tier_rank(target) if target else None,
+        "features": rows,
+    }
+
+
+def next_tier_feature_catalog_at_batch() -> list[dict]:
+    """Batch sibling of :func:`next_tier_feature_catalog_at`: one
+    ``next-tier-feature-catalog-at`` envelope per purchasable source
+    tier, in one pass.
+
+    Feature-axis catalog analogue of :func:`next_tier_capacity_diff_at_batch`
+    (capacity-only narrow lens) / :func:`next_tier_diff_at_batch` (full
+    diff): walks the source axis and returns the full
+    :func:`feature_catalog_at` catalogue for the rung above each
+    purchasable source. Lets a pricing-comparison matrix UI render the
+    "features at the rung above each rung" upgrade-preview column off
+    **one** round-trip instead of N calls to
+    :func:`next_tier_feature_catalog_at`.
+
+    Per-envelope shape matches the source-anchored scalar endpoint
+    ``/api/entitlement/next-tier-feature-catalog-at?tier=<source>``
+    (``tier``, ``tier_label``, ``tier_rank``, ``target``, ``target_label``,
+    ``target_rank``, ``features``) -- a parity test pins this so the
+    batch what-if cannot drift from the scalar what-if (the same
+    invariant :func:`next_tier_capacity_diff_at_batch` enforces against
+    :func:`next_tier_capacity_diff_at`). Inner ``features`` byte-equals
+    :func:`feature_catalog_at(target)` for the resolved target.
+
+    Envelopes are sorted by source ``(tier_rank, tier_id)`` ascending
+    -- byte-stable against :func:`next_tier_diff_at_batch` /
+    :func:`next_tier_unlocks_at_batch` / :func:`next_tier_locks_at_batch`
+    / :func:`next_tier_capacity_diff_at_batch` so a UI can fold the
+    responses into one matrix without re-sorting client-side.
+    Same-rank sibling tiers (``cloud_pro`` / ``pro`` both at rank 2) are
+    both returned.
+
+    Source list is :data:`_PURCHASABLE_TIERS` (trial excluded),
+    matching the sibling ``_at_batch`` helpers. The source-side ceiling
+    (``enterprise`` as source -- no rung strictly above) surfaces with
+    ``target=None`` and ``features=[]`` rather than being dropped, so
+    the matrix keeps a row for every purchasable rung.
+
+    Decoupled from the resolved entitlement (walks the static
+    catalogue), so grace vs enforce yields identical rows.
+
+    Never raises: a per-source builder failure collapses to
+    ``features=[]`` on the populated envelope so the surrounding
+    envelope stays visible; an unexpected top-level failure short-
+    circuits to ``[]`` so the matrix keeps rendering instead of
+    breaking.
+    """
+    try:
+        out: list[dict] = []
+        ordered = sorted(
+            _PURCHASABLE_TIERS, key=lambda t: (_TIER_RANK.get(t, -1), t)
+        )
+        for tid in ordered:
+            target = _next_purchasable_tier_after(tid)
+            out.append(_feature_catalog_at_envelope(tid, target))
+        return out
+    except Exception as exc:
+        logger.warning(
+            "entitlements: next_tier_feature_catalog_at_batch failed: %s", exc
+        )
+        return []
+
+
+def previous_tier_feature_catalog_at_batch() -> list[dict]:
+    """Batch sibling of :func:`previous_tier_feature_catalog_at`: one
+    ``previous-tier-feature-catalog-at`` envelope per purchasable source
+    tier, in one pass.
+
+    Source-anchored downgrade-side mirror of
+    :func:`next_tier_feature_catalog_at_batch` and feature-axis catalog
+    analogue of :func:`previous_tier_capacity_diff_at_batch`. Lets a
+    pricing-comparison matrix UI render the "features at the rung below
+    each rung" downgrade-preview column off **one** round-trip instead
+    of N calls to :func:`previous_tier_feature_catalog_at`.
+
+    Per-envelope shape matches the source-anchored scalar endpoint
+    ``/api/entitlement/previous-tier-feature-catalog-at?tier=<source>``
+    byte-for-byte -- a parity test pins this so the batch what-if
+    cannot drift from the scalar what-if. Inner ``features`` byte-equals
+    :func:`feature_catalog_at(target)` for the resolved target.
+
+    Envelopes are sorted by source ``(tier_rank, tier_id)`` ascending
+    -- byte-stable against :func:`previous_tier_diff_at_batch` /
+    :func:`previous_tier_unlocks_at_batch` /
+    :func:`previous_tier_locks_at_batch` /
+    :func:`previous_tier_capacity_diff_at_batch` so a UI can fold the
+    responses into one matrix without re-sorting client-side.
+
+    Source list is :data:`_PURCHASABLE_TIERS` (trial excluded). The
+    source-side floor (``oss`` / ``cloud_free`` as source -- no rung
+    strictly below) surfaces with ``target=None`` and ``features=[]``
+    rather than being dropped, so the matrix keeps a row for every
+    purchasable rung.
+
+    Decoupled from the resolved entitlement (walks the static
+    catalogue), so grace vs enforce yields identical rows.
+
+    Never raises: a per-source builder failure collapses to
+    ``features=[]`` on the populated envelope so the surrounding
+    envelope stays visible; an unexpected top-level failure short-
+    circuits to ``[]`` so the matrix keeps rendering.
+    """
+    try:
+        out: list[dict] = []
+        ordered = sorted(
+            _PURCHASABLE_TIERS, key=lambda t: (_TIER_RANK.get(t, -1), t)
+        )
+        for tid in ordered:
+            target = _previous_purchasable_tier_before(tid)
+            out.append(_feature_catalog_at_envelope(tid, target))
+        return out
+    except Exception as exc:
+        logger.warning(
+            "entitlements: previous_tier_feature_catalog_at_batch failed: %s",
+            exc,
+        )
+        return []
+
+
+def _runtime_catalog_at_envelope(source: str, target: str | None) -> dict:
+    """Private builder for the ``{next,previous}_tier_runtime_catalog_at_batch``
+    rows.
+
+    Runtime-axis catalog mirror of :func:`_feature_catalog_at_envelope`:
+    envelope shape matches the scalar
+    ``/api/entitlement/{next,previous}-tier-runtime-catalog-at`` endpoint
+    (``tier``, ``tier_label``, ``tier_rank``, ``target``, ``target_label``,
+    ``target_rank``, ``runtimes``) so a UI can fold the scalar and batch
+    responses without re-keying. ``runtimes`` collapses to ``[]`` at the
+    ladder ceiling / floor of the source axis (``target is None``) and on
+    a builder failure. Never raises.
+    """
+    src = (source or "").strip().lower()
+    rows: list[dict] = []
+    if target is not None:
+        try:
+            rows = runtime_catalog_at(target) or []
+        except Exception as exc:
+            logger.warning(
+                "entitlements: _runtime_catalog_at_envelope builder failed for %s->%s: %s",
+                src,
+                target,
+                exc,
+            )
+            rows = []
+    return {
+        "tier": src,
+        "tier_label": tier_label(src) if src in _TIER_ORDER else None,
+        "tier_rank": tier_rank(src) if src in _TIER_ORDER else -1,
+        "target": target,
+        "target_label": tier_label(target) if target else None,
+        "target_rank": tier_rank(target) if target else None,
+        "runtimes": rows,
+    }
+
+
+def next_tier_runtime_catalog_at_batch() -> list[dict]:
+    """Batch sibling of :func:`next_tier_runtime_catalog_at`: one
+    ``next-tier-runtime-catalog-at`` envelope per purchasable source
+    tier, in one pass.
+
+    Runtime-axis catalog analogue of
+    :func:`next_tier_feature_catalog_at_batch` (feature axis) and
+    :func:`next_tier_capacity_diff_at_batch` (capacity axis): walks the
+    source axis and returns the full :func:`runtime_catalog_at`
+    catalogue for the rung above each purchasable source. Lets a
+    pricing-comparison matrix UI render the "runtimes at the rung above
+    each rung" upgrade-preview column off **one** round-trip instead of
+    N calls to :func:`next_tier_runtime_catalog_at`.
+
+    Per-envelope shape matches the source-anchored scalar endpoint
+    ``/api/entitlement/next-tier-runtime-catalog-at?tier=<source>``
+    (``tier``, ``tier_label``, ``tier_rank``, ``target``, ``target_label``,
+    ``target_rank``, ``runtimes``) -- pinned by a parity test. Inner
+    ``runtimes`` byte-equals :func:`runtime_catalog_at(target)` for the
+    resolved target.
+
+    Envelopes are sorted by source ``(tier_rank, tier_id)`` ascending
+    -- byte-stable against every other ``next_*_at_batch`` sibling so a
+    UI can fold responses into one matrix without re-sorting.
+
+    Source list is :data:`_PURCHASABLE_TIERS` (trial excluded). The
+    source-side ceiling (``enterprise`` as source) surfaces with
+    ``target=None`` / ``runtimes=[]`` rather than being dropped.
+
+    Decoupled from the resolved entitlement, so grace vs enforce yields
+    identical rows. Never raises: per-source builder failure collapses
+    to ``runtimes=[]``; top-level failure short-circuits to ``[]``.
+    """
+    try:
+        out: list[dict] = []
+        ordered = sorted(
+            _PURCHASABLE_TIERS, key=lambda t: (_TIER_RANK.get(t, -1), t)
+        )
+        for tid in ordered:
+            target = _next_purchasable_tier_after(tid)
+            out.append(_runtime_catalog_at_envelope(tid, target))
+        return out
+    except Exception as exc:
+        logger.warning(
+            "entitlements: next_tier_runtime_catalog_at_batch failed: %s", exc
+        )
+        return []
+
+
+def previous_tier_runtime_catalog_at_batch() -> list[dict]:
+    """Batch sibling of :func:`previous_tier_runtime_catalog_at`: one
+    ``previous-tier-runtime-catalog-at`` envelope per purchasable source
+    tier, in one pass.
+
+    Source-anchored downgrade-side mirror of
+    :func:`next_tier_runtime_catalog_at_batch` and runtime-axis catalog
+    analogue of :func:`previous_tier_feature_catalog_at_batch`. Lets a
+    pricing-comparison matrix UI render the "runtimes at the rung below
+    each rung" downgrade-preview column off **one** round-trip.
+
+    Per-envelope shape matches
+    ``/api/entitlement/previous-tier-runtime-catalog-at?tier=<source>``
+    byte-for-byte -- pinned by a parity test. Envelopes sorted by
+    source ``(tier_rank, tier_id)`` ascending, matching the sibling
+    ``previous_*_at_batch`` helpers.
+
+    Source list is :data:`_PURCHASABLE_TIERS` (trial excluded). The
+    source-side floor (``oss`` / ``cloud_free`` as source) surfaces
+    with ``target=None`` / ``runtimes=[]``.
+
+    Decoupled from the resolved entitlement, so grace vs enforce yields
+    identical rows. Never raises: per-source builder failure collapses
+    to ``runtimes=[]``; top-level failure short-circuits to ``[]``.
+    """
+    try:
+        out: list[dict] = []
+        ordered = sorted(
+            _PURCHASABLE_TIERS, key=lambda t: (_TIER_RANK.get(t, -1), t)
+        )
+        for tid in ordered:
+            target = _previous_purchasable_tier_before(tid)
+            out.append(_runtime_catalog_at_envelope(tid, target))
+        return out
+    except Exception as exc:
+        logger.warning(
+            "entitlements: previous_tier_runtime_catalog_at_batch failed: %s",
+            exc,
+        )
+        return []
+
+
 def next_tier_lock_reason_at(
     tier: str, item, *, kind: str | None = None
 ) -> str | None:

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -19049,3 +19049,267 @@ def api_entitlement_previous_tier_runtime_catalog_at():
                 "runtimes": [],
             }
         )
+
+
+@bp_entitlement.route("/api/entitlement/next-tier-feature-catalog-at-batch")
+def api_entitlement_next_tier_feature_catalog_at_batch():
+    """``GET /api/entitlement/next-tier-feature-catalog-at-batch`` --
+    batch sibling of ``/api/entitlement/next-tier-feature-catalog-at``:
+    one ``next-tier-feature-catalog-at`` envelope per purchasable source
+    tier, in one round-trip.
+
+    Feature-axis catalog analogue of
+    ``/api/entitlement/next-tier-capacity-diff-at-batch`` (capacity-only
+    narrow lens) / ``/api/entitlement/next-tier-diff-at-batch`` (full
+    diff). Lets a pricing-comparison matrix UI render the "features at
+    the rung above each rung" upgrade-preview column off **one** call
+    instead of N calls to ``/next-tier-feature-catalog-at``.
+
+    No query params. The source list is
+    :data:`entitlements._PURCHASABLE_TIERS` (trial excluded), matching
+    the sibling diff / unlocks / locks / capacity ``_at_batch``
+    endpoints, so the batches fold into the same pricing-page table
+    byte-for-byte on the source axis.
+
+    Response shape::
+
+        {
+          "tiers":             [<envelope>, ...],
+          "current_tier":      "<resolved tier id>",
+          "current_tier_rank": <int>,
+          "grace":             <bool>,
+          "enforced":          <bool>,
+        }
+
+    Each ``<envelope>`` matches
+    ``/api/entitlement/next-tier-feature-catalog-at?tier=<source>`` for
+    that source exactly (``tier``, ``tier_label``, ``tier_rank``,
+    ``target``, ``target_label``, ``target_rank``, ``features``). The
+    inner ``features`` list carries the :func:`feature_catalog_at` rows
+    for the resolved target and is pinned byte-for-byte across both
+    endpoints. At the source-side ceiling (``enterprise`` as source --
+    no rung strictly above) the envelope carries ``target=null`` and
+    ``features=[]`` rather than being dropped, so the matrix keeps a
+    row for every purchasable rung.
+
+    - **Never 5xxs**: a resolver failure yields an empty ``tiers`` list
+      and the grace-shape envelope so the matrix keeps rendering.
+    """
+    try:
+        from clawmetry import entitlements as _ent
+
+        rows = _ent.next_tier_feature_catalog_at_batch() or []
+        ent = _ent.get_entitlement()
+        return jsonify(
+            {
+                "tiers": rows,
+                "current_tier": ent.tier,
+                "current_tier_rank": _ent.tier_rank(ent.tier),
+                "grace": bool(ent.grace),
+                "enforced": _ent.is_enforced(),
+            }
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_next_tier_feature_catalog_at_batch: error: %s",
+            exc,
+        )
+        return jsonify(
+            {
+                "tiers": [],
+                "current_tier": "oss",
+                "current_tier_rank": 0,
+                "grace": True,
+                "enforced": False,
+            }
+        )
+
+
+@bp_entitlement.route("/api/entitlement/previous-tier-feature-catalog-at-batch")
+def api_entitlement_previous_tier_feature_catalog_at_batch():
+    """``GET /api/entitlement/previous-tier-feature-catalog-at-batch`` --
+    batch sibling of ``/api/entitlement/previous-tier-feature-catalog-at``:
+    one ``previous-tier-feature-catalog-at`` envelope per purchasable
+    source tier, in one round-trip.
+
+    Source-anchored downgrade-side mirror of
+    ``/api/entitlement/next-tier-feature-catalog-at-batch`` and
+    feature-axis catalog analogue of
+    ``/api/entitlement/previous-tier-capacity-diff-at-batch``. Lets a
+    pricing-comparison matrix UI render the "features at the rung below
+    each rung" downgrade-preview column off **one** call.
+
+    No query params. Source list is
+    :data:`entitlements._PURCHASABLE_TIERS` (trial excluded).
+
+    Response shape::
+
+        {
+          "tiers":             [<envelope>, ...],
+          "current_tier":      "<resolved tier id>",
+          "current_tier_rank": <int>,
+          "grace":             <bool>,
+          "enforced":          <bool>,
+        }
+
+    Each ``<envelope>`` matches
+    ``/api/entitlement/previous-tier-feature-catalog-at?tier=<source>``
+    for that source exactly. At the source-side floor (``oss`` /
+    ``cloud_free`` as source -- no rung strictly below) the envelope
+    carries ``target=null`` and ``features=[]`` rather than being
+    dropped.
+
+    - **Never 5xxs**: resolver failure yields an empty ``tiers`` list
+      and the grace-shape envelope.
+    """
+    try:
+        from clawmetry import entitlements as _ent
+
+        rows = _ent.previous_tier_feature_catalog_at_batch() or []
+        ent = _ent.get_entitlement()
+        return jsonify(
+            {
+                "tiers": rows,
+                "current_tier": ent.tier,
+                "current_tier_rank": _ent.tier_rank(ent.tier),
+                "grace": bool(ent.grace),
+                "enforced": _ent.is_enforced(),
+            }
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_previous_tier_feature_catalog_at_batch: error: %s",
+            exc,
+        )
+        return jsonify(
+            {
+                "tiers": [],
+                "current_tier": "oss",
+                "current_tier_rank": 0,
+                "grace": True,
+                "enforced": False,
+            }
+        )
+
+
+@bp_entitlement.route("/api/entitlement/next-tier-runtime-catalog-at-batch")
+def api_entitlement_next_tier_runtime_catalog_at_batch():
+    """``GET /api/entitlement/next-tier-runtime-catalog-at-batch`` --
+    batch sibling of ``/api/entitlement/next-tier-runtime-catalog-at``:
+    one ``next-tier-runtime-catalog-at`` envelope per purchasable source
+    tier, in one round-trip.
+
+    Runtime-axis catalog analogue of
+    ``/api/entitlement/next-tier-feature-catalog-at-batch`` (feature
+    axis) and ``/api/entitlement/next-tier-capacity-diff-at-batch``
+    (capacity axis). Lets a pricing-comparison matrix UI render the
+    "runtimes at the rung above each rung" upgrade-preview column off
+    **one** call.
+
+    No query params. Source list is
+    :data:`entitlements._PURCHASABLE_TIERS` (trial excluded).
+
+    Response shape::
+
+        {
+          "tiers":             [<envelope>, ...],
+          "current_tier":      "<resolved tier id>",
+          "current_tier_rank": <int>,
+          "grace":             <bool>,
+          "enforced":          <bool>,
+        }
+
+    Each ``<envelope>`` matches
+    ``/api/entitlement/next-tier-runtime-catalog-at?tier=<source>`` for
+    that source exactly (``tier``, ``tier_label``, ``tier_rank``,
+    ``target``, ``target_label``, ``target_rank``, ``runtimes``). At the
+    source-side ceiling the envelope carries ``target=null`` and
+    ``runtimes=[]`` rather than being dropped.
+
+    - **Never 5xxs**: resolver failure yields an empty ``tiers`` list
+      and the grace-shape envelope.
+    """
+    try:
+        from clawmetry import entitlements as _ent
+
+        rows = _ent.next_tier_runtime_catalog_at_batch() or []
+        ent = _ent.get_entitlement()
+        return jsonify(
+            {
+                "tiers": rows,
+                "current_tier": ent.tier,
+                "current_tier_rank": _ent.tier_rank(ent.tier),
+                "grace": bool(ent.grace),
+                "enforced": _ent.is_enforced(),
+            }
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_next_tier_runtime_catalog_at_batch: error: %s",
+            exc,
+        )
+        return jsonify(
+            {
+                "tiers": [],
+                "current_tier": "oss",
+                "current_tier_rank": 0,
+                "grace": True,
+                "enforced": False,
+            }
+        )
+
+
+@bp_entitlement.route("/api/entitlement/previous-tier-runtime-catalog-at-batch")
+def api_entitlement_previous_tier_runtime_catalog_at_batch():
+    """``GET /api/entitlement/previous-tier-runtime-catalog-at-batch`` --
+    batch sibling of ``/api/entitlement/previous-tier-runtime-catalog-at``:
+    one ``previous-tier-runtime-catalog-at`` envelope per purchasable
+    source tier, in one round-trip.
+
+    Source-anchored downgrade-side mirror of
+    ``/api/entitlement/next-tier-runtime-catalog-at-batch`` and
+    runtime-axis catalog analogue of
+    ``/api/entitlement/previous-tier-feature-catalog-at-batch``.
+
+    No query params. Source list is
+    :data:`entitlements._PURCHASABLE_TIERS` (trial excluded).
+
+    Response shape mirrors
+    ``/api/entitlement/next-tier-runtime-catalog-at-batch`` byte-for-byte
+    on the envelope keys. Each ``<envelope>`` matches
+    ``/api/entitlement/previous-tier-runtime-catalog-at?tier=<source>``
+    for that source exactly. At the source-side floor (``oss`` /
+    ``cloud_free`` as source) the envelope carries ``target=null`` and
+    ``runtimes=[]``.
+
+    - **Never 5xxs**: resolver failure yields an empty ``tiers`` list
+      and the grace-shape envelope.
+    """
+    try:
+        from clawmetry import entitlements as _ent
+
+        rows = _ent.previous_tier_runtime_catalog_at_batch() or []
+        ent = _ent.get_entitlement()
+        return jsonify(
+            {
+                "tiers": rows,
+                "current_tier": ent.tier,
+                "current_tier_rank": _ent.tier_rank(ent.tier),
+                "grace": bool(ent.grace),
+                "enforced": _ent.is_enforced(),
+            }
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_previous_tier_runtime_catalog_at_batch: error: %s",
+            exc,
+        )
+        return jsonify(
+            {
+                "tiers": [],
+                "current_tier": "oss",
+                "current_tier_rank": 0,
+                "grace": True,
+                "enforced": False,
+            }
+        )

--- a/tests/test_entitlement_next_prev_tier_feature_runtime_catalog_at_batch.py
+++ b/tests/test_entitlement_next_prev_tier_feature_runtime_catalog_at_batch.py
@@ -1,0 +1,662 @@
+"""Tests for the four batch siblings of
+:func:`clawmetry.entitlements.next_tier_feature_catalog_at` /
+:func:`previous_tier_feature_catalog_at` /
+:func:`next_tier_runtime_catalog_at` /
+:func:`previous_tier_runtime_catalog_at`, and the four companion
+``/api/entitlement/{next,previous}-tier-{feature,runtime}-catalog-at-batch``
+endpoints (plus the private :func:`_feature_catalog_at_envelope` /
+:func:`_runtime_catalog_at_envelope` builders they share).
+
+Feature- and runtime-axis catalog analogues of
+:func:`next_tier_capacity_diff_at_batch` /
+:func:`previous_tier_capacity_diff_at_batch` and
+:func:`next_tier_diff_at_batch` / :func:`previous_tier_diff_at_batch`:
+the source axis walks :data:`_PURCHASABLE_TIERS` (trial excluded) in
+one pass, and each envelope carries the full
+:func:`feature_catalog_at` / :func:`runtime_catalog_at` catalogue for
+the rung above / below that source.
+
+Pins covered here:
+
+* the two private envelope builders compose source/target metadata
+  with the per-pair catalog list in the same envelope shape the scalar
+  catalog endpoints surface (``tier``, ``tier_label``, ``tier_rank``,
+  ``target``, ``target_label``, ``target_rank``, ``features`` /
+  ``runtimes``)
+* all four batches return one envelope per entry in
+  :data:`_PURCHASABLE_TIERS`, sorted by ``(tier_rank, tier_id)``, with
+  trial excluded from the source axis
+* every envelope byte-equals the scalar
+  :func:`next_tier_feature_catalog_at` /
+  :func:`next_tier_runtime_catalog_at` (etc.) helper for the same
+  source -- the batch-vs-scalar parity that stops the batch what-if
+  drifting from the scalar what-if
+* per-envelope inner ``features`` / ``runtimes`` byte-equals
+  :func:`feature_catalog_at(target)` / :func:`runtime_catalog_at(target)`
+  for the resolved target -- pins the catalog projection to its
+  sibling
+* source-axis and envelope keys are byte-stable against the sibling
+  ``next_*_at_batch`` / ``previous_*_at_batch`` families (diff,
+  capacity, unlocks, locks) so a UI can fold responses into one
+  matrix without re-sorting
+* at the source-side ceiling (``enterprise`` as source for the next
+  batch) and floor (``oss`` / ``cloud_free`` as source for the
+  previous batch) the envelope carries ``target=null`` and
+  ``features=[]`` / ``runtimes=[]`` rather than being dropped
+* grace vs enforce yields the same body (the ``_at`` family walks the
+  static catalogue, not the gated resolver)
+* the helpers never raise: a per-source builder failure collapses to
+  ``features=[]`` / ``runtimes=[]`` on the populated envelope; a
+  top-level failure short-circuits to ``[]``
+* the four API endpoints never 5xx: on the happy path the batch body
+  matches the helper output; a resolver failure yields an empty
+  ``tiers`` list plus the grace-shape envelope
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+_FEATURE_ENVELOPE_KEYS = {
+    "tier",
+    "tier_label",
+    "tier_rank",
+    "target",
+    "target_label",
+    "target_rank",
+    "features",
+}
+
+_RUNTIME_ENVELOPE_KEYS = {
+    "tier",
+    "tier_label",
+    "tier_rank",
+    "target",
+    "target_label",
+    "target_rank",
+    "runtimes",
+}
+
+_BATCH_RESPONSE_KEYS = {
+    "tiers",
+    "current_tier",
+    "current_tier_rank",
+    "grace",
+    "enforced",
+}
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    """Fresh entitlements module with HOME pointed at an empty tmp dir
+    so no real ~/.clawmetry/license.key or cloud_plan.json leaks in.
+    Enforcement off by default (grace mode) -- the batch helpers are
+    catalogue-derived and independent of the resolver, so the fixture
+    only needs to keep the live resolver from surprising the test."""
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# ── _feature_catalog_at_envelope ────────────────────────────────────────────
+
+
+def test_feature_envelope_shape_for_known_pair(ent):
+    env = ent._feature_catalog_at_envelope(ent.TIER_OSS, ent.TIER_CLOUD_STARTER)
+    assert set(env.keys()) == _FEATURE_ENVELOPE_KEYS
+    assert env["tier"] == ent.TIER_OSS
+    assert env["tier_label"] == ent.tier_label(ent.TIER_OSS)
+    assert env["tier_rank"] == ent.tier_rank(ent.TIER_OSS)
+    assert env["target"] == ent.TIER_CLOUD_STARTER
+    assert env["target_label"] == ent.tier_label(ent.TIER_CLOUD_STARTER)
+    assert env["target_rank"] == ent.tier_rank(ent.TIER_CLOUD_STARTER)
+    assert env["features"] == ent.feature_catalog_at(ent.TIER_CLOUD_STARTER)
+
+
+def test_feature_envelope_none_target_collapses_features(ent):
+    env = ent._feature_catalog_at_envelope(ent.TIER_ENTERPRISE, None)
+    assert env["tier"] == ent.TIER_ENTERPRISE
+    assert env["target"] is None
+    assert env["target_label"] is None
+    assert env["target_rank"] is None
+    assert env["features"] == []
+
+
+def test_feature_envelope_unknown_source_keeps_target_populated(ent):
+    env = ent._feature_catalog_at_envelope("bogus", ent.TIER_CLOUD_STARTER)
+    assert set(env.keys()) == _FEATURE_ENVELOPE_KEYS
+    assert env["tier_label"] is None
+    assert env["tier_rank"] == -1
+    assert env["target"] == ent.TIER_CLOUD_STARTER
+    # feature_catalog_at is target-driven -- unknown source doesn't
+    # affect the projection, just leaves the source metadata unresolved.
+    assert env["features"] == ent.feature_catalog_at(ent.TIER_CLOUD_STARTER)
+
+
+def test_feature_envelope_trims_and_lowercases_source(ent):
+    env = ent._feature_catalog_at_envelope("  OSS  ", ent.TIER_CLOUD_STARTER)
+    assert env["tier"] == ent.TIER_OSS
+    assert env["target"] == ent.TIER_CLOUD_STARTER
+
+
+def test_feature_envelope_swallows_builder_exception(ent, monkeypatch):
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "feature_catalog_at", boom)
+    env = ent._feature_catalog_at_envelope(ent.TIER_OSS, ent.TIER_CLOUD_STARTER)
+    assert env["target"] == ent.TIER_CLOUD_STARTER
+    assert env["features"] == []
+
+
+# ── _runtime_catalog_at_envelope ────────────────────────────────────────────
+
+
+def test_runtime_envelope_shape_for_known_pair(ent):
+    env = ent._runtime_catalog_at_envelope(ent.TIER_OSS, ent.TIER_CLOUD_STARTER)
+    assert set(env.keys()) == _RUNTIME_ENVELOPE_KEYS
+    assert env["tier"] == ent.TIER_OSS
+    assert env["target"] == ent.TIER_CLOUD_STARTER
+    assert env["runtimes"] == ent.runtime_catalog_at(ent.TIER_CLOUD_STARTER)
+
+
+def test_runtime_envelope_none_target_collapses_runtimes(ent):
+    env = ent._runtime_catalog_at_envelope(ent.TIER_ENTERPRISE, None)
+    assert env["target"] is None
+    assert env["target_label"] is None
+    assert env["target_rank"] is None
+    assert env["runtimes"] == []
+
+
+def test_runtime_envelope_swallows_builder_exception(ent, monkeypatch):
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "runtime_catalog_at", boom)
+    env = ent._runtime_catalog_at_envelope(ent.TIER_OSS, ent.TIER_CLOUD_STARTER)
+    assert env["target"] == ent.TIER_CLOUD_STARTER
+    assert env["runtimes"] == []
+
+
+# ── next_tier_feature_catalog_at_batch (helper) ─────────────────────────────
+
+
+def test_next_feature_batch_returns_one_envelope_per_purchasable(ent):
+    rows = ent.next_tier_feature_catalog_at_batch()
+    assert isinstance(rows, list)
+    assert len(rows) == len(ent._PURCHASABLE_TIERS)
+
+
+def test_next_feature_batch_each_envelope_has_envelope_shape(ent):
+    for env in ent.next_tier_feature_catalog_at_batch():
+        assert set(env.keys()) == _FEATURE_ENVELOPE_KEYS
+
+
+def test_next_feature_batch_source_axis_matches_purchasable(ent):
+    rows = ent.next_tier_feature_catalog_at_batch()
+    assert {env["tier"] for env in rows} == set(ent._PURCHASABLE_TIERS)
+
+
+def test_next_feature_batch_excludes_trial_from_sources(ent):
+    sources = {env["tier"] for env in ent.next_tier_feature_catalog_at_batch()}
+    assert ent.TIER_TRIAL not in sources
+
+
+def test_next_feature_batch_sorted_by_rank_then_id(ent):
+    rows = ent.next_tier_feature_catalog_at_batch()
+    keys = [(env["tier_rank"], env["tier"]) for env in rows]
+    assert keys == sorted(keys)
+
+
+def test_next_feature_batch_ceiling_collapses_to_empty(ent):
+    rows = ent.next_tier_feature_catalog_at_batch()
+    top = next(env for env in rows if env["tier"] == ent.TIER_ENTERPRISE)
+    assert top["target"] is None
+    assert top["target_label"] is None
+    assert top["target_rank"] is None
+    assert top["features"] == []
+
+
+def test_next_feature_batch_features_matches_scalar_helper_per_source(ent):
+    # Batch-vs-scalar parity: every envelope's features byte-equals the
+    # scalar :func:`next_tier_feature_catalog_at` for the same source.
+    for env in ent.next_tier_feature_catalog_at_batch():
+        scalar = ent.next_tier_feature_catalog_at(env["tier"]) or []
+        assert env["features"] == scalar
+
+
+def test_next_feature_batch_features_matches_feature_catalog_at_target(ent):
+    # Inner catalog parity: per-envelope features byte-equals
+    # :func:`feature_catalog_at(target)` for the resolved target.
+    for env in ent.next_tier_feature_catalog_at_batch():
+        if env["target"] is None:
+            assert env["features"] == []
+        else:
+            assert env["features"] == ent.feature_catalog_at(env["target"])
+
+
+def test_next_feature_batch_sort_matches_capacity_batch(ent):
+    # Byte-stable against the sibling capacity batch so a UI can fold
+    # both responses into one matrix without re-sorting client-side.
+    feat_sources = [
+        env["tier"] for env in ent.next_tier_feature_catalog_at_batch()
+    ]
+    cap_sources = [
+        env["tier"] for env in ent.next_tier_capacity_diff_at_batch()
+    ]
+    assert feat_sources == cap_sources
+
+
+def test_next_feature_batch_grace_and_enforce_match(ent, monkeypatch):
+    grace = ent.next_tier_feature_catalog_at_batch()
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    importlib.reload(ent)
+    ent.invalidate()
+    enforce = ent.next_tier_feature_catalog_at_batch()
+    assert enforce == grace
+
+
+def test_next_feature_batch_per_source_builder_failure_keeps_envelope(
+    ent, monkeypatch
+):
+    real = ent.feature_catalog_at
+    boom_target = ent._next_purchasable_tier_after(ent.TIER_OSS)
+
+    def maybe_boom(tier):
+        if tier == boom_target:
+            raise RuntimeError("synthetic")
+        return real(tier)
+
+    monkeypatch.setattr(ent, "feature_catalog_at", maybe_boom)
+    rows = ent.next_tier_feature_catalog_at_batch()
+    oss_env = next(env for env in rows if env["tier"] == ent.TIER_OSS)
+    assert oss_env["target"] == boom_target
+    assert oss_env["features"] == []
+    # A different source with a different target still hydrates fully.
+    other_env = next(
+        env
+        for env in rows
+        if env["target"] not in (None, boom_target)
+    )
+    assert other_env["features"] != []
+
+
+def test_next_feature_batch_top_level_failure_short_circuits_to_empty(
+    ent, monkeypatch
+):
+    def boom(*_, **__):
+        raise RuntimeError("top-level")
+
+    monkeypatch.setattr(ent, "_next_purchasable_tier_after", boom)
+    assert ent.next_tier_feature_catalog_at_batch() == []
+
+
+# ── previous_tier_feature_catalog_at_batch (helper) ─────────────────────────
+
+
+def test_previous_feature_batch_returns_one_envelope_per_purchasable(ent):
+    rows = ent.previous_tier_feature_catalog_at_batch()
+    assert isinstance(rows, list)
+    assert len(rows) == len(ent._PURCHASABLE_TIERS)
+
+
+def test_previous_feature_batch_each_envelope_has_envelope_shape(ent):
+    for env in ent.previous_tier_feature_catalog_at_batch():
+        assert set(env.keys()) == _FEATURE_ENVELOPE_KEYS
+
+
+def test_previous_feature_batch_source_axis_matches_purchasable(ent):
+    sources = {
+        env["tier"] for env in ent.previous_tier_feature_catalog_at_batch()
+    }
+    assert sources == set(ent._PURCHASABLE_TIERS)
+
+
+def test_previous_feature_batch_sorted_by_rank_then_id(ent):
+    rows = ent.previous_tier_feature_catalog_at_batch()
+    keys = [(env["tier_rank"], env["tier"]) for env in rows]
+    assert keys == sorted(keys)
+
+
+def test_previous_feature_batch_floor_collapses_to_empty(ent):
+    rows = ent.previous_tier_feature_catalog_at_batch()
+    for src in (ent.TIER_OSS, ent.TIER_CLOUD_FREE):
+        floor_env = next(env for env in rows if env["tier"] == src)
+        assert floor_env["target"] is None
+        assert floor_env["target_label"] is None
+        assert floor_env["target_rank"] is None
+        assert floor_env["features"] == []
+
+
+def test_previous_feature_batch_features_matches_scalar_helper_per_source(ent):
+    for env in ent.previous_tier_feature_catalog_at_batch():
+        scalar = ent.previous_tier_feature_catalog_at(env["tier"]) or []
+        assert env["features"] == scalar
+
+
+def test_previous_feature_batch_features_matches_feature_catalog_at_target(ent):
+    for env in ent.previous_tier_feature_catalog_at_batch():
+        if env["target"] is None:
+            assert env["features"] == []
+        else:
+            assert env["features"] == ent.feature_catalog_at(env["target"])
+
+
+def test_previous_feature_batch_sort_matches_capacity_batch(ent):
+    feat_sources = [
+        env["tier"] for env in ent.previous_tier_feature_catalog_at_batch()
+    ]
+    cap_sources = [
+        env["tier"] for env in ent.previous_tier_capacity_diff_at_batch()
+    ]
+    assert feat_sources == cap_sources
+
+
+def test_previous_feature_batch_grace_and_enforce_match(ent, monkeypatch):
+    grace = ent.previous_tier_feature_catalog_at_batch()
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    importlib.reload(ent)
+    ent.invalidate()
+    enforce = ent.previous_tier_feature_catalog_at_batch()
+    assert enforce == grace
+
+
+def test_previous_feature_batch_top_level_failure_short_circuits(ent, monkeypatch):
+    def boom(*_, **__):
+        raise RuntimeError("top-level")
+
+    monkeypatch.setattr(ent, "_previous_purchasable_tier_before", boom)
+    assert ent.previous_tier_feature_catalog_at_batch() == []
+
+
+# ── next_tier_runtime_catalog_at_batch (helper) ─────────────────────────────
+
+
+def test_next_runtime_batch_returns_one_envelope_per_purchasable(ent):
+    rows = ent.next_tier_runtime_catalog_at_batch()
+    assert isinstance(rows, list)
+    assert len(rows) == len(ent._PURCHASABLE_TIERS)
+
+
+def test_next_runtime_batch_each_envelope_has_envelope_shape(ent):
+    for env in ent.next_tier_runtime_catalog_at_batch():
+        assert set(env.keys()) == _RUNTIME_ENVELOPE_KEYS
+
+
+def test_next_runtime_batch_source_axis_matches_purchasable(ent):
+    sources = {env["tier"] for env in ent.next_tier_runtime_catalog_at_batch()}
+    assert sources == set(ent._PURCHASABLE_TIERS)
+
+
+def test_next_runtime_batch_sorted_by_rank_then_id(ent):
+    rows = ent.next_tier_runtime_catalog_at_batch()
+    keys = [(env["tier_rank"], env["tier"]) for env in rows]
+    assert keys == sorted(keys)
+
+
+def test_next_runtime_batch_ceiling_collapses_to_empty(ent):
+    rows = ent.next_tier_runtime_catalog_at_batch()
+    top = next(env for env in rows if env["tier"] == ent.TIER_ENTERPRISE)
+    assert top["target"] is None
+    assert top["target_label"] is None
+    assert top["target_rank"] is None
+    assert top["runtimes"] == []
+
+
+def test_next_runtime_batch_runtimes_matches_scalar_helper_per_source(ent):
+    for env in ent.next_tier_runtime_catalog_at_batch():
+        scalar = ent.next_tier_runtime_catalog_at(env["tier"]) or []
+        assert env["runtimes"] == scalar
+
+
+def test_next_runtime_batch_runtimes_matches_runtime_catalog_at_target(ent):
+    for env in ent.next_tier_runtime_catalog_at_batch():
+        if env["target"] is None:
+            assert env["runtimes"] == []
+        else:
+            assert env["runtimes"] == ent.runtime_catalog_at(env["target"])
+
+
+def test_next_runtime_batch_sort_matches_feature_batch(ent):
+    # Byte-stable against the sibling feature batch so a UI can fold
+    # both responses into one matrix without re-sorting client-side.
+    rt_sources = [
+        env["tier"] for env in ent.next_tier_runtime_catalog_at_batch()
+    ]
+    feat_sources = [
+        env["tier"] for env in ent.next_tier_feature_catalog_at_batch()
+    ]
+    assert rt_sources == feat_sources
+
+
+def test_next_runtime_batch_grace_and_enforce_match(ent, monkeypatch):
+    grace = ent.next_tier_runtime_catalog_at_batch()
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    importlib.reload(ent)
+    ent.invalidate()
+    enforce = ent.next_tier_runtime_catalog_at_batch()
+    assert enforce == grace
+
+
+def test_next_runtime_batch_top_level_failure_short_circuits(ent, monkeypatch):
+    def boom(*_, **__):
+        raise RuntimeError("top-level")
+
+    monkeypatch.setattr(ent, "_next_purchasable_tier_after", boom)
+    assert ent.next_tier_runtime_catalog_at_batch() == []
+
+
+# ── previous_tier_runtime_catalog_at_batch (helper) ─────────────────────────
+
+
+def test_previous_runtime_batch_returns_one_envelope_per_purchasable(ent):
+    rows = ent.previous_tier_runtime_catalog_at_batch()
+    assert isinstance(rows, list)
+    assert len(rows) == len(ent._PURCHASABLE_TIERS)
+
+
+def test_previous_runtime_batch_each_envelope_has_envelope_shape(ent):
+    for env in ent.previous_tier_runtime_catalog_at_batch():
+        assert set(env.keys()) == _RUNTIME_ENVELOPE_KEYS
+
+
+def test_previous_runtime_batch_floor_collapses_to_empty(ent):
+    rows = ent.previous_tier_runtime_catalog_at_batch()
+    for src in (ent.TIER_OSS, ent.TIER_CLOUD_FREE):
+        floor_env = next(env for env in rows if env["tier"] == src)
+        assert floor_env["target"] is None
+        assert floor_env["runtimes"] == []
+
+
+def test_previous_runtime_batch_runtimes_matches_scalar_helper_per_source(ent):
+    for env in ent.previous_tier_runtime_catalog_at_batch():
+        scalar = ent.previous_tier_runtime_catalog_at(env["tier"]) or []
+        assert env["runtimes"] == scalar
+
+
+def test_previous_runtime_batch_runtimes_matches_runtime_catalog_at_target(ent):
+    for env in ent.previous_tier_runtime_catalog_at_batch():
+        if env["target"] is None:
+            assert env["runtimes"] == []
+        else:
+            assert env["runtimes"] == ent.runtime_catalog_at(env["target"])
+
+
+def test_previous_runtime_batch_grace_and_enforce_match(ent, monkeypatch):
+    grace = ent.previous_tier_runtime_catalog_at_batch()
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    importlib.reload(ent)
+    ent.invalidate()
+    enforce = ent.previous_tier_runtime_catalog_at_batch()
+    assert enforce == grace
+
+
+# ── /api/entitlement/next-tier-feature-catalog-at-batch ─────────────────────
+
+
+def test_api_next_feature_batch_happy_path(client, ent):
+    resp = client.get("/api/entitlement/next-tier-feature-catalog-at-batch")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert set(body.keys()) == _BATCH_RESPONSE_KEYS
+    assert isinstance(body["tiers"], list)
+    assert len(body["tiers"]) == len(ent._PURCHASABLE_TIERS)
+    for env in body["tiers"]:
+        assert set(env.keys()) == _FEATURE_ENVELOPE_KEYS
+
+
+def test_api_next_feature_batch_matches_helper_body(client, ent):
+    resp = client.get("/api/entitlement/next-tier-feature-catalog-at-batch")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["tiers"] == ent.next_tier_feature_catalog_at_batch()
+
+
+def test_api_next_feature_batch_never_5xxs_on_resolver_failure(
+    client, ent, monkeypatch
+):
+    def boom():
+        raise RuntimeError("resolver dead")
+
+    monkeypatch.setattr(ent, "get_entitlement", boom)
+    resp = client.get("/api/entitlement/next-tier-feature-catalog-at-batch")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["tiers"] == []
+    assert body["grace"] is True
+    assert body["enforced"] is False
+
+
+# ── /api/entitlement/previous-tier-feature-catalog-at-batch ─────────────────
+
+
+def test_api_previous_feature_batch_happy_path(client, ent):
+    resp = client.get("/api/entitlement/previous-tier-feature-catalog-at-batch")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert set(body.keys()) == _BATCH_RESPONSE_KEYS
+    assert len(body["tiers"]) == len(ent._PURCHASABLE_TIERS)
+
+
+def test_api_previous_feature_batch_matches_helper_body(client, ent):
+    resp = client.get("/api/entitlement/previous-tier-feature-catalog-at-batch")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["tiers"] == ent.previous_tier_feature_catalog_at_batch()
+
+
+def test_api_previous_feature_batch_never_5xxs_on_resolver_failure(
+    client, ent, monkeypatch
+):
+    def boom():
+        raise RuntimeError("resolver dead")
+
+    monkeypatch.setattr(ent, "get_entitlement", boom)
+    resp = client.get("/api/entitlement/previous-tier-feature-catalog-at-batch")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["tiers"] == []
+
+
+# ── /api/entitlement/next-tier-runtime-catalog-at-batch ─────────────────────
+
+
+def test_api_next_runtime_batch_happy_path(client, ent):
+    resp = client.get("/api/entitlement/next-tier-runtime-catalog-at-batch")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert set(body.keys()) == _BATCH_RESPONSE_KEYS
+    assert len(body["tiers"]) == len(ent._PURCHASABLE_TIERS)
+    for env in body["tiers"]:
+        assert set(env.keys()) == _RUNTIME_ENVELOPE_KEYS
+
+
+def test_api_next_runtime_batch_matches_helper_body(client, ent):
+    resp = client.get("/api/entitlement/next-tier-runtime-catalog-at-batch")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["tiers"] == ent.next_tier_runtime_catalog_at_batch()
+
+
+def test_api_next_runtime_batch_never_5xxs_on_resolver_failure(
+    client, ent, monkeypatch
+):
+    def boom():
+        raise RuntimeError("resolver dead")
+
+    monkeypatch.setattr(ent, "get_entitlement", boom)
+    resp = client.get("/api/entitlement/next-tier-runtime-catalog-at-batch")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["tiers"] == []
+
+
+# ── /api/entitlement/previous-tier-runtime-catalog-at-batch ─────────────────
+
+
+def test_api_previous_runtime_batch_happy_path(client, ent):
+    resp = client.get("/api/entitlement/previous-tier-runtime-catalog-at-batch")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert set(body.keys()) == _BATCH_RESPONSE_KEYS
+    assert len(body["tiers"]) == len(ent._PURCHASABLE_TIERS)
+
+
+def test_api_previous_runtime_batch_matches_helper_body(client, ent):
+    resp = client.get("/api/entitlement/previous-tier-runtime-catalog-at-batch")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["tiers"] == ent.previous_tier_runtime_catalog_at_batch()
+
+
+def test_api_previous_runtime_batch_never_5xxs_on_resolver_failure(
+    client, ent, monkeypatch
+):
+    def boom():
+        raise RuntimeError("resolver dead")
+
+    monkeypatch.setattr(ent, "get_entitlement", boom)
+    resp = client.get("/api/entitlement/previous-tier-runtime-catalog-at-batch")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["tiers"] == []
+
+
+# ── Cross-endpoint axis parity ──────────────────────────────────────────────
+
+
+def test_all_four_endpoints_share_source_axis_order(client, ent):
+    # A UI can fold all four responses into one matrix without
+    # re-sorting: the source axis (envelope.tier order) is identical
+    # across all four endpoints and equal to the shipped
+    # /next-tier-capacity-diff-at-batch axis.
+    urls = [
+        "/api/entitlement/next-tier-feature-catalog-at-batch",
+        "/api/entitlement/previous-tier-feature-catalog-at-batch",
+        "/api/entitlement/next-tier-runtime-catalog-at-batch",
+        "/api/entitlement/previous-tier-runtime-catalog-at-batch",
+        "/api/entitlement/next-tier-capacity-diff-at-batch",
+    ]
+    axes = []
+    for url in urls:
+        body = client.get(url).get_json()
+        axes.append([env["tier"] for env in body["tiers"]])
+    for axis in axes[1:]:
+        assert axis == axes[0]


### PR DESCRIPTION
## Summary

- Batch siblings of the source-anchored feature/runtime catalog helpers (#3643) walking every purchasable source rung in one pass. Adds four helpers — `next_tier_feature_catalog_at_batch`, `previous_tier_feature_catalog_at_batch`, `next_tier_runtime_catalog_at_batch`, `previous_tier_runtime_catalog_at_batch` — plus the two private `_feature_catalog_at_envelope` / `_runtime_catalog_at_envelope` builders they share, and the four companion `GET /api/entitlement/{next,previous}-tier-{feature,runtime}-catalog-at-batch` endpoints.
- Feature- and runtime-axis catalog analogues of the shipped `next/previous_tier_capacity_diff_at_batch` and `next/previous_tier_diff_at_batch`. Per-envelope shape matches the source-anchored scalar endpoint (`tier` / `tier_label` / `tier_rank` / `target` / `target_label` / `target_rank` / `features` — or / `runtimes`). Source axis is `_PURCHASABLE_TIERS` (trial excluded), sorted by `(tier_rank, tier_id)` — byte-stable against every other `next_*_at_batch` / `previous_*_at_batch` sibling so a UI can fold the responses into one matrix without re-sorting client-side.
- Per-envelope inner `features` / `runtimes` list byte-equals `feature_catalog_at(target)` / `runtime_catalog_at(target)` for the resolved target and also byte-equals the scalar `next_tier_feature_catalog_at` (etc.) helper for the same source — pinned by the tests so the batch what-if cannot drift from either sibling. Ceiling (`enterprise` as source for `next_*`) and floor (`oss` / `cloud_free` as source for `previous_*`) collapse to `target=null` / `features=[]` (or `runtimes=[]`) rather than being dropped, so the matrix keeps a row for every purchasable rung.

## Test plan

- [x] `python3 -m pytest tests/test_entitlement_next_prev_tier_feature_runtime_catalog_at_batch.py` — 59/59 green
- [x] Broader entitlement suite (`pytest -k entitlement`, sandbox-ignored files skipped) — 5561 passed, 4 skipped, 1 unrelated collection error (missing `duckdb` in sandbox)
- [x] `python3 -m ruff check clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_next_prev_tier_feature_runtime_catalog_at_batch.py` — clean
- [x] `python3 -m py_compile` on all three edited files — OK

## Coverage pinned by the new tests (59 total)

- Private envelope shape (`_feature_catalog_at_envelope` / `_runtime_catalog_at_envelope`): keys, populated pair matches `feature_catalog_at(target)` / `runtime_catalog_at(target)`, `target=None` collapses list to `[]`, unknown source keeps target populated, source is trimmed / lowercased, builder exceptions collapse to `[]`
- Batch shape: one envelope per `_PURCHASABLE_TIERS` entry, trial excluded, sorted `(tier_rank, tier_id)`, ceiling / floor `target=null` + list `[]`
- Batch-vs-scalar parity: every envelope's `features` / `runtimes` byte-equals the scalar `next_tier_feature_catalog_at` / `next_tier_runtime_catalog_at` (etc.) for the same source, and byte-equals `feature_catalog_at(target)` / `runtime_catalog_at(target)` for the resolved target
- Cross-sibling sort parity: source axis byte-equals `next_tier_capacity_diff_at_batch` / `next_tier_feature_catalog_at_batch` / `previous_tier_capacity_diff_at_batch` — pinned across all four new endpoints so they fold into one matrix
- Grace vs enforce byte-identical (catalogue-derived, not gated)
- Per-source builder failure collapses that envelope's list to `[]` while keeping the row visible; top-level failure short-circuits to `[]`
- Endpoint response shape: `{tiers, current_tier, current_tier_rank, grace, enforced}`, envelope keys, endpoint-vs-helper parity, never 5xxs on a resolver failure (empty `tiers`, grace-shape envelope)

## Local operator verification checklist

Since this fires from a remote container with no access to the local daemon, live cloud snapshot, or a browser, the local operator handles verification before flipping the PR to ready-for-review:

- [ ] Copy the changed files into `~/.clawmetry/lib/pythonX.Y/site-packages/clawmetry/` (or reinstall the wheel)
- [ ] Clear `__pycache__` (`find ~/.clawmetry -name __pycache__ -exec rm -rf {} +`)
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` (and `com.clawmetry.dashboard` if separate)
- [ ] `curl -s http://localhost:8900/api/entitlement/next-tier-feature-catalog-at-batch | jq .` — expect 6 envelopes, enterprise-as-source collapsed to `target=null` / `features=[]`
- [ ] `curl -s http://localhost:8900/api/entitlement/previous-tier-feature-catalog-at-batch | jq .` — expect 6 envelopes, `oss` / `cloud_free`-as-source collapsed to `target=null` / `features=[]`
- [ ] `curl -s http://localhost:8900/api/entitlement/next-tier-runtime-catalog-at-batch | jq .` — expect 6 envelopes, ceiling collapsed to `runtimes=[]`
- [ ] `curl -s http://localhost:8900/api/entitlement/previous-tier-runtime-catalog-at-batch | jq .` — expect 6 envelopes, floor collapsed to `runtimes=[]`
- [ ] Decrypt the live cloud snapshot and confirm any pricing-preview panel that consumes the source-anchored feature/runtime catalog still renders identically at the resolved source rung (helper preserves scalar parity — no UX diff)
- [ ] Browser-check the pricing / upgrade / downgrade panels for any client-side crash on the new batch response shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EB2wUNJDrjwUo8krt29bvV)_