### PR TITLE
[RELEASE] fix(hooks): tell the truth about timeout-denials

### DIFF
--- a/clawmetry/hooks_claude_code.py
+++ b/clawmetry/hooks_claude_code.py
@@ -218,17 +218,33 @@ def evaluate(event: dict) -> "dict | None":
         )
         decision = (result or {}).get("decision") or ""
         pol = (result or {}).get("policy") or "policy"
-        # on_timeout mapping leaves raw "deny"/"approve" strings — accept both.
-        if decision in ("denied", "deny"):
+        # process_tool_call returns "denied"/"approved" for HUMAN decisions
+        # but the raw on_timeout strings "deny"/"approve" when the window
+        # lapsed — the distinction matters: telling the model (and the log)
+        # "the human declined" when nobody answered erodes trust in the
+        # whole gate (live confusion, 2026-07-26).
+        if decision == "denied":
             return _deny_payload(
                 f"Denied via ClawMetry approvals (policy '{pol}'). The human "
                 "declined this specific call — pick a different approach or "
                 "ask them what they'd prefer."
             )
-        if decision in ("approved", "approve"):
+        if decision == "deny":
+            return _deny_payload(
+                f"ClawMetry approval timed out with no decision (policy "
+                f"'{pol}', on_timeout: deny). The human never saw or didn't "
+                "reach it in time — worth asking them directly, or they can "
+                "raise this policy's timeout in the Approvals tab."
+            )
+        if decision == "approved":
             return _allow_payload(
                 f"Approved by the human via ClawMetry approvals "
                 f"(policy '{pol}')."
+            )
+        if decision == "approve":
+            return _allow_payload(
+                f"ClawMetry approval timed out (policy '{pol}', on_timeout: "
+                "approve) — proceeding per the policy's timeout action."
             )
         # monitored / no_policy / error / anything unexpected → no opinion
         return None

--- a/tests/test_hooks_claude_code.py
+++ b/tests/test_hooks_claude_code.py
@@ -102,6 +102,20 @@ def test_on_timeout_raw_strings_map_correctly(monkeypatch):
     assert h.evaluate(_evt())["decision"] == "approve"
 
 
+def test_timeout_deny_is_not_blamed_on_the_human(monkeypatch):
+    """A lapsed window must read as a timeout, not 'the human declined' —
+    live confusion 2026-07-26: user never saw the request, agent was told
+    a human said no."""
+    _wire(monkeypatch, "deny")
+    reason = h.evaluate(_evt())["reason"]
+    assert "timed out" in reason
+    assert "declined" not in reason
+    _wire(monkeypatch, "denied")
+    reason = h.evaluate(_evt())["reason"]
+    assert "declined" in reason
+    assert "timed out" not in reason
+
+
 def test_error_and_monitored_have_no_opinion(monkeypatch):
     for decision in ("error", "monitored", "no_policy"):
         _wire(monkeypatch, decision)


### PR DESCRIPTION
The PreToolUse gate blamed the human for timeout auto-denials ('The human declined…' when nobody answered). Distinct messages for human-deny vs timeout-deny vs timeout-approve, with a pointer to raise the policy timeout. +2 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)