### PR TITLE
[RELEASE] feat(approvals): 7-day approval windows + adaptive decision polling

### DIFF
--- a/clawmetry/approvals.py
+++ b/clawmetry/approvals.py
@@ -95,6 +95,18 @@ POLICIES_PATH = Path.home() / ".clawmetry" / "policies.yml"
 # the API.
 _POLL_INTERVAL_SEC = 3.0
 
+
+def _poll_interval(waited_s: float) -> float:
+    """Adaptive decision-poll cadence for long approval windows (7-day
+    default, #4066): snappy while the human is likely mid-tap, gentle for
+    the long tail — a week at 3s would be ~200k requests per approval.
+    3s for the first 2 min, 15s until the first hour, then 60s."""
+    if waited_s < 120:
+        return _POLL_INTERVAL_SEC
+    if waited_s < 3600:
+        return 15.0
+    return 60.0
+
 # Track in-flight approvals so we don't re-request on a watcher restart that
 # replays the same toolCall row. Keyed by tool_call_id (or composite when
 # missing — `f"{session_id}:{ts}"`).
@@ -189,7 +201,7 @@ def _compile_policy(p: dict) -> Optional[dict]:
             "command_not_regex": re.compile(cmd_not_re) if cmd_not_re else None,
             "args_regex": re.compile(args_re) if args_re else None,
             "action": (p.get("action") or "require_approval").strip(),
-            "timeout": int(p.get("timeout") or 60),
+            "timeout": int(p.get("timeout") or 604800),  # default 7d (#4066)
             "on_timeout": (p.get("on_timeout") or "deny").strip(),
         }
     except re.error as re_err:
@@ -471,7 +483,8 @@ def _poll_decision_local(approval_id: str, timeout_s: int) -> str:
     ``/api/approvals/<approval_id>/decide`` (routes/policy.py) which flips
     the row's ``status`` via ``update_approval_decision``. No network, no
     cloud auth — the whole loop stays inside the box."""
-    deadline = time.time() + timeout_s + 5  # 5 s grace past policy expiry
+    start = time.time()
+    deadline = start + timeout_s + 5  # 5 s grace past policy expiry
     last_status = "pending"
     try:
         from clawmetry import local_store as _lsm
@@ -502,7 +515,7 @@ def _poll_decision_local(approval_id: str, timeout_s: int) -> str:
                     return last_status
         except Exception as e:
             log.debug("approvals(local): poll error (will retry): %s", e)
-        time.sleep(_POLL_INTERVAL_SEC)
+        time.sleep(_poll_interval(time.time() - start))
     return last_status if last_status != "pending" else "timeout"
 
 
@@ -537,7 +550,8 @@ def _local_blocking_enabled(api_key: Optional[str]) -> bool:
 def _poll_decision(api_key: str, approval_id: str, timeout_s: int) -> str:
     """Poll cloud for the decision. Returns one of: approved/denied/timeout/error."""
     import urllib.request
-    deadline = time.time() + timeout_s + 5  # 5 s grace past policy expiry
+    start = time.time()
+    deadline = start + timeout_s + 5  # 5 s grace past policy expiry
     last_status = "pending"
     while time.time() < deadline:
         try:
@@ -554,7 +568,7 @@ def _poll_decision(api_key: str, approval_id: str, timeout_s: int) -> str:
                     return last_status
         except Exception as e:
             log.debug(f"poll error (will retry): {e}")
-        time.sleep(_POLL_INTERVAL_SEC)
+        time.sleep(_poll_interval(time.time() - start))
     return last_status if last_status != "pending" else "timeout"
 
 

--- a/clawmetry/hooks_claude_code.py
+++ b/clawmetry/hooks_claude_code.py
@@ -38,12 +38,10 @@ Deny emits BOTH the modern hookSpecificOutput JSON (stdout) and stderr +
 exit 2 (honored by every Claude Code version). Allow emits the modern JSON
 with exit 0.
 
-TIMEOUT: the installer sets the PreToolUse hook timeout to 900s, above the
-common policy timeouts (presets 60–300s; process_tool_call answers within
-policy.timeout + grace and then applies on_timeout, so the hook practically
-always answers well inside 900s). If a pathological >880s policy ever hits
-the hook timeout, current Claude Code blocks the call — same outcome as the
-default on_timeout: deny.
+TIMEOUT: the installer sets the PreToolUse hook timeout just above the
+7-day max policy window (#4066) — process_tool_call answers within
+policy.timeout + grace and then applies on_timeout, so the hook always
+answers before Claude Code's hook timeout would block the call.
 """
 from __future__ import annotations
 
@@ -65,7 +63,10 @@ _HOOK_CMD_NOTIFICATION = "clawmetry hooks run notification"
 # spelling `clawmetry hook claude-code` too, so uninstall cleans both).
 _HOOK_CMD_MARKERS = ("clawmetry hooks run", "clawmetry hook claude-code")
 
-_PRETOOL_TIMEOUT_S = 900
+# Must exceed the max policy window (7 days, #4066) + poll grace —
+# Claude Code BLOCKS the call when a hook times out, which would
+# override the policy's own on_timeout choice.
+_PRETOOL_TIMEOUT_S = 605100
 _NOTIFICATION_TIMEOUT_S = 10
 
 

--- a/clawmetry/hooks_claude_code.py
+++ b/clawmetry/hooks_claude_code.py
@@ -59,6 +59,7 @@ _SETTINGS_PATH = os.path.expanduser("~/.claude/settings.json")
 
 _HOOK_CMD_PRETOOL = "clawmetry hooks run pretooluse"
 _HOOK_CMD_NOTIFICATION = "clawmetry hooks run notification"
+_HOOK_CMD_STOP = "clawmetry hooks run stop"
 # Any command containing this marker is ours (covers the stale-branch
 # spelling `clawmetry hook claude-code` too, so uninstall cleans both).
 _HOOK_CMD_MARKERS = ("clawmetry hooks run", "clawmetry hook claude-code")
@@ -276,14 +277,21 @@ def main_pretooluse() -> int:
 
 # ── Notification → phone push ─────────────────────────────────────────────
 
-def _push_notify(api_key: str, kind: str, title: str, body: str) -> bool:
-    """Fire-and-forget POST /api/cloud/push/notify. Never raises."""
+def _push_notify(api_key: str, kind: str, title: str, body: str,
+                 extra: "dict | None" = None) -> bool:
+    """Fire-and-forget POST /api/cloud/push/notify. Never raises.
+
+    ``extra`` carries session context (session_id, cwd, node_id) so the
+    cloud can record WHICH terminal is waiting — the inbox's "Needs you
+    at the desk" section (kind=input records, stop/clear clears)."""
     try:
         import urllib.request
+        payload = {"kind": kind, "title": title, "body": body[:400],
+                   "open_url": "/approvals"}
+        payload.update(extra or {})
         req = urllib.request.Request(
             f"{_ingest_url()}/api/cloud/push/notify",
-            data=json.dumps({"kind": kind, "title": title,
-                             "body": body[:400], "open_url": "/cloud"}).encode(),
+            data=json.dumps(payload).encode(),
             headers={"Content-Type": "application/json",
                      "Authorization": f"Bearer {api_key}"},
             method="POST",
@@ -292,6 +300,17 @@ def _push_notify(api_key: str, kind: str, title: str, body: str) -> bool:
             return True
     except Exception:
         return False
+
+
+def _session_extra(event: dict) -> dict:
+    sid = (event.get("session_id") or "").strip()
+    extra = {"node_id": _node_id()}
+    if sid:
+        # Cloud rows key on the runtime-prefixed form the daemon uses.
+        extra["session_id"] = sid if ":" in sid else f"claude_code:{sid}"
+    if event.get("cwd"):
+        extra["cwd"] = str(event["cwd"])[:300]
+    return extra
 
 
 def main_notification() -> int:
@@ -308,12 +327,33 @@ def main_notification() -> int:
     if ntype == "permission_prompt":
         # Only reached when the PreToolUse gate had no opinion (no policy
         # matched) and Claude Code raised its own prompt — the phone can't
-        # answer it remotely, but you know to come back to the desk.
+        # answer it remotely, but the inbox shows WHICH terminal is waiting.
         _push_notify(api_key, "input", "Claude Code needs your permission",
-                     message or "A tool call is waiting for your approval.")
+                     message or "A tool call is waiting for your approval.",
+                     _session_extra(event))
     elif ntype == "idle_prompt":
         _push_notify(api_key, "stop", "Claude Code is done — waiting on you",
-                     message or "The agent finished and is waiting for input.")
+                     message or "The agent finished and is waiting for input.",
+                     _session_extra(event))
+    return 0
+
+
+def main_stop() -> int:
+    """Stop hook: bookkeeping only. The turn ended, so whatever native
+    prompt this session had is no longer waiting — clear its desk-attention
+    row. kind=clear sends NO push (a push per assistant turn would be
+    noise); observe-only exit 0 always."""
+    try:
+        raw = sys.stdin.read()
+        event = json.loads(raw) if raw.strip() else {}
+    except Exception:
+        return 0
+    api_key = _load_api_key()
+    if not api_key:
+        return 0
+    extra = _session_extra(event)
+    if extra.get("session_id"):
+        _push_notify(api_key, "clear", "", "", extra)
     return 0
 
 
@@ -398,9 +438,20 @@ def install(settings_path: "str | None" = None, matcher: str = "*") -> dict:
             })
             added.append("Notification")
 
+        # Stop = bookkeeping only (clears the "needs you at the desk" row
+        # for the session; no push) — see main_stop.
+        stop = hooks.setdefault("Stop", [])
+        if not _has_our_hook(stop):
+            stop.append({
+                "hooks": [{"type": "command",
+                           "command": _HOOK_CMD_STOP,
+                           "timeout": _NOTIFICATION_TIMEOUT_S}],
+            })
+            added.append("Stop")
+
         if added:
             _write_settings(path, settings)
-        _write_marker(["PreToolUse", "Notification"])
+        _write_marker(["PreToolUse", "Notification", "Stop"])
         return {"status": "installed" if added else "already_present",
                 "path": path, "added": added, "matcher": matcher,
                 "timeout": _PRETOOL_TIMEOUT_S}
@@ -469,6 +520,8 @@ def cli_main(argv: "list | None" = None) -> int:
             return main_pretooluse()
         if event == "notification":
             return main_notification()
+        if event == "stop":
+            return main_stop()
         sys.stderr.write(f"unknown hook event: {event!r}\n")
         return 1
     if cmd == "install":
@@ -494,5 +547,5 @@ def cli_main(argv: "list | None" = None) -> int:
         return 0
     sys.stderr.write(
         "usage: clawmetry hooks {install [--matcher RE] | uninstall | "
-        "status | run {pretooluse|notification}}\n")
+        "status | run {pretooluse|notification|stop}}\n")
     return 1

--- a/clawmetry/templates/tabs/approvals.html
+++ b/clawmetry/templates/tabs/approvals.html
@@ -95,10 +95,13 @@
           <label style="font-size:11px;color:var(--text-muted);display:block;margin-bottom:4px;" data-i18n="approvals.approval_timeout">Approval timeout</label>
           <select id="rule-timeout" style="width:100%;box-sizing:border-box;padding:7px 10px;border:1px solid var(--border);border-radius:6px;background:var(--bg-primary);color:var(--text-primary);font-size:12px;">
             <option value="30" data-i18n="approvals.timeout_30s">30 seconds</option>
-            <option value="60" selected data-i18n="approvals.timeout_1m">1 minute</option>
+            <option value="60" data-i18n="approvals.timeout_1m">1 minute</option>
             <option value="120" data-i18n="approvals.timeout_2m">2 minutes</option>
             <option value="300" data-i18n="approvals.timeout_5m">5 minutes</option>
             <option value="600" data-i18n="approvals.timeout_10m">10 minutes</option>
+            <option value="3600" data-i18n="approvals.timeout_1h">1 hour</option>
+            <option value="86400" data-i18n="approvals.timeout_24h">24 hours</option>
+            <option value="604800" selected data-i18n="approvals.timeout_7d">7 days</option>
           </select>
         </div>
         <div>
@@ -234,35 +237,35 @@
   var PRESETS = [
     {key:'rm_rf', name:'Block destructive deletes', icon:'🗑',
      desc:'Stops rm -rf, shred, unlink on important paths',
-     tool:'exec', pattern:'rm\\s+-rf|shred\\s|unlink\\s+/', timeout:60, on_timeout:'deny',
+     tool:'exec', pattern:'rm\\s+-rf|shred\\s|unlink\\s+/', timeout:604800, on_timeout:'deny',
      color:'#ef4444'},
     {key:'force_push', name:'Block force pushes', icon:'⚠️',
      desc:'Requires approval before git push --force',
-     tool:'exec', pattern:'git\\s+push.*--force|git\\s+push.*-f\\b', timeout:300, on_timeout:'deny',
+     tool:'exec', pattern:'git\\s+push.*--force|git\\s+push.*-f\\b', timeout:604800, on_timeout:'deny',
      color:'#f59e0b'},
     {key:'db_mutation', name:'Block database mutations', icon:'🗃',
      desc:'Catches DROP TABLE, TRUNCATE, DELETE without WHERE',
-     tool:'exec', pattern:'DROP\\s+TABLE|TRUNCATE\\s|DELETE\\s+FROM.*(?!WHERE)', timeout:120, on_timeout:'deny',
+     tool:'exec', pattern:'DROP\\s+TABLE|TRUNCATE\\s|DELETE\\s+FROM.*(?!WHERE)', timeout:604800, on_timeout:'deny',
      color:'#f97316'},
     {key:'sudo', name:'Block sudo / root commands', icon:'🔒',
      desc:'Prevents privilege escalation via sudo or su',
-     tool:'exec', pattern:'\\bsudo\\s|\\bsu\\s+-|\\bsu\\s+root', timeout:60, on_timeout:'deny',
+     tool:'exec', pattern:'\\bsudo\\s|\\bsu\\s+-|\\bsu\\s+root', timeout:604800, on_timeout:'deny',
      color:'#dc2626'},
     {key:'secrets', name:'Protect secrets & credentials', icon:'🔑',
      desc:'Blocks access to .env, credentials, private keys',
-     tool:'', pattern:'\\.env\\b|credentials|private_key|secret_key|api_key|AWS_SECRET', timeout:60, on_timeout:'deny',
+     tool:'', pattern:'\\.env\\b|credentials|private_key|secret_key|api_key|AWS_SECRET', timeout:604800, on_timeout:'deny',
      color:'#8b5cf6'},
     {key:'pkg_install', name:'Block package installs', icon:'📦',
      desc:'Requires approval for pip install, npm install, apt install',
-     tool:'exec', pattern:'pip\\s+install|npm\\s+install|apt\\s+install|brew\\s+install', timeout:120, on_timeout:'deny',
+     tool:'exec', pattern:'pip\\s+install|npm\\s+install|apt\\s+install|brew\\s+install', timeout:604800, on_timeout:'deny',
      color:'#6366f1'},
     {key:'network', name:'Block outbound network calls', icon:'🌐',
      desc:'Catches curl, wget, fetch to external URLs',
-     tool:'exec', pattern:'\\bcurl\\s|\\bwget\\s|\\bfetch\\(|requests\\.get|httpx\\.', timeout:60, on_timeout:'deny',
+     tool:'exec', pattern:'\\bcurl\\s|\\bwget\\s|\\bfetch\\(|requests\\.get|httpx\\.', timeout:604800, on_timeout:'deny',
      color:'#0ea5e9'},
     {key:'sys_config', name:'Block system config changes', icon:'⚙️',
      desc:'Prevents writes to /etc, systemctl, crontab edits',
-     tool:'exec', pattern:'/etc/|systemctl|crontab|chmod\\s+777|chown\\s+root', timeout:60, on_timeout:'deny',
+     tool:'exec', pattern:'/etc/|systemctl|crontab|chmod\\s+777|chown\\s+root', timeout:604800, on_timeout:'deny',
      color:'#64748b'}
   ];
 

--- a/tests/test_hooks_claude_code.py
+++ b/tests/test_hooks_claude_code.py
@@ -185,9 +185,9 @@ def test_install_idempotent_and_correct_timeouts(monkeypatch, tmp_path):
     assert len(pre) == 1, "must not duplicate on re-install"
     hk = pre[0]["hooks"][0]
     assert hk["command"] == "clawmetry hooks run pretooluse"
-    # Load-bearing: must exceed policy timeouts (presets 60-300s) or Claude
-    # Code times the hook out before the human decides.
-    assert hk["timeout"] == 900
+    # Load-bearing: must exceed the 7-day max policy window or Claude
+    # Code times the hook out (= blocks) before the human decides.
+    assert hk["timeout"] == 605100
     assert s["hooks"]["Notification"][0]["hooks"][0]["command"] == \
         "clawmetry hooks run notification"
     marker = json.load(open(str(tmp_path / "marker.json")))

--- a/tests/test_hooks_claude_code.py
+++ b/tests/test_hooks_claude_code.py
@@ -177,7 +177,7 @@ def test_install_idempotent_and_correct_timeouts(monkeypatch, tmp_path):
     sp = str(tmp_path / "settings.json")
     r1 = h.install(settings_path=sp)
     assert r1["status"] == "installed"
-    assert sorted(r1["added"]) == ["Notification", "PreToolUse"]
+    assert sorted(r1["added"]) == ["Notification", "PreToolUse", "Stop"]
     r2 = h.install(settings_path=sp)
     assert r2["status"] == "already_present"
     s = json.load(open(sp))
@@ -230,22 +230,42 @@ def test_uninstall_removes_only_ours(monkeypatch, tmp_path):
 def test_notification_permission_prompt_pushes(monkeypatch):
     calls = []
     monkeypatch.setattr(h, "_load_api_key", lambda: "cm_x")
+    monkeypatch.setattr(h, "_node_id", lambda: "mac")
     monkeypatch.setattr(h, "_push_notify",
-                        lambda k, kind, title, body: calls.append((kind, title, body)))
+                        lambda k, kind, title, body, extra=None:
+                        calls.append((kind, title, body, extra)))
     monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps(
         {"hook_event_name": "Notification",
          "notification_type": "permission_prompt",
-         "message": "Claude needs permission to run rm"})))
+         "message": "Claude needs permission to run rm",
+         "session_id": "abc123", "cwd": "/tmp/proj"})))
     assert h.main_notification() == 0
     assert calls and calls[0][0] == "input"
     assert "rm" in calls[0][2]
+    # Session context rides along so the inbox can show WHICH terminal.
+    assert calls[0][3]["session_id"] == "claude_code:abc123"
+    assert calls[0][3]["cwd"] == "/tmp/proj"
+
+
+def test_stop_hook_sends_silent_clear(monkeypatch):
+    calls = []
+    monkeypatch.setattr(h, "_load_api_key", lambda: "cm_x")
+    monkeypatch.setattr(h, "_node_id", lambda: "mac")
+    monkeypatch.setattr(h, "_push_notify",
+                        lambda k, kind, title, body, extra=None:
+                        calls.append((kind, extra)))
+    monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps(
+        {"hook_event_name": "Stop", "session_id": "abc123"})))
+    assert h.main_stop() == 0
+    assert calls == [("clear", {"node_id": "mac",
+                                "session_id": "claude_code:abc123"})]
 
 
 def test_notification_idle_prompt_pushes_stop(monkeypatch):
     calls = []
     monkeypatch.setattr(h, "_load_api_key", lambda: "cm_x")
     monkeypatch.setattr(h, "_push_notify",
-                        lambda k, kind, title, body: calls.append(kind))
+                        lambda k, kind, title, body, extra=None: calls.append(kind))
     monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps(
         {"notification_type": "idle_prompt", "message": "done"})))
     assert h.main_notification() == 0


### PR DESCRIPTION
Companion to clawmetry-cloud#1778. Policy timeout default/UI presets -> 7 days; decision polls back off (3s -> 15s -> 60s); hook timeout 605100s (must exceed the policy window since Claude Code blocks on hook timeout). 22/22 hook tests; the 7 failures in test_approvals_local_blocking are pre-existing on main (verified via stash baseline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)