### PR TITLE
fix: surface externally_supervised gateway status in health endpoint

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -12775,6 +12775,8 @@ async function loadSystemHealth() {
         gwDot = '🟡'; gwLabel = 'Warning'; gwColor = '#f59e0b';
       } else if (gwStatus === 'healthy') {
         gwDot = '🟢'; gwLabel = 'Healthy'; gwColor = 'var(--text-success,#22c55e)';
+      } else if (gwStatus === 'externally_supervised') {
+        gwDot = '🟡'; gwLabel = 'Supervised pause'; gwColor = '#f59e0b';
       } else {
         gwDot = '⚫'; gwLabel = 'Not running'; gwColor = 'var(--text-muted)';
       }

--- a/routes/health.py
+++ b/routes/health.py
@@ -581,7 +581,7 @@ def compute_gateway_health(
           "uptime_seconds": int | null,
           "rss_mb": float | null,
           "cpu_pct": float | null,
-          "status": "healthy" | "warning" | "critical" | "not_running",
+          "status": "healthy" | "warning" | "critical" | "not_running" | "externally_supervised",
           "memory_threshold_mb": 900,
         }
     """
@@ -600,6 +600,8 @@ def compute_gateway_health(
         except Exception:
             pid = None
     if pid is None:
+        if os.environ.get("OPENCLAW_SUPERVISOR_MODE") == "external":
+            payload["status"] = "externally_supervised"
         return payload
 
     vitals = None

--- a/tests/test_obs_gap_openclaw_supervisor_liveness_4149.py
+++ b/tests/test_obs_gap_openclaw_supervisor_liveness_4149.py
@@ -1,0 +1,63 @@
+"""Tests for issue #4149 — OPENCLAW_SUPERVISOR_MODE=external not reflected in gateway health.
+
+Verifies that compute_gateway_health() returns status "externally_supervised"
+when the gateway PID is absent but OPENCLAW_SUPERVISOR_MODE=external is set,
+so the dashboard badge distinguishes a supervised pause from a crash.
+
+Fingerprint: hgap-1e190bef38 (used to dedupe — keep it in the body).
+"""
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+
+def _stub_dashboard():
+    mod = types.ModuleType("dashboard")
+    sys.modules.setdefault("dashboard", mod)
+    return mod
+
+
+def _get_compute_gateway_health():
+    _stub_dashboard()
+    import routes.health as health_mod
+    return health_mod.compute_gateway_health
+
+
+def test_externally_supervised_when_no_pid(monkeypatch):
+    """No gateway PID + OPENCLAW_SUPERVISOR_MODE=external → status 'externally_supervised'."""
+    monkeypatch.setenv("OPENCLAW_SUPERVISOR_MODE", "external")
+    compute = _get_compute_gateway_health()
+    result = compute(
+        pid_path="/nonexistent/gateway.pid",
+        _cmdline_pid=lambda: None,
+    )
+    assert result["status"] == "externally_supervised"
+    assert result["pid"] is None
+
+
+def test_not_running_when_no_pid_no_supervisor(monkeypatch):
+    """No gateway PID + no supervisor env var → status 'not_running' (unchanged)."""
+    monkeypatch.delenv("OPENCLAW_SUPERVISOR_MODE", raising=False)
+    compute = _get_compute_gateway_health()
+    result = compute(
+        pid_path="/nonexistent/gateway.pid",
+        _cmdline_pid=lambda: None,
+    )
+    assert result["status"] == "not_running"
+    assert result["pid"] is None
+
+
+def test_supervisor_env_ignored_when_gateway_running(monkeypatch):
+    """OPENCLAW_SUPERVISOR_MODE=external has no effect when the gateway is up."""
+    monkeypatch.setenv("OPENCLAW_SUPERVISOR_MODE", "external")
+    compute = _get_compute_gateway_health()
+    result = compute(
+        pid_path="/nonexistent/gateway.pid",
+        _cmdline_pid=lambda: 99999,
+        _psutil_vitals=lambda pid: (120, 200.0, 1.5),
+    )
+    assert result["status"] in ("healthy", "warning", "critical")
+    assert result["pid"] == 99999


### PR DESCRIPTION
Closes #4149

## Summary

- `routes/health.py`: after the `if pid is None` guard in `compute_gateway_health()`, check `OPENCLAW_SUPERVISOR_MODE=external` and return `status: "externally_supervised"` instead of `"not_running"` so the health endpoint can distinguish a supervised pause from a crash.
- `clawmetry/static/js/app.js`: add a `gwStatus === 'externally_supervised'` branch in the gateway badge renderer — shows 🟡 "Supervised pause" (amber) instead of ⚫ "Not running" (grey).
- `tests/test_obs_gap_openclaw_supervisor_liveness_4149.py` (new): 3 tests covering the supervised case, the normal no-pid case, and the no-effect-when-running case.

## Test plan

- `python3 -m pytest tests/test_obs_gap_openclaw_supervisor_liveness_4149.py -v` — all 3 tests pass
- `python3 -m py_compile routes/health.py` — syntax clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01JXfqjMDk8zbqRCTmGwTomD)_