### PR TITLE
fix(license): auto_provision_pro honors CLAWMETRY_OFFLINE

### DIFF
--- a/clawmetry/license.py
+++ b/clawmetry/license.py
@@ -667,6 +667,13 @@ def auto_provision_pro(api_key: str, node_id: str | None = None) -> tuple[bool, 
         and the node continues on the free runtimes.
       * Idempotent — skips the download when clawmetry-pro is already current.
       * The wheel is fetched only from our own HTTPS /api/license/download.
+      * ``CLAWMETRY_OFFLINE=1`` skips the entitlement probe AND the wheel
+        download — no outbound network is touched. Symmetric with
+        :func:`_download_and_install_pro` (the signed-license path); without
+        this, the module docstring's "air-gapped install" claim was only
+        half-true, since ``clawmetry connect`` and the sync-daemon watchers
+        would still phone home to ``/api/license/entitlement`` and pull the
+        closed-source wheel behind the operator's back.
 
     Returns (installed, status_message). ``installed`` is True only when the
     pro wheel is now present (newly installed or already there for an entitled
@@ -675,6 +682,11 @@ def auto_provision_pro(api_key: str, node_id: str | None = None) -> tuple[bool, 
         key = (api_key or "").strip()
         if not key.startswith("cm_"):
             return False, ""
+        if _offline_mode():
+            return False, (
+                "offline mode: skipping clawmetry-pro auto-provision "
+                "(unset CLAWMETRY_OFFLINE to fetch the pro wheel)"
+            )
         base = _cloud_base()
         headers = {"X-Api-Key": key}
         # 1) Probe entitlement WITHOUT downloading the wheel.

--- a/tests/test_license.py
+++ b/tests/test_license.py
@@ -616,10 +616,18 @@ def test_activate_then_entitlement_resolves_pro(lic, monkeypatch):
 @pytest.fixture
 def prov(lic, monkeypatch, tmp_path):
     """license module with the pro marker redirected to a temp file + the cloud
-    base pointed at a fake server, and no real pro package present."""
+    base pointed at a fake server, and no real pro package present.
+
+    Note: the parent ``lic`` fixture sets ``CLAWMETRY_OFFLINE=1`` so tests never
+    leak to the real network by accident. Since ``auto_provision_pro`` now
+    honors that flag (early-returns without probing), phone-home tests must
+    opt back OUT explicitly — otherwise every stubbed urlopen would never be
+    reached. Tests that WANT the offline short-circuit stub urlopen to raise
+    on any call (see ``test_auto_provision_offline_env_skips_probe``)."""
     monkeypatch.setattr(lic.L, "_PRO_MARKER_PATH", str(tmp_path / "pro.json"))
     monkeypatch.setenv("CLAWMETRY_INGEST_URL", "https://fake.clawmetry.test")
     monkeypatch.setattr(lic.L, "_pro_installed_version", lambda: None)
+    monkeypatch.delenv("CLAWMETRY_OFFLINE", raising=False)
     return lic
 
 
@@ -722,6 +730,28 @@ def test_auto_provision_idempotent_when_pro_present(prov, monkeypatch):
     assert installed is True
     assert calls["download"] == 1  # re-validates with the server every call
     assert "already installed" in msg
+
+
+@pytest.mark.parametrize("truthy", ["1", "true", "YES"])
+def test_auto_provision_offline_env_skips_probe(prov, monkeypatch, truthy):
+    """CLAWMETRY_OFFLINE (any truthy spelling) short-circuits auto_provision_pro
+    before any HTTP is issued: neither /api/license/entitlement nor
+    /api/license/download is touched. Symmetric with the activate path's
+    offline gate (see ``test_activate_offline_env_skips_phone_home``) so a
+    single env var reliably keeps an air-gapped install off the wire whether
+    the operator connects via cm_ key or activates via signed license."""
+    import urllib.request
+
+    monkeypatch.setenv("CLAWMETRY_OFFLINE", truthy)
+
+    def _no_network(*a, **k):
+        raise AssertionError("network touched in offline mode")
+
+    monkeypatch.setattr(urllib.request, "urlopen", _no_network)
+    installed, msg = prov.L.auto_provision_pro("cm_prouser", node_id="n1")
+    assert installed is False
+    assert "offline mode" in msg
+    assert "CLAWMETRY_OFFLINE" in msg  # tells the operator the way out
 
 
 def test_download_wheel_refuses_non_https(prov):


### PR DESCRIPTION
## Summary

- Fills the half-truth in `clawmetry/license.py`'s "air-gapped install" contract. The Trust Model docstring promises `CLAWMETRY_OFFLINE=1` skips the phone-home entirely — but only the signed-license path (`_download_and_install_pro`, line ~621) honoured the flag. The cloud-account path (`auto_provision_pro`, called by `clawmetry connect` and by the sync-daemon start-up / entitlement-watcher / heartbeat-upgrade paths in `sync.py`) still probed `/api/license/entitlement` and downloaded the closed-source wheel behind the operator's back.
- Fix: an early return at the top of `auto_provision_pro` that returns `(False, "offline mode: skipping ... (unset CLAWMETRY_OFFLINE to fetch the pro wheel)")`. Mirrors the message shape of the existing offline gate in `_download_and_install_pro` and names the env var so an operator can turn phone-home back on without grepping the docs.
- Test-fixture ripple: the `lic` fixture already sets `CLAWMETRY_OFFLINE=1` to keep unit tests off the network. The `prov` fixture (used by the `auto_provision_pro` phone-home tests) now `delenv`s it explicitly, since with the new gate any stubbed `urlopen` would never be reached. Adds `test_auto_provision_offline_env_skips_probe` (parametrised over `"1" / "true" / "YES"`) that asserts the short-circuit with a `urlopen` stub that raises on any call — symmetric with `test_activate_offline_env_skips_phone_home` on the other side of the offline gate.

### Zero behaviour change for the default install

`CLAWMETRY_OFFLINE` is unset by default, so `_offline_mode()` returns `False` and `auto_provision_pro` falls through to the existing probe-and-install path byte-for-byte. Grace / enforce untouched. No new endpoint, no version bump, no `[RELEASE]` tag. Purely a defensive fix for the documented but half-broken air-gap opt-out.

## Test plan

- [x] `python3 -m py_compile clawmetry/license.py tests/test_license.py` — OK
- [x] `python3 -m pytest tests/test_license.py -x -q` — 56 passed
- [x] `python3 -m pytest tests/test_license.py tests/test_license_api.py tests/test_license_audit.py tests/test_license_permissions.py tests/test_license_pro_upgrade.py tests/test_license_pubkey.py tests/test_cli_activate_json.py tests/test_cli_license_json.py tests/test_connect_otp_skip.py -x -q` — 131 passed, 1 skipped
- [x] Regression spot-check on adjacent entitlement / paywall suites: `python3 -m pytest tests/test_entitlement_api.py tests/test_entitlement_api_fallback_shape.py tests/test_entitlement_expiry.py tests/test_paywall_body.py tests/test_paywall_body_runtime.py -x -q` — 89 passed
- [ ] CI green on this branch
- [ ] Local operator verification (below) — draft PR waits on the operator to flip ready-for-review

## Local operator verification checklist

Automated firing can only compile + unit-test in this repo. The daemon-side install path and live end-to-end verification need the operator:

- [ ] `git fetch origin feat/offline-env-gates-auto-provision-pro && git checkout feat/offline-env-gates-auto-provision-pro`
- [ ] Copy the changed source file into the running daemon's site-packages:
  ```sh
  cp clawmetry/license.py ~/.clawmetry/lib/python*/site-packages/clawmetry/
  find ~/.clawmetry/lib/python*/site-packages/clawmetry/__pycache__ -delete 2>/dev/null || true
  ```
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
- [ ] Reproduce the pre-fix behaviour (control): with `CLAWMETRY_OFFLINE` unset, `clawmetry connect --dry-run` (or the equivalent path that hits `auto_provision_pro`) still probes `/api/license/entitlement` and, for an entitled account, downloads the pro wheel. Confirm from `~/.clawmetry/sync.log`.
- [ ] Confirm the fix: `CLAWMETRY_OFFLINE=1 clawmetry connect ...` returns `Note: offline mode: skipping clawmetry-pro auto-provision (unset CLAWMETRY_OFFLINE to fetch the pro wheel)` and NOTHING hits `/api/license/entitlement` or `/api/license/download`. Verify from a tcpdump/mitmproxy trace or from `~/.clawmetry/sync.log` (no `GET /api/license/entitlement` line).
- [ ] Sanity: `CLAWMETRY_OFFLINE=1` set at the daemon level (via the launchd plist) — after `launchctl kickstart -k`, `tail -f ~/.clawmetry/sync.log` should show the sync-daemon's entitlement-watcher logging `pro auto-provision (daemon) skipped: ...` (via the `_pe` branch) or the debug line, not an `auto-provision failed` warning with a URLError.
- [ ] Decrypt the live cloud snapshot in the browser and confirm nothing else moved (this PR only touches the license module + its test suite).
- [ ] If all boxes are green, flip the PR from draft → ready-for-review and merge.

**Do not merge from an automated firing.** This PR is intentionally left as draft; the local operator owns the ready-for-review flip.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CQr3Jgc3Gh7vNVFUfG76Hq)_