### PR TITLE
fix(c6): route daily reminders and audit links to open tracking issue #3740

### DIFF
--- a/.github/workflows/apply-required-checks.yml
+++ b/.github/workflows/apply-required-checks.yml
@@ -37,7 +37,7 @@ name: Apply required E2E status checks (C6 -- one-shot)
 #   clawmetry-landing.
 #
 # Idempotent: running multiple times is safe.
-# Tracking: vivekchand/clawmetry#3666
+# Tracking: vivekchand/clawmetry#3740
 
 on:
   workflow_dispatch:

--- a/.github/workflows/c6-health.yml
+++ b/.github/workflows/c6-health.yml
@@ -8,7 +8,7 @@ name: C6 daily health check (branch-protection audit -- all 3 repos)
 # /branches/main endpoint (works for public repos; falls back to
 # UNKNOWN if protection detail is not visible cross-repo).
 #
-# On failure: posts an @-mentioned reminder to tracking issue #3666
+# On failure: posts an @-mentioned reminder to tracking issue #3740
 # at most once per calendar day. On success: posts a GREEN confirmation.
 #
 # To close C6:
@@ -18,7 +18,7 @@ name: C6 daily health check (branch-protection audit -- all 3 repos)
 #   2. Or: bash scripts/close-c6.sh
 #   3. Or: Settings > Branches > main > Required status checks (each repo)
 #
-# Tracking: vivekchand/clawmetry#3666
+# Tracking: vivekchand/clawmetry#3740
 
 on:
   schedule:
@@ -48,7 +48,7 @@ jobs:
 
           TOKEN = os.environ["GITHUB_TOKEN"]
           OWNER = "vivekchand"
-          TRACKING_ISSUE = 3666
+          TRACKING_ISSUE = 3740
           MARKER = "<!-- c6-health-check -->"
 
           HEADERS = {

--- a/.github/workflows/c6-pr-gate.yml
+++ b/.github/workflows/c6-pr-gate.yml
@@ -3,7 +3,7 @@ name: C6 Required-status-checks gate (PR audit)
 # Runs on every pull request to surface whether C6 (required-status-checks)
 # is configured on main. Fails visibly on every PR until the admin closes C6.
 #
-# The daily c6-health.yml posts to issue #3666 but the admin may not check
+# The daily c6-health.yml posts to issue #3740 but the admin may not check
 # that issue between merges. This check appears directly in the PR status
 # list alongside OSS golden path, E2E Browser Tests, etc. -- impossible to
 # miss when reviewing a PR.
@@ -34,7 +34,7 @@ name: C6 Required-status-checks gate (PR audit)
 #     bash scripts/close-c6.sh
 #     (uses your existing gh CLI session -- no PAT creation needed)
 #
-# Tracking: vivekchand/clawmetry#3666 (C6)
+# Tracking: vivekchand/clawmetry#3740 (C6)
 
 on:
   pull_request:


### PR DESCRIPTION
## Summary

Daily C6 reminders from `c6-health.yml` have been silently posting to **closed issue #3666** since 2026-07-14T21:07Z, when the user closed it. No reminder has reached the user since then.

PR #3746 addressed this routing bug but redirected to **#1646** (the C1 tracking issue) instead of the canonical open E2E Robustness epic **#3740**. This PR supersedes #3746 with the correct target.

**Three files updated (all `3666` or `1646` references corrected to `3740`):**

| File | Change |
|------|--------|
| `c6-health.yml` | `TRACKING_ISSUE = 3666` and header comment `#3666` both corrected to `3740` |
| `c6-pr-gate.yml` | Description line + `# Tracking:` comment corrected to `#3740` |
| `apply-required-checks.yml` | `# Tracking:` comment corrected to `#3740` |

## Why this matters

`c6-health.yml` runs daily at 09:00 UTC and @-mentions the repo owner with precise instructions to close C6 (apply required status checks). Since the issue it posts to is closed, those mentions go nowhere -- the user gets zero daily reminder and C6 stays RED indefinitely.

After this merge, the daily 09:00 UTC C6 reminder posts to #3740 (the open tracking issue), the user sees the @-mention in their GitHub notifications, and C6 can be closed with the 30-second PAT action described there.

## Acceptance test

After merge, the next 09:00 UTC run of `c6-health.yml` must post its `<!-- c6-health-check -->` comment to issue #3740, not #3666. Check #3740 comments after that time.

## Relation to PR #3746

PR #3746 (`fix/c6-reminder-redirect-open-issue`) touches the same two files (`c6-health.yml`, `apply-required-checks.yml`) and should be closed in favour of this PR once both cannot merge cleanly together. See comment on #3746.

Tracking: vivekchand/clawmetry#3740 (C6)

---
_E2E Robustness cron fire 2026-07-15 -- C6 reminder routing fix_

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_017YUuybt1Fwv1UxRF2F1XWs)_