### PR TITLE
fix: exclude named-profile gateway logs from default-profile selection

### DIFF
--- a/clawmetry/adapters/openclaw.py
+++ b/clawmetry/adapters/openclaw.py
@@ -17,6 +17,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import tempfile
 import time as _time
 from typing import List, Optional, Set
@@ -24,6 +25,12 @@ from typing import List, Optional, Set
 from .base import AgentAdapter, Capability, DetectResult, Event, Session
 
 logger = logging.getLogger("clawmetry.adapters.openclaw")
+
+# Named OpenClaw profiles write openclaw-{name}-YYYY-MM-DD.log alongside the
+# default-profile openclaw-YYYY-MM-DD.log.  Matching only the date-only form
+# prevents lexicographic sort from mis-selecting a named-profile log as
+# "the current log" and silently dropping default-profile gateway events.
+_DEFAULT_LOG_RE = re.compile(r"openclaw-\d{4}-\d{2}-\d{2}\.log$")
 
 # NeMo Guardrails compact tool-catalog injects these three meta-tool names into
 # the JSONL transcript when NEMOCLAW_TOOL_CATALOG is active. They are guardrail
@@ -477,7 +484,10 @@ def _gateway_log_files() -> list:
         if os.path.isdir(entry):
             candidates.append(entry)
     for d in candidates:
-        matches = sorted(glob.glob(os.path.join(d, "openclaw-*.log")))
+        matches = sorted(
+            m for m in glob.glob(os.path.join(d, "openclaw-*.log"))
+            if _DEFAULT_LOG_RE.search(os.path.basename(m))
+        )
         if matches:
             return matches[-5:]
     return []

--- a/routes/infra.py
+++ b/routes/infra.py
@@ -26,6 +26,7 @@ mechanical move — zero behaviour change.
 
 import json
 import os
+import re
 import sqlite3
 import subprocess
 import time
@@ -69,10 +70,11 @@ def resolve_gateway_log_path():
     # don't depend on glob's stat behaviour, then pick the most recent by
     # mtime — falling back to filename order if mtime can't be read.
     tmp_dir = "/tmp/openclaw"
+    _default_log_re = re.compile(r"openclaw-\d{4}-\d{2}-\d{2}\.log$")
     try:
         names = [
             n for n in os.listdir(tmp_dir)
-            if n.startswith("openclaw-") and n.endswith(".log")
+            if _default_log_re.search(n)
         ]
     except Exception:
         names = []


### PR DESCRIPTION
Closes #4021

## Problem

When OpenClaw named profiles (`openclaw --profile dev`) run alongside the default profile, both write to the same log directory:

- Default: `openclaw-2026-07-25.log`
- Named "dev": `openclaw-dev-2026-07-25.log`

The previous `openclaw-*.log` glob + alphabetic-last-pick in `_gateway_log_files()` silently promoted the named-profile log over the default's. Because letters sort after digits, `openclaw-dev-2026-07-25.log` sorted last and became `files[-1]` — the file `_gateway_log_events()` reads — dropping all default-profile gateway events. `resolve_gateway_log_path()` in `routes/infra.py` had the same blind spot.

## Changes

- **`clawmetry/adapters/openclaw.py`** — add `import re` + module-level `_DEFAULT_LOG_RE = re.compile(r"openclaw-\d{4}-\d{2}-\d{2}\.log$")`; filter the glob in `_gateway_log_files()` to only include filenames matching that date-only pattern before sorting. Named-profile log files are excluded. (+10 LOC)
- **`routes/infra.py`** — add `import re`; filter the `os.listdir()` names in `resolve_gateway_log_path()` with the same pattern before picking newest by mtime. (+4 LOC)

## Test plan

- `python3 -m pytest tests/test_obs_gap_gateway_log_events_3991.py tests/test_adapters.py` — 18 tests, all pass
- Manual: create two log files in a temp dir (`openclaw-2026-07-25.log` and `openclaw-dev-2026-07-25.log`); confirm `_gateway_log_files()` returns only the date-named file

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sug4Dms45duh2rvhDHwwSN)_