### PR TITLE
feat(license): license_age_days_at(epoch) scalar + endpoint

### DIFF
--- a/clawmetry/license.py
+++ b/clawmetry/license.py
@@ -1914,6 +1914,91 @@ def license_age_days() -> int | None:
     return age if age >= 0 else 0
 
 
+def license_age_days_at(epoch: int) -> int | None:
+    """Scalar view of "how many days from ``iat`` to ``epoch``?" -- the
+    perspective-epoch flavour of :func:`license_age_days`, for a
+    scheduled-audit / retrospective tile that wants to answer "how old
+    was the license as of <date>?" without the caller having to snapshot
+    the license state at that time or compute ``(epoch - iat) // 86400``
+    at every call site.
+
+    Returns:
+      * ``None`` when there is nothing meaningful to derive: no license
+        file on disk, an invalid signature (the payload can't be trusted
+        -- an attacker could stuff any ``iat`` into an unsigned body), a
+        signed payload whose ``iat`` claim is absent / non-numeric, OR a
+        non-numeric / bool ``epoch`` argument.
+      * A signed integer number of days otherwise. Zero when ``epoch``
+        equals the ``iat`` second; positive when ``epoch`` is after
+        ``iat`` (the normal case -- "N days old as of <date>"); negative
+        when ``epoch`` is BEFORE ``iat`` (support scenario: "the operator
+        rolled a machine back to a pre-issuance timestamp -- how far
+        before issuance were we?").
+
+    Deliberately NOT clamped to ``max(0, ...)`` -- unlike the "now"
+    flavour :func:`license_age_days`, which clamps because clock-skew is
+    the only way ``iat`` can be in the future when reading against
+    ``time.time()``. Here the caller EXPLICITLY passes a perspective
+    epoch, so a negative result is a real, actionable signal (they asked
+    a question that only makes sense pre-issuance), not clock skew to be
+    hidden. Mirrors the signed-integer posture of
+    :func:`days_until_expiry_at`, which returns negative days when the
+    perspective epoch is past ``exp``.
+
+    Days are floor-divided from seconds ``(epoch - iat) // 86400``,
+    matching how :func:`license_age_days` derives its "now" counterpart
+    from ``(now - iat)`` so the two scalars never disagree at the day
+    boundary when ``epoch`` equals the current time.
+
+    ``epoch`` is coerced through ``int()``; ``bool`` is explicitly
+    refused despite being an ``int`` subclass so a caller that passes
+    ``True`` / ``False`` gets ``None`` rather than a spurious "days
+    from iat to epoch 1" number. A non-numeric value collapses to
+    ``None`` so a caller cannot silently miscount on a typo.
+
+    Deliberately lenient on expiry, mirroring :func:`license_age_days`:
+    an expired-but-signature-valid key still carries a meaningful
+    ``iat`` (support scenario: "how old was this lapsed key evaluated
+    as of last Friday?") and callers would otherwise have to fall back
+    to :func:`current_license_info`. The :func:`is_expired` /
+    :func:`is_expiring_at` helpers independently carry the "past-
+    expiry" signals for callers that DO want to hide the row on lapsed
+    keys.
+
+    Pairs with :func:`license_issued_at` the way
+    :func:`days_until_expiry_at` pairs with :func:`license_expires_at`:
+    both derive from the same ``iat`` claim so they cannot disagree at
+    the day boundary. The perspective-epoch flavour lets a scheduled
+    audit tile answer "how old was the key when we shipped that build
+    last Friday?" without having to snapshot the license state at
+    those times.
+
+    Never raises. Any exception under the hood degrades to ``None`` so a
+    scheduled audit job never crashes on a bad install.
+    """
+    if isinstance(epoch, bool):
+        # ``bool`` is a subclass of ``int``; refuse it explicitly so a
+        # caller that passes ``True`` doesn't silently ask "days from
+        # iat to epoch 1?" and get a very negative number back.
+        return None
+    try:
+        wanted = int(epoch)
+    except (TypeError, ValueError):
+        return None
+    try:
+        issued = license_issued_at()
+    except Exception as exc:
+        logger.debug("license: license_age_days_at underlying read failed: %s", exc)
+        return None
+    if not isinstance(issued, int):
+        return None
+    try:
+        return (wanted - issued) // 86400
+    except Exception as exc:
+        logger.debug("license: license_age_days_at arithmetic failed: %s", exc)
+        return None
+
+
 # Canonical set of values :func:`license_state` may return. Kept in a frozenset
 # so a caller (`if state in LICENSE_STATES: ...`) never accidentally accepts a
 # typo like ``"actiev"`` as a valid state, and so :func:`is_state` can normalise

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -9772,6 +9772,112 @@ def api_license_days_until_expiry_at():
     )
 
 
+@bp_entitlement.route("/api/license/age-days-at")
+def api_license_age_days_at():
+    """``GET /api/license/age-days-at?epoch=<int>`` -- scalar view of the
+    installed license's age evaluated at an operator-supplied perspective
+    epoch, for a scheduled-audit / retrospective tile that wants to
+    answer "how old was the license as of <date>?" without the caller
+    having to snapshot the license state at that time or compute
+    ``(epoch - iat) // 86400`` at the call site.
+
+    Response shape (always HTTP 200)::
+
+        {
+          "age_days": <int|null>,        # signed days from iat to epoch
+          "requested_epoch": <int|null>, # int-coerced input, or null on typo
+          "issued_at": <int|null>,       # current on-disk iat
+          "has_license": <bool>,         # is a license file installed at all?
+          "valid": <bool>                # signature-valid AND not expired
+        }
+
+    ``age_days`` mirrors :func:`clawmetry.license.license_age_days_at`:
+
+      * ``null`` when there is no license file, on the invalid-signature
+        branch (payload cannot be trusted -- an attacker could stuff any
+        ``iat`` into an unsigned body), when the signed payload has no
+        ``iat`` claim, OR when ``epoch`` doesn't parse as an integer.
+      * A signed integer number of days otherwise. Zero when ``epoch``
+        equals the ``iat`` second; positive when ``epoch`` is after
+        ``iat`` (the normal case -- "N days old as of <date>"); negative
+        when ``epoch`` is BEFORE ``iat`` (support scenario: "the operator
+        rolled a machine back to a pre-issuance timestamp -- how far
+        before issuance were we?").
+
+    Deliberately NOT clamped to ``max(0, ...)`` -- unlike the "now"
+    endpoint ``/api/license/age-days``, which clamps because clock-skew
+    is the only way ``iat`` can be in the future when reading against
+    ``time.time()``. Here the caller EXPLICITLY passes a perspective
+    epoch, so a negative result is a real, actionable signal (they asked
+    a question that only makes sense pre-issuance), not clock skew to be
+    hidden. Mirrors the signed-integer posture of
+    ``/api/license/days-until-expiry-at``.
+
+    Deliberately lenient on expiry, mirroring ``/api/license/age-days``
+    and ``/api/license/issued-at``: a signed-but-lapsed key still
+    surfaces its real ``age_days`` at the perspective epoch, so a
+    support tile can render "was 12 days old as of that date" without
+    special-casing the expired branch. The ``valid`` field independently
+    carries the "signature-valid AND not expired" signal for callers
+    that DO want to hide the row on lapsed keys.
+
+    Query parameter:
+
+      * ``epoch`` -- required. Unix epoch seconds as an integer. A
+        missing / non-integer value collapses to ``age_days=null`` with
+        ``requested_epoch=null`` so a caller cannot silently miscount on
+        a typo. HTTP status is 200 either way -- the "bad input" signal
+        is the ``null`` result, not a 4xx, matching the never-crash
+        posture of the surrounding license endpoints.
+
+    Pairs with ``/api/license/issued-at`` and ``/api/license/age-days``
+    -- all three share :func:`_license_issued_snapshot`, so a UI binding
+    any pair of them for the same install cannot catch them disagreeing
+    on ``issued_at`` / ``has_license`` / ``valid``. Together they let a
+    dashboard render "on <date>, the license was N days old, issued at
+    epoch E" from two orthogonal one-shot GETs.
+
+    Never 5xxs -- any underlying failure degrades to
+    ``{age_days: null, requested_epoch: null, issued_at: null,
+    has_license: false, valid: false}`` (the OSS-free branch shape).
+    """
+    raw = request.args.get("epoch", "")
+    try:
+        requested = int(str(raw).strip())
+    except (TypeError, ValueError):
+        requested = None
+    try:
+        snap = _license_issued_snapshot()
+    except Exception as exc:
+        logger.warning("api_license_age_days_at: snapshot error: %s", exc)
+        snap = {
+            "issued_at": None,
+            "age_days": None,
+            "has_license": False,
+            "valid": False,
+        }
+    age_days: int | None
+    if requested is None:
+        age_days = None
+    else:
+        try:
+            from clawmetry import license as _lic
+
+            age_days = _lic.license_age_days_at(requested)
+        except Exception as exc:
+            logger.warning("api_license_age_days_at: derive error: %s", exc)
+            age_days = None
+    return jsonify(
+        {
+            "age_days": age_days,
+            "requested_epoch": requested,
+            "issued_at": snap["issued_at"],
+            "has_license": snap["has_license"],
+            "valid": snap["valid"],
+        }
+    )
+
+
 @bp_entitlement.route("/api/paywall/event", methods=["POST"])
 def api_paywall_event():
     body: dict = {}

--- a/tests/test_license_age_days_at_scalar.py
+++ b/tests/test_license_age_days_at_scalar.py
@@ -1,0 +1,453 @@
+"""Tests for the ``license_age_days_at(epoch)`` scalar helper on
+``clawmetry.license`` and its paired ``/api/license/age-days-at`` HTTP
+endpoint.
+
+The perspective-epoch flavour of the ``license_age_days`` scalar. Both
+derive from the same signed ``iat`` claim so they cannot disagree at the
+day boundary when the perspective epoch equals "now"; on any other
+epoch this helper answers "how old was the license as of ``epoch``?"
+without the caller having to snapshot the license state at that time or
+compute ``(epoch - iat) // 86400`` themselves.
+
+Mirrors ``tests/test_license_days_until_expiry_at.py`` line-for-line
+where the two scalars share posture (bool-refused, non-numeric coerced
+to None, never-raises, lenient on lapsed keys), and diverges on the
+one axis they must differ on: this scalar is intentionally NOT clamped
+to ``max(0, ...)`` because a perspective epoch BEFORE ``iat`` is a real
+signal the caller asked for (as opposed to clock skew, which is the
+only way ``iat`` can be in the future when reading against
+``time.time()`` from :func:`license_age_days`).
+
+Hermetic: each test mints tokens with its own ephemeral keypair and
+monkeypatches the module's embedded public key + LICENSE_PATH, mirroring
+``tests/test_license_days_until_expiry_at.py`` so nothing depends on the
+real production signing key or on real filesystem state.
+"""
+from __future__ import annotations
+
+import time
+from types import SimpleNamespace
+
+import pytest
+from flask import Flask
+
+
+# -- shared helpers (mirror test_license_days_until_expiry_at.py) -------------
+
+
+def _keypair():
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+    priv = Ed25519PrivateKey.generate()
+    pub_pem = priv.public_key().public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    return priv, pub_pem
+
+
+def _payload(tier="pro", nodes=3, exp_delta=365 * 86400, drop_iat=False):
+    now = int(time.time())
+    p = {
+        "sub": "acct_test",
+        "tier": tier,
+        "nodes": nodes,
+        "iat": now,
+        "exp": now + exp_delta,
+        "features": ["runtimes"],
+    }
+    if drop_iat:
+        p.pop("iat", None)
+    return p
+
+
+@pytest.fixture
+def app(monkeypatch, tmp_path):
+    import clawmetry.license as _lic
+
+    priv, pub_pem = _keypair()
+    monkeypatch.setattr(_lic, "_PUBLIC_KEY_PEM", pub_pem)
+    license_path = str(tmp_path / "license.key")
+    monkeypatch.setattr(_lic, "LICENSE_PATH", license_path)
+    monkeypatch.delenv("CLAWMETRY_LICENSE_SERVER", raising=False)
+    monkeypatch.delenv("CLAWMETRY_INGEST_URL", raising=False)
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("CLAWMETRY_OFFLINE", "1")
+
+    from routes.entitlement import bp_entitlement
+
+    flask_app = Flask(__name__)
+    flask_app.register_blueprint(bp_entitlement)
+    flask_app.config["TESTING"] = True
+
+    return SimpleNamespace(
+        app=flask_app,
+        lic=_lic,
+        priv=priv,
+        license_path=license_path,
+    )
+
+
+def _write_key_direct(app, exp_delta):
+    """Bypass activate() (which refuses expired tokens) and write a token
+    directly to the license file. Simulates a license that expired AFTER
+    it was installed."""
+    import os
+
+    tok = app.lic._encode_token(_payload(exp_delta=exp_delta), app.priv)
+    os.makedirs(os.path.dirname(app.license_path), exist_ok=True)
+    with open(app.license_path, "w", encoding="utf-8") as fh:
+        fh.write(tok)
+
+
+# -- clawmetry.license.license_age_days_at() ----------------------------------
+
+
+def test_license_age_days_at_no_license(app):
+    """No license file on disk -> None (nothing to compute against)."""
+    assert app.lic.license_age_days_at(int(time.time())) is None
+
+
+def test_license_age_days_at_now_matches_license_age_days(app):
+    """When ``epoch`` equals "now", the perspective-epoch scalar must
+    agree with :func:`license_age_days` at the day boundary (+/- 1 for
+    the fractional-second drift between the two calls: the base scalar
+    reads ``time.time()`` with sub-second precision inside itself, while
+    the caller here passes an ``int(time.time())`` that already
+    truncated the fraction)."""
+    tok = app.lic._encode_token(_payload(), app.priv)
+    app.lic.activate(tok)
+    now = int(time.time())
+    at_now = app.lic.license_age_days_at(now)
+    scalar_now = app.lic.license_age_days()
+    assert isinstance(at_now, int)
+    assert isinstance(scalar_now, int)
+    assert abs(at_now - scalar_now) <= 1
+
+
+def test_license_age_days_at_future_epoch(app):
+    """A perspective epoch 10 days from now against a just-issued key
+    should render age ~10 days."""
+    tok = app.lic._encode_token(_payload(), app.priv)
+    app.lic.activate(tok)
+    epoch = int(time.time()) + 10 * 86400
+    days = app.lic.license_age_days_at(epoch)
+    assert isinstance(days, int)
+    # Floor-divided; allow +/- 1 for the day-boundary jitter that also
+    # affects license_age_days itself.
+    assert 9 <= days <= 10
+
+
+def test_license_age_days_at_far_future_epoch(app):
+    """Perspective epoch 100 days from now against a just-issued key
+    should render age ~100 days -- unlike the "now" flavour, no cap on
+    how old the caller may ask about."""
+    tok = app.lic._encode_token(_payload(), app.priv)
+    app.lic.activate(tok)
+    epoch = int(time.time()) + 100 * 86400
+    days = app.lic.license_age_days_at(epoch)
+    assert isinstance(days, int)
+    assert 99 <= days <= 100
+
+
+def test_license_age_days_at_negative_when_epoch_before_iat(app):
+    """An operator asking "how old was the key on <date>?" where
+    <date> is BEFORE issuance -- perspective epoch BEFORE ``iat`` ->
+    negative int, NOT None and NOT clamped to 0. Distinct from
+    :func:`license_age_days`, which clamps because it can only reach
+    the future-``iat`` branch via clock skew (nothing to hide here --
+    the caller explicitly asked a pre-issuance question)."""
+    tok = app.lic._encode_token(_payload(), app.priv)
+    app.lic.activate(tok)
+    epoch = int(time.time()) - 15 * 86400
+    days = app.lic.license_age_days_at(epoch)
+    assert isinstance(days, int)
+    assert days < 0
+    # epoch - iat = -15d.
+    assert -16 <= days <= -14
+
+
+def test_license_age_days_at_zero_on_day_of_issuance(app):
+    """Perspective epoch on the day of issuance -> 0."""
+    tok = app.lic._encode_token(_payload(), app.priv)
+    app.lic.activate(tok)
+    info = app.lic.current_license_info()
+    assert isinstance(info, dict)
+    iat = info["issued_at"]
+    assert app.lic.license_age_days_at(iat) == 0
+    # Sub-day AFTER iat still floor-divides to 0.
+    assert app.lic.license_age_days_at(iat + 3600) == 0
+
+
+def test_license_age_days_at_signed_but_lapsed_still_countable(app):
+    """A lapsed-but-signed key must still surface a meaningful
+    ``age_days`` at an arbitrary perspective epoch -- support scenario
+    "how old was this lapsed key evaluated as of last Friday?".
+    Mirrors :func:`license_age_days`'s lenient posture on expiry."""
+    _write_key_direct(app, exp_delta=-5 * 86400)  # expired 5 days ago
+    # Perspective epoch 20 days AFTER the current time (still lapsed,
+    # but iat was ~now, so age_days ~ +20).
+    epoch = int(time.time()) + 20 * 86400
+    days = app.lic.license_age_days_at(epoch)
+    assert isinstance(days, int)
+    assert 19 <= days <= 20
+
+
+def test_license_age_days_at_no_iat_claim(app):
+    """A signed payload with the ``iat`` claim stripped -> None
+    regardless of perspective epoch. Nothing to reference."""
+    tok = app.lic._encode_token(_payload(drop_iat=True), app.priv)
+    import os
+
+    os.makedirs(os.path.dirname(app.license_path), exist_ok=True)
+    with open(app.license_path, "w", encoding="utf-8") as fh:
+        fh.write(tok)
+    assert app.lic.license_age_days_at(int(time.time())) is None
+    assert app.lic.license_age_days_at(0) is None
+    assert app.lic.license_age_days_at(2_000_000_000) is None
+
+
+def test_license_age_days_at_invalid_signature(app):
+    """File on disk but signature bogus -> None. current_license_info()
+    already collapses the payload on this branch; the scalar must
+    reflect that."""
+    import os
+
+    os.makedirs(os.path.dirname(app.license_path), exist_ok=True)
+    with open(app.license_path, "w", encoding="utf-8") as fh:
+        fh.write("CLAW1.garbage.garbage")
+    assert app.lic.license_age_days_at(int(time.time())) is None
+
+
+def test_license_age_days_at_non_numeric_epoch(app):
+    """A caller passing a typo must get None, not a crash."""
+    tok = app.lic._encode_token(_payload(), app.priv)
+    app.lic.activate(tok)
+    assert app.lic.license_age_days_at("garbage") is None  # type: ignore[arg-type]
+    assert app.lic.license_age_days_at(None) is None  # type: ignore[arg-type]
+    assert app.lic.license_age_days_at([1]) is None  # type: ignore[arg-type]
+
+
+def test_license_age_days_at_bool_epoch_rejected(app):
+    """``bool`` is an ``int`` subclass -- explicitly refuse it so a
+    caller that passes ``True`` doesn't silently get "days from iat
+    to epoch 1" back."""
+    tok = app.lic._encode_token(_payload(), app.priv)
+    app.lic.activate(tok)
+    assert app.lic.license_age_days_at(True) is None  # type: ignore[arg-type]
+    assert app.lic.license_age_days_at(False) is None  # type: ignore[arg-type]
+
+
+def test_license_age_days_at_float_epoch_coerced(app):
+    """Float epoch must coerce through ``int()`` rather than crash --
+    same posture as :func:`days_until_expiry_at`."""
+    tok = app.lic._encode_token(_payload(), app.priv)
+    app.lic.activate(tok)
+    now_f = float(time.time())
+    days = app.lic.license_age_days_at(now_f)
+    assert isinstance(days, int)
+
+
+def test_license_age_days_at_never_raises(monkeypatch):
+    """Any underlying failure -> None. Even a fully-broken
+    license_issued_at() must not propagate."""
+    import clawmetry.license as _lic
+
+    def _boom():
+        raise RuntimeError("simulated corrupt install")
+
+    monkeypatch.setattr(_lic, "license_issued_at", _boom)
+    assert _lic.license_age_days_at(int(time.time())) is None
+
+
+# -- GET /api/license/age-days-at ---------------------------------------------
+
+
+def test_endpoint_age_days_at_no_license(app):
+    with app.app.test_client() as c:
+        resp = c.get(f"/api/license/age-days-at?epoch={int(time.time())}")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["age_days"] is None
+    assert isinstance(data["requested_epoch"], int)
+    assert data["issued_at"] is None
+    assert data["has_license"] is False
+    assert data["valid"] is False
+
+
+def test_endpoint_age_days_at_active(app):
+    tok = app.lic._encode_token(_payload(), app.priv)
+    app.lic.activate(tok)
+    now = int(time.time())
+    with app.app.test_client() as c:
+        resp = c.get(f"/api/license/age-days-at?epoch={now + 45 * 86400}")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert isinstance(data["age_days"], int)
+    assert 44 <= data["age_days"] <= 45
+    assert data["requested_epoch"] == now + 45 * 86400
+    assert isinstance(data["issued_at"], int)
+    assert data["has_license"] is True
+    assert data["valid"] is True
+
+
+def test_endpoint_age_days_at_negative_for_pre_issuance_epoch(app):
+    """Perspective epoch BEFORE ``iat`` -> negative age_days, issued_at
+    still populated so a support tile can render the pair without a
+    second call."""
+    tok = app.lic._encode_token(_payload(), app.priv)
+    app.lic.activate(tok)
+    epoch = int(time.time()) - 30 * 86400
+    with app.app.test_client() as c:
+        resp = c.get(f"/api/license/age-days-at?epoch={epoch}")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert isinstance(data["age_days"], int)
+    assert data["age_days"] < 0
+    assert isinstance(data["issued_at"], int)
+    assert data["has_license"] is True
+    assert data["valid"] is True
+
+
+def test_endpoint_age_days_at_lapsed_key_still_surfaces_age(app):
+    """A lapsed-but-signed key evaluated at a post-lapse perspective
+    epoch -> positive age_days. ``valid`` is False (signature valid
+    but past expiry now) so a caller that wants to hide the row on
+    lapsed keys has the signal."""
+    _write_key_direct(app, exp_delta=-5 * 86400)
+    epoch = int(time.time()) + 20 * 86400
+    with app.app.test_client() as c:
+        resp = c.get(f"/api/license/age-days-at?epoch={epoch}")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert isinstance(data["age_days"], int)
+    assert 19 <= data["age_days"] <= 20
+    assert data["has_license"] is True
+    assert data["valid"] is False
+
+
+def test_endpoint_age_days_at_no_iat_claim(app):
+    """iat-less payload -> age_days null even for a valid epoch."""
+    tok = app.lic._encode_token(_payload(drop_iat=True), app.priv)
+    import os
+
+    os.makedirs(os.path.dirname(app.license_path), exist_ok=True)
+    with open(app.license_path, "w", encoding="utf-8") as fh:
+        fh.write(tok)
+    with app.app.test_client() as c:
+        resp = c.get(f"/api/license/age-days-at?epoch={int(time.time())}")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["age_days"] is None
+    assert data["issued_at"] is None
+    assert data["has_license"] is True
+
+
+def test_endpoint_age_days_at_missing_epoch_arg(app):
+    """No ``epoch=`` -> age_days null, requested_epoch null, HTTP 200."""
+    tok = app.lic._encode_token(_payload(), app.priv)
+    app.lic.activate(tok)
+    with app.app.test_client() as c:
+        resp = c.get("/api/license/age-days-at")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["age_days"] is None
+    assert data["requested_epoch"] is None
+    # The snapshot still populates issued_at from the on-disk key.
+    assert isinstance(data["issued_at"], int)
+    assert data["has_license"] is True
+
+
+def test_endpoint_age_days_at_non_integer_epoch(app):
+    """Typo epoch -> age_days null, requested_epoch null, HTTP 200
+    (never a 4xx). Mirrors the ``/api/license/days-until-expiry-at``
+    posture."""
+    tok = app.lic._encode_token(_payload(), app.priv)
+    app.lic.activate(tok)
+    with app.app.test_client() as c:
+        resp = c.get("/api/license/age-days-at?epoch=garbage")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["age_days"] is None
+    assert data["requested_epoch"] is None
+    assert data["has_license"] is True
+
+
+def test_endpoint_age_days_at_invalid_signature(app):
+    """File on disk but signature bogus -> age_days null, has_license
+    True (there IS a file), valid False."""
+    import os
+
+    os.makedirs(os.path.dirname(app.license_path), exist_ok=True)
+    with open(app.license_path, "w", encoding="utf-8") as fh:
+        fh.write("CLAW1.garbage.garbage")
+    with app.app.test_client() as c:
+        resp = c.get(f"/api/license/age-days-at?epoch={int(time.time())}")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["age_days"] is None
+    assert data["has_license"] is True
+    assert data["valid"] is False
+
+
+def test_endpoint_age_days_at_never_5xxs(app, monkeypatch):
+    """Even if the shared snapshot blows up mid-request, the endpoint
+    must still return HTTP 200 with the OSS-free shape (snapshot fallback
+    kicks in, requested_epoch is still echoed, age_days is null)."""
+    from routes import entitlement as _routes
+
+    monkeypatch.setattr(
+        _routes,
+        "_license_issued_snapshot",
+        lambda: (_ for _ in ()).throw(RuntimeError("simulated blowup")),
+    )
+    epoch = int(time.time())
+    with app.app.test_client() as c:
+        resp = c.get(f"/api/license/age-days-at?epoch={epoch}")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["age_days"] is None
+    assert data["requested_epoch"] == epoch
+    assert data["issued_at"] is None
+    assert data["has_license"] is False
+    assert data["valid"] is False
+
+
+# -- cross-endpoint consistency -----------------------------------------------
+
+
+def test_endpoint_agrees_with_age_days_at_now(app):
+    """When ``epoch`` equals "now", the perspective endpoint must agree
+    with ``/api/license/age-days`` at the day boundary (+/- 1 for the
+    fractional-second drift between the two request handlers: the base
+    endpoint reads ``time.time()`` with sub-second precision inside
+    ``license_age_days`` at handle-time, while the perspective endpoint
+    receives an ``int(time.time())`` from the caller that already
+    truncated the fraction). Both derive from the same signed ``iat``
+    claim, so a UI binding both cannot catch them disagreeing by more
+    than a day for the same install."""
+    tok = app.lic._encode_token(_payload(), app.priv)
+    app.lic.activate(tok)
+    now = int(time.time())
+    with app.app.test_client() as c:
+        a = c.get(f"/api/license/age-days-at?epoch={now}").get_json()
+        b = c.get("/api/license/age-days").get_json()
+    assert isinstance(a["age_days"], int)
+    assert isinstance(b["age_days"], int)
+    assert abs(a["age_days"] - b["age_days"]) <= 1
+
+
+def test_endpoint_agrees_with_issued_at_on_shared_snapshot(app):
+    """Both endpoints share :func:`_license_issued_snapshot` -- they
+    must surface identical ``issued_at`` / ``has_license`` / ``valid``
+    for the same install regardless of the epoch queried."""
+    tok = app.lic._encode_token(_payload(), app.priv)
+    app.lic.activate(tok)
+    epoch = int(time.time()) + 5 * 86400
+    with app.app.test_client() as c:
+        a = c.get(f"/api/license/age-days-at?epoch={epoch}").get_json()
+        b = c.get("/api/license/issued-at").get_json()
+    for key in ("issued_at", "has_license", "valid"):
+        assert a[key] == b[key], f"mismatch on {key}: {a[key]!r} vs {b[key]!r}"
+    assert a["requested_epoch"] == epoch


### PR DESCRIPTION
## Summary

- Adds `clawmetry.license.license_age_days_at(epoch: int) -> int | None`, the perspective-epoch flavour of `license_age_days()`. Answers "how old was the installed license as of `epoch`?" without the caller having to snapshot the license state at that time or compute `(epoch - iat) // 86400` themselves. Mirrors the existing `days_until_expiry_at(epoch)` scalar (merged in #4162): same coerced-through-`int()` input handling, same `bool`-is-refused guard, same never-raise fallback.
- Adds `GET /api/license/age-days-at?epoch=<int>` on `bp_entitlement`. Envelope carries `age_days` (signed), `requested_epoch` (echoed), `issued_at`, `has_license`, `valid` — same quartet-plus-echo as `/api/license/days-until-expiry-at` so the two endpoints share their reader helpers and a UI binding both cannot catch them disagreeing on install-state fields for the same install.

Posture notes (mirrors `license_age_days()` and `days_until_expiry_at()`):
- **Signed integer, deliberately NOT clamped to `max(0, ...)`** — unlike the "now" flavour `license_age_days()`, which clamps because clock-skew is the only way `iat` can be in the future when reading against `time.time()`. Here the caller EXPLICITLY passes a perspective epoch, so a negative result is a real, actionable signal (they asked a question that only makes sense pre-issuance), not clock skew to be hidden. Matches the signed-integer posture of `days_until_expiry_at`, which returns negative days when the perspective epoch is past `exp`.
- **Lenient on expiry**: a signed-but-lapsed key still surfaces its real `age_days` at the perspective epoch — the support scenario is "how old was this lapsed key evaluated as of last Friday?" — so an audit tile can render "was 12 days old as of `<date>`" without special-casing the expired branch. The `valid` field independently carries the "signature-valid AND not expired" signal for callers that DO want to hide the row on lapsed keys, exactly like the sibling endpoints.
- **`bool` is refused explicitly** despite being an `int` subclass, so a caller that passes `True` / `False` gets `None` rather than a spurious "days from iat to epoch 1" number.
- **Non-integer `epoch` collapses to `age_days=null` + `requested_epoch=null`, HTTP 200**: the bad-input signal is the `null` result, not a 4xx, matching the never-crash posture of the surrounding license endpoints.
- **Missing `iat` claim collapses to `null`** regardless of perspective epoch — nothing to reference against.
- **Invalid signature collapses to `null`**: the payload cannot be trusted (an attacker could stuff any `iat` into an unsigned body), matching how `license_issued_at()` refuses that branch.

Cross-endpoint consistency covered by two tests: the perspective endpoint at `epoch=now` agrees with `/api/license/age-days` within ±1 day (the base endpoint reads `time.time()` with sub-second precision inside `license_age_days` at handle-time while the perspective handler receives an already-truncated `int(time.time())`), and the shared `_license_issued_snapshot()` guarantees `issued_at` / `has_license` / `valid` match `/api/license/issued-at` exactly for the same install.

Zero behaviour change: purely additive, read-only. No new gate is enforced, no tier logic is altered.

## Test plan

- [x] `python3 -m pytest tests/test_license_age_days_at_scalar.py -q` — **24 passed**
- [x] `python3 -m pytest tests/test_license_days_until_expiry_at.py tests/test_license_days_until_expiry.py tests/test_license_issued_scalar.py tests/test_license_expires_at_scalar.py tests/test_license_is_expired_is_perpetual.py tests/test_license.py tests/test_license_api.py tests/test_entitlement_api.py tests/test_entitlement_api_fallback_shape.py -q` — **279 passed**, no regressions in adjacent license/entitlement suite
- [x] `python3 -m ruff check --select=E,F,W tests/test_license_age_days_at_scalar.py` — clean (no violations in the new file; the pre-existing 17 lint findings on the wider `clawmetry/license.py` / `routes/entitlement.py` are all outside the hunks this PR touches)
- [x] `python3 -m py_compile clawmetry/license.py routes/entitlement.py tests/test_license_age_days_at_scalar.py` — clean

### Local operator verification checklist (I can't reach the running daemon or a browser from this environment)

- [ ] Copy `clawmetry/license.py`, `routes/entitlement.py`, and `tests/test_license_age_days_at_scalar.py` into `~/.clawmetry/lib/pythonX.Y/site-packages/clawmetry/` and `.../site-packages/routes/`.
- [ ] Clear `__pycache__` under both directories.
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` to restart the daemon.
- [ ] `curl -s "http://localhost:8900/api/license/age-days-at?epoch=$(date +%s)" | jq .` — on an active install, expect `age_days` within ±1 of `/api/license/age-days`'s `age_days`; on OSS-free, expect `{"age_days": null, "requested_epoch": <epoch>, "issued_at": null, "has_license": false, "valid": false}`.
- [ ] `curl -s "http://localhost:8900/api/license/age-days-at?epoch=$(($(date +%s) + 86400*30))" | jq .` — perspective 30 days from now; `age_days` should be roughly 30 days larger than the "now" value (positive delta because the key will be older then).
- [ ] `curl -s "http://localhost:8900/api/license/age-days-at?epoch=$(($(date +%s) - 86400*365*10))" | jq .` — perspective 10 years ago; `age_days` should be strongly negative on any key (support tile can render "would have been -N days old as of `<date>`"). Confirms the endpoint is NOT clamped to 0, unlike `/api/license/age-days`.
- [ ] `curl -s "http://localhost:8900/api/license/age-days-at?epoch=garbage" | jq .` — expect `{"age_days": null, "requested_epoch": null, ...}` with HTTP 200 (never a 4xx).
- [ ] `curl -s "http://localhost:8900/api/license/age-days-at" | jq .` — no `epoch=` arg; expect `age_days=null`, `requested_epoch=null`, HTTP 200.
- [ ] Cross-check: `issued_at` / `has_license` / `valid` on `/api/license/age-days-at?epoch=<any>` must equal the same three fields on `/api/license/issued-at` for the same install (they share `_license_issued_snapshot()`).
- [ ] Decrypt the live cloud snapshot and browser-check the dashboard still loads (this PR touches shared license helpers but does not change any existing behaviour).

Marked draft — the local operator handles daemon verification, cloud-snapshot verification, release, and merge per FLYWHEEL.md.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vt5MuLpeaR1zB738cfvnxD)_