### PR TITLE
[RELEASE] fix(hooks): autonomous sessions skip blanket ask gates

### DIFF
--- a/clawmetry/hooks_claude_code.py
+++ b/clawmetry/hooks_claude_code.py
@@ -157,6 +157,26 @@ def _load_policies_fast(api_key: str) -> list:
 
 # ── PreToolUse gate ───────────────────────────────────────────────────────
 
+# Claude Code session modes where the user explicitly opted into autonomy:
+# blanket "ask my phone" gates must not nag those sessions (user report
+# 2026-07-26: auto-mode sessions were filling the approval inbox).
+# `acceptEdits` is NOT here — it auto-accepts file edits only; shell still
+# prompts natively, so the phone gate mirrors that.
+_AUTONOMOUS_MODES = frozenset({"auto", "dontAsk", "bypassPermissions"})
+
+
+def _is_blanket_ask(p: dict) -> bool:
+    """A catch-all require_approval rule (pattern .* with no narrowing) —
+    the interactive convenience gates, as opposed to targeted RISK gates
+    (rm -rf, force push, sudo, …) which keep protecting even autonomous
+    sessions: yolo mode is exactly when the safety net matters."""
+    if (p.get("action") or "") != "require_approval":
+        return False
+    if p.get("args_regex") is not None or p.get("command_not_regex") is not None:
+        return False
+    pat = getattr(p.get("command_regex"), "pattern", None)
+    return pat in (None, ".*", "^.*", ".+", "^.+")
+
 def _deny_payload(reason: str) -> dict:
     return {
         "hookSpecificOutput": {
@@ -203,6 +223,9 @@ def evaluate(event: dict) -> "dict | None":
 
         from clawmetry import approvals
         policies = _load_policies_fast(api_key)
+        mode = (event.get("permission_mode") or "").strip()
+        if mode in _AUTONOMOUS_MODES:
+            policies = [p for p in policies if not _is_blanket_ask(p)]
         if not policies:
             return None
         if not approvals.match_policy(policies, tool_name, tool_input):

--- a/tests/test_hooks_claude_code.py
+++ b/tests/test_hooks_claude_code.py
@@ -163,6 +163,41 @@ def test_always_allow_rule_outranks_catchall(monkeypatch):
     assert "Auto-approved" in p["reason"]
 
 
+def test_autonomous_mode_skips_blanket_ask_but_keeps_risk_gates(monkeypatch):
+    """auto/dontAsk/bypassPermissions sessions must not be nagged by the
+    catch-all ask gates — but targeted risk gates still protect them."""
+    catchall = ap._compile_policy({"name": "Ask my phone before shell commands",
+                                   "tool": "exec", "pattern_type": "command_regex",
+                                   "pattern": ".*", "action": "require_approval"})
+    risk = ap._compile_policy(dict(RAW_POLICY))  # rm -rf gate
+    monkeypatch.setattr(h, "_load_api_key", lambda: "cm_x")
+    monkeypatch.setattr(h, "_load_policies_fast", lambda k: [catchall, risk])
+
+    calls = []
+    monkeypatch.setattr(ap, "process_tool_call", lambda **kw: (
+        calls.append(kw["policies"]),
+        {"decision": "denied", "policy": kw["policies"][0]["name"]})[1])
+
+    # Benign command in auto mode: catch-all filtered out -> no gate at all.
+    evt = _evt(cmd="ls -la")
+    evt["permission_mode"] = "auto"
+    assert h.evaluate(evt) is None
+    assert calls == []
+
+    # Risky command in auto mode: the rm -rf gate still fires.
+    evt = _evt(cmd="rm -rf /tmp/x")
+    evt["permission_mode"] = "bypassPermissions"
+    assert h.evaluate(evt) is not None
+    assert calls and all(p["name"] != "Ask my phone before shell commands"
+                         for p in calls[0])
+
+    # Default mode: catch-all still gates benign commands.
+    calls.clear()
+    evt = _evt(cmd="ls -la")
+    evt["permission_mode"] = "default"
+    assert h.evaluate(evt) is not None
+
+
 def test_engine_exception_fails_open(monkeypatch):
     monkeypatch.setattr(h, "_load_api_key", lambda: "cm_x")
     monkeypatch.setattr(h, "_load_policies_fast", lambda k: _policies())


### PR DESCRIPTION
permission_mode-aware gating: auto/dontAsk/bypassPermissions sessions skip catch-all ask rules (no more inbox spam from deliberately-autonomous sessions); targeted risk gates still protect every mode; acceptEdits unchanged. +1 test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)