### PR TITLE
fix: remove ungated duplicate GET /api/audit-log from routes/health.py

### DIFF
--- a/routes/health.py
+++ b/routes/health.py
@@ -3597,58 +3597,6 @@ def api_security_threats_history():
     return jsonify({"threats": rows or [], "total": len(rows or [])})
 
 
-@bp_health.route("/api/audit-log")
-def api_audit_log():
-    """Return operator audit-log entries from DuckDB (#3306).
-
-    Records human actions (approve, deny, kill_session, config_change, etc.)
-    written via ``ingest_audit_log_entry``. Auth / RBAC enforcement is
-    cloud-side; this endpoint is the OSS read surface.
-
-    Query params:
-      actor      — filter by actor identity
-      action     — filter by action type
-      session_id — narrow to one session
-      since      — ISO timestamp lower bound
-      limit      — max rows (default 200)
-    """
-    actor = (request.args.get("actor") or "").strip() or None
-    action = (request.args.get("action") or "").strip() or None
-    session_id = (request.args.get("session_id") or "").strip() or None
-    since = (request.args.get("since") or "").strip() or None
-    try:
-        limit = max(1, min(1000, int(request.args.get("limit", 200))))
-    except (TypeError, ValueError):
-        limit = 200
-
-    rows = None
-    if is_local_store_read_enabled():
-        try:
-            from routes.local_query import local_store_via_daemon
-            rows = local_store_via_daemon(
-                "query_audit_log",
-                actor=actor,
-                action=action,
-                session_id=session_id,
-                since=since,
-                limit=limit,
-            )
-        except Exception:
-            rows = None
-
-    if rows is None:
-        try:
-            from clawmetry import local_store as _ls
-            rows = _ls.get_store().query_audit_log(
-                actor=actor, action=action, session_id=session_id,
-                since=since, limit=limit,
-            )
-        except Exception:
-            rows = []
-
-    return jsonify({"entries": rows or [], "total": len(rows or [])})
-
-
 @bp_health.route("/api/doctor-findings")
 def api_doctor_findings():
     """Return structured ``openclaw doctor`` diagnostic findings (#3468).


### PR DESCRIPTION
Closes #3683

## Summary

- `routes/health.py` registered `GET /api/audit-log` without entitlement gating (originally added in #3306).
- `routes/audit.py` later added the same URL with `@gate("audit_logs")` as part of the #3799 migration.
- Because `bp_audit` registers **after** `bp_health` in `dashboard.py` (lines 11658 vs 11602), Flask serves the gated version — making the health.py copy permanently dead code.
- Remove the 52-line ungated duplicate; the gated `routes/audit.py` handler remains the sole owner of this URL.

## Test plan

- `python3 -m pytest tests/test_audit_route_gate.py tests/test_audit.py -q` — 18 tests pass, no regressions.
- `python3 -m py_compile routes/health.py routes/audit.py` — clean compile.
- No other file imports or calls the removed `api_audit_log` function from `routes/health.py`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BZVHUxC4n3BVuv6uXfiqoW)_