### PR TITLE
feat(paywall): recent event filter kwargs + matched pre-limit count

### DIFF
--- a/clawmetry/_paywall_events.py
+++ b/clawmetry/_paywall_events.py
@@ -105,6 +105,54 @@ def _coerce_str(value: Any, limit: int) -> str:
     return text
 
 
+_FILTER_KEYS = ("event", "feature", "harness", "source", "plan_chosen")
+
+
+def _normalise_filters(**kwargs: Any) -> dict[str, str]:
+    """Collapse the filter kwargs to a ``{key: value}`` dict keeping only
+    non-blank string values.
+
+    A ``None``, empty string, or all-whitespace value means "not supplied"
+    and is dropped so the caller doesn't have to enumerate every
+    dimension. Non-string values are coerced via ``str(...)`` (matching
+    the store's own :func:`_coerce_str` posture) so a caller passing an
+    int is not silently unmatchable. Whitespace is stripped from the ends
+    only -- the stored values are never whitespace-padded, and stripping
+    the interior would break exact-match on legitimately spaced
+    ``source`` labels like ``"runtime switcher"``.
+
+    Never raises.
+    """
+    out: dict[str, str] = {}
+    for key in _FILTER_KEYS:
+        raw = kwargs.get(key)
+        if raw is None:
+            continue
+        try:
+            text = str(raw).strip()
+        except Exception:
+            continue
+        if not text:
+            continue
+        out[key] = text
+    return out
+
+
+def _row_matches_filters(row: dict, filters: dict[str, str]) -> bool:
+    """Return True iff every filter key/value matches the row's stored
+    field exactly. Missing row fields short-circuit to ``False`` (a filter
+    on a dimension the row does not carry is a mismatch, not a wildcard).
+    Never raises.
+    """
+    try:
+        for key, want in filters.items():
+            if row.get(key, "") != want:
+                return False
+        return True
+    except Exception:
+        return False
+
+
 class _PaywallEventStore:
     """Thread-safe bounded ring + running aggregates for paywall beacons.
 
@@ -255,12 +303,38 @@ class _PaywallEventStore:
                 "by_plan_chosen": {},
             }
 
-    def recent(self, limit: int) -> list[dict]:
+    def recent(
+        self,
+        limit: int,
+        *,
+        event: str | None = None,
+        feature: str | None = None,
+        harness: str | None = None,
+        source: str | None = None,
+        plan_chosen: str | None = None,
+    ) -> list[dict]:
         """Return up to ``limit`` most-recent events, newest first.
 
         ``limit`` is clamped into ``[0, _RECENT_MAX]`` so an operator can't
         blow the response size out with ``?limit=999999``. A negative or
         non-int limit falls back to ``_RECENT_DEFAULT``. Never raises.
+
+        Optional keyword filters (``event`` / ``feature`` / ``harness`` /
+        ``source`` / ``plan_chosen``) restrict the returned rows to those
+        whose corresponding field matches the supplied value exactly. A
+        ``None`` or empty-string filter is treated as "not supplied" and
+        does not restrict on that dimension -- there is deliberately no
+        way to query for rows with an empty field via this API, because
+        ``?feature=`` in the query string would then be ambiguous.
+
+        Filter matching is case-sensitive against the stored (post-
+        :func:`_coerce_str`) value, matching the case-sensitive keys of
+        :meth:`summary`'s ``by_*`` breakdowns. Filters are ``AND``-
+        combined so ``event=paywall_cta_click`` + ``feature=fleet`` narrows
+        the ring to CTA clicks on the ``fleet`` feature.
+
+        Never raises: a filter failure short-circuits to ``[]`` instead of
+        propagating.
         """
         try:
             try:
@@ -273,13 +347,63 @@ class _PaywallEventStore:
                 n = _RECENT_MAX
             if n == 0:
                 return []
+            filters = _normalise_filters(
+                event=event, feature=feature, harness=harness,
+                source=source, plan_chosen=plan_chosen,
+            )
             with self._lock:
                 snap = list(self._ring)
             snap.reverse()
+            if filters:
+                return [
+                    dict(e) for e in snap
+                    if _row_matches_filters(e, filters)
+                ][:n]
             return [dict(e) for e in snap[:n]]
         except Exception as exc:
             logger.warning("paywall.events: recent swallowed error: %s", exc)
             return []
+
+    def count_matching(
+        self,
+        *,
+        event: str | None = None,
+        feature: str | None = None,
+        harness: str | None = None,
+        source: str | None = None,
+        plan_chosen: str | None = None,
+    ) -> int:
+        """Return the count of ring rows matching the supplied filters,
+        BEFORE any ``limit`` clamp is applied.
+
+        Same filter semantics as :meth:`recent` (``None`` / empty string
+        means "not supplied", case-sensitive exact match, ``AND`` combined).
+        With no filters, returns the full ring size -- byte-equal to
+        :meth:`summary`'s ``in_window`` on a quiet store, and always the
+        ceiling ``recent(limit, **filters)`` could return at ``limit >=
+        RECENT_MAX_LIMIT``.
+
+        Purpose: a paywall dashboard tile rendering "showing N of M matches"
+        needs the pre-limit total. Splitting this off from :meth:`recent`
+        keeps :meth:`recent`'s return type stable (``list[dict]``) and
+        lets a caller ask "how many matched?" without paying the
+        ``dict(e)`` copy cost on every ring entry.
+
+        Never raises.
+        """
+        try:
+            filters = _normalise_filters(
+                event=event, feature=feature, harness=harness,
+                source=source, plan_chosen=plan_chosen,
+            )
+            with self._lock:
+                snap = list(self._ring)
+            if not filters:
+                return len(snap)
+            return sum(1 for e in snap if _row_matches_filters(e, filters))
+        except Exception as exc:
+            logger.warning("paywall.events: count_matching swallowed: %s", exc)
+            return 0
 
     def reset(self) -> None:
         with self._lock:
@@ -303,11 +427,49 @@ def summary() -> dict:
     return _STORE.summary()
 
 
-def recent(limit: int | None = None) -> list[dict]:
-    """Public shim for ``GET /api/paywall/events/recent``."""
+def recent(
+    limit: int | None = None,
+    *,
+    event: str | None = None,
+    feature: str | None = None,
+    harness: str | None = None,
+    source: str | None = None,
+    plan_chosen: str | None = None,
+) -> list[dict]:
+    """Public shim for ``GET /api/paywall/events/recent``.
+
+    ``limit`` defaults to :data:`RECENT_DEFAULT_LIMIT`. Filter kwargs are
+    optional; a ``None`` or empty-string value means "not supplied" and
+    does not restrict on that dimension. See
+    :meth:`_PaywallEventStore.recent` for the exact filter contract.
+    """
     if limit is None:
         limit = _RECENT_DEFAULT
-    return _STORE.recent(limit)
+    return _STORE.recent(
+        limit,
+        event=event, feature=feature, harness=harness,
+        source=source, plan_chosen=plan_chosen,
+    )
+
+
+def count_matching(
+    *,
+    event: str | None = None,
+    feature: str | None = None,
+    harness: str | None = None,
+    source: str | None = None,
+    plan_chosen: str | None = None,
+) -> int:
+    """Public shim for :meth:`_PaywallEventStore.count_matching`.
+
+    Returns the count of ring rows matching the supplied filters BEFORE
+    any ``limit`` clamp. Used by ``/api/paywall/events/recent`` so it can
+    render "showing N of M matches" alongside the filtered event list.
+    """
+    return _STORE.count_matching(
+        event=event, feature=feature, harness=harness,
+        source=source, plan_chosen=plan_chosen,
+    )
 
 
 def reset() -> None:

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -7209,6 +7209,21 @@ def api_paywall_events_recent():
     passing a bad, negative, or oversized value falls back to the default so
     the response size stays bounded.
 
+    Optional filter query params narrow the returned rows to those whose
+    corresponding field matches the supplied value exactly (case-
+    sensitive, ``AND``-combined across dimensions)::
+
+      ?event=<paywall_view|paywall_cta_click|...>
+      ?feature=<feature-key>
+      ?harness=<harness-key>
+      ?source=<source-key>
+      ?plan_chosen=<plan-code>
+
+    A blank or missing filter is "not supplied" and does not restrict on
+    that dimension -- there is deliberately no way to query for rows with
+    an empty field via this API. Filter mismatches never fail the request:
+    they simply return an empty ``events`` list and ``matched=0``.
+
     Body shape::
 
         {
@@ -7217,10 +7232,16 @@ def api_paywall_events_recent():
              "source": "...", "plan_chosen": "...", "ts": <float>},
             ...
           ],
-          "count": <int>,          # events actually returned
+          "count": <int>,          # events actually returned (post-filter, post-limit)
+          "matched": <int>,        # rows matching the filters, pre-limit (>= count)
           "limit": <int>,          # the resolved (post-clamp) limit
-          "in_window": <int>       # size of the underlying ring right now
+          "in_window": <int>,      # size of the underlying ring right now
+          "filters": {"<key>": "<value>", ...}   # echo of applied filters (blank ones omitted)
         }
+
+    ``matched`` lets a UI render "showing N of M matches" without a second
+    round-trip. On an unfiltered request ``matched`` byte-equals
+    ``in_window``.
 
     Ships in GRACE. Never 5xxs -- on any failure returns an empty envelope.
     """
@@ -7236,19 +7257,43 @@ def api_paywall_events_recent():
             limit_val = _pe.RECENT_DEFAULT_LIMIT
         if limit_val > _pe.RECENT_MAX_LIMIT:
             limit_val = _pe.RECENT_MAX_LIMIT
-        events = _pe.recent(limit_val)
+        filter_kwargs = {
+            key: request.args.get(key, "") or None
+            for key in ("event", "feature", "harness", "source", "plan_chosen")
+        }
+        # `_pe.recent` / `count_matching` treat empty / whitespace strings as
+        # "not supplied" so the query-string echo below is the canonical
+        # applied-filter set.
+        events = _pe.recent(limit_val, **filter_kwargs)
+        matched = _pe.count_matching(**filter_kwargs)
         summary = _pe.summary()
+        applied_filters = {
+            key: value.strip()
+            for key, value in filter_kwargs.items()
+            if isinstance(value, str) and value.strip()
+        }
         return jsonify(
             {
                 "events": events,
                 "count": len(events),
+                "matched": matched,
                 "limit": limit_val,
                 "in_window": summary.get("in_window", 0),
+                "filters": applied_filters,
             }
         )
     except Exception as exc:
         logger.warning("api_paywall_events_recent: error: %s", exc)
-        return jsonify({"events": [], "count": 0, "limit": 0, "in_window": 0})
+        return jsonify(
+            {
+                "events": [],
+                "count": 0,
+                "matched": 0,
+                "limit": 0,
+                "in_window": 0,
+                "filters": {},
+            }
+        )
 
 
 def _route_actor() -> str:

--- a/tests/test_paywall_events_api.py
+++ b/tests/test_paywall_events_api.py
@@ -231,14 +231,21 @@ def test_recent_event_rows_carry_all_fields(client):
 def test_recent_never_5xxs_on_store_failure(client, monkeypatch):
     from clawmetry import _paywall_events as pe
 
-    def _boom(_):
+    def _boom(*_a, **_kw):
         raise RuntimeError("simulated store failure")
 
     monkeypatch.setattr(pe, "recent", _boom)
     resp = client.get("/api/paywall/events/recent")
     assert resp.status_code == 200
     body = resp.get_json()
-    assert body == {"events": [], "count": 0, "limit": 0, "in_window": 0}
+    assert body == {
+        "events": [],
+        "count": 0,
+        "matched": 0,
+        "limit": 0,
+        "in_window": 0,
+        "filters": {},
+    }
 
 
 def test_recent_does_not_consult_entitlement(client, monkeypatch):

--- a/tests/test_paywall_events_recent_filters.py
+++ b/tests/test_paywall_events_recent_filters.py
@@ -1,0 +1,568 @@
+"""Unit + API tests for the ``event`` / ``feature`` / ``harness`` /
+``source`` / ``plan_chosen`` query-param filters on
+``GET /api/paywall/events/recent`` (and the mirror kwargs on
+:func:`clawmetry._paywall_events.recent`).
+
+Store-level invariants for the underlying ring / summary / raw ``recent``
+live in ``test_paywall_events_store.py``; envelope invariants for the
+unfiltered endpoint live in ``test_paywall_events_api.py``. This file
+pins the filter contract:
+
+* A blank / missing filter is "not supplied" and does not restrict on
+  that dimension.
+* Case-sensitive exact match on the stored (post-``_coerce_str``) value.
+* Filters ``AND``-combine across dimensions.
+* Filter mismatches never fail the request -- they return an empty
+  ``events`` list and ``matched=0``.
+* On the API envelope: ``matched`` is the pre-limit total; ``count`` is
+  the post-limit returned length; ``filters`` echoes the applied
+  filters (blank ones omitted).
+* Never 5xxs on a store failure, whether or not filters are supplied.
+"""
+from __future__ import annotations
+
+import json
+import threading
+
+import pytest
+from flask import Flask
+
+
+# ── store-level filter contract ────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _fresh_store():
+    from clawmetry import _paywall_events as pe
+
+    pe.reset()
+    yield
+    pe.reset()
+
+
+def _seed(events):
+    from clawmetry import _paywall_events as pe
+
+    for e in events:
+        pe.record_event(e)
+
+
+def test_recent_no_filter_matches_previous_behaviour():
+    from clawmetry import _paywall_events as pe
+
+    _seed([{"event": "paywall_view", "feature": "fleet"} for _ in range(3)])
+    # Unfiltered call must be byte-equal to the legacy signature.
+    got = pe.recent(10)
+    assert len(got) == 3
+    assert all(e["event"] == "paywall_view" for e in got)
+
+
+def test_recent_filter_event_matches_exactly():
+    from clawmetry import _paywall_events as pe
+
+    _seed(
+        [
+            {"event": "paywall_view", "feature": "fleet"},
+            {"event": "paywall_cta_click", "feature": "fleet", "plan_chosen": "pro"},
+            {"event": "paywall_view", "feature": "self_evolve"},
+        ]
+    )
+    got = pe.recent(10, event="paywall_cta_click")
+    assert len(got) == 1
+    assert got[0]["event"] == "paywall_cta_click"
+    assert got[0]["plan_chosen"] == "pro"
+
+
+def test_recent_filter_feature_matches_exactly():
+    from clawmetry import _paywall_events as pe
+
+    _seed(
+        [
+            {"event": "paywall_view", "feature": "fleet"},
+            {"event": "paywall_view", "feature": "self_evolve"},
+            {"event": "paywall_view", "feature": "fleet"},
+        ]
+    )
+    got = pe.recent(10, feature="fleet")
+    assert len(got) == 2
+    assert {row["feature"] for row in got} == {"fleet"}
+
+
+def test_recent_filter_harness_and_source_and_plan():
+    from clawmetry import _paywall_events as pe
+
+    _seed(
+        [
+            {
+                "event": "paywall_cta_click",
+                "feature": "fleet",
+                "harness": "claude_code",
+                "source": "runtime-switcher",
+                "plan_chosen": "pro",
+            },
+            {
+                "event": "paywall_cta_click",
+                "feature": "fleet",
+                "harness": "codex",
+                "source": "runtime-switcher",
+                "plan_chosen": "starter",
+            },
+        ]
+    )
+    got = pe.recent(10, harness="claude_code")
+    assert len(got) == 1
+    assert got[0]["harness"] == "claude_code"
+
+    got = pe.recent(10, source="runtime-switcher")
+    assert len(got) == 2
+
+    got = pe.recent(10, plan_chosen="pro")
+    assert len(got) == 1
+    assert got[0]["plan_chosen"] == "pro"
+
+
+def test_recent_filters_are_and_combined():
+    from clawmetry import _paywall_events as pe
+
+    _seed(
+        [
+            {"event": "paywall_view", "feature": "fleet"},
+            {"event": "paywall_cta_click", "feature": "fleet", "plan_chosen": "pro"},
+            {"event": "paywall_cta_click", "feature": "self_evolve", "plan_chosen": "pro"},
+        ]
+    )
+    got = pe.recent(10, event="paywall_cta_click", feature="fleet")
+    assert len(got) == 1
+    assert got[0]["feature"] == "fleet"
+    assert got[0]["event"] == "paywall_cta_click"
+
+
+def test_recent_filter_case_sensitive():
+    """The store keeps values verbatim (only truncates); a filter mismatch
+    on case must return no rows so the operator sees "no matches" rather
+    than a silently loose match."""
+    from clawmetry import _paywall_events as pe
+
+    _seed([{"event": "paywall_view", "feature": "Fleet"}])
+    assert pe.recent(10, feature="fleet") == []
+    assert len(pe.recent(10, feature="Fleet")) == 1
+
+
+def test_recent_filter_no_matches_returns_empty_list():
+    from clawmetry import _paywall_events as pe
+
+    _seed([{"event": "paywall_view", "feature": "fleet"}])
+    assert pe.recent(10, feature="does_not_exist") == []
+
+
+def test_recent_filter_blank_or_none_is_not_supplied():
+    from clawmetry import _paywall_events as pe
+
+    _seed(
+        [
+            {"event": "paywall_view", "feature": "fleet"},
+            {"event": "paywall_cta_click", "feature": "self_evolve"},
+        ]
+    )
+    # Both should behave the same as the unfiltered call.
+    assert len(pe.recent(10)) == 2
+    assert len(pe.recent(10, feature=None)) == 2
+    assert len(pe.recent(10, feature="")) == 2
+    assert len(pe.recent(10, feature="   ")) == 2
+
+
+def test_recent_filter_missing_row_field_never_matches():
+    """A filter on ``plan_chosen`` should only match rows that actually
+    carry a matching plan; a paywall_view without a plan must not
+    silently match a ``plan_chosen=`` filter."""
+    from clawmetry import _paywall_events as pe
+
+    _seed(
+        [
+            {"event": "paywall_view", "feature": "fleet"},
+            {"event": "paywall_cta_click", "feature": "fleet", "plan_chosen": "pro"},
+        ]
+    )
+    got = pe.recent(10, plan_chosen="pro")
+    assert len(got) == 1
+    assert got[0]["plan_chosen"] == "pro"
+
+
+def test_recent_filter_respects_limit_after_filter():
+    """The limit clamps the FILTERED list, not the raw ring."""
+    from clawmetry import _paywall_events as pe
+
+    for i in range(6):
+        pe.record_event({"event": "paywall_view", "feature": "fleet"})
+    for _ in range(2):
+        pe.record_event({"event": "paywall_cta_click", "feature": "fleet"})
+    # 8 total; filter to views -> 6; limit=3 -> 3 rows (newest views).
+    got = pe.recent(3, event="paywall_view")
+    assert len(got) == 3
+    assert all(e["event"] == "paywall_view" for e in got)
+
+
+def test_recent_filter_preserves_newest_first_ordering():
+    from clawmetry import _paywall_events as pe
+
+    for i in range(4):
+        pe.record_event({"event": "paywall_view", "feature": f"f{i}"})
+        pe.record_event({"event": "paywall_cta_click", "feature": f"f{i}"})
+    got = pe.recent(10, event="paywall_view")
+    assert [row["feature"] for row in got] == ["f3", "f2", "f1", "f0"]
+
+
+def test_recent_filter_returns_copies_not_ring_refs():
+    from clawmetry import _paywall_events as pe
+
+    pe.record_event({"event": "paywall_view", "feature": "fleet"})
+    got = pe.recent(10, feature="fleet")
+    got[0]["feature"] = "TAMPERED"
+    again = pe.recent(10, feature="fleet")
+    assert again[0]["feature"] == "fleet"
+
+
+def test_recent_filter_zero_limit_returns_empty():
+    from clawmetry import _paywall_events as pe
+
+    pe.record_event({"event": "paywall_view", "feature": "fleet"})
+    assert pe.recent(0, feature="fleet") == []
+
+
+def test_recent_filter_bad_limit_falls_back_to_default_then_still_filters():
+    from clawmetry import _paywall_events as pe
+
+    for _ in range(3):
+        pe.record_event({"event": "paywall_view", "feature": "fleet"})
+    for _ in range(2):
+        pe.record_event({"event": "paywall_cta_click", "feature": "fleet"})
+    # A garbage limit still resolves to the default (>= 5) so all 3 views land.
+    got = pe.recent("garbage", event="paywall_view")
+    assert len(got) == 3
+
+
+# ── count_matching ──────────────────────────────────────────────────────────
+
+
+def test_count_matching_unfiltered_equals_ring_size():
+    from clawmetry import _paywall_events as pe
+
+    for _ in range(5):
+        pe.record_event({"event": "paywall_view", "feature": "fleet"})
+    assert pe.count_matching() == 5
+
+
+def test_count_matching_narrows_by_dimension():
+    from clawmetry import _paywall_events as pe
+
+    _seed(
+        [
+            {"event": "paywall_view", "feature": "fleet"},
+            {"event": "paywall_cta_click", "feature": "fleet", "plan_chosen": "pro"},
+            {"event": "paywall_view", "feature": "self_evolve"},
+        ]
+    )
+    assert pe.count_matching(event="paywall_view") == 2
+    assert pe.count_matching(feature="fleet") == 2
+    assert pe.count_matching(feature="fleet", event="paywall_cta_click") == 1
+    assert pe.count_matching(plan_chosen="pro") == 1
+    assert pe.count_matching(feature="nope") == 0
+
+
+def test_count_matching_and_recent_agree_pre_limit():
+    """The number of matches ``count_matching`` reports must equal the
+    number of rows :func:`recent` returns at a limit large enough to
+    admit all matches."""
+    from clawmetry import _paywall_events as pe
+
+    for _ in range(6):
+        pe.record_event({"event": "paywall_view", "feature": "fleet"})
+    for _ in range(2):
+        pe.record_event({"event": "paywall_cta_click", "feature": "fleet"})
+    matched = pe.count_matching(event="paywall_view")
+    got = pe.recent(pe.RECENT_MAX_LIMIT, event="paywall_view")
+    assert matched == len(got) == 6
+
+
+def test_count_matching_never_raises():
+    """The store must swallow filter-time errors and return 0 rather than
+    propagate them into the API layer."""
+    from clawmetry import _paywall_events as pe
+
+    # An unhashable / weird filter value should just miss, not raise.
+    pe.record_event({"event": "paywall_view"})
+    assert pe.count_matching(event=object()) == 0
+
+
+# ── API endpoint filter contract ───────────────────────────────────────────
+
+
+@pytest.fixture
+def client():
+    from routes.entitlement import bp_entitlement
+    from clawmetry import _paywall_events as pe
+
+    pe.reset()
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    app.config["TESTING"] = True
+    try:
+        yield app.test_client()
+    finally:
+        pe.reset()
+
+
+def _post_beacon(client, payload):
+    return client.post(
+        "/api/paywall/event",
+        data=json.dumps(payload),
+        content_type="application/json",
+    )
+
+
+def test_api_recent_unfiltered_still_carries_new_envelope_keys(client):
+    _post_beacon(client, {"event": "paywall_view", "feature": "fleet"})
+    body = client.get("/api/paywall/events/recent").get_json()
+    # Legacy keys still present.
+    assert body["count"] == 1
+    assert body["in_window"] == 1
+    assert body["limit"] == 50
+    # New keys.
+    assert body["matched"] == 1
+    assert body["filters"] == {}
+
+
+def test_api_recent_envelope_shape_is_stable(client):
+    """Pin the full envelope key set so a paywall dashboard tile that binds
+    to these keys cannot silently blank when the endpoint drops one."""
+    body = client.get("/api/paywall/events/recent").get_json()
+    assert set(body.keys()) == {
+        "events", "count", "matched", "limit", "in_window", "filters",
+    }
+
+
+def test_api_recent_filter_narrows_events(client):
+    _post_beacon(client, {"event": "paywall_view", "feature": "fleet"})
+    _post_beacon(
+        client,
+        {"event": "paywall_cta_click", "feature": "fleet", "plan_chosen": "pro"},
+    )
+    _post_beacon(client, {"event": "paywall_view", "feature": "self_evolve"})
+
+    body = client.get("/api/paywall/events/recent?event=paywall_cta_click").get_json()
+    assert body["count"] == 1
+    assert body["matched"] == 1
+    assert body["events"][0]["event"] == "paywall_cta_click"
+    assert body["filters"] == {"event": "paywall_cta_click"}
+
+
+def test_api_recent_filter_and_combined(client):
+    _post_beacon(client, {"event": "paywall_view", "feature": "fleet"})
+    _post_beacon(client, {"event": "paywall_cta_click", "feature": "fleet"})
+    _post_beacon(client, {"event": "paywall_cta_click", "feature": "self_evolve"})
+
+    body = client.get(
+        "/api/paywall/events/recent?event=paywall_cta_click&feature=fleet"
+    ).get_json()
+    assert body["count"] == 1
+    assert body["matched"] == 1
+    assert body["filters"] == {"event": "paywall_cta_click", "feature": "fleet"}
+
+
+def test_api_recent_matched_reports_pre_limit_total(client):
+    for _ in range(6):
+        _post_beacon(client, {"event": "paywall_view", "feature": "fleet"})
+    body = client.get(
+        "/api/paywall/events/recent?event=paywall_view&limit=2"
+    ).get_json()
+    assert body["count"] == 2                # post-limit
+    assert body["matched"] == 6              # pre-limit total
+    assert body["limit"] == 2
+    assert body["in_window"] == 6
+
+
+def test_api_recent_matched_equals_in_window_when_unfiltered(client):
+    for _ in range(4):
+        _post_beacon(client, {"event": "paywall_view"})
+    body = client.get("/api/paywall/events/recent").get_json()
+    assert body["matched"] == body["in_window"] == 4
+
+
+def test_api_recent_no_match_returns_empty_events_and_matched_zero(client):
+    _post_beacon(client, {"event": "paywall_view", "feature": "fleet"})
+    body = client.get(
+        "/api/paywall/events/recent?feature=does_not_exist"
+    ).get_json()
+    assert body["events"] == []
+    assert body["count"] == 0
+    assert body["matched"] == 0
+    assert body["in_window"] == 1
+    assert body["filters"] == {"feature": "does_not_exist"}
+
+
+def test_api_recent_blank_filter_is_not_supplied(client):
+    _post_beacon(client, {"event": "paywall_view", "feature": "fleet"})
+    _post_beacon(client, {"event": "paywall_cta_click", "feature": "self_evolve"})
+    body = client.get(
+        "/api/paywall/events/recent?feature=&harness="
+    ).get_json()
+    assert body["count"] == 2
+    assert body["matched"] == 2
+    assert body["filters"] == {}
+
+
+def test_api_recent_filter_case_sensitive(client):
+    _post_beacon(client, {"event": "paywall_view", "feature": "Fleet"})
+    lower = client.get("/api/paywall/events/recent?feature=fleet").get_json()
+    assert lower["count"] == 0
+    assert lower["matched"] == 0
+    upper = client.get("/api/paywall/events/recent?feature=Fleet").get_json()
+    assert upper["count"] == 1
+    assert upper["matched"] == 1
+
+
+def test_api_recent_filter_survives_limit_clamp(client):
+    """A ``?limit=`` bogus + ``?event=`` filter combination must still
+    apply the filter after the limit falls back to default."""
+    for _ in range(3):
+        _post_beacon(client, {"event": "paywall_view"})
+    for _ in range(2):
+        _post_beacon(client, {"event": "paywall_cta_click"})
+    body = client.get(
+        "/api/paywall/events/recent?event=paywall_view&limit=nope"
+    ).get_json()
+    assert body["count"] == 3
+    assert body["matched"] == 3
+    assert body["limit"] == 50
+
+
+def test_api_recent_filter_all_five_dimensions_echoes_them(client):
+    _post_beacon(
+        client,
+        {
+            "event": "paywall_cta_click",
+            "feature": "fleet",
+            "harness": "claude_code",
+            "source": "runtime-switcher",
+            "plan_chosen": "pro",
+        },
+    )
+    body = client.get(
+        "/api/paywall/events/recent"
+        "?event=paywall_cta_click"
+        "&feature=fleet"
+        "&harness=claude_code"
+        "&source=runtime-switcher"
+        "&plan_chosen=pro"
+    ).get_json()
+    assert body["count"] == 1
+    assert body["matched"] == 1
+    assert body["filters"] == {
+        "event": "paywall_cta_click",
+        "feature": "fleet",
+        "harness": "claude_code",
+        "source": "runtime-switcher",
+        "plan_chosen": "pro",
+    }
+
+
+def test_api_recent_filter_does_not_change_in_window(client):
+    """A filtered request must NOT collapse ``in_window`` -- that field
+    reports the ring's total, filter-independent."""
+    for _ in range(3):
+        _post_beacon(client, {"event": "paywall_view", "feature": "fleet"})
+    for _ in range(2):
+        _post_beacon(client, {"event": "paywall_cta_click", "feature": "self_evolve"})
+    filtered = client.get(
+        "/api/paywall/events/recent?event=paywall_view"
+    ).get_json()
+    assert filtered["in_window"] == 5
+    assert filtered["matched"] == 3
+    assert filtered["count"] == 3
+
+
+def test_api_recent_filter_never_5xxs_on_store_failure(client, monkeypatch):
+    """The neutral empty envelope (including the new ``matched`` /
+    ``filters`` keys) must render even when the store raises under a
+    filtered call."""
+    from clawmetry import _paywall_events as pe
+
+    def _boom(*_a, **_kw):
+        raise RuntimeError("simulated store failure")
+
+    monkeypatch.setattr(pe, "recent", _boom)
+    resp = client.get("/api/paywall/events/recent?event=paywall_view")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body == {
+        "events": [],
+        "count": 0,
+        "matched": 0,
+        "limit": 0,
+        "in_window": 0,
+        "filters": {},
+    }
+
+
+def test_api_recent_filter_never_5xxs_when_count_matching_raises(client, monkeypatch):
+    from clawmetry import _paywall_events as pe
+
+    def _boom(**_kw):
+        raise RuntimeError("simulated count_matching failure")
+
+    monkeypatch.setattr(pe, "count_matching", _boom)
+    resp = client.get("/api/paywall/events/recent?event=paywall_view")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    # Falls through to the neutral empty envelope.
+    assert body["events"] == []
+    assert body["matched"] == 0
+    assert body["filters"] == {}
+
+
+def test_api_recent_filter_does_not_consult_entitlement(client, monkeypatch):
+    import clawmetry.entitlements as ent
+
+    monkeypatch.setattr(
+        ent, "get_entitlement",
+        lambda *a, **kw: (_ for _ in ()).throw(RuntimeError("nope")),
+    )
+    resp = client.get("/api/paywall/events/recent?event=paywall_view")
+    assert resp.status_code == 200
+
+
+def test_api_recent_ignores_unknown_query_params(client):
+    """A caller passing an unrelated ``?foo=bar`` must not affect the
+    response -- only the five documented filter dimensions matter."""
+    _post_beacon(client, {"event": "paywall_view", "feature": "fleet"})
+    body = client.get(
+        "/api/paywall/events/recent?foo=bar&nonsense=value"
+    ).get_json()
+    assert body["count"] == 1
+    assert body["matched"] == 1
+    assert body["filters"] == {}
+
+
+# ── thread-safety smoke: filter reads race with writes ────────────────────
+
+
+def test_concurrent_filtered_reads_do_not_raise(client):
+    """A filtered ``recent`` call must be safe against concurrent
+    ``record_event`` writes -- the ring lock covers the snapshot."""
+    from clawmetry import _paywall_events as pe
+
+    stop = threading.Event()
+
+    def _writer():
+        while not stop.is_set():
+            pe.record_event({"event": "paywall_view", "feature": "fleet"})
+
+    thread = threading.Thread(target=_writer, daemon=True)
+    thread.start()
+    try:
+        for _ in range(200):
+            got = pe.recent(50, feature="fleet")
+            assert all(row["feature"] == "fleet" for row in got)
+    finally:
+        stop.set()
+        thread.join(timeout=2.0)


### PR DESCRIPTION
## Summary

- `GET /api/paywall/events/recent` now accepts optional filter query params (`event` / `feature` / `harness` / `source` / `plan_chosen`) that narrow the returned rows exactly. Filters `AND`-combine across dimensions; blank / missing filter = "not supplied"; case-sensitive exact match against the stored (post-`_coerce_str`) value.
- Response envelope adds `matched` (rows matching filters, pre-limit; ≥ `count`) and `filters` (echo of applied filters, blank ones omitted). `matched` lets a paywall dashboard tile render "showing N of M matches" without a second round-trip; on an unfiltered request `matched` byte-equals `in_window`.
- Store extension mirrors the endpoint: `_PaywallEventStore.recent` grows the same filter kwargs (existing positional `recent(N)` calls still work), and a new `count_matching(**filters)` helper returns the pre-limit total without paying the `dict(e)` copy cost. Module-level shims `recent(...)` and `count_matching(...)` expose both.
- Ships in **GRACE** — no entitlement gate, no capacity accounting. Never 5xxs: on any store failure the endpoint falls back to the neutral empty envelope (now including the two new keys).

Motivation: the recently-added `/api/paywall/events/{summary,recent}` endpoints let an operator see beacon activity in aggregate, but recent-list callers who want "just the CTA clicks for feature=X" have to pull the whole ring and filter client-side. This closes that gap with a small, additive extension.

## Files changed

- `clawmetry/_paywall_events.py` — `recent()` grows filter kwargs, new `count_matching()` helper, `_normalise_filters` + `_row_matches_filters` internals, module shims.
- `routes/entitlement.py` — `api_paywall_events_recent` parses the five filter query params, calls `_pe.recent` + `_pe.count_matching`, adds `matched` and `filters` to the envelope, updates docstring.
- `tests/test_paywall_events_recent_filters.py` — 35 new cases (store + API).
- `tests/test_paywall_events_api.py` — updated the exact-envelope equality in `test_recent_never_5xxs_on_store_failure` to include the two new keys.

## Test plan

`tests/test_paywall_events_recent_filters.py` — 35 cases:

**Store level**
- [x] Unfiltered `recent(N)` byte-equal to legacy behavior
- [x] Filter by each dimension (`event` / `feature` / `harness` / `source` / `plan_chosen`) narrows correctly
- [x] Filters `AND`-combine
- [x] Case-sensitive exact match (no silent lowercase collapse)
- [x] Blank / `None` / whitespace filter is "not supplied"
- [x] Missing row field never matches a supplied filter
- [x] Limit applied AFTER the filter (not against the raw ring)
- [x] Newest-first ordering preserved under filter
- [x] `recent` returns copies, not ring refs, under filter
- [x] Zero limit + filter returns `[]`
- [x] Garbage limit falls back to default + filter still applies
- [x] `count_matching` unfiltered equals ring size
- [x] `count_matching` narrows by each dimension and combined
- [x] `count_matching` agrees with `recent` at a `RECENT_MAX_LIMIT` limit
- [x] `count_matching` never raises on a weird filter value

**API level**
- [x] Unfiltered envelope carries the two new keys (`matched`, `filters`)
- [x] Envelope key set pinned (drift would silently blank tiles)
- [x] Filter narrows the returned events
- [x] Filters `AND`-combined via query string
- [x] `matched` reports pre-limit total (`?limit=2` over 6 matches → count=2, matched=6)
- [x] `matched == in_window` on unfiltered request
- [x] No-match filter returns empty events + `matched=0` (not a 404)
- [x] Blank query-string filter is "not supplied" (`?feature=` no-op)
- [x] Case sensitivity preserved through the query string
- [x] Filter survives a bad `?limit=` value
- [x] All five filter dimensions echoed in `filters`
- [x] `in_window` is filter-independent
- [x] Never 5xxs when `_pe.recent` raises
- [x] Never 5xxs when `_pe.count_matching` raises
- [x] Does not consult entitlement (grace-mode read of a grace-mode write)
- [x] Ignores unknown query params (`?foo=bar` no-op)

**Thread-safety smoke**
- [x] Concurrent filtered `recent(50, feature=...)` reads race-safe against `record_event` writes

```
$ python -m pytest tests/test_paywall_events_recent_filters.py \
                   tests/test_paywall_events_api.py \
                   tests/test_paywall_events_store.py \
                   tests/test_paywall_event_api.py -q
97 passed in 4.39s

$ python -m pytest tests/test_entitlement_api.py tests/test_entitlements.py \
                   tests/test_paywall_body.py tests/test_paywall_body_runtime.py -q
143 passed in 3.47s   # no regressions in adjacent siblings

$ python -m py_compile clawmetry/_paywall_events.py routes/entitlement.py \
                       tests/test_paywall_events_recent_filters.py \
                       tests/test_paywall_events_api.py
OK
```

## Local operator verification checklist

The autonomous session can't reach the running daemon, `~/.openclaw`, the live cloud snapshot, or a browser. Verify locally before flipping ready-for-review:

- [ ] Copy the changed files into `~/.clawmetry/lib/pythonX.Y/site-packages/`:
  - `clawmetry/_paywall_events.py`
  - `routes/entitlement.py`
  Then clear `__pycache__/` under both.
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` (and `com.clawmetry.dashboard` if separately managed) so the daemon picks up the new route body.
- [ ] Fire a few beacons and hit the filtered endpoint:
  ```
  for i in 1 2 3; do
    curl -s -X POST http://localhost:8900/api/paywall/event \
      -H 'Content-Type: application/json' \
      -d '{"event":"paywall_view","feature":"fleet","harness":"claude_code"}'
  done
  curl -s -X POST http://localhost:8900/api/paywall/event \
    -H 'Content-Type: application/json' \
    -d '{"event":"paywall_cta_click","feature":"fleet","plan_chosen":"pro"}'

  curl -s 'http://localhost:8900/api/paywall/events/recent?event=paywall_cta_click' | jq .
  curl -s 'http://localhost:8900/api/paywall/events/recent?event=paywall_view&limit=2' | jq .
  ```
  - Confirm the filtered call returns only matching rows.
  - Confirm `matched` reflects the pre-limit total (`matched >= count`) and `filters` echoes the applied filters (blank ones omitted).
  - Confirm `in_window` is unchanged across filtered/unfiltered calls (filter-independent).
- [ ] Unknown-param smoke: `curl -s 'http://localhost:8900/api/paywall/events/recent?foo=bar'` should behave identically to the unfiltered call.
- [ ] Blank filter smoke: `curl -s 'http://localhost:8900/api/paywall/events/recent?feature=&harness='` should behave identically to the unfiltered call and echo `filters: {}`.
- [ ] Decrypt the live cloud snapshot and open the dashboard in a browser; confirm no regression in any surface that reads `/api/paywall/events/recent` (currently: none in-tree, but any future paywall dashboard tile keys off this envelope).
- [ ] Flip the PR out of draft once the above pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AJQKPEewVy9EvYfWbFi1v8)_