### PR TITLE
fix: stop dashboard import from closing sys.stdout (silent --help on Windows)

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -25,17 +25,18 @@ import sys
 # CI (issue surfaced by the bp_sessions refactor).
 sys.modules.setdefault("dashboard", sys.modules[__name__])
 
-# Force UTF-8 output on Windows (emoji in BANNER would crash with cp1252)
+# Force UTF-8 output on Windows (emoji in BANNER would crash with cp1252).
+# Must be reconfigure(), not a new TextIOWrapper around sys.stdout.buffer:
+# this block runs twice (the module header is duplicated inside this file),
+# and when the second wrapper replaces the first, the orphaned wrapper is
+# garbage-collected and closes the shared underlying buffer — leaving
+# sys.stdout closed for the rest of the process (silent --help, dead prints).
 if sys.platform == "win32":
     import io
 
     try:
-        sys.stdout = io.TextIOWrapper(
-            sys.stdout.buffer, encoding="utf-8", errors="replace"
-        )
-        sys.stderr = io.TextIOWrapper(
-            sys.stderr.buffer, encoding="utf-8", errors="replace"
-        )
+        sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+        sys.stderr.reconfigure(encoding="utf-8", errors="replace")
     except Exception:
         pass
 
@@ -8540,12 +8541,18 @@ MIT License
 import os
 import sys
 
-# Force UTF-8 output on Windows (emoji in BANNER would crash with cp1252)
+# Force UTF-8 output on Windows (emoji in BANNER would crash with cp1252).
+# reconfigure(), not a new TextIOWrapper — see the matching block at the top
+# of this file: a second wrapper orphans the first, whose GC finalizer closes
+# the shared buffer and kills sys.stdout for the whole process.
 if sys.platform == "win32":
     import io
 
-    sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding="utf-8", errors="replace")
-    sys.stderr = io.TextIOWrapper(sys.stderr.buffer, encoding="utf-8", errors="replace")
+    try:
+        sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+        sys.stderr.reconfigure(encoding="utf-8", errors="replace")
+    except Exception:
+        pass
 
 import threading
 from datetime import timezone, timedelta

--- a/tests/test_stdout_survives_import.py
+++ b/tests/test_stdout_survives_import.py
@@ -1,0 +1,71 @@
+"""Regression guard: importing dashboard must not close sys.stdout.
+
+dashboard.py's "Force UTF-8 output on Windows" blocks used to rebind
+sys.stdout / sys.stderr to fresh io.TextIOWrapper objects around the same
+underlying buffer. The module header appears twice in the file, so the
+second rebind orphaned the first wrapper; when the garbage collector
+finalized the orphan it closed the SHARED buffer, leaving sys.stdout
+closed for the rest of the process. Net effect on Windows: `clawmetry
+--help` printed nothing and exited 0, because clawmetry/cli.py's
+closed-handle guard then swapped the dead stream for a devnull sink.
+Fix: sys.stdout.reconfigure() in place, which is idempotent and never
+orphans a wrapper.
+
+Both tests run in a subprocess: the bug only manifests on a pristine
+import, and pytest's capture machinery would mask it in-process.
+"""
+import os
+import subprocess
+import sys
+
+import pytest
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+
+
+def _run(argv):
+    env = dict(os.environ)
+    env["CLAWMETRY_NO_TELEMETRY"] = "1"
+    env["PYTHONIOENCODING"] = "utf-8"
+    return subprocess.run(
+        argv,
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=180,
+    )
+
+
+def test_import_dashboard_keeps_stdout_open():
+    """A bare `import dashboard` must leave sys.stdout writable."""
+    code = (
+        "import gc, sys\n"
+        "import dashboard\n"
+        "gc.collect()\n"  # force-finalize any orphaned TextIOWrapper
+        "assert not sys.stdout.closed, 'dashboard import closed sys.stdout'\n"
+        "assert not sys.stderr.closed, 'dashboard import closed sys.stderr'\n"
+        "print('STDOUT_ALIVE')\n"
+    )
+    proc = _run([sys.executable, "-c", code])
+    assert proc.returncode == 0, f"stderr:\n{proc.stderr}"
+    assert "STDOUT_ALIVE" in proc.stdout, (
+        "print() after importing dashboard produced no output -- "
+        f"stdout was closed or redirected. stderr:\n{proc.stderr}"
+    )
+
+
+def test_cli_help_prints_usage():
+    """`clawmetry --help` must print usage text and exit 0 (was: silent)."""
+    proc = _run([sys.executable, "-m", "clawmetry", "--help"])
+    assert proc.returncode == 0, f"stderr:\n{proc.stderr}"
+    assert "usage" in proc.stdout.lower(), (
+        "--help printed nothing -- the closed-stdout-on-import bug is back. "
+        f"stdout={proc.stdout!r} stderr:\n{proc.stderr}"
+    )
+    assert "clawmetry" in proc.stdout.lower()
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary

- On Windows, `clawmetry --help` printed nothing and exited 0, and every post-import `print()` silently died. Root cause: the "Force UTF-8 output on Windows" block exists **twice** in `dashboard.py` (the module header is duplicated inside the file), and each rebound `sys.stdout`/`sys.stderr` to a fresh `io.TextIOWrapper` around the same underlying buffer. The second rebind orphaned the first wrapper; its GC finalizer then **closed the shared buffer**, leaving `sys.stdout` closed for the rest of the process.
- The symptom was masked: `clawmetry/cli.py`'s closed-handle guard (the pythonw/Task-Scheduler protection) detected the dead stream and swapped in a devnull sink, so argparse help went into the void with exit 0 instead of crashing with `ValueError: I/O operation on closed file` (which is what a bare `import dashboard; parser.print_help()` raises).
- Fix: `sys.stdout.reconfigure(encoding="utf-8", errors="replace")` in place at both sites. `reconfigure()` is idempotent and never orphans a wrapper, so running the block twice is harmless. Keeps the original intent (emoji in BANNER must not crash on cp1252).

## Test plan

- [x] Reproduced on Windows 11 / Python 3.13.14: fresh `pip install clawmetry` (0.12.556), `clawmetry --help` prints nothing, exits 0; `python -c "import dashboard; ..."` raises `ValueError: I/O operation on closed file` inside `print_help`
- [x] Confirmed mechanism empirically: after `import dashboard` + `gc.collect()`, `sys.stdout.closed` and `sys.__stdout__.closed` are both `True` on the un-fixed code
- [x] With the fix: `python -m clawmetry --help` prints 69 lines of usage, exit 0; `--version` prints `clawmetry 0.12.556`, exit 0; stdout stays open after import
- [x] Regression guard shipped in this PR: `tests/test_stdout_survives_import.py` (subprocess-based so pytest capture cannot mask it; hermetic via `CLAWMETRY_NO_TELEMETRY=1`)
- [x] Revert-proof per FLYWHEEL.md: `git stash` the `dashboard.py` fix, both tests FAIL; restore, both PASS
- [x] Dashboard still boots and serves after the change (HTTP 200 on `127.0.0.1:8900`, page title "ClawMetry")

Not covered: macOS/Linux behavior is unchanged (the touched blocks are `sys.platform == "win32"` gated); the new test still runs there as a cheap import-safety guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
