### PR TITLE
feat(usage): gate the 3 /api/anomalies* routes on `anomaly_detection` entitlement

### DIFF
--- a/routes/usage.py
+++ b/routes/usage.py
@@ -39,6 +39,7 @@ from datetime import datetime, timedelta
 from typing import Optional
 
 from flask import Blueprint, jsonify, make_response, request
+from clawmetry._gate import gate
 from clawmetry.config import is_local_store_read_enabled
 from routes._dedupe import build_sibling_bucket_max, is_sibling_dup
 
@@ -1954,6 +1955,7 @@ def api_usage():
 
 
 @bp_usage.route("/api/usage/anomalies")
+@gate("anomaly_detection")
 def api_usage_anomalies():
     """Return session cost anomalies vs rolling 7-day baseline."""
     import dashboard as _d
@@ -1986,6 +1988,7 @@ def api_usage_anomalies():
 
 
 @bp_usage.route("/api/anomalies")
+@gate("anomaly_detection")
 def api_anomalies():
     """Rolling-baseline anomaly detection endpoint.
 
@@ -2030,6 +2033,7 @@ def api_anomalies():
 
 
 @bp_usage.route("/api/anomalies/<int:anomaly_id>/ack", methods=["POST"])
+@gate("anomaly_detection")
 def api_anomaly_ack(anomaly_id):
     """Acknowledge an anomaly so it no longer appears in the active banner."""
     import dashboard as _d

--- a/tests/test_anomaly_detection_route_gates.py
+++ b/tests/test_anomaly_detection_route_gates.py
@@ -1,0 +1,394 @@
+"""Enforce/grace-mode contract tests for the ``bp_usage`` anomaly-detection
+endpoints in ``routes/usage.py``.
+
+``anomaly_detection`` is a Pro-only feature (see ``PRO_ONLY_FEATURES`` in
+``clawmetry/entitlements.py``). Three public JSON endpoints implement it,
+so all three wear the ``@gate("anomaly_detection")`` decorator:
+
+  * ``GET  /api/usage/anomalies``
+  * ``GET  /api/anomalies``
+  * ``POST /api/anomalies/<int:anomaly_id>/ack``
+
+Sibling of ``tests/test_cost_optimizer_route_gates.py``,
+``tests/test_assets_route_gates.py``,
+``tests/test_fleet_route_gates.py``, ``tests/test_audit_route_gate.py``,
+``tests/test_otel_export_route_gate.py``,
+``tests/test_run_compare_route_gate.py``, and
+``tests/test_error_triage_route_gate.py``. Pins the same contract for
+these three routes so a future edit to ``routes/usage.py`` can't
+silently drop the gate:
+
+  1. Enforce mode: each endpoint returns the shared 402 ``upgrade_required``
+     envelope with ``feature="anomaly_detection"`` and
+     ``required_tier=TIER_CLOUD_PRO``. Because the gate check fires before
+     any handler code runs, the 402 short-circuits before the DuckDB /
+     ``dashboard.py`` helpers are even touched -- no ``dashboard`` stub
+     is needed for the enforce path.
+  2. Grace mode: the gate is transparent. Downstream handlers run with
+     a stubbed ``dashboard`` so the payload builders can finish without
+     pulling in the real 17k-line module.
+  3. The 402 wire shape is byte-identical to what other ``@gate``d
+     routes return, so an existing front-end that already handles 402s
+     from ``bp_assets`` / ``bp_audit`` / ``bp_otel_export`` /
+     ``bp_config`` keeps working here without a special-case branch on
+     ``feature=="anomaly_detection"``.
+  4. A resolver crash never surfaces as 402 -- mirrors the defensive
+     contract pinned in ``tests/test_route_gates.py``.
+"""
+from __future__ import annotations
+
+import importlib
+import sys
+import threading
+import types
+
+import pytest
+from flask import Flask
+
+
+# ── fixtures ────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def enforce(monkeypatch, tmp_path):
+    """OSS install under ``CLAWMETRY_ENFORCE=1`` -- the tier is oss and
+    ``anomaly_detection`` (a Pro-only feature) is NOT allowed."""
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def grace(monkeypatch, tmp_path):
+    """Default grace mode -- every feature key passes through the gate."""
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+def _make_app():
+    from routes.usage import bp_usage
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_usage)
+    return app
+
+
+def _stub_dashboard(monkeypatch):
+    """Install a stub ``dashboard`` module so the anomaly handlers'
+    ``import dashboard as _d`` calls resolve to a hermetic object.
+
+    The handlers read a handful of helpers off ``dashboard``; we stub
+    them to return the smallest well-shaped values that keep the payload
+    builders from raising. This lets grace-mode tests exercise the whole
+    handler without needing the real 17k-line ``dashboard.py``.
+    """
+    stub = types.ModuleType("dashboard")
+
+    def _compute_transcript_analytics():
+        return {"sessions": []}
+
+    def _compute_session_cost_anomalies(_sessions):
+        return []
+
+    def _detect_and_store_anomalies():
+        return ([], {})
+
+    class _FakeDB:
+        def execute(self, *_a, **_kw):
+            return self
+
+        def commit(self):
+            return None
+
+        def close(self):
+            return None
+
+    def _get_anomaly_db():
+        return _FakeDB()
+
+    stub._compute_transcript_analytics = _compute_transcript_analytics
+    stub._compute_session_cost_anomalies = _compute_session_cost_anomalies
+    stub._detect_and_store_anomalies = _detect_and_store_anomalies
+    stub._get_anomaly_db = _get_anomaly_db
+    stub._anomaly_db_lock = threading.Lock()
+    stub._anomaly_detection_cache = {"data": None, "ts": 0.0}
+    stub._ANOMALY_CACHE_TTL = 60.0
+
+    monkeypatch.setitem(sys.modules, "dashboard", stub)
+    return stub
+
+
+def _disable_local_store(monkeypatch):
+    """Force the handlers off their DuckDB fast paths so the grace-mode
+    tests exercise the dashboard-import branch (which is what the gate
+    protects).
+
+    The GET /api/usage/anomalies and GET /api/anomalies handlers both
+    short-circuit to ``_try_local_store_*`` when
+    ``is_local_store_read_enabled()`` is truthy. Setting the env var to
+    ``0`` sends them down the ``import dashboard as _d`` branch instead.
+    """
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_READ", "0")
+
+
+# ── enforce mode: 402 on every gated endpoint ────────────────────────────────
+
+
+# Each entry is (http_method, path). Route decorator: methods=["POST"] on
+# ack, GET on the other two.
+_ENFORCE_MATRIX = [
+    ("GET", "/api/usage/anomalies"),
+    ("GET", "/api/anomalies"),
+    ("POST", "/api/anomalies/1/ack"),
+]
+
+
+def _call(client, method, path):
+    if method == "GET":
+        return client.get(path)
+    if method == "POST":
+        return client.post(path)
+    raise AssertionError(f"unhandled method {method!r}")
+
+
+@pytest.mark.parametrize("method,path", _ENFORCE_MATRIX)
+def test_anomaly_endpoint_returns_402_when_enforced(enforce, method, path):
+    """Each gated endpoint returns the shared 402 body in enforce mode."""
+    app = _make_app()
+    with app.test_client() as c:
+        r = _call(c, method, path)
+        assert r.status_code == 402, (
+            f"{method} {path} returned {r.status_code}, expected 402 "
+            "(gate should short-circuit before handler runs)"
+        )
+        body = r.get_json()
+        assert body["error"] == "upgrade_required"
+        assert body["feature"] == "anomaly_detection"
+        # Pro-only feature -- required_tier must be TIER_CLOUD_PRO so the
+        # paywall CTA routes users to the right plan (not Starter, not
+        # Enterprise).
+        assert body["required_tier"] == enforce.TIER_CLOUD_PRO
+        # ``tier`` reflects the caller's current tier so the UI can render
+        # the delta ("you have X, upgrade to Y"). On an OSS install with
+        # no license, this is TIER_OSS.
+        assert body["tier"] == enforce.TIER_OSS
+        assert isinstance(body.get("hint"), str) and body["hint"]
+        # No anomaly payload leaked through -- the gate short-circuited.
+        assert "anomalies" not in body
+        assert "baselines" not in body
+        assert "baseline_7d_avg_usd" not in body
+
+
+@pytest.mark.parametrize("method,path", _ENFORCE_MATRIX)
+def test_anomaly_402_body_shape_matches_shared_gate(enforce, method, path):
+    """The 402 body must carry the *same top-level keys* every other
+    ``@gate``d route returns so the front-end can handle any paid-feature
+    402 with one branch. Pins that a later refactor of ``@gate`` doesn't
+    silently drop ``required_tier`` or ``tier`` on these routes.
+    """
+    from clawmetry._gate import gate as _gate
+
+    reference_app = Flask(__name__)
+
+    @reference_app.route("/reference")
+    @_gate("anomaly_detection")
+    def _reference_view():  # pragma: no cover - never runs in enforce mode
+        return {"ok": True}
+
+    target_app = _make_app()
+
+    with reference_app.test_client() as rc, target_app.test_client() as ac:
+        ref_body = rc.get("/reference").get_json()
+        act_body = _call(ac, method, path).get_json()
+        assert set(ref_body.keys()) == set(act_body.keys())
+        assert set(ref_body.keys()) == {
+            "error",
+            "feature",
+            "tier",
+            "required_tier",
+            "hint",
+        }
+        assert ref_body["feature"] == act_body["feature"] == "anomaly_detection"
+        assert ref_body["required_tier"] == act_body["required_tier"]
+        assert ref_body["tier"] == act_body["tier"]
+
+
+@pytest.mark.parametrize("method,path", _ENFORCE_MATRIX)
+def test_anomaly_gate_fires_before_dashboard_import(
+    enforce, monkeypatch, method, path
+):
+    """The gate has to short-circuit the request *before* the handler
+    runs. Prove it by installing a distinctive booby-trap ``dashboard``
+    module: if the gate were missing, the handler's ``import dashboard
+    as _d`` would either succeed (leaking a 200) or blow up with an
+    ``AssertionError`` -- neither is a 402. The gate short-circuits, so
+    we never reach the import.
+
+    Also disables the DuckDB fast path via env so a lazy handler that
+    somehow bypassed the gate couldn't hide inside the local-store
+    branch and produce a green false negative.
+    """
+    _disable_local_store(monkeypatch)
+
+    class _Boom:  # pragma: no cover - only hit on regression
+        def __getattr__(self, name):
+            raise AssertionError(
+                f"gate should have short-circuited before "
+                f"dashboard.{name} was reached"
+            )
+
+    monkeypatch.setitem(sys.modules, "dashboard", _Boom())
+
+    app = _make_app()
+    with app.test_client() as c:
+        r = _call(c, method, path)
+        assert r.status_code == 402
+
+
+# ── grace mode: gate is transparent on every endpoint ───────────────────────
+
+
+@pytest.mark.parametrize("method,path", _ENFORCE_MATRIX)
+def test_anomaly_endpoint_is_transparent_in_grace_mode(
+    monkeypatch, grace, method, path
+):
+    """Grace mode (the current default until the enforce-phase release)
+    must let the request through unchanged. The downstream handler runs
+    with a stubbed ``dashboard`` and the DuckDB fast path disabled so
+    the payload builder is exercised without pulling in the real
+    17k-line module.
+    """
+    _disable_local_store(monkeypatch)
+    _stub_dashboard(monkeypatch)
+
+    app = _make_app()
+    with app.test_client() as c:
+        r = _call(c, method, path)
+        assert r.status_code != 402, (
+            f"{method} {path} 402'd in grace mode; gate is not transparent"
+        )
+        body = r.get_json()
+        assert isinstance(body, dict)
+        # The 402 short-circuit body has ``error="upgrade_required"``;
+        # the handler payload never does. Pins that the gate stayed
+        # transparent AND the handler emitted its own body.
+        assert body.get("error") != "upgrade_required"
+
+
+def test_usage_anomalies_grace_payload_shape(monkeypatch, grace):
+    """Grace mode: /api/usage/anomalies must still emit the pre-migration
+    envelope keys."""
+    _disable_local_store(monkeypatch)
+    _stub_dashboard(monkeypatch)
+
+    app = _make_app()
+    with app.test_client() as c:
+        body = c.get("/api/usage/anomalies").get_json()
+        assert "anomalies" in body
+        assert "baseline_7d_avg_usd" in body
+        assert "threshold_multiplier" in body
+
+
+def test_anomalies_grace_payload_shape(monkeypatch, grace):
+    """Grace mode: /api/anomalies must still emit the pre-migration
+    envelope keys."""
+    _disable_local_store(monkeypatch)
+    _stub_dashboard(monkeypatch)
+
+    app = _make_app()
+    with app.test_client() as c:
+        body = c.get("/api/anomalies").get_json()
+        assert "anomalies" in body
+        assert "active_count" in body
+        assert "has_active" in body
+        assert "baselines" in body
+
+
+def test_anomaly_ack_grace_payload_shape(monkeypatch, grace):
+    """Grace mode: POST /api/anomalies/<id>/ack must still return the
+    pre-migration ``{ok, id}`` envelope."""
+    _disable_local_store(monkeypatch)
+    _stub_dashboard(monkeypatch)
+
+    app = _make_app()
+    with app.test_client() as c:
+        r = c.post("/api/anomalies/42/ack")
+        body = r.get_json()
+        assert body.get("ok") is True
+        assert body.get("id") == 42
+
+
+# ── defensive fallthrough ────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("method,path", _ENFORCE_MATRIX)
+def test_entitlement_lookup_crash_falls_through(
+    monkeypatch, enforce, method, path
+):
+    """Mirrors the contract in ``tests/test_route_gates.py``: if the
+    entitlement read itself raises, the request path stays defensive and
+    the handler runs -- the worst that happens is a paid feature briefly
+    runs on a Free tier. A flaky entitlement check must never fail
+    closed.
+    """
+    def _explode():
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr("clawmetry.entitlements.get_entitlement", _explode)
+    _disable_local_store(monkeypatch)
+    _stub_dashboard(monkeypatch)
+
+    app = _make_app()
+    with app.test_client() as c:
+        r = _call(c, method, path)
+        # Graceful fallthrough: NOT 402. Handler runs and returns
+        # whatever it would have returned pre-migration (200 with the
+        # payload envelope on the happy path, or 500 with the ack
+        # error-fallback envelope if a helper raises -- both acceptable,
+        # the key is we did not fail closed with a 402).
+        assert r.status_code != 402
+
+
+# ── decorator wiring pin ─────────────────────────────────────────────────────
+
+
+def test_anomaly_routes_wear_gate_decorator():
+    """All three anomaly-detection routes must be wired with
+    ``@gate("anomaly_detection")``. Pin this at the module level so a
+    well-meaning revert that drops the decorator from any single route
+    (leaving a partial gate -- indistinguishable in a single-route grace
+    test) fails loudly instead of silently reverting the gate.
+
+    We check by inspecting the source rather than by calling the route
+    because the ``@gate`` decorator is transparent in grace mode; a
+    regression that dropped it would look identical in grace tests.
+    """
+    import inspect
+
+    from routes import usage
+
+    src = inspect.getsource(usage)
+    assert 'from clawmetry._gate import gate' in src, (
+        "routes/usage.py must import @gate from clawmetry._gate"
+    )
+    # Exactly three anomaly-detection routes exist today; if a fourth is
+    # added it should also wear the gate, so this pin should be updated
+    # in the same PR that adds it (a mismatch is a signal to inspect).
+    assert src.count('@gate("anomaly_detection")') == 3, (
+        'routes/usage.py must decorate all three anomaly-detection '
+        'routes with @gate("anomaly_detection") -- this is the only '
+        'enforcement point until the closed-source clawmetry-pro '
+        'package overrides the blueprint via the extensions entry '
+        'point.'
+    )


### PR DESCRIPTION
## Summary

- `routes/usage.py` hosts the three public **anomaly-detection JSON endpoints** on `bp_usage` — `GET /api/usage/anomalies`, `GET /api/anomalies`, and `POST /api/anomalies/<int:anomaly_id>/ack`. `anomaly_detection` is a **Pro-only feature** (declared in `PRO_ONLY_FEATURES` in `clawmetry/entitlements.py`), but the three routes were still on the "one blueprint per PR" gate migration list without a `@gate(...)` decorator. Prior gate migrations landed for `bp_fleet` (#3775), `bp_assets` (#3776), `bp_otel_export` (#3790), `bp_audit` (#3799), `bp_config` cost-optimizer (#3800), `bp_sessions` run-compare (#3802), and `bp_sessions` error-triage (#3804). This PR closes the matching gap on `bp_usage`.
- Add `@gate("anomaly_detection")` from `clawmetry/_gate.py` to all three routes in `routes/usage.py`. Route-decorator order matches every other `@gate`d route (`@bp_usage.route(...)` above `@gate(...)`) so Flask registers the gated function.
- **Zero behaviour change in grace mode.** `Entitlement.allows_feature()` returns `True` under grace, which is the default until the enforce-phase release flips `CLAWMETRY_ENFORCE=1`. Every existing OSS install continues to serve the current anomaly payload unchanged. In enforce mode the 402 body carries the standard `{error, feature, tier, required_tier, hint}` envelope emitted by every other `@gate`d route, so a front-end that already handles 402s from `bp_assets` / `bp_audit` / `bp_otel_export` / `bp_fleet` / `bp_config` / `bp_sessions` keeps working here without a `feature=="anomaly_detection"` branch. `required_tier` resolves to `cloud_pro` so the paywall CTA routes users to the right plan (not Starter, not Enterprise).
- Other endpoints on `bp_usage` (analytics, attribution, cache trends, forecast, model/skill splits, etc.) are intentionally NOT touched by this PR — those implement FREE features or Starter features on their own dedicated PRs. Only the three endpoints that implement the `anomaly_detection` paid feature get the gate, matching the surgical "one feature per PR" cadence of the prior migrations.

## Test plan

- [x] `python -m py_compile routes/usage.py tests/test_anomaly_detection_route_gates.py` — clean.
- [x] `python -m pytest tests/test_anomaly_detection_route_gates.py -q` — **19/19 passed** in 0.99s.
- [x] Sibling gate regression sweep: `python -m pytest tests/test_route_gates.py tests/test_gate_runtime.py tests/test_paywall_body.py tests/test_cost_optimizer_route_gates.py tests/test_assets_route_gates.py tests/test_fleet_route_gates.py tests/test_audit_route_gate.py tests/test_otel_export_route_gate.py tests/test_anomaly_detection_route_gates.py -q` — **130/130 passed** in 3.13s (no regressions in any other `@gate`d routes).
- [x] Pre-existing anomaly local-store fast-path suite unaffected: `python -m pytest tests/test_usage_local_store.py -q -k anomal` — **4/4 passed** (the local-store tests exercise `_try_local_store_usage_anomalies` / `_try_local_store_anomalies` directly; the gate is transparent in grace mode so their response shapes are unchanged).
- [ ] CI matrix green (Ubuntu / macOS / Windows × Py 3.9 / 3.11).

### Coverage the new tests pin

- **Enforce mode (parametrised across all 3 routes):** each of `GET /api/usage/anomalies`, `GET /api/anomalies`, and `POST /api/anomalies/<int:anomaly_id>/ack` returns 402 with `error="upgrade_required"`, `feature="anomaly_detection"`, `required_tier=TIER_CLOUD_PRO`, the caller's current `tier`, and a `hint` string. No anomaly payload keys (`anomalies`, `baselines`, `baseline_7d_avg_usd`) leak through.
- **Envelope parity:** the 402 body carries the *same top-level keys* the shared `@gate` decorator returns on a synthetic Flask view — pins that a later refactor of `@gate` doesn't silently drop `required_tier` or `tier` on these routes.
- **Gate fires before `dashboard` import (parametrised across all 3 routes):** installs a booby-trap `dashboard` module whose every attribute access raises `AssertionError`, and forces the DuckDB fast path off via `CLAWMETRY_LOCAL_STORE_READ=0` so a lazy handler that somehow bypassed the gate couldn't hide inside the local-store branch. The enforce-mode calls all return 402 with the booby trap never triggered, proving the gate short-circuits before the `import dashboard as _d` line at the top of each handler runs.
- **Grace mode (parametrised across all 3 routes):** the gate is transparent; the downstream handlers run against a stubbed `dashboard` (hermetic — no real `_compute_transcript_analytics`, `_detect_and_store_anomalies`, or `_get_anomaly_db` needed) and return the pre-migration envelopes.
- **Grace preserves the pre-migration payload shapes** for all three routes:
  - `GET /api/usage/anomalies` still emits `{anomalies, baseline_7d_avg_usd, threshold_multiplier}`.
  - `GET /api/anomalies` still emits `{anomalies, active_count, has_active, baselines, ...}`.
  - `POST /api/anomalies/<id>/ack` still emits `{ok: True, id: <same id>}`.
- **Defensive fallthrough:** an entitlement-lookup crash does not surface as 402 (mirrors the contract in `tests/test_route_gates.py::test_gate_decorator_never_raises_when_entitlement_lookup_fails`).
- **Decorator wiring pin:** static-source assertion that `from clawmetry._gate import gate` is present in `routes/usage.py` AND that `@gate("anomaly_detection")` appears exactly three times. A well-meaning revert that drops the decorator from one of the three routes (leaving a partial gate — indistinguishable in a single-route grace test) fails loudly here.

## Follow-ups (not in this PR)

- The last remaining PRO_ONLY feature without a route-level gate on this cadence is `per_run_waste_flags`. The per-run waste flags currently surface inside `GET /api/session-insight/` on `bp_sessions`, which is a mixed endpoint (also renders governance, recommendations, cost). Gating the whole endpoint would remove FREE surfaces alongside the paid one, so that migration needs a refactor (either split the paid slice into a distinct endpoint, or filter the paid keys out of the response body under enforce) — belongs in its own PR.
- `custom_webhooks`, `custom_alerts`, `budget_limits`, `asset_registry`, `approval_queue`, `otel_export`, `fleet`, `audit_logs`, `cost_optimizer`, `per_run_compare`, and `error_triage` are already gated on their own blueprints (see the audit trail in the commits above).

### Local operator verification checklist

I ran the endpoints under the Flask test client and the pytest suite in a fresh container, but I cannot reach the running daemon / live cloud snapshot / browser from this remote session — please verify locally before marking ready for review:

- [ ] Copy the two changed files into your installed site-packages:
  - `SITE=$(python3 -c 'import clawmetry, os; print(os.path.dirname(os.path.dirname(clawmetry.__file__)))')`
  - `cp routes/usage.py "$SITE/routes/usage.py"`
  - `cp tests/test_anomaly_detection_route_gates.py "$SITE/tests/test_anomaly_detection_route_gates.py"` (only if your local install ships tests)
  - `find "$SITE" -type d -name __pycache__ -exec rm -rf {} +`
- [ ] Restart sync: `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` (and `com.clawmetry.dashboard` if separate).
- [ ] Grace mode (default) unchanged:
  - `curl -s 'http://localhost:8900/api/usage/anomalies' | jq '.anomalies | length'` — still returns a non-negative count.
  - `curl -s 'http://localhost:8900/api/anomalies' | jq '.active_count'` — still returns the anomaly count.
  - `curl -s -X POST 'http://localhost:8900/api/anomalies/999999/ack' | jq .ok` → `true`
- [ ] Enforce mode fires 402: set `CLAWMETRY_ENFORCE=1` in the daemon environment and restart, then
  - `curl -s -o /dev/null -w '%{http_code}\n' 'http://localhost:8900/api/usage/anomalies'` → `402`
  - `curl -s -o /dev/null -w '%{http_code}\n' 'http://localhost:8900/api/anomalies'` → `402`
  - `curl -s -o /dev/null -w '%{http_code}\n' -X POST 'http://localhost:8900/api/anomalies/1/ack'` → `402`
  - Body carries `"feature":"anomaly_detection"` and `"required_tier":"cloud_pro"` on all three.
- [ ] Decrypt the live cloud snapshot and confirm the anomaly banner + "Acknowledge" button still render correctly in the browser under grace mode (no regression on the live UI — the `anomalies` snapshot slice is unchanged).
- [ ] Ready-for-review-by-operator once local + browser checks pass. Kept **DRAFT** here — do not merge remotely, do not bump `__version__`, do not open a `[RELEASE]` PR.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013S3wQrKfXCBLNPmitvJrHr)_