### PR TITLE
fix(e2e): respect quarantine list in C1 and C5 golden path tests (C7)

### DIFF
--- a/.github/workflows/oss-golden-path.yml
+++ b/.github/workflows/oss-golden-path.yml
@@ -199,7 +199,8 @@ jobs:
         run: |
           /tmp/oss-golden/bin/python -m pytest \
             tests/test_e2e_oss_golden_path.py \
-            -v --tb=short --junitxml=/tmp/junit-c1.xml
+            -v --tb=short --junitxml=/tmp/junit-c1.xml \
+            -m 'not quarantine'
 
       # Restart the dashboard so C5 starts with a clean server that has no
       # accumulated SSE streams or WebSocket reconnect loops from C1. Each
@@ -256,7 +257,8 @@ jobs:
         run: |
           /tmp/oss-golden/bin/python -m pytest \
             tests/test_e2e_oss_all_tabs.py \
-            -v --tb=short --junitxml=/tmp/junit-c5.xml
+            -v --tb=short --junitxml=/tmp/junit-c5.xml \
+            -m 'not quarantine'
 
       - name: Dashboard and gateway logs on failure
         if: failure()


### PR DESCRIPTION
## Summary

Closes the C7 gap: flaky tests quarantined by `auto-quarantine.yml` were not actually excluded from the `oss-golden-path.yml` PR gate, making the quarantine mechanism ineffective.

**Root cause**

The C7 quarantine mechanism works as follows:
- `scripts/auto_quarantine.py` detects flaky tests (failed then passed on re-run) and opens a PR to add them to `tests/quarantine.txt`
- `tests/conftest.py:pytest_collection_modifyitems` marks those tests with `pytest.mark.quarantine`
- `quarantine-sweep.yml` runs them daily with `-m quarantine` to detect if they go from flaky to broken
- The PR gate should skip them with `-m 'not quarantine'`

`ci.yml`'s `e2e-critical` job already does this correctly: `-m 'not quarantine'`. But `oss-golden-path.yml`'s C1 and C5 test steps were missing the flag entirely. A quarantined test still ran in the golden path gate, and if it failed during a PR run, the PR was blocked -- defeating the entire quarantine mechanism.

## Changes

`oss-golden-path.yml` only (2 lines added):

- **C1 step** (`test_e2e_oss_golden_path.py`): add `-m 'not quarantine'` to the pytest invocation
- **C5 step** (`test_e2e_oss_all_tabs.py`): add `-m 'not quarantine'` to the pytest invocation

When `tests/quarantine.txt` is empty (the normal state), this flag is a complete no-op. When `auto-quarantine.yml` adds a flaky test to `quarantine.txt` and the PR is merged, the next run of `oss-golden-path.yml` immediately respects the exclusion.

## Acceptance test

With a test node ID in `tests/quarantine.txt`, the golden path gate must skip it (show `1 deselected` in the pytest summary) and pass despite the test's flakiness.

Without any entries in `quarantine.txt`, both C1 and C5 must continue to pass exactly as before (the flag is a no-op on an empty quarantine list).

Tracking: vivekchand/clawmetry#3899 (E2E robustness epic, criterion C7)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JETs1cNWeaLToRGh9XpZgn)_