### PR TITLE
feat(entitlement): /api/entitlement/lock-reasons-batch bare plural URL alias

### DIFF
--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -6275,11 +6275,26 @@ def api_entitlement_affordable_tiers_at_batch():
         )
 
 
+@bp_entitlement.route(
+    "/api/entitlement/lock-reasons-batch",
+    endpoint="api_entitlement_lock_reasons_batch",
+)
 @bp_entitlement.route("/api/entitlement/lock-reason-batch")
 def api_entitlement_lock_reason_batch():
     """``GET /api/entitlement/lock-reason-batch?features=a,b,c&runtimes=x,y
     &channels=N&retention_days=K&nodes=M`` -- per-item plural sibling of
     ``/api/entitlement/lock-reason``.
+
+    Also reachable at ``/api/entitlement/lock-reasons-batch`` (bare plural
+    URL). Both URLs dispatch to the SAME view and return byte-identical
+    JSON. The alias exists so callers can address this endpoint under the
+    plural URL naming already used by its ``_at`` sibling
+    ``/api/entitlement/lock-reasons-at-batch`` -- same bare / ``_at``
+    symmetry that ``/min-tier-for-features`` <-> ``/min-tier-for-features-at``
+    already exposes. Registering the alias with a distinct Flask endpoint
+    name (``api_entitlement_lock_reasons_batch``) keeps ``url_for`` reverse
+    lookups unambiguous while sharing one implementation. Pinned by parity
+    tests in ``tests/test_entitlement_lock_reasons_batch_alias.py``.
 
     Where ``/required-tier-batch`` aggregates the most-constraining axis into
     one tier answer, this preserves the per-item detail so a Settings or

--- a/tests/test_entitlement_lock_reasons_batch_alias.py
+++ b/tests/test_entitlement_lock_reasons_batch_alias.py
@@ -1,0 +1,216 @@
+"""Tests pinning the ``/api/entitlement/lock-reasons-batch`` bare plural URL.
+
+``/api/entitlement/lock-reason-batch`` (singular URL) has been the per-item
+plural sibling of ``/lock-reason`` since it landed; it delegates to
+:func:`clawmetry.entitlements.lock_reasons_batch` (plural helper) and returns
+a five-axis body of rows. Its ``_at`` sibling was subsequently registered as
+``/api/entitlement/lock-reasons-at-batch`` under the plural URL naming --
+which left the bare URL out of step with the ``_at`` URL.
+
+This alias registers ``/api/entitlement/lock-reasons-batch`` as a second
+route on the same view function so the bare / ``_at`` URLs read symmetrically
+(``/min-tier-for-features`` <-> ``/min-tier-for-features-at``,
+``/lock-reasons-batch`` <-> ``/lock-reasons-at-batch``). Both URLs dispatch
+to the same code path and MUST return byte-identical JSON -- the tests below
+pin that contract so the alias cannot silently drift.
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# ── URL-map registration ──────────────────────────────────────────────────
+
+
+def test_alias_url_is_registered(client):
+    """Both URLs must be reachable and dispatch 200 on a happy path."""
+    bare = client.get("/api/entitlement/lock-reasons-batch?features=fleet")
+    canon = client.get("/api/entitlement/lock-reason-batch?features=fleet")
+    assert bare.status_code == 200
+    assert canon.status_code == 200
+
+
+def test_alias_endpoint_name_is_distinct():
+    """The alias must register under its own Flask endpoint name so
+    ``url_for`` reverse lookups stay unambiguous. Sibling ``_at`` URL is
+    already ``api_entitlement_lock_reasons_at_batch``; the bare alias
+    mirrors that naming."""
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    rules = {r.rule: r.endpoint for r in app.url_map.iter_rules()}
+    assert (
+        rules["/api/entitlement/lock-reasons-batch"]
+        == "entitlement.api_entitlement_lock_reasons_batch"
+    )
+    assert (
+        rules["/api/entitlement/lock-reason-batch"]
+        == "entitlement.api_entitlement_lock_reason_batch"
+    )
+
+
+# ── byte-parity across the whole surface ─────────────────────────────────
+
+
+def _bodies_match(client, qs: str) -> tuple[dict, dict]:
+    bare = client.get(f"/api/entitlement/lock-reasons-batch{qs}")
+    canon = client.get(f"/api/entitlement/lock-reason-batch{qs}")
+    assert bare.status_code == canon.status_code
+    return bare.get_json(), canon.get_json()
+
+
+def test_parity_features_only(client):
+    b, c = _bodies_match(client, "?features=fleet,sso")
+    assert b == c
+
+
+def test_parity_runtimes_only(client):
+    b, c = _bodies_match(client, "?runtimes=claude_code,openclaw")
+    assert b == c
+
+
+def test_parity_all_five_axes_grace(client):
+    b, c = _bodies_match(
+        client,
+        "?features=fleet,sso&runtimes=claude_code"
+        "&channels=5&retention_days=30&nodes=3",
+    )
+    assert b == c
+
+
+def test_parity_all_five_axes_enforce(client, ent, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    b, c = _bodies_match(
+        client,
+        "?features=fleet,sso&runtimes=claude_code"
+        "&channels=5&retention_days=30&nodes=3",
+    )
+    assert b == c
+    # Sanity: the shared body carries the enforce metadata.
+    assert b["enforced"] is True
+    assert b["grace"] is False
+
+
+def test_parity_unknown_ids_dont_500(client, ent, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    b, c = _bodies_match(
+        client, "?features=fleet,not_a_real_feature"
+    )
+    assert b == c
+    rows = {r["key"]: r for r in b["features"]}
+    assert rows["not_a_real_feature"]["locked"] is False
+    assert rows["not_a_real_feature"]["required_tier"] is None
+
+
+def test_parity_blank_capacity_treated_as_unsupplied(client):
+    """Blank capacities on both URLs must 400 with the same body."""
+    b = client.get(
+        "/api/entitlement/lock-reasons-batch"
+        "?channels=&retention_days=&nodes="
+    )
+    c = client.get(
+        "/api/entitlement/lock-reason-batch"
+        "?channels=&retention_days=&nodes="
+    )
+    assert b.status_code == 400
+    assert c.status_code == 400
+    assert b.get_json() == c.get_json()
+
+
+def test_parity_no_input_400(client):
+    b = client.get("/api/entitlement/lock-reasons-batch")
+    c = client.get("/api/entitlement/lock-reason-batch")
+    assert b.status_code == 400
+    assert c.status_code == 400
+    assert b.get_json() == c.get_json()
+
+
+def test_parity_non_int_capacity_silently_skipped(client):
+    b, c = _bodies_match(client, "?features=fleet&channels=abc")
+    assert b == c
+    assert b["channels"] is None
+
+
+def test_parity_capacity_alone_is_enough_input(client):
+    b, c = _bodies_match(client, "?channels=5")
+    assert b == c
+    b, c = _bodies_match(client, "?retention_days=30")
+    assert b == c
+    b, c = _bodies_match(client, "?nodes=3")
+    assert b == c
+
+
+def test_parity_carries_current_tier_metadata(client, ent):
+    b, c = _bodies_match(client, "?features=fleet")
+    assert b == c
+    for key in ("current_tier", "current_tier_rank", "grace", "enforced"):
+        assert key in b
+
+
+def test_parity_resolver_failure_returns_grace_shape(client, monkeypatch):
+    """A synthetic resolver crash must yield the SAME grace-shape body on
+    both URLs (never a 5xx)."""
+    import clawmetry.entitlements as _ent
+
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(_ent, "lock_reasons_batch", boom)
+    b, c = _bodies_match(client, "?features=fleet")
+    assert b == c
+    assert b["features"] == []
+    assert b["grace"] is True
+    assert b["enforced"] is False
+
+
+def test_parity_body_shape_matches_lock_reasons_at_batch_without_perspective(
+    client, ent
+):
+    """The bare body must match ``/lock-reasons-at-batch`` with the three
+    perspective_* keys stripped -- same relationship the sibling bare / _at
+    pairs already establish. Pins that adding the alias did not accidentally
+    drift the shape."""
+    at = client.get(
+        "/api/entitlement/lock-reasons-at-batch?tier=cloud_pro&features=fleet"
+    ).get_json()
+    bare = client.get(
+        "/api/entitlement/lock-reasons-batch?features=fleet"
+    ).get_json()
+    stripped = {
+        k: v
+        for k, v in at.items()
+        if k
+        not in {
+            "perspective_tier",
+            "perspective_tier_rank",
+            "perspective_tier_label",
+        }
+    }
+    assert bare == stripped


### PR DESCRIPTION
## Summary

- Registers `/api/entitlement/lock-reasons-batch` (bare, plural URL) as a second Flask route on the existing `api_entitlement_lock_reason_batch` view so callers can address the per-item plural batch endpoint under the plural URL naming already used by its `_at` sibling `/api/entitlement/lock-reasons-at-batch`.
- Both URLs dispatch to the SAME view and return byte-identical JSON — the alias is a naming symmetry, not new behaviour.
- Grace-mode only change. No `__version__` bump, no `[RELEASE]` PR, no gate enforced.

## Why

The per-item batch surface across the entitlement API today looks like this:

| URL                           | family | plural URL? |
|-------------------------------|--------|-------------|
| `/lock-reason-batch`          | bare   | ❌ singular |
| `/lock-reasons-at-batch`      | `_at`  | ✅ plural   |
| `/lock-reasons-batch`         | bare   | **← this PR** (plural) |

The bare / `_at` pair is meant to be a URL-naming twin (a caller drops `-at` for the live surface, adds `?tier=<p>` for the perspective surface). Today the pair is `/lock-reason-batch` ↔ `/lock-reasons-at-batch` — the bare URL is singular, the `_at` URL is plural. Anyone walking the pricing-matrix / paywall matrix off `/lock-reasons-at-batch?tier=<p>&features=...` and stripping the `-at` for the live view has to special-case this one URL to drop from plural to singular.

The docstring on the existing view even references `/lock-reasons-batch` (plural) as if it existed:

```py
# routes/entitlement.py:16246
``/lock-reasons-batch`` pairs with ``/lock-reason``: scalar ->
```

This PR registers the plural URL as an alias so the docs and the URL space finally agree, mirroring the pattern set by `/min-tier-for-features` ↔ `/min-tier-for-features-at` (bare / `_at` URL-naming twins on the plural grant-axis family).

## Changes

### `routes/entitlement.py`

Stacks a second `@bp_entitlement.route` above the existing decorator on `api_entitlement_lock_reason_batch`:

```py
@bp_entitlement.route(
    "/api/entitlement/lock-reasons-batch",
    endpoint="api_entitlement_lock_reasons_batch",
)
@bp_entitlement.route("/api/entitlement/lock-reason-batch")
def api_entitlement_lock_reason_batch():
    ...
```

The alias registers under a distinct Flask endpoint name (`api_entitlement_lock_reasons_batch`) so `url_for` reverse lookups stay unambiguous while both URLs share one implementation. No changes to the underlying helper (`clawmetry.entitlements.lock_reasons_batch`), no changes to the response body, no changes to the four sibling endpoints on the same view.

### `tests/test_entitlement_lock_reasons_batch_alias.py`

**14 tests, all green in 1.69s**:

- URL-map registration — both rules present, alias reachable on 200, alias has its own distinct Flask endpoint name (`api_entitlement_lock_reasons_batch`).
- Byte-parity on every axis combination (features / runtimes / channels / retention_days / nodes / mixed all-five-axes).
- Grace vs enforce parity — both URLs report the same locks under `CLAWMETRY_ENFORCE=1`.
- Unknown-id never-500 posture parity (typo in `features=` yields a grace-shape row on both URLs, no 500).
- 400 parity — missing / blank input → same status + same body on both URLs.
- Non-int-capacity silently-skipped parity — `?channels=abc` yields `channels: null` on both URLs.
- Capacity-alone-is-enough-input parity — `?channels=5` / `?retention_days=30` / `?nodes=3` all 200 on both URLs.
- Current-tier-metadata parity — every response carries `current_tier` / `current_tier_rank` / `grace` / `enforced`.
- Resolver-failure grace-shape parity — a monkeypatched crash yields the SAME grace-shape body on both URLs (never a 5xx).
- Bare body byte-equals `/lock-reasons-at-batch?tier=<p>&features=...` with the three `perspective_*` keys stripped — pins that the alias hasn't accidentally drifted the shape.

## Test plan

- [x] `python3 -m py_compile routes/entitlement.py tests/test_entitlement_lock_reasons_batch_alias.py` — clean
- [x] `ruff check routes/entitlement.py tests/test_entitlement_lock_reasons_batch_alias.py` — clean (`All checks passed!`)
- [x] `pytest tests/test_entitlement_lock_reasons_batch_alias.py -q` → **14/14 pass** in 1.69s
- [x] Sibling regression sweep (`-k 'entitlement and (lock_reason or blueprint or lock_reasons)'`) — **504/504 pass**
- [x] Full entitlement suite — **6613 pass, 4 skipped**; the one `test_retention_prune::test_entitlement_retention_value_drives_prune` error is pre-existing on `origin/main` (missing `duckdb` module in this container), NOT caused by this change.
- [x] Blueprint URL-map after registration — both `/api/entitlement/lock-reason-batch` and `/api/entitlement/lock-reasons-batch` present, distinct endpoint names, all rules unique.

## Local operator verification checklist

I can't touch the running daemon, `~/.openclaw`, the live snapshot, or a browser from here — please run:

- [ ] Copy the changed file into `~/.clawmetry/lib/python3.11/site-packages/routes/entitlement.py`; drop the test file into the local checkout under `tests/`
- [ ] Clear `__pycache__` on the `routes/` dir
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
- [ ] `curl -s 'http://localhost:8900/api/entitlement/lock-reasons-batch?features=fleet,sso' | jq .` — expect a 5-axis body identical to `curl -s 'http://localhost:8900/api/entitlement/lock-reason-batch?features=fleet,sso'`
- [ ] `curl -s 'http://localhost:8900/api/entitlement/lock-reasons-batch?features=fleet&runtimes=claude_code&channels=5&retention_days=30&nodes=3' | jq .` — expect all five axes populated on both URLs
- [ ] `curl -s -o /dev/null -w '%{http_code}\n' 'http://localhost:8900/api/entitlement/lock-reasons-batch'` → `400` (matches the singular URL)
- [ ] `curl -s 'http://localhost:8900/api/entitlement/lock-reasons-batch?features=bogus_id' | jq '.features[0]'` — expect `locked: false`, `required_tier: null` (grace-shape row for the typo, no 500)
- [ ] Byte-parity: strip the three `perspective_*` keys off `/lock-reasons-at-batch?tier=<p>&features=fleet` and confirm the remaining body byte-equals `/lock-reasons-batch?features=fleet` for every `p` in `_TIER_ORDER`
- [ ] Decrypt the live cloud snapshot and hit both URLs against the cloud read-through path
- [ ] Browser check: any surface currently calling `/lock-reason-batch` should keep rendering; nothing should call `/lock-reasons-batch` yet

No `__version__` bump, no tag, no `[RELEASE]` PR — staying in DRAFT until you've cleared local + cloud verification.

## MOAT / release checklist

- Not a MOAT fast-path change (no `local_store_via_daemon` / `_ls_call` / `_DAEMON_METHODS` touched).
- Not a `[RELEASE]` PR.


---
_Generated by [Claude Code](https://claude.ai/code/session_015Z1WE2DV2w8JM1vUyPDrrx)_