### PR TITLE
feat(cli): --json flag on clawmetry verify-integrity

### DIFF
--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -3900,21 +3900,79 @@ def _cmd_diagnose(args) -> None:
 
 
 def _cmd_verify_integrity(args) -> None:
-    """clawmetry verify-integrity — walk the hash chain and report validity."""
+    """clawmetry verify-integrity — walk the hash chain and report validity.
+
+    ``--json`` emits a stable envelope so wrapper scripts can branch on the
+    outcome without screen-scraping the human table. The payload mirrors the
+    ``LocalStore.verify_integrity`` return shape (``status``/``checked``/
+    ``pre_chain``/``broken_at``/``error``/``node_id``) and adds two synthetic
+    statuses for the environment errors that today only surface via exit
+    code + text:
+
+      - ``store_open_failed``  — cannot open the local store (exit 1)
+      - ``daemon_too_old``     — daemon proxy returned None so ``verify_integrity``
+                                 is not in its allowlist (exit 2)
+      - ``error``              — ``verify_integrity`` itself raised (exit 1)
+
+    Exit codes are unchanged from the human path: 0 for ``valid``/``empty``,
+    1 for ``invalid``/``store_open_failed``/``error``, 2 for ``daemon_too_old``.
+    Never crashes: any unexpected shape degrades to a parseable JSON payload
+    with an ``error`` key so a shell pipeline always sees a valid response.
+
+    Sibling of :func:`_cmd_tier` / :func:`_cmd_diagnose` / :func:`_cmd_license`
+    which all carry ``--json`` for the same reason -- the CLI diagnostic
+    surface stays uniformly scriptable.
+    """
+    import json as _json
     from clawmetry.local_store import get_store
 
+    as_json = bool(getattr(args, "as_json", False))
     node_id = getattr(args, "node_id", None) or None
-    print("ClawMetry Integrity Verify\n" + "─" * 40)
+    scope_default = node_id or "all"
+
+    def _emit_json(payload: dict, exit_code: int) -> None:
+        print(_json.dumps(payload, indent=2, sort_keys=True))
+        if exit_code:
+            raise SystemExit(exit_code)
+
+    if not as_json:
+        print("ClawMetry Integrity Verify\n" + "─" * 40)
 
     try:
         store = get_store(read_only=True)
     except Exception as exc:
+        if as_json:
+            _emit_json(
+                {
+                    "status": "store_open_failed",
+                    "node_id": scope_default,
+                    "checked": 0,
+                    "pre_chain": 0,
+                    "broken_at": None,
+                    "error": str(exc),
+                },
+                1,
+            )
+            return  # unreachable — _emit_json raises when exit_code != 0
         print(f"  Error: cannot open local store — {exc}")
         raise SystemExit(1) from exc
 
     try:
         result = store.verify_integrity(node_id=node_id)
     except Exception as exc:
+        if as_json:
+            _emit_json(
+                {
+                    "status": "error",
+                    "node_id": scope_default,
+                    "checked": 0,
+                    "pre_chain": 0,
+                    "broken_at": None,
+                    "error": str(exc),
+                },
+                1,
+            )
+            return
         print(f"  Error: verification failed — {exc}")
         raise SystemExit(1) from exc
 
@@ -3923,15 +3981,62 @@ def _cmd_verify_integrity(args) -> None:
     # have ``verify_integrity`` in their method allowlist and return None.
     # Degrade gracefully instead of crashing on ``result["status"]``.
     if result is None:
+        if as_json:
+            _emit_json(
+                {
+                    "status": "daemon_too_old",
+                    "node_id": scope_default,
+                    "checked": 0,
+                    "pre_chain": 0,
+                    "broken_at": None,
+                    "error": (
+                        "daemon proxy returned None — verify_integrity is not in the"
+                        " running daemon's method allowlist. Restart the sync daemon"
+                        " to pick up the new wheel, then re-run."
+                    ),
+                },
+                2,
+            )
+            return
         print("  Result:      ?  Could not reach the running daemon's verifier.")
         print("               This usually means the daemon is older than the CLI.")
         print("               Restart the sync daemon to pick up the new wheel, then re-run.")
         raise SystemExit(2)
 
-    status = result["status"]
-    checked = result["checked"]
-    pre_chain = result["pre_chain"]
-    scope = result["node_id"]
+    status = result.get("status") if isinstance(result, dict) else None
+    checked = result.get("checked", 0) if isinstance(result, dict) else 0
+    pre_chain = result.get("pre_chain", 0) if isinstance(result, dict) else 0
+    scope = (result.get("node_id") if isinstance(result, dict) else None) or scope_default
+    broken_at = result.get("broken_at") if isinstance(result, dict) else None
+    error = result.get("error") if isinstance(result, dict) else None
+
+    if as_json:
+        exit_code = 1 if status == "invalid" else 0
+        # Emit the store's shape verbatim so scripts pinning keys never drift
+        # from what LocalStore.verify_integrity documents. Any non-dict result
+        # (shouldn't happen, but the never-crash contract still applies)
+        # collapses to a parseable error envelope.
+        if isinstance(result, dict):
+            payload = {
+                "status": status or "error",
+                "node_id": scope,
+                "checked": int(checked or 0),
+                "pre_chain": int(pre_chain or 0),
+                "broken_at": broken_at,
+                "error": error,
+            }
+        else:
+            payload = {
+                "status": "error",
+                "node_id": scope_default,
+                "checked": 0,
+                "pre_chain": 0,
+                "broken_at": None,
+                "error": f"verify_integrity returned unexpected shape: {type(result).__name__}",
+            }
+            exit_code = 1
+        _emit_json(payload, exit_code)
+        return
 
     print(f"  Scope:       {scope}")
     print(f"  Checked:     {checked} stamped event(s)")
@@ -3944,8 +4049,6 @@ def _cmd_verify_integrity(args) -> None:
     elif status == "valid":
         print(f"  Result:      ✅  VALID — chain intact across {checked} event(s)")
     else:
-        broken_at = result["broken_at"]
-        error = result["error"]
         print(f"  Result:      ❌  INVALID — {error}")
         print(f"  First break: {broken_at}")
         raise SystemExit(1)
@@ -4466,6 +4569,16 @@ def main() -> None:
         dest="node_id",
         default=None,
         help="Limit verification to a single node (default: all nodes)",
+    )
+    p_verify.add_argument(
+        "--json",
+        action="store_true",
+        dest="as_json",
+        help=(
+            "Emit the verify_integrity result as JSON (mirrors the store's "
+            "return shape plus synthetic 'store_open_failed' / 'daemon_too_old'"
+            " statuses; exit codes unchanged)"
+        ),
     )
 
     # Parse just the first token to decide if it's a sub-command or dashboard flag

--- a/tests/test_cli_verify_integrity_json.py
+++ b/tests/test_cli_verify_integrity_json.py
@@ -1,0 +1,309 @@
+"""Tests for ``clawmetry verify-integrity --json`` — scriptable hash-chain verify.
+
+Companion to ``tests/test_verify_integrity_cli_proxy.py`` (the human-path
+harness). Together they pin both surfaces so a wrapper script can consume
+the outcome without screen-scraping AND the operator's terminal keeps
+rendering the human table when ``--json`` is omitted.
+
+Contract this file pins:
+
+* every branch of :func:`clawmetry.cli._cmd_verify_integrity` emits a
+  stable JSON envelope with the same six keys the store returns
+  (``status``/``node_id``/``checked``/``pre_chain``/``broken_at``/``error``),
+* exit codes match the human path (0 for ``valid``/``empty``, 1 for
+  ``invalid``/``store_open_failed``/``error``, 2 for ``daemon_too_old``)
+  so a shell wrapper's ``$?`` remains the primary signal,
+* two synthetic statuses cover the environment errors that today only
+  surfaced via exit code + text (``store_open_failed`` and
+  ``daemon_too_old``) — without them a script could not distinguish
+  "chain broken" from "cannot open store" from "daemon proxy is old",
+* the parser wires ``--json`` on the ``verify-integrity`` subcommand so
+  a future edit that silently drops the flag is caught before ship,
+* the human path is unchanged (regression guard on the default output).
+
+Sibling of ``tests/test_cli_license_json.py`` /
+``tests/test_cli_diagnose_subcommand.py`` — the CLI diagnostic quartet
+(``tier`` / ``runtimes`` / ``features`` / ``channels`` / ``diagnose`` /
+``license`` / ``verify-integrity``) stays uniformly scriptable.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+
+import pytest
+
+
+def _args(node_id=None, as_json=True):
+    return argparse.Namespace(node_id=node_id, as_json=as_json)
+
+
+# ── happy path: JSON payload shape ────────────────────────────────────────────
+
+
+def test_json_valid_emits_store_shape_and_exits_zero(monkeypatch, capsys):
+    """A ``valid`` result must round-trip the store's six keys unchanged and
+    exit 0 so the shell pipe treats it as success."""
+    from clawmetry import cli
+
+    class _ValidStore:
+        def verify_integrity(self, node_id=None):
+            assert node_id is None
+            return {
+                "status": "valid",
+                "node_id": "all",
+                "checked": 42,
+                "pre_chain": 3,
+                "broken_at": None,
+                "error": None,
+            }
+
+    monkeypatch.setattr(
+        "clawmetry.local_store.get_store",
+        lambda read_only=True: _ValidStore(),
+    )
+
+    cli._cmd_verify_integrity(_args())
+    payload = json.loads(capsys.readouterr().out)
+    assert payload == {
+        "status": "valid",
+        "node_id": "all",
+        "checked": 42,
+        "pre_chain": 3,
+        "broken_at": None,
+        "error": None,
+    }
+
+
+def test_json_empty_shape_and_exits_zero(monkeypatch, capsys):
+    """``empty`` (no stamped events) is a success outcome, not a failure —
+    exit 0 matches the human path and lets scripts branch on ``status``
+    instead of ``$?``."""
+    from clawmetry import cli
+
+    class _EmptyStore:
+        def verify_integrity(self, node_id=None):
+            return {
+                "status": "empty",
+                "node_id": "all",
+                "checked": 0,
+                "pre_chain": 0,
+                "broken_at": None,
+                "error": None,
+            }
+
+    monkeypatch.setattr(
+        "clawmetry.local_store.get_store",
+        lambda read_only=True: _EmptyStore(),
+    )
+
+    cli._cmd_verify_integrity(_args())
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == "empty"
+    assert payload["checked"] == 0
+
+
+def test_json_invalid_carries_broken_at_and_exits_one(monkeypatch, capsys):
+    """A broken chain must exit 1 AND surface ``broken_at`` + ``error`` so a
+    wrapper script has enough context to fire an alert without a re-read."""
+    from clawmetry import cli
+
+    class _BrokenStore:
+        def verify_integrity(self, node_id=None):
+            return {
+                "status": "invalid",
+                "node_id": "all",
+                "checked": 5,
+                "pre_chain": 0,
+                "broken_at": "evt-6",
+                "error": "chain break at event evt-6 (node node-a)",
+            }
+
+    monkeypatch.setattr(
+        "clawmetry.local_store.get_store",
+        lambda read_only=True: _BrokenStore(),
+    )
+
+    with pytest.raises(SystemExit) as ei:
+        cli._cmd_verify_integrity(_args())
+    assert ei.value.code == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == "invalid"
+    assert payload["broken_at"] == "evt-6"
+    assert "chain break" in payload["error"]
+
+
+def test_json_node_id_scopes_are_threaded_through(monkeypatch, capsys):
+    """``--node-id NODE`` is forwarded to ``verify_integrity`` and echoed
+    back on the payload's ``node_id`` field so scripts running per-node
+    verifications can key their state map off the payload directly."""
+    from clawmetry import cli
+
+    seen: dict = {}
+
+    class _Store:
+        def verify_integrity(self, node_id=None):
+            seen["node_id"] = node_id
+            return {
+                "status": "valid",
+                "node_id": node_id or "all",
+                "checked": 1,
+                "pre_chain": 0,
+                "broken_at": None,
+                "error": None,
+            }
+
+    monkeypatch.setattr(
+        "clawmetry.local_store.get_store",
+        lambda read_only=True: _Store(),
+    )
+
+    cli._cmd_verify_integrity(_args(node_id="node-42"))
+    payload = json.loads(capsys.readouterr().out)
+    assert seen["node_id"] == "node-42"
+    assert payload["node_id"] == "node-42"
+
+
+# ── environment / failure envelopes ──────────────────────────────────────────
+
+
+def test_json_daemon_too_old_returns_status_and_exit_two(monkeypatch, capsys):
+    """Old-daemon scenario: the proxy returns None. Under ``--json`` this must
+    surface as ``status=daemon_too_old`` with exit code 2 so a wrapper can
+    distinguish "verifier reachable but broken chain" from "verifier
+    unreachable"."""
+    from clawmetry import cli
+
+    class _NoneStore:
+        def verify_integrity(self, node_id=None):  # noqa: ARG002
+            return None
+
+    monkeypatch.setattr(
+        "clawmetry.local_store.get_store",
+        lambda read_only=True: _NoneStore(),
+    )
+
+    with pytest.raises(SystemExit) as ei:
+        cli._cmd_verify_integrity(_args())
+    assert ei.value.code == 2
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == "daemon_too_old"
+    assert payload["checked"] == 0
+    assert "Restart the sync daemon" in payload["error"]
+
+
+def test_json_store_open_failure_returns_status_and_exit_one(monkeypatch, capsys):
+    """A raised ``get_store`` must not crash the CLI. Under ``--json`` it
+    surfaces as ``status=store_open_failed`` with the underlying exception
+    string preserved so operators can see why."""
+    from clawmetry import cli
+
+    def _raiser(read_only=True):  # noqa: ARG001
+        raise RuntimeError("duckdb: writer lock held by another process")
+
+    monkeypatch.setattr("clawmetry.local_store.get_store", _raiser)
+
+    with pytest.raises(SystemExit) as ei:
+        cli._cmd_verify_integrity(_args())
+    assert ei.value.code == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == "store_open_failed"
+    assert "writer lock" in payload["error"]
+
+
+def test_json_verify_call_raising_returns_status_error(monkeypatch, capsys):
+    """A raised ``verify_integrity`` (bad DuckDB state, schema drift, …) must
+    surface as ``status=error`` with the exception string preserved. Exit 1
+    matches the human path."""
+    from clawmetry import cli
+
+    class _RaisingStore:
+        def verify_integrity(self, node_id=None):  # noqa: ARG002
+            raise RuntimeError("chain_hash column missing")
+
+    monkeypatch.setattr(
+        "clawmetry.local_store.get_store",
+        lambda read_only=True: _RaisingStore(),
+    )
+
+    with pytest.raises(SystemExit) as ei:
+        cli._cmd_verify_integrity(_args())
+    assert ei.value.code == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == "error"
+    assert "chain_hash column missing" in payload["error"]
+
+
+def test_json_unexpected_shape_degrades_to_error_envelope(monkeypatch, capsys):
+    """If the store's return shape ever changes to something non-dict the CLI
+    must not crash. Falls back to ``status=error`` with a self-describing
+    ``error`` message so the wrapper still has something parseable."""
+    from clawmetry import cli
+
+    class _WeirdStore:
+        def verify_integrity(self, node_id=None):  # noqa: ARG002
+            return "not-a-dict"
+
+    monkeypatch.setattr(
+        "clawmetry.local_store.get_store",
+        lambda read_only=True: _WeirdStore(),
+    )
+
+    with pytest.raises(SystemExit) as ei:
+        cli._cmd_verify_integrity(_args())
+    assert ei.value.code == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == "error"
+    assert "unexpected shape" in payload["error"]
+
+
+# ── regression guards ────────────────────────────────────────────────────────
+
+
+def test_default_human_output_is_unchanged(monkeypatch, capsys):
+    """Without ``--json`` the human header + result lines are preserved so
+    every operator's terminal still reads the same table. Guards against
+    accidental drift in the default output when the JSON branch is added."""
+    from clawmetry import cli
+
+    class _ValidStore:
+        def verify_integrity(self, node_id=None):  # noqa: ARG002
+            return {
+                "status": "valid",
+                "node_id": "all",
+                "checked": 7,
+                "pre_chain": 0,
+                "broken_at": None,
+                "error": None,
+            }
+
+    monkeypatch.setattr(
+        "clawmetry.local_store.get_store",
+        lambda read_only=True: _ValidStore(),
+    )
+
+    cli._cmd_verify_integrity(_args(as_json=False))
+    out = capsys.readouterr().out
+    assert "ClawMetry Integrity Verify" in out
+    assert "Scope:" in out
+    assert "Checked:" in out
+    assert "VALID" in out
+    # The header block MUST NOT leak JSON tokens onto the human path.
+    assert "{" not in out
+
+
+def test_verify_integrity_subcommand_is_registered():
+    """The subparser + dispatch table must list ``verify-integrity`` so the
+    subcommand is reachable from the CLI entry point (and so the
+    single-token dispatch in ``main()`` recognises it as a subcommand,
+    not a dashboard flag)."""
+    import inspect
+
+    import clawmetry.cli as cli
+
+    src = inspect.getsource(cli.main)
+    assert '"verify-integrity"' in src
+    assert "_cmd_verify_integrity" in src
+    # And ``--json`` is threaded onto the subparser so a shell wrapper can
+    # rely on ``clawmetry verify-integrity --json`` being a stable contract.
+    assert '"--json"' in src


### PR DESCRIPTION
## Summary

- Adds a `--json` flag to `clawmetry verify-integrity` so wrapper scripts can consume the hash-chain verification outcome without screen-scraping the human table. Completes the CLI diagnostic quartet — every other read-only diagnostic (`tier`, `license`, `runtimes`, `features`, `channels`, `diagnose`) already surfaces `--json`.
- The JSON payload mirrors `LocalStore.verify_integrity`'s six-key return shape verbatim (`status`/`node_id`/`checked`/`pre_chain`/`broken_at`/`error`) so scripts pinning the store's shape don't have to re-shape. Three synthetic statuses cover environment errors that today only surface via exit code + text:
  - `store_open_failed` — cannot open the local store (exit 1)
  - `daemon_too_old` — daemon proxy returned `None` because `verify_integrity` is not in its method allowlist (exit 2)
  - `error` — `verify_integrity` itself raised (exit 1)
- Exit codes are unchanged from the human path (0 for `valid`/`empty`, 1 for `invalid`/`store_open_failed`/`error`, 2 for `daemon_too_old`) so a shell wrapper's `$?` remains the primary signal. Any unexpected result shape degrades to a parseable envelope with an `error` key — matches the never-crash contract every other CLI diagnostic honours.
- Default (human) output is preserved character-for-character. `--json` is opt-in only; every existing operator terminal keeps rendering the same header + result block.

## What ships

- `clawmetry/cli.py`
  - `_cmd_verify_integrity(args)` — checks `getattr(args, "as_json", False)` and emits the store's shape verbatim under `--json`, with the two synthetic statuses layered on for the environment-error branches.
  - `p_verify.add_argument("--json", ...)` — wires the flag onto the subparser so `clawmetry verify-integrity --json` is a stable contract.
- `tests/test_cli_verify_integrity_json.py` (new, 10 cases)
  - Every real branch: `valid`, `empty`, `invalid`, `daemon_too_old`, `store_open_failed`, `verify_integrity` raising.
  - The unexpected-shape fallback (non-dict result → `status=error` envelope, exit 1).
  - `--node-id NODE` threading (forwarded to `verify_integrity`, echoed on payload `node_id`).
  - Human-path regression guard (default output still has `ClawMetry Integrity Verify` / `Scope:` / `Checked:` / `VALID` and never leaks JSON tokens).
  - Subparser + dispatch registration guard (`--json` present in `main()`'s source).

## What this does NOT do (by design)

- No behaviour change on the default path — the human table is byte-stable for existing operators.
- No new gate, tier check, or enforcement surface — `verify-integrity` remains read-only observability, same as its siblings.
- No changes to `LocalStore.verify_integrity` or the daemon-proxy allowlist — the store shape it exposes is what the store already documents.
- No version bump, no `[RELEASE]` tag, no dashboard-facing UI. CLI-only scope.

## Test plan

- [x] `python3 -m py_compile clawmetry/cli.py tests/test_cli_verify_integrity_json.py` — clean
- [x] `python3 -m pytest tests/test_cli_verify_integrity_json.py -x -q` — **10 passed**
- [x] Sibling CLI harnesses stay green (`test_cli_license_json.py`, `test_cli_diagnose_subcommand.py`, `test_cli_channels_subcommand.py`, `test_cli_features_subcommand.py`, `test_cli_runtimes_subcommand.py`, `test_cli_entitlement_why.py`, `test_cli_banner.py`, `test_verify_integrity_cli_proxy.py`) — **63 passed, 1 skipped**
- [x] Gate-suite spot check (`test_route_gates.py`, `test_audit_route_gate.py`, `test_tool_policy_route_gate.py`, `test_alerts_history_route_gate.py`) — **57 passed** (unchanged; this PR does not touch route gating)

### Local operator verification checklist

Because this fires as an autonomous remote-only run, the loop needs the operator to close it out on the actual host — I can't reach the running daemon, `~/.openclaw`, the live cloud snapshot, or a browser.

- [ ] `git fetch origin feat/cli-verify-integrity-json && git checkout feat/cli-verify-integrity-json`
- [ ] Copy the changed file into the local install and clear stale bytecode:
  ```
  cp clawmetry/cli.py ~/.clawmetry/lib/python3.*/site-packages/clawmetry/cli.py
  find ~/.clawmetry/lib -name __pycache__ -type d -exec rm -rf {} +
  ```
- [ ] Restart the sync daemon so the re-imported CLI wheel is picked up:
  ```
  launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync
  ```
- [ ] Default (human) path is unchanged — no JSON tokens should appear:
  ```
  clawmetry verify-integrity
  ```
- [ ] `--json` on a healthy install returns the store's six-key envelope with `status: valid` (or `empty`) and exits 0:
  ```
  clawmetry verify-integrity --json | jq .
  echo "exit=$?"
  ```
- [ ] `--node-id NODE --json` threads the scope through and echoes it back on the payload:
  ```
  clawmetry verify-integrity --node-id "$(clawmetry status --json | jq -r .node_id)" --json | jq .node_id
  ```
- [ ] Old-daemon degradation: with a daemon older than `0.12.343` (or by stopping the daemon and pointing the CLI at a stub proxy that returns `None`), `--json` surfaces `status: daemon_too_old` and exits 2 instead of crashing on `result["status"]`. Regression signal for the fix `test_verify_integrity_cli_proxy.py` already pins on the human path.
- [ ] Live-cloud sanity: decrypt the live snapshot, confirm no dashboard endpoint behaviour changed (this PR only adds a CLI flag — nothing HTTP-facing shifts).
- [ ] Merge is at your discretion; branch is left as **draft** so CI can gate the merge and the release cadence stays yours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LBDqqz4tMT3YqhKn7f82hf

---
_Generated by [Claude Code](https://claude.ai/code/session_01LBDqqz4tMT3YqhKn7f82hf)_