### PR TITLE
feat(status): license block in `clawmetry status --json`

### DIFF
--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -2032,6 +2032,23 @@ def _status_snapshot(args) -> dict:
       on import. Shape: ``{"discovered": [{"name", "value", "importable",
       "error"}], "importable_count": int, "broken_count": int}``. Empty
       ``discovered`` on installs with no plugins registered.
+    * ``license``: state of the self-hosted Pro/Enterprise license key at
+      ``~/.clawmetry/license.key`` — the same envelope
+      ``clawmetry license status --json`` emits, folded into the composite
+      snapshot so an operator can answer *"is my node on Pro?"* in one
+      command. Shape:
+      ``{"installed": bool, "valid": bool, "status": str,
+        "tier": str | null, "nodes": int | null, "sub": str | null,
+        "days_left": int | null,
+        "pubkey_fingerprint_sha256": str | null,
+        "permissions_safe": bool | null, "file_mode": str | null}``.
+      ``installed`` distinguishes *no license file yet* (status ``"none"``,
+      all other fields ``null``) from *file present but broken* (status
+      ``"invalid"`` / ``"expired"``). Complements
+      ``runtimes.plan`` (cloud entitlement mirror) and
+      ``extensions.discovered`` (whether the paid wheel imports): the
+      three together triage every "why isn't Pro on this box?" question
+      without a second command.
 
     Best-effort throughout: every helper is wrapped so a broken corner (e.g.
     an unreadable config file, an unavailable network) degrades to ``null``
@@ -2062,6 +2079,18 @@ def _status_snapshot(args) -> dict:
             "discovered": [],
             "importable_count": 0,
             "broken_count": 0,
+        },
+        "license": {
+            "installed": False,
+            "valid": False,
+            "status": "none",
+            "tier": None,
+            "nodes": None,
+            "sub": None,
+            "days_left": None,
+            "pubkey_fingerprint_sha256": None,
+            "permissions_safe": None,
+            "file_mode": None,
         },
     }
 
@@ -2236,6 +2265,43 @@ def _status_snapshot(args) -> dict:
             "importable_count": sum(1 for r in rows if r.get("importable")),
             "broken_count": sum(1 for r in rows if not r.get("importable")),
         }
+    except Exception:
+        pass
+
+    # License — self-hosted Pro/Enterprise key at ``~/.clawmetry/license.key``.
+    # Sibling of the ``extensions`` block above: extensions answer "would the
+    # paid wheel import?", this block answers "is a valid signed key on
+    # disk?". The two orthogonally cover the two failure modes an operator
+    # hits when Pro doesn't turn on — a broken wheel install vs. a
+    # missing / expired / tampered license file — so folding both into
+    # ``status --json`` collapses "why isn't Pro on this box?" from a
+    # multi-command dance to one jq pipeline. ``current_license_info``
+    # returns ``None`` when no file is on disk (fresh install / OSS mode)
+    # and a fully-populated dict on every file-exists branch (active /
+    # expired / signature-invalid). Never raises — a broken corner keeps
+    # the default ``status: "none"`` shape.
+    try:
+        from clawmetry.license import current_license_info as _license_info
+        info = _license_info()
+        if info is None:
+            # File not on disk yet — leave the default ``installed=False``
+            # / ``status="none"`` shape from ``snap`` initialisation intact
+            # so a script never sees ``null`` on a field it does not need
+            # to special-case.
+            pass
+        else:
+            snap["license"] = {
+                "installed": True,
+                "valid": bool(info.get("valid")),
+                "status": str(info.get("status") or "unknown"),
+                "tier": info.get("tier"),
+                "nodes": info.get("nodes"),
+                "sub": info.get("sub"),
+                "days_left": info.get("days_left"),
+                "pubkey_fingerprint_sha256": info.get("pubkey_fingerprint_sha256"),
+                "permissions_safe": info.get("permissions_safe"),
+                "file_mode": info.get("file_mode"),
+            }
     except Exception:
         pass
 
@@ -2416,6 +2482,28 @@ def _cmd_status(args) -> None:
                     print(f"    ❌ {_name}  — {_err}")
             if _bad:
                 print(f"    → {_bad} plugin(s) will NOT load on daemon start; {_ok} will.")
+    except Exception:
+        pass
+
+    # License — one-line summary when a self-hosted key is on disk. Silent
+    # when there is no key file (fresh OSS install), matching the extensions
+    # block's silence-on-empty policy so the human snapshot doesn't grow a
+    # section that carries no information for the default operator. Points
+    # to ``clawmetry license`` for the full envelope; this line is a triage
+    # hint, not a replacement.
+    try:
+        from clawmetry.license import current_license_info as _lic_info
+        _lic = _lic_info()
+        if _lic is not None:
+            print()
+            if _lic.get("valid"):
+                _tier = str(_lic.get("tier") or "pro").capitalize()
+                _days = _lic.get("days_left")
+                _days_txt = f", expires in {_days}d" if isinstance(_days, int) else ""
+                print(f"  License:     ✅ {_tier} (self-hosted{_days_txt})")
+            else:
+                _status = str(_lic.get("status") or "invalid")
+                print(f"  License:     ⚠️  {_status}  (run `clawmetry license` for details)")
     except Exception:
         pass
 

--- a/tests/test_cli_status_license.py
+++ b/tests/test_cli_status_license.py
@@ -1,0 +1,321 @@
+"""Tests for the ``license`` block in ``clawmetry status --json``.
+
+Sibling of ``test_cli_status_extensions.py``: this suite pins the newly-added
+``license`` field carrying the output of
+:func:`clawmetry.license.current_license_info`, so operators (and wrapper
+scripts) can tell from a fresh CLI process whether the self-hosted Pro /
+Enterprise license key at ``~/.clawmetry/license.key`` is present, valid,
+expired, or malformed — without needing a second ``clawmetry license --json``
+call.
+
+The block complements the two neighbouring diagnostics that already exist:
+
+* ``runtimes.pro_installed_version`` — is the paid wheel on disk?
+* ``extensions.discovered``           — does the paid wheel actually import?
+* ``license``                        — is a valid signed key on disk?
+
+Together they cover every failure mode an operator hits when Pro doesn't
+turn on.
+
+Every test is hermetic: an ephemeral Ed25519 keypair replaces the embedded
+production public key, and ``LICENSE_PATH`` is repointed into ``tmp_path`` so
+a developer's real key file is never read or written.
+"""
+from __future__ import annotations
+
+import json
+import time
+from types import SimpleNamespace
+
+import pytest
+
+
+def _keypair():
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+    priv = Ed25519PrivateKey.generate()
+    pub_pem = priv.public_key().public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    return priv, pub_pem
+
+
+def _payload(tier="pro", nodes=5, sub="acct_test", exp_delta=365 * 86400):
+    now = int(time.time())
+    return {
+        "sub": sub,
+        "tier": tier,
+        "nodes": nodes,
+        "iat": now,
+        "exp": now + exp_delta,
+    }
+
+
+def _ns(**overrides):
+    ns = SimpleNamespace(live=False, show_key=False, as_json=True, cmd="status")
+    for k, v in overrides.items():
+        setattr(ns, k, v)
+    return ns
+
+
+@pytest.fixture
+def stub_home(monkeypatch, tmp_path):
+    """Same isolation harness ``test_cli_status_json.py`` uses, plus an
+    ephemeral Ed25519 keypair for the license module so nothing under test
+    depends on the real production signing key or on the operator's home."""
+    import clawmetry.sync as _sync
+    import clawmetry.cli as cli
+    import clawmetry.extensions as ext
+    import clawmetry.license as _lic
+
+    monkeypatch.setattr(_sync, "CONFIG_FILE", tmp_path / "config.json")
+    monkeypatch.setattr(_sync, "STATE_FILE", tmp_path / "sync-state.json")
+    monkeypatch.setattr(_sync, "LOG_FILE", tmp_path / "sync.log")
+
+    plan_path = tmp_path / "cloud_plan.json"
+
+    import os as _os
+    import os.path as _op
+    real_expanduser = _op.expanduser
+
+    def _fake_expand(p):
+        if p == "~/.clawmetry/cloud_plan.json":
+            return str(plan_path)
+        return real_expanduser(p)
+
+    monkeypatch.setattr(_op, "expanduser", _fake_expand)
+    monkeypatch.setattr(_os.path, "expanduser", _fake_expand)
+
+    monkeypatch.setattr(cli, "_resolve_account_email", lambda _k: (None, None))
+    monkeypatch.setattr(cli, "_is_sync_running", lambda: False)
+
+    import platform as _platform
+    monkeypatch.setattr(_platform, "system", lambda: "Linux")
+
+    monkeypatch.setattr(
+        "clawmetry.sync._detect_family_runtimes", lambda: [], raising=False,
+    )
+    monkeypatch.setattr(
+        "clawmetry.license._pro_installed_version", lambda: None, raising=False,
+    )
+
+    # Ephemeral trust anchor + on-disk key path so no test can leak into
+    # ``~/.clawmetry/license.key`` on the developer's machine.
+    priv, pub_pem = _keypair()
+    monkeypatch.setattr(_lic, "_PUBLIC_KEY_PEM", pub_pem)
+    monkeypatch.setattr(_lic, "LICENSE_PATH", str(tmp_path / "license.key"))
+
+    # Reset the extension-loader mirrors so an adjacent suite that populated
+    # them cannot leak state into a probe run under this fixture.
+    ext._loaded = False
+    with ext._lock:
+        ext._loaded_plugins.clear()
+        ext._failed_plugins.clear()
+
+    return SimpleNamespace(tmp=tmp_path, plan_path=plan_path, priv=priv)
+
+
+def _run_and_parse(capsys, args):
+    import clawmetry.cli as cli
+    cli._cmd_status(args)
+    out = capsys.readouterr().out
+    return json.loads(out)
+
+
+def _write_license(stub_home, **overrides):
+    """Mint a token with the fixture's ephemeral key and drop it at
+    ``LICENSE_PATH`` so ``current_license_info`` sees it."""
+    import clawmetry.license as _lic
+    payload = _payload(**overrides)
+    token = _lic._encode_token(payload, stub_home.priv)
+    with open(_lic.LICENSE_PATH, "w", encoding="utf-8") as fh:
+        fh.write(token)
+    return payload, token
+
+
+# ── envelope ──────────────────────────────────────────────────────────────────
+
+
+def test_license_key_present_on_virgin_install(stub_home, capsys):
+    """No license file on disk → ``installed=False``, ``status="none"``,
+    every optional field ``null``. All documented subkeys are always
+    populated so ``jq .license.installed`` never sees a missing field."""
+    doc = _run_and_parse(capsys, _ns())
+    lic_block = doc["license"]
+    assert set(lic_block.keys()) == {
+        "installed", "valid", "status", "tier", "nodes", "sub",
+        "days_left", "pubkey_fingerprint_sha256",
+        "permissions_safe", "file_mode",
+    }
+    assert lic_block == {
+        "installed": False,
+        "valid": False,
+        "status": "none",
+        "tier": None,
+        "nodes": None,
+        "sub": None,
+        "days_left": None,
+        "pubkey_fingerprint_sha256": None,
+        "permissions_safe": None,
+        "file_mode": None,
+    }
+
+
+def test_license_reports_active_pro(stub_home, capsys):
+    """A valid, non-expired Pro key with 10 nodes surfaces as ``valid=True``
+    / ``status="active"`` / ``tier="pro"`` / ``nodes=10`` — the shape
+    ``clawmetry license status --json`` already returns, folded into the
+    composite snapshot so a wrapper script needs one CLI invocation."""
+    _write_license(stub_home, tier="pro", nodes=10, sub="acct-pro")
+
+    doc = _run_and_parse(capsys, _ns())
+    lic_block = doc["license"]
+    assert lic_block["installed"] is True
+    assert lic_block["valid"] is True
+    assert lic_block["status"] == "active"
+    assert lic_block["tier"] == "pro"
+    assert lic_block["nodes"] == 10
+    assert lic_block["sub"] == "acct-pro"
+    assert isinstance(lic_block["days_left"], int)
+    assert lic_block["days_left"] > 300  # 1-year token minted just now
+    # Trust anchor comes from the ephemeral pub key, so we cannot assert an
+    # exact value — but the field must populate to a hex-shaped string so
+    # audit scripts can compare it against ``clawmetry license fingerprint``.
+    fp = lic_block["pubkey_fingerprint_sha256"]
+    assert isinstance(fp, str) and len(fp) == 64 and all(
+        c in "0123456789abcdef" for c in fp
+    )
+
+
+def test_license_reports_expired_key(stub_home, capsys):
+    """An otherwise-valid key that is past its ``exp`` surfaces as
+    ``valid=False`` / ``status="expired"`` with ``days_left`` negative, so
+    a wrapper can still tell operators *what* the (now-stale) key was
+    for. Complements the ``status="invalid"`` case below."""
+    _write_license(stub_home, tier="enterprise", nodes=20, exp_delta=-3600)
+
+    doc = _run_and_parse(capsys, _ns())
+    lic_block = doc["license"]
+    assert lic_block["installed"] is True
+    assert lic_block["valid"] is False
+    assert lic_block["status"] == "expired"
+    # Payload is still parseable — the tier / nodes come through so the UI
+    # can render "your Enterprise license expired X days ago".
+    assert lic_block["tier"] == "enterprise"
+    assert lic_block["nodes"] == 20
+    assert isinstance(lic_block["days_left"], int) and lic_block["days_left"] <= 0
+
+
+def test_license_reports_invalid_signature(stub_home, capsys):
+    """A tampered / wrong-key-signed license file surfaces as
+    ``valid=False`` / ``status="invalid"`` with ``tier`` / ``nodes`` /
+    ``sub`` ALL NULL — never surface a claimed tier from an unverified
+    body, or a forger could stuff arbitrary values into the envelope.
+    The on-disk diagnostic fields (``permissions_safe``, ``file_mode``)
+    still populate so the operator has debug context."""
+    import clawmetry.license as _lic
+    # Write a token signed by a DIFFERENT keypair than the one the fixture
+    # installed as the trust anchor — signature verify fails.
+    other_priv, _other_pub = _keypair()
+    forged = _lic._encode_token(_payload(tier="pro", nodes=999), other_priv)
+    with open(_lic.LICENSE_PATH, "w", encoding="utf-8") as fh:
+        fh.write(forged)
+
+    doc = _run_and_parse(capsys, _ns())
+    lic_block = doc["license"]
+    assert lic_block["installed"] is True
+    assert lic_block["valid"] is False
+    assert lic_block["status"] == "invalid"
+    # Never surface an attacker-chosen tier / nodes / sub from an
+    # unverified payload — the whole point of the signature check.
+    assert lic_block["tier"] is None
+    assert lic_block["nodes"] is None
+    assert lic_block["sub"] is None
+    assert lic_block["days_left"] is None
+    # Trust anchor + on-disk fields are payload-independent — still populate.
+    assert lic_block["pubkey_fingerprint_sha256"] is not None
+
+
+def test_license_survives_helper_failure(stub_home, capsys, monkeypatch):
+    """``current_license_info`` itself blows up → snapshot still emits the
+    zero-shape default (no ``null``s, no 5xx). Guards the never-crash
+    contract every other CLI diagnostic honours — a badly-timed
+    ``KeyboardInterrupt`` or an ``OSError`` from a failing disk read must
+    not take out ``clawmetry status --json``."""
+    import clawmetry.license as _lic
+
+    def _explode():
+        raise RuntimeError("license read broke")
+
+    monkeypatch.setattr(_lic, "current_license_info", _explode)
+
+    doc = _run_and_parse(capsys, _ns())
+    # Falls back to the default zero-shape from ``snap`` initialisation.
+    assert doc["license"] == {
+        "installed": False,
+        "valid": False,
+        "status": "none",
+        "tier": None,
+        "nodes": None,
+        "sub": None,
+        "days_left": None,
+        "pubkey_fingerprint_sha256": None,
+        "permissions_safe": None,
+        "file_mode": None,
+    }
+
+
+def test_license_key_present_in_envelope_top_level(stub_home, capsys):
+    """The envelope contract check pins that ``license`` is now a
+    top-level key on every ``clawmetry status --json`` payload — same
+    guarantee ``test_cli_status_json`` gives for ``runtimes`` /
+    ``extensions`` etc. Wrapper scripts that iterate over documented
+    top-level keys keep working."""
+    doc = _run_and_parse(capsys, _ns())
+    assert "license" in doc
+
+
+# ── human path ───────────────────────────────────────────────────────────────
+
+
+def test_license_human_path_shows_active_row(stub_home, capsys):
+    """Without ``--json`` the human path renders a ✅ row when a valid
+    license is on disk. Absence would leave operators with no in-``status``
+    signal that the self-hosted key is installed and healthy."""
+    _write_license(stub_home, tier="pro", nodes=10)
+
+    import clawmetry.cli as cli
+    cli._cmd_status(_ns(as_json=False))
+    out = capsys.readouterr().out
+    assert "License:" in out
+    assert "Pro" in out or "pro" in out
+    # ``expires in Nd`` hint so an operator can see at a glance how much
+    # runway they have before the key stops verifying.
+    assert "expires in" in out
+
+
+def test_license_human_path_shows_expired_row(stub_home, capsys):
+    """An expired key renders a ⚠️ row pointing to ``clawmetry license``
+    for the full detail — same triage-hint policy the extensions block
+    uses (don't reprint the full envelope in the composite view)."""
+    _write_license(stub_home, tier="pro", exp_delta=-3600)
+
+    import clawmetry.cli as cli
+    cli._cmd_status(_ns(as_json=False))
+    out = capsys.readouterr().out
+    assert "License:" in out
+    assert "expired" in out
+    assert "clawmetry license" in out
+
+
+def test_license_human_path_omits_block_when_absent(stub_home, capsys):
+    """No license file → no ``License:`` header. A fresh OSS install
+    should not paint an empty section that adds no information — the
+    default state is "no key", and silence is the right default
+    (same as the extensions block on installs with no plugins)."""
+    import clawmetry.cli as cli
+    cli._cmd_status(_ns(as_json=False))
+    out = capsys.readouterr().out
+    assert "License:" not in out


### PR DESCRIPTION
## Summary

- Adds a `license` block to `_status_snapshot()` so `clawmetry status --json` includes the self-hosted Pro/Enterprise license state alongside the existing `runtimes` / `extensions` blocks — one command to answer "is my node on Pro?" instead of two.
- Mirrors the envelope `current_license_info()` already returns; on a fresh install (no `~/.clawmetry/license.key`) defaults to `{"installed": false, "status": "none", …}` with every optional field null so wrapper scripts never see a missing key.
- Composes with the two neighbouring diagnostics that already exist in the snapshot: `runtimes.pro_installed_version` (is the wheel on disk?) and `extensions.discovered` (does the wheel import?). The three together triage every "why isn't Pro on this box?" question without a second CLI invocation.
- Human path grows one triage-hint line (`License:     ✅ Pro (self-hosted, expires in Nd)`) when a key is on disk; silent when there is none — matching the extensions block's silence-on-empty policy so a fresh OSS install doesn't grow a section that carries no information.
- Never-crash contract preserved: any exception in the license read degrades to the zero-shape default rather than 5xx'ing the whole snapshot.
- Shipped in GRACE mode: pure diagnostic addition — no behaviour anywhere else changes, no gate enforced.

## Test plan

- [x] 9 new tests in `tests/test_cli_status_license.py`: virgin install (all keys populated to nulls), active Pro (`valid=true`), expired (`status="expired"`, tier/nodes still surface), tampered/wrong-key signature (`status="invalid"`, tier/nodes/sub NULL so no forger-chosen values leak from an unverified payload), helper-failure fallback (never 5xx), envelope contract, and three human-path branches (active row / expired row / silence on virgin install).
- [x] 152 sibling tests in `test_cli_status_json.py`, `test_cli_status_extensions.py`, `test_cli_license_json.py`, `test_license.py`, `test_entitlement_api.py`, `test_extensions_probe.py`, `test_cli_extensions_subcommand.py` all still pass.
- [x] `python -m py_compile clawmetry/cli.py tests/test_cli_status_license.py` — clean.
- [x] `ruff check` on the changed files — zero new violations (line count unchanged from `main`).

## Local operator verification checklist

I cannot reach the operator's laptop, live daemon, real `~/.clawmetry/license.key`, or the running dashboard from this repo — the operator should verify locally:

- [ ] Copy `clawmetry/cli.py` and `tests/test_cli_status_license.py` into `~/.clawmetry/lib/python3.11/site-packages/clawmetry/` (or the interpreter site-packages the daemon uses); clear `__pycache__`.
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
- [ ] `clawmetry status --json | jq .license` — on a machine WITHOUT a license key, expect `{"installed": false, "status": "none", …}` with every other field `null`.
- [ ] On a machine WITH a valid key, expect `installed:true` / `valid:true` / `status:"active"` / real `tier` / `nodes` / `days_left` / hex `pubkey_fingerprint_sha256`.
- [ ] `clawmetry status` (human path) shows the new `License:     ✅ …` line when a key is on disk; NO `License:` line when there's no key.
- [ ] Browser-check the dashboard — this PR touches only `clawmetry status`; the dashboard's `/api/entitlement` and `/api/extensions` paths are unchanged and should still render the entitlements + plugin panels exactly as before.


---
_Generated by [Claude Code](https://claude.ai/code/session_01LZe3oMoq7rQgeQv9Cin1w7)_