### PR TITLE
docs: refresh stale claims across CLAUDE.md, ARCHITECTURE.md, CONTRIBUTING.md, AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ ClawMetry is open-core — there are **four repos**. Pick the right one *before*
 
 - **clawmetry** (this repo, public OSS) — OpenClaw runtime + NeMo governance + 21 chat channels + entitlement gate (`clawmetry/entitlements.py`) + license client (`clawmetry/license.py`) + Enterprise feature **endpoints** (entitlement-gated; impl may defer to clawmetry-pro). Examples: `routes/otel_export.py`, `routes/audit.py`.
 - **clawmetry-pro** (private; not on public PyPI; shipped via the license-server wheel download) — the 10 gated runtime adapters (Claude Code, Codex, Cursor, …), Pro paid CLI capabilities, advanced-feature implementations. Plugs in via `clawmetry.extensions` entry point.
-- **clawmetry-cloud** (private) — cloud SaaS app + license server (`routes/license.py`) + Stripe + admin + closed-wheel hosting (`wheels/`).
+- **clawmetry-cloud** (private) — cloud SaaS app + license server (`clawmetry-cloud/routes/license.py`) + Stripe + admin + closed-wheel hosting (`wheels/`).
 - **clawmetry-landing** (private, public site) — marketing + pricing page + Buy buttons. No gated code.
 
 Quick chooser:

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -168,7 +168,7 @@ No environment variables, no config files, no database setup. If OpenClaw is run
 
 ## The Dashboard — What You See
 
-ClawMetry serves a single-page web app (embedded HTML/CSS/JS in the Python file) with these views:
+ClawMetry serves a single-page web app (frontend in `clawmetry/static/` + `clawmetry/templates/`) with these views:
 
 ### Overview (`/api/overview`)
 The main dashboard. Aggregates:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ All HTTP endpoints live here, organised by feature. Each module owns one or more
 | `interceptor.py` | ~630 | Zero-config HTTP monkey-patching for LLM cost tracking (patches httpx/requests) |
 | `providers_pricing.py` | ~390 | Multi-provider pricing table (Anthropic, OpenAI, Google, OpenRouter, etc.) |
 | `config.py` | ~200 | Configuration dataclass |
-| `extensions.py` | ~180 | Plugin/hook system |
+| `extensions.py` | ~230 | Plugin/hook system |
 | `track.py` | ~60 | Zero-config interceptor shorthand |
 | `providers/` | — | Pluggable data provider layer (LocalDataProvider, TursoDataProvider) |
 
@@ -146,7 +146,7 @@ Tests use `CLAWMETRY_URL` and `CLAWMETRY_TOKEN` env vars. Test matrix in CI: 3 O
 ## Deploy
 - **PyPI**: `pip install clawmetry && clawmetry`
 - **Docker**: `docker build -t clawmetry . && docker run -p 8900:8900 -v ~/.openclaw:/root/.openclaw:ro clawmetry`
-- **Current version**: `0.12.544` (in `dashboard.py` `__version__`)
+- **Current version**: `0.12.554` (in `dashboard.py` `__version__`)
 
 ## CI/CD (GitHub Actions)
 - `ci.yml` — Lint + test matrix on push/PR

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ clawmetry --help
 
 ```
 clawmetry/
-├── dashboard.py          # 🎯 Flask app, blueprint registration, embedded HTML/CSS/JS, shared helpers
+├── dashboard.py          # 🎯 Flask app, blueprint registration, shared helpers
 ├── routes/               # 🧩 Per-feature Blueprints (sessions, channels, brain, usage, health, …)
 ├── clawmetry/            # 📦 Installable package — CLI, sync daemon, proxy, interceptor, providers
 ├── history.py            # 📈 Optional time-series collector (SQLite)
@@ -53,7 +53,7 @@ clawmetry/
 
 See `CLAUDE.md` (`Key Files`) for the full per-module breakdown including line counts and Blueprint names.
 
-**Philosophy**: Keep it simple. The dashboard core is a Flask app in `dashboard.py` (with embedded HTML/CSS/JS) and a small `routes/` package of feature Blueprints — minimal dependencies, easy to understand, modify, and deploy.
+**Philosophy**: Keep it simple. The dashboard core is a Flask app in `dashboard.py` (shared helpers + blueprint registration; live frontend is in `clawmetry/static/` + `clawmetry/templates/`) and a small `routes/` package of feature Blueprints — minimal dependencies, easy to understand, modify, and deploy.
 
 ---
 
@@ -119,7 +119,7 @@ listed in the manifest so real OpenClaw event-shape drift is covered.
 If you want to add a new tab or major feature:
 
 1. **Open an Issue first** - describe what you want to build and why
-2. **Keep it lightweight** - remember this is a single-file app
+2. **Keep it lightweight** - minimal dependencies, no heavy frameworks
 3. **Follow the existing pattern** - look at how other tabs are implemented
 4. **Update the README** - document your new feature in the features table
 


### PR DESCRIPTION
Closes #3726

## Summary
- **CLAUDE.md**: bump `extensions.py` line count `~180` → `~230` (+28% drift, over threshold) and version string `0.12.544` → `0.12.554` to match actual `__version__`
- **ARCHITECTURE.md**: replace "embedded HTML/CSS/JS in the Python file" with "frontend in `clawmetry/static/` + `clawmetry/templates/`" — accurate since the static/templates migration
- **CONTRIBUTING.md**: remove three stale references — "embedded HTML/CSS/JS" in the file tree comment, "with embedded HTML/CSS/JS" in the philosophy blurb, and "this is a single-file app" in the contribution guidelines
- **AGENTS.md**: qualify `routes/license.py` → `clawmetry-cloud/routes/license.py` so OSS readers don't search for a file that lives in the private repo

## Test plan
- [ ] Doc-only change — no runtime surface; no tests required
- [ ] Verify `grep -r "embedded HTML/CSS/JS\|single-file app" CLAUDE.md ARCHITECTURE.md CONTRIBUTING.md AGENTS.md` returns no matches after merge

---
_Generated by [Claude Code](https://claude.ai/code/session_01Md6fGiJH1JnKfYxQN6uJE2)_