### PR TITLE
fix(c6): update c6-pr-gate.yml to reference canonical tracking issue #3906

### DIFF
--- a/.github/workflows/c6-pr-gate.yml
+++ b/.github/workflows/c6-pr-gate.yml
@@ -3,7 +3,7 @@ name: C6 Required-status-checks gate (PR audit)
 # Runs on every pull request to surface whether C6 (required-status-checks)
 # is configured on main. Fails visibly on every PR until the admin closes C6.
 #
-# The daily c6-health.yml posts to issue #3752 but the admin may not check
+# The daily c6-health.yml posts to issue #3906 but the admin may not check
 # that issue between merges. This check appears directly in the PR status
 # list alongside OSS golden path, E2E Browser Tests, etc. -- impossible to
 # miss when reviewing a PR.
@@ -34,7 +34,7 @@ name: C6 Required-status-checks gate (PR audit)
 #     bash scripts/close-c6.sh
 #     (uses your existing gh CLI session -- no PAT creation needed)
 #
-# Tracking: vivekchand/clawmetry#3752 (C6)
+# Tracking: vivekchand/clawmetry#3906 (C6)
 
 on:
   pull_request:


### PR DESCRIPTION
## Summary

PR #3929 fixed stale C6 tracking references in `c6-health.yml`, `c6-schedule-heal.yml`, `close-c6.sh`, and `apply-required-checks.yml` but missed `c6-pr-gate.yml`.

`c6-pr-gate.yml` runs on every PR and its job log is what developers see when they click the failing C6 check in the PR status list. Both comment references still pointed to `#3752` (stale), so clicking through from a failing PR check routed developers to the wrong issue.

**Changes (comments only, zero logic):**

| Location | Old | New |
|----------|-----|-----|
| Inline comment, line 9 | `posts to issue #3752` | `posts to issue #3906` |
| Tracking footer | `clawmetry#3752 (C6)` | `clawmetry#3906 (C6)` |

**Acceptance test:** After merge, a developer who sees a failing C6 check in their PR, opens the job log, and reads the tracking line will see the correct issue URL pointing to #3906.

**Why this fire:** C6 is the only remaining RED criterion (6/7 green). This is the last stale reference not covered by the companion PR #3929 cleanup. Together they ensure every C6 touchpoint -- health cron, schedule-heal, close-c6.sh, apply-required-checks.yml, and c6-pr-gate.yml -- routes to the canonical tracking issue.

Companion PR in clawmetry-cloud: fixes the same stale reference in that repo's `apply-required-checks.yml` (`#2146` -> `#3906`).

E2E Robustness epic: vivekchand/clawmetry#3906

---
_Generated by [Claude Code](https://claude.ai/code/session_01A3BmiNqRkTJNAFLQMwqW5F)_