### PR TITLE
feat(paywall): first_matching + last_matching scalar helpers + /api/paywall/events/{first,last}

### DIFF
--- a/clawmetry/_paywall_events.py
+++ b/clawmetry/_paywall_events.py
@@ -405,6 +405,91 @@ class _PaywallEventStore:
             logger.warning("paywall.events: count_matching swallowed: %s", exc)
             return 0
 
+    def last_matching(
+        self,
+        *,
+        event: str | None = None,
+        feature: str | None = None,
+        harness: str | None = None,
+        source: str | None = None,
+        plan_chosen: str | None = None,
+    ) -> dict | None:
+        """Return the single most-recent event matching the supplied
+        filters, or ``None`` if nothing matches.
+
+        Same filter semantics as :meth:`recent` / :meth:`count_matching`
+        (``None`` / empty-string means "not supplied", case-sensitive
+        exact match, ``AND`` combined). Equivalent to
+        ``recent(1, **filters)[0]`` when the ring has a match, and to
+        ``None`` when it does not -- but returns a scalar (dict-or-None)
+        instead of a list so a dashboard tile binding "last paywall
+        event of type X" does not need to unwrap a one-element list.
+        Short-circuits on the first newest-first match so the walk is
+        O(k) where k is the distance from the newest row to the first
+        matching row, not O(n).
+
+        Never raises: a filter failure short-circuits to ``None`` instead
+        of propagating.
+        """
+        try:
+            filters = _normalise_filters(
+                event=event, feature=feature, harness=harness,
+                source=source, plan_chosen=plan_chosen,
+            )
+            with self._lock:
+                snap = list(self._ring)
+            for e in reversed(snap):
+                if filters and not _row_matches_filters(e, filters):
+                    continue
+                return dict(e)
+            return None
+        except Exception as exc:
+            logger.warning("paywall.events: last_matching swallowed: %s", exc)
+            return None
+
+    def first_matching(
+        self,
+        *,
+        event: str | None = None,
+        feature: str | None = None,
+        harness: str | None = None,
+        source: str | None = None,
+        plan_chosen: str | None = None,
+    ) -> dict | None:
+        """Return the single oldest event matching the supplied filters,
+        or ``None`` if nothing matches.
+
+        Twin of :meth:`last_matching` for the other end of the ring:
+        same filter contract, same scalar (dict-or-None) return, same
+        short-circuit walk semantics (oldest-first). A dashboard tile
+        rendering "first paywall CTA click of this session" binds this
+        rather than paging the full ring via :meth:`recent` and
+        inspecting the tail.
+
+        Because the ring evicts oldest-first, the "first" match is
+        anchored to what the ring currently holds -- not to the all-time
+        first occurrence, which may have long since been evicted. That
+        matches the rest of this module's semantics (aggregations
+        reflect what's live, not what's been evicted).
+
+        Never raises.
+        """
+        try:
+            filters = _normalise_filters(
+                event=event, feature=feature, harness=harness,
+                source=source, plan_chosen=plan_chosen,
+            )
+            with self._lock:
+                snap = list(self._ring)
+            for e in snap:
+                if filters and not _row_matches_filters(e, filters):
+                    continue
+                return dict(e)
+            return None
+        except Exception as exc:
+            logger.warning("paywall.events: first_matching swallowed: %s", exc)
+            return None
+
     def reset(self) -> None:
         with self._lock:
             self._ring.clear()
@@ -467,6 +552,48 @@ def count_matching(
     render "showing N of M matches" alongside the filtered event list.
     """
     return _STORE.count_matching(
+        event=event, feature=feature, harness=harness,
+        source=source, plan_chosen=plan_chosen,
+    )
+
+
+def last_matching(
+    *,
+    event: str | None = None,
+    feature: str | None = None,
+    harness: str | None = None,
+    source: str | None = None,
+    plan_chosen: str | None = None,
+) -> dict | None:
+    """Public shim for :meth:`_PaywallEventStore.last_matching`.
+
+    Returns the single most-recent ring row matching the supplied
+    filters, or ``None`` if nothing matches. Scalar counterpart to
+    :func:`recent` -- a dashboard tile binding "last paywall CTA click
+    for feature X" avoids the one-element-list unwrap this way.
+    """
+    return _STORE.last_matching(
+        event=event, feature=feature, harness=harness,
+        source=source, plan_chosen=plan_chosen,
+    )
+
+
+def first_matching(
+    *,
+    event: str | None = None,
+    feature: str | None = None,
+    harness: str | None = None,
+    source: str | None = None,
+    plan_chosen: str | None = None,
+) -> dict | None:
+    """Public shim for :meth:`_PaywallEventStore.first_matching`.
+
+    Returns the single oldest ring row matching the supplied filters,
+    or ``None`` if nothing matches. Anchored to what the ring currently
+    holds -- see :meth:`_PaywallEventStore.first_matching` for the
+    eviction contract.
+    """
+    return _STORE.first_matching(
         event=event, feature=feature, harness=harness,
         source=source, plan_chosen=plan_chosen,
     )

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -7296,6 +7296,128 @@ def api_paywall_events_recent():
         )
 
 
+@bp_entitlement.route("/api/paywall/events/last")
+def api_paywall_events_last():
+    """``GET /api/paywall/events/last`` -- the single most-recent paywall
+    beacon matching the supplied filters, or ``null`` if none.
+
+    Scalar sibling of ``/api/paywall/events/recent`` for the common case
+    where a dashboard tile only needs "the most recent one" (e.g. "last
+    CTA click for feature X was at 12:03:41"). Avoids the one-element-
+    list unwrap and skips paying the ``dict(e)`` copy cost on every
+    ring entry.
+
+    Same categorical filter query params + semantics as
+    ``/api/paywall/events/recent`` -- ``?event=`` / ``?feature=`` /
+    ``?harness=`` / ``?source=`` / ``?plan_chosen=``, case-sensitive
+    exact match, ``AND`` combined, blank / missing = "not supplied".
+
+    Body shape::
+
+        {
+          "event": {"event": "...", "feature": "...", "harness": "...",
+                    "source": "...", "plan_chosen": "...", "ts": <float>} | null,
+          "matched": <int>,  # rows matching the filters (0 iff event is null)
+          "in_window": <int>,  # size of the underlying ring right now
+          "filters": {"<key>": "<value>", ...}
+        }
+
+    ``matched`` uses the same helper as ``/api/paywall/events/recent`` so
+    a UI can render "last of M matches" without a second round-trip.
+
+    Ships in GRACE. Never 5xxs -- on any failure returns the neutral
+    ``event=null`` envelope.
+    """
+    try:
+        from clawmetry import _paywall_events as _pe
+
+        filter_kwargs = {
+            key: request.args.get(key, "") or None
+            for key in ("event", "feature", "harness", "source", "plan_chosen")
+        }
+        event_row = _pe.last_matching(**filter_kwargs)
+        matched = _pe.count_matching(**filter_kwargs)
+        summary = _pe.summary()
+        applied_filters = {
+            key: value.strip()
+            for key, value in filter_kwargs.items()
+            if isinstance(value, str) and value.strip()
+        }
+        return jsonify(
+            {
+                "event": event_row,
+                "matched": matched,
+                "in_window": summary.get("in_window", 0),
+                "filters": applied_filters,
+            }
+        )
+    except Exception as exc:
+        logger.warning("api_paywall_events_last: error: %s", exc)
+        return jsonify(
+            {
+                "event": None,
+                "matched": 0,
+                "in_window": 0,
+                "filters": {},
+            }
+        )
+
+
+@bp_entitlement.route("/api/paywall/events/first")
+def api_paywall_events_first():
+    """``GET /api/paywall/events/first`` -- the single oldest paywall
+    beacon matching the supplied filters, or ``null`` if none.
+
+    Twin of ``/api/paywall/events/last`` for the other end of the ring:
+    same filter contract, same envelope shape, same never-5xx posture.
+    Anchored to what the ring currently holds -- because the ring evicts
+    oldest-first, "first" means "oldest still resident", not "all-time
+    first". Matches the rest of this module's semantics (aggregations
+    reflect what's live, not what's been evicted).
+
+    A dashboard tile rendering "first paywall CTA click of this session"
+    binds this rather than paging the full ring via
+    ``/api/paywall/events/recent`` and inspecting the tail.
+
+    Body shape is identical to ``/api/paywall/events/last``. Ships in
+    GRACE. Never 5xxs -- on any failure returns the neutral
+    ``event=null`` envelope.
+    """
+    try:
+        from clawmetry import _paywall_events as _pe
+
+        filter_kwargs = {
+            key: request.args.get(key, "") or None
+            for key in ("event", "feature", "harness", "source", "plan_chosen")
+        }
+        event_row = _pe.first_matching(**filter_kwargs)
+        matched = _pe.count_matching(**filter_kwargs)
+        summary = _pe.summary()
+        applied_filters = {
+            key: value.strip()
+            for key, value in filter_kwargs.items()
+            if isinstance(value, str) and value.strip()
+        }
+        return jsonify(
+            {
+                "event": event_row,
+                "matched": matched,
+                "in_window": summary.get("in_window", 0),
+                "filters": applied_filters,
+            }
+        )
+    except Exception as exc:
+        logger.warning("api_paywall_events_first: error: %s", exc)
+        return jsonify(
+            {
+                "event": None,
+                "matched": 0,
+                "in_window": 0,
+                "filters": {},
+            }
+        )
+
+
 def _route_actor() -> str:
     try:
         for h in ("X-Actor", "X-Forwarded-For"):

--- a/tests/test_paywall_events_first_last_api.py
+++ b/tests/test_paywall_events_first_last_api.py
@@ -1,0 +1,254 @@
+"""API tests for the two new scalar paywall-event read endpoints:
+
+  GET /api/paywall/events/last
+  GET /api/paywall/events/first
+
+Both are thin JSON wrappers around
+:func:`clawmetry._paywall_events.last_matching` /
+:func:`clawmetry._paywall_events.first_matching`. Store-level
+invariants live in ``test_paywall_events_first_last_matching.py``; the
+tests here pin the HTTP contract:
+
+* Both endpoints must never 5xx.
+* Both must never gate on the entitlement -- they surface OSS-free
+  beacon activity that a paywall dashboard tile needs even on OSS.
+* Empty ring returns the neutral ``event=null`` envelope.
+* Filter params echo back under ``filters`` (blank ones omitted).
+* ``matched`` mirrors the underlying ``count_matching`` count.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def client():
+    from routes.entitlement import bp_entitlement
+    from clawmetry import _paywall_events as pe
+
+    pe.reset()
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    app.config["TESTING"] = True
+    try:
+        yield app.test_client()
+    finally:
+        pe.reset()
+
+
+def _post_event(client, **fields):
+    resp = client.post(
+        "/api/paywall/event",
+        data=json.dumps(fields),
+        content_type="application/json",
+    )
+    assert resp.status_code == 204
+
+
+# ── /api/paywall/events/last ────────────────────────────────────────────────
+
+
+def test_last_empty_ring_returns_null_envelope(client):
+    body = client.get("/api/paywall/events/last").get_json()
+    assert body == {
+        "event": None,
+        "matched": 0,
+        "in_window": 0,
+        "filters": {},
+    }
+
+
+def test_last_reflects_most_recent_beacon(client):
+    _post_event(client, event="paywall_view", feature="fleet")
+    _post_event(client, event="paywall_view", feature="self_evolve")
+    _post_event(client, event="paywall_cta_click", feature="fleet")
+
+    body = client.get("/api/paywall/events/last").get_json()
+    assert body["event"] is not None
+    assert body["event"]["event"] == "paywall_cta_click"
+    assert body["event"]["feature"] == "fleet"
+    assert body["matched"] == 3
+    assert body["in_window"] == 3
+    assert body["filters"] == {}
+
+
+def test_last_filter_narrows_to_newest_match(client):
+    _post_event(client, event="paywall_view", feature="fleet")
+    _post_event(client, event="paywall_view", feature="self_evolve")
+    _post_event(client, event="paywall_cta_click", feature="fleet")
+
+    body = client.get(
+        "/api/paywall/events/last?event=paywall_view",
+    ).get_json()
+    assert body["event"] is not None
+    assert body["event"]["event"] == "paywall_view"
+    assert body["event"]["feature"] == "self_evolve"
+    assert body["matched"] == 2
+    assert body["filters"] == {"event": "paywall_view"}
+
+
+def test_last_no_match_returns_null_but_non_zero_in_window(client):
+    _post_event(client, event="paywall_view", feature="fleet")
+
+    body = client.get(
+        "/api/paywall/events/last?event=not_a_real_event",
+    ).get_json()
+    assert body["event"] is None
+    assert body["matched"] == 0
+    assert body["in_window"] == 1
+    assert body["filters"] == {"event": "not_a_real_event"}
+
+
+def test_last_blank_filter_is_not_supplied(client):
+    _post_event(client, event="paywall_view", feature="fleet")
+
+    body = client.get(
+        "/api/paywall/events/last?event=&feature=",
+    ).get_json()
+    assert body["event"] is not None
+    # Blank filters are "not supplied" -- not echoed under `filters`.
+    assert body["filters"] == {}
+    assert body["matched"] == 1
+
+
+def test_last_combines_filters_with_and(client):
+    _post_event(client, event="paywall_view", feature="fleet")
+    _post_event(client, event="paywall_view", feature="self_evolve")
+    _post_event(client, event="paywall_cta_click", feature="fleet")
+
+    body = client.get(
+        "/api/paywall/events/last"
+        "?event=paywall_view&feature=fleet",
+    ).get_json()
+    assert body["event"] is not None
+    assert body["event"]["event"] == "paywall_view"
+    assert body["event"]["feature"] == "fleet"
+    assert body["matched"] == 1
+    assert body["filters"] == {"event": "paywall_view", "feature": "fleet"}
+
+
+def test_last_never_5xxs_on_broken_store(client, monkeypatch):
+    from clawmetry import _paywall_events as pe
+
+    def _boom(**kwargs):
+        raise RuntimeError("simulated store outage")
+
+    monkeypatch.setattr(pe, "last_matching", _boom)
+    resp = client.get("/api/paywall/events/last")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body == {
+        "event": None,
+        "matched": 0,
+        "in_window": 0,
+        "filters": {},
+    }
+
+
+# ── /api/paywall/events/first ───────────────────────────────────────────────
+
+
+def test_first_empty_ring_returns_null_envelope(client):
+    body = client.get("/api/paywall/events/first").get_json()
+    assert body == {
+        "event": None,
+        "matched": 0,
+        "in_window": 0,
+        "filters": {},
+    }
+
+
+def test_first_reflects_oldest_beacon(client):
+    _post_event(client, event="paywall_view", feature="fleet")
+    _post_event(client, event="paywall_view", feature="self_evolve")
+    _post_event(client, event="paywall_cta_click", feature="fleet")
+
+    body = client.get("/api/paywall/events/first").get_json()
+    assert body["event"] is not None
+    assert body["event"]["event"] == "paywall_view"
+    assert body["event"]["feature"] == "fleet"
+    assert body["matched"] == 3
+    assert body["in_window"] == 3
+    assert body["filters"] == {}
+
+
+def test_first_filter_narrows_to_oldest_match(client):
+    _post_event(client, event="paywall_view", feature="fleet")
+    _post_event(client, event="paywall_cta_click", feature="fleet")
+    _post_event(client, event="paywall_view", feature="self_evolve")
+
+    body = client.get(
+        "/api/paywall/events/first?event=paywall_view",
+    ).get_json()
+    assert body["event"] is not None
+    assert body["event"]["event"] == "paywall_view"
+    assert body["event"]["feature"] == "fleet"  # oldest paywall_view
+    assert body["matched"] == 2
+    assert body["filters"] == {"event": "paywall_view"}
+
+
+def test_first_no_match_returns_null_but_non_zero_in_window(client):
+    _post_event(client, event="paywall_view", feature="fleet")
+
+    body = client.get(
+        "/api/paywall/events/first?feature=nonexistent",
+    ).get_json()
+    assert body["event"] is None
+    assert body["matched"] == 0
+    assert body["in_window"] == 1
+    assert body["filters"] == {"feature": "nonexistent"}
+
+
+def test_first_never_5xxs_on_broken_store(client, monkeypatch):
+    from clawmetry import _paywall_events as pe
+
+    def _boom(**kwargs):
+        raise RuntimeError("simulated store outage")
+
+    monkeypatch.setattr(pe, "first_matching", _boom)
+    resp = client.get("/api/paywall/events/first")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body == {
+        "event": None,
+        "matched": 0,
+        "in_window": 0,
+        "filters": {},
+    }
+
+
+# ── cross-checks ────────────────────────────────────────────────────────────
+
+
+def test_first_and_last_return_same_row_when_ring_has_one(client):
+    _post_event(client, event="paywall_view", feature="fleet")
+    first = client.get("/api/paywall/events/first").get_json()
+    last = client.get("/api/paywall/events/last").get_json()
+    assert first["event"] == last["event"]
+    assert first["matched"] == last["matched"] == 1
+
+
+def test_last_agrees_with_recent_limit_one(client):
+    """``/api/paywall/events/last`` is the scalar unwrap of
+    ``/api/paywall/events/recent?limit=1`` -- same row, same fields.
+    """
+    for i in range(5):
+        _post_event(client, event=f"e{i}", feature="fleet")
+    last = client.get("/api/paywall/events/last").get_json()
+    recent = client.get("/api/paywall/events/recent?limit=1").get_json()
+    assert last["event"] == recent["events"][0]
+
+
+def test_no_entitlement_gate_ships_in_grace(client):
+    """Both endpoints ship in GRACE -- no auth header, no license key
+    required, no tier check. If someone wires a paid gate accidentally
+    the paywall dashboard tile goes blank on OSS."""
+    for path in (
+        "/api/paywall/events/first",
+        "/api/paywall/events/last",
+    ):
+        resp = client.get(path)
+        assert resp.status_code == 200

--- a/tests/test_paywall_events_first_last_matching.py
+++ b/tests/test_paywall_events_first_last_matching.py
@@ -1,0 +1,276 @@
+"""Unit tests for :func:`clawmetry._paywall_events.first_matching` and
+:func:`clawmetry._paywall_events.last_matching` -- the scalar (dict-or-
+``None``) siblings of :func:`clawmetry._paywall_events.recent`.
+
+Both are thin filtered walks over the ring. The store-level invariants
+they inherit (thread-safe snapshot, filter parsing, never-raise, copy-
+on-return) live in ``test_paywall_events_store.py``; the tests here
+pin the return-shape and short-circuit contract that a paywall
+dashboard tile binding "last CTA click for feature X" depends on.
+"""
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _fresh_store():
+    from clawmetry import _paywall_events as pe
+
+    pe.reset()
+    yield
+    pe.reset()
+
+
+def test_last_matching_empty_ring_returns_none():
+    from clawmetry import _paywall_events as pe
+
+    assert pe.last_matching() is None
+    assert pe.last_matching(event="paywall_view") is None
+
+
+def test_first_matching_empty_ring_returns_none():
+    from clawmetry import _paywall_events as pe
+
+    assert pe.first_matching() is None
+    assert pe.first_matching(feature="fleet") is None
+
+
+def test_last_matching_with_no_filters_returns_newest_row():
+    from clawmetry import _paywall_events as pe
+
+    for i in range(3):
+        pe.record_event({"event": f"e{i}", "feature": "fleet"})
+    row = pe.last_matching()
+    assert row is not None
+    assert row["event"] == "e2"
+    assert row["feature"] == "fleet"
+
+
+def test_first_matching_with_no_filters_returns_oldest_row():
+    from clawmetry import _paywall_events as pe
+
+    for i in range(3):
+        pe.record_event({"event": f"e{i}", "feature": "fleet"})
+    row = pe.first_matching()
+    assert row is not None
+    assert row["event"] == "e0"
+
+
+def test_last_matching_respects_categorical_filter():
+    from clawmetry import _paywall_events as pe
+
+    pe.record_event({"event": "paywall_view", "feature": "fleet"})
+    pe.record_event({"event": "paywall_cta_click", "feature": "fleet"})
+    pe.record_event({"event": "paywall_view", "feature": "self_evolve"})
+
+    row = pe.last_matching(event="paywall_view")
+    assert row is not None
+    assert row["event"] == "paywall_view"
+    assert row["feature"] == "self_evolve"  # newest paywall_view
+
+
+def test_first_matching_respects_categorical_filter():
+    from clawmetry import _paywall_events as pe
+
+    pe.record_event({"event": "paywall_view", "feature": "fleet"})
+    pe.record_event({"event": "paywall_cta_click", "feature": "fleet"})
+    pe.record_event({"event": "paywall_view", "feature": "self_evolve"})
+
+    row = pe.first_matching(event="paywall_view")
+    assert row is not None
+    assert row["event"] == "paywall_view"
+    assert row["feature"] == "fleet"  # oldest paywall_view
+
+
+def test_last_matching_combines_filters_with_and():
+    from clawmetry import _paywall_events as pe
+
+    pe.record_event({"event": "paywall_view", "feature": "fleet"})
+    pe.record_event({"event": "paywall_view", "feature": "self_evolve"})
+    pe.record_event({"event": "paywall_cta_click", "feature": "fleet"})
+
+    row = pe.last_matching(event="paywall_view", feature="fleet")
+    assert row is not None
+    assert row["event"] == "paywall_view"
+    assert row["feature"] == "fleet"
+
+
+def test_first_matching_combines_filters_with_and():
+    from clawmetry import _paywall_events as pe
+
+    pe.record_event({"event": "paywall_view", "feature": "fleet"})
+    pe.record_event({"event": "paywall_view", "feature": "self_evolve"})
+    pe.record_event({"event": "paywall_view", "feature": "fleet"})
+
+    row = pe.first_matching(event="paywall_view", feature="fleet")
+    assert row is not None
+    assert row["feature"] == "fleet"
+
+
+def test_last_matching_no_match_returns_none():
+    from clawmetry import _paywall_events as pe
+
+    pe.record_event({"event": "paywall_view", "feature": "fleet"})
+    assert pe.last_matching(feature="nonexistent") is None
+    assert pe.last_matching(event="not_a_real_event") is None
+
+
+def test_first_matching_no_match_returns_none():
+    from clawmetry import _paywall_events as pe
+
+    pe.record_event({"event": "paywall_view", "feature": "fleet"})
+    assert pe.first_matching(feature="nonexistent") is None
+
+
+def test_last_matching_returns_all_fields():
+    from clawmetry import _paywall_events as pe
+
+    pe.record_event(
+        {
+            "event": "paywall_cta_click",
+            "feature": "self_evolve",
+            "harness": "claude_code",
+            "source": "runtime-switcher",
+            "plan_chosen": "pro",
+        }
+    )
+    row = pe.last_matching()
+    assert row is not None
+    for key in ("event", "feature", "harness", "source", "plan_chosen", "ts"):
+        assert key in row
+    assert row["plan_chosen"] == "pro"
+    assert isinstance(row["ts"], float)
+
+
+def test_first_matching_returns_all_fields():
+    from clawmetry import _paywall_events as pe
+
+    pe.record_event(
+        {
+            "event": "paywall_view",
+            "feature": "fleet",
+            "harness": "openclaw",
+            "source": "empty-state",
+            "plan_chosen": "",
+        }
+    )
+    row = pe.first_matching()
+    assert row is not None
+    for key in ("event", "feature", "harness", "source", "plan_chosen", "ts"):
+        assert key in row
+
+
+def test_last_matching_hands_back_a_copy():
+    """Callers mutating the returned dict must not corrupt the ring --
+    parity with ``recent`` / ``count_matching``.
+    """
+    from clawmetry import _paywall_events as pe
+
+    pe.record_event({"event": "paywall_view", "feature": "fleet"})
+    row = pe.last_matching()
+    assert row is not None
+    row["feature"] = "TAMPERED"
+    row2 = pe.last_matching()
+    assert row2 is not None
+    assert row2["feature"] == "fleet"
+
+
+def test_first_matching_hands_back_a_copy():
+    from clawmetry import _paywall_events as pe
+
+    pe.record_event({"event": "paywall_view", "feature": "fleet"})
+    row = pe.first_matching()
+    assert row is not None
+    row["feature"] = "TAMPERED"
+    row2 = pe.first_matching()
+    assert row2 is not None
+    assert row2["feature"] == "fleet"
+
+
+def test_last_matching_ignores_blank_and_none_filters():
+    """A blank / ``None`` filter is "not supplied" -- same as
+    :func:`recent` / :func:`count_matching`."""
+    from clawmetry import _paywall_events as pe
+
+    pe.record_event({"event": "paywall_view", "feature": "fleet"})
+    # Empty string and None both mean "unfiltered on that axis".
+    row1 = pe.last_matching(event="", feature=None)
+    row2 = pe.last_matching()
+    assert row1 == row2
+    assert row1 is not None
+
+
+def test_first_matching_ignores_blank_and_none_filters():
+    from clawmetry import _paywall_events as pe
+
+    pe.record_event({"event": "paywall_view", "feature": "fleet"})
+    row1 = pe.first_matching(event="", feature=None)
+    row2 = pe.first_matching()
+    assert row1 == row2
+    assert row1 is not None
+
+
+def test_last_matching_reflects_ring_eviction():
+    """After the ring evicts the newest oldest row, ``last_matching``
+    still points at the newest resident row -- not something evicted.
+    """
+    from clawmetry import _paywall_events as pe
+
+    pe._set_capacity(3)
+    try:
+        for i in range(6):
+            pe.record_event({"event": "paywall_view", "feature": f"f{i}"})
+        row = pe.last_matching()
+        assert row is not None
+        assert row["feature"] == "f5"
+    finally:
+        pe._set_capacity(200)
+
+
+def test_first_matching_reflects_ring_eviction():
+    """After eviction ``first_matching`` returns the oldest RESIDENT
+    row, not the all-time first (which has been evicted)."""
+    from clawmetry import _paywall_events as pe
+
+    pe._set_capacity(3)
+    try:
+        for i in range(6):
+            pe.record_event({"event": "paywall_view", "feature": f"f{i}"})
+        row = pe.first_matching()
+        assert row is not None
+        # After 6 records with capacity 3, oldest resident is f3.
+        assert row["feature"] == "f3"
+    finally:
+        pe._set_capacity(200)
+
+
+def test_last_and_first_match_when_ring_has_one_row():
+    from clawmetry import _paywall_events as pe
+
+    pe.record_event({"event": "paywall_view", "feature": "fleet"})
+    assert pe.last_matching() == pe.first_matching()
+
+
+def test_last_matching_agrees_with_recent_limit_one():
+    """``last_matching`` is the scalar unwrap of ``recent(1)`` --
+    same row, same fields, minus the list wrapper.
+    """
+    from clawmetry import _paywall_events as pe
+
+    for i in range(5):
+        pe.record_event({"event": f"e{i}", "feature": "fleet"})
+    listed = pe.recent(1)
+    scalar = pe.last_matching()
+    assert scalar == listed[0]
+
+
+def test_last_matching_filter_agrees_with_recent_filter():
+    from clawmetry import _paywall_events as pe
+
+    pe.record_event({"event": "paywall_view", "feature": "fleet"})
+    pe.record_event({"event": "paywall_cta_click", "feature": "fleet"})
+    pe.record_event({"event": "paywall_view", "feature": "self_evolve"})
+    listed = pe.recent(1, event="paywall_view")
+    scalar = pe.last_matching(event="paywall_view")
+    assert scalar == listed[0]


### PR DESCRIPTION
## Summary

- Adds `_PaywallEventStore.last_matching` / `first_matching` (+ module-level shims) — scalar (dict-or-None) siblings of `recent` / `count_matching`. A dashboard tile binding "last CTA click for feature X" now avoids the one-element-list unwrap and skips paying the `dict(e)` copy on every ring entry; both short-circuit on the first match (newest-first for `last`, oldest-first for `first`).
- Adds `GET /api/paywall/events/last` and `GET /api/paywall/events/first` on `bp_entitlement`, same categorical filter query params (`event`, `feature`, `harness`, `source`, `plan_chosen`) + same never-5xx / GRACE posture as `/api/paywall/events/recent`. Envelope: `{event: <dict|null>, matched, in_window, filters}`.
- Ships in GRACE — no entitlement gate, no capacity accounting.

## Test plan

- [x] `python3 -m pytest tests/test_paywall_events_first_last_matching.py tests/test_paywall_events_first_last_api.py` — 36 new tests pass
- [x] `python3 -m pytest tests/test_paywall_events_store.py tests/test_paywall_events_api.py tests/test_paywall_events_recent_filters.py tests/test_paywall_event_api.py tests/test_paywall_events_first_last_matching.py tests/test_paywall_events_first_last_api.py` — 133 total pass, no regressions
- [x] `ruff check clawmetry/_paywall_events.py routes/entitlement.py tests/test_paywall_events_first_last_matching.py tests/test_paywall_events_first_last_api.py` — clean
- [x] `python3 -c "import ast; ast.parse(open('clawmetry/_paywall_events.py').read()); ast.parse(open('routes/entitlement.py').read())"` — syntax OK

### Store-level invariants pinned (20 tests)

- Empty ring returns `None`
- Filter narrowing (event, feature, AND-combined)
- No match returns `None` with non-empty ring
- All six fields (event / feature / harness / source / plan_chosen / ts) present
- Copy-on-return: caller mutation cannot corrupt the ring
- Blank / `None` filter is "not supplied"
- Ring eviction: `first_matching` anchors to oldest RESIDENT row, not all-time first
- One-row ring: `first_matching == last_matching`
- Agreement with `recent(1)`: `last_matching == recent(1)[0]` when match exists

### HTTP contract pinned (16 tests)

- Empty ring returns neutral `event=null` envelope on both endpoints
- Filter query params echo back under `filters` (blank omitted, non-blank stripped)
- `matched` mirrors `count_matching` and equals 0 iff `event is null`
- `in_window` reflects the underlying ring size regardless of filter
- Never 5xx via `monkeypatch` on a broken store
- Agreement: `/api/paywall/events/last == /api/paywall/events/recent?limit=1` first row
- Both endpoints ship in GRACE — no entitlement gate

## Local operator verification checklist

The scheduled routine cannot touch your machine, daemon, or live cloud. When you pull this branch:

- [ ] `cp clawmetry/_paywall_events.py routes/entitlement.py ~/.clawmetry/lib/python3.*/site-packages/clawmetry/` (adjust python minor) — mirror `routes/entitlement.py` into the site-packages `routes/` peer if you install that way
- [ ] `find ~/.clawmetry/lib -name __pycache__ -exec rm -rf {} +` — bust stale bytecode
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` (or your platform equivalent) — restart the daemon
- [ ] `curl -s http://localhost:8900/api/paywall/events/last | jq` — expect `{"event": null, "matched": 0, "in_window": 0, "filters": {}}` on a quiet store
- [ ] `curl -s -X POST http://localhost:8900/api/paywall/event -H 'content-type: application/json' -d '{"event":"paywall_view","feature":"fleet"}'` then re-hit `/last` and `/first` — both should return that row
- [ ] Post a second event and confirm `/last` returns the newest while `/first` still returns the oldest
- [ ] Confirm the browser dashboard tiles still render (no schema break)

---
_Generated by [Claude Code](https://claude.ai/code/session_01X3ZXNzCwWLw6g9HiwYwQ4Q)_