### PR TITLE
fix: add missing /healthz liveness-probe endpoint

### DIFF
--- a/routes/health.py
+++ b/routes/health.py
@@ -2,8 +2,9 @@
 routes/health.py — Health / reliability / diagnostics / rate-limits endpoints.
 
 Extracted from dashboard.py as Phase 5.5 of the incremental modularisation.
-Owns the 11 routes registered on bp_health:
+Owns the routes registered on bp_health:
 
+  GET  /healthz                   — liveness probe (k8s / load-balancer, unauthenticated)
   GET  /api/reliability           — cross-session behavioral reliability trend
   GET  /api/heatmap               — activity heatmap (events per hour, N days)
   GET  /api/system-health         — comprehensive system health (services, disks, crons)
@@ -50,6 +51,13 @@ from flask import Blueprint, Response, jsonify, request
 from clawmetry.config import is_local_store_read_enabled
 
 bp_health = Blueprint('health', __name__)
+
+
+@bp_health.route("/healthz")
+def healthz():
+    """Kubernetes/load-balancer liveness probe — always returns 200."""
+    import dashboard as _d
+    return jsonify({"status": "ok", "service": "clawmetry", "version": _d.__version__})
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `GET /healthz` was missing from the codebase entirely — the route was never registered, causing the cloud deployment to return a Google infrastructure 404.
- Added `GET /healthz` on `bp_health` in `routes/health.py`; returns `{"status": "ok", "service": "clawmetry", "version": "<ver>"}` with 200.
- Route is intentionally unauthenticated — the auth middleware in `dashboard.py` already exempts all non-`/api/` paths, matching standard k8s/load-balancer probe expectations.

Closes #3768

## Test plan

- [ ] `curl http://localhost:8900/healthz` → `{"status": "ok", "service": "clawmetry", "version": "..."}` with HTTP 200
- [ ] `curl http://localhost:8900/api/health` still works (existing route unaffected)
- [ ] After cloud deploy: smoke watchdog records `/healthz` as PASS

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fb5iT83BAufHnB1m3Xy6nA)_