### PR TITLE
feat(cli): clawmetry nodes -- capacity-axis sibling of clawmetry channels

### DIFF
--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -3646,6 +3646,14 @@ def _entitlement_why_payload(kind: str, key: str) -> dict:
     :meth:`Entitlement.allows_channel_count`, mirroring
     :func:`_lock_row`'s "channels" branch so CLI and HTTP stay in lockstep.
     A non-integer ``key`` collapses to the never-crash grace-shape row.
+
+    ``kind="nodes"`` is the capacity-axis sibling of ``"channels"`` for the
+    registered-node count (fleet size) -- ``key`` is a node count, not an
+    id, so a non-integer ``key`` follows the same grace-shape fallback as
+    the ``"channels"`` branch. Backed by :func:`min_tier_for_node_count`
+    / :meth:`Entitlement.allows_node_count`; mirrors
+    ``GET /api/entitlement/lock-reason?nodes=<int>`` byte-for-byte so
+    ``clawmetry nodes --why N`` and the HTTP surface cannot drift.
     """
     key = (key or "").strip().lower()
     try:
@@ -3683,6 +3691,30 @@ def _entitlement_why_payload(kind: str, key: str) -> dict:
             reason = ent.lock_reason(str(n), kind="channels")
             # Canonicalise the key in the response so a caller passing "05"
             # or "5" sees the same string back.
+            key = str(n)
+        elif kind == "nodes":
+            # Capacity axis: ``key`` is a registered-node count. Same
+            # never-crash posture as the ``channels`` branch above -- a
+            # typo (e.g. ``--why abc``) collapses to the grace-shape row.
+            try:
+                n = int(key)
+            except (TypeError, ValueError):
+                return {
+                    "key": key,
+                    "kind": kind,
+                    "reason": None,
+                    "locked": False,
+                    "allowed": True,
+                    "required_tier": None,
+                    "required_tier_label": None,
+                    "required_tier_rank": -1,
+                    "current_tier": cur_tier,
+                    "current_tier_rank": cur_rank,
+                    "upgrade_required": False,
+                }
+            allowed = ent.allows_node_count(n)
+            required = _ent.min_tier_for_node_count(n)
+            reason = ent.lock_reason(str(n), kind="nodes")
             key = str(n)
         else:  # feature
             allowed = ent.allows_feature(key)
@@ -3727,16 +3759,18 @@ def _print_why_block(payload: dict) -> None:
     (aligned two-column block, single upgrade CTA when a paid tier unlocks
     the item) so shell operators recognise the layout across subcommands.
 
-    For ``kind="channels"`` the header phrases the capacity question
-    naturally ("why do I need <tier> for N concurrent channels?") since
-    the key is a count, not an id -- otherwise the shared "why is X
-    locked?" phrasing wins.
+    For ``kind="channels"`` / ``kind="nodes"`` the header phrases the
+    capacity question naturally ("what tier unlocks N concurrent channels?"
+    / "what tier unlocks N nodes?") since the key is a count, not an id --
+    otherwise the shared "why is X locked?" phrasing wins.
     """
     key = payload.get("key") or "(unknown)"
     kind = payload.get("kind") or "?"
     locked = bool(payload.get("locked"))
     if kind == "channels":
         print(f'ClawMetry: what tier unlocks {key} concurrent channels?')
+    elif kind == "nodes":
+        print(f'ClawMetry: what tier unlocks {key} nodes?')
     else:
         print(f'ClawMetry: why is "{key}" locked?')
     print("─" * 40)
@@ -4120,6 +4154,92 @@ def _cmd_channels(args) -> None:
         # Surface the row identically to a free/available runtime row.
         status = "✅ available"
         print(f"  {cid:<16} {label:<20} {status}")
+
+
+def _cmd_nodes(args) -> None:
+    """clawmetry nodes — show the resolved node-count cap for this install.
+
+    Capacity-axis sibling of :func:`_cmd_channels` for the ``nodes`` axis.
+    There is no enumerable adapter list here -- ``nodes`` is purely a
+    per-tier cap (Free / Cloud Free = 1; every paid tier is license-bound
+    to the ``nodes`` field on the payload; Enterprise is unlimited) --
+    so the default output is the header block alone. ``--why N`` answers
+    "what tier admits N registered nodes?" using the same lock-reason
+    payload ``clawmetry channels --why N`` emits so a wrapper script written
+    against either surface works interchangeably.
+
+    Reads :attr:`clawmetry.entitlements.Entitlement.node_limit` -- the same
+    field the fleet-registration path checks -- so the CLI and the runtime
+    cannot drift on the effective cap.
+
+    Never raises. A poisoned resolver surfaces the error inline (a warning
+    row in the human table, or an ``error`` key on the JSON payload with
+    ``node_limit=null``) so a wrapper script always sees a parseable
+    response. Matches the never-crash contract documented on
+    :func:`get_entitlement`.
+
+    Output:
+      default -- header block (tier / enforcement / node cap)
+      --json  -- ``{tier, grace, enforced, node_limit, error?: str}``
+      --why N -- lock-reason payload for N registered nodes (same shape
+                 as ``GET /api/entitlement/lock-reason?nodes=N``); pair
+                 with ``--json`` for scriptable output.
+    """
+    import json as _json
+
+    from clawmetry import entitlements as _ent
+
+    why = (getattr(args, "why", None) or "").strip().lower()
+    if why:
+        payload = _entitlement_why_payload("nodes", why)
+        if getattr(args, "as_json", False):
+            print(_json.dumps(payload, indent=2, sort_keys=True))
+        else:
+            _print_why_block(payload)
+        return
+
+    resolve_error: str | None = None
+    try:
+        ent = _ent.get_entitlement()
+        tier = ent.tier
+        grace = bool(ent.grace)
+        enforced = _ent.is_enforced()
+        # ``node_limit`` is an int on the dataclass; <=0 is the unlimited
+        # sentinel licenses use for Enterprise, so surface it as ``None``
+        # (matches the ``channel_limit`` JSON convention).
+        raw_limit = getattr(ent, "node_limit", None)
+        if isinstance(raw_limit, int) and raw_limit > 0:
+            node_limit: int | None = raw_limit
+        else:
+            node_limit = None
+    except Exception as exc:
+        # Mirror _cmd_channels never-crash fallback: a broken install still
+        # gets a parseable shape, with the failure surfaced to stderr so it
+        # isn't silently lost in a pipeline.
+        print(f"⚠️  entitlement resolution failed: {exc}", file=sys.stderr)
+        tier, grace, enforced, node_limit = "oss", True, False, None
+        resolve_error = str(exc)
+
+    if getattr(args, "as_json", False):
+        payload: dict = {
+            "tier": tier,
+            "grace": grace,
+            "enforced": enforced,
+            "node_limit": node_limit,
+        }
+        if resolve_error:
+            payload["error"] = resolve_error
+        print(_json.dumps(payload, indent=2, sort_keys=True))
+        return
+
+    mode_line = "off (grace)" if not enforced else "on"
+    cap_line = "unlimited" if node_limit is None else str(node_limit)
+    print("ClawMetry Nodes\n" + "─" * 40)
+    print(f"  Tier:        {tier}")
+    print(f"  Enforcement: {mode_line}")
+    print(f"  Node cap:    {cap_line}  (registered nodes)")
+    if resolve_error:
+        print(f"  ⚠️  resolver error: {resolve_error}")
 
 
 def _cmd_diagnose(args) -> None:
@@ -4893,6 +5013,32 @@ def main() -> None:
         ),
     )
 
+    # nodes — capacity-axis sibling of `clawmetry channels` for the
+    # registered-node count. No enumerable adapter list -- ``nodes`` is
+    # purely a per-tier cap -- so the default output is the header block
+    # (tier / enforcement / node cap) alone. Fills the last capacity-axis
+    # CLI gap left open after `channels` shipped in #3820.
+    p_nodes = sub.add_parser(
+        "nodes",
+        help="Show the resolved node-count cap for this install",
+    )
+    p_nodes.add_argument(
+        "--json",
+        action="store_true",
+        dest="as_json",
+        help="Emit {tier, grace, enforced, node_limit} JSON (jq-friendly)",
+    )
+    p_nodes.add_argument(
+        "--why",
+        metavar="N",
+        default=None,
+        help=(
+            "Print the lock-reason payload for N registered nodes "
+            "(same shape as GET /api/entitlement/lock-reason?nodes=N). "
+            "The nodes axis is capacity-scoped -- N is a count, not an id."
+        ),
+    )
+
     # diagnose — surface the entitlement resolver inputs so an operator
     # can answer "why did my install resolve to <tier>?" without reading
     # ~/.clawmetry by hand. Same shape as GET /api/entitlement/diagnostic.
@@ -4956,6 +5102,7 @@ def main() -> None:
         "runtimes",
         "features",
         "channels",
+        "nodes",
         "diagnose",
         "verify-integrity",
         "nemoclaw-daemons",
@@ -5002,6 +5149,8 @@ def main() -> None:
             _cmd_features(args)
         elif args.cmd == "channels":
             _cmd_channels(args)
+        elif args.cmd == "nodes":
+            _cmd_nodes(args)
         elif args.cmd == "diagnose":
             _cmd_diagnose(args)
         elif args.cmd == "verify-integrity":

--- a/tests/test_cli_nodes_subcommand.py
+++ b/tests/test_cli_nodes_subcommand.py
@@ -1,0 +1,276 @@
+"""Tests for the ``clawmetry nodes`` subcommand.
+
+Capacity-axis sibling of ``tests/test_cli_channels_subcommand.py`` for the
+``nodes`` axis. The subcommand surfaces the resolved node-count cap plus a
+``--why N`` diagnostic that answers "what tier admits N registered nodes?"
+using the same lock-reason payload ``clawmetry channels --why N`` emits, so
+a wrapper script written against either surface works interchangeably.
+
+The header / ``--why`` output must match ``GET /api/entitlement`` (for the
+node cap) and ``GET /api/entitlement/lock-reason?nodes=N`` (for the
+diagnostic) byte-for-byte so the CLI and HTTP surfaces cannot drift.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+
+import pytest
+
+
+@pytest.fixture
+def cli_mod(monkeypatch, tmp_path):
+    """Fresh entitlements module with HOME pointed at an empty tmp dir so the
+    resolver renders against the OSS-free default and never against a license
+    that happens to live on the host.
+    """
+    import importlib
+
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    import clawmetry.entitlements as ent
+
+    importlib.reload(ent)
+    ent.invalidate()
+
+    import clawmetry.cli as cli  # imported after entitlements is rebuilt
+
+    yield cli
+    ent.invalidate()
+
+
+def _ns(**kw) -> argparse.Namespace:
+    kw.setdefault("as_json", False)
+    kw.setdefault("why", None)
+    return argparse.Namespace(**kw)
+
+
+# ── default (no --why) header block ─────────────────────────────────────────
+
+
+def test_default_json_shape(cli_mod, capsys):
+    """The default ``--json`` output exposes exactly the four documented
+    keys (tier / grace / enforced / node_limit) so a wrapper script can
+    parse the response without special-casing which keys are present."""
+    cli_mod._cmd_nodes(_ns(as_json=True))
+    payload = json.loads(capsys.readouterr().out)
+    assert set(payload) == {"tier", "grace", "enforced", "node_limit"}
+
+
+def test_default_grace_reports_oss_free_cap(cli_mod, capsys):
+    """The OSS-free default resolves to tier=oss with node_limit=1 (the
+    per-tier floor) and grace=True, enforced=False."""
+    cli_mod._cmd_nodes(_ns(as_json=True))
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["tier"] == "oss"
+    assert payload["grace"] is True
+    assert payload["enforced"] is False
+    assert payload["node_limit"] == 1
+
+
+def test_default_human_block_prints_header(cli_mod, capsys):
+    """The non-JSON path prints an aligned header block matching the
+    ``clawmetry channels`` layout so shell operators recognise the
+    layout across capacity-axis subcommands."""
+    cli_mod._cmd_nodes(_ns(as_json=False))
+    out = capsys.readouterr().out
+    assert "ClawMetry Nodes" in out
+    assert "Tier:" in out
+    assert "Enforcement:" in out and "off (grace)" in out
+    assert "Node cap:" in out
+    # The free-tier OSS cap is 1 node; surface it verbatim.
+    assert "1" in out
+
+
+def test_default_survives_broken_resolver(cli_mod, capsys, monkeypatch):
+    """A poisoned :func:`get_entitlement` must produce the OSS-free
+    fallback shape, not a stack trace. Matches the never-crash contract."""
+    import clawmetry.entitlements as ent
+
+    def _boom():
+        raise RuntimeError("synthetic resolver failure")
+
+    monkeypatch.setattr(ent, "get_entitlement", _boom)
+    cli_mod._cmd_nodes(_ns(as_json=True))
+    payload = json.loads(capsys.readouterr().out)
+    # Fallback shape includes an ``error`` key so a shell wrapper never
+    # mistakes a broken resolver for a successful all-clear.
+    assert set(payload) == {"tier", "grace", "enforced", "node_limit", "error"}
+    assert payload["tier"] == "oss"
+    assert payload["node_limit"] is None
+    assert "synthetic" in payload["error"]
+
+
+# ── --why N (lock-reason payload) ──────────────────────────────────────────
+#
+# The ``--why`` payload shape must match the shared envelope emitted by
+# ``clawmetry {runtimes,features,channels} --why`` so a script written
+# against any axis works here interchangeably. The nodes axis is
+# capacity-scoped (N is a count, not an id), so behaviour mirrors the
+# channels ``--why`` branch: non-int input falls to the grace-shape
+# fallback, and the human header phrases the capacity question naturally.
+
+
+_EXPECTED_KEYS = {
+    "key",
+    "kind",
+    "reason",
+    "locked",
+    "allowed",
+    "required_tier",
+    "required_tier_label",
+    "required_tier_rank",
+    "current_tier",
+    "current_tier_rank",
+    "upgrade_required",
+}
+
+
+def test_why_json_matches_shared_envelope(cli_mod, capsys):
+    """The nodes --why JSON must expose the same keys as the runtime /
+    feature / channels variants so a script written against any axis works
+    here interchangeably."""
+    cli_mod._cmd_nodes(_ns(as_json=True, why="5"))
+    payload = json.loads(capsys.readouterr().out)
+    assert set(payload) == _EXPECTED_KEYS
+    assert payload["kind"] == "nodes"
+    assert payload["key"] == "5"
+
+
+def test_why_grace_reports_upgrade_target(cli_mod, capsys):
+    """In grace mode, a count above the free OSS floor of 1 must still
+    surface the tier that would unlock it (locked=False but
+    required_tier=cloud_starter + upgrade_required=True), matching the
+    channels ``--why`` preview behaviour. This is the guarantee that the
+    CLI can preview the upgrade ladder without flipping the enforce gate."""
+    import clawmetry.entitlements as ent
+
+    cli_mod._cmd_nodes(_ns(as_json=True, why="5"))
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["locked"] is False  # grace mode
+    assert payload["reason"] is None
+    assert payload["current_tier"] == ent.TIER_OSS
+    assert payload["required_tier"] == ent.TIER_CLOUD_STARTER
+    assert payload["upgrade_required"] is True
+
+
+def test_why_under_free_cap_reports_no_upgrade(cli_mod, capsys):
+    """A count that fits under the OSS free cap (1) resolves to
+    required_tier=oss and upgrade_required=False even under grace so the
+    CLI never dangles an upgrade CTA for a request the free floor
+    already covers."""
+    cli_mod._cmd_nodes(_ns(as_json=True, why="1"))
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["locked"] is False
+    assert payload["upgrade_required"] is False
+
+
+def test_why_enforce_locks_over_cap(cli_mod, capsys, monkeypatch):
+    """With CLAWMETRY_ENFORCE=1, asking for more registered nodes than
+    the OSS cap admits reports a real lock with a non-empty reason string
+    and the upgrade CTA."""
+    import clawmetry.entitlements as ent
+
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    cli_mod._cmd_nodes(_ns(as_json=True, why="5"))
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["locked"] is True
+    assert payload["reason"], "reason string must be non-empty when locked"
+    assert payload["required_tier"] == ent.TIER_CLOUD_STARTER
+    assert payload["upgrade_required"] is True
+
+
+def test_why_non_int_returns_parseable_fallback(cli_mod, capsys):
+    """A typo like ``--why abc`` must not crash and must not dangle an
+    upgrade CTA -- otherwise a shell wrapper mistakes a typo for
+    "no lock, all good"."""
+    cli_mod._cmd_nodes(_ns(as_json=True, why="abc"))
+    payload = json.loads(capsys.readouterr().out)
+    assert set(payload) == _EXPECTED_KEYS
+    assert payload["kind"] == "nodes"
+    assert payload["locked"] is False
+    assert payload["reason"] is None
+    assert payload["required_tier"] is None
+    assert payload["upgrade_required"] is False
+
+
+def test_why_key_canonicalised(cli_mod, capsys):
+    """A caller passing ``05`` or ``5`` sees the same canonical ``"5"``
+    string back in the payload -- matches the channels ``--why``
+    canonicalisation posture so scripts can key on ``payload["key"]``."""
+    cli_mod._cmd_nodes(_ns(as_json=True, why="05"))
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["key"] == "5"
+
+
+def test_why_human_block_uses_capacity_phrasing(cli_mod, capsys, monkeypatch):
+    """The non-JSON path for nodes uses a capacity-scoped header
+    ("what tier unlocks N nodes?") since the key is a count, not an
+    adapter id. Under enforcement the reason string surfaces verbatim
+    alongside the aligned two-column block."""
+    import clawmetry.entitlements as ent
+
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    cli_mod._cmd_nodes(_ns(as_json=False, why="5"))
+    out = capsys.readouterr().out
+    assert "what tier unlocks 5 nodes?" in out
+    assert "Kind:" in out and "nodes" in out
+    assert "Locked:" in out and "yes" in out
+    assert "Reason:" in out
+    assert "Required tier:" in out
+    assert "clawmetry license activate <KEY>" in out
+
+
+def test_why_survives_broken_resolver(cli_mod, capsys, monkeypatch):
+    """A poisoned :func:`get_entitlement` must produce the OSS-free
+    fallback shape, not a stack trace -- same never-crash contract as
+    the runtime / feature / channels variants."""
+    import clawmetry.entitlements as ent
+
+    def _boom():
+        raise RuntimeError("synthetic resolver failure")
+
+    monkeypatch.setattr(ent, "get_entitlement", _boom)
+    cli_mod._cmd_nodes(_ns(as_json=True, why="5"))
+    payload = json.loads(capsys.readouterr().out)
+    assert set(payload) == _EXPECTED_KEYS
+    assert payload["kind"] == "nodes"
+    assert payload["current_tier"] == "oss"
+    assert payload["locked"] is False
+    assert payload["reason"] is None
+
+
+# ── subparser wiring ───────────────────────────────────────────────────────
+
+
+def test_subparser_flags_registered():
+    """`nodes --why` and `nodes --json` must be reachable from the top-level
+    parser -- otherwise the human-facing docs promise flags that argparse
+    rejects at runtime."""
+    import inspect
+
+    import clawmetry.cli as cli
+
+    src = inspect.getsource(cli.main)
+    # The subparser is named `p_nodes` in main(); grep for both the
+    # subcommand name and its documented flag help so a rename or a
+    # dropped flag surfaces here rather than at first-run.
+    assert '"nodes"' in src
+    assert "Show the resolved node-count cap" in src
+    assert "GET /api/entitlement/lock-reason?nodes=N" in src
+
+
+def test_nodes_dispatch_wired():
+    """The top-level `args.cmd == "nodes"` branch must dispatch to
+    :func:`_cmd_nodes` -- otherwise the subparser accepts the command but
+    the runtime silently falls through to the dashboard fallback."""
+    import inspect
+
+    import clawmetry.cli as cli
+
+    src = inspect.getsource(cli.main)
+    assert 'args.cmd == "nodes"' in src
+    assert "_cmd_nodes(args)" in src


### PR DESCRIPTION
## Summary

- Adds `clawmetry nodes`, the capacity-axis CLI sibling of `clawmetry channels` for the registered-node axis: header block (tier / enforcement / node cap), `--json` for scripting, and `--why N` that mirrors `GET /api/entitlement/lock-reason?nodes=N` via the shared `_entitlement_why_payload` envelope.
- Extends `_entitlement_why_payload` / `_print_why_block` with the `nodes` branch (mirroring the existing `channels` branch: non-int input collapses to the grace-shape row, key is canonicalised, header phrases the capacity question naturally). Backed by `Entitlement.lock_reason(str(n), kind="nodes")` + `min_tier_for_node_count` so the CLI cannot drift from the HTTP surface.
- Grace-mode behaviour is unchanged: the subcommand only reads the resolved entitlement, it never enforces. In grace, requesting more than the OSS floor (1) still surfaces `required_tier=cloud_starter` + `upgrade_required=true` so the operator can preview the upgrade ladder without flipping the enforce gate -- matches the `channels --why` precedent.

## Test plan

- [x] `python3 -m py_compile clawmetry/cli.py tests/test_cli_nodes_subcommand.py`
- [x] `python3 -m pytest tests/test_cli_nodes_subcommand.py` → 14 passed
- [x] `python3 -m pytest tests/test_cli_entitlement_why.py tests/test_cli_features_subcommand.py tests/test_cli_runtimes_subcommand.py tests/test_cli_channels_subcommand.py tests/test_cli_license_json.py` → 32 passed (no regressions on the shared why-payload / neighbouring subcommands)
- [x] `python3 -m pytest tests/test_entitlement_api.py tests/test_entitlement_api_nodes.py tests/test_entitlements_min_tier_nodes.py` → 141 passed (min_tier_for_node_count + /api/entitlement surface still green)
- [x] `ruff check clawmetry/cli.py` — new code introduces zero additional lint errors (pre-existing count of 16 unchanged before/after)
- [x] End-to-end smoke: `clawmetry nodes` prints the header block, `clawmetry nodes --json` returns `{tier, grace, enforced, node_limit}`, `clawmetry nodes --why 5 --json` returns the shared lock-reason envelope with `kind: "nodes"`, `required_tier: "cloud_starter"`, `upgrade_required: true`.

## Local operator verification checklist

(I do not have access to the running daemon, the host filesystem, the live cloud snapshot, or a browser -- so this checklist covers the steps only the local operator can perform.)

- [ ] Copy the changed files into the site-packages install:
  ```
  cp clawmetry/cli.py ~/.clawmetry/lib/python3.*/site-packages/clawmetry/
  cp tests/test_cli_nodes_subcommand.py ~/.clawmetry/lib/python3.*/site-packages/tests/ 2>/dev/null || true
  find ~/.clawmetry/lib -name __pycache__ -exec rm -rf {} +
  ```
- [ ] Restart the daemon (belt-and-suspenders; the CLI change alone doesn't need it, but restarting picks up any incidental sync-path imports):
  ```
  launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync
  ```
- [ ] Confirm the CLI surface end-to-end on the host:
  ```
  clawmetry nodes                                   # header block
  clawmetry nodes --json | jq '.'                   # scriptable shape
  clawmetry nodes --why 5 --json | jq '.'           # lock-reason payload
  clawmetry nodes --why abc --json | jq '.'         # non-int fallback (locked=false, required_tier=null)
  ```
- [ ] Confirm parity with the HTTP surface:
  ```
  curl -s "http://localhost:8900/api/entitlement/lock-reason?nodes=5" | jq '.'   # should match the --why 5 payload byte-for-byte on shared keys
  ```
- [ ] Grace vs enforce sanity:
  ```
  CLAWMETRY_ENFORCE=1 clawmetry nodes --why 5 --json | jq '.locked, .reason, .required_tier'
  # Expect: true, non-empty reason, "cloud_starter"
  ```
- [ ] (Not applicable here -- no `/api/*` route added -- but for completeness) decrypt the live cloud snapshot after any subsequent release to confirm no snapshot shape changed.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016gceWyDprovYQbkZzsjyZi)_