### PR TITLE
fix: patch ntpath.expanduser in conftest to honor HOME on Windows

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,23 @@ import pytest
 import requests
 
 
+# On Windows, ntpath.expanduser resolves "~" from USERPROFILE (not HOME), so
+# monkeypatch.setenv("HOME", tmp_path) silently fails to sandbox the config
+# dir.  This shim restores POSIX parity for the test suite only.
+if sys.platform == "win32":
+    import ntpath as _ntpath
+
+    _nt_expanduser_orig = _ntpath.expanduser
+
+    def _nt_expanduser_home_aware(path):
+        if path[:1] == "~" and os.environ.get("HOME"):
+            return os.environ["HOME"] + path[1:]
+        return _nt_expanduser_orig(path)
+
+    _ntpath.expanduser = _nt_expanduser_home_aware
+    os.path.expanduser = _nt_expanduser_home_aware
+
+
 # Playwright's sync API can only be entered once per process. Share a single
 # browser across all E2E test modules via this session-scoped fixture; each
 # module owns its own contexts off the shared browser.

--- a/tests/test_home_sandbox_canary.py
+++ b/tests/test_home_sandbox_canary.py
@@ -1,0 +1,20 @@
+"""
+Cross-platform canary: monkeypatch.setenv("HOME", ...) must redirect
+os.path.expanduser("~") on every OS under pytest.
+
+On POSIX this passes without any shim.  On Windows the conftest shim
+patches ntpath.expanduser so that HOME takes precedence over USERPROFILE.
+If this test ever fails on Windows it means the conftest shim regressed.
+"""
+import os
+
+
+def test_home_env_redirects_expanduser(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    assert os.path.expanduser("~") == str(tmp_path)
+
+
+def test_home_env_with_subpath(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    expected = str(tmp_path / ".clawmetry")
+    assert os.path.expanduser("~/.clawmetry") == expected


### PR DESCRIPTION
Closes #3850

## Summary

- **`tests/conftest.py`** — adds a 12-line module-level shim (active only when `sys.platform == "win32"`) that patches `ntpath.expanduser` and `os.path.expanduser` to check `HOME` before falling back to `USERPROFILE`/`HOMEDRIVE`+`HOMEPATH`. Installed at pytest startup, so it covers all 350 existing `monkeypatch.setenv("HOME", ...)` call sites without touching them.
- **`tests/test_home_sandbox_canary.py`** (new) — two cross-platform tests verifying that `os.path.expanduser("~")` and `os.path.expanduser("~/.clawmetry")` follow a monkeypatched `HOME` on every OS. Pass on POSIX today; will pass on Windows once the shim is active.

## Test plan

- `pytest tests/test_home_sandbox_canary.py` — passes on Linux/macOS now; will pass on Windows with the shim.
- The 3 previously failing Windows tests (`test_reconnect_with_saved_key_skips_otp`, `test_send_now_pro_paywall_for_free_tier`, `test_already_connected_empty_enter_keeps_current`) should go green on the Windows CI runner.
- No runtime code changes; shim is test-only.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SJj58kvW33vnA5JSZuYpi1)_