### PR TITLE
fix(c6): redirect daily health reminders from closed #3666 to open #3752

### DIFF
--- a/.github/workflows/apply-required-checks.yml
+++ b/.github/workflows/apply-required-checks.yml
@@ -37,7 +37,7 @@ name: Apply required E2E status checks (C6 -- one-shot)
 #   clawmetry-landing.
 #
 # Idempotent: running multiple times is safe.
-# Tracking: vivekchand/clawmetry#3666
+# Tracking: vivekchand/clawmetry#3752
 
 on:
   workflow_dispatch:

--- a/.github/workflows/c6-health.yml
+++ b/.github/workflows/c6-health.yml
@@ -8,7 +8,7 @@ name: C6 daily health check (branch-protection audit -- all 3 repos)
 # /branches/main endpoint (works for public repos; falls back to
 # UNKNOWN if protection detail is not visible cross-repo).
 #
-# On failure: posts an @-mentioned reminder to tracking issue #3666
+# On failure: posts an @-mentioned reminder to tracking issue #3752
 # at most once per calendar day. On success: posts a GREEN confirmation.
 #
 # To close C6:
@@ -18,7 +18,7 @@ name: C6 daily health check (branch-protection audit -- all 3 repos)
 #   2. Or: bash scripts/close-c6.sh
 #   3. Or: Settings > Branches > main > Required status checks (each repo)
 #
-# Tracking: vivekchand/clawmetry#3666
+# Tracking: vivekchand/clawmetry#3752
 
 on:
   schedule:
@@ -48,7 +48,7 @@ jobs:
 
           TOKEN = os.environ["GITHUB_TOKEN"]
           OWNER = "vivekchand"
-          TRACKING_ISSUE = 3666
+          TRACKING_ISSUE = 3752
           MARKER = "<!-- c6-health-check -->"
 
           HEADERS = {
@@ -225,8 +225,8 @@ jobs:
                   "clawmetry-cloud and clawmetry-landing: protection details not readable "
                   "cross-repo (expected with github.token -- they were configured by the "
                   "same apply-required-checks run).\n\n"
-                  "The 7-day stop-condition countdown has been met "
-                  "(C1-C5/C7 green for 7+ days). "
+                  "C6 is now GREEN. The 7-criterion stop-condition countdown starts today "
+                  "(all 7 criteria must hold green for 7 consecutive days). "
                   "Disable the cron at https://claude.ai/code/scheduled."
               )
           else:

--- a/.github/workflows/c6-pr-gate.yml
+++ b/.github/workflows/c6-pr-gate.yml
@@ -3,7 +3,7 @@ name: C6 Required-status-checks gate (PR audit)
 # Runs on every pull request to surface whether C6 (required-status-checks)
 # is configured on main. Fails visibly on every PR until the admin closes C6.
 #
-# The daily c6-health.yml posts to issue #3666 but the admin may not check
+# The daily c6-health.yml posts to issue #3752 but the admin may not check
 # that issue between merges. This check appears directly in the PR status
 # list alongside OSS golden path, E2E Browser Tests, etc. -- impossible to
 # miss when reviewing a PR.
@@ -34,7 +34,7 @@ name: C6 Required-status-checks gate (PR audit)
 #     bash scripts/close-c6.sh
 #     (uses your existing gh CLI session -- no PAT creation needed)
 #
-# Tracking: vivekchand/clawmetry#3666 (C6)
+# Tracking: vivekchand/clawmetry#3752 (C6)
 
 on:
   pull_request:

--- a/.github/workflows/c6-schedule-heal.yml
+++ b/.github/workflows/c6-schedule-heal.yml
@@ -22,7 +22,7 @@ name: C6 auto-heal (daily required-checks application)
 #     clawmetry, clawmetry-cloud, clawmetry-landing
 #   This workflow picks it up at 10:15am UTC and closes C6 automatically.
 #
-# Tracking: vivekchand/clawmetry#3666 (C6)
+# Tracking: vivekchand/clawmetry#3752 (C6)
 
 on:
   schedule:
@@ -48,7 +48,7 @@ jobs:
             echo "has_pat=false" >> "$GITHUB_OUTPUT"
             echo "::error::E2E_ADMIN_PAT secret is not set -- C6 (required-status-checks) cannot be applied automatically."
             echo ""
-            echo "ACTION REQUIRED: Add E2E_ADMIN_PAT to close C6 (vivekchand/clawmetry#3666)."
+            echo "ACTION REQUIRED: Add E2E_ADMIN_PAT to close C6 (vivekchand/clawmetry#3752)."
             echo ""
             echo "Step 1: Create a fine-grained PAT"
             echo "  https://github.com/settings/personal-access-tokens/new"
@@ -65,7 +65,7 @@ jobs:
             echo "  Actions > 'Apply required E2E status checks (C6 -- one-shot)'"
             echo "  confirm=APPLY, pat_token=<paste PAT>"
             echo ""
-            echo "  Tracking: https://github.com/vivekchand/clawmetry/issues/3666"
+            echo "  Tracking: https://github.com/vivekchand/clawmetry/issues/3752"
             exit 1
           else
             echo "has_pat=true" >> "$GITHUB_OUTPUT"
@@ -84,4 +84,4 @@ jobs:
           echo "C6 auto-heal complete."
           echo "If apply_required_status_checks.py exited 0, branch protection is configured"
           echo "on clawmetry/main, clawmetry-cloud/main, clawmetry-landing/main."
-          echo "C6 is now GREEN. Tracking: https://github.com/vivekchand/clawmetry/issues/3666"
+          echo "C6 is now GREEN. Tracking: https://github.com/vivekchand/clawmetry/issues/3752"


### PR DESCRIPTION
## What

`c6-health.yml` had `TRACKING_ISSUE = 3666` hardcoded. Issue #3666 was closed by @vivekchand on 2026-07-14. The open canonical tracking issue is #3752.

**Effect of the bug:** the daily 09:00 UTC C6 audit posted reminder comments to a closed issue. The dedup guard then saw those comments, skipped subsequent days with no output at all, and the user received zero notification that C6 was still open. This cron fire is the first to catch it.

## Changes

| File | Change |
|------|--------|
| `c6-health.yml` | `TRACKING_ISSUE = 3666` -> `3752` (functional fix -- reminders now land on the open issue) |
| `c6-health.yml` | Fix premature stop-condition message: "7-day countdown has been met" -> "countdown starts today" |
| `c6-health.yml` | Update header comment `# ...tracking issue #3666` -> `#3752` |
| `c6-schedule-heal.yml` | Update `Tracking:` reference in echo output and header comment |
| `apply-required-checks.yml` | Update `Tracking:` comment at bottom |
| `c6-pr-gate.yml` | Update `Tracking:` comment at bottom |

No logic changes other than the issue number and the stop-condition message fix.

## Acceptance test

After merge, the 09:00 UTC run of `c6-health.yml` posts its daily C6 reminder to #3752 (not #3666). Verify via Actions > C6 daily health check > most recent run log: `Posted: https://github.com/vivekchand/clawmetry/issues/3752#issuecomment-...`

## C6 status

C6 is still RED (branch protection not yet configured). This PR does not close C6 -- it makes the daily reminder visible again so @vivekchand actually sees the prompt to run the one-shot workflow.

To close C6: [Actions > Apply required E2E status checks > Run workflow](https://github.com/vivekchand/clawmetry/actions/workflows/apply-required-checks.yml) with `confirm=APPLY` and a fine-grained PAT (Administration read+write on all 3 repos) pasted into `pat_token`.

---
_Generated by [Claude Code](https://claude.ai/code/session_019hjuDHuoEDNrZZcruSZGup)_