### PR TITLE
fix(c6): route health/notify comments to tracking issue #4029, sync check name

### DIFF
--- a/.github/workflows/apply-required-checks.yml
+++ b/.github/workflows/apply-required-checks.yml
@@ -18,7 +18,7 @@ name: Apply required E2E status checks (C6 -- one-shot)
 #     With only GITHUB_TOKEN (ghs_): read-only verify path in the script
 #     (exits 0 if C6 configured, exits 1 if not -- no admin rights needed).
 #     With E2E_ADMIN_PAT: full apply + verify.
-#     On failure, posts a notification comment on tracking issue #3970.
+#     On failure, posts a notification comment on tracking issue #4029.
 #
 # TOKEN PATHS (priority order):
 #   1. inputs.pat_token  -- PAT typed into the Run workflow dialog
@@ -37,7 +37,7 @@ name: Apply required E2E status checks (C6 -- one-shot)
 #   clawmetry-landing.
 #
 # Idempotent: running multiple times is safe.
-# Tracking: vivekchand/clawmetry#3970
+# Tracking: vivekchand/clawmetry#4029
 
 on:
   workflow_dispatch:
@@ -85,23 +85,21 @@ jobs:
             echo "    clawmetry, clawmetry-cloud, clawmetry-landing"
           elif [ -n "${{ inputs.pat_token }}" ]; then
             echo "  Using pat_token input -- will apply to all 3 repos:"
-            echo "  clawmetry         : OSS golden path (wheel + OpenClaw + 9 tabs)"
-            echo "  clawmetry         : Cross-repo handoff (C4)"
-            echo "  clawmetry         : MOAT Keystone (13-endpoint bar)"
-            echo "  clawmetry         : E2E Browser Tests (critical subset)"
+            echo "  clawmetry         : E2E Gate (required)"
             echo "  clawmetry-cloud   : Cloud golden-path browser E2E"
             echo "  clawmetry-landing : Landing golden path (C3)"
           else
             echo "  Using E2E_ADMIN_PAT secret -- will apply to all 3 repos:"
-            echo "  clawmetry         : OSS golden path (wheel + OpenClaw + 9 tabs)"
-            echo "  clawmetry         : Cross-repo handoff (C4)"
-            echo "  clawmetry         : MOAT Keystone (13-endpoint bar)"
-            echo "  clawmetry         : E2E Browser Tests (critical subset)"
+            echo "  clawmetry         : E2E Gate (required)"
             echo "  clawmetry-cloud   : Cloud golden-path browser E2E"
             echo "  clawmetry-landing : Landing golden path (C3)"
           fi
           echo ""
           echo "  Deprecated checks removed if present:"
+          echo "  clawmetry : OSS golden path (wheel + OpenClaw + 9 tabs)"
+          echo "  clawmetry : Cross-repo handoff (C4)"
+          echo "  clawmetry : MOAT Keystone (13-endpoint bar)"
+          echo "  clawmetry : E2E Browser Tests (critical subset)"
           echo "  clawmetry : visual-diff (paths: filter -- stalls non-UI PRs)"
           echo ""
           echo "Re-run with confirm=APPLY to apply."
@@ -119,7 +117,7 @@ jobs:
         run: python3 scripts/apply_required_status_checks.py
 
       # When the C6 read-only verify exits 1 (checks not yet configured on main),
-      # post or update a comment on the E2E Robustness tracking issue #3970 so the
+      # post or update a comment on the E2E Robustness tracking issue #4029 so the
       # repo admin receives a GitHub notification.
       #
       # Only fires on push-to-main (the automated verify path), NOT on manual
@@ -138,15 +136,12 @@ jobs:
 
           The [apply-required-checks workflow](${RUN_URL}) detected that required E2E status checks are NOT configured on \`clawmetry/main\`. PRs can currently merge without E2E passing.
 
-          **Missing checks:**
-          - \`OSS golden path (wheel + OpenClaw + 9 tabs)\`
-          - \`Cross-repo handoff (C4)\`
-          - \`MOAT Keystone (13-endpoint bar)\`
-          - \`E2E Browser Tests (critical subset)\`
+          **Missing check (1 name to add in GitHub Settings):**
+          - \`E2E Gate (required)\`
 
           **Fix option A (60 seconds, no PAT needed -- GitHub Settings UI):**
           Go to: https://github.com/vivekchand/clawmetry/settings/branches
-          Edit main > Require status checks > add the 4 names above.
+          Edit main > Require status checks > add the name above.
 
           **Fix option B (30 seconds, terminal):**
           \`\`\`bash
@@ -161,15 +156,15 @@ jobs:
 
           # Upsert: update existing comment if present, otherwise create new.
           existing_id=$(gh api -X GET \
-            "repos/${REPO}/issues/3970/comments" \
+            "repos/${REPO}/issues/4029/comments" \
             --jq 'map(select(.body | startswith("<!-- c6-notify-bot -->"))) | .[0].id // empty' \
             2>/dev/null || echo "")
           if [ -n "${existing_id}" ]; then
             gh api -X PATCH "repos/${REPO}/issues/comments/${existing_id}" \
               -f body="${BODY}" > /dev/null
-            echo "Updated existing C6 notification on #3970 (comment ${existing_id})"
+            echo "Updated existing C6 notification on #4029 (comment ${existing_id})"
           else
-            gh api -X POST "repos/${REPO}/issues/3970/comments" \
+            gh api -X POST "repos/${REPO}/issues/4029/comments" \
               -f body="${BODY}" > /dev/null
-            echo "Posted new C6 notification on #3970"
+            echo "Posted new C6 notification on #4029"
           fi

--- a/.github/workflows/c6-health.yml
+++ b/.github/workflows/c6-health.yml
@@ -10,7 +10,7 @@ name: C6 daily health check (branch-protection audit -- all 3 repos)
 # (can't verify) rather than "error" (broken). The health check gate
 # decision is based only on the clawmetry/main result (same-repo readable).
 #
-# On failure: posts an @-mentioned reminder to tracking issue #3864
+# On failure: posts an @-mentioned reminder to tracking issue #4029
 # at most once per calendar day. On success: posts a GREEN confirmation.
 #
 # To close C6 (any of these paths -- all take under 2 minutes):
@@ -20,7 +20,7 @@ name: C6 daily health check (branch-protection audit -- all 3 repos)
 #   2. Or: bash scripts/close-c6.sh
 #   3. Or: Settings > Branches > main > Required status checks (each repo)
 #
-# Tracking: vivekchand/clawmetry#3864
+# Tracking: vivekchand/clawmetry#4029
 
 on:
   schedule:
@@ -50,7 +50,7 @@ jobs:
 
           TOKEN = os.environ["GITHUB_TOKEN"]
           OWNER = "vivekchand"
-          TRACKING_ISSUE = 3864
+          TRACKING_ISSUE = 4029
           MARKER = "<!-- c6-health-check -->"
           # Repo this workflow runs in. GITHUB_TOKEN is repo-scoped: it can
           # read clawmetry (same-repo) but returns 403 for other repos.

--- a/.github/workflows/c6-pr-gate.yml
+++ b/.github/workflows/c6-pr-gate.yml
@@ -3,7 +3,7 @@ name: C6 Required-status-checks gate (PR audit)
 # Runs on every pull request to surface whether C6 (required-status-checks)
 # is configured on main. Fails visibly on every PR until the admin closes C6.
 #
-# The daily c6-health.yml posts to issue #3864 but the admin may not check
+# The daily c6-health.yml posts to issue #4029 but the admin may not check
 # that issue between merges. This check appears directly in the PR status
 # list alongside OSS golden path, E2E Browser Tests, etc. -- impossible to
 # miss when reviewing a PR.
@@ -44,7 +44,7 @@ name: C6 Required-status-checks gate (PR audit)
 #     Edit main > Require status checks > add:
 #       E2E Gate (required)
 #
-# Tracking: vivekchand/clawmetry#3864 (C6)
+# Tracking: vivekchand/clawmetry#4029 (C6)
 
 on:
   pull_request:
@@ -121,7 +121,7 @@ jobs:
           [Apply required E2E status checks (C6)](https://github.com/vivekchand/clawmetry/actions/workflows/apply-required-checks.yml)
           -- confirm=APPLY, pat_token=paste-token-here
 
-          _C6 is the sole remaining criterion of the E2E Robustness epic. All other 6 criteria (C1 OSS golden path, C2 Cloud golden path, C3 Landing, C4 Cross-repo handoff, C5 Visual diff all tabs, C7 Quarantine) are green. Tracking: [#3864](https://github.com/vivekchand/clawmetry/issues/3864)_"
+          _C6 is the sole remaining criterion of the E2E Robustness epic. All other 6 criteria (C1 OSS golden path, C2 Cloud golden path, C3 Landing, C4 Cross-repo handoff, C5 Visual diff all tabs, C7 Quarantine) are green. Tracking: [#4029](https://github.com/vivekchand/clawmetry/issues/4029)_"
 
           existing_id=$(gh api -X GET \
             "repos/${REPO}/issues/${PR}/comments" \

--- a/scripts/apply_required_status_checks.py
+++ b/scripts/apply_required_status_checks.py
@@ -46,7 +46,7 @@ Primary repo behaviour (clawmetry):
 When run locally (GITHUB_REPOSITORY not set), the script applies all 3
 checks and requires a token with cross-repo admin access.
 
-Tracking: vivekchand/clawmetry#3864 (C6)
+Tracking: vivekchand/clawmetry#4029 (C6)
 """
 from __future__ import annotations
 
@@ -399,7 +399,7 @@ def main() -> None:
                 "  Fix: re-run the workflow and paste a fine-grained PAT into the 'pat_token' field.\n"
                 "  PAT permissions: Administration (read+write) on clawmetry, clawmetry-cloud, clawmetry-landing.\n"
                 "  Alternative: bash scripts/close-c6.sh (uses your gh CLI session, ~30 sec).\n"
-                "  Tracking: vivekchand/clawmetry#3864 (C6)"
+                "  Tracking: vivekchand/clawmetry#4029 (C6)"
             )
         # Read-only path: GITHUB_TOKEN cannot write branch protection rules.
         # Scope verification to the current repo only to avoid cross-repo 403s.


### PR DESCRIPTION
## Summary

Three C6 workflows were posting admin @-mentions to stale/dead issues (#3864, #3970) instead of the active tracking issue #4029. Daily reminders were silently dropped because nobody monitors those old issues.

- `c6-health.yml`: `TRACKING_ISSUE 3864` -> `4029` so the daily health check @-mentions the admin on the correct thread
- `apply-required-checks.yml`: notification step now posts to `#4029` (was `#3970`); dry-run preview and notify body now show the single aggregator check `"E2E Gate (required)"` instead of the 4 individual checks replaced by PR #4111
- `scripts/apply_required_status_checks.py`: docstring tracking reference updated from `#3864` to `#4029`

## Root cause

Three independent workflows accumulated different stale issue numbers over successive PRs. Each prior fix corrected one file but left the others pointing at different dead issues, so @-mentions never reached the admin's inbox.

## Test plan

- [ ] Merge this PR
- [ ] Wait for `c6-health.yml` to fire (daily); confirm comment appears on #4029 not a stale issue
- [ ] Trigger `apply-required-checks.yml` manually; confirm notify comment posts to #4029 with `E2E Gate (required)` as the single required check name
- [ ] Once branch protection is configured (Settings UI or `bash scripts/close-c6.sh`), C6 turns GREEN

**Note:** Branch protection itself still requires a fine-grained PAT with `Administration: read+write` on all 3 repos (`E2E_ADMIN_PAT` secret). The 60-second manual fix is documented in [tracking issue #4029].

---
_Generated by [Claude Code](https://claude.ai/code/session_01EnWaCih42w33dXem86dGJX)_