### PR TITLE
feat(cli): clawmetry {features,runtimes} --why &lt;id&gt; diagnostic

### DIFF
--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -3264,6 +3264,97 @@ def _cmd_license(args) -> None:
             print(f"  Trust key:   sha256:{fp[:16]}…  (clawmetry license fingerprint)")
 
 
+def _entitlement_why_payload(kind: str, key: str) -> dict:
+    """Resolve the lock-reason payload for a single feature/runtime id.
+
+    Same shape the ``/api/entitlement/lock-reason`` HTTP endpoint emits so
+    ``clawmetry <features|runtimes> --why <id> --json`` and the dashboard
+    cannot drift on the upgrade affordance. Never raises: any resolver
+    failure returns the OSS-free "not locked, unknown" fallback so a wrapper
+    script always sees a parseable response — matches the never-crash
+    contract documented on :func:`get_entitlement`.
+    """
+    key = (key or "").strip().lower()
+    try:
+        from clawmetry import entitlements as _ent
+
+        ent = _ent.get_entitlement()
+        cur_tier = ent.tier
+        cur_rank = _ent.tier_rank(cur_tier)
+        if kind == "runtime":
+            allowed = ent.allows_runtime(key)
+            required = _ent.min_tier_for_runtime(key)
+            reason = ent.lock_reason(key, kind="runtime")
+        else:  # feature
+            allowed = ent.allows_feature(key)
+            required = _ent.min_tier_for_feature(key)
+            reason = ent.lock_reason(key, kind="feature")
+        req_rank = _ent.tier_rank(required) if required else -1
+        required_label = _ent.tier_label(required) if required else None
+        return {
+            "key": key,
+            "kind": kind,
+            "reason": reason,
+            "locked": reason is not None,
+            "allowed": bool(allowed),
+            "required_tier": required,
+            "required_tier_label": required_label,
+            "required_tier_rank": req_rank,
+            "current_tier": cur_tier,
+            "current_tier_rank": cur_rank,
+            "upgrade_required": bool(required) and req_rank > cur_rank,
+        }
+    except Exception as exc:
+        print(f"⚠️  entitlement resolution failed: {exc}", file=sys.stderr)
+        return {
+            "key": key,
+            "kind": kind,
+            "reason": None,
+            "locked": False,
+            "allowed": True,
+            "required_tier": None,
+            "required_tier_label": None,
+            "required_tier_rank": -1,
+            "current_tier": "oss",
+            "current_tier_rank": 0,
+            "upgrade_required": False,
+        }
+
+
+def _print_why_block(payload: dict) -> None:
+    """Human-readable render of :func:`_entitlement_why_payload`.
+
+    Mirrors the ``clawmetry tier`` / ``clawmetry features`` output style
+    (aligned two-column block, single upgrade CTA when a paid tier unlocks
+    the item) so shell operators recognise the layout across subcommands.
+    """
+    key = payload.get("key") or "(unknown)"
+    kind = payload.get("kind") or "?"
+    locked = bool(payload.get("locked"))
+    print(f'ClawMetry: why is "{key}" locked?')
+    print("─" * 40)
+    print(f"  Kind:            {kind}")
+    print(f"  Current tier:    {payload.get('current_tier', 'oss')}")
+    print(f"  Locked:          {'yes' if locked else 'no'}")
+    reason = payload.get("reason")
+    if reason:
+        print(f"  Reason:          {reason}")
+    req = payload.get("required_tier")
+    req_label = payload.get("required_tier_label")
+    if req:
+        rank = payload.get("required_tier_rank", -1)
+        rank_hint = f" (rank {rank})" if isinstance(rank, int) and rank >= 0 else ""
+        print(f"  Required tier:   {req_label or req}{rank_hint}")
+    if payload.get("upgrade_required"):
+        print("  Upgrade:         clawmetry license activate <KEY>")
+    elif not locked and not payload.get("reason"):
+        # Free/allowed or unknown id: don't dangle an upgrade CTA. Give the
+        # operator a one-line hint of which case they hit so a `--why` on a
+        # typo doesn't silently look like a "no lock" all-clear.
+        if not req:
+            print("  Note:            not a paid capability on this install")
+
+
 def _cmd_tier(args) -> None:
     """clawmetry tier — print the resolved open-core entitlement.
 
@@ -3361,6 +3452,15 @@ def _cmd_runtimes(args) -> None:
 
     from clawmetry import entitlements as _ent
 
+    why = (getattr(args, "why", None) or "").strip().lower()
+    if why:
+        payload = _entitlement_why_payload("runtime", why)
+        if getattr(args, "as_json", False):
+            print(_json.dumps(payload, indent=2, sort_keys=True))
+        else:
+            _print_why_block(payload)
+        return
+
     try:
         ent = _ent.get_entitlement()
         tier = ent.tier
@@ -3443,6 +3543,15 @@ def _cmd_features(args) -> None:
     import json as _json
 
     from clawmetry import entitlements as _ent
+
+    why = (getattr(args, "why", None) or "").strip().lower()
+    if why:
+        payload = _entitlement_why_payload("feature", why)
+        if getattr(args, "as_json", False):
+            print(_json.dumps(payload, indent=2, sort_keys=True))
+        else:
+            _print_why_block(payload)
+        return
 
     try:
         ent = _ent.get_entitlement()
@@ -3984,6 +4093,15 @@ def main() -> None:
         dest="as_json",
         help="Emit {tier, grace, enforced, runtimes:[...]} JSON (jq-friendly)",
     )
+    p_runtimes.add_argument(
+        "--why",
+        metavar="ID",
+        default=None,
+        help=(
+            "Print the lock-reason payload for a single runtime id "
+            "(same shape as GET /api/entitlement/lock-reason?runtime=<id>)"
+        ),
+    )
 
     # features — list every observable feature and which are unlocked.
     # CLI sibling of `clawmetry runtimes` and of the dashboard's GET
@@ -3998,6 +4116,15 @@ def main() -> None:
         action="store_true",
         dest="as_json",
         help="Emit {tier, grace, enforced, features:[...]} JSON (jq-friendly)",
+    )
+    p_features.add_argument(
+        "--why",
+        metavar="ID",
+        default=None,
+        help=(
+            "Print the lock-reason payload for a single feature id "
+            "(same shape as GET /api/entitlement/lock-reason?feature=<id>)"
+        ),
     )
 
     # verify-integrity — walk hash chain and report validity (Issue #2200)

--- a/tests/test_cli_entitlement_why.py
+++ b/tests/test_cli_entitlement_why.py
@@ -1,0 +1,195 @@
+"""Tests for the ``clawmetry <features|runtimes> --why <id>`` diagnostic.
+
+Sibling of ``tests/test_cli_features_subcommand.py`` and
+``tests/test_cli_runtimes_subcommand.py``. The ``--why`` flag is a thin read
+of :meth:`Entitlement.lock_reason` + :func:`min_tier_for_feature` /
+:func:`min_tier_for_runtime` and must never crash. It answers the operator
+question "why is X locked?" from the shell without hitting the HTTP API —
+so the JSON shape has to match ``/api/entitlement/lock-reason``.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+
+import pytest
+
+
+@pytest.fixture
+def cli_mod(monkeypatch, tmp_path):
+    """Fresh entitlements module with HOME pointed at an empty tmp dir so the
+    resolver renders against the OSS-free default and never against a license
+    that happens to live on the host.
+    """
+    import importlib
+
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    import clawmetry.entitlements as ent
+
+    importlib.reload(ent)
+    ent.invalidate()
+
+    import clawmetry.cli as cli  # imported after entitlements is rebuilt
+
+    yield cli
+    ent.invalidate()
+
+
+def _ns(**kw) -> argparse.Namespace:
+    kw.setdefault("as_json", False)
+    kw.setdefault("why", None)
+    return argparse.Namespace(**kw)
+
+
+# ── payload shape ──────────────────────────────────────────────────────────
+
+_EXPECTED_KEYS = {
+    "key",
+    "kind",
+    "reason",
+    "locked",
+    "allowed",
+    "required_tier",
+    "required_tier_label",
+    "required_tier_rank",
+    "current_tier",
+    "current_tier_rank",
+    "upgrade_required",
+}
+
+
+def test_why_json_matches_http_lock_reason_shape(cli_mod, capsys):
+    """The CLI --why JSON must expose the same keys as
+    ``GET /api/entitlement/lock-reason`` so scripts written against either
+    surface work interchangeably."""
+    cli_mod._cmd_runtimes(_ns(as_json=True, why="claude_code"))
+    payload = json.loads(capsys.readouterr().out)
+    assert set(payload) == _EXPECTED_KEYS
+    assert payload["key"] == "claude_code"
+    assert payload["kind"] == "runtime"
+
+
+def test_why_grace_reports_no_lock(cli_mod, capsys):
+    """In the default OSS-free + grace posture, ``lock_reason`` returns
+    None and the payload must report locked=False even for a paid runtime.
+    This is the guarantee that wiring the CLI is behaviour-neutral before
+    enforcement flips on."""
+    cli_mod._cmd_runtimes(_ns(as_json=True, why="claude_code"))
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["locked"] is False
+    assert payload["reason"] is None
+    assert payload["current_tier"] == "oss"
+    # required_tier is still meaningful — it's the tier that would unlock
+    # this runtime once enforcement is on — so the operator can preview the
+    # upgrade target without flipping the enforce gate.
+    assert payload["required_tier"] is not None
+    assert payload["upgrade_required"] is True
+
+
+def test_why_enforce_reports_locked_paid_runtime(cli_mod, capsys, monkeypatch):
+    """With CLAWMETRY_ENFORCE=1, a paid runtime resolves as locked and the
+    upgrade CTA fires."""
+    import clawmetry.entitlements as ent
+
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    cli_mod._cmd_runtimes(_ns(as_json=True, why="claude_code"))
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["locked"] is True
+    assert payload["reason"], "reason string must be non-empty when locked"
+    assert payload["upgrade_required"] is True
+    assert payload["required_tier"]
+
+
+def test_why_free_runtime_never_locks(cli_mod, capsys, monkeypatch):
+    """openclaw is FREE — enforcement or not, it never locks and no CTA
+    shows. Guards against a regression that would gate the free runtime."""
+    import clawmetry.entitlements as ent
+
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    cli_mod._cmd_runtimes(_ns(as_json=True, why="openclaw"))
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["locked"] is False
+    assert payload["reason"] is None
+    assert payload["upgrade_required"] is False
+
+
+def test_why_unknown_id_returns_parseable_fallback(cli_mod, capsys):
+    """A typo on --why must not crash and must not dangle an upgrade CTA —
+    otherwise a shell wrapper mistakes a typo for "no lock, all good"."""
+    cli_mod._cmd_runtimes(_ns(as_json=True, why="not-a-real-runtime"))
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["locked"] is False
+    assert payload["reason"] is None
+    assert payload["required_tier"] is None
+    assert payload["upgrade_required"] is False
+
+
+def test_why_human_block_renders_reason(cli_mod, capsys, monkeypatch):
+    """The non-JSON path prints a compact aligned block a shell operator can
+    read at a glance. Under enforcement the reason string surfaces verbatim."""
+    import clawmetry.entitlements as ent
+
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    cli_mod._cmd_runtimes(_ns(as_json=False, why="claude_code"))
+    out = capsys.readouterr().out
+    assert 'why is "claude_code" locked?' in out
+    assert "Kind:" in out and "runtime" in out
+    assert "Locked:" in out and "yes" in out
+    assert "Reason:" in out
+    assert "Required tier:" in out
+    assert "clawmetry license activate <KEY>" in out
+
+
+def test_why_features_dispatch_uses_feature_kind(cli_mod, capsys):
+    """`clawmetry features --why <id>` routes through the same helper but
+    with kind='feature' so the payload reflects feature semantics, not
+    runtime semantics."""
+    # Pick a known paid feature so the required_tier is populated even in
+    # grace mode.
+    import clawmetry.entitlements as ent
+
+    paid_feature = next(iter(ent.PAID_FEATURES))
+    cli_mod._cmd_features(_ns(as_json=True, why=paid_feature))
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["kind"] == "feature"
+    assert payload["key"] == paid_feature
+    # In grace: not locked, but the tier that would unlock it is still known.
+    assert payload["locked"] is False
+    assert payload["required_tier"] is not None
+
+
+def test_why_survives_broken_resolver(cli_mod, capsys, monkeypatch):
+    """A poisoned :func:`get_entitlement` must produce the OSS-free fallback
+    shape, not a stack trace. Matches the never-crash contract."""
+    import clawmetry.entitlements as ent
+
+    def _boom():
+        raise RuntimeError("synthetic resolver failure")
+
+    monkeypatch.setattr(ent, "get_entitlement", _boom)
+    cli_mod._cmd_runtimes(_ns(as_json=True, why="claude_code"))
+    payload = json.loads(capsys.readouterr().out)
+    assert set(payload) == _EXPECTED_KEYS
+    assert payload["current_tier"] == "oss"
+    assert payload["locked"] is False
+    assert payload["reason"] is None
+
+
+def test_why_subparser_flags_registered():
+    """Both `runtimes --why` and `features --why` must be reachable from the
+    top-level parser — otherwise the human-facing docs promise a flag that
+    argparse rejects at runtime."""
+    import inspect
+
+    import clawmetry.cli as cli
+
+    src = inspect.getsource(cli.main)
+    # Only one occurrence of `"--why"` is enough — both subparsers add it
+    # inline in `main`, so grep the source for the flag name and its metavar.
+    assert '"--why"' in src
+    assert "metavar=\"ID\"" in src


### PR DESCRIPTION
## Summary

- Adds `--why <id>` to `clawmetry features` and `clawmetry runtimes` — a shell-side diagnostic that answers "why is this capability locked?" without hitting the running dashboard.
- JSON output matches the exact key set that `GET /api/entitlement/lock-reason?<feature|runtime>=<id>` already returns, so scripts written against either surface work interchangeably (a pin test enforces the key set).
- Grace-safe: the default OSS-free posture still reports `locked=false` (grace mode returns no reason) while surfacing the `required_tier` the operator would need to upgrade to. Wiring the flag in changes no behaviour before enforcement flips on.

## What changed

`clawmetry/cli.py`
- New helpers `_entitlement_why_payload(kind, key)` and `_print_why_block(payload)` — one resolves the lock-reason payload, the other renders it in the house-style aligned block used by `clawmetry tier` / `clawmetry features`.
- `_cmd_runtimes` and `_cmd_features` dispatch to the helper when `args.why` is set (both `--json` and human paths supported).
- Both subparsers gain `--why ID` with a help string that names the equivalent HTTP endpoint.

`tests/test_cli_entitlement_why.py` — 9 new tests

- JSON shape matches `/api/entitlement/lock-reason` key-for-key (pin test).
- Grace mode → `locked=false`, `reason=null`, but `required_tier` populated.
- `CLAWMETRY_ENFORCE=1` + paid runtime → `locked=true`, reason string, upgrade CTA.
- Free runtime (`openclaw`) never locks even under enforcement.
- Unknown id → parseable fallback, no dangling upgrade CTA.
- Human path renders the reason string and the `clawmetry license activate <KEY>` CTA.
- `features --why` routes through the same helper with `kind="feature"`.
- Broken resolver falls back to OSS-free shape without crashing (matches `get_entitlement`'s never-crash contract).
- Subparser registration pin.

## Test plan

- [x] `python -m py_compile clawmetry/cli.py tests/test_cli_entitlement_why.py`
- [x] `python -m pytest tests/test_cli_entitlement_why.py` — 9 / 9 pass
- [x] `python -m pytest tests/test_cli_features_subcommand.py tests/test_cli_runtimes_subcommand.py` — no regressions (14 / 14 pass)
- [x] `make lint` — same 213 pre-existing lint findings as `origin/main` HEAD; this PR adds none. (Confirmed by `git stash && make lint`.)
- [x] Verified the JSON key set matches `routes/entitlement.py::api_entitlement_lock_reason` exactly.

## Local operator verification checklist

The remote agent cannot reach the running daemon, `~/.openclaw`, or the live cloud snapshot. To verify end-to-end on your machine after this PR merges:

- [ ] Copy the two changed files into the installed wheel:
  ```
  cp clawmetry/cli.py ~/.clawmetry/lib/python3.*/site-packages/clawmetry/cli.py
  ```
- [ ] Clear the `__pycache__` under `~/.clawmetry/lib/python3.*/site-packages/clawmetry/`.
- [ ] Restart the daemon:
  ```
  launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync
  ```
- [ ] `clawmetry runtimes --why claude_code` — expect `locked: no` in default grace posture, `required_tier` populated.
- [ ] `CLAWMETRY_ENFORCE=1 clawmetry runtimes --why claude_code` — expect `locked: yes` + upgrade CTA.
- [ ] `clawmetry features --why <known-paid-feature> --json | jq keys` — expect the same 11 keys `/api/entitlement/lock-reason` returns.
- [ ] Diff `clawmetry runtimes --why claude_code --json` vs `curl -s http://localhost:8900/api/entitlement/lock-reason?runtime=claude_code` — should be equivalent for the same install (allow ordering differences).
- [ ] Browser: hit the running dashboard and confirm the `/api/entitlement/lock-reason` payload is unchanged (this PR only adds a CLI-side reader; no HTTP endpoint touched).

## Notes

- No changes to `dashboard.py`, `routes/entitlement.py`, or any Blueprint — this is a pure CLI-side reader that consumes the same public helpers (`get_entitlement`, `lock_reason`, `min_tier_for_feature`, `min_tier_for_runtime`, `tier_rank`, `tier_label`) already used by the HTTP endpoint.
- No changes to `__version__`, no `[RELEASE]` tag, no enforcement flip. Stays in grace.
- No new dependencies.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GA3DHUtMuimvJZD6db6AxT

---
_Generated by [Claude Code](https://claude.ai/code/session_01GA3DHUtMuimvJZD6db6AxT)_