### PR TITLE
fix(autoupdate): Windows installs out-of-process; attempts are never invisible

### DIFF
--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -2481,18 +2481,30 @@ def _cmd_status(args) -> None:
         except Exception:
             _det = []
         print("  Runtimes:")
-        print("    🦞 OpenClaw            ✅ syncing  (free)")
+        # OpenClaw line is DETECTION-GATED: this used to print
+        # "OpenClaw syncing" unconditionally, telling a machine with no
+        # OpenClaw install that OpenClaw was detected and syncing (founder
+        # live-hit 2026-07-28). Wording: "watching (local)" is the local
+        # DuckDB ingest that renders the dashboard; "syncing" is reserved
+        # for the separate Cloud sync line above — one word per concept.
+        try:
+            import dashboard as _dash_det
+            _oc_present = bool(_dash_det._detect_openclaw_install())
+        except Exception:
+            _oc_present = False
+        if _oc_present:
+            print("    🦞 OpenClaw            ✅ watching (local)  (free)")
         try:
             from clawmetry.adapters.nemo import NemoClawAdapter as _NCA
             _nemo = _NCA().detect()
             if _nemo.detected:
-                print("    ⚡ NemoClaw            ✅ syncing  (free)")
+                print("    ⚡ NemoClaw            ✅ watching (local)  (free)")
         except Exception:
             pass
         for _r in _det:
             _n = int(_r.get("sessionCount") or 0)
             _nm = _r.get("displayName") or _r.get("name") or "runtime"
-            _state = "✅ watching" if _entitled else "○ detected, NOT watched"
+            _state = "✅ watching (local)" if _entitled else "○ detected, NOT watched"
             print(f"    • {_nm:<18} {_state}  ({_n} session{'s' if _n != 1 else ''})")
         if not _prover:
             print("    ⚠ Claude Code / Codex / Cursor / Aider / Goose / opencode / Qwen — NOT syncing")

--- a/clawmetry/update_respawn.py
+++ b/clawmetry/update_respawn.py
@@ -1,0 +1,130 @@
+"""clawmetry/update_respawn.py — Windows out-of-process updater.
+
+Why this exists: on Windows, pip cannot replace ``Scripts/clawmetry.exe``
+while any process is running it, and — measured on a real Windows 10 box,
+2026-07-28 — even RENAMING the running launcher fails with WinError 32, so
+the pre-rename trick in ``perform_self_update`` silently does nothing there
+and every in-process auto-update dies with
+``WinError 32 ... clawmetry.exe``. The only reliable order on Windows is:
+
+  1. this helper is spawned DETACHED by the process that wants to update,
+  2. the parent exits (its locks vanish with it),
+  3. the helper waits for the parent pid to terminate,
+  4. the helper runs ``pip install --upgrade clawmetry==<target>``,
+  5. the helper relaunches the parent's exact command line, detached,
+  6. output goes to ``~/.clawmetry/restart.log``.
+
+The helper deliberately runs the OLD wheel's copy of this module (it is
+spawned before pip runs) and therefore keeps zero non-stdlib imports and no
+imports from the rest of clawmetry.
+
+Usage (spawned by routes/update_check.py, not humans):
+
+    python -m clawmetry.update_respawn <parent_pid> <target_version> \
+        <log_path> <relaunch_cmd...>
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import time
+
+_DETACHED = 0x00000008 | 0x00000200  # DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP
+
+
+def _wait_for_pid_exit(pid: int, timeout_secs: float = 60.0) -> bool:
+    """Block until ``pid`` is gone (True) or the timeout passes (False)."""
+    if os.name == "nt":
+        try:
+            import ctypes
+
+            SYNCHRONIZE = 0x00100000
+            h = ctypes.windll.kernel32.OpenProcess(SYNCHRONIZE, False, int(pid))
+            if not h:
+                return True  # already gone
+            try:
+                # WAIT_OBJECT_0 == 0 means the process terminated.
+                rc = ctypes.windll.kernel32.WaitForSingleObject(
+                    h, int(timeout_secs * 1000)
+                )
+                return rc == 0
+            finally:
+                ctypes.windll.kernel32.CloseHandle(h)
+        except Exception:
+            pass
+    # POSIX / fallback: poll for existence.
+    deadline = time.time() + timeout_secs
+    while time.time() < deadline:
+        try:
+            os.kill(int(pid), 0)
+        except OSError:
+            return True
+        time.sleep(0.5)
+    return False
+
+
+def main(argv=None) -> int:
+    argv = list(sys.argv[1:] if argv is None else argv)
+    if len(argv) < 4:
+        print("usage: update_respawn <parent_pid> <target> <log> <cmd...>")
+        return 2
+    parent_pid, target, log_path = argv[0], argv[1], argv[2]
+    relaunch_cmd = argv[3:]
+    try:
+        int(parent_pid)
+    except (TypeError, ValueError):
+        print(f"update_respawn: invalid parent pid {parent_pid!r}")
+        return 2
+
+    try:
+        os.makedirs(os.path.dirname(log_path), exist_ok=True)
+    except Exception:
+        pass
+    log = open(log_path, "ab", buffering=0)
+
+    def _say(msg: str) -> None:
+        try:
+            log.write((time.strftime("%Y-%m-%d %H:%M:%S ") + msg + "\n").encode())
+        except Exception:
+            pass
+
+    _say(f"[update-respawn] waiting for parent pid {parent_pid} to exit")
+    if not _wait_for_pid_exit(int(parent_pid), timeout_secs=90.0):
+        _say("[update-respawn] parent did not exit in 90s; aborting (no relaunch, "
+             "the still-running parent keeps serving)")
+        return 1
+
+    spec = f"clawmetry=={target}" if target and target != "latest" else "clawmetry"
+    _say(f"[update-respawn] parent gone; pip install --upgrade {spec}")
+    ok = False
+    for attempt in (1, 2):
+        proc = subprocess.run(
+            [sys.executable, "-m", "pip", "install", "--upgrade",
+             "--no-cache-dir", spec],
+            stdout=log, stderr=log, timeout=300,
+        )
+        if proc.returncode == 0:
+            ok = True
+            break
+        _say(f"[update-respawn] pip attempt {attempt} failed "
+             f"(exit {proc.returncode}); retrying in 10s")
+        time.sleep(10)
+
+    _say(f"[update-respawn] install {'succeeded' if ok else 'FAILED'}; "
+         f"relaunching: {relaunch_cmd}")
+    # Relaunch EITHER WAY: a failed install must still bring the service back
+    # on the old version rather than leaving the machine with nothing running.
+    kwargs = {"stdin": subprocess.DEVNULL, "stdout": log, "stderr": log,
+              "close_fds": True}
+    if os.name == "nt":
+        kwargs["creationflags"] = _DETACHED
+    else:
+        kwargs["start_new_session"] = True
+    subprocess.Popen(relaunch_cmd, **kwargs)
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/routes/update_check.py
+++ b/routes/update_check.py
@@ -122,19 +122,22 @@ def _respawn_cmdline() -> list:
 
 
 def _schedule_windows_respawn(delay_secs: float = 5.0) -> None:
-    """Windows self-restart: spawn a tiny detached helper that waits for this
-    process to exit (freeing the port), relaunches the exact command line
-    detached, then exit this process.
+    """Windows self-update: hand everything to the OUT-OF-PROCESS helper.
 
-    Windows has no launchd/systemd to respawn us and ``os.execv`` there does
-    not replace the process (it forks a sibling and returns the console to
-    the shell), so the only reliable way onto the new wheel is a delayed
-    detached relaunch. Console-script installs relaunch via the (freshly
-    pip-rewritten) ``clawmetry.exe``; module runs relaunch via
-    ``sys.executable`` + argv. The relaunched process is detached from the
-    original console, so its output goes to ``~/.clawmetry/restart.log``
-    rather than the (possibly long-gone) terminal.
+    In-process pip cannot work on Windows while ANY process runs
+    ``Scripts/clawmetry.exe``: pip's overwrite hits WinError 32, and —
+    measured live on a Windows 10 box (2026-07-28) — even RENAMING the
+    running launcher is denied, so the pre-rename trick in
+    ``perform_self_update`` silently no-ops and every install attempt
+    fails into backoff. The reliable order is inverted:
+    exit first, THEN install. ``clawmetry.update_respawn`` (spawned
+    detached, running the old wheel's copy) waits for this pid to
+    terminate, runs pip, and relaunches the exact command line either
+    way. Output: ``~/.clawmetry/restart.log``.
+
+    ``delay_secs`` retained for signature compatibility (unused).
     """
+    del delay_secs
     if os.environ.get("PYTEST_CURRENT_TEST"):
         log.info("auto-update: windows respawn suppressed under pytest")
         return
@@ -149,21 +152,16 @@ def _schedule_windows_respawn(delay_secs: float = 5.0) -> None:
             except Exception:
                 pass
             log_path = os.path.join(log_dir, "restart.log")
-            helper_src = (
-                "import subprocess,sys,time\n"
-                "time.sleep(float(sys.argv[1]))\n"
-                "out=open(sys.argv[2],'ab',buffering=0)\n"
-                "subprocess.Popen(sys.argv[3:],creationflags=0x208,"
-                "close_fds=True,stdin=subprocess.DEVNULL,stdout=out,stderr=out)\n"
-            )
+            target = _pending_update_target.get("version") or "latest"
             subprocess.Popen(
-                [sys.executable, "-c", helper_src, str(delay_secs), log_path] + cmd,
+                [sys.executable, "-m", "clawmetry.update_respawn",
+                 str(os.getpid()), str(target), log_path] + cmd,
                 creationflags=flags, close_fds=True,
                 stdin=subprocess.DEVNULL,
                 stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
             )
-            log.info("auto-update: windows respawn armed (delay=%.0fs) cmd=%s",
-                     delay_secs, cmd)
+            log.info("auto-update: windows out-of-process updater armed "
+                     "(target=%s) cmd=%s", target, cmd)
             os._exit(0)
         except Exception as exc:
             global _auto_update_in_progress
@@ -173,6 +171,35 @@ def _schedule_windows_respawn(delay_secs: float = 5.0) -> None:
     t = threading.Timer(2.0, _respawn)
     t.daemon = True
     t.start()
+
+
+# Target the Windows helper should install, stashed by _maybe_auto_update
+# right before it schedules the respawn (the helper runs pip AFTER this
+# process exits, so it cannot read process state).
+_pending_update_target: dict = {}
+
+
+def _record_update_attempt(target, outcome: str, detail: str = "") -> None:
+    """Persist the last auto-update attempt where a human can find it.
+
+    Both prior Windows failures were INVISIBLE: the dashboard's logger has
+    no stdout handler, so 'upgrade failed' warnings went nowhere and the
+    node just sat in backoff while /api/update-check/status said everything
+    was fine (founder: "are you doing end to end test at all??",
+    2026-07-28). The attempt row rides the same config table the status
+    endpoint already reads, so /api/update-check/status and `clawmetry
+    status` can answer "why is this node not updating" directly. Never
+    raises.
+    """
+    try:
+        _set_update_check_config({
+            "last_attempt_target": str(target),
+            "last_attempt_outcome": str(outcome),
+            "last_attempt_detail": str(detail)[-500:],
+            "last_attempt_at": str(time.time()),
+        })
+    except Exception as exc:
+        log.debug("update-attempt record failed: %s", exc)
 
 
 # Cross-process guard: on a standard install BOTH the daemon and the dashboard
@@ -667,6 +694,22 @@ def _maybe_auto_update(current, target, latest=None):
     log.info("auto-update: upgrading clawmetry v%s -> v%s (latest available v%s, "
              "role=%s, plan=%s)",
              current, target, latest or target, _process_role, plan)
+    _record_update_attempt(target, "started", f"role={_process_role} plan={plan}")
+    if plan == "respawn":
+        # Windows: NO in-process pip. While any process runs Scripts/
+        # clawmetry.exe, pip's overwrite fails with WinError 32 and even
+        # renaming the running launcher is denied (measured live 2026-07-28;
+        # the pre-rename in perform_self_update silently no-ops there, which
+        # is why every prior Windows auto-update failed straight into a
+        # 30-minute backoff, invisibly). The out-of-process helper
+        # (clawmetry.update_respawn) installs AFTER this process exits and
+        # relaunches it either way.
+        _pending_update_target["version"] = str(target)
+        _record_update_attempt(target, "handoff",
+                               "out-of-process helper armed; process exits")
+        _release_update_lock()
+        _schedule_windows_respawn()
+        return
     try:
         from routes.meta import perform_self_update
         payload, _status = perform_self_update(
@@ -676,6 +719,7 @@ def _maybe_auto_update(current, target, latest=None):
             _backoff = _retry_backoff_for_error(_err)
             log.warning("auto-update: upgrade failed, will retry in %.0fs: %s",
                         _backoff, payload)
+            _record_update_attempt(target, "failed", _err[-400:])
             _failed_update_attempts[str(target)] = time.monotonic() + _backoff
             if len(_failed_update_attempts) > 64:
                 _failed_update_attempts.pop(
@@ -686,11 +730,10 @@ def _maybe_auto_update(current, target, latest=None):
             _release_update_lock()
             return
         _failed_update_attempts.pop(str(target), None)
+        _record_update_attempt(target, "installed", f"plan={plan}")
         _release_update_lock()
         if plan == "exec":
             _schedule_exec_restart()
-        elif plan == "respawn":
-            _schedule_windows_respawn()
         elif plan == "defer":
             log.info("auto-update: installed v%s; restart deferred "
                      "(CLAWMETRY_NO_EXEC_RESTART set)", target)
@@ -829,10 +872,28 @@ def api_update_check_status():
     config = _get_update_check_config()
     latest = _get_latest_update_check()
 
+    # Last auto-update ATTEMPT (started/handoff/installed/failed + detail).
+    # Read straight from the config table: these keys are written by
+    # _record_update_attempt and are exactly the "why is this node not
+    # updating" answer that used to be invisible.
+    attempt = {}
+    try:
+        with _get_fleet_db_lock():
+            db = _get_fleet_db()
+            rows = db.execute(
+                "SELECT key, value FROM update_check_config "
+                "WHERE key LIKE 'last_attempt_%'"
+            ).fetchall()
+            db.close()
+        attempt = {r["key"]: r["value"] for r in rows}
+    except Exception:
+        attempt = {}
+
     result = {
         "config": config,
         "latest_check": latest,
         "show_banner": _should_show_update_banner(config, latest),
+        "last_attempt": attempt,
         "updater": {
             "role": _process_role,
             "check_interval_secs": (

--- a/tests/test_auto_update.py
+++ b/tests/test_auto_update.py
@@ -20,10 +20,18 @@ def _uc():
 
 
 def _as_daemon(uc, monkeypatch):
-    """Run the checker as the supervised sync daemon (the default-on role)."""
+    """Run the checker as the supervised sync daemon (the default-on role).
+
+    Pins the restart plan to the supervised-POSIX "exit" path so these
+    gating tests behave identically on every CI OS — on a Windows runner
+    the real plan would be "respawn" (out-of-process helper, no in-process
+    pip), which is covered by its own dedicated tests below.
+    """
     monkeypatch.delenv("CLAWMETRY_AUTO_UPDATE", raising=False)
     uc._process_role = "daemon"
     monkeypatch.setattr(uc, "_daemon_supervised", lambda: True)
+    monkeypatch.setattr(uc, "_restart_plan", lambda r, p, s: "exit")
+    monkeypatch.setattr(uc, "_record_update_attempt", lambda *a, **k: None)
 
 
 def _mock_self_update(monkeypatch, calls, ok=True, restarts=None):
@@ -222,6 +230,8 @@ def test_dashboard_role_default_on_installs(monkeypatch):
     assert uc._process_role == "dashboard"  # reload resets the role
     monkeypatch.setattr(uc, "_get_update_check_config", lambda: {"auto_update": True})
     monkeypatch.setattr(uc, "_dashboard_supervised", lambda: False)
+    monkeypatch.setattr(uc, "_restart_plan", lambda r, p, s: "exec")
+    monkeypatch.setattr(uc, "_record_update_attempt", lambda *a, **k: None)
     scheduled = []
     monkeypatch.setattr(uc, "_schedule_exec_restart", lambda: scheduled.append("exec"))
     monkeypatch.setattr(uc, "_schedule_windows_respawn", lambda: scheduled.append("respawn"))
@@ -231,7 +241,7 @@ def test_dashboard_role_default_on_installs(monkeypatch):
     assert calls == ["auto"], "dashboard role must install on the default-on policy"
     # Unsupervised process must not exit-and-die: it restarts in place.
     assert restarts == [False]
-    assert scheduled in (["exec"], ["respawn"])  # POSIX vs Windows runner
+    assert scheduled == ["exec"]
 
 
 def test_restart_plan_matrix():
@@ -329,9 +339,13 @@ def test_supervised_daemon_restarts(monkeypatch):
     assert restarts == [True], "supervised daemon restarts to apply the wheel"
 
 
-def test_windows_always_respawns(monkeypatch):
-    """Windows has no supervisor: even a 'supervised-looking' process must use
-    the detached respawn, never exit-and-die."""
+def test_windows_hands_off_to_out_of_process_helper(monkeypatch):
+    """Windows must NOT run pip in-process: while any process runs
+    Scripts/clawmetry.exe, pip's overwrite AND the pre-rename both fail with
+    WinError 32 (measured live 2026-07-28), so every in-process attempt died
+    into a silent 30-minute backoff. The respawn plan stashes the target and
+    hands everything to clawmetry.update_respawn, which installs AFTER this
+    process exits."""
     uc = _uc()
     monkeypatch.delenv("CLAWMETRY_AUTO_UPDATE", raising=False)
     uc._process_role = "daemon"
@@ -340,12 +354,61 @@ def test_windows_always_respawns(monkeypatch):
     scheduled = []
     monkeypatch.setattr(uc, "_schedule_windows_respawn", lambda: scheduled.append("respawn"))
     monkeypatch.setattr(uc, "_get_update_check_config", lambda: {"auto_update": True})
+    monkeypatch.setattr(uc, "_record_update_attempt", lambda *a, **k: None)
     calls, restarts = [], []
     _mock_self_update(monkeypatch, calls, restarts=restarts)
     uc._maybe_auto_update("0.12.1", "0.12.2")
-    assert calls == ["auto"]
-    assert restarts == [False]
-    assert scheduled == ["respawn"]
+    assert calls == [], "Windows must never pip in-process (WinError 32)"
+    assert scheduled == ["respawn"], "the out-of-process helper must be armed"
+    assert uc._pending_update_target.get("version") == "0.12.2", \
+        "the helper's install target must be stashed before handoff"
+
+
+def test_update_respawn_helper_waits_pips_and_relaunches(monkeypatch, tmp_path):
+    """The helper's contract: wait for the parent, pip the target, relaunch
+    the exact command line."""
+    from clawmetry import update_respawn as ur
+
+    events = []
+    monkeypatch.setattr(
+        ur, "_wait_for_pid_exit",
+        lambda pid, timeout_secs=90.0: events.append(("wait", pid)) or True,
+    )
+
+    class _Proc:
+        returncode = 0
+
+    monkeypatch.setattr(ur.subprocess, "run",
+                        lambda cmd, **k: events.append(("pip", cmd)) or _Proc())
+    monkeypatch.setattr(ur.subprocess, "Popen",
+                        lambda cmd, **k: events.append(("relaunch", cmd)))
+    log = tmp_path / "restart.log"
+    rc = ur.main(["1234", "0.12.99", str(log), "clawmetry.exe", "--port", "8900"])
+    assert rc == 0
+    assert [e[0] for e in events] == ["wait", "pip", "relaunch"]
+    pip_cmd = [e for e in events if e[0] == "pip"][0][1]
+    assert "clawmetry==0.12.99" in pip_cmd
+    assert [e for e in events if e[0] == "relaunch"][0][1] == \
+        ["clawmetry.exe", "--port", "8900"]
+
+
+def test_update_respawn_helper_relaunches_even_on_pip_failure(monkeypatch, tmp_path):
+    """A failed install must still bring the service back on the old wheel;
+    a machine left with nothing running is worse than a stale one."""
+    from clawmetry import update_respawn as ur
+
+    monkeypatch.setattr(ur, "_wait_for_pid_exit", lambda pid, timeout_secs=90.0: True)
+    monkeypatch.setattr(ur.time, "sleep", lambda s: None)
+
+    class _Fail:
+        returncode = 1
+
+    relaunched = []
+    monkeypatch.setattr(ur.subprocess, "run", lambda cmd, **k: _Fail())
+    monkeypatch.setattr(ur.subprocess, "Popen", lambda cmd, **k: relaunched.append(cmd))
+    rc = ur.main(["1234", "0.12.99", str(tmp_path / "r.log"), "clawmetry.exe"])
+    assert rc == 1
+    assert relaunched, "failed install must still relaunch the service"
 
 
 def test_entitled_plan_enables_auto_update(monkeypatch):

--- a/tests/test_auto_update_fast_loop.py
+++ b/tests/test_auto_update_fast_loop.py
@@ -199,6 +199,7 @@ def _gate(monkeypatch, uc, supervised, platform="darwin", kill=None):
     monkeypatch.setattr(uc, "_daemon_supervised", lambda: supervised)
     monkeypatch.setattr(uc, "_get_update_check_config",
                         lambda: {"auto_update": True})
+    monkeypatch.setattr(uc, "_record_update_attempt", lambda *a, **k: None)
     monkeypatch.setattr(uc.sys, "platform", platform)
     restarts = []
     execs = []
@@ -232,11 +233,19 @@ def test_supervised_daemon_uses_normal_restart(monkeypatch):
 
 
 def test_exec_restart_skipped_on_windows(monkeypatch):
+    """Windows never uses execv AND never pips in-process: the plan is the
+    out-of-process helper handoff (WinError 32 on the running launcher,
+    measured live 2026-07-28)."""
     uc = _uc()
     restarts, execs = _gate(monkeypatch, uc, supervised=False, platform="win32")
+    respawns = []
+    monkeypatch.setattr(uc, "_schedule_windows_respawn",
+                        lambda *a, **k: respawns.append(1))
+    monkeypatch.setattr(uc, "_record_update_attempt", lambda *a, **k: None)
     uc._maybe_auto_update("0.12.1", "0.12.2")
-    assert restarts == [False]
-    assert execs == [], "no execv semantics on Windows; defer to next start"
+    assert restarts == [], "no in-process pip on Windows"
+    assert execs == [], "no execv semantics on Windows"
+    assert respawns == [1], "the out-of-process helper must be armed"
 
 
 def test_exec_restart_kill_switch(monkeypatch):


### PR DESCRIPTION
Root cause of the failed 575-to-576 unattended update, measured live: on Windows, renaming the RUNNING clawmetry.exe is denied (WinError 32), so the pre-rename trick never protects pip and every in-process attempt fails into silent backoff. The respawn plan now hands off to a detached stdlib-only helper (clawmetry.update_respawn) that waits for the process to exit, pips the target with retry, and relaunches the exact command line even on failure. Every attempt is persisted and surfaced as last_attempt in /api/update-check/status so a stuck node is diagnosable from the API. Also detection-gates the hardcoded OpenClaw status line and switches ingest wording to watching-local vs cloud sync. Live-verified helper chain on the affected machine; 39 suite tests green.