### PR TITLE
feat(license): license_nodes + is_within_node_limit scalar helpers + endpoints

### DIFF
--- a/clawmetry/license.py
+++ b/clawmetry/license.py
@@ -1273,3 +1273,79 @@ def pro_installation_info() -> dict:
         "version": version,
         "marker": marker,
     }
+
+
+def license_nodes() -> int | None:
+    """Scalar view onto the installed license's ``nodes`` claim -- the paid
+    node-coverage count -- for a fleet/capacity tile that wants ONE integer
+    rather than the whole :func:`current_license_info` envelope.
+
+    Returns:
+      * ``None`` when there is nothing trustworthy to surface:
+        no license file on disk, an invalid signature (the payload can't
+        be trusted -- an attacker could stuff any ``nodes`` count into an
+        unsigned body), an expired license (a lapsed customer must not
+        keep rendering as "5 nodes covered"), OR a signed payload whose
+        ``nodes`` claim is absent / non-numeric / less than 1.
+      * A positive integer otherwise -- the covered node count.
+
+    Mirrors the "refuse expired keys" posture already used by
+    :func:`license_tier`, so a fleet capacity tile bound to this scalar
+    cannot keep rendering the paid coverage on a lapsed install. A caller
+    who wants the CLAIM even on an expired key (support: "how many nodes
+    was this key SUPPOSED to cover?") should keep reading
+    :func:`current_license_info` directly and pull ``nodes`` there.
+
+    Never raises. Any exception under the hood degrades to ``None`` so a
+    dashboard tile bound to this helper never breaks on a partial install.
+    """
+    try:
+        info = current_license_info()
+    except Exception as exc:
+        logger.debug("license: license_nodes underlying read failed: %s", exc)
+        return None
+    if not isinstance(info, dict):
+        return None
+    if not info.get("valid"):
+        # invalid-signature and expired branches both collapse to None on
+        # purpose -- see docstring for the fleet-tile rationale.
+        return None
+    nodes = info.get("nodes")
+    try:
+        n = int(nodes)
+    except (TypeError, ValueError):
+        return None
+    return n if n >= 1 else None
+
+
+def is_within_node_limit(nodes: int) -> bool:
+    """Boolean gate for "does connecting the Nth node fit under my license?"
+
+    Returns ``True`` iff a license is installed, signature-valid, NOT
+    expired, its ``nodes`` claim resolves to a positive integer, AND the
+    caller's ``nodes`` value is between 1 and that limit inclusive. Every
+    other state returns ``False``: no license, invalid signature, expired
+    key, missing/non-numeric ``nodes`` claim, ``nodes<=0``, or a live limit
+    that simply does not cover the caller's count.
+
+    ``nodes`` is coerced through ``int()``; non-numeric input, zero, or a
+    negative count collapses to ``False`` (a fleet of "connect -5 nodes"
+    never fits any coverage). Never raises; every underlying failure
+    returns ``False`` so a scheduled fleet-capacity check never crashes
+    on a bad install.
+
+    Pairs with :func:`license_nodes` the way :func:`is_expiring_within`
+    pairs with :func:`days_until_expiry` -- the scalar reports the raw
+    number for tiles, this bool answers the yes/no question a gate needs
+    without the caller having to compare against the limit themselves.
+    """
+    try:
+        requested = int(nodes)
+    except (TypeError, ValueError):
+        return False
+    if requested < 1:
+        return False
+    limit = license_nodes()
+    if limit is None:
+        return False
+    return requested <= limit

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -8497,6 +8497,152 @@ def api_license_pro_installation():
         return jsonify({"installed": False, "version": None, "marker": {}})
 
 
+def _license_nodes_snapshot() -> dict:
+    """Shared helper: read once, derive the trio the two node-limit endpoints
+    both need (``nodes``, ``has_license``, ``valid``). Lives in the handler
+    layer -- not in :mod:`clawmetry.license` -- because ``has_license`` is
+    an install-state fact rather than a license-payload fact, and both
+    endpoints below need the pair together so a UI cannot catch them
+    disagreeing on ``has_license`` for the same install.
+
+    Never raises: any underlying failure collapses to
+    ``{nodes: None, has_license: False, valid: False}`` so callers keep the
+    "OSS-free" branch shape.
+    """
+    try:
+        from clawmetry import license as _lic
+
+        info = _lic.current_license_info()
+        nodes = _lic.license_nodes()
+    except Exception as exc:
+        logger.debug("_license_nodes_snapshot: underlying read failed: %s", exc)
+        return {"nodes": None, "has_license": False, "valid": False}
+    if not isinstance(info, dict):
+        return {"nodes": None, "has_license": False, "valid": False}
+    return {
+        "nodes": nodes,
+        "has_license": True,
+        "valid": bool(info.get("valid")),
+    }
+
+
+@bp_entitlement.route("/api/license/nodes")
+def api_license_nodes():
+    """``GET /api/license/nodes`` -- scalar view of the installed license's
+    node-coverage count, for a fleet-capacity tile that wants ONE integer
+    rather than the whole ``/api/license/status`` envelope.
+
+    Response shape (always HTTP 200)::
+
+        {
+          "nodes": <int|null>,       # covered node count (None if untrusted)
+          "has_license": <bool>,     # is a license file installed at all?
+          "valid": <bool>            # signature-valid AND not expired
+        }
+
+    ``nodes`` mirrors :func:`clawmetry.license.license_nodes`: ``None`` for
+    no license, invalid signature, or expired install -- an expired Pro key
+    deliberately collapses to ``null`` so a fleet-capacity tile that keys
+    off this field cannot keep rendering the paid coverage on a lapsed
+    customer. A caller who wants the raw ``nodes`` claim even on an expired
+    key (support: "how many nodes was this SUPPOSED to cover?") should keep
+    hitting ``/api/license/status``.
+
+    Never 5xxs -- any underlying failure degrades to
+    ``{nodes: null, has_license: false, valid: false}`` (the OSS-free
+    branch shape), matching the "never crash on bad input" posture of the
+    surrounding license endpoints.
+    """
+    try:
+        return jsonify(_license_nodes_snapshot())
+    except Exception as exc:
+        logger.warning("api_license_nodes: error: %s", exc)
+        return jsonify({"nodes": None, "has_license": False, "valid": False})
+
+
+@bp_entitlement.route("/api/license/within-node-limit")
+def api_license_within_node_limit():
+    """``GET /api/license/within-node-limit?nodes=<N>`` -- boolean gate for
+    "does a fleet of N nodes fit under the installed license?" UIs.
+
+    Query parameters:
+      * ``nodes`` (int, required) -- the fleet size to test against.
+        Non-numeric or missing input degrades to ``within_limit=false``
+        rather than a 4xx, matching the surrounding endpoints' never-5xx /
+        never-4xx posture. Values below 1 also collapse to ``false`` (a
+        fleet of "connect zero nodes" is meaningless).
+
+    Response shape (always HTTP 200)::
+
+        {
+          "within_limit": <bool>,
+          "nodes": <int|null>,           # currently-covered node count
+          "requested_nodes": <int>,      # normalised echo of the query
+          "has_license": <bool>,
+          "valid": <bool>                # signature-valid AND not expired
+        }
+
+    ``within_limit`` is ``True`` iff a license is installed, signature-
+    valid, NOT expired, its ``nodes`` claim resolves to a positive
+    integer, AND ``requested_nodes`` is between 1 and that limit
+    inclusive. An expired Pro install returns ``within_limit=false`` on
+    purpose -- the caller wants "am I entitled right now" not "was I ever
+    entitled", and the ``valid`` field carries the "signed but lapsed"
+    signal so a paywall UI can drive both banners off one URL.
+
+    Mirrors :func:`clawmetry.license.is_within_node_limit` -- the HTTP
+    shape layers ``nodes`` / ``requested_nodes`` / ``has_license`` /
+    ``valid`` on top of that bool so a fleet widget never needs a second
+    call to ``/api/license/status`` to render the accompanying "N of M
+    nodes covered" copy.
+    """
+    raw = request.args.get("nodes", "")
+    try:
+        requested = int(raw)
+    except (TypeError, ValueError):
+        snap = _license_nodes_snapshot()
+        return jsonify(
+            {
+                "within_limit": False,
+                "nodes": snap["nodes"],
+                "requested_nodes": 0,
+                "has_license": snap["has_license"],
+                "valid": snap["valid"],
+            }
+        )
+    if requested < 1:
+        snap = _license_nodes_snapshot()
+        return jsonify(
+            {
+                "within_limit": False,
+                "nodes": snap["nodes"],
+                "requested_nodes": max(requested, 0),
+                "has_license": snap["has_license"],
+                "valid": snap["valid"],
+            }
+        )
+    try:
+        snap = _license_nodes_snapshot()
+    except Exception as exc:
+        logger.warning("api_license_within_node_limit: error: %s", exc)
+        snap = {"nodes": None, "has_license": False, "valid": False}
+    limit = snap["nodes"]
+    within = (
+        snap["has_license"]
+        and snap["valid"]
+        and isinstance(limit, int)
+        and 1 <= requested <= limit
+    )
+    return jsonify(
+        {
+            "within_limit": bool(within),
+            "nodes": limit,
+            "requested_nodes": requested,
+            "has_license": snap["has_license"],
+            "valid": snap["valid"],
+        }
+    )
+
 @bp_entitlement.route("/api/paywall/event", methods=["POST"])
 def api_paywall_event():
     body: dict = {}

--- a/tests/test_license_nodes_scalar.py
+++ b/tests/test_license_nodes_scalar.py
@@ -1,0 +1,277 @@
+"""Tests for the ``license_nodes()`` / ``is_within_node_limit()`` scalar
+helpers in :mod:`clawmetry.license` plus their matching
+``/api/license/nodes`` and ``/api/license/within-node-limit`` HTTP endpoints.
+
+Mirrors ``tests/test_license_api.py``'s hermetic pattern -- ephemeral
+Ed25519 keypair, ``LICENSE_PATH`` monkeypatched into ``tmp_path``, and
+``CLAWMETRY_OFFLINE=1`` so ``activate()`` never phones home during the
+suite. Nothing here touches the operator's real license file.
+"""
+from __future__ import annotations
+
+import time
+from types import SimpleNamespace
+
+import pytest
+from flask import Flask
+
+
+def _keypair():
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+    priv = Ed25519PrivateKey.generate()
+    pub_pem = priv.public_key().public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    return priv, pub_pem
+
+
+def _payload(tier="pro", nodes=3, exp_delta=365 * 86400):
+    now = int(time.time())
+    return {
+        "sub": "acct_test",
+        "tier": tier,
+        "nodes": nodes,
+        "iat": now,
+        "exp": now + exp_delta,
+        "features": ["runtimes"],
+    }
+
+
+@pytest.fixture
+def env(monkeypatch, tmp_path):
+    import clawmetry.license as _lic
+
+    priv, pub_pem = _keypair()
+    monkeypatch.setattr(_lic, "_PUBLIC_KEY_PEM", pub_pem)
+    license_path = str(tmp_path / "license.key")
+    monkeypatch.setattr(_lic, "LICENSE_PATH", license_path)
+    monkeypatch.delenv("CLAWMETRY_LICENSE_SERVER", raising=False)
+    monkeypatch.delenv("CLAWMETRY_INGEST_URL", raising=False)
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("CLAWMETRY_OFFLINE", "1")
+
+    from routes.entitlement import bp_entitlement
+
+    flask_app = Flask(__name__)
+    flask_app.register_blueprint(bp_entitlement)
+    flask_app.config["TESTING"] = True
+
+    return SimpleNamespace(
+        app=flask_app, lic=_lic, priv=priv, license_path=license_path
+    )
+
+
+# ── license_nodes() ───────────────────────────────────────────────────────────
+
+
+def test_license_nodes_none_when_no_license(env):
+    assert env.lic.license_nodes() is None
+
+
+def test_license_nodes_active_returns_int(env):
+    tok = env.lic._encode_token(_payload(nodes=7), env.priv)
+    env.lic.activate(tok)
+    assert env.lic.license_nodes() == 7
+
+
+def test_license_nodes_expired_collapses_to_none(env):
+    # A lapsed customer must NOT keep rendering as "N nodes covered" via the
+    # scalar helper -- matches the license_tier() posture for expired keys.
+    tok = env.lic._encode_token(_payload(nodes=5, exp_delta=-3600), env.priv)
+    env.lic.activate(tok)
+    # activate refuses expired keys, so we write the file directly to
+    # simulate the "expired since activation" state.
+    with open(env.license_path, "w", encoding="utf-8") as fh:
+        fh.write(tok + "\n")
+    assert env.lic.license_nodes() is None
+
+
+def test_license_nodes_invalid_signature_collapses_to_none(env, monkeypatch):
+    """An unsigned / forged file must NOT surface a trusted node count."""
+    # A signature-invalid file: write a token minted with a DIFFERENT keypair
+    # than the one _PUBLIC_KEY_PEM was patched to.
+    other_priv, _ = _keypair()
+    tok = env.lic._encode_token(_payload(nodes=99), other_priv)
+    with open(env.license_path, "w", encoding="utf-8") as fh:
+        fh.write(tok + "\n")
+    assert env.lic.license_nodes() is None
+
+
+def test_license_nodes_nonpositive_claim_collapses(env):
+    """A signed but nonsensical ``nodes=0`` claim collapses to None (a covered
+    fleet of zero is meaningless — refuse it rather than surface it)."""
+    tok = env.lic._encode_token(_payload(nodes=0), env.priv)
+    env.lic.activate(tok)
+    assert env.lic.license_nodes() is None
+
+
+# ── is_within_node_limit(n) ───────────────────────────────────────────────────
+
+
+def test_is_within_node_limit_false_when_no_license(env):
+    assert env.lic.is_within_node_limit(1) is False
+    assert env.lic.is_within_node_limit(100) is False
+
+
+def test_is_within_node_limit_true_at_and_below_limit(env):
+    tok = env.lic._encode_token(_payload(nodes=5), env.priv)
+    env.lic.activate(tok)
+    assert env.lic.is_within_node_limit(1) is True
+    assert env.lic.is_within_node_limit(5) is True
+
+
+def test_is_within_node_limit_false_above_limit(env):
+    tok = env.lic._encode_token(_payload(nodes=3), env.priv)
+    env.lic.activate(tok)
+    assert env.lic.is_within_node_limit(4) is False
+
+
+def test_is_within_node_limit_rejects_zero_and_negative(env):
+    tok = env.lic._encode_token(_payload(nodes=5), env.priv)
+    env.lic.activate(tok)
+    assert env.lic.is_within_node_limit(0) is False
+    assert env.lic.is_within_node_limit(-1) is False
+
+
+def test_is_within_node_limit_rejects_non_int(env):
+    tok = env.lic._encode_token(_payload(nodes=5), env.priv)
+    env.lic.activate(tok)
+    assert env.lic.is_within_node_limit("garbage") is False  # type: ignore[arg-type]
+    assert env.lic.is_within_node_limit(None) is False  # type: ignore[arg-type]
+
+
+def test_is_within_node_limit_expired_key_returns_false(env):
+    tok = env.lic._encode_token(_payload(nodes=5, exp_delta=-3600), env.priv)
+    with open(env.license_path, "w", encoding="utf-8") as fh:
+        fh.write(tok + "\n")
+    # Even at nodes=1, an expired license refuses the gate.
+    assert env.lic.is_within_node_limit(1) is False
+
+
+# ── /api/license/nodes ────────────────────────────────────────────────────────
+
+
+def test_api_license_nodes_no_license(env):
+    with env.app.test_client() as c:
+        resp = c.get("/api/license/nodes")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body == {"nodes": None, "has_license": False, "valid": False}
+
+
+def test_api_license_nodes_active(env):
+    tok = env.lic._encode_token(_payload(nodes=8), env.priv)
+    env.lic.activate(tok)
+    with env.app.test_client() as c:
+        resp = c.get("/api/license/nodes")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body == {"nodes": 8, "has_license": True, "valid": True}
+
+
+def test_api_license_nodes_expired(env):
+    tok = env.lic._encode_token(_payload(nodes=8, exp_delta=-3600), env.priv)
+    with open(env.license_path, "w", encoding="utf-8") as fh:
+        fh.write(tok + "\n")
+    with env.app.test_client() as c:
+        resp = c.get("/api/license/nodes")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    # nodes collapses to null on the expired branch, but has_license stays
+    # True — the file IS on disk, just no longer trusted for gating.
+    assert body["nodes"] is None
+    assert body["has_license"] is True
+    assert body["valid"] is False
+
+
+# ── /api/license/within-node-limit ────────────────────────────────────────────
+
+
+def test_api_within_no_license(env):
+    with env.app.test_client() as c:
+        resp = c.get("/api/license/within-node-limit?nodes=1")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["within_limit"] is False
+    assert body["has_license"] is False
+    assert body["valid"] is False
+    assert body["requested_nodes"] == 1
+
+
+def test_api_within_at_limit(env):
+    tok = env.lic._encode_token(_payload(nodes=5), env.priv)
+    env.lic.activate(tok)
+    with env.app.test_client() as c:
+        resp = c.get("/api/license/within-node-limit?nodes=5")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["within_limit"] is True
+    assert body["nodes"] == 5
+    assert body["requested_nodes"] == 5
+    assert body["has_license"] is True
+    assert body["valid"] is True
+
+
+def test_api_within_above_limit(env):
+    tok = env.lic._encode_token(_payload(nodes=3), env.priv)
+    env.lic.activate(tok)
+    with env.app.test_client() as c:
+        resp = c.get("/api/license/within-node-limit?nodes=4")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["within_limit"] is False
+    assert body["nodes"] == 3
+    assert body["requested_nodes"] == 4
+    assert body["valid"] is True
+
+
+def test_api_within_bad_query_is_200_with_false(env):
+    tok = env.lic._encode_token(_payload(nodes=3), env.priv)
+    env.lic.activate(tok)
+    with env.app.test_client() as c:
+        resp = c.get("/api/license/within-node-limit?nodes=garbage")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["within_limit"] is False
+    assert body["nodes"] == 3
+    assert body["requested_nodes"] == 0
+
+
+def test_api_within_missing_query_is_200_with_false(env):
+    tok = env.lic._encode_token(_payload(nodes=3), env.priv)
+    env.lic.activate(tok)
+    with env.app.test_client() as c:
+        resp = c.get("/api/license/within-node-limit")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["within_limit"] is False
+    assert body["requested_nodes"] == 0
+
+
+def test_api_within_zero_and_negative(env):
+    tok = env.lic._encode_token(_payload(nodes=5), env.priv)
+    env.lic.activate(tok)
+    with env.app.test_client() as c:
+        r0 = c.get("/api/license/within-node-limit?nodes=0")
+        rn = c.get("/api/license/within-node-limit?nodes=-3")
+    for r, requested in ((r0, 0), (rn, 0)):
+        assert r.status_code == 200
+        body = r.get_json()
+        assert body["within_limit"] is False
+        assert body["requested_nodes"] == requested
+
+
+def test_api_within_expired_returns_false(env):
+    tok = env.lic._encode_token(_payload(nodes=5, exp_delta=-3600), env.priv)
+    with open(env.license_path, "w", encoding="utf-8") as fh:
+        fh.write(tok + "\n")
+    with env.app.test_client() as c:
+        resp = c.get("/api/license/within-node-limit?nodes=1")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["within_limit"] is False
+    assert body["has_license"] is True
+    assert body["valid"] is False


### PR DESCRIPTION
## Summary

Adds two scalar license helpers in `clawmetry/license.py` plus matching endpoints in `routes/entitlement.py`, following the same pattern already used for `license_tier` / `is_tier` and `days_until_expiry` / `is_expiring_within`:

- **`license_nodes() -> int | None`** — raw covered-node count from the installed license's payload. Refused (returns `None`) on the no-license / invalid-signature / expired branches so a fleet-capacity tile never renders paid coverage for a lapsed customer.
- **`is_within_node_limit(nodes: int) -> bool`** — yes/no gate for "does a fleet of N nodes fit under the installed license?". Pairs with `license_nodes()` the way `is_expiring_within()` pairs with `days_until_expiry()`.

### HTTP surface

- `GET /api/license/nodes` → `{nodes, has_license, valid}`
- `GET /api/license/within-node-limit?nodes=N` → `{within_limit, nodes, requested_nodes, has_license, valid}`

Both endpoints never 5xx — on any underlying failure they degrade to the OSS-free branch shape (`nodes=None`, `has_license=false`, `within_limit=false`), matching the never-crash posture of the surrounding license routes.

### Grace mode

Ships in **GRACE** — no enforcement, no behaviour change. Purely observational scalars a paywall / fleet-capacity tile can bind to without pulling the whole `/api/license/status` envelope.

### Tests

21 new unit + endpoint tests in `tests/test_license_nodes_scalar.py` cover:

- No-license, active, expired, invalid-signature, `nodes<=0` branches on `license_nodes()`
- Above / below / at-limit, zero / negative, non-int input branches on `is_within_node_limit()`
- OSS-free / active / expired shapes on `/api/license/nodes`
- Bad-query, missing-query, zero/negative, above/below-limit, expired branches on `/api/license/within-node-limit`

All hermetic — ephemeral Ed25519 keypair + `tmp_path` license file + `CLAWMETRY_OFFLINE=1`; no network, no operator-state mutation. Existing `tests/test_license*.py` (77 tests) still pass.

## Files changed

- `clawmetry/license.py` — +76 lines (two new helpers appended after `current_license_info()`)
- `routes/entitlement.py` — +147 lines (shared `_license_nodes_snapshot()` helper + two new route handlers inserted after `/api/license/pubkey`, grouped with the other `/api/license/*` endpoints)
- `tests/test_license_nodes_scalar.py` — +277 lines (new file)

## Local operator verification checklist

Because the autonomous fire can't touch the running daemon or the live cloud snapshot:

- [ ] Rebuild wheel or copy the changed files into `~/.clawmetry/lib/pythonX.Y/site-packages/clawmetry/` and `.../site-packages/routes/`.
- [ ] Clear `__pycache__` under both directories (`find ~/.clawmetry/lib -name __pycache__ -exec rm -rf {} +`).
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` (macOS) or the equivalent systemd `--user` restart.
- [ ] Confirm `GET /api/license/nodes` returns `{"nodes": null, "has_license": false, "valid": false}` on a Free install.
- [ ] Confirm `GET /api/license/within-node-limit?nodes=1` returns `{"within_limit": false, ...}` on a Free install.
- [ ] After `clawmetry activate <PRO_KEY>` (nodes=N), confirm both endpoints reflect the new claim (`nodes=N`, `within_limit=true` for `?nodes<=N`, `false` for `?nodes>N`).
- [ ] Decrypt the live cloud snapshot and confirm the endpoints work through the cloud relay too.
- [ ] Browser-check any paywall/fleet-capacity tiles bound to these URLs (dashboard hits `/api/license/status` today; the new scalars are opt-in).

## Notes

- No `__version__` bump, no tag, no `[RELEASE]` PR — the operator drives the release loop.
- No enforcement gate changes; both endpoints are read-only observational scalars.
- No new dependencies — uses `cryptography` (already required) and `flask` (already required).

---
_Generated by [Claude Code](https://claude.ai/code/session_018FUGuBru3HSHLBhcdKzpw4)_