### PR TITLE
feat(entitlement): per-value tiers_for_{channel_count,retention_window,node_count}_batch helpers + /api/entitlement/tiers-for-*-batch endpoints

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -17977,3 +17977,235 @@ def tiers_for_capacity_batch_at(
             "retention_days": None,
             "nodes": None,
         }
+
+
+def tiers_for_channel_count_batch(counts) -> list[dict]:
+    """Per-value availability-ladder for N channel-count values in ONE
+    round-trip.
+
+    Per-value axis batch sibling of :func:`tiers_for_channel_count`. The
+    ``tiers_for_*`` twin of :func:`min_tier_for_channel_count_batch`: where
+    ``min_tier_for_channel_count_batch`` yields one cheapest-tier answer
+    per value, this yields the full "Fits in: <tier>, ..." availability
+    ladder per value so a pricing-matrix walkthrough comparing several
+    hypothetical channel counts renders every column in one round-trip
+    instead of N calls to :func:`tiers_for_channel_count` + client-side
+    row assembly.
+
+    Row shape is byte-identical to :func:`tiers_for_channel_count`::
+
+        {
+          "item":            <int>,
+          "kind":            "channel_count",
+          "label":           "5 channels",
+          "free":            <bool>,
+          "min_tier":        "<tier id>" | None,
+          "min_tier_label":  "<label>" | None,
+          "min_tier_rank":   <int> | None,
+          "tiers":           [<row>, ...],
+        }
+
+    Per-row parity with :func:`tiers_for_channel_count` is pinned in the
+    test suite so the batch cannot silently drift from the scalar.
+
+    Argument handling mirrors :func:`min_tier_for_channel_count_batch`:
+
+    * ``counts is None`` or non-iterable -- returns ``[]``.
+    * Non-int items collapse to a row where every field is ``None``
+      (matches :func:`tiers_for_channel_count`'s ``None``-on-bad-input
+      posture rather than raising). The raw stringified token surfaces
+      in ``item`` so a caller can still identify the offending entry.
+    * Duplicates by normalised int key are dropped preserving first-seen
+      order so the response is stable and byte-deterministic across
+      calls.
+
+    Decoupled from the resolved entitlement: delegates per row to
+    :func:`tiers_for_channel_count`, which walks the static
+    ``_TIER_CHANNEL_LIMIT`` map. Grace vs enforce yields byte-identical
+    rows -- pinned in the test suite via a grace/enforce reload
+    roundtrip. Never raises: per-row failures short-circuit to the
+    all-``None`` shape so the batch keeps building.
+    """
+    return _tiers_for_capacity_batch(counts, "channel_count")
+
+
+def tiers_for_retention_window_batch(days_list) -> list[dict]:
+    """Per-value availability-ladder for N retention-window values in ONE
+    round-trip. Retention-axis twin of
+    :func:`tiers_for_channel_count_batch`.
+
+    Each item in ``days_list`` may be:
+
+    * an int (or int-parseable string) -- a finite ``days`` window.
+    * ``None`` or the case-insensitive string ``"unlimited"`` -- an
+      unlimited-history request. The emitted row's ``item`` is ``None``
+      and ``label`` is ``"unlimited"`` (matches
+      :func:`tiers_for_retention_window` (``days=None``) byte-for-byte).
+      This is the *only* per-axis batch on the retention axis that
+      admits the unlimited sentinel; :func:`tiers_for_capacity_batch`
+      treats ``retention_days=None`` as *unset* (matching
+      :func:`min_tier_batch` semantics), so a caller previously had to
+      route the unlimited-history question through the singular
+      endpoint.
+    * Any other value (blank / non-int / non-``"unlimited"`` string) --
+      collapses to the all-``None`` row shape (matches
+      :func:`tiers_for_retention_window`'s ``None``-on-bad-input
+      posture rather than raising).
+
+    Duplicates by normalised key (``<n>`` for a parsed int, the string
+    ``"unlimited"`` for the unlimited sentinel, ``str(raw)`` otherwise)
+    are dropped preserving first-seen order for byte-stable output.
+
+    ``days_list is None`` or non-iterable -- returns ``[]``. Never
+    raises: per-row failures short-circuit to the all-``None`` shape.
+    """
+    try:
+        if days_list is None:
+            return []
+        items = list(days_list)
+    except TypeError:
+        return []
+    out: list[dict] = []
+    seen: set[str] = set()
+    for raw in items:
+        try:
+            row, key = _tiers_for_retention_batch_row(raw)
+        except Exception as exc:
+            logger.warning(
+                "entitlements: tiers_for_retention_window_batch row "
+                "failed: %s",
+                exc,
+            )
+            row = _tiers_for_null_row(raw, "retention_window")
+            key = str(raw)
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(row)
+    return out
+
+
+def tiers_for_node_count_batch(counts) -> list[dict]:
+    """Per-value availability-ladder for N node-count values in ONE
+    round-trip. Node-axis twin of :func:`tiers_for_channel_count_batch`.
+
+    Same per-value grouping, same never-raise posture, same duplicate
+    dedup by normalised int key. Delegates per row to
+    :func:`tiers_for_node_count`; grace vs enforce yields byte-identical
+    rows.
+    """
+    return _tiers_for_capacity_batch(counts, "node_count")
+
+
+def _tiers_for_capacity_batch(values, kind: str) -> list[dict]:
+    """Shared body for :func:`tiers_for_channel_count_batch` and
+    :func:`tiers_for_node_count_batch` (the two integer-only capacity
+    axes -- retention has its own body because it admits the
+    ``None`` / ``"unlimited"`` sentinel).
+
+    Iterates ``values``, dedupes by normalised int key preserving
+    first-seen order, and delegates to the singular ``tiers_for_*``
+    helper for the per-row shape so parity is automatic. Non-int items
+    collapse to the all-``None`` shape (matches the singular helpers'
+    ``None``-on-bad-input posture).
+
+    Never raises: per-row failures short-circuit to the all-``None``
+    shape so the batch keeps building.
+    """
+    try:
+        if values is None:
+            return []
+        items = list(values)
+    except TypeError:
+        return []
+    delegate = (
+        tiers_for_channel_count
+        if kind == "channel_count"
+        else tiers_for_node_count
+    )
+    out: list[dict] = []
+    seen: set[str] = set()
+    for raw in items:
+        try:
+            n = int(raw)
+            key = str(n)
+            parsed: int | None = n
+        except (TypeError, ValueError):
+            key = str(raw)
+            parsed = None
+        if key in seen:
+            continue
+        seen.add(key)
+        if parsed is None:
+            out.append(_tiers_for_null_row(raw, kind))
+            continue
+        try:
+            body = delegate(parsed)
+        except Exception as exc:
+            logger.warning(
+                "entitlements: _tiers_for_capacity_batch row failed: %s",
+                exc,
+            )
+            body = None
+        if body is None:
+            out.append(_tiers_for_null_row(raw, kind))
+        else:
+            out.append(body)
+    return out
+
+
+def _tiers_for_retention_batch_row(raw) -> tuple[dict, str]:
+    """Per-value row for :func:`tiers_for_retention_window_batch`.
+
+    Handles the ``None`` / ``"unlimited"`` sentinel that the shared
+    integer-only capacity batch cannot express: ``None`` and the
+    case-insensitive string ``"unlimited"`` both route to
+    :func:`tiers_for_retention_window` (``days=None``) and dedup under
+    the key ``"unlimited"``. Any other value falls through to
+    :func:`tiers_for_retention_window` for parity with the singular
+    helper.
+
+    Returns ``(row, dedup_key)``.
+    """
+    if raw is None or (
+        isinstance(raw, str) and raw.strip().lower() == "unlimited"
+    ):
+        body = tiers_for_retention_window(None)
+        if body is None:
+            return _tiers_for_null_row(None, "retention_window"), "unlimited"
+        return body, "unlimited"
+    try:
+        n = int(raw)
+    except (TypeError, ValueError):
+        return _tiers_for_null_row(raw, "retention_window"), str(raw)
+    body = tiers_for_retention_window(n)
+    if body is None:
+        return _tiers_for_null_row(raw, "retention_window"), str(n)
+    return body, str(n)
+
+
+def _tiers_for_null_row(raw, kind: str) -> dict:
+    """All-``None`` row for :func:`_tiers_for_capacity_batch` /
+    :func:`tiers_for_retention_window_batch` when the input value cannot
+    be parsed or the singular helper returned ``None``. Field set
+    matches the happy-path row so a caller does not have to branch on
+    the shape.
+
+    ``item`` echoes the raw token (stringified) so a UI can still
+    label the offending row; ``label`` / ``free`` / ``min_tier*`` /
+    ``tiers`` are all ``None`` / ``False`` / ``[]`` respectively.
+    """
+    try:
+        item = int(raw)
+    except (TypeError, ValueError):
+        item = raw if raw is None else str(raw)
+    return {
+        "item": item,
+        "kind": kind,
+        "label": None,
+        "free": False,
+        "min_tier": None,
+        "min_tier_label": None,
+        "min_tier_rank": None,
+        "tiers": [],
+    }

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -20860,6 +20860,235 @@ def api_entitlement_tiers_for_capacity_batch():
         )
 
 
+def _tiers_for_capacity_perval_fallback(kind: str) -> dict:
+    """Grace-shape fallback body for the three per-value
+    ``/tiers-for-<capacity-axis>-batch`` endpoints. Never 5xxs: on a
+    resolver crash the pricing surface keeps rendering with an empty
+    ``rows`` list instead of a stack trace. Envelope mirrors the happy-
+    path body so a caller does not have to branch on the error shape.
+    """
+    return {
+        "kind": kind,
+        "count": 0,
+        "rows": [],
+        "current_tier": "oss",
+        "current_tier_rank": 0,
+        "grace": True,
+        "enforced": False,
+    }
+
+
+def _parse_tiers_for_capacity_batch_csv(name: str, unlimited_ok: bool):
+    """Parse a comma-separated ``/tiers-for-<axis>-batch`` query arg.
+
+    Empty / whitespace tokens are dropped. When ``unlimited_ok`` is
+    True the case-insensitive string ``"unlimited"`` is emitted
+    verbatim (the retention helper routes it to the ``None``
+    sentinel); otherwise it passes through unmodified and collapses to
+    the all-``None`` row shape via the helper's non-int branch. Non-
+    int tokens on the two count axes pass through unmodified so
+    :func:`clawmetry.entitlements._tiers_for_capacity_batch` yields
+    the documented all-``None`` row for them.
+
+    Returns ``(values, err)`` where ``err`` is ``None`` on success,
+    ``"missing"`` when the arg is absent, blank, or contains only
+    commas / whitespace (endpoint should 400). Never raises.
+    """
+    raw = request.args.get(name)
+    if raw is None or not raw.strip():
+        return [], "missing"
+    out: list = []
+    for token in raw.split(","):
+        t = token.strip()
+        if not t:
+            continue
+        if unlimited_ok and t.lower() == "unlimited":
+            out.append("unlimited")
+            continue
+        out.append(t)
+    if not out:
+        return [], "missing"
+    return out, None
+
+
+@bp_entitlement.route(
+    "/api/entitlement/tiers-for-channel-count-batch"
+)
+def api_entitlement_tiers_for_channel_count_batch():
+    """``GET /api/entitlement/tiers-for-channel-count-batch?counts=1,5,10``
+    -- per-value batch sibling of
+    ``/api/entitlement/tiers-for-channel-count``.
+
+    Where the singular endpoint folds ONE channel count to ONE
+    availability ladder, this preserves the per-value grouping so a
+    pricing-matrix walkthrough comparing several hypothetical channel
+    counts ("at 1 / 5 / 10 / 25 channels -- Fits in: <tiers> per row")
+    renders off ONE round-trip instead of N calls to
+    ``/tiers-for-channel-count`` + client-side row assembly. Wraps
+    :func:`clawmetry.entitlements.tiers_for_channel_count_batch`.
+
+    Distinct from ``/api/entitlement/tiers-for-capacity-batch`` (per-
+    axis rows for a THREE-axis bundle -- one row per axis, single
+    scalar per axis) and ``/api/entitlement/tiers-for-batch`` (per-
+    bundle folded answer across N feature+runtime *bundles*). This
+    endpoint preserves per-value rows on a SINGLE capacity axis.
+
+    ``counts=`` is required. Missing / blank / only-commas ->
+    ``400``. Comma-separated tokens are normalised: whitespace-
+    stripped, deduplicated by parsed int key preserving first-seen
+    order. Non-int tokens collapse to the all-``None`` row shape
+    (matches the singular endpoint's ``None``-on-bad-input posture
+    rather than failing the whole batch). Never 5xxs: the grace-shape
+    envelope is returned on any resolver failure.
+
+    Response shape::
+
+        {
+          "kind":  "channel_count",
+          "count": <int>,
+          "rows":  [<row>, ...],
+          "current_tier":       "...",
+          "current_tier_rank":  <int>,
+          "grace":              <bool>,
+          "enforced":           <bool>,
+        }
+
+    Each ``<row>`` mirrors the bare singular endpoint body minus the
+    resolver envelope: ``item`` / ``kind`` (``"channel_count"``) /
+    ``label`` / ``free`` / ``min_tier`` / ``min_tier_label`` /
+    ``min_tier_rank`` / ``tiers``. Per-row parity with
+    ``/api/entitlement/tiers-for-channel-count?count=<n>`` is pinned
+    in the test suite so the batch cannot silently drift from the
+    scalar.
+    """
+    values, err = _parse_tiers_for_capacity_batch_csv(
+        "counts", unlimited_ok=False
+    )
+    if err == "missing":
+        return jsonify({"error": "missing counts"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        rows = _ent.tiers_for_channel_count_batch(values)
+        env = _resolver_envelope(_ent)
+        return jsonify(
+            {
+                "kind": "channel_count",
+                "count": len(rows),
+                "rows": rows,
+                **env,
+            }
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_tiers_for_channel_count_batch: error: %s",
+            exc,
+        )
+        return jsonify(_tiers_for_capacity_perval_fallback("channel_count"))
+
+
+@bp_entitlement.route(
+    "/api/entitlement/tiers-for-node-count-batch"
+)
+def api_entitlement_tiers_for_node_count_batch():
+    """``GET /api/entitlement/tiers-for-node-count-batch?counts=1,3,5`` --
+    per-value batch sibling of
+    ``/api/entitlement/tiers-for-node-count``. Node-axis twin of
+    ``/api/entitlement/tiers-for-channel-count-batch``.
+
+    Same posture: ``counts=`` required (missing / blank / only-commas
+    -> ``400``), comma-separated int tokens deduped by parsed int key
+    preserving first-seen order, non-int tokens collapse to the all-
+    ``None`` row shape, never 5xxs. Wraps
+    :func:`clawmetry.entitlements.tiers_for_node_count_batch`.
+
+    Response shape and row shape byte-identical to
+    ``/api/entitlement/tiers-for-channel-count-batch`` with ``kind``
+    ``"node_count"``.
+    """
+    values, err = _parse_tiers_for_capacity_batch_csv(
+        "counts", unlimited_ok=False
+    )
+    if err == "missing":
+        return jsonify({"error": "missing counts"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        rows = _ent.tiers_for_node_count_batch(values)
+        env = _resolver_envelope(_ent)
+        return jsonify(
+            {
+                "kind": "node_count",
+                "count": len(rows),
+                "rows": rows,
+                **env,
+            }
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_tiers_for_node_count_batch: error: %s",
+            exc,
+        )
+        return jsonify(_tiers_for_capacity_perval_fallback("node_count"))
+
+
+@bp_entitlement.route(
+    "/api/entitlement/tiers-for-retention-window-batch"
+)
+def api_entitlement_tiers_for_retention_window_batch():
+    """``GET /api/entitlement/tiers-for-retention-window-batch?days=7,30,unlimited``
+    -- per-value batch sibling of
+    ``/api/entitlement/tiers-for-retention-window``. Retention-axis
+    twin of ``/api/entitlement/tiers-for-channel-count-batch``.
+
+    Same posture with one addition: the case-insensitive token
+    ``unlimited`` is accepted and routes to the unlimited-history row
+    (``item=null`` / ``label="unlimited"``). This is the *only* per-
+    value batch on the retention axis that admits the unlimited
+    sentinel; ``/tiers-for-capacity-batch`` treats
+    ``retention_days=None`` as *unset* (matching
+    ``/min-tier-batch``'s posture), so a caller previously had to
+    route the unlimited-history question through the singular
+    endpoint.
+
+    ``days=`` is required. Missing / blank / only-commas -> ``400``.
+    Duplicates by parsed int key or the ``"unlimited"`` sentinel are
+    dropped preserving first-seen order. Non-int / non-
+    ``"unlimited"`` tokens collapse to the all-``None`` row shape.
+    Never 5xxs.
+
+    Response shape and row shape byte-identical to
+    ``/api/entitlement/tiers-for-channel-count-batch`` with ``kind``
+    ``"retention_window"``.
+    """
+    values, err = _parse_tiers_for_capacity_batch_csv(
+        "days", unlimited_ok=True
+    )
+    if err == "missing":
+        return jsonify({"error": "missing days"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        rows = _ent.tiers_for_retention_window_batch(values)
+        env = _resolver_envelope(_ent)
+        return jsonify(
+            {
+                "kind": "retention_window",
+                "count": len(rows),
+                "rows": rows,
+                **env,
+            }
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_tiers_for_retention_window_batch: error: %s",
+            exc,
+        )
+        return jsonify(
+            _tiers_for_capacity_perval_fallback("retention_window")
+        )
+
+
 @bp_entitlement.route("/api/entitlement/tiers-for-features")
 def api_entitlement_tiers_for_features():
     """``GET /api/entitlement/tiers-for-features?features=a,b,c`` --

--- a/tests/test_entitlement_tiers_for_capacity_perval_batch.py
+++ b/tests/test_entitlement_tiers_for_capacity_perval_batch.py
@@ -1,0 +1,635 @@
+"""Tests for the per-value ``/api/entitlement/tiers-for-channel-count-batch``
+/ ``/api/entitlement/tiers-for-node-count-batch`` /
+``/api/entitlement/tiers-for-retention-window-batch`` endpoints and the
+underlying :func:`tiers_for_channel_count_batch` /
+:func:`tiers_for_node_count_batch` /
+:func:`tiers_for_retention_window_batch` helpers.
+
+Closes the per-value slot on the three scalar capacity axes in the
+``tiers_for_*`` family. Where :func:`tiers_for_capacity_batch` folds ONE
+scalar per axis (three per-axis rows) and :func:`tiers_for_features` /
+:func:`tiers_for_runtimes` fold N grant-axis bundles to N ladder answers,
+this per-value batch preserves per-value grouping on a SINGLE capacity
+axis so a pricing-matrix walkthrough comparing several hypothetical
+channel / node / retention-window values renders every column off one
+round-trip.
+
+Mirrors the shape ``/api/entitlement/min-tier-for-<axis>-batch`` (PR
+#3946) landed for the ``min_tier_for_*`` family.
+
+Distinct from :mod:`tests.test_entitlement_tiers_for_capacity_batch`,
+which covers the *per-axis* :func:`tiers_for_capacity_batch` (one scalar
+per axis, three per-axis rows).
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+_ROW_KEYS = {
+    "item",
+    "kind",
+    "label",
+    "free",
+    "min_tier",
+    "min_tier_label",
+    "min_tier_rank",
+    "tiers",
+}
+
+_ENVELOPE_KEYS = {
+    "kind",
+    "count",
+    "rows",
+    "current_tier",
+    "current_tier_rank",
+    "grace",
+    "enforced",
+}
+
+
+# ── Helper: row shape mirrors singular tiers_for_* helper ─────────────────
+
+def test_helper_channel_count_row_shape_mirrors_singular(ent):
+    rows = ent.tiers_for_channel_count_batch([1, 5, 25])
+    assert len(rows) == 3
+    for row, n in zip(rows, [1, 5, 25]):
+        assert set(row.keys()) == _ROW_KEYS
+        singular = ent.tiers_for_channel_count(n)
+        assert row == singular
+
+
+def test_helper_node_count_row_shape_mirrors_singular(ent):
+    rows = ent.tiers_for_node_count_batch([1, 3, 5])
+    assert len(rows) == 3
+    for row, n in zip(rows, [1, 3, 5]):
+        assert set(row.keys()) == _ROW_KEYS
+        singular = ent.tiers_for_node_count(n)
+        assert row == singular
+
+
+def test_helper_retention_window_row_shape_mirrors_singular(ent):
+    rows = ent.tiers_for_retention_window_batch([7, 30, 365])
+    assert len(rows) == 3
+    for row, n in zip(rows, [7, 30, 365]):
+        assert set(row.keys()) == _ROW_KEYS
+        singular = ent.tiers_for_retention_window(n)
+        assert row == singular
+
+
+# ── Helper: retention admits None / "unlimited" sentinel ──────────────────
+
+def test_helper_retention_admits_none_as_unlimited(ent):
+    rows = ent.tiers_for_retention_window_batch([None])
+    assert len(rows) == 1
+    assert rows[0]["item"] is None
+    assert rows[0]["label"] == "unlimited"
+    assert rows[0] == ent.tiers_for_retention_window(None)
+
+
+def test_helper_retention_admits_string_unlimited(ent):
+    rows = ent.tiers_for_retention_window_batch(["unlimited"])
+    assert len(rows) == 1
+    assert rows[0]["item"] is None
+    assert rows[0]["label"] == "unlimited"
+
+
+def test_helper_retention_admits_unlimited_case_insensitive(ent):
+    for spelling in ["UNLIMITED", "Unlimited", "  UnLiMiTeD  "]:
+        rows = ent.tiers_for_retention_window_batch([spelling])
+        assert len(rows) == 1, spelling
+        assert rows[0]["item"] is None
+        assert rows[0]["label"] == "unlimited"
+
+
+def test_helper_retention_none_and_unlimited_dedup_together(ent):
+    # Both surface as key "unlimited" so only the first survives.
+    rows = ent.tiers_for_retention_window_batch(
+        [None, "unlimited", "UNLIMITED"]
+    )
+    assert len(rows) == 1
+
+
+def test_helper_channel_count_rejects_none(ent):
+    rows = ent.tiers_for_channel_count_batch([None])
+    assert len(rows) == 1
+    assert rows[0]["min_tier"] is None
+    assert rows[0]["tiers"] == []
+
+
+def test_helper_node_count_rejects_none(ent):
+    rows = ent.tiers_for_node_count_batch([None])
+    assert len(rows) == 1
+    assert rows[0]["min_tier"] is None
+    assert rows[0]["tiers"] == []
+
+
+# ── Helper: dedup by normalised int key preserving first-seen order ───────
+
+def test_helper_channel_count_dedup_int_repeats(ent):
+    rows = ent.tiers_for_channel_count_batch([5, 5, 5, 10, 5])
+    assert [r["item"] for r in rows] == [5, 10]
+
+
+def test_helper_node_count_dedup_int_repeats(ent):
+    rows = ent.tiers_for_node_count_batch([3, 3, 5, 5, 3])
+    assert [r["item"] for r in rows] == [3, 5]
+
+
+def test_helper_channel_count_dedup_cross_type_string_int(ent):
+    # "5" and 5 normalise to the same int key.
+    rows = ent.tiers_for_channel_count_batch(["5", 5])
+    assert len(rows) == 1
+    assert rows[0]["item"] == 5
+
+
+def test_helper_node_count_dedup_cross_type_string_int(ent):
+    rows = ent.tiers_for_node_count_batch([3, "3"])
+    assert len(rows) == 1
+
+
+def test_helper_retention_dedup_cross_type_string_int(ent):
+    rows = ent.tiers_for_retention_window_batch([30, "30"])
+    assert len(rows) == 1
+
+
+def test_helper_channel_count_preserves_first_seen_order(ent):
+    rows = ent.tiers_for_channel_count_batch([25, 1, 10, 5])
+    assert [r["item"] for r in rows] == [25, 1, 10, 5]
+
+
+def test_helper_retention_preserves_first_seen_order(ent):
+    rows = ent.tiers_for_retention_window_batch([365, "unlimited", 30, 7])
+    assert [r["item"] for r in rows] == [365, None, 30, 7]
+    assert rows[1]["label"] == "unlimited"
+
+
+# ── Helper: bad-input row collapses to all-None shape ─────────────────────
+
+def test_helper_channel_count_non_int_collapses_to_null_row(ent):
+    rows = ent.tiers_for_channel_count_batch(["bogus"])
+    assert len(rows) == 1
+    r = rows[0]
+    assert set(r.keys()) == _ROW_KEYS
+    assert r["item"] == "bogus"
+    assert r["min_tier"] is None
+    assert r["min_tier_label"] is None
+    assert r["min_tier_rank"] is None
+    assert r["label"] is None
+    assert r["free"] is False
+    assert r["tiers"] == []
+
+
+def test_helper_node_count_non_int_collapses_to_null_row(ent):
+    rows = ent.tiers_for_node_count_batch(["nope"])
+    assert len(rows) == 1
+    assert rows[0]["min_tier"] is None
+    assert rows[0]["tiers"] == []
+
+
+def test_helper_retention_non_int_non_unlimited_collapses_to_null_row(ent):
+    rows = ent.tiers_for_retention_window_batch(["gibberish"])
+    assert len(rows) == 1
+    assert rows[0]["min_tier"] is None
+    assert rows[0]["tiers"] == []
+
+
+def test_helper_bad_input_does_not_fail_batch(ent):
+    # bogus + real value in same call — real value still resolves.
+    rows = ent.tiers_for_channel_count_batch(["bogus", 5])
+    assert len(rows) == 2
+    assert rows[0]["min_tier"] is None
+    assert rows[1]["item"] == 5
+    assert rows[1]["min_tier"] == ent.min_tier_for_channel_count(5)
+
+
+# ── Helper: empty / None / non-iterable input ─────────────────────────────
+
+def test_helper_channel_count_none_input_returns_empty(ent):
+    assert ent.tiers_for_channel_count_batch(None) == []
+
+
+def test_helper_node_count_none_input_returns_empty(ent):
+    assert ent.tiers_for_node_count_batch(None) == []
+
+
+def test_helper_retention_none_input_returns_empty(ent):
+    # NOTE: None-as-input (missing) is [], distinct from [None] which
+    # asks for the unlimited-history row.
+    assert ent.tiers_for_retention_window_batch(None) == []
+
+
+def test_helper_channel_count_empty_list_returns_empty(ent):
+    assert ent.tiers_for_channel_count_batch([]) == []
+
+
+def test_helper_retention_empty_list_returns_empty(ent):
+    assert ent.tiers_for_retention_window_batch([]) == []
+
+
+def test_helper_channel_count_non_iterable_returns_empty(ent):
+    assert ent.tiers_for_channel_count_batch(42) == []
+    assert ent.tiers_for_channel_count_batch(3.14) == []
+
+
+# ── Helper: grace vs enforce parity ───────────────────────────────────────
+
+def test_helper_grace_enforce_parity_channel_count(ent, monkeypatch):
+    baseline = ent.tiers_for_channel_count_batch([1, 5, 10, 25])
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    importlib.reload(ent)
+    ent.invalidate()
+    enforced = ent.tiers_for_channel_count_batch([1, 5, 10, 25])
+    assert baseline == enforced
+
+
+def test_helper_grace_enforce_parity_node_count(ent, monkeypatch):
+    baseline = ent.tiers_for_node_count_batch([1, 3, 5])
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    importlib.reload(ent)
+    ent.invalidate()
+    enforced = ent.tiers_for_node_count_batch([1, 3, 5])
+    assert baseline == enforced
+
+
+def test_helper_grace_enforce_parity_retention(ent, monkeypatch):
+    baseline = ent.tiers_for_retention_window_batch([7, 30, "unlimited"])
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    importlib.reload(ent)
+    ent.invalidate()
+    enforced = ent.tiers_for_retention_window_batch([7, 30, "unlimited"])
+    assert baseline == enforced
+
+
+# ── API: happy path + envelope + row shape ────────────────────────────────
+
+def test_api_channel_count_batch_happy_path(client, ent):
+    r = client.get(
+        "/api/entitlement/tiers-for-channel-count-batch?counts=1,5,25"
+    )
+    assert r.status_code == 200
+    j = r.get_json()
+    assert set(j.keys()) == _ENVELOPE_KEYS
+    assert j["kind"] == "channel_count"
+    assert j["count"] == 3
+    assert len(j["rows"]) == 3
+    for row, n in zip(j["rows"], [1, 5, 25]):
+        assert set(row.keys()) == _ROW_KEYS
+        assert row["item"] == n
+        assert row["kind"] == "channel_count"
+
+
+def test_api_node_count_batch_happy_path(client, ent):
+    r = client.get(
+        "/api/entitlement/tiers-for-node-count-batch?counts=1,3,5"
+    )
+    assert r.status_code == 200
+    j = r.get_json()
+    assert set(j.keys()) == _ENVELOPE_KEYS
+    assert j["kind"] == "node_count"
+    assert j["count"] == 3
+    for row, n in zip(j["rows"], [1, 3, 5]):
+        assert row["item"] == n
+        assert row["kind"] == "node_count"
+
+
+def test_api_retention_window_batch_happy_path(client, ent):
+    r = client.get(
+        "/api/entitlement/tiers-for-retention-window-batch?days=7,30,365"
+    )
+    assert r.status_code == 200
+    j = r.get_json()
+    assert set(j.keys()) == _ENVELOPE_KEYS
+    assert j["kind"] == "retention_window"
+    assert j["count"] == 3
+    for row, n in zip(j["rows"], [7, 30, 365]):
+        assert row["item"] == n
+        assert row["kind"] == "retention_window"
+
+
+# ── API: cross-endpoint parity vs singular ─────────────────────────────────
+
+_ENV_KEYS = {"current_tier", "current_tier_rank", "grace", "enforced"}
+
+
+def _strip_env(body: dict) -> dict:
+    return {k: v for k, v in body.items() if k not in _ENV_KEYS}
+
+
+def test_api_channel_count_parity_vs_singular(client, ent):
+    j = client.get(
+        "/api/entitlement/tiers-for-channel-count-batch?counts=1,5,10,25"
+    ).get_json()
+    for n, row in zip([1, 5, 10, 25], j["rows"]):
+        singular = client.get(
+            f"/api/entitlement/tiers-for-channel-count?count={n}"
+        ).get_json()
+        assert row == _strip_env(singular)
+
+
+def test_api_node_count_parity_vs_singular(client, ent):
+    j = client.get(
+        "/api/entitlement/tiers-for-node-count-batch?counts=1,3,5"
+    ).get_json()
+    for n, row in zip([1, 3, 5], j["rows"]):
+        singular = client.get(
+            f"/api/entitlement/tiers-for-node-count?count={n}"
+        ).get_json()
+        assert row == _strip_env(singular)
+
+
+def test_api_retention_parity_vs_singular(client, ent):
+    j = client.get(
+        "/api/entitlement/tiers-for-retention-window-batch?days=7,30"
+    ).get_json()
+    for n, row in zip([7, 30], j["rows"]):
+        singular = client.get(
+            f"/api/entitlement/tiers-for-retention-window?days={n}"
+        ).get_json()
+        assert row == _strip_env(singular)
+
+
+def test_api_retention_unlimited_parity_vs_singular(client, ent):
+    j = client.get(
+        "/api/entitlement/tiers-for-retention-window-batch?days=unlimited"
+    ).get_json()
+    singular = client.get(
+        "/api/entitlement/tiers-for-retention-window?days=unlimited"
+    ).get_json()
+    assert j["rows"] == [_strip_env(singular)]
+    assert j["rows"][0]["item"] is None
+    assert j["rows"][0]["label"] == "unlimited"
+
+
+# ── API: 400 on missing / blank / only-commas ─────────────────────────────
+
+def test_api_channel_count_missing_arg_returns_400(client):
+    r = client.get("/api/entitlement/tiers-for-channel-count-batch")
+    assert r.status_code == 400
+    assert "missing counts" in r.get_json()["error"]
+
+
+def test_api_node_count_missing_arg_returns_400(client):
+    r = client.get("/api/entitlement/tiers-for-node-count-batch")
+    assert r.status_code == 400
+
+
+def test_api_retention_missing_arg_returns_400(client):
+    r = client.get("/api/entitlement/tiers-for-retention-window-batch")
+    assert r.status_code == 400
+    assert "missing days" in r.get_json()["error"]
+
+
+def test_api_channel_count_blank_arg_returns_400(client):
+    r = client.get(
+        "/api/entitlement/tiers-for-channel-count-batch?counts="
+    )
+    assert r.status_code == 400
+
+
+def test_api_retention_blank_arg_returns_400(client):
+    r = client.get(
+        "/api/entitlement/tiers-for-retention-window-batch?days="
+    )
+    assert r.status_code == 400
+
+
+def test_api_channel_count_only_commas_returns_400(client):
+    r = client.get(
+        "/api/entitlement/tiers-for-channel-count-batch?counts=,,,,"
+    )
+    assert r.status_code == 400
+
+
+def test_api_retention_only_commas_returns_400(client):
+    r = client.get(
+        "/api/entitlement/tiers-for-retention-window-batch?days=,,,"
+    )
+    assert r.status_code == 400
+
+
+# ── API: non-int tokens surface as all-None rows without failing batch ────
+
+def test_api_channel_count_non_int_row_collapses_to_null(client):
+    r = client.get(
+        "/api/entitlement/tiers-for-channel-count-batch?counts=bogus,5"
+    )
+    assert r.status_code == 200
+    j = r.get_json()
+    assert j["count"] == 2
+    assert j["rows"][0]["min_tier"] is None
+    assert j["rows"][0]["tiers"] == []
+    assert j["rows"][1]["item"] == 5
+    assert j["rows"][1]["min_tier"] is not None
+
+
+def test_api_node_count_non_int_row_collapses_to_null(client):
+    r = client.get(
+        "/api/entitlement/tiers-for-node-count-batch?counts=nope,3"
+    )
+    assert r.status_code == 200
+    j = r.get_json()
+    assert j["count"] == 2
+    assert j["rows"][0]["min_tier"] is None
+    assert j["rows"][1]["item"] == 3
+
+
+def test_api_retention_non_int_non_unlimited_row_collapses_to_null(client):
+    r = client.get(
+        "/api/entitlement/tiers-for-retention-window-batch"
+        "?days=gibberish,30"
+    )
+    assert r.status_code == 200
+    j = r.get_json()
+    assert j["count"] == 2
+    assert j["rows"][0]["min_tier"] is None
+    assert j["rows"][1]["item"] == 30
+
+
+# ── API: retention unlimited round-trip (case-insensitive) ────────────────
+
+def test_api_retention_unlimited_case_insensitive(client):
+    for spelling in ["unlimited", "UNLIMITED", "Unlimited"]:
+        r = client.get(
+            "/api/entitlement/tiers-for-retention-window-batch"
+            f"?days={spelling}"
+        )
+        assert r.status_code == 200, spelling
+        j = r.get_json()
+        assert len(j["rows"]) == 1
+        assert j["rows"][0]["item"] is None
+        assert j["rows"][0]["label"] == "unlimited"
+
+
+def test_api_retention_unlimited_mixed_with_ints(client):
+    r = client.get(
+        "/api/entitlement/tiers-for-retention-window-batch"
+        "?days=7,unlimited,30"
+    )
+    assert r.status_code == 200
+    j = r.get_json()
+    assert [row["item"] for row in j["rows"]] == [7, None, 30]
+    assert j["rows"][1]["label"] == "unlimited"
+
+
+# ── API: resolver envelope carried on happy path ──────────────────────────
+
+def test_api_resolver_envelope_channel_count(client):
+    j = client.get(
+        "/api/entitlement/tiers-for-channel-count-batch?counts=1"
+    ).get_json()
+    assert "current_tier" in j
+    assert "current_tier_rank" in j
+    assert "grace" in j
+    assert "enforced" in j
+    assert j["grace"] is True
+    assert j["enforced"] is False
+
+
+def test_api_resolver_envelope_node_count(client):
+    j = client.get(
+        "/api/entitlement/tiers-for-node-count-batch?counts=1"
+    ).get_json()
+    assert j["grace"] is True
+    assert j["enforced"] is False
+
+
+def test_api_resolver_envelope_retention(client):
+    j = client.get(
+        "/api/entitlement/tiers-for-retention-window-batch?days=7"
+    ).get_json()
+    assert j["grace"] is True
+    assert j["enforced"] is False
+
+
+# ── API: uniform envelope + row keys across the three axes ────────────────
+
+def test_api_uniform_envelope_keys_across_axes(client):
+    channel = client.get(
+        "/api/entitlement/tiers-for-channel-count-batch?counts=5"
+    ).get_json()
+    node = client.get(
+        "/api/entitlement/tiers-for-node-count-batch?counts=3"
+    ).get_json()
+    retention = client.get(
+        "/api/entitlement/tiers-for-retention-window-batch?days=30"
+    ).get_json()
+    assert set(channel.keys()) == set(node.keys()) == set(retention.keys())
+    assert set(channel.keys()) == _ENVELOPE_KEYS
+
+
+def test_api_uniform_row_keys_across_axes(client):
+    channel = client.get(
+        "/api/entitlement/tiers-for-channel-count-batch?counts=5"
+    ).get_json()["rows"][0]
+    node = client.get(
+        "/api/entitlement/tiers-for-node-count-batch?counts=3"
+    ).get_json()["rows"][0]
+    retention = client.get(
+        "/api/entitlement/tiers-for-retention-window-batch?days=30"
+    ).get_json()["rows"][0]
+    assert set(channel.keys()) == set(node.keys()) == set(retention.keys())
+    assert set(channel.keys()) == _ROW_KEYS
+
+
+# ── API: never-5xxs on a delegate crash ───────────────────────────────────
+
+def test_api_channel_count_never_5xxs_on_delegate_crash(client, monkeypatch):
+    from clawmetry import entitlements as _ent
+
+    def _boom(_x):
+        raise RuntimeError("simulated resolver failure")
+
+    monkeypatch.setattr(_ent, "tiers_for_channel_count_batch", _boom)
+    r = client.get(
+        "/api/entitlement/tiers-for-channel-count-batch?counts=1"
+    )
+    assert r.status_code == 200
+    j = r.get_json()
+    assert set(j.keys()) == _ENVELOPE_KEYS
+    assert j["kind"] == "channel_count"
+    assert j["rows"] == []
+    assert j["count"] == 0
+    assert j["grace"] is True
+    assert j["enforced"] is False
+
+
+def test_api_node_count_never_5xxs_on_delegate_crash(client, monkeypatch):
+    from clawmetry import entitlements as _ent
+
+    def _boom(_x):
+        raise RuntimeError("simulated resolver failure")
+
+    monkeypatch.setattr(_ent, "tiers_for_node_count_batch", _boom)
+    r = client.get(
+        "/api/entitlement/tiers-for-node-count-batch?counts=1"
+    )
+    assert r.status_code == 200
+    j = r.get_json()
+    assert j["rows"] == []
+    assert j["kind"] == "node_count"
+
+
+def test_api_retention_never_5xxs_on_delegate_crash(client, monkeypatch):
+    from clawmetry import entitlements as _ent
+
+    def _boom(_x):
+        raise RuntimeError("simulated resolver failure")
+
+    monkeypatch.setattr(_ent, "tiers_for_retention_window_batch", _boom)
+    r = client.get(
+        "/api/entitlement/tiers-for-retention-window-batch?days=7"
+    )
+    assert r.status_code == 200
+    j = r.get_json()
+    assert j["rows"] == []
+    assert j["kind"] == "retention_window"
+
+
+# ── API: dedup happens through the query-string parser too ────────────────
+
+def test_api_channel_count_dedups_repeated_tokens(client):
+    j = client.get(
+        "/api/entitlement/tiers-for-channel-count-batch?counts=5,5,5,10,5"
+    ).get_json()
+    assert [r["item"] for r in j["rows"]] == [5, 10]
+
+
+def test_api_retention_dedups_unlimited_repeats(client):
+    j = client.get(
+        "/api/entitlement/tiers-for-retention-window-batch"
+        "?days=unlimited,unlimited,UNLIMITED"
+    ).get_json()
+    assert [r["item"] for r in j["rows"]] == [None]
+
+
+def test_api_channel_count_skips_blank_tokens(client):
+    j = client.get(
+        "/api/entitlement/tiers-for-channel-count-batch?counts=5,,10,,,25"
+    ).get_json()
+    assert [r["item"] for r in j["rows"]] == [5, 10, 25]


### PR DESCRIPTION
## Summary

Closes the per-value slot on the three scalar capacity axes in the `tiers_for_*` family. Availability-ladder twin of PR #3946 (`min_tier_for_{channel_count,retention_window,node_count}_batch`).

- The existing per-axis scalar batch `tiers_for_capacity_batch(*, channels=N, retention_days=K, nodes=M)` folds ONE scalar per axis into three per-axis rows — it cannot compare several hypothetical values on a single axis in one round-trip.
- The per-bundle grant-axis batches `tiers_for_features(...)` / `tiers_for_runtimes(...)` fold N grant bundles to one ladder answer per bundle, not N per-value rows on one capacity axis.
- Neither preserves per-value grouping on a single scalar capacity axis; this closes the gap so a pricing-matrix walkthrough comparing "at 1 / 5 / 10 / 25 channels — Fits in: `<tiers>` per row" renders off ONE call instead of N to `/tiers-for-channel-count` + client-side row assembly.
- **GRACE-safe**: no behavior change to any existing endpoint or helper. Purely additive.

## New helpers in `clawmetry/entitlements.py`

- `tiers_for_channel_count_batch(counts)` — per-value ladder for N channel counts
- `tiers_for_retention_window_batch(days_list)` — per-value ladder for N retention windows (admits `None` / `"unlimited"` sentinel)
- `tiers_for_node_count_batch(counts)` — per-value ladder for N node counts
- `_tiers_for_capacity_batch(values, kind)` — shared body for the two integer-only axes
- `_tiers_for_retention_batch_row(raw)` — retention-only sentinel handler
- `_tiers_for_null_row(raw, kind)` — shared bad-input fallback shape

Row shape byte-identical to the singular `tiers_for_<axis>` helper (`item` / `kind` / `label` / `free` / `min_tier` / `min_tier_label` / `min_tier_rank` / `tiers`). Per-row parity is pinned in the test suite so the batch cannot silently drift from the scalar.

Retention batch admits `None` or the case-insensitive string `"unlimited"` as the unlimited sentinel (routes to `tiers_for_retention_window(None)`); the two count axes reject `None` — matches every capacity-axis helper's `None`-on-bad-input posture. Duplicates by normalised int key (or `"unlimited"` for the retention sentinel) are dropped preserving first-seen order for byte-stable output. Never raises: per-row failures short-circuit to the all-`None` row shape.

## New endpoints on `bp_entitlement` (`routes/entitlement.py`)

- `GET /api/entitlement/tiers-for-channel-count-batch?counts=<csv>`
- `GET /api/entitlement/tiers-for-node-count-batch?counts=<csv>`
- `GET /api/entitlement/tiers-for-retention-window-batch?days=<csv>`

`400` on missing / blank / only-commas arg. Non-int tokens do NOT fail the whole batch: they surface as an all-`None` row so a UI never sees a stack trace on a stray typo. Never 5xxs: grace-shape fallback envelope on any resolver failure. Per-row body byte-identical to the bare singular endpoint minus the resolver envelope so a caller can render each row through the existing singular-endpoint components without reshaping.

## Test plan

`tests/test_entitlement_tiers_for_capacity_perval_batch.py` — 59 cases:

**Helper level**
- [x] Helper row shape mirrors `tiers_for_<axis>` singular for every axis
- [x] Per-row parity with the singular across a representative range of values
- [x] Retention admits `None` + `"unlimited"` (case-insensitive, whitespace-stripped) as the unlimited sentinel; both dedup under the same key
- [x] Channels / nodes reject `None` (collapse to all-`None` row)
- [x] Dedup by normalised int key preserving first-seen order (int, str, cross-type)
- [x] Bad-input rows collapse to the all-`None` row shape (missing / non-int / non-`"unlimited"`)
- [x] Bad input does not fail sibling rows in the same batch
- [x] Empty / `None` / non-iterable input → `[]`
- [x] Grace vs enforce parity: byte-identical rows across modes (all three axes)

**API level**
- [x] Happy path envelope + per-row body shape (all three axes)
- [x] Cross-endpoint parity vs `/tiers-for-<axis>?<param>=<v>` for every batched value
- [x] Retention `unlimited` round-trips to `item=null` / `label="unlimited"` (case-insensitive) and matches the singular endpoint
- [x] `400` on missing / blank / only-commas arg (all three axes)
- [x] Non-int tokens surface as all-`None` rows without failing the batch
- [x] Retention unlimited mixed with ints preserves order
- [x] Resolver envelope carried on happy path (all three axes)
- [x] Uniform envelope + row keys across the three axes so a pricing UI switching axes reads the same shape
- [x] Never-5xxs on a delegate crash (grace-shape fallback, all three axes)
- [x] Query-string parser dedup + blank-token skipping

```
$ python3 -m pytest tests/test_entitlement_tiers_for_capacity_perval_batch.py
59 passed in 2.54s

$ python3 -m pytest tests/test_entitlement_tiers_for_capacity_batch.py \
                    tests/test_entitlement_tiers_for_capacity_perval_batch.py \
                    tests/test_entitlement_min_tier_for_capacity_bare.py \
                    tests/test_entitlement_min_tier_for_plural_bare.py \
                    tests/test_entitlement_min_tier_for_plural_at.py \
                    tests/test_entitlement_api.py \
                    tests/test_entitlements.py
360 passed in 15.65s   # no regressions in adjacent siblings

$ ruff check clawmetry/entitlements.py routes/entitlement.py \
             tests/test_entitlement_tiers_for_capacity_perval_batch.py
All checks passed!
```

## Files changed

- `clawmetry/entitlements.py` — 3 new public helpers + 3 private helpers (+232 LOC)
- `routes/entitlement.py` — 3 new endpoints + 2 private helpers (+229 LOC)
- `tests/test_entitlement_tiers_for_capacity_perval_batch.py` — 59 new cases (+635 LOC)

## Local operator verification checklist

The autonomous session can't reach the running daemon, `~/.openclaw`, the live cloud snapshot, or a browser. Verify locally before flipping ready-for-review:

- [ ] Copy the two changed files into `~/.clawmetry/lib/pythonX.Y/site-packages/clawmetry/` (`entitlements.py`) and `~/.clawmetry/lib/pythonX.Y/site-packages/routes/` (`entitlement.py`), then clear `__pycache__/` under both.
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` (and `com.clawmetry.dashboard` if separately managed) so the daemon picks up the new endpoints.
- [ ] Hit each new endpoint against the live daemon and check the envelope:
  ```
  curl -s 'http://localhost:8900/api/entitlement/tiers-for-channel-count-batch?counts=1,5,25' | jq .
  curl -s 'http://localhost:8900/api/entitlement/tiers-for-node-count-batch?counts=1,3,5' | jq .
  curl -s 'http://localhost:8900/api/entitlement/tiers-for-retention-window-batch?days=7,30,unlimited' | jq .
  ```
  - Confirm one row per input value (post-dedup), each row carries the full `tiers` availability ladder, and the top-level envelope carries `current_tier` / `grace=true` / `enforced=false` on OSS install.
- [ ] Cross-check parity with the singular endpoint — each batch row should byte-equal the singular endpoint body minus the resolver envelope:
  ```
  diff <(curl -s '.../tiers-for-channel-count?count=5' \
           | jq 'del(.current_tier, .current_tier_rank, .grace, .enforced)') \
       <(curl -s '.../tiers-for-channel-count-batch?counts=5' | jq '.rows[0]')
  ```
- [ ] Error paths: `?counts=` → `400`; `?counts=,,,` → `400`; `?counts=bogus,5` → `200` with an all-null row for `bogus` and a real answer for `5`.
- [ ] Retention `unlimited` round-trip: `curl -s '.../tiers-for-retention-window-batch?days=unlimited' | jq '.rows[0]'` should show `item: null, label: "unlimited"` matching `.../tiers-for-retention-window?days=unlimited`.
- [ ] Decrypt the live cloud snapshot and open the dashboard in a browser; visit the Pricing / Fleet / Retention surfaces and confirm no regression in the existing paywall affordances.
- [ ] Flip the PR out of draft once the above pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YLh86jovL8odzfnZyo7CG9)_