### PR TITLE
feat(entitlement): tiers_for_channel_count/retention_window/node_count + 3 endpoints

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -15768,3 +15768,239 @@ def tier_path_at_batch(
             "entitlements: tier_path_at_batch failed: %s", exc
         )
         return None
+
+
+# ── capacity-axis tiers_for helpers ──────────────────────────────────────────
+#
+# Inverse siblings of ``min_tier_for_channel_count`` /
+# ``min_tier_for_retention_window`` / ``min_tier_for_node_count``. Where the
+# scalar ``min_tier_for_*`` helpers return the *cheapest* purchasable tier that
+# admits a capacity value (one id the upgrade-CTA uses), the ``tiers_for_*``
+# helpers below return the **full** ladder of tiers that admit the same value.
+# Closes the feature/runtime symmetry gap: ``tiers_for_feature`` /
+# ``tiers_for_runtime`` already exist for the two grant axes, but the three
+# capacity axes only expose the scalar side. A pricing-page row or capacity
+# tooltip ("Fits in: Starter, Cloud Pro, Self-hosted Pro, Trial, Enterprise")
+# now reads off the same shape as the feature/runtime rows.
+#
+# Row shape mirrors ``tiers_for_feature`` / ``tiers_for_runtime`` exactly:
+#
+#     {
+#       "item":           <int|None>,           # the queried capacity value
+#       "kind":           "channel_count" |     # matches the endpoint slug
+#                         "retention_window" |
+#                         "node_count",
+#       "label":          "5 channels" | "30 days" | "4 nodes",
+#       "free":           <bool>,               # OSS admits this value
+#       "min_tier":       "<tier id>" | None,   # matches min_tier_for_* scalar
+#       "min_tier_label": "<label>" | None,
+#       "min_tier_rank":  <int> | None,
+#       "tiers":          [<_tier_row>, ...],   # every tier admitting this value
+#     }
+#
+# ``tiers`` walks :data:`_TIER_ORDER` (includes the promotional ``trial`` tier
+# with ``purchasable=False``); ``min_tier`` walks :data:`_PURCHASABLE_TIERS`
+# (trial excluded) so it byte-equals the existing scalar helper. Rows sorted
+# ``(rank, id)`` for stable output. Never raises: bad input returns ``None``,
+# resolver failure logs at warning and returns ``None``.
+
+
+def tiers_for_channel_count(count: int) -> dict | None:
+    """Inverse of :func:`min_tier_for_channel_count`: list **every** tier that
+    admits ``count`` configured channel adapters.
+
+    Where ``min_tier_for_channel_count`` answers "cheapest purchasable tier
+    that admits N channels" -- one id the upgrade-CTA renders -- this helper
+    returns the full "Fits in: Starter, Cloud Pro, Self-hosted Pro, Trial,
+    Enterprise" availability list a pricing-page row or capacity tooltip
+    needs. Walks :data:`_TIER_ORDER` so the promotional ``trial`` tier
+    appears alongside the purchasable plans (each row carries ``purchasable``
+    so the UI can dim or badge it).
+
+    Semantics:
+
+    * ``count <= 0`` -- collapses to "free everywhere": every tier in
+      :data:`_TIER_ORDER` admits a zero/negative count (either "not measured
+      yet" or trivially satisfied). ``min_tier`` matches
+      :func:`min_tier_for_channel_count` (which returns :data:`TIER_OSS`).
+    * Non-int ``count`` -- returns ``None`` so a caller can distinguish
+      "free" from "couldn't parse". Never raises. Matches
+      :func:`min_tier_for_channel_count`'s posture on bad input.
+    * Otherwise -- the ladder of tiers whose ``_TIER_CHANNEL_LIMIT`` value
+      is either ``None`` (unlimited) or ``>= count``. ``min_tier`` matches
+      the existing scalar helper exactly (purchasable-only walk).
+
+    Rows sorted ``(tier_rank, tier_id)`` for stable output.
+    """
+    try:
+        try:
+            n = int(count)
+        except (TypeError, ValueError):
+            return None
+        carriers: list[str] = []
+        for tier in _TIER_ORDER:
+            cap = _TIER_CHANNEL_LIMIT.get(tier, _FREE_CHANNEL_LIMIT)
+            if n <= 0 or cap is None or n <= cap:
+                carriers.append(tier)
+        rows = [
+            _tier_row(t)
+            for t in sorted(carriers, key=lambda t: (tier_rank(t), t))
+        ]
+        min_t = min_tier_for_channel_count(n)
+        is_free = n <= _FREE_CHANNEL_LIMIT
+        label = f"{n} channel" if n == 1 else f"{n} channels"
+        return {
+            "item": n,
+            "kind": "channel_count",
+            "label": label,
+            "free": is_free,
+            "min_tier": min_t,
+            "min_tier_label": tier_label(min_t) if min_t else None,
+            "min_tier_rank": tier_rank(min_t) if min_t else None,
+            "tiers": rows,
+        }
+    except Exception as exc:
+        logger.warning(
+            "entitlements: tiers_for_channel_count failed: %s", exc
+        )
+        return None
+
+
+def tiers_for_retention_window(days: int | None) -> dict | None:
+    """Inverse of :func:`min_tier_for_retention_window`: list every tier that
+    admits a ``days`` event-retention history window.
+
+    Where ``min_tier_for_retention_window`` returns the cheapest purchasable
+    tier admitting the window -- one id the history-range toggle renders --
+    this helper returns the full "Fits in: <tier>, ..." availability list.
+
+    Semantics mirror :func:`min_tier_for_retention_window` on input parsing
+    and the ``free`` flag:
+
+    * ``days is None`` (caller asked for unlimited history) -- only tiers
+      with ``_TIER_RETENTION_DAYS[t] is None`` admit the request. On the
+      current tier table that is :data:`TIER_ENTERPRISE` alone. ``item`` is
+      ``None``, ``label`` is ``"unlimited"``, ``free`` is ``False`` (OSS
+      does not admit unlimited history).
+    * ``days <= 0`` -- collapses to "free everywhere": every tier in
+      :data:`_TIER_ORDER` admits a zero/negative window (trivially
+      satisfied). ``min_tier`` matches :func:`min_tier_for_retention_window`
+      (which returns :data:`TIER_OSS`).
+    * Non-int ``days`` (other than the explicit ``None``) -- returns
+      ``None`` so a caller can distinguish "free" from "couldn't parse".
+      Never raises.
+    * Otherwise -- the ladder of tiers whose retention cap is ``None``
+      (unlimited) or ``>= days``. ``min_tier`` matches the existing scalar
+      helper exactly (purchasable-only walk).
+
+    Rows sorted ``(tier_rank, tier_id)`` for stable output.
+    """
+    try:
+        if days is None:
+            carriers = [
+                t for t in _TIER_ORDER
+                if _TIER_RETENTION_DAYS.get(t, 7) is None
+            ]
+            rows = [
+                _tier_row(t)
+                for t in sorted(carriers, key=lambda t: (tier_rank(t), t))
+            ]
+            min_t = min_tier_for_retention_window(None)
+            return {
+                "item": None,
+                "kind": "retention_window",
+                "label": "unlimited",
+                "free": False,
+                "min_tier": min_t,
+                "min_tier_label": tier_label(min_t) if min_t else None,
+                "min_tier_rank": tier_rank(min_t) if min_t else None,
+                "tiers": rows,
+            }
+        try:
+            n = int(days)
+        except (TypeError, ValueError):
+            return None
+        carriers: list[str] = []
+        for tier in _TIER_ORDER:
+            cap = _TIER_RETENTION_DAYS.get(tier, 7)
+            if n <= 0 or cap is None or n <= cap:
+                carriers.append(tier)
+        rows = [
+            _tier_row(t)
+            for t in sorted(carriers, key=lambda t: (tier_rank(t), t))
+        ]
+        min_t = min_tier_for_retention_window(n)
+        free_cap = _TIER_RETENTION_DAYS.get(TIER_OSS, 7)
+        is_free = n <= 0 or (free_cap is not None and n <= free_cap)
+        label = f"{n} day" if n == 1 else f"{n} days"
+        return {
+            "item": n,
+            "kind": "retention_window",
+            "label": label,
+            "free": is_free,
+            "min_tier": min_t,
+            "min_tier_label": tier_label(min_t) if min_t else None,
+            "min_tier_rank": tier_rank(min_t) if min_t else None,
+            "tiers": rows,
+        }
+    except Exception as exc:
+        logger.warning(
+            "entitlements: tiers_for_retention_window failed: %s", exc
+        )
+        return None
+
+
+def tiers_for_node_count(count: int) -> dict | None:
+    """Inverse of :func:`min_tier_for_node_count`: list every tier that admits
+    ``count`` registered nodes.
+
+    Where ``min_tier_for_node_count`` returns the cheapest purchasable tier
+    admitting the node count -- one id the fleet-page upgrade affordance
+    renders -- this helper returns the full "Fits in: <tier>, ..."
+    availability list.
+
+    Semantics mirror :func:`min_tier_for_node_count`:
+
+    * ``count <= 0`` -- collapses to "free everywhere": every tier in
+      :data:`_TIER_ORDER` admits a zero/negative count. ``min_tier`` matches
+      :func:`min_tier_for_node_count` (which returns :data:`TIER_OSS`).
+    * Non-int ``count`` -- returns ``None`` so a caller can distinguish
+      "free" from "couldn't parse". Never raises.
+    * Otherwise -- the ladder of tiers whose ``_TIER_NODE_LIMIT`` value is
+      either ``None`` (unlimited) or ``>= count``. ``min_tier`` matches the
+      scalar helper exactly (purchasable-only walk).
+
+    Rows sorted ``(tier_rank, tier_id)`` for stable output.
+    """
+    try:
+        try:
+            n = int(count)
+        except (TypeError, ValueError):
+            return None
+        carriers: list[str] = []
+        for tier in _TIER_ORDER:
+            cap = _TIER_NODE_LIMIT.get(tier, _FREE_NODE_LIMIT)
+            if n <= 0 or cap is None or n <= cap:
+                carriers.append(tier)
+        rows = [
+            _tier_row(t)
+            for t in sorted(carriers, key=lambda t: (tier_rank(t), t))
+        ]
+        min_t = min_tier_for_node_count(n)
+        is_free = n <= _FREE_NODE_LIMIT
+        label = f"{n} node" if n == 1 else f"{n} nodes"
+        return {
+            "item": n,
+            "kind": "node_count",
+            "label": label,
+            "free": is_free,
+            "min_tier": min_t,
+            "min_tier_label": tier_label(min_t) if min_t else None,
+            "min_tier_rank": tier_rank(min_t) if min_t else None,
+            "tiers": rows,
+        }
+    except Exception as exc:
+        logger.warning(
+            "entitlements: tiers_for_node_count failed: %s", exc
+        )
+        return None

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -19529,3 +19529,193 @@ def api_entitlement_previous_tier_runtime_catalog_at_batch():
                 "enforced": False,
             }
         )
+
+
+# ── capacity-axis tiers-for endpoints ────────────────────────────────────────
+#
+# Inverse siblings of ``/api/entitlement/required-tier?channels=`` /
+# ``retention_days=`` / ``nodes=``. Where ``required-tier`` returns the
+# cheapest tier that admits a capacity value (one id used by the upgrade-CTA),
+# these return the full "Fits in: ..." availability ladder a pricing-page row
+# or capacity tooltip needs. Same relationship the existing
+# ``/api/entitlement/tiers-for?feature=|runtime=`` endpoint has to
+# ``/api/entitlement/required-tier?feature=|runtime=``, extended to the three
+# capacity axes.
+
+
+def _resolver_envelope(_ent) -> dict:
+    ent = _ent.get_entitlement()
+    return {
+        "current_tier": ent.tier,
+        "current_tier_rank": _ent.tier_rank(ent.tier),
+        "grace": bool(ent.grace),
+        "enforced": _ent.is_enforced(),
+    }
+
+
+@bp_entitlement.route("/api/entitlement/tiers-for-channel-count")
+def api_entitlement_tiers_for_channel_count():
+    """``GET /api/entitlement/tiers-for-channel-count?count=<int>`` --
+    inverse of ``/api/entitlement/required-tier?channels=<int>``: returns
+    the full ladder of tiers that admit ``count`` configured channel
+    adapters, not just the cheapest one. The "Fits in: Starter, Cloud Pro,
+    Self-hosted Pro, Trial, Enterprise" availability list a pricing-page
+    row or capacity tooltip needs.
+
+    ``count=`` is required. Missing key -> ``400``. Non-int / blank value
+    -> ``400``. Never 5xxs: a resolver failure yields empty ``tiers`` list
+    and the grace-shape envelope so the pricing UI keeps rendering.
+
+    Response shape mirrors ``/api/entitlement/tiers-for`` exactly plus the
+    resolver envelope::
+
+        {
+          "item":              <int>,
+          "kind":              "channel_count",
+          "label":             "5 channels",
+          "free":              <bool>,
+          "min_tier":          "<tier id>" | null,
+          "min_tier_label":    "<label>" | null,
+          "min_tier_rank":     <int> | null,
+          "tiers":             [<row>, ...],
+          "current_tier":      "...",
+          "current_tier_rank": <int>,
+          "grace":             <bool>,
+          "enforced":          <bool>,
+        }
+    """
+    raw = request.args.get("count")
+    if raw is None:
+        return jsonify({"error": "missing count"}), 400
+    raw_stripped = raw.strip()
+    if not raw_stripped:
+        return jsonify({"error": "missing count"}), 400
+    try:
+        n = int(raw_stripped)
+    except (TypeError, ValueError):
+        return jsonify({"error": "count must be an integer"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        body = _ent.tiers_for_channel_count(n)
+        env = _resolver_envelope(_ent)
+        if body is None:
+            return jsonify({"tiers": [], **env})
+        return jsonify({**body, **env})
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_tiers_for_channel_count: error: %s", exc
+        )
+        return jsonify(
+            {
+                "tiers": [],
+                "current_tier": "oss",
+                "current_tier_rank": 0,
+                "grace": True,
+                "enforced": False,
+            }
+        )
+
+
+@bp_entitlement.route("/api/entitlement/tiers-for-retention-window")
+def api_entitlement_tiers_for_retention_window():
+    """``GET /api/entitlement/tiers-for-retention-window?days=<int>`` --
+    inverse of ``/api/entitlement/required-tier?retention_days=<int>``:
+    returns the full ladder of tiers admitting a ``days`` history window.
+
+    ``days=`` is required. Pass ``days=unlimited`` (case-insensitive) for
+    the unlimited-history request; the helper only accepts tiers whose
+    retention cap is ``None`` (Enterprise on the current tier table).
+    Missing key -> ``400``. Blank / non-int / non-``unlimited`` value ->
+    ``400``. Never 5xxs.
+
+    Response shape mirrors ``/api/entitlement/tiers-for-channel-count`` --
+    ``item`` is the parsed ``days`` value, or ``null`` for the unlimited
+    request; ``kind`` is ``"retention_window"``; ``label`` is ``"30
+    days"`` / ``"unlimited"``.
+    """
+    raw = request.args.get("days")
+    if raw is None:
+        return jsonify({"error": "missing days"}), 400
+    raw_stripped = raw.strip()
+    if not raw_stripped:
+        return jsonify({"error": "missing days"}), 400
+    unlimited = raw_stripped.lower() == "unlimited"
+    if unlimited:
+        parsed: int | None = None
+    else:
+        try:
+            parsed = int(raw_stripped)
+        except (TypeError, ValueError):
+            return (
+                jsonify(
+                    {"error": "days must be an integer or 'unlimited'"}
+                ),
+                400,
+            )
+    try:
+        from clawmetry import entitlements as _ent
+
+        body = _ent.tiers_for_retention_window(parsed)
+        env = _resolver_envelope(_ent)
+        if body is None:
+            return jsonify({"tiers": [], **env})
+        return jsonify({**body, **env})
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_tiers_for_retention_window: error: %s", exc
+        )
+        return jsonify(
+            {
+                "tiers": [],
+                "current_tier": "oss",
+                "current_tier_rank": 0,
+                "grace": True,
+                "enforced": False,
+            }
+        )
+
+
+@bp_entitlement.route("/api/entitlement/tiers-for-node-count")
+def api_entitlement_tiers_for_node_count():
+    """``GET /api/entitlement/tiers-for-node-count?count=<int>`` --
+    inverse of ``/api/entitlement/required-tier?nodes=<int>``: returns the
+    full ladder of tiers admitting ``count`` registered nodes.
+
+    ``count=`` is required. Missing key -> ``400``. Non-int / blank value
+    -> ``400``. Never 5xxs.
+
+    Response shape mirrors ``/api/entitlement/tiers-for-channel-count`` --
+    ``kind`` is ``"node_count"``; ``label`` is ``"4 nodes"``.
+    """
+    raw = request.args.get("count")
+    if raw is None:
+        return jsonify({"error": "missing count"}), 400
+    raw_stripped = raw.strip()
+    if not raw_stripped:
+        return jsonify({"error": "missing count"}), 400
+    try:
+        n = int(raw_stripped)
+    except (TypeError, ValueError):
+        return jsonify({"error": "count must be an integer"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        body = _ent.tiers_for_node_count(n)
+        env = _resolver_envelope(_ent)
+        if body is None:
+            return jsonify({"tiers": [], **env})
+        return jsonify({**body, **env})
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_tiers_for_node_count: error: %s", exc
+        )
+        return jsonify(
+            {
+                "tiers": [],
+                "current_tier": "oss",
+                "current_tier_rank": 0,
+                "grace": True,
+                "enforced": False,
+            }
+        )

--- a/tests/test_entitlement_tiers_for_capacity.py
+++ b/tests/test_entitlement_tiers_for_capacity.py
@@ -1,0 +1,596 @@
+"""Tests for the capacity-axis ``tiers_for_*`` helpers and their HTTP
+wrappers:
+
+* ``clawmetry.entitlements.tiers_for_channel_count``
+* ``clawmetry.entitlements.tiers_for_retention_window``
+* ``clawmetry.entitlements.tiers_for_node_count``
+* ``GET /api/entitlement/tiers-for-channel-count``
+* ``GET /api/entitlement/tiers-for-retention-window``
+* ``GET /api/entitlement/tiers-for-node-count``
+
+Inverse siblings of the ``min_tier_for_*`` capacity helpers -- where the
+scalar helpers return the *cheapest* purchasable tier admitting a
+capacity value (one id the upgrade-CTA renders), these list the **full**
+ladder of tiers that admit it. Closes the feature/runtime symmetry gap:
+``tiers_for_feature`` and ``tiers_for_runtime`` already exist for the
+grant axes but the three capacity axes only exposed the scalar side.
+
+Invariants pinned:
+
+* ``min_tier`` on every row byte-equals the matching scalar
+  ``min_tier_for_*`` helper -- keeps the ladder and the scalar in lock
+  step
+* free tiers appear in the ladder for values that fit under the free
+  cap; do NOT appear for values above it
+* Enterprise (unlimited on every axis) always appears
+* row shape is identical to ``tiers_for_feature`` / ``tiers_for_runtime``
+  (``item`` / ``kind`` / ``label`` / ``free`` / ``min_tier`` /
+  ``min_tier_label`` / ``min_tier_rank`` / ``tiers``) so a matrix UI can
+  render every ``tiers_for_*`` row through one component
+* bad input (non-int, empty, ``None`` for non-retention axes) returns
+  ``None`` from the helper and ``400`` from the endpoint
+* helpers never raise
+* endpoints never 5xx
+* the live entitlement is not mutated by the helper
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+# ── fixtures ─────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+#   tiers_for_channel_count
+# ══════════════════════════════════════════════════════════════════════════════
+
+
+# ── shape ────────────────────────────────────────────────────────────────────
+
+
+def test_channel_count_returns_full_shape(ent):
+    body = ent.tiers_for_channel_count(5)
+    assert body is not None
+    assert set(body.keys()) == {
+        "item",
+        "kind",
+        "label",
+        "free",
+        "min_tier",
+        "min_tier_label",
+        "min_tier_rank",
+        "tiers",
+    }
+    assert body["kind"] == "channel_count"
+    assert body["item"] == 5
+
+
+def test_channel_count_row_shape_matches_tiers_for(ent):
+    body = ent.tiers_for_channel_count(5)
+    assert body["tiers"]
+    for row in body["tiers"]:
+        assert set(row.keys()) == {"id", "label", "rank", "purchasable"}
+        assert isinstance(row["id"], str) and row["id"]
+        assert isinstance(row["label"], str) and row["label"]
+        assert isinstance(row["rank"], int)
+        assert isinstance(row["purchasable"], bool)
+
+
+def test_channel_count_tier_rows_sorted_by_rank_then_id(ent):
+    body = ent.tiers_for_channel_count(5)
+    ranks = [(r["rank"], r["id"]) for r in body["tiers"]]
+    assert ranks == sorted(ranks)
+
+
+def test_channel_count_label_singular_vs_plural(ent):
+    assert ent.tiers_for_channel_count(1)["label"] == "1 channel"
+    assert ent.tiers_for_channel_count(2)["label"] == "2 channels"
+    assert ent.tiers_for_channel_count(0)["label"] == "0 channels"
+
+
+# ── carriage ─────────────────────────────────────────────────────────────────
+
+
+def test_channel_count_within_free_cap_includes_oss(ent):
+    body = ent.tiers_for_channel_count(ent._FREE_CHANNEL_LIMIT)
+    ids = {row["id"] for row in body["tiers"]}
+    assert ent.TIER_OSS in ids
+    assert ent.TIER_CLOUD_FREE in ids
+    assert body["free"] is True
+
+
+def test_channel_count_above_free_cap_excludes_oss(ent):
+    body = ent.tiers_for_channel_count(ent._FREE_CHANNEL_LIMIT + 1)
+    ids = {row["id"] for row in body["tiers"]}
+    assert ent.TIER_OSS not in ids
+    assert ent.TIER_CLOUD_FREE not in ids
+    # unlimited-cap tiers still cover it
+    assert ent.TIER_CLOUD_STARTER in ids
+    assert ent.TIER_ENTERPRISE in ids
+    assert body["free"] is False
+
+
+def test_channel_count_zero_admitted_by_every_tier(ent):
+    body = ent.tiers_for_channel_count(0)
+    ids = {row["id"] for row in body["tiers"]}
+    assert ids == set(ent._TIER_ORDER)
+    assert body["free"] is True
+
+
+def test_channel_count_negative_admitted_by_every_tier(ent):
+    body = ent.tiers_for_channel_count(-3)
+    ids = {row["id"] for row in body["tiers"]}
+    assert ids == set(ent._TIER_ORDER)
+
+
+def test_channel_count_huge_still_admitted_by_unlimited_tiers(ent):
+    body = ent.tiers_for_channel_count(10_000_000)
+    ids = {row["id"] for row in body["tiers"]}
+    # Every unlimited-cap tier must admit any finite count.
+    for tier, cap in ent._TIER_CHANNEL_LIMIT.items():
+        if cap is None:
+            assert tier in ids, tier
+
+
+# ── min_tier consistency ─────────────────────────────────────────────────────
+
+
+def test_channel_count_min_tier_matches_scalar_helper(ent):
+    for n in (-3, 0, 1, 3, 4, 10, 100, 10_000_000):
+        body = ent.tiers_for_channel_count(n)
+        assert body is not None, n
+        assert body["min_tier"] == ent.min_tier_for_channel_count(n), n
+
+
+def test_channel_count_min_tier_row_is_purchasable(ent):
+    body = ent.tiers_for_channel_count(50)
+    assert body["min_tier"] is not None
+    by_id = {row["id"]: row for row in body["tiers"]}
+    if body["min_tier"] in by_id:
+        assert by_id[body["min_tier"]]["purchasable"] is True
+
+
+def test_channel_count_trial_row_marked_non_purchasable(ent):
+    body = ent.tiers_for_channel_count(50)
+    by_id = {row["id"]: row for row in body["tiers"]}
+    if ent.TIER_TRIAL in by_id:
+        assert by_id[ent.TIER_TRIAL]["purchasable"] is False
+
+
+# ── input handling / safety ──────────────────────────────────────────────────
+
+
+def test_channel_count_non_int_returns_none(ent):
+    assert ent.tiers_for_channel_count("nope") is None  # type: ignore[arg-type]
+    assert ent.tiers_for_channel_count(None) is None  # type: ignore[arg-type]
+    assert ent.tiers_for_channel_count(object()) is None  # type: ignore[arg-type]
+
+
+def test_channel_count_string_int_coerces(ent):
+    body = ent.tiers_for_channel_count("5")  # type: ignore[arg-type]
+    assert body is not None
+    assert body["item"] == 5
+
+
+def test_channel_count_never_raises(monkeypatch, ent):
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "_tier_row", boom)
+    assert ent.tiers_for_channel_count(5) is None
+
+
+def test_channel_count_does_not_mutate_live_entitlement(ent):
+    live_before = ent.get_entitlement().to_dict()
+    ent.tiers_for_channel_count(5)
+    ent.tiers_for_channel_count(0)
+    ent.tiers_for_channel_count(1_000_000)
+    live_after = ent.get_entitlement().to_dict()
+    assert live_before == live_after
+
+
+# ── API ──────────────────────────────────────────────────────────────────────
+
+
+def test_channel_count_api_returns_ladder(client, ent):
+    rv = client.get("/api/entitlement/tiers-for-channel-count?count=5")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["kind"] == "channel_count"
+    assert body["item"] == 5
+    ids = {row["id"] for row in body["tiers"]}
+    assert ent.TIER_OSS not in ids
+    assert ent.TIER_ENTERPRISE in ids
+    # resolver envelope
+    assert body["current_tier"] == ent.get_entitlement().tier
+    assert body["grace"] is True
+    assert body["enforced"] is False
+
+
+def test_channel_count_api_zero_returns_every_tier(client, ent):
+    rv = client.get("/api/entitlement/tiers-for-channel-count?count=0")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    ids = {row["id"] for row in body["tiers"]}
+    assert ids == set(ent._TIER_ORDER)
+
+
+def test_channel_count_api_missing_count_is_400(client):
+    rv = client.get("/api/entitlement/tiers-for-channel-count")
+    assert rv.status_code == 400
+    assert "error" in rv.get_json()
+
+
+def test_channel_count_api_blank_count_is_400(client):
+    rv = client.get("/api/entitlement/tiers-for-channel-count?count=")
+    assert rv.status_code == 400
+    assert "error" in rv.get_json()
+
+
+def test_channel_count_api_non_int_is_400(client):
+    rv = client.get("/api/entitlement/tiers-for-channel-count?count=nope")
+    assert rv.status_code == 400
+    body = rv.get_json()
+    assert "error" in body
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+#   tiers_for_retention_window
+# ══════════════════════════════════════════════════════════════════════════════
+
+
+def test_retention_returns_full_shape(ent):
+    body = ent.tiers_for_retention_window(30)
+    assert body is not None
+    assert set(body.keys()) == {
+        "item",
+        "kind",
+        "label",
+        "free",
+        "min_tier",
+        "min_tier_label",
+        "min_tier_rank",
+        "tiers",
+    }
+    assert body["kind"] == "retention_window"
+    assert body["item"] == 30
+
+
+def test_retention_row_shape(ent):
+    body = ent.tiers_for_retention_window(30)
+    for row in body["tiers"]:
+        assert set(row.keys()) == {"id", "label", "rank", "purchasable"}
+
+
+def test_retention_label_singular_vs_plural(ent):
+    assert ent.tiers_for_retention_window(1)["label"] == "1 day"
+    assert ent.tiers_for_retention_window(7)["label"] == "7 days"
+    assert ent.tiers_for_retention_window(0)["label"] == "0 days"
+    assert ent.tiers_for_retention_window(None)["label"] == "unlimited"
+
+
+def test_retention_free_flag(ent):
+    # OSS retention cap is 7 days.
+    assert ent.tiers_for_retention_window(1)["free"] is True
+    assert ent.tiers_for_retention_window(7)["free"] is True
+    assert ent.tiers_for_retention_window(8)["free"] is False
+    assert ent.tiers_for_retention_window(0)["free"] is True
+    assert ent.tiers_for_retention_window(None)["free"] is False
+
+
+def test_retention_within_free_cap_includes_oss(ent):
+    body = ent.tiers_for_retention_window(7)
+    ids = {row["id"] for row in body["tiers"]}
+    assert ent.TIER_OSS in ids
+
+
+def test_retention_above_free_cap_excludes_oss(ent):
+    body = ent.tiers_for_retention_window(30)
+    ids = {row["id"] for row in body["tiers"]}
+    assert ent.TIER_OSS not in ids
+
+
+def test_retention_above_starter_cap_excludes_starter(ent):
+    # Starter caps at 30 days; 31 requires cloud_pro or above.
+    body = ent.tiers_for_retention_window(31)
+    ids = {row["id"] for row in body["tiers"]}
+    assert ent.TIER_CLOUD_STARTER not in ids
+    assert ent.TIER_CLOUD_PRO in ids
+    assert ent.TIER_ENTERPRISE in ids
+
+
+def test_retention_unlimited_only_enterprise(ent):
+    body = ent.tiers_for_retention_window(None)
+    ids = {row["id"] for row in body["tiers"]}
+    # Every tier whose cap is None admits unlimited -- currently just Enterprise.
+    expected = {
+        t for t, cap in ent._TIER_RETENTION_DAYS.items() if cap is None
+    }
+    assert ids == expected
+    assert ent.TIER_ENTERPRISE in ids
+
+
+def test_retention_min_tier_matches_scalar_helper(ent):
+    for d in (-3, 0, 1, 7, 8, 30, 90, 365, None):
+        body = ent.tiers_for_retention_window(d)
+        assert body is not None, d
+        assert body["min_tier"] == ent.min_tier_for_retention_window(d), d
+
+
+def test_retention_non_int_returns_none(ent):
+    assert ent.tiers_for_retention_window("nope") is None  # type: ignore[arg-type]
+    assert ent.tiers_for_retention_window(object()) is None  # type: ignore[arg-type]
+
+
+def test_retention_never_raises(monkeypatch, ent):
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "_tier_row", boom)
+    assert ent.tiers_for_retention_window(30) is None
+    assert ent.tiers_for_retention_window(None) is None
+
+
+def test_retention_does_not_mutate_live_entitlement(ent):
+    live_before = ent.get_entitlement().to_dict()
+    ent.tiers_for_retention_window(30)
+    ent.tiers_for_retention_window(None)
+    live_after = ent.get_entitlement().to_dict()
+    assert live_before == live_after
+
+
+# ── API ──────────────────────────────────────────────────────────────────────
+
+
+def test_retention_api_days_returns_ladder(client, ent):
+    rv = client.get(
+        "/api/entitlement/tiers-for-retention-window?days=30"
+    )
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["kind"] == "retention_window"
+    assert body["item"] == 30
+    ids = {row["id"] for row in body["tiers"]}
+    assert ent.TIER_OSS not in ids
+    assert ent.TIER_CLOUD_STARTER in ids
+
+
+def test_retention_api_unlimited(client, ent):
+    rv = client.get(
+        "/api/entitlement/tiers-for-retention-window?days=unlimited"
+    )
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["item"] is None
+    assert body["label"] == "unlimited"
+    ids = {row["id"] for row in body["tiers"]}
+    assert ent.TIER_ENTERPRISE in ids
+
+
+def test_retention_api_unlimited_case_insensitive(client, ent):
+    rv = client.get(
+        "/api/entitlement/tiers-for-retention-window?days=Unlimited"
+    )
+    assert rv.status_code == 200
+    assert rv.get_json()["item"] is None
+
+
+def test_retention_api_missing_days_is_400(client):
+    rv = client.get("/api/entitlement/tiers-for-retention-window")
+    assert rv.status_code == 400
+
+
+def test_retention_api_blank_days_is_400(client):
+    rv = client.get(
+        "/api/entitlement/tiers-for-retention-window?days="
+    )
+    assert rv.status_code == 400
+
+
+def test_retention_api_bad_days_is_400(client):
+    rv = client.get(
+        "/api/entitlement/tiers-for-retention-window?days=forever"
+    )
+    assert rv.status_code == 400
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+#   tiers_for_node_count
+# ══════════════════════════════════════════════════════════════════════════════
+
+
+def test_node_count_returns_full_shape(ent):
+    body = ent.tiers_for_node_count(4)
+    assert body is not None
+    assert set(body.keys()) == {
+        "item",
+        "kind",
+        "label",
+        "free",
+        "min_tier",
+        "min_tier_label",
+        "min_tier_rank",
+        "tiers",
+    }
+    assert body["kind"] == "node_count"
+    assert body["item"] == 4
+
+
+def test_node_count_row_shape(ent):
+    body = ent.tiers_for_node_count(4)
+    for row in body["tiers"]:
+        assert set(row.keys()) == {"id", "label", "rank", "purchasable"}
+
+
+def test_node_count_label_singular_vs_plural(ent):
+    assert ent.tiers_for_node_count(1)["label"] == "1 node"
+    assert ent.tiers_for_node_count(2)["label"] == "2 nodes"
+    assert ent.tiers_for_node_count(0)["label"] == "0 nodes"
+
+
+def test_node_count_within_free_cap_includes_oss(ent):
+    body = ent.tiers_for_node_count(ent._FREE_NODE_LIMIT)
+    ids = {row["id"] for row in body["tiers"]}
+    assert ent.TIER_OSS in ids
+    assert body["free"] is True
+
+
+def test_node_count_above_free_cap_excludes_oss(ent):
+    body = ent.tiers_for_node_count(ent._FREE_NODE_LIMIT + 1)
+    ids = {row["id"] for row in body["tiers"]}
+    assert ent.TIER_OSS not in ids
+    assert ent.TIER_ENTERPRISE in ids
+    assert body["free"] is False
+
+
+def test_node_count_zero_admitted_by_every_tier(ent):
+    body = ent.tiers_for_node_count(0)
+    ids = {row["id"] for row in body["tiers"]}
+    assert ids == set(ent._TIER_ORDER)
+
+
+def test_node_count_min_tier_matches_scalar_helper(ent):
+    for n in (-3, 0, 1, 4, 10, 100, 10_000):
+        body = ent.tiers_for_node_count(n)
+        assert body is not None, n
+        assert body["min_tier"] == ent.min_tier_for_node_count(n), n
+
+
+def test_node_count_non_int_returns_none(ent):
+    assert ent.tiers_for_node_count("nope") is None  # type: ignore[arg-type]
+    assert ent.tiers_for_node_count(None) is None  # type: ignore[arg-type]
+
+
+def test_node_count_never_raises(monkeypatch, ent):
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "_tier_row", boom)
+    assert ent.tiers_for_node_count(4) is None
+
+
+def test_node_count_does_not_mutate_live_entitlement(ent):
+    live_before = ent.get_entitlement().to_dict()
+    ent.tiers_for_node_count(4)
+    ent.tiers_for_node_count(0)
+    ent.tiers_for_node_count(1_000)
+    live_after = ent.get_entitlement().to_dict()
+    assert live_before == live_after
+
+
+# ── API ──────────────────────────────────────────────────────────────────────
+
+
+def test_node_count_api_returns_ladder(client, ent):
+    rv = client.get("/api/entitlement/tiers-for-node-count?count=4")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["kind"] == "node_count"
+    assert body["item"] == 4
+    ids = {row["id"] for row in body["tiers"]}
+    assert ent.TIER_OSS not in ids
+    assert ent.TIER_ENTERPRISE in ids
+
+
+def test_node_count_api_zero_returns_every_tier(client, ent):
+    rv = client.get("/api/entitlement/tiers-for-node-count?count=0")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    ids = {row["id"] for row in body["tiers"]}
+    assert ids == set(ent._TIER_ORDER)
+
+
+def test_node_count_api_missing_count_is_400(client):
+    rv = client.get("/api/entitlement/tiers-for-node-count")
+    assert rv.status_code == 400
+
+
+def test_node_count_api_blank_count_is_400(client):
+    rv = client.get("/api/entitlement/tiers-for-node-count?count=")
+    assert rv.status_code == 400
+
+
+def test_node_count_api_non_int_is_400(client):
+    rv = client.get(
+        "/api/entitlement/tiers-for-node-count?count=nope"
+    )
+    assert rv.status_code == 400
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+#   cross-axis symmetry
+# ══════════════════════════════════════════════════════════════════════════════
+
+
+def test_all_three_helpers_share_row_shape(ent):
+    """Every capacity ``tiers_for_*`` row must share the ``tiers_for_feature``
+    / ``tiers_for_runtime`` row shape so a matrix UI can render every row
+    through one component."""
+    shape = {
+        "item",
+        "kind",
+        "label",
+        "free",
+        "min_tier",
+        "min_tier_label",
+        "min_tier_rank",
+        "tiers",
+    }
+    for body in (
+        ent.tiers_for_channel_count(5),
+        ent.tiers_for_retention_window(30),
+        ent.tiers_for_retention_window(None),
+        ent.tiers_for_node_count(4),
+        ent.tiers_for_feature("fleet"),
+        ent.tiers_for_runtime("claude_code"),
+    ):
+        assert set(body.keys()) == shape
+
+
+def test_kinds_match_endpoint_slugs(ent):
+    """The ``kind`` field must match the endpoint slug so a client can
+    round-trip a row back to the endpoint that produced it."""
+    assert ent.tiers_for_channel_count(5)["kind"] == "channel_count"
+    assert ent.tiers_for_retention_window(30)["kind"] == "retention_window"
+    assert ent.tiers_for_node_count(4)["kind"] == "node_count"
+
+
+def test_grace_vs_enforce_yields_identical_rows(monkeypatch, ent):
+    """Row content is derived from the static tier tables, not the resolver,
+    so flipping grace/enforce cannot shift the ladder."""
+    a_channel = ent.tiers_for_channel_count(5)
+    a_ret = ent.tiers_for_retention_window(30)
+    a_node = ent.tiers_for_node_count(4)
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    b_channel = ent.tiers_for_channel_count(5)
+    b_ret = ent.tiers_for_retention_window(30)
+    b_node = ent.tiers_for_node_count(4)
+    assert a_channel == b_channel
+    assert a_ret == b_ret
+    assert a_node == b_node


### PR DESCRIPTION
## Summary

- Adds three inverse siblings of the existing capacity-axis `min_tier_for_*` helpers -- `tiers_for_channel_count`, `tiers_for_retention_window`, `tiers_for_node_count` -- and the matching HTTP wrappers:
  - `GET /api/entitlement/tiers-for-channel-count?count=<int>`
  - `GET /api/entitlement/tiers-for-retention-window?days=<int|unlimited>`
  - `GET /api/entitlement/tiers-for-node-count?count=<int>`
- Closes the feature/runtime symmetry gap: `tiers_for_feature` and `tiers_for_runtime` already list every tier that grants a feature/runtime, but the three capacity axes only exposed the scalar `min_tier_for_*` side. A pricing-page row or capacity tooltip ("Fits in: Starter, Cloud Pro, Self-hosted Pro, Trial, Enterprise") now reads off the same shape as the feature/runtime rows.
- Row shape mirrors `tiers_for_feature` / `tiers_for_runtime` exactly (`item` / `kind` / `label` / `free` / `min_tier` / `min_tier_label` / `min_tier_rank` / `tiers`) so a matrix UI can render every `tiers_for_*` row through one component. `min_tier` byte-equals the matching scalar `min_tier_for_*` helper (pinned by tests) so the ladder and the scalar cannot drift.
- Grace-mode change only -- no behaviour change on any existing surface.

## Test plan

- [x] `tests/test_entitlement_tiers_for_capacity.py` -- 57 tests, all green locally
  - row shape parity with `tiers_for_feature` / `tiers_for_runtime` (all three axes)
  - `min_tier` byte-equals the matching `min_tier_for_channel_count` / `min_tier_for_retention_window` / `min_tier_for_node_count` scalar for a fanned-out set of values (negative, zero, at-cap, above-cap, unlimited, huge)
  - `free` flag: OSS admits values at/under its cap; excludes values above; retention `None` (unlimited) is NOT free
  - carriage: values within the free cap include OSS/Cloud Free; values above exclude them but Enterprise (unlimited on every axis) always appears
  - retention `days=None` (unlimited) yields only tiers whose cap is `None` -- currently just Enterprise
  - trial row present with `purchasable=False`; min_tier row (when present) is `purchasable=True`
  - rows sorted by `(rank, id)` for stable output
  - `kind` matches the endpoint slug so a client can round-trip a row back to the endpoint that produced it
  - grace vs enforce yields byte-identical rows (row content is derived from static tier tables, not the resolver)
  - helpers never raise, never mutate the live entitlement, return `None` on non-int input
  - API happy paths + envelope (`current_tier`, `_rank`, `grace`, `enforced`)
  - API error paths: missing param -> 400, blank param -> 400, non-int -> 400 (per axis)
  - retention API accepts `days=unlimited` (case-insensitive) as the sentinel for the `None` request
- [x] `ruff check clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_tiers_for_capacity.py` -- clean
- [x] `python -m py_compile` on the three changed files -- OK
- [x] Sibling test files (`test_entitlement_tiers_for.py`, `test_entitlement_api.py`, `test_entitlement_min_tier_capacity.py`, `test_entitlement_node_count.py`, `test_entitlements_min_tier_capacity.py`, `test_entitlements_min_tier_nodes.py`, `test_entitlements_retention_window.py`) still green -- 149/149
- [x] `test_blueprint_uniqueness.py` + `test_circular_import.py` still green -- 10/10
- [x] Full `pytest tests/ -k entitlement` collection green -- 6078 passed on the entitlement selector; the handful of unrelated collection errors (`test_duckdb_relay_integration`, `test_spans_otlp_edge_cases`, `test_license[_audit]`, `test_retention_prune`, `test_e2e`, `test_event_id_unification_and_dedup`, `test_event_metrics_extraction`, `test_local_store_multi_agent`, `test_local_store_rename`, `test_obs_gap_openclaw_voice_lifecycle_3014`) come from missing `duckdb` / `google.protobuf` / a `pyo3` cryptography quirk on the ephemeral env, not this change

### Local operator verification checklist

I can't touch the running daemon, `~/.openclaw`, the live snapshot, or a browser from here -- please run:

- [ ] Copy the two changed files into `~/.clawmetry/lib/python3.11/site-packages/clawmetry/` (`entitlements.py`) and `~/.clawmetry/lib/python3.11/site-packages/routes/` (`entitlement.py`); drop the test file into the local checkout under `tests/`
- [ ] Clear `__pycache__` on both dirs
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
- [ ] `curl -s 'http://localhost:8900/api/entitlement/tiers-for-channel-count?count=5' | jq .` -- expect the shaped envelope with `kind=channel_count`, `item=5`, non-empty `tiers[]`, and the resolver envelope
- [ ] `curl -s 'http://localhost:8900/api/entitlement/tiers-for-retention-window?days=30' | jq .` -- expect `kind=retention_window`, `item=30`, `free=false`, no OSS/Cloud Free in `tiers[]`
- [ ] `curl -s 'http://localhost:8900/api/entitlement/tiers-for-retention-window?days=unlimited' | jq .` -- expect `item=null`, `label="unlimited"`, only unlimited-cap tiers (Enterprise on the current table) in `tiers[]`
- [ ] `curl -s 'http://localhost:8900/api/entitlement/tiers-for-node-count?count=4' | jq .` -- expect `kind=node_count`, `item=4`, `free=false`
- [ ] `curl -s -o /dev/null -w '%{http_code}\n' 'http://localhost:8900/api/entitlement/tiers-for-channel-count'` -> `400`
- [ ] `curl -s -o /dev/null -w '%{http_code}\n' 'http://localhost:8900/api/entitlement/tiers-for-retention-window?days=forever'` -> `400`
- [ ] Compare `min_tier` on each row against `/api/entitlement/required-tier?channels=` / `?retention_days=` / `?nodes=` for the same value -- must byte-equal
- [ ] Decrypt the live cloud snapshot and hit the same endpoints against the cloud read-through path
- [ ] Browser check: any surface currently calling `/required-tier` for the capacity axes should keep rendering; nothing should call the new `/tiers-for-*` routes yet

No `__version__` bump, no tag, no `[RELEASE]` PR -- staying in DRAFT until you've cleared local + cloud verification.

## MOAT / release checklist

- Not a MOAT fast-path change (no `local_store_via_daemon` / `_ls_call` / `_DAEMON_METHODS` touched).
- Not a `[RELEASE]` PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NHnKUe6sAuwmpwLfUCzcoN)_