### PR TITLE
fix: add OS temp-dir fallback to _gateway_log_files()

### DIFF
--- a/clawmetry/adapters/openclaw.py
+++ b/clawmetry/adapters/openclaw.py
@@ -17,6 +17,7 @@ import hashlib
 import json
 import logging
 import os
+import tempfile
 import time as _time
 from typing import List, Optional, Set
 
@@ -469,6 +470,12 @@ def _gateway_log_files() -> list:
         "/tmp/openclaw",
         os.path.join(openclaw_dir, "logs"),
     ]
+    # On Windows and on hosts where /tmp/openclaw is unsafe the gateway writes
+    # to a user-scoped openclaw-* directory under the OS temp dir instead.
+    tmp_base = tempfile.gettempdir()
+    for entry in sorted(glob.glob(os.path.join(tmp_base, "openclaw-*"))):
+        if os.path.isdir(entry):
+            candidates.append(entry)
     for d in candidates:
         matches = sorted(glob.glob(os.path.join(d, "openclaw-*.log")))
         if matches:


### PR DESCRIPTION
Closes #3962

## Summary

- `_gateway_log_files()` in `clawmetry/adapters/openclaw.py` only probed `/tmp/openclaw` and `~/.openclaw/logs`, missing the OS-temp-dir fallback path the gateway uses on Windows and when `/tmp/openclaw` is unavailable
- After the two existing candidates, now also globs `openclaw-*` directories under `tempfile.gettempdir()` (cross-platform) and appends any that are directories to the probe list
- `_gateway_log_meta()` and the sandbox-log merge in `_openshell_sandbox_logs()` both call `_gateway_log_files()` and so gain the fix automatically

## Test plan

- [ ] On a normal Linux host: existing behavior unchanged (no `openclaw-*` dirs under `/tmp` unless gateway is in fallback mode)
- [ ] On Windows or a host where `/tmp/openclaw` is write-protected: `_gateway_log_files()` returns logs from the user-scoped `openclaw-<id>` dir under `%TEMP%` / `gettempdir()`
- [ ] `make lint` passes on the changed file (pre-existing errors in `dashboard.py` are unrelated)

---
_Generated by [Claude Code](https://claude.ai/code/session_01R1irgZXQ7ZrzZwJD9hfEDK)_