### PR TITLE
fix: surface gateway supervisor mode in host status (#3783)

### DIFF
--- a/clawmetry/adapters/openclaw.py
+++ b/clawmetry/adapters/openclaw.py
@@ -1303,14 +1303,16 @@ def _gateway_host_status() -> dict:
     details alongside the existing ``plugins`` list.
 
     Returns a dict with whichever fields are present:
-    - ``"gatewayHostName"``       — machine hostname
-    - ``"gatewayNetworkAddress"`` — primary network address / IP
-    - ``"gatewayHostOS"``         — OS name or platform string
-    - ``"gatewayHostRuntime"``    — runtime identifier (e.g. Node version)
-    - ``"gatewayHostUptime"``     — uptime in seconds
-    - ``"gatewayHostCPU"``        — CPU usage value or dict
-    - ``"gatewayHostMemory"``     — memory info (bytes or dict)
-    - ``"gatewayHostDisk"``       — disk info (bytes or dict)
+    - ``"gatewayHostName"``            — machine hostname
+    - ``"gatewayNetworkAddress"``      — primary network address / IP
+    - ``"gatewayHostOS"``              — OS name or platform string
+    - ``"gatewayHostRuntime"``         — runtime identifier (e.g. Node version)
+    - ``"gatewayHostUptime"``          — uptime in seconds
+    - ``"gatewayHostCPU"``             — CPU usage value or dict
+    - ``"gatewayHostMemory"``          — memory info (bytes or dict)
+    - ``"gatewayHostDisk"``            — disk info (bytes or dict)
+    - ``"gatewaySupervisorMode"``      — supervisor mode (e.g. ``"external"``)
+    - ``"gatewaySupervisorModeVersion"`` — restart-handoff contract version
 
     Returns ``{}`` when the RPC is unavailable or the response carries no
     host fields. Never raises.
@@ -1374,6 +1376,18 @@ def _gateway_host_status() -> dict:
         )
         if disk is not None:
             result["gatewayHostDisk"] = disk
+        supervisor_mode = (
+            payload.get("supervisorMode")
+            or payload.get("supervisor_mode")
+        )
+        if supervisor_mode:
+            result["gatewaySupervisorMode"] = str(supervisor_mode)
+        supervisor_mode_version = (
+            payload.get("supervisorModeVersion")
+            or payload.get("supervisor_mode_version")
+        )
+        if supervisor_mode_version:
+            result["gatewaySupervisorModeVersion"] = str(supervisor_mode_version)
         return result
     except Exception:
         return {}

--- a/tests/test_obs_gap_openclaw_supervisor_mode_3783.py
+++ b/tests/test_obs_gap_openclaw_supervisor_mode_3783.py
@@ -1,0 +1,92 @@
+"""Tests for issue #3783 — openclaw: external supervisor mode not surfaced.
+
+Verifies that _gateway_host_status() extracts supervisorMode /
+supervisorModeVersion from the gateway.status RPC payload and surfaces
+them on DetectResult.meta.
+
+Fingerprint: hgap-21ddd6b36b (used to dedupe — keep it in the body).
+"""
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _restore_sys_modules():
+    saved_dashboard = sys.modules.get("dashboard")
+    saved_adapter = sys.modules.get("clawmetry.adapters.openclaw")
+    yield
+    if saved_dashboard is None:
+        sys.modules.pop("dashboard", None)
+    else:
+        sys.modules["dashboard"] = saved_dashboard
+    if saved_adapter is None:
+        sys.modules.pop("clawmetry.adapters.openclaw", None)
+    else:
+        sys.modules["clawmetry.adapters.openclaw"] = saved_adapter
+
+
+def _make_mock_dashboard(rpc_return):
+    mod = types.ModuleType("dashboard")
+    mod._gw_ws_rpc = lambda method, params=None: rpc_return
+    sys.modules["dashboard"] = mod
+    return mod
+
+
+def _reload_adapter():
+    import clawmetry.adapters.openclaw as oc_mod
+    importlib.reload(oc_mod)
+    return oc_mod
+
+
+def test_supervisor_mode_external_extracted():
+    """supervisorMode='external' is surfaced as gatewaySupervisorMode."""
+    _make_mock_dashboard({
+        "hostName": "gw.local",
+        "supervisorMode": "external",
+        "supervisorModeVersion": "1",
+    })
+    oc = _reload_adapter()
+    result = oc._gateway_host_status()
+    assert result["gatewaySupervisorMode"] == "external"
+    assert result["gatewaySupervisorModeVersion"] == "1"
+
+
+def test_supervisor_mode_snake_case_fallback():
+    """supervisor_mode / supervisor_mode_version keys are also accepted."""
+    _make_mock_dashboard({
+        "hostname": "gw.local",
+        "supervisor_mode": "external",
+        "supervisor_mode_version": "2",
+    })
+    oc = _reload_adapter()
+    result = oc._gateway_host_status()
+    assert result["gatewaySupervisorMode"] == "external"
+    assert result["gatewaySupervisorModeVersion"] == "2"
+
+
+def test_absent_supervisor_fields_not_in_result():
+    """When gateway.status carries no supervisor fields, keys are absent."""
+    _make_mock_dashboard({
+        "hostName": "gw.local",
+        "os": "linux",
+    })
+    oc = _reload_adapter()
+    result = oc._gateway_host_status()
+    assert "gatewaySupervisorMode" not in result
+    assert "gatewaySupervisorModeVersion" not in result
+
+
+def test_supervisor_mode_without_version():
+    """supervisorMode present without a version → only mode key emitted."""
+    _make_mock_dashboard({
+        "supervisorMode": "external",
+    })
+    oc = _reload_adapter()
+    result = oc._gateway_host_status()
+    assert result["gatewaySupervisorMode"] == "external"
+    assert "gatewaySupervisorModeVersion" not in result


### PR DESCRIPTION
Closes #3783

## What

`_gateway_host_status()` (`clawmetry/adapters/openclaw.py`) reads eight fields from the `gateway.status` RPC but skipped `supervisorMode` / `supervisorModeVersion`. When `OPENCLAW_SUPERVISOR_MODE=external` is set, ClawMetry couldn't distinguish an externally-supervised gateway (where native restart/self-update is intentionally blocked) from a normal one — a blocked self-update would look like a fault.

## Changes

- **`clawmetry/adapters/openclaw.py`** — added two extractions at the end of `_gateway_host_status()`:
  - `supervisorMode` / `supervisor_mode` → `gatewaySupervisorMode`
  - `supervisorModeVersion` / `supervisor_mode_version` → `gatewaySupervisorModeVersion`
  - Updated docstring to document both new fields.
- **`tests/test_obs_gap_openclaw_supervisor_mode_3783.py`** (new) — 4 tests: camelCase keys extracted, snake_case fallback keys accepted, absent fields not present, mode without version.

## Test plan

- `python3 -m pytest tests/test_obs_gap_openclaw_supervisor_mode_3783.py` — 4/4 pass
- `python3 -m pytest tests/test_obs_gap_openclaw_gateway_host_status_3551.py` — 5/5 pass (no regression)

---
_Generated by [Claude Code](https://claude.ai/code/session_01D1mtUg2VcqfqKY22UPXDbS)_