### PR TITLE
fix: surface model-router launch log when router fails to start (#3721)

### DIFF
--- a/clawmetry/adapters/openclaw.py
+++ b/clawmetry/adapters/openclaw.py
@@ -922,6 +922,45 @@ def _model_router_health_ok(port: int) -> bool:
         return False
 
 
+def _model_router_launch_log(tail_lines: int = 50) -> Optional[str]:
+    """Read the NemoClaw model-router launch log (#3721).
+
+    The provisioning path writes a startup log during harness onboarding
+    (``readRouterLaunchLog`` in the harness test helper). ClawMetry surfaces
+    the last ``tail_lines`` lines so a failed startup is diagnosable from the
+    dashboard rather than just showing a binary not-running verdict.
+
+    Path resolution (first match wins):
+    1. ``NEMOCLAW_MODEL_ROUTER_LOG`` env var override.
+    2. ``<venv>/model-router.log`` (same directory as fingerprint + proxy-config
+       files — the canonical NemoClaw model-router directory).
+    3. ``~/.nemoclaw/model-router.log`` (home-directory fallback).
+
+    Returns the last ``tail_lines`` as a stripped string, or ``None`` when no
+    log file is found. Never raises.
+    """
+    venv = os.environ.get("NEMOCLAW_MODEL_ROUTER_VENV") or os.path.expanduser(
+        os.path.join("~", ".nemoclaw", "model-router-venv")
+    )
+    candidates = [
+        os.environ.get("NEMOCLAW_MODEL_ROUTER_LOG", ""),
+        os.path.join(venv, "model-router.log"),
+        os.path.expanduser(os.path.join("~", ".nemoclaw", "model-router.log")),
+    ]
+    for path in candidates:
+        if not path:
+            continue
+        try:
+            with open(path, "r", encoding="utf-8", errors="replace") as fh:
+                lines = fh.readlines()
+            return "".join(lines[-tail_lines:]).strip() or None
+        except OSError:
+            continue
+        except Exception:
+            continue
+    return None
+
+
 def _model_router_live() -> dict:
     """Runtime-liveness signal for the NemoClaw model-router proxy (#2795).
 
@@ -930,13 +969,28 @@ def _model_router_live() -> dict:
     healthy one. This discovers the live proxy and polls its ``/health``
     endpoint, surfacing the distinct liveness signal on ``DetectResult.meta``.
 
+    When the router is not running, includes ``modelRouterLaunchLog`` (last 50
+    lines of the startup log, #3721) so a failed start is diagnosable from the
+    dashboard. The key is absent when no log file exists.
+
     Returns ``{"modelRouterRunning": bool}`` (plus ``modelRouterPort`` when the
-    listening port is discoverable). Read-only, best-effort, never raises.
+    listening port is discoverable, and ``modelRouterLaunchLog`` when a log
+    file is present). Read-only, best-effort, never raises.
     """
     port = _discover_model_router_port()
     if port is None:
-        return {"modelRouterRunning": False}
-    return {"modelRouterPort": port, "modelRouterRunning": _model_router_health_ok(port)}
+        result: dict = {"modelRouterRunning": False}
+        log = _model_router_launch_log()
+        if log is not None:
+            result["modelRouterLaunchLog"] = log
+        return result
+    running = _model_router_health_ok(port)
+    result = {"modelRouterPort": port, "modelRouterRunning": running}
+    if not running:
+        log = _model_router_launch_log()
+        if log is not None:
+            result["modelRouterLaunchLog"] = log
+    return result
 
 
 def _parse_proxy_config_model_list(content: str) -> Optional[List[str]]:

--- a/tests/test_obs_gap_talk_sandbox.py
+++ b/tests/test_obs_gap_talk_sandbox.py
@@ -186,6 +186,59 @@ def test_model_router_live_absent_returns_not_running(monkeypatch):
     assert oc._model_router_live() == {"modelRouterRunning": False}
 
 
+# -- #3721 model-router launch log ------------------------------------------
+
+def test_model_router_launch_log_read_via_env_var(tmp_path, monkeypatch):
+    log_file = tmp_path / "router.log"
+    log_file.write_text("Starting model-router\nListening on :4100\nFatal: port in use\n")
+    monkeypatch.setenv("NEMOCLAW_MODEL_ROUTER_LOG", str(log_file))
+    from clawmetry.adapters.openclaw import _model_router_launch_log
+    result = _model_router_launch_log()
+    assert result is not None
+    assert "Fatal: port in use" in result
+
+
+def test_model_router_launch_log_absent_returns_none(tmp_path, monkeypatch):
+    monkeypatch.setenv("NEMOCLAW_MODEL_ROUTER_LOG", "")
+    monkeypatch.setenv("NEMOCLAW_MODEL_ROUTER_VENV", str(tmp_path / "venv"))
+    monkeypatch.setenv("HOME", str(tmp_path))
+    from clawmetry.adapters.openclaw import _model_router_launch_log
+    assert _model_router_launch_log() is None
+
+
+def test_model_router_live_includes_launch_log_when_not_running(tmp_path, monkeypatch):
+    log_file = tmp_path / "router.log"
+    log_file.write_text("Error: failed to bind\n")
+    monkeypatch.setenv("NEMOCLAW_MODEL_ROUTER_LOG", str(log_file))
+    import clawmetry.adapters.openclaw as oc
+    monkeypatch.setattr(oc, "_discover_model_router_port", lambda: None)
+    out = oc._model_router_live()
+    assert out["modelRouterRunning"] is False
+    assert "failed to bind" in out.get("modelRouterLaunchLog", "")
+
+
+def test_model_router_live_omits_launch_log_key_when_no_log(tmp_path, monkeypatch):
+    monkeypatch.setenv("NEMOCLAW_MODEL_ROUTER_LOG", "")
+    monkeypatch.setenv("NEMOCLAW_MODEL_ROUTER_VENV", str(tmp_path / "venv"))
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.adapters.openclaw as oc
+    monkeypatch.setattr(oc, "_discover_model_router_port", lambda: None)
+    out = oc._model_router_live()
+    assert out == {"modelRouterRunning": False}
+
+
+def test_model_router_live_running_omits_launch_log(tmp_path, monkeypatch):
+    log_file = tmp_path / "router.log"
+    log_file.write_text("Router started\n")
+    monkeypatch.setenv("NEMOCLAW_MODEL_ROUTER_LOG", str(log_file))
+    import clawmetry.adapters.openclaw as oc
+    monkeypatch.setattr(oc, "_discover_model_router_port", lambda: 49000)
+    monkeypatch.setattr(oc, "_model_router_health_ok", lambda port: True)
+    out = oc._model_router_live()
+    assert out == {"modelRouterPort": 49000, "modelRouterRunning": True}
+    assert "modelRouterLaunchLog" not in out
+
+
 def test_model_router_health_ok_probes_real_localhost_server():
     # Spin up a tiny HTTP server that answers 200 on /health and assert the
     # probe (and its TCP fallback) report it as up.


### PR DESCRIPTION
Closes #3721

## Summary

- Adds `_model_router_launch_log()` in `clawmetry/adapters/openclaw.py`: reads the NemoClaw model-router startup log (last 50 lines) from `NEMOCLAW_MODEL_ROUTER_LOG` env var → `<venv>/model-router.log` → `~/.nemoclaw/model-router.log`. Returns `None` when no file is found; never raises.
- Updates `_model_router_live()` to include `modelRouterLaunchLog` in the result dict **only when the router is not running and a log file is present** — so the existing exact-equality tests continue to pass unchanged.
- Adds 5 new test cases in `tests/test_obs_gap_talk_sandbox.py` covering env-var path, absent file, log included on not-running, key absent with no file, and log omitted when router is healthy.

## Test plan

- `python3 -m pytest tests/test_obs_gap_talk_sandbox.py -k model_router` → 16 passed (11 existing + 5 new)
- All existing model-router tests pass without modification (conditional key inclusion preserves exact-equality assertions)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XnYA94CGqBta6cAPLgRJYb)_