### PR TITLE
fix(c6): schedule-heal exits 0 when checks already configured via Settings UI

### DIFF
--- a/.github/workflows/c6-schedule-heal.yml
+++ b/.github/workflows/c6-schedule-heal.yml
@@ -5,10 +5,10 @@ name: C6 auto-heal (required-checks application)
 # Self-heals C6 within 2 hours after E2E_ADMIN_PAT secret is added.
 #
 # When E2E_ADMIN_PAT is NOT set:
-#   - emits an ::error:: annotation (visible red badge)
-#   - writes a formatted job summary showing current required-check state
-#     and a one-click close path (no log-reading required)
-#   - exits 1 so the badge stays red until the PAT is configured
+#   - reads current branch protection state (read-only, no admin needed)
+#   - if checks already configured (e.g. via Settings UI): exits 0 (C6 green)
+#   - if checks not yet configured: emits ::error:: annotation and exits 1
+#     (red badge acts as a forcing signal until the admin acts)
 #
 # When E2E_ADMIN_PAT IS set:
 #   - runs scripts/apply_required_status_checks.py to configure checks
@@ -77,7 +77,11 @@ jobs:
       # 'contexts' was read, so checks configured via Option A (Settings UI)
       # appeared as MISSING even though they were correctly configured.
       # This matches the logic in c6-health.yml and apply_required_status_checks.py.
+      #
+      # Exports checks_ok=true/false to GITHUB_OUTPUT so downstream steps can
+      # skip when the admin has already configured C6 via the Settings UI.
       - name: Read current required-check state (read-only)
+        id: read-state
         env:
           GH_TOKEN: ${{ github.token }}
           OWNER: vivekchand
@@ -174,8 +178,22 @@ except Exception:
             fi
           } >> "$GITHUB_STEP_SUMMARY"
 
+          # Export for downstream steps: skip error/apply if checks are already set.
+          echo "checks_ok=${ALL_OK}" >> "$GITHUB_OUTPUT"
+
+      # Fires when all required checks are already configured -- e.g. the admin
+      # used Option A (Settings UI) to add them. No PAT or further action needed.
+      # Without this step the workflow would exit 1 every 2 hours even though C6
+      # is already closed, producing perpetual red CI noise post-closure.
+      - name: C6 already configured (no PAT needed)
+        if: steps.read-state.outputs.checks_ok == 'true'
+        run: |
+          echo "C6 is GREEN -- all required E2E status checks are configured on main."
+          echo "Branch protection is correctly set. E2E_ADMIN_PAT is not needed."
+          echo "Tracking: https://github.com/vivekchand/clawmetry/issues/4029"
+
       - name: Error: E2E_ADMIN_PAT not set
-        if: steps.pat-check.outputs.has_pat == 'false'
+        if: steps.pat-check.outputs.has_pat == 'false' && steps.read-state.outputs.checks_ok != 'true'
         run: |
           echo "::error::E2E_ADMIN_PAT secret is not set -- C6 (required-status-checks) cannot be applied automatically."
           echo ""
@@ -185,13 +203,13 @@ except Exception:
           exit 1
 
       - name: Apply required E2E status checks (C6)
-        if: steps.pat-check.outputs.has_pat == 'true'
+        if: steps.pat-check.outputs.has_pat == 'true' && steps.read-state.outputs.checks_ok != 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.E2E_ADMIN_PAT }}
         run: python3 scripts/apply_required_status_checks.py
 
       - name: Post-apply summary
-        if: steps.pat-check.outputs.has_pat == 'true'
+        if: steps.pat-check.outputs.has_pat == 'true' && steps.read-state.outputs.checks_ok != 'true'
         run: |
           {
             echo "## C6 auto-heal: required checks applied"

--- a/scripts/apply_required_status_checks.py
+++ b/scripts/apply_required_status_checks.py
@@ -46,7 +46,7 @@ Primary repo behaviour (clawmetry):
 When run locally (GITHUB_REPOSITORY not set), the script applies all 6
 checks and requires a token with cross-repo admin access.
 
-Tracking: vivekchand/clawmetry#3970 (C6)
+Tracking: vivekchand/clawmetry#4029 (C6)
 """
 from __future__ import annotations
 
@@ -398,7 +398,7 @@ def main() -> None:
                 "  Fix: re-run the workflow and paste a fine-grained PAT into the 'pat_token' field.\n"
                 "  PAT permissions: Administration (read+write) on clawmetry, clawmetry-cloud, clawmetry-landing.\n"
                 "  Alternative: bash scripts/close-c6.sh (uses your gh CLI session, ~30 sec).\n"
-                "  Tracking: vivekchand/clawmetry#3970 (C6)"
+                "  Tracking: vivekchand/clawmetry#4029 (C6)"
             )
         # Read-only path: GITHUB_TOKEN cannot write branch protection rules.
         # Scope verification to the current repo only to avoid cross-repo 403s.


### PR DESCRIPTION
## Summary

- **Bug fixed**: `c6-schedule-heal.yml` always exited 1 when `E2E_ADMIN_PAT` was absent, even when branch protection was already correctly configured (e.g. via the GitHub Settings UI). This meant the workflow would produce red CI badges every 2 hours forever after C6 was closed via Option A -- the admin would see perpetual CI noise even after doing the right thing.

- **Root cause**: The schedule-heal only checked `has_pat == false` to decide whether to error out. It never checked whether checks were actually configured. The read-only state check wrote its results only to the job summary, not to `GITHUB_OUTPUT`, so downstream steps could not use them.

- **Fix**:
  - `c6-schedule-heal.yml`: the `read-state` step now exports `checks_ok=true/false` to `GITHUB_OUTPUT`. A new "C6 already configured" success step fires when `checks_ok == true`, logging the green state clearly. The error/apply/post-apply steps are now gated on `checks_ok != true` so they skip when Settings UI already has the right protection in place.
  - `scripts/apply_required_status_checks.py`: fix 2 stale `#3970` references in docstring and error message (tracking issue is `#4029`).

## Why this matters

After the admin configures branch protection via Settings UI (Option A -- the simplest close path), the schedule-heal workflow was supposed to self-heal to green on the next run. Before this fix it would NEVER self-heal: the PAT check happens before the protection check, so the workflow always hit the `exit 1` error step. The admin would have to also set `E2E_ADMIN_PAT` (a separate step) to get a green badge.

After this fix: configure branch protection via Settings UI -> next 2-hour run detects the checks -> exits 0 -> CI badge turns green. The PAT is only needed for auto-application; once C6 is done, it is not needed.

## Test plan

- [ ] Merge this PR
- [ ] Configure branch protection via Settings UI (Option A in the issue/workflow comments) for clawmetry/main
- [ ] Wait for the next `c6-schedule-heal.yml` run (within 2 hours) -- confirm it exits 0 and shows "C6 is GREEN" in the logs
- [ ] Confirm the CI badge turns green

## Acceptance test

After merge, when branch protection is configured on clawmetry/main (via any method), the next `c6-schedule-heal.yml` run shows conclusion=success instead of failure.

Closes criterion: C6 self-heal correctness (C6 detection was already working; now the exit code matches the detection).

Tracking: vivekchand/clawmetry#4029

---
_Generated by [Claude Code](https://claude.ai/code/session_016Q37rmoPrt6a1xjoprY3Xc)_