### PR TITLE
fix(sessions): surface PTY relay fields in list_sessions() extra (#3839)

### DIFF
--- a/clawmetry/adapters/openclaw.py
+++ b/clawmetry/adapters/openclaw.py
@@ -1723,6 +1723,27 @@ class OpenClawAdapter(AgentAdapter):
             _cdcont = s.get("cronDeliveredContent") or s.get("deliveredContent")
             if _cdcont is not None:
                 extra["cronDeliveredContent"] = str(_cdcont)
+            # PTY relay state (#3839): PR #107335 ('macOS paired-node terminals')
+            # and PR #107086 ('Control UI catalog terminals') stamp relay state,
+            # resume command, viewer preference, and paired-node identity on
+            # session records so the Control UI can open native terminal sessions.
+            # All four reads silently no-op when the fields are absent.
+            _pty = s.get("ptyRelayState") or s.get("ptyRelay")
+            if _pty is not None:
+                extra["ptyRelayState"] = str(_pty)
+            _rc = s.get("resumeCommand") or s.get("resumeCmd")
+            if _rc is not None:
+                extra["resumeCommand"] = str(_rc)
+            _vp = s.get("viewerPreference") or s.get("terminalPreference")
+            if _vp is not None:
+                extra["viewerPreference"] = str(_vp)
+            _pn = (
+                s.get("pairedNodeId")
+                or s.get("pairNodeId")
+                or s.get("pairedNode")
+            )
+            if _pn is not None:
+                extra["pairedNodeId"] = str(_pn)
             # On-exit cron trigger kind (#3526): OpenClaw 2026.7.1 (#92037)
             # stamps the schedule kind that triggered this session delivery
             # ("on-exit", "every", "interval", "cron", …) so callers can

--- a/tests/test_obs_gap_openclaw_pty_relay_3839.py
+++ b/tests/test_obs_gap_openclaw_pty_relay_3839.py
@@ -1,0 +1,105 @@
+"""Regression tests for issue #3839.
+
+OpenClaw PR #107335 ('macOS paired-node terminals') and PR #107086 ('Control UI
+catalog terminals') add PTY relay state, a validated resume command, a
+viewer-vs-terminal preference, and a paired-node identity to gateway session
+records.  Before this fix, OpenClawAdapter.list_sessions() dropped all four
+fields so they never appeared in the unified Session shape.
+"""
+
+import clawmetry.adapters.openclaw as ocmod
+from clawmetry.adapters.openclaw import OpenClawAdapter
+
+
+class _FakeDash:
+    def __init__(self, extra_fields=None):
+        self._fields = extra_fields or {}
+
+    def _get_sessions(self):
+        record = {"sessionId": "sess-pty"}
+        record.update(self._fields)
+        return [record]
+
+
+def test_list_sessions_captures_pty_relay_state(monkeypatch):
+    monkeypatch.setattr(ocmod, "_d", lambda: _FakeDash({"ptyRelayState": "active"}))
+    sessions = OpenClawAdapter().list_sessions(limit=10)
+    assert sessions[0].extra.get("ptyRelayState") == "active", (
+        "list_sessions() must surface ptyRelayState in extra"
+    )
+
+
+def test_list_sessions_captures_pty_relay_alias(monkeypatch):
+    monkeypatch.setattr(ocmod, "_d", lambda: _FakeDash({"ptyRelay": "inactive"}))
+    sessions = OpenClawAdapter().list_sessions(limit=10)
+    assert sessions[0].extra.get("ptyRelayState") == "inactive", (
+        "list_sessions() must accept the ptyRelay alias"
+    )
+
+
+def test_list_sessions_captures_resume_command(monkeypatch):
+    monkeypatch.setattr(
+        ocmod, "_d",
+        lambda: _FakeDash({"resumeCommand": "openclaw attach sess-pty"}),
+    )
+    sessions = OpenClawAdapter().list_sessions(limit=10)
+    assert sessions[0].extra.get("resumeCommand") == "openclaw attach sess-pty", (
+        "list_sessions() must surface resumeCommand in extra"
+    )
+
+
+def test_list_sessions_captures_resume_cmd_alias(monkeypatch):
+    monkeypatch.setattr(
+        ocmod, "_d",
+        lambda: _FakeDash({"resumeCmd": "openclaw attach sess-pty"}),
+    )
+    sessions = OpenClawAdapter().list_sessions(limit=10)
+    assert sessions[0].extra.get("resumeCommand") == "openclaw attach sess-pty", (
+        "list_sessions() must accept the resumeCmd alias"
+    )
+
+
+def test_list_sessions_captures_viewer_preference(monkeypatch):
+    monkeypatch.setattr(ocmod, "_d", lambda: _FakeDash({"viewerPreference": "terminal"}))
+    sessions = OpenClawAdapter().list_sessions(limit=10)
+    assert sessions[0].extra.get("viewerPreference") == "terminal", (
+        "list_sessions() must surface viewerPreference in extra"
+    )
+
+
+def test_list_sessions_captures_terminal_preference_alias(monkeypatch):
+    monkeypatch.setattr(ocmod, "_d", lambda: _FakeDash({"terminalPreference": "viewer"}))
+    sessions = OpenClawAdapter().list_sessions(limit=10)
+    assert sessions[0].extra.get("viewerPreference") == "viewer", (
+        "list_sessions() must accept the terminalPreference alias"
+    )
+
+
+def test_list_sessions_captures_paired_node_id(monkeypatch):
+    monkeypatch.setattr(ocmod, "_d", lambda: _FakeDash({"pairedNodeId": "node-42"}))
+    sessions = OpenClawAdapter().list_sessions(limit=10)
+    assert sessions[0].extra.get("pairedNodeId") == "node-42", (
+        "list_sessions() must surface pairedNodeId in extra"
+    )
+
+
+def test_list_sessions_captures_pair_node_id_alias(monkeypatch):
+    monkeypatch.setattr(ocmod, "_d", lambda: _FakeDash({"pairNodeId": "node-99"}))
+    sessions = OpenClawAdapter().list_sessions(limit=10)
+    assert sessions[0].extra.get("pairedNodeId") == "node-99", (
+        "list_sessions() must accept the pairNodeId alias"
+    )
+
+
+def test_list_sessions_omits_pty_fields_for_ordinary_session(monkeypatch):
+    monkeypatch.setattr(ocmod, "_d", lambda: _FakeDash({"kind": "direct"}))
+    sessions = OpenClawAdapter().list_sessions(limit=10)
+    assert "ptyRelayState" not in sessions[0].extra, (
+        "ptyRelayState must not appear in extra for ordinary direct sessions"
+    )
+    assert "resumeCommand" not in sessions[0].extra, (
+        "resumeCommand must not appear in extra for ordinary direct sessions"
+    )
+    assert "pairedNodeId" not in sessions[0].extra, (
+        "pairedNodeId must not appear in extra for ordinary direct sessions"
+    )


### PR DESCRIPTION
Closes #3839

## Summary

- **`clawmetry/adapters/openclaw.py`** — adds 4 field reads after the `cronDeliveredContent` block in `list_sessions()`, following the existing `s.get("primary") or s.get("alias")` pattern already used for cron fields, GLM overload, and failover model. Captures `ptyRelayState`, `resumeCommand`, `viewerPreference`, and `pairedNodeId` (with their known alias spellings) into `Session.extra`.
- **`tests/test_obs_gap_openclaw_pty_relay_3839.py`** (new) — 9 tests: primary field name, each alias, and a negative case confirming the keys are absent on ordinary direct sessions.

## Test plan

- `python3 -m pytest tests/test_obs_gap_openclaw_pty_relay_3839.py -v` — all 9 pass
- `python3 -c "import ast; ast.parse(open('clawmetry/adapters/openclaw.py').read())"` — syntax clean
- All reads silently no-op when fields are absent, so this is a zero-regression change for users without paired-node support

---
_Generated by [Claude Code](https://claude.ai/code/session_01DxcPWZ39VN29Ru1xULAFvJ)_