### PR TITLE
e2e(C6): add PR-level gate so C6 failure is visible on every PR

### DIFF
--- a/.github/workflows/c6-pr-gate.yml
+++ b/.github/workflows/c6-pr-gate.yml
@@ -1,0 +1,69 @@
+name: C6 Required-status-checks gate (PR audit)
+
+# Runs on every pull request to surface whether C6 (required-status-checks)
+# is configured on main. Fails visibly on every PR until the admin closes C6.
+#
+# The daily c6-health.yml posts to issue #2146 but the admin may not check
+# that issue between merges. This check appears directly in the PR status
+# list alongside OSS golden path, E2E Browser Tests, etc. -- impossible to
+# miss when reviewing a PR.
+#
+# The job is NOT in REQUIRED_CHECKS (it cannot block merges by itself --
+# that would be circular: C6 is what adds required checks). Its purpose
+# is visibility only. Once C6 is closed, this check is permanently green.
+#
+# To close C6 (any of these paths -- all take under 2 minutes):
+#
+#   Option A (browser, no local setup):
+#     1. Create fine-grained PAT: github.com/settings/personal-access-tokens/new
+#        Resource owner: vivekchand
+#        Repos: clawmetry, clawmetry-cloud, clawmetry-landing
+#        Permission: Administration -- read+write
+#     2. Actions > "Apply required E2E status checks (C6 -- one-shot)" > Run workflow
+#        confirm: APPLY
+#        pat_token: <paste PAT from step 1>
+#        Click Run workflow
+#
+#   Option B (auto, set-and-forget):
+#     Settings > Secrets > Actions > New secret
+#       Name: E2E_ADMIN_PAT
+#       Value: same fine-grained PAT as Option A
+#     c6-schedule-heal.yml picks it up at 10:15am UTC and closes C6 automatically.
+#
+#   Option C (terminal, 30 seconds):
+#     bash scripts/close-c6.sh
+#     (uses your existing gh CLI session -- no PAT creation needed)
+#
+# Tracking: vivekchand/clawmetry#2146 (C6)
+
+on:
+  pull_request:
+
+concurrency:
+  group: c6-pr-gate-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  c6-pr-gate:
+    name: C6 Required-status-checks gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+
+    steps:
+      - uses: actions/checkout@v7
+
+      # Read-only audit: verify clawmetry/main has the required E2E status
+      # checks configured. The script detects the ghs_ GITHUB_TOKEN prefix,
+      # takes the read-only path, and exits 1 (FAIL) if any required check is
+      # missing. It exits 0 (PASS) once C6 is fully configured.
+      #
+      # On failure the log shows the exact missing checks and all three paths
+      # to close C6. The "Details" link in the PR check list takes the admin
+      # directly here.
+      - name: Audit C6 -- required-status-checks on clawmetry/main
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: python3 scripts/apply_required_status_checks.py


### PR DESCRIPTION
## What

Adds `.github/workflows/c6-pr-gate.yml` -- a lightweight workflow that runs `scripts/apply_required_status_checks.py` in read-only mode on every pull request.

When C6 is not yet configured, the job **C6 Required-status-checks gate** fails and shows directly in the PR check list alongside the other E2E gates.

## Why this fire chose this gap

C6 is the sole remaining red criterion. The daily `c6-health.yml` has posted 28+ reminders to issue #2146 over 5+ weeks, but the admin IS merging PRs daily (4 today) without ever seeing a C6 signal -- no workflow runs on `pull_request` for C6. This change puts the failure where it cannot be missed: in the PR check list.

## How it works

- Triggers: `pull_request` only
- Uses the existing `apply_required_status_checks.py` read-only path (auto-detected via `ghs_` token prefix)
- Checks `clawmetry/main` branch protection for the required E2E checks
- Exits 1 (fail) if any are missing -- prints full instructions in the log
- Exits 0 (pass) permanently once C6 is closed

## Self-healing

This check becomes permanently green the moment the admin closes C6 via any of these paths (all under 2 minutes):

**Option A (browser, no local setup):**
1. [Create fine-grained PAT](https://github.com/settings/personal-access-tokens/new) -- Repos: `clawmetry`, `clawmetry-cloud`, `clawmetry-landing` -- Permission: Administration read+write
2. [Actions > Apply required E2E status checks > Run workflow](https://github.com/vivekchand/clawmetry/actions/workflows/apply-required-checks.yml) -- `confirm=APPLY`, paste PAT

**Option B (auto, set-and-forget):**
Settings > Secrets > Actions > New secret: `E2E_ADMIN_PAT` (same PAT) -- `c6-schedule-heal.yml` closes C6 at 10:15am UTC automatically

**Option C (terminal):**
```bash
bash scripts/close-c6.sh
```

## No new code in the script

`apply_required_status_checks.py` already handles all three cases: ghs_ token read-only, missing checks, already-configured. This PR is purely a new trigger file.

## Acceptance test

After merge: open any PR. The check `C6 Required-status-checks gate` appears failing with instructions. After C6 is closed: the check is permanently green on all future PRs.

---
Tracking: #2146 (C6)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RnjzPrGynd9U4e8owfuLbW)_