### PR TITLE
feat(entitlement): min-tier-for-{channel-count,node-count,retention-window} bare endpoints

### DIFF
--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -21811,6 +21811,231 @@ def api_entitlement_min_tier_for_runtimes():
         )
 
 
+def _min_tier_for_capacity_fallback(item, kind: str) -> dict:
+    """Grace-shape fallback body for the three ``min-tier-for-<capacity-axis>``
+    endpoints. Never 5xxs: on a resolver crash the pricing surface keeps
+    rendering with ``required_tier=null`` instead of a stack trace.
+    """
+    return {
+        "item": item,
+        "kind": kind,
+        "label": None,
+        "free": False,
+        "required_tier": None,
+        "required_tier_label": None,
+        "required_tier_rank": -1,
+        "current_tier": "oss",
+        "current_tier_rank": 0,
+        "grace": True,
+        "enforced": False,
+    }
+
+
+def _min_tier_for_capacity_body(
+    _ent, item, kind: str, label: str, required
+) -> dict:
+    """Assemble the response body for a ``min-tier-for-<capacity-axis>``
+    endpoint. Uniform ``required_tier*`` naming across the three capacity
+    axes (channel_count, node_count, retention_window) so a paywall UI
+    switching axes reads the same envelope, and byte-identical to the
+    ``required_tier*`` naming the plural grant-axis siblings
+    (``/min-tier-for-features`` / ``/min-tier-for-runtimes``) use.
+
+    ``free`` is derived from the min-tier helper's own answer (matching
+    the sibling ``/tiers-for-<axis>`` endpoint's ``free`` semantics for
+    every currently-defined cap): if the cheapest admitting tier IS
+    :data:`TIER_OSS`, the request fits in the free floor.
+    """
+    return {
+        "item": item,
+        "kind": kind,
+        "label": label,
+        "free": bool(required == _ent.TIER_OSS),
+        "required_tier": required,
+        "required_tier_label": (
+            _ent.tier_label(required) if required else None
+        ),
+        "required_tier_rank": (
+            _ent.tier_rank(required) if required else -1
+        ),
+        **_resolver_envelope(_ent),
+    }
+
+
+@bp_entitlement.route("/api/entitlement/min-tier-for-channel-count")
+def api_entitlement_min_tier_for_channel_count():
+    """``GET /api/entitlement/min-tier-for-channel-count?count=<int>`` --
+    resolver-scoped sibling of :func:`min_tier_for_channel_count`: the
+    cheapest *purchasable* tier admitting ``count`` configured channel
+    adapters.
+
+    Fills the *bare* slot for the scalar capacity-axis ``min_tier_for_*``
+    family alongside the ladder-axis sibling
+    ``/api/entitlement/tiers-for-channel-count`` (which returns the full
+    "Fits in: <tier>, ..." availability list) and the plural grant-axis
+    bare endpoints ``/min-tier-for-features`` / ``/min-tier-for-runtimes``
+    (#3734). Symmetric with ``/min-tier-for-node-count`` and
+    ``/min-tier-for-retention-window`` so the three scalar capacity axes
+    look identical from the caller's side. A dashboard wiring "you have
+    5 channels -- Available in Cloud Starter" can now hit ONE endpoint
+    that folds the walk in place of scanning the full ladder from
+    ``/tiers-for-channel-count``.
+
+    ``count=`` is required. Missing key -> ``400``. Blank / non-int
+    value -> ``400``. Never 5xxs: a resolver failure yields the grace-
+    shape fallback envelope so the pricing surface keeps rendering.
+
+    Response shape::
+
+        {
+          "item":                <int>,
+          "kind":                "channel_count",
+          "label":               "5 channels",
+          "free":                <bool>,
+          "required_tier":       "cloud_starter" | null,
+          "required_tier_label": "Cloud Starter" | null,
+          "required_tier_rank":  <int>,
+          "current_tier":        "...",
+          "current_tier_rank":   <int>,
+          "grace":               <bool>,
+          "enforced":            <bool>,
+        }
+    """
+    raw = request.args.get("count")
+    if raw is None:
+        return jsonify({"error": "missing count"}), 400
+    raw_stripped = raw.strip()
+    if not raw_stripped:
+        return jsonify({"error": "missing count"}), 400
+    try:
+        n = int(raw_stripped)
+    except (TypeError, ValueError):
+        return jsonify({"error": "count must be an integer"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        required = _ent.min_tier_for_channel_count(n)
+        label = f"{n} channel" if n == 1 else f"{n} channels"
+        return jsonify(
+            _min_tier_for_capacity_body(
+                _ent, n, "channel_count", label, required
+            )
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_min_tier_for_channel_count: error: %s", exc
+        )
+        return jsonify(
+            _min_tier_for_capacity_fallback(n, "channel_count")
+        )
+
+
+@bp_entitlement.route("/api/entitlement/min-tier-for-node-count")
+def api_entitlement_min_tier_for_node_count():
+    """``GET /api/entitlement/min-tier-for-node-count?count=<int>`` --
+    node-axis twin of ``/api/entitlement/min-tier-for-channel-count``.
+
+    Resolver-scoped sibling of :func:`min_tier_for_node_count`: the
+    cheapest *purchasable* tier admitting ``count`` registered nodes --
+    the id the fleet-page lock affordance ("you have 4 nodes --
+    Available in Cloud Starter") reads from.
+
+    Same never-5xx posture, same 400-on-blank/non-int parsing. Response
+    shape and error paths mirror ``/min-tier-for-channel-count`` exactly,
+    with ``kind="node_count"`` and ``label="4 nodes"``.
+    """
+    raw = request.args.get("count")
+    if raw is None:
+        return jsonify({"error": "missing count"}), 400
+    raw_stripped = raw.strip()
+    if not raw_stripped:
+        return jsonify({"error": "missing count"}), 400
+    try:
+        n = int(raw_stripped)
+    except (TypeError, ValueError):
+        return jsonify({"error": "count must be an integer"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        required = _ent.min_tier_for_node_count(n)
+        label = f"{n} node" if n == 1 else f"{n} nodes"
+        return jsonify(
+            _min_tier_for_capacity_body(
+                _ent, n, "node_count", label, required
+            )
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_min_tier_for_node_count: error: %s", exc
+        )
+        return jsonify(_min_tier_for_capacity_fallback(n, "node_count"))
+
+
+@bp_entitlement.route("/api/entitlement/min-tier-for-retention-window")
+def api_entitlement_min_tier_for_retention_window():
+    """``GET /api/entitlement/min-tier-for-retention-window?days=<int>`` --
+    retention-axis twin of ``/api/entitlement/min-tier-for-channel-count``.
+
+    Resolver-scoped sibling of :func:`min_tier_for_retention_window`: the
+    cheapest *purchasable* tier admitting a ``days`` history window -- the
+    id the history-range toggle lock affordance reads from.
+
+    ``days=unlimited`` (case-insensitive) requests the unlimited-history
+    window; only tiers whose retention cap is ``None`` admit the request
+    (Enterprise on the current tier table). ``item`` is ``null`` and
+    ``label`` is ``"unlimited"`` in that case.
+
+    ``days=`` is required. Missing key -> ``400``. Blank / non-int /
+    non-``unlimited`` value -> ``400``. Never 5xxs: same grace-shape
+    fallback as the two count-axis siblings.
+
+    Response shape mirrors ``/min-tier-for-channel-count`` with
+    ``kind="retention_window"``.
+    """
+    raw = request.args.get("days")
+    if raw is None:
+        return jsonify({"error": "missing days"}), 400
+    raw_stripped = raw.strip()
+    if not raw_stripped:
+        return jsonify({"error": "missing days"}), 400
+    unlimited = raw_stripped.lower() == "unlimited"
+    if unlimited:
+        parsed: int | None = None
+    else:
+        try:
+            parsed = int(raw_stripped)
+        except (TypeError, ValueError):
+            return (
+                jsonify(
+                    {"error": "days must be an integer or 'unlimited'"}
+                ),
+                400,
+            )
+    try:
+        from clawmetry import entitlements as _ent
+
+        required = _ent.min_tier_for_retention_window(parsed)
+        if parsed is None:
+            label = "unlimited"
+        else:
+            label = (
+                f"{parsed} day" if parsed == 1 else f"{parsed} days"
+            )
+        return jsonify(
+            _min_tier_for_capacity_body(
+                _ent, parsed, "retention_window", label, required
+            )
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_min_tier_for_retention_window: error: %s",
+            exc,
+        )
+        return jsonify(
+            _min_tier_for_capacity_fallback(parsed, "retention_window")
+        )
+
+
 def _min_tier_for_bundle_row_to_body(row: dict, list_key: str) -> dict:
     """Rename the batch helper's ``min_tier*`` keys to the endpoint's
     ``required_tier*`` keys so per-row bodies stay byte-identical to

--- a/tests/test_entitlement_min_tier_for_capacity_bare.py
+++ b/tests/test_entitlement_min_tier_for_capacity_bare.py
@@ -1,0 +1,457 @@
+"""Tests for the bare ``/api/entitlement/min-tier-for-channel-count`` /
+``/api/entitlement/min-tier-for-node-count`` /
+``/api/entitlement/min-tier-for-retention-window`` endpoints.
+
+Fills the *bare* slot for the three scalar capacity-axis
+``min_tier_for_*`` helpers alongside the ladder-axis siblings
+``/api/entitlement/tiers-for-channel-count`` /
+``/tiers-for-node-count`` / ``/tiers-for-retention-window`` (which return
+the full "Fits in: <tier>, ..." availability list) and the plural grant-
+axis bare endpoints ``/min-tier-for-features`` / ``/min-tier-for-runtimes``
+(#3734). Wraps the existing
+:func:`clawmetry.entitlements.min_tier_for_channel_count` /
+:func:`clawmetry.entitlements.min_tier_for_node_count` /
+:func:`clawmetry.entitlements.min_tier_for_retention_window` helpers so
+the three scalar capacity axes look identical from the caller's side.
+
+These tests pin:
+
+* API happy path: shape, resolver envelope, ``kind``, ``item``, ``label``,
+  ``free``
+* API error paths: 400 on missing / blank / non-int ``count`` / ``days``
+* cross-endpoint parity: ``required_tier`` byte-equals the helper's return
+* ``days=unlimited`` (case-insensitive) round-trips to ``item=null`` /
+  ``label="unlimited"`` and required_tier=None-cap tier
+* symmetry across the three axes: identical envelope shape
+* uniform ``required_tier*`` naming with the plural grant-axis siblings
+  so a UI switching axes reads the same envelope
+* resolver envelope carried on happy path
+* never-5xxs on a delegate crash
+* grace vs enforce parity: the resolver-scoped body must not drift
+  between grace and enforce modes
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+_BARE_ENVELOPE_KEYS = {
+    "item",
+    "kind",
+    "label",
+    "free",
+    "required_tier",
+    "required_tier_label",
+    "required_tier_rank",
+    "current_tier",
+    "current_tier_rank",
+    "grace",
+    "enforced",
+}
+
+
+# ── API: happy path ────────────────────────────────────────────────────────
+
+
+def test_api_channel_count_happy_path(client, ent):
+    r = client.get(
+        "/api/entitlement/min-tier-for-channel-count?count=5"
+    )
+    assert r.status_code == 200
+    j = r.get_json()
+    assert set(j.keys()) == _BARE_ENVELOPE_KEYS
+    assert j["kind"] == "channel_count"
+    assert j["item"] == 5
+    assert j["label"] == "5 channels"
+    assert j["required_tier"] == ent.min_tier_for_channel_count(5)
+    assert j["required_tier_label"] == ent.tier_label(j["required_tier"])
+    assert j["required_tier_rank"] == ent.tier_rank(j["required_tier"])
+
+
+def test_api_node_count_happy_path(client, ent):
+    r = client.get("/api/entitlement/min-tier-for-node-count?count=4")
+    assert r.status_code == 200
+    j = r.get_json()
+    assert set(j.keys()) == _BARE_ENVELOPE_KEYS
+    assert j["kind"] == "node_count"
+    assert j["item"] == 4
+    assert j["label"] == "4 nodes"
+    assert j["required_tier"] == ent.min_tier_for_node_count(4)
+
+
+def test_api_retention_window_happy_path(client, ent):
+    r = client.get(
+        "/api/entitlement/min-tier-for-retention-window?days=30"
+    )
+    assert r.status_code == 200
+    j = r.get_json()
+    assert set(j.keys()) == _BARE_ENVELOPE_KEYS
+    assert j["kind"] == "retention_window"
+    assert j["item"] == 30
+    assert j["label"] == "30 days"
+    assert j["required_tier"] == ent.min_tier_for_retention_window(30)
+
+
+# ── API: singular label conjugation ───────────────────────────────────────
+
+
+def test_api_channel_count_singular_label(client):
+    j = client.get(
+        "/api/entitlement/min-tier-for-channel-count?count=1"
+    ).get_json()
+    assert j["label"] == "1 channel"
+
+
+def test_api_node_count_singular_label(client):
+    j = client.get(
+        "/api/entitlement/min-tier-for-node-count?count=1"
+    ).get_json()
+    assert j["label"] == "1 node"
+
+
+def test_api_retention_window_singular_label(client):
+    j = client.get(
+        "/api/entitlement/min-tier-for-retention-window?days=1"
+    ).get_json()
+    assert j["label"] == "1 day"
+
+
+# ── API: error paths ──────────────────────────────────────────────────────
+
+
+def test_api_channel_count_missing_count_returns_400(client):
+    r = client.get("/api/entitlement/min-tier-for-channel-count")
+    assert r.status_code == 400
+    assert r.get_json().get("error") == "missing count"
+
+
+def test_api_node_count_missing_count_returns_400(client):
+    r = client.get("/api/entitlement/min-tier-for-node-count")
+    assert r.status_code == 400
+    assert r.get_json().get("error") == "missing count"
+
+
+def test_api_retention_window_missing_days_returns_400(client):
+    r = client.get("/api/entitlement/min-tier-for-retention-window")
+    assert r.status_code == 400
+    assert r.get_json().get("error") == "missing days"
+
+
+def test_api_channel_count_blank_count_returns_400(client):
+    r = client.get(
+        "/api/entitlement/min-tier-for-channel-count?count=%20%20"
+    )
+    assert r.status_code == 400
+
+
+def test_api_node_count_blank_count_returns_400(client):
+    r = client.get(
+        "/api/entitlement/min-tier-for-node-count?count=%20%20"
+    )
+    assert r.status_code == 400
+
+
+def test_api_retention_window_blank_days_returns_400(client):
+    r = client.get(
+        "/api/entitlement/min-tier-for-retention-window?days=%20%20"
+    )
+    assert r.status_code == 400
+
+
+def test_api_channel_count_nonint_count_returns_400(client):
+    r = client.get(
+        "/api/entitlement/min-tier-for-channel-count?count=nope"
+    )
+    assert r.status_code == 400
+    assert "integer" in r.get_json().get("error", "")
+
+
+def test_api_node_count_nonint_count_returns_400(client):
+    r = client.get(
+        "/api/entitlement/min-tier-for-node-count?count=nope"
+    )
+    assert r.status_code == 400
+
+
+def test_api_retention_window_nonint_days_returns_400(client):
+    r = client.get(
+        "/api/entitlement/min-tier-for-retention-window?days=nope"
+    )
+    assert r.status_code == 400
+    assert (
+        "integer" in r.get_json().get("error", "")
+        or "unlimited" in r.get_json().get("error", "")
+    )
+
+
+# ── API: retention `unlimited` handling ───────────────────────────────────
+
+
+def test_api_retention_window_unlimited(client, ent):
+    r = client.get(
+        "/api/entitlement/min-tier-for-retention-window?days=unlimited"
+    )
+    assert r.status_code == 200
+    j = r.get_json()
+    assert j["item"] is None
+    assert j["label"] == "unlimited"
+    assert j["kind"] == "retention_window"
+    assert j["required_tier"] == ent.min_tier_for_retention_window(None)
+
+
+def test_api_retention_window_unlimited_case_insensitive(client, ent):
+    for spelling in ("Unlimited", "UNLIMITED", "unLimIted"):
+        j = client.get(
+            f"/api/entitlement/min-tier-for-retention-window?days={spelling}"
+        ).get_json()
+        assert j["item"] is None
+        assert j["label"] == "unlimited"
+
+
+# ── API: zero / negative collapses to free floor ──────────────────────────
+
+
+def test_api_channel_count_zero_is_free(client, ent):
+    j = client.get(
+        "/api/entitlement/min-tier-for-channel-count?count=0"
+    ).get_json()
+    assert j["required_tier"] == ent.TIER_OSS
+    assert j["free"] is True
+
+
+def test_api_node_count_zero_is_free(client, ent):
+    j = client.get(
+        "/api/entitlement/min-tier-for-node-count?count=0"
+    ).get_json()
+    assert j["required_tier"] == ent.TIER_OSS
+    assert j["free"] is True
+
+
+def test_api_retention_window_zero_is_free(client, ent):
+    j = client.get(
+        "/api/entitlement/min-tier-for-retention-window?days=0"
+    ).get_json()
+    assert j["required_tier"] == ent.TIER_OSS
+    assert j["free"] is True
+
+
+# ── API: cross-endpoint parity with helper ────────────────────────────────
+
+
+@pytest.mark.parametrize("n", [1, 3, 10, 50, 1000])
+def test_api_channel_count_required_tier_byte_equals_helper(
+    client, ent, n
+):
+    j = client.get(
+        f"/api/entitlement/min-tier-for-channel-count?count={n}"
+    ).get_json()
+    assert j["required_tier"] == ent.min_tier_for_channel_count(n)
+
+
+@pytest.mark.parametrize("n", [1, 3, 10, 50, 1000])
+def test_api_node_count_required_tier_byte_equals_helper(client, ent, n):
+    j = client.get(
+        f"/api/entitlement/min-tier-for-node-count?count={n}"
+    ).get_json()
+    assert j["required_tier"] == ent.min_tier_for_node_count(n)
+
+
+@pytest.mark.parametrize("d", [1, 7, 30, 90, 365])
+def test_api_retention_window_required_tier_byte_equals_helper(
+    client, ent, d
+):
+    j = client.get(
+        f"/api/entitlement/min-tier-for-retention-window?days={d}"
+    ).get_json()
+    assert j["required_tier"] == ent.min_tier_for_retention_window(d)
+
+
+# ── API: uniform envelope across the three scalar capacity axes ──────────
+
+
+def test_api_three_axes_share_envelope_keys(client):
+    """A paywall UI switching capacity axes reads the same envelope --
+    pin that the three scalar min-tier-for-<axis> bodies expose the
+    same key set so no axis leaks a different shape."""
+    ch = client.get(
+        "/api/entitlement/min-tier-for-channel-count?count=5"
+    ).get_json()
+    nd = client.get(
+        "/api/entitlement/min-tier-for-node-count?count=4"
+    ).get_json()
+    rw = client.get(
+        "/api/entitlement/min-tier-for-retention-window?days=30"
+    ).get_json()
+    assert set(ch.keys()) == set(nd.keys()) == set(rw.keys()) == (
+        _BARE_ENVELOPE_KEYS
+    )
+
+
+def test_api_capacity_axes_share_envelope_with_grant_axes(client):
+    """The three scalar capacity axes must expose the same
+    ``required_tier*`` naming as the plural grant-axis siblings
+    (``/min-tier-for-features``/``/min-tier-for-runtimes``) so the
+    ``min_tier_for_*`` HTTP family is uniform. Pins that the naming
+    (``required_tier`` / ``required_tier_label`` / ``required_tier_rank``)
+    is not axis-specific."""
+    grant = client.get(
+        "/api/entitlement/min-tier-for-features?features=fleet"
+    ).get_json()
+    ch = client.get(
+        "/api/entitlement/min-tier-for-channel-count?count=5"
+    ).get_json()
+    shared = {
+        "kind",
+        "free",
+        "required_tier",
+        "required_tier_label",
+        "required_tier_rank",
+        "current_tier",
+        "current_tier_rank",
+        "grace",
+        "enforced",
+    }
+    assert shared <= set(grant.keys())
+    assert shared <= set(ch.keys())
+
+
+# ── API: resolver envelope carried ────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "/api/entitlement/min-tier-for-channel-count?count=5",
+        "/api/entitlement/min-tier-for-node-count?count=4",
+        "/api/entitlement/min-tier-for-retention-window?days=30",
+    ],
+)
+def test_api_carries_resolver_envelope(client, url):
+    j = client.get(url).get_json()
+    for k in ("current_tier", "current_tier_rank", "grace", "enforced"):
+        assert k in j
+    assert j["grace"] is True
+    assert j["enforced"] is False
+
+
+# ── API: never-5xxs on a delegate crash ───────────────────────────────────
+
+
+def test_api_channel_count_never_5xxs_on_delegate_crash(
+    client, ent, monkeypatch
+):
+    def _boom(*_a, **_kw):
+        raise RuntimeError("delegate boom")
+
+    monkeypatch.setattr(ent, "min_tier_for_channel_count", _boom)
+    r = client.get(
+        "/api/entitlement/min-tier-for-channel-count?count=5"
+    )
+    assert r.status_code == 200
+    j = r.get_json()
+    assert j["required_tier"] is None
+    assert j["item"] == 5
+    assert j["kind"] == "channel_count"
+
+
+def test_api_node_count_never_5xxs_on_delegate_crash(
+    client, ent, monkeypatch
+):
+    def _boom(*_a, **_kw):
+        raise RuntimeError("delegate boom")
+
+    monkeypatch.setattr(ent, "min_tier_for_node_count", _boom)
+    r = client.get("/api/entitlement/min-tier-for-node-count?count=4")
+    assert r.status_code == 200
+    j = r.get_json()
+    assert j["required_tier"] is None
+    assert j["item"] == 4
+    assert j["kind"] == "node_count"
+
+
+def test_api_retention_window_never_5xxs_on_delegate_crash(
+    client, ent, monkeypatch
+):
+    def _boom(*_a, **_kw):
+        raise RuntimeError("delegate boom")
+
+    monkeypatch.setattr(ent, "min_tier_for_retention_window", _boom)
+    r = client.get(
+        "/api/entitlement/min-tier-for-retention-window?days=30"
+    )
+    assert r.status_code == 200
+    j = r.get_json()
+    assert j["required_tier"] is None
+    assert j["item"] == 30
+    assert j["kind"] == "retention_window"
+
+
+def test_api_retention_window_unlimited_never_5xxs_on_delegate_crash(
+    client, ent, monkeypatch
+):
+    def _boom(*_a, **_kw):
+        raise RuntimeError("delegate boom")
+
+    monkeypatch.setattr(ent, "min_tier_for_retention_window", _boom)
+    r = client.get(
+        "/api/entitlement/min-tier-for-retention-window?days=unlimited"
+    )
+    assert r.status_code == 200
+    j = r.get_json()
+    assert j["required_tier"] is None
+    assert j["item"] is None
+    assert j["kind"] == "retention_window"
+
+
+# ── grace vs enforce parity ───────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "/api/entitlement/min-tier-for-channel-count?count=5",
+        "/api/entitlement/min-tier-for-node-count?count=4",
+        "/api/entitlement/min-tier-for-retention-window?days=30",
+    ],
+)
+def test_api_grace_vs_enforce_identical(client, ent, monkeypatch, url):
+    grace = client.get(url).get_json()
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    importlib.reload(ent)
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    enforce_client = app.test_client()
+    enforce = enforce_client.get(url).get_json()
+    # The pricing-surface fields (item / kind / label / required_tier /
+    # free) must byte-equal between grace and enforce: enforcement is a
+    # gating concern, not a description concern.
+    for k in ("item", "kind", "label", "required_tier", "free"):
+        assert grace[k] == enforce[k], (
+            f"key {k} drifted grace vs enforce"
+        )


### PR DESCRIPTION
## Summary

- Adds three new `GET /api/entitlement/min-tier-for-<axis>` endpoints that wrap the existing scalar capacity-axis helpers `min_tier_for_channel_count`, `min_tier_for_node_count`, `min_tier_for_retention_window`. Fills the *bare* slot for the three scalar capacity axes alongside the plural grant-axis bare endpoints `/min-tier-for-features` / `/min-tier-for-runtimes` shipped in #3734, so a paywall UI ("you have 5 channels — Available in Cloud Starter") can hit ONE endpoint per axis instead of scanning the ladder returned by `/tiers-for-<axis>`.
- Response shape mirrors `/min-tier-for-features` exactly except for the axis-specific `item` / `label` fields, so the six `/min-tier-for-*` bare endpoints (features, runtimes, channel_count, node_count, retention_window) now expose a uniform `required_tier` / `required_tier_label` / `required_tier_rank` envelope on top of the standard resolver envelope. Symmetric with the three existing `/tiers-for-<axis>` siblings, which return the full "Fits in: <tier>, ..." ladder.
- Ships in GRACE mode — zero behavior change to any existing surface. New URLs only.

### New endpoints

| URL | Params | Delegates to |
|-----|--------|--------------|
| `/api/entitlement/min-tier-for-channel-count` | `count=<int>` | `min_tier_for_channel_count` |
| `/api/entitlement/min-tier-for-node-count` | `count=<int>` | `min_tier_for_node_count` |
| `/api/entitlement/min-tier-for-retention-window` | `days=<int\|unlimited>` | `min_tier_for_retention_window` |

Same 400-on-missing/blank/non-int posture and same never-5xxs grace-shape fallback as the two grant-axis siblings. `days=unlimited` (case-insensitive) round-trips to `item=null` / `label="unlimited"`, matching `/tiers-for-retention-window`'s contract for the unlimited-history request.

## Test plan

- [x] `python3 -m pytest tests/test_entitlement_min_tier_for_capacity_bare.py -x -q` — 47 tests pass. Covers: happy path shape, singular label conjugation, missing-arg / blank / non-int → 400, `days=unlimited` case-insensitive, zero/negative collapses to `TIER_OSS` + `free=True`, cross-endpoint parity with helper, uniform envelope across all three axes, uniform envelope with plural grant-axis siblings, resolver envelope carried, never-5xx on delegate crash, grace vs enforce parity.
- [x] `python3 -m pytest tests/test_entitlement_min_tier_for_plural_bare.py tests/test_entitlement_min_tier_for_plural_at.py -x -q` — 103 sibling tests still pass, no regression on the plural grant-axis bare/`_at` endpoints.
- [x] `python3 -m py_compile routes/entitlement.py tests/test_entitlement_min_tier_for_capacity_bare.py`.
- [x] `python3 -m ruff check routes/entitlement.py tests/test_entitlement_min_tier_for_capacity_bare.py` — clean.

### Local operator verification checklist

The autonomous fire has no access to the running daemon, `~/.openclaw`, the live cloud snapshot, or a browser, so these steps are left for the local operator:

- [ ] Copy `routes/entitlement.py` into `~/.clawmetry/lib/pythonX.Y/site-packages/routes/` and clear `__pycache__` (or `pip install --upgrade` after this branch lands and a release cuts).
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync com.clawmetry.dashboard`
- [ ] `curl -s http://localhost:8900/api/entitlement/min-tier-for-channel-count?count=5 | jq` — should return the `required_tier` matching `min_tier_for_channel_count(5)`, with `grace=true`, `enforced=false`.
- [ ] `curl -s http://localhost:8900/api/entitlement/min-tier-for-node-count?count=4 | jq` — analogous.
- [ ] `curl -s http://localhost:8900/api/entitlement/min-tier-for-retention-window?days=unlimited | jq` — `item=null`, `label="unlimited"`, `required_tier` matches `min_tier_for_retention_window(None)`.
- [ ] Decrypt the live cloud snapshot in the browser; confirm nothing paints differently (grace-only rollout — should be zero visible drift).
- [ ] Nothing enforced yet; the endpoints exist for downstream paywall UI to consume when the operator wires them in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code

---
_Generated by [Claude Code](https://claude.ai/code/session_01C7o8dYyxWaN3WN6F9u5hRS)_