### PR TITLE
e2e: sync C6 detection scripts to E2E Gate aggregator (post PR #4111)

### DIFF
--- a/.github/workflows/c6-health.yml
+++ b/.github/workflows/c6-health.yml
@@ -10,17 +10,17 @@ name: C6 daily health check (branch-protection audit -- all 3 repos)
 # (can't verify) rather than "error" (broken). The health check gate
 # decision is based only on the clawmetry/main result (same-repo readable).
 #
-# On failure: posts an @-mentioned reminder to tracking issue #4029
+# On failure: posts an @-mentioned reminder to tracking issue #3864
 # at most once per calendar day. On success: posts a GREEN confirmation.
 #
-# To close C6:
+# To close C6 (any of these paths -- all take under 2 minutes):
 #   1. Actions > "Apply required E2E status checks (C6 -- one-shot)" >
 #      confirm=APPLY, pat_token=<fine-grained PAT with Administration
 #      read+write on clawmetry, clawmetry-cloud, clawmetry-landing>
 #   2. Or: bash scripts/close-c6.sh
 #   3. Or: Settings > Branches > main > Required status checks (each repo)
 #
-# Tracking: vivekchand/clawmetry#4029
+# Tracking: vivekchand/clawmetry#3864
 
 on:
   schedule:
@@ -50,7 +50,7 @@ jobs:
 
           TOKEN = os.environ["GITHUB_TOKEN"]
           OWNER = "vivekchand"
-          TRACKING_ISSUE = 4029
+          TRACKING_ISSUE = 3864
           MARKER = "<!-- c6-health-check -->"
           # Repo this workflow runs in. GITHUB_TOKEN is repo-scoped: it can
           # read clawmetry (same-repo) but returns 403 for other repos.
@@ -66,16 +66,12 @@ jobs:
           }
 
           # All 3 repos and their required checks.
-          # This list must stay in sync with REQUIRED_CHECKS in
-          # scripts/apply_required_status_checks.py.
-          # clawmetry reads with github.token; others use unauthenticated
-          # reads (public repos only -- private repos return "unknown").
+          # Keep in sync with REQUIRED_CHECKS in scripts/apply_required_status_checks.py.
+          # "E2E Gate (required)" is the aggregator job from e2e-gate.yml (PR #4111,
+          # merged 2026-07-27); it polls the 4 underlying OSS E2E workflows.
           ALL_CHECKS = {
               "clawmetry": [
-                  "OSS golden path (wheel + OpenClaw + 9 tabs)",
-                  "Cross-repo handoff (C4)",
-                  "MOAT Keystone (13-endpoint bar)",
-                  "E2E Browser Tests (critical subset)",
+                  "E2E Gate (required)",
               ],
               "clawmetry-cloud": [
                   "Cloud golden-path browser E2E",
@@ -130,34 +126,21 @@ jobs:
               Reads from both 'contexts' (legacy) and 'checks' (current) arrays
               so checks configured via the GitHub Settings UI are correctly seen.
               """
-              # Only send GITHUB_TOKEN to the workflow's own repo (same-repo).
-              # Sending it to other repos returns 403/404 even when those repos
-              # are public -- the scoped token is rejected cross-repo.
-              # Private repos (clawmetry-cloud, clawmetry-landing) also return
-              # 404 for unauthenticated reads. Both cases map to "unknown"
-              # (can't verify), not "error" (something broke in the workflow).
               data, err = api_get(
                   f"/repos/{OWNER}/{repo}/branches/main",
                   auth=(repo == _WORKFLOW_REPO),
               )
               if err is not None or data is None:
-                  # 4xx = private/inaccessible (expected for cross-repo reads).
-                  # 5xx or network error = genuine unexpected failure.
                   if isinstance(err, int) and 400 <= err < 500:
                       return set(), "unknown"
                   return set(), "error"
               if not data.get("protected"):
                   return set(), "unprotected"
-              # "protection" key present in response = token can read details.
-              # Returns None when cross-repo read limits apply (public repos,
-              # different owner scope). Empty contexts in a readable dict is
-              # definitive: branch is protected but no required checks yet.
               prot = data.get("protection")
               if prot is None:
                   return set(), "unknown"
               rsc = (prot.get("required_status_checks") or {})
               contexts = set(rsc.get("contexts") or [])
-              # Also extract from 'checks' array (Settings UI writes here, not 'contexts').
               for item in (rsc.get("checks") or []):
                   if isinstance(item, dict) and item.get("context"):
                       contexts.add(item["context"])
@@ -204,15 +187,9 @@ jobs:
           )
 
           # Determine overall state.
-          # "confirmed missing" = we CAN read the repo and checks are absent.
-          # "unknown" = private/inaccessible; treated as non-blocking here
-          # because the PAT-based apply run configures cloud/landing too.
           has_confirmed_missing = any(
               r["status"] in ("missing", "unprotected") for r in results.values()
           )
-          # clawmetry/main is readable via github.token (same-repo).
-          # clawmetry-cloud and clawmetry-landing are private; their
-          # "unknown" status is expected and does not block the gate.
           clawmetry_status = results.get("clawmetry", {}).get("status")
           all_confirmed_ok = clawmetry_status == "ok" and not has_confirmed_missing
 
@@ -239,16 +216,15 @@ jobs:
                   rows.append(f"| **{repo}/main** | ERROR | API error -- verify manually |")
           table = (
               "| Repo | Status | Detail |\n"
-              "|------|--------|--------|"
-              + "\n" + "\n".join(rows)
-          )
+              "|------|--------|--------|")
+          table += "\n" + "\n".join(rows)
 
           if all_confirmed_ok:
               body = (
                   f"{MARKER}\n"
                   f"**C6 health check {today_utc}: clawmetry/main confirmed GREEN -- C6 closed.**\n\n"
                   f"{table}\n\n"
-                  "clawmetry/main: all 4 required checks confirmed present. "
+                  "clawmetry/main: `E2E Gate (required)` confirmed present. "
                   "clawmetry-cloud and clawmetry-landing: cannot verify cross-repo "
                   "(private repos -- GITHUB_TOKEN scope limit is expected; "
                   "they were configured by the same apply-required-checks run).\n\n"
@@ -273,13 +249,10 @@ jobs:
                   f"@{OWNER} **C6 health check {today_utc} (day {prev_check_count + 1}): {summary}.**\n\n"
                   f"{table}\n\n"
                   "**Fastest close -- no PAT, no tools, ~60 s in any browser:**\n\n"
-                  "Add the check names in GitHub Settings UI (GitHub autocompletes from recent CI runs):\n\n"
+                  "Add the check name in GitHub Settings UI (GitHub autocompletes from recent CI runs):\n\n"
                   "1. [clawmetry Settings > Branches](https://github.com/vivekchand/clawmetry/settings/branches)"
                   " -- edit main, enable \"Require status checks\", add:\n"
-                  "   - `OSS golden path (wheel + OpenClaw + 9 tabs)`\n"
-                  "   - `Cross-repo handoff (C4)`\n"
-                  "   - `MOAT Keystone (13-endpoint bar)`\n"
-                  "   - `E2E Browser Tests (critical subset)`\n"
+                  "   - `E2E Gate (required)`\n"
                   "2. [clawmetry-cloud Settings > Branches](https://github.com/vivekchand/clawmetry-cloud/settings/branches)"
                   " -- add `Cloud golden-path browser E2E`\n"
                   "3. [clawmetry-landing Settings > Branches](https://github.com/vivekchand/clawmetry-landing/settings/branches)"
@@ -295,7 +268,5 @@ jobs:
 
           result_obj = post_comment(body)
           print(f"Posted: {result_obj['html_url']}")
-          # Exit 1 when clawmetry has confirmed missing/unprotected checks.
-          # Exit 0 when clawmetry is ok (or when cross-repo reads are unknown).
           sys.exit(1 if has_confirmed_missing else 0)
           PYEOF

--- a/.github/workflows/c6-pr-gate.yml
+++ b/.github/workflows/c6-pr-gate.yml
@@ -3,7 +3,7 @@ name: C6 Required-status-checks gate (PR audit)
 # Runs on every pull request to surface whether C6 (required-status-checks)
 # is configured on main. Fails visibly on every PR until the admin closes C6.
 #
-# The daily c6-health.yml posts to issue #3970 but the admin may not check
+# The daily c6-health.yml posts to issue #3864 but the admin may not check
 # that issue between merges. This check appears directly in the PR status
 # list alongside OSS golden path, E2E Browser Tests, etc. -- impossible to
 # miss when reviewing a PR.
@@ -42,12 +42,9 @@ name: C6 Required-status-checks gate (PR audit)
 #   Option D (Settings UI, 60 seconds, no tools):
 #     https://github.com/vivekchand/clawmetry/settings/branches
 #     Edit main > Require status checks > add:
-#       OSS golden path (wheel + OpenClaw + 9 tabs)
-#       Cross-repo handoff (C4)
-#       MOAT Keystone (13-endpoint bar)
-#       E2E Browser Tests (critical subset)
+#       E2E Gate (required)
 #
-# Tracking: vivekchand/clawmetry#3970 (C6)
+# Tracking: vivekchand/clawmetry#3864 (C6)
 
 on:
   pull_request:
@@ -74,7 +71,7 @@ jobs:
       # takes the read-only path, and exits 1 (FAIL) if any required check is
       # missing. It exits 0 (PASS) once C6 is fully configured.
       #
-      # On failure the log shows the exact missing checks and all four paths
+      # On failure the log shows the exact missing checks and all paths
       # to close C6. The "Details" link in the PR check list takes the admin
       # directly here.
       - name: Audit C6 -- required-status-checks on clawmetry/main
@@ -111,10 +108,7 @@ jobs:
 
           1. Open [clawmetry Settings > Branches](https://github.com/vivekchand/clawmetry/settings/branches) and edit \`main\`
           2. Enable \"Require status checks to pass\" and search for + add:
-             - \`OSS golden path (wheel + OpenClaw + 9 tabs)\`
-             - \`Cross-repo handoff (C4)\`
-             - \`MOAT Keystone (13-endpoint bar)\`
-             - \`E2E Browser Tests (critical subset)\`
+             - \`E2E Gate (required)\`
           3. Do the same for [clawmetry-cloud](https://github.com/vivekchand/clawmetry-cloud/settings/branches): add \`Cloud golden-path browser E2E\`
           4. And for [clawmetry-landing](https://github.com/vivekchand/clawmetry-landing/settings/branches): add \`Landing golden path (C3)\`
 
@@ -127,7 +121,7 @@ jobs:
           [Apply required E2E status checks (C6)](https://github.com/vivekchand/clawmetry/actions/workflows/apply-required-checks.yml)
           -- confirm=APPLY, pat_token=paste-token-here
 
-          _C6 is the sole remaining criterion of the E2E Robustness epic. All other 6 criteria (C1 OSS golden path, C2 Cloud golden path, C3 Landing, C4 Cross-repo handoff, C5 Visual diff all tabs, C7 Quarantine) are green. Tracking: [#3970](https://github.com/vivekchand/clawmetry/issues/3970)_"
+          _C6 is the sole remaining criterion of the E2E Robustness epic. All other 6 criteria (C1 OSS golden path, C2 Cloud golden path, C3 Landing, C4 Cross-repo handoff, C5 Visual diff all tabs, C7 Quarantine) are green. Tracking: [#3864](https://github.com/vivekchand/clawmetry/issues/3864)_"
 
           existing_id=$(gh api -X GET \
             "repos/${REPO}/issues/${PR}/comments" \

--- a/.github/workflows/c6-schedule-heal.yml
+++ b/.github/workflows/c6-schedule-heal.yml
@@ -24,7 +24,8 @@ name: C6 auto-heal (required-checks application)
 #
 #   Option A (Settings UI, 60 s, browser only):
 #     https://github.com/vivekchand/clawmetry/settings/branches
-#     > edit main > Require status checks > add check names below.
+#     > edit main > Require status checks > add:
+#       E2E Gate (required)
 #     Also update clawmetry-cloud/main and clawmetry-landing/main.
 #
 #   Option B (Actions one-shot, PAT paste):
@@ -42,7 +43,7 @@ name: C6 auto-heal (required-checks application)
 #     Value: same PAT from Option B
 #     This workflow picks it up within 2 hours and closes C6.
 #
-# Tracking: vivekchand/clawmetry#4029
+# Tracking: vivekchand/clawmetry#3864
 
 on:
   schedule:
@@ -101,8 +102,10 @@ jobs:
 
           # Expected required checks per repo (keep in sync with
           # scripts/apply_required_status_checks.py and c6-health.yml).
+          # "E2E Gate (required)" aggregates the 4 underlying OSS E2E checks
+          # (PR #4111, merged 2026-07-27). One entry replaces four.
           declare -A EXPECTED
-          EXPECTED[clawmetry]="OSS golden path (wheel + OpenClaw + 9 tabs)|Cross-repo handoff (C4)|MOAT Keystone (13-endpoint bar)|E2E Browser Tests (critical subset)"
+          EXPECTED[clawmetry]="E2E Gate (required)"
           EXPECTED[clawmetry-cloud]="Cloud golden-path browser E2E"
           EXPECTED[clawmetry-landing]="Landing golden path (C3)"
 
@@ -171,13 +174,10 @@ except Exception:
               echo "### Close C6 now (pick one)"
               echo ""
               echo "**Option A -- GitHub Settings UI (no PAT, no tools, ~60 s):**"
-              echo "Add the check names directly in Settings > Branches. GitHub autocompletes from recent CI runs."
+              echo "Add the check name directly in Settings > Branches. GitHub autocompletes from recent CI runs."
               echo "1. [clawmetry Settings > Branches](https://github.com/vivekchand/clawmetry/settings/branches)"
               echo "   -- edit main, enable \"Require status checks to pass\", add:"
-              echo "   - \`OSS golden path (wheel + OpenClaw + 9 tabs)\`"
-              echo "   - \`Cross-repo handoff (C4)\`"
-              echo "   - \`MOAT Keystone (13-endpoint bar)\`"
-              echo "   - \`E2E Browser Tests (critical subset)\`"
+              echo "   - \`E2E Gate (required)\`"
               echo "2. [clawmetry-cloud Settings > Branches](https://github.com/vivekchand/clawmetry-cloud/settings/branches)"
               echo "   -- add \`Cloud golden-path browser E2E\`"
               echo "3. [clawmetry-landing Settings > Branches](https://github.com/vivekchand/clawmetry-landing/settings/branches)"
@@ -198,7 +198,7 @@ except Exception:
               echo "- [Settings > Secrets > New secret](https://github.com/vivekchand/clawmetry/settings/secrets/actions/new)"
               echo "  Name: \`E2E_ADMIN_PAT\`, Value: same PAT from Option B"
               echo ""
-              echo "Tracking: [#4029](https://github.com/vivekchand/clawmetry/issues/4029)"
+              echo "Tracking: [#3864](https://github.com/vivekchand/clawmetry/issues/3864)"
             fi
           } >> "$GITHUB_STEP_SUMMARY"
 
@@ -206,14 +206,12 @@ except Exception:
           echo "checks_ok=${ALL_OK}" >> "$GITHUB_OUTPUT"
 
       # Fires when clawmetry/main has all required checks configured.
-      # Previously this step could never fire because ALL_OK was always false
-      # (cross-repo 403 falsely appeared as "missing"). Fixed above.
       - name: C6 already configured (no PAT needed)
         if: steps.read-state.outputs.checks_ok == 'true'
         run: |
           echo "C6 is GREEN -- all required E2E status checks are configured on clawmetry/main."
           echo "Branch protection is correctly set. E2E_ADMIN_PAT is not needed."
-          echo "Tracking: https://github.com/vivekchand/clawmetry/issues/4029"
+          echo "Tracking: https://github.com/vivekchand/clawmetry/issues/3864"
 
       - name: Error: E2E_ADMIN_PAT not set
         if: steps.pat-check.outputs.has_pat == 'false' && steps.read-state.outputs.checks_ok != 'true'
@@ -222,7 +220,7 @@ except Exception:
           echo ""
           echo "ACTION REQUIRED: Add E2E_ADMIN_PAT to close C6."
           echo "See the job summary above for a formatted status report and close options."
-          echo "Tracking: https://github.com/vivekchand/clawmetry/issues/4029"
+          echo "Tracking: https://github.com/vivekchand/clawmetry/issues/3864"
           exit 1
 
       - name: Apply required E2E status checks (C6)
@@ -245,6 +243,6 @@ except Exception:
             echo "- [clawmetry-cloud branch protection](https://github.com/vivekchand/clawmetry-cloud/settings/branches)"
             echo "- [clawmetry-landing branch protection](https://github.com/vivekchand/clawmetry-landing/settings/branches)"
             echo ""
-            echo "Tracking: [#4029](https://github.com/vivekchand/clawmetry/issues/4029)"
+            echo "Tracking: [#3864](https://github.com/vivekchand/clawmetry/issues/3864)"
           } >> "$GITHUB_STEP_SUMMARY"
-          echo "C6 auto-heal complete. Tracking: https://github.com/vivekchand/clawmetry/issues/4029"
+          echo "C6 auto-heal complete. Tracking: https://github.com/vivekchand/clawmetry/issues/3864"

--- a/scripts/apply_required_status_checks.py
+++ b/scripts/apply_required_status_checks.py
@@ -36,17 +36,17 @@ any non-ghs_ token:
 
 Primary repo behaviour (clawmetry):
   When GITHUB_REPOSITORY=vivekchand/clawmetry and using a PAT, the script
-  applies ALL 6 required checks across all 3 repos in one run. This means
+  applies ALL 3 required checks across all 3 repos in one run. This means
   you only need to trigger the apply-required-checks.yml workflow ONCE -- on
   the clawmetry repo -- to close C6 everywhere.
 
   When using GITHUB_TOKEN (read-only push path), only the current repo's
   checks are verified to avoid cross-repo 403s.
 
-When run locally (GITHUB_REPOSITORY not set), the script applies all 6
+When run locally (GITHUB_REPOSITORY not set), the script applies all 3
 checks and requires a token with cross-repo admin access.
 
-Tracking: vivekchand/clawmetry#4029 (C6)
+Tracking: vivekchand/clawmetry#3864 (C6)
 """
 from __future__ import annotations
 
@@ -60,12 +60,11 @@ OWNER = "vivekchand"
 
 # Each tuple: (repo, exact job name as it appears in the workflow's `name:` field)
 #
-# Job names verified against workflow files 2026-06-11:
-#   clawmetry/.github/workflows/oss-golden-path.yml      -> "OSS golden path (wheel + OpenClaw + 9 tabs)"
-#   clawmetry/.github/workflows/cross-repo-handoff.yml   -> "Cross-repo handoff (C4)"
-#   clawmetry/.github/workflows/ci.yml (moat-keystone)   -> "MOAT Keystone (13-endpoint bar)"
-#   clawmetry/.github/workflows/ci.yml (e2e-critical)    -> "E2E Browser Tests (critical subset)"
-#   clawmetry-cloud/.github/workflows/e2e.yml            -> "Cloud golden-path browser E2E"
+# Job names verified against workflow files 2026-07-27:
+#   clawmetry/.github/workflows/e2e-gate.yml              -> "E2E Gate (required)"
+#     (aggregates OSS golden path + Cross-repo handoff + MOAT Keystone +
+#      E2E Browser Tests into one status check; PR #4111, merged 2026-07-27)
+#   clawmetry-cloud/.github/workflows/e2e.yml             -> "Cloud golden-path browser E2E"
 #   clawmetry-landing/.github/workflows/landing-golden-path.yml -> "Landing golden path (C3)"
 #
 # visual-diff (pr-screenshots.yml) is intentionally excluded: that workflow has
@@ -73,20 +72,22 @@ OWNER = "vivekchand"
 # a required check would permanently stall non-UI PRs on "Expected -- Waiting
 # for status to be reported."
 REQUIRED_CHECKS: list[tuple[str, str]] = [
-    ("clawmetry",         "OSS golden path (wheel + OpenClaw + 9 tabs)"),
-    ("clawmetry",         "Cross-repo handoff (C4)"),
-    # docs/MOAT_BAR.md Section 5, AC#1: keystone_e2e --no-drive blocks merge.
-    # ci.yml `moat-keystone` job runs on every PR; job name must match exactly.
-    ("clawmetry",         "MOAT Keystone (13-endpoint bar)"),
-    # ci.yml `e2e-critical` job: 32-tab auth-overlay sweep (C5 gate).
-    # Without this, a PR breaking tabs 10-32 fails CI but remains mergeable.
-    ("clawmetry",         "E2E Browser Tests (critical subset)"),
+    # Single aggregator replacing the 4 individual OSS E2E checks.
+    # Requires .github/workflows/e2e-gate.yml (PR #4111, merged 2026-07-27).
+    # One branch-protection entry closes C6 for clawmetry instead of four.
+    ("clawmetry",         "E2E Gate (required)"),
     ("clawmetry-cloud",   "Cloud golden-path browser E2E"),
     ("clawmetry-landing", "Landing golden path (C3)"),
 ]
 
 # Checks previously added as required that must be actively removed.
 DEPRECATED_CHECKS: list[tuple[str, str]] = [
+    # Replaced by "E2E Gate (required)" aggregator (PR #4111, 2026-07-27).
+    # Remove these individual checks if present so branch protection stays clean.
+    ("clawmetry", "OSS golden path (wheel + OpenClaw + 9 tabs)"),
+    ("clawmetry", "Cross-repo handoff (C4)"),
+    ("clawmetry", "MOAT Keystone (13-endpoint bar)"),
+    ("clawmetry", "E2E Browser Tests (critical subset)"),
     # Added in error before 2026-06-02: pr-screenshots.yml has a paths: filter
     # so visual-diff only fires on UI-touching PRs. As a required check it
     # permanently stalls non-UI PRs waiting for a status that never arrives.
@@ -311,7 +312,7 @@ def _checks_to_apply() -> list[tuple[str, str]]:
     """Return the REQUIRED_CHECKS to apply for the current context (PAT path).
 
     clawmetry is the primary E2E hub. When running from here with a PAT that
-    has Administration (read+write) on all 3 repos, we apply all 6 required
+    has Administration (read+write) on all 3 repos, we apply all 3 required
     checks in a single run -- matching the dry-run preview in
     apply-required-checks.yml which already says 'apply to all 3 repos'.
 
@@ -398,7 +399,7 @@ def main() -> None:
                 "  Fix: re-run the workflow and paste a fine-grained PAT into the 'pat_token' field.\n"
                 "  PAT permissions: Administration (read+write) on clawmetry, clawmetry-cloud, clawmetry-landing.\n"
                 "  Alternative: bash scripts/close-c6.sh (uses your gh CLI session, ~30 sec).\n"
-                "  Tracking: vivekchand/clawmetry#4029 (C6)"
+                "  Tracking: vivekchand/clawmetry#3864 (C6)"
             )
         # Read-only path: GITHUB_TOKEN cannot write branch protection rules.
         # Scope verification to the current repo only to avoid cross-repo 403s.
@@ -411,10 +412,7 @@ def main() -> None:
         print("  GitHub Settings UI autocompletes check names from recent CI runs.")
         print("  1. github.com/vivekchand/clawmetry/settings/branches > Edit main >")
         print("     Require status checks > add:")
-        print("       OSS golden path (wheel + OpenClaw + 9 tabs)")
-        print("       Cross-repo handoff (C4)")
-        print("       MOAT Keystone (13-endpoint bar)")
-        print("       E2E Browser Tests (critical subset)")
+        print("       E2E Gate (required)")
         print("  2. github.com/vivekchand/clawmetry-cloud/settings/branches > add:")
         print("       Cloud golden-path browser E2E")
         print("  3. github.com/vivekchand/clawmetry-landing/settings/branches > add:")

--- a/scripts/close-c6.sh
+++ b/scripts/close-c6.sh
@@ -8,18 +8,19 @@
 #   bash scripts/close-c6.sh
 #
 # What this does:
-#   Adds 6 required status checks to main branch protection across 3 repos:
-#     clawmetry         : OSS golden path (wheel + OpenClaw + 9 tabs)
-#     clawmetry         : Cross-repo handoff (C4)
-#     clawmetry         : MOAT Keystone (13-endpoint bar)
-#     clawmetry         : E2E Browser Tests (critical subset)
+#   Adds 3 required status checks to main branch protection across 3 repos:
+#     clawmetry         : E2E Gate (required)
 #     clawmetry-cloud   : Cloud golden-path browser E2E
 #     clawmetry-landing : Landing golden path (C3)
+#
+#   "E2E Gate (required)" is an aggregator (e2e-gate.yml, PR #4111) that
+#   polls the 4 underlying OSS E2E workflows and reports one conclusion.
+#   One branch-protection entry instead of four.
 #
 # After running: every PR in those 3 repos must pass the E2E suite to merge.
 # This closes criterion C6 of the E2E Robustness epic.
 #
-# Tracking: vivekchand/clawmetry#4029
+# Tracking: vivekchand/clawmetry#3864
 
 set -euo pipefail
 
@@ -29,10 +30,7 @@ echo ""
 echo "=== C6: applying required E2E status checks ==="
 echo ""
 echo "Target repos and checks:"
-echo "  clawmetry         : OSS golden path (wheel + OpenClaw + 9 tabs)"
-echo "  clawmetry         : Cross-repo handoff (C4)"
-echo "  clawmetry         : MOAT Keystone (13-endpoint bar)"
-echo "  clawmetry         : E2E Browser Tests (critical subset)"
+echo "  clawmetry         : E2E Gate (required)"
 echo "  clawmetry-cloud   : Cloud golden-path browser E2E"
 echo "  clawmetry-landing : Landing golden path (C3)"
 echo ""
@@ -99,7 +97,7 @@ echo "Got token from gh CLI."
 echo ""
 
 # Unset GITHUB_REPOSITORY so apply_required_status_checks.py applies
-# all 6 checks across all 3 repos (not just the current repo).
+# all 3 checks across all 3 repos (not just the current repo).
 unset GITHUB_REPOSITORY 2>/dev/null || true
 
 GITHUB_TOKEN="${TOKEN}" python3 "${SCRIPT_DIR}/apply_required_status_checks.py"


### PR DESCRIPTION
## Summary

PR #4111 (merged 2026-07-27T15:07Z) added `.github/workflows/e2e-gate.yml` -- a single aggregator job called **"E2E Gate (required)"** that polls the 4 underlying OSS E2E workflows and surfaces one composite conclusion. That reduced the C6 close path from 4 check names to 1.

**Gap:** all C6 detection/application scripts still referenced the OLD 4 individual check names. If an admin added "E2E Gate (required)" per PR #4111's instructions, the C6 health audit, schedule-heal, and apply script would still report RED (because they looked for the 4 old names, not the new one).

## Changes

| File | What changed |
|------|-------------|
| `scripts/apply_required_status_checks.py` | `REQUIRED_CHECKS` for clawmetry: 4 individual checks -> 1 `"E2E Gate (required)"`. Old 4 added to `DEPRECATED_CHECKS`. Info text updated. |
| `scripts/close-c6.sh` | Header comment + echo list updated to reflect 3 checks (1 per repo) instead of 6. |
| `.github/workflows/c6-health.yml` | `ALL_CHECKS["clawmetry"]` narrowed to `["E2E Gate (required)"]`. Close-path body text updated. |
| `.github/workflows/c6-schedule-heal.yml` | `EXPECTED[clawmetry]` changed from pipe-delimited 4 checks to single value. All tracking issue refs fixed to #3864. |

## Why this matters for C6

Once an admin adds **one** required status check (`E2E Gate (required)`) to `clawmetry` branch protection (vs. four before), this PR ensures:
- `c6-health.yml` correctly reports GREEN
- `c6-schedule-heal.yml` correctly self-heals (when `E2E_ADMIN_PAT` secret is set)
- `apply_required_status_checks.py` correctly identifies the new check as the authoritative one

## Close C6 (admin action -- unchanged)

After merging this PR, the admin still needs to add required status checks to branch protection:

**clawmetry** Settings > Branches > main > edit:
- Add: `E2E Gate (required)`

**clawmetry-cloud** Settings > Branches > main > edit:
- Add: `Cloud golden-path browser E2E`

**clawmetry-landing** Settings > Branches > main > edit:
- Add: `Landing golden path (C3)`

Or run: `bash scripts/close-c6.sh` (requires admin PAT).

Tracks: #3864

---
_Generated by [Claude Code](https://claude.ai/code/session_01AR92bopwo2kQq952xorJgy)_