### PR TITLE
fix(autoupdate): the update lock rides through the Windows handoff

### DIFF
--- a/clawmetry/update_respawn.py
+++ b/clawmetry/update_respawn.py
@@ -99,18 +99,34 @@ def main(argv=None) -> int:
     spec = f"clawmetry=={target}" if target and target != "latest" else "clawmetry"
     _say(f"[update-respawn] parent gone; pip install --upgrade {spec}")
     ok = False
-    for attempt in (1, 2):
-        proc = subprocess.run(
-            [sys.executable, "-m", "pip", "install", "--upgrade",
-             "--no-cache-dir", spec],
-            stdout=log, stderr=log, timeout=300,
-        )
-        if proc.returncode == 0:
-            ok = True
-            break
-        _say(f"[update-respawn] pip attempt {attempt} failed "
-             f"(exit {proc.returncode}); retrying in 10s")
-        time.sleep(10)
+    try:
+        # Retry ladder sized for the two real failure modes seen live
+        # (2026-07-28): the PyPI simple-index propagation lag (the JSON API
+        # advertises a release 1-3 minutes before pip can install it) and a
+        # sibling process briefly holding the launcher exe. 10s+10s was too
+        # short for either.
+        for attempt, wait in ((1, 20), (2, 60), (3, 120)):
+            proc = subprocess.run(
+                [sys.executable, "-m", "pip", "install", "--upgrade",
+                 "--no-cache-dir", spec],
+                stdout=log, stderr=log, timeout=300,
+            )
+            if proc.returncode == 0:
+                ok = True
+                break
+            _say(f"[update-respawn] pip attempt {attempt} failed "
+                 f"(exit {proc.returncode}); retrying in {wait}s")
+            time.sleep(wait)
+    finally:
+        # Release the cross-process update lock the PARENT was holding when
+        # it handed off (see routes/update_check.py): the lock now rides
+        # through the handoff so a sibling process cannot start a concurrent
+        # pip while this helper works — the exact race that bricked
+        # site-packages metadata on the 0.12.580 run.
+        try:
+            os.remove(os.path.expanduser("~/.clawmetry/update-in-progress.lock"))
+        except OSError:
+            pass
 
     _say(f"[update-respawn] install {'succeeded' if ok else 'FAILED'}; "
          f"relaunching: {relaunch_cmd}")

--- a/routes/update_check.py
+++ b/routes/update_check.py
@@ -718,7 +718,13 @@ def _maybe_auto_update(current, target, latest=None):
         _pending_update_target["version"] = str(target)
         _record_update_attempt(target, "handoff",
                                "out-of-process helper armed; process exits")
-        _release_update_lock()
+        # The lock is NOT released here: it rides through the handoff and the
+        # HELPER deletes it when its pip run finishes. Releasing before the
+        # handoff let the daemon's and dashboard's helpers pip CONCURRENTLY
+        # (live-hit on the 0.12.580 run, 2026-07-28: one helper's uninstall
+        # raced the other's install, WinError 32 + a metadata-bricked
+        # site-packages with ~lawmetry corpses). The 15-minute staleness
+        # window still breaks the lock if a helper dies before cleanup.
         _schedule_windows_respawn()
         return
     try:

--- a/tests/test_auto_update.py
+++ b/tests/test_auto_update.py
@@ -472,3 +472,49 @@ def test_update_respawn_relaunch_env_forces_utf8(monkeypatch, tmp_path):
     env = captured.get("env") or {}
     assert env.get("PYTHONIOENCODING") == "utf-8"
     assert env.get("PYTHONUTF8") == "1"
+
+
+def test_windows_handoff_keeps_update_lock(monkeypatch, tmp_path):
+    """The lock must ride THROUGH the handoff: releasing it before the helper
+    runs let sibling helpers pip concurrently and brick site-packages
+    metadata (live-hit on the 0.12.580 run)."""
+    uc = _uc()
+    monkeypatch.delenv("CLAWMETRY_AUTO_UPDATE", raising=False)
+    uc._process_role = "daemon"
+    monkeypatch.setattr(uc, "_daemon_supervised", lambda: True)
+    monkeypatch.setattr(uc, "_restart_plan", lambda r, p, s: "respawn")
+    monkeypatch.setattr(uc, "_schedule_windows_respawn", lambda *a, **k: None)
+    monkeypatch.setattr(uc, "_get_update_check_config", lambda: {"auto_update": True})
+    monkeypatch.setattr(uc, "_record_update_attempt", lambda *a, **k: None)
+    monkeypatch.setattr(uc, "_UPDATE_LOCK_PATH", str(tmp_path / "u.lock"))
+    released = []
+    monkeypatch.setattr(uc, "_release_update_lock", lambda: released.append(1))
+    calls = []
+    _mock_self_update(monkeypatch, calls)
+    uc._maybe_auto_update("0.12.1", "0.12.2")
+    assert released == [], "handoff must NOT release the lock; the helper does"
+    import os as _os
+    assert _os.path.exists(str(tmp_path / "u.lock")), "lock file must persist through handoff"
+
+
+def test_update_respawn_helper_releases_lock(monkeypatch, tmp_path):
+    """The helper deletes the inherited cross-process lock when pip finishes,
+    success or failure."""
+    from clawmetry import update_respawn as ur
+
+    lockdir = tmp_path / ".clawmetry"
+    lockdir.mkdir()
+    lock = lockdir / "update-in-progress.lock"
+    lock.write_text("held")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    monkeypatch.setattr(ur, "_wait_for_pid_exit", lambda pid, timeout_secs=90.0: True)
+    monkeypatch.setattr(ur.time, "sleep", lambda s: None)
+
+    class _Fail:
+        returncode = 1
+
+    monkeypatch.setattr(ur.subprocess, "run", lambda cmd, **k: _Fail())
+    monkeypatch.setattr(ur.subprocess, "Popen", lambda cmd, **k: None)
+    ur.main(["1234", "0.12.99", str(tmp_path / "r.log"), "x.exe"])
+    assert not lock.exists(), "helper must release the lock even on pip failure"


### PR DESCRIPTION
The 0.12.580 run exposed a helper-vs-helper pip race: the lock was released before the handoff, so two detached helpers installed concurrently and bricked site-packages metadata. The lock now persists through the handoff and the helper releases it when pip finishes either way; retry ladder resized for PyPI propagation lag (20s/60s/120s). Guard tests included; overlay applied live to the affected machine.