### PR TITLE
fix(obs-gap): surface fallbackRuntime engine dimension (#3649)

### DIFF
--- a/clawmetry/adapters/openclaw.py
+++ b/clawmetry/adapters/openclaw.py
@@ -1447,6 +1447,16 @@ class OpenClawAdapter(AgentAdapter):
             _fm_fallback = s.get("fallbackModel") or s.get("fastModeFallbackModel")
             if _fm_fallback is not None:
                 extra["fallbackModel"] = _fm_fallback
+            # Runtime-engine fallback dimension (#3649): CHANGELOG #98021 added
+            # an atomic runtime (engine) selection alongside model and thinking;
+            # capture it so engine switches (OpenClaw↔Codex) are distinguishable.
+            _fb_runtime = (
+                s.get("fallbackRuntime")
+                or s.get("fallbackRuntimeEngine")
+                or s.get("runtimeEngine")
+            )
+            if _fb_runtime is not None:
+                extra["fallbackRuntime"] = _fb_runtime
             # /think reasoning-level tier (#3324): PR #94067 stores the active
             # level (light/medium/deep) on session records; surface when present.
             _think_level = s.get("thinkLevel") or s.get("reasoningLevel")
@@ -1823,6 +1833,15 @@ class OpenClawAdapter(AgentAdapter):
                             _fm_fallback = obj.get("fallbackModel") or obj.get("fastModeFallbackModel")
                             if _fm_fallback is not None:
                                 extra["fallbackModel"] = _fm_fallback
+                            # Runtime-engine fallback dimension (#3649): same
+                            # atomic engine field captured at the event level.
+                            _fb_runtime = (
+                                obj.get("fallbackRuntime")
+                                or obj.get("fallbackRuntimeEngine")
+                                or obj.get("runtimeEngine")
+                            )
+                            if _fb_runtime is not None:
+                                extra["fallbackRuntime"] = _fb_runtime
                             # /think reasoning-level tier (#3324): PR #94067 stores
                             # the active level (light/medium/deep) on model-turn
                             # records; try camelCase then snake_case.

--- a/tests/test_obs_gap_openclaw_fallback_runtime_3649.py
+++ b/tests/test_obs_gap_openclaw_fallback_runtime_3649.py
@@ -1,0 +1,95 @@
+"""Regression tests for issue #3649.
+
+OpenClaw CHANGELOG #98021 ("GPT-5.6 Ultra and runtime switching") introduced
+a distinct runtime (engine) dimension — Sol, Terra, Luna — that changes
+atomically alongside model and thinking-mode during fallback.  ClawMetry was
+not reading it: ``list_sessions()`` never placed ``fallbackRuntime`` in
+``Session.extra`` and ``list_events()`` did not extract it from the event blob.
+"""
+
+import json
+
+from clawmetry.adapters.openclaw import OpenClawAdapter
+import clawmetry.adapters.openclaw as ocmod
+
+
+class _FakeDash:
+    def __init__(self, key="fallbackRuntime", val="codex"):
+        self._key = key
+        self._val = val
+
+    def _get_sessions(self):
+        return [{"sessionId": "sess-fbr-1", self._key: self._val}]
+
+
+def test_list_sessions_surfaces_fallback_runtime(monkeypatch):
+    monkeypatch.setattr(ocmod, "_d", lambda: _FakeDash("fallbackRuntime", "codex"))
+    sessions = OpenClawAdapter().list_sessions(limit=10)
+    assert len(sessions) == 1
+    assert sessions[0].extra.get("fallbackRuntime") == "codex", (
+        "list_sessions() must propagate 'fallbackRuntime' into Session.extra"
+    )
+
+
+def test_list_sessions_surfaces_fallback_runtime_engine_alias(monkeypatch):
+    monkeypatch.setattr(
+        ocmod, "_d", lambda: _FakeDash("fallbackRuntimeEngine", "openclaw")
+    )
+    sessions = OpenClawAdapter().list_sessions(limit=10)
+    assert sessions[0].extra.get("fallbackRuntime") == "openclaw", (
+        "list_sessions() must also handle the 'fallbackRuntimeEngine' alias"
+    )
+
+
+def test_list_sessions_surfaces_runtime_engine_alias(monkeypatch):
+    monkeypatch.setattr(ocmod, "_d", lambda: _FakeDash("runtimeEngine", "sol"))
+    sessions = OpenClawAdapter().list_sessions(limit=10)
+    assert sessions[0].extra.get("fallbackRuntime") == "sol", (
+        "list_sessions() must also handle the 'runtimeEngine' alias"
+    )
+
+
+def test_list_sessions_omits_fallback_runtime_when_absent(monkeypatch):
+    class _NoDash:
+        def _get_sessions(self):
+            return [{"sessionId": "sess-fbr-2"}]
+
+    monkeypatch.setattr(ocmod, "_d", lambda: _NoDash())
+    sessions = OpenClawAdapter().list_sessions(limit=10)
+    assert "fallbackRuntime" not in sessions[0].extra, (
+        "fallbackRuntime must not appear in extra when the upstream record omits it"
+    )
+
+
+def test_list_events_surfaces_fallback_runtime(monkeypatch):
+    data = json.dumps({"fallbackRuntime": "codex"})
+
+    class _FakeStore:
+        def _fetch(self, sql, params):
+            # id, event_type, ts, model, token_count, data, agent_id, node_id
+            return [("e-fbr-1", "message", "0", None, 0, data, "main", None)]
+
+    import clawmetry.local_store as ls
+    monkeypatch.setattr(ls, "get_store", lambda read_only=True: _FakeStore())
+
+    events = OpenClawAdapter().list_events("sess-fbr-1", limit=10)
+    assert len(events) == 1
+    assert events[0].extra.get("fallbackRuntime") == "codex", (
+        "list_events() must extract 'fallbackRuntime' from the data blob into extra"
+    )
+
+
+def test_list_events_surfaces_runtime_engine_alias(monkeypatch):
+    data = json.dumps({"runtimeEngine": "luna"})
+
+    class _FakeStore:
+        def _fetch(self, sql, params):
+            return [("e-fbr-2", "message", "0", None, 0, data, "main", None)]
+
+    import clawmetry.local_store as ls
+    monkeypatch.setattr(ls, "get_store", lambda read_only=True: _FakeStore())
+
+    events = OpenClawAdapter().list_events("sess-fbr-2", limit=10)
+    assert events[0].extra.get("fallbackRuntime") == "luna", (
+        "list_events() must also handle the 'runtimeEngine' alias in the blob"
+    )


### PR DESCRIPTION
Closes #3649

## What

OpenClaw CHANGELOG #98021 ("GPT-5.6 Ultra and runtime switching") introduced a distinct **runtime (engine) dimension** — Sol, Terra, Luna — that changes atomically alongside model and thinking-mode during fallback. Without this fix, a fallback that switches from the OpenClaw engine to the Codex engine is indistinguishable from a same-engine model-only fallback in the dashboard.

## Changes

- **`clawmetry/adapters/openclaw.py`** — two additive spots, each mirroring the existing `fallbackModel` pattern:
  - Session-level block (~L1449): probe `fallbackRuntime` → `fallbackRuntimeEngine` → `runtimeEngine` and write to `extra["fallbackRuntime"]`
  - Event-level blob-decode block (~L1835): same 3-alias probe in the `list_events()` path
- **`tests/test_obs_gap_openclaw_fallback_runtime_3649.py`** (new): 6 tests covering session + event extraction for primary and alias field names, plus the absence case. Follows the established `test_obs_gap_openclaw_capability_profile_3469.py` pattern.

## Test plan

- `python -m pytest tests/test_obs_gap_openclaw_fallback_runtime_3649.py -v` — 4 session tests pass locally; 2 event tests require DuckDB (same condition as the reference test #3469, which also fails locally but passes in CI)
- No behaviour change for sessions/events that don't include `fallbackRuntime`

---
_Generated by [Claude Code](https://claude.ai/code/session_016db6xokQVXTVVc1MxVTaGm)_