### PR TITLE
fix: show per-cron model in list view and pre-fill edit form

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -10235,7 +10235,7 @@ function renderCronList(jobs) {
       html += '</span>';
     }
     html += '</div>';
-    html += '<div class="cron-schedule">' + formatSchedule(j.schedule) + '</div>';
+    html += '<div class="cron-schedule">' + formatSchedule(j.schedule) + (j.model ? ' &middot; <span style="font-size:11px;opacity:.75;" title="Per-job agent-turn model">' + escHtml(j.model) + '</span>' : '') + '</div>';
     html += '<div class="cron-meta">';
     if (j.state && j.state.lastRunAtMs) html += 'Last: ' + timeAgo(j.state.lastRunAtMs);
     // Prefer the agent's reported next-run time; fall back to a client-side
@@ -10825,7 +10825,7 @@ function cronEdit(jobId) {
   }
   document.getElementById('cron-edit-prompt').value = (job.payload && (job.payload.text || job.payload.message || job.payload.prompt)) || (job.config && job.config.prompt) || '';
   document.getElementById('cron-edit-channel').value = (job.payload && job.payload.channel) || (job.config && job.config.channel) || '';
-  document.getElementById('cron-edit-model').value = (job.payload && job.payload.model) || (job.config && job.config.model) || '';
+  document.getElementById('cron-edit-model').value = (job.payload && job.payload.model) || (job.config && job.config.model) || job.model || '';
   document.getElementById('cron-edit-enabled').checked = job.enabled !== false;
   var modal = document.getElementById('cron-edit-modal');
   modal.style.display = 'flex';


### PR DESCRIPTION
Closes #3697

## What

Two-line JS fix to surface the per-job agent-turn model that `/api/crons` already returns but the UI never showed:

- **`renderCronList`**: appends the model name (muted, smaller text) after the schedule expression when `j.model` is present
- **`cronEdit`**: adds `|| job.model` as a fallback in the model input pre-fill — it was reading `job.payload.model || job.config.model` but the API sends it as a top-level `job.model` key

## Why the data was already there

Both code paths in `routes/crons.py` already carry the model through:
- Gateway path: `_with_costs()` preserves all top-level fields via `j2 = dict(job)`
- Local-store path: `_row_to_cron_job` L193 carries extras (including `model`) through `job.setdefault(k, v)`

## Test plan

- Open the Crons tab with a job that has a configured model → model name appears alongside the schedule (e.g. `Every 5min · claude-haiku-4-5`)
- Click Edit on that job → model input pre-fills correctly instead of being blank
- Jobs without a model → no change in appearance

---
_Generated by [Claude Code](https://claude.ai/code/session_014jprhWpzv29HasB4nWepVW)_