### PR TITLE
fix: Windows log streams (openclaw.cmd launch, select-on-pipe, missing tail)

### DIFF
--- a/clawmetry/process_control.py
+++ b/clawmetry/process_control.py
@@ -269,6 +269,55 @@ def _start_tokens_equivalent(want: str, have: str, tol: int = 3) -> bool:
     return any(abs(x - y) <= tol for x in a for y in b)
 
 
+class PipeLineReader:
+    """Portable non-blocking line reader for a subprocess pipe.
+
+    ``select.select()`` on a pipe is POSIX-only — on Windows select works
+    on sockets exclusively and raises OSError, which crashed every
+    streaming reader (dashboard SSE log streams, daemon gateway-log
+    streamer, sandbox OCSF drain). A daemon reader thread pumping lines
+    into a queue gives the same wait-with-timeout semantics on every OS.
+    """
+
+    def __init__(self, stream) -> None:
+        import queue
+        import threading
+
+        self._q: "queue.Queue[str]" = queue.Queue()
+        self._eof = False
+
+        def _pump() -> None:
+            try:
+                for line in iter(stream.readline, ""):
+                    self._q.put(line)
+            except Exception:
+                pass
+            finally:
+                self._eof = True
+
+        threading.Thread(target=_pump, daemon=True).start()
+
+    def readline(self, timeout: float = 0) -> Optional[str]:
+        """Next line, or None when nothing arrived within ``timeout``.
+
+        ``timeout=0`` polls only lines already buffered (the select(..., 0)
+        drain idiom); a positive timeout blocks up to that long.
+        """
+        import queue
+
+        try:
+            if timeout and timeout > 0:
+                return self._q.get(timeout=timeout)
+            return self._q.get_nowait()
+        except queue.Empty:
+            return None
+
+    @property
+    def eof(self) -> bool:
+        """True once the stream ended AND every buffered line was consumed."""
+        return self._eof and self._q.empty()
+
+
 def is_alive(pid: int) -> bool:
     """True iff ``pid`` is a live process we can address. Never raises.
 

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -123,6 +123,9 @@ _shutdown_lock = threading.Lock()
 
 # sb_name → Popen handle for long-lived `openshell logs --tail` processes
 _ocsf_tail_procs: dict = {}
+# sb_name → PipeLineReader over that Popen's stdout. select() on a pipe is
+# POSIX-only, so the non-blocking drain goes through the portable reader.
+_ocsf_tail_readers: dict = {}
 _OCSF_TAIL_DRAIN_LIMIT = 200  # max lines drained per sync tick
 
 
@@ -135,6 +138,7 @@ def _ocsf_tail_shutdown() -> None:
         except Exception:
             pass
     _ocsf_tail_procs.clear()
+    _ocsf_tail_readers.clear()
 
 
 def _drain_local_store_now() -> tuple[int, float]:
@@ -2474,17 +2478,22 @@ def sync_sandbox_sessions_openshell(config: dict, state: dict) -> int:
                     proc = _openshell_sandbox_logs_tail(sb_name)
                     if proc is not None:
                         _ocsf_tail_procs[sb_name] = proc
+                        from clawmetry.process_control import PipeLineReader
+                        _ocsf_tail_readers[sb_name] = PipeLineReader(proc.stdout)
 
                 if proc is not None:
                     # Non-blocking drain: read only lines already buffered.
-                    import select as _select
+                    # (select() on a pipe is POSIX-only; the reader thread
+                    # gives the same timeout-0 poll on every OS.)
+                    reader = _ocsf_tail_readers.get(sb_name)
+                    if reader is None:
+                        from clawmetry.process_control import PipeLineReader
+                        reader = PipeLineReader(proc.stdout)
+                        _ocsf_tail_readers[sb_name] = reader
                     ingested = 0
                     for _ in range(_OCSF_TAIL_DRAIN_LIMIT):
-                        ready, _, _ = _select.select([proc.stdout], [], [], 0)
-                        if not ready:
-                            break
-                        line = proc.stdout.readline()
-                        if not line:
+                        line = reader.readline(0)
+                        if line is None:
                             break
                         line = line.strip()
                         if not line:
@@ -17214,44 +17223,47 @@ def start_log_streamer(config: dict, paths: dict) -> threading.Thread:
     def _stream_worker():
         log.info(f"Log streamer started — watching {log_dir}")
         current_file = None
-        proc = None
+        fh = None
         batch = []
         last_push = time.time()
 
         while True:
             try:
-                # Find/rotate to latest log file
+                # Find/rotate to latest log file. Pure-Python follow with
+                # tail -f -n 0 semantics: ``tail`` does not exist on Windows
+                # and select() on a pipe is POSIX-only, so the subprocess
+                # approach silently killed log streaming there.
                 latest = _find_latest_log()
                 if latest != current_file:
-                    if proc:
+                    if fh:
                         try:
-                            proc.kill()
+                            fh.close()
                         except Exception:
                             pass
+                        fh = None
                     current_file = latest
                     if not current_file:
                         time.sleep(5)
                         continue
-                    proc = subprocess.Popen(
-                        ["tail", "-f", "-n", "0", current_file],
-                        stdout=subprocess.PIPE,
-                        stderr=subprocess.PIPE,
-                        text=True,
-                    )
-                    log.info(f"Tailing {current_file}")
+                    try:
+                        fh = open(
+                            current_file, "r", encoding="utf-8", errors="replace"
+                        )
+                        fh.seek(0, 2)
+                        log.info(f"Tailing {current_file}")
+                    except OSError:
+                        fh = None
 
-                if not proc or not proc.stdout:
+                if not fh:
                     time.sleep(2)
                     continue
 
-                # Non-blocking read with select
-                import select
-
-                ready, _, _ = select.select([proc.stdout], [], [], STREAM_INTERVAL)
-                if ready:
-                    line = proc.stdout.readline()
-                    if line:
-                        batch.append(line.rstrip())
+                line = fh.readline()
+                if line:
+                    batch.append(line.rstrip())
+                else:
+                    # Caught up — wait for new lines without spinning.
+                    time.sleep(min(STREAM_INTERVAL, 1.0))
 
                 # Push batch every STREAM_INTERVAL seconds
                 now = time.time()
@@ -17270,12 +17282,12 @@ def start_log_streamer(config: dict, paths: dict) -> threading.Thread:
             except Exception as e:
                 log.debug(f"Stream worker error: {e}")
                 time.sleep(5)
-                if proc:
+                if fh:
                     try:
-                        proc.kill()
+                        fh.close()
                     except Exception:
                         pass
-                    proc = None
+                    fh = None
                     current_file = None
 
     t = threading.Thread(target=_stream_worker, daemon=True, name="log-streamer")

--- a/routes/infra.py
+++ b/routes/infra.py
@@ -26,7 +26,6 @@ mechanical move — zero behaviour change.
 
 import json
 import os
-import select
 import sqlite3
 import subprocess
 import time
@@ -889,22 +888,32 @@ def _generate_openclaw_json_logs(started_at, sse_max_seconds, release_fn):
     text output).  Callers must check ``shutil.which("openclaw")`` before
     calling; this generator assumes the binary is available.
     """
+    import shutil as _shutil
+
+    from clawmetry.process_control import PipeLineReader
+
+    # Resolve through which(): on Windows the openclaw CLI is an npm
+    # ``openclaw.cmd`` wrapper, and CreateProcess only launches it when
+    # given the full name with extension — a bare "openclaw" argv raised
+    # FileNotFoundError (WinError 2) mid-stream, after headers were sent.
     proc = subprocess.Popen(
-        ["openclaw", "logs", "--follow", "--json"],
+        [_shutil.which("openclaw") or "openclaw", "logs", "--follow", "--json"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         text=True,
     )
+    # select() on a pipe is POSIX-only; the reader thread is portable.
+    reader = PipeLineReader(proc.stdout)
     try:
         while True:
             if time.time() - started_at > sse_max_seconds:
                 yield 'event: done\ndata: {"reason":"max_duration_reached"}\n\n'
                 break
-            ready, _, _ = select.select([proc.stdout], [], [], 1.0)
-            if not ready:
-                continue
-            raw_line = proc.stdout.readline()
-            if not raw_line:
+            raw_line = reader.readline(1.0)
+            if raw_line is None:
+                if reader.eof:
+                    yield 'event: done\ndata: {"reason":"stream_ended"}\n\n'
+                    break
                 continue
             raw = raw_line.rstrip()
             try:
@@ -966,28 +975,32 @@ def api_logs_stream():
             yield 'data: {"line":"No log file found"}\n\n'
             release()
             return
-        proc = subprocess.Popen(
-            ["tail", "-f", "-n", "0", log_file],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-        )
+        # Pure-Python follow (tail -f -n 0 semantics: only new lines).
+        # ``tail`` does not exist on Windows and select() on a pipe is
+        # POSIX-only, so the subprocess approach broke this stream there;
+        # reading the file directly needs neither.
+        try:
+            fh = open(log_file, "r", encoding="utf-8", errors="replace")
+        except OSError:
+            yield 'data: {"line":"Cannot open log file"}\n\n'
+            release()
+            return
+        fh.seek(0, 2)
         try:
             while True:
                 if time.time() - started_at > _d.SSE_MAX_SECONDS:
                     yield 'event: done\ndata: {"reason":"max_duration_reached"}\n\n'
                     break
-                ready, _, _ = select.select([proc.stdout], [], [], 1.0)
-                if not ready:
+                line = fh.readline()
+                if not line:
+                    time.sleep(1.0)
                     continue
-                line = proc.stdout.readline()
-                if line:
-                    yield f"data: {json.dumps({'line': line.rstrip()})}\n\n"
+                yield f"data: {json.dumps({'line': line.rstrip()})}\n\n"
         except GeneratorExit:
             pass
         finally:
             try:
-                proc.kill()
+                fh.close()
             except Exception:
                 pass
             release()

--- a/tests/test_log_streams_windows.py
+++ b/tests/test_log_streams_windows.py
@@ -1,0 +1,132 @@
+"""Regression tests for portable log streaming (#windows-streams).
+
+Windows broke every log stream three different ways:
+- ``Popen(["openclaw", ...])`` cannot launch the npm ``openclaw.cmd``
+  wrapper (CreateProcess wants the full name with extension), so
+  /api/logs-stream crashed with FileNotFoundError mid-SSE and the
+  frontend's retries then drowned in 429s.
+- ``select.select()`` on a pipe is POSIX-only (Windows select works on
+  sockets exclusively), used by both SSE generators, the daemon
+  gateway-log streamer, and the sandbox OCSF drain.
+- ``tail`` does not exist on Windows (dashboard fallback stream and the
+  daemon streamer spawned it).
+
+The fix: ``process_control.PipeLineReader`` (thread+queue pump) for
+subprocess pipes, pure-Python file follows instead of ``tail``, and
+``shutil.which()`` resolution for the openclaw binary.
+"""
+
+import io
+import re
+import subprocess
+import sys
+import time
+import types
+from pathlib import Path
+
+from clawmetry.process_control import PipeLineReader
+
+
+def test_pipe_line_reader_reads_live_subprocess():
+    proc = subprocess.Popen(
+        [sys.executable, "-c", "print('alpha'); print('beta')"],
+        stdout=subprocess.PIPE, text=True,
+    )
+    reader = PipeLineReader(proc.stdout)
+    lines = []
+    deadline = time.time() + 10
+    while len(lines) < 2 and time.time() < deadline:
+        line = reader.readline(0.5)
+        if line is not None:
+            lines.append(line.strip())
+    proc.wait(timeout=10)
+    assert lines == ["alpha", "beta"]
+    deadline = time.time() + 5
+    while not reader.eof and time.time() < deadline:
+        time.sleep(0.05)
+    assert reader.eof
+    assert reader.readline(0) is None
+
+
+def test_pipe_line_reader_timeout_zero_polls_buffered_only():
+    reader = PipeLineReader(io.StringIO("one\n"))
+    deadline = time.time() + 5
+    line = None
+    while line is None and time.time() < deadline:
+        line = reader.readline(0)
+    assert line == "one\n"
+    assert reader.readline(0) is None
+
+
+def test_json_log_stream_uses_resolved_binary_and_no_select(monkeypatch):
+    """Red on the un-fixed code twice over: argv[0] was a bare "openclaw"
+    (WinError 2 on Windows), and select.select on a fake pipe raises."""
+    import routes.infra as infra
+
+    captured = {}
+
+    class _FakeProc:
+        def __init__(self):
+            self.stdout = io.StringIO(
+                '{"type":"log","message":"hello-stream"}\n'
+            )
+        def kill(self):
+            pass
+
+    def fake_popen(argv, **kwargs):
+        captured["argv"] = argv
+        return _FakeProc()
+
+    monkeypatch.setattr(infra.subprocess, "Popen", fake_popen)
+    import shutil as _shutil
+    monkeypatch.setattr(_shutil, "which", lambda name: r"C:\fake\openclaw.CMD")
+
+    released = []
+    gen = infra._generate_openclaw_json_logs(
+        started_at=time.time(), sse_max_seconds=5, release_fn=lambda: released.append(1)
+    )
+    events = []
+    for ev in gen:
+        events.append(ev)
+        if len(events) >= 2:
+            break
+    assert captured["argv"][0] == r"C:\fake\openclaw.CMD"
+    assert any("hello-stream" in e for e in events)
+    # Stream ends (eof) rather than spinning until max_duration.
+    assert any("stream_ended" in e or "max_duration" in e for e in events)
+
+
+# ── Class guard: the POSIX idioms must not come back ──────────────────────
+
+_REPO = Path(__file__).resolve().parents[1]
+_STREAM_FILES = [
+    _REPO / "routes" / "infra.py",
+    _REPO / "clawmetry" / "sync.py",
+]
+
+
+def _code_lines(path):
+    for lineno, line in enumerate(
+        path.read_text(encoding="utf-8", errors="replace").splitlines(), 1
+    ):
+        yield lineno, line.split("#", 1)[0]
+
+
+def test_no_select_on_pipes_in_stream_paths():
+    offenders = [
+        f"{p.name}:{n}" for p in _STREAM_FILES
+        for n, code in _code_lines(p) if re.search(r"\bselect\.select\(", code)
+    ]
+    assert offenders == [], (
+        f"select.select on a pipe is POSIX-only; use PipeLineReader: {offenders}"
+    )
+
+
+def test_no_tail_subprocess_in_stream_paths():
+    offenders = [
+        f"{p.name}:{n}" for p in _STREAM_FILES
+        for n, code in _code_lines(p) if re.search(r"\"tail\"", code)
+    ]
+    assert offenders == [], (
+        f"`tail` does not exist on Windows; follow the file in Python: {offenders}"
+    )


### PR DESCRIPTION
Live failure on a real Windows 11 node: the dashboard Logs tab crashed mid-SSE (`FileNotFoundError` from `Popen(["openclaw", ...])` - CreateProcess cannot launch the npm `openclaw.cmd` wrapper from a bare name), and the frontend's retries then hit the SSE rate limiter (endless 429s). The same POSIX assumptions break the fallback stream and the daemon: `select.select()` on a pipe raises on Windows (sockets only), and `tail` does not exist there.

Fixes all four sites through one portable primitive:

- `process_control.PipeLineReader`: reader thread + queue with wait-with-timeout and timeout-0 poll semantics on every OS. Used by the `openclaw logs --follow --json` SSE generator and the sandbox OCSF drain (reader registry cleared on daemon shutdown).
- `shutil.which()` resolution for the openclaw binary (CreateProcess launches .cmd only with the full name).
- Pure-Python file follows (tail -f -n 0 semantics) for the dashboard fallback stream and the daemon gateway-log streamer - one fewer subprocess on every OS, no tail dependency.
- The JSON SSE stream ends with an honest `stream_ended` event on EOF instead of spinning until max_duration.

Verification: 5 regression tests, revert-proven on a real Windows 11 machine (collection fails on the un-fixed tree; the class guards flag all four historical sites). Includes auto-discovering guards that fail if `select.select` or a `tail` subprocess returns to `routes/infra.py` or `clawmetry/sync.py`.

Same Windows-hardening arc as #3854 / #3915; the audit that predicted this class is in #3854's history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)