### PR TITLE
feat(license): license_issued_at + license_age_days scalar helpers + endpoints

### DIFF
--- a/clawmetry/license.py
+++ b/clawmetry/license.py
@@ -898,6 +898,8 @@ def inspect_key(key: str) -> dict | None:
         tier_in = str(payload.get("tier", "pro")).strip().lower()
         # Mirror parse_license: known tiers render as-is, unknown -> pro.
         tier = tier_in if tier_in in ("enterprise", "starter") else "pro"
+        iat = payload.get("iat")
+        issued_at = int(iat) if isinstance(iat, (int, float)) else None
         return {
             "valid": not expired,
             "status": "expired" if expired else "active",
@@ -905,6 +907,7 @@ def inspect_key(key: str) -> dict | None:
             "nodes": int(payload.get("nodes", 1) or 1),
             "sub": str(payload.get("sub", "")),
             "exp": exp,
+            "issued_at": issued_at,
             "days_left": days_left,
             # Trust-anchor identity is payload-independent — same value as
             # current_license_info() populates on every file-exists branch, so
@@ -974,6 +977,7 @@ def current_license_info() -> dict | None:
                 "nodes": None,
                 "sub": None,
                 "exp": None,
+                "issued_at": None,
                 "days_left": None,
                 "pubkey_fingerprint_sha256": pubkey_fp,
                 "permissions_safe": perms_safe,
@@ -985,6 +989,8 @@ def current_license_info() -> dict | None:
         if isinstance(exp, (int, float)):
             days_left = int((exp - _t.time()) // 86400)
             expired = _t.time() > exp
+        iat = payload.get("iat")
+        issued_at = int(iat) if isinstance(iat, (int, float)) else None
         return {
             "valid": not expired,
             "status": "expired" if expired else "active",
@@ -992,6 +998,7 @@ def current_license_info() -> dict | None:
             "nodes": payload.get("nodes", 1),
             "sub": payload.get("sub", ""),
             "exp": exp,
+            "issued_at": issued_at,
             "days_left": days_left,
             "pubkey_fingerprint_sha256": pubkey_fp,
             "permissions_safe": perms_safe,
@@ -1597,3 +1604,89 @@ def license_file_mode() -> str | None:
     except Exception as exc:
         logger.debug("license: license_file_mode read failed: %s", exc)
         return None
+
+
+def license_issued_at() -> int | None:
+    """Scalar view onto the installed license's ``iat`` claim -- the epoch
+    timestamp the key was signed at -- for a "license issued: <date>" row
+    that wants ONE integer rather than the whole
+    :func:`current_license_info` envelope.
+
+    Returns:
+      * ``None`` when there is nothing trustworthy to surface: no license
+        file on disk, an invalid signature (the payload can't be trusted --
+        an attacker could stuff any ``iat`` into an unsigned body), OR a
+        signed payload whose ``iat`` claim is absent / non-numeric.
+      * A positive epoch integer otherwise -- the exact timestamp carried
+        by the signed payload, unmodified.
+
+    Deliberately lenient on expiry, unlike :func:`license_tier` /
+    :func:`license_nodes` / :func:`license_subject`: an expired but
+    signature-valid key still carries a meaningful ``iat`` (support
+    scenario: "how old is this lapsed key?") and callers would otherwise
+    have to fall back to ``/api/license/status``. Mirrors the "works on
+    expired keys" posture of :func:`days_until_expiry`, which continues to
+    return signed integer days past expiry so a UI can render "expired 12
+    days ago" without special-casing.
+
+    Never raises. Any exception under the hood degrades to ``None`` so a
+    UI tile bound to this helper never breaks on a partial install.
+    """
+    try:
+        info = current_license_info()
+    except Exception as exc:
+        logger.debug("license: license_issued_at underlying read failed: %s", exc)
+        return None
+    if not isinstance(info, dict):
+        return None
+    if info.get("status") == "invalid":
+        # Invalid-signature branch: payload cannot be trusted, refuse to
+        # surface any payload-derived claim (mirrors the tier / nodes /
+        # subject scalars). Expired-but-signed keys still carry a
+        # meaningful ``iat`` so we do NOT refuse them here.
+        return None
+    issued = info.get("issued_at")
+    return int(issued) if isinstance(issued, int) else None
+
+
+def license_age_days() -> int | None:
+    """Scalar view onto the installed license's age -- days since the
+    ``iat`` claim -- for a support/audit tile that wants ONE integer
+    rather than computing ``(now - iat) // 86400`` at every call site.
+
+    Returns:
+      * ``None`` when there is nothing meaningful to derive: no license
+        file, an invalid signature, or a signed payload whose ``iat``
+        claim is absent / non-numeric.
+      * A non-negative integer number of days otherwise. Zero on the day
+        of issuance; grows monotonically thereafter.
+
+    Days are floor-divided from seconds (``(now - iat) // 86400``),
+    matching how :func:`days_until_expiry` derives its counterpart from
+    ``(exp - now)`` so the two scalars never disagree at the day
+    boundary. Clamped to ``max(0, ...)`` to guard against clock skew
+    (``iat`` in the future would otherwise render as a negative age).
+
+    Pairs with :func:`license_issued_at` the way :func:`days_until_expiry`
+    pairs with the raw ``exp`` claim on :func:`current_license_info` --
+    the raw scalar surfaces the epoch, this one surfaces the caller-
+    friendly derived integer without either side having to do the arithmetic.
+
+    Never raises. Any exception under the hood degrades to ``None`` so a
+    scheduled audit tile never crashes on a bad install.
+    """
+    import time as _t
+
+    try:
+        issued = license_issued_at()
+    except Exception as exc:
+        logger.debug("license: license_age_days underlying read failed: %s", exc)
+        return None
+    if not isinstance(issued, int):
+        return None
+    try:
+        age = int((_t.time() - issued) // 86400)
+    except Exception as exc:
+        logger.debug("license: license_age_days arithmetic failed: %s", exc)
+        return None
+    return age if age >= 0 else 0

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -9032,6 +9032,170 @@ def api_license_file_mode():
         )
 
 
+def _license_issued_snapshot() -> dict:
+    """Shared helper: read once, derive the quartet the two ``iat``-derived
+    endpoints both need (``issued_at``, ``age_days``, ``has_license``,
+    ``valid``). Lives in the handler layer -- not in
+    :mod:`clawmetry.license` -- because ``has_license`` is an install-state
+    fact rather than a license-payload fact, and both endpoints below need
+    the pair together so a UI cannot catch them disagreeing on
+    ``has_license`` for the same install.
+
+    Deliberately lenient on expiry, matching the ``license_issued_at`` /
+    ``license_age_days`` posture: a signed-but-lapsed key still surfaces
+    its real ``issued_at`` / ``age_days`` so a support/audit tile can
+    render "issued 800 days ago" without special-casing the expired
+    branch. The ``valid`` field independently carries the "signature-valid
+    AND not expired" signal for callers that DO want to hide the row on
+    lapsed keys.
+
+    Never raises: any underlying failure collapses to
+    ``{issued_at: None, age_days: None, has_license: False, valid: False}``
+    so callers keep the "OSS-free" branch shape.
+    """
+    try:
+        from clawmetry import license as _lic
+
+        info = _lic.current_license_info()
+        issued = _lic.license_issued_at()
+        age = _lic.license_age_days()
+    except Exception as exc:
+        logger.debug("_license_issued_snapshot: underlying read failed: %s", exc)
+        return {
+            "issued_at": None,
+            "age_days": None,
+            "has_license": False,
+            "valid": False,
+        }
+    if not isinstance(info, dict):
+        return {
+            "issued_at": None,
+            "age_days": None,
+            "has_license": False,
+            "valid": False,
+        }
+    return {
+        "issued_at": issued,
+        "age_days": age,
+        "has_license": True,
+        "valid": bool(info.get("valid")),
+    }
+
+
+@bp_entitlement.route("/api/license/issued-at")
+def api_license_issued_at():
+    """``GET /api/license/issued-at`` -- scalar view of the installed
+    license's ``iat`` claim (epoch seconds), for a "license issued: <date>"
+    row that wants ONE integer rather than the whole
+    ``/api/license/status`` envelope.
+
+    Response shape (always HTTP 200)::
+
+        {
+          "issued_at": <int|null>,   # epoch seconds; None if untrusted
+          "age_days": <int|null>,    # days since issuance
+          "has_license": <bool>,     # is a license file installed at all?
+          "valid": <bool>            # signature-valid AND not expired
+        }
+
+    ``issued_at`` mirrors :func:`clawmetry.license.license_issued_at`:
+
+      * ``null`` when there is no license file, on the invalid-signature
+        branch (payload cannot be trusted -- an attacker could stuff any
+        ``iat`` into an unsigned body), OR when the signed payload has
+        no ``iat`` claim.
+      * A positive epoch integer otherwise, unmodified from the signed
+        payload.
+
+    Deliberately lenient on expiry, unlike ``/api/license/nodes`` and
+    ``/api/license/tier``: a signed-but-lapsed key still surfaces its
+    real ``issued_at`` so a support tile can render "issued 800 days ago"
+    on an expired key. The ``valid`` field independently carries the
+    "signature-valid AND not expired" signal for callers that DO want to
+    hide the row on lapsed keys.
+
+    Pairs with ``/api/license/age-days`` -- this endpoint surfaces the
+    raw epoch for a debug row, that endpoint answers the "how old" gate a
+    UI tile needs without the caller having to do the arithmetic. The two
+    endpoints share :func:`_license_issued_snapshot` so a UI binding both
+    sees a consistent snapshot.
+
+    Never 5xxs -- any underlying failure degrades to
+    ``{issued_at: null, age_days: null, has_license: false, valid: false}``
+    (the OSS-free branch shape), matching the never-crash posture of the
+    surrounding license endpoints.
+    """
+    try:
+        return jsonify(_license_issued_snapshot())
+    except Exception as exc:
+        logger.warning("api_license_issued_at: error: %s", exc)
+        return jsonify(
+            {
+                "issued_at": None,
+                "age_days": None,
+                "has_license": False,
+                "valid": False,
+            }
+        )
+
+
+@bp_entitlement.route("/api/license/age-days")
+def api_license_age_days():
+    """``GET /api/license/age-days`` -- scalar view of the installed
+    license's age (days since the ``iat`` claim), for a support/audit
+    tile that wants ONE integer rather than computing
+    ``(now - iat) // 86400`` at the call site.
+
+    Response shape (always HTTP 200)::
+
+        {
+          "age_days": <int|null>,    # days since issuance; None if untrusted
+          "issued_at": <int|null>,   # epoch seconds
+          "has_license": <bool>,     # is a license file installed at all?
+          "valid": <bool>            # signature-valid AND not expired
+        }
+
+    ``age_days`` mirrors :func:`clawmetry.license.license_age_days`:
+
+      * ``null`` when there is no license file, on the invalid-signature
+        branch, or when the signed payload has no ``iat`` claim.
+      * A non-negative integer otherwise -- zero on the day of issuance,
+        growing monotonically thereafter. Clamped to ``max(0, ...)`` so a
+        clock-skew ``iat`` in the future never renders as a negative age.
+
+    Days are floor-divided from seconds ``(now - iat) // 86400``,
+    matching how ``/api/license/days-until-expiry`` derives its
+    counterpart from ``(exp - now)`` so the two scalars never disagree at
+    the day boundary.
+
+    Deliberately lenient on expiry (see ``/api/license/issued-at``): a
+    signed-but-lapsed key still surfaces its real ``age_days``. The
+    ``valid`` field independently carries the "signature-valid AND not
+    expired" signal for callers that want to hide the row on lapsed keys.
+
+    Never 5xxs -- any underlying failure degrades to
+    ``{age_days: null, issued_at: null, has_license: false, valid: false}``.
+    """
+    try:
+        snap = _license_issued_snapshot()
+        return jsonify(
+            {
+                "age_days": snap["age_days"],
+                "issued_at": snap["issued_at"],
+                "has_license": snap["has_license"],
+                "valid": snap["valid"],
+            }
+        )
+    except Exception as exc:
+        logger.warning("api_license_age_days: error: %s", exc)
+        return jsonify(
+            {
+                "age_days": None,
+                "issued_at": None,
+                "has_license": False,
+                "valid": False,
+            }
+        )
 
 
 @bp_entitlement.route("/api/paywall/event", methods=["POST"])

--- a/tests/test_license.py
+++ b/tests/test_license.py
@@ -499,7 +499,7 @@ def test_inspect_key_fingerprint_degrades_to_none_when_pubkey_broken(lic, monkey
 # a UI can render the row without special-casing which keys are present.
 
 _EXPECTED_FILE_EXISTS_KEYS = frozenset({
-    "valid", "status", "tier", "nodes", "sub", "exp", "days_left",
+    "valid", "status", "tier", "nodes", "sub", "exp", "issued_at", "days_left",
     "pubkey_fingerprint_sha256", "permissions_safe", "file_mode",
 })
 

--- a/tests/test_license_issued_scalar.py
+++ b/tests/test_license_issued_scalar.py
@@ -1,0 +1,428 @@
+"""Tests for the ``license_issued_at()`` / ``license_age_days()`` scalar
+helpers in :mod:`clawmetry.license` plus their matching
+``/api/license/issued-at`` and ``/api/license/age-days`` HTTP endpoints.
+
+Mirrors ``tests/test_license_days_until_expiry.py``'s hermetic pattern --
+ephemeral Ed25519 keypair, ``LICENSE_PATH`` monkeypatched into
+``tmp_path``, and ``CLAWMETRY_OFFLINE=1`` so ``activate()`` never phones
+home during the suite. Nothing here touches the operator's real license
+file.
+"""
+from __future__ import annotations
+
+import os
+import time
+from types import SimpleNamespace
+
+import pytest
+from flask import Flask
+
+
+def _keypair():
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+    priv = Ed25519PrivateKey.generate()
+    pub_pem = priv.public_key().public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    return priv, pub_pem
+
+
+def _payload(
+    tier="pro",
+    nodes=3,
+    exp_delta=365 * 86400,
+    iat_delta=0,
+    drop_iat=False,
+    bad_iat=None,
+):
+    """Build a signed-payload dict. ``iat_delta`` shifts ``iat`` from now
+    (negative = older); ``drop_iat`` omits the claim; ``bad_iat`` forces
+    a non-numeric value."""
+    now = int(time.time())
+    p = {
+        "sub": "acct_test",
+        "tier": tier,
+        "nodes": nodes,
+        "iat": now + iat_delta,
+        "exp": now + exp_delta,
+        "features": ["runtimes"],
+    }
+    if drop_iat:
+        p.pop("iat", None)
+    if bad_iat is not None:
+        p["iat"] = bad_iat
+    return p
+
+
+@pytest.fixture
+def app(monkeypatch, tmp_path):
+    import clawmetry.license as _lic
+
+    priv, pub_pem = _keypair()
+    monkeypatch.setattr(_lic, "_PUBLIC_KEY_PEM", pub_pem)
+    license_path = str(tmp_path / "license.key")
+    monkeypatch.setattr(_lic, "LICENSE_PATH", license_path)
+    monkeypatch.delenv("CLAWMETRY_LICENSE_SERVER", raising=False)
+    monkeypatch.delenv("CLAWMETRY_INGEST_URL", raising=False)
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("CLAWMETRY_OFFLINE", "1")
+
+    from routes.entitlement import bp_entitlement
+
+    flask_app = Flask(__name__)
+    flask_app.register_blueprint(bp_entitlement)
+    flask_app.config["TESTING"] = True
+
+    return SimpleNamespace(
+        app=flask_app,
+        lic=_lic,
+        priv=priv,
+        license_path=license_path,
+    )
+
+
+def _write_key_direct(app, payload):
+    """Bypass ``activate()`` (which refuses expired/malformed tokens) and
+    write a token directly to the license file. Simulates a licence that
+    expired AFTER install or was signed with an anomalous ``iat``."""
+    tok = app.lic._encode_token(payload, app.priv)
+    os.makedirs(os.path.dirname(app.license_path), exist_ok=True)
+    with open(app.license_path, "w", encoding="utf-8") as fh:
+        fh.write(tok)
+
+
+# ── clawmetry.license.license_issued_at() ─────────────────────────────────────
+
+
+def test_license_issued_at_none_when_no_license(app):
+    """No license file on disk -> None (nothing to surface)."""
+    assert app.lic.license_issued_at() is None
+
+
+def test_license_issued_at_active_returns_epoch(app):
+    """Active licence -> the exact ``iat`` epoch, unmodified from the
+    signed payload."""
+    now = int(time.time())
+    tok = app.lic._encode_token(_payload(iat_delta=-3600), app.priv)  # 1h ago
+    app.lic.activate(tok)
+    issued = app.lic.license_issued_at()
+    assert isinstance(issued, int)
+    # Allow +/- 5s for wall-clock jitter around the call.
+    assert (now - 3600) - 5 <= issued <= (now - 3600) + 5
+
+
+def test_license_issued_at_expired_still_returns_epoch(app):
+    """Expired-but-signed licence -> still surfaces ``iat``. Unlike
+    :func:`license_tier` / :func:`license_nodes`, this scalar is lenient
+    on expiry so a support UI can render "issued 800 days ago" on lapsed
+    keys."""
+    _write_key_direct(app, _payload(iat_delta=-800 * 86400, exp_delta=-5 * 86400))
+    issued = app.lic.license_issued_at()
+    assert isinstance(issued, int)
+    assert issued < int(time.time())
+
+
+def test_license_issued_at_invalid_signature(app):
+    """File on disk but signature bogus -> None. An attacker could stuff
+    any ``iat`` into an unsigned body, so we refuse to trust it."""
+    os.makedirs(os.path.dirname(app.license_path), exist_ok=True)
+    with open(app.license_path, "w", encoding="utf-8") as fh:
+        fh.write("CLAW1.garbage.garbage")
+    assert app.lic.license_issued_at() is None
+
+
+def test_license_issued_at_missing_iat_claim(app):
+    """Payload with no ``iat`` claim -> None. Signed but nothing to surface."""
+    _write_key_direct(app, _payload(drop_iat=True))
+    assert app.lic.license_issued_at() is None
+
+
+def test_license_issued_at_non_numeric_iat(app):
+    """Payload with a non-numeric ``iat`` -> None (never raises)."""
+    _write_key_direct(app, _payload(bad_iat="tomorrow"))
+    assert app.lic.license_issued_at() is None
+
+
+def test_license_issued_at_never_raises(monkeypatch):
+    """Any underlying failure -> None. Even a fully-broken
+    current_license_info() must not propagate."""
+    import clawmetry.license as _lic
+
+    def _boom():
+        raise RuntimeError("simulated corrupt install")
+
+    monkeypatch.setattr(_lic, "current_license_info", _boom)
+    assert _lic.license_issued_at() is None
+
+
+# ── clawmetry.license.license_age_days() ──────────────────────────────────────
+
+
+def test_license_age_days_none_when_no_license(app):
+    assert app.lic.license_age_days() is None
+
+
+def test_license_age_days_zero_on_day_of_issue(app):
+    """Just-issued licence -> 0 days old."""
+    tok = app.lic._encode_token(_payload(iat_delta=0), app.priv)
+    app.lic.activate(tok)
+    assert app.lic.license_age_days() == 0
+
+
+def test_license_age_days_positive_after_days(app):
+    """Licence issued N days ago -> ~N days old (floor-divided from seconds)."""
+    _write_key_direct(app, _payload(iat_delta=-30 * 86400))
+    age = app.lic.license_age_days()
+    assert isinstance(age, int)
+    # Allow +/- 1 for clock jitter across the day boundary.
+    assert 29 <= age <= 31
+
+
+def test_license_age_days_works_on_expired_licence(app):
+    """Expired-but-signed licence -> still returns an age. The scalar
+    mirrors :func:`license_issued_at` (lenient on expiry)."""
+    _write_key_direct(app, _payload(iat_delta=-400 * 86400, exp_delta=-30 * 86400))
+    age = app.lic.license_age_days()
+    assert isinstance(age, int)
+    assert 399 <= age <= 401
+
+
+def test_license_age_days_clock_skew_iat_in_future_clamps_to_zero(app):
+    """A clock-skewed ``iat`` in the future must not render as a negative
+    age -- clamped to 0 so callers can safely render ``f"{age} days old"``."""
+    _write_key_direct(app, _payload(iat_delta=+7 * 86400))
+    age = app.lic.license_age_days()
+    assert age == 0
+
+
+def test_license_age_days_invalid_signature(app):
+    """File on disk but signature bogus -> None (refuse to derive age
+    from an untrusted ``iat``)."""
+    os.makedirs(os.path.dirname(app.license_path), exist_ok=True)
+    with open(app.license_path, "w", encoding="utf-8") as fh:
+        fh.write("CLAW1.garbage.garbage")
+    assert app.lic.license_age_days() is None
+
+
+def test_license_age_days_missing_iat_claim(app):
+    _write_key_direct(app, _payload(drop_iat=True))
+    assert app.lic.license_age_days() is None
+
+
+def test_license_age_days_never_raises(monkeypatch):
+    import clawmetry.license as _lic
+
+    def _boom():
+        raise RuntimeError("simulated corrupt install")
+
+    monkeypatch.setattr(_lic, "license_issued_at", _boom)
+    assert _lic.license_age_days() is None
+
+
+# ── current_license_info() / inspect_key() envelope carry ``issued_at`` ──────
+
+
+def test_current_license_info_active_carries_issued_at(app):
+    tok = app.lic._encode_token(_payload(iat_delta=-3600), app.priv)
+    app.lic.activate(tok)
+    info = app.lic.current_license_info()
+    assert isinstance(info, dict)
+    assert "issued_at" in info
+    assert isinstance(info["issued_at"], int)
+
+
+def test_current_license_info_invalid_signature_issued_at_none(app):
+    os.makedirs(os.path.dirname(app.license_path), exist_ok=True)
+    with open(app.license_path, "w", encoding="utf-8") as fh:
+        fh.write("CLAW1.garbage.garbage")
+    info = app.lic.current_license_info()
+    assert isinstance(info, dict)
+    assert info["issued_at"] is None
+
+
+def test_current_license_info_expired_carries_issued_at(app):
+    _write_key_direct(app, _payload(iat_delta=-100 * 86400, exp_delta=-1 * 86400))
+    info = app.lic.current_license_info()
+    assert isinstance(info, dict)
+    assert isinstance(info["issued_at"], int)
+
+
+def test_inspect_key_carries_issued_at(app):
+    """Dry-run inspector must expose ``issued_at`` too so a UI can render
+    a "would install" summary the same way it renders the on-disk one."""
+    tok = app.lic._encode_token(_payload(iat_delta=-2 * 86400), app.priv)
+    dry = app.lic.inspect_key(tok)
+    assert isinstance(dry, dict)
+    assert "issued_at" in dry
+    assert isinstance(dry["issued_at"], int)
+
+
+# ── GET /api/license/issued-at ───────────────────────────────────────────────
+
+
+def test_endpoint_issued_at_no_license(app):
+    with app.app.test_client() as c:
+        resp = c.get("/api/license/issued-at")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data == {
+        "issued_at": None,
+        "age_days": None,
+        "has_license": False,
+        "valid": False,
+    }
+
+
+def test_endpoint_issued_at_active(app):
+    tok = app.lic._encode_token(_payload(iat_delta=-3 * 86400), app.priv)
+    app.lic.activate(tok)
+    with app.app.test_client() as c:
+        resp = c.get("/api/license/issued-at")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert isinstance(data["issued_at"], int)
+    assert isinstance(data["age_days"], int)
+    assert 2 <= data["age_days"] <= 4
+    assert data["has_license"] is True
+    assert data["valid"] is True
+
+
+def test_endpoint_issued_at_expired(app):
+    """Lenient on expiry: surface ``issued_at`` + ``age_days`` on lapsed
+    keys; ``valid=false`` carries the "signed but expired" signal."""
+    _write_key_direct(app, _payload(iat_delta=-500 * 86400, exp_delta=-5 * 86400))
+    with app.app.test_client() as c:
+        resp = c.get("/api/license/issued-at")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert isinstance(data["issued_at"], int)
+    assert isinstance(data["age_days"], int)
+    assert data["has_license"] is True
+    assert data["valid"] is False
+
+
+def test_endpoint_issued_at_invalid_file(app):
+    os.makedirs(os.path.dirname(app.license_path), exist_ok=True)
+    with open(app.license_path, "w", encoding="utf-8") as fh:
+        fh.write("CLAW1.garbage.garbage")
+    with app.app.test_client() as c:
+        resp = c.get("/api/license/issued-at")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["has_license"] is True
+    assert data["issued_at"] is None
+    assert data["age_days"] is None
+    assert data["valid"] is False
+
+
+def test_endpoint_issued_at_never_5xxs(app, monkeypatch):
+    """Even if the shared snapshot blows up mid-request, the endpoint
+    must still return HTTP 200 with the OSS-free shape."""
+    from routes import entitlement as _routes
+
+    monkeypatch.setattr(
+        _routes,
+        "_license_issued_snapshot",
+        lambda: (_ for _ in ()).throw(RuntimeError("simulated blowup")),
+    )
+    with app.app.test_client() as c:
+        resp = c.get("/api/license/issued-at")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data == {
+        "issued_at": None,
+        "age_days": None,
+        "has_license": False,
+        "valid": False,
+    }
+
+
+# ── GET /api/license/age-days ────────────────────────────────────────────────
+
+
+def test_endpoint_age_days_no_license(app):
+    with app.app.test_client() as c:
+        resp = c.get("/api/license/age-days")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data == {
+        "age_days": None,
+        "issued_at": None,
+        "has_license": False,
+        "valid": False,
+    }
+
+
+def test_endpoint_age_days_active(app):
+    tok = app.lic._encode_token(_payload(iat_delta=-14 * 86400), app.priv)
+    app.lic.activate(tok)
+    with app.app.test_client() as c:
+        resp = c.get("/api/license/age-days")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert isinstance(data["age_days"], int)
+    assert 13 <= data["age_days"] <= 15
+    assert isinstance(data["issued_at"], int)
+    assert data["has_license"] is True
+    assert data["valid"] is True
+
+
+def test_endpoint_age_days_clock_skew_clamps_to_zero(app):
+    """``iat`` in the future -> age_days clamps to 0, never negative."""
+    _write_key_direct(app, _payload(iat_delta=+30 * 86400))
+    with app.app.test_client() as c:
+        resp = c.get("/api/license/age-days")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["age_days"] == 0
+    assert data["has_license"] is True
+
+
+def test_endpoint_age_days_missing_iat(app):
+    _write_key_direct(app, _payload(drop_iat=True))
+    with app.app.test_client() as c:
+        resp = c.get("/api/license/age-days")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["age_days"] is None
+    assert data["issued_at"] is None
+    assert data["has_license"] is True
+
+
+def test_endpoint_age_days_never_5xxs(app, monkeypatch):
+    from routes import entitlement as _routes
+
+    monkeypatch.setattr(
+        _routes,
+        "_license_issued_snapshot",
+        lambda: (_ for _ in ()).throw(RuntimeError("simulated blowup")),
+    )
+    with app.app.test_client() as c:
+        resp = c.get("/api/license/age-days")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data == {
+        "age_days": None,
+        "issued_at": None,
+        "has_license": False,
+        "valid": False,
+    }
+
+
+# ── consistency: both endpoints see the same snapshot ────────────────────────
+
+
+def test_both_endpoints_agree_on_snapshot(app):
+    """Both endpoints share :func:`_license_issued_snapshot` -- they must
+    surface identical ``issued_at`` / ``age_days`` / ``has_license`` /
+    ``valid`` values for the same install."""
+    tok = app.lic._encode_token(_payload(iat_delta=-42 * 86400), app.priv)
+    app.lic.activate(tok)
+    with app.app.test_client() as c:
+        a = c.get("/api/license/issued-at").get_json()
+        b = c.get("/api/license/age-days").get_json()
+    for key in ("issued_at", "age_days", "has_license", "valid"):
+        assert a[key] == b[key], f"mismatch on {key}: {a[key]!r} vs {b[key]!r}"


### PR DESCRIPTION
## Summary

Adds two scalar helpers on the installed licence's `iat` claim (issued-at epoch) and their matching HTTP endpoints, mirroring the pattern already used by `days_until_expiry`/`is_expiring_within` and the `license_permissions_safe`/`license_file_mode` pair.

- `clawmetry.license.license_issued_at() -> int | None` — signed `iat` epoch or `None` on no-file / invalid-signature / missing-claim.
- `clawmetry.license.license_age_days() -> int | None` — derived days since `iat`, floor-divided from seconds, clamped to `max(0, ...)` so a clock-skew `iat` in the future never renders as a negative age.
- `GET /api/license/issued-at` and `GET /api/license/age-days` — return `{issued_at, age_days, has_license, valid}`. Never 5xx; degrade to the OSS-free branch on any underlying failure. Both endpoints share `_license_issued_snapshot()` so a UI binding both cannot catch them disagreeing.

### Envelope carry

`current_license_info()` and `inspect_key()` now surface `issued_at` in every file-exists branch (`None` on invalid-signature / missing-claim, positive int otherwise), keeping the shape uniform the same way `permissions_safe`/`file_mode` do. The shape-pin `frozenset` in `tests/test_license.py` was extended accordingly.

### Design note — leniency on expiry

Both scalars deliberately surface a value on expired-but-signed keys, unlike `license_tier`/`license_nodes`/`license_subject`. An expired key still carries a meaningful `iat` (support scenario: "how old is this lapsed key?"), and the envelope's `valid` field independently carries the signed-but-expired signal for callers that want to hide the row on lapsed installs. This mirrors `days_until_expiry`, which continues to return signed integer days past expiry.

## Test plan

30 new tests in `tests/test_license_issued_scalar.py`; 357 adjacent license tests still green.

- [x] `python -m py_compile clawmetry/license.py routes/entitlement.py tests/test_license_issued_scalar.py`
- [x] `python -m pytest tests/test_license_issued_scalar.py -x -q` — 30 passed
- [x] `python -m pytest tests/test_license*.py tests/test_cli_license_json.py tests/test_cli_status_license.py -q` — 357 passed, 1 skipped
- [x] `python -m pytest tests/test_entitlement_api.py tests/test_entitlement_api_fallback_shape.py tests/test_paywall_events_api.py -q` — 58 passed
- [x] No changes to `dashboard.py`, `__version__`, or any release-triggering path — this stays a small helper-tier addition matching the recent PRs (#4113, #4116, #4121).

### Local operator verification checklist

I can't do these from the CI environment; leaving for the operator on the host:

- [ ] Copy the changed files into `~/.clawmetry/lib/pythonX.Y/site-packages/clawmetry/` (or however you overlay the working tree onto the running daemon).
- [ ] Clear `__pycache__/` under both `clawmetry/` and `routes/`.
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` to restart the sync daemon.
- [ ] `curl -s http://localhost:8900/api/license/issued-at | jq` and `curl -s http://localhost:8900/api/license/age-days | jq` — expect matching `issued_at` / `age_days` values and the correct `valid` / `has_license` for your install (or the OSS-free shape if no licence is installed).
- [ ] `curl -s http://localhost:8900/api/license/status | jq` — check the envelope now includes `issued_at` next to the other payload fields.
- [ ] Decrypt the live cloud snapshot and confirm the new fields flow through cleanly (no breakage in the browser).
- [ ] Browser: hit any tile bound to the licence envelope and check nothing regressed on the shape change.

If any of that is red, ping this PR — the changes are additive so a revert is a two-line frozenset pull-back plus this branch.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pt5GRaqxV6YraohdrxRaXp)_