### PR TITLE
feat(entitlement): /api/entitlement/runtime-detection pairs runtime_probe + tier

### DIFF
--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -285,6 +285,23 @@ is the single source of truth -- handlers never re-derive tier logic here.
                                          instead of walking ``/tier-path``
                                          and hydrating each rung
                                          individually.
+  GET  /api/entitlement/runtime-detection -- pair the
+                                         :mod:`clawmetry.runtime_probe`
+                                         presence probes with the resolved
+                                         entitlement so the dashboard can
+                                         render "runtimes on this machine +
+                                         which unlock at which tier" in one
+                                         round-trip. Each probe row carries
+                                         ``found`` (present on disk),
+                                         ``allowed`` (granted by the current
+                                         tier), and the paid ``required_tier``
+                                         to unlock it if it is not; the
+                                         envelope also carries
+                                         ``actionable_tier`` -- the single
+                                         cheapest tier that unlocks every
+                                         detected-but-locked runtime -- so
+                                         a paywall CTA does not need N
+                                         extra ``/required-tier`` calls.
 """
 
 from __future__ import annotations
@@ -23197,3 +23214,235 @@ def api_entitlement_tiers_for_runtimes_at_batch():
                 **env,
             }
         )
+
+
+# ── /api/entitlement/runtime-detection ──────────────────────────────────────
+# Presence-detect every supported runtime and decorate each row with the
+# resolved entitlement view (allowed/locked + required_tier). Lets the
+# dashboard render a single card answering "what's on this machine, what
+# would unlock" without shell-scraping the CLI. Grace-mode compatible: rows
+# always report the intrinsic locked-if-enforced picture so the paywall UI
+# stays honest, and the ``allowed`` bit reflects only the entitlement's
+# ``runtimes`` set -- the grace-vs-enforce toggle lives on the top-level
+# ``grace`` / ``enforced`` fields for the UI to interpret.
+#
+# Response shape::
+#
+#     {
+#       "current_tier": "oss",
+#       "current_tier_label": "OSS",
+#       "grace": true,
+#       "enforced": false,
+#       "probes": [
+#         {"id": "openclaw", "label": "OpenClaw", "free": true,
+#          "found": true, "allowed": true,
+#          "required_tier": "oss", "required_tier_label": "OSS"},
+#         {"id": "claude_code", "label": "Claude Code", "free": false,
+#          "found": true, "allowed": false,
+#          "required_tier": "cloud_starter",
+#          "required_tier_label": "Cloud Starter"},
+#         ...
+#       ],
+#       "counts": {
+#         "total": 14,
+#         "detected": 3,
+#         "detected_free": 1,
+#         "detected_locked": 2,
+#         "unlocked": 2,
+#         "locked": 12
+#       },
+#       "detected_locked": ["claude_code", "cursor"],
+#       "actionable_tier": "cloud_starter",
+#       "actionable_tier_label": "Cloud Starter"
+#     }
+#
+# Read-only. Never raises: on any failure at any stage the endpoint returns
+# a neutral empty envelope (``probes: []`` + zeroed counts) with the current
+# tier the resolver could still supply.
+_EMPTY_RUNTIME_DETECTION = {
+    "current_tier": "oss",
+    "current_tier_label": "OSS",
+    "grace": True,
+    "enforced": False,
+    "probes": [],
+    "counts": {
+        "total": 0,
+        "detected": 0,
+        "detected_free": 0,
+        "detected_locked": 0,
+        "unlocked": 0,
+        "locked": 0,
+    },
+    "detected_locked": [],
+    "actionable_tier": None,
+    "actionable_tier_label": None,
+}
+
+
+@bp_entitlement.route("/api/entitlement/runtime-detection")
+def api_entitlement_runtime_detection():
+    """``GET /api/entitlement/runtime-detection`` -- probe results merged with
+    the resolved entitlement so a paywall CTA card can render "runtimes on
+    this machine + which unlock at which tier" off a single round-trip.
+
+    Never 5xx: on any resolver / probe failure returns the neutral empty
+    envelope defined by :data:`_EMPTY_RUNTIME_DETECTION` so the frontend
+    card stays rendered.
+    """
+    try:
+        from clawmetry import runtime_probe as _probe
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_runtime_detection: probe import failed: %s", exc
+        )
+        return jsonify(dict(_EMPTY_RUNTIME_DETECTION))
+
+    try:
+        from clawmetry import entitlements as _ent
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_runtime_detection: entitlements import failed: %s",
+            exc,
+        )
+        # Still return whatever the probes found so the UI can at least list
+        # "these runtimes are on this machine" without tier decoration.
+        try:
+            raw = _probe.probe_runtimes() or []
+        except Exception:
+            raw = []
+        env = dict(_EMPTY_RUNTIME_DETECTION)
+        env["probes"] = [
+            {
+                "id": p.get("id"),
+                "label": p.get("label"),
+                "free": bool(p.get("free")),
+                "found": bool(p.get("found")),
+                "allowed": bool(p.get("free")),
+                "required_tier": None,
+                "required_tier_label": None,
+            }
+            for p in raw
+        ]
+        env["counts"] = _runtime_detection_counts(env["probes"])
+        env["detected_locked"] = [
+            r["id"] for r in env["probes"] if r["found"] and not r["allowed"]
+        ]
+        return jsonify(env)
+
+    try:
+        ent = _ent.get_entitlement()
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_runtime_detection: resolver failed: %s", exc
+        )
+        try:
+            ent = _ent._oss_free()
+        except Exception:
+            return jsonify(dict(_EMPTY_RUNTIME_DETECTION))
+
+    try:
+        raw = _probe.probe_runtimes() or []
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_runtime_detection: probe_runtimes failed: %s", exc
+        )
+        raw = []
+
+    allowed_runtimes = set()
+    try:
+        allowed_runtimes = set(getattr(ent, "runtimes", set()) or set())
+    except Exception:
+        allowed_runtimes = set()
+
+    probes_out = []
+    for p in raw:
+        rid = p.get("id") if isinstance(p, dict) else None
+        try:
+            req_t = _ent.min_tier_for_runtime(rid or "")
+        except Exception:
+            req_t = None
+        try:
+            req_lbl = _ent.tier_label(req_t) if req_t else None
+        except Exception:
+            req_lbl = None
+        probes_out.append(
+            {
+                "id": rid,
+                "label": p.get("label") if isinstance(p, dict) else None,
+                "free": bool(p.get("free")) if isinstance(p, dict) else False,
+                "found": bool(p.get("found")) if isinstance(p, dict) else False,
+                "allowed": bool(rid and rid in allowed_runtimes),
+                "required_tier": req_t,
+                "required_tier_label": req_lbl,
+            }
+        )
+
+    detected_locked = [
+        r["id"] for r in probes_out if r["found"] and not r["allowed"] and r["id"]
+    ]
+
+    actionable_tier = None
+    actionable_tier_label = None
+    if detected_locked:
+        try:
+            actionable_tier = _ent.min_tier_for_runtimes(detected_locked)
+        except Exception:
+            actionable_tier = None
+        if actionable_tier:
+            try:
+                actionable_tier_label = _ent.tier_label(actionable_tier)
+            except Exception:
+                actionable_tier_label = None
+
+    try:
+        current_tier = getattr(ent, "tier", None) or "oss"
+    except Exception:
+        current_tier = "oss"
+    try:
+        current_tier_label = _ent.tier_label(current_tier)
+    except Exception:
+        current_tier_label = "OSS"
+    try:
+        grace = bool(getattr(ent, "grace", True))
+    except Exception:
+        grace = True
+    try:
+        enforced = bool(_ent.is_enforced())
+    except Exception:
+        enforced = False
+
+    return jsonify(
+        {
+            "current_tier": current_tier,
+            "current_tier_label": current_tier_label,
+            "grace": grace,
+            "enforced": enforced,
+            "probes": probes_out,
+            "counts": _runtime_detection_counts(probes_out),
+            "detected_locked": detected_locked,
+            "actionable_tier": actionable_tier,
+            "actionable_tier_label": actionable_tier_label,
+        }
+    )
+
+
+def _runtime_detection_counts(probes: list) -> dict:
+    """Aggregate row for ``/api/entitlement/runtime-detection``. Pure fn."""
+    total = len(probes)
+    detected = sum(1 for r in probes if r.get("found"))
+    detected_free = sum(
+        1 for r in probes if r.get("found") and r.get("free")
+    )
+    detected_locked = sum(
+        1 for r in probes if r.get("found") and not r.get("allowed")
+    )
+    unlocked = sum(1 for r in probes if r.get("allowed"))
+    locked = total - unlocked
+    return {
+        "total": total,
+        "detected": detected,
+        "detected_free": detected_free,
+        "detected_locked": detected_locked,
+        "unlocked": unlocked,
+        "locked": locked,
+    }

--- a/tests/test_entitlement_api_runtime_detection.py
+++ b/tests/test_entitlement_api_runtime_detection.py
@@ -1,0 +1,322 @@
+"""Tests for ``GET /api/entitlement/runtime-detection``.
+
+The endpoint pairs :func:`clawmetry.runtime_probe.probe_runtimes` with the
+resolved entitlement so the dashboard renders "runtimes on this machine +
+which unlock at which tier" off a single round-trip. Tests pin:
+
+* The response envelope has the expected keys (a paywall CTA card reading
+  ``.probes`` / ``.counts`` / ``.actionable_tier`` would silently blank on
+  drift).
+* Per-row decoration is correct: free runtimes are always ``allowed``, paid
+  runtimes are ``allowed`` iff the resolved tier grants them, and each row
+  carries the paid ``required_tier`` / ``required_tier_label`` needed to
+  unlock it.
+* ``counts`` and ``detected_locked`` correctly reflect planted-on-disk
+  fixture probes.
+* ``actionable_tier`` = the cheapest tier that unlocks EVERY detected +
+  locked runtime -- so the CTA card renders "Upgrade to Cloud Starter" once,
+  not per-row.
+* The endpoint never 5xxs: probe / resolver / import failures fall through
+  to the neutral empty envelope so the frontend card stays rendered.
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def client(monkeypatch, tmp_path):
+    """Flask test client with bp_entitlement and a clean HOME/USERPROFILE.
+
+    Both HOME and USERPROFILE are set because ``os.path.expanduser`` on
+    Windows honours only USERPROFILE (see #3850).
+    """
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client(), tmp_path
+
+
+# ── shape invariants ─────────────────────────────────────────────────────────
+
+_EXPECTED_ENVELOPE_KEYS = frozenset(
+    {
+        "current_tier",
+        "current_tier_label",
+        "grace",
+        "enforced",
+        "probes",
+        "counts",
+        "detected_locked",
+        "actionable_tier",
+        "actionable_tier_label",
+    }
+)
+
+_EXPECTED_COUNT_KEYS = frozenset(
+    {
+        "total",
+        "detected",
+        "detected_free",
+        "detected_locked",
+        "unlocked",
+        "locked",
+    }
+)
+
+_EXPECTED_ROW_KEYS = frozenset(
+    {
+        "id",
+        "label",
+        "free",
+        "found",
+        "allowed",
+        "required_tier",
+        "required_tier_label",
+    }
+)
+
+
+def test_envelope_shape_stable(client):
+    c, _ = client
+    resp = c.get("/api/entitlement/runtime-detection")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert _EXPECTED_ENVELOPE_KEYS.issubset(body.keys())
+    assert _EXPECTED_COUNT_KEYS.issubset(body["counts"].keys())
+
+
+def test_every_probe_row_has_stable_keys(client):
+    c, _ = client
+    body = c.get("/api/entitlement/runtime-detection").get_json()
+    assert body["probes"], "probes should never be empty on a healthy resolve"
+    for row in body["probes"]:
+        assert _EXPECTED_ROW_KEYS.issubset(row.keys()), row
+
+
+def test_probes_cover_full_catalogue(client):
+    """Every runtime in the probe catalogue appears exactly once."""
+    from clawmetry.runtime_probe import RUNTIME_PROBES
+
+    c, _ = client
+    body = c.get("/api/entitlement/runtime-detection").get_json()
+    ids = [r["id"] for r in body["probes"]]
+    assert len(ids) == len(set(ids)), "duplicate probe ids in response"
+    assert set(ids) == {p.id for p in RUNTIME_PROBES}
+    assert body["counts"]["total"] == len(RUNTIME_PROBES)
+
+
+# ── tier decoration ──────────────────────────────────────────────────────────
+
+
+def test_oss_install_free_runtimes_allowed_paid_locked(client):
+    c, _ = client
+    body = c.get("/api/entitlement/runtime-detection").get_json()
+    assert body["current_tier"] == "oss"
+
+    rows = {r["id"]: r for r in body["probes"]}
+    # openclaw + nemoclaw are free-forever -> always allowed and required_tier=oss.
+    for rid in ("openclaw", "nemoclaw"):
+        assert rows[rid]["free"] is True
+        assert rows[rid]["allowed"] is True
+        assert rows[rid]["required_tier"] == "oss"
+        assert rows[rid]["required_tier_label"] == "OSS"
+
+    # Paid runtimes -> not allowed on OSS, required_tier is a paid rung.
+    for rid in ("claude_code", "cursor", "codex", "aider"):
+        assert rows[rid]["free"] is False
+        assert rows[rid]["allowed"] is False
+        assert rows[rid]["required_tier"] not in (None, "", "oss")
+
+
+def test_grace_flag_reflects_enforce_env(monkeypatch, tmp_path):
+    """Top-level ``grace`` / ``enforced`` mirror the resolver, so the UI can
+    show "would be locked" copy without a second round-trip."""
+    from routes.entitlement import bp_entitlement
+
+    for enforce, expected_grace, expected_enforced in (
+        ("0", True, False),
+        ("1", False, True),
+    ):
+        monkeypatch.setenv("CLAWMETRY_ENFORCE", enforce)
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv("USERPROFILE", str(tmp_path))
+
+        import clawmetry.entitlements as e
+
+        importlib.reload(e)
+        e.invalidate()
+
+        app = Flask(__name__)
+        app.register_blueprint(bp_entitlement)
+        client = app.test_client()
+
+        body = client.get("/api/entitlement/runtime-detection").get_json()
+        assert body["grace"] is expected_grace
+        assert body["enforced"] is expected_enforced
+
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+
+
+# ── on-disk fixtures drive detection ─────────────────────────────────────────
+
+
+def test_planted_paid_runtime_detected_and_locked(client):
+    c, home = client
+    (home / ".claude" / "projects").mkdir(parents=True)
+
+    body = c.get("/api/entitlement/runtime-detection").get_json()
+    rows = {r["id"]: r for r in body["probes"]}
+    assert rows["claude_code"]["found"] is True
+    assert rows["claude_code"]["allowed"] is False
+    assert "claude_code" in body["detected_locked"]
+    assert body["counts"]["detected"] >= 1
+    assert body["counts"]["detected_locked"] >= 1
+
+
+def test_planted_free_runtime_detected_and_allowed(client):
+    """OpenClaw's default paths -> found=True, allowed=True (free-forever).
+
+    Its presence must NOT bump ``detected_locked``.
+    """
+    c, home = client
+    openclaw_dir = home / ".openclaw"
+    openclaw_dir.mkdir(parents=True)
+    (openclaw_dir / "openclaw.json").write_text("{}")
+
+    body = c.get("/api/entitlement/runtime-detection").get_json()
+    rows = {r["id"]: r for r in body["probes"]}
+    assert rows["openclaw"]["found"] is True
+    assert rows["openclaw"]["allowed"] is True
+    assert "openclaw" not in body["detected_locked"]
+
+
+def test_multiple_paid_runtimes_actionable_tier_covers_all(client):
+    """``actionable_tier`` is the ONE tier that unlocks every detected +
+    locked runtime -- the CTA card renders "Upgrade to X" once, not N times.
+    """
+    c, home = client
+    (home / ".claude" / "projects").mkdir(parents=True)  # claude_code
+    (home / ".codex" / "sessions").mkdir(parents=True)  # codex
+
+    body = c.get("/api/entitlement/runtime-detection").get_json()
+
+    assert set(body["detected_locked"]) >= {"claude_code", "codex"}
+
+    # min_tier_for_runtimes over any subset of PAID_RUNTIMES today collapses
+    # to cloud_starter (single-rung ladder for paid runtimes).
+    from clawmetry import entitlements as e
+
+    expected = e.min_tier_for_runtimes(body["detected_locked"])
+    assert body["actionable_tier"] == expected
+    assert body["actionable_tier_label"] == e.tier_label(expected)
+
+
+def test_no_paid_runtimes_actionable_tier_none(client):
+    """A machine with only free runtimes present -> no CTA to render."""
+    c, home = client
+    (home / ".openclaw").mkdir(parents=True)
+    (home / ".openclaw" / "openclaw.json").write_text("{}")
+
+    body = c.get("/api/entitlement/runtime-detection").get_json()
+    assert body["detected_locked"] == []
+    assert body["actionable_tier"] is None
+    assert body["actionable_tier_label"] is None
+
+
+# ── counts arithmetic ────────────────────────────────────────────────────────
+
+
+def test_counts_are_consistent_with_rows(client):
+    """counts.total == len(probes); counts.unlocked + counts.locked == total;
+    counts.detected == rows with found=True; counts.detected_locked == rows
+    with found=True AND allowed=False."""
+    c, home = client
+    (home / ".claude" / "projects").mkdir(parents=True)
+    (home / ".openclaw").mkdir(parents=True)
+    (home / ".openclaw" / "openclaw.json").write_text("{}")
+
+    body = c.get("/api/entitlement/runtime-detection").get_json()
+    rows = body["probes"]
+    counts = body["counts"]
+
+    assert counts["total"] == len(rows)
+    assert counts["unlocked"] + counts["locked"] == counts["total"]
+    assert counts["detected"] == sum(1 for r in rows if r["found"])
+    assert counts["detected_free"] == sum(
+        1 for r in rows if r["found"] and r["free"]
+    )
+    assert counts["detected_locked"] == sum(
+        1 for r in rows if r["found"] and not r["allowed"]
+    )
+    assert counts["detected_locked"] == len(body["detected_locked"])
+
+
+# ── never 5xx ────────────────────────────────────────────────────────────────
+
+
+def test_endpoint_survives_probe_failure(monkeypatch, tmp_path):
+    """A broken probe module -> empty envelope, not 500."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+
+    from clawmetry import runtime_probe as _probe
+
+    monkeypatch.setattr(
+        _probe,
+        "probe_runtimes",
+        lambda: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
+
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    resp = app.test_client().get("/api/entitlement/runtime-detection")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    # Envelope keys still present, probes empty, no NoneType-in-len errors.
+    assert _EXPECTED_ENVELOPE_KEYS.issubset(body.keys())
+    assert body["probes"] == []
+    assert body["counts"]["total"] == 0
+    assert body["detected_locked"] == []
+    assert body["actionable_tier"] is None
+
+
+def test_endpoint_survives_resolver_failure(monkeypatch, tmp_path):
+    """Resolver blowing up -> falls back to OSS-free view, still 200."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    monkeypatch.setattr(
+        e, "get_entitlement", lambda force=False: (_ for _ in ()).throw(RuntimeError("boom"))
+    )
+
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    resp = app.test_client().get("/api/entitlement/runtime-detection")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    # OSS-free fallback -> current_tier="oss", free runtimes still allowed.
+    assert body["current_tier"] == "oss"
+    assert body["probes"], "OSS-free fallback should still list probes"
+    free_row = next(r for r in body["probes"] if r["id"] == "openclaw")
+    assert free_row["allowed"] is True


### PR DESCRIPTION
## Summary

- Adds `GET /api/entitlement/runtime-detection` — pairs the presence probes in `clawmetry/runtime_probe.py` (landed in the 14-runtime detection PR) with the resolved entitlement so the dashboard can render "runtimes on this machine + which unlock at which tier" off a single round-trip.
- Each probe row carries `found` (present on disk), `allowed` (granted by the current tier), and `required_tier` / `required_tier_label` (the paid rung that unlocks it if not).
- The envelope also carries `actionable_tier` — the single cheapest tier that unlocks EVERY detected-but-locked runtime — so a paywall CTA card can render "Upgrade to X" once, not per-row.
- Grace-mode only. No `__version__` bump, no `[RELEASE]` PR, no gate enforced. Draft PR — awaiting operator verification below.

## Why

`clawmetry/runtime_probe.py` already knows how to presence-check all 14 runtimes at their default data locations, but today it's only wired into the CLI onboarding wizard (`clawmetry status`). The dashboard has no HTTP surface for the same signal, so a machine full of Cursor / Claude Code sessions can sit on the OSS free tier with the paywall UI blind to what would actually unlock. This is the highest-leverage conversion moment and it currently ships nothing.

This PR gives the frontend one endpoint that answers "what does this operator have on their machine, and what tier would unlock it" without shell-scraping the CLI or making N `/api/entitlement/required-tier?runtime=…` calls per row.

## Changes

### `routes/entitlement.py`

- **New:** `GET /api/entitlement/runtime-detection` (`api_entitlement_runtime_detection`) at end-of-file. Composes `runtime_probe.probe_runtimes()`, `entitlements.get_entitlement()`, `entitlements.min_tier_for_runtime()`, `entitlements.min_tier_for_runtimes()`, and `entitlements.tier_label()`. Read-only. Neutral empty envelope on any resolver / probe / import failure (never 5xx).
- **New:** `_runtime_detection_counts(probes)` — pure aggregate helper (`total` / `detected` / `detected_free` / `detected_locked` / `unlocked` / `locked`).
- **New:** `_EMPTY_RUNTIME_DETECTION` — module-level neutral envelope for the never-raise fall-through paths.
- Module docstring gains a matching entry so the top-of-file endpoint index stays accurate.

Response shape:

```json
{
  "current_tier": "oss",
  "current_tier_label": "OSS",
  "grace": true,
  "enforced": false,
  "probes": [
    {"id": "openclaw", "label": "OpenClaw", "free": true,
     "found": true, "allowed": true,
     "required_tier": "oss", "required_tier_label": "OSS"},
    {"id": "claude_code", "label": "Claude Code", "free": false,
     "found": true, "allowed": false,
     "required_tier": "cloud_starter", "required_tier_label": "Cloud Starter"},
    ...
  ],
  "counts": {"total": 14, "detected": 3, "detected_free": 1,
             "detected_locked": 2, "unlocked": 2, "locked": 12},
  "detected_locked": ["claude_code", "cursor"],
  "actionable_tier": "cloud_starter",
  "actionable_tier_label": "Cloud Starter"
}
```

### `tests/test_entitlement_api_runtime_detection.py` (new, 12 tests)

- Envelope shape stable (`_EXPECTED_ENVELOPE_KEYS` / `_EXPECTED_COUNT_KEYS` / `_EXPECTED_ROW_KEYS`) — drift would silently blank a paywall dashboard card.
- Every probe row carries the seven expected keys.
- `probes` covers the full `RUNTIME_PROBES` catalogue exactly once; count matches.
- OSS install: free runtimes are always `allowed=True` with `required_tier="oss"`; paid runtimes are `allowed=False` with a paid `required_tier`.
- Top-level `grace` / `enforced` mirror `CLAWMETRY_ENFORCE=0/1` — pinned in both directions so the UI can render "would be locked" copy without a second round-trip.
- Planted-on-disk fixture drives `found=True` on the correct probe (Claude Code path).
- Free runtime detected via fixture is `allowed=True` and NOT in `detected_locked`.
- Multiple paid runtimes detected → `actionable_tier == min_tier_for_runtimes(detected_locked)` (matches the resolver, no drift).
- No paid runtimes detected → `actionable_tier is None` (no CTA to render).
- `counts` arithmetic: `total == len(probes)`; `unlocked + locked == total`; `detected == found rows`; `detected_locked == len(detected_locked)`.
- Probe module raising → 200 with empty envelope (not 500).
- Resolver raising → 200 with OSS-free fallback (probes still rendered).

## Test plan

- [x] `python3 -m py_compile routes/entitlement.py tests/test_entitlement_api_runtime_detection.py` — clean
- [x] `ruff check routes/entitlement.py tests/test_entitlement_api_runtime_detection.py` → `All checks passed!`
- [x] `pytest tests/test_entitlement_api_runtime_detection.py -q` → **12/12 pass** in 1.57s
- [x] Adjacent regression sweep: `pytest tests/test_onboard_runtime_detection.py tests/test_entitlement_api.py tests/test_entitlement_api_fallback_shape.py tests/test_entitlements.py -q` → **122/122 pass**
- [x] Blueprint URL-map uniqueness + circular imports: `pytest tests/test_blueprint_uniqueness.py tests/test_circular_import.py -q` → **10/10 pass**
- [x] Live Flask URL map: 258 rules, no duplicates; `/api/entitlement/runtime-detection` registered as `GET` only.
- [x] `make lint` — pre-existing 213 ruff issues on `dashboard.py` unchanged (unrelated to this PR); ruff on the two touched files is clean.

## Local operator verification checklist

I can't touch the running daemon, `~/.openclaw`, the live cloud snapshot, or a browser from here — please run:

- [ ] Copy the modified `routes/entitlement.py` into `~/.clawmetry/lib/python3.11/site-packages/routes/` and drop the new `tests/test_entitlement_api_runtime_detection.py` into the local checkout under `tests/`.
- [ ] Clear `__pycache__` under `routes/` and `clawmetry/`.
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
- [ ] Baseline healthy shape:
  ```
  curl -s http://localhost:8900/api/entitlement/runtime-detection | jq '. | {current_tier, grace, enforced, total: .counts.total, detected: .counts.detected, detected_locked, actionable_tier}'
  ```
  On a machine with Claude Code + Cursor installed, expect `detected>=2`, `detected_locked` including `claude_code` / `cursor`, and `actionable_tier="cloud_starter"` (single paid rung today).
- [ ] Row shape spot-check:
  ```
  curl -s http://localhost:8900/api/entitlement/runtime-detection | jq '.probes[] | select(.id=="claude_code")'
  ```
  Expect `{id, label, free:false, found:true|false, allowed:false, required_tier:"cloud_starter", required_tier_label:"Cloud Starter"}`.
- [ ] Free runtime row:
  ```
  curl -s http://localhost:8900/api/entitlement/runtime-detection | jq '.probes[] | select(.id=="openclaw")'
  ```
  Expect `allowed:true, required_tier:"oss"`.
- [ ] Grace flag round-trip: if you flip `CLAWMETRY_ENFORCE=1` on the daemon and re-hit the endpoint, expect `grace:false, enforced:true` (per-row `allowed` unchanged — the intrinsic locked-if-enforced view is stable across the grace toggle so the UI can render "would be locked" copy off the flag alone).
- [ ] `curl -X POST http://localhost:8900/api/entitlement/runtime-detection` → `405` (read-only).
- [ ] Decrypt the live cloud snapshot and hit the same endpoint against the cloud read-through path — expect the same envelope shape with cloud-side probe defaults (typically an empty detection set if the sandbox has no runtime data mounted).
- [ ] Browser check: no existing tab reads `/api/entitlement/runtime-detection` yet, so this should be a pure-add with no rendering regression. The intent is for a follow-up paywall-card component to consume it once the operator confirms the endpoint shape.

No `__version__` bump, no tag, no `[RELEASE]` PR — staying in DRAFT until you've cleared local + cloud verification.

## MOAT / release checklist

- Not a MOAT fast-path change (no `local_store_via_daemon` / `_ls_call` / `_DAEMON_METHODS` touched).
- Not a `[RELEASE]` PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wyj6gUFHiQt2q7M9aa9nw1)_