### PR TITLE
fix(c6): remove silent exit guard so verify script runs on every push

### DIFF
--- a/.github/workflows/apply-required-checks.yml
+++ b/.github/workflows/apply-required-checks.yml
@@ -14,16 +14,15 @@ name: Apply required E2E status checks (C6 -- one-shot)
 #                      local clone, no gh CLI, no secret setup needed.
 #                      The token is masked via ::add-mask:: before use.
 #
-#   push to main -- informational only (exits 0 regardless of C6 state).
-#     c6-schedule-heal.yml handles daily auto-apply when E2E_ADMIN_PAT
-#     is configured.  This workflow no longer reds main on push.
+#   push to main -- runs apply_required_status_checks.py.
+#     With only GITHUB_TOKEN (ghs_): read-only verify path in the script
+#     (exits 0 if C6 configured, exits 1 if not -- no admin rights needed).
+#     With E2E_ADMIN_PAT: full apply + verify.
 #
 # TOKEN PATHS (priority order):
 #   1. inputs.pat_token  -- PAT typed into the Run workflow dialog
 #   2. secrets.E2E_ADMIN_PAT -- pre-stored repo secret
-#   3. github.token (ghs_) -- read-only fallback; exits 0 on push
-#                              (informational); exits 1 if confirm=APPLY
-#                              is used without an admin token.
+#   3. github.token (ghs_) -- read-only verify via public branch endpoint
 #
 # NOTE: administration:write is intentionally absent from permissions.
 #   It is NOT a valid GITHUB_TOKEN permission in Actions; requesting it
@@ -37,7 +36,7 @@ name: Apply required E2E status checks (C6 -- one-shot)
 #   clawmetry-landing.
 #
 # Idempotent: running multiple times is safe.
-# Tracking: vivekchand/clawmetry#3752
+# Tracking: vivekchand/clawmetry#3897
 
 on:
   workflow_dispatch:
@@ -113,14 +112,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ inputs.pat_token || secrets.E2E_ADMIN_PAT || github.token }}
           CONFIRM_INPUT: ${{ inputs.confirm || '' }}
-        run: |
-          # On push with only GITHUB_TOKEN (no admin PAT): exit 0 (informational).
-          # c6-schedule-heal.yml handles daily auto-apply when E2E_ADMIN_PAT is set.
-          if [[ "${GITHUB_EVENT_NAME:-}" == "push" ]] && [[ "$GITHUB_TOKEN" == ghs_* ]]; then
-            echo "No E2E_ADMIN_PAT configured. Exiting 0 (informational on push)."
-            echo "c6-schedule-heal.yml will auto-apply at 10:15 UTC when E2E_ADMIN_PAT is set."
-            echo "Or run manually: Actions > 'Apply required E2E status checks (C6 -- one-shot)'"
-            echo "  > confirm=APPLY with pat_token pasted in."
-            exit 0
-          fi
-          python3 scripts/apply_required_status_checks.py
+        run: python3 scripts/apply_required_status_checks.py


### PR DESCRIPTION
## Problem

`apply-required-checks.yml` "Apply required status checks" step was
exiting 0 in under 1 second on every push to main when `GITHUB_TOKEN`
is the default `ghs_` Actions token (no `E2E_ADMIN_PAT` configured).
The early bash guard printed a message and called `exit 0` before
`apply_required_status_checks.py` ran at all.

Evidence: run 29830084849 -- step started_at and completed_at both
`12:26:22` (0-second runtime, no Python output).

This meant C6 was silently reporting green even when required status
checks were absent from branch protection.

## Fix

Remove the early exit guard entirely. `apply_required_status_checks.py`
already handles the `ghs_` case correctly via a read-only verification
path (public `GET /repos/{owner}/{repo}/branches/main` endpoint -- no
admin rights needed). It exits 0 if C6 is configured, exits 1 if not.
With an admin PAT it applies + verifies.

The step now unconditionally runs:
```
python3 scripts/apply_required_status_checks.py
```

## Behaviour after merge

- **push (ghs_ token)**: script runs read-only verify; job green if C6
  configured, red if not -- gives real signal instead of always-green
- **push (E2E_ADMIN_PAT configured)**: full apply + verify as before
- **workflow_dispatch APPLY + pat_token**: unchanged
- **workflow_dispatch dry-run**: unchanged (separate step, not affected)

## Tracking

Part of E2E Robustness Epic: vivekchand/clawmetry#3897 (C6 criterion)

---
_Generated by [Claude Code](https://claude.ai/code/session_019EFGfVdtxUimj7m4DmmLha)_