### PR TITLE
feat(paywall): filter kwargs on /api/paywall/events/summary (mirror of /recent)

### DIFF
--- a/clawmetry/_paywall_events.py
+++ b/clawmetry/_paywall_events.py
@@ -234,7 +234,15 @@ class _PaywallEventStore:
             # Genuinely defensive -- record must never leak into the 204 route.
             logger.debug("paywall.events: record swallowed error: %s", exc)
 
-    def summary(self) -> dict:
+    def summary(
+        self,
+        *,
+        event: str | None = None,
+        feature: str | None = None,
+        harness: str | None = None,
+        source: str | None = None,
+        plan_chosen: str | None = None,
+    ) -> dict:
         """Return a JSON-safe aggregate snapshot of the current ring.
 
         Aggregations (``by_event`` etc.) reflect ONLY the events currently
@@ -246,9 +254,33 @@ class _PaywallEventStore:
         from the per-key dicts so a mostly-empty payload doesn't flood
         every dimension's tally with an ``""`` bucket.
 
+        Optional keyword filters (``event`` / ``feature`` / ``harness`` /
+        ``source`` / ``plan_chosen``) narrow the aggregation to rows whose
+        corresponding field matches the supplied value exactly. Same
+        semantics as :meth:`recent` / :meth:`count_matching`: ``None`` or
+        empty-string means "not supplied", case-sensitive exact match,
+        ``AND`` combined. With no filters the returned shape is byte-
+        identical to the pre-filter contract EXCEPT for the always-present
+        ``filters`` and ``matched`` fields (added below).
+
+        ``filters`` echoes the applied filter set (empty dict when none
+        supplied) so a caller can distinguish "I asked for feature=X and
+        got 0 rows" from "I asked for nothing and got 0 rows". ``matched``
+        is the count of rows the ``by_*`` aggregation was computed over --
+        byte-equal to ``in_window`` on an unfiltered call, otherwise the
+        pre-aggregation subset size. Process-lifetime counters
+        (``total``, ``dropped``, ``first_ts``, ``last_ts``, ``capacity``)
+        are NOT sliced by the filters -- they describe the ring itself, not
+        the subset the caller cares about, and slicing them would silently
+        under-report churn to a filtered dashboard tile.
+
         Never raises.
         """
         try:
+            filters = _normalise_filters(
+                event=event, feature=feature, harness=harness,
+                source=source, plan_chosen=plan_chosen,
+            )
             with self._lock:
                 snap = list(self._ring)
                 total = self._total
@@ -257,12 +289,17 @@ class _PaywallEventStore:
                 last_ts = self._last_ts
                 capacity = self._capacity
 
+            if filters:
+                bucket = [e for e in snap if _row_matches_filters(e, filters)]
+            else:
+                bucket = snap
+
             by_event: Counter = Counter()
             by_feature: Counter = Counter()
             by_harness: Counter = Counter()
             by_source: Counter = Counter()
             by_plan: Counter = Counter()
-            for e in snap:
+            for e in bucket:
                 if e.get("event"):
                     by_event[e["event"]] += 1
                 if e.get("feature"):
@@ -286,6 +323,8 @@ class _PaywallEventStore:
                 "by_harness": dict(by_harness),
                 "by_source": dict(by_source),
                 "by_plan_chosen": dict(by_plan),
+                "filters": dict(filters),
+                "matched": len(bucket),
             }
         except Exception as exc:
             logger.warning("paywall.events: summary swallowed error: %s", exc)
@@ -301,6 +340,8 @@ class _PaywallEventStore:
                 "by_harness": {},
                 "by_source": {},
                 "by_plan_chosen": {},
+                "filters": {},
+                "matched": 0,
             }
 
     def recent(
@@ -422,9 +463,25 @@ def record_event(payload: Any) -> None:
     _STORE.record(payload)
 
 
-def summary() -> dict:
-    """Public shim for ``GET /api/paywall/events/summary``."""
-    return _STORE.summary()
+def summary(
+    *,
+    event: str | None = None,
+    feature: str | None = None,
+    harness: str | None = None,
+    source: str | None = None,
+    plan_chosen: str | None = None,
+) -> dict:
+    """Public shim for ``GET /api/paywall/events/summary``.
+
+    Filter kwargs are optional; a ``None`` or empty-string value means
+    "not supplied" and does not restrict on that dimension. See
+    :meth:`_PaywallEventStore.summary` for the filter contract and the
+    exact response shape (always includes ``filters`` and ``matched``).
+    """
+    return _STORE.summary(
+        event=event, feature=feature, harness=harness,
+        source=source, plan_chosen=plan_chosen,
+    )
 
 
 def recent(

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -7155,21 +7155,43 @@ def api_paywall_events_summary():
     """``GET /api/paywall/events/summary`` -- rolling in-process aggregate
     of client-side ``POST /api/paywall/event`` beacons.
 
+    Optional filter query params narrow the aggregation to rows whose
+    corresponding field matches the supplied value exactly (case-
+    sensitive, ``AND``-combined). Same names + semantics as
+    ``/api/paywall/events/recent`` so a dashboard tile can bind one
+    filter set to both endpoints without translation::
+
+      ?event=<paywall_view|paywall_cta_click|...>
+      ?feature=<feature-key>
+      ?harness=<harness-key>
+      ?source=<source-key>
+      ?plan_chosen=<plan-code>
+
     Body shape::
 
         {
           "total": <int>,        # all-time recorded events (survives eviction)
-          "in_window": <int>,    # currently in the ring
+          "in_window": <int>,    # currently in the ring, unfiltered
           "dropped": <int>,      # events evicted by ring rotation
           "capacity": <int>,     # ring size (CLAWMETRY_PAYWALL_EVENT_CAPACITY)
           "first_ts": <float|null>,  # epoch seconds of first-ever event
           "last_ts":  <float|null>,  # epoch seconds of most-recent event
-          "by_event": {"<name>": <int>, ...},        # in-window
+          "by_event": {"<name>": <int>, ...},        # in-window, post-filter
           "by_feature": {"<key>":  <int>, ...},
           "by_harness": {"<key>":  <int>, ...},
           "by_source":  {"<key>":  <int>, ...},
-          "by_plan_chosen": {"<plan>": <int>, ...}
+          "by_plan_chosen": {"<plan>": <int>, ...},
+          "filters": {"<key>": "<value>", ...},      # echo of applied filters
+          "matched": <int>                           # rows the by_* aggregate covers
         }
+
+    Process-lifetime counters (``total``, ``dropped``, ``first_ts``,
+    ``last_ts``, ``capacity``) and ``in_window`` are NEVER filtered --
+    they describe the ring itself, not the subset the caller cares about,
+    so a filtered dashboard tile can still see churn / evictions in
+    context. The ``by_*`` breakdowns and ``matched`` count reflect the
+    filtered subset. On an unfiltered request ``matched`` byte-equals
+    ``in_window``.
 
     Ships in GRACE -- no entitlement gate, no capacity accounting. Grace-
     mode read of a grace-mode write.
@@ -7180,7 +7202,11 @@ def api_paywall_events_summary():
     try:
         from clawmetry import _paywall_events as _pe
 
-        return jsonify(_pe.summary())
+        filter_kwargs = {
+            key: request.args.get(key, "") or None
+            for key in ("event", "feature", "harness", "source", "plan_chosen")
+        }
+        return jsonify(_pe.summary(**filter_kwargs))
     except Exception as exc:
         logger.warning("api_paywall_events_summary: error: %s", exc)
         return jsonify(
@@ -7196,6 +7222,8 @@ def api_paywall_events_summary():
                 "by_harness": {},
                 "by_source": {},
                 "by_plan_chosen": {},
+                "filters": {},
+                "matched": 0,
             }
         )
 

--- a/tests/test_paywall_events_api.py
+++ b/tests/test_paywall_events_api.py
@@ -90,12 +90,15 @@ def test_summary_reflects_prior_paywall_event_posts(client):
 def test_summary_shape_is_stable(client):
     """A pricing dashboard tile binds to a fixed set of keys. If the
     endpoint ever drops one, tiles blank silently -- pin the full key
-    set."""
+    set. ``filters`` and ``matched`` are the always-present mirror of
+    ``/api/paywall/events/recent`` so a tile binding one filter set to
+    both endpoints reads the same shape from each."""
     body = client.get("/api/paywall/events/summary").get_json()
     expected = {
         "total", "in_window", "dropped", "capacity",
         "first_ts", "last_ts",
         "by_event", "by_feature", "by_harness", "by_source", "by_plan_chosen",
+        "filters", "matched",
     }
     assert set(body.keys()) == expected
 

--- a/tests/test_paywall_events_summary_filters.py
+++ b/tests/test_paywall_events_summary_filters.py
@@ -1,0 +1,359 @@
+"""Filter-aware ``summary`` tests for :mod:`clawmetry._paywall_events`
+and the ``GET /api/paywall/events/summary`` HTTP endpoint.
+
+Pairs with ``test_paywall_events_recent_filters.py`` -- the store's
+``summary(...)`` filter kwargs are the natural mirror of
+``recent(...)`` / ``count_matching(...)``, and both endpoints must accept
+the same filter contract so a dashboard tile can bind one filter set to
+both surfaces without translation.
+
+Invariants pinned:
+
+* Filter kwargs restrict the ``by_*`` aggregate to matching rows only.
+* Process-lifetime counters (``total`` / ``dropped`` / ``first_ts`` /
+  ``last_ts`` / ``capacity``) and unfiltered ``in_window`` are NEVER
+  sliced by the filters -- they describe the ring itself, not the
+  caller's subset, so a filtered tile can still see churn / evictions.
+* ``matched`` is byte-equal to ``in_window`` on an unfiltered call and
+  reflects the pre-aggregation subset size when filters are applied.
+* ``filters`` echoes the applied filter set (empty dict when none) so a
+  caller distinguishes "asked for nothing, got 0" from "asked for X, got 0".
+* Blank / whitespace-only filter values collapse to "not supplied"
+  matching the ``recent`` endpoint's contract.
+* Filters are ``AND`` combined, case-sensitive, and per-dimension
+  independent.
+* HTTP endpoint never 5xxs and always emits the two new fields.
+"""
+from __future__ import annotations
+
+import pytest
+from flask import Flask
+
+
+# ── store-level ─────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _fresh_store():
+    from clawmetry import _paywall_events as pe
+
+    pe.reset()
+    yield
+    pe.reset()
+
+
+def _seed(pe, rows):
+    for r in rows:
+        pe.record_event(r)
+
+
+def test_summary_no_filter_emits_filters_and_matched_fields():
+    """Backwards-compat + new-field contract: an unfiltered call still
+    matches the pre-filter shape AND now always includes ``filters={}``
+    and ``matched == in_window`` so callers can rely on the mirror."""
+    from clawmetry import _paywall_events as pe
+
+    _seed(pe, [
+        {"event": "paywall_view", "feature": "fleet"},
+        {"event": "paywall_cta_click", "feature": "fleet", "plan_chosen": "pro"},
+    ])
+    s = pe.summary()
+    assert s["filters"] == {}
+    assert s["matched"] == s["in_window"] == 2
+    assert s["by_event"] == {"paywall_view": 1, "paywall_cta_click": 1}
+
+
+def test_summary_filter_by_event_restricts_by_star_aggregates():
+    from clawmetry import _paywall_events as pe
+
+    _seed(pe, [
+        {"event": "paywall_view", "feature": "fleet"},
+        {"event": "paywall_view", "feature": "anomaly"},
+        {"event": "paywall_cta_click", "feature": "fleet", "plan_chosen": "pro"},
+    ])
+    s = pe.summary(event="paywall_view")
+    assert s["filters"] == {"event": "paywall_view"}
+    assert s["matched"] == 2
+    assert s["by_event"] == {"paywall_view": 2}
+    assert s["by_feature"] == {"fleet": 1, "anomaly": 1}
+    # No CTA rows in the subset -- plan_chosen bucket must not leak.
+    assert s["by_plan_chosen"] == {}
+    # in_window reflects the FULL ring, not the filtered subset.
+    assert s["in_window"] == 3
+
+
+def test_summary_filter_by_feature_isolates_plan_chosen_slice():
+    """The motivating use case: a dashboard tile filtered to feature=fleet
+    asks 'which plans did fleet CTA clicks convert to?' and must see only
+    fleet-scoped plan_chosen counts."""
+    from clawmetry import _paywall_events as pe
+
+    _seed(pe, [
+        {"event": "paywall_cta_click", "feature": "fleet",   "plan_chosen": "pro"},
+        {"event": "paywall_cta_click", "feature": "fleet",   "plan_chosen": "pro"},
+        {"event": "paywall_cta_click", "feature": "fleet",   "plan_chosen": "starter"},
+        {"event": "paywall_cta_click", "feature": "anomaly", "plan_chosen": "pro"},
+        {"event": "paywall_cta_click", "feature": "anomaly", "plan_chosen": "starter"},
+    ])
+    s = pe.summary(feature="fleet")
+    assert s["matched"] == 3
+    assert s["by_feature"] == {"fleet": 3}
+    assert s["by_plan_chosen"] == {"pro": 2, "starter": 1}
+    # anomaly-scoped rows must not leak in.
+    assert "anomaly" not in s["by_feature"]
+
+
+def test_summary_and_combines_filters():
+    from clawmetry import _paywall_events as pe
+
+    _seed(pe, [
+        {"event": "paywall_view",       "feature": "fleet"},
+        {"event": "paywall_cta_click",  "feature": "fleet", "plan_chosen": "pro"},
+        {"event": "paywall_cta_click",  "feature": "anomaly", "plan_chosen": "pro"},
+    ])
+    s = pe.summary(event="paywall_cta_click", feature="fleet")
+    assert s["filters"] == {"event": "paywall_cta_click", "feature": "fleet"}
+    assert s["matched"] == 1
+    assert s["by_plan_chosen"] == {"pro": 1}
+
+
+def test_summary_filter_mismatch_returns_empty_by_star_but_keeps_ring_stats():
+    from clawmetry import _paywall_events as pe
+
+    _seed(pe, [
+        {"event": "paywall_view", "feature": "fleet"},
+    ])
+    s = pe.summary(feature="does_not_exist")
+    assert s["matched"] == 0
+    assert s["filters"] == {"feature": "does_not_exist"}
+    assert s["by_event"] == {}
+    assert s["by_feature"] == {}
+    assert s["by_plan_chosen"] == {}
+    # Process-lifetime + unfiltered ring stats survive.
+    assert s["total"] == 1
+    assert s["in_window"] == 1
+    assert s["first_ts"] is not None
+    assert s["last_ts"] is not None
+
+
+def test_summary_blank_and_whitespace_filters_treated_as_not_supplied():
+    """Matches the recent-endpoint contract: an empty or whitespace-only
+    value collapses to "not supplied" so ``?feature=`` on the URL does
+    not accidentally match rows with no feature."""
+    from clawmetry import _paywall_events as pe
+
+    _seed(pe, [
+        {"event": "paywall_view", "feature": "fleet"},
+    ])
+    for blank in ("", "   ", "\t", None):
+        s = pe.summary(feature=blank)
+        assert s["filters"] == {}, f"blank {blank!r} leaked into filters"
+        assert s["matched"] == 1
+
+
+def test_summary_filter_is_case_sensitive():
+    from clawmetry import _paywall_events as pe
+
+    _seed(pe, [
+        {"event": "paywall_view", "feature": "Fleet"},
+    ])
+    assert pe.summary(feature="Fleet")["matched"] == 1
+    assert pe.summary(feature="fleet")["matched"] == 0
+
+
+def test_summary_process_lifetime_counters_survive_filter():
+    """Filters must never scale down ``total`` / ``dropped`` /
+    ``capacity`` / ``in_window`` -- those describe the ring itself, not
+    the caller's subset. A filtered dashboard tile must still see churn."""
+    from clawmetry import _paywall_events as pe
+
+    _seed(pe, [
+        {"event": "paywall_view", "feature": "fleet"},
+        {"event": "paywall_view", "feature": "anomaly"},
+        {"event": "paywall_view", "feature": "anomaly"},
+    ])
+    filtered = pe.summary(feature="fleet")
+    unfiltered = pe.summary()
+    assert filtered["total"] == unfiltered["total"] == 3
+    assert filtered["in_window"] == unfiltered["in_window"] == 3
+    assert filtered["dropped"] == unfiltered["dropped"] == 0
+    assert filtered["capacity"] == unfiltered["capacity"]
+    # But the by_* aggregate IS scaled.
+    assert filtered["matched"] == 1
+    assert filtered["by_feature"] == {"fleet": 1}
+
+
+def test_summary_shim_accepts_all_five_filter_dimensions():
+    """The public :func:`summary` shim must expose the same kwargs as
+    the store method so ``recent`` / ``count_matching`` / ``summary``
+    stay a coherent surface."""
+    from clawmetry import _paywall_events as pe
+
+    _seed(pe, [
+        {"event": "paywall_view",       "feature": "fleet",   "harness": "claude_code",
+         "source": "runtime-switcher",  "plan_chosen": ""},
+        {"event": "paywall_cta_click",  "feature": "fleet",   "harness": "codex",
+         "source": "sidebar",           "plan_chosen": "pro"},
+        {"event": "paywall_view",       "feature": "anomaly", "harness": "claude_code",
+         "source": "runtime-switcher",  "plan_chosen": ""},
+    ])
+    for kwarg, value, expected in (
+        ("event",       "paywall_view",      2),
+        ("feature",     "fleet",             2),
+        ("harness",     "claude_code",       2),
+        ("source",      "runtime-switcher",  2),
+        ("plan_chosen", "pro",               1),
+    ):
+        s = pe.summary(**{kwarg: value})
+        assert s["matched"] == expected, f"{kwarg}={value!r} matched {s['matched']}, want {expected}"
+        assert s["filters"] == {kwarg: value}
+
+
+def test_summary_empty_store_with_filter_returns_zero_matched_and_echo():
+    from clawmetry import _paywall_events as pe
+
+    s = pe.summary(event="paywall_view")
+    assert s["matched"] == 0
+    assert s["in_window"] == 0
+    assert s["total"] == 0
+    assert s["filters"] == {"event": "paywall_view"}
+    assert s["by_event"] == {}
+
+
+# ── HTTP endpoint ───────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def client():
+    from routes.entitlement import bp_entitlement
+    from clawmetry import _paywall_events as pe
+
+    pe.reset()
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    app.config["TESTING"] = True
+    try:
+        yield app.test_client()
+    finally:
+        pe.reset()
+
+
+def _post(client, payload):
+    return client.post("/api/paywall/event", json=payload)
+
+
+def test_http_summary_no_filter_backwards_compatible(client):
+    """An unfiltered GET still returns every pre-filter key the
+    dashboard tile binds to, PLUS the new ``filters`` / ``matched`` mirror."""
+    _post(client, {"event": "paywall_view", "feature": "fleet"})
+    body = client.get("/api/paywall/events/summary").get_json()
+    assert body["total"] == 1
+    assert body["in_window"] == 1
+    assert body["by_event"] == {"paywall_view": 1}
+    assert body["by_feature"] == {"fleet": 1}
+    assert body["filters"] == {}
+    assert body["matched"] == body["in_window"]
+
+
+def test_http_summary_filter_by_feature(client):
+    _post(client, {"event": "paywall_cta_click", "feature": "fleet",   "plan_chosen": "pro"})
+    _post(client, {"event": "paywall_cta_click", "feature": "fleet",   "plan_chosen": "starter"})
+    _post(client, {"event": "paywall_cta_click", "feature": "anomaly", "plan_chosen": "pro"})
+    body = client.get("/api/paywall/events/summary?feature=fleet").get_json()
+    assert body["filters"] == {"feature": "fleet"}
+    assert body["matched"] == 2
+    assert body["in_window"] == 3
+    assert body["by_plan_chosen"] == {"pro": 1, "starter": 1}
+    # Ring stats unfiltered.
+    assert body["total"] == 3
+
+
+def test_http_summary_and_combines_multiple_query_params(client):
+    _post(client, {"event": "paywall_view",      "feature": "fleet"})
+    _post(client, {"event": "paywall_cta_click", "feature": "fleet",   "plan_chosen": "pro"})
+    _post(client, {"event": "paywall_cta_click", "feature": "anomaly", "plan_chosen": "pro"})
+    body = client.get(
+        "/api/paywall/events/summary?event=paywall_cta_click&feature=fleet"
+    ).get_json()
+    assert body["matched"] == 1
+    assert body["filters"] == {"event": "paywall_cta_click", "feature": "fleet"}
+    assert body["by_plan_chosen"] == {"pro": 1}
+
+
+def test_http_summary_blank_query_param_treated_as_not_supplied(client):
+    """?feature= (empty value) must NOT restrict on that dimension --
+    matching how ``/api/paywall/events/recent`` handles it."""
+    _post(client, {"event": "paywall_view", "feature": "fleet"})
+    body = client.get("/api/paywall/events/summary?feature=").get_json()
+    assert body["filters"] == {}
+    assert body["matched"] == 1
+
+
+def test_http_summary_filter_mismatch_returns_empty_aggregate_not_5xx(client):
+    _post(client, {"event": "paywall_view", "feature": "fleet"})
+    resp = client.get("/api/paywall/events/summary?feature=does_not_exist")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["matched"] == 0
+    assert body["by_feature"] == {}
+    assert body["filters"] == {"feature": "does_not_exist"}
+    # Ring stats survive the filter.
+    assert body["total"] == 1
+    assert body["in_window"] == 1
+
+
+def test_http_summary_fallback_shape_includes_new_fields(client, monkeypatch):
+    """Even the error-path neutral shape must carry ``filters`` +
+    ``matched`` so a caller can trust the top-level key set is stable."""
+    from clawmetry import _paywall_events as pe
+
+    def _boom(**kwargs):
+        raise RuntimeError("simulated store failure")
+
+    monkeypatch.setattr(pe, "summary", _boom)
+    resp = client.get("/api/paywall/events/summary?feature=fleet")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    for key in (
+        "total", "in_window", "dropped", "capacity", "first_ts", "last_ts",
+        "by_event", "by_feature", "by_harness", "by_source", "by_plan_chosen",
+        "filters", "matched",
+    ):
+        assert key in body, f"error-path fallback missing {key!r}"
+    assert body["matched"] == 0
+    assert body["filters"] == {}
+
+
+def test_http_summary_matches_recent_filter_names(client):
+    """Both endpoints must accept the same query-param names so a tile
+    can bind one filter set to both surfaces. Iterate every dimension
+    and confirm ``summary?<k>=v`` produces the same slice count as
+    ``recent?limit=200&<k>=v``."""
+    rows = [
+        {"event": "paywall_view",      "feature": "fleet",   "harness": "claude_code",
+         "source": "runtime-switcher"},
+        {"event": "paywall_cta_click", "feature": "fleet",   "harness": "codex",
+         "source": "sidebar",          "plan_chosen": "pro"},
+        {"event": "paywall_view",      "feature": "anomaly", "harness": "claude_code",
+         "source": "runtime-switcher"},
+    ]
+    for r in rows:
+        _post(client, r)
+
+    for kv in (
+        "event=paywall_view",
+        "feature=fleet",
+        "harness=claude_code",
+        "source=runtime-switcher",
+        "plan_chosen=pro",
+    ):
+        summary_matched = client.get(
+            f"/api/paywall/events/summary?{kv}"
+        ).get_json()["matched"]
+        recent_matched = client.get(
+            f"/api/paywall/events/recent?limit=200&{kv}"
+        ).get_json()["matched"]
+        assert summary_matched == recent_matched, (
+            f"{kv}: summary.matched={summary_matched} "
+            f"differs from recent.matched={recent_matched}"
+        )


### PR DESCRIPTION
## Summary

- Adds the same optional `event` / `feature` / `harness` / `source` / `plan_chosen` filter kwargs to `_PaywallEventStore.summary()` (and its public shim) that `recent()` / `count_matching()` already accept, and wires them onto `GET /api/paywall/events/summary` as query params. A paywall dashboard tile filtered to e.g. `feature=fleet` can now get the per-slice `by_plan_chosen` rollup in one call instead of pulling all recent events and re-counting client-side.
- The summary response always includes two new top-level fields — `filters` (echo of applied filter set, `{}` when none supplied) and `matched` (post-filter subset size; `matched == in_window` on an unfiltered call) — mirroring the fields `GET /api/paywall/events/recent` already emits. Ships in GRACE: no entitlement gate.
- Process-lifetime counters (`total`, `dropped`, `first_ts`, `last_ts`, `capacity`) and the unfiltered `in_window` are **never** sliced by the filters — they describe the ring itself, so a filtered tile still sees churn / evictions in context. Only the `by_*` breakdowns and `matched` reflect the filtered subset.
- The pinned shape test in `tests/test_paywall_events_api.py` tightens to include the two new keys so a future regression that drops them fails immediately. The error-path fallback shape carries them too so the top-level key set is stable across happy path and fallback.
- Filter semantics match `recent` byte-for-byte: `None` / empty / whitespace value collapses to "not supplied", case-sensitive exact match, `AND` combined across dimensions. The two endpoints now accept the same query-param names so a tile can bind one filter set to both surfaces without translation.

## Test plan

- [x] `python -m pytest tests/test_paywall_events_store.py tests/test_paywall_events_api.py tests/test_paywall_event_api.py tests/test_paywall_events_recent_filters.py tests/test_paywall_events_summary_filters.py -q` → **114 passed** (17 new)
- [x] `ruff check clawmetry/_paywall_events.py routes/entitlement.py tests/test_paywall_events_summary_filters.py tests/test_paywall_events_api.py` → **All checks passed**
- [x] `python -m py_compile clawmetry/_paywall_events.py routes/entitlement.py` → OK
- [x] Confirmed the 3 pre-existing paywall-flash / runtime-switcher-overlay failures in the broader sweep also fail on untouched `origin/main` — not caused by this change.
- [x] Backwards compat: existing consumers of `_paywall_events.summary()` still get the same shape plus two additive keys (nothing renamed / removed).

## Local operator verification checklist

Since the agent can't reach the daemon, cloud snapshot, or a browser, an operator should:

- [ ] Copy the changed files into `~/.clawmetry/lib/pythonX.Y/site-packages/clawmetry/` (and `routes/`) on the host, clearing `__pycache__/` under both dirs.
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` (or the equivalent restart for the local dashboard).
- [ ] `curl -s 'http://localhost:8900/api/paywall/events/summary' | jq 'keys'` → contains `"filters"` and `"matched"`.
- [ ] `curl -s 'http://localhost:8900/api/paywall/events/summary?feature=fleet' | jq '{filters, matched, in_window, by_plan_chosen}'` — with any live fleet paywall traffic:
  - `filters == {"feature": "fleet"}`
  - `matched <= in_window`
  - `by_plan_chosen` reflects only fleet-scoped rows.
- [ ] `curl -s 'http://localhost:8900/api/paywall/events/summary?feature='` → `filters == {}`, `matched == in_window` (blank query value must not restrict).
- [ ] For parity with `/recent`: iterate `?event=X`, `?feature=X`, `?harness=X`, `?source=X`, `?plan_chosen=X` and confirm `summary.matched == recent.matched` for each.
- [ ] Decrypt the live cloud snapshot and browser-check that the paywall dashboard tile (if any) still renders unchanged for the unfiltered case.

Ships in GRACE — no behavior change on any current call site; the two new query params are strictly additive.

---
_Generated by [Claude Code](https://claude.ai/code/session_017gxU4LFSuZ5ACRDRXN1Au6)_