### PR TITLE
fix(crons): promote model field to first-class column

### DIFF
--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -446,6 +446,7 @@ _DDL = [
         last_run_at    VARCHAR,
         last_status    VARCHAR,
         next_run_at    VARCHAR,
+        model          VARCHAR,
         data           BLOB,
         updated_at     BIGINT NOT NULL,
         PRIMARY KEY (agent_type, cron_id)
@@ -1130,6 +1131,9 @@ _MIGRATIONS_V2 = [
     # Issue #3367 — expose NemoClaw sandbox runtime kind (terminal vs docker)
     # on session and event rows. Stamped at ingest time from sandbox config.
     ("events",   "runtime_kind",      "VARCHAR"),
+    # Issue #3719 — per-cron-job model attribution (openclaw Quick Create
+    # lets users pick an agent-turn model; harness exposes it per job).
+    ("crons",    "model",             "VARCHAR"),
 ]
 
 # ── Integrity / hash-chain (Issue #2200) ────────────────────────────────────
@@ -2543,7 +2547,7 @@ class LocalStore:
                               if k not in {"cron_id", "agent_type", "agent_id",
                                            "name", "schedule", "enabled",
                                            "last_run_at", "last_status",
-                                           "next_run_at"}})
+                                           "next_run_at", "model"}})
         schedule = cron.get("schedule")
         if isinstance(schedule, (dict, list)):
             schedule = json.dumps(schedule, separators=(",", ":"))
@@ -2552,8 +2556,8 @@ class LocalStore:
             self._conn.execute("""
                 INSERT INTO crons (
                     agent_type, cron_id, agent_id, name, schedule, enabled,
-                    last_run_at, last_status, next_run_at, data, updated_at
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    last_run_at, last_status, next_run_at, model, data, updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 ON CONFLICT (agent_type, cron_id) DO UPDATE SET
                     agent_id     = excluded.agent_id,
                     name         = COALESCE(excluded.name, crons.name),
@@ -2562,13 +2566,15 @@ class LocalStore:
                     last_run_at  = excluded.last_run_at,
                     last_status  = excluded.last_status,
                     next_run_at  = excluded.next_run_at,
+                    model        = COALESCE(excluded.model, crons.model),
                     data         = COALESCE(excluded.data, crons.data),
                     updated_at   = excluded.updated_at
             """, [atype, cid, cron.get("agent_id") or "main",
                   cron.get("name"), schedule,
                   bool(cron.get("enabled", True)),
                   cron.get("last_run_at"), cron.get("last_status"),
-                  cron.get("next_run_at"), data_blob, now_ms])
+                  cron.get("next_run_at"), cron.get("model") or None,
+                  data_blob, now_ms])
 
     def ingest_cron_run(self, run: dict[str, Any]) -> None:
         """Upsert one cron-run row (issue #605 DuckDB follow-up).
@@ -6691,7 +6697,7 @@ class LocalStore:
         where = ("WHERE " + " AND ".join(clauses)) if clauses else ""
         sql = f"""
             SELECT agent_type, cron_id, agent_id, name, schedule, enabled,
-                   last_run_at, last_status, next_run_at, data, updated_at
+                   last_run_at, last_status, next_run_at, model, data, updated_at
             FROM crons
             {where}
             ORDER BY updated_at DESC
@@ -6700,7 +6706,7 @@ class LocalStore:
         params.append(int(limit))
         cols = ["agent_type", "cron_id", "agent_id", "name", "schedule",
                 "enabled", "last_run_at", "last_status", "next_run_at",
-                "data", "updated_at"]
+                "model", "data", "updated_at"]
         return _decode_data_blob_rows(self._fetch(sql, params), cols)
 
     def query_cron_runs(

--- a/routes/crons.py
+++ b/routes/crons.py
@@ -183,6 +183,7 @@ def _row_to_cron_job(row):
         "schedule": schedule or {},
         "enabled": bool(row.get("enabled", True)),
         "createdAtMs": int(extras.get("createdAtMs") or 0),
+        "model": row.get("model") or "",
         "state": {
             "lastRunAtMs": _parse_iso_to_ms(row.get("last_run_at")),
             "lastStatus": row.get("last_status") or "pending",
@@ -190,7 +191,7 @@ def _row_to_cron_job(row):
             **state_extras,
         },
     }
-    # Carry through any extra top-level fields (prompt, channel, model, ...)
+    # Carry through any extra top-level fields (prompt, channel, ...)
     for k, v in extras.items():
         if k not in {"createdAtMs", "schedule", "lastDurationMs",
                      "consecutiveFailures", "lastError", "runHistory",


### PR DESCRIPTION
Closes #3719

## What

OpenClaw's Quick Create UI lets users pick an agent-turn model per cron job (harness changelog #95341). The gateway already returns this `model` field on every job record, and `sync_crons` already writes it — but it was stored in the freeform `data` BLOB and only surfaced through the generic extras carry-through loop in `_row_to_cron_job`. That's fragile: a future refactor of the exclusion set could silently drop it.

## Changes

- **`clawmetry/local_store.py`** — add `model VARCHAR` to the `crons` DDL; add `("crons", "model", "VARCHAR")` to `_MIGRATIONS_V2` (same idempotent ALTER pattern used 15+ times in the codebase, safe on existing DBs); exclude `model` from the BLOB in `ingest_cron` and bind it as a named parameter with `COALESCE` on conflict; project it explicitly in the `query_crons` SELECT.
- **`routes/crons.py`** — set `job["model"] = row.get("model") or ""` directly in the `job` dict in `_row_to_cron_job`, instead of relying on extras carry-through.

The JS `renderCrons()` already renders `j.model` next to the schedule when truthy (app.js ~L10238) — no frontend change needed.

## Test plan

- `python3 -m pytest tests/ -q -k cron` — existing cron tests pass
- Fresh DB: `model` column present in DDL, ingest/query round-trips cleanly
- Existing DB: migration adds column on startup, historical rows get `NULL` (rendered as blank by the UI guard `j.model ? ... : ''`)


---
_Generated by [Claude Code](https://claude.ai/code/session_01BsRKYRpTWVWDdYMumLD84Y)_