### PR TITLE
chore(c6): add day counter to health check + fix final stale #2146 ref

### DIFF
--- a/.github/workflows/apply-required-checks.yml
+++ b/.github/workflows/apply-required-checks.yml
@@ -37,7 +37,7 @@ name: Apply required E2E status checks (C6 -- one-shot)
 #   clawmetry-landing.
 #
 # Idempotent: running multiple times is safe.
-# Tracking: vivekchand/clawmetry#2146 (C6)
+# Tracking: vivekchand/clawmetry#3666
 
 on:
   workflow_dispatch:

--- a/.github/workflows/c6-health.yml
+++ b/.github/workflows/c6-health.yml
@@ -168,6 +168,14 @@ jobs:
                   print(f"Health check already posted today ({today_utc}). Skipping.")
                   sys.exit(1 if results.get("clawmetry", {}).get("status") != "ok" else 0)
 
+          # Count previous health-check posts for escalation display.
+          prev_check_count = sum(
+              1
+              for c in (comments or [])
+              if (c.get("user") or {}).get("login", "") == "github-actions[bot]"
+              and MARKER in c.get("body", "")
+          )
+
           # Determine overall state.
           has_confirmed_missing = any(
               r["status"] in ("missing", "unprotected") for r in results.values()
@@ -235,7 +243,7 @@ jobs:
 
               body = (
                   f"{MARKER}\n"
-                  f"@{OWNER} **C6 health check {today_utc}: {summary}.**\n\n"
+                  f"@{OWNER} **C6 health check {today_utc} (day {prev_check_count + 1}): {summary}.**\n\n"
                   f"{table}\n\n"
                   "**Close C6 now -- 2 clicks, no local setup needed:**\n\n"
                   "**Step 1:** [Create fine-grained PAT]"


### PR DESCRIPTION
## Summary

Two small C6 quality improvements:

- `c6-health.yml`: daily failure reminders now include **(day N)** so the escalating urgency of C6 being open is visible at a glance each day (e.g. "C6 health check 2026-07-15 (day 6): ..."). The counter is derived from the count of previous health-check posts on the tracking issue, so it increments automatically.
- `apply-required-checks.yml`: fixes the last remaining stale `#2146` tracking reference (4 other files were fixed in PR #3716 -- this file was missed in that sweep).

No logic changes. No new dependencies. No workflow triggers added.

## Test plan

- `grep -n '2146' .github/workflows/apply-required-checks.yml` returns 0 lines
- `grep -n 'prev_check_count' .github/workflows/c6-health.yml` returns 2 lines (the `sum(...)` block and the f-string)
- `grep -n 'day {prev_check_count' .github/workflows/c6-health.yml` returns 1 line (the failure message)
- Next `c6-health.yml` scheduled run (09:00 UTC) will post with "(day N)" in the subject

## E2E Robustness epic

Part of E2E Robustness Epic #3666. **C6 is the sole remaining blocker -- 30 seconds to close:**

1. [Create fine-grained PAT](https://github.com/settings/personal-access-tokens/new?name=clawmetry-c6): Resource owner `vivekchand`, repos `clawmetry` + `clawmetry-cloud` + `clawmetry-landing`, permission: Administration (read+write)
2. [Actions > Apply required E2E status checks > Run workflow](https://github.com/vivekchand/clawmetry/actions/workflows/apply-required-checks.yml): `confirm=APPLY`, paste PAT, click Run

C1/C2/C3/C4/C5/C7 all green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FsGAND6EY6zsr7CJhWJujh)_