### PR TITLE
fix(c6): redirect daily C6 reminders to canonical tracking issue #3906

### DIFF
--- a/.github/workflows/apply-required-checks.yml
+++ b/.github/workflows/apply-required-checks.yml
@@ -36,7 +36,7 @@ name: Apply required E2E status checks (C6 -- one-shot)
 #   clawmetry-landing.
 #
 # Idempotent: running multiple times is safe.
-# Tracking: vivekchand/clawmetry#3897
+# Tracking: vivekchand/clawmetry#3906
 
 on:
   workflow_dispatch:

--- a/.github/workflows/c6-health.yml
+++ b/.github/workflows/c6-health.yml
@@ -8,7 +8,7 @@ name: C6 daily health check (branch-protection audit -- all 3 repos)
 # /branches/main endpoint (works for public repos; falls back to
 # UNKNOWN if protection detail is not visible cross-repo).
 #
-# On failure: posts an @-mentioned reminder to tracking issue #3752
+# On failure: posts an @-mentioned reminder to tracking issue #3906
 # at most once per calendar day. On success: posts a GREEN confirmation.
 #
 # To close C6:
@@ -18,7 +18,7 @@ name: C6 daily health check (branch-protection audit -- all 3 repos)
 #   2. Or: bash scripts/close-c6.sh
 #   3. Or: Settings > Branches > main > Required status checks (each repo)
 #
-# Tracking: vivekchand/clawmetry#3752
+# Tracking: vivekchand/clawmetry#3906
 
 on:
   schedule:
@@ -48,7 +48,7 @@ jobs:
 
           TOKEN = os.environ["GITHUB_TOKEN"]
           OWNER = "vivekchand"
-          TRACKING_ISSUE = 3752
+          TRACKING_ISSUE = 3906
           MARKER = "<!-- c6-health-check -->"
 
           HEADERS = {

--- a/.github/workflows/c6-pr-gate.yml
+++ b/.github/workflows/c6-pr-gate.yml
@@ -3,7 +3,7 @@ name: C6 Required-status-checks gate (PR audit)
 # Runs on every pull request to surface whether C6 (required-status-checks)
 # is configured on main. Fails visibly on every PR until the admin closes C6.
 #
-# The daily c6-health.yml posts to issue #3752 but the admin may not check
+# The daily c6-health.yml posts to issue #3906 but the admin may not check
 # that issue between merges. This check appears directly in the PR status
 # list alongside OSS golden path, E2E Browser Tests, etc. -- impossible to
 # miss when reviewing a PR.
@@ -34,7 +34,7 @@ name: C6 Required-status-checks gate (PR audit)
 #     bash scripts/close-c6.sh
 #     (uses your existing gh CLI session -- no PAT creation needed)
 #
-# Tracking: vivekchand/clawmetry#3752 (C6)
+# Tracking: vivekchand/clawmetry#3906
 
 on:
   pull_request:

--- a/.github/workflows/c6-pr-gate.yml
+++ b/.github/workflows/c6-pr-gate.yml
@@ -34,7 +34,7 @@ name: C6 Required-status-checks gate (PR audit)
 #     bash scripts/close-c6.sh
 #     (uses your existing gh CLI session -- no PAT creation needed)
 #
-# Tracking: vivekchand/clawmetry#3906
+# Tracking: vivekchand/clawmetry#3906 (C6)
 
 on:
   pull_request:

--- a/.github/workflows/c6-schedule-heal.yml
+++ b/.github/workflows/c6-schedule-heal.yml
@@ -23,8 +23,7 @@ name: C6 auto-heal (daily required-checks application)
 #     clawmetry, clawmetry-cloud, clawmetry-landing
 #   This workflow picks it up at 10:15am UTC and closes C6 automatically.
 #
-# Tracking: vivekchand/clawmetry#3864 (E2E robustness epic)
-#           vivekchand/clawmetry#3752 (C6)
+# Tracking: vivekchand/clawmetry#3906
 
 on:
   schedule:
@@ -139,7 +138,7 @@ jobs:
               echo "bash scripts/close-c6.sh"
               echo "\`\`\`"
               echo ""
-              echo "Tracking: [#3864](https://github.com/vivekchand/clawmetry/issues/3864)"
+              echo "Tracking: [#3906](https://github.com/vivekchand/clawmetry/issues/3906)"
             fi
           } >> "$GITHUB_STEP_SUMMARY"
 
@@ -150,7 +149,7 @@ jobs:
           echo ""
           echo "ACTION REQUIRED: Add E2E_ADMIN_PAT to close C6."
           echo "See the job summary above for a formatted status report and close options."
-          echo "Tracking: https://github.com/vivekchand/clawmetry/issues/3864"
+          echo "Tracking: https://github.com/vivekchand/clawmetry/issues/3906"
           exit 1
 
       - name: Apply required E2E status checks (C6)
@@ -173,7 +172,7 @@ jobs:
             echo "- [clawmetry-cloud branch protection](https://github.com/vivekchand/clawmetry-cloud/settings/branches)"
             echo "- [clawmetry-landing branch protection](https://github.com/vivekchand/clawmetry-landing/settings/branches)"
             echo ""
-            echo "Tracking: [#3864](https://github.com/vivekchand/clawmetry/issues/3864)"
+            echo "Tracking: [#3906](https://github.com/vivekchand/clawmetry/issues/3906)"
           } >> "$GITHUB_STEP_SUMMARY"
           echo "C6 auto-heal complete. If apply_required_status_checks.py exited 0, branch protection"
-          echo "is configured on all 3 repos. Tracking: https://github.com/vivekchand/clawmetry/issues/3864"
+          echo "is configured on all 3 repos. Tracking: https://github.com/vivekchand/clawmetry/issues/3906"

--- a/scripts/close-c6.sh
+++ b/scripts/close-c6.sh
@@ -19,7 +19,7 @@
 # After running: every PR in those 3 repos must pass the E2E suite to merge.
 # This closes criterion C6 of the E2E Robustness epic.
 #
-# Tracking: vivekchand/clawmetry#3752
+# Tracking: vivekchand/clawmetry#3906
 
 set -euo pipefail
 


### PR DESCRIPTION
## What

The C6 daily health workflow (`c6-health.yml`) was posting @-mention reminders to **issue #3752** (stale). The auto-heal workflow referenced **#3864**, and the helper scripts pointed to **#3897**. None of these match the canonical E2E robustness tracking issue **#3906** where the cron fires its per-fire logs.

Because the dedup check in `c6-health.yml` reads back from issue #3752 (not #3906), it would either:
- silently 404 on `post_comment()` if #3752 does not exist (workflow crash every day), or
- post reminders to an issue nobody watches

Either way, the daily "please set branch protection" nudge was invisible.

## Changes (tracking references only, zero logic change)

| File | Old ref | New ref |
|------|---------|---------|
| `c6-health.yml` | `TRACKING_ISSUE = 3752` | `TRACKING_ISSUE = 3906` |
| `c6-health.yml` comments | `#3752` | `#3906` |
| `c6-schedule-heal.yml` | `#3864`, `#3752` | `#3906` |
| `close-c6.sh` | `#3752` | `#3906` |
| `apply-required-checks.yml` | `#3897` | `#3906` |

## Effect after merge

The `c6-health.yml` daily job (9 UTC) will post its next @vivekchand reminder directly on issue #3906. The dedup will also read from #3906, so it correctly skips repeat posts on the same day.

C6 still requires the admin branch-protection action -- this PR just ensures the daily nudge reaches the right place.

## Acceptance test

After merge, the next `c6-health.yml` run (9 UTC daily, or trigger manually via `workflow_dispatch`) should post a comment on https://github.com/vivekchand/clawmetry/issues/3906 with the `<!-- c6-health-check -->` marker.

---

E2E Robustness fire log entry: `2026-07-22T08:30Z -- c6-health dedup bug fixed via this PR; daily reminders now route to #3906`

---
_Generated by [Claude Code](https://claude.ai/code/session_01QuQ3nGTYhdySmzT7nzwg5Q)_