### PR TITLE
fix: correct routes/meta.py blueprint list and version in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ All HTTP endpoints live here, organised by feature. Each module owns one or more
 | `routes/infra.py` | ~2,400 | `bp_logs` + `bp_memory` + `bp_security` + `bp_config` — logs stream, memory files, security posture, cost-optimizer |
 | `routes/overview.py` | ~1,900 | `bp_overview` — main dashboard endpoint, channels list, timeline, cloud-CTA OTP |
 | `routes/crons.py` | ~1,500 | `bp_crons` — cron CRUD + run log + health summary |
-| `routes/meta.py` | ~1,600 | `bp_auth` + `bp_gateway` + `bp_otel` + `bp_version` + `bp_version_impact` + `bp_clusters` — auth, gateway proxy, OTLP ingestion, version meta |
+| `routes/meta.py` | ~1,600 | `bp_auth` + `bp_gateway` + `bp_otel` + `bp_version` + `bp_version_impact` + `bp_cloud_relay` + `bp_otlp_traces` — auth, gateway proxy, OTLP ingestion, version meta |
 | `routes/alerts.py` | ~980 | `bp_alerts` + `bp_budget` — alert rules, webhooks, velocity, budget config |
 | `routes/fleet_history.py` | ~240 | `bp_fleet` + `bp_history` — multi-node fleet + SQLite time-series |
 | `routes/nemoclaw.py` | ~125 | `bp_nemoclaw` — NeMo Guardrails governance + approval queue |
@@ -146,7 +146,7 @@ Tests use `CLAWMETRY_URL` and `CLAWMETRY_TOKEN` env vars. Test matrix in CI: 3 O
 ## Deploy
 - **PyPI**: `pip install clawmetry && clawmetry`
 - **Docker**: `docker build -t clawmetry . && docker run -p 8900:8900 -v ~/.openclaw:/root/.openclaw:ro clawmetry`
-- **Current version**: `0.12.554` (in `dashboard.py` `__version__`)
+- **Current version**: `0.12.565` (in `dashboard.py` `__version__`)
 
 ## CI/CD (GitHub Actions)
 - `ci.yml` — Lint + test matrix on push/PR


### PR DESCRIPTION
Closes #3889

## Summary

- **`bp_clusters` → `bp_cloud_relay` + `bp_otlp_traces`**: The `routes/meta.py` table row in CLAUDE.md listed a `bp_clusters` blueprint that does not exist. The two blueprints actually defined in that file but missing from the docs were `bp_cloud_relay` and `bp_otlp_traces`.
- **Version string**: Updated the "Current version" reference on line 149 from `0.12.554` to `0.12.565` to match `dashboard.py:263`.

## Test plan

- [ ] No Python files changed — lint/test suite unaffected.
- [ ] Verify `grep bp_clusters routes/meta.py` returns empty (it does).
- [ ] Verify `grep __version__ dashboard.py` shows `0.12.565` (it does).

---
_Generated by [Claude Code](https://claude.ai/code/session_01F9hw1JdDRuyFV4UZFDJxx7)_