### PR TITLE
feat(trial): activate the free trial locally after email OTP verification

### DIFF
--- a/clawmetry/license.py
+++ b/clawmetry/license.py
@@ -235,6 +235,13 @@ def parse_license(token: str):
         elif tier_in == "starter":
             # Self-hosted Starter keys ($90/node/yr) issued by the cloud.
             tier = _ent.TIER_CLOUD_STARTER
+        elif tier_in == "trial":
+            # Local-trial keys (7 days, minted by /api/license/trial after
+            # email verification). MUST map to TIER_TRIAL explicitly: the
+            # forward-compat fallback below coerces unknown tiers to Pro,
+            # which would silently turn every time-boxed trial into a full
+            # Pro entitlement.
+            tier = _ent.TIER_TRIAL
         else:
             # Unknown tiers still default to Pro (forward compatibility).
             tier = _ent.TIER_PRO

--- a/clawmetry/static/js/gw-setup.js
+++ b/clawmetry/static/js/gw-setup.js
@@ -163,13 +163,113 @@ async function _gwApplyRuntimeDetection() {
   }
 }
 
-// Placeholder until the local-trial endpoint lands (task: local trial).
-// Falls back to the existing cloud sign-up path so the button is never dead.
+// ── Local trial activation ─────────────────────────────────────────────
+// Email + OTP, then everything continues locally: the cloud mints a signed
+// 7-day trial key, /api/trial/activate writes it to this install, and the
+// entitlement flips without the user ever leaving this dashboard. Uses the
+// existing /api/cloud-cta/send-otp proxy for the code email. Google/GitHub
+// sign-in stays available via the existing cloud modal (accounts are
+// trial-by-default there, so that path unlocks too).
+
+function _gwTrialErr(msg) {
+  var e = document.getElementById('gw-trial-error');
+  if (e) { e.textContent = msg || ''; e.style.display = msg ? '' : 'none'; }
+}
+
 function gwStartTrial() {
-  if (typeof openCloudModal === 'function') {
-    document.getElementById('gw-setup-overlay').style.display = 'none';
-    openCloudModal();
-  }
+  var cta = document.getElementById('gw-detected-cta');
+  if (!cta) return;
+  cta.innerHTML =
+    '<div style="text-align:left;">' +
+      '<p style="color:var(--text-muted,#888); font-size:12px; margin:0 0 8px; line-height:1.5;">' +
+        'Enter your email to start your 7-day free trial. Your data stays on this machine.' +
+      '</p>' +
+      '<input id="gw-trial-email" type="email" placeholder="you@company.com" ' +
+        'style="width:100%; padding:10px 12px; border:1px solid var(--border-primary,#444); border-radius:8px; background:var(--bg-primary,#111); color:var(--text-primary,#fff); font-size:13px; box-sizing:border-box; outline:none; margin-bottom:8px;" ' +
+        'onkeydown="if(event.key===\'Enter\')gwTrialSendCode()">' +
+      '<div id="gw-trial-error" style="display:none; color:#ff4444; font-size:12px; margin-bottom:8px;"></div>' +
+      '<button id="gw-trial-send-btn" onclick="gwTrialSendCode()" style="width:100%; padding:11px; border:none; border-radius:8px; background:var(--bg-accent,#0f6fff); color:#fff; font-size:14px; font-weight:600; cursor:pointer; font-family:Manrope,sans-serif;">Email me a code</button>' +
+      '<p style="color:var(--text-faint,#555); font-size:11px; margin:10px 0 0; text-align:center;">' +
+        'Prefer <a href="#" onclick="if(typeof openCloudModal===\'function\'){document.getElementById(\'gw-setup-overlay\').style.display=\'none\';openCloudModal();}return false;" style="color:var(--text-muted,#888);">Google or GitHub sign-in</a>?' +
+      '</p>' +
+    '</div>';
+  setTimeout(function () { var el = document.getElementById('gw-trial-email'); if (el) el.focus(); }, 50);
+}
+
+var _gwTrialEmail = '';
+function gwTrialSendCode() {
+  var emailEl = document.getElementById('gw-trial-email');
+  var email = (emailEl && emailEl.value || '').trim();
+  if (!email || email.indexOf('@') < 0) { _gwTrialErr('Enter a valid email.'); return; }
+  _gwTrialErr('');
+  _gwTrialEmail = email;
+  var btn = document.getElementById('gw-trial-send-btn');
+  if (btn) { btn.textContent = 'Sending code'; btn.disabled = true; }
+  fetch('/api/cloud-cta/send-otp', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email: email }),
+  }).then(function (r) { return r.json(); }).then(function (d) {
+    if (d.ok === false) {
+      _gwTrialErr(d.error || 'Could not send the code. Try again.');
+      if (btn) { btn.textContent = 'Email me a code'; btn.disabled = false; }
+      return;
+    }
+    _gwTrialCodeStep();
+  }).catch(function () {
+    _gwTrialErr('Network error. Try again.');
+    if (btn) { btn.textContent = 'Email me a code'; btn.disabled = false; }
+  });
+}
+
+function _gwTrialCodeStep() {
+  var cta = document.getElementById('gw-detected-cta');
+  if (!cta) return;
+  cta.innerHTML =
+    '<div style="text-align:left;">' +
+      '<p style="color:var(--text-muted,#888); font-size:12px; margin:0 0 8px; line-height:1.5;">' +
+        'We emailed a 6-digit code to <span style="color:var(--text-primary,#fff);">' + _gwTrialEmail + '</span>.' +
+      '</p>' +
+      '<input id="gw-trial-code" type="text" inputmode="numeric" maxlength="6" placeholder="123456" ' +
+        'style="width:100%; padding:10px 12px; border:1px solid var(--border-primary,#444); border-radius:8px; background:var(--bg-primary,#111); color:var(--text-primary,#fff); font-size:16px; letter-spacing:6px; text-align:center; font-family:monospace; box-sizing:border-box; outline:none; margin-bottom:8px;" ' +
+        'onkeydown="if(event.key===\'Enter\')gwTrialActivate()">' +
+      '<div id="gw-trial-error" style="display:none; color:#ff4444; font-size:12px; margin-bottom:8px;"></div>' +
+      '<button id="gw-trial-activate-btn" onclick="gwTrialActivate()" style="width:100%; padding:11px; border:none; border-radius:8px; background:var(--bg-accent,#0f6fff); color:#fff; font-size:14px; font-weight:600; cursor:pointer; font-family:Manrope,sans-serif;">Activate trial</button>' +
+      '<p style="color:var(--text-faint,#555); font-size:11px; margin:8px 0 0; text-align:center;">' +
+        '<a href="#" onclick="gwStartTrial();return false;" style="color:var(--text-muted,#888);">Use a different email</a>' +
+      '</p>' +
+    '</div>';
+  setTimeout(function () { var el = document.getElementById('gw-trial-code'); if (el) el.focus(); }, 50);
+}
+
+function gwTrialActivate() {
+  var codeEl = document.getElementById('gw-trial-code');
+  var code = (codeEl && codeEl.value || '').replace(/\s/g, '');
+  if (code.length !== 6) { _gwTrialErr('Enter the 6-digit code from your email.'); return; }
+  _gwTrialErr('');
+  var btn = document.getElementById('gw-trial-activate-btn');
+  if (btn) { btn.textContent = 'Activating'; btn.disabled = true; }
+  fetch('/api/trial/activate', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email: _gwTrialEmail, code: code }),
+  }).then(function (r) { return r.json(); }).then(function (d) {
+    if (!d.ok) {
+      _gwTrialErr(d.error || 'Activation failed. Try again.');
+      if (btn) { btn.textContent = 'Activate trial'; btn.disabled = false; }
+      return;
+    }
+    var cta = document.getElementById('gw-detected-cta');
+    if (cta) {
+      cta.innerHTML =
+        '<p style="color:#4ade80; font-size:13px; font-weight:600; margin:0 0 4px; text-align:center;">Trial active</p>' +
+        '<p style="color:var(--text-muted,#888); font-size:12px; margin:0; text-align:center;">Your agent runtimes are now being watched. Reloading&hellip;</p>';
+    }
+    setTimeout(function () { location.reload(); }, 1200);
+  }).catch(function () {
+    _gwTrialErr('Network error. Try again.');
+    if (btn) { btn.textContent = 'Activate trial'; btn.disabled = false; }
+  });
 }
 
 function _isCloudModalOpen() {

--- a/dashboard.py
+++ b/dashboard.py
@@ -104,6 +104,7 @@ from routes.health import bp_health
 from routes.alerts import bp_alerts, bp_budget
 from routes.channels import bp_channels
 from routes.overview import bp_overview
+from routes.trial import bp_trial
 from routes.components import bp_components
 from routes.fleet_history import bp_fleet
 from routes.infra import bp_logs, bp_memory, bp_security, bp_config
@@ -11709,6 +11710,7 @@ def detect_config(args=None):
         app.register_blueprint(bp_runtime_ingest)
     app.register_blueprint(bp_otlp_traces)
     app.register_blueprint(bp_overview)
+    app.register_blueprint(bp_trial)
     app.register_blueprint(bp_security)
     app.register_blueprint(bp_sessions)
     app.register_blueprint(bp_sla)

--- a/routes/trial.py
+++ b/routes/trial.py
@@ -1,0 +1,116 @@
+"""
+routes/trial.py — Local free-trial activation.
+
+Owns the routes registered on ``bp_trial``:
+
+  POST /api/trial/activate — verify an email OTP with the cloud, receive a
+                             signed 7-day trial license key, and activate it
+                             on THIS install. The user never leaves the
+                             local dashboard.
+
+Why this exists: the paid runtimes (Claude Code, Codex, Cursor, ...) need a
+Trial/Pro entitlement, but until now the only path to a trial ran through
+the full cloud sign-up (account page in a new tab, node registration, then
+waiting for a daemon heartbeat to cache the plan). For someone who just
+installed ClawMetry locally that is a funnel cliff. The flow here keeps the
+account-creation requirement (email, verified by OTP; the cloud endpoint
+also accepts its OAuth session) but completes everything else locally:
+
+  browser modal -> POST /api/cloud-cta/send-otp   (existing proxy, sends code)
+  browser modal -> POST /api/trial/activate       (this module)
+                     -> cloud POST /api/license/trial  {email, code}
+                     <- signed Ed25519 key, tier="trial", 7 days
+                     -> clawmetry.license.activate(key)
+                          writes ~/.clawmetry/license.key (0600)
+                          invalidates the entitlement cache
+                          best-effort installs the clawmetry-pro wheel
+
+The signed key is the entitlement (verified offline by clawmetry.license),
+so after this call the trial keeps working with no cloud session, no cm_
+key, and no network.
+"""
+
+import json
+import urllib.error
+import urllib.request
+
+from flask import Blueprint, jsonify, request
+
+bp_trial = Blueprint("trial", __name__)
+
+# The trial-mint endpoint lives on the license server (same app that hosts
+# /api/license/activate). clawmetry.license._cloud_base honours
+# CLAWMETRY_LICENSE_SERVER / CLAWMETRY_INGEST_URL for self-hosted setups.
+_TRIAL_PATH = "/api/license/trial"
+
+
+@bp_trial.route("/api/trial/activate", methods=["POST"])
+def api_trial_activate():
+    """Exchange a verified email OTP for a trial license and activate it."""
+    data = request.get_json(silent=True) or {}
+    email = (data.get("email") or "").strip().lower()
+    code = (data.get("code") or "").strip()
+    if not email or "@" not in email:
+        return jsonify({"ok": False, "error": "Enter a valid email."}), 400
+    if not code or not code.isdigit() or len(code) != 6:
+        return jsonify({"ok": False, "error": "Enter the 6-digit code from your email."}), 400
+
+    from clawmetry import license as _lic
+
+    base = _lic._cloud_base().rstrip("/")
+    body = json.dumps({"email": email, "code": code}).encode("utf-8")
+    req = urllib.request.Request(
+        base + _TRIAL_PATH,
+        data=body,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            payload = json.loads(resp.read().decode("utf-8", errors="replace"))
+    except urllib.error.HTTPError as exc:
+        # The cloud replies with a JSON error body on 4xx (wrong code, trial
+        # already used). Surface its message rather than a generic failure.
+        try:
+            payload = json.loads(exc.read().decode("utf-8", errors="replace"))
+        except Exception:
+            payload = {}
+        msg = payload.get("error") or f"Trial request failed ({exc.code})."
+        return jsonify({"ok": False, "error": msg}), 400
+    except Exception:
+        return jsonify({
+            "ok": False,
+            "error": "Could not reach the license server. Check your connection and try again.",
+        }), 502
+
+    key = (payload.get("key") or "").strip()
+    if not payload.get("ok") or not key:
+        return jsonify({
+            "ok": False,
+            "error": payload.get("error") or "The license server did not return a key.",
+        }), 502
+
+    # activate() verifies the signature offline, writes the key 0600,
+    # invalidates the entitlement cache, and best-effort installs the
+    # clawmetry-pro wheel. Never raises.
+    ok, msg = _lic.activate(key, actor="local-trial")
+    if not ok:
+        return jsonify({"ok": False, "error": msg}), 502
+
+    try:
+        from clawmetry import entitlements as _ent
+
+        ent = _ent.get_entitlement(force=True)
+        tier = ent.tier
+        tier_label = _ent.tier_label(ent.tier)
+        expiry = getattr(ent, "expiry", None)
+    except Exception:
+        tier, tier_label, expiry = "trial", "Trial", None
+
+    return jsonify({
+        "ok": True,
+        "tier": tier,
+        "tier_label": tier_label,
+        "expiry": expiry,
+        "message": msg,
+    })

--- a/tests/test_local_trial.py
+++ b/tests/test_local_trial.py
@@ -1,0 +1,216 @@
+"""Tests for the local trial-activation flow.
+
+Two halves:
+
+1. ``parse_license`` tier mapping — a signed token with ``tier="trial"``
+   MUST resolve to :data:`clawmetry.entitlements.TIER_TRIAL`. This is the
+   revert-proof guard for the fix: before it, the forward-compat fallback
+   coerced unknown tiers to TIER_PRO, so a 7-day trial key silently granted
+   a permanent-feature Pro entitlement (until exp) instead of a trial.
+
+2. ``POST /api/trial/activate`` (routes/trial.py) — exchanges an email+OTP
+   for a key minted by the (mocked) cloud, activates it on this install,
+   and reports the refreshed entitlement. Hermetic: ephemeral keypair,
+   monkeypatched public key, no network.
+"""
+from __future__ import annotations
+
+import io
+import json
+import time
+import urllib.error
+from types import SimpleNamespace
+
+import pytest
+
+
+def _keypair():
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+    priv = Ed25519PrivateKey.generate()
+    pub_pem = priv.public_key().public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    return priv, pub_pem
+
+
+def _trial_payload(exp_delta=7 * 86400):
+    now = int(time.time())
+    return {
+        "jti": "lic_trial_test",
+        "sub": "trial@example.com",
+        "tier": "trial",
+        "nodes": 2,
+        "iat": now,
+        "exp": now + exp_delta,
+    }
+
+
+@pytest.fixture
+def lic(monkeypatch, tmp_path):
+    import clawmetry.license as L
+
+    priv, pub_pem = _keypair()
+    monkeypatch.setattr(L, "_PUBLIC_KEY_PEM", pub_pem)
+    monkeypatch.setattr(L, "LICENSE_PATH", str(tmp_path / "license.key"))
+    monkeypatch.setattr(L, "_CONFIG_PATH", str(tmp_path / "config.json"))
+    monkeypatch.delenv("CLAWMETRY_LICENSE_SERVER", raising=False)
+    monkeypatch.delenv("CLAWMETRY_INGEST_URL", raising=False)
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("CLAWMETRY_OFFLINE", "1")
+    return SimpleNamespace(L=L, priv=priv, pub_pem=pub_pem)
+
+
+# ── tier mapping ─────────────────────────────────────────────────────────────
+
+
+def test_trial_token_maps_to_tier_trial(lic):
+    """The revert-proof: pre-fix this asserted-tier came back TIER_PRO."""
+    from clawmetry import entitlements as ent
+
+    tok = lic.L._encode_token(_trial_payload(), lic.priv)
+    e = lic.L.parse_license(tok)
+    assert e is not None
+    assert e.tier == ent.TIER_TRIAL
+    assert e.tier != ent.TIER_PRO
+
+
+def test_trial_entitlement_unlocks_paid_runtimes(lic):
+    """TIER_TRIAL is a paid tier: claude_code and friends must be allowed."""
+    tok = lic.L._encode_token(_trial_payload(), lic.priv)
+    e = lic.L.parse_license(tok)
+    assert e.allows_runtime("claude_code")
+    assert e.allows_runtime("cursor")
+    assert e.allows_runtime("openclaw")  # free runtimes stay allowed
+
+
+def test_expired_trial_token_does_not_entitle(lic):
+    """An expired trial key must not resolve into an active entitlement.
+
+    parse_license builds the entitlement with the token's exp; the resolver
+    treats a past expiry as expired. Assert the expiry travels through.
+    """
+    tok = lic.L._encode_token(_trial_payload(exp_delta=-3600), lic.priv)
+    e = lic.L.parse_license(tok)
+    # The entitlement object carries the (past) expiry for the resolver.
+    assert e is not None
+    assert float(e.expiry) < time.time()
+
+
+def test_starter_and_pro_mapping_unchanged(lic):
+    """The trial branch must not disturb the existing tier mappings."""
+    from clawmetry import entitlements as ent
+
+    p = _trial_payload()
+    p["tier"] = "starter"
+    assert lic.L.parse_license(lic.L._encode_token(p, lic.priv)).tier == ent.TIER_CLOUD_STARTER
+    p["tier"] = "pro"
+    assert lic.L.parse_license(lic.L._encode_token(p, lic.priv)).tier == ent.TIER_PRO
+    p["tier"] = "somefuturetier"
+    assert lic.L.parse_license(lic.L._encode_token(p, lic.priv)).tier == ent.TIER_PRO
+
+
+# ── /api/trial/activate ──────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def trial_app(lic, monkeypatch):
+    """Minimal Flask app carrying only bp_trial, with the cloud mocked."""
+    from flask import Flask
+
+    from routes.trial import bp_trial
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_trial)
+    return app
+
+
+def _mock_cloud(monkeypatch, lic, status=200, body=None):
+    """Route routes.trial's urlopen to a canned cloud response."""
+    import routes.trial as T
+
+    if body is None:
+        key = lic.L._encode_token(_trial_payload(), lic.priv)
+        body = {"ok": True, "key": key}
+    raw = json.dumps(body).encode("utf-8")
+    calls = []
+
+    def fake_urlopen(req, timeout=0):
+        calls.append(req)
+        if status >= 400:
+            raise urllib.error.HTTPError(
+                req.full_url, status, "err", {}, io.BytesIO(raw)
+            )
+
+        class _Resp:
+            def read(self):
+                return raw
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+        return _Resp()
+
+    monkeypatch.setattr(T.urllib.request, "urlopen", fake_urlopen)
+    return calls
+
+
+def test_activate_happy_path_writes_key_and_reports_trial(trial_app, lic, monkeypatch):
+    calls = _mock_cloud(monkeypatch, lic)
+    # Entitlement resolution must read the SAME monkeypatched license path.
+    from clawmetry import entitlements as ent
+
+    monkeypatch.setattr(ent, "_LICENSE_PATH", lic.L.LICENSE_PATH)
+    ent.invalidate()
+
+    client = trial_app.test_client()
+    r = client.post(
+        "/api/trial/activate",
+        json={"email": "Trial@Example.com", "code": "123456"},
+    )
+    assert r.status_code == 200, r.get_json()
+    d = r.get_json()
+    assert d["ok"] is True
+    assert d["tier"] == ent.TIER_TRIAL
+    # The signed key landed on disk and verifies offline.
+    import os
+
+    assert os.path.isfile(lic.L.LICENSE_PATH)
+    with open(lic.L.LICENSE_PATH, encoding="utf-8") as fh:
+        assert lic.L.verify_token(fh.read().strip())["tier"] == "trial"
+    # The email was normalised before hitting the cloud.
+    sent = json.loads(calls[0].data.decode("utf-8"))
+    assert sent["email"] == "trial@example.com"
+
+
+def test_activate_rejects_bad_email_and_code_shapes(trial_app):
+    client = trial_app.test_client()
+    assert client.post("/api/trial/activate", json={"email": "nope", "code": "123456"}).status_code == 400
+    assert client.post("/api/trial/activate", json={"email": "a@b.co", "code": "12"}).status_code == 400
+    assert client.post("/api/trial/activate", json={"email": "a@b.co", "code": "abcdef"}).status_code == 400
+
+
+def test_activate_surfaces_cloud_error_message(trial_app, lic, monkeypatch):
+    _mock_cloud(monkeypatch, lic, status=400, body={"ok": False, "error": "Invalid or expired code."})
+    client = trial_app.test_client()
+    r = client.post("/api/trial/activate", json={"email": "a@b.co", "code": "123456"})
+    assert r.status_code == 400
+    assert "Invalid or expired code." in r.get_json()["error"]
+
+
+def test_activate_rejects_forged_key_from_cloud(trial_app, lic, monkeypatch):
+    """A key signed by the wrong keypair must not activate."""
+    other_priv, _ = _keypair()
+    forged = lic.L._encode_token(_trial_payload(), other_priv)
+    _mock_cloud(monkeypatch, lic, body={"ok": True, "key": forged})
+    client = trial_app.test_client()
+    r = client.post("/api/trial/activate", json={"email": "a@b.co", "code": "123456"})
+    assert r.status_code == 502
+    import os
+
+    assert not os.path.isfile(lic.L.LICENSE_PATH)


### PR DESCRIPTION
## Why

Trying a paid runtime previously required the full cloud sign-up: account page in a new tab, node registration, then a daemon heartbeat before the plan reached the local install. For someone who just ran pip install on their own machine that is a funnel cliff at the exact conversion moment.

## What

The trial now completes inside the local dashboard. The setup modal asks for an email, the existing send-otp proxy emails the code, and the new POST /api/trial/activate exchanges the verified code with the license server for a signed 7-day trial key, activated through the existing clawmetry.license.activate() path. The signed key IS the entitlement (verified offline), so after activation the trial works with no cloud session and no network. Google/GitHub sign-in remains available via the existing cloud modal.

Critical mapping fix: parse_license coerced unknown tiers to TIER_PRO, so a trial token would have granted full Pro. tier=trial now maps to TIER_TRIAL, with a revert-proof test.

## Cross-repo

Pairs with clawmetry-cloud PR adding POST /api/license/trial (OTP-verified minting, one trial per email, reissue for lost keys). This PR is safe to merge first: until the cloud endpoint deploys, activation returns the license-server error to the modal and nothing else changes.

## Verification

Full browser E2E (Playwright) against the real dashboard and the real cloud handler code with a stubbed OTP store: email step, wrong-code error surfaced, correct code, key written 0600 and verified on disk, entitlement flipped oss to trial, claude_code unlocked in runtime-detection after reload. 8 new hermetic tests plus revert-proof (red on unfixed code, green restored).

Stacked on #4117 (the runtime-aware setup modal this UI builds on).

🤖 Generated with [Claude Code](https://claude.com/claude-code)