### PR TITLE
feat(paywall): since/until time-window filters on /api/paywall/events/{first,last}

### DIFF
--- a/clawmetry/_paywall_events.py
+++ b/clawmetry/_paywall_events.py
@@ -585,6 +585,8 @@ class _PaywallEventStore:
         harness: str | None = None,
         source: str | None = None,
         plan_chosen: str | None = None,
+        since: Any = None,
+        until: Any = None,
     ) -> dict | None:
         """Return the single most-recent event matching the supplied
         filters, or ``None`` if nothing matches.
@@ -600,6 +602,16 @@ class _PaywallEventStore:
         O(k) where k is the distance from the newest row to the first
         matching row, not O(n).
 
+        Optional keyword bounds (``since`` / ``until``) further restrict
+        the walk to rows whose ``ts`` falls in the half-open interval
+        ``[since, until)`` (epoch seconds; either bound may be ``None`` =
+        unbounded on that side). Bounds and categorical filters are
+        ``AND`` combined; a bogus bound collapses to "not supplied" via
+        :func:`_coerce_ts_bound`. Semantics match :meth:`recent` so a
+        dashboard tile can rebind the same window pair from
+        ``/api/paywall/events/recent`` to ``/api/paywall/events/last``
+        without translation.
+
         Never raises: a filter failure short-circuits to ``None`` instead
         of propagating.
         """
@@ -608,10 +620,16 @@ class _PaywallEventStore:
                 event=event, feature=feature, harness=harness,
                 source=source, plan_chosen=plan_chosen,
             )
+            since_ts, until_ts = _normalise_time_bounds(since, until)
+            has_window = since_ts is not None or until_ts is not None
             with self._lock:
                 snap = list(self._ring)
             for e in reversed(snap):
                 if filters and not _row_matches_filters(e, filters):
+                    continue
+                if has_window and not _row_matches_time_window(
+                    e, since_ts, until_ts,
+                ):
                     continue
                 return dict(e)
             return None
@@ -627,6 +645,8 @@ class _PaywallEventStore:
         harness: str | None = None,
         source: str | None = None,
         plan_chosen: str | None = None,
+        since: Any = None,
+        until: Any = None,
     ) -> dict | None:
         """Return the single oldest event matching the supplied filters,
         or ``None`` if nothing matches.
@@ -644,6 +664,15 @@ class _PaywallEventStore:
         matches the rest of this module's semantics (aggregations
         reflect what's live, not what's been evicted).
 
+        Optional keyword bounds (``since`` / ``until``) restrict the walk
+        to rows whose ``ts`` falls in the half-open interval
+        ``[since, until)`` (epoch seconds; either bound may be ``None`` =
+        unbounded on that side). Bounds and categorical filters are
+        ``AND`` combined; a bogus bound collapses to "not supplied" via
+        :func:`_coerce_ts_bound`. "First" with a window means "oldest
+        resident row whose ``ts`` is in the window" -- rows evicted from
+        the ring cannot be re-surfaced by a wider window.
+
         Never raises.
         """
         try:
@@ -651,10 +680,16 @@ class _PaywallEventStore:
                 event=event, feature=feature, harness=harness,
                 source=source, plan_chosen=plan_chosen,
             )
+            since_ts, until_ts = _normalise_time_bounds(since, until)
+            has_window = since_ts is not None or until_ts is not None
             with self._lock:
                 snap = list(self._ring)
             for e in snap:
                 if filters and not _row_matches_filters(e, filters):
+                    continue
+                if has_window and not _row_matches_time_window(
+                    e, since_ts, until_ts,
+                ):
                     continue
                 return dict(e)
             return None
@@ -766,6 +801,8 @@ def last_matching(
     harness: str | None = None,
     source: str | None = None,
     plan_chosen: str | None = None,
+    since: Any = None,
+    until: Any = None,
 ) -> dict | None:
     """Public shim for :meth:`_PaywallEventStore.last_matching`.
 
@@ -773,10 +810,15 @@ def last_matching(
     filters, or ``None`` if nothing matches. Scalar counterpart to
     :func:`recent` -- a dashboard tile binding "last paywall CTA click
     for feature X" avoids the one-element-list unwrap this way.
+
+    Optional ``since`` / ``until`` restrict to the half-open
+    ``[since, until)`` epoch-seconds interval, matching the contract of
+    :func:`recent` / :func:`summary` / :func:`count_matching`.
     """
     return _STORE.last_matching(
         event=event, feature=feature, harness=harness,
         source=source, plan_chosen=plan_chosen,
+        since=since, until=until,
     )
 
 
@@ -787,6 +829,8 @@ def first_matching(
     harness: str | None = None,
     source: str | None = None,
     plan_chosen: str | None = None,
+    since: Any = None,
+    until: Any = None,
 ) -> dict | None:
     """Public shim for :meth:`_PaywallEventStore.first_matching`.
 
@@ -794,10 +838,15 @@ def first_matching(
     or ``None`` if nothing matches. Anchored to what the ring currently
     holds -- see :meth:`_PaywallEventStore.first_matching` for the
     eviction contract.
+
+    Optional ``since`` / ``until`` restrict to the half-open
+    ``[since, until)`` epoch-seconds interval, matching the contract of
+    :func:`recent` / :func:`summary` / :func:`count_matching`.
     """
     return _STORE.first_matching(
         event=event, feature=feature, harness=harness,
         source=source, plan_chosen=plan_chosen,
+        since=since, until=until,
     )
 
 

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -7731,21 +7731,36 @@ def api_paywall_events_last():
     ``?harness=`` / ``?source=`` / ``?plan_chosen=``, case-sensitive
     exact match, ``AND`` combined, blank / missing = "not supplied".
 
+    Optional time-window params restrict to rows whose ``ts`` falls in
+    the half-open ``[since, until)`` epoch-seconds interval::
+
+      ?since=<float-epoch-seconds>
+      ?until=<float-epoch-seconds>
+
+    Either bound may be omitted or blank. Bad bounds (non-numeric, NaN,
+    negative) collapse to "not supplied" -- matching the semantics of
+    ``/api/paywall/events/recent`` so a caller can rebind the same
+    window pair without translation.
+
     Body shape::
 
         {
           "event": {"event": "...", "feature": "...", "harness": "...",
                     "source": "...", "plan_chosen": "...", "ts": <float>} | null,
-          "matched": <int>,  # rows matching the filters (0 iff event is null)
+          "matched": <int>,  # rows matching the filters + window (0 iff event is null)
           "in_window": <int>,  # size of the underlying ring right now
-          "filters": {"<key>": "<value>", ...}
+          "filters": {"<key>": "<value>", ...},
+          "time_window": {"since": <float|null>, "until": <float|null>}
+                                                 # echo of resolved bounds
         }
 
     ``matched`` uses the same helper as ``/api/paywall/events/recent`` so
     a UI can render "last of M matches" without a second round-trip.
+    ``time_window`` is always present so the top-level key set stays
+    stable regardless of whether time bounds were supplied.
 
     Ships in GRACE. Never 5xxs -- on any failure returns the neutral
-    ``event=null`` envelope.
+    ``event=null`` envelope (still carrying ``time_window``).
     """
     try:
         from clawmetry import _paywall_events as _pe
@@ -7754,9 +7769,13 @@ def api_paywall_events_last():
             key: request.args.get(key, "") or None
             for key in ("event", "feature", "harness", "source", "plan_chosen")
         }
-        event_row = _pe.last_matching(**filter_kwargs)
-        matched = _pe.count_matching(**filter_kwargs)
-        summary = _pe.summary()
+        window_kwargs = {
+            key: request.args.get(key, "") or None
+            for key in ("since", "until")
+        }
+        event_row = _pe.last_matching(**filter_kwargs, **window_kwargs)
+        matched = _pe.count_matching(**filter_kwargs, **window_kwargs)
+        summary = _pe.summary(**window_kwargs)
         applied_filters = {
             key: value.strip()
             for key, value in filter_kwargs.items()
@@ -7768,6 +7787,9 @@ def api_paywall_events_last():
                 "matched": matched,
                 "in_window": summary.get("in_window", 0),
                 "filters": applied_filters,
+                "time_window": summary.get(
+                    "time_window", {"since": None, "until": None},
+                ),
             }
         )
     except Exception as exc:
@@ -7778,6 +7800,7 @@ def api_paywall_events_last():
                 "matched": 0,
                 "in_window": 0,
                 "filters": {},
+                "time_window": {"since": None, "until": None},
             }
         )
 
@@ -7798,9 +7821,16 @@ def api_paywall_events_first():
     binds this rather than paging the full ring via
     ``/api/paywall/events/recent`` and inspecting the tail.
 
-    Body shape is identical to ``/api/paywall/events/last``. Ships in
-    GRACE. Never 5xxs -- on any failure returns the neutral
-    ``event=null`` envelope.
+    Optional time-window params (``?since=`` / ``?until=``) restrict to
+    rows whose ``ts`` falls in the half-open ``[since, until)`` epoch-
+    seconds interval. With a window supplied, "first" means "oldest
+    resident row in the window" -- rows evicted from the ring cannot be
+    re-surfaced by a wider window. Same coercion contract as
+    ``/api/paywall/events/recent``.
+
+    Body shape is identical to ``/api/paywall/events/last`` and always
+    carries ``time_window``. Ships in GRACE. Never 5xxs -- on any
+    failure returns the neutral ``event=null`` envelope.
     """
     try:
         from clawmetry import _paywall_events as _pe
@@ -7809,9 +7839,13 @@ def api_paywall_events_first():
             key: request.args.get(key, "") or None
             for key in ("event", "feature", "harness", "source", "plan_chosen")
         }
-        event_row = _pe.first_matching(**filter_kwargs)
-        matched = _pe.count_matching(**filter_kwargs)
-        summary = _pe.summary()
+        window_kwargs = {
+            key: request.args.get(key, "") or None
+            for key in ("since", "until")
+        }
+        event_row = _pe.first_matching(**filter_kwargs, **window_kwargs)
+        matched = _pe.count_matching(**filter_kwargs, **window_kwargs)
+        summary = _pe.summary(**window_kwargs)
         applied_filters = {
             key: value.strip()
             for key, value in filter_kwargs.items()
@@ -7823,6 +7857,9 @@ def api_paywall_events_first():
                 "matched": matched,
                 "in_window": summary.get("in_window", 0),
                 "filters": applied_filters,
+                "time_window": summary.get(
+                    "time_window", {"since": None, "until": None},
+                ),
             }
         )
     except Exception as exc:
@@ -7833,6 +7870,7 @@ def api_paywall_events_first():
                 "matched": 0,
                 "in_window": 0,
                 "filters": {},
+                "time_window": {"since": None, "until": None},
             }
         )
 

--- a/tests/test_paywall_events_first_last_api.py
+++ b/tests/test_paywall_events_first_last_api.py
@@ -58,6 +58,7 @@ def test_last_empty_ring_returns_null_envelope(client):
         "matched": 0,
         "in_window": 0,
         "filters": {},
+        "time_window": {"since": None, "until": None},
     }
 
 
@@ -145,6 +146,7 @@ def test_last_never_5xxs_on_broken_store(client, monkeypatch):
         "matched": 0,
         "in_window": 0,
         "filters": {},
+        "time_window": {"since": None, "until": None},
     }
 
 
@@ -158,6 +160,7 @@ def test_first_empty_ring_returns_null_envelope(client):
         "matched": 0,
         "in_window": 0,
         "filters": {},
+        "time_window": {"since": None, "until": None},
     }
 
 
@@ -217,6 +220,7 @@ def test_first_never_5xxs_on_broken_store(client, monkeypatch):
         "matched": 0,
         "in_window": 0,
         "filters": {},
+        "time_window": {"since": None, "until": None},
     }
 
 

--- a/tests/test_paywall_events_first_last_time_window.py
+++ b/tests/test_paywall_events_first_last_time_window.py
@@ -1,0 +1,574 @@
+"""Time-window filter tests for the ``first_matching`` / ``last_matching``
+scalar helpers in :mod:`clawmetry._paywall_events` and their HTTP
+endpoints ``/api/paywall/events/{first,last}``.
+
+Pairs with:
+
+* ``test_paywall_events_first_last_matching.py`` -- store-level
+  categorical filter contract, empty-ring / short-circuit invariants.
+* ``test_paywall_events_first_last_api.py`` -- HTTP shape + never-5xx
+  posture for the two scalar endpoints.
+* ``test_paywall_events_time_window.py`` -- same time-window contract
+  applied to ``recent`` / ``summary`` / ``count_matching``. The tests
+  here extend that contract to the two scalar endpoints so a dashboard
+  tile can rebind the same ``[since, until)`` window pair from
+  ``/api/paywall/events/recent`` to ``/api/paywall/events/last``
+  without translation.
+
+Invariants pinned:
+
+* ``since`` is inclusive, ``until`` is exclusive -- ``[since, until)``.
+* Either bound may be ``None`` / blank -- meaning "unbounded on that side".
+* Bad bounds (non-numeric, NaN, negative epoch, ``bool``) collapse to
+  "not supplied" via :func:`_coerce_ts_bound`, so a stray query string
+  cannot silently drop every row.
+* The window ``AND``-combines with the categorical filters
+  (``event`` / ``feature`` / ``harness`` / ``source`` / ``plan_chosen``).
+* ``matched`` reflects the post-filter, post-window subset size and
+  stays byte-equal to ``count_matching(**filters, **window)``.
+* The response envelope ALWAYS carries ``time_window`` -- with or
+  without bounds supplied, and on the neutral fallback envelope too --
+  so a caller can trust the top-level key set.
+* Endpoints never 5xx.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+from flask import Flask
+
+
+# ── fixtures ────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _fresh_store():
+    from clawmetry import _paywall_events as pe
+
+    pe.reset()
+    yield
+    pe.reset()
+
+
+@pytest.fixture
+def clock(monkeypatch):
+    """Deterministic clock for the store's ``time.time()`` calls.
+
+    Yields a mutable ``{"now": <float>}`` box; the test bumps
+    ``clock["now"]`` between ``record_event`` calls so recorded ``ts``
+    values are predictable, and the window tests can pin exact
+    inclusive / exclusive boundaries.
+    """
+    from clawmetry import _paywall_events as pe
+
+    box = {"now": 1_000_000.0}
+    monkeypatch.setattr(pe.time, "time", lambda: box["now"])
+    return box
+
+
+@pytest.fixture
+def client():
+    from routes.entitlement import bp_entitlement
+    from clawmetry import _paywall_events as pe
+
+    pe.reset()
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    app.config["TESTING"] = True
+    try:
+        yield app.test_client()
+    finally:
+        pe.reset()
+
+
+def _record(pe, clock, ts, payload):
+    clock["now"] = float(ts)
+    pe.record_event(payload)
+
+
+def _post_event(client, **fields):
+    resp = client.post(
+        "/api/paywall/event",
+        data=json.dumps(fields),
+        content_type="application/json",
+    )
+    assert resp.status_code == 204
+
+
+# ── store-level: last_matching ──────────────────────────────────────────────
+
+
+def test_last_matching_since_inclusive_boundary(clock):
+    from clawmetry import _paywall_events as pe
+
+    _record(pe, clock, 100.0, {"event": "e0"})
+    _record(pe, clock, 200.0, {"event": "e1"})
+    _record(pe, clock, 300.0, {"event": "e2"})
+
+    # since=200 is inclusive -> e1 and e2 remain, newest is e2
+    row = pe.last_matching(since=200.0)
+    assert row is not None
+    assert row["event"] == "e2"
+
+    # since=201 excludes e1 -> newest becomes e2
+    row = pe.last_matching(since=201.0)
+    assert row is not None
+    assert row["event"] == "e2"
+
+    # since=301 excludes everything -> None
+    assert pe.last_matching(since=301.0) is None
+
+
+def test_last_matching_until_exclusive_boundary(clock):
+    from clawmetry import _paywall_events as pe
+
+    _record(pe, clock, 100.0, {"event": "e0"})
+    _record(pe, clock, 200.0, {"event": "e1"})
+    _record(pe, clock, 300.0, {"event": "e2"})
+
+    # until=300 excludes e2 -> newest becomes e1
+    row = pe.last_matching(until=300.0)
+    assert row is not None
+    assert row["event"] == "e1"
+
+    # until=300.001 includes e2 -> newest is e2
+    row = pe.last_matching(until=300.001)
+    assert row is not None
+    assert row["event"] == "e2"
+
+    # until=100 excludes everything (e0 lands ON boundary, exclusive)
+    assert pe.last_matching(until=100.0) is None
+
+
+def test_last_matching_since_and_until_and_combine(clock):
+    from clawmetry import _paywall_events as pe
+
+    for ts in (100.0, 200.0, 300.0, 400.0):
+        _record(pe, clock, ts, {"event": f"e{int(ts)}"})
+
+    # [200, 400) -> e200, e300; newest is e300
+    row = pe.last_matching(since=200.0, until=400.0)
+    assert row is not None
+    assert row["event"] == "e300"
+
+
+def test_last_matching_window_and_categorical_filters_and_combine(clock):
+    from clawmetry import _paywall_events as pe
+
+    _record(pe, clock, 100.0, {"event": "paywall_view", "feature": "fleet"})
+    _record(pe, clock, 200.0, {"event": "paywall_cta_click", "feature": "fleet"})
+    _record(pe, clock, 300.0, {"event": "paywall_view", "feature": "self_evolve"})
+    _record(pe, clock, 400.0, {"event": "paywall_view", "feature": "fleet"})
+
+    # event=paywall_view + [150, 350) -> only ts=300 (self_evolve)
+    row = pe.last_matching(event="paywall_view", since=150.0, until=350.0)
+    assert row is not None
+    assert row["feature"] == "self_evolve"
+
+    # event=paywall_view + feature=fleet + [150, 500) -> ts=400
+    row = pe.last_matching(
+        event="paywall_view", feature="fleet", since=150.0, until=500.0,
+    )
+    assert row is not None
+    assert row["ts"] == 400.0
+
+
+def test_last_matching_bad_bounds_collapse_to_unbounded(clock):
+    from clawmetry import _paywall_events as pe
+
+    _record(pe, clock, 100.0, {"event": "e0"})
+    _record(pe, clock, 200.0, {"event": "e1"})
+
+    # Every "bad" bound collapses; last_matching returns the newest row.
+    for since_bad in (None, "", "   ", "junk", -1, -0.5, "nan", True, False):
+        for until_bad in (None, "", "   ", "junk", "nan", True, False):
+            row = pe.last_matching(since=since_bad, until=until_bad)
+            assert row is not None
+            assert row["event"] == "e1", (since_bad, until_bad)
+
+
+def test_last_matching_empty_window_returns_none(clock):
+    from clawmetry import _paywall_events as pe
+
+    _record(pe, clock, 100.0, {"event": "e0"})
+    # since >= until -> empty window by construction.
+    assert pe.last_matching(since=200.0, until=200.0) is None
+    assert pe.last_matching(since=500.0, until=100.0) is None
+
+
+def test_last_matching_numeric_string_bounds_accepted(clock):
+    from clawmetry import _paywall_events as pe
+
+    _record(pe, clock, 100.0, {"event": "e0"})
+    _record(pe, clock, 200.0, {"event": "e1"})
+
+    row = pe.last_matching(since="150", until="500")
+    assert row is not None
+    assert row["event"] == "e1"
+
+
+# ── store-level: first_matching ─────────────────────────────────────────────
+
+
+def test_first_matching_since_inclusive_boundary(clock):
+    from clawmetry import _paywall_events as pe
+
+    _record(pe, clock, 100.0, {"event": "e0"})
+    _record(pe, clock, 200.0, {"event": "e1"})
+    _record(pe, clock, 300.0, {"event": "e2"})
+
+    # since=200 -> e1, e2; oldest is e1
+    row = pe.first_matching(since=200.0)
+    assert row is not None
+    assert row["event"] == "e1"
+
+    # since=201 -> e2 only; oldest is e2
+    row = pe.first_matching(since=201.0)
+    assert row is not None
+    assert row["event"] == "e2"
+
+
+def test_first_matching_until_exclusive_boundary(clock):
+    from clawmetry import _paywall_events as pe
+
+    _record(pe, clock, 100.0, {"event": "e0"})
+    _record(pe, clock, 200.0, {"event": "e1"})
+    _record(pe, clock, 300.0, {"event": "e2"})
+
+    # until=200 excludes e1 -> oldest is e0
+    row = pe.first_matching(until=200.0)
+    assert row is not None
+    assert row["event"] == "e0"
+
+    # until=100.5 includes e0 -> oldest is e0
+    row = pe.first_matching(until=100.5)
+    assert row is not None
+    assert row["event"] == "e0"
+
+    # until=100 excludes e0 (boundary is exclusive) -> None
+    assert pe.first_matching(until=100.0) is None
+
+
+def test_first_matching_window_and_categorical_filters_and_combine(clock):
+    from clawmetry import _paywall_events as pe
+
+    _record(pe, clock, 100.0, {"event": "paywall_view", "feature": "fleet"})
+    _record(pe, clock, 200.0, {"event": "paywall_cta_click", "feature": "fleet"})
+    _record(pe, clock, 300.0, {"event": "paywall_view", "feature": "self_evolve"})
+    _record(pe, clock, 400.0, {"event": "paywall_view", "feature": "fleet"})
+
+    # event=paywall_view + [150, 500) -> ts=300, 400; oldest is 300 (self_evolve)
+    row = pe.first_matching(event="paywall_view", since=150.0, until=500.0)
+    assert row is not None
+    assert row["ts"] == 300.0
+    assert row["feature"] == "self_evolve"
+
+    # event=paywall_view + feature=fleet + [150, 500) -> ts=400 only
+    row = pe.first_matching(
+        event="paywall_view", feature="fleet", since=150.0, until=500.0,
+    )
+    assert row is not None
+    assert row["ts"] == 400.0
+
+
+def test_first_matching_bad_bounds_collapse_to_unbounded(clock):
+    from clawmetry import _paywall_events as pe
+
+    _record(pe, clock, 100.0, {"event": "e0"})
+    _record(pe, clock, 200.0, {"event": "e1"})
+
+    for since_bad in (None, "", "   ", "junk", -1, "nan", True, False):
+        for until_bad in (None, "", "   ", "junk", "nan", True, False):
+            row = pe.first_matching(since=since_bad, until=until_bad)
+            assert row is not None
+            assert row["event"] == "e0", (since_bad, until_bad)
+
+
+def test_first_matching_empty_window_returns_none(clock):
+    from clawmetry import _paywall_events as pe
+
+    _record(pe, clock, 100.0, {"event": "e0"})
+    assert pe.first_matching(since=200.0, until=200.0) is None
+    assert pe.first_matching(since=500.0, until=100.0) is None
+
+
+# ── store-level: agreement with recent / count_matching ─────────────────────
+
+
+def test_last_matching_with_window_agrees_with_recent_limit_one(clock):
+    from clawmetry import _paywall_events as pe
+
+    for ts in (100.0, 200.0, 300.0, 400.0):
+        _record(pe, clock, ts, {"event": f"e{int(ts)}", "feature": "fleet"})
+
+    # Both should look at the same [200, 400) window and pick the newest.
+    row = pe.last_matching(since=200.0, until=400.0)
+    recent = pe.recent(1, since=200.0, until=400.0)
+    assert recent and row == recent[0]
+
+
+def test_first_matching_with_window_agrees_with_recent_tail(clock):
+    from clawmetry import _paywall_events as pe
+
+    for ts in (100.0, 200.0, 300.0, 400.0):
+        _record(pe, clock, ts, {"event": f"e{int(ts)}", "feature": "fleet"})
+
+    # recent is newest-first; the tail is the oldest.
+    recent = pe.recent(200, since=200.0, until=400.0)
+    row = pe.first_matching(since=200.0, until=400.0)
+    assert recent
+    assert row == recent[-1]
+
+
+def test_scalar_matched_equals_count_matching_with_window(clock):
+    """A dashboard tile computing ``matched`` off ``count_matching`` must
+    stay in lock-step with what ``first_matching`` / ``last_matching``
+    walk over."""
+    from clawmetry import _paywall_events as pe
+
+    _record(pe, clock, 100.0, {"event": "paywall_view", "feature": "fleet"})
+    _record(pe, clock, 200.0, {"event": "paywall_cta_click", "feature": "fleet"})
+    _record(pe, clock, 300.0, {"event": "paywall_view", "feature": "self_evolve"})
+    _record(pe, clock, 400.0, {"event": "paywall_view", "feature": "fleet"})
+
+    kwargs = dict(event="paywall_view", since=150.0, until=500.0)
+    count = pe.count_matching(**kwargs)
+    row = pe.last_matching(**kwargs)
+    assert count == 2
+    assert row is not None
+    # If count > 0, both scalar helpers must find a row.
+    assert pe.first_matching(**kwargs) is not None
+
+
+# ── HTTP contract: /api/paywall/events/last ─────────────────────────────────
+
+
+def test_last_endpoint_always_carries_time_window(client):
+    """Even with no bounds and an empty ring, ``time_window`` is present."""
+    body = client.get("/api/paywall/events/last").get_json()
+    assert body["time_window"] == {"since": None, "until": None}
+
+
+def test_last_endpoint_echoes_resolved_bounds(client):
+    _post_event(client, event="paywall_view", feature="fleet")
+    body = client.get(
+        "/api/paywall/events/last?since=100&until=99999999999",
+    ).get_json()
+    assert body["time_window"] == {"since": 100.0, "until": 99999999999.0}
+
+
+def test_last_endpoint_bad_bounds_collapse_and_reflect(client):
+    _post_event(client, event="paywall_view", feature="fleet")
+    body = client.get(
+        "/api/paywall/events/last?since=junk&until=nan",
+    ).get_json()
+    # Bad bounds collapse; both echo as null.
+    assert body["time_window"] == {"since": None, "until": None}
+    # Event is still returned (window collapsed to unbounded).
+    assert body["event"] is not None
+    assert body["matched"] == 1
+
+
+def test_last_endpoint_window_narrows_matched(client, clock):
+    """Bounds must actually filter -- exercising both the store and the
+    HTTP glue in one shot."""
+    from clawmetry import _paywall_events as pe
+
+    _record(pe, clock, 100.0, {"event": "paywall_view", "feature": "fleet"})
+    _record(pe, clock, 200.0, {"event": "paywall_view", "feature": "fleet"})
+    _record(pe, clock, 300.0, {"event": "paywall_view", "feature": "fleet"})
+
+    body = client.get(
+        "/api/paywall/events/last?since=150&until=250",
+    ).get_json()
+    assert body["matched"] == 1
+    assert body["event"] is not None
+    assert body["event"]["ts"] == 200.0
+    # in_window is process-lifetime ring size, NOT window-filtered.
+    assert body["in_window"] == 3
+
+
+def test_last_endpoint_window_and_categorical_filter_and_combine(client, clock):
+    from clawmetry import _paywall_events as pe
+
+    _record(pe, clock, 100.0, {"event": "paywall_view", "feature": "fleet"})
+    _record(pe, clock, 200.0, {"event": "paywall_cta_click", "feature": "fleet"})
+    _record(pe, clock, 300.0, {"event": "paywall_view", "feature": "self_evolve"})
+    _record(pe, clock, 400.0, {"event": "paywall_view", "feature": "fleet"})
+
+    body = client.get(
+        "/api/paywall/events/last"
+        "?event=paywall_view&feature=fleet&since=150&until=500",
+    ).get_json()
+    assert body["event"] is not None
+    assert body["event"]["ts"] == 400.0
+    assert body["matched"] == 1
+    assert body["filters"] == {"event": "paywall_view", "feature": "fleet"}
+    assert body["time_window"] == {"since": 150.0, "until": 500.0}
+
+
+def test_last_endpoint_empty_window_returns_null(client, clock):
+    from clawmetry import _paywall_events as pe
+
+    _record(pe, clock, 100.0, {"event": "paywall_view", "feature": "fleet"})
+
+    body = client.get(
+        "/api/paywall/events/last?since=200&until=200",
+    ).get_json()
+    assert body["event"] is None
+    assert body["matched"] == 0
+    assert body["in_window"] == 1
+    assert body["time_window"] == {"since": 200.0, "until": 200.0}
+
+
+def test_last_endpoint_blank_bounds_are_not_supplied(client):
+    _post_event(client, event="paywall_view", feature="fleet")
+    body = client.get(
+        "/api/paywall/events/last?since=&until=",
+    ).get_json()
+    assert body["event"] is not None
+    assert body["time_window"] == {"since": None, "until": None}
+
+
+def test_last_endpoint_never_5xxs_with_window(client, monkeypatch):
+    from clawmetry import _paywall_events as pe
+
+    def _boom(**kwargs):
+        raise RuntimeError("simulated store outage")
+
+    monkeypatch.setattr(pe, "last_matching", _boom)
+    resp = client.get("/api/paywall/events/last?since=100&until=200")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    # Neutral fallback envelope still carries time_window.
+    assert body == {
+        "event": None,
+        "matched": 0,
+        "in_window": 0,
+        "filters": {},
+        "time_window": {"since": None, "until": None},
+    }
+
+
+# ── HTTP contract: /api/paywall/events/first ────────────────────────────────
+
+
+def test_first_endpoint_always_carries_time_window(client):
+    body = client.get("/api/paywall/events/first").get_json()
+    assert body["time_window"] == {"since": None, "until": None}
+
+
+def test_first_endpoint_echoes_resolved_bounds(client):
+    _post_event(client, event="paywall_view", feature="fleet")
+    body = client.get(
+        "/api/paywall/events/first?since=100&until=99999999999",
+    ).get_json()
+    assert body["time_window"] == {"since": 100.0, "until": 99999999999.0}
+
+
+def test_first_endpoint_window_narrows_matched(client, clock):
+    from clawmetry import _paywall_events as pe
+
+    _record(pe, clock, 100.0, {"event": "paywall_view", "feature": "fleet"})
+    _record(pe, clock, 200.0, {"event": "paywall_view", "feature": "fleet"})
+    _record(pe, clock, 300.0, {"event": "paywall_view", "feature": "fleet"})
+
+    body = client.get(
+        "/api/paywall/events/first?since=150&until=350",
+    ).get_json()
+    # [150, 350) -> ts=200 and ts=300 remain; oldest is 200.
+    assert body["event"] is not None
+    assert body["event"]["ts"] == 200.0
+    assert body["matched"] == 2
+    assert body["in_window"] == 3
+
+
+def test_first_endpoint_window_and_categorical_filter_and_combine(client, clock):
+    from clawmetry import _paywall_events as pe
+
+    _record(pe, clock, 100.0, {"event": "paywall_view", "feature": "fleet"})
+    _record(pe, clock, 200.0, {"event": "paywall_cta_click", "feature": "fleet"})
+    _record(pe, clock, 300.0, {"event": "paywall_view", "feature": "self_evolve"})
+    _record(pe, clock, 400.0, {"event": "paywall_view", "feature": "fleet"})
+
+    body = client.get(
+        "/api/paywall/events/first"
+        "?event=paywall_view&since=150&until=500",
+    ).get_json()
+    # event=paywall_view in [150, 500) -> ts=300 (self_evolve), 400 (fleet).
+    # first = ts=300.
+    assert body["event"] is not None
+    assert body["event"]["ts"] == 300.0
+    assert body["event"]["feature"] == "self_evolve"
+    assert body["matched"] == 2
+    assert body["filters"] == {"event": "paywall_view"}
+    assert body["time_window"] == {"since": 150.0, "until": 500.0}
+
+
+def test_first_endpoint_empty_window_returns_null(client, clock):
+    from clawmetry import _paywall_events as pe
+
+    _record(pe, clock, 100.0, {"event": "paywall_view", "feature": "fleet"})
+
+    body = client.get(
+        "/api/paywall/events/first?since=200&until=200",
+    ).get_json()
+    assert body["event"] is None
+    assert body["matched"] == 0
+    assert body["in_window"] == 1
+    assert body["time_window"] == {"since": 200.0, "until": 200.0}
+
+
+def test_first_endpoint_never_5xxs_with_window(client, monkeypatch):
+    from clawmetry import _paywall_events as pe
+
+    def _boom(**kwargs):
+        raise RuntimeError("simulated store outage")
+
+    monkeypatch.setattr(pe, "first_matching", _boom)
+    resp = client.get("/api/paywall/events/first?since=100&until=200")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body == {
+        "event": None,
+        "matched": 0,
+        "in_window": 0,
+        "filters": {},
+        "time_window": {"since": None, "until": None},
+    }
+
+
+# ── cross-endpoint agreement ────────────────────────────────────────────────
+
+
+def test_last_endpoint_agrees_with_recent_limit_one_with_window(client, clock):
+    """``/api/paywall/events/last`` is the scalar unwrap of
+    ``/api/paywall/events/recent?limit=1`` -- for any given window pair
+    the two must return the same top row."""
+    from clawmetry import _paywall_events as pe
+
+    for ts in (100.0, 200.0, 300.0, 400.0):
+        _record(pe, clock, ts, {"event": f"e{int(ts)}", "feature": "fleet"})
+
+    q = "since=150&until=350"
+    last = client.get(f"/api/paywall/events/last?{q}").get_json()
+    recent = client.get(f"/api/paywall/events/recent?limit=1&{q}").get_json()
+    assert recent["events"], "expected at least one match in the window"
+    assert last["event"] == recent["events"][0]
+    # time_window echo must match byte-for-byte between the two endpoints.
+    assert last["time_window"] == recent["time_window"]
+
+
+def test_first_endpoint_agrees_with_recent_tail_with_window(client, clock):
+    from clawmetry import _paywall_events as pe
+
+    for ts in (100.0, 200.0, 300.0, 400.0):
+        _record(pe, clock, ts, {"event": f"e{int(ts)}", "feature": "fleet"})
+
+    q = "since=150&until=350"
+    first = client.get(f"/api/paywall/events/first?{q}").get_json()
+    recent = client.get(f"/api/paywall/events/recent?limit=200&{q}").get_json()
+    assert recent["events"]
+    assert first["event"] == recent["events"][-1]
+    assert first["time_window"] == recent["time_window"]


### PR DESCRIPTION
## Summary

- Extends the scalar `first_matching` / `last_matching` helpers -- and the two `/api/paywall/events/{first,last}` endpoints -- to accept the same `since` / `until` epoch-seconds bounds that `recent` / `summary` / `count_matching` already take (added in [8f5ed90](https://github.com/vivekchand/clawmetry/commit/8f5ed90)). A dashboard tile that wanted to bind one `[since, until)` window pair across the four `/api/paywall/events/*` read endpoints previously had to fake it by calling `/recent?limit=1&since=...` and unwrapping the one-element list -- exactly the ergonomics the scalar helpers exist to remove.
- Semantics byte-identical to the existing `_recent` / `_summary` window contract: half-open `[since, until)`, inclusive-since, exclusive-until; either bound may be null / blank = unbounded on that side; `AND`-combined with the categorical filters; bad bounds (non-numeric / NaN / negative / bool) collapse to "not supplied" via `_coerce_ts_bound` so a stray query string cannot silently drop every row.
- "First" with a window means "oldest resident row in the window" — rows evicted from the ring cannot be re-surfaced by a wider window. Same "aggregations reflect what's live, not what's been evicted" contract as the rest of the module.
- Response envelope now always carries `time_window: {since, until}` -- with or without bounds supplied, on the neutral fallback envelope, and byte-equal to the `/api/paywall/events/recent` echo so a caller can trust the top-level key set is stable. Matches how `/recent` and `/summary` were extended.

### Zero behaviour change

Purely additive: `since` / `until` default to `None`, matching the pre-PR walk. New `time_window` key is additive to the envelope. Grace/enforce untouched. No `__version__` bump, no `[RELEASE]` tag, no new endpoint.

## What changed

- **`clawmetry/_paywall_events.py`**
  - `_PaywallEventStore.{first,last}_matching`: new `since` / `until` kwargs wired through `_normalise_time_bounds` + `_row_matches_time_window`; short-circuit walk semantics preserved.
  - Module-level `first_matching` / `last_matching` shims pass the pair through.
- **`routes/entitlement.py`**
  - `/api/paywall/events/last` / `/first`: parse `since` / `until` query args, pass them to `last_matching` / `first_matching` / `count_matching`, echo the resolved `time_window` from `summary(**window_kwargs)`. Neutral fallback envelope also carries `time_window`.
- **`tests/test_paywall_events_first_last_api.py`**
  - Empty-ring + broken-store envelope assertions updated for the new `time_window` key.
- **`tests/test_paywall_events_first_last_time_window.py`** (new, 33 tests)
  - Store-level: boundary inclusivity (since inclusive / until exclusive), `AND` with categorical filters, bad-bound collapse (`None`, `""`, `"junk"`, `"nan"`, negative, `bool`), empty window (`since >= until`), numeric-string bounds, agreement with `recent(1)` / `recent(200)[-1]` / `count_matching`.
  - HTTP: `time_window` always present, resolved bounds echoed, bad-bound collapse, window narrowing `matched`, `in_window` reflects ring not filter, empty window returns `null`, never-5xx with bounds (neutral envelope carries `time_window`), cross-endpoint agreement with `/api/paywall/events/recent` for the same window.

## Test plan

- [x] `python3 -m py_compile clawmetry/_paywall_events.py routes/entitlement.py tests/test_paywall_events_first_last_api.py tests/test_paywall_events_first_last_time_window.py` — OK
- [x] `python3 -m pytest tests/test_paywall_events_first_last_time_window.py tests/test_paywall_events_first_last_api.py tests/test_paywall_events_first_last_matching.py -q` — **67 passed**
- [x] Full paywall-events regression sweep: `tests/test_paywall_events_store.py tests/test_paywall_events_api.py tests/test_paywall_events_recent_filters.py tests/test_paywall_events_summary_filters.py tests/test_paywall_events_time_window.py tests/test_paywall_events_first_last_matching.py tests/test_paywall_events_first_last_api.py tests/test_paywall_events_first_last_time_window.py tests/test_paywall_event_api.py` — **209 passed**
- [ ] CI green on this branch
- [ ] Local operator verification (below) — draft PR waits on the operator to flip ready-for-review

## Local operator verification checklist

The scheduled routine cannot reach the running daemon / live cloud snapshot / browser; the operator drives:

- [ ] `git fetch origin feat/paywall-events-first-last-time-window && git checkout feat/paywall-events-first-last-time-window`
- [ ] Copy the two changed source files into the daemon's site-packages:
  ```sh
  cp clawmetry/_paywall_events.py ~/.clawmetry/lib/python*/site-packages/clawmetry/
  cp routes/entitlement.py        ~/.clawmetry/lib/python*/site-packages/routes/
  find ~/.clawmetry/lib/python*/site-packages/clawmetry/__pycache__ -delete 2>/dev/null || true
  find ~/.clawmetry/lib/python*/site-packages/routes/__pycache__    -delete 2>/dev/null || true
  ```
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
- [ ] Confirm both endpoints now carry `time_window` even with no bounds:
  ```sh
  curl -s http://localhost:8900/api/paywall/events/last  | python -m json.tool
  curl -s http://localhost:8900/api/paywall/events/first | python -m json.tool
  ```
  Expect: `time_window: {"since": null, "until": null}` in every response.
- [ ] Fire two beacons then constrain the window and confirm `matched` narrows:
  ```sh
  curl -s -X POST http://localhost:8900/api/paywall/event -H 'content-type: application/json' -d '{"event":"paywall_view","feature":"fleet"}'
  # ...wait a few seconds...
  curl -s -X POST http://localhost:8900/api/paywall/event -H 'content-type: application/json' -d '{"event":"paywall_view","feature":"fleet"}'
  # Pick a bound in the middle of the two beacon timestamps:
  curl -s "http://localhost:8900/api/paywall/events/last?since=$(python -c 'import time; print(int(time.time())-5)')" | python -m json.tool
  ```
  Expect: only the newer beacon; `matched: 1`; `time_window.since` echoed.
- [ ] Sanity: bad bounds collapse. `curl -s 'http://localhost:8900/api/paywall/events/last?since=junk&until=nan'` should return `time_window: {"since": null, "until": null}` and still include the newest beacon.
- [ ] Cross-endpoint agreement: for any `?since=X&until=Y`, `/events/last` should equal `/events/recent?limit=1&since=X&until=Y`'s first row.
- [ ] Decrypt the live cloud snapshot in the browser and confirm nothing else moved (additive change only — no existing endpoint's default response contract shrunk).
- [ ] If all boxes are green, flip the PR from draft → ready-for-review and merge.

**Do not merge from an automated firing.** This PR is intentionally left as draft; the local operator owns the ready-for-review flip.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KTCJWoYFjstu6o5vacefyW)_