### PR TITLE
chore(e2e): fix stale #2146 refs to canonical C6 tracking issue #3666

### DIFF
--- a/.github/workflows/c6-pr-gate.yml
+++ b/.github/workflows/c6-pr-gate.yml
@@ -3,7 +3,7 @@ name: C6 Required-status-checks gate (PR audit)
 # Runs on every pull request to surface whether C6 (required-status-checks)
 # is configured on main. Fails visibly on every PR until the admin closes C6.
 #
-# The daily c6-health.yml posts to issue #2146 but the admin may not check
+# The daily c6-health.yml posts to issue #3666 but the admin may not check
 # that issue between merges. This check appears directly in the PR status
 # list alongside OSS golden path, E2E Browser Tests, etc. -- impossible to
 # miss when reviewing a PR.
@@ -34,7 +34,7 @@ name: C6 Required-status-checks gate (PR audit)
 #     bash scripts/close-c6.sh
 #     (uses your existing gh CLI session -- no PAT creation needed)
 #
-# Tracking: vivekchand/clawmetry#2146 (C6)
+# Tracking: vivekchand/clawmetry#3666 (C6)
 
 on:
   pull_request:

--- a/.github/workflows/c6-schedule-heal.yml
+++ b/.github/workflows/c6-schedule-heal.yml
@@ -22,7 +22,7 @@ name: C6 auto-heal (daily required-checks application)
 #     clawmetry, clawmetry-cloud, clawmetry-landing
 #   This workflow picks it up at 10:15am UTC and closes C6 automatically.
 #
-# Tracking: vivekchand/clawmetry#2146 (C6)
+# Tracking: vivekchand/clawmetry#3666 (C6)
 
 on:
   schedule:
@@ -48,7 +48,7 @@ jobs:
             echo "has_pat=false" >> "$GITHUB_OUTPUT"
             echo "::error::E2E_ADMIN_PAT secret is not set -- C6 (required-status-checks) cannot be applied automatically."
             echo ""
-            echo "ACTION REQUIRED: Add E2E_ADMIN_PAT to close C6 (vivekchand/clawmetry#2146)."
+            echo "ACTION REQUIRED: Add E2E_ADMIN_PAT to close C6 (vivekchand/clawmetry#3666)."
             echo ""
             echo "Step 1: Create a fine-grained PAT"
             echo "  https://github.com/settings/personal-access-tokens/new"
@@ -65,7 +65,7 @@ jobs:
             echo "  Actions > 'Apply required E2E status checks (C6 -- one-shot)'"
             echo "  confirm=APPLY, pat_token=<paste PAT>"
             echo ""
-            echo "  Tracking: https://github.com/vivekchand/clawmetry/issues/2146"
+            echo "  Tracking: https://github.com/vivekchand/clawmetry/issues/3666"
             exit 1
           else
             echo "has_pat=true" >> "$GITHUB_OUTPUT"
@@ -84,4 +84,4 @@ jobs:
           echo "C6 auto-heal complete."
           echo "If apply_required_status_checks.py exited 0, branch protection is configured"
           echo "on clawmetry/main, clawmetry-cloud/main, clawmetry-landing/main."
-          echo "C6 is now GREEN. Tracking: https://github.com/vivekchand/clawmetry/issues/2146"
+          echo "C6 is now GREEN. Tracking: https://github.com/vivekchand/clawmetry/issues/3666"

--- a/scripts/apply_required_status_checks.py
+++ b/scripts/apply_required_status_checks.py
@@ -46,7 +46,7 @@ Primary repo behaviour (clawmetry):
 When run locally (GITHUB_REPOSITORY not set), the script applies all 6
 checks and requires a token with cross-repo admin access.
 
-Tracking: vivekchand/clawmetry#2146 (C6)
+Tracking: vivekchand/clawmetry#3666 (C6)
 """
 from __future__ import annotations
 
@@ -374,9 +374,9 @@ def main() -> None:
                 "  Fix: re-run the workflow and paste a fine-grained PAT into the 'pat_token' field.\n"
                 "  PAT permissions: Administration (read+write) on clawmetry, clawmetry-cloud, clawmetry-landing.\n"
                 "  Alternative: bash scripts/close-c6.sh (uses your gh CLI session, ~30 sec).\n"
-                "  Tracking: vivekchand/clawmetry#2146 (C6)"
+                "  Tracking: vivekchand/clawmetry#3666 (C6)"
             )
-        # Read-only path: GITHUB_TOKEN cannot write branch protection.
+        # Read-only path: GITHUB_TOKEN cannot write branch protection rules.
         # Scope verification to the current repo only to avoid cross-repo 403s.
         local_checks, local_deprecated = _readonly_scope()
         print("=== E2E Robustness C6: read-only verify (GITHUB_TOKEN, no write access) ===")

--- a/scripts/close-c6.sh
+++ b/scripts/close-c6.sh
@@ -19,7 +19,7 @@
 # After running: every PR in those 3 repos must pass the E2E suite to merge.
 # This closes criterion C6 of the E2E Robustness epic.
 #
-# Tracking: vivekchand/clawmetry#2146
+# Tracking: vivekchand/clawmetry#3666
 
 set -euo pipefail
 


### PR DESCRIPTION
## Summary

Fire 3 (2026-07-14T04:00Z) fixed `c6-health.yml` to post daily reminders to the canonical E2E tracking issue #3666 instead of the stale #2146. Four files were missed in that PR and still pointed users at #2146 when following C6 closure instructions:

- `scripts/close-c6.sh` -- `# Tracking:` comment in the header
- `.github/workflows/c6-schedule-heal.yml` -- header comment + two `echo` lines in the runner shell
- `.github/workflows/c6-pr-gate.yml` -- `# Tracking:` comment visible in PR check log
- `scripts/apply_required_status_checks.py` -- module docstring + error message string printed to users

No functional change. All substitutions are in comments, doc strings, or user-facing help text.

## Why this matters

When a developer clicks "Details" on the failing `C6 Required-status-checks gate` PR check or runs `bash scripts/close-c6.sh`, the log/output says "Tracking: ...#2146". That issue is stale; #3666 is the live issue with current state, daily health-check comments, and the per-fire log. Sending users to #2146 breaks the feedback loop.

## Test plan

- [x] `grep -r '2146' scripts/ .github/workflows/c6-*.yml` returns 0 lines after this change
- [x] No workflow logic changed -- only string literals and comments updated
- [x] `c6-pr-gate.yml` CI run on this PR will show the correct issue URL in its log output

## E2E Robustness epic

Part of E2E Robustness Epic #3666 (C6). All 6 other criteria (C1-C5, C7) are green. C6 remains the sole blocker -- one admin action closes it:

1. [Create fine-grained PAT](https://github.com/settings/personal-access-tokens/new?name=clawmetry-c6) with Administration (read+write) on `clawmetry`, `clawmetry-cloud`, `clawmetry-landing`
2. [Actions > Apply required E2E status checks > Run workflow](https://github.com/vivekchand/clawmetry/actions/workflows/apply-required-checks.yml): `confirm=APPLY`, paste PAT, click Run

---
_Generated by [Claude Code](https://claude.ai/code/session_01D2t1C8KCpQyAae68tzAvgw)_