### PR TITLE
feat(policy): gate /api/tool-policy on `tool_policy` entitlement

### DIFF
--- a/routes/policy.py
+++ b/routes/policy.py
@@ -72,6 +72,7 @@ def _arg_preview(args) -> str:
 
 
 @bp_policy.route("/api/tool-policy")
+@gate("tool_policy")
 def api_tool_policy():
     """Per-agent effective sandbox mode + tool allow/deny.
 

--- a/tests/test_tool_policy_route_gate.py
+++ b/tests/test_tool_policy_route_gate.py
@@ -1,0 +1,351 @@
+"""Tests for the ``@gate("tool_policy")`` migration on
+``routes/policy.py::api_tool_policy``.
+
+Sibling of ``tests/test_audit_route_gate.py``,
+``tests/test_otel_export_route_gate.py``, ``tests/test_fleet_route_gates.py``,
+``tests/test_assets_route_gates.py``, and
+``tests/test_anomaly_detection_route_gates.py``. Pins:
+
+- Enforce mode returns the shared 402 ``upgrade_required`` envelope with
+  ``feature="tool_policy"``, ``required_tier=cloud_pro`` (tool policy is a
+  Pro-only feature, not Enterprise), ``tier`` = the caller's current tier,
+  and a ``hint`` string.
+- Grace mode is transparent: the downstream handler runs, populates the
+  governance summary, and returns the ``{"agents": [...], "summary": {...},
+  "_source": "local_store"}`` envelope even though the caller is OSS.
+- The gate fires *before* the LocalStore ``query_tool_policy`` read so a
+  daemon mid-restart or a fresh install without a ``tool_policy`` table
+  can't leak through as a 200 in enforce mode.
+- A resolver crash never surfaces as 402 (mirrors the defensive contract
+  pinned in ``tests/test_route_gates.py``).
+- The 402 wire shape is byte-identical to what other ``@gate``d routes
+  return, so an existing front-end that already handles 402 keeps working
+  without a branch on ``feature=="tool_policy"``.
+
+The other ``bp_policy`` endpoints (``/api/approvals``, ``/api/approvals-audit``)
+are intentionally NOT retested here — they're already gated on
+``approval_queue`` (a Starter feature) and pinned by
+``tests/test_route_gates.py``. Only the newly-migrated ``/api/tool-policy``
+route is exercised, matching the "one feature per PR" cadence of the
+sibling migrations.
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+# ── fixtures ────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def enforce(monkeypatch, tmp_path):
+    """OSS install under ``CLAWMETRY_ENFORCE=1`` — the tier is oss/free and
+    ``tool_policy`` (a Pro-only feature) is NOT allowed."""
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def grace(monkeypatch, tmp_path):
+    """Default grace mode — every feature key passes through the gate."""
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+def _make_app():
+    from routes.policy import bp_policy
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_policy)
+    return app
+
+
+# ── enforce mode: 402 contract ──────────────────────────────────────────────
+
+
+def test_tool_policy_returns_402_when_enforced(enforce, monkeypatch):
+    """The route wears ``@gate("tool_policy")`` so an OSS install in enforce
+    mode gets the shared 402 body instead of the agents envelope."""
+    # Belt-and-braces: even if ``_ls_call`` returned data the gate must
+    # short-circuit before it. Stub the LocalStore lookup so a regression
+    # that drops the decorator would produce a 200 with a sentinel row.
+    def _sentinel(name, **_kw):
+        return [{"agent_id": "gate_should_have_fired"}]
+
+    import routes.policy as P
+    monkeypatch.setattr(P, "_ls_call", _sentinel)
+
+    app = _make_app()
+    with app.test_client() as c:
+        r = c.get("/api/tool-policy")
+        assert r.status_code == 402
+        body = r.get_json()
+        assert body["error"] == "upgrade_required"
+        assert body["feature"] == "tool_policy"
+        # Current tier is echoed so the UI can distinguish "not entitled at
+        # all" from "entitled but on a downgrade path".
+        assert "tier" in body
+        # required_tier lets the paywall render the right upgrade CTA.
+        # tool_policy is Pro-only, NOT Enterprise — so the CTA has to
+        # target Pro or users get sent to the wrong upgrade flow.
+        assert body["required_tier"] == enforce.TIER_CLOUD_PRO
+        assert isinstance(body.get("hint"), str) and body["hint"]
+        # No agents payload leaked through.
+        assert "agents" not in body
+        assert "summary" not in body
+
+
+def test_tool_policy_402_body_shape_matches_shared_gate(enforce):
+    """The 402 body must carry the *same top-level keys* every other
+    ``@gate``d route returns so the front-end can handle any paid-feature
+    402 with one branch."""
+    from clawmetry._gate import gate as _gate
+
+    reference_app = Flask(__name__)
+
+    @reference_app.route("/reference")
+    @_gate("tool_policy")
+    def _reference_view():
+        return {"ok": True}
+
+    policy_app = _make_app()
+
+    with reference_app.test_client() as rc, policy_app.test_client() as ac:
+        ref_body = rc.get("/reference").get_json()
+        tp_body = ac.get("/api/tool-policy").get_json()
+        assert set(ref_body.keys()) == set(tp_body.keys())
+        # Envelope keys pinned so a later refactor of ``@gate`` doesn't
+        # silently drop ``required_tier`` or ``tier``.
+        assert set(ref_body.keys()) == {
+            "error",
+            "feature",
+            "tier",
+            "required_tier",
+            "hint",
+        }
+        assert ref_body["feature"] == tp_body["feature"] == "tool_policy"
+        assert ref_body["required_tier"] == tp_body["required_tier"]
+        assert ref_body["tier"] == tp_body["tier"]
+
+
+def test_tool_policy_gate_fires_before_local_store_read(enforce, monkeypatch):
+    """The gate has to short-circuit the request *before* the LocalStore
+    ``query_tool_policy`` call runs. Otherwise a slow DuckDB open, or a
+    fresh install where the ``tool_policy`` table hasn't been materialised
+    yet, would leak through as a 500 instead of the 402 the caller expects.
+    """
+    calls: list[tuple[str, dict]] = []
+
+    def _spy(name, **kwargs):
+        calls.append((name, kwargs))
+        return []
+
+    import routes.policy as P
+    monkeypatch.setattr(P, "_ls_call", _spy)
+
+    app = _make_app()
+    with app.test_client() as c:
+        r = c.get("/api/tool-policy?limit=42&agent_id=abc")
+        assert r.status_code == 402
+        # The gate ran and short-circuited: the LocalStore read never started.
+        assert calls == []
+
+
+def test_tool_policy_gate_wins_over_query_string_error(enforce):
+    """Even a malformed ``?limit=`` must not shadow the 402 — the gate fires
+    before the query-string parse fallthrough, so the enforcement signal
+    reaches the caller regardless of how they hit the URL."""
+    app = _make_app()
+    with app.test_client() as c:
+        r = c.get("/api/tool-policy?limit=not-a-number&agent_id=")
+        assert r.status_code == 402
+
+
+# ── grace mode: transparent ──────────────────────────────────────────────────
+
+
+def test_tool_policy_passes_in_grace_mode(grace, monkeypatch):
+    """Grace mode (the current default until the enforce-phase release)
+    must let the request through unchanged. The downstream handler builds
+    the agents+summary envelope; the LocalStore is stubbed to keep the
+    test hermetic."""
+    def _empty(name, **_kw):
+        return []
+
+    import routes.policy as P
+    monkeypatch.setattr(P, "_ls_call", _empty)
+
+    app = _make_app()
+    with app.test_client() as c:
+        r = c.get("/api/tool-policy")
+        assert r.status_code == 200
+        body = r.get_json()
+        assert "agents" in body
+        assert "summary" in body
+        assert body["_source"] == "local_store"
+        # The pre-migration handler always returned this shape, so seeing
+        # it here proves the gate stayed transparent AND the handler ran.
+        assert body["agents"] == []
+        assert body["summary"]["agent_count"] == 0
+        assert body["summary"]["sandboxed_agents"] == 0
+
+
+def test_tool_policy_grace_populates_summary_rollup(grace, monkeypatch):
+    """Grace mode: the governance rollup (``strongest_mode``,
+    ``sandboxed_agents``, allow/deny totals) still fires end-to-end. Pins
+    that the migration didn't accidentally short-circuit the summary
+    computation."""
+    def _canned(name, **_kw):
+        return [
+            {"agent_id": "a1", "sandbox_mode": "all",     "allow_count": 3, "deny_count": 1},
+            {"agent_id": "a2", "sandbox_mode": "non-main", "allow_count": 5, "deny_count": 2},
+            {"agent_id": "a3", "sandbox_mode": "off",     "allow_count": 0, "deny_count": 0},
+        ]
+
+    import routes.policy as P
+    monkeypatch.setattr(P, "_ls_call", _canned)
+
+    app = _make_app()
+    with app.test_client() as c:
+        r = c.get("/api/tool-policy")
+        assert r.status_code == 200
+        body = r.get_json()
+        summary = body["summary"]
+        assert summary["agent_count"] == 3
+        # a1 (all) and a2 (non-main) are sandboxed; a3 (off) is not.
+        assert summary["sandboxed_agents"] == 2
+        # ``all`` outranks ``non-main`` which outranks ``off``.
+        assert summary["strongest_mode"] == "all"
+        assert summary["total_allowed_tools"] == 8
+        assert summary["total_denied_tools"] == 3
+
+
+def test_tool_policy_grace_forwards_agent_id_and_limit(grace, monkeypatch):
+    """Grace mode: the ``?agent_id=`` and ``?limit=`` query params still
+    reach the LocalStore call. Pins the full filter surface across the
+    gate migration."""
+    captured: list[dict] = []
+
+    def _recorder(name, **kwargs):
+        captured.append({"method": name, **kwargs})
+        return []
+
+    import routes.policy as P
+    monkeypatch.setattr(P, "_ls_call", _recorder)
+
+    app = _make_app()
+    with app.test_client() as c:
+        r = c.get("/api/tool-policy?agent_id=main&limit=17")
+        assert r.status_code == 200
+        assert captured == [{
+            "method": "query_tool_policy",
+            "agent_id": "main",
+            "limit": 17,
+        }]
+
+
+# ── defensive fallthrough ────────────────────────────────────────────────────
+
+
+def test_tool_policy_never_raises_when_entitlement_lookup_fails(
+    enforce, monkeypatch
+):
+    """If the entitlement read itself throws, the request must go through
+    (grace-fallback contract). Mirrors
+    ``tests/test_route_gates.py::test_gate_decorator_never_raises_when_entitlement_lookup_fails``."""
+    def _explode():
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr("clawmetry.entitlements.get_entitlement", _explode)
+
+    def _empty(name, **_kw):
+        return []
+
+    import routes.policy as P
+    monkeypatch.setattr(P, "_ls_call", _empty)
+
+    app = _make_app()
+    with app.test_client() as c:
+        r = c.get("/api/tool-policy")
+        # Graceful fallthrough: 200 with the envelope, NOT 402 and NOT 5xx.
+        assert r.status_code == 200
+        body = r.get_json()
+        assert "agents" in body
+        assert "summary" in body
+        assert body["_source"] == "local_store"
+
+
+def test_tool_policy_never_raises_when_local_store_read_fails(grace, monkeypatch):
+    """If the LocalStore read itself throws, the route still returns a
+    well-formed empty envelope with 200, not a 500. The pre-migration
+    ``_ls_call`` already swallowed to ``None`` so this pins that
+    contract survived the gate migration."""
+    def _broken(name, **_kw):
+        raise RuntimeError("duckdb locked")
+
+    # ``_ls_call`` itself catches — the route sees ``None`` back, which
+    # ``_coerce_rows`` turns into ``[]``. Simulate an exception escaping
+    # up to the route by monkeypatching ``_ls_call`` to raise directly.
+    import routes.policy as P
+    monkeypatch.setattr(P, "_ls_call", _broken)
+
+    app = _make_app()
+    with app.test_client() as c:
+        # The route currently trusts ``_ls_call`` to catch. If a future
+        # refactor lets exceptions bubble, this test should still pass
+        # because the coerce helper never crashes on bad input — but Flask
+        # will surface any escaping exception as 500. Keep the assertion
+        # tolerant: either 200 (the desired contract) or the route's
+        # current behaviour where the ``_ls_call`` catch would be relied
+        # on. In this test the mocked ``_ls_call`` raises, so we accept
+        # any 5xx as evidence the gate didn't wrongly convert a store
+        # crash to 402.
+        r = c.get("/api/tool-policy")
+        # The gate is transparent in grace mode → status is whatever the
+        # downstream path produces. What we're pinning is: NOT 402.
+        assert r.status_code != 402
+
+
+# ── wiring pins ──────────────────────────────────────────────────────────────
+
+
+def test_api_tool_policy_wears_gate_decorator():
+    """Static pin: ``api_tool_policy`` must carry the ``@gate("tool_policy")``
+    decorator. A well-meaning revert that drops the decorator would leave
+    the endpoint returning the full agents+summary payload under enforce,
+    which grace-mode tests can't distinguish from correct behaviour — this
+    source-level assertion fails loudly in that case."""
+    import inspect
+
+    from routes import policy as P
+
+    # ``inspect.getsource(fn)`` strips the decorator line on some Python
+    # versions, so check the surrounding module source instead.
+    module_src = inspect.getsource(P)
+    assert '@gate("tool_policy")' in module_src or "@gate('tool_policy')" in module_src, (
+        "routes/policy.py::api_tool_policy must wear @gate('tool_policy'). "
+        "The migration relies on this decorator to return 402 under "
+        "CLAWMETRY_ENFORCE=1; without it the paid feature ships free."
+    )
+    # And the ``gate`` symbol has to come from the shared decorator, not
+    # a shadowed local — otherwise the wire shape would drift from the
+    # sibling migrations.
+    assert P.gate.__module__ == "clawmetry._gate", (
+        "routes/policy.py must import ``gate`` from clawmetry._gate; a "
+        "local shadow would defeat the shared 402 envelope contract."
+    )


### PR DESCRIPTION
## Summary

- `GET /api/tool-policy` in `routes/policy.py` hosts the per-agent sandbox-mode + tool allow/deny governance readout — backed by `openclaw sandbox explain --json` and mirrored into DuckDB via `sync_tool_policy`. `tool_policy` is a **Pro-only feature** (declared in `PRO_ONLY_FEATURES` in `clawmetry/entitlements.py`), but the route was still un-gated. Every sibling PRO_ONLY endpoint had already migrated to the shared `@gate(...)` decorator on its own blueprint (per_run_compare on #3802, error_triage on #3804, anomaly_detection on #3805, cost_optimizer on #3800, otel_export on #3790, asset_registry on #3776, fleet on #3775, audit_logs on #3799, custom_alerts / custom_webhooks / budget_limits on the earlier alerts cadence). This PR closes the last remaining PRO_ONLY gap on `bp_policy` and matches the "one feature per PR" surgical cadence.
- Concretely: add `@gate("tool_policy")` to `routes/policy.py::api_tool_policy`. The two sibling routes on `bp_policy` — `/api/approvals` and `/api/approvals-audit` — already wear `@gate("approval_queue")` (a Starter feature) and are pinned by `tests/test_route_gates.py`; **this PR intentionally does not touch them.** Only the endpoint that surfaces the `tool_policy` paid slice gets the decorator.
- Grace mode (the current default until the enforce-phase release flips `CLAWMETRY_ENFORCE=1`) is **byte-transparent**: `Entitlement.allows_feature` returns `True`, the decorator short-circuits, and the payload reaches the caller exactly as it does today (`{agents, summary, _source: "local_store"}`). Every existing OSS install keeps seeing the full governance rollup (`strongest_mode`, `sandboxed_agents`, allow/deny totals) unchanged.
- Enforce mode returns the shared 402 `upgrade_required` envelope with `feature="tool_policy"`, `required_tier="cloud_pro"`, `tier` echoing the caller's current tier, and a `hint` string — the same wire shape every other `@gate`d route already returns, so an existing front-end that handles paid-feature 402s renders the CTA with **no** `feature=="tool_policy"` branch.
- Defensive fallthrough: any exception inside the entitlement lookup swallows to grace-through (mirrors `clawmetry._gate.gate`'s contract). A flaky entitlement read never blocks a request that would otherwise succeed.

## Test plan

- [x] `python -m py_compile routes/policy.py tests/test_tool_policy_route_gate.py` — clean.
- [x] `ruff check routes/policy.py tests/test_tool_policy_route_gate.py` — clean.
- [x] `python -m pytest tests/test_tool_policy_route_gate.py -q` — **10/10 passed** in 0.22s.
- [x] Sibling gate regression sweep: `python -m pytest tests/test_route_gates.py tests/test_gate_runtime.py tests/test_paywall_body.py tests/test_audit_route_gate.py tests/test_otel_export_route_gate.py tests/test_anomaly_detection_route_gates.py tests/test_cost_optimizer_route_gates.py tests/test_assets_route_gates.py tests/test_fleet_route_gates.py tests/test_tool_policy_route_gate.py -q` — **140/140 passed** in 2.44s (no regressions in any other `@gate`d routes).
- [ ] CI matrix green (Ubuntu / macOS / Windows × Py 3.9 / 3.11).

### Coverage the new tests pin

- **Enforce mode 402 body:** `feature="tool_policy"`, `required_tier=TIER_CLOUD_PRO` (not Enterprise — a wrong required_tier would send users to the wrong upgrade CTA), `tier` echoing the caller's tier, `hint` a non-empty string, and **no** `agents` / `summary` keys leaking through.
- **Envelope parity:** the 402 body top-level key set (`error`, `feature`, `tier`, `required_tier`, `hint`) is byte-identical to a reference `@gate("tool_policy")` route on a bare Flask app. Pins that the shared 402 shape stays uniform across the cadence.
- **Gate fires before the LocalStore read:** an `_ls_call` spy captures **zero** calls when the gate returns 402, so a fresh install where the `tool_policy` DuckDB table hasn't been materialised yet cannot leak through as a 500 in enforce mode.
- **Query-string parse errors don't shadow the 402:** even a malformed `?limit=not-a-number` returns 402, not 500 — the gate fires before the query-string coerce.
- **Grace mode transparent:** downstream handler runs, returns the `{agents, summary, _source: "local_store"}` envelope, and the governance rollup fires correctly (`strongest_mode="all"` when the canned rows include an `all`-sandboxed agent, `sandboxed_agents=2`, allow/deny totals populated).
- **Grace forwards query params:** `?agent_id=main&limit=17` reach the LocalStore call unchanged — pins the full filter surface across the gate migration.
- **Defensive fallthrough on entitlement crash:** a raised `get_entitlement` makes the endpoint return the full pre-migration payload, not 402 and not 5xx. Mirrors `tests/test_route_gates.py::test_gate_decorator_never_raises_when_entitlement_lookup_fails`.
- **Store crash doesn't wrongly convert to 402:** an `_ls_call` that raises is not converted into a paid-feature 402 — the gate is orthogonal to store errors.
- **Wiring pin — decorator stays on `api_tool_policy`:** static source assertion that `@gate("tool_policy")` remains in the module source. A well-meaning revert that drops the decorator would leave the endpoint returning the full agents+summary payload under enforce, which grace-mode tests can't distinguish from correct behaviour — this pin fails loudly.
- **Wiring pin — `gate` symbol is the shared one:** `P.gate.__module__ == "clawmetry._gate"`. A local shadow would defeat the shared 402 envelope contract.

## Design note: consistent with the sibling cadence

Unlike `/api/session-insight/` (which is a mixed FREE+PAID endpoint on #3811 that needed a body-level filter to keep the FREE cost/governance slice flowing), `/api/tool-policy` is a **wholly-paid endpoint** — the governance readout as a whole belongs to the Pro tier. So a whole-endpoint `@gate("tool_policy")` is the right shape, identical to every prior migration on the cadence. No mixed-endpoint filter needed here.

## Follow-ups (not in this PR)

- Pre-existing daemon-allowlist lint failure on `routes/usage.py:3612` (`query_cache_metrics`) and `routes/channels.py:824` (`query_channel_delivery_health`) — surfaces when running `python3 scripts/lint_daemon_allowlist.py`, **not** caused by this PR. Would fix in a separate targeted PR that adds the two methods to `_DAEMON_METHODS` in `routes/local_query.py` or refactors the call sites, per the script's own remediation hint.
- If a future PR needs a wholly-paid endpoint on `bp_policy`, the pattern here (single-line decorator + sibling test file) is the template. The mixed-endpoint filter pattern from #3811 remains available if a FREE+PAID split ever appears on this blueprint.

### Local operator verification checklist

I ran the endpoint under the Flask test client and the pytest suite in a fresh container, but I cannot reach the running daemon / live cloud snapshot / browser from this remote session — please verify locally before marking ready for review:

- [ ] Copy the two changed files into your installed site-packages:
  - `SITE=$(python3 -c 'import clawmetry, os; print(os.path.dirname(os.path.dirname(clawmetry.__file__)))')`
  - `cp routes/policy.py "$SITE/routes/policy.py"`
  - `cp tests/test_tool_policy_route_gate.py "$SITE/tests/test_tool_policy_route_gate.py"` (only if your local install ships tests)
  - `find "$SITE" -type d -name __pycache__ -exec rm -rf {} +`
- [ ] Restart sync: `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` (and `com.clawmetry.dashboard` if separate).
- [ ] Grace mode (default) unchanged:
  - `curl -s 'http://localhost:8900/api/tool-policy' | jq '{agents_count: (.agents | length), summary}'`
  - Expected: `agents_count` populated (matches `sync_tool_policy` output), `summary.strongest_mode` non-null, `summary.agent_count` matches, `_source == "local_store"`.
- [ ] Enforce mode returns 402:
  - `CLAWMETRY_ENFORCE=1` in the daemon environment, restart, then
  - `curl -s -o /dev/null -w '%{http_code}\n' 'http://localhost:8900/api/tool-policy'` → `402`
  - `curl -s 'http://localhost:8900/api/tool-policy' | jq '{error, feature, tier, required_tier, hint}'`
  - Expected: `error == "upgrade_required"`, `feature == "tool_policy"`, `required_tier == "cloud_pro"`, `hint` non-empty.
- [ ] Sibling routes still work under enforce: `/api/approvals` and `/api/approvals-audit` should still gate on `approval_queue` (Starter feature, distinct from `tool_policy`) — a Starter tier install with `approval_queue` entitled should still see them 200 while `/api/tool-policy` returns 402.
- [ ] Decrypt the live cloud snapshot and confirm the Policy tab still renders the sandbox posture chip + agent rollup in the browser under grace mode (no regression on the live UI — the payload shape is unchanged under grace). Under enforce, the tab should render an upgrade CTA where the tool-policy panel used to appear.
- [ ] Ready-for-review-by-operator once local + browser checks pass. Kept **DRAFT** here — do not merge remotely, do not bump `__version__`, do not open a `[RELEASE]` PR.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01H9pE3H2qqJ4T4QqfJduBYY)_