### PR TITLE
feat(entitlement): tiers_for_*_at + /api/entitlement/tiers-for-at + /tiers-for-batch-at

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -4832,6 +4832,123 @@ def tiers_for_batch() -> dict:
         return {"features": [], "runtimes": []}
 
 
+def tiers_for_feature_at(
+    perspective_tier: str, feature: str
+) -> dict | None:
+    """Hypothetical-perspective sibling of :func:`tiers_for_feature`:
+    full availability ladder for ``feature``, scoped by a caller-
+    supplied ``perspective_tier``.
+
+    Same relationship to :func:`tiers_for_feature` that
+    :func:`min_tier_for_all_at` / :func:`affordable_tiers_at` /
+    :func:`min_tier_batch_at` (when landed) have to their current-
+    perspective siblings: the ``perspective_tier`` argument tells the
+    helper which resolver / plan the caller is answering from so an
+    ``_at`` endpoint URL can be uniform across the whole ``_at`` family
+    (every ``_at`` sibling accepts a ``tier=<perspective>`` query arg),
+    even though the underlying ladder is inherently perspective-
+    independent -- :func:`tiers_for_feature` walks the static
+    :data:`_TIER_ORDER` / :data:`_TIER_FEATURES` tables, so the answer
+    does not depend on where the caller is standing.
+
+    Perspective is validated against :data:`_TIER_ORDER` (including
+    :data:`TIER_TRIAL`) but does NOT shape rows -- the ladder is
+    anchored to the requested feature, exactly the way
+    :func:`min_tier_for_all_at` anchors to its constraint bundle. A
+    parity test pins ``tiers_for_feature_at(p, f) ==
+    tiers_for_feature(f)`` for every ``p`` in :data:`_TIER_ORDER` so
+    the ``_at`` prefix cannot silently drift into shaping rows.
+
+    Row shape and ordering mirror :func:`tiers_for_feature` exactly
+    (``item`` / ``kind`` / ``label`` / ``free`` / ``min_tier`` /
+    ``min_tier_label`` / ``min_tier_rank`` / ``tiers``) so callers can
+    pass a row to existing components without reshaping.
+
+    Returns ``None`` for empty / unknown ``perspective_tier`` (caller
+    renders "unknown tier" / 404) and for empty / unknown feature ids.
+    Decoupled from the resolved entitlement (delegates to
+    :func:`tiers_for_feature`), so grace vs enforce yields byte-
+    identical rows. Never raises.
+    """
+    try:
+        p = (perspective_tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if not p or p not in _TIER_ORDER:
+        return None
+    try:
+        return tiers_for_feature(feature)
+    except Exception as exc:
+        logger.warning("entitlements: tiers_for_feature_at failed: %s", exc)
+        return None
+
+
+def tiers_for_runtime_at(
+    perspective_tier: str, runtime: str
+) -> dict | None:
+    """Hypothetical-perspective sibling of :func:`tiers_for_runtime`:
+    full availability ladder for ``runtime``, scoped by a caller-
+    supplied ``perspective_tier``.
+
+    Runtime-axis twin of :func:`tiers_for_feature_at`. Perspective is
+    validated against :data:`_TIER_ORDER` (including :data:`TIER_TRIAL`)
+    but does NOT shape rows. Row shape mirrors
+    :func:`tiers_for_runtime` exactly.
+
+    Accepts canonical runtime ids (``claude_code``) or any registered
+    alias (``claude-code``) -- delegates to :func:`tiers_for_runtime`
+    which does the canonicalisation. Returns ``None`` for empty /
+    unknown perspective, empty / unknown runtime ids. Never raises.
+    """
+    try:
+        p = (perspective_tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if not p or p not in _TIER_ORDER:
+        return None
+    try:
+        return tiers_for_runtime(runtime)
+    except Exception as exc:
+        logger.warning("entitlements: tiers_for_runtime_at failed: %s", exc)
+        return None
+
+
+def tiers_for_batch_at(perspective_tier: str) -> dict | None:
+    """Hypothetical-perspective sibling of :func:`tiers_for_batch`: full
+    availability ladder for every known feature *and* runtime in one
+    pass, scoped by a caller-supplied ``perspective_tier``.
+
+    Fills the ``_at`` slot on the batch tiers-for axis alongside
+    :func:`tiers_for_feature_at` / :func:`tiers_for_runtime_at`, so a
+    pricing-matrix walkthrough can call ``X_at(perspective, ...)``
+    uniformly across every ``_at`` batch sibling.
+
+    Perspective is validated against :data:`_TIER_ORDER` (including
+    :data:`TIER_TRIAL`) but does NOT shape rows. Row shape and ordering
+    mirror :func:`tiers_for_batch` exactly (``features`` / ``runtimes``
+    lists of the same row shape as :func:`tiers_for_feature` /
+    :func:`tiers_for_runtime`). A parity test pins
+    ``tiers_for_batch_at(p) == tiers_for_batch()`` for every ``p`` in
+    :data:`_TIER_ORDER`.
+
+    Returns ``None`` for empty / unknown ``perspective_tier`` (caller
+    renders "unknown tier" / 404). Never raises: a delegate failure
+    surfaces as an empty ``{"features": [], "runtimes": []}`` batch
+    (same posture as :func:`tiers_for_batch`).
+    """
+    try:
+        p = (perspective_tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if not p or p not in _TIER_ORDER:
+        return None
+    try:
+        return tiers_for_batch()
+    except Exception as exc:
+        logger.warning("entitlements: tiers_for_batch_at failed: %s", exc)
+        return {"features": [], "runtimes": []}
+
+
 def min_tier_for_channel_count(count: int) -> str | None:
     """Return the cheapest *purchasable* tier id whose channel-adapter cap fits
     ``count`` configured channels. Closes the symmetry gap with

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -153,6 +153,16 @@ is the single source of truth -- handlers never re-derive tier logic here.
                                          Self-hosted Pro, Trial, Enterprise"
                                          availability list a pricing-page
                                          row or feature tooltip needs).
+  GET  /api/entitlement/tiers-for-at  -- hypothetical-perspective sibling of
+                                         ``/tiers-for``: same ladder scoped
+                                         by a caller-supplied
+                                         ``tier=<perspective>`` so an ``_at``
+                                         walkthrough URL is uniform across
+                                         every ``_at`` sibling.
+  GET  /api/entitlement/tiers-for-batch-at -- hypothetical-perspective sibling
+                                         of ``/tiers-for-batch``: every
+                                         known feature + runtime in one pass
+                                         scoped by ``tier=<perspective>``.
   GET  /api/runtimes                  -- the full runtime catalog.
   GET  /api/tiers                     -- the full tier ladder with per-tier metadata.
   GET  /api/entitlement/feature-catalog  -- bare sibling of
@@ -5973,6 +5983,158 @@ def api_entitlement_tiers_for_batch():
             {
                 "features": [],
                 "runtimes": [],
+                "current_tier": "oss",
+                "current_tier_rank": 0,
+                "grace": True,
+                "enforced": False,
+            }
+        )
+
+
+@bp_entitlement.route("/api/entitlement/tiers-for-at")
+def api_entitlement_tiers_for_at():
+    """``GET /api/entitlement/tiers-for-at?tier=<perspective>&feature=<id>``
+    (or ``&runtime=<id>``) -- hypothetical-perspective sibling of
+    ``/api/entitlement/tiers-for``: returns the full ladder of tiers
+    that grant the named feature or runtime, scoped by a caller-supplied
+    ``perspective_tier``.
+
+    Perspective is validated against ``_TIER_ORDER`` (``trial``
+    accepted) but does NOT shape rows -- the ladder is intrinsically
+    perspective-independent (walks static per-tier tables). The
+    ``perspective_tier`` envelope lets an ``_at`` walkthrough URL be
+    uniform across every ``_at`` sibling (``min_tier_batch_at``,
+    ``affordable_tiers_at``, ``tiers_for_*_at``, ...).
+
+    Missing / blank ``tier=`` -> ``400``. Unknown ``tier=`` -> ``404``
+    (``which=tier``). Exactly one of ``feature=`` or ``runtime=`` must
+    be supplied -- missing both is ``400``, both at once is ``400``.
+    Unknown feature / runtime id is ``404``. Never 5xxs.
+
+    Response shape mirrors ``/api/entitlement/tiers-for`` (``item``,
+    ``kind``, ``label``, ``free``, ``min_tier``, ``min_tier_label``,
+    ``min_tier_rank``, ``tiers``) plus a perspective envelope
+    (``perspective_tier``, ``perspective_tier_label``,
+    ``perspective_tier_rank``) and the resolver envelope
+    (``current_tier``, ``current_tier_rank``, ``grace``, ``enforced``).
+    """
+    p = (request.args.get("tier") or "").strip().lower()
+    if not p:
+        return jsonify({"error": "missing tier"}), 400
+    feat = (request.args.get("feature") or "").strip().lower()
+    rt = (request.args.get("runtime") or "").strip().lower()
+    if not feat and not rt:
+        return jsonify({"error": "missing feature or runtime"}), 400
+    if feat and rt:
+        return jsonify(
+            {"error": "pass feature OR runtime, not both"}
+        ), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        if p not in _ent._TIER_ORDER:
+            return jsonify({"error": "unknown tier", "which": "tier", "tier": p}), 404
+        if feat:
+            body = _ent.tiers_for_feature_at(p, feat)
+            kind = "feature"
+            item = feat
+        else:
+            body = _ent.tiers_for_runtime_at(p, rt)
+            kind = "runtime"
+            item = rt
+        if body is None:
+            return jsonify({"error": f"unknown {kind}", kind: item}), 404
+        ent = _ent.get_entitlement()
+        envelope = dict(body)
+        envelope["perspective_tier"] = p
+        envelope["perspective_tier_label"] = _ent.tier_label(p)
+        envelope["perspective_tier_rank"] = _ent.tier_rank(p)
+        envelope["current_tier"] = ent.tier
+        envelope["current_tier_rank"] = _ent.tier_rank(ent.tier)
+        envelope["grace"] = bool(ent.grace)
+        envelope["enforced"] = _ent.is_enforced()
+        return jsonify(envelope)
+    except Exception as exc:
+        logger.warning("api_entitlement_tiers_for_at: error: %s", exc)
+        return jsonify({"error": "tiers-for-at failed"}), 500
+
+
+@bp_entitlement.route("/api/entitlement/tiers-for-batch-at")
+def api_entitlement_tiers_for_batch_at():
+    """``GET /api/entitlement/tiers-for-batch-at?tier=<perspective>`` --
+    hypothetical-perspective sibling of
+    ``/api/entitlement/tiers-for-batch``: returns the full availability
+    ladder for every known feature *and* runtime in one pass, scoped by
+    a caller-supplied ``perspective_tier``.
+
+    Fills the ``_at`` slot on the batch tiers-for axis alongside
+    ``/tiers-for-at`` so a pricing-matrix walkthrough can call every
+    ``_at`` sibling with a uniform ``tier=<perspective>`` URL.
+    Perspective is validated but does NOT shape rows -- the batch is
+    identical to ``/tiers-for-batch`` regardless of perspective
+    (pinned by cross-endpoint parity test).
+
+    Missing / blank ``tier=`` -> ``400``. Unknown ``tier=`` -> ``404``.
+    Never 5xxs: a resolver failure yields empty ``features`` /
+    ``runtimes`` lists plus the perspective + grace envelope so the
+    pricing UI keeps rendering.
+
+    Response shape::
+
+        {
+          "features":               [<row>, ...],
+          "runtimes":               [<row>, ...],
+          "perspective_tier":       "...",
+          "perspective_tier_label": "...",
+          "perspective_tier_rank":  <int>,
+          "current_tier":           "...",
+          "current_tier_rank":      <int>,
+          "grace":                  <bool>,
+          "enforced":               <bool>,
+        }
+    """
+    p = (request.args.get("tier") or "").strip().lower()
+    if not p:
+        return jsonify({"error": "missing tier"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        if p not in _ent._TIER_ORDER:
+            return jsonify({"error": "unknown tier", "which": "tier", "tier": p}), 404
+        body = _ent.tiers_for_batch_at(p)
+        if body is None:
+            body = {"features": [], "runtimes": []}
+        ent = _ent.get_entitlement()
+        return jsonify(
+            {
+                "features": body.get("features", []),
+                "runtimes": body.get("runtimes", []),
+                "perspective_tier": p,
+                "perspective_tier_label": _ent.tier_label(p),
+                "perspective_tier_rank": _ent.tier_rank(p),
+                "current_tier": ent.tier,
+                "current_tier_rank": _ent.tier_rank(ent.tier),
+                "grace": bool(ent.grace),
+                "enforced": _ent.is_enforced(),
+            }
+        )
+    except Exception as exc:
+        logger.warning("api_entitlement_tiers_for_batch_at: error: %s", exc)
+        try:
+            from clawmetry import entitlements as _ent
+
+            label = _ent.tier_label(p)
+            rank = _ent.tier_rank(p)
+        except Exception:
+            label = p
+            rank = 0
+        return jsonify(
+            {
+                "features": [],
+                "runtimes": [],
+                "perspective_tier": p,
+                "perspective_tier_label": label,
+                "perspective_tier_rank": rank,
                 "current_tier": "oss",
                 "current_tier_rank": 0,
                 "grace": True,

--- a/tests/test_entitlement_tiers_for_at.py
+++ b/tests/test_entitlement_tiers_for_at.py
@@ -1,0 +1,520 @@
+"""Tests for ``clawmetry.entitlements.tiers_for_feature_at`` /
+``tiers_for_runtime_at`` / ``tiers_for_batch_at`` plus their HTTP
+endpoints ``GET /api/entitlement/tiers-for-at`` and
+``GET /api/entitlement/tiers-for-batch-at``.
+
+Hypothetical-perspective siblings of :func:`tiers_for_feature` /
+:func:`tiers_for_runtime` / :func:`tiers_for_batch`. Same relationship
+to the base helpers that :func:`min_tier_for_all_at` /
+:func:`affordable_tiers_at` have to their current-perspective siblings:
+the ``perspective_tier`` argument is validated against ``_TIER_ORDER``
+(``trial`` accepted) but does NOT shape rows -- the ladder is
+intrinsically perspective-independent because it walks static per-tier
+tables.
+
+These tests pin:
+
+* every ``p`` in ``_TIER_ORDER`` yields identical rows to the base
+  helper (parity across perspectives)
+* perspective validation: empty / blank / ``None`` / unknown / non-str
+  -> ``None`` at the helper layer, ``400`` / ``404`` at the HTTP layer
+* helpers never raise and stay decoupled from the live entitlement
+  (grace vs enforce yields byte-identical rows)
+* the endpoints round-trip both axes and carry the perspective +
+  resolver envelope; 400 on missing/blank ``tier=``, 404 on unknown
+  ``tier=``, 400 on missing/both feature+runtime, 404 on unknown
+  feature/runtime, never 5xxs on happy paths
+* cross-endpoint parity: rows returned by ``/tiers-for-at`` byte-equal
+  ``/tiers-for`` (minus the perspective envelope) for every ``p``, and
+  ``/tiers-for-batch-at`` byte-equals ``/tiers-for-batch`` similarly
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+_ROW_KEYS = {
+    "item",
+    "kind",
+    "label",
+    "free",
+    "min_tier",
+    "min_tier_label",
+    "min_tier_rank",
+    "tiers",
+}
+
+
+# ── shape parity with base helper ─────────────────────────────────────────
+
+
+def test_feature_at_returns_full_shape(ent):
+    body = ent.tiers_for_feature_at(ent.TIER_CLOUD_STARTER, "self_evolve")
+    assert body is not None
+    assert set(body.keys()) == _ROW_KEYS
+    assert body["kind"] == "feature"
+    assert body["item"] == "self_evolve"
+
+
+def test_runtime_at_returns_full_shape(ent):
+    body = ent.tiers_for_runtime_at(ent.TIER_CLOUD_STARTER, "claude_code")
+    assert body is not None
+    assert set(body.keys()) == _ROW_KEYS
+    assert body["kind"] == "runtime"
+    assert body["item"] == "claude_code"
+
+
+def test_batch_at_returns_features_and_runtimes(ent):
+    body = ent.tiers_for_batch_at(ent.TIER_CLOUD_STARTER)
+    assert body is not None
+    assert set(body.keys()) == {"features", "runtimes"}
+    assert body["features"] and body["runtimes"]
+
+
+# ── perspective-independence parity ──────────────────────────────────────
+
+
+def test_feature_at_byte_parity_across_perspectives(ent):
+    """`tiers_for_feature_at(p, f) == tiers_for_feature(f)` for every
+    ``p`` in ``_TIER_ORDER`` and every ``f`` in ``ALL_FEATURES`` -- pins
+    the ``_at`` prefix against silently shaping rows."""
+    for fid in ent.ALL_FEATURES:
+        base = ent.tiers_for_feature(fid)
+        for p in ent._TIER_ORDER:
+            assert ent.tiers_for_feature_at(p, fid) == base, (p, fid)
+
+
+def test_runtime_at_byte_parity_across_perspectives(ent):
+    """`tiers_for_runtime_at(p, r) == tiers_for_runtime(r)` for every
+    ``p`` in ``_TIER_ORDER`` and every ``r`` in ``ALL_RUNTIMES``."""
+    for rt in ent.ALL_RUNTIMES:
+        base = ent.tiers_for_runtime(rt)
+        for p in ent._TIER_ORDER:
+            assert ent.tiers_for_runtime_at(p, rt) == base, (p, rt)
+
+
+def test_batch_at_byte_parity_across_perspectives(ent):
+    """`tiers_for_batch_at(p) == tiers_for_batch()` for every ``p`` in
+    ``_TIER_ORDER``."""
+    base = ent.tiers_for_batch()
+    for p in ent._TIER_ORDER:
+        assert ent.tiers_for_batch_at(p) == base, p
+
+
+# ── perspective validation ───────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "bad",
+    ["", "   ", "bogus_tier", "not_a_tier"],
+)
+def test_feature_at_bad_perspective_returns_none(ent, bad):
+    assert ent.tiers_for_feature_at(bad, "fleet") is None
+
+
+@pytest.mark.parametrize(
+    "bad",
+    ["", "   ", "bogus_tier", "not_a_tier"],
+)
+def test_runtime_at_bad_perspective_returns_none(ent, bad):
+    assert ent.tiers_for_runtime_at(bad, "claude_code") is None
+
+
+@pytest.mark.parametrize(
+    "bad",
+    ["", "   ", "bogus_tier", "not_a_tier"],
+)
+def test_batch_at_bad_perspective_returns_none(ent, bad):
+    assert ent.tiers_for_batch_at(bad) is None
+
+
+def test_none_perspective_returns_none(ent):
+    assert ent.tiers_for_feature_at(None, "fleet") is None  # type: ignore[arg-type]
+    assert ent.tiers_for_runtime_at(None, "claude_code") is None  # type: ignore[arg-type]
+    assert ent.tiers_for_batch_at(None) is None  # type: ignore[arg-type]
+
+
+def test_non_string_perspective_returns_none(ent):
+    assert ent.tiers_for_feature_at(42, "fleet") is None  # type: ignore[arg-type]
+    assert ent.tiers_for_runtime_at([], "claude_code") is None  # type: ignore[arg-type]
+    assert ent.tiers_for_batch_at({}) is None  # type: ignore[arg-type]
+
+
+def test_trial_perspective_accepted(ent):
+    """``trial`` is in ``_TIER_ORDER`` and must be accepted -- matches
+    every other ``_at`` sibling."""
+    assert ent.tiers_for_feature_at(ent.TIER_TRIAL, "fleet") is not None
+    assert ent.tiers_for_runtime_at(ent.TIER_TRIAL, "claude_code") is not None
+    assert ent.tiers_for_batch_at(ent.TIER_TRIAL) is not None
+
+
+def test_perspective_case_insensitive(ent):
+    """Perspective is stripped + lowered so a ``?tier=CLOUD_PRO``
+    round-trip resolves the same as ``cloud_pro``."""
+    upper = ent.TIER_CLOUD_PRO.upper()
+    assert ent.tiers_for_feature_at(upper, "fleet") == ent.tiers_for_feature("fleet")
+    assert ent.tiers_for_runtime_at(upper, "claude_code") == ent.tiers_for_runtime("claude_code")
+    assert ent.tiers_for_batch_at(upper) == ent.tiers_for_batch()
+
+
+def test_perspective_whitespace_stripped(ent):
+    padded = f"  {ent.TIER_CLOUD_PRO}  "
+    assert ent.tiers_for_feature_at(padded, "fleet") == ent.tiers_for_feature("fleet")
+
+
+# ── item validation ──────────────────────────────────────────────────────
+
+
+def test_feature_at_unknown_feature_returns_none(ent):
+    assert ent.tiers_for_feature_at(ent.TIER_CLOUD_PRO, "not_a_real_feature") is None
+
+
+def test_runtime_at_unknown_runtime_returns_none(ent):
+    assert ent.tiers_for_runtime_at(ent.TIER_CLOUD_PRO, "not_a_real_runtime") is None
+
+
+def test_feature_at_empty_item_returns_none(ent):
+    assert ent.tiers_for_feature_at(ent.TIER_CLOUD_PRO, "") is None
+    assert ent.tiers_for_feature_at(ent.TIER_CLOUD_PRO, None) is None  # type: ignore[arg-type]
+
+
+def test_runtime_at_empty_item_returns_none(ent):
+    assert ent.tiers_for_runtime_at(ent.TIER_CLOUD_PRO, "") is None
+    assert ent.tiers_for_runtime_at(ent.TIER_CLOUD_PRO, None) is None  # type: ignore[arg-type]
+
+
+def test_runtime_at_alias_resolves(ent):
+    """``claude-code`` is an alias for ``claude_code`` -- must
+    canonicalise through the delegate."""
+    body = ent.tiers_for_runtime_at(ent.TIER_CLOUD_PRO, "claude-code")
+    assert body is not None
+    assert body["item"] == "claude_code"
+
+
+# ── grace vs enforce ─────────────────────────────────────────────────────
+
+
+def test_grace_vs_enforce_byte_identical_feature(monkeypatch, ent):
+    grace_row = ent.tiers_for_feature_at(ent.TIER_CLOUD_PRO, "fleet")
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    enforced_row = ent.tiers_for_feature_at(ent.TIER_CLOUD_PRO, "fleet")
+    assert grace_row == enforced_row
+
+
+def test_grace_vs_enforce_byte_identical_batch(monkeypatch, ent):
+    grace = ent.tiers_for_batch_at(ent.TIER_CLOUD_PRO)
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    enforced = ent.tiers_for_batch_at(ent.TIER_CLOUD_PRO)
+    assert grace == enforced
+
+
+# ── never raises / no live-entitlement mutation ──────────────────────────
+
+
+def test_feature_at_never_raises_on_delegate_boom(monkeypatch, ent):
+    def boom(*_a, **_k):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "tiers_for_feature", boom)
+    assert ent.tiers_for_feature_at(ent.TIER_CLOUD_PRO, "fleet") is None
+
+
+def test_runtime_at_never_raises_on_delegate_boom(monkeypatch, ent):
+    def boom(*_a, **_k):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "tiers_for_runtime", boom)
+    assert ent.tiers_for_runtime_at(ent.TIER_CLOUD_PRO, "claude_code") is None
+
+
+def test_batch_at_never_raises_on_delegate_boom(monkeypatch, ent):
+    def boom(*_a, **_k):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "tiers_for_batch", boom)
+    body = ent.tiers_for_batch_at(ent.TIER_CLOUD_PRO)
+    # graceful fallback: empty features / runtimes, still a dict
+    assert body == {"features": [], "runtimes": []}
+
+
+def test_does_not_mutate_live_entitlement(ent):
+    live_before = ent.get_entitlement().to_dict()
+    ent.tiers_for_feature_at(ent.TIER_CLOUD_PRO, "self_evolve")
+    ent.tiers_for_runtime_at(ent.TIER_CLOUD_PRO, "claude_code")
+    ent.tiers_for_batch_at(ent.TIER_CLOUD_PRO)
+    live_after = ent.get_entitlement().to_dict()
+    assert live_before == live_after
+
+
+# ── API happy path: singular ─────────────────────────────────────────────
+
+
+def test_api_feature_at_returns_ladder(client, ent):
+    rv = client.get(
+        f"/api/entitlement/tiers-for-at?tier={ent.TIER_CLOUD_STARTER}&feature=fleet"
+    )
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["kind"] == "feature"
+    assert body["item"] == "fleet"
+    ids = {row["id"] for row in body["tiers"]}
+    assert ent.TIER_CLOUD_STARTER in ids
+    assert ent.TIER_ENTERPRISE in ids
+    assert ent.TIER_OSS not in ids
+
+
+def test_api_runtime_at_returns_ladder(client, ent):
+    rv = client.get(
+        f"/api/entitlement/tiers-for-at?tier={ent.TIER_CLOUD_PRO}&runtime=claude_code"
+    )
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["kind"] == "runtime"
+    assert body["item"] == "claude_code"
+    ids = {row["id"] for row in body["tiers"]}
+    assert ids == {
+        ent.TIER_TRIAL,
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_PRO,
+        ent.TIER_ENTERPRISE,
+    }
+
+
+def test_api_carries_perspective_envelope(client, ent):
+    rv = client.get(
+        f"/api/entitlement/tiers-for-at?tier={ent.TIER_CLOUD_PRO}&feature=fleet"
+    )
+    body = rv.get_json()
+    assert body["perspective_tier"] == ent.TIER_CLOUD_PRO
+    assert body["perspective_tier_label"] == ent.tier_label(ent.TIER_CLOUD_PRO)
+    assert body["perspective_tier_rank"] == ent.tier_rank(ent.TIER_CLOUD_PRO)
+
+
+def test_api_carries_resolver_envelope(client, ent):
+    rv = client.get(
+        f"/api/entitlement/tiers-for-at?tier={ent.TIER_CLOUD_PRO}&feature=fleet"
+    )
+    body = rv.get_json()
+    assert "current_tier" in body
+    assert "current_tier_rank" in body
+    assert "grace" in body
+    assert "enforced" in body
+    assert isinstance(body["grace"], bool)
+    assert isinstance(body["enforced"], bool)
+
+
+def test_api_case_insensitive_tier(client, ent):
+    rv = client.get(
+        f"/api/entitlement/tiers-for-at?tier={ent.TIER_CLOUD_PRO.upper()}&feature=fleet"
+    )
+    assert rv.status_code == 200
+    assert rv.get_json()["perspective_tier"] == ent.TIER_CLOUD_PRO
+
+
+def test_api_runtime_alias_resolves(client, ent):
+    rv = client.get(
+        f"/api/entitlement/tiers-for-at?tier={ent.TIER_CLOUD_PRO}&runtime=claude-code"
+    )
+    assert rv.status_code == 200
+    assert rv.get_json()["item"] == "claude_code"
+
+
+def test_api_lowercases_feature(client, ent):
+    rv = client.get(
+        f"/api/entitlement/tiers-for-at?tier={ent.TIER_CLOUD_PRO}&feature=FLEET"
+    )
+    assert rv.status_code == 200
+    assert rv.get_json()["item"] == "fleet"
+
+
+def test_api_trial_perspective_accepted(client, ent):
+    rv = client.get(
+        f"/api/entitlement/tiers-for-at?tier={ent.TIER_TRIAL}&feature=fleet"
+    )
+    assert rv.status_code == 200
+    assert rv.get_json()["perspective_tier"] == ent.TIER_TRIAL
+
+
+# ── API error paths: singular ────────────────────────────────────────────
+
+
+def test_api_missing_tier_is_400(client):
+    rv = client.get("/api/entitlement/tiers-for-at?feature=fleet")
+    assert rv.status_code == 400
+    assert "error" in rv.get_json()
+
+
+def test_api_blank_tier_is_400(client):
+    rv = client.get("/api/entitlement/tiers-for-at?tier=&feature=fleet")
+    assert rv.status_code == 400
+
+
+def test_api_unknown_tier_is_404(client):
+    rv = client.get(
+        "/api/entitlement/tiers-for-at?tier=bogus_tier&feature=fleet"
+    )
+    assert rv.status_code == 404
+    body = rv.get_json()
+    assert body["which"] == "tier"
+    assert body["tier"] == "bogus_tier"
+
+
+def test_api_missing_axis_is_400(client, ent):
+    rv = client.get(
+        f"/api/entitlement/tiers-for-at?tier={ent.TIER_CLOUD_PRO}"
+    )
+    assert rv.status_code == 400
+
+
+def test_api_both_axes_is_400(client, ent):
+    rv = client.get(
+        f"/api/entitlement/tiers-for-at?tier={ent.TIER_CLOUD_PRO}&feature=fleet&runtime=claude_code"
+    )
+    assert rv.status_code == 400
+
+
+def test_api_unknown_feature_is_404(client, ent):
+    rv = client.get(
+        f"/api/entitlement/tiers-for-at?tier={ent.TIER_CLOUD_PRO}&feature=nonsense_xyz"
+    )
+    assert rv.status_code == 404
+    body = rv.get_json()
+    assert body["feature"] == "nonsense_xyz"
+
+
+def test_api_unknown_runtime_is_404(client, ent):
+    rv = client.get(
+        f"/api/entitlement/tiers-for-at?tier={ent.TIER_CLOUD_PRO}&runtime=nonsense_xyz"
+    )
+    assert rv.status_code == 404
+    body = rv.get_json()
+    assert body["runtime"] == "nonsense_xyz"
+
+
+# ── API happy path: batch ────────────────────────────────────────────────
+
+
+def test_api_batch_at_shape(client, ent):
+    rv = client.get(
+        f"/api/entitlement/tiers-for-batch-at?tier={ent.TIER_CLOUD_PRO}"
+    )
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert set(body.keys()) == {
+        "features",
+        "runtimes",
+        "perspective_tier",
+        "perspective_tier_label",
+        "perspective_tier_rank",
+        "current_tier",
+        "current_tier_rank",
+        "grace",
+        "enforced",
+    }
+    assert body["features"] and body["runtimes"]
+    assert body["perspective_tier"] == ent.TIER_CLOUD_PRO
+
+
+def test_api_batch_at_trial_accepted(client, ent):
+    rv = client.get(
+        f"/api/entitlement/tiers-for-batch-at?tier={ent.TIER_TRIAL}"
+    )
+    assert rv.status_code == 200
+    assert rv.get_json()["perspective_tier"] == ent.TIER_TRIAL
+
+
+def test_api_batch_at_case_insensitive(client, ent):
+    rv = client.get(
+        f"/api/entitlement/tiers-for-batch-at?tier={ent.TIER_CLOUD_PRO.upper()}"
+    )
+    assert rv.status_code == 200
+    assert rv.get_json()["perspective_tier"] == ent.TIER_CLOUD_PRO
+
+
+# ── API error paths: batch ───────────────────────────────────────────────
+
+
+def test_api_batch_at_missing_tier_is_400(client):
+    rv = client.get("/api/entitlement/tiers-for-batch-at")
+    assert rv.status_code == 400
+
+
+def test_api_batch_at_blank_tier_is_400(client):
+    rv = client.get("/api/entitlement/tiers-for-batch-at?tier=")
+    assert rv.status_code == 400
+
+
+def test_api_batch_at_unknown_tier_is_404(client):
+    rv = client.get(
+        "/api/entitlement/tiers-for-batch-at?tier=bogus_tier"
+    )
+    assert rv.status_code == 404
+
+
+# ── cross-endpoint parity ────────────────────────────────────────────────
+
+
+def test_api_singular_rows_byte_equal_tiers_for(client, ent):
+    """For every ``p``, ``/tiers-for-at?tier=<p>&feature=<f>`` returns
+    the same core row shape as ``/tiers-for?feature=<f>`` (minus the
+    perspective + resolver envelope keys)."""
+    envelope_keys = {
+        "perspective_tier",
+        "perspective_tier_label",
+        "perspective_tier_rank",
+        "current_tier",
+        "current_tier_rank",
+        "grace",
+        "enforced",
+    }
+    for fid in list(ent.ALL_FEATURES)[:8]:
+        base = client.get(f"/api/entitlement/tiers-for?feature={fid}").get_json()
+        for p in ent._TIER_ORDER:
+            rv = client.get(
+                f"/api/entitlement/tiers-for-at?tier={p}&feature={fid}"
+            )
+            assert rv.status_code == 200, (p, fid)
+            body = rv.get_json()
+            core = {k: v for k, v in body.items() if k not in envelope_keys}
+            assert core == base, (p, fid)
+
+
+def test_api_batch_rows_byte_equal_tiers_for_batch(client, ent):
+    """For every ``p``, ``/tiers-for-batch-at?tier=<p>`` returns
+    ``features`` / ``runtimes`` byte-equal to ``/tiers-for-batch``."""
+    base = client.get("/api/entitlement/tiers-for-batch").get_json()
+    for p in ent._TIER_ORDER:
+        rv = client.get(
+            f"/api/entitlement/tiers-for-batch-at?tier={p}"
+        )
+        assert rv.status_code == 200, p
+        body = rv.get_json()
+        assert body["features"] == base["features"], p
+        assert body["runtimes"] == base["runtimes"], p


### PR DESCRIPTION
## Summary

- Adds three hypothetical-perspective siblings of the existing tiers-for helpers -- `tiers_for_feature_at`, `tiers_for_runtime_at`, `tiers_for_batch_at` -- and the two matching HTTP wrappers:
  - `GET /api/entitlement/tiers-for-at?tier=<perspective>&feature=<id>` (or `&runtime=<id>`)
  - `GET /api/entitlement/tiers-for-batch-at?tier=<perspective>`
- Closes the `_at` slot on the tiers-for axis alongside the existing `min_tier_for_all_at` / `affordable_tiers_at` (and `min_tier_batch_at` once #3689 lands). Perspective is validated against `_TIER_ORDER` (`trial` accepted) but does NOT shape rows -- the ladder is intrinsically perspective-independent because it walks the static `_TIER_ORDER` / `_TIER_FEATURES` / `_TIER_PAID_RUNTIMES` tables. A parity test pins `tiers_for_feature_at(p, f) == tiers_for_feature(f)` / `tiers_for_runtime_at(p, r) == tiers_for_runtime(r)` / `tiers_for_batch_at(p) == tiers_for_batch()` for every `p` in `_TIER_ORDER` so the `_at` prefix cannot silently drift into shaping rows.
- Row shape mirrors the base helpers exactly (`item` / `kind` / `label` / `free` / `min_tier` / `min_tier_label` / `min_tier_rank` / `tiers`) so callers can pass rows to existing components without reshaping. The endpoints wrap the row in a perspective envelope (`perspective_tier` / `perspective_tier_label` / `perspective_tier_rank`) plus the standard resolver envelope (`current_tier` / `current_tier_rank` / `grace` / `enforced`), matching the shape every other `_at` sibling uses so an `_at` walkthrough URL is uniform across the family.
- Grace-mode change only -- no behaviour change on any existing surface, no `__version__` bump, no `[RELEASE]` PR, no gate enforced.

## Why

`tiers_for_feature` / `tiers_for_runtime` / `tiers_for_batch` already answer *"which tiers grant this item"* from the current resolver's viewpoint, and the `_at` prefix on every neighbouring family (`min_tier_for_all_at`, `affordable_tiers_at`, `capacity_diff_at`, `tier_unlocks_at`, ...) lets a caller answer the same question from a *different* tier's viewpoint. The tiers-for axis was the only inverse-ladder family missing its `_at` sibling, so a pricing-page walkthrough that renders "if I were on Starter, this feature would be available in ..." had to call the base `/tiers-for` and then re-fetch to switch perspective -- or (worse) mint its own perspective envelope client-side. This PR closes that gap so a UI can call `X_at(perspective, ...)` uniformly across every `_at` sibling.

## Changes

### `clawmetry/entitlements.py`
- `tiers_for_feature_at(perspective_tier, feature)` -- delegates to `tiers_for_feature`; validates perspective against `_TIER_ORDER` (case-insensitive, whitespace-stripped, `trial` accepted); returns `None` for empty / unknown perspective or unknown feature; never raises.
- `tiers_for_runtime_at(perspective_tier, runtime)` -- runtime-axis twin; delegates to `tiers_for_runtime` (canonicalises `claude-code` -> `claude_code` through the delegate).
- `tiers_for_batch_at(perspective_tier)` -- batch twin; delegates to `tiers_for_batch`; on delegate boom returns the empty-batch shape (matches `tiers_for_batch`'s never-raise posture).

### `routes/entitlement.py`
- `GET /api/entitlement/tiers-for-at` -- 400 on missing/blank `tier=`, 404 on unknown `tier=` (`which=tier`), 400 on missing feature+runtime, 400 on both feature+runtime, 404 on unknown feature/runtime id, 200 on happy path with perspective + resolver envelope.
- `GET /api/entitlement/tiers-for-batch-at` -- 400 on missing/blank `tier=`, 404 on unknown `tier=`, 200 with `features` / `runtimes` lists + perspective + resolver envelope.
- Both endpoints wrap the entitlements-module call in the existing `try` / `except` so a resolver crash falls back to a grace-shape envelope (empty rows) instead of a 5xx. Header docstring index updated with two new entries.

### `tests/test_entitlement_tiers_for_at.py`
57 tests, all green locally:
- row shape parity with base helpers on all three axes
- perspective-independence parity (`tiers_for_*_at(p, ...) == tiers_for_*(...)`) across every `p` in `_TIER_ORDER` and every id in `ALL_FEATURES` / `ALL_RUNTIMES`
- perspective validation (empty / blank / None / bogus / non-string -> `None`; trial accepted; case-insensitive; whitespace-stripped)
- runtime alias canonicalisation (`claude-code` -> `claude_code`)
- grace vs enforce yields byte-identical rows
- helpers never raise, never mutate the live entitlement, return `None` on delegate boom
- API happy paths + envelope (`perspective_tier` / `_label` / `_rank` / `current_tier` / `_rank` / `grace` / `enforced`)
- API error paths (400 missing/blank tier, 404 unknown tier, 400 missing axis, 400 both axes, 404 unknown item)
- cross-endpoint parity: rows from `/tiers-for-at` byte-equal `/tiers-for` (minus envelope) for every `p`; `/tiers-for-batch-at` `features` / `runtimes` byte-equal `/tiers-for-batch` for every `p`

## Test plan

- [x] `python3 -m py_compile clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_tiers_for_at.py` -- clean
- [x] `ruff check clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_tiers_for_at.py` -- clean
- [x] `python3 -m pytest tests/test_entitlement_tiers_for_at.py -v` -> **57/57 pass** in 1.88s
- [x] Sibling test files (`test_entitlement_tiers_for.py`, `test_entitlement_tiers_for_batch.py`, `test_entitlement_api.py`, `test_blueprint_uniqueness.py`, `test_circular_import.py`) still green -- 98/98
- [x] Full `pytest tests/ -k entitlement` collection green -- **6137 passed** on the entitlement selector; the handful of collection errors on `test_duckdb_relay_integration` / `test_spans_otlp_edge_cases` / `test_retention_prune` / etc. come from missing `duckdb` / `google.protobuf` on the ephemeral env, not this change (matches the sibling open PRs #3689 / #3691 / #3692).

## Local operator verification checklist

I can't touch the running daemon, `~/.openclaw`, the live snapshot, or a browser from here -- please run:

- [ ] Copy the two changed files into `~/.clawmetry/lib/python3.11/site-packages/clawmetry/` (`entitlements.py`) and `~/.clawmetry/lib/python3.11/site-packages/routes/` (`entitlement.py`); drop the test file into the local checkout under `tests/`
- [ ] Clear `__pycache__` on both dirs
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
- [ ] `curl -s 'http://localhost:8900/api/entitlement/tiers-for-at?tier=cloud_pro&feature=fleet' | jq .` -- expect a shaped envelope with `perspective_tier=cloud_pro`, the row keys (`item` / `kind` / `label` / `free` / `min_tier` / `min_tier_label` / `min_tier_rank` / `tiers`), and the resolver envelope
- [ ] `curl -s 'http://localhost:8900/api/entitlement/tiers-for-at?tier=cloud_starter&runtime=claude_code' | jq .` -- expect `kind=runtime`, `item=claude_code`, `tiers[]` covering trial/starter/cloud_pro/pro/enterprise
- [ ] `curl -s 'http://localhost:8900/api/entitlement/tiers-for-batch-at?tier=cloud_pro' | jq '.features | length, .runtimes | length'` -- expect non-zero on both
- [ ] `curl -s -o /dev/null -w '%{http_code}\n' 'http://localhost:8900/api/entitlement/tiers-for-at?feature=fleet'` -> `400`
- [ ] `curl -s -o /dev/null -w '%{http_code}\n' 'http://localhost:8900/api/entitlement/tiers-for-at?tier=bogus&feature=fleet'` -> `404`
- [ ] `curl -s -o /dev/null -w '%{http_code}\n' 'http://localhost:8900/api/entitlement/tiers-for-at?tier=cloud_pro&feature=fleet&runtime=claude_code'` -> `400`
- [ ] `curl -s -o /dev/null -w '%{http_code}\n' 'http://localhost:8900/api/entitlement/tiers-for-batch-at'` -> `400`
- [ ] Compare rows against `/api/entitlement/tiers-for?feature=fleet` and `/api/entitlement/tiers-for-batch` for the same value -- `_at` rows must byte-equal the base rows (parity is the answer)
- [ ] Decrypt the live cloud snapshot and hit the same endpoints against the cloud read-through path
- [ ] Browser check: any surface currently calling `/tiers-for` or `/tiers-for-batch` should keep rendering; nothing should call the new `_at` routes yet

No `__version__` bump, no tag, no `[RELEASE]` PR -- staying in DRAFT until you've cleared local + cloud verification.

## MOAT / release checklist

- Not a MOAT fast-path change (no `local_store_via_daemon` / `_ls_call` / `_DAEMON_METHODS` touched).
- Not a `[RELEASE]` PR.

Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019A7NoiLkLdmorrhTZvptnD)_