### PR TITLE
fix: auto-quarantine exit code never captured when flaky tests found (C7)

### DIFF
--- a/.github/workflows/auto-quarantine.yml
+++ b/.github/workflows/auto-quarantine.yml
@@ -58,8 +58,17 @@ jobs:
           if [ -n "${{ inputs.lookback }}" ]; then
             ARGS="$ARGS --lookback ${{ inputs.lookback }}"
           fi
+          # GitHub Actions uses set -eo pipefail by default. Without set +e,
+          # bash exits the run block immediately when auto_quarantine.py exits
+          # with code 2 (new flaky tests found), so the echo line never runs
+          # and steps.detect.outputs.exit_code is never set to '2'.
+          # Fix: disable exit-on-error for the python call, capture the exit
+          # code in SCRIPT_EXIT, then re-enable.
+          set +e
           python3 scripts/auto_quarantine.py $ARGS
-          echo "exit_code=$?" >> "$GITHUB_OUTPUT"
+          SCRIPT_EXIT=$?
+          set -e
+          echo "exit_code=${SCRIPT_EXIT}" >> "$GITHUB_OUTPUT"
         continue-on-error: true
 
       - name: Open PR for newly quarantined tests

--- a/.github/workflows/auto-quarantine.yml
+++ b/.github/workflows/auto-quarantine.yml
@@ -84,7 +84,7 @@ jobs:
           git commit -m "test: auto-quarantine flaky E2E tests [C7]
 
           Flaky tests detected by auto_quarantine.py: failed in an OSS
-          Golden Path run then passed on re-run. Added to quarantine.txt
+          Golden Path run then passed on re-run of the same commit. Added to quarantine.txt
           so they are excluded from the main PR gate and swept daily.
 
           Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"


### PR DESCRIPTION
## Summary

- Fixes a silent bug in `auto-quarantine.yml` where the `steps.detect.outputs.exit_code` output was never set to `'2'` when `auto_quarantine.py` found new flaky tests, so the "Open PR for newly quarantined tests" step was effectively dead code.

## Root cause

GitHub Actions run blocks execute under `set -eo pipefail` by default. `auto_quarantine.py` exits with code **2** to signal "new flaky tests written to quarantine.txt" (per its documented exit codes). Because code 2 is non-zero, bash exits the run block immediately at that line -- before `echo "exit_code=$?" >> "$GITHUB_OUTPUT"` runs. The output variable is never set, so `steps.detect.outputs.exit_code == '2'` is always `false`, and the PR-opening step never fires.

The `continue-on-error: true` on the step prevents the *workflow* from failing, but it does not change the in-process `set -e` behavior of the run block itself.

This means C7's auto-quarantine has been silently broken since it was added: detected flaky tests would be written to disk by the script, but the PR to commit them would never open.

## Fix

```diff
-    python3 scripts/auto_quarantine.py $ARGS
-    echo "exit_code=$?" >> "$GITHUB_OUTPUT"
+    set +e
+    python3 scripts/auto_quarantine.py $ARGS
+    SCRIPT_EXIT=$?
+    set -e
+    echo "exit_code=${SCRIPT_EXIT}" >> "$GITHUB_OUTPUT"
```

Standard bash idiom for capturing exit codes from commands that may exit non-zero: disable `set -e` for that one call, save `$?` before it can change, re-enable.

## Test plan

- [ ] `echo "exit_code=2"` now correctly reaches `$GITHUB_OUTPUT` when the script exits 2
- [ ] Exit code 0 (no new tests): no PR opened, summary says "No new flaky tests detected"
- [ ] Exit code 1 (script error): step fails (continue-on-error keeps workflow alive), PR not opened
- [ ] Exit code 2 (new tests quarantined): PR-opening step fires, `quarantine.txt` committed
- [ ] CI passes on this PR

Tracking: vivekchand/clawmetry#3740 (C7)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QDPjzUAhK8MbwQFnDUCMhf)_