### PR TITLE
feat(paywall): since/until time-window filters on /api/paywall/events/{summary,recent}

### DIFF
--- a/clawmetry/_paywall_events.py
+++ b/clawmetry/_paywall_events.py
@@ -153,6 +153,83 @@ def _row_matches_filters(row: dict, filters: dict[str, str]) -> bool:
         return False
 
 
+def _coerce_ts_bound(raw: Any) -> float | None:
+    """Coerce one of ``since`` / ``until`` to epoch-seconds ``float``, or
+    return ``None`` for "not supplied".
+
+    A ``None``, empty string, all-whitespace string, non-numeric string,
+    ``NaN``, or negative timestamp collapses to ``None`` so a caller's
+    stray query string cannot restrict the window unexpectedly. An ``int``
+    or ``float`` passes through after the same NaN / negative filter.
+
+    Never raises.
+    """
+    if raw is None:
+        return None
+    try:
+        if isinstance(raw, bool):
+            # ``bool`` is an ``int`` subclass in Python; treat it as "not
+            # supplied" so a stray ``True`` / ``False`` doesn't get coerced
+            # to ``1.0`` / ``0.0`` and start slicing.
+            return None
+        if isinstance(raw, (int, float)):
+            value = float(raw)
+        else:
+            text = str(raw).strip()
+            if not text:
+                return None
+            value = float(text)
+    except (TypeError, ValueError):
+        return None
+    # NaN comparisons always return False; treat NaN and negative epoch as
+    # "not supplied" so a bogus bound is ignored rather than dropping every
+    # row on the floor.
+    if value != value:  # pragma: no cover - explicit NaN guard
+        return None
+    if value < 0:
+        return None
+    return value
+
+
+def _normalise_time_bounds(
+    since: Any, until: Any,
+) -> tuple[float | None, float | None]:
+    """Return the coerced ``(since, until)`` pair (each ``float | None``).
+
+    ``since`` is inclusive, ``until`` is exclusive -- the standard half-open
+    ``[since, until)`` convention -- so back-to-back windows do NOT double-
+    count events landing exactly on the boundary. If both bounds resolve
+    and ``since >= until`` the window is empty by construction; the store
+    passes the pair through unchanged and every row is filtered out, which
+    is the intended "empty window" behaviour.
+
+    Never raises.
+    """
+    return _coerce_ts_bound(since), _coerce_ts_bound(until)
+
+
+def _row_matches_time_window(
+    row: dict, since: float | None, until: float | None,
+) -> bool:
+    """Return True iff ``row['ts']`` falls in the half-open window
+    ``[since, until)``. Either bound may be ``None`` meaning "unbounded on
+    that side". A row without a numeric ``ts`` is treated as a mismatch
+    when either bound is supplied (a bounded query cannot match a row of
+    unknown age), and as a match when neither bound is supplied. Never
+    raises.
+    """
+    if since is None and until is None:
+        return True
+    ts = row.get("ts")
+    if not isinstance(ts, (int, float)) or isinstance(ts, bool):
+        return False
+    if since is not None and ts < since:
+        return False
+    if until is not None and ts >= until:
+        return False
+    return True
+
+
 class _PaywallEventStore:
     """Thread-safe bounded ring + running aggregates for paywall beacons.
 
@@ -242,6 +319,8 @@ class _PaywallEventStore:
         harness: str | None = None,
         source: str | None = None,
         plan_chosen: str | None = None,
+        since: Any = None,
+        until: Any = None,
     ) -> dict:
         """Return a JSON-safe aggregate snapshot of the current ring.
 
@@ -261,18 +340,32 @@ class _PaywallEventStore:
         empty-string means "not supplied", case-sensitive exact match,
         ``AND`` combined. With no filters the returned shape is byte-
         identical to the pre-filter contract EXCEPT for the always-present
-        ``filters`` and ``matched`` fields (added below).
+        ``filters``, ``matched``, and ``time_window`` fields (added below).
 
-        ``filters`` echoes the applied filter set (empty dict when none
-        supplied) so a caller can distinguish "I asked for feature=X and
-        got 0 rows" from "I asked for nothing and got 0 rows". ``matched``
-        is the count of rows the ``by_*`` aggregation was computed over --
-        byte-equal to ``in_window`` on an unfiltered call, otherwise the
-        pre-aggregation subset size. Process-lifetime counters
-        (``total``, ``dropped``, ``first_ts``, ``last_ts``, ``capacity``)
-        are NOT sliced by the filters -- they describe the ring itself, not
-        the subset the caller cares about, and slicing them would silently
-        under-report churn to a filtered dashboard tile.
+        Optional keyword bounds (``since`` / ``until``) further restrict
+        the aggregation to rows whose ``ts`` falls in the half-open
+        interval ``[since, until)`` (epoch seconds; either bound may be
+        ``None`` = unbounded on that side). Bounds and categorical
+        filters are ``AND`` combined. A bogus bound (non-numeric string,
+        ``NaN``, negative epoch, ``bool``) collapses to "not supplied" so
+        an operator typo cannot silently drop every row; see
+        :func:`_coerce_ts_bound` for the exact contract.
+
+        ``filters`` echoes the applied categorical filter set (empty dict
+        when none supplied) so a caller can distinguish "I asked for
+        feature=X and got 0 rows" from "I asked for nothing and got 0
+        rows". ``time_window`` is a sibling ``{"since": <float|null>,
+        "until": <float|null>}`` echo of the resolved time bounds -- it
+        is always present so a dashboard tile can trust the top-level key
+        set is stable regardless of whether time bounds were supplied.
+        ``matched`` is the count of rows the ``by_*`` aggregation was
+        computed over -- byte-equal to ``in_window`` on a fully-unfiltered
+        call, otherwise the post-filter, post-window subset size. Process-
+        lifetime counters (``total``, ``dropped``, ``first_ts``,
+        ``last_ts``, ``capacity``) are NOT sliced by the filters or the
+        window -- they describe the ring itself, not the subset the caller
+        cares about, and slicing them would silently under-report churn to
+        a filtered dashboard tile.
 
         Never raises.
         """
@@ -281,6 +374,7 @@ class _PaywallEventStore:
                 event=event, feature=feature, harness=harness,
                 source=source, plan_chosen=plan_chosen,
             )
+            since_ts, until_ts = _normalise_time_bounds(since, until)
             with self._lock:
                 snap = list(self._ring)
                 total = self._total
@@ -289,10 +383,14 @@ class _PaywallEventStore:
                 last_ts = self._last_ts
                 capacity = self._capacity
 
+            bucket = snap
             if filters:
-                bucket = [e for e in snap if _row_matches_filters(e, filters)]
-            else:
-                bucket = snap
+                bucket = [e for e in bucket if _row_matches_filters(e, filters)]
+            if since_ts is not None or until_ts is not None:
+                bucket = [
+                    e for e in bucket
+                    if _row_matches_time_window(e, since_ts, until_ts)
+                ]
 
             by_event: Counter = Counter()
             by_feature: Counter = Counter()
@@ -325,6 +423,7 @@ class _PaywallEventStore:
                 "by_plan_chosen": dict(by_plan),
                 "filters": dict(filters),
                 "matched": len(bucket),
+                "time_window": {"since": since_ts, "until": until_ts},
             }
         except Exception as exc:
             logger.warning("paywall.events: summary swallowed error: %s", exc)
@@ -342,6 +441,7 @@ class _PaywallEventStore:
                 "by_plan_chosen": {},
                 "filters": {},
                 "matched": 0,
+                "time_window": {"since": None, "until": None},
             }
 
     def recent(
@@ -353,6 +453,8 @@ class _PaywallEventStore:
         harness: str | None = None,
         source: str | None = None,
         plan_chosen: str | None = None,
+        since: Any = None,
+        until: Any = None,
     ) -> list[dict]:
         """Return up to ``limit`` most-recent events, newest first.
 
@@ -367,6 +469,13 @@ class _PaywallEventStore:
         does not restrict on that dimension -- there is deliberately no
         way to query for rows with an empty field via this API, because
         ``?feature=`` in the query string would then be ambiguous.
+
+        Optional keyword bounds (``since`` / ``until``) restrict the
+        returned rows to those whose ``ts`` falls in the half-open
+        interval ``[since, until)`` (epoch seconds; either bound may be
+        ``None`` = unbounded on that side). Bounds combine with categorical
+        filters via ``AND``. See :func:`_coerce_ts_bound` for the exact
+        "bad bound collapses to unbounded" contract.
 
         Filter matching is case-sensitive against the stored (post-
         :func:`_coerce_str`) value, matching the case-sensitive keys of
@@ -392,14 +501,21 @@ class _PaywallEventStore:
                 event=event, feature=feature, harness=harness,
                 source=source, plan_chosen=plan_chosen,
             )
+            since_ts, until_ts = _normalise_time_bounds(since, until)
             with self._lock:
                 snap = list(self._ring)
             snap.reverse()
-            if filters:
-                return [
-                    dict(e) for e in snap
-                    if _row_matches_filters(e, filters)
-                ][:n]
+
+            def _keep(row: dict) -> bool:
+                if filters and not _row_matches_filters(row, filters):
+                    return False
+                if (since_ts is not None or until_ts is not None) and not \
+                        _row_matches_time_window(row, since_ts, until_ts):
+                    return False
+                return True
+
+            if filters or since_ts is not None or until_ts is not None:
+                return [dict(e) for e in snap if _keep(e)][:n]
             return [dict(e) for e in snap[:n]]
         except Exception as exc:
             logger.warning("paywall.events: recent swallowed error: %s", exc)
@@ -413,13 +529,17 @@ class _PaywallEventStore:
         harness: str | None = None,
         source: str | None = None,
         plan_chosen: str | None = None,
+        since: Any = None,
+        until: Any = None,
     ) -> int:
         """Return the count of ring rows matching the supplied filters,
         BEFORE any ``limit`` clamp is applied.
 
-        Same filter semantics as :meth:`recent` (``None`` / empty string
-        means "not supplied", case-sensitive exact match, ``AND`` combined).
-        With no filters, returns the full ring size -- byte-equal to
+        Same filter + window semantics as :meth:`recent` (``None`` /
+        empty string means "not supplied", case-sensitive exact match,
+        ``AND`` combined; ``since`` / ``until`` restrict to the half-open
+        ``[since, until)`` epoch-seconds interval). With no filters and no
+        window, returns the full ring size -- byte-equal to
         :meth:`summary`'s ``in_window`` on a quiet store, and always the
         ceiling ``recent(limit, **filters)`` could return at ``limit >=
         RECENT_MAX_LIMIT``.
@@ -437,11 +557,22 @@ class _PaywallEventStore:
                 event=event, feature=feature, harness=harness,
                 source=source, plan_chosen=plan_chosen,
             )
+            since_ts, until_ts = _normalise_time_bounds(since, until)
             with self._lock:
                 snap = list(self._ring)
-            if not filters:
+            has_window = since_ts is not None or until_ts is not None
+            if not filters and not has_window:
                 return len(snap)
-            return sum(1 for e in snap if _row_matches_filters(e, filters))
+            count = 0
+            for e in snap:
+                if filters and not _row_matches_filters(e, filters):
+                    continue
+                if has_window and not _row_matches_time_window(
+                    e, since_ts, until_ts,
+                ):
+                    continue
+                count += 1
+            return count
         except Exception as exc:
             logger.warning("paywall.events: count_matching swallowed: %s", exc)
             return 0
@@ -470,17 +601,23 @@ def summary(
     harness: str | None = None,
     source: str | None = None,
     plan_chosen: str | None = None,
+    since: Any = None,
+    until: Any = None,
 ) -> dict:
     """Public shim for ``GET /api/paywall/events/summary``.
 
     Filter kwargs are optional; a ``None`` or empty-string value means
-    "not supplied" and does not restrict on that dimension. See
-    :meth:`_PaywallEventStore.summary` for the filter contract and the
-    exact response shape (always includes ``filters`` and ``matched``).
+    "not supplied" and does not restrict on that dimension. Time bounds
+    (``since`` / ``until``) restrict to the half-open ``[since, until)``
+    epoch-seconds interval and may be supplied as ``float`` / ``int`` /
+    numeric-string; bad or blank values collapse to "not supplied". See
+    :meth:`_PaywallEventStore.summary` for the exact response shape
+    (always includes ``filters``, ``matched``, and ``time_window``).
     """
     return _STORE.summary(
         event=event, feature=feature, harness=harness,
         source=source, plan_chosen=plan_chosen,
+        since=since, until=until,
     )
 
 
@@ -492,12 +629,15 @@ def recent(
     harness: str | None = None,
     source: str | None = None,
     plan_chosen: str | None = None,
+    since: Any = None,
+    until: Any = None,
 ) -> list[dict]:
     """Public shim for ``GET /api/paywall/events/recent``.
 
     ``limit`` defaults to :data:`RECENT_DEFAULT_LIMIT`. Filter kwargs are
     optional; a ``None`` or empty-string value means "not supplied" and
-    does not restrict on that dimension. See
+    does not restrict on that dimension. ``since`` / ``until`` restrict
+    to the half-open ``[since, until)`` epoch-seconds interval. See
     :meth:`_PaywallEventStore.recent` for the exact filter contract.
     """
     if limit is None:
@@ -506,6 +646,7 @@ def recent(
         limit,
         event=event, feature=feature, harness=harness,
         source=source, plan_chosen=plan_chosen,
+        since=since, until=until,
     )
 
 
@@ -516,16 +657,20 @@ def count_matching(
     harness: str | None = None,
     source: str | None = None,
     plan_chosen: str | None = None,
+    since: Any = None,
+    until: Any = None,
 ) -> int:
     """Public shim for :meth:`_PaywallEventStore.count_matching`.
 
-    Returns the count of ring rows matching the supplied filters BEFORE
-    any ``limit`` clamp. Used by ``/api/paywall/events/recent`` so it can
-    render "showing N of M matches" alongside the filtered event list.
+    Returns the count of ring rows matching the supplied filters +
+    time-window BEFORE any ``limit`` clamp. Used by
+    ``/api/paywall/events/recent`` so it can render "showing N of M
+    matches" alongside the filtered event list.
     """
     return _STORE.count_matching(
         event=event, feature=feature, harness=harness,
         source=source, plan_chosen=plan_chosen,
+        since=since, until=until,
     )
 
 

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -7167,6 +7167,16 @@ def api_paywall_events_summary():
       ?source=<source-key>
       ?plan_chosen=<plan-code>
 
+    Optional time-window params further restrict to rows whose ``ts``
+    falls in the half-open ``[since, until)`` epoch-seconds interval::
+
+      ?since=<float-epoch-seconds>
+      ?until=<float-epoch-seconds>
+
+    Either bound may be omitted or blank (= "unbounded on that side").
+    A non-numeric, NaN, or negative bound collapses to "not supplied"
+    so an operator typo cannot silently drop every row.
+
     Body shape::
 
         {
@@ -7181,8 +7191,10 @@ def api_paywall_events_summary():
           "by_harness": {"<key>":  <int>, ...},
           "by_source":  {"<key>":  <int>, ...},
           "by_plan_chosen": {"<plan>": <int>, ...},
-          "filters": {"<key>": "<value>", ...},      # echo of applied filters
-          "matched": <int>                           # rows the by_* aggregate covers
+          "filters": {"<key>": "<value>", ...},      # echo of applied categorical filters
+          "matched": <int>,                          # rows the by_* aggregate covers
+          "time_window": {"since": <float|null>, "until": <float|null>}
+                                                     # echo of resolved bounds
         }
 
     Process-lifetime counters (``total``, ``dropped``, ``first_ts``,
@@ -7190,8 +7202,8 @@ def api_paywall_events_summary():
     they describe the ring itself, not the subset the caller cares about,
     so a filtered dashboard tile can still see churn / evictions in
     context. The ``by_*`` breakdowns and ``matched`` count reflect the
-    filtered subset. On an unfiltered request ``matched`` byte-equals
-    ``in_window``.
+    filtered subset (categorical + time-window). On a fully-unfiltered
+    request ``matched`` byte-equals ``in_window``.
 
     Ships in GRACE -- no entitlement gate, no capacity accounting. Grace-
     mode read of a grace-mode write.
@@ -7206,6 +7218,11 @@ def api_paywall_events_summary():
             key: request.args.get(key, "") or None
             for key in ("event", "feature", "harness", "source", "plan_chosen")
         }
+        # ``since`` / ``until`` share the same "blank means not supplied"
+        # posture as the categorical filters; the store layer does the
+        # numeric coercion + NaN / negative guarding.
+        for key in ("since", "until"):
+            filter_kwargs[key] = request.args.get(key, "") or None
         return jsonify(_pe.summary(**filter_kwargs))
     except Exception as exc:
         logger.warning("api_paywall_events_summary: error: %s", exc)
@@ -7224,6 +7241,7 @@ def api_paywall_events_summary():
                 "by_plan_chosen": {},
                 "filters": {},
                 "matched": 0,
+                "time_window": {"since": None, "until": None},
             }
         )
 
@@ -7252,6 +7270,15 @@ def api_paywall_events_recent():
     an empty field via this API. Filter mismatches never fail the request:
     they simply return an empty ``events`` list and ``matched=0``.
 
+    Optional time-window params restrict to rows whose ``ts`` falls in the
+    half-open ``[since, until)`` epoch-seconds interval::
+
+      ?since=<float-epoch-seconds>
+      ?until=<float-epoch-seconds>
+
+    Either bound may be omitted or blank. Bad bounds (non-numeric, NaN,
+    negative) collapse to "not supplied".
+
     Body shape::
 
         {
@@ -7261,14 +7288,16 @@ def api_paywall_events_recent():
             ...
           ],
           "count": <int>,          # events actually returned (post-filter, post-limit)
-          "matched": <int>,        # rows matching the filters, pre-limit (>= count)
+          "matched": <int>,        # rows matching the filters + window, pre-limit (>= count)
           "limit": <int>,          # the resolved (post-clamp) limit
           "in_window": <int>,      # size of the underlying ring right now
-          "filters": {"<key>": "<value>", ...}   # echo of applied filters (blank ones omitted)
+          "filters": {"<key>": "<value>", ...},  # echo of applied categorical filters
+          "time_window": {"since": <float|null>, "until": <float|null>}
+                                                 # echo of resolved bounds
         }
 
     ``matched`` lets a UI render "showing N of M matches" without a second
-    round-trip. On an unfiltered request ``matched`` byte-equals
+    round-trip. On a fully-unfiltered request ``matched`` byte-equals
     ``in_window``.
 
     Ships in GRACE. Never 5xxs -- on any failure returns an empty envelope.
@@ -7289,12 +7318,19 @@ def api_paywall_events_recent():
             key: request.args.get(key, "") or None
             for key in ("event", "feature", "harness", "source", "plan_chosen")
         }
+        window_kwargs = {
+            key: request.args.get(key, "") or None
+            for key in ("since", "until")
+        }
         # `_pe.recent` / `count_matching` treat empty / whitespace strings as
         # "not supplied" so the query-string echo below is the canonical
-        # applied-filter set.
-        events = _pe.recent(limit_val, **filter_kwargs)
-        matched = _pe.count_matching(**filter_kwargs)
-        summary = _pe.summary()
+        # applied-filter set. Time bounds go through their own numeric
+        # coercion in the store, so we ask the store what it actually
+        # resolved to (via `summary(**window_kwargs)["time_window"]`)
+        # rather than echoing the raw string.
+        events = _pe.recent(limit_val, **filter_kwargs, **window_kwargs)
+        matched = _pe.count_matching(**filter_kwargs, **window_kwargs)
+        summary = _pe.summary(**window_kwargs)
         applied_filters = {
             key: value.strip()
             for key, value in filter_kwargs.items()
@@ -7308,6 +7344,9 @@ def api_paywall_events_recent():
                 "limit": limit_val,
                 "in_window": summary.get("in_window", 0),
                 "filters": applied_filters,
+                "time_window": summary.get(
+                    "time_window", {"since": None, "until": None},
+                ),
             }
         )
     except Exception as exc:
@@ -7320,6 +7359,7 @@ def api_paywall_events_recent():
                 "limit": 0,
                 "in_window": 0,
                 "filters": {},
+                "time_window": {"since": None, "until": None},
             }
         )
 

--- a/tests/test_paywall_events_api.py
+++ b/tests/test_paywall_events_api.py
@@ -90,15 +90,15 @@ def test_summary_reflects_prior_paywall_event_posts(client):
 def test_summary_shape_is_stable(client):
     """A pricing dashboard tile binds to a fixed set of keys. If the
     endpoint ever drops one, tiles blank silently -- pin the full key
-    set. ``filters`` and ``matched`` are the always-present mirror of
-    ``/api/paywall/events/recent`` so a tile binding one filter set to
-    both endpoints reads the same shape from each."""
+    set. ``filters`` / ``matched`` / ``time_window`` are the always-
+    present mirror of ``/api/paywall/events/recent`` so a tile binding
+    one filter set to both endpoints reads the same shape from each."""
     body = client.get("/api/paywall/events/summary").get_json()
     expected = {
         "total", "in_window", "dropped", "capacity",
         "first_ts", "last_ts",
         "by_event", "by_feature", "by_harness", "by_source", "by_plan_chosen",
-        "filters", "matched",
+        "filters", "matched", "time_window",
     }
     assert set(body.keys()) == expected
 
@@ -248,6 +248,7 @@ def test_recent_never_5xxs_on_store_failure(client, monkeypatch):
         "limit": 0,
         "in_window": 0,
         "filters": {},
+        "time_window": {"since": None, "until": None},
     }
 
 

--- a/tests/test_paywall_events_recent_filters.py
+++ b/tests/test_paywall_events_recent_filters.py
@@ -338,6 +338,7 @@ def test_api_recent_envelope_shape_is_stable(client):
     body = client.get("/api/paywall/events/recent").get_json()
     assert set(body.keys()) == {
         "events", "count", "matched", "limit", "in_window", "filters",
+        "time_window",
     }
 
 
@@ -501,6 +502,7 @@ def test_api_recent_filter_never_5xxs_on_store_failure(client, monkeypatch):
         "limit": 0,
         "in_window": 0,
         "filters": {},
+        "time_window": {"since": None, "until": None},
     }
 
 

--- a/tests/test_paywall_events_time_window.py
+++ b/tests/test_paywall_events_time_window.py
@@ -1,0 +1,459 @@
+"""Time-window filter tests for :mod:`clawmetry._paywall_events` and
+the ``/api/paywall/events/summary`` + ``/api/paywall/events/recent``
+HTTP endpoints.
+
+Pairs with ``test_paywall_events_summary_filters.py`` and
+``test_paywall_events_recent_filters.py`` -- the store's ``since`` /
+``until`` kwargs are the natural third dimension after the categorical
+filters, and both endpoints must accept them via the same query-string
+names so a dashboard tile can bind one window pair to both surfaces
+without translation.
+
+Invariants pinned:
+
+* ``since`` is inclusive, ``until`` is exclusive -- half-open
+  ``[since, until)``. Back-to-back windows do NOT double-count events
+  landing on the boundary.
+* Either bound may be ``None`` / blank -- meaning "unbounded on that side".
+* Bad bounds (non-numeric, NaN, negative epoch, ``bool``) collapse to
+  "not supplied" so a stray query string cannot silently drop every row.
+* The window AND-combines with the categorical filters
+  (``event`` / ``feature`` / ``harness`` / ``source`` / ``plan_chosen``).
+* Process-lifetime counters (``total``, ``dropped``, ``first_ts``,
+  ``last_ts``, ``capacity``) and unfiltered ``in_window`` are NEVER
+  sliced by the window -- they describe the ring itself.
+* ``matched`` reflects the post-filter, post-window subset size and stays
+  in lock-step across summary / recent for the same query.
+* Both endpoints always emit ``time_window: {"since": ..., "until": ...}``
+  so a caller can rely on the top-level key set being stable.
+* Endpoints never 5xx -- the neutral fallback envelope must also carry
+  ``time_window``.
+"""
+from __future__ import annotations
+
+import math
+
+import pytest
+from flask import Flask
+
+
+# ── fixtures ────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _fresh_store():
+    from clawmetry import _paywall_events as pe
+
+    pe.reset()
+    yield
+    pe.reset()
+
+
+@pytest.fixture
+def clock(monkeypatch):
+    """Deterministic clock for the store's ``time.time()`` calls.
+
+    Yields a mutable ``{"now": <float>}`` box; the test bumps
+    ``clock["now"]`` between ``record_event`` calls so recorded ``ts``
+    values are predictable, and the window tests can pin exact
+    inclusive / exclusive boundaries.
+    """
+    from clawmetry import _paywall_events as pe
+
+    box = {"now": 1_000_000.0}
+    monkeypatch.setattr(pe.time, "time", lambda: box["now"])
+    return box
+
+
+def _record(pe, clock, ts, payload):
+    clock["now"] = float(ts)
+    pe.record_event(payload)
+
+
+# ── _coerce_ts_bound / _normalise_time_bounds ────────────────────────────────
+
+
+def test_coerce_ts_bound_accepts_float_int_and_numeric_string():
+    from clawmetry._paywall_events import _coerce_ts_bound
+
+    assert _coerce_ts_bound(1000.5) == 1000.5
+    assert _coerce_ts_bound(1000) == 1000.0
+    assert _coerce_ts_bound("1234.5") == 1234.5
+    assert _coerce_ts_bound("  1234.5  ") == 1234.5   # stripped
+
+
+def test_coerce_ts_bound_rejects_bogus_values():
+    from clawmetry._paywall_events import _coerce_ts_bound
+
+    assert _coerce_ts_bound(None) is None
+    assert _coerce_ts_bound("") is None
+    assert _coerce_ts_bound("   ") is None
+    assert _coerce_ts_bound("notanumber") is None
+    assert _coerce_ts_bound(float("nan")) is None
+    assert _coerce_ts_bound("nan") is None
+    assert _coerce_ts_bound(-1) is None
+    assert _coerce_ts_bound(-0.001) is None
+    assert _coerce_ts_bound("-5") is None
+    # ``bool`` collapses -- a stray True should not become 1.0.
+    assert _coerce_ts_bound(True) is None
+    assert _coerce_ts_bound(False) is None
+
+
+def test_normalise_time_bounds_returns_pair():
+    from clawmetry._paywall_events import _normalise_time_bounds
+
+    assert _normalise_time_bounds(None, None) == (None, None)
+    assert _normalise_time_bounds("10", "20") == (10.0, 20.0)
+    assert _normalise_time_bounds("junk", 42) == (None, 42.0)
+    # Empty window (since >= until) is passed through unchanged; the store
+    # simply filters every row out.
+    assert _normalise_time_bounds(100, 100) == (100.0, 100.0)
+
+
+# ── _row_matches_time_window ────────────────────────────────────────────────
+
+
+def test_row_matches_time_window_half_open_interval():
+    from clawmetry._paywall_events import _row_matches_time_window
+
+    row = {"ts": 100.0}
+    # No bounds -> match.
+    assert _row_matches_time_window(row, None, None)
+    # since inclusive.
+    assert _row_matches_time_window(row, 100.0, None)
+    assert not _row_matches_time_window(row, 100.0001, None)
+    # until exclusive.
+    assert not _row_matches_time_window(row, None, 100.0)
+    assert _row_matches_time_window(row, None, 100.0001)
+    # Both bounds.
+    assert _row_matches_time_window(row, 99.0, 101.0)
+    assert not _row_matches_time_window(row, 101.0, 200.0)
+
+
+def test_row_without_numeric_ts_only_matches_unbounded_window():
+    from clawmetry._paywall_events import _row_matches_time_window
+
+    assert _row_matches_time_window({}, None, None)
+    assert not _row_matches_time_window({}, 100.0, None)
+    assert not _row_matches_time_window({"ts": "notanumber"}, 100.0, None)
+    assert not _row_matches_time_window({"ts": True}, 100.0, None)
+
+
+# ── store-level summary ──────────────────────────────────────────────────────
+
+
+def test_summary_unfiltered_call_emits_time_window_field():
+    from clawmetry import _paywall_events as pe
+
+    pe.record_event({"event": "paywall_view", "feature": "fleet"})
+    s = pe.summary()
+    assert s["time_window"] == {"since": None, "until": None}
+    # Unfiltered: matched == in_window, matching the categorical contract.
+    assert s["matched"] == s["in_window"] == 1
+
+
+def test_summary_since_is_inclusive(clock):
+    from clawmetry import _paywall_events as pe
+
+    _record(pe, clock, 100.0, {"event": "paywall_view", "feature": "a"})
+    _record(pe, clock, 101.0, {"event": "paywall_view", "feature": "b"})
+
+    s = pe.summary(since=100.0)
+    assert s["time_window"] == {"since": 100.0, "until": None}
+    assert s["matched"] == 2
+
+    s = pe.summary(since=100.5)
+    assert s["matched"] == 1
+    assert s["by_feature"] == {"b": 1}
+
+
+def test_summary_until_is_exclusive(clock):
+    from clawmetry import _paywall_events as pe
+
+    _record(pe, clock, 100.0, {"event": "paywall_view", "feature": "a"})
+    _record(pe, clock, 101.0, {"event": "paywall_view", "feature": "b"})
+
+    # until=101.0 excludes the ts=101.0 row (half-open).
+    s = pe.summary(until=101.0)
+    assert s["time_window"] == {"since": None, "until": 101.0}
+    assert s["matched"] == 1
+    assert s["by_feature"] == {"a": 1}
+
+
+def test_summary_back_to_back_windows_do_not_double_count(clock):
+    """Half-open ``[since, until)`` guarantees adjacent windows partition
+    the ring cleanly. A dashboard rendering minute-bucket tiles depends
+    on this."""
+    from clawmetry import _paywall_events as pe
+
+    for ts in (100.0, 100.5, 101.0, 101.5, 102.0):
+        _record(pe, clock, ts, {"event": "paywall_view", "feature": "f"})
+
+    left = pe.summary(since=100.0, until=101.0)["matched"]
+    right = pe.summary(since=101.0, until=102.0)["matched"]
+    tail = pe.summary(since=102.0)["matched"]
+    assert left + right + tail == pe.summary()["in_window"] == 5
+    # Explicit boundary check: ts=101.0 must land in `right`, not `left`.
+    assert left == 2 and right == 2 and tail == 1
+
+
+def test_summary_ring_stats_not_sliced_by_window(clock):
+    from clawmetry import _paywall_events as pe
+
+    for ts in (100.0, 200.0, 300.0):
+        _record(pe, clock, ts, {"event": "paywall_view", "feature": "f"})
+
+    s = pe.summary(since=250.0)
+    assert s["matched"] == 1              # only ts=300 lands in the window
+    assert s["in_window"] == 3            # ring size unaffected
+    assert s["total"] == 3                # lifetime counter unaffected
+    assert s["first_ts"] == 100.0         # never sliced
+    assert s["last_ts"] == 300.0
+
+
+def test_summary_window_and_categorical_filter_combine(clock):
+    from clawmetry import _paywall_events as pe
+
+    _record(pe, clock, 100.0, {"event": "paywall_view",      "feature": "fleet"})
+    _record(pe, clock, 200.0, {"event": "paywall_cta_click", "feature": "fleet"})
+    _record(pe, clock, 300.0, {"event": "paywall_cta_click", "feature": "anomaly"})
+
+    s = pe.summary(event="paywall_cta_click", since=150.0, until=250.0)
+    assert s["matched"] == 1
+    assert s["by_feature"] == {"fleet": 1}
+    assert s["filters"] == {"event": "paywall_cta_click"}
+    assert s["time_window"] == {"since": 150.0, "until": 250.0}
+
+
+def test_summary_bogus_bound_collapses_to_not_supplied(clock):
+    from clawmetry import _paywall_events as pe
+
+    _record(pe, clock, 100.0, {"event": "paywall_view", "feature": "f"})
+    for bad in ("junk", float("nan"), -1, True):
+        s = pe.summary(since=bad)
+        assert s["matched"] == 1, f"since={bad!r} silently sliced the ring"
+        assert s["time_window"]["since"] is None
+    for bad in ("junk", -0.5, False):
+        s = pe.summary(until=bad)
+        assert s["matched"] == 1, f"until={bad!r} silently sliced the ring"
+        assert s["time_window"]["until"] is None
+
+
+def test_summary_empty_window_matches_nothing(clock):
+    """``since >= until`` is an empty half-open interval by construction --
+    a caller supplying identical bounds asks for zero rows and gets them,
+    but the ring stats survive."""
+    from clawmetry import _paywall_events as pe
+
+    _record(pe, clock, 100.0, {"event": "paywall_view", "feature": "f"})
+    s = pe.summary(since=200.0, until=200.0)
+    assert s["matched"] == 0
+    assert s["by_feature"] == {}
+    assert s["in_window"] == 1
+    assert s["time_window"] == {"since": 200.0, "until": 200.0}
+
+
+# ── store-level recent + count_matching ─────────────────────────────────────
+
+
+def test_recent_respects_time_window(clock):
+    from clawmetry import _paywall_events as pe
+
+    _record(pe, clock, 100.0, {"event": "paywall_view", "feature": "old"})
+    _record(pe, clock, 200.0, {"event": "paywall_view", "feature": "new"})
+
+    rows = pe.recent(50, since=150.0)
+    assert len(rows) == 1
+    assert rows[0]["feature"] == "new"
+
+
+def test_recent_window_and_filter_and_limit_compose(clock):
+    from clawmetry import _paywall_events as pe
+
+    for ts, feature in ((100.0, "fleet"), (110.0, "fleet"), (120.0, "fleet"),
+                        (200.0, "anomaly")):
+        _record(pe, clock, ts, {"event": "paywall_cta_click", "feature": feature})
+
+    rows = pe.recent(2, feature="fleet", since=100.0, until=200.0)
+    # Newest-first within the window; limit clamps AFTER filtering.
+    assert len(rows) == 2
+    assert [r["ts"] for r in rows] == [120.0, 110.0]
+
+
+def test_count_matching_agrees_with_recent_within_ceiling(clock):
+    from clawmetry import _paywall_events as pe
+
+    for ts in (100.0, 110.0, 120.0, 200.0):
+        _record(pe, clock, ts, {"event": "paywall_view", "feature": "f"})
+
+    matched = pe.count_matching(since=100.0, until=150.0)
+    rows = pe.recent(pe.RECENT_MAX_LIMIT, since=100.0, until=150.0)
+    assert matched == len(rows) == 3
+
+
+def test_count_matching_unbounded_returns_full_ring(clock):
+    from clawmetry import _paywall_events as pe
+
+    for ts in (100.0, 110.0):
+        _record(pe, clock, ts, {"event": "paywall_view", "feature": "f"})
+    assert pe.count_matching() == 2
+
+
+# ── HTTP endpoints ───────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def client():
+    from routes.entitlement import bp_entitlement
+    from clawmetry import _paywall_events as pe
+
+    pe.reset()
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    app.config["TESTING"] = True
+    try:
+        yield app.test_client()
+    finally:
+        pe.reset()
+
+
+def _post(client, payload):
+    return client.post("/api/paywall/event", json=payload)
+
+
+def test_http_summary_unfiltered_carries_time_window(client):
+    _post(client, {"event": "paywall_view", "feature": "fleet"})
+    body = client.get("/api/paywall/events/summary").get_json()
+    assert body["time_window"] == {"since": None, "until": None}
+
+
+def test_http_summary_since_until_query_params(client, clock):
+    from clawmetry import _paywall_events as pe
+
+    # `_post` triggers `record_event` which reads `time.time()`; the
+    # `clock` fixture makes those reads deterministic.
+    clock["now"] = 100.0
+    _post(client, {"event": "paywall_view", "feature": "old"})
+    clock["now"] = 200.0
+    _post(client, {"event": "paywall_view", "feature": "new"})
+
+    body = client.get(
+        "/api/paywall/events/summary?since=150&until=300"
+    ).get_json()
+    assert body["time_window"] == {"since": 150.0, "until": 300.0}
+    assert body["matched"] == 1
+    assert body["by_feature"] == {"new": 1}
+    # Ring stats survive.
+    assert body["in_window"] == 2
+    assert body["total"] == 2
+
+    # `_pe` unused-import guard so an accidental removal of the fixture
+    # dependency doesn't break the test silently.
+    assert pe.RECENT_MAX_LIMIT >= 1
+
+
+def test_http_summary_blank_time_bounds_treated_as_not_supplied(client):
+    _post(client, {"event": "paywall_view", "feature": "f"})
+    body = client.get("/api/paywall/events/summary?since=&until=").get_json()
+    assert body["time_window"] == {"since": None, "until": None}
+    assert body["matched"] == 1
+
+
+def test_http_summary_bad_time_bounds_collapse(client):
+    _post(client, {"event": "paywall_view", "feature": "f"})
+    body = client.get(
+        "/api/paywall/events/summary?since=notanumber&until=NaN"
+    ).get_json()
+    assert body["time_window"] == {"since": None, "until": None}
+    assert body["matched"] == 1
+
+
+def test_http_recent_since_until_query_params(client, clock):
+    clock["now"] = 100.0
+    _post(client, {"event": "paywall_view", "feature": "old"})
+    clock["now"] = 200.0
+    _post(client, {"event": "paywall_view", "feature": "new"})
+
+    body = client.get(
+        "/api/paywall/events/recent?since=150&until=300"
+    ).get_json()
+    assert body["time_window"] == {"since": 150.0, "until": 300.0}
+    assert body["matched"] == 1
+    assert body["count"] == 1
+    assert body["events"][0]["feature"] == "new"
+
+
+def test_http_recent_unfiltered_carries_time_window(client):
+    _post(client, {"event": "paywall_view", "feature": "f"})
+    body = client.get("/api/paywall/events/recent").get_json()
+    assert body["time_window"] == {"since": None, "until": None}
+
+
+def test_http_summary_matched_equals_recent_matched_across_window(client, clock):
+    """Dashboard tile bound to both endpoints with the same query must see
+    the same ``matched`` count regardless of the categorical filters +
+    window combined."""
+    for ts, event, feature in (
+        (100.0, "paywall_view",      "fleet"),
+        (110.0, "paywall_view",      "fleet"),
+        (120.0, "paywall_cta_click", "fleet"),
+        (200.0, "paywall_view",      "anomaly"),
+    ):
+        clock["now"] = ts
+        _post(client, {"event": event, "feature": feature})
+
+    q = "event=paywall_view&feature=fleet&since=100&until=150"
+    s = client.get(f"/api/paywall/events/summary?{q}").get_json()
+    r = client.get(f"/api/paywall/events/recent?limit=200&{q}").get_json()
+    assert s["matched"] == r["matched"] == 2
+    assert s["time_window"] == r["time_window"] == {
+        "since": 100.0, "until": 150.0,
+    }
+
+
+def test_http_summary_fallback_shape_includes_time_window(client, monkeypatch):
+    """Even the error-path neutral shape must carry ``time_window`` so a
+    caller can trust the top-level key set is stable."""
+    from clawmetry import _paywall_events as pe
+
+    def _boom(**kwargs):
+        raise RuntimeError("simulated store failure")
+
+    monkeypatch.setattr(pe, "summary", _boom)
+    body = client.get(
+        "/api/paywall/events/summary?since=100&until=200"
+    ).get_json()
+    assert "time_window" in body
+    assert body["time_window"] == {"since": None, "until": None}
+    assert body["matched"] == 0
+
+
+def test_http_recent_fallback_shape_includes_time_window(client, monkeypatch):
+    from clawmetry import _paywall_events as pe
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("simulated store failure")
+
+    monkeypatch.setattr(pe, "recent", _boom)
+    body = client.get("/api/paywall/events/recent?since=100").get_json()
+    assert "time_window" in body
+    assert body["time_window"] == {"since": None, "until": None}
+    assert body["events"] == []
+
+
+def test_http_recent_time_window_echoed_even_when_filters_mismatch(client, clock):
+    """A window that matches nothing must still echo the resolved bounds
+    so the UI can render the window it asked for."""
+    clock["now"] = 100.0
+    _post(client, {"event": "paywall_view", "feature": "f"})
+    body = client.get(
+        "/api/paywall/events/recent?since=500&until=600"
+    ).get_json()
+    assert body["matched"] == 0
+    assert body["events"] == []
+    assert body["time_window"] == {"since": 500.0, "until": 600.0}
+
+
+def test_math_is_used():
+    """Sanity: ``math`` is imported at module top for the NaN test."""
+    assert math.isnan(float("nan"))


### PR DESCRIPTION
## Summary

- Adds `since` / `until` (epoch-seconds, half-open `[since, until)`) filter kwargs to `_PaywallEventStore.summary` / `recent` / `count_matching` and their module shims in `clawmetry/_paywall_events.py`.
- Wires the matching `?since=&until=` query params through both `/api/paywall/events/summary` and `/api/paywall/events/recent` in `routes/entitlement.py`.
- Both endpoints now always emit `time_window: {"since": <float|null>, "until": <float|null>}` at the top level so a dashboard tile can trust the envelope key set is stable. Neutral fallback envelopes carry the new field too.
- Ships in **GRACE** — no entitlement gate, no capacity accounting; a bogus bound (non-numeric, NaN, negative epoch, `bool`) collapses to "not supplied" so a stray query string cannot silently blank a tile.

## Design notes

- **Half-open interval.** `since` is inclusive, `until` is exclusive. Back-to-back windows (`[100,200)` + `[200,300)`) partition the ring cleanly with no double-counting on the boundary — pinned by `test_summary_back_to_back_windows_do_not_double_count`.
- **Ring stats are never sliced by the window.** `total`, `dropped`, `first_ts`, `last_ts`, `capacity`, and unfiltered `in_window` still describe the ring itself so a filtered tile can see churn / evictions in context. The `by_*` breakdowns and `matched` reflect the post-filter, post-window subset.
- **Filter + window `AND`-combine.** `event=paywall_cta_click&feature=fleet&since=100&until=200` narrows to CTA clicks on `fleet` in that window.
- **Cross-endpoint parity.** `summary.matched == recent.matched` for the same categorical filters + window, so a dashboard tile binding the same query to both endpoints reads the same "N of M" figure from each. Pinned by `test_http_summary_matched_equals_recent_matched_across_window`.

## Test plan

- [x] `python -m py_compile clawmetry/_paywall_events.py routes/entitlement.py tests/test_paywall_events_time_window.py` — clean
- [x] `python -m pytest tests/test_paywall_events_time_window.py` — 28 passed
- [x] Full paywall suite regression sweep: `python -m pytest tests/test_paywall_events_store.py tests/test_paywall_events_api.py tests/test_paywall_events_summary_filters.py tests/test_paywall_events_recent_filters.py tests/test_paywall_events_time_window.py tests/test_paywall_event_api.py` — 142 passed (existing shape-pinning tests updated for the new `time_window` field)
- [x] Entitlement API sanity: `python -m pytest tests/test_entitlement_api.py tests/test_entitlement_api_fallback_shape.py` — 39 passed

## Local operator verification checklist

Since this branch can't touch the live daemon or the browser from the sandbox, please verify locally before flipping to ready-for-review:

- [ ] Copy changed files into the installed package: `cp clawmetry/_paywall_events.py ~/.clawmetry/lib/python*/site-packages/clawmetry/` and `cp routes/entitlement.py ~/.clawmetry/lib/python*/site-packages/routes/`
- [ ] Clear `__pycache__`: `find ~/.clawmetry/lib -name __pycache__ -exec rm -rf {} +` (ignore the "no such file" warnings)
- [ ] Restart the daemon: `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
- [ ] Fire a few paywall beacons from the running UI (view a locked tile, click the CTA) so the ring has something to slice
- [ ] `curl 'http://localhost:8900/api/paywall/events/summary' | jq '.time_window'` — expect `{"since": null, "until": null}`
- [ ] `curl 'http://localhost:8900/api/paywall/events/summary?since=0&until=9999999999' | jq '.matched, .time_window'` — expect the full ring count and the echoed bounds as floats
- [ ] `curl 'http://localhost:8900/api/paywall/events/recent?since=0&until=9999999999' | jq '.matched, .time_window'` — same as summary
- [ ] `curl 'http://localhost:8900/api/paywall/events/summary?since=junk' | jq '.time_window.since'` — expect `null` (typo does NOT slice the ring)
- [ ] Snapshot decrypts + browser tile renders with the new `time_window` key present in both endpoint envelopes

---
_Generated by [Claude Code](https://claude.ai/code/session_01EcSB9fcwTUTVPYFnCUBXGJ)_