### PR TITLE
feat(entitlement): affordable_tiers_batch + /api/entitlement/affordable-tiers-batch

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -5601,6 +5601,209 @@ def min_tier_batch_at(
         return None
 
 
+
+def _affordable_row(key, kind: str) -> dict:
+    """Per-item full-list qualifying-tier row for
+    :func:`affordable_tiers_batch`.
+
+    Row-shape sibling of :func:`_min_tier_row`: mirrors the same
+    ``key`` + ``kind`` + normalised value contract and carries the
+    same floor scalar (``min_tier`` / ``free`` / label / rank), but
+    additionally carries the **full ordered list** of qualifying
+    tiers (``tiers``) so a pricing-matrix UI can render "each row's
+    cheapest qualifying tier -- and every tier above that also
+    qualifies" off ONE batch call. Same relationship to
+    :func:`_min_tier_row` that :func:`affordable_tiers` has to
+    :func:`min_tier_for_all` at the aggregate level.
+
+    Kind semantics mirror :func:`_min_tier_row` exactly:
+
+    * ``"feature"`` / ``"runtime"`` -- ``key`` is a normalised id
+      (whitespace stripped, lowercased; runtimes additionally
+      canonicalised via :func:`canonical_runtime` so
+      ``claude-code`` -> ``claude_code``). Unknown ids get
+      ``min_tier=None`` / ``free=False`` / ``min_tier_label=None`` /
+      ``min_tier_rank=-1`` / ``tiers=[]`` -- the caller distinguishes
+      "unknown" from "free" via the ``free`` flag.
+    * ``"channels"`` / ``"retention_days"`` / ``"nodes"`` -- ``key``
+      is int-parseable; non-int input collapses to the same all-None
+      shape with ``tiers=[]``. Retention passes the parsed int
+      straight through, so ``retention_days=<int>`` is treated as a
+      finite request, not the ``None`` unlimited sentinel (matches
+      every other 5-axis batch: this helper's ``None`` means "not
+      supplied").
+
+    ``tiers`` rows carry ``tier`` / ``tier_label`` / ``tier_rank`` /
+    ``is_minimum`` -- byte-identical to :func:`affordable_tiers` rows
+    for the single-axis single-item case, so a pricing UI can share
+    row renderers between the aggregate ``/affordable-tiers`` surface
+    and the per-item ``/affordable-tiers-batch`` surface.
+
+    Floor scalar (``min_tier`` / ``free`` / label / rank) is composed
+    from :func:`_min_tier_row` so the row byte-equals the matching
+    :func:`min_tier_batch` row on those fields -- a caller can drop
+    the ``tiers`` list off any row and get the exact
+    :func:`min_tier_batch` shape back. This keeps the two batches
+    internally consistent even for free items where alphabetical
+    tie-breaking among rank-0 tiers would otherwise land
+    :func:`affordable_tiers`' first row on ``cloud_free`` while
+    :func:`min_tier_for_feature` returns ``oss``.
+
+    Never raises: any resolver failure short-circuits to the all-
+    ``None`` shape (with ``tiers=[]``) so the caller keeps rendering.
+    """
+    base = _min_tier_row(key, kind)
+    try:
+        if kind == "feature":
+            fid = base["key"]
+            if fid in ALL_FEATURES:
+                tiers = affordable_tiers(features=[fid]) or []
+            else:
+                tiers = []
+        elif kind == "runtime":
+            rt = base["key"]
+            if rt in ALL_RUNTIMES:
+                tiers = affordable_tiers(runtimes=[rt]) or []
+            else:
+                tiers = []
+        elif kind in ("channels", "retention_days", "nodes"):
+            try:
+                n = int(key)
+            except (TypeError, ValueError):
+                tiers = []
+            else:
+                if kind == "channels":
+                    tiers = affordable_tiers(channels=n) or []
+                elif kind == "retention_days":
+                    tiers = affordable_tiers(retention_days=n) or []
+                else:
+                    tiers = affordable_tiers(nodes=n) or []
+        else:
+            tiers = []
+        out = dict(base)
+        out["tiers"] = tiers
+        return out
+    except Exception:
+        out = dict(base)
+        out["tiers"] = []
+        return out
+
+
+def affordable_tiers_batch(
+    *,
+    features=None,
+    runtimes=None,
+    channels: int | None = None,
+    retention_days: int | None = None,
+    nodes: int | None = None,
+) -> dict:
+    """Per-item full ordered list of qualifying tiers for every supplied
+    item across all five capacity axes in one pass.
+
+    Per-item plural sibling of :func:`affordable_tiers` (which
+    aggregates across a whole constraint bundle and returns ONE
+    ordered list). Same relationship it has to :func:`affordable_tiers`
+    that :func:`min_tier_batch` has to :func:`min_tier_for_all`: the
+    aggregate helper collapses the answer to a single bundle-wide
+    view; the batch preserves the per-item detail so a pricing-matrix
+    UI ("show me each requested feature + runtime + capacity row with
+    its individual cheapest tier AND every tier above that also
+    qualifies") renders off ONE round-trip instead of N calls to
+    :func:`affordable_tiers`.
+
+    Envelope shape mirrors :func:`min_tier_batch` / :func:`lock_reasons_batch`
+    exactly (same five-axis kwargs, same per-axis ``None`` "not
+    supplied" sentinel, same never-raise contract)::
+
+        {
+          "features":       [<row>, ...],
+          "runtimes":       [<row>, ...],
+          "channels":       <row> | None,
+          "retention_days": <row> | None,
+          "nodes":          <row> | None,
+        }
+
+    Each ``<row>`` carries ``key``, ``kind``, ``free`` (True iff
+    ``min_tier == TIER_OSS``), ``min_tier`` (``None`` for unknown /
+    unparseable input), ``min_tier_label``, ``min_tier_rank``
+    (``-1`` when ``min_tier`` is ``None``), and ``tiers`` -- the
+    full ordered list of qualifying tiers for that single item, with
+    each entry carrying ``tier`` / ``tier_label`` / ``tier_rank`` /
+    ``is_minimum``. ``tiers`` is ``[]`` (not ``None``) for unknown /
+    unparseable items, matching the never-crash posture of
+    :func:`_min_tier_row`.
+
+    Per-row parity with :func:`affordable_tiers` is pinned in the
+    test suite: for every feature id ``f`` in :data:`ALL_FEATURES`,
+    ``affordable_tiers_batch(features=[f])['features'][0]['tiers']``
+    byte-equals ``affordable_tiers(features=[f])``; ditto for every id
+    in :data:`ALL_RUNTIMES` and for the three capacity axes against
+    their singular ``affordable_tiers(<axis>=n)`` call.
+
+    Feature ids are normalised via :func:`_normalise_csv` (whitespace
+    stripped, lowercased, duplicates dropped while preserving first-
+    seen order). Runtime ids additionally canonicalise via
+    :func:`canonical_runtime` so aliases (``claude-code`` ->
+    ``claude_code``) resolve the same way they do on the singular
+    ``/api/entitlement/affordable-tiers?runtimes=`` endpoint;
+    duplicates that collapse after canonicalisation only contribute
+    one row.
+
+    Critically, ``retention_days=None`` here means *unset* -- NOT
+    *unlimited*. Same posture as :func:`min_tier_batch` /
+    :func:`lock_reasons_batch`: asking for the unlimited-retention
+    tier is the singular :func:`min_tier_for_retention_window`
+    (``days=None``) call's job and would mis-route the batch to
+    Enterprise otherwise.
+
+    Decoupled from the resolved entitlement (delegates to
+    :func:`affordable_tiers`, which walks the static per-tier maps),
+    so grace vs enforce yields byte-identical rows -- pinned in the
+    test suite via a grace / enforce reload roundtrip. Never raises:
+    a per-row failure short-circuits to the all-``None`` row shape
+    with ``tiers=[]`` so the pricing UI keeps rendering.
+    """
+    try:
+        feats = _normalise_csv(features)
+        raw_rts = _normalise_csv(runtimes)
+        seen: set[str] = set()
+        rt_rows: list[dict] = []
+        for raw in raw_rts:
+            rt = canonical_runtime(raw)
+            key = rt if rt else raw
+            if key in seen:
+                continue
+            seen.add(key)
+            rt_rows.append(_affordable_row(raw, "runtime"))
+        return {
+            "features": [_affordable_row(f, "feature") for f in feats],
+            "runtimes": rt_rows,
+            "channels": (
+                _affordable_row(channels, "channels")
+                if channels is not None
+                else None
+            ),
+            "retention_days": (
+                _affordable_row(retention_days, "retention_days")
+                if retention_days is not None
+                else None
+            ),
+            "nodes": (
+                _affordable_row(nodes, "nodes") if nodes is not None else None
+            ),
+        }
+    except Exception as exc:
+        logger.warning("entitlements: affordable_tiers_batch failed: %s", exc)
+        return {
+            "features": [],
+            "runtimes": [],
+            "channels": None,
+            "retention_days": None,
+            "nodes": None,
+        }
+
+
+
 def lock_reason(item: str, *, kind: str | None = None) -> str | None:
     try:
         return get_entitlement().lock_reason(item, kind=kind)

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -5754,6 +5754,122 @@ def api_entitlement_min_tier_batch_at():
         )
 
 
+
+@bp_entitlement.route("/api/entitlement/affordable-tiers-batch")
+def api_entitlement_affordable_tiers_batch():
+    """``GET /api/entitlement/affordable-tiers-batch?features=a,b,c
+    &runtimes=x,y&channels=N&retention_days=K&nodes=M`` -- per-item
+    plural sibling of ``/api/entitlement/affordable-tiers``.
+
+    Where ``/affordable-tiers`` collapses the answer to a single
+    ordered list of qualifying tiers for a whole constraint bundle,
+    this preserves the per-item detail so a pricing-matrix UI
+    ("show me each requested feature + runtime + capacity row with
+    its individual cheapest tier AND every tier above that also
+    qualifies") renders off ONE round-trip instead of N calls to
+    ``/affordable-tiers``. Same relationship it has to
+    ``/affordable-tiers`` that ``/min-tier-batch`` has to
+    ``/required-tier-batch``. Wraps
+    :func:`clawmetry.entitlements.affordable_tiers_batch` and appends
+    the same ``current_tier`` / ``grace`` / ``enforced`` envelope
+    ``/lock-reason-batch`` returns so a caller sees the same resolver
+    context alongside the per-item answers.
+
+    At least one of ``features=`` / ``runtimes=`` / ``channels=`` /
+    ``retention_days=`` / ``nodes=`` must be supplied (non-empty /
+    parseable after normalisation). ``features=`` / ``runtimes=``
+    take comma-separated tokens (whitespace and duplicates are
+    normalised away; runtime aliases like ``claude-code``
+    canonicalise to ``claude_code``; unknown ids contribute an all-
+    ``None`` row with ``tiers=[]`` -- they do not error). The three
+    capacity axes take a single int each; a blank or non-int value
+    is treated as "not supplied" (matches the singular endpoint's
+    never-crash posture rather than mis-routing a typo to
+    Enterprise). Never 5xxs: the grace-shape envelope is returned on
+    any resolver failure.
+
+    Response shape::
+
+        {
+          "features":       [<row>, ...],
+          "runtimes":       [<row>, ...],
+          "channels":       <row> | None,
+          "retention_days": <row> | None,
+          "nodes":          <row> | None,
+          "current_tier":       "...",
+          "current_tier_rank":  <int>,
+          "grace":              <bool>,
+          "enforced":           <bool>,
+        }
+
+    Each ``<row>`` carries ``key``, ``kind``, ``free``, ``min_tier``,
+    ``min_tier_label``, ``min_tier_rank`` (``-1`` when ``min_tier``
+    is ``None``), and ``tiers`` -- the full ordered list of
+    qualifying tiers for that single item (each entry carrying
+    ``tier`` / ``tier_label`` / ``tier_rank`` / ``is_minimum``).
+    Per-row parity with the singular
+    ``/affordable-tiers?features=<id>`` endpoint is pinned in the
+    test suite so the batch cannot silently drift from the scalar.
+    """
+    try:
+        from clawmetry import entitlements as _ent
+
+        features = _parse_csv_arg("features")
+        runtimes = _parse_csv_arg("runtimes")
+        (_, channels_ok, channels_n, _) = _parse_capacity_arg("channels")
+        (_, retention_ok, retention_n, _) = _parse_capacity_arg("retention_days")
+        (_, nodes_ok, nodes_n, _) = _parse_capacity_arg("nodes")
+
+        if (
+            not features
+            and not runtimes
+            and not channels_ok
+            and not retention_ok
+            and not nodes_ok
+        ):
+            return (
+                jsonify(
+                    {
+                        "error": (
+                            "supply at least one of features=<csv>, "
+                            "runtimes=<csv>, channels=<int>, "
+                            "retention_days=<int>, or nodes=<int>"
+                        )
+                    }
+                ),
+                400,
+            )
+
+        batch = _ent.affordable_tiers_batch(
+            features=features or None,
+            runtimes=runtimes or None,
+            channels=channels_n if channels_ok else None,
+            retention_days=retention_n if retention_ok else None,
+            nodes=nodes_n if nodes_ok else None,
+        )
+        ent = _ent.get_entitlement()
+        batch["current_tier"] = ent.tier
+        batch["current_tier_rank"] = _ent.tier_rank(ent.tier)
+        batch["grace"] = bool(ent.grace)
+        batch["enforced"] = _ent.is_enforced()
+        return jsonify(batch)
+    except Exception as exc:
+        logger.warning("api_entitlement_affordable_tiers_batch: error: %s", exc)
+        return jsonify(
+            {
+                "features": [],
+                "runtimes": [],
+                "channels": None,
+                "retention_days": None,
+                "nodes": None,
+                "current_tier": "oss",
+                "current_tier_rank": 0,
+                "grace": True,
+                "enforced": False,
+            }
+        )
+
+
 @bp_entitlement.route("/api/entitlement/lock-reason-batch")
 def api_entitlement_lock_reason_batch():
     """``GET /api/entitlement/lock-reason-batch?features=a,b,c&runtimes=x,y

--- a/tests/test_entitlement_affordable_tiers_batch.py
+++ b/tests/test_entitlement_affordable_tiers_batch.py
@@ -1,0 +1,532 @@
+"""Tests for ``clawmetry.entitlements.affordable_tiers_batch`` and the
+``GET /api/entitlement/affordable-tiers-batch`` endpoint.
+
+Per-item plural sibling of :func:`affordable_tiers`. Where
+:func:`affordable_tiers` / ``/api/entitlement/affordable-tiers`` collapse
+the answer to a single ordered list of qualifying tiers for a whole
+constraint bundle, this surface preserves the per-item detail so a
+pricing-matrix UI ("show me each requested feature + runtime + capacity
+row with its individual cheapest tier -- and every tier above that also
+qualifies") renders off ONE round-trip instead of N calls to
+``/affordable-tiers``. Same relationship it has to
+:func:`affordable_tiers` that :func:`min_tier_batch` has to
+:func:`min_tier_for_all`.
+
+These tests pin:
+
+* full response shape (per-axis rows, envelope keys, row fields incl.
+  ``tiers``)
+* per-row parity with :func:`affordable_tiers` across every feature id
+  in :data:`ALL_FEATURES`, every runtime id in :data:`ALL_RUNTIMES`,
+  and the three capacity axes
+* per-row ``min_tier`` parity with :func:`_min_tier_row` -- the batch
+  ``_at`` slot / floor must byte-equal :func:`min_tier_batch` for the
+  same inputs
+* runtime canonicalisation (``claude-code`` -> ``claude_code``)
+* dedup after canonicalisation
+* unknown ids contribute an all-``None`` row with ``tiers=[]`` (rather
+  than raising)
+* ``retention_days=None`` means unset, NOT unlimited
+* grace vs enforce yields byte-identical rows (helper is decoupled
+  from the resolver)
+* never-raises contract
+* API: 400 on no axis supplied, 200 with the batch shape + resolver
+  envelope on happy path
+* API cross-parity with the singular ``/affordable-tiers`` endpoint
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+_EXPECTED_ROW_KEYS = {
+    "key",
+    "kind",
+    "free",
+    "min_tier",
+    "min_tier_label",
+    "min_tier_rank",
+    "tiers",
+}
+
+_EXPECTED_TIER_ROW_KEYS = {
+    "tier",
+    "tier_label",
+    "tier_rank",
+    "is_minimum",
+}
+
+
+# ── affordable_tiers_batch -- shape ─────────────────────────────────────────
+
+
+def test_helper_returns_envelope_with_five_axes(ent):
+    out = ent.affordable_tiers_batch(
+        features=["fleet", "sso"],
+        runtimes=["claude_code"],
+        channels=5,
+        retention_days=30,
+        nodes=3,
+    )
+    assert set(out.keys()) == {
+        "features",
+        "runtimes",
+        "channels",
+        "retention_days",
+        "nodes",
+    }
+    assert isinstance(out["features"], list)
+    assert isinstance(out["runtimes"], list)
+    for axis in ("channels", "retention_days", "nodes"):
+        assert isinstance(out[axis], dict)
+
+
+def test_helper_row_shape(ent):
+    out = ent.affordable_tiers_batch(features=["fleet"])
+    row = out["features"][0]
+    assert set(row.keys()) == _EXPECTED_ROW_KEYS
+    assert row["kind"] == "feature"
+    assert isinstance(row["tiers"], list)
+
+
+def test_helper_tier_row_shape(ent):
+    """Each tier entry in a row's ``tiers`` list must carry the same
+    ``tier`` / ``tier_label`` / ``tier_rank`` / ``is_minimum`` keys that
+    :func:`affordable_tiers` returns."""
+    out = ent.affordable_tiers_batch(features=["fleet"])
+    row = out["features"][0]
+    if row["tiers"]:
+        assert set(row["tiers"][0].keys()) == _EXPECTED_TIER_ROW_KEYS
+
+
+def test_helper_no_inputs_returns_empty_shape(ent):
+    out = ent.affordable_tiers_batch()
+    assert out["features"] == []
+    assert out["runtimes"] == []
+    assert out["channels"] is None
+    assert out["retention_days"] is None
+    assert out["nodes"] is None
+
+
+# ── affordable_tiers_batch -- per-row parity with affordable_tiers ─────────
+
+
+def test_feature_row_tiers_match_affordable_tiers(ent):
+    """Every feature id in ALL_FEATURES must have a batch row whose
+    ``tiers`` list byte-equals :func:`affordable_tiers` for the same
+    single-feature bundle."""
+    for fid in sorted(ent.ALL_FEATURES):
+        out = ent.affordable_tiers_batch(features=[fid])
+        assert len(out["features"]) == 1
+        row = out["features"][0]
+        assert row["key"] == fid
+        expected = ent.affordable_tiers(features=[fid]) or []
+        assert row["tiers"] == expected
+
+
+def test_runtime_row_tiers_match_affordable_tiers(ent):
+    for rt in sorted(ent.ALL_RUNTIMES):
+        out = ent.affordable_tiers_batch(runtimes=[rt])
+        assert len(out["runtimes"]) == 1
+        row = out["runtimes"][0]
+        assert row["key"] == rt
+        expected = ent.affordable_tiers(runtimes=[rt]) or []
+        assert row["tiers"] == expected
+
+
+def test_channels_row_tiers_match_affordable_tiers(ent):
+    for n in (0, 1, 3, 5, 25, 100, 10000):
+        out = ent.affordable_tiers_batch(channels=n)
+        expected = ent.affordable_tiers(channels=n) or []
+        assert out["channels"]["tiers"] == expected
+        assert out["channels"]["key"] == str(n)
+        assert out["channels"]["kind"] == "channels"
+
+
+def test_retention_row_tiers_match_affordable_tiers(ent):
+    for days in (0, 1, 7, 30, 90, 365, 3650):
+        out = ent.affordable_tiers_batch(retention_days=days)
+        expected = ent.affordable_tiers(retention_days=days) or []
+        assert out["retention_days"]["tiers"] == expected
+        assert out["retention_days"]["key"] == str(days)
+
+
+def test_nodes_row_tiers_match_affordable_tiers(ent):
+    for n in (0, 1, 3, 5, 25, 100, 10000):
+        out = ent.affordable_tiers_batch(nodes=n)
+        expected = ent.affordable_tiers(nodes=n) or []
+        assert out["nodes"]["tiers"] == expected
+        assert out["nodes"]["key"] == str(n)
+
+
+# ── affordable_tiers_batch -- floor parity with min_tier_batch ─────────────
+
+
+def test_feature_row_min_tier_matches_min_tier_batch(ent):
+    """The per-row floor scalar (``min_tier`` / ``free`` / label /
+    rank) must byte-equal :func:`min_tier_batch` for the same input.
+    Pins the two batches against each other so the aggregate view
+    (batch min_tier + batch full-list) stays internally consistent."""
+    for fid in sorted(ent.ALL_FEATURES):
+        aff = ent.affordable_tiers_batch(features=[fid])["features"][0]
+        mtb = ent.min_tier_batch(features=[fid])["features"][0]
+        assert aff["min_tier"] == mtb["min_tier"]
+        assert aff["free"] == mtb["free"]
+        assert aff["min_tier_label"] == mtb["min_tier_label"]
+        assert aff["min_tier_rank"] == mtb["min_tier_rank"]
+
+
+def test_runtime_row_min_tier_matches_min_tier_batch(ent):
+    for rt in sorted(ent.ALL_RUNTIMES):
+        aff = ent.affordable_tiers_batch(runtimes=[rt])["runtimes"][0]
+        mtb = ent.min_tier_batch(runtimes=[rt])["runtimes"][0]
+        assert aff["min_tier"] == mtb["min_tier"]
+        assert aff["free"] == mtb["free"]
+
+
+def test_capacity_rows_min_tier_match_min_tier_batch(ent):
+    for axis, values in (
+        ("channels", (0, 1, 5, 25, 100)),
+        ("retention_days", (0, 7, 30, 90, 365)),
+        ("nodes", (0, 1, 5, 25, 100)),
+    ):
+        for n in values:
+            aff = ent.affordable_tiers_batch(**{axis: n})[axis]
+            mtb = ent.min_tier_batch(**{axis: n})[axis]
+            assert aff["min_tier"] == mtb["min_tier"], (axis, n)
+            assert aff["free"] == mtb["free"], (axis, n)
+
+
+# ── affordable_tiers_batch -- runtime canonicalisation + dedup ─────────────
+
+
+def test_runtime_alias_canonicalises(ent):
+    out = ent.affordable_tiers_batch(runtimes=["claude-code"])
+    assert len(out["runtimes"]) == 1
+    assert out["runtimes"][0]["key"] == "claude_code"
+    expected = ent.affordable_tiers(runtimes=["claude_code"]) or []
+    assert out["runtimes"][0]["tiers"] == expected
+
+
+def test_runtime_alias_dedups_against_canonical(ent):
+    out = ent.affordable_tiers_batch(runtimes=["claude-code", "claude_code"])
+    assert len(out["runtimes"]) == 1
+    assert out["runtimes"][0]["key"] == "claude_code"
+
+
+# ── affordable_tiers_batch -- unknown ids ──────────────────────────────────
+
+
+def test_unknown_feature_returns_all_none_row(ent):
+    out = ent.affordable_tiers_batch(features=["definitely_not_a_feature"])
+    assert len(out["features"]) == 1
+    row = out["features"][0]
+    assert row["key"] == "definitely_not_a_feature"
+    assert row["min_tier"] is None
+    assert row["free"] is False
+    assert row["min_tier_label"] is None
+    assert row["min_tier_rank"] == -1
+    assert row["tiers"] == []
+
+
+def test_unknown_runtime_returns_all_none_row(ent):
+    out = ent.affordable_tiers_batch(runtimes=["definitely_not_a_runtime"])
+    assert len(out["runtimes"]) == 1
+    row = out["runtimes"][0]
+    assert row["min_tier"] is None
+    assert row["free"] is False
+    assert row["tiers"] == []
+
+
+def test_non_int_capacity_returns_all_none_row(ent):
+    out = ent.affordable_tiers_batch(channels="oops")
+    assert out["channels"]["min_tier"] is None
+    assert out["channels"]["free"] is False
+    assert out["channels"]["min_tier_rank"] == -1
+    assert out["channels"]["tiers"] == []
+
+
+# ── affordable_tiers_batch -- input normalisation ─────────────────────────
+
+
+def test_features_are_lowercased_and_deduped(ent):
+    out = ent.affordable_tiers_batch(features=["FLEET", " fleet ", "sso", "fleet"])
+    keys = [r["key"] for r in out["features"]]
+    assert keys == ["fleet", "sso"]
+
+
+def test_features_accepts_csv_string(ent):
+    out = ent.affordable_tiers_batch(features="fleet,sso")
+    keys = [r["key"] for r in out["features"]]
+    assert keys == ["fleet", "sso"]
+
+
+# ── affordable_tiers_batch -- unset vs unlimited ──────────────────────────
+
+
+def test_retention_none_means_unset_not_unlimited(ent):
+    out = ent.affordable_tiers_batch(retention_days=None)
+    assert out["retention_days"] is None
+
+
+def test_channels_none_means_unset(ent):
+    out = ent.affordable_tiers_batch(channels=None)
+    assert out["channels"] is None
+
+
+def test_nodes_none_means_unset(ent):
+    out = ent.affordable_tiers_batch(nodes=None)
+    assert out["nodes"] is None
+
+
+# ── affordable_tiers_batch -- grace vs enforce parity ──────────────────────
+
+
+def test_grace_vs_enforce_yields_byte_identical_rows(monkeypatch, tmp_path):
+    """The helper walks the static per-tier maps via
+    :func:`affordable_tiers`, so grace vs enforce yields byte-identical
+    rows -- a pricing-page must render the same numbers on both sides of
+    the enforcement cutover."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    import clawmetry.entitlements as e_grace
+
+    importlib.reload(e_grace)
+    e_grace.invalidate()
+    grace_out = e_grace.affordable_tiers_batch(
+        features=sorted(e_grace.ALL_FEATURES),
+        runtimes=sorted(e_grace.ALL_RUNTIMES),
+        channels=5,
+        retention_days=30,
+        nodes=3,
+    )
+    e_grace.invalidate()
+
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    import clawmetry.entitlements as e_enf
+
+    importlib.reload(e_enf)
+    e_enf.invalidate()
+    enf_out = e_enf.affordable_tiers_batch(
+        features=sorted(e_enf.ALL_FEATURES),
+        runtimes=sorted(e_enf.ALL_RUNTIMES),
+        channels=5,
+        retention_days=30,
+        nodes=3,
+    )
+    e_enf.invalidate()
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+
+    assert grace_out == enf_out
+
+
+# ── affordable_tiers_batch -- never raises ─────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "features,runtimes,channels,retention_days,nodes",
+    [
+        (None, None, None, None, None),
+        ([], [], None, None, None),
+        ([""], [""], None, None, None),
+        (["fleet", None, ""], ["claude_code"], "oops", "oops", "oops"),
+        (["FLEET"], ["CLAUDE-CODE"], -1, -1, -1),
+        (object(), object(), None, None, None),
+        ("fleet,sso", "claude_code,codex", 5, 30, 3),
+    ],
+)
+def test_helper_never_raises(ent, features, runtimes, channels, retention_days, nodes):
+    try:
+        out = ent.affordable_tiers_batch(
+            features=features,
+            runtimes=runtimes,
+            channels=channels,
+            retention_days=retention_days,
+            nodes=nodes,
+        )
+    except Exception:  # pragma: no cover
+        pytest.fail("affordable_tiers_batch must not raise")
+    assert set(out.keys()) == {
+        "features",
+        "runtimes",
+        "channels",
+        "retention_days",
+        "nodes",
+    }
+
+
+# ── /api/entitlement/affordable-tiers-batch ────────────────────────────────
+
+
+def test_endpoint_400_on_no_axis(client):
+    r = client.get("/api/entitlement/affordable-tiers-batch")
+    assert r.status_code == 400
+    body = r.get_json()
+    assert "error" in body
+
+
+def test_endpoint_happy_path_features(client):
+    r = client.get(
+        "/api/entitlement/affordable-tiers-batch?features=fleet,sso"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert set(body.keys()) >= {
+        "features",
+        "runtimes",
+        "channels",
+        "retention_days",
+        "nodes",
+        "current_tier",
+        "current_tier_rank",
+        "grace",
+        "enforced",
+    }
+    assert [r["key"] for r in body["features"]] == ["fleet", "sso"]
+    assert body["runtimes"] == []
+    assert body["channels"] is None
+
+
+def test_endpoint_happy_path_all_axes(client):
+    r = client.get(
+        "/api/entitlement/affordable-tiers-batch"
+        "?features=fleet"
+        "&runtimes=claude_code"
+        "&channels=5"
+        "&retention_days=30"
+        "&nodes=3"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["features"][0]["key"] == "fleet"
+    assert body["runtimes"][0]["key"] == "claude_code"
+    assert body["channels"]["key"] == "5"
+    assert body["retention_days"]["key"] == "30"
+    assert body["nodes"]["key"] == "3"
+
+
+def test_endpoint_runtime_alias_canonicalises(client):
+    r = client.get(
+        "/api/entitlement/affordable-tiers-batch?runtimes=claude-code"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["runtimes"][0]["key"] == "claude_code"
+
+
+def test_endpoint_unknown_id_does_not_500(client):
+    r = client.get(
+        "/api/entitlement/affordable-tiers-batch"
+        "?features=definitely_not_a_feature"
+        "&runtimes=definitely_not_a_runtime"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["features"][0]["min_tier"] is None
+    assert body["features"][0]["free"] is False
+    assert body["features"][0]["tiers"] == []
+    assert body["runtimes"][0]["min_tier"] is None
+    assert body["runtimes"][0]["tiers"] == []
+
+
+def test_endpoint_non_int_capacity_treated_as_unsupplied(client):
+    """Blank / non-int capacity args must be treated as "not supplied"
+    (mirrors the singular endpoint's never-crash posture) rather than
+    mis-routing a typo to Enterprise."""
+    r = client.get(
+        "/api/entitlement/affordable-tiers-batch"
+        "?features=fleet&channels=oops&retention_days=&nodes=oops"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["channels"] is None
+    assert body["retention_days"] is None
+    assert body["nodes"] is None
+
+
+def test_endpoint_per_row_parity_with_singular_affordable_tiers(client, ent):
+    """Each batch row's ``tiers`` list must byte-equal the singular
+    ``/api/entitlement/affordable-tiers?features=<id>`` response's
+    ``tiers`` (stripped to the same 4-key rows). Pins the batch against
+    the scalar so they can never silently drift."""
+    for fid in sorted(ent.ALL_FEATURES):
+        batch = client.get(
+            f"/api/entitlement/affordable-tiers-batch?features={fid}"
+        ).get_json()
+        singular = client.get(
+            f"/api/entitlement/affordable-tiers?features={fid}"
+        ).get_json()
+        # The singular endpoint augments each tier row with ``is_current`` /
+        # ``is_current_or_better`` -- strip them for the batch comparison.
+        singular_stripped = [
+            {
+                "tier": r["tier"],
+                "tier_label": r["tier_label"],
+                "tier_rank": r["tier_rank"],
+                "is_minimum": r["is_minimum"],
+            }
+            for r in singular["tiers"]
+        ]
+        assert batch["features"][0]["tiers"] == singular_stripped
+
+
+def test_endpoint_carries_resolver_envelope(client, ent):
+    r = client.get(
+        "/api/entitlement/affordable-tiers-batch?features=fleet"
+    )
+    body = r.get_json()
+    live = ent.get_entitlement()
+    assert body["current_tier"] == live.tier
+    assert body["current_tier_rank"] == ent.tier_rank(live.tier)
+    assert body["grace"] == bool(live.grace)
+    assert body["enforced"] == ent.is_enforced()
+
+
+def test_endpoint_tiers_ordered_by_rank(client):
+    r = client.get(
+        "/api/entitlement/affordable-tiers-batch?features=fleet"
+    )
+    body = r.get_json()
+    tiers = body["features"][0]["tiers"]
+    ranks = [t["tier_rank"] for t in tiers]
+    assert ranks == sorted(ranks)
+
+
+def test_endpoint_first_tier_is_minimum(client, ent):
+    """Only the first (cheapest) row in a per-item ``tiers`` list has
+    ``is_minimum=True``; every row above must have ``is_minimum=False``."""
+    for fid in sorted(ent.ALL_FEATURES):
+        r = client.get(
+            f"/api/entitlement/affordable-tiers-batch?features={fid}"
+        )
+        tiers = r.get_json()["features"][0]["tiers"]
+        if not tiers:
+            continue
+        assert tiers[0]["is_minimum"] is True
+        for row in tiers[1:]:
+            assert row["is_minimum"] is False


### PR DESCRIPTION
## Summary

- Adds `affordable_tiers_batch(*, features, runtimes, channels, retention_days, nodes)` -- per-item plural sibling of `affordable_tiers`. Where `affordable_tiers` / `/api/entitlement/affordable-tiers` collapse the answer to a single ordered list of qualifying tiers for a whole constraint bundle, this preserves the per-item detail so a pricing-matrix UI ("show me each requested feature + runtime + capacity row with its individual cheapest tier -- and every tier above that also qualifies") renders off ONE round-trip instead of N calls to `/affordable-tiers`. Same relationship it has to `affordable_tiers` that `min_tier_batch` has to `min_tier_for_all`.
- Adds `GET /api/entitlement/affordable-tiers-batch` -- 400 on no axis supplied, 200 with the batch envelope + `current_tier`/`_rank` + `grace`/`enforced` resolver context on happy path. Never 5xxs.
- Row floor scalar (`min_tier` / `free` / `min_tier_label` / `min_tier_rank`) is composed from `_min_tier_row` so each row byte-equals the matching `min_tier_batch` row on those fields -- drop the `tiers` list off any row and you get the exact `min_tier_batch` shape back. Keeps the two batches internally consistent even for free items where alphabetical tie-breaking among rank-0 tiers would otherwise land `affordable_tiers`' first row on `cloud_free` while `min_tier_for_feature` returns `oss`.

Grace-mode change only -- no behaviour change on any existing surface.

## Test plan

- [x] `tests/test_entitlement_affordable_tiers_batch.py` -- 40 tests, all green locally
  - envelope shape parity with `min_tier_batch` (five axes, row shape incl. new `tiers` field)
  - per-row `tiers` list parity with the singular `affordable_tiers(<axis>=<value>)` helper across every id in `ALL_FEATURES` / `ALL_RUNTIMES` and the three capacity axes
  - per-row floor scalar parity with `min_tier_batch` across every id in `ALL_FEATURES` / `ALL_RUNTIMES` and the three capacity axes -- pins the two batches against each other so they can never silently drift
  - runtime canonicalisation (`claude-code` -> `claude_code`) and dedup
  - unknown ids contribute an all-`None` row with `tiers=[]` (rather than raising)
  - `retention_days=None` means unset, NOT unlimited
  - grace vs enforce yields byte-identical rows
  - never-raises contract on the helper (7 parametrised inputs)
  - API happy path (features-only, all-axes), tier alias canonicalises, unknown id doesn't 500, non-int capacity treated as unsupplied
  - API error path (400 no axis)
  - cross-endpoint parity: per-row `tiers` byte-equal `/affordable-tiers?features=<id>` (stripped of the singular endpoint's `is_current`/`is_current_or_better` augmentation) for every id in `ALL_FEATURES`
  - resolver envelope (`current_tier`, `_rank`, `grace`, `enforced`)
  - tiers ordered by `tier_rank` ascending; only the first row carries `is_minimum=True`
- [x] `ruff check clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_affordable_tiers_batch.py` -- clean
- [x] `python -m py_compile` on the three changed files -- OK
- [x] Sibling test files (`test_entitlement_min_tier_batch.py`, `test_entitlement_affordable_tiers.py`, `test_entitlement_api.py`) still green -- 106/106
- [x] `test_blueprint_uniqueness.py` + `test_circular_import.py` still green -- 10/10

### Local operator verification checklist

I can't touch the running daemon, `~/.openclaw`, the live snapshot, or a browser from here -- please run:

- [ ] Copy the two changed files into `~/.clawmetry/lib/python3.11/site-packages/clawmetry/` (`entitlements.py`) and `~/.clawmetry/lib/python3.11/site-packages/routes/` (`entitlement.py`); drop the test file into the local checkout under `tests/`
- [ ] Clear `__pycache__` on both dirs
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
- [ ] `curl -s 'http://localhost:8900/api/entitlement/affordable-tiers-batch?features=fleet,sso&runtimes=claude_code&channels=5&retention_days=30&nodes=3' | jq .` -- expect a shaped envelope with per-axis rows carrying `key`/`kind`/`free`/`min_tier`/`min_tier_label`/`min_tier_rank`/`tiers`, plus the resolver envelope
- [ ] `curl -s -o /dev/null -w '%{http_code}\n' 'http://localhost:8900/api/entitlement/affordable-tiers-batch'` -> `400`
- [ ] Compare rows against `/api/entitlement/affordable-tiers?features=<id>` for a few ids -- per-row `tiers` must byte-equal the singular `tiers` (after stripping the singular endpoint's `is_current`/`is_current_or_better` fields)
- [ ] Compare row floor scalar (`min_tier`/`free`/`min_tier_label`/`min_tier_rank`) against `/api/entitlement/min-tier-batch?features=<id>` for the same bundle -- fields must byte-equal
- [ ] Decrypt the live cloud snapshot and hit the same endpoint against the cloud read-through path
- [ ] Browser check: any surface currently calling `/affordable-tiers` or `/min-tier-batch` should keep rendering; nothing should call the new `/affordable-tiers-batch` route yet

No `__version__` bump, no tag, no `[RELEASE]` PR -- staying in DRAFT until you've cleared local + cloud verification.

## MOAT / release checklist

- Not a MOAT fast-path change (no `local_store_via_daemon` / `_ls_call` / `_DAEMON_METHODS` touched).
- Not a `[RELEASE]` PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014jPpQaHQkgHtHoszvQvkeo)_