### PR TITLE
feat(entitlement): capacity_headroom_path_batch + /api/entitlement/capacity-headroom-path-batch

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -3410,6 +3410,139 @@ def capacity_headroom_path(
         return None
 
 
+def capacity_headroom_path_batch(
+    from_tier: str,
+    to_tiers,
+    *,
+    channels: int | None = None,
+    retention_days: int | None = None,
+    nodes: int | None = None,
+) -> dict | None:
+    """Batch sibling of :func:`capacity_headroom_path`: per-rung capacity-
+    headroom envelopes for a caller-supplied subset of destination tiers all
+    walked from a single ``from_tier`` in ONE round-trip.
+
+    Composes :func:`capacity_headroom_path` (scalar single-destination
+    headroom walk) and :func:`capacity_diff_path_batch` (multi-destination
+    capacity-diff path batch) -- same per-rung headroom body as the path
+    helper, same multi-destination axis as the capacity-diff path batch.
+    Fills the ``_path_batch`` slot on the capacity-headroom axis alongside
+    :func:`capacity_headroom` (scalar current), :func:`capacity_headroom_at`
+    (scalar what-if), :func:`capacity_headroom_batch` (per-tier what-if
+    matrix) and :func:`capacity_headroom_path` (scalar path). Lets a
+    capacity-only pricing-comparison "from my current rung, here are the 3
+    tiers I'm considering -- watch my headroom recover rung by rung on the
+    way to each" surface render every rung for every candidate destination
+    off ONE call instead of N calls to :func:`capacity_headroom_path`.
+
+    Per-destination row shape::
+
+        {
+          "to":         "<tier id>",
+          "to_label":   "...",
+          "to_rank":    <int>,
+          "direction":  "upgrade" | "downgrade" | "lateral" | "identity",
+          "path":       [<capacity_headroom_at row>, ...],
+        }
+
+    Each ``path`` row is byte-identical to a row from
+    :func:`capacity_headroom_path` for the same ``(from_tier, to)`` pair --
+    a parity test pins this so the scalar and batch path helpers cannot
+    drift. The walked rungs are destination-specific (the path's rung set
+    depends on ``to``), so per-destination ``path`` lengths can legitimately
+    differ -- this matches :func:`capacity_diff_path_batch`'s posture.
+
+    Shape::
+
+        {
+          "tiers": [
+            {"to": "<id>", "to_label": ..., "to_rank": ..., "direction": ..., "path": [...]},
+            ...
+          ],
+          "unknown": ["bogus_id", ...],
+        }
+
+    Supplied destination ids are normalised via :func:`_normalise_csv`
+    (whitespace stripped, lowercased, duplicates dropped, first-seen order
+    preserved). Unknown ids are echoed in ``unknown[]`` instead of short-
+    circuiting -- a partially-bad caller still gets paths back for the
+    valid ids alongside a list of what was dropped, matching
+    :func:`capacity_diff_path_batch`'s posture. ``trial`` IS accepted as a
+    destination (it is excluded from the walked intermediate rungs the way
+    :func:`capacity_headroom_path` already excludes it, but is a valid
+    endpoint via the lateral / identity branches).
+
+    Per-axis "None means axis not supplied" posture matches
+    :func:`capacity_headroom_path` /  :func:`capacity_headroom_at` /
+    :func:`capacity_headroom_batch`: an unsupplied axis stays ``None`` on
+    every rung of every destination; a supplied axis is echoed on every
+    rung and the cap is walked off each destination rung's static cap.
+
+    Returns ``None`` for empty / unknown ``from_tier`` (caller renders
+    "unknown tier" / 404).
+
+    Resolver-independent: delegates per-destination to
+    :func:`capacity_headroom_path`, which walks the static per-tier caps
+    via :func:`capacity_headroom_at` -- so grace vs enforce yields
+    byte-identical rows. Never raises: per-destination failures short-
+    circuit that id into ``unknown[]`` and the rest of the batch keeps
+    building.
+    """
+    try:
+        f = (from_tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if f not in _TIER_FEATURES:
+        return None
+    candidates = _normalise_csv(to_tiers)
+    kwargs: dict[str, int] = {}
+    if channels is not None:
+        kwargs["channels"] = channels
+    if retention_days is not None:
+        kwargs["retention_days"] = retention_days
+    if nodes is not None:
+        kwargs["nodes"] = nodes
+    rows: list[dict] = []
+    unknown: list[str] = []
+    from_rank = _TIER_RANK.get(f, -1)
+    for tid in candidates:
+        if tid not in _TIER_FEATURES:
+            unknown.append(tid)
+            continue
+        try:
+            path = capacity_headroom_path(f, tid, **kwargs)
+        except Exception as exc:
+            logger.warning(
+                "entitlements: capacity_headroom_path_batch row %r failed: %s",
+                tid,
+                exc,
+            )
+            unknown.append(tid)
+            continue
+        if path is None:
+            unknown.append(tid)
+            continue
+        to_rank = _TIER_RANK.get(tid, -1)
+        if f == tid:
+            direction = "identity"
+        elif from_rank == to_rank:
+            direction = "lateral"
+        elif to_rank > from_rank:
+            direction = "upgrade"
+        else:
+            direction = "downgrade"
+        rows.append(
+            {
+                "to": tid,
+                "to_label": tier_label(tid),
+                "to_rank": to_rank,
+                "direction": direction,
+                "path": path,
+            }
+        )
+    return {"tiers": rows, "unknown": unknown}
+
+
 def _capacity_row(from_tier: str, to_tier: str) -> dict:
     """Build one ``capacity_diff``-shape row for an arbitrary ``from -> to`` pair.
 

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -114,6 +114,18 @@ is the single source of truth -- handlers never re-derive tier logic here.
                                           UI can render "watch your headroom
                                           recover rung by rung" off ONE
                                           round-trip.
+  GET  /api/entitlement/capacity-headroom-path-batch -- batch sibling of
+                                          ``/capacity-headroom-path`` and
+                                          headroom-shaped twin of
+                                          ``/capacity-diff-path-batch``: walk
+                                          the per-rung headroom envelopes from
+                                          ONE ``?from=`` to N candidate
+                                          ``?to=a,b,c`` destinations in ONE
+                                          round-trip. Fan-out shape matches
+                                          ``/capacity-diff-path-batch`` and
+                                          ``/tier-spec-path-batch``; unknown
+                                          destinations bucket into
+                                          ``unknown[]`` instead of 404ing.
   GET  /api/entitlement/preview-batch  -- plural sibling of ``/preview``:
                                          the full ``Entitlement.to_dict``
                                          shape rendered for every purchasable
@@ -15979,6 +15991,124 @@ def api_entitlement_capacity_diff_path_batch():
     except Exception as exc:
         logger.warning(
             "api_entitlement_capacity_diff_path_batch: error: %s", exc
+        )
+        return jsonify(
+            {
+                "from": f,
+                "from_label": None,
+                "from_rank": -1,
+                "tiers": [],
+                "unknown": [],
+            }
+        )
+
+
+@bp_entitlement.route("/api/entitlement/capacity-headroom-path-batch")
+def api_entitlement_capacity_headroom_path_batch():
+    """``GET /api/entitlement/capacity-headroom-path-batch?from=<id>&to=a,b,c
+    &channels=<int>&retention_days=<int>&nodes=<int>`` -- batch sibling of
+    ``/api/entitlement/capacity-headroom-path``.
+
+    Where ``/capacity-headroom-path`` walks the rungs between ONE
+    ``(from, to)`` pair, this walks the rungs between ONE ``from`` and N
+    candidate ``to`` tiers in ONE round-trip. Pairs with
+    ``/capacity-headroom-path`` the same way ``/capacity-diff-path-batch``
+    pairs with ``/capacity-diff-path``: scalar -> matrix in one call.
+    Headroom-shaped twin of ``/capacity-diff-path-batch`` (same fan-out
+    shape, per-axis headroom body instead of marginal-transition body).
+
+    Use case: a capacity-only pricing-comparison "from my current rung,
+    here are the 3 tiers I'm considering -- watch my headroom recover rung
+    by rung on the way to each" surface hydrates the per-rung headroom
+    envelopes to every candidate off ONE call instead of N calls to
+    ``/capacity-headroom-path``. Same-rank siblings strictly between the
+    endpoints are included for each per-destination path; same-rank
+    siblings of each destination are excluded so the per-destination path
+    terminates exactly at its own ``to``. Per-destination path lengths can
+    legitimately differ (the rungs walked depend on the destination),
+    matching ``/capacity-diff-path-batch``'s posture.
+
+    Each row in ``tiers[].path`` is byte-identical to a row from
+    ``/capacity-headroom-path?from=<from>&to=<to>&...`` -- pinned by the
+    parity tests so the scalar and batch path accessors cannot drift.
+    Supplied destination ids are normalised (whitespace stripped,
+    lowercased, duplicates dropped, first-seen order preserved). Unknown
+    ids do not 404 the call -- they are echoed in ``unknown[]`` so a
+    partially-bad caller still gets paths back for the valid ids.
+
+    Per-axis ``None`` on every row means "axis not supplied" (matches
+    ``/capacity-headroom-path``'s posture). A blank, non-int, negative, or
+    ``bool``-in-disguise value on any axis short-circuits that axis to
+    ``None`` on every row of every destination -- a stray query string
+    cannot silently blank the whole matrix.
+
+    Response shape::
+
+        {
+          "from":       "<tier id>",
+          "from_label": "...",
+          "from_rank":  <int>,
+          "tiers": [
+            {
+              "to":        "<tier id>",
+              "to_label":  "...",
+              "to_rank":   <int>,
+              "direction": "upgrade" | "downgrade" | "lateral" | "identity",
+              "path":      [<capacity-headroom row>, ...],
+            },
+            ...
+          ],
+          "unknown":    ["bogus_id", ...],
+        }
+
+    - **400** when ``from=`` is missing / blank, or ``to=`` is missing /
+      empty after normalisation
+    - **404** when ``from`` is unknown (body carries ``which: "tier"``)
+    - **200** with bucketed unknowns for unknown destination ids -- does
+      NOT 404 the call, matching every other batch sibling
+    - **Never 5xxs**: a synthesis failure short-circuits to an envelope
+      with empty rows so the matrix keeps rendering.
+
+    Decoupled from the resolved entitlement -- every rung walks the static
+    per-tier caps via :func:`entitlements.capacity_headroom_at` -- so grace
+    vs enforce yields byte-identical ``path`` payloads.
+    """
+    f = (request.args.get("from") or "").strip().lower()
+    if not f:
+        return jsonify({"error": "missing from"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        if f not in _ent._TIER_ORDER:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "tier", "tier": f}
+                ),
+                404,
+            )
+        targets = _parse_csv_arg("to")
+        if not targets:
+            return jsonify({"error": "supply to=<csv>"}), 400
+        kwargs: dict[str, int] = {}
+        for name in ("channels", "retention_days", "nodes"):
+            present, ok, val, _raw = _parse_capacity_arg(name)
+            if present and ok and val is not None and val >= 0:
+                kwargs[name] = val
+        batch = _ent.capacity_headroom_path_batch(f, targets, **kwargs)
+        if batch is None:
+            batch = {"tiers": [], "unknown": []}
+        return jsonify(
+            {
+                "from": f,
+                "from_label": _ent.tier_label(f),
+                "from_rank": _ent.tier_rank(f),
+                "tiers": batch.get("tiers", []),
+                "unknown": batch.get("unknown", []),
+            }
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_capacity_headroom_path_batch: error: %s", exc
         )
         return jsonify(
             {

--- a/tests/test_entitlement_capacity_headroom_path_batch.py
+++ b/tests/test_entitlement_capacity_headroom_path_batch.py
@@ -1,0 +1,583 @@
+"""Tests for ``capacity_headroom_path_batch(from_tier, to_tiers, ...)`` plus
+its HTTP endpoint ``/api/entitlement/capacity-headroom-path-batch``.
+
+Batch sibling of :func:`capacity_headroom_path`: where the scalar path
+helper walks the per-rung capacity-headroom envelope for one
+``(from, to)`` pair, the batch helper walks N candidate destinations from
+one source in ONE round-trip. Headroom-shaped twin of
+:func:`capacity_diff_path_batch` (same fan-out shape, per-axis headroom
+body instead of marginal-transition body).
+
+Each per-destination ``path`` must be byte-identical to the matching
+scalar :func:`capacity_headroom_path` payload for the same
+``(from, to, axes)`` inputs -- pinned by the parity tests below so the
+scalar and batch path accessors cannot drift.
+
+Coverage:
+
+* per-destination ``path`` byte-equal to the scalar
+  :func:`capacity_headroom_path` payload
+* per-row body matches the singular :func:`capacity_headroom_at` shape
+  (``tier`` / ``tier_label`` / ``channels`` / ``retention_days`` /
+  ``nodes``) with the full ``_headroom_row`` triple per axis
+* per-destination ``direction`` derived from the same ranks the scalar
+  endpoint uses
+* batch envelope mirrors ``/capacity-headroom-path``'s envelope on the
+  source side (``from`` / ``from_label`` / ``from_rank``) and carries
+  ``tiers`` + ``unknown``
+* per-axis "None means axis not supplied" posture propagates to every
+  rung of every destination
+* input normalised (whitespace stripped, lowercased, duplicates dropped,
+  first-seen order preserved)
+* unknown destination ids echoed in ``unknown[]`` instead of 404'ing the
+  call (matching every other batch sibling)
+* identity ``from == to`` yields a per-destination entry whose ``path``
+  is ``[]``
+* lateral (same rank) yields a one-row per-destination ``path``
+* upgrade / downgrade direction labelled correctly
+* trial accepted as a destination (lateral / identity endpoint only --
+  excluded from intermediate rungs, same as the scalar helper)
+* unknown / empty / garbage ``from_tier`` returns ``None`` (helper) /
+  400 / 404 (HTTP)
+* helpers never raise -- a per-destination failure short-circuits that
+  id into ``unknown[]`` and the rest of the batch keeps building
+* HTTP endpoint 400 on missing / empty input, 404 on unknown source
+  tier, never 5xx on a row failure
+* grace vs enforce yields identical rows (resolver-independent)
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+_ROW_KEYS = {"tier", "tier_label", "channels", "retention_days", "nodes"}
+_AXIS_KEYS = {
+    "kind",
+    "used",
+    "cap",
+    "remaining",
+    "is_unlimited",
+    "at_limit",
+    "over_limit",
+    "pct_used",
+}
+
+_ITEM_KEYS = {"to", "to_label", "to_rank", "direction", "path"}
+
+_ENVELOPE_KEYS = {
+    "from",
+    "from_label",
+    "from_rank",
+    "tiers",
+    "unknown",
+}
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# ── helper-level: shape ──────────────────────────────────────────────────────
+
+
+def test_helper_returns_dict_shape(ent):
+    out = ent.capacity_headroom_path_batch(
+        ent.TIER_OSS,
+        [ent.TIER_CLOUD_STARTER, ent.TIER_ENTERPRISE],
+        channels=2,
+    )
+    assert isinstance(out, dict)
+    assert set(out.keys()) == {"tiers", "unknown"}
+    assert isinstance(out["tiers"], list)
+    assert isinstance(out["unknown"], list)
+
+
+def test_helper_each_item_carries_full_envelope(ent):
+    out = ent.capacity_headroom_path_batch(
+        ent.TIER_OSS,
+        [ent.TIER_CLOUD_STARTER, ent.TIER_ENTERPRISE],
+        channels=2,
+    )
+    for item in out["tiers"]:
+        assert set(item.keys()) == _ITEM_KEYS
+        assert isinstance(item["to"], str)
+        assert isinstance(item["to_label"], str)
+        assert isinstance(item["to_rank"], int)
+        assert item["direction"] in {
+            "upgrade",
+            "downgrade",
+            "lateral",
+            "identity",
+        }
+        assert isinstance(item["path"], list)
+
+
+def test_helper_per_row_matches_headroom_at_shape(ent):
+    """Per-row body matches the singular :func:`capacity_headroom_at`
+    envelope exactly -- ``tier``/``tier_label`` + three per-axis
+    ``_headroom_row`` triples."""
+    out = ent.capacity_headroom_path_batch(
+        ent.TIER_OSS,
+        [ent.TIER_ENTERPRISE],
+        channels=2,
+        retention_days=5,
+        nodes=1,
+    )
+    for row in out["tiers"][0]["path"]:
+        assert set(row.keys()) == _ROW_KEYS
+        for axis in ("channels", "retention_days", "nodes"):
+            assert set(row[axis].keys()) == _AXIS_KEYS
+
+
+# ── helper-level: parity with scalar ─────────────────────────────────────────
+
+
+def test_helper_per_item_path_byte_equal_to_scalar(ent):
+    """Pin: per-destination ``path`` is byte-identical to the scalar
+    :func:`capacity_headroom_path` payload for the same
+    ``(from, to, axes)`` inputs."""
+    candidates = [
+        ent.TIER_CLOUD_FREE,
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_ENTERPRISE,
+    ]
+    out = ent.capacity_headroom_path_batch(
+        ent.TIER_OSS, candidates, channels=2, retention_days=5, nodes=1
+    )
+    by_id = {item["to"]: item["path"] for item in out["tiers"]}
+    for tid in candidates:
+        scalar = ent.capacity_headroom_path(
+            ent.TIER_OSS, tid, channels=2, retention_days=5, nodes=1
+        )
+        assert by_id[tid] == scalar
+
+
+def test_helper_per_item_direction_matches_rank_geometry(ent):
+    candidates = [
+        ent.TIER_OSS,
+        ent.TIER_CLOUD_FREE,
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_PRO,
+        ent.TIER_ENTERPRISE,
+    ]
+    out = ent.capacity_headroom_path_batch(
+        ent.TIER_CLOUD_STARTER, candidates, channels=2
+    )
+    by_id = {item["to"]: item for item in out["tiers"]}
+    src_rank = ent.tier_rank(ent.TIER_CLOUD_STARTER)
+    for tid in candidates:
+        tgt_rank = ent.tier_rank(tid)
+        if tid == ent.TIER_CLOUD_STARTER:
+            expected = "identity"
+        elif src_rank == tgt_rank:
+            expected = "lateral"
+        elif tgt_rank > src_rank:
+            expected = "upgrade"
+        else:
+            expected = "downgrade"
+        assert by_id[tid]["direction"] == expected
+
+
+# ── helper-level: per-axis "None means axis not supplied" posture ────────────
+
+
+def test_helper_unsupplied_axis_stays_none_on_every_rung(ent):
+    out = ent.capacity_headroom_path_batch(
+        ent.TIER_OSS,
+        [ent.TIER_CLOUD_PRO, ent.TIER_ENTERPRISE],
+        channels=2,
+    )
+    for item in out["tiers"]:
+        for row in item["path"]:
+            assert row["channels"] is not None
+            assert row["retention_days"] is None
+            assert row["nodes"] is None
+
+
+def test_helper_supplied_axis_echoed_on_every_rung(ent):
+    out = ent.capacity_headroom_path_batch(
+        ent.TIER_OSS, [ent.TIER_ENTERPRISE], channels=42
+    )
+    for row in out["tiers"][0]["path"]:
+        assert row["channels"]["used"] == 42
+
+
+def test_helper_nothing_supplied_returns_all_none_rows(ent):
+    out = ent.capacity_headroom_path_batch(
+        ent.TIER_OSS, [ent.TIER_ENTERPRISE]
+    )
+    for row in out["tiers"][0]["path"]:
+        assert row["channels"] is None
+        assert row["retention_days"] is None
+        assert row["nodes"] is None
+
+
+# ── helper-level: input normalisation ────────────────────────────────────────
+
+
+def test_helper_supply_order_preserved(ent):
+    out = ent.capacity_headroom_path_batch(
+        ent.TIER_OSS,
+        [ent.TIER_ENTERPRISE, ent.TIER_CLOUD_PRO, ent.TIER_CLOUD_STARTER],
+        channels=2,
+    )
+    assert [item["to"] for item in out["tiers"]] == [
+        ent.TIER_ENTERPRISE,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_CLOUD_STARTER,
+    ]
+
+
+def test_helper_normalises_input(ent):
+    out = ent.capacity_headroom_path_batch(
+        ent.TIER_OSS,
+        [
+            "  CLOUD_PRO  ",
+            "cloud_starter",
+            "cloud_pro",
+            "",
+        ],
+        channels=2,
+    )
+    assert [item["to"] for item in out["tiers"]] == [
+        "cloud_pro",
+        "cloud_starter",
+    ]
+
+
+def test_helper_unknown_destination_ids_echoed(ent):
+    out = ent.capacity_headroom_path_batch(
+        ent.TIER_OSS,
+        [ent.TIER_CLOUD_PRO, "bogus_tier", "still_bogus"],
+        channels=2,
+    )
+    assert [item["to"] for item in out["tiers"]] == [ent.TIER_CLOUD_PRO]
+    assert set(out["unknown"]) == {"bogus_tier", "still_bogus"}
+
+
+# ── helper-level: direction branches ─────────────────────────────────────────
+
+
+def test_helper_identity_yields_empty_path(ent):
+    out = ent.capacity_headroom_path_batch(
+        ent.TIER_CLOUD_PRO,
+        [ent.TIER_CLOUD_PRO, ent.TIER_ENTERPRISE],
+        channels=2,
+    )
+    by_id = {item["to"]: item for item in out["tiers"]}
+    assert by_id[ent.TIER_CLOUD_PRO]["direction"] == "identity"
+    assert by_id[ent.TIER_CLOUD_PRO]["path"] == []
+    assert by_id[ent.TIER_ENTERPRISE]["direction"] == "upgrade"
+
+
+def test_helper_lateral_yields_one_row_path(ent):
+    out = ent.capacity_headroom_path_batch(
+        ent.TIER_CLOUD_PRO, [ent.TIER_PRO], channels=2
+    )
+    assert len(out["tiers"]) == 1
+    item = out["tiers"][0]
+    assert item["direction"] == "lateral"
+    assert len(item["path"]) == 1
+    assert item["path"][0]["tier"] == ent.TIER_PRO
+
+
+def test_helper_upgrade_walks_intermediate_rungs(ent):
+    out = ent.capacity_headroom_path_batch(
+        ent.TIER_OSS, [ent.TIER_ENTERPRISE], channels=2
+    )
+    item = out["tiers"][0]
+    assert item["direction"] == "upgrade"
+    tiers = [row["tier"] for row in item["path"]]
+    assert tiers[-1] == ent.TIER_ENTERPRISE
+    assert ent.TIER_OSS not in tiers
+
+
+def test_helper_downgrade_walks_descending(ent):
+    out = ent.capacity_headroom_path_batch(
+        ent.TIER_ENTERPRISE, [ent.TIER_OSS], channels=2
+    )
+    item = out["tiers"][0]
+    assert item["direction"] == "downgrade"
+    tiers = [row["tier"] for row in item["path"]]
+    ranks = [ent.tier_rank(r) for r in tiers]
+    assert ranks == sorted(ranks, reverse=True)
+
+
+# ── helper-level: trial endpoint ─────────────────────────────────────────────
+
+
+def test_helper_trial_destination_accepted(ent):
+    """``trial`` is a valid endpoint (matching :func:`capacity_headroom_path`
+    semantics) even though it is excluded from the walked intermediate
+    rungs."""
+    out = ent.capacity_headroom_path_batch(
+        ent.TIER_OSS, [ent.TIER_TRIAL], channels=2
+    )
+    assert out["unknown"] == []
+    assert [item["to"] for item in out["tiers"]] == [ent.TIER_TRIAL]
+
+
+# ── helper-level: error / edge cases ─────────────────────────────────────────
+
+
+def test_helper_unknown_from_tier_returns_none(ent):
+    assert (
+        ent.capacity_headroom_path_batch(
+            "not_a_tier", [ent.TIER_ENTERPRISE]
+        )
+        is None
+    )
+
+
+def test_helper_empty_destinations_yields_empty_envelope(ent):
+    out = ent.capacity_headroom_path_batch(ent.TIER_OSS, [])
+    assert out == {"tiers": [], "unknown": []}
+
+
+def test_helper_garbage_inputs_never_raise(ent):
+    assert ent.capacity_headroom_path_batch("", []) is None
+    assert ent.capacity_headroom_path_batch(None, None) is None  # type: ignore[arg-type]
+    assert ent.capacity_headroom_path_batch("  ", "  ") is None
+
+
+def test_helper_grace_and_enforce_yield_identical_output(ent, monkeypatch):
+    candidates = [ent.TIER_CLOUD_STARTER, ent.TIER_ENTERPRISE]
+    grace = ent.capacity_headroom_path_batch(
+        ent.TIER_OSS, candidates, channels=2, retention_days=5, nodes=1
+    )
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    enforced = ent.capacity_headroom_path_batch(
+        ent.TIER_OSS, candidates, channels=2, retention_days=5, nodes=1
+    )
+    assert grace == enforced
+
+
+def test_helper_row_failure_short_circuits_item(ent, monkeypatch):
+    """A per-destination failure pushes that id into ``unknown[]`` while
+    the rest of the batch keeps building."""
+    real = ent.capacity_headroom_path
+
+    def fake(f, t, **kw):
+        if t == ent.TIER_CLOUD_PRO:
+            raise RuntimeError("boom")
+        return real(f, t, **kw)
+
+    monkeypatch.setattr(ent, "capacity_headroom_path", fake)
+    out = ent.capacity_headroom_path_batch(
+        ent.TIER_OSS,
+        [ent.TIER_CLOUD_PRO, ent.TIER_ENTERPRISE],
+        channels=2,
+    )
+    assert [item["to"] for item in out["tiers"]] == [ent.TIER_ENTERPRISE]
+    assert ent.TIER_CLOUD_PRO in out["unknown"]
+
+
+# ── HTTP: /api/entitlement/capacity-headroom-path-batch ──────────────────────
+
+
+def test_api_400_on_missing_from(client):
+    r = client.get(
+        "/api/entitlement/capacity-headroom-path-batch?to=cloud_pro,enterprise"
+    )
+    assert r.status_code == 400
+
+
+def test_api_400_on_missing_to(client):
+    r = client.get(
+        "/api/entitlement/capacity-headroom-path-batch?from=oss"
+    )
+    assert r.status_code == 400
+    body = r.get_json()
+    assert body["error"] == "supply to=<csv>"
+
+
+def test_api_400_on_empty_to(client):
+    r = client.get(
+        "/api/entitlement/capacity-headroom-path-batch?from=oss&to=,,"
+    )
+    assert r.status_code == 400
+
+
+def test_api_404_on_unknown_from_tier(client):
+    r = client.get(
+        "/api/entitlement/capacity-headroom-path-batch"
+        "?from=not_a_tier&to=enterprise"
+    )
+    assert r.status_code == 404
+    body = r.get_json()
+    assert body["which"] == "tier"
+
+
+def test_api_200_with_unknown_destination_bucketed(client, ent):
+    r = client.get(
+        f"/api/entitlement/capacity-headroom-path-batch?from={ent.TIER_OSS}"
+        f"&to={ent.TIER_CLOUD_PRO},bogus_tier&channels=2"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert [item["to"] for item in body["tiers"]] == [ent.TIER_CLOUD_PRO]
+    assert body["unknown"] == ["bogus_tier"]
+
+
+def test_api_happy_path_ascending(client, ent):
+    r = client.get(
+        f"/api/entitlement/capacity-headroom-path-batch?from={ent.TIER_OSS}"
+        f"&to={ent.TIER_CLOUD_STARTER},{ent.TIER_ENTERPRISE}&channels=2"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert set(body.keys()) == _ENVELOPE_KEYS
+    assert body["from"] == ent.TIER_OSS
+    assert isinstance(body["from_label"], str)
+    assert body["from_rank"] == ent.tier_rank(ent.TIER_OSS)
+    tos = [item["to"] for item in body["tiers"]]
+    assert tos == [ent.TIER_CLOUD_STARTER, ent.TIER_ENTERPRISE]
+    for item in body["tiers"]:
+        assert item["direction"] == "upgrade"
+        assert item["path"][-1]["tier"] == item["to"]
+
+
+def test_api_identity_branch(client, ent):
+    r = client.get(
+        "/api/entitlement/capacity-headroom-path-batch"
+        f"?from={ent.TIER_CLOUD_PRO}&to={ent.TIER_CLOUD_PRO}"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["tiers"][0]["direction"] == "identity"
+    assert body["tiers"][0]["path"] == []
+
+
+def test_api_lateral_branch(client, ent):
+    r = client.get(
+        "/api/entitlement/capacity-headroom-path-batch"
+        f"?from={ent.TIER_CLOUD_PRO}&to={ent.TIER_PRO}&channels=2"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["tiers"][0]["direction"] == "lateral"
+    assert len(body["tiers"][0]["path"]) == 1
+
+
+def test_api_downgrade_branch(client, ent):
+    r = client.get(
+        "/api/entitlement/capacity-headroom-path-batch"
+        f"?from={ent.TIER_ENTERPRISE}&to={ent.TIER_OSS}&channels=2"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["tiers"][0]["direction"] == "downgrade"
+
+
+def test_api_per_item_path_matches_scalar_route(client, ent):
+    """HTTP parity: each per-destination ``path`` is byte-identical to the
+    scalar ``/capacity-headroom-path?from=&to=&axes=`` ``path`` payload
+    for the same ``(from, to, axes)`` inputs."""
+    candidates = [
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_ENTERPRISE,
+    ]
+    batch = client.get(
+        f"/api/entitlement/capacity-headroom-path-batch?from={ent.TIER_OSS}"
+        f"&to={','.join(candidates)}&channels=2&retention_days=5"
+    ).get_json()
+    for item in batch["tiers"]:
+        scalar = client.get(
+            f"/api/entitlement/capacity-headroom-path?from={ent.TIER_OSS}"
+            f"&to={item['to']}&channels=2&retention_days=5"
+        ).get_json()
+        assert item["path"] == scalar["path"]
+        assert item["direction"] == scalar["direction"]
+        assert item["to_label"] == scalar["to_label"]
+        assert item["to_rank"] == scalar["to_rank"]
+
+
+def test_api_bad_axis_collapses_to_none_on_every_row(client, ent):
+    """A stray ``?channels=junk`` cannot silently blank the whole matrix
+    -- the bad axis short-circuits to ``None`` on every rung of every
+    destination (matches the scalar ``/capacity-headroom-path``
+    posture)."""
+    r = client.get(
+        f"/api/entitlement/capacity-headroom-path-batch?from={ent.TIER_OSS}"
+        f"&to={ent.TIER_CLOUD_PRO},{ent.TIER_ENTERPRISE}&channels=junk"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    for item in body["tiers"]:
+        for row in item["path"]:
+            assert row["channels"] is None
+
+
+def test_api_input_normalised(client, ent):
+    r = client.get(
+        f"/api/entitlement/capacity-headroom-path-batch?from={ent.TIER_OSS}"
+        f"&to=  CLOUD_PRO  ,cloud_starter,cloud_pro,&channels=2"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert [item["to"] for item in body["tiers"]] == [
+        "cloud_pro",
+        "cloud_starter",
+    ]
+
+
+def test_api_grace_and_enforce_yield_identical_body(
+    client, ent, monkeypatch
+):
+    grace = client.get(
+        f"/api/entitlement/capacity-headroom-path-batch?from={ent.TIER_OSS}"
+        f"&to={ent.TIER_CLOUD_STARTER},{ent.TIER_ENTERPRISE}"
+        f"&channels=2&retention_days=5"
+    ).get_json()
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    enforced = client.get(
+        f"/api/entitlement/capacity-headroom-path-batch?from={ent.TIER_OSS}"
+        f"&to={ent.TIER_CLOUD_STARTER},{ent.TIER_ENTERPRISE}"
+        f"&channels=2&retention_days=5"
+    ).get_json()
+    assert grace == enforced
+
+
+def test_api_never_5xx_on_synthesis_failure(monkeypatch, client, ent):
+    """A blow-up inside the batch helper must NOT 5xx: the route returns
+    an envelope with empty ``tiers``/``unknown`` so the matrix keeps
+    rendering."""
+    import clawmetry.entitlements as _ent
+
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(_ent, "capacity_headroom_path_batch", boom)
+    r = client.get(
+        "/api/entitlement/capacity-headroom-path-batch"
+        f"?from={ent.TIER_OSS}&to={ent.TIER_ENTERPRISE}"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["tiers"] == []
+    assert body["unknown"] == []


### PR DESCRIPTION
## Summary

Fills the `_path_batch` slot on the capacity-headroom axis. Where `/capacity-headroom-path` walks the per-rung headroom envelope for ONE `(from, to)` pair, this walks the per-rung envelopes from ONE `from` to N candidate `to` tiers in ONE round-trip. Headroom-shaped twin of `/capacity-diff-path-batch` — same fan-out shape, per-axis headroom body instead of marginal-transition body.

Round-trip savings: a capacity-only pricing-comparison "from my current rung, here are the 3 tiers I'm considering — watch my headroom recover rung by rung on the way to each" surface hydrates the per-rung envelopes to every candidate off ONE call instead of N calls to `/capacity-headroom-path`.

### What lands

- `clawmetry/entitlements.py`: `capacity_headroom_path_batch(from_tier, to_tiers, *, channels=None, retention_days=None, nodes=None) -> {"tiers": [...], "unknown": [...]}`. Delegates per-destination to `capacity_headroom_path`; a per-destination failure pushes that id into `unknown[]` and the rest of the batch keeps building. Never raises.
- `routes/entitlement.py`: `GET /api/entitlement/capacity-headroom-path-batch?from=<id>&to=a,b,c&channels=<int>&retention_days=<int>&nodes=<int>` — mirrors `/capacity-diff-path-batch`'s envelope (`from` / `from_label` / `from_rank` + `tiers` + `unknown`). Blueprint entry in the module docstring also updated.
- `tests/test_entitlement_capacity_headroom_path_batch.py`: 35 tests — helper shape, per-row body matches `capacity_headroom_at`, per-path byte-equal to scalar `capacity_headroom_path` (pinning), direction geometry across all four branches (upgrade / downgrade / lateral / identity), axis "None means unsupplied" propagation, input normalisation, trial endpoint acceptance, grace/enforce parity, per-item failure fallback, and the full HTTP surface (400 / 404 / 200-with-bucketed-unknowns / never-5xx).

### Zero behaviour change

The helper walks static per-tier caps via `capacity_headroom_at` — grace vs enforce yields byte-identical bodies. Purely additive: no existing endpoint/helper touched, no version bump, no enforcement flip, no `[RELEASE]` tag.

## Test plan

- [x] `python3 -m py_compile clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_capacity_headroom_path_batch.py` — OK
- [x] `python3 -m pytest tests/test_entitlement_capacity_headroom_path_batch.py -x -q` — 35 passed
- [x] Regression: `python3 -m pytest tests/test_entitlement_capacity_headroom{,_at,_batch,_path}.py tests/test_entitlement_capacity_diff_path_batch.py -q` — 130 passed
- [ ] CI green on this branch
- [ ] Local operator verification (below) — draft PR waits on the operator to flip ready-for-review

## Local operator verification checklist

Automated firing can only compile + unit-test in this repo. The daemon-side install path, live snapshot decrypt, and browser check need the operator:

- [ ] `git fetch origin feat/capacity-headroom-path-batch && git checkout feat/capacity-headroom-path-batch`
- [ ] Copy the two changed source files into the running daemon's site-packages:
  ```sh
  cp clawmetry/entitlements.py ~/.clawmetry/lib/python*/site-packages/clawmetry/
  cp routes/entitlement.py     ~/.clawmetry/lib/python*/site-packages/routes/
  find ~/.clawmetry/lib/python*/site-packages/clawmetry/__pycache__ -delete 2>/dev/null || true
  find ~/.clawmetry/lib/python*/site-packages/routes/__pycache__    -delete 2>/dev/null || true
  ```
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
- [ ] Confirm the new endpoint is live:
  ```sh
  curl -s 'http://localhost:8900/api/entitlement/capacity-headroom-path-batch?from=oss&to=cloud_starter,cloud_pro,enterprise&channels=2' | python -m json.tool | head -60
  ```
  Expect: envelope with `from` / `from_label` / `from_rank` + `tiers[]` (three entries, ascending `direction=upgrade`) + `unknown: []`.
- [ ] Confirm per-destination `path` is byte-identical to the scalar route:
  ```sh
  diff <(curl -s 'http://localhost:8900/api/entitlement/capacity-headroom-path-batch?from=oss&to=enterprise&channels=2' | python -c 'import json,sys; print(json.dumps(json.load(sys.stdin)["tiers"][0]["path"], sort_keys=True, indent=2))') \
       <(curl -s 'http://localhost:8900/api/entitlement/capacity-headroom-path?from=oss&to=enterprise&channels=2'       | python -c 'import json,sys; print(json.dumps(json.load(sys.stdin)["path"],            sort_keys=True, indent=2))')
  ```
  Expect: empty diff.
- [ ] Decrypt the live cloud snapshot in the browser and confirm nothing else moved (this PR is additive, no existing endpoint touched).
- [ ] If all four boxes are green, flip the PR from draft → ready-for-review and merge.

**Do not merge from an automated firing.** This PR is intentionally left as draft; the local operator owns the ready-for-review flip.

---
_Generated by [Claude Code](https://claude.ai/code/session_01K1LagqEbJgSTWmitQV1whF)_