### PR TITLE
fix: ingest NemoClaw advisor-session JSONL alongside main sessions

### DIFF
--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -2370,70 +2370,81 @@ def sync_sandbox_sessions_openshell(config: dict, state: dict) -> int:
         if not sb_name:
             continue
 
-        sessions_path = "/sandbox/.openclaw/agents/main/sessions"
-        try:
-            ls_out = subprocess.run(
-                [openshell_bin, "sandbox", "exec", "--name", sb_name, "--",
-                 "sh", "-c", f"ls {sessions_path}/ 2>/dev/null"],
-                capture_output=True, text=True, timeout=10,
-            )
-            if ls_out.returncode != 0:
-                continue
-            fnames = [
-                f.strip() for f in ls_out.stdout.splitlines()
-                if f.strip().endswith(".jsonl")
-                and ".trajectory." not in f
-                and ".checkpoint." not in f
-                and ".deleted." not in f
-            ]
-        except Exception as _le:
-            log.debug("sandbox-session sync: ls failed for %s: %s", sb_name, _le)
-            continue
-
-        for fname in fnames:
-            # Warmup sessions (nemoclaw-onboard-warmup-*) are harness
-            # onboarding artefacts — skip so they never reach DuckDB (#3366).
-            if fname.startswith("nemoclaw-onboard-warmup-"):
-                continue
-            cursor_key = f"{sb_name}/{fname}"
-            last_line = cursors.get(cursor_key, 0)
+        # Scan both main and advisor agent dirs (#3698).
+        # NemoClaw's advisor/analysis session runner (createAgentSession) writes
+        # to agents/advisor/sessions alongside the regular agents/main/sessions.
+        for _agent_dir in ("main", "advisor"):
+            _sessions_path = f"/sandbox/.openclaw/agents/{_agent_dir}/sessions"
             try:
-                cat_out = subprocess.run(
+                ls_out = subprocess.run(
                     [openshell_bin, "sandbox", "exec", "--name", sb_name, "--",
-                     "cat", f"{sessions_path}/{fname}"],
-                    capture_output=True, text=True, timeout=30,
+                     "sh", "-c", f"ls {_sessions_path}/ 2>/dev/null"],
+                    capture_output=True, text=True, timeout=10,
                 )
-                if cat_out.returncode != 0:
+                if ls_out.returncode != 0:
                     continue
-                all_lines = cat_out.stdout.splitlines()
-                batch: list[dict] = []
-                for raw in all_lines[last_line:]:
-                    raw = raw.strip()
-                    if not raw:
-                        continue
-                    try:
-                        obj = json.loads(raw)
-                    except Exception:
-                        continue
-                    if isinstance(obj, dict):
-                        batch.append(obj)
-                if batch:
-                    # Stamp sandbox runtimeKind on each event so the adapter
-                    # can expose it in list_sessions/list_events (#3367).
-                    _rk = _sb_rk_map.get(sb_name, "")
-                    if _rk:
-                        for _ev in batch:
-                            if isinstance(_ev, dict):
-                                _ev["_nemo_rk"] = _rk
-                    _flush_session_batch(batch, fname, api_key, enc_key, node_id, None,
-                                         agent_type="nemoclaw")
-                    total += len(batch)
-                cursors[cursor_key] = len(all_lines)
-            except Exception as _ce:
+                fnames = [
+                    f.strip() for f in ls_out.stdout.splitlines()
+                    if f.strip().endswith(".jsonl")
+                    and ".trajectory." not in f
+                    and ".checkpoint." not in f
+                    and ".deleted." not in f
+                ]
+            except Exception as _le:
                 log.debug(
-                    "sandbox-session sync: read failed for %s/%s: %s",
-                    sb_name, fname, _ce,
+                    "sandbox-session sync: ls failed for %s/%s: %s",
+                    sb_name, _agent_dir, _le,
                 )
+                continue
+
+            for fname in fnames:
+                # Warmup sessions (nemoclaw-onboard-warmup-*) are harness
+                # onboarding artefacts — skip so they never reach DuckDB (#3366).
+                if _agent_dir == "main" and fname.startswith("nemoclaw-onboard-warmup-"):
+                    continue
+                # Namespace cursor keys by agent_dir so main and advisor files
+                # with the same filename don't share a cursor position.
+                cursor_key = f"{sb_name}/{_agent_dir}/{fname}"
+                last_line = cursors.get(cursor_key, 0)
+                try:
+                    cat_out = subprocess.run(
+                        [openshell_bin, "sandbox", "exec", "--name", sb_name, "--",
+                         "cat", f"{_sessions_path}/{fname}"],
+                        capture_output=True, text=True, timeout=30,
+                    )
+                    if cat_out.returncode != 0:
+                        continue
+                    all_lines = cat_out.stdout.splitlines()
+                    batch: list[dict] = []
+                    for raw in all_lines[last_line:]:
+                        raw = raw.strip()
+                        if not raw:
+                            continue
+                        try:
+                            obj = json.loads(raw)
+                        except Exception:
+                            continue
+                        if isinstance(obj, dict):
+                            if _agent_dir != "main":
+                                obj["_nemo_agent_dir"] = _agent_dir
+                            batch.append(obj)
+                    if batch:
+                        # Stamp sandbox runtimeKind on each event so the adapter
+                        # can expose it in list_sessions/list_events (#3367).
+                        _rk = _sb_rk_map.get(sb_name, "")
+                        if _rk:
+                            for _ev in batch:
+                                if isinstance(_ev, dict):
+                                    _ev["_nemo_rk"] = _rk
+                        _flush_session_batch(batch, fname, api_key, enc_key, node_id, None,
+                                             agent_type="nemoclaw")
+                        total += len(batch)
+                    cursors[cursor_key] = len(all_lines)
+                except Exception as _ce:
+                    log.debug(
+                        "sandbox-session sync: read failed for %s/%s/%s: %s",
+                        sb_name, _agent_dir, fname, _ce,
+                    )
 
         # OCSF audit log ingest — gap #3299 / fix #3389.
         # Uses a long-lived tail process (Popen) so events emitted between

--- a/tests/test_obs_gap_nemoclaw_advisor_ingest_3698.py
+++ b/tests/test_obs_gap_nemoclaw_advisor_ingest_3698.py
@@ -1,0 +1,126 @@
+"""Tests for #3698 — NemoClaw advisor-session JSONL ingestion via openshell.
+
+sync_sandbox_sessions_openshell() must scan agents/advisor/sessions alongside
+agents/main/sessions so LLM-consuming advisor/analysis sessions (tool calls,
+retry outcomes) are visible in ClawMetry.
+"""
+import json
+from unittest.mock import MagicMock, patch
+
+from clawmetry.sync import sync_sandbox_sessions_openshell
+
+CONFIG = {"api_key": "ak", "encryption_key": None, "node_id": "n1"}
+
+
+def _run(returncode=0, stdout=""):
+    r = MagicMock()
+    r.returncode = returncode
+    r.stdout = stdout
+    return r
+
+
+def _advisor_event(session_id, event_type, extra=None):
+    ev = {"id": f"{session_id}-{event_type}", "sessionId": session_id,
+          "type": event_type}
+    if extra:
+        ev.update(extra)
+    return json.dumps(ev)
+
+
+def test_advisor_sessions_ingested_when_present():
+    """JSONL in agents/advisor/sessions must reach _flush_session_batch."""
+    sandbox_list = json.dumps([{"name": "sb"}])
+    advisor_line = _advisor_event("adv-sess-1", "tool_execution_start",
+                                  {"attemptNumber": 1})
+
+    side_effects = [
+        _run(0, sandbox_list),
+        _run(1, ""),                   # ls agents/main/sessions (absent)
+        _run(0, "adv-sess-1.jsonl\n"), # ls agents/advisor/sessions
+        _run(0, advisor_line + "\n"),  # cat advisor/adv-sess-1.jsonl
+    ]
+
+    flushed = []
+    with patch("clawmetry.sync._find_openshell_bin", return_value="/usr/bin/openshell"), \
+         patch("subprocess.run", side_effect=side_effects), \
+         patch("clawmetry.sync._flush_session_batch",
+               side_effect=lambda b, *a, **k: flushed.extend(b)):
+        count = sync_sandbox_sessions_openshell(CONFIG, {})
+
+    assert count == 1
+    assert len(flushed) == 1
+    assert flushed[0].get("_nemo_agent_dir") == "advisor"
+
+
+def test_advisor_sessions_tagged_nemoclaw():
+    """Advisor sessions must land with agent_type='nemoclaw'."""
+    sandbox_list = json.dumps([{"name": "sb"}])
+    advisor_line = _advisor_event("adv-sess-2", "tool_execution_end",
+                                  {"isError": False, "retryResponse": "success"})
+
+    side_effects = [
+        _run(0, sandbox_list),
+        _run(1, ""),
+        _run(0, "adv-sess-2.jsonl\n"),
+        _run(0, advisor_line + "\n"),
+    ]
+
+    flush_kwargs = []
+    with patch("clawmetry.sync._find_openshell_bin", return_value="/usr/bin/openshell"), \
+         patch("subprocess.run", side_effect=side_effects), \
+         patch("clawmetry.sync._flush_session_batch",
+               side_effect=lambda b, *a, **k: flush_kwargs.append(k)):
+        sync_sandbox_sessions_openshell(CONFIG, {})
+
+    assert flush_kwargs, "flush was never called"
+    assert flush_kwargs[0].get("agent_type") == "nemoclaw"
+
+
+def test_advisor_cursor_namespaced_separately_from_main():
+    """Cursor keys for advisor sessions must be distinct from main keys."""
+    sandbox_list = json.dumps([{"name": "sb"}])
+    main_line = json.dumps({"id": "m1", "type": "message"})
+    adv_line = _advisor_event("adv-sess-3", "tool_execution_start")
+
+    side_effects = [
+        _run(0, sandbox_list),
+        _run(0, "sess.jsonl\n"),      # ls agents/main/sessions
+        _run(0, main_line + "\n"),     # cat main/sess.jsonl
+        _run(0, "sess.jsonl\n"),      # ls agents/advisor/sessions (same filename)
+        _run(0, adv_line + "\n"),      # cat advisor/sess.jsonl
+    ]
+
+    state = {}
+    with patch("clawmetry.sync._find_openshell_bin", return_value="/usr/bin/openshell"), \
+         patch("subprocess.run", side_effect=side_effects), \
+         patch("clawmetry.sync._flush_session_batch"):
+        sync_sandbox_sessions_openshell(CONFIG, state)
+
+    cursors = state["sandbox_session_cursors"]
+    assert "sb/main/sess.jsonl" in cursors
+    assert "sb/advisor/sess.jsonl" in cursors
+    assert cursors["sb/main/sess.jsonl"] == 1
+    assert cursors["sb/advisor/sess.jsonl"] == 1
+
+
+def test_main_events_not_stamped_with_agent_dir():
+    """Regular main sessions must not gain _nemo_agent_dir."""
+    sandbox_list = json.dumps([{"name": "sb"}])
+    main_line = json.dumps({"id": "m2", "type": "message"})
+
+    side_effects = [
+        _run(0, sandbox_list),
+        _run(0, "main.jsonl\n"),
+        _run(0, main_line + "\n"),
+        _run(1, ""),
+    ]
+
+    flushed = []
+    with patch("clawmetry.sync._find_openshell_bin", return_value="/usr/bin/openshell"), \
+         patch("subprocess.run", side_effect=side_effects), \
+         patch("clawmetry.sync._flush_session_batch",
+               side_effect=lambda b, *a, **k: flushed.extend(b)):
+        sync_sandbox_sessions_openshell(CONFIG, {})
+
+    assert flushed
+    assert "_nemo_agent_dir" not in flushed[0]

--- a/tests/test_sandbox_session_sync.py
+++ b/tests/test_sandbox_session_sync.py
@@ -34,8 +34,9 @@ def test_happy_path_flushes_events_and_advances_cursor():
 
     side_effects = [
         _run(0, sandbox_list),
-        _run(0, ls_output),
-        _run(0, cat_output),
+        _run(0, ls_output),   # ls agents/main/sessions
+        _run(0, cat_output),  # cat main/abc123.jsonl
+        _run(1, ""),          # ls agents/advisor/sessions (absent — nonzero)
     ]
 
     state = {}
@@ -48,7 +49,8 @@ def test_happy_path_flushes_events_and_advances_cursor():
 
     assert count == 2
     assert len(flushed) == 2
-    assert state["sandbox_session_cursors"]["my-sandbox/abc123.jsonl"] == 2
+    # cursor key now includes agent_dir (#3698)
+    assert state["sandbox_session_cursors"]["my-sandbox/main/abc123.jsonl"] == 2
 
 
 def test_sidecar_files_excluded():
@@ -59,8 +61,9 @@ def test_sidecar_files_excluded():
     # Only abc.jsonl should be read (1 cat call); sidecars produce no cat call
     side_effects = [
         _run(0, sandbox_list),
-        _run(0, ls_output),
-        _run(0, cat_output),
+        _run(0, ls_output),   # ls agents/main/sessions
+        _run(0, cat_output),  # cat main/abc.jsonl (only non-sidecar)
+        _run(1, ""),          # ls agents/advisor/sessions (absent)
     ]
     flushed = []
     with patch("clawmetry.sync._find_openshell_bin", return_value="/usr/bin/openshell"), \
@@ -81,7 +84,12 @@ def test_sandbox_sessions_tagged_as_nemoclaw():
     ls_output = "sess.jsonl\n"
     cat_output = "\n".join(events) + "\n"
 
-    side_effects = [_run(0, sandbox_list), _run(0, ls_output), _run(0, cat_output)]
+    side_effects = [
+        _run(0, sandbox_list),
+        _run(0, ls_output),   # ls agents/main/sessions
+        _run(0, cat_output),  # cat main/sess.jsonl
+        _run(1, ""),          # ls agents/advisor/sessions (absent)
+    ]
 
     flush_kwargs = []
     with patch("clawmetry.sync._find_openshell_bin", return_value="/usr/bin/openshell"), \
@@ -107,7 +115,12 @@ def test_cursor_skips_already_seen_lines_on_second_call():
     flushed = []
 
     def make_effects():
-        return [_run(0, sandbox_list), _run(0, ls_output), _run(0, cat_output)]
+        return [
+            _run(0, sandbox_list),
+            _run(0, ls_output),  # ls agents/main/sessions
+            _run(0, cat_output), # cat main/sess.jsonl
+            _run(1, ""),         # ls agents/advisor/sessions (absent)
+        ]
 
     with patch("clawmetry.sync._find_openshell_bin", return_value="/usr/bin/openshell"), \
          patch("subprocess.run", side_effect=make_effects()), \
@@ -116,7 +129,8 @@ def test_cursor_skips_already_seen_lines_on_second_call():
         sync_sandbox_sessions_openshell(CONFIG, state)
 
     assert len(flushed) == 1
-    assert state["sandbox_session_cursors"]["sb/sess.jsonl"] == 1
+    # cursor key now includes agent_dir (#3698)
+    assert state["sandbox_session_cursors"]["sb/main/sess.jsonl"] == 1
 
     flushed.clear()
     with patch("clawmetry.sync._find_openshell_bin", return_value="/usr/bin/openshell"), \


### PR DESCRIPTION
Closes #3698

## Summary

- **Root cause:** `sync_sandbox_sessions_openshell()` only scanned `/sandbox/.openclaw/agents/main/sessions` inside NemoClaw sandboxes. NemoClaw's advisor/analysis session runner (`createAgentSession`) writes to `agents/advisor/sessions` — that path was never read, making every advisor LLM call, tool execution, and retry outcome invisible to ClawMetry.
- **Fix:** Refactor the per-sandbox scan to loop over `("main", "advisor")` agent dirs. Cursor keys gain an `/{agent_dir}/` component to namespace main vs advisor independently. Advisor events are stamped with `_nemo_agent_dir="advisor"` for traceability. The read path (`NemoClawAdapter.list_events`) already decodes `tool_execution_start`/`tool_execution_end` retry lifecycle fields from fix #3650 — no adapter change needed.
- **Cursor key change:** Existing keys (`sb/sess.jsonl`) become `sb/main/sess.jsonl`, causing a one-time re-read of main events on next daemon start. Safe — `_flush_session_batch` upserts by event ID.

## Test plan

- All 5 existing `test_sandbox_session_sync.py` tests updated and passing (cursor assertions, extra mock call for advisor `ls`)
- 4 new tests in `test_obs_gap_nemoclaw_advisor_ingest_3698.py`: advisor events ingested, tagged `agent_type='nemoclaw'`, cursor namespaced separately, main events not stamped with `_nemo_agent_dir`
- `python3.11 -m pytest tests/test_sandbox_session_sync.py tests/test_obs_gap_nemoclaw_advisor_ingest_3698.py` → 9 passed

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q56pvie2UPWNxKbi4Ga8Yx)_