### PR TITLE
feat(license): days_until_expiry_at(epoch) scalar + endpoint

### DIFF
--- a/clawmetry/license.py
+++ b/clawmetry/license.py
@@ -1164,6 +1164,81 @@ def is_expiring_at(epoch: int) -> bool:
     return int(exp) == wanted
 
 
+def days_until_expiry_at(epoch: int) -> int | None:
+    """Scalar view of "how many days from ``epoch`` until the installed
+    license's ``exp`` claim?" for a perspective-epoch audit tile that
+    wants to answer "was the license in the renewal window on <date>?"
+    without the caller having to compute ``(exp - epoch) // 86400`` at
+    every call site.
+
+    Returns:
+      * ``None`` when there is nothing meaningful to compute against: no
+        license file on disk, an invalid signature (the payload can't be
+        trusted -- an attacker could stuff any ``exp`` into an unsigned
+        body), a signed payload whose ``exp`` claim is absent
+        (perpetual license -- nothing to count down to), OR a non-numeric
+        / bool ``epoch`` argument.
+      * A signed integer number of days otherwise. Zero when ``epoch``
+        falls on the day of expiry; negative when ``epoch`` is after
+        ``exp`` (support scenario: "how many days past expiry was
+        <date>?"); positive when ``epoch`` is before ``exp``. A caller
+        distinguishes "expires that day" from "expired 3 days before
+        then" by sign without a second call to
+        :func:`current_license_info`.
+
+    Days are floor-divided from seconds ``(exp - epoch) // 86400``,
+    matching how :func:`days_until_expiry` derives its "now" counterpart
+    from the same claim so the two scalars never disagree at the day
+    boundary when ``epoch`` equals the current time.
+
+    ``epoch`` is coerced through ``int()``; ``bool`` is explicitly
+    refused despite being an ``int`` subclass so a caller that passes
+    ``True`` / ``False`` gets ``None`` rather than a spurious "days
+    until epoch 1" number. A non-numeric value collapses to ``None`` so
+    a caller cannot silently miscount on a typo.
+
+    Deliberately lenient on expiry, mirroring :func:`days_until_expiry`:
+    an expired-but-signature-valid key still carries a meaningful ``exp``
+    (support scenario: "when did this lapsed key expire, evaluated as
+    of last Friday?") and callers would otherwise have to fall back to
+    ``current_license_info``. The :func:`is_expired` /
+    :func:`is_expiring_at` helpers independently carry the "past-expiry"
+    / "exact-match" signals for callers that DO want to hide the row on
+    lapsed keys.
+
+    Pairs with :func:`license_expires_at` the way
+    :func:`days_until_expiry` pairs with :func:`license_expires_at`:
+    both derive from the same ``exp`` claim so they cannot disagree at
+    the day boundary. The perspective-epoch flavour lets a scheduled
+    audit tile answer "would we have warned yesterday? last week?"
+    without having to snapshot the license state at those times.
+
+    Never raises. Any exception under the hood degrades to ``None`` so a
+    scheduled audit job never crashes on a bad install.
+    """
+    if isinstance(epoch, bool):
+        # ``bool`` is a subclass of ``int``; refuse it explicitly so a
+        # caller that passes ``True`` doesn't silently ask "days until
+        # epoch 1?" and get a very negative number back.
+        return None
+    try:
+        wanted = int(epoch)
+    except (TypeError, ValueError):
+        return None
+    try:
+        exp = license_expires_at()
+    except Exception as exc:
+        logger.debug("license: days_until_expiry_at underlying read failed: %s", exc)
+        return None
+    if not isinstance(exp, int):
+        return None
+    try:
+        return (exp - wanted) // 86400
+    except Exception as exc:
+        logger.debug("license: days_until_expiry_at arithmetic failed: %s", exc)
+        return None
+
+
 def license_tier() -> str | None:
     """Scalar view onto the installed license's ``tier`` claim -- for a
     paywall tile / tier badge that wants ONE string rather than the whole

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -9674,6 +9674,104 @@ def api_license_is_expiring_at():
     )
 
 
+@bp_entitlement.route("/api/license/days-until-expiry-at")
+def api_license_days_until_expiry_at():
+    """``GET /api/license/days-until-expiry-at?epoch=<int>`` -- scalar
+    countdown evaluated at an operator-supplied perspective epoch, for a
+    scheduled-audit / retrospective tile that wants to answer "how many
+    days until (or past) expiry was <date>?" without the caller having
+    to compute ``(exp - epoch) // 86400`` at the call site.
+
+    Response shape (always HTTP 200)::
+
+        {
+          "days_left": <int|null>,           # signed days from epoch to exp
+          "requested_epoch": <int|null>,     # int-coerced input, or null on typo
+          "expires_at": <int|null>,          # current on-disk exp
+          "has_license": <bool>,             # is a license file installed at all?
+          "valid": <bool>                    # signature-valid AND not expired
+        }
+
+    ``days_left`` mirrors :func:`clawmetry.license.days_until_expiry_at`:
+
+      * ``null`` when there is no license file, on the invalid-signature
+        branch (payload cannot be trusted -- an attacker could stuff any
+        ``exp`` into an unsigned body), on the perpetual-license branch
+        (no ``exp`` to count against), OR when ``epoch`` doesn't parse
+        as an integer.
+      * A signed integer number of days otherwise. Zero when ``epoch``
+        falls on the day of expiry; negative when ``epoch`` is after
+        ``exp`` (support scenario: "how many days past expiry was
+        <date>?"); positive when ``epoch`` is before ``exp``.
+
+    Deliberately lenient on expiry, mirroring
+    ``/api/license/days-until-expiry`` and ``/api/license/expires-at``: a
+    signed-but-lapsed key still surfaces its real ``days_left`` (with a
+    negative sign when ``epoch`` is after ``exp``) so a support/audit
+    tile can render "would have been expired 12 days ago as of last
+    Friday" without special-casing the expired branch. The ``valid``
+    field independently carries the "signature-valid AND not expired"
+    signal for callers that DO want to hide the row on lapsed keys.
+
+    Query parameter:
+
+      * ``epoch`` -- required. Unix epoch seconds as an integer. A
+        missing / non-integer value collapses to ``days_left=null`` with
+        ``requested_epoch=null`` so a caller cannot silently miscount on
+        a typo. HTTP status is 200 either way -- the "bad input" signal
+        is the ``null`` result, not a 4xx, matching the never-crash
+        posture of the surrounding license endpoints.
+
+    Pairs with ``/api/license/is-expiring-at`` -- both share the
+    perspective-epoch input pattern and the
+    :func:`_license_expires_snapshot` reader, so a UI binding both
+    endpoints for the same install cannot catch them disagreeing on
+    ``expires_at`` / ``has_license`` / ``valid``. Together they let a
+    dashboard render "on <date>, the license would have been N days
+    from expiry -- an exact match against a specific ``exp`` value?"
+    from two orthogonal one-shot GETs.
+
+    Never 5xxs -- any underlying failure degrades to
+    ``{days_left: null, requested_epoch: null, expires_at: null,
+    has_license: false, valid: false}`` (the OSS-free branch shape).
+    """
+    raw = request.args.get("epoch", "")
+    try:
+        requested = int(str(raw).strip())
+    except (TypeError, ValueError):
+        requested = None
+    try:
+        snap = _license_expires_snapshot()
+    except Exception as exc:
+        logger.warning("api_license_days_until_expiry_at: snapshot error: %s", exc)
+        snap = {
+            "expires_at": None,
+            "days_until_expiry": None,
+            "has_license": False,
+            "valid": False,
+        }
+    days_left: int | None
+    if requested is None:
+        days_left = None
+    else:
+        try:
+            from clawmetry import license as _lic
+
+            days_left = _lic.days_until_expiry_at(requested)
+        except Exception as exc:
+            logger.warning("api_license_days_until_expiry_at: derive error: %s", exc)
+            days_left = None
+    return jsonify(
+        {
+            "days_left": days_left,
+            "requested_epoch": requested,
+            "expires_at": snap["expires_at"],
+            "has_license": snap["has_license"],
+            "valid": snap["valid"],
+        }
+    )
+
+
 @bp_entitlement.route("/api/paywall/event", methods=["POST"])
 def api_paywall_event():
     body: dict = {}

--- a/tests/test_license_days_until_expiry_at.py
+++ b/tests/test_license_days_until_expiry_at.py
@@ -1,0 +1,440 @@
+"""Tests for the ``days_until_expiry_at(epoch)`` scalar helper on
+``clawmetry.license`` and its paired ``/api/license/days-until-expiry-at``
+HTTP endpoint.
+
+The perspective-epoch flavour of the ``days_until_expiry`` scalar. Both
+derive from the same signed ``exp`` claim so they cannot disagree at the
+day boundary when the perspective epoch equals "now"; on any other
+epoch this helper answers "how many days from ``epoch`` until (or past)
+expiry?" without the caller having to snapshot the license state at
+that time or do the ``(exp - epoch) // 86400`` arithmetic themselves.
+
+Hermetic: each test mints tokens with its own ephemeral keypair and
+monkeypatches the module's embedded public key + LICENSE_PATH, mirroring
+``tests/test_license_days_until_expiry.py`` so nothing depends on the
+real production signing key or on real filesystem state.
+"""
+from __future__ import annotations
+
+import time
+from types import SimpleNamespace
+
+import pytest
+from flask import Flask
+
+
+# ── shared helpers (mirror test_license_days_until_expiry.py) ────────────────
+
+
+def _keypair():
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+    priv = Ed25519PrivateKey.generate()
+    pub_pem = priv.public_key().public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    return priv, pub_pem
+
+
+def _payload(tier="pro", nodes=3, exp_delta=365 * 86400, drop_exp=False):
+    now = int(time.time())
+    p = {
+        "sub": "acct_test",
+        "tier": tier,
+        "nodes": nodes,
+        "iat": now,
+        "exp": now + exp_delta,
+        "features": ["runtimes"],
+    }
+    if drop_exp:
+        p.pop("exp", None)
+    return p
+
+
+@pytest.fixture
+def app(monkeypatch, tmp_path):
+    import clawmetry.license as _lic
+
+    priv, pub_pem = _keypair()
+    monkeypatch.setattr(_lic, "_PUBLIC_KEY_PEM", pub_pem)
+    license_path = str(tmp_path / "license.key")
+    monkeypatch.setattr(_lic, "LICENSE_PATH", license_path)
+    monkeypatch.delenv("CLAWMETRY_LICENSE_SERVER", raising=False)
+    monkeypatch.delenv("CLAWMETRY_INGEST_URL", raising=False)
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("CLAWMETRY_OFFLINE", "1")
+
+    from routes.entitlement import bp_entitlement
+
+    flask_app = Flask(__name__)
+    flask_app.register_blueprint(bp_entitlement)
+    flask_app.config["TESTING"] = True
+
+    return SimpleNamespace(
+        app=flask_app,
+        lic=_lic,
+        priv=priv,
+        license_path=license_path,
+    )
+
+
+def _write_key_direct(app, exp_delta):
+    """Bypass activate() (which refuses expired tokens) and write a token
+    directly to the license file. Simulates a license that expired AFTER
+    it was installed."""
+    import os
+
+    tok = app.lic._encode_token(_payload(exp_delta=exp_delta), app.priv)
+    os.makedirs(os.path.dirname(app.license_path), exist_ok=True)
+    with open(app.license_path, "w", encoding="utf-8") as fh:
+        fh.write(tok)
+
+
+# ── clawmetry.license.days_until_expiry_at() ─────────────────────────────────
+
+
+def test_days_until_expiry_at_no_license(app):
+    """No license file on disk -> None (nothing to count down against)."""
+    assert app.lic.days_until_expiry_at(int(time.time())) is None
+
+
+def test_days_until_expiry_at_now_matches_days_until_expiry(app):
+    """When ``epoch`` equals "now", the perspective-epoch scalar must
+    agree with :func:`days_until_expiry` at the day boundary (+/- 1 for
+    the fractional-second drift between the two calls: the base scalar
+    reads ``time.time()`` with sub-second precision inside
+    ``current_license_info``, while the caller here passes an
+    ``int(time.time())`` that already truncated the fraction)."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    now = int(time.time())
+    at_now = app.lic.days_until_expiry_at(now)
+    scalar_now = app.lic.days_until_expiry()
+    assert isinstance(at_now, int)
+    assert isinstance(scalar_now, int)
+    assert abs(at_now - scalar_now) <= 1
+
+
+def test_days_until_expiry_at_future_epoch(app):
+    """A perspective epoch 10 days from now should count down 20 days
+    against an exp 30 days from now."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    epoch = int(time.time()) + 10 * 86400
+    days = app.lic.days_until_expiry_at(epoch)
+    assert isinstance(days, int)
+    # Floor-divided; allow +/- 1 for the day-boundary jitter that also
+    # affects days_until_expiry itself.
+    assert 19 <= days <= 20
+
+
+def test_days_until_expiry_at_past_epoch(app):
+    """A perspective epoch 5 days ago should count 35 days remaining
+    against an exp 30 days from now."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    epoch = int(time.time()) - 5 * 86400
+    days = app.lic.days_until_expiry_at(epoch)
+    assert isinstance(days, int)
+    assert 34 <= days <= 35
+
+
+def test_days_until_expiry_at_negative_when_epoch_past_exp(app):
+    """An operator asking "how many days past expiry would we have been
+    on <date>?" -- a perspective epoch AFTER ``exp`` -> negative int,
+    NOT None. The scalar must let a support tile render "expired 10 days
+    before that date" without a second call."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    epoch = int(time.time()) + 45 * 86400
+    days = app.lic.days_until_expiry_at(epoch)
+    assert isinstance(days, int)
+    assert days < 0
+    # exp - epoch = 30d - 45d = -15d.
+    assert -16 <= days <= -14
+
+
+def test_days_until_expiry_at_zero_on_day_of_expiry(app):
+    """Perspective epoch on the day of expiry -> 0."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    # Snap perspective to the same second as exp so (exp - epoch)//86400 == 0.
+    info = app.lic.current_license_info()
+    assert isinstance(info, dict)
+    exp = info["exp"]
+    assert app.lic.days_until_expiry_at(exp) == 0
+    assert app.lic.days_until_expiry_at(exp - 3600) == 0  # <24h before
+
+
+def test_days_until_expiry_at_signed_but_lapsed_still_countable(app):
+    """A lapsed-but-signed key must still surface a meaningful
+    ``days_left`` at an arbitrary perspective epoch -- support scenario
+    "when did we tell them it was going to lapse, evaluated as of last
+    Friday?". Mirrors :func:`license_expires_at`'s lenient posture."""
+    _write_key_direct(app, exp_delta=-5 * 86400)  # expired 5 days ago
+    # Perspective epoch 20 days BEFORE the current time -> the exp was
+    # (5 + 20) = 25 days INTO the future then, so days_left ~ +15.
+    epoch = int(time.time()) - 20 * 86400
+    days = app.lic.days_until_expiry_at(epoch)
+    assert isinstance(days, int)
+    assert 14 <= days <= 15
+
+
+def test_days_until_expiry_at_perpetual_license(app):
+    """Perpetual (no ``exp``) license -> None regardless of perspective
+    epoch. Nothing to count down to."""
+    tok = app.lic._encode_token(_payload(drop_exp=True), app.priv)
+    import os
+
+    os.makedirs(os.path.dirname(app.license_path), exist_ok=True)
+    with open(app.license_path, "w", encoding="utf-8") as fh:
+        fh.write(tok)
+    assert app.lic.days_until_expiry_at(int(time.time())) is None
+    assert app.lic.days_until_expiry_at(0) is None
+    assert app.lic.days_until_expiry_at(2_000_000_000) is None
+
+
+def test_days_until_expiry_at_invalid_signature(app):
+    """File on disk but signature bogus -> None. current_license_info()
+    already collapses the payload on this branch; the scalar must
+    reflect that."""
+    import os
+
+    os.makedirs(os.path.dirname(app.license_path), exist_ok=True)
+    with open(app.license_path, "w", encoding="utf-8") as fh:
+        fh.write("CLAW1.garbage.garbage")
+    assert app.lic.days_until_expiry_at(int(time.time())) is None
+
+
+def test_days_until_expiry_at_non_numeric_epoch(app):
+    """A caller passing a typo must get None, not a crash."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    assert app.lic.days_until_expiry_at("garbage") is None  # type: ignore[arg-type]
+    assert app.lic.days_until_expiry_at(None) is None  # type: ignore[arg-type]
+    assert app.lic.days_until_expiry_at([1]) is None  # type: ignore[arg-type]
+
+
+def test_days_until_expiry_at_bool_epoch_rejected(app):
+    """``bool`` is an ``int`` subclass -- explicitly refuse it so a
+    caller that passes ``True`` doesn't silently get "days until
+    epoch 1" back."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    assert app.lic.days_until_expiry_at(True) is None  # type: ignore[arg-type]
+    assert app.lic.days_until_expiry_at(False) is None  # type: ignore[arg-type]
+
+
+def test_days_until_expiry_at_float_epoch_coerced(app):
+    """Float epoch must coerce through ``int()`` rather than crash --
+    same posture as :func:`is_expiring_at`."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    now_f = float(time.time())
+    days = app.lic.days_until_expiry_at(now_f)
+    assert isinstance(days, int)
+
+
+def test_days_until_expiry_at_never_raises(monkeypatch):
+    """Any underlying failure -> None. Even a fully-broken
+    license_expires_at() must not propagate."""
+    import clawmetry.license as _lic
+
+    def _boom():
+        raise RuntimeError("simulated corrupt install")
+
+    monkeypatch.setattr(_lic, "license_expires_at", _boom)
+    assert _lic.days_until_expiry_at(int(time.time())) is None
+
+
+# ── GET /api/license/days-until-expiry-at ────────────────────────────────────
+
+
+def test_endpoint_days_until_expiry_at_no_license(app):
+    with app.app.test_client() as c:
+        resp = c.get(f"/api/license/days-until-expiry-at?epoch={int(time.time())}")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["days_left"] is None
+    assert isinstance(data["requested_epoch"], int)
+    assert data["expires_at"] is None
+    assert data["has_license"] is False
+    assert data["valid"] is False
+
+
+def test_endpoint_days_until_expiry_at_active(app):
+    tok = app.lic._encode_token(_payload(exp_delta=45 * 86400), app.priv)
+    app.lic.activate(tok)
+    now = int(time.time())
+    with app.app.test_client() as c:
+        resp = c.get(f"/api/license/days-until-expiry-at?epoch={now}")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert isinstance(data["days_left"], int)
+    assert 43 <= data["days_left"] <= 45
+    assert data["requested_epoch"] == now
+    assert isinstance(data["expires_at"], int)
+    assert data["has_license"] is True
+    assert data["valid"] is True
+
+
+def test_endpoint_days_until_expiry_at_negative_for_past_epoch(app):
+    """Perspective epoch AFTER ``exp`` -> negative days_left, expires_at
+    still populated so a support tile can render the pair without a
+    second call."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    epoch = int(time.time()) + 60 * 86400
+    with app.app.test_client() as c:
+        resp = c.get(f"/api/license/days-until-expiry-at?epoch={epoch}")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert isinstance(data["days_left"], int)
+    assert data["days_left"] < 0
+    assert isinstance(data["expires_at"], int)
+    assert data["has_license"] is True
+    assert data["valid"] is True
+
+
+def test_endpoint_days_until_expiry_at_lapsed_key_still_surfaces_days(app):
+    """A lapsed-but-signed key evaluated at a pre-lapse perspective
+    epoch -> positive days_left. ``valid`` is False (signature valid
+    but past expiry now) so a caller that wants to hide the row on
+    lapsed keys has the signal."""
+    _write_key_direct(app, exp_delta=-5 * 86400)
+    epoch = int(time.time()) - 20 * 86400  # 15 days before the exp
+    with app.app.test_client() as c:
+        resp = c.get(f"/api/license/days-until-expiry-at?epoch={epoch}")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert isinstance(data["days_left"], int)
+    assert 14 <= data["days_left"] <= 15
+    assert data["has_license"] is True
+    assert data["valid"] is False
+
+
+def test_endpoint_days_until_expiry_at_perpetual_license(app):
+    """Perpetual license -> days_left null even for a valid epoch."""
+    tok = app.lic._encode_token(_payload(drop_exp=True), app.priv)
+    import os
+
+    os.makedirs(os.path.dirname(app.license_path), exist_ok=True)
+    with open(app.license_path, "w", encoding="utf-8") as fh:
+        fh.write(tok)
+    with app.app.test_client() as c:
+        resp = c.get(f"/api/license/days-until-expiry-at?epoch={int(time.time())}")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["days_left"] is None
+    assert data["expires_at"] is None
+    assert data["has_license"] is True
+
+
+def test_endpoint_days_until_expiry_at_missing_epoch_arg(app):
+    """No ``epoch=`` -> days_left null, requested_epoch null, HTTP 200."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    with app.app.test_client() as c:
+        resp = c.get("/api/license/days-until-expiry-at")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["days_left"] is None
+    assert data["requested_epoch"] is None
+    # The snapshot still populates expires_at from the on-disk key.
+    assert isinstance(data["expires_at"], int)
+    assert data["has_license"] is True
+
+
+def test_endpoint_days_until_expiry_at_non_integer_epoch(app):
+    """Typo epoch -> days_left null, requested_epoch null, HTTP 200
+    (never a 4xx). Mirrors the ``/api/license/is-expiring-at`` posture."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    with app.app.test_client() as c:
+        resp = c.get("/api/license/days-until-expiry-at?epoch=garbage")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["days_left"] is None
+    assert data["requested_epoch"] is None
+    assert data["has_license"] is True
+
+
+def test_endpoint_days_until_expiry_at_invalid_signature(app):
+    """File on disk but signature bogus -> days_left null, has_license
+    True (there IS a file), valid False."""
+    import os
+
+    os.makedirs(os.path.dirname(app.license_path), exist_ok=True)
+    with open(app.license_path, "w", encoding="utf-8") as fh:
+        fh.write("CLAW1.garbage.garbage")
+    with app.app.test_client() as c:
+        resp = c.get(f"/api/license/days-until-expiry-at?epoch={int(time.time())}")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["days_left"] is None
+    assert data["has_license"] is True
+    assert data["valid"] is False
+
+
+def test_endpoint_days_until_expiry_at_never_5xxs(app, monkeypatch):
+    """Even if the shared snapshot blows up mid-request, the endpoint
+    must still return HTTP 200 with the OSS-free shape (snapshot fallback
+    kicks in, requested_epoch is still echoed, days_left is null)."""
+    from routes import entitlement as _routes
+
+    monkeypatch.setattr(
+        _routes,
+        "_license_expires_snapshot",
+        lambda: (_ for _ in ()).throw(RuntimeError("simulated blowup")),
+    )
+    epoch = int(time.time())
+    with app.app.test_client() as c:
+        resp = c.get(f"/api/license/days-until-expiry-at?epoch={epoch}")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["days_left"] is None
+    assert data["requested_epoch"] == epoch
+    assert data["expires_at"] is None
+    assert data["has_license"] is False
+    assert data["valid"] is False
+
+
+# ── cross-endpoint consistency ───────────────────────────────────────────────
+
+
+def test_endpoint_agrees_with_days_until_expiry_at_now(app):
+    """When ``epoch`` equals "now", the perspective endpoint must
+    agree with ``/api/license/days-until-expiry`` at the day boundary
+    (+/- 1 for the fractional-second drift between the two request
+    handlers: the base endpoint reads ``time.time()`` with sub-second
+    precision inside ``current_license_info`` at handle-time, while the
+    perspective endpoint receives an ``int(time.time())`` from the
+    caller that already truncated the fraction). Both derive from the
+    same signed ``exp`` claim, so a UI binding both cannot catch them
+    disagreeing by more than a day for the same install."""
+    tok = app.lic._encode_token(_payload(exp_delta=45 * 86400), app.priv)
+    app.lic.activate(tok)
+    now = int(time.time())
+    with app.app.test_client() as c:
+        a = c.get(f"/api/license/days-until-expiry-at?epoch={now}").get_json()
+        b = c.get("/api/license/days-until-expiry").get_json()
+    assert isinstance(a["days_left"], int)
+    assert isinstance(b["days_left"], int)
+    assert abs(a["days_left"] - b["days_left"]) <= 1
+
+
+def test_endpoint_agrees_with_is_expiring_at_on_shared_snapshot(app):
+    """Both perspective-epoch endpoints share :func:`_license_expires_snapshot`
+    -- they must surface identical ``expires_at`` / ``has_license`` /
+    ``valid`` for the same install regardless of the epoch queried."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    epoch = int(time.time()) + 5 * 86400
+    with app.app.test_client() as c:
+        a = c.get(f"/api/license/days-until-expiry-at?epoch={epoch}").get_json()
+        b = c.get(f"/api/license/is-expiring-at?epoch={epoch}").get_json()
+    for key in ("expires_at", "has_license", "valid"):
+        assert a[key] == b[key], f"mismatch on {key}: {a[key]!r} vs {b[key]!r}"
+    assert a["requested_epoch"] == b["requested_epoch"] == epoch


### PR DESCRIPTION
## Summary

- Adds `clawmetry.license.days_until_expiry_at(epoch: int) -> int | None`, the perspective-epoch flavour of `days_until_expiry()`. Answers "how many days from `epoch` until (or past) the installed license's `exp`?" without the caller having to snapshot license state at that time or compute `(exp - epoch) // 86400` themselves. Mirrors the existing `is_expiring_at(epoch)` scalar (line 1125): same coerced-through-`int()` input handling, same `bool`-is-refused guard, same never-raise fallback.
- Adds `GET /api/license/days-until-expiry-at?epoch=<int>` on `bp_entitlement`. Envelope carries `days_left` (signed), `requested_epoch` (echoed), `expires_at`, `has_license`, `valid` — same quartet as `/api/license/is-expiring-at` so the two endpoints share `_license_expires_snapshot()` and a UI binding both cannot catch them disagreeing on `expires_at` / `has_license` / `valid` for the same install.

Posture notes (mirror `days_until_expiry()` and `is_expiring_at()`):
- **Lenient on expiry**: a signed-but-lapsed key still surfaces its real `days_left` at a pre-lapse perspective epoch — the support scenario is "would we have warned last Friday? was the exp still in the future then?" — so an audit tile can render "would have been 15 days from expiry as of `<date>`" without special-casing the expired branch. The `valid` field independently carries the "signature-valid AND not expired" signal for callers that DO want to hide the row on lapsed keys, exactly like the sibling endpoints.
- **`bool` is refused explicitly** despite being an `int` subclass, so a caller that passes `True` / `False` gets `None` rather than a spurious "days until epoch 1" number.
- **Non-integer `epoch` collapses to `days_left=null` + `requested_epoch=null`, HTTP 200**: the bad-input signal is the `null` result, not a 4xx, matching the never-crash posture of the surrounding license endpoints.
- **Perpetual license (no `exp` claim) collapses to `null`** regardless of perspective epoch — nothing to count against.
- **Invalid signature collapses to `null`**: the payload cannot be trusted (an attacker could stuff any `exp` into an unsigned body), matching how `license_expires_at()` refuses that branch.

Cross-endpoint consistency covered by two tests: the perspective endpoint at `epoch=now` agrees with `/api/license/days-until-expiry` within ±1 day (the base scalar reads `time.time()` with sub-second precision inside `current_license_info` while the perspective handler receives an already-truncated `int(time.time())`), and the shared `_license_expires_snapshot()` guarantees `expires_at` / `has_license` / `valid` match `/api/license/is-expiring-at` exactly for the same install.

Zero behaviour change: purely additive, read-only. No new gate is enforced, no tier logic is altered.

## Test plan

- [x] `python3 -m pytest tests/test_license_days_until_expiry_at.py -q` — **24 passed**
- [x] `python3 -m pytest tests/test_license.py tests/test_license_api.py tests/test_license_days_until_expiry.py tests/test_license_expires_at_scalar.py tests/test_license_issued_scalar.py tests/test_license_is_expired_is_perpetual.py tests/test_entitlement_api.py -q` — **248 passed**, no regressions in adjacent license/entitlement suite
- [x] `python3 -m ruff check --select=E,F,W tests/test_license_days_until_expiry_at.py` — clean (no violations introduced in the new file or the edited hunks of `clawmetry/license.py` / `routes/entitlement.py`)
- [x] `python3 -m py_compile clawmetry/license.py routes/entitlement.py tests/test_license_days_until_expiry_at.py` — clean

### Local operator verification checklist (I can't reach the running daemon or a browser from this environment)

- [ ] Copy `clawmetry/license.py`, `routes/entitlement.py`, and `tests/test_license_days_until_expiry_at.py` into `~/.clawmetry/lib/pythonX.Y/site-packages/clawmetry/` and `.../site-packages/routes/`.
- [ ] Clear `__pycache__` under both directories.
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` to restart the daemon.
- [ ] `curl -s "http://localhost:8900/api/license/days-until-expiry-at?epoch=$(date +%s)" | jq .` — on an active install, expect `days_left` within ±1 of `/api/license/days-until-expiry`'s `days_left`; on OSS-free, expect `{"days_left": null, "requested_epoch": <int>, "expires_at": null, "has_license": false, "valid": false}`.
- [ ] `curl -s "http://localhost:8900/api/license/days-until-expiry-at?epoch=$(($(date +%s) - 86400*30))" | jq .` — perspective 30 days ago; `days_left` should be roughly 30 days larger than the "now" value (positive delta because the license had more life left back then).
- [ ] `curl -s "http://localhost:8900/api/license/days-until-expiry-at?epoch=$(($(date +%s) + 86400*365*10))" | jq .` — perspective 10 years from now; `days_left` should be strongly negative on any non-perpetual key (support tile can render "would have been expired N days ago as of `<future date>`"), or `null` on a perpetual key.
- [ ] `curl -s "http://localhost:8900/api/license/days-until-expiry-at?epoch=garbage" | jq .` — expect `{"days_left": null, "requested_epoch": null, ...}` with HTTP 200 (never a 4xx).
- [ ] `curl -s "http://localhost:8900/api/license/days-until-expiry-at" | jq .` — no `epoch=` arg; expect `days_left=null`, `requested_epoch=null`, HTTP 200.
- [ ] Cross-check: `expires_at` / `has_license` / `valid` on `/api/license/days-until-expiry-at?epoch=<X>` must equal the same three fields on `/api/license/is-expiring-at?epoch=<X>` for the same install (they share `_license_expires_snapshot()`).
- [ ] Decrypt the live cloud snapshot and browser-check the dashboard still loads (this PR touches shared license helpers but does not change any existing behaviour).

Marked draft — the local operator handles daemon verification, cloud-snapshot verification, release, and merge per FLYWHEEL.md.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SvWyCr36qeiVZULm5tE1ot)_