### PR TITLE
docs(entitlements): drop stale "resolvers are stubs" claim in module docstring

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -22,13 +22,18 @@ Open-core model
 
 Resolution order (first hit wins), all cached
 ---------------------------------------------
-1. A local signed license file (``~/.clawmetry/license.key``)  -> self-hosted Pro/Enterprise
-2. A cloud plan cached from the last heartbeat                  -> cloud Free/Starter/Pro/Trial
+1. A local signed license file (``~/.clawmetry/license.key``)   -> self-hosted Pro/Enterprise
+2. A cloud plan cached at ``~/.clawmetry/cloud_plan.json``      -> cloud Free/Starter/Pro/Trial
 3. else                                                         -> OSS free
 
-Both (1) and (2) are stubs in this phase — (1) lands with the Ed25519 license
-client, (2) when the daemon caches the heartbeat plan. Today this always
-resolves to the OSS-free entitlement.
+(1) is Ed25519-verified offline by :mod:`clawmetry.license` (the embedded
+public key ships in this OSS package; the private key lives on the license
+server). (2) is written by the sync daemon after each successful heartbeat
+that returned a plan payload. Both readers are defensive: a missing file
+skips to the next source, and a bad/expired token or malformed JSON logs a
+warning and skips to the next source — the resolver never raises. On a
+fresh install with no license key and no cloud plan cached, resolution
+falls through to the OSS-free entitlement.
 
 Rollout: GRACE vs ENFORCE
 -------------------------


### PR DESCRIPTION
## Summary

The `clawmetry/entitlements.py` module docstring still described the local-license and cloud-plan resolvers as unimplemented stubs and stated that the resolver "always resolves to the OSS-free entitlement." Both statements are now stale:

1. **Local license** — the Ed25519 license client shipped in `clawmetry/license.py`; `_read_local_license()` at `clawmetry/entitlements.py:2179` delegates to `clawmetry.license.load_license()`, which offline-verifies the signature against the embedded public key and builds an Entitlement.
2. **Cloud plan** — the sync daemon writes `~/.clawmetry/cloud_plan.json` after each successful heartbeat that returned a plan payload; `_read_cloud_plan()` at `clawmetry/entitlements.py:2191` reads that file.

So on installs that have either artefact, `get_entitlement()` resolves to a paid tier — the "always OSS-free" claim reads as "the paid path isn't implemented yet," which would mislead any new reader auditing the resolver.

## Changes

- **`clawmetry/entitlements.py`** module docstring only. Rewrote the "Resolution order" section to describe what actually happens today: Ed25519-verified license file, daemon-written cloud plan cache, or fall-through to OSS-free. Added a note that both readers are defensive (missing file → skip; bad token / malformed JSON → warning + skip; resolver never raises). Corrected the cache path in bullet (2) from an abstract "cached from the last heartbeat" to the actual path `~/.clawmetry/cloud_plan.json` (matches `_CLOUD_PLAN_CACHE` at line 396). No code change.

## Non-goals

- **No behaviour change.** Grace mode still defaults to True on OSS-free; `allows_*` semantics untouched.
- **No new tier / feature / runtime.** `FREE_RUNTIMES`, `FREE_FEATURES`, `_PAID_TIERS` all unchanged.
- **No enforce-mode flip.** `CLAWMETRY_ENFORCE=1` is still the operator-controlled switch.
- **No test change.** No test asserts the old docstring text (verified with `grep -rn 'stubs in this phase' clawmetry/ routes/ tests/` → 0 hits).

## Test plan

- [x] `python3 -m py_compile clawmetry/entitlements.py` — syntax OK
- [x] `python3 -c "from clawmetry import entitlements; print(entitlements.get_entitlement().to_dict()['tier'])"` prints `oss` (fresh install falls through to OSS-free path, unchanged)
- [x] `python3 -m pytest tests/test_entitlement_api.py tests/test_entitlement_api_fallback_shape.py` — 39/39 passed
- [x] `grep -rn "stubs in this phase\|always resolves to the OSS-free" clawmetry/ routes/ tests/` — 0 remaining references

## Local operator verification checklist

Since I cannot touch the local daemon, live snapshot, or a browser from this session, please verify on your host:

- [ ] Copy the updated file into the installed package: `cp clawmetry/entitlements.py ~/.clawmetry/lib/python3.*/site-packages/clawmetry/entitlements.py`
- [ ] Clear cached bytecode: `find ~/.clawmetry/lib -name '__pycache__' -type d -exec rm -rf {} +`
- [ ] Restart the sync daemon: `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
- [ ] Confirm nothing regresses: `curl -s http://localhost:8900/api/entitlement | jq '.tier, .grace'` should return the same tier + grace value as before this change
- [ ] Decrypt the live cloud snapshot in the browser and confirm the entitlement banner still reads the same tier
- [ ] Merge only after the above passes; keep DRAFT until then

## Rollout

Docstring-only, so grace-mode semantics are preserved end-to-end. No `[RELEASE]` PR needed — this can ride the next unrelated release. Kept DRAFT per the routine's contract.

---
_Generated by [Claude Code](https://claude.ai/code/session_01J7vHaQRZCWRk5UCJL2HJZF)_