### PR TITLE
feat: expose Skill Workshop approval-policy via GET /api/skills/workshop

### DIFF
--- a/routes/skills.py
+++ b/routes/skills.py
@@ -530,6 +530,51 @@ def compute_skills_payload():
     return {"skills": skills_out, "summary": summary}
 
 
+def _get_workshop_config():
+    """Read the skills.workshop section from the OpenClaw config file.
+
+    Returns the dict at cfg["skills"]["workshop"] or {} if absent or
+    unreadable — callers always get a dict, never raise.
+    """
+    try:
+        import dashboard as _d
+        cfg = _d._load_openclaw_config_cached()
+        if not isinstance(cfg, dict):
+            return {}
+        return (cfg.get("skills") or {}).get("workshop") or {}
+    except Exception:
+        return {}
+
+
+@bp_skills.route("/api/skills/workshop")
+def api_skills_workshop():
+    """Return Skill Workshop approval-policy config.
+
+    Surfaces ``skills.workshop.approvalPolicy`` from ``~/.openclaw/openclaw.json``
+    so the dashboard can show whether autonomous apply/reject/quarantine
+    actions are enabled without a human-approval prompt.
+
+    Response shape::
+
+        {
+          "approval_policy":     string | null,   # raw config value; null = key absent
+          "auto_actions_enabled": bool,            # True when policy != "pending"
+          "config":              dict,             # full skills.workshop object
+        }
+
+    When ``approval_policy`` is null the OpenClaw default applies (behaviour
+    depends on the installed OpenClaw version).
+    """
+    workshop = _get_workshop_config()
+    policy = workshop.get("approvalPolicy")
+    auto_actions_enabled = isinstance(policy, str) and policy != "pending"
+    return jsonify({
+        "approval_policy": policy,
+        "auto_actions_enabled": auto_actions_enabled,
+        "config": workshop,
+    })
+
+
 @bp_skills.route("/api/skills")
 def api_skills():
     """List all installed skills with fidelity stats."""


### PR DESCRIPTION
Closes #3762

## What this does

Adds a `GET /api/skills/workshop` endpoint that surfaces the `skills.workshop.approvalPolicy` config value from `~/.openclaw/openclaw.json`. Without this, autonomous Skill Workshop mutations (apply/reject/quarantine) are entirely invisible in the ClawMetry dashboard.

## Changes

- `routes/skills.py` — `_get_workshop_config()` helper reads `skills.workshop` from the existing `_load_openclaw_config_cached()` loader (graceful `{}` fallback when key absent); `api_skills_workshop()` route returns `{ "approval_policy": string|null, "auto_actions_enabled": bool, "config": dict }`. Werkzeug automatically gives the static `/api/skills/workshop` path priority over the existing `/<skill_name>` parameterised rule — no conflict.

## What it doesn't cover

The apply/reject/quarantine **event stream** (the second half of the gap) isn't wired in this PR — no JSONL event type corresponds to skill mutations yet. That can land once the OpenClaw event schema is confirmed.

## Test plan

- `GET /api/skills/workshop` with no OpenClaw config → `{ "approval_policy": null, "auto_actions_enabled": false, "config": {} }` (no error).
- With `~/.openclaw/openclaw.json` containing `{ "skills": { "workshop": { "approvalPolicy": "pending" } } }` → `auto_actions_enabled: false`.
- With `approvalPolicy` set to any value other than `"pending"` (e.g. `"allow"`) → `auto_actions_enabled: true`.
- Existing `/api/skills` and `/api/skills/<name>` routes unaffected.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KKGzfFUMus9uHHSxFsgFYJ)_