### PR TITLE
fix(c6): update tracking ref from #3666 to #3752 in C6 helper scripts

### DIFF
--- a/scripts/apply_required_status_checks.py
+++ b/scripts/apply_required_status_checks.py
@@ -46,7 +46,7 @@ Primary repo behaviour (clawmetry):
 When run locally (GITHUB_REPOSITORY not set), the script applies all 6
 checks and requires a token with cross-repo admin access.
 
-Tracking: vivekchand/clawmetry#3666 (C6)
+Tracking: vivekchand/clawmetry#3752 (C6)
 """
 from __future__ import annotations
 
@@ -374,7 +374,7 @@ def main() -> None:
                 "  Fix: re-run the workflow and paste a fine-grained PAT into the 'pat_token' field.\n"
                 "  PAT permissions: Administration (read+write) on clawmetry, clawmetry-cloud, clawmetry-landing.\n"
                 "  Alternative: bash scripts/close-c6.sh (uses your gh CLI session, ~30 sec).\n"
-                "  Tracking: vivekchand/clawmetry#3666 (C6)"
+                "  Tracking: vivekchand/clawmetry#3752 (C6)"
             )
         # Read-only path: GITHUB_TOKEN cannot write branch protection rules.
         # Scope verification to the current repo only to avoid cross-repo 403s.

--- a/scripts/close-c6.sh
+++ b/scripts/close-c6.sh
@@ -19,7 +19,7 @@
 # After running: every PR in those 3 repos must pass the E2E suite to merge.
 # This closes criterion C6 of the E2E Robustness epic.
 #
-# Tracking: vivekchand/clawmetry#3666
+# Tracking: vivekchand/clawmetry#3752
 
 set -euo pipefail
 


### PR DESCRIPTION
## What

PR #3756 updated the tracking issue reference from the closed #3666 to the open #3752 in four workflow YAML files. This PR covers the two helper scripts that #3756 missed.

When a developer follows the terminal path to close C6 (`bash scripts/close-c6.sh`) and hits an error, the script output previously said `Tracking: vivekchand/clawmetry#3666 (C6)`. Clicking that link lands on a closed issue with no further guidance -- a dead end.

## Changes

| File | Change |
|------|--------|
| `scripts/apply_required_status_checks.py` | Fix `#3666` to `#3752` in module docstring (1 place) and `CONFIRM_INPUT==APPLY` error message (1 place) |
| `scripts/close-c6.sh` | Fix `#3666` to `#3752` in tracking comment (1 place) |

No logic changes. No overlap with PR #3756 (different files).

## Acceptance test

After merge: `grep -r '#3666' scripts/` returns no matches. The two script files only reference `#3752`.

## C6 status

C6 is still RED (branch protection not yet configured). This PR makes the error output point to the right issue when a developer runs `scripts/close-c6.sh`.

To close C6: [Actions > Apply required E2E status checks > Run workflow](https://github.com/vivekchand/clawmetry/actions/workflows/apply-required-checks.yml) with `confirm=APPLY` and a fine-grained PAT (Administration read+write on all 3 repos) pasted into `pat_token`.

---
E2E Robustness cron fire 03 -- 2026-07-15T14:00Z -- tracking vivekchand/clawmetry#3752

---
_Generated by [Claude Code](https://claude.ai/code/session_013GpXCFyWAHky5dqMHD6HJN)_