### PR TITLE
fix(c6): redirect daily health-check reminders to open tracking issue #1646

### DIFF
--- a/.github/workflows/apply-required-checks.yml
+++ b/.github/workflows/apply-required-checks.yml
@@ -37,7 +37,7 @@ name: Apply required E2E status checks (C6 -- one-shot)
 #   clawmetry-landing.
 #
 # Idempotent: running multiple times is safe.
-# Tracking: vivekchand/clawmetry#3666
+# Tracking: vivekchand/clawmetry#1646
 
 on:
   workflow_dispatch:

--- a/.github/workflows/c6-health.yml
+++ b/.github/workflows/c6-health.yml
@@ -8,7 +8,7 @@ name: C6 daily health check (branch-protection audit -- all 3 repos)
 # /branches/main endpoint (works for public repos; falls back to
 # UNKNOWN if protection detail is not visible cross-repo).
 #
-# On failure: posts an @-mentioned reminder to tracking issue #3666
+# On failure: posts an @-mentioned reminder to tracking issue #1646
 # at most once per calendar day. On success: posts a GREEN confirmation.
 #
 # To close C6:
@@ -18,7 +18,7 @@ name: C6 daily health check (branch-protection audit -- all 3 repos)
 #   2. Or: bash scripts/close-c6.sh
 #   3. Or: Settings > Branches > main > Required status checks (each repo)
 #
-# Tracking: vivekchand/clawmetry#3666
+# Tracking: vivekchand/clawmetry#1646
 
 on:
   schedule:
@@ -48,7 +48,7 @@ jobs:
 
           TOKEN = os.environ["GITHUB_TOKEN"]
           OWNER = "vivekchand"
-          TRACKING_ISSUE = 3666
+          TRACKING_ISSUE = 1646
           MARKER = "<!-- c6-health-check -->"
 
           HEADERS = {


### PR DESCRIPTION
## Summary

- `c6-health.yml` posts a daily `@vivekchand` C6 reminder to a hardcoded issue number. Issue #3666 was closed by the user on 2026-07-14 while C6 was still red, so reminders have been landing in a closed thread that does not re-enter GitHub's notification inbox.
- This PR changes `TRACKING_ISSUE` from `3666` to `1646` (the still-open E2E Robustness epic), so daily reminders actually reach the user again.
- Also updates the `# Tracking:` comment in `apply-required-checks.yml` to point to the same open issue.

## Files changed

| File | Change |
|------|--------|
| `.github/workflows/c6-health.yml` | `TRACKING_ISSUE = 3666` -> `1646`; header comment updated |
| `.github/workflows/apply-required-checks.yml` | `# Tracking: #3666` -> `#1646` |

## Acceptance test

After merge, the next 09:00 UTC run of `c6-health.yml` must post its reminder as a comment on issue #1646, not #3666. Confirm by checking issue #1646 for a `<!-- c6-health-check -->` comment from `github-actions[bot]`.

## What C6 still needs (unchanged by this PR)

A one-time admin action to apply required status checks:
1. [Create fine-grained PAT](https://github.com/settings/personal-access-tokens/new?name=clawmetry-c6) with Administration read+write on all 3 repos.
2. [Actions > Apply required E2E status checks > Run workflow](https://github.com/vivekchand/clawmetry/actions/workflows/apply-required-checks.yml) with `confirm=APPLY` and the PAT pasted into `pat_token`.

Or: `bash scripts/close-c6.sh` from a terminal with an authenticated `gh` session.

C1/C2/C3/C4/C5/C7 are all green. C6 is the sole remaining blocker.

_E2E Robustness cron fire 2026-07-15 -- tracking: #1646_

---
_Generated by [Claude Code](https://claude.ai/code/session_0123VXRGD5Nmn8UFendZRwr6)_