### PR TITLE
fix(autoupdate): relaunched process gets a UTF-8 stdout (cp1252 banner crash)

### DIFF
--- a/clawmetry/update_respawn.py
+++ b/clawmetry/update_respawn.py
@@ -116,8 +116,18 @@ def main(argv=None) -> int:
          f"relaunching: {relaunch_cmd}")
     # Relaunch EITHER WAY: a failed install must still bring the service back
     # on the old version rather than leaving the machine with nothing running.
+    #
+    # PYTHONIOENCODING / PYTHONUTF8 are load-bearing: the relaunched process
+    # writes stdout to THIS LOG FILE (not a console), so Python picks the
+    # locale codec — cp1252 on Windows — and the startup banner's arrows and
+    # emoji die with UnicodeEncodeError, killing the freshly updated
+    # dashboard right after a perfect install (live-hit on the 0.12.579
+    # unattended run, 2026-07-28; same encoding class as the #3791 CLI bug).
+    env = dict(os.environ)
+    env.setdefault("PYTHONIOENCODING", "utf-8")
+    env.setdefault("PYTHONUTF8", "1")
     kwargs = {"stdin": subprocess.DEVNULL, "stdout": log, "stderr": log,
-              "close_fds": True}
+              "close_fds": True, "env": env}
     if os.name == "nt":
         kwargs["creationflags"] = _DETACHED
     else:

--- a/tests/test_auto_update.py
+++ b/tests/test_auto_update.py
@@ -449,3 +449,26 @@ def test_entitled_plan_respects_optout_and_never_disables(monkeypatch):
     monkeypatch.delenv("CLAWMETRY_AUTO_UPDATE", raising=False)
     state["auto_update"] = True
     S._sync_auto_update_with_plan("cloud_free"); assert state["auto_update"] is True
+
+
+def test_update_respawn_relaunch_env_forces_utf8(monkeypatch, tmp_path):
+    """The relaunched process writes stdout to the log FILE, so without
+    PYTHONIOENCODING the Windows locale codec (cp1252) kills the startup
+    banner with UnicodeEncodeError right after a perfect install (live-hit
+    on the 0.12.579 unattended run)."""
+    from clawmetry import update_respawn as ur
+
+    monkeypatch.setattr(ur, "_wait_for_pid_exit", lambda pid, timeout_secs=90.0: True)
+
+    class _Proc:
+        returncode = 0
+
+    captured = {}
+    monkeypatch.setattr(ur.subprocess, "run", lambda cmd, **k: _Proc())
+    monkeypatch.setattr(ur.subprocess, "Popen",
+                        lambda cmd, **k: captured.update(k))
+    rc = ur.main(["1234", "0.12.99", str(tmp_path / "r.log"), "clawmetry.exe"])
+    assert rc == 0
+    env = captured.get("env") or {}
+    assert env.get("PYTHONIOENCODING") == "utf-8"
+    assert env.get("PYTHONUTF8") == "1"


### PR DESCRIPTION
The 0.12.579 unattended run proved detect+install+relaunch, then the relaunched dashboard died printing its startup banner: stdout is the helper's log file, so cp1252 killed the Unicode banner. PYTHONIOENCODING=utf-8 + PYTHONUTF8=1 in the relaunch env; guard test included. Live overlay applied to the affected machine.