### PR TITLE
feat(license): pro_installed_at + pro_install_age_days scalar helpers + endpoints

### DIFF
--- a/clawmetry/license.py
+++ b/clawmetry/license.py
@@ -1289,6 +1289,103 @@ def pro_installation_info() -> dict:
     }
 
 
+def pro_installed_at() -> int | None:
+    """Scalar view onto the ``installed_at`` field of the ``clawmetry-pro``
+    provisioning marker (``~/.clawmetry/pro_installed.json``) -- the epoch
+    timestamp the paid wheel was first laid down on this node -- for a
+    "pro installed: <date>" row that wants ONE integer rather than the
+    whole :func:`pro_installation_info` envelope.
+
+    Returns:
+      * ``None`` when there is nothing meaningful to surface: the marker
+        file is missing (wheel was never provisioned OR was provisioned by
+        a pre-marker version of ClawMetry), the marker exists but has no
+        ``installed_at`` key, or the value carried by the marker is
+        non-numeric / negative.
+      * A positive epoch integer otherwise -- the exact timestamp written
+        by :func:`_write_pro_marker` at provision time.
+
+    Deliberately independent of ``importlib.metadata`` -- an operator can
+    have the marker on disk (wheel was provisioned yesterday) even when
+    Python cannot currently import ``clawmetry-pro`` (wheel was pip-
+    uninstalled since). That disagreement is exactly what a paywall-
+    debugging tile wants to see, so this scalar answers "when was the
+    marker last written?" without collapsing to :func:`pro_installed`.
+
+    Pairs with :func:`pro_install_age_days` the way
+    :func:`license_issued_at` pairs with :func:`license_age_days`: this
+    getter surfaces the raw epoch for a debug row, that helper answers the
+    "how old" derived integer without the caller having to compute
+    ``(now - installed_at) // 86400`` themselves.
+
+    Never raises. Any exception under the hood degrades to ``None`` so a
+    UI tile bound to this helper never breaks on a partial install.
+    """
+    try:
+        marker = _read_pro_marker()
+    except Exception as exc:
+        logger.debug("license: pro_installed_at marker read failed: %s", exc)
+        return None
+    if not isinstance(marker, dict):
+        return None
+    installed_at = marker.get("installed_at")
+    if not isinstance(installed_at, (int, float)):
+        return None
+    if isinstance(installed_at, bool):
+        # ``bool`` is a subclass of ``int``; refuse it explicitly so a
+        # marker that somehow contains ``{"installed_at": true}`` collapses
+        # to ``None`` rather than surfacing as epoch 1.
+        return None
+    if installed_at <= 0:
+        return None
+    return int(installed_at)
+
+
+def pro_install_age_days() -> int | None:
+    """Scalar view onto how long ago the ``clawmetry-pro`` wheel was
+    provisioned on this node -- days since the ``installed_at`` field of
+    the provisioning marker -- for a support/audit tile that wants ONE
+    integer rather than computing ``(now - installed_at) // 86400`` at
+    every call site.
+
+    Returns:
+      * ``None`` when there is nothing meaningful to derive: no marker
+        file, a marker with no ``installed_at`` key, or a marker whose
+        ``installed_at`` value is non-numeric / non-positive.
+      * A non-negative integer number of days otherwise. Zero on the day
+        of provisioning; grows monotonically thereafter.
+
+    Days are floor-divided from seconds ``(now - installed_at) // 86400``,
+    matching how :func:`license_age_days` derives its counterpart from the
+    signed ``iat`` claim so the two scalars never disagree at the day
+    boundary. Clamped to ``max(0, ...)`` to guard against clock skew (an
+    ``installed_at`` in the future would otherwise render as a negative
+    age and break ``f"{age} days old"`` formatting).
+
+    Pairs with :func:`pro_installed_at` the way :func:`license_age_days`
+    pairs with :func:`license_issued_at`: raw epoch for the debug row,
+    derived integer for the display tile, both reading the same marker so
+    a UI binding both cannot catch them disagreeing on the same install.
+
+    Never raises. Any exception under the hood degrades to ``None`` so a
+    scheduled audit tile never crashes on a bad install.
+    """
+    import time as _t
+
+    try:
+        installed = pro_installed_at()
+    except Exception as exc:
+        logger.debug("license: pro_install_age_days underlying read failed: %s", exc)
+        return None
+    if not isinstance(installed, int):
+        return None
+    try:
+        age = int((_t.time() - installed) // 86400)
+    except Exception as exc:
+        logger.debug("license: pro_install_age_days arithmetic failed: %s", exc)
+        return None
+    return age if age >= 0 else 0
+
 
 def license_nodes() -> int | None:
     """Scalar view onto the installed license's ``nodes`` claim -- the paid

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -8497,6 +8497,179 @@ def api_license_pro_installation():
         return jsonify({"installed": False, "version": None, "marker": {}})
 
 
+def _pro_install_snapshot() -> dict:
+    """Shared helper: read once, derive the quartet the two ``installed_at``-
+    derived endpoints both need (``installed_at``, ``age_days``,
+    ``marker_present``, ``installed``). Lives in the handler layer -- not
+    in :mod:`clawmetry.license` -- because ``marker_present`` /
+    ``installed`` are install-state facts rather than marker-payload
+    facts, and both endpoints below need them together so a UI cannot
+    catch them disagreeing on the same install.
+
+    ``installed_at`` mirrors :func:`clawmetry.license.pro_installed_at` --
+    the raw epoch surfaced by the marker, unmodified. ``age_days`` mirrors
+    :func:`clawmetry.license.pro_install_age_days` -- floor-divided from
+    seconds, clamped to ``max(0, ...)`` so a clock-skewed
+    ``installed_at`` in the future never renders as a negative age.
+
+    ``marker_present`` is deliberately independent of ``installed``: an
+    operator can have the marker on disk (wheel was provisioned
+    yesterday) even when Python cannot currently import
+    ``clawmetry-pro`` (wheel was pip-uninstalled since), and the paywall-
+    debug tile that binds these endpoints wants to see that disagreement
+    rather than have it collapsed into a single boolean.
+
+    Never raises: any underlying failure collapses to
+    ``{installed_at: None, age_days: None, marker_present: False,
+    installed: False}`` so callers keep the "no marker" branch shape.
+    """
+    try:
+        from clawmetry import license as _lic
+
+        installed_at = _lic.pro_installed_at()
+        age = _lic.pro_install_age_days()
+        installed = _lic.pro_installed()
+    except Exception as exc:
+        logger.debug("_pro_install_snapshot: underlying read failed: %s", exc)
+        return {
+            "installed_at": None,
+            "age_days": None,
+            "marker_present": False,
+            "installed": False,
+        }
+    marker_present = installed_at is not None
+    return {
+        "installed_at": installed_at,
+        "age_days": age,
+        "marker_present": marker_present,
+        "installed": bool(installed),
+    }
+
+
+@bp_entitlement.route("/api/license/pro-installed-at")
+def api_license_pro_installed_at():
+    """``GET /api/license/pro-installed-at`` -- scalar view of the
+    ``installed_at`` field of the ``clawmetry-pro`` provisioning marker
+    (``~/.clawmetry/pro_installed.json``), for a "pro installed:
+    <date>" row that wants ONE integer rather than the whole
+    ``/api/license/pro-installation`` envelope.
+
+    Response shape (always HTTP 200)::
+
+        {
+          "installed_at": <int|null>,    # epoch seconds; None if no marker
+          "age_days": <int|null>,        # days since provisioning
+          "marker_present": <bool>,      # is the marker file readable?
+          "installed": <bool>            # can Python import clawmetry-pro right now?
+        }
+
+    ``installed_at`` mirrors :func:`clawmetry.license.pro_installed_at`:
+
+      * ``null`` when the marker is missing (wheel was never provisioned
+        OR was provisioned by a pre-marker version of ClawMetry), when
+        the marker exists but has no ``installed_at`` key, or when the
+        value carried by the marker is non-numeric / non-positive.
+      * A positive epoch integer otherwise, unmodified from what
+        :func:`clawmetry.license._write_pro_marker` wrote at provision
+        time.
+
+    Deliberately independent of ``installed``: an operator can have the
+    marker on disk yet Python cannot currently import ``clawmetry-pro``
+    (wheel was pip-uninstalled since), and that disagreement is exactly
+    what a paywall-debugging tile needs to see rather than collapsing
+    both facts into one boolean. The ``installed`` field on this
+    envelope surfaces the live ``importlib.metadata`` probe so a caller
+    binding a single endpoint gets both facts side-by-side.
+
+    Pairs with ``/api/license/pro-install-age-days`` -- this endpoint
+    surfaces the raw epoch for a debug row, that endpoint answers the
+    "how old" gate without the caller having to do the arithmetic. The
+    two endpoints share :func:`_pro_install_snapshot` so a UI binding
+    both sees a consistent snapshot.
+
+    Never 5xxs -- any underlying failure degrades to
+    ``{installed_at: null, age_days: null, marker_present: false,
+    installed: false}`` (the "no marker" branch shape), matching the
+    never-crash posture of the surrounding license endpoints.
+    """
+    try:
+        return jsonify(_pro_install_snapshot())
+    except Exception as exc:
+        logger.warning("api_license_pro_installed_at: error: %s", exc)
+        return jsonify(
+            {
+                "installed_at": None,
+                "age_days": None,
+                "marker_present": False,
+                "installed": False,
+            }
+        )
+
+
+@bp_entitlement.route("/api/license/pro-install-age-days")
+def api_license_pro_install_age_days():
+    """``GET /api/license/pro-install-age-days`` -- scalar view of how
+    long ago the ``clawmetry-pro`` wheel was provisioned (days since the
+    marker's ``installed_at``), for a support/audit tile that wants ONE
+    integer rather than computing ``(now - installed_at) // 86400`` at
+    the call site.
+
+    Response shape (always HTTP 200)::
+
+        {
+          "age_days": <int|null>,        # days since provisioning
+          "installed_at": <int|null>,    # epoch seconds
+          "marker_present": <bool>,      # is the marker file readable?
+          "installed": <bool>            # can Python import clawmetry-pro right now?
+        }
+
+    ``age_days`` mirrors :func:`clawmetry.license.pro_install_age_days`:
+
+      * ``null`` when the marker is missing, has no ``installed_at``
+        key, or carries a non-numeric / non-positive value.
+      * A non-negative integer otherwise -- zero on the day of
+        provisioning, growing monotonically thereafter. Clamped to
+        ``max(0, ...)`` so a clock-skewed ``installed_at`` in the future
+        never renders as a negative age.
+
+    Days are floor-divided from seconds ``(now - installed_at) // 86400``,
+    matching how ``/api/license/age-days`` derives its counterpart from
+    the signed ``iat`` claim so the two scalars never disagree at the
+    day boundary.
+
+    Deliberately independent of ``installed`` (see
+    ``/api/license/pro-installed-at``): a marker on disk with the wheel
+    since uninstalled still surfaces its real ``age_days``. The
+    ``installed`` field independently carries the live-importability
+    signal for callers that DO want to hide the row on a broken
+    install.
+
+    Never 5xxs -- any underlying failure degrades to
+    ``{age_days: null, installed_at: null, marker_present: false,
+    installed: false}``.
+    """
+    try:
+        snap = _pro_install_snapshot()
+        return jsonify(
+            {
+                "age_days": snap["age_days"],
+                "installed_at": snap["installed_at"],
+                "marker_present": snap["marker_present"],
+                "installed": snap["installed"],
+            }
+        )
+    except Exception as exc:
+        logger.warning("api_license_pro_install_age_days: error: %s", exc)
+        return jsonify(
+            {
+                "age_days": None,
+                "installed_at": None,
+                "marker_present": False,
+                "installed": False,
+            }
+        )
+
+
 def _license_nodes_snapshot() -> dict:
     """Shared helper: read once, derive the trio the two node-limit endpoints
     both need (``nodes``, ``has_license``, ``valid``). Lives in the handler

--- a/tests/test_license_pro_install_age_scalar.py
+++ b/tests/test_license_pro_install_age_scalar.py
@@ -1,0 +1,429 @@
+"""Tests for the ``pro_installed_at()`` / ``pro_install_age_days()``
+scalar helpers on ``clawmetry.license`` and their paired
+``/api/license/pro-installed-at`` + ``/api/license/pro-install-age-days``
+HTTP endpoints.
+
+These scalars view onto the ``installed_at`` field of the
+``clawmetry-pro`` provisioning marker (``~/.clawmetry/pro_installed.json``),
+mirroring the ``license_issued_at`` / ``license_age_days`` pattern that
+already exists for the signed-license ``iat`` claim. Same never-raise
+posture, same clock-skew clamp, same "share a snapshot across the two
+endpoints so a UI cannot catch them disagreeing" invariant.
+
+The env is hermetic: the marker path is monkeypatched into ``tmp_path``
+and ``_pro_installed_version`` is stubbed so tests never touch the real
+site-packages.
+"""
+from __future__ import annotations
+
+import json
+import os
+import time
+from types import SimpleNamespace
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def env(monkeypatch, tmp_path):
+    """Isolated license env mirroring
+    ``tests/test_license_pro_installation.py``: tmp marker path,
+    controllable pro-version reader, Flask app with the entitlement
+    blueprint mounted."""
+    import clawmetry.license as _lic
+
+    marker_path = str(tmp_path / "pro_installed.json")
+    monkeypatch.setattr(_lic, "_PRO_MARKER_PATH", marker_path)
+
+    state = {"version": None}
+    monkeypatch.setattr(_lic, "_pro_installed_version", lambda: state["version"])
+
+    from routes.entitlement import bp_entitlement
+
+    flask_app = Flask(__name__)
+    flask_app.register_blueprint(bp_entitlement)
+    flask_app.config["TESTING"] = True
+
+    return SimpleNamespace(
+        app=flask_app,
+        lic=_lic,
+        marker_path=marker_path,
+        state=state,
+    )
+
+
+def _write_marker(env, payload):
+    os.makedirs(os.path.dirname(env.marker_path), exist_ok=True)
+    with open(env.marker_path, "w", encoding="utf-8") as fh:
+        json.dump(payload, fh)
+
+
+# ── clawmetry.license.pro_installed_at() ─────────────────────────────────────
+
+
+def test_pro_installed_at_none_when_no_marker(env):
+    """No marker file on disk -> None (nothing to surface)."""
+    assert env.lic.pro_installed_at() is None
+
+
+def test_pro_installed_at_returns_epoch_when_marker_present(env):
+    now = int(time.time())
+    _write_marker(env, {"installed_at": now - 3600, "version": "0.3.4"})
+    got = env.lic.pro_installed_at()
+    assert isinstance(got, int)
+    assert got == now - 3600
+
+
+def test_pro_installed_at_accepts_float_installed_at(env):
+    """Some markers wrote ``installed_at`` as a float; must coerce to int
+    rather than collapse to None."""
+    now = time.time()
+    _write_marker(env, {"installed_at": now - 60.0, "version": "0.3.4"})
+    got = env.lic.pro_installed_at()
+    assert isinstance(got, int)
+    assert got == int(now - 60.0)
+
+
+def test_pro_installed_at_independent_of_live_import(env):
+    """Marker on disk but ``clawmetry-pro`` not importable -> still returns
+    the epoch. That disagreement (marker present, wheel missing) is
+    exactly what a paywall-debugging tile wants to surface."""
+    _write_marker(env, {"installed_at": 1_700_000_000, "version": "0.3.4"})
+    # state["version"] stays None -> pro_installed() is False.
+    assert env.lic.pro_installed() is False
+    assert env.lic.pro_installed_at() == 1_700_000_000
+
+
+def test_pro_installed_at_missing_installed_at_key(env):
+    """Marker exists but ``installed_at`` key absent -> None."""
+    _write_marker(env, {"version": "0.3.4", "source": "test"})
+    assert env.lic.pro_installed_at() is None
+
+
+def test_pro_installed_at_non_numeric_installed_at(env):
+    """``installed_at`` is a string -> None (never raises)."""
+    _write_marker(env, {"installed_at": "yesterday", "version": "0.3.4"})
+    assert env.lic.pro_installed_at() is None
+
+
+def test_pro_installed_at_bool_installed_at_rejected(env):
+    """``bool`` is an ``int`` subclass -- explicitly refuse it so a marker
+    that somehow contains ``{"installed_at": true}`` collapses to None
+    rather than surfacing as epoch 1."""
+    _write_marker(env, {"installed_at": True, "version": "0.3.4"})
+    assert env.lic.pro_installed_at() is None
+
+
+def test_pro_installed_at_zero_and_negative_rejected(env):
+    """Non-positive epochs are meaningless -> None."""
+    _write_marker(env, {"installed_at": 0, "version": "0.3.4"})
+    assert env.lic.pro_installed_at() is None
+    _write_marker(env, {"installed_at": -1, "version": "0.3.4"})
+    assert env.lic.pro_installed_at() is None
+
+
+def test_pro_installed_at_corrupt_marker_json(env):
+    """Marker file is not JSON -> None (via _read_pro_marker's fallback)."""
+    os.makedirs(os.path.dirname(env.marker_path), exist_ok=True)
+    with open(env.marker_path, "w", encoding="utf-8") as fh:
+        fh.write("{not valid json")
+    assert env.lic.pro_installed_at() is None
+
+
+def test_pro_installed_at_marker_is_list_not_dict(env):
+    """_read_pro_marker returns {} for non-dict JSON -> scalar returns None."""
+    os.makedirs(os.path.dirname(env.marker_path), exist_ok=True)
+    with open(env.marker_path, "w", encoding="utf-8") as fh:
+        json.dump(["not", "a", "dict"], fh)
+    assert env.lic.pro_installed_at() is None
+
+
+def test_pro_installed_at_never_raises(env, monkeypatch):
+    """Even if ``_read_pro_marker`` blows up, the scalar must not
+    propagate -- degrade to None."""
+    def _boom():
+        raise RuntimeError("simulated corrupt install")
+
+    monkeypatch.setattr(env.lic, "_read_pro_marker", _boom)
+    assert env.lic.pro_installed_at() is None
+
+
+# ── clawmetry.license.pro_install_age_days() ─────────────────────────────────
+
+
+def test_pro_install_age_days_none_when_no_marker(env):
+    assert env.lic.pro_install_age_days() is None
+
+
+def test_pro_install_age_days_zero_on_day_of_install(env):
+    """Just-provisioned wheel -> 0 days old."""
+    _write_marker(env, {"installed_at": int(time.time()), "version": "0.3.4"})
+    assert env.lic.pro_install_age_days() == 0
+
+
+def test_pro_install_age_days_positive_after_days(env):
+    """Wheel provisioned N days ago -> ~N days old (floor-divided from
+    seconds)."""
+    _write_marker(
+        env,
+        {"installed_at": int(time.time()) - 30 * 86400, "version": "0.3.4"},
+    )
+    age = env.lic.pro_install_age_days()
+    assert isinstance(age, int)
+    # Allow +/- 1 for clock jitter across the day boundary.
+    assert 29 <= age <= 31
+
+
+def test_pro_install_age_days_clock_skew_installed_at_in_future_clamps_to_zero(env):
+    """A clock-skewed ``installed_at`` in the future must not render as a
+    negative age -- clamped to 0 so callers can safely render
+    ``f"{age} days old"``."""
+    _write_marker(
+        env,
+        {"installed_at": int(time.time()) + 7 * 86400, "version": "0.3.4"},
+    )
+    assert env.lic.pro_install_age_days() == 0
+
+
+def test_pro_install_age_days_missing_installed_at(env):
+    _write_marker(env, {"version": "0.3.4"})
+    assert env.lic.pro_install_age_days() is None
+
+
+def test_pro_install_age_days_non_numeric_installed_at(env):
+    _write_marker(env, {"installed_at": "tomorrow", "version": "0.3.4"})
+    assert env.lic.pro_install_age_days() is None
+
+
+def test_pro_install_age_days_independent_of_live_import(env):
+    """Marker present but wheel not importable -> still returns age. Age
+    tracks the marker, not live importability -- ``installed`` is the
+    separate signal for that."""
+    _write_marker(
+        env,
+        {"installed_at": int(time.time()) - 5 * 86400, "version": "0.3.4"},
+    )
+    assert env.lic.pro_installed() is False
+    age = env.lic.pro_install_age_days()
+    assert isinstance(age, int)
+    assert 4 <= age <= 6
+
+
+def test_pro_install_age_days_never_raises(env, monkeypatch):
+    def _boom():
+        raise RuntimeError("simulated corrupt install")
+
+    monkeypatch.setattr(env.lic, "pro_installed_at", _boom)
+    assert env.lic.pro_install_age_days() is None
+
+
+# ── GET /api/license/pro-installed-at ────────────────────────────────────────
+
+
+def test_endpoint_pro_installed_at_no_marker(env):
+    with env.app.test_client() as c:
+        resp = c.get("/api/license/pro-installed-at")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data == {
+        "installed_at": None,
+        "age_days": None,
+        "marker_present": False,
+        "installed": False,
+    }
+
+
+def test_endpoint_pro_installed_at_healthy(env):
+    """Marker on disk + wheel importable -> full quartet populated."""
+    now = int(time.time())
+    _write_marker(env, {"installed_at": now - 3 * 86400, "version": "0.3.4"})
+    env.state["version"] = "0.3.4"
+    with env.app.test_client() as c:
+        resp = c.get("/api/license/pro-installed-at")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert isinstance(data["installed_at"], int)
+    assert isinstance(data["age_days"], int)
+    assert 2 <= data["age_days"] <= 4
+    assert data["marker_present"] is True
+    assert data["installed"] is True
+
+
+def test_endpoint_pro_installed_at_marker_present_but_wheel_missing(env):
+    """The paywall-debug case: marker on disk but pip-uninstall wiped
+    the wheel. Both facts must surface -- marker_present=true,
+    installed=false -- so the UI can render the disagreement."""
+    _write_marker(env, {"installed_at": 1_700_000_000, "version": "0.3.4"})
+    # state["version"] stays None -> pro_installed() is False.
+    with env.app.test_client() as c:
+        resp = c.get("/api/license/pro-installed-at")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["installed_at"] == 1_700_000_000
+    assert data["marker_present"] is True
+    assert data["installed"] is False
+
+
+def test_endpoint_pro_installed_at_wheel_present_but_no_marker(env):
+    """The opposite disagreement: pre-marker install (or marker deleted)
+    yet the wheel is importable. installed=true but marker_present=false
+    and the age scalars collapse to None because there's nothing to
+    date."""
+    env.state["version"] = "0.3.4"
+    with env.app.test_client() as c:
+        resp = c.get("/api/license/pro-installed-at")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["installed_at"] is None
+    assert data["age_days"] is None
+    assert data["marker_present"] is False
+    assert data["installed"] is True
+
+
+def test_endpoint_pro_installed_at_corrupt_marker(env):
+    os.makedirs(os.path.dirname(env.marker_path), exist_ok=True)
+    with open(env.marker_path, "w", encoding="utf-8") as fh:
+        fh.write("{not json")
+    with env.app.test_client() as c:
+        resp = c.get("/api/license/pro-installed-at")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data == {
+        "installed_at": None,
+        "age_days": None,
+        "marker_present": False,
+        "installed": False,
+    }
+
+
+def test_endpoint_pro_installed_at_never_5xxs(env, monkeypatch):
+    """Even if the shared snapshot blows up mid-request, the endpoint
+    must still return HTTP 200 with the no-marker shape."""
+    from routes import entitlement as _routes
+
+    monkeypatch.setattr(
+        _routes,
+        "_pro_install_snapshot",
+        lambda: (_ for _ in ()).throw(RuntimeError("simulated blowup")),
+    )
+    with env.app.test_client() as c:
+        resp = c.get("/api/license/pro-installed-at")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data == {
+        "installed_at": None,
+        "age_days": None,
+        "marker_present": False,
+        "installed": False,
+    }
+
+
+# ── GET /api/license/pro-install-age-days ────────────────────────────────────
+
+
+def test_endpoint_pro_install_age_days_no_marker(env):
+    with env.app.test_client() as c:
+        resp = c.get("/api/license/pro-install-age-days")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data == {
+        "age_days": None,
+        "installed_at": None,
+        "marker_present": False,
+        "installed": False,
+    }
+
+
+def test_endpoint_pro_install_age_days_active(env):
+    now = int(time.time())
+    _write_marker(env, {"installed_at": now - 14 * 86400, "version": "0.3.4"})
+    env.state["version"] = "0.3.4"
+    with env.app.test_client() as c:
+        resp = c.get("/api/license/pro-install-age-days")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert isinstance(data["age_days"], int)
+    assert 13 <= data["age_days"] <= 15
+    assert isinstance(data["installed_at"], int)
+    assert data["marker_present"] is True
+    assert data["installed"] is True
+
+
+def test_endpoint_pro_install_age_days_clock_skew_clamps_to_zero(env):
+    _write_marker(
+        env,
+        {"installed_at": int(time.time()) + 30 * 86400, "version": "0.3.4"},
+    )
+    with env.app.test_client() as c:
+        resp = c.get("/api/license/pro-install-age-days")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["age_days"] == 0
+    assert data["marker_present"] is True
+
+
+def test_endpoint_pro_install_age_days_missing_installed_at(env):
+    _write_marker(env, {"version": "0.3.4"})
+    with env.app.test_client() as c:
+        resp = c.get("/api/license/pro-install-age-days")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["age_days"] is None
+    assert data["installed_at"] is None
+    # marker_present hangs off installed_at, so it collapses to False
+    # here -- consistent with the scalar's "nothing to date" branch.
+    assert data["marker_present"] is False
+
+
+def test_endpoint_pro_install_age_days_never_5xxs(env, monkeypatch):
+    from routes import entitlement as _routes
+
+    monkeypatch.setattr(
+        _routes,
+        "_pro_install_snapshot",
+        lambda: (_ for _ in ()).throw(RuntimeError("simulated blowup")),
+    )
+    with env.app.test_client() as c:
+        resp = c.get("/api/license/pro-install-age-days")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data == {
+        "age_days": None,
+        "installed_at": None,
+        "marker_present": False,
+        "installed": False,
+    }
+
+
+# ── consistency: both endpoints see the same snapshot ────────────────────────
+
+
+def test_both_endpoints_agree_on_snapshot(env):
+    """Both endpoints share :func:`_pro_install_snapshot` -- they must
+    surface identical ``installed_at`` / ``age_days`` / ``marker_present``
+    / ``installed`` values for the same install."""
+    _write_marker(
+        env,
+        {"installed_at": int(time.time()) - 42 * 86400, "version": "0.3.4"},
+    )
+    env.state["version"] = "0.3.4"
+    with env.app.test_client() as c:
+        a = c.get("/api/license/pro-installed-at").get_json()
+        b = c.get("/api/license/pro-install-age-days").get_json()
+    for key in ("installed_at", "age_days", "marker_present", "installed"):
+        assert a[key] == b[key], f"mismatch on {key}: {a[key]!r} vs {b[key]!r}"
+
+
+def test_both_endpoints_agree_on_disagreement_shape(env):
+    """The marker-present-but-wheel-missing case: both endpoints must
+    surface installed=False in lockstep so a UI binding both cannot
+    catch them disagreeing."""
+    _write_marker(env, {"installed_at": 1_700_000_000, "version": "0.3.4"})
+    with env.app.test_client() as c:
+        a = c.get("/api/license/pro-installed-at").get_json()
+        b = c.get("/api/license/pro-install-age-days").get_json()
+    for key in ("installed_at", "age_days", "marker_present", "installed"):
+        assert a[key] == b[key], f"mismatch on {key}: {a[key]!r} vs {b[key]!r}"
+    assert a["marker_present"] is True
+    assert a["installed"] is False


### PR DESCRIPTION
## Summary

- Adds `clawmetry.license.pro_installed_at() -> int | None`, a scalar view onto the `installed_at` field of the `clawmetry-pro` provisioning marker (`~/.clawmetry/pro_installed.json`), for a "pro installed: `<date>`" row that wants ONE integer rather than the whole `/api/license/pro-installation` envelope. Follows the same scalar-plus-derived pattern already used for `license_issued_at()` / `license_age_days()`, `license_tier`, `license_nodes`, `license_subject`, etc.
- Adds `clawmetry.license.pro_install_age_days() -> int | None`, the derived integer twin — days floor-divided from `(now - installed_at) // 86400`, matching how `license_age_days` derives its counterpart from `(now - iat)` so the two scalars never disagree at the day boundary. Clamped to `max(0, ...)` to guard against clock skew.
- Adds `GET /api/license/pro-installed-at` and `GET /api/license/pro-install-age-days` on `bp_entitlement`. Both share a `_pro_install_snapshot()` helper so a UI binding both in the same tile can never catch them disagreeing on `marker_present` / `installed` for the same install. Matches the shape pattern of `/api/license/issued-at` / `/api/license/age-days`.

Posture notes (mirrors `pro_installation_info`):
- **Independent of live importability**: the scalars read the marker, not `importlib.metadata`. An operator can have the marker on disk (wheel was provisioned yesterday) even when Python cannot currently import `clawmetry-pro` (wheel was pip-uninstalled since). That disagreement is exactly what a paywall-debug tile needs to see, so `installed` (live probe) and `marker_present`/`installed_at`/`age_days` (marker-derived) are surfaced side-by-side rather than collapsed into one boolean.
- **Non-numeric / non-positive `installed_at` collapses to `null`**: string, list, bool (explicitly refused despite being an `int` subclass), zero, and negatives all collapse so a corrupt marker never surfaces a bogus epoch. HTTP 200 either way — the bad-data signal is `installed_at: null`, not a 4xx.
- **Corrupt marker JSON collapses to `null`**: `_read_pro_marker()` already returns `{}` on unreadable / non-JSON / non-dict marker files, and the scalars fall through to `null` from there.
- **Clock-skew clamp on the derived age**: an `installed_at` in the future (bad clock, wrong-TZ marker write) renders as `0` days old, never negative, so `f"{age} days old"` formatting stays safe.

Cross-endpoint consistency covered by two tests: both endpoints share `_pro_install_snapshot()`, so `installed_at` / `age_days` / `marker_present` / `installed` are always identical between them for the same install — matches the invariant already covered between `/api/license/issued-at` and `/api/license/age-days`, and between `/api/license/pubkey-fingerprint` and `/api/license/is-pubkey-fingerprint`.

Zero behaviour change: purely additive, read-only. No new gate is enforced, no tier logic is altered.

## Test plan

- [x] `python3 -m pytest tests/test_license_pro_install_age_scalar.py -q` — **32 passed**
- [x] `python3 -m pytest tests/test_license_pro_installation.py tests/test_license_issued_scalar.py tests/test_license_days_until_expiry.py tests/test_license.py tests/test_license_api.py tests/test_entitlement_api.py tests/test_entitlement_api_fallback_shape.py -q` — **200 passed**, no regressions in adjacent license/entitlement suite
- [x] `python3 -m ruff check --select=E,F,W tests/test_license_pro_install_age_scalar.py` — clean (no violations introduced in the new file or the edited hunks of `clawmetry/license.py` / `routes/entitlement.py`)
- [x] `python3 -m py_compile clawmetry/license.py routes/entitlement.py tests/test_license_pro_install_age_scalar.py` — clean

### Local operator verification checklist (I can't reach the running daemon or a browser from this environment)

- [ ] Copy `clawmetry/license.py`, `routes/entitlement.py`, and `tests/test_license_pro_install_age_scalar.py` into `~/.clawmetry/lib/pythonX.Y/site-packages/clawmetry/` and `.../site-packages/routes/`.
- [ ] Clear `__pycache__` under both directories.
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` to restart the daemon.
- [ ] `curl -s http://localhost:8900/api/license/pro-installed-at | jq .` — expect `{"installed_at": null, "age_days": null, "marker_present": false, "installed": false}` on a Pro-not-provisioned install, or `{"installed_at": <epoch>, "age_days": <n>, "marker_present": true, "installed": true}` if the paid wheel has been installed on this node.
- [ ] `curl -s http://localhost:8900/api/license/pro-installation | jq '.marker.installed_at'` — the value must match `/api/license/pro-installed-at`'s `installed_at` exactly (they read the same marker).
- [ ] `curl -s http://localhost:8900/api/license/pro-install-age-days | jq .` — expect `age_days >= 0` on a Pro-provisioned node; must match `/api/license/pro-installed-at`'s `age_days` (they share `_pro_install_snapshot()`).
- [ ] If you can arrange a marker-present-but-wheel-missing state (e.g. `pip uninstall clawmetry-pro` after provisioning): `/api/license/pro-installed-at` should surface `marker_present: true, installed: false, installed_at: <epoch>` — the paywall-debug disagreement is visible on one endpoint.
- [ ] Decrypt the live cloud snapshot and browser-check the dashboard still loads (this PR touches shared license helpers but does not change any existing behaviour).

Marked draft — the local operator handles daemon verification, cloud-snapshot verification, release, and merge per FLYWHEEL.md.

---
_Generated by [Claude Code](https://claude.ai/code/session_01J5jMoqUN9atVAsjAz2eqUB)_