### PR TITLE
e2e(c6): make schedule-heal fail visibly when E2E_ADMIN_PAT is absent

### DIFF
--- a/.github/workflows/c6-schedule-heal.yml
+++ b/.github/workflows/c6-schedule-heal.yml
@@ -3,14 +3,9 @@ name: C6 auto-heal (daily required-checks application)
 # Applies required E2E status checks to main branch protection daily.
 # Self-heals C6 the morning after E2E_ADMIN_PAT secret is added.
 #
-# Why this is needed:
-#   apply-required-checks.yml runs on push and workflow_dispatch but its
-#   apply step condition (`push || confirm==APPLY`) is never true for a
-#   schedule trigger. Adding a schedule to that file would run the workflow
-#   but execute zero steps. This dedicated workflow avoids that confusion.
-#
 # When E2E_ADMIN_PAT is NOT set:
-#   logs a one-line hint and exits 0 -- no red badge, no noise.
+#   emits an ::error:: annotation and exits 1 -- visible red badge until
+#   the secret is configured. This makes the missing PAT impossible to ignore.
 #
 # When E2E_ADMIN_PAT IS set:
 #   runs scripts/apply_required_status_checks.py which configures required
@@ -31,7 +26,7 @@ name: C6 auto-heal (daily required-checks application)
 
 on:
   schedule:
-    - cron: '15 10 * * *'  # 10:15am UTC daily, 15 min after c6-health audit
+    - cron: '15 10 * * *'  # 10:15am UTC daily
   workflow_dispatch:
 
 permissions:
@@ -51,18 +46,27 @@ jobs:
         run: |
           if [ -z "${ADMIN_PAT}" ]; then
             echo "has_pat=false" >> "$GITHUB_OUTPUT"
-            echo "No E2E_ADMIN_PAT configured -- skipping C6 auto-heal."
+            echo "::error::E2E_ADMIN_PAT secret is not set -- C6 (required-status-checks) cannot be applied automatically."
             echo ""
-            echo "To enable automatic C6 closure:"
-            echo "  1. Create a fine-grained PAT at https://github.com/settings/personal-access-tokens/new"
-            echo "     Resource owner: vivekchand"
-            echo "     Repos: clawmetry, clawmetry-cloud, clawmetry-landing"
-            echo "     Permission: Administration -- read+write"
-            echo "  2. Add it as a repo secret: Settings > Secrets > Actions > New secret"
-            echo "     Name: E2E_ADMIN_PAT"
-            echo "  This workflow will close C6 automatically the next morning at 10:15am UTC."
+            echo "ACTION REQUIRED: Add E2E_ADMIN_PAT to close C6 (vivekchand/clawmetry#2146)."
+            echo ""
+            echo "Step 1: Create a fine-grained PAT"
+            echo "  https://github.com/settings/personal-access-tokens/new"
+            echo "  Resource owner: vivekchand"
+            echo "  Repos: clawmetry, clawmetry-cloud, clawmetry-landing"
+            echo "  Permission: Administration -- read+write"
+            echo ""
+            echo "Step 2A (automatic) -- store as repo secret:"
+            echo "  Settings > Secrets > Actions > New secret"
+            echo "  Name: E2E_ADMIN_PAT"
+            echo "  This workflow closes C6 automatically the next morning at 10:15am UTC."
+            echo ""
+            echo "Step 2B (immediate) -- apply right now:"
+            echo "  Actions > 'Apply required E2E status checks (C6 -- one-shot)'"
+            echo "  confirm=APPLY, pat_token=<paste PAT>"
             echo ""
             echo "  Tracking: https://github.com/vivekchand/clawmetry/issues/2146"
+            exit 1
           else
             echo "has_pat=true" >> "$GITHUB_OUTPUT"
             echo "E2E_ADMIN_PAT found -- applying required E2E status checks."


### PR DESCRIPTION
## Summary

`c6-schedule-heal.yml` previously exited 0 (success) when `E2E_ADMIN_PAT`
was not set. This produced a **green badge** every day, hiding the fact that
C6 (required-status-checks) was never being applied. The silent success made
it easy to miss that action was needed.

This PR changes the no-PAT path to:
1. Emit a `::error::` GitHub Actions annotation (visible in the check summary)
2. Exit 1, turning the daily `c6-schedule-heal` badge **red** until the secret is added

## What changes

`.github/workflows/c6-schedule-heal.yml` -- no-PAT branch now exits 1 with
a structured error message pointing to the exact steps needed to close C6.

## How to close C6 (one-time, ~3 minutes)

**Option A (fastest, uses existing gh session):**
```bash
bash scripts/close-c6.sh
```

**Option B (browser, no terminal):**
1. Create fine-grained PAT at https://github.com/settings/personal-access-tokens/new
   - Resource owner: `vivekchand`
   - Repos: `clawmetry`, `clawmetry-cloud`, `clawmetry-landing`
   - Permission: Administration read+write
2. Actions > "Apply required E2E status checks (C6 -- one-shot)" > `confirm=APPLY`, paste PAT

**Option C (set-and-forget):** Add `E2E_ADMIN_PAT` repo secret with the PAT above.
`c6-schedule-heal.yml` closes C6 at 10:15 UTC each day once the secret is present.

## Context

6/7 criteria have been GREEN for 42+ days. C6 is the only remaining blocker.
Once C6 is done, all 7 criteria are green and the 7-day stop-condition
countdown begins, after which the cron can be disabled.

Tracking: vivekchand/clawmetry#2146

---
_Generated by [Claude Code](https://claude.ai/code/session_01KUWCwUh87D9fg3eJUvFZDy)_