### PR TITLE
fix(logs): consume named SSE events and add missing Logs tab panel (#3761)

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -1216,6 +1216,7 @@ function switchTab(name) {
   if (name === 'policy') { if (typeof loadToolPolicy === 'function') loadToolPolicy(); }
   if (name === 'approvals') { if (typeof loadApprovalsTab === 'function') loadApprovalsTab(); }
   if (name === 'alerts') { if (typeof loadAlertsPage === 'function') loadAlertsPage(); }
+  if (name === 'logs') loadLogs();
   if (name === 'dives') { if (typeof loadDivesPage === 'function') loadDivesPage(); }
   if (name === 'actions') loadQAHistory();
   if (name === 'models') loadModelAttribution();
@@ -16639,6 +16640,29 @@ function startLogStream() {
     processFlowEvent(data.line);
     document.getElementById('refresh-time').textContent = 'Live \u2022 ' + new Date().toLocaleTimeString();
   };
+  // Named events emitted by _generate_openclaw_json_logs() in routes/infra.py.
+  // EventSource.onmessage only fires for unnamed data: events; named events
+  // require addEventListener or they are silently dropped (#3761).
+  logStream.addEventListener('log-meta', function(e) {
+    try {
+      var meta = JSON.parse(e.data);
+      var s = document.getElementById('log-stream-status');
+      if (s && meta.file) s.title = 'Source: ' + meta.file + (meta.size ? ' (' + meta.size + ' bytes)' : '');
+      var srcEl = document.getElementById('log-source-path');
+      if (srcEl && meta.file) srcEl.textContent = meta.file;
+    } catch(ex) {}
+  });
+  logStream.addEventListener('log-notice', function(e) {
+    try {
+      var notice = JSON.parse(e.data);
+      var msg = notice.message || notice.reason || JSON.stringify(notice);
+      var line = '[NOTICE] ' + msg;
+      streamBuffer.push(line);
+      if (streamBuffer.length > MAX_STREAM_LINES) streamBuffer.shift();
+      appendLogLine('ov-logs', line);
+      appendLogLine('logs-full', line);
+    } catch(ex) {}
+  });
   logStream.onerror = function() {
     var s = document.getElementById('log-stream-status');
     if (s) { s.textContent = t("app.dot_reconnecting", null, "\u25cf Reconnecting\u2026"); s.style.color = '#f59e0b'; }

--- a/clawmetry/templates/tabs/logs.html
+++ b/clawmetry/templates/tabs/logs.html
@@ -1,0 +1,24 @@
+<div class="page" id="page-logs">
+  <div style="display:flex;justify-content:space-between;align-items:flex-start;margin-bottom:14px;gap:16px;flex-wrap:wrap;">
+    <div>
+      <div style="font-size:18px;font-weight:700;color:var(--text-primary);">Logs</div>
+      <div style="font-size:12px;color:var(--text-muted);margin-top:4px;">
+        Live OpenClaw log stream &mdash; <span id="log-source-path" style="font-family:monospace;color:var(--text-secondary);font-size:11px;"></span>
+        <span id="log-stream-status" style="margin-left:8px;font-size:11px;font-weight:600;color:var(--text-muted);">&#9679; Connecting&hellip;</span>
+      </div>
+    </div>
+    <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;">
+      <input id="log-filter" type="text" placeholder="Filter logs&hellip;" oninput="filterLogLines()" style="font-size:12px;padding:6px 10px;border:1px solid var(--border-primary);border-radius:6px;background:var(--bg-secondary);color:var(--text-primary);width:180px;">
+      <select id="log-lines" onchange="loadLogs()" style="font-size:12px;padding:6px 8px;border:1px solid var(--border-primary);border-radius:6px;background:var(--bg-secondary);color:var(--text-primary);">
+        <option value="100">100 lines</option>
+        <option value="250" selected>250 lines</option>
+        <option value="500">500 lines</option>
+        <option value="1000">1000 lines</option>
+      </select>
+      <button class="refresh-btn" onclick="loadLogs()" title="Reload historical logs">&#8635;</button>
+    </div>
+  </div>
+  <div id="logs-full" style="font-family:monospace;font-size:12px;line-height:1.6;background:var(--bg-secondary);border:1px solid var(--border-primary);border-radius:8px;padding:12px 16px;max-height:calc(100vh - 180px);overflow-y:auto;white-space:pre-wrap;word-break:break-all;">
+    <span style="color:var(--text-muted);">Loading&hellip;</span>
+  </div>
+</div>

--- a/clawmetry/templates/tabs/overview.html
+++ b/clawmetry/templates/tabs/overview.html
@@ -525,6 +525,10 @@
       <div class="tool-spark"><span>--</span></div></div>
     <div id="active-tasks-grid"></div>
     <div id="activity-stream"></div>
+    <!-- Live log stream overview target (#3761): startLogStream() appends lines
+         here via appendLogLine('ov-logs', ...). Hidden in overview; the full
+         panel lives in page-logs (tabs/logs.html). -->
+    <div id="ov-logs"></div>
   </div>
 
   <!-- old system health removed, now inside tasks pane -->

--- a/dashboard.py
+++ b/dashboard.py
@@ -12176,6 +12176,9 @@ DASHBOARD_HTML = r"""
       <div class="left-nav-item left-nav-item-sub" data-tab="notifications" onclick="switchTab('notifications')">
         <span class="left-nav-label" data-i18n="nav.notifications">Notifications</span>
       </div>
+      <div class="left-nav-item left-nav-item-sub" data-tab="logs" onclick="switchTab('logs')" title="Live OpenClaw log stream">
+        <span class="left-nav-label">Logs</span>
+      </div>
       <div class="left-nav-item left-nav-item-sub" data-tab="security" onclick="switchTab('security')">
         <span class="left-nav-label" data-i18n="nav.security">Security</span>
       </div>
@@ -12273,6 +12276,9 @@ DASHBOARD_HTML = r"""
 
 <!-- HARNESS (declarative per-runtime custom panel; #2667) -->
 {% include 'tabs/harness.html' %}
+
+<!-- LOGS (live stream + historical viewer; #3761) -->
+{% include 'tabs/logs.html' %}
 
 <!-- SWIMLANE COMPARE — N parallel live lanes (sessions / runtimes) -->
 {% include 'tabs/swimlane.html' %}


### PR DESCRIPTION
Fixes #3761

## Root cause

The backend (`routes/infra.py` `_generate_openclaw_json_logs()`) already emitted correctly-typed named SSE events:

- `event: log-meta` — file/source/sourceKind/cursor/size identity
- `event: log-notice` — rotation/truncation hints
- unnamed `data:` — raw log lines

But `EventSource.onmessage` only fires for **unnamed** `data:` events per the EventSource spec. The named `log-meta` and `log-notice` events were silently dropped because no `addEventListener` calls existed in `startLogStream()`.

Additionally, the display targets (`ov-logs`, `logs-full`, `log-stream-status`) referenced throughout `app.js` were never rendered in any HTML template — the Logs tab panel was entirely missing — so even the unnamed raw-line events couldn't display.

## Changes

### `clawmetry/static/js/app.js`
- **`startLogStream()`**: add `logStream.addEventListener('log-meta', ...)` — stores source file path in the status tooltip and `#log-source-path` span; add `logStream.addEventListener('log-notice', ...)` — formats rotation/truncation notices as `[NOTICE] …` lines and appends them to both stream targets.
- **`switchTab()`**: add `if (name === 'logs') loadLogs();` so the historical log fetch fires on tab activation.

### `clawmetry/templates/tabs/logs.html` *(new)*
Full logs panel (`page-logs`) containing:
- `#logs-full` — monospace output area for live stream + historical lines
- `#log-stream-status` — live/connecting/reconnecting indicator
- `#log-source-path` — populated by `log-meta` events
- `#log-filter` — client-side text filter (wired to existing `filterLogLines()`)
- `#log-lines` — line-count selector (wired to existing `loadLogs()`)

### `clawmetry/templates/tabs/overview.html`
Add `#ov-logs` div to the hidden-elements shim block so `startLogStream()`'s `appendLogLine('ov-logs', …)` calls have a valid DOM target instead of silently no-oping.

### `dashboard.py`
- Include `tabs/logs.html` in the live `DASHBOARD_HTML`.
- Add a **Logs** entry in the Advanced sidebar drawer.

## Test plan
- [ ] Navigate to Advanced → Logs; panel renders with status indicator
- [ ] `log-meta` events populate the source path in the subtitle and tooltip
- [ ] `log-notice` (rotation) events appear as `[NOTICE]` lines in the stream
- [ ] Raw log lines appear in `#logs-full` as before
- [ ] Filter input narrows visible lines
- [ ] Line-count selector reloads historical logs
- [ ] `make lint` passes (pre-existing errors only, none from changed files)

---
_Generated by [Claude Code](https://claude.ai/code/session_012hupJim9w3wsbdYe91NLNR)_