### PR TITLE
fix(c6): verify reads both 'checks' and 'contexts' so badge self-heals after Settings UI config

### DIFF
--- a/.github/workflows/c6-health.yml
+++ b/.github/workflows/c6-health.yml
@@ -119,6 +119,11 @@ jobs:
                                  /branches/main returns protection=None)
                 'unprotected' -- branch has no protection configured
                 'error'       -- API error / repo not reachable
+
+              Reads from both 'contexts' (legacy) and 'checks' (current) arrays
+              so checks configured via the GitHub Settings UI are correctly seen.
+              Settings UI writes to 'checks' only; reading only 'contexts' causes
+              false C6-missing reports after admin configuration via the UI.
               """
               data, err = api_get(f"/repos/{OWNER}/{repo}/branches/main")
               if err is not None or data is None:
@@ -133,7 +138,11 @@ jobs:
               if prot is None:
                   return set(), "unknown"
               rsc = (prot.get("required_status_checks") or {})
-              contexts = set(rsc.get("contexts", []))
+              contexts = set(rsc.get("contexts") or [])
+              # Also extract from 'checks' array (Settings UI writes here, not 'contexts').
+              for item in (rsc.get("checks") or []):
+                  if isinstance(item, dict) and item.get("context"):
+                      contexts.add(item["context"])
               return contexts, "ok"
 
           # Audit all repos.

--- a/scripts/apply_required_status_checks.py
+++ b/scripts/apply_required_status_checks.py
@@ -151,11 +151,18 @@ def add_required_check(repo: str, context: str, token: str) -> None:
     path = f"/repos/{OWNER}/{repo}/branches/main/protection/required_status_checks"
     try:
         current = _api("GET", path, token=token)
-        existing: list[str] = current.get("contexts", [])
+        existing: list[str] = list(current.get("contexts") or [])
+        # Build a full set from both arrays to avoid duplicates when checks were
+        # already configured via the Settings UI (which writes to 'checks' only).
+        existing_set: set[str] = set(existing)
+        for item in (current.get("checks") or []):
+            if isinstance(item, dict) and item.get("context"):
+                existing_set.add(item["context"])
     except RuntimeError:
         existing = []
+        existing_set = set()
 
-    if context in existing:
+    if context in existing_set:
         print(f"  [{repo}] already required: {context!r}")
         return
 
@@ -169,7 +176,7 @@ def remove_required_check(repo: str, context: str, token: str) -> None:
     path = f"/repos/{OWNER}/{repo}/branches/main/protection/required_status_checks"
     try:
         current = _api("GET", path, token=token)
-        existing: list[str] = current.get("contexts", [])
+        existing: list[str] = list(current.get("contexts") or [])
     except RuntimeError:
         print(f"  [{repo}] no branch protection found, skipping removal of: {context!r}")
         return
@@ -192,6 +199,11 @@ def _get_branch_protection_contexts(repo: str, token: str) -> set[str] | None:
 
     Returns the set of configured context strings, or None if the branch
     endpoint is unreachable or returns no protection data.
+
+    Reads from both 'contexts' (legacy) and 'checks' (current) arrays.
+    GitHub Settings UI writes required checks to the 'checks' array only;
+    reading only 'contexts' causes false C6-missing reports after an admin
+    configures checks via the Settings UI.
     """
     path = f"/repos/{OWNER}/{repo}/branches/main"
     try:
@@ -201,7 +213,12 @@ def _get_branch_protection_contexts(repo: str, token: str) -> set[str] | None:
         return None
     protection = data.get("protection") or {}
     rsc = protection.get("required_status_checks") or {}
-    return set(rsc.get("contexts", []))
+    contexts: set[str] = set(rsc.get("contexts") or [])
+    # Also extract from 'checks' array so Settings UI-configured checks are seen.
+    for item in (rsc.get("checks") or []):
+        if isinstance(item, dict) and item.get("context"):
+            contexts.add(item["context"])
+    return contexts
 
 
 def verify_required_checks_readonly(
@@ -250,6 +267,9 @@ def verify_required_checks(
 
     Returns True if all required checks are present and no deprecated checks
     remain. Prints a FAIL line for each discrepancy so CI logs are actionable.
+
+    Reads from both 'contexts' (legacy) and 'checks' (current) arrays so
+    checks configured via the GitHub Settings UI are detected as present.
     """
     repos = dict.fromkeys([r for r, _ in checks + deprecated])
     ok = True
@@ -257,7 +277,11 @@ def verify_required_checks(
         path = f"/repos/{OWNER}/{repo}/branches/main/protection/required_status_checks"
         try:
             current = _api("GET", path, token=token)
-            actual: set[str] = set(current.get("contexts", []))
+            actual: set[str] = set(current.get("contexts") or [])
+            # Also read from 'checks' array: Settings UI writes here, not 'contexts'.
+            for check in (current.get("checks") or []):
+                if isinstance(check, dict) and check.get("context"):
+                    actual.add(check["context"])
         except RuntimeError as exc:
             print(f"  [{repo}] FAIL: could not read required checks: {exc}")
             ok = False


### PR DESCRIPTION
## Summary

C6 (required status checks) is the sole remaining E2E robustness gap. The `apply-required-checks.yml` workflow correctly exits 1 (red badge) when checks are not yet configured. But there is a bug that prevents the badge from ever going green, even after the admin configures the checks:

**The bug:** `apply_required_status_checks.py` and `c6-health.yml` read only the `contexts` array when verifying branch protection state. GitHub's API has two arrays:
- `contexts` (legacy, deprecated): populated when checks are written via the deprecated contexts API field
- `checks` (current): populated when checks are configured via the **GitHub Settings UI** or the newer checks API field

When an admin uses the Settings UI (the fastest, zero-PAT path documented in issue #3970), GitHub writes required checks to `checks` only. The verify functions read only `contexts`, so they keep reporting C6 as missing. The admin sees no feedback that their action worked and the badge never self-heals.

## What this PR fixes

Three read paths updated to union both arrays:

| Location | Function | Fix |
|----------|----------|-----|
| `scripts/apply_required_status_checks.py` | `_get_branch_protection_contexts` | reads `contexts` + `checks` |
| `scripts/apply_required_status_checks.py` | `verify_required_checks` (PAT verify-after-apply) | reads `contexts` + `checks` |
| `scripts/apply_required_status_checks.py` | `add_required_check` (existence check) | checks both before adding, avoids duplicates |
| `.github/workflows/c6-health.yml` | `read_protection` | reads `contexts` + `checks` |

The write path (PATCH with `contexts`) is unchanged and correct: GitHub accepts either field and stores them internally; when reading back after an API write, checks appear in both arrays for backward compat. Only Settings UI writes go to `checks` only.

## Acceptance test

After merging and the admin runs the Settings UI steps in #3970:
- The next push to `main` triggers `apply-required-checks.yml`
- `verify_required_checks_readonly` now detects the UI-configured checks (via `checks` array)
- The workflow exits 0 (green badge) instead of 1
- `c6-health.yml` daily audit correctly reports `clawmetry/main: OK`
- C6 is marked green and the 7-day countdown begins

## No behavior change while checks are absent

While checks are genuinely not configured (current state), both `contexts` and `checks` arrays are empty, so the verify functions still exit 1. No false positives.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PuqoWgAcvjPeRUYcMKFzTq)_