### PR TITLE
fix(obs-gap): surface model-router currency verdict on DetectResult.meta

### DIFF
--- a/clawmetry/adapters/openclaw.py
+++ b/clawmetry/adapters/openclaw.py
@@ -301,6 +301,35 @@ def _model_router_fingerprint() -> dict:
         return {}
 
 
+def _model_router_currency() -> dict:
+    """Compute the NemoClaw model-router currency verdict (#3652).
+
+    Mirrors ``isManagedModelRouterCurrent()`` from harness
+    ``src/lib/onboard/model-router.ts``: compares the installed fingerprint
+    (``<venv>/.nemoclaw-source-fingerprint``) against the expected/current
+    source pin (``<venv>/.nemoclaw-expected-fingerprint``) written by the
+    harness during onboarding to record the SHA the current NemoClaw version
+    pins its model-router to.
+
+    Returns ``{"modelRouterCurrent": bool}`` when both files are present and
+    readable; ``{}`` when either is absent (plain OpenClaw, old NemoClaw
+    installs that pre-date the expected-pin file, or no venv at all).
+    Never raises.
+    """
+    venv = os.environ.get("NEMOCLAW_MODEL_ROUTER_VENV") or os.path.expanduser(
+        os.path.join("~", ".nemoclaw", "model-router-venv"))
+    try:
+        with open(os.path.join(venv, ".nemoclaw-source-fingerprint"), encoding="utf-8") as fh:
+            installed = (fh.read() or "").strip()
+        with open(os.path.join(venv, ".nemoclaw-expected-fingerprint"), encoding="utf-8") as fh:
+            expected = (fh.read() or "").strip()
+        if not installed or not expected:
+            return {}
+        return {"modelRouterCurrent": installed == expected}
+    except (OSError, ValueError):
+        return {}
+
+
 def _resolve_ollama_host() -> str:
     """Return the active Ollama base URL from env vars or the default.
 
@@ -1304,6 +1333,10 @@ class OpenClawAdapter(AgentAdapter):
             # OpenClaw, so meta is unchanged there. (#2610 skill-catalog deferred
             # — see note above: no host-readable on-disk location.)
             meta.update(_model_router_fingerprint())
+            # Currency verdict (#3652): is the installed router up-to-date?
+            # Distinct from liveness (crashed vs alive); this catches the case
+            # where NemoClaw upgraded but the router wasn't reinstalled.
+            meta.update(_model_router_currency())
             meta.update(_model_router_proxy_config_models())
             # Runtime liveness (#2795). The fingerprint above only proves the
             # router was INSTALLED; probe /health so a crashed router is no

--- a/tests/test_obs_gap_nemoclaw_model_router_currency_3652.py
+++ b/tests/test_obs_gap_nemoclaw_model_router_currency_3652.py
@@ -1,0 +1,61 @@
+"""Tests for #3652 — NemoClaw model-router install currency/staleness verdict.
+
+Mirrors ``isManagedModelRouterCurrent()`` from harness
+``src/lib/onboard/model-router.ts``: a stale model-router (installed from
+an old source SHA that no longer matches the expected/current source pin)
+must be distinguishable from a current one in ``DetectResult.meta``.
+"""
+from __future__ import annotations
+
+import pytest
+
+from clawmetry.adapters.openclaw import _model_router_currency
+
+_SHA_A = "git:aaaa111122223333444455556666777788889999"
+_SHA_B = "git:bbbb111122223333444455556666777788889999"
+
+
+def _write_fps(venv_path, installed, expected=None):
+    (venv_path / ".nemoclaw-source-fingerprint").write_text(installed)
+    if expected is not None:
+        (venv_path / ".nemoclaw-expected-fingerprint").write_text(expected)
+
+
+def test_current_when_fingerprints_match(tmp_path, monkeypatch):
+    venv = tmp_path / "mrv"
+    venv.mkdir()
+    _write_fps(venv, _SHA_A, _SHA_A)
+    monkeypatch.setenv("NEMOCLAW_MODEL_ROUTER_VENV", str(venv))
+    assert _model_router_currency() == {"modelRouterCurrent": True}
+
+
+def test_stale_when_fingerprints_differ(tmp_path, monkeypatch):
+    venv = tmp_path / "mrv"
+    venv.mkdir()
+    _write_fps(venv, _SHA_A, _SHA_B)
+    monkeypatch.setenv("NEMOCLAW_MODEL_ROUTER_VENV", str(venv))
+    assert _model_router_currency() == {"modelRouterCurrent": False}
+
+
+def test_no_expected_file_returns_empty(tmp_path, monkeypatch):
+    """Old installs that pre-date the expected-pin file must return {} (unknown)."""
+    venv = tmp_path / "mrv"
+    venv.mkdir()
+    _write_fps(venv, _SHA_A)
+    monkeypatch.setenv("NEMOCLAW_MODEL_ROUTER_VENV", str(venv))
+    assert _model_router_currency() == {}
+
+
+def test_no_venv_returns_empty(tmp_path, monkeypatch):
+    """Plain OpenClaw installs (no venv) must return {} silently."""
+    monkeypatch.setenv("NEMOCLAW_MODEL_ROUTER_VENV", str(tmp_path / "nope"))
+    assert _model_router_currency() == {}
+
+
+def test_trailing_newline_stripped_before_compare(tmp_path, monkeypatch):
+    """Trailing newlines in fingerprint files must not cause false stale verdict."""
+    venv = tmp_path / "mrv"
+    venv.mkdir()
+    _write_fps(venv, _SHA_A + "\n", _SHA_A + "\n")
+    monkeypatch.setenv("NEMOCLAW_MODEL_ROUTER_VENV", str(venv))
+    assert _model_router_currency() == {"modelRouterCurrent": True}


### PR DESCRIPTION
Closes #3652

## Summary

- **`clawmetry/adapters/openclaw.py`** — adds `_model_router_currency()` (~25 LOC): reads `<venv>/.nemoclaw-source-fingerprint` (installed SHA) and `<venv>/.nemoclaw-expected-fingerprint` (current source pin written by NemoClaw onboarding), compares them, and returns `{"modelRouterCurrent": bool}`. Wired into `detect()` right after `_model_router_fingerprint()`. Returns `{}` on plain OpenClaw or old installs (graceful no-op). Never raises.
- **`tests/test_obs_gap_nemoclaw_model_router_currency_3652.py`** (new, ~50 LOC) — 5 tests: matching SHAs → `True`, mismatched → `False`, missing expected-pin file → `{}`, no venv → `{}`, trailing newline stripped before compare.

This surfaces the gap identified in #3652: a stale managed router (installed from an old source SHA after NemoClaw upgrade) was not distinguishable from a current one in `DetectResult.meta`, even though `isManagedModelRouterCurrent()` already computes this in the harness.

## Test plan

- `python3 -m py_compile clawmetry/adapters/openclaw.py` — syntax clean ✅
- `python3 -m pytest tests/test_obs_gap_nemoclaw_model_router_currency_3652.py -v` — 5/5 pass ✅
- `python3 -m pytest tests/test_obs_gap_talk_sandbox.py -v` — all model-router related tests still pass ✅

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lm6X6q8krStLCAov7TYS1F)_