### PR TITLE
fix(openclaw): surface OPENCLAW_SUPERVISOR_MODE env var when gateway is down (#4023)

### DIFF
--- a/clawmetry/adapters/openclaw.py
+++ b/clawmetry/adapters/openclaw.py
@@ -1557,6 +1557,35 @@ def _gateway_host_status() -> dict:
         return {}
 
 
+def _gateway_supervisor_mode_env() -> dict:
+    """Read OpenClaw external-supervisor mode from the local environment (#4023).
+
+    ``OPENCLAW_SUPERVISOR_MODE`` is set by the operator when an external lifecycle
+    owner (e.g. OCM) supervises the gateway.  When the gateway is down during a
+    supervised restart handoff, ``_gateway_host_status()`` is not called (it
+    requires a live RPC connection), so the supervisor context is invisible.
+
+    This helper reads the env var unconditionally as a baseline fallback.  When
+    the gateway IS live, ``_gateway_host_status()`` overwrites these keys with
+    the authoritative RPC value.
+
+    Returns ``{"gatewaySupervisorMode": ...}`` (and optionally
+    ``"gatewaySupervisorModeVersion"``) when the env var is set, ``{}`` otherwise.
+    Never raises.
+    """
+    try:
+        mode = os.environ.get("OPENCLAW_SUPERVISOR_MODE")
+        if not mode:
+            return {}
+        result: dict = {"gatewaySupervisorMode": str(mode)}
+        version = os.environ.get("OPENCLAW_SUPERVISOR_MODE_VERSION")
+        if version:
+            result["gatewaySupervisorModeVersion"] = str(version)
+        return result
+    except Exception:
+        return {}
+
+
 def _gateway_presence_roster() -> dict:
     """Who's-online presence roster from the OpenClaw gateway.status RPC (#3884).
 
@@ -1933,6 +1962,11 @@ class OpenClawAdapter(AgentAdapter):
             # from ~/.nemoclaw/agents.yaml (written by harness onboarding,
             # commit 01e5525).
             meta.update(_nemoclaw_agents_manifest())
+            # External-supervisor mode env-var fallback (#4023): surface
+            # OPENCLAW_SUPERVISOR_MODE even when the gateway is down (e.g. during
+            # a supervised restart handoff). _gateway_host_status() below will
+            # overwrite with the live RPC value when the gateway is up.
+            meta.update(_gateway_supervisor_mode_env())
             # Gateway plugin health (#3200): per-plugin state (loaded/errored/
             # disabled) added to gateway.status in harness 2026.6.9 (#93395).
             # Only meaningful — and safe to query — when the gateway is live.

--- a/tests/test_obs_gap_openclaw_supervisor_mode_env_4023.py
+++ b/tests/test_obs_gap_openclaw_supervisor_mode_env_4023.py
@@ -1,0 +1,80 @@
+"""Tests for issue #4023 — openclaw: external supervisor mode env-var fallback.
+
+Verifies that _gateway_supervisor_mode_env() surfaces OPENCLAW_SUPERVISOR_MODE
+and OPENCLAW_SUPERVISOR_MODE_VERSION from the local environment so the
+supervisor context appears even when the gateway is down (RPC unavailable).
+
+Fingerprint: hgap-fada9f0f13 (used to dedupe — keep it in the body).
+"""
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+import types
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _restore_env_and_modules(monkeypatch):
+    saved_dashboard = sys.modules.get("dashboard")
+    saved_adapter = sys.modules.get("clawmetry.adapters.openclaw")
+    monkeypatch.delenv("OPENCLAW_SUPERVISOR_MODE", raising=False)
+    monkeypatch.delenv("OPENCLAW_SUPERVISOR_MODE_VERSION", raising=False)
+    yield
+    if saved_dashboard is None:
+        sys.modules.pop("dashboard", None)
+    else:
+        sys.modules["dashboard"] = saved_dashboard
+    if saved_adapter is None:
+        sys.modules.pop("clawmetry.adapters.openclaw", None)
+    else:
+        sys.modules["clawmetry.adapters.openclaw"] = saved_adapter
+
+
+def _stub_dashboard():
+    mod = types.ModuleType("dashboard")
+    sys.modules["dashboard"] = mod
+    return mod
+
+
+def _reload_adapter():
+    _stub_dashboard()
+    import clawmetry.adapters.openclaw as oc_mod
+    importlib.reload(oc_mod)
+    return oc_mod
+
+
+def test_supervisor_mode_env_external(monkeypatch):
+    """OPENCLAW_SUPERVISOR_MODE=external is surfaced as gatewaySupervisorMode."""
+    monkeypatch.setenv("OPENCLAW_SUPERVISOR_MODE", "external")
+    oc = _reload_adapter()
+    result = oc._gateway_supervisor_mode_env()
+    assert result["gatewaySupervisorMode"] == "external"
+    assert "gatewaySupervisorModeVersion" not in result
+
+
+def test_supervisor_mode_env_with_version(monkeypatch):
+    """Both mode and version env vars are surfaced when set."""
+    monkeypatch.setenv("OPENCLAW_SUPERVISOR_MODE", "external")
+    monkeypatch.setenv("OPENCLAW_SUPERVISOR_MODE_VERSION", "2")
+    oc = _reload_adapter()
+    result = oc._gateway_supervisor_mode_env()
+    assert result["gatewaySupervisorMode"] == "external"
+    assert result["gatewaySupervisorModeVersion"] == "2"
+
+
+def test_supervisor_mode_env_absent():
+    """When env var is not set, helper returns empty dict."""
+    oc = _reload_adapter()
+    result = oc._gateway_supervisor_mode_env()
+    assert result == {}
+
+
+def test_supervisor_mode_env_empty_string(monkeypatch):
+    """Empty string is treated as absent (falsy) and returns empty dict."""
+    monkeypatch.setenv("OPENCLAW_SUPERVISOR_MODE", "")
+    oc = _reload_adapter()
+    result = oc._gateway_supervisor_mode_env()
+    assert result == {}


### PR DESCRIPTION
## Summary

When `OPENCLAW_SUPERVISOR_MODE=external` is set but the gateway is temporarily down (during a supervised restart handoff), ClawMetry treated it as a plain dead gateway — the supervisor context was invisible. This is because `_gateway_host_status()` (which reads `supervisorMode` from the RPC payload) is only called inside the `if running:` block.

This PR adds `_gateway_supervisor_mode_env()` — a tiny env-var reader called unconditionally before `if running:` — so the supervisor context appears in `DetectResult.meta` even when the gateway is momentarily offline. When the gateway IS live, `_gateway_host_status()` overwrites those keys with the authoritative RPC values.

## Changes

- `clawmetry/adapters/openclaw.py` — new `_gateway_supervisor_mode_env() -> dict` helper (~20 LOC) reads `OPENCLAW_SUPERVISOR_MODE` / `OPENCLAW_SUPERVISOR_MODE_VERSION` from env; called unconditionally in `detect()` before the `if running:` block.
- `tests/test_obs_gap_openclaw_supervisor_mode_env_4023.py` (new) — 4 tests: env var present, env var + version, env var absent, empty string treated as absent.

## Test plan

- [x] `python3 -m pytest tests/test_obs_gap_openclaw_supervisor_mode_env_4023.py tests/test_obs_gap_openclaw_supervisor_mode_3783.py -v` — 8 passed (4 new + 4 existing RPC-based tests unaffected)
- [x] `python3 -c 'import ast; ast.parse(open("clawmetry/adapters/openclaw.py").read())'` — syntax OK
- [ ] CI green

## Bot meta

<!-- bot-autofix -->
Draft PR opened autonomously based on the plan in #4023. Marked draft for human review — mark Ready for Review once happy.

Closes #4023

---
_Generated by [Claude Code](https://claude.ai/code/session_01989WiEDVcEiXjQbBregmc4)_