### PR TITLE
[RELEASE] fix(pricing): route Ollama colon-tag models to local provider (closes #3857)

### DIFF
--- a/clawmetry/providers_pricing.py
+++ b/clawmetry/providers_pricing.py
@@ -256,6 +256,11 @@ def provider_for_model(model: str) -> str:
     # treating it as free/local.
     if "mistral" in m or "mixtral" in m or "codestral" in m:
         return "mistral"
+    # Ollama `name:tag` format (e.g. qwen3:8b, deepseek-r1:latest). Hosted
+    # API ids never use colon-tag without a provider prefix; the colon with no
+    # slash is a strong signal that the model is running locally on Ollama.
+    if ":" in m and "/" not in m:
+        return "local"
     return ""
 
 

--- a/tests/test_pricing_accuracy.py
+++ b/tests/test_pricing_accuracy.py
@@ -41,3 +41,14 @@ def test_genuine_local_still_free():
     assert pp.provider_for_model("ollama/llama3.1") == "local"
     assert pp.provider_for_model("llama3.1") == "local"
     assert _rates("local", "llama3.1") == (0.0, 0.0)
+
+
+def test_ollama_colon_tag_is_local():
+    # Ollama name:tag format must resolve to "local" (zero per-token cost).
+    # Hosted APIs never use colon-tag; bare name:tag is an Ollama convention.
+    for model in ("qwen3:8b", "deepseek-r1:latest", "deepseek-coder:6.7b"):
+        assert pp.provider_for_model(model) == "local", model
+        assert pp.estimate_event_cost_usd(model, input_tokens=1000, output_tokens=500) == 0.0, model
+    # Bare hosted names (no colon) must NOT be zeroed — they use paid APIs.
+    for model in ("qwen-max", "deepseek-chat"):
+        assert pp.provider_for_model(model) != "local", model


### PR DESCRIPTION
## Summary

- `provider_for_model` had no guard for Ollama's `name:tag` format (e.g. `qwen3:8b`, `deepseek-r1:latest`). These models fell through all family-name checks and landed on the unknown-provider default of $1/$3 per 1M tokens instead of $0.
- Hosted APIs never use colon-tag format without a provider prefix, so `":" in model and "/" not in model` is a reliable Ollama-local signal.
- Fix is placed **after** the existing family-name checks so conservative hosted routing for bare names (`qwen-max`, `deepseek-chat`, `mistral-large-latest`) is unchanged.

**Reproducer (before fix):**
```python
from clawmetry.providers_pricing import estimate_event_cost_usd
estimate_event_cost_usd("qwen3:8b", input_tokens=1000, output_tokens=500)
# returned 0.0025 — should be 0.0 for a local Ollama model
```

## Test plan

- [x] `provider_for_model("qwen3:8b")` → `"local"`, cost → `0.0`
- [x] `provider_for_model("deepseek-r1:latest")` → `"local"`, cost → `0.0`
- [x] `provider_for_model("deepseek-coder:6.7b")` → `"local"`, cost → `0.0`
- [x] `provider_for_model("qwen-max")` → not `"local"`, cost → non-zero (hosted API, no colon)
- [x] `provider_for_model("deepseek-chat")` → not `"local"`, cost → non-zero (hosted API, no colon)
- [x] Existing `test_hosted_qwen_deepseek_not_zero` still passes (bare names unaffected)
- [x] Existing `test_genuine_local_still_free` still passes (`ollama/llama3.1`, `llama3.1`)
- [x] Existing `test_mistral_routes_to_provider_not_local` still passes
- [x] New `test_ollama_colon_tag_is_local` added to `tests/test_pricing_accuracy.py`
- [x] `OPENCLAW_BIN_AVAILABLE` not set in this sandbox — human verification against real Ollama traffic recommended before merge

---

### Release plan

- [x] PR title starts with `[RELEASE]` so `release-on-merge.yml` auto-bumps + publishes
- [ ] After auto-publish: `pip install --upgrade --no-cache-dir clawmetry` then verify `qwen3:8b` sessions show $0.00 cost in the Tokens tab

---
_Generated by [Claude Code](https://claude.ai/code/session_015iyPwoWRhJaDv6CspY1Egy)_