### PR TITLE
feat(extensions): failed_plugins() + surface load failures on /api/extensions

### DIFF
--- a/clawmetry/extensions.py
+++ b/clawmetry/extensions.py
@@ -34,8 +34,18 @@ _loaded = False
 # ``GET /api/extensions`` so operators can confirm clawmetry-pro is actually
 # wired in without scraping ``pip list``. A plugin that raised during load
 # is intentionally NOT recorded here — matches the warning-and-continue
-# posture of ``load_plugins`` itself.
+# posture of ``load_plugins`` itself; the failure lands in
+# :data:`_failed_plugins` instead so ``/api/extensions`` can surface it.
 _loaded_plugins: List[str] = []
+# Plugin entry points that raised during load, in attempted-load order.
+# Each entry is ``{"name": <ep.name>, "error": <str(exc)>}``. The
+# warning-and-continue posture of :func:`load_plugins` means these failures
+# never take down the host process, but an operator triaging
+# "why didn't clawmetry-pro load?" would otherwise have to tail daemon logs
+# — this mirror lets ``clawmetry status`` / ``GET /api/extensions`` report
+# the failure directly. Cleared on every :func:`load_plugins` re-entry so a
+# reloaded daemon does not report stale failures from an earlier pass.
+_failed_plugins: List[Dict[str, str]] = []
 
 
 def register(event: str, handler: Callable[[Dict[str, Any]], None]) -> None:
@@ -116,10 +126,12 @@ def load_plugins(app=None) -> None:
     if _loaded:
         return
     _loaded = True
-    # Reset the diagnostic mirror so a test that flips ``_loaded`` back to
-    # False and re-runs the loader doesn't see stale names from the prior pass.
+    # Reset the diagnostic mirrors so a test that flips ``_loaded`` back to
+    # False and re-runs the loader doesn't see stale names or stale failures
+    # from the prior pass.
     with _lock:
         _loaded_plugins.clear()
+        _failed_plugins.clear()
 
     try:
         eps = _select_entry_points("clawmetry.extensions")
@@ -153,6 +165,15 @@ def load_plugins(app=None) -> None:
             logger.info(f"Loaded ClawMetry extension plugin: {ep.name!r}")
         except Exception as exc:
             logger.warning(f"Failed to load extension plugin {ep.name!r}: {exc}")
+            # Record the failure so operators triaging "why didn't clawmetry-pro
+            # load?" can read it off ``failed_plugins()`` / ``/api/extensions``
+            # instead of tailing daemon logs. Only the exception's ``str`` is
+            # captured — no traceback, so bug-report-style paths / secrets in
+            # frames never leak into a diagnostic endpoint.
+            name = getattr(ep, "name", "") or ""
+            if name:
+                with _lock:
+                    _failed_plugins.append({"name": name, "error": str(exc)})
 
 
 def registered_events() -> List[str]:
@@ -176,7 +197,34 @@ def loaded_plugins() -> List[str]:
     in?" without scraping ``pip list`` or importing the package. Returns a
     SHALLOW COPY so callers can't mutate the registry. Names appear in load
     order; entries that raised during load are excluded — matching the
-    warning-and-continue posture of :func:`load_plugins`. Never raises.
+    warning-and-continue posture of :func:`load_plugins`. The excluded
+    entries land in :func:`failed_plugins` so an operator can still see them.
+    Never raises.
     """
     with _lock:
         return list(_loaded_plugins)
+
+
+def failed_plugins() -> List[Dict[str, str]]:
+    """Entry-point plugins that raised during load, in attempted-load order.
+
+    Diagnostic companion to :func:`loaded_plugins`. Each entry is
+    ``{"name": <ep.name>, "error": <str(exc)>}``. The
+    warning-and-continue posture of :func:`load_plugins` means a broken
+    plugin never takes down the host process, but until this helper existed
+    the only way to know a plugin had *tried and failed* was tailing daemon
+    logs — a bad experience when an operator installs ``clawmetry-pro``,
+    restarts the daemon, and sees ``loaded_plugins() == []`` with no obvious
+    signal for whether the wheel is even installed. Now the pair of
+    ``loaded_plugins()`` + ``failed_plugins()`` answers the triage question
+    directly.
+
+    Returns a SHALLOW COPY of the per-entry dicts so callers can freely
+    mutate them without corrupting the registry. Entries appear in the
+    order the loader attempted them. Cleared on every :func:`load_plugins`
+    re-entry so a reloaded daemon does not report stale failures. Only the
+    exception's ``str`` is captured — no traceback — so paths / secrets in
+    frames never leak into ``GET /api/extensions``. Never raises.
+    """
+    with _lock:
+        return [dict(entry) for entry in _failed_plugins]

--- a/routes/extensions.py
+++ b/routes/extensions.py
@@ -33,11 +33,26 @@ def api_extensions():
     Response shape::
 
         {
-          "plugins":        ["clawmetry-pro", ...],
-          "plugin_count":   1,
-          "events":         ["session.snapshot", ...],
-          "handler_counts": {"session.snapshot": 2, ...}
+          "plugins":             ["clawmetry-pro", ...],
+          "plugin_count":        1,
+          "failed_plugins":      [{"name": "clawmetry-pro", "error": "..."}],
+          "failed_plugin_count": 1,
+          "events":              ["session.snapshot", ...],
+          "handler_counts":      {"session.snapshot": 2, ...}
         }
+
+    ``plugins`` and ``failed_plugins`` are complementary — a given entry
+    point appears in exactly one of them per load attempt. The pair answers
+    the triage question an operator would otherwise tail daemon logs for:
+    *did the paid package try to load, and if so did it succeed?* Only the
+    exception's ``str`` is surfaced (no traceback) so paths / secrets from
+    frames never leak.
+
+    ``failed_plugins`` is derived from an in-memory mirror populated by
+    :func:`clawmetry.extensions.load_plugins`. On installs running an older
+    ``clawmetry`` where the mirror doesn't exist yet (or if fetching it
+    raises), the key falls back to ``[]`` / ``0`` and the rest of the
+    envelope still populates — the endpoint never 5xxs.
 
     Never raises and never returns 5xx — any introspection failure resolves to
     an empty shape so the dashboard's diagnostic panel always has something
@@ -47,11 +62,22 @@ def api_extensions():
         from clawmetry import extensions as _ext
 
         plugins = list(_ext.loaded_plugins())
+        # Older ``clawmetry`` may not ship :func:`failed_plugins` yet; degrade
+        # to an empty list instead of 5xx'ing the whole envelope so a mixed
+        # deploy (new routes, old core) still surfaces the loaded-plugin
+        # side.
+        try:
+            failed = [dict(entry) for entry in _ext.failed_plugins()]
+        except Exception as exc:
+            logger.warning("extensions: failed_plugins introspection failed: %s", exc)
+            failed = []
         events = list(_ext.registered_events())
         handler_counts = {evt: _ext.handler_count(evt) for evt in events}
         return jsonify({
             "plugins": plugins,
             "plugin_count": len(plugins),
+            "failed_plugins": failed,
+            "failed_plugin_count": len(failed),
             "events": events,
             "handler_counts": handler_counts,
         })
@@ -60,6 +86,8 @@ def api_extensions():
         return jsonify({
             "plugins": [],
             "plugin_count": 0,
+            "failed_plugins": [],
+            "failed_plugin_count": 0,
             "events": [],
             "handler_counts": {},
         })

--- a/tests/test_extensions_introspection.py
+++ b/tests/test_extensions_introspection.py
@@ -35,19 +35,22 @@ def _fake_eps(*pairs):
 
 @pytest.fixture(autouse=True)
 def _reset_loader():
-    """Drop the once-guard + the loaded-name mirror before every test so
-    monkeypatched entry points actually run. Also snapshot/restore the event
-    registry so handlers registered here can't leak into adjacent suites and
-    handlers from adjacent suites can't leak in here."""
+    """Drop the once-guard + the loaded-name mirror + the failed-name mirror
+    before every test so monkeypatched entry points actually run. Also
+    snapshot/restore the event registry so handlers registered here can't
+    leak into adjacent suites and handlers from adjacent suites can't leak
+    in here."""
     ext._loaded = False
     with ext._lock:
         ext._loaded_plugins.clear()
+        ext._failed_plugins.clear()
         prior_registry = {k: list(v) for k, v in ext._registry.items()}
         ext._registry.clear()
     yield
     ext._loaded = False
     with ext._lock:
         ext._loaded_plugins.clear()
+        ext._failed_plugins.clear()
         ext._registry.clear()
         ext._registry.update(prior_registry)
 
@@ -119,6 +122,125 @@ def test_loaded_plugins_records_app_style_plugins(monkeypatch):
     assert ext.loaded_plugins() == ["needs-app"]
 
 
+# ── failed_plugins() ─────────────────────────────────────────────────────────
+
+
+def test_failed_plugins_empty_before_load():
+    assert ext.failed_plugins() == []
+
+
+def test_failed_plugins_records_load_failures(monkeypatch):
+    def boom():
+        raise RuntimeError("kaboom")
+
+    monkeypatch.setattr(
+        ext, "_select_entry_points",
+        lambda group: _fake_eps((boom, "broken")),
+    )
+    ext.load_plugins()
+    failed = ext.failed_plugins()
+    assert failed == [{"name": "broken", "error": "kaboom"}]
+    # Companion mirror stays empty for the failed plugin.
+    assert ext.loaded_plugins() == []
+
+
+def test_failed_plugins_complementary_to_loaded(monkeypatch):
+    """A given entry point appears in exactly one of the two lists per load."""
+    def boom():
+        raise ValueError("nope")
+
+    def good():
+        return None
+
+    monkeypatch.setattr(
+        ext, "_select_entry_points",
+        lambda group: _fake_eps((good, "ok"), (boom, "broken")),
+    )
+    ext.load_plugins()
+    assert ext.loaded_plugins() == ["ok"]
+    assert [e["name"] for e in ext.failed_plugins()] == ["broken"]
+
+
+def test_failed_plugins_preserves_attempt_order(monkeypatch):
+    monkeypatch.setattr(
+        ext, "_select_entry_points",
+        lambda group: _fake_eps(
+            ((lambda: (_ for _ in ()).throw(RuntimeError("a"))), "first"),
+            ((lambda: (_ for _ in ()).throw(RuntimeError("b"))), "second"),
+        ),
+    )
+    ext.load_plugins()
+    assert [e["name"] for e in ext.failed_plugins()] == ["first", "second"]
+
+
+def test_failed_plugins_returns_a_copy(monkeypatch):
+    """Caller mutation of the returned list or its dicts must not corrupt
+    the registry."""
+    def boom():
+        raise RuntimeError("owned")
+
+    monkeypatch.setattr(
+        ext, "_select_entry_points",
+        lambda group: _fake_eps((boom, "broken")),
+    )
+    ext.load_plugins()
+
+    view = ext.failed_plugins()
+    view.append({"name": "ghost", "error": "phantom"})
+    view[0]["error"] = "tampered"
+
+    fresh = ext.failed_plugins()
+    assert fresh == [{"name": "broken", "error": "owned"}]
+
+
+def test_failed_plugins_resets_on_reentry(monkeypatch):
+    """A rerun of ``load_plugins`` must start with a clean failure list so a
+    reloaded daemon doesn't report stale failures from a prior pass."""
+    def boom():
+        raise RuntimeError("first-round")
+
+    monkeypatch.setattr(
+        ext, "_select_entry_points",
+        lambda group: _fake_eps((boom, "broken")),
+    )
+    ext.load_plugins()
+    assert ext.failed_plugins() == [{"name": "broken", "error": "first-round"}]
+
+    # Simulate a daemon reload where ``_loaded`` was reset; this time the
+    # plugin behaves.
+    ext._loaded = False
+    monkeypatch.setattr(
+        ext, "_select_entry_points",
+        lambda group: _fake_eps((lambda: None, "broken")),
+    )
+    ext.load_plugins()
+    assert ext.failed_plugins() == []  # stale failure did not survive
+    assert ext.loaded_plugins() == ["broken"]
+
+
+def test_failed_plugins_captures_only_str_not_traceback(monkeypatch):
+    """Only ``str(exc)`` lands in the mirror — never the traceback / frame
+    locals — so paths and secrets in frames never leak into the diagnostic
+    endpoint. Pinned so a future refactor cannot silently upgrade the
+    capture to a traceback dump.
+    """
+    def boom():
+        secret = "/Users/op/.clawmetry/license.key"  # noqa: F841
+        raise RuntimeError("plain")
+
+    monkeypatch.setattr(
+        ext, "_select_entry_points",
+        lambda group: _fake_eps((boom, "broken")),
+    )
+    ext.load_plugins()
+
+    entry = ext.failed_plugins()[0]
+    assert set(entry.keys()) == {"name", "error"}
+    assert entry["error"] == "plain"
+    assert "Traceback" not in entry["error"]
+    assert "license.key" not in entry["error"]
+
+
 # ── GET /api/extensions ──────────────────────────────────────────────────────
 
 
@@ -138,6 +260,8 @@ def test_api_extensions_shape_empty(client):
     assert body == {
         "plugins": [],
         "plugin_count": 0,
+        "failed_plugins": [],
+        "failed_plugin_count": 0,
         "events": [],
         "handler_counts": {},
     }
@@ -181,6 +305,56 @@ def test_api_extensions_never_raises(client, monkeypatch):
     assert body == {
         "plugins": [],
         "plugin_count": 0,
+        "failed_plugins": [],
+        "failed_plugin_count": 0,
         "events": [],
         "handler_counts": {},
     }
+
+
+def test_api_extensions_reports_failed_plugins(client, monkeypatch):
+    def boom():
+        raise RuntimeError("kaboom")
+
+    def good():
+        return None
+
+    monkeypatch.setattr(
+        ext, "_select_entry_points",
+        lambda group: _fake_eps((good, "clawmetry-pro"), (boom, "flaky-plugin")),
+    )
+    ext.load_plugins()
+
+    body = json.loads(client.get("/api/extensions").data)
+    assert body["plugins"] == ["clawmetry-pro"]
+    assert body["plugin_count"] == 1
+    assert body["failed_plugins"] == [
+        {"name": "flaky-plugin", "error": "kaboom"},
+    ]
+    assert body["failed_plugin_count"] == 1
+
+
+def test_api_extensions_survives_missing_failed_plugins_helper(client, monkeypatch):
+    """A mixed deploy where the routes package is new but the core ``clawmetry``
+    is old (no :func:`failed_plugins`) must still populate the loaded-plugin
+    side of the envelope instead of 5xx'ing the whole response.
+    """
+    monkeypatch.setattr(
+        ext, "_select_entry_points",
+        lambda group: _fake_eps((lambda: None, "clawmetry-pro")),
+    )
+    ext.load_plugins()
+
+    # Simulate the older wheel by making the accessor raise (an older wheel
+    # would raise ``AttributeError`` on the missing symbol; behaviourally
+    # equivalent from the route's perspective).
+    def missing():
+        raise AttributeError("failed_plugins")
+
+    monkeypatch.setattr(ext, "failed_plugins", missing)
+
+    body = json.loads(client.get("/api/extensions").data)
+    assert body["plugins"] == ["clawmetry-pro"]
+    assert body["plugin_count"] == 1
+    assert body["failed_plugins"] == []
+    assert body["failed_plugin_count"] == 0


### PR DESCRIPTION
## Summary

Diagnostic companion to `loaded_plugins()`. When an entry-point plugin raises during `load_plugins()`, record `{name, error}` on a new in-memory mirror so an operator triaging *"why didn't clawmetry-pro load?"* can read the failure off the same endpoint they already hit for loaded plugins, instead of tailing daemon logs.

- Adds `clawmetry.extensions.failed_plugins() -> list[dict]` populated by the `except` branch of `load_plugins()`. Each entry is `{"name": ep.name, "error": str(exc)}`. Cleared on every `load_plugins()` re-entry alongside `_loaded_plugins`, and pinned by test to only capture `str(exc)` — never the traceback — so paths / secrets in frames never leak into `/api/extensions`.
- Extends `GET /api/extensions` with `failed_plugins` + `failed_plugin_count` keys. The accessor is wrapped in its own never-raise fallback so a mixed deploy (new `routes/`, old `clawmetry/` without the helper) still populates the loaded-plugin side of the envelope instead of 5xx'ing.
- `loaded_plugins()` and `failed_plugins()` are complementary — a given entry point appears in exactly one of them per load attempt, pinned by parity test.
- 9 new tests (7 helper-level, 2 route-level) alongside the existing 10, all green (`19/19` in `test_extensions_introspection.py`).

Grace-mode change only — no behaviour change on any existing surface, no `__version__` bump, no `[RELEASE]` PR, no gate enforced.

## Why this and why now

`load_plugins()` warns-and-continues on any plugin exception (a broken plugin must never take down the daemon / dashboard / proxy). But the *only* trace of a plugin that tried and failed was a `logger.warning` line in the process log. If an operator installs the closed-source `clawmetry-pro` wheel, restarts the daemon, and sees `loaded_plugins() == []` in `/api/extensions`, they have no in-process signal to distinguish:

1. The wheel isn't installed at all.
2. The wheel is installed but its entry point raised during load.

Case 2 is the one that eats support hours. This PR closes that gap by making the pair `plugins` + `failed_plugins` self-describing: either the plugin loaded, or the endpoint tells you why it didn't.

Related history:
- PR #2277 wired `load_plugins()` into the sync daemon
- PR #2347 / #2356 wired it into the enforcement proxy and the claudecode dashboard
- PR #2992 added the `loaded_plugins()` / `GET /api/extensions` diagnostic surface — this PR completes the pair.

## Changes

### `clawmetry/extensions.py`
- New module-level `_failed_plugins: list[dict[str, str]]`.
- `load_plugins()` records `{name, error: str(exc)}` inside the existing `except` branch (only when `ep.name` is truthy — matches the guard `_loaded_plugins.append` already uses).
- `load_plugins()` clears `_failed_plugins` alongside `_loaded_plugins` on re-entry so a reloaded daemon doesn't report stale failures from the prior pass.
- New `failed_plugins() -> list[dict]` returning a **deep** shallow copy of the per-entry dicts (both the list and each dict are copied) so caller mutation can't corrupt the registry.

### `routes/extensions.py`
- `GET /api/extensions` gains `failed_plugins` (list of `{name, error}`) and `failed_plugin_count` (int).
- The `failed_plugins()` call is wrapped in its own `try` / `except` inside the outer never-raise fallback: an older `clawmetry` wheel that predates this helper still produces a valid envelope (loaded-plugin side + empty failed-plugin side) instead of collapsing the whole response.
- Never-raise fallback body updated with the new keys.

### `tests/test_extensions_introspection.py`
- Fixture resets `_failed_plugins` alongside `_loaded_plugins` so leaks in either direction can't happen between test files.
- 7 new helper-level tests:
  - empty-state contract before any load
  - failure recording contract (`{name, error}` shape)
  - complementary-with-`loaded_plugins()` parity across a mixed batch
  - attempt-order preservation across multiple failures
  - copy semantics (mutating the returned list OR its dicts does not corrupt the registry)
  - reset-on-reentry (a broken plugin that starts working on the next reload disappears from the failed list and appears in the loaded list)
  - `str(exc)`-only capture (no `Traceback` / no path leakage from frame locals)
- 2 new route-level tests:
  - happy path: `failed_plugins` populated end-to-end
  - mixed-deploy fallback: monkeypatched `AttributeError` on `failed_plugins()` still yields a valid envelope, not a 5xx

## Test plan

- [x] `python3 -m py_compile clawmetry/extensions.py routes/extensions.py tests/test_extensions_introspection.py` — clean
- [x] `ruff check clawmetry/extensions.py routes/extensions.py tests/test_extensions_introspection.py` — clean
- [x] `python3 -m pytest tests/test_extensions_introspection.py -v` → **19/19 pass** in 0.33s
- [x] `python3 -m pytest tests/test_extensions.py tests/test_sync_loads_plugins.py tests/test_proxy_loads_plugins.py tests/test_claudecode_loads_plugins.py -q` → **20/20 pass** — no regression on the plugin-loader wire-up tests
- [x] `python3 -m pytest tests/test_extensions_introspection.py tests/test_extensions.py tests/test_entitlement_api.py tests/test_blueprint_uniqueness.py tests/test_circular_import.py -q` → **71/71 pass** — no regression on adjacent surfaces (route uniqueness, circular-import guard, entitlement API envelope)

### Local operator verification checklist

I can't touch the running daemon, `~/.openclaw`, the live snapshot, or a browser from here — please:

- [ ] Copy the two changed files into `~/.clawmetry/lib/python3.11/site-packages/clawmetry/` (`extensions.py`) and `~/.clawmetry/lib/python3.11/site-packages/routes/` (`extensions.py`); drop the updated test file into the local checkout under `tests/`
- [ ] Clear `__pycache__` on both dirs
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
- [ ] `curl -s 'http://localhost:8900/api/extensions' | jq .` — expect the extended envelope with `plugins`, `plugin_count`, `failed_plugins`, `failed_plugin_count`, `events`, `handler_counts`
- [ ] On an OSS-only install both `plugins` and `failed_plugins` should be `[]` and their counts `0`
- [ ] If `clawmetry-pro` is installed and loads cleanly, `plugins` should contain `clawmetry-pro` and `failed_plugins` stay `[]`
- [ ] Optional smoke: temporarily point the `clawmetry-pro` entry point at a raising callable (e.g. via a `.pth` shim) and confirm `failed_plugins` now carries `{"name": "clawmetry-pro", "error": "..."}` and the daemon log still shows the original `Failed to load extension plugin ...` warning
- [ ] Confirm `/api/entitlement` still returns its existing shape (this PR does not touch it)
- [ ] Decrypt the live cloud snapshot and hit the same endpoint against the cloud read-through path
- [ ] Browser check: no UI surface consumes the new keys yet — a diagnostic badge in the status footer is a follow-up. Nothing should break.

No `__version__` bump, no tag, no `[RELEASE]` PR — staying in DRAFT until you've cleared local + cloud verification.

## MOAT / release checklist

- Not a MOAT fast-path change (no `local_store_via_daemon` / `_ls_call` / `_DAEMON_METHODS` touched).
- Not a `[RELEASE]` PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RHPfUmf3Axf6ySWK7MZYUg

---
_Generated by [Claude Code](https://claude.ai/code/session_01RHPfUmf3Axf6ySWK7MZYUg)_