### PR TITLE
fix: ingest OpenClaw backup/snapshot lifecycle into DuckDB

### DIFF
--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -726,6 +726,28 @@ _DDL = [
     "CREATE INDEX IF NOT EXISTS idx_assets_status ON assets(status, updated_at)",
     "CREATE INDEX IF NOT EXISTS idx_assets_type   ON assets(asset_type, updated_at)",
     "CREATE INDEX IF NOT EXISTS idx_assets_run    ON assets(source_run_id)",
+    # Issue #3696 — OpenClaw backup/snapshot lifecycle observability.
+    # OpenClaw 2026.7+ ships `openclaw backup sqlite create|list|verify`.
+    # We ingest the backup manifest (or infer from file naming) so the
+    # dashboard can surface: last backup timestamp, verify status, and
+    # whether any backup exists at all. Graceful fallback: if no backup
+    # directory is found, query_backups() returns an empty list.
+    """
+    CREATE TABLE IF NOT EXISTS backups (
+        backup_id        VARCHAR PRIMARY KEY,
+        node_id          VARCHAR NOT NULL DEFAULT '',
+        ts               VARCHAR NOT NULL,
+        backup_type      VARCHAR NOT NULL DEFAULT 'global',
+        agent_id         VARCHAR,
+        scope            VARCHAR NOT NULL DEFAULT 'sqlite',
+        file_path        VARCHAR,
+        file_size_bytes  BIGINT,
+        verify_status    VARCHAR,
+        verify_ts        VARCHAR,
+        updated_at       BIGINT NOT NULL
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_backups_ts   ON backups(ts DESC)",
     # Issue #1088 Phase 4 (2026-05-13) — channel-message foundation. Replaces
     # the per-provider log-grep + JSONL-scan path that the 21 routes in
     # ``routes/channels.py`` use today. Each row is one inbound or outbound
@@ -2575,6 +2597,46 @@ class LocalStore:
                   cron.get("last_run_at"), cron.get("last_status"),
                   cron.get("next_run_at"), cron.get("model") or None,
                   data_blob, now_ms])
+
+    def ingest_backup_record(self, rec: dict[str, Any]) -> None:
+        """Upsert one OpenClaw backup/snapshot row (issue #3696).
+
+        Required: ``backup_id``. All other fields are optional and default to
+        safe sentinel values. Re-ingesting the same id is idempotent — only
+        ``verify_status``, ``verify_ts``, and ``file_size_bytes`` are updated
+        on conflict so a later verify run can promote an earlier 'pending' row
+        without duplicating it.
+        """
+        bid = rec.get("backup_id")
+        if not bid:
+            raise ValueError("backup record must include 'backup_id'")
+        now_ms = int(time.time() * 1000)
+        with self._write_lock:
+            self._conn.execute("""
+                INSERT INTO backups (
+                    backup_id, node_id, ts, backup_type, agent_id,
+                    scope, file_path, file_size_bytes, verify_status,
+                    verify_ts, updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT (backup_id) DO UPDATE SET
+                    verify_status   = COALESCE(excluded.verify_status,
+                                               backups.verify_status),
+                    verify_ts       = COALESCE(excluded.verify_ts,
+                                               backups.verify_ts),
+                    file_size_bytes = COALESCE(excluded.file_size_bytes,
+                                               backups.file_size_bytes),
+                    updated_at      = excluded.updated_at
+            """, [bid,
+                  rec.get("node_id") or "",
+                  rec.get("ts") or "",
+                  rec.get("backup_type") or "global",
+                  rec.get("agent_id"),
+                  rec.get("scope") or "sqlite",
+                  rec.get("file_path"),
+                  rec.get("file_size_bytes"),
+                  rec.get("verify_status"),
+                  rec.get("verify_ts"),
+                  now_ms])
 
     def ingest_cron_run(self, run: dict[str, Any]) -> None:
         """Upsert one cron-run row (issue #605 DuckDB follow-up).
@@ -6708,6 +6770,41 @@ class LocalStore:
                 "enabled", "last_run_at", "last_status", "next_run_at",
                 "model", "data", "updated_at"]
         return _decode_data_blob_rows(self._fetch(sql, params), cols)
+
+    def query_backups(
+        self,
+        *,
+        node_id: str | None = None,
+        backup_type: str | None = None,
+        limit: int = 50,
+    ) -> list[dict[str, Any]]:
+        """OpenClaw backup/snapshot records (issue #3696).
+
+        Returns rows newest-first by ``ts``. Empty list when no backups have
+        been ingested yet (normal for fresh installs or installs that have
+        never run ``openclaw backup sqlite create``).
+        """
+        clauses: list[str] = []
+        params: list[Any] = []
+        if node_id:
+            clauses.append("node_id = ?"); params.append(node_id)
+        if backup_type:
+            clauses.append("backup_type = ?"); params.append(backup_type)
+        where = ("WHERE " + " AND ".join(clauses)) if clauses else ""
+        sql = f"""
+            SELECT backup_id, node_id, ts, backup_type, agent_id,
+                   scope, file_path, file_size_bytes, verify_status,
+                   verify_ts, updated_at
+            FROM backups
+            {where}
+            ORDER BY ts DESC
+            LIMIT ?
+        """
+        params.append(int(limit))
+        cols = ["backup_id", "node_id", "ts", "backup_type", "agent_id",
+                "scope", "file_path", "file_size_bytes", "verify_status",
+                "verify_ts", "updated_at"]
+        return [dict(zip(cols, r)) for r in self._fetch(sql, params)]
 
     def query_cron_runs(
         self,

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -9891,6 +9891,124 @@ def _sync_cron_runs_from_state_sqlite(config: dict, state: dict, store) -> int:
     return n_ingested
 
 
+def sync_backups(config: dict, state: dict, paths: dict) -> int:
+    """Ingest OpenClaw backup/snapshot records into DuckDB (issue #3696).
+
+    Probes candidate directories under the OpenClaw home in order of
+    likelihood.  If a ``manifest.jsonl`` is present, each line is a JSON
+    record; otherwise we walk ``*.sqlite`` / ``*.duckdb`` files and infer
+    metadata from the naming convention ``{type}_backup_{ts}[_{agent}].ext``
+    (e.g. ``global_backup_20260713_143000.sqlite``).  Returns early with 0
+    on any import error or when no backup directory is found — callers must
+    not crash on empty results.
+    """
+    _record_sync_progress("backups", 0)
+    openclaw_dir = _get_openclaw_dir()
+    # Try common paths; keep fallback ordering stable across OpenClaw versions.
+    candidate_dirs = [
+        os.path.join(openclaw_dir, "backups"),
+        os.path.join(openclaw_dir, "state", "backups"),
+        os.path.join(openclaw_dir, "agents", "main", "backups"),
+    ]
+    backup_dir = next((d for d in candidate_dirs if os.path.isdir(d)), None)
+    if not backup_dir:
+        _record_sync_progress("backups", 0, 0)
+        return 0
+
+    try:
+        from clawmetry import local_store as _ls
+        store = _ls.get_store()
+    except Exception as e:
+        log.debug("sync_backups: store unavailable: %s", e)
+        return 0
+
+    node_id = config.get("node_id", "")
+    n_ingested = 0
+
+    # Prefer manifest JSONL when present (authoritative, written by OpenClaw).
+    manifest_path = os.path.join(backup_dir, "manifest.jsonl")
+    if os.path.isfile(manifest_path):
+        try:
+            with open(manifest_path, "rb") as fh:
+                for raw_line in fh:
+                    line = raw_line.strip()
+                    if not line:
+                        continue
+                    try:
+                        rec = json.loads(line)
+                    except Exception:
+                        continue
+                    bid = rec.get("backup_id") or rec.get("id")
+                    if not bid:
+                        continue
+                    try:
+                        store.ingest_backup_record({
+                            "backup_id":      bid,
+                            "node_id":        rec.get("node_id") or node_id,
+                            "ts":             rec.get("ts") or rec.get("created_at") or "",
+                            "backup_type":    rec.get("backup_type") or rec.get("type") or "global",
+                            "agent_id":       rec.get("agent_id"),
+                            "scope":          rec.get("scope") or "sqlite",
+                            "file_path":      rec.get("file") or rec.get("file_path"),
+                            "file_size_bytes": rec.get("file_size_bytes") or rec.get("size"),
+                            "verify_status":  rec.get("verify_status") or rec.get("verify"),
+                            "verify_ts":      rec.get("verify_ts"),
+                        })
+                        n_ingested += 1
+                    except Exception as e_in:
+                        log.debug("sync_backups: ingest failed for %s: %s", bid, e_in)
+        except Exception as e_manifest:
+            log.debug("sync_backups: manifest read error: %s", e_manifest)
+    else:
+        # Fall back: walk backup files and infer metadata from naming.
+        # Expected convention: ``{type}_backup_{YYYYMMDD_HHMMSS}[_{agent_id}].{ext}``
+        # e.g. ``global_backup_20260713_143000.sqlite``
+        import re as _re
+        _pat = _re.compile(
+            r"^(?P<btype>global|agent|per_agent)_backup_"
+            r"(?P<date>\d{8})_(?P<time>\d{6})"
+            r"(?:_(?P<agent>[^.]+))?"
+            r"\.(?:sqlite|duckdb)$"
+        )
+        try:
+            for fname in sorted(os.listdir(backup_dir)):
+                m = _pat.match(fname)
+                if not m:
+                    continue
+                fpath = os.path.join(backup_dir, fname)
+                try:
+                    fsize = os.path.getsize(fpath)
+                except OSError:
+                    fsize = None
+                d, t = m.group("date"), m.group("time")
+                ts_str = f"{d[:4]}-{d[4:6]}-{d[6:8]}T{t[:2]}:{t[2:4]}:{t[4:6]}"
+                bid = fname.rsplit(".", 1)[0]
+                try:
+                    store.ingest_backup_record({
+                        "backup_id":       bid,
+                        "node_id":         node_id,
+                        "ts":              ts_str,
+                        "backup_type":     m.group("btype").replace("per_agent", "agent"),
+                        "agent_id":        m.group("agent"),
+                        "scope":           "sqlite" if fname.endswith(".sqlite") else "duckdb",
+                        "file_path":       fpath,
+                        "file_size_bytes": fsize,
+                        "verify_status":   None,
+                        "verify_ts":       None,
+                    })
+                    n_ingested += 1
+                except Exception as e_in:
+                    log.debug("sync_backups: ingest failed for %s: %s", fname, e_in)
+        except Exception as e_walk:
+            log.debug("sync_backups: directory walk error: %s", e_walk)
+
+    if n_ingested:
+        _record_sync_progress("backups", n_ingested, n_ingested)
+    else:
+        _record_sync_progress("backups", 0, 0)
+    return n_ingested
+
+
 def sync_crons(config: dict, state: dict, paths: dict) -> int:
     """Sync cron job definitions to cloud.
 
@@ -17435,6 +17553,13 @@ def run_daemon() -> None:
             log.info(f"  Cron runs: {crr} rows ingested")
     except Exception as e:
         log.warning(f"  Cron-run ingest error: {e}")
+    # Issue #3696 — OpenClaw backup/snapshot lifecycle observability.
+    try:
+        bk = sync_backups(config, state, paths)
+        if bk:
+            log.info(f"  Backups: {bk} records ingested")
+    except Exception as e:
+        log.warning(f"  Backup ingest error: {e}")
     # OpenClaw 2026.5.x run ledger (tasks/runs.sqlite) → DuckDB run_ledger.
     # Feeds the Scheduler lane monitor + sub-agent fan-out tree.
     try:
@@ -17918,6 +18043,11 @@ def run_daemon() -> None:
                 sync_run_ledger(config, state, paths)
             except Exception as _e_rl:
                 log.debug("sync_run_ledger error (non-fatal): %s", _e_rl)
+            # Issue #3696 — OpenClaw backup/snapshot lifecycle observability.
+            try:
+                sync_backups(config, state, paths)
+            except Exception as _e_bk:
+                log.debug("sync_backups error (non-fatal): %s", _e_bk)
 
             # Effective sandbox + tool policy per agent (PRD P1-1) → DuckDB
             # tool_policy. Throttled — config is near-static and each agent is

--- a/routes/health.py
+++ b/routes/health.py
@@ -3046,6 +3046,57 @@ def api_loop_signals():
     })
 
 
+@bp_health.route("/api/backups")
+def api_backups():
+    """Return OpenClaw backup/snapshot records (issue #3696).
+
+    Query params (all optional):
+      limit       — max rows (default 50, clamp 1..200)
+      node_id     — filter to a specific node
+      backup_type — filter to 'global' or 'agent'
+
+    Response:
+      {
+        "backups": [
+          {"backup_id": str, "node_id": str, "ts": str,
+           "backup_type": str, "agent_id": str|null,
+           "scope": str, "file_path": str|null,
+           "file_size_bytes": int|null,
+           "verify_status": str|null, "verify_ts": str|null}
+        ],
+        "count": <int>,
+        "last_backup_ts": <str|null>,
+        "last_verify_status": <str|null>
+      }
+
+    Empty-list fallback (HTTP 200) on any error or when no backups have
+    been ingested yet — this is normal for fresh installs.
+    """
+    try:
+        limit = max(1, min(200, int(request.args.get("limit", 50))))
+    except (TypeError, ValueError):
+        limit = 50
+    node_id = request.args.get("node_id") or None
+    backup_type = request.args.get("backup_type") or None
+
+    rows = _ls_call("query_backups", node_id=node_id,
+                    backup_type=backup_type, limit=limit)
+    if not rows:
+        rows = []
+
+    last_backup_ts = rows[0].get("ts") if rows else None
+    last_verify_status = next(
+        (r.get("verify_status") for r in rows if r.get("verify_status")),
+        None,
+    )
+    return jsonify({
+        "backups": rows,
+        "count": len(rows),
+        "last_backup_ts": last_backup_ts,
+        "last_verify_status": last_verify_status,
+    })
+
+
 # ---------------------------------------------------------------------------
 # MCP tool call observability (#850)
 # ---------------------------------------------------------------------------

--- a/routes/local_query.py
+++ b/routes/local_query.py
@@ -803,6 +803,8 @@ _DAEMON_METHODS = frozenset({
     "log_ar_history",
     "list_ar_rules",
     "query_ar_history",
+    # Issue #3696 — OpenClaw backup/snapshot lifecycle observability.
+    "query_backups",
 })
 
 

--- a/tests/test_backups_local_store.py
+++ b/tests/test_backups_local_store.py
@@ -1,0 +1,258 @@
+"""Tests for issue #3696 — OpenClaw backup/snapshot lifecycle observability.
+
+Verifies that:
+  1. ingest_backup_record() stores records with correct fields.
+  2. query_backups() returns them sorted newest-first and honours filters.
+  3. Re-ingesting the same backup_id updates verify_status without duplicating.
+  4. GET /api/backups returns the expected JSON shape and derives
+     last_backup_ts / last_verify_status correctly.
+  5. An empty DuckDB (no backups) returns a valid empty response.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def store_and_app(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_BATCH", "5")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_READ", "1")
+
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    import routes.health as rh
+    importlib.reload(rh)
+
+    store = ls.get_store()
+    _seed_store(store)
+
+    app = Flask(__name__)
+    app.register_blueprint(rh.bp_health)
+    yield store, app
+    try:
+        store.stop(flush=True)
+    except Exception:
+        pass
+
+
+@pytest.fixture()
+def empty_store(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "empty.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_READ", "1")
+
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    import routes.health as rh
+    importlib.reload(rh)
+
+    store = ls.get_store()
+    app = Flask(__name__)
+    app.register_blueprint(rh.bp_health)
+    yield store, app
+    try:
+        store.stop(flush=True)
+    except Exception:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Seed helpers
+# ---------------------------------------------------------------------------
+
+def _seed_store(store, *, node_id: str = "node-1") -> None:
+    """Seed three backup records:
+      - global ok  (2026-07-10)
+      - per-agent pending (2026-07-12, newer)
+      - global failed (2026-07-08, oldest)
+    """
+    store.ingest_backup_record({
+        "backup_id":       "global_backup_20260710_120000",
+        "node_id":         node_id,
+        "ts":              "2026-07-10T12:00:00",
+        "backup_type":     "global",
+        "agent_id":        None,
+        "scope":           "sqlite",
+        "file_path":       "/home/user/.openclaw/backups/global_backup_20260710_120000.sqlite",
+        "file_size_bytes": 1048576,
+        "verify_status":   "ok",
+        "verify_ts":       "2026-07-10T12:01:00",
+    })
+    store.ingest_backup_record({
+        "backup_id":       "agent_backup_20260712_090000_main",
+        "node_id":         node_id,
+        "ts":              "2026-07-12T09:00:00",
+        "backup_type":     "agent",
+        "agent_id":        "main",
+        "scope":           "sqlite",
+        "file_path":       "/home/user/.openclaw/backups/agent_backup_20260712_090000_main.sqlite",
+        "file_size_bytes": 524288,
+        "verify_status":   "pending",
+        "verify_ts":       None,
+    })
+    store.ingest_backup_record({
+        "backup_id":       "global_backup_20260708_080000",
+        "node_id":         node_id,
+        "ts":              "2026-07-08T08:00:00",
+        "backup_type":     "global",
+        "agent_id":        None,
+        "scope":           "sqlite",
+        "file_path":       "/home/user/.openclaw/backups/global_backup_20260708_080000.sqlite",
+        "file_size_bytes": 1000000,
+        "verify_status":   "failed",
+        "verify_ts":       "2026-07-08T08:02:00",
+    })
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — query_backups()
+# ---------------------------------------------------------------------------
+
+def test_query_backups_returns_three_rows(store_and_app):
+    store, _ = store_and_app
+    rows = store.query_backups()
+    assert len(rows) == 3
+
+
+def test_query_backups_sorted_newest_first(store_and_app):
+    store, _ = store_and_app
+    rows = store.query_backups()
+    timestamps = [r["ts"] for r in rows]
+    assert timestamps == sorted(timestamps, reverse=True)
+
+
+def test_query_backups_filter_by_backup_type(store_and_app):
+    store, _ = store_and_app
+    global_rows = store.query_backups(backup_type="global")
+    assert all(r["backup_type"] == "global" for r in global_rows)
+    assert len(global_rows) == 2
+
+    agent_rows = store.query_backups(backup_type="agent")
+    assert len(agent_rows) == 1
+    assert agent_rows[0]["agent_id"] == "main"
+
+
+def test_query_backups_filter_by_node_id(store_and_app):
+    store, _ = store_and_app
+    rows = store.query_backups(node_id="node-1")
+    assert len(rows) == 3
+
+    rows_none = store.query_backups(node_id="node-nonexistent")
+    assert rows_none == []
+
+
+def test_query_backups_limit(store_and_app):
+    store, _ = store_and_app
+    rows = store.query_backups(limit=2)
+    assert len(rows) == 2
+    # Should be the two newest
+    assert rows[0]["ts"] == "2026-07-12T09:00:00"
+    assert rows[1]["ts"] == "2026-07-10T12:00:00"
+
+
+def test_query_backups_correct_fields(store_and_app):
+    store, _ = store_and_app
+    rows = store.query_backups(backup_type="global", limit=1)
+    row = rows[0]  # newest global = 2026-07-10
+    assert row["backup_id"] == "global_backup_20260710_120000"
+    assert row["verify_status"] == "ok"
+    assert row["file_size_bytes"] == 1048576
+    assert row["scope"] == "sqlite"
+
+
+def test_ingest_backup_record_idempotent_verify_update(store_and_app):
+    """Re-ingesting the same backup_id with a new verify_status must update
+    the status without creating a duplicate row."""
+    store, _ = store_and_app
+    store.ingest_backup_record({
+        "backup_id":      "agent_backup_20260712_090000_main",
+        "node_id":        "node-1",
+        "ts":             "2026-07-12T09:00:00",
+        "backup_type":    "agent",
+        "verify_status":  "ok",
+        "verify_ts":      "2026-07-12T09:01:30",
+    })
+    rows = store.query_backups()
+    assert len(rows) == 3  # still 3, not 4
+    agent_row = next(r for r in rows if r["backup_id"] == "agent_backup_20260712_090000_main")
+    assert agent_row["verify_status"] == "ok"
+    assert agent_row["verify_ts"] == "2026-07-12T09:01:30"
+
+
+def test_ingest_backup_record_missing_id_raises(store_and_app):
+    store, _ = store_and_app
+    with pytest.raises(ValueError, match="backup_id"):
+        store.ingest_backup_record({"node_id": "node-1", "ts": "2026-07-13T00:00:00"})
+
+
+# ---------------------------------------------------------------------------
+# API tests — GET /api/backups
+# ---------------------------------------------------------------------------
+
+def test_api_backups_returns_200(store_and_app):
+    _, app = store_and_app
+    with app.test_client() as c:
+        resp = c.get("/api/backups")
+    assert resp.status_code == 200
+
+
+def test_api_backups_response_shape(store_and_app):
+    _, app = store_and_app
+    with app.test_client() as c:
+        data = c.get("/api/backups").get_json()
+    assert "backups" in data
+    assert "count" in data
+    assert "last_backup_ts" in data
+    assert "last_verify_status" in data
+
+
+def test_api_backups_derives_last_backup_ts(store_and_app):
+    _, app = store_and_app
+    with app.test_client() as c:
+        data = c.get("/api/backups").get_json()
+    # Newest record is 2026-07-12
+    assert data["last_backup_ts"] == "2026-07-12T09:00:00"
+
+
+def test_api_backups_derives_last_verify_status(store_and_app):
+    _, app = store_and_app
+    with app.test_client() as c:
+        data = c.get("/api/backups").get_json()
+    # First record with a non-null verify_status (newest-first = pending)
+    assert data["last_verify_status"] == "pending"
+
+
+def test_api_backups_empty_store(empty_store):
+    _, app = empty_store
+    with app.test_client() as c:
+        resp = c.get("/api/backups")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["backups"] == []
+    assert data["count"] == 0
+    assert data["last_backup_ts"] is None
+    assert data["last_verify_status"] is None
+
+
+def test_api_backups_limit_param(store_and_app):
+    _, app = store_and_app
+    with app.test_client() as c:
+        data = c.get("/api/backups?limit=1").get_json()
+    assert data["count"] == 1
+
+
+def test_api_backups_backup_type_filter(store_and_app):
+    _, app = store_and_app
+    with app.test_client() as c:
+        data = c.get("/api/backups?backup_type=agent").get_json()
+    assert data["count"] == 1
+    assert data["backups"][0]["backup_type"] == "agent"


### PR DESCRIPTION
Closes #3696

## Summary

- **`clawmetry/local_store.py`** — adds `backups` table to `_DDL`, `ingest_backup_record()` (upsert, idempotent on `backup_id` — later verify runs promote `pending` → `ok`/`failed` without duplicating), and `query_backups()` (newest-first, optional `node_id`/`backup_type` filters)
- **`clawmetry/sync.py`** — adds `sync_backups()`: probes `~/.openclaw/backups/`, `~/.openclaw/state/backups/`, `~/.openclaw/agents/main/backups/` in order; prefers `manifest.jsonl` if present; falls back to walking `*.sqlite`/`*.duckdb` files and inferring metadata from the naming convention `{type}_backup_{YYYYMMDD_HHMMSS}[_{agent}].ext`. Returns 0 gracefully when no backup directory exists. Wired into both the startup sweep and the steady-state poll loop.
- **`routes/local_query.py`** — registers `query_backups` in `_DAEMON_METHODS` so the dashboard process never grabs the DuckDB writer lock
- **`routes/health.py`** — `GET /api/backups?limit=50&node_id=…&backup_type=…` → `{backups, count, last_backup_ts, last_verify_status}`; empty-list 200 on any error or fresh install with no backups
- **`tests/test_backups_local_store.py`** (new) — 15 tests: per-type rollup, sort order, idempotent verify update, missing-id validation, API response shape, empty store, and filter params

## Test plan

- `python3 -m pytest tests/test_backups_local_store.py -v` → 15/15 passed
- Manual: run `clawmetry` with a seeded `~/.openclaw/backups/` directory → `GET /api/backups` returns records
- Fresh install (no backup dir): `GET /api/backups` → `{"backups": [], "count": 0, ...}`

---
_Generated by [Claude Code](https://claude.ai/code/session_01RW31snQ7aekZ489f6wX9fD)_