### PR TITLE
fix(channels): add ClickClack to frontend icon/color/slot maps (#3961)

### DIFF
--- a/clawmetry/gateway_tap.py
+++ b/clawmetry/gateway_tap.py
@@ -101,6 +101,7 @@ CHANNEL_NAMES: tuple[str, ...] = (
     "tlon",
     "synologychat",
     "nextcloudtalk",
+    "clickclack",
 )
 
 

--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -4389,7 +4389,7 @@ function _enterBrainHistoryMode() {
 }
 
 // Provider → emoji + display name. Mirrors routes/brain.py `_CHANNEL_ICON`
-// and clawmetry/sync.py `_CHANNEL_DIRS` (the canonical 21-adapter list).
+// and clawmetry/sync.py `_CHANNEL_DIRS` (the canonical 22-adapter list).
 // Keep these three in sync when a new adapter ships.
 var _channelIcons = {
   'telegram': '📱', 'whatsapp': '💬', 'discord': '🎮', 'slack': '💼',
@@ -4397,7 +4397,7 @@ var _channelIcons = {
   'googlechat': '🔵', 'matrix': '🔢', 'msteams': '🏢', 'mattermost': '⚡',
   'line': '💚', 'nostr': '🟣', 'twitch': '💜', 'bluebubbles': '💙',
   'feishu': '🟠', 'zalo': '🩵', 'tlon': '🟤', 'synologychat': '🟦',
-  'nextcloudtalk': '☁️',
+  'nextcloudtalk': '☁️', 'clickclack': '🗨️',
   'cli': '🖥️', 'tui': '⌨️', 'cron': '⏰'
 };
 var _channelColors = {
@@ -4406,7 +4406,7 @@ var _channelColors = {
   'googlechat': '#1A73E8', 'matrix': '#0DBD8B', 'msteams': '#4B53BC', 'mattermost': '#0072C6',
   'line': '#06C755', 'nostr': '#9333ea', 'twitch': '#9146FF', 'bluebubbles': '#3478F6',
   'feishu': '#00D6B9', 'zalo': '#0068FF', 'tlon': '#A78BFA', 'synologychat': '#1A73E8',
-  'nextcloudtalk': '#0082C9',
+  'nextcloudtalk': '#0082C9', 'clickclack': '#FF6B35',
   'cli': '#94a3b8', 'tui': '#94a3b8', 'cron': '#6B7280'
 };
 // Display-name overrides for channels whose snake/lower-case key isn't a
@@ -4422,7 +4422,8 @@ var _channelDisplayNames = {
   'cli':        'CLI',
   'tui':        'TUI',
   'synologychat': 'Synology Chat',
-  'nextcloudtalk': 'Nextcloud Talk'
+  'nextcloudtalk': 'Nextcloud Talk',
+  'clickclack':    'ClickClack'
 };
 
 function _channelDisplayName(provider) {
@@ -12562,6 +12563,7 @@ async function loadSystemHealth() {
                : p === 'tlon'           ? '🌊'
                : p === 'synology-chat'  ? '🖥️'
                : p === 'nextcloud-talk' ? '☁️'
+               : p === 'clickclack'     ? '🗨️'
                : '📨';
         };
         if (ingest.length === 0) {
@@ -16827,7 +16829,7 @@ function hideUnconfiguredChannels(svgRoot) {
   // Priority order for slot assignment (up to 3 visible at a time)
   var SLOT_ORDER = ['tui', 'telegram', 'whatsapp', 'imessage', 'signal', 'discord', 'slack',
                     'irc', 'webchat', 'googlechat', 'bluebubbles', 'msteams', 'matrix',
-                    'mattermost', 'line', 'nostr', 'twitch', 'feishu', 'zalo'];
+                    'mattermost', 'line', 'nostr', 'twitch', 'feishu', 'zalo', 'clickclack'];
   fetch('/api/channels').then(function(r){return r.json();}).then(function(d) {
     var active = d.channels || ['telegram', 'signal', 'whatsapp'];
     // Build display list: up to 3 channels, prioritized by SLOT_ORDER
@@ -18425,7 +18427,7 @@ function initOverviewFlow() {
     };
     var OV_SLOT_ORDER = ['tui', 'telegram', 'whatsapp', 'imessage', 'signal', 'discord', 'slack',
                          'irc', 'webchat', 'googlechat', 'bluebubbles', 'msteams', 'matrix',
-                         'mattermost', 'line', 'nostr', 'twitch', 'feishu', 'zalo'];
+                         'mattermost', 'line', 'nostr', 'twitch', 'feishu', 'zalo', 'clickclack'];
     var visibleChannels = OV_SLOT_ORDER.filter(function(ch) { return active.indexOf(ch) !== -1; }).slice(0, 3);
     // Use the clone SVG as root for getElementById (it's already in DOM via container)
     function ovEl(id) { return document.getElementById(id); }


### PR DESCRIPTION
## Summary

The backend already supports ClickClack (sync.py `_CHANNEL_DIRS`, `routes/channels.py` endpoint, `entitlements.ALL_CHANNELS`) since #3870, but `app.js` was never updated. As a result the adapter arrives invisibly: no icon, no brand color, no display-name override, and no slot in the Channels-tab flow diagram.

This PR wires the frontend to match the backend, closing the observability gap reported in #3961.

## Changes

- **`clawmetry/static/js/app.js`**
  - `_channelIcons`: add `'clickclack': '🗨️'`
  - `_channelColors`: add `'clickclack': '#FF6B35'`
  - `_channelDisplayNames`: add `'clickclack': 'ClickClack'`
  - Health-page ingest emoji switch: add `clickclack` arm
  - `SLOT_ORDER` / `OV_SLOT_ORDER`: append `'clickclack'`
  - Comment: update "21-adapter" to "22-adapter"
- **`clawmetry/gateway_tap.py`**
  - `CHANNEL_NAMES`: add `"clickclack"` (doc-mirror of `_CHANNEL_DIRS`)

## Test plan

- [ ] `python3 -m pytest tests/test_entitlement_channel_catalog.py -q` — 27 tests, all pass (runs locally ✅)
- [ ] `node --check clawmetry/static/js/app.js` — JS syntax clean ✅
- [ ] Manually confirm ClickClack channels appear in the Channels tab with 🗨️ icon and orange color

## Bot meta

<!-- bot-autofix -->
Draft PR opened autonomously based on the plan in #3961. Marked draft for human review — mark Ready for Review once happy.

Closes #3961

---
_Generated by [Claude Code](https://claude.ai/code/session_01VRNbZH9UekvTPPxgD5UWS7)_