### PR TITLE
[RELEASE] 0.12.561 - vm-usage-log ingest (per-VM LLM cost for token-blind runtimes)

### DIFF
--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -11319,6 +11319,156 @@ _FAMILY_ADAPTER_SPECS = (
 )
 
 
+_VM_USAGE_DEFAULT_ALLOW = ("picoclaw", "cursor")
+
+
+def sync_vm_usage_log(config: dict, state: dict, paths: dict) -> int:
+    """Ingest the hosted-VM per-call LLM usage log into DuckDB (+ cloud).
+
+    Hosted agent VMs run a loopback LLM shim that appends one JSON line per
+    model call (ts, model, token splits, opaque session ref — numbers only,
+    never content) to CLAWMETRY_VM_USAGE_LOG. For runtimes whose own session
+    stores carry no tokens (picoclaw: flat providers.Message JSONL; cursor:
+    proprietary backend) this log is the ONLY cost source, so the Cost tab
+    read $0 forever (live-hit 2026-07-20).
+
+    Double-count invariant: ingest ONLY when CLAWMETRY_VM_USAGE_RUNTIME is
+    in the token-blind allowlist — self-reporting runtimes (openclaw,
+    nanoclaw deep usage, claude_code, ...) are structurally excluded even
+    when the provisioner exports the env vars fleet-wide. Events land with
+    top-level model + data.usage split and cost_usd=None, so ingest-time
+    extraction derives cache-aware cost once (#2049); session ids are
+    namespaced "<runtime>:vmusage:<session>" so the Cost tab's runtime
+    prefix filter attributes them correctly. Offset+inode high-water in
+    sync-state.json; deterministic ids make any replay a PK no-op.
+    """
+    log_path = os.environ.get("CLAWMETRY_VM_USAGE_LOG", "").strip()
+    runtime = os.environ.get("CLAWMETRY_VM_USAGE_RUNTIME", "").strip().lower()
+    if not log_path or not runtime:
+        return 0
+    allow = tuple(x.strip().lower() for x in os.environ.get(
+        "CLAWMETRY_VM_USAGE_ALLOW",
+        ",".join(_VM_USAGE_DEFAULT_ALLOW)).split(",") if x.strip())
+    if runtime not in allow:
+        return 0
+    if not _sync_allowed():
+        return 0
+    try:
+        from clawmetry import local_store
+    except Exception:
+        return 0
+    try:
+        st = os.stat(log_path)
+    except OSError:
+        return 0
+    node_id = config.get("node_id") or ""
+    api_key = config.get("api_key")
+    mark = state.setdefault("vm_usage_log", {})
+    if mark.get("inode") != st.st_ino or st.st_size < int(mark.get("offset") or 0):
+        mark["inode"], mark["offset"] = st.st_ino, 0
+    offset = int(mark.get("offset") or 0)
+    if st.st_size <= offset:
+        return 0
+    rows: list = []
+    sessions: dict = {}
+    with open(log_path, "rb") as fh:
+        fh.seek(offset)
+        for _ in range(5000):
+            raw = fh.readline()
+            if not raw or not raw.endswith(b"\n"):
+                break  # partial tail line: picked up next tick
+            offset = fh.tell()
+            try:
+                line = json.loads(raw)
+            except Exception:
+                continue
+            model = str(line.get("model") or "")
+            ti = int(line.get("input_tokens") or 0)
+            to = int(line.get("output_tokens") or 0)
+            cr = int(line.get("cache_read_tokens") or 0)
+            cw = int(line.get("cache_write_tokens") or 0)
+            if not model or not (ti or to or cr or cw):
+                continue
+            sess = str(line.get("session") or "").strip() or "unknown"
+            ns_sess = "%s:vmusage:%s" % (runtime, sess)
+            import hashlib
+            digest = hashlib.sha1(("%s:%s" % (
+                st.st_ino, raw.decode("utf-8", "replace"))).encode()
+            ).hexdigest()[:24]
+            ts_iso = (_epoch_to_iso(line.get("ts"))
+                      or datetime.now(timezone.utc).isoformat())
+            rows.append({
+                "id": "vmusage:" + digest,
+                "node_id": node_id,
+                "agent_id": "main",
+                "agent_type": "openclaw",
+                "session_id": ns_sess,
+                "workspace_id": None,
+                "event_type": "llm_usage",
+                "ts": ts_iso,
+                "model": model,
+                "cost_usd": None,
+                "token_count": None,
+                "data": {"_runtime": runtime, "source": "vm-usage-log",
+                         "usage": {"input_tokens": ti,
+                                   "output_tokens": to,
+                                   "cache_read_input_tokens": cr,
+                                   "cache_creation_input_tokens": cw}},
+            })
+            meta = sessions.setdefault(
+                ns_sess, {"first": ts_iso, "last": ts_iso, "n": 0,
+                          "model": model, "tokens": 0})
+            meta["first"] = min(meta["first"], ts_iso)
+            meta["last"] = max(meta["last"], ts_iso)
+            meta["n"] += 1
+            meta["tokens"] += ti + to
+            meta["model"] = model
+    if not rows:
+        mark["offset"] = offset
+        return 0
+    store = local_store.get_store()
+    cloud_session_rows = []
+    try:
+        store.ingest_many(rows)
+        for ns_sess, meta in sessions.items():
+            srow = {
+                "agent_type": "openclaw",
+                "session_id": ns_sess,
+                "node_id": node_id,
+                "agent_id": "main",
+                "title": "Model usage (%s)" % runtime,
+                "started_at": meta["first"],
+                "last_active_at": meta["last"],
+                "ended_at": meta["last"],
+                "status": "ended",
+                "total_tokens": int(meta["tokens"]),
+                "cost_usd": None,
+                "message_count": int(meta["n"]),
+                "metadata": {"runtime": runtime, "source": "vm-usage-log",
+                             "model": meta["model"],
+                             "recent_model": meta["model"]},
+            }
+            store.ingest_session(srow)
+            crow = dict(srow)
+            crow["runtime"] = runtime
+            crow["model"] = meta["model"]
+            crow.pop("metadata", None)
+            cloud_session_rows.append(crow)
+        store.flush()
+    except Exception as exc:
+        log.warning("vm-usage ingest failed (retry next tick): %s", exc)
+        return 0
+    mark["offset"] = offset   # advance ONLY after a clean ingest+flush
+    if cloud_session_rows and api_key:
+        try:
+            _post("/ingest/sessions",
+                  {"node_id": node_id, "sessions": cloud_session_rows},
+                  api_key)
+        except Exception as _pe:
+            log.debug("vm-usage cloud push failed (continuing): %s", _pe)
+    return len(rows)
+
+
 def _family_ingest_rev() -> str:
     """Installed clawmetry-pro version, stamped into family high-water marks.
 
@@ -17561,6 +17711,7 @@ def run_daemon() -> None:
         log.warning(f"  Session metadata error: {e}")
     try:
         fr = sync_family_runtimes(config, state, paths)
+        fr += sync_vm_usage_log(config, state, paths)
         if fr:
             log.info(f"  Family-runtime sessions (PicoClaw/NanoClaw): {fr} events synced")
     except Exception as e:
@@ -18005,6 +18156,11 @@ def run_daemon() -> None:
             if now_fam - last_family > family_interval:
                 try:
                     ev += sync_family_runtimes(config, state, paths)
+                    try:
+                        ev += sync_vm_usage_log(config, state, paths)
+                    except Exception as _vu_e:
+                        log.warning("vm-usage ingest failed (continuing): %s",
+                                    _vu_e)
                 except Exception as _fam_e:
                     log.warning("family-runtime ingest failed (continuing): %s", _fam_e)
                 last_family = now_fam

--- a/dashboard.py
+++ b/dashboard.py
@@ -260,7 +260,7 @@ def _otlp_service_name_to_agent_type(service_name):
     return slug or "custom"
 
 
-__version__ = "0.12.560"
+__version__ = "0.12.561"
 
 # Extensions (Phase 2): import the plugin host now, but defer the actual
 # load_plugins() call until after the Flask app is created below so we can

--- a/tests/test_vm_usage_ingest.py
+++ b/tests/test_vm_usage_ingest.py
@@ -1,0 +1,125 @@
+"""sync_vm_usage_log: hosted-VM per-call LLM usage → DuckDB cost events.
+
+The only cost source for token-blind runtimes (picoclaw — live-hit
+2026-07-20: BYOK picoclaw showed $0 forever). Allowlist prevents double
+counting on self-reporting runtimes."""
+from __future__ import annotations
+
+import importlib
+import json
+import os
+import time
+
+import pytest
+
+
+@pytest.fixture
+def iso_sync(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "e.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_BATCH", "5")
+    import clawmetry.local_store as ls
+    import clawmetry.sync as sync
+    importlib.reload(ls)
+    importlib.reload(sync)
+    monkeypatch.setattr(ls, "_daemon_registered", lambda: False)
+    monkeypatch.delenv("CLAWMETRY_ROLE", raising=False)
+    yield sync, ls
+    try:
+        ls.get_store().stop(flush=True)
+    except Exception:
+        pass
+
+
+def _write_log(path, n=3, session="telegram-chat42"):
+    with open(path, "a") as fh:
+        for i in range(n):
+            fh.write(json.dumps({
+                "ts": time.time(), "model": "claude-haiku-4-5",
+                "input_tokens": 1000, "output_tokens": 200,
+                "cache_read_tokens": 100, "cache_write_tokens": 50,
+                "session": session}) + "\n")
+
+
+def _wait_flush(store, timeout=3.0):
+    import time as _t
+    end = _t.monotonic() + timeout
+    while _t.monotonic() < end:
+        if store.health()["ring_depth"] == 0:
+            return
+        _t.sleep(0.02)
+    raise AssertionError("flush did not drain")
+
+
+def test_ingests_priced_events_for_allowlisted_runtime(iso_sync, tmp_path, monkeypatch):
+    sync, ls = iso_sync
+    log = tmp_path / "llm-usage.jsonl"
+    _write_log(log, n=3)
+    monkeypatch.setenv("CLAWMETRY_VM_USAGE_LOG", str(log))
+    monkeypatch.setenv("CLAWMETRY_VM_USAGE_RUNTIME", "picoclaw")
+    state = {}
+    from unittest.mock import patch
+    with patch.object(sync, "_sync_allowed", return_value=True), \
+         patch.object(sync, "_post", return_value={}):
+        n = sync.sync_vm_usage_log({"node_id": "n1", "api_key": "k"}, state, {})
+    assert n == 3
+    store = ls.get_store()
+    _wait_flush(store)
+    rows = store._fetch(
+        "SELECT session_id, event_type, model, cost_usd, token_count "
+        "FROM events WHERE session_id LIKE 'picoclaw:vmusage:%'", [])
+    assert len(rows) == 3
+    for sid, etype, model, cost, tokens in rows:
+        assert etype == "llm_usage" and model == "claude-haiku-4-5"
+        assert sid == "picoclaw:vmusage:telegram-chat42"
+        assert cost is not None and cost > 0, "ingest-time cost derivation"
+        assert tokens == 1200
+    # hand-check one line's cost against the pricing helper
+    from clawmetry.providers_pricing import estimate_event_cost_usd
+    expect = estimate_event_cost_usd(
+        "claude-haiku-4-5", input_tokens=1000, output_tokens=200,
+        cache_read_tokens=100, cache_write_tokens=50)
+    assert abs(rows[0][3] - expect) < 1e-9
+    # replay with fresh state: PK-deduped, no inflation
+    with patch.object(sync, "_sync_allowed", return_value=True), \
+         patch.object(sync, "_post", return_value={}):
+        sync.sync_vm_usage_log({"node_id": "n1", "api_key": "k"}, {}, {})
+    _wait_flush(store)
+    rows2 = store._fetch(
+        "SELECT COUNT(*) FROM events WHERE session_id LIKE 'picoclaw:vmusage:%'", [])
+    assert rows2[0][0] == 3
+
+
+def test_offset_advances_and_rotation_resets(iso_sync, tmp_path, monkeypatch):
+    sync, ls = iso_sync
+    log = tmp_path / "llm-usage.jsonl"
+    _write_log(log, n=2)
+    monkeypatch.setenv("CLAWMETRY_VM_USAGE_LOG", str(log))
+    monkeypatch.setenv("CLAWMETRY_VM_USAGE_RUNTIME", "picoclaw")
+    state = {}
+    from unittest.mock import patch
+    with patch.object(sync, "_sync_allowed", return_value=True), \
+         patch.object(sync, "_post", return_value={}):
+        assert sync.sync_vm_usage_log({"node_id": "n"}, state, {}) == 2
+        # nothing new: offset holds, zero ingested
+        assert sync.sync_vm_usage_log({"node_id": "n"}, state, {}) == 0
+        # rotation: replace the file (new inode) -> offset resets, new lines land
+        os.replace(log, str(log) + ".1")
+        _write_log(log, n=1, session="web-web")
+        assert sync.sync_vm_usage_log({"node_id": "n"}, state, {}) == 1
+
+
+def test_allowlist_blocks_self_reporting_runtimes(iso_sync, tmp_path, monkeypatch):
+    sync, ls = iso_sync
+    log = tmp_path / "llm-usage.jsonl"
+    _write_log(log, n=2)
+    monkeypatch.setenv("CLAWMETRY_VM_USAGE_LOG", str(log))
+    monkeypatch.setenv("CLAWMETRY_VM_USAGE_RUNTIME", "nanoclaw")
+    from unittest.mock import patch
+    with patch.object(sync, "_sync_allowed", return_value=True):
+        assert sync.sync_vm_usage_log({"node_id": "n"}, {}, {}) == 0
+    # override allowlist opts a verified runtime in
+    monkeypatch.setenv("CLAWMETRY_VM_USAGE_ALLOW", "nanoclaw")
+    with patch.object(sync, "_sync_allowed", return_value=True), \
+         patch.object(sync, "_post", return_value={}):
+        assert sync.sync_vm_usage_log({"node_id": "n", "api_key": "k"}, {}, {}) == 2


### PR DESCRIPTION
Hosted VMs' llm_shim v2 writes a per-call usage JSONL; this ingests it as priced cost events for runtimes whose own stores carry no tokens (picoclaw, cursor), with a token-blind allowlist preventing double counting on self-reporting runtimes.

Tests: 3 new (priced ingest + pricing hand-check + replay idempotency; offset/rotation; allowlist), family suite 7 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)