### PR TITLE
feat(entitlement): tiers_for_features + tiers_for_runtimes + /tiers-for-features + /tiers-for-runtimes

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -4913,6 +4913,215 @@ def tiers_for_runtime_at(
         return None
 
 
+def tiers_for_features(features) -> dict | None:
+    """Ladder-intersection sibling of :func:`min_tier_for_features`: the
+    set of tiers that grant **every** supplied feature at once, wrapped
+    in the same row shape a pricing-page component consumes off
+    :func:`tiers_for_feature`.
+
+    Where :func:`min_tier_for_features` collapses the caller-supplied
+    bundle to a single ``min_tier`` id (the cheapest purchasable tier
+    that admits all items), this helper returns the *full* ladder of
+    tiers that admit all items -- the ``"Available in: ...`` list a
+    "you use fleet + sso -- Available in Enterprise" tooltip renders.
+    Closes the ``tiers_for_*`` symmetry gap alongside the singular /
+    fixed-batch siblings: the caller-supplied-list shape had no plural
+    on the ladder axis, so a UI building the bundle-ladder off
+    ``min_tier_for_features`` had to fan out one ``/tiers-for`` call
+    per known id + intersect on the client.
+
+    Semantics mirror :func:`min_tier_for_features` on input handling:
+
+    * ``None`` / non-iterable -- returns ``None``. Never raises.
+    * Empty iterable -- returns the empty shape (``items=[]``,
+      ``tiers=[]``, ``min_tier=None``) rather than ``None``. Difference
+      from ``min_tier_for_features`` on purpose: the endpoint can then
+      surface a stable 200 shape when the caller supplied ``features=``
+      but every token was unknown / dropped.
+    * Unknown ids (not in :data:`ALL_FEATURES` after strip+lower) --
+      collected into ``unknown`` and dropped from the intersection so a
+      typo does not silently mis-route the ladder to Enterprise.
+    * Duplicates are de-duplicated preserving first-seen order (matches
+      :func:`_parse_csv_arg` on the endpoint side).
+    * All-known-free items -- ``tiers`` covers every tier in
+      :data:`_TIER_ORDER`, ``min_tier`` is :data:`TIER_OSS` (mirrors
+      :func:`min_tier_for_features`).
+    * Mixed -- ``tiers`` is the intersection of the per-item grant sets
+      (rank+id sorted for stable output); ``min_tier`` matches
+      :func:`min_tier_for_features` exactly.
+
+    Response shape::
+
+        {
+          "items":          ["fleet", "sso"],   # canonical known ids
+          "unknown":        ["bogus"],           # stripped+lowered ids
+          "kind":           "features",
+          "count":          <len(items)>,
+          "min_tier":       "enterprise" | None,
+          "min_tier_label": "Enterprise" | None,
+          "min_tier_rank":  <int> | None,
+          "tiers":          [<_tier_row>, ...],  # intersection ladder
+        }
+
+    Each entry in ``tiers`` matches the row shape used by
+    :func:`tiers_for_feature` (``id`` / ``label`` / ``rank`` /
+    ``purchasable``). ``min_tier`` is the cheapest *purchasable* tier
+    (trial excluded), matching :func:`min_tier_for_features`.
+
+    Never raises: a delegate failure surfaces as the empty shape so the
+    pricing UI keeps rendering.
+    """
+    try:
+        if features is None:
+            return None
+        items = list(features)
+    except TypeError:
+        return None
+    seen: set[str] = set()
+    known: list[str] = []
+    unknown: list[str] = []
+    for token in items:
+        raw = token if isinstance(token, str) else ""
+        canon = raw.strip().lower()
+        if canon and canon in ALL_FEATURES:
+            if canon not in seen:
+                seen.add(canon)
+                known.append(canon)
+        else:
+            unknown.append(canon)
+    try:
+        if not known:
+            min_t: str | None = None
+            tier_ids: list[str] = []
+        else:
+            common: set[str] | None = None
+            for fid in known:
+                carriers: set[str] = set()
+                is_free = fid in FREE_FEATURES
+                for tier in _TIER_ORDER:
+                    paid_feats = _TIER_FEATURES.get(tier, frozenset())
+                    if is_free or fid in paid_feats:
+                        carriers.add(tier)
+                common = carriers if common is None else (common & carriers)
+            tier_ids = sorted(common or set(), key=lambda t: (tier_rank(t), t))
+            min_t = min_tier_for_features(known)
+        rows = [_tier_row(t) for t in tier_ids]
+        return {
+            "items": known,
+            "unknown": unknown,
+            "kind": "features",
+            "count": len(known),
+            "min_tier": min_t,
+            "min_tier_label": tier_label(min_t) if min_t else None,
+            "min_tier_rank": tier_rank(min_t) if min_t else None,
+            "tiers": rows,
+        }
+    except Exception as exc:
+        logger.warning("entitlements: tiers_for_features failed: %s", exc)
+        return {
+            "items": known,
+            "unknown": unknown,
+            "kind": "features",
+            "count": len(known),
+            "min_tier": None,
+            "min_tier_label": None,
+            "min_tier_rank": None,
+            "tiers": [],
+        }
+
+
+def tiers_for_runtimes(runtimes) -> dict | None:
+    """Ladder-intersection sibling of :func:`min_tier_for_runtimes`:
+    the set of tiers that grant **every** supplied runtime at once,
+    wrapped in the same row shape a pricing-page component consumes off
+    :func:`tiers_for_runtime`.
+
+    Runtime-axis twin of :func:`tiers_for_features`. Semantics mirror
+    :func:`min_tier_for_runtimes` on input handling and
+    :func:`tiers_for_features` on shape:
+
+    * ``None`` / non-iterable -- returns ``None``. Never raises.
+    * Empty iterable -- returns the empty shape (``items=[]``,
+      ``tiers=[]``, ``min_tier=None``).
+    * Unknown ids (not in :data:`ALL_RUNTIMES` after
+      :func:`canonical_runtime`) -- collected into ``unknown`` and
+      dropped from the intersection.
+    * Aliases (``claude-code`` -> ``claude_code``) are canonicalised
+      through :func:`canonical_runtime` before intersection.
+    * Duplicates are de-duplicated preserving first-seen order after
+      canonicalisation.
+    * All-known-free items -- ``tiers`` covers every tier in
+      :data:`_TIER_ORDER` (:data:`FREE_RUNTIMES` are granted at every
+      tier); ``min_tier`` is :data:`TIER_OSS`.
+    * Mixed -- ``tiers`` is the intersection of the per-item grant sets;
+      ``min_tier`` matches :func:`min_tier_for_runtimes` exactly.
+
+    Response shape mirrors :func:`tiers_for_features` with
+    ``kind="runtimes"``.
+
+    Never raises: a delegate failure surfaces as the empty shape.
+    """
+    try:
+        if runtimes is None:
+            return None
+        items = list(runtimes)
+    except TypeError:
+        return None
+    seen: set[str] = set()
+    known: list[str] = []
+    unknown: list[str] = []
+    for token in items:
+        raw = token if isinstance(token, str) else ""
+        canon = canonical_runtime(raw)
+        if canon and canon in ALL_RUNTIMES:
+            if canon not in seen:
+                seen.add(canon)
+                known.append(canon)
+        else:
+            unknown.append(raw.strip().lower() if isinstance(raw, str) else "")
+    try:
+        if not known:
+            min_t: str | None = None
+            tier_ids: list[str] = []
+        else:
+            common: set[str] | None = None
+            for rt in known:
+                carriers: set[str] = set()
+                is_free = rt in FREE_RUNTIMES
+                is_paid = rt in PAID_RUNTIMES
+                for tier in _TIER_ORDER:
+                    if is_free:
+                        carriers.add(tier)
+                    elif is_paid and tier in _TIER_PAID_RUNTIMES:
+                        carriers.add(tier)
+                common = carriers if common is None else (common & carriers)
+            tier_ids = sorted(common or set(), key=lambda t: (tier_rank(t), t))
+            min_t = min_tier_for_runtimes(known)
+        rows = [_tier_row(t) for t in tier_ids]
+        return {
+            "items": known,
+            "unknown": unknown,
+            "kind": "runtimes",
+            "count": len(known),
+            "min_tier": min_t,
+            "min_tier_label": tier_label(min_t) if min_t else None,
+            "min_tier_rank": tier_rank(min_t) if min_t else None,
+            "tiers": rows,
+        }
+    except Exception as exc:
+        logger.warning("entitlements: tiers_for_runtimes failed: %s", exc)
+        return {
+            "items": known,
+            "unknown": unknown,
+            "kind": "runtimes",
+            "count": len(known),
+            "min_tier": None,
+            "min_tier_label": None,
+            "min_tier_rank": None,
+            "tiers": [],
+        }
+
+
 def tiers_for_batch_at(perspective_tier: str) -> dict | None:
     """Hypothetical-perspective sibling of :func:`tiers_for_batch`: full
     availability ladder for every known feature *and* runtime in one

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -20242,3 +20242,169 @@ def api_entitlement_tiers_for_capacity_batch():
                 "enforced": False,
             }
         )
+
+
+@bp_entitlement.route("/api/entitlement/tiers-for-features")
+def api_entitlement_tiers_for_features():
+    """``GET /api/entitlement/tiers-for-features?features=a,b,c`` --
+    ladder-intersection sibling of ``/api/entitlement/tiers-for``: the
+    set of tiers that grant **every** supplied feature at once, wrapped
+    in the same row shape a pricing-page component consumes off
+    ``/tiers-for?feature=<id>``.
+
+    Closes the ``tiers_for_*`` symmetry gap alongside the singular /
+    fixed-batch siblings: the caller-supplied-list shape had no plural
+    on the ladder axis, so a UI building the bundle-ladder off
+    ``/required-tier-batch?features=`` had to fan out one ``/tiers-for``
+    call per known id + intersect on the client. This wraps
+    :func:`clawmetry.entitlements.tiers_for_features` so the whole
+    "you use fleet + sso -- Available in: Enterprise" ladder lands in
+    one round-trip.
+
+    - **400** when ``features=`` is missing / blank after parsing
+      (empty string or all-empty tokens). All-unknown IS 200 with an
+      ``unknown`` list and empty ``tiers`` -- distinguishes "caller
+      asked for nothing" from "caller asked but every token was a typo"
+      so the paywall UI can render "these ids are unknown: X" instead
+      of a null.
+    - Blank / whitespace tokens are dropped; ids are lowercased and
+      de-duplicated preserving first-seen order (matches
+      ``_parse_csv_arg``).
+    - Unknown ids (not in ``ALL_FEATURES``) contribute nothing to the
+      intersection so a typo does NOT silently mis-route the ladder to
+      Enterprise. Every unknown id lands in the ``unknown`` list on the
+      response so the caller can echo them.
+    - Never 5xxs: a resolver failure yields the empty shape + the
+      grace-shape envelope so the pricing UI keeps rendering.
+
+    Response shape::
+
+        {
+          "items":             ["fleet", "sso"],
+          "unknown":           ["bogus"],
+          "kind":              "features",
+          "count":             2,
+          "min_tier":          "enterprise" | null,
+          "min_tier_label":    "Enterprise" | null,
+          "min_tier_rank":     <int> | null,
+          "tiers":             [<_tier_row>, ...],
+          "current_tier":      "...",
+          "current_tier_rank": <int>,
+          "grace":             <bool>,
+          "enforced":          <bool>,
+        }
+
+    Where ``<_tier_row>`` matches ``/api/entitlement/tiers-for`` exactly
+    (``id`` / ``label`` / ``rank`` / ``purchasable``). ``min_tier``
+    byte-equals ``/api/entitlement/required-tier-batch?features=<same>``
+    ``.required_tier`` for the same input (parity is the answer).
+    """
+    raw = request.args.get("features")
+    if raw is None or not raw.strip():
+        return jsonify({"error": "missing features"}), 400
+    features = _parse_csv_arg("features")
+    try:
+        from clawmetry import entitlements as _ent
+
+        body = _ent.tiers_for_features(features)
+        env = _resolver_envelope(_ent)
+        if body is None:
+            return jsonify(
+                {
+                    "items": [],
+                    "unknown": features,
+                    "kind": "features",
+                    "count": 0,
+                    "min_tier": None,
+                    "min_tier_label": None,
+                    "min_tier_rank": None,
+                    "tiers": [],
+                    **env,
+                }
+            )
+        return jsonify({**body, **env})
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_tiers_for_features: error: %s", exc
+        )
+        return jsonify(
+            {
+                "items": [],
+                "unknown": features,
+                "kind": "features",
+                "count": 0,
+                "min_tier": None,
+                "min_tier_label": None,
+                "min_tier_rank": None,
+                "tiers": [],
+                "current_tier": "oss",
+                "current_tier_rank": 0,
+                "grace": True,
+                "enforced": False,
+            }
+        )
+
+
+@bp_entitlement.route("/api/entitlement/tiers-for-runtimes")
+def api_entitlement_tiers_for_runtimes():
+    """``GET /api/entitlement/tiers-for-runtimes?runtimes=x,y,z`` --
+    runtime-axis twin of ``/api/entitlement/tiers-for-features``.
+
+    Wraps :func:`clawmetry.entitlements.tiers_for_runtimes`. Runtime
+    aliases (``claude-code`` -> ``claude_code``) are canonicalised
+    before intersection; input order is preserved after canonical
+    de-duplication so the response ``items`` list is stable.
+
+    - **400** when ``runtimes=`` is missing / blank after parsing.
+      All-unknown IS 200 with the ``unknown`` list populated (mirrors
+      ``/tiers-for-features``).
+    - Never 5xxs: a resolver failure yields the empty shape + the
+      grace-shape envelope.
+
+    Response shape mirrors ``/tiers-for-features`` with
+    ``kind="runtimes"``.
+    """
+    raw = request.args.get("runtimes")
+    if raw is None or not raw.strip():
+        return jsonify({"error": "missing runtimes"}), 400
+    runtimes = _parse_csv_arg("runtimes")
+    try:
+        from clawmetry import entitlements as _ent
+
+        body = _ent.tiers_for_runtimes(runtimes)
+        env = _resolver_envelope(_ent)
+        if body is None:
+            return jsonify(
+                {
+                    "items": [],
+                    "unknown": runtimes,
+                    "kind": "runtimes",
+                    "count": 0,
+                    "min_tier": None,
+                    "min_tier_label": None,
+                    "min_tier_rank": None,
+                    "tiers": [],
+                    **env,
+                }
+            )
+        return jsonify({**body, **env})
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_tiers_for_runtimes: error: %s", exc
+        )
+        return jsonify(
+            {
+                "items": [],
+                "unknown": runtimes,
+                "kind": "runtimes",
+                "count": 0,
+                "min_tier": None,
+                "min_tier_label": None,
+                "min_tier_rank": None,
+                "tiers": [],
+                "current_tier": "oss",
+                "current_tier_rank": 0,
+                "grace": True,
+                "enforced": False,
+            }
+        )

--- a/tests/test_entitlement_tiers_for_plural.py
+++ b/tests/test_entitlement_tiers_for_plural.py
@@ -1,0 +1,513 @@
+"""Tests for ``clawmetry.entitlements.tiers_for_features`` /
+``tiers_for_runtimes`` + the matching HTTP wrappers
+``GET /api/entitlement/tiers-for-features`` /
+``GET /api/entitlement/tiers-for-runtimes``.
+
+Ladder-intersection sibling of :func:`min_tier_for_features` /
+:func:`min_tier_for_runtimes`: where the ``min_tier_for_*`` plurals
+collapse a caller-supplied bundle to a single ``min_tier`` id, the
+``tiers_for_*`` plurals return the *full* ladder of tiers that grant
+every supplied item at once. Closes the ``tiers_for_*`` symmetry gap
+alongside the singular / fixed-batch siblings.
+
+These tests pin:
+
+* the intersection ladder matches the singular ``tiers_for_*`` grant
+  sets (set-intersection is the answer)
+* ``min_tier`` matches the existing ``min_tier_for_features`` /
+  ``min_tier_for_runtimes`` helpers byte-for-byte (consistency
+  invariant)
+* unknown ids never mis-route the ladder to Enterprise -- they land in
+  ``unknown`` and drop from the intersection
+* runtime aliases (``claude-code`` -> ``claude_code``) canonicalise
+* the endpoints reject missing/blank ``features=`` / ``runtimes=``
+  cleanly and never 5xx
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# ── shape ─────────────────────────────────────────────────────────────────
+
+
+def test_features_returns_full_shape(ent):
+    body = ent.tiers_for_features(["fleet", "sso"])
+    assert body is not None
+    assert set(body.keys()) == {
+        "items",
+        "unknown",
+        "kind",
+        "count",
+        "min_tier",
+        "min_tier_label",
+        "min_tier_rank",
+        "tiers",
+    }
+    assert body["kind"] == "features"
+
+
+def test_runtimes_returns_full_shape(ent):
+    body = ent.tiers_for_runtimes(["claude_code", "codex"])
+    assert body is not None
+    assert set(body.keys()) == {
+        "items",
+        "unknown",
+        "kind",
+        "count",
+        "min_tier",
+        "min_tier_label",
+        "min_tier_rank",
+        "tiers",
+    }
+    assert body["kind"] == "runtimes"
+
+
+def test_tier_rows_have_expected_keys(ent):
+    body = ent.tiers_for_features(["fleet"])
+    assert body["tiers"], "paid feature must list at least one tier"
+    for row in body["tiers"]:
+        assert set(row.keys()) == {"id", "label", "rank", "purchasable"}
+
+
+def test_tier_rows_sorted_by_rank_then_id(ent):
+    body = ent.tiers_for_features(["fleet"])
+    ranks = [(r["rank"], r["id"]) for r in body["tiers"]]
+    assert ranks == sorted(ranks)
+
+
+# ── intersection semantics ────────────────────────────────────────────────
+
+
+def test_features_ladder_is_intersection_of_singular_rows(ent):
+    ids = ["fleet", "self_evolve"]
+    body = ent.tiers_for_features(ids)
+    common = None
+    for fid in ids:
+        s = {row["id"] for row in ent.tiers_for_feature(fid)["tiers"]}
+        common = s if common is None else common & s
+    assert {row["id"] for row in body["tiers"]} == common
+
+
+def test_runtimes_ladder_is_intersection_of_singular_rows(ent):
+    ids = ["claude_code", "codex", "openclaw"]
+    body = ent.tiers_for_runtimes(ids)
+    common = None
+    for rid in ids:
+        s = {row["id"] for row in ent.tiers_for_runtime(rid)["tiers"]}
+        common = s if common is None else common & s
+    assert {row["id"] for row in body["tiers"]} == common
+
+
+def test_single_feature_ladder_matches_singular(ent):
+    body = ent.tiers_for_features(["fleet"])
+    singular = ent.tiers_for_feature("fleet")
+    assert {r["id"] for r in body["tiers"]} == {
+        r["id"] for r in singular["tiers"]
+    }
+
+
+def test_single_runtime_ladder_matches_singular(ent):
+    body = ent.tiers_for_runtimes(["claude_code"])
+    singular = ent.tiers_for_runtime("claude_code")
+    assert {r["id"] for r in body["tiers"]} == {
+        r["id"] for r in singular["tiers"]
+    }
+
+
+# ── min_tier consistency ──────────────────────────────────────────────────
+
+
+def test_min_tier_matches_min_tier_for_features(ent):
+    inputs = [
+        ["fleet"],
+        ["fleet", "self_evolve"],
+        ["fleet", "self_evolve", "sso"],
+        ["sessions"],  # all free
+        ["sessions", "fleet"],  # mixed free + paid
+    ]
+    for bundle in inputs:
+        body = ent.tiers_for_features(bundle)
+        assert body["min_tier"] == ent.min_tier_for_features(bundle), bundle
+
+
+def test_min_tier_matches_min_tier_for_runtimes(ent):
+    inputs = [
+        ["openclaw"],
+        ["claude_code"],
+        ["claude_code", "codex"],
+        ["openclaw", "claude_code"],  # mixed free + paid
+    ]
+    for bundle in inputs:
+        body = ent.tiers_for_runtimes(bundle)
+        assert body["min_tier"] == ent.min_tier_for_runtimes(bundle), bundle
+
+
+# ── all-free bundles ──────────────────────────────────────────────────────
+
+
+def test_all_free_features_intersect_to_every_tier(ent):
+    body = ent.tiers_for_features(["sessions"])
+    assert body["min_tier"] == ent.TIER_OSS
+    assert {r["id"] for r in body["tiers"]} == set(ent._TIER_ORDER)
+
+
+def test_all_free_runtimes_intersect_to_every_tier(ent):
+    body = ent.tiers_for_runtimes(["openclaw", "nemoclaw"])
+    assert body["min_tier"] == ent.TIER_OSS
+    assert {r["id"] for r in body["tiers"]} == set(ent._TIER_ORDER)
+
+
+# ── enterprise-only feature narrows the intersection ──────────────────────
+
+
+def test_enterprise_feature_narrows_intersection_to_enterprise(ent):
+    body = ent.tiers_for_features(["fleet", "sso"])
+    # ``sso`` is enterprise-only -> the intersection collapses to
+    # {enterprise} regardless of what other paid features are stacked in.
+    assert {r["id"] for r in body["tiers"]} == {ent.TIER_ENTERPRISE}
+    assert body["min_tier"] == ent.TIER_ENTERPRISE
+
+
+# ── input handling: unknown / dedup / alias ───────────────────────────────
+
+
+def test_unknown_feature_lands_in_unknown_and_drops_from_intersection(ent):
+    body = ent.tiers_for_features(["fleet", "bogus"])
+    assert "bogus" in body["unknown"]
+    assert body["items"] == ["fleet"]
+    # unknown must NOT mis-route the ladder to Enterprise
+    assert body["min_tier"] == ent.min_tier_for_feature("fleet")
+
+
+def test_unknown_runtime_lands_in_unknown_and_drops_from_intersection(ent):
+    body = ent.tiers_for_runtimes(["claude_code", "not_a_runtime"])
+    assert "not_a_runtime" in body["unknown"]
+    assert body["items"] == ["claude_code"]
+    assert body["min_tier"] == ent.min_tier_for_runtime("claude_code")
+
+
+def test_all_unknown_features_returns_empty_shape(ent):
+    body = ent.tiers_for_features(["nope1", "nope2"])
+    assert body["items"] == []
+    assert body["unknown"] == ["nope1", "nope2"]
+    assert body["tiers"] == []
+    assert body["min_tier"] is None
+    assert body["count"] == 0
+
+
+def test_all_unknown_runtimes_returns_empty_shape(ent):
+    body = ent.tiers_for_runtimes(["nope1", "nope2"])
+    assert body["items"] == []
+    assert body["unknown"] == ["nope1", "nope2"]
+    assert body["tiers"] == []
+    assert body["min_tier"] is None
+    assert body["count"] == 0
+
+
+def test_features_dedup_preserves_first_seen_order(ent):
+    body = ent.tiers_for_features(["fleet", "self_evolve", "fleet"])
+    assert body["items"] == ["fleet", "self_evolve"]
+
+
+def test_runtimes_dedup_preserves_first_seen_order(ent):
+    body = ent.tiers_for_runtimes(["claude_code", "codex", "claude_code"])
+    assert body["items"] == ["claude_code", "codex"]
+
+
+def test_runtime_alias_canonicalises(ent):
+    body = ent.tiers_for_runtimes(["claude-code"])
+    assert body["items"] == ["claude_code"]
+    # min_tier matches the canonical singular
+    assert body["min_tier"] == ent.min_tier_for_runtime("claude_code")
+
+
+def test_features_case_and_whitespace_normalised(ent):
+    body = ent.tiers_for_features(["  FLEET  ", "Self_Evolve"])
+    assert body["items"] == ["fleet", "self_evolve"]
+
+
+# ── safety: never raise, well-defined None/empty ──────────────────────────
+
+
+def test_features_none_returns_none(ent):
+    assert ent.tiers_for_features(None) is None
+
+
+def test_runtimes_none_returns_none(ent):
+    assert ent.tiers_for_runtimes(None) is None
+
+
+def test_features_non_iterable_returns_none(ent):
+    assert ent.tiers_for_features(42) is None  # type: ignore[arg-type]
+
+
+def test_runtimes_non_iterable_returns_none(ent):
+    assert ent.tiers_for_runtimes(42) is None  # type: ignore[arg-type]
+
+
+def test_features_empty_returns_empty_shape(ent):
+    body = ent.tiers_for_features([])
+    assert body is not None
+    assert body["items"] == []
+    assert body["tiers"] == []
+    assert body["min_tier"] is None
+    assert body["count"] == 0
+
+
+def test_runtimes_empty_returns_empty_shape(ent):
+    body = ent.tiers_for_runtimes([])
+    assert body is not None
+    assert body["items"] == []
+    assert body["tiers"] == []
+    assert body["min_tier"] is None
+    assert body["count"] == 0
+
+
+def test_features_non_string_tokens_land_in_unknown(ent):
+    body = ent.tiers_for_features([None, 42, "fleet"])  # type: ignore[list-item]
+    assert body["items"] == ["fleet"]
+    # Non-string tokens count as unknown but never crash.
+    assert len(body["unknown"]) == 2
+
+
+# ── grace vs enforce (rows are perspective-independent) ───────────────────
+
+
+def test_grace_vs_enforce_ladder_is_identical(ent, monkeypatch):
+    body_grace = ent.tiers_for_features(["fleet", "self_evolve"])
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    body_enforce = ent.tiers_for_features(["fleet", "self_evolve"])
+    assert body_grace == body_enforce
+
+
+# ── does not mutate the live entitlement ──────────────────────────────────
+
+
+def test_call_does_not_mutate_live_entitlement(ent):
+    before = ent.get_entitlement().tier
+    ent.tiers_for_features(["fleet", "sso"])
+    ent.tiers_for_runtimes(["claude_code", "codex"])
+    after = ent.get_entitlement().tier
+    assert before == after
+
+
+# ── API: happy path ───────────────────────────────────────────────────────
+
+
+def _envelope_keys():
+    return {"current_tier", "current_tier_rank", "grace", "enforced"}
+
+
+def _body_keys():
+    return {
+        "items",
+        "unknown",
+        "kind",
+        "count",
+        "min_tier",
+        "min_tier_label",
+        "min_tier_rank",
+        "tiers",
+    }
+
+
+def test_features_api_happy_path(client):
+    r = client.get("/api/entitlement/tiers-for-features?features=fleet,sso")
+    assert r.status_code == 200
+    data = r.get_json()
+    assert set(data.keys()) == _body_keys() | _envelope_keys()
+    assert data["items"] == ["fleet", "sso"]
+    assert data["kind"] == "features"
+    # sso is enterprise-only -> intersection collapses to {enterprise}
+    assert {row["id"] for row in data["tiers"]} == {"enterprise"}
+
+
+def test_runtimes_api_happy_path(client):
+    r = client.get(
+        "/api/entitlement/tiers-for-runtimes?runtimes=claude_code,codex"
+    )
+    assert r.status_code == 200
+    data = r.get_json()
+    assert set(data.keys()) == _body_keys() | _envelope_keys()
+    assert data["items"] == ["claude_code", "codex"]
+    assert data["kind"] == "runtimes"
+
+
+def test_features_api_alias_and_case(client):
+    r = client.get(
+        "/api/entitlement/tiers-for-features?features=%20FLEET%20,Self_Evolve"
+    )
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data["items"] == ["fleet", "self_evolve"]
+
+
+def test_runtimes_api_alias(client):
+    r = client.get(
+        "/api/entitlement/tiers-for-runtimes?runtimes=claude-code"
+    )
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data["items"] == ["claude_code"]
+
+
+def test_features_api_dedup(client):
+    r = client.get(
+        "/api/entitlement/tiers-for-features?features=fleet,fleet,self_evolve"
+    )
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data["items"] == ["fleet", "self_evolve"]
+
+
+# ── API: error paths ─────────────────────────────────────────────────────
+
+
+def test_features_api_missing_400(client):
+    r = client.get("/api/entitlement/tiers-for-features")
+    assert r.status_code == 400
+    assert "features" in r.get_json().get("error", "").lower()
+
+
+def test_features_api_blank_400(client):
+    r = client.get("/api/entitlement/tiers-for-features?features=%20%20")
+    assert r.status_code == 400
+
+
+def test_runtimes_api_missing_400(client):
+    r = client.get("/api/entitlement/tiers-for-runtimes")
+    assert r.status_code == 400
+    assert "runtimes" in r.get_json().get("error", "").lower()
+
+
+def test_runtimes_api_blank_400(client):
+    r = client.get("/api/entitlement/tiers-for-runtimes?runtimes=%20%20")
+    assert r.status_code == 400
+
+
+# ── API: all-unknown IS 200 (echo the unknown list) ──────────────────────
+
+
+def test_features_api_all_unknown_is_200(client):
+    r = client.get(
+        "/api/entitlement/tiers-for-features?features=bogus1,bogus2"
+    )
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data["items"] == []
+    assert set(data["unknown"]) == {"bogus1", "bogus2"}
+    assert data["tiers"] == []
+    assert data["min_tier"] is None
+
+
+def test_runtimes_api_all_unknown_is_200(client):
+    r = client.get(
+        "/api/entitlement/tiers-for-runtimes?runtimes=bogus1,bogus2"
+    )
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data["items"] == []
+    assert set(data["unknown"]) == {"bogus1", "bogus2"}
+    assert data["tiers"] == []
+    assert data["min_tier"] is None
+
+
+# ── API: min_tier parity with /required-tier-batch ───────────────────────
+
+
+def test_features_api_min_tier_matches_required_tier_batch(client):
+    a = client.get("/api/entitlement/tiers-for-features?features=fleet,sso")
+    b = client.get(
+        "/api/entitlement/required-tier-batch?features=fleet,sso"
+    )
+    assert a.status_code == 200 and b.status_code == 200
+    assert a.get_json()["min_tier"] == b.get_json()["required_tier"]
+
+
+def test_runtimes_api_min_tier_matches_required_tier_batch(client):
+    a = client.get(
+        "/api/entitlement/tiers-for-runtimes?runtimes=claude_code,codex"
+    )
+    b = client.get(
+        "/api/entitlement/required-tier-batch?runtimes=claude_code,codex"
+    )
+    assert a.status_code == 200 and b.status_code == 200
+    assert a.get_json()["min_tier"] == b.get_json()["required_tier"]
+
+
+# ── API: envelope shape ──────────────────────────────────────────────────
+
+
+def test_envelope_present_on_features_endpoint(client):
+    r = client.get("/api/entitlement/tiers-for-features?features=fleet")
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data["current_tier"] == "oss"
+    assert data["current_tier_rank"] == 0
+    assert data["grace"] is True
+
+
+def test_envelope_present_on_runtimes_endpoint(client):
+    r = client.get(
+        "/api/entitlement/tiers-for-runtimes?runtimes=claude_code"
+    )
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data["current_tier"] == "oss"
+    assert data["current_tier_rank"] == 0
+    assert data["grace"] is True
+
+
+# ── cross-endpoint parity: singular vs plural for a one-item bundle ──────
+
+
+def test_features_singleton_parity_with_singular_endpoint(client):
+    plural = client.get(
+        "/api/entitlement/tiers-for-features?features=fleet"
+    ).get_json()
+    singular = client.get(
+        "/api/entitlement/tiers-for?feature=fleet"
+    ).get_json()
+    assert {r["id"] for r in plural["tiers"]} == {
+        r["id"] for r in singular["tiers"]
+    }
+    assert plural["min_tier"] == singular["min_tier"]
+
+
+def test_runtimes_singleton_parity_with_singular_endpoint(client):
+    plural = client.get(
+        "/api/entitlement/tiers-for-runtimes?runtimes=claude_code"
+    ).get_json()
+    singular = client.get(
+        "/api/entitlement/tiers-for?runtime=claude_code"
+    ).get_json()
+    assert {r["id"] for r in plural["tiers"]} == {
+        r["id"] for r in singular["tiers"]
+    }
+    assert plural["min_tier"] == singular["min_tier"]


### PR DESCRIPTION
## Summary

- Adds `tiers_for_features(features)` and `tiers_for_runtimes(runtimes)` -- ladder-intersection siblings of `min_tier_for_features` / `min_tier_for_runtimes`: the set of tiers that grant **every** supplied item at once, wrapped in the row shape a pricing-page component consumes off `tiers_for_feature` / `tiers_for_runtime`.
- Adds `GET /api/entitlement/tiers-for-features?features=csv` and `GET /api/entitlement/tiers-for-runtimes?runtimes=csv` -- 400 on missing/blank, all-unknown IS 200 with the `unknown` list populated + empty `tiers`. Uses the existing `_parse_csv_arg` helper so dedup/normalisation matches `/required-tier-batch` byte-for-byte.
- Grace-mode change only -- no behaviour change on any existing surface, no `__version__` bump, no `[RELEASE]` PR, no gate enforced.

## Why

`tiers_for_feature` / `tiers_for_runtime` / `tiers_for_batch` / `tiers_for_*_at` / `tiers_for_batch_at` / `tiers_for_channel_count` / `tiers_for_retention_window` / `tiers_for_node_count` / `tiers_for_capacity_batch` cover the singular, fixed-batch, hypothetical-perspective, and per-axis capacity slots on the `tiers_for_*` family. The **caller-supplied-list** slot on the grant axes was the missing piece: a UI building the bundle-ladder ("you use fleet + sso -- Available in: Enterprise") off `/required-tier-batch?features=fleet,sso` had `.required_tier` but no full ladder to render "Available in: [...]" -- it had to fan out one `/tiers-for` call per known id and intersect the grant sets client-side. This PR closes that gap so the whole ladder-for-a-bundle lands in one round-trip and every surface can call `/tiers-for-<axis>?<axis>=csv` uniformly.

## Changes

### `clawmetry/entitlements.py`

- `tiers_for_features(features)` -- intersection of per-feature grant sets across the known-ids in the bundle; dedup preserves first-seen order; unknown ids land in `unknown` and drop from the intersection (a typo does NOT silently mis-route the ladder to Enterprise). Empty iterable returns the empty shape (`items=[]`, `tiers=[]`, `min_tier=None`); `None` / non-iterable returns `None`. Never raises. `min_tier` byte-equals `min_tier_for_features` for the same input.
- `tiers_for_runtimes(runtimes)` -- runtime-axis twin; canonicalises aliases (`claude-code` -> `claude_code`) through `canonical_runtime` before intersection. Same shape / posture as the features helper with `kind="runtimes"`.

Response shape:

```json
{
  "items":          ["fleet", "sso"],
  "unknown":        ["bogus"],
  "kind":           "features",
  "count":          2,
  "min_tier":       "enterprise",
  "min_tier_label": "Enterprise",
  "min_tier_rank":  <int>,
  "tiers":          [<_tier_row>, ...]
}
```

Each entry in `tiers` matches the `_tier_row` shape used by `tiers_for_feature` (`id` / `label` / `rank` / `purchasable`) so callers can pass rows to existing components without reshaping.

### `routes/entitlement.py`

- `GET /api/entitlement/tiers-for-features?features=a,b,c` -- 400 on missing / blank; **all-unknown IS 200** with `unknown` populated and empty `tiers` (distinguishes "caller asked for nothing" from "caller asked but every token was a typo" so the paywall UI can render "these ids are unknown: X" instead of a null). Wraps the helper in a `try` / `except` so a resolver crash falls back to a grace-shape envelope + empty rows instead of a 5xx.
- `GET /api/entitlement/tiers-for-runtimes?runtimes=x,y,z` -- runtime twin.
- Both endpoints stack the standard resolver envelope (`current_tier` / `current_tier_rank` / `grace` / `enforced`) on top of the helper body, matching every other `tiers_for_*` endpoint on the family.

### `tests/test_entitlement_tiers_for_plural.py`

**47 tests, all green** (1.35s):

- shape parity with the singular `tiers_for_*` row shape + `unknown` / `count` additions
- intersection semantics: ladder equals the set-intersection of `tiers_for_feature(f).tiers` / `tiers_for_runtime(rt).tiers` across known items
- singleton parity: `tiers_for_features(["fleet"])` -> same tier ids as `tiers_for_feature("fleet")`
- `min_tier` byte-equals `min_tier_for_features` / `min_tier_for_runtimes` across empty / all-free / mixed / paid / enterprise-only bundles
- all-free bundle covers every tier (`_TIER_ORDER`); enterprise-only feature narrows to `{enterprise}` even when stacked with lower-tier features
- unknown ids land in `unknown` and drop from the intersection (a typo does NOT mis-route the ladder to Enterprise)
- dedup preserves first-seen order (matches `_parse_csv_arg`); case + whitespace normalised; runtime aliases canonicalised
- safety: `None` / non-iterable -> `None`; empty iterable -> empty shape (not `None`); non-string tokens land in `unknown` and never crash
- grace vs enforce yields byte-identical rows (parity test); does-not-mutate the live entitlement
- API happy paths (single + multi item; case + alias + dedup)
- API error paths (400 missing / blank on both endpoints; all-unknown IS 200 with `unknown` populated)
- API `min_tier` byte-equals `/required-tier-batch?features=<same>` / `?runtimes=<same>` (`.required_tier`) -- cross-endpoint parity so the paywall CTA and the ladder cannot silently disagree
- singleton parity across endpoints: `/tiers-for-features?features=fleet` -> same tier ids + `min_tier` as `/tiers-for?feature=fleet`

## Test plan

- [x] `python3 -m py_compile clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_tiers_for_plural.py` -- clean
- [x] `ruff check clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_tiers_for_plural.py` -- clean
- [x] `pytest tests/test_entitlement_tiers_for_plural.py -v` -> **47/47 pass** in 1.35s
- [x] Sibling test files (`test_entitlement_tiers_for.py`, `test_entitlement_tiers_for_batch.py`, `test_entitlement_tiers_for_capacity.py`, `test_entitlement_api.py`, `test_blueprint_uniqueness.py`, `test_circular_import.py`) still green -- **155/155 pass**

## Local operator verification checklist

I can't touch the running daemon, `~/.openclaw`, the live snapshot, or a browser from here -- please run:

- [ ] Copy the two changed files into `~/.clawmetry/lib/python3.11/site-packages/clawmetry/` (`entitlements.py`) and `~/.clawmetry/lib/python3.11/site-packages/routes/` (`entitlement.py`); drop the test file into the local checkout under `tests/`
- [ ] Clear `__pycache__` on both dirs
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
- [ ] `curl -s 'http://localhost:8900/api/entitlement/tiers-for-features?features=fleet,sso' | jq .` -- expect `items=["fleet","sso"]`, `min_tier="enterprise"`, `tiers[]` narrowed to `{enterprise}` (sso is enterprise-only), plus the resolver envelope
- [ ] `curl -s 'http://localhost:8900/api/entitlement/tiers-for-features?features=fleet,bogus' | jq .` -- expect `items=["fleet"]`, `unknown=["bogus"]`, `tiers[]` covering trial+starter+cloud_pro+pro+enterprise
- [ ] `curl -s 'http://localhost:8900/api/entitlement/tiers-for-runtimes?runtimes=claude-code,codex' | jq .` -- expect `items=["claude_code","codex"]` (alias canonicalised), `min_tier="cloud_starter"` (paid runtimes are granted at every paid tier)
- [ ] `curl -s -o /dev/null -w '%{http_code}\n' 'http://localhost:8900/api/entitlement/tiers-for-features'` -> `400`
- [ ] `curl -s -o /dev/null -w '%{http_code}\n' 'http://localhost:8900/api/entitlement/tiers-for-runtimes?runtimes=%20%20'` -> `400`
- [ ] `curl -s 'http://localhost:8900/api/entitlement/tiers-for-features?features=bogus1,bogus2' | jq .` -- expect 200 with `items=[]`, `unknown=["bogus1","bogus2"]`, `tiers=[]`, `min_tier=null`
- [ ] Cross-check `min_tier` against `/api/entitlement/required-tier-batch?features=<same>` / `?runtimes=<same>` -- must byte-equal `.required_tier`
- [ ] Cross-check singleton parity: `/tiers-for-features?features=fleet` -> same tier ids + `min_tier` as `/tiers-for?feature=fleet`
- [ ] Decrypt the live cloud snapshot and hit the same endpoints against the cloud read-through path
- [ ] Browser check: any surface currently calling `/tiers-for` / `/tiers-for-batch` should keep rendering; nothing should call the new `/tiers-for-features` / `/tiers-for-runtimes` routes yet

No `__version__` bump, no tag, no `[RELEASE]` PR -- staying in DRAFT until you've cleared local + cloud verification.

## MOAT / release checklist

- Not a MOAT fast-path change (no `local_store_via_daemon` / `_ls_call` / `_DAEMON_METHODS` touched).
- Not a `[RELEASE]` PR.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ar5hGUAT8qZuBThGKHmBGd)_