### PR TITLE
feat(entitlement): tiers_for_*_capacity_*_at + /api/entitlement/tiers-for-*-at (capacity axes)

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -16703,3 +16703,181 @@ def tiers_for_capacity_batch(
             "retention_days": None,
             "nodes": None,
         }
+
+
+def tiers_for_channel_count_at(
+    perspective_tier: str, count: int
+) -> dict | None:
+    """Hypothetical-perspective sibling of :func:`tiers_for_channel_count`:
+    full availability ladder for a ``count`` channel-adapter capacity value,
+    scoped by a caller-supplied ``perspective_tier``.
+
+    Fills the ``_at`` slot on the channel-count capacity axis alongside
+    :func:`tiers_for_feature_at` / :func:`tiers_for_runtime_at` /
+    :func:`tiers_for_batch_at`, so a pricing-matrix walkthrough can call
+    ``X_at(perspective, ...)`` uniformly across every ``_at`` sibling in
+    the ``tiers_for_*`` family.
+
+    Perspective is validated against :data:`_TIER_ORDER` (including
+    :data:`TIER_TRIAL`) but does NOT shape rows -- the ladder is
+    intrinsically perspective-independent (walks the static
+    :data:`_TIER_CHANNEL_LIMIT` table), exactly like
+    :func:`tiers_for_feature_at`. A parity test pins
+    ``tiers_for_channel_count_at(p, n) == tiers_for_channel_count(n)`` for
+    every ``p`` in :data:`_TIER_ORDER` so the ``_at`` prefix cannot
+    silently drift into shaping rows.
+
+    Row shape and ordering mirror :func:`tiers_for_channel_count`
+    exactly. ``min_tier`` matches :func:`min_tier_for_channel_count`.
+
+    Returns ``None`` for empty / unknown ``perspective_tier`` (caller
+    renders "unknown tier" / 404) and for non-int ``count``. Decoupled
+    from the resolved entitlement (delegates to
+    :func:`tiers_for_channel_count`), so grace vs enforce yields byte-
+    identical rows. Never raises.
+    """
+    try:
+        p = (perspective_tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if not p or p not in _TIER_ORDER:
+        return None
+    try:
+        return tiers_for_channel_count(count)
+    except Exception as exc:
+        logger.warning(
+            "entitlements: tiers_for_channel_count_at failed: %s", exc
+        )
+        return None
+
+
+def tiers_for_retention_window_at(
+    perspective_tier: str, days: int | None
+) -> dict | None:
+    """Hypothetical-perspective sibling of :func:`tiers_for_retention_window`:
+    full availability ladder for a ``days`` event-retention window, scoped
+    by a caller-supplied ``perspective_tier``.
+
+    Retention-axis twin of :func:`tiers_for_channel_count_at`. Perspective
+    is validated against :data:`_TIER_ORDER` (including
+    :data:`TIER_TRIAL`) but does NOT shape rows. Row shape mirrors
+    :func:`tiers_for_retention_window` exactly.
+
+    Accepts the explicit ``days=None`` "unlimited" sentinel that the
+    singular helper accepts -- delegates without further parsing, so the
+    same "None means unlimited on this axis" semantics carry through
+    unchanged. Non-int (non-``None``) ``days`` yields ``None`` (matches
+    the singular helper's posture on bad input rather than mis-routing
+    to Enterprise).
+
+    Returns ``None`` for empty / unknown ``perspective_tier`` (caller
+    renders "unknown tier" / 404). Never raises.
+    """
+    try:
+        p = (perspective_tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if not p or p not in _TIER_ORDER:
+        return None
+    try:
+        return tiers_for_retention_window(days)
+    except Exception as exc:
+        logger.warning(
+            "entitlements: tiers_for_retention_window_at failed: %s", exc
+        )
+        return None
+
+
+def tiers_for_node_count_at(
+    perspective_tier: str, count: int
+) -> dict | None:
+    """Hypothetical-perspective sibling of :func:`tiers_for_node_count`:
+    full availability ladder for a ``count`` registered-nodes capacity
+    value, scoped by a caller-supplied ``perspective_tier``.
+
+    Node-axis twin of :func:`tiers_for_channel_count_at`. Perspective is
+    validated against :data:`_TIER_ORDER` (including :data:`TIER_TRIAL`)
+    but does NOT shape rows. Row shape mirrors
+    :func:`tiers_for_node_count` exactly.
+
+    Returns ``None`` for empty / unknown ``perspective_tier`` (caller
+    renders "unknown tier" / 404) and for non-int ``count``. Never
+    raises.
+    """
+    try:
+        p = (perspective_tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if not p or p not in _TIER_ORDER:
+        return None
+    try:
+        return tiers_for_node_count(count)
+    except Exception as exc:
+        logger.warning(
+            "entitlements: tiers_for_node_count_at failed: %s", exc
+        )
+        return None
+
+
+def tiers_for_capacity_batch_at(
+    perspective_tier: str,
+    *,
+    channels: int | None = None,
+    retention_days: int | None = None,
+    nodes: int | None = None,
+) -> dict | None:
+    """Hypothetical-perspective sibling of
+    :func:`tiers_for_capacity_batch`: per-item availability ladder for
+    every supplied capacity axis in one pass, scoped by a caller-supplied
+    ``perspective_tier``.
+
+    Fills the last ``_at`` slot in the ``tiers_for_*`` family alongside
+    :func:`tiers_for_batch_at` (grant-axis batch) and the three per-axis
+    ``tiers_for_*_at`` siblings, so a pricing-matrix walkthrough can
+    hit every ``tiers_for_*`` shape uniformly at a fixed perspective.
+
+    Perspective is validated against :data:`_TIER_ORDER` (including
+    :data:`TIER_TRIAL`) but does NOT shape rows -- the batch is
+    identical to :func:`tiers_for_capacity_batch` regardless of
+    perspective (pinned by a parity test).
+
+    Envelope shape mirrors :func:`tiers_for_capacity_batch` exactly::
+
+        {
+          "channels":       <row> | None,
+          "retention_days": <row> | None,
+          "nodes":          <row> | None,
+        }
+
+    Critically, ``retention_days=None`` here means *unset* -- NOT
+    *unlimited* (matches :func:`tiers_for_capacity_batch` /
+    :func:`min_tier_batch` on the same axis). Asking for the
+    unlimited-retention ladder at a hypothetical perspective is
+    :func:`tiers_for_retention_window_at` (``days=None``) call's job.
+
+    Returns ``None`` for empty / unknown ``perspective_tier`` (caller
+    renders "unknown tier" / 404). Never raises: a delegate failure
+    surfaces as an all-``None`` envelope shape (same posture as
+    :func:`tiers_for_capacity_batch`).
+    """
+    try:
+        p = (perspective_tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if not p or p not in _TIER_ORDER:
+        return None
+    try:
+        return tiers_for_capacity_batch(
+            channels=channels,
+            retention_days=retention_days,
+            nodes=nodes,
+        )
+    except Exception as exc:
+        logger.warning(
+            "entitlements: tiers_for_capacity_batch_at failed: %s", exc
+        )
+        return {
+            "channels": None,
+            "retention_days": None,
+            "nodes": None,
+        }

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -20408,3 +20408,303 @@ def api_entitlement_tiers_for_runtimes():
                 "enforced": False,
             }
         )
+
+
+# ── capacity-axis tiers-for-*-at endpoints ───────────────────────────────────
+#
+# Hypothetical-perspective siblings of the four capacity-axis ``tiers_for_*``
+# endpoints above. Fill the ``_at`` slot on the capacity family alongside
+# ``/api/entitlement/tiers-for-at`` / ``/tiers-for-batch-at`` on the grant
+# axes, so a pricing-matrix walkthrough can call every ``/tiers-for-*-at``
+# endpoint with a uniform ``tier=<perspective>`` URL. The ladder itself is
+# perspective-independent (walks the static per-tier caps via the singular
+# helpers) so parity with the non-``_at`` sibling is pinned in the test suite.
+
+
+def _perspective_envelope(_ent, p: str) -> dict:
+    ent = _ent.get_entitlement()
+    return {
+        "perspective_tier": p,
+        "perspective_tier_label": _ent.tier_label(p),
+        "perspective_tier_rank": _ent.tier_rank(p),
+        "current_tier": ent.tier,
+        "current_tier_rank": _ent.tier_rank(ent.tier),
+        "grace": bool(ent.grace),
+        "enforced": _ent.is_enforced(),
+    }
+
+
+def _perspective_fallback(p: str) -> dict:
+    try:
+        from clawmetry import entitlements as _ent
+
+        label = _ent.tier_label(p)
+        rank = _ent.tier_rank(p)
+    except Exception:
+        label = p
+        rank = 0
+    return {
+        "perspective_tier": p,
+        "perspective_tier_label": label,
+        "perspective_tier_rank": rank,
+        "current_tier": "oss",
+        "current_tier_rank": 0,
+        "grace": True,
+        "enforced": False,
+    }
+
+
+@bp_entitlement.route("/api/entitlement/tiers-for-channel-count-at")
+def api_entitlement_tiers_for_channel_count_at():
+    """``GET /api/entitlement/tiers-for-channel-count-at?tier=<perspective>
+    &count=<int>`` -- hypothetical-perspective sibling of
+    ``/api/entitlement/tiers-for-channel-count``: returns the full ladder
+    of tiers admitting ``count`` configured channel adapters, scoped by a
+    caller-supplied ``perspective_tier``.
+
+    Perspective is validated against ``_TIER_ORDER`` (``trial``
+    accepted) but does NOT shape rows -- the ladder is intrinsically
+    perspective-independent (walks the static per-tier channel-cap
+    table). The ``perspective_tier`` envelope keeps every ``_at`` URL
+    uniform across the ``tiers_for_*`` family.
+
+    Missing / blank ``tier=`` -> ``400``. Unknown ``tier=`` -> ``404``
+    (``which=tier``). Missing / blank / non-int ``count=`` -> ``400``.
+    Never 5xxs: a resolver failure yields empty ``tiers`` list plus the
+    perspective + grace envelope so the pricing UI keeps rendering.
+
+    Response shape mirrors ``/api/entitlement/tiers-for-channel-count``
+    plus the perspective envelope (``perspective_tier``,
+    ``perspective_tier_label``, ``perspective_tier_rank``).
+    """
+    p = (request.args.get("tier") or "").strip().lower()
+    if not p:
+        return jsonify({"error": "missing tier"}), 400
+    raw = request.args.get("count")
+    if raw is None:
+        return jsonify({"error": "missing count"}), 400
+    raw_stripped = raw.strip()
+    if not raw_stripped:
+        return jsonify({"error": "missing count"}), 400
+    try:
+        n = int(raw_stripped)
+    except (TypeError, ValueError):
+        return jsonify({"error": "count must be an integer"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        if p not in _ent._TIER_ORDER:
+            return (
+                jsonify({"error": "unknown tier", "which": "tier", "tier": p}),
+                404,
+            )
+        body = _ent.tiers_for_channel_count_at(p, n)
+        env = _perspective_envelope(_ent, p)
+        if body is None:
+            return jsonify({"tiers": [], **env})
+        return jsonify({**body, **env})
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_tiers_for_channel_count_at: error: %s", exc
+        )
+        return jsonify({"tiers": [], **_perspective_fallback(p)})
+
+
+@bp_entitlement.route("/api/entitlement/tiers-for-retention-window-at")
+def api_entitlement_tiers_for_retention_window_at():
+    """``GET /api/entitlement/tiers-for-retention-window-at?tier=<perspective>
+    &days=<int>`` -- hypothetical-perspective sibling of
+    ``/api/entitlement/tiers-for-retention-window``.
+
+    Pass ``days=unlimited`` (case-insensitive) for the unlimited-history
+    request; the helper only accepts tiers whose retention cap is
+    ``None`` (Enterprise on the current tier table). Perspective is
+    validated but does NOT shape rows.
+
+    Missing / blank ``tier=`` -> ``400``. Unknown ``tier=`` -> ``404``.
+    Missing ``days=`` -> ``400``. Blank / non-int / non-``unlimited``
+    value -> ``400``. Never 5xxs.
+
+    Response shape mirrors
+    ``/api/entitlement/tiers-for-retention-window`` plus the perspective
+    envelope.
+    """
+    p = (request.args.get("tier") or "").strip().lower()
+    if not p:
+        return jsonify({"error": "missing tier"}), 400
+    raw = request.args.get("days")
+    if raw is None:
+        return jsonify({"error": "missing days"}), 400
+    raw_stripped = raw.strip()
+    if not raw_stripped:
+        return jsonify({"error": "missing days"}), 400
+    unlimited = raw_stripped.lower() == "unlimited"
+    if unlimited:
+        parsed: int | None = None
+    else:
+        try:
+            parsed = int(raw_stripped)
+        except (TypeError, ValueError):
+            return (
+                jsonify(
+                    {"error": "days must be an integer or 'unlimited'"}
+                ),
+                400,
+            )
+    try:
+        from clawmetry import entitlements as _ent
+
+        if p not in _ent._TIER_ORDER:
+            return (
+                jsonify({"error": "unknown tier", "which": "tier", "tier": p}),
+                404,
+            )
+        body = _ent.tiers_for_retention_window_at(p, parsed)
+        env = _perspective_envelope(_ent, p)
+        if body is None:
+            return jsonify({"tiers": [], **env})
+        return jsonify({**body, **env})
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_tiers_for_retention_window_at: error: %s", exc
+        )
+        return jsonify({"tiers": [], **_perspective_fallback(p)})
+
+
+@bp_entitlement.route("/api/entitlement/tiers-for-node-count-at")
+def api_entitlement_tiers_for_node_count_at():
+    """``GET /api/entitlement/tiers-for-node-count-at?tier=<perspective>
+    &count=<int>`` -- hypothetical-perspective sibling of
+    ``/api/entitlement/tiers-for-node-count``.
+
+    Perspective is validated against ``_TIER_ORDER`` (``trial``
+    accepted) but does NOT shape rows.
+
+    Missing / blank ``tier=`` -> ``400``. Unknown ``tier=`` -> ``404``.
+    Missing / blank / non-int ``count=`` -> ``400``. Never 5xxs.
+
+    Response shape mirrors ``/api/entitlement/tiers-for-node-count``
+    plus the perspective envelope.
+    """
+    p = (request.args.get("tier") or "").strip().lower()
+    if not p:
+        return jsonify({"error": "missing tier"}), 400
+    raw = request.args.get("count")
+    if raw is None:
+        return jsonify({"error": "missing count"}), 400
+    raw_stripped = raw.strip()
+    if not raw_stripped:
+        return jsonify({"error": "missing count"}), 400
+    try:
+        n = int(raw_stripped)
+    except (TypeError, ValueError):
+        return jsonify({"error": "count must be an integer"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        if p not in _ent._TIER_ORDER:
+            return (
+                jsonify({"error": "unknown tier", "which": "tier", "tier": p}),
+                404,
+            )
+        body = _ent.tiers_for_node_count_at(p, n)
+        env = _perspective_envelope(_ent, p)
+        if body is None:
+            return jsonify({"tiers": [], **env})
+        return jsonify({**body, **env})
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_tiers_for_node_count_at: error: %s", exc
+        )
+        return jsonify({"tiers": [], **_perspective_fallback(p)})
+
+
+@bp_entitlement.route("/api/entitlement/tiers-for-capacity-batch-at")
+def api_entitlement_tiers_for_capacity_batch_at():
+    """``GET /api/entitlement/tiers-for-capacity-batch-at?tier=<perspective>
+    &channels=N&retention_days=K&nodes=M`` -- hypothetical-perspective
+    sibling of ``/api/entitlement/tiers-for-capacity-batch``.
+
+    Fills the last ``_at`` slot in the ``/tiers-for-*`` family alongside
+    ``/tiers-for-at`` / ``/tiers-for-batch-at`` on the grant axes and the
+    three per-axis capacity ``/tiers-for-*-at`` endpoints, so a pricing-
+    matrix walkthrough can call every ``/tiers-for-*-at`` endpoint with
+    a uniform ``tier=<perspective>`` URL.
+
+    Perspective is validated against ``_TIER_ORDER`` (``trial``
+    accepted) but does NOT shape rows -- the batch is identical to
+    ``/tiers-for-capacity-batch`` regardless of perspective (pinned by
+    cross-endpoint parity test).
+
+    Missing / blank ``tier=`` -> ``400``. Unknown ``tier=`` -> ``404``.
+    At least one of ``channels=`` / ``retention_days=`` / ``nodes=``
+    must parse successfully; the endpoint 400s only when *no* axis
+    parsed (matches ``/tiers-for-capacity-batch``'s never-mis-route
+    posture). Never 5xxs.
+
+    ``retention_days`` treats ``None`` (parameter omitted /
+    unparseable) as *unset* -- NOT *unlimited* (matches
+    ``/min-tier-batch``'s posture). Asking for the unlimited-retention
+    ladder at a hypothetical perspective is the singular
+    ``/tiers-for-retention-window-at?days=unlimited`` call's job.
+
+    Response shape mirrors ``/api/entitlement/tiers-for-capacity-batch``
+    plus the perspective envelope.
+    """
+    p = (request.args.get("tier") or "").strip().lower()
+    if not p:
+        return jsonify({"error": "missing tier"}), 400
+    (_, channels_ok, channels_n, _) = _parse_capacity_arg("channels")
+    (_, retention_ok, retention_n, _) = _parse_capacity_arg("retention_days")
+    (_, nodes_ok, nodes_n, _) = _parse_capacity_arg("nodes")
+
+    if not channels_ok and not retention_ok and not nodes_ok:
+        return (
+            jsonify(
+                {
+                    "error": (
+                        "supply at least one of channels=<int>, "
+                        "retention_days=<int>, or nodes=<int>"
+                    )
+                }
+            ),
+            400,
+        )
+
+    try:
+        from clawmetry import entitlements as _ent
+
+        if p not in _ent._TIER_ORDER:
+            return (
+                jsonify({"error": "unknown tier", "which": "tier", "tier": p}),
+                404,
+            )
+        body = _ent.tiers_for_capacity_batch_at(
+            p,
+            channels=channels_n if channels_ok else None,
+            retention_days=retention_n if retention_ok else None,
+            nodes=nodes_n if nodes_ok else None,
+        )
+        env = _perspective_envelope(_ent, p)
+        if body is None:
+            body = {"channels": None, "retention_days": None, "nodes": None}
+        return jsonify(
+            {
+                "channels": body.get("channels"),
+                "retention_days": body.get("retention_days"),
+                "nodes": body.get("nodes"),
+                **env,
+            }
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_tiers_for_capacity_batch_at: error: %s", exc
+        )
+        return jsonify(
+            {
+                "channels": None,
+                "retention_days": None,
+                "nodes": None,
+                **_perspective_fallback(p),
+            }
+        )

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -20410,6 +20410,7 @@ def api_entitlement_tiers_for_runtimes():
         )
 
 
+
 # ── capacity-axis tiers-for-*-at endpoints ───────────────────────────────────
 #
 # Hypothetical-perspective siblings of the four capacity-axis ``tiers_for_*``

--- a/tests/test_entitlement_tiers_for_capacity_at.py
+++ b/tests/test_entitlement_tiers_for_capacity_at.py
@@ -1,0 +1,826 @@
+"""Tests for ``clawmetry.entitlements.tiers_for_channel_count_at`` /
+``tiers_for_retention_window_at`` / ``tiers_for_node_count_at`` /
+``tiers_for_capacity_batch_at`` plus their HTTP endpoints
+``GET /api/entitlement/tiers-for-channel-count-at`` /
+``.../tiers-for-retention-window-at`` /
+``.../tiers-for-node-count-at`` /
+``.../tiers-for-capacity-batch-at``.
+
+Hypothetical-perspective siblings of the four capacity-axis
+``tiers_for_*`` helpers. Same relationship to the base helpers that
+``tiers_for_feature_at`` / ``tiers_for_runtime_at`` / ``tiers_for_batch_at``
+have to their non-``_at`` siblings on the grant axes: the
+``perspective_tier`` argument is validated against ``_TIER_ORDER``
+(``trial`` accepted) but does NOT shape rows -- the ladder is
+intrinsically perspective-independent because it walks static per-tier
+capacity tables.
+
+These tests pin:
+
+* every ``p`` in ``_TIER_ORDER`` yields identical rows to the base
+  helper (parity across perspectives) for every capacity axis
+* perspective validation: empty / blank / ``None`` / unknown / non-str
+  -> ``None`` at the helper layer, ``400`` / ``404`` at the HTTP layer
+* helpers never raise and stay decoupled from the live entitlement
+  (grace vs enforce yields byte-identical rows)
+* the endpoints round-trip every axis and carry the perspective +
+  resolver envelope; 400 on missing/blank ``tier=``, 404 on unknown
+  ``tier=``, 400 on missing/blank/non-int capacity args (per-axis
+  endpoints); the batch endpoint 400s only when NO axis parsed (matches
+  ``/tiers-for-capacity-batch``'s never-mis-route posture)
+* cross-endpoint parity: rows returned by ``/tiers-for-*-at`` byte-equal
+  the non-``_at`` sibling (minus the perspective envelope) for every
+  ``p``
+* ``retention_days=None`` means *unset* in the batch, NOT unlimited
+  (matches ``/tiers-for-capacity-batch``'s semantics); the singular
+  ``/tiers-for-retention-window-at?days=unlimited`` call handles the
+  unlimited request
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+_ROW_KEYS = {
+    "item",
+    "kind",
+    "label",
+    "free",
+    "min_tier",
+    "min_tier_label",
+    "min_tier_rank",
+    "tiers",
+}
+
+_ENVELOPE_KEYS = {
+    "perspective_tier",
+    "perspective_tier_label",
+    "perspective_tier_rank",
+    "current_tier",
+    "current_tier_rank",
+    "grace",
+    "enforced",
+}
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+#   tiers_for_channel_count_at
+# ══════════════════════════════════════════════════════════════════════════════
+
+
+# ── shape parity ─────────────────────────────────────────────────────────────
+
+
+def test_channel_at_returns_full_shape(ent):
+    body = ent.tiers_for_channel_count_at(ent.TIER_CLOUD_STARTER, 5)
+    assert body is not None
+    assert set(body.keys()) == _ROW_KEYS
+    assert body["kind"] == "channel_count"
+    assert body["item"] == 5
+
+
+def test_channel_at_row_shape_matches_singular(ent):
+    body = ent.tiers_for_channel_count_at(ent.TIER_CLOUD_STARTER, 5)
+    assert body["tiers"]
+    for row in body["tiers"]:
+        assert set(row.keys()) == {"id", "label", "rank", "purchasable"}
+
+
+# ── perspective-independence parity ──────────────────────────────────────────
+
+
+def test_channel_at_byte_parity_across_perspectives(ent):
+    """`tiers_for_channel_count_at(p, n) == tiers_for_channel_count(n)`
+    for every ``p`` in ``_TIER_ORDER`` -- pins the ``_at`` prefix
+    against silently shaping rows."""
+    for n in (-1, 0, 1, 3, 5, 100, 10_000):
+        base = ent.tiers_for_channel_count(n)
+        for p in ent._TIER_ORDER:
+            assert ent.tiers_for_channel_count_at(p, n) == base, (p, n)
+
+
+# ── perspective validation ───────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("bad", ["", "   ", "bogus_tier", "not_a_tier"])
+def test_channel_at_bad_perspective_returns_none(ent, bad):
+    assert ent.tiers_for_channel_count_at(bad, 5) is None
+
+
+def test_channel_at_none_perspective_returns_none(ent):
+    assert ent.tiers_for_channel_count_at(None, 5) is None  # type: ignore[arg-type]
+
+
+def test_channel_at_non_string_perspective_returns_none(ent):
+    assert ent.tiers_for_channel_count_at(42, 5) is None  # type: ignore[arg-type]
+    assert ent.tiers_for_channel_count_at([], 5) is None  # type: ignore[arg-type]
+
+
+def test_channel_at_trial_perspective_accepted(ent):
+    assert ent.tiers_for_channel_count_at(ent.TIER_TRIAL, 5) is not None
+
+
+def test_channel_at_perspective_case_insensitive(ent):
+    upper = ent.TIER_CLOUD_PRO.upper()
+    assert (
+        ent.tiers_for_channel_count_at(upper, 5)
+        == ent.tiers_for_channel_count(5)
+    )
+
+
+def test_channel_at_perspective_whitespace_stripped(ent):
+    padded = f"  {ent.TIER_CLOUD_PRO}  "
+    assert (
+        ent.tiers_for_channel_count_at(padded, 5)
+        == ent.tiers_for_channel_count(5)
+    )
+
+
+# ── input validation ─────────────────────────────────────────────────────────
+
+
+def test_channel_at_non_int_count_returns_none(ent):
+    assert ent.tiers_for_channel_count_at(ent.TIER_CLOUD_PRO, "nope") is None  # type: ignore[arg-type]
+    assert ent.tiers_for_channel_count_at(ent.TIER_CLOUD_PRO, None) is None  # type: ignore[arg-type]
+
+
+def test_channel_at_string_int_coerces(ent):
+    body = ent.tiers_for_channel_count_at(ent.TIER_CLOUD_PRO, "5")  # type: ignore[arg-type]
+    assert body is not None
+    assert body["item"] == 5
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+#   tiers_for_retention_window_at
+# ══════════════════════════════════════════════════════════════════════════════
+
+
+def test_retention_at_returns_full_shape(ent):
+    body = ent.tiers_for_retention_window_at(ent.TIER_CLOUD_STARTER, 30)
+    assert body is not None
+    assert set(body.keys()) == _ROW_KEYS
+    assert body["kind"] == "retention_window"
+    assert body["item"] == 30
+
+
+def test_retention_at_unlimited_accepted(ent):
+    """``days=None`` on the singular helper means "unlimited" -- the
+    ``_at`` sibling must preserve that sentinel through the delegate."""
+    body = ent.tiers_for_retention_window_at(ent.TIER_CLOUD_STARTER, None)
+    assert body is not None
+    assert body["item"] is None
+    assert body["label"] == "unlimited"
+
+
+def test_retention_at_byte_parity_across_perspectives(ent):
+    for d in (-3, 0, 1, 7, 8, 30, 90, 365, None):
+        base = ent.tiers_for_retention_window(d)
+        for p in ent._TIER_ORDER:
+            assert ent.tiers_for_retention_window_at(p, d) == base, (p, d)
+
+
+@pytest.mark.parametrize("bad", ["", "   ", "bogus_tier"])
+def test_retention_at_bad_perspective_returns_none(ent, bad):
+    assert ent.tiers_for_retention_window_at(bad, 30) is None
+
+
+def test_retention_at_none_perspective_returns_none(ent):
+    assert ent.tiers_for_retention_window_at(None, 30) is None  # type: ignore[arg-type]
+
+
+def test_retention_at_trial_perspective_accepted(ent):
+    assert (
+        ent.tiers_for_retention_window_at(ent.TIER_TRIAL, 30)
+        is not None
+    )
+
+
+def test_retention_at_non_int_days_returns_none(ent):
+    assert (
+        ent.tiers_for_retention_window_at(ent.TIER_CLOUD_PRO, "nope")  # type: ignore[arg-type]
+        is None
+    )
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+#   tiers_for_node_count_at
+# ══════════════════════════════════════════════════════════════════════════════
+
+
+def test_node_at_returns_full_shape(ent):
+    body = ent.tiers_for_node_count_at(ent.TIER_CLOUD_STARTER, 4)
+    assert body is not None
+    assert set(body.keys()) == _ROW_KEYS
+    assert body["kind"] == "node_count"
+    assert body["item"] == 4
+
+
+def test_node_at_byte_parity_across_perspectives(ent):
+    for n in (-3, 0, 1, 4, 10, 100, 10_000):
+        base = ent.tiers_for_node_count(n)
+        for p in ent._TIER_ORDER:
+            assert ent.tiers_for_node_count_at(p, n) == base, (p, n)
+
+
+@pytest.mark.parametrize("bad", ["", "   ", "bogus_tier"])
+def test_node_at_bad_perspective_returns_none(ent, bad):
+    assert ent.tiers_for_node_count_at(bad, 4) is None
+
+
+def test_node_at_none_perspective_returns_none(ent):
+    assert ent.tiers_for_node_count_at(None, 4) is None  # type: ignore[arg-type]
+
+
+def test_node_at_trial_perspective_accepted(ent):
+    assert ent.tiers_for_node_count_at(ent.TIER_TRIAL, 4) is not None
+
+
+def test_node_at_non_int_returns_none(ent):
+    assert ent.tiers_for_node_count_at(ent.TIER_CLOUD_PRO, "nope") is None  # type: ignore[arg-type]
+    assert ent.tiers_for_node_count_at(ent.TIER_CLOUD_PRO, None) is None  # type: ignore[arg-type]
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+#   tiers_for_capacity_batch_at
+# ══════════════════════════════════════════════════════════════════════════════
+
+
+def test_capacity_batch_at_returns_all_axes(ent):
+    body = ent.tiers_for_capacity_batch_at(
+        ent.TIER_CLOUD_STARTER, channels=5, retention_days=30, nodes=4
+    )
+    assert body is not None
+    assert set(body.keys()) == {"channels", "retention_days", "nodes"}
+    assert body["channels"] is not None
+    assert body["retention_days"] is not None
+    assert body["nodes"] is not None
+
+
+def test_capacity_batch_at_omits_axis_when_unset(ent):
+    body = ent.tiers_for_capacity_batch_at(
+        ent.TIER_CLOUD_STARTER, channels=5
+    )
+    assert body["channels"] is not None
+    assert body["retention_days"] is None
+    assert body["nodes"] is None
+
+
+def test_capacity_batch_at_retention_none_means_unset_not_unlimited(ent):
+    """Critical: ``retention_days=None`` here is *unset*, NOT
+    *unlimited*. If it silently mapped to unlimited a caller supplying
+    every axis but leaving retention off would get a mis-routed
+    Enterprise row instead of an omitted one -- matches
+    ``tiers_for_capacity_batch`` on the same axis. The singular
+    ``tiers_for_retention_window_at(p, None)`` call is how a caller
+    asks for the unlimited-retention ladder."""
+    body = ent.tiers_for_capacity_batch_at(
+        ent.TIER_CLOUD_STARTER, retention_days=None
+    )
+    assert body["retention_days"] is None
+
+
+def test_capacity_batch_at_byte_parity_across_perspectives(ent):
+    combos = [
+        {"channels": 5},
+        {"retention_days": 30},
+        {"nodes": 4},
+        {"channels": 5, "retention_days": 30, "nodes": 4},
+        {"channels": 0, "retention_days": 7, "nodes": 1},
+        {"channels": 10_000, "nodes": 10_000},
+    ]
+    for kwargs in combos:
+        base = ent.tiers_for_capacity_batch(**kwargs)
+        for p in ent._TIER_ORDER:
+            assert (
+                ent.tiers_for_capacity_batch_at(p, **kwargs) == base
+            ), (p, kwargs)
+
+
+@pytest.mark.parametrize("bad", ["", "   ", "bogus_tier"])
+def test_capacity_batch_at_bad_perspective_returns_none(ent, bad):
+    assert (
+        ent.tiers_for_capacity_batch_at(bad, channels=5) is None
+    )
+
+
+def test_capacity_batch_at_none_perspective_returns_none(ent):
+    assert (
+        ent.tiers_for_capacity_batch_at(None, channels=5) is None  # type: ignore[arg-type]
+    )
+
+
+def test_capacity_batch_at_non_string_perspective_returns_none(ent):
+    assert (
+        ent.tiers_for_capacity_batch_at(42, channels=5) is None  # type: ignore[arg-type]
+    )
+
+
+def test_capacity_batch_at_trial_accepted(ent):
+    assert (
+        ent.tiers_for_capacity_batch_at(ent.TIER_TRIAL, channels=5)
+        is not None
+    )
+
+
+def test_capacity_batch_at_case_insensitive(ent):
+    upper = ent.TIER_CLOUD_PRO.upper()
+    assert (
+        ent.tiers_for_capacity_batch_at(upper, channels=5)
+        == ent.tiers_for_capacity_batch(channels=5)
+    )
+
+
+# ── grace vs enforce (every helper) ──────────────────────────────────────────
+
+
+def test_grace_vs_enforce_byte_identical_channel(monkeypatch, ent):
+    grace = ent.tiers_for_channel_count_at(ent.TIER_CLOUD_PRO, 5)
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    enforced = ent.tiers_for_channel_count_at(ent.TIER_CLOUD_PRO, 5)
+    assert grace == enforced
+
+
+def test_grace_vs_enforce_byte_identical_retention(monkeypatch, ent):
+    grace = ent.tiers_for_retention_window_at(ent.TIER_CLOUD_PRO, 30)
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    enforced = ent.tiers_for_retention_window_at(ent.TIER_CLOUD_PRO, 30)
+    assert grace == enforced
+
+
+def test_grace_vs_enforce_byte_identical_node(monkeypatch, ent):
+    grace = ent.tiers_for_node_count_at(ent.TIER_CLOUD_PRO, 4)
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    enforced = ent.tiers_for_node_count_at(ent.TIER_CLOUD_PRO, 4)
+    assert grace == enforced
+
+
+def test_grace_vs_enforce_byte_identical_capacity_batch(monkeypatch, ent):
+    grace = ent.tiers_for_capacity_batch_at(
+        ent.TIER_CLOUD_PRO, channels=5, retention_days=30, nodes=4
+    )
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    enforced = ent.tiers_for_capacity_batch_at(
+        ent.TIER_CLOUD_PRO, channels=5, retention_days=30, nodes=4
+    )
+    assert grace == enforced
+
+
+# ── never raises / no live-entitlement mutation ──────────────────────────────
+
+
+def test_channel_at_never_raises_on_delegate_boom(monkeypatch, ent):
+    def boom(*_a, **_k):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "tiers_for_channel_count", boom)
+    assert (
+        ent.tiers_for_channel_count_at(ent.TIER_CLOUD_PRO, 5) is None
+    )
+
+
+def test_retention_at_never_raises_on_delegate_boom(monkeypatch, ent):
+    def boom(*_a, **_k):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "tiers_for_retention_window", boom)
+    assert (
+        ent.tiers_for_retention_window_at(ent.TIER_CLOUD_PRO, 30) is None
+    )
+
+
+def test_node_at_never_raises_on_delegate_boom(monkeypatch, ent):
+    def boom(*_a, **_k):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "tiers_for_node_count", boom)
+    assert ent.tiers_for_node_count_at(ent.TIER_CLOUD_PRO, 4) is None
+
+
+def test_capacity_batch_at_never_raises_on_delegate_boom(monkeypatch, ent):
+    def boom(*_a, **_k):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "tiers_for_capacity_batch", boom)
+    body = ent.tiers_for_capacity_batch_at(
+        ent.TIER_CLOUD_PRO, channels=5, retention_days=30, nodes=4
+    )
+    # graceful fallback: all-None envelope, still a dict
+    assert body == {
+        "channels": None,
+        "retention_days": None,
+        "nodes": None,
+    }
+
+
+def test_does_not_mutate_live_entitlement(ent):
+    live_before = ent.get_entitlement().to_dict()
+    ent.tiers_for_channel_count_at(ent.TIER_CLOUD_PRO, 5)
+    ent.tiers_for_retention_window_at(ent.TIER_CLOUD_PRO, 30)
+    ent.tiers_for_node_count_at(ent.TIER_CLOUD_PRO, 4)
+    ent.tiers_for_capacity_batch_at(
+        ent.TIER_CLOUD_PRO, channels=5, retention_days=30, nodes=4
+    )
+    live_after = ent.get_entitlement().to_dict()
+    assert live_before == live_after
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+#   HTTP: /api/entitlement/tiers-for-channel-count-at
+# ══════════════════════════════════════════════════════════════════════════════
+
+
+def test_api_channel_at_returns_ladder(client, ent):
+    rv = client.get(
+        f"/api/entitlement/tiers-for-channel-count-at?tier={ent.TIER_CLOUD_STARTER}&count=5"
+    )
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["kind"] == "channel_count"
+    assert body["item"] == 5
+
+
+def test_api_channel_at_carries_perspective_envelope(client, ent):
+    rv = client.get(
+        f"/api/entitlement/tiers-for-channel-count-at?tier={ent.TIER_CLOUD_PRO}&count=5"
+    )
+    body = rv.get_json()
+    assert body["perspective_tier"] == ent.TIER_CLOUD_PRO
+    assert body["perspective_tier_label"] == ent.tier_label(ent.TIER_CLOUD_PRO)
+    assert body["perspective_tier_rank"] == ent.tier_rank(ent.TIER_CLOUD_PRO)
+
+
+def test_api_channel_at_carries_resolver_envelope(client, ent):
+    rv = client.get(
+        f"/api/entitlement/tiers-for-channel-count-at?tier={ent.TIER_CLOUD_PRO}&count=5"
+    )
+    body = rv.get_json()
+    for k in ("current_tier", "current_tier_rank", "grace", "enforced"):
+        assert k in body
+    assert isinstance(body["grace"], bool)
+    assert isinstance(body["enforced"], bool)
+
+
+def test_api_channel_at_case_insensitive_tier(client, ent):
+    rv = client.get(
+        f"/api/entitlement/tiers-for-channel-count-at?tier={ent.TIER_CLOUD_PRO.upper()}&count=5"
+    )
+    assert rv.status_code == 200
+    assert rv.get_json()["perspective_tier"] == ent.TIER_CLOUD_PRO
+
+
+def test_api_channel_at_trial_perspective_accepted(client, ent):
+    rv = client.get(
+        f"/api/entitlement/tiers-for-channel-count-at?tier={ent.TIER_TRIAL}&count=5"
+    )
+    assert rv.status_code == 200
+
+
+def test_api_channel_at_missing_tier_is_400(client):
+    rv = client.get(
+        "/api/entitlement/tiers-for-channel-count-at?count=5"
+    )
+    assert rv.status_code == 400
+    assert "error" in rv.get_json()
+
+
+def test_api_channel_at_blank_tier_is_400(client):
+    rv = client.get(
+        "/api/entitlement/tiers-for-channel-count-at?tier=&count=5"
+    )
+    assert rv.status_code == 400
+
+
+def test_api_channel_at_unknown_tier_is_404(client):
+    rv = client.get(
+        "/api/entitlement/tiers-for-channel-count-at?tier=bogus_tier&count=5"
+    )
+    assert rv.status_code == 404
+    body = rv.get_json()
+    assert body["which"] == "tier"
+    assert body["tier"] == "bogus_tier"
+
+
+def test_api_channel_at_missing_count_is_400(client, ent):
+    rv = client.get(
+        f"/api/entitlement/tiers-for-channel-count-at?tier={ent.TIER_CLOUD_PRO}"
+    )
+    assert rv.status_code == 400
+
+
+def test_api_channel_at_blank_count_is_400(client, ent):
+    rv = client.get(
+        f"/api/entitlement/tiers-for-channel-count-at?tier={ent.TIER_CLOUD_PRO}&count="
+    )
+    assert rv.status_code == 400
+
+
+def test_api_channel_at_non_int_count_is_400(client, ent):
+    rv = client.get(
+        f"/api/entitlement/tiers-for-channel-count-at?tier={ent.TIER_CLOUD_PRO}&count=nope"
+    )
+    assert rv.status_code == 400
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+#   HTTP: /api/entitlement/tiers-for-retention-window-at
+# ══════════════════════════════════════════════════════════════════════════════
+
+
+def test_api_retention_at_returns_ladder(client, ent):
+    rv = client.get(
+        f"/api/entitlement/tiers-for-retention-window-at?tier={ent.TIER_CLOUD_PRO}&days=30"
+    )
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["kind"] == "retention_window"
+    assert body["item"] == 30
+
+
+def test_api_retention_at_unlimited(client, ent):
+    rv = client.get(
+        f"/api/entitlement/tiers-for-retention-window-at?tier={ent.TIER_CLOUD_PRO}&days=unlimited"
+    )
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["item"] is None
+    assert body["label"] == "unlimited"
+
+
+def test_api_retention_at_unlimited_case_insensitive(client, ent):
+    rv = client.get(
+        f"/api/entitlement/tiers-for-retention-window-at?tier={ent.TIER_CLOUD_PRO}&days=Unlimited"
+    )
+    assert rv.status_code == 200
+    assert rv.get_json()["item"] is None
+
+
+def test_api_retention_at_missing_tier_is_400(client):
+    rv = client.get(
+        "/api/entitlement/tiers-for-retention-window-at?days=30"
+    )
+    assert rv.status_code == 400
+
+
+def test_api_retention_at_unknown_tier_is_404(client):
+    rv = client.get(
+        "/api/entitlement/tiers-for-retention-window-at?tier=bogus_tier&days=30"
+    )
+    assert rv.status_code == 404
+
+
+def test_api_retention_at_missing_days_is_400(client, ent):
+    rv = client.get(
+        f"/api/entitlement/tiers-for-retention-window-at?tier={ent.TIER_CLOUD_PRO}"
+    )
+    assert rv.status_code == 400
+
+
+def test_api_retention_at_blank_days_is_400(client, ent):
+    rv = client.get(
+        f"/api/entitlement/tiers-for-retention-window-at?tier={ent.TIER_CLOUD_PRO}&days="
+    )
+    assert rv.status_code == 400
+
+
+def test_api_retention_at_non_int_days_is_400(client, ent):
+    rv = client.get(
+        f"/api/entitlement/tiers-for-retention-window-at?tier={ent.TIER_CLOUD_PRO}&days=forever"
+    )
+    assert rv.status_code == 400
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+#   HTTP: /api/entitlement/tiers-for-node-count-at
+# ══════════════════════════════════════════════════════════════════════════════
+
+
+def test_api_node_at_returns_ladder(client, ent):
+    rv = client.get(
+        f"/api/entitlement/tiers-for-node-count-at?tier={ent.TIER_CLOUD_PRO}&count=4"
+    )
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["kind"] == "node_count"
+    assert body["item"] == 4
+
+
+def test_api_node_at_missing_tier_is_400(client):
+    rv = client.get(
+        "/api/entitlement/tiers-for-node-count-at?count=4"
+    )
+    assert rv.status_code == 400
+
+
+def test_api_node_at_unknown_tier_is_404(client):
+    rv = client.get(
+        "/api/entitlement/tiers-for-node-count-at?tier=bogus_tier&count=4"
+    )
+    assert rv.status_code == 404
+
+
+def test_api_node_at_missing_count_is_400(client, ent):
+    rv = client.get(
+        f"/api/entitlement/tiers-for-node-count-at?tier={ent.TIER_CLOUD_PRO}"
+    )
+    assert rv.status_code == 400
+
+
+def test_api_node_at_non_int_count_is_400(client, ent):
+    rv = client.get(
+        f"/api/entitlement/tiers-for-node-count-at?tier={ent.TIER_CLOUD_PRO}&count=nope"
+    )
+    assert rv.status_code == 400
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+#   HTTP: /api/entitlement/tiers-for-capacity-batch-at
+# ══════════════════════════════════════════════════════════════════════════════
+
+
+def test_api_capacity_batch_at_shape(client, ent):
+    rv = client.get(
+        f"/api/entitlement/tiers-for-capacity-batch-at?tier={ent.TIER_CLOUD_PRO}&channels=5&retention_days=30&nodes=4"
+    )
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert set(body.keys()) == (
+        {"channels", "retention_days", "nodes"} | _ENVELOPE_KEYS
+    )
+    assert body["channels"] is not None
+    assert body["retention_days"] is not None
+    assert body["nodes"] is not None
+    assert body["perspective_tier"] == ent.TIER_CLOUD_PRO
+
+
+def test_api_capacity_batch_at_omits_axis(client, ent):
+    rv = client.get(
+        f"/api/entitlement/tiers-for-capacity-batch-at?tier={ent.TIER_CLOUD_PRO}&channels=5"
+    )
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["channels"] is not None
+    assert body["retention_days"] is None
+    assert body["nodes"] is None
+
+
+def test_api_capacity_batch_at_missing_tier_is_400(client):
+    rv = client.get(
+        "/api/entitlement/tiers-for-capacity-batch-at?channels=5"
+    )
+    assert rv.status_code == 400
+
+
+def test_api_capacity_batch_at_blank_tier_is_400(client):
+    rv = client.get(
+        "/api/entitlement/tiers-for-capacity-batch-at?tier=&channels=5"
+    )
+    assert rv.status_code == 400
+
+
+def test_api_capacity_batch_at_unknown_tier_is_404(client):
+    rv = client.get(
+        "/api/entitlement/tiers-for-capacity-batch-at?tier=bogus_tier&channels=5"
+    )
+    assert rv.status_code == 404
+
+
+def test_api_capacity_batch_at_no_axis_is_400(client, ent):
+    rv = client.get(
+        f"/api/entitlement/tiers-for-capacity-batch-at?tier={ent.TIER_CLOUD_PRO}"
+    )
+    assert rv.status_code == 400
+
+
+def test_api_capacity_batch_at_all_axes_bogus_is_400(client, ent):
+    """Matches ``/tiers-for-capacity-batch`` never-mis-route posture --
+    every axis unparseable is caller error, not a mis-routed Enterprise
+    ladder."""
+    rv = client.get(
+        f"/api/entitlement/tiers-for-capacity-batch-at?tier={ent.TIER_CLOUD_PRO}&channels=nope&retention_days=nope&nodes=nope"
+    )
+    assert rv.status_code == 400
+
+
+def test_api_capacity_batch_at_trial_accepted(client, ent):
+    rv = client.get(
+        f"/api/entitlement/tiers-for-capacity-batch-at?tier={ent.TIER_TRIAL}&channels=5"
+    )
+    assert rv.status_code == 200
+    assert rv.get_json()["perspective_tier"] == ent.TIER_TRIAL
+
+
+def test_api_capacity_batch_at_case_insensitive_tier(client, ent):
+    rv = client.get(
+        f"/api/entitlement/tiers-for-capacity-batch-at?tier={ent.TIER_CLOUD_PRO.upper()}&channels=5"
+    )
+    assert rv.status_code == 200
+    assert rv.get_json()["perspective_tier"] == ent.TIER_CLOUD_PRO
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+#   Cross-endpoint parity
+# ══════════════════════════════════════════════════════════════════════════════
+
+
+def test_api_channel_at_rows_byte_equal_non_at(client, ent):
+    """For every ``p``, ``/tiers-for-channel-count-at?tier=<p>&count=<n>``
+    returns the same core row shape as ``/tiers-for-channel-count?count=<n>``
+    (minus the perspective envelope keys). Pins the ``_at`` endpoint
+    against silently shaping rows."""
+    base = client.get(
+        "/api/entitlement/tiers-for-channel-count?count=5"
+    ).get_json()
+    # strip resolver envelope from base for comparison
+    base_core = {
+        k: v
+        for k, v in base.items()
+        if k not in _ENVELOPE_KEYS
+    }
+    for p in ent._TIER_ORDER:
+        rv = client.get(
+            f"/api/entitlement/tiers-for-channel-count-at?tier={p}&count=5"
+        )
+        assert rv.status_code == 200, p
+        body = rv.get_json()
+        core = {k: v for k, v in body.items() if k not in _ENVELOPE_KEYS}
+        assert core == base_core, p
+
+
+def test_api_retention_at_rows_byte_equal_non_at(client, ent):
+    base = client.get(
+        "/api/entitlement/tiers-for-retention-window?days=30"
+    ).get_json()
+    base_core = {
+        k: v
+        for k, v in base.items()
+        if k not in _ENVELOPE_KEYS
+    }
+    for p in ent._TIER_ORDER:
+        rv = client.get(
+            f"/api/entitlement/tiers-for-retention-window-at?tier={p}&days=30"
+        )
+        assert rv.status_code == 200, p
+        body = rv.get_json()
+        core = {k: v for k, v in body.items() if k not in _ENVELOPE_KEYS}
+        assert core == base_core, p
+
+
+def test_api_node_at_rows_byte_equal_non_at(client, ent):
+    base = client.get(
+        "/api/entitlement/tiers-for-node-count?count=4"
+    ).get_json()
+    base_core = {
+        k: v
+        for k, v in base.items()
+        if k not in _ENVELOPE_KEYS
+    }
+    for p in ent._TIER_ORDER:
+        rv = client.get(
+            f"/api/entitlement/tiers-for-node-count-at?tier={p}&count=4"
+        )
+        assert rv.status_code == 200, p
+        body = rv.get_json()
+        core = {k: v for k, v in body.items() if k not in _ENVELOPE_KEYS}
+        assert core == base_core, p
+
+
+def test_api_capacity_batch_at_rows_byte_equal_non_at(client, ent):
+    base = client.get(
+        "/api/entitlement/tiers-for-capacity-batch?channels=5&retention_days=30&nodes=4"
+    ).get_json()
+    for p in ent._TIER_ORDER:
+        rv = client.get(
+            f"/api/entitlement/tiers-for-capacity-batch-at?tier={p}&channels=5&retention_days=30&nodes=4"
+        )
+        assert rv.status_code == 200, p
+        body = rv.get_json()
+        for axis in ("channels", "retention_days", "nodes"):
+            assert body[axis] == base[axis], (p, axis)


### PR DESCRIPTION
## Summary

- Adds `tiers_for_channel_count_at`, `tiers_for_retention_window_at`, `tiers_for_node_count_at`, and `tiers_for_capacity_batch_at` — hypothetical-perspective siblings of the four capacity-axis `tiers_for_*` helpers that landed alongside `tiers_for_capacity_batch` in #3707.
- Adds `GET /api/entitlement/tiers-for-channel-count-at`, `.../tiers-for-retention-window-at`, `.../tiers-for-node-count-at`, and `.../tiers-for-capacity-batch-at` — each carries the perspective envelope (`perspective_tier` / `..._label` / `..._rank`) plus the resolver envelope, matching `/tiers-for-at` / `/tiers-for-batch-at` on the grant axes exactly.
- Grace-mode change only — no behaviour change on any existing surface, no `__version__` bump, no `[RELEASE]` PR, no gate enforced.

## Why

`tiers_for_feature_at` / `tiers_for_runtime_at` / `tiers_for_batch_at` (#3702) filled the `_at` slot on the grant axes; `tiers_for_capacity_batch` (#3707) filled the caller-supplied capacity-bundle slot on the current-perspective side. The remaining gap in the `tiers_for_*` family is the `_at` variant of the four capacity-axis helpers: a pricing-matrix walkthrough at a hypothetical perspective (`tier=<p>`) could hit every grant-axis endpoint uniformly, but had to fall back to the non-`_at` capacity endpoints — either fanning out three per-axis calls or building the ladder client-side from `/min-tier-batch`. This PR closes that gap so every `tiers_for_*` shape (feature / runtime / per-axis capacity / capacity batch / grant batch) has a `_at` sibling and a walkthrough URL can pass `tier=<p>` uniformly across the whole family.

The ladders themselves walk the static per-tier capacity tables, so byte-parity with the non-`_at` sibling is intrinsic — pinned in the test suite via a cross-perspective parity test on every axis.

## Changes

### `clawmetry/entitlements.py`

- `tiers_for_channel_count_at(perspective_tier, count)` — validates perspective against `_TIER_ORDER` (trial accepted), delegates to `tiers_for_channel_count`. Returns `None` for empty/unknown perspective or non-int count. Never raises.
- `tiers_for_retention_window_at(perspective_tier, days)` — twin for the retention-window axis. Preserves the `days=None` "unlimited" sentinel through the delegate so the singular `tiers_for_retention_window_at(p, None)` call still asks for the unlimited-history ladder.
- `tiers_for_node_count_at(perspective_tier, count)` — twin for the node-count axis.
- `tiers_for_capacity_batch_at(perspective_tier, *, channels, retention_days, nodes)` — batch sibling. Perspective validated but does NOT shape rows; ladder is identical to `tiers_for_capacity_batch` for any perspective. `retention_days=None` here means *unset* — NOT *unlimited* (matches `tiers_for_capacity_batch` / `min_tier_batch` on the same axis). A delegate failure surfaces as an all-`None` envelope so the pricing UI keeps rendering.

Response shape (per-axis endpoints):

```json
{
  "item":                    5,
  "kind":                    "channel_count",
  "label":                   "5 channels",
  "free":                    false,
  "min_tier":                "cloud_starter",
  "min_tier_label":          "Cloud Starter",
  "min_tier_rank":           2,
  "tiers":                   [<_tier_row>, ...],
  "perspective_tier":        "cloud_pro",
  "perspective_tier_label":  "Cloud Pro",
  "perspective_tier_rank":   3,
  "current_tier":            "oss",
  "current_tier_rank":       0,
  "grace":                   true,
  "enforced":                false
}
```

### `routes/entitlement.py`

- Four new endpoints on `bp_entitlement`. Missing/blank `tier=` → `400`; unknown `tier=` → `404` (`which=tier`). Per-axis endpoints: missing/blank/non-int capacity arg → `400`. Batch endpoint: at least one of `channels=` / `retention_days=` / `nodes=` must parse; 400 only when *none* parsed (matches `/tiers-for-capacity-batch`'s never-mis-route posture). All four never 5xx: a resolver failure returns the fallback envelope so the pricing UI keeps rendering.
- Reuses the existing `_parse_capacity_arg` helper on the batch endpoint so its dedup/normalisation matches `/tiers-for-capacity-batch` byte-for-byte.
- Two small helpers (`_perspective_envelope` / `_perspective_fallback`) factor the shared envelope out of the four endpoints so the shape matches `/tiers-for-at` / `/tiers-for-batch-at` byte-for-byte.

### `tests/test_entitlement_tiers_for_capacity_at.py`

**88 tests, all green** (3.43s):

- shape parity: every helper returns the same 8-key row shape as the singular `tiers_for_*` sibling
- `min_tier` byte-equals the matching non-`_at` sibling on every axis (pinned across `_TIER_ORDER`)
- byte-parity across perspectives: `tiers_for_channel_count_at(p, n) == tiers_for_channel_count(n)` for every `p` in `_TIER_ORDER` — pins the `_at` prefix against silently shaping rows (repeated for retention, nodes, capacity batch)
- perspective validation: empty / blank / `None` / unknown / non-string → `None` at the helper layer; `400` / `404` at the HTTP layer
- `trial` perspective accepted (matches every other `_at` sibling)
- perspective is case-insensitive + whitespace-stripped (`?tier=CLOUD_PRO` → `cloud_pro`)
- `retention_days=None` on the batch means *unset*, NOT unlimited (parity with `tiers_for_capacity_batch`); the singular `tiers_for_retention_window_at(p, None)` call handles the unlimited request
- grace vs enforce yields byte-identical rows on every helper (pinned via a `CLAWMETRY_ENFORCE=1` reload roundtrip)
- helpers never raise on a delegate-boom (`monkeypatch` the delegate to raise); no live-entitlement mutation
- API happy paths: single + full-bundle capacity args; case-insensitive tier; trial perspective; envelope shape
- API error paths: 400 on missing/blank `tier=`, 404 on unknown `tier=` (`which=tier`), 400 on per-axis missing/blank/non-int args, 400 on batch no-axis, 400 on batch all-bogus-axes
- cross-endpoint parity: `/tiers-for-*-at?tier=<p>&...` returns the same core row shape as `/tiers-for-*?...` (minus the perspective envelope keys) for every `p` in `_TIER_ORDER` — pins the `_at` endpoint against silently shaping rows on every axis, including the batch

## Test plan

- [x] `python3 -m py_compile clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_tiers_for_capacity_at.py` — clean
- [x] `ruff check clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_tiers_for_capacity_at.py` — clean
- [x] `pytest tests/test_entitlement_tiers_for_capacity_at.py -v` → **88/88 pass** in 3.43s
- [x] Sibling test files (`test_entitlement_tiers_for.py`, `test_entitlement_tiers_for_at.py`, `test_entitlement_tiers_for_batch.py`, `test_entitlement_tiers_for_capacity.py`, `test_entitlement_tiers_for_capacity_batch.py`, `test_entitlement_api.py`, `test_blueprint_uniqueness.py`, `test_circular_import.py`) still green — **255/255 pass**
- [x] Full entitlement test suite: 6364 pass across the wider tree (3 unrelated errors, all `ModuleNotFoundError: duckdb` on tests that pull `clawmetry.local_store` — pre-existing environmental issue, not touched by this diff)

## Local operator verification checklist

I can't touch the running daemon, `~/.openclaw`, the live snapshot, or a browser from here — please run:

- [ ] Copy the changed files into `~/.clawmetry/lib/python3.11/site-packages/clawmetry/` (`entitlements.py`) and `~/.clawmetry/lib/python3.11/site-packages/routes/` (`entitlement.py`); drop the test file into the local checkout under `tests/`
- [ ] Clear `__pycache__` on both dirs
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
- [ ] `curl -s 'http://localhost:8900/api/entitlement/tiers-for-channel-count-at?tier=cloud_pro&count=5' | jq .` — expect `kind="channel_count"`, `item=5`, `perspective_tier="cloud_pro"`, `tiers[]` matching `/tiers-for-channel-count?count=5`
- [ ] `curl -s 'http://localhost:8900/api/entitlement/tiers-for-retention-window-at?tier=cloud_pro&days=unlimited' | jq .` — expect `item=null`, `label="unlimited"`, `tiers[]` = `[enterprise]`
- [ ] `curl -s 'http://localhost:8900/api/entitlement/tiers-for-node-count-at?tier=cloud_starter&count=4' | jq .` — expect `kind="node_count"`, `item=4`
- [ ] `curl -s 'http://localhost:8900/api/entitlement/tiers-for-capacity-batch-at?tier=cloud_pro&channels=5&retention_days=30&nodes=4' | jq .` — expect all three axes populated, `perspective_tier="cloud_pro"`
- [ ] `curl -s -o /dev/null -w '%{http_code}\n' 'http://localhost:8900/api/entitlement/tiers-for-channel-count-at?count=5'` → `400`
- [ ] `curl -s -o /dev/null -w '%{http_code}\n' 'http://localhost:8900/api/entitlement/tiers-for-channel-count-at?tier=bogus&count=5'` → `404`
- [ ] `curl -s -o /dev/null -w '%{http_code}\n' 'http://localhost:8900/api/entitlement/tiers-for-capacity-batch-at?tier=cloud_pro'` → `400`
- [ ] Cross-check byte-parity: strip the perspective envelope from `/tiers-for-channel-count-at?tier=<p>&count=5` and confirm it byte-equals `/tiers-for-channel-count?count=5` for every `p` in `_TIER_ORDER` (repeat on the retention / node / batch endpoints)
- [ ] Decrypt the live cloud snapshot and hit the same endpoints against the cloud read-through path
- [ ] Browser check: any surface currently calling `/tiers-for-at` / `/tiers-for-batch-at` / `/tiers-for-<capacity>` should keep rendering; nothing should call the new `/tiers-for-*-at` capacity endpoints yet

No `__version__` bump, no tag, no `[RELEASE]` PR — staying in DRAFT until you've cleared local + cloud verification.

## MOAT / release checklist

- Not a MOAT fast-path change (no `local_store_via_daemon` / `_ls_call` / `_DAEMON_METHODS` touched).
- Not a `[RELEASE]` PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CSE9ngzfhNi3eKjfcQ6Jj1)_