### PR TITLE
feat(agents): gate /api/agents/&lt;name&gt;/sessions on runtime entitlement

### DIFF
--- a/routes/agents.py
+++ b/routes/agents.py
@@ -12,6 +12,17 @@ Zero coupling to ``dashboard.py``: this module only imports from
 ``clawmetry.adapters``. The adapters themselves reach into dashboard
 globals where needed (OpenClawAdapter) — that indirection stays
 contained inside the adapter.
+
+Runtime gating
+--------------
+``/api/agents/<name>/sessions`` returns per-runtime session data and is
+therefore gated with :func:`require_runtime` — mirrors what
+``dashboard_claudecode.py`` does with ``@gate_runtime("claude_code")``
+for the standalone Claude Code dashboard. The two detection endpoints
+(``/api/agents`` and ``/api/agents/<name>``) stay ungated so the UI can
+render locked runtime chips + an upgrade CTA in context (same reasoning
+``dashboard_claudecode.py`` uses to keep ``/api/health`` reachable in
+enforce mode).
 """
 from __future__ import annotations
 
@@ -21,6 +32,7 @@ from flask import Blueprint, jsonify, request
 from clawmetry.config import is_local_store_read_enabled
 
 from clawmetry.adapters import registry
+from clawmetry._gate import require_runtime
 
 bp_agents = Blueprint("agents", __name__)
 
@@ -112,6 +124,9 @@ def api_agent_detail(name: str):
 
 @bp_agents.route("/api/agents/<name>/sessions")
 def api_agent_sessions(name: str):
+    blocked = require_runtime(name)
+    if blocked is not None:
+        return blocked
     try:
         limit = max(1, min(1000, int(request.args.get("limit", 100))))
     except (TypeError, ValueError):

--- a/tests/test_agents_route_runtime_gate.py
+++ b/tests/test_agents_route_runtime_gate.py
@@ -1,0 +1,194 @@
+"""Runtime-gate wiring for the per-agent sessions endpoint on ``bp_agents``.
+
+``/api/agents/<name>/sessions`` returns per-runtime session data, so it is
+gated with :func:`clawmetry._gate.require_runtime` — the same contract
+``dashboard_claudecode.py`` enforces with ``@gate_runtime("claude_code")``
+on its JSON endpoints. This module pins the contract on the real
+``routes/agents.py`` blueprint that ``dashboard.py`` registers:
+
+* Enforce mode + OSS-free install → paid-runtime session listings return
+  402 with ``error="upgrade_required"``, ``runtime=<canonical>``, and
+  ``required_tier=cloud_starter`` (mirrors ``tests/test_claudecode_runtime_gate``
+  / ``routes/fleet_history.py``).
+* Enforce mode + free runtime (``openclaw``, ``nemoclaw``) → gate passes
+  through unchanged.
+* Grace mode (the default) → gate is transparent for both free and paid
+  runtimes so wiring the gate in does not shift any current behaviour.
+* Runtime aliases (``claude-code``) canonicalise before the gate so an
+  alias for a paid runtime still 402s consistently in enforce mode.
+* The two detection endpoints (``/api/agents``, ``/api/agents/<name>``)
+  intentionally stay ungated — the UI needs them in enforce mode to
+  render locked runtime chips + an upgrade CTA. Mirrors the
+  ``bp_claudecode`` decision to keep ``/api/health`` reachable.
+* A flaky entitlement read never surfaces as 402 — the request falls
+  through, matching the defensive contract in
+  ``tests/test_route_gates.py`` and ``tests/test_claudecode_runtime_gate``.
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def enforce(monkeypatch, tmp_path):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def grace(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+def _make_app():
+    from routes.agents import bp_agents
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_agents)
+    return app
+
+
+# One per PAID_RUNTIMES entry — the gate must 402 for every paid runtime,
+# not just the (currently) most common one. Kept in lockstep with
+# ``clawmetry.entitlements.PAID_RUNTIMES``; adding a new paid runtime
+# there flows through this parametrisation automatically.
+def _paid_runtime_ids():
+    from clawmetry import entitlements as _ent
+    return sorted(_ent.PAID_RUNTIMES)
+
+
+@pytest.mark.parametrize("runtime", _paid_runtime_ids())
+def test_paid_runtime_sessions_returns_402_when_enforced(enforce, runtime):
+    app = _make_app()
+    with app.test_client() as c:
+        r = c.get(f"/api/agents/{runtime}/sessions")
+        assert r.status_code == 402, (
+            f"/api/agents/{runtime}/sessions → {r.status_code}"
+        )
+        body = r.get_json()
+        assert body["error"] == "upgrade_required"
+        assert body["runtime"] == runtime
+        assert body["required_tier"] == enforce.TIER_CLOUD_STARTER
+        assert "hint" in body
+        assert "tier" in body
+
+
+@pytest.mark.parametrize("runtime", ["openclaw", "nemoclaw"])
+def test_free_runtime_sessions_passes_through_when_enforced(enforce, runtime):
+    """FREE_RUNTIMES must never 402 — even in enforce mode. The gate has to
+    stay transparent for the OSS runtimes, otherwise every install would
+    lose its own sessions view when enforcement flips on."""
+    app = _make_app()
+    with app.test_client() as c:
+        r = c.get(f"/api/agents/{runtime}/sessions")
+        assert r.status_code != 402, (
+            f"/api/agents/{runtime}/sessions unexpectedly 402'd for a free runtime"
+        )
+
+
+@pytest.mark.parametrize("runtime", ["claude_code", "openclaw", "codex"])
+def test_sessions_transparent_in_grace_mode(grace, runtime):
+    """Grace mode is the default until enforcement flips on; the wiring
+    must not shift any current behaviour. Downstream may return 200-empty
+    or 5xx depending on filesystem state — we only need to confirm the
+    gate did NOT short-circuit with 402."""
+    app = _make_app()
+    with app.test_client() as c:
+        r = c.get(f"/api/agents/{runtime}/sessions")
+        assert r.status_code != 402, (
+            f"/api/agents/{runtime}/sessions unexpectedly gated in grace mode: "
+            f"{r.status_code}"
+        )
+
+
+@pytest.mark.parametrize("alias,canonical", [
+    ("claude-code", "claude_code"),
+    ("claudecode", "claude_code"),
+    ("qwen-code", "qwen_code"),
+    ("deep-agents", "deepagents"),
+])
+def test_paid_runtime_alias_still_402s(enforce, alias, canonical):
+    """``require_runtime`` canonicalises the runtime id (``claude-code`` →
+    ``claude_code``) before the entitlement check, so an alias for a paid
+    runtime still 402s with the canonical id echoed back."""
+    app = _make_app()
+    with app.test_client() as c:
+        r = c.get(f"/api/agents/{alias}/sessions")
+        assert r.status_code == 402
+        body = r.get_json()
+        assert body["runtime"] == canonical
+
+
+def test_top_level_agents_list_stays_reachable_in_enforce_mode(enforce):
+    """``/api/agents`` renders the multi-agent chip bar (locked + unlocked
+    together) so the UI can render an upgrade CTA on locked chips. Gating
+    it would leave enforced installs with an empty chip bar and no way to
+    discover paid runtimes exist. Mirrors ``routes/fleet_history.py``
+    keeping ``/fleet`` reachable and ``dashboard_claudecode.py`` keeping
+    ``/api/health`` reachable."""
+    app = _make_app()
+    with app.test_client() as c:
+        r = c.get("/api/agents")
+        assert r.status_code != 402
+
+
+def test_paid_agent_detail_stays_reachable_in_enforce_mode(enforce):
+    """``/api/agents/<name>`` returns adapter ``detect()`` output — an
+    install-probe (does the runtime workspace exist?), not the runtime's
+    data. The UI needs it in enforce mode to distinguish "not installed"
+    from "installed but not entitled" — otherwise the upgrade CTA can't
+    render the right copy. Parallels ``dashboard_claudecode.py``'s
+    decision to keep ``/api/health`` ungated."""
+    app = _make_app()
+    with app.test_client() as c:
+        r = c.get("/api/agents/claude_code")
+        assert r.status_code != 402
+
+
+def test_gate_swallows_entitlement_lookup_errors(enforce, monkeypatch):
+    """A flaky entitlement read must never break the request path — the
+    worst that happens is a paid runtime briefly serves a Free tier.
+    Mirrors ``tests/test_gate_runtime.py::
+    test_gate_runtime_never_raises_when_entitlement_lookup_fails``."""
+
+    def explode():
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr("clawmetry.entitlements.get_entitlement", explode)
+
+    app = _make_app()
+    with app.test_client() as c:
+        r = c.get("/api/agents/claude_code/sessions")
+        assert r.status_code != 402
+
+
+def test_gate_precedes_downstream_lookup_in_enforce_mode(enforce):
+    """A path parameter that would normally hit a downstream ``Unknown
+    agent: <name>`` 404 must still return 402 in enforce mode for a paid
+    runtime — the upgrade CTA has to win, otherwise the UI would render
+    "unknown agent" for a non-entitled user instead of the upgrade path.
+    Mirrors the pattern pinned in ``tests/test_claudecode_runtime_gate.py::
+    test_bp_claudecode_gate_precedes_downstream_errors_in_enforce_mode``."""
+    app = _make_app()
+    with app.test_client() as c:
+        r = c.get("/api/agents/claude_code/sessions")
+        assert r.status_code == 402
+        body = r.get_json()
+        assert body["error"] == "upgrade_required"
+        assert body["runtime"] == "claude_code"


### PR DESCRIPTION
## Summary

- Wraps `/api/agents/<name>/sessions` in `require_runtime(name)` — the inline analogue of the `@gate_runtime("claude_code")` decorator `dashboard_claudecode.py` already uses on its JSON endpoints. Runtimes in `FREE_RUNTIMES` (`openclaw`, `nemoclaw`) and grace mode still pass through unchanged, so the wire behaviour is unaffected until `CLAWMETRY_ENFORCE=1` flips on. Aliases (`claude-code`, `qwen-code`, `deep-agents`, …) canonicalise before the check so an alias for a paid runtime 402s consistently.
- The two detection endpoints — `/api/agents` and `/api/agents/<name>` — stay ungated on purpose. The UI needs both in enforce mode to render locked runtime chips + an upgrade CTA in context, mirroring the choice `dashboard_claudecode.py` made for `/api/health` and `routes/fleet_history.py` made for `/fleet`.
- Pins the contract with `tests/test_agents_route_runtime_gate.py` — 25 tests, parametrised across every `PAID_RUNTIMES` id (12 runtimes today) and the common runtime aliases. Also covers the free-runtime pass-through, grace-mode no-op, defensive fallthrough on flaky entitlement reads, and the gate-precedes-downstream-404 contract already pinned for `bp_claudecode`.

## Test plan

- [x] `python3 -m py_compile routes/agents.py tests/test_agents_route_runtime_gate.py`
- [x] `python3 -m pytest tests/test_agents_route_runtime_gate.py -v` → 25 passed
- [x] `python3 -m pytest tests/test_claudecode_runtime_gate.py tests/test_gate_runtime.py tests/test_route_gates.py -q` → 57 passed, no regressions in adjacent gate tests

### Local operator verification checklist

The remote fire has no access to `~/.openclaw`, the running daemon, the live cloud snapshot, or a browser, so the observable checks are yours:

- [ ] Copy `routes/agents.py` into `~/.clawmetry/lib/python3.*/site-packages/clawmetry/routes/agents.py` (adjust for your `python*` dir); clear `__pycache__` under `~/.clawmetry/lib/python3.*/site-packages/routes/` and `.../clawmetry/`.
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` and `launchctl kickstart -k gui/$(id -u)/com.clawmetry.dashboard` (or your equivalents).
- [ ] Grace mode (default): `curl -s localhost:8900/api/agents/claude_code/sessions | jq '.sessions|length'` — still returns whatever it returned before (no 402).
- [ ] Grace mode: `curl -s localhost:8900/api/agents/openclaw/sessions | jq '.sessions|length'` — unchanged.
- [ ] Enforce mode: `CLAWMETRY_ENFORCE=1 launchctl kickstart -k gui/$(id -u)/com.clawmetry.dashboard` (or whichever launcher owns the env); then `curl -sw '%{http_code}\n' localhost:8900/api/agents/claude_code/sessions` returns **402** with an `upgrade_required` body, and `curl -sw '%{http_code}\n' localhost:8900/api/agents/openclaw/sessions` still returns **200**.
- [ ] Enforce mode: `curl -sw '%{http_code}\n' localhost:8900/api/agents` and `curl -sw '%{http_code}\n' localhost:8900/api/agents/claude_code` both stay reachable (not 402) — the UI still needs them to render locked chips + the upgrade CTA.
- [ ] Decrypt today's live cloud snapshot in the browser and confirm the runtime chip bar and detection panels render unchanged (grace mode is still the ambient default).
- [ ] `[RELEASE]` bump, PyPI publish, and merge stay with you — this PR intentionally does not touch `__version__` and stays draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016qvFqfRDAoZESoWLQPaeP1)_