### PR TITLE
fix(adapter): respect openclaw.json logging.file in gateway log discovery

### DIFF
--- a/clawmetry/adapters/openclaw.py
+++ b/clawmetry/adapters/openclaw.py
@@ -462,6 +462,35 @@ def _openshell_sandbox_ocsf_enabled(name: str) -> dict:
         return {}
 
 
+def _read_logging_file_config() -> str:
+    """Read ``logging.file`` from openclaw.json and return the path string.
+
+    openclaw.json can redirect gateway log output to an arbitrary path via
+    ``{"logging": {"file": "/custom/path/openclaw.log"}}``.  Returns the
+    string value when present, empty string otherwise.  Never raises (#4054).
+    """
+    try:
+        home = os.environ.get("OPENCLAW_HOME") or os.path.expanduser("~/.openclaw")
+        cfg_path = os.path.join(home, "openclaw.json")
+        if not os.path.isfile(cfg_path):
+            alt = os.path.expanduser("~/.clawdbot/openclaw.json")
+            if os.path.isfile(alt):
+                cfg_path = alt
+            else:
+                return ""
+        with open(cfg_path) as _fh:
+            cfg = json.load(_fh)
+        if not isinstance(cfg, dict):
+            return ""
+        logging_cfg = cfg.get("logging")
+        if not isinstance(logging_cfg, dict):
+            return ""
+        log_file = logging_cfg.get("file")
+        return str(log_file) if log_file else ""
+    except Exception:
+        return ""
+
+
 def _gateway_log_files() -> list:
     """Return the newest-5 rotating gateway log files across known candidate dirs.
 
@@ -477,6 +506,15 @@ def _gateway_log_files() -> list:
         "/tmp/openclaw",
         os.path.join(openclaw_dir, "logs"),
     ]
+
+    # If openclaw.json sets logging.file, check that path's parent directory
+    # first so installs with a custom log location are visible (#4054).
+    custom_log_file = _read_logging_file_config()
+    if custom_log_file:
+        custom_dir = os.path.dirname(os.path.abspath(custom_log_file))
+        if custom_dir not in candidates:
+            candidates.insert(0, custom_dir)
+
     # On Windows and on hosts where /tmp/openclaw is unsafe the gateway writes
     # to a user-scoped openclaw-* directory under the OS temp dir instead.
     tmp_base = tempfile.gettempdir()
@@ -490,6 +528,12 @@ def _gateway_log_files() -> list:
         )
         if matches:
             return matches[-5:]
+
+    # Fallback: if logging.file points to a single file that doesn't match the
+    # rotation naming pattern, return it directly so callers still see events.
+    if custom_log_file and os.path.isfile(custom_log_file):
+        return [custom_log_file]
+
     return []
 
 

--- a/tests/test_obs_gap_logging_file_4054.py
+++ b/tests/test_obs_gap_logging_file_4054.py
@@ -1,0 +1,102 @@
+"""Tests for #4054: _gateway_log_files() respects openclaw.json logging.file.
+
+Covers:
+- Rotation-pattern file in a custom dir picked up via parent-dir candidate.
+- Non-rotation single file returned via direct fallback path.
+- Missing / malformed config falls back gracefully without raising.
+"""
+import json
+import os
+
+import pytest
+
+from clawmetry.adapters.openclaw import _gateway_log_files, _read_logging_file_config
+
+
+def _write_config(tmp_path, log_file_path):
+    """Write a minimal openclaw.json pointing logging.file at log_file_path."""
+    cfg = {"logging": {"file": str(log_file_path)}}
+    cfg_path = tmp_path / "openclaw.json"
+    cfg_path.write_text(json.dumps(cfg))
+    return cfg_path
+
+
+class TestReadLoggingFileConfig:
+    def test_returns_path_from_config(self, tmp_path, monkeypatch):
+        log_path = tmp_path / "custom" / "openclaw.log"
+        _write_config(tmp_path, log_path)
+        monkeypatch.setenv("OPENCLAW_HOME", str(tmp_path))
+        assert _read_logging_file_config() == str(log_path)
+
+    def test_missing_config_returns_empty(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("OPENCLAW_HOME", str(tmp_path))
+        assert _read_logging_file_config() == ""
+
+    def test_config_without_logging_key_returns_empty(self, tmp_path, monkeypatch):
+        (tmp_path / "openclaw.json").write_text(json.dumps({"other": "key"}))
+        monkeypatch.setenv("OPENCLAW_HOME", str(tmp_path))
+        assert _read_logging_file_config() == ""
+
+    def test_malformed_json_returns_empty(self, tmp_path, monkeypatch):
+        (tmp_path / "openclaw.json").write_text("{not valid json")
+        monkeypatch.setenv("OPENCLAW_HOME", str(tmp_path))
+        assert _read_logging_file_config() == ""
+
+
+class TestGatewayLogFilesCustomPath:
+    def test_rotation_pattern_file_in_custom_dir(self, tmp_path, monkeypatch):
+        """logging.file parent dir added to candidates; rotation file found there."""
+        custom_dir = tmp_path / "custom_logs"
+        custom_dir.mkdir()
+        log_file = custom_dir / "openclaw-2026-07-26.log"
+        log_file.write_text('{"level":"info","msg":"hello"}\n')
+
+        _write_config(tmp_path, log_file)
+        monkeypatch.setenv("OPENCLAW_HOME", str(tmp_path))
+        # Prevent default candidates from matching anything real on this host.
+        monkeypatch.setenv("CLAWMETRY_OPENCLAW_DIR", str(tmp_path / "nonexistent"))
+
+        result = _gateway_log_files()
+        assert str(log_file) in result
+
+    def test_non_rotation_single_file_fallback(self, tmp_path, monkeypatch):
+        """logging.file with non-standard name returned directly as fallback."""
+        custom_dir = tmp_path / "logs"
+        custom_dir.mkdir()
+        log_file = custom_dir / "gateway.log"
+        log_file.write_text('{"level":"info","msg":"hello"}\n')
+
+        _write_config(tmp_path, log_file)
+        monkeypatch.setenv("OPENCLAW_HOME", str(tmp_path))
+        monkeypatch.setenv("CLAWMETRY_OPENCLAW_DIR", str(tmp_path / "nonexistent"))
+
+        result = _gateway_log_files()
+        assert result == [str(log_file)]
+
+    def test_no_config_returns_empty_when_no_default_dirs(self, tmp_path, monkeypatch):
+        """No openclaw.json and no default log dirs → empty list, no exception."""
+        monkeypatch.setenv("OPENCLAW_HOME", str(tmp_path))
+        monkeypatch.setenv("CLAWMETRY_OPENCLAW_DIR", str(tmp_path / "nonexistent"))
+        result = _gateway_log_files()
+        assert result == []
+
+    def test_custom_dir_takes_priority_over_defaults(self, tmp_path, monkeypatch):
+        """Custom dir inserted at front of candidates, checked before hardcoded dirs."""
+        custom_dir = tmp_path / "priority_logs"
+        custom_dir.mkdir()
+        log_file = custom_dir / "openclaw-2026-07-26.log"
+        log_file.write_text('{"level":"info","msg":"custom"}\n')
+
+        # Also create a file in the openclaw_dir/logs default location.
+        default_logs = tmp_path / "oc" / "logs"
+        default_logs.mkdir(parents=True)
+        default_log = default_logs / "openclaw-2026-07-25.log"
+        default_log.write_text('{"level":"info","msg":"default"}\n')
+
+        _write_config(tmp_path, log_file)
+        monkeypatch.setenv("OPENCLAW_HOME", str(tmp_path))
+        monkeypatch.setenv("CLAWMETRY_OPENCLAW_DIR", str(tmp_path / "oc"))
+
+        result = _gateway_log_files()
+        # Custom dir is checked first; its file wins.
+        assert str(log_file) in result


### PR DESCRIPTION
Closes #4054

## Summary

- **`clawmetry/adapters/openclaw.py`** — adds `_read_logging_file_config()` (mirrors `_workshop_approval_config()`) to parse `logging.file` from `openclaw.json`; updates `_gateway_log_files()` to insert the custom path's parent directory at the front of candidates and fall back to returning the file directly when it doesn't match the `openclaw-YYYY-MM-DD.log` rotation pattern.
- **`tests/test_obs_gap_logging_file_4054.py`** — 8 new tests: config parsing (happy path, missing key, malformed JSON), rotation-dir pickup, single-file fallback, priority ordering vs default dirs, graceful empty return.

## Test plan

- `python3 -m pytest tests/test_obs_gap_logging_file_4054.py -v` → 8 passed
- `python3 -m py_compile clawmetry/adapters/openclaw.py` → no errors
- Existing gateway-log tests (`tests/test_obs_gap_gateway_log_events_3991.py`) unaffected — they monkeypatch `_gateway_log_files` directly

---
_Generated by [Claude Code](https://claude.ai/code/session_01CoLav2WQPdAtPu322UGvpQ)_