### PR TITLE
fix(e2e): complete C6 tracking-issue fix -- c6-health and c6-schedule-heal now post to #4029

### DIFF
--- a/.github/workflows/c6-health.yml
+++ b/.github/workflows/c6-health.yml
@@ -9,7 +9,7 @@ name: C6 daily health check (branch-protection audit -- all 3 repos)
 # used cross-repo (returns 403 even on public repos); unauthenticated
 # reads return the full protection.required_status_checks object.
 #
-# On failure: posts an @-mentioned reminder to tracking issue #3864
+# On failure: posts an @-mentioned reminder to tracking issue #4029
 # at most once per calendar day. On success: posts a GREEN confirmation.
 #
 # To close C6:
@@ -19,7 +19,7 @@ name: C6 daily health check (branch-protection audit -- all 3 repos)
 #   2. Or: bash scripts/close-c6.sh
 #   3. Or: Settings > Branches > main > Required status checks (each repo)
 #
-# Tracking: vivekchand/clawmetry#3864
+# Tracking: vivekchand/clawmetry#4029
 
 on:
   schedule:
@@ -49,7 +49,7 @@ jobs:
 
           TOKEN = os.environ["GITHUB_TOKEN"]
           OWNER = "vivekchand"
-          TRACKING_ISSUE = 3864
+          TRACKING_ISSUE = 4029
           MARKER = "<!-- c6-health-check -->"
           # Repo this workflow runs in. Cross-repo reads must NOT send the
           # scoped GITHUB_TOKEN: Actions tokens are repo-scoped and return 403

--- a/.github/workflows/c6-schedule-heal.yml
+++ b/.github/workflows/c6-schedule-heal.yml
@@ -23,7 +23,7 @@ name: C6 auto-heal (daily required-checks application)
 #     clawmetry, clawmetry-cloud, clawmetry-landing
 #   This workflow picks it up at 10:15am UTC and closes C6 automatically.
 #
-# Tracking: vivekchand/clawmetry#3864
+# Tracking: vivekchand/clawmetry#4029
 
 on:
   schedule:
@@ -162,7 +162,7 @@ except Exception:
               echo "bash scripts/close-c6.sh"
               echo "\`\`\`"
               echo ""
-              echo "Tracking: [#3864](https://github.com/vivekchand/clawmetry/issues/3864)"
+              echo "Tracking: [#4029](https://github.com/vivekchand/clawmetry/issues/4029)"
             fi
           } >> "$GITHUB_STEP_SUMMARY"
 
@@ -173,7 +173,7 @@ except Exception:
           echo ""
           echo "ACTION REQUIRED: Add E2E_ADMIN_PAT to close C6."
           echo "See the job summary above for a formatted status report and close options."
-          echo "Tracking: https://github.com/vivekchand/clawmetry/issues/3864"
+          echo "Tracking: https://github.com/vivekchand/clawmetry/issues/4029"
           exit 1
 
       - name: Apply required E2E status checks (C6)
@@ -196,7 +196,7 @@ except Exception:
             echo "- [clawmetry-cloud branch protection](https://github.com/vivekchand/clawmetry-cloud/settings/branches)"
             echo "- [clawmetry-landing branch protection](https://github.com/vivekchand/clawmetry-landing/settings/branches)"
             echo ""
-            echo "Tracking: [#3864](https://github.com/vivekchand/clawmetry/issues/3864)"
+            echo "Tracking: [#4029](https://github.com/vivekchand/clawmetry/issues/4029)"
           } >> "$GITHUB_STEP_SUMMARY"
           echo "C6 auto-heal complete. If apply_required_status_checks.py exited 0, branch protection"
-          echo "is configured on all 3 repos. Tracking: https://github.com/vivekchand/clawmetry/issues/3864"
+          echo "is configured on all 3 repos. Tracking: https://github.com/vivekchand/clawmetry/issues/4029"


### PR DESCRIPTION
## Summary

PR #4030 fixed `apply-required-checks.yml`, `scripts/apply_required_status_checks.py`, and `scripts/close-c6.sh` but missed the two workflows that send daily C6 notifications. Both still post/link to issue `#3864` (nonexistent), so the admin never sees daily C6 reminders.

**Files changed:**

| File | Occurrences fixed |
|------|------------------|
| `.github/workflows/c6-health.yml` | 3 -- `TRACKING_ISSUE = 3864`, header comment, dedup check all pointed to wrong issue |
| `.github/workflows/c6-schedule-heal.yml` | 5 -- header comment, job summary tracking links (x2), error step output (x2) |

No logic changes. Pure reference fix (`s/3864/4029/g`).

## Why this matters

- `c6-health.yml` runs at **9:00 UTC daily** and posts a `<!-- c6-health-check -->` comment to the tracking issue when C6 (required-status-checks) is not configured. With `TRACKING_ISSUE = 3864`, every daily notification goes to a nonexistent issue. The admin never receives a GitHub ping. The cron fires, makes noise, and silently drops the alert.
- `c6-schedule-heal.yml` runs at **10:15 UTC daily** and its job summary + error step link to `#3864`. When the admin opens the Actions job to understand why C6 is red, the tracking link sends them nowhere.

After this PR, both workflows post to `#4029` (the E2E Robustness epic tracking issue created 2026-07-25).

## Acceptance test

After merge: trigger `c6-health.yml` via `workflow_dispatch`. If C6 is not yet configured, a comment from `github-actions[bot]` should appear on issue `#4029` within 60s.

## Next step for C6

To configure required-status-checks (the actual C6 close), the admin can use any of:
- **Settings UI** (60s): Settings > Branches > main > Require status checks > add the 4 check names
- **Actions one-shot** (needs fine-grained PAT with Administration: write): Actions > "Apply required E2E status checks (C6)" > confirm=APPLY, pat_token=...
- **Terminal** (30s): `bash scripts/close-c6.sh`

---
_Generated by [Claude Code](https://claude.ai/code/session_018gnBLAbPXstBLbNFdE2ems)_