### PR TITLE
feat(cli): clawmetry diagnose — scriptable read of entitlement resolver inputs

### DIFF
--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -3803,6 +3803,102 @@ def _cmd_channels(args) -> None:
         print(f"  {cid:<16} {label:<20} {status}")
 
 
+def _cmd_diagnose(args) -> None:
+    """clawmetry diagnose — surface the entitlement resolver inputs.
+
+    Sibling of :func:`_cmd_tier` for operators who need to answer "why is
+    my resolved tier what it is?": license file present or not, cloud
+    plan cache present or not, enforcement env var, and the in-process
+    resolver cache state. Reads
+    :func:`clawmetry.entitlements.resolution_diagnostic` -- the same
+    source ``GET /api/entitlement/diagnostic`` serves -- so the CLI and
+    the HTTP surface cannot drift on the inputs they expose.
+
+    Read-only, side-effect free. Never raises: any resolver failure
+    surfaces inline (a warning line in the human block, or an ``error``
+    key on the JSON payload with the partial dict intact) so a wrapper
+    script always sees a parseable response. Matches the never-crash
+    contract documented on :func:`get_entitlement`.
+
+    Output:
+      default -- human-readable block (license, cloud plan, enforce env,
+                 cache state) matching the aligned two-column style
+                 shared with ``clawmetry tier`` / ``features`` / ``runtimes``
+      --json  -- :func:`resolution_diagnostic` dict serialized (indent=2,
+                 sort_keys=True) so a shell wrapper can pipe it to jq
+    """
+    import json as _json
+
+    from clawmetry import entitlements as _ent
+
+    payload: dict = {}
+    err: str | None = None
+    try:
+        payload = _ent.resolution_diagnostic()
+    except Exception as exc:
+        err = str(exc)
+        print(f"⚠️  entitlement diagnostic failed: {exc}", file=sys.stderr)
+
+    if getattr(args, "as_json", False):
+        if err:
+            payload = dict(payload)
+            payload["error"] = err
+        print(_json.dumps(payload, indent=2, sort_keys=True))
+        return
+
+    print("ClawMetry Diagnose\n" + "─" * 40)
+    if err:
+        print(f"  ⚠️  diagnostic error: {err}")
+        return
+
+    def _row(label: str, value) -> None:
+        print(f"  {label:<24} {value}")
+
+    lic_present = bool(payload.get("license_present"))
+    lic_size = int(payload.get("license_size_bytes") or 0)
+    lic_path = payload.get("license_path") or "?"
+    _row("License file:", "yes" if lic_present else "no")
+    _row("  path:", lic_path)
+    if lic_present:
+        _row("  size (bytes):", lic_size)
+    if payload.get("license_error"):
+        _row("  error:", payload["license_error"])
+
+    cp_present = bool(payload.get("cloud_plan_present"))
+    cp_size = int(payload.get("cloud_plan_size_bytes") or 0)
+    cp_path = payload.get("cloud_plan_path") or "?"
+    _row("Cloud plan cache:", "yes" if cp_present else "no")
+    _row("  path:", cp_path)
+    if cp_present:
+        _row("  size (bytes):", cp_size)
+    if payload.get("cloud_plan_error"):
+        _row("  error:", payload["cloud_plan_error"])
+
+    enforce_env = payload.get("enforce_env")
+    is_enforced = bool(payload.get("is_enforced"))
+    _row("Enforce env:", enforce_env if enforce_env not in (None, "") else "(unset)")
+    _row("Enforced:", "yes" if is_enforced else "no (grace)")
+
+    ret_env_name = payload.get("retention_override_env_name") or "?"
+    ret_env_val = payload.get("retention_override_env_value")
+    _row(
+        f"{ret_env_name}:",
+        ret_env_val if ret_env_val not in (None, "") else "(unset)",
+    )
+
+    age = payload.get("cache_age_seconds")
+    ttl = payload.get("cache_ttl_seconds")
+    hit = bool(payload.get("cache_hit_next_call"))
+    cached_tier = payload.get("cache_cached_tier")
+    _row("Cache age (s):", "-" if age is None else age)
+    _row("Cache TTL (s):", "-" if ttl is None else ttl)
+    _row("Cache hit next call:", "yes" if hit else "no")
+    if cached_tier:
+        _row("Cached tier:", cached_tier)
+    if payload.get("cache_error"):
+        _row("Cache error:", payload["cache_error"])
+
+
 def _cmd_verify_integrity(args) -> None:
     """clawmetry verify-integrity — walk the hash chain and report validity."""
     from clawmetry.local_store import get_store
@@ -4340,6 +4436,26 @@ def main() -> None:
         ),
     )
 
+    # diagnose — surface the entitlement resolver inputs so an operator
+    # can answer "why did my install resolve to <tier>?" without reading
+    # ~/.clawmetry by hand. Same shape as GET /api/entitlement/diagnostic.
+    p_diagnose = sub.add_parser(
+        "diagnose",
+        help=(
+            "Show entitlement resolver inputs (license file, cloud plan "
+            "cache, enforce env, in-process cache state)"
+        ),
+    )
+    p_diagnose.add_argument(
+        "--json",
+        action="store_true",
+        dest="as_json",
+        help=(
+            "Emit resolution_diagnostic() as JSON (same shape as "
+            "GET /api/entitlement/diagnostic)"
+        ),
+    )
+
     # verify-integrity — walk hash chain and report validity (Issue #2200)
     p_verify = sub.add_parser(
         "verify-integrity",
@@ -4373,6 +4489,7 @@ def main() -> None:
         "runtimes",
         "features",
         "channels",
+        "diagnose",
         "verify-integrity",
         "nemoclaw-daemons",
     )
@@ -4418,6 +4535,8 @@ def main() -> None:
             _cmd_features(args)
         elif args.cmd == "channels":
             _cmd_channels(args)
+        elif args.cmd == "diagnose":
+            _cmd_diagnose(args)
         elif args.cmd == "verify-integrity":
             _cmd_verify_integrity(args)
         elif args.cmd == "nemoclaw-daemons":

--- a/tests/test_cli_diagnose_subcommand.py
+++ b/tests/test_cli_diagnose_subcommand.py
@@ -1,0 +1,172 @@
+"""Tests for the `clawmetry diagnose` CLI subcommand.
+
+The subcommand is a thin read of
+``clawmetry.entitlements.resolution_diagnostic()`` and must never crash --
+even when the resolver itself blows up. Mirrors
+``tests/test_cli_channels_subcommand.py`` /
+``tests/test_cli_features_subcommand.py`` /
+``tests/test_cli_runtimes_subcommand.py`` so the CLI diagnostic quartet
+(tier / runtimes / features / channels / diagnose) is covered by the
+same shape of test.
+
+The diagnose surface is not tier-gated -- it emits the *inputs* the
+resolver consulted (license file present, cloud plan cached, enforce
+env, cache age/ttl), not the tier grants themselves -- so a Free install
+sees the same shape a Pro install does. What flips between installs is
+whether the license/cloud rows are populated, and whether the enforce
+env is set.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+
+import pytest
+
+
+@pytest.fixture
+def cli_mod(monkeypatch, tmp_path):
+    """Fresh entitlements module with HOME pointed at an empty tmp dir so
+    the diagnostic block is rendered against the OSS-free default and
+    never against a license that happens to live on the host."""
+    import importlib
+
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    import clawmetry.entitlements as ent
+
+    importlib.reload(ent)
+    ent.invalidate()
+
+    import clawmetry.cli as cli  # imported after entitlements is rebuilt
+
+    yield cli
+    ent.invalidate()
+
+
+def _ns(**kw) -> argparse.Namespace:
+    return argparse.Namespace(**kw)
+
+
+def test_diagnose_block_surfaces_resolver_inputs(cli_mod, capsys):
+    cli_mod._cmd_diagnose(_ns(as_json=False))
+    out = capsys.readouterr().out
+    assert "ClawMetry Diagnose" in out
+    # The four resolver inputs the diagnostic exists to answer for.
+    assert "License file:" in out
+    assert "Cloud plan cache:" in out
+    assert "Enforce env:" in out
+    assert "Cache TTL (s):" in out
+    # Default (empty) install is grace mode with no license and no cloud
+    # plan cache -- both rows must render "no", not silently disappear.
+    assert "no" in out.split("License file:", 1)[1].split("\n", 1)[0]
+    assert "no" in out.split("Cloud plan cache:", 1)[1].split("\n", 1)[0]
+    # Grace surfaces as "no (grace)" on the Enforced row.
+    assert "no (grace)" in out
+
+
+def test_diagnose_json_is_machine_readable(cli_mod, capsys):
+    cli_mod._cmd_diagnose(_ns(as_json=True))
+    out = capsys.readouterr().out.strip()
+    payload = json.loads(out)
+    # The JSON payload IS resolution_diagnostic() verbatim -- the CLI
+    # must never re-shape the dict, since scripts pin the keys.
+    for key in (
+        "license_path",
+        "license_present",
+        "license_size_bytes",
+        "cloud_plan_path",
+        "cloud_plan_present",
+        "cloud_plan_size_bytes",
+        "enforce_env",
+        "is_enforced",
+        "cache_age_seconds",
+        "cache_ttl_seconds",
+        "cache_hit_next_call",
+        "cache_cached_tier",
+        "retention_override_env_name",
+        "retention_override_env_value",
+    ):
+        assert key in payload, key
+    # Default install: no license, no cloud plan, no enforce env.
+    assert payload["license_present"] is False
+    assert payload["cloud_plan_present"] is False
+    assert payload["is_enforced"] is False
+
+
+def test_diagnose_enforced_env_flips_is_enforced(cli_mod, capsys, monkeypatch):
+    """Setting CLAWMETRY_ENFORCE=1 must flip the ``is_enforced`` bit AND
+    surface the raw env value on the ``enforce_env`` key so an operator
+    debugging "why is enforce on?" sees both signals."""
+    import clawmetry.entitlements as ent
+
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    cli_mod._cmd_diagnose(_ns(as_json=True))
+    payload = json.loads(capsys.readouterr().out.strip())
+    assert payload["enforce_env"] == "1"
+    assert payload["is_enforced"] is True
+
+
+def test_diagnose_reflects_license_file_present(cli_mod, capsys, tmp_path):
+    """When ~/.clawmetry/license.key exists, ``license_present`` flips
+    to True and ``license_size_bytes`` reports the file size. The
+    resolver contract only depends on file presence + size for this
+    surface; whether the key is valid is a separate concern the
+    diagnostic does NOT try to answer."""
+    import os
+
+    import clawmetry.entitlements as ent
+
+    lic_dir = tmp_path / ".clawmetry"
+    lic_dir.mkdir(parents=True, exist_ok=True)
+    lic_file = lic_dir / "license.key"
+    lic_file.write_bytes(b"stub-license-payload")
+    # The module already snapshotted _LICENSE_PATH from HOME -- monkeypatch
+    # it so the stat() in resolution_diagnostic() reaches the file we just
+    # wrote regardless of when the module was reloaded relative to HOME.
+    ent._LICENSE_PATH = str(lic_file)
+
+    cli_mod._cmd_diagnose(_ns(as_json=True))
+    payload = json.loads(capsys.readouterr().out.strip())
+    assert payload["license_present"] is True
+    assert payload["license_size_bytes"] == os.path.getsize(str(lic_file))
+
+
+def test_diagnose_falls_back_when_resolver_errors(cli_mod, capsys, monkeypatch):
+    """A poisoned resolution_diagnostic() must not crash the CLI -- both
+    the human and JSON paths degrade to a parseable shape."""
+    import clawmetry.entitlements as ent
+
+    def _boom():
+        raise RuntimeError("synthetic diagnostic failure")
+
+    monkeypatch.setattr(ent, "resolution_diagnostic", _boom)
+
+    # Human path: warning + inline "diagnostic error" line, no traceback.
+    cli_mod._cmd_diagnose(_ns(as_json=False))
+    captured = capsys.readouterr()
+    assert "synthetic diagnostic failure" in captured.err
+    assert "diagnostic error" in captured.out
+
+    # JSON path: empty payload with an ``error`` key surfaced so the
+    # wrapper script sees the failure without a shell exit code trap.
+    cli_mod._cmd_diagnose(_ns(as_json=True))
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out.strip())
+    assert payload.get("error") == "synthetic diagnostic failure"
+
+
+def test_diagnose_subcommand_is_registered():
+    """The subparser + dispatch table must list ``diagnose`` so the
+    subcommand is reachable from the CLI entry point (and so the
+    single-token dispatch in ``main()`` recognises it as a subcommand,
+    not a dashboard flag)."""
+    import inspect
+
+    import clawmetry.cli as cli
+
+    src = inspect.getsource(cli.main)
+    assert '"diagnose"' in src
+    assert "_cmd_diagnose" in src


### PR DESCRIPTION
## Summary

Adds a new CLI subcommand, `clawmetry diagnose`, that surfaces the *inputs* the entitlement resolver consulted — license file presence/size, cloud plan cache presence/size, `CLAWMETRY_ENFORCE` env, `CLAWMETRY_RETENTION_DAYS` env, and the in-process resolver cache state (age / TTL / hit / cached tier).

The subcommand is a thin wrapper around `clawmetry.entitlements.resolution_diagnostic()` — the same source `GET /api/entitlement/diagnostic` already serves — so the CLI and the HTTP surface cannot drift on what they expose.

Sibling of the existing entitlement CLI quartet (`tier` / `runtimes` / `features` / `channels`): read-only, side-effect-free, never crashes, and honours the same `--json` convention so wrapper scripts get a parseable shape regardless of resolver health.

## What ships

- `clawmetry/cli.py`
  - `_cmd_diagnose(args)` — human-readable block matching the aligned two-column style shared with `tier` / `features` / `runtimes` / `channels`. Grace-preserving; no gate applied.
  - `_cmd_diagnose(--json)` — emits `resolution_diagnostic()` verbatim (`indent=2`, `sort_keys=True`) so a wrapper can pipe through jq.
  - `p_diagnose` subparser + `--json` flag; wired into the `_subcmds` tuple and the main dispatch table so it is reachable from the CLI entry point.
- `tests/test_cli_diagnose_subcommand.py` (new)
  - Human block surfaces license / cloud plan / enforce env / cache TTL rows.
  - `--json` payload keys are stable (14 fields tied to `resolution_diagnostic`).
  - `CLAWMETRY_ENFORCE=1` flips both `enforce_env` and `is_enforced`.
  - A stub `~/.clawmetry/license.key` flips `license_present` + `license_size_bytes`.
  - Poisoned `resolution_diagnostic` gracefully degrades (warning to stderr on the human path, `error` key on the JSON payload).
  - Subparser + dispatch registration guard.

## What this does NOT do (by design)

- Does not add any gate, tier check, or behaviour change. `diagnose` is read-only observability, not an enforcement surface.
- Does not change `resolution_diagnostic()` or any HTTP endpoint — the shape it exposes is what `/api/entitlement/diagnostic` already emits.
- No version bump, no `[RELEASE]` tag, no dashboard-facing UI. Local-operator scope only.

## Test evidence

```
$ python3 -m pytest tests/test_cli_diagnose_subcommand.py -x -q
6 passed in 0.24s

$ python3 -m pytest tests/test_cli_channels_subcommand.py tests/test_cli_features_subcommand.py \
    tests/test_cli_runtimes_subcommand.py tests/test_cli_license_json.py \
    tests/test_cli_entitlement_why.py tests/test_cli_banner.py -x -q
44 passed, 1 skipped in 1.36s
```

Sample `clawmetry diagnose` output on a fresh (unlicensed) install:

```
ClawMetry Diagnose
────────────────────────────────────────
  License file:            no
    path:                  ~/.clawmetry/license.key
  Cloud plan cache:        no
    path:                  ~/.clawmetry/cloud_plan.json
  Enforce env:             (unset)
  Enforced:                no (grace)
  CLAWMETRY_RETENTION_DAYS: (unset)
  Cache age (s):           -
  Cache TTL (s):           60.0
  Cache hit next call:     no
```

## Local operator verification checklist

Because this fires as an autonomous, remote-only run, the reviewer needs to close the loop on the actual host:

- [ ] `git fetch origin feat/cli-diagnose-subcommand && git checkout feat/cli-diagnose-subcommand`
- [ ] Copy the changed files into the local install:
  ```
  cp clawmetry/cli.py ~/.clawmetry/lib/python3.*/site-packages/clawmetry/cli.py
  find ~/.clawmetry/lib -name __pycache__ -type d -exec rm -rf {} +
  ```
- [ ] `clawmetry diagnose` — human block renders four rows (license, cloud plan, enforce env, cache TTL). Expect `no (grace)` on an unlicensed install.
- [ ] `clawmetry diagnose --json | jq .` — payload keys match `resolution_diagnostic()` exactly. No extra shaping.
- [ ] `CLAWMETRY_ENFORCE=1 clawmetry diagnose --json | jq '.is_enforced, .enforce_env'` — flips to `true` / `"1"`.
- [ ] `curl -s http://localhost:8900/api/entitlement/diagnostic | jq -S .` and `clawmetry diagnose --json | jq -S .` — same shape. If they drift, that is the bug this PR is designed to prevent.
- [ ] Restart the sync daemon so a re-imported CLI wheel is picked up:
  ```
  launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync
  ```
- [ ] Live-cloud sanity: decrypt the live snapshot, confirm no dashboard endpoint behaviour changed (this PR only adds a CLI subcommand — nothing HTTP-facing shifts).
- [ ] Merge is at your discretion; branch is left as **draft** so CI can gate the merge and the release cadence stays yours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CNwVTcwcNDVPvtKJzEZZ1q

---
_Generated by [Claude Code](https://claude.ai/code/session_01CNwVTcwcNDVPvtKJzEZZ1q)_