### PR TITLE
fix: surface gateway subsystem log events in detect() meta (#3991)

### DIFF
--- a/clawmetry/adapters/openclaw.py
+++ b/clawmetry/adapters/openclaw.py
@@ -511,6 +511,72 @@ def _gateway_log_meta() -> dict:
         return {}
 
 
+def _gateway_log_events(count: int = 50) -> list:
+    """Return the last ``count`` structured events from the gateway log file.
+
+    The gateway writes line-delimited JSON to rotating ``openclaw-*.log`` files
+    (same paths as ``_gateway_log_files()``).  Each line carries at minimum
+    ``level`` and ``msg``; most also carry ``subsystem`` and a timestamp field
+    (``time``, ``ts``, or ``timestamp``).
+
+    Returns a list of event dicts, newest-first.  Returns ``[]`` when no log
+    file exists, on any parse error, or on non-OpenClaw hosts.  Never raises.
+
+    Closes #3991.
+    """
+    try:
+        files = _gateway_log_files()
+        if not files:
+            return []
+        log_path = files[-1]
+        # Read a trailing chunk large enough to hold ``count`` typical lines
+        # (~300 bytes each) without loading the full (potentially large) log.
+        chunk_size = max(8192, count * 300)
+        try:
+            with open(log_path, "rb") as fh:
+                fh.seek(0, 2)
+                size = fh.tell()
+                fh.seek(max(0, size - chunk_size))
+                raw_bytes = fh.read()
+        except OSError:
+            return []
+        lines = raw_bytes.decode("utf-8", "replace").splitlines()
+        events: list = []
+        for raw in reversed(lines):
+            raw = raw.strip()
+            if not raw:
+                continue
+            try:
+                obj = json.loads(raw)
+            except (ValueError, TypeError):
+                continue
+            if not isinstance(obj, dict):
+                continue
+            evt: dict = {}
+            # Timestamp — accept any common key name.
+            for _ts_key in ("time", "ts", "timestamp"):
+                _ts_val = obj.get(_ts_key)
+                if _ts_val is not None:
+                    evt["ts"] = _ts_val
+                    break
+            for _field, _key in (
+                ("level", "level"),
+                ("msg", "msg"),
+                ("message", "msg"),
+                ("subsystem", "subsystem"),
+            ):
+                _val = obj.get(_field)
+                if _val is not None and _key not in evt:
+                    evt[_key] = _val
+            if evt:
+                events.append(evt)
+            if len(events) >= count:
+                break
+        return events
+    except Exception:
+        return []
+
+
 def _openshell_sandbox_logs(name: str, count: int = 20) -> list:
     """Retrieve OCSF JSON audit log lines for a NemoClaw sandbox.
 
@@ -1871,6 +1937,9 @@ class OpenClawAdapter(AgentAdapter):
             _gw_log = _gateway_log_meta()
             if _gw_log:
                 meta.update(_gw_log)
+            _gw_events = _gateway_log_events()
+            if _gw_events:
+                meta["gatewayLogEvents"] = _gw_events
             return DetectResult(
                 name=self.name,
                 display_name=self.display_name,

--- a/tests/test_obs_gap_gateway_log_events_3991.py
+++ b/tests/test_obs_gap_gateway_log_events_3991.py
@@ -1,0 +1,107 @@
+"""Tests for #3991 — gateway structured/subsystem log lines parsed into events.
+
+Verifies _gateway_log_events() reads the most-recent gateway log file, parses
+each JSON line, and surfaces ts/level/msg/subsystem into event dicts, newest-first.
+
+Fingerprint: hgap-646613da33
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from clawmetry.adapters.openclaw import _gateway_log_events
+
+
+def _write_log(path, lines):
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def test_well_formed_lines_parsed(monkeypatch, tmp_path):
+    """Standard log lines surface level, msg, and subsystem."""
+    log = tmp_path / "openclaw-2026-07-24.log"
+    events_in = [
+        {"time": 1721808000, "level": "info",  "msg": "gateway started", "subsystem": "core"},
+        {"time": 1721808001, "level": "warn",  "msg": "high latency",    "subsystem": "llm"},
+        {"time": 1721808002, "level": "error", "msg": "tool failed",     "subsystem": "tools"},
+    ]
+    _write_log(log, [json.dumps(e) for e in events_in])
+    monkeypatch.setattr(
+        "clawmetry.adapters.openclaw._gateway_log_files",
+        lambda: [str(log)],
+    )
+
+    result = _gateway_log_events()
+
+    assert len(result) == 3
+    # newest-first order
+    assert result[0]["msg"] == "tool failed"
+    assert result[0]["level"] == "error"
+    assert result[0]["subsystem"] == "tools"
+    assert result[0]["ts"] == 1721808002
+    assert result[2]["msg"] == "gateway started"
+
+
+def test_non_json_lines_silently_skipped(monkeypatch, tmp_path):
+    """Non-JSON lines (plain text, truncated) are dropped without error."""
+    log = tmp_path / "openclaw-2026-07-24.log"
+    _write_log(log, [
+        "plain text line",
+        json.dumps({"level": "info", "msg": "ok", "subsystem": "core"}),
+        "{broken json",
+    ])
+    monkeypatch.setattr(
+        "clawmetry.adapters.openclaw._gateway_log_files",
+        lambda: [str(log)],
+    )
+
+    result = _gateway_log_events()
+
+    assert len(result) == 1
+    assert result[0]["msg"] == "ok"
+
+
+def test_missing_log_file_returns_empty(monkeypatch):
+    """No log files found → empty list, no exception."""
+    monkeypatch.setattr(
+        "clawmetry.adapters.openclaw._gateway_log_files",
+        lambda: [],
+    )
+    assert _gateway_log_events() == []
+
+
+def test_count_limits_returned_events(monkeypatch, tmp_path):
+    """Only the last ``count`` events are returned."""
+    log = tmp_path / "openclaw-2026-07-24.log"
+    lines = [json.dumps({"level": "info", "msg": f"line {i}"}) for i in range(20)]
+    _write_log(log, lines)
+    monkeypatch.setattr(
+        "clawmetry.adapters.openclaw._gateway_log_files",
+        lambda: [str(log)],
+    )
+
+    result = _gateway_log_events(count=5)
+
+    assert len(result) == 5
+    # newest first → "line 19" comes first
+    assert result[0]["msg"] == "line 19"
+
+
+def test_alternate_timestamp_keys_accepted(monkeypatch, tmp_path):
+    """``ts`` and ``timestamp`` keys are also accepted as the event timestamp."""
+    log = tmp_path / "openclaw-2026-07-24.log"
+    _write_log(log, [
+        json.dumps({"ts": 111, "level": "info", "msg": "ts key"}),
+        json.dumps({"timestamp": 222, "level": "info", "msg": "timestamp key"}),
+    ])
+    monkeypatch.setattr(
+        "clawmetry.adapters.openclaw._gateway_log_files",
+        lambda: [str(log)],
+    )
+
+    result = _gateway_log_events()
+
+    assert len(result) == 2
+    tss = {e["ts"] for e in result}
+    assert tss == {111, 222}


### PR DESCRIPTION
Closes #3991

## What

Adds `_gateway_log_events(count=50)` to `clawmetry/adapters/openclaw.py` and wires it into `detect()` as `gatewayLogEvents`.

- Tails the most-recent rotating gateway log file without loading the full file into memory (reads a trailing chunk sized to `count × 300` bytes)
- Parses each JSON line; accepts `time`, `ts`, or `timestamp` as the timestamp key
- Promotes `level`, `msg`/`message`, and `subsystem` into event dicts
- Returns newest-first; silently drops non-JSON lines; returns `[]` when no log exists
- `detect()` only sets `gatewayLogEvents` when the list is non-empty — same pattern as the existing `_gateway_log_meta()` merge

## Tests

5 new tests in `tests/test_obs_gap_gateway_log_events_3991.py`:
- Well-formed lines parsed correctly with correct newest-first ordering
- Non-JSON / plain-text lines silently skipped
- Missing log file returns `[]`
- `count` parameter correctly limits returned events
- Alternate timestamp keys (`ts`, `timestamp`) accepted

All 5 pass.

## Test plan

```
python3 -m pytest tests/test_obs_gap_gateway_log_events_3991.py -v
# → 5 passed
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01X4bYxhu4x4K4HNNaHsdaoB)_