### PR TITLE
[RELEASE] Brain type-count chips follow the runtime switcher

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -4781,6 +4781,15 @@ function renderBrainFilterChips(sources) {
 function renderBrainTypeChips(events) {
   var container = document.getElementById('brain-type-chips');
   if (!container || !events) return;
+  // Scope the counts to the header's runtime selection, exactly like the
+  // list (renderBrainStream) and chart (renderBrainChart) do. Node-wide
+  // counts over a runtime-scoped list read as a bug: a ?runtime=cursor tab
+  // showed "AGENT (84)" chips over a 1-row stream because the 84 were
+  // another runtime's events (live-hit 2026-07-25).
+  var _tcRt = (typeof _cmRuntimeFilter === 'function') ? _cmClientFilterRt(_cmRuntimeFilter()) : 'all';
+  if (_tcRt && _tcRt !== 'all' && typeof _cmRuntimeOf === 'function') {
+    events = events.filter(function(ev) { return _cmRuntimeOf(ev) === _tcRt; });
+  }
   var typeColors = {'USER':'#60a5fa','AGENT':'#a855f7','EXEC':'#f59e0b','THINK':'#94a3b8','TOOL':'#f97316','WRITE':'#10b981','SEARCH':'#06b6d4','BROWSER':'#ec4899','SPAWN':'#8b5cf6','MSG':'#22c55e','READ':'#6ee7b7','CONTEXT':'#64748b','RESULT':'#6ee7b7'};
   var typeCounts = {};
   events.forEach(function(ev) { typeCounts[ev.type] = (typeCounts[ev.type]||0) + 1; });

--- a/tests/test_brain_type_chips_scope.js
+++ b/tests/test_brain_type_chips_scope.js
@@ -1,0 +1,93 @@
+// renderBrainTypeChips must count only the selected runtime's events.
+//
+// The Brain LIST (renderBrainStream) and CHART (renderBrainChart) scope to
+// the header's runtime switcher, but the type-count chips counted the whole
+// node-wide event array. On a ?runtime=cursor tab whose window held mostly
+// Claude Code events, the user saw "AGENT (84)" chips above a 1-row stream
+// (live-hit 2026-07-25) — counts that contradict the list they label.
+//
+// Extraction pattern mirrors test_brain_time_range.js: pull the shipped
+// function out of app.js via regex + vm so the test tracks the real source.
+
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const APP_JS = path.join(__dirname, '..', 'clawmetry', 'static', 'js', 'app.js');
+const src = fs.readFileSync(APP_JS, 'utf8');
+
+let passed = 0;
+let failed = 0;
+
+function truthy(v, label) {
+  if (v) { passed++; console.log('  ok   ' + label); }
+  else { failed++; console.log('  FAIL ' + label + ' (got falsy)'); }
+}
+
+function extractFunction(name) {
+  const re = new RegExp('^function ' + name + '\\b[\\s\\S]*?^\\}', 'm');
+  const m = src.match(re);
+  if (!m) throw new Error('could not find function ' + name + ' in app.js');
+  return m[0];
+}
+
+function chipsHtmlFor(runtimeFilter, events) {
+  const container = { innerHTML: '' };
+  const sandbox = {
+    document: { getElementById: (id) => (id === 'brain-type-chips' ? container : null) },
+    _brainTypeFilter: 'all',
+    // Header switcher state + the same helpers the list/chart use.
+    _cmRuntimeFilter: () => runtimeFilter,
+    _cmClientFilterRt: (rt) => rt,
+    _cmRuntimeOf: (ev) => ev.runtime || 'openclaw',
+    console,
+  };
+  vm.createContext(sandbox);
+  vm.runInContext(extractFunction('renderBrainTypeChips'), sandbox);
+  vm.runInContext(
+    'renderBrainTypeChips(' + JSON.stringify(events) + ')', sandbox);
+  return container.innerHTML;
+}
+
+const MIXED = [
+  { type: 'AGENT', runtime: 'claude_code' },
+  { type: 'AGENT', runtime: 'claude_code' },
+  { type: 'EXEC',  runtime: 'claude_code' },
+  { type: 'USER',  runtime: 'cursor' },
+  { type: 'AGENT', runtime: 'cursor' },
+];
+
+{
+  const html = chipsHtmlFor('cursor', MIXED);
+  truthy(html.indexOf('USER (1)') >= 0,
+         'cursor scope: USER counts only cursor events');
+  truthy(html.indexOf('AGENT (1)') >= 0,
+         'cursor scope: AGENT count excludes claude_code AGENT rows');
+  truthy(html.indexOf('EXEC') < 0,
+         'cursor scope: other-runtime-only types disappear');
+}
+
+{
+  const html = chipsHtmlFor('all', MIXED);
+  truthy(html.indexOf('AGENT (3)') >= 0, 'all scope: node-wide AGENT count kept');
+  truthy(html.indexOf('EXEC (1)') >= 0, 'all scope: EXEC chip present');
+}
+
+{
+  // Helpers absent (old embeds, race at parse time): degrade to node-wide.
+  const container = { innerHTML: '' };
+  const sandbox = {
+    document: { getElementById: () => container },
+    _brainTypeFilter: 'all',
+    console,
+  };
+  vm.createContext(sandbox);
+  vm.runInContext(extractFunction('renderBrainTypeChips'), sandbox);
+  vm.runInContext('renderBrainTypeChips(' + JSON.stringify(MIXED) + ')', sandbox);
+  truthy(container.innerHTML.indexOf('AGENT (3)') >= 0,
+         'no helpers: falls back to unscoped counts, never throws');
+}
+
+console.log('');
+console.log('PASS ' + passed + ' / FAIL ' + failed);
+process.exit(failed === 0 ? 0 : 1);

--- a/tests/test_brain_type_chips_scope_js.py
+++ b/tests/test_brain_type_chips_scope_js.py
@@ -1,0 +1,37 @@
+"""Runner for the Node-based Brain type-chip runtime-scope unit tests.
+
+``tests/test_brain_type_chips_scope.js`` extracts ``renderBrainTypeChips``
+from the shipped app.js (vm + regex, same pattern as test_brain_time_range)
+and asserts the chip counts follow the header runtime switcher the same way
+the list and chart do — node-wide counts over a runtime-scoped stream read
+as a bug ("AGENT (84)" above a 1-row cursor feed, live-hit 2026-07-25).
+
+Skipped (not failed) when ``node`` is not on PATH.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+
+import pytest
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_JS_TEST = os.path.join(_HERE, "test_brain_type_chips_scope.js")
+
+
+@pytest.mark.skipif(
+    shutil.which("node") is None,
+    reason="node not on PATH; JS unit tests only run when Node is available",
+)
+def test_brain_type_chips_scope_js_suite() -> None:
+    proc = subprocess.run(
+        ["node", _JS_TEST],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert proc.returncode == 0, (
+        "JS suite failed:\n" + proc.stdout + "\n" + proc.stderr
+    )


### PR DESCRIPTION
The Brain list and chart scope to the header runtime switcher; the type-count chips didn't, so a `?runtime=cursor` tab showed another runtime's counts above a scoped stream (live-hit 2026-07-25: 'AGENT (84)' over a 1-row feed). Chips now use the same `_cmClientFilterRt`/`_cmRuntimeOf` scoping, with a node-wide fallback when the helpers are absent. Node-based unit suite included (extraction pattern of test_brain_time_range.js).

Release carrier: fleet daemons restart on this update, which also activates the already-published clawmetry-pro 0.4.4 (Cursor Agent-transcript source) on running nodes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)