### PR TITLE
feat(evals): gate /api/evals/* on `eval_suite` entitlement

### DIFF
--- a/routes/evals.py
+++ b/routes/evals.py
@@ -22,6 +22,8 @@ from __future__ import annotations
 
 from flask import Blueprint, jsonify, request
 
+from clawmetry._gate import gate
+
 bp_evals = Blueprint("evals", __name__)
 
 
@@ -101,6 +103,7 @@ def evaluators_catalogue():
 
 
 @bp_evals.route("/api/evals/recent", methods=["GET"])
+@gate("eval_suite")
 def evals_recent():
     """Recent scored sessions. ``?limit=`` defaults to 50, capped at 200."""
     try:
@@ -112,6 +115,7 @@ def evals_recent():
 
 
 @bp_evals.route("/api/evals/summary", methods=["GET"])
+@gate("eval_suite")
 def evals_summary():
     """Aggregate over the recent window. ``?window=1d`` (1d, 6h, 24h ok)."""
     raw = (request.args.get("window") or "24h").strip().lower()
@@ -145,6 +149,7 @@ def evals_summary():
 
 
 @bp_evals.route("/api/evals/rescore/<session_id>", methods=["POST"])
+@gate("eval_suite")
 def evals_rescore(session_id: str):
     """Manually trigger a re-score for one session. Synchronous — returns
     the new score (or skip / failure) so the UI can flash a toast.
@@ -172,6 +177,7 @@ def evals_rescore(session_id: str):
 
 
 @bp_evals.route("/api/evals/rubric", methods=["GET"])
+@gate("eval_suite")
 def evals_rubric_get():
     """Return the raw rubric YAML text + the parsed default for reference."""
     try:
@@ -187,6 +193,7 @@ def evals_rubric_get():
 
 
 @bp_evals.route("/api/evals/regression-summary", methods=["GET"])
+@gate("eval_suite")
 def evals_regression_summary():
     """Phase 3 (refs #1619) — aggregate replay outcomes over a window.
 
@@ -224,6 +231,7 @@ def evals_regression_summary():
 
 
 @bp_evals.route("/api/evals/key", methods=["GET"])
+@gate("eval_suite")
 def evals_key_get():
     """Presence-only: which judge providers have a key (env or UI-saved).
     NEVER returns the key value itself."""
@@ -239,6 +247,7 @@ def evals_key_get():
 
 
 @bp_evals.route("/api/evals/key", methods=["POST"])
+@gate("eval_suite")
 def evals_key_save():
     """Save (or clear) a judge API key locally so evals can run without an env
     var. Body: ``{"provider": "anthropic"|"openai", "api_key": "<key>"}``. An
@@ -263,6 +272,7 @@ def evals_key_save():
 
 
 @bp_evals.route("/api/evals/rubric", methods=["POST"])
+@gate("eval_suite")
 def evals_rubric_save():
     """Replace the rubric YAML. Validates parse before writing.
 

--- a/tests/test_evals_route_gates.py
+++ b/tests/test_evals_route_gates.py
@@ -1,0 +1,520 @@
+"""Enforce/grace-mode contract tests for the ``bp_evals`` endpoints in
+``routes/evals.py``.
+
+``eval_suite`` is a Pro-only feature (see ``PRO_ONLY_FEATURES`` in
+``clawmetry/entitlements.py``). Seven public JSON endpoints implement it,
+so all seven wear the ``@gate("eval_suite")`` decorator:
+
+  * ``GET  /api/evals/recent``
+  * ``GET  /api/evals/summary``
+  * ``POST /api/evals/rescore/<session_id>``
+  * ``GET  /api/evals/rubric``
+  * ``POST /api/evals/rubric``
+  * ``GET  /api/evals/regression-summary``
+  * ``GET  /api/evals/key``
+  * ``POST /api/evals/key``
+
+The eighth route on ``bp_evals`` — ``GET /api/evaluators`` — is the
+shop-menu catalogue. It intentionally exposes the ``locked: true`` state
+of Pro evaluators so the UI can render an upgrade CTA, so it stays free
+and is deliberately *not* gated. This test file pins that split so a
+well-meaning refactor that gates the catalogue too (which would blank
+the CTA under enforce and confuse the upgrade flow) fails loudly.
+
+Sibling of ``tests/test_anomaly_detection_route_gates.py``,
+``tests/test_cost_optimizer_route_gates.py``,
+``tests/test_assets_route_gates.py``,
+``tests/test_fleet_route_gates.py``, ``tests/test_audit_route_gate.py``,
+``tests/test_otel_export_route_gate.py``,
+``tests/test_run_compare_route_gate.py``, and
+``tests/test_error_triage_route_gate.py``. Pins the same contract for
+these eight routes so a future edit to ``routes/evals.py`` can't
+silently drop the gate:
+
+  1. Enforce mode: each gated endpoint returns the shared 402
+     ``upgrade_required`` envelope with ``feature="eval_suite"`` and
+     ``required_tier=TIER_CLOUD_PRO``. The gate check fires before any
+     handler code runs, so the 402 short-circuits before
+     ``clawmetry.eval_runner`` or the DuckDB helpers are even imported.
+  2. Grace mode: the gate is transparent. Downstream handlers run with
+     a stubbed ``clawmetry.eval_runner`` + local-store hop so the
+     payload builders can finish without touching disk.
+  3. The 402 wire shape is byte-identical to what other ``@gate``d
+     routes return, so an existing front-end that already handles 402s
+     from ``bp_assets`` / ``bp_audit`` / ``bp_otel_export`` /
+     ``bp_config`` keeps working here without a special-case branch on
+     ``feature=="eval_suite"``.
+  4. A resolver crash never surfaces as 402 -- mirrors the defensive
+     contract pinned in ``tests/test_route_gates.py``.
+  5. The catalogue ``/api/evaluators`` stays free -- a whole-blueprint
+     gate would break the upgrade CTA render path.
+"""
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+
+import pytest
+from flask import Flask
+
+
+# ── fixtures ────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def enforce(monkeypatch, tmp_path):
+    """OSS install under ``CLAWMETRY_ENFORCE=1`` -- the tier is oss and
+    ``eval_suite`` (a Pro-only feature) is NOT allowed."""
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def grace(monkeypatch, tmp_path):
+    """Default grace mode -- every feature key passes through the gate."""
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+def _make_app():
+    from routes.evals import bp_evals
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_evals)
+    return app
+
+
+def _stub_eval_runner(monkeypatch):
+    """Install a stub ``clawmetry.eval_runner`` so the handlers'
+    ``from clawmetry import eval_runner`` calls resolve to a hermetic
+    object with the surface the routes actually touch.
+
+    The handlers touch a handful of module-level attributes and helper
+    functions; we stub each to return the smallest well-shaped value
+    that keeps the payload builders from raising. This lets grace-mode
+    tests exercise the whole handler without touching the real
+    disk-backed rubric or judge-key files.
+    """
+    stub = types.ModuleType("clawmetry.eval_runner")
+
+    stub.RUBRIC_PATH = "/tmp/does-not-exist.yaml"
+    stub.DEFAULT_RUBRIC = {"kind": "default", "criteria": []}
+
+    def is_enabled():
+        return True
+
+    def get_rubric_yaml():
+        return "kind: default\n"
+
+    def judge_keys_present():
+        return {"anthropic": False, "openai": False}
+
+    def save_judge_key(_provider, _api_key):
+        return None
+
+    def save_rubric_yaml(_text):
+        return None
+
+    def load_rubric(_name):
+        return {"kind": "default", "criteria": []}
+
+    class _Result:
+        def to_dict(self):
+            return {"session_id": "sid", "score": 0.5}
+
+    class _Runner:
+        def score_session(self, _sid):
+            return _Result()
+
+    stub.is_enabled = is_enabled
+    stub.get_rubric_yaml = get_rubric_yaml
+    stub.judge_keys_present = judge_keys_present
+    stub.save_judge_key = save_judge_key
+    stub.save_rubric_yaml = save_rubric_yaml
+    stub.load_rubric = load_rubric
+    stub.EvalRunner = _Runner
+
+    monkeypatch.setitem(sys.modules, "clawmetry.eval_runner", stub)
+    return stub
+
+
+def _stub_regression_replay(monkeypatch):
+    """Install a stub ``clawmetry.eval_regression_replay`` for the
+    regression-summary handler so grace-mode tests don't hit the real
+    DuckDB reader."""
+    stub = types.ModuleType("clawmetry.eval_regression_replay")
+
+    def regression_summary(window_days: int = 7):
+        return {
+            "tested": 0, "improved": 0, "regressed": 0, "same": 0,
+            "errored": 0, "window_days": window_days, "last_run_at": None,
+        }
+
+    stub.regression_summary = regression_summary
+    monkeypatch.setitem(sys.modules, "clawmetry.eval_regression_replay", stub)
+    return stub
+
+
+def _stub_store_helpers(monkeypatch):
+    """Stub the ``routes.local_query.local_store_via_daemon`` and
+    ``clawmetry.local_store`` calls so grace-mode tests don't require a
+    live daemon or a DuckDB file. Both return ``None`` -- the handlers
+    already treat that as "no rows" and emit an empty envelope.
+    """
+    from routes import evals as evals_module
+
+    def _none(*_a, **_kw):
+        return None
+
+    monkeypatch.setattr(evals_module, "_store_via_daemon_or_direct", _none)
+
+
+# ── enforce mode: 402 on every gated endpoint ────────────────────────────────
+
+
+# Each entry is (http_method, path). Route decorators declare methods
+# explicitly (GET/POST) on each endpoint.
+_ENFORCE_MATRIX = [
+    ("GET",  "/api/evals/recent"),
+    ("GET",  "/api/evals/summary"),
+    ("POST", "/api/evals/rescore/sid-42"),
+    ("GET",  "/api/evals/rubric"),
+    ("POST", "/api/evals/rubric"),
+    ("GET",  "/api/evals/regression-summary"),
+    ("GET",  "/api/evals/key"),
+    ("POST", "/api/evals/key"),
+]
+
+
+def _call(client, method, path, *, json=None):
+    if method == "GET":
+        return client.get(path)
+    if method == "POST":
+        return client.post(path, json=json or {})
+    raise AssertionError(f"unhandled method {method!r}")
+
+
+@pytest.mark.parametrize("method,path", _ENFORCE_MATRIX)
+def test_evals_endpoint_returns_402_when_enforced(enforce, method, path):
+    """Each gated endpoint returns the shared 402 body in enforce mode."""
+    app = _make_app()
+    with app.test_client() as c:
+        r = _call(c, method, path)
+        assert r.status_code == 402, (
+            f"{method} {path} returned {r.status_code}, expected 402 "
+            "(gate should short-circuit before handler runs)"
+        )
+        body = r.get_json()
+        assert body["error"] == "upgrade_required"
+        assert body["feature"] == "eval_suite"
+        # Pro-only feature -- required_tier must be TIER_CLOUD_PRO so the
+        # paywall CTA routes users to the right plan (not Starter, not
+        # Enterprise).
+        assert body["required_tier"] == enforce.TIER_CLOUD_PRO
+        # ``tier`` reflects the caller's current tier so the UI can
+        # render the delta ("you have X, upgrade to Y"). On an OSS
+        # install with no license, this is TIER_OSS.
+        assert body["tier"] == enforce.TIER_OSS
+        assert isinstance(body.get("hint"), str) and body["hint"]
+        # No eval payload leaked through -- the gate short-circuited.
+        assert "evals" not in body
+        assert "avg_score" not in body
+        assert "yaml" not in body
+        assert "present" not in body
+
+
+@pytest.mark.parametrize("method,path", _ENFORCE_MATRIX)
+def test_evals_402_body_shape_matches_shared_gate(enforce, method, path):
+    """The 402 body must carry the *same top-level keys* every other
+    ``@gate``d route returns so the front-end can handle any paid-feature
+    402 with one branch. Pins that a later refactor of ``@gate`` doesn't
+    silently drop ``required_tier`` or ``tier`` on these routes.
+    """
+    from clawmetry._gate import gate as _gate
+
+    reference_app = Flask(__name__)
+
+    @reference_app.route("/reference")
+    @_gate("eval_suite")
+    def _reference_view():  # pragma: no cover - never runs in enforce mode
+        return {"ok": True}
+
+    target_app = _make_app()
+
+    with reference_app.test_client() as rc, target_app.test_client() as ac:
+        ref_body = rc.get("/reference").get_json()
+        act_body = _call(ac, method, path).get_json()
+        assert set(ref_body.keys()) == set(act_body.keys())
+        assert set(ref_body.keys()) == {
+            "error",
+            "feature",
+            "tier",
+            "required_tier",
+            "hint",
+        }
+        assert ref_body["feature"] == act_body["feature"] == "eval_suite"
+        assert ref_body["required_tier"] == act_body["required_tier"]
+        assert ref_body["tier"] == act_body["tier"]
+
+
+@pytest.mark.parametrize("method,path", _ENFORCE_MATRIX)
+def test_evals_gate_fires_before_eval_runner_import(
+    enforce, monkeypatch, method, path
+):
+    """The gate has to short-circuit the request *before* the handler
+    runs. Prove it by installing a distinctive booby-trap
+    ``clawmetry.eval_runner`` module: if the gate were missing, the
+    handler's ``from clawmetry import eval_runner`` would either succeed
+    (leaking a 200) or blow up with an ``AssertionError`` -- neither is
+    a 402. The gate short-circuits, so we never reach the import.
+    """
+    class _Boom:  # pragma: no cover - only hit on regression
+        def __getattr__(self, name):
+            raise AssertionError(
+                f"gate should have short-circuited before "
+                f"eval_runner.{name} was reached"
+            )
+
+    monkeypatch.setitem(sys.modules, "clawmetry.eval_runner", _Boom())
+    monkeypatch.setitem(sys.modules, "clawmetry.eval_regression_replay", _Boom())
+
+    app = _make_app()
+    with app.test_client() as c:
+        r = _call(c, method, path)
+        assert r.status_code == 402
+
+
+# ── grace mode: gate is transparent on every endpoint ───────────────────────
+
+
+@pytest.mark.parametrize("method,path", _ENFORCE_MATRIX)
+def test_evals_endpoint_is_transparent_in_grace_mode(
+    monkeypatch, grace, method, path
+):
+    """Grace mode (the current default until the enforce-phase release)
+    must let the request through unchanged. The downstream handler runs
+    with a stubbed ``clawmetry.eval_runner`` + local-store hop so the
+    payload builder is exercised without touching disk.
+    """
+    _stub_eval_runner(monkeypatch)
+    _stub_regression_replay(monkeypatch)
+    _stub_store_helpers(monkeypatch)
+
+    body_json = None
+    if method == "POST" and path == "/api/evals/key":
+        body_json = {"provider": "anthropic", "api_key": "sk-test"}
+    if method == "POST" and path == "/api/evals/rubric":
+        body_json = {"yaml": "kind: default\n"}
+
+    app = _make_app()
+    with app.test_client() as c:
+        r = _call(c, method, path, json=body_json)
+        assert r.status_code != 402, (
+            f"{method} {path} 402'd in grace mode; gate is not transparent"
+        )
+        body = r.get_json()
+        assert isinstance(body, dict)
+        # The 402 short-circuit body has ``error="upgrade_required"``;
+        # the handler payload never does. Pins that the gate stayed
+        # transparent AND the handler emitted its own body.
+        assert body.get("error") != "upgrade_required"
+
+
+def test_evals_recent_grace_payload_shape(monkeypatch, grace):
+    """Grace mode: /api/evals/recent must still emit the pre-migration
+    ``{evals, limit}`` envelope."""
+    _stub_store_helpers(monkeypatch)
+
+    app = _make_app()
+    with app.test_client() as c:
+        body = c.get("/api/evals/recent").get_json()
+        assert "evals" in body
+        assert body.get("limit") == 50
+
+
+def test_evals_summary_grace_payload_shape(monkeypatch, grace):
+    """Grace mode: /api/evals/summary must still emit the pre-migration
+    aggregate envelope."""
+    _stub_store_helpers(monkeypatch)
+
+    app = _make_app()
+    with app.test_client() as c:
+        body = c.get("/api/evals/summary").get_json()
+        for key in ("avg_score", "total", "scored", "p50", "p10",
+                    "window_hours"):
+            assert key in body, f"grace payload missing {key!r}"
+
+
+def test_evals_rubric_grace_payload_shape(monkeypatch, grace):
+    """Grace mode: GET /api/evals/rubric must still emit the pre-migration
+    ``{yaml, rubric_path, default, enabled}`` envelope."""
+    _stub_eval_runner(monkeypatch)
+
+    app = _make_app()
+    with app.test_client() as c:
+        body = c.get("/api/evals/rubric").get_json()
+        for key in ("yaml", "rubric_path", "default", "enabled"):
+            assert key in body, f"grace payload missing {key!r}"
+
+
+def test_evals_key_grace_payload_shape(monkeypatch, grace):
+    """Grace mode: GET /api/evals/key must still emit the pre-migration
+    ``{present, any}`` envelope (no key values leaked)."""
+    _stub_eval_runner(monkeypatch)
+
+    app = _make_app()
+    with app.test_client() as c:
+        body = c.get("/api/evals/key").get_json()
+        assert "present" in body
+        assert "any" in body
+        assert body["any"] is False
+        # Presence-only endpoint must never echo a raw key back.
+        assert "api_key" not in body
+
+
+def test_evals_regression_summary_grace_payload_shape(monkeypatch, grace):
+    """Grace mode: /api/evals/regression-summary must still emit the
+    aggregate envelope."""
+    _stub_regression_replay(monkeypatch)
+
+    app = _make_app()
+    with app.test_client() as c:
+        body = c.get("/api/evals/regression-summary").get_json()
+        for key in ("tested", "improved", "regressed", "same", "errored",
+                    "window_days", "last_run_at"):
+            assert key in body, f"grace payload missing {key!r}"
+
+
+# ── /api/evaluators catalogue stays free ────────────────────────────────────
+
+
+def test_evaluators_catalogue_is_not_gated_in_enforce_mode(monkeypatch, enforce):
+    """``/api/evaluators`` is the shop-menu catalogue -- it exposes the
+    ``locked: true`` state of Pro evaluators so the dashboard can render
+    an upgrade CTA. Gating it too would blank the CTA target under
+    enforce mode and break the very upgrade flow it exists to serve.
+
+    So this endpoint deliberately stays free. Pin the split here: if a
+    later refactor blanket-gates the whole ``bp_evals`` blueprint
+    (rather than the seven paid endpoints), this test fails and calls
+    the reviewer's attention to the CTA regression.
+    """
+    # Even without a store, the catalogue returns the static evaluator
+    # list. Any 402 here would signal the wrong-shape gate.
+    app = _make_app()
+    with app.test_client() as c:
+        r = c.get("/api/evaluators")
+        assert r.status_code != 402, (
+            "/api/evaluators must not be gated -- it's the shop-menu "
+            "catalogue that carries the upgrade CTA."
+        )
+        body = r.get_json()
+        # The catalogue must at least respond with a dict envelope even
+        # when the evaluators module has nothing to return; the handler
+        # is defensive by design (returns ``{evaluators: [], error: ...}``
+        # on catalog import failure).
+        assert isinstance(body, dict)
+
+
+# ── defensive fallthrough ────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("method,path", _ENFORCE_MATRIX)
+def test_entitlement_lookup_crash_falls_through(
+    monkeypatch, enforce, method, path
+):
+    """Mirrors the contract in ``tests/test_route_gates.py``: if the
+    entitlement read itself raises, the request path stays defensive and
+    the handler runs -- the worst that happens is a paid feature briefly
+    runs on a Free tier. A flaky entitlement check must never fail
+    closed.
+    """
+    def _explode():
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr("clawmetry.entitlements.get_entitlement", _explode)
+    _stub_eval_runner(monkeypatch)
+    _stub_regression_replay(monkeypatch)
+    _stub_store_helpers(monkeypatch)
+
+    body_json = None
+    if method == "POST" and path == "/api/evals/key":
+        body_json = {"provider": "anthropic", "api_key": "sk-test"}
+    if method == "POST" and path == "/api/evals/rubric":
+        body_json = {"yaml": "kind: default\n"}
+
+    app = _make_app()
+    with app.test_client() as c:
+        r = _call(c, method, path, json=body_json)
+        # Graceful fallthrough: NOT 402. Handler runs and returns
+        # whatever it would have returned pre-migration (200 with the
+        # payload envelope on the happy path, or a 4xx/5xx envelope if
+        # a helper raises -- both acceptable, the key is we did not
+        # fail closed with a 402).
+        assert r.status_code != 402
+
+
+# ── decorator wiring pin ─────────────────────────────────────────────────────
+
+
+def test_evals_routes_wear_gate_decorator():
+    """All seven paid eval routes must be wired with
+    ``@gate("eval_suite")``. Pin this at the module level so a
+    well-meaning revert that drops the decorator from any single route
+    (leaving a partial gate -- indistinguishable in a single-route grace
+    test) fails loudly instead of silently reverting the gate.
+
+    We check by inspecting the source rather than by calling the route
+    because the ``@gate`` decorator is transparent in grace mode; a
+    regression that dropped it would look identical in grace tests.
+    """
+    import inspect
+
+    from routes import evals as evals_module
+
+    src = inspect.getsource(evals_module)
+    assert 'from clawmetry._gate import gate' in src, (
+        "routes/evals.py must import @gate from clawmetry._gate"
+    )
+    # Exactly seven distinct paid endpoints exist today (recent, summary,
+    # rescore, rubric GET+POST, regression-summary, key GET+POST = 8
+    # route entries, one route decorator each). If a ninth is added it
+    # should also wear the gate, so this pin should be updated in the
+    # same PR that adds it (a mismatch is a signal to inspect).
+    assert src.count('@gate("eval_suite")') == 8, (
+        'routes/evals.py must decorate all eight paid eval routes with '
+        '@gate("eval_suite") -- this is the only enforcement point '
+        'until the closed-source clawmetry-pro package overrides the '
+        'blueprint via the extensions entry point.'
+    )
+    # The shop-menu catalogue must NOT wear the gate -- gating it would
+    # blank the upgrade CTA target under enforce mode.
+    catalogue_src = inspect.getsource(evals_module.evaluators_catalogue)
+    assert '@gate' not in catalogue_src, (
+        "/api/evaluators (the shop-menu catalogue) must stay free; "
+        "gating it would blank the upgrade CTA target under enforce."
+    )
+
+
+def test_gate_symbol_is_shared():
+    """Wiring pin -- ``routes.evals.gate`` must resolve to the shared
+    ``clawmetry._gate.gate`` symbol. A local shadow would defeat the
+    shared 402 envelope contract, since the envelope shape is enforced
+    by the shared decorator's implementation.
+    """
+    from routes import evals as evals_module
+
+    assert evals_module.gate.__module__ == "clawmetry._gate"


### PR DESCRIPTION
## Summary

- `routes/evals.py` hosts the LLM-as-judge scoring endpoints on `bp_evals`. `eval_suite` is a **Pro-only feature** (declared in `PRO_ONLY_FEATURES` in `clawmetry/entitlements.py`), but every endpoint on this blueprint was still un-gated. Every sibling PRO_ONLY endpoint had already migrated to the shared `@gate(...)` decorator on its own blueprint (per_run_compare on #3802, error_triage on #3804, anomaly_detection on #3805, cost_optimizer on #3800, otel_export on #3790, asset_registry on #3776, fleet on #3775, audit_logs on #3799, custom_alerts / custom_webhooks / budget_limits on the earlier alerts cadence, tool_policy on #3812). This PR closes the last remaining PRO_ONLY gap on `bp_evals` and matches the "one feature per PR" surgical cadence.
- Concretely: add `@gate("eval_suite")` to the seven paid endpoints on `bp_evals`:
  - `GET  /api/evals/recent`
  - `GET  /api/evals/summary`
  - `POST /api/evals/rescore/<session_id>`
  - `GET  /api/evals/rubric`
  - `POST /api/evals/rubric`
  - `GET  /api/evals/regression-summary`
  - `GET  /api/evals/key`
  - `POST /api/evals/key`
- **`/api/evaluators` intentionally stays free.** It is the shop-menu catalogue that exposes the `locked: true` state of Pro evaluators so the dashboard can render the correct upgrade CTA. Gating it too would blank the CTA target under enforce mode and break the very upgrade flow it exists to serve. A dedicated wiring pin in the new test file (`test_evals_routes_wear_gate_decorator`) asserts this split so a well-meaning refactor that blanket-gates the whole blueprint fails loudly.
- Grace mode (the current default until the enforce-phase release flips `CLAWMETRY_ENFORCE=1`) is **byte-transparent**: `Entitlement.allows_feature` returns `True`, the decorator short-circuits, and each payload reaches the caller exactly as it does today (`{evals, limit}` for recent, `{avg_score, total, scored, p50, p10, window_hours}` for summary, etc.). Every existing OSS install keeps seeing the eval endpoints unchanged.
- Enforce mode returns the shared 402 `upgrade_required` envelope with `feature="eval_suite"`, `required_tier="cloud_pro"`, `tier` echoing the caller's current tier, and a `hint` string — the same wire shape every other `@gate`d route already returns, so an existing front-end that handles paid-feature 402s renders the CTA with **no** `feature=="eval_suite"` branch.
- Defensive fallthrough: any exception inside the entitlement lookup swallows to grace-through (mirrors `clawmetry._gate.gate`'s contract). A flaky entitlement read never blocks a request that would otherwise succeed.

## Test plan

- [x] `python -m py_compile routes/evals.py tests/test_evals_route_gates.py` — clean.
- [x] `ruff check routes/evals.py tests/test_evals_route_gates.py` — clean.
- [x] `python -m pytest tests/test_evals_route_gates.py -q` — **48/48 passed** in 1.07s.
- [x] Sibling gate regression sweep: `python -m pytest tests/test_route_gates.py tests/test_gate_runtime.py tests/test_paywall_body.py tests/test_anomaly_detection_route_gates.py tests/test_cost_optimizer_route_gates.py tests/test_assets_route_gates.py tests/test_fleet_route_gates.py tests/test_audit_route_gate.py tests/test_otel_export_route_gate.py tests/test_evals_route_gates.py -q` — **178/178 passed** in 3.37s (no regressions in any other `@gate`d routes).
- [ ] CI matrix green (Ubuntu / macOS / Windows × Py 3.9 / 3.11).

### Coverage the new tests pin

- **Enforce mode 402 body:** `feature="eval_suite"`, `required_tier=TIER_CLOUD_PRO` (not Starter, not Enterprise — a wrong required_tier would send users to the wrong upgrade CTA), `tier` echoing the caller's tier, `hint` a non-empty string, and **no** `evals` / `avg_score` / `yaml` / `present` keys leaking through.
- **Envelope parity:** the 402 body top-level key set (`error`, `feature`, `tier`, `required_tier`, `hint`) is byte-identical to a reference `@gate("eval_suite")` route on a bare Flask app. Pins that the shared 402 shape stays uniform across the cadence.
- **Gate fires before the eval_runner import:** a `clawmetry.eval_runner` booby-trap raises `AssertionError` on any attribute access; each enforce test still returns 402, so a fresh install without a rubric file cannot leak through as a 500 in enforce mode.
- **Grace mode transparent:** each downstream handler runs, returns its pre-migration envelope. Per-endpoint payload-shape pins on `/api/evals/recent`, `/api/evals/summary`, `/api/evals/rubric`, `/api/evals/key`, `/api/evals/regression-summary`.
- **Presence-only key endpoint stays presence-only:** `GET /api/evals/key` never echoes a raw `api_key` back in grace mode (regression pin for the never-leak-a-key contract that was already in place before the gate).
- **`/api/evaluators` catalogue stays free:** dedicated test that the shop-menu catalogue is not gated in enforce mode. If a later refactor blanket-gates the whole blueprint, this pin fires and calls the reviewer's attention to the CTA regression.
- **Defensive fallthrough on entitlement crash:** a raised `get_entitlement` makes each endpoint return its pre-migration payload, not 402 and not fail-closed. Mirrors `tests/test_route_gates.py::test_gate_decorator_never_raises_when_entitlement_lookup_fails`.
- **Wiring pin — decorator stays on all seven views:** `inspect.getsource(routes.evals)` must contain exactly eight `@gate("eval_suite")` markers (seven distinct paid endpoints — the two rubric routes and the two key routes both have their own decorator, and rescore has one). A well-meaning revert that drops the decorator would leave the endpoint returning the full payload under enforce, which grace-mode tests can't distinguish from correct behaviour — this pin fails loudly.
- **Wiring pin — `evaluators_catalogue` intentionally has no gate:** static-source assertion that the catalogue view is *not* decorated, so a refactor that blanket-gates the whole blueprint fires this pin instead of silently blanking the upgrade CTA.
- **Wiring pin — `gate` symbol is the shared one:** `routes.evals.gate.__module__ == "clawmetry._gate"`. A local shadow would defeat the shared 402 envelope contract.

## Design note: catalogue stays free, paid endpoints get the decorator

Unlike `/api/session-insight/` (which is a mixed FREE+PAID endpoint on #3811 that needed a body-level filter to keep the FREE cost/governance slice flowing), the eval blueprint splits cleanly at the URL boundary: `/api/evaluators` is the free catalogue, and the seven paid endpoints are wholly-paid. So a whole-endpoint `@gate("eval_suite")` on each paid route is the right shape, matching every prior "one feature per PR" migration. No mixed-endpoint filter needed here.

## Follow-ups (not in this PR)

- The pre-existing `tests/test_eval_runner.py` and `tests/test_eval_regression_replay.py` failures on `test_runner_skips_when_rate_limit_exhausted`, `test_score_persists_when_judge_succeeds`, and friends reproduce on unmodified `origin/main` (confirmed via `git stash` and re-running the failing test with the branch unpatched). Unrelated to this gate migration; would fix in a separate targeted PR that adjusts the fixture setup for the missing judge-key handling path.

### Local operator verification checklist

I ran the endpoint under the Flask test client and the pytest suite in a fresh container, but I cannot reach the running daemon / live cloud snapshot / browser from this remote session — please verify locally before marking ready for review:

- [ ] Copy the two changed files into your installed site-packages:
  - `SITE=$(python3 -c 'import clawmetry, os; print(os.path.dirname(os.path.dirname(clawmetry.__file__)))')`
  - `cp routes/evals.py "$SITE/routes/evals.py"`
  - `cp tests/test_evals_route_gates.py "$SITE/tests/test_evals_route_gates.py"` (only if your local install ships tests)
  - `find "$SITE" -type d -name __pycache__ -exec rm -rf {} +`
- [ ] Restart sync: `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` (and `com.clawmetry.dashboard` if separate).
- [ ] Grace mode (default) unchanged:
  - `curl -s 'http://localhost:8900/api/evals/recent' | jq '{count: (.evals | length), limit}'`
  - Expected: `count` matches the persisted eval row count, `limit == 50`.
  - `curl -s 'http://localhost:8900/api/evals/summary' | jq '{avg_score, total, scored, window_hours}'`
  - Expected: aggregate fields populated (or all zeros on a fresh install), `window_hours == 24`.
  - `curl -s 'http://localhost:8900/api/evaluators' | jq '.evaluators | length'`
  - Expected: catalogue length > 0 (the catalogue must stay free — no 402).
- [ ] Enforce mode returns 402:
  - `CLAWMETRY_ENFORCE=1` in the daemon environment, restart, then
  - `curl -s -o /dev/null -w '%{http_code}\n' 'http://localhost:8900/api/evals/recent'` → `402`
  - `curl -s 'http://localhost:8900/api/evals/recent' | jq '{error, feature, tier, required_tier, hint}'`
  - Expected: `error == "upgrade_required"`, `feature == "eval_suite"`, `required_tier == "cloud_pro"`, `hint` non-empty.
  - Repeat for `/api/evals/summary`, `/api/evals/rubric`, `/api/evals/key`, `/api/evals/regression-summary`.
- [ ] Catalogue stays free under enforce: `curl -s -o /dev/null -w '%{http_code}\n' 'http://localhost:8900/api/evaluators'` → `200` (must not be 402 — the CTA target).
- [ ] Sibling routes still work under enforce: the anomaly-detection / cost-optimizer / asset-registry / fleet / audit-logs / otel-export / run-compare / error-triage / tool-policy endpoints should still gate on their own feature keys — no cross-contamination.
- [ ] Decrypt the live cloud snapshot and confirm the Evals tab still renders the recent-scores card + aggregate + rubric editor in the browser under grace mode (no regression on the live UI — the payload shape is unchanged under grace). Under enforce, the tab should render an upgrade CTA where the eval cards used to appear, but the evaluator catalogue tile (the CTA target) must still render.
- [ ] Ready-for-review-by-operator once local + browser checks pass. Kept **DRAFT** here — do not merge remotely, do not bump `__version__`, do not open a `[RELEASE]` PR.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JWB52Pvk9wp5revqSnHCn1)_