### PR TITLE
fix(trial): the local trial actually turns the product on

### DIFF
--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -2440,17 +2440,31 @@ def _cmd_status(args) -> None:
     # the cloud on a Trial/Pro account — so we read the daemon's plan cache.
     try:
         print()
-        # Is this node's account entitled? (daemon mirrors the cloud plan here.)
+        # Is this node entitled? Resolve through clawmetry.entitlements — the
+        # SAME source the dashboard and gate use (license.key first, cloud
+        # plan cache second). Reading only cloud_plan.json here made status
+        # contradict itself on a self-hosted trial: "License: Trial" in the
+        # header while this gate said "FREE plan, NOT syncing" because the
+        # user's OLD cloud account was trial_expired (founder live-hit
+        # 2026-07-28).
         _entitled = False
         _plan = ""
         try:
-            import json as _j2
-            _cp = Path(os.path.expanduser("~/.clawmetry/cloud_plan.json"))
-            if _cp.is_file():
-                _plan = str((json.loads(_cp.read_text()) or {}).get("plan", "")).lower()
-                _entitled = _plan not in ("", "cloud_free", "free")
+            from clawmetry import entitlements as _ent_st
+            _e = _ent_st.get_entitlement(force=True)
+            _entitled = bool(_e.is_paid() and not _e.expired())
+            _plan = _e.tier or ""
         except Exception:
-            pass
+            # Fallback: the old cloud-plan cache read (entitlements missing
+            # on a very old install).
+            try:
+                import json as _j2
+                _cp = Path(os.path.expanduser("~/.clawmetry/cloud_plan.json"))
+                if _cp.is_file():
+                    _plan = str((json.loads(_cp.read_text()) or {}).get("plan", "")).lower()
+                    _entitled = _plan not in ("", "cloud_free", "free")
+            except Exception:
+                pass
         _prover = None
         try:
             from clawmetry.license import _pro_installed_version as _pv

--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -859,6 +859,18 @@ async function checkAgentPresence() {
   try {
     var data = await fetch('/api/agent-presence').then(function(r){return r.json();});
     var noAgent = !!(data && data.no_agent === true);
+    // Detected runtimes that are ALL entitled (e.g. Claude Code right after
+    // a trial activation) are being watched — telling that user to "Install
+    // OpenClaw or NVIDIA NemoClaw to start seeing data" is wrong twice over
+    // (they have an agent, and it IS covered). Treat as agent-present:
+    // suppress this banner and let the data arrive. (Founder live-hit
+    // 2026-07-28: trial active, 3 Claude Code sessions detected, banner
+    // still pitched installing a second agent.)
+    var _detected = (data && data.detected_runtimes) || [];
+    if (noAgent && _detected.length > 0 &&
+        _detected.every(function(r){ return r && r.entitled; })) {
+      noAgent = false;
+    }
     if (noAgent) {
       // No OpenClaw, no NemoClaw, no local data — show the persistent
       // empty-state banner and hide the first-heartbeat one so we don't

--- a/clawmetry/static/js/gw-setup.js
+++ b/clawmetry/static/js/gw-setup.js
@@ -42,7 +42,13 @@ async function checkGwConfig() {
       // open cloud modal — the two share the same backdrop and confuse the
       // user. Defer until the cloud modal closes.
       if (_isCloudModalOpen()) return;
-      await _gwApplyRuntimeDetection();
+      var show = await _gwApplyRuntimeDetection();
+      // Nothing left to set up (no OpenClaw gateway on this machine and
+      // every detected runtime is already watched, e.g. right after a trial
+      // activation): popping the modal on every load is pure friction —
+      // the user reported it reappearing after they had already finished
+      // the trial flow (2026-07-28).
+      if (show === false) return;
       document.getElementById('gw-setup-overlay').style.display = 'flex';
     } else {
       updateGwStatus(true, d.url);
@@ -110,8 +116,8 @@ async function _gwApplyRuntimeDetection() {
   try {
     var r = await fetch('/api/entitlement/runtime-detection');
     det = await r.json();
-  } catch (e) { return; }
-  if (!det || !det.probes) return;
+  } catch (e) { return true; }
+  if (!det || !det.probes) return true;
 
   var found = det.probes.filter(function (p) { return p.found; });
   var selfHosted = det.probes.filter(function (p) {
@@ -119,7 +125,7 @@ async function _gwApplyRuntimeDetection() {
   });
 
   // OpenClaw is here: the token step is the right ask, so keep it as-is.
-  if (selfHosted.length) return;
+  if (selfHosted.length) return true;
 
   // No OpenClaw on this machine. The token form must not be the mandatory
   // first step, and the modal must be dismissible.
@@ -132,7 +138,7 @@ async function _gwApplyRuntimeDetection() {
     // Nothing detected. Stay runtime neutral rather than naming one runtime
     // the user may never have heard of.
     if (sub) sub.textContent = 'No AI agent runtimes found on this machine yet. Start one and ClawMetry picks it up automatically.';
-    return;
+    return true;
   }
 
   var names = found.map(function (p) { return p.label; });
@@ -145,22 +151,22 @@ async function _gwApplyRuntimeDetection() {
   if (block) block.style.display = '';
 
   var locked = found.filter(function (p) { return !p.allowed; });
-  if (cta) {
-    if (locked.length) {
-      var tier = det.actionable_tier_label || 'Starter';
-      cta.innerHTML =
-        '<p style="color:var(--text-muted,#888); font-size:12px; margin:0 0 10px; text-align:left; line-height:1.5;">' +
-          'Watching ' + locked.map(function (p) { return p.label; }).join(', ') +
-          ' is part of ' + tier + '. Start a free trial to turn it on now.' +
-        '</p>' +
-        '<button id="gw-trial-btn" onclick="gwStartTrial()" style="width:100%; padding:12px; border:none; border-radius:8px; background:var(--bg-accent,#0f6fff); color:#fff; font-size:15px; font-weight:600; cursor:pointer; font-family:Manrope,sans-serif;">Start free trial</button>';
-    } else {
-      cta.innerHTML =
-        '<p style="color:var(--text-muted,#888); font-size:12px; margin:0; text-align:left;">' +
-          'These are watched on your current plan. Data appears as your agents run.' +
-        '</p>';
-    }
+  if (!locked.length) {
+    // Everything detected is already watched (e.g. the trial just
+    // activated). There is NOTHING for this modal to ask — suppress it
+    // instead of greeting the user with a setup step on every load.
+    return false;
   }
+  if (cta) {
+    var tier = det.actionable_tier_label || 'Starter';
+    cta.innerHTML =
+      '<p style="color:var(--text-muted,#888); font-size:12px; margin:0 0 10px; text-align:left; line-height:1.5;">' +
+        'Watching ' + locked.map(function (p) { return p.label; }).join(', ') +
+        ' is part of ' + tier + '. Start a free trial to turn it on now.' +
+      '</p>' +
+      '<button id="gw-trial-btn" onclick="gwStartTrial()" style="width:100%; padding:12px; border:none; border-radius:8px; background:var(--bg-accent,#0f6fff); color:#fff; font-size:15px; font-weight:600; cursor:pointer; font-family:Manrope,sans-serif;">Start free trial</button>';
+  }
+  return true;
 }
 
 // ── Local trial activation ─────────────────────────────────────────────

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -1345,8 +1345,31 @@ def _sync_allowed() -> bool:
     """Gate for large blob uploads. Heartbeats + approvals/alerts polls
     bypass this — they MUST keep firing so we detect the upgrade (or, for
     KiloClaw-provisioned accounts, the moment the user clicks "View
-    Observability" and the cloud flips reason='intent_pending' off)."""
-    return _TRIAL_STATE.get("sync_allowed", True)
+    Observability" and the cloud flips reason='intent_pending' off).
+
+    A valid SELF-HOSTED license overrides a cloud "paused" verdict. The
+    cloud's ``sync_allowed=False`` reflects the CLOUD ACCOUNT's plan, but
+    this flag also gates LOCAL DuckDB ingest (sync_family_runtimes and
+    every other sync_* function), so a node whose old cloud account said
+    ``trial_expired`` refused to ingest Claude Code into its OWN local
+    store even while holding a freshly activated local trial key — the
+    entitlement resolver said Trial, the daemon said paused, and the
+    Activity tab stayed empty (founder live-hit 2026-07-28). The signed
+    key IS the entitlement (Ed25519, verified offline, license-first in
+    the resolution order); the cloud remains free to refuse uploads
+    server-side for its own capacity reasons.
+    """
+    if _TRIAL_STATE.get("sync_allowed", True):
+        return True
+    try:
+        from clawmetry import entitlements as _ent
+
+        ent = _ent.get_entitlement()
+        if ent.source == "license" and ent.is_paid() and not ent.expired():
+            return True
+    except Exception:
+        pass
+    return False
 
 
 def get_machine_id() -> str:
@@ -17559,7 +17582,23 @@ def run_daemon() -> None:
     except Exception as _ext_e:
         log.warning("extensions load_plugins failed: %s", _ext_e)
 
-    config = load_config()
+    try:
+        config = load_config()
+    except FileNotFoundError:
+        # LOCAL-ONLY mode: no ~/.clawmetry/config.json means the user never
+        # ran `clawmetry connect` — which must not stop the daemon from
+        # ingesting into the LOCAL store. Before this fallback, a machine on
+        # a self-hosted trial (Claude Code detected, license active, no
+        # cloud account) crash-looped with "Run: clawmetry connect", so the
+        # product the trial unlocked could never show data (founder
+        # live-hit 2026-07-28). Config stays IN MEMORY only: writing a
+        # config.json here would make `clawmetry status` (which keys
+        # "Connected" off the file's existence) lie about cloud sync.
+        import socket as _sock
+
+        config = {"api_key": "", "node_id": _sock.gethostname() or "local"}
+        log.info("local-only mode: no cloud config — ingesting to the local "
+                 "store only (run `clawmetry connect` to add cloud sync)")
     # If node_id looks like email prefix (contains + or @), use hostname instead
     nid = config.get("node_id", "")
     if not nid:

--- a/routes/trial.py
+++ b/routes/trial.py
@@ -31,12 +31,54 @@ key, and no network.
 """
 
 import json
+import os
+import subprocess
+import sys
 import urllib.error
 import urllib.request
 
 from flask import Blueprint, jsonify, request
 
 bp_trial = Blueprint("trial", __name__)
+
+
+def _ensure_local_daemon() -> None:
+    """Best-effort: spawn the sync daemon detached so ingestion starts now.
+
+    Safe to call when a daemon is already running — run_daemon() checks the
+    pid lock and exits immediately. Detach semantics mirror the CLI's
+    _start_subprocess: POSIX gets start_new_session, Windows gets
+    DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP so the daemon survives the
+    dashboard (and its console) exiting. Never raises.
+    """
+    if os.environ.get("PYTEST_CURRENT_TEST"):
+        # Tests assert the spawn via monkeypatched Popen; never launch a
+        # real daemon out of the test runner's sandbox.
+        return
+    try:
+        log_dir = os.path.expanduser("~/.clawmetry")
+        try:
+            os.makedirs(log_dir, exist_ok=True)
+        except Exception:
+            pass
+        log_fh = open(os.path.join(log_dir, "sync.log"), "a")
+        kwargs = {"stdin": subprocess.DEVNULL, "stdout": log_fh,
+                  "stderr": subprocess.STDOUT, "close_fds": True}
+        if os.name == "nt":
+            kwargs["creationflags"] = (
+                subprocess.DETACHED_PROCESS | subprocess.CREATE_NEW_PROCESS_GROUP
+            )
+        else:
+            kwargs["start_new_session"] = True
+        subprocess.Popen([sys.executable, "-m", "clawmetry.sync"], **kwargs)
+        try:
+            log_fh.close()
+        except Exception:
+            pass
+    except Exception:
+        # A missed spawn must never fail the activation; the daemon also
+        # starts on the next `clawmetry` launch / connect.
+        pass
 
 # The trial-mint endpoint lives on the license server (same app that hosts
 # /api/license/activate). clawmetry.license._cloud_base honours
@@ -96,6 +138,15 @@ def api_trial_activate():
     ok, msg = _lic.activate(key, actor="local-trial")
     if not ok:
         return jsonify({"ok": False, "error": msg}), 502
+
+    # The trial is only real to the user when their runtime's data actually
+    # shows up. Ingestion is the sync daemon's job, and a local-only install
+    # has never started one — so activation without this spawn left the
+    # Activity tab empty ("we don't seem to have started trial of pro",
+    # founder live-hit 2026-07-28, 3 detected Claude Code sessions, zero
+    # ingested). run_daemon() itself exits if another instance already holds
+    # the pid lock, so the spawn is idempotent.
+    _ensure_local_daemon()
 
     try:
         from clawmetry import entitlements as _ent

--- a/tests/test_local_trial_sync_gate.py
+++ b/tests/test_local_trial_sync_gate.py
@@ -1,0 +1,171 @@
+"""The local trial must actually TURN ON the product (founder live-hit
+2026-07-28: trial key active, dashboard tier=trial, `clawmetry status` said
+"FREE plan, NOT syncing", 3 detected Claude Code sessions never ingested,
+setup modal re-appeared on every load, and the empty-state banner told the
+user to install OpenClaw).
+
+Four guards, each anchored to one of the broken links:
+
+1. ``_sync_allowed`` honours a valid self-hosted license even when the CLOUD
+   account state says paused (the daemon-side gate that blocked LOCAL DuckDB
+   ingest). Revert-proof: reverting the override turns
+   ``test_sync_allowed_license_overrides_cloud_pause`` red.
+2. ``/api/trial/activate`` spawns the local sync daemon (detached) so the
+   detected runtime's sessions start ingesting immediately.
+3. The setup modal suppresses itself when every detected runtime is already
+   watched (JS contract).
+4. The no-agent banner treats all-entitled detected runtimes as
+   agent-present (JS contract).
+"""
+from __future__ import annotations
+
+import os
+from types import SimpleNamespace
+
+import pytest
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+# ── 1. the daemon-side gate ─────────────────────────────────────────────────
+
+
+def _ent(source="license", paid=True, expired=False):
+    return SimpleNamespace(
+        source=source,
+        is_paid=lambda: paid,
+        expired=lambda: expired,
+    )
+
+
+@pytest.fixture
+def sync_mod(monkeypatch):
+    from clawmetry import sync as S
+
+    # Simulate the cloud verdict: paused (expired cloud account).
+    monkeypatch.setitem(S._TRIAL_STATE, "sync_allowed", False)
+    return S
+
+
+def test_sync_allowed_license_overrides_cloud_pause(sync_mod, monkeypatch):
+    """A valid self-hosted trial/pro key entitles LOCAL ingest regardless of
+    the (possibly stale/expired) cloud account plan."""
+    from clawmetry import entitlements as E
+
+    monkeypatch.setattr(E, "get_entitlement", lambda force=False: _ent())
+    assert sync_mod._sync_allowed() is True, \
+        "a licensed node must never be 'paused' out of its own local store"
+
+
+def test_sync_allowed_still_pauses_unlicensed(sync_mod, monkeypatch):
+    from clawmetry import entitlements as E
+
+    monkeypatch.setattr(
+        E, "get_entitlement",
+        lambda force=False: _ent(source="oss", paid=False),
+    )
+    assert sync_mod._sync_allowed() is False, \
+        "without a license the cloud pause verdict stands"
+
+
+def test_sync_allowed_expired_license_does_not_override(sync_mod, monkeypatch):
+    from clawmetry import entitlements as E
+
+    monkeypatch.setattr(
+        E, "get_entitlement",
+        lambda force=False: _ent(expired=True),
+    )
+    assert sync_mod._sync_allowed() is False, \
+        "an expired key must not resurrect a paused node"
+
+
+def test_sync_allowed_cloud_yes_stays_yes(monkeypatch):
+    from clawmetry import sync as S
+
+    monkeypatch.setitem(S._TRIAL_STATE, "sync_allowed", True)
+    assert S._sync_allowed() is True
+
+
+# ── 2. activation starts the daemon ─────────────────────────────────────────
+
+
+def test_ensure_local_daemon_spawn_shape(monkeypatch):
+    """The spawn is detached per-OS and runs `python -m clawmetry.sync`."""
+    import routes.trial as T
+
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+    captured = {}
+
+    def _fake_popen(cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["kwargs"] = kwargs
+        return SimpleNamespace(pid=4242)
+
+    monkeypatch.setattr(T.subprocess, "Popen", _fake_popen)
+    T._ensure_local_daemon()
+    assert captured["cmd"][-2:] == ["-m", "clawmetry.sync"]
+    kw = captured["kwargs"]
+    if os.name == "nt":
+        assert kw.get("creationflags"), "Windows spawn must be detached"
+    else:
+        assert kw.get("start_new_session") is True
+
+
+def test_trial_activation_calls_ensure_daemon(monkeypatch, tmp_path):
+    """The activation handler must kick ingestion, not just write the key."""
+    import routes.trial as T
+
+    spawned = []
+    monkeypatch.setattr(T, "_ensure_local_daemon", lambda: spawned.append(1))
+    import clawmetry.license as L
+
+    monkeypatch.setattr(L, "activate", lambda key, actor="": (True, "ok"))
+    monkeypatch.setattr(L, "_cloud_base", lambda: "https://cloud.test")
+
+    import io
+    import json as _json
+    import urllib.request as _ur
+
+    class _Resp:
+        def read(self):
+            return _json.dumps({"ok": True, "key": "CLAW1.x.y"}).encode()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    monkeypatch.setattr(T.urllib.request, "urlopen", lambda req, timeout=0: _Resp())
+
+    from flask import Flask
+
+    app = Flask(__name__)
+    app.register_blueprint(T.bp_trial)
+    r = app.test_client().post(
+        "/api/trial/activate", json={"email": "a@b.co", "code": "123456"}
+    )
+    assert r.status_code == 200, r.get_json()
+    assert spawned == [1], "activation must start the local sync daemon"
+
+
+# ── 3+4. frontend contracts ─────────────────────────────────────────────────
+
+
+def _read(rel):
+    with open(os.path.join(ROOT, rel), encoding="utf-8") as fh:
+        return fh.read()
+
+
+def test_gw_setup_suppresses_modal_when_all_watched():
+    src = _read("clawmetry/static/js/gw-setup.js")
+    assert "if (show === false) return;" in src, \
+        "checkGwConfig must honour the suppress signal"
+    assert "return false;" in src, \
+        "_gwApplyRuntimeDetection must return false when nothing needs setup"
+
+
+def test_no_agent_banner_suppressed_for_entitled_runtimes():
+    src = _read("clawmetry/static/js/app.js")
+    assert "_detected.every(function(r){ return r && r.entitled; })" in src, \
+        "checkAgentPresence must treat all-entitled detected runtimes as agent-present"


### PR DESCRIPTION
## Why

Activating the local trial wrote a valid key and flipped the dashboard tier to Trial, and then nothing else happened: clawmetry status said FREE plan NOT syncing, the 3 detected Claude Code sessions never ingested, the setup modal greeted every page load, and the empty-state banner told the user to install OpenClaw. Found live on the founder's Windows machine minutes after the first real trial activation.

## What

Five links repaired: (1) sync.py _sync_allowed obeyed only the cloud account verdict, which also gates LOCAL DuckDB ingest, so a validly licensed node refused to ingest into its own store; a self-hosted license now overrides the pause. (2) run_daemon() hard-required config.json, so a local-only node could not run the ingestion daemon at all; it now falls back to an in-memory local-only config and ingests locally. (3) clawmetry status resolves entitlement through clawmetry.entitlements instead of raw cloud_plan.json. (4) POST /api/trial/activate spawns the sync daemon so ingestion starts with the trial. (5) The setup modal suppresses itself when every detected runtime is watched, and the no-agent banner treats all-entitled detected runtimes as agent-present.

## Verification

Verified live on the affected machine: with the fixed sync.py the daemon logs local-only mode, ingests all 3 Claude Code sessions (runtime=claude_code, 1312/54/7 messages) into DuckDB, and /api/sessions serves them. 8 new tests; revert-proof red on the _sync_allowed override; JS contract guards for both frontend suppressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
