### PR TITLE
fix(autoupdate): relaunch via the .exe when argv0 is the extensionless launcher

### DIFF
--- a/routes/update_check.py
+++ b/routes/update_check.py
@@ -114,10 +114,21 @@ def _restart_plan(role: str, platform: str, supervised: bool) -> str:
 def _respawn_cmdline() -> list:
     """The exact command line to relaunch THIS process. Console-script
     installs relaunch via the (freshly pip-rewritten) launcher exe; module
-    runs relaunch via the interpreter + argv."""
+    runs relaunch via the interpreter + argv.
+
+    Windows console-script quirk (live-hit on the FIRST otherwise-successful
+    unattended update, 2026-07-28): inside a process launched via
+    ``Scripts/clawmetry.exe``, ``sys.argv[0]`` is the EXTENSIONLESS
+    ``...\\Scripts\\clawmetry`` — no ``.exe`` suffix — so the suffix check
+    alone missed it, the fallback built ``python ...\\Scripts\\clawmetry``
+    (a file that does not exist on Windows), and the relaunch died with
+    Errno 2 after a perfect install. Probe ``argv0 + '.exe'`` too.
+    """
     argv0 = sys.argv[0] or ""
     if argv0.lower().endswith(".exe") and os.path.exists(argv0):
         return [argv0] + sys.argv[1:]
+    if os.name == "nt" and argv0 and os.path.exists(argv0 + ".exe"):
+        return [argv0 + ".exe"] + sys.argv[1:]
     return [sys.executable] + sys.argv
 
 

--- a/tests/test_auto_update.py
+++ b/tests/test_auto_update.py
@@ -269,6 +269,17 @@ def test_respawn_cmdline_console_script_vs_module(monkeypatch, tmp_path):
     monkeypatch.setattr(_sys, "argv", ["dashboard.py", "--port", "8900"])
     assert uc._respawn_cmdline() == [_sys.executable, "dashboard.py", "--port", "8900"], \
         "module runs must relaunch via the interpreter"
+    # Windows console-script quirk: inside a clawmetry.exe process argv[0]
+    # is the EXTENSIONLESS launcher path. Revert-proof for the Errno 2
+    # relaunch failure on the first live unattended update (2026-07-28):
+    # a perfect install died at the relaunch because the fallback built
+    # `python ...\Scripts\clawmetry`, a file that does not exist.
+    import os as _os
+    if _os.name == "nt":
+        stem = str(exe)[:-4]
+        monkeypatch.setattr(_sys, "argv", [stem, "--port", "8900"])
+        assert uc._respawn_cmdline() == [str(exe), "--port", "8900"], \
+            "extensionless console-script argv0 must relaunch via the .exe"
 
 
 def test_update_lock_serializes_concurrent_updaters(monkeypatch, tmp_path):


### PR DESCRIPTION
Last-mile fix from the first live unattended update: install succeeded in ten seconds, relaunch died with Errno 2 because console-script argv0 on Windows is the extensionless launcher path. Probes argv0+.exe. Revert-proof test on the Windows runner. With this, the full loop (detect, install, relaunch) is hands-free on Windows.