### PR TITLE
fix(nemo): map advisor tool_execution_start/end events + surface retry fields

### DIFF
--- a/clawmetry/adapters/nemo.py
+++ b/clawmetry/adapters/nemo.py
@@ -218,6 +218,11 @@ _EVENT_TYPE_MAP: dict[str, str] = {
     "TOOL_END":    "tool.result",
     "tool_end":    "tool.result",
     "tool_result": "tool.result",
+    # Advisor/session-runner tool execution (pi-coding-agent SDK, #3720)
+    "TOOL_EXECUTION_START": "tool.call",
+    "tool_execution_start": "tool.call",
+    "TOOL_EXECUTION_END":   "tool.result",
+    "tool_execution_end":   "tool.result",
 }
 
 # Stable ordered list of unique ClawMetry event_types this adapter can emit.
@@ -621,6 +626,22 @@ class NeMoAdapter:
                 "is_error": row["data"]["is_error"],
                 "error": error,
             })
+            # Advisor retry-outcome fields (#3720): isError is an explicit bool
+            # (False is meaningful — not equivalent to absent error text), so
+            # _first's is-not-None guard correctly preserves it.
+            _is_err_explicit = _first(attrs, "isError", "is_error")
+            if _is_err_explicit is not None:
+                inner["is_error"] = bool(_is_err_explicit)
+                row["data"]["is_error"] = inner["is_error"]
+            _outcome = _first(attrs, "retryOutcome", "retry_outcome")
+            if _outcome:
+                inner["retry_outcome"] = str(_outcome)
+            _attempt = _first(attrs, "attemptNumber", "attempt_number")
+            if _attempt is not None:
+                try:
+                    inner["attempt_number"] = int(_attempt)
+                except (TypeError, ValueError):
+                    pass
 
         # Stamp the discriminator the dashboard's read path looks for
         # (routes/sessions.py::_is_openclaw_event), and nest the

--- a/tests/test_nemo_adapter.py
+++ b/tests/test_nemo_adapter.py
@@ -394,6 +394,40 @@ def test_on_event_swallows_ingest_errors(adapter, monkeypatch, caplog):
     assert any("local_store.ingest raised" in r.message for r in caplog.records)
 
 
+def test_advisor_tool_execution_start_mapped(adapter):
+    """TOOL_EXECUTION_START / tool_execution_start map to tool.call (#3720)."""
+    for raw_type in ("TOOL_EXECUTION_START", "tool_execution_start"):
+        row = adapter.map_event({
+            "event_type": raw_type,
+            "trace_id":   "adv-session-1",
+            "attributes": {"tool_name": "edit_file"},
+        })
+        assert row is not None, f"{raw_type!r} must not be dropped"
+        assert row["event_type"] == "tool.call"
+        assert row["data"]["data"]["name"] == "edit_file"
+
+
+def test_advisor_tool_execution_end_retry_outcome(adapter):
+    """TOOL_EXECUTION_END surfaces retry fields; isError=False must not be dropped (#3720)."""
+    for raw_type in ("TOOL_EXECUTION_END", "tool_execution_end"):
+        row = adapter.map_event({
+            "event_type": raw_type,
+            "trace_id":   "adv-session-2",
+            "attributes": {
+                "tool_name":     "bash",
+                "retryOutcome":  "fail-then-success",
+                "attemptNumber": 2,
+                "isError":       False,
+            },
+        })
+        assert row is not None, f"{raw_type!r} must not be dropped"
+        assert row["event_type"] == "tool.result"
+        inner = row["data"]["data"]
+        assert inner["retry_outcome"] == "fail-then-success"
+        assert inner["attempt_number"] == 2
+        assert inner["is_error"] is False  # explicit False preserved, not bool(error)
+
+
 def test_mapped_event_types_constant():
     """The public ``MAPPED_EVENT_TYPES`` tuple matches what the mapper produces."""
     from clawmetry.adapters.nemo import MAPPED_EVENT_TYPES, _EVENT_TYPE_MAP


### PR DESCRIPTION
Closes #3720

## What

The pi-coding-agent SDK's advisor/session-runner emits `TOOL_EXECUTION_START` / `tool_execution_start` and `TOOL_EXECUTION_END` / `tool_execution_end` event types. These were absent from `_EVENT_TYPE_MAP`, so `NeMoAdapter.map_event()` dropped them with a warning — making every advisor tool call invisible in the Brain feed.

Advisor `tool.result` events also carry retry-outcome metadata (`retryOutcome`, `attemptNumber`, `isError`) that was never extracted.

## Changes

- **`clawmetry/adapters/nemo.py`** — 4 new entries in `_EVENT_TYPE_MAP` (SCREAMING_SNAKE and lowercase), plus retry-outcome extraction in the `tool.result` enrichment block (`retry_outcome`, `attempt_number`, `is_error`). `isError` uses `_first`'s is-not-None guard so `isError=False` is not silently dropped. ~12 LOC.
- **`tests/test_nemo_adapter.py`** — 2 new tests: `test_advisor_tool_execution_start_mapped` (both case forms → `tool.call`) and `test_advisor_tool_execution_end_retry_outcome` (retry fields preserved, `is_error=False` preserved). ~30 LOC.

## Test plan

- `python -m pytest tests/test_nemo_adapter.py -q` — 30/30 pass (was 28/28 before)
- Step 3 (advisor prose event type) stays open in #3720 pending SDK event-name confirmation

---
_Generated by [Claude Code](https://claude.ai/code/session_01LvTo8f34Z2wc5wAcfH4jpN)_