### PR TITLE
feat(runtime): default the switcher to the one runtime that has sessions

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -8875,6 +8875,27 @@ function _cmPopulateGlobalRuntime(counts) {
   // Visibility gate: zero-count free runtimes render when the switcher is
   // shown but must not summon it by themselves — a plain single-runtime
   // install (openclaw only, nothing locked) keeps its switcher-free header.
+  // Smart default (founder 2026-07-28): when the user has NEVER chosen a
+  // runtime (no stored key, no URL pin) and exactly ONE runtime has sessions,
+  // default to it instead of "All runtimes". A Claude-Code-only machine
+  // showed "OpenClaw 0 sessions / NemoClaw 0 sessions / Claude Code
+  // 3 sessions" and still made the user pick by hand. Multiple non-zero
+  // runtimes (or none) keep the honest "All runtimes" aggregate. One-time:
+  // the pick persists via the same path as a manual selection, so the
+  // user's later choices always win. MUST run BEFORE the visibility gate
+  // below: the single-runtime case is exactly when the switcher hides
+  // itself, which used to early-return past any chance to default.
+  if (_cmRuntimeFilter() === 'all' && _cmRuntimeFilterUrlPin() === null) {
+    var _neverChosen = false;
+    try { _neverChosen = localStorage.getItem('cm-runtime-filter') === null; } catch (e) {}
+    if (_neverChosen) {
+      var _nonzero = observed.filter(function(k) { return (counts[k] || 0) > 0; });
+      if (_nonzero.length === 1 && !otlpApps.length) {
+        _cmSetRuntimeFilter(_nonzero[0]);
+        try { _cmApplyRuntimeTabVisibility(); } catch (e) {}
+      }
+    }
+  }
   var gate = observed.filter(function(k) { return counts[k]; }).length +
     otlpApps.length + locked.length;
   if (gate < 2) { wrap.style.display = 'none'; return; }

--- a/tests/test_runtime_default_nonzero.py
+++ b/tests/test_runtime_default_nonzero.py
@@ -1,0 +1,23 @@
+"""The runtime switcher must default to the single runtime that actually has
+sessions when the user has never chosen one (founder 2026-07-28: a
+Claude-Code-only machine listed OpenClaw 0 / NemoClaw 0 / Claude Code 3 and
+still made the user pick by hand). JS contract guard in the shipped app.js."""
+import os
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def _app_js():
+    with open(os.path.join(ROOT, "clawmetry", "static", "js", "app.js"),
+              encoding="utf-8") as fh:
+        return fh.read()
+
+
+def test_smart_default_present_and_guarded():
+    src = _app_js()
+    assert "localStorage.getItem('cm-runtime-filter') === null" in src, \
+        "smart default must fire only when the user never chose a runtime"
+    assert "_nonzero.length === 1" in src, \
+        "smart default must require exactly one runtime with sessions"
+    assert "_cmRuntimeFilterUrlPin() === null" in src, \
+        "URL-pinned tabs must keep their pinned runtime"


### PR DESCRIPTION
Founder ask: a Claude-Code-only machine still made the user pick the runtime by hand. First-load default now follows the data (exactly-one-non-zero rule), persisted via the same path as a manual pick so user choices always win; URL-pinned tabs and OTLP apps are exempt. Placed before the switcher's single-runtime visibility gate, which used to early-return past any chance to default. Verified live in a fresh headless browser on the affected machine.