### PR TITLE
test: skip quarantined tests in PR gate jobs (C7)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,10 @@ jobs:
         env:
           CLAWMETRY_URL: http://localhost:8900
           CLAWMETRY_TOKEN: ci-test-token
-        run: python3 -m pytest tests/test_api.py -v --tb=short
+        # -m 'not quarantine': skip any tests listed in tests/quarantine.txt
+        # (marked by conftest.py:pytest_collection_modifyitems via quarantine.txt).
+        # Quarantined tests still run daily in quarantine-sweep.yml.
+        run: python3 -m pytest tests/test_api.py -v --tb=short -m 'not quarantine'
 
   # ── MOAT verifier (hermetic, hard-fail) ────────────────────────────────────────────────────
   # Issue #1491 / PRD #1133 invariant #3: "A regression in either direction
@@ -380,11 +383,16 @@ jobs:
         env:
           CLAWMETRY_URL: http://localhost:8900
           CLAWMETRY_TOKEN: ci-test-token
+        # -m 'not quarantine': skip any tests listed in tests/quarantine.txt
+        # (marked by conftest.py:pytest_collection_modifyitems). This lets
+        # a flaky test be quarantined without blocking all PRs. Quarantined
+        # tests still run daily in quarantine-sweep.yml and hard-fail if
+        # they go permanently broken (not just intermittent).
         run: |
           python3 -m pytest \
             tests/test_e2e.py::TestTabsLoad \
             tests/test_e2e_oss_all_tabs.py::TestAllTabsPostAuth \
-            -v --tb=short
+            -v --tb=short -m 'not quarantine'
 
   # ── pip install smoke test across platforms ─────────────────────────────────────────
   pip-install:


### PR DESCRIPTION
## Summary

- Adds `-m 'not quarantine'` to the `api-tests` and `e2e-critical` pytest commands in `ci.yml`.
- Without this flag, tests listed in `tests/quarantine.txt` (marked by `conftest.py:pytest_collection_modifyitems`) have no effect in CI: they still run and still block PRs, defeating the entire C7 quarantine mechanism.
- This is the missing link that closes C7: auto-quarantine detects flaky tests from `oss-golden-path.yml` JUnit artifacts, writes them to `quarantine.txt`, and NOW those tests will be correctly skipped in the two most flakiness-prone PR gate jobs.

**Root cause of the gap:** `conftest.py` correctly applies the `quarantine` mark at collection time, but the CI jobs running `api-tests` and `e2e-critical` never passed `-m 'not quarantine'` to pytest, so the mark was applied and immediately ignored.

**What stays unchanged:** Quarantined tests continue to run daily in `quarantine-sweep.yml` (up to 3 attempts). That workflow hard-fails when a quarantined test goes from flaky to permanently broken, enforcing the 24h investigation SLA.

Tracking: vivekchand/clawmetry#3740 (C7)

## Test plan

- [ ] The two changed pytest commands now carry `-m 'not quarantine'`
- [ ] `quarantine.txt` is currently empty so there is zero behavior change on this PR; the flag becomes active the first time `auto-quarantine.yml` quarantines a test
- [ ] `quarantine-sweep.yml` is not changed and continues running daily
- [ ] CI passes green on this PR (no quarantined tests to skip, no regressions)

---
_Generated by [Claude Code](https://claude.ai/code/session_014AaeY2anGCkesDQBoBdpyf)_