### PR TITLE
fix(e2e): apply-required-checks notify step posts to wrong issue (#4029 should be #3970)

### DIFF
--- a/.github/workflows/apply-required-checks.yml
+++ b/.github/workflows/apply-required-checks.yml
@@ -18,7 +18,7 @@ name: Apply required E2E status checks (C6 -- one-shot)
 #     With only GITHUB_TOKEN (ghs_): read-only verify path in the script
 #     (exits 0 if C6 configured, exits 1 if not -- no admin rights needed).
 #     With E2E_ADMIN_PAT: full apply + verify.
-#     On failure, posts a notification comment on tracking issue #4029.
+#     On failure, posts a notification comment on tracking issue #3970.
 #
 # TOKEN PATHS (priority order):
 #   1. inputs.pat_token  -- PAT typed into the Run workflow dialog
@@ -37,7 +37,7 @@ name: Apply required E2E status checks (C6 -- one-shot)
 #   clawmetry-landing.
 #
 # Idempotent: running multiple times is safe.
-# Tracking: vivekchand/clawmetry#4029
+# Tracking: vivekchand/clawmetry#3970
 
 on:
   workflow_dispatch:
@@ -119,7 +119,7 @@ jobs:
         run: python3 scripts/apply_required_status_checks.py
 
       # When the C6 read-only verify exits 1 (checks not yet configured on main),
-      # post or update a comment on the E2E Robustness tracking issue #4029 so the
+      # post or update a comment on the E2E Robustness tracking issue #3970 so the
       # repo admin receives a GitHub notification.
       #
       # Only fires on push-to-main (the automated verify path), NOT on manual
@@ -161,15 +161,15 @@ jobs:
 
           # Upsert: update existing comment if present, otherwise create new.
           existing_id=$(gh api -X GET \
-            "repos/${REPO}/issues/4029/comments" \
+            "repos/${REPO}/issues/3970/comments" \
             --jq 'map(select(.body | startswith("<!-- c6-notify-bot -->"))) | .[0].id // empty' \
             2>/dev/null || echo "")
           if [ -n "${existing_id}" ]; then
             gh api -X PATCH "repos/${REPO}/issues/comments/${existing_id}" \
               -f body="${BODY}" > /dev/null
-            echo "Updated existing C6 notification on #4029 (comment ${existing_id})"
+            echo "Updated existing C6 notification on #3970 (comment ${existing_id})"
           else
-            gh api -X POST "repos/${REPO}/issues/4029/comments" \
+            gh api -X POST "repos/${REPO}/issues/3970/comments" \
               -f body="${BODY}" > /dev/null
-            echo "Posted new C6 notification on #4029"
+            echo "Posted new C6 notification on #3970"
           fi


### PR DESCRIPTION
## Summary

The "Notify tracking issue when C6 checks are missing" step in `apply-required-checks.yml` was posting C6 failure comments to `#4029` instead of the canonical E2E Robustness epic `#3970`.

PR #4042 (merged 2026-07-26) fixed 8 other files from `#4036` to `#3970` but missed the four `#4029` references inside the functional `gh api` calls and echo lines in this file, so every push-to-main C6 failure notification has been routing to a ghost issue since the workflow was written.

## What changed

`apply-required-checks.yml` notify step:

| Before | After |
|---|---|
| `issues/4029/comments` (GET) | `issues/3970/comments` |
| `issues/4029/comments` (POST) | `issues/3970/comments` |
| `echo "... on #4029"` (x2) | `echo "... on #3970"` |
| `# Tracking: ...#4029` | `# Tracking: ...#3970` |

No logic changes. Idempotency preserved.

## Acceptance test

After merge, trigger a push to main and confirm any C6 failure notification appears on issue #3970 (not #4029).

Tracking: #3970 (C6 sole remaining gap)

---
_Generated by [Claude Code](https://claude.ai/code/session_0188MFUECEPdqDVAEAVSipKd)_