### PR TITLE
feat(paywall): distinct_values helper + /api/paywall/events/distinct endpoint

### DIFF
--- a/clawmetry/_paywall_events.py
+++ b/clawmetry/_paywall_events.py
@@ -697,6 +697,115 @@ class _PaywallEventStore:
             logger.warning("paywall.events: first_matching swallowed: %s", exc)
             return None
 
+    def distinct_values(
+        self,
+        *,
+        event: str | None = None,
+        feature: str | None = None,
+        harness: str | None = None,
+        source: str | None = None,
+        plan_chosen: str | None = None,
+        since: Any = None,
+        until: Any = None,
+    ) -> dict:
+        """Return the sorted set of distinct non-empty values per
+        categorical dimension currently in the ring (post-filter,
+        post-window).
+
+        Answers "which values would a filter dropdown actually let the
+        operator pick?" without paying for the full ``by_*`` count
+        aggregation :meth:`summary` builds. The five per-dimension lists
+        are exactly the keys of :meth:`summary`'s ``by_*`` dicts for
+        identical filter + window inputs -- pinned in the test suite so
+        the two views cannot silently drift.
+
+        Same filter / window semantics as :meth:`summary` /
+        :meth:`recent` / :meth:`count_matching`: ``None`` or empty-string
+        means "not supplied", case-sensitive exact match on categorical
+        filters, half-open ``[since, until)`` on the time window,
+        ``AND``-combined. Because filters narrow the ring BEFORE the
+        distinct set is computed, a caller can drive a
+        "further narrow by:" dropdown UX -- filter on ``event=X`` and
+        the returned ``feature`` list is only those features that
+        actually co-occur with event ``X`` in the current ring, not the
+        full ring's feature set.
+
+        Empty-string field values are excluded from every returned list
+        (matches :meth:`summary`'s ``by_*`` posture). Each list is
+        sorted ascending (case-sensitive, string-compare) so callers
+        get a stable order across calls independent of ring insertion
+        order.
+
+        Envelope shape::
+
+            {
+              "distinct": {
+                "event":       [<str>, ...],
+                "feature":     [<str>, ...],
+                "harness":     [<str>, ...],
+                "source":      [<str>, ...],
+                "plan_chosen": [<str>, ...],
+              },
+              "in_window": <int>,          # ring size right now, unfiltered
+              "matched":   <int>,          # rows the distinct set was computed over
+              "filters":   {"<key>": "<value>", ...},   # echo of applied categorical filters
+              "time_window": {"since": <float|null>, "until": <float|null>},
+            }
+
+        ``in_window`` is NEVER filtered (matches :meth:`summary` /
+        :meth:`count_matching`) -- it describes the ring itself, so a
+        filtered dashboard tile can still see "0 of 42 rows match the
+        current filter" context. ``matched`` is the post-filter,
+        post-window subset size; on a fully-unfiltered call it byte-
+        equals ``in_window``.
+
+        Never raises: a failure short-circuits to the neutral all-empty
+        envelope so a paywall dashboard tile keeps rendering.
+        """
+        try:
+            filters = _normalise_filters(
+                event=event, feature=feature, harness=harness,
+                source=source, plan_chosen=plan_chosen,
+            )
+            since_ts, until_ts = _normalise_time_bounds(since, until)
+            with self._lock:
+                snap = list(self._ring)
+            has_window = since_ts is not None or until_ts is not None
+
+            distinct: dict[str, set[str]] = {k: set() for k in _FILTER_KEYS}
+            matched = 0
+            for row in snap:
+                if filters and not _row_matches_filters(row, filters):
+                    continue
+                if has_window and not _row_matches_time_window(
+                    row, since_ts, until_ts,
+                ):
+                    continue
+                matched += 1
+                for key in _FILTER_KEYS:
+                    val = row.get(key, "")
+                    if val:
+                        distinct[key].add(val)
+
+            return {
+                "distinct": {k: sorted(distinct[k]) for k in _FILTER_KEYS},
+                "in_window": len(snap),
+                "matched": matched,
+                "filters": dict(filters),
+                "time_window": {"since": since_ts, "until": until_ts},
+            }
+        except Exception as exc:
+            logger.warning(
+                "paywall.events: distinct_values swallowed error: %s", exc,
+            )
+            return {
+                "distinct": {k: [] for k in _FILTER_KEYS},
+                "in_window": 0,
+                "matched": 0,
+                "filters": {},
+                "time_window": {"since": None, "until": None},
+            }
+
     def reset(self) -> None:
         with self._lock:
             self._ring.clear()
@@ -844,6 +953,33 @@ def first_matching(
     :func:`recent` / :func:`summary` / :func:`count_matching`.
     """
     return _STORE.first_matching(
+        event=event, feature=feature, harness=harness,
+        source=source, plan_chosen=plan_chosen,
+        since=since, until=until,
+    )
+
+
+def distinct_values(
+    *,
+    event: str | None = None,
+    feature: str | None = None,
+    harness: str | None = None,
+    source: str | None = None,
+    plan_chosen: str | None = None,
+    since: Any = None,
+    until: Any = None,
+) -> dict:
+    """Public shim for :meth:`_PaywallEventStore.distinct_values`.
+
+    Returns the sorted set of distinct non-empty values per categorical
+    dimension currently in the ring (post-filter, post-window). Same
+    filter + window contract as :func:`summary` / :func:`recent` /
+    :func:`count_matching`; see :meth:`_PaywallEventStore.distinct_values`
+    for the exact response shape. Used by
+    ``GET /api/paywall/events/distinct`` to populate filter-dropdown
+    options for the paywall dashboard.
+    """
+    return _STORE.distinct_values(
         event=event, feature=feature, harness=harness,
         source=source, plan_chosen=plan_chosen,
         since=since, until=until,

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -8991,6 +8991,95 @@ def api_paywall_events_count():
         )
 
 
+_PAYWALL_DISTINCT_DIMS = ("event", "feature", "harness", "source", "plan_chosen")
+
+
+@bp_entitlement.route("/api/paywall/events/distinct")
+def api_paywall_events_distinct():
+    """``GET /api/paywall/events/distinct`` -- sorted distinct values per
+    categorical dimension currently in the ring.
+
+    Populates filter-dropdown options for the paywall-events dashboard:
+    a UI wanting to render "Filter by feature: [ dropdown ]" needs to
+    know which features have actually fired at least one beacon this
+    session so the dropdown never lists dead options. This endpoint
+    hands back exactly that list for each of the five categorical
+    dimensions in one round-trip.
+
+    Same categorical filter query params + semantics as the sibling
+    paywall-events endpoints -- ``?event=`` / ``?feature=`` /
+    ``?harness=`` / ``?source=`` / ``?plan_chosen=``, case-sensitive
+    exact match, ``AND`` combined, blank / missing = "not supplied".
+    Filters narrow the ring BEFORE the distinct set is computed, so a
+    caller can drive a "further narrow by:" dropdown UX -- passing
+    ``?event=paywall_cta_click`` returns only the features that
+    actually co-occur with CTA clicks in the current ring.
+
+    Same time-window params as ``/api/paywall/events/{summary,recent,count}``::
+
+      ?since=<float-epoch-seconds>
+      ?until=<float-epoch-seconds>
+
+    Half-open ``[since, until)``; either bound may be omitted or blank.
+    Bad bounds (non-numeric, NaN, negative) collapse to "not supplied"
+    so an operator typo cannot silently drop every row.
+
+    Body shape::
+
+        {
+          "distinct": {
+            "event":       [<str>, ...],   # sorted ascending, non-empty only
+            "feature":     [<str>, ...],
+            "harness":     [<str>, ...],
+            "source":      [<str>, ...],
+            "plan_chosen": [<str>, ...],
+          },
+          "in_window": <int>,            # ring size right now, unfiltered
+          "matched":   <int>,            # rows the distinct set covers (post-filter, post-window)
+          "filters":   {"<key>": "<value>", ...},   # echo of applied categorical filters
+          "time_window": {"since": <float|null>, "until": <float|null>}
+                                                    # echo of resolved bounds
+        }
+
+    The per-dimension lists are byte-equal to the sorted keys of
+    ``/api/paywall/events/summary``'s corresponding ``by_*`` dict for
+    the same filter + window inputs -- pinned in the test suite so the
+    two views cannot silently drift. On a fully-unfiltered request
+    ``matched`` byte-equals ``in_window``.
+
+    Ships in GRACE. Never 5xxs -- on any failure returns the neutral
+    empty envelope so a paywall-dashboard dropdown keeps rendering
+    (empty options are correct: the store has nothing to offer).
+    """
+    try:
+        from clawmetry import _paywall_events as _pe
+
+        filter_kwargs = {
+            key: request.args.get(key, "") or None
+            for key in _PAYWALL_DISTINCT_DIMS
+        }
+        window_kwargs = {
+            key: request.args.get(key, "") or None
+            for key in ("since", "until")
+        }
+        # The store treats blank / whitespace strings as "not supplied"
+        # and does its own numeric coercion on the time bounds, so the
+        # response's ``filters`` / ``time_window`` echoes come from the
+        # store's normalised view rather than the raw query string.
+        return jsonify(_pe.distinct_values(**filter_kwargs, **window_kwargs))
+    except Exception as exc:
+        logger.warning("api_paywall_events_distinct: error: %s", exc)
+        return jsonify(
+            {
+                "distinct": {k: [] for k in _PAYWALL_DISTINCT_DIMS},
+                "in_window": 0,
+                "matched": 0,
+                "filters": {},
+                "time_window": {"since": None, "until": None},
+            }
+        )
+
+
 def _route_actor() -> str:
     try:
         for h in ("X-Actor", "X-Forwarded-For"):

--- a/tests/test_paywall_events_distinct.py
+++ b/tests/test_paywall_events_distinct.py
@@ -1,0 +1,369 @@
+"""Store-level tests for the paywall-event distinct-values helper:
+
+  ``clawmetry._paywall_events.distinct_values``
+  ``clawmetry._paywall_events._PaywallEventStore.distinct_values``
+
+Categorical dropdown-population sibling of ``summary`` / ``recent`` /
+``count_matching`` -- returns the sorted set of distinct non-empty
+values per categorical dimension currently in the ring (post-filter,
+post-window). Anchored to the SAME filter + window semantics as the
+rest of the store, and pinned against ``summary``'s ``by_*`` keys so
+the two views cannot silently drift.
+
+Store-level tests here pin:
+
+* Envelope shape and always-present keys.
+* Sorted, deduplicated, non-empty-only per-dimension lists.
+* Categorical filters narrow BEFORE the distinct set is computed
+  (drives "further narrow by:" dropdown UX).
+* Time-window semantics (half-open ``[since, until)``, bad bounds
+  collapse to unbounded).
+* Parity with :meth:`summary` -- per-dimension keys match by_* keys
+  byte-for-byte on identical filter + window inputs.
+* Never-raises posture on a broken store.
+
+HTTP shape tests live in ``test_paywall_events_distinct_api.py`` and
+should stay independent so a route-only regression cannot silently
+break the store contract.
+"""
+from __future__ import annotations
+
+import pytest
+
+
+# ── fixtures ────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def store():
+    """A fresh in-process store, isolated per test."""
+    from clawmetry import _paywall_events as pe
+
+    pe.reset()
+    yield pe
+    pe.reset()
+
+
+@pytest.fixture
+def clock(monkeypatch):
+    """Deterministic clock so tests can pin exact ``since`` / ``until``
+    boundaries."""
+    from clawmetry import _paywall_events as pe
+
+    box = {"now": 1_000_000.0}
+    monkeypatch.setattr(pe.time, "time", lambda: box["now"])
+    return box
+
+
+def _rec(store, **fields):
+    store.record_event(fields)
+
+
+def _rec_at(store, clock, ts, **fields):
+    clock["now"] = float(ts)
+    store.record_event(fields)
+
+
+# ── envelope shape ─────────────────────────────────────────────────────────
+
+
+def test_distinct_empty_ring_returns_neutral_envelope(store):
+    body = store.distinct_values()
+    assert body == {
+        "distinct": {
+            "event": [],
+            "feature": [],
+            "harness": [],
+            "source": [],
+            "plan_chosen": [],
+        },
+        "in_window": 0,
+        "matched": 0,
+        "filters": {},
+        "time_window": {"since": None, "until": None},
+    }
+
+
+def test_distinct_envelope_always_carries_top_level_keys(store):
+    _rec(store, event="paywall_view", feature="fleet")
+    body = store.distinct_values()
+    assert set(body.keys()) == {
+        "distinct", "in_window", "matched", "filters", "time_window",
+    }
+    assert set(body["distinct"].keys()) == {
+        "event", "feature", "harness", "source", "plan_chosen",
+    }
+
+
+# ── unfiltered semantics ───────────────────────────────────────────────────
+
+
+def test_distinct_unfiltered_returns_sorted_uniques(store):
+    _rec(store, event="paywall_view", feature="fleet")
+    _rec(store, event="paywall_cta_click", feature="anomaly_detection")
+    _rec(store, event="paywall_view", feature="fleet")  # dup
+
+    body = store.distinct_values()
+    assert body["distinct"]["event"] == [
+        "paywall_cta_click", "paywall_view",  # sorted ascending
+    ]
+    assert body["distinct"]["feature"] == ["anomaly_detection", "fleet"]
+    assert body["in_window"] == 3
+    assert body["matched"] == 3
+    assert body["filters"] == {}
+
+
+def test_distinct_excludes_empty_string_values(store):
+    """A row that only carries ``event`` must NOT contribute an empty
+    string to the other dimensions -- matches :meth:`summary`'s
+    ``by_*`` posture (empty keys are excluded)."""
+    _rec(store, event="paywall_view")  # every other field empty
+    _rec(store, event="paywall_view", feature="fleet")
+
+    body = store.distinct_values()
+    assert body["distinct"]["event"] == ["paywall_view"]
+    assert body["distinct"]["feature"] == ["fleet"]
+    # No empty strings anywhere.
+    for values in body["distinct"].values():
+        assert "" not in values
+
+
+def test_distinct_all_five_dimensions_populate(store):
+    _rec(
+        store,
+        event="paywall_cta_click",
+        feature="self_evolve",
+        harness="claude_code",
+        source="banner",
+        plan_chosen="cloud_pro",
+    )
+    _rec(
+        store,
+        event="paywall_view",
+        feature="fleet",
+        harness="codex",
+        source="tile",
+        plan_chosen="cloud_starter",
+    )
+    body = store.distinct_values()
+    assert body["distinct"] == {
+        "event": ["paywall_cta_click", "paywall_view"],
+        "feature": ["fleet", "self_evolve"],
+        "harness": ["claude_code", "codex"],
+        "source": ["banner", "tile"],
+        "plan_chosen": ["cloud_pro", "cloud_starter"],
+    }
+
+
+def test_distinct_sort_is_case_sensitive_string_order(store):
+    """Sort is Python's default string sort -- uppercase < lowercase.
+    Pinned so a later locale-collation refactor cannot silently
+    reorder dropdown options."""
+    for name in ("banana", "Apple", "cherry"):
+        _rec(store, event="paywall_view", feature=name)
+    body = store.distinct_values()
+    assert body["distinct"]["feature"] == ["Apple", "banana", "cherry"]
+
+
+def test_distinct_unfiltered_matched_equals_in_window(store):
+    for i in range(5):
+        _rec(store, event="paywall_view", feature=f"f{i}")
+    body = store.distinct_values()
+    assert body["matched"] == body["in_window"] == 5
+
+
+# ── categorical filters ────────────────────────────────────────────────────
+
+
+def test_distinct_filter_narrows_before_distinct_set(store):
+    """Filters run BEFORE the distinct set is computed, so the returned
+    ``feature`` list is only those features that co-occur with the
+    filter -- drives the "further narrow by:" dropdown UX."""
+    _rec(store, event="paywall_view", feature="fleet")
+    _rec(store, event="paywall_view", feature="anomaly")
+    _rec(store, event="paywall_cta_click", feature="self_evolve")
+
+    body = store.distinct_values(event="paywall_view")
+    assert body["distinct"]["feature"] == ["anomaly", "fleet"]  # NOT self_evolve
+    assert body["distinct"]["event"] == ["paywall_view"]
+    assert body["matched"] == 2
+    assert body["in_window"] == 3  # ring unaffected
+    assert body["filters"] == {"event": "paywall_view"}
+
+
+def test_distinct_filter_no_match_returns_empty_but_nonzero_in_window(store):
+    _rec(store, event="paywall_view", feature="fleet")
+    body = store.distinct_values(event="not_a_real_event")
+    for values in body["distinct"].values():
+        assert values == []
+    assert body["matched"] == 0
+    assert body["in_window"] == 1
+    assert body["filters"] == {"event": "not_a_real_event"}
+
+
+def test_distinct_blank_filter_is_not_supplied(store):
+    _rec(store, event="paywall_view", feature="fleet")
+    body = store.distinct_values(event="", feature="  ")
+    assert body["filters"] == {}
+    assert body["distinct"]["feature"] == ["fleet"]
+    assert body["matched"] == 1
+
+
+def test_distinct_combines_filters_with_and(store):
+    _rec(store, event="paywall_view", feature="fleet", harness="claude_code")
+    _rec(store, event="paywall_view", feature="fleet", harness="codex")
+    _rec(store, event="paywall_cta_click", feature="fleet", harness="claude_code")
+
+    body = store.distinct_values(event="paywall_view", feature="fleet")
+    assert body["distinct"]["harness"] == ["claude_code", "codex"]
+    assert body["matched"] == 2
+    assert body["filters"] == {"event": "paywall_view", "feature": "fleet"}
+
+
+# ── time-window semantics ──────────────────────────────────────────────────
+
+
+def test_distinct_time_window_echoes_resolved_bounds(store, clock):
+    _rec_at(store, clock, 100.0, event="paywall_view", feature="a")
+    _rec_at(store, clock, 200.0, event="paywall_view", feature="b")
+
+    body = store.distinct_values(since=150, until=250)
+    assert body["distinct"]["feature"] == ["b"]
+    assert body["matched"] == 1
+    assert body["time_window"] == {"since": 150.0, "until": 250.0}
+
+
+def test_distinct_since_is_inclusive_until_is_exclusive(store, clock):
+    _rec_at(store, clock, 100.0, event="paywall_view", feature="a")
+    _rec_at(store, clock, 101.0, event="paywall_view", feature="b")
+
+    # since=100 includes ts=100.
+    body = store.distinct_values(since=100)
+    assert body["distinct"]["feature"] == ["a", "b"]
+
+    # until=101 excludes ts=101.
+    body = store.distinct_values(until=101)
+    assert body["distinct"]["feature"] == ["a"]
+
+
+def test_distinct_bad_bounds_collapse_to_unbounded(store, clock):
+    _rec_at(store, clock, 100.0, event="paywall_view", feature="a")
+    _rec_at(store, clock, 200.0, event="paywall_view", feature="b")
+
+    body = store.distinct_values(since="junk", until="nan")
+    assert body["distinct"]["feature"] == ["a", "b"]  # unbounded => full ring
+    assert body["time_window"] == {"since": None, "until": None}
+
+
+def test_distinct_empty_window_matches_nothing(store, clock):
+    _rec_at(store, clock, 100.0, event="paywall_view", feature="f")
+    body = store.distinct_values(since=200, until=200)
+    for values in body["distinct"].values():
+        assert values == []
+    assert body["matched"] == 0
+    assert body["in_window"] == 1
+    assert body["time_window"] == {"since": 200.0, "until": 200.0}
+
+
+def test_distinct_window_and_categorical_filter_combine(store, clock):
+    _rec_at(store, clock, 100.0, event="paywall_view",      feature="fleet")
+    _rec_at(store, clock, 200.0, event="paywall_cta_click", feature="fleet")
+    _rec_at(store, clock, 300.0, event="paywall_cta_click", feature="anomaly")
+
+    body = store.distinct_values(
+        event="paywall_cta_click", since=150, until=250,
+    )
+    assert body["distinct"]["feature"] == ["fleet"]
+    assert body["matched"] == 1
+    assert body["filters"] == {"event": "paywall_cta_click"}
+    assert body["time_window"] == {"since": 150.0, "until": 250.0}
+
+
+# ── cross-view parity with summary() ───────────────────────────────────────
+
+
+def test_distinct_matches_summary_by_star_keys_unfiltered(store):
+    """The five per-dimension distinct lists byte-equal the sorted keys
+    of :meth:`summary`'s ``by_*`` dicts for the same inputs -- pinned
+    so a caller can trust the two views agree on which dropdown
+    options are live."""
+    _rec(
+        store,
+        event="paywall_view", feature="fleet",
+        harness="claude_code", source="banner", plan_chosen="cloud_pro",
+    )
+    _rec(
+        store,
+        event="paywall_cta_click", feature="anomaly",
+        harness="codex", source="tile", plan_chosen="cloud_starter",
+    )
+    _rec(
+        store,
+        event="paywall_view", feature="fleet",
+        harness="claude_code", source="banner", plan_chosen="cloud_pro",
+    )
+
+    distinct = store.distinct_values()["distinct"]
+    summary = store.summary()
+    for dim, by_key in (
+        ("event", "by_event"),
+        ("feature", "by_feature"),
+        ("harness", "by_harness"),
+        ("source", "by_source"),
+        ("plan_chosen", "by_plan_chosen"),
+    ):
+        assert distinct[dim] == sorted(summary[by_key].keys()), dim
+
+
+def test_distinct_matches_summary_by_star_keys_with_filter(store):
+    _rec(store, event="paywall_view", feature="fleet")
+    _rec(store, event="paywall_view", feature="anomaly")
+    _rec(store, event="paywall_cta_click", feature="self_evolve")
+
+    distinct = store.distinct_values(event="paywall_view")["distinct"]
+    summary = store.summary(event="paywall_view")
+    assert distinct["feature"] == sorted(summary["by_feature"].keys())
+    assert distinct["event"] == sorted(summary["by_event"].keys())
+
+
+def test_distinct_matched_equals_summary_matched(store, clock):
+    for ts, feature in (
+        (100.0, "fleet"), (110.0, "fleet"),
+        (120.0, "anomaly"), (200.0, "fleet"),
+    ):
+        _rec_at(store, clock, ts, event="paywall_view", feature=feature)
+
+    distinct = store.distinct_values(feature="fleet", since=100, until=200)
+    summary = store.summary(feature="fleet", since=100, until=200)
+    assert distinct["matched"] == summary["matched"]
+
+
+# ── never-raise ────────────────────────────────────────────────────────────
+
+
+def test_distinct_never_raises_on_broken_ring(store, monkeypatch):
+    """A store-internal explosion falls back to the neutral envelope,
+    never propagating -- pins the never-raise posture that the
+    ``/api/paywall/events/distinct`` route relies on to stay 200."""
+    _rec(store, event="paywall_view", feature="fleet")
+
+    # Force the lock acquisition inside distinct_values to blow up.
+    class _BoomLock:
+        def __enter__(self):
+            raise RuntimeError("simulated lock outage")
+
+        def __exit__(self, *_):
+            return False
+
+    monkeypatch.setattr(store._STORE, "_lock", _BoomLock())
+    body = store.distinct_values()
+    assert body == {
+        "distinct": {
+            "event": [], "feature": [], "harness": [],
+            "source": [], "plan_chosen": [],
+        },
+        "in_window": 0,
+        "matched": 0,
+        "filters": {},
+        "time_window": {"since": None, "until": None},
+    }

--- a/tests/test_paywall_events_distinct_api.py
+++ b/tests/test_paywall_events_distinct_api.py
@@ -1,0 +1,350 @@
+"""API tests for the paywall-event distinct-values endpoint:
+
+  GET /api/paywall/events/distinct
+
+Thin JSON wrapper around :func:`clawmetry._paywall_events.distinct_values`
+-- populates filter-dropdown options for the paywall-events dashboard so
+a UI never lists dead filter values. Store-level distinct_values
+invariants (sorting, dedup, filter-before-distinct, empty-string
+exclusion, ``summary`` parity) live in ``test_paywall_events_distinct.py``;
+these tests pin the HTTP contract:
+
+* Never 5xxs.
+* Ships in GRACE -- no entitlement gate.
+* Empty ring returns the neutral all-empty envelope, including a
+  ``time_window: {since: null, until: null}`` echo so a dashboard tile
+  can trust the top-level key set is stable regardless of window
+  supply.
+* Categorical filter params (``event`` / ``feature`` / ``harness`` /
+  ``source`` / ``plan_chosen``) narrow the ring BEFORE the distinct
+  set is computed and echo back under ``filters`` (blank ones
+  omitted).
+* Time-window params (``since`` / ``until``) apply the half-open
+  ``[since, until)`` semantics and echo the resolved bounds under
+  ``time_window``. Bad bounds collapse to "not supplied".
+* Cross-endpoint agreement: for the same inputs the per-dimension
+  ``distinct`` list byte-equals the sorted keys of
+  ``/api/paywall/events/summary``'s corresponding ``by_*`` dict.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+from flask import Flask
+
+
+# ── fixtures ────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def client():
+    from routes.entitlement import bp_entitlement
+    from clawmetry import _paywall_events as pe
+
+    pe.reset()
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    app.config["TESTING"] = True
+    try:
+        yield app.test_client()
+    finally:
+        pe.reset()
+
+
+@pytest.fixture
+def clock(monkeypatch):
+    from clawmetry import _paywall_events as pe
+
+    box = {"now": 1_000_000.0}
+    monkeypatch.setattr(pe.time, "time", lambda: box["now"])
+    return box
+
+
+def _post_event(client, **fields):
+    resp = client.post(
+        "/api/paywall/event",
+        data=json.dumps(fields),
+        content_type="application/json",
+    )
+    assert resp.status_code == 204
+
+
+def _post_at(client, clock, ts, **fields):
+    clock["now"] = float(ts)
+    _post_event(client, **fields)
+
+
+_EMPTY_DISTINCT = {
+    "event": [],
+    "feature": [],
+    "harness": [],
+    "source": [],
+    "plan_chosen": [],
+}
+
+
+# ── empty ring ──────────────────────────────────────────────────────────────
+
+
+def test_distinct_empty_ring_returns_neutral_envelope(client):
+    body = client.get("/api/paywall/events/distinct").get_json()
+    assert body == {
+        "distinct": _EMPTY_DISTINCT,
+        "in_window": 0,
+        "matched": 0,
+        "filters": {},
+        "time_window": {"since": None, "until": None},
+    }
+
+
+def test_distinct_envelope_always_carries_top_level_keys(client):
+    body = client.get("/api/paywall/events/distinct").get_json()
+    assert set(body.keys()) == {
+        "distinct", "in_window", "matched", "filters", "time_window",
+    }
+    assert set(body["distinct"].keys()) == set(_EMPTY_DISTINCT.keys())
+
+
+# ── unfiltered ──────────────────────────────────────────────────────────────
+
+
+def test_distinct_unfiltered_returns_sorted_uniques(client):
+    _post_event(client, event="paywall_view", feature="fleet")
+    _post_event(client, event="paywall_cta_click", feature="anomaly")
+    _post_event(client, event="paywall_view", feature="fleet")  # dup
+
+    body = client.get("/api/paywall/events/distinct").get_json()
+    assert body["distinct"]["event"] == ["paywall_cta_click", "paywall_view"]
+    assert body["distinct"]["feature"] == ["anomaly", "fleet"]
+    assert body["in_window"] == 3
+    assert body["matched"] == 3
+
+
+def test_distinct_unfiltered_matched_equals_in_window(client):
+    for i in range(4):
+        _post_event(client, event="paywall_view", feature=f"f{i}")
+    body = client.get("/api/paywall/events/distinct").get_json()
+    assert body["matched"] == body["in_window"] == 4
+
+
+# ── categorical filters ────────────────────────────────────────────────────
+
+
+def test_distinct_filter_narrows_before_distinct_set(client):
+    _post_event(client, event="paywall_view", feature="fleet")
+    _post_event(client, event="paywall_view", feature="anomaly")
+    _post_event(client, event="paywall_cta_click", feature="self_evolve")
+
+    body = client.get(
+        "/api/paywall/events/distinct?event=paywall_view",
+    ).get_json()
+    # self_evolve co-occurs only with paywall_cta_click -- must not appear.
+    assert body["distinct"]["feature"] == ["anomaly", "fleet"]
+    assert body["distinct"]["event"] == ["paywall_view"]
+    assert body["matched"] == 2
+    assert body["in_window"] == 3
+    assert body["filters"] == {"event": "paywall_view"}
+
+
+def test_distinct_blank_filter_is_not_supplied(client):
+    _post_event(client, event="paywall_view", feature="fleet")
+    body = client.get(
+        "/api/paywall/events/distinct?event=&feature=",
+    ).get_json()
+    assert body["filters"] == {}
+    assert body["distinct"]["feature"] == ["fleet"]
+    assert body["matched"] == 1
+
+
+def test_distinct_combines_filters_with_and(client):
+    _post_event(client, event="paywall_view", feature="fleet", harness="claude_code")
+    _post_event(client, event="paywall_view", feature="fleet", harness="codex")
+    _post_event(client, event="paywall_cta_click", feature="fleet", harness="claude_code")
+
+    body = client.get(
+        "/api/paywall/events/distinct"
+        "?event=paywall_view&feature=fleet",
+    ).get_json()
+    assert body["distinct"]["harness"] == ["claude_code", "codex"]
+    assert body["matched"] == 2
+    assert body["filters"] == {"event": "paywall_view", "feature": "fleet"}
+
+
+def test_distinct_all_five_filter_axes_echo(client):
+    _post_event(
+        client,
+        event="paywall_cta_click",
+        feature="fleet",
+        harness="claude_code",
+        source="banner",
+        plan_chosen="cloud_pro",
+    )
+    body = client.get(
+        "/api/paywall/events/distinct"
+        "?event=paywall_cta_click"
+        "&feature=fleet"
+        "&harness=claude_code"
+        "&source=banner"
+        "&plan_chosen=cloud_pro",
+    ).get_json()
+    assert body["filters"] == {
+        "event": "paywall_cta_click",
+        "feature": "fleet",
+        "harness": "claude_code",
+        "source": "banner",
+        "plan_chosen": "cloud_pro",
+    }
+    assert body["matched"] == 1
+
+
+def test_distinct_filter_no_match_yields_empty_lists(client):
+    _post_event(client, event="paywall_view", feature="fleet")
+    body = client.get(
+        "/api/paywall/events/distinct?event=not_a_real_event",
+    ).get_json()
+    assert body["distinct"] == _EMPTY_DISTINCT
+    assert body["matched"] == 0
+    assert body["in_window"] == 1
+
+
+# ── time-window semantics ──────────────────────────────────────────────────
+
+
+def test_distinct_time_window_echoes_resolved_bounds(client, clock):
+    _post_at(client, clock, 100.0, event="paywall_view", feature="a")
+    _post_at(client, clock, 200.0, event="paywall_view", feature="b")
+
+    body = client.get(
+        "/api/paywall/events/distinct?since=150&until=250",
+    ).get_json()
+    assert body["distinct"]["feature"] == ["b"]
+    assert body["time_window"] == {"since": 150.0, "until": 250.0}
+
+
+def test_distinct_since_is_inclusive_until_is_exclusive(client, clock):
+    _post_at(client, clock, 100.0, event="paywall_view", feature="a")
+    _post_at(client, clock, 101.0, event="paywall_view", feature="b")
+
+    body = client.get(
+        "/api/paywall/events/distinct?since=100",
+    ).get_json()
+    assert body["distinct"]["feature"] == ["a", "b"]
+    assert body["time_window"] == {"since": 100.0, "until": None}
+
+    body = client.get(
+        "/api/paywall/events/distinct?until=101",
+    ).get_json()
+    assert body["distinct"]["feature"] == ["a"]
+    assert body["time_window"] == {"since": None, "until": 101.0}
+
+
+def test_distinct_bad_bounds_collapse_to_unbounded(client, clock):
+    _post_at(client, clock, 100.0, event="paywall_view", feature="a")
+    _post_at(client, clock, 200.0, event="paywall_view", feature="b")
+
+    body = client.get(
+        "/api/paywall/events/distinct?since=junk&until=nan",
+    ).get_json()
+    assert body["distinct"]["feature"] == ["a", "b"]
+    assert body["time_window"] == {"since": None, "until": None}
+
+
+def test_distinct_empty_window_matches_nothing(client, clock):
+    _post_at(client, clock, 100.0, event="paywall_view", feature="f")
+    body = client.get(
+        "/api/paywall/events/distinct?since=200&until=200",
+    ).get_json()
+    assert body["distinct"] == _EMPTY_DISTINCT
+    assert body["matched"] == 0
+    assert body["in_window"] == 1
+    assert body["time_window"] == {"since": 200.0, "until": 200.0}
+
+
+def test_distinct_window_and_categorical_filter_combine(client, clock):
+    _post_at(client, clock, 100.0, event="paywall_view",      feature="fleet")
+    _post_at(client, clock, 200.0, event="paywall_cta_click", feature="fleet")
+    _post_at(client, clock, 300.0, event="paywall_cta_click", feature="anomaly")
+
+    body = client.get(
+        "/api/paywall/events/distinct"
+        "?event=paywall_cta_click&since=150&until=250",
+    ).get_json()
+    assert body["distinct"]["feature"] == ["fleet"]
+    assert body["matched"] == 1
+    assert body["filters"] == {"event": "paywall_cta_click"}
+    assert body["time_window"] == {"since": 150.0, "until": 250.0}
+
+
+# ── cross-endpoint agreement with /summary ─────────────────────────────────
+
+
+def test_distinct_agrees_with_summary_by_star_keys(client):
+    """For the same filter + window inputs the per-dimension distinct
+    list byte-equals the sorted keys of ``/summary``'s corresponding
+    ``by_*`` dict -- pinned so the two dashboard views cannot silently
+    drift."""
+    _post_event(client, event="paywall_view", feature="fleet", harness="claude_code")
+    _post_event(client, event="paywall_cta_click", feature="anomaly", harness="codex")
+    _post_event(client, event="paywall_view", feature="fleet", harness="claude_code")
+
+    distinct_body = client.get("/api/paywall/events/distinct").get_json()
+    summary_body = client.get("/api/paywall/events/summary").get_json()
+    for dim, by_key in (
+        ("event", "by_event"),
+        ("feature", "by_feature"),
+        ("harness", "by_harness"),
+        ("source", "by_source"),
+        ("plan_chosen", "by_plan_chosen"),
+    ):
+        assert distinct_body["distinct"][dim] == sorted(
+            summary_body[by_key].keys(),
+        ), dim
+
+
+def test_distinct_agrees_with_summary_matched(client, clock):
+    for ts, feature in ((100.0, "fleet"), (200.0, "fleet"),
+                        (300.0, "anomaly")):
+        _post_at(client, clock, ts, event="paywall_view", feature=feature)
+
+    query = "?event=paywall_view&since=150"
+    distinct = client.get(f"/api/paywall/events/distinct{query}").get_json()
+    summary = client.get(f"/api/paywall/events/summary{query}").get_json()
+    assert distinct["matched"] == summary["matched"]
+    assert distinct["time_window"] == summary["time_window"]
+    assert distinct["filters"] == summary["filters"]
+
+
+# ── never-5xx / grace ──────────────────────────────────────────────────────
+
+
+def test_distinct_never_5xxs_on_broken_store(client, monkeypatch):
+    from clawmetry import _paywall_events as pe
+
+    def _boom(**kwargs):
+        raise RuntimeError("simulated store outage")
+
+    monkeypatch.setattr(pe, "distinct_values", _boom)
+    resp = client.get("/api/paywall/events/distinct")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body == {
+        "distinct": _EMPTY_DISTINCT,
+        "in_window": 0,
+        "matched": 0,
+        "filters": {},
+        "time_window": {"since": None, "until": None},
+    }
+
+
+def test_distinct_ships_in_grace_no_entitlement_gate(client):
+    """No auth header, no license key, no tier check."""
+    resp = client.get("/api/paywall/events/distinct")
+    assert resp.status_code == 200
+    resp = client.get("/api/paywall/events/distinct?feature=fleet")
+    assert resp.status_code == 200
+
+
+def test_distinct_response_is_json(client):
+    resp = client.get("/api/paywall/events/distinct")
+    assert resp.headers["Content-Type"].startswith("application/json")


### PR DESCRIPTION
## Summary

- Adds `distinct_values()` to `clawmetry/_paywall_events.py` — returns the sorted set of distinct non-empty values per categorical dimension (`event` / `feature` / `harness` / `source` / `plan_chosen`) currently in the paywall-events ring, respecting the same filter + time-window contract as the sibling `summary` / `recent` / `count_matching` / `last_matching` / `first_matching` helpers.
- Adds `GET /api/paywall/events/distinct` in `routes/entitlement.py` — thin JSON wrapper so a UI populating filter dropdowns for `/api/paywall/events/{summary,recent}` never lists dead options. Filters narrow the ring **before** the distinct set is computed, driving a "further narrow by:" dropdown UX (e.g. `?event=paywall_cta_click` returns only the features that actually co-occur with CTA clicks).
- Adds two new test files (39 tests): `tests/test_paywall_events_distinct.py` (store-level) and `tests/test_paywall_events_distinct_api.py` (HTTP), including cross-view parity pins that the per-dimension `distinct` lists byte-equal the sorted keys of `/summary`'s `by_*` dicts on identical filter + window inputs, so the two dashboard views cannot silently drift.

Ships in **GRACE**. Endpoint never 5xxs — any failure returns the neutral all-empty envelope so the dashboard dropdown keeps rendering.

Envelope shape:

```
{
  "distinct": {
    "event":       [<str>, ...],   # sorted ascending, non-empty only
    "feature":     [<str>, ...],
    "harness":     [<str>, ...],
    "source":      [<str>, ...],
    "plan_chosen": [<str>, ...],
  },
  "in_window":  <int>,   # ring size right now, unfiltered
  "matched":    <int>,   # rows the distinct set covers (post-filter, post-window)
  "filters":    {"<key>": "<value>", ...},
  "time_window": {"since": <float|null>, "until": <float|null>}
}
```

## Test plan

- [x] `python -m py_compile clawmetry/_paywall_events.py routes/entitlement.py tests/test_paywall_events_distinct*.py` — clean
- [x] `pytest tests/test_paywall_events_distinct.py tests/test_paywall_events_distinct_api.py` — **39 passed**
- [x] `pytest tests/test_paywall_event*.py` (all sibling paywall-event tests) — **270 passed**, no regressions
- [x] Verified `/api/paywall/events/distinct` is registered on `bp_entitlement` alongside the other five paywall-event endpoints

## Local operator verification checklist

Since this session can't reach your daemon or browser:

- [ ] Copy the changed files into `~/.clawmetry/lib/pythonX.Y/site-packages/clawmetry/` and `~/.clawmetry/lib/pythonX.Y/site-packages/routes/`
- [ ] Clear `__pycache__` under both dirs
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` (or your platform equivalent)
- [ ] `curl -sS http://localhost:8900/api/paywall/events/distinct | jq .` — expect the neutral envelope on a quiet ring, populated after a few `paywall_view` beacons
- [ ] Cross-check per-dimension parity: `curl -sS 'http://localhost:8900/api/paywall/events/distinct?event=paywall_view' | jq .distinct.feature` byte-equals `curl -sS 'http://localhost:8900/api/paywall/events/summary?event=paywall_view' | jq '.by_feature | keys | sort'`
- [ ] Decrypt the live cloud snapshot in the browser and confirm the dashboard's paywall-events tile can still bind `by_*` (unchanged) alongside the new `distinct` list

## Not touched

- `__version__` — no bump; no `[RELEASE]` PR opened per fire-time policy
- No gate enforcement change — endpoint is GRACE-mode read of a GRACE-mode write

---
_Generated by [Claude Code](https://claude.ai/code/session_011zV7JTc5Ldy5MsAHaP5cc9)_