### PR TITLE
test: C7 auto-quarantine -- detect and quarantine flaky E2E tests within 24h

### DIFF
--- a/.github/workflows/auto-quarantine.yml
+++ b/.github/workflows/auto-quarantine.yml
@@ -1,0 +1,117 @@
+name: Auto-quarantine (C7)
+
+# Runs daily at 04:15 UTC (1h after quarantine-sweep.yml at 02:23 UTC).
+# Detects tests that failed in an OSS Golden Path run then passed on a
+# re-run (= flaky). Opens a PR to add them to tests/quarantine.txt.
+# Tracking: vivekchand/clawmetry#3730 (C7)
+
+on:
+  schedule:
+    - cron: "15 4 * * *"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Dry run (print but do not write quarantine.txt)"
+        required: false
+        default: "true"
+        type: boolean
+      lookback:
+        description: "Number of recent workflow runs to scan"
+        required: false
+        default: "30"
+        type: string
+
+concurrency:
+  group: auto-quarantine
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+  pull-requests: write
+  actions: read
+
+jobs:
+  detect-and-quarantine:
+    name: Detect flaky tests and quarantine within 24h
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Detect flaky tests
+        id: detect
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO_OWNER: vivekchand
+          REPO_NAME: clawmetry
+        run: |
+          ARGS=""
+          if [ "${{ inputs.dry_run }}" = "true" ] && [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            ARGS="--dry-run"
+          fi
+          if [ -n "${{ inputs.lookback }}" ]; then
+            ARGS="$ARGS --lookback ${{ inputs.lookback }}"
+          fi
+          python3 scripts/auto_quarantine.py $ARGS
+          echo "exit_code=$?" >> "$GITHUB_OUTPUT"
+        continue-on-error: true
+
+      - name: Open PR for newly quarantined tests
+        if: steps.detect.outputs.exit_code == '2'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config user.email "actions@github.com"
+          git config user.name "Auto-Quarantine Bot"
+          BRANCH="auto-quarantine/$(date +%Y%m%d-%H%M%S)"
+          git checkout -b "$BRANCH"
+          git add tests/quarantine.txt
+          git commit -m "test: auto-quarantine flaky E2E tests [C7]
+
+          Flaky tests detected by auto_quarantine.py: failed in an OSS
+          Golden Path run then passed on re-run. Added to quarantine.txt
+          so they are excluded from the main PR gate and swept daily.
+
+          Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+          git push -u origin "$BRANCH"
+          gh pr create \
+            --title "test: auto-quarantine flaky E2E tests (C7)" \
+            --body "$(cat <<'EOF'
+          ## Summary
+
+          Flaky tests detected by the daily auto-quarantine sweep (C7).
+          These tests failed in a recent OSS Golden Path run then passed
+          on a re-run of the same commit -- a clear flakiness signal.
+
+          Added to \`tests/quarantine.txt\` so they are:
+          - Excluded from the per-PR gate (no more PR blocks from flakiness)
+          - Swept daily by \`quarantine-sweep.yml\` (alerts if they go from flaky to broken)
+
+          ## Test plan
+
+          - [ ] Review the quarantined test list in \`tests/quarantine.txt\`
+          - [ ] Verify the root cause of each test's flakiness is tracked separately
+          - [ ] Merge this PR to restore PR gate reliability
+
+          Tracking: vivekchand/clawmetry#3730 (C7)
+          EOF
+          )" \
+            --label "e2e,testing" \
+            --base main \
+            --head "$BRANCH"
+
+      - name: Summary
+        if: always()
+        run: |
+          code="${{ steps.detect.outputs.exit_code }}"
+          case "$code" in
+            0) echo "No new flaky tests detected." ;;
+            2) echo "New flaky tests quarantined -- PR opened." ;;
+            *) echo "Script error (exit $code) -- check logs above." ;;
+          esac

--- a/.github/workflows/oss-golden-path.yml
+++ b/.github/workflows/oss-golden-path.yml
@@ -185,7 +185,7 @@ jobs:
         run: |
           /tmp/oss-golden/bin/python -m pytest \
             tests/test_e2e_oss_golden_path.py \
-            -v --tb=short
+            -v --tb=short --junitxml=/tmp/junit-c1.xml
 
       # Restart the dashboard so C5 starts with a clean server that has no
       # accumulated SSE streams or WebSocket reconnect loops from C1. Each
@@ -222,7 +222,7 @@ jobs:
         run: |
           /tmp/oss-golden/bin/python -m pytest \
             tests/test_e2e_oss_all_tabs.py \
-            -v --tb=short
+            -v --tb=short --junitxml=/tmp/junit-c5.xml
 
       - name: Dashboard and gateway logs on failure
         if: failure()
@@ -231,6 +231,15 @@ jobs:
           tail -150 /tmp/oss-golden-dashboard.log || true
           echo "==== openclaw gateway log ===="
           tail -100 /tmp/openclaw-logs/gateway.log || true
+
+      - name: Upload JUnit test reports
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: junit-c1c5-${{ github.run_id }}
+          path: /tmp/junit-*.xml
+          if-no-files-found: warn
+          retention-days: 7
 
       - name: Upload logs on failure
         if: failure()

--- a/scripts/auto_quarantine.py
+++ b/scripts/auto_quarantine.py
@@ -1,0 +1,432 @@
+#!/usr/bin/env python3
+"""Detect flaky E2E tests and append them to tests/quarantine.txt.
+
+A test is classified as flaky when:
+  - It failed in a recent OSS Golden Path run (junit-c1c5-<run_id> artifact), AND
+  - There exists a LATER run for the SAME head commit (SHA) that PASSED.
+
+Failed-then-passed on the same commit == flaky; add to quarantine.txt so
+the per-PR gate is not blocked by intermittent failures.
+
+Usage
+-----
+  GITHUB_TOKEN=ghp_xxx python3 scripts/auto_quarantine.py
+  python3 scripts/auto_quarantine.py --dry-run
+  python3 scripts/auto_quarantine.py --lookback 50
+
+Exit codes
+----------
+  0  No new flaky tests found (or --dry-run mode)
+  1  Script error (missing token, API failure, etc.)
+  2  New flaky tests written to tests/quarantine.txt (caller should open a PR)
+
+Tracking: vivekchand/clawmetry#3730 (C7)
+"""
+from __future__ import annotations
+
+import argparse
+import datetime
+import io
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+import xml.etree.ElementTree as ET
+import zipfile
+
+OWNER = os.environ.get("REPO_OWNER", "vivekchand")
+REPO = os.environ.get("REPO_NAME", "clawmetry")
+WORKFLOW_FILE = "oss-golden-path.yml"
+
+
+# ---------------------------------------------------------------------------
+# GitHub API helpers
+# ---------------------------------------------------------------------------
+
+
+class _CaptureRedirect(urllib.request.BaseHandler):
+    """Capture redirect responses instead of following them.
+
+    GitHub's artifact download endpoint issues a 302 redirect to a presigned
+    S3 URL. We must NOT forward our Authorization header to S3 (S3 rejects
+    duplicate auth), so we capture the Location and re-fetch without it.
+    """
+
+    def http_error_301(self, req, fp, code, msg, headers):  # noqa: PLR0913
+        raise urllib.error.HTTPError(req.full_url, code, msg, headers, fp)
+
+    def http_error_302(self, req, fp, code, msg, headers):  # noqa: PLR0913
+        raise urllib.error.HTTPError(req.full_url, code, msg, headers, fp)
+
+    def http_error_303(self, req, fp, code, msg, headers):  # noqa: PLR0913
+        raise urllib.error.HTTPError(req.full_url, code, msg, headers, fp)
+
+    def http_error_307(self, req, fp, code, msg, headers):  # noqa: PLR0913
+        raise urllib.error.HTTPError(req.full_url, code, msg, headers, fp)
+
+    def http_error_308(self, req, fp, code, msg, headers):  # noqa: PLR0913
+        raise urllib.error.HTTPError(req.full_url, code, msg, headers, fp)
+
+
+def _api(path: str, *, token: str) -> dict | list:
+    """GET a GitHub API endpoint and return parsed JSON."""
+    url = f"https://api.github.com{path}"
+    headers = {
+        "Authorization": f"token {token}",
+        "Accept": "application/vnd.github.v3+json",
+        "User-Agent": "clawmetry-auto-quarantine/1.0",
+    }
+    req = urllib.request.Request(url, headers=headers)
+    try:
+        with urllib.request.urlopen(req) as resp:  # noqa: S310
+            return json.loads(resp.read())
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode(errors="replace")
+        raise RuntimeError(f"GitHub GET {path} => {exc.code}: {body}") from exc
+
+
+def _download_zip(artifact_id: int, *, token: str) -> bytes:
+    """Download a GitHub artifact ZIP file, following the S3 redirect."""
+    url = (
+        f"https://api.github.com/repos/{OWNER}/{REPO}"
+        f"/actions/artifacts/{artifact_id}/zip"
+    )
+    headers = {
+        "Authorization": f"token {token}",
+        "Accept": "application/vnd.github.v3+json",
+        "User-Agent": "clawmetry-auto-quarantine/1.0",
+    }
+    req = urllib.request.Request(url, headers=headers)
+    opener = urllib.request.build_opener(_CaptureRedirect())
+    try:
+        with opener.open(req) as resp:  # noqa: S310
+            return resp.read()  # unlikely -- GitHub always redirects
+    except urllib.error.HTTPError as exc:
+        if exc.code in (301, 302, 303, 307, 308):
+            location = exc.headers.get("Location", "")
+            if not location:
+                raise RuntimeError(
+                    f"Redirect from artifacts/{artifact_id}/zip had no Location header"
+                ) from exc
+            # S3 presigned URL -- no Authorization header needed or wanted
+            with urllib.request.urlopen(location) as s3_resp:  # noqa: S310
+                return s3_resp.read()
+        body = exc.read().decode(errors="replace")
+        raise RuntimeError(
+            f"Download artifact {artifact_id} => {exc.code}: {body}"
+        ) from exc
+
+
+# ---------------------------------------------------------------------------
+# JUnit XML parsing
+# ---------------------------------------------------------------------------
+
+
+def _classname_to_file_and_class(classname: str) -> tuple[str, str | None]:
+    """Split a JUnit classname into (file_path, class_name_or_None).
+
+    pytest generates classname like:
+      "tests.test_e2e_oss_golden_path"            (module-level function)
+      "tests.test_e2e_oss_golden_path.TestClass"  (class method)
+
+    Returns:
+      file_path: "tests/test_e2e_oss_golden_path.py"
+      class_name: "TestClass" or None
+    """
+    parts = classname.split(".")
+    # A trailing PascalCase component is a class name, not a module segment
+    if parts and parts[-1] and parts[-1][0].isupper():
+        class_name: str | None = parts[-1]
+        module_parts = parts[:-1]
+    else:
+        class_name = None
+        module_parts = parts
+    file_path = "/".join(module_parts) + ".py"
+    return file_path, class_name
+
+
+def _parse_junit_xml(xml_bytes: bytes) -> set[str]:
+    """Return pytest node IDs of all FAILED/ERRORED test cases in a JUnit XML blob."""
+    failed: set[str] = set()
+    try:
+        root = ET.fromstring(xml_bytes)  # noqa: S314
+    except ET.ParseError as exc:
+        print(f"  WARN: could not parse JUnit XML: {exc}", file=sys.stderr)
+        return failed
+
+    # Support both <testsuite> root and <testsuites> wrapper
+    suites = (
+        [root]
+        if root.tag == "testsuite"
+        else root.findall("testsuite")
+    )
+    for suite in suites:
+        for tc in suite.findall("testcase"):
+            if tc.find("failure") is None and tc.find("error") is None:
+                continue  # test passed or was skipped
+            classname = tc.get("classname", "")
+            name = tc.get("name", "")
+            file_path, class_name = _classname_to_file_and_class(classname)
+            if class_name:
+                node_id = f"{file_path}::{class_name}::{name}"
+            else:
+                node_id = f"{file_path}::{name}"
+            failed.add(node_id)
+    return failed
+
+
+def _extract_junit_from_zip(zip_bytes: bytes) -> set[str]:
+    """Extract all JUnit XML files from a zip blob and return all failing test IDs."""
+    failed: set[str] = set()
+    try:
+        with zipfile.ZipFile(io.BytesIO(zip_bytes)) as zf:
+            xml_names = [n for n in zf.namelist() if n.endswith(".xml")]
+            if not xml_names:
+                print("  WARN: artifact ZIP contains no XML files", file=sys.stderr)
+                return failed
+            for xml_name in xml_names:
+                xml_data = zf.read(xml_name)
+                failed |= _parse_junit_xml(xml_data)
+    except zipfile.BadZipFile as exc:
+        print(f"  WARN: artifact is not a valid ZIP: {exc}", file=sys.stderr)
+    return failed
+
+
+# ---------------------------------------------------------------------------
+# Core flakiness detection
+# ---------------------------------------------------------------------------
+
+
+def _get_workflow_id(token: str) -> int:
+    """Return the numeric workflow ID for WORKFLOW_FILE."""
+    data = _api(f"/repos/{OWNER}/{REPO}/actions/workflows", token=token)
+    for wf in data.get("workflows", []):
+        if WORKFLOW_FILE in wf.get("path", ""):
+            return int(wf["id"])
+    raise RuntimeError(
+        f"Workflow {WORKFLOW_FILE!r} not found in {OWNER}/{REPO}. "
+        "Check that the workflow file exists and REPO_OWNER/REPO_NAME are correct."
+    )
+
+
+def _get_runs(workflow_id: int, lookback: int, token: str) -> list[dict]:
+    """Return the N most recent completed workflow runs, newest first."""
+    data = _api(
+        f"/repos/{OWNER}/{REPO}/actions/workflows/{workflow_id}/runs"
+        f"?per_page={lookback}&status=completed",
+        token=token,
+    )
+    return data.get("workflow_runs", [])
+
+
+def _find_artifact_id(run_id: int, token: str) -> int | None:
+    """Return the artifact ID for the junit-c1c5-<run_id> artifact, or None."""
+    data = _api(
+        f"/repos/{OWNER}/{REPO}/actions/runs/{run_id}/artifacts",
+        token=token,
+    )
+    target = f"junit-c1c5-{run_id}"
+    for art in data.get("artifacts", []):
+        if art.get("name", "") == target:
+            return int(art["id"])
+    return None
+
+
+def detect_flaky_tests(lookback: int, token: str) -> set[str]:
+    """Return the set of test node IDs that appear to be flaky."""
+    print(f"Scanning {lookback} recent runs of {WORKFLOW_FILE} in {OWNER}/{REPO} ...")
+
+    workflow_id = _get_workflow_id(token)
+    runs = _get_runs(workflow_id, lookback, token)
+    print(f"  Fetched {len(runs)} completed run(s).")
+
+    if not runs:
+        print("  No completed runs found.")
+        return set()
+
+    # Index: sha -> list of (run_number, conclusion)
+    sha_runs: dict[str, list[tuple[int, str]]] = {}
+    for run in runs:
+        sha = run.get("head_sha", "")
+        num = run.get("run_number", 0)
+        conclusion = run.get("conclusion") or ""
+        if sha:
+            sha_runs.setdefault(sha, []).append((num, conclusion))
+
+    # Sort each SHA's runs by run_number ascending so "later" means higher number
+    for sha in sha_runs:
+        sha_runs[sha].sort(key=lambda t: t[0])
+
+    flaky_tests: set[str] = set()
+
+    failed_runs = [r for r in runs if r.get("conclusion") == "failure"]
+    print(f"  Found {len(failed_runs)} failed run(s) to inspect.")
+
+    for run in failed_runs:
+        run_id = run["id"]
+        run_num = run.get("run_number", 0)
+        sha = run.get("head_sha", "")
+
+        # Is there a later run for the same SHA that passed?
+        later_passed = any(
+            num > run_num and conc == "success"
+            for num, conc in sha_runs.get(sha, [])
+        )
+        if not later_passed:
+            print(
+                f"  Run #{run_num} (id={run_id}, sha={sha[:8]}): "
+                "failed, no later pass -- not classified as flaky"
+            )
+            continue
+
+        print(
+            f"  Run #{run_num} (id={run_id}, sha={sha[:8]}): "
+            "failed then passed on re-run -> checking JUnit XML"
+        )
+
+        artifact_id = _find_artifact_id(run_id, token)
+        if artifact_id is None:
+            print(
+                f"    No junit-c1c5-{run_id} artifact found "
+                "(run may predate JUnit XML upload step)"
+            )
+            continue
+
+        try:
+            zip_bytes = _download_zip(artifact_id, token=token)
+        except RuntimeError as exc:
+            print(f"    WARN: could not download artifact {artifact_id}: {exc}")
+            continue
+
+        failing = _extract_junit_from_zip(zip_bytes)
+        if failing:
+            print(f"    Flaky tests found ({len(failing)}): {sorted(failing)}")
+            flaky_tests |= failing
+        else:
+            print("    No failing tests in JUnit XML (or no XML in artifact)")
+
+    return flaky_tests
+
+
+# ---------------------------------------------------------------------------
+# quarantine.txt helpers
+# ---------------------------------------------------------------------------
+
+
+def _quarantine_path() -> str:
+    """Return the absolute path to tests/quarantine.txt."""
+    here = os.path.dirname(os.path.abspath(__file__))
+    return os.path.normpath(os.path.join(here, "..", "tests", "quarantine.txt"))
+
+
+def _read_quarantine(path: str) -> tuple[str, set[str]]:
+    """Return (raw_content, set_of_test_ids) from quarantine.txt."""
+    try:
+        with open(path, encoding="utf-8") as fh:
+            content = fh.read()
+    except FileNotFoundError:
+        return "", set()
+
+    existing: set[str] = set()
+    for line in content.splitlines():
+        stripped = line.strip()
+        if stripped and not stripped.startswith("#"):
+            existing.add(stripped)
+    return content, existing
+
+
+def _write_quarantine(path: str, existing_content: str, new_tests: set[str]) -> None:
+    """Append new_tests to quarantine.txt with an auto-quarantine comment."""
+    today = datetime.date.today().isoformat()
+    lines_to_add = [
+        f"# Auto-quarantined by auto_quarantine.py on {today}: "
+        "failed then passed on re-run",
+    ]
+    for tid in sorted(new_tests):
+        lines_to_add.append(tid)
+
+    # Ensure existing content ends with exactly one newline before appending
+    content = existing_content.rstrip("\n") + "\n"
+    content += "\n".join(lines_to_add) + "\n"
+
+    with open(path, "w", encoding="utf-8") as fh:
+        fh.write(content)
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Detect flaky E2E tests (failed then passed on re-run) and "
+            "append them to tests/quarantine.txt."
+        )
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print what would be quarantined but do not write quarantine.txt",
+    )
+    parser.add_argument(
+        "--lookback",
+        type=int,
+        default=30,
+        metavar="N",
+        help="Number of recent workflow runs to scan (default: 30)",
+    )
+    args = parser.parse_args()
+
+    token = os.environ.get("GITHUB_TOKEN", "").strip()
+    if not token:
+        print(
+            "Error: GITHUB_TOKEN is not set.\n"
+            "Set it before running:\n"
+            "  export GITHUB_TOKEN=ghp_xxx\n"
+            "  python3 scripts/auto_quarantine.py --dry-run",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    try:
+        flaky = detect_flaky_tests(args.lookback, token)
+    except RuntimeError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    quarantine_file = _quarantine_path()
+    existing_content, existing_ids = _read_quarantine(quarantine_file)
+    new_flaky = flaky - existing_ids
+
+    if not new_flaky:
+        msg = (
+            f"Scanning {args.lookback} runs... 0 new flaky tests found"
+            + (" (dry run)." if args.dry_run else ". quarantine.txt unchanged.")
+        )
+        print(msg)
+        sys.exit(0)
+
+    print(f"\n{len(new_flaky)} new flaky test(s) detected:")
+    for tid in sorted(new_flaky):
+        print(f"  {tid}")
+
+    if args.dry_run:
+        print(
+            f"\n--dry-run: would add {len(new_flaky)} test(s) to {quarantine_file}"
+        )
+        print(
+            f"Scanning {args.lookback} runs... "
+            f"{len(new_flaky)} new flaky tests found (dry run)."
+        )
+        sys.exit(0)
+
+    _write_quarantine(quarantine_file, existing_content, new_flaky)
+    print(f"\nWrote {len(new_flaky)} new test(s) to {quarantine_file}")
+    sys.exit(2)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Closes the C7 gap: flaky failures must be quarantined within 24h, not silently retried forever.

Previously `tests/quarantine.txt` and `quarantine-sweep.yml` existed but there was NO automated pipeline to DETECT flaky tests and add them to the file. Developers could silently re-run failing CI and merge without ever quarantining the flaky test. This PR closes that loop with three targeted changes:

- **Part 1 (`oss-golden-path.yml`)**: adds `--junitxml=/tmp/junit-c1.xml` and `--junitxml=/tmp/junit-c5.xml` to the C1 and C5 pytest steps, then uploads a `junit-c1c5-<run_id>` artifact (on `always()`) so failed run data is available for analysis.
- **Part 2 (`scripts/auto_quarantine.py`)**: daily script that scans the N most recent OSS Golden Path runs, downloads JUnit XML from failed runs, and classifies a test as flaky when a later run for the SAME head SHA passed. Writes new test IDs to `tests/quarantine.txt` and exits 2 so the caller can open a PR. Supports `--dry-run` and `--lookback N`. Handles missing `GITHUB_TOKEN` with a clear error (exit 1). Follows the urllib + GITHUB_TOKEN style of `scripts/apply_required_status_checks.py`.
- **Part 3 (`.github/workflows/auto-quarantine.yml`)**: daily cron at 04:15 UTC (1h after `quarantine-sweep.yml`) that runs `auto_quarantine.py` and opens a PR when new flaky tests are detected. Supports `workflow_dispatch` with `dry_run` and `lookback` inputs.

## Test plan

- [ ] Run `GITHUB_TOKEN=<token> python3 scripts/auto_quarantine.py --dry-run` locally -- should exit 0 and print "Scanning 30 runs... N new flaky tests found (dry run)."
- [ ] Run without `GITHUB_TOKEN` -- should print a clear error and exit 1
- [ ] Trigger `auto-quarantine` workflow via Actions > workflow_dispatch with `dry_run=true` -- should exit 0 with no PR opened
- [ ] Verify `oss-golden-path.yml` still passes (JUnit XML is written whether tests pass or fail; upload step has `if-no-files-found: warn` so it never hard-fails)
- [ ] After a real flaky failure occurs: verify `auto-quarantine` opens a PR adding the test to `tests/quarantine.txt` within 24h

Tracking: vivekchand/clawmetry#3730 (C7)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FXMGKkWVgLuc2c4dremcaq)_