### PR TITLE
feat(license): license_permissions_safe + license_file_mode scalar helpers + endpoints

### DIFF
--- a/clawmetry/license.py
+++ b/clawmetry/license.py
@@ -1513,3 +1513,87 @@ def is_subject(subject: str) -> bool:
     if actual is None:
         return False
     return actual.lower() == requested
+
+
+def license_permissions_safe() -> bool | None:
+    """Scalar view onto the installed license file's on-disk permission
+    hygiene -- for a security-posture tile that wants ONE tri-state
+    rather than the whole :func:`current_license_info` envelope.
+
+    The license key is a bearer secret: anyone holding the file can
+    present it to the offline verifier. On POSIX the file must not be
+    group/world readable; a 0o644 (default umask) key file is a
+    silently-leaked bearer credential.
+
+    Returns:
+      * ``None`` when there is no license file on disk -- nothing to
+        check, and a UI tile bound to this scalar should render as
+        "not applicable" rather than "safe" (a Free install has no
+        credential to protect).
+      * ``True`` when the file exists AND has no group/world mode bits
+        set (POSIX), OR when running on Windows where POSIX mode bits
+        do not apply and the default ACL restricts the file to the
+        owning user.
+      * ``False`` when the file exists on POSIX AND has any of the
+        group/other bits set (``0o077``) -- exactly the state a
+        "tighten file permissions" affordance should highlight.
+
+    Deliberately orthogonal to signature validity: a tampered or expired
+    license file still has meaningful hygiene state (in fact, MORE
+    urgent to surface -- a loose-permission key file may indicate the
+    same corruption that broke the signature). So the return value
+    depends only on existence + POSIX mode, never on the payload
+    branches that :func:`license_tier` / :func:`license_subject` gate
+    themselves on.
+
+    Never raises. Any exception under the hood degrades to ``None`` so
+    a scheduled security-posture check never crashes on a bad install.
+    """
+    try:
+        if not os.path.isfile(LICENSE_PATH):
+            return None
+        return _file_permissions_safe(LICENSE_PATH)
+    except Exception as exc:
+        logger.debug("license: license_permissions_safe read failed: %s", exc)
+        return None
+
+
+def license_file_mode() -> str | None:
+    """Scalar view onto the installed license file's POSIX mode -- for a
+    security-posture / debug tile that wants the raw octal (e.g.
+    ``"0644"``) rather than the whole :func:`current_license_info`
+    envelope.
+
+    Returns:
+      * ``None`` when there is nothing meaningful to surface: no
+        license file on disk, OR running on Windows where POSIX mode
+        bits do not apply.
+      * A four-character octal string like ``"0600"`` (safe),
+        ``"0644"`` (world-readable), or ``"0666"`` (world-writable)
+        otherwise. Format is stable and matches ``chmod`` -- the same
+        digits an operator would pass to ``chmod 0600 <path>`` to fix
+        an unsafe key file.
+
+    Deliberately orthogonal to signature validity: the on-disk mode is
+    a file-hygiene fact, not a license-payload fact, so the return
+    value depends only on existence + platform, never on the payload
+    branches that :func:`license_tier` / :func:`license_subject` gate
+    themselves on. Pairs with :func:`license_permissions_safe` the way
+    :func:`license_nodes` pairs with :func:`is_within_node_limit` --
+    this scalar surfaces the raw mode for a debug row, that bool
+    answers the yes/no question a security tile needs without the
+    caller having to parse octal themselves.
+
+    Never raises. Any exception under the hood degrades to ``None`` so
+    a scheduled hygiene check never crashes on a stat() failure.
+    """
+    try:
+        if os.name != "posix":
+            return None
+        if not os.path.isfile(LICENSE_PATH):
+            return None
+        mode = os.stat(LICENSE_PATH).st_mode & 0o777
+        return f"{mode:04o}"
+    except Exception as exc:
+        logger.debug("license: license_file_mode read failed: %s", exc)
+        return None

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -8897,6 +8897,143 @@ def api_license_is_subject():
     )
 
 
+def _license_permissions_snapshot() -> dict:
+    """Shared helper: read once, derive the trio the two permission-hygiene
+    endpoints both need (``permissions_safe``, ``file_mode``,
+    ``has_license``). Lives in the handler layer -- not in
+    :mod:`clawmetry.license` -- because ``has_license`` is an install-state
+    fact rather than a license-payload fact, and both endpoints below need
+    the trio together so a UI cannot catch them disagreeing on
+    ``has_license`` for the same install.
+
+    Deliberately independent of signature validity: the on-disk mode is a
+    file-hygiene fact, not a license-payload fact, so a tampered or expired
+    key file still surfaces its real ``file_mode`` here -- exactly the
+    state a "tighten file permissions" affordance needs to render.
+
+    Never raises: any underlying failure collapses to
+    ``{permissions_safe: None, file_mode: None, has_license: False}`` so
+    callers keep the "OSS-free" branch shape.
+    """
+    try:
+        from clawmetry import license as _lic
+
+        has = _lic.has_license() if hasattr(_lic, "has_license") else os.path.isfile(
+            _lic.LICENSE_PATH
+        )
+        perms = _lic.license_permissions_safe()
+        mode = _lic.license_file_mode()
+    except Exception as exc:
+        logger.debug("_license_permissions_snapshot: underlying read failed: %s", exc)
+        return {"permissions_safe": None, "file_mode": None, "has_license": False}
+    return {
+        "permissions_safe": perms,
+        "file_mode": mode,
+        "has_license": bool(has),
+    }
+
+
+@bp_entitlement.route("/api/license/permissions-safe")
+def api_license_permissions_safe():
+    """``GET /api/license/permissions-safe`` -- tri-state scalar of the
+    installed license file's on-disk permission hygiene, for a
+    security-posture tile that wants ONE field rather than the whole
+    ``/api/license/status`` envelope.
+
+    Response shape (always HTTP 200)::
+
+        {
+          "permissions_safe": <bool|null>,   # None = no license file
+          "file_mode": <str|null>,           # e.g. "0600"; null on Windows
+          "has_license": <bool>              # is a license file installed?
+        }
+
+    ``permissions_safe`` mirrors
+    :func:`clawmetry.license.license_permissions_safe`:
+
+      * ``null`` when there is no license file (Free install -- nothing to
+        protect).
+      * ``true`` when the file exists AND has no group/world mode bits set
+        (POSIX), OR when running on Windows where POSIX mode bits do not
+        apply.
+      * ``false`` when the file exists on POSIX AND has any of the
+        group/other bits set -- exactly the state a "tighten file
+        permissions" affordance should highlight.
+
+    Deliberately orthogonal to signature validity: a tampered or expired
+    license file still surfaces its real ``permissions_safe`` here, so a
+    security-posture tile can render the hygiene banner even when the
+    payload branches (``tier`` / ``sub`` / ``nodes``) have collapsed to
+    ``null`` under the "refuse untrusted claims" posture used elsewhere.
+
+    Never 5xxs -- any underlying failure degrades to
+    ``{permissions_safe: null, file_mode: null, has_license: false}`` (the
+    OSS-free branch shape), matching the never-crash posture of the
+    surrounding license endpoints.
+    """
+    try:
+        return jsonify(_license_permissions_snapshot())
+    except Exception as exc:
+        logger.warning("api_license_permissions_safe: error: %s", exc)
+        return jsonify(
+            {"permissions_safe": None, "file_mode": None, "has_license": False}
+        )
+
+
+@bp_entitlement.route("/api/license/file-mode")
+def api_license_file_mode():
+    """``GET /api/license/file-mode`` -- scalar view of the installed
+    license file's POSIX mode, for a debug row / operator-hint tile that
+    wants the raw octal (e.g. ``"0644"``) rather than the whole
+    ``/api/license/status`` envelope.
+
+    Response shape (always HTTP 200)::
+
+        {
+          "file_mode": <str|null>,           # e.g. "0600"; null on Windows
+          "permissions_safe": <bool|null>,   # None = no license file
+          "has_license": <bool>              # is a license file installed?
+        }
+
+    ``file_mode`` mirrors :func:`clawmetry.license.license_file_mode`:
+
+      * ``null`` when there is nothing meaningful to surface (no license
+        file on disk, OR running on Windows where POSIX mode bits do not
+        apply).
+      * A four-character octal string like ``"0600"`` (safe), ``"0644"``
+        (world-readable), or ``"0666"`` (world-writable) otherwise --
+        stable format matching ``chmod`` so an operator can copy-paste
+        the digits into a ``chmod 0600 <path>`` fix.
+
+    Pairs with ``/api/license/permissions-safe`` the way
+    ``/api/license/nodes`` pairs with ``/api/license/within-node-limit``
+    -- this endpoint surfaces the raw octal for a debug row, that endpoint
+    answers the yes/no question a security tile needs without the caller
+    having to parse octal themselves. The two endpoints share
+    :func:`_license_permissions_snapshot` so a UI binding both sees a
+    consistent snapshot.
+
+    Never 5xxs -- any underlying failure degrades to
+    ``{file_mode: null, permissions_safe: null, has_license: false}``.
+    """
+    try:
+        snap = _license_permissions_snapshot()
+        return jsonify(
+            {
+                "file_mode": snap["file_mode"],
+                "permissions_safe": snap["permissions_safe"],
+                "has_license": snap["has_license"],
+            }
+        )
+    except Exception as exc:
+        logger.warning("api_license_file_mode: error: %s", exc)
+        return jsonify(
+            {"file_mode": None, "permissions_safe": None, "has_license": False}
+        )
+
+
+
+
 @bp_entitlement.route("/api/paywall/event", methods=["POST"])
 def api_paywall_event():
     body: dict = {}

--- a/tests/test_license_permissions_scalar.py
+++ b/tests/test_license_permissions_scalar.py
@@ -1,0 +1,510 @@
+"""Tests for the ``license_permissions_safe()`` / ``license_file_mode()``
+scalar helpers in :mod:`clawmetry.license` plus their matching
+``/api/license/permissions-safe`` and ``/api/license/file-mode`` HTTP
+endpoints.
+
+These scalars cover the on-disk hygiene axis of the license file --
+independent from tier / subject / nodes, which gate on the signed
+PAYLOAD. A tampered or expired license file still has meaningful
+hygiene state (in fact, more urgent to surface -- loose permissions may
+indicate the same corruption that broke the signature), so the
+permission-hygiene branch deliberately never collapses to ``None`` on
+the invalid-signature or expired branches the way ``license_tier`` /
+``license_subject`` / ``license_nodes`` do.
+
+Mirrors ``tests/test_license_subject_scalar.py``'s hermetic pattern --
+ephemeral Ed25519 keypair, ``LICENSE_PATH`` monkeypatched into
+``tmp_path``, and ``CLAWMETRY_OFFLINE=1`` so ``activate()`` never
+phones home during the suite. Nothing here touches the operator's
+real license file.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import time
+from types import SimpleNamespace
+
+import pytest
+from flask import Flask
+
+
+POSIX_ONLY = pytest.mark.skipif(
+    sys.platform.startswith("win") or os.name != "posix",
+    reason="POSIX file mode bits do not apply on Windows",
+)
+
+
+def _keypair():
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+    priv = Ed25519PrivateKey.generate()
+    pub_pem = priv.public_key().public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    return priv, pub_pem
+
+
+def _payload(sub="acct_test", tier="pro", nodes=1, exp_delta=365 * 86400):
+    now = int(time.time())
+    payload = {
+        "sub": sub,
+        "tier": tier,
+        "nodes": nodes,
+        "iat": now,
+        "features": ["runtimes"],
+    }
+    if exp_delta is not None:
+        payload["exp"] = now + exp_delta
+    return payload
+
+
+@pytest.fixture
+def env(monkeypatch, tmp_path):
+    import clawmetry.license as _lic
+
+    priv, pub_pem = _keypair()
+    monkeypatch.setattr(_lic, "_PUBLIC_KEY_PEM", pub_pem)
+    license_path = str(tmp_path / "license.key")
+    monkeypatch.setattr(_lic, "LICENSE_PATH", license_path)
+    monkeypatch.delenv("CLAWMETRY_LICENSE_SERVER", raising=False)
+    monkeypatch.delenv("CLAWMETRY_INGEST_URL", raising=False)
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("CLAWMETRY_OFFLINE", "1")
+    _lic._warned_perms_for.clear()
+
+    from routes.entitlement import bp_entitlement
+
+    flask_app = Flask(__name__)
+    flask_app.register_blueprint(bp_entitlement)
+    flask_app.config["TESTING"] = True
+
+    return SimpleNamespace(
+        app=flask_app, lic=_lic, priv=priv, license_path=license_path
+    )
+
+
+def _write_raw(env, token: str, mode: int | None = None) -> None:
+    with open(env.license_path, "w", encoding="utf-8") as fh:
+        fh.write(token + "\n")
+    if mode is not None and os.name == "posix":
+        os.chmod(env.license_path, mode)
+
+
+# -- license_permissions_safe() --
+
+
+def test_license_permissions_safe_none_when_no_license(env):
+    """No license file on disk -- nothing to protect, so the scalar
+    returns None rather than True. A UI tile keying off this should
+    render as "not applicable" not "safe"."""
+    assert env.lic.license_permissions_safe() is None
+
+
+@POSIX_ONLY
+def test_license_permissions_safe_true_after_activate(env):
+    """activate() writes 0o600 via _secure_write, so the scalar
+    reports safe immediately after activation."""
+    tok = env.lic._encode_token(_payload(), env.priv)
+    env.lic.activate(tok)
+    assert env.lic.license_permissions_safe() is True
+
+
+@POSIX_ONLY
+def test_license_permissions_safe_false_on_loose_mode(env):
+    """A license file with any group/world bits set collapses to False --
+    exactly the state a "tighten permissions" affordance should surface."""
+    tok = env.lic._encode_token(_payload(), env.priv)
+    _write_raw(env, tok, mode=0o644)
+    assert env.lic.license_permissions_safe() is False
+
+
+@POSIX_ONLY
+def test_license_permissions_safe_false_on_world_writable(env):
+    tok = env.lic._encode_token(_payload(), env.priv)
+    _write_raw(env, tok, mode=0o666)
+    assert env.lic.license_permissions_safe() is False
+
+
+@POSIX_ONLY
+def test_license_permissions_safe_false_on_group_readable(env):
+    """Just group-read (0o640) is enough to flag: the license is a bearer
+    secret, so any group visibility is a leak."""
+    tok = env.lic._encode_token(_payload(), env.priv)
+    _write_raw(env, tok, mode=0o640)
+    assert env.lic.license_permissions_safe() is False
+
+
+@POSIX_ONLY
+def test_license_permissions_safe_true_on_0o400(env):
+    """0o400 -- owner-read-only -- has no group/world bits, so it's safe
+    even though write access has been removed."""
+    tok = env.lic._encode_token(_payload(), env.priv)
+    _write_raw(env, tok, mode=0o400)
+    assert env.lic.license_permissions_safe() is True
+
+
+@POSIX_ONLY
+def test_license_permissions_safe_true_on_expired_key(env):
+    """The hygiene scalar is deliberately orthogonal to signature
+    validity -- an expired key file with tight permissions still reads
+    as safe (the "refuse untrusted claims" posture doesn't apply
+    because we're not surfacing a claim, we're surfacing a mode)."""
+    tok = env.lic._encode_token(_payload(exp_delta=-3600), env.priv)
+    _write_raw(env, tok, mode=0o600)
+    assert env.lic.license_permissions_safe() is True
+
+
+@POSIX_ONLY
+def test_license_permissions_safe_true_on_invalid_signature(env):
+    """Same orthogonality: an unsigned / forged file with tight
+    permissions still reads as safe on the hygiene axis. A UI that
+    wants "is this trustworthy?" should combine this with
+    /api/license/valid, not with this scalar alone."""
+    other_priv, _ = _keypair()
+    tok = env.lic._encode_token(_payload(), other_priv)
+    _write_raw(env, tok, mode=0o600)
+    assert env.lic.license_permissions_safe() is True
+
+
+@POSIX_ONLY
+def test_license_permissions_safe_false_on_expired_with_loose_mode(env):
+    """The MOST urgent state to surface: expired key AND loose permissions.
+    The scalar reports False so a security tile can highlight both."""
+    tok = env.lic._encode_token(_payload(exp_delta=-3600), env.priv)
+    _write_raw(env, tok, mode=0o644)
+    assert env.lic.license_permissions_safe() is False
+
+
+def test_license_permissions_safe_never_raises(env, monkeypatch):
+    def _boom(*_a, **_kw):
+        raise RuntimeError("simulated stat() failure")
+
+    tok = env.lic._encode_token(_payload(), env.priv)
+    env.lic.activate(tok)
+    monkeypatch.setattr(env.lic.os.path, "isfile", _boom)
+    assert env.lic.license_permissions_safe() is None
+
+
+# -- license_file_mode() --
+
+
+def test_license_file_mode_none_when_no_license(env):
+    assert env.lic.license_file_mode() is None
+
+
+@POSIX_ONLY
+def test_license_file_mode_returns_octal_after_activate(env):
+    tok = env.lic._encode_token(_payload(), env.priv)
+    env.lic.activate(tok)
+    assert env.lic.license_file_mode() == "0600"
+
+
+@POSIX_ONLY
+def test_license_file_mode_reflects_loose_mode(env):
+    tok = env.lic._encode_token(_payload(), env.priv)
+    _write_raw(env, tok, mode=0o644)
+    assert env.lic.license_file_mode() == "0644"
+
+
+@POSIX_ONLY
+def test_license_file_mode_reflects_world_writable(env):
+    tok = env.lic._encode_token(_payload(), env.priv)
+    _write_raw(env, tok, mode=0o666)
+    assert env.lic.license_file_mode() == "0666"
+
+
+@POSIX_ONLY
+def test_license_file_mode_reflects_owner_only(env):
+    tok = env.lic._encode_token(_payload(), env.priv)
+    _write_raw(env, tok, mode=0o400)
+    assert env.lic.license_file_mode() == "0400"
+
+
+@POSIX_ONLY
+def test_license_file_mode_always_four_digit_string(env):
+    """Format is stable: always four characters, matching ``chmod`` --
+    an operator can copy-paste the digits verbatim into a fix command."""
+    tok = env.lic._encode_token(_payload(), env.priv)
+    _write_raw(env, tok, mode=0o600)
+    mode = env.lic.license_file_mode()
+    assert isinstance(mode, str)
+    assert len(mode) == 4
+    assert mode.startswith("0")
+    # All chars are valid octal digits (0-7).
+    assert all(c in "01234567" for c in mode)
+
+
+@POSIX_ONLY
+def test_license_file_mode_reflects_expired_file(env):
+    """Same orthogonality as permissions_safe: mode reflects the file's
+    actual bits regardless of signature validity."""
+    tok = env.lic._encode_token(_payload(exp_delta=-3600), env.priv)
+    _write_raw(env, tok, mode=0o600)
+    assert env.lic.license_file_mode() == "0600"
+
+
+@POSIX_ONLY
+def test_license_file_mode_reflects_invalid_signature(env):
+    other_priv, _ = _keypair()
+    tok = env.lic._encode_token(_payload(), other_priv)
+    _write_raw(env, tok, mode=0o600)
+    assert env.lic.license_file_mode() == "0600"
+
+
+def test_license_file_mode_never_raises(env, monkeypatch):
+    tok = env.lic._encode_token(_payload(), env.priv)
+    env.lic.activate(tok)
+
+    def _boom(*_a, **_kw):
+        raise RuntimeError("simulated stat() failure")
+
+    monkeypatch.setattr(env.lic.os, "stat", _boom)
+    assert env.lic.license_file_mode() is None
+
+
+def test_license_file_mode_none_on_windows(env, monkeypatch):
+    """On Windows POSIX modes don't apply, so the scalar returns None
+    even when a license file is present."""
+    tok = env.lic._encode_token(_payload(), env.priv)
+    env.lic.activate(tok)
+    monkeypatch.setattr(env.lic.os, "name", "nt")
+    assert env.lic.license_file_mode() is None
+
+
+# -- /api/license/permissions-safe --
+
+
+def test_api_permissions_safe_no_license(env):
+    with env.app.test_client() as c:
+        resp = c.get("/api/license/permissions-safe")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body == {
+        "permissions_safe": None,
+        "file_mode": None,
+        "has_license": False,
+    }
+
+
+@POSIX_ONLY
+def test_api_permissions_safe_after_activate(env):
+    tok = env.lic._encode_token(_payload(), env.priv)
+    env.lic.activate(tok)
+    with env.app.test_client() as c:
+        resp = c.get("/api/license/permissions-safe")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body == {
+        "permissions_safe": True,
+        "file_mode": "0600",
+        "has_license": True,
+    }
+
+
+@POSIX_ONLY
+def test_api_permissions_safe_loose_mode(env):
+    tok = env.lic._encode_token(_payload(), env.priv)
+    _write_raw(env, tok, mode=0o644)
+    with env.app.test_client() as c:
+        resp = c.get("/api/license/permissions-safe")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["permissions_safe"] is False
+    assert body["file_mode"] == "0644"
+    assert body["has_license"] is True
+
+
+@POSIX_ONLY
+def test_api_permissions_safe_expired_key(env):
+    """Signature-invalid / expired branch: the file IS on disk so
+    has_license is True, permissions_safe reflects the real mode
+    (orthogonal to signature validity)."""
+    tok = env.lic._encode_token(_payload(exp_delta=-3600), env.priv)
+    _write_raw(env, tok, mode=0o600)
+    with env.app.test_client() as c:
+        resp = c.get("/api/license/permissions-safe")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["permissions_safe"] is True
+    assert body["file_mode"] == "0600"
+    assert body["has_license"] is True
+
+
+@POSIX_ONLY
+def test_api_permissions_safe_invalid_signature(env):
+    other_priv, _ = _keypair()
+    tok = env.lic._encode_token(_payload(), other_priv)
+    _write_raw(env, tok, mode=0o600)
+    with env.app.test_client() as c:
+        resp = c.get("/api/license/permissions-safe")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["permissions_safe"] is True
+    assert body["file_mode"] == "0600"
+    assert body["has_license"] is True
+
+
+def test_api_permissions_safe_never_5xx(env, monkeypatch):
+    def _boom(*_a, **_kw):
+        raise RuntimeError("simulated introspection failure")
+
+    monkeypatch.setattr(env.lic, "license_permissions_safe", _boom)
+    monkeypatch.setattr(env.lic, "license_file_mode", _boom)
+    with env.app.test_client() as c:
+        resp = c.get("/api/license/permissions-safe")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body == {
+        "permissions_safe": None,
+        "file_mode": None,
+        "has_license": False,
+    }
+
+
+# -- /api/license/file-mode --
+
+
+def test_api_file_mode_no_license(env):
+    with env.app.test_client() as c:
+        resp = c.get("/api/license/file-mode")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body == {
+        "file_mode": None,
+        "permissions_safe": None,
+        "has_license": False,
+    }
+
+
+@POSIX_ONLY
+def test_api_file_mode_after_activate(env):
+    tok = env.lic._encode_token(_payload(), env.priv)
+    env.lic.activate(tok)
+    with env.app.test_client() as c:
+        resp = c.get("/api/license/file-mode")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body == {
+        "file_mode": "0600",
+        "permissions_safe": True,
+        "has_license": True,
+    }
+
+
+@POSIX_ONLY
+def test_api_file_mode_loose_mode(env):
+    tok = env.lic._encode_token(_payload(), env.priv)
+    _write_raw(env, tok, mode=0o644)
+    with env.app.test_client() as c:
+        resp = c.get("/api/license/file-mode")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["file_mode"] == "0644"
+    assert body["permissions_safe"] is False
+    assert body["has_license"] is True
+
+
+@POSIX_ONLY
+def test_api_file_mode_owner_only(env):
+    tok = env.lic._encode_token(_payload(), env.priv)
+    _write_raw(env, tok, mode=0o400)
+    with env.app.test_client() as c:
+        resp = c.get("/api/license/file-mode")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["file_mode"] == "0400"
+    assert body["permissions_safe"] is True
+
+
+@POSIX_ONLY
+def test_api_file_mode_world_writable(env):
+    tok = env.lic._encode_token(_payload(), env.priv)
+    _write_raw(env, tok, mode=0o666)
+    with env.app.test_client() as c:
+        resp = c.get("/api/license/file-mode")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["file_mode"] == "0666"
+    assert body["permissions_safe"] is False
+
+
+def test_api_file_mode_never_5xx(env, monkeypatch):
+    def _boom(*_a, **_kw):
+        raise RuntimeError("simulated introspection failure")
+
+    monkeypatch.setattr(env.lic, "license_permissions_safe", _boom)
+    monkeypatch.setattr(env.lic, "license_file_mode", _boom)
+    with env.app.test_client() as c:
+        resp = c.get("/api/license/file-mode")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body == {
+        "file_mode": None,
+        "permissions_safe": None,
+        "has_license": False,
+    }
+
+
+# -- cross-consistency between the pair --
+
+
+@POSIX_ONLY
+def test_scalar_matches_endpoint(env):
+    """Scalar helpers and the endpoints must agree on the same install."""
+    tok = env.lic._encode_token(_payload(), env.priv)
+    _write_raw(env, tok, mode=0o644)
+    scalar_safe = env.lic.license_permissions_safe()
+    scalar_mode = env.lic.license_file_mode()
+    with env.app.test_client() as c:
+        perms_body = c.get("/api/license/permissions-safe").get_json()
+        mode_body = c.get("/api/license/file-mode").get_json()
+    assert perms_body["permissions_safe"] == scalar_safe
+    assert perms_body["file_mode"] == scalar_mode
+    assert mode_body["file_mode"] == scalar_mode
+    assert mode_body["permissions_safe"] == scalar_safe
+
+
+@POSIX_ONLY
+def test_paired_endpoints_return_identical_snapshot(env):
+    """The two endpoints share ``_license_permissions_snapshot`` -- so
+    a UI binding both cannot catch them disagreeing on the trio."""
+    tok = env.lic._encode_token(_payload(), env.priv)
+    _write_raw(env, tok, mode=0o640)
+    with env.app.test_client() as c:
+        perms = c.get("/api/license/permissions-safe").get_json()
+        mode = c.get("/api/license/file-mode").get_json()
+    for field in ("permissions_safe", "file_mode", "has_license"):
+        assert perms[field] == mode[field]
+
+
+@POSIX_ONLY
+def test_envelope_permissions_match_scalars(env):
+    """The scalars must agree with the ``current_license_info`` envelope's
+    ``permissions_safe`` / ``file_mode`` fields on the active branch --
+    a UI mixing the two must never see them disagree."""
+    tok = env.lic._encode_token(_payload(), env.priv)
+    _write_raw(env, tok, mode=0o644)
+    info = env.lic.current_license_info()
+    assert env.lic.license_permissions_safe() == info["permissions_safe"]
+    assert env.lic.license_file_mode() == info["file_mode"]
+
+
+@POSIX_ONLY
+def test_hygiene_orthogonal_to_valid(env):
+    """A signature-invalid file with tight permissions surfaces
+    ``permissions_safe=True`` even though ``/api/license/status`` reports
+    ``valid=False``. This is the point: hygiene is a file-mode axis, not
+    a payload-trust axis."""
+    other_priv, _ = _keypair()
+    tok = env.lic._encode_token(_payload(), other_priv)
+    _write_raw(env, tok, mode=0o600)
+    with env.app.test_client() as c:
+        perms = c.get("/api/license/permissions-safe").get_json()
+    assert perms["permissions_safe"] is True
+    assert perms["has_license"] is True
+    info = env.lic.current_license_info()
+    assert info["valid"] is False  # signature check failed
+    assert info["permissions_safe"] is True  # but mode is tight


### PR DESCRIPTION
## Summary

Adds a file-hygiene axis pair of scalar helpers on `clawmetry/license.py` plus matching endpoints in `routes/entitlement.py`, following the same paired-scalar pattern already used for `license_tier`/`is_tier`, `license_nodes`/`is_within_node_limit`, and (open) `has_license`/`is_license_valid` (#4113), `license_subject`/`is_subject` (#4116):

- **`license_permissions_safe() -> bool | None`** — tri-state on-disk hygiene of `~/.clawmetry/license.key`:
  - `None` when there is no license file (Free install — nothing to protect).
  - `True` when the file exists AND has no group/world mode bits set (POSIX), OR on Windows where POSIX mode bits do not apply.
  - `False` when the file exists on POSIX AND has any group/other bits set (`0o077`) — exactly the state a "tighten permissions" affordance should highlight.

- **`license_file_mode() -> str | None`** — raw four-character octal (`"0600"`, `"0644"`, `"0666"`, …) for a debug row / operator-hint tile. `None` on no file or on Windows. Format matches `chmod` so an operator can copy-paste the digits verbatim into a `chmod 0600 <path>` fix.

Both scalars are **deliberately orthogonal to signature validity** — a tampered or expired license file still surfaces its real hygiene state (in fact, MORE urgent to surface — loose permissions may indicate the same corruption that broke the signature). This is different from `license_tier` / `license_subject` / `license_nodes`, which collapse to `None` on invalid/expired branches under the "refuse untrusted claims" posture. Here we're not surfacing a claim, we're surfacing a mode.

### HTTP surface

- `GET /api/license/permissions-safe` → `{permissions_safe, file_mode, has_license}`
- `GET /api/license/file-mode`        → `{file_mode, permissions_safe, has_license}`

Shared `_license_permissions_snapshot()` helper reads the trio once so the paired endpoints can't disagree on `has_license` / `file_mode` for the same install — a UI binding both sees a consistent snapshot. Both endpoints never 5xx — on any underlying failure they degrade to `{permissions_safe: null, file_mode: null, has_license: false}`, matching the never-crash posture of the surrounding license routes.

### Grace mode

Ships in **GRACE** — no enforcement, no behaviour change. Purely observational scalars a security-posture / "tighten permissions" affordance can bind to without pulling the whole `/api/license/status` envelope.

### Tests

36 new unit + endpoint tests in `tests/test_license_permissions_scalar.py` cover:

- No-license, active-tight (0o600), loose (0o644 / 0o666 / 0o640), owner-only (0o400), expired, invalid-signature, expired-plus-loose, never-raises branches on both scalars
- Windows branch: `os.name = "nt"` collapses `license_file_mode()` to `None`
- Same coverage on both `/api/license/permissions-safe` and `/api/license/file-mode`, plus never-5xx on introspection failure
- Cross-consistency: scalar ↔ endpoint agreement, paired endpoints return byte-identical `(permissions_safe, file_mode, has_license)`, envelope `permissions_safe` / `file_mode` match the module-level scalars, hygiene axis is orthogonal to the `valid` axis (invalid-signature with tight mode still reads safe)

All hermetic — ephemeral Ed25519 keypair + `tmp_path` license file + `CLAWMETRY_OFFLINE=1`; nothing here touches the operator's real license file. Existing `test_license_permissions.py` (7 tests), adjacent `test_license_*` scalars (153 tests), and `test_entitlement_api*` (39 tests) still pass — 198 total, no regressions.

## Files changed

- `clawmetry/license.py` — +84 lines (two new helpers appended after `is_within_node_limit()`)
- `routes/entitlement.py` — +136 lines (shared `_license_permissions_snapshot()` helper + two new route handlers inserted after `/api/license/within-node-limit`, grouped with the other `/api/license/*` endpoints)
- `tests/test_license_permissions_scalar.py` — +510 lines (new file)

## Test plan

- [x] `python3 -m py_compile clawmetry/license.py routes/entitlement.py tests/test_license_permissions_scalar.py` — clean
- [x] `python3 -m pytest tests/test_license_permissions_scalar.py -q` — 36 passed
- [x] `python3 -m pytest tests/test_license_permissions.py tests/test_license_{nodes,tier,days_until_expiry,is_expired_is_perpetual,pro_installation}_scalar.py tests/test_license_pro_installation.py -q` — 198 passed across the adjacent license + entitlement suites (no regressions)
- [x] `python3 -m pytest tests/test_entitlement_api.py tests/test_entitlement_api_fallback_shape.py -q` — included in the 198 above

## Local operator verification checklist

Because the autonomous fire can't touch the running daemon or the live cloud snapshot:

- [ ] Rebuild wheel or copy the changed files into `~/.clawmetry/lib/pythonX.Y/site-packages/clawmetry/` and `.../site-packages/routes/`.
- [ ] Clear `__pycache__` under both directories (`find ~/.clawmetry/lib -name __pycache__ -exec rm -rf {} +`).
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` (macOS) or the equivalent `systemctl --user restart` on Linux.
- [ ] Confirm `GET /api/license/permissions-safe` returns `{"permissions_safe": null, "file_mode": null, "has_license": false}` on a Free install.
- [ ] After `clawmetry activate <KEY>`, confirm `GET /api/license/permissions-safe` returns `{"permissions_safe": true, "file_mode": "0600", "has_license": true}`.
- [ ] With `chmod 0644 ~/.clawmetry/license.key`, confirm `GET /api/license/permissions-safe` returns `{"permissions_safe": false, "file_mode": "0644", "has_license": true}` — the "tighten permissions" affordance branch.
- [ ] Confirm `GET /api/license/file-mode` returns the same octal string via its own endpoint and both endpoints agree on `(permissions_safe, file_mode, has_license)`.
- [ ] Restore the safe mode: `chmod 0600 ~/.clawmetry/license.key` and re-hit both endpoints to confirm they flip back.
- [ ] Decrypt the live cloud snapshot and confirm the endpoints work through the cloud relay too.
- [ ] Browser-check any security-posture / operator-hint tiles bound to these URLs (dashboard hits `/api/license/status` today; the new scalars are opt-in).

## Notes

- No `__version__` bump, no tag, no `[RELEASE]` PR — the operator drives the release loop.
- No enforcement gate changes; both endpoints are read-only observational scalars.
- No new dependencies — uses `cryptography` (already required) and `flask` (already required).
- Complements open PR #4113 (`has_license` / `is_license_valid` install-state scalars) and #4116 (`license_subject` / `is_subject` subject-identity scalars) plus the merged `license_nodes` / `is_within_node_limit` node-capacity scalars — this PR is the **file-hygiene axis**; those cover install-state, subject-identity, and node-capacity respectively. None of them touch the same functions or the same tests.
- Pre-existing `daemon-allowlist` lint failures on `routes/usage.py:3612` and `routes/channels.py:824` reproduce on `origin/main` and are unrelated to this diff.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WVzAEFr7GvCmxAXqQ56YDq)_