### PR TITLE
ci(e2e): C6 daily auto-heal when E2E_ADMIN_PAT is configured

### DIFF
--- a/.github/workflows/c6-schedule-heal.yml
+++ b/.github/workflows/c6-schedule-heal.yml
@@ -1,0 +1,83 @@
+name: C6 auto-heal (daily required-checks application)
+
+# Applies required E2E status checks to main branch protection daily.
+# Self-heals C6 the morning after E2E_ADMIN_PAT secret is added.
+#
+# Why this is needed:
+#   apply-required-checks.yml runs on push and workflow_dispatch but its
+#   apply step condition (`push || confirm==APPLY`) is never true for a
+#   schedule trigger. Adding a schedule to that file would run the workflow
+#   but execute zero steps. This dedicated workflow avoids that confusion.
+#
+# When E2E_ADMIN_PAT is NOT set:
+#   logs a one-line hint and exits 0 -- no red badge, no noise.
+#
+# When E2E_ADMIN_PAT IS set:
+#   runs scripts/apply_required_status_checks.py which configures required
+#   status checks across clawmetry, clawmetry-cloud, clawmetry-landing.
+#   Idempotent: safe to re-run when already configured.
+#
+# To close C6 without waiting for tomorrow:
+#   Actions > "Apply required E2E status checks (C6 -- one-shot)" >
+#   confirm=APPLY, pat_token=<PAT> > Run workflow
+#
+# To close C6 automatically:
+#   Settings > Secrets > Actions > New secret: E2E_ADMIN_PAT
+#   Value: fine-grained PAT with Administration (read+write) on:
+#     clawmetry, clawmetry-cloud, clawmetry-landing
+#   This workflow picks it up at 10:15am UTC and closes C6 automatically.
+#
+# Tracking: vivekchand/clawmetry#2146 (C6)
+
+on:
+  schedule:
+    - cron: '15 10 * * *'  # 10:15am UTC daily, 15 min after c6-health audit
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  c6-auto-heal:
+    name: C6 auto-heal (apply required checks if E2E_ADMIN_PAT is set)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Check for admin token
+        id: pat-check
+        env:
+          ADMIN_PAT: ${{ secrets.E2E_ADMIN_PAT }}
+        run: |
+          if [ -z "${ADMIN_PAT}" ]; then
+            echo "has_pat=false" >> "$GITHUB_OUTPUT"
+            echo "No E2E_ADMIN_PAT configured -- skipping C6 auto-heal."
+            echo ""
+            echo "To enable automatic C6 closure:"
+            echo "  1. Create a fine-grained PAT at https://github.com/settings/personal-access-tokens/new"
+            echo "     Resource owner: vivekchand"
+            echo "     Repos: clawmetry, clawmetry-cloud, clawmetry-landing"
+            echo "     Permission: Administration -- read+write"
+            echo "  2. Add it as a repo secret: Settings > Secrets > Actions > New secret"
+            echo "     Name: E2E_ADMIN_PAT"
+            echo "  This workflow will close C6 automatically the next morning at 10:15am UTC."
+            echo ""
+            echo "  Tracking: https://github.com/vivekchand/clawmetry/issues/2146"
+          else
+            echo "has_pat=true" >> "$GITHUB_OUTPUT"
+            echo "E2E_ADMIN_PAT found -- applying required E2E status checks."
+          fi
+
+      - name: Apply required E2E status checks (C6)
+        if: steps.pat-check.outputs.has_pat == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.E2E_ADMIN_PAT }}
+        run: python3 scripts/apply_required_status_checks.py
+
+      - name: Summary
+        if: steps.pat-check.outputs.has_pat == 'true'
+        run: |
+          echo "C6 auto-heal complete."
+          echo "If apply_required_status_checks.py exited 0, branch protection is configured"
+          echo "on clawmetry/main, clawmetry-cloud/main, clawmetry-landing/main."
+          echo "C6 is now GREEN. Tracking: https://github.com/vivekchand/clawmetry/issues/2146"


### PR DESCRIPTION
## Summary

**Tracking: vivekchand/clawmetry#2146 (C6)**

C1/C2/C3/C4/C5/C7 have been green for 7+ days. C6 (required-status-checks) is the sole remaining gap.

**Root cause of the stall**: `apply-required-checks.yml` runs on `push` and `workflow_dispatch` but its apply step guard (`push || confirm==APPLY`) is always false for a `schedule` trigger. Adding `schedule` to that file would queue a run that executes zero meaningful steps. There was no automated daily attempt to close C6 even when `E2E_ADMIN_PAT` became available.

**This PR**: adds `c6-schedule-heal.yml` -- a focused daily workflow at 10:15am UTC that:
- Silently exits 0 when `E2E_ADMIN_PAT` is absent (no red badge, no noise)
- Runs `scripts/apply_required_status_checks.py` with the PAT when present (configures branch protection across all 3 repos)

## How to close C6 (two options, both simpler than before)

**Option A (automatic, one-time setup):**
1. Create a fine-grained PAT: https://github.com/settings/personal-access-tokens/new
   - Resource owner: `vivekchand`
   - Repos: `clawmetry`, `clawmetry-cloud`, `clawmetry-landing`
   - Permission: Administration -- read+write
2. Add it as: Settings > Secrets > Actions > New secret > `E2E_ADMIN_PAT`
3. Done -- this workflow closes C6 automatically at 10:15am UTC next morning

**Option B (immediate, no secret needed):**
Actions > "Apply required E2E status checks (C6 -- one-shot)" > `confirm=APPLY`, `pat_token=<PAT>` > Run workflow

## Verification

After merging: check that the daily 10:15am UTC run of this workflow appears green once `E2E_ADMIN_PAT` is set. Until the secret is added, runs show the "No E2E_ADMIN_PAT" hint and exit 0.

## Current E2E status (2026-07-12)

| Criterion | Status |
|-----------|--------|
| C1 OSS golden path | GREEN -- 5/5 runs success today |
| C2 Cloud golden path | GREEN |
| C3 Landing golden path | GREEN |
| C4 Cross-repo handoff | GREEN |
| C5 Visual-diff all tabs | GREEN -- 33-tab sweep in oss-golden-path.yml passing |
| **C6 Required-status-checks** | **RED -- this PR unblocks auto-close** |
| C7 Failure quarantine | GREEN |

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRK5dc4ZtAG93UHP1iF9o)_