### PR TITLE
fix(c6): wire C6 notification workflows to tracking issue #4029

### DIFF
--- a/.github/workflows/apply-required-checks.yml
+++ b/.github/workflows/apply-required-checks.yml
@@ -18,7 +18,7 @@ name: Apply required E2E status checks (C6 -- one-shot)
 #     With only GITHUB_TOKEN (ghs_): read-only verify path in the script
 #     (exits 0 if C6 configured, exits 1 if not -- no admin rights needed).
 #     With E2E_ADMIN_PAT: full apply + verify.
-#     On failure, posts a notification comment on tracking issue #3970.
+#     On failure, posts a notification comment on tracking issue #4029.
 #
 # TOKEN PATHS (priority order):
 #   1. inputs.pat_token  -- PAT typed into the Run workflow dialog
@@ -37,7 +37,7 @@ name: Apply required E2E status checks (C6 -- one-shot)
 #   clawmetry-landing.
 #
 # Idempotent: running multiple times is safe.
-# Tracking: vivekchand/clawmetry#3970
+# Tracking: vivekchand/clawmetry#4029
 
 on:
   workflow_dispatch:
@@ -119,7 +119,7 @@ jobs:
         run: python3 scripts/apply_required_status_checks.py
 
       # When the C6 read-only verify exits 1 (checks not yet configured on main),
-      # post or update a comment on the E2E Robustness tracking issue #3970 so the
+      # post or update a comment on the E2E Robustness tracking issue #4029 so the
       # repo admin receives a GitHub notification.
       #
       # Only fires on push-to-main (the automated verify path), NOT on manual
@@ -161,15 +161,15 @@ jobs:
 
           # Upsert: update existing comment if present, otherwise create new.
           existing_id=$(gh api -X GET \
-            "repos/${REPO}/issues/3970/comments" \
+            "repos/${REPO}/issues/4029/comments" \
             --jq 'map(select(.body | startswith("<!-- c6-notify-bot -->"))) | .[0].id // empty' \
             2>/dev/null || echo "")
           if [ -n "${existing_id}" ]; then
             gh api -X PATCH "repos/${REPO}/issues/comments/${existing_id}" \
               -f body="${BODY}" > /dev/null
-            echo "Updated existing C6 notification on #3970 (comment ${existing_id})"
+            echo "Updated existing C6 notification on #4029 (comment ${existing_id})"
           else
-            gh api -X POST "repos/${REPO}/issues/3970/comments" \
+            gh api -X POST "repos/${REPO}/issues/4029/comments" \
               -f body="${BODY}" > /dev/null
-            echo "Posted new C6 notification on #3970"
+            echo "Posted new C6 notification on #4029"
           fi

--- a/.github/workflows/c6-health.yml
+++ b/.github/workflows/c6-health.yml
@@ -9,7 +9,7 @@ name: C6 daily health check (branch-protection audit -- all 3 repos)
 # used cross-repo (returns 403 even on public repos); unauthenticated
 # reads return the full protection.required_status_checks object.
 #
-# On failure: posts an @-mentioned reminder to tracking issue #3970
+# On failure: posts an @-mentioned reminder to tracking issue #4029
 # at most once per calendar day. On success: posts a GREEN confirmation.
 #
 # To close C6:
@@ -19,7 +19,7 @@ name: C6 daily health check (branch-protection audit -- all 3 repos)
 #   2. Or: bash scripts/close-c6.sh
 #   3. Or: Settings > Branches > main > Required status checks (each repo)
 #
-# Tracking: vivekchand/clawmetry#3970
+# Tracking: vivekchand/clawmetry#4029
 
 on:
   schedule:
@@ -49,7 +49,7 @@ jobs:
 
           TOKEN = os.environ["GITHUB_TOKEN"]
           OWNER = "vivekchand"
-          TRACKING_ISSUE = 3970
+          TRACKING_ISSUE = 4029
           MARKER = "<!-- c6-health-check -->"
           # Repo this workflow runs in. Cross-repo reads must NOT send the
           # scoped GITHUB_TOKEN: Actions tokens are repo-scoped and return 403

--- a/.github/workflows/c6-pr-gate.yml
+++ b/.github/workflows/c6-pr-gate.yml
@@ -3,7 +3,7 @@ name: C6 Required-status-checks gate (PR audit)
 # Runs on every pull request to surface whether C6 (required-status-checks)
 # is configured on main. Fails visibly on every PR until the admin closes C6.
 #
-# The daily c6-health.yml posts to issue #3970 but the admin may not check
+# The daily c6-health.yml posts to issue #4029 but the admin may not check
 # that issue between merges. This check appears directly in the PR status
 # list alongside OSS golden path, E2E Browser Tests, etc. -- impossible to
 # miss when reviewing a PR.
@@ -38,7 +38,7 @@ name: C6 Required-status-checks gate (PR audit)
 #     bash scripts/close-c6.sh
 #     (uses your existing gh CLI session -- no PAT creation needed)
 #
-# Tracking: vivekchand/clawmetry#3970 (C6)
+# Tracking: vivekchand/clawmetry#4029 (C6)
 
 on:
   pull_request:
@@ -112,7 +112,7 @@ jobs:
           [Apply required E2E status checks (C6)](https://github.com/vivekchand/clawmetry/actions/workflows/apply-required-checks.yml)
           -- confirm=APPLY, pat_token=paste-token-here
 
-          _C6 is the sole remaining criterion of the E2E Robustness epic. All other 6 criteria (C1 OSS golden path, C2 Cloud golden path, C3 Landing, C4 Cross-repo handoff, C5 Visual diff all tabs, C7 Quarantine) are green. Tracking: [#3970](https://github.com/vivekchand/clawmetry/issues/3970)_"
+          _C6 is the sole remaining criterion of the E2E Robustness epic. All other 6 criteria (C1 OSS golden path, C2 Cloud golden path, C3 Landing, C4 Cross-repo handoff, C5 Visual diff all tabs, C7 Quarantine) are green. Tracking: [#4029](https://github.com/vivekchand/clawmetry/issues/4029)_"
 
           existing_id=$(gh api -X GET \
             "repos/${REPO}/issues/${PR}/comments" \

--- a/.github/workflows/c6-schedule-heal.yml
+++ b/.github/workflows/c6-schedule-heal.yml
@@ -23,7 +23,7 @@ name: C6 auto-heal (daily required-checks application)
 #     clawmetry, clawmetry-cloud, clawmetry-landing
 #   This workflow picks it up at 10:15am UTC and closes C6 automatically.
 #
-# Tracking: vivekchand/clawmetry#3970
+# Tracking: vivekchand/clawmetry#4029
 
 on:
   schedule:
@@ -162,7 +162,7 @@ except Exception:
               echo "bash scripts/close-c6.sh"
               echo "\`\`\`"
               echo ""
-              echo "Tracking: [#3970](https://github.com/vivekchand/clawmetry/issues/3970)"
+              echo "Tracking: [#4029](https://github.com/vivekchand/clawmetry/issues/4029)"
             fi
           } >> "$GITHUB_STEP_SUMMARY"
 
@@ -173,7 +173,7 @@ except Exception:
           echo ""
           echo "ACTION REQUIRED: Add E2E_ADMIN_PAT to close C6."
           echo "See the job summary above for a formatted status report and close options."
-          echo "Tracking: https://github.com/vivekchand/clawmetry/issues/3970"
+          echo "Tracking: https://github.com/vivekchand/clawmetry/issues/4029"
           exit 1
 
       - name: Apply required E2E status checks (C6)
@@ -196,7 +196,7 @@ except Exception:
             echo "- [clawmetry-cloud branch protection](https://github.com/vivekchand/clawmetry-cloud/settings/branches)"
             echo "- [clawmetry-landing branch protection](https://github.com/vivekchand/clawmetry-landing/settings/branches)"
             echo ""
-            echo "Tracking: [#3970](https://github.com/vivekchand/clawmetry/issues/3970)"
+            echo "Tracking: [#4029](https://github.com/vivekchand/clawmetry/issues/4029)"
           } >> "$GITHUB_STEP_SUMMARY"
           echo "C6 auto-heal complete. If apply_required_status_checks.py exited 0, branch protection"
-          echo "is configured on all 3 repos. Tracking: https://github.com/vivekchand/clawmetry/issues/3970"
+          echo "is configured on all 3 repos. Tracking: https://github.com/vivekchand/clawmetry/issues/4029"


### PR DESCRIPTION
## Summary

All four C6 notification workflows were posting @-mentions, daily health checks, and PR gate comments to stale issue **#3970** instead of the canonical E2E Robustness tracking issue **#4029**. This silently fragmented the C6 close signal — admins following up on #4029 never saw the daily status updates.

## Changes

| File | What changed |
|------|-------------|
| `.github/workflows/c6-health.yml` | `TRACKING_ISSUE = 3970` → `4029`; header comment updated |
| `.github/workflows/apply-required-checks.yml` | Two `issues/3970/comments` API paths → `4029`; echo messages updated; header updated |
| `.github/workflows/c6-pr-gate.yml` | PR comment body link `#3970` → `#4029`; header comments updated |
| `.github/workflows/c6-schedule-heal.yml` | Summary output links and echo statements `3970` → `4029` (multiple occurrences) |

## Why this matters

C6 requires all three repos to have required status checks enforced so PRs cannot merge without E2E passing. Until an admin sets `E2E_ADMIN_PAT` or configures branch protection manually, the C6 workflows are the primary communication channel reminding the admin to act. With stale issue refs, those reminders were invisible on the tracking thread.

## Test plan

- [ ] Merge this PR
- [ ] Verify next daily `c6-health.yml` run posts to #4029, not #3970
- [ ] Verify next PR on the repo shows C6 gate comment linking to #4029
- [ ] Verify `c6-schedule-heal.yml` summary output references #4029

---
_Generated by [Claude Code](https://claude.ai/code/session_01GUQ7uonC8xeFJATH3ShMJi)_