### PR TITLE
feat(extensions): surface probed_plugins in /api/extensions

### DIFF
--- a/routes/extensions.py
+++ b/routes/extensions.py
@@ -33,12 +33,16 @@ def api_extensions():
     Response shape::
 
         {
-          "plugins":             ["clawmetry-pro", ...],
-          "plugin_count":        1,
-          "failed_plugins":      [{"name": "clawmetry-pro", "error": "..."}],
-          "failed_plugin_count": 1,
-          "events":              ["session.snapshot", ...],
-          "handler_counts":      {"session.snapshot": 2, ...}
+          "plugins":              ["clawmetry-pro", ...],
+          "plugin_count":         1,
+          "failed_plugins":       [{"name": "clawmetry-pro", "error": "..."}],
+          "failed_plugin_count":  1,
+          "probed_plugins":       [{"name": "clawmetry-pro",
+                                    "value": "clawmetry_pro.ext:register_all",
+                                    "importable": true, "error": null}, ...],
+          "probed_plugin_count":  1,
+          "events":               ["session.snapshot", ...],
+          "handler_counts":       {"session.snapshot": 2, ...}
         }
 
     ``plugins`` and ``failed_plugins`` are complementary — a given entry
@@ -48,11 +52,31 @@ def api_extensions():
     exception's ``str`` is surfaced (no traceback) so paths / secrets from
     frames never leak.
 
+    ``probed_plugins`` is a third, orthogonal view produced by
+    :func:`clawmetry.extensions.probe_plugins`: a side-effect-free
+    enumeration of every ``clawmetry.extensions`` entry point currently
+    visible to ``importlib.metadata``, with each entry's ``value`` string
+    and whether ``ep.load()`` (import only — not invocation) succeeds
+    RIGHT NOW. Complements the in-process ``plugins`` /
+    ``failed_plugins`` mirrors, which reflect the state captured when
+    :func:`clawmetry.extensions.load_plugins` last ran at daemon startup.
+    The probe answers "would ClawMetry try to load this on the next
+    restart, and would the import work?" — the two questions diverge when
+    a wheel is installed after startup, when a post-startup dependency
+    upgrade broke the import, or when the on-disk marker exists but the
+    module can't actually be imported.
+
     ``failed_plugins`` is derived from an in-memory mirror populated by
     :func:`clawmetry.extensions.load_plugins`. On installs running an older
     ``clawmetry`` where the mirror doesn't exist yet (or if fetching it
     raises), the key falls back to ``[]`` / ``0`` and the rest of the
     envelope still populates — the endpoint never 5xxs.
+
+    ``probed_plugins`` degrades the same way: an older ``clawmetry`` that
+    lacks :func:`probe_plugins` reports ``[]`` / ``0`` here while the
+    other fields still populate. That way a mixed deploy (new routes,
+    old core) never 5xxs the dashboard's diagnostic panel just because a
+    younger field is missing on the core side.
 
     Never raises and never returns 5xx — any introspection failure resolves to
     an empty shape so the dashboard's diagnostic panel always has something
@@ -71,6 +95,14 @@ def api_extensions():
         except Exception as exc:
             logger.warning("extensions: failed_plugins introspection failed: %s", exc)
             failed = []
+        # Same defensive posture for the newer :func:`probe_plugins` accessor:
+        # an older core wheel that predates it should still let the rest of
+        # the envelope populate.
+        try:
+            probed = [dict(entry) for entry in _ext.probe_plugins()]
+        except Exception as exc:
+            logger.warning("extensions: probe_plugins introspection failed: %s", exc)
+            probed = []
         events = list(_ext.registered_events())
         handler_counts = {evt: _ext.handler_count(evt) for evt in events}
         return jsonify({
@@ -78,6 +110,8 @@ def api_extensions():
             "plugin_count": len(plugins),
             "failed_plugins": failed,
             "failed_plugin_count": len(failed),
+            "probed_plugins": probed,
+            "probed_plugin_count": len(probed),
             "events": events,
             "handler_counts": handler_counts,
         })
@@ -88,6 +122,8 @@ def api_extensions():
             "plugin_count": 0,
             "failed_plugins": [],
             "failed_plugin_count": 0,
+            "probed_plugins": [],
+            "probed_plugin_count": 0,
             "events": [],
             "handler_counts": {},
         })

--- a/tests/test_extensions_introspection.py
+++ b/tests/test_extensions_introspection.py
@@ -262,6 +262,8 @@ def test_api_extensions_shape_empty(client):
         "plugin_count": 0,
         "failed_plugins": [],
         "failed_plugin_count": 0,
+        "probed_plugins": [],
+        "probed_plugin_count": 0,
         "events": [],
         "handler_counts": {},
     }
@@ -307,6 +309,8 @@ def test_api_extensions_never_raises(client, monkeypatch):
         "plugin_count": 0,
         "failed_plugins": [],
         "failed_plugin_count": 0,
+        "probed_plugins": [],
+        "probed_plugin_count": 0,
         "events": [],
         "handler_counts": {},
     }
@@ -358,3 +362,127 @@ def test_api_extensions_survives_missing_failed_plugins_helper(client, monkeypat
     assert body["plugin_count"] == 1
     assert body["failed_plugins"] == []
     assert body["failed_plugin_count"] == 0
+
+
+# ── GET /api/extensions × probed_plugins ────────────────────────────────────
+
+
+def _probe_fake_eps(*triples):
+    """Build a fake entry-point list that matches the ``probe_plugins`` row
+    shape — same helper the probe unit tests use, inlined here so the API
+    test doesn't reach across modules for its stubs."""
+    class _EP:
+        def __init__(self, fn, name, value):
+            self._fn = fn
+            self.name = name
+            self.value = value
+
+        def load(self):
+            return self._fn()
+
+    return [_EP(fn, n, v) for fn, n, v in triples]
+
+
+def test_api_extensions_reports_probed_plugins(client, monkeypatch):
+    """The probe surfaces every visible entry point with its ``value`` string
+    and whether ``ep.load()`` succeeds right now — even ones ``load_plugins``
+    hasn't touched (a wheel installed post-startup, before a daemon reload)."""
+    def _ok():
+        return lambda: None
+
+    def _bad():
+        raise RuntimeError("import kaboom")
+
+    monkeypatch.setattr(
+        ext, "_select_entry_points",
+        lambda group: _probe_fake_eps(
+            (_ok,  "clawmetry-pro", "clawmetry_pro.ext:register_all"),
+            (_bad, "flaky-plugin",  "flaky.mod:register_all"),
+        ),
+    )
+
+    body = json.loads(client.get("/api/extensions").data)
+    assert body["probed_plugin_count"] == 2
+    assert body["probed_plugins"] == [
+        {
+            "name": "clawmetry-pro",
+            "value": "clawmetry_pro.ext:register_all",
+            "importable": True,
+            "error": None,
+        },
+        {
+            "name": "flaky-plugin",
+            "value": "flaky.mod:register_all",
+            "importable": False,
+            "error": "import kaboom",
+        },
+    ]
+
+
+def test_api_extensions_probed_independent_of_load_plugins(client, monkeypatch):
+    """``probed_plugins`` reflects the CURRENT importability of every visible
+    entry point — it must NOT require ``load_plugins`` to have run. That's
+    the whole point: on a short-lived process (``clawmetry status`` shell,
+    or a dashboard restart after a post-startup wheel install) the probe
+    still populates while ``plugins`` reads empty.
+    """
+    monkeypatch.setattr(
+        ext, "_select_entry_points",
+        lambda group: _probe_fake_eps(
+            (lambda: (lambda: None), "clawmetry-pro", "pkg:reg"),
+        ),
+    )
+    # Deliberately do NOT call ext.load_plugins() — the ``plugins`` mirror
+    # should stay empty while the probe still surfaces the entry point.
+
+    body = json.loads(client.get("/api/extensions").data)
+    assert body["plugins"] == []
+    assert body["plugin_count"] == 0
+    assert body["probed_plugin_count"] == 1
+    assert body["probed_plugins"][0]["name"] == "clawmetry-pro"
+    assert body["probed_plugins"][0]["importable"] is True
+
+
+def test_api_extensions_survives_missing_probe_plugins_helper(client, monkeypatch):
+    """A mixed deploy where the routes package is new but the core
+    ``clawmetry`` is old (no :func:`probe_plugins`) must still populate the
+    rest of the envelope instead of 5xx'ing the whole response — same
+    contract we honour for the older ``failed_plugins`` accessor.
+    """
+    monkeypatch.setattr(
+        ext, "_select_entry_points",
+        lambda group: _fake_eps((lambda: None, "clawmetry-pro")),
+    )
+    ext.load_plugins()
+
+    def missing():
+        raise AttributeError("probe_plugins")
+
+    monkeypatch.setattr(ext, "probe_plugins", missing)
+
+    body = json.loads(client.get("/api/extensions").data)
+    assert body["plugins"] == ["clawmetry-pro"]
+    assert body["plugin_count"] == 1
+    assert body["probed_plugins"] == []
+    assert body["probed_plugin_count"] == 0
+
+
+def test_api_extensions_probed_row_never_leaks_traceback(client, monkeypatch):
+    """A load-time error surfaces as ``str(exc)`` only — no traceback / frame
+    locals — matching the same posture the ``failed_plugins`` mirror honours,
+    so a stack-frame path never leaks into ``GET /api/extensions``.
+    """
+    def _leaky():
+        secret = "/home/op/.clawmetry/license.key"  # noqa: F841
+        raise RuntimeError("plain")
+
+    monkeypatch.setattr(
+        ext, "_select_entry_points",
+        lambda group: _probe_fake_eps((_leaky, "clawmetry-pro", "pkg:reg")),
+    )
+
+    body = json.loads(client.get("/api/extensions").data)
+    row = body["probed_plugins"][0]
+    assert row["error"] == "plain"
+    assert "Traceback" not in row["error"]
+    assert "license.key" not in row["error"]


### PR DESCRIPTION
## Summary

- Adds `probed_plugins` + `probed_plugin_count` to `GET /api/extensions`, exposing the side-effect-free `clawmetry.extensions.probe_plugins()` view over HTTP alongside the existing in-process `plugins` / `failed_plugins` mirrors.
- The probe answers a distinct triage question — *"would ClawMetry try to load this on the next restart, and would the import work right now?"* — that diverges from `plugins` when a wheel is installed after daemon startup, when a post-startup dependency upgrade breaks the import, or when the on-disk marker exists but the module can't actually be imported.
- Mirrors the existing defensive posture: an older core wheel that predates `probe_plugins()` (or a helper that raises) degrades the field to `[]` / `0` rather than 5xx'ing the whole envelope, so a mixed deploy (new routes, old core) never blanks the dashboard's diagnostic tab.

## What changed

- `routes/extensions.py` — resolves `probe_plugins()` inside `api_extensions()` under its own `try` / `except` block, appending `probed_plugins` + `probed_plugin_count` to the JSON envelope. Docstring updated to describe the three orthogonal views and their degrade contracts.
- `tests/test_extensions_introspection.py`:
  - `test_api_extensions_shape_empty` updated to include the two new keys (twice, matching the file's existing duplicated fixture literal).
  - `test_api_extensions_reports_probed_plugins` — pins full row shape (name / value / importable / error) for one success + one import-error entry.
  - `test_api_extensions_probed_independent_of_load_plugins` — the whole point: the probe populates even when `load_plugins()` was never called on this process.
  - `test_api_extensions_survives_missing_probe_plugins_helper` — same fallback contract as `failed_plugins` (mixed deploy, new routes + old core).
  - `test_api_extensions_probed_row_never_leaks_traceback` — only `str(exc)` is captured; no traceback / frame locals leak.

## Test plan

- [x] `python -m pytest tests/test_extensions_introspection.py tests/test_extensions_probe.py tests/test_extensions.py tests/test_cli_extensions_subcommand.py tests/test_cli_status_extensions.py tests/test_claudecode_loads_plugins.py tests/test_sync_loads_plugins.py tests/test_proxy_loads_plugins.py` — 69 passed
- [x] `python -m py_compile routes/extensions.py tests/test_extensions_introspection.py` — clean
- [x] `ruff check routes/extensions.py tests/test_extensions_introspection.py` — clean (pre-existing lint noise in `dashboard.py` is unchanged, and CI already treats ruff as warnings-only)
- [x] The existing CLI↔HTTP drift test (`test_extensions_json_matches_api_extensions_response`) uses a shared-subset check on 6 keys — additive extension to the HTTP surface does not break it. The CLI `--json` shape is untouched by this PR; catching the CLI up to also emit `probed_plugins` can follow as a separate change.

## Local operator verification checklist

The remote fire has no access to the local daemon / live cloud snapshot / browser, so the operator drives:

- [ ] Copy `routes/extensions.py` into `~/.clawmetry/lib/python3.*/site-packages/routes/` (or reinstall the wheel).
- [ ] Clear `__pycache__/` for `routes/` and `clawmetry/`.
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` (macOS) or the systemd equivalent.
- [ ] `curl -sS http://localhost:8900/api/extensions | jq .` — envelope now includes `probed_plugins` + `probed_plugin_count`.
- [ ] Cross-check on a node WITH `clawmetry-pro` installed: `probed_plugins[].importable` should be `true` for each entry, and the `name` set should equal `plugins ∪ failed_plugins[].name`.
- [ ] Cross-check on a node WITHOUT `clawmetry-pro`: `probed_plugins == []` and `probed_plugin_count == 0`.
- [ ] Cross-check the "installed after startup" flow: `pip install clawmetry-pro` on a running daemon (no restart), then hit `/api/extensions` — `probed_plugins` should show the new entry as `importable: true` even while `plugins` is still empty until the next daemon restart.
- [ ] Decrypt the live cloud snapshot, verify the diagnostic panel renders the new field without a browser console error.
- [ ] Browser: dashboard extensions/diagnostic tab still loads (any consumer relying on additive-only extension is unaffected).

Stays in GRACE — no gating change, no version bump, no release tag. Local operator handles verification, release, and merge per FLYWHEEL.md.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XS7Ygk8AovyWBZP374eoC5)_