### PR TITLE
test: add JUnit coverage to e2e-critical so flaky tests auto-quarantine within 24h (C7)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
                   errors += 1
           if errors:
               sys.exit(1)
-          print(f'✅ Syntax OK ({len(glob.glob("clawmetry/**/*.py", recursive=True)) + 1} files)')
+          print(f'✅ Syntax OK ({len(glob.glob(\"clawmetry/**/*.py\", recursive=True)) + 1} files)')
           "
       - name: Install ruff (fast linter)
         run: pip install ruff

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
                   errors += 1
           if errors:
               sys.exit(1)
-          print(f'✅ Syntax OK ({len(glob.glob(\"clawmetry/**/*.py\", recursive=True)) + 1} files)')
+          print(f'✅ Syntax OK ({len(glob.glob("clawmetry/**/*.py", recursive=True)) + 1} files)')
           "
       - name: Install ruff (fast linter)
         run: pip install ruff
@@ -415,7 +415,17 @@ jobs:
           python3 -m pytest \
             tests/test_e2e.py::TestTabsLoad \
             tests/test_e2e_oss_all_tabs.py::TestAllTabsPostAuth \
-            -v --tb=short -m 'not quarantine'
+            -v --tb=short -m 'not quarantine' \
+            --junitxml=/tmp/junit-e2e-critical.xml
+
+      - name: Upload JUnit test report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: junit-e2e-critical-${{ github.run_id }}
+          path: /tmp/junit-e2e-critical.xml
+          if-no-files-found: warn
+          retention-days: 7
 
   # ── pip install smoke test across platforms ─────────────────────────────────────────
   pip-install:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
           done
           echo "✅ JS Syntax OK"
 
-  # ── API tests across all 3 platforms ─────────────────────────────────────────────
+  # ── API tests across all 3 platforms ─────────────────────────────────────────────────────
   api-tests:
     name: API Tests (${{ matrix.os }})
     needs: lint
@@ -143,7 +143,7 @@ jobs:
         # Quarantined tests still run daily in quarantine-sweep.yml.
         run: python3 -m pytest tests/test_api.py -v --tb=short -m 'not quarantine'
 
-  # ── MOAT verifier (hermetic, hard-fail) ────────────────────────────────────────────────────
+  # ── MOAT verifier (hermetic, hard-fail) ────────────────────────────────────────────────────────────────────────────────────────
   # Issue #1491 / PRD #1133 invariant #3: "A regression in either direction
   # is caught BEFORE merge." These files exercise the
   # OpenClaw → DuckDB → API surface contract end-to-end, plus the lint
@@ -193,7 +193,7 @@ jobs:
             tests/test_openclaw_detection_real.py \
             -q
 
-  # ── Entitlement API test suite (~2700 hermetic tests) ─────────────────────
+  # ── Entitlement API test suite (~2700 hermetic tests) ─────────────────────────
   # Covers every helper in clawmetry/entitlements.py and every endpoint
   # under routes/entitlement.py via Flask test client. No live server, no
   # gateway, no network. Runtime ~60s. HARD-FAIL: no continue-on-error.
@@ -220,7 +220,7 @@ jobs:
             tests/test_tier_cli.py \
             -q
 
-  # ── Compression / cache-safety eval (Tier-1, deterministic) ──────────────
+  # ── Compression / cache-safety eval (Tier-1, deterministic) ──────────────────
   # Issue #2844 (epic #2837): port Headroom's eval rigor so we can claim
   # "compression-safe" with proof. This Tier-1 gate is pure-Python and spends
   # ZERO API budget — it proves CCR payload compression is byte-for-byte
@@ -244,7 +244,7 @@ jobs:
       - name: Run compression/cache-safety eval suite
         run: python3 -m pytest tests/test_compression_safety_eval.py -q
 
-  # ── MOAT keystone (DuckDB-first invariant, 13-endpoint bar) ──────────────
+  # ── MOAT keystone (DuckDB-first invariant, 13-endpoint bar) ──────────────────
   # Implements `docs/MOAT_BAR.md` Section 5 acceptance criterion #1:
   # `keystone_e2e.py --no-drive` exits 0 on every PR. The keystone is the
   # canonical 13-endpoint verifier (PR #1672) that asserts every
@@ -427,7 +427,7 @@ jobs:
           if-no-files-found: warn
           retention-days: 7
 
-  # ── pip install smoke test across platforms ─────────────────────────────────────────
+  # ── pip install smoke test across platforms ────────────────────────────────────────────────────
   pip-install:
     name: pip install (${{ matrix.os }})
     needs: lint
@@ -528,7 +528,7 @@ jobs:
           fi
           echo "✅ /static/js/app.js served from installed wheel"
 
-  # ── Eval suite gate (Phase 2 evals, refs #1619 / PR #1626) ──────────────
+  # ── Eval suite gate (Phase 2 evals, refs #1619 / PR #1626) ──────────────────
   # Runs ClawMetry's own golden suite (tests/data/golden_ci.yaml) through
   # the `clawmetry eval` CLI on every PR. Catches regressions in:
   #   * eval_suite_runner.py YAML parsing / runner loop
@@ -543,7 +543,7 @@ jobs:
   # community PRs) the job emits an explicit "SKIPPED" warning and exits
   # 0. The gate hard-fails only when the secret IS set AND any test
   # fails. This keeps green-checks-only test runs unblocked while still
-  # gating the merge for maintainer-owned PRs.
+  # gating the merge for maintainer-approved PRs.
   #
   # To disable the gate temporarily (e.g. during a known-broken judge
   # provider outage), set the repo variable `CLAWMETRY_EVALS_GATE` to
@@ -617,7 +617,7 @@ jobs:
           if-no-files-found: warn
           retention-days: 7
 
-  # ── Live OpenClaw E2E ──────────────────────────────────────────────────────
+  # ── Live OpenClaw E2E ────────────────────────────────────────────────────────────────────────────
   # Closes #1544. Boots a real openclaw gateway, sends a real message
   # through `openclaw agent --local`, drives the daemon's
   # sync_sessions_recent over the on-disk JSONL, and asserts every

--- a/scripts/auto_quarantine.py
+++ b/scripts/auto_quarantine.py
@@ -2,11 +2,15 @@
 """Detect flaky E2E tests and append them to tests/quarantine.txt.
 
 A test is classified as flaky when:
-  - It failed in a recent OSS Golden Path run (junit-c1c5-<run_id> artifact), AND
+  - It failed in a recent watched CI run (junit artifact), AND
   - There exists a LATER run for the SAME head commit (SHA) that PASSED.
 
 Failed-then-passed on the same commit == flaky; add to quarantine.txt so
 the per-PR gate is not blocked by intermittent failures.
+
+Watched workflows (WATCHED_WORKFLOWS constant):
+  - oss-golden-path.yml -- uploads junit-c1c5-{run_id} (C1+C5 gate)
+  - ci.yml              -- uploads junit-e2e-critical-{run_id} (e2e-critical job)
 
 Usage
 -----
@@ -37,7 +41,21 @@ import zipfile
 
 OWNER = os.environ.get("REPO_OWNER", "vivekchand")
 REPO = os.environ.get("REPO_NAME", "clawmetry")
-WORKFLOW_FILE = "oss-golden-path.yml"
+
+# Each entry: (workflow_filename, junit_artifact_name_prefix).
+# Artifact for run {run_id} is named "{prefix}-{run_id}".
+# C7 requirement: flaky tests in ANY required-check workflow must be
+# quarantined within 24h. Previously only oss-golden-path.yml was scanned;
+# adding ci.yml closes the gap for TestTabsLoad / TestAllTabsPostAuth
+# flakiness detected in the e2e-critical job (also a required check).
+WATCHED_WORKFLOWS: list[tuple[str, str]] = [
+    # C1+C5 gate: uploads junit-c1c5-{run_id}.
+    ("oss-golden-path.yml", "junit-c1c5"),
+    # e2e-critical job in ci.yml: uploads junit-e2e-critical-{run_id}.
+    # Without this entry, flaky tests in TestTabsLoad / TestAllTabsPostAuth
+    # would block PRs without ever reaching quarantine.txt (C7 coverage gap).
+    ("ci.yml", "junit-e2e-critical"),
+]
 
 
 # ---------------------------------------------------------------------------
@@ -198,14 +216,14 @@ def _extract_junit_from_zip(zip_bytes: bytes) -> set[str]:
 # ---------------------------------------------------------------------------
 
 
-def _get_workflow_id(token: str) -> int:
-    """Return the numeric workflow ID for WORKFLOW_FILE."""
+def _get_workflow_id(workflow_file: str, token: str) -> int:
+    """Return the numeric workflow ID for workflow_file."""
     data = _api(f"/repos/{OWNER}/{REPO}/actions/workflows", token=token)
     for wf in data.get("workflows", []):
-        if WORKFLOW_FILE in wf.get("path", ""):
+        if workflow_file in wf.get("path", ""):
             return int(wf["id"])
     raise RuntimeError(
-        f"Workflow {WORKFLOW_FILE!r} not found in {OWNER}/{REPO}. "
+        f"Workflow {workflow_file!r} not found in {OWNER}/{REPO}. "
         "Check that the workflow file exists and REPO_OWNER/REPO_NAME are correct."
     )
 
@@ -220,24 +238,37 @@ def _get_runs(workflow_id: int, lookback: int, token: str) -> list[dict]:
     return data.get("workflow_runs", [])
 
 
-def _find_artifact_id(run_id: int, token: str) -> int | None:
-    """Return the artifact ID for the junit-c1c5-<run_id> artifact, or None."""
+def _find_artifact_id(run_id: int, artifact_prefix: str, token: str) -> int | None:
+    """Return the artifact ID for {artifact_prefix}-{run_id}, or None."""
     data = _api(
         f"/repos/{OWNER}/{REPO}/actions/runs/{run_id}/artifacts",
         token=token,
     )
-    target = f"junit-c1c5-{run_id}"
+    target = f"{artifact_prefix}-{run_id}"
     for art in data.get("artifacts", []):
         if art.get("name", "") == target:
             return int(art["id"])
     return None
 
 
-def detect_flaky_tests(lookback: int, token: str) -> set[str]:
-    """Return the set of test node IDs that appear to be flaky."""
-    print(f"Scanning {lookback} recent runs of {WORKFLOW_FILE} in {OWNER}/{REPO} ...")
+def _detect_flaky_in_workflow(
+    workflow_file: str,
+    artifact_prefix: str,
+    lookback: int,
+    token: str,
+) -> set[str]:
+    """Detect flaky tests in a single workflow.
 
-    workflow_id = _get_workflow_id(token)
+    A test is flaky when it failed in one run then passed on a re-run of the
+    same commit (same head_sha, higher run_number).
+    """
+    print(f"Scanning {lookback} recent runs of {workflow_file} in {OWNER}/{REPO} ...")
+    try:
+        workflow_id = _get_workflow_id(workflow_file, token)
+    except RuntimeError as exc:
+        print(f"  WARN: {exc} -- skipping {workflow_file}")
+        return set()
+
     runs = _get_runs(workflow_id, lookback, token)
     print(f"  Fetched {len(runs)} completed run(s).")
 
@@ -285,10 +316,10 @@ def detect_flaky_tests(lookback: int, token: str) -> set[str]:
             "failed then passed on re-run -> checking JUnit XML"
         )
 
-        artifact_id = _find_artifact_id(run_id, token)
+        artifact_id = _find_artifact_id(run_id, artifact_prefix, token)
         if artifact_id is None:
             print(
-                f"    No junit-c1c5-{run_id} artifact found "
+                f"    No {artifact_prefix}-{run_id} artifact found "
                 "(run may predate JUnit XML upload step)"
             )
             continue
@@ -307,6 +338,21 @@ def detect_flaky_tests(lookback: int, token: str) -> set[str]:
             print("    No failing tests in JUnit XML (or no XML in artifact)")
 
     return flaky_tests
+
+
+def detect_flaky_tests(lookback: int, token: str) -> set[str]:
+    """Return the set of test node IDs that appear to be flaky.
+
+    Scans every workflow in WATCHED_WORKFLOWS. A test is flaky when it
+    failed in a workflow run then passed on a later re-run of the same
+    commit.
+    """
+    all_flaky: set[str] = set()
+    for workflow_file, artifact_prefix in WATCHED_WORKFLOWS:
+        all_flaky |= _detect_flaky_in_workflow(
+            workflow_file, artifact_prefix, lookback, token
+        )
+    return all_flaky
 
 
 # ---------------------------------------------------------------------------
@@ -376,7 +422,7 @@ def main() -> None:
         type=int,
         default=30,
         metavar="N",
-        help="Number of recent workflow runs to scan (default: 30)",
+        help="Number of recent workflow runs to scan per workflow (default: 30)",
     )
     args = parser.parse_args()
 
@@ -403,7 +449,7 @@ def main() -> None:
 
     if not new_flaky:
         msg = (
-            f"Scanning {args.lookback} runs... 0 new flaky tests found"
+            f"Scanning {args.lookback} runs per workflow... 0 new flaky tests found"
             + (" (dry run)." if args.dry_run else ". quarantine.txt unchanged.")
         )
         print(msg)
@@ -418,7 +464,7 @@ def main() -> None:
             f"\n--dry-run: would add {len(new_flaky)} test(s) to {quarantine_file}"
         )
         print(
-            f"Scanning {args.lookback} runs... "
+            f"Scanning {args.lookback} runs per workflow... "
             f"{len(new_flaky)} new flaky tests found (dry run)."
         )
         sys.exit(0)


### PR DESCRIPTION
## What and why

Closes C7 gap: the `e2e-critical` job in `ci.yml` was a required status check but it never emitted a JUnit XML artifact. As a result, `auto_quarantine.py` (which powers the daily auto-quarantine sweep) could only see flaky failures in `oss-golden-path.yml` -- any test that went intermittently flaky in the `e2e-critical` job would block every PR indefinitely with no path to quarantine.

## Changes

### `.github/workflows/ci.yml`
- Added `--junitxml=/tmp/junit-e2e-critical.xml` to the `pytest` command in the `e2e-critical` job
- Added an `upload-artifact` step (runs on `always()`) that publishes the report as `junit-e2e-critical-${{ github.run_id }}`

### `scripts/auto_quarantine.py`
- Replaced single `WORKFLOW_FILE = "oss-golden-path.yml"` with `WATCHED_WORKFLOWS: list[tuple[str, str]]` covering both required-check workflows:
  ```python
  WATCHED_WORKFLOWS = [
      ("oss-golden-path.yml", "junit-c1c5"),
      ("ci.yml",              "junit-e2e-critical"),
  ]
  ```
- Extracted `_detect_flaky_in_workflow(workflow_file, artifact_prefix, lookback, token)` so each workflow is scanned independently
- `detect_flaky_tests()` now unions results from all watched workflows
- Updated `_get_workflow_id` and `_find_artifact_id` to accept workflow-specific parameters

## Test plan
- [ ] `e2e-critical` job produces `junit-e2e-critical-<run_id>` artifact on next CI run
- [ ] Daily `auto-quarantine.yml` run picks up failures from both `oss-golden-path.yml` and `ci.yml`
- [ ] A test that fails then passes on the same SHA across those two workflows triggers a quarantine PR

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_01CVpy84huQQANuaSenNRYA7)_