### PR TITLE
fix(sessions): capture runtime and thinking_level from model_change events

### DIFF
--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -3403,7 +3403,7 @@ def _local_ingest_sessions_batch(rows: list, node_id: str) -> None:
         meta_extras = {
             k: v for k, v in s.items()
             if k in ("channel", "chat_type", "subject", "recent_model",
-                     "session_key", "end_reason")
+                     "session_key", "end_reason", "runtime", "thinking_level")
             and v
         }
         store.ingest_session({
@@ -10656,6 +10656,8 @@ def sync_session_metadata(config: dict, state: dict = None) -> int:
                 # pick the dominant one as the primary.
                 model_tokens: dict = {}
                 last_seen_model = ""
+                last_seen_runtime = ""
+                last_seen_thinking_level = ""
                 # event_count (= JSONL line count) is the "messages" badge
                 # the Embodied tab renders. The cloud Postgres copy of the
                 # sessions table was previously plaintext-blank for this
@@ -10690,6 +10692,12 @@ def sync_session_metadata(config: dict, state: dict = None) -> int:
                         etype = ev.get("type", "")
                         if etype == "model_change" and ev.get("modelId"):
                             last_seen_model = ev["modelId"]
+                            _rt = ev.get("runtime") or ev.get("runtimeId")
+                            if _rt:
+                                last_seen_runtime = _rt
+                            _tl = ev.get("thinkingLevel") or ev.get("thinking_level")
+                            if _tl:
+                                last_seen_thinking_level = _tl
                         elif etype == "session":
                             if ev.get("label"):
                                 label = ev["label"]
@@ -10738,6 +10746,8 @@ def sync_session_metadata(config: dict, state: dict = None) -> int:
                         "end_reason": end_reason,
                         "model": model,
                         "recent_model": last_seen_model or model,
+                        "runtime": last_seen_runtime,
+                        "thinking_level": last_seen_thinking_level,
                         "total_tokens": total_tokens,
                         "total_cost": total_cost,
                         "started_at": started_at,

--- a/routes/sessions.py
+++ b/routes/sessions.py
@@ -501,6 +501,7 @@ def _try_local_store_sessions():
             "subject":        title or meta.get("subject", ""),
             "session_type":   meta.get("session_type", "main"),
             "runtime":        meta.get("runtime", ""),
+            "thinking_level": meta.get("thinking_level", ""),
             "_source":        "local_store",
         })
     # Decorate with channel context from the typed openclaw_channels table.


### PR DESCRIPTION
Closes #3695

## Summary

OpenClaw's `/model` dialog atomically selects `{model, runtime, thinking_level}` (Sol/Terra/Luna engine + thinking mode, per openclaw#98021), but `model_change` events were only being parsed for `modelId` — the `runtime` and `thinkingLevel` fields were silently dropped, making runtime/thinking attribution invisible in cost and usage analytics.

- Extract `runtime` and `thinkingLevel` from `model_change` events in `sync_session_metadata` (same scan that already tracks `last_seen_model`)
- Include `runtime` and `thinking_level` in the session batch row written to DuckDB via `_local_ingest_sessions_batch`
- Expose `thinking_level` in `/api/sessions` response (`runtime` was already returned)

## Test plan

- Session with a `model_change` event carrying `{"modelId": "...", "runtime": "Sol", "thinkingLevel": "high"}` → `/api/sessions` now returns `runtime: "Sol"` and `thinking_level: "high"` for that session
- Session with no runtime/thinking fields → both fields return `""` (no regression)
- `python3 -c "import ast; ast.parse(open('clawmetry/sync.py').read()); ast.parse(open('routes/sessions.py').read()); print('OK')"` passes

---
_Generated by [Claude Code](https://claude.ai/code/session_013kLHjiwmzhRcvLtgzdfpWf)_