### PR TITLE
fix: honest Agents tab empty state when daemon not running but runtime detected

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -9181,7 +9181,19 @@ async function renderInventory() {
     if (statsEl) statsEl.style.display = 'none';
     if (stripEl) stripEl.style.display = 'none';
     rosterEl.innerHTML = '';
-    if (emptyEl) emptyEl.style.display = '';
+    if (emptyEl) {
+      var bodyEl = document.getElementById('inv-empty-body');
+      var detected = (inv && inv.detectedRuntimes) || [];
+      if (detected.length && bodyEl) {
+        var rtNames = detected.map(function (r) { return r.displayName || r.name; }).join(', ');
+        var msg = inv.daemonRunning
+          ? rtNames + ' detected. Sync is starting up -- data will appear shortly.'
+          : rtNames + ' is running, but the sync daemon is not ingesting yet.'
+            + ' Run: <code>clawmetry connect</code> (or <code>clawmetry sync</code>).';
+        bodyEl.innerHTML = msg;
+      }
+      emptyEl.style.display = '';
+    }
     return;
   }
   if (emptyEl) emptyEl.style.display = 'none';

--- a/routes/inventory.py
+++ b/routes/inventory.py
@@ -53,6 +53,26 @@ def _zero():
     return {"agents": [], "total": 0}
 
 
+def _daemon_running() -> bool:
+    try:
+        from routes.local_query import _cached_discovery
+        return _cached_discovery() is not None
+    except Exception:
+        return False
+
+
+def _detected_runtimes() -> list:
+    try:
+        from clawmetry.adapters import registry
+        return [
+            r.to_dict()
+            for r in registry.detect_all()
+            if getattr(r, "detected", False)
+        ]
+    except Exception:
+        return []
+
+
 def _build_local_inventory():
     """Compose the node-wide roster locally, reusing the daemon's builder so the
     shape matches the snapshot byte-for-byte. Never raises; returns the
@@ -147,11 +167,18 @@ def api_inventory():
         node_wide = _build_local_inventory()
     except Exception:
         node_wide = None
-    if not node_wide or not isinstance(node_wide, dict):
-        return jsonify(_zero())
-    # Empty roster: return the bare zero shape (the cold-fallthrough contract)
-    # so cloud / store-less renders an honest empty state, not a stray nodeId.
-    if not node_wide.get("agents"):
+    if not node_wide or not isinstance(node_wide, dict) or not node_wide.get("agents"):
+        # Local store enabled but roster empty — surface detected runtimes so
+        # the UI can render an honest "daemon not ingesting yet" state instead
+        # of the misleading "No agents yet" copy (issue #3917).
+        detected = _detected_runtimes()
+        if detected:
+            return jsonify({
+                "agents": [],
+                "total": 0,
+                "detectedRuntimes": detected,
+                "daemonRunning": _daemon_running(),
+            })
         return jsonify(_zero())
 
     # Per-runtime no-leak: when a specific runtime is requested, return ONLY

--- a/tests/test_agent_inventory.py
+++ b/tests/test_agent_inventory.py
@@ -260,6 +260,43 @@ def test_query_agent_meta_not_nested_in_write_lock(app_and_store):
 # ── 6. snapshot wiring: both keys are emitted in the payload dict ───────────
 
 
+def test_api_inventory_empty_store_with_detected_runtimes(app_and_store, monkeypatch):
+    """When the local store is enabled but the roster is empty AND registry
+    detects runtimes, /api/inventory must return detectedRuntimes + daemonRunning
+    instead of the bare zero shape (issue #3917)."""
+    a, ls, inv_mod = app_and_store
+    from clawmetry.adapters.base import DetectResult
+
+    fake_detect = DetectResult(
+        name="openclaw",
+        display_name="OpenClaw",
+        detected=True,
+    )
+    monkeypatch.setattr(inv_mod, "_detected_runtimes", lambda: [fake_detect.to_dict()])
+    monkeypatch.setattr(inv_mod, "_daemon_running", lambda: False)
+
+    cli = a.test_client()
+    body = cli.get("/api/inventory").get_json()
+    assert body["agents"] == []
+    assert body["total"] == 0
+    assert body["daemonRunning"] is False
+    detected = body["detectedRuntimes"]
+    assert isinstance(detected, list) and len(detected) == 1
+    assert detected[0]["name"] == "openclaw"
+    assert detected[0]["displayName"] == "OpenClaw"
+
+
+def test_api_inventory_empty_store_no_detected_runtimes_still_zero(app_and_store, monkeypatch):
+    """When neither the store has agents nor any runtime is detected, the
+    response must be the bare zero shape (the cloud cold-fallthrough contract)."""
+    a, ls, inv_mod = app_and_store
+    monkeypatch.setattr(inv_mod, "_detected_runtimes", lambda: [])
+
+    cli = a.test_client()
+    body = cli.get("/api/inventory").get_json()
+    assert body == {"agents": [], "total": 0}
+
+
 def test_snapshot_emits_both_inventory_keys():
     """Mechanical guard that ``sync_system_snapshot`` ships both inventory keys
     (node-wide + byRuntime) built from the already-computed rollups. A full


### PR DESCRIPTION
Closes #3917

## What changed

When OpenClaw (or another runtime) is detected on the machine but the sync daemon hasn't been started yet, the Agents tab used to show "No agents yet, and that is fine." — contradicting the header which already showed "OpenClaw - 5 sessions". This is the gaslighting bug reported in #3917.

**Root cause:** `/api/inventory` builds its roster from DuckDB rollups (populated only by the daemon). Without a running daemon the store is empty, so the roster is empty, so the UI shows the generic "nothing here" state — even though `registry.detect_all()` works independently and correctly sees the runtime.

**Fix:**

- `routes/inventory.py` — two small helpers (`_daemon_running`, `_detected_runtimes`) and a single conditional: when the local store is enabled but the roster is empty AND `registry.detect_all()` finds detected runtimes, return `{"agents": [], "total": 0, "detectedRuntimes": [...], "daemonRunning": <bool>}` instead of the bare zero shape. The cloud cold-fallthrough path (`is_local_store_read_enabled() == False`) is untouched.
- `clawmetry/static/js/app.js` — in `renderInventory()`, when `agents.length === 0` and `inv.detectedRuntimes` is non-empty, update `inv-empty-body` with an actionable message: `"OpenClaw is running, but the sync daemon is not ingesting yet. Run: clawmetry connect"` (or a "starting up" variant when the daemon is present but data hasn't arrived yet).
- `tests/test_agent_inventory.py` — two new tests: one asserts the richer response when detected runtimes exist, one asserts the bare zero shape still returns when no runtimes are detected.

## Test plan

- `pytest tests/test_agent_inventory.py tests/test_inventory_selected_legibility.py` — 15/15 pass
- Manual: fresh install with OpenClaw running but without `clawmetry connect` → Agents tab now shows the actionable message instead of "No agents yet"

---
_Generated by [Claude Code](https://claude.ai/code/session_01AT7S3JKcady3d9rh8xcSDW)_