### PR TITLE
feat(entitlement): tiers_for_features_at + tiers_for_runtimes_at + /api/entitlement/tiers-for-{features,runtimes}-at

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -5122,6 +5122,76 @@ def tiers_for_runtimes(runtimes) -> dict | None:
         }
 
 
+def tiers_for_features_at(
+    perspective_tier: str, features
+) -> dict | None:
+    """Hypothetical-perspective sibling of :func:`tiers_for_features`.
+
+    Fills the ``_at`` slot on the ``tiers_for_features`` ladder axis
+    alongside :func:`min_tier_for_features_at`, so a pricing-matrix
+    walkthrough can call ``X_at(perspective, ...)`` uniformly across the
+    whole ``_at`` family. Same relationship to
+    :func:`tiers_for_features` that :func:`min_tier_for_features_at`
+    has to :func:`min_tier_for_features`: ``perspective_tier`` is
+    validated against :data:`_TIER_ORDER` (including :data:`TIER_TRIAL`)
+    but does NOT shape the answer -- the ladder still intersects the
+    per-item ``tiers_for_feature`` grant sets and the result depends
+    only on the static per-tier feature map, not on the caller's live
+    plan. A parity test pins ``tiers_for_features_at(p, ...) ==
+    tiers_for_features(...)`` for every ``p`` in :data:`_TIER_ORDER` so
+    the ``_at`` prefix cannot silently drift into shaping the result.
+
+    Returns ``None`` for empty / non-string / unknown ``perspective_tier``
+    (caller renders "unknown tier" / 404), matching the ``None`` posture
+    the rest of the ``_at`` family uses for the perspective-validation
+    failure mode. All other semantics -- ``None`` / non-iterable ->
+    ``None``, empty iterable -> empty ladder shape, unknown ids echoed
+    in ``unknown``, duplicates collapsed, all-free bundle -> full
+    ladder + :data:`TIER_OSS` -- inherit from :func:`tiers_for_features`
+    unchanged. Never raises: a delegate failure logs a warning and
+    returns ``None`` so a pricing-matrix walkthrough keeps rendering.
+    """
+    try:
+        p = (perspective_tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if not p or p not in _TIER_ORDER:
+        return None
+    try:
+        return tiers_for_features(features)
+    except Exception as exc:
+        logger.warning("entitlements: tiers_for_features_at failed: %s", exc)
+        return None
+
+
+def tiers_for_runtimes_at(
+    perspective_tier: str, runtimes
+) -> dict | None:
+    """Runtime-axis twin of :func:`tiers_for_features_at`.
+
+    Same perspective-validated wrapper contract: ``perspective_tier``
+    validated against :data:`_TIER_ORDER` (including
+    :data:`TIER_TRIAL`); the ladder is resolved off the static per-tier
+    runtime map via :func:`tiers_for_runtimes`, so the answer is
+    perspective-independent by design. A parity test pins
+    ``tiers_for_runtimes_at(p, ...) == tiers_for_runtimes(...)`` for
+    every ``p`` in :data:`_TIER_ORDER` (including runtime aliases like
+    ``claude-code`` which canonicalise the same way they do on the
+    non-``_at`` sibling). Never raises.
+    """
+    try:
+        p = (perspective_tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if not p or p not in _TIER_ORDER:
+        return None
+    try:
+        return tiers_for_runtimes(runtimes)
+    except Exception as exc:
+        logger.warning("entitlements: tiers_for_runtimes_at failed: %s", exc)
+        return None
+
+
 def tiers_for_batch_at(perspective_tier: str) -> dict | None:
     """Hypothetical-perspective sibling of :func:`tiers_for_batch`: full
     availability ladder for every known feature *and* runtime in one

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -21090,3 +21090,205 @@ def api_entitlement_min_tier_for_runtimes_at():
                 "enforced": False,
             }
         )
+
+
+@bp_entitlement.route("/api/entitlement/tiers-for-features-at")
+def api_entitlement_tiers_for_features_at():
+    """``GET /api/entitlement/tiers-for-features-at?tier=<perspective>
+    &features=a,b,c`` -- hypothetical-perspective sibling of
+    ``/api/entitlement/tiers-for-features``: the full ladder of tiers
+    admitting every feature in the bundle, scoped by a caller-supplied
+    ``perspective_tier``.
+
+    Fills the ``_at`` slot for the ``tiers_for_features`` ladder axis so
+    a pricing-matrix walkthrough (``?tier=<p>``) can hit
+    ``/tiers-for-features-at`` uniformly across the whole ``_at`` family
+    (alongside ``/min-tier-for-features-at`` on the scalar axis and the
+    four capacity-axis ``/tiers-for-*-at`` endpoints on the capacity
+    axis).
+
+    Perspective is validated against :data:`entitlements._TIER_ORDER`
+    (including ``trial``) but does NOT shape the answer -- the ladder id
+    list depends only on the static per-tier feature map. A parity
+    contract pinned in the test suite guarantees the six body keys
+    (``items`` / ``unknown`` / ``kind`` / ``count`` / ``min_tier`` /
+    ``min_tier_label`` / ``min_tier_rank`` / ``tiers``) byte-equal
+    ``/tiers-for-features?features=<same>`` for every perspective. The
+    response layers ``perspective_tier`` / ``perspective_tier_label`` /
+    ``perspective_tier_rank`` on top of the standard resolver envelope
+    so a walkthrough surface can render the "from <perspective>" copy
+    off one round-trip.
+
+    Response shape::
+
+        {
+          "items":                  ["fleet", "sso"],
+          "unknown":                ["bogus"],
+          "kind":                   "features",
+          "count":                  2,
+          "min_tier":               "enterprise" | null,
+          "min_tier_label":         "Enterprise" | null,
+          "min_tier_rank":          <int> | null,
+          "tiers":                  [<_tier_row>, ...],
+          "perspective_tier":       "cloud_pro",
+          "perspective_tier_label": "Cloud Pro",
+          "perspective_tier_rank":  3,
+          "current_tier":           "oss",
+          "current_tier_rank":      0,
+          "grace":                  true,
+          "enforced":               false,
+        }
+
+    - **400** when ``tier=`` is missing / blank, OR when ``features=``
+      is missing / blank after CSV normalisation.
+    - **404** when ``tier`` is unknown. The body carries ``which=tier``
+      so a caller can render the right "unknown tier" message.
+    - **All-unknown features IS 200** with ``unknown`` populated and
+      ``tiers=[]`` / ``min_tier=null`` -- distinguishes "caller asked
+      for nothing" from "caller asked but every token was a typo" so a
+      paywall UI can render "these ids are unknown: X" instead of a
+      null.
+    - **Never 5xxs**: a resolver failure yields the fallback envelope
+      (empty ``items`` / ``tiers`` list, ``min_tier=null``) so the
+      pricing walkthrough keeps rendering.
+    """
+    raw_tier = request.args.get("tier")
+    tier_in = (raw_tier or "").strip().lower()
+    if not tier_in:
+        return jsonify({"error": "missing tier"}), 400
+
+    raw_features = request.args.get("features")
+    if raw_features is None or not raw_features.strip():
+        return jsonify({"error": "missing features"}), 400
+    features_csv = _parse_csv_arg("features")
+    if not features_csv:
+        return jsonify({"error": "missing features"}), 400
+
+    try:
+        from clawmetry import entitlements as _ent
+
+        if tier_in not in _ent._TIER_ORDER:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "tier", "tier": tier_in}
+                ),
+                404,
+            )
+
+        body = _ent.tiers_for_features_at(tier_in, features_csv)
+        env = _perspective_envelope(_ent, tier_in)
+        if body is None:
+            return jsonify(
+                {
+                    "items": [],
+                    "unknown": features_csv,
+                    "kind": "features",
+                    "count": 0,
+                    "min_tier": None,
+                    "min_tier_label": None,
+                    "min_tier_rank": None,
+                    "tiers": [],
+                    **env,
+                }
+            )
+        return jsonify({**body, **env})
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_tiers_for_features_at: error: %s", exc
+        )
+        return jsonify(
+            {
+                "items": [],
+                "unknown": features_csv,
+                "kind": "features",
+                "count": 0,
+                "min_tier": None,
+                "min_tier_label": None,
+                "min_tier_rank": None,
+                "tiers": [],
+                **_perspective_fallback(tier_in),
+            }
+        )
+
+
+@bp_entitlement.route("/api/entitlement/tiers-for-runtimes-at")
+def api_entitlement_tiers_for_runtimes_at():
+    """``GET /api/entitlement/tiers-for-runtimes-at?tier=<perspective>
+    &runtimes=x,y,z`` -- runtime-axis twin of
+    ``/api/entitlement/tiers-for-features-at``.
+
+    Wraps :func:`clawmetry.entitlements.tiers_for_runtimes_at`. Runtime
+    aliases (``claude-code`` -> ``claude_code``) are canonicalised
+    before intersection; the perspective envelope layers on top of the
+    standard resolver envelope. Perspective is validated but does NOT
+    shape rows -- the ladder byte-equals
+    ``/tiers-for-runtimes?runtimes=<same>`` for every perspective
+    (pinned by the parity tests).
+
+    - **400** when ``tier=`` is missing / blank, OR when ``runtimes=``
+      is missing / blank after CSV normalisation.
+    - **404** when ``tier`` is unknown (``which=tier``).
+    - **All-unknown runtimes IS 200** with the ``unknown`` list
+      populated (mirrors ``/tiers-for-runtimes``).
+    - **Never 5xxs**: a resolver failure yields the fallback envelope.
+
+    Response shape mirrors ``/tiers-for-features-at`` with
+    ``kind="runtimes"``.
+    """
+    raw_tier = request.args.get("tier")
+    tier_in = (raw_tier or "").strip().lower()
+    if not tier_in:
+        return jsonify({"error": "missing tier"}), 400
+
+    raw_runtimes = request.args.get("runtimes")
+    if raw_runtimes is None or not raw_runtimes.strip():
+        return jsonify({"error": "missing runtimes"}), 400
+    runtimes_csv = _parse_csv_arg("runtimes")
+    if not runtimes_csv:
+        return jsonify({"error": "missing runtimes"}), 400
+
+    try:
+        from clawmetry import entitlements as _ent
+
+        if tier_in not in _ent._TIER_ORDER:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "tier", "tier": tier_in}
+                ),
+                404,
+            )
+
+        body = _ent.tiers_for_runtimes_at(tier_in, runtimes_csv)
+        env = _perspective_envelope(_ent, tier_in)
+        if body is None:
+            return jsonify(
+                {
+                    "items": [],
+                    "unknown": runtimes_csv,
+                    "kind": "runtimes",
+                    "count": 0,
+                    "min_tier": None,
+                    "min_tier_label": None,
+                    "min_tier_rank": None,
+                    "tiers": [],
+                    **env,
+                }
+            )
+        return jsonify({**body, **env})
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_tiers_for_runtimes_at: error: %s", exc
+        )
+        return jsonify(
+            {
+                "items": [],
+                "unknown": runtimes_csv,
+                "kind": "runtimes",
+                "count": 0,
+                "min_tier": None,
+                "min_tier_label": None,
+                "min_tier_rank": None,
+                "tiers": [],
+                **_perspective_fallback(tier_in),
+            }
+        )

--- a/tests/test_entitlement_tiers_for_plural_at.py
+++ b/tests/test_entitlement_tiers_for_plural_at.py
@@ -1,0 +1,601 @@
+"""Tests for ``clawmetry.entitlements.tiers_for_features_at`` /
+``tiers_for_runtimes_at`` and the two matching HTTP endpoints.
+
+Hypothetical-perspective siblings of :func:`tiers_for_features` /
+:func:`tiers_for_runtimes`. Fills the ``_at`` slot on the plural
+``tiers_for_*`` ladder axes alongside :func:`min_tier_for_features_at`
+so a pricing-matrix walkthrough (``?tier=<p>``) can hit
+``/tiers-for-features-at`` uniformly across the whole ``_at`` family
+instead of falling back to per-item ``/tiers-for-at`` calls +
+intersecting on the client.
+
+These tests pin:
+
+* perspective validation: empty / blank / ``None`` / non-string /
+  unknown short-circuits to ``None`` on the helper and 400 / 404 on the
+  endpoint
+* trial accepted as perspective (matches the rest of the ``_at`` family)
+* case-insensitive + whitespace-stripped perspective
+* byte-parity vs the non-``_at`` sibling for every perspective in
+  :data:`_TIER_ORDER` -- the ``_at`` prefix cannot silently drift into
+  shaping the answer
+* semantics inherited from the non-``_at`` sibling: empty iterable ->
+  empty ladder shape (NOT ``None`` -- distinguishes "asked for nothing"
+  from perspective-validation failure), unknown-only bundle -> empty
+  ladder shape with ``unknown`` populated, mixed bundle -> intersection
+  ladder + matching ``min_tier``
+* runtime canonicalisation on the runtime helper
+  (``claude-code`` -> ``claude_code``)
+* grace vs enforce yields byte-identical results
+* helpers never raise on a delegate crash (monkeypatched)
+* API happy path: shape, envelope keys, perspective envelope, resolver
+  envelope, ``kind``, ``count`` fields
+* API error paths: 400 on missing / blank ``tier=`` or ``features=`` /
+  ``runtimes=``, 404 on unknown ``tier=``
+* all-unknown IS 200 with ``unknown`` populated and empty ``tiers`` list
+  (not confused with "asked for nothing")
+* CSV dedup / normalisation via the shared ``_parse_csv_arg`` helper
+* cross-endpoint parity: the eight body keys
+  (``items``/``unknown``/``kind``/``count``/``min_tier``/
+  ``min_tier_label``/``min_tier_rank``/``tiers``) byte-equal
+  ``/tiers-for-features?features=X`` for every perspective
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# ── helpers: perspective validation ────────────────────────────────────────
+
+
+@pytest.mark.parametrize("bad", ["", "   ", "bogus", "cloud_pro_typo"])
+def test_helper_empty_or_unknown_perspective_returns_none(ent, bad):
+    assert ent.tiers_for_features_at(bad, ["fleet"]) is None
+    assert ent.tiers_for_runtimes_at(bad, ["claude_code"]) is None
+
+
+def test_helper_none_perspective_returns_none(ent):
+    assert ent.tiers_for_features_at(None, ["fleet"]) is None
+    assert ent.tiers_for_runtimes_at(None, ["claude_code"]) is None
+
+
+def test_helper_non_string_perspective_returns_none(ent):
+    for bad in (object(), 123, ["cloud_pro"]):
+        assert ent.tiers_for_features_at(bad, ["fleet"]) is None
+        assert ent.tiers_for_runtimes_at(bad, ["claude_code"]) is None
+
+
+def test_helper_perspective_is_case_insensitive(ent):
+    assert (
+        ent.tiers_for_features_at("CLOUD_PRO", ["fleet"])
+        == ent.tiers_for_features(["fleet"])
+    )
+    assert (
+        ent.tiers_for_runtimes_at("CLOUD_STARTER", ["claude_code"])
+        == ent.tiers_for_runtimes(["claude_code"])
+    )
+
+
+def test_helper_perspective_is_whitespace_stripped(ent):
+    assert (
+        ent.tiers_for_features_at("  cloud_pro  ", ["fleet"])
+        == ent.tiers_for_features(["fleet"])
+    )
+    assert (
+        ent.tiers_for_runtimes_at("  cloud_starter  ", ["claude_code"])
+        == ent.tiers_for_runtimes(["claude_code"])
+    )
+
+
+def test_helper_trial_is_accepted_as_perspective(ent):
+    """Trial is in :data:`_TIER_ORDER` (non-purchasable but a valid
+    hypothetical perspective across every ``_at`` sibling)."""
+    assert (
+        ent.tiers_for_features_at(ent.TIER_TRIAL, ["fleet"])
+        == ent.tiers_for_features(["fleet"])
+    )
+    assert (
+        ent.tiers_for_runtimes_at(ent.TIER_TRIAL, ["claude_code"])
+        == ent.tiers_for_runtimes(["claude_code"])
+    )
+
+
+# ── helpers: byte-parity vs non-_at sibling for every perspective ──────────
+
+
+def _every_perspective(ent):
+    return list(ent._TIER_ORDER)
+
+
+def test_helper_features_parity_across_all_perspectives(ent):
+    bundles = [
+        [],
+        ["fleet"],
+        ["fleet", "sso"],
+        ["bogus"],
+        ["fleet", "bogus"],
+    ]
+    for p in _every_perspective(ent):
+        for bundle in bundles:
+            assert ent.tiers_for_features_at(p, bundle) == ent.tiers_for_features(
+                bundle
+            ), f"perspective={p} bundle={bundle}"
+
+
+def test_helper_runtimes_parity_across_all_perspectives(ent):
+    bundles = [
+        [],
+        ["claude_code"],
+        ["claude-code", "codex"],
+        ["bogus"],
+        ["claude_code", "bogus"],
+    ]
+    for p in _every_perspective(ent):
+        for bundle in bundles:
+            assert ent.tiers_for_runtimes_at(p, bundle) == ent.tiers_for_runtimes(
+                bundle
+            ), f"perspective={p} bundle={bundle}"
+
+
+# ── helpers: inherited semantics ───────────────────────────────────────────
+
+
+def test_helper_features_empty_iterable_returns_empty_shape(ent):
+    body = ent.tiers_for_features_at(ent.TIER_CLOUD_PRO, [])
+    assert body is not None
+    assert body["items"] == []
+    assert body["unknown"] == []
+    assert body["kind"] == "features"
+    assert body["count"] == 0
+    assert body["min_tier"] is None
+    assert body["tiers"] == []
+
+
+def test_helper_runtimes_empty_iterable_returns_empty_shape(ent):
+    body = ent.tiers_for_runtimes_at(ent.TIER_CLOUD_PRO, [])
+    assert body is not None
+    assert body["items"] == []
+    assert body["kind"] == "runtimes"
+    assert body["min_tier"] is None
+    assert body["tiers"] == []
+
+
+def test_helper_features_none_iterable_returns_none(ent):
+    assert ent.tiers_for_features_at(ent.TIER_CLOUD_PRO, None) is None
+    assert ent.tiers_for_runtimes_at(ent.TIER_CLOUD_PRO, None) is None
+
+
+def test_helper_features_all_unknown_populates_unknown(ent):
+    body = ent.tiers_for_features_at(
+        ent.TIER_CLOUD_PRO, ["bogus1", "bogus2"]
+    )
+    assert body is not None
+    assert body["items"] == []
+    assert set(body["unknown"]) == {"bogus1", "bogus2"}
+    assert body["tiers"] == []
+    assert body["min_tier"] is None
+
+
+def test_helper_runtimes_all_unknown_populates_unknown(ent):
+    body = ent.tiers_for_runtimes_at(
+        ent.TIER_CLOUD_PRO, ["bogus1", "bogus2"]
+    )
+    assert body is not None
+    assert body["items"] == []
+    assert body["tiers"] == []
+    assert body["min_tier"] is None
+
+
+def test_helper_features_non_iterable_returns_none(ent):
+    assert ent.tiers_for_features_at(ent.TIER_CLOUD_PRO, 42) is None
+    assert ent.tiers_for_runtimes_at(ent.TIER_CLOUD_PRO, 42) is None
+
+
+def test_helper_runtimes_at_matches_non_at_on_canonical_id(ent):
+    """The runtime helper delegates to :func:`tiers_for_runtimes`
+    unchanged; canonical ids resolve to the paid-runtime tier ladder."""
+    got = ent.tiers_for_runtimes_at(ent.TIER_CLOUD_PRO, ["claude_code"])
+    assert got == ent.tiers_for_runtimes(["claude_code"])
+    assert got is not None
+    # claude_code is a paid runtime -- not every tier grants it
+    assert got["min_tier"] is not None
+    assert got["min_tier"] != ent.TIER_OSS
+
+
+def test_helper_runtimes_at_canonicalises_alias(ent):
+    """``claude-code`` -> ``claude_code`` before intersection, matching
+    the non-``_at`` sibling's behaviour."""
+    got = ent.tiers_for_runtimes_at(ent.TIER_CLOUD_PRO, ["claude-code"])
+    assert got is not None
+    assert got["items"] == ["claude_code"]
+
+
+# ── helpers: grace vs enforce parity ───────────────────────────────────────
+
+
+def test_helper_features_grace_vs_enforce_identical(ent, monkeypatch):
+    grace = ent.tiers_for_features_at(ent.TIER_CLOUD_PRO, ["fleet", "sso"])
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    importlib.reload(ent)
+    enforce = ent.tiers_for_features_at(ent.TIER_CLOUD_PRO, ["fleet", "sso"])
+    assert grace == enforce
+
+
+def test_helper_runtimes_grace_vs_enforce_identical(ent, monkeypatch):
+    grace = ent.tiers_for_runtimes_at(ent.TIER_CLOUD_PRO, ["claude_code"])
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    importlib.reload(ent)
+    enforce = ent.tiers_for_runtimes_at(ent.TIER_CLOUD_PRO, ["claude_code"])
+    assert grace == enforce
+
+
+# ── helpers: never-raises contract ─────────────────────────────────────────
+
+
+def test_helper_features_never_raises_on_delegate_crash(ent, monkeypatch):
+    def _boom(*_a, **_kw):
+        raise RuntimeError("delegate boom")
+
+    monkeypatch.setattr(ent, "tiers_for_features", _boom)
+    assert (
+        ent.tiers_for_features_at(ent.TIER_CLOUD_PRO, ["fleet"]) is None
+    )
+
+
+def test_helper_runtimes_never_raises_on_delegate_crash(ent, monkeypatch):
+    def _boom(*_a, **_kw):
+        raise RuntimeError("delegate boom")
+
+    monkeypatch.setattr(ent, "tiers_for_runtimes", _boom)
+    assert (
+        ent.tiers_for_runtimes_at(ent.TIER_CLOUD_PRO, ["claude_code"])
+        is None
+    )
+
+
+# ── API: happy path ───────────────────────────────────────────────────────
+
+
+_BODY_KEYS = {
+    "items",
+    "unknown",
+    "kind",
+    "count",
+    "min_tier",
+    "min_tier_label",
+    "min_tier_rank",
+    "tiers",
+}
+
+_ENVELOPE_KEYS = {
+    "perspective_tier",
+    "perspective_tier_label",
+    "perspective_tier_rank",
+    "current_tier",
+    "current_tier_rank",
+    "grace",
+    "enforced",
+}
+
+
+def test_api_features_at_happy_path(client, ent):
+    r = client.get(
+        "/api/entitlement/tiers-for-features-at?tier=cloud_pro&features=fleet,sso"
+    )
+    assert r.status_code == 200
+    j = r.get_json()
+    assert set(j.keys()) == _BODY_KEYS | _ENVELOPE_KEYS
+    assert j["kind"] == "features"
+    assert j["items"] == ["fleet", "sso"]
+    assert j["unknown"] == []
+    assert j["count"] == 2
+    assert j["perspective_tier"] == "cloud_pro"
+    assert j["perspective_tier_label"] == ent.tier_label("cloud_pro")
+    assert j["perspective_tier_rank"] == ent.tier_rank("cloud_pro")
+    assert j["min_tier"] == ent.min_tier_for_features(["fleet", "sso"])
+
+
+def test_api_runtimes_at_happy_path(client, ent):
+    r = client.get(
+        "/api/entitlement/tiers-for-runtimes-at?tier=cloud_starter&runtimes=claude-code,codex"
+    )
+    assert r.status_code == 200
+    j = r.get_json()
+    assert set(j.keys()) == _BODY_KEYS | _ENVELOPE_KEYS
+    assert j["kind"] == "runtimes"
+    assert j["items"] == ["claude_code", "codex"]  # canonicalised
+    assert j["unknown"] == []
+    assert j["perspective_tier"] == "cloud_starter"
+    assert j["min_tier"] == ent.min_tier_for_runtimes(
+        ["claude_code", "codex"]
+    )
+
+
+def test_api_features_at_case_insensitive_tier(client):
+    r = client.get(
+        "/api/entitlement/tiers-for-features-at?tier=CLOUD_PRO&features=fleet"
+    )
+    assert r.status_code == 200
+    assert r.get_json()["perspective_tier"] == "cloud_pro"
+
+
+def test_api_runtimes_at_case_insensitive_tier(client):
+    r = client.get(
+        "/api/entitlement/tiers-for-runtimes-at?tier=CLOUD_STARTER&runtimes=claude_code"
+    )
+    assert r.status_code == 200
+    assert r.get_json()["perspective_tier"] == "cloud_starter"
+
+
+def test_api_features_at_trial_perspective_accepted(client, ent):
+    r = client.get(
+        "/api/entitlement/tiers-for-features-at?tier=trial&features=fleet"
+    )
+    assert r.status_code == 200
+    assert r.get_json()["perspective_tier"] == "trial"
+
+
+def test_api_runtimes_at_trial_perspective_accepted(client, ent):
+    r = client.get(
+        "/api/entitlement/tiers-for-runtimes-at?tier=trial&runtimes=claude_code"
+    )
+    assert r.status_code == 200
+    assert r.get_json()["perspective_tier"] == "trial"
+
+
+# ── API: error paths ──────────────────────────────────────────────────────
+
+
+def test_api_features_at_missing_tier_returns_400(client):
+    r = client.get(
+        "/api/entitlement/tiers-for-features-at?features=fleet"
+    )
+    assert r.status_code == 400
+
+
+def test_api_runtimes_at_missing_tier_returns_400(client):
+    r = client.get(
+        "/api/entitlement/tiers-for-runtimes-at?runtimes=claude_code"
+    )
+    assert r.status_code == 400
+
+
+def test_api_features_at_blank_tier_returns_400(client):
+    r = client.get(
+        "/api/entitlement/tiers-for-features-at?tier=%20%20&features=fleet"
+    )
+    assert r.status_code == 400
+
+
+def test_api_runtimes_at_blank_tier_returns_400(client):
+    r = client.get(
+        "/api/entitlement/tiers-for-runtimes-at?tier=%20%20&runtimes=claude_code"
+    )
+    assert r.status_code == 400
+
+
+def test_api_features_at_missing_features_returns_400(client):
+    r = client.get(
+        "/api/entitlement/tiers-for-features-at?tier=cloud_pro"
+    )
+    assert r.status_code == 400
+
+
+def test_api_runtimes_at_missing_runtimes_returns_400(client):
+    r = client.get(
+        "/api/entitlement/tiers-for-runtimes-at?tier=cloud_pro"
+    )
+    assert r.status_code == 400
+
+
+def test_api_features_at_blank_features_returns_400(client):
+    r = client.get(
+        "/api/entitlement/tiers-for-features-at?tier=cloud_pro&features=%20%20"
+    )
+    assert r.status_code == 400
+
+
+def test_api_runtimes_at_blank_runtimes_returns_400(client):
+    r = client.get(
+        "/api/entitlement/tiers-for-runtimes-at?tier=cloud_pro&runtimes=%20%20"
+    )
+    assert r.status_code == 400
+
+
+def test_api_features_at_unknown_tier_returns_404(client):
+    r = client.get(
+        "/api/entitlement/tiers-for-features-at?tier=bogus&features=fleet"
+    )
+    assert r.status_code == 404
+    j = r.get_json()
+    assert j.get("which") == "tier"
+
+
+def test_api_runtimes_at_unknown_tier_returns_404(client):
+    r = client.get(
+        "/api/entitlement/tiers-for-runtimes-at?tier=bogus&runtimes=claude_code"
+    )
+    assert r.status_code == 404
+    j = r.get_json()
+    assert j.get("which") == "tier"
+
+
+# ── API: all-unknown IS 200 ────────────────────────────────────────────────
+
+
+def test_api_features_at_all_unknown_is_200(client):
+    r = client.get(
+        "/api/entitlement/tiers-for-features-at?tier=cloud_pro&features=bogus1,bogus2"
+    )
+    assert r.status_code == 200
+    j = r.get_json()
+    assert j["items"] == []
+    assert set(j["unknown"]) == {"bogus1", "bogus2"}
+    assert j["min_tier"] is None
+    assert j["count"] == 0
+    assert j["tiers"] == []
+
+
+def test_api_runtimes_at_all_unknown_is_200(client):
+    r = client.get(
+        "/api/entitlement/tiers-for-runtimes-at?tier=cloud_pro&runtimes=bogus1,bogus2"
+    )
+    assert r.status_code == 200
+    j = r.get_json()
+    assert j["items"] == []
+    assert j["min_tier"] is None
+    assert j["count"] == 0
+    assert j["tiers"] == []
+
+
+# ── API: CSV normalisation / dedup ─────────────────────────────────────────
+
+
+def test_api_features_at_dedup_preserves_order(client):
+    r = client.get(
+        "/api/entitlement/tiers-for-features-at?tier=cloud_pro&features=fleet,,sso,fleet"
+    )
+    assert r.status_code == 200
+    assert r.get_json()["items"] == ["fleet", "sso"]
+
+
+def test_api_runtimes_at_dedup_preserves_order(client):
+    r = client.get(
+        "/api/entitlement/tiers-for-runtimes-at?tier=cloud_pro&runtimes=claude-code,,codex,claude_code"
+    )
+    assert r.status_code == 200
+    assert r.get_json()["items"] == ["claude_code", "codex"]
+
+
+def test_api_features_at_mixed_known_unknown(client, ent):
+    r = client.get(
+        "/api/entitlement/tiers-for-features-at?tier=cloud_pro&features=fleet,bogus"
+    )
+    assert r.status_code == 200
+    j = r.get_json()
+    assert j["items"] == ["fleet"]
+    assert j["unknown"] == ["bogus"]
+    assert j["min_tier"] == ent.min_tier_for_features(["fleet"])
+
+
+# ── API: cross-endpoint byte-parity with non-_at sibling ───────────────────
+
+
+@pytest.mark.parametrize(
+    "perspective",
+    ["cloud_free", "trial", "cloud_starter", "cloud_pro", "pro", "enterprise"],
+)
+def test_api_features_at_body_byte_equals_non_at_endpoint(
+    client, perspective
+):
+    """The eight body keys (``items`` / ``unknown`` / ``kind`` /
+    ``count`` / ``min_tier`` / ``min_tier_label`` / ``min_tier_rank`` /
+    ``tiers``) byte-equal ``/tiers-for-features?features=<same>`` for
+    every perspective -- the ``_at`` prefix cannot silently drift into
+    shaping the ladder."""
+    at = client.get(
+        f"/api/entitlement/tiers-for-features-at?tier={perspective}&features=fleet,sso"
+    )
+    non_at = client.get(
+        "/api/entitlement/tiers-for-features?features=fleet,sso"
+    )
+    assert at.status_code == 200
+    assert non_at.status_code == 200
+    at_body = {k: at.get_json()[k] for k in _BODY_KEYS}
+    non_at_body = {k: non_at.get_json()[k] for k in _BODY_KEYS}
+    assert at_body == non_at_body, (
+        f"perspective={perspective} shaped the ladder -- "
+        f"_at prefix must not shape rows"
+    )
+
+
+@pytest.mark.parametrize(
+    "perspective",
+    ["cloud_free", "trial", "cloud_starter", "cloud_pro", "pro", "enterprise"],
+)
+def test_api_runtimes_at_body_byte_equals_non_at_endpoint(
+    client, perspective
+):
+    at = client.get(
+        f"/api/entitlement/tiers-for-runtimes-at?tier={perspective}&runtimes=claude_code,codex"
+    )
+    non_at = client.get(
+        "/api/entitlement/tiers-for-runtimes?runtimes=claude_code,codex"
+    )
+    assert at.status_code == 200
+    assert non_at.status_code == 200
+    at_body = {k: at.get_json()[k] for k in _BODY_KEYS}
+    non_at_body = {k: non_at.get_json()[k] for k in _BODY_KEYS}
+    assert at_body == non_at_body, (
+        f"perspective={perspective} shaped the ladder -- "
+        f"_at prefix must not shape rows"
+    )
+
+
+# ── API: resolver + perspective envelope carried ──────────────────────────
+
+
+def test_api_features_at_carries_resolver_envelope(client, ent):
+    r = client.get(
+        "/api/entitlement/tiers-for-features-at?tier=cloud_pro&features=fleet"
+    )
+    j = r.get_json()
+    for k in ("current_tier", "current_tier_rank", "grace", "enforced"):
+        assert k in j
+    assert j["grace"] is True
+    assert j["enforced"] is False
+
+
+def test_api_runtimes_at_carries_resolver_envelope(client, ent):
+    r = client.get(
+        "/api/entitlement/tiers-for-runtimes-at?tier=cloud_pro&runtimes=claude_code"
+    )
+    j = r.get_json()
+    for k in ("current_tier", "current_tier_rank", "grace", "enforced"):
+        assert k in j
+    assert j["grace"] is True
+    assert j["enforced"] is False
+
+
+def test_api_features_at_carries_perspective_envelope(client, ent):
+    r = client.get(
+        "/api/entitlement/tiers-for-features-at?tier=cloud_starter&features=fleet"
+    )
+    j = r.get_json()
+    assert j["perspective_tier"] == "cloud_starter"
+    assert j["perspective_tier_label"] == ent.tier_label("cloud_starter")
+    assert j["perspective_tier_rank"] == ent.tier_rank("cloud_starter")
+
+
+def test_api_runtimes_at_carries_perspective_envelope(client, ent):
+    r = client.get(
+        "/api/entitlement/tiers-for-runtimes-at?tier=cloud_starter&runtimes=claude_code"
+    )
+    j = r.get_json()
+    assert j["perspective_tier"] == "cloud_starter"
+    assert j["perspective_tier_label"] == ent.tier_label("cloud_starter")
+    assert j["perspective_tier_rank"] == ent.tier_rank("cloud_starter")


### PR DESCRIPTION
## Summary

- Adds `tiers_for_features_at(perspective_tier, features)` and `tiers_for_runtimes_at(perspective_tier, runtimes)` — perspective-scoped ladder-intersection siblings of the two singular plural helpers.
- Adds `GET /api/entitlement/tiers-for-features-at` and `GET /api/entitlement/tiers-for-runtimes-at` — the hypothetical-perspective sibling endpoints of `/tiers-for-features` and `/tiers-for-runtimes`.
- Grace-mode change only — no behaviour change on any existing surface, no `__version__` bump, no `[RELEASE]` PR, no gate enforced.

## Why

The `_at` family fills a "hypothetical perspective" slot on every existing helper so a pricing-matrix walkthrough (`tier=<p>`) can hit the whole surface uniformly. Today the singular-scalar level, the plural min-tier level, the batch level, and the capacity `tiers_for_*` level are all covered:

- `min_tier_for_features_at` / `min_tier_for_runtimes_at` — plural scalar min-tier `_at` (#3711)
- `tiers_for_channel_count_at` / `tiers_for_retention_window_at` / `tiers_for_node_count_at` — capacity `tiers_for_*` `_at`
- `tiers_for_feature_at` / `tiers_for_runtime_at` — singular grant-axis `tiers_for_*` `_at`
- `tiers_for_batch_at` — fixed-batch `tiers_for_*` `_at`

But the *plural* grant-axis ladder (`tiers_for_features` / `tiers_for_runtimes`) had no `_at` sibling. A caller walking a pricing page column axis-by-axis on the ladder axis had to either fall back to `/tiers-for-batch-at` (which iterates over every known id, not a caller-supplied bundle) or synthesise the perspective envelope client-side from `/tiers-for-features` + a separate `/api/entitlement` call for `current_tier` / `grace` / `enforced`. This PR closes that gap so every axis in the `tiers_for_*` family exposes an `_at` sibling for the plural grant-axis case and the walkthrough URL can pass `tier=<p>` uniformly across singular / plural / batch / capacity.

The ladder answer is perspective-independent by design — it intersects the per-item `tiers_for_feature` / `tiers_for_runtime` grant sets from the static per-tier maps — so `tiers_for_features_at(p, ...) == tiers_for_features(...)` for every `p` in `_TIER_ORDER` (including `trial`). This mirrors the `_at`-does-not-shape-answers contract every sibling `_at` helper already follows, and is pinned in the test suite via a byte-parity check across every perspective.

## Changes

### `clawmetry/entitlements.py`

- `tiers_for_features_at(perspective_tier, features)` and `tiers_for_runtimes_at(perspective_tier, runtimes)`:
  - Validate perspective against `_TIER_ORDER` (trial accepted). Empty / blank / `None` / non-string / unknown perspective → `None`. Case-insensitive + whitespace-stripped.
  - Delegate to the matching `tiers_for_features` / `tiers_for_runtimes` helper unchanged. All non-`_at` semantics (empty iterable → empty ladder shape, unknown ids echoed in `unknown`, all-free bundle → full ladder + `TIER_OSS`, non-iterable → `None`) inherit unchanged.
  - Runtime aliases (`claude-code` → `claude_code`) canonicalise via `canonical_runtime` before intersection, matching the non-`_at` sibling.
  - Never raise: a delegate crash logs a warning and returns `None`.

### `routes/entitlement.py`

- `GET /api/entitlement/tiers-for-features-at` and `GET /api/entitlement/tiers-for-runtimes-at`. Args mirror `/api/entitlement/tiers-for-features` / `/tiers-for-runtimes` byte-for-byte plus the `tier=` arg. Response shape:

```json
{
  "items":                  ["fleet", "sso"],
  "unknown":                ["bogus"],
  "kind":                   "features",
  "count":                  2,
  "min_tier":               "enterprise",
  "min_tier_label":         "Enterprise",
  "min_tier_rank":          6,
  "tiers":                  [...],
  "perspective_tier":       "cloud_pro",
  "perspective_tier_label": "Cloud Pro",
  "perspective_tier_rank":  4,
  "current_tier":           "oss",
  "current_tier_rank":      0,
  "grace":                  true,
  "enforced":               false
}
```

- **400** on missing / blank `tier=`, or missing / blank `features=` / `runtimes=`.
- **404** on unknown `tier=` (body carries `which=tier`, matching the sibling `_at` posture).
- **All-unknown ids IS 200** with `items=[]`, `unknown=[...]`, `tiers=[]`, `min_tier=null` — distinguishes "caller asked for nothing" from "caller asked but every token was a typo".
- **Never 5xxs**: a resolver failure yields the fallback envelope so the pricing walkthrough keeps rendering.

### `tests/test_entitlement_tiers_for_plural_at.py`

**60 tests, all green** (4.1s):

- perspective validation: empty / blank / `None` / non-string / unknown → `None` at the helper layer; 400 / 404 at the HTTP layer
- trial accepted as perspective
- case-insensitive + whitespace-stripped perspective (`?tier=CLOUD_PRO` → `cloud_pro`)
- inherited semantics: empty iterable → empty ladder shape (NOT `None`), unknown-only bundle → empty ladder + populated `unknown`, `None` iterable → `None`, non-iterable → `None`
- runtime canonicalisation (`claude-code` → `claude_code` in `items`)
- per-perspective parity across every `p` in `_TIER_ORDER` for a mix of bundles including known-only, mixed, and all-unknown
- grace vs enforce yields byte-identical answers on both axes (pinned via a `CLAWMETRY_ENFORCE=1` reload roundtrip)
- helpers never raise on a delegate crash (monkeypatched delegate to raise)
- API happy paths: all four axis/id combinations, case-insensitive tier, trial perspective, envelope shape
- API error paths: 400 on missing / blank `tier=` / missing / blank `features=` / `runtimes=`; 404 on unknown `tier=`
- Cross-endpoint byte-parity: the eight body keys (`items` / `unknown` / `kind` / `count` / `min_tier` / `min_tier_label` / `min_tier_rank` / `tiers`) byte-equal `/tiers-for-features?features=<same>` / `/tiers-for-runtimes?runtimes=<same>` for every `p` in `_TIER_ORDER`

## Test plan

- [x] `python3 -m py_compile clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_tiers_for_plural_at.py` — clean
- [x] `ruff check clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_tiers_for_plural_at.py` — clean (`All checks passed!`)
- [x] `pytest tests/test_entitlement_tiers_for_plural_at.py -q` → **60/60 pass** in 4.13s
- [x] Sibling test files (`test_entitlement_min_tier_for_plural_at`, `test_entitlement_tiers_for_plural`, `test_entitlement_tiers_for_at`, `test_entitlement_tiers_for`, `test_entitlement_min_tier`, `test_blueprint_uniqueness`, `test_circular_import`) still green — **245/245 pass**
- [x] Blueprint URL-map uniqueness after registration — **237 routes, all unique**; both new endpoints present.

## Local operator verification checklist

I can't touch the running daemon, `~/.openclaw`, the live snapshot, or a browser from here — please run:

- [ ] Copy the changed files into `~/.clawmetry/lib/python3.11/site-packages/clawmetry/` (`entitlements.py`) and `~/.clawmetry/lib/python3.11/site-packages/routes/` (`entitlement.py`); drop the test file into the local checkout under `tests/`
- [ ] Clear `__pycache__` on both dirs
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
- [ ] `curl -s 'http://localhost:8900/api/entitlement/tiers-for-features-at?tier=cloud_pro&features=fleet,sso' | jq .` — expect `items=["fleet","sso"]`, `kind="features"`, `perspective_tier="cloud_pro"`, `tiers` matching `/tiers-for-features?features=fleet,sso`
- [ ] `curl -s 'http://localhost:8900/api/entitlement/tiers-for-runtimes-at?tier=cloud_starter&runtimes=claude-code,codex' | jq .` — expect `items=["claude_code","codex"]` (canonicalised), `kind="runtimes"`, `perspective_tier="cloud_starter"`
- [ ] `curl -s 'http://localhost:8900/api/entitlement/tiers-for-features-at?tier=trial&features=fleet' | jq .perspective_tier` → `"trial"` (accepted as perspective)
- [ ] `curl -s -o /dev/null -w '%{http_code}\n' 'http://localhost:8900/api/entitlement/tiers-for-features-at?features=fleet'` → `400`
- [ ] `curl -s -o /dev/null -w '%{http_code}\n' 'http://localhost:8900/api/entitlement/tiers-for-features-at?tier=cloud_pro'` → `400`
- [ ] `curl -s -o /dev/null -w '%{http_code}\n' 'http://localhost:8900/api/entitlement/tiers-for-features-at?tier=cloud_pro&features='` → `400`
- [ ] `curl -s -o /dev/null -w '%{http_code}\n' 'http://localhost:8900/api/entitlement/tiers-for-features-at?tier=bogus&features=fleet'` → `404` with body `{"which":"tier",...}`
- [ ] `curl -s 'http://localhost:8900/api/entitlement/tiers-for-features-at?tier=cloud_pro&features=bogus1,bogus2' | jq '.items,.unknown,.tiers'` — expect `[]`, `["bogus1","bogus2"]`, `[]` (all-unknown IS 200)
- [ ] Cross-check byte-parity: strip the seven envelope keys off `/tiers-for-features-at?tier=<p>&features=<X>` and confirm the remaining eight body keys byte-equal `/tiers-for-features?features=<X>` for every `p` in `_TIER_ORDER` (and same for runtimes)
- [ ] Decrypt the live cloud snapshot and hit the same endpoints against the cloud read-through path
- [ ] Browser check: any surface currently calling `/tiers-for-features` / `/tiers-for-runtimes` / `/tiers-for-batch-at` should keep rendering; nothing should call the new endpoints yet

No `__version__` bump, no tag, no `[RELEASE]` PR — staying in DRAFT until you've cleared local + cloud verification.

## MOAT / release checklist

- Not a MOAT fast-path change (no `local_store_via_daemon` / `_ls_call` / `_DAEMON_METHODS` touched).
- Not a `[RELEASE]` PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_016Q4amFygPa1LbLChgN2KnF)_