### PR TITLE
feat(claudecode): gate bp_claudecode JSON endpoints on the "claude_code" runtime

### DIFF
--- a/dashboard_claudecode.py
+++ b/dashboard_claudecode.py
@@ -40,6 +40,8 @@ from flask import (
     request,
 )
 
+from clawmetry._gate import gate_runtime
+
 __version__ = "0.1.0"
 
 logger = logging.getLogger("clawmetry.claudecode")
@@ -631,6 +633,7 @@ def index():
 
 
 @bp_claudecode.route("/api/sessions")
+@gate_runtime("claude_code")
 def api_sessions():
     """List all Claude Code sessions with metadata."""
     sessions = _get_sessions_cached()
@@ -649,6 +652,7 @@ def api_sessions():
 
 
 @bp_claudecode.route("/api/session/<session_id>")
+@gate_runtime("claude_code")
 def api_session_detail(session_id: str):
     """Return detailed parsed transcript for a session."""
     fpath = _resolve_session_path(session_id)
@@ -662,12 +666,14 @@ def api_session_detail(session_id: str):
 
 
 @bp_claudecode.route("/api/analytics")
+@gate_runtime("claude_code")
 def api_analytics():
     """Aggregated analytics across all Claude Code sessions."""
     return jsonify(_compute_analytics())
 
 
 @bp_claudecode.route("/api/projects")
+@gate_runtime("claude_code")
 def api_projects():
     """List all detected Claude Code projects."""
     projects_dir = _get_claude_projects_dir()

--- a/tests/test_claudecode_runtime_gate.py
+++ b/tests/test_claudecode_runtime_gate.py
@@ -1,0 +1,175 @@
+"""Runtime-gate wiring for ``bp_claudecode`` JSON endpoints.
+
+The Claude Code dashboard variant (``dashboard_claudecode.py``) is the first
+route surface to gate on a *runtime* rather than a *feature*. It uses
+``@gate_runtime("claude_code")`` because ``claude_code`` sits in
+``PAID_RUNTIMES`` — every non-``openclaw``/``nemoclaw`` runtime ships in the
+closed-source ``clawmetry-pro`` package.
+
+Pins the same contract ``tests/test_gate_runtime.py`` already covers on
+synthetic Flask views, but on the real blueprint that ``dashboard.py``
+registers:
+
+* Enforce mode + OSS-free install → every JSON endpoint returns 402 with
+  ``feature="upgrade_required"``, ``runtime="claude_code"``, and
+  ``required_tier=cloud_starter`` (mirrors ``routes/fleet_history.py`` /
+  ``routes/assets.py`` in what the frontend can key off).
+* Grace mode (the default) → the gate is transparent so the request path is
+  unchanged. Wiring the gate in must not shift any current behaviour.
+* The ``/`` HTML shell and ``/favicon.ico`` stay reachable in enforce mode
+  so the frontend can render an upgrade CTA in context, matching the choice
+  ``routes/fleet_history.py`` made for ``/fleet``.
+* A crashing entitlement read never surfaces as 402 — mirrors the
+  defensive-fallthrough contract in ``tests/test_route_gates.py``.
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def enforce(monkeypatch, tmp_path):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def grace(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+def _make_app():
+    from dashboard_claudecode import bp_claudecode
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_claudecode)
+    return app
+
+
+# JSON endpoints that must go through @gate_runtime("claude_code"). The
+# ``/`` HTML shell and ``/favicon.ico`` are intentionally NOT here.
+_GATED_JSON = [
+    ("/api/sessions", "GET"),
+    ("/api/session/sid-123", "GET"),
+    ("/api/analytics", "GET"),
+    ("/api/projects", "GET"),
+]
+
+
+@pytest.mark.parametrize("path,method", _GATED_JSON)
+def test_bp_claudecode_json_returns_402_when_enforced(enforce, path, method):
+    app = _make_app()
+    with app.test_client() as c:
+        r = c.open(path, method=method)
+        assert r.status_code == 402, f"{method} {path} → {r.status_code}"
+        body = r.get_json()
+        assert body["error"] == "upgrade_required"
+        assert body["runtime"] == "claude_code"
+        assert body["required_tier"] == enforce.TIER_CLOUD_STARTER
+        assert "hint" in body
+        # The current tier is echoed so the UI can render "You're on
+        # <tier>. Upgrade to <required_tier> to unlock claude_code."
+        assert "tier" in body
+
+
+@pytest.mark.parametrize("path,method", _GATED_JSON)
+def test_bp_claudecode_json_transparent_in_grace_mode(grace, path, method):
+    """Grace mode is the default until enforcement flips on; the wiring
+    must not shift any current request path. The downstream handler may
+    return anything from 200-empty to 500 depending on filesystem state --
+    we only need to confirm the gate did NOT short-circuit with 402."""
+    app = _make_app()
+    with app.test_client() as c:
+        r = c.open(path, method=method)
+        assert r.status_code != 402, (
+            f"{method} {path} unexpectedly gated in grace mode: {r.status_code}"
+        )
+
+
+def test_bp_claudecode_html_index_stays_reachable_in_enforce_mode(enforce):
+    """The ``/`` HTML shell has to load in enforce mode so the frontend can
+    render an upgrade CTA in context. A 402 on the whole page would leave
+    the user stranded with a raw JSON error instead of a navigable page.
+    Mirrors what ``routes/fleet_history.py`` does for ``/fleet``."""
+    app = _make_app()
+    with app.test_client() as c:
+        r = c.get("/")
+        # Any 2xx is fine (200 today). What matters is that it's NOT 402.
+        assert r.status_code != 402
+
+
+def test_bp_claudecode_favicon_stays_reachable_in_enforce_mode(enforce):
+    """The favicon is a static asset the browser fetches whenever the HTML
+    shell loads. Gating it would leak a 402 into the network tab on every
+    page load even after the user has dismissed the upgrade CTA."""
+    app = _make_app()
+    with app.test_client() as c:
+        r = c.get("/favicon.ico")
+        assert r.status_code != 402
+
+
+def test_bp_claudecode_health_stays_reachable_in_enforce_mode(enforce):
+    """The ``/api/health`` endpoint is a diagnostics probe (does the
+    process see the Claude Code home?). Gating it would make the frontend
+    unable to distinguish "runtime not installed" from "not entitled",
+    both of which the CTA needs to render differently."""
+    app = _make_app()
+    with app.test_client() as c:
+        r = c.get("/api/health")
+        assert r.status_code != 402
+
+
+def test_bp_claudecode_gate_swallows_entitlement_lookup_errors(
+    enforce, monkeypatch
+):
+    """A flaky entitlement read must never break the request path -- the
+    worst that happens is a paid runtime briefly serves a Free tier.
+    Mirrors ``tests/test_gate_runtime.py::
+    test_gate_runtime_never_raises_when_entitlement_lookup_fails``."""
+
+    def explode():
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr("clawmetry.entitlements.get_entitlement", explode)
+
+    app = _make_app()
+    with app.test_client() as c:
+        # Any of the gated JSON paths — a lookup crash falls through, so we
+        # should see the downstream handler run (may be 2xx or 5xx, but
+        # never 402).
+        r = c.get("/api/sessions")
+        assert r.status_code != 402
+
+
+def test_bp_claudecode_gate_precedes_downstream_errors_in_enforce_mode(
+    enforce,
+):
+    """A path parameter that would normally hit a downstream 404 (session
+    not found) must still return 402 in enforce mode -- the upgrade CTA
+    has to win, otherwise the UI would render "session not found" for a
+    non-entitled user instead of the upgrade path. Mirrors the assets PR:
+    ``@gate`` precedes body validation on ``POST /api/assets``."""
+    app = _make_app()
+    with app.test_client() as c:
+        # Non-existent session id would normally 404 downstream.
+        r = c.get("/api/session/does-not-exist")
+        assert r.status_code == 402
+        body = r.get_json()
+        assert body["error"] == "upgrade_required"
+        assert body["runtime"] == "claude_code"


### PR DESCRIPTION
## Summary

- The 4 JSON endpoints on `bp_claudecode` — `GET /api/sessions`, `GET /api/session/<id>`, `GET /api/analytics`, `GET /api/projects` — serve the paid `claude_code` runtime (a member of `PAID_RUNTIMES`), but were the first route surface in the tree to gate on a **runtime** rather than a **feature key**. `clawmetry/_gate.py` documents `gate_runtime()` and `require_runtime()` as the sibling of `gate()` for exactly this case, and `tests/test_gate_runtime.py` already pins the 402 contract on synthetic Flask views — this closes the matching hole by wiring `@gate_runtime("claude_code")` onto the real blueprint.
- The `/` HTML shell, `/favicon.ico`, and `/api/health` stay intentionally ungated, mirroring the decision `routes/fleet_history.py` (via #3775) made for `/fleet`: in enforce mode the frontend has to load its shell + diagnostics so it can render the upgrade CTA in context. A 402 on the whole page would leave the user stranded with a raw JSON error instead of a navigable page, and gating the favicon would leak a 402 into the network tab on every page load.
- **Zero behaviour change today:** the gate is transparent in grace mode — which is the default until the enforce-phase release — so this PR does not affect any live install. Adds `tests/test_claudecode_runtime_gate.py` that pins the enforce-mode 402 contract and the grace-mode transparency so a later enforce flip has a covered target.

## Test plan

- [x] `python3 -m py_compile dashboard_claudecode.py tests/test_claudecode_runtime_gate.py`
- [x] `python3 -m pytest tests/test_claudecode_runtime_gate.py -q` → 13 passed
- [x] `python3 -m pytest tests/test_gate_runtime.py tests/test_claudecode_runtime_gate.py tests/test_route_gates.py -q` → 56 passed / 1 pre-existing failure on `tests/test_route_gates.py::test_gated_route_returns_402_when_enforced[/api/assets-GET]` (this failure exists on `origin/main` unchanged — `routes/assets.py` is missing `@gate("asset_registry")`, tracked separately by #3776)
- [x] Regression sweep — existing Claude Code test suites unchanged: `python3 -m pytest tests/test_claudecode.py tests/test_claudecode_loads_plugins.py -q` → 23 passed
- [ ] CI matrix green on this branch

### Coverage the new tests pin

- **Enforce mode:** every JSON endpoint returns 402 with `error="upgrade_required"`, `runtime="claude_code"`, `required_tier=TIER_CLOUD_STARTER`, and the caller's current `tier` in the body.
- **Grace mode:** gate is transparent on every JSON endpoint (the downstream handler runs; the assertion only pins "not 402").
- **HTML shell + favicon + health:** stay reachable in enforce mode so the frontend can render the upgrade CTA in context and distinguish "runtime not installed" from "not entitled".
- **Precedence:** in enforce mode the 402 fires *before* the downstream 404 on `GET /api/session/does-not-exist` — the upgrade CTA has to win, otherwise the UI would render "session not found" for a non-entitled user instead of the upgrade path. Same precedence stance `bp_assets` takes on `POST /api/assets` in #3776.
- **Defensive fallthrough:** an entitlement-lookup crash does not surface as 402 (mirrors the contract in `tests/test_route_gates.py::test_gate_decorator_never_raises_when_entitlement_lookup_fails` and `tests/test_gate_runtime.py::test_gate_runtime_never_raises_when_entitlement_lookup_fails`).

### Local operator verification checklist

The daemon and live-cloud paths can only be exercised on the operator's host, not from this remote session. Please run:

- [ ] Copy changed files into your installed site-packages:
  ```
  SITE=$(python3 -c 'import clawmetry, os; print(os.path.dirname(os.path.dirname(clawmetry.__file__)))')
  cp dashboard_claudecode.py "$SITE/dashboard_claudecode.py"
  find "$SITE" -type d -name __pycache__ -exec rm -rf {} +
  ```
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
- [ ] Grace mode (default) unchanged: `curl -s http://localhost:8900/api/sessions | jq .` on the `bp_claudecode` mount point still returns the sessions payload as before. (The mount point depends on how `bp_claudecode` is registered — see `dashboard.py`; may be `/` or `/claudecode`.)
- [ ] Enforce mode fires 402: `CLAWMETRY_ENFORCE=1 launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` then `curl -s -o /dev/null -w '%{http_code}\n' http://localhost:8900/api/sessions` → `402`; body contains `"runtime":"claude_code"` and `"required_tier":"cloud_starter"`.
- [ ] `/` HTML page still loads under enforce mode: `curl -s -o /dev/null -w '%{http_code}\n' http://localhost:8900/` → `200`, NOT `402`.
- [ ] `/api/health` still reachable under enforce mode: `curl -s http://localhost:8900/api/health | jq .` returns the health payload — needed so the CTA can render "runtime not installed" differently from "not entitled".
- [ ] Decrypt the live cloud snapshot and confirm nothing regressed on the Claude Code dashboard in the browser.
- [ ] Ready-for-review-by-operator once local + browser checks pass (kept DRAFT here — do not merge remotely).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018cXW4SWLjLGV9wKh7e1ddy)_