### PR TITLE
fix(c6-ruleset): drop administration:write from permissions block

### DIFF
--- a/.github/workflows/c6-apply-ruleset.yml
+++ b/.github/workflows/c6-apply-ruleset.yml
@@ -1,8 +1,7 @@
 name: Apply E2E required checks via Rulesets API (C6)
 
-# Uses POST /repos/{owner}/{repo}/rulesets with administration:write
-# GITHUB_TOKEN to upsert a ruleset that enforces the 4 required E2E
-# status checks on clawmetry/main.
+# Uses POST /repos/{owner}/{repo}/rulesets to upsert a ruleset that
+# enforces the 4 required E2E status checks on clawmetry/main.
 #
 # WHY RULESETS INSTEAD OF BRANCH PROTECTION:
 #   Branch protection requires an admin PAT -- GITHUB_TOKEN cannot write it.
@@ -18,6 +17,11 @@ name: Apply E2E required checks via Rulesets API (C6)
 # On 403 (token lacks ruleset-write rights): logs clear instructions
 # and exits 1 so the PR gate shows red and the admin knows to act.
 #
+# NOTE: administration:write is NOT listed in the permissions block because
+# requesting it at the workflow level causes GitHub to kill the run with 0
+# jobs on personal repos (plan-level restriction). The Python script handles
+# the 403 runtime error gracefully instead.
+#
 # Tracking: vivekchand/clawmetry#3952 (C6)
 
 on:
@@ -27,7 +31,6 @@ on:
 
 permissions:
   contents: read
-  administration: write
   issues: write
 
 jobs:


### PR DESCRIPTION
## Summary

The `c6-apply-ruleset.yml` workflow merged in #4090 ran post-merge but produced **0 jobs with `conclusion: failure`** -- GitHub silently killed the run before queuing any jobs.

**Root cause:** Requesting `administration: write` in the workflow-level `permissions:` block causes GitHub to block the entire run at the queue stage on personal repos where this permission is restricted. The run fails immediately with 0 jobs and no log output -- the Python script's 403 handler never runs.

**Fix:** Drop `administration: write` from the `permissions:` block. Without it, the job queues and runs normally. The Python script already handles the 403 runtime case:
- If the token has implicit admin access to the Rulesets API, the ruleset is created (C6 auto-closes).
- If the API returns 403, the existing error handler prints the 3 fallback options and exits 1 with a clear message.

The only functional change is removing one line from the permissions block and adding a comment explaining why `administration: write` is intentionally absent.

## What was NOT changed

- All Python logic is identical to #4090.
- The 403 fallback message and the three manual options (Settings UI / PAT workflow / `scripts/close-c6.sh`) are unchanged.
- The self-healing on-push-to-main behavior is unchanged.

## How to verify after merge

Watch the `Apply E2E required checks via Rulesets API (C6)` workflow run triggered by this merge. It should now show **at least 1 job** (instead of 0). If the job exits 0, C6 is closed. If it exits 1 with a 403 error, use Option A (Settings UI) from the log output.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NaUvFENt3YSwbSTTTRYA9U)_