### PR TITLE
fix(windows): Claude Code discovery, portable system metrics, runtime-aware setup

### DIFF
--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -108,8 +108,16 @@ def _maybe_apply_nemoclaw_preset(_input, BOLD, CYAN, DIM) -> None:
         return
 
     print()
-    result = subprocess.run(["bash", script_path], check=False)
-    if result.returncode == 0:
+    # The preset helper is a .sh script. Windows has no bash on PATH by
+    # default, and Popen raises FileNotFoundError rather than returning a
+    # non-zero code, which would abort onboarding instead of falling through
+    # to the "run this manually" hint below.
+    try:
+        result = subprocess.run(["bash", script_path], check=False)
+    except (FileNotFoundError, OSError):
+        print(f"  {DIM('bash was not found on PATH.')}")
+        result = None
+    if result is not None and result.returncode == 0:
         print()
         return
 
@@ -1374,8 +1382,16 @@ def _start_subprocess() -> None:
     import subprocess
     import shutil
 
+    import os as _os
+
     sync_script = str(__import__("pathlib").Path(__file__).parent / "sync.py")
-    log_file = str(__import__("pathlib").Path.home() / ".clawmetry" / "sync.log")
+    log_path = __import__("pathlib").Path.home() / ".clawmetry" / "sync.log"
+    # A fresh install may not have ~/.clawmetry yet; open(..., "a") would raise.
+    try:
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+    except Exception:
+        pass
+    log_file = str(log_path)
 
     # Use setsid if available — ensures daemon survives kubectl exec session end
     cmd = (
@@ -1383,14 +1399,32 @@ def _start_subprocess() -> None:
         if shutil.which("setsid")
         else [sys.executable, sync_script]
     )
-    proc = subprocess.Popen(
-        cmd,
-        stdout=open(log_file, "a"),
-        stderr=subprocess.STDOUT,
-        stdin=subprocess.DEVNULL,
-        start_new_session=True,
-        close_fds=True,
-    )
+
+    spawn_kwargs = {"stdin": subprocess.DEVNULL, "close_fds": True}
+    if _os.name == "nt":
+        # start_new_session is POSIX-only and silently no-ops on Windows, which
+        # left the daemon inside the launching console's process group: closing
+        # that window delivered CTRL_CLOSE_EVENT and killed the daemon with it.
+        # DETACHED_PROCESS cuts it loose from the console, and a new process
+        # group stops Ctrl+C in the parent terminal from propagating.
+        spawn_kwargs["creationflags"] = (
+            subprocess.DETACHED_PROCESS | subprocess.CREATE_NEW_PROCESS_GROUP
+        )
+    else:
+        spawn_kwargs["start_new_session"] = True
+
+    # The child inherits a duplicate of this handle, so closing ours right
+    # after the spawn is correct and avoids leaking it for the CLI's lifetime.
+    log_fh = open(log_file, "a")
+    try:
+        proc = subprocess.Popen(
+            cmd, stdout=log_fh, stderr=subprocess.STDOUT, **spawn_kwargs
+        )
+    finally:
+        try:
+            log_fh.close()
+        except Exception:
+            pass
     print(f"✅  Sync daemon started (pid {proc.pid})")
 
 

--- a/clawmetry/static/js/gw-setup.js
+++ b/clawmetry/static/js/gw-setup.js
@@ -42,11 +42,134 @@ async function checkGwConfig() {
       // open cloud modal — the two share the same backdrop and confuse the
       // user. Defer until the cloud modal closes.
       if (_isCloudModalOpen()) return;
+      await _gwApplyRuntimeDetection();
       document.getElementById('gw-setup-overlay').style.display = 'flex';
     } else {
       updateGwStatus(true, d.url);
     }
   } catch(e) {}
+}
+
+// ── Runtime-aware setup ────────────────────────────────────────────────
+// ClawMetry watches 14 runtimes but this wizard used to demand an OpenClaw
+// gateway token unconditionally. On a machine running only Claude Code that
+// is a dead end: the user has no gateway, no token, and no way past the
+// modal. Worse on Windows, where the "how to find your token" hint printed a
+// POSIX pipeline that cannot run there. Detection now decides what this step
+// asks for. The backend already existed at
+// /api/entitlement/runtime-detection; nothing was consuming it.
+
+function _gwIsWindows() {
+  try {
+    var p = (navigator.userAgentData && navigator.userAgentData.platform) || navigator.platform || '';
+    if (/win/i.test(p)) return true;
+    return /Windows/i.test(navigator.userAgent || '');
+  } catch (e) { return false; }
+}
+
+function gwShowOpenClawBlock() {
+  var b = document.getElementById('gw-openclaw-block');
+  var t = document.getElementById('gw-openclaw-toggle');
+  if (b) b.style.display = '';
+  if (t) t.style.display = 'none';
+}
+
+function _gwRuntimeRow(p) {
+  var badge = !p.allowed
+    ? '<span style="font-size:10px; padding:2px 7px; border-radius:99px; background:rgba(255,180,0,0.14); color:#ffb400; white-space:nowrap;">needs ' + (p.required_tier_label || 'an upgrade') + '</span>'
+    : '<span style="font-size:10px; padding:2px 7px; border-radius:99px; background:rgba(74,222,128,0.14); color:#4ade80; white-space:nowrap;">watching</span>';
+  return '' +
+    '<div style="display:flex; align-items:center; justify-content:space-between; gap:12px; padding:9px 12px; margin-bottom:6px; border:1px solid var(--border-primary,#333); border-radius:8px; background:var(--bg-primary,#111);">' +
+      '<span style="display:flex; align-items:center; gap:8px; min-width:0;">' +
+        '<span style="color:#4ade80; font-size:13px;">&#10003;</span>' +
+        '<span style="color:var(--text-primary,#fff); font-size:13px; font-weight:600; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;">' + (p.label || p.id) + '</span>' +
+      '</span>' + badge +
+    '</div>';
+}
+
+async function _gwApplyRuntimeDetection() {
+  var sub = document.getElementById('gw-setup-sub');
+  var block = document.getElementById('gw-detected-block');
+  var list = document.getElementById('gw-detected-list');
+  var cta = document.getElementById('gw-detected-cta');
+  var ocBlock = document.getElementById('gw-openclaw-block');
+  var ocToggle = document.getElementById('gw-openclaw-toggle');
+  var overlay = document.getElementById('gw-setup-overlay');
+  var closeBtn = document.getElementById('gw-setup-close');
+
+  // Windows has no `cat`, so swap the token hint for a PowerShell one.
+  if (_gwIsWindows()) {
+    var hint = document.getElementById('gw-hint-local');
+    if (hint) {
+      hint.textContent =
+        '(Get-Content ~/.openclaw/openclaw.json | ConvertFrom-Json).gateway.auth.token';
+    }
+  }
+
+  var det = null;
+  try {
+    var r = await fetch('/api/entitlement/runtime-detection');
+    det = await r.json();
+  } catch (e) { return; }
+  if (!det || !det.probes) return;
+
+  var found = det.probes.filter(function (p) { return p.found; });
+  var selfHosted = det.probes.filter(function (p) {
+    return (p.id === 'openclaw' || p.id === 'nemoclaw') && p.found;
+  });
+
+  // OpenClaw is here: the token step is the right ask, so keep it as-is.
+  if (selfHosted.length) return;
+
+  // No OpenClaw on this machine. The token form must not be the mandatory
+  // first step, and the modal must be dismissible.
+  if (ocBlock) ocBlock.style.display = 'none';
+  if (ocToggle) ocToggle.style.display = '';
+  if (overlay) overlay.dataset.mandatory = 'false';
+  if (closeBtn) closeBtn.style.display = '';
+
+  if (!found.length) {
+    // Nothing detected. Stay runtime neutral rather than naming one runtime
+    // the user may never have heard of.
+    if (sub) sub.textContent = 'No AI agent runtimes found on this machine yet. Start one and ClawMetry picks it up automatically.';
+    return;
+  }
+
+  var names = found.map(function (p) { return p.label; });
+  if (sub) {
+    sub.textContent = names.length === 1
+      ? 'ClawMetry found ' + names[0] + ' on this machine.'
+      : 'ClawMetry found ' + names.length + ' agent runtimes on this machine.';
+  }
+  if (list) list.innerHTML = found.map(_gwRuntimeRow).join('');
+  if (block) block.style.display = '';
+
+  var locked = found.filter(function (p) { return !p.allowed; });
+  if (cta) {
+    if (locked.length) {
+      var tier = det.actionable_tier_label || 'Starter';
+      cta.innerHTML =
+        '<p style="color:var(--text-muted,#888); font-size:12px; margin:0 0 10px; text-align:left; line-height:1.5;">' +
+          'Watching ' + locked.map(function (p) { return p.label; }).join(', ') +
+          ' is part of ' + tier + '. Start a free trial to turn it on now.' +
+        '</p>' +
+        '<button id="gw-trial-btn" onclick="gwStartTrial()" style="width:100%; padding:12px; border:none; border-radius:8px; background:var(--bg-accent,#0f6fff); color:#fff; font-size:15px; font-weight:600; cursor:pointer; font-family:Manrope,sans-serif;">Start free trial</button>';
+    } else {
+      cta.innerHTML =
+        '<p style="color:var(--text-muted,#888); font-size:12px; margin:0; text-align:left;">' +
+          'These are watched on your current plan. Data appears as your agents run.' +
+        '</p>';
+    }
+  }
+}
+
+// Placeholder until the local-trial endpoint lands (task: local trial).
+// Falls back to the existing cloud sign-up path so the button is never dead.
+function gwStartTrial() {
+  if (typeof openCloudModal === 'function') {
+    document.getElementById('gw-setup-overlay').style.display = 'none';
+    openCloudModal();
+  }
 }
 
 function _isCloudModalOpen() {

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -14833,7 +14833,13 @@ def _build_tool_stats():
         _session_channels = {}
         _sessions_json = os.path.join(session_dir, "sessions.json")
         try:
-            with open(_sessions_json) as _sjf:
+            # encoding is explicit: text-mode open() without it uses the
+            # locale codec, which is cp1252 on Windows. sessions.json carries
+            # user-authored session titles (emoji are routine), so the default
+            # raised UnicodeDecodeError there and this whole channel-info
+            # preload was skipped. The sibling JSONL readers avoid it by
+            # opening "rb"; this one is text.
+            with open(_sessions_json, encoding="utf-8") as _sjf:
                 _sj = json.load(_sjf)
             for _sk, _sv in _sj.items():
                 _sf = os.path.basename(_sv.get("sessionFile", ""))

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -3900,12 +3900,23 @@ def _encode_cwd_for_claude_projects(cwd: str) -> str:
     """Reproduce Claude Code's project-dir naming convention.
 
     Claude Code derives the ``~/.claude/projects/<dir>`` slug by replacing
-    both ``/`` and ``.`` with ``-`` in the agent's CWD. So
+    every path-structural character in the agent's CWD with ``-``. So
     ``/Users/vivek/.openclaw/workspace`` → ``-Users-vivek--openclaw-workspace``
     (the leading ``-`` comes from the absolute path's leading ``/``; the
     consecutive ``--`` comes from ``/.`` collapsing).
+
+    Windows paths use ``\\`` as the separator and carry a drive-letter
+    ``:``; both collapse to ``-`` the same way, so ``C:\\Users\\Vivek`` →
+    ``C--Users-Vivek``. Handling only ``/`` and ``.`` (the pre-2026-07
+    behaviour) left every Windows install constructing a path that can
+    never exist on disk, so Claude Code sessions silently never synced
+    there — the caller's ``~/.claude/projects/*`` scan fallback was doing
+    all the work, and it only fires when a session id is already known.
     """
-    return (cwd or "").replace("/", "-").replace(".", "-")
+    out = cwd or ""
+    for _ch in ("/", "\\", ":", "."):
+        out = out.replace(_ch, "-")
+    return out
 
 
 def _looks_like_openclaw_process(proc) -> bool:

--- a/dashboard.py
+++ b/dashboard.py
@@ -17861,7 +17861,17 @@ Examples:
 Docs: https://docs.clawmetry.com
 """
 
-PID_FILE = "/tmp/clawmetry.pid"
+# Windows has no /tmp, so the literal path resolved to C:\tmp and every read
+# failed into the bare except below — _read_pid() always returned None, which
+# is what silently disabled the stale-instance reclaim at startup (two dev
+# servers could then bind the same port and requests would land on whichever
+# Windows picked). tempfile.gettempdir() honours %TEMP% there; POSIX keeps the
+# exact path it has always used so existing pid files stay discoverable.
+PID_FILE = (
+    os.path.join(_tempfile.gettempdir(), "clawmetry.pid")
+    if os.name == "nt"
+    else "/tmp/clawmetry.pid"
+)
 LAUNCHD_LABEL = "com.clawmetry.dashboard"
 LAUNCHD_PLIST = os.path.expanduser(f"~/Library/LaunchAgents/{LAUNCHD_LABEL}.plist")
 SYSTEMD_SERVICE = os.path.expanduser(

--- a/dashboard.py
+++ b/dashboard.py
@@ -12474,13 +12474,26 @@ DASHBOARD_HTML = r"""
     <button id="gw-setup-close" onclick="document.getElementById('gw-setup-overlay').style.display='none'" style="display:none; position:absolute; top:12px; right:16px; background:none; border:none; color:var(--text-muted, #888); font-size:22px; cursor:pointer; padding:4px 8px; line-height:1;">✕</button>
     <img src="/static/img/logo.svg" style="width:64px;height:64px;margin-bottom:16px;display:block;margin-left:auto;margin-right:auto;" alt="ClawMetry">
     <h2 style="color:var(--text-primary, #fff); margin:0 0 8px; font-size:24px; font-weight:700;">ClawMetry Setup</h2>
-    <p style="color:var(--text-muted, #888); margin:0 0 24px; font-size:14px;">Enter your OpenClaw gateway token to connect.</p>
-    <input id="gw-token-input" type="password" placeholder="Paste your gateway token" 
+    <p id="gw-setup-sub" style="color:var(--text-muted, #888); margin:0 0 24px; font-size:14px;">Looking for AI agents on this machine.</p>
+
+    <!-- Runtime detection panel. Populated by gw-setup.js from
+         /api/entitlement/runtime-detection. ClawMetry watches 14 runtimes,
+         so the setup step must not assume OpenClaw: a machine running only
+         Claude Code used to get an OpenClaw token wall it could never
+         satisfy (and a POSIX shell command on Windows). -->
+    <div id="gw-detected-block" style="display:none; text-align:left; margin:0 0 20px;">
+      <div style="font-weight:600; color:var(--text-secondary, #aaa); font-size:12px; text-transform:uppercase; letter-spacing:0.04em; margin:0 0 10px;">Found on this machine</div>
+      <div id="gw-detected-list"></div>
+      <div id="gw-detected-cta" style="margin-top:16px;"></div>
+    </div>
+
+    <div id="gw-openclaw-block">
+    <input id="gw-token-input" type="password" placeholder="Paste your gateway token"
       style="width:100%; padding:12px 16px; border:1px solid var(--border-primary, #444); border-radius:8px; background:var(--bg-primary, #111); color:var(--text-primary, #fff); font-size:14px; font-family:monospace; box-sizing:border-box; outline:none; margin-bottom:8px;"
       onkeydown="if(event.key==='Enter')gwSetupConnect()">
     <div id="gw-setup-hint" style="color:var(--text-muted, #888); font-size:12px; margin:0 0 4px; text-align:left;">
       <div style="font-weight:600;color:var(--text-secondary, #aaa);margin:6px 0 4px;">Local install (pip / brew / install.sh)</div>
-      <code style="display:block;color:var(--text-accent, #0af); background:rgba(0,170,255,0.1); padding:6px 8px; border-radius:4px; font-size:11px; word-break:break-all;">cat ~/.openclaw/openclaw.json | python3 -c "import json,sys;print(json.load(sys.stdin)['gateway']['auth']['token'])"</code>
+      <code id="gw-hint-local" style="display:block;color:var(--text-accent, #0af); background:rgba(0,170,255,0.1); padding:6px 8px; border-radius:4px; font-size:11px; word-break:break-all;">cat ~/.openclaw/openclaw.json | python3 -c "import json,sys;print(json.load(sys.stdin)['gateway']['auth']['token'])"</code>
       <div style="font-weight:600;color:var(--text-secondary, #aaa);margin:8px 0 4px;">Docker install</div>
       <code style="display:block;color:var(--text-accent, #0af); background:rgba(0,170,255,0.1); padding:6px 8px; border-radius:4px; font-size:11px; word-break:break-all;">docker exec $(docker ps -q) env | grep TOKEN</code>
       <div style="font-weight:600;color:var(--text-secondary, #aaa);margin:8px 0 4px;">Remote / Docker / reverse-proxy</div>
@@ -12494,6 +12507,14 @@ DASHBOARD_HTML = r"""
       Connect
     </button>
     <p style="color:var(--text-faint, #555); font-size:11px; margin:16px 0 0;">Token is stored locally on this ClawMetry instance.</p>
+    </div><!-- /gw-openclaw-block -->
+
+    <!-- Shown instead of the token form when OpenClaw is not on this
+         machine. Keeps the gateway path one click away without making it
+         the mandatory first step. -->
+    <div id="gw-openclaw-toggle" style="display:none; margin-top:4px;">
+      <a href="#" onclick="gwShowOpenClawBlock();return false;" style="color:var(--text-muted, #888); font-size:12px; text-decoration:underline; cursor:pointer;">I run an OpenClaw gateway, let me paste a token</a>
+    </div>
   </div>
 </div>
 

--- a/helpers/hardware.py
+++ b/helpers/hardware.py
@@ -80,6 +80,18 @@ def _detect_host_hardware():
                         break
             except Exception:
                 pass
+            # `wmic` is deprecated and is ABSENT from Windows 11 24H2+, where
+            # the calls above raise FileNotFoundError and leave cpu/ram unknown.
+            # helpers.system reads the registry / GlobalMemoryStatusEx instead,
+            # which needs no external binary. Kept as a fallback rather than a
+            # replacement so older hosts kept their existing behaviour.
+            try:
+                if not cpu or cpu == "Unknown CPU":
+                    from helpers.system import cpu_model as _cpu_model
+
+                    cpu = _cpu_model() or cpu
+            except Exception:
+                pass
             try:
                 mem = _sp.run(
                     ["wmic", "computersystem", "get", "TotalPhysicalMemory", "/value"],
@@ -89,6 +101,15 @@ def _detect_host_hardware():
                     if line.startswith("TotalPhysicalMemory="):
                         ram_gb = round(int(line.split("=", 1)[1].strip()) / (1024 ** 3))
                         break
+            except Exception:
+                pass
+            try:
+                if not ram_gb:
+                    from helpers.system import memory_usage as _mem
+
+                    _mu = _mem()
+                    if _mu:
+                        ram_gb = round(_mu["total_mb"] / 1024)
             except Exception:
                 pass
     except Exception:

--- a/helpers/system.py
+++ b/helpers/system.py
@@ -18,6 +18,7 @@ the legacy `uptime -p` output the dashboard JS expects.
 
 from __future__ import annotations
 
+import ctypes
 import os
 import re
 import subprocess
@@ -124,3 +125,276 @@ def format_uptime(seconds: int | None) -> str:
 def uptime_pretty() -> str:
     """Convenience: portable replacement for `subprocess.run(['uptime', '-p'])`."""
     return format_uptime(uptime_seconds())
+
+
+# ── Disk / memory / CPU ─────────────────────────────────────────────────
+#
+# The legacy callers shelled out to `df -h /`, `free -h` and read
+# /proc/loadavg directly. None of those exist on Windows, and because every
+# call site wraps them in a bare `except`, Windows didn't error — it just
+# rendered "--" for Disk, RAM and Load on the main dashboard and dropped the
+# CPU/Load rows from the machine panel entirely. Same class of bug as #1127
+# (`uptime -p` on macOS), so the fix lives in the same module.
+#
+# Everything below is stdlib-only (psutil is used when present but is NOT a
+# dependency) and returns None rather than raising, so callers keep their
+# existing graceful-fallback shape.
+
+
+def _system_root() -> str:
+    """Root path to measure for "disk used" — ``/`` on POSIX, the system
+    drive (usually ``C:\\``) on Windows."""
+    if os.name == "nt":
+        return os.environ.get("SystemDrive", "C:") + "\\"
+    return "/"
+
+
+def disk_usage(path: str | None = None) -> dict | None:
+    """Portable replacement for parsing ``df -h /``.
+
+    Returns ``{"mount", "total_gb", "used_gb", "free_gb", "pct"}`` or None.
+    ``shutil.disk_usage`` wraps GetDiskFreeSpaceEx / statvfs, so this is
+    accurate on all three platforms without a subprocess.
+    """
+    import shutil
+
+    target = path or _system_root()
+    try:
+        total, used, free = shutil.disk_usage(target)
+    except Exception:
+        return None
+    if not total:
+        return None
+    return {
+        "mount": target,
+        "total_gb": round(total / (1024 ** 3), 1),
+        "used_gb": round(used / (1024 ** 3), 1),
+        "free_gb": round(free / (1024 ** 3), 1),
+        "pct": round(used * 100.0 / total, 1),
+    }
+
+
+class _MEMORYSTATUSEX(ctypes.Structure):
+    """Win32 MEMORYSTATUSEX — ctypes is stdlib on every platform, so the
+    struct definition is harmless where it is never instantiated."""
+
+    _fields_ = [
+        ("dwLength", ctypes.c_ulong),
+        ("dwMemoryLoad", ctypes.c_ulong),
+        ("ullTotalPhys", ctypes.c_ulonglong),
+        ("ullAvailPhys", ctypes.c_ulonglong),
+        ("ullTotalPageFile", ctypes.c_ulonglong),
+        ("ullAvailPageFile", ctypes.c_ulonglong),
+        ("ullTotalVirtual", ctypes.c_ulonglong),
+        ("ullAvailVirtual", ctypes.c_ulonglong),
+        ("ullAvailExtendedVirtual", ctypes.c_ulonglong),
+    ]
+
+
+def memory_usage() -> dict | None:
+    """Portable replacement for parsing ``free -h`` / ``free -m``.
+
+    Returns ``{"total_mb", "used_mb", "available_mb", "pct"}`` or None.
+    """
+    # 1. psutil when available — most accurate everywhere.
+    try:
+        import psutil  # type: ignore
+
+        vm = psutil.virtual_memory()
+        return {
+            "total_mb": int(vm.total / (1024 ** 2)),
+            "used_mb": int((vm.total - vm.available) / (1024 ** 2)),
+            "available_mb": int(vm.available / (1024 ** 2)),
+            "pct": round(vm.percent, 1),
+        }
+    except Exception:
+        pass
+
+    # 2. Windows: GlobalMemoryStatusEx via ctypes.
+    if os.name == "nt":
+        try:
+            stat = _MEMORYSTATUSEX()
+            stat.dwLength = ctypes.sizeof(_MEMORYSTATUSEX)
+            if ctypes.windll.kernel32.GlobalMemoryStatusEx(ctypes.byref(stat)):  # type: ignore[attr-defined]
+                total = int(stat.ullTotalPhys)
+                avail = int(stat.ullAvailPhys)
+                return {
+                    "total_mb": int(total / (1024 ** 2)),
+                    "used_mb": int((total - avail) / (1024 ** 2)),
+                    "available_mb": int(avail / (1024 ** 2)),
+                    "pct": round((total - avail) * 100.0 / total, 1) if total else 0.0,
+                }
+        except Exception:
+            pass
+
+    # 3. Linux: /proc/meminfo. Prefer MemAvailable (kernel's own estimate of
+    #    reclaimable memory) over MemFree, which understates by page cache.
+    if sys.platform.startswith("linux"):
+        try:
+            info = {}
+            with open("/proc/meminfo") as f:
+                for line in f:
+                    k, _, rest = line.partition(":")
+                    parts = rest.split()
+                    if parts:
+                        info[k] = int(parts[0])  # kB
+            total_kb = info.get("MemTotal", 0)
+            avail_kb = info.get("MemAvailable", info.get("MemFree", 0))
+            if total_kb:
+                return {
+                    "total_mb": int(total_kb / 1024),
+                    "used_mb": int((total_kb - avail_kb) / 1024),
+                    "available_mb": int(avail_kb / 1024),
+                    "pct": round((total_kb - avail_kb) * 100.0 / total_kb, 1),
+                }
+        except Exception:
+            pass
+
+    # 4. macOS / BSD: hw.memsize for the total; vm_stat for the free pages.
+    if sys.platform == "darwin" or "bsd" in sys.platform:
+        try:
+            total = int(
+                subprocess.run(
+                    ["sysctl", "-n", "hw.memsize"],
+                    capture_output=True, text=True, timeout=2,
+                ).stdout.strip()
+            )
+            free_bytes = 0
+            vm = subprocess.run(
+                ["vm_stat"], capture_output=True, text=True, timeout=2
+            ).stdout
+            page = 4096
+            m = re.search(r"page size of (\d+) bytes", vm)
+            if m:
+                page = int(m.group(1))
+            for key in ("Pages free", "Pages inactive", "Pages speculative"):
+                m = re.search(rf"{key}:\s+(\d+)", vm)
+                if m:
+                    free_bytes += int(m.group(1)) * page
+            if total:
+                return {
+                    "total_mb": int(total / (1024 ** 2)),
+                    "used_mb": int((total - free_bytes) / (1024 ** 2)),
+                    "available_mb": int(free_bytes / (1024 ** 2)),
+                    "pct": round((total - free_bytes) * 100.0 / total, 1),
+                }
+        except Exception:
+            pass
+
+    return None
+
+
+def load_average() -> tuple | None:
+    """1/5/15-minute load averages, or None where the OS has no such concept.
+
+    Windows genuinely has no load-average equivalent — callers should fall
+    back to :func:`cpu_percent` rather than rendering a fake number.
+    """
+    try:
+        return os.getloadavg()  # type: ignore[attr-defined]
+    except (AttributeError, OSError):
+        return None
+
+
+# Previous CPU-time sample, so cpu_percent() can compute a delta without
+# blocking. /api/overview is on the dashboard's hot path (fires on every
+# refresh), so sleeping ~100ms for a sample window is not acceptable here.
+_cpu_prev: tuple[float, float] | None = None
+
+
+def cpu_percent() -> float | None:
+    """System-wide CPU utilisation since the previous call, or None.
+
+    Non-blocking by design: the first call primes the sample and returns
+    None, and every subsequent call reports utilisation over the interval
+    since the last one. The dashboard polls on a timer, so the value
+    populates on the second refresh.
+    """
+    global _cpu_prev
+
+    busy = idle = None
+
+    if os.name == "nt":
+        try:
+            idle_t = ctypes.c_ulonglong()
+            kern_t = ctypes.c_ulonglong()
+            user_t = ctypes.c_ulonglong()
+            if ctypes.windll.kernel32.GetSystemTimes(  # type: ignore[attr-defined]
+                ctypes.byref(idle_t), ctypes.byref(kern_t), ctypes.byref(user_t)
+            ):
+                # kernel time already includes idle time.
+                idle = float(idle_t.value)
+                busy = float(kern_t.value) + float(user_t.value) - idle
+        except Exception:
+            return None
+    elif sys.platform.startswith("linux"):
+        try:
+            with open("/proc/stat") as f:
+                parts = [float(x) for x in f.readline().split()[1:]]
+            # user nice system idle iowait irq softirq steal ...
+            idle = parts[3] + (parts[4] if len(parts) > 4 else 0.0)
+            busy = sum(parts) - idle
+        except Exception:
+            return None
+    else:
+        try:
+            import psutil  # type: ignore
+
+            return float(psutil.cpu_percent(interval=None))
+        except Exception:
+            return None
+
+    if busy is None or idle is None:
+        return None
+
+    prev = _cpu_prev
+    _cpu_prev = (busy, idle)
+    if prev is None:
+        return None
+    d_busy = busy - prev[0]
+    d_idle = idle - prev[1]
+    total = d_busy + d_idle
+    if total <= 0:
+        return None
+    return round(max(0.0, min(100.0, d_busy * 100.0 / total)), 1)
+
+
+def cpu_model() -> str | None:
+    """Human-readable CPU model name, or None."""
+    if sys.platform.startswith("linux"):
+        try:
+            with open("/proc/cpuinfo") as f:
+                for line in f:
+                    if line.lower().startswith("model name"):
+                        return line.split(":", 1)[1].strip()
+        except Exception:
+            pass
+    elif sys.platform == "darwin":
+        try:
+            out = subprocess.run(
+                ["sysctl", "-n", "machdep.cpu.brand_string"],
+                capture_output=True, text=True, timeout=2,
+            ).stdout.strip()
+            if out:
+                return out
+        except Exception:
+            pass
+    elif os.name == "nt":
+        # Registry, not `wmic` — wmic is deprecated and is absent from
+        # Windows 11 24H2+, where shelling out to it fails outright.
+        try:
+            import winreg  # type: ignore
+
+            with winreg.OpenKey(
+                winreg.HKEY_LOCAL_MACHINE,
+                r"HARDWARE\DESCRIPTION\System\CentralProcessor\0",
+            ) as k:
+                val = winreg.QueryValueEx(k, "ProcessorNameString")[0]
+                if val:
+                    return str(val).strip()
+        except Exception:
+            pass
+
+    import platform
+
+    return platform.processor() or None

--- a/routes/components.py
+++ b/routes/components.py
@@ -756,43 +756,38 @@ def api_component_runtime():
             items.append({"label": "Uptime", "value": up, "status": "ok"})
     except Exception:
         pass
-    # Memory
+    # Memory — portable (`free` is Linux-only; absent on macOS and Windows).
     try:
-        mem = (
-            subprocess.check_output(["free", "-h"], timeout=5)
-            .decode()
-            .strip()
-            .split("\n")
-        )
-        if len(mem) >= 2:
-            parts = mem[1].split()
-            used, total = parts[2], parts[1]
-            items.append(
-                {"label": "Memory", "value": f"{used} / {total}", "status": "ok"}
-            )
+        from helpers.system import memory_usage
+
+        mu = memory_usage()
+        if mu:
+            items.append({
+                "label": "Memory",
+                "value": (
+                    f"{round(mu['used_mb'] / 1024, 1)}G / "
+                    f"{round(mu['total_mb'] / 1024, 1)}G"
+                ),
+                "status": "ok",
+            })
     except Exception:
         pass
-    # Disk
+    # Disk — portable (`df` does not exist on Windows).
     try:
-        df = (
-            subprocess.check_output(["df", "-h", "/"], timeout=5)
-            .decode()
-            .strip()
-            .split("\n")
-        )
-        if len(df) >= 2:
-            parts = df[1].split()
-            items.append(
-                {
-                    "label": "Disk /",
-                    "value": f"{parts[2]} / {parts[1]} ({parts[4]} used)",
-                    "status": "critical"
-                    if int(parts[4].replace("%", "")) > 90
-                    else "warning"
-                    if int(parts[4].replace("%", "")) > 80
-                    else "ok",
-                }
-            )
+        from helpers.system import disk_usage
+
+        du = disk_usage()
+        if du:
+            pct = int(round(du["pct"]))
+            items.append({
+                "label": f"Disk {du['mount']}",
+                "value": f"{du['used_gb']}G / {du['total_gb']}G ({pct}% used)",
+                "status": "critical"
+                if pct > 90
+                else "warning"
+                if pct > 80
+                else "ok",
+            })
     except Exception:
         pass
     # Node.js
@@ -814,19 +809,16 @@ def api_component_machine():
     items.append({"label": "Hostname", "value": socket.gethostname(), "status": "ok"})
     # IP
     items.append({"label": "IP", "value": _d.get_local_ip(), "status": "ok"})
-    # CPU
+    # CPU — /proc/cpuinfo is Linux-only; helpers.system falls back to the
+    # Windows registry / macOS sysctl / platform.processor().
     try:
-        with open("/proc/cpuinfo") as f:
-            for line in f:
-                if line.startswith("model name"):
-                    items.append(
-                        {
-                            "label": "CPU",
-                            "value": line.split(":")[1].strip(),
-                            "status": "ok",
-                        }
-                    )
-                    break
+        from helpers.system import cpu_model
+
+        items.append({
+            "label": "CPU",
+            "value": cpu_model() or "unknown",
+            "status": "ok",
+        })
     except Exception:
         items.append(
             {"label": "CPU", "value": platform.processor() or "unknown", "status": "ok"}
@@ -835,19 +827,35 @@ def api_component_machine():
     items.append(
         {"label": "CPU Cores", "value": str(os.cpu_count() or "?"), "status": "ok"}
     )
-    # Load average
+    # Load average — os.getloadavg() raises AttributeError on Windows, which
+    # dropped this row entirely. Report CPU utilisation there instead.
     try:
-        load = os.getloadavg()
+        from helpers.system import cpu_percent, load_average
+
         cores = os.cpu_count() or 1
-        load_str = f"{load[0]:.2f} / {load[1]:.2f} / {load[2]:.2f}"
-        status = (
-            "critical"
-            if load[0] > cores * 2
-            else "warning"
-            if load[0] > cores
-            else "ok"
-        )
-        items.append({"label": "Load (1/5/15m)", "value": load_str, "status": status})
+        load = load_average()
+        if load:
+            items.append({
+                "label": "Load (1/5/15m)",
+                "value": f"{load[0]:.2f} / {load[1]:.2f} / {load[2]:.2f}",
+                "status": "critical"
+                if load[0] > cores * 2
+                else "warning"
+                if load[0] > cores
+                else "ok",
+            })
+        else:
+            cp = cpu_percent()
+            if cp is not None:
+                items.append({
+                    "label": "CPU Usage",
+                    "value": f"{cp}%",
+                    "status": "critical"
+                    if cp > 90
+                    else "warning"
+                    if cp > 75
+                    else "ok",
+                })
     except Exception:
         pass
     # GPU

--- a/routes/health.py
+++ b/routes/health.py
@@ -1760,16 +1760,17 @@ def api_health():
 
     # 3. Memory usage (RSS of this process + overall)
     try:
-        import resource
+        # `resource` is POSIX-only and `free` is Linux-only, so this whole
+        # memory check silently vanished on Windows. helpers.system covers
+        # all three platforms with stdlib calls.
+        from helpers.system import memory_usage
 
-        rss_mb = (
-            resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024
-        )  # KB -> MB on Linux
-        mem = subprocess.run(["free", "-m"], capture_output=True, text=True, timeout=2)
-        mem_parts = mem.stdout.strip().split("\n")[1].split()
-        used_mb = int(mem_parts[2])
-        total_mb = int(mem_parts[1])
-        pct = (used_mb / total_mb) * 100
+        mu = memory_usage()
+        if not mu:
+            raise RuntimeError("memory usage unavailable")
+        used_mb = mu["used_mb"]
+        total_mb = mu["total_mb"]
+        pct = mu["pct"]
         if pct > 90:
             checks.append(
                 {

--- a/routes/overview.py
+++ b/routes/overview.py
@@ -37,6 +37,65 @@ from clawmetry.config import is_local_store_read_enabled
 bp_overview = Blueprint('overview', __name__)
 
 
+def _system_rows() -> list:
+    """Disk / RAM / Load rows for the dashboard's system panel.
+
+    Shape is ``[[label, value, colour], ...]`` — unchanged from the legacy
+    inline blocks this replaces (there were two near-identical copies, one
+    per overview handler).
+
+    Previously each row shelled out to ``df -h /`` / ``free -h`` or read
+    ``/proc/loadavg``. None of those exist on Windows, and every row was
+    wrapped in a bare ``except``, so Windows silently rendered "--" for
+    Disk, RAM *and* Load on the primary dashboard. ``helpers.system`` now
+    provides stdlib-only equivalents that work on all three platforms.
+    """
+    from helpers.system import (
+        cpu_percent, disk_usage, load_average, memory_usage, uptime_pretty,
+    )
+
+    rows = []
+
+    du = disk_usage()
+    if du:
+        pct = int(round(du["pct"]))
+        colour = "green" if pct < 80 else ("yellow" if pct < 90 else "red")
+        rows.append([
+            f"Disk {du['mount']}",
+            f"{du['used_gb']}G / {du['total_gb']}G ({pct}%)",
+            colour,
+        ])
+    else:
+        rows.append(["Disk", "--", ""])
+
+    mu = memory_usage()
+    if mu:
+        rows.append([
+            "RAM",
+            f"{round(mu['used_mb'] / 1024, 1)}G / {round(mu['total_mb'] / 1024, 1)}G",
+            "",
+        ])
+    else:
+        rows.append(["RAM", "--", ""])
+
+    # Windows has no load-average concept. Rather than render a permanent
+    # "--", fall back to instantaneous CPU utilisation, which is the metric
+    # a Windows user actually expects in that slot.
+    la = load_average()
+    if la:
+        rows.append(["Load", " ".join(f"{v:.2f}" for v in la[:3]), ""])
+    else:
+        cp = cpu_percent()
+        # cpu_percent() is non-blocking and returns None until it has two
+        # samples to diff, so the row populates on the next dashboard poll.
+        rows.append(["CPU", f"{cp}%" if cp is not None else "--", ""])
+
+    up = uptime_pretty()
+    rows.append(["Uptime", up.replace("up ", "") if up != "unknown" else "--", ""])
+
+    return rows
+
+
 # Default OpenClaw heartbeat cadence (30 min). Surfaced in /api/overview's
 # `heartbeat` block so the dashboard can compare to actual gap.
 _HEARTBEAT_EXPECTED_SECONDS = 1800
@@ -976,48 +1035,8 @@ def _try_local_store_overview():
         mem_files = []
     total_size = sum(f.get("size", 0) for f in mem_files)
 
-    # System info — copied verbatim from the legacy handler so the response
-    # shape matches byte-for-byte. Each subprocess has a 2s timeout so a slow
-    # df/free/uptime can't hang the request thread.
-    system = []
-    try:
-        disk = (
-            _sub.run(["df", "-h", "/"], capture_output=True, text=True, timeout=2)
-            .stdout.strip().split("\n")[-1].split()
-        )
-        disk_pct = int(disk[4].replace("%", "")) if len(disk) > 4 else 0
-        disk_color = "green" if disk_pct < 80 else ("yellow" if disk_pct < 90 else "red")
-        system.append(["Disk /", f"{disk[2]} / {disk[1]} ({disk[4]})", disk_color])
-    except Exception:
-        system.append(["Disk /", "--", ""])
-
-    try:
-        mem = (
-            _sub.run(["free", "-h"], capture_output=True, text=True, timeout=2)
-            .stdout.strip().split("\n")[1].split()
-        )
-        system.append(["RAM", f"{mem[2]} / {mem[1]}", ""])
-    except Exception:
-        system.append(["RAM", "--", ""])
-
-    try:
-        load = open("/proc/loadavg").read().split()[:3]
-        system.append(["Load", " ".join(load), ""])
-    except Exception:
-        system.append(["Load", "--", ""])
-
-    try:
-        # Portable: GNU `uptime -p` doesn't exist on macOS / BSD.
-        from helpers.system import uptime_pretty
-
-        uptime = uptime_pretty()
-        system.append([
-            "Uptime",
-            uptime.replace("up ", "") if uptime != "unknown" else "--",
-            "",
-        ])
-    except Exception:
-        system.append(["Uptime", "--", ""])
+    # System info — portable across Linux/macOS/Windows via helpers.system.
+    system = _system_rows()
 
     if _sys.platform != "win32":
         try:
@@ -1142,55 +1161,8 @@ def api_overview():
     mem_files = _d._get_memory_files()
     total_size = sum(f["size"] for f in mem_files)
 
-    # System info
-    system = []
-    # 2s timeout on every subprocess: on slow/NFS-backed volumes df/free/uptime
-    # can hang the request thread indefinitely, and /api/overview is on the
-    # dashboard's hot path (fires every refresh). Better to show "--" than hang.
-    try:
-        disk = (
-            subprocess.run(["df", "-h", "/"], capture_output=True, text=True, timeout=2)
-            .stdout.strip()
-            .split("\n")[-1]
-            .split()
-        )
-        disk_pct = int(disk[4].replace("%", "")) if len(disk) > 4 else 0
-        disk_color = (
-            "green" if disk_pct < 80 else ("yellow" if disk_pct < 90 else "red")
-        )
-        system.append(["Disk /", f"{disk[2]} / {disk[1]} ({disk[4]})", disk_color])
-    except Exception:
-        system.append(["Disk /", "--", ""])
-
-    try:
-        mem = (
-            subprocess.run(["free", "-h"], capture_output=True, text=True, timeout=2)
-            .stdout.strip()
-            .split("\n")[1]
-            .split()
-        )
-        system.append(["RAM", f"{mem[2]} / {mem[1]}", ""])
-    except Exception:
-        system.append(["RAM", "--", ""])
-
-    try:
-        load = open("/proc/loadavg").read().split()[:3]
-        system.append(["Load", " ".join(load), ""])
-    except Exception:
-        system.append(["Load", "--", ""])
-
-    try:
-        # Portable: GNU `uptime -p` doesn't exist on macOS / BSD.
-        from helpers.system import uptime_pretty
-
-        uptime = uptime_pretty()
-        system.append([
-            "Uptime",
-            uptime.replace("up ", "") if uptime != "unknown" else "--",
-            "",
-        ])
-    except Exception:
-        system.append(["Uptime", "--", ""])
+    # System info — portable across Linux/macOS/Windows via helpers.system.
+    system = _system_rows()
 
     if sys.platform != "win32":
         try:
@@ -1226,13 +1198,10 @@ def api_overview():
         infra["runtime"] = "Runtime"
 
     try:
-        disk_info = (
-            subprocess.run(["df", "-h", "/"], capture_output=True, text=True, timeout=2)
-            .stdout.strip()
-            .split("\n")[-1]
-            .split()
-        )
-        infra["storage"] = f"{disk_info[1]} root"
+        from helpers.system import disk_usage as _du
+
+        _d_info = _du()
+        infra["storage"] = f"{_d_info['total_gb']}G {_d_info['mount']}" if _d_info else "Disk"
     except Exception:
         infra["storage"] = "Disk"
 

--- a/tests/test_no_unsanitized_markdown.py
+++ b/tests/test_no_unsanitized_markdown.py
@@ -15,8 +15,8 @@ straight into the DOM, or a regression to the unpinned CDN, goes red.
 import pathlib
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]
-APP_JS = (ROOT / "clawmetry" / "static" / "js" / "app.js").read_text()
-DASHBOARD = (ROOT / "dashboard.py").read_text()
+APP_JS = (ROOT / "clawmetry" / "static" / "js" / "app.js").read_text(encoding="utf-8")
+DASHBOARD = (ROOT / "dashboard.py").read_text(encoding="utf-8")
 VENDOR = ROOT / "clawmetry" / "static" / "vendor"
 
 
@@ -49,5 +49,5 @@ def test_vendored_libs_present_and_pinned():
     assert marked.exists(), "vendored marked.min.js missing (won't ship in wheel)"
     assert purify.exists(), "vendored purify.min.js missing (won't ship in wheel)"
     # Pinned, recognizable builds (banner comment carries the version).
-    assert "marked v" in marked.read_text()[:200]
-    assert "DOMPurify" in purify.read_text()[:200]
+    assert "marked v" in marked.read_text(encoding="utf-8")[:200]
+    assert "DOMPurify" in purify.read_text(encoding="utf-8")[:200]

--- a/tests/test_openclaw_claude_session_ingest.py
+++ b/tests/test_openclaw_claude_session_ingest.py
@@ -276,6 +276,29 @@ def test_encode_cwd_matches_claude_code_convention():
     assert enc("/srv/app.dir/work") == "-srv-app-dir-work"
 
 
+def test_encode_cwd_handles_windows_paths():
+    """Windows CWDs must collapse ``\\`` and the drive-letter ``:`` too.
+
+    Ground truth: on a Windows host with CWD ``C:\\Users\\Vivek``, Claude
+    Code writes to ``~/.claude/projects/C--Users-Vivek/``. Encoding only
+    ``/`` and ``.`` returned the CWD unchanged, so the constructed path
+    never existed and Claude Code sessions never synced on Windows.
+    """
+    from clawmetry import sync as sync_mod
+    enc = sync_mod._encode_cwd_for_claude_projects
+
+    assert enc(r"C:\Users\Vivek") == "C--Users-Vivek"
+    # Nested workspace, and a dot-dir mid-path.
+    assert (
+        enc(r"C:\Users\Vivek\.openclaw\workspace")
+        == "C--Users-Vivek--openclaw-workspace"
+    )
+    # Non-C drive letters get the same treatment.
+    assert enc(r"D:\work\repo") == "D--work-repo"
+    # UNC share: the leading double backslash collapses to "--".
+    assert enc(r"\\server\share\proj") == "--server-share-proj"
+
+
 def test_translate_handles_lines_without_timestamp(sync_with_isolated_store):
     """Lines lacking ``timestamp`` are silently dropped — the events
     table indexes on ts so storing NULL would corrupt the read path."""

--- a/tests/test_security_posture_encrypted.py
+++ b/tests/test_security_posture_encrypted.py
@@ -7,7 +7,7 @@ heartbeat payload (the cloud stored that in cleartext).
 """
 import pathlib
 
-SYNC = (pathlib.Path(__file__).resolve().parents[1] / "clawmetry" / "sync.py").read_text()
+SYNC = (pathlib.Path(__file__).resolve().parents[1] / "clawmetry" / "sync.py").read_text(encoding="utf-8")
 
 
 def test_security_posture_in_encrypted_snapshot():


### PR DESCRIPTION
## Why

ClawMetry has a product demo on Windows coming up, and running the dashboard on a real Windows 10 machine surfaced four classes of Windows breakage. None of them crashed anything: every one failed silently, rendering empty tiles or dead ends instead of errors.

## What

1. Claude Code sessions never synced on Windows. The cwd slug encoder handled only "/" and ".", so a Windows cwd like C:\Users\Vivek never matched the real ~/.claude/projects/C--Users-Vivek directory. Now also collapses backslash and the drive colon. Verified against the actual directory on a Windows host.

2. Disk, RAM and Load tiles rendered as dashes. They shelled out to df and free and read /proc/loadavg, none of which exist on Windows. helpers/system.py now provides stdlib-only portable equivalents (shutil.disk_usage, GlobalMemoryStatusEx, GetSystemTimes deltas, registry CPU model), and the Load slot falls back to CPU utilisation where load average does not exist.

3. Setup demanded an OpenClaw gateway token even when OpenClaw is not installed. Detection via /api/entitlement/runtime-detection (endpoint existed; nothing consumed it) now drives the setup step: it lists the runtimes actually found on the machine, keeps the gateway token path one click away, and the local install hint switches to PowerShell on Windows.

4. Portability sweep: the sync daemon now detaches properly on Windows (start_new_session is POSIX-only, so closing the launching console killed the daemon), the pid file honours TEMP instead of /tmp, hardware probing falls back from wmic (absent on Windows 11 24H2+) to the registry, and sessions.json is read as UTF-8 (cp1252 locale decode raised on emoji in session titles).

## Verification

- Ran the dashboard on Windows 10 (real machine, not CI): system rows show real values, runtime detection modal renders correctly (Playwright screenshot), PID file writable, hardware probe returns correct CPU/RAM with wmic simulated absent.
- New tests: Windows + UNC slug encoding; existing encoder tests unchanged and green.
- Full targeted test sweep: 324 passed. 13 failures reproduce identically on the unmodified base commit in a clean worktree (pre-existing Windows failures, list in comments).

🤖 Generated with [Claude Code](https://claude.com/claude-code)