### PR TITLE
feat(entitlement): min_tier_for_all_breakdown + /api/entitlement/required-tier-breakdown

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -6400,6 +6400,198 @@ def min_tier_for_all(
         return None
 
 
+def min_tier_for_all_breakdown(
+    *,
+    features=None,
+    runtimes=None,
+    channels: int | None = None,
+    retention_days: int | None = None,
+    nodes: int | None = None,
+) -> dict:
+    """Per-axis breakdown of :func:`min_tier_for_all` with the binding
+    constraint(s) called out.
+
+    Where :func:`min_tier_for_all` collapses the answer to a single
+    ``min_tier`` id, this helper preserves the per-axis contribution and
+    identifies which axis (or axes, on a tie) is *driving* the required
+    tier. A dashboard surface can then render an honest "you need Pro
+    *because* you have 8 channels (Starter caps at 5)" tooltip off ONE
+    round-trip instead of five ``min_tier_for_*`` calls + a client-side
+    max-by-rank + a comparison against the aggregate floor.
+
+    Same input semantics as :func:`min_tier_for_all` (same five-axis
+    kwargs, same per-axis ``None`` "not supplied" sentinel, same
+    ``retention_days=None means unset, not unlimited`` posture, same
+    never-raise contract).
+
+    Response shape::
+
+        {
+          "min_tier":       "cloud_pro" | None,   # matches min_tier_for_all
+          "min_tier_label": "Pro" | None,
+          "min_tier_rank":  <int> | None,
+          "axes": {
+            "features":       <axis_row> | None,  # None iff axis unsupplied
+            "runtimes":       <axis_row> | None,
+            "channels":       <axis_row> | None,
+            "retention_days": <axis_row> | None,
+            "nodes":          <axis_row> | None,
+          },
+          "binding_axes":  ["features"] | [],     # axis ids whose min_tier
+                                                  # equals the aggregate floor
+        }
+
+    Each ``<axis_row>`` carries ``kind``, ``supplied`` (``True`` -- an
+    unsupplied axis short-circuits to ``None`` at the envelope level),
+    ``min_tier`` (``None`` when the axis collapses to nothing -- empty
+    iterable / non-int / all-unknown tokens), ``min_tier_label``,
+    ``min_tier_rank`` (``-1`` when ``min_tier`` is ``None``), and
+    ``binding`` (``True`` iff this axis' ``min_tier`` matches the
+    aggregate ``min_tier``). Grant axes additionally carry ``items``
+    (the normalised list actually contributing) so the tooltip can name
+    the offender ("channel-adapter *slack* needs Starter"). Capacity
+    axes additionally carry ``value`` (the parsed int, or the raw
+    input if it did not parse) so the tooltip can render the offending
+    number.
+
+    ``binding_axes`` is the list of axis keys (``"features"`` /
+    ``"runtimes"`` / ``"channels"`` / ``"retention_days"`` / ``"nodes"``)
+    whose per-axis ``min_tier`` matches the aggregate floor. On a tie
+    (two axes both resolve to Pro), both are listed in envelope order.
+    When ``min_tier`` is ``None`` -- no constraints, or every supplied
+    axis collapsed -- ``binding_axes`` is the empty list.
+
+    Decoupled from the resolved entitlement (walks the static per-tier
+    caps via the singular ``min_tier_for_*`` helpers), so grace vs
+    enforce yields byte-identical output. Never raises: a delegate
+    failure surfaces as the null-floor / empty-axes / empty-binding
+    shape so the pricing UI keeps rendering instead of 500-ing.
+    """
+    empty = {
+        "min_tier": None,
+        "min_tier_label": None,
+        "min_tier_rank": None,
+        "axes": {
+            "features": None,
+            "runtimes": None,
+            "channels": None,
+            "retention_days": None,
+            "nodes": None,
+        },
+        "binding_axes": [],
+    }
+    try:
+        axes: dict = {
+            "features": None,
+            "runtimes": None,
+            "channels": None,
+            "retention_days": None,
+            "nodes": None,
+        }
+
+        if features is not None:
+            feats = _normalise_csv(features)
+            known = [f for f in feats if f in ALL_FEATURES]
+            axis_min = min_tier_for_features(known) if known else None
+            axes["features"] = {
+                "kind": "features",
+                "supplied": True,
+                "items": known,
+                "min_tier": axis_min,
+                "min_tier_label": tier_label(axis_min) if axis_min else None,
+                "min_tier_rank": tier_rank(axis_min) if axis_min else -1,
+                "binding": False,
+            }
+
+        if runtimes is not None:
+            raw_rts = _normalise_csv(runtimes)
+            seen: set[str] = set()
+            canon_rts: list[str] = []
+            for raw in raw_rts:
+                rt = canonical_runtime(raw)
+                key = rt if rt else raw
+                if key in seen:
+                    continue
+                seen.add(key)
+                if rt and rt in ALL_RUNTIMES:
+                    canon_rts.append(rt)
+            axis_min = min_tier_for_runtimes(canon_rts) if canon_rts else None
+            axes["runtimes"] = {
+                "kind": "runtimes",
+                "supplied": True,
+                "items": canon_rts,
+                "min_tier": axis_min,
+                "min_tier_label": tier_label(axis_min) if axis_min else None,
+                "min_tier_rank": tier_rank(axis_min) if axis_min else -1,
+                "binding": False,
+            }
+
+        def _capacity_row(kind: str, raw, resolver) -> dict:
+            try:
+                n = int(raw)
+                parsed = True
+            except (TypeError, ValueError):
+                n = None
+                parsed = False
+            axis_min = resolver(n) if parsed else None
+            return {
+                "kind": kind,
+                "supplied": True,
+                "value": n if parsed else raw,
+                "min_tier": axis_min,
+                "min_tier_label": tier_label(axis_min) if axis_min else None,
+                "min_tier_rank": tier_rank(axis_min) if axis_min else -1,
+                "binding": False,
+            }
+
+        if channels is not None:
+            axes["channels"] = _capacity_row(
+                "channels", channels, min_tier_for_channel_count
+            )
+        if retention_days is not None:
+            axes["retention_days"] = _capacity_row(
+                "retention_days",
+                retention_days,
+                min_tier_for_retention_window,
+            )
+        if nodes is not None:
+            axes["nodes"] = _capacity_row(
+                "nodes", nodes, min_tier_for_node_count
+            )
+
+        candidate_tiers: list[str] = []
+        for axis in axes.values():
+            if axis and axis["min_tier"]:
+                candidate_tiers.append(axis["min_tier"])
+        if not candidate_tiers:
+            return {
+                "min_tier": None,
+                "min_tier_label": None,
+                "min_tier_rank": None,
+                "axes": axes,
+                "binding_axes": [],
+            }
+
+        floor = max(candidate_tiers, key=tier_rank)
+        floor_rank = tier_rank(floor)
+        binding_axes: list[str] = []
+        for key in ("features", "runtimes", "channels", "retention_days", "nodes"):
+            axis = axes[key]
+            if axis and axis["min_tier"] == floor:
+                axis["binding"] = True
+                binding_axes.append(key)
+        return {
+            "min_tier": floor,
+            "min_tier_label": tier_label(floor),
+            "min_tier_rank": floor_rank,
+            "axes": axes,
+            "binding_axes": binding_axes,
+        }
+    except Exception as exc:
+        logger.warning("entitlements: min_tier_for_all_breakdown failed: %s", exc)
+        return empty
+
+
 def affordable_tiers(
     *,
     features=None,

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -58,6 +58,19 @@ is the single source of truth -- handlers never re-derive tier logic here.
                                           fleet + otel_export + sso -- what
                                           tier covers everything?" in a single
                                           round-trip.
+  GET  /api/entitlement/required-tier-breakdown -- per-axis breakdown sibling
+                                          of ``/required-tier-batch``: same
+                                          inputs and top-level
+                                          ``required_tier`` field, but
+                                          additionally exposes each axis'
+                                          individual ``min_tier`` and calls
+                                          out which axis (or axes, on a tie)
+                                          is the *binding* constraint driving
+                                          the aggregate floor -- so a paywall
+                                          CTA can render "You need Pro
+                                          *because* you have 8 channels
+                                          (Starter caps at 5)" off ONE
+                                          round-trip.
   GET  /api/entitlement/lock-reason-batch -- per-item plural sibling of
                                           ``/lock-reason``: same CSV +
                                           capacity inputs as
@@ -3305,6 +3318,164 @@ def api_entitlement_required_tier_batch():
                 "current_tier_rank": 0,
                 "upgrade_required": False,
                 "allowed": True,
+            }
+        )
+
+
+@bp_entitlement.route("/api/entitlement/required-tier-breakdown")
+def api_entitlement_required_tier_breakdown():
+    """``GET /api/entitlement/required-tier-breakdown?features=a,b&runtimes=x,y
+    &channels=N&retention_days=K&nodes=M`` -- per-axis breakdown sibling of
+    ``/api/entitlement/required-tier-batch``.
+
+    Wraps :func:`entitlements.min_tier_for_all_breakdown`. Where
+    ``/required-tier-batch`` collapses to a single ``required_tier`` id,
+    this endpoint additionally returns each axis' individual ``min_tier``
+    and calls out which axis (or axes, on a tie) is the *binding*
+    constraint driving the aggregate floor -- so a paywall CTA can render
+    "You need Pro *because* you have 8 channels (Starter caps at 5)" off
+    ONE round-trip instead of five ``/required-tier`` calls + a
+    client-side max-by-rank.
+
+    At least one of ``features=`` / ``runtimes=`` / ``channels=`` /
+    ``retention_days=`` / ``nodes=`` must be supplied (non-empty /
+    parseable after normalisation) -- otherwise 400. The three capacity
+    axes accept a single int each; a blank or non-int value contributes
+    nothing to the aggregate floor (the axis row still renders with
+    ``min_tier=null`` so the caller can flag the bad input in a
+    tooltip, matching the never-crash posture of the singular endpoint).
+    ``retention_days=`` mirrors the strict :func:`min_tier_for_all`
+    posture: an unset param is *unset*, NOT *unlimited* -- asking for
+    the unlimited-retention floor is the singular
+    ``/required-tier?retention_days=`` call's job.
+
+    Response body::
+
+        {
+          "features":       [<normalised csv>],
+          "runtimes":       [<normalised csv>],
+          "channels":       <int> | null,
+          "retention_days": <int> | null,
+          "nodes":          <int> | null,
+          "required_tier":       "cloud_pro" | null,
+          "required_tier_label": "Pro" | null,
+          "required_tier_rank":  <int>,      # -1 when required_tier is null
+          "current_tier":        <resolved-tier>,
+          "current_tier_rank":   <int>,
+          "upgrade_required":    <bool>,
+          "axes":         { <axis row per supplied kwarg> | null },
+          "binding_axes": ["features", "channels"]  # ordered; empty on null
+        }
+
+    ``axes`` and ``binding_axes`` come straight from
+    :func:`min_tier_for_all_breakdown`; see that helper's docstring for
+    the row shape. The ``required_tier*`` / ``current_tier*`` /
+    ``upgrade_required`` fields match ``/required-tier-batch`` exactly
+    so a caller migrating from the batch endpoint can adopt the
+    breakdown without reshaping its main paywall payload.
+
+    Never 5xxs: the OSS-fallback shape is returned on any resolver
+    failure.
+    """
+    try:
+        from clawmetry import entitlements as _ent
+
+        features = _parse_csv_arg("features")
+        runtimes = _parse_csv_arg("runtimes")
+        (channels_present, channels_ok, channels_n, _) = _parse_capacity_arg(
+            "channels"
+        )
+        (retention_present, retention_ok, retention_n, _) = _parse_capacity_arg(
+            "retention_days"
+        )
+        (nodes_present, nodes_ok, nodes_n, _) = _parse_capacity_arg("nodes")
+
+        if (
+            not features
+            and not runtimes
+            and not channels_present
+            and not retention_present
+            and not nodes_present
+        ):
+            return (
+                jsonify(
+                    {
+                        "error": (
+                            "supply at least one of features=<csv>, "
+                            "runtimes=<csv>, channels=<int>, "
+                            "retention_days=<int>, or nodes=<int>"
+                        )
+                    }
+                ),
+                400,
+            )
+
+        breakdown = _ent.min_tier_for_all_breakdown(
+            features=features or None,
+            runtimes=runtimes or None,
+            channels=channels_n if channels_ok else None,
+            retention_days=retention_n if retention_ok else None,
+            nodes=nodes_n if nodes_ok else None,
+        )
+
+        ent = _ent.get_entitlement()
+        required = breakdown.get("min_tier")
+        required_label = breakdown.get("min_tier_label")
+        req_rank = _ent.tier_rank(required) if required else -1
+        cur_rank = _ent.tier_rank(ent.tier)
+
+        return jsonify(
+            {
+                "features": features,
+                "runtimes": runtimes,
+                "channels": channels_n if channels_ok else None,
+                "retention_days": retention_n if retention_ok else None,
+                "nodes": nodes_n if nodes_ok else None,
+                "required_tier": required,
+                "required_tier_label": required_label,
+                "required_tier_rank": req_rank,
+                "current_tier": ent.tier,
+                "current_tier_rank": cur_rank,
+                "upgrade_required": bool(required) and req_rank > cur_rank,
+                "axes": breakdown.get("axes")
+                or {
+                    "features": None,
+                    "runtimes": None,
+                    "channels": None,
+                    "retention_days": None,
+                    "nodes": None,
+                },
+                "binding_axes": breakdown.get("binding_axes") or [],
+            }
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_required_tier_breakdown: error: %s", exc
+        )
+        (_, channels_ok, channels_n, _) = _parse_capacity_arg("channels")
+        (_, retention_ok, retention_n, _) = _parse_capacity_arg("retention_days")
+        (_, nodes_ok, nodes_n, _) = _parse_capacity_arg("nodes")
+        return jsonify(
+            {
+                "features": _parse_csv_arg("features"),
+                "runtimes": _parse_csv_arg("runtimes"),
+                "channels": channels_n if channels_ok else None,
+                "retention_days": retention_n if retention_ok else None,
+                "nodes": nodes_n if nodes_ok else None,
+                "required_tier": None,
+                "required_tier_label": None,
+                "required_tier_rank": -1,
+                "current_tier": "oss",
+                "current_tier_rank": 0,
+                "upgrade_required": False,
+                "axes": {
+                    "features": None,
+                    "runtimes": None,
+                    "channels": None,
+                    "retention_days": None,
+                    "nodes": None,
+                },
+                "binding_axes": [],
             }
         )
 

--- a/tests/test_entitlement_required_tier_breakdown.py
+++ b/tests/test_entitlement_required_tier_breakdown.py
@@ -1,0 +1,385 @@
+"""Tests for :func:`clawmetry.entitlements.min_tier_for_all_breakdown`
+and the ``/api/entitlement/required-tier-breakdown`` endpoint.
+
+The breakdown helper is the per-axis companion of
+:func:`min_tier_for_all`. Where the floor helper collapses to one tier
+id, the breakdown additionally exposes each axis' individual
+``min_tier`` and calls out which axis (or axes, on a tie) is *binding*
+the aggregate floor -- so a paywall CTA can render "You need Pro
+*because* you have 8 channels (Starter caps at 5)" off one round-trip.
+
+This file pins:
+
+* Parity with :func:`min_tier_for_all` on the aggregate floor across the
+  five capacity axes -- so a future tier shuffle breaks loudly here.
+* The per-axis row shape (``kind``, ``supplied``, ``min_tier``,
+  ``min_tier_label``, ``min_tier_rank``, ``binding``, plus ``items`` for
+  grants / ``value`` for capacities).
+* ``binding_axes`` identification -- single-axis dominance, multi-axis
+  ties, and the "nothing binds" null-floor case.
+* Grace vs enforce invariance -- decoupled from the resolved
+  entitlement (walks the static per-tier caps).
+* The never-raise contract on unknown ids, non-int capacity input, and
+  the "nothing supplied" edge.
+* HTTP envelope shape (``required_tier`` / ``current_tier`` /
+  ``upgrade_required`` mirror ``/required-tier-batch`` exactly; the
+  breakdown fields sit alongside).
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# ── helper: envelope shape + null-floor edge ───────────────────────────────
+
+
+def _axis_keys():
+    return ("features", "runtimes", "channels", "retention_days", "nodes")
+
+
+def test_no_constraints_returns_null_floor(ent):
+    """Mirrors :func:`min_tier_for_all`: "nothing asked" -> null floor,
+    every axis unsupplied, empty ``binding_axes``."""
+    out = ent.min_tier_for_all_breakdown()
+    assert out["min_tier"] is None
+    assert out["min_tier_label"] is None
+    assert out["min_tier_rank"] is None
+    for k in _axis_keys():
+        assert out["axes"][k] is None
+    assert out["binding_axes"] == []
+
+
+def test_all_axes_none_returns_null_floor(ent):
+    out = ent.min_tier_for_all_breakdown(
+        features=None,
+        runtimes=None,
+        channels=None,
+        retention_days=None,
+        nodes=None,
+    )
+    assert out["min_tier"] is None
+    assert out["binding_axes"] == []
+
+
+def test_all_axes_collapse_to_none_returns_null_floor(ent):
+    """Empty iterables / all-unknown items collapse each axis' ``min_tier``
+    to ``None``; when every supplied axis collapses the aggregate floor
+    is ``None`` too, and no axis is binding."""
+    out = ent.min_tier_for_all_breakdown(
+        features=[], runtimes=(), channels="not-an-int"
+    )
+    assert out["min_tier"] is None
+    assert out["binding_axes"] == []
+    assert out["axes"]["features"] is not None
+    assert out["axes"]["features"]["min_tier"] is None
+    assert out["axes"]["features"]["items"] == []
+    assert out["axes"]["runtimes"]["items"] == []
+    assert out["axes"]["channels"]["value"] == "not-an-int"
+
+
+# ── parity with min_tier_for_all across the five axes ──────────────────────
+
+
+def test_parity_features_only(ent):
+    out = ent.min_tier_for_all_breakdown(features=["fleet"])
+    assert out["min_tier"] == ent.min_tier_for_all(features=["fleet"])
+    assert out["binding_axes"] == ["features"]
+
+
+def test_parity_runtimes_only(ent):
+    out = ent.min_tier_for_all_breakdown(runtimes=["openclaw"])
+    assert out["min_tier"] == ent.min_tier_for_all(runtimes=["openclaw"])
+    assert out["min_tier"] == ent.TIER_OSS
+    assert out["binding_axes"] == ["runtimes"]
+
+
+def test_parity_channels_only(ent):
+    out = ent.min_tier_for_all_breakdown(channels=5)
+    assert out["min_tier"] == ent.min_tier_for_all(channels=5)
+    if out["min_tier"] is not None:
+        assert "channels" in out["binding_axes"]
+
+
+def test_parity_retention_only(ent):
+    out = ent.min_tier_for_all_breakdown(retention_days=30)
+    assert out["min_tier"] == ent.min_tier_for_all(retention_days=30)
+
+
+def test_parity_nodes_only(ent):
+    out = ent.min_tier_for_all_breakdown(nodes=2)
+    assert out["min_tier"] == ent.min_tier_for_all(nodes=2)
+
+
+def test_parity_mixed_bundle(ent):
+    bundle = dict(
+        features=["fleet"],
+        runtimes=["claude_code"],
+        channels=8,
+        retention_days=30,
+        nodes=2,
+    )
+    out = ent.min_tier_for_all_breakdown(**bundle)
+    assert out["min_tier"] == ent.min_tier_for_all(**bundle)
+    if out["min_tier"] is not None:
+        assert out["min_tier_rank"] == ent.tier_rank(out["min_tier"])
+        assert out["min_tier_label"] == ent.tier_label(out["min_tier"])
+
+
+# ── binding-axis identification ────────────────────────────────────────────
+
+
+def test_binding_axis_is_the_highest_rank(ent):
+    """Enterprise-only features MUST bind the floor when mixed with
+    otherwise-free axes."""
+    out = ent.min_tier_for_all_breakdown(
+        features=["sso"], runtimes=["openclaw"], channels=2
+    )
+    assert out["min_tier"] == ent.TIER_ENTERPRISE
+    assert out["binding_axes"] == ["features"]
+    assert out["axes"]["features"]["binding"] is True
+    assert out["axes"]["runtimes"]["binding"] is False
+    assert out["axes"]["channels"]["binding"] is False
+
+
+def test_binding_axes_tie_lists_all_binders(ent):
+    """When two axes both resolve to the aggregate floor, both are listed
+    in ``binding_axes`` in envelope order (features / runtimes / channels
+    / retention_days / nodes)."""
+    # A paid feature + paid runtime both at Enterprise -> both bind.
+    out = ent.min_tier_for_all_breakdown(features=["sso"], runtimes=["claude_code"])
+    if out["min_tier"] == ent.TIER_ENTERPRISE:
+        assert "features" in out["binding_axes"]
+        # runtime binds iff its min_tier == floor
+        rt_row = out["axes"]["runtimes"]
+        assert rt_row["binding"] == (rt_row["min_tier"] == out["min_tier"])
+
+
+def test_binding_axes_null_when_floor_null(ent):
+    """When the aggregate floor is ``None`` (nothing / unknown-only),
+    ``binding_axes`` is empty."""
+    out = ent.min_tier_for_all_breakdown(features=["bogus-feature-id"])
+    assert out["min_tier"] is None
+    assert out["binding_axes"] == []
+    # axis row still renders so the caller can flag the unknown token
+    assert out["axes"]["features"] is not None
+    assert out["axes"]["features"]["items"] == []
+
+
+# ── per-axis row shape ─────────────────────────────────────────────────────
+
+
+def test_grant_axis_row_shape(ent):
+    out = ent.min_tier_for_all_breakdown(features=["fleet"])
+    row = out["axes"]["features"]
+    assert row["kind"] == "features"
+    assert row["supplied"] is True
+    assert row["items"] == ["fleet"]
+    assert row["min_tier"] == ent.min_tier_for_features(["fleet"])
+    assert row["min_tier_label"] == ent.tier_label(row["min_tier"])
+    assert row["min_tier_rank"] == ent.tier_rank(row["min_tier"])
+    assert isinstance(row["binding"], bool)
+
+
+def test_capacity_axis_row_shape(ent):
+    out = ent.min_tier_for_all_breakdown(channels=5)
+    row = out["axes"]["channels"]
+    assert row["kind"] == "channels"
+    assert row["supplied"] is True
+    assert row["value"] == 5
+    assert row["min_tier"] == ent.min_tier_for_channel_count(5)
+
+
+def test_capacity_row_preserves_bad_input(ent):
+    """A non-int capacity value keeps ``supplied=True`` (the caller DID
+    supply it), reports ``min_tier=None``, and echoes the raw input in
+    ``value`` so the tooltip can flag the typo."""
+    out = ent.min_tier_for_all_breakdown(channels="five")
+    row = out["axes"]["channels"]
+    assert row["supplied"] is True
+    assert row["value"] == "five"
+    assert row["min_tier"] is None
+    assert row["min_tier_rank"] == -1
+
+
+def test_runtime_axis_canonicalises_aliases(ent):
+    """``claude-code`` -> ``claude_code`` matches the singular
+    :func:`min_tier_for_runtime` posture (aliases collapse)."""
+    out = ent.min_tier_for_all_breakdown(runtimes=["claude-code"])
+    row = out["axes"]["runtimes"]
+    assert "claude_code" in row["items"]
+
+
+def test_unsupplied_axes_are_none(ent):
+    """Axes the caller did not supply short-circuit to ``None`` at the
+    envelope level."""
+    out = ent.min_tier_for_all_breakdown(features=["fleet"])
+    assert out["axes"]["runtimes"] is None
+    assert out["axes"]["channels"] is None
+    assert out["axes"]["retention_days"] is None
+    assert out["axes"]["nodes"] is None
+
+
+# ── grace / enforce invariance ─────────────────────────────────────────────
+
+
+def test_grace_vs_enforce_yields_identical_breakdown(monkeypatch, tmp_path):
+    """Decoupled from the resolved entitlement: reloading with
+    ``CLAWMETRY_ENFORCE=1`` MUST produce byte-identical output for the
+    same bundle."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    grace = e.min_tier_for_all_breakdown(
+        features=["fleet"], runtimes=["claude_code"], channels=5
+    )
+
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    importlib.reload(e)
+    e.invalidate()
+    enforced = e.min_tier_for_all_breakdown(
+        features=["fleet"], runtimes=["claude_code"], channels=5
+    )
+    assert grace == enforced
+
+
+# ── never-raise contract ───────────────────────────────────────────────────
+
+
+def test_never_raises_on_garbage(ent):
+    """Every bad-input shape must fall through to the null-floor envelope
+    rather than 500-ing / raising."""
+    for bad in (
+        {"features": object()},
+        {"runtimes": 42},
+        {"channels": {"nope": "dict"}},
+        {"retention_days": ["not", "int"]},
+        {"nodes": None},
+    ):
+        out = ent.min_tier_for_all_breakdown(**bad)
+        assert isinstance(out, dict)
+        assert "axes" in out
+        assert "binding_axes" in out
+
+
+# ── HTTP endpoint ──────────────────────────────────────────────────────────
+
+
+def test_endpoint_400_on_no_args(client):
+    resp = client.get("/api/entitlement/required-tier-breakdown")
+    assert resp.status_code == 400
+    body = resp.get_json()
+    assert "error" in body
+
+
+def test_endpoint_features_only_returns_shape(ent, client):
+    resp = client.get(
+        "/api/entitlement/required-tier-breakdown?features=fleet"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    # Top-level shape mirrors /required-tier-batch
+    for k in (
+        "features",
+        "runtimes",
+        "channels",
+        "retention_days",
+        "nodes",
+        "required_tier",
+        "required_tier_label",
+        "required_tier_rank",
+        "current_tier",
+        "current_tier_rank",
+        "upgrade_required",
+    ):
+        assert k in body, f"missing key {k}"
+    # Breakdown-specific fields
+    assert "axes" in body and isinstance(body["axes"], dict)
+    assert "binding_axes" in body
+    assert body["required_tier"] == ent.min_tier_for_all(features=["fleet"])
+    assert "features" in body["binding_axes"]
+
+
+def test_endpoint_mixed_bundle_matches_helper(ent, client):
+    resp = client.get(
+        "/api/entitlement/required-tier-breakdown"
+        "?features=fleet&runtimes=claude_code&channels=8"
+        "&retention_days=30&nodes=2"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    expected = ent.min_tier_for_all_breakdown(
+        features=["fleet"],
+        runtimes=["claude_code"],
+        channels=8,
+        retention_days=30,
+        nodes=2,
+    )
+    assert body["required_tier"] == expected["min_tier"]
+    assert body["required_tier_label"] == expected["min_tier_label"]
+    assert body["binding_axes"] == expected["binding_axes"]
+    assert body["axes"] == expected["axes"]
+
+
+def test_endpoint_bad_capacity_value_still_200(ent, client):
+    """Non-int capacity value doesn't 400 -- it contributes nothing to
+    the floor (matches ``/required-tier`` never-crash posture)."""
+    resp = client.get(
+        "/api/entitlement/required-tier-breakdown?features=fleet&channels=five"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["channels"] is None  # unparseable -> not echoed
+    # features axis still binds
+    assert "features" in body["binding_axes"]
+
+
+def test_endpoint_unknown_feature_returns_null_floor(client):
+    resp = client.get(
+        "/api/entitlement/required-tier-breakdown?features=bogus"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["required_tier"] is None
+    assert body["required_tier_rank"] == -1
+    assert body["upgrade_required"] is False
+    assert body["binding_axes"] == []
+
+
+def test_endpoint_upgrade_required_flag(ent, client):
+    """When the aggregate floor exceeds the resolved tier, the endpoint
+    reports ``upgrade_required=True``."""
+    resp = client.get(
+        "/api/entitlement/required-tier-breakdown?features=sso"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    required_rank = body["required_tier_rank"]
+    current_rank = body["current_tier_rank"]
+    assert body["upgrade_required"] == (required_rank > current_rank)


### PR DESCRIPTION
## Summary

Adds a per-axis breakdown companion to `min_tier_for_all` so a paywall CTA can render "You need Pro *because* you have 8 channels (Starter caps at 5)" from a single round-trip instead of five singular `/required-tier` calls plus client-side max-by-rank.

`min_tier_for_all` collapses the answer to one `min_tier` id; the new `min_tier_for_all_breakdown` additionally exposes each axis' individual `min_tier` and calls out which axis (or axes, on a tie) is *binding* the aggregate floor.

## Changes

- **`clawmetry/entitlements.py`** — add `min_tier_for_all_breakdown(*, features, runtimes, channels, retention_days, nodes)`.
  - Same input semantics as `min_tier_for_all` (five-axis kwargs, per-axis `None` "not supplied" sentinel, `retention_days=None` means *unset* not *unlimited*, never-raise contract).
  - Response carries the aggregate floor (`min_tier` / `min_tier_label` / `min_tier_rank`), a per-axis row per supplied kwarg (`kind` / `supplied` / `items`|`value` / `min_tier` / `min_tier_label` / `min_tier_rank` / `binding`), and a `binding_axes` list in envelope order (`features` → `nodes`).
  - Decoupled from the resolved entitlement (walks the static per-tier caps via the singular `min_tier_for_*` helpers) so grace vs enforce yields byte-identical output.

- **`routes/entitlement.py`** — add `GET /api/entitlement/required-tier-breakdown` wrapping the helper.
  - Same arg parsing as `/required-tier-batch` (`features=csv`, `runtimes=csv`, `channels=int`, `retention_days=int`, `nodes=int`); at least one required or 400.
  - Response mirrors `/required-tier-batch` (`required_tier` / `current_tier` / `upgrade_required` / echoed inputs) so a caller migrating from the batch endpoint can adopt the breakdown without reshaping its main paywall payload. `axes` and `binding_axes` sit alongside.
  - Never 5xxs — OSS-floor fallback shape on any resolver failure (matches the sibling endpoint's posture).

- **`tests/test_entitlement_required_tier_breakdown.py`** — 25 tests (all passing locally) pinning:
  - Parity with `min_tier_for_all` across the five axes and mixed bundles.
  - Per-axis row shape (grant vs capacity rows, unsupplied axes short-circuit to `None`, aliases like `claude-code` canonicalise).
  - Binding-axis identification — single-axis dominance, multi-axis ties (in envelope order), and the null-floor case (`binding_axes == []`).
  - Grace vs enforce invariance (reload roundtrip yields byte-identical output).
  - Never-raise contract on garbage inputs (`object()`, `dict`, `42`, etc.).
  - HTTP envelope — 400 on no args, 200 on unknown feature (null floor), `upgrade_required` semantics, bad-capacity-value handling.

No behaviour change to any existing helper or endpoint. The 323-test suite covering `min_tier`, `min_tier_batch`, `affordable_tiers`, `required_tier_*`, and `entitlement_api` still passes locally.

## Test plan

- [x] `python -m py_compile clawmetry/entitlements.py routes/entitlement.py`
- [x] `python -m pytest tests/test_entitlement_required_tier_breakdown.py -x -q` → 25 passed
- [x] Sibling suites still green: `tests/test_entitlement_min_tier*.py`, `tests/test_entitlement_required_tier*.py`, `tests/test_entitlement_affordable_tiers*.py`, `tests/test_entitlement_api.py` → 323 passed
- [ ] CI green on the PR

## Local operator verification checklist

Since this session runs remotely with no access to the local daemon, `~/.openclaw`, or the live cloud snapshot, the operator needs to walk the trial path:

1. `cp clawmetry/entitlements.py routes/entitlement.py ~/.clawmetry/lib/python*/site-packages/clawmetry/` (adjust for your daemon install layout).
2. `find ~/.clawmetry -name __pycache__ -exec rm -rf {} +`
3. `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` (macOS) or the equivalent systemd/service reload on your host.
4. Hit the new endpoint and diff against the sibling:
   ```
   curl -s "http://localhost:8900/api/entitlement/required-tier-breakdown?features=fleet&runtimes=claude_code&channels=8&retention_days=30&nodes=2" | jq .
   curl -s "http://localhost:8900/api/entitlement/required-tier-batch?features=fleet&runtimes=claude_code&channels=8&retention_days=30&nodes=2" | jq .
   ```
   `required_tier` / `required_tier_label` / `required_tier_rank` / `current_tier` / `current_tier_rank` / `upgrade_required` should match byte-for-byte; the breakdown additionally carries `axes` and `binding_axes`.
5. Decrypt the live cloud snapshot to confirm no snapshot schema changed (the helper is stateless — this is a smoke-check for the operator's peace of mind).
6. Browser-check `app.clawmetry.com` on a trial: no card should render blank as a result of this change (there is no new frontend consumer yet — this is server-side only).

Keep this PR **DRAFT** until the above is walked; do not release.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HG9fTsvYSYRSW7ZJVirp6N)_