### PR TITLE
feat(skills): surface Skill Workshop approval policy in skills tab (#3838)

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -2270,7 +2270,12 @@ async function loadSkills() {
   // fetch is safe in cloud too — no more "local-only" dead end.
   listEl.innerHTML = '<div style="color:var(--text-muted);font-size:13px;padding:16px;">' + t("app.loading", null, "Loading...") + '</div>';
   try {
-    var data = await fetch('/api/skills').then(function(r) { return r.json(); });
+    var _fetched = await Promise.all([
+      fetch('/api/skills').then(function(r) { return r.json(); }),
+      fetch('/api/skills/workshop').then(function(r) { return r.json(); }).catch(function() { return null; })
+    ]);
+    var data = _fetched[0];
+    var workshop = _fetched[1];
     var skills = data.skills || [];
     var summary = data.summary || {};
     var installed = summary.total_installed || 0;
@@ -2297,11 +2302,23 @@ async function loadSkills() {
         : card(t('skills.all_good', null, 'All good'), '\u2713', '#22c55e',
                t('skills.all_good_sub', null, 'every skill is being used'));
     }
+    var workshopCard = '';
+    if (workshop) {
+      var wPolicy = workshop.approval_policy;
+      if (wPolicy === 'pending') {
+        workshopCard = card('Workshop', '🔒', '#22c55e', 'approval gate on');
+      } else if (workshop.auto_actions_enabled) {
+        workshopCard = card('Workshop', '⚡', '#f59e0b', 'auto-apply active');
+      } else {
+        workshopCard = card('Workshop', '•', '#94a3b8', 'default behavior');
+      }
+    }
     summaryEl.innerHTML =
       card('Installed', installed, 'var(--text-primary)') +
       (dead   > 0 ? card('Safe to remove', dead,  '#ef4444', 'never used') : '') +
       (stuck  > 0 ? card('Not working',    stuck, '#f59e0b', 'broken or misdescribed') : '') +
-      verdictCard;
+      verdictCard +
+      workshopCard;
 
     if (skills.length === 0) {
       listEl.innerHTML = '<div style="color:var(--text-muted);font-size:13px;padding:16px;">' + t("app.nothing_installed_yet_skills", null, "Nothing installed yet. Skills let your agent handle specific tasks \u2014 add some to get started.") + '</div>';


### PR DESCRIPTION
## Summary

The `/api/skills/workshop` backend endpoint already reads `skills.workshop.approvalPolicy` from the OpenClaw config (`routes/skills.py`), but `loadSkills()` in the frontend never called it — leaving the Skill Workshop governance signal invisible on the Skills tab. This adds a "Workshop" stat card to the existing skills summary row to surface whether the agent's autonomous apply/reject/quarantine actions require human approval.

## Changes

- **`clawmetry/static/js/app.js` — `loadSkills()`**: fetch `/api/skills` and `/api/skills/workshop` concurrently via `Promise.all`; workshop fetch errors are caught and return `null` so older daemons don't crash the tab.
- **`clawmetry/static/js/app.js` — summary cards**: appends a `workshopCard` using the existing `card()` helper:
  - `approval_policy === "pending"` → 🔒 green "Workshop · approval gate on"
  - `auto_actions_enabled === true` → ⚡ amber "Workshop · auto-apply active"
  - `approval_policy === null` → • gray "Workshop · default behavior"
  - workshop endpoint unreachable → card omitted silently

## Test plan

- [ ] Load the Skills tab; confirm a "Workshop" stat card appears in the summary row alongside Installed / Safe to remove / Not working.
- [ ] With no `skills.workshop` config key in `~/.openclaw/openclaw.json` → gray "default behavior" card.
- [ ] With `approvalPolicy: "pending"` → green 🔒 "approval gate on" card.
- [ ] With `approvalPolicy: "auto"` or similar → amber ⚡ "auto-apply active" card.
- [ ] On an old daemon that returns 404/500 on `/api/skills/workshop` → Skills tab loads normally, no Workshop card, no JS error.

## Bot meta
<!-- bot-autofix -->
Draft PR opened autonomously based on the plan in #3838. Marked draft for human review — mark Ready for Review once happy.

Closes #3838

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gzru8zFei4WN3Ci6DPcfDY)_