### PR TITLE
fix(entitlement): unbreak main — restore module docstrings + truncated fn body + widen CI syntax gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,16 +19,42 @@ jobs:
         run: |
           python3 -c "
           import ast, glob, sys
+          # dashboard.py imports every routes/*.py Blueprint at module
+          # top level, so a SyntaxError anywhere under routes/ bricks the
+          # dashboard startup end-to-end. PR #3946 corrupted
+          # routes/entitlement.py (dropped module docstring open, lost
+          # tail fn body) and rode green through this gate because the
+          # glob only covered clawmetry/**/*.py -- CI api-tests then
+          # failed for three consecutive merged PRs before anyone
+          # noticed. Include routes/**/*.py + tests/**/*.py + the
+          # top-level scripts alongside dashboard.py so this gate
+          # covers every .py the server actually loads.
           errors = 0
-          for f in ['dashboard.py'] + glob.glob('clawmetry/**/*.py', recursive=True):
+          files = (
+              ['dashboard.py', 'dashboard_claudecode.py', 'history.py']
+              + glob.glob('clawmetry/**/*.py', recursive=True)
+              + glob.glob('routes/**/*.py', recursive=True)
+              + glob.glob('tests/**/*.py', recursive=True)
+          )
+          seen = set()
+          checked = []
+          for f in files:
+              if f in seen:
+                  continue
+              seen.add(f)
               try:
-                  ast.parse(open(f).read(), filename=f)
+                  src = open(f).read()
+              except FileNotFoundError:
+                  continue
+              checked.append(f)
+              try:
+                  ast.parse(src, filename=f)
               except SyntaxError as e:
                   print(f'❌ {f}:{e.lineno}: {e.msg}')
                   errors += 1
           if errors:
               sys.exit(1)
-          print(f'✅ Syntax OK ({len(glob.glob(\"clawmetry/**/*.py\", recursive=True)) + 1} files)')
+          print(f'✅ Syntax OK ({len(checked)} files)')
           "
       - name: Install ruff (fast linter)
         run: pip install ruff
@@ -46,8 +72,15 @@ jobs:
           import glob, re, sys
           pat = re.compile(r'sys\.(stdout|stderr)\s*=\s*io\.TextIOWrapper\(', re.S)
           bad = []
-          for f in ['dashboard.py'] + glob.glob('clawmetry/**/*.py', recursive=True):
-              src = open(f, encoding='utf-8', errors='replace').read()
+          for f in (
+              ['dashboard.py']
+              + glob.glob('clawmetry/**/*.py', recursive=True)
+              + glob.glob('routes/**/*.py', recursive=True)
+          ):
+              try:
+                  src = open(f, encoding='utf-8', errors='replace').read()
+              except FileNotFoundError:
+                  continue
               for m in pat.finditer(src):
                   line = src[:m.start()].count(chr(10)) + 1
                   bad.append(f'{f}:{line}: use sys.{m.group(1)}.reconfigure(...) instead of a TextIOWrapper rebind')

--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -1,3 +1,4 @@
+"""
 clawmetry/entitlements.py — open-core entitlement resolution.
 
 Single source of truth for "what is this install allowed to do". Everything

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -1,3 +1,4 @@
+"""
 routes/entitlement.py -- ``bp_entitlement``.
 
 Exposes the resolved open-core entitlement so the frontend knows which
@@ -24222,4 +24223,22 @@ def api_entitlement_runtime_detection():
 
 
 def _runtime_detection_counts(probes: list) -> dict:
-    """Aggregate row for ``/api/entitlement/runtime-detection``. Pure fn.
+    """Aggregate row for ``/api/entitlement/runtime-detection``. Pure fn."""
+    total = len(probes)
+    detected = sum(1 for r in probes if r.get("found"))
+    detected_free = sum(
+        1 for r in probes if r.get("found") and r.get("free")
+    )
+    detected_locked = sum(
+        1 for r in probes if r.get("found") and not r.get("allowed")
+    )
+    unlocked = sum(1 for r in probes if r.get("allowed"))
+    locked = total - unlocked
+    return {
+        "total": total,
+        "detected": detected,
+        "detected_free": detected_free,
+        "detected_locked": detected_locked,
+        "unlocked": unlocked,
+        "locked": locked,
+    }


### PR DESCRIPTION
## Summary

`origin/main` is currently broken: `routes/entitlement.py` and `clawmetry/entitlements.py` both lost their opening `"""` (module‑docstring open) during PR #3946, and `routes/entitlement.py` additionally lost the body of the tail helper `_runtime_detection_counts` (it ends mid‑docstring). Both files fail `ast.parse`, which means `dashboard.py` fails to import (it imports both at module top level), and any local `clawmetry` install off the latest wheel would crash at startup. CI `api-tests` on `main` have been red since #3946 — runs #5810 / #5811 / #5813 (PRs #3946, #3951, #3955) all merged despite failing.

The existing CI syntax gate did not catch it because its glob only covered `['dashboard.py'] + clawmetry/**/*.py`, so anything under `routes/**` could break freely. The `clawmetry/entitlements.py` corruption WAS within the glob but the current run's exit path lost it in the mix.

This PR:

- Restores the missing `"""` at the top of `clawmetry/entitlements.py` and `routes/entitlement.py`.
- Restores the truncated `_runtime_detection_counts` body verbatim from commit 72142ac (the PR that first introduced it, before the corruption). Pure aggregation over the probes list — no side effects.
- Widens the CI syntax gate in `.github/workflows/ci.yml` to also cover `routes/**/*.py`, `tests/**/*.py`, `dashboard_claudecode.py`, and `history.py`, so this class of break is caught in <10 s at gate time instead of surfacing downstream as a red `api-tests` job. Also widens the sibling `TextIOWrapper`-rebind guard (#3791) to include `routes/**/*.py` for the same reason.

No behavior change beyond "the app now boots and `/api/entitlement` returns the documented shape again". No `__version__` bump; not a `[RELEASE]` PR.

## Test plan

- [x] `python3 -c "import ast, glob; [ast.parse(open(f).read(), filename=f) for f in ['dashboard.py'] + glob.glob('clawmetry/**/*.py', recursive=True) + glob.glob('routes/**/*.py', recursive=True) + glob.glob('tests/**/*.py', recursive=True)]"` — parses 790 files clean.
- [x] `python3 -c "import dashboard"` — succeeds (previously `SyntaxError` at `routes/entitlement.py:29`).
- [x] `OPENCLAW_GATEWAY_TOKEN=ci-test-token python3 dashboard.py --port 8901 --no-debug` boots without error.
- [x] `curl -H "Authorization: Bearer ci-test-token" http://localhost:8901/api/health` → 200 with `checks` array.
- [x] `curl -H "Authorization: Bearer ci-test-token" http://localhost:8901/api/entitlement` → 200 with the full entitlement JSON (`features`, `runtimes`, `enforce_at`, `expiry`, `channel_limit`, `effective_retention_days`, …).
- [ ] CI `Syntax & Lint` job passes on this PR under the widened gate — confirms it now covers `routes/**` and would have caught the corruption.
- [ ] CI `api-tests` job passes on this PR — confirms end-to-end recovery from the broken state.

### Local operator verification checklist

Because I cannot touch the operator's machine from CI, please run these on your side after checkout:

- [ ] `cp -r clawmetry/entitlements.py routes/entitlement.py ~/.clawmetry/lib/python3.11/site-packages/clawmetry/` (adjust for actual site-packages layout — `routes/` is a top-level sibling of `clawmetry/` in the installed wheel, verify path).
- [ ] `find ~/.clawmetry -name __pycache__ -exec rm -rf {} +`
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
- [ ] `curl -H "Authorization: Bearer $CLAWMETRY_TOKEN" http://localhost:8900/api/entitlement | jq '.tier, .features, .runtimes'` — should return the resolved entitlement, not a 500.
- [ ] Decrypt the live cloud snapshot in the browser and confirm the entitlement panel renders (no more "unknown" locked runtime badges from a 500).
- [ ] `curl http://localhost:8900/api/entitlement/runtime-detection` — the restored `_runtime_detection_counts` should return a `counts: {total, detected, detected_free, detected_locked, unlocked, locked}` object.

Notes for the operator on the wider open‑core roadmap:

- P3 / P4 / P6 (cloud plan wiring, closed‑source `clawmetry-pro` package, enterprise SSO) still require the private `clawmetry-cloud` / not-yet-existing `clawmetry-pro` repos I don't have access to, so I've left them to you.
- Since P1 / P2 are already extensively implemented and iterated (dozens of merged PRs), my next scheduled fire — assuming this fix lands — was going to be a very small extension: `min_tier_for_{channel_count,retention_window,node_count}_at_batch` + `tiers_for_{channel_count,retention_window,node_count}_at_batch` helpers + endpoints, closing the last symmetry gap in the `_at_batch` family. I've deferred that to the next fire so this PR stays focused on the unblock.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vhb27VsSXGgXQXkKNvZrU8)_