### PR TITLE
fix(trial): entitlement properties, unclosable setup modal, honest status copy

### DIFF
--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -2452,7 +2452,10 @@ def _cmd_status(args) -> None:
         try:
             from clawmetry import entitlements as _ent_st
             _e = _ent_st.get_entitlement(force=True)
-            _entitled = bool(_e.is_paid() and not _e.expired())
+            # is_paid / expired are properties — calling them raised and the
+            # fallback silently reported the stale cloud plan ("FREE plan")
+            # under a valid trial key (founder live-hit 2026-07-28, twice).
+            _entitled = bool(_e.is_paid and not _e.expired)
             _plan = _e.tier or ""
         except Exception:
             # Fallback: the old cloud-plan cache read (entitlements missing
@@ -2489,7 +2492,7 @@ def _cmd_status(args) -> None:
         for _r in _det:
             _n = int(_r.get("sessionCount") or 0)
             _nm = _r.get("displayName") or _r.get("name") or "runtime"
-            _state = "✅ syncing" if _entitled else "○ detected, NOT syncing"
+            _state = "✅ watching" if _entitled else "○ detected, NOT watched"
             print(f"    • {_nm:<18} {_state}  ({_n} session{'s' if _n != 1 else ''})")
         if not _prover:
             print("    ⚠ Claude Code / Codex / Cursor / Aider / Goose / opencode / Qwen — NOT syncing")
@@ -2500,9 +2503,12 @@ def _cmd_status(args) -> None:
                 print("      → paid runtimes need a Trial/Pro account. The daemon auto-downloads the")
                 print("        runtime pack on start once entitled — link your account in the dashboard.")
         elif _det and not _entitled:
-            print(f"    clawmetry-pro {_prover} installed and detecting the above — but your account")
-            print(f"      is on the FREE plan ({_plan or 'free'}), so paid runtimes are NOT synced to")
-            print("      the cloud. Link to a Trial/Pro account (the dashboard prompts you) to sync them.")
+            print(f"    clawmetry-pro {_prover} installed and detecting the above — but this node")
+            print(f"      has no active Trial/Pro entitlement ({_plan or 'free'}), so paid runtimes")
+            print("      are not watched. Start the free trial from the dashboard to turn them on.")
+        elif _det and _entitled:
+            _lbl = {"trial": "Trial"}.get((_plan or "").lower(), _plan or "entitled")
+            print(f"    clawmetry-pro {_prover} watching the above locally ({_lbl} plan).")
         elif _prover and not _det:
             print(f"    clawmetry-pro {_prover} installed — no other runtimes found on this machine yet.")
     except Exception:

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -1365,7 +1365,11 @@ def _sync_allowed() -> bool:
         from clawmetry import entitlements as _ent
 
         ent = _ent.get_entitlement()
-        if ent.source == "license" and ent.is_paid() and not ent.expired():
+        # is_paid / expired are PROPERTIES, not methods. Calling them raised
+        # TypeError, the except swallowed it, and the override silently never
+        # fired — the exact bug class the tests missed because their doubles
+        # used callables (fixed: tests now build REAL Entitlement objects).
+        if ent.source == "license" and ent.is_paid and not ent.expired:
             return True
     except Exception:
         pass

--- a/routes/meta.py
+++ b/routes/meta.py
@@ -775,6 +775,20 @@ def api_auth_check():
     # needsSetup:true when the token was correctly injected via env.
     gateway_token = _d.GATEWAY_TOKEN or os.environ.get("OPENCLAW_GATEWAY_TOKEN", "").strip()
     if not gateway_token:
+        # needsSetup drives app.js bootDashboard() into a MANDATORY setup
+        # modal (close button hidden). That is only a sensible ask when an
+        # OpenClaw install exists whose token could actually be pasted. On a
+        # machine running only Claude Code / Cursor / etc. there is no
+        # gateway and never will be — the mandatory modal was an unclosable
+        # dead end on every page load (founder live-hit 2026-07-28, after
+        # trial activation). No OpenClaw -> open localhost mode, same as the
+        # dashboard's actual serving behaviour.
+        try:
+            openclaw_present = bool(_d._detect_openclaw_install())
+        except Exception:
+            openclaw_present = False
+        if not openclaw_present:
+            return jsonify({"authRequired": False, "valid": True, "needsSetup": False})
         return jsonify({"authRequired": True, "valid": False, "needsSetup": True})
     token = request.headers.get("Authorization", "").replace("Bearer ", "").strip()
     if not token:

--- a/tests/test_local_trial_sync_gate.py
+++ b/tests/test_local_trial_sync_gate.py
@@ -31,11 +31,22 @@ ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 
 def _ent(source="license", paid=True, expired=False):
-    return SimpleNamespace(
-        source=source,
-        is_paid=lambda: paid,
-        expired=lambda: expired,
-    )
+    """A REAL Entitlement, not a shape-alike double.
+
+    The first version of these tests used a SimpleNamespace with is_paid /
+    expired as LAMBDAS — but on the real class they are PROPERTIES, so the
+    production code calling ``ent.is_paid()`` raised TypeError while the
+    tests stayed green. The bug shipped and the founder hit it live twice
+    (status said "FREE plan" under a valid trial key). Doubles must match
+    the real contract; the cheapest way is to not use a double at all.
+    """
+    import time as _t
+
+    from clawmetry import entitlements as E
+
+    tier = E.TIER_TRIAL if paid else E.TIER_OSS
+    expiry = (_t.time() - 3600) if expired else (_t.time() + 6 * 86400)
+    return E._build(tier, source, expiry=expiry)
 
 
 @pytest.fixture
@@ -155,6 +166,33 @@ def test_trial_activation_calls_ensure_daemon(monkeypatch, tmp_path):
 def _read(rel):
     with open(os.path.join(ROOT, rel), encoding="utf-8") as fh:
         return fh.read()
+
+
+def test_auth_check_no_openclaw_is_not_needs_setup(monkeypatch):
+    """/api/auth/check must not demand gateway setup on a machine with no
+    OpenClaw: needsSetup drives app.js into a MANDATORY (uncloseable) modal,
+    and without an OpenClaw install there is no token that could ever be
+    pasted. Revert-proof for the unclosable-popup live-hit (2026-07-28)."""
+    import dashboard as _d
+    from flask import Flask
+
+    from routes.meta import bp_auth
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_auth)
+    monkeypatch.setattr(_d, "GATEWAY_TOKEN", "", raising=False)
+    monkeypatch.delenv("OPENCLAW_GATEWAY_TOKEN", raising=False)
+
+    monkeypatch.setattr(_d, "_detect_openclaw_install", lambda: False)
+    r = app.test_client().get("/api/auth/check").get_json()
+    assert r["needsSetup"] is False, \
+        "no OpenClaw on the machine: the mandatory setup modal must not fire"
+    assert r["authRequired"] is False
+
+    monkeypatch.setattr(_d, "_detect_openclaw_install", lambda: True)
+    r = app.test_client().get("/api/auth/check").get_json()
+    assert r["needsSetup"] is True, \
+        "OpenClaw present without a token still needs the setup step"
 
 
 def test_gw_setup_suppresses_modal_when_all_watched():


### PR DESCRIPTION
Three live-verified follow-ups to #4136: property-vs-method bug that silently disabled the license override (tests now use real Entitlement objects; revert-proof red), needsSetup no longer fires on machines with no OpenClaw (the unclosable mandatory modal), and status copy reflects local watching rather than cloud sync. Evidence: fresh status shows Claude Code watching (Trial plan); Playwright fresh load shows modal none + banner none.