### PR TITLE
fix(license): /activate + /deactivate shape parity across all branches

### DIFF
--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -8217,21 +8217,53 @@ def _route_actor() -> str:
         return ""
 
 
+def _activate_envelope(ok, message, error=None):
+    """Full-shape envelope for ``/api/license/activate``.
+
+    Every branch (missing-key, healthy-success, healthy-failure,
+    introspection-exception) carries the SAME field set so a UI can
+    render `data.ok` + `data.message` uniformly without special-casing
+    which keys are present. ``error`` is populated on the two failure
+    branches for back-compat with the pre-shape-parity consumers that
+    read `data.error`; healthy branches leave it ``None``. Mirrors the
+    parity contract PR #4047 landed for ``/status`` + ``/verify``.
+    """
+    return {"ok": bool(ok), "message": str(message), "error": error}
+
+
 @bp_entitlement.route("/api/license/activate", methods=["POST"])
 def api_license_activate():
+    """``POST /api/license/activate`` -- install a signed license key.
+
+    Shape parity across all four branches (missing-key / healthy-success /
+    healthy-failure / introspection-exception): every branch populates
+    ``{ok, message, error}`` so a UI can bind to ``data.message`` without
+    checking whether it's the missing-key branch (which used to only
+    populate ``error``) or the exception branch (which used to only
+    populate ``error``). ``error`` is a back-compat alias populated on
+    the two failure branches -- pre-parity consumers reading
+    ``data.error`` keep working unchanged.
+
+    Still 4xx / 5xx on the failure branches -- this is a POST mutation
+    and the client legitimately needs to know the write failed. The
+    healthy-failure branch (bad/expired/duplicate-node key) stays 400;
+    the introspection-exception branch (import failure, corrupt install)
+    stays 500. Only the SHAPE of the failure body changes -- the status
+    codes match what shipped before this PR.
+    """
     try:
         body = request.get_json(silent=True) or {}
         key = str(body.get("key", "")).strip()
         if not key:
-            return jsonify({"ok": False, "error": "key is required"}), 400
+            return jsonify(_activate_envelope(False, "key is required", error="key is required")), 400
         from clawmetry import license as _lic
 
         ok, msg = _lic.activate(key, actor=_route_actor())
         status_code = 200 if ok else 400
-        return jsonify({"ok": ok, "message": msg}), status_code
+        return jsonify(_activate_envelope(ok, msg, error=None if ok else msg)), status_code
     except Exception as exc:
         logger.warning("api_license_activate: error: %s", exc)
-        return jsonify({"ok": False, "error": str(exc)}), 500
+        return jsonify(_activate_envelope(False, str(exc), error=str(exc))), 500
 
 
 @bp_entitlement.route("/api/license/verify", methods=["POST"])
@@ -8298,18 +8330,55 @@ def api_license_verify():
         return jsonify(_dry_run_envelope("invalid", {"error": str(exc)}))
 
 
+def _deactivate_envelope(ok, removed, message="", error=None):
+    """Full-shape envelope for ``/api/license/deactivate``.
+
+    Every branch (healthy-noop, healthy-removed, remove-failed,
+    introspection-exception) carries ``{ok, removed, message, error}``
+    so a UI can bind to ``data.removed`` uniformly without checking
+    whether it's the exception branch (which used to drop the field
+    entirely). ``message`` is populated on every branch; ``error`` is
+    populated only on the two failure branches for back-compat.
+    """
+    return {
+        "ok": bool(ok),
+        "removed": bool(removed),
+        "message": str(message),
+        "error": error,
+    }
+
+
 @bp_entitlement.route("/api/license/deactivate", methods=["POST"])
 def api_license_deactivate():
+    """``POST /api/license/deactivate`` -- remove the on-disk license file.
+
+    Shape parity across all four branches (healthy-noop / healthy-removed /
+    remove-failed / introspection-exception): every branch populates
+    ``{ok, removed, message, error}``. ``removed`` no longer disappears
+    on the exception branch, so a UI can bind to ``data.removed`` without
+    a guard. ``error`` is a back-compat alias populated on the two
+    failure branches -- the pre-parity remove-failed shape already
+    carried ``error="remove_failed"`` and that string is preserved.
+
+    Still 5xx on the two failure branches -- deactivation is a mutation
+    and the client legitimately needs to know disk removal or module
+    import failed. Only the SHAPE of the failure body changes.
+    """
     try:
         from clawmetry import license as _lic
 
         ok, removed = _lic.deactivate(actor=_route_actor())
         if not ok:
-            return jsonify({"ok": False, "removed": False, "error": "remove_failed"}), 500
-        return jsonify({"ok": True, "removed": removed})
+            return jsonify(_deactivate_envelope(
+                False, False, message="remove_failed", error="remove_failed",
+            )), 500
+        message = "license file removed" if removed else "no license file to remove"
+        return jsonify(_deactivate_envelope(True, removed, message=message)), 200
     except Exception as exc:
         logger.warning("api_license_deactivate: error: %s", exc)
-        return jsonify({"ok": False, "error": str(exc)}), 500
+        return jsonify(_deactivate_envelope(
+            False, False, message=str(exc), error=str(exc),
+        )), 500
 
 
 @bp_entitlement.route("/api/entitlement/next-tier-unlocks-at")

--- a/tests/test_license_api.py
+++ b/tests/test_license_api.py
@@ -214,6 +214,104 @@ def test_activate_expired_key(app):
     assert resp.get_json()["ok"] is False
 
 
+# The activate-branch shape-parity contract: every branch of the endpoint
+# (missing-key / healthy-success / healthy-failure / introspection-exception)
+# populates the SAME field set so a UI can bind to ``data.message`` uniformly
+# without checking whether it's the missing-key branch (which used to only
+# populate ``error``) or the exception branch (which used to only populate
+# ``error``). Mirrors the parity contract PR #4047 landed for ``/status`` +
+# ``/verify``.
+_ACTIVATE_SHAPE_KEYS = {"ok", "message", "error"}
+
+
+def test_activate_missing_key_carries_full_shape(app):
+    """The missing-key branch used to return only ``{ok, error}``. It now
+    populates ``message`` too so a UI reading ``data.message`` never sees
+    undefined on the 400 branch."""
+    with app.app.test_client() as c:
+        resp = c.post(
+            "/api/license/activate",
+            data=json.dumps({}),
+            content_type="application/json",
+        )
+    assert resp.status_code == 400
+    data = resp.get_json()
+    missing = _ACTIVATE_SHAPE_KEYS - set(data)
+    assert not missing, f"missing-key branch missing keys: {missing}"
+    assert data["ok"] is False
+    assert data["message"] == "key is required"
+    # error stays populated for back-compat with pre-parity consumers.
+    assert data["error"] == "key is required"
+
+
+def test_activate_healthy_success_carries_full_shape_error_none(app):
+    """The healthy-success branch used to return ``{ok, message}`` -- it now
+    also populates ``error: None`` for shape parity with the failure branches,
+    so a UI can bind to ``data.error`` uniformly."""
+    tok = app.lic._encode_token(_payload("pro", nodes=2), app.priv)
+    with app.app.test_client() as c:
+        resp = c.post(
+            "/api/license/activate",
+            data=json.dumps({"key": tok}),
+            content_type="application/json",
+        )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    missing = _ACTIVATE_SHAPE_KEYS - set(data)
+    assert not missing, f"healthy-success branch missing keys: {missing}"
+    assert data["ok"] is True
+    assert "pro" in data["message"].lower()
+    assert data["error"] is None
+
+
+def test_activate_healthy_failure_carries_full_shape(app):
+    """Bad/expired/duplicate key -> 400 with ``ok=False``. The shape
+    still carries ``{ok, message, error}`` so a UI can bind to
+    ``data.error`` for the alert channel and ``data.message`` for the
+    human-readable text."""
+    with app.app.test_client() as c:
+        resp = c.post(
+            "/api/license/activate",
+            data=json.dumps({"key": "CLAW1.not.real"}),
+            content_type="application/json",
+        )
+    assert resp.status_code == 400
+    data = resp.get_json()
+    missing = _ACTIVATE_SHAPE_KEYS - set(data)
+    assert not missing, f"healthy-failure branch missing keys: {missing}"
+    assert data["ok"] is False
+    assert data["message"]  # some human-readable reason
+    # error mirrors message on the failure branch for back-compat.
+    assert data["error"] == data["message"]
+
+
+def test_activate_introspection_failure_5xx_but_full_shape(app, monkeypatch):
+    """A broken activate call (import failure, corrupt install) still 5xxes --
+    this is a POST mutation and the client legitimately needs to know the
+    write failed -- but the body carries the full ``{ok, message, error}``
+    shape rather than dropping ``message`` like it used to."""
+    import clawmetry.license as _lic
+
+    def boom(*_args, **_kwargs):
+        raise RuntimeError("simulated activate failure")
+
+    monkeypatch.setattr(_lic, "activate", boom)
+    tok = app.lic._encode_token(_payload("pro", nodes=1), app.priv)
+    with app.app.test_client() as c:
+        resp = c.post(
+            "/api/license/activate",
+            data=json.dumps({"key": tok}),
+            content_type="application/json",
+        )
+    assert resp.status_code == 500
+    data = resp.get_json()
+    missing = _ACTIVATE_SHAPE_KEYS - set(data)
+    assert not missing, f"exception branch missing keys: {missing}"
+    assert data["ok"] is False
+    assert "simulated activate failure" in data["message"]
+    assert "simulated activate failure" in data["error"]
+
+
 # ── /api/license/verify (dry-run) ─────────────────────────────────────────────
 
 
@@ -362,6 +460,89 @@ def test_deactivate_idempotent_when_no_license(app):
     data = resp.get_json()
     assert data["ok"] is True
     assert data["removed"] is False
+
+
+# Same shape-parity contract as :data:`_ACTIVATE_SHAPE_KEYS`, extended with
+# the ``removed`` field that :func:`clawmetry.license.deactivate` returns.
+# Every branch (healthy-noop / healthy-removed / remove-failed /
+# introspection-exception) populates the same key set so a UI can bind to
+# ``data.removed`` without checking whether it's the exception branch (which
+# used to drop the field entirely).
+_DEACTIVATE_SHAPE_KEYS = {"ok", "removed", "message", "error"}
+
+
+def test_deactivate_healthy_noop_carries_full_shape(app):
+    """The idempotent no-op branch used to return ``{ok, removed}``. It now
+    also populates ``{message, error: None}`` for shape parity."""
+    with app.app.test_client() as c:
+        resp = c.post("/api/license/deactivate")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    missing = _DEACTIVATE_SHAPE_KEYS - set(data)
+    assert not missing, f"healthy-noop branch missing keys: {missing}"
+    assert data["ok"] is True
+    assert data["removed"] is False
+    assert data["message"]
+    assert data["error"] is None
+
+
+def test_deactivate_healthy_removed_carries_full_shape(app):
+    """The healthy-removed branch used to return ``{ok, removed}``. It now
+    also populates ``{message, error: None}`` for shape parity."""
+    tok = app.lic._encode_token(_payload(), app.priv)
+    app.lic.activate(tok)
+    with app.app.test_client() as c:
+        resp = c.post("/api/license/deactivate")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    missing = _DEACTIVATE_SHAPE_KEYS - set(data)
+    assert not missing, f"healthy-removed branch missing keys: {missing}"
+    assert data["ok"] is True
+    assert data["removed"] is True
+    assert data["message"]
+    assert data["error"] is None
+
+
+def test_deactivate_remove_failed_carries_full_shape(app, monkeypatch):
+    """A disk-error deactivate (``deactivate`` returns ``(False, False)``)
+    still 5xxes -- the client legitimately needs to know disk removal failed --
+    but the body carries the full ``{ok, removed, message, error}`` shape
+    with the pre-parity ``error="remove_failed"`` sentinel preserved."""
+    import clawmetry.license as _lic
+
+    monkeypatch.setattr(_lic, "deactivate", lambda actor="": (False, False))
+    with app.app.test_client() as c:
+        resp = c.post("/api/license/deactivate")
+    assert resp.status_code == 500
+    data = resp.get_json()
+    missing = _DEACTIVATE_SHAPE_KEYS - set(data)
+    assert not missing, f"remove-failed branch missing keys: {missing}"
+    assert data["ok"] is False
+    assert data["removed"] is False
+    assert data["error"] == "remove_failed"  # pre-parity sentinel preserved
+    assert data["message"] == "remove_failed"
+
+
+def test_deactivate_introspection_failure_5xx_but_full_shape(app, monkeypatch):
+    """A broken deactivate call (import failure, corrupt install) still
+    5xxes -- POST mutation, client needs to know -- but the body carries
+    the full shape including ``removed=False`` rather than dropping it."""
+    import clawmetry.license as _lic
+
+    def boom(*_args, **_kwargs):
+        raise RuntimeError("simulated deactivate failure")
+
+    monkeypatch.setattr(_lic, "deactivate", boom)
+    with app.app.test_client() as c:
+        resp = c.post("/api/license/deactivate")
+    assert resp.status_code == 500
+    data = resp.get_json()
+    missing = _DEACTIVATE_SHAPE_KEYS - set(data)
+    assert not missing, f"exception branch missing keys: {missing}"
+    assert data["ok"] is False
+    assert data["removed"] is False
+    assert "simulated deactivate failure" in data["message"]
+    assert "simulated deactivate failure" in data["error"]
 
 
 # ── /api/license audit producers ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- PR #4047 landed the never-5xx + full-shape envelope for the two READ license endpoints (`/api/license/status`, `/api/license/verify`). The two MUTATION endpoints still leaked shape drift on their failure branches, so a UI binding to a field guaranteed on one branch got `undefined` on another.
- `POST /api/license/activate` — the missing-key branch (400) returned only `{ok, error}`, dropping `message`; the introspection-exception branch (500) also dropped `message`. Now every branch (missing-key / healthy-success / healthy-failure / introspection-exception) carries `{ok, message, error}`.
- `POST /api/license/deactivate` — the introspection-exception branch (500) dropped `removed` entirely. Now every branch (healthy-noop / healthy-removed / remove-failed / introspection-exception) carries `{ok, removed, message, error}`.
- Status codes are unchanged — these are POST mutations and the client still needs 4xx/5xx to know the write failed. Only the SHAPE of the failure body changes.

### Envelope contract

| endpoint | fields on every branch |
|---|---|
| `POST /api/license/activate` | `{ok, message, error}` |
| `POST /api/license/deactivate` | `{ok, removed, message, error}` |

`error` is populated only on failure branches and preserves the pre-parity strings (`"key is required"`, `"remove_failed"`) so consumers reading `data.error` keep working unchanged. On healthy branches it is `None`, so a UI can bind to `data.error` uniformly without checking which branch it hit.

## Test plan

- [x] `python -m pytest tests/test_license_api.py -q` — **26 passed** (18 pre-existing + 8 new shape-parity tests, four per endpoint covering all four branches)
- [x] Broader focused sweep: `test_license*.py`, `test_cli_license_json.py`, `test_is_pro_user_license_branch.py`, `test_entitlement_api*.py` — **161 passed, 1 skipped**
- [x] `python -m py_compile routes/entitlement.py tests/test_license_api.py`
- [x] `ruff check routes/entitlement.py tests/test_license_api.py` — clean (the 213 pre-existing errors in `dashboard.py` / `clawmetry/` are outside this diff, matches PR #4047's scope note)

### Backward compatibility

- Existing tests asserting `resp.status_code == 400`, `data["ok"] is False`, `data["removed"] is True/False`, and `"pro" in data["message"].lower()` all still pass unchanged.
- The pre-parity `error` strings (`"key is required"`, `"remove_failed"`) are preserved on the branches that shipped them so any undocumented downstream consumer reading `data.error` keeps working.
- No frontend JS/HTML consumes these mutation endpoints today — verified by grep across `clawmetry/static/`, `clawmetry/templates/`, and `dashboard.py`.

### Local operator verification checklist

The remote sandbox can't touch `~/.clawmetry`, the running daemon, or a browser — the following are for the local operator to confirm before merge:

- [ ] Copy changed files into the installed package: `cp routes/entitlement.py ~/.clawmetry/lib/python*/site-packages/routes/ && cp tests/test_license_api.py ~/.clawmetry/lib/python*/site-packages/tests/`
- [ ] Clear cached bytecode: `find ~/.clawmetry -name __pycache__ -type d -exec rm -rf {} +`
- [ ] Restart the daemon: `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
- [ ] `curl -s -X POST http://localhost:8900/api/license/activate -H 'Content-Type: application/json' -d '{}' | jq` — should return `{"ok": false, "message": "key is required", "error": "key is required"}` at HTTP 400.
- [ ] `curl -s -X POST http://localhost:8900/api/license/activate -H 'Content-Type: application/json' -d '{"key":"CLAW1.not.real"}' | jq` — should return the same three-key envelope with `data.error == data.message` and HTTP 400.
- [ ] With no license installed: `curl -s -X POST http://localhost:8900/api/license/deactivate | jq` — should return `{"ok": true, "removed": false, "message": "no license file to remove", "error": null}` at HTTP 200.
- [ ] Decrypt the live cloud snapshot, browser-check the license/entitlement tile still renders (no shape regression) and that any Activate/Deactivate button paths still work.

---
_Generated by [Claude Code](https://claude.ai/code/session_01X6BBNr7ErqgTZADnGLavfB)_