### PR TITLE
fix(plugin-health): forward 'polling' and 'shutdown' lifecycle detail flags

### DIFF
--- a/clawmetry/adapters/openclaw.py
+++ b/clawmetry/adapters/openclaw.py
@@ -1408,10 +1408,11 @@ def _gateway_plugin_health() -> dict:
 
     As of harness 2026.7.21 (#3883), the shared plugin-SDK monitor introduces a
     ``phase`` field per plugin entry (``"admission"``, ``"claim-identity"``,
-    ``"adoption-handoff"``, ``"pruning"``) so a plugin stuck mid-admission is
-    distinguishable from a healthy ``"loaded"`` one.  Per-step detail flags
-    (``admission``, ``claim_identity``, ``adoption_handoff``, ``pruning``) are
-    forwarded when present.
+    ``"adoption-handoff"``, ``"pruning"``, ``"polling"``, ``"shutdown"``) so a
+    plugin stuck mid-admission is distinguishable from a healthy ``"loaded"``
+    one.  Per-step detail flags (``admission``, ``claim_identity``,
+    ``adoption_handoff``, ``pruning``, ``polling``, ``shutdown``) are forwarded
+    when present (#4058).
 
     Returns a dict with keys when any plugin data is present:
     - ``"gatewayPluginHealth"`` — the raw list of plugin entries.
@@ -1453,7 +1454,7 @@ def _gateway_plugin_health() -> dict:
                 plugin["phase"] = str(phase).lower()
                 phase_summary[plugin["phase"]] = phase_summary.get(plugin["phase"], 0) + 1
             # Per-step lifecycle detail flags (forwarded when present)
-            for detail_key in ("admission", "claim_identity", "adoption_handoff", "pruning"):
+            for detail_key in ("admission", "claim_identity", "adoption_handoff", "pruning", "polling", "shutdown"):
                 val = entry.get(detail_key)
                 if val is not None:
                     plugin[detail_key] = val

--- a/tests/test_obs_gap_openclaw_plugin_lifecycle_polling_shutdown_4058.py
+++ b/tests/test_obs_gap_openclaw_plugin_lifecycle_polling_shutdown_4058.py
@@ -1,0 +1,123 @@
+"""Tests for issue #4058 — openclaw: channel plugin lifecycle 'polling' and 'shutdown'
+detail flags not forwarded by _gateway_plugin_health().
+
+Verifies that the per-step detail-flag loop covers all six SDK lifecycle steps,
+including 'polling' and 'shutdown' which were previously silently dropped.
+
+Fingerprint: hgap-57d9fbd884 (used to dedupe — keep it in the body).
+"""
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _restore_sys_modules():
+    saved_dashboard = sys.modules.get("dashboard")
+    saved_adapter = sys.modules.get("clawmetry.adapters.openclaw")
+    yield
+    if saved_dashboard is None:
+        sys.modules.pop("dashboard", None)
+    else:
+        sys.modules["dashboard"] = saved_dashboard
+    if saved_adapter is None:
+        sys.modules.pop("clawmetry.adapters.openclaw", None)
+    else:
+        sys.modules["clawmetry.adapters.openclaw"] = saved_adapter
+
+
+def _make_mock_dashboard(rpc_return):
+    mod = types.ModuleType("dashboard")
+    mod._gw_ws_rpc = lambda method, params=None: rpc_return
+    sys.modules["dashboard"] = mod
+    return mod
+
+
+def _reload_adapter():
+    import clawmetry.adapters.openclaw as oc_mod
+    importlib.reload(oc_mod)
+    return oc_mod
+
+
+def test_polling_detail_flag_forwarded():
+    """Per-step 'polling' detail flag is forwarded when present."""
+    _make_mock_dashboard({
+        "plugins": [
+            {"name": "irc", "state": "loaded", "phase": "polling", "polling": "active"},
+        ]
+    })
+    oc = _reload_adapter()
+    result = oc._gateway_plugin_health()
+    entry = result["gatewayPluginHealth"][0]
+    assert entry.get("polling") == "active"
+
+
+def test_shutdown_detail_flag_forwarded():
+    """Per-step 'shutdown' detail flag is forwarded when present."""
+    _make_mock_dashboard({
+        "plugins": [
+            {"name": "google-chat", "state": "loaded", "phase": "shutdown", "shutdown": "graceful"},
+        ]
+    })
+    oc = _reload_adapter()
+    result = oc._gateway_plugin_health()
+    entry = result["gatewayPluginHealth"][0]
+    assert entry.get("shutdown") == "graceful"
+
+
+def test_polling_and_shutdown_in_phase_summary():
+    """Phase summary includes 'polling' and 'shutdown' counts when present."""
+    _make_mock_dashboard({
+        "plugins": [
+            {"name": "irc", "state": "loaded", "phase": "polling", "polling": "active"},
+            {"name": "synology-chat", "state": "loaded", "phase": "polling"},
+            {"name": "google-chat", "state": "loaded", "phase": "shutdown", "shutdown": "graceful"},
+        ]
+    })
+    oc = _reload_adapter()
+    result = oc._gateway_plugin_health()
+    ps = result.get("gatewayPluginPhaseSummary", {})
+    assert ps.get("polling") == 2
+    assert ps.get("shutdown") == 1
+
+
+def test_absent_polling_shutdown_flags_not_injected():
+    """Absent polling/shutdown fields are not added to plugin entries."""
+    _make_mock_dashboard({
+        "plugins": [
+            {"name": "telegram", "state": "loaded", "type": "channel"},
+        ]
+    })
+    oc = _reload_adapter()
+    result = oc._gateway_plugin_health()
+    entry = result["gatewayPluginHealth"][0]
+    assert "polling" not in entry
+    assert "shutdown" not in entry
+
+
+def test_all_six_detail_flags_forwarded_together():
+    """All six lifecycle detail flags are forwarded when a plugin carries all of them."""
+    _make_mock_dashboard({
+        "plugins": [
+            {
+                "name": "irc", "state": "loaded", "phase": "polling",
+                "admission": "ok", "claim_identity": "ok",
+                "adoption_handoff": "ok", "pruning": False,
+                "polling": "active", "shutdown": None,
+            },
+        ]
+    })
+    oc = _reload_adapter()
+    result = oc._gateway_plugin_health()
+    entry = result["gatewayPluginHealth"][0]
+    assert entry.get("admission") == "ok"
+    assert entry.get("claim_identity") == "ok"
+    assert entry.get("adoption_handoff") == "ok"
+    assert entry.get("pruning") is False
+    assert entry.get("polling") == "active"
+    # shutdown is None — entry.get(detail_key) is not None check excludes it
+    assert "shutdown" not in entry


### PR DESCRIPTION
Closes #4058

## What

`_gateway_plugin_health()` already tallied `polling` and `shutdown` phases correctly in `gatewayPluginPhaseSummary`, but the per-entry detail-flag loop only covered four of the six SDK lifecycle steps:

```python
# before
for detail_key in ("admission", "claim_identity", "adoption_handoff", "pruning"):
# after
for detail_key in ("admission", "claim_identity", "adoption_handoff", "pruning", "polling", "shutdown"):
```

Any `polling`/`shutdown` fields from the gateway `gateway.status` response were silently dropped even though the phase count still incremented.

## Changes

- `clawmetry/adapters/openclaw.py` — add `"polling"` and `"shutdown"` to the detail-key tuple; update docstring to list all six steps. (~3 LOC)
- `tests/test_obs_gap_openclaw_plugin_lifecycle_polling_shutdown_4058.py` (new) — 5 tests covering: polling flag forwarded, shutdown flag forwarded, both in phase summary, absent flags not injected, all six flags forwarded together. All 14 tests (5 new + 9 existing from #3883) pass.

## Test plan

- [x] `pytest tests/test_obs_gap_openclaw_plugin_lifecycle_polling_shutdown_4058.py tests/test_obs_gap_openclaw_plugin_ingress_lifecycle_3883.py` — 14 passed, 0 failed

---
_Generated by [Claude Code](https://claude.ai/code/session_01PZ5DmmjCoZLftvTjgUyTFw)_