### PR TITLE
e2e(C6): test administration:write at job level to auto-close required-checks gate

### DIFF
--- a/.github/workflows/c6-admin-test.yml
+++ b/.github/workflows/c6-admin-test.yml
@@ -1,0 +1,309 @@
+name: C6 ruleset upsert (job-level administration:write test)
+
+# Tests whether GITHUB_TOKEN with 'administration: write' declared at the
+# JOB level (not the workflow level) can create a repository ruleset that
+# enforces 'E2E Gate (required)' on clawmetry/main.
+#
+# WHY THIS PR:
+#   All previous C6 auto-close attempts requested 'administration: write' at
+#   the WORKFLOW level, which was confirmed to cause "0 jobs queued" on this
+#   personal repo (run #30243855242). This workflow tests the JOB-LEVEL variant
+#   which has NOT been tried before.
+#
+# OUTCOMES:
+#   a) "0 jobs queued" for the whole workflow ->
+#      Job-level admin:write also unsupported on this repo/plan. Revert this
+#      file. C6 needs human action via Settings UI or close-c6.sh.
+#   b) Job runs but returns 403 ->
+#      ::error:: annotation and exit 1 make it visible. C6 needs human action.
+#   c) Job runs and succeeds ->
+#      C6 is NOW GREEN -- ruleset applied, PRs cannot merge without E2E Gate.
+#
+# The existing c6-apply-ruleset.yml is NOT modified: its graceful-403 behaviour
+# is preserved as a fallback regardless of this test outcome.
+#
+# CLEANUP:
+#   Outcome (a) or (b): delete this file in a follow-up PR.
+#   Outcome (c): merge this file's logic into c6-apply-ruleset.yml and delete.
+#
+# Tracking: vivekchand/clawmetry#4029 (C6)
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: c6-admin-job-level-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  upsert-ruleset:
+    name: C6 ruleset upsert (job-level administration:write)
+    runs-on: ubuntu-latest
+    # Job-level permissions -- NOT workflow level.
+    # Workflow-level administration:write caused "0 jobs queued" (run #30243855242).
+    # Job-level has not been tested. If GitHub still refuses, outcomes (a)/(b) apply.
+    permissions:
+      administration: write
+      contents: read
+      issues: write
+
+    steps:
+      - name: Upsert E2E required-checks ruleset via job-level administration:write
+        id: upsert
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          python3 - <<'PYEOF'
+          import json
+          import os
+          import sys
+          import urllib.error
+          import urllib.request
+
+          TOKEN = os.environ["GITHUB_TOKEN"]
+          OWNER = "vivekchand"
+          REPO = "clawmetry"
+          RULESET_NAME = "E2E Required Status Checks (C6)"
+          REQUIRED_CHECKS = ["E2E Gate (required)"]
+
+          HEADERS = {
+              "Authorization": f"Bearer {TOKEN}",
+              "Accept": "application/vnd.github+json",
+              "X-GitHub-Api-Version": "2022-11-28",
+              "Content-Type": "application/json",
+              "User-Agent": "clawmetry-c6-admin-test/1.0",
+          }
+
+          def set_output(key, value):
+              path = os.environ.get("GITHUB_OUTPUT", "")
+              if path:
+                  with open(path, "a") as f:
+                      f.write(f"{key}={value}\n")
+
+          def api(method, path, body=None):
+              url = f"https://api.github.com{path}"
+              data = json.dumps(body).encode() if body is not None else None
+              req = urllib.request.Request(url, data=data, headers=HEADERS, method=method)
+              try:
+                  with urllib.request.urlopen(req) as r:
+                      return json.loads(r.read()), None
+              except urllib.error.HTTPError as exc:
+                  raw = exc.read().decode(errors="replace")
+                  return None, (exc.code, raw)
+
+          print("Testing Rulesets API with job-level administration:write ...")
+          print(f"  Token prefix: {TOKEN[:8]}...")
+          print()
+
+          rulesets, err = api("GET", f"/repos/{OWNER}/{REPO}/rulesets")
+          if err:
+              code, body = err
+              if code == 403:
+                  print(
+                      "::error title=C6 admin:write blocked::"
+                      "403 on GET /rulesets even with job-level administration:write. "
+                      "GITHUB_TOKEN cannot manage rulesets on this personal repo. "
+                      "C6 requires human action: bash scripts/close-c6.sh (30 s) or "
+                      "Settings UI (60 s). "
+                      "Tracking: https://github.com/vivekchand/clawmetry/issues/4029"
+                  )
+                  set_output("result", "blocked_403")
+                  sys.exit(1)
+              else:
+                  print(f"::error::GET /rulesets failed: {code} {body[:400]}")
+                  set_output("result", "error")
+                  sys.exit(1)
+
+          print(f"GET /rulesets succeeded -- {len(rulesets or [])} existing ruleset(s) found.")
+
+          existing_id = None
+          for rs in (rulesets or []):
+              if rs.get("name") == RULESET_NAME:
+                  existing_id = rs["id"]
+                  print(f"  Found existing ruleset id={existing_id}: {RULESET_NAME!r}")
+                  break
+
+          ruleset_body = {
+              "name": RULESET_NAME,
+              "target": "branch",
+              "enforcement": "active",
+              "conditions": {
+                  "ref_name": {
+                      "include": ["refs/heads/main"],
+                      "exclude": [],
+                  }
+              },
+              "rules": [
+                  {
+                      "type": "required_status_checks",
+                      "parameters": {
+                          "strict_required_status_checks_policy": False,
+                          "required_status_checks": [
+                              {"context": c} for c in REQUIRED_CHECKS
+                          ],
+                      },
+                  }
+              ],
+          }
+
+          if existing_id:
+              result, err = api(
+                  "PUT",
+                  f"/repos/{OWNER}/{REPO}/rulesets/{existing_id}",
+                  ruleset_body,
+              )
+              verb = "Updated"
+          else:
+              result, err = api(
+                  "POST",
+                  f"/repos/{OWNER}/{REPO}/rulesets",
+                  ruleset_body,
+              )
+              verb = "Created"
+
+          if err:
+              code, body = err
+              if code == 403:
+                  print(
+                      f"::error title=C6 admin:write blocked::"
+                      f"403 on {verb} /rulesets -- GITHUB_TOKEN cannot write rulesets "
+                      "even with job-level administration:write. "
+                      "C6 requires human action: bash scripts/close-c6.sh (30 s) or "
+                      "Settings UI (60 s). "
+                      "Tracking: https://github.com/vivekchand/clawmetry/issues/4029"
+                  )
+                  set_output("result", "blocked_403")
+                  sys.exit(1)
+              else:
+                  print(f"::error::{verb} ruleset failed: {code} {body[:400]}")
+                  set_output("result", "error")
+                  sys.exit(1)
+
+          rs_id = (result or {}).get("id", "?")
+          rs_url = (result or {}).get("html_url", "")
+          print()
+          print(f"SUCCESS: {verb} ruleset id={rs_id}")
+          if rs_url:
+              print(f"  {rs_url}")
+          print(f"  Enforcing: {REQUIRED_CHECKS}")
+          print()
+          print("C6 is NOW GREEN -- job-level administration:write WORKS on this personal repo.")
+          print("PRs cannot merge without E2E Gate (required) passing.")
+          print(f"Verify: https://github.com/{OWNER}/{REPO}/settings/branches")
+          set_output("result", "success")
+          PYEOF
+
+      - name: Write job summary
+        if: always()
+        env:
+          RESULT: ${{ steps.upsert.outputs.result }}
+        run: |
+          {
+            echo "## C6 job-level administration:write test"
+            echo ""
+            case "${RESULT:-}" in
+              success)
+                echo "> :white_check_mark: **C6 is NOW GREEN.** Ruleset applied via job-level administration:write."
+                echo ">"
+                echo "> Required check enforced: \`E2E Gate (required)\` on \`clawmetry/main\`."
+                echo "> PRs cannot merge without E2E passing."
+                echo "> [Verify](https://github.com/vivekchand/clawmetry/settings/branches)"
+                echo "> Tracking: [#4029](https://github.com/vivekchand/clawmetry/issues/4029)"
+                ;;
+              blocked_403)
+                echo "> :x: **403 blocked.** GITHUB_TOKEN cannot manage rulesets even with job-level administration:write."
+                echo ">"
+                echo "> **C6 requires a one-time human action.**"
+                echo ">"
+                echo "> Fastest close -- browser only, 60 s:"
+                echo "> 1. [clawmetry Settings > Branches](https://github.com/vivekchand/clawmetry/settings/branches)"
+                echo ">    Edit main > Require status checks > add \`E2E Gate (required)\`"
+                echo "> 2. [clawmetry-cloud Settings > Branches](https://github.com/vivekchand/clawmetry-cloud/settings/branches)"
+                echo ">    add \`Cloud golden-path browser E2E\`"
+                echo "> 3. [clawmetry-landing Settings > Branches](https://github.com/vivekchand/clawmetry-landing/settings/branches)"
+                echo ">    add \`Landing golden path (C3)\`"
+                echo ">"
+                echo "> Terminal shortcut -- 30 s: \`bash scripts/close-c6.sh\`"
+                echo "> Tracking: [#4029](https://github.com/vivekchand/clawmetry/issues/4029)"
+                ;;
+              *)
+                echo "> :grey_question: Unknown result -- check the step log above."
+                ;;
+            esac
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Post success comment on tracking issue
+        if: steps.upsert.outputs.result == 'success'
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          python3 - <<'PYEOF'
+          import json, os, sys, urllib.request, urllib.error
+
+          TOKEN = os.environ["GITHUB_TOKEN"]
+          OWNER = "vivekchand"
+          REPO = "clawmetry"
+          TRACKING_ISSUE = 4029
+          MARKER = "<!-- c6-job-level-admin-success -->"
+          RUN_URL = (
+              f"https://github.com/{OWNER}/{REPO}/actions/runs/"
+              + os.environ.get("GITHUB_RUN_ID", "")
+          )
+          HEADERS = {
+              "Authorization": f"Bearer {TOKEN}",
+              "Accept": "application/vnd.github+json",
+              "X-GitHub-Api-Version": "2022-11-28",
+              "Content-Type": "application/json",
+              "User-Agent": "clawmetry-c6-admin-test/1.0",
+          }
+
+          def get_comments():
+              req = urllib.request.Request(
+                  f"https://api.github.com/repos/{OWNER}/{REPO}"
+                  f"/issues/{TRACKING_ISSUE}/comments?per_page=20",
+                  headers=HEADERS,
+              )
+              with urllib.request.urlopen(req) as r:
+                  return json.loads(r.read())
+
+          def post_comment(body):
+              data = json.dumps({"body": body}).encode()
+              req = urllib.request.Request(
+                  f"https://api.github.com/repos/{OWNER}/{REPO}"
+                  f"/issues/{TRACKING_ISSUE}/comments",
+                  data=data, headers=HEADERS, method="POST",
+              )
+              with urllib.request.urlopen(req) as r:
+                  return json.loads(r.read())
+
+          try:
+              comments = get_comments()
+          except Exception:
+              comments = []
+
+          if any(MARKER in (c.get("body") or "") for c in comments):
+              print("Success comment already posted.")
+              sys.exit(0)
+
+          body = (
+              f"{MARKER}\n"
+              "**C6 auto-closed via job-level administration:write.**\n\n"
+              "The `c6-admin-test.yml` workflow successfully created the "
+              "`E2E Required Status Checks (C6)` repository ruleset on "
+              f"`clawmetry/main` using `administration: write` declared at the "
+              "job level (not the workflow level -- the workflow-level variant "
+              "was previously confirmed to cause 0-jobs-queued on this repo).\n\n"
+              "Required check now enforced:\n"
+              "- `E2E Gate (required)` (aggregates OSS golden path + cross-repo "
+              "handoff + MOAT keystone + E2E browser tests)\n\n"
+              f"[Workflow run]({RUN_URL})\n\n"
+              "**C6 is now GREEN.** 7-day stop-condition countdown is running "
+              "(all 7 criteria must hold green for 7 consecutive days).\n\n"
+              "_Next: verify clawmetry-cloud and clawmetry-landing also "
+              "have their required checks via Settings UI or close-c6.sh._"
+          )
+          result = post_comment(body)
+          print(f"Posted: {result['html_url']}")
+          PYEOF


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/c6-admin-test.yml` -- an isolated test of whether `administration: write` declared at the **job level** (not the workflow level) unlocks the GitHub Rulesets API to auto-close C6.
- The workflow-level variant was confirmed to cause "0 jobs queued" (run #30243855242). This PR tests the job-level variant, which has **not been tried before**.
- The existing `c6-apply-ruleset.yml` is **not modified** -- its graceful-403 behavior is preserved as a fallback.

Three outcomes on merge:

| Outcome | What you see | Next step |
|---------|-------------|-----------|
| **(a)** 0 jobs queued for the whole workflow | Actions UI shows no runs for `c6-admin-test.yml` after merge | Job-level also blocked; delete this file; C6 needs Settings UI or `close-c6.sh` |
| **(b)** Job runs, gets 403 | `::error::` annotation + exit 1, red badge | Delete this file; C6 needs Settings UI or `close-c6.sh` |
| **(c)** Job runs, succeeds | `SUCCESS` in log + success comment on #4029 | C6 is GREEN; merge this file's logic into `c6-apply-ruleset.yml`; delete test file |

## Test plan

- [ ] Merge this PR and watch the Actions run for `c6-admin-test.yml`
- [ ] If outcome (c): check [Settings > Branches > main](https://github.com/vivekchand/clawmetry/settings/branches) to verify the `E2E Required Status Checks (C6)` ruleset is active
- [ ] If outcome (a) or (b): open a follow-up PR to delete `.github/workflows/c6-admin-test.yml` and update [#4029](https://github.com/vivekchand/clawmetry/issues/4029) that the definitive close path is the Settings UI or `bash scripts/close-c6.sh`

Tracking: #4029 (C6)

---
_Generated by [Claude Code](https://claude.ai/code/session_011KZc7NSEZLFzWgsR24PCJn)_