### PR TITLE
feat(entitlement): min_tier_for_{channel_count,retention_window,node_count}_at + /api/entitlement/min-tier-for-*-at

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -5710,6 +5710,110 @@ def min_tier_for_runtimes_at(
         return None
 
 
+def min_tier_for_channel_count_at(
+    perspective_tier: str, count: int
+) -> str | None:
+    """Hypothetical-perspective sibling of :func:`min_tier_for_channel_count`.
+
+    Fills the ``_at`` slot for the channel-count capacity axis alongside
+    :func:`min_tier_for_features_at` / :func:`min_tier_for_runtimes_at` so a
+    pricing-matrix walkthrough can call ``X_at(perspective, ...)`` uniformly
+    across every ``_at`` sibling in the ``min_tier_for_*`` family. Same
+    relationship to :func:`min_tier_for_channel_count` that
+    :func:`tiers_for_channel_count_at` has to :func:`tiers_for_channel_count`:
+    ``perspective_tier`` is validated against :data:`_TIER_ORDER` (including
+    :data:`TIER_TRIAL`) but does NOT shape the answer -- the scalar tier id
+    depends only on the static :data:`_TIER_CHANNEL_LIMIT` table, not on the
+    caller's live plan. A parity test pins
+    ``min_tier_for_channel_count_at(p, n) == min_tier_for_channel_count(n)``
+    for every ``p`` in :data:`_TIER_ORDER` so the ``_at`` prefix cannot
+    silently drift into shaping the result.
+
+    Returns ``None`` for empty / unknown ``perspective_tier`` (caller renders
+    "unknown tier" / 404), matching the ``None`` posture the rest of the
+    ``_at`` family uses for the perspective-validation failure mode. All
+    other semantics -- ``count <= 0`` -> :data:`TIER_OSS`, non-int ->
+    ``None``, over-cap -> :data:`TIER_ENTERPRISE` -- inherit from
+    :func:`min_tier_for_channel_count` unchanged. Never raises: a delegate
+    failure logs a warning and returns ``None``.
+    """
+    try:
+        p = (perspective_tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if not p or p not in _TIER_ORDER:
+        return None
+    try:
+        return min_tier_for_channel_count(count)
+    except Exception as exc:
+        logger.warning(
+            "entitlements: min_tier_for_channel_count_at failed: %s", exc
+        )
+        return None
+
+
+def min_tier_for_retention_window_at(
+    perspective_tier: str, days: int | None
+) -> str | None:
+    """Hypothetical-perspective sibling of
+    :func:`min_tier_for_retention_window`. Retention-axis twin of
+    :func:`min_tier_for_channel_count_at`.
+
+    Accepts the explicit ``days=None`` "unlimited" sentinel that the
+    singular helper accepts -- delegates without further parsing, so the
+    same "None means unlimited on this axis" semantics carry through
+    unchanged and only tiers whose retention cap is ``None`` admit the
+    request. Non-int (non-``None``) ``days`` yields ``None`` (matches the
+    singular helper's posture on bad input rather than mis-routing to
+    Enterprise). ``days <= 0`` collapses to :data:`TIER_OSS`.
+
+    Perspective is validated against :data:`_TIER_ORDER` (including
+    :data:`TIER_TRIAL`) but does NOT shape the answer. Returns ``None`` for
+    empty / unknown ``perspective_tier``. Never raises.
+    """
+    try:
+        p = (perspective_tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if not p or p not in _TIER_ORDER:
+        return None
+    try:
+        return min_tier_for_retention_window(days)
+    except Exception as exc:
+        logger.warning(
+            "entitlements: min_tier_for_retention_window_at failed: %s", exc
+        )
+        return None
+
+
+def min_tier_for_node_count_at(
+    perspective_tier: str, count: int
+) -> str | None:
+    """Hypothetical-perspective sibling of :func:`min_tier_for_node_count`.
+    Node-axis twin of :func:`min_tier_for_channel_count_at`.
+
+    Perspective is validated against :data:`_TIER_ORDER` (including
+    :data:`TIER_TRIAL`) but does NOT shape the answer -- the scalar tier
+    id depends only on the static :data:`_TIER_NODE_LIMIT` table. Returns
+    ``None`` for empty / unknown ``perspective_tier`` (caller renders
+    "unknown tier" / 404) and for non-int ``count``. All other semantics
+    inherit from :func:`min_tier_for_node_count`. Never raises.
+    """
+    try:
+        p = (perspective_tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if not p or p not in _TIER_ORDER:
+        return None
+    try:
+        return min_tier_for_node_count(count)
+    except Exception as exc:
+        logger.warning(
+            "entitlements: min_tier_for_node_count_at failed: %s", exc
+        )
+        return None
+
+
 def _min_tier_for_features_bundle_row(bundle) -> dict:
     """Per-bundle row shape for :func:`min_tier_for_features_batch`.
 

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -22164,6 +22164,255 @@ def api_entitlement_min_tier_for_retention_window():
         )
 
 
+def _min_tier_for_capacity_at_body(
+    _ent, tier_in: str, item, kind: str, label, required
+) -> dict:
+    """Assemble the response body for a ``min-tier-for-<capacity-axis>-at``
+    endpoint. Layers ``perspective_tier`` / ``perspective_tier_label`` /
+    ``perspective_tier_rank`` on top of the standard capacity body so a
+    pricing-matrix walkthrough surface can render the "from <perspective>"
+    copy off one round-trip, matching how ``/min-tier-for-features-at`` /
+    ``/min-tier-for-runtimes-at`` layer perspective onto the grant-axis
+    bodies. Never raises.
+    """
+    return {
+        "item": item,
+        "kind": kind,
+        "label": label,
+        "free": bool(required == _ent.TIER_OSS),
+        "required_tier": required,
+        "required_tier_label": (
+            _ent.tier_label(required) if required else None
+        ),
+        "required_tier_rank": (
+            _ent.tier_rank(required) if required else -1
+        ),
+        "perspective_tier": tier_in,
+        "perspective_tier_label": _ent.tier_label(tier_in),
+        "perspective_tier_rank": _ent.tier_rank(tier_in),
+        **_resolver_envelope(_ent),
+    }
+
+
+def _min_tier_for_capacity_at_fallback(
+    tier_in: str, item, kind: str
+) -> dict:
+    """Grace-shape fallback body for the three
+    ``min-tier-for-<capacity-axis>-at`` endpoints. Same never-5xx posture
+    as :func:`_min_tier_for_capacity_fallback` with the perspective envelope
+    left null so a caller can still render the "from <perspective>" copy
+    with placeholders on a resolver crash.
+    """
+    return {
+        "item": item,
+        "kind": kind,
+        "label": None,
+        "free": False,
+        "required_tier": None,
+        "required_tier_label": None,
+        "required_tier_rank": -1,
+        "perspective_tier": tier_in,
+        "perspective_tier_label": None,
+        "perspective_tier_rank": -1,
+        "current_tier": "oss",
+        "current_tier_rank": 0,
+        "grace": True,
+        "enforced": False,
+    }
+
+
+@bp_entitlement.route("/api/entitlement/min-tier-for-channel-count-at")
+def api_entitlement_min_tier_for_channel_count_at():
+    """``GET /api/entitlement/min-tier-for-channel-count-at?tier=<perspective>
+    &count=<int>`` -- hypothetical-perspective sibling of
+    ``/api/entitlement/min-tier-for-channel-count``.
+
+    Fills the ``_at`` slot for the channel-count capacity axis alongside
+    ``/min-tier-for-features-at`` / ``/min-tier-for-runtimes-at`` so a
+    pricing-matrix walkthrough (``?tier=<p>``) can hit every scalar
+    ``min-tier-for-*`` axis uniformly at a fixed perspective.
+
+    Perspective is validated against :data:`entitlements._TIER_ORDER`
+    (including ``trial``) but does NOT shape rows -- the answer is
+    perspective-independent (parity-pinned by
+    :func:`entitlements.min_tier_for_channel_count_at`). Response layers
+    ``perspective_tier`` on top of the ``/min-tier-for-channel-count``
+    body so a walkthrough surface renders the "from <perspective>" copy
+    off one round-trip.
+
+    - **400** when ``tier=`` is missing / blank, OR when ``count=`` is
+      missing / blank / non-int.
+    - **404** when ``tier`` is unknown (body carries ``which=tier``).
+    - **Never 5xxs**: resolver failure -> perspective-carrying grace body.
+    """
+    raw_tier = request.args.get("tier")
+    tier_in = (raw_tier or "").strip().lower()
+    if not tier_in:
+        return jsonify({"error": "missing tier"}), 400
+
+    raw = request.args.get("count")
+    if raw is None:
+        return jsonify({"error": "missing count"}), 400
+    raw_stripped = raw.strip()
+    if not raw_stripped:
+        return jsonify({"error": "missing count"}), 400
+    try:
+        n = int(raw_stripped)
+    except (TypeError, ValueError):
+        return jsonify({"error": "count must be an integer"}), 400
+
+    try:
+        from clawmetry import entitlements as _ent
+
+        if tier_in not in _ent._TIER_ORDER:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "tier", "tier": tier_in}
+                ),
+                404,
+            )
+        required = _ent.min_tier_for_channel_count_at(tier_in, n)
+        label = f"{n} channel" if n == 1 else f"{n} channels"
+        return jsonify(
+            _min_tier_for_capacity_at_body(
+                _ent, tier_in, n, "channel_count", label, required
+            )
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_min_tier_for_channel_count_at: error: %s", exc
+        )
+        return jsonify(
+            _min_tier_for_capacity_at_fallback(tier_in, n, "channel_count")
+        )
+
+
+@bp_entitlement.route("/api/entitlement/min-tier-for-node-count-at")
+def api_entitlement_min_tier_for_node_count_at():
+    """``GET /api/entitlement/min-tier-for-node-count-at?tier=<perspective>
+    &count=<int>`` -- node-axis twin of
+    ``/api/entitlement/min-tier-for-channel-count-at``. Same perspective
+    contract, same never-5xx posture, same perspective-independence
+    guarantee (parity-pinned). Response shape and error paths mirror
+    ``/min-tier-for-channel-count-at`` with ``kind="node_count"`` and
+    ``label="4 nodes"``.
+    """
+    raw_tier = request.args.get("tier")
+    tier_in = (raw_tier or "").strip().lower()
+    if not tier_in:
+        return jsonify({"error": "missing tier"}), 400
+
+    raw = request.args.get("count")
+    if raw is None:
+        return jsonify({"error": "missing count"}), 400
+    raw_stripped = raw.strip()
+    if not raw_stripped:
+        return jsonify({"error": "missing count"}), 400
+    try:
+        n = int(raw_stripped)
+    except (TypeError, ValueError):
+        return jsonify({"error": "count must be an integer"}), 400
+
+    try:
+        from clawmetry import entitlements as _ent
+
+        if tier_in not in _ent._TIER_ORDER:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "tier", "tier": tier_in}
+                ),
+                404,
+            )
+        required = _ent.min_tier_for_node_count_at(tier_in, n)
+        label = f"{n} node" if n == 1 else f"{n} nodes"
+        return jsonify(
+            _min_tier_for_capacity_at_body(
+                _ent, tier_in, n, "node_count", label, required
+            )
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_min_tier_for_node_count_at: error: %s", exc
+        )
+        return jsonify(
+            _min_tier_for_capacity_at_fallback(tier_in, n, "node_count")
+        )
+
+
+@bp_entitlement.route("/api/entitlement/min-tier-for-retention-window-at")
+def api_entitlement_min_tier_for_retention_window_at():
+    """``GET /api/entitlement/min-tier-for-retention-window-at?tier=<perspective>
+    &days=<int|unlimited>`` -- retention-axis twin of
+    ``/api/entitlement/min-tier-for-channel-count-at``.
+
+    ``days=unlimited`` (case-insensitive) requests the unlimited-history
+    window; only tiers whose retention cap is ``None`` admit the request
+    (Enterprise on the current tier table). ``item`` is ``null`` and
+    ``label`` is ``"unlimited"`` in that case, matching the bare
+    ``/min-tier-for-retention-window`` endpoint's shape.
+
+    Same 400-on-missing-tier / 400-on-blank-days / 404-on-unknown-tier /
+    never-5xx contracts as the two count-axis siblings.
+    """
+    raw_tier = request.args.get("tier")
+    tier_in = (raw_tier or "").strip().lower()
+    if not tier_in:
+        return jsonify({"error": "missing tier"}), 400
+
+    raw = request.args.get("days")
+    if raw is None:
+        return jsonify({"error": "missing days"}), 400
+    raw_stripped = raw.strip()
+    if not raw_stripped:
+        return jsonify({"error": "missing days"}), 400
+    unlimited = raw_stripped.lower() == "unlimited"
+    if unlimited:
+        parsed: int | None = None
+    else:
+        try:
+            parsed = int(raw_stripped)
+        except (TypeError, ValueError):
+            return (
+                jsonify(
+                    {"error": "days must be an integer or 'unlimited'"}
+                ),
+                400,
+            )
+
+    try:
+        from clawmetry import entitlements as _ent
+
+        if tier_in not in _ent._TIER_ORDER:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "tier", "tier": tier_in}
+                ),
+                404,
+            )
+        required = _ent.min_tier_for_retention_window_at(tier_in, parsed)
+        if parsed is None:
+            label = "unlimited"
+        else:
+            label = (
+                f"{parsed} day" if parsed == 1 else f"{parsed} days"
+            )
+        return jsonify(
+            _min_tier_for_capacity_at_body(
+                _ent, tier_in, parsed, "retention_window", label, required
+            )
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_min_tier_for_retention_window_at: error: %s",
+            exc,
+        )
+        return jsonify(
+            _min_tier_for_capacity_at_fallback(
+                tier_in, parsed, "retention_window"
+            )
+        )
+
+
 def _min_tier_for_bundle_row_to_body(row: dict, list_key: str) -> dict:
     """Rename the batch helper's ``min_tier*`` keys to the endpoint's
     ``required_tier*`` keys so per-row bodies stay byte-identical to

--- a/tests/test_entitlement_min_tier_for_capacity_at.py
+++ b/tests/test_entitlement_min_tier_for_capacity_at.py
@@ -1,0 +1,608 @@
+"""Tests for the ``_at`` variants of the scalar capacity-axis
+``min-tier-for-<axis>`` endpoints:
+
+* ``/api/entitlement/min-tier-for-channel-count-at``
+* ``/api/entitlement/min-tier-for-node-count-at``
+* ``/api/entitlement/min-tier-for-retention-window-at``
+
+Fills the ``_at`` slot for the three scalar capacity axes alongside
+``/min-tier-for-features-at`` / ``/min-tier-for-runtimes-at`` so a
+pricing-matrix walkthrough (``?tier=<p>``) can hit every scalar
+``min-tier-for-*`` axis uniformly at a fixed perspective. Wraps the new
+:func:`clawmetry.entitlements.min_tier_for_channel_count_at` /
+:func:`clawmetry.entitlements.min_tier_for_node_count_at` /
+:func:`clawmetry.entitlements.min_tier_for_retention_window_at` helpers
+so the ``_at`` family is uniform.
+
+These tests pin:
+
+* API happy path: shape, perspective envelope, resolver envelope
+* API error paths: 400 on missing / blank / non-int, 404 on unknown tier
+* perspective-independence parity: the ``_at`` answer byte-equals the
+  bare helper's answer for every ``perspective_tier`` in
+  ``_TIER_ORDER`` (the ``_at`` prefix must not shape rows)
+* helper-side parity: the ``_at`` helper byte-equals the bare helper
+* ``days=unlimited`` (case-insensitive) round-trips to ``item=null`` /
+  ``label="unlimited"``
+* zero / negative collapse to the free floor (parity with bare)
+* uniform envelope keys across the three ``_at`` axes
+* never-5xxs on a delegate crash
+* grace vs enforce parity: the resolver-scoped body must not drift
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+_AT_ENVELOPE_KEYS = {
+    "item",
+    "kind",
+    "label",
+    "free",
+    "required_tier",
+    "required_tier_label",
+    "required_tier_rank",
+    "perspective_tier",
+    "perspective_tier_label",
+    "perspective_tier_rank",
+    "current_tier",
+    "current_tier_rank",
+    "grace",
+    "enforced",
+}
+
+
+# ── helper-side: perspective-independence parity ──────────────────────────
+
+
+@pytest.mark.parametrize("count", [1, 3, 5, 50, 1000])
+def test_helper_channel_count_at_matches_bare_for_every_perspective(
+    ent, count
+):
+    bare = ent.min_tier_for_channel_count(count)
+    for p in ent._TIER_ORDER:
+        assert ent.min_tier_for_channel_count_at(p, count) == bare, (
+            f"drift at perspective {p!r}"
+        )
+
+
+@pytest.mark.parametrize("count", [1, 3, 5, 50, 1000])
+def test_helper_node_count_at_matches_bare_for_every_perspective(ent, count):
+    bare = ent.min_tier_for_node_count(count)
+    for p in ent._TIER_ORDER:
+        assert ent.min_tier_for_node_count_at(p, count) == bare, (
+            f"drift at perspective {p!r}"
+        )
+
+
+@pytest.mark.parametrize("days", [1, 7, 30, 90, 365, None])
+def test_helper_retention_window_at_matches_bare_for_every_perspective(
+    ent, days
+):
+    bare = ent.min_tier_for_retention_window(days)
+    for p in ent._TIER_ORDER:
+        assert ent.min_tier_for_retention_window_at(p, days) == bare, (
+            f"drift at perspective {p!r} days={days!r}"
+        )
+
+
+# ── helper-side: invalid perspective / bad input ──────────────────────────
+
+
+def test_helper_channel_count_at_unknown_perspective_returns_none(ent):
+    assert ent.min_tier_for_channel_count_at("bogus", 5) is None
+    assert ent.min_tier_for_channel_count_at("", 5) is None
+    assert ent.min_tier_for_channel_count_at(None, 5) is None
+
+
+def test_helper_node_count_at_unknown_perspective_returns_none(ent):
+    assert ent.min_tier_for_node_count_at("bogus", 5) is None
+    assert ent.min_tier_for_node_count_at(None, 5) is None
+
+
+def test_helper_retention_window_at_unknown_perspective_returns_none(ent):
+    assert ent.min_tier_for_retention_window_at("bogus", 30) is None
+    assert ent.min_tier_for_retention_window_at("bogus", None) is None
+
+
+def test_helper_channel_count_at_nonint_count_returns_none(ent):
+    assert ent.min_tier_for_channel_count_at("cloud_pro", "nope") is None
+
+
+def test_helper_retention_window_at_nonint_days_returns_none(ent):
+    assert ent.min_tier_for_retention_window_at("cloud_pro", "nope") is None
+
+
+# ── API: happy path ────────────────────────────────────────────────────────
+
+
+def test_api_channel_count_at_happy_path(client, ent):
+    r = client.get(
+        "/api/entitlement/min-tier-for-channel-count-at"
+        "?tier=cloud_pro&count=5"
+    )
+    assert r.status_code == 200
+    j = r.get_json()
+    assert set(j.keys()) == _AT_ENVELOPE_KEYS
+    assert j["kind"] == "channel_count"
+    assert j["item"] == 5
+    assert j["label"] == "5 channels"
+    assert j["required_tier"] == ent.min_tier_for_channel_count(5)
+    assert j["perspective_tier"] == "cloud_pro"
+    assert j["perspective_tier_label"] == ent.tier_label("cloud_pro")
+    assert j["perspective_tier_rank"] == ent.tier_rank("cloud_pro")
+
+
+def test_api_node_count_at_happy_path(client, ent):
+    r = client.get(
+        "/api/entitlement/min-tier-for-node-count-at"
+        "?tier=cloud_starter&count=4"
+    )
+    assert r.status_code == 200
+    j = r.get_json()
+    assert set(j.keys()) == _AT_ENVELOPE_KEYS
+    assert j["kind"] == "node_count"
+    assert j["item"] == 4
+    assert j["label"] == "4 nodes"
+    assert j["required_tier"] == ent.min_tier_for_node_count(4)
+    assert j["perspective_tier"] == "cloud_starter"
+
+
+def test_api_retention_window_at_happy_path(client, ent):
+    r = client.get(
+        "/api/entitlement/min-tier-for-retention-window-at"
+        "?tier=enterprise&days=30"
+    )
+    assert r.status_code == 200
+    j = r.get_json()
+    assert set(j.keys()) == _AT_ENVELOPE_KEYS
+    assert j["kind"] == "retention_window"
+    assert j["item"] == 30
+    assert j["label"] == "30 days"
+    assert j["required_tier"] == ent.min_tier_for_retention_window(30)
+    assert j["perspective_tier"] == "enterprise"
+
+
+# ── API: singular label conjugation ───────────────────────────────────────
+
+
+def test_api_channel_count_at_singular_label(client):
+    j = client.get(
+        "/api/entitlement/min-tier-for-channel-count-at"
+        "?tier=cloud_pro&count=1"
+    ).get_json()
+    assert j["label"] == "1 channel"
+
+
+def test_api_node_count_at_singular_label(client):
+    j = client.get(
+        "/api/entitlement/min-tier-for-node-count-at"
+        "?tier=cloud_pro&count=1"
+    ).get_json()
+    assert j["label"] == "1 node"
+
+
+def test_api_retention_window_at_singular_label(client):
+    j = client.get(
+        "/api/entitlement/min-tier-for-retention-window-at"
+        "?tier=cloud_pro&days=1"
+    ).get_json()
+    assert j["label"] == "1 day"
+
+
+# ── API: error paths ──────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "/api/entitlement/min-tier-for-channel-count-at?count=5",
+        "/api/entitlement/min-tier-for-node-count-at?count=4",
+        "/api/entitlement/min-tier-for-retention-window-at?days=30",
+    ],
+)
+def test_api_at_missing_tier_returns_400(client, url):
+    r = client.get(url)
+    assert r.status_code == 400
+    assert r.get_json().get("error") == "missing tier"
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "/api/entitlement/min-tier-for-channel-count-at?tier=&count=5",
+        "/api/entitlement/min-tier-for-node-count-at?tier=%20%20&count=4",
+    ],
+)
+def test_api_at_blank_tier_returns_400(client, url):
+    r = client.get(url)
+    assert r.status_code == 400
+    assert r.get_json().get("error") == "missing tier"
+
+
+def test_api_channel_count_at_unknown_tier_returns_404(client):
+    r = client.get(
+        "/api/entitlement/min-tier-for-channel-count-at"
+        "?tier=bogus&count=5"
+    )
+    assert r.status_code == 404
+    j = r.get_json()
+    assert j.get("which") == "tier"
+    assert j.get("tier") == "bogus"
+
+
+def test_api_node_count_at_unknown_tier_returns_404(client):
+    r = client.get(
+        "/api/entitlement/min-tier-for-node-count-at?tier=bogus&count=4"
+    )
+    assert r.status_code == 404
+    assert r.get_json().get("which") == "tier"
+
+
+def test_api_retention_window_at_unknown_tier_returns_404(client):
+    r = client.get(
+        "/api/entitlement/min-tier-for-retention-window-at"
+        "?tier=bogus&days=30"
+    )
+    assert r.status_code == 404
+    assert r.get_json().get("which") == "tier"
+
+
+def test_api_channel_count_at_missing_count_returns_400(client):
+    r = client.get(
+        "/api/entitlement/min-tier-for-channel-count-at?tier=cloud_pro"
+    )
+    assert r.status_code == 400
+    assert r.get_json().get("error") == "missing count"
+
+
+def test_api_channel_count_at_blank_count_returns_400(client):
+    r = client.get(
+        "/api/entitlement/min-tier-for-channel-count-at"
+        "?tier=cloud_pro&count=%20%20"
+    )
+    assert r.status_code == 400
+
+
+def test_api_channel_count_at_nonint_count_returns_400(client):
+    r = client.get(
+        "/api/entitlement/min-tier-for-channel-count-at"
+        "?tier=cloud_pro&count=nope"
+    )
+    assert r.status_code == 400
+    assert "integer" in r.get_json().get("error", "")
+
+
+def test_api_node_count_at_missing_count_returns_400(client):
+    r = client.get(
+        "/api/entitlement/min-tier-for-node-count-at?tier=cloud_pro"
+    )
+    assert r.status_code == 400
+    assert r.get_json().get("error") == "missing count"
+
+
+def test_api_retention_window_at_missing_days_returns_400(client):
+    r = client.get(
+        "/api/entitlement/min-tier-for-retention-window-at?tier=cloud_pro"
+    )
+    assert r.status_code == 400
+    assert r.get_json().get("error") == "missing days"
+
+
+def test_api_retention_window_at_nonint_days_returns_400(client):
+    r = client.get(
+        "/api/entitlement/min-tier-for-retention-window-at"
+        "?tier=cloud_pro&days=nope"
+    )
+    assert r.status_code == 400
+
+
+# ── API: retention `unlimited` handling ───────────────────────────────────
+
+
+def test_api_retention_window_at_unlimited(client, ent):
+    r = client.get(
+        "/api/entitlement/min-tier-for-retention-window-at"
+        "?tier=cloud_pro&days=unlimited"
+    )
+    assert r.status_code == 200
+    j = r.get_json()
+    assert j["item"] is None
+    assert j["label"] == "unlimited"
+    assert j["kind"] == "retention_window"
+    assert j["required_tier"] == ent.min_tier_for_retention_window(None)
+    assert j["perspective_tier"] == "cloud_pro"
+
+
+def test_api_retention_window_at_unlimited_case_insensitive(client):
+    for spelling in ("Unlimited", "UNLIMITED", "unLimIted"):
+        j = client.get(
+            "/api/entitlement/min-tier-for-retention-window-at"
+            f"?tier=cloud_pro&days={spelling}"
+        ).get_json()
+        assert j["item"] is None
+        assert j["label"] == "unlimited"
+
+
+# ── API: zero / negative collapses to free floor (parity with bare) ───────
+
+
+def test_api_channel_count_at_zero_is_free(client, ent):
+    j = client.get(
+        "/api/entitlement/min-tier-for-channel-count-at"
+        "?tier=cloud_pro&count=0"
+    ).get_json()
+    assert j["required_tier"] == ent.TIER_OSS
+    assert j["free"] is True
+
+
+def test_api_node_count_at_zero_is_free(client, ent):
+    j = client.get(
+        "/api/entitlement/min-tier-for-node-count-at"
+        "?tier=cloud_pro&count=0"
+    ).get_json()
+    assert j["required_tier"] == ent.TIER_OSS
+    assert j["free"] is True
+
+
+def test_api_retention_window_at_zero_is_free(client, ent):
+    j = client.get(
+        "/api/entitlement/min-tier-for-retention-window-at"
+        "?tier=cloud_pro&days=0"
+    ).get_json()
+    assert j["required_tier"] == ent.TIER_OSS
+    assert j["free"] is True
+
+
+# ── API: cross-endpoint parity with bare ──────────────────────────────────
+
+
+@pytest.mark.parametrize("n", [1, 3, 10, 50, 1000])
+def test_api_channel_count_at_matches_bare(client, ent, n):
+    bare = client.get(
+        f"/api/entitlement/min-tier-for-channel-count?count={n}"
+    ).get_json()
+    at = client.get(
+        "/api/entitlement/min-tier-for-channel-count-at"
+        f"?tier=cloud_pro&count={n}"
+    ).get_json()
+    # answer axis must not depend on perspective
+    for k in ("required_tier", "required_tier_label", "required_tier_rank",
+              "free", "kind", "item", "label"):
+        assert bare[k] == at[k], f"key {k} drifted"
+
+
+@pytest.mark.parametrize("n", [1, 3, 10, 50, 1000])
+def test_api_node_count_at_matches_bare(client, ent, n):
+    bare = client.get(
+        f"/api/entitlement/min-tier-for-node-count?count={n}"
+    ).get_json()
+    at = client.get(
+        "/api/entitlement/min-tier-for-node-count-at"
+        f"?tier=cloud_pro&count={n}"
+    ).get_json()
+    for k in ("required_tier", "required_tier_label", "required_tier_rank",
+              "free", "kind", "item", "label"):
+        assert bare[k] == at[k], f"key {k} drifted"
+
+
+@pytest.mark.parametrize("d", [1, 7, 30, 90, 365])
+def test_api_retention_window_at_matches_bare(client, ent, d):
+    bare = client.get(
+        f"/api/entitlement/min-tier-for-retention-window?days={d}"
+    ).get_json()
+    at = client.get(
+        "/api/entitlement/min-tier-for-retention-window-at"
+        f"?tier=cloud_pro&days={d}"
+    ).get_json()
+    for k in ("required_tier", "required_tier_label", "required_tier_rank",
+              "free", "kind", "item", "label"):
+        assert bare[k] == at[k], f"key {k} drifted"
+
+
+# ── API: uniform envelope across the three `_at` axes ─────────────────────
+
+
+def test_api_three_at_axes_share_envelope_keys(client):
+    ch = client.get(
+        "/api/entitlement/min-tier-for-channel-count-at"
+        "?tier=cloud_pro&count=5"
+    ).get_json()
+    nd = client.get(
+        "/api/entitlement/min-tier-for-node-count-at"
+        "?tier=cloud_pro&count=4"
+    ).get_json()
+    rw = client.get(
+        "/api/entitlement/min-tier-for-retention-window-at"
+        "?tier=cloud_pro&days=30"
+    ).get_json()
+    assert set(ch.keys()) == set(nd.keys()) == set(rw.keys()) == (
+        _AT_ENVELOPE_KEYS
+    )
+
+
+# ── API: perspective envelope carried ─────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "/api/entitlement/min-tier-for-channel-count-at?tier=cloud_pro&count=5",
+        "/api/entitlement/min-tier-for-node-count-at?tier=cloud_pro&count=4",
+        "/api/entitlement/min-tier-for-retention-window-at?tier=cloud_pro&days=30",
+    ],
+)
+def test_api_at_carries_perspective_envelope(client, ent, url):
+    j = client.get(url).get_json()
+    assert j["perspective_tier"] == "cloud_pro"
+    assert j["perspective_tier_label"] == ent.tier_label("cloud_pro")
+    assert j["perspective_tier_rank"] == ent.tier_rank("cloud_pro")
+
+
+# ── API: perspective-independence across every tier ──────────────────────
+
+
+@pytest.mark.parametrize("perspective", ["oss", "cloud_starter", "cloud_pro",
+                                          "enterprise", "trial"])
+def test_api_channel_count_at_answer_independent_of_perspective(
+    client, ent, perspective
+):
+    bare = client.get(
+        "/api/entitlement/min-tier-for-channel-count?count=5"
+    ).get_json()
+    at = client.get(
+        "/api/entitlement/min-tier-for-channel-count-at"
+        f"?tier={perspective}&count=5"
+    ).get_json()
+    assert at["required_tier"] == bare["required_tier"]
+    assert at["perspective_tier"] == perspective
+
+
+# ── API: resolver envelope carried on happy path ─────────────────────────
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "/api/entitlement/min-tier-for-channel-count-at?tier=cloud_pro&count=5",
+        "/api/entitlement/min-tier-for-node-count-at?tier=cloud_pro&count=4",
+        "/api/entitlement/min-tier-for-retention-window-at?tier=cloud_pro&days=30",
+    ],
+)
+def test_api_at_carries_resolver_envelope(client, url):
+    j = client.get(url).get_json()
+    for k in ("current_tier", "current_tier_rank", "grace", "enforced"):
+        assert k in j
+    assert j["grace"] is True
+    assert j["enforced"] is False
+
+
+# ── API: never-5xxs on a delegate crash ───────────────────────────────────
+
+
+def test_api_channel_count_at_never_5xxs_on_delegate_crash(
+    client, ent, monkeypatch
+):
+    def _boom(*_a, **_kw):
+        raise RuntimeError("delegate boom")
+
+    monkeypatch.setattr(ent, "min_tier_for_channel_count_at", _boom)
+    r = client.get(
+        "/api/entitlement/min-tier-for-channel-count-at"
+        "?tier=cloud_pro&count=5"
+    )
+    assert r.status_code == 200
+    j = r.get_json()
+    assert j["required_tier"] is None
+    assert j["item"] == 5
+    assert j["kind"] == "channel_count"
+    assert j["perspective_tier"] == "cloud_pro"
+
+
+def test_api_node_count_at_never_5xxs_on_delegate_crash(
+    client, ent, monkeypatch
+):
+    def _boom(*_a, **_kw):
+        raise RuntimeError("delegate boom")
+
+    monkeypatch.setattr(ent, "min_tier_for_node_count_at", _boom)
+    r = client.get(
+        "/api/entitlement/min-tier-for-node-count-at"
+        "?tier=cloud_pro&count=4"
+    )
+    assert r.status_code == 200
+    j = r.get_json()
+    assert j["required_tier"] is None
+    assert j["item"] == 4
+    assert j["kind"] == "node_count"
+
+
+def test_api_retention_window_at_never_5xxs_on_delegate_crash(
+    client, ent, monkeypatch
+):
+    def _boom(*_a, **_kw):
+        raise RuntimeError("delegate boom")
+
+    monkeypatch.setattr(ent, "min_tier_for_retention_window_at", _boom)
+    r = client.get(
+        "/api/entitlement/min-tier-for-retention-window-at"
+        "?tier=cloud_pro&days=30"
+    )
+    assert r.status_code == 200
+    j = r.get_json()
+    assert j["required_tier"] is None
+    assert j["item"] == 30
+    assert j["kind"] == "retention_window"
+
+
+def test_api_retention_window_at_unlimited_never_5xxs_on_delegate_crash(
+    client, ent, monkeypatch
+):
+    def _boom(*_a, **_kw):
+        raise RuntimeError("delegate boom")
+
+    monkeypatch.setattr(ent, "min_tier_for_retention_window_at", _boom)
+    r = client.get(
+        "/api/entitlement/min-tier-for-retention-window-at"
+        "?tier=cloud_pro&days=unlimited"
+    )
+    assert r.status_code == 200
+    j = r.get_json()
+    assert j["required_tier"] is None
+    assert j["item"] is None
+    assert j["kind"] == "retention_window"
+
+
+# ── grace vs enforce parity ───────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "/api/entitlement/min-tier-for-channel-count-at?tier=cloud_pro&count=5",
+        "/api/entitlement/min-tier-for-node-count-at?tier=cloud_pro&count=4",
+        "/api/entitlement/min-tier-for-retention-window-at?tier=cloud_pro&days=30",
+    ],
+)
+def test_api_at_grace_vs_enforce_identical(client, ent, monkeypatch, url):
+    grace = client.get(url).get_json()
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    importlib.reload(ent)
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    enforce_client = app.test_client()
+    enforce = enforce_client.get(url).get_json()
+    # The pricing-surface fields (item / kind / label / required_tier /
+    # free / perspective_tier) must byte-equal between grace and enforce:
+    # enforcement is a gating concern, not a description concern.
+    for k in ("item", "kind", "label", "required_tier", "free",
+              "perspective_tier"):
+        assert grace[k] == enforce[k], (
+            f"key {k} drifted grace vs enforce"
+        )


### PR DESCRIPTION
## Summary

Closes the `_at` slot for the three scalar capacity axes so a pricing-matrix walkthrough (`?tier=<p>`) can hit every scalar `min-tier-for-*` axis uniformly at a fixed perspective.

- Before this change, the `min_tier_for_*` helper family had `_at` perspective siblings for the grant axes (`min_tier_for_features_at` / `min_tier_for_runtimes_at`, #3711) but the three capacity axes (`channel_count` / `retention_window` / `node_count`) only had bare helpers. The `tiers_for_*` family already had `_at` siblings on all three capacity axes (`tiers_for_channel_count_at`, etc.) — this closes the symmetry gap in the `min_tier_for_*` family.
- Perspective is validated against `_TIER_ORDER` (including `trial`) but does NOT shape the answer — the scalar tier id depends only on the static per-tier capacity table. Parity contract pinned in the test suite guarantees the `required_tier` byte-equals the bare helper for every `perspective_tier`, so the `_at` prefix cannot silently drift into shaping the result.
- GRACE-safe: no behavior change to any existing endpoint or helper. Response layers the `perspective_tier` envelope on top of the existing `/min-tier-for-<axis>` body so a walkthrough surface renders the "from &lt;perspective&gt;" copy off one round-trip.

**New helpers in `clawmetry/entitlements.py`:**
- `min_tier_for_channel_count_at(perspective_tier, count)`
- `min_tier_for_retention_window_at(perspective_tier, days)`
- `min_tier_for_node_count_at(perspective_tier, count)`

**New endpoints on `bp_entitlement` (routes/entitlement.py):**
- `GET /api/entitlement/min-tier-for-channel-count-at?tier=<p>&count=<n>`
- `GET /api/entitlement/min-tier-for-node-count-at?tier=<p>&count=<n>`
- `GET /api/entitlement/min-tier-for-retention-window-at?tier=<p>&days=<n|unlimited>`

400 on missing / blank / non-int; 404 on unknown perspective tier; never 5xxs (delegate failure → perspective-carrying grace body). Zero / negative collapse to `TIER_OSS`; `days=unlimited` (case-insensitive) rides through as `item=null` / `label="unlimited"`.

## Test plan

`tests/test_entitlement_min_tier_for_capacity_at.py` — 80 cases:

- [x] Helper-side perspective-independence parity across the full `_TIER_ORDER` for all three axes
- [x] API happy path + envelope key set (14-key `_AT_ENVELOPE_KEYS`)
- [x] API error paths: 400 on missing / blank / non-int; 404 on unknown perspective tier
- [x] Cross-endpoint parity with the bare siblings (`/min-tier-for-channel-count` etc.) for the answer axis
- [x] `days=unlimited` round-trip (item=null, label="unlimited"), case-insensitive
- [x] Zero / negative collapse to `TIER_OSS` on all three axes
- [x] Uniform envelope keys across the three `_at` axes
- [x] Perspective envelope carried on happy path
- [x] Resolver envelope carried on happy path
- [x] Never-5xxs on a delegate crash (including `days=unlimited` variant)
- [x] Grace-vs-enforce parity on the description fields (item / kind / label / required_tier / free / perspective_tier)

```
$ python3 -m pytest tests/test_entitlement_min_tier_for_capacity_at.py
80 passed in 5.79s

$ python3 -m pytest tests/test_entitlement_min_tier_for_capacity_bare.py \
                    tests/test_entitlement_min_tier_for_plural_at.py \
                    tests/test_entitlement_min_tier_for_plural_bare.py
150 passed in 12.74s   # no regressions in adjacent siblings

$ python3 -m py_compile clawmetry/entitlements.py routes/entitlement.py
OK
```

## Local operator verification checklist

The autonomous session can't reach the running daemon, `~/.openclaw`, the live cloud snapshot, or a browser. Verify locally before flipping ready-for-review:

- [ ] Copy the three changed files into `~/.clawmetry/lib/pythonX.Y/site-packages/clawmetry/` (or `routes/` for `routes/entitlement.py`) and clear `__pycache__/`.
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` (and `com.clawmetry.dashboard` if separately managed) so the daemon picks up the new endpoints.
- [ ] Hit each new endpoint against the live daemon and check the envelope:
  ```
  curl -s 'http://localhost:8900/api/entitlement/min-tier-for-channel-count-at?tier=cloud_pro&count=5' | jq .
  curl -s 'http://localhost:8900/api/entitlement/min-tier-for-node-count-at?tier=cloud_starter&count=4' | jq .
  curl -s 'http://localhost:8900/api/entitlement/min-tier-for-retention-window-at?tier=enterprise&days=unlimited' | jq .
  ```
  - Confirm `perspective_tier` echoes back, `required_tier` byte-equals `/api/entitlement/min-tier-for-<axis>` at the same `count`/`days`, and `grace=true` / `enforced=false` on OSS install.
- [ ] Confirm the three bare siblings still respond identically (no regression):
  ```
  diff <(curl -s '.../min-tier-for-channel-count?count=5' | jq 'del(.item)') \
       <(curl -s '.../min-tier-for-channel-count-at?tier=cloud_pro&count=5' | jq 'del(.item, .perspective_tier, .perspective_tier_label, .perspective_tier_rank)')
  ```
- [ ] Error paths: `?count=nope` → 400; `?tier=bogus&count=5` → 404 with `which=tier`.
- [ ] Decrypt the live cloud snapshot and open the dashboard in a browser; visit the Pricing / Fleet / Retention surfaces and confirm no regression in the existing paywall affordances.
- [ ] Flip the PR out of draft once the four above pass.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TSwHwVPMQ8hoNT4rvbroxQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01TSwHwVPMQ8hoNT4rvbroxQ)_