### PR TITLE
feat(entitlement): min_tier_at + /api/entitlement/min-tier-at

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -5718,6 +5718,109 @@ def min_tier_batch_at(
         return None
 
 
+def min_tier_at(
+    perspective_tier: str,
+    *,
+    feature: str | None = None,
+    runtime: str | None = None,
+    channels: int | None = None,
+    retention_days: int | None = None,
+    nodes: int | None = None,
+) -> str | None:
+    """Perspective-scoped scalar sibling of the five singular
+    ``min_tier_for_*`` helpers -- the cheapest purchasable tier that
+    admits a single-axis constraint, scoped by a caller-supplied
+    ``perspective_tier``.
+
+    Fills the ``_at`` slot for the singular-scalar min-tier surface
+    alongside :func:`min_tier_batch_at` (per-item batch what-if) and
+    :func:`min_tier_for_all_at` (aggregate bundle what-if). A pricing-
+    matrix walkthrough at a hypothetical perspective (``tier=<p>``) can
+    then hit ``min_tier_at`` uniformly for a single-axis scalar query,
+    matching the URL shape it already uses for the batch and bundle
+    siblings.
+
+    Same relationship to the singular ``min_tier_for_*`` helpers that
+    :func:`min_tier_batch_at` has to :func:`min_tier_batch` and
+    :func:`min_tier_for_all_at` has to :func:`min_tier_for_all`: the
+    scalar answer is inherently perspective-independent (it walks the
+    static per-tier caps via the matching ``min_tier_for_*`` helper),
+    so ``perspective_tier`` is validated but does NOT shape the result.
+    A parity test pins ``min_tier_at(p, **axis) ==
+    min_tier_for_<axis>(**axis)`` for every ``p`` in :data:`_TIER_ORDER`
+    (including :data:`TIER_TRIAL`) so the ``_at`` prefix cannot silently
+    drift into shaping the answer.
+
+    Exactly one axis must be supplied:
+
+    * ``feature=<id>`` -> delegates to :func:`min_tier_for_feature`.
+    * ``runtime=<id>`` -> delegates to :func:`min_tier_for_runtime`.
+      Aliases with hyphens (e.g. ``claude-code``) are NOT canonicalised
+      -- they land as unknown ids and return ``None``, matching the
+      ``/min-tier`` route posture and every other singular scalar
+      helper on this axis. Callers that need alias canonicalisation
+      should preprocess via :func:`canonical_runtime`.
+    * ``channels=<int>`` -> delegates to :func:`min_tier_for_channel_count`.
+    * ``retention_days=<int>`` -> delegates to :func:`min_tier_for_retention_window`.
+      ``None`` here means *unset* (zero-axes-supplied), NOT the
+      unlimited-history sentinel -- pass the unlimited request through
+      :func:`min_tier_for_retention_window` directly (matches the
+      ``/min-tier`` route, which never accepts ``None`` on this axis
+      either).
+    * ``nodes=<int>`` -> delegates to :func:`min_tier_for_node_count`.
+
+    Zero or more than one axis supplied -> ``None``. Empty / blank /
+    ``None`` / non-string / unknown ``perspective_tier`` -> ``None``.
+    Perspective is case-insensitive and whitespace-stripped (matches
+    every other ``_at`` sibling).
+
+    Decoupled from the resolved entitlement (delegates to the static
+    per-tier map through the singular ``min_tier_for_*`` helpers), so
+    grace vs enforce yields byte-identical answers.
+
+    Never raises: a delegate crash logs a warning and returns ``None``
+    so a pricing-matrix walkthrough keeps rendering instead of breaking.
+    """
+    try:
+        p = (perspective_tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if not p or p not in _TIER_ORDER:
+        return None
+
+    def _axis_supplied(value) -> bool:
+        if value is None:
+            return False
+        if isinstance(value, str):
+            return value.strip() != ""
+        return True
+
+    axes = (
+        _axis_supplied(feature),
+        _axis_supplied(runtime),
+        channels is not None,
+        retention_days is not None,
+        nodes is not None,
+    )
+    if sum(1 for a in axes if a) != 1:
+        return None
+    try:
+        if _axis_supplied(feature):
+            return min_tier_for_feature(feature)
+        if _axis_supplied(runtime):
+            return min_tier_for_runtime(runtime)
+        if channels is not None:
+            return min_tier_for_channel_count(channels)
+        if retention_days is not None:
+            return min_tier_for_retention_window(retention_days)
+        if nodes is not None:
+            return min_tier_for_node_count(nodes)
+    except Exception as exc:
+        logger.warning("entitlements: min_tier_at failed: %s", exc)
+        return None
+    return None
+
+
 def _affordable_row(key, kind: str) -> dict:
     """Per-item full-list qualifying-tier row for
     :func:`affordable_tiers_batch`.

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -5764,6 +5764,250 @@ def api_entitlement_min_tier_batch_at():
         )
 
 
+@bp_entitlement.route("/api/entitlement/min-tier-at")
+def api_entitlement_min_tier_at():
+    """``GET /api/entitlement/min-tier-at?tier=<perspective>&<axis>=<value>``
+    -- hypothetical-perspective sibling of ``/api/entitlement/min-tier``.
+
+    Wraps :func:`entitlements.min_tier_at` so a pricing-matrix walkthrough
+    at a hypothetical perspective can render "if I were on Starter, this
+    ONE axis constraint would land at Pro" off ONE round-trip without
+    switching the resolver. Fills the ``_at`` slot for the singular
+    scalar min-tier surface alongside :func:`api_entitlement_min_tier_batch_at`
+    (per-item batch what-if) and :func:`api_entitlement_required_tier_at`
+    (aggregate bundle what-if) so a caller can call ``X_at`` uniformly
+    across the whole ``_at`` scalar / batch / bundle surface.
+
+    Args mirror ``/api/entitlement/min-tier`` byte-for-byte -- exactly
+    one of ``feature=<id>``, ``runtime=<id>``, ``channels=<int>``,
+    ``retention_days=<int>``, or ``nodes=<int>`` must be supplied --
+    plus the additional ``tier=`` perspective arg. Perspective is
+    validated against :data:`entitlements._TIER_ORDER` (including
+    :data:`entitlements.TIER_TRIAL`) but does NOT shape the result: the
+    scalar answer is inherently perspective-independent (it walks the
+    static per-tier caps via the matching ``min_tier_for_<axis>``
+    helper), so per-row output byte-equals ``/min-tier`` for the same
+    axis regardless of perspective. A cross-endpoint parity test pins
+    this so the scalar what-if and the scalar current cannot silently
+    drift.
+
+    Response shape mirrors ``/min-tier`` (``key`` / ``value`` / ``free``
+    / ``min_tier`` / ``tier_label`` / ``tier_rank``) with the
+    ``perspective_tier`` / ``perspective_tier_label`` /
+    ``perspective_tier_rank`` envelope and the standard resolver
+    envelope (``current_tier`` / ``current_tier_rank`` / ``grace`` /
+    ``enforced``) layered on so the pricing surface reads current tier /
+    grace / enforced off the same call.
+
+    - **400** when ``tier=`` is missing / blank, or when zero / more
+      than one axis is supplied, or when a capacity axis value is
+      non-int.
+    - **404** when ``tier=`` is unknown (body carries ``which=tier``),
+      or when the ``feature=`` / ``runtime=`` id is unknown (matches
+      ``/min-tier``'s 404 posture on unknown grant ids). Capacity axes
+      never 404 -- any parseable int (including zero / negative --
+      which collapses to :data:`entitlements.TIER_OSS` matching the
+      helpers' contract) resolves to a real tier.
+    - **Never 5xxs**: a resolver failure yields the same shape with
+      ``min_tier=null`` and the perspective envelope populated so the
+      pricing walkthrough keeps rendering.
+    """
+    raw_tier = request.args.get("tier")
+    tier_in = (raw_tier or "").strip().lower()
+    if not tier_in:
+        return jsonify({"error": "missing tier"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        if tier_in not in _ent._TIER_ORDER:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "tier", "tier": tier_in}
+                ),
+                404,
+            )
+
+        feature = (request.args.get("feature") or "").strip()
+        runtime = (request.args.get("runtime") or "").strip().lower()
+        (
+            channels_present,
+            channels_ok,
+            channels_n,
+            channels_raw,
+        ) = _parse_capacity_arg("channels")
+        (
+            retention_present,
+            retention_ok,
+            retention_n,
+            retention_raw,
+        ) = _parse_capacity_arg("retention_days")
+        (
+            nodes_present,
+            nodes_ok,
+            nodes_n,
+            nodes_raw,
+        ) = _parse_capacity_arg("nodes")
+
+        supplied = [
+            bool(feature),
+            bool(runtime),
+            channels_present,
+            retention_present,
+            nodes_present,
+        ]
+        n_supplied = sum(1 for s in supplied if s)
+        if n_supplied == 0:
+            return (
+                jsonify(
+                    {
+                        "error": (
+                            "supply exactly one of feature=<id>, "
+                            "runtime=<id>, channels=<int>, "
+                            "retention_days=<int>, or nodes=<int>"
+                        ),
+                    }
+                ),
+                400,
+            )
+        if n_supplied > 1:
+            return (
+                jsonify(
+                    {
+                        "error": (
+                            "supply only one of feature=, runtime=, "
+                            "channels=, retention_days=, or nodes="
+                        ),
+                    }
+                ),
+                400,
+            )
+        if channels_present and not channels_ok:
+            return (
+                jsonify({"error": "channels= must be an integer"}),
+                400,
+            )
+        if retention_present and not retention_ok:
+            return (
+                jsonify({"error": "retention_days= must be an integer"}),
+                400,
+            )
+        if nodes_present and not nodes_ok:
+            return (
+                jsonify({"error": "nodes= must be an integer"}),
+                400,
+            )
+
+        if feature:
+            min_t = _ent.min_tier_for_feature(feature)
+            key, value = "feature", feature
+            known = feature in _ent.ALL_FEATURES
+        elif runtime:
+            min_t = _ent.min_tier_for_runtime(runtime)
+            key, value = "runtime", runtime
+            known = runtime in _ent.ALL_RUNTIMES
+        elif channels_present:
+            min_t = _ent.min_tier_for_channel_count(channels_n)
+            key, value = "channels", str(channels_n)
+            known = True
+        elif retention_present:
+            min_t = _ent.min_tier_for_retention_window(retention_n)
+            key, value = "retention_days", str(retention_n)
+            known = True
+        else:
+            min_t = _ent.min_tier_for_node_count(nodes_n)
+            key, value = "nodes", str(nodes_n)
+            known = True
+
+        ent = _ent.get_entitlement()
+        base = {
+            "perspective_tier": tier_in,
+            "perspective_tier_label": _ent.tier_label(tier_in),
+            "perspective_tier_rank": _ent.tier_rank(tier_in),
+            "current_tier": ent.tier,
+            "current_tier_rank": _ent.tier_rank(ent.tier),
+            "grace": bool(ent.grace),
+            "enforced": _ent.is_enforced(),
+        }
+        if not known:
+            return (
+                jsonify(
+                    {
+                        "key": key,
+                        "value": value,
+                        "free": False,
+                        "min_tier": None,
+                        "tier_label": None,
+                        "tier_rank": None,
+                        "error": "unknown",
+                        **base,
+                    }
+                ),
+                404,
+            )
+        return jsonify(
+            {
+                "key": key,
+                "value": value,
+                "free": min_t == _ent.TIER_OSS,
+                "min_tier": min_t,
+                "tier_label": _ent.tier_label(min_t) if min_t else None,
+                "tier_rank": _ent.tier_rank(min_t) if min_t else None,
+                **base,
+            }
+        )
+    except Exception as exc:
+        logger.warning("api_entitlement_min_tier_at: error: %s", exc)
+        feature = (request.args.get("feature") or "").strip()
+        runtime = (request.args.get("runtime") or "").strip().lower()
+        (
+            channels_present,
+            _channels_ok,
+            _channels_n,
+            channels_raw,
+        ) = _parse_capacity_arg("channels")
+        (
+            retention_present,
+            _retention_ok,
+            _retention_n,
+            retention_raw,
+        ) = _parse_capacity_arg("retention_days")
+        (
+            nodes_present,
+            _nodes_ok,
+            _nodes_n,
+            nodes_raw,
+        ) = _parse_capacity_arg("nodes")
+        if feature:
+            key, value = "feature", feature
+        elif runtime:
+            key, value = "runtime", runtime
+        elif channels_present:
+            key, value = "channels", channels_raw
+        elif retention_present:
+            key, value = "retention_days", retention_raw
+        elif nodes_present:
+            key, value = "nodes", nodes_raw
+        else:
+            key, value = "", ""
+        return jsonify(
+            {
+                "key": key,
+                "value": value,
+                "free": False,
+                "min_tier": None,
+                "tier_label": None,
+                "tier_rank": None,
+                "perspective_tier": tier_in,
+                "perspective_tier_label": None,
+                "perspective_tier_rank": -1,
+                "current_tier": "oss",
+                "current_tier_rank": 0,
+                "grace": True,
+                "enforced": False,
+            }
+        )
+
+
 @bp_entitlement.route("/api/entitlement/affordable-tiers-batch")
 def api_entitlement_affordable_tiers_batch():
     """``GET /api/entitlement/affordable-tiers-batch?features=a,b,c

--- a/tests/test_entitlement_min_tier_at.py
+++ b/tests/test_entitlement_min_tier_at.py
@@ -1,0 +1,626 @@
+"""Tests for ``clawmetry.entitlements.min_tier_at`` and the
+``GET /api/entitlement/min-tier-at`` endpoint.
+
+Perspective-scoped scalar sibling of the five singular ``min_tier_for_*``
+helpers -- the cheapest purchasable tier that admits a single-axis
+constraint, scoped by a caller-supplied ``perspective_tier``. Same
+relationship to :func:`min_tier_for_feature` / :func:`min_tier_for_runtime`
+/ :func:`min_tier_for_channel_count` / :func:`min_tier_for_retention_window`
+/ :func:`min_tier_for_node_count` that :func:`min_tier_batch_at` has to
+:func:`min_tier_batch` and :func:`min_tier_for_all_at` has to
+:func:`min_tier_for_all` -- perspective is validated but does NOT shape
+the answer so a walkthrough surface can call ``X_at(perspective, axis)``
+uniformly across every ``_at`` scalar / batch / bundle sibling.
+
+These tests pin:
+
+* perspective validation: empty / blank / None / non-string / unknown
+  short-circuits to ``None`` at the helper layer; 400 / 404 at the HTTP
+  layer
+* trial accepted as perspective (matches every other ``_at`` sibling)
+* perspective case-insensitive + whitespace-stripped
+* axis validation: zero axes / more than one axis short-circuits to
+  ``None`` at the helper layer; 400 at the HTTP layer
+* per-axis parity with the singular ``min_tier_for_*`` helper for every
+  perspective in :data:`_TIER_ORDER` -- the ``_at`` prefix cannot silently
+  drift into shaping the answer
+* per-axis coverage: every feature id in :data:`ALL_FEATURES`, every
+  runtime id in :data:`ALL_RUNTIMES`, and every capacity axis
+* runtime canonicalisation (``claude-code`` -> ``claude_code``) via the
+  singular helper
+* ``retention_days=None`` in the helper means unset (matches the route
+  parsing), NOT the unlimited-history sentinel
+* grace vs enforce yields byte-identical answers (pinned via a
+  ``CLAWMETRY_ENFORCE=1`` reload roundtrip)
+* helper never raises on a delegate crash (``monkeypatch`` the delegate
+  to raise)
+* API happy paths: all five axes, case-insensitive tier, trial
+  perspective, envelope shape
+* API error paths: 400 on missing / blank ``tier=``, 400 on no axis /
+  more than one axis / non-int capacity, 404 on unknown ``tier=``, 404
+  on unknown feature / runtime id
+* Cross-endpoint parity: ``/min-tier-at?tier=<p>&<axis>=<v>`` on the
+  scalar body (drop the perspective + resolver envelope keys) byte-equals
+  ``/min-tier?<axis>=<v>`` for every ``p`` in :data:`_TIER_ORDER`
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# ────────────────────────── perspective validation ──────────────────────────
+
+
+def test_helper_empty_perspective_returns_none(ent):
+    assert ent.min_tier_at("", feature="fleet") is None
+
+
+def test_helper_blank_perspective_returns_none(ent):
+    assert ent.min_tier_at("   ", feature="fleet") is None
+
+
+def test_helper_none_perspective_returns_none(ent):
+    assert ent.min_tier_at(None, feature="fleet") is None  # type: ignore[arg-type]
+
+
+def test_helper_unknown_perspective_returns_none(ent):
+    assert ent.min_tier_at("bogus", feature="fleet") is None
+
+
+def test_helper_non_string_perspective_returns_none(ent):
+    assert ent.min_tier_at(42, feature="fleet") is None  # type: ignore[arg-type]
+    assert ent.min_tier_at([], feature="fleet") is None  # type: ignore[arg-type]
+
+
+def test_helper_perspective_is_case_insensitive(ent):
+    for p in ent._TIER_ORDER:
+        assert (
+            ent.min_tier_at(p.upper(), feature="fleet")
+            == ent.min_tier_at(p, feature="fleet")
+        )
+
+
+def test_helper_perspective_is_whitespace_stripped(ent):
+    for p in ent._TIER_ORDER:
+        assert (
+            ent.min_tier_at(f"  {p}  ", feature="fleet")
+            == ent.min_tier_at(p, feature="fleet")
+        )
+
+
+def test_helper_trial_is_accepted_as_perspective(ent):
+    got = ent.min_tier_at(ent.TIER_TRIAL, feature="fleet")
+    assert got == ent.min_tier_for_feature("fleet")
+
+
+# ─────────────────────────────── axis validation ───────────────────────────────
+
+
+def test_helper_zero_axes_returns_none(ent):
+    for p in ent._TIER_ORDER:
+        assert ent.min_tier_at(p) is None
+
+
+def test_helper_two_axes_returns_none(ent):
+    for p in ent._TIER_ORDER:
+        assert ent.min_tier_at(p, feature="fleet", channels=5) is None
+        assert ent.min_tier_at(p, runtime="claude_code", nodes=3) is None
+        assert (
+            ent.min_tier_at(
+                p, retention_days=30, nodes=3
+            )
+            is None
+        )
+
+
+def test_helper_three_axes_returns_none(ent):
+    for p in ent._TIER_ORDER:
+        assert (
+            ent.min_tier_at(
+                p, feature="fleet", runtime="claude_code", channels=5
+            )
+            is None
+        )
+
+
+def test_helper_all_five_axes_returns_none(ent):
+    for p in ent._TIER_ORDER:
+        assert (
+            ent.min_tier_at(
+                p,
+                feature="fleet",
+                runtime="claude_code",
+                channels=5,
+                retention_days=30,
+                nodes=3,
+            )
+            is None
+        )
+
+
+def test_helper_blank_feature_string_treated_as_unsupplied(ent):
+    # A blank feature="" behaves as if that axis wasn't passed; combined
+    # with an actually-supplied axis it degrades to a single-axis call.
+    for p in ent._TIER_ORDER:
+        assert (
+            ent.min_tier_at(p, feature="", channels=5)
+            == ent.min_tier_for_channel_count(5)
+        )
+
+
+def test_helper_blank_runtime_string_treated_as_unsupplied(ent):
+    for p in ent._TIER_ORDER:
+        assert (
+            ent.min_tier_at(p, runtime="   ", nodes=3)
+            == ent.min_tier_for_node_count(3)
+        )
+
+
+# ─────────────────────────── per-axis parity contract ───────────────────────────
+
+
+def test_helper_feature_parity_across_perspectives(ent):
+    for p in ent._TIER_ORDER:
+        for fid in ent.ALL_FEATURES:
+            assert (
+                ent.min_tier_at(p, feature=fid)
+                == ent.min_tier_for_feature(fid)
+            )
+
+
+def test_helper_runtime_parity_across_perspectives(ent):
+    for p in ent._TIER_ORDER:
+        for rt in ent.ALL_RUNTIMES:
+            assert (
+                ent.min_tier_at(p, runtime=rt)
+                == ent.min_tier_for_runtime(rt)
+            )
+
+
+def test_helper_channels_parity_across_perspectives(ent):
+    for p in ent._TIER_ORDER:
+        for n in (0, 1, 3, 5, 10, 100):
+            assert (
+                ent.min_tier_at(p, channels=n)
+                == ent.min_tier_for_channel_count(n)
+            )
+
+
+def test_helper_retention_parity_across_perspectives(ent):
+    for p in ent._TIER_ORDER:
+        for d in (0, 1, 7, 30, 90, 365):
+            assert (
+                ent.min_tier_at(p, retention_days=d)
+                == ent.min_tier_for_retention_window(d)
+            )
+
+
+def test_helper_nodes_parity_across_perspectives(ent):
+    for p in ent._TIER_ORDER:
+        for n in (0, 1, 3, 5, 10, 100):
+            assert (
+                ent.min_tier_at(p, nodes=n)
+                == ent.min_tier_for_node_count(n)
+            )
+
+
+def test_helper_runtime_alias_not_canonicalised(ent):
+    # Matches min_tier_for_runtime's contract: aliases with hyphens are
+    # not canonicalised at the helper layer -- they land as unknown ids.
+    # The /min-tier route has the same posture (no canonical_runtime
+    # call), so scalar and _at siblings stay in step.
+    for p in ent._TIER_ORDER:
+        assert ent.min_tier_at(p, runtime="claude-code") is None
+        assert ent.min_tier_for_runtime("claude-code") is None
+
+
+def test_helper_unknown_feature_returns_none(ent):
+    for p in ent._TIER_ORDER:
+        assert ent.min_tier_at(p, feature="bogus-feature") is None
+
+
+def test_helper_unknown_runtime_returns_none(ent):
+    for p in ent._TIER_ORDER:
+        assert ent.min_tier_at(p, runtime="bogus-runtime") is None
+
+
+def test_helper_retention_none_kwarg_means_unset(ent):
+    # retention_days=None with no other axis supplied -> 0 axes -> None.
+    # The unlimited-history sentinel must be requested through the
+    # singular helper directly (matches the /min-tier route parsing).
+    for p in ent._TIER_ORDER:
+        assert ent.min_tier_at(p, retention_days=None) is None
+
+
+def test_helper_channels_none_kwarg_means_unset(ent):
+    for p in ent._TIER_ORDER:
+        assert ent.min_tier_at(p, channels=None) is None
+
+
+def test_helper_nodes_none_kwarg_means_unset(ent):
+    for p in ent._TIER_ORDER:
+        assert ent.min_tier_at(p, nodes=None) is None
+
+
+def test_helper_channels_negative_collapses_to_oss(ent):
+    for p in ent._TIER_ORDER:
+        assert ent.min_tier_at(p, channels=-1) == ent.TIER_OSS
+        assert ent.min_tier_at(p, channels=0) == ent.TIER_OSS
+
+
+def test_helper_nodes_negative_collapses_to_oss(ent):
+    for p in ent._TIER_ORDER:
+        assert ent.min_tier_at(p, nodes=-1) == ent.TIER_OSS
+        assert ent.min_tier_at(p, nodes=0) == ent.TIER_OSS
+
+
+def test_helper_retention_negative_collapses_to_oss(ent):
+    for p in ent._TIER_ORDER:
+        assert ent.min_tier_at(p, retention_days=-1) == ent.TIER_OSS
+        assert ent.min_tier_at(p, retention_days=0) == ent.TIER_OSS
+
+
+def test_helper_channels_non_int_returns_none(ent):
+    for p in ent._TIER_ORDER:
+        assert ent.min_tier_at(p, channels="not-an-int") is None  # type: ignore[arg-type]
+
+
+def test_helper_nodes_non_int_returns_none(ent):
+    for p in ent._TIER_ORDER:
+        assert ent.min_tier_at(p, nodes="not-an-int") is None  # type: ignore[arg-type]
+
+
+def test_helper_retention_non_int_returns_none(ent):
+    for p in ent._TIER_ORDER:
+        assert ent.min_tier_at(p, retention_days="not-an-int") is None  # type: ignore[arg-type]
+
+
+# ────────────────────────────── grace vs enforce ──────────────────────────────
+
+
+def test_helper_grace_vs_enforce_yields_byte_identical_answers(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    import clawmetry.entitlements as e_grace
+
+    importlib.reload(e_grace)
+    e_grace.invalidate()
+    grace_answers = {
+        p: [
+            e_grace.min_tier_at(p, feature="fleet"),
+            e_grace.min_tier_at(p, runtime="claude_code"),
+            e_grace.min_tier_at(p, channels=5),
+            e_grace.min_tier_at(p, retention_days=30),
+            e_grace.min_tier_at(p, nodes=3),
+        ]
+        for p in e_grace._TIER_ORDER
+    }
+    e_grace.invalidate()
+
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    import clawmetry.entitlements as e_enf
+
+    importlib.reload(e_enf)
+    e_enf.invalidate()
+    enf_answers = {
+        p: [
+            e_enf.min_tier_at(p, feature="fleet"),
+            e_enf.min_tier_at(p, runtime="claude_code"),
+            e_enf.min_tier_at(p, channels=5),
+            e_enf.min_tier_at(p, retention_days=30),
+            e_enf.min_tier_at(p, nodes=3),
+        ]
+        for p in e_enf._TIER_ORDER
+    }
+    e_enf.invalidate()
+
+    assert grace_answers == enf_answers
+
+    # Restore grace mode for downstream tests.
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    importlib.reload(e_grace)
+    e_grace.invalidate()
+
+
+# ──────────────────────────── never-raise contract ────────────────────────────
+
+
+def test_helper_never_raises_on_delegate_crash(monkeypatch, ent):
+    def _boom(*_a, **_k):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(ent, "min_tier_for_feature", _boom)
+    monkeypatch.setattr(ent, "min_tier_for_runtime", _boom)
+    monkeypatch.setattr(ent, "min_tier_for_channel_count", _boom)
+    monkeypatch.setattr(ent, "min_tier_for_retention_window", _boom)
+    monkeypatch.setattr(ent, "min_tier_for_node_count", _boom)
+
+    for p in ent._TIER_ORDER:
+        assert ent.min_tier_at(p, feature="fleet") is None
+        assert ent.min_tier_at(p, runtime="claude_code") is None
+        assert ent.min_tier_at(p, channels=5) is None
+        assert ent.min_tier_at(p, retention_days=30) is None
+        assert ent.min_tier_at(p, nodes=3) is None
+
+
+# ─────────────────────────────── API happy paths ───────────────────────────────
+
+
+def test_api_feature_happy_path(client, ent):
+    r = client.get(
+        "/api/entitlement/min-tier-at?tier=cloud_pro&feature=fleet"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["key"] == "feature"
+    assert body["value"] == "fleet"
+    assert body["min_tier"] == ent.min_tier_for_feature("fleet")
+    assert body["perspective_tier"] == "cloud_pro"
+    assert body["perspective_tier_label"] == ent.tier_label("cloud_pro")
+    assert body["perspective_tier_rank"] == ent.tier_rank("cloud_pro")
+    assert "current_tier" in body
+    assert "current_tier_rank" in body
+    assert "grace" in body
+    assert "enforced" in body
+
+
+def test_api_runtime_happy_path(client, ent):
+    r = client.get(
+        "/api/entitlement/min-tier-at?tier=cloud_starter&runtime=claude_code"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["key"] == "runtime"
+    assert body["value"] == "claude_code"
+    assert body["min_tier"] == ent.min_tier_for_runtime("claude_code")
+
+
+def test_api_runtime_alias_unknown(client, ent):
+    # /min-tier-at follows /min-tier: hyphen-alias runtime ids are not
+    # canonicalised at the route layer, so they surface as unknown
+    # (matches min_tier_for_runtime, whose PAID_RUNTIMES set only holds
+    # canonical underscore-form ids).
+    r = client.get(
+        "/api/entitlement/min-tier-at?tier=cloud_pro&runtime=claude-code"
+    )
+    assert r.status_code == 404
+    body = r.get_json()
+    assert body.get("error") == "unknown"
+    assert body["min_tier"] is None
+
+
+def test_api_channels_happy_path(client, ent):
+    r = client.get(
+        "/api/entitlement/min-tier-at?tier=cloud_pro&channels=5"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["key"] == "channels"
+    assert body["value"] == "5"
+    assert body["min_tier"] == ent.min_tier_for_channel_count(5)
+
+
+def test_api_retention_happy_path(client, ent):
+    r = client.get(
+        "/api/entitlement/min-tier-at?tier=cloud_pro&retention_days=30"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["key"] == "retention_days"
+    assert body["value"] == "30"
+    assert body["min_tier"] == ent.min_tier_for_retention_window(30)
+
+
+def test_api_nodes_happy_path(client, ent):
+    r = client.get(
+        "/api/entitlement/min-tier-at?tier=cloud_pro&nodes=3"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["key"] == "nodes"
+    assert body["value"] == "3"
+    assert body["min_tier"] == ent.min_tier_for_node_count(3)
+
+
+def test_api_case_insensitive_tier(client, ent):
+    r = client.get(
+        "/api/entitlement/min-tier-at?tier=CLOUD_PRO&feature=fleet"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["perspective_tier"] == "cloud_pro"
+
+
+def test_api_trial_perspective(client, ent):
+    r = client.get(
+        "/api/entitlement/min-tier-at?tier=trial&feature=fleet"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["perspective_tier"] == "trial"
+    assert body["min_tier"] == ent.min_tier_for_feature("fleet")
+
+
+# ─────────────────────────────── API error paths ───────────────────────────────
+
+
+def test_api_missing_tier(client):
+    r = client.get("/api/entitlement/min-tier-at?feature=fleet")
+    assert r.status_code == 400
+    assert "tier" in (r.get_json() or {}).get("error", "")
+
+
+def test_api_blank_tier(client):
+    r = client.get(
+        "/api/entitlement/min-tier-at?tier=%20%20&feature=fleet"
+    )
+    assert r.status_code == 400
+
+
+def test_api_unknown_tier(client):
+    r = client.get(
+        "/api/entitlement/min-tier-at?tier=bogus&feature=fleet"
+    )
+    assert r.status_code == 404
+    body = r.get_json()
+    assert body.get("which") == "tier"
+    assert body.get("tier") == "bogus"
+
+
+def test_api_no_axis(client):
+    r = client.get("/api/entitlement/min-tier-at?tier=cloud_pro")
+    assert r.status_code == 400
+
+
+def test_api_two_axes(client):
+    r = client.get(
+        "/api/entitlement/min-tier-at?tier=cloud_pro&feature=fleet&channels=5"
+    )
+    assert r.status_code == 400
+
+
+def test_api_channels_non_int(client):
+    r = client.get(
+        "/api/entitlement/min-tier-at?tier=cloud_pro&channels=abc"
+    )
+    assert r.status_code == 400
+    assert "integer" in (r.get_json() or {}).get("error", "")
+
+
+def test_api_retention_non_int(client):
+    r = client.get(
+        "/api/entitlement/min-tier-at?tier=cloud_pro&retention_days=abc"
+    )
+    assert r.status_code == 400
+
+
+def test_api_nodes_non_int(client):
+    r = client.get(
+        "/api/entitlement/min-tier-at?tier=cloud_pro&nodes=abc"
+    )
+    assert r.status_code == 400
+
+
+def test_api_unknown_feature_returns_404(client):
+    r = client.get(
+        "/api/entitlement/min-tier-at?tier=cloud_pro&feature=bogus-feature"
+    )
+    assert r.status_code == 404
+    body = r.get_json()
+    assert body.get("error") == "unknown"
+    assert body["min_tier"] is None
+    # Perspective envelope populated even on the unknown-id 404 -- a
+    # pricing UI reading current_tier / grace from the same response
+    # doesn't need a separate call to render the "not available" copy.
+    assert body["perspective_tier"] == "cloud_pro"
+
+
+def test_api_unknown_runtime_returns_404(client):
+    r = client.get(
+        "/api/entitlement/min-tier-at?tier=cloud_pro&runtime=bogus-runtime"
+    )
+    assert r.status_code == 404
+    body = r.get_json()
+    assert body.get("error") == "unknown"
+    assert body["min_tier"] is None
+    assert body["perspective_tier"] == "cloud_pro"
+
+
+# ────────────────────────── cross-endpoint parity ──────────────────────────
+
+
+_PARITY_KEYS = (
+    "key",
+    "value",
+    "free",
+    "min_tier",
+    "tier_label",
+    "tier_rank",
+)
+
+
+def _min_tier_body(client, args: str) -> dict:
+    r = client.get(f"/api/entitlement/min-tier?{args}")
+    assert r.status_code == 200, r.get_data(as_text=True)
+    return {k: r.get_json()[k] for k in _PARITY_KEYS}
+
+
+def _min_tier_at_body(client, tier: str, args: str) -> dict:
+    r = client.get(f"/api/entitlement/min-tier-at?tier={tier}&{args}")
+    assert r.status_code == 200, r.get_data(as_text=True)
+    return {k: r.get_json()[k] for k in _PARITY_KEYS}
+
+
+def test_api_scalar_parity_feature_across_perspectives(client, ent):
+    expected = _min_tier_body(client, "feature=fleet")
+    for p in ent._TIER_ORDER:
+        assert _min_tier_at_body(client, p, "feature=fleet") == expected
+
+
+def test_api_scalar_parity_runtime_across_perspectives(client, ent):
+    expected = _min_tier_body(client, "runtime=claude_code")
+    for p in ent._TIER_ORDER:
+        assert (
+            _min_tier_at_body(client, p, "runtime=claude_code") == expected
+        )
+
+
+def test_api_scalar_parity_channels_across_perspectives(client, ent):
+    expected = _min_tier_body(client, "channels=5")
+    for p in ent._TIER_ORDER:
+        assert _min_tier_at_body(client, p, "channels=5") == expected
+
+
+def test_api_scalar_parity_retention_across_perspectives(client, ent):
+    expected = _min_tier_body(client, "retention_days=30")
+    for p in ent._TIER_ORDER:
+        assert (
+            _min_tier_at_body(client, p, "retention_days=30") == expected
+        )
+
+
+def test_api_scalar_parity_nodes_across_perspectives(client, ent):
+    expected = _min_tier_body(client, "nodes=3")
+    for p in ent._TIER_ORDER:
+        assert _min_tier_at_body(client, p, "nodes=3") == expected
+
+
+def test_api_scalar_parity_every_feature_across_perspectives(client, ent):
+    for fid in ent.ALL_FEATURES:
+        expected = _min_tier_body(client, f"feature={fid}")
+        for p in ent._TIER_ORDER:
+            assert _min_tier_at_body(client, p, f"feature={fid}") == expected
+
+
+def test_api_scalar_parity_every_runtime_across_perspectives(client, ent):
+    for rt in ent.ALL_RUNTIMES:
+        expected = _min_tier_body(client, f"runtime={rt}")
+        for p in ent._TIER_ORDER:
+            assert _min_tier_at_body(client, p, f"runtime={rt}") == expected


### PR DESCRIPTION
## Summary

- Adds `min_tier_at(perspective_tier, *, feature, runtime, channels, retention_days, nodes)` — perspective-scoped scalar sibling of the five singular `min_tier_for_*` helpers.
- Adds `GET /api/entitlement/min-tier-at?tier=<perspective>&<axis>=<value>` — hypothetical-perspective sibling of `/api/entitlement/min-tier`. Perspective envelope layers on top of the standard resolver envelope; scalar body byte-equals `/min-tier` for the same axis regardless of perspective.
- Grace-mode change only — no behaviour change on any existing surface, no `__version__` bump, no `[RELEASE]` PR, no gate enforced.

## Why

The `_at` family fills a "hypothetical perspective" slot on every existing helper so a pricing-matrix walkthrough (`tier=<p>`) can hit the whole surface uniformly. Today the batch and bundle levels are covered — `min_tier_batch_at` (per-item batch what-if), `min_tier_for_all_at` / `/required-tier-at` (aggregate bundle what-if) — but the singular scalar `/min-tier` had no `_at` slot. A caller walking a pricing page column axis-by-axis had to either fall back to `/min-tier-batch-at` with one axis at a time (heavier envelope than needed for a single-cell lookup) or synthesise the perspective envelope client-side from `/min-tier` + a separate `/api/entitlement` call for `current_tier` / `grace` / `enforced`. This PR closes that gap so every axis in the min-tier family exposes an `_at` sibling and the walkthrough URL can pass `tier=<p>` uniformly across scalar / batch / bundle.

The scalar answer is perspective-independent by design — it walks the static per-tier caps via the matching singular helper — so `min_tier_at(p, **axis) == min_tier_for_<axis>(**axis)` for every `p` in `_TIER_ORDER` (including `trial`). This mirrors the `_at`-does-not-shape-answers contract every sibling `_at` helper already follows, and is pinned in the test suite.

## Changes

### `clawmetry/entitlements.py`

- `min_tier_at(perspective_tier, *, feature=None, runtime=None, channels=None, retention_days=None, nodes=None)`:
  - Validates perspective against `_TIER_ORDER` (trial accepted). Empty / blank / `None` / non-string / unknown perspective → `None`. Case-insensitive + whitespace-stripped.
  - Exactly one axis must be supplied. Zero axes → `None`; more than one axis → `None`. Blank `feature=""` / `runtime="   "` is treated as unsupplied (matches the route's `if feature:` truthy check).
  - Delegates to the matching `min_tier_for_<axis>` helper. `retention_days=None` in the helper means *unset* (matches the `/min-tier` route parsing which never passes `None`), NOT the unlimited-history sentinel — pass the unlimited request through `min_tier_for_retention_window` directly.
  - Runtime aliases with hyphens (e.g. `claude-code`) are NOT canonicalised — they land as unknown ids and return `None`, matching `min_tier_for_runtime` / `/min-tier`'s posture. Callers needing canonicalisation should preprocess via `canonical_runtime`.
  - Never raises: a delegate crash logs a warning and returns `None`.

### `routes/entitlement.py`

- `GET /api/entitlement/min-tier-at`. Args mirror `/api/entitlement/min-tier` byte-for-byte (exactly one of `feature=<id>`, `runtime=<id>`, `channels=<int>`, `retention_days=<int>`, or `nodes=<int>`) plus the `tier=<perspective>` arg. Response shape:

```json
{
  "key":                    "feature" | "runtime" | "channels" | "retention_days" | "nodes",
  "value":                  "<input>",
  "free":                   <bool>,
  "min_tier":               "<tier id>" | null,
  "tier_label":             "<Display Label>" | null,
  "tier_rank":              <int> | null,
  "perspective_tier":       "cloud_pro",
  "perspective_tier_label": "Cloud Pro",
  "perspective_tier_rank":  3,
  "current_tier":           "oss",
  "current_tier_rank":      0,
  "grace":                  true,
  "enforced":               false
}
```

- **400** on missing / blank `tier=`, zero / more than one axis supplied, or non-int capacity value.
- **404** on unknown `tier=` (body carries `which=tier`), or unknown `feature=` / `runtime=` id (matches `/min-tier`'s 404 posture on unknown grant ids). Capacity axes never 404: any parseable int (including 0 / negative — which collapses to `TIER_OSS` per the helpers' contract) resolves to a real tier.
- **Never 5xxs**: a resolver failure yields the same shape with `min_tier=null` and the perspective envelope populated so the pricing walkthrough keeps rendering.
- The unknown-id 404 body still carries the perspective + resolver envelope so a pricing UI can render "not available" copy off the same call.

### `tests/test_entitlement_min_tier_at.py`

**58 tests, all green** (1.75s):

- perspective validation: empty / blank / `None` / non-string / unknown → `None` at the helper layer; 400 / 404 at the HTTP layer
- trial accepted as perspective
- case-insensitive + whitespace-stripped perspective (`?tier=CLOUD_PRO` → `cloud_pro`)
- axis validation: zero axes / 2 / 3 / all five axes → `None` at helper; 400 at route
- blank `feature=""` / `runtime="   "` treated as unsupplied — degrades to single-axis semantics when combined with another axis
- per-axis parity across every `p` in `_TIER_ORDER` for every feature id in `ALL_FEATURES`, every runtime id in `ALL_RUNTIMES`, and a range of `(channels, retention_days, nodes)` values including `0` / negative / mid-tier
- `retention_days=None` kwarg means unset (matches `/min-tier` route parsing), NOT the unlimited-history sentinel
- non-int capacity values → `None` at helper; 400 at route
- runtime hyphen-aliases (`claude-code`) NOT canonicalised — surface as unknown (matches `min_tier_for_runtime` / `/min-tier` posture)
- grace vs enforce yields byte-identical answers across all five axes and every perspective (pinned via a `CLAWMETRY_ENFORCE=1` reload roundtrip)
- helper never raises on a delegate crash (monkeypatched the five delegates to raise)
- API happy paths: all five axes, case-insensitive tier, trial perspective, envelope shape
- API error paths: 400 on missing / blank `tier=` / no axis / two axes / non-int capacity; 404 on unknown tier / unknown feature / unknown runtime
- Cross-endpoint parity: `/min-tier-at?tier=<p>&<axis>=<v>` body (six scalar keys) byte-equals `/min-tier?<axis>=<v>` for every `p` in `_TIER_ORDER` — pinned across all five axes plus every feature id and every runtime id

## Test plan

- [x] `python3 -m py_compile clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_min_tier_at.py` — clean
- [x] `ruff check clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_min_tier_at.py` — clean (`All checks passed!`)
- [x] `pytest tests/test_entitlement_min_tier_at.py -q` → **58/58 pass** in 1.75s
- [x] Sibling test files (`test_entitlement_min_tier`, `test_entitlement_min_tier_batch`, `test_entitlement_min_tier_batch_at`, `test_entitlement_api`, `test_blueprint_uniqueness`, `test_circular_import`) still green — **164/164 pass**
- [x] Blueprint URL-map uniqueness after registration — **227 routes, all unique**

## Local operator verification checklist

I can't touch the running daemon, `~/.openclaw`, the live snapshot, or a browser from here — please run:

- [ ] Copy the changed files into `~/.clawmetry/lib/python3.11/site-packages/clawmetry/` (`entitlements.py`) and `~/.clawmetry/lib/python3.11/site-packages/routes/` (`entitlement.py`); drop the test file into the local checkout under `tests/`
- [ ] Clear `__pycache__` on both dirs
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
- [ ] `curl -s 'http://localhost:8900/api/entitlement/min-tier-at?tier=cloud_pro&feature=fleet' | jq .` — expect `key="feature"`, `value="fleet"`, `min_tier` matching `/min-tier?feature=fleet`, `perspective_tier="cloud_pro"`, resolver envelope populated
- [ ] `curl -s 'http://localhost:8900/api/entitlement/min-tier-at?tier=cloud_starter&runtime=claude_code' | jq .` — expect `key="runtime"`, `min_tier="cloud_starter"`
- [ ] `curl -s 'http://localhost:8900/api/entitlement/min-tier-at?tier=cloud_pro&channels=5' | jq .` — expect `key="channels"`, `value="5"`, `min_tier` matching `/min-tier?channels=5`
- [ ] `curl -s -o /dev/null -w '%{http_code}\n' 'http://localhost:8900/api/entitlement/min-tier-at?feature=fleet'` → `400`
- [ ] `curl -s -o /dev/null -w '%{http_code}\n' 'http://localhost:8900/api/entitlement/min-tier-at?tier=cloud_pro'` → `400`
- [ ] `curl -s -o /dev/null -w '%{http_code}\n' 'http://localhost:8900/api/entitlement/min-tier-at?tier=cloud_pro&feature=fleet&channels=5'` → `400`
- [ ] `curl -s -o /dev/null -w '%{http_code}\n' 'http://localhost:8900/api/entitlement/min-tier-at?tier=cloud_pro&channels=abc'` → `400`
- [ ] `curl -s -o /dev/null -w '%{http_code}\n' 'http://localhost:8900/api/entitlement/min-tier-at?tier=bogus&feature=fleet'` → `404`
- [ ] `curl -s -o /dev/null -w '%{http_code}\n' 'http://localhost:8900/api/entitlement/min-tier-at?tier=cloud_pro&feature=bogus-feature'` → `404`
- [ ] Cross-check byte-parity: strip the six perspective + resolver envelope keys off `/min-tier-at?tier=<p>&<axis>=<v>` and confirm the remaining six keys (`key`, `value`, `free`, `min_tier`, `tier_label`, `tier_rank`) byte-equal `/min-tier?<axis>=<v>` for every `p` in `_TIER_ORDER`
- [ ] Decrypt the live cloud snapshot and hit the same endpoint against the cloud read-through path
- [ ] Browser check: any surface currently calling `/min-tier` / `/min-tier-batch` / `/min-tier-batch-at` should keep rendering; nothing should call the new `/min-tier-at` route yet

No `__version__` bump, no tag, no `[RELEASE]` PR — staying in DRAFT until you've cleared local + cloud verification.

## MOAT / release checklist

- Not a MOAT fast-path change (no `local_store_via_daemon` / `_ls_call` / `_DAEMON_METHODS` touched).
- Not a `[RELEASE]` PR.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DHa7sYFJdCNVsHSrf9QEro)_