### PR TITLE
fix(adapters): include rotation archives in _gateway_log_files() (#4056)

### DIFF
--- a/clawmetry/adapters/openclaw.py
+++ b/clawmetry/adapters/openclaw.py
@@ -28,9 +28,12 @@ logger = logging.getLogger("clawmetry.adapters.openclaw")
 
 # Named OpenClaw profiles write openclaw-{name}-YYYY-MM-DD.log alongside the
 # default-profile openclaw-YYYY-MM-DD.log.  Matching only the date-only form
-# prevents lexicographic sort from mis-selecting a named-profile log as
-# "the current log" and silently dropping default-profile gateway events.
-_DEFAULT_LOG_RE = re.compile(r"openclaw-\d{4}-\d{2}-\d{2}\.log$")
+# (plus an optional .N rotation suffix) prevents lexicographic sort from
+# mis-selecting a named-profile log as "the current log" and silently dropping
+# default-profile gateway events.  The (\.\d+)? group also matches rotation
+# archives like openclaw-YYYY-MM-DD.1.log so the newest-5 window includes
+# rotated history within the current day (closes #4056).
+_DEFAULT_LOG_RE = re.compile(r"openclaw-\d{4}-\d{2}-\d{2}(\.\d+)?\.log$")
 
 # NeMo Guardrails compact tool-catalog injects these three meta-tool names into
 # the JSONL transcript when NEMOCLAW_TOOL_CATALOG is active. They are guardrail

--- a/tests/test_obs_gap_openclaw_rotated_logs_4056.py
+++ b/tests/test_obs_gap_openclaw_rotated_logs_4056.py
@@ -1,0 +1,122 @@
+"""Tests for #4056 — rotated log archives (.N.log) included in _gateway_log_files().
+
+_DEFAULT_LOG_RE previously required the date to be immediately followed by
+'.log', so rotation archives like openclaw-2026-07-20.1.log were silently
+dropped.  The fix extends the regex with an optional '(\\.\\d+)?' group.
+
+Fingerprint: hgap-cd81abf74f-rotated
+"""
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from clawmetry.adapters.openclaw import _DEFAULT_LOG_RE, _gateway_log_files
+
+
+# ---------------------------------------------------------------------------
+# Regex unit tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("name", [
+    "openclaw-2026-07-20.log",
+    "openclaw-2026-07-20.1.log",
+    "openclaw-2026-07-20.2.log",
+    "openclaw-2026-07-20.5.log",
+    "openclaw-2025-01-01.log",
+    "openclaw-2025-01-01.3.log",
+])
+def test_regex_matches_valid_names(name):
+    assert _DEFAULT_LOG_RE.search(name), f"{name!r} should match"
+
+
+@pytest.mark.parametrize("name", [
+    "openclaw--2026-07-20.log",          # named profile (double-dash)
+    "openclaw-work-2026-07-20.log",      # named profile (name in path)
+    "openclaw-2026-07-20.log.gz",        # compressed
+    "openclaw-2026-07-20.abc.log",       # non-numeric suffix
+    "other-2026-07-20.log",              # wrong prefix
+])
+def test_regex_rejects_invalid_names(name):
+    assert not _DEFAULT_LOG_RE.search(name), f"{name!r} should not match"
+
+
+# ---------------------------------------------------------------------------
+# _gateway_log_files() integration tests
+# ---------------------------------------------------------------------------
+
+def _populate_dir(d, filenames):
+    """Create empty files in directory d; return sorted absolute paths."""
+    paths = []
+    for name in filenames:
+        p = d / name
+        p.write_text("", encoding="utf-8")
+        paths.append(str(p))
+    return sorted(paths)
+
+
+def test_rotation_archives_included(monkeypatch, tmp_path):
+    """Rotation archives appear in the result alongside the base log file."""
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    expected = _populate_dir(log_dir, [
+        "openclaw-2026-07-20.log",
+        "openclaw-2026-07-20.1.log",
+        "openclaw-2026-07-20.2.log",
+    ])
+
+    monkeypatch.setenv("CLAWMETRY_OPENCLAW_DIR", str(tmp_path))
+
+    result = _gateway_log_files()
+    assert sorted(result) == sorted(expected)
+
+
+def test_rotation_archives_capped_at_five(monkeypatch, tmp_path):
+    """Result is limited to the 5 lexicographically-last files."""
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    _populate_dir(log_dir, [
+        "openclaw-2026-07-19.log",
+        "openclaw-2026-07-20.log",
+        "openclaw-2026-07-20.1.log",
+        "openclaw-2026-07-20.2.log",
+        "openclaw-2026-07-20.3.log",
+        "openclaw-2026-07-20.4.log",
+        "openclaw-2026-07-20.5.log",
+    ])
+
+    monkeypatch.setenv("CLAWMETRY_OPENCLAW_DIR", str(tmp_path))
+
+    result = _gateway_log_files()
+    assert len(result) == 5
+
+
+def test_named_profile_logs_excluded(monkeypatch, tmp_path):
+    """Named-profile logs (double-dash) are never returned."""
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    _populate_dir(log_dir, [
+        "openclaw--work-2026-07-20.log",   # named profile — must be excluded
+        "openclaw-2026-07-20.log",          # default profile — must be included
+        "openclaw-2026-07-20.1.log",        # rotation archive — must be included
+    ])
+
+    monkeypatch.setenv("CLAWMETRY_OPENCLAW_DIR", str(tmp_path))
+
+    result = _gateway_log_files()
+    basenames = [os.path.basename(p) for p in result]
+    assert "openclaw--work-2026-07-20.log" not in basenames
+    assert "openclaw-2026-07-20.log" in basenames
+    assert "openclaw-2026-07-20.1.log" in basenames
+
+
+def test_no_logs_returns_empty(monkeypatch, tmp_path):
+    """Empty candidate directories → empty list, no exception."""
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+
+    monkeypatch.setenv("CLAWMETRY_OPENCLAW_DIR", str(tmp_path))
+
+    result = _gateway_log_files()
+    assert result == []


### PR DESCRIPTION
## Summary

`_DEFAULT_LOG_RE` in `clawmetry/adapters/openclaw.py` required the date segment to be immediately followed by `.log`, silently dropping rotation archives like `openclaw-2026-07-20.1.log` even though `_gateway_log_files()` promises a "newest-5" window. This PR extends the regex with an optional `(\.\d+)?` group so numbered rotation archives are included alongside the active log file.

## Changes

- `clawmetry/adapters/openclaw.py` — extend `_DEFAULT_LOG_RE` from `r"openclaw-\d{4}-\d{2}-\d{2}\.log$"` to `r"openclaw-\d{4}-\d{2}-\d{2}(\.\d+)?\.log$"`; update comment to reflect the intent
- `tests/test_obs_gap_openclaw_rotated_logs_4056.py` — 15 new unit tests: regex match/reject parametrized cases, and `_gateway_log_files()` integration tests covering archives included, cap-at-5, named-profile exclusion, and empty-dir fallback

## Test plan

- [ ] `python3 -m pytest tests/test_obs_gap_openclaw_rotated_logs_4056.py -v` — all 15 pass locally
- [ ] Confirm `_DEFAULT_LOG_RE.search("openclaw-2026-07-20.1.log")` returns a match
- [ ] Confirm `_DEFAULT_LOG_RE.search("openclaw--work-2026-07-20.log")` still returns `None`
- [ ] Run existing `tests/test_obs_gap_gateway_log_events_3991.py` — still passes (unchanged code path)

## Bot meta

<!-- bot-autofix -->
Draft PR opened autonomously based on the plan in #4056. Marked draft for human review — mark Ready for Review once happy.

Closes #4056

---
_Generated by [Claude Code](https://claude.ai/code/session_01W8d5ymw9aARqRWe8A6JGzX)_