### PR TITLE
feat(entitlement): tiers_for_features_batch + tiers_for_runtimes_batch (bundle-axis ladder)

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -5129,6 +5129,128 @@ def tiers_for_runtimes(runtimes) -> dict | None:
         }
 
 
+def tiers_for_features_batch(bundles) -> list[dict]:
+    """Per-bundle ladder-intersection for N caller-supplied feature bundles
+    in ONE round-trip.
+
+    Bundle-axis batch sibling of :func:`tiers_for_features` (which folds
+    ONE bundle to ONE ladder). Where the singular helper answers "which
+    tiers grant this whole bundle at once?", this answers the same question
+    for N distinct bundles so a pricing-matrix / upgrade-walkthrough
+    comparing several hypothetical configs ("Starter add-ons vs Pro add-ons
+    vs Enterprise add-ons") renders off ONE call instead of N calls to
+    :func:`tiers_for_features`.
+
+    Distinct from :func:`min_tier_for_features_batch`, which collapses each
+    bundle to a single cheapest tier: this returns the FULL ladder per
+    bundle so an "Available in: Starter, Cloud Pro, ..." tooltip can render
+    directly off each row without a follow-up call. Same relationship the
+    singular :func:`tiers_for_features` has to :func:`min_tier_for_features`.
+
+    Row shape mirrors :func:`tiers_for_features` exactly (per-bundle)::
+
+        {
+          "items":          ["fleet", "sso"],   # canonical known ids
+          "unknown":        ["bogus"],           # stripped+lowered ids
+          "kind":           "features",
+          "count":          <len(items)>,
+          "min_tier":       "enterprise" | None,
+          "min_tier_label": "Enterprise" | None,
+          "min_tier_rank":  <int> | None,
+          "tiers":          [<row>, ...],
+        }
+
+    Per-bundle normalisation is delegated to :func:`tiers_for_features` so
+    a batch row and the equivalent singular call return byte-identical
+    bodies. Empty / all-unknown bundles surface as the stable empty-shape
+    row (``tiers=[]``, ``min_tier=None``) -- distinguishes "caller asked
+    for nothing in this slot" from "caller asked and every token was a
+    typo".
+
+    Argument handling:
+
+    * ``bundles is None`` or non-iterable -- returns ``[]``.
+    * Each bundle may itself be ``None``, non-iterable, or empty -- the
+      helper emits the empty row shape rather than raising.
+
+    Decoupled from the resolved entitlement: delegates per-bundle to
+    :func:`tiers_for_features`, which walks the static per-tier feature
+    map, so grace vs enforce yields byte-identical rows. Never raises:
+    per-bundle failures short-circuit to the empty row shape so the batch
+    keeps building.
+    """
+    try:
+        if bundles is None:
+            return []
+        items = list(bundles)
+    except TypeError:
+        return []
+    out: list[dict] = []
+    empty_row = {
+        "items": [],
+        "unknown": [],
+        "kind": "features",
+        "count": 0,
+        "min_tier": None,
+        "min_tier_label": None,
+        "min_tier_rank": None,
+        "tiers": [],
+    }
+    for bundle in items:
+        try:
+            row = tiers_for_features(bundle if bundle is not None else [])
+        except Exception as exc:
+            logger.warning(
+                "entitlements: tiers_for_features_batch row failed: %s", exc
+            )
+            row = None
+        out.append(row if isinstance(row, dict) else dict(empty_row))
+    return out
+
+
+def tiers_for_runtimes_batch(bundles) -> list[dict]:
+    """Runtime-axis twin of :func:`tiers_for_features_batch`.
+
+    Same relationship to :func:`tiers_for_runtimes` that
+    :func:`tiers_for_features_batch` has to :func:`tiers_for_features`.
+    Per-bundle rows carry ``kind="runtimes"`` and the ``runtimes``-shape
+    ``items`` list; aliases (``claude-code`` -> ``claude_code``) canonicalise
+    the same way the singular helper does before intersection so a caller
+    posting either form gets the same ladder back.
+
+    Row shape mirrors :func:`tiers_for_runtimes` (``kind="runtimes"``).
+    Argument handling and never-raise contract match
+    :func:`tiers_for_features_batch` byte-for-byte.
+    """
+    try:
+        if bundles is None:
+            return []
+        items = list(bundles)
+    except TypeError:
+        return []
+    out: list[dict] = []
+    empty_row = {
+        "items": [],
+        "unknown": [],
+        "kind": "runtimes",
+        "count": 0,
+        "min_tier": None,
+        "min_tier_label": None,
+        "min_tier_rank": None,
+        "tiers": [],
+    }
+    for bundle in items:
+        try:
+            row = tiers_for_runtimes(bundle if bundle is not None else [])
+        except Exception as exc:
+            logger.warning(
+                "entitlements: tiers_for_runtimes_batch row failed: %s", exc
+            )
+            row = None
+        out.append(row if isinstance(row, dict) else dict(empty_row))
+    return out
+
+
 def tiers_for_features_at(
     perspective_tier: str, features
 ) -> dict | None:

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -22067,6 +22067,188 @@ def api_entitlement_min_tier_for_runtimes_batch():
 
 
 @bp_entitlement.route(
+    "/api/entitlement/tiers-for-features-batch",
+    methods=["POST"],
+)
+def api_entitlement_tiers_for_features_batch():
+    """``POST /api/entitlement/tiers-for-features-batch`` -- bundle-axis
+    batch sibling of ``/api/entitlement/tiers-for-features``.
+
+    Where the singular endpoint returns ONE ladder of tiers that grant
+    a caller-supplied bundle of features, this returns N ladders for N
+    caller-supplied bundles in ONE round-trip so a pricing-matrix /
+    upgrade-walkthrough comparing several hypothetical feature sets
+    ("Starter add-ons vs Pro add-ons vs Enterprise add-ons") renders off
+    one call instead of N calls to ``/tiers-for-features``.
+
+    Distinct from ``/min-tier-for-features-batch``, which collapses each
+    bundle to a single cheapest ``required_tier``: this returns the FULL
+    ladder per bundle so an "Available in: Starter, Cloud Pro, ..."
+    tooltip renders directly off each row without a follow-up call. Same
+    relationship the singular ``/tiers-for-features`` has to
+    ``/min-tier-for-features``.
+
+    POST rather than GET because the caller-supplied set of bundles can
+    grow past a comfortable query-string length; the sibling singular
+    endpoint uses GET+CSV where the bundle is small.
+
+    Request body::
+
+        {
+          "bundles": [
+            ["fleet", "sso"],
+            ["otel_export"],
+            []
+          ]
+        }
+
+    A shorthand ``{"bundles": ["fleet", "sso"]}`` (bare list of strings)
+    is treated as ONE bundle, matching the singular endpoint's bare-CSV
+    posture; a missing / non-list ``bundles`` value is a 400. An empty
+    ``bundles=[]`` list is a 400 for the same reason the singular
+    endpoint 400s on an empty ``features=`` -- distinguishes "caller
+    asked for nothing" from "caller asked and every token was unknown".
+
+    Response shape::
+
+        {
+          "bundles": [<row>, ...],
+          "count":   <int>,        # len(bundles)
+          "current_tier":      "...",
+          "current_tier_rank": <int>,
+          "grace":             <bool>,
+          "enforced":          <bool>,
+        }
+
+    Each ``<row>`` is byte-identical to the bare singular endpoint body
+    minus the resolver envelope::
+
+        {
+          "items":          ["fleet", "sso"],
+          "unknown":        ["bogus"],
+          "kind":           "features",
+          "count":          2,
+          "min_tier":       "enterprise" | null,
+          "min_tier_label": "Enterprise" | null,
+          "min_tier_rank":  <int> | null,
+          "tiers":          [<tier_row>, ...],
+        }
+
+    Per-bundle normalisation is delegated to
+    :func:`clawmetry.entitlements.tiers_for_features` (whitespace
+    stripped, lowercased, deduplicated preserving first-seen order;
+    unknown ids bucketed into the per-bundle ``unknown`` instead of
+    mis-routing the ladder to a higher tier). Empty / all-unknown
+    bundles surface as a stable empty-shape row (``tiers=[]``,
+    ``min_tier=null``); does NOT short-circuit the batch.
+
+    - **400** when ``bundles`` is missing / non-list / empty.
+    - **Never 5xxs**: a resolver failure yields the fallback envelope
+      (empty ``bundles`` list) so the pricing surface keeps rendering.
+    """
+    body = request.get_json(silent=True) or {}
+    bundles, err = _parse_bundles_body(body)
+    if err == "missing":
+        return jsonify({"error": "missing bundles"}), 400
+    if err == "empty":
+        return jsonify({"error": "empty bundles"}), 400
+    if err == "bundles_must_be_list":
+        return jsonify({"error": "bundles must be a list"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        rows = _ent.tiers_for_features_batch(bundles)
+        env = _resolver_envelope(_ent)
+        return jsonify(
+            {
+                "bundles": list(rows),
+                "count": len(rows),
+                **env,
+            }
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_tiers_for_features_batch: error: %s", exc
+        )
+        return jsonify(
+            {
+                "bundles": [],
+                "count": 0,
+                "current_tier": "oss",
+                "current_tier_rank": 0,
+                "grace": True,
+                "enforced": False,
+            }
+        )
+
+
+@bp_entitlement.route(
+    "/api/entitlement/tiers-for-runtimes-batch",
+    methods=["POST"],
+)
+def api_entitlement_tiers_for_runtimes_batch():
+    """``POST /api/entitlement/tiers-for-runtimes-batch`` -- runtime-axis
+    twin of ``/api/entitlement/tiers-for-features-batch``.
+
+    Same never-5xx posture, same partial-unknown bucketing, same POST
+    envelope. Runtime aliases (``claude-code`` -> ``claude_code``) are
+    canonicalised per bundle through
+    :func:`clawmetry.entitlements.canonical_runtime` so a caller does
+    not need to normalise before calling; unknown ids land in the per-
+    bundle ``unknown`` and drop from the intersection (a typo does NOT
+    silently mis-route the ladder to a higher tier).
+
+    Request body::
+
+        {
+          "bundles": [
+            ["claude_code", "codex"],
+            ["openclaw"],
+            []
+          ]
+        }
+
+    Response shape and error paths mirror
+    ``/tiers-for-features-batch`` exactly, with ``kind="runtimes"`` per
+    row (``items`` is the runtime list).
+    """
+    body = request.get_json(silent=True) or {}
+    bundles, err = _parse_bundles_body(body)
+    if err == "missing":
+        return jsonify({"error": "missing bundles"}), 400
+    if err == "empty":
+        return jsonify({"error": "empty bundles"}), 400
+    if err == "bundles_must_be_list":
+        return jsonify({"error": "bundles must be a list"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        rows = _ent.tiers_for_runtimes_batch(bundles)
+        env = _resolver_envelope(_ent)
+        return jsonify(
+            {
+                "bundles": list(rows),
+                "count": len(rows),
+                **env,
+            }
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_tiers_for_runtimes_batch: error: %s", exc
+        )
+        return jsonify(
+            {
+                "bundles": [],
+                "count": 0,
+                "current_tier": "oss",
+                "current_tier_rank": 0,
+                "grace": True,
+                "enforced": False,
+            }
+        )
+
+
+@bp_entitlement.route(
     "/api/entitlement/min-tier-for-features-at-batch",
     methods=["POST"],
 )

--- a/tests/test_entitlement_tiers_for_bundle_batch.py
+++ b/tests/test_entitlement_tiers_for_bundle_batch.py
@@ -1,0 +1,423 @@
+"""Tests for the bundle-batch ``/api/entitlement/tiers-for-features-batch``
+and ``/api/entitlement/tiers-for-runtimes-batch`` endpoints (plus their
+:func:`clawmetry.entitlements.tiers_for_features_batch` /
+:func:`clawmetry.entitlements.tiers_for_runtimes_batch` helpers).
+
+Fills the bundle-axis batch slot alongside the singular
+``/tiers-for-features`` / ``/tiers-for-runtimes`` endpoints (which fold
+ONE bundle to ONE ladder) so a pricing-matrix surface comparing several
+hypothetical feature/runtime sets renders off ONE round-trip instead of
+N calls to the singular endpoints. Same relationship the existing
+``/min-tier-for-features-batch`` has to ``/min-tier-for-features``.
+
+These tests pin:
+
+  * helper: bundle normalisation (whitespace, lowercase, dedup preserving
+    first-seen order), unknown-id bucketing, runtime alias
+    canonicalisation, empty / all-unknown bundles surface as a stable row
+  * helper: per-row parity with the singular helper
+    (``tiers_for_features_batch([b])[0]`` byte-equals ``tiers_for_features(b)``)
+  * API happy path: shape, resolver envelope, ``count``
+  * API error paths: 400 on missing / non-list / empty ``bundles``
+  * API per-row body byte-equals the bare singular endpoint body minus
+    the resolver envelope
+  * API never-5xxs on a delegate crash
+  * grace vs enforce yields byte-identical per-row bodies (rows are
+    perspective-independent)
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# ── helper: features batch ────────────────────────────────────────────────
+
+
+def test_helper_features_batch_returns_list(ent):
+    rows = ent.tiers_for_features_batch([["fleet"], ["otel_export"]])
+    assert isinstance(rows, list)
+    assert len(rows) == 2
+
+
+def test_helper_features_batch_row_shape(ent):
+    rows = ent.tiers_for_features_batch([["fleet", "sso"]])
+    row = rows[0]
+    assert set(row.keys()) == {
+        "items",
+        "unknown",
+        "kind",
+        "count",
+        "min_tier",
+        "min_tier_label",
+        "min_tier_rank",
+        "tiers",
+    }
+    assert row["kind"] == "features"
+
+
+def test_helper_features_batch_dedups_and_lowers(ent):
+    """Delegates to :func:`tiers_for_features` per bundle, so normalisation
+    matches the singular helper byte-for-byte: whitespace stripped,
+    lowercased, deduplicated preserving first-seen order."""
+    rows = ent.tiers_for_features_batch(
+        [["fleet", "SSO", "fleet"], ["otel_export"]]
+    )
+    assert rows[0]["items"] == ["fleet", "sso"]
+    assert rows[0]["count"] == 2
+    assert rows[1]["items"] == ["otel_export"]
+
+
+def test_helper_features_batch_buckets_unknown(ent):
+    rows = ent.tiers_for_features_batch([["fleet", "bogus"]])
+    assert rows[0]["items"] == ["fleet"]
+    assert rows[0]["unknown"] == ["bogus"]
+    # Unknown does NOT mis-route the ladder to a higher tier.
+    assert rows[0]["min_tier"] == ent.min_tier_for_features(["fleet"])
+
+
+def test_helper_features_batch_empty_bundle_is_stable_row(ent):
+    rows = ent.tiers_for_features_batch([[]])
+    assert len(rows) == 1
+    assert rows[0]["items"] == []
+    assert rows[0]["unknown"] == []
+    assert rows[0]["count"] == 0
+    assert rows[0]["min_tier"] is None
+    assert rows[0]["tiers"] == []
+
+
+def test_helper_features_batch_all_unknown_is_stable_row(ent):
+    rows = ent.tiers_for_features_batch([["bogus", "also-bogus"]])
+    assert rows[0]["items"] == []
+    # Bare hyphen ids get lowercased but the raw string still lands.
+    assert set(rows[0]["unknown"]) == {"bogus", "also-bogus"}
+    assert rows[0]["min_tier"] is None
+    assert rows[0]["tiers"] == []
+
+
+def test_helper_features_batch_none_bundles_is_empty(ent):
+    assert ent.tiers_for_features_batch(None) == []
+
+
+def test_helper_features_batch_non_iterable_is_empty(ent):
+    assert ent.tiers_for_features_batch(123) == []
+
+
+def test_helper_features_batch_none_per_bundle_is_stable_row(ent):
+    rows = ent.tiers_for_features_batch([None, ["fleet"]])
+    assert len(rows) == 2
+    assert rows[0]["items"] == []
+    assert rows[0]["count"] == 0
+    assert rows[0]["tiers"] == []
+    assert rows[1]["items"] == ["fleet"]
+
+
+def test_helper_features_batch_row_equals_singular(ent):
+    for bundle in (["fleet", "sso"], ["otel_export"], ["fleet", "bogus"], []):
+        rows = ent.tiers_for_features_batch([bundle])
+        assert rows[0] == ent.tiers_for_features(bundle)
+
+
+def test_helper_features_batch_free_bundle_covers_all_tiers(ent):
+    # A bundle of only free features must be available at every tier.
+    free_ids = list(sorted(ent.FREE_FEATURES))[:2]
+    rows = ent.tiers_for_features_batch([free_ids])
+    tier_ids = {t["id"] for t in rows[0]["tiers"]}
+    assert tier_ids == set(ent._TIER_ORDER)
+    assert rows[0]["min_tier"] == ent.TIER_OSS
+
+
+# ── helper: runtimes batch ────────────────────────────────────────────────
+
+
+def test_helper_runtimes_batch_row_shape(ent):
+    rows = ent.tiers_for_runtimes_batch([["openclaw"]])
+    assert set(rows[0].keys()) == {
+        "items",
+        "unknown",
+        "kind",
+        "count",
+        "min_tier",
+        "min_tier_label",
+        "min_tier_rank",
+        "tiers",
+    }
+    assert rows[0]["kind"] == "runtimes"
+
+
+def test_helper_runtimes_batch_canonicalises_alias(ent):
+    # ``claude-code`` (hyphen) should canonicalise to ``claude_code``.
+    rows = ent.tiers_for_runtimes_batch([["claude-code"]])
+    assert rows[0]["items"] == ["claude_code"]
+    assert rows[0]["unknown"] == []
+
+
+def test_helper_runtimes_batch_row_equals_singular(ent):
+    for bundle in (["openclaw"], ["claude_code", "codex"], ["bogus"], []):
+        rows = ent.tiers_for_runtimes_batch([bundle])
+        assert rows[0] == ent.tiers_for_runtimes(bundle)
+
+
+def test_helper_runtimes_batch_free_runtimes_appear_everywhere(ent):
+    rows = ent.tiers_for_runtimes_batch([list(sorted(ent.FREE_RUNTIMES))])
+    tier_ids = {t["id"] for t in rows[0]["tiers"]}
+    assert tier_ids == set(ent._TIER_ORDER)
+
+
+def test_helper_runtimes_batch_paid_runtimes_skip_floor(ent):
+    paid = list(sorted(ent.PAID_RUNTIMES))[:1]
+    rows = ent.tiers_for_runtimes_batch([paid])
+    tier_ids = {t["id"] for t in rows[0]["tiers"]}
+    assert ent.TIER_OSS not in tier_ids
+    assert ent.TIER_CLOUD_FREE not in tier_ids
+
+
+def test_helper_runtimes_batch_none_bundles_is_empty(ent):
+    assert ent.tiers_for_runtimes_batch(None) == []
+
+
+def test_helper_runtimes_batch_non_iterable_is_empty(ent):
+    assert ent.tiers_for_runtimes_batch(42) == []
+
+
+# ── perspective independence ─────────────────────────────────────────────
+
+
+def test_helper_features_batch_grace_vs_enforce_same_rows(monkeypatch, ent):
+    """Rows are decoupled from the resolved entitlement -- they walk the
+    static per-tier feature map, not the caller's tier. Flipping enforce
+    on must yield byte-identical rows."""
+    grace_rows = ent.tiers_for_features_batch(
+        [["fleet", "sso"], ["otel_export"], []]
+    )
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    enforce_rows = ent.tiers_for_features_batch(
+        [["fleet", "sso"], ["otel_export"], []]
+    )
+    assert grace_rows == enforce_rows
+
+
+# ── API: features batch ──────────────────────────────────────────────────
+
+
+def test_api_features_batch_happy_path(client):
+    r = client.post(
+        "/api/entitlement/tiers-for-features-batch",
+        json={"bundles": [["fleet", "sso"], ["otel_export"]]},
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert set(body.keys()) >= {
+        "bundles",
+        "count",
+        "current_tier",
+        "current_tier_rank",
+        "grace",
+        "enforced",
+    }
+    assert body["count"] == 2
+    assert len(body["bundles"]) == 2
+    assert body["bundles"][0]["kind"] == "features"
+
+
+def test_api_features_batch_row_shape(client):
+    r = client.post(
+        "/api/entitlement/tiers-for-features-batch",
+        json={"bundles": [["fleet", "sso"]]},
+    )
+    row = r.get_json()["bundles"][0]
+    assert set(row.keys()) == {
+        "items",
+        "unknown",
+        "kind",
+        "count",
+        "min_tier",
+        "min_tier_label",
+        "min_tier_rank",
+        "tiers",
+    }
+
+
+def test_api_features_batch_row_byte_equals_helper(client, ent):
+    bundles = [["fleet", "sso"], ["otel_export"], []]
+    r = client.post(
+        "/api/entitlement/tiers-for-features-batch",
+        json={"bundles": bundles},
+    )
+    body = r.get_json()
+    for row, bundle in zip(body["bundles"], bundles):
+        assert row == ent.tiers_for_features(bundle)
+
+
+def test_api_features_batch_missing_bundles_400(client):
+    r = client.post(
+        "/api/entitlement/tiers-for-features-batch",
+        json={},
+    )
+    assert r.status_code == 400
+    assert "bundles" in r.get_json()["error"]
+
+
+def test_api_features_batch_empty_bundles_400(client):
+    r = client.post(
+        "/api/entitlement/tiers-for-features-batch",
+        json={"bundles": []},
+    )
+    assert r.status_code == 400
+    assert "empty" in r.get_json()["error"]
+
+
+def test_api_features_batch_non_list_bundles_400(client):
+    r = client.post(
+        "/api/entitlement/tiers-for-features-batch",
+        json={"bundles": "fleet,sso"},
+    )
+    assert r.status_code == 400
+
+
+def test_api_features_batch_bare_list_of_strings_is_one_bundle(client):
+    """The bundles-shorthand documented on the endpoint: a bare list of
+    strings is treated as ONE bundle."""
+    r = client.post(
+        "/api/entitlement/tiers-for-features-batch",
+        json={"bundles": ["fleet", "sso"]},
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["count"] == 1
+    assert body["bundles"][0]["items"] == ["fleet", "sso"]
+
+
+def test_api_features_batch_never_5xxs_on_delegate_crash(client, monkeypatch, ent):
+    def _boom(*_a, **_k):
+        raise RuntimeError("resolver on fire")
+
+    monkeypatch.setattr(ent, "tiers_for_features_batch", _boom)
+    r = client.post(
+        "/api/entitlement/tiers-for-features-batch",
+        json={"bundles": [["fleet"]]},
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["bundles"] == []
+    assert body["count"] == 0
+    assert body["grace"] is True
+
+
+def test_api_features_batch_all_unknown_row_still_populates(client):
+    r = client.post(
+        "/api/entitlement/tiers-for-features-batch",
+        json={"bundles": [["bogus"]]},
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    row = body["bundles"][0]
+    assert row["items"] == []
+    assert row["unknown"] == ["bogus"]
+    assert row["min_tier"] is None
+    assert row["tiers"] == []
+
+
+# ── API: runtimes batch ──────────────────────────────────────────────────
+
+
+def test_api_runtimes_batch_happy_path(client):
+    r = client.post(
+        "/api/entitlement/tiers-for-runtimes-batch",
+        json={"bundles": [["claude_code", "codex"], ["openclaw"]]},
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["count"] == 2
+    assert body["bundles"][0]["kind"] == "runtimes"
+
+
+def test_api_runtimes_batch_row_byte_equals_helper(client, ent):
+    bundles = [["claude_code", "codex"], ["openclaw"], []]
+    r = client.post(
+        "/api/entitlement/tiers-for-runtimes-batch",
+        json={"bundles": bundles},
+    )
+    body = r.get_json()
+    for row, bundle in zip(body["bundles"], bundles):
+        assert row == ent.tiers_for_runtimes(bundle)
+
+
+def test_api_runtimes_batch_canonicalises_alias(client):
+    r = client.post(
+        "/api/entitlement/tiers-for-runtimes-batch",
+        json={"bundles": [["claude-code"]]},
+    )
+    body = r.get_json()
+    assert body["bundles"][0]["items"] == ["claude_code"]
+
+
+def test_api_runtimes_batch_missing_bundles_400(client):
+    r = client.post(
+        "/api/entitlement/tiers-for-runtimes-batch",
+        json={},
+    )
+    assert r.status_code == 400
+
+
+def test_api_runtimes_batch_empty_bundles_400(client):
+    r = client.post(
+        "/api/entitlement/tiers-for-runtimes-batch",
+        json={"bundles": []},
+    )
+    assert r.status_code == 400
+
+
+def test_api_runtimes_batch_never_5xxs_on_delegate_crash(client, monkeypatch, ent):
+    def _boom(*_a, **_k):
+        raise RuntimeError("resolver on fire")
+
+    monkeypatch.setattr(ent, "tiers_for_runtimes_batch", _boom)
+    r = client.post(
+        "/api/entitlement/tiers-for-runtimes-batch",
+        json={"bundles": [["openclaw"]]},
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["bundles"] == []
+    assert body["count"] == 0
+
+
+# ── envelope parity ──────────────────────────────────────────────────────
+
+
+def test_api_batch_envelope_matches_resolver(client, ent):
+    r = client.post(
+        "/api/entitlement/tiers-for-features-batch",
+        json={"bundles": [["fleet"]]},
+    )
+    body = r.get_json()
+    ent_obj = ent.get_entitlement()
+    assert body["current_tier"] == ent_obj.tier
+    assert body["current_tier_rank"] == ent.tier_rank(ent_obj.tier)
+    assert body["grace"] is bool(ent_obj.grace)
+    assert body["enforced"] is ent.is_enforced()


### PR DESCRIPTION
## Summary

Fills the bundle-axis batch slot on the `tiers_for_*` surface alongside the existing `/min-tier-for-features-batch` / `/min-tier-for-runtimes-batch` endpoints. Where the singular `/tiers-for-features` folds ONE bundle of features to ONE ladder of tiers, the new `/tiers-for-features-batch` (POST) folds N bundles to N ladders in ONE round-trip so a pricing-matrix / upgrade-walkthrough comparing several hypothetical feature sets ("Starter add-ons vs Pro add-ons vs Enterprise add-ons") renders off one call instead of N calls to `/tiers-for-features`.

Same relationship the singular `/tiers-for-features` has to `/min-tier-for-features`:

- `/min-tier-for-features-batch` collapses each bundle to a single cheapest `required_tier`
- `/tiers-for-features-batch` returns the FULL ladder per bundle so an "Available in: Starter, Cloud Pro, ..." tooltip renders directly off each row

- **`clawmetry/entitlements.py`** — `tiers_for_features_batch(bundles)` and `tiers_for_runtimes_batch(bundles)`. Delegate per-bundle to the singular `tiers_for_features` / `tiers_for_runtimes` (so grace vs enforce yields byte-identical rows and batch normalisation stays in lockstep with the singular endpoint). Never raise: per-bundle failures short-circuit to the empty-shape row.
- **`routes/entitlement.py`** — `POST /api/entitlement/tiers-for-features-batch` and `POST /api/entitlement/tiers-for-runtimes-batch`. Reuse the existing `_parse_bundles_body` + `_resolver_envelope` helpers so the POST envelope, per-row body, and 400 error paths match the sibling `/min-tier-for-*-batch` endpoints exactly.
- **`tests/test_entitlement_tiers_for_bundle_batch.py`** (new, 35 tests) — helper normalisation, per-row parity with singular helper (`tiers_for_features_batch([b])[0] == tiers_for_features(b)`), alias canonicalisation (`claude-code` → `claude_code`), perspective independence (grace == enforce), API 400 paths on missing / non-list / empty `bundles`, API never-5xxs on delegate crash, envelope parity with the resolver.

## Test plan

- [x] `python3 -m pytest tests/test_entitlement_tiers_for_bundle_batch.py -v` → **35 passed**
- [x] Regression: `python3 -m pytest tests/test_entitlement_tiers_for.py tests/test_entitlement_tiers_for_plural.py tests/test_entitlement_tiers_for_batch.py tests/test_entitlement_min_tier_for_bundle_batch.py tests/test_entitlement_api.py tests/test_entitlement_tiers_for_at.py` → **279 passed**
- [x] `python3 -m py_compile clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_tiers_for_bundle_batch.py` — syntax clean

## Local operator verification checklist

(This session runs against the public open-source repo only — no access to the running daemon, host filesystem, live cloud snapshot, or a browser — so the steps below cover what only the local operator can perform.)

- [ ] Copy the changed files into the site-packages install:
  ```
  cp clawmetry/entitlements.py ~/.clawmetry/lib/python3.*/site-packages/clawmetry/
  cp routes/entitlement.py ~/.clawmetry/lib/python3.*/site-packages/routes/
  find ~/.clawmetry/lib -name __pycache__ -exec rm -rf {} +
  ```
- [ ] Restart the daemon so the new routes are picked up:
  ```
  launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync
  ```
- [ ] Confirm the new endpoints answer:
  ```
  curl -s -XPOST -H 'Content-Type: application/json' \
    -d '{"bundles":[["fleet","sso"],["otel_export"],[]]}' \
    http://localhost:8900/api/entitlement/tiers-for-features-batch | jq '.count, .bundles[0].min_tier'
  # expect: 3, "enterprise"

  curl -s -XPOST -H 'Content-Type: application/json' \
    -d '{"bundles":[["claude_code","codex"],["openclaw"]]}' \
    http://localhost:8900/api/entitlement/tiers-for-runtimes-batch | jq '.bundles[0].kind, .bundles[1].min_tier'
  # expect: "runtimes", "oss"

  curl -s -XPOST -H 'Content-Type: application/json' -d '{}' \
    http://localhost:8900/api/entitlement/tiers-for-features-batch
  # expect: 400 + {"error":"missing bundles"}
  ```
- [ ] Confirm per-row parity with the singular endpoint on a live install:
  ```
  curl -s "http://localhost:8900/api/entitlement/tiers-for-features?features=fleet,sso" | jq 'del(.current_tier,.current_tier_rank,.grace,.enforced)' > /tmp/singular.json
  curl -s -XPOST -H 'Content-Type: application/json' -d '{"bundles":[["fleet","sso"]]}' \
    http://localhost:8900/api/entitlement/tiers-for-features-batch | jq '.bundles[0]' > /tmp/batch.json
  diff /tmp/singular.json /tmp/batch.json
  # expect: empty diff
  ```
- [ ] Decrypt the live cloud snapshot after any subsequent release to confirm no snapshot shape changed (this PR adds read-only endpoints; no snapshot fields move).

---
_Generated by [Claude Code](https://claude.ai/code/session_019L6hPA3v6m8AnAoWjKMzXy)_