### PR TITLE
e2e: assert window.switchTab is callable before tab overlay sweep

### DIFF
--- a/.github/scripts/visual-diff.mjs
+++ b/.github/scripts/visual-diff.mjs
@@ -173,13 +173,32 @@ async function shoot(browser, baseUrl, view, tab, file) {
 
     // Switch to the requested tab via the page's own router. Overview is the
     // default landing tab so we only call switchTab() for everything else.
+    //
+    // Use an explicit return string instead of the old short-circuit guard
+    //   (typeof switchTab === 'function' && switchTab(tab))
+    // so that a missing switchTab() surfaces as a logged error rather than
+    // silently screenshotting the overview tab for every non-overview case.
+    // This was the root cause of the user-reported issue (2026-05-17):
+    // "screenshots are always broken -- gateway token not passed for OSS,
+    // never displays other screens" -- the bot was always on overview.
     if (tab !== "overview") {
       try {
-        await page.evaluate((name) => {
-          if (typeof window.switchTab === "function") window.switchTab(name);
+        const switchResult = await page.evaluate((name) => {
+          if (typeof window.switchTab !== "function") return "no-switchtab";
+          window.switchTab(name);
+          return "ok";
         }, tab);
-      } catch {
+        if (switchResult !== "ok") {
+          ok = false;
+          console.error(
+            `[switch-fail] ${baseUrl} tab=${tab}: window.switchTab() not available ` +
+            `(result=${switchResult}). app.js may have failed to load or ` +
+            `auth is blocking. Ensure OPENCLAW_GATEWAY_TOKEN matches CLAWMETRY_VISUAL_DIFF_TOKEN.`
+          );
+        }
+      } catch (switchErr) {
         ok = false;
+        console.error(`[switch-fail] ${baseUrl} tab=${tab} threw: ${switchErr && switchErr.message}`);
       }
     }
 
@@ -327,11 +346,12 @@ async function main() {
             `${label} ${view.name}/${tab}: HTTP ${res.status || "no-response"} (expected 200)`
           );
         } else if (!res.ok) {
-          // HTTP 200 but ok=false: shoot() detected an auth overlay or render
-          // error. Treat as an auth gap so the workflow fails loudly instead of
-          // silently posting overlay screenshots with a green exit code.
+          // HTTP 200 but ok=false: shoot() detected an auth overlay, a
+          // switchTab() failure, or a render error. Treat as an auth gap so
+          // the workflow fails loudly instead of silently posting screenshots
+          // of the overview tab with a green exit code.
           authGaps.push(
-            `${label} ${view.name}/${tab}: auth overlay visible or render error (token not accepted)`
+            `${label} ${view.name}/${tab}: auth overlay, switchTab() failure, or render error (token not accepted or app.js not loaded)`
           );
         }
       }

--- a/tests/test_e2e_oss_all_tabs.py
+++ b/tests/test_e2e_oss_all_tabs.py
@@ -202,13 +202,35 @@ class TestAllTabsPostAuth:
         only calls switchTab() and checks the overlay state. Re-navigating
         to "/" per test caused 33 sequential page loads that saturated the
         waitress WSGI queue and produced spurious TimeoutErrors.
+
+        If this test fails with AssertionError containing 'window.switchTab()
+        not available', the root cause is not the overlay itself but that
+        app.js failed to load or parse (e.g. syntax error shipped in the
+        bundle) or that auth is still blocking script execution on load.
+        Check the server log and /api/auth/check before investigating tabs.
         """
         page = _overlay_page
 
         if tab != "overview":
-            page.evaluate(
-                "typeof window.switchTab === 'function' && "
-                f"window.switchTab({json.dumps(tab)})"
+            # Use an explicit return value instead of the short-circuit bool
+            # guard ("typeof ... === 'function' && switchTab()") so that a
+            # missing switchTab fails loudly rather than silently checking the
+            # overview tab for every parametrized case.
+            result = page.evaluate(
+                "(tab) => {"
+                "  if (typeof window.switchTab !== 'function') return 'no-switchtab';"
+                "  window.switchTab(tab);"
+                "  return 'ok';"
+                "}",
+                tab,
+            )
+            assert result == "ok", (
+                f"Tab '{tab}': window.switchTab() not available on the loaded page. "
+                f"Root causes: (1) app.js failed to parse or load (404/syntax error); "
+                f"(2) auth overlay is still blocking JS execution; "
+                f"(3) page has not finished initialising. "
+                f"Ensure OPENCLAW_GATEWAY_TOKEN={TOKEN!r} matches CLAWMETRY_TOKEN "
+                f"and that {BASE_URL!r} is reachable."
             )
 
         page.wait_for_timeout(500)

--- a/tests/test_e2e_oss_golden_path.py
+++ b/tests/test_e2e_oss_golden_path.py
@@ -88,6 +88,30 @@ def _api(path: str) -> dict:
         return json.loads(resp.read())
 
 
+def _switch_tab(page, tab: str) -> None:
+    """Switch the dashboard to *tab* via window.switchTab(), asserting it exists.
+
+    Replaces the old short-circuit guard
+      page.evaluate("typeof window.switchTab === 'function' && switchTab(tab)")
+    which silently no-oped when switchTab was absent, causing every subsequent
+    overlay check to inspect the overview tab instead of the intended tab.
+    """
+    result = page.evaluate(
+        "(tab) => {"
+        "  if (typeof window.switchTab !== 'function') return 'no-switchtab';"
+        "  window.switchTab(tab);"
+        "  return 'ok';"
+        "}",
+        tab,
+    )
+    assert result == "ok", (
+        f"window.switchTab() not available when switching to tab '{tab}'. "
+        f"Root causes: app.js parse/load error, auth overlay still blocking, "
+        f"or page not yet initialised. "
+        f"Ensure {BASE_URL!r} started with OPENCLAW_GATEWAY_TOKEN={TOKEN!r}."
+    )
+
+
 class TestOSSGoldenPath:
     """Full OSS golden path: wheel-installed dashboard + synced OpenClaw data + 9 tabs.
 
@@ -171,10 +195,7 @@ class TestOSSGoldenPath:
 
         # Switch to the transcripts (Sessions) tab; this triggers loadTranscripts()
         # which fetches /api/sessions and renders the list into #transcript-list.
-        page.evaluate(
-            "typeof window.switchTab === 'function' && "
-            "window.switchTab('transcripts')"
-        )
+        _switch_tab(page, "transcripts")
 
         # Wait up to 8s for the seeded session title to appear in the live DOM.
         # Playwright polls after each mutation so this catches the render as
@@ -217,10 +238,7 @@ class TestOSSGoldenPath:
         page.goto(BASE_URL + "/", wait_until="domcontentloaded", timeout=15000)
 
         if tab != "overview":
-            page.evaluate(
-                "typeof window.switchTab === 'function' && "
-                f"window.switchTab({json.dumps(tab)})"
-            )
+            _switch_tab(page, tab)
 
         page.wait_for_timeout(1000)
 


### PR DESCRIPTION
## Problem

All three call sites that navigate between dashboard tabs used a silent short-circuit guard:

```js
// test_e2e_oss_all_tabs.py / test_e2e_oss_golden_path.py
page.evaluate("typeof window.switchTab === 'function' && window.switchTab(tab)")

// visual-diff.mjs
if (typeof window.switchTab === "function") window.switchTab(name);
```

When `window.switchTab` is undefined (app.js failed to parse, auth overlay blocked script execution, or the page hasn't fully booted), this expression evaluates to `false`/no-op and the tab switch is **silently skipped**. The test then checks overlays on whatever tab is already active (overview), so every parametrized case in the 33-tab C5 sweep passes even though it checked the same tab 33 times.

This is the root cause of the user-reported symptom (2026-05-17):
> "the screenshots are always broken -- gateway token is not passed for OSS so it never displays other screens"

The bot was always on the overview tab. The screenshots of "brain", "usage", "crons", etc. were all just the overview tab, making the visual diff meaningless for those tabs.

## Fix

Replace the short-circuit bool guard with an explicit return-string pattern at all three call sites:

```js
// Returns "ok" on success, "no-switchtab" if the function is absent
result = page.evaluate(
    "(tab) => { if (typeof window.switchTab !== 'function') return 'no-switchtab'; window.switchTab(tab); return 'ok'; }",
    tab,
)
assert result == "ok", f"Tab '{tab}': window.switchTab() not available -- ..."
```

A missing `switchTab` now surfaces as a clear `AssertionError` naming the root cause (app.js load failure / auth blocking) instead of masking it as a false-positive overlay pass.

Additionally, `test_e2e_oss_golden_path.py` extracts the pattern into a shared `_switch_tab(page, tab)` helper to keep C1's 9-tab sweep and render-tier tests consistent.

## Files changed

| File | Change |
|------|--------|
| `tests/test_e2e_oss_all_tabs.py` | Replace silent `&&` guard with asserting evaluate in `test_tab_loads_without_auth_overlay` |
| `tests/test_e2e_oss_golden_path.py` | Extract `_switch_tab()` helper; use it in `test_c1_tab_no_auth_overlay` and `test_sessions_tab_renders_seeded_session` |
| `.github/scripts/visual-diff.mjs` | Replace silent no-op in `shoot()` with `switchResult !== "ok"` check that sets `ok = false` and logs `[switch-fail]` |

## Acceptance test

Start the dashboard **without** `OPENCLAW_GATEWAY_TOKEN` (so app.js auth blocks), then run:

```bash
CLAWMETRY_URL=http://localhost:8900 CLAWMETRY_TOKEN=bad-token \
  pytest tests/test_e2e_oss_all_tabs.py::TestAllTabsPostAuth::test_tab_loads_without_auth_overlay[brain] -v
```

Before this PR: test passes (silently checks overview tab).
After this PR: test fails with `AssertionError: Tab 'brain': window.switchTab() not available`.

## Tracking

Closes part of vivekchand/clawmetry#3943 (E2E Robustness epic, C5 robustness dimension).


---
_Generated by [Claude Code](https://claude.ai/code/session_01QzxZs67FqkZvhFTmnN2Nsx)_