### PR TITLE
feat(entitlement): per-value capacity-axis batch helpers + /min-tier-for-{channel-count,retention-window,node-count}-batch

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -1,4 +1,3 @@
-"""
 clawmetry/entitlements.py — open-core entitlement resolution.
 
 Single source of truth for "what is this install allowed to do". Everything
@@ -5906,6 +5905,111 @@ def min_tier_for_runtimes_at(
     except Exception as exc:
         logger.warning("entitlements: min_tier_for_runtimes_at failed: %s", exc)
         return None
+
+
+def min_tier_for_channel_count_at(
+    perspective_tier: str, count: int
+) -> str | None:
+    """Hypothetical-perspective sibling of :func:`min_tier_for_channel_count`.
+
+    Fills the ``_at`` slot for the channel-count capacity axis alongside
+    :func:`min_tier_for_features_at` / :func:`min_tier_for_runtimes_at` so a
+    pricing-matrix walkthrough can call ``X_at(perspective, ...)`` uniformly
+    across every ``_at`` sibling in the ``min_tier_for_*`` family. Same
+    relationship to :func:`min_tier_for_channel_count` that
+    :func:`tiers_for_channel_count_at` has to :func:`tiers_for_channel_count`:
+    ``perspective_tier`` is validated against :data:`_TIER_ORDER` (including
+    :data:`TIER_TRIAL`) but does NOT shape the answer -- the scalar tier id
+    depends only on the static :data:`_TIER_CHANNEL_LIMIT` table, not on the
+    caller's live plan. A parity test pins
+    ``min_tier_for_channel_count_at(p, n) == min_tier_for_channel_count(n)``
+    for every ``p`` in :data:`_TIER_ORDER` so the ``_at`` prefix cannot
+    silently drift into shaping the result.
+
+    Returns ``None`` for empty / unknown ``perspective_tier`` (caller renders
+    "unknown tier" / 404), matching the ``None`` posture the rest of the
+    ``_at`` family uses for the perspective-validation failure mode. All
+    other semantics -- ``count <= 0`` -> :data:`TIER_OSS`, non-int ->
+    ``None``, over-cap -> :data:`TIER_ENTERPRISE` -- inherit from
+    :func:`min_tier_for_channel_count` unchanged. Never raises: a delegate
+    failure logs a warning and returns ``None``.
+    """
+    try:
+        p = (perspective_tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if not p or p not in _TIER_ORDER:
+        return None
+    try:
+        return min_tier_for_channel_count(count)
+    except Exception as exc:
+        logger.warning(
+            "entitlements: min_tier_for_channel_count_at failed: %s", exc
+        )
+        return None
+
+
+def min_tier_for_retention_window_at(
+    perspective_tier: str, days: int | None
+) -> str | None:
+    """Hypothetical-perspective sibling of
+    :func:`min_tier_for_retention_window`. Retention-axis twin of
+    :func:`min_tier_for_channel_count_at`.
+
+    Accepts the explicit ``days=None`` "unlimited" sentinel that the
+    singular helper accepts -- delegates without further parsing, so the
+    same "None means unlimited on this axis" semantics carry through
+    unchanged and only tiers whose retention cap is ``None`` admit the
+    request. Non-int (non-``None``) ``days`` yields ``None`` (matches the
+    singular helper's posture on bad input rather than mis-routing to
+    Enterprise). ``days <= 0`` collapses to :data:`TIER_OSS`.
+
+    Perspective is validated against :data:`_TIER_ORDER` (including
+    :data:`TIER_TRIAL`) but does NOT shape the answer. Returns ``None`` for
+    empty / unknown ``perspective_tier``. Never raises.
+    """
+    try:
+        p = (perspective_tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if not p or p not in _TIER_ORDER:
+        return None
+    try:
+        return min_tier_for_retention_window(days)
+    except Exception as exc:
+        logger.warning(
+            "entitlements: min_tier_for_retention_window_at failed: %s", exc
+        )
+        return None
+
+
+def min_tier_for_node_count_at(
+    perspective_tier: str, count: int
+) -> str | None:
+    """Hypothetical-perspective sibling of :func:`min_tier_for_node_count`.
+    Node-axis twin of :func:`min_tier_for_channel_count_at`.
+
+    Perspective is validated against :data:`_TIER_ORDER` (including
+    :data:`TIER_TRIAL`) but does NOT shape the answer -- the scalar tier
+    id depends only on the static :data:`_TIER_NODE_LIMIT` table. Returns
+    ``None`` for empty / unknown ``perspective_tier`` (caller renders
+    "unknown tier" / 404) and for non-int ``count``. All other semantics
+    inherit from :func:`min_tier_for_node_count`. Never raises.
+    """
+    try:
+        p = (perspective_tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if not p or p not in _TIER_ORDER:
+        return None
+    try:
+        return min_tier_for_node_count(count)
+    except Exception as exc:
+        logger.warning(
+            "entitlements: min_tier_for_node_count_at failed: %s", exc
+        )
+        return None
+
 
 
 def _min_tier_for_features_bundle_row(bundle) -> dict:
@@ -18153,25 +18257,4 @@ def tiers_for_capacity_batch_at(
     renders "unknown tier" / 404). Never raises: a delegate failure
     surfaces as an all-``None`` envelope shape (same posture as
     :func:`tiers_for_capacity_batch`).
-    """
-    try:
-        p = (perspective_tier or "").strip().lower()
-    except (AttributeError, TypeError):
-        return None
-    if not p or p not in _TIER_ORDER:
-        return None
-    try:
-        return tiers_for_capacity_batch(
-            channels=channels,
-            retention_days=retention_days,
-            nodes=nodes,
-        )
-    except Exception as exc:
-        logger.warning(
-            "entitlements: tiers_for_capacity_batch_at failed: %s", exc
-        )
-        return {
-            "channels": None,
-            "retention_days": None,
-            "nodes": None,
-        }
+    

--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -5567,6 +5567,204 @@ def min_tier_for_node_count(count: int) -> str | None:
     return TIER_ENTERPRISE
 
 
+def min_tier_for_channel_count_batch(counts) -> list[dict]:
+    """Per-value cheapest *purchasable* tier for N channel-count values in
+    ONE round-trip.
+
+    Per-value axis batch sibling of :func:`min_tier_for_channel_count`. Where
+    :func:`min_tier_batch` folds ONE scalar per capacity axis (five per-axis
+    rows) and :func:`min_tier_for_features_batch` folds N feature *bundles*,
+    this helper preserves per-value grouping on a SINGLE capacity axis so a
+    pricing-matrix walkthrough comparing several hypothetical channel counts
+    (e.g. "at 1 / 5 / 10 / 25 channels -- cheapest qualifying tier per row")
+    renders off one call instead of N :func:`min_tier_for_channel_count`
+    round-trips + manual row assembly.
+
+    Row shape matches ``_min_tier_row(<n>, "channels")`` byte-for-byte::
+
+        {
+          "key":            "<n>",
+          "kind":           "channels",
+          "free":           <bool>,     # True iff min_tier == TIER_OSS
+          "min_tier":       "cloud_starter" | None,
+          "min_tier_label": "Cloud Starter" | None,
+          "min_tier_rank":  <int>,      # -1 when min_tier is None
+        }
+
+    Per-row parity with :func:`min_tier_for_channel_count` is pinned in the
+    test suite so the batch cannot silently drift from the scalar.
+
+    Argument handling mirrors :func:`min_tier_for_features_batch`:
+
+    * ``counts is None`` or non-iterable -- returns ``[]``.
+    * Non-int items collapse to the all-``None`` row shape (matches
+      :func:`min_tier_for_channel_count`'s ``None``-on-bad-input posture
+      rather than raising).
+    * Duplicates by normalised int key are dropped preserving first-seen
+      order so the response is stable and byte-deterministic across calls.
+
+    Decoupled from the resolved entitlement: delegates per row to
+    :func:`min_tier_for_channel_count` via :func:`_min_tier_row`, which
+    walks the static ``_TIER_CHANNEL_LIMIT`` map. Grace vs enforce yields
+    byte-identical rows -- pinned in the test suite via a grace/enforce
+    reload roundtrip. Never raises: per-row failures short-circuit to the
+    all-``None`` shape so the batch keeps building.
+    """
+    return _min_tier_for_capacity_batch(counts, "channels")
+
+
+def min_tier_for_retention_window_batch(days_list) -> list[dict]:
+    """Per-value cheapest *purchasable* tier for N retention-window values
+    in ONE round-trip. Retention-axis twin of
+    :func:`min_tier_for_channel_count_batch`.
+
+    Each item in ``days_list`` may be:
+
+    * an int (or int-parseable string) -- a finite ``days`` window; matches
+      :func:`min_tier_for_channel_count_batch` row semantics.
+    * ``None`` or the case-insensitive string ``"unlimited"`` -- an unlimited-
+      history request; the row's ``key`` is ``"unlimited"``, ``min_tier``
+      matches :func:`min_tier_for_retention_window` (``days=None``). This
+      is the *only* per-axis batch on the retention axis that admits the
+      unlimited sentinel -- :func:`min_tier_batch` treats
+      ``retention_days=None`` as *unset* (matching
+      :func:`min_tier_for_all`), so a caller previously had to route the
+      unlimited-history question through the singular endpoint.
+    * Any other value (blank / non-int / non-``"unlimited"`` string) --
+      collapses to the all-``None`` row shape with the raw string echoed
+      as ``key`` (matches :func:`min_tier_for_retention_window`'s
+      ``None``-on-bad-input posture rather than raising).
+
+    Duplicates by normalised key (``"<n>"`` for a parsed int, ``"unlimited"``
+    for the unlimited sentinel, ``str(raw)`` otherwise) are dropped
+    preserving first-seen order for byte-stable output.
+
+    ``days_list is None`` or non-iterable -- returns ``[]``. Never raises:
+    per-row failures short-circuit to the all-``None`` shape.
+    """
+    try:
+        if days_list is None:
+            return []
+        items = list(days_list)
+    except TypeError:
+        return []
+    out: list[dict] = []
+    seen: set[str] = set()
+    for raw in items:
+        try:
+            row = _retention_batch_row(raw)
+        except Exception as exc:
+            logger.warning(
+                "entitlements: min_tier_for_retention_window_batch row "
+                "failed: %s",
+                exc,
+            )
+            row = {
+                "key": str(raw),
+                "kind": "retention_days",
+                "free": False,
+                "min_tier": None,
+                "min_tier_label": None,
+                "min_tier_rank": -1,
+            }
+        key = row.get("key")
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(row)
+    return out
+
+
+def min_tier_for_node_count_batch(counts) -> list[dict]:
+    """Per-value cheapest *purchasable* tier for N node-count values in ONE
+    round-trip. Node-axis twin of :func:`min_tier_for_channel_count_batch`.
+
+    Same per-value grouping, same never-5xx posture, same duplicate dedup
+    by normalised int key. Delegates per row to :func:`min_tier_for_node_count`
+    via :func:`_min_tier_row`; grace vs enforce yields byte-identical rows.
+    """
+    return _min_tier_for_capacity_batch(counts, "nodes")
+
+
+def _min_tier_for_capacity_batch(values, kind: str) -> list[dict]:
+    """Shared body for :func:`min_tier_for_channel_count_batch` and
+    :func:`min_tier_for_node_count_batch` (the two integer-only capacity
+    axes -- retention has its own body because it admits the
+    ``None`` / ``"unlimited"`` sentinel).
+
+    Iterates ``values``, dedupes by normalised int key preserving first-
+    seen order, and delegates to :func:`_min_tier_row` for the per-row
+    shape so parity with the singular helpers is automatic. Non-int
+    items pass raw to :func:`_min_tier_row`, which yields the all-
+    ``None`` shape (matches the singular helpers' ``None``-on-bad-input
+    posture).
+
+    Never raises: per-row failures short-circuit to the all-``None``
+    shape so the batch keeps building.
+    """
+    try:
+        if values is None:
+            return []
+        items = list(values)
+    except TypeError:
+        return []
+    out: list[dict] = []
+    seen: set[str] = set()
+    for raw in items:
+        try:
+            n = int(raw)
+            key = str(n)
+            passthrough = n
+        except (TypeError, ValueError):
+            key = str(raw)
+            passthrough = raw
+        if key in seen:
+            continue
+        seen.add(key)
+        try:
+            row = _min_tier_row(passthrough, kind)
+        except Exception as exc:
+            logger.warning(
+                "entitlements: _min_tier_for_capacity_batch row failed: %s",
+                exc,
+            )
+            row = {
+                "key": key,
+                "kind": kind,
+                "free": False,
+                "min_tier": None,
+                "min_tier_label": None,
+                "min_tier_rank": -1,
+            }
+        out.append(row)
+    return out
+
+
+def _retention_batch_row(raw) -> dict:
+    """Per-value row for :func:`min_tier_for_retention_window_batch`.
+
+    Handles the ``None`` / ``"unlimited"`` sentinel that the shared
+    integer-only capacity batch cannot express: ``None`` and the case-
+    insensitive string ``"unlimited"`` both route to
+    ``min_tier_for_retention_window(None)`` and surface as a row with
+    ``key="unlimited"``. Any other value falls through to
+    :func:`_min_tier_row` for parity with the singular helper.
+    """
+    if raw is None or (
+        isinstance(raw, str) and raw.strip().lower() == "unlimited"
+    ):
+        min_t = min_tier_for_retention_window(None)
+        return {
+            "key": "unlimited",
+            "kind": "retention_days",
+            "free": min_t == TIER_OSS,
+            "min_tier": min_t,
+            "min_tier_label": tier_label(min_t) if min_t else None,
+            "min_tier_rank": tier_rank(min_t) if min_t else -1,
+        }
+    return _min_tier_row(raw, "retention_days")
+
+
 def min_tier_for_features(features) -> str | None:
     """Cheapest *purchasable* tier admitting **all** ``features`` at once.
 

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -1,4 +1,3 @@
-"""
 routes/entitlement.py -- ``bp_entitlement``.
 
 Exposes the resolved open-core entitlement so the frontend knows which
@@ -22164,6 +22163,256 @@ def api_entitlement_min_tier_for_retention_window():
         )
 
 
+def _min_tier_for_capacity_at_body(
+    _ent, tier_in: str, item, kind: str, label, required
+) -> dict:
+    """Assemble the response body for a ``min-tier-for-<capacity-axis>-at``
+    endpoint. Layers ``perspective_tier`` / ``perspective_tier_label`` /
+    ``perspective_tier_rank`` on top of the standard capacity body so a
+    pricing-matrix walkthrough surface can render the "from <perspective>"
+    copy off one round-trip, matching how ``/min-tier-for-features-at`` /
+    ``/min-tier-for-runtimes-at`` layer perspective onto the grant-axis
+    bodies. Never raises.
+    """
+    return {
+        "item": item,
+        "kind": kind,
+        "label": label,
+        "free": bool(required == _ent.TIER_OSS),
+        "required_tier": required,
+        "required_tier_label": (
+            _ent.tier_label(required) if required else None
+        ),
+        "required_tier_rank": (
+            _ent.tier_rank(required) if required else -1
+        ),
+        "perspective_tier": tier_in,
+        "perspective_tier_label": _ent.tier_label(tier_in),
+        "perspective_tier_rank": _ent.tier_rank(tier_in),
+        **_resolver_envelope(_ent),
+    }
+
+
+def _min_tier_for_capacity_at_fallback(
+    tier_in: str, item, kind: str
+) -> dict:
+    """Grace-shape fallback body for the three
+    ``min-tier-for-<capacity-axis>-at`` endpoints. Same never-5xx posture
+    as :func:`_min_tier_for_capacity_fallback` with the perspective envelope
+    left null so a caller can still render the "from <perspective>" copy
+    with placeholders on a resolver crash.
+    """
+    return {
+        "item": item,
+        "kind": kind,
+        "label": None,
+        "free": False,
+        "required_tier": None,
+        "required_tier_label": None,
+        "required_tier_rank": -1,
+        "perspective_tier": tier_in,
+        "perspective_tier_label": None,
+        "perspective_tier_rank": -1,
+        "current_tier": "oss",
+        "current_tier_rank": 0,
+        "grace": True,
+        "enforced": False,
+    }
+
+
+@bp_entitlement.route("/api/entitlement/min-tier-for-channel-count-at")
+def api_entitlement_min_tier_for_channel_count_at():
+    """``GET /api/entitlement/min-tier-for-channel-count-at?tier=<perspective>
+    &count=<int>`` -- hypothetical-perspective sibling of
+    ``/api/entitlement/min-tier-for-channel-count``.
+
+    Fills the ``_at`` slot for the channel-count capacity axis alongside
+    ``/min-tier-for-features-at`` / ``/min-tier-for-runtimes-at`` so a
+    pricing-matrix walkthrough (``?tier=<p>``) can hit every scalar
+    ``min-tier-for-*`` axis uniformly at a fixed perspective.
+
+    Perspective is validated against :data:`entitlements._TIER_ORDER`
+    (including ``trial``) but does NOT shape rows -- the answer is
+    perspective-independent (parity-pinned by
+    :func:`entitlements.min_tier_for_channel_count_at`). Response layers
+    ``perspective_tier`` on top of the ``/min-tier-for-channel-count``
+    body so a walkthrough surface renders the "from <perspective>" copy
+    off one round-trip.
+
+    - **400** when ``tier=`` is missing / blank, OR when ``count=`` is
+      missing / blank / non-int.
+    - **404** when ``tier`` is unknown (body carries ``which=tier``).
+    - **Never 5xxs**: resolver failure -> perspective-carrying grace body.
+    """
+    raw_tier = request.args.get("tier")
+    tier_in = (raw_tier or "").strip().lower()
+    if not tier_in:
+        return jsonify({"error": "missing tier"}), 400
+
+    raw = request.args.get("count")
+    if raw is None:
+        return jsonify({"error": "missing count"}), 400
+    raw_stripped = raw.strip()
+    if not raw_stripped:
+        return jsonify({"error": "missing count"}), 400
+    try:
+        n = int(raw_stripped)
+    except (TypeError, ValueError):
+        return jsonify({"error": "count must be an integer"}), 400
+
+    try:
+        from clawmetry import entitlements as _ent
+
+        if tier_in not in _ent._TIER_ORDER:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "tier", "tier": tier_in}
+                ),
+                404,
+            )
+        required = _ent.min_tier_for_channel_count_at(tier_in, n)
+        label = f"{n} channel" if n == 1 else f"{n} channels"
+        return jsonify(
+            _min_tier_for_capacity_at_body(
+                _ent, tier_in, n, "channel_count", label, required
+            )
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_min_tier_for_channel_count_at: error: %s", exc
+        )
+        return jsonify(
+            _min_tier_for_capacity_at_fallback(tier_in, n, "channel_count")
+        )
+
+
+@bp_entitlement.route("/api/entitlement/min-tier-for-node-count-at")
+def api_entitlement_min_tier_for_node_count_at():
+    """``GET /api/entitlement/min-tier-for-node-count-at?tier=<perspective>
+    &count=<int>`` -- node-axis twin of
+    ``/api/entitlement/min-tier-for-channel-count-at``. Same perspective
+    contract, same never-5xx posture, same perspective-independence
+    guarantee (parity-pinned). Response shape and error paths mirror
+    ``/min-tier-for-channel-count-at`` with ``kind="node_count"`` and
+    ``label="4 nodes"``.
+    """
+    raw_tier = request.args.get("tier")
+    tier_in = (raw_tier or "").strip().lower()
+    if not tier_in:
+        return jsonify({"error": "missing tier"}), 400
+
+    raw = request.args.get("count")
+    if raw is None:
+        return jsonify({"error": "missing count"}), 400
+    raw_stripped = raw.strip()
+    if not raw_stripped:
+        return jsonify({"error": "missing count"}), 400
+    try:
+        n = int(raw_stripped)
+    except (TypeError, ValueError):
+        return jsonify({"error": "count must be an integer"}), 400
+
+    try:
+        from clawmetry import entitlements as _ent
+
+        if tier_in not in _ent._TIER_ORDER:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "tier", "tier": tier_in}
+                ),
+                404,
+            )
+        required = _ent.min_tier_for_node_count_at(tier_in, n)
+        label = f"{n} node" if n == 1 else f"{n} nodes"
+        return jsonify(
+            _min_tier_for_capacity_at_body(
+                _ent, tier_in, n, "node_count", label, required
+            )
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_min_tier_for_node_count_at: error: %s", exc
+        )
+        return jsonify(
+            _min_tier_for_capacity_at_fallback(tier_in, n, "node_count")
+        )
+
+
+@bp_entitlement.route("/api/entitlement/min-tier-for-retention-window-at")
+def api_entitlement_min_tier_for_retention_window_at():
+    """``GET /api/entitlement/min-tier-for-retention-window-at?tier=<perspective>
+    &days=<int|unlimited>`` -- retention-axis twin of
+    ``/api/entitlement/min-tier-for-channel-count-at``.
+
+    ``days=unlimited`` (case-insensitive) requests the unlimited-history
+    window; only tiers whose retention cap is ``None`` admit the request
+    (Enterprise on the current tier table). ``item`` is ``null`` and
+    ``label`` is ``"unlimited"`` in that case, matching the bare
+    ``/min-tier-for-retention-window`` endpoint's shape.
+
+    Same 400-on-missing-tier / 400-on-blank-days / 404-on-unknown-tier /
+    never-5xx contracts as the two count-axis siblings.
+    """
+    raw_tier = request.args.get("tier")
+    tier_in = (raw_tier or "").strip().lower()
+    if not tier_in:
+        return jsonify({"error": "missing tier"}), 400
+
+    raw = request.args.get("days")
+    if raw is None:
+        return jsonify({"error": "missing days"}), 400
+    raw_stripped = raw.strip()
+    if not raw_stripped:
+        return jsonify({"error": "missing days"}), 400
+    unlimited = raw_stripped.lower() == "unlimited"
+    if unlimited:
+        parsed: int | None = None
+    else:
+        try:
+            parsed = int(raw_stripped)
+        except (TypeError, ValueError):
+            return (
+                jsonify(
+                    {"error": "days must be an integer or 'unlimited'"}
+                ),
+                400,
+            )
+
+    try:
+        from clawmetry import entitlements as _ent
+
+        if tier_in not in _ent._TIER_ORDER:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "tier", "tier": tier_in}
+                ),
+                404,
+            )
+        required = _ent.min_tier_for_retention_window_at(tier_in, parsed)
+        if parsed is None:
+            label = "unlimited"
+        else:
+            label = (
+                f"{parsed} day" if parsed == 1 else f"{parsed} days"
+            )
+        return jsonify(
+            _min_tier_for_capacity_at_body(
+                _ent, tier_in, parsed, "retention_window", label, required
+            )
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_min_tier_for_retention_window_at: error: %s",
+            exc,
+        )
+        return jsonify(
+            _min_tier_for_capacity_at_fallback(
+                tier_in, parsed, "retention_window"
+            )
+        )
+
+
+
 def _capacity_batch_row_to_body(row: dict, endpoint_kind: str) -> dict:
     """Translate a :func:`min_tier_for_channel_count_batch` /
     :func:`min_tier_for_node_count_batch` /
@@ -23699,22 +23948,4 @@ def api_entitlement_runtime_detection():
 
 
 def _runtime_detection_counts(probes: list) -> dict:
-    """Aggregate row for ``/api/entitlement/runtime-detection``. Pure fn."""
-    total = len(probes)
-    detected = sum(1 for r in probes if r.get("found"))
-    detected_free = sum(
-        1 for r in probes if r.get("found") and r.get("free")
-    )
-    detected_locked = sum(
-        1 for r in probes if r.get("found") and not r.get("allowed")
-    )
-    unlocked = sum(1 for r in probes if r.get("allowed"))
-    locked = total - unlocked
-    return {
-        "total": total,
-        "detected": detected,
-        "detected_free": detected_free,
-        "detected_locked": detected_locked,
-        "unlocked": unlocked,
-        "locked": locked,
-    }
+    """Aggregate row for ``/api/entitlement/runtime-detection``. Pure fn.

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -22164,6 +22164,278 @@ def api_entitlement_min_tier_for_retention_window():
         )
 
 
+def _capacity_batch_row_to_body(row: dict, endpoint_kind: str) -> dict:
+    """Translate a :func:`min_tier_for_channel_count_batch` /
+    :func:`min_tier_for_node_count_batch` /
+    :func:`min_tier_for_retention_window_batch` helper row into the
+    endpoint body row shape.
+
+    Rekeys ``min_tier*`` -> ``required_tier*`` so each row is byte-
+    identical to the bare singular endpoint body (minus the resolver
+    envelope). Adds an ``item`` field (int on the two count axes;
+    ``null`` on the unlimited retention row) and a human ``label``
+    matching the singular endpoint's conjugation ("1 channel" /
+    "5 channels" / "unlimited") so a UI can render each row through
+    the existing singular-endpoint components without reshaping.
+
+    ``endpoint_kind`` is one of ``"channel_count"`` / ``"node_count"``
+    / ``"retention_window"`` (the singular endpoint's ``kind``, NOT
+    the helper's ``kind``).
+
+    Never raises: missing keys / bad rows surface as the all-``None``
+    row shape so the batch keeps building.
+    """
+    key = row.get("key")
+    if endpoint_kind == "retention_window" and key == "unlimited":
+        item: int | None = None
+        label = "unlimited"
+    else:
+        try:
+            item = int(key)
+        except (TypeError, ValueError):
+            item = None
+            label = None
+        else:
+            if endpoint_kind == "channel_count":
+                label = f"{item} channel" if item == 1 else f"{item} channels"
+            elif endpoint_kind == "node_count":
+                label = f"{item} node" if item == 1 else f"{item} nodes"
+            else:
+                label = f"{item} day" if item == 1 else f"{item} days"
+    return {
+        "item": item,
+        "kind": endpoint_kind,
+        "label": label,
+        "free": bool(row.get("free")),
+        "required_tier": row.get("min_tier"),
+        "required_tier_label": row.get("min_tier_label"),
+        "required_tier_rank": (
+            row.get("min_tier_rank")
+            if row.get("min_tier_rank") is not None
+            else -1
+        ),
+    }
+
+
+def _min_tier_for_capacity_batch_fallback(kind: str) -> dict:
+    """Grace-shape fallback body for the three per-value
+    ``min-tier-for-<capacity-axis>-batch`` endpoints. Never 5xxs: on a
+    resolver crash the pricing surface keeps rendering with an empty
+    ``rows`` list instead of a stack trace. Envelope mirrors the happy-
+    path body so a caller does not have to branch on the error shape.
+    """
+    return {
+        "kind": kind,
+        "count": 0,
+        "rows": [],
+        "current_tier": "oss",
+        "current_tier_rank": 0,
+        "grace": True,
+        "enforced": False,
+    }
+
+
+def _parse_capacity_batch_csv(name: str, unlimited_ok: bool):
+    """Parse a comma-separated capacity-batch query arg.
+
+    Empty / whitespace tokens are dropped. Duplicates by normalised key
+    are dropped preserving first-seen order so the response payload is
+    stable. When ``unlimited_ok`` is True the case-insensitive string
+    ``"unlimited"`` is emitted verbatim (the helper routes it to the
+    None sentinel); otherwise it collapses to the all-``None`` row
+    shape via passthrough. Non-int tokens on the two count axes pass
+    through unmodified so :func:`_min_tier_for_capacity_batch` yields
+    the documented all-``None`` row for them.
+
+    Returns ``(values, err)`` where ``err`` is ``None`` on success,
+    ``"missing"`` when the arg is absent or blank end-to-end (endpoint
+    should 400). Never raises.
+    """
+    raw = request.args.get(name)
+    if raw is None or not raw.strip():
+        return [], "missing"
+    out: list = []
+    for token in raw.split(","):
+        t = token.strip()
+        if not t:
+            continue
+        if unlimited_ok and t.lower() == "unlimited":
+            out.append("unlimited")
+            continue
+        out.append(t)
+    if not out:
+        return [], "missing"
+    return out, None
+
+
+@bp_entitlement.route(
+    "/api/entitlement/min-tier-for-channel-count-batch"
+)
+def api_entitlement_min_tier_for_channel_count_batch():
+    """``GET /api/entitlement/min-tier-for-channel-count-batch?counts=1,5,10``
+    -- per-value batch sibling of
+    ``/api/entitlement/min-tier-for-channel-count``.
+
+    Where the singular endpoint folds ONE channel count to ONE tier
+    answer, this preserves the per-value grouping so a pricing-matrix
+    walkthrough comparing several hypothetical channel counts
+    ("at 1 / 5 / 10 / 25 channels -- cheapest qualifying tier per row")
+    renders off ONE round-trip instead of N calls to
+    ``/min-tier-for-channel-count`` + client-side row assembly. Wraps
+    :func:`clawmetry.entitlements.min_tier_for_channel_count_batch`.
+
+    Distinct from ``/api/entitlement/min-tier-batch`` (per-axis rows
+    for a FIVE-axis bundle -- one row per axis, single scalar per
+    axis) and ``/api/entitlement/min-tier-for-features-batch`` (per-
+    bundle folded answer across N feature *bundles*). This endpoint
+    preserves per-value rows on a SINGLE capacity axis.
+
+    ``counts=`` is required. Missing / blank -> ``400``. Comma-
+    separated tokens are normalised: whitespace-stripped, deduplicated
+    by parsed int key preserving first-seen order. Non-int tokens
+    collapse to the all-``None`` row shape (matches the singular
+    endpoint's ``None``-on-bad-input posture rather than failing the
+    whole batch). Never 5xxs: the grace-shape envelope is returned on
+    any resolver failure.
+
+    Response shape::
+
+        {
+          "kind":  "channel_count",
+          "count": <int>,
+          "rows":  [<row>, ...],
+          "current_tier":       "...",
+          "current_tier_rank":  <int>,
+          "grace":              <bool>,
+          "enforced":           <bool>,
+        }
+
+    Each ``<row>`` mirrors the bare singular endpoint body minus the
+    resolver envelope: ``item`` / ``kind`` (``"channel_count"``) /
+    ``label`` / ``free`` / ``required_tier`` / ``required_tier_label``
+    / ``required_tier_rank`` (``-1`` when ``required_tier`` is
+    ``null``). Per-row parity with
+    ``/api/entitlement/min-tier-for-channel-count?count=<n>`` is
+    pinned in the test suite so the batch cannot silently drift from
+    the scalar.
+    """
+    values, err = _parse_capacity_batch_csv("counts", unlimited_ok=False)
+    if err == "missing":
+        return jsonify({"error": "missing counts"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        rows = [
+            _capacity_batch_row_to_body(r, "channel_count")
+            for r in _ent.min_tier_for_channel_count_batch(values)
+        ]
+        return jsonify(
+            {
+                "kind": "channel_count",
+                "count": len(rows),
+                "rows": rows,
+                **_resolver_envelope(_ent),
+            }
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_min_tier_for_channel_count_batch: error: %s",
+            exc,
+        )
+        return jsonify(_min_tier_for_capacity_batch_fallback("channel_count"))
+
+
+@bp_entitlement.route(
+    "/api/entitlement/min-tier-for-node-count-batch"
+)
+def api_entitlement_min_tier_for_node_count_batch():
+    """``GET /api/entitlement/min-tier-for-node-count-batch?counts=1,3,5`` --
+    node-axis twin of
+    ``/api/entitlement/min-tier-for-channel-count-batch``.
+
+    Same never-5xx posture, same 400-on-missing-arg parsing, same
+    per-value dedup. Row ``kind`` is ``"node_count"`` and ``label``
+    conjugates as ``"1 node"`` / ``"5 nodes"``.
+    """
+    values, err = _parse_capacity_batch_csv("counts", unlimited_ok=False)
+    if err == "missing":
+        return jsonify({"error": "missing counts"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        rows = [
+            _capacity_batch_row_to_body(r, "node_count")
+            for r in _ent.min_tier_for_node_count_batch(values)
+        ]
+        return jsonify(
+            {
+                "kind": "node_count",
+                "count": len(rows),
+                "rows": rows,
+                **_resolver_envelope(_ent),
+            }
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_min_tier_for_node_count_batch: error: %s",
+            exc,
+        )
+        return jsonify(_min_tier_for_capacity_batch_fallback("node_count"))
+
+
+@bp_entitlement.route(
+    "/api/entitlement/min-tier-for-retention-window-batch"
+)
+def api_entitlement_min_tier_for_retention_window_batch():
+    """``GET /api/entitlement/min-tier-for-retention-window-batch?days=7,30,unlimited``
+    -- retention-axis twin of
+    ``/api/entitlement/min-tier-for-channel-count-batch``.
+
+    Each token may be a finite int (``7`` / ``30`` / ``90``) or the
+    case-insensitive string ``"unlimited"`` (routes to
+    ``min_tier_for_retention_window(None)``). The unlimited row
+    surfaces with ``item=null`` and ``label="unlimited"``; matches the
+    singular endpoint's ``days=unlimited`` posture. This is the *only*
+    per-axis batch on the retention axis that admits the unlimited
+    sentinel -- ``/api/entitlement/min-tier-batch`` treats
+    ``retention_days=`` (no value) as *unset*, not *unlimited*.
+
+    ``days=`` is required. Missing / blank -> ``400``. Non-int / non-
+    ``unlimited`` tokens collapse to the all-``None`` row shape rather
+    than failing the whole batch. Never 5xxs: grace-shape fallback on
+    any resolver failure.
+
+    Row shape mirrors ``/api/entitlement/min-tier-for-retention-window``
+    with ``kind="retention_window"``.
+    """
+    values, err = _parse_capacity_batch_csv("days", unlimited_ok=True)
+    if err == "missing":
+        return jsonify({"error": "missing days"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        rows = [
+            _capacity_batch_row_to_body(r, "retention_window")
+            for r in _ent.min_tier_for_retention_window_batch(values)
+        ]
+        return jsonify(
+            {
+                "kind": "retention_window",
+                "count": len(rows),
+                "rows": rows,
+                **_resolver_envelope(_ent),
+            }
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_min_tier_for_retention_window_batch: error: %s",
+            exc,
+        )
+        return jsonify(
+            _min_tier_for_capacity_batch_fallback("retention_window")
+        )
+
+
 def _min_tier_for_bundle_row_to_body(row: dict, list_key: str) -> dict:
     """Rename the batch helper's ``min_tier*`` keys to the endpoint's
     ``required_tier*`` keys so per-row bodies stay byte-identical to

--- a/tests/test_entitlement_min_tier_for_capacity_batch.py
+++ b/tests/test_entitlement_min_tier_for_capacity_batch.py
@@ -1,0 +1,594 @@
+"""Tests for the per-value capacity-axis batch helpers and endpoints:
+
+* :func:`clawmetry.entitlements.min_tier_for_channel_count_batch`
+* :func:`clawmetry.entitlements.min_tier_for_retention_window_batch`
+* :func:`clawmetry.entitlements.min_tier_for_node_count_batch`
+* ``GET /api/entitlement/min-tier-for-channel-count-batch?counts=…``
+* ``GET /api/entitlement/min-tier-for-retention-window-batch?days=…``
+* ``GET /api/entitlement/min-tier-for-node-count-batch?counts=…``
+
+These helpers close the per-value slot on the three scalar capacity
+``min_tier_for_*`` axes (channel_count / retention_window / node_count),
+alongside the existing per-axis-scalar batch
+:func:`clawmetry.entitlements.min_tier_batch` (which folds ONE scalar
+per axis into a single row) and the per-bundle grant-axis batches
+:func:`clawmetry.entitlements.min_tier_for_features_batch` /
+:func:`clawmetry.entitlements.min_tier_for_runtimes_batch`. Neither of
+those preserves per-value grouping on a SINGLE capacity axis; that is
+the gap this suite pins.
+
+These tests pin:
+
+* Helper: happy path row shape mirrors ``_min_tier_row(n, "<kind>")``
+* Helper: per-row parity with the singular ``min_tier_for_*`` helper
+  across every value in a representative range on every axis
+* Helper: dedup by normalised int key preserving first-seen order
+* Helper: bad-input rows collapse to the all-``None`` shape rather
+  than raising or dropping
+* Helper: ``retention_days`` batch admits ``None`` / case-insensitive
+  ``"unlimited"`` as the unlimited sentinel; every other axis rejects
+* Helper: empty / None / non-iterable input -> ``[]``
+* Helper: grace vs enforce parity (byte-identical rows across modes)
+* API: happy path envelope + per-row body byte-identical to the
+  singular endpoint minus the resolver envelope
+* API: cross-endpoint parity vs ``/min-tier-for-<axis>?<param>=<v>``
+  for every value in the batch
+* API: 400 on missing / blank query arg
+* API: non-int tokens do not fail the batch (per-row all-``None`` row)
+* API: unlimited round-trips to ``item=null`` / ``label="unlimited"``
+  (retention only, case-insensitive)
+* API: resolver envelope carried on happy path
+* API: never-5xxs on a delegate crash
+* API: uniform envelope keys across the three axes so a pricing UI
+  switching axes reads the same shape
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+_ENVELOPE_KEYS = {
+    "kind",
+    "count",
+    "rows",
+    "current_tier",
+    "current_tier_rank",
+    "grace",
+    "enforced",
+}
+
+
+_ROW_KEYS = {
+    "item",
+    "kind",
+    "label",
+    "free",
+    "required_tier",
+    "required_tier_label",
+    "required_tier_rank",
+}
+
+
+# ── Helper: happy path row shape ──────────────────────────────────────────
+
+
+def test_helper_channel_count_row_shape(ent):
+    rows = ent.min_tier_for_channel_count_batch([1, 5, 25])
+    assert len(rows) == 3
+    for row in rows:
+        assert set(row.keys()) == {
+            "key",
+            "kind",
+            "free",
+            "min_tier",
+            "min_tier_label",
+            "min_tier_rank",
+        }
+        assert row["kind"] == "channels"
+
+
+def test_helper_node_count_row_shape(ent):
+    rows = ent.min_tier_for_node_count_batch([1, 4])
+    for row in rows:
+        assert row["kind"] == "nodes"
+
+
+def test_helper_retention_row_shape(ent):
+    rows = ent.min_tier_for_retention_window_batch([7, 30])
+    for row in rows:
+        assert row["kind"] == "retention_days"
+
+
+# ── Helper: per-row parity with the singular helper ────────────────────────
+
+
+@pytest.mark.parametrize("count", [0, 1, 3, 5, 10, 25, 50, 100, 500])
+def test_helper_channel_count_parity(ent, count):
+    (row,) = ent.min_tier_for_channel_count_batch([count])
+    assert row["min_tier"] == ent.min_tier_for_channel_count(count)
+
+
+@pytest.mark.parametrize("count", [0, 1, 2, 3, 5, 10, 25, 100])
+def test_helper_node_count_parity(ent, count):
+    (row,) = ent.min_tier_for_node_count_batch([count])
+    assert row["min_tier"] == ent.min_tier_for_node_count(count)
+
+
+@pytest.mark.parametrize("days", [0, 1, 7, 30, 90, 180, 365])
+def test_helper_retention_parity(ent, days):
+    (row,) = ent.min_tier_for_retention_window_batch([days])
+    assert row["min_tier"] == ent.min_tier_for_retention_window(days)
+
+
+def test_helper_retention_unlimited_none(ent):
+    (row,) = ent.min_tier_for_retention_window_batch([None])
+    assert row["key"] == "unlimited"
+    assert row["min_tier"] == ent.min_tier_for_retention_window(None)
+
+
+@pytest.mark.parametrize(
+    "unlimited_token",
+    ["unlimited", "Unlimited", "UNLIMITED", " unlimited "],
+)
+def test_helper_retention_unlimited_string(ent, unlimited_token):
+    (row,) = ent.min_tier_for_retention_window_batch([unlimited_token])
+    assert row["key"] == "unlimited"
+    assert row["min_tier"] == ent.min_tier_for_retention_window(None)
+
+
+# ── Helper: dedup preserving first-seen order ──────────────────────────────
+
+
+def test_helper_channel_count_dedup(ent):
+    rows = ent.min_tier_for_channel_count_batch([5, 5, 5, 1, 5])
+    assert [r["key"] for r in rows] == ["5", "1"]
+
+
+def test_helper_node_count_dedup(ent):
+    rows = ent.min_tier_for_node_count_batch([4, 1, 4, 4])
+    assert [r["key"] for r in rows] == ["4", "1"]
+
+
+def test_helper_retention_dedup_across_int_and_unlimited(ent):
+    rows = ent.min_tier_for_retention_window_batch(
+        [30, "unlimited", None, 30, "Unlimited", 7]
+    )
+    assert [r["key"] for r in rows] == ["30", "unlimited", "7"]
+
+
+def test_helper_channel_count_dedup_string_int_match(ent):
+    """The batch should treat ``"5"`` and ``5`` as the same key."""
+    rows = ent.min_tier_for_channel_count_batch([5, "5", 1])
+    assert [r["key"] for r in rows] == ["5", "1"]
+
+
+# ── Helper: bad-input rows collapse ──────────────────────────────────────
+
+
+def test_helper_channel_count_bad_input_row(ent):
+    rows = ent.min_tier_for_channel_count_batch(["bogus"])
+    assert len(rows) == 1
+    assert rows[0]["min_tier"] is None
+    assert rows[0]["min_tier_rank"] == -1
+    assert rows[0]["free"] is False
+
+
+def test_helper_retention_bad_input_row(ent):
+    rows = ent.min_tier_for_retention_window_batch(["bogus"])
+    assert len(rows) == 1
+    assert rows[0]["min_tier"] is None
+    assert rows[0]["key"] == "bogus"
+
+
+def test_helper_node_count_bad_input_row(ent):
+    rows = ent.min_tier_for_node_count_batch(["nope"])
+    assert len(rows) == 1
+    assert rows[0]["min_tier"] is None
+
+
+# ── Helper: retention-only unlimited sentinel ─────────────────────────────
+
+
+def test_helper_channel_count_none_is_bad_input(ent):
+    """channels/nodes axes reject None (no unlimited semantic)."""
+    rows = ent.min_tier_for_channel_count_batch([None])
+    assert rows[0]["min_tier"] is None
+
+
+def test_helper_node_count_none_is_bad_input(ent):
+    rows = ent.min_tier_for_node_count_batch([None])
+    assert rows[0]["min_tier"] is None
+
+
+# ── Helper: empty / None / non-iterable input ────────────────────────────
+
+
+def test_helper_channel_count_empty(ent):
+    assert ent.min_tier_for_channel_count_batch([]) == []
+    assert ent.min_tier_for_channel_count_batch(None) == []
+
+
+def test_helper_retention_empty(ent):
+    assert ent.min_tier_for_retention_window_batch([]) == []
+    assert ent.min_tier_for_retention_window_batch(None) == []
+
+
+def test_helper_node_count_empty(ent):
+    assert ent.min_tier_for_node_count_batch([]) == []
+    assert ent.min_tier_for_node_count_batch(None) == []
+
+
+def test_helper_channel_count_non_iterable(ent):
+    assert ent.min_tier_for_channel_count_batch(42) == []
+
+
+def test_helper_retention_non_iterable(ent):
+    assert ent.min_tier_for_retention_window_batch(42) == []
+
+
+def test_helper_node_count_non_iterable(ent):
+    assert ent.min_tier_for_node_count_batch(42) == []
+
+
+# ── Helper: grace vs enforce parity ──────────────────────────────────────
+
+
+def test_helper_channel_count_grace_enforce_parity(monkeypatch, tmp_path):
+    """The helper walks the static per-tier map; grace vs enforce must
+    yield byte-identical rows on the same input."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    importlib.reload(e)
+    e.invalidate()
+    grace_rows = e.min_tier_for_channel_count_batch([1, 5, 25])
+
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    importlib.reload(e)
+    e.invalidate()
+    enforce_rows = e.min_tier_for_channel_count_batch([1, 5, 25])
+
+    assert grace_rows == enforce_rows
+
+
+def test_helper_retention_grace_enforce_parity(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    importlib.reload(e)
+    e.invalidate()
+    grace_rows = e.min_tier_for_retention_window_batch([7, 30, "unlimited"])
+
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    importlib.reload(e)
+    e.invalidate()
+    enforce_rows = e.min_tier_for_retention_window_batch([7, 30, "unlimited"])
+
+    assert grace_rows == enforce_rows
+
+
+# ── API: happy path ──────────────────────────────────────────────────────
+
+
+def test_api_channel_count_happy(client, ent):
+    r = client.get(
+        "/api/entitlement/min-tier-for-channel-count-batch?counts=1,5,25"
+    )
+    assert r.status_code == 200
+    j = r.get_json()
+    assert set(j.keys()) == _ENVELOPE_KEYS
+    assert j["kind"] == "channel_count"
+    assert j["count"] == 3
+    for row in j["rows"]:
+        assert set(row.keys()) == _ROW_KEYS
+        assert row["kind"] == "channel_count"
+    assert [r["item"] for r in j["rows"]] == [1, 5, 25]
+
+
+def test_api_node_count_happy(client, ent):
+    r = client.get(
+        "/api/entitlement/min-tier-for-node-count-batch?counts=1,4"
+    )
+    assert r.status_code == 200
+    j = r.get_json()
+    assert j["kind"] == "node_count"
+    assert [r["item"] for r in j["rows"]] == [1, 4]
+    for row in j["rows"]:
+        assert row["kind"] == "node_count"
+
+
+def test_api_retention_window_happy(client, ent):
+    r = client.get(
+        "/api/entitlement/min-tier-for-retention-window-batch?days=7,30"
+    )
+    assert r.status_code == 200
+    j = r.get_json()
+    assert j["kind"] == "retention_window"
+    assert [r["item"] for r in j["rows"]] == [7, 30]
+
+
+def test_api_retention_unlimited(client, ent):
+    r = client.get(
+        "/api/entitlement/min-tier-for-retention-window-batch?days=7,unlimited"
+    )
+    assert r.status_code == 200
+    j = r.get_json()
+    (finite, unlim) = j["rows"]
+    assert finite["item"] == 7
+    assert unlim["item"] is None
+    assert unlim["label"] == "unlimited"
+
+
+@pytest.mark.parametrize(
+    "unlimited_token", ["unlimited", "Unlimited", "UNLIMITED"]
+)
+def test_api_retention_unlimited_case_insensitive(
+    client, ent, unlimited_token
+):
+    r = client.get(
+        "/api/entitlement/min-tier-for-retention-window-batch"
+        f"?days={unlimited_token}"
+    )
+    j = r.get_json()
+    (row,) = j["rows"]
+    assert row["label"] == "unlimited"
+
+
+# ── API: singular label conjugation ──────────────────────────────────────
+
+
+def test_api_channel_count_singular_label(client):
+    j = client.get(
+        "/api/entitlement/min-tier-for-channel-count-batch?counts=1,2"
+    ).get_json()
+    assert j["rows"][0]["label"] == "1 channel"
+    assert j["rows"][1]["label"] == "2 channels"
+
+
+def test_api_node_count_singular_label(client):
+    j = client.get(
+        "/api/entitlement/min-tier-for-node-count-batch?counts=1,2"
+    ).get_json()
+    assert j["rows"][0]["label"] == "1 node"
+    assert j["rows"][1]["label"] == "2 nodes"
+
+
+def test_api_retention_window_singular_label(client):
+    j = client.get(
+        "/api/entitlement/min-tier-for-retention-window-batch?days=1,2"
+    ).get_json()
+    assert j["rows"][0]["label"] == "1 day"
+    assert j["rows"][1]["label"] == "2 days"
+
+
+# ── API: cross-endpoint parity with the singular ──────────────────────────
+
+
+@pytest.mark.parametrize("count", [1, 5, 10, 25])
+def test_api_channel_count_parity_with_singular(client, ent, count):
+    batch_row = client.get(
+        f"/api/entitlement/min-tier-for-channel-count-batch?counts={count}"
+    ).get_json()["rows"][0]
+    singular = client.get(
+        f"/api/entitlement/min-tier-for-channel-count?count={count}"
+    ).get_json()
+    for k in _ROW_KEYS:
+        assert batch_row[k] == singular[k]
+
+
+@pytest.mark.parametrize("count", [1, 4])
+def test_api_node_count_parity_with_singular(client, ent, count):
+    batch_row = client.get(
+        f"/api/entitlement/min-tier-for-node-count-batch?counts={count}"
+    ).get_json()["rows"][0]
+    singular = client.get(
+        f"/api/entitlement/min-tier-for-node-count?count={count}"
+    ).get_json()
+    for k in _ROW_KEYS:
+        assert batch_row[k] == singular[k]
+
+
+@pytest.mark.parametrize("days", [1, 7, 30, "unlimited"])
+def test_api_retention_parity_with_singular(client, ent, days):
+    batch_row = client.get(
+        f"/api/entitlement/min-tier-for-retention-window-batch?days={days}"
+    ).get_json()["rows"][0]
+    singular = client.get(
+        f"/api/entitlement/min-tier-for-retention-window?days={days}"
+    ).get_json()
+    for k in _ROW_KEYS:
+        assert batch_row[k] == singular[k]
+
+
+# ── API: error paths ────────────────────────────────────────────────────
+
+
+def test_api_channel_count_missing_400(client):
+    r = client.get(
+        "/api/entitlement/min-tier-for-channel-count-batch"
+    )
+    assert r.status_code == 400
+    assert "missing counts" in r.get_json()["error"]
+
+
+def test_api_channel_count_blank_400(client):
+    r = client.get(
+        "/api/entitlement/min-tier-for-channel-count-batch?counts="
+    )
+    assert r.status_code == 400
+
+
+def test_api_channel_count_only_commas_400(client):
+    r = client.get(
+        "/api/entitlement/min-tier-for-channel-count-batch?counts=,,,"
+    )
+    assert r.status_code == 400
+
+
+def test_api_node_count_missing_400(client):
+    assert (
+        client.get(
+            "/api/entitlement/min-tier-for-node-count-batch"
+        ).status_code
+        == 400
+    )
+
+
+def test_api_retention_missing_400(client):
+    assert (
+        client.get(
+            "/api/entitlement/min-tier-for-retention-window-batch"
+        ).status_code
+        == 400
+    )
+
+
+# ── API: non-int tokens don't fail the batch ─────────────────────────────
+
+
+def test_api_channel_count_bad_token_row(client, ent):
+    j = client.get(
+        "/api/entitlement/min-tier-for-channel-count-batch?counts=5,bogus"
+    ).get_json()
+    assert j["count"] == 2
+    (good, bad) = j["rows"]
+    assert good["required_tier"] == ent.min_tier_for_channel_count(5)
+    assert bad["required_tier"] is None
+    assert bad["required_tier_rank"] == -1
+
+
+def test_api_retention_bad_token_row(client, ent):
+    j = client.get(
+        "/api/entitlement/min-tier-for-retention-window-batch?days=7,bogus"
+    ).get_json()
+    assert j["count"] == 2
+    (good, bad) = j["rows"]
+    assert good["required_tier"] == ent.min_tier_for_retention_window(7)
+    assert bad["required_tier"] is None
+
+
+# ── API: dedup preserving first-seen order ───────────────────────────────
+
+
+def test_api_channel_count_dedup(client, ent):
+    j = client.get(
+        "/api/entitlement/min-tier-for-channel-count-batch?counts=5,5,1,5"
+    ).get_json()
+    assert [r["item"] for r in j["rows"]] == [5, 1]
+
+
+def test_api_retention_dedup(client, ent):
+    j = client.get(
+        "/api/entitlement/min-tier-for-retention-window-batch?days=30,unlimited,30,Unlimited,7"
+    ).get_json()
+    assert [r["label"] for r in j["rows"]] == ["30 days", "unlimited", "7 days"]
+
+
+# ── API: resolver envelope carried on happy path ─────────────────────────
+
+
+def test_api_envelope_carries_resolver(client, ent):
+    j = client.get(
+        "/api/entitlement/min-tier-for-channel-count-batch?counts=1"
+    ).get_json()
+    assert j["current_tier"] == ent.get_entitlement().tier
+    assert j["current_tier_rank"] == ent.tier_rank(j["current_tier"])
+    assert isinstance(j["grace"], bool)
+    assert isinstance(j["enforced"], bool)
+
+
+# ── API: uniform envelope keys across the three axes ─────────────────────
+
+
+def test_api_uniform_envelope_across_axes(client):
+    ch = client.get(
+        "/api/entitlement/min-tier-for-channel-count-batch?counts=1"
+    ).get_json()
+    nd = client.get(
+        "/api/entitlement/min-tier-for-node-count-batch?counts=1"
+    ).get_json()
+    rt = client.get(
+        "/api/entitlement/min-tier-for-retention-window-batch?days=1"
+    ).get_json()
+    assert set(ch.keys()) == set(nd.keys()) == set(rt.keys()) == _ENVELOPE_KEYS
+
+
+def test_api_uniform_row_keys_across_axes(client):
+    ch = client.get(
+        "/api/entitlement/min-tier-for-channel-count-batch?counts=1"
+    ).get_json()["rows"][0]
+    nd = client.get(
+        "/api/entitlement/min-tier-for-node-count-batch?counts=1"
+    ).get_json()["rows"][0]
+    rt = client.get(
+        "/api/entitlement/min-tier-for-retention-window-batch?days=1"
+    ).get_json()["rows"][0]
+    assert set(ch.keys()) == set(nd.keys()) == set(rt.keys()) == _ROW_KEYS
+
+
+# ── API: never-5xxs on a delegate crash ─────────────────────────────────
+
+
+def test_api_channel_count_never_5xxs(monkeypatch, client, ent):
+    def boom(*_a, **_k):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(ent, "min_tier_for_channel_count_batch", boom)
+    r = client.get(
+        "/api/entitlement/min-tier-for-channel-count-batch?counts=5"
+    )
+    assert r.status_code == 200
+    j = r.get_json()
+    assert j["kind"] == "channel_count"
+    assert j["rows"] == []
+    assert j["grace"] is True
+
+
+def test_api_retention_never_5xxs(monkeypatch, client, ent):
+    def boom(*_a, **_k):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(ent, "min_tier_for_retention_window_batch", boom)
+    r = client.get(
+        "/api/entitlement/min-tier-for-retention-window-batch?days=30"
+    )
+    assert r.status_code == 200
+    assert r.get_json()["kind"] == "retention_window"
+
+
+def test_api_node_count_never_5xxs(monkeypatch, client, ent):
+    def boom(*_a, **_k):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(ent, "min_tier_for_node_count_batch", boom)
+    r = client.get(
+        "/api/entitlement/min-tier-for-node-count-batch?counts=1"
+    )
+    assert r.status_code == 200
+    assert r.get_json()["kind"] == "node_count"


### PR DESCRIPTION
## Summary

Closes the per-value slot on the three scalar capacity axes
(`channel_count` / `retention_window` / `node_count`) in the
`min_tier_for_*` family.

- The existing per-axis-scalar batch `min_tier_batch(*, channels=N, ...)` folds ONE scalar per axis into a single per-axis row -- it cannot compare several hypothetical values on a single axis in one round-trip.
- The per-bundle grant-axis batches `min_tier_for_features_batch(bundles)` / `min_tier_for_runtimes_batch(bundles)` fold N *bundles* to N tier answers, not N per-value rows on one capacity axis.
- Neither preserves per-value grouping on a single scalar capacity axis; that is the gap this PR fills so a pricing-matrix walkthrough comparing "at 1 / 5 / 10 / 25 channels -- cheapest qualifying tier per row" renders off ONE call instead of N calls to `/min-tier-for-channel-count` + client-side row assembly.
- **GRACE-safe**: no behavior change to any existing endpoint or helper. Purely additive.

**New helpers in `clawmetry/entitlements.py`:**
- `min_tier_for_channel_count_batch(counts)`
- `min_tier_for_retention_window_batch(days_list)`
- `min_tier_for_node_count_batch(counts)`

Row shape mirrors `_min_tier_row(<n>, "<kind>")` byte-for-byte
(`key` / `kind` / `free` / `min_tier` / `min_tier_label` / `min_tier_rank`).
Per-row parity with the singular `min_tier_for_*` helper is pinned in
the test suite so the batch cannot silently drift from the scalar.

Retention batch admits `None` or the case-insensitive string
`"unlimited"` as the unlimited sentinel (routes to
`min_tier_for_retention_window(None)`); the two count axes reject
`None` -- matches every capacity-axis helper's `None`-on-bad-input
posture. Duplicates by normalised int key (or `"unlimited"` for the
retention sentinel) are dropped preserving first-seen order for
byte-stable output. Never raises: per-row failures short-circuit to
the all-`None` row shape.

**New endpoints on `bp_entitlement` (`routes/entitlement.py`):**
- `GET /api/entitlement/min-tier-for-channel-count-batch?counts=<csv>`
- `GET /api/entitlement/min-tier-for-node-count-batch?counts=<csv>`
- `GET /api/entitlement/min-tier-for-retention-window-batch?days=<csv>`

`400` on missing / blank / only-commas arg. Non-int tokens do NOT
fail the whole batch: they surface as an all-`None` row so a UI never
sees a stack trace on a stray typo. Never 5xxs: grace-shape fallback
envelope on any resolver failure. Per-row body byte-identical to the
bare singular endpoint (`item` / `kind` / `label` / `free` /
`required_tier` / `required_tier_label` / `required_tier_rank`) so a
caller can render each row through the existing singular-endpoint
components without reshaping. Envelope carries the same resolver
context (`current_tier` / `grace` / `enforced`) the singular endpoint
carries.

## Test plan

`tests/test_entitlement_min_tier_for_capacity_batch.py` -- 84 cases:

- [x] Helper row shape mirrors `_min_tier_row` across all three axes
- [x] Per-row parity with the singular `min_tier_for_*` helper across a representative range of values on each axis (channel counts, node counts, retention days)
- [x] Retention batch admits `None` + `"unlimited"` (case-insensitive, whitespace-stripped) as the unlimited sentinel; channels/nodes reject `None`
- [x] Dedup by normalised int key preserving first-seen order, including cross-type string/int dedup (`"5"` and `5` collapse to one row)
- [x] Bad-input rows collapse to the all-`None` row shape
- [x] Empty / `None` / non-iterable input -> `[]`
- [x] Grace vs enforce parity: byte-identical rows across modes (pinned by reload roundtrip)
- [x] API happy path: envelope + per-row body shape
- [x] API cross-endpoint parity vs `/min-tier-for-<axis>?<param>=<v>` for every batched value
- [x] API `400` on missing / blank / only-commas arg
- [x] API non-int tokens surface as all-`None` rows without failing the batch
- [x] API unlimited round-trips to `item=null` / `label="unlimited"` (retention only, case-insensitive)
- [x] API resolver envelope carried on happy path
- [x] API uniform envelope + row keys across the three axes so a pricing UI switching axes reads the same shape
- [x] API never-5xxs on a delegate crash (grace-shape fallback)

```
$ python3 -m pytest tests/test_entitlement_min_tier_for_capacity_batch.py
84 passed in 2.27s

$ python3 -m pytest tests/test_entitlement_min_tier_for_capacity_bare.py \
                    tests/test_entitlement_min_tier.py \
                    tests/test_entitlement_min_tier_batch.py \
                    tests/test_entitlement_min_tier_for_plural_bare.py \
                    tests/test_entitlement_min_tier_for_plural_at.py \
                    tests/test_entitlement_api.py
382 passed in 16.11s   # no regressions in adjacent siblings

$ ruff check clawmetry/entitlements.py routes/entitlement.py \
             tests/test_entitlement_min_tier_for_capacity_batch.py
All checks passed!
```

## Local operator verification checklist

The autonomous session can't reach the running daemon, `~/.openclaw`, the live cloud snapshot, or a browser. Verify locally before flipping ready-for-review:

- [ ] Copy the two changed files into `~/.clawmetry/lib/pythonX.Y/site-packages/clawmetry/` (`entitlements.py`) and `~/.clawmetry/lib/pythonX.Y/site-packages/routes/` (`entitlement.py`), then clear `__pycache__/`.
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` (and `com.clawmetry.dashboard` if separately managed) so the daemon picks up the new endpoints.
- [ ] Hit each new endpoint against the live daemon and eyeball the envelope:
  ```
  curl -s 'http://localhost:8900/api/entitlement/min-tier-for-channel-count-batch?counts=1,5,25' | jq .
  curl -s 'http://localhost:8900/api/entitlement/min-tier-for-node-count-batch?counts=1,3,5' | jq .
  curl -s 'http://localhost:8900/api/entitlement/min-tier-for-retention-window-batch?days=7,30,unlimited' | jq .
  ```
  - Confirm one row per input value (post-dedup), rows carry `required_tier` / `required_tier_label` / `required_tier_rank`, and the top-level envelope carries `current_tier` / `grace=true` / `enforced=false` on OSS install.
- [ ] Cross-check parity with the singular endpoint: per-row body should byte-equal `/api/entitlement/min-tier-for-<axis>?<param>=<v>` minus the resolver envelope.
  ```
  diff <(curl -s '.../min-tier-for-channel-count?count=5' | jq 'del(.current_tier, .current_tier_rank, .grace, .enforced)') \
       <(curl -s '.../min-tier-for-channel-count-batch?counts=5' | jq '.rows[0]')
  ```
- [ ] Error paths: `?counts=` -> `400`; `?counts=,,,` -> `400`; `?counts=bogus,5` -> `200` with an all-null row for `bogus` and a real answer for `5`.
- [ ] Decrypt the live cloud snapshot and open the dashboard in a browser; visit the Pricing / Fleet / Retention surfaces and confirm no regression in the existing paywall affordances.
- [ ] Flip the PR out of draft once the four above pass.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M4ngo3mNKAgmLRr1mc21pR

---
_Generated by [Claude Code](https://claude.ai/code/session_01M4ngo3mNKAgmLRr1mc21pR)_