### PR TITLE
feat(entitlement): min_tier_for_features + min_tier_for_runtimes bare endpoints

### DIFF
--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -21536,3 +21536,184 @@ def api_entitlement_tiers_for_runtimes_at():
                 **_perspective_fallback(tier_in),
             }
         )
+
+
+@bp_entitlement.route("/api/entitlement/min-tier-for-features")
+def api_entitlement_min_tier_for_features():
+    """``GET /api/entitlement/min-tier-for-features?features=a,b,c`` --
+    resolver-scoped sibling of ``min_tier_for_features``: the cheapest
+    *purchasable* tier admitting every feature in the bundle.
+
+    Fills the *bare* slot for the plural grant-axis ``min_tier_for_*``
+    family alongside the singular ``/min-tier?feature=<id>`` route (which
+    resolves ONE feature at a time) and the ``_at`` sibling
+    ``/min-tier-for-features-at?tier=<perspective>&features=<csv>`` (which
+    layers a hypothetical-perspective envelope on top). A dashboard wiring
+    "you are using fleet + otel_export + sso -- Available in Enterprise"
+    can now hit ONE endpoint that folds the per-feature ``max-by-rank``
+    walk in place of N calls to ``/min-tier?feature=`` + client-side
+    aggregation.
+
+    Body byte-identical to ``/min-tier-for-features-at?tier=<p>&features=``
+    with the three ``perspective_tier`` / ``perspective_tier_label`` /
+    ``perspective_tier_rank`` envelope keys stripped -- pinned by a
+    parity test so the bare and ``_at`` bodies cannot drift.
+
+    Response shape::
+
+        {
+          "features":            ["fleet", "sso"],
+          "unknown":             ["bogus"],
+          "kind":                "features",
+          "count":               2,
+          "required_tier":       "enterprise" | null,
+          "required_tier_label": "Enterprise" | null,
+          "required_tier_rank":  <int>,
+          "free":                <bool>,
+          "current_tier":        "oss",
+          "current_tier_rank":   <int>,
+          "grace":               <bool>,
+          "enforced":            <bool>,
+        }
+
+    - **400** when ``features=`` is missing / blank after CSV
+      normalisation.
+    - **All-unknown features IS 200** with ``unknown`` populated and
+      ``required_tier=null`` -- distinguishes "caller asked for nothing"
+      from "caller asked but every token was a typo" so a paywall UI can
+      render "these ids are unknown: X" instead of a null.
+    - **Never 5xxs**: a resolver failure yields the fallback envelope
+      (empty ``features`` list, ``required_tier=null``) so the pricing
+      surface keeps rendering.
+    """
+    features_csv = _parse_csv_arg("features")
+    if not features_csv:
+        return jsonify({"error": "missing features"}), 400
+
+    try:
+        from clawmetry import entitlements as _ent
+
+        known: list[str] = []
+        unknown: list[str] = []
+        for fid in features_csv:
+            if fid in _ent.ALL_FEATURES:
+                if fid not in known:
+                    known.append(fid)
+            else:
+                if fid not in unknown:
+                    unknown.append(fid)
+
+        required = _ent.min_tier_for_features(known) if known else None
+        env = _resolver_envelope(_ent)
+        return jsonify(
+            {
+                "features": known,
+                "unknown": unknown,
+                "kind": "features",
+                "count": len(known),
+                "required_tier": required,
+                "required_tier_label": (
+                    _ent.tier_label(required) if required else None
+                ),
+                "required_tier_rank": (
+                    _ent.tier_rank(required) if required else -1
+                ),
+                "free": bool(required == _ent.TIER_OSS),
+                **env,
+            }
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_min_tier_for_features: error: %s", exc
+        )
+        return jsonify(
+            {
+                "features": [],
+                "unknown": features_csv,
+                "kind": "features",
+                "count": 0,
+                "required_tier": None,
+                "required_tier_label": None,
+                "required_tier_rank": -1,
+                "free": False,
+                "current_tier": "oss",
+                "current_tier_rank": 0,
+                "grace": True,
+                "enforced": False,
+            }
+        )
+
+
+@bp_entitlement.route("/api/entitlement/min-tier-for-runtimes")
+def api_entitlement_min_tier_for_runtimes():
+    """``GET /api/entitlement/min-tier-for-runtimes?runtimes=x,y,z`` --
+    runtime-axis twin of ``/api/entitlement/min-tier-for-features``.
+
+    Same never-5xx posture, same partial-unknown bucketing.
+    Runtime aliases (``claude-code`` -> ``claude_code``) are canonicalised
+    through :func:`clawmetry.entitlements.canonical_runtime` so a caller
+    does not need to normalise before calling; unknown ids land in
+    ``unknown`` and drop from the ``required_tier`` walk (a typo does NOT
+    silently mis-route the ladder to a higher tier).
+
+    Response shape and error paths mirror
+    ``/min-tier-for-features`` exactly, with ``kind="runtimes"`` and a
+    ``runtimes`` list in place of ``features``.
+    """
+    runtimes_csv = _parse_csv_arg("runtimes")
+    if not runtimes_csv:
+        return jsonify({"error": "missing runtimes"}), 400
+
+    try:
+        from clawmetry import entitlements as _ent
+
+        known: list[str] = []
+        unknown: list[str] = []
+        for rt in runtimes_csv:
+            canon = _ent.canonical_runtime(rt)
+            if canon and canon in _ent.ALL_RUNTIMES:
+                if canon not in known:
+                    known.append(canon)
+            else:
+                if rt not in unknown:
+                    unknown.append(rt)
+
+        required = _ent.min_tier_for_runtimes(known) if known else None
+        env = _resolver_envelope(_ent)
+        return jsonify(
+            {
+                "runtimes": known,
+                "unknown": unknown,
+                "kind": "runtimes",
+                "count": len(known),
+                "required_tier": required,
+                "required_tier_label": (
+                    _ent.tier_label(required) if required else None
+                ),
+                "required_tier_rank": (
+                    _ent.tier_rank(required) if required else -1
+                ),
+                "free": bool(required == _ent.TIER_OSS),
+                **env,
+            }
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_min_tier_for_runtimes: error: %s", exc
+        )
+        return jsonify(
+            {
+                "runtimes": [],
+                "unknown": runtimes_csv,
+                "kind": "runtimes",
+                "count": 0,
+                "required_tier": None,
+                "required_tier_label": None,
+                "required_tier_rank": -1,
+                "free": False,
+                "current_tier": "oss",
+                "current_tier_rank": 0,
+                "grace": True,
+                "enforced": False,
+            }
+        )

--- a/tests/test_entitlement_min_tier_for_plural_bare.py
+++ b/tests/test_entitlement_min_tier_for_plural_bare.py
@@ -1,0 +1,411 @@
+"""Tests for the bare ``/api/entitlement/min-tier-for-features`` and
+``/api/entitlement/min-tier-for-runtimes`` endpoints.
+
+Fills the *bare* slot in the plural grant-axis ``min_tier_for_*`` family
+alongside the singular ``/min-tier?feature=<id>`` route (which resolves
+ONE feature at a time) and the ``_at`` sibling
+``/min-tier-for-features-at`` (which layers a hypothetical-perspective
+envelope on top). Wraps the existing
+:func:`clawmetry.entitlements.min_tier_for_features` /
+:func:`clawmetry.entitlements.min_tier_for_runtimes` helpers.
+
+These tests pin:
+
+* API happy path: shape, resolver envelope, ``kind``, ``count``, ``free``
+* API error paths: 400 on missing / blank ``features=`` / ``runtimes=``
+* all-unknown IS 200 with ``unknown`` populated and ``required_tier=null``
+  (not confused with "asked for nothing")
+* CSV dedup / normalisation via the shared ``_parse_csv_arg`` helper
+* runtime canonicalisation (``claude-code`` -> ``claude_code``)
+* body byte-parity with the ``_at`` sibling once the three perspective
+  keys are stripped -- the bare and ``_at`` bodies must not drift
+* cross-endpoint parity: ``required_tier`` byte-equals the helper's return
+* resolver envelope carried
+* never-5xxs on a delegate crash
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+_BARE_ENVELOPE_KEYS = {
+    "current_tier",
+    "current_tier_rank",
+    "grace",
+    "enforced",
+    "required_tier",
+    "required_tier_label",
+    "required_tier_rank",
+    "free",
+    "kind",
+    "count",
+    "unknown",
+}
+
+
+# ── API: happy path ────────────────────────────────────────────────────────
+
+
+def test_api_features_happy_path(client, ent):
+    r = client.get(
+        "/api/entitlement/min-tier-for-features?features=fleet,sso"
+    )
+    assert r.status_code == 200
+    j = r.get_json()
+    expected = _BARE_ENVELOPE_KEYS | {"features"}
+    assert set(j.keys()) == expected
+    assert j["kind"] == "features"
+    assert j["features"] == ["fleet", "sso"]
+    assert j["unknown"] == []
+    assert j["count"] == 2
+    assert j["required_tier"] == ent.min_tier_for_features(["fleet", "sso"])
+    assert j["required_tier_label"] == ent.tier_label(j["required_tier"])
+    assert j["required_tier_rank"] == ent.tier_rank(j["required_tier"])
+
+
+def test_api_runtimes_happy_path(client, ent):
+    r = client.get(
+        "/api/entitlement/min-tier-for-runtimes?runtimes=claude-code,codex"
+    )
+    assert r.status_code == 200
+    j = r.get_json()
+    expected = _BARE_ENVELOPE_KEYS | {"runtimes"}
+    assert set(j.keys()) == expected
+    assert j["kind"] == "runtimes"
+    assert j["runtimes"] == ["claude_code", "codex"]  # canonicalised
+    assert j["unknown"] == []
+    assert j["required_tier"] == ent.min_tier_for_runtimes(
+        ["claude_code", "codex"]
+    )
+
+
+def test_api_features_bare_body_has_no_perspective_keys(client):
+    r = client.get(
+        "/api/entitlement/min-tier-for-features?features=fleet"
+    )
+    j = r.get_json()
+    assert "perspective_tier" not in j
+    assert "perspective_tier_label" not in j
+    assert "perspective_tier_rank" not in j
+
+
+def test_api_runtimes_bare_body_has_no_perspective_keys(client):
+    r = client.get(
+        "/api/entitlement/min-tier-for-runtimes?runtimes=claude_code"
+    )
+    j = r.get_json()
+    assert "perspective_tier" not in j
+    assert "perspective_tier_label" not in j
+    assert "perspective_tier_rank" not in j
+
+
+# ── API: error paths ──────────────────────────────────────────────────────
+
+
+def test_api_features_missing_features_returns_400(client):
+    r = client.get("/api/entitlement/min-tier-for-features")
+    assert r.status_code == 400
+    assert r.get_json().get("error") == "missing features"
+
+
+def test_api_runtimes_missing_runtimes_returns_400(client):
+    r = client.get("/api/entitlement/min-tier-for-runtimes")
+    assert r.status_code == 400
+    assert r.get_json().get("error") == "missing runtimes"
+
+
+def test_api_features_blank_features_returns_400(client):
+    r = client.get(
+        "/api/entitlement/min-tier-for-features?features=%20%20"
+    )
+    assert r.status_code == 400
+
+
+def test_api_runtimes_blank_runtimes_returns_400(client):
+    r = client.get(
+        "/api/entitlement/min-tier-for-runtimes?runtimes=%20%20"
+    )
+    assert r.status_code == 400
+
+
+def test_api_features_empty_csv_returns_400(client):
+    r = client.get("/api/entitlement/min-tier-for-features?features=")
+    assert r.status_code == 400
+
+
+def test_api_runtimes_empty_csv_returns_400(client):
+    r = client.get("/api/entitlement/min-tier-for-runtimes?runtimes=")
+    assert r.status_code == 400
+
+
+# ── API: all-unknown IS 200 ────────────────────────────────────────────────
+
+
+def test_api_features_all_unknown_is_200(client):
+    r = client.get(
+        "/api/entitlement/min-tier-for-features?features=bogus1,bogus2"
+    )
+    assert r.status_code == 200
+    j = r.get_json()
+    assert j["features"] == []
+    assert j["unknown"] == ["bogus1", "bogus2"]
+    assert j["required_tier"] is None
+    assert j["required_tier_label"] is None
+    assert j["required_tier_rank"] == -1
+    assert j["count"] == 0
+    assert j["free"] is False
+
+
+def test_api_runtimes_all_unknown_is_200(client):
+    r = client.get(
+        "/api/entitlement/min-tier-for-runtimes?runtimes=bogus1,bogus2"
+    )
+    assert r.status_code == 200
+    j = r.get_json()
+    assert j["runtimes"] == []
+    assert j["unknown"] == ["bogus1", "bogus2"]
+    assert j["required_tier"] is None
+    assert j["count"] == 0
+    assert j["free"] is False
+
+
+# ── API: CSV normalisation / dedup ─────────────────────────────────────────
+
+
+def test_api_features_dedup_preserves_order(client):
+    r = client.get(
+        "/api/entitlement/min-tier-for-features?features=fleet,,sso,fleet"
+    )
+    assert r.status_code == 200
+    assert r.get_json()["features"] == ["fleet", "sso"]
+
+
+def test_api_runtimes_dedup_preserves_order(client):
+    r = client.get(
+        "/api/entitlement/min-tier-for-runtimes?runtimes=claude-code,,codex,claude_code"
+    )
+    assert r.status_code == 200
+    assert r.get_json()["runtimes"] == ["claude_code", "codex"]
+
+
+def test_api_features_mixed_known_unknown(client, ent):
+    r = client.get(
+        "/api/entitlement/min-tier-for-features?features=fleet,bogus"
+    )
+    assert r.status_code == 200
+    j = r.get_json()
+    assert j["features"] == ["fleet"]
+    assert j["unknown"] == ["bogus"]
+    assert j["required_tier"] == ent.min_tier_for_features(["fleet"])
+
+
+def test_api_runtimes_mixed_known_unknown(client, ent):
+    r = client.get(
+        "/api/entitlement/min-tier-for-runtimes?runtimes=claude_code,bogus"
+    )
+    assert r.status_code == 200
+    j = r.get_json()
+    assert j["runtimes"] == ["claude_code"]
+    assert j["unknown"] == ["bogus"]
+    assert j["required_tier"] == ent.min_tier_for_runtimes(["claude_code"])
+
+
+# ── API: cross-endpoint parity ────────────────────────────────────────────
+
+
+def test_api_features_required_tier_byte_equals_helper(client, ent):
+    r = client.get(
+        "/api/entitlement/min-tier-for-features?features=fleet,sso"
+    )
+    assert r.status_code == 200
+    assert (
+        r.get_json()["required_tier"]
+        == ent.min_tier_for_features(["fleet", "sso"])
+    )
+
+
+def test_api_runtimes_required_tier_byte_equals_helper(client, ent):
+    r = client.get(
+        "/api/entitlement/min-tier-for-runtimes?runtimes=claude_code,codex"
+    )
+    assert r.status_code == 200
+    assert (
+        r.get_json()["required_tier"]
+        == ent.min_tier_for_runtimes(["claude_code", "codex"])
+    )
+
+
+# ── API: body byte-parity with _at sibling (perspective keys stripped) ───
+
+
+_PERSPECTIVE_ENVELOPE_KEYS = {
+    "perspective_tier",
+    "perspective_tier_label",
+    "perspective_tier_rank",
+}
+
+
+@pytest.mark.parametrize(
+    "perspective",
+    ["cloud_free", "trial", "cloud_starter", "cloud_pro", "pro", "enterprise"],
+)
+def test_api_features_bare_matches_at_with_perspective_stripped(
+    client, perspective
+):
+    """The bare body must byte-equal the ``_at`` body once the three
+    perspective envelope keys are stripped. Pins that the bare and
+    ``_at`` bodies cannot drift."""
+    bare = client.get(
+        "/api/entitlement/min-tier-for-features?features=fleet,sso"
+    ).get_json()
+    at = client.get(
+        f"/api/entitlement/min-tier-for-features-at?tier={perspective}&features=fleet,sso"
+    ).get_json()
+    at_stripped = {k: v for k, v in at.items() if k not in _PERSPECTIVE_ENVELOPE_KEYS}
+    assert bare == at_stripped, (
+        f"bare vs _at?tier={perspective} bodies diverged "
+        f"(perspective keys stripped): "
+        f"bare_only={set(bare) - set(at_stripped)} "
+        f"at_only={set(at_stripped) - set(bare)}"
+    )
+
+
+@pytest.mark.parametrize(
+    "perspective",
+    ["cloud_free", "trial", "cloud_starter", "cloud_pro", "pro", "enterprise"],
+)
+def test_api_runtimes_bare_matches_at_with_perspective_stripped(
+    client, perspective
+):
+    bare = client.get(
+        "/api/entitlement/min-tier-for-runtimes?runtimes=claude_code,codex"
+    ).get_json()
+    at = client.get(
+        f"/api/entitlement/min-tier-for-runtimes-at?tier={perspective}&runtimes=claude_code,codex"
+    ).get_json()
+    at_stripped = {k: v for k, v in at.items() if k not in _PERSPECTIVE_ENVELOPE_KEYS}
+    assert bare == at_stripped
+
+
+# ── API: resolver envelope carried ────────────────────────────────────────
+
+
+def test_api_features_carries_resolver_envelope(client):
+    r = client.get(
+        "/api/entitlement/min-tier-for-features?features=fleet"
+    )
+    j = r.get_json()
+    for k in ("current_tier", "current_tier_rank", "grace", "enforced"):
+        assert k in j
+    assert j["grace"] is True
+    assert j["enforced"] is False
+
+
+def test_api_runtimes_carries_resolver_envelope(client):
+    r = client.get(
+        "/api/entitlement/min-tier-for-runtimes?runtimes=claude_code"
+    )
+    j = r.get_json()
+    for k in ("current_tier", "current_tier_rank", "grace", "enforced"):
+        assert k in j
+    assert j["grace"] is True
+    assert j["enforced"] is False
+
+
+# ── API: never-5xxs on a delegate crash ───────────────────────────────────
+
+
+def test_api_features_never_5xxs_on_delegate_crash(client, ent, monkeypatch):
+    def _boom(*_a, **_kw):
+        raise RuntimeError("delegate boom")
+
+    monkeypatch.setattr(ent, "min_tier_for_features", _boom)
+    r = client.get(
+        "/api/entitlement/min-tier-for-features?features=fleet"
+    )
+    assert r.status_code == 200
+    j = r.get_json()
+    assert j["required_tier"] is None
+    assert j["features"] == []
+    assert j["unknown"] == ["fleet"]
+    assert j["kind"] == "features"
+
+
+def test_api_runtimes_never_5xxs_on_delegate_crash(client, ent, monkeypatch):
+    def _boom(*_a, **_kw):
+        raise RuntimeError("delegate boom")
+
+    monkeypatch.setattr(ent, "min_tier_for_runtimes", _boom)
+    r = client.get(
+        "/api/entitlement/min-tier-for-runtimes?runtimes=claude_code"
+    )
+    assert r.status_code == 200
+    j = r.get_json()
+    assert j["required_tier"] is None
+    assert j["runtimes"] == []
+    assert j["unknown"] == ["claude_code"]
+    assert j["kind"] == "runtimes"
+
+
+# ── grace vs enforce parity ───────────────────────────────────────────────
+
+
+def test_api_features_grace_vs_enforce_identical(client, ent, monkeypatch):
+    grace = client.get(
+        "/api/entitlement/min-tier-for-features?features=fleet,sso"
+    ).get_json()
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    importlib.reload(ent)
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    enforce_client = app.test_client()
+    enforce = enforce_client.get(
+        "/api/entitlement/min-tier-for-features?features=fleet,sso"
+    ).get_json()
+    # required_tier / kind / features / count / free must byte-equal.
+    for k in ("required_tier", "kind", "features", "count", "free", "unknown"):
+        assert grace[k] == enforce[k], f"key {k} drifted grace vs enforce"
+
+
+def test_api_runtimes_grace_vs_enforce_identical(client, ent, monkeypatch):
+    grace = client.get(
+        "/api/entitlement/min-tier-for-runtimes?runtimes=claude_code"
+    ).get_json()
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    importlib.reload(ent)
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    enforce_client = app.test_client()
+    enforce = enforce_client.get(
+        "/api/entitlement/min-tier-for-runtimes?runtimes=claude_code"
+    ).get_json()
+    for k in ("required_tier", "kind", "runtimes", "count", "free", "unknown"):
+        assert grace[k] == enforce[k], f"key {k} drifted grace vs enforce"


### PR DESCRIPTION
## Summary

- Adds `GET /api/entitlement/min-tier-for-features` and `GET /api/entitlement/min-tier-for-runtimes` -- bare siblings of the existing `_at` routes (`/min-tier-for-features-at` / `/min-tier-for-runtimes-at`).
- Wraps the existing `clawmetry.entitlements.min_tier_for_features` / `min_tier_for_runtimes` helpers -- no changes to `entitlements.py`, no new resolver behavior.
- Grace-mode only. No `__version__` bump, no `[RELEASE]` PR, no gate enforced.

## Why

The plural grant-axis `min_tier_for_*` family already exposes its `_at` (hypothetical-perspective) sibling but NOT the bare (resolver-scoped) sibling. Today a dashboard wiring "you are using fleet + otel_export + sso -- Available in Enterprise" has to either:

- fire N calls to `/min-tier?feature=<id>` and fold the max-by-rank on the client, or
- fall back to `/required-tier-batch?features=<csv>` (which combines features + runtimes and lacks the per-axis `kind` / `count` / `unknown` envelope), or
- pass a dummy `?tier=<any>` through `/min-tier-for-features-at` and strip the perspective keys client-side.

None of the three matches the surface area of every other `min_tier_for_*` axis. This PR fills the gap so the same `/min-tier-for-{features,runtimes}` name reads:

| helper                       | bare route                          | `_at` sibling                            |
|------------------------------|-------------------------------------|------------------------------------------|
| `min_tier_for_feature`       | `/min-tier?feature=`                | -- (scalar axis, `/min-tier-at` covers it) |
| `min_tier_for_runtime`       | `/min-tier?runtime=`                | -- (scalar axis, `/min-tier-at` covers it) |
| `min_tier_for_features`      | `/min-tier-for-features` **← this PR** | `/min-tier-for-features-at` (merged #3711) |
| `min_tier_for_runtimes`      | `/min-tier-for-runtimes` **← this PR** | `/min-tier-for-runtimes-at` (merged #3711) |
| `min_tier_for_channel_count` | `/min-tier?channels=`               | -- (scalar axis)                          |
| `min_tier_for_retention_window` | `/min-tier?retention_days=`      | -- (scalar axis)                          |
| `min_tier_for_node_count`    | `/min-tier?nodes=`                  | -- (scalar axis)                          |
| `min_tier_for_all`           | `/required-tier-batch`              | `/required-tier-at`                       |

## Changes

### `routes/entitlement.py`

- `GET /api/entitlement/min-tier-for-features?features=a,b,c` -- resolves the cheapest *purchasable* tier admitting every feature in the bundle. Response envelope:

  ```json
  {
    "features":            ["fleet", "sso"],
    "unknown":             ["bogus"],
    "kind":                "features",
    "count":               2,
    "required_tier":       "enterprise",
    "required_tier_label": "Enterprise",
    "required_tier_rank":  6,
    "free":                false,
    "current_tier":        "oss",
    "current_tier_rank":   0,
    "grace":               true,
    "enforced":            false
  }
  ```

- `GET /api/entitlement/min-tier-for-runtimes?runtimes=x,y,z` -- runtime-axis twin. Runtime aliases (`claude-code` -> `claude_code`) canonicalised via `canonical_runtime`.

- **400** on missing / blank / empty CSV -- matches every other `min_tier_for_*` route.
- **All-unknown IS 200** with `unknown` populated, `required_tier=null` -- distinguishes "caller asked for nothing" from "every token was a typo" so a paywall UI can render "these ids are unknown: X" instead of a null.
- **Never 5xxs**: a delegate crash yields the fallback envelope (empty items, `required_tier=null`) so a paywall surface keeps rendering.
- Body byte-identical to `/min-tier-for-features-at?tier=<p>&features=` with the three `perspective_tier` / `perspective_tier_label` / `perspective_tier_rank` envelope keys stripped -- pinned by parity tests across every `p` in `_TIER_ORDER`.

### `tests/test_entitlement_min_tier_for_plural_bare.py`

**36 tests, all green in 2.69s**:

- happy path shape + envelope keys on both axes (13 keys per body + `features` or `runtimes`)
- bare body carries **NO** `perspective_*` keys (asserted directly)
- 400 on missing / blank / empty CSV on both axes
- all-unknown IS 200 on both axes (`unknown` populated, `required_tier=null`, `count=0`, `free=false`)
- CSV dedup preserves first-seen order + runtime canonicalisation on the runtime endpoint
- mixed known + unknown bucketing
- `required_tier` byte-equals the helper's return (`ent.min_tier_for_features([...])` / `ent.min_tier_for_runtimes([...])`)
- **body byte-equals `_at` sibling body with the three perspective keys stripped, across every `p` in `_TIER_ORDER`** -- 6 parametrized perspectives × 2 axes = 12 assertions pinning the bare / `_at` cannot drift
- resolver envelope carried (`current_tier` / `current_tier_rank` / `grace` / `enforced`)
- never-5xxs on a delegate crash (monkeypatched delegate to raise)
- grace vs enforce byte-identical bodies

## Test plan

- [x] `python3 -m py_compile routes/entitlement.py tests/test_entitlement_min_tier_for_plural_bare.py` -- clean
- [x] `ruff check routes/entitlement.py tests/test_entitlement_min_tier_for_plural_bare.py` -- clean (`All checks passed!`)
- [x] `pytest tests/test_entitlement_min_tier_for_plural_bare.py -q` -> **36/36 pass** in 2.69s
- [x] Sibling regression sweep -- **107/107 pass** across `test_entitlement_min_tier_for_plural_at`, `test_entitlement_min_tier`, `test_blueprint_uniqueness`, `test_circular_import`
- [x] Blueprint URL-map uniqueness after registration -- **238 routes, all unique**; both new endpoints present.

## Local operator verification checklist

I can't touch the running daemon, `~/.openclaw`, the live snapshot, or a browser from here -- please run:

- [ ] Copy the changed file into `~/.clawmetry/lib/python3.11/site-packages/routes/entitlement.py`; drop the test file into the local checkout under `tests/`
- [ ] Clear `__pycache__` on the routes dir
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
- [ ] `curl -s 'http://localhost:8900/api/entitlement/min-tier-for-features?features=fleet,sso' | jq .` -- expect `features=["fleet","sso"]`, `kind="features"`, `required_tier` matching `/min-tier?feature=fleet` / `/min-tier?feature=sso` (max-by-rank), NO `perspective_tier` keys
- [ ] `curl -s 'http://localhost:8900/api/entitlement/min-tier-for-runtimes?runtimes=claude-code,codex' | jq .` -- expect `runtimes=["claude_code","codex"]` (canonicalised), `kind="runtimes"`
- [ ] `curl -s -o /dev/null -w '%{http_code}\n' 'http://localhost:8900/api/entitlement/min-tier-for-features'` -> `400`
- [ ] `curl -s -o /dev/null -w '%{http_code}\n' 'http://localhost:8900/api/entitlement/min-tier-for-features?features='` -> `400`
- [ ] `curl -s 'http://localhost:8900/api/entitlement/min-tier-for-features?features=bogus1,bogus2' | jq '.features,.unknown,.required_tier'` -- expect `[]`, `["bogus1","bogus2"]`, `null` (all-unknown IS 200)
- [ ] Cross-check byte-parity: strip the three `perspective_*` keys off `/min-tier-for-features-at?tier=<p>&features=` and confirm the remaining body byte-equals `/min-tier-for-features?features=` for every `p` in `_TIER_ORDER` (and same for runtimes)
- [ ] Decrypt the live cloud snapshot and hit the same endpoints against the cloud read-through path
- [ ] Browser check: any surface currently calling `/min-tier` / `/required-tier-batch` should keep rendering; nothing should call the new endpoints yet

No `__version__` bump, no tag, no `[RELEASE]` PR -- staying in DRAFT until you've cleared local + cloud verification.

## MOAT / release checklist

- Not a MOAT fast-path change (no `local_store_via_daemon` / `_ls_call` / `_DAEMON_METHODS` touched).
- Not a `[RELEASE]` PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VKo8AzMXUdT7CUMk9mC88R)_