### PR TITLE
test: fix sys.modules leak in gateway obs-gap stubs

### DIFF
--- a/tests/test_obs_gap_openclaw_gateway_host_status_3551.py
+++ b/tests/test_obs_gap_openclaw_gateway_host_status_3551.py
@@ -11,6 +11,28 @@ import importlib
 import sys
 import types
 
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _restore_sys_modules():
+    """Restore sys.modules entries clobbered by _make_mock_dashboard/_reload_adapter.
+
+    Without this, the minimal stub installed for each test leaks into subsequent
+    test files, causing AttributeError on real dashboard attributes.
+    """
+    saved_dashboard = sys.modules.get("dashboard")
+    saved_adapter = sys.modules.get("clawmetry.adapters.openclaw")
+    yield
+    if saved_dashboard is None:
+        sys.modules.pop("dashboard", None)
+    else:
+        sys.modules["dashboard"] = saved_dashboard
+    if saved_adapter is None:
+        sys.modules.pop("clawmetry.adapters.openclaw", None)
+    else:
+        sys.modules["clawmetry.adapters.openclaw"] = saved_adapter
+
 
 def _make_mock_dashboard(rpc_return):
     """Return a minimal mock dashboard module with _gw_ws_rpc wired up."""

--- a/tests/test_obs_gap_openclaw_gateway_plugin_health_3200.py
+++ b/tests/test_obs_gap_openclaw_gateway_plugin_health_3200.py
@@ -11,6 +11,28 @@ import importlib
 import sys
 import types
 
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _restore_sys_modules():
+    """Restore sys.modules entries clobbered by _make_mock_dashboard/_reload_adapter.
+
+    Without this, the minimal stub installed for each test leaks into subsequent
+    test files, causing AttributeError on real dashboard attributes.
+    """
+    saved_dashboard = sys.modules.get("dashboard")
+    saved_adapter = sys.modules.get("clawmetry.adapters.openclaw")
+    yield
+    if saved_dashboard is None:
+        sys.modules.pop("dashboard", None)
+    else:
+        sys.modules["dashboard"] = saved_dashboard
+    if saved_adapter is None:
+        sys.modules.pop("clawmetry.adapters.openclaw", None)
+    else:
+        sys.modules["clawmetry.adapters.openclaw"] = saved_adapter
+
 
 def _make_mock_dashboard(rpc_return):
     """Return a minimal mock dashboard module with _gw_ws_rpc wired up."""


### PR DESCRIPTION
## Summary

- `test_obs_gap_openclaw_gateway_host_status_3551.py` and `test_obs_gap_openclaw_gateway_plugin_health_3200.py` both call `_make_mock_dashboard()` which installs a minimal stub into `sys.modules["dashboard"]` — a module with only `_gw_ws_rpc` — and never cleans it up.
- `_reload_adapter()` then calls `importlib.reload()` on the openclaw adapter, re-binding it to the stub. Both poisoned entries persist for the rest of the pytest session.
- Any test that runs after either file and accesses real `dashboard` attributes (`_get_sessions`, `_sessions_cache`) gets `AttributeError` — ~20 tests failed in the full suite while passing perfectly in isolation.

## Fix

Added an `autouse=True` pytest fixture `_restore_sys_modules` to both offending files. It snapshots `sys.modules["dashboard"]` and `sys.modules["clawmetry.adapters.openclaw"]` before each test and restores them (or removes the keys if they weren't present before) after each test.

```python
@pytest.fixture(autouse=True)
def _restore_sys_modules():
    saved_dashboard = sys.modules.get("dashboard")
    saved_adapter = sys.modules.get("clawmetry.adapters.openclaw")
    yield
    # restore / remove both entries so the stub doesn't bleed into later tests
    ...
```

## Test plan

- [ ] `python3 -m pytest tests/test_obs_gap_openclaw_gateway_host_status_3551.py tests/test_obs_gap_openclaw_gateway_plugin_health_3200.py tests/test_obs_gap_openclaw_session_sqlite_fields_2875.py tests/test_obs_gap_talk_sandbox.py` — was 20 failures, now **70 passed**
- [ ] Each file still passes in isolation (no regression to the gateway tests themselves)

Closes #3666

---
_Generated by [Claude Code](https://claude.ai/code/session_01ATQxMbQL2kQnpBHDtcXEeP)_