### PR TITLE
feat(license): pro-installation helpers + /api/license/pro-installed{,ation} endpoints

### DIFF
--- a/clawmetry/license.py
+++ b/clawmetry/license.py
@@ -1191,3 +1191,85 @@ def is_perpetual() -> bool:
     except Exception as exc:
         logger.warning("license: is_perpetual failed: %s", exc)
         return False
+
+
+def pro_installed_version() -> str | None:
+    """Public alias for :func:`_pro_installed_version` -- the on-disk
+    ``clawmetry-pro`` package version, or ``None`` if the paid wheel is
+    not importable.
+
+    Kept as a thin wrapper so external callers (routes, CLI, dashboards)
+    can bind to a stable public name without reaching into the underscore
+    helper. The underlying reader is idempotent (pure ``importlib.metadata``
+    lookup) and never raises; this wrapper preserves both properties.
+    """
+    try:
+        return _pro_installed_version()
+    except Exception as exc:
+        logger.debug("license: pro_installed_version wrapper failed: %s", exc)
+        return None
+
+
+def pro_installed() -> bool:
+    """Scalar gate for "is the paid wheel actually importable right now?"
+
+    Returns ``True`` iff :func:`pro_installed_version` returns a non-empty
+    version string. Every other state -- wheel never provisioned, wheel
+    unpacked but ``importlib.metadata`` can't see it, transient
+    introspection failure -- collapses to ``False`` so a paywall renderer
+    or a health tile bound to this helper never crashes on a partial
+    install.
+
+    Complements :func:`is_tier` / :func:`license_tier` (which read the
+    license *claim*): a healthy Pro install must have both a signed
+    Pro-tier claim AND the wheel on-disk. Splitting the two lets an
+    operator diagnose "activated but wheel missing" (download failed,
+    ``CLAWMETRY_OFFLINE=1`` on a fresh install, air-gapped node) from
+    "wheel installed but license expired" (paid feature stops unlocking
+    on renewal lapse).
+
+    Never raises.
+    """
+    return bool(pro_installed_version())
+
+
+def pro_installation_info() -> dict:
+    """Operator-facing description of the ``clawmetry-pro`` install state.
+
+    Combines the two independent facts a paywall / install-health UI
+    typically wants together:
+
+    * ``installed`` / ``version`` -- can Python actually import
+      ``clawmetry-pro`` right now? (Live ``importlib.metadata`` probe.)
+    * ``marker`` -- the ``~/.clawmetry/pro_installed.json`` sidecar written
+      by :func:`_write_pro_marker` at provision time
+      (``installed_at`` unix seconds, ``source``, ``node_id``, the
+      ``version`` recorded at write time). ``{}`` when the marker file is
+      missing or unreadable.
+
+    The two can disagree in normal operation (marker present but wheel
+    was pip-uninstalled; wheel present but marker never written on a
+    pre-marker install), and that disagreement is exactly what an
+    operator debugging a paywall glitch needs to see, so both are
+    surfaced side-by-side rather than collapsed.
+
+    Never raises -- any underlying failure degrades to
+    ``{installed: False, version: None, marker: {}}`` so a UI bound to
+    this helper never breaks on a partial install."""
+    try:
+        version = pro_installed_version()
+    except Exception as exc:
+        logger.debug("license: pro_installation_info version read failed: %s", exc)
+        version = None
+    try:
+        marker = _read_pro_marker()
+    except Exception as exc:
+        logger.debug("license: pro_installation_info marker read failed: %s", exc)
+        marker = {}
+    if not isinstance(marker, dict):
+        marker = {}
+    return {
+        "installed": bool(version),
+        "version": version,
+        "marker": marker,
+    }

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -8420,6 +8420,83 @@ def api_license_is_perpetual():
         return jsonify({"perpetual": False, "has_license": False, "has_exp": False})
 
 
+@bp_entitlement.route("/api/license/pro-installed")
+def api_license_pro_installed():
+    """``GET /api/license/pro-installed`` -- scalar gate for "is the paid
+    wheel actually importable right now?".
+
+    Payload:
+
+      * ``installed`` -- ``True`` iff Python can currently import
+        ``clawmetry-pro``. Complements ``/api/license/tier`` (which reads
+        the license *claim*): a healthy Pro node needs both a signed
+        Pro-tier license AND the wheel on-disk, and splitting them lets
+        an operator diagnose "activated but wheel missing"
+        (``CLAWMETRY_OFFLINE=1`` install, air-gapped node, failed
+        download) apart from "wheel installed but licence expired"
+        (paid feature stops unlocking on renewal lapse).
+      * ``version`` -- the ``importlib.metadata`` version string when
+        installed, else ``None``. A UI can render ``vX.Y.Z`` next to a
+        green "Pro installed" badge without a second call.
+
+    Wrapper around :func:`clawmetry.license.pro_installed` /
+    :func:`clawmetry.license.pro_installed_version`.
+
+    Never 5xxs. Any underlying introspection failure degrades to
+    ``{"installed": False, "version": None}`` at HTTP 200, matching the
+    never-crash posture of the paired scalar license endpoints.
+    """
+    try:
+        from clawmetry import license as _lic
+
+        version = _lic.pro_installed_version()
+        return jsonify(
+            {
+                "installed": bool(version),
+                "version": version,
+            }
+        )
+    except Exception as exc:
+        logger.warning("api_license_pro_installed: error: %s", exc)
+        return jsonify({"installed": False, "version": None})
+
+
+@bp_entitlement.route("/api/license/pro-installation")
+def api_license_pro_installation():
+    """``GET /api/license/pro-installation`` -- combined install-state view
+    for the ``clawmetry-pro`` wheel.
+
+    Payload -- the same envelope
+    :func:`clawmetry.license.pro_installation_info` returns:
+
+      * ``installed`` -- ``True`` iff ``clawmetry-pro`` is currently
+        importable.
+      * ``version`` -- live ``importlib.metadata`` version string when
+        installed, else ``None``.
+      * ``marker`` -- ``~/.clawmetry/pro_installed.json`` sidecar written
+        at provision time (``installed_at`` unix seconds, ``source``,
+        ``node_id``, and the ``version`` recorded at write time). ``{}``
+        when the marker file is missing / unreadable.
+
+    Live version and marker can disagree in normal operation (marker
+    present but wheel was pip-uninstalled; wheel present but marker
+    never written on a pre-marker install), and that disagreement is
+    exactly what an operator debugging a paywall glitch needs to see, so
+    both are surfaced side-by-side rather than collapsed into a single
+    boolean.
+
+    Never 5xxs. Any underlying introspection failure degrades to
+    ``{"installed": False, "version": None, "marker": {}}`` at HTTP 200.
+    """
+    try:
+        from clawmetry import license as _lic
+
+        return jsonify(_lic.pro_installation_info())
+    except Exception as exc:
+        logger.warning("api_license_pro_installation: error: %s", exc)
+        return jsonify({"installed": False, "version": None, "marker": {}})
+
+
 @bp_entitlement.route("/api/paywall/event", methods=["POST"])
 def api_paywall_event():
     body: dict = {}

--- a/tests/test_license_pro_installation.py
+++ b/tests/test_license_pro_installation.py
@@ -1,0 +1,332 @@
+"""Tests for the ``pro_installed`` / ``pro_installed_version`` /
+``pro_installation_info`` public helpers on ``clawmetry.license`` and their
+paired ``/api/license/pro-installed`` + ``/api/license/pro-installation``
+endpoints on ``routes.entitlement``.
+
+These are the scalar / envelope views onto the ``clawmetry-pro`` install-state
+axis -- an axis independent from the license *claim* (tier / exp / etc.). A
+healthy Pro node needs both a signed Pro-tier license AND the wheel on-disk,
+and splitting the two lets an operator diagnose "activated but wheel missing"
+apart from "wheel installed but licence expired".
+
+Both fronts must be never-crash: any underlying failure (broken
+``importlib.metadata``, unreadable marker file, missing pubkey PEM) must
+degrade to ``installed=False`` / empty marker rather than propagating an
+exception up the paywall renderer.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def env(monkeypatch, tmp_path):
+    """Isolated license env: tmp marker path, controllable pro-version reader,
+    Flask app with the entitlement blueprint mounted."""
+    import clawmetry.license as _lic
+
+    marker_path = str(tmp_path / "pro_installed.json")
+    monkeypatch.setattr(_lic, "_PRO_MARKER_PATH", marker_path)
+
+    # Default: paid wheel NOT installed. Individual tests flip this via the
+    # ``state`` handle below to model "wheel present" without mutating the
+    # real site-packages.
+    state = {"version": None}
+    monkeypatch.setattr(
+        _lic, "_pro_installed_version", lambda: state["version"]
+    )
+
+    from routes.entitlement import bp_entitlement
+
+    flask_app = Flask(__name__)
+    flask_app.register_blueprint(bp_entitlement)
+    flask_app.config["TESTING"] = True
+
+    return SimpleNamespace(
+        app=flask_app,
+        lic=_lic,
+        marker_path=marker_path,
+        state=state,
+    )
+
+
+def _write_marker(env, payload):
+    import json
+    import os
+
+    os.makedirs(os.path.dirname(env.marker_path), exist_ok=True)
+    with open(env.marker_path, "w", encoding="utf-8") as fh:
+        json.dump(payload, fh)
+
+
+# -- module-level scalar: pro_installed_version --
+
+
+def test_pro_installed_version_none_when_not_installed(env):
+    assert env.lic.pro_installed_version() is None
+
+
+def test_pro_installed_version_returns_string_when_installed(env):
+    env.state["version"] = "0.3.4"
+    assert env.lic.pro_installed_version() == "0.3.4"
+
+
+def test_pro_installed_version_never_raises(env, monkeypatch):
+    def boom():
+        raise RuntimeError("simulated importlib.metadata failure")
+
+    monkeypatch.setattr(env.lic, "_pro_installed_version", boom)
+    # Must degrade to None rather than propagate the RuntimeError up into
+    # a paywall renderer that just wanted a version string.
+    assert env.lic.pro_installed_version() is None
+
+
+# -- module-level scalar: pro_installed --
+
+
+def test_pro_installed_false_when_not_installed(env):
+    assert env.lic.pro_installed() is False
+
+
+def test_pro_installed_true_when_installed(env):
+    env.state["version"] = "0.3.4"
+    assert env.lic.pro_installed() is True
+
+
+def test_pro_installed_false_on_empty_version_string(env, monkeypatch):
+    """A zero-length version string is not a healthy install -- treat it as
+    "not installed" so a health tile bound to this gate doesn't render
+    green for a broken metadata reader."""
+    monkeypatch.setattr(env.lic, "_pro_installed_version", lambda: "")
+    assert env.lic.pro_installed() is False
+
+
+def test_pro_installed_never_raises(env, monkeypatch):
+    def boom():
+        raise RuntimeError("simulated importlib.metadata failure")
+
+    monkeypatch.setattr(env.lic, "_pro_installed_version", boom)
+    assert env.lic.pro_installed() is False
+
+
+# -- module-level envelope: pro_installation_info --
+
+
+_INFO_SHAPE = {"installed", "version", "marker"}
+
+
+def test_pro_installation_info_no_wheel_no_marker(env):
+    info = env.lic.pro_installation_info()
+    assert set(info) == _INFO_SHAPE
+    assert info["installed"] is False
+    assert info["version"] is None
+    assert info["marker"] == {}
+
+
+def test_pro_installation_info_wheel_present_no_marker(env):
+    """Wheel importable but marker never written -- normal on a pre-marker
+    or manually-installed wheel. Both facts should surface side-by-side."""
+    env.state["version"] = "0.3.4"
+    info = env.lic.pro_installation_info()
+    assert info["installed"] is True
+    assert info["version"] == "0.3.4"
+    assert info["marker"] == {}
+
+
+def test_pro_installation_info_marker_present_no_wheel(env):
+    """Marker present but wheel was pip-uninstalled -- exactly the
+    disagreement that needs to be visible to an operator debugging a
+    paywall glitch."""
+    _write_marker(
+        env,
+        {
+            "installed_at": 1_700_000_000,
+            "version": "0.3.4",
+            "source": "downloaded",
+            "node_id": "node-abc",
+        },
+    )
+    info = env.lic.pro_installation_info()
+    assert info["installed"] is False
+    assert info["version"] is None
+    assert info["marker"] == {
+        "installed_at": 1_700_000_000,
+        "version": "0.3.4",
+        "source": "downloaded",
+        "node_id": "node-abc",
+    }
+
+
+def test_pro_installation_info_healthy_install(env):
+    """Both wheel importable AND marker present -- the fully-healthy path."""
+    env.state["version"] = "0.3.4"
+    _write_marker(
+        env,
+        {
+            "installed_at": 1_700_000_000,
+            "version": "0.3.4",
+            "source": "downloaded",
+            "node_id": "node-abc",
+        },
+    )
+    info = env.lic.pro_installation_info()
+    assert info["installed"] is True
+    assert info["version"] == "0.3.4"
+    assert info["marker"]["source"] == "downloaded"
+
+
+def test_pro_installation_info_never_raises_on_version_failure(env, monkeypatch):
+    def boom():
+        raise RuntimeError("simulated importlib.metadata failure")
+
+    monkeypatch.setattr(env.lic, "_pro_installed_version", boom)
+    info = env.lic.pro_installation_info()
+    assert set(info) == _INFO_SHAPE
+    assert info["installed"] is False
+    assert info["version"] is None
+    # Marker read is independent of the version read; empty here because
+    # no marker was written in this test.
+    assert info["marker"] == {}
+
+
+def test_pro_installation_info_never_raises_on_marker_failure(env, monkeypatch):
+    def boom():
+        raise RuntimeError("simulated marker read failure")
+
+    monkeypatch.setattr(env.lic, "_read_pro_marker", boom)
+    env.state["version"] = "0.3.4"
+    info = env.lic.pro_installation_info()
+    # Version leg still succeeds; marker leg degrades to {}.
+    assert info["installed"] is True
+    assert info["version"] == "0.3.4"
+    assert info["marker"] == {}
+
+
+def test_pro_installation_info_marker_wrong_type(env, monkeypatch):
+    """A corrupt marker file whose top-level JSON is a list, not an object,
+    must not leak a wrong-shape marker up to the caller -- collapse to {}."""
+    monkeypatch.setattr(env.lic, "_read_pro_marker", lambda: ["not", "a", "dict"])
+    info = env.lic.pro_installation_info()
+    assert info["marker"] == {}
+
+
+# -- endpoint: /api/license/pro-installed --
+
+
+_INSTALLED_SHAPE = {"installed", "version"}
+
+
+def test_endpoint_pro_installed_no_wheel(env):
+    with env.app.test_client() as c:
+        resp = c.get("/api/license/pro-installed")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert set(data) == _INSTALLED_SHAPE
+    assert data["installed"] is False
+    assert data["version"] is None
+
+
+def test_endpoint_pro_installed_wheel_present(env):
+    env.state["version"] = "0.3.4"
+    with env.app.test_client() as c:
+        resp = c.get("/api/license/pro-installed")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["installed"] is True
+    assert data["version"] == "0.3.4"
+
+
+def test_endpoint_pro_installed_never_5xx(env, monkeypatch):
+    def boom():
+        raise RuntimeError("simulated importlib.metadata failure")
+
+    monkeypatch.setattr(env.lic, "_pro_installed_version", boom)
+    with env.app.test_client() as c:
+        resp = c.get("/api/license/pro-installed")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert set(data) == _INSTALLED_SHAPE
+    assert data["installed"] is False
+    assert data["version"] is None
+
+
+# -- endpoint: /api/license/pro-installation --
+
+
+def test_endpoint_pro_installation_no_wheel_no_marker(env):
+    with env.app.test_client() as c:
+        resp = c.get("/api/license/pro-installation")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert set(data) == _INFO_SHAPE
+    assert data["installed"] is False
+    assert data["version"] is None
+    assert data["marker"] == {}
+
+
+def test_endpoint_pro_installation_full_healthy(env):
+    env.state["version"] = "0.3.4"
+    _write_marker(
+        env,
+        {
+            "installed_at": 1_700_000_000,
+            "version": "0.3.4",
+            "source": "downloaded",
+        },
+    )
+    with env.app.test_client() as c:
+        resp = c.get("/api/license/pro-installation")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["installed"] is True
+    assert data["version"] == "0.3.4"
+    assert data["marker"]["source"] == "downloaded"
+    assert data["marker"]["installed_at"] == 1_700_000_000
+
+
+def test_endpoint_pro_installation_wheel_uninstalled_marker_stays(env):
+    """Marker + no wheel -- the operator-visible disagreement branch."""
+    _write_marker(
+        env,
+        {
+            "installed_at": 1_700_000_000,
+            "version": "0.3.4",
+            "source": "downloaded",
+        },
+    )
+    with env.app.test_client() as c:
+        resp = c.get("/api/license/pro-installation")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["installed"] is False
+    assert data["version"] is None
+    # Marker survives on its own leg so the UI can render "was installed on
+    # <date> from <source>, but the wheel is gone now" without needing a
+    # second endpoint call.
+    assert data["marker"]["installed_at"] == 1_700_000_000
+
+
+def test_endpoint_pro_installation_never_5xx(env, monkeypatch):
+    """Broken install (import / marker mismatch) must degrade to the empty
+    envelope at HTTP 200 rather than 500 -- matches the never-crash posture
+    of the sibling ``/api/license/*`` endpoints."""
+
+    def boom_version():
+        raise RuntimeError("simulated importlib.metadata failure")
+
+    def boom_marker():
+        raise RuntimeError("simulated marker read failure")
+
+    monkeypatch.setattr(env.lic, "_pro_installed_version", boom_version)
+    monkeypatch.setattr(env.lic, "_read_pro_marker", boom_marker)
+    with env.app.test_client() as c:
+        resp = c.get("/api/license/pro-installation")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert set(data) == _INFO_SHAPE
+    assert data["installed"] is False
+    assert data["version"] is None
+    assert data["marker"] == {}


### PR DESCRIPTION
## Summary

- Adds three public helpers on `clawmetry.license` and their paired read-only HTTP endpoints so a paywall / install-health UI can bind to the `clawmetry-pro` wheel install-state axis without reaching into the private `_pro_installed_version` / `_read_pro_marker` helpers.
- The wheel install-state axis is independent from the license *claim* (tier / exp / etc.) already covered by the existing `/api/license/tier`, `/api/license/is-expired`, and `/api/license/status` endpoints. Splitting the two lets an operator diagnose "activated but wheel missing" (`CLAWMETRY_OFFLINE=1` install, air-gapped node, failed download) apart from "wheel installed but licence expired" (paid feature stops unlocking on renewal lapse).
- Grace-mode behaviour is unchanged — these are pure reads that never touch enforcement.

### New public helpers (`clawmetry/license.py`)

| Function | Returns | Purpose |
|---|---|---|
| `pro_installed_version()` | `str \| None` | Thin never-raises wrapper for the existing private `_pro_installed_version()` `importlib.metadata` probe. |
| `pro_installed()` | `bool` | Scalar gate — "is the paid wheel actually importable right now?" Empty version strings collapse to `False` so a broken metadata reader doesn't render as a green health tile. |
| `pro_installation_info()` | `{installed, version, marker}` | Combined envelope. Live wheel version and on-disk provision marker are surfaced side-by-side because they can disagree in normal operation (marker present + wheel pip-uninstalled; wheel present + marker never written on a pre-marker install) and that disagreement is exactly what an operator debugging a paywall glitch needs to see. |

### New endpoints (`routes/entitlement.py`, `bp_entitlement`)

| Endpoint | Payload |
|---|---|
| `GET /api/license/pro-installed` | `{installed: bool, version: str \| null}` |
| `GET /api/license/pro-installation` | `{installed: bool, version: str \| null, marker: {installed_at, version, source, node_id, …}}` |

Both endpoints degrade to their empty envelope at HTTP 200 on any underlying introspection failure, matching the never-5xx posture of the sibling `/api/license/*` scalar endpoints.

## Test plan

- [x] `python -m pytest tests/test_license_pro_installation.py` — 21 cases green
- [x] `python -m pytest tests/test_license.py tests/test_license_api.py tests/test_license_is_expired_is_perpetual.py tests/test_license_tier_scalar.py tests/test_license_pubkey.py` — 170 sibling cases still green (no regression)
- [x] `python -m pytest tests/test_entitlement_api.py tests/test_entitlement_api_fallback_shape.py` — 39 sibling entitlement cases still green
- [x] `python -m py_compile clawmetry/license.py routes/entitlement.py tests/test_license_pro_installation.py` — clean

Coverage matrix on the new test file:

- Module-level scalar `pro_installed_version` — absent / present / never-raises.
- Module-level scalar `pro_installed` — absent / present / empty-string / never-raises.
- Module-level envelope `pro_installation_info` — every four-way branch of the (wheel × marker) matrix, plus wrong-type marker and never-raises on either leg failing independently.
- Endpoint `/api/license/pro-installed` — every branch, never-5xx.
- Endpoint `/api/license/pro-installation` — full-healthy / marker-only / no-license / never-5xx, and pins that the envelope shape is stable across every branch so a UI can bind to one code path.

Tests use an ephemeral `_PRO_MARKER_PATH` under `tmp_path` and monkeypatch `_pro_installed_version` so no real site-packages or `~/.clawmetry/` state is touched.

## Local operator verification checklist

I can't reach the host from this sandbox, so the local-daemon / live-cloud legs are on you:

- [ ] Copy the changed files into the venv the daemon uses: `cp clawmetry/license.py ~/.clawmetry/lib/python3.11/site-packages/clawmetry/` and `cp routes/entitlement.py ~/.clawmetry/lib/python3.11/site-packages/routes/` (adjust `python3.X` to match your daemon's interpreter).
- [ ] Clear the byte-cache so the new code is picked up: `find ~/.clawmetry/lib -name __pycache__ -exec rm -rf {} +`
- [ ] Restart the daemon: `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
- [ ] Hit both new endpoints against the running dashboard:
  - `curl -s http://localhost:8900/api/license/pro-installed | jq`
  - `curl -s http://localhost:8900/api/license/pro-installation | jq`
- [ ] Sanity-check the existing sibling endpoints still return their unchanged shape:
  - `curl -s http://localhost:8900/api/license/status | jq`
  - `curl -s http://localhost:8900/api/license/is-perpetual | jq`
- [ ] If clawmetry-pro is installed on the host: `installed=true`, `version` is a version string, `marker.installed_at` is a unix seconds int.
- [ ] Decrypt a live cloud snapshot to confirm the new endpoints are reachable through the cloud relay and don't break the snapshot decrypt path.
- [ ] Browser-check `/entitlements` (or wherever the paywall UI lives) after redeploy — nothing should regress since these are additive read-only endpoints.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JMvgCjuc8z1UPbvXwqUnJr)_