### PR TITLE
test(e2e): enforce 3-way tab-list sync to close C5 drift gap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -449,7 +449,7 @@ jobs:
         run: |
           python3 -m pytest \
             tests/test_e2e.py::TestTabsLoad \
-            tests/test_e2e_oss_all_tabs.py::TestAllTabsPostAuth \
+            tests/test_e2e_oss_all_tabs.py \
             -v --tb=short -m 'not quarantine' \
             --junitxml=/tmp/junit-e2e-critical.xml
 

--- a/tests/test_e2e_oss_all_tabs.py
+++ b/tests/test_e2e_oss_all_tabs.py
@@ -168,6 +168,117 @@ def test_canonical_tabs_cover_all_templates():
     )
 
 
+def test_pr_screenshot_tabs_match_canonical():
+    """PR_SCREENSHOT_TABS in pr-screenshots.yml must equal CANONICAL_TABS exactly.
+
+    Closes a silent-drift gap: a tab added to CANONICAL_TABS (so the
+    post-auth overlay sweep covers it) but NOT added to PR_SCREENSHOT_TABS
+    would never appear in the visual-diff screenshot run, meaning a login-
+    overlay regression on that tab would pass CI undetected.
+
+    When this test fails it names the diverging entries and the three files
+    that must be kept in sync.
+    """
+    import re
+
+    workflow_path = (
+        pathlib.Path(__file__).parent.parent
+        / ".github"
+        / "workflows"
+        / "pr-screenshots.yml"
+    )
+    if not workflow_path.exists():
+        pytest.skip(
+            f"pr-screenshots.yml not found at {workflow_path} -- not a source checkout"
+        )
+
+    content = workflow_path.read_text()
+    m = re.search(r'PR_SCREENSHOT_TABS:\s+"([^"]+)"', content)
+    if not m:
+        pytest.fail(
+            "Could not find PR_SCREENSHOT_TABS: \"...\" in "
+            ".github/workflows/pr-screenshots.yml. "
+            "Ensure the env var uses double-quoted value on one line."
+        )
+
+    pr_tabs = [t.strip() for t in m.group(1).split(",") if t.strip()]
+    canonical_set = set(CANONICAL_TABS)
+    pr_set = set(pr_tabs)
+
+    errors = []
+    only_in_canonical = canonical_set - pr_set
+    only_in_pr = pr_set - canonical_set
+    if only_in_canonical:
+        errors.append(
+            f"In CANONICAL_TABS but NOT in PR_SCREENSHOT_TABS: {sorted(only_in_canonical)}"
+        )
+    if only_in_pr:
+        errors.append(
+            f"In PR_SCREENSHOT_TABS but NOT in CANONICAL_TABS: {sorted(only_in_pr)}"
+        )
+
+    assert not errors, (
+        "Tab list mismatch -- these three sources must be identical:\n"
+        "  CANONICAL_TABS in tests/test_e2e_oss_all_tabs.py\n"
+        "  PR_SCREENSHOT_TABS in .github/workflows/pr-screenshots.yml\n"
+        "  DEFAULT_TABS in .github/scripts/visual-diff.mjs\n"
+        + "\n".join(errors)
+    )
+
+
+def test_visual_diff_default_tabs_match_canonical():
+    """DEFAULT_TABS in visual-diff.mjs must equal CANONICAL_TABS exactly.
+
+    Closes a silent-drift gap: a tab added to CANONICAL_TABS but NOT to
+    DEFAULT_TABS would never be screenshotted in the visual-diff run, so a
+    login-overlay regression on that tab would pass CI undetected.
+    """
+    import re
+
+    script_path = (
+        pathlib.Path(__file__).parent.parent
+        / ".github"
+        / "scripts"
+        / "visual-diff.mjs"
+    )
+    if not script_path.exists():
+        pytest.skip(
+            f"visual-diff.mjs not found at {script_path} -- not a source checkout"
+        )
+
+    content = script_path.read_text()
+    m = re.search(r'const DEFAULT_TABS\s*=\s*"([^"]+)"', content)
+    if not m:
+        pytest.fail(
+            "Could not find `const DEFAULT_TABS = \"...\"` in "
+            ".github/scripts/visual-diff.mjs."
+        )
+
+    vd_tabs = [t.strip() for t in m.group(1).split(",") if t.strip()]
+    canonical_set = set(CANONICAL_TABS)
+    vd_set = set(vd_tabs)
+
+    errors = []
+    only_in_canonical = canonical_set - vd_set
+    only_in_vd = vd_set - canonical_set
+    if only_in_canonical:
+        errors.append(
+            f"In CANONICAL_TABS but NOT in DEFAULT_TABS: {sorted(only_in_canonical)}"
+        )
+    if only_in_vd:
+        errors.append(
+            f"In DEFAULT_TABS but NOT in CANONICAL_TABS: {sorted(only_in_vd)}"
+        )
+
+    assert not errors, (
+        "Tab list mismatch -- these three sources must be identical:\n"
+        "  CANONICAL_TABS in tests/test_e2e_oss_all_tabs.py\n"
+        "  PR_SCREENSHOT_TABS in .github/workflows/pr-screenshots.yml\n"
+        "  DEFAULT_TABS in .github/scripts/visual-diff.mjs\n"
+        + "\n".join(errors)
+    )
+
+
 class TestAllTabsPostAuth:
     """Every canonical OSS dashboard tab must render without auth overlay post-login.
 


### PR DESCRIPTION
## Summary

- Add `test_pr_screenshot_tabs_match_canonical` -- parses `PR_SCREENSHOT_TABS` from `.github/workflows/pr-screenshots.yml` and asserts exact set equality with `CANONICAL_TABS`.
- Add `test_visual_diff_default_tabs_match_canonical` -- parses `DEFAULT_TABS` from `.github/scripts/visual-diff.mjs` and asserts exact set equality with `CANONICAL_TABS`.
- Update `ci.yml` e2e-critical step to run the full `tests/test_e2e_oss_all_tabs.py` module instead of `::TestAllTabsPostAuth` only, so the two new sync tests and `test_canonical_tabs_cover_all_templates` run as hard gates on every PR.

## Problem closed

The `test_canonical_tabs_cover_all_templates` test checked only one direction: new template files missing from `CANONICAL_TABS`. The reverse drift was unguarded: a tab added to `CANONICAL_TABS` (so the C5 overlay sweep covers it) but not added to `PR_SCREENSHOT_TABS` or `DEFAULT_TABS` would pass all CI checks while silently skipping visual-diff screenshot coverage -- meaning a login-overlay regression on that tab would ship undetected.

Both new tests skip gracefully when run outside a source checkout (installed-wheel runs) so the wheel-based jobs in `oss-golden-path.yml` are unaffected.

## Acceptance

All three tab lists currently match at 33 tabs each -- verified locally:
```
PR tabs count: 33, canonical count: 33
Only in canonical: []  Only in PR: []

VD tabs count: 33, canonical count: 33
Only in canonical: []  Only in VD: []
```

---
_Generated by [Claude Code](https://claude.ai/code/session_019qsMQdi86HJ9U1AXB2vX7t)_