### PR TITLE
fix: Ollama colon-tag models (qwen3:8b) now priced at $0

### DIFF
--- a/clawmetry/providers_pricing.py
+++ b/clawmetry/providers_pricing.py
@@ -243,6 +243,12 @@ def provider_for_model(model: str) -> str:
         h in m for h in _LOCAL_MODEL_HINTS
     ):
         return "local"
+    # Ollama colon-tag format (e.g. "qwen3:8b", "mistral:7b-instruct") has no
+    # slash and always contains a colon — a pattern no hosted API uses. Treat it
+    # as local so the per-token cost is honestly $0 rather than the conservative
+    # unknown-provider default.
+    if ":" in m and "/" not in m:
+        return "local"
     if "gpt" in m or "codex" in m or m.startswith(("o1", "o3", "o4")):
         return "openai"
     if "claude" in m:


### PR DESCRIPTION
Closes #3857

## What

`provider_for_model("qwen3:8b")` was returning `""` — the `name:tag` format didn't match any existing check, so `_get_rates` fell through to the conservative unknown-provider default `(1.0, 3.0)` per 1M tokens. A 1000-in / 500-out call incorrectly cost $0.0025 instead of $0.00.

## Fix

Added a single colon-tag guard in `provider_for_model` (`clawmetry/providers_pricing.py`), placed after the `_LOCAL_PROVIDERS` prefix check and before the broad content heuristics:

```python
# Ollama colon-tag format (e.g. "qwen3:8b", "mistral:7b-instruct") has no
# slash and always contains a colon — a pattern no hosted API uses.
if ":" in m and "/" not in m:
    return "local"
```

Hosted APIs never embed a colon in a model id; `name:tag` is an Ollama convention. Models with a slash are unaffected — provider-prefix and local-prefix checks run first.

## Test plan

- `provider_for_model("qwen3:8b")` → `"local"` ✓
- `estimate_event_cost_usd("qwen3:8b", 1000, 500)` → `0.0` ✓
- `provider_for_model("qwen-max")` → `""` (conservative, not free) ✓
- `provider_for_model("ollama/qwen3:8b")` → `"local"` (existing path unchanged) ✓
- `provider_for_model("openai/gpt-4o")` → `"openai"` (slash prefix wins) ✓
- `estimate_event_cost_usd("claude-opus-4-1", 1_000_000, 1_000_000)` → `> 0` ✓

---
_Generated by [Claude Code](https://claude.ai/code/session_01StTGS78c4cCv5JT8uPy91K)_