### PR TITLE
feat(openclaw): surface who's-online presence roster from gateway.status (#3884)

### DIFF
--- a/clawmetry/adapters/openclaw.py
+++ b/clawmetry/adapters/openclaw.py
@@ -1478,6 +1478,76 @@ def _gateway_host_status() -> dict:
         return {}
 
 
+def _gateway_presence_roster() -> dict:
+    """Who's-online presence roster from the OpenClaw gateway.status RPC (#3884).
+
+    As of the Control UI who's-online roster release, the gateway.status response
+    includes a list of currently-connected users under a ``connectedUsers`` (or
+    ``onlineUsers`` / ``presence``) key.  Each entry carries at minimum an
+    ``email`` field; ``displayName`` and ``avatar`` (or ``avatarUrl``) are
+    included when the user's profile is populated.
+
+    Returns a dict with:
+    - ``"gatewayPresenceRoster"`` — list of normalized user dicts, each with
+      ``email`` (str), and optionally ``displayName`` (str) and ``avatar`` (str).
+    - ``"gatewayPresenceCount"`` — number of online users.
+
+    Returns ``{}`` when the RPC is unavailable, carries no user list, or the
+    list is empty. Never raises.
+    """
+    try:
+        d = _d()
+        rpc = getattr(d, "_gw_ws_rpc", None)
+        if rpc is None:
+            return {}
+        payload = rpc("gateway.status")
+        if not isinstance(payload, dict):
+            return {}
+        raw_users = (
+            payload.get("connectedUsers")
+            or payload.get("connected_users")
+            or payload.get("onlineUsers")
+            or payload.get("online_users")
+            or payload.get("presence")
+        )
+        if not isinstance(raw_users, list) or not raw_users:
+            return {}
+        roster = []
+        for entry in raw_users:
+            if not isinstance(entry, dict):
+                continue
+            email = (
+                entry.get("email")
+                or entry.get("emailAddress")
+                or entry.get("email_address")
+            )
+            if not email:
+                continue
+            user: dict = {"email": str(email)}
+            display_name = (
+                entry.get("displayName")
+                or entry.get("display_name")
+                or entry.get("name")
+            )
+            if display_name:
+                user["displayName"] = str(display_name)
+            avatar = (
+                entry.get("avatar")
+                or entry.get("avatarUrl")
+                or entry.get("avatar_url")
+                or entry.get("photoUrl")
+                or entry.get("photo_url")
+            )
+            if avatar:
+                user["avatar"] = str(avatar)
+            roster.append(user)
+        if not roster:
+            return {}
+        return {"gatewayPresenceRoster": roster, "gatewayPresenceCount": len(roster)}
+    except Exception:
+        return {}
+
+
 class OpenClawAdapter(AgentAdapter):
     name = "openclaw"
     display_name = "OpenClaw"
@@ -1555,6 +1625,9 @@ class OpenClawAdapter(AgentAdapter):
                 # Gateway host/system status (#3551): host name, OS, runtime,
                 # uptime, CPU, memory, disk from the same gateway.status RPC.
                 meta.update(_gateway_host_status())
+                # Who's-online presence roster (#3884): connected users from the
+                # Control UI facepile, via the same gateway.status RPC.
+                meta.update(_gateway_presence_roster())
             # Docker runtime health (#3390): the NemoClaw harness treats Docker
             # daemon liveness as a distinct signal from gateway liveness. Only
             # written when docker CLI is present so non-Docker environments are

--- a/tests/test_obs_gap_openclaw_presence_roster_3884.py
+++ b/tests/test_obs_gap_openclaw_presence_roster_3884.py
@@ -1,0 +1,144 @@
+"""Tests for issue #3884 — openclaw: who's-online presence roster.
+
+Verifies that _gateway_presence_roster() extracts connected-user entries from
+the gateway.status RPC response and surfaces them on DetectResult.meta.
+
+Fingerprint: hgap-5d37b03e2e (used to dedupe — keep it in the body).
+"""
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _restore_sys_modules():
+    """Restore sys.modules entries clobbered by _make_mock_dashboard/_reload_adapter."""
+    saved_dashboard = sys.modules.get("dashboard")
+    saved_adapter = sys.modules.get("clawmetry.adapters.openclaw")
+    yield
+    if saved_dashboard is None:
+        sys.modules.pop("dashboard", None)
+    else:
+        sys.modules["dashboard"] = saved_dashboard
+    if saved_adapter is None:
+        sys.modules.pop("clawmetry.adapters.openclaw", None)
+    else:
+        sys.modules["clawmetry.adapters.openclaw"] = saved_adapter
+
+
+def _make_mock_dashboard(rpc_return):
+    """Return a minimal mock dashboard module with _gw_ws_rpc wired up."""
+    mod = types.ModuleType("dashboard")
+    mod._gw_ws_rpc = lambda method, params=None: rpc_return
+    sys.modules["dashboard"] = mod
+    return mod
+
+
+def _reload_adapter():
+    import clawmetry.adapters.openclaw as oc_mod
+    importlib.reload(oc_mod)
+    return oc_mod
+
+
+def test_full_roster_returned():
+    """All user fields are extracted when the RPC returns a connectedUsers list."""
+    _make_mock_dashboard({
+        "connectedUsers": [
+            {
+                "email": "alice@example.com",
+                "displayName": "Alice",
+                "avatar": "https://example.com/alice.png",
+            },
+            {
+                "email": "bob@example.com",
+                "displayName": "Bob",
+                "avatarUrl": "https://example.com/bob.png",
+            },
+        ],
+    })
+    oc = _reload_adapter()
+    result = oc._gateway_presence_roster()
+    assert result["gatewayPresenceCount"] == 2
+    roster = result["gatewayPresenceRoster"]
+    assert len(roster) == 2
+    assert roster[0]["email"] == "alice@example.com"
+    assert roster[0]["displayName"] == "Alice"
+    assert roster[0]["avatar"] == "https://example.com/alice.png"
+    assert roster[1]["email"] == "bob@example.com"
+    assert roster[1]["displayName"] == "Bob"
+    assert roster[1]["avatar"] == "https://example.com/bob.png"
+
+
+def test_fallback_key_variants_resolved():
+    """Alternate key spellings (onlineUsers, email_address, display_name) are tried."""
+    _make_mock_dashboard({
+        "onlineUsers": [
+            {
+                "email_address": "carol@example.com",
+                "display_name": "Carol",
+                "photo_url": "https://example.com/carol.png",
+            },
+        ],
+    })
+    oc = _reload_adapter()
+    result = oc._gateway_presence_roster()
+    assert result["gatewayPresenceCount"] == 1
+    user = result["gatewayPresenceRoster"][0]
+    assert user["email"] == "carol@example.com"
+    assert user["displayName"] == "Carol"
+    assert user["avatar"] == "https://example.com/carol.png"
+
+
+def test_entry_without_email_skipped():
+    """User entries missing an email are silently dropped; valid entries kept."""
+    _make_mock_dashboard({
+        "connectedUsers": [
+            {"displayName": "Ghost"},
+            {"email": "real@example.com", "displayName": "Real"},
+        ],
+    })
+    oc = _reload_adapter()
+    result = oc._gateway_presence_roster()
+    assert result["gatewayPresenceCount"] == 1
+    assert result["gatewayPresenceRoster"][0]["email"] == "real@example.com"
+
+
+def test_empty_user_list_gives_empty_dict():
+    """A gateway.status response with an empty connectedUsers list returns {}."""
+    _make_mock_dashboard({"connectedUsers": []})
+    oc = _reload_adapter()
+    assert oc._gateway_presence_roster() == {}
+
+
+def test_no_presence_key_gives_empty_dict():
+    """A gateway.status response with only plugins and no user roster returns {}."""
+    _make_mock_dashboard({
+        "plugins": [{"name": "telegram", "state": "loaded"}],
+        "hostName": "mybox",
+    })
+    oc = _reload_adapter()
+    assert oc._gateway_presence_roster() == {}
+
+
+def test_rpc_returns_none_gives_empty_dict():
+    """When the RPC returns None (gateway down), return {}."""
+    _make_mock_dashboard(None)
+    oc = _reload_adapter()
+    assert oc._gateway_presence_roster() == {}
+
+
+def test_optional_fields_absent_when_not_in_entry():
+    """displayName and avatar are omitted from the user dict when not provided."""
+    _make_mock_dashboard({
+        "presence": [{"email": "minimal@example.com"}],
+    })
+    oc = _reload_adapter()
+    result = oc._gateway_presence_roster()
+    user = result["gatewayPresenceRoster"][0]
+    assert user["email"] == "minimal@example.com"
+    assert "displayName" not in user
+    assert "avatar" not in user


### PR DESCRIPTION
## Summary

The OpenClaw Control UI's who's-online facepile exposes a connected-user roster (email, displayName, avatar) via the `gateway.status` RPC, but the adapter never read or surfaced it. This PR adds `_gateway_presence_roster()` to the OpenClaw adapter, wires it into `detect()`, and tests it.

## Changes

- **`clawmetry/adapters/openclaw.py`** — new `_gateway_presence_roster()` function (follows the exact same pattern as `_gateway_plugin_health()` and `_gateway_host_status()`): calls `rpc("gateway.status")`, extracts `connectedUsers` / `connected_users` / `onlineUsers` / `online_users` / `presence` array, normalizes each entry to `{email, displayName?, avatar?}`, returns `{"gatewayPresenceRoster": [...], "gatewayPresenceCount": N}` or `{}` when no users are online. Called inside the `if running:` block in `detect()`.
- **`tests/test_obs_gap_openclaw_presence_roster_3884.py`** — 7 tests: full roster with all fields, fallback key variants (snake_case, `onlineUsers`, `email_address`, `photo_url`), entry missing email is skipped, empty list, no presence key in payload, RPC returns None, optional fields absent when not provided.

## Test plan

- [ ] `python3 -m pytest tests/test_obs_gap_openclaw_presence_roster_3884.py -v` — 7/7 pass locally
- [ ] Sibling tests `test_obs_gap_openclaw_gateway_host_status_3551.py` and `test_obs_gap_openclaw_gateway_plugin_health_3200.py` — 10/10 still pass (no regressions)
- [ ] `python3 -c 'import ast; ast.parse(open("clawmetry/adapters/openclaw.py").read())'` — clean

## Bot meta

<!-- bot-autofix -->
Draft PR opened autonomously based on the plan in #3884. Marked draft for human review — mark Ready for Review once happy.

Closes #3884

---
_Generated by [Claude Code](https://claude.ai/code/session_01RB6yKFaescBd6raDFjLvhu)_