### PR TITLE
fix: surface skills.workshop.approvalPolicy in adapter detect() metadata

### DIFF
--- a/clawmetry/adapters/openclaw.py
+++ b/clawmetry/adapters/openclaw.py
@@ -1821,6 +1821,43 @@ def _gateway_trusted_proxy_devices() -> dict:
         }
     except Exception:
         return {}
+
+
+def _workshop_approval_config() -> dict:
+    """Read Skill Workshop approval-policy from openclaw.json (#3992).
+
+    Surfaces ``skills.workshop.approvalPolicy`` in the adapter's detect()
+    metadata so cloud-synced fleet views can show whether agent-initiated
+    skill apply/reject/quarantine actions are gated by human approval.
+
+    Returns ``{"workshopApprovalPolicy": <value>}`` when the key is present,
+    ``{}`` otherwise. Never raises.
+    """
+    try:
+        import json as _json
+        home = os.environ.get("OPENCLAW_HOME") or os.path.expanduser("~/.openclaw")
+        cfg_path = os.path.join(home, "openclaw.json")
+        if not os.path.isfile(cfg_path):
+            alt = os.path.expanduser("~/.clawdbot/openclaw.json")
+            if os.path.isfile(alt):
+                cfg_path = alt
+            else:
+                return {}
+        with open(cfg_path) as fh:
+            cfg = _json.load(fh)
+        if not isinstance(cfg, dict):
+            return {}
+        workshop = (cfg.get("skills") or {}).get("workshop")
+        if not isinstance(workshop, dict):
+            return {}
+        policy = workshop.get("approvalPolicy")
+        if policy is None:
+            return {}
+        return {"workshopApprovalPolicy": str(policy)}
+    except Exception:
+        return {}
+
+
 class OpenClawAdapter(AgentAdapter):
     name = "openclaw"
     display_name = "OpenClaw"
@@ -1940,6 +1977,11 @@ class OpenClawAdapter(AgentAdapter):
             _gw_events = _gateway_log_events()
             if _gw_events:
                 meta["gatewayLogEvents"] = _gw_events
+            # Skill Workshop approval-policy (#3992): surfaces
+            # skills.workshop.approvalPolicy from openclaw.json so cloud-synced
+            # fleet views know whether autonomous skill actions are gated by
+            # human approval.  Returns {} on installs without the key.
+            meta.update(_workshop_approval_config())
             return DetectResult(
                 name=self.name,
                 display_name=self.display_name,

--- a/tests/test_obs_gap_workshop_approval_3992.py
+++ b/tests/test_obs_gap_workshop_approval_3992.py
@@ -1,0 +1,43 @@
+"""Tests for _workshop_approval_config() in the OpenClaw adapter (#3992).
+
+Gap: detect() metadata didn't include skills.workshop.approvalPolicy, so
+cloud-synced fleet views couldn't surface whether autonomous skill
+apply/reject/quarantine actions are gated by human approval.
+"""
+import json
+
+import pytest
+
+from clawmetry.adapters.openclaw import _workshop_approval_config
+
+
+def test_policy_pending(tmp_path, monkeypatch):
+    cfg = {"skills": {"workshop": {"approvalPolicy": "pending"}}}
+    (tmp_path / "openclaw.json").write_text(json.dumps(cfg))
+    monkeypatch.setenv("OPENCLAW_HOME", str(tmp_path))
+    assert _workshop_approval_config() == {"workshopApprovalPolicy": "pending"}
+
+
+def test_policy_auto(tmp_path, monkeypatch):
+    cfg = {"skills": {"workshop": {"approvalPolicy": "auto"}}}
+    (tmp_path / "openclaw.json").write_text(json.dumps(cfg))
+    monkeypatch.setenv("OPENCLAW_HOME", str(tmp_path))
+    assert _workshop_approval_config() == {"workshopApprovalPolicy": "auto"}
+
+
+def test_policy_absent(tmp_path, monkeypatch):
+    cfg = {"skills": {"workshop": {}}}
+    (tmp_path / "openclaw.json").write_text(json.dumps(cfg))
+    monkeypatch.setenv("OPENCLAW_HOME", str(tmp_path))
+    assert _workshop_approval_config() == {}
+
+
+def test_no_config_file(tmp_path, monkeypatch):
+    monkeypatch.setenv("OPENCLAW_HOME", str(tmp_path))
+    assert _workshop_approval_config() == {}
+
+
+def test_non_dict_config(tmp_path, monkeypatch):
+    (tmp_path / "openclaw.json").write_text("[1, 2, 3]")
+    monkeypatch.setenv("OPENCLAW_HOME", str(tmp_path))
+    assert _workshop_approval_config() == {}


### PR DESCRIPTION
Closes #3992

## Summary

- `clawmetry/adapters/openclaw.py` — adds `_workshop_approval_config()` helper that reads `~/.openclaw/openclaw.json` and returns `{"workshopApprovalPolicy": <value>}` when `skills.workshop.approvalPolicy` is set. Wired into `detect()` via `meta.update(...)` so cloud-sync snapshots and fleet views include the setting.
- `tests/test_obs_gap_workshop_approval_3992.py` (new) — 5 unit tests: policy `"pending"`, policy `"auto"`, key absent, no config file, malformed config.

**Not included:** the apply/reject/quarantine action audit log — its on-disk path and schema are only referenced in OpenClaw's Unreleased CHANGELOG, not in the stable API. That can follow once the format is documented.

## Test plan

- `python3 -m pytest tests/test_obs_gap_workshop_approval_3992.py -v` — all 5 pass.
- `python3 -m py_compile clawmetry/adapters/openclaw.py` — clean.
- On a machine without `~/.openclaw/openclaw.json`: `detect().meta` unchanged (key absent, `{}` is a no-op `update`).

---
_Generated by [Claude Code](https://claude.ai/code/session_015E6AAyG4A3wNt76u2iu7ri)_