### PR TITLE
fix: include rotation archives in _gateway_log_files() (#4056)

### DIFF
--- a/clawmetry/adapters/openclaw.py
+++ b/clawmetry/adapters/openclaw.py
@@ -1,4 +1,3 @@
-"""OpenClawAdapter — thin wrapper around existing dashboard.py helpers.
 
 This adapter does NOT re-implement OpenClaw session parsing. It delegates
 to the long-standing helpers in ``dashboard.py`` via a late import, the
@@ -26,12 +25,14 @@ from .base import AgentAdapter, Capability, DetectResult, Event, Session
 
 logger = logging.getLogger("clawmetry.adapters.openclaw")
 
-# Gateway log filename patterns (#4055):
-#   default profile : openclaw-YYYY-MM-DD.log
-#   named profiles  : openclaw-{name}-YYYY-MM-DD.log  (e.g. openclaw-work-2026-07-26.log)
-# The optional (.+-)? prefix matches named profiles while the date anchor
-# ensures unrelated files (openclaw-debug.log, etc.) are still excluded.
-_DEFAULT_LOG_RE = re.compile(r"openclaw-(.+-)?\d{4}-\d{2}-\d{2}\.log$")
+# Gateway log filename patterns (#4055, #4056):
+#   default profile          : openclaw-YYYY-MM-DD.log
+#   named profiles (#4055)   : openclaw-{name}-YYYY-MM-DD.log
+#   rotation archives (#4056): openclaw-YYYY-MM-DD.N.log
+#   named + rotated          : openclaw-{name}-YYYY-MM-DD.N.log
+# (.+-)? matches named profiles; (\.\d+)? matches rotation archives; the date
+# anchor excludes unrelated files (openclaw-debug.log, etc.).
+_DEFAULT_LOG_RE = re.compile(r"openclaw-(.+-)?\d{4}-\d{2}-\d{2}(\.\d+)?\.log$")
 
 # NeMo Guardrails compact tool-catalog injects these three meta-tool names into
 # the JSONL transcript when NEMOCLAW_TOOL_CATALOG is active. They are guardrail

--- a/clawmetry/adapters/openclaw.py
+++ b/clawmetry/adapters/openclaw.py
@@ -1,4 +1,4 @@
-
+"""
 This adapter does NOT re-implement OpenClaw session parsing. It delegates
 to the long-standing helpers in ``dashboard.py`` via a late import, the
 same way ``routes/*.py`` modules do. The point of this file is to expose

--- a/tests/test_obs_gap_openclaw_rotated_logs_4056.py
+++ b/tests/test_obs_gap_openclaw_rotated_logs_4056.py
@@ -1,0 +1,129 @@
+"""Tests for #4056 -- rotated log archives (.N.log) included in _gateway_log_files().
+
+_DEFAULT_LOG_RE previously required the date to be immediately followed by
+'.log', so rotation archives like openclaw-2026-07-20.1.log were silently
+dropped.  The fix extends the regex with an optional '(\\.\\d+)?' group so
+numbered rotation archives are included alongside the active log file.
+
+Also covers named-profile rotation archives (openclaw-work-YYYY-MM-DD.N.log)
+made possible by the combined pattern from #4055 + #4056.
+
+Fingerprint: hgap-cd81abf74f-rotated
+"""
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from clawmetry.adapters.openclaw import _DEFAULT_LOG_RE, _gateway_log_files
+
+
+# ---------------------------------------------------------------------------
+# Regex unit tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("name", [
+    "openclaw-2026-07-20.log",
+    "openclaw-2026-07-20.1.log",
+    "openclaw-2026-07-20.2.log",
+    "openclaw-2026-07-20.5.log",
+    "openclaw-2025-01-01.log",
+    "openclaw-2025-01-01.3.log",
+    "openclaw-work-2026-07-20.log",        # named profile (#4055)
+    "openclaw-work-2026-07-20.1.log",      # named profile rotation archive
+    "openclaw-prod-2026-07-20.3.log",      # named profile rotation archive
+])
+def test_regex_matches_valid_names(name):
+    assert _DEFAULT_LOG_RE.search(name), f"{name!r} should match"
+
+
+@pytest.mark.parametrize("name", [
+    "openclaw-2026-07-20.log.gz",        # compressed
+    "openclaw-2026-07-20.abc.log",       # non-numeric suffix
+    "other-2026-07-20.log",              # wrong prefix
+])
+def test_regex_rejects_invalid_names(name):
+    assert not _DEFAULT_LOG_RE.search(name), f"{name!r} should not match"
+
+
+# ---------------------------------------------------------------------------
+# _gateway_log_files() integration tests
+# ---------------------------------------------------------------------------
+
+def _populate_dir(d, filenames):
+    """Create empty files in directory d; return sorted absolute paths."""
+    paths = []
+    for name in filenames:
+        p = d / name
+        p.write_text("", encoding="utf-8")
+        paths.append(str(p))
+    return sorted(paths)
+
+
+def test_rotation_archives_included(monkeypatch, tmp_path):
+    """Rotation archives appear in the result alongside the base log file."""
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    expected = _populate_dir(log_dir, [
+        "openclaw-2026-07-20.log",
+        "openclaw-2026-07-20.1.log",
+        "openclaw-2026-07-20.2.log",
+    ])
+
+    monkeypatch.setenv("CLAWMETRY_OPENCLAW_DIR", str(tmp_path))
+
+    result = _gateway_log_files()
+    assert sorted(result) == sorted(expected)
+
+
+def test_rotation_archives_capped_at_five(monkeypatch, tmp_path):
+    """Result is limited to the 5 lexicographically-last files."""
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    _populate_dir(log_dir, [
+        "openclaw-2026-07-19.log",
+        "openclaw-2026-07-20.log",
+        "openclaw-2026-07-20.1.log",
+        "openclaw-2026-07-20.2.log",
+        "openclaw-2026-07-20.3.log",
+        "openclaw-2026-07-20.4.log",
+        "openclaw-2026-07-20.5.log",
+    ])
+
+    monkeypatch.setenv("CLAWMETRY_OPENCLAW_DIR", str(tmp_path))
+
+    result = _gateway_log_files()
+    assert len(result) == 5
+
+
+def test_named_profile_rotation_archives_included(monkeypatch, tmp_path):
+    """Named-profile rotation archives are included along with default-profile files."""
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    _populate_dir(log_dir, [
+        "openclaw-2026-07-20.log",          # default profile
+        "openclaw-2026-07-20.1.log",        # rotation archive
+        "openclaw-work-2026-07-20.log",     # named profile (#4055)
+        "openclaw-work-2026-07-20.1.log",   # named profile rotation archive
+    ])
+
+    monkeypatch.setenv("CLAWMETRY_OPENCLAW_DIR", str(tmp_path))
+
+    result = _gateway_log_files()
+    basenames = [os.path.basename(p) for p in result]
+    assert "openclaw-2026-07-20.log" in basenames
+    assert "openclaw-2026-07-20.1.log" in basenames
+    assert "openclaw-work-2026-07-20.log" in basenames
+    assert "openclaw-work-2026-07-20.1.log" in basenames
+
+
+def test_no_logs_returns_empty(monkeypatch, tmp_path):
+    """Empty candidate directories give an empty list, no exception."""
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+
+    monkeypatch.setenv("CLAWMETRY_OPENCLAW_DIR", str(tmp_path))
+
+    result = _gateway_log_files()
+    assert result == []


### PR DESCRIPTION
## Summary

Extends `_DEFAULT_LOG_RE` with an optional `(\.\d+)?` group so rotation archives like `openclaw-2026-07-20.1.log` are included alongside the active log file.

- Combines the named-profile prefix fix from #4055 (`(.+-)?`) with the rotation-archive suffix fix (`(\.\d+)?`) into a single pattern: `openclaw-(.+-)?\d{4}-\d{2}-\d{2}(\.\d+)?\.log$`
- Covers all four log filename shapes: default, named-profile, rotated, and named-profile + rotated
- Adds `tests/test_obs_gap_openclaw_rotated_logs_4056.py` with 5 parametrised integration tests (regex unit tests + `_gateway_log_files()` integration tests including the 5-file cap)
- Replaces the now-closed draft PR #4063 (which had a conflicting regex and stale test assertions)

Closes #4056

---
_Generated by [Claude Code](https://claude.ai/code/session_012TP7eQd4QgDtHUWzmTAbFa)_