### PR TITLE
feat(entitlement): min_tier_for_features_at + min_tier_for_runtimes_at + /min-tier-for-{features,runtimes}-at

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -5352,6 +5352,74 @@ def min_tier_for_runtimes(runtimes) -> str | None:
     return max(tiers, key=tier_rank)
 
 
+def min_tier_for_features_at(
+    perspective_tier: str, features
+) -> str | None:
+    """Hypothetical-perspective sibling of :func:`min_tier_for_features`.
+
+    Fills the ``_at`` slot for the ``min_tier_for_features`` scalar so a
+    pricing-matrix walkthrough can call ``X_at(perspective, ...)`` uniformly
+    across the whole ``_at`` family. Same relationship to
+    :func:`min_tier_for_features` that :func:`min_tier_batch_at` has to
+    :func:`min_tier_batch`: ``perspective_tier`` is validated against
+    :data:`_TIER_ORDER` (including :data:`TIER_TRIAL`) but does NOT shape
+    the answer -- the walk still folds :func:`min_tier_for_feature` over
+    the bundle, and the resulting scalar tier id depends only on the
+    static per-tier feature map, not on the caller's live plan. A parity
+    test pins ``min_tier_for_features_at(p, ...) == min_tier_for_features(...)``
+    for every ``p`` in :data:`_TIER_ORDER` so the ``_at`` prefix cannot
+    silently drift into shaping the result.
+
+    Returns ``None`` for empty / unknown ``perspective_tier`` (caller
+    renders "unknown tier" / 404), matching the ``None`` posture the rest
+    of the ``_at`` family uses for the perspective-validation failure
+    mode. All other semantics -- empty / ``None`` iterable, unknown ids,
+    all-free bundle -> :data:`TIER_OSS`, non-iterable -> ``None`` --
+    inherit from :func:`min_tier_for_features` unchanged. Never raises: a
+    delegate failure logs a warning and returns ``None`` so a
+    pricing-matrix walkthrough keeps rendering instead of breaking.
+    """
+    try:
+        p = (perspective_tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if not p or p not in _TIER_ORDER:
+        return None
+    try:
+        return min_tier_for_features(features)
+    except Exception as exc:
+        logger.warning("entitlements: min_tier_for_features_at failed: %s", exc)
+        return None
+
+
+def min_tier_for_runtimes_at(
+    perspective_tier: str, runtimes
+) -> str | None:
+    """Runtime-axis twin of :func:`min_tier_for_features_at`.
+
+    Same perspective contract, same never-raise posture, same
+    perspective-independence guarantee (pinned by a parity test in the
+    suite). Delegates to :func:`min_tier_for_runtimes`, which already
+    canonicalises runtime aliases (``claude-code`` -> ``claude_code``)
+    through :func:`canonical_runtime` so a caller does not need to
+    normalise before calling.
+
+    Returns ``None`` for empty / unknown ``perspective_tier``; all other
+    semantics inherit from :func:`min_tier_for_runtimes`.
+    """
+    try:
+        p = (perspective_tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if not p or p not in _TIER_ORDER:
+        return None
+    try:
+        return min_tier_for_runtimes(runtimes)
+    except Exception as exc:
+        logger.warning("entitlements: min_tier_for_runtimes_at failed: %s", exc)
+        return None
+
+
 def min_tier_for_all(
     *,
     features=None,

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -20861,3 +20861,232 @@ def api_entitlement_tiers_for_capacity_batch_at():
                 **_perspective_fallback(p),
             }
         )
+
+
+@bp_entitlement.route("/api/entitlement/min-tier-for-features-at")
+def api_entitlement_min_tier_for_features_at():
+    """``GET /api/entitlement/min-tier-for-features-at?tier=<perspective>
+    &features=a,b,c`` -- hypothetical-perspective sibling of
+    ``min_tier_for_features``: the cheapest *purchasable* tier admitting
+    every feature in the bundle, scoped by a caller-supplied
+    ``perspective_tier``.
+
+    Fills the ``_at`` slot for the ``min_tier_for_features`` scalar so a
+    pricing-matrix walkthrough (``?tier=<p>``) can hit
+    ``/min-tier-for-features-at`` uniformly across the whole ``_at``
+    family instead of falling back to ``/required-tier-batch?features=<csv>``
+    (which combines features + runtimes and lacks the perspective envelope).
+
+    Perspective is validated against :data:`entitlements._TIER_ORDER`
+    (including ``trial``) but does NOT shape the answer -- the scalar tier
+    id depends only on the static per-tier feature map. A parity contract
+    pinned in the test suite guarantees the ``required_tier`` byte-equals
+    ``min_tier_for_features(features)`` for every perspective. The
+    response layers ``perspective_tier`` / ``perspective_tier_label`` /
+    ``perspective_tier_rank`` on top of the standard resolver envelope so
+    a walkthrough surface can render the "from <perspective>" copy off
+    one round-trip.
+
+    Response shape::
+
+        {
+          "features":               ["fleet", "sso"],
+          "unknown":                ["bogus"],
+          "kind":                   "features",
+          "count":                  2,
+          "required_tier":          "enterprise" | null,
+          "required_tier_label":    "Enterprise" | null,
+          "required_tier_rank":     <int>,
+          "free":                   <bool>,
+          "perspective_tier":       "cloud_pro",
+          "perspective_tier_label": "Cloud Pro",
+          "perspective_tier_rank":  <int>,
+          "current_tier":           "oss",
+          "current_tier_rank":      <int>,
+          "grace":                  <bool>,
+          "enforced":               <bool>,
+        }
+
+    - **400** when ``tier=`` is missing / blank, OR when ``features=`` is
+      missing / blank after CSV normalisation.
+    - **404** when ``tier`` is unknown. The body carries ``which=tier`` so
+      a caller can render the right "unknown tier" message.
+    - **All-unknown features IS 200** with ``unknown`` populated and
+      ``required_tier=null`` -- distinguishes "caller asked for nothing"
+      from "caller asked but every token was a typo" so a paywall UI can
+      render "these ids are unknown: X" instead of a null.
+    - **Never 5xxs**: a resolver failure yields the fallback envelope
+      (empty ``features`` list, ``required_tier=null``) so the pricing
+      walkthrough keeps rendering.
+    """
+    raw_tier = request.args.get("tier")
+    tier_in = (raw_tier or "").strip().lower()
+    if not tier_in:
+        return jsonify({"error": "missing tier"}), 400
+
+    features_csv = _parse_csv_arg("features")
+    if not features_csv:
+        return jsonify({"error": "missing features"}), 400
+
+    try:
+        from clawmetry import entitlements as _ent
+
+        if tier_in not in _ent._TIER_ORDER:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "tier", "tier": tier_in}
+                ),
+                404,
+            )
+
+        known: list[str] = []
+        unknown: list[str] = []
+        for fid in features_csv:
+            if fid in _ent.ALL_FEATURES:
+                if fid not in known:
+                    known.append(fid)
+            else:
+                if fid not in unknown:
+                    unknown.append(fid)
+
+        required = _ent.min_tier_for_features_at(tier_in, known) if known else None
+        env = _resolver_envelope(_ent)
+        return jsonify(
+            {
+                "features": known,
+                "unknown": unknown,
+                "kind": "features",
+                "count": len(known),
+                "required_tier": required,
+                "required_tier_label": (
+                    _ent.tier_label(required) if required else None
+                ),
+                "required_tier_rank": (
+                    _ent.tier_rank(required) if required else -1
+                ),
+                "free": bool(required == _ent.TIER_OSS),
+                "perspective_tier": tier_in,
+                "perspective_tier_label": _ent.tier_label(tier_in),
+                "perspective_tier_rank": _ent.tier_rank(tier_in),
+                **env,
+            }
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_min_tier_for_features_at: error: %s", exc
+        )
+        return jsonify(
+            {
+                "features": [],
+                "unknown": features_csv,
+                "kind": "features",
+                "count": 0,
+                "required_tier": None,
+                "required_tier_label": None,
+                "required_tier_rank": -1,
+                "free": False,
+                "perspective_tier": tier_in,
+                "perspective_tier_label": None,
+                "perspective_tier_rank": -1,
+                "current_tier": "oss",
+                "current_tier_rank": 0,
+                "grace": True,
+                "enforced": False,
+            }
+        )
+
+
+@bp_entitlement.route("/api/entitlement/min-tier-for-runtimes-at")
+def api_entitlement_min_tier_for_runtimes_at():
+    """``GET /api/entitlement/min-tier-for-runtimes-at?tier=<perspective>
+    &runtimes=x,y,z`` -- runtime-axis twin of
+    ``/api/entitlement/min-tier-for-features-at``.
+
+    Same perspective contract, same never-5xx posture, same
+    perspective-independence guarantee (pinned by a parity test).
+    Runtime aliases (``claude-code`` -> ``claude_code``) are canonicalised
+    through :func:`clawmetry.entitlements.canonical_runtime` so a caller
+    does not need to normalise before calling; unknown ids land in
+    ``unknown`` and drop from the ``required_tier`` walk (a typo does NOT
+    silently mis-route the ladder to Enterprise).
+
+    Response shape and error paths mirror
+    ``/min-tier-for-features-at`` exactly, with ``kind="runtimes"`` and a
+    ``runtimes`` list in place of ``features``.
+    """
+    raw_tier = request.args.get("tier")
+    tier_in = (raw_tier or "").strip().lower()
+    if not tier_in:
+        return jsonify({"error": "missing tier"}), 400
+
+    runtimes_csv = _parse_csv_arg("runtimes")
+    if not runtimes_csv:
+        return jsonify({"error": "missing runtimes"}), 400
+
+    try:
+        from clawmetry import entitlements as _ent
+
+        if tier_in not in _ent._TIER_ORDER:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "tier", "tier": tier_in}
+                ),
+                404,
+            )
+
+        known: list[str] = []
+        unknown: list[str] = []
+        for rt in runtimes_csv:
+            canon = _ent.canonical_runtime(rt)
+            if canon and canon in _ent.ALL_RUNTIMES:
+                if canon not in known:
+                    known.append(canon)
+            else:
+                if rt not in unknown:
+                    unknown.append(rt)
+
+        required = _ent.min_tier_for_runtimes_at(tier_in, known) if known else None
+        env = _resolver_envelope(_ent)
+        return jsonify(
+            {
+                "runtimes": known,
+                "unknown": unknown,
+                "kind": "runtimes",
+                "count": len(known),
+                "required_tier": required,
+                "required_tier_label": (
+                    _ent.tier_label(required) if required else None
+                ),
+                "required_tier_rank": (
+                    _ent.tier_rank(required) if required else -1
+                ),
+                "free": bool(required == _ent.TIER_OSS),
+                "perspective_tier": tier_in,
+                "perspective_tier_label": _ent.tier_label(tier_in),
+                "perspective_tier_rank": _ent.tier_rank(tier_in),
+                **env,
+            }
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_min_tier_for_runtimes_at: error: %s", exc
+        )
+        return jsonify(
+            {
+                "runtimes": [],
+                "unknown": runtimes_csv,
+                "kind": "runtimes",
+                "count": 0,
+                "required_tier": None,
+                "required_tier_label": None,
+                "required_tier_rank": -1,
+                "free": False,
+                "perspective_tier": tier_in,
+                "perspective_tier_label": None,
+                "perspective_tier_rank": -1,
+                "current_tier": "oss",
+                "current_tier_rank": 0,
+                "grace": True,
+                "enforced": False,
+            }
+        )

--- a/tests/test_entitlement_min_tier_for_plural_at.py
+++ b/tests/test_entitlement_min_tier_for_plural_at.py
@@ -1,0 +1,559 @@
+"""Tests for ``clawmetry.entitlements.min_tier_for_features_at`` /
+``min_tier_for_runtimes_at`` and the two matching HTTP endpoints.
+
+Hypothetical-perspective siblings of :func:`min_tier_for_features` /
+:func:`min_tier_for_runtimes`. Fills the ``_at`` slot on the plural
+min_tier axes so a pricing-matrix walkthrough (``?tier=<p>``) can call
+``min_tier_for_features_at`` and ``min_tier_for_runtimes_at`` uniformly
+across the whole ``_at`` family instead of falling back to
+``/required-tier-batch`` (which combines features + runtimes and lacks
+a perspective envelope).
+
+These tests pin:
+
+* perspective validation: empty / blank / ``None`` / non-string /
+  unknown short-circuits to ``None`` on the helper and 400 / 404 on the
+  endpoint
+* trial accepted as perspective (matches the rest of the ``_at`` family)
+* case-insensitive + whitespace-stripped perspective
+* byte-parity vs the non-``_at`` sibling for every perspective in
+  :data:`_TIER_ORDER` -- the ``_at`` prefix cannot silently drift into
+  shaping the answer
+* semantics inherited from the non-``_at`` sibling: empty iterable ->
+  ``None``, unknown-only bundle -> ``None``, all-free bundle ->
+  :data:`TIER_OSS`, mixed bundle -> most-constraining tier
+* runtime canonicalisation on the runtime helper
+  (``claude-code`` -> ``claude_code``)
+* grace vs enforce yields byte-identical results
+* helpers never raise on a delegate crash (monkeypatched)
+* API happy path: shape, envelope keys, perspective envelope, resolver
+  envelope, ``kind``, ``count`` fields
+* API error paths: 400 on missing / blank ``tier=`` or ``features=`` /
+  ``runtimes=``, 404 on unknown ``tier=``
+* all-unknown IS 200 with ``unknown`` populated and ``required_tier=null``
+  (not confused with "asked for nothing")
+* CSV dedup / normalisation via the shared ``_parse_csv_arg`` helper
+* cross-endpoint parity: ``/min-tier-for-features-at?tier=<p>&features=X``
+  ``.required_tier`` byte-equals ``min_tier_for_features_at(p, [X])`` on
+  every perspective; same for the runtimes endpoint
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# ── helpers: perspective validation ────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "bad", ["", "   ", "bogus", "cloud_pro_typo"]
+)
+def test_helper_empty_or_unknown_perspective_returns_none(ent, bad):
+    assert ent.min_tier_for_features_at(bad, ["fleet"]) is None
+    assert ent.min_tier_for_runtimes_at(bad, ["claude_code"]) is None
+
+
+def test_helper_none_perspective_returns_none(ent):
+    assert ent.min_tier_for_features_at(None, ["fleet"]) is None
+    assert ent.min_tier_for_runtimes_at(None, ["claude_code"]) is None
+
+
+def test_helper_non_string_perspective_returns_none(ent):
+    for bad in (object(), 123, ["cloud_pro"]):
+        assert ent.min_tier_for_features_at(bad, ["fleet"]) is None
+        assert ent.min_tier_for_runtimes_at(bad, ["claude_code"]) is None
+
+
+def test_helper_perspective_is_case_insensitive(ent):
+    assert (
+        ent.min_tier_for_features_at("CLOUD_PRO", ["fleet"])
+        == ent.min_tier_for_features(["fleet"])
+    )
+    assert (
+        ent.min_tier_for_runtimes_at("CLOUD_STARTER", ["claude_code"])
+        == ent.min_tier_for_runtimes(["claude_code"])
+    )
+
+
+def test_helper_perspective_is_whitespace_stripped(ent):
+    assert (
+        ent.min_tier_for_features_at("  cloud_pro  ", ["fleet"])
+        == ent.min_tier_for_features(["fleet"])
+    )
+    assert (
+        ent.min_tier_for_runtimes_at("  cloud_starter  ", ["claude_code"])
+        == ent.min_tier_for_runtimes(["claude_code"])
+    )
+
+
+def test_helper_trial_is_accepted_as_perspective(ent):
+    """Trial is in :data:`_TIER_ORDER` (non-purchasable but a valid
+    hypothetical perspective across every ``_at`` sibling)."""
+    assert (
+        ent.min_tier_for_features_at(ent.TIER_TRIAL, ["fleet"])
+        == ent.min_tier_for_features(["fleet"])
+    )
+    assert (
+        ent.min_tier_for_runtimes_at(ent.TIER_TRIAL, ["claude_code"])
+        == ent.min_tier_for_runtimes(["claude_code"])
+    )
+
+
+# ── helpers: byte-parity vs non-_at sibling for every perspective ──────────
+
+
+def _every_perspective(ent):
+    return list(ent._TIER_ORDER)
+
+
+def test_helper_features_parity_across_all_perspectives(ent):
+    bundles = [
+        [],
+        ["fleet"],
+        ["fleet", "sso"],
+        ["bogus"],
+        ["fleet", "bogus"],
+    ]
+    for p in _every_perspective(ent):
+        for bundle in bundles:
+            assert ent.min_tier_for_features_at(p, bundle) == ent.min_tier_for_features(
+                bundle
+            ), f"perspective={p} bundle={bundle}"
+
+
+def test_helper_runtimes_parity_across_all_perspectives(ent):
+    bundles = [
+        [],
+        ["claude_code"],
+        ["claude-code", "codex"],
+        ["bogus"],
+        ["claude_code", "bogus"],
+    ]
+    for p in _every_perspective(ent):
+        for bundle in bundles:
+            assert ent.min_tier_for_runtimes_at(p, bundle) == ent.min_tier_for_runtimes(
+                bundle
+            ), f"perspective={p} bundle={bundle}"
+
+
+# ── helpers: inherited semantics ───────────────────────────────────────────
+
+
+def test_helper_features_empty_iterable_returns_none(ent):
+    assert ent.min_tier_for_features_at(ent.TIER_CLOUD_PRO, []) is None
+    assert ent.min_tier_for_runtimes_at(ent.TIER_CLOUD_PRO, []) is None
+
+
+def test_helper_features_none_iterable_returns_none(ent):
+    assert ent.min_tier_for_features_at(ent.TIER_CLOUD_PRO, None) is None
+    assert ent.min_tier_for_runtimes_at(ent.TIER_CLOUD_PRO, None) is None
+
+
+def test_helper_features_all_unknown_returns_none(ent):
+    assert (
+        ent.min_tier_for_features_at(ent.TIER_CLOUD_PRO, ["bogus1", "bogus2"])
+        is None
+    )
+    assert (
+        ent.min_tier_for_runtimes_at(ent.TIER_CLOUD_PRO, ["bogus1", "bogus2"])
+        is None
+    )
+
+
+def test_helper_features_non_iterable_returns_none(ent):
+    assert ent.min_tier_for_features_at(ent.TIER_CLOUD_PRO, 42) is None
+    assert ent.min_tier_for_runtimes_at(ent.TIER_CLOUD_PRO, 42) is None
+
+
+def test_helper_runtimes_at_matches_non_at_on_canonical_id(ent):
+    """The runtime helper delegates to :func:`min_tier_for_runtimes`
+    unchanged; canonical ids resolve to the paid-runtime tier."""
+    got = ent.min_tier_for_runtimes_at(ent.TIER_CLOUD_PRO, ["claude_code"])
+    assert got == ent.min_tier_for_runtimes(["claude_code"])
+    assert got is not None
+    assert got != ent.TIER_OSS  # claude_code is a paid runtime
+
+
+# ── helpers: grace vs enforce parity ───────────────────────────────────────
+
+
+def test_helper_features_grace_vs_enforce_identical(ent, monkeypatch):
+    grace = ent.min_tier_for_features_at(ent.TIER_CLOUD_PRO, ["fleet", "sso"])
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    importlib.reload(ent)
+    enforce = ent.min_tier_for_features_at(ent.TIER_CLOUD_PRO, ["fleet", "sso"])
+    assert grace == enforce
+
+
+def test_helper_runtimes_grace_vs_enforce_identical(ent, monkeypatch):
+    grace = ent.min_tier_for_runtimes_at(ent.TIER_CLOUD_PRO, ["claude_code"])
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    importlib.reload(ent)
+    enforce = ent.min_tier_for_runtimes_at(ent.TIER_CLOUD_PRO, ["claude_code"])
+    assert grace == enforce
+
+
+# ── helpers: never-raises contract ─────────────────────────────────────────
+
+
+def test_helper_features_never_raises_on_delegate_crash(ent, monkeypatch):
+    def _boom(*_a, **_kw):
+        raise RuntimeError("delegate boom")
+
+    monkeypatch.setattr(ent, "min_tier_for_features", _boom)
+    assert (
+        ent.min_tier_for_features_at(ent.TIER_CLOUD_PRO, ["fleet"]) is None
+    )
+
+
+def test_helper_runtimes_never_raises_on_delegate_crash(ent, monkeypatch):
+    def _boom(*_a, **_kw):
+        raise RuntimeError("delegate boom")
+
+    monkeypatch.setattr(ent, "min_tier_for_runtimes", _boom)
+    assert (
+        ent.min_tier_for_runtimes_at(ent.TIER_CLOUD_PRO, ["claude_code"])
+        is None
+    )
+
+
+# ── API: happy path ───────────────────────────────────────────────────────
+
+
+_ENVELOPE_KEYS = {
+    "perspective_tier",
+    "perspective_tier_label",
+    "perspective_tier_rank",
+    "current_tier",
+    "current_tier_rank",
+    "grace",
+    "enforced",
+    "required_tier",
+    "required_tier_label",
+    "required_tier_rank",
+    "free",
+    "kind",
+    "count",
+    "unknown",
+}
+
+
+def test_api_features_at_happy_path(client, ent):
+    r = client.get(
+        "/api/entitlement/min-tier-for-features-at?tier=cloud_pro&features=fleet,sso"
+    )
+    assert r.status_code == 200
+    j = r.get_json()
+    expected = _ENVELOPE_KEYS | {"features"}
+    assert set(j.keys()) == expected
+    assert j["kind"] == "features"
+    assert j["features"] == ["fleet", "sso"]
+    assert j["unknown"] == []
+    assert j["count"] == 2
+    assert j["perspective_tier"] == "cloud_pro"
+    assert j["perspective_tier_label"] == ent.tier_label("cloud_pro")
+    assert j["perspective_tier_rank"] == ent.tier_rank("cloud_pro")
+    assert j["required_tier"] == ent.min_tier_for_features(["fleet", "sso"])
+
+
+def test_api_runtimes_at_happy_path(client, ent):
+    r = client.get(
+        "/api/entitlement/min-tier-for-runtimes-at?tier=cloud_starter&runtimes=claude-code,codex"
+    )
+    assert r.status_code == 200
+    j = r.get_json()
+    expected = _ENVELOPE_KEYS | {"runtimes"}
+    assert set(j.keys()) == expected
+    assert j["kind"] == "runtimes"
+    assert j["runtimes"] == ["claude_code", "codex"]  # canonicalised
+    assert j["unknown"] == []
+    assert j["perspective_tier"] == "cloud_starter"
+    assert j["required_tier"] == ent.min_tier_for_runtimes(
+        ["claude_code", "codex"]
+    )
+
+
+def test_api_features_at_case_insensitive_tier(client):
+    r = client.get(
+        "/api/entitlement/min-tier-for-features-at?tier=CLOUD_PRO&features=fleet"
+    )
+    assert r.status_code == 200
+    assert r.get_json()["perspective_tier"] == "cloud_pro"
+
+
+def test_api_runtimes_at_case_insensitive_tier(client):
+    r = client.get(
+        "/api/entitlement/min-tier-for-runtimes-at?tier=CLOUD_STARTER&runtimes=claude_code"
+    )
+    assert r.status_code == 200
+    assert r.get_json()["perspective_tier"] == "cloud_starter"
+
+
+def test_api_features_at_trial_perspective_accepted(client, ent):
+    r = client.get(
+        "/api/entitlement/min-tier-for-features-at?tier=trial&features=fleet"
+    )
+    assert r.status_code == 200
+    assert r.get_json()["perspective_tier"] == "trial"
+
+
+def test_api_runtimes_at_trial_perspective_accepted(client, ent):
+    r = client.get(
+        "/api/entitlement/min-tier-for-runtimes-at?tier=trial&runtimes=claude_code"
+    )
+    assert r.status_code == 200
+    assert r.get_json()["perspective_tier"] == "trial"
+
+
+# ── API: error paths ──────────────────────────────────────────────────────
+
+
+def test_api_features_at_missing_tier_returns_400(client):
+    r = client.get(
+        "/api/entitlement/min-tier-for-features-at?features=fleet"
+    )
+    assert r.status_code == 400
+
+
+def test_api_runtimes_at_missing_tier_returns_400(client):
+    r = client.get(
+        "/api/entitlement/min-tier-for-runtimes-at?runtimes=claude_code"
+    )
+    assert r.status_code == 400
+
+
+def test_api_features_at_blank_tier_returns_400(client):
+    r = client.get(
+        "/api/entitlement/min-tier-for-features-at?tier=%20%20&features=fleet"
+    )
+    assert r.status_code == 400
+
+
+def test_api_runtimes_at_blank_tier_returns_400(client):
+    r = client.get(
+        "/api/entitlement/min-tier-for-runtimes-at?tier=%20%20&runtimes=claude_code"
+    )
+    assert r.status_code == 400
+
+
+def test_api_features_at_missing_features_returns_400(client):
+    r = client.get(
+        "/api/entitlement/min-tier-for-features-at?tier=cloud_pro"
+    )
+    assert r.status_code == 400
+
+
+def test_api_runtimes_at_missing_runtimes_returns_400(client):
+    r = client.get(
+        "/api/entitlement/min-tier-for-runtimes-at?tier=cloud_pro"
+    )
+    assert r.status_code == 400
+
+
+def test_api_features_at_blank_features_returns_400(client):
+    r = client.get(
+        "/api/entitlement/min-tier-for-features-at?tier=cloud_pro&features=%20%20"
+    )
+    assert r.status_code == 400
+
+
+def test_api_runtimes_at_blank_runtimes_returns_400(client):
+    r = client.get(
+        "/api/entitlement/min-tier-for-runtimes-at?tier=cloud_pro&runtimes=%20%20"
+    )
+    assert r.status_code == 400
+
+
+def test_api_features_at_unknown_tier_returns_404(client):
+    r = client.get(
+        "/api/entitlement/min-tier-for-features-at?tier=bogus&features=fleet"
+    )
+    assert r.status_code == 404
+    j = r.get_json()
+    assert j.get("which") == "tier"
+
+
+def test_api_runtimes_at_unknown_tier_returns_404(client):
+    r = client.get(
+        "/api/entitlement/min-tier-for-runtimes-at?tier=bogus&runtimes=claude_code"
+    )
+    assert r.status_code == 404
+    j = r.get_json()
+    assert j.get("which") == "tier"
+
+
+# ── API: all-unknown IS 200 ────────────────────────────────────────────────
+
+
+def test_api_features_at_all_unknown_is_200(client):
+    r = client.get(
+        "/api/entitlement/min-tier-for-features-at?tier=cloud_pro&features=bogus1,bogus2"
+    )
+    assert r.status_code == 200
+    j = r.get_json()
+    assert j["features"] == []
+    assert j["unknown"] == ["bogus1", "bogus2"]
+    assert j["required_tier"] is None
+    assert j["count"] == 0
+    assert j["free"] is False
+
+
+def test_api_runtimes_at_all_unknown_is_200(client):
+    r = client.get(
+        "/api/entitlement/min-tier-for-runtimes-at?tier=cloud_pro&runtimes=bogus1,bogus2"
+    )
+    assert r.status_code == 200
+    j = r.get_json()
+    assert j["runtimes"] == []
+    assert j["unknown"] == ["bogus1", "bogus2"]
+    assert j["required_tier"] is None
+    assert j["count"] == 0
+
+
+# ── API: CSV normalisation / dedup ─────────────────────────────────────────
+
+
+def test_api_features_at_dedup_preserves_order(client):
+    r = client.get(
+        "/api/entitlement/min-tier-for-features-at?tier=cloud_pro&features=fleet,,sso,fleet"
+    )
+    assert r.status_code == 200
+    assert r.get_json()["features"] == ["fleet", "sso"]
+
+
+def test_api_runtimes_at_dedup_preserves_order(client):
+    r = client.get(
+        "/api/entitlement/min-tier-for-runtimes-at?tier=cloud_pro&runtimes=claude-code,,codex,claude_code"
+    )
+    assert r.status_code == 200
+    assert r.get_json()["runtimes"] == ["claude_code", "codex"]
+
+
+def test_api_features_at_mixed_known_unknown(client, ent):
+    r = client.get(
+        "/api/entitlement/min-tier-for-features-at?tier=cloud_pro&features=fleet,bogus"
+    )
+    assert r.status_code == 200
+    j = r.get_json()
+    assert j["features"] == ["fleet"]
+    assert j["unknown"] == ["bogus"]
+    assert j["required_tier"] == ent.min_tier_for_features(["fleet"])
+
+
+# ── API: cross-endpoint parity ────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "perspective",
+    ["cloud_free", "trial", "cloud_starter", "cloud_pro", "pro", "enterprise"],
+)
+def test_api_features_at_required_tier_byte_equals_helper(client, ent, perspective):
+    r = client.get(
+        f"/api/entitlement/min-tier-for-features-at?tier={perspective}&features=fleet,sso"
+    )
+    assert r.status_code == 200
+    assert (
+        r.get_json()["required_tier"]
+        == ent.min_tier_for_features_at(perspective, ["fleet", "sso"])
+    )
+
+
+@pytest.mark.parametrize(
+    "perspective",
+    ["cloud_free", "trial", "cloud_starter", "cloud_pro", "pro", "enterprise"],
+)
+def test_api_runtimes_at_required_tier_byte_equals_helper(client, ent, perspective):
+    r = client.get(
+        f"/api/entitlement/min-tier-for-runtimes-at?tier={perspective}&runtimes=claude_code,codex"
+    )
+    assert r.status_code == 200
+    assert (
+        r.get_json()["required_tier"]
+        == ent.min_tier_for_runtimes_at(perspective, ["claude_code", "codex"])
+    )
+
+
+# ── API: byte-parity vs non-_at sibling ────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "perspective",
+    ["cloud_free", "trial", "cloud_starter", "cloud_pro", "pro", "enterprise"],
+)
+def test_api_features_at_required_tier_byte_equals_non_at_helper(
+    client, ent, perspective
+):
+    r = client.get(
+        f"/api/entitlement/min-tier-for-features-at?tier={perspective}&features=fleet,sso"
+    )
+    assert r.status_code == 200
+    assert (
+        r.get_json()["required_tier"]
+        == ent.min_tier_for_features(["fleet", "sso"])
+    ), f"perspective={perspective} shaped the answer -- _at prefix must not shape rows"
+
+
+@pytest.mark.parametrize(
+    "perspective",
+    ["cloud_free", "trial", "cloud_starter", "cloud_pro", "pro", "enterprise"],
+)
+def test_api_runtimes_at_required_tier_byte_equals_non_at_helper(
+    client, ent, perspective
+):
+    r = client.get(
+        f"/api/entitlement/min-tier-for-runtimes-at?tier={perspective}&runtimes=claude_code,codex"
+    )
+    assert r.status_code == 200
+    assert (
+        r.get_json()["required_tier"]
+        == ent.min_tier_for_runtimes(["claude_code", "codex"])
+    ), f"perspective={perspective} shaped the answer -- _at prefix must not shape rows"
+
+
+# ── API: resolver envelope carried ────────────────────────────────────────
+
+
+def test_api_features_at_carries_resolver_envelope(client, ent):
+    r = client.get(
+        "/api/entitlement/min-tier-for-features-at?tier=cloud_pro&features=fleet"
+    )
+    j = r.get_json()
+    for k in ("current_tier", "current_tier_rank", "grace", "enforced"):
+        assert k in j
+    assert j["grace"] is True
+    assert j["enforced"] is False
+
+
+def test_api_runtimes_at_carries_resolver_envelope(client, ent):
+    r = client.get(
+        "/api/entitlement/min-tier-for-runtimes-at?tier=cloud_pro&runtimes=claude_code"
+    )
+    j = r.get_json()
+    for k in ("current_tier", "current_tier_rank", "grace", "enforced"):
+        assert k in j
+    assert j["grace"] is True
+    assert j["enforced"] is False


### PR DESCRIPTION
## Summary

- Adds `min_tier_for_features_at(perspective_tier, features)` and `min_tier_for_runtimes_at(perspective_tier, runtimes)` — perspective siblings of the plural `min_tier_for_features` / `min_tier_for_runtimes` helpers. Fills the `_at` slot on the plural min-tier axes so a pricing-matrix walkthrough (`?tier=<p>`) can hit these endpoints uniformly across the whole `_at` family (matches `min_tier_batch_at`, `affordable_tiers_at`, `min_tier_for_all_at`, etc.).
- Adds `GET /api/entitlement/min-tier-for-features-at?tier=<p>&features=<csv>` and `GET /api/entitlement/min-tier-for-runtimes-at?tier=<p>&runtimes=<csv>`. Perspective envelope (`perspective_tier` / `perspective_tier_label` / `perspective_tier_rank`) layers on top of the standard resolver envelope so the walkthrough surface reads current tier / grace / enforced off ONE round-trip.
- Grace-mode change only — no behaviour change on any existing surface, no `__version__` bump, no `[RELEASE]` PR, no gate enforced.

## Why

Every other `_at` family sibling — `min_tier_batch_at`, `affordable_tiers_at`, `min_tier_for_all_at`, `tiers_for_feature_at` / `tiers_for_runtime_at` / `tiers_for_batch_at`, and the recently landed `min_tier_batch_at` — has a hypothetical-perspective counterpart so a pricing walkthrough can pass `tier=<p>` uniformly and get a full picture back. The plural `min_tier_for_features` / `min_tier_for_runtimes` axis was the missing `_at` slot: today a pricing surface has to fall back to `/required-tier-batch?features=<csv>` (which combines features + runtimes into one scalar and lacks the perspective envelope) or fan out one `/required-tier?feature=<f>` per id and max-by-rank on the client. This PR closes that gap so every axis in the min_tier family exposes an `_at` sibling on both the helper and the HTTP surface.

The scalar `required_tier` is perspective-independent by design — it depends only on the static per-tier feature/runtime map. A parity contract pinned in the test suite guarantees `min_tier_for_features_at(p, ...) == min_tier_for_features(...)` for every `p` in `_TIER_ORDER` (including `trial`); same for runtimes. This mirrors the `_at`-does-not-shape-rows contract every sibling `_at` helper follows.

## Changes

### `clawmetry/entitlements.py`

- `min_tier_for_features_at(perspective_tier, features)` — validates perspective against `_TIER_ORDER` (trial accepted), delegates to `min_tier_for_features`. Empty/blank/`None`/non-string/unknown perspective → `None`. Case-insensitive + whitespace-stripped. Never raises: a delegate crash logs a warning and returns `None`.
- `min_tier_for_runtimes_at(perspective_tier, runtimes)` — runtime-axis twin. Semantics inherited from `min_tier_for_runtimes` (which does not itself canonicalise aliases; canonicalisation happens at the HTTP layer).

### `routes/entitlement.py`

- `GET /api/entitlement/min-tier-for-features-at` and `/min-tier-for-runtimes-at`. Response shape:

```json
{
  "features":               ["fleet", "sso"],
  "unknown":                ["bogus"],
  "kind":                   "features",
  "count":                  2,
  "required_tier":          "enterprise",
  "required_tier_label":    "Enterprise",
  "required_tier_rank":     5,
  "free":                   false,
  "perspective_tier":       "cloud_pro",
  "perspective_tier_label": "Cloud Pro",
  "perspective_tier_rank":  3,
  "current_tier":           "oss",
  "current_tier_rank":      0,
  "grace":                  true,
  "enforced":               false
}
```

- **400** on missing/blank `tier=`, or missing/blank `features=` / `runtimes=` after CSV normalisation.
- **404** on unknown `tier` (body carries `which=tier`).
- **All-unknown IS 200** with `unknown[]` populated and `required_tier=null` — distinguishes "asked for nothing" from "asked but every token was a typo" so a paywall UI can render "these ids are unknown: X" instead of a null.
- Runtime endpoint canonicalises aliases (`claude-code` → `claude_code`) via `canonical_runtime`. Reuses the existing `_parse_csv_arg` helper so dedup / normalisation matches `/required-tier-batch` byte-for-byte.
- Never 5xxs: a resolver failure yields the fallback envelope (empty items list, `required_tier=null`) so the pricing walkthrough keeps rendering.

### `tests/test_entitlement_min_tier_for_plural_at.py`

**67 tests, all green** (3.20s):

- perspective validation: empty / blank / `None` / non-string / unknown → `None` at the helper layer; 400 / 404 at the HTTP layer
- trial accepted as perspective
- case-insensitive + whitespace-stripped perspective (`?tier=CLOUD_PRO` → `cloud_pro`)
- byte-parity vs the non-`_at` sibling for every perspective in `_TIER_ORDER` — pins the `_at` prefix against silently shaping the answer
- inherited semantics: empty iterable / `None` / all-unknown → `None`; non-iterable → `None`
- grace vs enforce yields byte-identical results (pinned via a `CLAWMETRY_ENFORCE=1` reload roundtrip)
- helpers never raise on a delegate crash (`monkeypatch` the delegate to raise)
- API happy paths: single + multi item, case-insensitive tier, trial perspective, envelope shape
- API error paths: 400 on missing/blank `tier=` / `features=` / `runtimes=`; 404 on unknown tier
- All-unknown IS 200 with `unknown[]` populated and `required_tier=null`
- CSV dedup preserves first-seen order; runtime aliases canonicalised on the endpoint
- Cross-endpoint parity: `/min-tier-for-features-at?tier=<p>&features=...` `.required_tier` byte-equals `min_tier_for_features_at(p, [...])` on every perspective; same for runtimes
- Resolver envelope carried on every response (`current_tier`, `grace`, `enforced`)

## Test plan

- [x] `python3 -m py_compile clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_min_tier_for_plural_at.py` — clean
- [x] `ruff check` on the three changed files — clean (`All checks passed!`)
- [x] `pytest tests/test_entitlement_min_tier_for_plural_at.py -v` → **67/67 pass** in 3.20s
- [x] Sibling test files (`test_entitlement_min_tier_batch_at`, `test_entitlement_api`, `test_entitlement_tiers_for_capacity`, `test_blueprint_uniqueness`, `test_circular_import`) still green — **157/157 pass**

## Local operator verification checklist

I can't touch the running daemon, `~/.openclaw`, the live snapshot, or a browser from here — please run:

- [ ] Copy the changed files into `~/.clawmetry/lib/python3.11/site-packages/clawmetry/` (`entitlements.py`) and `~/.clawmetry/lib/python3.11/site-packages/routes/` (`entitlement.py`); drop the test file into the local checkout under `tests/`
- [ ] Clear `__pycache__` on both dirs
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
- [ ] `curl -s 'http://localhost:8900/api/entitlement/min-tier-for-features-at?tier=cloud_pro&features=fleet,sso' | jq .` — expect `features=["fleet","sso"]`, `required_tier="enterprise"` (sso is enterprise-only), `perspective_tier="cloud_pro"`, resolver envelope populated
- [ ] `curl -s 'http://localhost:8900/api/entitlement/min-tier-for-runtimes-at?tier=cloud_starter&runtimes=claude-code,codex' | jq .` — expect `runtimes=["claude_code","codex"]` (alias canonicalised), `required_tier="cloud_starter"`
- [ ] `curl -s -o /dev/null -w '%{http_code}\n' 'http://localhost:8900/api/entitlement/min-tier-for-features-at?features=fleet'` → `400`
- [ ] `curl -s -o /dev/null -w '%{http_code}\n' 'http://localhost:8900/api/entitlement/min-tier-for-runtimes-at?tier=cloud_pro'` → `400`
- [ ] `curl -s -o /dev/null -w '%{http_code}\n' 'http://localhost:8900/api/entitlement/min-tier-for-features-at?tier=bogus&features=fleet'` → `404`
- [ ] `curl -s 'http://localhost:8900/api/entitlement/min-tier-for-features-at?tier=cloud_pro&features=bogus1,bogus2' | jq .` — expect 200, `features=[]`, `unknown=["bogus1","bogus2"]`, `required_tier=null`, `count=0`
- [ ] Cross-check byte-parity: `.required_tier` on `/min-tier-for-features-at?tier=<p>&features=fleet,sso` must equal `.required_tier` from `/required-tier-batch?features=fleet,sso` on every `<p>` in `_TIER_ORDER`
- [ ] Decrypt the live cloud snapshot and hit the same endpoints against the cloud read-through path
- [ ] Browser check: no existing surface calls these new routes yet; every existing paywall / required-tier surface should keep rendering unchanged

No `__version__` bump, no tag, no `[RELEASE]` PR — staying in DRAFT until you've cleared local + cloud verification.

## MOAT / release checklist

- Not a MOAT fast-path change (no `local_store_via_daemon` / `_ls_call` / `_DAEMON_METHODS` touched).
- Not a `[RELEASE]` PR.


---
_Generated by [Claude Code](https://claude.ai/code/session_014eyh9MyTovcNvgox3dX6cE)_