### PR TITLE
feat(error-triage): gate the 3 /api/error-triage/* routes on `error_triage` entitlement

### DIFF
--- a/routes/sessions.py
+++ b/routes/sessions.py
@@ -29,6 +29,7 @@ import csv
 from datetime import timezone
 from flask import Blueprint, jsonify, request, Response
 from clawmetry.config import is_local_store_read_enabled, hide_clawmetry_session
+from clawmetry._gate import gate
 from routes._dedupe import build_sibling_bucket_max, is_sibling_dup
 
 bp_sessions = Blueprint('sessions', __name__)
@@ -7456,6 +7457,7 @@ def _err_triage_event_id():
 
 
 @bp_sessions.route("/api/error-triage/resolve", methods=["POST"])
+@gate("error_triage")
 def api_error_triage_resolve():
     """Mark an error as resolved (idempotent — re-POST refreshes the note).
 
@@ -7481,6 +7483,7 @@ def api_error_triage_resolve():
 
 
 @bp_sessions.route("/api/error-triage/resolve", methods=["DELETE"])
+@gate("error_triage")
 def api_error_triage_unresolve():
     """Remove the resolved marker for an error.
 
@@ -7500,6 +7503,7 @@ def api_error_triage_unresolve():
 
 
 @bp_sessions.route("/api/error-triage/resolved")
+@gate("error_triage")
 def api_error_triage_resolved():
     """Return the current resolved-set as ``{event_id: {resolved_at, note}}``.
 

--- a/tests/test_error_triage_route_gate.py
+++ b/tests/test_error_triage_route_gate.py
@@ -1,0 +1,360 @@
+"""Tests for the ``@gate("error_triage")`` migration on the three
+``/api/error-triage/*`` routes in ``routes/sessions.py``.
+
+Sibling of ``tests/test_audit_route_gate.py``,
+``tests/test_otel_export_route_gate.py``, ``tests/test_fleet_route_gates.py``,
+``tests/test_assets_route_gates.py``, and
+``tests/test_cost_optimizer_route_gates.py``. Pins:
+
+- Enforce mode returns the shared 402 ``upgrade_required`` envelope with
+  ``feature="error_triage"``, ``required_tier=cloud_pro`` (error triage is
+  Pro-only, per ``PRO_ONLY_FEATURES`` in ``clawmetry/entitlements.py``),
+  ``tier`` = the caller's current tier, and a ``hint`` string.
+- The gate fires *before* the daemon-proxy read/write so a broken or absent
+  ``local_store_via_daemon`` cannot leak through as a 5xx in enforce mode.
+- The gate wins over the handler's own 400 branch (missing ``event_id``),
+  so an unauthenticated caller sees the upgrade CTA rather than an
+  argument-validation error.
+- Grace mode (the default until the enforce-phase release) is transparent:
+  the downstream handler runs and returns the ``{"ok": ...}`` /
+  ``{"resolved": ..., "count": ...}`` envelopes exactly as before.
+- A resolver crash never surfaces as 402 (mirrors the defensive contract
+  pinned in ``tests/test_route_gates.py``).
+- The 402 wire shape is byte-identical to what other ``@gate``d routes
+  return, so an existing front-end that already handles 402 keeps working
+  without a branch on ``feature=="error_triage"``.
+
+The behavioural tests for the store layer + the pre-migration Flask
+lifecycle stay in ``tests/test_error_triage.py`` since they don't touch
+the gate.
+"""
+from __future__ import annotations
+
+import importlib
+import inspect
+
+import pytest
+from flask import Flask
+
+
+# ── fixtures ────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def enforce(monkeypatch, tmp_path):
+    """OSS install under ``CLAWMETRY_ENFORCE=1`` — the tier is oss/free and
+    ``error_triage`` (a Pro-only feature) is NOT allowed."""
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def grace(monkeypatch, tmp_path):
+    """Default grace mode — every feature key passes through the gate."""
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+def _make_app():
+    from routes.sessions import bp_sessions
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_sessions)
+    return app
+
+
+# ── enforce mode: 402 contract ──────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "method,path",
+    [
+        ("POST", "/api/error-triage/resolve"),
+        ("DELETE", "/api/error-triage/resolve?event_id=ev:abc"),
+        ("GET", "/api/error-triage/resolved"),
+    ],
+)
+def test_error_triage_returns_402_when_enforced(
+    enforce, monkeypatch, method, path
+):
+    """Every route wears ``@gate("error_triage")`` so an OSS install in
+    enforce mode gets the shared 402 body instead of the handler payload."""
+    # Belt-and-braces: if the gate silently dropped, the daemon call below
+    # would produce a distinctive body — a well-meaning revert would fail
+    # loudly here.
+    def _sentinel(method_name, **_kw):
+        return {"gate_should_have_fired": True}
+
+    monkeypatch.setattr(
+        "routes.local_query.local_store_via_daemon", _sentinel, raising=False,
+    )
+
+    app = _make_app()
+    with app.test_client() as c:
+        if method == "POST":
+            r = c.post(path, json={"event_id": "ev:abc", "note": "hi"})
+        elif method == "DELETE":
+            r = c.delete(path)
+        else:
+            r = c.get(path)
+        assert r.status_code == 402
+        body = r.get_json()
+        assert body["error"] == "upgrade_required"
+        assert body["feature"] == "error_triage"
+        # Current tier is echoed so the UI can distinguish "not entitled at
+        # all" from "entitled but on a downgrade path".
+        assert "tier" in body
+        # required_tier lets the paywall render the right upgrade CTA.
+        # Error triage is Pro-only — not Starter, not Enterprise.
+        assert body["required_tier"] == enforce.TIER_CLOUD_PRO
+        assert isinstance(body.get("hint"), str) and body["hint"]
+        # No triage payload leaked through.
+        assert "ok" not in body
+        assert "resolved" not in body
+        assert "removed" not in body
+
+
+def test_error_triage_402_body_shape_matches_shared_gate(enforce):
+    """The 402 body must carry the *same top-level keys* every other
+    ``@gate``d route returns so the front-end can handle any paid-feature
+    402 with one branch."""
+    from clawmetry._gate import gate as _gate
+
+    reference_app = Flask(__name__)
+
+    @reference_app.route("/reference")
+    @_gate("error_triage")
+    def _reference_view():
+        return {"ok": True}
+
+    triage_app = _make_app()
+
+    with reference_app.test_client() as rc, triage_app.test_client() as tc:
+        ref_body = rc.get("/reference").get_json()
+        tri_body = tc.get("/api/error-triage/resolved").get_json()
+        assert set(ref_body.keys()) == set(tri_body.keys())
+        # Envelope keys pinned so a later refactor of `@gate` doesn't
+        # silently drop `required_tier` or `tier`.
+        assert set(ref_body.keys()) == {
+            "error",
+            "feature",
+            "tier",
+            "required_tier",
+            "hint",
+        }
+        assert ref_body["feature"] == tri_body["feature"] == "error_triage"
+        assert ref_body["required_tier"] == tri_body["required_tier"]
+        assert ref_body["tier"] == tri_body["tier"]
+
+
+def test_error_triage_gate_fires_before_daemon_call(enforce, monkeypatch):
+    """The gate has to short-circuit the request *before* the
+    ``local_store_via_daemon`` call runs. Otherwise a hung / absent daemon
+    would surface as 503 instead of the 402 the caller expects."""
+    calls: list[tuple] = []
+
+    def _spy(method_name, **kwargs):
+        calls.append((method_name, kwargs))
+        return True
+
+    monkeypatch.setattr(
+        "routes.local_query.local_store_via_daemon", _spy, raising=False,
+    )
+
+    app = _make_app()
+    with app.test_client() as c:
+        r_post = c.post(
+            "/api/error-triage/resolve", json={"event_id": "ev:1"}
+        )
+        r_delete = c.delete("/api/error-triage/resolve?event_id=ev:1")
+        r_get = c.get("/api/error-triage/resolved")
+    assert r_post.status_code == 402
+    assert r_delete.status_code == 402
+    assert r_get.status_code == 402
+    # The gate ran and short-circuited: the daemon call never started.
+    assert calls == []
+
+
+def test_error_triage_gate_wins_over_missing_event_id_400(enforce):
+    """The pre-migration handler returned 400 on a missing ``event_id``.
+    Under enforce, the 402 must win so the UI shows the upgrade CTA rather
+    than a confusing validation error to an OSS caller."""
+    app = _make_app()
+    with app.test_client() as c:
+        # POST with an empty body — pre-gate this returned 400.
+        r_post = c.post("/api/error-triage/resolve", json={})
+        # DELETE with no query string — pre-gate this returned 400.
+        r_delete = c.delete("/api/error-triage/resolve")
+    assert r_post.status_code == 402
+    assert r_delete.status_code == 402
+    assert r_post.get_json().get("feature") == "error_triage"
+    assert r_delete.get_json().get("feature") == "error_triage"
+
+
+# ── grace mode: transparent ──────────────────────────────────────────────────
+
+
+def test_error_triage_resolve_passes_in_grace_mode(grace, monkeypatch):
+    """Grace mode: POST /resolve reaches the daemon proxy and returns the
+    pre-migration ``{"ok": True, "event_id": ...}`` envelope."""
+    captured: list[tuple] = []
+
+    def _fake(method_name, **kwargs):
+        captured.append((method_name, kwargs))
+        # ``mark_error_resolved`` returns True on success.
+        return True
+
+    monkeypatch.setattr(
+        "routes.local_query.local_store_via_daemon", _fake, raising=False,
+    )
+
+    app = _make_app()
+    with app.test_client() as c:
+        r = c.post(
+            "/api/error-triage/resolve",
+            json={"event_id": "ev:1", "note": "known flaky"},
+        )
+        assert r.status_code == 200
+        body = r.get_json()
+        assert body == {"ok": True, "event_id": "ev:1"}
+    assert captured == [
+        ("mark_error_resolved", {"event_id": "ev:1", "note": "known flaky"})
+    ]
+
+
+def test_error_triage_unresolve_passes_in_grace_mode(grace, monkeypatch):
+    """Grace mode: DELETE /resolve reaches the daemon proxy and returns
+    the pre-migration ``{"ok": True, "removed": bool, "event_id": ...}``
+    envelope. ``removed=False`` is the idempotent "wasn't there" case."""
+    def _fake(method_name, **kwargs):
+        assert method_name == "unmark_error_resolved"
+        # Returning False mirrors the idempotent unmark path.
+        return False
+
+    monkeypatch.setattr(
+        "routes.local_query.local_store_via_daemon", _fake, raising=False,
+    )
+
+    app = _make_app()
+    with app.test_client() as c:
+        r = c.delete("/api/error-triage/resolve?event_id=ev:missing")
+        assert r.status_code == 200
+        assert r.get_json() == {
+            "ok": True, "removed": False, "event_id": "ev:missing",
+        }
+
+
+def test_error_triage_resolved_passes_in_grace_mode(grace, monkeypatch):
+    """Grace mode: GET /resolved reaches the daemon proxy and returns the
+    pre-migration ``{"resolved": {...}, "count": N}`` envelope. The
+    ``?limit=`` query param still reaches the read call."""
+    seen_kwargs: list[dict] = []
+
+    def _fake(method_name, **kwargs):
+        seen_kwargs.append(kwargs)
+        assert method_name == "query_resolved_errors"
+        return {
+            "ev:abc": {"resolved_at": 1700000000.0, "note": "known"},
+            "ev:def": {"resolved_at": 1700000001.0, "note": None},
+        }
+
+    monkeypatch.setattr(
+        "routes.local_query.local_store_via_daemon", _fake, raising=False,
+    )
+
+    app = _make_app()
+    with app.test_client() as c:
+        r = c.get("/api/error-triage/resolved?limit=17")
+        assert r.status_code == 200
+        body = r.get_json()
+        assert body["count"] == 2
+        assert set(body["resolved"].keys()) == {"ev:abc", "ev:def"}
+        # ?limit=17 reaches the store call (clamped 1..5000).
+        assert seen_kwargs == [{"limit": 17}]
+
+
+def test_error_triage_grace_preserves_missing_event_id_400(grace):
+    """Grace mode: the pre-migration validation error still fires on a
+    missing ``event_id`` so callers with a real license keep getting the
+    same argument-validation contract. Pins that the gate didn't accidentally
+    swallow the 400."""
+    app = _make_app()
+    with app.test_client() as c:
+        r_post = c.post("/api/error-triage/resolve", json={})
+        r_delete = c.delete("/api/error-triage/resolve")
+    for r in (r_post, r_delete):
+        assert r.status_code == 400
+        body = r.get_json()
+        assert body.get("ok") is False
+        assert "event_id" in (body.get("error") or "")
+        # No paywall keys leaked into the 400.
+        assert "feature" not in body
+        assert "required_tier" not in body
+
+
+# ── defensive fallthrough ────────────────────────────────────────────────────
+
+
+def test_error_triage_never_raises_when_entitlement_lookup_fails(
+    enforce, monkeypatch
+):
+    """If the entitlement read itself throws, the request must go through
+    (grace-fallback contract). Mirrors
+    ``tests/test_route_gates.py::test_gate_decorator_never_raises_when_entitlement_lookup_fails``."""
+    def _explode():
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr("clawmetry.entitlements.get_entitlement", _explode)
+
+    def _fake(method_name, **_kw):
+        if method_name == "query_resolved_errors":
+            return {}
+        return True
+
+    monkeypatch.setattr(
+        "routes.local_query.local_store_via_daemon", _fake, raising=False,
+    )
+
+    app = _make_app()
+    with app.test_client() as c:
+        r = c.get("/api/error-triage/resolved")
+        # Graceful fallthrough: 200 with the envelope, NOT 402 and NOT 5xx.
+        assert r.status_code == 200
+        body = r.get_json()
+        assert body == {"resolved": {}, "count": 0}
+
+
+# ── static wiring pins ───────────────────────────────────────────────────────
+
+
+def test_error_triage_gate_decorator_wired_in_source():
+    """Static-source assertion: ``from clawmetry._gate import gate`` and
+    ``@gate("error_triage")`` are both present in ``routes/sessions.py``.
+    A well-meaning revert that drops the decorator (leaving the endpoints
+    unguarded, indistinguishable in grace-mode tests) fails loudly here."""
+    from routes import sessions as S
+
+    src = inspect.getsource(S)
+    assert "from clawmetry._gate import gate" in src, (
+        "routes/sessions.py must import the shared gate decorator so the "
+        "error-triage endpoints stay on the shared paywall envelope."
+    )
+    # The three routes each get their own @gate("error_triage") — pin the
+    # count so a partial revert (dropping the decorator on one of the three
+    # while leaving the others) also fails loudly.
+    assert src.count('@gate("error_triage")') == 3, (
+        "All three /api/error-triage/* routes must carry "
+        "@gate('error_triage'); a partial gate is a covert paywall bypass."
+    )


### PR DESCRIPTION
## Summary

- `routes/sessions.py` hosts the three public **error-triage JSON endpoints** on `bp_sessions` — `POST /api/error-triage/resolve`, `DELETE /api/error-triage/resolve`, and `GET /api/error-triage/resolved` (the resolved-set foundation shipped in #2230). `error_triage` is a **Pro-only feature** (declared in `PRO_ONLY_FEATURES` in `clawmetry/entitlements.py`), but the three routes were still on the "one blueprint per PR" gate migration list without a `@gate(...)` decorator. Prior gate migrations landed for `bp_fleet` (#3775), `bp_assets` (#3776), `bp_otel_export` (#3790), `bp_audit` (#3799), `bp_config` cost-optimizer (#3800), and `bp_sessions` run-compare (#3802). This PR closes the matching gap on `bp_sessions`'s error-triage surface.
- Add `@gate("error_triage")` from `clawmetry/_gate.py` to all three routes in `routes/sessions.py`. Route-decorator order matches every other `@gate`d route (`@bp_sessions.route(...)` above `@gate(...)`) so Flask registers the gated function.
- **Zero behaviour change in grace mode.** `Entitlement.allows_feature()` returns `True` under grace, which is the default until the enforce-phase release flips `CLAWMETRY_ENFORCE=1`. Every existing OSS install continues to serve the current triage payload unchanged. In enforce mode the 402 body carries the standard `{error, feature, tier, required_tier, hint}` envelope emitted by every other `@gate`d route, so a front-end that already handles 402s from `bp_assets` / `bp_audit` / `bp_otel_export` / `bp_fleet` / `bp_config` keeps working here without a `feature=="error_triage"` branch. `required_tier` resolves to `cloud_pro` so the paywall CTA routes users to the right plan (not Starter, not Enterprise).
- Other endpoints on `bp_sessions` (session list, transcript viewer, sub-agent tree, cost split, run-compare, etc.) are intentionally NOT touched by this PR — those implement `sessions` / `transcripts` / other FREE features (run-compare is on its own PR #3802). Only the three endpoints that implement the `error_triage` paid feature get the gate, matching the surgical "one feature per PR" cadence of the prior migrations.

## Test plan

- [x] `python -m py_compile routes/sessions.py tests/test_error_triage_route_gate.py` — clean.
- [x] `python -m pytest tests/test_error_triage_route_gate.py -q` — **12/12 passed** in 0.64s.
- [x] Sibling gate regression sweep: `python -m pytest tests/test_route_gates.py tests/test_audit_route_gate.py tests/test_otel_export_route_gate.py tests/test_fleet_route_gates.py tests/test_assets_route_gates.py tests/test_gate_runtime.py tests/test_paywall_body.py tests/test_error_triage.py tests/test_error_triage_route_gate.py -q` — **118/118 passed** in 2.94s (no regressions in the other `@gate`d routes or in the pre-existing behavioural error-triage suite).
- [ ] CI matrix green (Ubuntu / macOS / Windows × Py 3.9 / 3.11).

### Coverage the new tests pin

- **Enforce mode (parametrised across all 3 routes):** each of `POST /api/error-triage/resolve`, `DELETE /api/error-triage/resolve?event_id=...`, and `GET /api/error-triage/resolved` returns 402 with `error="upgrade_required"`, `feature="error_triage"`, `required_tier=TIER_CLOUD_PRO`, the caller's current `tier`, and a `hint` string. No triage payload keys (`ok`, `resolved`, `removed`, ...) leak through.
- **Envelope parity:** the 402 body carries the *same top-level keys* the shared `@gate` decorator returns on a synthetic Flask view — pins that a later refactor of `@gate` doesn't silently drop `required_tier` or `tier` on these routes.
- **Gate fires before the daemon proxy:** monkeypatches `routes.local_query.local_store_via_daemon` to a spy; the enforce-mode calls all return 402 with the spy never invoked, proving the gate short-circuits before the DuckDB-writer round trip.
- **Gate wins over the handler's own 400 branch:** the pre-migration handler returned 400 on a missing `event_id`. Under enforce, the 402 must win so an OSS caller sees the upgrade CTA rather than a confusing argument-validation error.
- **Grace mode (parametrised across all 3 routes):** the gate is transparent; the downstream handlers run against a stubbed `local_store_via_daemon` (hermetic — no real DuckDB open) and return the pre-migration envelopes (`{ok, event_id}`, `{ok, removed, event_id}`, `{resolved, count}`).
- **Grace preserves the 400 contract:** grace mode still returns 400 on missing `event_id`, so callers with a real license keep the same validation surface.
- **Defensive fallthrough:** an entitlement-lookup crash does not surface as 402 (mirrors the contract in `tests/test_route_gates.py::test_gate_decorator_never_raises_when_entitlement_lookup_fails`).
- **Decorator wiring pin:** static-source assertion that `from clawmetry._gate import gate` is present in `routes/sessions.py` AND that `@gate("error_triage")` appears exactly three times. A well-meaning revert that drops the decorator from one of the three routes (leaving a partial gate — indistinguishable in a single-route grace test) fails loudly here.

## Follow-ups (not in this PR)

- The remaining PRO_ONLY features without a route gate on this cadence are `per_run_waste_flags` (needs a refactor of `/api/session-insight/<session_id>` — the endpoint mixes FREE and PAID slices) and `anomaly_detection` (routes on `bp_usage`). Those belong in their own surgical PRs.
- `custom_webhooks`, `custom_alerts`, `budget_limits`, `asset_registry`, `approval_queue`, `otel_export`, `fleet`, `audit_logs`, and `cost_optimizer` are already gated on their own blueprints (see the audit trail in the commits above).

### Local operator verification checklist

I ran the endpoints under the Flask test client and the pytest suite in a fresh container, but I cannot reach the running daemon / live cloud snapshot / browser from this remote session — please verify locally before marking ready for review:

- [ ] Copy the two changed files into your installed site-packages:
  - `SITE=$(python3 -c 'import clawmetry, os; print(os.path.dirname(os.path.dirname(clawmetry.__file__)))')`
  - `cp routes/sessions.py "$SITE/routes/sessions.py"`
  - `cp tests/test_error_triage_route_gate.py "$SITE/tests/test_error_triage_route_gate.py"` (only if your local install ships tests)
  - `find "$SITE" -type d -name __pycache__ -exec rm -rf {} +`
- [ ] Restart sync: `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` (and `com.clawmetry.dashboard` if separate).
- [ ] Grace mode (default) unchanged:
  - `curl -s -X POST 'http://localhost:8900/api/error-triage/resolve' -H 'content-type: application/json' -d '{"event_id":"ev:smoke","note":"grace check"}' | jq .ok` → `true`
  - `curl -s 'http://localhost:8900/api/error-triage/resolved?limit=50' | jq '.resolved | keys | length'` → `>= 1`
  - `curl -s -X DELETE 'http://localhost:8900/api/error-triage/resolve?event_id=ev:smoke' | jq .removed` → `true`
- [ ] Enforce mode fires 402: set `CLAWMETRY_ENFORCE=1` in the daemon environment and restart, then
  - `curl -s -o /dev/null -w '%{http_code}\n' -X POST 'http://localhost:8900/api/error-triage/resolve' -H 'content-type: application/json' -d '{"event_id":"x"}'` → `402`
  - `curl -s -o /dev/null -w '%{http_code}\n' -X DELETE 'http://localhost:8900/api/error-triage/resolve?event_id=x'` → `402`
  - `curl -s -o /dev/null -w '%{http_code}\n' 'http://localhost:8900/api/error-triage/resolved'` → `402`
  - Body carries `"feature":"error_triage"` and `"required_tier":"cloud_pro"` on all three.
  - `curl -s -X POST 'http://localhost:8900/api/error-triage/resolve' -H 'content-type: application/json' -d '{}' | jq .feature` → `"error_triage"` (paywall wins over the pre-migration 400 branch).
- [ ] Decrypt the live cloud snapshot and confirm the Tracing / Health error rows still render the "Resolve" button + "Show resolved" toggle correctly in the browser under grace mode (no regression on the live UI — the `resolvedErrors` snapshot slice is unchanged).
- [ ] Ready-for-review-by-operator once local + browser checks pass. Kept **DRAFT** here — do not merge remotely, do not bump `__version__`, do not open a `[RELEASE]` PR.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015wMTrzD88TuEvfhdVuoZHh)_