### PR TITLE
fix(e2e): redirect c6-health daily posts from closed #3666 to open #3752

### DIFF
--- a/.github/workflows/c6-health.yml
+++ b/.github/workflows/c6-health.yml
@@ -8,7 +8,7 @@ name: C6 daily health check (branch-protection audit -- all 3 repos)
 # /branches/main endpoint (works for public repos; falls back to
 # UNKNOWN if protection detail is not visible cross-repo).
 #
-# On failure: posts an @-mentioned reminder to tracking issue #3666
+# On failure: posts an @-mentioned reminder to tracking issue #3752
 # at most once per calendar day. On success: posts a GREEN confirmation.
 #
 # To close C6:
@@ -18,7 +18,7 @@ name: C6 daily health check (branch-protection audit -- all 3 repos)
 #   2. Or: bash scripts/close-c6.sh
 #   3. Or: Settings > Branches > main > Required status checks (each repo)
 #
-# Tracking: vivekchand/clawmetry#3666
+# Tracking: vivekchand/clawmetry#3752
 
 on:
   schedule:
@@ -48,7 +48,7 @@ jobs:
 
           TOKEN = os.environ["GITHUB_TOKEN"]
           OWNER = "vivekchand"
-          TRACKING_ISSUE = 3666
+          TRACKING_ISSUE = 3752
           MARKER = "<!-- c6-health-check -->"
 
           HEADERS = {


### PR DESCRIPTION
## Summary

`c6-health.yml` posts a daily C6 status @-mention to `TRACKING_ISSUE`. The target was #3666, but @vivekchand closed #3666 as completed on 2026-07-14T21:07:05Z. Since then, the daily reminders have been landing on a closed issue with reduced notification surface.

This PR redirects `TRACKING_ISSUE` from `3666` to `3752`, the canonical open E2E tracking issue created 2026-07-15.

**Change**: 1 integer literal in `.github/workflows/c6-health.yml`

```diff
-TRACKING_ISSUE = 3666
+TRACKING_ISSUE = 3752
```

Plus the header comment `# Tracking:` reference updated to match.

No logic change. Dedup, comment body, and @vivekchand mention are identical.

## Context

- C6 (required status checks) is the only remaining RED criterion out of 7
- C1/C2/C3/C4/C5/C7 all GREEN for 7+ days
- PR #3743 (C7 quarantine mark fix) is also ready to merge: all 19 real CI checks pass; only the expected `C6 Required-status-checks gate` badge shows red (by design until C6 closes)
- C6 needs one admin action: run `bash scripts/close-c6.sh` or use [Actions > Apply required E2E status checks](https://github.com/vivekchand/clawmetry/actions/workflows/apply-required-checks.yml) with `confirm=APPLY` + fine-grained PAT

## Test plan

- [ ] After merge, next `c6-health.yml` run posts to #3752 (not closed #3666)
- [ ] Daily @vivekchand mention reaches the open tracking issue
- [ ] No other behavior change

Tracking: vivekchand/clawmetry#3752 (C6)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CtvZweMqN5edWtoiRmP84z)_