### PR TITLE
feat(license): license_tier + is_tier scalar helpers + endpoints

### DIFF
--- a/clawmetry/license.py
+++ b/clawmetry/license.py
@@ -1055,3 +1055,78 @@ def is_expiring_within(days: int) -> bool:
     if remaining is None:
         return False
     return 0 <= remaining <= threshold
+
+
+def license_tier() -> str | None:
+    """Scalar view onto the installed license's ``tier`` claim -- for a
+    paywall tile / tier badge that wants ONE string rather than the whole
+    :func:`current_license_info` envelope.
+
+    Returns:
+      * ``None`` when there is nothing trustworthy to surface:
+        no license file on disk, an invalid signature (the payload
+        can't be trusted -- an attacker could stuff any tier into an
+        unsigned body), OR a signed payload whose ``tier`` claim is
+        absent / non-string / an empty string after strip.
+      * A lowercased, whitespace-stripped tier string otherwise
+        (typically ``"pro"``, ``"enterprise"``, or ``"trial"``, but the
+        helper is deliberately open-ended so a future tier lands
+        without a code change).
+
+    Casing is normalised so a caller can compare against a hard-coded
+    ``"pro"`` without a ``.lower()`` on every read; the raw claim from
+    :func:`current_license_info` is preserved separately for UIs that
+    want the operator-visible form.
+
+    Never raises. Any exception under the hood degrades to ``None`` so a
+    UI tile bound to this helper never breaks on a partial install.
+    """
+    try:
+        info = current_license_info()
+    except Exception as exc:
+        logger.debug("license: license_tier underlying read failed: %s", exc)
+        return None
+    if not isinstance(info, dict):
+        return None
+    if not info.get("valid"):
+        # Invalid-signature / expired branches: current_license_info() may
+        # still surface ``tier`` on the expired branch (the signature was
+        # good at signing time, only the ``exp`` claim has passed), but a
+        # tier scalar for gating paywall UI should refuse expired keys the
+        # same way it refuses unsigned ones -- otherwise a lapsed Pro
+        # customer keeps rendering as "Pro" until they re-activate.
+        return None
+    tier = info.get("tier")
+    if not isinstance(tier, str):
+        return None
+    normalized = tier.strip().lower()
+    return normalized or None
+
+
+def is_tier(tier: str) -> bool:
+    """Boolean gate for "am I on tier <X>?" UIs.
+
+    Returns ``True`` iff a license is installed, signature-valid, NOT
+    expired, and its normalised ``tier`` claim exactly matches ``tier``
+    (case-insensitive, whitespace-stripped). Every other state returns
+    ``False``: no license, invalid signature, expired key, missing/empty
+    ``tier`` claim, or a live tier that simply differs from the request.
+
+    ``tier`` is coerced through ``str()`` and normalised the same way
+    :func:`license_tier` normalises the stored claim, so a caller can
+    pass ``"Pro"``, ``"pro"``, or ``"  PRO "`` and get the same answer.
+    Non-string / empty input collapses to ``False`` (nothing "is tier
+    empty-string"). Never raises; every underlying failure returns
+    ``False`` so a scheduled paywall renderer never crashes on a bad
+    install.
+    """
+    try:
+        requested = str(tier).strip().lower()
+    except Exception:
+        return False
+    if not requested:
+        return False
+    actual = license_tier()
+    if actual is None:
+        return False
+    return actual == requested

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -8053,6 +8053,131 @@ def api_license_expiring_within():
     )
 
 
+def _license_tier_snapshot() -> dict:
+    """Shared helper: read once, derive the trio the two tier endpoints
+    both need (``tier``, ``has_license``, ``valid``). Lives in the
+    handler layer -- not in :mod:`clawmetry.license` -- because
+    ``has_license`` is an install-state fact rather than a license-payload
+    fact, and both endpoints below need the pair together so a UI cannot
+    catch them disagreeing on ``has_license`` for the same install.
+
+    Never raises: any underlying failure collapses to
+    ``{tier: None, has_license: False, valid: False}`` so callers keep
+    the "OSS-free" branch shape.
+    """
+    try:
+        from clawmetry import license as _lic
+
+        info = _lic.current_license_info()
+        tier = _lic.license_tier()
+    except Exception as exc:
+        logger.debug("_license_tier_snapshot: underlying read failed: %s", exc)
+        return {"tier": None, "has_license": False, "valid": False}
+    if not isinstance(info, dict):
+        return {"tier": None, "has_license": False, "valid": False}
+    return {
+        "tier": tier,
+        "has_license": True,
+        "valid": bool(info.get("valid")),
+    }
+
+
+@bp_entitlement.route("/api/license/tier")
+def api_license_tier():
+    """``GET /api/license/tier`` -- scalar view of the installed license's
+    tier claim, for a paywall tile / tier badge that wants ONE string
+    rather than the whole ``/api/license/status`` envelope.
+
+    Response shape (always HTTP 200)::
+
+        {
+          "tier": <str|null>,        # normalised (lowercased, stripped) tier
+          "has_license": <bool>,     # is a license file installed at all?
+          "valid": <bool>            # signature-valid AND not expired
+        }
+
+    ``tier`` mirrors :func:`clawmetry.license.license_tier`: ``None`` for
+    no license, invalid signature, or expired install -- an expired Pro
+    key deliberately collapses to ``null`` so a paywall tile that keys
+    off this field cannot keep rendering "Pro" for a lapsed customer.
+    A caller who wants ``sub`` / ``nodes`` / ``exp`` alongside should
+    keep hitting ``/api/license/status``.
+
+    Never 5xxs -- any underlying failure degrades to
+    ``{tier: null, has_license: false, valid: false}`` (the OSS-free
+    branch shape), matching the "never crash on bad input" posture of
+    the surrounding license endpoints.
+    """
+    try:
+        return jsonify(_license_tier_snapshot())
+    except Exception as exc:
+        logger.warning("api_license_tier: error: %s", exc)
+        return jsonify({"tier": None, "has_license": False, "valid": False})
+
+
+@bp_entitlement.route("/api/license/is-tier")
+def api_license_is_tier():
+    """``GET /api/license/is-tier?tier=<name>`` -- boolean gate for
+    "am I on tier <X> right now?" UIs.
+
+    Query parameters:
+      * ``tier`` (str, required) -- the tier to test against. Compared
+        case-insensitively after strip, matching
+        :func:`clawmetry.license.is_tier`. Missing / empty input degrades
+        to ``is_tier=false`` rather than a 4xx, matching the surrounding
+        endpoints' never-5xx / never-4xx posture.
+
+    Response shape (always HTTP 200)::
+
+        {
+          "is_tier": <bool>,
+          "tier": <str|null>,          # currently-installed tier
+          "requested_tier": <str>,     # normalised echo of the query
+          "has_license": <bool>,
+          "valid": <bool>              # signature-valid AND not expired
+        }
+
+    ``is_tier`` is ``True`` iff a license is installed, signature-valid,
+    NOT expired, and its normalised tier byte-equals ``requested_tier``.
+    An expired Pro install returns ``is_tier=false`` even for
+    ``?tier=pro`` on purpose -- the caller wants "am I entitled right
+    now" not "was I ever entitled", and the ``valid`` field carries the
+    "signed but lapsed" signal so a paywall UI can drive both banners
+    off one URL.
+
+    Mirrors :func:`clawmetry.license.is_tier` -- the HTTP shape layers
+    ``tier`` / ``requested_tier`` / ``has_license`` / ``valid`` on top
+    of that bool so a widget never needs a second call to
+    ``/api/license/status`` to render the accompanying "you're on X"
+    copy.
+    """
+    raw = request.args.get("tier", "") or ""
+    try:
+        requested = str(raw).strip().lower()
+    except Exception:
+        requested = ""
+    try:
+        snap = _license_tier_snapshot()
+    except Exception as exc:
+        logger.warning("api_license_is_tier: error: %s", exc)
+        snap = {"tier": None, "has_license": False, "valid": False}
+    match = bool(
+        requested
+        and snap["valid"]
+        and isinstance(snap["tier"], str)
+        and snap["tier"] == requested
+    )
+    return jsonify(
+        {
+            "is_tier": match,
+            "tier": snap["tier"],
+            "requested_tier": requested,
+            "has_license": snap["has_license"],
+            "valid": snap["valid"],
+        }
+    )
+
+
 @bp_entitlement.route("/api/paywall/event", methods=["POST"])
 def api_paywall_event():
     body: dict = {}

--- a/tests/test_license_tier_scalar.py
+++ b/tests/test_license_tier_scalar.py
@@ -1,0 +1,501 @@
+"""Tests for the license-tier scalar helpers and endpoints.
+
+Covers:
+  * clawmetry.license.license_tier()   -- module-level scalar.
+  * clawmetry.license.is_tier()        -- boolean gate.
+  * GET /api/license/tier              -- envelope, never-5xx.
+  * GET /api/license/is-tier           -- envelope, never-5xx, bad-input degrade.
+
+Hermetic: each test mints tokens with its own ephemeral keypair and
+monkeypatches the module's embedded public key + LICENSE_PATH so nothing
+depends on the real production signing key or on real filesystem state.
+"""
+from __future__ import annotations
+
+import os
+import time
+from types import SimpleNamespace
+
+import pytest
+from flask import Flask
+
+
+# -- shared helpers (mirror test_license_days_until_expiry.py) ---------------
+
+
+def _keypair():
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+    priv = Ed25519PrivateKey.generate()
+    pub_pem = priv.public_key().public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    return priv, pub_pem
+
+
+def _payload(tier="pro", nodes=3, exp_delta=365 * 86400, drop_exp=False):
+    now = int(time.time())
+    p = {
+        "sub": "acct_test",
+        "tier": tier,
+        "nodes": nodes,
+        "iat": now,
+        "exp": now + exp_delta,
+        "features": ["runtimes"],
+    }
+    if drop_exp:
+        p.pop("exp", None)
+    return p
+
+
+@pytest.fixture
+def app(monkeypatch, tmp_path):
+    import clawmetry.license as _lic
+
+    priv, pub_pem = _keypair()
+    monkeypatch.setattr(_lic, "_PUBLIC_KEY_PEM", pub_pem)
+    license_path = str(tmp_path / "license.key")
+    monkeypatch.setattr(_lic, "LICENSE_PATH", license_path)
+    monkeypatch.delenv("CLAWMETRY_LICENSE_SERVER", raising=False)
+    monkeypatch.delenv("CLAWMETRY_INGEST_URL", raising=False)
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("CLAWMETRY_OFFLINE", "1")
+
+    from routes.entitlement import bp_entitlement
+
+    flask_app = Flask(__name__)
+    flask_app.register_blueprint(bp_entitlement)
+    flask_app.config["TESTING"] = True
+
+    return SimpleNamespace(
+        app=flask_app,
+        lic=_lic,
+        priv=priv,
+        license_path=license_path,
+    )
+
+
+def _write_key_direct(app, exp_delta, tier="pro"):
+    """Bypass activate() (which refuses expired tokens) and write a token
+    directly to the license file. Simulates a license that expired AFTER
+    it was installed -- the branch current_license_info() has to handle."""
+    tok = app.lic._encode_token(_payload(tier=tier, exp_delta=exp_delta), app.priv)
+    os.makedirs(os.path.dirname(app.license_path), exist_ok=True)
+    with open(app.license_path, "w", encoding="utf-8") as fh:
+        fh.write(tok)
+
+
+# -- clawmetry.license.license_tier() ----------------------------------------
+
+
+def test_license_tier_no_license(app):
+    """No license file on disk -> None (nothing trustworthy to surface)."""
+    assert app.lic.license_tier() is None
+
+
+def test_license_tier_active_pro(app):
+    tok = app.lic._encode_token(_payload(tier="pro"), app.priv)
+    app.lic.activate(tok)
+    assert app.lic.license_tier() == "pro"
+
+
+def test_license_tier_active_enterprise(app):
+    tok = app.lic._encode_token(_payload(tier="enterprise"), app.priv)
+    app.lic.activate(tok)
+    assert app.lic.license_tier() == "enterprise"
+
+
+def test_license_tier_open_ended(app):
+    """A future tier lands without a code change -- helper is deliberately
+    open-ended, not a hard-coded enum."""
+    tok = app.lic._encode_token(_payload(tier="ultra"), app.priv)
+    app.lic.activate(tok)
+    assert app.lic.license_tier() == "ultra"
+
+
+def test_license_tier_normalises_casing(app):
+    """A tier stored as ``"Pro"`` or ``"  PRO "`` -> lowercased + stripped."""
+    tok = app.lic._encode_token(_payload(tier="  PRO  "), app.priv)
+    app.lic.activate(tok)
+    assert app.lic.license_tier() == "pro"
+
+
+def test_license_tier_expired_collapses_to_none(app):
+    """Expired keys collapse to None -- a lapsed Pro customer must NOT keep
+    rendering as ``"pro"`` until they re-activate. The gate matches
+    is_expired() semantics."""
+    _write_key_direct(app, exp_delta=-5 * 86400, tier="pro")
+    assert app.lic.license_tier() is None
+
+
+def test_license_tier_invalid_signature(app):
+    """File exists but signature bogus -> None. Never trust an unsigned
+    body's tier claim; a forger could stuff any value."""
+    os.makedirs(os.path.dirname(app.license_path), exist_ok=True)
+    with open(app.license_path, "w", encoding="utf-8") as fh:
+        fh.write("CLAW1.garbage.garbage")
+    assert app.lic.license_tier() is None
+
+
+def test_license_tier_empty_string_claim(app):
+    """A payload with ``tier=""`` -> None (nothing to gate off empty string)."""
+    tok = app.lic._encode_token(_payload(tier=""), app.priv)
+    app.lic.activate(tok)
+    assert app.lic.license_tier() is None
+
+
+def test_license_tier_whitespace_only_claim(app):
+    """A payload with ``tier="   "`` -> None after strip."""
+    tok = app.lic._encode_token(_payload(tier="   "), app.priv)
+    app.lic.activate(tok)
+    assert app.lic.license_tier() is None
+
+
+def test_license_tier_non_string_claim(app, monkeypatch):
+    """A payload with ``tier=123`` -> None (never returns non-string)."""
+    monkeypatch.setattr(
+        app.lic,
+        "current_license_info",
+        lambda: {"valid": True, "tier": 123, "status": "active"},
+    )
+    assert app.lic.license_tier() is None
+
+
+def test_license_tier_never_raises(monkeypatch):
+    """Any underlying failure -> None. Even a fully-broken
+    current_license_info() must not propagate."""
+    import clawmetry.license as _lic
+
+    def _boom():
+        raise RuntimeError("simulated corrupt install")
+
+    monkeypatch.setattr(_lic, "current_license_info", _boom)
+    assert _lic.license_tier() is None
+
+
+# -- clawmetry.license.is_tier() ---------------------------------------------
+
+
+def test_is_tier_no_license(app):
+    """No license -> False regardless of the requested tier."""
+    assert app.lic.is_tier("pro") is False
+    assert app.lic.is_tier("enterprise") is False
+
+
+def test_is_tier_matching(app):
+    tok = app.lic._encode_token(_payload(tier="pro"), app.priv)
+    app.lic.activate(tok)
+    assert app.lic.is_tier("pro") is True
+
+
+def test_is_tier_non_matching(app):
+    tok = app.lic._encode_token(_payload(tier="pro"), app.priv)
+    app.lic.activate(tok)
+    assert app.lic.is_tier("enterprise") is False
+
+
+def test_is_tier_case_insensitive_query(app):
+    tok = app.lic._encode_token(_payload(tier="pro"), app.priv)
+    app.lic.activate(tok)
+    assert app.lic.is_tier("Pro") is True
+    assert app.lic.is_tier("  PRO ") is True
+
+
+def test_is_tier_case_insensitive_stored(app):
+    """A tier stored as ``"Enterprise"`` still matches a plain
+    ``"enterprise"`` query -- both sides are normalised."""
+    tok = app.lic._encode_token(_payload(tier="Enterprise"), app.priv)
+    app.lic.activate(tok)
+    assert app.lic.is_tier("enterprise") is True
+
+
+def test_is_tier_expired_is_not_current(app):
+    """An expired Pro install returns False even for ``is_tier('pro')`` --
+    the gate asks 'am I entitled right now', not 'was I ever entitled'."""
+    _write_key_direct(app, exp_delta=-5 * 86400, tier="pro")
+    assert app.lic.is_tier("pro") is False
+
+
+def test_is_tier_invalid_signature(app):
+    """Bogus file -> False regardless of the requested tier."""
+    os.makedirs(os.path.dirname(app.license_path), exist_ok=True)
+    with open(app.license_path, "w", encoding="utf-8") as fh:
+        fh.write("CLAW1.garbage.garbage")
+    assert app.lic.is_tier("pro") is False
+
+
+def test_is_tier_empty_query(app):
+    """Empty / whitespace-only query -> False. Nothing 'is tier <blank>'."""
+    tok = app.lic._encode_token(_payload(tier="pro"), app.priv)
+    app.lic.activate(tok)
+    assert app.lic.is_tier("") is False
+    assert app.lic.is_tier("   ") is False
+
+
+def test_is_tier_non_string_query(app):
+    """Non-string / None input coerces safely to False without a TypeError."""
+    tok = app.lic._encode_token(_payload(tier="pro"), app.priv)
+    app.lic.activate(tok)
+    assert app.lic.is_tier(None) is False  # type: ignore[arg-type]
+    assert app.lic.is_tier(0) is False  # type: ignore[arg-type]
+
+
+def test_is_tier_never_raises(monkeypatch):
+    import clawmetry.license as _lic
+
+    def _boom():
+        raise RuntimeError("simulated corrupt install")
+
+    monkeypatch.setattr(_lic, "current_license_info", _boom)
+    assert _lic.is_tier("pro") is False
+
+
+# -- GET /api/license/tier ---------------------------------------------------
+
+
+def test_endpoint_tier_no_license(app):
+    with app.app.test_client() as c:
+        resp = c.get("/api/license/tier")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data == {"tier": None, "has_license": False, "valid": False}
+
+
+def test_endpoint_tier_active(app):
+    tok = app.lic._encode_token(_payload(tier="pro"), app.priv)
+    app.lic.activate(tok)
+    with app.app.test_client() as c:
+        resp = c.get("/api/license/tier")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data == {"tier": "pro", "has_license": True, "valid": True}
+
+
+def test_endpoint_tier_expired(app):
+    """Expired install -> tier collapses to None but has_license stays True
+    and valid flips to False. A UI can drive both 'no Pro right now' and
+    'you had Pro' banners off one call."""
+    _write_key_direct(app, exp_delta=-5 * 86400, tier="pro")
+    with app.app.test_client() as c:
+        resp = c.get("/api/license/tier")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["tier"] is None
+    assert data["has_license"] is True
+    assert data["valid"] is False
+
+
+def test_endpoint_tier_invalid_file(app):
+    os.makedirs(os.path.dirname(app.license_path), exist_ok=True)
+    with open(app.license_path, "w", encoding="utf-8") as fh:
+        fh.write("CLAW1.garbage.garbage")
+    with app.app.test_client() as c:
+        resp = c.get("/api/license/tier")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["tier"] is None
+    assert data["has_license"] is True
+    assert data["valid"] is False
+
+
+def test_endpoint_tier_normalises_casing(app):
+    tok = app.lic._encode_token(_payload(tier="  PRO "), app.priv)
+    app.lic.activate(tok)
+    with app.app.test_client() as c:
+        resp = c.get("/api/license/tier")
+    assert resp.status_code == 200
+    assert resp.get_json()["tier"] == "pro"
+
+
+def test_endpoint_tier_never_5xxs(app, monkeypatch):
+    from routes import entitlement as _routes
+
+    monkeypatch.setattr(
+        _routes,
+        "_license_tier_snapshot",
+        lambda: (_ for _ in ()).throw(RuntimeError("simulated blowup")),
+    )
+    with app.app.test_client() as c:
+        resp = c.get("/api/license/tier")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data == {"tier": None, "has_license": False, "valid": False}
+
+
+# -- GET /api/license/is-tier ------------------------------------------------
+
+
+def test_endpoint_is_tier_no_license(app):
+    with app.app.test_client() as c:
+        resp = c.get("/api/license/is-tier?tier=pro")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data == {
+        "is_tier": False,
+        "tier": None,
+        "requested_tier": "pro",
+        "has_license": False,
+        "valid": False,
+    }
+
+
+def test_endpoint_is_tier_matching(app):
+    tok = app.lic._encode_token(_payload(tier="pro"), app.priv)
+    app.lic.activate(tok)
+    with app.app.test_client() as c:
+        resp = c.get("/api/license/is-tier?tier=pro")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["is_tier"] is True
+    assert data["tier"] == "pro"
+    assert data["requested_tier"] == "pro"
+    assert data["has_license"] is True
+    assert data["valid"] is True
+
+
+def test_endpoint_is_tier_non_matching(app):
+    tok = app.lic._encode_token(_payload(tier="pro"), app.priv)
+    app.lic.activate(tok)
+    with app.app.test_client() as c:
+        resp = c.get("/api/license/is-tier?tier=enterprise")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["is_tier"] is False
+    assert data["tier"] == "pro"
+    assert data["requested_tier"] == "enterprise"
+    assert data["valid"] is True
+
+
+def test_endpoint_is_tier_case_insensitive(app):
+    tok = app.lic._encode_token(_payload(tier="Enterprise"), app.priv)
+    app.lic.activate(tok)
+    with app.app.test_client() as c:
+        resp = c.get("/api/license/is-tier?tier=ENTERPRISE")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["is_tier"] is True
+    assert data["tier"] == "enterprise"
+    assert data["requested_tier"] == "enterprise"
+
+
+def test_endpoint_is_tier_expired_is_not_current(app):
+    """Expired install -> is_tier=false even for the tier the payload
+    carries -- ``valid`` still surfaces False so a UI can render an
+    'was Pro, renew' banner from one call."""
+    _write_key_direct(app, exp_delta=-5 * 86400, tier="pro")
+    with app.app.test_client() as c:
+        resp = c.get("/api/license/is-tier?tier=pro")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["is_tier"] is False
+    assert data["tier"] is None
+    assert data["has_license"] is True
+    assert data["valid"] is False
+
+
+def test_endpoint_is_tier_empty_query(app):
+    """Missing / empty ``tier`` param -> HTTP 200 with is_tier=false and
+    requested_tier='' (never a 4xx)."""
+    tok = app.lic._encode_token(_payload(tier="pro"), app.priv)
+    app.lic.activate(tok)
+    with app.app.test_client() as c:
+        resp = c.get("/api/license/is-tier")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["is_tier"] is False
+    assert data["requested_tier"] == ""
+    assert data["tier"] == "pro"
+    assert data["has_license"] is True
+    assert data["valid"] is True
+
+
+def test_endpoint_is_tier_whitespace_query(app):
+    tok = app.lic._encode_token(_payload(tier="pro"), app.priv)
+    app.lic.activate(tok)
+    with app.app.test_client() as c:
+        resp = c.get("/api/license/is-tier?tier=%20%20")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["is_tier"] is False
+    assert data["requested_tier"] == ""
+
+
+def test_endpoint_is_tier_never_5xxs(app, monkeypatch):
+    from routes import entitlement as _routes
+
+    monkeypatch.setattr(
+        _routes,
+        "_license_tier_snapshot",
+        lambda: (_ for _ in ()).throw(RuntimeError("simulated blowup")),
+    )
+    with app.app.test_client() as c:
+        resp = c.get("/api/license/is-tier?tier=pro")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["is_tier"] is False
+    assert data["tier"] is None
+    assert data["requested_tier"] == "pro"
+    assert data["has_license"] is False
+    assert data["valid"] is False
+
+
+# -- cross-consistency --------------------------------------------------------
+
+
+def test_tier_endpoints_agree_on_has_license(app):
+    """Both endpoints must return the same ``has_license`` for the same
+    install -- otherwise a UI binding one to each URL sees inconsistent
+    state."""
+    for scenario in ("none", "active", "expired", "invalid"):
+        if scenario == "active":
+            tok = app.lic._encode_token(_payload(tier="pro"), app.priv)
+            app.lic.activate(tok)
+        elif scenario == "expired":
+            _write_key_direct(app, exp_delta=-1 * 86400, tier="pro")
+        elif scenario == "invalid":
+            os.makedirs(os.path.dirname(app.license_path), exist_ok=True)
+            with open(app.license_path, "w", encoding="utf-8") as fh:
+                fh.write("CLAW1.garbage.garbage")
+        with app.app.test_client() as c:
+            a = c.get("/api/license/tier").get_json()
+            b = c.get("/api/license/is-tier?tier=pro").get_json()
+        assert a["has_license"] == b["has_license"], scenario
+        assert a["valid"] == b["valid"], scenario
+        assert a["tier"] == b["tier"], scenario
+        # Reset for next iteration.
+        if os.path.exists(app.license_path):
+            os.unlink(app.license_path)
+
+
+def test_scalar_matches_endpoint(app):
+    """The module-level scalar and the endpoint's ``tier`` field must
+    byte-match across every install branch -- else a caller bound to one
+    can see a different tier than a caller bound to the other."""
+    # active
+    tok = app.lic._encode_token(_payload(tier="pro"), app.priv)
+    app.lic.activate(tok)
+    with app.app.test_client() as c:
+        assert c.get("/api/license/tier").get_json()["tier"] == app.lic.license_tier()
+
+    # expired
+    os.unlink(app.license_path)
+    _write_key_direct(app, exp_delta=-1 * 86400, tier="pro")
+    with app.app.test_client() as c:
+        assert c.get("/api/license/tier").get_json()["tier"] == app.lic.license_tier()
+    assert app.lic.license_tier() is None
+
+    # invalid
+    os.unlink(app.license_path)
+    with open(app.license_path, "w", encoding="utf-8") as fh:
+        fh.write("CLAW1.garbage.garbage")
+    with app.app.test_client() as c:
+        assert c.get("/api/license/tier").get_json()["tier"] == app.lic.license_tier()
+    assert app.lic.license_tier() is None
+
+    # no-license
+    os.unlink(app.license_path)
+    with app.app.test_client() as c:
+        assert c.get("/api/license/tier").get_json()["tier"] == app.lic.license_tier()
+    assert app.lic.license_tier() is None


### PR DESCRIPTION
## Summary

Adds a pair of scalar / boolean-gate helpers on the license-**tier** axis, mirroring the "scalar + paired endpoint" pattern already established for the license-lifecycle axis (`days_until_expiry` / `is_expiring_within` on PR #4081, `is_expired` / `is_perpetual` on the currently-open draft PR #4084): a module-level helper that returns ONE value plus a shape-parity API endpoint, so a paywall tile can bind directly off the URL without parsing the full `/api/license/status` envelope.

- **`clawmetry/license.py`** — two new module-level helpers:
  - `license_tier() -> str | None` — lowercased, whitespace-stripped `tier` claim for an installed, signature-valid, **NOT-expired** license (typically `"pro"`, `"enterprise"`, `"trial"`; deliberately open-ended so a future tier lands without a code change). Returns `None` for no license, invalid signature (an unsigned body's tier claim is not trustworthy — an attacker could stuff any value), and expired keys (a lapsed Pro customer must NOT keep rendering as `"pro"` until they re-activate). Casing normalisation lets callers compare against a hard-coded `"pro"` without a `.lower()` on every read. Never raises.
  - `is_tier(tier: str) -> bool` — `True` iff `license_tier()` byte-equals the requested tier after case-insensitive strip normalisation on **both** sides (`"Pro"`, `"pro"`, and `"  PRO "` all resolve identically). Empty / non-string / non-matching / expired all collapse to `False`. Never raises.

- **`routes/entitlement.py`** — two paired endpoints on `bp_entitlement`:
  - `GET /api/license/tier` → `{tier, has_license, valid}` — always HTTP 200, degrades to the OSS-free branch shape on any underlying blowup.
  - `GET /api/license/is-tier?tier=<name>` → `{is_tier, tier, requested_tier, has_license, valid}` — boolean gate with the surrounding license envelope layered on top so a widget never needs a second `/api/license/status` hit. Missing / empty / whitespace-only `tier=` param degrades to `is_tier=false` and `requested_tier=""` (not a 4xx), matching the surrounding endpoints' never-5xx / never-4xx posture.
  - Shared `_license_tier_snapshot()` helper reads `current_license_info()` + `license_tier()` once so the endpoint pair can't disagree on `has_license` / `tier` / `valid` for the same install.

- **`tests/test_license_tier_scalar.py`** — 37 new tests:
  - Scalar-helper coverage: no-license, active-pro, active-enterprise, open-ended tier, casing normalisation, expired collapse, invalid signature, empty-string claim, whitespace-only claim, non-string claim, never-raises.
  - `is_tier`: matching, non-matching, case-insensitive on both sides, expired-not-current, invalid signature, empty query, non-string query, never-raises.
  - Endpoint envelope shape parity on every branch (fixed 3-key set for `/tier`, 5-key set for `/is-tier`); envelope value matches the module-level scalar byte-for-byte across every install state.
  - Never-5xx via monkeypatched blowup on both endpoints.
  - Cross-consistency: the two endpoints agree on `has_license` / `valid` / `tier` across all four install branches (none / active / expired / invalid).

Purely additive read-side helpers on the open-core license axis — no gate enforcement change, no behavior change on any existing endpoint. Ships in GRACE.

## Test plan

- [x] `python3 -m pytest tests/test_license_tier_scalar.py -q` — 37 new tests pass.
- [x] `python3 -m pytest tests/test_license.py tests/test_license_api.py tests/test_license_days_until_expiry.py tests/test_license_permissions.py tests/test_license_pubkey.py tests/test_license_audit.py -q` — 142 sibling license tests still pass (no regression on the adjacent license surface).
- [x] `python3 -m pytest tests/test_entitlement_api.py tests/test_entitlement_api_fallback_shape.py -q` — 39 sibling entitlement-API tests still pass.
- [x] `python3 -m py_compile clawmetry/license.py routes/entitlement.py tests/test_license_tier_scalar.py` — clean.
- [x] `ruff check clawmetry/license.py routes/entitlement.py tests/test_license_tier_scalar.py` — clean.
- [x] Blueprint + module import smoke: `from routes.entitlement import bp_entitlement` and `from clawmetry import license as _l; _l.license_tier, _l.is_tier` both succeed.
- [x] Python 3.9 AST parse (the CI lint gate) — clean; `from __future__ import annotations` is already present at the top of `clawmetry/license.py` so the `str | None` return-type syntax works on 3.9.

## Local operator verification checklist

The autonomous session cannot reach the running daemon, `~/.openclaw`, the live cloud snapshot, or a browser, so the local operator handles the live-install verification below before flipping this PR from Draft to Ready.

- [ ] Copy changed files into `~/.clawmetry/lib/python3.X/site-packages/clawmetry/` (`license.py`) and `~/.clawmetry/lib/python3.X/site-packages/routes/` (`entitlement.py`); place the new test file under the local `tests/` copy.
- [ ] Clear stale bytecode: `find ~/.clawmetry -name __pycache__ -type d -exec rm -rf {} +`.
- [ ] Restart the sync daemon: `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`.
- [ ] Hit the new endpoints against the running dashboard:
  - `curl -sS http://localhost:8900/api/license/tier | jq .` — on an OSS install expect `{"tier":null,"has_license":false,"valid":false}`; on an active Pro install expect `{"tier":"pro","has_license":true,"valid":true}`; on an active Enterprise install expect `{"tier":"enterprise","has_license":true,"valid":true}`; on an expired install expect `{"tier":null,"has_license":true,"valid":false}` (the collapse is deliberate — see PR body).
  - `curl -sS "http://localhost:8900/api/license/is-tier?tier=pro" | jq .` — on an active Pro install expect `is_tier=true`; on an OSS install expect `is_tier=false`, `requested_tier="pro"`, `tier=null`; on an active Enterprise install expect `is_tier=false`, `requested_tier="pro"`, `tier="enterprise"`, `valid=true`.
  - `curl -sS "http://localhost:8900/api/license/is-tier?tier=Enterprise" | jq .` on an Enterprise install — confirm `is_tier=true` and `requested_tier="enterprise"` (case-insensitive normalisation on the query side).
- [ ] Confirm cross-consistency with `/api/license/status`:
  - `has_license` on both new endpoints agrees with `status != "no_license"` on `/api/license/status`.
  - `valid` on both new endpoints matches `valid` on `/api/license/status`.
  - `tier` on `/api/license/tier` matches the lowercased-stripped form of the `tier` field on `/api/license/status` for the active branch, and collapses to `null` on the expired / invalid branches.
- [ ] Decrypt the live cloud snapshot and confirm the entitlement blueprint still registers cleanly (no import-order regressions from the added helpers).
- [ ] Browser-check that no existing license / paywall tile regressed — the change is purely additive so this is a sanity pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_017PE37HykZsUxtbLd6Z4NVp)_