### PR TITLE
feat(entitlement): tiers_for_features_at_batch + tiers_for_runtimes_at_batch (+2 endpoints)

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -5321,6 +5321,97 @@ def tiers_for_runtimes_at(
         return None
 
 
+def tiers_for_features_at_batch(
+    perspective_tier: str, bundles
+) -> list[dict] | None:
+    """Hypothetical-perspective sibling of :func:`tiers_for_features_batch`:
+    per-bundle full ladder-intersection for N caller-supplied feature bundles
+    in one round-trip, scoped by a caller-supplied ``perspective_tier``.
+
+    Same relationship to :func:`tiers_for_features_batch` that
+    :func:`tiers_for_features_at` has to :func:`tiers_for_features` and
+    :func:`min_tier_for_features_at_batch` has to
+    :func:`min_tier_for_features_batch`: the ``perspective_tier`` argument
+    tells the helper which resolver / plan the caller is answering from so
+    an ``_at`` endpoint URL can be uniform across the whole ``_at`` batch
+    family (every ``_at`` sibling accepts a ``tier=<perspective>`` query
+    arg), even though the underlying answer is inherently perspective-
+    independent -- :func:`tiers_for_features_batch` walks the static per-
+    tier feature map, so the per-row body does not depend on where the
+    caller is standing. A parity test pins ``tiers_for_features_at_batch(p,
+    bs) == tiers_for_features_batch(bs)`` for every ``p`` in
+    :data:`_TIER_ORDER` so the ``_at`` prefix cannot silently drift into
+    shaping rows.
+
+    Fills the ``_at`` slot on the bundle-axis batch tiers-for family
+    alongside :func:`min_tier_for_features_at_batch` (per-bundle cheapest
+    tier what-if), :func:`affordable_tiers_at_batch` (per-item plural
+    what-if) and :func:`tiers_for_features_at` (singular what-if) so a
+    pricing-matrix walkthrough can call ``X_at(perspective, ...)``
+    uniformly across the whole ``_at`` surface.
+
+    Row shape mirrors :func:`tiers_for_features_batch` exactly -- each row
+    is byte-identical to the equivalent :func:`tiers_for_features` body
+    for that bundle. Per-bundle normalisation (whitespace stripped,
+    lowercased, deduplicated preserving first-seen order; unknown ids
+    bucketed into the per-bundle ``unknown``) is inherited from
+    :func:`tiers_for_features_batch` unchanged. Empty / all-unknown bundles
+    surface as the stable empty-shape row (``tiers=[]``, ``min_tier=None``);
+    does NOT short-circuit the batch.
+
+    Perspective is validated against :data:`_TIER_ORDER` (including
+    :data:`TIER_TRIAL`); returns ``None`` for empty / unknown
+    ``perspective_tier`` (caller renders "unknown tier" / 404), matching
+    the ``None`` posture the rest of the ``_at_batch`` family uses for
+    the perspective-validation failure mode. Never raises: a delegation
+    failure logs a warning and returns ``None`` so a pricing-matrix
+    walkthrough keeps rendering.
+    """
+    try:
+        p = (perspective_tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if not p or p not in _TIER_ORDER:
+        return None
+    try:
+        return tiers_for_features_batch(bundles)
+    except Exception as exc:
+        logger.warning(
+            "entitlements: tiers_for_features_at_batch failed: %s", exc
+        )
+        return None
+
+
+def tiers_for_runtimes_at_batch(
+    perspective_tier: str, bundles
+) -> list[dict] | None:
+    """Runtime-axis twin of :func:`tiers_for_features_at_batch`.
+
+    Same perspective contract, same never-raise posture, same
+    perspective-independence guarantee (delegates to
+    :func:`tiers_for_runtimes_batch`, which walks the static per-tier
+    runtime map). Runtime aliases (``claude-code`` -> ``claude_code``)
+    canonicalise per bundle exactly the way they do on the non-``_at``
+    sibling and the singular :func:`tiers_for_runtimes_at`.
+
+    Returns ``None`` for empty / unknown ``perspective_tier``; all other
+    semantics inherit from :func:`tiers_for_runtimes_batch`.
+    """
+    try:
+        p = (perspective_tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if not p or p not in _TIER_ORDER:
+        return None
+    try:
+        return tiers_for_runtimes_batch(bundles)
+    except Exception as exc:
+        logger.warning(
+            "entitlements: tiers_for_runtimes_at_batch failed: %s", exc
+        )
+        return None
+
+
 def tiers_for_batch_at(perspective_tier: str) -> dict | None:
     """Hypothetical-perspective sibling of :func:`tiers_for_batch`: full
     availability ladder for every known feature *and* runtime in one

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -22403,3 +22403,168 @@ def api_entitlement_min_tier_for_runtimes_at_batch():
                 **env,
             }
         )
+
+
+@bp_entitlement.route(
+    "/api/entitlement/tiers-for-features-at-batch",
+    methods=["POST"],
+)
+def api_entitlement_tiers_for_features_at_batch():
+    """``POST /api/entitlement/tiers-for-features-at-batch?tier=<perspective>``
+    -- what-if sibling of ``/api/entitlement/tiers-for-features-batch``.
+
+    Where the bare batch folds N feature bundles against the LIVE resolved
+    entitlement's grace/enforce envelope, this folds them under a
+    hypothetical ``perspective_tier`` supplied as the ``tier=`` query arg.
+    The per-row body remains perspective-independent -- each row delegates
+    to :func:`clawmetry.entitlements.tiers_for_features`, which walks the
+    static per-tier feature map -- but the outer envelope carries
+    ``perspective_tier`` / ``perspective_tier_label`` /
+    ``perspective_tier_rank`` alongside the live resolver keys so a
+    pricing-matrix walkthrough can hit ``X_at`` uniformly across the whole
+    ``_at`` batch surface.
+
+    Fills the ``_at_batch`` slot on the bundle-axis tiers-for family
+    alongside ``/min-tier-for-features-at-batch`` (per-bundle cheapest
+    tier what-if) and ``/affordable-tiers-at-batch`` (per-item plural
+    what-if) so a pricing-matrix / upgrade-walkthrough can render "if I
+    were on Starter, here are the tier ladders for these three
+    hypothetical feature sets" off ONE round-trip instead of N calls to
+    ``/tiers-for-features-at``.
+
+    Body parity: per-row bodies byte-identical to the bare batch's
+    per-row bodies for the same bundles -- pinned by parity tests so the
+    bare and ``_at`` bodies cannot drift.
+
+    Request body: mirrors ``/tiers-for-features-batch`` exactly. A
+    shorthand ``{"bundles": ["fleet", "sso"]}`` (bare list of strings) is
+    treated as ONE bundle, matching the singular endpoint's bare-CSV
+    posture.
+
+    Response envelope: adds ``perspective_tier`` /
+    ``perspective_tier_label`` / ``perspective_tier_rank`` on top of the
+    bare batch envelope.
+
+    - **400** when ``tier=`` is missing / blank, or when ``bundles`` is
+      missing / non-list / empty.
+    - **404** when ``tier=`` is unknown -- caller renders "unknown tier".
+    - **Never 5xxs**: a resolver failure yields the fallback envelope
+      (empty ``bundles`` list) so the pricing surface keeps rendering.
+    """
+    tier_in = (request.args.get("tier") or "").strip().lower()
+    if not tier_in:
+        return jsonify({"error": "missing tier"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        if tier_in not in _ent._TIER_ORDER:
+            return (
+                jsonify({"error": "unknown tier", "tier": tier_in}),
+                404,
+            )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_tiers_for_features_at_batch: error: %s", exc
+        )
+        return jsonify({"error": "unknown tier", "tier": tier_in}), 404
+
+    body = request.get_json(silent=True) or {}
+    bundles, err = _parse_bundles_body(body)
+    if err == "missing":
+        return jsonify({"error": "missing bundles"}), 400
+    if err == "empty":
+        return jsonify({"error": "empty bundles"}), 400
+    if err == "bundles_must_be_list":
+        return jsonify({"error": "bundles must be a list"}), 400
+
+    try:
+        rows = _ent.tiers_for_features_at_batch(tier_in, bundles) or []
+        env = _perspective_envelope(_ent, tier_in)
+        return jsonify(
+            {
+                "bundles": list(rows),
+                "count": len(rows),
+                **env,
+            }
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_tiers_for_features_at_batch: error: %s", exc
+        )
+        env = _perspective_fallback(tier_in)
+        return jsonify(
+            {
+                "bundles": [],
+                "count": 0,
+                **env,
+            }
+        )
+
+
+@bp_entitlement.route(
+    "/api/entitlement/tiers-for-runtimes-at-batch",
+    methods=["POST"],
+)
+def api_entitlement_tiers_for_runtimes_at_batch():
+    """``POST /api/entitlement/tiers-for-runtimes-at-batch?tier=<perspective>``
+    -- runtime-axis twin of
+    ``/api/entitlement/tiers-for-features-at-batch``.
+
+    Same perspective validation (``tier=`` must be a known member of
+    ``_TIER_ORDER``, else 404), same never-5xx posture, same partial-
+    unknown bucketing, same POST envelope shape. Runtime aliases
+    (``claude-code`` -> ``claude_code``) canonicalise per bundle so a
+    caller posting either form gets the same ladder back.
+
+    Response body per row and error paths mirror
+    ``/tiers-for-features-at-batch`` exactly, with ``kind="runtimes"``
+    per row (``items`` is the runtime list).
+    """
+    tier_in = (request.args.get("tier") or "").strip().lower()
+    if not tier_in:
+        return jsonify({"error": "missing tier"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        if tier_in not in _ent._TIER_ORDER:
+            return (
+                jsonify({"error": "unknown tier", "tier": tier_in}),
+                404,
+            )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_tiers_for_runtimes_at_batch: error: %s", exc
+        )
+        return jsonify({"error": "unknown tier", "tier": tier_in}), 404
+
+    body = request.get_json(silent=True) or {}
+    bundles, err = _parse_bundles_body(body)
+    if err == "missing":
+        return jsonify({"error": "missing bundles"}), 400
+    if err == "empty":
+        return jsonify({"error": "empty bundles"}), 400
+    if err == "bundles_must_be_list":
+        return jsonify({"error": "bundles must be a list"}), 400
+
+    try:
+        rows = _ent.tiers_for_runtimes_at_batch(tier_in, bundles) or []
+        env = _perspective_envelope(_ent, tier_in)
+        return jsonify(
+            {
+                "bundles": list(rows),
+                "count": len(rows),
+                **env,
+            }
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_tiers_for_runtimes_at_batch: error: %s", exc
+        )
+        env = _perspective_fallback(tier_in)
+        return jsonify(
+            {
+                "bundles": [],
+                "count": 0,
+                **env,
+            }
+        )

--- a/tests/test_entitlement_tiers_for_bundle_at_batch.py
+++ b/tests/test_entitlement_tiers_for_bundle_at_batch.py
@@ -1,0 +1,503 @@
+"""Tests for the perspective-scoped bundle-batch
+``/api/entitlement/tiers-for-features-at-batch`` and
+``/api/entitlement/tiers-for-runtimes-at-batch`` endpoints (plus their
+:func:`clawmetry.entitlements.tiers_for_features_at_batch` /
+:func:`clawmetry.entitlements.tiers_for_runtimes_at_batch` helpers).
+
+Fills the ``_at_batch`` slot on the bundle-axis tiers-for family alongside
+the existing ``/min-tier-for-features-at-batch`` /
+``/min-tier-for-runtimes-at-batch`` (per-bundle cheapest tier what-if) and
+``/affordable-tiers-at-batch`` (per-item plural what-if) so a pricing-
+matrix / upgrade-walkthrough can call ``X_at(perspective, ...)`` uniformly
+across every ``_at`` batch sibling.
+
+These tests pin:
+
+  * helper: perspective validation (empty / non-string / unknown -> None)
+  * helper: per-row parity with the bare batch (rows are perspective-
+    independent -- the ``_at`` prefix does NOT shape rows)
+  * helper: bundle normalisation, unknown-id bucketing, runtime alias
+    canonicalisation inherit from the bare batch delegate
+  * helper: never raises on a delegate crash
+  * API: happy path shape and envelope keys
+  * API: per-row body byte-equals the bare batch endpoint body
+  * API: 400 on missing ``tier=`` / missing / empty / non-list ``bundles``
+  * API: 404 on unknown ``tier=``
+  * API: never-5xxs on a delegate crash (returns fallback envelope)
+  * grace vs enforce yields byte-identical per-row bodies
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# ── helper: features_at_batch ────────────────────────────────────────────
+
+
+def test_helper_features_at_batch_returns_list(ent):
+    rows = ent.tiers_for_features_at_batch(
+        ent.TIER_CLOUD_STARTER, [["fleet"], ["otel_export"]]
+    )
+    assert isinstance(rows, list)
+    assert len(rows) == 2
+
+
+def test_helper_features_at_batch_row_shape(ent):
+    rows = ent.tiers_for_features_at_batch(
+        ent.TIER_CLOUD_STARTER, [["fleet", "sso"]]
+    )
+    row = rows[0]
+    assert set(row.keys()) == {
+        "items",
+        "unknown",
+        "kind",
+        "count",
+        "min_tier",
+        "min_tier_label",
+        "min_tier_rank",
+        "tiers",
+    }
+    assert row["kind"] == "features"
+
+
+def test_helper_features_at_batch_empty_perspective_is_none(ent):
+    assert ent.tiers_for_features_at_batch("", [["fleet"]]) is None
+
+
+def test_helper_features_at_batch_none_perspective_is_none(ent):
+    assert ent.tiers_for_features_at_batch(None, [["fleet"]]) is None
+
+
+def test_helper_features_at_batch_unknown_perspective_is_none(ent):
+    assert (
+        ent.tiers_for_features_at_batch("no-such-tier", [["fleet"]]) is None
+    )
+
+
+def test_helper_features_at_batch_non_string_perspective_is_none(ent):
+    assert ent.tiers_for_features_at_batch(42, [["fleet"]]) is None
+
+
+def test_helper_features_at_batch_row_equals_bare_batch(ent):
+    """Rows are perspective-independent -- byte-equal to the bare-batch
+    delegate. Pinned across every known tier including TIER_TRIAL."""
+    bundles = [["fleet", "sso"], ["otel_export"], []]
+    bare = ent.tiers_for_features_batch(bundles)
+    for perspective in ent._TIER_ORDER:
+        assert (
+            ent.tiers_for_features_at_batch(perspective, bundles) == bare
+        )
+
+
+def test_helper_features_at_batch_row_equals_singular(ent):
+    for bundle in (["fleet", "sso"], ["otel_export"], ["fleet", "bogus"], []):
+        rows = ent.tiers_for_features_at_batch(
+            ent.TIER_CLOUD_PRO, [bundle]
+        )
+        assert rows[0] == ent.tiers_for_features(bundle)
+
+
+def test_helper_features_at_batch_none_bundles_delegates_to_empty(ent):
+    # Delegate returns [] for None; the _at wrapper preserves that.
+    assert ent.tiers_for_features_at_batch(ent.TIER_CLOUD_STARTER, None) == []
+
+
+def test_helper_features_at_batch_non_iterable_bundles(ent):
+    assert ent.tiers_for_features_at_batch(ent.TIER_CLOUD_STARTER, 123) == []
+
+
+def test_helper_features_at_batch_never_raises(ent, monkeypatch):
+    def _boom(*_a, **_k):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(ent, "tiers_for_features_batch", _boom)
+    assert (
+        ent.tiers_for_features_at_batch(
+            ent.TIER_CLOUD_STARTER, [["fleet"]]
+        )
+        is None
+    )
+
+
+# ── helper: runtimes_at_batch ────────────────────────────────────────────
+
+
+def test_helper_runtimes_at_batch_row_shape(ent):
+    rows = ent.tiers_for_runtimes_at_batch(
+        ent.TIER_CLOUD_STARTER, [["openclaw"]]
+    )
+    assert set(rows[0].keys()) == {
+        "items",
+        "unknown",
+        "kind",
+        "count",
+        "min_tier",
+        "min_tier_label",
+        "min_tier_rank",
+        "tiers",
+    }
+    assert rows[0]["kind"] == "runtimes"
+
+
+def test_helper_runtimes_at_batch_canonicalises_alias(ent):
+    rows = ent.tiers_for_runtimes_at_batch(
+        ent.TIER_CLOUD_STARTER, [["claude-code"]]
+    )
+    assert rows[0]["items"] == ["claude_code"]
+    assert rows[0]["unknown"] == []
+
+
+def test_helper_runtimes_at_batch_row_equals_bare_batch(ent):
+    bundles = [["claude_code", "codex"], ["openclaw"], []]
+    bare = ent.tiers_for_runtimes_batch(bundles)
+    for perspective in ent._TIER_ORDER:
+        assert (
+            ent.tiers_for_runtimes_at_batch(perspective, bundles) == bare
+        )
+
+
+def test_helper_runtimes_at_batch_empty_perspective_is_none(ent):
+    assert ent.tiers_for_runtimes_at_batch("", [["openclaw"]]) is None
+
+
+def test_helper_runtimes_at_batch_unknown_perspective_is_none(ent):
+    assert (
+        ent.tiers_for_runtimes_at_batch("no-such-tier", [["openclaw"]])
+        is None
+    )
+
+
+def test_helper_runtimes_at_batch_never_raises(ent, monkeypatch):
+    def _boom(*_a, **_k):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(ent, "tiers_for_runtimes_batch", _boom)
+    assert (
+        ent.tiers_for_runtimes_at_batch(
+            ent.TIER_CLOUD_STARTER, [["openclaw"]]
+        )
+        is None
+    )
+
+
+# ── perspective independence ─────────────────────────────────────────────
+
+
+def test_helper_features_at_batch_grace_vs_enforce_same_rows(
+    monkeypatch, ent
+):
+    bundles = [["fleet", "sso"], ["otel_export"], []]
+    grace_rows = ent.tiers_for_features_at_batch(
+        ent.TIER_CLOUD_STARTER, bundles
+    )
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    enforce_rows = ent.tiers_for_features_at_batch(
+        ent.TIER_CLOUD_STARTER, bundles
+    )
+    assert grace_rows == enforce_rows
+
+
+# ── API: features at batch ───────────────────────────────────────────────
+
+
+def test_api_features_at_batch_happy_path(client, ent):
+    r = client.post(
+        "/api/entitlement/tiers-for-features-at-batch?tier=cloud_starter",
+        json={"bundles": [["fleet", "sso"], ["otel_export"]]},
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert set(body.keys()) >= {
+        "bundles",
+        "count",
+        "current_tier",
+        "current_tier_rank",
+        "grace",
+        "enforced",
+        "perspective_tier",
+        "perspective_tier_label",
+        "perspective_tier_rank",
+    }
+    assert body["count"] == 2
+    assert body["perspective_tier"] == "cloud_starter"
+    assert body["bundles"][0]["kind"] == "features"
+
+
+def test_api_features_at_batch_row_shape(client):
+    r = client.post(
+        "/api/entitlement/tiers-for-features-at-batch?tier=cloud_pro",
+        json={"bundles": [["fleet", "sso"]]},
+    )
+    row = r.get_json()["bundles"][0]
+    assert set(row.keys()) == {
+        "items",
+        "unknown",
+        "kind",
+        "count",
+        "min_tier",
+        "min_tier_label",
+        "min_tier_rank",
+        "tiers",
+    }
+
+
+def test_api_features_at_batch_row_byte_equals_bare_batch(client, ent):
+    bundles = [["fleet", "sso"], ["otel_export"], []]
+    r_at = client.post(
+        "/api/entitlement/tiers-for-features-at-batch?tier=cloud_starter",
+        json={"bundles": bundles},
+    )
+    r_bare = client.post(
+        "/api/entitlement/tiers-for-features-batch",
+        json={"bundles": bundles},
+    )
+    assert r_at.status_code == 200
+    assert r_bare.status_code == 200
+    at_body = r_at.get_json()
+    bare_body = r_bare.get_json()
+    assert at_body["bundles"] == bare_body["bundles"]
+
+
+def test_api_features_at_batch_row_byte_equals_singular(client, ent):
+    bundles = [["fleet", "sso"], ["otel_export"], []]
+    r = client.post(
+        "/api/entitlement/tiers-for-features-at-batch?tier=cloud_pro",
+        json={"bundles": bundles},
+    )
+    body = r.get_json()
+    for row, bundle in zip(body["bundles"], bundles):
+        assert row == ent.tiers_for_features(bundle)
+
+
+def test_api_features_at_batch_missing_tier_400(client):
+    r = client.post(
+        "/api/entitlement/tiers-for-features-at-batch",
+        json={"bundles": [["fleet"]]},
+    )
+    assert r.status_code == 400
+    assert "tier" in r.get_json()["error"]
+
+
+def test_api_features_at_batch_unknown_tier_404(client):
+    r = client.post(
+        "/api/entitlement/tiers-for-features-at-batch?tier=no-such-tier",
+        json={"bundles": [["fleet"]]},
+    )
+    assert r.status_code == 404
+    body = r.get_json()
+    assert "unknown" in body["error"]
+    assert body["tier"] == "no-such-tier"
+
+
+def test_api_features_at_batch_missing_bundles_400(client):
+    r = client.post(
+        "/api/entitlement/tiers-for-features-at-batch?tier=cloud_starter",
+        json={},
+    )
+    assert r.status_code == 400
+    assert "bundles" in r.get_json()["error"]
+
+
+def test_api_features_at_batch_empty_bundles_400(client):
+    r = client.post(
+        "/api/entitlement/tiers-for-features-at-batch?tier=cloud_starter",
+        json={"bundles": []},
+    )
+    assert r.status_code == 400
+    assert "empty" in r.get_json()["error"]
+
+
+def test_api_features_at_batch_non_list_bundles_400(client):
+    r = client.post(
+        "/api/entitlement/tiers-for-features-at-batch?tier=cloud_starter",
+        json={"bundles": "fleet,sso"},
+    )
+    assert r.status_code == 400
+
+
+def test_api_features_at_batch_bare_list_of_strings_is_one_bundle(client):
+    r = client.post(
+        "/api/entitlement/tiers-for-features-at-batch?tier=cloud_starter",
+        json={"bundles": ["fleet", "sso"]},
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["count"] == 1
+    assert body["bundles"][0]["items"] == ["fleet", "sso"]
+
+
+def test_api_features_at_batch_never_5xxs_on_delegate_crash(
+    client, monkeypatch, ent
+):
+    def _boom(*_a, **_k):
+        raise RuntimeError("resolver on fire")
+
+    monkeypatch.setattr(ent, "tiers_for_features_at_batch", _boom)
+    r = client.post(
+        "/api/entitlement/tiers-for-features-at-batch?tier=cloud_starter",
+        json={"bundles": [["fleet"]]},
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["bundles"] == []
+    assert body["count"] == 0
+    assert body["perspective_tier"] == "cloud_starter"
+
+
+def test_api_features_at_batch_all_unknown_row_still_populates(client):
+    r = client.post(
+        "/api/entitlement/tiers-for-features-at-batch?tier=cloud_starter",
+        json={"bundles": [["bogus"]]},
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    row = body["bundles"][0]
+    assert row["items"] == []
+    assert row["unknown"] == ["bogus"]
+    assert row["min_tier"] is None
+    assert row["tiers"] == []
+
+
+# ── API: runtimes at batch ───────────────────────────────────────────────
+
+
+def test_api_runtimes_at_batch_happy_path(client):
+    r = client.post(
+        "/api/entitlement/tiers-for-runtimes-at-batch?tier=cloud_starter",
+        json={"bundles": [["claude_code", "codex"], ["openclaw"]]},
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["count"] == 2
+    assert body["bundles"][0]["kind"] == "runtimes"
+    assert body["perspective_tier"] == "cloud_starter"
+
+
+def test_api_runtimes_at_batch_row_byte_equals_bare_batch(client, ent):
+    bundles = [["claude_code", "codex"], ["openclaw"], []]
+    r_at = client.post(
+        "/api/entitlement/tiers-for-runtimes-at-batch?tier=cloud_pro",
+        json={"bundles": bundles},
+    )
+    r_bare = client.post(
+        "/api/entitlement/tiers-for-runtimes-batch",
+        json={"bundles": bundles},
+    )
+    assert r_at.status_code == 200
+    assert r_bare.status_code == 200
+    assert r_at.get_json()["bundles"] == r_bare.get_json()["bundles"]
+
+
+def test_api_runtimes_at_batch_canonicalises_alias(client):
+    r = client.post(
+        "/api/entitlement/tiers-for-runtimes-at-batch?tier=cloud_starter",
+        json={"bundles": [["claude-code"]]},
+    )
+    body = r.get_json()
+    assert body["bundles"][0]["items"] == ["claude_code"]
+
+
+def test_api_runtimes_at_batch_missing_tier_400(client):
+    r = client.post(
+        "/api/entitlement/tiers-for-runtimes-at-batch",
+        json={"bundles": [["openclaw"]]},
+    )
+    assert r.status_code == 400
+
+
+def test_api_runtimes_at_batch_unknown_tier_404(client):
+    r = client.post(
+        "/api/entitlement/tiers-for-runtimes-at-batch?tier=no-such-tier",
+        json={"bundles": [["openclaw"]]},
+    )
+    assert r.status_code == 404
+
+
+def test_api_runtimes_at_batch_missing_bundles_400(client):
+    r = client.post(
+        "/api/entitlement/tiers-for-runtimes-at-batch?tier=cloud_starter",
+        json={},
+    )
+    assert r.status_code == 400
+
+
+def test_api_runtimes_at_batch_empty_bundles_400(client):
+    r = client.post(
+        "/api/entitlement/tiers-for-runtimes-at-batch?tier=cloud_starter",
+        json={"bundles": []},
+    )
+    assert r.status_code == 400
+
+
+def test_api_runtimes_at_batch_never_5xxs_on_delegate_crash(
+    client, monkeypatch, ent
+):
+    def _boom(*_a, **_k):
+        raise RuntimeError("resolver on fire")
+
+    monkeypatch.setattr(ent, "tiers_for_runtimes_at_batch", _boom)
+    r = client.post(
+        "/api/entitlement/tiers-for-runtimes-at-batch?tier=cloud_starter",
+        json={"bundles": [["openclaw"]]},
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["bundles"] == []
+    assert body["count"] == 0
+    assert body["perspective_tier"] == "cloud_starter"
+
+
+# ── envelope parity ──────────────────────────────────────────────────────
+
+
+def test_api_at_batch_envelope_carries_perspective(client, ent):
+    r = client.post(
+        "/api/entitlement/tiers-for-features-at-batch?tier=cloud_pro",
+        json={"bundles": [["fleet"]]},
+    )
+    body = r.get_json()
+    assert body["perspective_tier"] == "cloud_pro"
+    assert body["perspective_tier_label"] == ent.tier_label("cloud_pro")
+    assert body["perspective_tier_rank"] == ent.tier_rank("cloud_pro")
+    ent_obj = ent.get_entitlement()
+    assert body["current_tier"] == ent_obj.tier
+    assert body["current_tier_rank"] == ent.tier_rank(ent_obj.tier)
+    assert body["grace"] is bool(ent_obj.grace)
+    assert body["enforced"] is ent.is_enforced()
+
+
+def test_api_at_batch_perspective_trial_allowed(client, ent):
+    """``TIER_TRIAL`` is a valid perspective (matches every other ``_at``
+    sibling) even though it is not purchasable."""
+    r = client.post(
+        f"/api/entitlement/tiers-for-features-at-batch?tier={ent.TIER_TRIAL}",
+        json={"bundles": [["fleet"]]},
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["perspective_tier"] == ent.TIER_TRIAL


### PR DESCRIPTION
## Summary

- Fills the `_at_batch` slot on the bundle-axis tiers-for family alongside `/min-tier-for-features-at-batch` / `/min-tier-for-runtimes-at-batch` (per-bundle cheapest-tier what-if) and `/affordable-tiers-at-batch` (per-item plural what-if), so a pricing-matrix walkthrough can call `X_at(perspective, ...)` uniformly across every `_at` batch sibling.
- Adds two helpers (`tiers_for_features_at_batch`, `tiers_for_runtimes_at_batch`) and two POST endpoints (`/api/entitlement/tiers-for-features-at-batch?tier=<perspective>`, `/api/entitlement/tiers-for-runtimes-at-batch?tier=<perspective>`).
- Rows are perspective-independent (delegates walk the static per-tier maps); the envelope carries `perspective_tier` / `perspective_tier_label` / `perspective_tier_rank` on top of the bare-batch envelope. Never 5xxs; 400 on missing `tier=` / bad `bundles`; 404 on unknown `tier=`.

## Test plan

- [x] `python3 -m py_compile` on all three changed files — clean
- [x] `ruff check clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_tiers_for_bundle_at_batch.py` — all checks pass
- [x] `python3 -m pytest tests/test_entitlement_tiers_for_bundle_at_batch.py` — 40/40 pass
- [x] `python3 -m pytest -k "entitlement and (tiers_for or min_tier_for or affordable or bundle_batch)"` — 838 passed, no regressions in sibling families
- [ ] CI green on this branch

## Files touched

- `clawmetry/entitlements.py` — two new helpers with docstrings mirroring the sibling `_at_batch` / `_at` shapes.
- `routes/entitlement.py` — two POST endpoints on `bp_entitlement`; identical error paths, envelope, and never-5xx posture to the existing `/min-tier-for-*-at-batch` twins.
- `tests/test_entitlement_tiers_for_bundle_at_batch.py` — 40 tests pinning helper perspective validation, per-row parity with the bare batch (walked across every tier in `_TIER_ORDER` including `TIER_TRIAL`), singular parity, bundle normalisation, unknown-id bucketing, runtime alias canonicalisation, grace-vs-enforce byte parity, and every API 200 / 400 / 404 / never-5xx path.

## Local operator verification checklist

Autonomous fire can only prove correctness at the code + unit-test layer. To close the flywheel, please run these on the live daemon:

- [ ] Copy changed files into `~/.clawmetry/lib/python3.<Y>/site-packages/clawmetry/` and `~/.clawmetry/lib/python3.<Y>/site-packages/routes/`
- [ ] Clear `__pycache__/` under both directories
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
- [ ] `curl -s 'http://localhost:8900/api/entitlement/tiers-for-features-at-batch?tier=cloud_starter' -H 'content-type: application/json' -d '{"bundles":[["fleet","sso"],["otel_export"]]}' | jq .`
- [ ] Same for `/tiers-for-runtimes-at-batch` with `bundles=[["claude_code","codex"],["openclaw"]]`
- [ ] Confirm envelope carries `perspective_tier`, `perspective_tier_label`, `perspective_tier_rank`; per-row `bundles[i]` byte-equal to `/tiers-for-features-batch` for the same bundle
- [ ] Decrypt the live cloud snapshot in the browser and confirm no regression on existing entitlement surfaces

Draft: everything grace-mode, zero behaviour change on existing surfaces. No `__version__` bump, no `[RELEASE]` tag.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PXb8XFsavXhqmY9EDQuQTT)_