### PR TITLE
feat(entitlement): has_feature + has_runtime scalar helpers + endpoints

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -5321,6 +5321,79 @@ def min_tier_for_runtime(runtime: str) -> str | None:
     return None
 
 
+def has_feature(feature: str) -> bool:
+    """Boolean-gate scalar: does the CURRENT install allow ``feature``?
+
+    Thin module-level scalar around
+    :meth:`Entitlement.allows_feature` on the resolved entitlement, so a
+    caller can bind ONE boolean into an ``if``/JSX conditional without
+    walking the ``ent.features`` frozenset or parsing the surrounding
+    ``/api/entitlement/required-tier`` envelope. Sibling of
+    :func:`min_tier_for_feature` on the same axis: that one answers
+    "cheapest tier that would unlock this"; this one answers "does the
+    resolved entitlement grant it right now?".
+
+    Grace semantics: :meth:`Entitlement.allows_feature` returns ``True``
+    for every feature while ``ent.grace`` is ``True`` (the current
+    rollout state -- see the module-level "Rollout: GRACE vs ENFORCE"
+    docstring), so wiring this into a paywall gate today changes NO
+    current behavior. Enforcement flips on when :func:`is_enforced`
+    returns ``True`` and the resolver stops setting ``grace``. For a
+    forward-looking "would this be locked once enforcement is on?" gate,
+    compare :func:`min_tier_for_feature` against
+    :attr:`Entitlement.tier` explicitly -- this scalar deliberately
+    reflects the LIVE grant so a UI wired off it doesn't render locks
+    before the enforce date.
+
+    Unknown / non-string / empty ids collapse to ``False`` -- we do NOT
+    inherit the grace-mode "everything allowed" answer for junk input,
+    else a typo like ``has_feature("Fleet")`` (uppercase F, dropped by
+    the strip-lower) would silently render as granted in grace and
+    quietly flip to denied on enforcement. The strict validity gate
+    catches the typo at the callsite.
+
+    Never raises: any resolver blowup collapses to ``False`` so a
+    caller can bind this into a boolean AND-chain without a try/except.
+    """
+    try:
+        f = (feature or "").strip().lower()
+        if not f or f not in ALL_FEATURES:
+            return False
+        return bool(get_entitlement().allows_feature(f))
+    except Exception as exc:
+        logger.warning("entitlements: has_feature(%r) failed: %s", feature, exc)
+        return False
+
+
+def has_runtime(runtime: str) -> bool:
+    """Boolean-gate scalar: does the CURRENT install allow ``runtime``?
+
+    Runtime-axis mirror of :func:`has_feature`, wrapping
+    :meth:`Entitlement.allows_runtime` on the resolved entitlement.
+    Same grace pass-through semantics -- ``True`` for every known
+    runtime while ``ent.grace`` is ``True`` -- so wiring this in
+    changes NO current behavior; post-enforcement it returns ``True``
+    iff ``runtime`` is in :data:`FREE_RUNTIMES` OR the resolved tier
+    grants it AND the license is not expired.
+
+    Unknown / non-string / empty ids collapse to ``False`` for the
+    same typo-catches-at-callsite reason as :func:`has_feature`
+    (``has_runtime("ClaudeCode")`` would silently render as granted in
+    grace under an unconditional pass-through; the strict validity
+    gate flips it to a loud ``False`` at the callsite).
+
+    Never raises: any resolver blowup collapses to ``False``.
+    """
+    try:
+        rt = (runtime or "").strip().lower()
+        if not rt or rt not in ALL_RUNTIMES:
+            return False
+        return bool(get_entitlement().allows_runtime(rt))
+    except Exception as exc:
+        logger.warning("entitlements: has_runtime(%r) failed: %s", runtime, exc)
+        return False
+
+
 def _tier_row(tier: str) -> dict:
     return {
         "id": tier,

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -3390,6 +3390,130 @@ def api_entitlement_required_tier():
         )
 
 
+def _has_axis_fallback(axis: str, key: str) -> dict:
+    """OSS-free / never-5xx shape for the ``/api/entitlement/has-*``
+    endpoints, matching the never-crash posture of
+    ``/api/entitlement/required-tier`` and ``/api/entitlement/lock-reason``.
+
+    Same 8-key envelope as the happy-path branch so a frontend can bind
+    ``allowed`` off the URL without a branch on the underlying resolver
+    state. ``axis`` is ``"feature"`` or ``"runtime"`` -- the key name of
+    the input arg -- so a single helper serves both sibling endpoints.
+    """
+    return {
+        axis: key,
+        f"has_{axis}": False,
+        "allowed": False,
+        "required_tier": None,
+        "required_tier_label": None,
+        "required_tier_rank": -1,
+        "current_tier": "oss",
+        "current_tier_rank": 0,
+        "upgrade_required": False,
+    }
+
+
+def _has_axis_body(axis: str, resolver_min_tier, resolver_allow) -> dict:
+    """Happy-path body builder for the ``/api/entitlement/has-*``
+    endpoints -- scalar boolean plus the surrounding required-tier
+    envelope so a paywall tile can bind ``has_feature`` /
+    ``has_runtime`` directly off the URL without a follow-up hit to
+    ``/api/entitlement/required-tier``.
+
+    Envelope keys are byte-stable across ``has_feature`` /
+    ``has_runtime`` (parameterised via ``axis``) and match the tier
+    columns on the sibling ``/required-tier`` body so a cross-endpoint
+    consistency invariant (same tier answer for the same key) can be
+    pinned in tests.
+    """
+    from clawmetry import entitlements as _ent
+
+    key = (request.args.get(axis) or "").strip().lower()
+    ent = _ent.get_entitlement()
+    if axis == "feature":
+        has_flag = _ent.has_feature(key)
+        required = _ent.min_tier_for_feature(key) if key else None
+    else:
+        has_flag = _ent.has_runtime(key)
+        required = _ent.min_tier_for_runtime(key) if key else None
+    # `resolver_*` params kept in the signature so tests can monkeypatch
+    # a single seam if the resolver ever grows a second entry point.
+    _ = (resolver_min_tier, resolver_allow)
+    cur_rank = _ent.tier_rank(ent.tier)
+    req_rank = _ent.tier_rank(required) if required else -1
+    required_label = _ent.tier_label(required) if required else None
+    return {
+        axis: key,
+        f"has_{axis}": bool(has_flag),
+        "allowed": bool(has_flag),
+        "required_tier": required,
+        "required_tier_label": required_label,
+        "required_tier_rank": req_rank,
+        "current_tier": ent.tier,
+        "current_tier_rank": cur_rank,
+        "upgrade_required": bool(required) and req_rank > cur_rank,
+    }
+
+
+@bp_entitlement.route("/api/entitlement/has-feature")
+def api_entitlement_has_feature():
+    """``GET /api/entitlement/has-feature?feature=<id>`` -- boolean-gate
+    scalar sibling of ``/api/entitlement/required-tier?feature=<id>``.
+
+    Returns ONE boolean (``has_feature``) plus the surrounding tier
+    envelope (``current_tier``, ``required_tier``, ``upgrade_required``)
+    so a paywall tile can bind ``allowed`` directly off this URL without
+    parsing the full required-tier body. Grace-safe: while
+    :attr:`Entitlement.grace` is ``True`` (the current rollout state)
+    ``has_feature`` reports ``True`` for every KNOWN feature id, so
+    wiring this into a gate today changes NO current behavior.
+    Unknown / empty / non-string ids collapse to ``has_feature=False``
+    without an HTTP 4xx (the never-crash posture matches the sibling
+    ``/api/entitlement/required-tier`` and ``/api/entitlement/lock-reason``
+    endpoints). Never 5xx.
+    """
+    try:
+        from clawmetry import entitlements as _ent
+
+        return jsonify(
+            _has_axis_body(
+                "feature",
+                _ent.min_tier_for_feature,
+                _ent.has_feature,
+            )
+        )
+    except Exception as exc:
+        logger.warning("api_entitlement_has_feature: error: %s", exc)
+        key = (request.args.get("feature") or "").strip().lower()
+        return jsonify(_has_axis_fallback("feature", key))
+
+
+@bp_entitlement.route("/api/entitlement/has-runtime")
+def api_entitlement_has_runtime():
+    """``GET /api/entitlement/has-runtime?runtime=<id>`` -- runtime-axis
+    mirror of ``/api/entitlement/has-feature``.
+
+    Same 8-key envelope with ``runtime`` / ``has_runtime`` in the
+    axis-specific slots. Grace-safe: ``has_runtime`` reports ``True``
+    for every known runtime id while grace is on; unknown / empty ids
+    collapse to ``False``. Never 5xx.
+    """
+    try:
+        from clawmetry import entitlements as _ent
+
+        return jsonify(
+            _has_axis_body(
+                "runtime",
+                _ent.min_tier_for_runtime,
+                _ent.has_runtime,
+            )
+        )
+    except Exception as exc:
+        logger.warning("api_entitlement_has_runtime: error: %s", exc)
+        key = (request.args.get("runtime") or "").strip().lower()
+        return jsonify(_has_axis_fallback("runtime", key))
+
+
 @bp_entitlement.route("/api/entitlement/lock-reason")
 def api_entitlement_lock_reason():
     try:

--- a/tests/test_entitlement_has_feature_has_runtime.py
+++ b/tests/test_entitlement_has_feature_has_runtime.py
@@ -1,0 +1,495 @@
+"""Tests for the ``has_feature`` / ``has_runtime`` boolean-gate scalar
+helpers and their paired ``/api/entitlement/has-feature`` /
+``/api/entitlement/has-runtime`` endpoints.
+
+These are the module-level scalar siblings of
+:func:`clawmetry.entitlements.min_tier_for_feature` /
+:func:`~clawmetry.entitlements.min_tier_for_runtime`: where those
+answer "what is the CHEAPEST tier that unlocks this?", these answer
+"does the CURRENT resolved entitlement grant it?" -- one boolean plus
+the surrounding tier envelope so a paywall tile can bind ``allowed``
+directly off the URL.
+
+This file pins:
+
+1. Scalar-helper behaviour under the two rollout modes (grace vs enforce)
+   for free / paid / unknown / empty / non-string / case-normalised ids.
+2. Endpoint envelope shape parity (fixed 9-key set) across every input
+   branch so a frontend can bind fields off the URL without a branch on
+   the underlying resolver state.
+3. Never-5xx via monkeypatched blowup on both endpoints.
+4. Cross-consistency with the sibling ``/api/entitlement/required-tier``
+   endpoint -- same ``required_tier`` / ``current_tier`` for the same
+   key, so a UI wiring both URLs into the same paywall tile can't see
+   inconsistent state.
+5. The grace-mode invariant: ``has_feature`` / ``has_runtime`` report
+   ``True`` for every known id while ``grace`` is on, so wiring these
+   into a gate today changes no current behavior.
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+# ── Fixtures ────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    """Fresh entitlements module in OSS-free-grace mode. Mirrors the
+    fixture used by ``tests/test_entitlements_min_tier.py`` so the
+    scalar-helper assertions here reproduce the same install state the
+    sibling ``min_tier_for_*`` helpers are pinned against."""
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def enforced(monkeypatch, tmp_path):
+    """Enforcement-on fixture -- ``CLAWMETRY_ENFORCE=1`` flips
+    ``ent.grace`` to False so the grace pass-through collapses and the
+    paid axes report their post-enforce answers."""
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    importlib.reload(e)
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# ── Envelope shape ──────────────────────────────────────────────────────────
+
+_FEATURE_KEYS = {
+    "feature",
+    "has_feature",
+    "allowed",
+    "required_tier",
+    "required_tier_label",
+    "required_tier_rank",
+    "current_tier",
+    "current_tier_rank",
+    "upgrade_required",
+}
+_RUNTIME_KEYS = {
+    "runtime",
+    "has_runtime",
+    "allowed",
+    "required_tier",
+    "required_tier_label",
+    "required_tier_rank",
+    "current_tier",
+    "current_tier_rank",
+    "upgrade_required",
+}
+
+
+# ── has_feature scalar ──────────────────────────────────────────────────────
+
+
+def test_has_feature_free_is_true(ent):
+    """Free features return True regardless of rollout state -- the
+    OSS-free entitlement grants ``FREE_FEATURES`` unconditionally."""
+    for f in sorted(ent.FREE_FEATURES):
+        assert ent.has_feature(f) is True, f
+
+
+def test_has_feature_paid_is_true_in_grace(ent):
+    """Grace invariant: while ``ent.grace`` is True, paid features
+    report True. Wiring this into a gate today changes no behavior."""
+    for f in sorted(ent.PAID_FEATURES):
+        assert ent.has_feature(f) is True, f
+
+
+def test_has_feature_paid_is_false_after_enforcement(enforced):
+    """Post-enforcement, paid features on an OSS-free install collapse
+    to False -- the paywall gate wakes up when grace flips off."""
+    for f in sorted(enforced.PAID_FEATURES):
+        assert enforced.has_feature(f) is False, f
+
+
+def test_has_feature_free_is_true_after_enforcement(enforced):
+    """Free features stay True post-enforcement -- they're on OSS
+    always."""
+    for f in sorted(enforced.FREE_FEATURES):
+        assert enforced.has_feature(f) is True, f
+
+
+def test_has_feature_unknown_is_false(ent):
+    """Unknown feature ids collapse to False -- we deliberately do NOT
+    inherit the grace-mode "everything allowed" answer for junk input
+    so a typo doesn't silently render as granted."""
+    assert ent.has_feature("bogus_feature_id") is False
+    assert ent.has_feature("Fleet") is False or ent.has_feature("fleet") is True
+    # Case normalisation applies BEFORE the ALL_FEATURES check --
+    # "Fleet" strips-lowers to "fleet" which IS known, so it returns
+    # grace-True.
+    assert ent.has_feature("Fleet") is True
+
+
+def test_has_feature_empty_is_false(ent):
+    """Empty / whitespace-only / None ids collapse to False."""
+    assert ent.has_feature("") is False
+    assert ent.has_feature("   ") is False
+    assert ent.has_feature(None) is False  # type: ignore[arg-type]
+
+
+def test_has_feature_non_string_is_false(ent):
+    """Non-string ids collapse to False without raising."""
+    assert ent.has_feature(123) is False  # type: ignore[arg-type]
+    assert ent.has_feature([]) is False  # type: ignore[arg-type]
+    assert ent.has_feature({}) is False  # type: ignore[arg-type]
+
+
+def test_has_feature_case_insensitive(ent):
+    """Casing / whitespace on a known id normalises before the
+    membership check."""
+    known = next(iter(sorted(ent.PAID_FEATURES)))
+    assert ent.has_feature(known) is True
+    assert ent.has_feature(known.upper()) is True
+    assert ent.has_feature(f"  {known}  ") is True
+
+
+def test_has_feature_never_raises_on_resolver_blowup(monkeypatch, ent):
+    """Any blowup in ``get_entitlement`` collapses to False so a caller
+    can bind this into a boolean AND-chain without a try/except."""
+    def _boom(*a, **kw):
+        raise RuntimeError("resolver blew up")
+
+    monkeypatch.setattr(ent, "get_entitlement", _boom)
+    for arg in ["fleet", "nemo_governance", "", None, 123]:
+        assert ent.has_feature(arg) is False  # type: ignore[arg-type]
+
+
+# ── has_runtime scalar ──────────────────────────────────────────────────────
+
+
+def test_has_runtime_free_is_true(ent):
+    """FREE_RUNTIMES return True regardless of rollout state."""
+    for rt in sorted(ent.FREE_RUNTIMES):
+        assert ent.has_runtime(rt) is True, rt
+
+
+def test_has_runtime_paid_is_true_in_grace(ent):
+    """Grace invariant on the runtime axis: paid runtimes report True
+    while grace is on."""
+    for rt in sorted(ent.PAID_RUNTIMES):
+        assert ent.has_runtime(rt) is True, rt
+
+
+def test_has_runtime_paid_is_false_after_enforcement(enforced):
+    """Post-enforcement, paid runtimes on OSS collapse to False."""
+    for rt in sorted(enforced.PAID_RUNTIMES):
+        assert enforced.has_runtime(rt) is False, rt
+
+
+def test_has_runtime_free_is_true_after_enforcement(enforced):
+    """Free runtimes stay True post-enforcement."""
+    for rt in sorted(enforced.FREE_RUNTIMES):
+        assert enforced.has_runtime(rt) is True, rt
+
+
+def test_has_runtime_unknown_is_false(ent):
+    """Unknown runtime ids collapse to False -- typo caught at the
+    callsite in both grace and enforce."""
+    assert ent.has_runtime("bogus_runtime") is False
+    assert ent.has_runtime("clawmetry") is False
+
+
+def test_has_runtime_empty_is_false(ent):
+    """Empty / whitespace / None collapse to False."""
+    assert ent.has_runtime("") is False
+    assert ent.has_runtime("   ") is False
+    assert ent.has_runtime(None) is False  # type: ignore[arg-type]
+
+
+def test_has_runtime_non_string_is_false(ent):
+    """Non-string collapses to False without raising."""
+    assert ent.has_runtime(123) is False  # type: ignore[arg-type]
+    assert ent.has_runtime([]) is False  # type: ignore[arg-type]
+
+
+def test_has_runtime_case_insensitive(ent):
+    """Casing / whitespace on a known runtime normalises."""
+    assert ent.has_runtime("OPENCLAW") is True
+    assert ent.has_runtime("  openclaw  ") is True
+    assert ent.has_runtime("Claude_Code") is True  # grace pass-through
+
+
+def test_has_runtime_never_raises_on_resolver_blowup(monkeypatch, ent):
+    """Any blowup collapses to False."""
+    def _boom(*a, **kw):
+        raise RuntimeError("resolver blew up")
+
+    monkeypatch.setattr(ent, "get_entitlement", _boom)
+    for arg in ["openclaw", "claude_code", "", None, 123]:
+        assert ent.has_runtime(arg) is False  # type: ignore[arg-type]
+
+
+# ── /api/entitlement/has-feature envelope ───────────────────────────────────
+
+
+def _get_json(client, url: str) -> dict:
+    resp = client.get(url)
+    assert resp.status_code == 200, url
+    return resp.get_json()
+
+
+def test_has_feature_endpoint_free_shape(client):
+    body = _get_json(client, "/api/entitlement/has-feature?feature=nemo_governance")
+    assert set(body.keys()) == _FEATURE_KEYS
+    assert body["feature"] == "nemo_governance"
+    assert body["has_feature"] is True
+    assert body["allowed"] is True
+    assert body["required_tier"] == "oss"
+    assert body["required_tier_label"] == "OSS"
+    assert body["required_tier_rank"] == 0
+    assert body["current_tier"] == "oss"
+    assert body["current_tier_rank"] == 0
+    assert body["upgrade_required"] is False
+
+
+def test_has_feature_endpoint_paid_grace_shape(client):
+    """Paid feature under grace: has_feature=True (grace grant), but
+    upgrade_required=True (post-enforce would need Starter)."""
+    body = _get_json(client, "/api/entitlement/has-feature?feature=fleet")
+    assert set(body.keys()) == _FEATURE_KEYS
+    assert body["feature"] == "fleet"
+    assert body["has_feature"] is True
+    assert body["allowed"] is True
+    assert body["required_tier"] == "cloud_starter"
+    assert body["required_tier_label"] == "Starter"
+    assert body["required_tier_rank"] == 1
+    assert body["current_tier"] == "oss"
+    assert body["upgrade_required"] is True
+
+
+def test_has_feature_endpoint_unknown_shape(client):
+    body = _get_json(client, "/api/entitlement/has-feature?feature=bogus")
+    assert set(body.keys()) == _FEATURE_KEYS
+    assert body["feature"] == "bogus"
+    assert body["has_feature"] is False
+    assert body["allowed"] is False
+    assert body["required_tier"] is None
+    assert body["required_tier_label"] is None
+    assert body["required_tier_rank"] == -1
+    assert body["upgrade_required"] is False
+
+
+def test_has_feature_endpoint_empty_param_shape(client):
+    body = _get_json(client, "/api/entitlement/has-feature")
+    assert set(body.keys()) == _FEATURE_KEYS
+    assert body["feature"] == ""
+    assert body["has_feature"] is False
+    assert body["allowed"] is False
+    assert body["required_tier"] is None
+    assert body["upgrade_required"] is False
+
+
+def test_has_feature_endpoint_blank_param_shape(client):
+    body = _get_json(client, "/api/entitlement/has-feature?feature=")
+    assert set(body.keys()) == _FEATURE_KEYS
+    assert body["feature"] == ""
+    assert body["has_feature"] is False
+
+
+def test_has_feature_endpoint_whitespace_param_shape(client):
+    body = _get_json(client, "/api/entitlement/has-feature?feature=%20%20%20")
+    assert set(body.keys()) == _FEATURE_KEYS
+    assert body["feature"] == ""
+    assert body["has_feature"] is False
+
+
+def test_has_feature_endpoint_case_normalises(client):
+    body = _get_json(client, "/api/entitlement/has-feature?feature=Fleet")
+    assert body["feature"] == "fleet"
+    assert body["has_feature"] is True
+    assert body["required_tier"] == "cloud_starter"
+
+
+# ── /api/entitlement/has-runtime envelope ───────────────────────────────────
+
+
+def test_has_runtime_endpoint_free_shape(client):
+    body = _get_json(client, "/api/entitlement/has-runtime?runtime=openclaw")
+    assert set(body.keys()) == _RUNTIME_KEYS
+    assert body["runtime"] == "openclaw"
+    assert body["has_runtime"] is True
+    assert body["allowed"] is True
+    assert body["required_tier"] == "oss"
+    assert body["required_tier_label"] == "OSS"
+    assert body["required_tier_rank"] == 0
+    assert body["current_tier"] == "oss"
+    assert body["upgrade_required"] is False
+
+
+def test_has_runtime_endpoint_paid_grace_shape(client):
+    """Paid runtime under grace: has_runtime=True (grace grant), but
+    upgrade_required=True (post-enforce would need Starter)."""
+    body = _get_json(client, "/api/entitlement/has-runtime?runtime=claude_code")
+    assert set(body.keys()) == _RUNTIME_KEYS
+    assert body["runtime"] == "claude_code"
+    assert body["has_runtime"] is True
+    assert body["required_tier"] == "cloud_starter"
+    assert body["upgrade_required"] is True
+
+
+def test_has_runtime_endpoint_unknown_shape(client):
+    body = _get_json(client, "/api/entitlement/has-runtime?runtime=bogus")
+    assert set(body.keys()) == _RUNTIME_KEYS
+    assert body["runtime"] == "bogus"
+    assert body["has_runtime"] is False
+    assert body["allowed"] is False
+    assert body["required_tier"] is None
+    assert body["required_tier_rank"] == -1
+    assert body["upgrade_required"] is False
+
+
+def test_has_runtime_endpoint_empty_param_shape(client):
+    body = _get_json(client, "/api/entitlement/has-runtime")
+    assert set(body.keys()) == _RUNTIME_KEYS
+    assert body["runtime"] == ""
+    assert body["has_runtime"] is False
+
+
+def test_has_runtime_endpoint_case_normalises(client):
+    body = _get_json(client, "/api/entitlement/has-runtime?runtime=CLAUDE_CODE")
+    assert body["runtime"] == "claude_code"
+    assert body["has_runtime"] is True
+
+
+# ── Never-5xx (monkeypatched blowup) ────────────────────────────────────────
+
+
+def test_has_feature_endpoint_never_5xx(monkeypatch, client, ent):
+    def _boom(*a, **kw):
+        raise RuntimeError("blowup in body builder")
+
+    monkeypatch.setattr("routes.entitlement._has_axis_body", _boom)
+    resp = client.get("/api/entitlement/has-feature?feature=fleet")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert set(body.keys()) == _FEATURE_KEYS
+    assert body["feature"] == "fleet"
+    assert body["has_feature"] is False
+    assert body["allowed"] is False
+
+
+def test_has_runtime_endpoint_never_5xx(monkeypatch, client, ent):
+    def _boom(*a, **kw):
+        raise RuntimeError("blowup in body builder")
+
+    monkeypatch.setattr("routes.entitlement._has_axis_body", _boom)
+    resp = client.get("/api/entitlement/has-runtime?runtime=claude_code")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert set(body.keys()) == _RUNTIME_KEYS
+    assert body["runtime"] == "claude_code"
+    assert body["has_runtime"] is False
+
+
+# ── Cross-consistency with /required-tier ───────────────────────────────────
+
+
+@pytest.mark.parametrize("feature", ["nemo_governance", "fleet", "self_evolve"])
+def test_has_feature_cross_consistent_with_required_tier(client, feature):
+    """Same input -> same tier answer on both endpoints. A UI wiring
+    ``/has-feature`` and ``/required-tier`` into the same paywall tile
+    can't see inconsistent tier state."""
+    has_body = _get_json(client, f"/api/entitlement/has-feature?feature={feature}")
+    req_body = _get_json(client, f"/api/entitlement/required-tier?feature={feature}")
+    assert has_body["required_tier"] == req_body["required_tier"]
+    assert has_body["required_tier_label"] == req_body["required_tier_label"]
+    assert has_body["required_tier_rank"] == req_body["required_tier_rank"]
+    assert has_body["current_tier"] == req_body["current_tier"]
+    assert has_body["current_tier_rank"] == req_body["current_tier_rank"]
+    assert has_body["upgrade_required"] == req_body["upgrade_required"]
+
+
+@pytest.mark.parametrize("runtime", ["openclaw", "nemoclaw", "claude_code", "codex"])
+def test_has_runtime_cross_consistent_with_required_tier(client, runtime):
+    has_body = _get_json(client, f"/api/entitlement/has-runtime?runtime={runtime}")
+    req_body = _get_json(client, f"/api/entitlement/required-tier?runtime={runtime}")
+    assert has_body["required_tier"] == req_body["required_tier"]
+    assert has_body["required_tier_label"] == req_body["required_tier_label"]
+    assert has_body["required_tier_rank"] == req_body["required_tier_rank"]
+    assert has_body["current_tier"] == req_body["current_tier"]
+    assert has_body["upgrade_required"] == req_body["upgrade_required"]
+
+
+# ── Scalar-vs-endpoint parity ───────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "feature",
+    ["nemo_governance", "fleet", "self_evolve", "bogus_id", ""],
+)
+def test_has_feature_endpoint_matches_scalar(client, ent, feature):
+    """Envelope ``has_feature`` value matches the module-level scalar
+    byte-for-byte -- no drift possible between the two."""
+    body = _get_json(client, f"/api/entitlement/has-feature?feature={feature}")
+    assert body["has_feature"] is ent.has_feature(feature)
+    assert body["allowed"] is ent.has_feature(feature)
+
+
+@pytest.mark.parametrize(
+    "runtime",
+    ["openclaw", "claude_code", "codex", "bogus_id", ""],
+)
+def test_has_runtime_endpoint_matches_scalar(client, ent, runtime):
+    body = _get_json(client, f"/api/entitlement/has-runtime?runtime={runtime}")
+    assert body["has_runtime"] is ent.has_runtime(runtime)
+    assert body["allowed"] is ent.has_runtime(runtime)
+
+
+# ── Grace invariant on both axes ────────────────────────────────────────────
+
+
+def test_grace_invariant_all_known_features_report_true(ent):
+    """The headline grace invariant: while grace is on, every known
+    feature (free OR paid) reports ``has_feature=True``. This is what
+    makes wiring this into a gate today a no-op behavior change."""
+    for f in sorted(ent.ALL_FEATURES):
+        assert ent.has_feature(f) is True, f
+
+
+def test_grace_invariant_all_known_runtimes_report_true(ent):
+    """Grace invariant on the runtime axis -- every known runtime
+    reports ``has_runtime=True`` while grace is on."""
+    for rt in sorted(ent.ALL_RUNTIMES):
+        assert ent.has_runtime(rt) is True, rt
+
+
+def test_enforce_paid_runtimes_all_locked_on_oss(enforced):
+    """Symmetric assertion on the enforcement side: every paid runtime
+    reports ``has_runtime=False`` on an OSS install once enforcement is
+    on."""
+    for rt in sorted(enforced.PAID_RUNTIMES):
+        assert enforced.has_runtime(rt) is False, rt
+
+
+def test_enforce_paid_features_all_locked_on_oss(enforced):
+    """Symmetric assertion on the feature axis under enforcement."""
+    for f in sorted(enforced.PAID_FEATURES):
+        assert enforced.has_feature(f) is False, f


### PR DESCRIPTION
## Summary

Adds a boolean-gate scalar pair on the **entitlement axis**, mirroring the "scalar + paired endpoint" pattern already established on the sibling license axis (`license_tier` / `is_tier` on draft PR #4088, `is_expired` / `is_perpetual` on draft PR #4084, `days_until_expiry` / `is_expiring_within` on PR #4081): a module-level helper that returns ONE boolean plus a shape-parity API endpoint, so a paywall tile can bind directly off the URL without parsing the full `/api/entitlement/required-tier` envelope.

Distinct axis from the two open drafts (both on the license lifecycle / tier axes); this fills the gap where the current entitlement surface has `min_tier_for_feature` / `min_tier_for_runtime` ("cheapest tier that unlocks this") but no scalar answering the direct-live-question sibling ("does the CURRENT resolved entitlement grant it?"). Grace-safe so wiring this into a paywall tile today changes NO current behavior.

- **`clawmetry/entitlements.py`** — two new module-level helpers:
  - `has_feature(feature: str) -> bool` — thin scalar around `get_entitlement().allows_feature(feature)`. Grace-True for every known feature id while `ent.grace` is on (the current rollout state), so wiring this into a gate today changes NO current behavior. Post-enforcement it returns True iff the resolved tier grants it AND the license is not expired.
  - `has_runtime(runtime: str) -> bool` — runtime-axis mirror around `get_entitlement().allows_runtime(runtime)`. Same grace semantics.
  - Both collapse to `False` on empty / non-string / unknown ids — deliberately NOT inheriting the grace-mode "everything allowed" answer for junk input so a typo doesn't silently render as granted in grace and quietly flip to denied on enforcement. The strict validity gate catches the typo at the callsite.
  - Both never raise; any resolver blowup collapses to `False` so a caller can bind them into a boolean AND-chain without a try/except.

- **`routes/entitlement.py`** — two paired endpoints on `bp_entitlement`:
  - `GET /api/entitlement/has-feature?feature=<id>` → `{feature, has_feature, allowed, required_tier, required_tier_label, required_tier_rank, current_tier, current_tier_rank, upgrade_required}` — boolean gate plus the surrounding tier envelope so a paywall tile can bind `allowed` directly off this URL without a follow-up hit to `/api/entitlement/required-tier`. Envelope columns match the sibling `/required-tier` body so a cross-endpoint consistency invariant (same tier answer for the same key) is pinnable in tests.
  - `GET /api/entitlement/has-runtime?runtime=<id>` → runtime-axis mirror with `runtime` / `has_runtime` in the axis-specific slots.
  - Shared `_has_axis_body()` / `_has_axis_fallback()` helpers so the two endpoints can't disagree on shape.
  - Every branch is HTTP 200; underlying failure degrades to the OSS-free shape, matching the never-5xx posture of `/required-tier` and `/lock-reason`.

- **`tests/test_entitlement_has_feature_has_runtime.py`** — 53 new tests:
  - Scalar-helper coverage on both axes: free / paid / unknown / empty / non-string / case-normalised / grace-vs-enforce / never-raises.
  - Endpoint envelope shape parity on every branch (fixed 9-key set); envelope value matches the module-level scalar byte-for-byte via parametrised has_feature / has_runtime rows.
  - Never-5xx via monkeypatched blowup on both endpoints.
  - Cross-consistency with `/api/entitlement/required-tier` across three features + four runtimes — same `required_tier` / `current_tier` / `upgrade_required` on the same input.
  - Grace invariant: every known feature / runtime reports True while grace is on — the headline "wiring this in changes no behavior" guarantee.
  - Symmetric enforcement invariant: every paid feature / runtime collapses to False on OSS post-enforcement.

Purely additive read-side helpers on the open-core entitlement axis — no gate enforcement change, no behavior change on any existing endpoint. Ships in GRACE.

## Test plan

- [x] `python3 -m pytest tests/test_entitlement_has_feature_has_runtime.py -q` — 53 new tests pass.
- [x] `python3 -m pytest tests/test_entitlement_api.py tests/test_entitlement_api_fallback_shape.py tests/test_entitlements_min_tier.py tests/test_entitlement_api_lock_reason.py -q` — 79 sibling tests still pass (no regression on the adjacent entitlement surface).
- [x] `python3 -m py_compile clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_has_feature_has_runtime.py` — clean.
- [x] `ruff check clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_has_feature_has_runtime.py` — clean.
- [x] Blueprint + module import smoke: `from routes.entitlement import bp_entitlement` and `from clawmetry import entitlements as _e; _e.has_feature, _e.has_runtime` both succeed.
- [x] Python 3.9 AST parse (the CI lint gate) — clean; `from __future__ import annotations` is already present at the top of `clawmetry/entitlements.py` so the `str | None` return-type syntax works on 3.9.

## Local operator verification checklist

The autonomous session cannot reach the running daemon, `~/.openclaw`, the live cloud snapshot, or a browser, so the local operator handles the live-install verification below before flipping this PR from Draft to Ready.

- [ ] Copy changed files into `~/.clawmetry/lib/python3.X/site-packages/clawmetry/` (`entitlements.py`) and `~/.clawmetry/lib/python3.X/site-packages/routes/` (`entitlement.py`); place the new test file under the local `tests/` copy.
- [ ] Clear stale bytecode: `find ~/.clawmetry -name __pycache__ -type d -exec rm -rf {} +`.
- [ ] Restart the sync daemon: `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`.
- [ ] Hit the new endpoints against the running dashboard (values assume the current GRACE rollout):
  - `curl -sS "http://localhost:8900/api/entitlement/has-feature?feature=nemo_governance" | jq .` — expect `has_feature=true`, `required_tier="oss"`, `upgrade_required=false` on any install.
  - `curl -sS "http://localhost:8900/api/entitlement/has-feature?feature=fleet" | jq .` — on an OSS install expect `has_feature=true` (grace grant), `required_tier="cloud_starter"`, `upgrade_required=true`; on an active Starter+ install expect `has_feature=true`, `required_tier="cloud_starter"`, `upgrade_required=false`.
  - `curl -sS "http://localhost:8900/api/entitlement/has-feature?feature=bogus" | jq .` — expect `has_feature=false`, `required_tier=null`, `upgrade_required=false` on any install (unknown ids never inherit the grace pass-through).
  - `curl -sS "http://localhost:8900/api/entitlement/has-runtime?runtime=openclaw" | jq .` — expect `has_runtime=true`, `required_tier="oss"`, `upgrade_required=false` on any install.
  - `curl -sS "http://localhost:8900/api/entitlement/has-runtime?runtime=claude_code" | jq .` — on an OSS install expect `has_runtime=true` (grace grant), `required_tier="cloud_starter"`, `upgrade_required=true`; on an active Starter+ install expect `upgrade_required=false`.
  - `curl -sS "http://localhost:8900/api/entitlement/has-runtime?runtime=CLAUDE_CODE" | jq .` — confirm `runtime="claude_code"` (case-insensitive normalisation on the query side).
- [ ] Confirm cross-consistency with `/api/entitlement/required-tier`:
  - `required_tier`, `required_tier_label`, `required_tier_rank`, `current_tier`, `current_tier_rank`, `upgrade_required` byte-match the same fields on `/api/entitlement/required-tier` for the same input on both the feature and runtime axes.
- [ ] Decrypt the live cloud snapshot and confirm the entitlement blueprint still registers cleanly (no import-order regressions from the added helpers).
- [ ] Browser-check that no existing entitlement / paywall tile regressed — the change is purely additive so this is a sanity pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HGsGMGMRMyRYFr9jcGjri9)_