### PR TITLE
fix: Windows uninstall crashed mid-purge (daemon never stopped, locked files, zombie launcher)

### DIFF
--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -245,6 +245,102 @@ def _kill_dashboard_processes() -> int:
     return killed
 
 
+def _windows_clawmetry_pids() -> list:
+    """Enumerate ``(pid, cmdline)`` of clawmetry processes on Windows.
+
+    CIM via PowerShell (no psutil dependency), restricted to python /
+    clawmetry executables so an editor with a clawmetry file open can
+    never match. Skips the current process and its parent so
+    ``clawmetry uninstall`` (running from clawmetry.exe) never kills
+    itself mid-run. Returns [] on any failure and on non-Windows.
+    """
+    if os.name != "nt":
+        return []
+    import json as _json
+    import subprocess as _sp
+
+    _patterns = (
+        "-m clawmetry",
+        "clawmetry.exe",
+        "clawmetry\\sync.py",
+        "clawmetry/sync.py",
+        "clawmetry\\dashboard.py",
+        "clawmetry/dashboard.py",
+    )
+    skip = {os.getpid(), os.getppid()}
+    try:
+        r = _sp.run(
+            [
+                "powershell", "-NoProfile", "-Command",
+                "Get-CimInstance Win32_Process -Filter "
+                "\"Name='python.exe' OR Name='pythonw.exe' OR Name='clawmetry.exe'\" "
+                "| Select-Object ProcessId,CommandLine | ConvertTo-Json -Compress",
+            ],
+            capture_output=True, text=True, check=False, timeout=30,
+        )
+        if r.returncode != 0 or not (r.stdout or "").strip():
+            return []
+        data = _json.loads(r.stdout)
+        if isinstance(data, dict):
+            data = [data]
+        out = []
+        for entry in data:
+            try:
+                pid = int(entry.get("ProcessId") or 0)
+            except (TypeError, ValueError):
+                continue
+            cmd = entry.get("CommandLine") or ""
+            if pid and pid not in skip and any(p in cmd for p in _patterns):
+                out.append((pid, cmd))
+        return out
+    except Exception:
+        return []
+
+
+def _stop_windows_processes() -> int:
+    """Terminate clawmetry daemon/dashboard processes on Windows.
+
+    Windows cannot delete files a live process holds open (WinError 32),
+    so uninstall MUST take every clawmetry process down BEFORE purging
+    files; skipping this crashed uninstall mid-purge on sync.log (#3914).
+    Returns the number of processes terminated. Never raises.
+    """
+    import subprocess as _sp
+
+    killed = 0
+    for pid, _cmd in _windows_clawmetry_pids():
+        try:
+            r = _sp.run(
+                ["taskkill", "/PID", str(pid), "/T", "/F"],
+                capture_output=True, check=False, timeout=30,
+            )
+            if r.returncode == 0:
+                killed += 1
+        except Exception:
+            pass
+    return killed
+
+
+def _safe_unlink(path, retries: int = 3, delay: float = 0.5) -> bool:
+    """``unlink()`` that survives Windows file locks. True when the file is gone.
+
+    A file some process still holds open (WinError 32) must produce a
+    warning and let the purge continue; one locked file aborting the whole
+    uninstall midway is how #3914 left half-uninstalled nodes behind.
+    """
+    import time as _time
+
+    for attempt in range(retries):
+        try:
+            path.unlink(missing_ok=True)
+            return True
+        except OSError:
+            if attempt + 1 < retries:
+                _time.sleep(delay)
+    print(f"  ⚠️  Could not remove {path} (still in use). Remove it manually.")
+    return False
+
+
 def _stop_existing_daemon() -> None:
     """Stop any running sync daemon, deregister old node, clear stale state."""
     import subprocess
@@ -1662,9 +1758,18 @@ def _cmd_uninstall() -> None:
             except Exception:
                 pass
         print("  ✅  Stopped and removed sync daemon" + (f" + {_stray} stray process(es)" if _stray else ""))
+    elif system == "Windows":
+        # No service manager here (daemon runs as a plain process or a
+        # Scheduled Task child). Stop every clawmetry process BEFORE the
+        # purge: Windows cannot delete files a live process holds open, so
+        # a running daemon crashed uninstall on its own sync.log (#3914).
+        _stray_win = _stop_windows_processes()
+        if _stray_win:
+            print(f"  ✅  Stopped {_stray_win} clawmetry process(es)")
     # The bootout above kills launchd-managed processes; this sweeps up
-    # dashboards started by hand (clawmetry --port ...).
-    _stray_dash = _kill_dashboard_processes()
+    # dashboards started by hand (clawmetry --port ...). POSIX only; the
+    # Windows sweep above already covers dashboards.
+    _stray_dash = 0 if system == "Windows" else _kill_dashboard_processes()
     if _stray_dash:
         print(f"  ✅  Killed {_stray_dash} dashboard process(es)")
 
@@ -1677,16 +1782,48 @@ def _cmd_uninstall() -> None:
     )
     print("  ✅  Uninstalled clawmetry pip package")
 
-    # 3. Remove config directory (includes venv)
+    # 2b. Windows: pip cannot remove Scripts\clawmetry.exe while this very
+    # uninstall runs through it (a running exe is locked). Left alone it
+    # becomes a zombie launcher whose every later invocation dies with
+    # ModuleNotFoundError. A running exe CAN'T be overwritten but its file
+    # CAN be deleted after exit, so hand the delete to a detached cmd that
+    # fires once this process is gone.
+    if os.name == "nt":
+        for _cand in (
+            Path(sys.executable).parent / "Scripts" / "clawmetry.exe",
+            Path(sys.executable).parent / "clawmetry.exe",
+        ):
+            if _cand.exists():
+                try:
+                    subprocess.Popen(
+                        f'cmd /c ping -n 3 127.0.0.1 >nul & del /f /q "{_cand}"',
+                        creationflags=0x00000008 | 0x08000000,  # DETACHED | NO_WINDOW
+                    )
+                    print(f"  ✅  Scheduled removal of {_cand} (in use by this uninstall)")
+                except Exception:
+                    print(f"  ⚠️  Could not schedule removal of {_cand}. Remove it manually.")
+
+    # 3. Remove config directory (includes venv). ignore_errors hides
+    # locked-file failures, so verify and re-try instead of printing a
+    # false success over a directory that is still there (#3914).
     if clawmetry_dir.exists():
         shutil.rmtree(clawmetry_dir, ignore_errors=True)
-        print(f"  ✅  Removed {clawmetry_dir}")
+        if clawmetry_dir.exists():
+            import time as _time_u
 
-    # 4. Remove config/state/log files
+            _time_u.sleep(0.5)
+            shutil.rmtree(clawmetry_dir, ignore_errors=True)
+        if clawmetry_dir.exists():
+            print(f"  ⚠️  Could not fully remove {clawmetry_dir} (files in use). Remove it manually.")
+        else:
+            print(f"  ✅  Removed {clawmetry_dir}")
+
+    # 4. Remove config/state/log files. A locked file (e.g. sync.log under
+    # a daemon that survived the stop) warns and continues, never aborts.
     for f in [CONFIG_FILE, STATE_FILE, LOG_FILE]:
         if f.exists():
-            f.unlink(missing_ok=True)
-            print(f"  ✅  Removed {f}")
+            if _safe_unlink(f):
+                print(f"  ✅  Removed {f}")
 
     # 5. Remove venv installs
     for vp in venv_paths:

--- a/tests/test_uninstall_windows.py
+++ b/tests/test_uninstall_windows.py
@@ -1,0 +1,150 @@
+"""Regression tests for Windows uninstall (#3914).
+
+`clawmetry uninstall` on Windows crashed mid-purge: no code path stopped
+the running sync daemon (the Darwin/Linux branches don't run, and
+_kill_dashboard_processes shells to POSIX `ps`), so the daemon kept
+sync.log open and the purge died on WinError 32 AFTER pip uninstall had
+already removed the package. The node was left with a zombie
+Scripts\\clawmetry.exe (every later invocation: ModuleNotFoundError), a
+half-deleted ~/.clawmetry, and a false "Removed" success message printed
+over a directory that was still there.
+
+Pinned here: processes are stopped BEFORE any file purge on Windows, a
+locked file warns-and-continues instead of aborting, and the process
+enumeration can never match the uninstall process itself.
+"""
+
+import builtins
+import os
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+import clawmetry.cli as cli
+
+
+# ── _safe_unlink ──────────────────────────────────────────────────────────
+
+
+def test_safe_unlink_removes_file(tmp_path):
+    f = tmp_path / "gone.log"
+    f.write_text("x")
+    assert cli._safe_unlink(f) is True
+    assert not f.exists()
+
+
+def test_safe_unlink_missing_file_is_ok(tmp_path):
+    assert cli._safe_unlink(tmp_path / "never-existed.log") is True
+
+
+def test_safe_unlink_locked_file_warns_not_raises(tmp_path, monkeypatch, capsys):
+    """The #3914 crash: one locked file must never abort the purge."""
+    f = tmp_path / "sync.log"
+    f.write_text("held open")
+    if os.name == "nt":
+        # Real lock: an open handle without FILE_SHARE_DELETE blocks unlink.
+        handle = open(f, "r")
+        try:
+            result = cli._safe_unlink(f, retries=2, delay=0.05)
+        finally:
+            handle.close()
+    else:
+        monkeypatch.setattr(
+            Path, "unlink", lambda self, missing_ok=False: (_ for _ in ()).throw(
+                PermissionError(32, "in use", str(f))
+            )
+        )
+        result = cli._safe_unlink(f, retries=2, delay=0.05)
+    assert result is False
+    assert "Remove it manually" in capsys.readouterr().out
+
+
+# ── _windows_clawmetry_pids ───────────────────────────────────────────────
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows process enumeration")
+def test_windows_pids_excludes_self_and_non_clawmetry(monkeypatch):
+    import json
+
+    fake_rows = [
+        {"ProcessId": os.getpid(), "CommandLine": "clawmetry.exe uninstall"},
+        {"ProcessId": os.getppid(), "CommandLine": "clawmetry.exe uninstall"},
+        {"ProcessId": 4242, "CommandLine": "python.exe -m clawmetry.sync"},
+        {"ProcessId": 4243, "CommandLine": "python.exe -m pytest tests"},
+    ]
+
+    def fake_run(cmd, **kwargs):
+        return types.SimpleNamespace(returncode=0, stdout=json.dumps(fake_rows), stderr="")
+
+    import subprocess
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    pids = [pid for pid, _ in cli._windows_clawmetry_pids()]
+    assert pids == [4242]  # daemon found; self, parent, and pytest excluded
+
+
+# ── uninstall ordering: stop processes BEFORE purging files ───────────────
+
+
+def test_uninstall_windows_stops_processes_before_purge(monkeypatch, tmp_path, capsys):
+    """Red on the un-fixed code: no Windows stop branch existed at all, so
+    the daemon lived through the purge and sync.log unlink crashed."""
+    import shutil
+    import subprocess
+    import platform
+    import clawmetry.sync as sync
+
+    calls = []
+
+    # Sandbox every filesystem root the command touches (both env vars —
+    # Windows expanduser ignores HOME, see clawmetry#3850).
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+    clawmetry_dir = tmp_path / ".clawmetry"
+    clawmetry_dir.mkdir()
+    log_file = clawmetry_dir / "sync.log"
+    log_file.write_text("live")
+    monkeypatch.setattr(sync, "CONFIG_FILE", clawmetry_dir / "config.json", raising=False)
+    monkeypatch.setattr(sync, "STATE_FILE", clawmetry_dir / "sync-state.json", raising=False)
+    monkeypatch.setattr(sync, "LOG_FILE", log_file, raising=False)
+
+    monkeypatch.setattr(platform, "system", lambda: "Windows")
+    monkeypatch.setattr(builtins, "input", lambda prompt="": "uninstall")
+    monkeypatch.setattr(cli, "_get_nemoclaw_sandboxes", lambda: [], raising=False)
+
+    monkeypatch.setattr(
+        cli, "_stop_windows_processes", lambda: calls.append("stop") or 1
+    )
+    monkeypatch.setattr(
+        cli, "_kill_dashboard_processes", lambda: calls.append("posix-dash-kill") or 0
+    )
+    monkeypatch.setattr(
+        cli, "_safe_unlink", lambda p, **kw: calls.append("unlink") or True
+    )
+    real_rmtree = shutil.rmtree
+    monkeypatch.setattr(
+        shutil, "rmtree",
+        lambda p, **kw: calls.append("rmtree") or real_rmtree(p, ignore_errors=True),
+    )
+    monkeypatch.setattr(
+        subprocess, "run",
+        lambda *a, **kw: calls.append("pip") or types.SimpleNamespace(returncode=0, stdout="", stderr=""),
+    )
+    monkeypatch.setattr(
+        subprocess, "Popen",
+        lambda *a, **kw: calls.append("popen") or types.SimpleNamespace(pid=0),
+    )
+
+    cli._cmd_uninstall()
+
+    assert "stop" in calls, f"Windows process stop never ran: {calls}"
+    first_purge = min(
+        (calls.index(c) for c in ("rmtree", "unlink", "pip") if c in calls),
+        default=len(calls),
+    )
+    assert calls.index("stop") < first_purge, f"purge before process stop: {calls}"
+    # The POSIX ps-based dashboard sweep is a silent no-op on Windows and
+    # must not be relied on there.
+    assert "posix-dash-kill" not in calls


### PR DESCRIPTION
## Why

Live failure on a real Windows 11 node (#3914): `clawmetry uninstall` crashed with `PermissionError: [WinError 32]` on `sync.log` after pip uninstall had already removed the package, leaving the worst possible state: a zombie `Scripts\clawmetry.exe` (every later invocation: `ModuleNotFoundError`), a half-deleted `~/.clawmetry`, a false 'Removed' success message, and the daemon still syncing from in-memory code.

Root cause: the uninstall flow has Darwin and Linux process-stop branches but none for Windows, and `_kill_dashboard_processes` shells to POSIX `ps` (silent no-op on nt). Windows cannot delete files a live process holds open.

## What

- `_windows_clawmetry_pids()`: CIM enumeration via PowerShell (no new dependencies), restricted to python/clawmetry executables plus explicit clawmetry cmdline patterns (an editor or a pytest run can never match); skips self and parent so uninstall never kills itself.
- `_stop_windows_processes()`: `taskkill /T /F` every match, wired as the Windows branch of step 1, BEFORE any file purge.
- `_safe_unlink()`: retry-then-warn on locked files; one locked file can no longer abort the purge midway.
- rmtree outcome verified: honest warning when the directory survives, no more false success.
- Zombie launcher handled: a detached `cmd` deletes the running `clawmetry.exe` right after the uninstall process exits (a running exe cannot be overwritten on Windows, but its file can be deleted post-exit).

## Verification

- 5 regression tests in `tests/test_uninstall_windows.py`, revert-proven on a real Windows 11 machine: all red on the un-fixed `cli.py` (the ordering guard fails because no Windows stop branch exists; the locked-file test reproduces the exact WinError 32 crash with a real file handle), all green with the fix.
- Existing uninstall suite: the 2 launchagent test failures are pre-existing on Windows dev boxes (Darwin-mocked tests hitting `os.getuid`), identical on clean main, untouched by this diff.
- Manual recovery of the affected node used exactly these steps (stop daemon, purge, remove launcher) and left it clean, so the automated order is field-tested.

Closes #3914. Same WinError 32 class as #3875 (auto-update brick), which can reuse `_windows_clawmetry_pids`/`_stop_windows_processes` for its dashboard-stop step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)