### PR TITLE
feat(license): is_expired + is_perpetual scalar helpers + endpoints

### DIFF
--- a/clawmetry/license.py
+++ b/clawmetry/license.py
@@ -1055,3 +1055,64 @@ def is_expiring_within(days: int) -> bool:
     if remaining is None:
         return False
     return 0 <= remaining <= threshold
+
+
+def is_expired() -> bool:
+    """True iff an installed, signature-valid license has an ``exp`` claim in
+    the past.
+
+    The boolean "already expired" gate that pairs with ``is_expiring_within``
+    (renewal-window warning) and complements the loud red banner a UI might
+    render off ``current_license_info().status == "expired"``: bind a paywall
+    tile directly to this scalar without threading the full license envelope
+    into the component.
+
+    Returns ``False`` for every state that is not "installed, signed, past
+    ``exp``": no license file, invalid signature (an attacker could stuff any
+    ``exp`` into an unsigned body, so we refuse to trust it), perpetual /
+    no-``exp`` keys, and active / future-``exp`` keys.
+
+    Never raises. Any underlying introspection failure (import error,
+    corrupt install, cryptography-lib mismatch) collapses to ``False`` so a
+    caller can bind this into a boolean AND-chain without a try/except.
+    """
+    try:
+        info = current_license_info()
+        if not info:
+            return False
+        return info.get("status") == "expired"
+    except Exception as exc:
+        logger.warning("license: is_expired failed: %s", exc)
+        return False
+
+
+def is_perpetual() -> bool:
+    """True iff an installed, signature-valid license carries no ``exp`` claim.
+
+    A "lifetime" key never expires, so a paywall UI wants to hide the renewal
+    counter and render a "Lifetime" badge instead of "Expires in N days".
+    This scalar answers that gate directly without the caller having to check
+    ``current_license_info()["exp"] is None`` AND rule out the invalid /
+    no-license branches (both of which also collapse ``exp`` to ``None`` but
+    aren't perpetual -- they're *no trustworthy license at all*).
+
+    Returns ``False`` for: no license file, invalid signature (untrusted body
+    -- we don't infer "perpetual" from an unsigned payload), and any signed
+    key that carries an ``exp`` claim regardless of active-vs-expired.
+
+    Never raises. Any underlying introspection failure collapses to ``False``.
+    """
+    try:
+        info = current_license_info()
+        if not info:
+            return False
+        # The invalid-signature branch of ``current_license_info`` collapses
+        # ``exp`` to ``None`` on purpose (we don't trust an unsigned body), so
+        # a naive ``exp is None`` check would misfire and label a *forged*
+        # license as "perpetual". Rule the invalid branch out explicitly.
+        if info.get("status") == "invalid":
+            return False
+        return info.get("exp") is None
+    except Exception as exc:
+        logger.warning("license: is_perpetual failed: %s", exc)
+        return False

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -8177,6 +8177,124 @@ def api_license_expiring_within():
     )
 
 
+def _license_gate_snapshot() -> dict:
+    """Shared one-shot read of the installed-license state for the boolean-gate
+    endpoints below.
+
+    Reads :func:`clawmetry.license.current_license_info` ONCE so the paired
+    ``/api/license/is-expired`` and ``/api/license/is-perpetual`` endpoints
+    can't disagree on ``has_license`` / ``status`` for the same key -- a UI
+    that binds both in the same tile always sees a consistent snapshot.
+
+    Never raises. Any introspection failure (import error, corrupt install,
+    cryptography-lib mismatch) collapses to the no-license shape so the
+    endpoint stack never 5xxs; the "expired" / "perpetual" gates degrade to
+    ``False`` on that branch, matching the module-level scalar helpers'
+    OSS-free posture.
+    """
+    info = None
+    try:
+        from clawmetry import license as _lic
+
+        info = _lic.current_license_info()
+    except Exception as exc:
+        logger.debug("_license_gate_snapshot: error: %s", exc)
+        info = None
+    has_license = info is not None
+    status = info.get("status") if info else None
+    exp = info.get("exp") if info else None
+    return {
+        "has_license": has_license,
+        "status": status,
+        "has_exp": bool(has_license and exp is not None),
+        # An "invalid-signature" branch collapses ``exp`` to ``None`` on
+        # purpose (we don't trust an unsigned body) -- rule it out here so a
+        # forged file can't masquerade as "perpetual" via the gate endpoint.
+        "expired": bool(has_license and status == "expired"),
+        "perpetual": bool(has_license and status != "invalid" and exp is None),
+    }
+
+
+@bp_entitlement.route("/api/license/is-expired")
+def api_license_is_expired():
+    """``GET /api/license/is-expired`` -- boolean gate for "already past the
+    ``exp`` claim".
+
+    Payload:
+
+      * ``expired`` -- ``True`` iff an installed, signature-valid license
+        carries an ``exp`` claim in the past. ``False`` for every other state
+        (no license, invalid signature, perpetual key, active / future ``exp``)
+        so a paywall tile can bind directly to this scalar without threading
+        the full ``/api/license/status`` envelope through.
+      * ``has_license`` -- ``True`` iff a license file is on disk and
+        introspection succeeded, mirroring the ``/api/license/status`` "does a
+        file exist" branch so a UI can distinguish "expired" from "never had
+        one" without a second request.
+      * ``status`` -- passes through ``current_license_info().status``
+        (``"active"`` / ``"expired"`` / ``"invalid"`` / ``None``) so a shared
+        renderer can decide whether to show the loud "expired" banner (from
+        the boolean gate) or the quieter "invalid signature" warning
+        (``status == "invalid"``) alongside it.
+
+    Never 5xxs. Underlying introspection failure degrades to
+    ``{"expired": False, "has_license": False, "status": null}`` at HTTP 200,
+    matching the never-crash posture of ``/api/license/status`` and the
+    surrounding entitlement gate endpoints.
+    """
+    try:
+        snap = _license_gate_snapshot()
+        return jsonify(
+            {
+                "expired": snap["expired"],
+                "has_license": snap["has_license"],
+                "status": snap["status"],
+            }
+        )
+    except Exception as exc:
+        logger.warning("api_license_is_expired: error: %s", exc)
+        return jsonify({"expired": False, "has_license": False, "status": None})
+
+
+@bp_entitlement.route("/api/license/is-perpetual")
+def api_license_is_perpetual():
+    """``GET /api/license/is-perpetual`` -- boolean gate for "lifetime key,
+    no renewal needed".
+
+    Payload:
+
+      * ``perpetual`` -- ``True`` iff an installed, signature-valid license
+        carries NO ``exp`` claim. A UI reading this can hide the renewal
+        counter and render a "Lifetime" badge instead of "Expires in
+        N days". ``False`` for every other state -- no license, invalid
+        signature (we refuse to infer "perpetual" from an untrusted body),
+        and any signed key with an ``exp`` claim.
+      * ``has_license`` -- ``True`` iff a license file is on disk and
+        introspection succeeded, mirroring ``/api/license/is-expired`` so the
+        paired endpoints agree on this key.
+      * ``has_exp`` -- ``True`` iff the installed license carries an ``exp``
+        claim (regardless of active-vs-expired). The complement of
+        ``perpetual`` on the "signature-valid, on-disk" subset -- a UI
+        showing an expiry-date tile can hide it when ``has_exp == False``.
+
+    Never 5xxs. Underlying introspection failure degrades to
+    ``{"perpetual": False, "has_license": False, "has_exp": False}`` at HTTP
+    200.
+    """
+    try:
+        snap = _license_gate_snapshot()
+        return jsonify(
+            {
+                "perpetual": snap["perpetual"],
+                "has_license": snap["has_license"],
+                "has_exp": snap["has_exp"],
+            }
+        )
+    except Exception as exc:
+        logger.warning("api_license_is_perpetual: error: %s", exc)
+        return jsonify({"perpetual": False, "has_license": False, "has_exp": False})
+
+
 @bp_entitlement.route("/api/paywall/event", methods=["POST"])
 def api_paywall_event():
     body: dict = {}

--- a/tests/test_license_is_expired_is_perpetual.py
+++ b/tests/test_license_is_expired_is_perpetual.py
@@ -1,0 +1,436 @@
+"""Tests for the ``is_expired`` / ``is_perpetual`` scalar helpers on
+``clawmetry.license`` and their paired ``/api/license/is-{expired,perpetual}``
+endpoints on ``routes.entitlement``.
+
+These are the two boolean gates on the license-lifecycle axis:
+
+* ``is_expired`` -- installed, signature-valid, ``exp`` in the past.
+* ``is_perpetual`` -- installed, signature-valid, no ``exp`` claim.
+
+They complement the ``is_expiring_within`` renewal-window helper (already in
+flight on a sibling PR) and let a paywall UI bind directly to a boolean URL
+without parsing the full ``/api/license/status`` envelope.
+
+Uses an ephemeral Ed25519 keypair (never the production key) and a tmp_path
+license file so no real file system state is touched.
+"""
+from __future__ import annotations
+
+import time
+from types import SimpleNamespace
+
+import pytest
+from flask import Flask
+
+
+# -- shared helpers (mirrors test_license_api.py) --
+
+
+def _keypair():
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+    priv = Ed25519PrivateKey.generate()
+    pub_pem = priv.public_key().public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    return priv, pub_pem
+
+
+def _payload(tier="pro", nodes=3, exp_delta=365 * 86400, perpetual=False):
+    now = int(time.time())
+    body = {
+        "sub": "acct_test",
+        "tier": tier,
+        "nodes": nodes,
+        "iat": now,
+        "features": ["runtimes"],
+    }
+    if not perpetual:
+        body["exp"] = now + exp_delta
+    return body
+
+
+# -- fixtures --
+
+
+@pytest.fixture
+def env(monkeypatch, tmp_path):
+    """Isolated license env: ephemeral pubkey, tmp license path, no network."""
+    import clawmetry.license as _lic
+
+    priv, pub_pem = _keypair()
+    monkeypatch.setattr(_lic, "_PUBLIC_KEY_PEM", pub_pem)
+    license_path = str(tmp_path / "license.key")
+    monkeypatch.setattr(_lic, "LICENSE_PATH", license_path)
+    monkeypatch.delenv("CLAWMETRY_LICENSE_SERVER", raising=False)
+    monkeypatch.delenv("CLAWMETRY_INGEST_URL", raising=False)
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("CLAWMETRY_OFFLINE", "1")
+
+    from routes.entitlement import bp_entitlement
+
+    flask_app = Flask(__name__)
+    flask_app.register_blueprint(bp_entitlement)
+    flask_app.config["TESTING"] = True
+
+    return SimpleNamespace(
+        app=flask_app,
+        lic=_lic,
+        priv=priv,
+        license_path=license_path,
+    )
+
+
+def _install(env, payload):
+    """Write a signed token to the license path (bypasses ``activate``'s
+    phone-home)."""
+    tok = env.lic._encode_token(payload, env.priv)
+    env.lic._secure_write(env.license_path, tok)
+
+
+def _install_raw(env, raw: str):
+    """Write raw (possibly-forged) contents to the license path."""
+    env.lic._secure_write(env.license_path, raw)
+
+
+# -- module-level scalar: is_expired --
+
+
+def test_is_expired_no_license(env):
+    assert env.lic.is_expired() is False
+
+
+def test_is_expired_active(env):
+    _install(env, _payload(exp_delta=365 * 86400))
+    assert env.lic.is_expired() is False
+
+
+def test_is_expired_expired(env):
+    _install(env, _payload(exp_delta=-3600))
+    assert env.lic.is_expired() is True
+
+
+def test_is_expired_perpetual(env):
+    """Lifetime keys must NOT surface as expired -- perpetual is neither
+    expired nor expiring."""
+    _install(env, _payload(perpetual=True))
+    assert env.lic.is_expired() is False
+
+
+def test_is_expired_invalid_signature(env):
+    """An invalid-signature branch must NOT surface as expired -- a forger
+    could stuff any ``exp`` into an unsigned body, so we refuse to trust it."""
+    _install_raw(env, "CLAW1.eyJ0aWVyIjoicHJvIn0=.not_a_real_signature")
+    assert env.lic.is_expired() is False
+
+
+def test_is_expired_never_raises(env, monkeypatch):
+    def boom():
+        raise RuntimeError("simulated introspection failure")
+
+    monkeypatch.setattr(env.lic, "current_license_info", boom)
+    # Must degrade to False, not propagate the RuntimeError.
+    assert env.lic.is_expired() is False
+
+
+# -- module-level scalar: is_perpetual --
+
+
+def test_is_perpetual_no_license(env):
+    assert env.lic.is_perpetual() is False
+
+
+def test_is_perpetual_active_timed(env):
+    """A signed key with an ``exp`` claim is NOT perpetual, even while active."""
+    _install(env, _payload(exp_delta=365 * 86400))
+    assert env.lic.is_perpetual() is False
+
+
+def test_is_perpetual_expired_timed(env):
+    """A signed key with an ``exp`` claim in the past is expired, not
+    perpetual -- the two gates are mutually exclusive on the same install."""
+    _install(env, _payload(exp_delta=-3600))
+    assert env.lic.is_perpetual() is False
+
+
+def test_is_perpetual_true_when_no_exp_claim(env):
+    _install(env, _payload(perpetual=True))
+    assert env.lic.is_perpetual() is True
+
+
+def test_is_perpetual_rejects_invalid_signature(env):
+    """An invalid-signature branch collapses ``exp`` to ``None`` in
+    ``current_license_info``, but we must NOT infer "perpetual" from an
+    untrusted body -- a forger could produce a bogus file to bypass the
+    renewal counter entirely."""
+    _install_raw(env, "CLAW1.eyJ0aWVyIjoicHJvIn0=.not_a_real_signature")
+    assert env.lic.is_perpetual() is False
+
+
+def test_is_perpetual_never_raises(env, monkeypatch):
+    def boom():
+        raise RuntimeError("simulated introspection failure")
+
+    monkeypatch.setattr(env.lic, "current_license_info", boom)
+    assert env.lic.is_perpetual() is False
+
+
+# -- expired / perpetual mutual exclusion --
+
+
+@pytest.mark.parametrize(
+    "installer",
+    [
+        lambda e: None,  # no license
+        lambda e: _install(e, _payload(exp_delta=365 * 86400)),  # active
+        lambda e: _install(e, _payload(exp_delta=-3600)),  # expired
+        lambda e: _install(e, _payload(perpetual=True)),  # perpetual
+        lambda e: _install_raw(e, "CLAW1.bad.bad"),  # invalid
+    ],
+)
+def test_expired_and_perpetual_never_both_true(env, installer):
+    """The two gates are mutually exclusive -- a UI reading both should never
+    have to decide which to prefer."""
+    installer(env)
+    assert not (env.lic.is_expired() and env.lic.is_perpetual())
+
+
+# -- endpoint: /api/license/is-expired --
+
+
+_EXPIRED_SHAPE = {"expired", "has_license", "status"}
+
+
+def test_endpoint_is_expired_no_license(env):
+    with env.app.test_client() as c:
+        resp = c.get("/api/license/is-expired")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert set(data) == _EXPIRED_SHAPE
+    assert data["expired"] is False
+    assert data["has_license"] is False
+    assert data["status"] is None
+
+
+def test_endpoint_is_expired_active(env):
+    _install(env, _payload(exp_delta=365 * 86400))
+    with env.app.test_client() as c:
+        resp = c.get("/api/license/is-expired")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["expired"] is False
+    assert data["has_license"] is True
+    assert data["status"] == "active"
+
+
+def test_endpoint_is_expired_expired(env):
+    _install(env, _payload(exp_delta=-3600))
+    with env.app.test_client() as c:
+        resp = c.get("/api/license/is-expired")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["expired"] is True
+    assert data["has_license"] is True
+    assert data["status"] == "expired"
+
+
+def test_endpoint_is_expired_perpetual(env):
+    _install(env, _payload(perpetual=True))
+    with env.app.test_client() as c:
+        resp = c.get("/api/license/is-expired")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["expired"] is False
+    assert data["has_license"] is True
+    assert data["status"] == "active"  # perpetual keys are active
+
+
+def test_endpoint_is_expired_invalid_signature(env):
+    _install_raw(env, "CLAW1.eyJ0aWVyIjoicHJvIn0=.not_a_real_signature")
+    with env.app.test_client() as c:
+        resp = c.get("/api/license/is-expired")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    # An invalid signature must NOT surface as "expired" -- the UI wants the
+    # quieter "invalid" branch instead of the loud "expired" banner.
+    assert data["expired"] is False
+    assert data["has_license"] is True
+    assert data["status"] == "invalid"
+
+
+def test_endpoint_is_expired_never_5xx(env, monkeypatch):
+    """Broken install (import / crypto mismatch) must degrade to the
+    no-license shape at HTTP 200 rather than 500 -- matches the never-crash
+    posture of ``/api/license/status`` and ``/api/entitlement``."""
+    def boom():
+        raise RuntimeError("simulated introspection failure")
+
+    monkeypatch.setattr(env.lic, "current_license_info", boom)
+    with env.app.test_client() as c:
+        resp = c.get("/api/license/is-expired")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert set(data) == _EXPIRED_SHAPE
+    assert data["expired"] is False
+    assert data["has_license"] is False
+    assert data["status"] is None
+
+
+# -- endpoint: /api/license/is-perpetual --
+
+
+_PERPETUAL_SHAPE = {"perpetual", "has_license", "has_exp"}
+
+
+def test_endpoint_is_perpetual_no_license(env):
+    with env.app.test_client() as c:
+        resp = c.get("/api/license/is-perpetual")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert set(data) == _PERPETUAL_SHAPE
+    assert data["perpetual"] is False
+    assert data["has_license"] is False
+    assert data["has_exp"] is False
+
+
+def test_endpoint_is_perpetual_active_timed(env):
+    _install(env, _payload(exp_delta=365 * 86400))
+    with env.app.test_client() as c:
+        resp = c.get("/api/license/is-perpetual")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["perpetual"] is False
+    assert data["has_license"] is True
+    assert data["has_exp"] is True
+
+
+def test_endpoint_is_perpetual_expired_timed(env):
+    _install(env, _payload(exp_delta=-3600))
+    with env.app.test_client() as c:
+        resp = c.get("/api/license/is-perpetual")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    # Expired-timed is NOT perpetual; ``has_exp`` still True because the ``exp``
+    # claim exists on-disk regardless of active-vs-past.
+    assert data["perpetual"] is False
+    assert data["has_license"] is True
+    assert data["has_exp"] is True
+
+
+def test_endpoint_is_perpetual_true(env):
+    _install(env, _payload(perpetual=True))
+    with env.app.test_client() as c:
+        resp = c.get("/api/license/is-perpetual")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["perpetual"] is True
+    assert data["has_license"] is True
+    assert data["has_exp"] is False
+
+
+def test_endpoint_is_perpetual_rejects_invalid_signature(env):
+    _install_raw(env, "CLAW1.eyJ0aWVyIjoicHJvIn0=.not_a_real_signature")
+    with env.app.test_client() as c:
+        resp = c.get("/api/license/is-perpetual")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    # Invalid branch: perpetual False (we don't trust the unsigned body),
+    # has_license True (the file exists), has_exp False (the invalid branch
+    # collapses ``exp`` to None on purpose).
+    assert data["perpetual"] is False
+    assert data["has_license"] is True
+    assert data["has_exp"] is False
+
+
+def test_endpoint_is_perpetual_never_5xx(env, monkeypatch):
+    def boom():
+        raise RuntimeError("simulated introspection failure")
+
+    monkeypatch.setattr(env.lic, "current_license_info", boom)
+    with env.app.test_client() as c:
+        resp = c.get("/api/license/is-perpetual")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert set(data) == _PERPETUAL_SHAPE
+    assert data["perpetual"] is False
+    assert data["has_license"] is False
+    assert data["has_exp"] is False
+
+
+# -- cross-consistency between the endpoint pair --
+
+
+@pytest.mark.parametrize(
+    "installer",
+    [
+        pytest.param(lambda e: None, id="no_license"),
+        pytest.param(lambda e: _install(e, _payload(exp_delta=365 * 86400)), id="active"),
+        pytest.param(lambda e: _install(e, _payload(exp_delta=-3600)), id="expired"),
+        pytest.param(lambda e: _install(e, _payload(perpetual=True)), id="perpetual"),
+        pytest.param(lambda e: _install_raw(e, "CLAW1.bad.bad"), id="invalid"),
+    ],
+)
+def test_endpoint_pair_agrees_on_has_license(env, installer):
+    """The paired endpoints share a single snapshot -- they must agree on
+    ``has_license`` for every branch."""
+    installer(env)
+    with env.app.test_client() as c:
+        exp_resp = c.get("/api/license/is-expired").get_json()
+        per_resp = c.get("/api/license/is-perpetual").get_json()
+    assert exp_resp["has_license"] == per_resp["has_license"]
+
+
+@pytest.mark.parametrize(
+    "installer",
+    [
+        pytest.param(lambda e: None, id="no_license"),
+        pytest.param(lambda e: _install(e, _payload(exp_delta=365 * 86400)), id="active"),
+        pytest.param(lambda e: _install(e, _payload(exp_delta=-3600)), id="expired"),
+        pytest.param(lambda e: _install(e, _payload(perpetual=True)), id="perpetual"),
+        pytest.param(lambda e: _install_raw(e, "CLAW1.bad.bad"), id="invalid"),
+    ],
+)
+def test_endpoint_expired_and_perpetual_never_both_true(env, installer):
+    """The two gates are mutually exclusive on every install branch."""
+    installer(env)
+    with env.app.test_client() as c:
+        exp_resp = c.get("/api/license/is-expired").get_json()
+        per_resp = c.get("/api/license/is-perpetual").get_json()
+    assert not (exp_resp["expired"] and per_resp["perpetual"])
+
+
+def test_endpoint_matches_module_scalar(env):
+    """Envelope ``expired`` / ``perpetual`` must byte-match the module-level
+    scalar on every branch -- else a UI bound to the URL sees a different
+    answer than a script importing the helper directly."""
+    for installer in (
+        lambda: None,
+        lambda: _install(env, _payload(exp_delta=365 * 86400)),
+        lambda: _install(env, _payload(exp_delta=-3600)),
+        lambda: _install(env, _payload(perpetual=True)),
+    ):
+        installer()
+        with env.app.test_client() as c:
+            exp_resp = c.get("/api/license/is-expired").get_json()
+            per_resp = c.get("/api/license/is-perpetual").get_json()
+        assert exp_resp["expired"] == env.lic.is_expired()
+        assert per_resp["perpetual"] == env.lic.is_perpetual()
+
+
+def test_endpoint_status_matches_status_endpoint(env):
+    """The ``status`` field on ``/api/license/is-expired`` must match the
+    ``status`` field on ``/api/license/status`` for the same install -- else
+    a UI binding one field from each URL sees inconsistent state."""
+    for installer in (
+        lambda: _install(env, _payload(exp_delta=365 * 86400)),
+        lambda: _install(env, _payload(exp_delta=-3600)),
+        lambda: _install(env, _payload(perpetual=True)),
+        lambda: _install_raw(env, "CLAW1.bad.bad"),
+    ):
+        installer()
+        with env.app.test_client() as c:
+            gate = c.get("/api/license/is-expired").get_json()
+            status = c.get("/api/license/status").get_json()
+        assert gate["status"] == status["status"]


### PR DESCRIPTION
## Summary

Fills the two boolean-gate slots on the license-lifecycle axis, mirroring the "scalar + paired endpoint" pattern already established for the entitlement family (`capacity_headroom_at`, `next_tier_capacity_diff`, `next_tier_unlocks`, …) and now spreading to the license axis (`is_expiring_within` on PR #4081): a module-level scalar helper that returns ONE boolean, plus a shape-parity API endpoint, so a paywall tile can bind directly off the URL without parsing the full `/api/license/status` envelope.

- **`clawmetry/license.py`** — two new module-level helpers:
  - `is_expired() -> bool` — `True` iff an installed, signature-valid license carries an `exp` claim in the past. `False` for every other state (no license file, invalid signature, perpetual / no-`exp` keys, active / future-`exp` keys). The invalid-signature branch collapses `exp` to `None` on purpose (we don't trust an unsigned body), so we key off `status == "expired"` from `current_license_info()` rather than raw `exp` comparison — an attacker who stuffs an `exp` into a forged file can't flip this gate.
  - `is_perpetual() -> bool` — `True` iff an installed, signature-valid license carries NO `exp` claim, so a UI can render a "Lifetime" badge instead of a renewal counter. `False` for no license, invalid signature (we explicitly rule out the invalid branch — else a forger could label a bogus file as "perpetual" and bypass the renewal counter entirely), and any signed key with an `exp` claim regardless of active-vs-expired.
  - Both never raise. Any introspection failure (import error, corrupt install, cryptography-lib mismatch) collapses to `False` so a caller can bind them into a boolean AND-chain without a try/except.

- **`routes/entitlement.py`** — two paired endpoints on `bp_entitlement`:
  - `GET /api/license/is-expired` → `{expired, has_license, status}`.
  - `GET /api/license/is-perpetual` → `{perpetual, has_license, has_exp}`.
  - Shared `_license_gate_snapshot()` helper reads `current_license_info()` once so the endpoint pair can't disagree on `has_license` / `status` for the same installed key.
  - Every branch is HTTP 200; underlying failure degrades to the no-license shape, matching the never-5xx posture of `/api/license/status` and the surrounding entitlement gate endpoints.

- **`tests/test_license_is_expired_is_perpetual.py`** — 41 new tests:
  - Scalar-helper coverage: no-license, active, expired, perpetual, invalid-signature, never-raises.
  - Endpoint envelope shape parity on every branch (fixed 3-key set); envelope value matches the module-level scalar byte-for-byte.
  - Never-5xx via monkeypatched blowup on both endpoints.
  - Mutual-exclusion invariant: `is_expired()` and `is_perpetual()` never both `True` on the same install (parametrised across all five install branches).
  - Cross-consistency: the endpoint pair agrees on `has_license` across all install branches.
  - `status` field on `/api/license/is-expired` matches `status` field on `/api/license/status` across the four file-exists branches — a UI binding one field from each URL can't see inconsistent state.

Purely additive read-side helpers on the open-core license axis — no gate enforcement change, no behavior change on any existing endpoint. Ships in GRACE.

## Test plan

- [x] `python3 -m pytest tests/test_license_is_expired_is_perpetual.py -q` — 41 new tests pass.
- [x] `python3 -m pytest tests/test_license.py tests/test_license_api.py tests/test_license_permissions.py tests/test_license_pubkey.py tests/test_license_audit.py -q` — 99 sibling tests still pass (no regression on the adjacent license surface).
- [x] `python3 -m pytest tests/test_entitlement_api.py tests/test_entitlement_api_fallback_shape.py -q` — 39 sibling entitlement-API tests still pass.
- [x] `python3 -m py_compile clawmetry/license.py routes/entitlement.py tests/test_license_is_expired_is_perpetual.py` — clean.
- [x] `ruff check clawmetry/license.py routes/entitlement.py tests/test_license_is_expired_is_perpetual.py` — clean.
- [x] Blueprint + module import smoke: `from routes.entitlement import bp_entitlement` and `from clawmetry import license as _l; _l.is_expired, _l.is_perpetual` both succeed.

## Local operator verification checklist

The autonomous session cannot reach the running daemon, `~/.openclaw`, the live cloud snapshot, or a browser, so the local operator handles the live-install verification below before flipping this PR from Draft to Ready.

- [ ] Copy changed files into `~/.clawmetry/lib/python3.X/site-packages/clawmetry/` (`license.py`) and `~/.clawmetry/lib/python3.X/site-packages/routes/` (`entitlement.py`); place the new test file under the local `tests/` copy.
- [ ] Clear stale bytecode: `find ~/.clawmetry -name __pycache__ -type d -exec rm -rf {} +`.
- [ ] Restart the sync daemon: `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`.
- [ ] Hit the new endpoints against the running dashboard:
  - `curl -sS http://localhost:8900/api/license/is-expired | jq .` — on an OSS install expect `{"expired":false,"has_license":false,"status":null}`; on an active Pro/Enterprise install expect `{"expired":false,"has_license":true,"status":"active"}`; on an expired install expect `{"expired":true,"has_license":true,"status":"expired"}`.
  - `curl -sS http://localhost:8900/api/license/is-perpetual | jq .` — on an OSS install expect `{"perpetual":false,"has_license":false,"has_exp":false}`; on a timed install expect `{"perpetual":false,"has_license":true,"has_exp":true}`; on a lifetime install expect `{"perpetual":true,"has_license":true,"has_exp":false}`.
- [ ] Confirm cross-consistency with `/api/license/status`:
  - `has_license` on both new endpoints agrees with `status != "no_license"` on `/api/license/status`.
  - `expired` on `/api/license/is-expired` matches `status == "expired"` on `/api/license/status`.
  - `status` field on `/api/license/is-expired` byte-matches the `status` field on `/api/license/status`.
- [ ] Decrypt the live cloud snapshot and confirm the entitlement blueprint still registers cleanly (no import-order regressions from the added helpers).
- [ ] Browser-check that no existing license / paywall tile regressed — the change is purely additive so this is a sanity pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DRgk5Nh5cGwKAC5Xn6WPAC)_