### PR TITLE
feat(license): is_pubkey_fingerprint + pubkey-fingerprint scalar endpoints

### DIFF
--- a/clawmetry/license.py
+++ b/clawmetry/license.py
@@ -1649,6 +1649,60 @@ def license_issued_at() -> int | None:
     return int(issued) if isinstance(issued, int) else None
 
 
+def is_pubkey_fingerprint(fp: str) -> bool:
+    """Boolean gate for "is this install verifying against pubkey <FP>?" UIs.
+
+    Returns ``True`` iff :func:`pubkey_fingerprint` resolves to a non-empty
+    SHA-256 hex string AND ``fp`` matches it under a tolerant normalisation:
+
+      * whitespace stripped on both sides,
+      * lowercased (SHA-256 hex is case-insensitive),
+      * ``:`` separators removed -- many display formats print
+        fingerprints as ``ab:cd:ef:...`` and an operator comparing a
+        pasted string against the canonical one should not have to strip
+        colons themselves,
+      * short-form (16-char, matching :func:`pubkey_info`'s
+        ``fingerprint_short``) also matches if it is a prefix of the
+        full digest, so a UI can accept either the full digest or the
+        short-form printed on ``/api/license/pubkey``.
+
+    Every other state returns ``False``: unparseable embedded PEM
+    (fingerprint helper collapses to ``None``), non-string / empty input,
+    or a normalised digest that simply differs from the trust anchor.
+    Never raises; every underlying failure returns ``False`` so a
+    scheduled trust-anchor audit never crashes on a bad install.
+
+    Pairs with :func:`pubkey_fingerprint` the way :func:`is_subject`
+    pairs with :func:`license_subject` -- the scalar reports the raw
+    hex digest for a badge tile, this bool answers the yes/no question
+    a supply-chain / trust-anchor audit needs without the caller having
+    to normalise the string themselves.
+    """
+    try:
+        requested = str(fp).strip().lower().replace(":", "")
+    except Exception:
+        return False
+    if not requested:
+        return False
+    # Only hex is valid -- reject accidental non-hex input up-front so
+    # ``is_pubkey_fingerprint("not a fingerprint")`` collapses to ``False``
+    # instead of doing a full comparison against the real digest.
+    if not all(c in "0123456789abcdef" for c in requested):
+        return False
+    try:
+        actual = pubkey_fingerprint()
+    except Exception:
+        return False
+    if not isinstance(actual, str) or not actual:
+        return False
+    actual_norm = actual.strip().lower()
+    if len(requested) == 64:
+        return actual_norm == requested
+    if len(requested) == 16:
+        return actual_norm.startswith(requested)
+    return False
+
+
 def license_age_days() -> int | None:
     """Scalar view onto the installed license's age -- days since the
     ``iat`` claim -- for a support/audit tile that wants ONE integer

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -9344,6 +9344,158 @@ def api_license_is_state():
     )
 
 
+def _license_pubkey_fingerprint_snapshot() -> dict:
+    """Shared helper: read once, derive the trio the two pubkey-fingerprint
+    endpoints both need (``pubkey_fingerprint_sha256``,
+    ``pubkey_fingerprint_short``, ``valid``). Lives in the handler layer so a
+    UI binding both endpoints cannot catch them disagreeing on the trust
+    anchor for the same install.
+
+    ``valid`` here means the EMBEDDED PUBKEY parses -- distinct from
+    ``/api/license/valid`` (signature-valid + not expired). A tampered
+    ``_PUBLIC_KEY_PEM`` collapses ``valid`` to ``False`` even without any
+    license file installed, exactly matching the trust-anchor semantic a
+    supply-chain / attestation tile needs.
+
+    Never raises: any underlying failure collapses to
+    ``{pubkey_fingerprint_sha256: None, pubkey_fingerprint_short: None,
+    valid: False}`` so callers keep the "OSS-free" branch shape.
+    """
+    try:
+        from clawmetry import license as _lic
+
+        fp = _lic.pubkey_fingerprint()
+    except Exception as exc:
+        logger.debug(
+            "_license_pubkey_fingerprint_snapshot: underlying read failed: %s",
+            exc,
+        )
+        return {
+            "pubkey_fingerprint_sha256": None,
+            "pubkey_fingerprint_short": None,
+            "valid": False,
+        }
+    short = fp[:16] if isinstance(fp, str) and fp else None
+    return {
+        "pubkey_fingerprint_sha256": fp if isinstance(fp, str) and fp else None,
+        "pubkey_fingerprint_short": short,
+        "valid": bool(fp) and isinstance(fp, str),
+    }
+
+
+@bp_entitlement.route("/api/license/pubkey-fingerprint")
+def api_license_pubkey_fingerprint():
+    """``GET /api/license/pubkey-fingerprint`` -- scalar view of the embedded
+    Ed25519 verification key's SHA-256 fingerprint, for a trust-anchor
+    attestation tile that wants ONE string rather than the whole
+    ``/api/license/pubkey`` envelope (algorithm, format, PEM body, ...).
+
+    Response shape (always HTTP 200)::
+
+        {
+          "pubkey_fingerprint_sha256": <str|null>,   # 64-char lowercase hex
+          "pubkey_fingerprint_short":  <str|null>,   # first 16 chars
+          "valid": <bool>                            # embedded PEM parses?
+        }
+
+    Independent of any installed license file: this endpoint answers
+    "which trust anchor is THIS install verifying against?" so an
+    operator can compare the value to the canonical fingerprint published
+    at ``https://clawmetry.com/security`` and detect that ``_PUBLIC_KEY_PEM``
+    hasn't been swapped for an attacker-controlled key. A dashboard tile
+    that only needs the fingerprint string should bind here rather than to
+    ``/api/license/pubkey``; the two share :func:`pubkey_fingerprint` so
+    they never disagree.
+
+    Never 5xxs -- any underlying failure degrades to
+    ``{pubkey_fingerprint_sha256: null, pubkey_fingerprint_short: null,
+    valid: false}`` matching the never-crash posture of the surrounding
+    license endpoints.
+    """
+    try:
+        return jsonify(_license_pubkey_fingerprint_snapshot())
+    except Exception as exc:
+        logger.warning("api_license_pubkey_fingerprint: error: %s", exc)
+        return jsonify(
+            {
+                "pubkey_fingerprint_sha256": None,
+                "pubkey_fingerprint_short": None,
+                "valid": False,
+            }
+        )
+
+
+@bp_entitlement.route("/api/license/is-pubkey-fingerprint")
+def api_license_is_pubkey_fingerprint():
+    """``GET /api/license/is-pubkey-fingerprint?fp=<hex>`` -- boolean gate
+    for "is this install verifying against pubkey <FP> right now?" UIs.
+
+    Query parameters:
+      * ``fp`` (str, required) -- the fingerprint to test against. Compared
+        under the same tolerant normalisation as
+        :func:`clawmetry.license.is_pubkey_fingerprint`: whitespace
+        stripped, lowercased, ``:`` separators removed, either the full
+        64-char hex OR the 16-char short-form accepted. Missing / empty
+        input degrades to ``is_pubkey_fingerprint=false`` rather than a
+        4xx, matching the surrounding endpoints' never-5xx / never-4xx
+        posture.
+
+    Response shape (always HTTP 200)::
+
+        {
+          "is_pubkey_fingerprint": <bool>,
+          "pubkey_fingerprint_sha256": <str|null>,   # currently-active fp
+          "pubkey_fingerprint_short":  <str|null>,   # first 16 chars
+          "requested_fp": <str>,                     # normalised echo
+          "valid": <bool>                            # embedded PEM parses?
+        }
+
+    ``is_pubkey_fingerprint`` is ``True`` iff the embedded PEM parses AND
+    the normalised request matches (full or short form). A typo like
+    ``?fp=abcxyz`` collapses to ``False`` (non-hex rejected up-front) so a
+    caller cannot silently mis-gate on a bad string.
+
+    Mirrors :func:`clawmetry.license.is_pubkey_fingerprint` -- the HTTP
+    shape layers ``pubkey_fingerprint_sha256`` /
+    ``pubkey_fingerprint_short`` / ``requested_fp`` / ``valid`` on top of
+    that bool so a supply-chain audit widget never needs a second call to
+    ``/api/license/pubkey-fingerprint`` to render the accompanying
+    "expected <X>" copy.
+    """
+    raw = request.args.get("fp", "") or ""
+    try:
+        requested = raw.strip().lower().replace(":", "")
+    except Exception:
+        requested = ""
+    try:
+        snap = _license_pubkey_fingerprint_snapshot()
+    except Exception as exc:
+        logger.warning("api_license_is_pubkey_fingerprint: error: %s", exc)
+        snap = {
+            "pubkey_fingerprint_sha256": None,
+            "pubkey_fingerprint_short": None,
+            "valid": False,
+        }
+    actual = snap["pubkey_fingerprint_sha256"]
+    matches = False
+    if requested and isinstance(actual, str) and actual:
+        if all(c in "0123456789abcdef" for c in requested):
+            actual_norm = actual.strip().lower()
+            if len(requested) == 64:
+                matches = actual_norm == requested
+            elif len(requested) == 16:
+                matches = actual_norm.startswith(requested)
+    return jsonify(
+        {
+            "is_pubkey_fingerprint": bool(matches),
+            "pubkey_fingerprint_sha256": snap["pubkey_fingerprint_sha256"],
+            "pubkey_fingerprint_short": snap["pubkey_fingerprint_short"],
+            "requested_fp": requested,
+            "valid": snap["valid"],
+        }
+    )
+
+
 @bp_entitlement.route("/api/paywall/event", methods=["POST"])
 def api_paywall_event():
     body: dict = {}

--- a/tests/test_license_pubkey_fingerprint_scalar.py
+++ b/tests/test_license_pubkey_fingerprint_scalar.py
@@ -1,0 +1,323 @@
+"""Tests for the ``is_pubkey_fingerprint(fp)`` predicate in
+:mod:`clawmetry.license` plus its matching
+``/api/license/pubkey-fingerprint`` and
+``/api/license/is-pubkey-fingerprint`` HTTP endpoints.
+
+``pubkey_fingerprint()`` itself already exists (returns the SHA-256 of
+the embedded Ed25519 verification key), and ``/api/license/pubkey``
+returns the full envelope (algorithm, format, PEM body, fingerprint).
+This module pins the contract for the newly-added scalar endpoint that
+surfaces JUST the fingerprint plus the matching boolean predicate a
+supply-chain / trust-anchor audit widget needs -- mirroring the
+``license_subject`` / ``is_subject`` and ``license_tier`` / ``is_tier``
+scalar-plus-predicate pattern.
+
+Hermetic: ephemeral Ed25519 keypair monkeypatched into
+``_PUBLIC_KEY_PEM`` so nothing here depends on the canonical embedded
+key. Independent of any installed license file -- the fingerprint is a
+trust-anchor fact, not a license-payload fact.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from flask import Flask
+
+
+def _keypair():
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+    priv = Ed25519PrivateKey.generate()
+    pub_pem = priv.public_key().public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    return priv, pub_pem
+
+
+@pytest.fixture
+def env(monkeypatch):
+    import clawmetry.license as _lic
+
+    priv, pub_pem = _keypair()
+    monkeypatch.setattr(_lic, "_PUBLIC_KEY_PEM", pub_pem)
+
+    from routes.entitlement import bp_entitlement
+
+    flask_app = Flask(__name__)
+    flask_app.register_blueprint(bp_entitlement)
+    flask_app.config["TESTING"] = True
+
+    return SimpleNamespace(app=flask_app, lic=_lic, priv=priv, pub_pem=pub_pem)
+
+
+# ── is_pubkey_fingerprint(fp) ─────────────────────────────────────────────────
+
+
+def test_is_pubkey_fingerprint_true_on_exact_full_match(env):
+    fp = env.lic.pubkey_fingerprint()
+    assert env.lic.is_pubkey_fingerprint(fp) is True
+
+
+def test_is_pubkey_fingerprint_case_insensitive(env):
+    fp = env.lic.pubkey_fingerprint()
+    assert env.lic.is_pubkey_fingerprint(fp.upper()) is True
+
+
+def test_is_pubkey_fingerprint_strips_whitespace(env):
+    fp = env.lic.pubkey_fingerprint()
+    assert env.lic.is_pubkey_fingerprint(f"  {fp}  ") is True
+    assert env.lic.is_pubkey_fingerprint(f"\n{fp}\n") is True
+
+
+def test_is_pubkey_fingerprint_strips_colon_separators(env):
+    """Many display formats print fingerprints as ``ab:cd:ef:...``. The
+    predicate accepts either colon-separated or bare-hex input so an
+    operator pasting a fingerprint from a support ticket does not have
+    to strip colons themselves."""
+    fp = env.lic.pubkey_fingerprint()
+    colonised = ":".join(fp[i : i + 2] for i in range(0, len(fp), 2))
+    assert env.lic.is_pubkey_fingerprint(colonised) is True
+
+
+def test_is_pubkey_fingerprint_short_form_matches(env):
+    """The 16-char short-form matches iff it is a prefix of the full
+    digest, mirroring ``pubkey_info()['fingerprint_short']``."""
+    fp = env.lic.pubkey_fingerprint()
+    assert env.lic.is_pubkey_fingerprint(fp[:16]) is True
+
+
+def test_is_pubkey_fingerprint_false_on_wrong_short(env):
+    # A 16-char hex string that is NOT a prefix of the real digest must
+    # collapse to False -- otherwise short-form matching would let any
+    # arbitrary 16-char hex pass.
+    fp = env.lic.pubkey_fingerprint()
+    # Flip every nibble of the first 16 chars so it is guaranteed not to
+    # be a prefix.
+    bad_short = "".join(f"{15 - int(c, 16):x}" for c in fp[:16])
+    assert env.lic.is_pubkey_fingerprint(bad_short) is False
+
+
+def test_is_pubkey_fingerprint_false_on_wrong_full(env):
+    fp = env.lic.pubkey_fingerprint()
+    # Flip the last char so it's still valid hex but a different digest.
+    flipped_last = "0" if fp[-1] != "0" else "1"
+    wrong = fp[:-1] + flipped_last
+    assert env.lic.is_pubkey_fingerprint(wrong) is False
+
+
+def test_is_pubkey_fingerprint_false_on_empty(env):
+    assert env.lic.is_pubkey_fingerprint("") is False
+    assert env.lic.is_pubkey_fingerprint("   ") is False
+
+
+def test_is_pubkey_fingerprint_false_on_non_hex(env):
+    # Non-hex must be rejected up-front -- an operator typo like "not-a-fp"
+    # should collapse to False, not do a full comparison against the real
+    # digest.
+    assert env.lic.is_pubkey_fingerprint("not-a-fingerprint") is False
+    assert env.lic.is_pubkey_fingerprint("z" * 64) is False
+
+
+def test_is_pubkey_fingerprint_false_on_wrong_length(env):
+    # 32-char (neither full 64 nor short 16) must collapse to False, even
+    # though it is valid hex.
+    fp = env.lic.pubkey_fingerprint()
+    assert env.lic.is_pubkey_fingerprint(fp[:32]) is False
+
+
+def test_is_pubkey_fingerprint_false_on_non_string(env):
+    # ``str()`` coercion means ``None`` becomes "None" (non-hex) -> False.
+    # An int similarly coerces to a decimal string with letters missing.
+    assert env.lic.is_pubkey_fingerprint(None) is False
+    assert env.lic.is_pubkey_fingerprint(12345) is False
+
+
+def test_is_pubkey_fingerprint_false_when_pubkey_unparseable(env, monkeypatch):
+    """If ``pubkey_fingerprint()`` collapses to None (tampered PEM), the
+    predicate collapses to False even for a syntactically-plausible
+    request -- an attacker cannot force ``is_pubkey_fingerprint`` to True
+    by swapping in a broken PEM."""
+    monkeypatch.setattr(env.lic, "pubkey_fingerprint", lambda: None)
+    assert env.lic.is_pubkey_fingerprint("a" * 64) is False
+
+
+def test_is_pubkey_fingerprint_never_raises_on_broken_read(env, monkeypatch):
+    def _boom():
+        raise RuntimeError("simulated fingerprint failure")
+
+    monkeypatch.setattr(env.lic, "pubkey_fingerprint", _boom)
+    # Wrapped in try/except -> collapses to False.
+    assert env.lic.is_pubkey_fingerprint("a" * 64) is False
+
+
+# ── GET /api/license/pubkey-fingerprint ───────────────────────────────────────
+
+
+def test_api_pubkey_fingerprint_shape(env):
+    client = env.app.test_client()
+    resp = client.get("/api/license/pubkey-fingerprint")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert set(data.keys()) == {
+        "pubkey_fingerprint_sha256",
+        "pubkey_fingerprint_short",
+        "valid",
+    }
+    fp = env.lic.pubkey_fingerprint()
+    assert data["pubkey_fingerprint_sha256"] == fp
+    assert data["pubkey_fingerprint_short"] == fp[:16]
+    assert data["valid"] is True
+
+
+def test_api_pubkey_fingerprint_matches_pubkey_envelope(env):
+    """The scalar endpoint and the existing ``/api/license/pubkey``
+    envelope MUST agree on the fingerprint for the same install --
+    they share :func:`pubkey_fingerprint` so a UI binding both cannot
+    catch them disagreeing."""
+    client = env.app.test_client()
+    scalar = client.get("/api/license/pubkey-fingerprint").get_json()
+    envelope = client.get("/api/license/pubkey").get_json()
+    assert scalar["pubkey_fingerprint_sha256"] == envelope["fingerprint_sha256"]
+    assert scalar["pubkey_fingerprint_short"] == envelope["fingerprint_short"]
+
+
+def test_api_pubkey_fingerprint_survives_broken_pubkey(env, monkeypatch):
+    """When the embedded PEM can't parse, the endpoint stays HTTP 200
+    with the OSS-free branch shape -- never 5xx."""
+    monkeypatch.setattr(env.lic, "pubkey_fingerprint", lambda: None)
+    client = env.app.test_client()
+    resp = client.get("/api/license/pubkey-fingerprint")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data == {
+        "pubkey_fingerprint_sha256": None,
+        "pubkey_fingerprint_short": None,
+        "valid": False,
+    }
+
+
+def test_api_pubkey_fingerprint_never_5xxs(env, monkeypatch):
+    def _boom():
+        raise RuntimeError("simulated read failure")
+
+    monkeypatch.setattr(env.lic, "pubkey_fingerprint", _boom)
+    client = env.app.test_client()
+    resp = client.get("/api/license/pubkey-fingerprint")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data == {
+        "pubkey_fingerprint_sha256": None,
+        "pubkey_fingerprint_short": None,
+        "valid": False,
+    }
+
+
+# ── GET /api/license/is-pubkey-fingerprint ────────────────────────────────────
+
+
+def test_api_is_pubkey_fingerprint_shape(env):
+    client = env.app.test_client()
+    fp = env.lic.pubkey_fingerprint()
+    resp = client.get(f"/api/license/is-pubkey-fingerprint?fp={fp}")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert set(data.keys()) == {
+        "is_pubkey_fingerprint",
+        "pubkey_fingerprint_sha256",
+        "pubkey_fingerprint_short",
+        "requested_fp",
+        "valid",
+    }
+    assert data["is_pubkey_fingerprint"] is True
+    assert data["pubkey_fingerprint_sha256"] == fp
+    assert data["requested_fp"] == fp.lower()
+    assert data["valid"] is True
+
+
+def test_api_is_pubkey_fingerprint_case_insensitive(env):
+    client = env.app.test_client()
+    fp = env.lic.pubkey_fingerprint()
+    resp = client.get(f"/api/license/is-pubkey-fingerprint?fp={fp.upper()}")
+    assert resp.get_json()["is_pubkey_fingerprint"] is True
+
+
+def test_api_is_pubkey_fingerprint_accepts_colon_separators(env):
+    client = env.app.test_client()
+    fp = env.lic.pubkey_fingerprint()
+    colonised = ":".join(fp[i : i + 2] for i in range(0, len(fp), 2))
+    resp = client.get(f"/api/license/is-pubkey-fingerprint?fp={colonised}")
+    data = resp.get_json()
+    assert data["is_pubkey_fingerprint"] is True
+    # Normalised echo strips the colons for a UI to render "vs. <fp>".
+    assert ":" not in data["requested_fp"]
+
+
+def test_api_is_pubkey_fingerprint_short_form_matches(env):
+    client = env.app.test_client()
+    fp = env.lic.pubkey_fingerprint()
+    resp = client.get(f"/api/license/is-pubkey-fingerprint?fp={fp[:16]}")
+    assert resp.get_json()["is_pubkey_fingerprint"] is True
+
+
+def test_api_is_pubkey_fingerprint_false_on_wrong(env):
+    client = env.app.test_client()
+    resp = client.get("/api/license/is-pubkey-fingerprint?fp=" + ("a" * 64))
+    data = resp.get_json()
+    assert data["is_pubkey_fingerprint"] is False
+    # Trust-anchor fields still populate so a UI can show
+    # "expected <X>, got <Y>".
+    assert data["pubkey_fingerprint_sha256"] == env.lic.pubkey_fingerprint()
+
+
+def test_api_is_pubkey_fingerprint_false_on_missing_param(env):
+    client = env.app.test_client()
+    resp = client.get("/api/license/is-pubkey-fingerprint")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["is_pubkey_fingerprint"] is False
+    assert data["requested_fp"] == ""
+    # Trust-anchor still populates -- the missing-param branch must not
+    # blank out the "currently-active" fields.
+    assert data["pubkey_fingerprint_sha256"] == env.lic.pubkey_fingerprint()
+
+
+def test_api_is_pubkey_fingerprint_false_on_typo(env):
+    """A non-hex typo like ``?fp=abcxyz`` collapses to False (non-hex
+    rejected up-front) -- a caller cannot silently mis-gate on a bad
+    string."""
+    client = env.app.test_client()
+    resp = client.get("/api/license/is-pubkey-fingerprint?fp=abcxyz")
+    data = resp.get_json()
+    assert data["is_pubkey_fingerprint"] is False
+
+
+def test_api_is_pubkey_fingerprint_never_5xxs(env, monkeypatch):
+    def _boom():
+        raise RuntimeError("simulated fingerprint failure")
+
+    monkeypatch.setattr(env.lic, "pubkey_fingerprint", _boom)
+    client = env.app.test_client()
+    fp_guess = "a" * 64
+    resp = client.get(f"/api/license/is-pubkey-fingerprint?fp={fp_guess}")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["is_pubkey_fingerprint"] is False
+    assert data["pubkey_fingerprint_sha256"] is None
+
+
+def test_api_pubkey_fingerprint_and_is_endpoint_agree(env):
+    """Binding both endpoints in the same UI tile MUST show a consistent
+    trust-anchor snapshot -- they share the same underlying helper."""
+    client = env.app.test_client()
+    scalar = client.get("/api/license/pubkey-fingerprint").get_json()
+    fp = scalar["pubkey_fingerprint_sha256"]
+    predicate = client.get(
+        f"/api/license/is-pubkey-fingerprint?fp={fp}"
+    ).get_json()
+    assert scalar["pubkey_fingerprint_sha256"] == predicate["pubkey_fingerprint_sha256"]
+    assert scalar["pubkey_fingerprint_short"] == predicate["pubkey_fingerprint_short"]
+    assert scalar["valid"] == predicate["valid"]
+    assert predicate["is_pubkey_fingerprint"] is True


### PR DESCRIPTION
## Summary

- Adds `clawmetry.license.is_pubkey_fingerprint(fp) -> bool`, a case-insensitive whitespace-tolerant predicate matching the operator-supplied fingerprint against the embedded Ed25519 verification key's SHA-256 digest. Full 64-char hex OR 16-char short-form both match; non-hex / wrong-length input collapses to `False` up-front so a caller cannot silently mis-gate on a typo.
- Adds `GET /api/license/pubkey-fingerprint` and `GET /api/license/is-pubkey-fingerprint?fp=<hex>` on `bp_entitlement`. Both share a `_license_pubkey_fingerprint_snapshot()` helper so a UI binding both in the same tile can never catch them disagreeing on the trust anchor.
- Trust-anchor semantics: independent of any installed license file. The pubkey fingerprint is a trust-anchor fact, not a license-payload fact — an operator can compare `/api/license/pubkey-fingerprint` against the canonical fingerprint to confirm nobody has swapped `_PUBLIC_KEY_PEM` for an attacker-controlled key.
- Tolerant normalisation on the predicate: whitespace stripped, lowercased, `:` separators removed (many display formats print fingerprints as `ab:cd:ef:...`). Short-form (16 chars) matches iff it is a prefix of the full digest. Broken PEM → predicate collapses to `False` for every request, so an attacker cannot force `True` by swapping in a bad key.

Follows the same scalar-plus-predicate pattern already used for `license_subject` / `is_subject`, `license_tier` / `is_tier`, and `license_nodes` / `is_within_node_limit`. `pubkey_fingerprint()` itself already existed as a scalar in `clawmetry/license.py`; this PR closes the gap by adding the matching predicate + dedicated HTTP endpoints so a caller doesn't have to pull the whole `/api/license/pubkey` envelope for one field.

Zero behaviour change: purely additive, read-only. No new gate is enforced, no tier logic is altered.

## Test plan

- [x] `python -m pytest tests/test_license_pubkey_fingerprint_scalar.py -q` — 26 passed
- [x] `python -m pytest tests/test_license_pubkey.py tests/test_license_subject_scalar.py tests/test_license_nodes_scalar.py tests/test_license_permissions_scalar.py tests/test_license_presence_scalar.py tests/test_license_issued_scalar.py tests/test_license_tier_scalar.py tests/test_license_is_expired_is_perpetual.py tests/test_license_days_until_expiry.py tests/test_license.py tests/test_license_api.py tests/test_license_permissions.py -q` — 378 passed (no regressions in adjacent license suite)
- [x] `python -m pytest tests/test_entitlement_api.py tests/test_entitlement_api_fallback_shape.py tests/test_cli_status_license.py tests/test_cli_license_json.py tests/test_is_pro_user_license_branch.py -q` — 78 passed, 1 skipped (entitlement API + CLI regression checks clean)
- [x] `ruff check clawmetry/license.py routes/entitlement.py tests/test_license_pubkey_fingerprint_scalar.py` — clean
- [x] `python -m py_compile clawmetry/license.py routes/entitlement.py tests/test_license_pubkey_fingerprint_scalar.py` — clean

### Local operator verification checklist (I can't reach the running daemon or a browser from this environment)

- [ ] Copy `clawmetry/license.py`, `routes/entitlement.py`, and `tests/test_license_pubkey_fingerprint_scalar.py` into `~/.clawmetry/lib/pythonX.Y/site-packages/clawmetry/` and `.../site-packages/routes/`.
- [ ] Clear `__pycache__` under both directories.
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` to restart the daemon.
- [ ] `curl -s http://localhost:8900/api/license/pubkey-fingerprint | jq .` — expect `{"pubkey_fingerprint_sha256": "<64-char hex>", "pubkey_fingerprint_short": "<first 16>", "valid": true}` on a healthy install.
- [ ] `curl -s http://localhost:8900/api/license/pubkey | jq '{fingerprint_sha256, fingerprint_short}'` — the two fields must match the scalar endpoint exactly (they share `pubkey_fingerprint()`).
- [ ] `FP=$(curl -s http://localhost:8900/api/license/pubkey-fingerprint | jq -r .pubkey_fingerprint_sha256)` then `curl -s "http://localhost:8900/api/license/is-pubkey-fingerprint?fp=$FP" | jq .` — expect `is_pubkey_fingerprint=true`.
- [ ] `curl -s "http://localhost:8900/api/license/is-pubkey-fingerprint?fp=$(echo $FP | fold -w2 | paste -sd:)" | jq .` — colon-separated form should also match (`is_pubkey_fingerprint=true`, `requested_fp` should have colons stripped).
- [ ] `curl -s "http://localhost:8900/api/license/is-pubkey-fingerprint?fp=abcxyz" | jq .` — expect `is_pubkey_fingerprint=false` (typo rejection).
- [ ] `curl -s "http://localhost:8900/api/license/is-pubkey-fingerprint?fp=$(printf 'a%.0s' {1..64})" | jq .` — expect `is_pubkey_fingerprint=false` (wrong-fp rejection).
- [ ] Decrypt the live cloud snapshot and browser-check the dashboard still loads (this PR touches shared license/pubkey helpers but does not change any existing behaviour).

Marked draft — the local operator handles daemon verification, cloud-snapshot verification, release, and merge per FLYWHEEL.md.

---
_Generated by [Claude Code](https://claude.ai/code/session_016sWnfgqMSszYtfeqkEGy5o)_