### PR TITLE
feat(overview): gate /api/health-timeline on per_runtime_health_timeline

### DIFF
--- a/routes/overview.py
+++ b/routes/overview.py
@@ -31,6 +31,7 @@ import time as _time
 from datetime import datetime, timedelta, timezone
 
 from flask import Blueprint, jsonify, request
+from clawmetry._gate import gate
 from clawmetry.config import is_local_store_read_enabled
 
 bp_overview = Blueprint('overview', __name__)
@@ -1484,6 +1485,7 @@ _health_timeline_cache_lock = threading.Lock()
 
 
 @bp_overview.route("/api/health-timeline")
+@gate("per_runtime_health_timeline")
 def api_health_timeline():
     """Per-runtime sparkline of recent sessions, severity by health (#2196 item #4).
 

--- a/tests/test_health_timeline_route_gate.py
+++ b/tests/test_health_timeline_route_gate.py
@@ -1,0 +1,317 @@
+"""Enforce/grace-mode contract for the ``/api/health-timeline`` endpoint
+in ``routes/overview.py``.
+
+The endpoint returns a per-runtime sparkline of recent-session severity --
+it is the surface behind the ``per_runtime_health_timeline`` feature key
+in ``clawmetry.entitlements`` (a Starter-tier feature). Every other paid
+route on the ``bp_overview`` blueprint stays free (the top-bar overview,
+channel list, timeline, cloud-CTA endpoints, device summary, prompt-error
+scans, activity heatmap): only the per-runtime health sparkline is paid.
+
+Sibling of ``tests/test_fleet_route_gates.py``,
+``tests/test_evals_route_gates.py``, ``tests/test_assets_route_gates.py``,
+``tests/test_anomaly_detection_route_gates.py``,
+``tests/test_cost_optimizer_route_gates.py``,
+``tests/test_audit_route_gate.py``, ``tests/test_otel_export_route_gate.py``,
+``tests/test_run_compare_route_gate.py``, and
+``tests/test_error_triage_route_gate.py``. Pins the same contract for the
+per-runtime health-timeline endpoint so a future edit to
+``routes/overview.py`` cannot silently drop the gate:
+
+  1. Enforce mode: ``/api/health-timeline`` returns the shared 402
+     ``upgrade_required`` envelope with
+     ``feature="per_runtime_health_timeline"`` and
+     ``required_tier=TIER_CLOUD_STARTER`` (Starter is the lowest paid
+     tier that unlocks Starter features).
+  2. Grace mode (default until the enforce-phase release): the gate is
+     transparent and the handler runs.
+  3. The 402 wire shape is byte-identical to the shared decorator's
+     envelope so an existing front-end that already handles 402s from
+     ``bp_fleet`` / ``bp_evals`` / ``bp_assets`` keeps working here
+     without a special-case branch.
+  4. Entitlement-lookup crashes never surface as 402 -- the gate falls
+     through and the handler runs (mirrors the defensive contract pinned
+     across the other gate tests).
+  5. The remaining ``bp_overview`` endpoints stay ungated -- the shell
+     endpoints have to stay reachable on OSS installs so the dashboard
+     shell renders and the upgrade CTA has somewhere to live.
+"""
+from __future__ import annotations
+
+import importlib
+import inspect
+
+import pytest
+from flask import Flask
+
+
+# ── fixtures ────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def enforce(monkeypatch, tmp_path):
+    """OSS install under ``CLAWMETRY_ENFORCE=1`` -- the tier is oss and
+    ``per_runtime_health_timeline`` (a Starter feature) is NOT allowed."""
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def grace(monkeypatch, tmp_path):
+    """Default grace mode -- every feature key passes through the gate."""
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+def _make_app():
+    from routes.overview import bp_overview
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_overview)
+    return app
+
+
+def _stub_store_helpers(monkeypatch):
+    """Stub ``routes.local_query.local_store_via_daemon`` and the
+    ``clawmetry.waste_flags`` helpers the handler leans on so grace-mode
+    tests don't require a live daemon / DuckDB. ``local_store_via_daemon``
+    returns an empty list -- the handler treats that as "no sessions"
+    and emits an empty ``runtimes`` envelope, which is enough to exercise
+    the gate + handler path without touching disk.
+    """
+    import routes.local_query as _lq
+
+    monkeypatch.setattr(
+        _lq, "local_store_via_daemon", lambda *_a, **_kw: [], raising=False,
+    )
+
+
+# ── enforce mode: 402 with the shared upgrade-required envelope ─────────────
+
+
+def test_health_timeline_returns_402_when_enforced(enforce):
+    """OSS install + ``CLAWMETRY_ENFORCE=1`` short-circuits with 402 so the
+    handler never touches DuckDB / the sessions scan."""
+    app = _make_app()
+    with app.test_client() as c:
+        r = c.get("/api/health-timeline")
+        assert r.status_code == 402, (
+            f"/api/health-timeline returned {r.status_code}, expected 402 "
+            "(gate should short-circuit before the sessions scan runs)"
+        )
+        body = r.get_json()
+        assert body["error"] == "upgrade_required"
+        assert body["feature"] == "per_runtime_health_timeline"
+        # Starter feature -- required_tier must be TIER_CLOUD_STARTER so the
+        # paywall CTA routes users to Starter (not Pro, not Enterprise).
+        assert body["required_tier"] == enforce.TIER_CLOUD_STARTER
+        # ``tier`` reflects the caller's current tier so the UI can render
+        # the delta ("you have OSS, upgrade to Starter"). On an OSS install
+        # with no license, this is TIER_OSS.
+        assert body["tier"] == enforce.TIER_OSS
+        assert isinstance(body.get("hint"), str) and body["hint"]
+        # No timeline payload leaked through -- the gate short-circuited.
+        assert "runtimes" not in body
+        assert "generated_at" not in body
+
+
+def test_health_timeline_402_body_shape_matches_shared_gate(enforce):
+    """The 402 body carries the exact same top-level keys every other
+    ``@gate``d route returns so the front-end can handle any paid-feature
+    402 with one branch. Pins that a later refactor of ``@gate`` doesn't
+    silently drop ``required_tier`` or ``tier`` on this route.
+    """
+    from clawmetry._gate import gate as _gate
+
+    reference_app = Flask(__name__)
+
+    @reference_app.route("/reference")
+    @_gate("per_runtime_health_timeline")
+    def _reference_view():  # pragma: no cover - never runs in enforce mode
+        return {"ok": True}
+
+    target_app = _make_app()
+
+    with reference_app.test_client() as rc, target_app.test_client() as ac:
+        ref_body = rc.get("/reference").get_json()
+        act_body = ac.get("/api/health-timeline").get_json()
+        assert set(ref_body.keys()) == set(act_body.keys())
+        assert set(ref_body.keys()) == {
+            "error",
+            "feature",
+            "tier",
+            "required_tier",
+            "hint",
+        }
+        assert ref_body["feature"] == act_body["feature"]
+        assert ref_body["feature"] == "per_runtime_health_timeline"
+        assert ref_body["required_tier"] == act_body["required_tier"]
+        assert ref_body["tier"] == act_body["tier"]
+
+
+def test_health_timeline_gate_fires_before_sessions_scan(enforce, monkeypatch):
+    """The gate must short-circuit the request *before* the handler runs.
+    Prove it by wiring a distinctive booby-trap onto the sessions scan: if
+    the gate were missing, the handler's ``local_store_via_daemon`` call
+    would either succeed (leaking a 200) or blow up with an
+    ``AssertionError`` -- neither is a 402. The gate short-circuits, so we
+    never reach the scan.
+    """
+    import routes.local_query as _lq
+
+    def _boom(*_a, **_kw):  # pragma: no cover - only hit on regression
+        raise AssertionError(
+            "gate should have short-circuited before the sessions scan ran"
+        )
+
+    monkeypatch.setattr(_lq, "local_store_via_daemon", _boom, raising=False)
+
+    app = _make_app()
+    with app.test_client() as c:
+        r = c.get("/api/health-timeline")
+        assert r.status_code == 402
+
+
+# ── grace mode: gate is transparent ─────────────────────────────────────────
+
+
+def test_health_timeline_is_transparent_in_grace_mode(monkeypatch, grace):
+    """Grace mode (the current default until the enforce-phase release) must
+    let the request through unchanged. The downstream handler runs with a
+    stubbed store hop so the payload builder is exercised without touching
+    disk.
+    """
+    _stub_store_helpers(monkeypatch)
+
+    app = _make_app()
+    with app.test_client() as c:
+        r = c.get("/api/health-timeline")
+        assert r.status_code != 402, (
+            "/api/health-timeline 402'd in grace mode; gate is not transparent"
+        )
+        body = r.get_json()
+        assert isinstance(body, dict)
+        # The 402 short-circuit body has ``error="upgrade_required"``;
+        # the handler payload never does. Pins that the gate stayed
+        # transparent AND the handler emitted its own body shape.
+        assert body.get("error") != "upgrade_required"
+
+
+def test_health_timeline_grace_payload_shape(monkeypatch, grace):
+    """Grace mode: the handler must still emit the pre-migration
+    ``{runtimes, generated_at}`` envelope even when the store is empty.
+    Pins the wire shape the dashboard's sparkline widget consumes so an
+    unrelated refactor cannot silently break the front-end.
+    """
+    _stub_store_helpers(monkeypatch)
+
+    app = _make_app()
+    with app.test_client() as c:
+        body = c.get("/api/health-timeline").get_json()
+        assert "runtimes" in body
+        assert isinstance(body["runtimes"], list)
+        assert "generated_at" in body
+
+
+# ── defensive fallthrough ────────────────────────────────────────────────────
+
+
+def test_entitlement_lookup_crash_falls_through(monkeypatch, enforce):
+    """Mirrors the contract in ``tests/test_route_gates.py``: if the
+    entitlement read itself raises, the request path stays defensive and
+    the handler runs -- the worst that happens is a paid feature briefly
+    runs on a Free tier. A flaky entitlement check must never fail closed.
+    """
+    def _explode(*_a, **_kw):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr("clawmetry.entitlements.get_entitlement", _explode)
+    _stub_store_helpers(monkeypatch)
+
+    app = _make_app()
+    with app.test_client() as c:
+        r = c.get("/api/health-timeline")
+        # Graceful fallthrough: NOT 402. The handler runs and returns
+        # whatever it would have returned pre-migration (200 with the
+        # payload envelope on the happy path).
+        assert r.status_code != 402
+
+
+# ── decorator wiring pin ─────────────────────────────────────────────────────
+
+
+def test_health_timeline_wears_gate_decorator():
+    """``routes/overview.py`` must wire ``/api/health-timeline`` with
+    ``@gate("per_runtime_health_timeline")``. Pin at the source level so a
+    well-meaning revert that drops the decorator (indistinguishable in a
+    single-route grace test) fails loudly.
+    """
+    from routes import overview as overview_module
+
+    src = inspect.getsource(overview_module)
+    assert "from clawmetry._gate import gate" in src, (
+        "routes/overview.py must import @gate from clawmetry._gate"
+    )
+    handler_src = inspect.getsource(overview_module.api_health_timeline)
+    # ``inspect.getsource`` returns the decorator lines above the def when
+    # the function is fetched by name, so grepping the source is enough.
+    assert '@gate("per_runtime_health_timeline")' in handler_src, (
+        'api_health_timeline must be decorated with '
+        '@gate("per_runtime_health_timeline") -- this is the only '
+        "enforcement point until the closed-source clawmetry-pro package "
+        "overrides the endpoint via the extensions entry point."
+    )
+
+
+def test_gate_symbol_is_shared():
+    """Wiring pin -- ``routes.overview.gate`` must resolve to the shared
+    ``clawmetry._gate.gate`` symbol. A local shadow would defeat the shared
+    402 envelope contract, since the envelope shape is enforced by the
+    shared decorator's implementation.
+    """
+    from routes import overview as overview_module
+
+    assert overview_module.gate.__module__ == "clawmetry._gate"
+
+
+# ── neighbouring bp_overview endpoints stay free ────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/api/cloud-cta/status",
+    ],
+)
+def test_sibling_bp_overview_endpoints_stay_free(enforce, path):
+    """Only ``/api/health-timeline`` is gated on the ``bp_overview``
+    blueprint. The shell endpoints have to stay reachable on OSS installs
+    so the dashboard shell renders and the upgrade CTA has somewhere to
+    live. Pin the split here: if a later refactor blanket-gates the whole
+    ``bp_overview`` blueprint (rather than just the paid endpoint), this
+    test fails and calls the reviewer's attention to the CTA regression.
+
+    Only the endpoints with no external dependencies are asserted here --
+    ``/api/overview``/``/api/timeline``/``/api/channels`` reach into
+    ``dashboard`` helpers and the sync daemon and would require broader
+    stubbing than "not gated" needs.
+    """
+    app = _make_app()
+    with app.test_client() as c:
+        r = c.get(path)
+        assert r.status_code != 402, (
+            f"{path} 402'd in enforce mode -- shell endpoints must stay "
+            "reachable so the OSS dashboard renders."
+        )


### PR DESCRIPTION
## Summary

- Wire the shared `@gate("per_runtime_health_timeline")` decorator onto `/api/health-timeline` in `routes/overview.py` — the per-runtime health-timeline sparkline is a Starter-tier feature (see `STARTER_FEATURES` in `clawmetry/entitlements.py`) but was the last endpoint on that surface still ungated.
- Default `grace` mode is unchanged: the decorator is transparent, the sessions scan runs, and the pre-migration `{runtimes, generated_at}` envelope keeps flowing to the dashboard.
- Under `CLAWMETRY_ENFORCE=1` on an OSS install the endpoint short-circuits with the standard 402 `upgrade_required` envelope carrying `feature="per_runtime_health_timeline"` and `required_tier=TIER_CLOUD_STARTER` — the same wire shape the other `@gate`d routes already return, so the front-end handles it with the existing 402 branch.
- Sibling `bp_overview` endpoints (top-bar overview, channels, timeline, cloud-CTA endpoints, device summary, prompt-error scans, activity heatmap) stay free so the OSS dashboard shell still renders and the upgrade CTA has somewhere to live.
- New `tests/test_health_timeline_route_gate.py` pins the enforce/grace/defensive-fallthrough contract and the decorator wiring at the source level — modelled directly on `tests/test_fleet_route_gates.py` and `tests/test_evals_route_gates.py`.

## Test plan

- [x] `python -m pytest tests/test_health_timeline_route_gate.py -q` — 9/9 pass
- [x] `python -m pytest tests/test_fleet_route_gates.py tests/test_evals_route_gates.py tests/test_route_gates.py -q` — sibling gate tests still green (77/77)
- [x] `python -m ruff check routes/overview.py tests/test_health_timeline_route_gate.py` — clean on the two touched files (`make lint` has 213 pre-existing errors on `main`, all in `dashboard.py`; none introduced by this PR)
- [x] `python -m py_compile routes/overview.py tests/test_health_timeline_route_gate.py` — clean

## Local operator verification checklist

Everything below needs the daemon + live snapshot + browser I can't reach from this environment. Please tick as you run each step.

- [ ] Sync the branch into the running install: `rsync -a routes/overview.py ~/.clawmetry/lib/python*/site-packages/clawmetry/../routes/overview.py` (or whichever site-packages layout the daemon has) and drop the matching `__pycache__` entries.
- [ ] Restart the daemons: `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync gui/$(id -u)/com.clawmetry.dashboard`.
- [ ] Hit `/api/entitlement` on `http://localhost:8900` — confirm `grace: true`, `tier: oss` (or whatever the local install actually resolves to).
- [ ] With `CLAWMETRY_ENFORCE=0` (default): `curl -s http://localhost:8900/api/health-timeline | jq '.runtimes | length'` — returns `>= 0`, the existing sparkline widget still populates in the browser.
- [ ] With `CLAWMETRY_ENFORCE=1` (temporary flip): `curl -s -w '%{http_code}\n' http://localhost:8900/api/health-timeline` — returns `402` with the shared upgrade-required envelope; the dashboard shell still loads and other endpoints (`/api/overview`, `/api/channels`, `/api/timeline`) keep 200-ing.
- [ ] Decrypt the live cloud snapshot and confirm the front-end handles the 402 with the existing paid-feature CTA (not a fresh error toast).
- [ ] Flip `CLAWMETRY_ENFORCE` back to `0` before ending the verification session so the OSS default stays behavioural-change-free.

## Roadmap notes for the local operator (P3 / P4 / P6)

These next phases -- cloud plan resolver, closed-source `clawmetry-pro` package, enterprise on-prem key rotation -- need the private `clawmetry-cloud` repo (and the not-yet-existing `clawmetry-pro` repo). This automated fire has no access to either, so they stay parked for the local operator. The public repo can continue to migrate ungated endpoints onto the shared `@gate` decorator in the meantime (this PR is one of those).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01HkK4wmNdpiCQ358FnobmaN)_