### PR TITLE
feat(license): license_expires_at + is_expiring_at scalar helpers + endpoints

### DIFF
--- a/clawmetry/license.py
+++ b/clawmetry/license.py
@@ -1071,6 +1071,99 @@ def is_expiring_within(days: int) -> bool:
     return 0 <= remaining <= threshold
 
 
+def license_expires_at() -> int | None:
+    """Scalar view onto the installed license's ``exp`` claim -- the epoch
+    timestamp the key expires at -- for a "license expires: <date>" row
+    that wants ONE integer rather than the whole
+    :func:`current_license_info` envelope.
+
+    Returns:
+      * ``None`` when there is nothing meaningful to surface: no license
+        file on disk, an invalid signature (the payload can't be trusted
+        -- an attacker could stuff any ``exp`` into an unsigned body), OR
+        a signed payload whose ``exp`` claim is absent / non-numeric
+        (perpetual license). A caller distinguishes "perpetual" from "no
+        license" via :func:`is_perpetual` + :func:`has_license`.
+      * A positive epoch integer otherwise -- the exact timestamp carried
+        by the signed payload, unmodified.
+
+    Deliberately lenient on expiry, mirroring :func:`license_issued_at`:
+    an expired-but-signature-valid key still carries a meaningful ``exp``
+    (support scenario: "when did this lapsed key expire?") and callers
+    would otherwise have to fall back to ``/api/license/status``. The
+    :func:`is_expired` / :func:`days_until_expiry` helpers independently
+    carry the "past-expiry" signal for callers that DO want to hide the
+    row on lapsed keys.
+
+    Pairs with :func:`days_until_expiry` the way :func:`license_issued_at`
+    pairs with :func:`license_age_days` -- this scalar surfaces the raw
+    epoch for an audit row, that one answers the caller-friendly "how
+    many days left" without either side having to do the arithmetic. The
+    two are floor-divided from the same ``exp`` so they never disagree at
+    the day boundary.
+
+    Never raises. Any exception under the hood degrades to ``None`` so a
+    UI tile bound to this helper never breaks on a partial install.
+    """
+    try:
+        info = current_license_info()
+    except Exception as exc:
+        logger.debug("license: license_expires_at underlying read failed: %s", exc)
+        return None
+    if not isinstance(info, dict):
+        return None
+    if info.get("status") == "invalid":
+        # Invalid-signature branch: payload cannot be trusted, refuse to
+        # surface any payload-derived claim (mirrors the issued_at scalar).
+        # Expired-but-signed keys still carry a meaningful ``exp`` so we
+        # do NOT refuse them here.
+        return None
+    exp = info.get("exp")
+    return int(exp) if isinstance(exp, (int, float)) else None
+
+
+def is_expiring_at(epoch: int) -> bool:
+    """Boolean gate for "does the installed license expire at THIS exact
+    epoch?" UIs -- e.g. a "we noticed your key expires <date>" tile that
+    binds a specific ``exp`` value and wants to detect renewal (the on-
+    disk key no longer matches the value it was rendered with).
+
+    Returns ``True`` iff a license is installed, signature-valid, NOT
+    expired, carries an ``exp`` claim, AND that claim matches ``epoch``
+    exactly. Perpetual licenses (no ``exp``) and the no-license path both
+    return ``False``: nothing to compare against.
+
+    ``epoch`` is coerced through ``int()``; a non-numeric value collapses
+    to ``False`` so a caller cannot silently mis-gate on a typo. Never
+    raises; every underlying failure returns ``False`` so a scheduled
+    reminder job never crashes on a bad install.
+
+    Deliberately strict on validity, unlike the underlying
+    :func:`license_expires_at` scalar (which is lenient on expiry so a
+    support tile can render "expired 12 days ago"). A predicate that
+    fired ``True`` on an already-lapsed key would push callers to gate
+    renewal UI on a value that no longer implies the customer is
+    entitled.
+    """
+    try:
+        wanted = int(epoch)
+    except (TypeError, ValueError):
+        return False
+    try:
+        info = current_license_info()
+    except Exception as exc:
+        logger.debug("license: is_expiring_at underlying read failed: %s", exc)
+        return False
+    if not isinstance(info, dict):
+        return False
+    if not info.get("valid"):
+        return False
+    exp = info.get("exp")
+    if not isinstance(exp, (int, float)):
+        return False
+    return int(exp) == wanted
+
+
 def license_tier() -> str | None:
     """Scalar view onto the installed license's ``tier`` claim -- for a
     paywall tile / tier badge that wants ONE string rather than the whole

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -9198,6 +9198,183 @@ def api_license_age_days():
         )
 
 
+def _license_expires_snapshot() -> dict:
+    """Shared helper: read once, derive the quartet the two ``exp``-derived
+    endpoints both need (``expires_at``, ``days_until_expiry``,
+    ``has_license``, ``valid``). Lives in the handler layer -- not in
+    :mod:`clawmetry.license` -- because ``has_license`` is an install-state
+    fact rather than a license-payload fact, and both endpoints below need
+    the pair together so a UI cannot catch them disagreeing on
+    ``has_license`` for the same install.
+
+    Deliberately lenient on expiry, matching the ``license_expires_at`` /
+    ``days_until_expiry`` posture: a signed-but-lapsed key still surfaces
+    its real ``expires_at`` (with a negative ``days_until_expiry``) so a
+    support/audit tile can render "expired 12 days ago" without special-
+    casing the expired branch. The ``valid`` field independently carries
+    the "signature-valid AND not expired" signal for callers that DO want
+    to hide the row on lapsed keys.
+
+    Never raises: any underlying failure collapses to
+    ``{expires_at: None, days_until_expiry: None, has_license: False,
+    valid: False}`` so callers keep the "OSS-free" branch shape.
+    """
+    try:
+        from clawmetry import license as _lic
+
+        info = _lic.current_license_info()
+        expires = _lic.license_expires_at()
+        days = _lic.days_until_expiry()
+    except Exception as exc:
+        logger.debug("_license_expires_snapshot: underlying read failed: %s", exc)
+        return {
+            "expires_at": None,
+            "days_until_expiry": None,
+            "has_license": False,
+            "valid": False,
+        }
+    if not isinstance(info, dict):
+        return {
+            "expires_at": None,
+            "days_until_expiry": None,
+            "has_license": False,
+            "valid": False,
+        }
+    return {
+        "expires_at": expires,
+        "days_until_expiry": days,
+        "has_license": True,
+        "valid": bool(info.get("valid")),
+    }
+
+
+@bp_entitlement.route("/api/license/expires-at")
+def api_license_expires_at():
+    """``GET /api/license/expires-at`` -- scalar view of the installed
+    license's ``exp`` claim (epoch seconds), for a "license expires:
+    <date>" row that wants ONE integer rather than the whole
+    ``/api/license/status`` envelope.
+
+    Response shape (always HTTP 200)::
+
+        {
+          "expires_at": <int|null>,          # epoch; None if untrusted / perpetual
+          "days_until_expiry": <int|null>,   # signed days remaining
+          "has_license": <bool>,             # is a license file installed at all?
+          "valid": <bool>                    # signature-valid AND not expired
+        }
+
+    ``expires_at`` mirrors :func:`clawmetry.license.license_expires_at`:
+
+      * ``null`` when there is no license file, on the invalid-signature
+        branch (payload cannot be trusted -- an attacker could stuff any
+        ``exp`` into an unsigned body), OR when the signed payload has
+        no ``exp`` claim (perpetual license -- distinguish from
+        no-license via ``has_license``).
+      * A positive epoch integer otherwise, unmodified from the signed
+        payload.
+
+    Deliberately lenient on expiry, unlike ``/api/license/tier`` and
+    ``/api/license/nodes``: a signed-but-lapsed key still surfaces its
+    real ``expires_at`` so a support tile can render "expired 12 days
+    ago" on an expired key. The ``valid`` field independently carries
+    the "signature-valid AND not expired" signal for callers that DO
+    want to hide the row on lapsed keys.
+
+    Pairs with ``/api/license/days-until-expiry`` -- this endpoint
+    surfaces the raw epoch for an audit row, that endpoint answers the
+    caller-friendly "how many days left" without the caller having to do
+    the arithmetic. The two endpoints share :func:`_license_expires_snapshot`
+    so a UI binding both sees a consistent snapshot.
+
+    Never 5xxs -- any underlying failure degrades to
+    ``{expires_at: null, days_until_expiry: null, has_license: false,
+    valid: false}`` (the OSS-free branch shape), matching the never-crash
+    posture of the surrounding license endpoints.
+    """
+    try:
+        return jsonify(_license_expires_snapshot())
+    except Exception as exc:
+        logger.warning("api_license_expires_at: error: %s", exc)
+        return jsonify(
+            {
+                "expires_at": None,
+                "days_until_expiry": None,
+                "has_license": False,
+                "valid": False,
+            }
+        )
+
+
+@bp_entitlement.route("/api/license/is-expiring-at")
+def api_license_is_expiring_at():
+    """``GET /api/license/is-expiring-at?epoch=<int>`` -- predicate
+    matching the operator-supplied epoch against the installed license's
+    ``exp`` claim, for a "we noticed your key expires <date>" tile that
+    binds a specific ``exp`` value and wants to detect renewal (the on-
+    disk key no longer matches the value it was rendered with).
+
+    Response shape (always HTTP 200)::
+
+        {
+          "is_expiring_at": <bool>,          # exact match; else false
+          "requested_epoch": <int|null>,     # int-coerced input, or null on typo
+          "expires_at": <int|null>,          # current on-disk exp for comparison
+          "has_license": <bool>,
+          "valid": <bool>                    # signature-valid AND not expired
+        }
+
+    ``is_expiring_at`` mirrors :func:`clawmetry.license.is_expiring_at`:
+
+      * ``false`` when there is no license file, on the invalid-signature
+        branch, on the expired branch (a predicate that fired ``true`` on
+        a lapsed key would push callers to gate renewal UI on a value
+        that no longer implies entitlement), on the perpetual-license
+        branch (no ``exp`` to compare), OR when ``epoch`` doesn't parse
+        as an integer.
+      * ``true`` iff the installed key is signature-valid, not expired,
+        carries an ``exp`` claim, AND that claim equals the supplied
+        ``epoch`` exactly.
+
+    Deliberately strict on validity, unlike the sibling
+    ``/api/license/expires-at`` endpoint (which is lenient on expiry so a
+    support tile can render "expired 12 days ago"). See the docstring on
+    :func:`clawmetry.license.is_expiring_at` for the rationale.
+
+    Query parameter:
+
+      * ``epoch`` -- required. Unix epoch seconds as an integer. A
+        missing / non-integer value collapses to
+        ``is_expiring_at=false`` with ``requested_epoch=null`` so a
+        caller cannot silently mis-gate on a typo. HTTP status is 200
+        either way -- the "bad input" signal is the ``false`` result,
+        not a 4xx, matching the never-crash posture of the surrounding
+        license endpoints.
+    """
+    raw = request.args.get("epoch", "")
+    try:
+        requested = int(str(raw).strip())
+    except (TypeError, ValueError):
+        requested = None
+    snap = _license_expires_snapshot()
+    try:
+        from clawmetry import license as _lic
+
+        matched = _lic.is_expiring_at(requested) if requested is not None else False
+    except Exception as exc:
+        logger.warning("api_license_is_expiring_at: error: %s", exc)
+        matched = False
+    return jsonify(
+        {
+            "is_expiring_at": bool(matched),
+            "requested_epoch": requested,
+            "expires_at": snap["expires_at"],
+            "has_license": snap["has_license"],
+            "valid": snap["valid"],
+        }
+    )
+
+
 @bp_entitlement.route("/api/paywall/event", methods=["POST"])
 def api_paywall_event():
     body: dict = {}

--- a/tests/test_license_expires_at_scalar.py
+++ b/tests/test_license_expires_at_scalar.py
@@ -1,0 +1,515 @@
+"""Tests for the ``license_expires_at()`` / ``is_expiring_at()`` scalar
+helpers in :mod:`clawmetry.license` plus their matching
+``/api/license/expires-at`` and ``/api/license/is-expiring-at`` HTTP
+endpoints.
+
+Mirrors ``tests/test_license_issued_scalar.py``'s hermetic pattern --
+ephemeral Ed25519 keypair, ``LICENSE_PATH`` monkeypatched into
+``tmp_path``, and ``CLAWMETRY_OFFLINE=1`` so ``activate()`` never phones
+home during the suite. Nothing here touches the operator's real license
+file.
+"""
+from __future__ import annotations
+
+import os
+import time
+from types import SimpleNamespace
+
+import pytest
+from flask import Flask
+
+
+def _keypair():
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+    priv = Ed25519PrivateKey.generate()
+    pub_pem = priv.public_key().public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    return priv, pub_pem
+
+
+def _payload(
+    tier="pro",
+    nodes=3,
+    exp_delta=365 * 86400,
+    iat_delta=0,
+    drop_exp=False,
+    bad_exp=None,
+):
+    """Build a signed-payload dict. ``exp_delta`` shifts ``exp`` from now
+    (negative = expired); ``drop_exp`` omits the claim (perpetual);
+    ``bad_exp`` forces a non-numeric value."""
+    now = int(time.time())
+    p = {
+        "sub": "acct_test",
+        "tier": tier,
+        "nodes": nodes,
+        "iat": now + iat_delta,
+        "exp": now + exp_delta,
+        "features": ["runtimes"],
+    }
+    if drop_exp:
+        p.pop("exp", None)
+    if bad_exp is not None:
+        p["exp"] = bad_exp
+    return p
+
+
+@pytest.fixture
+def app(monkeypatch, tmp_path):
+    import clawmetry.license as _lic
+
+    priv, pub_pem = _keypair()
+    monkeypatch.setattr(_lic, "_PUBLIC_KEY_PEM", pub_pem)
+    license_path = str(tmp_path / "license.key")
+    monkeypatch.setattr(_lic, "LICENSE_PATH", license_path)
+    monkeypatch.delenv("CLAWMETRY_LICENSE_SERVER", raising=False)
+    monkeypatch.delenv("CLAWMETRY_INGEST_URL", raising=False)
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("CLAWMETRY_OFFLINE", "1")
+
+    from routes.entitlement import bp_entitlement
+
+    flask_app = Flask(__name__)
+    flask_app.register_blueprint(bp_entitlement)
+    flask_app.config["TESTING"] = True
+
+    return SimpleNamespace(
+        app=flask_app,
+        lic=_lic,
+        priv=priv,
+        license_path=license_path,
+    )
+
+
+def _write_key_direct(app, payload):
+    """Bypass ``activate()`` (which refuses expired/malformed tokens) and
+    write a token directly to the license file. Simulates a licence that
+    expired AFTER install or was signed with an anomalous ``exp``."""
+    tok = app.lic._encode_token(payload, app.priv)
+    os.makedirs(os.path.dirname(app.license_path), exist_ok=True)
+    with open(app.license_path, "w", encoding="utf-8") as fh:
+        fh.write(tok)
+
+
+# ── clawmetry.license.license_expires_at() ────────────────────────────────────
+
+
+def test_license_expires_at_none_when_no_license(app):
+    """No license file on disk -> None (nothing to surface)."""
+    assert app.lic.license_expires_at() is None
+
+
+def test_license_expires_at_active_returns_epoch(app):
+    """Active licence -> the exact ``exp`` epoch, unmodified from the
+    signed payload."""
+    now = int(time.time())
+    delta = 365 * 86400
+    tok = app.lic._encode_token(_payload(exp_delta=delta), app.priv)
+    app.lic.activate(tok)
+    expires = app.lic.license_expires_at()
+    assert isinstance(expires, int)
+    # Allow +/- 5s for wall-clock jitter around the call.
+    assert (now + delta) - 5 <= expires <= (now + delta) + 5
+
+
+def test_license_expires_at_expired_still_returns_epoch(app):
+    """Expired-but-signed licence -> still surfaces ``exp``. Unlike
+    :func:`license_tier` / :func:`license_nodes`, this scalar is lenient
+    on expiry so a support UI can render "expired 12 days ago" on lapsed
+    keys."""
+    _write_key_direct(app, _payload(exp_delta=-12 * 86400))
+    expires = app.lic.license_expires_at()
+    assert isinstance(expires, int)
+    assert expires < int(time.time())
+
+
+def test_license_expires_at_invalid_signature(app):
+    """File on disk but signature bogus -> None. An attacker could stuff
+    any ``exp`` into an unsigned body, so we refuse to trust it."""
+    os.makedirs(os.path.dirname(app.license_path), exist_ok=True)
+    with open(app.license_path, "w", encoding="utf-8") as fh:
+        fh.write("CLAW1.garbage.garbage")
+    assert app.lic.license_expires_at() is None
+
+
+def test_license_expires_at_missing_exp_claim(app):
+    """Perpetual license (no ``exp`` claim) -> None. Signed but nothing
+    to surface. Callers distinguish perpetual from no-license via
+    :func:`is_perpetual` + :func:`has_license`."""
+    _write_key_direct(app, _payload(drop_exp=True))
+    assert app.lic.license_expires_at() is None
+
+
+def test_license_expires_at_non_numeric_exp(app):
+    """Payload with a non-numeric ``exp`` -> None (never raises)."""
+    _write_key_direct(app, _payload(bad_exp="never"))
+    assert app.lic.license_expires_at() is None
+
+
+def test_license_expires_at_never_raises(monkeypatch):
+    """Any underlying failure -> None. Even a fully-broken
+    current_license_info() must not propagate."""
+    import clawmetry.license as _lic
+
+    def _boom():
+        raise RuntimeError("simulated corrupt install")
+
+    monkeypatch.setattr(_lic, "current_license_info", _boom)
+    assert _lic.license_expires_at() is None
+
+
+def test_license_expires_at_matches_days_until_expiry_boundary(app):
+    """The raw scalar and the derived days-until-expiry scalar are
+    floor-divided from the SAME ``exp`` claim: for any active licence,
+    ``days_until_expiry() == (expires_at - now) // 86400`` (allowing a
+    +/- 1 day tolerance for the wall-clock crossing a day boundary
+    between the two reads)."""
+    tok = app.lic._encode_token(_payload(exp_delta=45 * 86400), app.priv)
+    app.lic.activate(tok)
+    expires = app.lic.license_expires_at()
+    days = app.lic.days_until_expiry()
+    assert isinstance(expires, int)
+    assert isinstance(days, int)
+    derived = (expires - int(time.time())) // 86400
+    assert abs(derived - days) <= 1
+
+
+# ── clawmetry.license.is_expiring_at() ────────────────────────────────────────
+
+
+def test_is_expiring_at_false_when_no_license(app):
+    """No license file -> False. Nothing to compare against."""
+    assert app.lic.is_expiring_at(int(time.time()) + 86400) is False
+
+
+def test_is_expiring_at_true_on_exact_match(app):
+    """Active licence, epoch matches ``exp`` -> True."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    expires = app.lic.license_expires_at()
+    assert expires is not None
+    assert app.lic.is_expiring_at(expires) is True
+
+
+def test_is_expiring_at_false_on_off_by_one(app):
+    """A one-second-off epoch is NOT a match. The predicate is exact."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    expires = app.lic.license_expires_at()
+    assert expires is not None
+    assert app.lic.is_expiring_at(expires + 1) is False
+    assert app.lic.is_expiring_at(expires - 1) is False
+
+
+def test_is_expiring_at_false_on_expired_key(app):
+    """Deliberately strict on validity: an already-lapsed key returns
+    False even for the correct ``exp`` value. See docstring rationale."""
+    _write_key_direct(app, _payload(exp_delta=-1 * 86400))
+    expires = app.lic.license_expires_at()
+    assert expires is not None  # scalar is lenient on expiry
+    assert app.lic.is_expiring_at(expires) is False  # predicate is strict
+
+
+def test_is_expiring_at_false_on_perpetual_key(app):
+    """Perpetual licence (no ``exp``) -> False for any epoch."""
+    _write_key_direct(app, _payload(drop_exp=True))
+    assert app.lic.is_expiring_at(int(time.time()) + 86400) is False
+
+
+def test_is_expiring_at_false_on_invalid_signature(app):
+    """Invalid-signature branch -> False. An attacker could stuff any
+    ``exp`` into an unsigned body."""
+    os.makedirs(os.path.dirname(app.license_path), exist_ok=True)
+    with open(app.license_path, "w", encoding="utf-8") as fh:
+        fh.write("CLAW1.garbage.garbage")
+    assert app.lic.is_expiring_at(int(time.time()) + 86400) is False
+
+
+def test_is_expiring_at_typo_input_returns_false(app):
+    """Non-integer input collapses to False. A caller cannot silently
+    mis-gate on a typo."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    assert app.lic.is_expiring_at("not-a-number") is False  # type: ignore[arg-type]
+    assert app.lic.is_expiring_at(None) is False  # type: ignore[arg-type]
+
+
+def test_is_expiring_at_coerces_numeric_strings(app):
+    """A numeric-string epoch coerces via int() and can match."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    expires = app.lic.license_expires_at()
+    assert expires is not None
+    assert app.lic.is_expiring_at(str(expires)) is True  # type: ignore[arg-type]
+
+
+def test_is_expiring_at_never_raises(monkeypatch):
+    """Any underlying failure -> False. Never propagates."""
+    import clawmetry.license as _lic
+
+    def _boom():
+        raise RuntimeError("simulated corrupt install")
+
+    monkeypatch.setattr(_lic, "current_license_info", _boom)
+    assert _lic.is_expiring_at(int(time.time()) + 86400) is False
+
+
+# ── current_license_info() envelope carries ``exp`` on every branch ──────────
+
+
+def test_current_license_info_active_carries_exp(app):
+    tok = app.lic._encode_token(_payload(exp_delta=90 * 86400), app.priv)
+    app.lic.activate(tok)
+    info = app.lic.current_license_info()
+    assert isinstance(info, dict)
+    assert "exp" in info
+    assert isinstance(info["exp"], (int, float))
+
+
+def test_current_license_info_invalid_signature_exp_none(app):
+    os.makedirs(os.path.dirname(app.license_path), exist_ok=True)
+    with open(app.license_path, "w", encoding="utf-8") as fh:
+        fh.write("CLAW1.garbage.garbage")
+    info = app.lic.current_license_info()
+    assert isinstance(info, dict)
+    assert info["exp"] is None
+
+
+def test_current_license_info_expired_carries_exp(app):
+    _write_key_direct(app, _payload(exp_delta=-2 * 86400))
+    info = app.lic.current_license_info()
+    assert isinstance(info, dict)
+    assert isinstance(info["exp"], (int, float))
+
+
+# ── GET /api/license/expires-at ──────────────────────────────────────────────
+
+
+def test_endpoint_expires_at_no_license(app):
+    with app.app.test_client() as c:
+        resp = c.get("/api/license/expires-at")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data == {
+        "expires_at": None,
+        "days_until_expiry": None,
+        "has_license": False,
+        "valid": False,
+    }
+
+
+def test_endpoint_expires_at_active(app):
+    tok = app.lic._encode_token(_payload(exp_delta=60 * 86400), app.priv)
+    app.lic.activate(tok)
+    with app.app.test_client() as c:
+        resp = c.get("/api/license/expires-at")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert isinstance(data["expires_at"], int)
+    assert isinstance(data["days_until_expiry"], int)
+    assert 58 <= data["days_until_expiry"] <= 61
+    assert data["has_license"] is True
+    assert data["valid"] is True
+
+
+def test_endpoint_expires_at_expired(app):
+    """Lenient on expiry: surface ``expires_at`` + signed ``days_until_expiry``
+    on lapsed keys; ``valid=false`` carries the "signed but expired" signal."""
+    _write_key_direct(app, _payload(exp_delta=-8 * 86400))
+    with app.app.test_client() as c:
+        resp = c.get("/api/license/expires-at")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert isinstance(data["expires_at"], int)
+    assert isinstance(data["days_until_expiry"], int)
+    assert data["days_until_expiry"] < 0
+    assert data["has_license"] is True
+    assert data["valid"] is False
+
+
+def test_endpoint_expires_at_perpetual(app):
+    """Perpetual licence (no ``exp``) -> ``expires_at=None`` but
+    ``has_license=True``, so a UI distinguishes perpetual from no-license
+    via ``has_license`` rather than a magic ``expires_at`` value."""
+    _write_key_direct(app, _payload(drop_exp=True))
+    with app.app.test_client() as c:
+        resp = c.get("/api/license/expires-at")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["expires_at"] is None
+    assert data["days_until_expiry"] is None
+    assert data["has_license"] is True
+
+
+def test_endpoint_expires_at_invalid_file(app):
+    os.makedirs(os.path.dirname(app.license_path), exist_ok=True)
+    with open(app.license_path, "w", encoding="utf-8") as fh:
+        fh.write("CLAW1.garbage.garbage")
+    with app.app.test_client() as c:
+        resp = c.get("/api/license/expires-at")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["has_license"] is True
+    assert data["expires_at"] is None
+    assert data["days_until_expiry"] is None
+    assert data["valid"] is False
+
+
+def test_endpoint_expires_at_never_5xxs(app, monkeypatch):
+    """Even if the shared snapshot blows up mid-request, the endpoint
+    must still return HTTP 200 with the OSS-free shape."""
+    from routes import entitlement as _routes
+
+    monkeypatch.setattr(
+        _routes,
+        "_license_expires_snapshot",
+        lambda: (_ for _ in ()).throw(RuntimeError("simulated blowup")),
+    )
+    with app.app.test_client() as c:
+        resp = c.get("/api/license/expires-at")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data == {
+        "expires_at": None,
+        "days_until_expiry": None,
+        "has_license": False,
+        "valid": False,
+    }
+
+
+# ── GET /api/license/is-expiring-at ──────────────────────────────────────────
+
+
+def test_endpoint_is_expiring_at_no_license(app):
+    with app.app.test_client() as c:
+        resp = c.get("/api/license/is-expiring-at?epoch=1800000000")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["is_expiring_at"] is False
+    assert data["requested_epoch"] == 1800000000
+    assert data["expires_at"] is None
+    assert data["has_license"] is False
+    assert data["valid"] is False
+
+
+def test_endpoint_is_expiring_at_exact_match(app):
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    expires = app.lic.license_expires_at()
+    assert expires is not None
+    with app.app.test_client() as c:
+        resp = c.get(f"/api/license/is-expiring-at?epoch={expires}")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["is_expiring_at"] is True
+    assert data["requested_epoch"] == expires
+    assert data["expires_at"] == expires
+    assert data["has_license"] is True
+    assert data["valid"] is True
+
+
+def test_endpoint_is_expiring_at_off_by_one_rejected(app):
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    expires = app.lic.license_expires_at()
+    assert expires is not None
+    with app.app.test_client() as c:
+        resp = c.get(f"/api/license/is-expiring-at?epoch={expires + 1}")
+    data = resp.get_json()
+    assert data["is_expiring_at"] is False
+    assert data["requested_epoch"] == expires + 1
+    assert data["expires_at"] == expires
+
+
+def test_endpoint_is_expiring_at_typo_rejected(app):
+    """Non-integer ``epoch`` -> ``is_expiring_at=false`` with
+    ``requested_epoch=null``. HTTP 200 either way -- the bad-input signal
+    is the false result, not a 4xx."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    with app.app.test_client() as c:
+        resp = c.get("/api/license/is-expiring-at?epoch=tomorrow")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["is_expiring_at"] is False
+    assert data["requested_epoch"] is None
+    assert data["has_license"] is True
+
+
+def test_endpoint_is_expiring_at_missing_param(app):
+    """No ``epoch`` at all -> false with ``requested_epoch=null``."""
+    with app.app.test_client() as c:
+        resp = c.get("/api/license/is-expiring-at")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["is_expiring_at"] is False
+    assert data["requested_epoch"] is None
+
+
+def test_endpoint_is_expiring_at_expired_key_rejected(app):
+    """Deliberately strict on validity: an already-lapsed key returns
+    ``is_expiring_at=false`` even for the correct ``exp`` value.
+    ``expires_at`` still surfaces the actual on-disk value (lenient
+    scalar) so the caller can see WHY the predicate said false."""
+    _write_key_direct(app, _payload(exp_delta=-5 * 86400))
+    expires = app.lic.license_expires_at()
+    assert expires is not None
+    with app.app.test_client() as c:
+        resp = c.get(f"/api/license/is-expiring-at?epoch={expires}")
+    data = resp.get_json()
+    assert data["is_expiring_at"] is False
+    assert data["expires_at"] == expires
+    assert data["has_license"] is True
+    assert data["valid"] is False
+
+
+def test_endpoint_is_expiring_at_perpetual_rejected(app):
+    """Perpetual licence (no ``exp``) -> false for any epoch."""
+    _write_key_direct(app, _payload(drop_exp=True))
+    with app.app.test_client() as c:
+        resp = c.get("/api/license/is-expiring-at?epoch=1800000000")
+    data = resp.get_json()
+    assert data["is_expiring_at"] is False
+    assert data["expires_at"] is None
+    assert data["has_license"] is True
+
+
+# ── consistency: both endpoints see the same snapshot ────────────────────────
+
+
+def test_both_endpoints_agree_on_snapshot(app):
+    """Both endpoints share :func:`_license_expires_snapshot` -- they
+    must surface identical ``expires_at`` / ``has_license`` / ``valid``
+    values for the same install."""
+    tok = app.lic._encode_token(_payload(exp_delta=42 * 86400), app.priv)
+    app.lic.activate(tok)
+    with app.app.test_client() as c:
+        a = c.get("/api/license/expires-at").get_json()
+        b = c.get("/api/license/is-expiring-at?epoch=1").get_json()
+    for key in ("expires_at", "has_license", "valid"):
+        assert a[key] == b[key], f"mismatch on {key}: {a[key]!r} vs {b[key]!r}"
+
+
+def test_expires_at_matches_days_until_expiry_endpoint_boundary(app):
+    """``/api/license/expires-at`` and ``/api/license/days-until-expiry``
+    are derived from the SAME ``exp`` claim: the scalar and the derived
+    days must never disagree at the day boundary (allow +/- 1 for
+    wall-clock crossings between the two reads). The two endpoints use
+    different key names -- ``days_until_expiry`` here, ``days_left`` on
+    the older endpoint -- but they floor-divide the same seconds."""
+    tok = app.lic._encode_token(_payload(exp_delta=100 * 86400), app.priv)
+    app.lic.activate(tok)
+    with app.app.test_client() as c:
+        a = c.get("/api/license/expires-at").get_json()
+        b = c.get("/api/license/days-until-expiry").get_json()
+    assert isinstance(a["expires_at"], int)
+    assert isinstance(a["days_until_expiry"], int)
+    assert isinstance(b["days_left"], int)
+    derived = (a["expires_at"] - int(time.time())) // 86400
+    assert abs(derived - a["days_until_expiry"]) <= 1
+    # Cross-endpoint consistency: the two derived-days scalars must agree.
+    assert abs(a["days_until_expiry"] - b["days_left"]) <= 1


### PR DESCRIPTION
## Summary

- Adds `clawmetry.license.license_expires_at() -> int | None`, a scalar view onto the installed license's `exp` claim (epoch seconds), for a "license expires: <date>" row that wants ONE integer rather than the whole `current_license_info()` envelope. Follows the same pattern already used for `license_issued_at()` / `license_age_days()`, `license_tier`, `license_nodes`, `license_subject`, etc.
- Adds a matching `is_expiring_at(epoch) -> bool` predicate for a "we noticed your key expires <date>" tile that binds a specific `exp` value and wants to detect renewal (the on-disk key no longer matches the value it was rendered with). Deliberately strict on validity (unlike the underlying scalar which is lenient on expiry) so a caller cannot silently mis-gate renewal UI on a lapsed key.
- Adds `GET /api/license/expires-at` and `GET /api/license/is-expiring-at?epoch=<int>` on `bp_entitlement`. Both share a `_license_expires_snapshot()` helper so a UI binding both in the same tile can never catch them disagreeing on `has_license` / `valid` for the same install. Matches the shape pattern of `/api/license/issued-at` / `/api/license/age-days`.

Posture notes (mirrors `license_issued_at`):
- **Lenient on expiry** on the scalar: an expired-but-signature-valid key still surfaces its real `exp` epoch so a support tile can render "expired 12 days ago". The `valid` field carries the "signature-valid AND not expired" signal for callers that DO want to hide the row on lapsed keys.
- **Strict on validity** on the predicate: an already-lapsed key returns `is_expiring_at=false` even for the correct `exp` value — a predicate that fired `true` on a lapsed key would push callers to gate renewal UI on a value that no longer implies entitlement.
- **Invalid-signature branch collapses to `null`/`false`**: an attacker could stuff any `exp` into an unsigned body, so we refuse to trust it.
- **Perpetual license (no `exp` claim)**: scalar returns `null`, predicate returns `false`. Callers distinguish perpetual from no-license via `has_license`.
- **Typo rejection**: non-integer `epoch` input collapses to `is_expiring_at=false` with `requested_epoch=null` up-front, so a caller cannot silently mis-gate on a typo. HTTP 200 either way — the bad-input signal is the `false` result, not a 4xx.

Cross-endpoint consistency covered by a test: the raw `expires_at` scalar and the derived `days_until_expiry` are floor-divided from the SAME `exp` claim, so they never disagree at the day boundary — matches the invariant already covered between `/api/license/issued-at` and `/api/license/age-days`.

Zero behaviour change: purely additive, read-only. No new gate is enforced, no tier logic is altered.

## Test plan

- [x] `python3 -m pytest tests/test_license_expires_at_scalar.py -q` — **35 passed**
- [x] `python3 -m pytest tests/test_license_days_until_expiry.py tests/test_license_issued_scalar.py tests/test_license_tier_scalar.py tests/test_license_nodes_scalar.py tests/test_license_subject_scalar.py tests/test_license_presence_scalar.py tests/test_license_is_expired_is_perpetual.py tests/test_license.py tests/test_license_api.py tests/test_entitlement_api.py tests/test_entitlement_api_fallback_shape.py -q` — **360 passed**, no regressions in adjacent license/entitlement suite
- [x] `python3 -m ruff check --select=E,F,W tests/test_license_expires_at_scalar.py` — clean (no violations introduced in the new file or the edited hunks of `clawmetry/license.py` / `routes/entitlement.py`)
- [x] `python -m py_compile clawmetry/license.py routes/entitlement.py tests/test_license_expires_at_scalar.py` — clean

### Local operator verification checklist (I can't reach the running daemon or a browser from this environment)

- [ ] Copy `clawmetry/license.py`, `routes/entitlement.py`, and `tests/test_license_expires_at_scalar.py` into `~/.clawmetry/lib/pythonX.Y/site-packages/clawmetry/` and `.../site-packages/routes/`.
- [ ] Clear `__pycache__` under both directories.
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` to restart the daemon.
- [ ] `curl -s http://localhost:8900/api/license/expires-at | jq .` — expect `{"expires_at": null, "days_until_expiry": null, "has_license": false, "valid": false}` on an unlicensed install, or `{"expires_at": <epoch>, "days_until_expiry": <int>, "has_license": true, "valid": true}` if a Pro key is installed.
- [ ] `curl -s http://localhost:8900/api/license/status | jq '{exp, days_left}'` — the `exp` field must match `/api/license/expires-at`'s `expires_at` exactly (they share `current_license_info()`).
- [ ] `EPOCH=$(curl -s http://localhost:8900/api/license/expires-at | jq -r '.expires_at // empty')` then `curl -s "http://localhost:8900/api/license/is-expiring-at?epoch=$EPOCH" | jq .` — expect `is_expiring_at=true` on a valid Pro install; `expires_at` in the response must match.
- [ ] `curl -s "http://localhost:8900/api/license/is-expiring-at?epoch=tomorrow" | jq .` — expect `is_expiring_at=false`, `requested_epoch=null` (typo rejection).
- [ ] `curl -s "http://localhost:8900/api/license/is-expiring-at" | jq .` — expect `is_expiring_at=false`, `requested_epoch=null` (missing-param rejection).
- [ ] `curl -s "http://localhost:8900/api/license/is-expiring-at?epoch=1" | jq .` — expect `is_expiring_at=false` (wrong-epoch rejection).
- [ ] Decrypt the live cloud snapshot and browser-check the dashboard still loads (this PR touches shared license helpers but does not change any existing behaviour).

Marked draft — the local operator handles daemon verification, cloud-snapshot verification, release, and merge per FLYWHEEL.md.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JAkwz9vsAVTMEwHaD1RZTN)_