### PR TITLE
feat(cli): `clawmetry bundle` — cheapest tier admitting a mixed 5-axis constraint bundle

### DIFF
--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -4568,6 +4568,185 @@ def _cmd_retention(args) -> None:
     print(f"  {override_env_name}: {env_display}")
 
 
+def _cmd_bundle(args) -> None:
+    """clawmetry bundle — cheapest tier admitting a mixed 5-axis constraint bundle.
+
+    Aggregate CLI sibling of :func:`_cmd_runtimes` / :func:`_cmd_features` /
+    :func:`_cmd_channels` / :func:`_cmd_nodes` / :func:`_cmd_retention`: each
+    of those answers ONE axis in isolation ("which runtimes does my tier
+    unlock?", "how many concurrent channels?"), this one folds a mixed
+    bundle across all five axes into ONE ``required_tier`` answer + the
+    full ``affordable_tiers`` ladder that would qualify.
+
+    Wraps :func:`clawmetry.entitlements.min_tier_for_all` (and
+    :func:`affordable_tiers`) -- the same helpers ``/api/entitlement/
+    required-tier`` and ``/api/entitlement/affordable-tiers`` consume --
+    so the CLI, the JSON API, and any dashboard pricing tooltip cannot
+    drift on the required-tier answer.
+
+    Args:
+      --features CSV       -- comma-separated feature ids (matches ``/required-tier?features=``)
+      --runtimes CSV       -- comma-separated runtime ids (matches ``/required-tier?runtimes=``)
+      --channels N         -- concurrent-channel count
+      --retention-days N   -- desired retention window in days
+      --nodes N            -- registered-node count
+      --tier <perspective> -- resolve from a hypothetical perspective tier
+                              (delegates to :func:`min_tier_for_all_at` /
+                              :func:`affordable_tiers_at`; the answer is
+                              perspective-independent by design, matching
+                              the ``_at`` family's parity guarantee, but
+                              the perspective is echoed on the payload so
+                              a pricing tooltip's "if I were on X" copy
+                              round-trips)
+      --json               -- emit the payload as JSON (jq-friendly)
+
+    Never raises. A poisoned resolver / helper collapses to the OSS-free
+    "no constraints" fallback shape (``required_tier=None``,
+    ``affordable_tiers=[]``, ``error`` populated on the JSON payload) so
+    a wrapper script always sees a parseable response -- matches the
+    never-crash contract documented on :func:`get_entitlement`.
+
+    Output:
+      default -- header block (tier / enforcement / perspective) + the
+                 constraint bundle echoed back + ``Required tier`` line
+                 + affordable-tiers table (id, label, status).
+      --json  -- ``{tier, grace, enforced, perspective, constraints:
+                 {features, runtimes, channels, retention_days, nodes},
+                 required_tier, required_tier_label, required_tier_rank,
+                 affordable_tiers:[...], error?: str}``
+    """
+    import json as _json
+
+    from clawmetry import entitlements as _ent
+
+    def _csv(raw):
+        if raw is None:
+            return []
+        parts = [p.strip().lower() for p in str(raw).split(",")]
+        return [p for p in parts if p]
+
+    def _int_or_none(raw):
+        if raw is None or raw == "":
+            return None
+        try:
+            return int(raw)
+        except (TypeError, ValueError):
+            return None
+
+    features = _csv(getattr(args, "features", None))
+    runtimes = _csv(getattr(args, "runtimes", None))
+    channels = _int_or_none(getattr(args, "channels", None))
+    retention_days = _int_or_none(getattr(args, "retention_days", None))
+    nodes = _int_or_none(getattr(args, "nodes", None))
+    perspective_raw = getattr(args, "perspective", None)
+    perspective = (perspective_raw or "").strip().lower() or None
+
+    try:
+        ent = _ent.get_entitlement()
+        tier = ent.tier
+        grace = bool(ent.grace)
+        enforced = _ent.is_enforced()
+    except Exception as exc:
+        print(f"⚠️  entitlement resolution failed: {exc}", file=sys.stderr)
+        tier, grace, enforced = "oss", True, False
+
+    perspective_unknown = False
+    if perspective is not None and perspective not in _ent._TIER_ORDER:
+        perspective_unknown = True
+
+    kwargs = dict(
+        features=features or None,
+        runtimes=runtimes or None,
+        channels=channels,
+        retention_days=retention_days,
+        nodes=nodes,
+    )
+
+    required_tier: str | None = None
+    ladder: list[dict] = []
+    resolve_error: str | None = None
+    if not perspective_unknown:
+        try:
+            if perspective:
+                required_tier = _ent.min_tier_for_all_at(perspective, **kwargs)
+                ladder_raw = _ent.affordable_tiers_at(perspective, **kwargs)
+            else:
+                required_tier = _ent.min_tier_for_all(**kwargs)
+                ladder_raw = _ent.affordable_tiers(**kwargs)
+            ladder = list(ladder_raw) if ladder_raw else []
+        except Exception as exc:
+            resolve_error = str(exc)
+
+    required_tier_label = _ent.tier_label(required_tier) if required_tier else None
+    required_tier_rank = _ent.tier_rank(required_tier) if required_tier else None
+
+    payload: dict = {
+        "tier": tier,
+        "grace": grace,
+        "enforced": enforced,
+        "perspective": perspective,
+        "constraints": {
+            "features": features,
+            "runtimes": runtimes,
+            "channels": channels,
+            "retention_days": retention_days,
+            "nodes": nodes,
+        },
+        "required_tier": required_tier,
+        "required_tier_label": required_tier_label,
+        "required_tier_rank": required_tier_rank,
+        "affordable_tiers": ladder,
+    }
+    if perspective_unknown:
+        payload["error"] = f"unknown perspective tier: {perspective_raw}"
+    elif resolve_error:
+        payload["error"] = resolve_error
+
+    if getattr(args, "as_json", False):
+        print(_json.dumps(payload, indent=2, sort_keys=True))
+        return
+
+    mode_line = "off (grace)" if not enforced else "on"
+    print("ClawMetry Bundle\n" + "─" * 40)
+    print(f"  Tier:            {tier}")
+    print(f"  Enforcement:     {mode_line}")
+    if perspective:
+        note = " (unknown -- ignored)" if perspective_unknown else ""
+        print(f"  Perspective:     {perspective}{note}")
+    print()
+    print("  Constraints")
+    feat_line = ", ".join(features) if features else "(none)"
+    rt_line = ", ".join(runtimes) if runtimes else "(none)"
+    ch_line = str(channels) if channels is not None else "(unset)"
+    rd_line = str(retention_days) if retention_days is not None else "(unset)"
+    nd_line = str(nodes) if nodes is not None else "(unset)"
+    print(f"    Features:      {feat_line}")
+    print(f"    Runtimes:      {rt_line}")
+    print(f"    Channels:      {ch_line}")
+    print(f"    Retention (d): {rd_line}")
+    print(f"    Nodes:         {nd_line}")
+    print()
+    if payload.get("error"):
+        print(f"  ⚠️  {payload['error']}")
+        return
+    if required_tier is None:
+        print("  Required tier:   (no constraints supplied)")
+        return
+    label = required_tier_label or required_tier
+    print(f"  Required tier:   {required_tier}  ({label})")
+
+    if not ladder:
+        return
+    print()
+    print(f"  {'ID':<20} {'Label':<24} Status")
+    print("  " + "─" * 56)
+    for row in ladder:
+        rid = str(row.get("tier", ""))
+        rlabel = str(row.get("tier_label", rid))
+        status = "★ minimum" if row.get("is_minimum") else "  qualifies"
+        print(f"  {rid:<20} {rlabel:<24} {status}")
+
+
 def _cmd_diagnose(args) -> None:
     """clawmetry diagnose — surface the entitlement resolver inputs.
 
@@ -5531,6 +5710,58 @@ def main() -> None:
         ),
     )
 
+    # bundle — cheapest tier admitting a mixed 5-axis constraint bundle.
+    # Aggregate CLI sibling of `clawmetry {runtimes,features,channels,
+    # nodes,retention}` (each folds ONE axis); this folds a mixed bundle
+    # across ALL five axes into ONE required_tier + affordable-tiers
+    # ladder. Wraps `min_tier_for_all` / `affordable_tiers` so CLI, HTTP
+    # (`/api/entitlement/required-tier` + `/affordable-tiers`), and the
+    # dashboard pricing tooltip cannot drift on the fold answer.
+    p_bundle = sub.add_parser(
+        "bundle",
+        help=(
+            "Cheapest tier admitting a mixed features/runtimes/channels/"
+            "retention/nodes bundle"
+        ),
+    )
+    p_bundle.add_argument(
+        "--features", metavar="CSV", default=None,
+        help="Comma-separated feature ids (e.g. anomaly_detection,cost_optimizer)",
+    )
+    p_bundle.add_argument(
+        "--runtimes", metavar="CSV", default=None,
+        help="Comma-separated runtime ids (e.g. claude_code,cursor)",
+    )
+    p_bundle.add_argument(
+        "--channels", metavar="N", default=None,
+        help="Concurrent-channel count (capacity axis)",
+    )
+    p_bundle.add_argument(
+        "--retention-days", dest="retention_days", metavar="N", default=None,
+        help="Desired retention window in days (capacity axis)",
+    )
+    p_bundle.add_argument(
+        "--nodes", metavar="N", default=None,
+        help="Registered-node count (capacity axis)",
+    )
+    p_bundle.add_argument(
+        "--tier", dest="perspective", metavar="TIER", default=None,
+        help=(
+            "Resolve from a hypothetical perspective tier (delegates to "
+            "min_tier_for_all_at / affordable_tiers_at; the perspective is "
+            "echoed on the payload but does not shape the answer)"
+        ),
+    )
+    p_bundle.add_argument(
+        "--json", action="store_true", dest="as_json",
+        help=(
+            "Emit {tier, grace, enforced, perspective, constraints, "
+            "required_tier, affordable_tiers:[...], error?: str} JSON "
+            "(jq-friendly). Mirrors /api/entitlement/required-tier + "
+            "/affordable-tiers on the shared keys."
+        ),
+    )
+
     # extensions — surface loaded / failed entry-point plugins and event hooks
     # from the shell so an operator can answer "did clawmetry-pro actually
     # load on this node?" without curl'ing /api/extensions or tailing daemon
@@ -5618,6 +5849,7 @@ def main() -> None:
         "channels",
         "nodes",
         "retention",
+        "bundle",
         "extensions",
         "diagnose",
         "verify-integrity",
@@ -5669,6 +5901,8 @@ def main() -> None:
             _cmd_nodes(args)
         elif args.cmd == "retention":
             _cmd_retention(args)
+        elif args.cmd == "bundle":
+            _cmd_bundle(args)
         elif args.cmd == "extensions":
             _cmd_extensions(args)
         elif args.cmd == "diagnose":

--- a/tests/test_cli_bundle_subcommand.py
+++ b/tests/test_cli_bundle_subcommand.py
@@ -1,0 +1,262 @@
+"""Tests for the ``clawmetry bundle`` CLI subcommand.
+
+Aggregate CLI sibling of ``clawmetry {runtimes,features,channels,nodes,
+retention}`` -- each of those folds ONE entitlement axis in isolation,
+``bundle`` folds a mixed 5-axis bundle into ONE ``required_tier`` +
+``affordable_tiers`` ladder. The command wraps
+:func:`clawmetry.entitlements.min_tier_for_all` /
+:func:`affordable_tiers` (and their ``_at`` perspective siblings) so
+these tests pin CLI -> helper delegation, the never-crash contract, the
+``--json`` shape, the ``--tier`` perspective-independent parity, and the
+subparser/dispatch registration.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+
+import pytest
+
+
+@pytest.fixture
+def cli_mod(monkeypatch, tmp_path):
+    """Fresh entitlements module with HOME pointed at an empty tmp dir so
+    the bundle fold is rendered against the OSS-free default and never
+    against a license that happens to live on the host."""
+    import importlib
+
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    import clawmetry.entitlements as ent
+
+    importlib.reload(ent)
+    ent.invalidate()
+
+    import clawmetry.cli as cli  # imported after entitlements is rebuilt
+
+    yield cli
+    ent.invalidate()
+
+
+def _ns(**kw) -> argparse.Namespace:
+    defaults = dict(
+        features=None,
+        runtimes=None,
+        channels=None,
+        retention_days=None,
+        nodes=None,
+        perspective=None,
+        as_json=False,
+    )
+    defaults.update(kw)
+    return argparse.Namespace(**defaults)
+
+
+def test_bundle_empty_bundle_reports_no_constraints(cli_mod, capsys):
+    """No axes supplied → required_tier=None + explanatory line, never a stack."""
+    cli_mod._cmd_bundle(_ns())
+    out = capsys.readouterr().out
+    assert "ClawMetry Bundle" in out
+    assert "no constraints supplied" in out
+    # The affordable-tiers table must not render when there is no floor.
+    assert "★ minimum" not in out
+    assert "qualifies" not in out
+
+
+def test_bundle_empty_bundle_json_shape(cli_mod, capsys):
+    """JSON payload for the empty-bundle path is the documented shape."""
+    import clawmetry.entitlements as ent
+
+    cli_mod._cmd_bundle(_ns(as_json=True))
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["tier"] == ent.TIER_OSS
+    assert payload["grace"] is True
+    assert payload["enforced"] is False
+    assert payload["perspective"] is None
+    assert payload["required_tier"] is None
+    assert payload["required_tier_label"] is None
+    assert payload["required_tier_rank"] is None
+    assert payload["affordable_tiers"] == []
+    assert payload["constraints"] == {
+        "features": [],
+        "runtimes": [],
+        "channels": None,
+        "retention_days": None,
+        "nodes": None,
+    }
+    assert "error" not in payload
+
+
+def test_bundle_delegates_to_min_tier_for_all(cli_mod, capsys):
+    """CLI answer matches :func:`min_tier_for_all` byte-for-byte on the fold."""
+    import clawmetry.entitlements as ent
+
+    kwargs = dict(
+        features=["anomaly_detection", "self_evolve"],
+        runtimes=["claude_code", "cursor"],
+        channels=10,
+        retention_days=30,
+        nodes=3,
+    )
+    expected = ent.min_tier_for_all(**kwargs)
+    expected_ladder = ent.affordable_tiers(**kwargs)
+
+    cli_mod._cmd_bundle(_ns(
+        as_json=True,
+        features="anomaly_detection,self_evolve",
+        runtimes="claude_code,cursor",
+        channels="10",
+        retention_days="30",
+        nodes="3",
+    ))
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["required_tier"] == expected
+    assert payload["affordable_tiers"] == expected_ladder
+    assert payload["constraints"] == {
+        "features": ["anomaly_detection", "self_evolve"],
+        "runtimes": ["claude_code", "cursor"],
+        "channels": 10,
+        "retention_days": 30,
+        "nodes": 3,
+    }
+
+
+def test_bundle_human_table_lists_ladder(cli_mod, capsys):
+    """The human table renders every qualifying tier row and marks the minimum."""
+    cli_mod._cmd_bundle(_ns(
+        features="anomaly_detection",
+        channels="10",
+    ))
+    out = capsys.readouterr().out
+    assert "Required tier:" in out
+    assert "★ minimum" in out
+    # The minimum row must appear exactly once.
+    assert out.count("★ minimum") == 1
+
+
+def test_bundle_perspective_matches_bare(cli_mod, capsys):
+    """The ``_at`` perspective must NOT shape the answer (parity guarantee)."""
+    import clawmetry.entitlements as ent
+
+    perspective_answers: list[dict] = []
+    for perspective in ent._TIER_ORDER:
+        cli_mod._cmd_bundle(_ns(
+            as_json=True,
+            features="anomaly_detection",
+            channels="25",
+            perspective=perspective,
+        ))
+        perspective_answers.append(json.loads(capsys.readouterr().out))
+
+    cli_mod._cmd_bundle(_ns(
+        as_json=True,
+        features="anomaly_detection",
+        channels="25",
+    ))
+    bare = json.loads(capsys.readouterr().out)
+
+    for row in perspective_answers:
+        assert row["required_tier"] == bare["required_tier"]
+        assert row["affordable_tiers"] == bare["affordable_tiers"]
+        # The perspective is echoed on the payload but must not change the fold.
+        assert row["perspective"] in ent._TIER_ORDER
+
+
+def test_bundle_unknown_perspective_is_surfaced_not_crashed(cli_mod, capsys):
+    """An unknown ``--tier`` renders an error line and empty required_tier."""
+    cli_mod._cmd_bundle(_ns(
+        features="anomaly_detection",
+        perspective="not_a_tier",
+    ))
+    out = capsys.readouterr().out
+    assert "unknown perspective tier: not_a_tier" in out
+    # JSON path is also graceful and carries the ``error`` key.
+    cli_mod._cmd_bundle(_ns(
+        as_json=True,
+        features="anomaly_detection",
+        perspective="not_a_tier",
+    ))
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["required_tier"] is None
+    assert payload["affordable_tiers"] == []
+    assert "unknown perspective tier: not_a_tier" in payload["error"]
+    assert payload["perspective"] == "not_a_tier"
+
+
+def test_bundle_non_int_capacity_axis_collapses_not_crashes(cli_mod, capsys):
+    """A typo like ``--channels abc`` must collapse the axis to ``None`` and
+    never crash -- per the never-raise contract on :func:`get_entitlement`."""
+    cli_mod._cmd_bundle(_ns(
+        as_json=True,
+        features="anomaly_detection",
+        channels="abc",
+        retention_days="not_a_number",
+        nodes="",
+    ))
+    payload = json.loads(capsys.readouterr().out)
+    # The non-int values collapsed to None so only the features axis contributes.
+    assert payload["constraints"]["channels"] is None
+    assert payload["constraints"]["retention_days"] is None
+    assert payload["constraints"]["nodes"] is None
+    # A single axis still resolves an answer -- min_tier_for_all wins on features alone.
+    import clawmetry.entitlements as ent
+    assert payload["required_tier"] == ent.min_tier_for_all(features=["anomaly_detection"])
+
+
+def test_bundle_falls_back_when_resolver_errors(cli_mod, capsys, monkeypatch):
+    """A poisoned :func:`min_tier_for_all` must not crash the CLI."""
+    import clawmetry.entitlements as ent
+
+    def _boom(**_kwargs):
+        raise RuntimeError("synthetic bundle failure")
+
+    monkeypatch.setattr(ent, "min_tier_for_all", _boom)
+    cli_mod._cmd_bundle(_ns(
+        as_json=True,
+        features="anomaly_detection",
+    ))
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["required_tier"] is None
+    assert payload["affordable_tiers"] == []
+    assert "synthetic bundle failure" in payload["error"]
+
+
+def test_bundle_grace_and_enforce_yield_identical_fold(cli_mod, capsys, monkeypatch):
+    """The ``bundle`` answer is decoupled from the resolved entitlement -- it
+    walks the static per-tier caps -- so grace vs enforce must yield the
+    same required_tier and ladder for a given bundle."""
+    import clawmetry.entitlements as ent
+
+    cli_mod._cmd_bundle(_ns(
+        as_json=True,
+        features="anomaly_detection",
+        channels="10",
+    ))
+    grace = json.loads(capsys.readouterr().out)
+
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    cli_mod._cmd_bundle(_ns(
+        as_json=True,
+        features="anomaly_detection",
+        channels="10",
+    ))
+    enforce = json.loads(capsys.readouterr().out)
+
+    assert grace["required_tier"] == enforce["required_tier"]
+    assert grace["affordable_tiers"] == enforce["affordable_tiers"]
+    assert grace["enforced"] is False
+    assert enforce["enforced"] is True
+
+
+def test_bundle_subcommand_is_registered():
+    """The subparser + dispatch table must list ``bundle`` so it is reachable
+    from the CLI entry point."""
+    import inspect
+
+    import clawmetry.cli as cli
+
+    src = inspect.getsource(cli.main)
+    assert '"bundle"' in src
+    assert "_cmd_bundle" in src


### PR DESCRIPTION
## Summary

Aggregate CLI sibling of `clawmetry {runtimes,features,channels,nodes,retention}`: each of those answers ONE entitlement axis in isolation, `bundle` folds a mixed bundle across ALL five axes into ONE `required_tier` + `affordable_tiers` ladder in one shell call.

Wraps `clawmetry.entitlements.min_tier_for_all` / `affordable_tiers` (and the `_at` perspective siblings via `--tier`) — the same helpers `/api/entitlement/required-tier` and `/api/entitlement/affordable-tiers` consume — so CLI, HTTP, and the dashboard pricing tooltip cannot drift on the fold answer.

## Usage

```
clawmetry bundle \
  --features anomaly_detection,self_evolve \
  --runtimes claude_code,cursor \
  --channels 10 --retention-days 30 --nodes 3

ClawMetry Bundle
────────────────────────────────────────
  Tier:            oss
  Enforcement:     off (grace)

  Constraints
    Features:      anomaly_detection, self_evolve
    Runtimes:      claude_code, cursor
    Channels:      10
    Retention (d): 30
    Nodes:         3

  Required tier:   cloud_pro  (Pro)

  ID                   Label                    Status
  ────────────────────────────────────────────────────────
  cloud_pro            Pro                      ★ minimum
  pro                  Self-hosted Pro            qualifies
  enterprise           Enterprise                 qualifies
```

`clawmetry bundle --json` emits the payload verbatim for scriptable consumers; `--tier <perspective>` reroutes through `min_tier_for_all_at` / `affordable_tiers_at` and echoes the perspective on the payload without shaping the answer (matches the `_at` family's parity guarantee).

## Changes

**New CLI subcommand** in `clawmetry/cli.py`:

- `_cmd_bundle(args)` — folds the 5-axis bundle via `min_tier_for_all` / `affordable_tiers` (or their `_at` siblings). Never raises: unknown perspective / non-int capacity / resolver crash all collapse to the OSS-free grace-shape (`required_tier=None`, `affordable_tiers=[]`, `error` populated on JSON). Matches the never-crash contract on `get_entitlement`.
- `p_bundle` subparser with `--features CSV`, `--runtimes CSV`, `--channels N`, `--retention-days N`, `--nodes N`, `--tier TIER` (perspective), `--json`.
- `bundle` registered in `_subcmds` + dispatched in `main()` alongside the other per-axis subcommands.

**Tests** (`tests/test_cli_bundle_subcommand.py`, 10 cases):

- Empty bundle → `no constraints supplied` line + documented JSON shape.
- Delegates to `min_tier_for_all` / `affordable_tiers` byte-for-byte on `required_tier` + `affordable_tiers`.
- Human table renders the ladder and marks the minimum row exactly once.
- Perspective parity: every `_TIER_ORDER` perspective produces the same fold as the bare helper.
- Unknown `--tier` surfaces on both text and JSON paths, never crashes.
- Non-int capacity axis collapses to `None` (typo like `--channels abc`).
- Poisoned resolver falls back to grace-shape.
- Grace vs enforce yield byte-identical folds (the `bundle` answer walks static per-tier caps, not the resolved entitlement).
- Subparser + dispatch registration is exercised via `inspect.getsource(cli.main)`.

Behaviour-neutral for existing callers — this is a new read-only CLI subcommand wrapping existing helpers. Grace posture preserved end-to-end.

## Test plan

- [x] `python3 -m py_compile clawmetry/cli.py tests/test_cli_bundle_subcommand.py`
- [x] `python3 -m pytest tests/test_cli_bundle_subcommand.py -q` — 10 passed
- [x] Sibling CLI regression: `pytest tests/test_cli_{runtimes,features,channels,nodes,retention,diagnose}_subcommand.py -q` — 51 passed
- [x] Manual `_cmd_bundle(...)` smoke tests: empty / mixed / perspective / unknown perspective / typo capacity → every path graceful

## Local operator verification checklist

Since this session cannot reach the operator's local daemon or live cloud snapshot:

- [ ] `cp clawmetry/cli.py ~/.clawmetry/lib/python*/site-packages/clawmetry/` (adjust for the daemon's venv layout).
- [ ] Clear stale bytecode: `find ~/.clawmetry -name __pycache__ -type d -exec rm -rf {} + 2>/dev/null`.
- [ ] Kick the daemon: `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` (or the equivalent on non-macOS).
- [ ] `clawmetry bundle --help` — expect the new subcommand to render with every flag documented.
- [ ] `clawmetry bundle --features anomaly_detection,self_evolve --runtimes claude_code,cursor --channels 10 --retention-days 30 --nodes 3` — expect the header + constraints + `Required tier: cloud_pro` + ladder table.
- [ ] `clawmetry bundle --json --features anomaly_detection --channels 5` — expect the JSON payload documented above, parseable with `jq`.
- [ ] `clawmetry bundle --tier cloud_starter --features anomaly_detection` — expect the same `required_tier` as the bare call (perspective-independent parity).
- [ ] `clawmetry bundle --tier bogus --features anomaly_detection` — expect `⚠️ unknown perspective tier: bogus` + `required_tier: null` (never a stack trace).
- [ ] `clawmetry bundle --channels abc` — expect the axis to collapse to `null` on the JSON payload, no crash.
- [ ] `clawmetry bundle` (empty) — expect `Required tier: (no constraints supplied)`.
- [ ] `curl -s http://localhost:8900/api/entitlement | jq` — sanity check the resolver still boots (this PR does not touch resolver or endpoints).
- [ ] Decrypt the live cloud snapshot and confirm the encrypted daemon push still round-trips (this PR does not touch `sync.py` or the crypto layer, so no drift expected — sanity check only).
- [ ] Ready this PR for review only after the CLI subcommand looks right against the local daemon.

Kept **DRAFT** — do not merge, do not tag, do not bump `__version__`. Local operator handles the release loop per `FLYWHEEL.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_017cUoMDJrBf85wNi8mBJ8u5)_