### PR TITLE
fix: surface runtimeAlias and thinkingMode in list_sessions() (#3672)

### DIFF
--- a/clawmetry/adapters/openclaw.py
+++ b/clawmetry/adapters/openclaw.py
@@ -1503,6 +1503,31 @@ class OpenClawAdapter(AgentAdapter):
             )
             if _fb_runtime is not None:
                 extra["fallbackRuntime"] = _fb_runtime
+            # Atomic runtime alias (#3672): CHANGELOG #98021 "GPT-5.6 Ultra
+            # and runtime switching" added Sol/Terra/Luna as named runtime
+            # variants switched atomically with model and thinking via /model
+            # and fallback.  Capture the selected alias so cost/model
+            # attribution can distinguish which variant served the session.
+            _rt_alias = (
+                s.get("runtimeAlias")
+                or s.get("selectedRuntimeAlias")
+                or s.get("modelRuntimeAlias")
+            )
+            if _rt_alias is not None:
+                extra["runtimeAlias"] = _rt_alias
+            # Thinking-mode selection (#3672): atomic alongside runtimeAlias;
+            # surface as-is (bool or string) so the dashboard can show whether
+            # extended thinking was active.  Use is-not-None guards so
+            # thinkingMode=False (thinking disabled) is never silently dropped.
+            _thinking_mode = s.get("thinkingMode")
+            if _thinking_mode is None:
+                _thinking_mode = s.get("isThinkingEnabled")
+            if _thinking_mode is None:
+                _thinking_mode = s.get("thinkingEnabled")
+            if _thinking_mode is not None:
+                extra["thinkingMode"] = (
+                    _thinking_mode if isinstance(_thinking_mode, str) else bool(_thinking_mode)
+                )
             # /think reasoning-level tier (#3324): PR #94067 stores the active
             # level (light/medium/deep) on session records; surface when present.
             _think_level = s.get("thinkLevel") or s.get("reasoningLevel")

--- a/tests/test_obs_gap_openclaw_runtime_alias_3672.py
+++ b/tests/test_obs_gap_openclaw_runtime_alias_3672.py
@@ -1,0 +1,94 @@
+"""Regression tests for issue #3672.
+
+CHANGELOG #98021 ("GPT-5.6 Ultra and runtime switching") added Sol, Terra,
+and Luna as named runtime aliases switched atomically with model and thinking
+mode.  ClawMetry was not capturing either field: ``list_sessions()`` never
+placed ``runtimeAlias`` or ``thinkingMode`` in ``Session.extra``.
+"""
+
+import clawmetry.adapters.openclaw as ocmod
+
+
+class _FakeDash:
+    def __init__(self, **fields):
+        self._fields = fields
+
+    def _get_sessions(self):
+        row = {"sessionId": "sess-3672-1"}
+        row.update(self._fields)
+        return [row]
+
+
+def test_list_sessions_surfaces_runtime_alias(monkeypatch):
+    monkeypatch.setattr(ocmod, "_d", lambda: _FakeDash(runtimeAlias="sol"))
+    sessions = ocmod.OpenClawAdapter().list_sessions(limit=10)
+    assert len(sessions) == 1
+    assert sessions[0].extra.get("runtimeAlias") == "sol", (
+        "list_sessions() must surface 'runtimeAlias' in Session.extra"
+    )
+
+
+def test_list_sessions_surfaces_runtime_alias_via_selected_alias(monkeypatch):
+    monkeypatch.setattr(ocmod, "_d", lambda: _FakeDash(selectedRuntimeAlias="terra"))
+    sessions = ocmod.OpenClawAdapter().list_sessions(limit=10)
+    assert sessions[0].extra.get("runtimeAlias") == "terra", (
+        "list_sessions() must handle 'selectedRuntimeAlias' as a fallback key"
+    )
+
+
+def test_list_sessions_surfaces_runtime_alias_via_model_runtime_alias(monkeypatch):
+    monkeypatch.setattr(ocmod, "_d", lambda: _FakeDash(modelRuntimeAlias="luna"))
+    sessions = ocmod.OpenClawAdapter().list_sessions(limit=10)
+    assert sessions[0].extra.get("runtimeAlias") == "luna", (
+        "list_sessions() must handle 'modelRuntimeAlias' as a second fallback key"
+    )
+
+
+def test_list_sessions_omits_runtime_alias_when_absent(monkeypatch):
+    monkeypatch.setattr(ocmod, "_d", lambda: _FakeDash())
+    sessions = ocmod.OpenClawAdapter().list_sessions(limit=10)
+    assert "runtimeAlias" not in sessions[0].extra, (
+        "runtimeAlias must be absent when the session record omits it"
+    )
+
+
+def test_list_sessions_surfaces_thinking_mode_true(monkeypatch):
+    monkeypatch.setattr(ocmod, "_d", lambda: _FakeDash(thinkingMode=True))
+    sessions = ocmod.OpenClawAdapter().list_sessions(limit=10)
+    assert sessions[0].extra.get("thinkingMode") is True, (
+        "list_sessions() must surface thinkingMode=True in Session.extra"
+    )
+
+
+def test_list_sessions_surfaces_thinking_mode_false(monkeypatch):
+    """thinkingMode=False must NOT be dropped (thinking disabled is meaningful)."""
+    monkeypatch.setattr(ocmod, "_d", lambda: _FakeDash(thinkingMode=False))
+    sessions = ocmod.OpenClawAdapter().list_sessions(limit=10)
+    assert "thinkingMode" in sessions[0].extra, (
+        "list_sessions() must not drop thinkingMode=False"
+    )
+    assert sessions[0].extra["thinkingMode"] is False
+
+
+def test_list_sessions_surfaces_thinking_mode_via_is_thinking_enabled(monkeypatch):
+    monkeypatch.setattr(ocmod, "_d", lambda: _FakeDash(isThinkingEnabled=True))
+    sessions = ocmod.OpenClawAdapter().list_sessions(limit=10)
+    assert sessions[0].extra.get("thinkingMode") is True, (
+        "list_sessions() must handle 'isThinkingEnabled' as a fallback key"
+    )
+
+
+def test_list_sessions_surfaces_thinking_mode_string(monkeypatch):
+    monkeypatch.setattr(ocmod, "_d", lambda: _FakeDash(thinkingMode="extended"))
+    sessions = ocmod.OpenClawAdapter().list_sessions(limit=10)
+    assert sessions[0].extra.get("thinkingMode") == "extended", (
+        "list_sessions() must preserve string thinkingMode values unchanged"
+    )
+
+
+def test_list_sessions_omits_thinking_mode_when_absent(monkeypatch):
+    monkeypatch.setattr(ocmod, "_d", lambda: _FakeDash())
+    sessions = ocmod.OpenClawAdapter().list_sessions(limit=10)
+    assert "thinkingMode" not in sessions[0].extra, (
+        "thinkingMode must be absent when the session record omits it"
+    )


### PR DESCRIPTION
Closes #3672

## Summary

- CHANGELOG #98021 ("GPT-5.6 Ultra and runtime switching") added Sol/Terra/Luna as named runtime aliases switched atomically with model and thinking mode; ClawMetry wasn't capturing either field in `Session.extra`.
- Adds `runtimeAlias` extraction in `list_sessions()` (with fallbacks `selectedRuntimeAlias`, `modelRuntimeAlias`) so cost/model attribution can distinguish which runtime variant served a session.
- Adds `thinkingMode` extraction (with fallbacks `isThinkingEnabled`, `thinkingEnabled`) using `is not None` guards so `thinkingMode=False` is never silently dropped.

## Test plan

- [ ] `python3 -m pytest tests/test_obs_gap_openclaw_runtime_alias_3672.py -v` — 9 new tests, all pass
- [ ] `python3 -m pytest tests/test_obs_gap_openclaw_fallback_runtime_3649.py tests/test_obs_gap_openclaw_utility_model_3538.py tests/test_obs_gap_openclaw_capability_profile_3469.py -v` — no regressions in adjacent obs-gap tests (4 pre-existing failures due to missing `duckdb` in test environment, unrelated to this change)
- [ ] `python3 -m py_compile clawmetry/adapters/openclaw.py` — syntax clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01DDLSydGgkn17cbkcaysRBy)_