### PR TITLE
fix(ci): restore missing triple-quote in entitlement modules + complete truncated _runtime_detection_counts

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -1,4 +1,4 @@
-clawmetry/entitlements.py — open-core entitlement resolution.
+"""clawmetry/entitlements.py -- open-core entitlement resolution.
 
 Single source of truth for "what is this install allowed to do". Everything
 that gates a runtime or an advanced feature reads :func:`get_entitlement` —

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -1,4 +1,4 @@
-routes/entitlement.py -- ``bp_entitlement``.
+"""routes/entitlement.py -- ``bp_entitlement``.
 
 Exposes the resolved open-core entitlement so the frontend knows which
 runtimes/features to surface (and, once enforcement is live, which to render
@@ -24222,4 +24222,22 @@ def api_entitlement_runtime_detection():
 
 
 def _runtime_detection_counts(probes: list) -> dict:
-    """Aggregate row for ``/api/entitlement/runtime-detection``. Pure fn.
+    """Aggregate row for ``/api/entitlement/runtime-detection``. Pure fn."""
+    total = len(probes)
+    detected = sum(1 for r in probes if r.get("found"))
+    detected_free = sum(
+        1 for r in probes if r.get("found") and r.get("free")
+    )
+    detected_locked = sum(
+        1 for r in probes if r.get("found") and not r.get("allowed")
+    )
+    unlocked = sum(1 for r in probes if r.get("allowed"))
+    locked = total - unlocked
+    return {
+        "total": total,
+        "detected": detected,
+        "detected_free": detected_free,
+        "detected_locked": detected_locked,
+        "unlocked": unlocked,
+        "locked": locked,
+    }


### PR DESCRIPTION
## Summary

Main CI has been red since b69062d (2026-07-23 03:50 UTC). Three syntax errors in two files caused:
- **Syntax & Lint** job: FAIL on `clawmetry/entitlements.py:1`
- **OSS Golden Path (C1)**, **API Latency Smoke**, **Apply required E2E checks (C6)**: FAIL because the dashboard server fails to start

All three root causes trace back to `375f5d2` (per-value capacity-axis batch PR), which stripped the opening `"""` from both entitlement modules and truncated `_runtime_detection_counts`.

### Changes

**`clawmetry/entitlements.py` line 1:**
- Before: `clawmetry/entitlements.py — open-core entitlement resolution.` (em-dash, no opening `"""`)
- After: `"""clawmetry/entitlements.py -- open-core entitlement resolution.` (opens module docstring; `--` replaces em-dash per FLYWHEEL.md no-em-dash rule)

**`routes/entitlement.py` line 1:**
- Before: `routes/entitlement.py -- \`\`bp_entitlement\`\`.` (no opening `"""`)
- After: `"""routes/entitlement.py -- \`\`bp_entitlement\`\`.` (opens module docstring; line 304 `"""` now correctly closes it)

**`routes/entitlement.py` line 24225 (was truncated):**
- The `_runtime_detection_counts` helper was cut off after its opening docstring fragment. Restored the closing `"""` and the 16-line function body from commit `72142ac`.

### Verification

```
python3 -c "
import ast, glob, sys
files = ['dashboard.py', 'routes/entitlement.py'] + glob.glob('clawmetry/**/*.py', recursive=True)
for f in files: ast.parse(open(f).read(), filename=f)
print(f'OK -- all {len(files)} files parse cleanly')
"
# Output: OK -- all 72 files parse cleanly
```

This fix is purely additive/restorative -- no logic changes, no new endpoints, no behavior change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NKnVsgjrTGCG5yKGm3L8WJ)_