### PR TITLE
fix: correct stale issue references in C6 notification paths (#3864)

### DIFF
--- a/.github/workflows/apply-required-checks.yml
+++ b/.github/workflows/apply-required-checks.yml
@@ -18,7 +18,7 @@ name: Apply required E2E status checks (C6 -- one-shot)
 #     With only GITHUB_TOKEN (ghs_): read-only verify path in the script
 #     (exits 0 if C6 configured, exits 1 if not -- no admin rights needed).
 #     With E2E_ADMIN_PAT: full apply + verify.
-#     On failure, posts a notification comment on tracking issue #3970.
+#     On failure, posts a notification comment on tracking issue #3864.
 #
 # TOKEN PATHS (priority order):
 #   1. inputs.pat_token  -- PAT typed into the Run workflow dialog
@@ -37,7 +37,7 @@ name: Apply required E2E status checks (C6 -- one-shot)
 #   clawmetry-landing.
 #
 # Idempotent: running multiple times is safe.
-# Tracking: vivekchand/clawmetry#3970
+# Tracking: vivekchand/clawmetry#3864
 
 on:
   workflow_dispatch:
@@ -119,7 +119,7 @@ jobs:
         run: python3 scripts/apply_required_status_checks.py
 
       # When the C6 read-only verify exits 1 (checks not yet configured on main),
-      # post or update a comment on the E2E Robustness tracking issue #3970 so the
+      # post or update a comment on the E2E Robustness tracking issue #3864 so the
       # repo admin receives a GitHub notification.
       #
       # Only fires on push-to-main (the automated verify path), NOT on manual
@@ -161,15 +161,15 @@ jobs:
 
           # Upsert: update existing comment if present, otherwise create new.
           existing_id=$(gh api -X GET \
-            "repos/${REPO}/issues/3970/comments" \
+            "repos/${REPO}/issues/3864/comments" \
             --jq 'map(select(.body | startswith("<!-- c6-notify-bot -->"))) | .[0].id // empty' \
             2>/dev/null || echo "")
           if [ -n "${existing_id}" ]; then
             gh api -X PATCH "repos/${REPO}/issues/comments/${existing_id}" \
               -f body="${BODY}" > /dev/null
-            echo "Updated existing C6 notification on #3970 (comment ${existing_id})"
+            echo "Updated existing C6 notification on #3864 (comment ${existing_id})"
           else
-            gh api -X POST "repos/${REPO}/issues/3970/comments" \
+            gh api -X POST "repos/${REPO}/issues/3864/comments" \
               -f body="${BODY}" > /dev/null
-            echo "Posted new C6 notification on #3970"
+            echo "Posted new C6 notification on #3864"
           fi

--- a/scripts/close-c6.sh
+++ b/scripts/close-c6.sh
@@ -19,7 +19,7 @@
 # After running: every PR in those 3 repos must pass the E2E suite to merge.
 # This closes criterion C6 of the E2E Robustness epic.
 #
-# Tracking: vivekchand/clawmetry#3906
+# Tracking: vivekchand/clawmetry#3864
 
 set -euo pipefail
 


### PR DESCRIPTION
## Summary

- `apply-required-checks.yml` was posting push-triggered C6 missing-check notifications to issue **#3970** (does not exist). Every push to main since the workflow was written has silently failed at the notification step -- the `gh api` GET and POST both 404'd, swallowing the notification.
- `close-c6.sh` had a stale comment referencing **#3906** instead of the actual tracking issue.
- Both corrected to **#3864** (the real E2E Robustness epic tracker).

No logic changes -- the core apply path (`apply_required_status_checks.py`) is unaffected.

## Test plan

- [ ] `apply-required-checks.yml` notification step references `issues/3864/comments` in both GET (dedup check) and POST (create comment) -- confirmed by inspection of pushed diff.
- [ ] `scripts/close-c6.sh` comment now references #3864 -- confirmed by inspection.
- [ ] No other logic changed; the core `apply_required_status_checks.py` runner is untouched.

---

*E2E Robustness cron fire 2026-07-24. C6 is the sole remaining red criterion (6/7 green). This fixes the silent notification failure on every push to main. Tracking: #3864.*

---
_Generated by [Claude Code](https://claude.ai/code/session_017ysT49vagDmABXH8UkVkxP)_