### PR TITLE
[RELEASE] 0.12.559 - family high-water marks carry the pro ingest rev

### DIFF
--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -11319,6 +11319,22 @@ _FAMILY_ADAPTER_SPECS = (
 )
 
 
+def _family_ingest_rev() -> str:
+    """Installed clawmetry-pro version, stamped into family high-water marks.
+
+    The adapters live in clawmetry-pro; what they extract per session
+    (tokens, cost, model) changes across pro releases. Stamping the rev
+    means an upgrade re-ingests every session once instead of trusting a
+    mark written by older extraction code. "" when pro is absent.
+    """
+    try:
+        import importlib.metadata as _ilm
+
+        return _ilm.version("clawmetry-pro")
+    except Exception:
+        return ""
+
+
 def _family_adapter_classes():
     """Return the importable non-OpenClaw runtime adapter classes."""
     classes = []
@@ -11708,6 +11724,7 @@ def sync_family_runtimes(config: dict, state: dict, paths: dict) -> int:
     # 29 of 387 ~/.claude sessions were OpenClaw-spawned.
     openclaw_spawned_claude = _openclaw_spawned_claude_ids()
 
+    _ingest_rev = _family_ingest_rev()
     for cls in _family_adapter_classes():
         try:
             adapter = cls()  # construct once (discovery globs/DB opens are not free)
@@ -11727,9 +11744,18 @@ def sync_family_runtimes(config: dict, state: dict, paths: dict) -> int:
                 # ``ended`` (the adapter sets it to the last event ts) every turn,
                 # so they're never wrongly skipped; idle/ended sessions cost ~0.
                 _evt_hw = state.setdefault("family_event_high_water", {})
-                _hw_ts = _evt_hw.get(ns_id)
+                # The mark is "<ts>@@<ingest-rev>" (rev = installed
+                # clawmetry-pro version). A pro upgrade changes what the
+                # adapters extract (live-hit 2026-07-19: nanoclaw sessions
+                # ingested by a pre-deep-usage wheel were skipped forever,
+                # so their $0 cost could never heal) — a rev mismatch
+                # re-ingests the session once. Pre-rev marks (plain ts)
+                # mismatch "" vs the real rev and re-ingest once too.
+                _hw_raw = str(_evt_hw.get(ns_id) or "")
+                _hw_ts, _, _hw_rev = _hw_raw.partition("@@")
                 _activity = ended or started
-                if _hw_ts and _activity and _activity <= _hw_ts:
+                if (_hw_ts and _activity and _activity <= _hw_ts
+                        and _hw_rev == _ingest_rev):
                     continue
                 metadata = {
                     "runtime": runtime,
@@ -11960,13 +11986,13 @@ def sync_family_runtimes(config: dict, state: dict, paths: dict) -> int:
                         # again. Only on a clean ingest -- a failure leaves the
                         # mark behind so we retry the session next cycle.
                         if _activity:
-                            _evt_hw[ns_id] = _activity
+                            _evt_hw[ns_id] = _activity + "@@" + _ingest_rev
                     except Exception as _ee:
                         log.warning("family event ingest failed (%s): %s", ns_id, _ee)
                 elif _activity:
                     # No event rows (e.g. an empty/metadata-only session): still
                     # mark it seen so we don't re-scan it every cycle forever.
-                    _evt_hw[ns_id] = _activity
+                    _evt_hw[ns_id] = _activity + "@@" + _ingest_rev
         except Exception as exc:
             log.warning(
                 "family runtime ingest failed for %s: %s",

--- a/dashboard.py
+++ b/dashboard.py
@@ -260,7 +260,7 @@ def _otlp_service_name_to_agent_type(service_name):
     return slug or "custom"
 
 
-__version__ = "0.12.558"
+__version__ = "0.12.559"
 
 # Extensions (Phase 2): import the plugin host now, but defer the actual
 # load_plugins() call until after the Flask app is created below so we can

--- a/tests/test_family_runtime_ingest.py
+++ b/tests/test_family_runtime_ingest.py
@@ -216,3 +216,68 @@ def test_openclaw_spawned_claude_skipped(tmp_path, monkeypatch):
     assert f"claude_code:{spawned_id}" not in sids, "OpenClaw-spawned session must be skipped (dedup)"
     try: store.stop(flush=True)
     except Exception: pass
+
+
+def test_family_high_water_rev_mismatch_reingests(sync_with_isolated_store):
+    """A pro upgrade changes what adapters extract; marks written by the old
+    wheel must not suppress re-ingest (live-hit 2026-07-19: nanoclaw
+    sessions ingested pre-deep-usage stayed $0 forever)."""
+    sync, ls = sync_with_isolated_store
+    config = {"node_id": "test-node", "api_key": "test-key"}
+    state = {}
+    # Fixture-backed adapters only: the other specs (claude_code, codex, ...)
+    # would sweep the dev machine's real homes and break determinism.
+    _specs = tuple(sp for sp in sync._FAMILY_ADAPTER_SPECS
+                   if sp[0].rsplit(".", 1)[-1] in ("picoclaw", "nanoclaw"))
+
+    with patch.object(sync, "_FAMILY_ADAPTER_SPECS", _specs), \
+         patch.object(sync, "_sync_allowed", return_value=True), \
+         patch.object(sync, "_post", return_value={}), \
+         patch.object(sync, "_family_ingest_rev", return_value="0.4.0"):
+        n1 = sync.sync_family_runtimes(config, state, {})
+    assert n1 > 0
+    hw = state["family_event_high_water"]
+    assert all(v.endswith("@@0.4.0") for v in hw.values()), hw
+
+    # Same rev, no new activity: skipped.
+    with patch.object(sync, "_FAMILY_ADAPTER_SPECS", _specs), \
+         patch.object(sync, "_sync_allowed", return_value=True), \
+         patch.object(sync, "_post", return_value={}), \
+         patch.object(sync, "_family_ingest_rev", return_value="0.4.0"):
+        n2 = sync.sync_family_runtimes(config, state, {})
+    assert n2 == 0
+
+    # New rev: everything re-ingests once, marks re-stamped.
+    with patch.object(sync, "_FAMILY_ADAPTER_SPECS", _specs), \
+         patch.object(sync, "_sync_allowed", return_value=True), \
+         patch.object(sync, "_post", return_value={}), \
+         patch.object(sync, "_family_ingest_rev", return_value="0.4.1"):
+        n3 = sync.sync_family_runtimes(config, state, {})
+    assert n3 > 0
+    assert all(v.endswith("@@0.4.1")
+               for v in state["family_event_high_water"].values())
+
+
+def test_family_high_water_legacy_plain_ts_reingests_once(sync_with_isolated_store):
+    """Marks written before the rev stamp (plain ISO ts) must re-ingest once."""
+    sync, ls = sync_with_isolated_store
+    config = {"node_id": "test-node", "api_key": "test-key"}
+    state = {}
+    _specs = tuple(sp for sp in sync._FAMILY_ADAPTER_SPECS
+                   if sp[0].rsplit(".", 1)[-1] in ("picoclaw", "nanoclaw"))
+    with patch.object(sync, "_FAMILY_ADAPTER_SPECS", _specs), \
+         patch.object(sync, "_sync_allowed", return_value=True), \
+         patch.object(sync, "_post", return_value={}), \
+         patch.object(sync, "_family_ingest_rev", return_value="0.4.1"):
+        n1 = sync.sync_family_runtimes(config, state, {})
+    assert n1 > 0
+    # Rewrite marks to the legacy plain-ts format.
+    hw = state["family_event_high_water"]
+    for k in list(hw):
+        hw[k] = hw[k].split("@@")[0]
+    with patch.object(sync, "_FAMILY_ADAPTER_SPECS", _specs), \
+         patch.object(sync, "_sync_allowed", return_value=True), \
+         patch.object(sync, "_post", return_value={}), \
+         patch.object(sync, "_family_ingest_rev", return_value="0.4.1"):
+        n2 = sync.sync_family_runtimes(config, state, {})
+    assert n2 > 0, "legacy plain-ts marks must not suppress re-ingest"


### PR DESCRIPTION
A clawmetry-pro upgrade changes what the runtime adapters extract per session, but `sync_family_runtimes` skips sessions whose activity hasn't advanced past the stored high-water mark - written by the OLD wheel.

Live-hit 2026-07-19: nanoclaw sessions ingested by the pre-deep-usage pro 0.4.0 stayed $0 on the Cost tab forever after pro 0.4.1 shipped, because the mark suppressed re-ingest.

Fix: the mark becomes `<ts>@@<pro version>`; rev mismatch (or legacy plain-ts mark) re-ingests once and re-stamps. Event upserts are PK-deduped so the one-time re-read is safe.

Tests: test_family_runtime_ingest.py 7 passed (2 new: rev-mismatch re-ingest, legacy-mark re-ingest; both hermetic - adapter specs scoped to the fixture-backed picoclaw/nanoclaw).

🤖 Generated with [Claude Code](https://claude.com/claude-code)