### PR TITLE
[RELEASE] Dives ride Claude Code's own OAuth on standalone nodes

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -260,7 +260,7 @@ def _otlp_service_name_to_agent_type(service_name):
     return slug or "custom"
 
 
-__version__ = "0.12.563"
+__version__ = "0.12.564"
 
 # Extensions (Phase 2): import the plugin host now, but defer the actual
 # load_plugins() call until after the Flask app is created below so we can

--- a/routes/advisor.py
+++ b/routes/advisor.py
@@ -168,9 +168,28 @@ def _load_anthropic_auth() -> tuple[str | None, str | None]:
                 )
             except Exception:
                 pass
-        # Only return claude_cli if the binary AND an OAuth profile exist.
-        # Without the profile `claude -p` would prompt interactively, which
-        # hangs the HTTP request.
+        if not has_profile:
+            # Standalone Claude Code nodes (no OpenClaw): the harness's own
+            # OAuth lives under ~/.claude, not the OpenClaw profile store —
+            # so the "use the default agent harness" fallback never fired on
+            # the most common runtime and the UI demanded an API key the
+            # harness never needed (live-hit 2026-07-21). Linux/hosted keeps
+            # a credentials file; macOS keeps the token in the Keychain, so
+            # a completed OAuth login marker is the signal there. Either
+            # way `claude -p` runs non-interactively.
+            if os.path.isfile(os.path.expanduser("~/.claude/.credentials.json")):
+                has_profile = True
+            else:
+                cc_cfg = os.path.expanduser("~/.claude.json")
+                if os.path.isfile(cc_cfg):
+                    try:
+                        with open(cc_cfg) as f:
+                            has_profile = bool(json.load(f).get("oauthAccount"))
+                    except Exception:
+                        pass
+        # Only return claude_cli if the binary AND an OAuth login exist.
+        # Without one `claude -p` would prompt interactively, which hangs
+        # the HTTP request.
         if has_profile:
             return "claude_cli", claude_bin
 

--- a/tests/test_advisor_claude_code_auth.py
+++ b/tests/test_advisor_claude_code_auth.py
@@ -1,0 +1,44 @@
+"""_load_anthropic_auth must recognize Claude Code's own OAuth so Dives ride
+the default agent harness on standalone Claude Code nodes (live-hit
+2026-07-21: node with 150 Claude Code sessions told to export an API key)."""
+import json
+import os
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture
+def clean_env(monkeypatch, tmp_path):
+    for v in ("ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN", "CLAUDE_API_KEY"):
+        monkeypatch.delenv(v, raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    return tmp_path
+
+
+def _load():
+    from routes.advisor import _load_anthropic_auth
+    with patch("routes.advisor._read_anthropic_key_from_openclaw_config",
+               return_value=None), \
+         patch("shutil.which", return_value="/usr/local/bin/claude"):
+        return _load_anthropic_auth()
+
+
+def test_claude_code_credentials_file_enables_cli_mode(clean_env):
+    cc = clean_env / ".claude"
+    cc.mkdir()
+    (cc / ".credentials.json").write_text('{"claudeAiOauth": {"accessToken": "x"}}')
+    mode, cred = _load()
+    assert mode == "claude_cli"
+
+
+def test_claude_code_oauth_marker_enables_cli_mode(clean_env):
+    (clean_env / ".claude.json").write_text(json.dumps(
+        {"oauthAccount": {"emailAddress": "u@x.test"}}))
+    mode, cred = _load()
+    assert mode == "claude_cli"
+
+
+def test_no_auth_anywhere_stays_none(clean_env):
+    mode, cred = _load()
+    assert mode is None and cred is None


### PR DESCRIPTION
Dive/Ask queries fall back to the default agent harness as intended, but the claude-cli OAuth detection only knew OpenClaw's auth-profile layout. Standalone Claude Code nodes were told to export an API key their harness never needed. Now recognizes Claude Code's own credential file (Linux/hosted) and oauthAccount marker (macOS keychain).

Tests: 3 new + existing advisor auth resolution suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)