### PR TITLE
fix(c6): redirect C6 notifications from closed #4036 to canonical tracking issue #3970

### DIFF
--- a/.github/workflows/apply-required-checks.yml
+++ b/.github/workflows/apply-required-checks.yml
@@ -18,7 +18,7 @@ name: Apply required E2E status checks (C6 -- one-shot)
 #     With only GITHUB_TOKEN (ghs_): read-only verify path in the script
 #     (exits 0 if C6 configured, exits 1 if not -- no admin rights needed).
 #     With E2E_ADMIN_PAT: full apply + verify.
-#     On failure, posts a notification comment on tracking issue #4036.
+#     On failure, posts a notification comment on tracking issue #3970.
 #
 # TOKEN PATHS (priority order):
 #   1. inputs.pat_token  -- PAT typed into the Run workflow dialog
@@ -37,7 +37,7 @@ name: Apply required E2E status checks (C6 -- one-shot)
 #   clawmetry-landing.
 #
 # Idempotent: running multiple times is safe.
-# Tracking: vivekchand/clawmetry#4036
+# Tracking: vivekchand/clawmetry#3970
 
 on:
   workflow_dispatch:
@@ -119,7 +119,7 @@ jobs:
         run: python3 scripts/apply_required_status_checks.py
 
       # When the C6 read-only verify exits 1 (checks not yet configured on main),
-      # post or update a comment on the E2E Robustness tracking issue #4036 so the
+      # post or update a comment on the E2E Robustness tracking issue #3970 so the
       # repo admin receives a GitHub notification.
       #
       # Only fires on push-to-main (the automated verify path), NOT on manual
@@ -161,15 +161,15 @@ jobs:
 
           # Upsert: update existing comment if present, otherwise create new.
           existing_id=$(gh api -X GET \
-            "repos/${REPO}/issues/4036/comments" \
+            "repos/${REPO}/issues/3970/comments" \
             --jq 'map(select(.body | startswith("<!-- c6-notify-bot -->"))) | .[0].id // empty' \
             2>/dev/null || echo "")
           if [ -n "${existing_id}" ]; then
             gh api -X PATCH "repos/${REPO}/issues/comments/${existing_id}" \
               -f body="${BODY}" > /dev/null
-            echo "Updated existing C6 notification on #4036 (comment ${existing_id})"
+            echo "Updated existing C6 notification on #3970 (comment ${existing_id})"
           else
-            gh api -X POST "repos/${REPO}/issues/4036/comments" \
+            gh api -X POST "repos/${REPO}/issues/3970/comments" \
               -f body="${BODY}" > /dev/null
-            echo "Posted new C6 notification on #4036"
+            echo "Posted new C6 notification on #3970"
           fi

--- a/.github/workflows/c6-health.yml
+++ b/.github/workflows/c6-health.yml
@@ -9,7 +9,7 @@ name: C6 daily health check (branch-protection audit -- all 3 repos)
 # used cross-repo (returns 403 even on public repos); unauthenticated
 # reads return the full protection.required_status_checks object.
 #
-# On failure: posts an @-mentioned reminder to tracking issue #4036
+# On failure: posts an @-mentioned reminder to tracking issue #3970
 # at most once per calendar day. On success: posts a GREEN confirmation.
 #
 # To close C6:
@@ -19,7 +19,7 @@ name: C6 daily health check (branch-protection audit -- all 3 repos)
 #   2. Or: bash scripts/close-c6.sh
 #   3. Or: Settings > Branches > main > Required status checks (each repo)
 #
-# Tracking: vivekchand/clawmetry#4036
+# Tracking: vivekchand/clawmetry#3970
 
 on:
   schedule:
@@ -49,7 +49,7 @@ jobs:
 
           TOKEN = os.environ["GITHUB_TOKEN"]
           OWNER = "vivekchand"
-          TRACKING_ISSUE = 4036
+          TRACKING_ISSUE = 3970
           MARKER = "<!-- c6-health-check -->"
           # Repo this workflow runs in. Cross-repo reads must NOT send the
           # scoped GITHUB_TOKEN: Actions tokens are repo-scoped and return 403

--- a/.github/workflows/c6-pr-gate.yml
+++ b/.github/workflows/c6-pr-gate.yml
@@ -3,7 +3,7 @@ name: C6 Required-status-checks gate (PR audit)
 # Runs on every pull request to surface whether C6 (required-status-checks)
 # is configured on main. Fails visibly on every PR until the admin closes C6.
 #
-# The daily c6-health.yml posts to issue #4036 but the admin may not check
+# The daily c6-health.yml posts to issue #3970 but the admin may not check
 # that issue between merges. This check appears directly in the PR status
 # list alongside OSS golden path, E2E Browser Tests, etc. -- impossible to
 # miss when reviewing a PR.
@@ -38,7 +38,7 @@ name: C6 Required-status-checks gate (PR audit)
 #     bash scripts/close-c6.sh
 #     (uses your existing gh CLI session -- no PAT creation needed)
 #
-# Tracking: vivekchand/clawmetry#4036 (C6)
+# Tracking: vivekchand/clawmetry#3970 (C6)
 
 on:
   pull_request:
@@ -112,7 +112,7 @@ jobs:
           [Apply required E2E status checks (C6)](https://github.com/vivekchand/clawmetry/actions/workflows/apply-required-checks.yml)
           -- confirm=APPLY, pat_token=paste-token-here
 
-          _C6 is the sole remaining criterion of the E2E Robustness epic. All other 6 criteria (C1 OSS golden path, C2 Cloud golden path, C3 Landing, C4 Cross-repo handoff, C5 Visual diff all tabs, C7 Quarantine) are green. Tracking: [#4036](https://github.com/vivekchand/clawmetry/issues/4036)_"
+          _C6 is the sole remaining criterion of the E2E Robustness epic. All other 6 criteria (C1 OSS golden path, C2 Cloud golden path, C3 Landing, C4 Cross-repo handoff, C5 Visual diff all tabs, C7 Quarantine) are green. Tracking: [#3970](https://github.com/vivekchand/clawmetry/issues/3970)_"
 
           existing_id=$(gh api -X GET \
             "repos/${REPO}/issues/${PR}/comments" \

--- a/.github/workflows/c6-schedule-heal.yml
+++ b/.github/workflows/c6-schedule-heal.yml
@@ -23,7 +23,7 @@ name: C6 auto-heal (daily required-checks application)
 #     clawmetry, clawmetry-cloud, clawmetry-landing
 #   This workflow picks it up at 10:15am UTC and closes C6 automatically.
 #
-# Tracking: vivekchand/clawmetry#4036
+# Tracking: vivekchand/clawmetry#3970
 
 on:
   schedule:
@@ -162,7 +162,7 @@ except Exception:
               echo "bash scripts/close-c6.sh"
               echo "\`\`\`"
               echo ""
-              echo "Tracking: [#4036](https://github.com/vivekchand/clawmetry/issues/4036)"
+              echo "Tracking: [#3970](https://github.com/vivekchand/clawmetry/issues/3970)"
             fi
           } >> "$GITHUB_STEP_SUMMARY"
 
@@ -173,7 +173,7 @@ except Exception:
           echo ""
           echo "ACTION REQUIRED: Add E2E_ADMIN_PAT to close C6."
           echo "See the job summary above for a formatted status report and close options."
-          echo "Tracking: https://github.com/vivekchand/clawmetry/issues/4036"
+          echo "Tracking: https://github.com/vivekchand/clawmetry/issues/3970"
           exit 1
 
       - name: Apply required E2E status checks (C6)
@@ -196,7 +196,7 @@ except Exception:
             echo "- [clawmetry-cloud branch protection](https://github.com/vivekchand/clawmetry-cloud/settings/branches)"
             echo "- [clawmetry-landing branch protection](https://github.com/vivekchand/clawmetry-landing/settings/branches)"
             echo ""
-            echo "Tracking: [#4036](https://github.com/vivekchand/clawmetry/issues/4036)"
+            echo "Tracking: [#3970](https://github.com/vivekchand/clawmetry/issues/3970)"
           } >> "$GITHUB_STEP_SUMMARY"
           echo "C6 auto-heal complete. If apply_required_status_checks.py exited 0, branch protection"
-          echo "is configured on all 3 repos. Tracking: https://github.com/vivekchand/clawmetry/issues/4036"
+          echo "is configured on all 3 repos. Tracking: https://github.com/vivekchand/clawmetry/issues/3970"

--- a/.github/workflows/cross-repo-handoff.yml
+++ b/.github/workflows/cross-repo-handoff.yml
@@ -113,7 +113,7 @@ jobs:
       # PR reviewer can see at a glance whether C4 ran with real apps or
       # inline stubs. In stub mode a one-liner call-to-action links to the
       # tracking issue so the gap is visible without digging into logs.
-      # Tracking: vivekchand/clawmetry#4036 (C4)
+      # Tracking: vivekchand/clawmetry#3970 (C4)
       - name: Write C4 fidelity summary
         if: always()
         run: |
@@ -124,7 +124,7 @@ jobs:
               echo "**Mode: REAL APPS** -- CLOUD_REPO_PAT configured"
               echo ""
               echo "| Tier | What was tested |"
-              echo "|------|-----------------|"
+              echo "|------|------------------|"
               echo "| T1 | Real clawmetry-landing (run_landing.py) |"
               echo "| T2 | Real clawmetry-cloud (run_cloud.py) |"
               echo "| T3 | Real DaemonSim from cloud checkout |"
@@ -141,7 +141,7 @@ jobs:
               echo ""
               echo "> **To upgrade C4 to real-apps mode:** set the \`CLOUD_REPO_PAT\` repository"
               echo "> secret (Contents read on clawmetry-cloud + clawmetry-landing)."
-              echo "> See [tracking issue #4036](https://github.com/vivekchand/clawmetry/issues/4036)."
+              echo "> See [tracking issue #3970](https://github.com/vivekchand/clawmetry/issues/3970)."
             fi
           } >> "$GITHUB_STEP_SUMMARY"
 

--- a/.github/workflows/oss-golden-path.yml
+++ b/.github/workflows/oss-golden-path.yml
@@ -10,7 +10,7 @@ name: OSS Golden Path (C1)
 # Budget: 12 minutes wall-clock (raised from 8; Playwright chromium download
 # ~100 MB takes up to 4.5 min on a cold runner -- cache hit drops it to ~30 s;
 # C5 33-tab Playwright sweep adds ~90 s on top of the C1 9-tab sweep).
-# Tracking: vivekchand/clawmetry#1646 (C1), #3666 (C5), #4036 (E2E epic)
+# Tracking: vivekchand/clawmetry#1646 (C1), #3666 (C5), #3970 (E2E epic)
 
 on:
   pull_request:
@@ -146,7 +146,7 @@ jobs:
       # crash (e.g. ImportError on a broken branch) caused conftest.py to
       # launch a second server from source, which also crashed, producing
       # confusing ERROR-at-setup failures instead of a clear "server never
-      # started" message. (Tracking: vivekchand/clawmetry#4036)
+      # started" message. (Tracking: vivekchand/clawmetry#3970)
       - name: Start dashboard from installed wheel
         run: |
           OPENCLAW_GATEWAY_TOKEN=ci-golden-token \
@@ -214,7 +214,7 @@ jobs:
       # post-auth overlay sweep that is the direct fix for the user-reported
       # gateway-token bug (2026-05-17). Previously, ANY C1 failure caused C5
       # to be skipped, meaning auth regressions on broken branches were never
-      # caught. (Tracking: vivekchand/clawmetry#4036)
+      # caught. (Tracking: vivekchand/clawmetry#3970)
       - name: Restart dashboard (clean state for C5 sweep)
         if: always()
         run: |

--- a/scripts/apply_required_status_checks.py
+++ b/scripts/apply_required_status_checks.py
@@ -46,7 +46,7 @@ Primary repo behaviour (clawmetry):
 When run locally (GITHUB_REPOSITORY not set), the script applies all 6
 checks and requires a token with cross-repo admin access.
 
-Tracking: vivekchand/clawmetry#4036 (C6)
+Tracking: vivekchand/clawmetry#3970 (C6)
 """
 from __future__ import annotations
 
@@ -398,7 +398,7 @@ def main() -> None:
                 "  Fix: re-run the workflow and paste a fine-grained PAT into the 'pat_token' field.\n"
                 "  PAT permissions: Administration (read+write) on clawmetry, clawmetry-cloud, clawmetry-landing.\n"
                 "  Alternative: bash scripts/close-c6.sh (uses your gh CLI session, ~30 sec).\n"
-                "  Tracking: vivekchand/clawmetry#4036 (C6)"
+                "  Tracking: vivekchand/clawmetry#3970 (C6)"
             )
         # Read-only path: GITHUB_TOKEN cannot write branch protection rules.
         # Scope verification to the current repo only to avoid cross-repo 403s.

--- a/scripts/close-c6.sh
+++ b/scripts/close-c6.sh
@@ -19,7 +19,7 @@
 # After running: every PR in those 3 repos must pass the E2E suite to merge.
 # This closes criterion C6 of the E2E Robustness epic.
 #
-# Tracking: vivekchand/clawmetry#4036
+# Tracking: vivekchand/clawmetry#3970
 
 set -euo pipefail
 


### PR DESCRIPTION
## Summary

PR #4037 incorrectly wired all C6 notification references to `#4036` (closed as duplicate by owner on 2026-07-26) instead of the canonical open tracking issue `#3970`. As a result, every push to main and every daily health-check now posts C6 alerts to a dead issue, breaking the escalation loop that is supposed to prompt branch protection configuration.

**Impact:** The admin receives C6 notifications on a closed issue. The daily `c6-health.yml` TRACKING_ISSUE variable points to 4036, so `@vivekchand` pings land on a resolved/duplicate thread that is easy to miss.

**Fix:** Update all 8 affected files so every issue reference points to `#3970`.

**Files changed:**

| File | Change type |
|------|-------------|
| `.github/workflows/apply-required-checks.yml` | Functional: `issues/4036/comments` API calls now target `issues/3970/comments` |
| `.github/workflows/c6-health.yml` | Functional: `TRACKING_ISSUE = 4036` changed to `TRACKING_ISSUE = 3970` |
| `.github/workflows/c6-schedule-heal.yml` | Display: job summary URLs updated |
| `.github/workflows/c6-pr-gate.yml` | Display: PR comment body tracking link updated |
| `.github/workflows/cross-repo-handoff.yml` | Display: fidelity summary tracking link updated |
| `.github/workflows/oss-golden-path.yml` | Comment: tracking references updated (keeps #1646 and #3666) |
| `scripts/close-c6.sh` | Comment: header tracking reference updated |
| `scripts/apply_required_status_checks.py` | Docstring and error message string updated |

**Note:** C6 itself still requires admin action to configure branch protection. This PR only fixes the notification routing so future C6 alerts land on the correct open issue.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PssxiBa19MiygswdzFtgne)_