### PR TITLE
feat(entitlement): tier_spec_batch + /api/entitlement/tier-spec-batch

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -6264,6 +6264,87 @@ def tier_spec(tier: str) -> dict | None:
     }
 
 
+def tier_spec_batch(tiers) -> dict:
+    """Plural sibling of :func:`tier_spec`: return spec rows for a
+    caller-supplied subset of tier ids in one pass.
+
+    Mirrors :func:`feature_spec_batch` / :func:`runtime_spec_batch` /
+    :func:`channel_spec_batch` on the tier axis. Where :func:`tier_catalog`
+    returns rows for *every* known tier, this lets a pricing-comparison
+    matrix UI hydrate only the N rows it is about to render off **one**
+    round-trip instead of N calls to ``/api/entitlement/tier-spec``. Each
+    returned row is byte-identical to the corresponding row from
+    :func:`tier_catalog` (and to the scalar :func:`tier_spec` for the same
+    id) -- a parity test pins this so the scalar / bulk / batch accessors
+    cannot drift.
+
+    Shape::
+
+        {
+          "tiers":   [<spec_row>, ...],   # one per known supplied id, in supply order
+          "unknown": ["bogus_id", ...],   # supplied ids not in _TIER_ORDER, in supply order
+        }
+
+    Supplied ids are normalised via :func:`_normalise_csv` (whitespace
+    stripped, lowercased, duplicates dropped while preserving first-seen
+    order) so the response is stable across repeated calls. ``trial`` IS
+    accepted (it lives in :data:`_TIER_ORDER` and the scalar helper
+    resolves it). Empty / ``None`` input returns
+    ``{"tiers": [], "unknown": []}`` -- the HTTP wrapper turns that into
+    a 400, this helper does not raise.
+
+    Resolver-independent for every catalogue field: only the
+    ``is_current`` flag on each row depends on the resolved entitlement,
+    so grace vs enforce yields byte-identical rows apart from that flag.
+    Never raises: a resolver failure short-circuits to the OSS-free
+    fallback (``is_current`` degrades to False for non-OSS rows) so the
+    matrix keeps rendering, and a per-tier row-build failure drops that
+    id into ``unknown[]`` while the rest of the batch keeps going.
+    """
+    ids = _normalise_csv(tiers)
+    try:
+        ent = get_entitlement()
+        current = ent.tier
+    except Exception as exc:
+        logger.warning(
+            "entitlements: tier_spec_batch falling back to OSS-free: %s", exc
+        )
+        current = TIER_OSS
+    paid_runtimes_sorted = sorted(PAID_RUNTIMES)
+    rows: list[dict] = []
+    unknown: list[str] = []
+    for tid in ids:
+        if tid not in _TIER_ORDER:
+            unknown.append(tid)
+            continue
+        try:
+            paid_feats = _TIER_FEATURES.get(tid, frozenset())
+            unlocks_paid = tid in _TIER_PAID_RUNTIMES
+            rows.append(
+                {
+                    "id": tid,
+                    "label": tier_label(tid),
+                    "is_paid": tid in _PAID_TIERS,
+                    "is_current": tid == current,
+                    "rank": _TIER_ORDER.index(tid),
+                    "unlocks_paid_runtimes": unlocks_paid,
+                    "retention_days": _TIER_RETENTION_DAYS.get(tid, 7),
+                    "channel_limit": _TIER_CHANNEL_LIMIT.get(
+                        tid, _FREE_CHANNEL_LIMIT
+                    ),
+                    "node_limit": _TIER_NODE_LIMIT.get(tid, _FREE_NODE_LIMIT),
+                    "features": sorted(paid_feats),
+                    "runtimes": list(paid_runtimes_sorted) if unlocks_paid else [],
+                }
+            )
+        except Exception as exc:
+            logger.warning(
+                "entitlements: tier_spec_batch row %r failed: %s", tid, exc
+            )
+            unknown.append(tid)
+    return {"tiers": rows, "unknown": unknown}
+
+
 def tier_catalog_at(tier: str) -> list[dict] | None:
     """What-if sibling of :func:`tier_catalog`: the full tier ladder with
     ``is_current`` recomputed as if the install were on ``tier`` instead of

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -6080,6 +6080,74 @@ def api_entitlement_tier_spec():
         return jsonify({"error": "tier-spec failed"}), 500
 
 
+@bp_entitlement.route("/api/entitlement/tier-spec-batch")
+def api_entitlement_tier_spec_batch():
+    """``GET /api/entitlement/tier-spec-batch?tiers=a,b,c`` -- plural
+    sibling of ``/api/entitlement/tier-spec``.
+
+    Returns the full catalogue spec row for every supplied tier id in
+    one round-trip. Mirrors the scalar / batch pair
+    :func:`api_entitlement_feature_spec_batch` and
+    :func:`api_entitlement_runtime_spec_batch` establish on the feature
+    / runtime axes, so a pricing-comparison matrix UI hydrates the N
+    visible tier rows off one call instead of N calls to
+    ``/tier-spec``.
+
+    Each ``tiers[]`` entry is byte-identical to a row from
+    :func:`entitlements.tier_catalog` (and to the scalar
+    :func:`entitlements.tier_spec` for the same id) -- a parity test
+    pins this so the scalar / bulk / batch accessors cannot drift.
+    Supplied ids are normalised (whitespace stripped, lowercased,
+    duplicates dropped while preserving first-seen order). Unknown ids
+    do not 404 the call -- they are echoed in ``unknown[]`` so a
+    partially-bad caller still gets rows back for the valid ids
+    alongside a list of what was dropped.
+
+    Response shape::
+
+        {
+          "tiers":             [<spec_row>, ...],
+          "unknown":           ["bogus_id", ...],
+          "current_tier":      "...",
+          "current_tier_rank": <int>,
+          "grace":             <bool>,
+          "enforced":          <bool>,
+        }
+
+    - **400** when ``tiers=`` is missing or empty after normalisation
+    - **Never 5xxs**: a resolver crash short-circuits to the OSS-free
+      shape (empty rows, ``current_tier=oss``, ``grace=true``).
+    """
+    try:
+        tiers = _parse_csv_arg("tiers")
+        if not tiers:
+            return (
+                jsonify({"error": "supply tiers=<csv>"}),
+                400,
+            )
+        from clawmetry import entitlements as _ent
+
+        batch = _ent.tier_spec_batch(tiers)
+        ent = _ent.get_entitlement()
+        batch["current_tier"] = ent.tier
+        batch["current_tier_rank"] = _ent.tier_rank(ent.tier)
+        batch["grace"] = bool(ent.grace)
+        batch["enforced"] = _ent.is_enforced()
+        return jsonify(batch)
+    except Exception as exc:
+        logger.warning("api_entitlement_tier_spec_batch: error: %s", exc)
+        return jsonify(
+            {
+                "tiers": [],
+                "unknown": [],
+                "current_tier": "oss",
+                "current_tier_rank": 0,
+                "grace": True,
+                "enforced": False,
+            }
+        )
+
+
 @bp_entitlement.route("/api/features")
 def api_features():
     try:

--- a/tests/test_entitlement_tier_spec_batch.py
+++ b/tests/test_entitlement_tier_spec_batch.py
@@ -1,0 +1,340 @@
+"""Tests for ``clawmetry.entitlements.tier_spec_batch`` + ``GET
+/api/entitlement/tier-spec-batch``.
+
+``tier_spec_batch`` is the plural / caller-subset sibling of
+:func:`tier_spec` on the tier axis -- the batch accessor a pricing-page
+matrix UI hydrates the N rows it is about to render off in ONE
+round-trip instead of N calls to ``/api/entitlement/tier-spec``. Each
+returned row must be byte-identical to the corresponding row from
+:func:`tier_catalog` (and to the scalar :func:`tier_spec`) so the
+scalar / bulk / batch accessors cannot drift; the parity tests below
+pin that.
+
+Coverage mirrors ``test_entitlement_channel_spec_batch.py`` /
+``test_entitlement_feature_spec_batch``-style tests where they exist:
+
+* helper row shape matches ``tier_spec`` / ``tier_catalog`` for the
+  same id (no drift between the scalar and bulk accessors)
+* input is normalised (whitespace stripped, lowercased, duplicates
+  dropped, first-seen order preserved) and both CSV strings and
+  iterables of ids are accepted
+* unknown ids are echoed in ``unknown[]`` instead of 404'ing the call
+* catalogue-derived fields are identical in grace vs enforce mode
+  (only ``is_current`` shifts with the resolved tier)
+* the helper never raises -- a resolver crash short-circuits to the
+  OSS-free fallback so the matrix keeps rendering
+* the HTTP endpoint 400s on missing / empty input, echoes unknown ids
+  in a 200, never 5xxs on a resolver crash, and carries the standard
+  ``grace`` / ``enforced`` / ``current_tier`` / ``current_tier_rank``
+  envelope fields
+* the wire body byte-equals the corresponding rows from
+  ``/api/entitlement/tier-spec`` (pins the scalar/batch no-drift
+  contract on the wire, not just in Python).
+"""
+from __future__ import annotations
+
+import importlib
+import json
+
+import pytest
+from flask import Flask
+
+
+_SPEC_KEYS = {
+    "id",
+    "label",
+    "is_paid",
+    "is_current",
+    "rank",
+    "unlocks_paid_runtimes",
+    "retention_days",
+    "channel_limit",
+    "node_limit",
+    "features",
+    "runtimes",
+}
+
+_ENVELOPE_KEYS = {"current_tier", "current_tier_rank", "grace", "enforced"}
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    """Fresh entitlements module with HOME pointed at an empty tmp dir so no
+    real ~/.clawmetry/license.key or cloud_plan.json leaks in. Enforcement off
+    by default (grace mode)."""
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# ── helper: shape ─────────────────────────────────────────────────────────────
+
+
+def test_batch_empty_list_returns_empty_envelope(ent):
+    assert ent.tier_spec_batch([]) == {"tiers": [], "unknown": []}
+
+
+def test_batch_none_input_returns_empty_envelope(ent):
+    assert ent.tier_spec_batch(None) == {"tiers": [], "unknown": []}
+
+
+def test_batch_empty_string_returns_empty_envelope(ent):
+    assert ent.tier_spec_batch("") == {"tiers": [], "unknown": []}
+
+
+def test_batch_row_shape_matches_scalar(ent):
+    body = ent.tier_spec_batch([ent.TIER_CLOUD_STARTER])
+    assert len(body["tiers"]) == 1
+    assert set(body["tiers"][0].keys()) == _SPEC_KEYS
+    assert body["tiers"][0]["id"] == ent.TIER_CLOUD_STARTER
+
+
+# ── helper: parity with scalar tier_spec / tier_catalog ──────────────────────
+
+
+def test_batch_every_row_matches_tier_spec_exactly(ent):
+    ids = list(ent._TIER_ORDER)
+    body = ent.tier_spec_batch(ids)
+    rows_by_id = {row["id"]: row for row in body["tiers"]}
+    assert set(rows_by_id) == set(ids)
+    for tid in ids:
+        assert rows_by_id[tid] == ent.tier_spec(tid), tid
+
+
+def test_batch_rows_match_tier_catalog(ent):
+    """Pin scalar / bulk / batch no-drift: every batch row is byte-identical
+    to the same row from :func:`tier_catalog`."""
+    cat_by_id = {row["id"]: row for row in ent.tier_catalog()}
+    ids = list(cat_by_id)
+    body = ent.tier_spec_batch(ids)
+    assert body["unknown"] == []
+    for row in body["tiers"]:
+        assert row == cat_by_id[row["id"]], row["id"]
+
+
+# ── helper: normalisation ─────────────────────────────────────────────────────
+
+
+def test_batch_supply_order_preserved(ent):
+    ids = [ent.TIER_ENTERPRISE, ent.TIER_OSS, ent.TIER_CLOUD_STARTER]
+    body = ent.tier_spec_batch(ids)
+    assert [r["id"] for r in body["tiers"]] == ids
+
+
+def test_batch_string_csv_input(ent):
+    csv = f"{ent.TIER_OSS},{ent.TIER_CLOUD_PRO},{ent.TIER_ENTERPRISE}"
+    body = ent.tier_spec_batch(csv)
+    assert [r["id"] for r in body["tiers"]] == [
+        ent.TIER_OSS,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_ENTERPRISE,
+    ]
+
+
+def test_batch_whitespace_and_case_normalised(ent):
+    body = ent.tier_spec_batch(["  CLOUD_STARTER  ", "Enterprise"])
+    assert [r["id"] for r in body["tiers"]] == [
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_ENTERPRISE,
+    ]
+
+
+def test_batch_duplicates_dropped_first_seen_wins(ent):
+    body = ent.tier_spec_batch(
+        [ent.TIER_CLOUD_PRO, ent.TIER_CLOUD_PRO, ent.TIER_OSS, ent.TIER_CLOUD_PRO]
+    )
+    assert [r["id"] for r in body["tiers"]] == [
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_OSS,
+    ]
+
+
+def test_batch_trial_is_accepted(ent):
+    body = ent.tier_spec_batch([ent.TIER_TRIAL])
+    assert len(body["tiers"]) == 1
+    assert body["tiers"][0]["id"] == ent.TIER_TRIAL
+    assert body["unknown"] == []
+
+
+def test_batch_unknown_ids_echoed_in_unknown(ent):
+    body = ent.tier_spec_batch([ent.TIER_OSS, "nope_xyz", "also_bogus"])
+    assert [r["id"] for r in body["tiers"]] == [ent.TIER_OSS]
+    assert body["unknown"] == ["nope_xyz", "also_bogus"]
+
+
+def test_batch_unknown_only_returns_empty_tiers(ent):
+    body = ent.tier_spec_batch(["nope_xyz", "also_bogus"])
+    assert body["tiers"] == []
+    assert body["unknown"] == ["nope_xyz", "also_bogus"]
+
+
+# ── helper: grace / enforce identity on catalogue fields ──────────────────────
+
+
+def test_batch_grace_and_enforce_agree_on_catalogue_fields(ent, monkeypatch, tmp_path):
+    ids = list(ent._TIER_ORDER)
+    grace = ent.tier_spec_batch(ids)
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    cache = tmp_path / ".clawmetry" / "cloud_plan.json"
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    cache.write_text(json.dumps({"plan": "cloud_pro"}))
+    ent.invalidate()
+    enforced = ent.tier_spec_batch(ids)
+    # unknown[] must match, and every catalogue-derived field must byte-equal;
+    # only is_current is allowed to shift with the resolved tier.
+    assert enforced["unknown"] == grace["unknown"]
+    g_by_id = {r["id"]: r for r in grace["tiers"]}
+    for row in enforced["tiers"]:
+        g = g_by_id[row["id"]]
+        for k in _SPEC_KEYS - {"is_current"}:
+            assert row[k] == g[k], (row["id"], k)
+
+
+def test_batch_is_current_reflects_resolved_tier(ent, monkeypatch, tmp_path):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    cache = tmp_path / ".clawmetry" / "cloud_plan.json"
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    cache.write_text(json.dumps({"plan": "cloud_pro"}))
+    ent.invalidate()
+    body = ent.tier_spec_batch(list(ent._TIER_ORDER))
+    for row in body["tiers"]:
+        assert row["is_current"] is (row["id"] == ent.TIER_CLOUD_PRO), row["id"]
+
+
+# ── helper: never-raise ───────────────────────────────────────────────────────
+
+
+def test_batch_never_raises_when_resolver_crashes(ent, monkeypatch):
+    def boom(*_a, **_kw):
+        raise RuntimeError("simulated resolver failure")
+
+    monkeypatch.setattr(ent, "get_entitlement", boom)
+    body = ent.tier_spec_batch([ent.TIER_CLOUD_PRO, ent.TIER_OSS])
+    ids = [r["id"] for r in body["tiers"]]
+    assert ids == [ent.TIER_CLOUD_PRO, ent.TIER_OSS]
+    # Under the OSS-free fallback, only OSS is marked current.
+    for row in body["tiers"]:
+        assert row["is_current"] is (row["id"] == ent.TIER_OSS), row["id"]
+
+
+# ── HTTP endpoint ─────────────────────────────────────────────────────────────
+
+
+def test_endpoint_returns_rows_and_envelope(client, ent):
+    csv = f"{ent.TIER_OSS},{ent.TIER_CLOUD_PRO}"
+    resp = client.get(f"/api/entitlement/tier-spec-batch?tiers={csv}")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert _ENVELOPE_KEYS <= set(body.keys())
+    assert [r["id"] for r in body["tiers"]] == [ent.TIER_OSS, ent.TIER_CLOUD_PRO]
+    assert body["unknown"] == []
+    assert body["grace"] is True
+    assert body["enforced"] is False
+    assert body["current_tier"] == ent.TIER_OSS
+    assert body["current_tier_rank"] == ent.tier_rank(ent.TIER_OSS)
+
+
+def test_endpoint_missing_arg_returns_400(client):
+    resp = client.get("/api/entitlement/tier-spec-batch")
+    assert resp.status_code == 400
+    assert "error" in resp.get_json()
+
+
+def test_endpoint_blank_arg_returns_400(client):
+    resp = client.get("/api/entitlement/tier-spec-batch?tiers=%20%20,%20")
+    assert resp.status_code == 400
+
+
+def test_endpoint_unknown_only_returns_200(client):
+    """Unknown ids alone do not 400 -- they normalise to a non-empty list
+    so the helper runs and returns ``unknown=[...]`` with empty tiers."""
+    resp = client.get(
+        "/api/entitlement/tier-spec-batch?tiers=not_a_tier,also_bogus"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["tiers"] == []
+    assert body["unknown"] == ["not_a_tier", "also_bogus"]
+
+
+def test_endpoint_lowercases_and_dedupes(client, ent):
+    resp = client.get(
+        f"/api/entitlement/tier-spec-batch?tiers={ent.TIER_CLOUD_PRO.upper()},"
+        f"{ent.TIER_CLOUD_PRO}"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert [r["id"] for r in body["tiers"]] == [ent.TIER_CLOUD_PRO]
+
+
+def test_endpoint_every_known_tier_round_trips(client, ent):
+    csv = ",".join(ent._TIER_ORDER)
+    resp = client.get(f"/api/entitlement/tier-spec-batch?tiers={csv}")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert [r["id"] for r in body["tiers"]] == list(ent._TIER_ORDER)
+    assert body["unknown"] == []
+
+
+def test_endpoint_body_tiers_byte_equal_scalar(client, ent):
+    """The batch endpoint body must byte-equal the corresponding rows from
+    ``/api/entitlement/tier-spec`` -- pins the scalar / batch no-drift
+    contract on the wire."""
+    csv = ",".join(ent._TIER_ORDER)
+    batch_resp = client.get(f"/api/entitlement/tier-spec-batch?tiers={csv}")
+    assert batch_resp.status_code == 200
+    for row in batch_resp.get_json()["tiers"]:
+        scalar_resp = client.get(
+            f"/api/entitlement/tier-spec?tier={row['id']}"
+        )
+        assert scalar_resp.status_code == 200
+        assert row == scalar_resp.get_json(), row["id"]
+
+
+def test_endpoint_envelope_carries_resolved_tier(
+    client, ent, monkeypatch, tmp_path
+):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    cache = tmp_path / ".clawmetry" / "cloud_plan.json"
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    cache.write_text(json.dumps({"plan": "cloud_pro"}))
+    ent.invalidate()
+    resp = client.get(
+        f"/api/entitlement/tier-spec-batch?tiers={ent.TIER_CLOUD_PRO}"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["current_tier"] == ent.TIER_CLOUD_PRO
+    assert body["current_tier_rank"] == ent.tier_rank(ent.TIER_CLOUD_PRO)
+    assert body["grace"] is False
+    assert body["enforced"] is True
+
+
+def test_endpoint_never_5xxs_when_resolver_crashes(client, ent, monkeypatch):
+    def boom(*_a, **_kw):
+        raise RuntimeError("simulated resolver failure")
+
+    monkeypatch.setattr(ent, "get_entitlement", boom)
+    resp = client.get(
+        f"/api/entitlement/tier-spec-batch?tiers={ent.TIER_CLOUD_PRO}"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    # Endpoint short-circuits to the OSS-free envelope on resolver failure.
+    assert body["current_tier"] == "oss"
+    assert body["grace"] is True
+    assert body["enforced"] is False


### PR DESCRIPTION
## Summary

- Add `tier_spec_batch(tiers)` in `clawmetry/entitlements.py` — the plural sibling of `tier_spec` on the tier axis, mirroring the existing `feature_spec_batch` / `runtime_spec_batch` / `channel_spec_batch` accessors. Each returned row is byte-identical to the corresponding `tier_spec` / `tier_catalog` row (parity pinned by tests), so a pricing-comparison matrix UI hydrates N tier rows off one call instead of N calls to `/tier-spec`.
- Register `GET /api/entitlement/tier-spec-batch?tiers=a,b,c` in `routes/entitlement.py` with the standard `current_tier` / `current_tier_rank` / `grace` / `enforced` envelope. 400 on empty/missing input, 200 (with `unknown[]` echoed) on unknown-only input, never 5xxs on resolver crash.
- Add `tests/test_entitlement_tier_spec_batch.py` (25 tests) pinning shape, scalar/batch parity (both Python-level and wire-level), input normalisation (CSV string or iterable, whitespace / case / dedup, `trial` acceptance), grace-vs-enforce catalogue-field identity, resolver-crash fallback, and the envelope fields.

Grace-mode is the default: every row's `is_current` reflects the resolved tier (OSS in the OSS-free fallback), so no behaviour changes for existing callers. Fills a gap left by the incremental spec/batch build-out on the other three axes.

## Test plan

- [x] `python -m pytest tests/test_entitlement_tier_spec_batch.py` — 25/25 pass
- [x] `python -m pytest tests/test_entitlement_tier_spec.py tests/test_entitlement_channel_spec_batch.py tests/test_entitlement_tier_spec_at.py tests/test_entitlement_tier_spec_at_batch.py` — 119/119 pass (no regressions on neighbour tests)
- [x] `ruff check clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_tier_spec_batch.py` — clean (`make lint` errors on `main` today are pre-existing and confined to `dashboard.py` / other files this PR does not touch)
- [x] `python -m py_compile` on all three modified files — clean

## Local operator verification checklist

The remote environment has no access to the live daemon, `~/.openclaw`, or the decrypted cloud snapshot, so the on-host verification steps below are for the local operator to run before flipping the PR out of draft:

- [ ] Copy the changed files into the daemon's site-packages copy:
      ```
      cp clawmetry/entitlements.py ~/.clawmetry/lib/python3.11/site-packages/clawmetry/entitlements.py
      cp routes/entitlement.py     ~/.clawmetry/lib/python3.11/site-packages/routes/entitlement.py
      ```
      (or the matching `pythonX.Y` for your install), then clear the bytecode cache:
      ```
      find ~/.clawmetry/lib -name '__pycache__' -type d -exec rm -rf {} +
      ```
- [ ] Kick the daemon so the new endpoint is picked up:
      ```
      launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync
      ```
- [ ] Sanity-hit the new endpoint against the live dashboard:
      ```
      curl -s 'http://localhost:8900/api/entitlement/tier-spec-batch?tiers=oss,cloud_pro,enterprise' | jq
      curl -si 'http://localhost:8900/api/entitlement/tier-spec-batch' | head -1   # expect HTTP/1.0 400
      curl -s  'http://localhost:8900/api/entitlement/tier-spec-batch?tiers=CLOUD_STARTER,cloud_starter,not_a_tier' | jq
      ```
      Confirm: (a) 200 + rows in `tiers[]`, (b) 400 on missing arg, (c) dedup + `unknown: ["not_a_tier"]` on the third call.
- [ ] Decrypt the live cloud snapshot in the browser and confirm the endpoint responds identically to the local hit above (should be catalogue-derived, so grace vs enforce agrees on every field except `is_current`).
- [ ] Browser-check the dashboard for any regression in the pricing / paywall UI (this PR is additive — no existing endpoint changes shape).
- [ ] Once verified, flip the PR out of draft for merge review. **This PR does not bump `__version__` or open a `[RELEASE]` PR** — release cadence stays with the operator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EGP7qzgo8XTg1QPu4t3DPa

---
_Generated by [Claude Code](https://claude.ai/code/session_01EGP7qzgo8XTg1QPu4t3DPa)_