### PR TITLE
fix: surface advisor-session tool-execution retry/exhaustion in NemoClaw events

### DIFF
--- a/clawmetry/adapters/nemo.py
+++ b/clawmetry/adapters/nemo.py
@@ -1023,7 +1023,7 @@ class NemoClawAdapter(AgentAdapter):
                 if r[6]:
                     extra["runtimeKind"] = str(r[6])
                 raw_data = r[5]
-                if raw_data is not None and r[1] == "sandbox.audit_log":
+                if raw_data is not None:
                     try:
                         if isinstance(raw_data, (bytes, bytearray)):
                             raw_data = bytes(raw_data).decode("utf-8", "replace")
@@ -1031,14 +1031,42 @@ class NemoClawAdapter(AgentAdapter):
                             json.loads(raw_data) if isinstance(raw_data, str) else raw_data
                         )
                         if isinstance(obj, dict):
-                            for _field in (
-                                "class_uid", "type_uid", "activity_name",
-                                "verdict", "rule_name",
-                            ):
-                                _val = obj.get(_field)
-                                if _val is not None:
-                                    extra[_field] = _val
-                            extra["ocsf"] = True
+                            if r[1] == "sandbox.audit_log":
+                                for _field in (
+                                    "class_uid", "type_uid", "activity_name",
+                                    "verdict", "rule_name",
+                                ):
+                                    _val = obj.get(_field)
+                                    if _val is not None:
+                                        extra[_field] = _val
+                                extra["ocsf"] = True
+                            # Advisor-session tool-execution retry/exhaustion
+                            # lifecycle (#3650): tool_execution_start /
+                            # tool_execution_end events carry attempt number,
+                            # per-attempt error flag, and resolved retry outcome
+                            # so the dashboard can distinguish a single clean
+                            # call from fail-then-success or exhaustion.
+                            # isError uses is-not-None (False is meaningful).
+                            _attempt = (
+                                obj.get("attemptNumber")
+                                or obj.get("attempt_number")
+                            )
+                            if _attempt is not None:
+                                try:
+                                    extra["attempt_number"] = int(_attempt)
+                                except (TypeError, ValueError):
+                                    pass
+                            _is_err = obj.get("isError")
+                            if _is_err is None:
+                                _is_err = obj.get("is_error")
+                            if _is_err is not None:
+                                extra["is_error"] = bool(_is_err)
+                            _rr = (
+                                obj.get("retryResponse")
+                                or obj.get("retry_response")
+                            )
+                            if _rr:
+                                extra["retry_response"] = _rr
                     except Exception:
                         pass
                 events.append(Event(

--- a/tests/test_obs_gap_nemoclaw_advisor_tool_retry_3650.py
+++ b/tests/test_obs_gap_nemoclaw_advisor_tool_retry_3650.py
@@ -1,0 +1,131 @@
+"""Tests for #3650 — NemoClaw advisor-session tool-execution retry/exhaustion lifecycle.
+
+NemoClaw's advisor session runner drives terminal tool calls through a
+retry/repair loop, emitting tool_execution_start / tool_execution_end (with
+isError) per attempt and modeling terminal outcomes ('exhausted' vs 'success').
+Before this fix NemoClawAdapter.list_events() never decoded the blob for those
+event types, so a tool that failed twice then succeeded looked identical to a
+single clean call.
+"""
+from __future__ import annotations
+
+import importlib
+import time
+import uuid
+
+import pytest
+
+
+@pytest.fixture
+def isolated_store(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_BATCH", "1")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.local_store as _ls
+    importlib.reload(_ls)
+    s = _ls.LocalStore()
+    s.start()
+    monkeypatch.setattr(_ls, "get_store", lambda *a, **kw: s)
+    yield s
+    s.stop(flush=True)
+
+
+def _seed(store, session_id, event_type, data=None):
+    store.ingest({
+        "id": str(uuid.uuid4()),
+        "node_id": "nemo+test-node",
+        "agent_id": "advisor",
+        "agent_type": "nemoclaw",
+        "session_id": session_id,
+        "event_type": event_type,
+        "ts": time.time(),
+        "data": data or {},
+    })
+
+
+def _wait_flush(s, timeout=2.0):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if s.health()["ring_depth"] == 0:
+            return
+        time.sleep(0.02)
+
+
+def test_tool_execution_start_surfaces_attempt_number(isolated_store):
+    """tool_execution_start events must surface attemptNumber as attempt_number."""
+    _seed(isolated_store, "sess-1", "tool_execution_start", {"attemptNumber": 1})
+    _wait_flush(isolated_store)
+
+    from clawmetry.adapters.nemo import NemoClawAdapter
+    events = NemoClawAdapter().list_events("sess-1")
+    assert len(events) == 1
+    assert events[0].extra.get("attempt_number") == 1
+
+
+def test_tool_execution_end_retry_surfaces_all_fields(isolated_store):
+    """tool_execution_end with isError=True and retryResponse='retry' must expose both fields."""
+    _seed(isolated_store, "sess-2", "tool_execution_end", {
+        "attemptNumber": 1,
+        "isError": True,
+        "retryResponse": "retry",
+    })
+    _wait_flush(isolated_store)
+
+    from clawmetry.adapters.nemo import NemoClawAdapter
+    events = NemoClawAdapter().list_events("sess-2")
+    assert len(events) == 1
+    ex = events[0].extra
+    assert ex.get("attempt_number") == 1
+    assert ex.get("is_error") is True
+    assert ex.get("retry_response") == "retry"
+
+
+def test_tool_execution_end_success_preserves_is_error_false(isolated_store):
+    """is_error=False must not be dropped; False distinguishes success from missing."""
+    _seed(isolated_store, "sess-3", "tool_execution_end", {
+        "attemptNumber": 2,
+        "isError": False,
+        "retryResponse": "success",
+    })
+    _wait_flush(isolated_store)
+
+    from clawmetry.adapters.nemo import NemoClawAdapter
+    events = NemoClawAdapter().list_events("sess-3")
+    assert len(events) == 1
+    ex = events[0].extra
+    assert ex.get("is_error") is False
+    assert ex.get("retry_response") == "success"
+    assert ex.get("attempt_number") == 2
+
+
+def test_tool_execution_exhaustion(isolated_store):
+    """retryResponse='exhausted' must be visible so the dashboard can flag exhausted tool calls."""
+    _seed(isolated_store, "sess-4", "tool_execution_end", {
+        "attemptNumber": 3,
+        "isError": True,
+        "retryResponse": "exhausted",
+    })
+    _wait_flush(isolated_store)
+
+    from clawmetry.adapters.nemo import NemoClawAdapter
+    events = NemoClawAdapter().list_events("sess-4")
+    assert len(events) == 1
+    ex = events[0].extra
+    assert ex.get("retry_response") == "exhausted"
+    assert ex.get("is_error") is True
+    assert ex.get("attempt_number") == 3
+
+
+def test_plain_events_gain_no_spurious_retry_keys(isolated_store):
+    """Regular session events without retry fields must not gain attempt_number etc."""
+    _seed(isolated_store, "sess-5", "session.started", {"sessionId": "sess-5"})
+    _wait_flush(isolated_store)
+
+    from clawmetry.adapters.nemo import NemoClawAdapter
+    events = NemoClawAdapter().list_events("sess-5")
+    assert len(events) == 1
+    ex = events[0].extra
+    assert "attempt_number" not in ex
+    assert "is_error" not in ex
+    assert "retry_response" not in ex


### PR DESCRIPTION
Closes #3650

## Summary

- `NemoClawAdapter.list_events()` decoded the data blob only for `sandbox.audit_log` events; all other event types had their blobs silently ignored
- Restructured the blob-decode block to run for every event type, keeping the OCSF field extraction gated on the `sandbox.audit_log` check as before
- Added extraction of three advisor-session retry/exhaustion fields into `Event.extra`:
  - `attemptNumber` → `attempt_number` (int)
  - `isError` → `is_error` (bool; `is not None` guard preserves `False` for successful attempts)
  - `retryResponse` → `retry_response` (str: `'success'`, `'exhausted'`, `'retry'`)

## Test plan

- `python -m pytest tests/test_obs_gap_nemoclaw_advisor_tool_retry_3650.py -v` — 5 new tests all green
- `python -m pytest tests/test_obs_gap_nemoclaw_*.py tests/test_nemoclaw_runtime_adapter.py -v` — 120 existing tests pass, 13 pre-existing Flask-import failures unrelated to this change
- `python -m py_compile clawmetry/adapters/nemo.py` — syntax clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01DtvN9356BdLtYwFAyeGqHb)_