### PR TITLE
feat(license): license_subject + is_subject scalar helpers + endpoints

### DIFF
--- a/clawmetry/license.py
+++ b/clawmetry/license.py
@@ -1419,3 +1419,90 @@ def is_license_valid() -> bool:
     if not isinstance(info, dict):
         return False
     return bool(info.get("valid"))
+
+
+def license_subject() -> str | None:
+    """Scalar view onto the installed license's ``sub`` claim -- the customer
+    identifier the license was issued to (typically an account id or a
+    contact email) -- for a "Licensed to <X>" badge / support-context tile
+    that wants ONE string rather than the whole :func:`current_license_info`
+    envelope.
+
+    Returns:
+      * ``None`` when there is nothing trustworthy to surface:
+        no license file on disk, an invalid signature (the payload can't
+        be trusted -- an attacker could stuff any ``sub`` string into an
+        unsigned body and impersonate a real customer), an expired license
+        (a lapsed customer must not keep rendering as the account holder
+        for gating / audit purposes), OR a signed payload whose ``sub``
+        claim is absent / non-string / an empty string after strip.
+      * The stripped subject string otherwise -- the operator-visible
+        identifier bound to the current license.
+
+    Casing is preserved: subjects are typically email addresses / account
+    ids where case can matter for exact-match comparisons, so a UI badge
+    renders the customer-facing form verbatim. :func:`is_subject` handles
+    case-insensitive matching on top for callers that want it.
+
+    Mirrors the "refuse expired keys" posture already used by
+    :func:`license_tier` / :func:`license_nodes`, so a support tile bound
+    to this scalar cannot keep rendering the paid customer on a lapsed
+    install. A caller who wants the CLAIM even on an expired key (support:
+    "who was this key issued to?") should keep reading
+    :func:`current_license_info` directly and pull ``sub`` there.
+
+    Never raises. Any exception under the hood degrades to ``None`` so a
+    dashboard tile bound to this helper never breaks on a partial install.
+    """
+    try:
+        info = current_license_info()
+    except Exception as exc:
+        logger.debug("license: license_subject underlying read failed: %s", exc)
+        return None
+    if not isinstance(info, dict):
+        return None
+    if not info.get("valid"):
+        # invalid-signature and expired branches both collapse to None on
+        # purpose -- see docstring for the support-tile rationale.
+        return None
+    sub = info.get("sub")
+    if not isinstance(sub, str):
+        return None
+    stripped = sub.strip()
+    return stripped or None
+
+
+def is_subject(subject: str) -> bool:
+    """Boolean gate for "is this license issued to subject <X>?" UIs.
+
+    Returns ``True`` iff a license is installed, signature-valid, NOT
+    expired, its ``sub`` claim resolves to a non-empty string, AND that
+    string matches ``subject`` (case-insensitive, whitespace-stripped on
+    both sides). Every other state returns ``False``: no license, invalid
+    signature, expired key, missing/empty ``sub`` claim, or a live
+    subject that simply differs from the request.
+
+    ``subject`` is coerced through ``str()`` and normalised the same way
+    the stored claim is normalised, so a caller can pass ``"acct_test"``,
+    ``"  acct_test "``, or ``"ACCT_TEST"`` and get the same answer.
+    Non-string / empty input collapses to ``False`` (nothing "is subject
+    empty-string"). Never raises; every underlying failure returns
+    ``False`` so a scheduled paywall / audit check never crashes on a
+    bad install.
+
+    Pairs with :func:`license_subject` the way :func:`is_tier` pairs
+    with :func:`license_tier` -- the scalar reports the raw string for a
+    badge tile, this bool answers the yes/no question a multi-tenant
+    dispatcher or a license-transfer detector needs without the caller
+    having to normalise the string themselves.
+    """
+    try:
+        requested = str(subject).strip().lower()
+    except Exception:
+        return False
+    if not requested:
+        return False
+    actual = license_subject()
+    if actual is None:
+        return False
+    return actual.lower() == requested

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -8760,6 +8760,143 @@ def api_license_valid():
         return jsonify({"valid": False, "present": False, "status": None})
 
 
+def _license_subject_snapshot() -> dict:
+    """Shared helper: read once, derive the trio the two subject endpoints
+    both need (``subject``, ``has_license``, ``valid``). Lives in the
+    handler layer -- not in :mod:`clawmetry.license` -- because
+    ``has_license`` is an install-state fact rather than a license-payload
+    fact, and both endpoints below need the pair together so a UI cannot
+    catch them disagreeing on ``has_license`` for the same install.
+
+    Never raises: any underlying failure collapses to
+    ``{subject: None, has_license: False, valid: False}`` so callers keep
+    the "OSS-free" branch shape.
+    """
+    try:
+        from clawmetry import license as _lic
+
+        info = _lic.current_license_info()
+        subject = _lic.license_subject()
+    except Exception as exc:
+        logger.debug("_license_subject_snapshot: underlying read failed: %s", exc)
+        return {"subject": None, "has_license": False, "valid": False}
+    if not isinstance(info, dict):
+        return {"subject": None, "has_license": False, "valid": False}
+    return {
+        "subject": subject,
+        "has_license": True,
+        "valid": bool(info.get("valid")),
+    }
+
+
+@bp_entitlement.route("/api/license/subject")
+def api_license_subject():
+    """``GET /api/license/subject`` -- scalar view of the installed license's
+    ``sub`` claim (the customer identifier -- typically an account id or a
+    contact email), for a "Licensed to <X>" badge / support-context tile
+    that wants ONE string rather than the whole ``/api/license/status``
+    envelope.
+
+    Response shape (always HTTP 200)::
+
+        {
+          "subject": <str|null>,     # customer identifier (None if untrusted)
+          "has_license": <bool>,     # is a license file installed at all?
+          "valid": <bool>            # signature-valid AND not expired
+        }
+
+    ``subject`` mirrors :func:`clawmetry.license.license_subject`: ``None``
+    for no license, invalid signature, or expired install -- an expired
+    Pro key deliberately collapses to ``null`` so a support tile that keys
+    off this field cannot keep rendering the paid customer on a lapsed
+    install. A caller who wants the raw ``sub`` claim even on an expired
+    key (support: "who was this key issued to?") should keep hitting
+    ``/api/license/status``.
+
+    Never 5xxs -- any underlying failure degrades to
+    ``{subject: null, has_license: false, valid: false}`` (the OSS-free
+    branch shape), matching the "never crash on bad input" posture of
+    the surrounding license endpoints.
+    """
+    try:
+        return jsonify(_license_subject_snapshot())
+    except Exception as exc:
+        logger.warning("api_license_subject: error: %s", exc)
+        return jsonify({"subject": None, "has_license": False, "valid": False})
+
+
+@bp_entitlement.route("/api/license/is-subject")
+def api_license_is_subject():
+    """``GET /api/license/is-subject?subject=<value>`` -- boolean gate for
+    "is this license issued to subject <X> right now?" UIs.
+
+    Query parameters:
+      * ``subject`` (str, required) -- the subject to test against.
+        Compared case-insensitively after strip, matching
+        :func:`clawmetry.license.is_subject`. Missing / empty input
+        degrades to ``is_subject=false`` rather than a 4xx, matching the
+        surrounding endpoints' never-5xx / never-4xx posture.
+
+    Response shape (always HTTP 200)::
+
+        {
+          "is_subject": <bool>,
+          "subject": <str|null>,          # currently-active subject claim
+          "requested_subject": <str>,     # normalised echo of the query
+          "has_license": <bool>,
+          "valid": <bool>                 # signature-valid AND not expired
+        }
+
+    ``is_subject`` is ``True`` iff a license is installed, signature-
+    valid, NOT expired, its ``sub`` claim resolves to a non-empty string,
+    AND ``requested_subject`` matches that string case-insensitively. An
+    expired Pro install returns ``is_subject=false`` on purpose -- the
+    caller wants "is this key still bound to <X>?" not "was it ever", and
+    the ``valid`` field carries the "signed but lapsed" signal so a
+    multi-tenant dispatcher can drive both branches off one URL.
+
+    Mirrors :func:`clawmetry.license.is_subject` -- the HTTP shape layers
+    ``subject`` / ``requested_subject`` / ``has_license`` / ``valid`` on
+    top of that bool so an audit widget never needs a second call to
+    ``/api/license/status`` to render the accompanying "Licensed to X"
+    copy.
+    """
+    raw = request.args.get("subject", "") or ""
+    requested = raw.strip()
+    if not requested:
+        snap = _license_subject_snapshot()
+        return jsonify(
+            {
+                "is_subject": False,
+                "subject": snap["subject"],
+                "requested_subject": "",
+                "has_license": snap["has_license"],
+                "valid": snap["valid"],
+            }
+        )
+    try:
+        snap = _license_subject_snapshot()
+    except Exception as exc:
+        logger.warning("api_license_is_subject: error: %s", exc)
+        snap = {"subject": None, "has_license": False, "valid": False}
+    actual = snap["subject"]
+    matches = (
+        snap["has_license"]
+        and snap["valid"]
+        and isinstance(actual, str)
+        and actual.lower() == requested.lower()
+    )
+    return jsonify(
+        {
+            "is_subject": bool(matches),
+            "subject": actual,
+            "requested_subject": requested,
+            "has_license": snap["has_license"],
+            "valid": snap["valid"],
+        }
+    )
+
+
 @bp_entitlement.route("/api/paywall/event", methods=["POST"])
 def api_paywall_event():
     body: dict = {}

--- a/tests/test_license_subject_scalar.py
+++ b/tests/test_license_subject_scalar.py
@@ -1,0 +1,466 @@
+"""Tests for the ``license_subject()`` / ``is_subject()`` scalar helpers in
+:mod:`clawmetry.license` plus their matching ``/api/license/subject`` and
+``/api/license/is-subject`` HTTP endpoints.
+
+Mirrors ``tests/test_license_nodes_scalar.py``'s hermetic pattern --
+ephemeral Ed25519 keypair, ``LICENSE_PATH`` monkeypatched into
+``tmp_path``, and ``CLAWMETRY_OFFLINE=1`` so ``activate()`` never phones
+home during the suite. Nothing here touches the operator's real license
+file.
+"""
+from __future__ import annotations
+
+import time
+from types import SimpleNamespace
+
+import pytest
+from flask import Flask
+
+
+def _keypair():
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+    priv = Ed25519PrivateKey.generate()
+    pub_pem = priv.public_key().public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    return priv, pub_pem
+
+
+def _payload(sub="acct_test", tier="pro", nodes=1, exp_delta=365 * 86400):
+    now = int(time.time())
+    payload = {
+        "sub": sub,
+        "tier": tier,
+        "nodes": nodes,
+        "iat": now,
+        "features": ["runtimes"],
+    }
+    if exp_delta is not None:
+        payload["exp"] = now + exp_delta
+    return payload
+
+
+@pytest.fixture
+def env(monkeypatch, tmp_path):
+    import clawmetry.license as _lic
+
+    priv, pub_pem = _keypair()
+    monkeypatch.setattr(_lic, "_PUBLIC_KEY_PEM", pub_pem)
+    license_path = str(tmp_path / "license.key")
+    monkeypatch.setattr(_lic, "LICENSE_PATH", license_path)
+    monkeypatch.delenv("CLAWMETRY_LICENSE_SERVER", raising=False)
+    monkeypatch.delenv("CLAWMETRY_INGEST_URL", raising=False)
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("CLAWMETRY_OFFLINE", "1")
+
+    from routes.entitlement import bp_entitlement
+
+    flask_app = Flask(__name__)
+    flask_app.register_blueprint(bp_entitlement)
+    flask_app.config["TESTING"] = True
+
+    return SimpleNamespace(
+        app=flask_app, lic=_lic, priv=priv, license_path=license_path
+    )
+
+
+# ── license_subject() ─────────────────────────────────────────────────────────
+
+
+def test_license_subject_none_when_no_license(env):
+    assert env.lic.license_subject() is None
+
+
+def test_license_subject_active_returns_string(env):
+    tok = env.lic._encode_token(_payload(sub="acme@company.com"), env.priv)
+    env.lic.activate(tok)
+    assert env.lic.license_subject() == "acme@company.com"
+
+
+def test_license_subject_preserves_casing(env):
+    # Subjects (emails, account ids) can be case-sensitive for exact-match
+    # display, so the scalar preserves the operator-visible form verbatim.
+    # is_subject() handles case-insensitive matching separately.
+    tok = env.lic._encode_token(_payload(sub="Acct_MixedCase"), env.priv)
+    env.lic.activate(tok)
+    assert env.lic.license_subject() == "Acct_MixedCase"
+
+
+def test_license_subject_strips_whitespace(env):
+    tok = env.lic._encode_token(_payload(sub="  acme@company.com  "), env.priv)
+    env.lic.activate(tok)
+    assert env.lic.license_subject() == "acme@company.com"
+
+
+def test_license_subject_expired_collapses_to_none(env):
+    # A lapsed customer must NOT keep rendering as "Licensed to <X>" via
+    # the scalar helper -- matches the license_tier() / license_nodes()
+    # posture for expired keys.
+    tok = env.lic._encode_token(
+        _payload(sub="acme@company.com", exp_delta=-3600), env.priv
+    )
+    with open(env.license_path, "w", encoding="utf-8") as fh:
+        fh.write(tok + "\n")
+    assert env.lic.license_subject() is None
+
+
+def test_license_subject_invalid_signature_collapses_to_none(env):
+    """An unsigned / forged file must NOT surface a trusted subject."""
+    other_priv, _ = _keypair()
+    tok = env.lic._encode_token(_payload(sub="attacker@evil.com"), other_priv)
+    with open(env.license_path, "w", encoding="utf-8") as fh:
+        fh.write(tok + "\n")
+    assert env.lic.license_subject() is None
+
+
+def test_license_subject_missing_claim_collapses(env):
+    """A signed payload with an empty ``sub`` claim collapses to None (an
+    empty-string identifier is meaningless -- refuse it rather than
+    surface it)."""
+    tok = env.lic._encode_token(_payload(sub=""), env.priv)
+    env.lic.activate(tok)
+    assert env.lic.license_subject() is None
+
+
+def test_license_subject_whitespace_only_claim_collapses(env):
+    tok = env.lic._encode_token(_payload(sub="   "), env.priv)
+    env.lic.activate(tok)
+    assert env.lic.license_subject() is None
+
+
+def test_license_subject_perpetual_key_returns_string(env):
+    # No ``exp`` at all — the perpetual branch of current_license_info
+    # returns valid=True with days_left=None, and the scalar surfaces the
+    # subject just like it does for a normal active key.
+    tok = env.lic._encode_token(_payload(sub="lifetime@company.com", exp_delta=None), env.priv)
+    env.lic.activate(tok)
+    assert env.lic.license_subject() == "lifetime@company.com"
+
+
+def test_license_subject_never_raises_on_broken_read(env, monkeypatch):
+    def _boom():
+        raise RuntimeError("simulated introspection failure")
+
+    monkeypatch.setattr(env.lic, "current_license_info", _boom)
+    # Wrapped in try/except in the helper -> collapses to None.
+    assert env.lic.license_subject() is None
+
+
+# ── is_subject(subject) ───────────────────────────────────────────────────────
+
+
+def test_is_subject_false_when_no_license(env):
+    assert env.lic.is_subject("acme@company.com") is False
+
+
+def test_is_subject_true_on_exact_match(env):
+    tok = env.lic._encode_token(_payload(sub="acme@company.com"), env.priv)
+    env.lic.activate(tok)
+    assert env.lic.is_subject("acme@company.com") is True
+
+
+def test_is_subject_true_case_insensitive(env):
+    tok = env.lic._encode_token(_payload(sub="Acme@Company.com"), env.priv)
+    env.lic.activate(tok)
+    assert env.lic.is_subject("ACME@COMPANY.COM") is True
+    assert env.lic.is_subject("acme@company.com") is True
+
+
+def test_is_subject_strips_whitespace_on_query(env):
+    tok = env.lic._encode_token(_payload(sub="acme@company.com"), env.priv)
+    env.lic.activate(tok)
+    assert env.lic.is_subject("  acme@company.com  ") is True
+
+
+def test_is_subject_false_on_mismatch(env):
+    tok = env.lic._encode_token(_payload(sub="acme@company.com"), env.priv)
+    env.lic.activate(tok)
+    assert env.lic.is_subject("other@company.com") is False
+
+
+def test_is_subject_rejects_empty_and_whitespace(env):
+    tok = env.lic._encode_token(_payload(sub="acme@company.com"), env.priv)
+    env.lic.activate(tok)
+    assert env.lic.is_subject("") is False
+    assert env.lic.is_subject("   ") is False
+
+
+def test_is_subject_rejects_non_string(env):
+    tok = env.lic._encode_token(_payload(sub="acme@company.com"), env.priv)
+    env.lic.activate(tok)
+    assert env.lic.is_subject(None) is False  # type: ignore[arg-type]
+    assert env.lic.is_subject(42) is False  # type: ignore[arg-type]
+
+
+def test_is_subject_expired_key_returns_false(env):
+    tok = env.lic._encode_token(
+        _payload(sub="acme@company.com", exp_delta=-3600), env.priv
+    )
+    with open(env.license_path, "w", encoding="utf-8") as fh:
+        fh.write(tok + "\n")
+    # Even with the exact subject, an expired license refuses the gate.
+    assert env.lic.is_subject("acme@company.com") is False
+
+
+def test_is_subject_invalid_signature_returns_false(env):
+    other_priv, _ = _keypair()
+    tok = env.lic._encode_token(_payload(sub="acme@company.com"), other_priv)
+    with open(env.license_path, "w", encoding="utf-8") as fh:
+        fh.write(tok + "\n")
+    assert env.lic.is_subject("acme@company.com") is False
+
+
+# ── /api/license/subject ──────────────────────────────────────────────────────
+
+
+def test_api_license_subject_no_license(env):
+    with env.app.test_client() as c:
+        resp = c.get("/api/license/subject")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body == {"subject": None, "has_license": False, "valid": False}
+
+
+def test_api_license_subject_active(env):
+    tok = env.lic._encode_token(_payload(sub="acme@company.com"), env.priv)
+    env.lic.activate(tok)
+    with env.app.test_client() as c:
+        resp = c.get("/api/license/subject")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body == {
+        "subject": "acme@company.com",
+        "has_license": True,
+        "valid": True,
+    }
+
+
+def test_api_license_subject_expired(env):
+    tok = env.lic._encode_token(
+        _payload(sub="acme@company.com", exp_delta=-3600), env.priv
+    )
+    with open(env.license_path, "w", encoding="utf-8") as fh:
+        fh.write(tok + "\n")
+    with env.app.test_client() as c:
+        resp = c.get("/api/license/subject")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    # subject collapses to null on the expired branch, but has_license
+    # stays True — the file IS on disk, just no longer trusted for gating.
+    assert body["subject"] is None
+    assert body["has_license"] is True
+    assert body["valid"] is False
+
+
+def test_api_license_subject_invalid_signature(env):
+    other_priv, _ = _keypair()
+    tok = env.lic._encode_token(_payload(sub="attacker@evil.com"), other_priv)
+    with open(env.license_path, "w", encoding="utf-8") as fh:
+        fh.write(tok + "\n")
+    with env.app.test_client() as c:
+        resp = c.get("/api/license/subject")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["subject"] is None
+    assert body["has_license"] is True
+    assert body["valid"] is False
+
+
+def test_api_license_subject_never_5xx(env, monkeypatch):
+    def _boom():
+        raise RuntimeError("simulated introspection failure")
+
+    monkeypatch.setattr(env.lic, "current_license_info", _boom)
+    monkeypatch.setattr(env.lic, "license_subject", _boom)
+    with env.app.test_client() as c:
+        resp = c.get("/api/license/subject")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body == {"subject": None, "has_license": False, "valid": False}
+
+
+# ── /api/license/is-subject ───────────────────────────────────────────────────
+
+
+def test_api_is_subject_no_license(env):
+    with env.app.test_client() as c:
+        resp = c.get("/api/license/is-subject?subject=acme@company.com")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["is_subject"] is False
+    assert body["has_license"] is False
+    assert body["valid"] is False
+    assert body["requested_subject"] == "acme@company.com"
+    assert body["subject"] is None
+
+
+def test_api_is_subject_exact_match(env):
+    tok = env.lic._encode_token(_payload(sub="acme@company.com"), env.priv)
+    env.lic.activate(tok)
+    with env.app.test_client() as c:
+        resp = c.get("/api/license/is-subject?subject=acme@company.com")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["is_subject"] is True
+    assert body["subject"] == "acme@company.com"
+    assert body["requested_subject"] == "acme@company.com"
+    assert body["has_license"] is True
+    assert body["valid"] is True
+
+
+def test_api_is_subject_case_insensitive(env):
+    tok = env.lic._encode_token(_payload(sub="Acme@Company.com"), env.priv)
+    env.lic.activate(tok)
+    with env.app.test_client() as c:
+        resp = c.get("/api/license/is-subject?subject=acme@company.com")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["is_subject"] is True
+    # subject echoes the stored (casing-preserved) form
+    assert body["subject"] == "Acme@Company.com"
+    # requested_subject echoes the query (already stripped)
+    assert body["requested_subject"] == "acme@company.com"
+
+
+def test_api_is_subject_mismatch(env):
+    tok = env.lic._encode_token(_payload(sub="acme@company.com"), env.priv)
+    env.lic.activate(tok)
+    with env.app.test_client() as c:
+        resp = c.get("/api/license/is-subject?subject=other@company.com")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["is_subject"] is False
+    assert body["subject"] == "acme@company.com"
+    assert body["requested_subject"] == "other@company.com"
+    assert body["valid"] is True
+
+
+def test_api_is_subject_empty_query_is_200_with_false(env):
+    tok = env.lic._encode_token(_payload(sub="acme@company.com"), env.priv)
+    env.lic.activate(tok)
+    with env.app.test_client() as c:
+        resp = c.get("/api/license/is-subject?subject=")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["is_subject"] is False
+    assert body["subject"] == "acme@company.com"
+    assert body["requested_subject"] == ""
+
+
+def test_api_is_subject_missing_query_is_200_with_false(env):
+    tok = env.lic._encode_token(_payload(sub="acme@company.com"), env.priv)
+    env.lic.activate(tok)
+    with env.app.test_client() as c:
+        resp = c.get("/api/license/is-subject")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["is_subject"] is False
+    assert body["requested_subject"] == ""
+
+
+def test_api_is_subject_whitespace_query_collapses_to_empty(env):
+    tok = env.lic._encode_token(_payload(sub="acme@company.com"), env.priv)
+    env.lic.activate(tok)
+    with env.app.test_client() as c:
+        resp = c.get("/api/license/is-subject?subject=%20%20%20")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    # Whitespace-only strips to the empty branch, which returns False.
+    assert body["is_subject"] is False
+    assert body["requested_subject"] == ""
+
+
+def test_api_is_subject_strips_whitespace_on_query(env):
+    tok = env.lic._encode_token(_payload(sub="acme@company.com"), env.priv)
+    env.lic.activate(tok)
+    with env.app.test_client() as c:
+        resp = c.get("/api/license/is-subject?subject=%20acme@company.com%20")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["is_subject"] is True
+    assert body["requested_subject"] == "acme@company.com"
+
+
+def test_api_is_subject_expired_returns_false(env):
+    tok = env.lic._encode_token(
+        _payload(sub="acme@company.com", exp_delta=-3600), env.priv
+    )
+    with open(env.license_path, "w", encoding="utf-8") as fh:
+        fh.write(tok + "\n")
+    with env.app.test_client() as c:
+        resp = c.get("/api/license/is-subject?subject=acme@company.com")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["is_subject"] is False
+    assert body["has_license"] is True
+    assert body["valid"] is False
+
+
+def test_api_is_subject_invalid_signature_returns_false(env):
+    other_priv, _ = _keypair()
+    tok = env.lic._encode_token(_payload(sub="acme@company.com"), other_priv)
+    with open(env.license_path, "w", encoding="utf-8") as fh:
+        fh.write(tok + "\n")
+    with env.app.test_client() as c:
+        resp = c.get("/api/license/is-subject?subject=acme@company.com")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["is_subject"] is False
+    assert body["has_license"] is True
+    assert body["valid"] is False
+
+
+def test_api_is_subject_never_5xx(env, monkeypatch):
+    def _boom():
+        raise RuntimeError("simulated introspection failure")
+
+    monkeypatch.setattr(env.lic, "current_license_info", _boom)
+    monkeypatch.setattr(env.lic, "license_subject", _boom)
+    with env.app.test_client() as c:
+        resp = c.get("/api/license/is-subject?subject=acme@company.com")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["is_subject"] is False
+    # snapshot degrades — subject falls through as None
+    assert body["subject"] is None
+
+
+# ── cross-consistency ─────────────────────────────────────────────────────────
+
+
+def test_scalar_matches_envelope_field(env):
+    """The scalar helper and current_license_info()['sub'] should agree on
+    the value for every branch where the scalar returns non-None."""
+    tok = env.lic._encode_token(_payload(sub="acme@company.com"), env.priv)
+    env.lic.activate(tok)
+    info = env.lic.current_license_info()
+    scalar = env.lic.license_subject()
+    # info['sub'] is the raw payload string; scalar is the stripped form.
+    assert scalar == info["sub"].strip()
+
+
+def test_scalar_and_endpoint_agree(env):
+    """The scalar helper and the /api/license/subject endpoint must
+    return the SAME subject for the same install."""
+    tok = env.lic._encode_token(_payload(sub="acme@company.com"), env.priv)
+    env.lic.activate(tok)
+    scalar = env.lic.license_subject()
+    with env.app.test_client() as c:
+        resp = c.get("/api/license/subject")
+    body = resp.get_json()
+    assert body["subject"] == scalar
+
+
+def test_is_subject_and_endpoint_agree(env):
+    """The is_subject() bool and the /api/license/is-subject endpoint
+    must return the SAME verdict for the same query on the same install."""
+    tok = env.lic._encode_token(_payload(sub="acme@company.com"), env.priv)
+    env.lic.activate(tok)
+    scalar = env.lic.is_subject("ACME@company.com")
+    with env.app.test_client() as c:
+        resp = c.get("/api/license/is-subject?subject=ACME@company.com")
+    body = resp.get_json()
+    assert body["is_subject"] == scalar


### PR DESCRIPTION
## Summary

Adds a subject-axis pair of install-state scalars on `clawmetry/license.py` plus matching endpoints in `routes/entitlement.py`, following the same pattern already used for `license_tier`/`is_tier` and `license_nodes`/`is_within_node_limit`:

- **`license_subject() -> str | None`** — stripped `sub` claim from the installed license; `None` on no file, invalid signature, expired key, or missing/empty claim. Matches the `license_tier` / `license_nodes` posture: a lapsed customer must not keep rendering as the account holder for gating / audit purposes. The raw operator-visible casing is preserved for badge display; `is_subject` handles case-insensitive matching separately.
- **`is_subject(subject: str) -> bool`** — exact-match gate (case-insensitive, whitespace-stripped on both sides) that answers "is this license issued to `<X>` right now?" for a multi-tenant dispatcher / license-transfer detector without the caller having to normalise the claim themselves.

### HTTP surface

- `GET /api/license/subject` → `{subject, has_license, valid}`
- `GET /api/license/is-subject?subject=<value>` → `{is_subject, subject, requested_subject, has_license, valid}`

Shared `_license_subject_snapshot()` helper reads `current_license_info()` + `license_subject()` once so the paired endpoints can't disagree on `has_license` / `valid` for the same install — a UI binding both sees a consistent snapshot. Both endpoints never 5xx — on any underlying failure they degrade to `{subject: null, has_license: false, valid: false}` (the OSS-free branch shape), matching the never-crash posture of the surrounding license routes.

### Grace mode

Ships in **GRACE** — no enforcement, no behaviour change. Purely observational scalars a support tile / multi-tenant dispatcher can bind to without pulling the whole `/api/license/status` envelope.

### Tests

38 new unit + endpoint tests in `tests/test_license_subject_scalar.py` cover:

- No-license, active, expired, invalid-signature, perpetual, empty-claim, whitespace-only-claim, casing-preservation, whitespace-strip, never-raises branches on `license_subject()`
- Exact-match, case-insensitive, whitespace-strip, mismatch, empty, non-string, expired, invalid-signature branches on `is_subject()`
- Same coverage on both `/api/license/subject` and `/api/license/is-subject`, plus never-5xx on introspection failure
- Cross-consistency: scalar ↔ endpoint agreement, `is_subject()` ↔ endpoint verdict agreement, scalar matches `current_license_info()['sub'].strip()`

All hermetic — ephemeral Ed25519 keypair + `tmp_path` license file + `CLAWMETRY_OFFLINE=1`; no network, no operator-state mutation. Existing `test_license_*` (174 tests) and `test_entitlement_api*` (39 tests) still pass.

## Files changed

- `clawmetry/license.py` — +87 lines (two new helpers appended after `is_within_node_limit()`)
- `routes/entitlement.py` — +138 lines (shared `_license_subject_snapshot()` helper + two new route handlers inserted after `/api/license/within-node-limit`, grouped with the other `/api/license/*` endpoints)
- `tests/test_license_subject_scalar.py` — +466 lines (new file)

## Test plan

- [x] `python3 -m py_compile clawmetry/license.py routes/entitlement.py tests/test_license_subject_scalar.py` — clean
- [x] `ruff check clawmetry/license.py routes/entitlement.py tests/test_license_subject_scalar.py` — clean
- [x] `python3 -m pytest tests/test_license_subject_scalar.py -q` — 38 passed
- [x] `python3 -m pytest tests/test_license_{api,tier_scalar,nodes_scalar,days_until_expiry,is_expired_is_perpetual,pro_installation}.py -q` — 174 passed (no regressions on adjacent license suites)
- [x] `python3 -m pytest tests/test_entitlement_api.py tests/test_entitlement_api_fallback_shape.py -q` — 39 passed (no regressions on entitlement handler tests)

## Local operator verification checklist

Because the autonomous fire can't touch the running daemon or the live cloud snapshot:

- [ ] Rebuild wheel or copy the changed files into `~/.clawmetry/lib/pythonX.Y/site-packages/clawmetry/` and `.../site-packages/routes/`.
- [ ] Clear `__pycache__` under both directories (`find ~/.clawmetry/lib -name __pycache__ -exec rm -rf {} +`).
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` (macOS) or the equivalent `systemctl --user restart` on Linux.
- [ ] Confirm `GET /api/license/subject` returns `{"subject": null, "has_license": false, "valid": false}` on a Free install.
- [ ] Confirm `GET /api/license/is-subject?subject=anything` returns `{"is_subject": false, ...}` on a Free install.
- [ ] After `clawmetry activate <KEY>` (with a key whose `sub` is e.g. `acme@company.com`), confirm `GET /api/license/subject` returns `{"subject": "acme@company.com", "has_license": true, "valid": true}`.
- [ ] Confirm `GET /api/license/is-subject?subject=ACME@COMPANY.COM` returns `{"is_subject": true, "subject": "acme@company.com", "requested_subject": "ACME@COMPANY.COM", ...}` (case-insensitive match).
- [ ] Confirm `GET /api/license/is-subject?subject=other@company.com` returns `{"is_subject": false, "subject": "acme@company.com", ...}`.
- [ ] Decrypt the live cloud snapshot and confirm the endpoints work through the cloud relay too.
- [ ] Browser-check any support / "Licensed to <X>" tiles bound to these URLs (dashboard hits `/api/license/status` today; the new scalars are opt-in).

## Notes

- No `__version__` bump, no tag, no `[RELEASE]` PR — the operator drives the release loop.
- No enforcement gate changes; both endpoints are read-only observational scalars.
- No new dependencies — uses `cryptography` (already required) and `flask` (already required).
- Complements open PR #4113 (`has_license` / `is_license_valid` install-state scalars) and the merged `license_nodes` / `is_within_node_limit` node-capacity scalars — this PR is subject-identity axis; those cover presence-validity axis and node-capacity axis respectively. They don't touch the same functions.

---
_Generated by [Claude Code](https://claude.ai/code/session_012puM27TirGfdWKgLBfWvTw)_