### PR TITLE
fix: Windows POSIX-only API crashes and broken pid liveness probes

### DIFF
--- a/clawmetry/adapters/openclaw.py
+++ b/clawmetry/adapters/openclaw.py
@@ -87,8 +87,12 @@ def _gateway_live() -> bool:
             with open(pid_file) as fh:
                 pid = int((fh.read() or "0").strip())
             if pid > 0:
-                os.kill(pid, 0)
-                return True
+                # Portable probe: os.kill(pid, 0) never raises on Windows,
+                # so a stale gateway.pid would read as "running" forever.
+                from clawmetry.process_control import is_alive as _pid_alive
+
+                if _pid_alive(pid):
+                    return True
     except (OSError, ValueError):
         pass
     try:

--- a/clawmetry/mcp_server.py
+++ b/clawmetry/mcp_server.py
@@ -24,7 +24,13 @@ def _read_discovery() -> dict[str, Any] | None:
         pid = int(data.get("pid") or 0)
         if not (port and token and pid):
             return None
-        os.kill(pid, 0)  # raises OSError if the daemon process is dead
+        # os.kill(pid, 0) never raises on Windows, so a stale discovery
+        # file would point every query at a dead daemon. is_alive() is
+        # portable.
+        from clawmetry.process_control import is_alive as _pid_alive
+
+        if not _pid_alive(pid):
+            return None
         return {"port": port, "token": token}
     except (FileNotFoundError, OSError, ValueError, json.JSONDecodeError):
         return None

--- a/clawmetry/process_control.py
+++ b/clawmetry/process_control.py
@@ -270,11 +270,46 @@ def _start_tokens_equivalent(want: str, have: str, tol: int = 3) -> bool:
 
 
 def is_alive(pid: int) -> bool:
-    """True iff ``pid`` is a live process we can address. Never raises."""
+    """True iff ``pid`` is a live process we can address. Never raises.
+
+    This is the ONLY sanctioned liveness probe. The POSIX ``os.kill(pid, 0)``
+    idiom is NOT a probe on Windows: signal 0 is ``CTRL_C_EVENT`` there, and
+    the call succeeds even for long-dead pids, so it reports everything as
+    alive (verified empirically on Windows 11 / CPython 3.12 — dead pid,
+    detached process, and group-leader all return without error). Windows
+    must ask the Win32 API instead.
+    """
     if pid is None or pid <= 0:
         return False
+    pid = int(pid)
+    if os.name == "nt":
+        try:
+            import ctypes
+
+            PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+            STILL_ACTIVE = 259
+            ERROR_ACCESS_DENIED = 5
+            kernel32 = ctypes.windll.kernel32
+            handle = kernel32.OpenProcess(
+                PROCESS_QUERY_LIMITED_INFORMATION, False, pid
+            )
+            if not handle:
+                # Access denied means the pid exists (another user/session);
+                # anything else (invalid parameter) means no such process.
+                return kernel32.GetLastError() == ERROR_ACCESS_DENIED
+            try:
+                exit_code = ctypes.c_ulong()
+                if not kernel32.GetExitCodeProcess(
+                    handle, ctypes.byref(exit_code)
+                ):
+                    return False
+                return exit_code.value == STILL_ACTIVE
+            finally:
+                kernel32.CloseHandle(handle)
+        except Exception:  # noqa: BLE001
+            return False
     try:
-        os.kill(int(pid), 0)
+        os.kill(pid, 0)
         return True
     except ProcessLookupError:
         return False

--- a/clawmetry/proxy.py
+++ b/clawmetry/proxy.py
@@ -2678,10 +2678,13 @@ def stop_proxy() -> bool:
 
     try:
         pid = int(PROXY_PID_FILE.read_text().strip())
-        os.kill(pid, 15)  # SIGTERM
+        # Windows raises plain OSError (winerror 87) for a dead pid, which
+        # ProcessLookupError does not catch — a stale pid file crashed
+        # stop_proxy there. OSError covers both subclasses on POSIX too.
+        os.kill(pid, 15)  # SIGTERM (TerminateProcess on Windows)
         PROXY_PID_FILE.unlink(missing_ok=True)
         return True
-    except (ValueError, ProcessLookupError, PermissionError):
+    except (ValueError, OSError):
         PROXY_PID_FILE.unlink(missing_ok=True)
         return False
 
@@ -2693,9 +2696,15 @@ def proxy_status() -> dict:
 
     try:
         pid = int(PROXY_PID_FILE.read_text().strip())
-        os.kill(pid, 0)  # Check if process exists
-        return {"running": True, "pid": pid}
-    except (ValueError, ProcessLookupError, PermissionError):
+        # Portable probe: os.kill(pid, 0) never raises on Windows, so a
+        # stale pid file reported the proxy as running forever.
+        from clawmetry.process_control import is_alive as _pid_alive
+
+        if _pid_alive(pid):
+            return {"running": True, "pid": pid}
+        PROXY_PID_FILE.unlink(missing_ok=True)
+        return {"running": False}
+    except (ValueError, OSError):
         PROXY_PID_FILE.unlink(missing_ok=True)
         return {"running": False}
 

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -821,7 +821,12 @@ def save_config(data: dict) -> None:
     tmp_fd, tmp_path = tempfile.mkstemp(dir=CONFIG_DIR, prefix=".config.tmp.")
     try:
         os.write(tmp_fd, content)
-        os.fchmod(tmp_fd, 0o600)
+        if hasattr(os, "fchmod"):
+            # POSIX only — Windows has no os.fchmod (crashed `clawmetry
+            # connect` at the final save). mkstemp already creates the file
+            # 0o600 on POSIX and owner-scoped via ACLs on Windows, so the
+            # explicit fchmod is belt-and-braces where it exists.
+            os.fchmod(tmp_fd, 0o600)
     finally:
         os.close(tmp_fd)
     os.replace(tmp_path, CONFIG_FILE)

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -70,14 +70,17 @@ def _acquire_pid_lock() -> bool:
                 except OSError:
                     return False
                 continue
-            try:
-                os.kill(existing_pid, 0)
+            # os.kill(pid, 0) is not a liveness probe on Windows (never
+            # raises for dead pids -> a stale lock file would block the
+            # daemon from ever starting again). is_alive() is portable.
+            from clawmetry.process_control import is_alive as _pid_alive
+
+            if _pid_alive(existing_pid):
                 return False
-            except ProcessLookupError:
-                try:
-                    pid_path.unlink()
-                except OSError:
-                    pass
+            try:
+                pid_path.unlink()
+            except OSError:
+                pass
                 continue
 
 
@@ -5464,8 +5467,12 @@ def _openclaw_gateway_running() -> bool:
             with open(pid_file) as fh:
                 pid = int((fh.read() or "0").strip())
             if pid > 0:
-                os.kill(pid, 0)  # raises if the process is gone
-                return True
+                # Portable probe: os.kill(pid, 0) never raises on Windows,
+                # so a stale gateway.pid would read as "running" forever.
+                from clawmetry.process_control import is_alive as _pid_alive
+
+                if _pid_alive(pid):
+                    return True
     except (OSError, ValueError):
         pass
     try:

--- a/dashboard.py
+++ b/dashboard.py
@@ -8838,8 +8838,12 @@ def _openclaw_gateway_running():
             with open(pid_path) as fh:
                 pid = int((fh.read() or "0").strip())
             if pid > 0:
-                os.kill(pid, 0)
-                return True
+                # Portable probe: os.kill(pid, 0) never raises on Windows,
+                # so a stale gateway.pid would read as "running" forever.
+                from clawmetry.process_control import is_alive as _pid_alive
+
+                if _pid_alive(pid):
+                    return True
     except (OSError, ValueError):
         pass
     try:
@@ -15502,7 +15506,25 @@ def _scan_security_posture():
 
     # Check 7: Workspace permissions (AGENTS.md, SOUL.md not world-readable)
     oc_home = os.path.expanduser("~/.openclaw")
-    if os.path.isdir(oc_home):
+    if os.name == "nt":
+        # POSIX mode bits are meaningless on Windows: st_mode reports 0o777
+        # for every normal directory, so the world-readable branch below
+        # would warn (and dock the score) on every Windows install with a
+        # chmod remediation that cannot be run. Access there is governed by
+        # NTFS ACLs, and the user-profile dir is owner-scoped by default.
+        if os.path.isdir(oc_home):
+            checks.append(
+                {
+                    "id": "workspace_perms",
+                    "label": "Workspace permissions",
+                    "status": "pass",
+                    "detail": "Access to the OpenClaw home directory is governed by Windows ACLs (user-profile scoped).",
+                    "remediation": None,
+                    "severity": "medium",
+                    "weight": 5,
+                }
+            )
+    elif os.path.isdir(oc_home):
         try:
             mode = oct(os.stat(oc_home).st_mode)[-3:]
             if mode[-1] != "0":  # world-readable
@@ -17778,11 +17800,11 @@ def _read_pid():
 
 
 def _is_pid_running(pid):
-    try:
-        os.kill(pid, 0)
-        return True
-    except (ProcessLookupError, PermissionError):
-        return False
+    # Delegates to the portable probe: os.kill(pid, 0) never raises on
+    # Windows, so this used to report stale dashboard pids as running.
+    from clawmetry.process_control import is_alive as _pid_alive
+
+    return _pid_alive(pid)
 
 
 def _is_macos():
@@ -18410,7 +18432,9 @@ def _kill_all_sync_procs():
     pid = _read_pid()
     if pid and _is_pid_running(pid):
         try:
-            os.kill(pid, signal.SIGKILL)
+            # signal.SIGKILL does not exist on Windows (AttributeError);
+            # SIGTERM maps to TerminateProcess there, same hard-kill intent.
+            os.kill(pid, getattr(signal, "SIGKILL", signal.SIGTERM))
         except OSError:
             pass
 

--- a/routes/local_query.py
+++ b/routes/local_query.py
@@ -126,10 +126,12 @@ def _read_discovery():
             return None
         # Cheap liveness check: PID alive? Avoids the ~5s socket
         # connect-refused wait when the daemon was killed but the file
-        # wasn't cleaned up (atexit doesn't fire on SIGKILL).
-        try:
-            _os.kill(pid, 0)
-        except OSError:
+        # wasn't cleaned up (atexit doesn't fire on SIGKILL). Uses the
+        # portable probe: os.kill(pid, 0) never raises on Windows, so it
+        # would treat every stale discovery file as a live daemon.
+        from clawmetry.process_control import is_alive as _pid_alive
+
+        if not _pid_alive(pid):
             return None
         return {"port": port, "token": token}
     except (FileNotFoundError, ValueError, OSError):

--- a/tests/test_pid_liveness_windows.py
+++ b/tests/test_pid_liveness_windows.py
@@ -1,0 +1,157 @@
+"""Regression tests for portable pid liveness (#windows-liveness).
+
+os.kill(pid, 0) is NOT a liveness probe on Windows: signal 0 is
+CTRL_C_EVENT there, and the call returns without error even for
+long-dead pids (verified empirically on Windows 11 / CPython 3.12 —
+dead pid, detached process, and group-leader all "succeed"). Every raw
+os.kill(pid, 0) probe therefore reported stale pid files as live
+processes on Windows:
+
+- the sync daemon refused to start after a crash (stale sync.pid read
+  as "another instance is running")
+- gateway/dashboard/proxy status stuck on "running" after the process
+  died
+- the MCP server and /__local_query__ kept dispatching to a dead daemon
+
+The portable probe is clawmetry.process_control.is_alive() (Win32
+OpenProcess + GetExitCodeProcess on Windows, the POSIX idiom
+elsewhere). These tests pin its semantics, prove the stale-lock
+recovery, and guard against raw-probe reintroduction.
+"""
+
+import os
+import re
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+from clawmetry.process_control import is_alive
+
+
+def _spawn_sleeper():
+    return subprocess.Popen([sys.executable, "-c", "import time; time.sleep(30)"])
+
+
+def _spawn_dead():
+    child = subprocess.Popen([sys.executable, "-c", "pass"])
+    child.wait()
+    return child
+
+
+def test_is_alive_true_for_live_child():
+    child = _spawn_sleeper()
+    try:
+        assert is_alive(child.pid) is True
+        # The probe must OBSERVE, never signal: the child stays alive.
+        time.sleep(0.2)
+        assert child.poll() is None
+    finally:
+        child.kill()
+        child.wait()
+
+
+def test_is_alive_false_for_exited_child():
+    child = _spawn_dead()
+    deadline = time.time() + 5
+    while is_alive(child.pid) and time.time() < deadline:
+        time.sleep(0.1)
+    # Red on the old code (Windows): os.kill(pid, 0) never raises, so the
+    # dead child was reported alive forever.
+    assert is_alive(child.pid) is False
+
+
+def test_is_alive_rejects_garbage():
+    assert is_alive(None) is False
+    assert is_alive(0) is False
+    assert is_alive(-1) is False
+
+
+def test_acquire_pid_lock_reclaims_stale_lock(monkeypatch, tmp_path):
+    """A crashed daemon leaves sync.pid behind; the next start must reclaim it.
+
+    Red on the old code (Windows): the stale pid probed as alive, so
+    _acquire_pid_lock returned False and the daemon could never start
+    again until the file was deleted by hand.
+    """
+    import clawmetry.sync as sync
+
+    dead = _spawn_dead()
+    pid_file = tmp_path / "sync.pid"
+    pid_file.write_text(str(dead.pid))
+    monkeypatch.setattr(sync, "_pid_file", lambda: pid_file)
+
+    assert sync._acquire_pid_lock() is True
+    assert pid_file.read_text().strip() == str(os.getpid())
+    pid_file.unlink()
+
+
+def test_acquire_pid_lock_respects_live_lock(monkeypatch, tmp_path):
+    """A genuinely running instance must still win the lock."""
+    import clawmetry.sync as sync
+
+    live = _spawn_sleeper()
+    try:
+        pid_file = tmp_path / "sync.pid"
+        pid_file.write_text(str(live.pid))
+        monkeypatch.setattr(sync, "_pid_file", lambda: pid_file)
+
+        assert sync._acquire_pid_lock() is False
+        assert pid_file.read_text().strip() == str(live.pid)
+    finally:
+        live.kill()
+        live.wait()
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows ACL branch of check 7")
+def test_security_posture_no_false_world_readable_on_windows(monkeypatch, tmp_path):
+    """POSIX mode bits read as 0o777 for every Windows dir; check 7 must not
+    emit its false 'world-readable' warn + un-runnable chmod remediation."""
+    import dashboard
+
+    (tmp_path / ".openclaw").mkdir()
+    (tmp_path / ".openclaw" / "openclaw.json").write_text("{}")
+    real_expanduser = os.path.expanduser
+    monkeypatch.setattr(
+        os.path,
+        "expanduser",
+        lambda p: p.replace("~", str(tmp_path), 1) if p.startswith("~") else real_expanduser(p),
+    )
+
+    result = dashboard._scan_security_posture()
+    checks = result if isinstance(result, list) else result.get("checks", [])
+    workspace = [c for c in checks if c.get("id") == "workspace_perms"]
+    assert workspace, "workspace_perms check missing from posture scan"
+    assert workspace[0]["status"] == "pass"
+    assert "chmod" not in (workspace[0].get("remediation") or "")
+
+
+# ── Class guard: no raw os.kill(pid, 0) probes may come back ──────────────
+
+_REPO = Path(__file__).resolve().parents[1]
+_RAW_PROBE = re.compile(r"\b_?os\.kill\(\s*[^,()]+,\s*0\s*\)")
+
+
+def test_no_raw_pid0_probes_outside_process_control():
+    """Auto-discovering guard: the portable probe lives in process_control;
+    any raw os.kill(pid, 0) elsewhere silently breaks Windows again."""
+    offenders = []
+    targets = [_REPO / "dashboard.py"]
+    targets += sorted((_REPO / "clawmetry").rglob("*.py"))
+    targets += sorted((_REPO / "routes").rglob("*.py"))
+    for path in targets:
+        if path.name == "process_control.py":
+            continue
+        for lineno, line in enumerate(
+            path.read_text(encoding="utf-8", errors="replace").splitlines(), 1
+        ):
+            code = line.split("#", 1)[0]  # the fixes reference the idiom in comments
+            if _RAW_PROBE.search(code):
+                offenders.append(f"{path.relative_to(_REPO)}:{lineno}")
+    assert offenders == [], (
+        "raw os.kill(pid, 0) probes found — use "
+        "clawmetry.process_control.is_alive() instead (os.kill(pid, 0) "
+        f"never raises on Windows): {offenders}"
+    )

--- a/tests/test_save_config_windows.py
+++ b/tests/test_save_config_windows.py
@@ -1,0 +1,61 @@
+"""Regression tests for save_config on Windows (#windows-connect-crash).
+
+`clawmetry connect` crashed at the very last step on Windows:
+
+    File "clawmetry/sync.py", line 824, in save_config
+        os.fchmod(tmp_fd, 0o600)
+    AttributeError: module 'os' has no attribute 'fchmod'
+
+os.fchmod is POSIX-only. The user had completed the whole flow (OTP, key
+validation, encryption key) and lost it all at the final write. save_config
+must succeed on platforms without os.fchmod while keeping the 0o600
+tighten-up where the API exists.
+"""
+
+import json
+import os
+import stat
+import sys
+
+import pytest
+
+import clawmetry.sync as sync
+
+
+@pytest.fixture
+def config_paths(monkeypatch, tmp_path):
+    """Point CONFIG_DIR/CONFIG_FILE at a sandbox so tests never touch ~/.clawmetry."""
+    monkeypatch.setattr(sync, "CONFIG_DIR", tmp_path)
+    monkeypatch.setattr(sync, "CONFIG_FILE", tmp_path / "config.json")
+    return tmp_path / "config.json"
+
+
+def test_save_config_without_fchmod(monkeypatch, config_paths):
+    """Windows has no os.fchmod — save_config must still write the file.
+
+    Simulates Windows on any platform by removing the attribute; on a real
+    Windows runner delattr is a no-op and this exercises the genuine path.
+    """
+    monkeypatch.delattr(os, "fchmod", raising=False)
+    sync.save_config({"api_key": "cm_test", "node_id": "win-node"})
+    assert json.loads(config_paths.read_text()) == {
+        "api_key": "cm_test",
+        "node_id": "win-node",
+    }
+
+
+def test_save_config_atomic_no_temp_left_behind(monkeypatch, config_paths):
+    """The temp file must be replaced, not orphaned, on the no-fchmod path."""
+    monkeypatch.delattr(os, "fchmod", raising=False)
+    sync.save_config({"probe": True})
+    leftovers = [p for p in config_paths.parent.iterdir() if p.name != "config.json"]
+    assert leftovers == []
+
+
+@pytest.mark.skipif(
+    not hasattr(os, "fchmod"), reason="POSIX-only mode check (no fchmod here)"
+)
+def test_save_config_mode_0600_on_posix(config_paths):
+    """Where fchmod exists the config must stay owner-only (0o600)."""
+    sync.save_config({"api_key": "cm_test"})
+    assert stat.S_IMODE(config_paths.stat().st_mode) == 0o600


### PR DESCRIPTION
## Why

Found live on a real Windows 11 machine while onboarding a node: `clawmetry connect` completed the entire flow (OTP, key validation, encryption key) and then crashed at the final step:

```
File "clawmetry/sync.py", line 824, in save_config
    os.fchmod(tmp_fd, 0o600)
AttributeError: module 'os' has no attribute 'fchmod'
```

Per FLYWHEEL section on auditing the whole class (not the one instance), a 5-family sweep of POSIX-only APIs across `clawmetry/`, `routes/`, and `dashboard.py` followed, with each candidate adversarially verified against its real call path, plus empirical verification on Windows 11 / CPython 3.12.

## What

**1. `save_config` crash (`os.fchmod` is POSIX-only).** Guarded behind `hasattr`; `mkstemp` already creates the file `0o600` on POSIX and owner-scoped via ACLs on Windows.

**2. Every pid liveness probe was a broken oracle on Windows.** `os.kill(pid, 0)` is not a probe there: signal 0 is `CTRL_C_EVENT`, and the call returns without error even for long-dead pids (empirically verified: dead pid, detached process, and group-leader all succeed; in other console contexts it can instead raise for live pids). Consequences on Windows:
- a crashed sync daemon could never start again (stale `sync.pid` read as another live instance)
- gateway/dashboard/proxy status stuck on running after the process died
- MCP server and `/__local_query__` kept dispatching to a dead daemon
- `stop_proxy` crashed on a stale pid file (Windows raises plain `OSError`, not `ProcessLookupError`)
- `signal.SIGKILL` does not exist on Windows (`AttributeError` in the stop path)

Fix: `process_control.is_alive()` gains a real Windows implementation (`OpenProcess` + `GetExitCodeProcess` via ctypes; access-denied counts as alive), and all 8 probe sites route through it.

**3. Security posture check 7 false positive (adversarially verified, reachable via `/api/security/posture` and the 5-minute daemon snapshot loop).** Every Windows directory stats as `0o777`, so the world-readable warn fired on every Windows install with a `chmod 700` remediation that cannot be run, permanently deflating the security score. Now reports the honest ACL story on Windows.

## Verification (real Windows 11 machine, not simulated)

- New regression tests: `tests/test_save_config_windows.py`, `tests/test_pid_liveness_windows.py` (liveness semantics, stale-lock reclaim, live-lock respect, posture no-false-warn, and an auto-discovering guard that fails if any raw `os.kill(pid, 0)` probe returns)
- Revert-to-red proof: stashing the fixes reproduces the exact reported traceback and 5 liveness failures; restoring goes green
- The fix turns 4 pre-existing Windows test failures green, including upstream `test_process_control.py::test_is_alive_and_dead` and `test_pid_reuse_guard_refuses_dead_pid`
- Related suite slice (process_control/proxy/mcp/local_query/gateway/posture): 325 passed, zero new failures vs clean main
- Also filed #3850 for the systemic Windows test-sandbox gap discovered during this work (350 `HOME` monkeypatch sites that Windows ignores)

🤖 Generated with [Claude Code](https://claude.com/claude-code)