### PR TITLE
fix(c6): zero-prereq close-c6.sh + 2h heal schedule

### DIFF
--- a/.github/workflows/c6-schedule-heal.yml
+++ b/.github/workflows/c6-schedule-heal.yml
@@ -1,7 +1,8 @@
-name: C6 auto-heal (daily required-checks application)
+name: C6 auto-heal (required-checks application)
 
-# Applies required E2E status checks to main branch protection daily.
-# Self-heals C6 the morning after E2E_ADMIN_PAT secret is added.
+# Applies required E2E status checks to main branch protection.
+# Runs every 2 hours and once daily at 10:15am UTC.
+# Self-heals C6 within 2 hours after E2E_ADMIN_PAT secret is added.
 #
 # When E2E_ADMIN_PAT is NOT set:
 #   - emits an ::error:: annotation (visible red badge)
@@ -13,21 +14,34 @@ name: C6 auto-heal (daily required-checks application)
 #   - runs scripts/apply_required_status_checks.py to configure checks
 #   - writes a post-apply summary
 #
-# To close C6 without waiting for tomorrow:
-#   Actions > "Apply required E2E status checks (C6 -- one-shot)" >
-#   confirm=APPLY, pat_token=<PAT> > Run workflow
+# Fastest close paths (no waiting for this schedule):
 #
-# To close C6 automatically:
-#   Settings > Secrets > Actions > New secret: E2E_ADMIN_PAT
-#   Value: fine-grained PAT with Administration (read+write) on:
-#     clawmetry, clawmetry-cloud, clawmetry-landing
-#   This workflow picks it up at 10:15am UTC and closes C6 automatically.
+#   Option A (Settings UI, 60 s, browser only):
+#     https://github.com/vivekchand/clawmetry/settings/branches
+#     > edit main > Require status checks > add check names below.
+#     Also update clawmetry-cloud/main and clawmetry-landing/main.
+#
+#   Option B (Actions one-shot, PAT paste):
+#     Actions > "Apply required E2E status checks (C6 -- one-shot)"
+#     confirm=APPLY, pat_token=<PAT> > Run workflow
+#     PAT creation: https://github.com/settings/personal-access-tokens/new?name=clawmetry-c6
+#     Permissions: Administration read+write on clawmetry/clawmetry-cloud/clawmetry-landing
+#
+#   Option C (terminal, 30 s, now zero-prerequisites):
+#     bash scripts/close-c6.sh
+#     (auto-installs gh CLI on macOS/Ubuntu if needed)
+#
+#   Option D (set-and-forget -- this workflow does the rest):
+#     Settings > Secrets > Actions > New secret: E2E_ADMIN_PAT
+#     Value: same PAT from Option B
+#     This workflow picks it up within 2 hours and closes C6.
 #
 # Tracking: vivekchand/clawmetry#4029
 
 on:
   schedule:
-    - cron: '15 10 * * *'  # 10:15am UTC daily
+    - cron: '0 */2 * * *'   # every 2 hours -- heals within 2h of E2E_ADMIN_PAT being set
+    - cron: '15 10 * * *'   # 10:15am UTC daily (kept for predictability)
   workflow_dispatch:
 
 permissions:
@@ -80,11 +94,6 @@ jobs:
           ALL_OK=true
           SUMMARY_ROWS=""
           for REPO in $REPOS; do
-            # Read BOTH 'contexts' (legacy API/script path) AND 'checks'
-            # (GitHub Settings UI path) into a single sorted JSON array.
-            # The old jq query (.protection.required_status_checks.contexts // [])
-            # only read the legacy array, causing false MISSING reports after
-            # an admin used Option A (Settings UI) to configure required checks.
             PROTECTION=$(gh api "/repos/${OWNER}/${REPO}/branches/main" 2>/dev/null | \
               python3 -c "
 import json, sys
@@ -115,7 +124,6 @@ except Exception:
             done
           done
 
-          # Write the job summary
           {
             echo "## C6: Required E2E Status Checks"
             echo ""
@@ -153,14 +161,14 @@ except Exception:
               echo "2. [Run Apply workflow](https://github.com/vivekchand/clawmetry/actions/workflows/apply-required-checks.yml)"
               echo "   -- \`confirm=APPLY\`, \`pat_token=<PAT>\` -- closes all 3 repos in one run"
               echo ""
-              echo "**Option C -- store PAT as secret (auto-heals daily at 10:15 UTC):**"
-              echo "- [Settings > Secrets > New secret](https://github.com/vivekchand/clawmetry/settings/secrets/actions/new)"
-              echo "  Name: \`E2E_ADMIN_PAT\`, Value: same PAT from Option B"
-              echo ""
-              echo "**Option D -- terminal (uses existing gh CLI session, ~30 sec):**"
+              echo "**Option C -- terminal (zero prerequisites, auto-installs gh CLI on macOS/Ubuntu):**"
               echo "\`\`\`bash"
               echo "bash scripts/close-c6.sh"
               echo "\`\`\`"
+              echo ""
+              echo "**Option D -- store PAT as secret (this workflow heals within 2 hours):**"
+              echo "- [Settings > Secrets > New secret](https://github.com/vivekchand/clawmetry/settings/secrets/actions/new)"
+              echo "  Name: \`E2E_ADMIN_PAT\`, Value: same PAT from Option B"
               echo ""
               echo "Tracking: [#4029](https://github.com/vivekchand/clawmetry/issues/4029)"
             fi
@@ -198,5 +206,4 @@ except Exception:
             echo ""
             echo "Tracking: [#4029](https://github.com/vivekchand/clawmetry/issues/4029)"
           } >> "$GITHUB_STEP_SUMMARY"
-          echo "C6 auto-heal complete. If apply_required_status_checks.py exited 0, branch protection"
-          echo "is configured on all 3 repos. Tracking: https://github.com/vivekchand/clawmetry/issues/4029"
+          echo "C6 auto-heal complete. Tracking: https://github.com/vivekchand/clawmetry/issues/4029"

--- a/scripts/close-c6.sh
+++ b/scripts/close-c6.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
-# close-c6.sh: Apply required E2E status checks across all 3 repos in one shot.
+# close-c6.sh: Apply required E2E status checks across all 3 repos.
 #
-# Prerequisites: gh CLI installed and authenticated as repo admin. ~30 seconds.
-# No PAT creation, no repo secret setup, no Actions UI needed.
+# Zero prerequisites -- auto-installs gh CLI on macOS (brew) and
+# Ubuntu/Debian (apt) if not already present. ~30-60 seconds total.
 #
 # Usage:
 #   bash scripts/close-c6.sh
@@ -19,7 +19,7 @@
 # After running: every PR in those 3 repos must pass the E2E suite to merge.
 # This closes criterion C6 of the E2E Robustness epic.
 #
-# Tracking: vivekchand/clawmetry#3970
+# Tracking: vivekchand/clawmetry#4029
 
 set -euo pipefail
 
@@ -37,16 +37,56 @@ echo "  clawmetry-cloud   : Cloud golden-path browser E2E"
 echo "  clawmetry-landing : Landing golden path (C3)"
 echo ""
 
+# Auto-install gh CLI if not present.
+# Supports macOS (brew), Ubuntu/Debian (apt), and exits clearly on others.
 if ! command -v gh &>/dev/null; then
-  echo "ERROR: gh CLI not found."
-  echo "Install from https://cli.github.com then run: gh auth login"
-  exit 1
+  echo "gh CLI not found. Attempting auto-install..."
+  if command -v brew &>/dev/null; then
+    echo "  macOS detected -- installing via brew"
+    brew install gh
+  elif command -v apt-get &>/dev/null; then
+    echo "  Ubuntu/Debian detected -- installing via apt"
+    if ! command -v curl &>/dev/null; then
+      sudo apt-get install -y curl
+    fi
+    curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+      | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
+    sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] \
+https://cli.github.com/packages stable main" \
+      | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+    sudo apt-get update && sudo apt-get install -y gh
+  else
+    echo "ERROR: Cannot auto-install gh CLI on this platform."
+    echo "Install manually from https://cli.github.com then re-run."
+    echo ""
+    echo "Or skip gh CLI entirely -- use the browser path instead:"
+    echo "  1. Create PAT: https://github.com/settings/personal-access-tokens/new?name=clawmetry-c6"
+    echo "     Repos: clawmetry, clawmetry-cloud, clawmetry-landing"
+    echo "     Permission: Administration -- read+write"
+    echo "  2. GitHub Actions > Apply required E2E status checks (C6) > Run workflow"
+    echo "     confirm=APPLY, pat_token=<paste PAT>"
+    exit 1
+  fi
+  echo "gh CLI installed successfully."
+  echo ""
 fi
 
+# Authenticate if needed. Opens browser on interactive terminals;
+# errors clearly on non-interactive shells (e.g. CI) where web auth
+# cannot complete.
 if ! gh auth status --active 2>/dev/null; then
-  echo ""
-  echo "ERROR: gh CLI is not authenticated. Run: gh auth login"
-  exit 1
+  if [ -t 0 ]; then
+    echo "gh CLI not authenticated. Opening browser for GitHub auth..."
+    gh auth login --web
+  else
+    echo "ERROR: gh CLI is not authenticated and no interactive terminal is available."
+    echo "Run interactively: bash scripts/close-c6.sh"
+    echo "Or use the browser path:"
+    echo "  GitHub Actions > Apply required E2E status checks (C6 -- one-shot)"
+    echo "  confirm=APPLY, pat_token=<fine-grained PAT with Administration: read+write>"
+    exit 1
+  fi
 fi
 
 TOKEN=$(gh auth token)


### PR DESCRIPTION
## Summary

C6 (required-status-checks) is the sole remaining E2E gap. This PR removes two friction points that slow down closing it.

### Changes

**`scripts/close-c6.sh` -- zero prerequisites**
- Auto-installs gh CLI on macOS (brew) and Ubuntu/Debian (apt) if not present
- Adds interactive `gh auth login --web` fallback when not authenticated
- Errors clearly on non-interactive shells (CI) with a browser-path alternative
- Fixes tracking issue reference from #3970 to #4029

**`.github/workflows/c6-schedule-heal.yml` -- faster auto-heal**
- Adds `0 */2 * * *` cron schedule (every 2 hours) alongside the existing daily 10:15am UTC run
- When `E2E_ADMIN_PAT` is set, C6 now heals within 2 hours rather than waiting up to 24h for the next 10:15am UTC window
- Updates close-option docs to note that `close-c6.sh` is now zero-prerequisites

### Why

The two fastest close paths for C6 are:
- **Option A**: Settings UI, 60 s, browser only (no code change needed)
- **Option C**: `bash scripts/close-c6.sh` -- previously required gh CLI installed; now installs itself

Once `E2E_ADMIN_PAT` is stored as a repo secret, this workflow previously took up to 24h to pick it up. The every-2h schedule closes that window.

## Test plan

- [ ] Verify `close-c6.sh` still works with gh CLI pre-installed (unchanged path)
- [ ] Test auto-install on a fresh Ubuntu container: `docker run --rm ubuntu bash -c "apt-get update -q && apt-get install -y -q python3 bash curl && bash scripts/close-c6.sh"`
- [ ] Confirm `c6-schedule-heal.yml` lint passes (YAML validity)

Tracking: #4029 (C6 -- sole remaining E2E gap)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gr48Qin54md23bHegaCGZW)_