### PR TITLE
fix: add ClickClack channel adapter (sync + entitlements + route)

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -143,6 +143,7 @@ ALL_CHANNELS: tuple[str, ...] = (
     "tlon",
     "synologychat",
     "nextcloudtalk",
+    "clickclack",
 )
 
 # Display labels for every known chat-channel adapter. Fallback for an
@@ -169,6 +170,7 @@ CHANNEL_LABELS = {
     "tlon": "Tlon",
     "synologychat": "Synology Chat",
     "nextcloudtalk": "Nextcloud Talk",
+    "clickclack": "ClickClack",
 }
 
 _TIER_ORDER = (

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -4893,6 +4893,7 @@ _CHANNEL_DIRS: tuple[str, ...] = (
     "tlon",
     "synologychat",
     "nextcloudtalk",
+    "clickclack",
 )
 
 # Filenames inside ``~/.openclaw/<channel>/`` that are NOT conversation

--- a/routes/channels.py
+++ b/routes/channels.py
@@ -2811,3 +2811,16 @@ def api_channel_nextcloud_talk():
         if fast is not None:
             return jsonify(fast)
     return _d._generic_channel_data("nextcloud-talk")
+
+
+@bp_channels.route("/api/channel/clickclack")
+def api_channel_clickclack():
+    """Issue #3781 — ingest ClickClack channel transcripts."""
+    import dashboard as _d
+    if _local_store_read_enabled():
+        fast = _try_local_store_provider_messages(
+            "clickclack", request.args.get("limit", 50, type=int),
+        )
+        if fast is not None:
+            return jsonify(fast)
+    return _d._generic_channel_data("clickclack")


### PR DESCRIPTION
Closes #3781

## Summary

- **`clawmetry/sync.py`** — add `"clickclack"` to `_CHANNEL_DIRS` so the daemon ingests `~/.openclaw/clickclack/*.jsonl` on every sync cycle
- **`clawmetry/entitlements.py`** — add `"clickclack"` to `ALL_CHANNELS` and `"ClickClack"` to `CHANNEL_LABELS`; the existing pin test (`test_all_channels_matches_sync_channel_dirs`) enforces these lists stay in lockstep
- **`routes/channels.py`** — add `GET /api/channel/clickclack` using the standard local-store fast-path → generic-fallback pattern (identical to `feishu`, `zalo`, `tlon`, etc.)

## Test plan

- `python3 -m pytest tests/test_entitlement_channel_catalog.py -q` — all 27 tests pass (pin test, label coverage test, catalogue shape tests)
- Manual: place a `.jsonl` file in `~/.openclaw/clickclack/` and confirm the Channels tab surfaces it after the next sync cycle

---
_Generated by [Claude Code](https://claude.ai/code/session_0137ayrCmkDYAzU66BDnvkF5)_