### PR TITLE
fix(ci): update e2e-gate.yml tracking ref from #3864 to #4029

### DIFF
--- a/.github/workflows/e2e-gate.yml
+++ b/.github/workflows/e2e-gate.yml
@@ -21,7 +21,7 @@ name: E2E Gate (required)
 #   add "E2E Gate (required)"
 #   (1 check name instead of 4)
 #
-# Tracking: vivekchand/clawmetry#3864 (C6)
+# Tracking: vivekchand/clawmetry#4029 (C6)
 
 on:
   pull_request:


### PR DESCRIPTION
## Summary

`e2e-gate.yml` is the workflow that creates the `E2E Gate (required)` aggregated check -- the single check name the admin needs to add to branch protection to close C6. Its header comment still referenced ghost issue `#3864` instead of the active tracking issue `#4029`, so any automated cross-link from GitHub's check run back to the tracking issue was silently going nowhere.

**Change:** 1-line comment update: `#3864` -> `#4029` in `e2e-gate.yml` line 24.

## Test plan

- [ ] CI passes (no workflow logic changed -- comment-only fix)
- [ ] After merge: `e2e-gate.yml` header correctly links to the active tracking issue `#4029`

Tracking: vivekchand/clawmetry#4029 (C6)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BozkLYxeUSLTPZzafEua2k)_