### PR TITLE
[RELEASE] docs(moat): document cloud-sync roundtrip E2E coverage — closes #1456

### DIFF
--- a/tests/MOAT_EVENT_SHAPES.md
+++ b/tests/MOAT_EVENT_SHAPES.md
@@ -15,3 +15,19 @@ so OpenClaw event-shape drift cannot be hidden by synthetic-only tests.
 | tool_call | tests/test_moat_regression_1129.py, tests/test_moat_send_message_e2e.py | tests/test_moat_live_openclaw_e2e.py | 2026-05-18 |
 | test.crash_recovery | tests/test_moat_daemon_crash_recovery.py | tests/test_moat_live_openclaw_e2e.py | 2026-05-20 |
 | trace.artifacts | tests/test_moat_regression_1129.py | tests/test_moat_live_openclaw_e2e.py | 2026-05-18 |
+
+## Cloud-sync roundtrip coverage
+
+The encrypted upload → cloud cache → dashboard decrypt arc is covered by
+`tests/test_moat_cloud_roundtrip_e2e.py` (5 hermetic tests, wired into CI
+since 2026-05-17, no live cloud infra required):
+
+| Test | Contract locked in |
+|------|--------------------|
+| `test_envelope_shape_matches_documented_contract` | `{key, ttl_s, blob}` cross-repo envelope; cache key format; no plaintext leaks |
+| `test_mock_cloud_receives_and_stores_ciphertext` | Heartbeat POST delivers ciphertext to mock cloud; stored under correct key |
+| `test_stored_ciphertext_decrypts_to_original_events` | AES-256-GCM roundtrip; decrypted payload matches v3 event shape + content |
+| `test_cloud_brain_endpoint_serves_blob_back` | `/api/cloud/brain?key=…` returns blob with correct `_source`/`_shape` fields |
+| `test_dashboard_client_decrypt_reproduces_original` | Served blob decrypts byte-for-byte to what the daemon originally encrypted |
+
+Resolves the P0 gap tracked in issue #1456.

--- a/tests/MOAT_EVENT_SHAPES.md
+++ b/tests/MOAT_EVENT_SHAPES.md
@@ -22,12 +22,10 @@ The encrypted upload → cloud cache → dashboard decrypt arc is covered by
 `tests/test_moat_cloud_roundtrip_e2e.py` (5 hermetic tests, wired into CI
 since 2026-05-17, no live cloud infra required):
 
-| Test | Contract locked in |
-|------|--------------------|
-| `test_envelope_shape_matches_documented_contract` | `{key, ttl_s, blob}` cross-repo envelope; cache key format; no plaintext leaks |
-| `test_mock_cloud_receives_and_stores_ciphertext` | Heartbeat POST delivers ciphertext to mock cloud; stored under correct key |
-| `test_stored_ciphertext_decrypts_to_original_events` | AES-256-GCM roundtrip; decrypted payload matches v3 event shape + content |
-| `test_cloud_brain_endpoint_serves_blob_back` | `/api/cloud/brain?key=…` returns blob with correct `_source`/`_shape` fields |
-| `test_dashboard_client_decrypt_reproduces_original` | Served blob decrypts byte-for-byte to what the daemon originally encrypted |
+- `test_envelope_shape_matches_documented_contract` — `{key, ttl_s, blob}` cross-repo envelope; cache key format; no plaintext leaks
+- `test_mock_cloud_receives_and_stores_ciphertext` — Heartbeat POST delivers ciphertext to mock cloud; stored under correct key
+- `test_stored_ciphertext_decrypts_to_original_events` — AES-256-GCM roundtrip; decrypted payload matches v3 event shape + content
+- `test_cloud_brain_endpoint_serves_blob_back` — `/api/cloud/brain?key=…` returns blob with correct `_source`/`_shape` fields
+- `test_dashboard_client_decrypt_reproduces_original` — Served blob decrypts byte-for-byte to what the daemon originally encrypted
 
 Resolves the P0 gap tracked in issue #1456.


### PR DESCRIPTION
## Summary

- `tests/MOAT_EVENT_SHAPES.md` gains a new **Cloud-sync roundtrip coverage** section listing all 5 hermetic tests in `test_moat_cloud_roundtrip_e2e.py` and the exact contracts each one pins.
- No production code changed; single-file docs-only update.

## Background

Issue #1456 flagged a P0 gap: no E2E test for the full arc `daemon DuckDB → AES-256-GCM encrypt → /ingest/events → cloud cache → /api/cloud/brain → client decrypt`. The fix (`tests/test_moat_cloud_roundtrip_e2e.py`, 5 hermetic tests with an in-process mock cloud server) landed on `main` in 2026-05-17 (SHA `5889173c`) and has been running in CI since. This PR adds the manifest entry that documents what those tests cover so future contributors don't have to dig into the test source to verify coverage.

closes #1456

---
_Generated by [Claude Code](https://claude.ai/code/session_019b3x9iww5YLgV2TqXm8qwH)_