### PR TITLE
feat(fleet): gate multi-node JSON API on the "fleet" entitlement

### DIFF
--- a/routes/fleet_history.py
+++ b/routes/fleet_history.py
@@ -11,6 +11,13 @@ Owns the 5 routes registered on ``bp_fleet``:
     GET  /api/nodes                     — list all registered nodes
     GET  /api/nodes/<node_id>           — detail + 24h history for one node
 
+The 4 JSON API endpoints implement the ``fleet`` entitlement feature (a
+Starter+ paid capability) and are decorated with ``@gate("fleet")`` so
+enforce-mode installs on the OSS tier get a 402 ``upgrade_required``
+response instead of silently exercising a paid code path. The ``/fleet``
+HTML page is intentionally ungated — the UI itself renders the upgrade
+CTA in enforce mode so the shell stays reachable.
+
 Module-level helpers (``_fleet_db``, ``_fleet_db_lock``, ``_fleet_check_key``,
 ``_fleet_update_statuses``, ``_ext_emit``, ``FLEET_HTML``) stay in
 ``dashboard.py`` and are reached via late ``import dashboard as _d``.
@@ -21,6 +28,8 @@ import json
 import time
 
 from flask import Blueprint, jsonify, request
+
+from clawmetry._gate import gate
 
 bp_fleet = Blueprint('fleet', __name__)
 
@@ -36,6 +45,7 @@ def fleet_page():
 
 
 @bp_fleet.route("/api/nodes/register", methods=["POST"])
+@gate("fleet")
 def api_nodes_register():
     """Register or update a remote node."""
     import dashboard as _d
@@ -76,6 +86,7 @@ def api_nodes_register():
 
 
 @bp_fleet.route("/api/nodes/<node_id>/metrics", methods=["POST"])
+@gate("fleet")
 def api_nodes_push_metrics(node_id):
     """Receive metrics push from a remote node."""
     import dashboard as _d
@@ -104,6 +115,7 @@ def api_nodes_push_metrics(node_id):
 
 
 @bp_fleet.route("/api/nodes")
+@gate("fleet")
 def api_nodes_list():
     """List all registered nodes with latest metrics."""
     import dashboard as _d
@@ -193,6 +205,7 @@ def api_nodes_list():
 
 
 @bp_fleet.route("/api/nodes/<node_id>")
+@gate("fleet")
 def api_node_detail(node_id):
     """Get detailed info for a single node with metric history."""
     import dashboard as _d

--- a/tests/test_fleet_route_gates.py
+++ b/tests/test_fleet_route_gates.py
@@ -1,0 +1,192 @@
+"""Tests for entitlement gating on the fleet (multi-node) JSON API.
+
+Pins the 402 ``upgrade_required`` contract on the 4 endpoints registered by
+``routes.fleet_history.bp_fleet`` that implement the paid ``fleet`` feature.
+The ``/fleet`` HTML page is intentionally ungated so the shell stays
+reachable and can render an upgrade CTA -- see the module docstring on
+``routes/fleet_history.py``.
+
+Companion to ``tests/test_route_gates.py`` (feature gating for other paid
+surfaces) and ``tests/test_gate_runtime.py`` (runtime gating).
+"""
+from __future__ import annotations
+
+import importlib
+import json
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def enforce(monkeypatch, tmp_path):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def grace(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+def _make_app():
+    from routes.fleet_history import bp_fleet
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_fleet)
+    return app
+
+
+# ── Enforce mode: OSS install gets 402 on every JSON endpoint ────────────────
+
+
+@pytest.mark.parametrize(
+    "path,method",
+    [
+        ("/api/nodes/register", "POST"),
+        ("/api/nodes/node-abc/metrics", "POST"),
+        ("/api/nodes", "GET"),
+        ("/api/nodes/node-abc", "GET"),
+    ],
+)
+def test_fleet_json_endpoints_return_402_when_enforced(enforce, path, method):
+    """Every fleet JSON endpoint short-circuits with 402 on the OSS tier so
+    a paid feature never briefly executes in enforce mode. The gate fires
+    BEFORE any handler body — the fleet-key auth check, DuckDB open, etc.
+    are all downstream of it — so we never touch the daemon or DB in the
+    enforced-blocked path."""
+    app = _make_app()
+    with app.test_client() as c:
+        r = c.open(
+            path,
+            method=method,
+            data=json.dumps({}),
+            content_type="application/json",
+        )
+        assert r.status_code == 402, f"{method} {path} returned {r.status_code}"
+        body = r.get_json()
+        assert body["error"] == "upgrade_required"
+        assert body["feature"] == "fleet"
+        # required_tier lets the UI route to the correct upgrade CTA
+        # (Starter, not Pro or Enterprise -- fleet is a Starter-tier feature).
+        assert body["required_tier"] == enforce.TIER_CLOUD_STARTER
+
+
+def test_fleet_402_body_carries_current_tier(enforce):
+    """The 402 body includes ``tier`` = current install tier so the UI can
+    distinguish "OSS user hitting fleet" from "Trial expired" without a
+    second entitlement fetch."""
+    app = _make_app()
+    with app.test_client() as c:
+        r = c.get("/api/nodes")
+        assert r.status_code == 402
+        body = r.get_json()
+        assert body["tier"] == enforce.TIER_OSS
+
+
+# ── Grace mode: no gate short-circuit — request proceeds to handler body ─────
+
+
+@pytest.mark.parametrize(
+    "path,method",
+    [
+        ("/api/nodes/register", "POST"),
+        ("/api/nodes/node-abc/metrics", "POST"),
+        ("/api/nodes", "GET"),
+        ("/api/nodes/node-abc", "GET"),
+    ],
+)
+def test_fleet_json_endpoints_pass_in_grace_mode(grace, monkeypatch, path, method):
+    """Grace mode (default until the enforce-phase release) is transparent:
+    the gate lets every fleet call through unchanged. Downstream handler
+    behaviour is out of scope for this suite — we only need to prove the
+    gate did NOT short-circuit with 402. The write endpoints hit the
+    fleet-key auth check and return 401; the read endpoints reach the
+    handler body which we stub off to avoid needing a real DuckDB."""
+    # Stub out the dashboard helpers the read endpoints use so we don't need
+    # a running daemon / DuckDB. Any non-402 outcome is fine — we assert on
+    # "not 402" (the gate short-circuit) rather than 200 specifically.
+    import dashboard as _d
+
+    monkeypatch.setattr(_d, "_fleet_check_key", lambda _r: False, raising=False)
+    monkeypatch.setattr(_d, "_fleet_update_statuses", lambda: None, raising=False)
+
+    app = _make_app()
+    with app.test_client() as c:
+        r = c.open(
+            path,
+            method=method,
+            data=json.dumps({}),
+            content_type="application/json",
+        )
+        assert r.status_code != 402, (
+            f"{method} {path} returned 402 in grace mode — gate should be transparent"
+        )
+
+
+# ── /fleet HTML shell stays reachable so the UI can render its own CTA ───────
+
+
+def test_fleet_html_page_is_not_gated(enforce, monkeypatch):
+    """The ``/fleet`` HTML page is intentionally ungated. In enforce mode
+    the shell still loads so the front-end can render an upgrade CTA in
+    context — a 402 on the whole page would leave the user stranded with a
+    raw JSON error. Only the JSON API endpoints (which paid features
+    actually use) are gated."""
+    # Stub the FLEET_HTML constant so the handler doesn't need the full
+    # dashboard template to load in the test process.
+    import dashboard as _d
+
+    monkeypatch.setattr(_d, "FLEET_HTML", "<html>fleet</html>", raising=False)
+
+    app = _make_app()
+    with app.test_client() as c:
+        r = c.get("/fleet")
+        assert r.status_code != 402, (
+            "/fleet HTML must stay reachable in enforce mode so the UI can "
+            "render the upgrade CTA."
+        )
+
+
+# ── Defensive: entitlement lookup failure never blocks a fleet call ──────────
+
+
+def test_fleet_gate_never_raises_when_entitlement_lookup_fails(
+    enforce, monkeypatch
+):
+    """If the entitlement resolver itself raises, the gate swallows the
+    error and lets the request through — the audit chain still records
+    the call and the worst case is a paid feature briefly running on
+    Free. A flaky entitlement read must never break the request path."""
+    from clawmetry import entitlements
+
+    def _explode(*_args, **_kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(entitlements, "get_entitlement", _explode)
+
+    # Stub the dashboard helpers to avoid daemon/DB deps on the fallthrough.
+    import dashboard as _d
+
+    monkeypatch.setattr(_d, "_fleet_update_statuses", lambda: None, raising=False)
+
+    app = _make_app()
+    with app.test_client() as c:
+        r = c.get("/api/nodes")
+        assert r.status_code != 402, (
+            "Entitlement lookup errors must not surface as 402 — the gate "
+            "should fall through and let the handler run."
+        )


### PR DESCRIPTION
## Summary

- The 4 JSON endpoints on `bp_fleet` — `POST /api/nodes/register`, `POST /api/nodes/<node_id>/metrics`, `GET /api/nodes`, `GET /api/nodes/<node_id>` — implement the paid `fleet` feature (a Starter+ capability listed in `STARTER_FEATURES`), but were the only paid-feature routes in the tree that did NOT wear the `@gate(...)` decorator. `routes/alerts.py` and `routes/policy.py` already gate `budget_limits`, `custom_alerts`, `custom_webhooks`, and `approval_queue`; `bp_fleet` was the last unhooked paid surface.
- Wire `@gate("fleet")` onto the 4 JSON endpoints so an enforce-mode OSS install gets a structured 402 `upgrade_required` response (with the correct `required_tier=cloud_starter`, so the UI can render the right upgrade CTA) instead of silently exercising a paid code path.
- **Zero behaviour change today:** the gate is transparent in grace mode — which is the default until the enforce-phase release — so this PR does not affect any live install. Adds tests that pin the enforce-mode 402 contract and the grace-mode transparency so a later enforce flip has a covered target.
- The `/fleet` HTML page stays intentionally ungated. In enforce mode the shell still loads so the frontend can render the upgrade CTA in context — a 402 on the whole page would leave the user stranded with a raw JSON error instead of a navigable page. Only the JSON API (which paid features actually use) is gated.

## Test plan

- [x] `python3 -m py_compile routes/fleet_history.py tests/test_fleet_route_gates.py`
- [x] `python3 -m pytest tests/test_fleet_route_gates.py -q` → 11 passed
- [x] `python3 -m pytest tests/test_route_gates.py tests/test_gate_runtime.py tests/test_fleet_route_gates.py -q` → 54 passed / 1 pre-existing failure on `tests/test_route_gates.py::test_gated_route_returns_402_when_enforced[/api/assets-GET]` (this failure exists on `origin/main` unchanged — `routes/assets.py` is missing `@gate("asset_registry")`, tracked separately)
- [x] `python3 -m pytest tests/test_entitlement_api.py tests/test_entitlements_min_tier_nodes.py tests/test_entitlement_node_count.py -q` → 52 passed (entitlement suite unaffected)
- [ ] CI matrix green on this branch

### Coverage the new tests pin

- Enforce mode: every JSON endpoint returns 402 with `feature="fleet"`, `required_tier=TIER_CLOUD_STARTER`, and the current `tier` in the body.
- Grace mode: gate is transparent on every endpoint (dashboard helpers stubbed off so no daemon/DB dependency).
- `/fleet` HTML page stays reachable in enforce mode.
- Defensive fallthrough: an entitlement-lookup crash does not surface as 402 (mirrors the `tests/test_route_gates.py` contract).

### Local operator verification checklist

The daemon and live-cloud paths can only be exercised on the operator's host, not from this remote session. Please run:

- [ ] Copy changed files into your installed site-packages:
  ```
  SITE=$(python3 -c 'import clawmetry, os; print(os.path.dirname(os.path.dirname(clawmetry.__file__)))')
  cp routes/fleet_history.py "$SITE/routes/fleet_history.py"
  find "$SITE" -type d -name __pycache__ -exec rm -rf {} +
  ```
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
- [ ] Grace mode (default) unchanged: `curl -s http://localhost:8900/api/nodes | jq .` still returns the fleet payload as before.
- [ ] Enforce mode fires 402: `CLAWMETRY_ENFORCE=1 launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` then `curl -s -o /dev/null -w '%{http_code}\n' http://localhost:8900/api/nodes` → `402`; body contains `"feature":"fleet"` and `"required_tier":"cloud_starter"`.
- [ ] `/fleet` HTML page still loads under enforce mode: `curl -s -o /dev/null -w '%{http_code}\n' http://localhost:8900/fleet` → `200` (or whatever the current OK is), NOT `402`.
- [ ] Decrypt the live cloud snapshot and confirm nothing regressed on `/api/nodes` in the browser.
- [ ] Ready-for-review-by-operator once local + browser checks pass (kept DRAFT here — do not merge remotely).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011i7SYzn77B37siHZ1Y4scT)_