### PR TITLE
fix(e2e): replace fixed 2s wait with 8s overlay polling in _overlay_page fixture (C5)

### DIFF
--- a/tests/test_e2e_oss_all_tabs.py
+++ b/tests/test_e2e_oss_all_tabs.py
@@ -62,9 +62,30 @@ def _overlay_page(_shared_chromium):
     page = ctx.new_page()
     # One page load for the entire tab suite.
     page.goto(BASE_URL + "/", wait_until="domcontentloaded", timeout=15000)
-    # Let auth-bootstrap.js fetch /api/auth/check and gw-setup.js fetch
-    # /api/gw/config settle before any tab test checks for overlays.
-    page.wait_for_timeout(2000)
+    # Poll up to 8s for the auth overlay to disappear (replaces fixed 2s wait).
+    # A fixed wait races /api/auth/check on cold CI runners: the overlay can
+    # still be visible when switchTab() runs, causing every tab silently to
+    # land on overview with the overlay present -- the root symptom of the
+    # 2026-05-17 user report. Matches the approach in visual-diff.mjs.
+    try:
+        page.wait_for_function(
+            """() => {
+                for (const id of ['login-overlay', 'gw-setup-overlay',
+                                  'auth-overlay', 'setup-overlay']) {
+                    const el = document.getElementById(id);
+                    if (!el) continue;
+                    const cs = getComputedStyle(el);
+                    if (cs.display !== 'none' && cs.visibility !== 'hidden') return false;
+                }
+                return true;
+            }""",
+            timeout=8000,
+            polling=200,
+        )
+    except Exception:
+        # Overlay still visible after 8s -- the tab tests will report it with
+        # descriptive messages; no silent fallthrough to wrong-tab screenshots.
+        pass
     yield page
     ctx.close()
 


### PR DESCRIPTION
## Summary

- **Root cause fixed**: `_overlay_page` fixture in `tests/test_e2e_oss_all_tabs.py` used `page.wait_for_timeout(2000)` after `page.goto("/")`. On cold CI runners the WSGI server can take >2s to service `/api/auth/check`, so `switchTab()` runs while the auth overlay is still visible -- every parametrized tab silently lands on the overview tab with the overlay present, producing 33 false positives in C5.
- **Fix**: Replace the fixed 2s sleep with `page.wait_for_function(...)` polling every 200ms up to 8s, matching the approach already used in `.github/scripts/visual-diff.mjs`. If the overlay is still visible after 8s, the `except` clause passes through and the individual tab assertions fire with descriptive messages.
- **No behaviour change when auth is fast**: On warm runners the polling loop exits at the first 200ms tick, so there is no slowdown in the happy path.

## Connection to E2E criteria

| Criterion | Impact |
|---|---|
| C5: post-auth all-tabs sweep | Direct fix -- eliminates the auth-race false positives that caused this gate to fail on cold CI |
| C1: OSS golden path | Indirect -- C5 runs in the same `oss-golden-path.yml` workflow |

Tracking issue: #4017

## Files changed

- `tests/test_e2e_oss_all_tabs.py`: `_overlay_page` fixture, lines ~65-72

---
_Generated by [Claude Code](https://claude.ai/code/session_0178rVUA2JQKsbQYFp4UhXXf)_