### PR TITLE
fix: restore broken C6 daily pings (TRACKING_ISSUE 3906 -> 3864)

### DIFF
--- a/.github/workflows/c6-health.yml
+++ b/.github/workflows/c6-health.yml
@@ -9,7 +9,7 @@ name: C6 daily health check (branch-protection audit -- all 3 repos)
 # used cross-repo (returns 403 even on public repos); unauthenticated
 # reads return the full protection.required_status_checks object.
 #
-# On failure: posts an @-mentioned reminder to tracking issue #3906
+# On failure: posts an @-mentioned reminder to tracking issue #3864
 # at most once per calendar day. On success: posts a GREEN confirmation.
 #
 # To close C6:
@@ -19,7 +19,7 @@ name: C6 daily health check (branch-protection audit -- all 3 repos)
 #   2. Or: bash scripts/close-c6.sh
 #   3. Or: Settings > Branches > main > Required status checks (each repo)
 #
-# Tracking: vivekchand/clawmetry#3906
+# Tracking: vivekchand/clawmetry#3864
 
 on:
   schedule:
@@ -49,7 +49,7 @@ jobs:
 
           TOKEN = os.environ["GITHUB_TOKEN"]
           OWNER = "vivekchand"
-          TRACKING_ISSUE = 3906
+          TRACKING_ISSUE = 3864
           MARKER = "<!-- c6-health-check -->"
           # Repo this workflow runs in. Cross-repo reads must NOT send the
           # scoped GITHUB_TOKEN: Actions tokens are repo-scoped and return 403

--- a/.github/workflows/c6-schedule-heal.yml
+++ b/.github/workflows/c6-schedule-heal.yml
@@ -23,7 +23,7 @@ name: C6 auto-heal (daily required-checks application)
 #     clawmetry, clawmetry-cloud, clawmetry-landing
 #   This workflow picks it up at 10:15am UTC and closes C6 automatically.
 #
-# Tracking: vivekchand/clawmetry#3906
+# Tracking: vivekchand/clawmetry#3864
 
 on:
   schedule:
@@ -162,7 +162,7 @@ except Exception:
               echo "bash scripts/close-c6.sh"
               echo "\`\`\`"
               echo ""
-              echo "Tracking: [#3906](https://github.com/vivekchand/clawmetry/issues/3906)"
+              echo "Tracking: [#3864](https://github.com/vivekchand/clawmetry/issues/3864)"
             fi
           } >> "$GITHUB_STEP_SUMMARY"
 
@@ -173,7 +173,7 @@ except Exception:
           echo ""
           echo "ACTION REQUIRED: Add E2E_ADMIN_PAT to close C6."
           echo "See the job summary above for a formatted status report and close options."
-          echo "Tracking: https://github.com/vivekchand/clawmetry/issues/3906"
+          echo "Tracking: https://github.com/vivekchand/clawmetry/issues/3864"
           exit 1
 
       - name: Apply required E2E status checks (C6)
@@ -196,7 +196,7 @@ except Exception:
             echo "- [clawmetry-cloud branch protection](https://github.com/vivekchand/clawmetry-cloud/settings/branches)"
             echo "- [clawmetry-landing branch protection](https://github.com/vivekchand/clawmetry-landing/settings/branches)"
             echo ""
-            echo "Tracking: [#3906](https://github.com/vivekchand/clawmetry/issues/3906)"
+            echo "Tracking: [#3864](https://github.com/vivekchand/clawmetry/issues/3864)"
           } >> "$GITHUB_STEP_SUMMARY"
           echo "C6 auto-heal complete. If apply_required_status_checks.py exited 0, branch protection"
-          echo "is configured on all 3 repos. Tracking: https://github.com/vivekchand/clawmetry/issues/3906"
+          echo "is configured on all 3 repos. Tracking: https://github.com/vivekchand/clawmetry/issues/3864"

--- a/scripts/apply_required_status_checks.py
+++ b/scripts/apply_required_status_checks.py
@@ -46,7 +46,7 @@ Primary repo behaviour (clawmetry):
 When run locally (GITHUB_REPOSITORY not set), the script applies all 6
 checks and requires a token with cross-repo admin access.
 
-Tracking: vivekchand/clawmetry#3752 (C6)
+Tracking: vivekchand/clawmetry#3864 (C6)
 """
 from __future__ import annotations
 
@@ -398,7 +398,7 @@ def main() -> None:
                 "  Fix: re-run the workflow and paste a fine-grained PAT into the 'pat_token' field.\n"
                 "  PAT permissions: Administration (read+write) on clawmetry, clawmetry-cloud, clawmetry-landing.\n"
                 "  Alternative: bash scripts/close-c6.sh (uses your gh CLI session, ~30 sec).\n"
-                "  Tracking: vivekchand/clawmetry#3752 (C6)"
+                "  Tracking: vivekchand/clawmetry#3864 (C6)"
             )
         # Read-only path: GITHUB_TOKEN cannot write branch protection rules.
         # Scope verification to the current repo only to avoid cross-repo 403s.


### PR DESCRIPTION
## Summary

`c6-health.yml` had `TRACKING_ISSUE = 3906` hardcoded, but issue #3906 does not exist. `post_comment()` threw an uncaught `urllib.error.HTTPError (404)` on every run, crashing the script before posting. **@vivekchand received zero daily C6 reminder pings since at least 2026-07-19** (5+ days of silence, confirmed by workflow run history showing `failure` on runs 35-39).

Similarly, `c6-schedule-heal.yml` linked to non-existent `#3906` in its error messages, and `apply_required_status_checks.py` referenced the older `#3752` in its docstring.

### Files changed

| File | Change |
|------|--------|
| `.github/workflows/c6-health.yml` | `TRACKING_ISSUE = 3906` -> `3864`; comment ref updated |
| `.github/workflows/c6-schedule-heal.yml` | All `#3906` text/link refs -> `#3864` |
| `scripts/apply_required_status_checks.py` | Docstring and error message `#3752` -> `#3864` |

### Acceptance test

After merge, the next `c6-health.yml` run at 09:00 UTC should post a comment to issue #3864 (the active E2E Robustness epic) instead of crashing. Status: C6 still RED (required-status-checks not yet enforced) but daily @vivekchand pings will resume.

### Context

This is a fire from the E2E Robustness Driver cron (fires every 2h). C1-C5 and C7 are all GREEN; C6 is the sole remaining blocker. The fix here restores the notification channel so the daily reminder actually reaches @vivekchand. Tracking: #3864.

---
_Generated by [Claude Code](https://claude.ai/code/session_015qCtCuTTZP73KVBAVgRgLp)_