### PR TITLE
fix(uninstall): remove ALL com.clawmetry.* launchd agents, not just sync

### DIFF
--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -213,6 +213,39 @@ def _kill_sync_daemon() -> None:
         )
 
 
+def _kill_dashboard_processes() -> int:
+    """SIGTERM running clawmetry dashboard/server processes (best-effort).
+
+    Skips the current process and its parent so `clawmetry uninstall`
+    (which itself runs from bin/clawmetry) never kills itself mid-run.
+    Returns the number of processes signalled.
+    """
+    import signal
+    import subprocess as _sp
+
+    patterns = ("bin/clawmetry", "clawmetry/dashboard.py")
+    skip = {os.getpid(), os.getppid()}
+    killed = 0
+    try:
+        r = _sp.run(
+            ["ps", "-axo", "pid=,command="],
+            capture_output=True, text=True, check=False,
+        )
+        for line in r.stdout.splitlines():
+            pid_str, _, cmd = line.strip().partition(" ")
+            if not pid_str.isdigit() or int(pid_str) in skip:
+                continue
+            if any(p in cmd for p in patterns):
+                try:
+                    os.kill(int(pid_str), signal.SIGTERM)
+                    killed += 1
+                except Exception:
+                    pass
+    except Exception:
+        pass
+    return killed
+
+
 def _stop_existing_daemon() -> None:
     """Stop any running sync daemon, deregister old node, clear stale state."""
     import subprocess
@@ -1421,14 +1454,20 @@ def _cmd_uninstall() -> None:
     # Collect what will be removed
     items = []
 
-    # 1. Daemons
+    # 1. Daemons — every com.clawmetry.* job (sync, dashboard, sandbox.*),
+    # not just sync. The dashboard agent has KeepAlive, so missing it here
+    # leaves a launchd job that resurrects the server after uninstall.
+    daemon_plists: list = []
+    daemon_units: list = []
     if system == "Darwin":
-        plist = home / "Library" / "LaunchAgents" / "com.clawmetry.sync.plist"
-        if plist.exists():
+        la_dir = home / "Library" / "LaunchAgents"
+        daemon_plists = sorted(la_dir.glob("com.clawmetry.*.plist"))
+        for plist in daemon_plists:
             items.append(("Daemon", f"launchd service: {plist}"))
     elif system == "Linux":
-        svc = home / ".config" / "systemd" / "user" / "clawmetry-sync.service"
-        if svc.exists():
+        sysd_user = home / ".config" / "systemd" / "user"
+        daemon_units = sorted(sysd_user.glob("clawmetry*.service"))
+        for svc in daemon_units:
             items.append(("Daemon", f"systemd service: {svc}"))
         if _is_sync_running():
             items.append(("Daemon", "Running sync process"))
@@ -1540,15 +1579,24 @@ def _cmd_uninstall() -> None:
     except Exception:
         pass
 
-    # 1. Stop daemons
+    # 1. Stop daemons. Boot the launchd jobs out BEFORE deleting any files:
+    # the dashboard agent has KeepAlive, so a plist left registered restarts
+    # the server (even from a deleted ~/.clawmetry, whose files it holds open).
     if system == "Darwin":
-        plist = home / "Library" / "LaunchAgents" / "com.clawmetry.sync.plist"
-        if plist.exists():
-            subprocess.run(
-                ["launchctl", "unload", str(plist)], check=False, capture_output=True
+        uid = os.getuid()
+        for plist in daemon_plists:
+            label = plist.stem
+            r = subprocess.run(
+                ["launchctl", "bootout", f"gui/{uid}/{label}"],
+                check=False, capture_output=True,
             )
-            plist.unlink()
-            print("  ✅  Stopped and removed launchd daemon")
+            if r.returncode != 0:  # older macOS without bootout
+                subprocess.run(
+                    ["launchctl", "unload", str(plist)],
+                    check=False, capture_output=True,
+                )
+            plist.unlink(missing_ok=True)
+            print(f"  ✅  Stopped and removed launchd service: {label}")
         # Belt-and-suspenders: kill any sync daemons started by hand (not via
         # launchd). Without this, install.sh's pkill is the only thing that takes
         # them down, which surfaces to the user as "Killed stray pre-existing
@@ -1559,15 +1607,18 @@ def _cmd_uninstall() -> None:
             _kill_sync_daemon()
             print(f"  ✅  Killed {_stray} stray sync process(es)")
     elif system == "Linux":
-        _svcs = [home / ".config" / "systemd" / "user" / "clawmetry-sync.service",
-                 __import__("pathlib").Path("/etc/systemd/system/clawmetry-sync.service")]
+        _unit_names = {svc.stem for svc in daemon_units} | {"clawmetry-sync"}
+        _svcs = list(daemon_units) + [
+            __import__("pathlib").Path("/etc/systemd/system/clawmetry-sync.service")
+        ]
         if shutil.which("systemctl"):
-            for _scope in (["--user"], []):  # --user (non-root) + system (root)
-                subprocess.run(
-                    ["systemctl", *_scope, "disable", "--now", "clawmetry-sync"],
-                    check=False,
-                    capture_output=True,
-                )
+            for _unit in sorted(_unit_names):
+                for _scope in (["--user"], []):  # --user (non-root) + system (root)
+                    subprocess.run(
+                        ["systemctl", *_scope, "disable", "--now", _unit],
+                        check=False,
+                        capture_output=True,
+                    )
         _stray = _count_sync_daemons()
         _kill_sync_daemon()
         for svc in _svcs:
@@ -1577,6 +1628,11 @@ def _cmd_uninstall() -> None:
             except Exception:
                 pass
         print("  ✅  Stopped and removed sync daemon" + (f" + {_stray} stray process(es)" if _stray else ""))
+    # The bootout above kills launchd-managed processes; this sweeps up
+    # dashboards started by hand (clawmetry --port ...).
+    _stray_dash = _kill_dashboard_processes()
+    if _stray_dash:
+        print(f"  ✅  Killed {_stray_dash} dashboard process(es)")
 
     # 2. Pip uninstall (BEFORE removing venv, since sys.executable may live there)
     print("  ⏳  Uninstalling pip package...")

--- a/tests/test_uninstall_removes_all_launchagents.py
+++ b/tests/test_uninstall_removes_all_launchagents.py
@@ -1,0 +1,117 @@
+"""`clawmetry uninstall` must remove EVERY com.clawmetry.* LaunchAgent.
+
+Regression (2026-07-15): uninstall only handled com.clawmetry.sync.plist,
+leaving com.clawmetry.dashboard.plist registered. That agent has KeepAlive,
+so launchd kept the dashboard serving on localhost:8900 from the already
+deleted ~/.clawmetry venv (open file handles survive the rmtree) — and
+respawned it on every login.
+"""
+
+import subprocess
+import sys
+import types
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import clawmetry.cli as cli_mod
+import clawmetry.sync as sync_mod
+
+
+def _setup_fake_darwin(tmp_path, monkeypatch, recorded):
+    home = tmp_path / "home"
+    la_dir = home / "Library" / "LaunchAgents"
+    la_dir.mkdir(parents=True)
+
+    for label in (
+        "com.clawmetry.dashboard",
+        "com.clawmetry.sync",
+        "com.clawmetry.sandbox.nemoclaw-sandbox",
+    ):
+        (la_dir / f"{label}.plist").write_text("<plist/>")
+    (la_dir / "com.other.app.plist").write_text("<plist/>")
+
+    clawmetry_dir = home / ".clawmetry"
+    (clawmetry_dir / "bin").mkdir(parents=True)
+    (clawmetry_dir / "bin" / "clawmetry").write_text("#!/usr/bin/env python3\n")
+
+    monkeypatch.setattr(Path, "home", lambda: home)
+    monkeypatch.setattr("platform.system", lambda: "Darwin")
+
+    def fake_run(cmd, *a, **kw):
+        recorded.append(list(cmd))
+        return types.SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setattr("builtins.input", lambda *_: "uninstall")
+    monkeypatch.setattr(cli_mod, "_get_nemoclaw_sandboxes", lambda: [])
+    monkeypatch.setattr(cli_mod, "_count_sync_daemons", lambda: 0)
+    monkeypatch.setattr(cli_mod, "_kill_sync_daemon", lambda: None)
+    for name in ("CONFIG_FILE", "STATE_FILE", "LOG_FILE"):
+        monkeypatch.setattr(sync_mod, name, home / f".fake_{name.lower()}")
+    return home, la_dir
+
+
+def test_uninstall_removes_all_clawmetry_launchagents(tmp_path, monkeypatch):
+    recorded = []
+    home, la_dir = _setup_fake_darwin(tmp_path, monkeypatch, recorded)
+    dash_kills = []
+    monkeypatch.setattr(
+        cli_mod, "_kill_dashboard_processes", lambda: dash_kills.append(1) or 0
+    )
+
+    cli_mod._cmd_uninstall()
+
+    leftovers = sorted(p.name for p in la_dir.glob("com.clawmetry.*.plist"))
+    assert leftovers == [], f"launchd plists survived uninstall: {leftovers}"
+    # Unrelated agents must be untouched.
+    assert (la_dir / "com.other.app.plist").exists()
+    assert not (home / ".clawmetry").exists()
+
+    booted = {c[2].rsplit("/", 1)[-1] for c in recorded if c[:2] == ["launchctl", "bootout"]}
+    assert booted == {
+        "com.clawmetry.dashboard",
+        "com.clawmetry.sync",
+        "com.clawmetry.sandbox.nemoclaw-sandbox",
+    }
+    assert dash_kills, "_kill_dashboard_processes was not invoked"
+
+
+def test_uninstall_falls_back_to_unload_without_bootout(tmp_path, monkeypatch):
+    recorded = []
+    _, la_dir = _setup_fake_darwin(tmp_path, monkeypatch, recorded)
+    monkeypatch.setattr(cli_mod, "_kill_dashboard_processes", lambda: 0)
+
+    def fake_run(cmd, *a, **kw):
+        recorded.append(list(cmd))
+        rc = 1 if cmd[:2] == ["launchctl", "bootout"] else 0
+        return types.SimpleNamespace(returncode=rc, stdout="", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    cli_mod._cmd_uninstall()
+
+    unloaded = [c for c in recorded if c[:2] == ["launchctl", "unload"]]
+    assert len(unloaded) == 3
+    assert not list(la_dir.glob("com.clawmetry.*.plist"))
+
+
+def test_kill_dashboard_processes_skips_self(monkeypatch):
+    import os
+
+    own = os.getpid()
+    ps_out = (
+        f"  {own} /Users/x/.clawmetry/bin/python3 /Users/x/.clawmetry/bin/clawmetry uninstall\n"
+        f"  424242 /Users/x/.clawmetry/bin/python3 /Users/x/.clawmetry/bin/clawmetry --no-debug --port 8900\n"
+        f"  424243 /usr/bin/some-unrelated-daemon --port 8900\n"
+    )
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda *a, **kw: types.SimpleNamespace(returncode=0, stdout=ps_out, stderr=""),
+    )
+    killed = []
+    monkeypatch.setattr(os, "kill", lambda pid, sig: killed.append(pid))
+
+    assert cli_mod._kill_dashboard_processes() == 1
+    assert killed == [424242]


### PR DESCRIPTION
## Problem

`clawmetry uninstall` reported "fully uninstalled" but the dashboard kept serving on `localhost:8900`. Reproduced live on Vivek's machine on 2026-07-15:

- Uninstall only unloads `com.clawmetry.sync.plist`. It never touches `com.clawmetry.dashboard.plist` (the :8900 server, `KeepAlive=true`) or `com.clawmetry.sandbox.*.plist`.
- The dashboard process survives the `rm -rf ~/.clawmetry` because it holds the deleted venv files open — so the UI keeps working with zero bytes of clawmetry on disk.
- `KeepAlive` means launchd resurrects it after any kill and on every login; the orphaned sandbox agents crash-loop with exit code 78 (binary gone).

## Fix

- **macOS**: glob every `~/Library/LaunchAgents/com.clawmetry.*.plist`, `launchctl bootout gui/$UID/<label>` each (fallback to `launchctl unload` on older macOS), delete the plist. Runs **before** any file deletion so KeepAlive can't resurrect anything.
- **Linux**: same broadening — disable/remove every `clawmetry*.service` user unit instead of hardcoding `clawmetry-sync`.
- New `_kill_dashboard_processes()` sweeps up hand-started dashboards (`bin/clawmetry` / `clawmetry/dashboard.py` cmdlines), excluding the uninstall process itself and its parent so uninstall never kills itself. Does not match the ClawMetry.app desktop bundle.
- The uninstall preview now lists every agent that will be removed.

## Tests

`tests/test_uninstall_removes_all_launchagents.py` (3 tests, pass on py3.9):
- all `com.clawmetry.*` plists booted out + deleted, unrelated plists untouched
- `launchctl unload` fallback when `bootout` is unavailable
- `_kill_dashboard_processes` skips its own PID

🤖 Generated with [Claude Code](https://claude.com/claude-code)