### PR TITLE
feat(assets): gate the 4 bp_assets JSON endpoints on the "asset_registry" entitlement

### DIFF
--- a/routes/assets.py
+++ b/routes/assets.py
@@ -15,6 +15,8 @@ import uuid
 
 from flask import Blueprint, jsonify, request
 
+from clawmetry._gate import gate
+
 logger = logging.getLogger("clawmetry.routes.assets")
 
 bp_assets = Blueprint("assets", __name__)
@@ -54,6 +56,7 @@ def _try_store_call(method_name: str, **kwargs):
 
 
 @bp_assets.route("/api/assets", methods=["GET"])
+@gate("asset_registry")
 def list_assets():
     """List assets newest-first.
 
@@ -81,6 +84,7 @@ def list_assets():
 
 
 @bp_assets.route("/api/assets/<asset_id>", methods=["GET"])
+@gate("asset_registry")
 def get_asset(asset_id: str):
     """Return one asset by id, or 404."""
     asset = _try_store_call("get_asset", asset_id=asset_id)
@@ -90,6 +94,7 @@ def get_asset(asset_id: str):
 
 
 @bp_assets.route("/api/assets", methods=["POST"])
+@gate("asset_registry")
 def create_asset():
     """Create or upsert an asset.
 
@@ -123,6 +128,7 @@ def create_asset():
 
 
 @bp_assets.route("/api/assets/<asset_id>/review", methods=["POST"])
+@gate("asset_registry")
 def review_asset(asset_id: str):
     """Approve or reject an asset.
 

--- a/tests/test_assets_route_gates.py
+++ b/tests/test_assets_route_gates.py
@@ -1,0 +1,174 @@
+"""Enforce-mode contract tests for the ``bp_assets`` JSON API.
+
+``asset_registry`` is a Pro-only feature (see ``PRO_ONLY_FEATURES`` in
+``clawmetry/entitlements.py``). All four JSON endpoints on ``bp_assets``
+(list, get one, create, review) implement it, so they all wear the
+``@gate("asset_registry")`` decorator.
+
+These tests pin two things so a future edit can't silently break the
+tier story:
+
+  1. Enforce mode: each endpoint returns a 402 ``upgrade_required``
+     body with ``feature="asset_registry"`` and
+     ``required_tier=TIER_CLOUD_PRO``. The gate check fires before any
+     handler code runs, so the 402 short-circuits before the daemon /
+     DuckDB path is even touched — no ``_try_store_call`` monkeypatch
+     needed.
+  2. Grace mode: the gate is transparent. The endpoint doesn't
+     short-circuit with 402; whatever the downstream handler returns
+     (200 empty list, 4xx bad request, 5xx if the daemon is off) wins.
+
+Companion to ``tests/test_route_gates.py`` (which pins the same contract
+for one representative endpoint) and follows the same pattern used for
+``bp_alerts`` and ``bp_policy`` gates.
+"""
+from __future__ import annotations
+
+import importlib
+import json
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def enforce(monkeypatch, tmp_path):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def grace(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+def _app_with_assets_bp():
+    from routes.assets import bp_assets
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_assets)
+    return app
+
+
+# ── enforce mode: 402 on every JSON endpoint ─────────────────────────────────
+
+
+_ENFORCE_MATRIX = [
+    ("GET", "/api/assets", None),
+    ("GET", "/api/assets/asset-abc", None),
+    ("POST", "/api/assets", {"asset_type": "skill", "name": "hello"}),
+    ("POST", "/api/assets/asset-abc/review", {"action": "approve"}),
+]
+
+
+@pytest.mark.parametrize("method,path,body", _ENFORCE_MATRIX)
+def test_assets_endpoint_returns_402_when_enforced(enforce, method, path, body):
+    app = _app_with_assets_bp()
+    with app.test_client() as c:
+        r = c.open(
+            path,
+            method=method,
+            data=json.dumps(body) if body is not None else None,
+            content_type="application/json" if body is not None else None,
+        )
+        assert r.status_code == 402, (
+            f"{method} {path} returned {r.status_code}, expected 402 "
+            "(gate should short-circuit before handler runs)"
+        )
+        payload = r.get_json()
+        assert payload["error"] == "upgrade_required"
+        assert payload["feature"] == "asset_registry"
+        assert payload["required_tier"] == enforce.TIER_CLOUD_PRO
+        # ``tier`` reflects the caller's current tier so the UI can render
+        # the delta ("you have X, upgrade to Y"). On an OSS install with no
+        # license, this is TIER_OSS.
+        assert payload["tier"] == enforce.TIER_OSS
+
+
+# ── grace mode: gate is transparent on every JSON endpoint ───────────────────
+
+
+@pytest.mark.parametrize("method,path,body", _ENFORCE_MATRIX)
+def test_assets_endpoint_is_transparent_in_grace_mode(
+    monkeypatch, grace, method, path, body
+):
+    # Stub the DuckDB path so the handler returns deterministically in-process
+    # without needing the sync daemon or a real store. The gate should be a
+    # no-op in grace mode; the stub just proves the handler ran through.
+    def _stub_try_store_call(method_name, **kwargs):
+        if method_name == "get_asset":
+            return {"id": kwargs.get("asset_id"), "asset_type": "skill"}
+        if method_name == "query_assets":
+            return []
+        if method_name == "ingest_asset":
+            return True
+        if method_name == "update_asset_status":
+            return True
+        return None
+
+    import routes.assets as _assets_mod
+    monkeypatch.setattr(_assets_mod, "_try_store_call", _stub_try_store_call)
+
+    app = _app_with_assets_bp()
+    with app.test_client() as c:
+        r = c.open(
+            path,
+            method=method,
+            data=json.dumps(body) if body is not None else None,
+            content_type="application/json" if body is not None else None,
+        )
+        assert r.status_code != 402, (
+            f"{method} {path} 402'd in grace mode; gate is not transparent"
+        )
+
+
+# ── enforce mode: 402 wins over routing errors on the JSON endpoints ─────────
+
+
+def test_enforce_mode_402_precedes_json_validation(enforce):
+    """Gate must fire before body validation. A POST with a missing required
+    field would normally 400; in enforce mode it should still 402 so the UI
+    renders the upgrade CTA, not a validation error."""
+    app = _app_with_assets_bp()
+    with app.test_client() as c:
+        r = c.post("/api/assets", json={})  # missing asset_type + name
+        assert r.status_code == 402
+        assert r.get_json()["feature"] == "asset_registry"
+
+
+# ── defensive: an entitlement-lookup crash falls through, does NOT 402 ──────
+
+
+def test_entitlement_lookup_crash_falls_through(monkeypatch, enforce):
+    """Mirrors the contract in tests/test_route_gates.py: if the entitlement
+    read itself raises, the request path stays defensive and the handler
+    runs — the worst that happens is a paid feature briefly runs on a Free
+    tier. A flaky entitlement check must never fail closed."""
+    def _explode():
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr("clawmetry.entitlements.get_entitlement", _explode)
+
+    def _stub_try_store_call(method_name, **kwargs):
+        return [] if method_name == "query_assets" else None
+
+    import routes.assets as _assets_mod
+    monkeypatch.setattr(_assets_mod, "_try_store_call", _stub_try_store_call)
+
+    app = _app_with_assets_bp()
+    with app.test_client() as c:
+        r = c.get("/api/assets")
+        assert r.status_code != 402


### PR DESCRIPTION
## Summary

- The 4 JSON endpoints on `bp_assets` — `GET /api/assets`, `GET /api/assets/<asset_id>`, `POST /api/assets`, `POST /api/assets/<asset_id>/review` — implement the paid `asset_registry` feature (a Pro-only capability listed in `PRO_ONLY_FEATURES`), but were the last paid-feature routes in the tree that did NOT wear the `@gate(...)` decorator. `routes/alerts.py`, `routes/policy.py`, and `routes/fleet_history.py` (via #3775) already gate their paid surfaces; this closes the matching hole on `bp_assets` — and `@gate("asset_registry")` is even the canonical example in the `clawmetry/_gate.py` docstring.
- Wire `@gate("asset_registry")` onto the 4 endpoints so an enforce-mode OSS install gets a structured 402 `upgrade_required` response (with `required_tier=cloud_pro`, so the UI can render the right upgrade CTA) instead of silently exercising a paid code path.
- **Zero behaviour change today:** the gate is transparent in grace mode — which is the default until the enforce-phase release — so this PR does not affect any live install. Adds `tests/test_assets_route_gates.py` that pins the enforce-mode 402 contract and the grace-mode transparency so a later enforce flip has a covered target.
- Also fixes the pre-existing failure on `tests/test_route_gates.py::test_gated_route_returns_402_when_enforced[/api/assets-GET]` that PR #3775 called out ("routes/assets.py is missing `@gate("asset_registry")`, tracked separately").

## Test plan

- [x] `python3 -m py_compile routes/assets.py tests/test_assets_route_gates.py`
- [x] `python3 -m pytest tests/test_assets_route_gates.py -q` → 10 passed
- [x] `python3 -m pytest tests/test_route_gates.py tests/test_gate_runtime.py tests/test_assets_route_gates.py tests/test_entitlement_api.py -q` → 86 passed (including the previously-failing `test_gated_route_returns_402_when_enforced[/api/assets-GET]`)
- [x] Regression sweep vs. `origin/main`: on pristine main = 11 failed / 307 passed; with this PR = 10 failed / 318 passed. The 10 remaining failures are pre-existing infrastructure issues (missing optional deps like `duckdb`), unchanged by this PR.
- [ ] CI matrix green on this branch

### Coverage the new tests pin

- **Enforce mode:** every JSON endpoint returns 402 with `feature="asset_registry"`, `required_tier=TIER_CLOUD_PRO`, and the caller's current `tier` in the body.
- **Grace mode:** gate is transparent on every endpoint (`_try_store_call` stubbed off so no daemon/DB dependency).
- **Precedence:** in enforce mode the 402 fires *before* body validation on `POST /api/assets` — an empty body would normally 400, but the upgrade CTA has to win so the UI can render it.
- **Defensive fallthrough:** an entitlement-lookup crash does not surface as 402 (mirrors the contract in `tests/test_route_gates.py::test_gate_decorator_never_raises_when_entitlement_lookup_fails`).

### Local operator verification checklist

The daemon and live-cloud paths can only be exercised on the operator's host, not from this remote session. Please run:

- [ ] Copy changed files into your installed site-packages:
  ```
  SITE=$(python3 -c 'import clawmetry, os; print(os.path.dirname(os.path.dirname(clawmetry.__file__)))')
  cp routes/assets.py "$SITE/routes/assets.py"
  find "$SITE" -type d -name __pycache__ -exec rm -rf {} +
  ```
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
- [ ] Grace mode (default) unchanged: `curl -s http://localhost:8900/api/assets | jq .` still returns the asset payload as before.
- [ ] Enforce mode fires 402: `CLAWMETRY_ENFORCE=1 launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` then `curl -s -o /dev/null -w '%{http_code}\n' http://localhost:8900/api/assets` → `402`; body contains `"feature":"asset_registry"` and `"required_tier":"cloud_pro"`.
- [ ] Enforce mode still 402 on the write endpoints: `curl -s -o /dev/null -w '%{http_code}\n' -X POST -H 'content-type: application/json' -d '{}' http://localhost:8900/api/assets` → `402` (NOT `400` — the gate has to win over body validation).
- [ ] Decrypt the live cloud snapshot and confirm nothing regressed on `/api/assets` in the browser.
- [ ] Ready-for-review-by-operator once local + browser checks pass (kept DRAFT here — do not merge remotely).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RAtMGDeFjboadGf467LJw3)_