### PR TITLE
feat(entitlement): per-value capacity-axis `_at_batch` helpers + `/api/entitlement/{min-tier,tiers}-for-{channel-count,retention-window,node-count}-at-batch`

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,1 @@
-{"sessionId":"89ad2fed-569c-4090-a946-00c301cc9d34","pid":36628,"acquiredAt":1776252618284}
+{"sessionId":"f271c034-babc-54dc-a872-7fae11bb2816","pid":615,"procStart":"4310","acquiredAt":1784831074533}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"f271c034-babc-54dc-a872-7fae11bb2816","pid":615,"procStart":"4310","acquiredAt":1784831074533}

--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -6012,6 +6012,123 @@ def min_tier_for_node_count_at(
         return None
 
 
+def min_tier_for_channel_count_at_batch(
+    perspective_tier: str, counts
+) -> list[dict] | None:
+    """Hypothetical-perspective sibling of
+    :func:`min_tier_for_channel_count_batch`: per-value cheapest
+    *purchasable* tier for N channel-count values in one round-trip,
+    scoped by a caller-supplied ``perspective_tier``.
+
+    Fills the last ``_at`` slot on the channel-count capacity axis
+    alongside :func:`min_tier_for_channel_count_at` (singular ``_at``)
+    and :func:`min_tier_for_features_at_batch` /
+    :func:`min_tier_for_runtimes_at_batch` on the grant axes, so a
+    pricing-matrix walkthrough can call ``X_at_batch(perspective, ...)``
+    uniformly across every ``_at_batch`` sibling in the
+    ``min_tier_for_*`` family.
+
+    Perspective is validated against :data:`_TIER_ORDER` (including
+    :data:`TIER_TRIAL`) but does NOT shape rows -- the batch is
+    identical to :func:`min_tier_for_channel_count_batch` regardless
+    of perspective. A parity test pins
+    ``min_tier_for_channel_count_at_batch(p, cs) ==
+    min_tier_for_channel_count_batch(cs)`` for every ``p`` in
+    :data:`_TIER_ORDER` so the ``_at`` prefix cannot silently drift
+    into shaping rows.
+
+    Returns ``None`` for empty / unknown ``perspective_tier`` (caller
+    renders "unknown tier" / 404), matching the ``None`` posture the
+    rest of the ``_at_batch`` family uses for the perspective-
+    validation failure mode. All other semantics (non-iterable ->
+    ``[]``, non-int rows collapse to the all-``None`` shape,
+    duplicates dropped by parsed int key preserving first-seen order,
+    grace vs enforce byte-identical) inherit from
+    :func:`min_tier_for_channel_count_batch` unchanged. Never raises:
+    a delegation failure logs a warning and returns ``None``.
+    """
+    try:
+        p = (perspective_tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if not p or p not in _TIER_ORDER:
+        return None
+    try:
+        return min_tier_for_channel_count_batch(counts)
+    except Exception as exc:
+        logger.warning(
+            "entitlements: min_tier_for_channel_count_at_batch failed: %s",
+            exc,
+        )
+        return None
+
+
+def min_tier_for_retention_window_at_batch(
+    perspective_tier: str, days_list
+) -> list[dict] | None:
+    """Hypothetical-perspective sibling of
+    :func:`min_tier_for_retention_window_batch`. Retention-axis twin
+    of :func:`min_tier_for_channel_count_at_batch`.
+
+    Perspective is validated against :data:`_TIER_ORDER` (including
+    :data:`TIER_TRIAL`) but does NOT shape rows. Admits the same
+    ``None`` / case-insensitive ``"unlimited"`` sentinel that
+    :func:`min_tier_for_retention_window_batch` admits (routes to the
+    unlimited-history row with ``key="unlimited"``).
+
+    Returns ``None`` for empty / unknown ``perspective_tier``; all
+    other semantics inherit from
+    :func:`min_tier_for_retention_window_batch` unchanged. Never
+    raises.
+    """
+    try:
+        p = (perspective_tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if not p or p not in _TIER_ORDER:
+        return None
+    try:
+        return min_tier_for_retention_window_batch(days_list)
+    except Exception as exc:
+        logger.warning(
+            "entitlements: min_tier_for_retention_window_at_batch "
+            "failed: %s",
+            exc,
+        )
+        return None
+
+
+def min_tier_for_node_count_at_batch(
+    perspective_tier: str, counts
+) -> list[dict] | None:
+    """Hypothetical-perspective sibling of
+    :func:`min_tier_for_node_count_batch`. Node-axis twin of
+    :func:`min_tier_for_channel_count_at_batch`.
+
+    Perspective is validated against :data:`_TIER_ORDER` (including
+    :data:`TIER_TRIAL`) but does NOT shape rows. Delegates per row to
+    :func:`min_tier_for_node_count_batch`; grace vs enforce yields
+    byte-identical rows.
+
+    Returns ``None`` for empty / unknown ``perspective_tier``; all
+    other semantics inherit from :func:`min_tier_for_node_count_batch`
+    unchanged. Never raises.
+    """
+    try:
+        p = (perspective_tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if not p or p not in _TIER_ORDER:
+        return None
+    try:
+        return min_tier_for_node_count_batch(counts)
+    except Exception as exc:
+        logger.warning(
+            "entitlements: min_tier_for_node_count_at_batch failed: %s",
+            exc,
+        )
+        return None
+
 
 def _min_tier_for_features_bundle_row(bundle) -> dict:
     """Per-bundle row shape for :func:`min_tier_for_features_batch`.
@@ -18512,3 +18629,119 @@ def _tiers_for_null_row(raw, kind: str) -> dict:
         "min_tier_rank": None,
         "tiers": [],
     }
+
+
+def tiers_for_channel_count_at_batch(
+    perspective_tier: str, counts
+) -> list[dict] | None:
+    """Hypothetical-perspective sibling of
+    :func:`tiers_for_channel_count_batch`: per-value full availability
+    ladder for N channel-count values in one round-trip, scoped by a
+    caller-supplied ``perspective_tier``.
+
+    Fills the last ``_at`` slot on the channel-count capacity axis
+    alongside :func:`tiers_for_channel_count_at` (singular ``_at``),
+    :func:`tiers_for_capacity_batch_at` (grant-axis batch ``_at``) and
+    :func:`tiers_for_features_at_batch` /
+    :func:`tiers_for_runtimes_at_batch` on the grant axes, so a
+    pricing-matrix walkthrough can call ``X_at_batch(perspective, ...)``
+    uniformly across every ``_at_batch`` sibling in the
+    ``tiers_for_*`` family.
+
+    Perspective is validated against :data:`_TIER_ORDER` (including
+    :data:`TIER_TRIAL`) but does NOT shape rows -- the batch is
+    identical to :func:`tiers_for_channel_count_batch` regardless of
+    perspective. A parity test pins
+    ``tiers_for_channel_count_at_batch(p, cs) ==
+    tiers_for_channel_count_batch(cs)`` for every ``p`` in
+    :data:`_TIER_ORDER` so the ``_at`` prefix cannot silently drift
+    into shaping rows.
+
+    Returns ``None`` for empty / unknown ``perspective_tier`` (caller
+    renders "unknown tier" / 404), matching the ``None`` posture the
+    rest of the ``_at_batch`` family uses for the perspective-
+    validation failure mode. All other semantics (non-iterable ->
+    ``[]``, non-int rows collapse to the all-``None`` shape,
+    duplicates dropped by parsed int key preserving first-seen order,
+    grace vs enforce byte-identical) inherit from
+    :func:`tiers_for_channel_count_batch` unchanged. Never raises: a
+    delegation failure logs a warning and returns ``None``.
+    """
+    try:
+        p = (perspective_tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if not p or p not in _TIER_ORDER:
+        return None
+    try:
+        return tiers_for_channel_count_batch(counts)
+    except Exception as exc:
+        logger.warning(
+            "entitlements: tiers_for_channel_count_at_batch failed: %s", exc
+        )
+        return None
+
+
+def tiers_for_retention_window_at_batch(
+    perspective_tier: str, days_list
+) -> list[dict] | None:
+    """Hypothetical-perspective sibling of
+    :func:`tiers_for_retention_window_batch`. Retention-axis twin of
+    :func:`tiers_for_channel_count_at_batch`.
+
+    Perspective is validated against :data:`_TIER_ORDER` (including
+    :data:`TIER_TRIAL`) but does NOT shape rows. Admits the same
+    ``None`` / case-insensitive ``"unlimited"`` sentinel that
+    :func:`tiers_for_retention_window_batch` admits (routes to the
+    unlimited-history row with ``item=None`` /
+    ``label="unlimited"``).
+
+    Returns ``None`` for empty / unknown ``perspective_tier``; all
+    other semantics inherit from
+    :func:`tiers_for_retention_window_batch` unchanged. Never raises.
+    """
+    try:
+        p = (perspective_tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if not p or p not in _TIER_ORDER:
+        return None
+    try:
+        return tiers_for_retention_window_batch(days_list)
+    except Exception as exc:
+        logger.warning(
+            "entitlements: tiers_for_retention_window_at_batch failed: %s",
+            exc,
+        )
+        return None
+
+
+def tiers_for_node_count_at_batch(
+    perspective_tier: str, counts
+) -> list[dict] | None:
+    """Hypothetical-perspective sibling of
+    :func:`tiers_for_node_count_batch`. Node-axis twin of
+    :func:`tiers_for_channel_count_at_batch`.
+
+    Perspective is validated against :data:`_TIER_ORDER` (including
+    :data:`TIER_TRIAL`) but does NOT shape rows. Delegates per row to
+    :func:`tiers_for_node_count_batch`; grace vs enforce yields
+    byte-identical rows.
+
+    Returns ``None`` for empty / unknown ``perspective_tier``; all
+    other semantics inherit from :func:`tiers_for_node_count_batch`
+    unchanged. Never raises.
+    """
+    try:
+        p = (perspective_tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if not p or p not in _TIER_ORDER:
+        return None
+    try:
+        return tiers_for_node_count_batch(counts)
+    except Exception as exc:
+        logger.warning(
+            "entitlements: tiers_for_node_count_at_batch failed: %s", exc
+        )
+        return None

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -21134,6 +21134,227 @@ def api_entitlement_tiers_for_retention_window_batch():
         )
 
 
+def _tiers_for_capacity_perval_at_body(_ent, tier_in: str, kind: str, rows):
+    """Assemble the response envelope for a
+    ``tiers-for-<capacity-axis>-at-batch`` endpoint.
+
+    Layers ``perspective_tier`` / ``perspective_tier_label`` /
+    ``perspective_tier_rank`` on top of the standard per-value tiers-for
+    batch envelope so a pricing-matrix walkthrough surface can render
+    the "from <perspective>" copy off one round-trip, matching how
+    ``/tiers-for-capacity-batch-at`` layers perspective onto the
+    per-axis grant-axis batch. Never raises.
+    """
+    return {
+        "kind": kind,
+        "count": len(rows),
+        "rows": rows,
+        "perspective_tier": tier_in,
+        "perspective_tier_label": _ent.tier_label(tier_in),
+        "perspective_tier_rank": _ent.tier_rank(tier_in),
+        **_resolver_envelope(_ent),
+    }
+
+
+def _tiers_for_capacity_perval_at_fallback(tier_in: str, kind: str) -> dict:
+    """Grace-shape fallback body for the three per-value
+    ``tiers-for-<capacity-axis>-at-batch`` endpoints. Same never-5xx
+    posture as :func:`_tiers_for_capacity_perval_fallback` with the
+    perspective envelope layered on so a caller can still render the
+    "from <perspective>" copy with placeholders on a resolver crash.
+    """
+    try:
+        from clawmetry import entitlements as _ent
+
+        label = _ent.tier_label(tier_in)
+        rank = _ent.tier_rank(tier_in)
+    except Exception:
+        label = tier_in
+        rank = 0
+    return {
+        "kind": kind,
+        "count": 0,
+        "rows": [],
+        "perspective_tier": tier_in,
+        "perspective_tier_label": label,
+        "perspective_tier_rank": rank,
+        "current_tier": "oss",
+        "current_tier_rank": 0,
+        "grace": True,
+        "enforced": False,
+    }
+
+
+@bp_entitlement.route(
+    "/api/entitlement/tiers-for-channel-count-at-batch"
+)
+def api_entitlement_tiers_for_channel_count_at_batch():
+    """``GET /api/entitlement/tiers-for-channel-count-at-batch?tier=<perspective>
+    &counts=1,5,10`` -- hypothetical-perspective sibling of
+    ``/api/entitlement/tiers-for-channel-count-batch``.
+
+    Fills the last ``_at_batch`` slot on the channel-count capacity axis
+    alongside ``/tiers-for-channel-count-at`` (singular ``_at``),
+    ``/tiers-for-capacity-batch-at`` (grant-axis batch ``_at``) and
+    ``/tiers-for-features-at-batch`` / ``/tiers-for-runtimes-at-batch``
+    on the grant axes, so a pricing-matrix walkthrough (``?tier=<p>``)
+    can hit every ``_at_batch`` sibling in the ``tiers-for-*`` family
+    with a uniform URL.
+
+    Perspective is validated against :data:`entitlements._TIER_ORDER`
+    (including ``trial``) but does NOT shape rows -- the batch is
+    identical to ``/tiers-for-channel-count-batch`` regardless of
+    perspective (parity-pinned by
+    :func:`entitlements.tiers_for_channel_count_at_batch`). Response
+    layers ``perspective_tier`` on top of the batch body so a
+    walkthrough surface renders the "from <perspective>" copy off one
+    round-trip.
+
+    - **400** when ``tier=`` is missing / blank, OR when ``counts=`` is
+      missing / blank / only-commas.
+    - **404** when ``tier`` is unknown (body carries ``which=tier``).
+    - **Never 5xxs**: resolver failure -> perspective-carrying grace
+      body with empty ``rows``.
+    """
+    raw_tier = request.args.get("tier")
+    tier_in = (raw_tier or "").strip().lower()
+    if not tier_in:
+        return jsonify({"error": "missing tier"}), 400
+    values, err = _parse_tiers_for_capacity_batch_csv(
+        "counts", unlimited_ok=False
+    )
+    if err == "missing":
+        return jsonify({"error": "missing counts"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        if tier_in not in _ent._TIER_ORDER:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "tier", "tier": tier_in}
+                ),
+                404,
+            )
+        rows = _ent.tiers_for_channel_count_at_batch(tier_in, values) or []
+        return jsonify(
+            _tiers_for_capacity_perval_at_body(
+                _ent, tier_in, "channel_count", rows
+            )
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_tiers_for_channel_count_at_batch: error: %s",
+            exc,
+        )
+        return jsonify(
+            _tiers_for_capacity_perval_at_fallback(tier_in, "channel_count")
+        )
+
+
+@bp_entitlement.route(
+    "/api/entitlement/tiers-for-node-count-at-batch"
+)
+def api_entitlement_tiers_for_node_count_at_batch():
+    """``GET /api/entitlement/tiers-for-node-count-at-batch?tier=<perspective>
+    &counts=1,3,5`` -- node-axis twin of
+    ``/api/entitlement/tiers-for-channel-count-at-batch``. Same
+    perspective contract, same never-5xx posture, same perspective-
+    independence guarantee (parity-pinned). Response shape and error
+    paths mirror ``/tiers-for-channel-count-at-batch`` with ``kind``
+    ``"node_count"``.
+    """
+    raw_tier = request.args.get("tier")
+    tier_in = (raw_tier or "").strip().lower()
+    if not tier_in:
+        return jsonify({"error": "missing tier"}), 400
+    values, err = _parse_tiers_for_capacity_batch_csv(
+        "counts", unlimited_ok=False
+    )
+    if err == "missing":
+        return jsonify({"error": "missing counts"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        if tier_in not in _ent._TIER_ORDER:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "tier", "tier": tier_in}
+                ),
+                404,
+            )
+        rows = _ent.tiers_for_node_count_at_batch(tier_in, values) or []
+        return jsonify(
+            _tiers_for_capacity_perval_at_body(
+                _ent, tier_in, "node_count", rows
+            )
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_tiers_for_node_count_at_batch: error: %s",
+            exc,
+        )
+        return jsonify(
+            _tiers_for_capacity_perval_at_fallback(tier_in, "node_count")
+        )
+
+
+@bp_entitlement.route(
+    "/api/entitlement/tiers-for-retention-window-at-batch"
+)
+def api_entitlement_tiers_for_retention_window_at_batch():
+    """``GET /api/entitlement/tiers-for-retention-window-at-batch?tier=<perspective>
+    &days=7,30,unlimited`` -- retention-axis twin of
+    ``/api/entitlement/tiers-for-channel-count-at-batch``.
+
+    Each token may be a finite int or the case-insensitive string
+    ``"unlimited"``; the unlimited row surfaces with ``item=null`` /
+    ``label="unlimited"``. This is the *only* per-value ``_at_batch``
+    on the retention axis that admits the unlimited sentinel --
+    ``/tiers-for-capacity-batch-at`` treats ``retention_days=None`` as
+    *unset*, not *unlimited*.
+
+    Same 400-on-missing-tier / 400-on-blank-days / 404-on-unknown-tier
+    / never-5xx contracts as the two count-axis siblings.
+    """
+    raw_tier = request.args.get("tier")
+    tier_in = (raw_tier or "").strip().lower()
+    if not tier_in:
+        return jsonify({"error": "missing tier"}), 400
+    values, err = _parse_tiers_for_capacity_batch_csv(
+        "days", unlimited_ok=True
+    )
+    if err == "missing":
+        return jsonify({"error": "missing days"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        if tier_in not in _ent._TIER_ORDER:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "tier", "tier": tier_in}
+                ),
+                404,
+            )
+        rows = (
+            _ent.tiers_for_retention_window_at_batch(tier_in, values) or []
+        )
+        return jsonify(
+            _tiers_for_capacity_perval_at_body(
+                _ent, tier_in, "retention_window", rows
+            )
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_tiers_for_retention_window_at_batch: error: %s",
+            exc,
+        )
+        return jsonify(
+            _tiers_for_capacity_perval_at_fallback(
+                tier_in, "retention_window"
+            )
+        )
+
+
 @bp_entitlement.route("/api/entitlement/tiers-for-features")
 def api_entitlement_tiers_for_features():
     """``GET /api/entitlement/tiers-for-features?features=a,b,c`` --
@@ -22957,6 +23178,240 @@ def api_entitlement_min_tier_for_retention_window_batch():
         )
         return jsonify(
             _min_tier_for_capacity_batch_fallback("retention_window")
+        )
+
+
+def _min_tier_for_capacity_at_batch_body(_ent, tier_in: str, kind: str, rows):
+    """Assemble the response envelope for a
+    ``min-tier-for-<capacity-axis>-at-batch`` endpoint.
+
+    Layers ``perspective_tier`` / ``perspective_tier_label`` /
+    ``perspective_tier_rank`` on top of the standard capacity-batch
+    envelope so a pricing-matrix walkthrough surface can render the
+    "from <perspective>" copy off one round-trip, matching how
+    ``/min-tier-for-features-at-batch`` layers perspective onto the
+    grant-axis batches. Never raises.
+    """
+    return {
+        "kind": kind,
+        "count": len(rows),
+        "rows": rows,
+        "perspective_tier": tier_in,
+        "perspective_tier_label": _ent.tier_label(tier_in),
+        "perspective_tier_rank": _ent.tier_rank(tier_in),
+        **_resolver_envelope(_ent),
+    }
+
+
+def _min_tier_for_capacity_at_batch_fallback(tier_in: str, kind: str) -> dict:
+    """Grace-shape fallback body for the three
+    ``min-tier-for-<capacity-axis>-at-batch`` endpoints. Same never-5xx
+    posture as :func:`_min_tier_for_capacity_batch_fallback` with the
+    perspective envelope layered on so a caller can still render the
+    "from <perspective>" copy with placeholders on a resolver crash.
+    """
+    try:
+        from clawmetry import entitlements as _ent
+
+        label = _ent.tier_label(tier_in)
+        rank = _ent.tier_rank(tier_in)
+    except Exception:
+        label = tier_in
+        rank = 0
+    return {
+        "kind": kind,
+        "count": 0,
+        "rows": [],
+        "perspective_tier": tier_in,
+        "perspective_tier_label": label,
+        "perspective_tier_rank": rank,
+        "current_tier": "oss",
+        "current_tier_rank": 0,
+        "grace": True,
+        "enforced": False,
+    }
+
+
+@bp_entitlement.route(
+    "/api/entitlement/min-tier-for-channel-count-at-batch"
+)
+def api_entitlement_min_tier_for_channel_count_at_batch():
+    """``GET /api/entitlement/min-tier-for-channel-count-at-batch?tier=<perspective>
+    &counts=1,5,10`` -- hypothetical-perspective sibling of
+    ``/api/entitlement/min-tier-for-channel-count-batch``.
+
+    Fills the last ``_at_batch`` slot on the channel-count capacity axis
+    alongside ``/min-tier-for-channel-count-at`` (singular ``_at``) and
+    ``/min-tier-for-features-at-batch`` /
+    ``/min-tier-for-runtimes-at-batch`` on the grant axes, so a
+    pricing-matrix walkthrough (``?tier=<p>``) can hit every
+    ``_at_batch`` sibling in the ``min-tier-for-*`` family with a
+    uniform URL.
+
+    Perspective is validated against :data:`entitlements._TIER_ORDER`
+    (including ``trial``) but does NOT shape rows -- the batch is
+    identical to ``/min-tier-for-channel-count-batch`` regardless of
+    perspective (parity-pinned by
+    :func:`entitlements.min_tier_for_channel_count_at_batch`). Response
+    layers ``perspective_tier`` on top of the batch body so a
+    walkthrough surface renders the "from <perspective>" copy off one
+    round-trip.
+
+    - **400** when ``tier=`` is missing / blank, OR when ``counts=`` is
+      missing / blank / only-commas.
+    - **404** when ``tier`` is unknown (body carries ``which=tier``).
+    - **Never 5xxs**: resolver failure -> perspective-carrying grace
+      body with empty ``rows``.
+    """
+    raw_tier = request.args.get("tier")
+    tier_in = (raw_tier or "").strip().lower()
+    if not tier_in:
+        return jsonify({"error": "missing tier"}), 400
+    values, err = _parse_capacity_batch_csv("counts", unlimited_ok=False)
+    if err == "missing":
+        return jsonify({"error": "missing counts"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        if tier_in not in _ent._TIER_ORDER:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "tier", "tier": tier_in}
+                ),
+                404,
+            )
+        helper_rows = (
+            _ent.min_tier_for_channel_count_at_batch(tier_in, values) or []
+        )
+        rows = [
+            _capacity_batch_row_to_body(r, "channel_count")
+            for r in helper_rows
+        ]
+        return jsonify(
+            _min_tier_for_capacity_at_batch_body(
+                _ent, tier_in, "channel_count", rows
+            )
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_min_tier_for_channel_count_at_batch: error: %s",
+            exc,
+        )
+        return jsonify(
+            _min_tier_for_capacity_at_batch_fallback(tier_in, "channel_count")
+        )
+
+
+@bp_entitlement.route(
+    "/api/entitlement/min-tier-for-node-count-at-batch"
+)
+def api_entitlement_min_tier_for_node_count_at_batch():
+    """``GET /api/entitlement/min-tier-for-node-count-at-batch?tier=<perspective>
+    &counts=1,3,5`` -- node-axis twin of
+    ``/api/entitlement/min-tier-for-channel-count-at-batch``. Same
+    perspective contract, same never-5xx posture, same perspective-
+    independence guarantee (parity-pinned). Response shape and error
+    paths mirror ``/min-tier-for-channel-count-at-batch`` with ``kind``
+    ``"node_count"`` and per-row ``label="1 node"`` /  ``"5 nodes"``.
+    """
+    raw_tier = request.args.get("tier")
+    tier_in = (raw_tier or "").strip().lower()
+    if not tier_in:
+        return jsonify({"error": "missing tier"}), 400
+    values, err = _parse_capacity_batch_csv("counts", unlimited_ok=False)
+    if err == "missing":
+        return jsonify({"error": "missing counts"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        if tier_in not in _ent._TIER_ORDER:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "tier", "tier": tier_in}
+                ),
+                404,
+            )
+        helper_rows = (
+            _ent.min_tier_for_node_count_at_batch(tier_in, values) or []
+        )
+        rows = [
+            _capacity_batch_row_to_body(r, "node_count")
+            for r in helper_rows
+        ]
+        return jsonify(
+            _min_tier_for_capacity_at_batch_body(
+                _ent, tier_in, "node_count", rows
+            )
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_min_tier_for_node_count_at_batch: error: %s",
+            exc,
+        )
+        return jsonify(
+            _min_tier_for_capacity_at_batch_fallback(tier_in, "node_count")
+        )
+
+
+@bp_entitlement.route(
+    "/api/entitlement/min-tier-for-retention-window-at-batch"
+)
+def api_entitlement_min_tier_for_retention_window_at_batch():
+    """``GET /api/entitlement/min-tier-for-retention-window-at-batch?tier=<perspective>
+    &days=7,30,unlimited`` -- retention-axis twin of
+    ``/api/entitlement/min-tier-for-channel-count-at-batch``.
+
+    Each token may be a finite int or the case-insensitive string
+    ``"unlimited"`` (routes to
+    ``min_tier_for_retention_window(None)``); the unlimited row
+    surfaces with ``item=null`` / ``label="unlimited"``. This is the
+    *only* per-axis ``_at_batch`` on the retention axis that admits
+    the unlimited sentinel -- the grant-axis
+    ``/tiers-for-capacity-batch-at`` treats ``retention_days=None`` as
+    *unset*, not *unlimited* (matching ``/min-tier-batch``'s posture).
+
+    Same 400-on-missing-tier / 400-on-blank-days / 404-on-unknown-tier
+    / never-5xx contracts as the two count-axis siblings.
+    """
+    raw_tier = request.args.get("tier")
+    tier_in = (raw_tier or "").strip().lower()
+    if not tier_in:
+        return jsonify({"error": "missing tier"}), 400
+    values, err = _parse_capacity_batch_csv("days", unlimited_ok=True)
+    if err == "missing":
+        return jsonify({"error": "missing days"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        if tier_in not in _ent._TIER_ORDER:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "tier", "tier": tier_in}
+                ),
+                404,
+            )
+        helper_rows = (
+            _ent.min_tier_for_retention_window_at_batch(tier_in, values) or []
+        )
+        rows = [
+            _capacity_batch_row_to_body(r, "retention_window")
+            for r in helper_rows
+        ]
+        return jsonify(
+            _min_tier_for_capacity_at_batch_body(
+                _ent, tier_in, "retention_window", rows
+            )
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_min_tier_for_retention_window_at_batch: "
+            "error: %s",
+            exc,
+        )
+        return jsonify(
+            _min_tier_for_capacity_at_batch_fallback(
+                tier_in, "retention_window"
+            )
         )
 
 

--- a/tests/test_entitlement_capacity_perval_at_batch.py
+++ b/tests/test_entitlement_capacity_perval_at_batch.py
@@ -1,0 +1,693 @@
+"""Tests for the per-value ``_at_batch`` capacity-axis helpers and endpoints:
+
+* :func:`clawmetry.entitlements.min_tier_for_channel_count_at_batch`
+* :func:`clawmetry.entitlements.min_tier_for_retention_window_at_batch`
+* :func:`clawmetry.entitlements.min_tier_for_node_count_at_batch`
+* :func:`clawmetry.entitlements.tiers_for_channel_count_at_batch`
+* :func:`clawmetry.entitlements.tiers_for_retention_window_at_batch`
+* :func:`clawmetry.entitlements.tiers_for_node_count_at_batch`
+* ``GET /api/entitlement/min-tier-for-channel-count-at-batch?tier=<p>&counts=…``
+* ``GET /api/entitlement/min-tier-for-node-count-at-batch?tier=<p>&counts=…``
+* ``GET /api/entitlement/min-tier-for-retention-window-at-batch?tier=<p>&days=…``
+* ``GET /api/entitlement/tiers-for-channel-count-at-batch?tier=<p>&counts=…``
+* ``GET /api/entitlement/tiers-for-node-count-at-batch?tier=<p>&counts=…``
+* ``GET /api/entitlement/tiers-for-retention-window-at-batch?tier=<p>&days=…``
+
+Fill the last ``_at_batch`` slots on the three scalar capacity axes
+(channel_count / retention_window / node_count) alongside the existing
+per-value ``/min-tier-for-<axis>-batch`` / ``/tiers-for-<axis>-batch``
+(no perspective) and the singular ``/min-tier-for-<axis>-at`` /
+``/tiers-for-<axis>-at`` (perspective + single value) so a pricing-
+matrix walkthrough can hit every per-value ``_at_batch`` axis at a
+fixed ``tier=<perspective>`` with a uniform URL.
+
+These tests pin:
+
+  * helper: perspective validation (empty / non-string / unknown -> None)
+  * helper: per-row parity with the bare batch (rows are perspective-
+    independent -- the ``_at`` prefix does NOT shape rows)
+  * helper: bad-input rows collapse to the all-``None`` shape rather
+    than raising or dropping (delegates to the bare batch)
+  * helper: retention batch admits ``None`` / case-insensitive
+    ``"unlimited"`` as the unlimited sentinel; the two count axes reject
+  * helper: empty / None / non-iterable values -> ``[]``
+  * helper: grace vs enforce parity (byte-identical rows across modes)
+  * helper: never raises on a delegate crash (returns ``None``)
+  * API: happy path envelope + per-row body byte-identical to the bare
+    per-value batch endpoint body (minus the perspective envelope)
+  * API: cross-endpoint parity vs
+    ``/min-tier-for-<axis>-batch?<param>=<vs>`` /
+    ``/tiers-for-<axis>-batch?<param>=<vs>`` for every value in the batch
+  * API: 400 on missing / blank ``tier=`` or values arg
+  * API: 404 on unknown ``tier=``
+  * API: non-int tokens do not fail the batch (per-row all-``None`` row)
+  * API: unlimited round-trips to ``item=null`` / ``label="unlimited"``
+    (retention only, case-insensitive)
+  * API: resolver + perspective envelope carried on happy path
+  * API: never-5xxs on a delegate crash (returns perspective-carrying
+    grace body with empty rows)
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+_ENVELOPE_KEYS = {
+    "kind",
+    "count",
+    "rows",
+    "perspective_tier",
+    "perspective_tier_label",
+    "perspective_tier_rank",
+    "current_tier",
+    "current_tier_rank",
+    "grace",
+    "enforced",
+}
+
+
+_MIN_TIER_ROW_KEYS = {
+    "item",
+    "kind",
+    "label",
+    "free",
+    "required_tier",
+    "required_tier_label",
+    "required_tier_rank",
+}
+
+
+_TIERS_ROW_KEYS = {
+    "item",
+    "kind",
+    "label",
+    "free",
+    "min_tier",
+    "min_tier_label",
+    "min_tier_rank",
+    "tiers",
+}
+
+
+_MIN_TIER_HELPERS = (
+    ("min_tier_for_channel_count_at_batch", [1, 5, 25]),
+    ("min_tier_for_node_count_at_batch", [1, 3, 10]),
+    ("min_tier_for_retention_window_at_batch", [7, 30, 90]),
+)
+
+_TIERS_HELPERS = (
+    ("tiers_for_channel_count_at_batch", [1, 5, 25]),
+    ("tiers_for_node_count_at_batch", [1, 3, 10]),
+    ("tiers_for_retention_window_at_batch", [7, 30, 90]),
+)
+
+
+# ── Helper: min_tier_for_<axis>_at_batch shape / delegation ──────────────
+
+
+@pytest.mark.parametrize("name,values", _MIN_TIER_HELPERS)
+def test_min_tier_at_batch_returns_list(ent, name, values):
+    fn = getattr(ent, name)
+    rows = fn(ent.TIER_CLOUD_STARTER, values)
+    assert isinstance(rows, list)
+    assert len(rows) == len(values)
+
+
+@pytest.mark.parametrize("name,values", _MIN_TIER_HELPERS)
+def test_min_tier_at_batch_empty_perspective_is_none(ent, name, values):
+    assert getattr(ent, name)("", values) is None
+
+
+@pytest.mark.parametrize("name,values", _MIN_TIER_HELPERS)
+def test_min_tier_at_batch_none_perspective_is_none(ent, name, values):
+    assert getattr(ent, name)(None, values) is None
+
+
+@pytest.mark.parametrize("name,values", _MIN_TIER_HELPERS)
+def test_min_tier_at_batch_unknown_perspective_is_none(ent, name, values):
+    assert getattr(ent, name)("no-such-tier", values) is None
+
+
+@pytest.mark.parametrize("name,values", _MIN_TIER_HELPERS)
+def test_min_tier_at_batch_non_string_perspective_is_none(ent, name, values):
+    assert getattr(ent, name)(42, values) is None
+
+
+@pytest.mark.parametrize("name,values", _MIN_TIER_HELPERS)
+def test_min_tier_at_batch_none_values_delegates_to_empty(ent, name, values):
+    """``None`` iterable propagates through the delegate."""
+    assert getattr(ent, name)(ent.TIER_CLOUD_STARTER, None) == []
+
+
+@pytest.mark.parametrize("name,values", _MIN_TIER_HELPERS)
+def test_min_tier_at_batch_row_equals_bare_batch_all_perspectives(
+    ent, name, values
+):
+    """Rows are perspective-independent -- byte-equal to the bare batch
+    delegate for every ``perspective_tier`` in :data:`_TIER_ORDER`."""
+    bare_name = name.replace("_at_batch", "_batch")
+    bare = getattr(ent, bare_name)(values)
+    for perspective in ent._TIER_ORDER:
+        assert getattr(ent, name)(perspective, values) == bare
+
+
+def test_min_tier_at_batch_retention_admits_unlimited(ent):
+    rows = ent.min_tier_for_retention_window_at_batch(
+        ent.TIER_CLOUD_STARTER, [7, None, "unlimited", "UNLIMITED"]
+    )
+    keys = [row["key"] for row in rows]
+    assert "unlimited" in keys
+    unl = next(r for r in rows if r["key"] == "unlimited")
+    assert unl["min_tier"] == ent.TIER_ENTERPRISE
+
+
+@pytest.mark.parametrize(
+    "name,values",
+    [
+        ("min_tier_for_channel_count_at_batch", [1, 5]),
+        ("min_tier_for_node_count_at_batch", [1, 3]),
+    ],
+)
+def test_min_tier_at_batch_count_axes_reject_unlimited(ent, name, values):
+    """``unlimited`` on the two integer-only count axes must NOT
+    silently mis-route to Enterprise; it collapses to the all-``None``
+    shape via the singular helper's None-on-bad-input posture."""
+    rows = getattr(ent, name)(ent.TIER_CLOUD_STARTER, ["unlimited"])
+    assert len(rows) == 1
+    assert rows[0]["min_tier"] is None
+
+
+@pytest.mark.parametrize("name,values", _MIN_TIER_HELPERS)
+def test_min_tier_at_batch_grace_vs_enforce_same_rows(
+    monkeypatch, ent, name, values
+):
+    grace = getattr(ent, name)(ent.TIER_CLOUD_STARTER, values)
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    enforced = getattr(ent, name)(ent.TIER_CLOUD_STARTER, values)
+    assert grace == enforced
+
+
+@pytest.mark.parametrize("name,values", _MIN_TIER_HELPERS)
+def test_min_tier_at_batch_never_raises(ent, monkeypatch, name, values):
+    bare_name = name.replace("_at_batch", "_batch")
+
+    def _boom(*_a, **_k):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(ent, bare_name, _boom)
+    assert getattr(ent, name)(ent.TIER_CLOUD_STARTER, values) is None
+
+
+# ── Helper: tiers_for_<axis>_at_batch shape / delegation ─────────────────
+
+
+@pytest.mark.parametrize("name,values", _TIERS_HELPERS)
+def test_tiers_at_batch_returns_list(ent, name, values):
+    fn = getattr(ent, name)
+    rows = fn(ent.TIER_CLOUD_STARTER, values)
+    assert isinstance(rows, list)
+    assert len(rows) == len(values)
+
+
+@pytest.mark.parametrize("name,values", _TIERS_HELPERS)
+def test_tiers_at_batch_empty_perspective_is_none(ent, name, values):
+    assert getattr(ent, name)("", values) is None
+
+
+@pytest.mark.parametrize("name,values", _TIERS_HELPERS)
+def test_tiers_at_batch_unknown_perspective_is_none(ent, name, values):
+    assert getattr(ent, name)("no-such-tier", values) is None
+
+
+@pytest.mark.parametrize("name,values", _TIERS_HELPERS)
+def test_tiers_at_batch_none_values_delegates_to_empty(ent, name, values):
+    assert getattr(ent, name)(ent.TIER_CLOUD_STARTER, None) == []
+
+
+@pytest.mark.parametrize("name,values", _TIERS_HELPERS)
+def test_tiers_at_batch_row_equals_bare_batch_all_perspectives(
+    ent, name, values
+):
+    bare_name = name.replace("_at_batch", "_batch")
+    bare = getattr(ent, bare_name)(values)
+    for perspective in ent._TIER_ORDER:
+        assert getattr(ent, name)(perspective, values) == bare
+
+
+def test_tiers_at_batch_retention_admits_unlimited(ent):
+    rows = ent.tiers_for_retention_window_at_batch(
+        ent.TIER_CLOUD_STARTER, [7, "unlimited"]
+    )
+    labels = [r.get("label") for r in rows]
+    assert "unlimited" in labels
+    unl = next(r for r in rows if r["label"] == "unlimited")
+    assert unl["min_tier"] == ent.TIER_ENTERPRISE
+    assert unl["item"] is None
+
+
+@pytest.mark.parametrize("name,values", _TIERS_HELPERS)
+def test_tiers_at_batch_grace_vs_enforce_same_rows(
+    monkeypatch, ent, name, values
+):
+    grace = getattr(ent, name)(ent.TIER_CLOUD_STARTER, values)
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    enforced = getattr(ent, name)(ent.TIER_CLOUD_STARTER, values)
+    assert grace == enforced
+
+
+@pytest.mark.parametrize("name,values", _TIERS_HELPERS)
+def test_tiers_at_batch_never_raises(ent, monkeypatch, name, values):
+    bare_name = name.replace("_at_batch", "_batch")
+
+    def _boom(*_a, **_k):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(ent, bare_name, _boom)
+    assert getattr(ent, name)(ent.TIER_CLOUD_STARTER, values) is None
+
+
+# ── API: min-tier-for-<axis>-at-batch endpoints ──────────────────────────
+
+
+_MIN_TIER_ENDPOINTS = (
+    ("channel-count", "counts", "1,5,10", "channel_count"),
+    ("node-count", "counts", "1,3,5", "node_count"),
+    ("retention-window", "days", "7,30,90", "retention_window"),
+)
+
+
+@pytest.mark.parametrize(
+    "path,arg,values,kind", _MIN_TIER_ENDPOINTS
+)
+def test_api_min_tier_at_batch_happy_path(
+    client, path, arg, values, kind
+):
+    r = client.get(
+        f"/api/entitlement/min-tier-for-{path}-at-batch"
+        f"?tier=cloud_pro&{arg}={values}"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert set(body.keys()) == _ENVELOPE_KEYS
+    assert body["kind"] == kind
+    assert body["count"] == len(values.split(","))
+    assert body["perspective_tier"] == "cloud_pro"
+    assert body["perspective_tier_label"] == "Pro"
+    for row in body["rows"]:
+        assert set(row.keys()) == _MIN_TIER_ROW_KEYS
+        assert row["kind"] == kind
+
+
+@pytest.mark.parametrize(
+    "path,arg,values,kind", _MIN_TIER_ENDPOINTS
+)
+def test_api_min_tier_at_batch_rows_equal_bare(client, path, arg, values, kind):
+    r_at = client.get(
+        f"/api/entitlement/min-tier-for-{path}-at-batch"
+        f"?tier=cloud_pro&{arg}={values}"
+    )
+    r_bare = client.get(
+        f"/api/entitlement/min-tier-for-{path}-batch?{arg}={values}"
+    )
+    assert r_at.status_code == 200
+    assert r_bare.status_code == 200
+    assert r_at.get_json()["rows"] == r_bare.get_json()["rows"]
+
+
+@pytest.mark.parametrize(
+    "path,arg,values,kind", _MIN_TIER_ENDPOINTS
+)
+def test_api_min_tier_at_batch_row_equals_singular_per_value(
+    client, path, arg, values, kind
+):
+    """Every row byte-equals the perspective-scoped singular endpoint
+    body minus the resolver envelope."""
+    singular_arg = "days" if arg == "days" else "count"
+    r_at = client.get(
+        f"/api/entitlement/min-tier-for-{path}-at-batch"
+        f"?tier=cloud_pro&{arg}={values}"
+    )
+    body = r_at.get_json()
+    for token, row in zip(values.split(","), body["rows"]):
+        singular = client.get(
+            f"/api/entitlement/min-tier-for-{path}-at"
+            f"?tier=cloud_pro&{singular_arg}={token}"
+        )
+        sbody = singular.get_json()
+        for key in _MIN_TIER_ROW_KEYS:
+            assert row[key] == sbody[key], (
+                f"row/singular drift on {key}={token}: {row[key]!r} vs "
+                f"{sbody[key]!r}"
+            )
+
+
+@pytest.mark.parametrize(
+    "path,arg,values,kind", _MIN_TIER_ENDPOINTS
+)
+def test_api_min_tier_at_batch_missing_tier_400(
+    client, path, arg, values, kind
+):
+    r = client.get(
+        f"/api/entitlement/min-tier-for-{path}-at-batch?{arg}={values}"
+    )
+    assert r.status_code == 400
+    assert "tier" in r.get_json()["error"]
+
+
+@pytest.mark.parametrize(
+    "path,arg,values,kind", _MIN_TIER_ENDPOINTS
+)
+def test_api_min_tier_at_batch_blank_tier_400(
+    client, path, arg, values, kind
+):
+    r = client.get(
+        f"/api/entitlement/min-tier-for-{path}-at-batch"
+        f"?tier=&{arg}={values}"
+    )
+    assert r.status_code == 400
+
+
+@pytest.mark.parametrize(
+    "path,arg,values,kind", _MIN_TIER_ENDPOINTS
+)
+def test_api_min_tier_at_batch_missing_values_400(
+    client, path, arg, values, kind
+):
+    r = client.get(
+        f"/api/entitlement/min-tier-for-{path}-at-batch?tier=cloud_pro"
+    )
+    assert r.status_code == 400
+
+
+@pytest.mark.parametrize(
+    "path,arg,values,kind", _MIN_TIER_ENDPOINTS
+)
+def test_api_min_tier_at_batch_blank_values_400(
+    client, path, arg, values, kind
+):
+    r = client.get(
+        f"/api/entitlement/min-tier-for-{path}-at-batch"
+        f"?tier=cloud_pro&{arg}="
+    )
+    assert r.status_code == 400
+
+
+@pytest.mark.parametrize(
+    "path,arg,values,kind", _MIN_TIER_ENDPOINTS
+)
+def test_api_min_tier_at_batch_unknown_tier_404(
+    client, path, arg, values, kind
+):
+    r = client.get(
+        f"/api/entitlement/min-tier-for-{path}-at-batch"
+        f"?tier=no-such-tier&{arg}={values}"
+    )
+    assert r.status_code == 404
+    body = r.get_json()
+    assert "unknown" in body["error"]
+    assert body["tier"] == "no-such-tier"
+
+
+@pytest.mark.parametrize(
+    "path,arg,values,kind", _MIN_TIER_ENDPOINTS
+)
+def test_api_min_tier_at_batch_non_int_row_does_not_fail_batch(
+    client, path, arg, values, kind
+):
+    r = client.get(
+        f"/api/entitlement/min-tier-for-{path}-at-batch"
+        f"?tier=cloud_pro&{arg}=1,bogus,5"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    # 1 + 5 + bogus (echoes as key 'bogus' via delegate's None-on-bad-input)
+    assert body["count"] == 3
+    bogus_row = next(r for r in body["rows"] if r["label"] is None)
+    assert bogus_row["required_tier"] is None
+
+
+def test_api_min_tier_at_batch_retention_unlimited(client):
+    r = client.get(
+        "/api/entitlement/min-tier-for-retention-window-at-batch"
+        "?tier=cloud_pro&days=7,UNLIMITED"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    unl = next(row for row in body["rows"] if row["label"] == "unlimited")
+    assert unl["item"] is None
+    assert unl["required_tier"] == "enterprise"
+
+
+@pytest.mark.parametrize(
+    "path,arg,values,kind", _MIN_TIER_ENDPOINTS
+)
+def test_api_min_tier_at_batch_never_5xxs_on_delegate_crash(
+    client, ent, monkeypatch, path, arg, values, kind
+):
+    def _boom(*_a, **_k):
+        raise RuntimeError("resolver on fire")
+
+    monkeypatch.setattr(
+        ent,
+        f"min_tier_for_{kind}_at_batch",
+        _boom,
+    )
+    r = client.get(
+        f"/api/entitlement/min-tier-for-{path}-at-batch"
+        f"?tier=cloud_pro&{arg}={values}"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["rows"] == []
+    assert body["count"] == 0
+    assert body["perspective_tier"] == "cloud_pro"
+
+
+# ── API: tiers-for-<axis>-at-batch endpoints ─────────────────────────────
+
+
+_TIERS_ENDPOINTS = _MIN_TIER_ENDPOINTS
+
+
+@pytest.mark.parametrize(
+    "path,arg,values,kind", _TIERS_ENDPOINTS
+)
+def test_api_tiers_at_batch_happy_path(client, path, arg, values, kind):
+    r = client.get(
+        f"/api/entitlement/tiers-for-{path}-at-batch"
+        f"?tier=cloud_pro&{arg}={values}"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert set(body.keys()) == _ENVELOPE_KEYS
+    assert body["kind"] == kind
+    assert body["count"] == len(values.split(","))
+    assert body["perspective_tier"] == "cloud_pro"
+    for row in body["rows"]:
+        assert set(row.keys()) == _TIERS_ROW_KEYS
+        assert row["kind"] == kind
+
+
+@pytest.mark.parametrize(
+    "path,arg,values,kind", _TIERS_ENDPOINTS
+)
+def test_api_tiers_at_batch_rows_equal_bare(
+    client, path, arg, values, kind
+):
+    r_at = client.get(
+        f"/api/entitlement/tiers-for-{path}-at-batch"
+        f"?tier=cloud_pro&{arg}={values}"
+    )
+    r_bare = client.get(
+        f"/api/entitlement/tiers-for-{path}-batch?{arg}={values}"
+    )
+    assert r_at.status_code == 200
+    assert r_bare.status_code == 200
+    assert r_at.get_json()["rows"] == r_bare.get_json()["rows"]
+
+
+@pytest.mark.parametrize(
+    "path,arg,values,kind", _TIERS_ENDPOINTS
+)
+def test_api_tiers_at_batch_missing_tier_400(
+    client, path, arg, values, kind
+):
+    r = client.get(
+        f"/api/entitlement/tiers-for-{path}-at-batch?{arg}={values}"
+    )
+    assert r.status_code == 400
+
+
+@pytest.mark.parametrize(
+    "path,arg,values,kind", _TIERS_ENDPOINTS
+)
+def test_api_tiers_at_batch_missing_values_400(
+    client, path, arg, values, kind
+):
+    r = client.get(
+        f"/api/entitlement/tiers-for-{path}-at-batch?tier=cloud_pro"
+    )
+    assert r.status_code == 400
+
+
+@pytest.mark.parametrize(
+    "path,arg,values,kind", _TIERS_ENDPOINTS
+)
+def test_api_tiers_at_batch_unknown_tier_404(
+    client, path, arg, values, kind
+):
+    r = client.get(
+        f"/api/entitlement/tiers-for-{path}-at-batch"
+        f"?tier=no-such-tier&{arg}={values}"
+    )
+    assert r.status_code == 404
+
+
+@pytest.mark.parametrize(
+    "path,arg,values,kind", _TIERS_ENDPOINTS
+)
+def test_api_tiers_at_batch_non_int_row_does_not_fail_batch(
+    client, path, arg, values, kind
+):
+    r = client.get(
+        f"/api/entitlement/tiers-for-{path}-at-batch"
+        f"?tier=cloud_pro&{arg}=1,bogus,5"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["count"] == 3
+    bogus_row = next(row for row in body["rows"] if row["label"] is None)
+    assert bogus_row["min_tier"] is None
+    assert bogus_row["tiers"] == []
+
+
+def test_api_tiers_at_batch_retention_unlimited(client):
+    r = client.get(
+        "/api/entitlement/tiers-for-retention-window-at-batch"
+        "?tier=cloud_pro&days=7,unlimited"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    unl = next(row for row in body["rows"] if row["label"] == "unlimited")
+    assert unl["item"] is None
+    assert unl["min_tier"] == "enterprise"
+
+
+@pytest.mark.parametrize(
+    "path,arg,values,kind", _TIERS_ENDPOINTS
+)
+def test_api_tiers_at_batch_never_5xxs_on_delegate_crash(
+    client, ent, monkeypatch, path, arg, values, kind
+):
+    def _boom(*_a, **_k):
+        raise RuntimeError("resolver on fire")
+
+    monkeypatch.setattr(
+        ent,
+        f"tiers_for_{kind}_at_batch",
+        _boom,
+    )
+    r = client.get(
+        f"/api/entitlement/tiers-for-{path}-at-batch"
+        f"?tier=cloud_pro&{arg}={values}"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["rows"] == []
+    assert body["count"] == 0
+    assert body["perspective_tier"] == "cloud_pro"
+
+
+# ── Cross-endpoint envelope-parity ───────────────────────────────────────
+
+
+def test_uniform_envelope_keys_across_min_tier_endpoints(client):
+    """All three ``min-tier-for-<axis>-at-batch`` endpoints emit the
+    same envelope keys so a pricing UI switching axes reads the same
+    shape."""
+    envelopes = []
+    for path, arg, values, _ in _MIN_TIER_ENDPOINTS:
+        r = client.get(
+            f"/api/entitlement/min-tier-for-{path}-at-batch"
+            f"?tier=cloud_pro&{arg}={values}"
+        )
+        envelopes.append(set(r.get_json().keys()))
+    assert envelopes[0] == envelopes[1] == envelopes[2] == _ENVELOPE_KEYS
+
+
+def test_uniform_envelope_keys_across_tiers_endpoints(client):
+    envelopes = []
+    for path, arg, values, _ in _TIERS_ENDPOINTS:
+        r = client.get(
+            f"/api/entitlement/tiers-for-{path}-at-batch"
+            f"?tier=cloud_pro&{arg}={values}"
+        )
+        envelopes.append(set(r.get_json().keys()))
+    assert envelopes[0] == envelopes[1] == envelopes[2] == _ENVELOPE_KEYS
+
+
+# ── Perspective-independence: URL parity across perspectives ─────────────
+
+
+@pytest.mark.parametrize(
+    "path,arg,values,kind", _MIN_TIER_ENDPOINTS
+)
+def test_api_min_tier_at_batch_rows_perspective_independent(
+    client, path, arg, values, kind
+):
+    """Rows are perspective-independent -- byte-equal across every
+    valid ``tier=<p>`` argument."""
+    baseline = client.get(
+        f"/api/entitlement/min-tier-for-{path}-at-batch"
+        f"?tier=cloud_pro&{arg}={values}"
+    ).get_json()["rows"]
+    for tier in ("oss", "cloud_starter", "trial", "enterprise"):
+        r = client.get(
+            f"/api/entitlement/min-tier-for-{path}-at-batch"
+            f"?tier={tier}&{arg}={values}"
+        )
+        assert r.get_json()["rows"] == baseline
+
+
+@pytest.mark.parametrize(
+    "path,arg,values,kind", _TIERS_ENDPOINTS
+)
+def test_api_tiers_at_batch_rows_perspective_independent(
+    client, path, arg, values, kind
+):
+    baseline = client.get(
+        f"/api/entitlement/tiers-for-{path}-at-batch"
+        f"?tier=cloud_pro&{arg}={values}"
+    ).get_json()["rows"]
+    for tier in ("oss", "cloud_starter", "trial", "enterprise"):
+        r = client.get(
+            f"/api/entitlement/tiers-for-{path}-at-batch"
+            f"?tier={tier}&{arg}={values}"
+        )
+        assert r.get_json()["rows"] == baseline


### PR DESCRIPTION
## Summary

Fills the last `_at_batch` slots on the three scalar capacity axes (`channel_count` / `retention_window` / `node_count`). Completes the `X_at(perspective, ...)` uniform-URL family so a pricing-matrix walkthrough can hit every `_at_batch` sibling in both the `min-tier-for-*` and `tiers-for-*` families with a uniform `?tier=<perspective>&<axis>=<vs>` URL.

Slots the family closes (`x`s existed already; **new** rows are what this PR adds):

| axis | scalar | scalar `_at` | batch | **batch `_at`** |
|------|--------|--------------|-------|-----------------|
| `min-tier-for-channel-count` | x | x | x | **NEW** |
| `min-tier-for-node-count` | x | x | x | **NEW** |
| `min-tier-for-retention-window` | x | x | x | **NEW** |
| `tiers-for-channel-count` | x | x | x | **NEW** |
| `tiers-for-node-count` | x | x | x | **NEW** |
| `tiers-for-retention-window` | x | x | x | **NEW** |

## Changes

**New helpers in `clawmetry/entitlements.py`:**

- `min_tier_for_channel_count_at_batch(perspective_tier, counts)`
- `min_tier_for_retention_window_at_batch(perspective_tier, days_list)`
- `min_tier_for_node_count_at_batch(perspective_tier, counts)`
- `tiers_for_channel_count_at_batch(perspective_tier, counts)`
- `tiers_for_retention_window_at_batch(perspective_tier, days_list)`
- `tiers_for_node_count_at_batch(perspective_tier, counts)`

Each validates `perspective_tier` against `_TIER_ORDER` (including `TIER_TRIAL`) and delegates to the existing bare `_batch`. Perspective does NOT shape rows — the answer is perspective-independent, pinned by a parity test that runs the batch across every tier in `_TIER_ORDER` and byte-compares against the bare batch delegate. Unknown / empty / non-string perspective returns `None` (matches the rest of the `_at_batch` family). Never raises: a delegation failure logs a warning and returns `None`.

**New endpoints in `routes/entitlement.py`:**

- `GET /api/entitlement/min-tier-for-channel-count-at-batch?tier=&counts=`
- `GET /api/entitlement/min-tier-for-node-count-at-batch?tier=&counts=`
- `GET /api/entitlement/min-tier-for-retention-window-at-batch?tier=&days=`
- `GET /api/entitlement/tiers-for-channel-count-at-batch?tier=&counts=`
- `GET /api/entitlement/tiers-for-node-count-at-batch?tier=&counts=`
- `GET /api/entitlement/tiers-for-retention-window-at-batch?tier=&days=`

Each wraps the helpers with the standard capacity-batch envelope plus the perspective envelope: **400** on missing / blank `tier=`, **404** on unknown `tier=` (`which=tier`), **400** on missing / blank / only-commas values arg, **never 5xxs** (grace-shape perspective-carrying fallback on resolver crash).

The retention endpoint is the only per-value `_at_batch` on the retention axis that admits the case-insensitive `"unlimited"` sentinel; the two count axes reject it and the row collapses to the all-`None` shape via the singular helper's `None`-on-bad-input posture, matching the bare `_batch` endpoints byte-for-byte.

## Test plan

New: `tests/test_entitlement_capacity_perval_at_batch.py` — 113 tests pinning:

- Perspective validation (empty / non-string / unknown → `None`)
- Per-row parity with bare batch across every perspective in `_TIER_ORDER`
- Per-row parity with the singular `_at` endpoint for every value in the batch
- Non-int row collapse without failing the batch (per-row all-`None` shape)
- Retention `unlimited` sentinel round-trip (case-insensitive; item=null / label="unlimited")
- Grace vs enforce byte-identical rows
- Uniform envelope keys across the three axes
- Never-5xxs on delegate crash (perspective-carrying grace body, empty rows)

All 113 new tests green; 351 sibling `test_entitlement_*_capacity_*` / `test_entitlement_tiers_for_bundle_at_batch` / `test_entitlement_min_tier_for_capacity_*` tests still green — no regressions.

Behaviour-neutral for existing callers (helpers wrap the bare `_batch`, endpoints are new). Grace posture preserved end-to-end.

## Local operator verification checklist

Since this session can't reach the operator's local daemon or live cloud snapshot:

- [ ] `cp -r clawmetry/entitlements.py routes/entitlement.py ~/.clawmetry/lib/python*/site-packages/clawmetry/` (adjust for the daemon's venv layout — the `routes/` path lives at `~/.clawmetry/lib/python*/site-packages/routes/entitlement.py`).
- [ ] Clear stale bytecode: `find ~/.clawmetry -name __pycache__ -type d -exec rm -rf {} + 2>/dev/null`.
- [ ] Kick the daemon: `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` (or the equivalent on non-macOS).
- [ ] `curl -s http://localhost:8900/api/entitlement | jq` (existing endpoint — sanity check the resolver still boots).
- [ ] Hit the six new endpoints and confirm the perspective envelope + rows:
      - `curl -s 'http://localhost:8900/api/entitlement/min-tier-for-channel-count-at-batch?tier=cloud_pro&counts=1,5,10,25' | jq`
      - `curl -s 'http://localhost:8900/api/entitlement/min-tier-for-node-count-at-batch?tier=cloud_pro&counts=1,3,5' | jq`
      - `curl -s 'http://localhost:8900/api/entitlement/min-tier-for-retention-window-at-batch?tier=cloud_pro&days=7,30,90,unlimited' | jq`
      - `curl -s 'http://localhost:8900/api/entitlement/tiers-for-channel-count-at-batch?tier=cloud_pro&counts=1,5,10,25' | jq`
      - `curl -s 'http://localhost:8900/api/entitlement/tiers-for-node-count-at-batch?tier=cloud_pro&counts=1,3,5' | jq`
      - `curl -s 'http://localhost:8900/api/entitlement/tiers-for-retention-window-at-batch?tier=cloud_pro&days=7,30,90,unlimited' | jq`
- [ ] `curl -si 'http://localhost:8900/api/entitlement/min-tier-for-channel-count-at-batch?counts=1'` — expect **400** (`missing tier`).
- [ ] `curl -si 'http://localhost:8900/api/entitlement/tiers-for-channel-count-at-batch?tier=bogus&counts=1'` — expect **404** (`which=tier`).
- [ ] Decrypt the live cloud snapshot and confirm the encrypted daemon push still round-trips (this PR does not touch `sync.py` or the crypto layer, so no drift expected — sanity check only).
- [ ] Browser: hit the dashboard on localhost, walk through the flow-panel and any pricing surface that reads capacity axes — confirm zero visible change (this is a NEW-endpoint-only PR; grace posture unchanged).
- [ ] Ready this PR for review only after the six new endpoints look right against the local daemon.

Kept **DRAFT** — do not merge, do not tag, do not bump `__version__`. Local operator handles the release loop per `FLYWHEEL.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_019xMaHs6cmmi23MgqKChogu)_