### PR TITLE
feat(otel_export): migrate /api/otel/export to the shared @gate decorator

### DIFF
--- a/routes/otel_export.py
+++ b/routes/otel_export.py
@@ -15,6 +15,12 @@ permissive, so the endpoint is reachable today for evaluation.
 The mapping is intentionally simple: one ``LogRecord`` per event, body = a
 short label, attributes = session_id / event_type / role / tool_name / model.
 Trace-tree export (events as Spans) is the next refinement.
+
+Gating: the route uses the shared :func:`clawmetry._gate.gate` decorator
+so the 402 body carries the same ``feature`` / ``tier`` / ``required_tier``
+envelope every other paid-feature route returns. Callers who used to read
+``feature`` and ``required_tier`` off other 402 responses now get the same
+shape here.
 """
 
 from __future__ import annotations
@@ -23,26 +29,11 @@ import logging
 
 from flask import Blueprint, jsonify, request
 
-from clawmetry._paywall import upgrade_required_body
+from clawmetry._gate import gate
 
 logger = logging.getLogger("clawmetry.routes.otel_export")
 
 bp_otel_export = Blueprint("otel_export", __name__)
-
-
-def _entitlement_allows() -> tuple[bool, dict]:
-    """Whether this install may use OTel export. Grace lets everyone through;
-    after enforce, only Pro+ installs do (Pro/Enterprise on clawmetry.com/pricing).
-    Kept for backward compatibility with the route handler below; new gated
-    routes use the shared :func:`clawmetry._gate.gate` decorator instead."""
-    try:
-        from clawmetry import entitlements as _ent
-
-        en = _ent.get_entitlement()
-        return en.allows_feature("otel_export"), en.to_dict()
-    except Exception as exc:  # pragma: no cover
-        logger.warning("otel_export: entitlement read failed, defaulting open: %s", exc)
-        return True, {"tier": "oss", "grace": True}
 
 
 def _event_to_log_record(ev: dict) -> dict:
@@ -122,16 +113,11 @@ def _fetch_events(limit: int) -> list[dict]:
 
 
 @bp_otel_export.route("/api/otel/export", methods=["GET"])
+@gate("otel_export")
 def api_otel_export():
-    """OTLP/JSON export of recent events. Pro+ entitlement-gated; permissive
-    during the open-core grace period. Never raises."""
-    allowed, _ent = _entitlement_allows()
-    if not allowed:
-        return jsonify(upgrade_required_body(
-            "otel_export",
-            hint="OTel export is a Pro feature on clawmetry.com/pricing",
-        )), 402
-
+    """OTLP/JSON export of recent events. Pro+ entitlement-gated via the
+    shared :func:`clawmetry._gate.gate` decorator; permissive during the
+    open-core grace period. Never raises."""
     try:
         limit = max(1, min(int(request.args.get("limit", 200) or 200), 5000))
     except Exception:

--- a/tests/test_otel_export.py
+++ b/tests/test_otel_export.py
@@ -1,13 +1,12 @@
-"""Tests for routes/otel_export.py — Enterprise OTLP/JSON export.
+"""Tests for routes/otel_export.py — Pro+ OTLP/JSON export.
 
-Validates the envelope shape, event→LogRecord mapping, attribute encoding, and
-the entitlement gate (allowed in grace, blocked + 402 once enforced).
+Validates the envelope shape, event→LogRecord mapping, and attribute
+encoding. The entitlement-gate contract (grace passthrough + enforce 402)
+is pinned end-to-end in ``tests/test_otel_export_route_gate.py`` now that
+the route uses the shared ``@gate("otel_export")`` decorator instead of a
+hand-rolled ``_entitlement_allows()`` helper.
 """
 from __future__ import annotations
-
-import importlib
-
-import pytest
 
 import routes.otel_export as O
 
@@ -50,25 +49,3 @@ def test_missing_fields_dont_raise():
     assert rec["timeUnixNano"] == "0"
 
 
-def test_entitlement_allows_in_grace(monkeypatch):
-    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
-    import clawmetry.entitlements as e
-    importlib.reload(e)
-    e.invalidate()
-    allowed, ent = O._entitlement_allows()
-    assert allowed is True
-    assert ent["grace"] is True
-
-
-def test_entitlement_blocks_otel_for_oss_when_enforced(monkeypatch):
-    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
-    import clawmetry.entitlements as e
-    importlib.reload(e)
-    e.invalidate()
-    allowed, ent = O._entitlement_allows()
-    assert allowed is False
-    assert ent["grace"] is False
-    # cleanup so other tests aren't poisoned
-    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
-    importlib.reload(e)
-    e.invalidate()

--- a/tests/test_otel_export_route_gate.py
+++ b/tests/test_otel_export_route_gate.py
@@ -1,0 +1,241 @@
+"""Tests for the ``@gate("otel_export")`` migration on ``routes/otel_export.py``.
+
+Sibling of ``tests/test_fleet_route_gates.py``, ``tests/test_assets_route_gates.py``,
+and ``tests/test_claudecode_runtime_gate.py``. Pins:
+
+- Enforce mode returns the shared 402 ``upgrade_required`` envelope with
+  ``feature="otel_export"``, ``required_tier=cloud_pro``, ``tier`` = the
+  caller's current tier, and a ``hint`` string.
+- Grace mode is transparent: the downstream handler runs and returns the
+  OTLP-JSON envelope.
+- The gate fires *before* body building so an empty event list can't leak
+  through as a 200 in enforce mode.
+- A resolver crash never surfaces as 402 (mirrors the defensive contract
+  pinned in ``tests/test_route_gates.py``).
+- The 402 wire shape is byte-identical to what other ``@gate``d routes
+  return, so an existing front-end that already handles 402 keeps working
+  without a branch on ``feature=="otel_export"``.
+
+The unit tests for the envelope shape and event → LogRecord mapping stay
+in ``tests/test_otel_export.py`` since they don't touch the gate.
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+# ── fixtures ────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def enforce(monkeypatch, tmp_path):
+    """OSS install under ``CLAWMETRY_ENFORCE=1`` — the tier is oss/free and
+    ``otel_export`` (a Pro-only feature) is NOT allowed."""
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def grace(monkeypatch, tmp_path):
+    """Default grace mode — every feature key passes through the gate."""
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+def _make_app():
+    from routes.otel_export import bp_otel_export
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_otel_export)
+    return app
+
+
+# ── enforce mode: 402 contract ──────────────────────────────────────────────
+
+
+def test_otel_export_returns_402_when_enforced(enforce, monkeypatch):
+    """The route wears ``@gate("otel_export")`` so an OSS install in enforce
+    mode gets the shared 402 body instead of the OTLP envelope."""
+    # Belt-and-braces: even if _fetch_events were to succeed the gate must
+    # short-circuit before it. Stub it to something distinctive so a
+    # regression that dropped the decorator would produce a 200 with the
+    # sentinel in the body.
+    monkeypatch.setattr(
+        "routes.otel_export._fetch_events",
+        lambda limit: [{"ts": 0, "event_type": "gate_should_have_fired"}],
+    )
+    app = _make_app()
+    with app.test_client() as c:
+        r = c.get("/api/otel/export")
+        assert r.status_code == 402
+        body = r.get_json()
+        assert body["error"] == "upgrade_required"
+        assert body["feature"] == "otel_export"
+        # Current tier is echoed so the UI can distinguish "not entitled at
+        # all" from "entitled but on a downgrade path".
+        assert "tier" in body
+        # required_tier lets the paywall render the right upgrade CTA.
+        assert body["required_tier"] == enforce.TIER_CLOUD_PRO
+        assert isinstance(body.get("hint"), str) and body["hint"]
+        # No OTLP payload leaked through.
+        assert "resourceLogs" not in body
+
+
+def test_otel_export_402_body_shape_matches_shared_gate(enforce):
+    """The 402 body must carry the *same top-level keys* every other
+    ``@gate``d route returns so the front-end can handle any paid-feature
+    402 with one branch."""
+    from clawmetry._gate import gate as _gate
+
+    reference_app = Flask(__name__)
+
+    @reference_app.route("/reference")
+    @_gate("otel_export")
+    def _reference_view():
+        return {"ok": True}
+
+    otel_app = _make_app()
+
+    with reference_app.test_client() as rc, otel_app.test_client() as oc:
+        ref_body = rc.get("/reference").get_json()
+        oel_body = oc.get("/api/otel/export").get_json()
+        assert set(ref_body.keys()) == set(oel_body.keys())
+        # Envelope keys pinned so a later refactor of `@gate` doesn't
+        # silently drop `required_tier` or `tier`.
+        assert set(ref_body.keys()) == {
+            "error",
+            "feature",
+            "tier",
+            "required_tier",
+            "hint",
+        }
+        assert ref_body["feature"] == oel_body["feature"] == "otel_export"
+        assert ref_body["required_tier"] == oel_body["required_tier"]
+        assert ref_body["tier"] == oel_body["tier"]
+
+
+def test_otel_export_gate_fires_before_body_build(enforce):
+    """The gate has to short-circuit the request *before* ``_fetch_events``
+    runs. Otherwise a slow local-query call would still fire on every 402,
+    or an exception inside the daemon fetch would leak through as a 500
+    instead of the 402 the caller expects."""
+    from routes import otel_export as O
+
+    calls: list[int] = []
+
+    def _spy(limit):
+        calls.append(limit)
+        return []
+
+    original = O._fetch_events
+    O._fetch_events = _spy
+    try:
+        app = _make_app()
+        with app.test_client() as c:
+            r = c.get("/api/otel/export?limit=42")
+            assert r.status_code == 402
+            # The gate ran and short-circuited: the fetch never started.
+            assert calls == []
+    finally:
+        O._fetch_events = original
+
+
+def test_otel_export_gate_wins_over_query_string_error(enforce):
+    """Even a malformed ``?limit=`` value must not shadow the 402 — the
+    gate fires before the limit-parse fallthrough, so the enforcement
+    signal reaches the caller regardless of how they hit the URL."""
+    app = _make_app()
+    with app.test_client() as c:
+        r = c.get("/api/otel/export?limit=not-a-number")
+        assert r.status_code == 402
+
+
+# ── grace mode: transparent ──────────────────────────────────────────────────
+
+
+def test_otel_export_passes_in_grace_mode(grace, monkeypatch):
+    """Grace mode (the current default until the enforce-phase release)
+    must let the request through unchanged. The downstream handler builds
+    the OTLP-JSON envelope; the fetch is stubbed to keep the test hermetic."""
+    monkeypatch.setattr("routes.otel_export._fetch_events", lambda limit: [])
+    app = _make_app()
+    with app.test_client() as c:
+        r = c.get("/api/otel/export")
+        assert r.status_code == 200
+        body = r.get_json()
+        assert "resourceLogs" in body
+        assert isinstance(body["resourceLogs"], list)
+        # The pre-migration hand-rolled 402 body carried no `resourceLogs`,
+        # so seeing it here proves the gate stayed transparent AND the
+        # handler ran.
+
+
+def test_otel_export_grace_forwards_limit_to_fetch(grace, monkeypatch):
+    """Grace mode: the ``?limit=`` query param still reaches the fetch.
+    Pins that the migration didn't accidentally hard-code the limit."""
+    seen: list[int] = []
+
+    monkeypatch.setattr(
+        "routes.otel_export._fetch_events",
+        lambda limit: (seen.append(limit) or []),
+    )
+    app = _make_app()
+    with app.test_client() as c:
+        r = c.get("/api/otel/export?limit=17")
+        assert r.status_code == 200
+        assert seen == [17]
+
+
+# ── defensive fallthrough ────────────────────────────────────────────────────
+
+
+def test_otel_export_never_raises_when_entitlement_lookup_fails(
+    enforce, monkeypatch
+):
+    """If the entitlement read itself throws, the request must go through
+    (grace-fallback contract). Mirrors
+    ``tests/test_route_gates.py::test_gate_decorator_never_raises_when_entitlement_lookup_fails``."""
+    def _explode():
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr("clawmetry.entitlements.get_entitlement", _explode)
+    monkeypatch.setattr("routes.otel_export._fetch_events", lambda limit: [])
+
+    app = _make_app()
+    with app.test_client() as c:
+        r = c.get("/api/otel/export")
+        # Graceful fallthrough: 200 with the envelope, NOT 402 and NOT 5xx.
+        assert r.status_code == 200
+        assert "resourceLogs" in r.get_json()
+
+
+# ── legacy helper cleanup ────────────────────────────────────────────────────
+
+
+def test_legacy_entitlement_allows_helper_removed():
+    """The hand-rolled ``_entitlement_allows`` helper was removed as part
+    of the migration. This pin fails loudly if a well-meaning revert
+    reintroduces it, so the module has one and only one gate implementation
+    (the shared ``@gate`` decorator) going forward."""
+    from routes import otel_export as O
+
+    assert not hasattr(O, "_entitlement_allows"), (
+        "routes/otel_export.py should route entitlement checks through "
+        "@gate('otel_export'); the hand-rolled _entitlement_allows helper "
+        "must not come back."
+    )


### PR DESCRIPTION
## Summary

- `routes/otel_export.py` wore a hand-rolled `_entitlement_allows()` helper + hand-rolled 402 body -- one of the last two paid-feature routes in the tree that had not yet been migrated to the shared `@gate(...)` decorator introduced by `clawmetry/_gate.py`. The `_gate.py` docstring itself names this file (and `routes/audit.py`) as the last hand-rolled 402 patterns the shared decorator was written to replace:

  > "The error shape matches what `routes/audit.py` and `routes/otel_export.py` have been returning by hand for months, so existing front-ends that already handle 402 continue to work."

  This PR closes half of that pending consolidation on the `otel_export` side. `routes/audit.py` is intentionally left for a follow-up so the diff here stays surgical, mirroring the "one blueprint per PR" cadence of #3775 (`bp_fleet`), #3776 (`bp_assets`), and #3780 (`bp_claudecode`).

- **Zero behaviour change today:** the gate is transparent in grace mode -- which is the default until the enforce-phase release -- so no live install is affected. In enforce mode the 402 body now carries the same `feature` / `tier` / `required_tier` / `hint` envelope every other `@gate`d paid-feature route returns (Pro-only feature -> `required_tier=cloud_pro`), so a caller that already handles 402s from `bp_alerts`, `bp_policy`, `bp_assets`, or `bp_fleet` keeps working here without a special-case branch on `feature=="otel_export"`.

- The previous `hint` string was slightly different from the shared `@gate` copy. Migrating to `@gate` picks up the standard hint so all paid routes speak with one voice; the pre-existing tailored copy said essentially the same thing ("OTel export is a Pro feature on clawmetry.com/pricing") as the shared hint already does.

## Test plan

- [x] `python3 -m py_compile routes/otel_export.py tests/test_otel_export.py tests/test_otel_export_route_gate.py` -- clean
- [x] `python3 -m pytest tests/test_otel_export_route_gate.py tests/test_otel_export.py -q` -> **12 passed** in 0.48s
- [x] Sibling gate regression sweep: `python3 -m pytest tests/test_route_gates.py tests/test_gate_runtime.py tests/test_otel_export.py tests/test_otel_export_route_gate.py tests/test_entitlement_api.py tests/test_blueprint_uniqueness.py tests/test_circular_import.py -q` -> **97 passed / 1 pre-existing failure** on `tests/test_route_gates.py::test_gated_route_returns_402_when_enforced[/api/assets-GET]` (this failure exists on `origin/main` unchanged -- `routes/assets.py` is missing `@gate("asset_registry")`, tracked separately by open PR #3776)
- [ ] CI matrix green on this branch

### Coverage the new tests pin

- **Enforce mode:** `GET /api/otel/export` returns 402 with `error="upgrade_required"`, `feature="otel_export"`, `required_tier=TIER_CLOUD_PRO`, the caller's current `tier`, and a `hint` string.
- **Envelope parity:** the 402 body carries the *same top-level keys* the shared `@gate` decorator returns on a synthetic Flask view -- pins that a later refactor of `@gate` doesn't silently drop `required_tier` or `tier` on this route.
- **Grace mode:** gate is transparent; the downstream handler runs and returns the OTLP-JSON `resourceLogs` envelope. `?limit=17` still reaches `_fetch_events`.
- **Precedence (gate fires before body build):** with `_fetch_events` spied, the fetch never runs in enforce mode -- the 402 short-circuits before the local-query call.
- **Precedence (gate wins over malformed input):** `?limit=not-a-number` still returns 402 in enforce mode, not a body-parsing 200/400.
- **Defensive fallthrough:** an entitlement-lookup crash does not surface as 402 (mirrors the contract in `tests/test_route_gates.py::test_gate_decorator_never_raises_when_entitlement_lookup_fails`).
- **Legacy-helper regression pin:** asserts `routes.otel_export._entitlement_allows` no longer exists so a well-meaning revert that reintroduces the hand-rolled helper fails loudly.

## Follow-ups (not in this PR)

- `routes/audit.py` still hand-rolls `_allowed()` + a 402 body for the `audit_logs` (Enterprise-only) feature. Same migration to `@gate("audit_logs")` planned as a separate surgical PR so this diff stays focused on `bp_otel_export`.

### Local operator verification checklist

The daemon and live-cloud paths can only be exercised on the operator's host, not from this remote session. Please run:

- [ ] Copy changed files into your installed site-packages:
  ```
  SITE=$(python3 -c 'import clawmetry, os; print(os.path.dirname(os.path.dirname(clawmetry.__file__)))')
  cp routes/otel_export.py "$SITE/routes/otel_export.py"
  find "$SITE" -type d -name __pycache__ -exec rm -rf {} +
  ```
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
- [ ] Grace mode (default) unchanged: `curl -s 'http://localhost:8900/api/otel/export?limit=5' | jq '.resourceLogs | length'` still returns the OTLP envelope (>= 1 resourceLogs entry, scopeLogs / logRecords populated).
- [ ] Enforce mode fires 402: `CLAWMETRY_ENFORCE=1 launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` then `curl -s -o /dev/null -w '%{http_code}\n' http://localhost:8900/api/otel/export` -> `402`; body contains `"feature":"otel_export"` and `"required_tier":"cloud_pro"` (matches the 402 shape from `/api/assets`, `/api/nodes`, `/api/budget/*`).
- [ ] Enforce mode still 402 on malformed input: `curl -s -o /dev/null -w '%{http_code}\n' 'http://localhost:8900/api/otel/export?limit=not-a-number'` -> `402` (NOT 200 / 400 -- the gate has to win over the query-string parse).
- [ ] Decrypt the live cloud snapshot and confirm nothing regressed on `/api/otel/export` in the browser.
- [ ] Ready-for-review-by-operator once local + browser checks pass (kept DRAFT here -- do not merge remotely).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018ajRx9CPA4UvtxABpmPpRz)_