### PR TITLE
feat(cli): clawmetry retention -- capacity-axis sibling for event-retention window

### DIFF
--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -3716,6 +3716,31 @@ def _entitlement_why_payload(kind: str, key: str) -> dict:
             required = _ent.min_tier_for_node_count(n)
             reason = ent.lock_reason(str(n), kind="nodes")
             key = str(n)
+        elif kind == "retention_days":
+            # Capacity axis: ``key`` is an event-history window in days.
+            # Sibling of the ``channels`` branch -- a non-int collapses to
+            # the grace-shape row so ``--why abc`` never crashes and never
+            # dangles an upgrade CTA the operator can't act on.
+            try:
+                n = int(key)
+            except (TypeError, ValueError):
+                return {
+                    "key": key,
+                    "kind": kind,
+                    "reason": None,
+                    "locked": False,
+                    "allowed": True,
+                    "required_tier": None,
+                    "required_tier_label": None,
+                    "required_tier_rank": -1,
+                    "current_tier": cur_tier,
+                    "current_tier_rank": cur_rank,
+                    "upgrade_required": False,
+                }
+            allowed = ent.allows_retention_window(n)
+            required = _ent.min_tier_for_retention_window(n)
+            reason = ent.lock_reason(str(n), kind="retention_days")
+            key = str(n)
         else:  # feature
             allowed = ent.allows_feature(key)
             required = _ent.min_tier_for_feature(key)
@@ -3759,10 +3784,11 @@ def _print_why_block(payload: dict) -> None:
     (aligned two-column block, single upgrade CTA when a paid tier unlocks
     the item) so shell operators recognise the layout across subcommands.
 
-    For ``kind="channels"`` / ``kind="nodes"`` the header phrases the
-    capacity question naturally ("what tier unlocks N concurrent channels?"
-    / "what tier unlocks N nodes?") since the key is a count, not an id --
-    otherwise the shared "why is X locked?" phrasing wins.
+    For ``kind="channels"`` / ``kind="nodes"`` / ``kind="retention_days"``
+    the header phrases the capacity question naturally ("what tier unlocks
+    N concurrent channels?" / "what tier unlocks N nodes?" / "what tier
+    unlocks N-day event retention?") since the key is a count, not an id
+    -- otherwise the shared "why is X locked?" phrasing wins.
     """
     key = payload.get("key") or "(unknown)"
     kind = payload.get("kind") or "?"
@@ -3771,6 +3797,8 @@ def _print_why_block(payload: dict) -> None:
         print(f'ClawMetry: what tier unlocks {key} concurrent channels?')
     elif kind == "nodes":
         print(f'ClawMetry: what tier unlocks {key} nodes?')
+    elif kind == "retention_days":
+        print(f'ClawMetry: what tier unlocks {key}-day event retention?')
     else:
         print(f'ClawMetry: why is "{key}" locked?')
     print("─" * 40)
@@ -4240,6 +4268,90 @@ def _cmd_nodes(args) -> None:
     print(f"  Node cap:    {cap_line}  (registered nodes)")
     if resolve_error:
         print(f"  ⚠️  resolver error: {resolve_error}")
+
+
+def _cmd_retention(args) -> None:
+    """clawmetry retention — event-retention window (capacity axis).
+
+    Sibling of :func:`_cmd_channels` / :func:`_cmd_nodes` for the fourth
+    entitlement axis. The ``retention_days`` capacity axis governs how far
+    back in history each plan can hold event data before the store rolls
+    over. Every event-store feature itself is free at every tier; what
+    upgrades unlock is a longer window. The current tier cap prints in the
+    header block alongside the effective cap (which applies the
+    ``CLAWMETRY_RETENTION_DAYS`` env override, capped to the tier ceiling).
+
+    Never raises: any resolver failure surfaces inline (a warning row in
+    the human block, or the fields collapsed to ``null`` on the JSON
+    payload) so a wrapper script always sees a parseable response. Matches
+    the never-crash contract documented on :func:`get_entitlement`.
+
+    Output:
+      default -- header block (tier / enforcement / retention cap /
+                 effective cap / env override)
+      --json  -- ``{tier, grace, enforced, retention_days,
+                 effective_retention_days, override_env_name,
+                 override_env_value}``
+      --why N -- lock-reason payload for an N-day retention window (same
+                 shape as ``GET /api/entitlement/lock-reason?retention_days=N``);
+                 pair with ``--json`` for scriptable output.
+    """
+    import json as _json
+
+    from clawmetry import entitlements as _ent
+
+    why = (getattr(args, "why", None) or "").strip().lower()
+    if why:
+        payload = _entitlement_why_payload("retention_days", why)
+        if getattr(args, "as_json", False):
+            print(_json.dumps(payload, indent=2, sort_keys=True))
+        else:
+            _print_why_block(payload)
+        return
+
+    override_env_name = getattr(_ent, "_RETENTION_OVERRIDE_ENV", "CLAWMETRY_RETENTION_DAYS")
+    override_env_value = os.environ.get(override_env_name)
+
+    try:
+        ent = _ent.get_entitlement()
+        tier = ent.tier
+        grace = bool(ent.grace)
+        enforced = _ent.is_enforced()
+        retention_days = ent.event_retention_days()
+        effective_days = ent.effective_retention_days()
+    except Exception as exc:
+        # Mirror the _cmd_channels never-crash fallback: a broken install
+        # still gets a parseable shape, with the failure surfaced to stderr
+        # so it isn't silently lost in a shell pipeline.
+        print(f"⚠️  entitlement resolution failed: {exc}", file=sys.stderr)
+        tier, grace, enforced = "oss", True, False
+        retention_days, effective_days = None, None
+
+    if getattr(args, "as_json", False):
+        payload = {
+            "tier": tier,
+            "grace": grace,
+            "enforced": enforced,
+            "retention_days": retention_days,
+            "effective_retention_days": effective_days,
+            "override_env_name": override_env_name,
+            "override_env_value": override_env_value,
+        }
+        print(_json.dumps(payload, indent=2, sort_keys=True))
+        return
+
+    mode_line = "off (grace)" if not enforced else "on"
+    cap_line = "unlimited" if retention_days in (None, 0) else f"{retention_days} days"
+    eff_line = (
+        "unlimited" if effective_days in (None, 0) else f"{effective_days} days"
+    )
+    print("ClawMetry Retention\n" + "─" * 40)
+    print(f"  Tier:            {tier}")
+    print(f"  Enforcement:     {mode_line}")
+    print(f"  Retention cap:   {cap_line}  (per-tier ceiling)")
+    print(f"  Effective:       {eff_line}  (after env override)")
+    env_display = override_env_value if override_env_value not in (None, "") else "(unset)"
+    print(f"  {override_env_name}: {env_display}")
 
 
 def _cmd_diagnose(args) -> None:
@@ -5039,6 +5151,36 @@ def main() -> None:
         ),
     )
 
+    # retention — event-retention window cap (capacity axis sibling of
+    # `clawmetry channels` / `clawmetry nodes`). Same header/JSON/--why
+    # triad as the other capacity subcommands so the four-axis CLI surface
+    # is uniform.
+    p_retention = sub.add_parser(
+        "retention",
+        help="Show the event-retention window cap and the tier that would extend it",
+    )
+    p_retention.add_argument(
+        "--json",
+        action="store_true",
+        dest="as_json",
+        help=(
+            "Emit {tier, grace, enforced, retention_days, "
+            "effective_retention_days, override_env_name, "
+            "override_env_value} JSON (jq-friendly)"
+        ),
+    )
+    p_retention.add_argument(
+        "--why",
+        metavar="N",
+        default=None,
+        help=(
+            "Print the lock-reason payload for an N-day retention window "
+            "(same shape as GET /api/entitlement/lock-reason?retention_days=N). "
+            "The retention axis is capacity-scoped, so N is a day count, "
+            "not an event-store id."
+        ),
+    )
+
     # diagnose — surface the entitlement resolver inputs so an operator
     # can answer "why did my install resolve to <tier>?" without reading
     # ~/.clawmetry by hand. Same shape as GET /api/entitlement/diagnostic.
@@ -5103,6 +5245,7 @@ def main() -> None:
         "features",
         "channels",
         "nodes",
+        "retention",
         "diagnose",
         "verify-integrity",
         "nemoclaw-daemons",
@@ -5151,6 +5294,8 @@ def main() -> None:
             _cmd_channels(args)
         elif args.cmd == "nodes":
             _cmd_nodes(args)
+        elif args.cmd == "retention":
+            _cmd_retention(args)
         elif args.cmd == "diagnose":
             _cmd_diagnose(args)
         elif args.cmd == "verify-integrity":

--- a/tests/test_cli_retention_subcommand.py
+++ b/tests/test_cli_retention_subcommand.py
@@ -1,0 +1,283 @@
+"""Tests for the ``clawmetry retention`` CLI subcommand.
+
+The subcommand is a thin read of :meth:`Entitlement.event_retention_days`
+/ :meth:`Entitlement.effective_retention_days` and must never crash --
+even when the entitlement resolver fails. Mirrors
+``tests/test_cli_channels_subcommand.py`` so the CLI capacity trio
+(channels / retention / nodes) is covered by the same shape of test.
+
+The retention axis is capacity-scoped -- every event-store feature is
+FREE at every tier; what upgrades unlock is a longer history window. So
+``clawmetry retention --why N`` answers "what tier admits N-day
+retention?" instead of "why is <feature> locked?". Payload shape must
+match the shared lock-reason envelope so a wrapper script written
+against the runtime / feature / channels variants also works here.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+
+import pytest
+
+
+@pytest.fixture
+def cli_mod(monkeypatch, tmp_path):
+    """Fresh entitlements module with HOME pointed at an empty tmp dir so
+    the resolver renders against the OSS-free default and never against a
+    license that happens to live on the host. Also scrubs the retention
+    override env var so its default (unset) is deterministic."""
+    import importlib
+
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.delenv("CLAWMETRY_RETENTION_DAYS", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    import clawmetry.entitlements as ent
+
+    importlib.reload(ent)
+    ent.invalidate()
+
+    import clawmetry.cli as cli  # imported after entitlements is rebuilt
+
+    yield cli
+    ent.invalidate()
+
+
+def _ns(**kw) -> argparse.Namespace:
+    kw.setdefault("as_json", False)
+    kw.setdefault("why", None)
+    return argparse.Namespace(**kw)
+
+
+_WHY_EXPECTED_KEYS = {
+    "key",
+    "kind",
+    "reason",
+    "locked",
+    "allowed",
+    "required_tier",
+    "required_tier_label",
+    "required_tier_rank",
+    "current_tier",
+    "current_tier_rank",
+    "upgrade_required",
+}
+
+
+# ── header block ───────────────────────────────────────────────────────────
+
+def test_retention_header_advertises_tier_cap(cli_mod, capsys):
+    cli_mod._cmd_retention(_ns(as_json=False))
+    out = capsys.readouterr().out
+    assert "ClawMetry Retention" in out
+    # OSS free cap is 7 days -- header must surface that so the operator
+    # sees the axis the tier upgrade would extend.
+    assert "Retention cap:   7 days" in out
+    assert "Effective:       7 days" in out
+    # In grace mode enforcement is off.
+    assert "Enforcement:     off (grace)" in out
+
+
+def test_retention_header_shows_env_override_when_set(cli_mod, capsys, monkeypatch):
+    """A finite override below the tier cap must surface in the human
+    block so operators can spot a retention downgrade coming from env."""
+    monkeypatch.setenv("CLAWMETRY_RETENTION_DAYS", "3")
+    cli_mod._cmd_retention(_ns(as_json=False))
+    out = capsys.readouterr().out
+    # Env row echoes the raw override value verbatim.
+    assert "CLAWMETRY_RETENTION_DAYS: 3" in out
+    # The effective cap is min(override, tier_cap) = min(3, 7) = 3.
+    assert "Effective:       3 days" in out
+    # The tier ceiling itself is unchanged.
+    assert "Retention cap:   7 days" in out
+
+
+def test_retention_header_env_row_reads_unset(cli_mod, capsys):
+    cli_mod._cmd_retention(_ns(as_json=False))
+    out = capsys.readouterr().out
+    assert "CLAWMETRY_RETENTION_DAYS: (unset)" in out
+
+
+# ── JSON envelope ──────────────────────────────────────────────────────────
+
+def test_retention_json_is_machine_readable(cli_mod, capsys):
+    import clawmetry.entitlements as ent
+
+    cli_mod._cmd_retention(_ns(as_json=True))
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["tier"] == ent.TIER_OSS
+    assert payload["grace"] is True
+    assert payload["enforced"] is False
+    assert payload["retention_days"] == 7
+    assert payload["effective_retention_days"] == 7
+    assert payload["override_env_name"] == "CLAWMETRY_RETENTION_DAYS"
+    assert payload["override_env_value"] is None
+
+
+def test_retention_json_reflects_env_override(cli_mod, capsys, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_RETENTION_DAYS", "3")
+    cli_mod._cmd_retention(_ns(as_json=True))
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["override_env_value"] == "3"
+    assert payload["retention_days"] == 7
+    # Effective cap = min(override, tier_cap).
+    assert payload["effective_retention_days"] == 3
+
+
+def test_retention_json_survives_broken_resolver(cli_mod, capsys, monkeypatch):
+    """A poisoned :func:`get_entitlement` must produce a parseable payload
+    with the fields collapsed to safe defaults -- not a stack trace."""
+    import clawmetry.entitlements as ent
+
+    def _boom():
+        raise RuntimeError("synthetic resolver failure")
+
+    monkeypatch.setattr(ent, "get_entitlement", _boom)
+    cli_mod._cmd_retention(_ns(as_json=True))
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["tier"] == "oss"
+    assert payload["grace"] is True
+    assert payload["enforced"] is False
+    assert payload["retention_days"] is None
+    assert payload["effective_retention_days"] is None
+
+
+# ── enforcement ────────────────────────────────────────────────────────────
+
+def test_retention_enforced_oss_still_shows_numeric_cap(
+    cli_mod, capsys, monkeypatch
+):
+    """Enforced OSS installs still surface the numeric retention cap
+    (7 days for the free tier). Only the enforcement label changes."""
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    import clawmetry.entitlements as ent
+
+    ent.invalidate()
+    cli_mod._cmd_retention(_ns(as_json=False))
+    out = capsys.readouterr().out
+    assert "Enforcement:     on" in out
+    assert "Retention cap:   7 days" in out
+
+
+# ── --why (lock-reason payload) ────────────────────────────────────────────
+
+def test_why_retention_json_matches_shared_envelope(cli_mod, capsys):
+    """--why JSON must expose the same keys as the runtime / feature /
+    channels variants so scripts written against either surface work
+    interchangeably."""
+    cli_mod._cmd_retention(_ns(as_json=True, why="30"))
+    payload = json.loads(capsys.readouterr().out)
+    assert set(payload) == _WHY_EXPECTED_KEYS
+    assert payload["kind"] == "retention_days"
+    assert payload["key"] == "30"
+
+
+def test_why_retention_grace_reports_upgrade_target(cli_mod, capsys):
+    """In grace mode, a window above the free cap must still surface the
+    tier that would unlock it (locked=False but required_tier=cloud_starter
+    + upgrade_required=True), matching the channels/runtime/feature preview
+    behaviour. That's the guarantee the CLI can preview the upgrade ladder
+    without flipping the enforce gate."""
+    import clawmetry.entitlements as ent
+
+    cli_mod._cmd_retention(_ns(as_json=True, why="30"))
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["locked"] is False  # grace mode
+    assert payload["reason"] is None
+    assert payload["current_tier"] == ent.TIER_OSS
+    assert payload["required_tier"] == ent.TIER_CLOUD_STARTER
+    assert payload["upgrade_required"] is True
+
+
+def test_why_retention_under_free_cap_reports_no_upgrade(cli_mod, capsys):
+    """A window that fits under the OSS free cap (7 days) resolves to
+    required_tier=oss and upgrade_required=False even under grace so the
+    CLI never dangles an upgrade CTA for a request the free floor already
+    covers."""
+    cli_mod._cmd_retention(_ns(as_json=True, why="7"))
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["locked"] is False
+    assert payload["upgrade_required"] is False
+
+
+def test_why_retention_enforce_locks_over_cap(cli_mod, capsys, monkeypatch):
+    """With CLAWMETRY_ENFORCE=1, asking for more retention days than the
+    OSS cap admits reports a real lock with a non-empty reason string and
+    the upgrade CTA."""
+    import clawmetry.entitlements as ent
+
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    cli_mod._cmd_retention(_ns(as_json=True, why="30"))
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["locked"] is True
+    assert payload["reason"], "reason string must be non-empty when locked"
+    assert payload["required_tier"] == ent.TIER_CLOUD_STARTER
+    assert payload["upgrade_required"] is True
+
+
+def test_why_retention_non_int_returns_parseable_fallback(cli_mod, capsys):
+    """A typo like ``--why abc`` must not crash and must not dangle an
+    upgrade CTA -- otherwise a shell wrapper mistakes a typo for
+    "no lock, all good"."""
+    cli_mod._cmd_retention(_ns(as_json=True, why="abc"))
+    payload = json.loads(capsys.readouterr().out)
+    assert set(payload) == _WHY_EXPECTED_KEYS
+    assert payload["kind"] == "retention_days"
+    assert payload["locked"] is False
+    assert payload["reason"] is None
+    assert payload["required_tier"] is None
+    assert payload["upgrade_required"] is False
+
+
+def test_why_retention_human_block_uses_capacity_phrasing(
+    cli_mod, capsys, monkeypatch
+):
+    """The non-JSON --why path uses a capacity-scoped header ("what tier
+    unlocks N-day event retention?") since the key is a count, not an
+    event-store id."""
+    import clawmetry.entitlements as ent
+
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    cli_mod._cmd_retention(_ns(as_json=False, why="30"))
+    out = capsys.readouterr().out
+    assert "what tier unlocks 30-day event retention?" in out
+    assert "Kind:" in out and "retention_days" in out
+    assert "Locked:" in out and "yes" in out
+    assert "Reason:" in out
+    assert "Required tier:" in out
+    assert "clawmetry license activate <KEY>" in out
+
+
+def test_why_retention_survives_broken_resolver(cli_mod, capsys, monkeypatch):
+    """A poisoned :func:`get_entitlement` must produce the OSS-free fallback
+    shape, not a stack trace."""
+    import clawmetry.entitlements as ent
+
+    def _boom():
+        raise RuntimeError("synthetic resolver failure")
+
+    monkeypatch.setattr(ent, "get_entitlement", _boom)
+    cli_mod._cmd_retention(_ns(as_json=True, why="30"))
+    payload = json.loads(capsys.readouterr().out)
+    assert set(payload) == _WHY_EXPECTED_KEYS
+    assert payload["kind"] == "retention_days"
+    assert payload["current_tier"] == "oss"
+    assert payload["locked"] is False
+    assert payload["reason"] is None
+
+
+# ── registration ───────────────────────────────────────────────────────────
+
+def test_retention_subcommand_is_registered():
+    """The subparser + dispatch table must list `retention` so it is
+    reachable from the CLI entry point."""
+    import inspect
+
+    import clawmetry.cli as cli
+
+    src = inspect.getsource(cli.main)
+    assert '"retention"' in src
+    assert "_cmd_retention" in src


### PR DESCRIPTION
## Summary

- Adds `clawmetry retention`, the fourth capacity-axis CLI subcommand alongside `clawmetry channels` (and the in-flight `clawmetry nodes` in #3870), so the CLI surface across the four axes (features / runtimes / channels / retention + nodes) resolves off one shared shape.
- Header block: tier / enforcement / per-tier retention cap / effective cap after the `CLAWMETRY_RETENTION_DAYS` env override. `--json` for scripting: `{tier, grace, enforced, retention_days, effective_retention_days, override_env_name, override_env_value}`.
- `--why N` mirrors `GET /api/entitlement/lock-reason?retention_days=N` via the shared `_entitlement_why_payload` envelope + `_print_why_block` extended with a `retention_days` branch. Backed by `Entitlement.lock_reason(str(n), kind="retention_days")` + `min_tier_for_retention_window` (both already present on `main`) so the CLI cannot drift from the HTTP surface.
- Grace-mode behaviour is unchanged: the subcommand only reads the resolved entitlement, it never enforces. Under grace, a window above the OSS floor (7 days) still surfaces `required_tier=cloud_starter` + `upgrade_required=true` so the operator can preview the upgrade ladder without flipping the enforce gate -- matches the `channels --why` precedent.

## Test plan

- [x] `python3 -m py_compile clawmetry/cli.py tests/test_cli_retention_subcommand.py`
- [x] `python3 -m pytest tests/test_cli_retention_subcommand.py` → 15 passed
- [x] `python3 -m pytest tests/test_cli_channels_subcommand.py tests/test_cli_features_subcommand.py tests/test_cli_runtimes_subcommand.py tests/test_cli_entitlement_why.py` → 32 passed (no regression on the shared why-payload / neighbouring subcommands)
- [x] `python3 -m pytest tests/test_entitlement_api.py tests/test_entitlement_api_lock_reason.py` → 49 passed (existing lock-reason `?retention_days=` HTTP surface still green)
- [x] `ruff check clawmetry/cli.py` → new code introduces zero additional lint errors (pre-existing count of 15 unchanged before/after)
- [x] End-to-end smoke on the CLI dispatch table:
  - `clawmetry retention` → header block with `Retention cap: 7 days` + env row
  - `clawmetry retention --json` → `{tier: "oss", grace: true, retention_days: 7, effective_retention_days: 7, override_env_name: "CLAWMETRY_RETENTION_DAYS", override_env_value: null}`
  - `clawmetry retention --why 30 --json` → shared lock-reason envelope with `kind: "retention_days"`, `required_tier: "cloud_starter"`, `upgrade_required: true`
  - `CLAWMETRY_RETENTION_DAYS=3 clawmetry retention --json` → `effective_retention_days: 3` (tier cap unchanged at 7)

## Local operator verification checklist

(I do not have access to the running daemon, the host filesystem, the live cloud snapshot, or a browser -- so this checklist covers the steps only the local operator can perform.)

- [ ] Copy the changed files into the site-packages install:
  ```
  cp clawmetry/cli.py ~/.clawmetry/lib/python3.*/site-packages/clawmetry/
  cp tests/test_cli_retention_subcommand.py ~/.clawmetry/lib/python3.*/site-packages/tests/ 2>/dev/null || true
  find ~/.clawmetry/lib -name __pycache__ -exec rm -rf {} +
  ```
- [ ] Restart the daemon (belt-and-suspenders; the CLI change alone doesn't need it, but restarting picks up any incidental sync-path imports):
  ```
  launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync
  ```
- [ ] Confirm the CLI surface end-to-end on the host:
  ```
  clawmetry retention                                # header block
  clawmetry retention --json | jq '.'                # scriptable shape
  clawmetry retention --why 30 --json | jq '.'       # lock-reason payload (kind=retention_days)
  clawmetry retention --why abc --json | jq '.'      # non-int fallback (locked=false, required_tier=null)
  CLAWMETRY_RETENTION_DAYS=3 clawmetry retention --json | jq '.effective_retention_days'  # → 3
  ```
- [ ] Confirm parity with the HTTP surface:
  ```
  curl -s "http://localhost:8900/api/entitlement/lock-reason?retention_days=30" | jq '.'
  # should match the --why 30 payload byte-for-byte on shared keys
  ```
- [ ] Grace vs enforce sanity:
  ```
  CLAWMETRY_ENFORCE=1 clawmetry retention --why 30 --json | jq '.locked, .reason, .required_tier'
  # Expect: true, non-empty reason, "cloud_starter"
  ```
- [ ] (Not applicable here -- no `/api/*` route added -- but for completeness) decrypt the live cloud snapshot after any subsequent release to confirm no snapshot shape changed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01H2xb7JfH4hQoEs8x3HWGab)_