### PR TITLE
fix(dashboard): _is_pro_user honors signed-license self-hosted Pro tiers

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -1011,25 +1011,65 @@ def _is_over_cap(scope: str):
 # rule is applied consistently from any per-feature dispatch path.
 #
 # Liveness rule used by the OSS daemon (no async cloud RPC at fire-time):
-#   * No ``cm_`` token on disk           → OSS-only           → NOT pro
-#   * Has ``cm_`` token + cached plan="cloud_pro"|"pro"|"trial" → pro
-#   * Has ``cm_`` token but no cached plan, or plan="free"     → NOT pro
+#   * Signed self-hosted license on disk with a Pro-equivalent tier   → pro
+#     (``pro``/``cloud_pro``/``trial``/``enterprise``, source=license)
+#   * No ``cm_`` token on disk (and no signed license)                → NOT pro
+#   * Has ``cm_`` token + cached plan="cloud_pro"|"pro"|"trial"       → pro
+#   * Has ``cm_`` token but no cached plan, or plan="free"            → NOT pro
 #
 # The cached plan is populated by the cloud-CTA status route the dashboard
 # already polls; we read it best-effort and fall back to the conservative
 # "not pro" answer so we never accidentally fire paid dispatch on a free
 # node. This means Cloud-Free users see the same paywall OSS users do
 # until they upgrade, which matches the strategic split.
+#
+# The self-hosted signed-license branch closes the gap called out in
+# #3755 (alerts + approvals): a $190/node/yr licensee with no ``cm_``
+# cloud token is still on a paid tier — the entitlements resolver
+# reports ``source == "license"`` and a Pro-equivalent ``tier`` — so
+# they get the same paid-dispatch surface Cloud-Pro users do (auto-
+# pause, per-agent Telegram alert fan-out, ...). Starter self-hosted
+# keys (TIER_CLOUD_STARTER) stay in the free branch: Starter does not
+# unlock Pro-only features and neither should this gate.
+_PRO_EQUIVALENT_TIERS = frozenset(
+    {"pro", "cloud_pro", "trial", "enterprise"}
+)
+
+
+def _license_grants_pro():
+    """True iff the entitlement resolver reports a signed self-hosted
+    license on a Pro-equivalent tier.
+
+    Fail-closed: any exception (entitlements module unimportable, resolver
+    raises, unexpected shape) returns False so a flaky lookup never leaks a
+    paid dispatch path onto a free node.
+    """
+    try:
+        from clawmetry import entitlements as _ent
+
+        ent = _ent.get_entitlement()
+        if getattr(ent, "source", "") != "license":
+            return False
+        return str(getattr(ent, "tier", "")).strip().lower() in _PRO_EQUIVALENT_TIERS
+    except Exception:
+        return False
+
+
 def _is_pro_user():
     """Best-effort, fail-closed Pro check used to gate paid dispatch.
 
-    Returns True only when both signals are present:
-      1. ``cm_`` cloud token resolvable on disk (user is paired), and
-      2. The cached plan tier is one of ``cloud_pro`` / ``pro`` / ``trial``.
+    Returns True when either signal is present:
+      1. A signed self-hosted license on disk resolves to a Pro-equivalent
+         tier (``pro`` / ``cloud_pro`` / ``trial`` / ``enterprise``,
+         ``source == "license"``), OR
+      2. A ``cm_`` cloud token is on disk AND the cached plan tier is one
+         of ``cloud_pro`` / ``pro`` / ``trial``.
 
     Any failure (no token, missing cache, exception) returns False so we
     never leak a Cloud-Pro dispatch path onto a free / OSS-only node.
     """
+    if _license_grants_pro():
+        return True
     try:
         token = _read_cloud_token() or ""
     except Exception:

--- a/tests/test_is_pro_user_license_branch.py
+++ b/tests/test_is_pro_user_license_branch.py
@@ -1,0 +1,153 @@
+"""Tests for ``dashboard._is_pro_user()`` self-hosted signed-license branch.
+
+The helper originally returned True only for cm_-authed cloud-paired nodes
+with a cached Pro plan. Self-hosted paid licensees (source="license", tier
+in {pro, cloud_pro, trial, enterprise}) were treated as Free, so per-agent
+Telegram alert fan-out and auto-pause never fired for customers who had
+already paid.
+
+These tests pin:
+  * The signed-license branch flips True for every Pro-equivalent tier.
+  * TIER_CLOUD_STARTER stays False (Starter has no Pro-only features and
+    the auto-pause / Telegram-dispatch code paths gated by this helper
+    are Pro-only in ``project_alerts_pro_feature.md``).
+  * The pre-existing cm_ + cached-plan path is unchanged (True for
+    cloud_pro/pro/trial, False otherwise).
+  * Any exception in the entitlements read fails closed to False so a
+    flaky lookup never leaks paid dispatch onto a free node.
+
+Sibling of the #3755 pattern (``_evaluate_alerts_local`` +
+``_approvals_local_blocking_watcher``), both of which added the same
+``entitlements.get_entitlement()`` normalisation for signed-license
+self-hosted nodes.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+
+@pytest.fixture
+def dash(monkeypatch, tmp_path):
+    """Fresh dashboard + entitlements modules with HOME pointed at a
+    disposable tmp dir so ~/.clawmetry/* lookups are hermetic."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    # Reload entitlements first so its module-level _LICENSE_PATH picks up
+    # the new HOME (the path is captured at import time).
+    import importlib
+
+    import clawmetry.entitlements as _ent
+
+    importlib.reload(_ent)
+    _ent.invalidate()
+
+    import dashboard as _d
+
+    # The plan cache is a module global; reset it so cross-test leakage
+    # from other suites can't taint _is_pro_user's second read path.
+    _d._cloud_plan_cache = {}
+    yield _d
+    _ent.invalidate()
+
+
+def _stub_no_token(monkeypatch, dash):
+    """Force the cm_ path to fail (no token on disk)."""
+    monkeypatch.setattr(dash, "_read_cloud_token", lambda: "")
+
+
+def _stub_cm_token_with_plan(monkeypatch, dash, plan: str):
+    """Force the cm_ path: token present + given plan cached."""
+    monkeypatch.setattr(dash, "_read_cloud_token", lambda: "cm_test_token")
+    dash._cloud_plan_cache = {"plan": plan}
+
+
+def _stub_entitlement(monkeypatch, dash, *, tier: str, source: str):
+    """Force ``get_entitlement()`` to return a canned Entitlement."""
+    from clawmetry import entitlements as _ent
+
+    ent = _ent._build(tier, source)
+    monkeypatch.setattr(_ent, "get_entitlement", lambda force=False: ent)
+
+
+# ── License branch ────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("tier", ["pro", "cloud_pro", "trial", "enterprise"])
+def test_signed_license_pro_equivalent_tiers_are_pro(monkeypatch, dash, tier):
+    """A signed self-hosted license on a Pro-equivalent tier flips True
+    even when no cm_ token / cached plan is present."""
+    _stub_no_token(monkeypatch, dash)
+    _stub_entitlement(monkeypatch, dash, tier=tier, source="license")
+    assert dash._is_pro_user() is True
+
+
+def test_signed_license_starter_is_not_pro(monkeypatch, dash):
+    """TIER_CLOUD_STARTER is a paid tier but doesn't unlock Pro-only
+    features (auto-pause, Telegram fan-out). The gate must stay False."""
+    _stub_no_token(monkeypatch, dash)
+    _stub_entitlement(monkeypatch, dash, tier="cloud_starter", source="license")
+    assert dash._is_pro_user() is False
+
+
+def test_cloud_source_pro_tier_alone_does_not_flip_license_branch(monkeypatch, dash):
+    """The license branch only fires for ``source == "license"``. A
+    cloud-sourced entitlement (source="cloud") still routes through the
+    cm_ + cached-plan path — with no cm_ token here, that returns False."""
+    _stub_no_token(monkeypatch, dash)
+    _stub_entitlement(monkeypatch, dash, tier="cloud_pro", source="cloud")
+    assert dash._is_pro_user() is False
+
+
+def test_oss_free_entitlement_is_not_pro(monkeypatch, dash):
+    """No license + no cm_ token → OSS free entitlement → not pro."""
+    _stub_no_token(monkeypatch, dash)
+    # Default get_entitlement() with HOME pointed at empty tmp dir already
+    # returns the OSS-free entitlement; don't stub it out here.
+    assert dash._is_pro_user() is False
+
+
+def test_entitlement_lookup_exception_fails_closed(monkeypatch, dash):
+    """A raising entitlements resolver must NOT flip the gate True."""
+    _stub_no_token(monkeypatch, dash)
+    from clawmetry import entitlements as _ent
+
+    def _boom(force=False):
+        raise RuntimeError("entitlements is unhappy")
+
+    monkeypatch.setattr(_ent, "get_entitlement", _boom)
+    assert dash._is_pro_user() is False
+
+
+# ── Pre-existing cm_ + cached-plan branch (behaviour preservation) ────────
+
+
+@pytest.mark.parametrize("plan", ["cloud_pro", "pro", "trial"])
+def test_cm_token_plus_pro_plan_still_flips_true(monkeypatch, dash, plan):
+    """The original cm_ + cached-plan path must be unchanged."""
+    _stub_cm_token_with_plan(monkeypatch, dash, plan)
+    # Ensure the license branch is inert so we prove the cm_ path fires.
+    _stub_entitlement(monkeypatch, dash, tier="oss", source="oss")
+    assert dash._is_pro_user() is True
+
+
+@pytest.mark.parametrize("plan", ["free", "cloud_free", "cloud_starter", ""])
+def test_cm_token_plus_non_pro_plan_still_stays_false(monkeypatch, dash, plan):
+    """Non-Pro cached plans (including Starter) must not flip the gate."""
+    _stub_cm_token_with_plan(monkeypatch, dash, plan)
+    _stub_entitlement(monkeypatch, dash, tier="oss", source="oss")
+    assert dash._is_pro_user() is False
+
+
+def test_no_cm_token_and_oss_entitlement_is_not_pro(monkeypatch, dash):
+    """Belt-and-braces: no token, no license → False (fail-closed)."""
+    monkeypatch.setattr(dash, "_read_cloud_token", lambda: None)
+    _stub_entitlement(monkeypatch, dash, tier="oss", source="oss")
+    assert dash._is_pro_user() is False


### PR DESCRIPTION
## Summary

Extends `dashboard._is_pro_user()` — the centralised Pro-tier gate used for auto-pause (#1169) and per-agent Telegram alert fan-out (#1168) — to also flip `True` for a signed self-hosted license on a Pro-equivalent tier. Pre-fix, a customer with a valid `CLAW1...` license on disk but no `cm_` cloud token was treated as Free, so paid dispatch never fired even though they had already paid.

The pattern mirrors #3755 exactly: consult `clawmetry.entitlements.get_entitlement()`, require `source == "license"`, and gate on `tier in {pro, cloud_pro, trial, enterprise}`. `TIER_CLOUD_STARTER` stays in the free branch — Starter does not unlock Pro-only features and neither should the gate this helper governs.

## Change surface

- `dashboard.py` — new `_license_grants_pro()` helper (17 LOC), `_is_pro_user()` gets a one-line early-return; existing cm_ + cached-plan path untouched. Docstring and header comment refreshed.
- `tests/test_is_pro_user_license_branch.py` — new test module, 16 cases.

## Behaviour delta

| Signal on disk                                      | Before | After |
|-----------------------------------------------------|:------:|:-----:|
| Signed license, tier ∈ {pro, cloud_pro, trial, enterprise} | ❌ | ✅ |
| Signed license, tier = cloud_starter                | ❌ | ❌ (unchanged) |
| cm_ token + cached plan ∈ {cloud_pro, pro, trial}   | ✅ | ✅ (unchanged) |
| cm_ token + cached plan ∈ {free, cloud_free, starter, ""} | ❌ | ❌ (unchanged) |
| No token, no license                                | ❌ | ❌ (unchanged) |
| Any lookup raises                                   | ❌ | ❌ (unchanged — fail-closed preserved) |

The only newly-True row is the one that closes the same "paying customer, no cloud pairing" gap #3755 already closed for alerts and approvals.

## Test plan

- [x] `python3 -m pytest tests/test_is_pro_user_license_branch.py` — 16/16 pass
- [x] `python3 -m pytest tests/test_per_agent_budget.py` — 24/24 pass (no regression on the auto-pause + Telegram dispatch tests that call `_is_pro_user` indirectly)
- [x] `python3 -m py_compile dashboard.py tests/test_is_pro_user_license_branch.py` — clean
- [ ] CI (lint + full test matrix, once ready-for-review)

## Local operator verification checklist

Since the agent cannot exercise a live daemon on your machine:

1. Copy the changed files into the daemon's site-packages:
   ```bash
   cp dashboard.py ~/.clawmetry/lib/python*/site-packages/
   ```
   (adjust the Python minor if your install differs).
2. Clear `__pycache__` so the new bytecode is picked up:
   ```bash
   find ~/.clawmetry/lib/python*/site-packages/__pycache__ -name "dashboard*.pyc" -delete
   ```
3. Kickstart the daemon so it re-reads the module:
   ```bash
   launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync
   ```
4. Confirm the entitlement resolver still reports your live tier:
   ```bash
   curl -s http://localhost:8900/api/entitlement | jq '.tier, .source'
   ```
5. On a self-hosted licensed node (`~/.clawmetry/license.key` present, no `cm_` token):
   - Verify `_is_pro_user()` now returns True by hitting a surface it gates. E.g. `/api/budget/config` should include `auto_pause_enabled` as a settable field, and per-agent Telegram alert fan-out should fire when a budget breach is synthesised.
6. Decrypt the live cloud snapshot and browser-check that no Pro DOM leaks on a genuinely Free (OSS) node — the fail-closed invariant is still what protects that.

## Rollout posture

Behaviour-expansion for paid self-hosted customers only (they gain access to features they've already paid for). No new gate goes live; no free user's UI changes. Grace vs enforce is not consulted here — this helper is a source signal, not a paywall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017vgaWJcvtCjvh5HeuMmEkf

---
_Generated by [Claude Code](https://claude.ai/code/session_017vgaWJcvtCjvh5HeuMmEkf)_