### PR TITLE
feat(cli): clawmetry channels - list adapters + concurrent-channel cap

### DIFF
--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -3619,6 +3619,90 @@ def _cmd_features(args) -> None:
         print("  Upgrade: clawmetry license activate <KEY>")
 
 
+def _cmd_channels(args) -> None:
+    """clawmetry channels — list every chat-channel adapter and the tier cap.
+
+    Sibling of :func:`_cmd_runtimes` / :func:`_cmd_features` for the third
+    entitlement axis. Every chat channel is FREE at every tier -- the
+    ``channels`` capacity axis governs how many concurrent channels each
+    plan admits, not which adapters unlock -- so every row surfaces as
+    available. The tier-scoped concurrent-channel cap is what upgrades
+    unlock, and it prints in the header block. Reads
+    :func:`clawmetry.entitlements.channel_catalog` -- the same source the
+    dashboard's channel-picker consumes -- so the CLI and the UI cannot
+    drift on the adapter list.
+
+    Never raises. A poisoned catalog read surfaces the error inline (a
+    warning row in the human table, or an ``error`` key on the JSON payload
+    with ``channels=[]``) so a wrapper script always sees a parseable
+    response. Matches the never-crash contract documented on
+    :func:`get_entitlement`.
+
+    Output:
+      default -- header block (tier / enforcement / channel cap) + table
+                 (id, label, status) of every adapter
+      --json  -- ``{tier, grace, enforced, channel_limit, channels: [...],
+                 error?: str}``
+    """
+    import json as _json
+
+    from clawmetry import entitlements as _ent
+
+    try:
+        ent = _ent.get_entitlement()
+        tier = ent.tier
+        grace = bool(ent.grace)
+        enforced = _ent.is_enforced()
+        channel_limit = ent.channel_limit()
+    except Exception as exc:
+        # Mirror _cmd_runtimes / _cmd_features never-crash fallback: a
+        # broken install still gets a parseable shape, with the failure
+        # surfaced to stderr so it isn't silently lost in a pipeline.
+        print(f"⚠️  entitlement resolution failed: {exc}", file=sys.stderr)
+        tier, grace, enforced, channel_limit = "oss", True, False, None
+
+    rows: list[dict] = []
+    catalog_error: str | None = None
+    try:
+        rows = list(_ent.channel_catalog())
+    except Exception as exc:
+        catalog_error = str(exc)
+
+    if getattr(args, "as_json", False):
+        payload: dict = {
+            "tier": tier,
+            "grace": grace,
+            "enforced": enforced,
+            "channel_limit": channel_limit,
+            "channels": rows,
+        }
+        if catalog_error:
+            payload["error"] = catalog_error
+        print(_json.dumps(payload, indent=2, sort_keys=True))
+        return
+
+    mode_line = "off (grace)" if not enforced else "on"
+    cap_line = "unlimited" if channel_limit in (None, 0) else str(channel_limit)
+    print("ClawMetry Channels\n" + "─" * 40)
+    print(f"  Tier:        {tier}")
+    print(f"  Enforcement: {mode_line}")
+    print(f"  Channel cap: {cap_line}  (concurrent adapters)")
+    if catalog_error:
+        print(f"  ⚠️  catalog error: {catalog_error}")
+        return
+
+    print()
+    print(f"  {'ID':<16} {'Label':<20} Status")
+    print("  " + "─" * 50)
+    for row in rows:
+        cid = str(row.get("id", ""))
+        label = str(row.get("label", cid))
+        # Every channel adapter is free at every tier; the cap is separate.
+        # Surface the row identically to a free/available runtime row.
+        status = "✅ available"
+        print(f"  {cid:<16} {label:<20} {status}")
+
+
 def _cmd_verify_integrity(args) -> None:
     """clawmetry verify-integrity — walk the hash chain and report validity."""
     from clawmetry.local_store import get_store
@@ -4127,6 +4211,24 @@ def main() -> None:
         ),
     )
 
+    # channels — list every chat-channel adapter and the tier-scoped cap.
+    # CLI sibling of `clawmetry runtimes` / `clawmetry features` for the
+    # third entitlement axis. Every adapter is FREE at every tier; the
+    # concurrent-channel cap is what the header block advertises.
+    p_channels = sub.add_parser(
+        "channels",
+        help="List every chat-channel adapter and the concurrent-channel cap",
+    )
+    p_channels.add_argument(
+        "--json",
+        action="store_true",
+        dest="as_json",
+        help=(
+            "Emit {tier, grace, enforced, channel_limit, channels:[...]} "
+            "JSON (jq-friendly)"
+        ),
+    )
+
     # verify-integrity — walk hash chain and report validity (Issue #2200)
     p_verify = sub.add_parser(
         "verify-integrity",
@@ -4159,6 +4261,7 @@ def main() -> None:
         "tier",
         "runtimes",
         "features",
+        "channels",
         "verify-integrity",
         "nemoclaw-daemons",
     )
@@ -4202,6 +4305,8 @@ def main() -> None:
             _cmd_runtimes(args)
         elif args.cmd == "features":
             _cmd_features(args)
+        elif args.cmd == "channels":
+            _cmd_channels(args)
         elif args.cmd == "verify-integrity":
             _cmd_verify_integrity(args)
         elif args.cmd == "nemoclaw-daemons":

--- a/tests/test_cli_channels_subcommand.py
+++ b/tests/test_cli_channels_subcommand.py
@@ -1,0 +1,138 @@
+"""Tests for the `clawmetry channels` CLI subcommand.
+
+The subcommand is a thin read of ``clawmetry.entitlements.channel_catalog()``
+and must never crash — even when the entitlement or catalog read fails.
+Mirrors ``tests/test_cli_runtimes_subcommand.py`` /
+``tests/test_cli_features_subcommand.py`` so the CLI trio (runtimes /
+features / channels) is covered by the same shape of test.
+
+Every chat-channel adapter is FREE at every tier (the ``channels``
+capacity axis governs how many *concurrent* adapters each plan admits, not
+which adapters unlock), so the table never shows a locked row. What the
+header block advertises is the tier-scoped concurrent-channel cap.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+
+import pytest
+
+
+@pytest.fixture
+def cli_mod(monkeypatch, tmp_path):
+    """Fresh entitlements module with HOME pointed at an empty tmp dir so the
+    table is rendered against the OSS-free default and never against a
+    license that happens to live on the host."""
+    import importlib
+
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    import clawmetry.entitlements as ent
+
+    importlib.reload(ent)
+    ent.invalidate()
+
+    import clawmetry.cli as cli  # imported after entitlements is rebuilt
+
+    yield cli
+    ent.invalidate()
+
+
+def _ns(**kw) -> argparse.Namespace:
+    return argparse.Namespace(**kw)
+
+
+def test_channels_table_lists_every_known_adapter(cli_mod, capsys):
+    import clawmetry.entitlements as ent
+
+    cli_mod._cmd_channels(_ns(as_json=False))
+    out = capsys.readouterr().out
+    assert "ClawMetry Channels" in out
+    # Every adapter in the catalogue surfaces — no silent drops.
+    for ch in ent.ALL_CHANNELS:
+        assert ch in out, ch
+    # Default install is in grace mode → no lock rows exist for channels.
+    assert "Enforcement: off (grace)" in out
+    assert "🔒 locked" not in out
+
+
+def test_channels_header_advertises_concurrent_channel_cap(cli_mod, capsys):
+    """OSS-free installs cap concurrent channels at 3; the header line must
+    surface that so the operator sees the axis the tier upgrade unlocks."""
+    cli_mod._cmd_channels(_ns(as_json=False))
+    out = capsys.readouterr().out
+    assert "Channel cap:" in out
+    # In grace mode ``channel_limit()`` returns None → header renders
+    # "unlimited". That IS the correct display for grace; the enforced OSS
+    # case (below) is where the numeric cap surfaces.
+    assert "unlimited" in out
+
+
+def test_channels_json_is_machine_readable(cli_mod, capsys):
+    import clawmetry.entitlements as ent
+
+    cli_mod._cmd_channels(_ns(as_json=True))
+    out = capsys.readouterr().out.strip()
+    payload = json.loads(out)
+    assert payload["tier"] == ent.TIER_OSS
+    assert payload["grace"] is True
+    assert payload["enforced"] is False
+    assert "channel_limit" in payload
+    ids = {row["id"] for row in payload["channels"]}
+    assert ids == set(ent.ALL_CHANNELS)
+    for row in payload["channels"]:
+        # Row shape is byte-identical to a ``channel_catalog`` row.
+        assert {"id", "label", "free", "allowed", "locked", "entitled"} <= set(row)
+        # Every adapter is free at every tier — no paid-channel tier.
+        assert row["free"] is True
+        assert row["locked"] is False
+
+
+def test_channels_enforced_oss_shows_numeric_cap(cli_mod, capsys, monkeypatch):
+    """Enforced OSS installs surface the numeric concurrent-channel cap
+    (3 for the free tier). The table itself stays lock-free because every
+    adapter is FREE — only the capacity axis is what upgrades unlock."""
+    import clawmetry.entitlements as ent
+
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    cli_mod._cmd_channels(_ns(as_json=False))
+    out = capsys.readouterr().out
+    assert "Enforcement: on" in out
+    # OSS free cap is 3 concurrent adapters.
+    assert "Channel cap: 3" in out
+    # No adapter row is locked — every channel is free at every tier.
+    assert "🔒 locked" not in out
+
+
+def test_channels_falls_back_when_catalog_errors(cli_mod, capsys, monkeypatch):
+    """A poisoned channel_catalog() must not crash the CLI."""
+    import clawmetry.entitlements as ent
+
+    def _boom():
+        raise RuntimeError("synthetic catalog failure")
+
+    monkeypatch.setattr(ent, "channel_catalog", _boom)
+    cli_mod._cmd_channels(_ns(as_json=False))
+    out = capsys.readouterr().out
+    assert "synthetic catalog failure" in out
+    # JSON path also stays graceful.
+    cli_mod._cmd_channels(_ns(as_json=True))
+    out_json = capsys.readouterr().out.strip()
+    payload = json.loads(out_json)
+    assert payload["channels"] == []
+    assert "synthetic catalog failure" in payload["error"]
+
+
+def test_channels_subcommand_is_registered():
+    """The subparser + dispatch table must list `channels` so it is
+    reachable from the CLI entry point."""
+    import inspect
+
+    import clawmetry.cli as cli
+
+    src = inspect.getsource(cli.main)
+    assert '"channels"' in src
+    assert "_cmd_channels" in src


### PR DESCRIPTION
## Summary

- Add `clawmetry channels` — the missing sibling of `clawmetry runtimes` / `clawmetry features` for the third entitlement axis (chat-channel adapters). Reads `clawmetry.entitlements.channel_catalog()` — the same source the dashboard's channel-picker consumes — so the CLI and the UI cannot drift on the adapter list.
- Every adapter is FREE at every tier: the `channels` capacity axis governs how many *concurrent* adapters a plan admits, not which adapters unlock. The table never shows a locked row; what upgrades unlock is the concurrent-channel cap, and that is what the header block advertises (`unlimited` in grace mode; the numeric cap under enforcement).
- Never-crash contract: a poisoned catalog read surfaces the error inline (warning row for the human table, `error` key for `--json`) and returns `channels=[]` so a wrapper script always sees a parseable response. Matches the sibling contracts on `runtimes` / `features`.

## Test plan

- [x] `python -m pytest tests/test_cli_channels_subcommand.py -v` — 6 new tests pass (table lists every adapter, header advertises the concurrent-channel cap, `--json` is machine-readable, enforced OSS surfaces the numeric cap `3`, a poisoned `channel_catalog()` does not crash the CLI, and the subparser + dispatch entries are registered).
- [x] `python -m pytest tests/test_cli_runtimes_subcommand.py tests/test_cli_features_subcommand.py tests/test_cli_banner.py tests/test_cli_entitlement_why.py -q` — 24 sibling CLI tests still pass (no regressions on the neighbouring subcommands).
- [x] `python -m py_compile clawmetry/cli.py tests/test_cli_channels_subcommand.py` — syntax OK.
- [x] Smoke run: `HOME=/tmp/clean-cli-check python -m clawmetry channels` — prints the expected header + 22-row adapter table.

## Local operator verification checklist

I can't reach the running daemon, `~/.openclaw`, or the browser from this container. Please run these on the host:

- [ ] `pip install -e .` (or copy `clawmetry/cli.py` + `tests/test_cli_channels_subcommand.py` into `~/.clawmetry/lib/pythonX.Y/site-packages/clawmetry/` and clear the site's `__pycache__`).
- [ ] `clawmetry channels` — confirm the header block (`Tier`, `Enforcement`, `Channel cap`) and the 22-row adapter table.
- [ ] `clawmetry channels --json | jq '.channels | length'` → should be 22 (the catalogue), and `jq '.channel_limit'` → `null` under grace, `3` under enforcement.
- [ ] `CLAWMETRY_ENFORCE=1 clawmetry channels` — header should read `Enforcement: on` and `Channel cap: 3` on an unlicensed install; no adapter row should be marked locked (every adapter is FREE at every tier).
- [ ] `clawmetry channels --help` — subcommand shows up in the parent help and `--json` is documented.
- [ ] Sanity: `clawmetry runtimes` and `clawmetry features` still render — the shared subparser table wasn't broken.

## Rollout notes

- Read-only, side-effect free. Zero behaviour change on any existing endpoint or CLI subcommand. Not a `[RELEASE]` PR.
- Stays inside the grace-first envelope: the new command inspects the resolved entitlement but never enforces or 402s.
- No new dependency, no new module — just a subparser, dispatch, `_cmd_channels`, and one test file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LzsRP6VtRGChewB3Gb4Dub)_