### PR TITLE
feat(obs-gap): ingest NemoClaw onboarding trace-timing artifact

### DIFF
--- a/clawmetry/adapters/nemo.py
+++ b/clawmetry/adapters/nemo.py
@@ -910,6 +910,80 @@ def _read_nemoclaw_sandbox_lifecycle() -> dict:
     return {"sandboxes": sandboxes}
 
 
+_NEMOCLAW_TRACE_TIMING_SCHEMA = "nemoclaw.trace_timing.v1"
+
+
+def _read_onboard_trace_timing() -> dict:
+    """Read the NemoClaw onboarding trace-timing artifact (#3651).
+
+    Tries several candidate paths for the JSON artifact written by the harness
+    during onboarding (``src/lib/onboard/tracing``). Validates
+    ``schema_version`` and surfaces:
+    - ``onboardTotalDurationMs`` (int) — total onboarding wall-clock time
+    - ``onboardPhases`` (dict) — per-phase durations keyed by phase name
+
+    Handles both dict-format phases ``{phase_name: duration_ms}`` and
+    list-format phases ``[{name, duration_ms}]``.  Returns ``{}`` when the
+    file is absent, the schema mismatches, or any parse error occurs — never
+    raises.
+    """
+    import os as _os
+    import json as _json
+    from pathlib import Path
+
+    home = Path.home()
+    nemoclaw_dir = home / ".nemoclaw"
+    env_path = _os.environ.get("NEMOCLAW_TRACE_TIMING_PATH", "")
+    candidates = [
+        Path(env_path) if env_path else None,
+        nemoclaw_dir / "onboard-trace-timing.json",
+        nemoclaw_dir / "scorecard" / "trace-timing.json",
+        nemoclaw_dir / "scorecard-trace-timing.json",
+    ]
+
+    for path in candidates:
+        if path is None or not path.exists():
+            continue
+        try:
+            raw = _json.loads(path.read_text(encoding="utf-8"))
+        except Exception as exc:
+            logger.debug("nemoclaw onboard trace-timing read failed (%s): %s", path, exc)
+            continue
+        if not isinstance(raw, dict):
+            continue
+        if raw.get("schema_version") != _NEMOCLAW_TRACE_TIMING_SCHEMA:
+            logger.debug(
+                "nemoclaw onboard trace-timing schema mismatch (%s): got %r",
+                path,
+                raw.get("schema_version"),
+            )
+            continue
+        out: dict = {}
+        total = raw.get("total_duration_ms")
+        if isinstance(total, (int, float)) and total >= 0:
+            out["onboardTotalDurationMs"] = int(total)
+        phases_raw = raw.get("phases", raw.get("phase_breakdown"))
+        if isinstance(phases_raw, dict):
+            out["onboardPhases"] = {
+                str(k): int(v)
+                for k, v in phases_raw.items()
+                if isinstance(v, (int, float))
+            }
+        elif isinstance(phases_raw, list):
+            phases_dict: dict = {}
+            for entry in phases_raw:
+                if isinstance(entry, dict):
+                    name = entry.get("name") or entry.get("phase")
+                    dur = entry.get("duration_ms") or entry.get("durationMs")
+                    if name and isinstance(dur, (int, float)):
+                        phases_dict[str(name)] = int(dur)
+            if phases_dict:
+                out["onboardPhases"] = phases_dict
+        if out:
+            return out
+    return {}
+
+
 class NemoClawAdapter(AgentAdapter):
     """Read-side adapter for the NemoClaw Free runtime.
 
@@ -939,6 +1013,7 @@ class NemoClawAdapter(AgentAdapter):
         meta.update(_read_model_router_model_list())
         meta.update(_read_nemoclaw_sandbox_lifecycle())
         meta["ollama_inference"] = _read_nemoclaw_ollama_inference()
+        meta.update(_read_onboard_trace_timing())
         return DetectResult(
             name=self.name,
             display_name=self.display_name,

--- a/tests/test_obs_gap_nemoclaw_trace_timing_3651.py
+++ b/tests/test_obs_gap_nemoclaw_trace_timing_3651.py
@@ -1,0 +1,95 @@
+"""Tests for #3651 — NemoClaw onboarding trace-timing ingestion.
+
+Verifies that ``_read_onboard_trace_timing()`` surfaces
+``onboardTotalDurationMs`` and ``onboardPhases`` from the
+``nemoclaw.trace_timing.v1`` artifact written by the harness during
+onboarding.  The function must return ``{}`` silently on any failure
+(absent file, schema mismatch, corrupt JSON).
+"""
+from __future__ import annotations
+
+import json
+import pytest
+
+from clawmetry.adapters.nemo import _read_onboard_trace_timing
+
+_SCHEMA = "nemoclaw.trace_timing.v1"
+
+
+def _write_artifact(path, content):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(content), encoding="utf-8")
+
+
+def test_absent_file_returns_empty(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("NEMOCLAW_TRACE_TIMING_PATH", raising=False)
+    assert _read_onboard_trace_timing() == {}
+
+
+def test_schema_mismatch_returns_empty(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("NEMOCLAW_TRACE_TIMING_PATH", raising=False)
+    artifact = tmp_path / ".nemoclaw" / "onboard-trace-timing.json"
+    _write_artifact(artifact, {"schema_version": "nemoclaw.trace_timing.v0", "total_duration_ms": 1000})
+    assert _read_onboard_trace_timing() == {}
+
+
+def test_dict_format_phases(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("NEMOCLAW_TRACE_TIMING_PATH", raising=False)
+    artifact = tmp_path / ".nemoclaw" / "onboard-trace-timing.json"
+    _write_artifact(artifact, {
+        "schema_version": _SCHEMA,
+        "total_duration_ms": 4200,
+        "phases": {
+            "nemoclaw.onboard.phase.preflight": 800,
+            "nemoclaw.onboard.phase.install": 3400,
+        },
+    })
+    result = _read_onboard_trace_timing()
+    assert result["onboardTotalDurationMs"] == 4200
+    assert result["onboardPhases"]["nemoclaw.onboard.phase.preflight"] == 800
+    assert result["onboardPhases"]["nemoclaw.onboard.phase.install"] == 3400
+
+
+def test_list_format_phases(tmp_path, monkeypatch):
+    """List-of-objects phase format is supported defensively."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("NEMOCLAW_TRACE_TIMING_PATH", raising=False)
+    artifact = tmp_path / ".nemoclaw" / "onboard-trace-timing.json"
+    _write_artifact(artifact, {
+        "schema_version": _SCHEMA,
+        "total_duration_ms": 2000,
+        "phases": [
+            {"name": "nemoclaw.onboard.phase.preflight", "duration_ms": 500},
+            {"name": "nemoclaw.onboard.phase.validate", "duration_ms": 1500},
+        ],
+    })
+    result = _read_onboard_trace_timing()
+    assert result["onboardTotalDurationMs"] == 2000
+    assert result["onboardPhases"]["nemoclaw.onboard.phase.preflight"] == 500
+    assert result["onboardPhases"]["nemoclaw.onboard.phase.validate"] == 1500
+
+
+def test_corrupt_json_returns_empty(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("NEMOCLAW_TRACE_TIMING_PATH", raising=False)
+    artifact = tmp_path / ".nemoclaw" / "onboard-trace-timing.json"
+    artifact.parent.mkdir(parents=True, exist_ok=True)
+    artifact.write_text("{not valid json{{", encoding="utf-8")
+    assert _read_onboard_trace_timing() == {}
+
+
+def test_env_var_override_path(tmp_path, monkeypatch):
+    """NEMOCLAW_TRACE_TIMING_PATH overrides the default candidate list."""
+    custom = tmp_path / "custom" / "trace.json"
+    _write_artifact(custom, {
+        "schema_version": _SCHEMA,
+        "total_duration_ms": 999,
+        "phases": {"nemoclaw.onboard.phase.preflight": 999},
+    })
+    monkeypatch.setenv("NEMOCLAW_TRACE_TIMING_PATH", str(custom))
+    monkeypatch.setenv("HOME", str(tmp_path / "empty_home"))
+    result = _read_onboard_trace_timing()
+    assert result["onboardTotalDurationMs"] == 999


### PR DESCRIPTION
Closes #3651

## Summary

- Adds `_read_onboard_trace_timing() -> dict` to `clawmetry/adapters/nemo.py` following the exact same defensive multi-path pattern as `_read_nemoclaw_skill_catalog()` and friends
- Surfaces `onboardTotalDurationMs` (int) and `onboardPhases` (dict of phase→duration_ms) into `DetectResult.meta` when the harness-written `nemoclaw.trace_timing.v1` JSON artifact is present
- Handles both dict-format phases `{name: ms}` and list-format phases `[{name, duration_ms}]` defensively; returns `{}` silently on any failure (absent file, schema mismatch, corrupt JSON) — zero risk to existing installs

## Test plan

- `python3 -m pytest tests/test_obs_gap_nemoclaw_trace_timing_3651.py -v` — 6 tests, all green:
  - absent file → `{}`
  - schema version mismatch → `{}`
  - dict-format phases → correct `onboardTotalDurationMs` + `onboardPhases`
  - list-format phases → same keys
  - corrupt JSON → `{}`
  - `NEMOCLAW_TRACE_TIMING_PATH` env var override → reads custom path

---
_Generated by [Claude Code](https://claude.ai/code/session_01DFMKp61ocM3LY83f4HeoQk)_