### PR TITLE
feat(license): has_license + is_license_valid install-state scalars + endpoints

### DIFF
--- a/clawmetry/license.py
+++ b/clawmetry/license.py
@@ -1275,6 +1275,7 @@ def pro_installation_info() -> dict:
     }
 
 
+
 def license_nodes() -> int | None:
     """Scalar view onto the installed license's ``nodes`` claim -- the paid
     node-coverage count -- for a fleet/capacity tile that wants ONE integer
@@ -1349,3 +1350,72 @@ def is_within_node_limit(nodes: int) -> bool:
     if limit is None:
         return False
     return requested <= limit
+
+
+def has_license() -> bool:
+    """True iff a license file exists on disk at :data:`LICENSE_PATH`.
+
+    The bare install-state gate: answers "does this operator have ANY
+    license file at all?" without caring whether the signature verifies,
+    whether the ``exp`` claim is in the past, or whether the payload
+    tier/nodes are anything reasonable. A dashboard that wants to render
+    a subtly-different empty state for "Free (never activated)" vs
+    "Free (license expired / broken)" binds to this scalar; a paywall
+    tile that only cares about entitlement should use
+    :func:`is_license_valid` instead.
+
+    Complements :func:`license_tier` / :func:`is_tier`, which both
+    collapse to ``None`` / ``False`` on the invalid-signature and
+    expired branches -- callers wanting to distinguish "has a broken
+    file" from "has nothing" need this presence gate as a separate
+    signal.
+
+    Never raises. Any underlying filesystem failure (perms, race with
+    a concurrent ``deactivate``) collapses to ``False`` so a paywall
+    renderer bound to this scalar never crashes on a partial install.
+    """
+    try:
+        return os.path.isfile(LICENSE_PATH)
+    except Exception as exc:
+        logger.debug("license: has_license failed: %s", exc)
+        return False
+
+
+def is_license_valid() -> bool:
+    """True iff a license is installed, signature-valid, AND not expired.
+
+    The single boolean gate every paywall tile actually wants: "is this
+    node entitled right now?". Pairs with :func:`has_license` -- the
+    presence gate answers "does a file exist?", this one answers "is
+    the file trustworthy AND live?". A UI wanting to distinguish "no
+    license" from "broken license" from "lapsed license" from "live
+    license" reads both scalars together (plus :func:`is_expired` /
+    :func:`current_license_info().status` for the specific broken /
+    lapsed reason).
+
+    Returns ``False`` on every one of:
+
+    * No license file on disk (:func:`has_license` is ``False``).
+    * File exists but signature does not verify (an attacker could
+      stuff any tier/nodes/exp into an unsigned body, so we treat the
+      whole install as untrusted).
+    * File exists, signature verifies, but ``exp`` is in the past.
+
+    Returns ``True`` iff the ``current_license_info().valid`` flag is
+    truthy for the installed file -- which is the same source of truth
+    :func:`license_tier` / :func:`is_tier` / :func:`license_nodes`
+    already use to gate their entitlement scalars, so a UI binding all
+    four sees a consistent snapshot.
+
+    Never raises. Any underlying introspection failure collapses to
+    ``False`` so a scheduled paywall renderer never crashes on a bad
+    install.
+    """
+    try:
+        info = current_license_info()
+    except Exception as exc:
+        logger.warning("license: is_license_valid failed: %s", exc)
+        return False
+    if not isinstance(info, dict):
+        return False
+    return bool(info.get("valid"))

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -8643,6 +8643,123 @@ def api_license_within_node_limit():
         }
     )
 
+
+def _license_presence_snapshot() -> dict:
+    """Shared one-shot read for the two install-state gate endpoints below.
+
+    Reads :func:`clawmetry.license.has_license` and
+    :func:`clawmetry.license.current_license_info` together so the paired
+    ``/api/license/present`` and ``/api/license/valid`` endpoints can't
+    disagree on ``present`` / ``status`` for the same install -- a UI that
+    binds both in the same tile always sees a consistent snapshot.
+
+    Returned dict::
+
+        {
+          "present": <bool>,              # is a license file on disk at all?
+          "valid": <bool>,                # signature-valid AND not expired
+          "status": <str|null>,           # "active"/"expired"/"invalid"/None
+        }
+
+    Never raises. Any introspection failure (import error, corrupt install,
+    cryptography-lib mismatch) collapses to
+    ``{present: False, valid: False, status: None}`` so the endpoint stack
+    never 5xxs, matching the OSS-free posture of the surrounding license
+    endpoints.
+    """
+    try:
+        from clawmetry import license as _lic
+
+        present = bool(_lic.has_license())
+        info = _lic.current_license_info() if present else None
+    except Exception as exc:
+        logger.debug("_license_presence_snapshot: error: %s", exc)
+        return {"present": False, "valid": False, "status": None}
+    status = info.get("status") if isinstance(info, dict) else None
+    valid = bool(isinstance(info, dict) and info.get("valid"))
+    return {
+        "present": present,
+        "valid": valid,
+        "status": status,
+    }
+
+
+@bp_entitlement.route("/api/license/present")
+def api_license_present():
+    """``GET /api/license/present`` -- bare install-state gate for
+    "does this operator have ANY license file at all?".
+
+    Response shape (always HTTP 200)::
+
+        {
+          "present": <bool>,       # is a license file on disk at LICENSE_PATH?
+          "valid": <bool>,          # signature-valid AND not expired
+          "status": <str|null>     # "active"/"expired"/"invalid"/None
+        }
+
+    ``present`` mirrors :func:`clawmetry.license.has_license`: ``True`` iff
+    a file exists at :data:`~clawmetry.license.LICENSE_PATH`, regardless of
+    whether it verifies or whether ``exp`` is in the past. That's the
+    signal a dashboard uses to render a subtly-different empty state for
+    "Free (never activated)" vs "Free (license expired / broken)" -- an
+    entitlement gate wanting "is this node currently entitled?" should
+    bind ``/api/license/valid`` instead.
+
+    ``valid`` / ``status`` are surfaced alongside so a UI can drive the
+    "you have a file but it's not trustworthy" banner off the same
+    request without a second call to ``/api/license/status``.
+
+    Never 5xxs -- any underlying failure degrades to
+    ``{present: false, valid: false, status: null}`` (the OSS-free branch
+    shape), matching the "never crash on bad input" posture of the
+    surrounding license endpoints.
+    """
+    try:
+        return jsonify(_license_presence_snapshot())
+    except Exception as exc:
+        logger.warning("api_license_present: error: %s", exc)
+        return jsonify({"present": False, "valid": False, "status": None})
+
+
+@bp_entitlement.route("/api/license/valid")
+def api_license_valid():
+    """``GET /api/license/valid`` -- top-level entitlement gate for
+    "is this node currently entitled?".
+
+    Response shape (always HTTP 200)::
+
+        {
+          "valid": <bool>,          # signature-valid AND not expired
+          "present": <bool>,       # is a license file on disk at all?
+          "status": <str|null>     # "active"/"expired"/"invalid"/None
+        }
+
+    ``valid`` mirrors :func:`clawmetry.license.is_license_valid`: ``True``
+    iff a license is installed, its signature verifies, and its ``exp``
+    claim is not in the past. Every "not entitled" reason -- no file,
+    forged signature, lapsed key -- collapses to ``valid=False`` so a
+    paywall tile can bind directly to this scalar without threading the
+    full ``/api/license/status`` envelope through.
+
+    ``present`` and ``status`` are surfaced alongside so a UI can render
+    the accompanying "you have a broken file" or "your key expired" copy
+    from the same request. An expired install returns
+    ``{valid: false, present: true, status: "expired"}``; an invalid
+    signature returns ``{valid: false, present: true, status: "invalid"}``;
+    an OSS-free node returns ``{valid: false, present: false, status: null}``.
+
+    Never 5xxs -- any underlying failure degrades to
+    ``{valid: false, present: false, status: null}`` (the OSS-free branch
+    shape), matching the "never crash on bad input" posture of the
+    surrounding license endpoints.
+    """
+    try:
+        return jsonify(_license_presence_snapshot())
+    except Exception as exc:
+        logger.warning("api_license_valid: error: %s", exc)
+        return jsonify({"valid": False, "present": False, "status": None})
+
+
 @bp_entitlement.route("/api/paywall/event", methods=["POST"])
 def api_paywall_event():
     body: dict = {}

--- a/tests/test_license_presence_scalar.py
+++ b/tests/test_license_presence_scalar.py
@@ -1,0 +1,457 @@
+"""Tests for the ``has_license`` / ``is_license_valid`` install-state scalar
+helpers on ``clawmetry.license`` and their paired
+``/api/license/{present,valid}`` endpoints on ``routes.entitlement``.
+
+These two scalars are the top-level install-state gates a paywall UI needs:
+
+* ``has_license`` -- bare file-exists check, regardless of signature /
+  expiry. Answers "does this operator have ANY license file at all?", the
+  signal a dashboard uses to distinguish "Free (never activated)" from
+  "Free (license expired or broken)".
+* ``is_license_valid`` -- installed AND signature-valid AND not expired.
+  The single boolean a paywall tile actually wants: "is this node
+  entitled right now?".
+
+Both are OSS-safe observational scalars. Ships in GRACE -- no enforcement
+gate changes, no behaviour shift.
+
+Uses an ephemeral Ed25519 keypair (never the production key) and a
+tmp_path license file so no real filesystem state is touched.
+"""
+from __future__ import annotations
+
+import time
+from types import SimpleNamespace
+
+import pytest
+from flask import Flask
+
+
+# -- shared helpers (mirrors test_license_is_expired_is_perpetual.py) --
+
+
+def _keypair():
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+    priv = Ed25519PrivateKey.generate()
+    pub_pem = priv.public_key().public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    return priv, pub_pem
+
+
+def _payload(tier="pro", nodes=3, exp_delta=365 * 86400, perpetual=False):
+    now = int(time.time())
+    body = {
+        "sub": "acct_test",
+        "tier": tier,
+        "nodes": nodes,
+        "iat": now,
+        "features": ["runtimes"],
+    }
+    if not perpetual:
+        body["exp"] = now + exp_delta
+    return body
+
+
+# -- fixtures --
+
+
+@pytest.fixture
+def env(monkeypatch, tmp_path):
+    """Isolated license env: ephemeral pubkey, tmp license path, no network."""
+    import clawmetry.license as _lic
+
+    priv, pub_pem = _keypair()
+    monkeypatch.setattr(_lic, "_PUBLIC_KEY_PEM", pub_pem)
+    license_path = str(tmp_path / "license.key")
+    monkeypatch.setattr(_lic, "LICENSE_PATH", license_path)
+    monkeypatch.delenv("CLAWMETRY_LICENSE_SERVER", raising=False)
+    monkeypatch.delenv("CLAWMETRY_INGEST_URL", raising=False)
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("CLAWMETRY_OFFLINE", "1")
+
+    from routes.entitlement import bp_entitlement
+
+    flask_app = Flask(__name__)
+    flask_app.register_blueprint(bp_entitlement)
+    flask_app.config["TESTING"] = True
+
+    return SimpleNamespace(
+        app=flask_app,
+        lic=_lic,
+        priv=priv,
+        license_path=license_path,
+    )
+
+
+def _install(env, payload):
+    """Write a signed token to the license path (bypasses ``activate``'s
+    phone-home)."""
+    tok = env.lic._encode_token(payload, env.priv)
+    env.lic._secure_write(env.license_path, tok)
+
+
+def _install_raw(env, raw: str):
+    """Write raw (possibly-forged) contents to the license path."""
+    env.lic._secure_write(env.license_path, raw)
+
+
+# -- module-level scalar: has_license --
+
+
+def test_has_license_no_license(env):
+    """Bare install: no file on disk -> has_license is False."""
+    assert env.lic.has_license() is False
+
+
+def test_has_license_active(env):
+    _install(env, _payload(exp_delta=365 * 86400))
+    assert env.lic.has_license() is True
+
+
+def test_has_license_expired(env):
+    """Expired keys still count as PRESENT -- the presence gate cares only
+    about file existence, not entitlement."""
+    _install(env, _payload(exp_delta=-3600))
+    assert env.lic.has_license() is True
+
+
+def test_has_license_perpetual(env):
+    _install(env, _payload(perpetual=True))
+    assert env.lic.has_license() is True
+
+
+def test_has_license_invalid_signature(env):
+    """A forged / bit-flipped file still counts as PRESENT -- the presence
+    gate is deliberately blind to signature validity so a UI can render a
+    "broken license file, please re-activate" banner rather than "no
+    license"."""
+    _install_raw(env, "CLAW1.eyJ0aWVyIjoicHJvIn0=.not_a_real_signature")
+    assert env.lic.has_license() is True
+
+
+def test_has_license_never_raises(env, monkeypatch):
+    def boom(_path):
+        raise OSError("simulated fs failure")
+
+    monkeypatch.setattr(env.lic.os.path, "isfile", boom)
+    # Must degrade to False, not propagate the OSError.
+    assert env.lic.has_license() is False
+
+
+# -- module-level scalar: is_license_valid --
+
+
+def test_is_license_valid_no_license(env):
+    assert env.lic.is_license_valid() is False
+
+
+def test_is_license_valid_active(env):
+    _install(env, _payload(exp_delta=365 * 86400))
+    assert env.lic.is_license_valid() is True
+
+
+def test_is_license_valid_perpetual(env):
+    """A signed lifetime key with no ``exp`` claim is valid indefinitely."""
+    _install(env, _payload(perpetual=True))
+    assert env.lic.is_license_valid() is True
+
+
+def test_is_license_valid_expired(env):
+    """An installed, signature-valid, PAST-``exp`` key is not entitled --
+    the paywall gate must refuse a lapsed customer."""
+    _install(env, _payload(exp_delta=-3600))
+    assert env.lic.is_license_valid() is False
+
+
+def test_is_license_valid_invalid_signature(env):
+    """Untrusted body -- refuse to grant entitlement from an unsigned
+    payload; an attacker could stuff any tier / exp into a forged file."""
+    _install_raw(env, "CLAW1.eyJ0aWVyIjoicHJvIn0=.not_a_real_signature")
+    assert env.lic.is_license_valid() is False
+
+
+def test_is_license_valid_never_raises(env, monkeypatch):
+    def boom():
+        raise RuntimeError("simulated introspection failure")
+
+    monkeypatch.setattr(env.lic, "current_license_info", boom)
+    assert env.lic.is_license_valid() is False
+
+
+# -- has_license / is_license_valid layering --
+
+
+@pytest.mark.parametrize(
+    "installer",
+    [
+        pytest.param(lambda e: None, id="no_license"),
+        pytest.param(lambda e: _install(e, _payload(exp_delta=365 * 86400)), id="active"),
+        pytest.param(lambda e: _install(e, _payload(exp_delta=-3600)), id="expired"),
+        pytest.param(lambda e: _install(e, _payload(perpetual=True)), id="perpetual"),
+        pytest.param(lambda e: _install_raw(e, "CLAW1.bad.bad"), id="invalid"),
+    ],
+)
+def test_valid_implies_present(env, installer):
+    """is_license_valid=True must never fire without has_license=True --
+    entitlement requires a file, but the reverse (present but invalid)
+    is a normal branch we surface deliberately."""
+    installer(env)
+    if env.lic.is_license_valid():
+        assert env.lic.has_license() is True
+
+
+# -- endpoint: /api/license/present --
+
+
+_PRESENCE_SHAPE = {"present", "valid", "status"}
+
+
+def test_endpoint_present_no_license(env):
+    with env.app.test_client() as c:
+        resp = c.get("/api/license/present")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert set(data) == _PRESENCE_SHAPE
+    assert data["present"] is False
+    assert data["valid"] is False
+    assert data["status"] is None
+
+
+def test_endpoint_present_active(env):
+    _install(env, _payload(exp_delta=365 * 86400))
+    with env.app.test_client() as c:
+        resp = c.get("/api/license/present")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["present"] is True
+    assert data["valid"] is True
+    assert data["status"] == "active"
+
+
+def test_endpoint_present_expired(env):
+    _install(env, _payload(exp_delta=-3600))
+    with env.app.test_client() as c:
+        resp = c.get("/api/license/present")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    # File exists (present) but the ``exp`` claim is past (not valid).
+    assert data["present"] is True
+    assert data["valid"] is False
+    assert data["status"] == "expired"
+
+
+def test_endpoint_present_invalid_signature(env):
+    _install_raw(env, "CLAW1.eyJ0aWVyIjoicHJvIn0=.not_a_real_signature")
+    with env.app.test_client() as c:
+        resp = c.get("/api/license/present")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    # A forged file still counts as PRESENT -- a UI can render a
+    # "broken license file" banner off ``status == "invalid"``.
+    assert data["present"] is True
+    assert data["valid"] is False
+    assert data["status"] == "invalid"
+
+
+def test_endpoint_present_perpetual(env):
+    _install(env, _payload(perpetual=True))
+    with env.app.test_client() as c:
+        resp = c.get("/api/license/present")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["present"] is True
+    assert data["valid"] is True
+    assert data["status"] == "active"
+
+
+def test_endpoint_present_never_5xx(env, monkeypatch):
+    """Broken install (import / crypto mismatch) must degrade to the
+    no-license shape at HTTP 200 rather than 500 -- matches the never-crash
+    posture of ``/api/license/status`` and the surrounding entitlement
+    gate endpoints."""
+    def boom():
+        raise RuntimeError("simulated introspection failure")
+
+    monkeypatch.setattr(env.lic, "current_license_info", boom)
+    with env.app.test_client() as c:
+        resp = c.get("/api/license/present")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert set(data) == _PRESENCE_SHAPE
+    # ``current_license_info`` blowing up only affects the ``valid`` /
+    # ``status`` fields; the presence check is a bare ``isfile`` and stays
+    # honest regardless. A missing file returns present=False.
+    assert data["present"] is False
+    assert data["valid"] is False
+    assert data["status"] is None
+
+
+# -- endpoint: /api/license/valid --
+
+
+_VALID_SHAPE = {"present", "valid", "status"}
+
+
+def test_endpoint_valid_no_license(env):
+    with env.app.test_client() as c:
+        resp = c.get("/api/license/valid")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert set(data) == _VALID_SHAPE
+    assert data["valid"] is False
+    assert data["present"] is False
+    assert data["status"] is None
+
+
+def test_endpoint_valid_active(env):
+    _install(env, _payload(exp_delta=365 * 86400))
+    with env.app.test_client() as c:
+        resp = c.get("/api/license/valid")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["valid"] is True
+    assert data["present"] is True
+    assert data["status"] == "active"
+
+
+def test_endpoint_valid_expired(env):
+    """Expired-but-signed keys must return valid=false + status=expired --
+    the paywall gate refuses a lapsed customer even though the signature
+    still checks out."""
+    _install(env, _payload(exp_delta=-3600))
+    with env.app.test_client() as c:
+        resp = c.get("/api/license/valid")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["valid"] is False
+    assert data["present"] is True
+    assert data["status"] == "expired"
+
+
+def test_endpoint_valid_invalid_signature(env):
+    _install_raw(env, "CLAW1.eyJ0aWVyIjoicHJvIn0=.not_a_real_signature")
+    with env.app.test_client() as c:
+        resp = c.get("/api/license/valid")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["valid"] is False
+    assert data["present"] is True
+    assert data["status"] == "invalid"
+
+
+def test_endpoint_valid_perpetual(env):
+    _install(env, _payload(perpetual=True))
+    with env.app.test_client() as c:
+        resp = c.get("/api/license/valid")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["valid"] is True
+    assert data["present"] is True
+    assert data["status"] == "active"
+
+
+def test_endpoint_valid_never_5xx(env, monkeypatch):
+    def boom():
+        raise RuntimeError("simulated introspection failure")
+
+    monkeypatch.setattr(env.lic, "current_license_info", boom)
+    with env.app.test_client() as c:
+        resp = c.get("/api/license/valid")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert set(data) == _VALID_SHAPE
+    # No license file on disk (fixture) => present is False, valid is False.
+    assert data["valid"] is False
+    assert data["present"] is False
+    assert data["status"] is None
+
+
+# -- cross-consistency between the endpoint pair --
+
+
+@pytest.mark.parametrize(
+    "installer",
+    [
+        pytest.param(lambda e: None, id="no_license"),
+        pytest.param(lambda e: _install(e, _payload(exp_delta=365 * 86400)), id="active"),
+        pytest.param(lambda e: _install(e, _payload(exp_delta=-3600)), id="expired"),
+        pytest.param(lambda e: _install(e, _payload(perpetual=True)), id="perpetual"),
+        pytest.param(lambda e: _install_raw(e, "CLAW1.bad.bad"), id="invalid"),
+    ],
+)
+def test_endpoint_pair_snapshots_agree(env, installer):
+    """The paired endpoints share a single snapshot -- they must return
+    byte-identical (present, valid, status) triples on every branch."""
+    installer(env)
+    with env.app.test_client() as c:
+        pres = c.get("/api/license/present").get_json()
+        valid = c.get("/api/license/valid").get_json()
+    assert pres["present"] == valid["present"]
+    assert pres["valid"] == valid["valid"]
+    assert pres["status"] == valid["status"]
+
+
+@pytest.mark.parametrize(
+    "installer",
+    [
+        pytest.param(lambda e: None, id="no_license"),
+        pytest.param(lambda e: _install(e, _payload(exp_delta=365 * 86400)), id="active"),
+        pytest.param(lambda e: _install(e, _payload(exp_delta=-3600)), id="expired"),
+        pytest.param(lambda e: _install(e, _payload(perpetual=True)), id="perpetual"),
+        pytest.param(lambda e: _install_raw(e, "CLAW1.bad.bad"), id="invalid"),
+    ],
+)
+def test_endpoint_matches_module_scalar(env, installer):
+    """Envelope ``present`` / ``valid`` must byte-match the module-level
+    scalar on every branch -- else a UI bound to the URL sees a different
+    answer than a script importing the helper directly."""
+    installer(env)
+    with env.app.test_client() as c:
+        pres = c.get("/api/license/present").get_json()
+        valid = c.get("/api/license/valid").get_json()
+    assert pres["present"] == env.lic.has_license()
+    assert valid["valid"] == env.lic.is_license_valid()
+
+
+@pytest.mark.parametrize(
+    "installer",
+    [
+        pytest.param(lambda e: _install(e, _payload(exp_delta=365 * 86400)), id="active"),
+        pytest.param(lambda e: _install(e, _payload(exp_delta=-3600)), id="expired"),
+        pytest.param(lambda e: _install(e, _payload(perpetual=True)), id="perpetual"),
+        pytest.param(lambda e: _install_raw(e, "CLAW1.bad.bad"), id="invalid"),
+    ],
+)
+def test_endpoint_status_matches_status_endpoint(env, installer):
+    """The ``status`` field on ``/api/license/{present,valid}`` must match
+    the ``status`` field on ``/api/license/status`` for the same install --
+    else a UI binding one field from each URL sees inconsistent state."""
+    installer(env)
+    with env.app.test_client() as c:
+        pres = c.get("/api/license/present").get_json()
+        status = c.get("/api/license/status").get_json()
+    # ``/api/license/status`` on the no-license branch returns
+    # {"has_license": False, ...} without a "status" key, but this
+    # parametrisation always installs some file, so ``status`` is set.
+    assert pres["status"] == status.get("status")
+
+
+def test_endpoint_valid_implies_present(env):
+    """valid=True must never fire without present=True on the endpoint pair
+    -- entitlement requires a file. Mirrors the module-scalar invariant."""
+    for installer in (
+        lambda: None,
+        lambda: _install(env, _payload(exp_delta=365 * 86400)),
+        lambda: _install(env, _payload(exp_delta=-3600)),
+        lambda: _install(env, _payload(perpetual=True)),
+        lambda: _install_raw(env, "CLAW1.bad.bad"),
+    ):
+        installer()
+        with env.app.test_client() as c:
+            data = c.get("/api/license/valid").get_json()
+        if data["valid"]:
+            assert data["present"] is True


### PR DESCRIPTION
## Summary

Adds two install-state scalar helpers on `clawmetry/license.py` plus matching endpoints in `routes/entitlement.py`, following the same pattern already used for `license_tier`/`is_tier`, `days_until_expiry`/`is_expiring_within`, and `is_expired`/`is_perpetual`:

- **`has_license() -> bool`** — bare file-exists check at `LICENSE_PATH`, regardless of signature or `exp`. Answers "does this operator have ANY license file at all?", the signal a dashboard uses to distinguish "Free (never activated)" from "Free (license expired / broken)".
- **`is_license_valid() -> bool`** — installed AND signature-valid AND not expired. The single boolean gate a paywall tile actually wants: "is this node entitled right now?". Every "not entitled" reason (no file, forged signature, lapsed key) collapses to `is_license_valid=False` so a paywall widget can bind directly to this scalar without threading the full `/api/license/status` envelope.

### HTTP surface

- `GET /api/license/present` → `{present, valid, status}`
- `GET /api/license/valid` → `{present, valid, status}`

Shared `_license_presence_snapshot()` helper reads `has_license()` + `current_license_info()` once so the paired endpoints can't disagree on `present` / `status` for the same install — a UI binding both sees a consistent snapshot. Both endpoints never 5xx — on any underlying failure they degrade to `{present: false, valid: false, status: null}`, matching the never-crash posture of the surrounding license routes.

### Grace mode

Ships in **GRACE** — no enforcement, no behaviour change. Purely observational scalars a paywall / empty-state tile can bind to without pulling the whole `/api/license/status` envelope.

### Tests

44 new unit + endpoint tests in `tests/test_license_presence_scalar.py` cover:

- No-license, active, expired, invalid-signature, perpetual branches on `has_license()`
- Same five branches on `is_license_valid()`, plus never-raises on introspection failure
- Same five branches on both `/api/license/present` and `/api/license/valid`, plus never-5xx on introspection failure
- Cross-consistency: `valid ⇒ present` invariant, endpoint pair returns byte-identical `(present, valid, status)`, envelope fields match module-level scalars, envelope `status` matches `/api/license/status`

All hermetic — ephemeral Ed25519 keypair + `tmp_path` license file + `CLAWMETRY_OFFLINE=1`; no network, no operator-state mutation. Existing `test_license_*` (153 tests) still pass; existing `test_entitlement_api*` (39 tests) still pass.

## Files changed

- `clawmetry/license.py` — +69 lines (two new helpers appended after `pro_installation_info()`)
- `routes/entitlement.py` — +116 lines (shared `_license_presence_snapshot()` helper + two new route handlers inserted after `/api/license/pro-installation`, grouped with the other `/api/license/*` endpoints)
- `tests/test_license_presence_scalar.py` — +398 lines (new file)

## Test plan

- [x] `python3 -m py_compile clawmetry/license.py routes/entitlement.py tests/test_license_presence_scalar.py` — clean
- [x] `python3 -m pytest tests/test_license_presence_scalar.py -q` — 44 passed
- [x] `python3 -m pytest tests/test_license_{api,tier_scalar,days_until_expiry,is_expired_is_perpetual,pro_installation}.py -q` — 153 passed (no regressions on adjacent license suites)
- [x] `python3 -m pytest tests/test_entitlement_api.py tests/test_entitlement_api_fallback_shape.py -q` — 39 passed (no regressions on entitlement handler tests)

## Local operator verification checklist

Because the autonomous fire can't touch the running daemon or the live cloud snapshot:

- [ ] Rebuild wheel or copy the changed files into `~/.clawmetry/lib/pythonX.Y/site-packages/clawmetry/` and `.../site-packages/routes/`.
- [ ] Clear `__pycache__` under both directories (`find ~/.clawmetry/lib -name __pycache__ -exec rm -rf {} +`).
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` (macOS) or the equivalent `systemctl --user restart` on Linux.
- [ ] Confirm `GET /api/license/present` returns `{"present": false, "valid": false, "status": null}` on a Free install.
- [ ] Confirm `GET /api/license/valid` returns the same shape on a Free install.
- [ ] After `clawmetry activate <KEY>`, confirm both endpoints return `{"present": true, "valid": true, "status": "active"}`.
- [ ] With a tampered license file (`echo garbage > ~/.clawmetry/license.key`), confirm both endpoints return `{"present": true, "valid": false, "status": "invalid"}`.
- [ ] Decrypt the live cloud snapshot and confirm the endpoints work through the cloud relay too.
- [ ] Browser-check any empty-state / paywall tiles bound to these URLs (dashboard hits `/api/license/status` today; the new scalars are opt-in).

## Notes

- No `__version__` bump, no tag, no `[RELEASE]` PR — the operator drives the release loop.
- No enforcement gate changes; both endpoints are read-only observational scalars.
- No new dependencies — uses `cryptography` (already required) and `flask` (already required).
- Complements open PR #4110 (`license_nodes` / `is_within_node_limit` node-capacity scalars) — this PR is install-state axis, that PR is node-capacity axis; they don't touch the same functions.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UBANvGZaGBaYdnj2rt5fs2)_