### PR TITLE
fix(license): inspect_key returns same envelope shape as current_license_info

### DIFF
--- a/clawmetry/license.py
+++ b/clawmetry/license.py
@@ -848,11 +848,22 @@ def inspect_key(key: str) -> dict | None:
       * Pre-flight from the CLI / dashboard before clicking *Activate*.
       * Air-gap: validate a key on a staging box before transporting it.
 
-    Returns a dict with the same shape as :func:`current_license_info` (so the
-    UI can render the two the same way), or ``None`` if the signature is bogus
-    or the token is malformed. An EXPIRED but otherwise-valid token returns a
-    dict with ``valid=False`` + ``status="expired"`` so the caller can still
-    show what the (now-stale) key was for. Never raises, never touches disk."""
+    Returns a dict with the same field set as :func:`current_license_info` (so
+    the UI can render the two the same way, and a support script can jq the
+    same keys off either) — or ``None`` if the signature is bogus or the token
+    is malformed. An EXPIRED but otherwise-valid token returns a dict with
+    ``valid=False`` + ``status="expired"`` so the caller can still show what
+    the (now-stale) key was for.
+
+    ``pubkey_fingerprint_sha256`` carries the payload-independent trust anchor
+    identity so a support call ("does the key you're pasting verify against
+    the fingerprint we ship?") can be answered off the same envelope. The two
+    on-disk-only fields — ``permissions_safe`` and ``file_mode`` — collapse to
+    ``None`` on a dry-run since there is no file to stat yet; the keys are
+    kept for shape parity with :func:`current_license_info` so a UI branching
+    on either envelope never has to check for missing keys.
+
+    Never raises, never touches disk."""
     import time as _t
 
     try:
@@ -876,6 +887,15 @@ def inspect_key(key: str) -> dict | None:
             "sub": str(payload.get("sub", "")),
             "exp": exp,
             "days_left": days_left,
+            # Trust-anchor identity is payload-independent — same value as
+            # current_license_info() populates on every file-exists branch, so
+            # a UI can render either envelope through one code path.
+            "pubkey_fingerprint_sha256": pubkey_fingerprint(),
+            # On-disk fields are meaningless on a dry-run (no file exists yet);
+            # kept in the envelope with None so the shape matches
+            # current_license_info() exactly.
+            "permissions_safe": None,
+            "file_mode": None,
         }
     except Exception as exc:  # never raise from a dry-run inspector
         logger.warning("license: inspect_key failed: %s", exc)

--- a/tests/test_license.py
+++ b/tests/test_license.py
@@ -390,6 +390,109 @@ def test_current_license_info(lic):
     assert info["days_left"] > 300
 
 
+# ── inspect_key: shape parity with current_license_info ─────────────────────
+#
+# The docstring on ``inspect_key`` promises "the same field set as
+# ``current_license_info`` (so the UI can render the two the same way)". Pin
+# the invariant: every non-None return from ``inspect_key`` MUST carry the
+# same 10-key envelope as ``current_license_info``'s file-exists branches, so
+# a UI, ``jq`` filter, or support script never has to branch on which envelope
+# it received. The two on-disk-only fields collapse to ``None`` on the dry-run
+# side; the trust-anchor fingerprint is payload-independent and byte-equals
+# what ``current_license_info`` populates.
+
+
+def test_inspect_key_active_matches_current_license_info_shape(lic):
+    tok = lic.L._encode_token(_payload("pro", nodes=7), lic.priv)
+    info = lic.L.inspect_key(tok)
+    assert info is not None
+    assert set(info.keys()) == _EXPECTED_FILE_EXISTS_KEYS
+
+
+def test_inspect_key_expired_matches_current_license_info_shape(lic):
+    tok = lic.L._encode_token(_payload("pro", nodes=4, exp_delta=-7200), lic.priv)
+    info = lic.L.inspect_key(tok)
+    assert info is not None
+    assert set(info.keys()) == _EXPECTED_FILE_EXISTS_KEYS
+
+
+def test_inspect_key_carries_trust_anchor_fingerprint(lic):
+    """The pubkey fingerprint is payload-independent, so an inspection
+    envelope MUST carry the same value ``current_license_info`` would
+    populate — a support script can then verify "does the pasted key
+    verify against the pubkey we ship?" without an extra API round-trip."""
+    tok = lic.L._encode_token(_payload("pro", nodes=1), lic.priv)
+    info = lic.L.inspect_key(tok)
+    assert info is not None
+    fp = info["pubkey_fingerprint_sha256"]
+    assert isinstance(fp, str)
+    assert len(fp) == 64
+    # Matches the standalone helper — the two must never drift.
+    assert fp == lic.L.pubkey_fingerprint()
+
+
+def test_inspect_key_on_disk_fields_are_none_on_dry_run(lic):
+    """A dry-run inspection never touches disk, so the two on-disk-only
+    fields (``permissions_safe`` / ``file_mode``) MUST collapse to ``None``.
+    Keeps the shape identical to ``current_license_info`` while making it
+    obvious to a caller that those fields carry no information yet."""
+    tok = lic.L._encode_token(_payload("pro", nodes=1), lic.priv)
+    info = lic.L.inspect_key(tok)
+    assert info is not None
+    assert info["permissions_safe"] is None
+    assert info["file_mode"] is None
+
+
+def test_inspect_key_expired_carries_trust_anchor_fingerprint(lic):
+    """Expired-but-parseable keys still populate the fingerprint — support
+    can confirm "this key was minted with our pubkey" even for a stale key."""
+    tok = lic.L._encode_token(_payload("pro", nodes=1, exp_delta=-3600), lic.priv)
+    info = lic.L.inspect_key(tok)
+    assert info is not None
+    assert info["status"] == "expired"
+    assert info["pubkey_fingerprint_sha256"] == lic.L.pubkey_fingerprint()
+    assert info["permissions_safe"] is None
+    assert info["file_mode"] is None
+
+
+def test_inspect_key_shape_parity_with_active_current_license_info(lic):
+    """End-to-end shape check: ``inspect_key`` on a token and
+    ``current_license_info`` after activating the SAME token must return the
+    exact same key set. Guards against future drift where either side adds
+    a field the other forgets."""
+    tok = lic.L._encode_token(_payload("pro", nodes=5), lic.priv)
+    dry = lic.L.inspect_key(tok)
+    lic.L.activate(tok)
+    live = lic.L.current_license_info()
+    assert dry is not None and live is not None
+    assert set(dry.keys()) == set(live.keys())
+    # Both envelopes must agree on the trust anchor — a mismatch would mean
+    # inspect_key was validating against a different key than the resolver.
+    assert dry["pubkey_fingerprint_sha256"] == live["pubkey_fingerprint_sha256"]
+
+
+def test_inspect_key_fingerprint_degrades_to_none_when_pubkey_broken(lic, monkeypatch):
+    """If the embedded pubkey PEM can't parse, ``pubkey_fingerprint`` returns
+    ``None`` (see its docstring). ``inspect_key`` must degrade cleanly to the
+    same ``None`` for the fingerprint field instead of raising — the outer
+    ``try/except`` would swallow it back to ``None`` anyway, but a token
+    that verified BEFORE the pubkey broke must still surface as an
+    inspection envelope with ``fingerprint=None``, not a total ``None``."""
+    tok = lic.L._encode_token(_payload("pro", nodes=1), lic.priv)
+    # Break the fingerprint helper AFTER we've minted a token so verification
+    # still passes. The two operations use the same pubkey source in prod so
+    # in practice a broken PEM breaks both — but the helper is defensive and
+    # returns None on any parse failure, so mirror that here.
+    monkeypatch.setattr(lic.L, "pubkey_fingerprint", lambda: None)
+    info = lic.L.inspect_key(tok)
+    assert info is not None
+    assert info["pubkey_fingerprint_sha256"] is None
+    # Rest of the envelope stays intact — a broken fingerprint helper is
+    # NOT allowed to blank the actual payload fields.
+    assert info["tier"] == "pro"
+    assert info["valid"] is True
+
+
 # ── current_license_info: uniform shape across active/expired/invalid ─────────
 #
 # When a license file exists, EVERY branch must return the same field set so


### PR DESCRIPTION
## Summary

- `clawmetry.license.inspect_key`'s docstring promises "the same shape as `current_license_info` (so the UI can render the two the same way)" — but the two returned different key sets. `current_license_info` populates a 10-key envelope on every file-exists branch (active / expired / invalid). `inspect_key` returned only 7 — missing `pubkey_fingerprint_sha256`, `permissions_safe`, `file_mode`. A UI or support script rendering either envelope through one code path had to special-case the three missing keys.
- Align the shape: `inspect_key` now populates the same 10-key envelope. `pubkey_fingerprint_sha256` is filled with the same trust-anchor id `current_license_info` populates (payload-independent), and the two on-disk-only fields (`permissions_safe`, `file_mode`) collapse to `None` on a dry-run since there is no file to stat yet. Never-raise contract unchanged.
- Grace-mode only. No `__version__` bump, no `[RELEASE]` PR, no gate enforced. `/api/license/verify` picks up the new keys automatically since it passes the `inspect_key` dict through verbatim after adding `dry_run=True`.

## Why

`inspect_key` is the dry-run counterpart of `activate` — used by:

* Support: "paste your key, let's see what tier/exp it carries" without touching the customer's install.
* Pre-flight from the CLI / dashboard before clicking *Activate*.
* Air-gap: validate a key on a staging box before transporting it.

`/api/license/status` returns `current_license_info` (10 keys). `/api/license/verify` returns `inspect_key(...)` + `dry_run=True` (7 keys plus `dry_run`). A UI card that renders "here's what's on disk" and "here's what the pasted key would install" side by side has to branch on which envelope it received, and a support script piping `jq '.pubkey_fingerprint_sha256'` off `verify` gets `null` even though the trust anchor identity is payload-independent and IS knowable at dry-run time.

The docstring already made the "same shape" promise. This PR delivers on it.

## Changes

### `clawmetry/license.py`

- `inspect_key` return value expanded from 7 keys to 10, matching `current_license_info`'s `_EXPECTED_FILE_EXISTS_KEYS` set (`valid`, `status`, `tier`, `nodes`, `sub`, `exp`, `days_left`, `pubkey_fingerprint_sha256`, `permissions_safe`, `file_mode`).
- `pubkey_fingerprint_sha256` is populated via the existing `pubkey_fingerprint()` helper — same value `current_license_info` populates, so a support script running `jq '.pubkey_fingerprint_sha256'` off either endpoint gets the same trust-anchor id.
- `permissions_safe` / `file_mode` collapse to `None` on a dry-run — there is no file yet, but the keys are kept for shape parity so a UI iterating over the envelope never has to check for missing keys.
- Docstring updated to describe the two on-disk-only fields' `None` collapse explicitly (so future readers don't wonder why they're always null on `/api/license/verify`).
- Never-raise contract preserved: `pubkey_fingerprint` is itself defensive and returns `None` on any parse failure; the outer `try/except` still swallows anything unexpected back to a total `None`.

### `tests/test_license.py`

Seven new tests, all green:

- `test_inspect_key_active_matches_current_license_info_shape` — active inspection returns exactly `_EXPECTED_FILE_EXISTS_KEYS` (the same set already pinned for `current_license_info`).
- `test_inspect_key_expired_matches_current_license_info_shape` — expired-but-parseable inspection returns the same set.
- `test_inspect_key_carries_trust_anchor_fingerprint` — the fingerprint field byte-equals the standalone `pubkey_fingerprint()` helper, so the two never drift.
- `test_inspect_key_on_disk_fields_are_none_on_dry_run` — pins the `permissions_safe=None` / `file_mode=None` invariant.
- `test_inspect_key_expired_carries_trust_anchor_fingerprint` — support scenario: "this key was minted with our pubkey, but it's stale" is answerable off the same envelope.
- `test_inspect_key_shape_parity_with_active_current_license_info` — end-to-end: `inspect_key(tok)` and `current_license_info()` after activating the SAME `tok` return the same key set AND the same fingerprint.
- `test_inspect_key_fingerprint_degrades_to_none_when_pubkey_broken` — a broken `pubkey_fingerprint` helper zeroes the field but does NOT blank the rest of the envelope.

## Test plan

- [x] `python3 -m py_compile clawmetry/license.py tests/test_license.py` — clean
- [x] `ruff check clawmetry/license.py tests/test_license.py` — `All checks passed!`
- [x] `pytest tests/test_license.py -q` → **53/53 pass** in 1.15s
- [x] `pytest tests/test_license.py tests/test_license_permissions.py tests/test_cli_license_json.py tests/test_license_pubkey.py -q` → **88 passed, 1 skipped** in 1.92s (broad license regression sweep, no drift)
- [x] `pytest tests/test_entitlement_api.py -q` → **32/32 pass** (entitlement API regression)
- [x] Repo-wide `make lint` has 213 pre-existing errors in `dashboard.py` (unused-variable warnings unrelated to this PR); the two files this PR touches are lint-clean.

## Local operator verification checklist

I can't touch the running daemon, `~/.openclaw`, the live cloud snapshot, or a browser from here — please run:

- [ ] Copy the modified file into `~/.clawmetry/lib/python3.11/site-packages/`: `clawmetry/license.py`; drop `tests/test_license.py` into the local checkout under `tests/`.
- [ ] Clear `__pycache__` under `clawmetry/` and `tests/`.
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
- [ ] Sanity smoke via the installed package (no key needed for shape):
  ```
  python3 -c 'from clawmetry.license import inspect_key; \
              import json; print(json.dumps(inspect_key("garbage"), indent=2))'
  ```
  expect `null` (invalid token — unchanged from prior behaviour).
- [ ] Mint a valid dev key locally (or use a support key) and inspect it:
  ```
  python3 -c 'from clawmetry.license import inspect_key; \
              import json; print(json.dumps(inspect_key("<KEY>"), indent=2))'
  ```
  expect all 10 keys present, `pubkey_fingerprint_sha256` populated (64-char hex), `permissions_safe=null`, `file_mode=null`.
- [ ] Byte-parity vs `current_license_info`:
  ```
  # after activating the same KEY:
  python3 -c 'from clawmetry.license import current_license_info; \
              import json; print(json.dumps(current_license_info(), indent=2))'
  ```
  compare — the two envelopes should carry the same key set; `pubkey_fingerprint_sha256` should byte-equal.
- [ ] HTTP surface for `/api/license/verify`:
  ```
  curl -s -X POST http://localhost:8900/api/license/verify \
    -H 'content-type: application/json' \
    -d '{"key":"<KEY>"}' | jq .
  ```
  expect the same 10 keys plus `dry_run:true`.
- [ ] Decrypt the live cloud snapshot and confirm the same read paths against the cloud read-through are unchanged (this PR only expands the dry-run response body — nothing on the write side or the sync daemon changes).
- [ ] Browser check: the dashboard's existing license-status card should render byte-identically; the license-verify surface (if any UI hits `/api/license/verify` today) should now also carry the fingerprint / on-disk fields.

No `__version__` bump, no tag, no `[RELEASE]` PR — staying in DRAFT until you've cleared local + cloud verification.

## MOAT / release checklist

- Not a MOAT fast-path change (no `local_store_via_daemon` / `_ls_call` / `_DAEMON_METHODS` touched).
- Not a `[RELEASE]` PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_0149BHfA3gsprGut4EPhfepB)_