### PR TITLE
feat(entitlement): capacity_headroom_batch + /api/entitlement/capacity-headroom-batch

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -3221,6 +3221,69 @@ def capacity_headroom_at(
         return None
 
 
+def capacity_headroom_batch(
+    *,
+    channels: int | None = None,
+    retention_days: int | None = None,
+    nodes: int | None = None,
+) -> list[dict]:
+    """Per-tier :func:`capacity_headroom_at` envelope for every purchasable
+    tier, walked in the same ``(rank, id)`` order the other ``*_batch``
+    siblings use.
+
+    Plural sibling of :func:`capacity_headroom_at`. Where the singular
+    ``_at`` helper answers "given my usage, what does headroom look like
+    at tier X" one tier at a time, the batch returns the same envelope
+    shape for every entry in :data:`_PURCHASABLE_TIERS` so a pricing-page
+    "at each tier, would my usage fit?" table can render every rung off
+    **one** round-trip instead of N calls to ``/capacity-headroom-at``.
+
+    Fills the ``_batch`` slot on the capacity-headroom axis alongside
+    :func:`capacity_diff_batch` (per-tier per-axis transition triples
+    against the resolved entitlement) and the per-axis
+    ``tiers_for_channel_count_batch`` / ``tiers_for_retention_window_batch``
+    / ``tiers_for_node_count_batch`` families. Each row is the exact
+    envelope :func:`capacity_headroom_at` returns
+    (``tier`` / ``tier_label`` / ``channels`` / ``retention_days`` /
+    ``nodes``) so a caller can pass any row through the existing
+    ``capacity_headroom_at`` renderer without reshaping.
+
+    Rows are ordered by tier rank ascending (cheapest -> most capable)
+    with ``id`` as a stable tiebreaker -- byte-stable against
+    :func:`capacity_diff_batch` / :func:`tier_unlocks_batch` /
+    :func:`tier_locks_batch` / :func:`preview_batch` so a pricing table
+    lines up rung-for-rung without client-side re-sort. The trial tier
+    is excluded (mirrors the other batches -- not purchasable).
+
+    Decoupled from the resolved entitlement -- every row walks the static
+    per-tier caps via :func:`capacity_headroom_at`, so grace vs enforce
+    yields byte-identical rows. Same per-axis "None means axis not
+    supplied" posture as the singular helpers: an unsupplied axis stays
+    ``None`` on every row; a supplied axis is echoed on every row.
+
+    Never raises: if the walker blows up the helper returns ``[]`` so the
+    pricing table falls back to an empty list instead of 500-ing.
+    """
+    try:
+        out: list[dict] = []
+        ordered = sorted(
+            _PURCHASABLE_TIERS, key=lambda t: (_TIER_RANK.get(t, -1), t)
+        )
+        for tid in ordered:
+            row = capacity_headroom_at(
+                tid,
+                channels=channels,
+                retention_days=retention_days,
+                nodes=nodes,
+            )
+            if row is not None:
+                out.append(row)
+        return out
+    except Exception as exc:
+        logger.warning("entitlements: capacity_headroom_batch failed: %s", exc)
+        return []
+
+
 def _capacity_row(from_tier: str, to_tier: str) -> dict:
     """Build one ``capacity_diff``-shape row for an arbitrary ``from -> to`` pair.
 

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -834,6 +834,97 @@ def api_entitlement_capacity_headroom_at():
         return jsonify({"error": "capacity-headroom-at failed"}), 500
 
 
+@bp_entitlement.route("/api/entitlement/capacity-headroom-batch")
+def api_entitlement_capacity_headroom_batch():
+    """``GET /api/entitlement/capacity-headroom-batch?channels=<int>
+    &retention_days=<int>&nodes=<int>`` -- per-tier headroom envelope for
+    every purchasable tier in one pass, given the caller-supplied per-axis
+    usage.
+
+    Plural sibling of ``/api/entitlement/capacity-headroom-at``: where the
+    singular ``_at`` endpoint returns one hypothetical tier's per-axis
+    envelope, the batch returns the same envelope for every entry in
+    :data:`entitlements._PURCHASABLE_TIERS` so a pricing-page "at each
+    tier, would my usage fit?" table can render every rung off **one**
+    round-trip instead of N calls to ``/capacity-headroom-at``.
+
+    Fills the ``_batch`` slot on the capacity-headroom axis alongside
+    ``/capacity-diff-batch`` (per-tier per-axis transition triples against
+    the resolved entitlement) and the per-axis
+    ``/tiers-for-channel-count-batch`` / ``/tiers-for-retention-window-batch``
+    / ``/tiers-for-node-count-batch`` families.
+
+    Response shape::
+
+        {
+          "tiers":             [<row>, ...],
+          "current_tier":      "<resolved tier id>",
+          "current_tier_rank": <int>,
+          "grace":             <bool>,
+          "enforced":          <bool>,
+        }
+
+    Each ``<row>`` matches ``/api/entitlement/capacity-headroom-at`` for
+    the same axis inputs byte-for-byte
+    (``tier`` / ``tier_label`` / ``channels`` / ``retention_days`` /
+    ``nodes``, with each per-axis row matching the
+    :func:`entitlements._headroom_row` shape). Rows are sorted by tier
+    rank ascending with ``id`` as a stable tiebreaker -- byte-stable
+    against ``/capacity-diff-batch`` / ``/tier-unlocks-batch`` /
+    ``/tier-locks-batch`` / ``/preview-batch`` so a pricing table lines
+    up rung-for-rung without client-side re-sort. The trial tier is
+    excluded (mirrors the other ``*-batch`` siblings -- not purchasable).
+
+    Per-axis ``None`` on every row means "axis not supplied" (matches
+    ``/capacity-headroom`` and ``/tiers-for-capacity-batch``'s posture).
+    A blank, non-int, negative, or ``bool``-in-disguise value on any
+    axis short-circuits that axis to ``None`` on every row -- a stray
+    query string cannot silently blank the whole ladder.
+
+    Decoupled from the resolved entitlement -- every row walks the
+    static per-tier caps -- so grace vs enforce yields byte-identical
+    ``tiers`` payloads. The envelope's ``current_tier`` / ``grace`` /
+    ``enforced`` still track the live resolver so the UI can highlight
+    the caller's current rung on the ladder.
+
+    Never 5xxs: on a resolver failure the empty-tiers grace envelope is
+    returned so a pricing table falls back to an empty list instead of
+    500-ing.
+    """
+    try:
+        from clawmetry import entitlements as _ent
+
+        kwargs: dict[str, int] = {}
+        for name in ("channels", "retention_days", "nodes"):
+            present, ok, val, _raw = _parse_capacity_arg(name)
+            if present and ok and val is not None and val >= 0:
+                kwargs[name] = val
+        rows = _ent.capacity_headroom_batch(**kwargs)
+        ent = _ent.get_entitlement()
+        return jsonify(
+            {
+                "tiers": rows,
+                "current_tier": ent.tier,
+                "current_tier_rank": _ent.tier_rank(ent.tier),
+                "grace": bool(ent.grace),
+                "enforced": _ent.is_enforced(),
+            }
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_capacity_headroom_batch: error: %s", exc
+        )
+        return jsonify(
+            {
+                "tiers": [],
+                "current_tier": "oss",
+                "current_tier_rank": 0,
+                "grace": True,
+                "enforced": False,
+            }
+        )
+
+
 @bp_entitlement.route("/api/entitlement/capacity-diff-batch")
 def api_entitlement_capacity_diff_batch():
     """``GET /api/entitlement/capacity-diff-batch`` -- per-axis capacity

--- a/tests/test_entitlement_capacity_headroom_batch.py
+++ b/tests/test_entitlement_capacity_headroom_batch.py
@@ -1,0 +1,225 @@
+"""Tests for :func:`clawmetry.entitlements.capacity_headroom_batch`.
+
+Plural sibling of :func:`capacity_headroom_at`. Fills the ``_batch`` slot
+on the capacity-headroom axis alongside :func:`capacity_diff_batch` and
+the per-axis ``tiers_for_{channel_count,retention_window,node_count}_batch``
+families.
+
+Pins:
+  * one row per purchasable tier, walked in ``(rank, id)`` order --
+    byte-stable against :func:`capacity_diff_batch` /
+    :func:`tier_unlocks_batch` / :func:`tier_locks_batch` so a pricing
+    table lines up rung-for-rung without client-side re-sort
+  * trial tier excluded (mirrors the other batches -- not purchasable)
+  * each row is byte-identical to the singular
+    :func:`capacity_headroom_at` for the same axis inputs
+  * decoupled from the resolved entitlement (grace vs enforce yields
+    byte-identical rows)
+  * per-axis "None means unset" posture propagates to every row
+  * never raises: a walker failure returns ``[]``
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def enforced(monkeypatch, tmp_path):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+# -- shape ---------------------------------------------------------------
+
+
+def test_returns_list(enforced):
+    assert isinstance(enforced.capacity_headroom_batch(channels=2), list)
+
+
+def test_one_row_per_purchasable_tier(enforced):
+    rows = enforced.capacity_headroom_batch(channels=2)
+    assert len(rows) == len(enforced._PURCHASABLE_TIERS)
+
+
+def test_trial_tier_excluded(enforced):
+    tiers = {r["tier"] for r in enforced.capacity_headroom_batch(channels=2)}
+    assert enforced.TIER_TRIAL not in tiers
+
+
+def test_row_envelope_shape(enforced):
+    rows = enforced.capacity_headroom_batch(
+        channels=2, retention_days=5, nodes=1
+    )
+    for r in rows:
+        assert set(r) == {
+            "tier", "tier_label", "channels", "retention_days", "nodes",
+        }
+
+
+# -- ordering: (rank, id) --------------------------------------------------
+
+
+def test_rows_ordered_by_rank_then_id(enforced):
+    rows = enforced.capacity_headroom_batch(channels=2)
+    seen = [(enforced._TIER_RANK.get(r["tier"], -1), r["tier"]) for r in rows]
+    assert seen == sorted(seen)
+
+
+def test_ordering_matches_capacity_diff_batch(enforced):
+    diff_ids = [r["target"] for r in enforced.capacity_diff_batch()]
+    headroom_ids = [
+        r["tier"] for r in enforced.capacity_headroom_batch(channels=2)
+    ]
+    assert diff_ids == headroom_ids
+
+
+# -- row parity with singular ---------------------------------------------
+
+
+def test_each_row_matches_capacity_headroom_at(enforced):
+    rows = enforced.capacity_headroom_batch(
+        channels=2, retention_days=5, nodes=1
+    )
+    for r in rows:
+        singular = enforced.capacity_headroom_at(
+            r["tier"], channels=2, retention_days=5, nodes=1
+        )
+        assert r == singular
+
+
+def test_unsupplied_axis_stays_none_on_every_row(enforced):
+    rows = enforced.capacity_headroom_batch(channels=2)
+    for r in rows:
+        assert r["channels"] is not None
+        assert r["retention_days"] is None
+        assert r["nodes"] is None
+
+
+def test_nothing_supplied_returns_all_none_rows(enforced):
+    rows = enforced.capacity_headroom_batch()
+    assert len(rows) == len(enforced._PURCHASABLE_TIERS)
+    for r in rows:
+        assert r["channels"] is None
+        assert r["retention_days"] is None
+        assert r["nodes"] is None
+
+
+# -- concrete per-tier caps ------------------------------------------------
+
+
+def _row_for(rows, tier):
+    for r in rows:
+        if r["tier"] == tier:
+            return r
+    raise AssertionError(f"tier {tier!r} missing from batch rows")
+
+
+def test_oss_channels_row_uses_free_cap(enforced):
+    rows = enforced.capacity_headroom_batch(channels=2)
+    row = _row_for(rows, enforced.TIER_OSS)["channels"]
+    assert row["cap"] == enforced._FREE_CHANNEL_LIMIT
+    assert row["is_unlimited"] is False
+
+
+def test_starter_channels_row_is_unlimited(enforced):
+    rows = enforced.capacity_headroom_batch(channels=99)
+    row = _row_for(rows, enforced.TIER_CLOUD_STARTER)["channels"]
+    assert row["cap"] is None
+    assert row["is_unlimited"] is True
+
+
+def test_pro_retention_row_cap_is_90d(enforced):
+    rows = enforced.capacity_headroom_batch(retention_days=45)
+    assert _row_for(rows, enforced.TIER_CLOUD_PRO)["retention_days"]["cap"] == 90
+
+
+def test_enterprise_retention_row_unlimited(enforced):
+    rows = enforced.capacity_headroom_batch(retention_days=365)
+    row = _row_for(rows, enforced.TIER_ENTERPRISE)["retention_days"]
+    assert row["cap"] is None
+    assert row["is_unlimited"] is True
+
+
+def test_starter_retention_over_limit_flag_flips(enforced):
+    rows = enforced.capacity_headroom_batch(retention_days=45)
+    row = _row_for(rows, enforced.TIER_CLOUD_STARTER)["retention_days"]
+    assert row["over_limit"] is True
+    assert row["remaining"] == -15
+
+
+# -- decoupled from resolver ----------------------------------------------
+
+
+def test_grace_vs_enforce_same_rows(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    import clawmetry.entitlements as e_grace
+
+    importlib.reload(e_grace)
+    e_grace.invalidate()
+    grace_rows = e_grace.capacity_headroom_batch(
+        channels=2, retention_days=5, nodes=1
+    )
+
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    import clawmetry.entitlements as e_enf
+
+    importlib.reload(e_enf)
+    e_enf.invalidate()
+    enf_rows = e_enf.capacity_headroom_batch(
+        channels=2, retention_days=5, nodes=1
+    )
+
+    assert grace_rows == enf_rows
+
+
+# -- never raises ---------------------------------------------------------
+
+
+def test_walker_failure_returns_empty_list(enforced, monkeypatch):
+    def _boom(*_a, **_kw):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(enforced, "capacity_headroom_at", _boom)
+    # The batch shells failures per row (via _at); a top-level exception in
+    # the sort/loop path collapses to [] rather than 500-ing.  We simulate
+    # that by breaking the tier-rank lookup instead.
+    monkeypatch.setattr(enforced, "_PURCHASABLE_TIERS", None)  # type: ignore[misc]
+    assert enforced.capacity_headroom_batch(channels=2) == []
+
+
+def test_per_row_helper_returning_none_is_dropped(enforced, monkeypatch):
+    real = enforced.capacity_headroom_at
+
+    def _drop_oss(perspective_tier, **kw):
+        if perspective_tier == enforced.TIER_OSS:
+            return None
+        return real(perspective_tier, **kw)
+
+    monkeypatch.setattr(enforced, "capacity_headroom_at", _drop_oss)
+    rows = enforced.capacity_headroom_batch(channels=2)
+    tiers = {r["tier"] for r in rows}
+    assert enforced.TIER_OSS not in tiers
+    # every other purchasable tier survives
+    assert tiers == set(enforced._PURCHASABLE_TIERS) - {enforced.TIER_OSS}

--- a/tests/test_entitlement_capacity_headroom_batch_api.py
+++ b/tests/test_entitlement_capacity_headroom_batch_api.py
@@ -1,0 +1,250 @@
+"""HTTP tests for ``/api/entitlement/capacity-headroom-batch``.
+
+Pins:
+  * envelope shape (``tiers`` / ``current_tier`` / ``current_tier_rank`` /
+    ``grace`` / ``enforced``)
+  * one row per purchasable tier, walked in ``(rank, id)`` order --
+    byte-stable against ``/capacity-diff-batch``
+  * each row is byte-identical to
+    ``/api/entitlement/capacity-headroom-at`` for the same axis inputs
+  * per-axis opt-in via query params (unsupplied axes stay ``None``
+    on every row)
+  * bad query values on any axis collapse that axis to ``None`` on
+    every row -- a stray ``?channels=junk`` cannot silently blank
+    the pricing ladder
+  * ``current_tier`` / ``grace`` / ``enforced`` still track the live
+    resolver even though ``tiers`` walks the static per-tier caps
+  * never 5xxs: a resolver failure returns the empty-tiers grace envelope
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def enforced(monkeypatch, tmp_path):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(enforced):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# -- envelope ------------------------------------------------------------
+
+
+def test_envelope_shape(client):
+    resp = client.get("/api/entitlement/capacity-headroom-batch?channels=2")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert set(body) == {
+        "tiers",
+        "current_tier",
+        "current_tier_rank",
+        "grace",
+        "enforced",
+    }
+
+
+def test_envelope_carries_resolver_state(client, enforced):
+    resp = client.get("/api/entitlement/capacity-headroom-batch?channels=2")
+    body = resp.get_json()
+    ent = enforced.get_entitlement()
+    assert body["current_tier"] == ent.tier
+    assert body["current_tier_rank"] == enforced.tier_rank(ent.tier)
+    assert body["enforced"] is True
+    assert body["grace"] == bool(ent.grace)
+
+
+# -- rows ----------------------------------------------------------------
+
+
+def test_one_row_per_purchasable_tier(client, enforced):
+    body = client.get(
+        "/api/entitlement/capacity-headroom-batch?channels=2"
+    ).get_json()
+    assert len(body["tiers"]) == len(enforced._PURCHASABLE_TIERS)
+
+
+def test_trial_tier_excluded(client, enforced):
+    body = client.get(
+        "/api/entitlement/capacity-headroom-batch?channels=2"
+    ).get_json()
+    tiers = {r["tier"] for r in body["tiers"]}
+    assert enforced.TIER_TRIAL not in tiers
+
+
+def test_row_envelope_shape(client):
+    body = client.get(
+        "/api/entitlement/capacity-headroom-batch?channels=2&retention_days=5&nodes=1"
+    ).get_json()
+    for r in body["tiers"]:
+        assert set(r) == {
+            "tier", "tier_label", "channels", "retention_days", "nodes",
+        }
+
+
+def test_row_ordering_matches_capacity_diff_batch(client, enforced):
+    diff_body = client.get(
+        "/api/entitlement/capacity-diff-batch"
+    ).get_json()
+    headroom_body = client.get(
+        "/api/entitlement/capacity-headroom-batch?channels=2"
+    ).get_json()
+    diff_ids = [r["target"] for r in diff_body["tiers"]]
+    headroom_ids = [r["tier"] for r in headroom_body["tiers"]]
+    assert diff_ids == headroom_ids
+
+
+def test_each_row_matches_scalar_at_endpoint(client, enforced):
+    body = client.get(
+        "/api/entitlement/capacity-headroom-batch?channels=2&retention_days=5&nodes=1"
+    ).get_json()
+    for r in body["tiers"]:
+        scalar = client.get(
+            f"/api/entitlement/capacity-headroom-at?tier={r['tier']}"
+            "&channels=2&retention_days=5&nodes=1"
+        )
+        assert scalar.status_code == 200
+        assert r == scalar.get_json()
+
+
+# -- per-axis opt-in ------------------------------------------------------
+
+
+def test_unsupplied_axis_stays_none_on_every_row(client):
+    body = client.get(
+        "/api/entitlement/capacity-headroom-batch?channels=2"
+    ).get_json()
+    for r in body["tiers"]:
+        assert r["channels"] is not None
+        assert r["retention_days"] is None
+        assert r["nodes"] is None
+
+
+def test_no_args_returns_ladder_with_all_none_rows(client, enforced):
+    body = client.get(
+        "/api/entitlement/capacity-headroom-batch"
+    ).get_json()
+    assert len(body["tiers"]) == len(enforced._PURCHASABLE_TIERS)
+    for r in body["tiers"]:
+        assert r["channels"] is None
+        assert r["retention_days"] is None
+        assert r["nodes"] is None
+
+
+@pytest.mark.parametrize("axis", ["channels", "retention_days", "nodes"])
+@pytest.mark.parametrize("bad", ["junk", "", "-1", "true", "false", "1.5"])
+def test_bad_axis_collapses_to_none_on_every_row(client, axis, bad):
+    body = client.get(
+        f"/api/entitlement/capacity-headroom-batch?{axis}={bad}"
+    ).get_json()
+    for r in body["tiers"]:
+        assert r[axis] is None
+
+
+def test_mixed_bad_and_good_axes(client):
+    body = client.get(
+        "/api/entitlement/capacity-headroom-batch?channels=junk&retention_days=5"
+    ).get_json()
+    for r in body["tiers"]:
+        assert r["channels"] is None
+        assert r["retention_days"] is not None
+        assert r["retention_days"]["used"] == 5
+
+
+# -- concrete per-tier caps ----------------------------------------------
+
+
+def _row_for(rows, tier):
+    for r in rows:
+        if r["tier"] == tier:
+            return r
+    raise AssertionError(f"tier {tier!r} missing from batch rows")
+
+
+def test_oss_channels_row_uses_free_cap(client, enforced):
+    body = client.get(
+        "/api/entitlement/capacity-headroom-batch?channels=2"
+    ).get_json()
+    row = _row_for(body["tiers"], enforced.TIER_OSS)["channels"]
+    assert row["cap"] == enforced._FREE_CHANNEL_LIMIT
+    assert row["is_unlimited"] is False
+
+
+def test_enterprise_retention_row_unlimited(client, enforced):
+    body = client.get(
+        "/api/entitlement/capacity-headroom-batch?retention_days=365"
+    ).get_json()
+    row = _row_for(body["tiers"], enforced.TIER_ENTERPRISE)["retention_days"]
+    assert row["cap"] is None
+    assert row["is_unlimited"] is True
+
+
+# -- decoupled from resolver ---------------------------------------------
+
+
+def test_tiers_grace_vs_enforce_byte_identical(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    def _rows(enforce: bool):
+        if enforce:
+            monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+        else:
+            monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+        import clawmetry.entitlements as e
+
+        importlib.reload(e)
+        e.invalidate()
+        from routes.entitlement import bp_entitlement
+
+        app = Flask(__name__)
+        app.register_blueprint(bp_entitlement)
+        c = app.test_client()
+        try:
+            return c.get(
+                "/api/entitlement/capacity-headroom-batch"
+                "?channels=2&retention_days=5&nodes=1"
+            ).get_json()["tiers"]
+        finally:
+            e.invalidate()
+
+    assert _rows(False) == _rows(True)
+
+
+# -- never 5xxs -----------------------------------------------------------
+
+
+def test_never_5xxs_on_helper_failure(monkeypatch, client, enforced):
+    def _bang(*_a, **_k):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(enforced, "capacity_headroom_batch", _bang)
+    monkeypatch.setattr(enforced, "get_entitlement", _bang)
+    resp = client.get(
+        "/api/entitlement/capacity-headroom-batch?channels=2"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body == {
+        "tiers": [],
+        "current_tier": "oss",
+        "current_tier_rank": 0,
+        "grace": True,
+        "enforced": False,
+    }


### PR DESCRIPTION
## Summary

- Adds `clawmetry.entitlements.capacity_headroom_batch(*, channels, retention_days, nodes)` — plural sibling of the recently-landed `capacity_headroom_at`. Walks every entry in `_PURCHASABLE_TIERS` and returns the per-tier headroom envelope for the caller-supplied per-axis usage in one pass, so a pricing-page *"at each tier, would my usage fit?"* table can render every rung off one round-trip instead of N calls to `/capacity-headroom-at`.
- Adds `GET /api/entitlement/capacity-headroom-batch` on `bp_entitlement` wrapping the helper in the same `{tiers, current_tier, current_tier_rank, grace, enforced}` envelope `/capacity-diff-batch` uses, with the same `_parse_capacity_arg`-based per-axis opt-in.
- Fills the `_batch` slot on the capacity-headroom axis alongside `capacity_diff_batch` (per-tier per-axis transition triples against the resolved entitlement) and the per-axis `tiers_for_{channel_count,retention_window,node_count}_batch` families. Zero behaviour change — GRACE preserved end-to-end.

## What changed

- `clawmetry/entitlements.py` — new `capacity_headroom_batch()` module-level helper. Walks `_PURCHASABLE_TIERS` in the same `(rank, id)` order the other `*_batch` siblings use and delegates each row to `capacity_headroom_at(tid, ...)` so rows are byte-identical to the scalar `_at` helper. Trial tier excluded. Never raises: a walker failure returns `[]`; a per-row `capacity_headroom_at` returning `None` drops that row.
- `routes/entitlement.py` — new `/api/entitlement/capacity-headroom-batch` handler mirroring the `/capacity-diff-batch` envelope. Reuses `_parse_capacity_arg` for the same per-axis "None means axis not supplied; blank / non-int / negative / bool collapses that axis to `None` on every row" posture as `/capacity-headroom`. Never 5xxs: a resolver failure returns the empty-tiers grace envelope.
- `tests/test_entitlement_capacity_headroom_batch.py` — 19 helper tests: envelope + row shape, `(rank, id)` ordering, byte-stable against `capacity_diff_batch`, per-row parity with `capacity_headroom_at`, per-axis opt-in, concrete per-tier caps (OSS / Starter / Pro / Enterprise), grace-vs-enforce byte-identical rows, walker-failure returns `[]`, per-row `None` drops the row.
- `tests/test_entitlement_capacity_headroom_batch_api.py` — 30 HTTP tests (parametrised): envelope shape + resolver-state carry, one row per purchasable tier, trial excluded, per-row byte parity with the scalar `_at` endpoint, per-axis opt-in, bad-axis collapse on every row, mixed bad + good, concrete OSS / Enterprise caps, grace-vs-enforce byte-identical `tiers` payload, never-5xxs on helper failure.

## Test plan

- [x] `python -m py_compile clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_capacity_headroom_batch.py tests/test_entitlement_capacity_headroom_batch_api.py` — clean
- [x] `ruff check routes/entitlement.py clawmetry/entitlements.py tests/test_entitlement_capacity_headroom_batch.py tests/test_entitlement_capacity_headroom_batch_api.py` — clean
- [x] `python -m pytest tests/test_entitlement_capacity_headroom_batch.py tests/test_entitlement_capacity_headroom_batch_api.py -q` — **49 passed**
- [x] Neighbouring capacity / headroom / entitlement API suites still pass (`tests/test_entitlement_capacity_headroom{,_at,_api}.py tests/test_entitlement_capacity_diff{,_batch,_at_batch}.py tests/test_entitlement_api.py` — 213 passed together with the new tests)

## Local operator verification checklist

The remote fire has no access to the local daemon / live cloud snapshot / browser, so the operator drives:

- [ ] Copy `clawmetry/entitlements.py` + `routes/entitlement.py` into `~/.clawmetry/lib/python3.*/site-packages/{clawmetry,routes}/` (or reinstall the wheel).
- [ ] Clear `__pycache__/` for `routes/` and `clawmetry/`.
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` (macOS) or the systemd equivalent.
- [ ] `curl -sS 'http://localhost:8900/api/entitlement/capacity-headroom-batch?channels=2&retention_days=5&nodes=1' | jq .` — envelope carries `tiers` (6 rows: `cloud_free, oss, cloud_starter, cloud_pro, pro, enterprise`), `current_tier`, `current_tier_rank`, `grace`, `enforced`.
- [ ] Ordering matches `curl -sS http://localhost:8900/api/entitlement/capacity-diff-batch | jq -r '.tiers[].target'` — pricing table lines up rung-for-rung.
- [ ] Per-row parity: pick any tier `T` and verify the batch row equals `curl -sS "http://localhost:8900/api/entitlement/capacity-headroom-at?tier=$T&channels=2&retention_days=5&nodes=1" | jq .` byte-for-byte.
- [ ] Bad-axis: `curl -sS 'http://localhost:8900/api/entitlement/capacity-headroom-batch?channels=junk' | jq '.tiers[].channels'` — every row is `null`.
- [ ] Decrypt the live cloud snapshot, verify a pricing-page surface that reads the new endpoint renders every rung without a browser console error.
- [ ] Browser: dashboard entitlement / pricing views still load (additive endpoint — nothing existing changes).

Stays in GRACE — no gating change, no version bump, no release tag. Local operator handles verification, release, and merge per FLYWHEEL.md.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XUzLmhRaXLyTqH2ZZQdqVU)_