### PR TITLE
e2e(c4): add job-summary fidelity report to cross-repo-handoff

### DIFF
--- a/.github/workflows/cross-repo-handoff.yml
+++ b/.github/workflows/cross-repo-handoff.yml
@@ -109,6 +109,42 @@ jobs:
             -v --tb=short \
             --junitxml=/tmp/junit-c4-${{ github.run_id }}.xml
 
+      # Post a Markdown fidelity table to the Actions job summary so every
+      # PR reviewer can see at a glance whether C4 ran with real apps or
+      # inline stubs. In stub mode a one-liner call-to-action links to the
+      # tracking issue so the gap is visible without digging into logs.
+      # Tracking: vivekchand/clawmetry#4036 (C4)
+      - name: Write C4 fidelity summary
+        if: always()
+        run: |
+          {
+            echo "## C4 Cross-Repo Handoff: Fidelity Report"
+            echo ""
+            if [ "${{ steps.access.outputs.available }}" = "true" ]; then
+              echo "**Mode: REAL APPS** -- CLOUD_REPO_PAT configured"
+              echo ""
+              echo "| Tier | What was tested |"
+              echo "|------|-----------------|"
+              echo "| T1 | Real clawmetry-landing (run_landing.py) |"
+              echo "| T2 | Real clawmetry-cloud (run_cloud.py) |"
+              echo "| T3 | Real DaemonSim from cloud checkout |"
+              echo "| T4 | Real DaemonSim + AES-256-GCM cache_push |"
+            else
+              echo "**Mode: STUB** -- CLOUD_REPO_PAT not set (fork PR or secret not configured)"
+              echo ""
+              echo "| Tier | What was tested | Full-fidelity equivalent |"
+              echo "|------|-----------------|-------------------------|"
+              echo "| T1 | Inline landing stub | Real app via run_landing.py |"
+              echo "| T2 | Inline cloud stub | Real app via run_cloud.py |"
+              echo "| T3 | InlineDaemonSim | Real DaemonSim from cloud checkout |"
+              echo "| T4 | InlineDaemonSim + cache_push | Real DaemonSim + AES-256-GCM payload |"
+              echo ""
+              echo "> **To upgrade C4 to real-apps mode:** set the \`CLOUD_REPO_PAT\` repository"
+              echo "> secret (Contents read on clawmetry-cloud + clawmetry-landing)."
+              echo "> See [tracking issue #4036](https://github.com/vivekchand/clawmetry/issues/4036)."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Upload JUnit results
         if: always() && steps.access.outputs.available == 'true'
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
## Summary

Adds a Markdown fidelity report to the C4 cross-repo-handoff job summary so every PR run makes the stub vs. real-apps gap visible in the Actions UI.

**Gap closed:** C4 runs in stub mode when `CLOUD_REPO_PAT` is absent (fork PRs, unconfigured repos). Previously this was silent -- the job passed but no one could tell it was testing inline stubs rather than the real landing/cloud apps. Now every run posts a table to the job summary.

## Files changed

- `.github/workflows/cross-repo-handoff.yml` -- new "Write C4 fidelity summary" step after "Run C4 cross-repo handoff"

## What the summary looks like

**Stub mode (no CLOUD_REPO_PAT):**

| Tier | What was tested | Full-fidelity equivalent |
|------|-----------------|-------------------------|
| T1 | Inline landing stub | Real app via run_landing.py |
| T2 | Inline cloud stub | Real app via run_cloud.py |
| T3 | InlineDaemonSim | Real DaemonSim from cloud checkout |
| T4 | InlineDaemonSim + cache_push | Real DaemonSim + AES-256-GCM payload |

Stub mode also renders a call-to-action linking to #4036 with instructions to set `CLOUD_REPO_PAT`.

**Real-apps mode (CLOUD_REPO_PAT configured):**

| Tier | What was tested |
|------|-----------------| 
| T1 | Real clawmetry-landing (run_landing.py) |
| T2 | Real clawmetry-cloud (run_cloud.py) |
| T3 | Real DaemonSim from cloud checkout |
| T4 | Real DaemonSim + AES-256-GCM cache_push |

## Acceptance test

Open any PR, check Actions > Cross-repo handoff (C4) > Summary tab -- the fidelity table must be present regardless of PAT availability.

## Remaining admin actions to reach full green

- **C6 (required status checks):** run `bash scripts/close-c6.sh` (~30 seconds, needs repo admin)
- **C4 real-apps mode:** set `CLOUD_REPO_PAT` secret (Contents read on clawmetry-cloud + clawmetry-landing)

Tracking: #4036

---
_Generated by [Claude Code](https://claude.ai/code/session_01JyMR7FEjqxZJQyFPApZuvx)_