### PR TITLE
fix(license): current_license_info returns uniform shape on invalid signature

### DIFF
--- a/clawmetry/license.py
+++ b/clawmetry/license.py
@@ -884,7 +884,19 @@ def inspect_key(key: str) -> dict | None:
 
 def current_license_info() -> dict | None:
     """Human-readable summary of the installed license, or None if there is no
-    valid one. Never raises."""
+    valid one. Never raises.
+
+    Returns ``None`` only when no license file is on disk. When a file exists,
+    every branch — active / expired / invalid-signature — returns the SAME
+    field set so a UI can render all three uniformly without special-casing
+    which keys are present. On the invalid-signature branch the payload cannot
+    be trusted (an attacker could stuff any tier/nodes into an unsigned body),
+    so ``tier``/``nodes``/``sub``/``exp``/``days_left`` collapse to ``None``;
+    the trust-anchor (``pubkey_fingerprint_sha256``) and on-disk permission
+    fields (``permissions_safe``, ``file_mode``) DO get populated in every
+    file-exists branch — those are exactly the operator-debug fields most
+    useful when a license file has been corrupted or tampered with.
+    """
     import time as _t
 
     try:
@@ -892,15 +904,8 @@ def current_license_info() -> dict | None:
             return None
         with open(LICENSE_PATH, "r", encoding="utf-8") as fh:
             payload = verify_token(fh.read().strip())
-        if payload is None:
-            return {"valid": False, "status": "invalid"}
-        exp = payload.get("exp")
-        days_left = None
-        expired = False
-        if isinstance(exp, (int, float)):
-            days_left = int((exp - _t.time()) // 86400)
-            expired = _t.time() > exp
-        # On POSIX, surface whether the on-disk key file is locked down.
+        # Trust-anchor + on-disk state are independent of the token payload,
+        # so we resolve them up-front and reuse across every branch below.
         # ``permissions_safe`` is True on Windows (mode bits don't apply) and
         # True when no group/world bits are set on the file. The UI can use
         # this to surface a "tighten file permissions" affordance without
@@ -910,6 +915,37 @@ def current_license_info() -> dict | None:
             mode = os.stat(LICENSE_PATH).st_mode & 0o777 if os.name == "posix" else None
         except Exception:
             mode = None
+        # Trust-anchor identity: a Pro/Enterprise license is only as
+        # trustworthy as the embedded public key that signed it, so we
+        # surface its fingerprint here for operator audits.
+        pubkey_fp = pubkey_fingerprint()
+        file_mode = f"{mode:04o}" if mode is not None else None
+
+        if payload is None:
+            # File exists but signature is bogus (bit-flip, tamper, key rotated
+            # server-side, wrong-environment key…). Never surface tier/nodes
+            # from an unverified body — they'd let a forger claim any tier — but
+            # keep the shape uniform so a UI can render this row like the
+            # others and lean on ``permissions_safe`` / ``file_mode`` to
+            # explain WHY (e.g. loose perms may indicate corruption).
+            return {
+                "valid": False,
+                "status": "invalid",
+                "tier": None,
+                "nodes": None,
+                "sub": None,
+                "exp": None,
+                "days_left": None,
+                "pubkey_fingerprint_sha256": pubkey_fp,
+                "permissions_safe": perms_safe,
+                "file_mode": file_mode,
+            }
+        exp = payload.get("exp")
+        days_left = None
+        expired = False
+        if isinstance(exp, (int, float)):
+            days_left = int((exp - _t.time()) // 86400)
+            expired = _t.time() > exp
         return {
             "valid": not expired,
             "status": "expired" if expired else "active",
@@ -918,12 +954,9 @@ def current_license_info() -> dict | None:
             "sub": payload.get("sub", ""),
             "exp": exp,
             "days_left": days_left,
-            # Trust-anchor identity: a Pro/Enterprise license is only as
-            # trustworthy as the embedded public key that signed it, so we
-            # surface its fingerprint here for operator audits.
-            "pubkey_fingerprint_sha256": pubkey_fingerprint(),
+            "pubkey_fingerprint_sha256": pubkey_fp,
             "permissions_safe": perms_safe,
-            "file_mode": (f"{mode:04o}" if mode is not None else None),
+            "file_mode": file_mode,
         }
     except Exception as exc:
         logger.warning("license: info read failed: %s", exc)

--- a/tests/test_license.py
+++ b/tests/test_license.py
@@ -390,6 +390,102 @@ def test_current_license_info(lic):
     assert info["days_left"] > 300
 
 
+# ── current_license_info: uniform shape across active/expired/invalid ─────────
+#
+# When a license file exists, EVERY branch must return the same field set so
+# a UI can render the row without special-casing which keys are present.
+
+_EXPECTED_FILE_EXISTS_KEYS = frozenset({
+    "valid", "status", "tier", "nodes", "sub", "exp", "days_left",
+    "pubkey_fingerprint_sha256", "permissions_safe", "file_mode",
+})
+
+
+def test_current_license_info_missing_file_returns_none(lic):
+    import os
+
+    assert not os.path.isfile(lic.L.LICENSE_PATH)
+    assert lic.L.current_license_info() is None
+
+
+def test_current_license_info_invalid_signature_matches_full_shape(lic):
+    """A file with a bogus signature returns the same field set as an active
+    or expired license, so a UI never has to branch on which keys exist."""
+    import os
+
+    other_priv, _ = _keypair()
+    forged = lic.L._encode_token(_payload(), other_priv)
+    os.makedirs(os.path.dirname(lic.L.LICENSE_PATH), exist_ok=True)
+    with open(lic.L.LICENSE_PATH, "w", encoding="utf-8") as fh:
+        fh.write(forged + "\n")
+
+    info = lic.L.current_license_info()
+    assert info is not None
+    assert set(info.keys()) == _EXPECTED_FILE_EXISTS_KEYS
+    assert info["valid"] is False
+    assert info["status"] == "invalid"
+    # Untrusted payload fields must NOT leak — an attacker could put any tier
+    # into an unsigned body, so treat them as unknown.
+    assert info["tier"] is None
+    assert info["nodes"] is None
+    assert info["sub"] is None
+    assert info["exp"] is None
+    assert info["days_left"] is None
+    # Trust anchor + on-disk state are payload-independent and must be filled.
+    assert isinstance(info["pubkey_fingerprint_sha256"], str)
+    assert len(info["pubkey_fingerprint_sha256"]) == 64
+    assert info["permissions_safe"] in (True, False)
+
+
+def test_current_license_info_expired_matches_full_shape(lic):
+    """activate() refuses expired keys, so simulate the on-disk state
+    directly — this pins the 'expired-but-signature-verifies' branch of
+    current_license_info(), which is the state a live install reaches when
+    a valid key ages past its exp."""
+    import os
+
+    tok = lic.L._encode_token(_payload("pro", nodes=4, exp_delta=-7200), lic.priv)
+    os.makedirs(os.path.dirname(lic.L.LICENSE_PATH), exist_ok=True)
+    with open(lic.L.LICENSE_PATH, "w", encoding="utf-8") as fh:
+        fh.write(tok + "\n")
+
+    info = lic.L.current_license_info()
+    assert info is not None
+    assert set(info.keys()) == _EXPECTED_FILE_EXISTS_KEYS
+    assert info["valid"] is False
+    assert info["status"] == "expired"
+    assert info["tier"] == "pro"
+    assert info["nodes"] == 4
+    assert info["days_left"] is not None and info["days_left"] <= 0
+
+
+def test_current_license_info_active_matches_full_shape(lic):
+    tok = lic.L._encode_token(_payload("pro", nodes=3), lic.priv)
+    lic.L.activate(tok)
+    info = lic.L.current_license_info()
+    assert info is not None
+    assert set(info.keys()) == _EXPECTED_FILE_EXISTS_KEYS
+    assert info["valid"] is True
+    assert info["status"] == "active"
+
+
+def test_current_license_info_garbage_file_returns_uniform_invalid_shape(lic):
+    """Not even a well-formed CLAW1 token — just random bytes — still gets the
+    full shape back so a UI's 'invalid license' row renders identically."""
+    import os
+
+    os.makedirs(os.path.dirname(lic.L.LICENSE_PATH), exist_ok=True)
+    with open(lic.L.LICENSE_PATH, "w", encoding="utf-8") as fh:
+        fh.write("not-even-a-token\n")
+
+    info = lic.L.current_license_info()
+    assert info is not None
+    assert set(info.keys()) == _EXPECTED_FILE_EXISTS_KEYS
+    assert info["valid"] is False
+    assert info["status"] == "invalid"
+    assert info["tier"] is None
+
+
 # ── integration with entitlements ──────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

- `current_license_info()` used to return a bare `{"valid": False, "status": "invalid"}` when the license file existed but failed signature verification, missing `pubkey_fingerprint_sha256`, `permissions_safe`, and `file_mode` — exactly the operator-debug fields most useful when diagnosing a corrupted/tampered file. Every "file exists" branch (active / expired / invalid) now returns the same field set so a UI can render all three uniformly.
- On the invalid-signature branch, `tier`/`nodes`/`sub`/`exp`/`days_left` collapse to `None` so an attacker's unsigned body can never leak a false tier into the UI. Trust-anchor + on-disk permission fields are always populated (they're payload-independent).
- `None` return still means "no file on disk" — consumer contract unchanged. `/api/license/status` jsonifies the enriched dict (additive), and `_cmd_license`'s status branch only reads `status` from the invalid dict (no rendering breakage).
- Adds tests pinning the uniform shape across missing / invalid-signature / expired / active / garbage-file paths so a future edit can't silently drift the contract again.

## Test plan

- [x] `python3 -m pytest tests/test_license.py tests/test_license_permissions.py tests/test_license_api.py` — 71 passed
- [x] `python3 -m pytest tests/test_cli_license_json.py tests/test_cli_activate_json.py tests/test_entitlement_api.py tests/test_entitlement_api_fallback_shape.py tests/test_license_pubkey.py tests/test_license_audit.py tests/test_license_pro_upgrade.py` — 86 passed, 1 skipped
- [x] `python3 -m py_compile clawmetry/license.py tests/test_license.py`

## Local operator verification checklist

Since this fire cannot touch the running daemon, live cloud snapshot, or a browser, the local operator should:

- [ ] Copy the changed file into the site-packages the daemon uses:
      `cp clawmetry/license.py ~/.clawmetry/lib/python*/site-packages/clawmetry/`
- [ ] Clear the bytecode cache: `find ~/.clawmetry/lib -name __pycache__ -exec rm -rf {} +`
- [ ] Kick the daemon: `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
- [ ] Corrupt the local license file (append a byte) then:
      `curl -s http://localhost:8900/api/license/status | jq '.status, .valid, .permissions_safe, .file_mode, .pubkey_fingerprint_sha256'`
      → expect `"invalid"`, `false`, and the trust-anchor/perms fields populated (previously all three were missing).
- [ ] Restore the license file. Repeat the curl — active shape unchanged.
- [ ] Decrypt the live snapshot and browser-check that the license-status row in the dashboard renders the invalid case with the trust-anchor + perms affordances now visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DYQKYafVogEXVvNgDXGEYq)_