### PR TITLE
feat(entitlement): tiers_for_capacity_batch + /api/entitlement/tiers-for-capacity-batch

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -16288,3 +16288,92 @@ def tiers_for_node_count(count: int) -> dict | None:
             "entitlements: tiers_for_node_count failed: %s", exc
         )
         return None
+
+
+def tiers_for_capacity_batch(
+    *,
+    channels: int | None = None,
+    retention_days: int | None = None,
+    nodes: int | None = None,
+) -> dict:
+    """Per-item availability ladder for every supplied capacity axis in one
+    pass.
+
+    Per-item plural sibling of :func:`tiers_for_channel_count` /
+    :func:`tiers_for_retention_window` / :func:`tiers_for_node_count`.
+    Closes the capacity-axis symmetry gap in the ``tiers_for_*`` family:
+    :func:`tiers_for_batch` collapses to the two grant axes (features +
+    runtimes) and does not accept capacity args at all -- so a pricing-page
+    that wants the full "Fits in: <tier>, ..." ladder for a caller-supplied
+    ``(channels, retention_days, nodes)`` capacity bundle either had to
+    fan out three ``/tiers-for-<axis>`` calls or build the ladder client-
+    side from ``/min-tier-batch``. This helper delivers the same
+    per-axis row shape those three singulars return, on all three axes,
+    in one round-trip.
+
+    Envelope shape mirrors :func:`min_tier_batch` on the three capacity
+    axes exactly (same "None means unset, not unlimited" posture, same
+    per-axis ``None`` "not supplied" sentinel, same never-raise
+    contract)::
+
+        {
+          "channels":       <row> | None,
+          "retention_days": <row> | None,
+          "nodes":          <row> | None,
+        }
+
+    Each ``<row>`` matches the singular ``tiers_for_<axis>`` helper
+    byte-for-byte (``item`` / ``kind`` / ``label`` / ``free`` /
+    ``min_tier`` / ``min_tier_label`` / ``min_tier_rank`` / ``tiers``)
+    so callers can pass any row through the existing ``tiers_for_*``
+    rendering components without reshaping. Per-row parity with each
+    singular helper is pinned in the test suite so the batch cannot
+    silently drift from the scalar.
+
+    Critically, ``retention_days=None`` here means *unset* -- NOT
+    *unlimited* (matches :func:`min_tier_batch` / :func:`lock_reasons_batch`
+    on the same axis). Asking for the unlimited-retention ladder is the
+    singular :func:`tiers_for_retention_window` (``days=None``) call's
+    job -- it would render an "Enterprise-only" row here otherwise and
+    a caller supplying every other axis but leaving retention off would
+    get a mis-routed Enterprise row instead of an omitted one.
+
+    A blank or non-int value on any axis short-circuits that axis to
+    ``None`` (matches the singular helpers' ``None``-on-bad-input
+    posture rather than raising -- the caller opts in per-axis by
+    supplying a value).
+
+    Decoupled from the resolved entitlement (walks the static per-tier
+    caps via the singular ``tiers_for_*`` helpers), so grace vs enforce
+    yields byte-identical rows -- pinned in the test suite via a grace
+    / enforce reload roundtrip. Never raises: if a resolver fails the
+    helper returns the all-``None`` envelope shape so the pricing UI
+    keeps rendering instead of 500-ing.
+    """
+    try:
+        return {
+            "channels": (
+                tiers_for_channel_count(channels)
+                if channels is not None
+                else None
+            ),
+            "retention_days": (
+                tiers_for_retention_window(retention_days)
+                if retention_days is not None
+                else None
+            ),
+            "nodes": (
+                tiers_for_node_count(nodes)
+                if nodes is not None
+                else None
+            ),
+        }
+    except Exception as exc:
+        logger.warning(
+            "entitlements: tiers_for_capacity_batch failed: %s", exc
+        )
+        return {
+            "channels": None,
+            "retention_days": None,
+            "nodes": None,
+        }

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -19975,3 +19975,108 @@ def api_entitlement_tiers_for_node_count():
                 "enforced": False,
             }
         )
+
+
+@bp_entitlement.route("/api/entitlement/tiers-for-capacity-batch")
+def api_entitlement_tiers_for_capacity_batch():
+    """``GET /api/entitlement/tiers-for-capacity-batch?channels=N
+    &retention_days=K&nodes=M`` -- per-item availability ladder for every
+    supplied capacity axis in one pass.
+
+    Per-item plural sibling of the three ``/tiers-for-<axis>`` endpoints.
+    Closes the capacity-axis symmetry gap in the ``/tiers-for-*`` family:
+    ``/tiers-for-batch`` collapses to the two grant axes (features +
+    runtimes) and does not accept capacity args at all -- so a pricing-
+    page that wants the full "Fits in: <tier>, ..." ladder for a caller-
+    supplied ``(channels, retention_days, nodes)`` capacity bundle
+    either had to fan out three ``/tiers-for-<axis>`` calls or build the
+    ladder client-side from ``/min-tier-batch``. This endpoint delivers
+    the same per-axis row shape those three singulars return, on all
+    three axes, off ONE round-trip.
+
+    At least one of ``channels=`` / ``retention_days=`` / ``nodes=``
+    must be supplied (non-empty / parseable after normalisation). A
+    blank or non-int value on an individual axis is treated as "not
+    supplied" for that axis (matches
+    ``/api/entitlement/min-tier-batch``'s never-crash posture rather
+    than mis-routing a typo to Enterprise); the endpoint 400s only when
+    *no* axis parsed successfully. Never 5xxs: the grace-shape envelope
+    is returned on any resolver failure.
+
+    Response shape::
+
+        {
+          "channels":       <row> | None,
+          "retention_days": <row> | None,
+          "nodes":          <row> | None,
+          "current_tier":       "...",
+          "current_tier_rank":  <int>,
+          "grace":              <bool>,
+          "enforced":           <bool>,
+        }
+
+    Each ``<row>`` matches the singular
+    ``/tiers-for-channel-count?count=`` /
+    ``/tiers-for-retention-window?days=`` /
+    ``/tiers-for-node-count?count=`` endpoint byte-for-byte (``item`` /
+    ``kind`` / ``label`` / ``free`` / ``min_tier`` / ``min_tier_label``
+    / ``min_tier_rank`` / ``tiers``) so a caller can pass any row
+    through the existing ``tiers_for_*`` rendering components without
+    reshaping. Per-row parity with the singular endpoints is pinned in
+    the test suite so the batch cannot silently drift from the scalars.
+
+    Critically, ``retention_days`` here treats ``None`` (parameter
+    omitted / unparseable) as *unset* -- NOT *unlimited* (matches
+    ``/min-tier-batch``'s posture on the same axis). Asking for the
+    unlimited-retention ladder is the singular
+    ``/tiers-for-retention-window?days=unlimited`` call's job.
+    """
+    (_, channels_ok, channels_n, _) = _parse_capacity_arg("channels")
+    (_, retention_ok, retention_n, _) = _parse_capacity_arg("retention_days")
+    (_, nodes_ok, nodes_n, _) = _parse_capacity_arg("nodes")
+
+    if not channels_ok and not retention_ok and not nodes_ok:
+        return (
+            jsonify(
+                {
+                    "error": (
+                        "supply at least one of channels=<int>, "
+                        "retention_days=<int>, or nodes=<int>"
+                    )
+                }
+            ),
+            400,
+        )
+
+    try:
+        from clawmetry import entitlements as _ent
+
+        body = _ent.tiers_for_capacity_batch(
+            channels=channels_n if channels_ok else None,
+            retention_days=retention_n if retention_ok else None,
+            nodes=nodes_n if nodes_ok else None,
+        )
+        env = _resolver_envelope(_ent)
+        return jsonify(
+            {
+                "channels": body.get("channels"),
+                "retention_days": body.get("retention_days"),
+                "nodes": body.get("nodes"),
+                **env,
+            }
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_tiers_for_capacity_batch: error: %s", exc
+        )
+        return jsonify(
+            {
+                "channels": None,
+                "retention_days": None,
+                "nodes": None,
+                "current_tier": "oss",
+                "current_tier_rank": 0,
+                "grace": True,
+                "enforced": False,
+            }
+        )

--- a/tests/test_entitlement_tiers_for_capacity_batch.py
+++ b/tests/test_entitlement_tiers_for_capacity_batch.py
@@ -1,0 +1,424 @@
+"""Tests for ``clawmetry.entitlements.tiers_for_capacity_batch`` +
+``GET /api/entitlement/tiers-for-capacity-batch``.
+
+Per-item plural sibling of ``tiers_for_channel_count`` /
+``tiers_for_retention_window`` / ``tiers_for_node_count`` for the three
+capacity axes. Closes the symmetry gap in the ``tiers_for_*`` family:
+``tiers_for_batch`` covers only features + runtimes (the grant axes) and
+doesn't accept capacity args at all -- so a pricing-page that wants the
+full "Fits in: <tier>, ..." ladder for a caller-supplied ``(channels,
+retention_days, nodes)`` capacity bundle either had to fan out three
+``/tiers-for-<axis>`` calls or build the ladder client-side from
+``/min-tier-batch``. These tests pin the contract:
+
+  - envelope shape mirrors ``min_tier_batch`` on the three capacity axes
+    exactly (per-axis ``None`` "not supplied" sentinel, same never-raise
+    contract)
+  - each row byte-equals the matching singular ``tiers_for_<axis>``
+    helper -- the batch cannot silently drift from the scalars
+  - ``retention_days=None`` means unset, NOT unlimited (matches
+    ``min_tier_batch`` on the same axis)
+  - grace vs enforce yields byte-identical rows
+  - the wrapper endpoint 400s only when *no* axis parsed successfully;
+    blank/non-int values on individual axes are treated as unsupplied
+  - never 5xxs on the wrapper endpoint
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+# ── fixtures ─────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+#   helper: shape
+# ══════════════════════════════════════════════════════════════════════════════
+
+
+def test_returns_three_axis_envelope(ent):
+    body = ent.tiers_for_capacity_batch(
+        channels=5, retention_days=30, nodes=3
+    )
+    assert isinstance(body, dict)
+    assert set(body.keys()) == {"channels", "retention_days", "nodes"}
+
+
+def test_returns_all_none_when_nothing_supplied(ent):
+    body = ent.tiers_for_capacity_batch()
+    assert body == {
+        "channels": None,
+        "retention_days": None,
+        "nodes": None,
+    }
+
+
+def test_omitted_axis_is_none(ent):
+    body = ent.tiers_for_capacity_batch(channels=5)
+    assert body["channels"] is not None
+    assert body["retention_days"] is None
+    assert body["nodes"] is None
+
+
+def test_channels_row_has_singular_shape(ent):
+    body = ent.tiers_for_capacity_batch(channels=5)
+    row = body["channels"]
+    assert set(row.keys()) == {
+        "item",
+        "kind",
+        "label",
+        "free",
+        "min_tier",
+        "min_tier_label",
+        "min_tier_rank",
+        "tiers",
+    }
+    assert row["kind"] == "channel_count"
+    assert row["item"] == 5
+
+
+def test_retention_row_has_singular_shape(ent):
+    body = ent.tiers_for_capacity_batch(retention_days=30)
+    row = body["retention_days"]
+    assert set(row.keys()) == {
+        "item",
+        "kind",
+        "label",
+        "free",
+        "min_tier",
+        "min_tier_label",
+        "min_tier_rank",
+        "tiers",
+    }
+    assert row["kind"] == "retention_window"
+    assert row["item"] == 30
+
+
+def test_nodes_row_has_singular_shape(ent):
+    body = ent.tiers_for_capacity_batch(nodes=3)
+    row = body["nodes"]
+    assert set(row.keys()) == {
+        "item",
+        "kind",
+        "label",
+        "free",
+        "min_tier",
+        "min_tier_label",
+        "min_tier_rank",
+        "tiers",
+    }
+    assert row["kind"] == "node_count"
+    assert row["item"] == 3
+
+
+def test_tier_rows_have_expected_keys(ent):
+    body = ent.tiers_for_capacity_batch(
+        channels=5, retention_days=30, nodes=3
+    )
+    for axis in ("channels", "retention_days", "nodes"):
+        for tier_row in body[axis]["tiers"]:
+            assert set(tier_row.keys()) == {
+                "id",
+                "label",
+                "rank",
+                "purchasable",
+            }
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+#   helper: parity with singular helpers
+# ══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.parametrize("count", [0, 1, 3, 5, 10, 100])
+def test_channels_row_equals_singular_helper(ent, count):
+    body = ent.tiers_for_capacity_batch(channels=count)
+    assert body["channels"] == ent.tiers_for_channel_count(count)
+
+
+@pytest.mark.parametrize("days", [0, 1, 7, 30, 90, 365])
+def test_retention_row_equals_singular_helper(ent, days):
+    body = ent.tiers_for_capacity_batch(retention_days=days)
+    assert body["retention_days"] == ent.tiers_for_retention_window(days)
+
+
+@pytest.mark.parametrize("count", [0, 1, 2, 3, 10, 100])
+def test_nodes_row_equals_singular_helper(ent, count):
+    body = ent.tiers_for_capacity_batch(nodes=count)
+    assert body["nodes"] == ent.tiers_for_node_count(count)
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+#   helper: retention_days=None means UNSET (not unlimited)
+# ══════════════════════════════════════════════════════════════════════════════
+
+
+def test_retention_none_means_unset_not_unlimited(ent):
+    """``retention_days=None`` means the axis was not supplied. Distinct
+    from the singular ``tiers_for_retention_window(None)`` semantics
+    where ``None`` means the unlimited-retention request -- mirrors
+    ``min_tier_batch`` / ``lock_reasons_batch`` on the same axis so a
+    caller supplying every other axis but leaving retention off does not
+    get a mis-routed Enterprise row."""
+    body = ent.tiers_for_capacity_batch(channels=5, nodes=3)
+    assert body["retention_days"] is None
+    # sanity: the singular helper would have returned an Enterprise row
+    unlimited = ent.tiers_for_retention_window(None)
+    assert unlimited is not None
+    assert unlimited["label"] == "unlimited"
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+#   helper: bad input
+# ══════════════════════════════════════════════════════════════════════════════
+
+
+def test_channels_non_int_row_is_none(ent):
+    body = ent.tiers_for_capacity_batch(channels="not-a-number")
+    assert body["channels"] is None
+
+
+def test_retention_non_int_row_is_none(ent):
+    body = ent.tiers_for_capacity_batch(retention_days="foo")
+    assert body["retention_days"] is None
+
+
+def test_nodes_non_int_row_is_none(ent):
+    body = ent.tiers_for_capacity_batch(nodes="bar")
+    assert body["nodes"] is None
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+#   helper: safety
+# ══════════════════════════════════════════════════════════════════════════════
+
+
+def test_does_not_mutate_live_entitlement(ent):
+    before = ent.get_entitlement().to_dict()
+    ent.tiers_for_capacity_batch(channels=5, retention_days=30, nodes=3)
+    after = ent.get_entitlement().to_dict()
+    assert before == after
+
+
+def test_never_raises_on_helper_boom(monkeypatch, ent):
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "tiers_for_channel_count", boom)
+    body = ent.tiers_for_capacity_batch(
+        channels=5, retention_days=30, nodes=3
+    )
+    assert body == {
+        "channels": None,
+        "retention_days": None,
+        "nodes": None,
+    }
+
+
+def test_stable_across_calls(ent):
+    a = ent.tiers_for_capacity_batch(channels=5, retention_days=30, nodes=3)
+    b = ent.tiers_for_capacity_batch(channels=5, retention_days=30, nodes=3)
+    assert a == b
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+#   helper: grace vs enforce parity
+# ══════════════════════════════════════════════════════════════════════════════
+
+
+def test_grace_vs_enforce_yields_identical_rows(monkeypatch, ent):
+    """The helper walks the static per-tier caps via the singular
+    ``tiers_for_*`` helpers, so per-axis rows are perspective-independent
+    on grace vs enforce."""
+    grace = ent.tiers_for_capacity_batch(
+        channels=5, retention_days=30, nodes=3
+    )
+
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    try:
+        enforced = e.tiers_for_capacity_batch(
+            channels=5, retention_days=30, nodes=3
+        )
+        assert enforced == grace
+    finally:
+        e.invalidate()
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+#   API surface
+# ══════════════════════════════════════════════════════════════════════════════
+
+
+def test_api_returns_envelope_shape(client):
+    rv = client.get(
+        "/api/entitlement/tiers-for-capacity-batch"
+        "?channels=5&retention_days=30&nodes=3"
+    )
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert set(body.keys()) == {
+        "channels",
+        "retention_days",
+        "nodes",
+        "current_tier",
+        "current_tier_rank",
+        "grace",
+        "enforced",
+    }
+
+
+def test_api_reports_grace_in_oss_default(client):
+    body = client.get(
+        "/api/entitlement/tiers-for-capacity-batch?channels=5"
+    ).get_json()
+    assert body["grace"] is True
+    assert body["enforced"] is False
+    assert body["current_tier"] == "oss"
+    assert body["current_tier_rank"] == 0
+
+
+def test_api_missing_all_axes_is_400(client):
+    rv = client.get("/api/entitlement/tiers-for-capacity-batch")
+    assert rv.status_code == 400
+
+
+def test_api_all_blank_axes_is_400(client):
+    rv = client.get(
+        "/api/entitlement/tiers-for-capacity-batch"
+        "?channels=&retention_days=&nodes="
+    )
+    assert rv.status_code == 400
+
+
+def test_api_all_non_int_axes_is_400(client):
+    """Non-int on every supplied axis short-circuits each to unsupplied,
+    so the endpoint 400s (matches min-tier-batch's posture)."""
+    rv = client.get(
+        "/api/entitlement/tiers-for-capacity-batch"
+        "?channels=abc&retention_days=xyz&nodes=nope"
+    )
+    assert rv.status_code == 400
+
+
+def test_api_partial_bad_input_treats_that_axis_as_unset(client):
+    """A blank / non-int value on ONE axis is treated as 'not supplied'
+    for that axis (matches min-tier-batch's never-crash posture rather
+    than mis-routing a typo to Enterprise). Other supplied axes still
+    render."""
+    rv = client.get(
+        "/api/entitlement/tiers-for-capacity-batch"
+        "?channels=5&retention_days=foo&nodes="
+    )
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["channels"] is not None
+    assert body["retention_days"] is None
+    assert body["nodes"] is None
+
+
+def test_api_single_axis_supplied(client):
+    rv = client.get("/api/entitlement/tiers-for-capacity-batch?channels=5")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["channels"] is not None
+    assert body["channels"]["kind"] == "channel_count"
+    assert body["channels"]["item"] == 5
+    assert body["retention_days"] is None
+    assert body["nodes"] is None
+
+
+def test_api_zero_on_every_axis_returns_all_tiers(client, ent):
+    rv = client.get(
+        "/api/entitlement/tiers-for-capacity-batch"
+        "?channels=0&retention_days=0&nodes=0"
+    )
+    assert rv.status_code == 200
+    body = rv.get_json()
+    for axis in ("channels", "retention_days", "nodes"):
+        ids = {t["id"] for t in body[axis]["tiers"]}
+        assert ids == set(ent._TIER_ORDER)
+
+
+def test_api_rows_match_singular_endpoints(client, ent):
+    """Per-row parity with the singular ``/tiers-for-<axis>`` endpoints
+    is the answer -- drop the envelope off any row and it byte-equals
+    the singular response for the same value."""
+    rv = client.get(
+        "/api/entitlement/tiers-for-capacity-batch"
+        "?channels=5&retention_days=30&nodes=3"
+    ).get_json()
+    envelope_keys = {
+        "current_tier",
+        "current_tier_rank",
+        "grace",
+        "enforced",
+    }
+
+    ch_single = client.get(
+        "/api/entitlement/tiers-for-channel-count?count=5"
+    ).get_json()
+    ch_row = {k: v for k, v in ch_single.items() if k not in envelope_keys}
+    assert rv["channels"] == ch_row
+
+    rt_single = client.get(
+        "/api/entitlement/tiers-for-retention-window?days=30"
+    ).get_json()
+    rt_row = {k: v for k, v in rt_single.items() if k not in envelope_keys}
+    assert rv["retention_days"] == rt_row
+
+    nd_single = client.get(
+        "/api/entitlement/tiers-for-node-count?count=3"
+    ).get_json()
+    nd_row = {k: v for k, v in nd_single.items() if k not in envelope_keys}
+    assert rv["nodes"] == nd_row
+
+
+def test_api_resolver_failure_returns_grace_envelope(monkeypatch, client):
+    import clawmetry.entitlements as e
+
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(e, "tiers_for_capacity_batch", boom)
+    rv = client.get(
+        "/api/entitlement/tiers-for-capacity-batch?channels=5"
+    )
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body == {
+        "channels": None,
+        "retention_days": None,
+        "nodes": None,
+        "current_tier": "oss",
+        "current_tier_rank": 0,
+        "grace": True,
+        "enforced": False,
+    }


### PR DESCRIPTION
## Summary

- Adds `tiers_for_capacity_batch(*, channels, retention_days, nodes)` — per-item plural sibling of `tiers_for_channel_count` / `tiers_for_retention_window` / `tiers_for_node_count`. Closes the capacity-axis symmetry gap in the `tiers_for_*` family: `tiers_for_batch` covers only features + runtimes (the grant axes) and does not accept capacity args at all — so a pricing-page that wants the full "Fits in: `<tier>`, ..." ladder for a caller-supplied `(channels, retention_days, nodes)` capacity bundle either had to fan out three `/tiers-for-<axis>` calls or build the ladder client-side from `/min-tier-batch`.
- Adds `GET /api/entitlement/tiers-for-capacity-batch` — 400 when no axis parses successfully, 200 with per-axis rows + the resolver envelope on happy path. Blank / non-int on individual axes is treated as unsupplied (matches `/min-tier-batch`'s never-crash posture rather than mis-routing a typo to Enterprise); the endpoint 400s only when *no* axis parsed.
- Envelope shape mirrors `min_tier_batch` on the three capacity axes exactly (per-axis `None` "not supplied" sentinel, `retention_days=None` means unset NOT unlimited, same never-raise contract). Each row byte-equals the matching singular `tiers_for_<axis>` helper — pinned in the test suite so the batch cannot silently drift from the scalars.

Grace-mode change only — no behaviour change on any existing surface, no `__version__` bump, no `[RELEASE]` PR, no gate enforced.

## Why

`tiers_for_feature` / `tiers_for_runtime` / `tiers_for_batch` cover the two grant axes. `tiers_for_channel_count` / `tiers_for_retention_window` / `tiers_for_node_count` cover the three capacity axes as scalars. The batch shape was the only gap: a pricing-page rendering the full five-axis availability matrix off one round-trip had `/tiers-for-batch` for features + runtimes but had to fan out three separate calls for the capacity axes. This PR fills that slot so the whole "Fits in: `<tier>`, ..." matrix hydrates off ONE call.

## Changes

### `clawmetry/entitlements.py`

- `tiers_for_capacity_batch(*, channels=None, retention_days=None, nodes=None)` — delegates to the three singular capacity `tiers_for_*` helpers on each supplied axis. Per-axis `None` = "not supplied" (row is `None`). Non-int on any axis short-circuits that axis to `None` via the singular helper's `None`-on-bad-input posture. Never raises: a resolver failure returns the all-`None` envelope.

### `routes/entitlement.py`

- `GET /api/entitlement/tiers-for-capacity-batch?channels=N&retention_days=K&nodes=M` — reuses the existing `_parse_capacity_arg` helper so blank / non-int on an individual axis is treated as unsupplied (matches `/min-tier-batch` byte-for-byte on the same axes). 400 only when no axis parsed. Wraps the entitlements-module call in the existing `try` / `except` so a resolver crash falls back to a grace-shape envelope instead of a 5xx.

### `tests/test_entitlement_tiers_for_capacity_batch.py`

**43 tests, all green** (2.06s):

- envelope shape (three axes, singular row shape parity)
- per-row parity with each singular helper across every capacity value under test (18 parametrised inputs across the three axes)
- `retention_days=None` means unset NOT unlimited (matches `min_tier_batch`)
- bad input per-axis returns `None` in the row (never raises)
- helper does not mutate the live entitlement
- grace vs enforce yields byte-identical rows
- API happy path (single axis, all three axes, zero-on-every-axis)
- API error path (400 no axis, 400 all-blank, 400 all-non-int)
- partial-bad-input row shape (typo on one axis + valid values on others → 200 with only the good rows)
- cross-endpoint parity: rows byte-equal `/tiers-for-channel-count?count=` / `/tiers-for-retention-window?days=` / `/tiers-for-node-count?count=` (stripped of the envelope) for the same values
- resolver failure returns grace-shape envelope

## Test plan

- [x] `python3 -m py_compile clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_tiers_for_capacity_batch.py` — clean
- [x] `ruff check clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_tiers_for_capacity_batch.py` — clean
- [x] `pytest tests/test_entitlement_tiers_for_capacity_batch.py -v` → **43/43 pass** in 2.06s
- [x] Sibling test files (`test_entitlement_tiers_for_capacity.py`, `test_entitlement_tiers_for_batch.py`, `test_entitlement_tiers_for.py`, `test_entitlement_api.py`, `test_blueprint_uniqueness.py`, `test_circular_import.py`) still green — **155/155 pass**

## Local operator verification checklist

I can't touch the running daemon, `~/.openclaw`, the live snapshot, or a browser from here — please run:

- [ ] Copy the two changed files into `~/.clawmetry/lib/python3.11/site-packages/clawmetry/` (`entitlements.py`) and `~/.clawmetry/lib/python3.11/site-packages/routes/` (`entitlement.py`); drop the test file into the local checkout under `tests/`
- [ ] Clear `__pycache__` on both dirs
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
- [ ] `curl -s 'http://localhost:8900/api/entitlement/tiers-for-capacity-batch?channels=5&retention_days=30&nodes=3' | jq .` — expect a shaped envelope with per-axis rows carrying the `tiers_for_<axis>` row shape (`item` / `kind` / `label` / `free` / `min_tier` / `min_tier_label` / `min_tier_rank` / `tiers`), plus the resolver envelope
- [ ] `curl -s 'http://localhost:8900/api/entitlement/tiers-for-capacity-batch?channels=5' | jq .` — expect `retention_days: null` and `nodes: null` alongside the `channels` row
- [ ] `curl -s -o /dev/null -w '%{http_code}\n' 'http://localhost:8900/api/entitlement/tiers-for-capacity-batch'` → `400`
- [ ] `curl -s -o /dev/null -w '%{http_code}\n' 'http://localhost:8900/api/entitlement/tiers-for-capacity-batch?channels=&retention_days=&nodes='` → `400`
- [ ] `curl -s 'http://localhost:8900/api/entitlement/tiers-for-capacity-batch?channels=5&retention_days=foo&nodes=' | jq .` — expect 200 with `channels` non-null but `retention_days: null` and `nodes: null`
- [ ] Compare rows against `/api/entitlement/tiers-for-channel-count?count=5`, `/api/entitlement/tiers-for-retention-window?days=30`, `/api/entitlement/tiers-for-node-count?count=3` — per-row body (minus the resolver envelope) must byte-equal the singular endpoints for the same values
- [ ] Decrypt the live cloud snapshot and hit the same endpoint against the cloud read-through path
- [ ] Browser check: any surface currently calling the three `/tiers-for-<axis>` endpoints should keep rendering; nothing should call the new capacity-batch route yet

No `__version__` bump, no tag, no `[RELEASE]` PR — staying in DRAFT until you've cleared local + cloud verification.

## MOAT / release checklist

- Not a MOAT fast-path change (no `local_store_via_daemon` / `_ls_call` / `_DAEMON_METHODS` touched).
- Not a `[RELEASE]` PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01C59QobGrQ9yWjTQGC4whPp)_