### PR TITLE
fix(c6): schedule-heal reads both contexts+checks arrays in status display

### DIFF
--- a/.github/workflows/c6-schedule-heal.yml
+++ b/.github/workflows/c6-schedule-heal.yml
@@ -57,6 +57,12 @@ jobs:
       # scope needed) to read the current protection.required_status_checks.
       # Writes a formatted summary to GITHUB_STEP_SUMMARY so the state is
       # visible directly in the job summary panel without reading log lines.
+      #
+      # NOTE: reads BOTH 'contexts' (legacy, written by API/script) AND
+      # 'checks' (current, written by GitHub Settings UI). Previously only
+      # 'contexts' was read, so checks configured via Option A (Settings UI)
+      # appeared as MISSING even though they were correctly configured.
+      # This matches the logic in c6-health.yml and apply_required_status_checks.py.
       - name: Read current required-check state (read-only)
         env:
           GH_TOKEN: ${{ github.token }}
@@ -74,8 +80,26 @@ jobs:
           ALL_OK=true
           SUMMARY_ROWS=""
           for REPO in $REPOS; do
-            PROTECTION=$(gh api "/repos/${OWNER}/${REPO}/branches/main" \
-              --jq '.protection.required_status_checks.contexts // []' 2>/dev/null || echo "[]")
+            # Read BOTH 'contexts' (legacy API/script path) AND 'checks'
+            # (GitHub Settings UI path) into a single sorted JSON array.
+            # The old jq query (.protection.required_status_checks.contexts // [])
+            # only read the legacy array, causing false MISSING reports after
+            # an admin used Option A (Settings UI) to configure required checks.
+            PROTECTION=$(gh api "/repos/${OWNER}/${REPO}/branches/main" 2>/dev/null | \
+              python3 -c "
+import json, sys
+try:
+    data = json.load(sys.stdin)
+    prot = (data.get('protection') or {})
+    rsc = (prot.get('required_status_checks') or {})
+    ctx = set(rsc.get('contexts') or [])
+    for item in (rsc.get('checks') or []):
+        if isinstance(item, dict) and item.get('context'):
+            ctx.add(item['context'])
+    print(json.dumps(sorted(ctx)))
+except Exception:
+    print('[]')
+" || echo "[]")
             IFS='|' read -ra EXPECTED_CHECKS <<< "${EXPECTED[$REPO]}"
             for CHECK in "${EXPECTED_CHECKS[@]}"; do
               if echo "$PROTECTION" | python3 -c \


### PR DESCRIPTION
## Summary

- Fixes a false-negative in `c6-schedule-heal.yml`'s read-only summary step
- After an admin configures required checks via **Option A (GitHub Settings UI)**, those checks land in the `checks` array, not `contexts`. The old `--jq '.protection.required_status_checks.contexts // []'` only read the legacy array, so the daily heal kept reporting every check as **MISSING** and exiting 1 even though C6 was correctly configured.
- Replaces the jq query with a Python extraction (matching `c6-health.yml` and `apply_required_status_checks.py`) that merges both `contexts` and `checks` into one set before the per-check comparison.

## What changed

`c6-schedule-heal.yml` read-only status step: one block replaced.

**Before:**
```bash
PROTECTION=$(gh api "/repos/${OWNER}/${REPO}/branches/main" \
  --jq '.protection.required_status_checks.contexts // []' 2>/dev/null || echo "[]")
```

**After:**
```bash
PROTECTION=$(gh api "/repos/${OWNER}/${REPO}/branches/main" 2>/dev/null | \
  python3 -c "
import json, sys
try:
    data = json.load(sys.stdin)
    prot = (data.get('protection') or {})
    rsc = (prot.get('required_status_checks') or {})
    ctx = set(rsc.get('contexts') or [])
    for item in (rsc.get('checks') or []):
        if isinstance(item, dict) and item.get('context'):
            ctx.add(item['context'])
    print(json.dumps(sorted(ctx)))
except Exception:
    print('[]')
" || echo "[]")
```

No changes to the apply path (`apply_required_status_checks.py`) -- that already reads both arrays correctly. No changes to `c6-health.yml` -- same fix was already there.

## Acceptance test

Trigger `c6-schedule-heal` via workflow_dispatch after configuring one required check via Settings UI. Job summary must show that check as OK, not MISSING.

## Context

Part of E2E Robustness epic (C6 -- required status checks). C1-C5 and C7 are all green. C6 is the sole remaining gap -- blocked on admin adding required checks to main branch protection. This fix ensures the daily health badge accurately reflects what is configured, so the admin gets clean signal after doing the Settings UI action.

Tracking: vivekchand/clawmetry#3970

---
_Generated by [Claude Code](https://claude.ai/code/session_01R468Fmr5fBAutoWGqB95y6)_