### PR TITLE
chore(e2e): redirect c6-health daily audit to tracking issue #3666

### DIFF
--- a/.github/workflows/c6-health.yml
+++ b/.github/workflows/c6-health.yml
@@ -8,7 +8,7 @@ name: C6 daily health check (branch-protection audit -- all 3 repos)
 # /branches/main endpoint (works for public repos; falls back to
 # UNKNOWN if protection detail is not visible cross-repo).
 #
-# On failure: posts an @-mentioned reminder to tracking issue #2146
+# On failure: posts an @-mentioned reminder to tracking issue #3666
 # at most once per calendar day. On success: posts a GREEN confirmation.
 #
 # To close C6:
@@ -18,7 +18,7 @@ name: C6 daily health check (branch-protection audit -- all 3 repos)
 #   2. Or: bash scripts/close-c6.sh
 #   3. Or: Settings > Branches > main > Required status checks (each repo)
 #
-# Tracking: vivekchand/clawmetry#2146
+# Tracking: vivekchand/clawmetry#3666
 
 on:
   schedule:
@@ -48,7 +48,7 @@ jobs:
 
           TOKEN = os.environ["GITHUB_TOKEN"]
           OWNER = "vivekchand"
-          TRACKING_ISSUE = 2146
+          TRACKING_ISSUE = 3666
           MARKER = "<!-- c6-health-check -->"
 
           HEADERS = {


### PR DESCRIPTION
## Summary

- `c6-health.yml` was posting its daily branch-protection audit comment to issue #2146 (the May 2026 tracking issue). Issue #3666 is now the canonical per-fire log for the E2E Robustness cron.
- Change: `TRACKING_ISSUE = 2146` -> `TRACKING_ISSUE = 3666` and update the matching header comment.
- Audit logic, required-checks list, and dedup marker are unchanged.

## Why

Daily C6 reminders were going to a different issue than the one the cron driver updates each fire. After this PR the owner will see the daily reminder alongside the per-fire log in #3666.

## Current E2E status (2026-07-14)

6 of 7 criteria are now GREEN:

| Criterion | Status |
|-----------|--------|
| C1 OSS golden path | Green |
| C2 Cloud golden path (daemon connect+sync) | Green -- merged 2026-07-14T03:04Z |
| C3 Landing golden path | Green |
| C4 Cross-repo handoff | Green |
| C5 Visual-diff all tabs post-auth | Green |
| C6 Required-status-checks | **RED -- sole remaining blocker** |
| C7 Failure quarantine | Green |

**C6 close instructions (2 clicks from the browser):**

1. [Create a fine-grained PAT](https://github.com/settings/personal-access-tokens/new?name=clawmetry-c6) with Administration (read+write) on `clawmetry`, `clawmetry-cloud`, `clawmetry-landing`
2. [Actions > Apply required E2E status checks > Run workflow](https://github.com/vivekchand/clawmetry/actions/workflows/apply-required-checks.yml) with `confirm=APPLY` and the PAT pasted into `pat_token`

Or locally in ~30s: `bash scripts/close-c6.sh`

Closes the C6 daily-reminder routing gap. Tracking: #3666.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RcHXS39QDTnJLjSpaYJ1ko)_