### PR TITLE
fix: granular dcode supervisor fields (PlatformOk, OpenshellAvailable, FailReason)

### DIFF
--- a/clawmetry/adapters/openclaw.py
+++ b/clawmetry/adapters/openclaw.py
@@ -762,10 +762,20 @@ def _sandbox_inference_configs() -> list:
                 # matching the supervisor's own gate exactly.
                 if "deepagents-code" in _sb.lower() or _sb.lower() == "dcode":
                     import sys as _sys
+                    import shutil as _shutil
+                    _platform_ok = _sys.platform.startswith("linux")
+                    _openshell_ok = bool(_shutil.which("openshell"))
                     _te["dcodeSupervisionFeasible"] = (
-                        _sys.platform.startswith("linux")
-                        and bool(_te.get("sandboxPhase"))
+                        _platform_ok and bool(_te.get("sandboxPhase"))
                     )
+                    _te["dcodeSupervisionPlatformOk"] = _platform_ok
+                    _te["dcodeOpenshellAvailable"] = _openshell_ok
+                    if not _platform_ok:
+                        _te["dcodeSupervisionFailReason"] = "non-linux platform"
+                    elif not _openshell_ok:
+                        _te["dcodeSupervisionFailReason"] = "openshell absent"
+                    else:
+                        _te["dcodeSupervisionFailReason"] = None
                 out.append(_te)
     except Exception:
         pass

--- a/tests/test_obs_gap_nemoclaw_dcode_supervisor_3675.py
+++ b/tests/test_obs_gap_nemoclaw_dcode_supervisor_3675.py
@@ -136,3 +136,70 @@ def test_non_dcode_sandbox_not_flagged(tmp_path, monkeypatch):
     assert "dcodeSupervisionFeasible" not in te, (
         f"unexpected dcodeSupervisionFeasible on non-dcode sandbox: {te}"
     )
+
+
+# ---------------------------------------------------------------------------
+# 5–7. New granular fields from #3764 (dcodeSupervisionPlatformOk,
+#       dcodeOpenshellAvailable, dcodeSupervisionFailReason)
+# ---------------------------------------------------------------------------
+
+def test_dcode_granular_fields_all_ok(tmp_path, monkeypatch):
+    """All conditions met → PlatformOk=True, OpenshellAvailable=True, FailReason=None."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    _write_sandboxes_json(tmp_path, {"sandboxes": {}})
+    _write_agents_yaml(tmp_path, (
+        "agents:\n"
+        "  - name: deepagents-code\n"
+        "    sandbox: deepagents-code\n"
+    ))
+    monkeypatch.setattr(shutil, "which", lambda _cmd: "/usr/bin/openshell")
+    monkeypatch.setattr(subprocess, "run", _fake_run_with_phase)
+    monkeypatch.setattr(sys, "platform", "linux")
+
+    result = _sandbox_inference_configs()
+    te = next((r for r in result if r["sandbox"] == "deepagents-code"), None)
+    assert te is not None
+    assert te.get("dcodeSupervisionPlatformOk") is True
+    assert te.get("dcodeOpenshellAvailable") is True
+    assert te.get("dcodeSupervisionFailReason") is None
+
+
+def test_dcode_fail_reason_non_linux(tmp_path, monkeypatch):
+    """Non-Linux → PlatformOk=False, FailReason='non-linux platform'."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    _write_sandboxes_json(tmp_path, {"sandboxes": {}})
+    _write_agents_yaml(tmp_path, (
+        "agents:\n"
+        "  - name: deepagents-code\n"
+        "    sandbox: deepagents-code\n"
+    ))
+    monkeypatch.setattr(shutil, "which", lambda _cmd: "/usr/bin/openshell")
+    monkeypatch.setattr(subprocess, "run", _fake_run_with_phase)
+    monkeypatch.setattr(sys, "platform", "darwin")
+
+    result = _sandbox_inference_configs()
+    te = next((r for r in result if r["sandbox"] == "deepagents-code"), None)
+    assert te is not None
+    assert te.get("dcodeSupervisionPlatformOk") is False
+    assert te.get("dcodeSupervisionFailReason") == "non-linux platform"
+
+
+def test_dcode_fail_reason_openshell_absent(tmp_path, monkeypatch):
+    """Linux but openshell not in PATH → OpenshellAvailable=False, FailReason='openshell absent'."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    _write_sandboxes_json(tmp_path, {"sandboxes": {}})
+    _write_agents_yaml(tmp_path, (
+        "agents:\n"
+        "  - name: deepagents-code\n"
+        "    sandbox: deepagents-code\n"
+    ))
+    monkeypatch.setattr(shutil, "which", lambda _cmd: None)
+    monkeypatch.setattr(subprocess, "run", _fake_run_no_phase)
+    monkeypatch.setattr(sys, "platform", "linux")
+
+    result = _sandbox_inference_configs()
+    te = next((r for r in result if r["sandbox"] == "deepagents-code"), None)
+    assert te is not None
+    assert te.get("dcodeSupervisionPlatformOk") is True
+    assert te.get("dcodeOpenshellAvailable") is False
+    assert te.get("dcodeSupervisionFailReason") == "openshell absent"


### PR DESCRIPTION
Closes #3764

## Summary

- Extends the `dcodeSupervisionFeasible` block in `clawmetry/adapters/openclaw.py` to emit three new granular fields alongside the existing flag:
  - `dcodeSupervisionPlatformOk` — Linux platform check in isolation (`sys.platform.startswith("linux")`)
  - `dcodeOpenshellAvailable` — whether `openshell` is in PATH (`shutil.which("openshell")`)
  - `dcodeSupervisionFailReason` — human-readable string (`"non-linux platform"` or `"openshell absent"`) when feasibility is False, `None` when all conditions are met
- Adds 3 new test cases to the existing `test_obs_gap_nemoclaw_dcode_supervisor_3675.py` covering all-OK, non-Linux, and openshell-absent paths (7 tests total, all passing)

## Test plan

- [x] All 7 tests in `tests/test_obs_gap_nemoclaw_dcode_supervisor_3675.py` pass (`python3 -m pytest tests/test_obs_gap_nemoclaw_dcode_supervisor_3675.py -v`)
- [x] Existing 4 tests for `dcodeSupervisionFeasible` unmodified and still green
- [x] Change is additive only — no existing fields removed or altered
- [x] `dcodeSupervisionFailReason` is `None` (not absent) on the happy path, so consumers can safely check its truthiness

**Note:** Phase 2 (live event ingestion of signal-forwarding / bounded-wait transitions from the supervisor's log) remains out of scope — blocked until the supervisor's log path/schema is confirmed. This PR ships only the static enrichment fields that were explicitly noted as "ready to implement now" in the issue.

---
_Generated by [Claude Code](https://claude.ai/code/session_01P5vRXVTGFHhX2gDEkSuwDP)_