### PR TITLE
fix(alerts): work self-hosted - local entitlement unlocks the tab, rules save locally

### DIFF
--- a/clawmetry/static/js/alerts.js
+++ b/clawmetry/static/js/alerts.js
@@ -98,6 +98,20 @@
   // ── Tier resolution ───────────────────────────────────────────────────────
 
   async function resolveTier() {
+    // Self-hosted entitlement FIRST (founder 2026-07-28: alerts must work
+    // without a cloud signup). A local Trial/Pro license entitles the tab;
+    // rules then live in the LOCAL store and fire via the local evaluator.
+    // Only when the local entitlement is free do we consult the cloud
+    // account (the original flow).
+    try {
+      const ent = await fetch('/api/entitlement').then(r => r.json());
+      if (ent && ent.is_paid && !ent.expired) {
+        alertsState.localMode = true;
+        const days = ent.days_until_expiry;
+        return { tier: ent.tier === 'trial' ? 'trial' : 'pro',
+                 trialDaysLeft: (days === null || days === undefined) ? null : days };
+      }
+    } catch (e) { /* fall through to the cloud path */ }
     try {
       const status = await fetch('/api/cloud-cta/status').then(r => r.json());
       if (!status.connected) return { tier: 'none' };
@@ -137,7 +151,8 @@
     }
 
     try {
-      const data = await fetch('/api/cloud-proxy/api/alerts').then(r => r.json());
+      const data = await fetch(alertsState.localMode
+        ? '/api/alerts/rules' : '/api/cloud-proxy/api/alerts').then(r => r.json());
       // Cache hit returns an E2E-encrypted ``rules_blob`` ({rules:[...]}) that
       // only the browser can decrypt; cache miss returns plaintext
       // ``{alerts:[]}``. Reading data.alerts alone meant a saved rule (which
@@ -148,6 +163,19 @@
         serverRules = await alertsDecryptRulesBlob(data.rules_blob);
       } else {
         serverRules = data.alerts || data.rules || [];
+      }
+      if (alertsState.localMode) {
+        // Local rows speak the local schema (type/threshold/channels);
+        // normalise onto the fields the renderer reads.
+        serverRules = (serverRules || []).map(function (r) {
+          return Object.assign({}, r, {
+            alert_type: r.alert_type || r.type,
+            name: r.name || r.type,
+            threshold_value: (r.threshold_value !== undefined && r.threshold_value !== null)
+              ? r.threshold_value : r.threshold,
+            channel_ids: r.channel_ids || r.channels || [],
+          });
+        });
       }
       // Preserve optimistic ``pending-`` rules until the cloud cache catches
       // up (the daemon cache_push lags the write by ~2 heartbeats). Without
@@ -167,7 +195,9 @@
     // the same local /api/alerts/history the nav badge uses when cloud has
     // nothing (or errors), so the two stay consistent.
     try {
-      const hist = await fetch('/api/cloud-proxy/api/alerts/history?limit=20')
+      const hist = await fetch(alertsState.localMode
+        ? '/api/alerts/history?limit=20'
+        : '/api/cloud-proxy/api/alerts/history?limit=20')
         .then(r => r.json());
       alertsState.history = hist.history || [];
     } catch {
@@ -454,7 +484,8 @@
       }
       let resp;
       if (isExample && newEnabled) {
-        resp = await fetch('/api/cloud-proxy/api/alerts', {
+        resp = await fetch(alertsState.localMode
+          ? '/api/alerts/rules' : '/api/cloud-proxy/api/alerts', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
@@ -468,7 +499,8 @@
           }),
         });
       } else {
-        resp = await fetch('/api/cloud-proxy/api/alerts/' + ruleId, {
+        resp = await fetch((alertsState.localMode
+          ? '/api/alerts/rules/' : '/api/cloud-proxy/api/alerts/') + ruleId, {
           method: 'PUT',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ enabled: newEnabled }),
@@ -663,9 +695,10 @@
     };
 
     const isEdit = !!alertsState.editorRule;
-    const url = isEdit
-      ? '/api/cloud-proxy/api/alerts/' + alertsState.editorRule.id
-      : '/api/cloud-proxy/api/alerts';
+    const url = alertsState.localMode
+      ? (isEdit ? '/api/alerts/rules/' + alertsState.editorRule.id : '/api/alerts/rules')
+      : (isEdit ? '/api/cloud-proxy/api/alerts/' + alertsState.editorRule.id
+                : '/api/cloud-proxy/api/alerts');
     const method = isEdit ? 'PUT' : 'POST';
 
     const resp = await fetch(url, {

--- a/routes/alerts.py
+++ b/routes/alerts.py
@@ -664,6 +664,25 @@ def api_alert_rules():
         channels = data.get("channels", ["banner"])
         cooldown = data.get("cooldown_min", 30)
         enabled = data.get("enabled", True)
+        # Self-hosted bridge (founder 2026-07-28: "alerts should work in the
+        # self-hosted setup"): the Alerts tab speaks the cloud vocabulary
+        # (alert_type / threshold_value / channel_ids). A locally-entitled
+        # install (self-hosted Trial/Pro key) saves those rules HERE instead
+        # of at the cloud; map the fields onto the local schema. Cloud-vocab
+        # types without a local evaluator equivalent land on "anomaly" so
+        # the rule persists and renders; evaluator parity is tracked
+        # separately.
+        _cloud_type = (data.get("alert_type") or "").strip()
+        if _cloud_type and not rtype:
+            _CLOUD_TO_LOCAL = {
+                "cost_daily": "threshold", "session_cost": "threshold",
+                "token_velocity": "token_spike", "agent_offline": "agent_down",
+            }
+            rtype = _CLOUD_TO_LOCAL.get(_cloud_type, "anomaly")
+            if not threshold:
+                threshold = data.get("threshold_value", 0)
+            if data.get("channel_ids") and channels == ["banner"]:
+                channels = list(data.get("channel_ids") or []) or ["banner"]
         if rtype not in ("threshold", "spike", "token_spike", "anomaly",
                          "agent_down", "unproductive_burn"):
             return jsonify({"error": "Invalid alert type"}), 400

--- a/tests/test_alerts_local_entitlement.py
+++ b/tests/test_alerts_local_entitlement.py
@@ -1,0 +1,68 @@
+"""Alerts must function on a self-hosted entitlement without any cloud signup
+(founder 2026-07-28: "it should work in the self-hosted setup as well").
+
+Guards the two halves: the local rules route accepts the Alerts tab's cloud
+vocabulary, and the tab's tier resolution consults the local entitlement
+before demanding a cloud account."""
+import os
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def test_local_rules_route_accepts_cloud_vocabulary(monkeypatch):
+    import dashboard as _d
+    from flask import Flask
+
+    from routes.alerts import bp_alerts
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_alerts)
+
+    writes = []
+
+    class _Db:
+        def execute(self, q, params=()):
+            writes.append((q, params))
+
+            class _R:
+                def fetchall(self):
+                    return []
+
+                def fetchone(self):
+                    return None
+            return _R()
+
+        def commit(self):
+            pass
+
+        def close(self):
+            pass
+
+    import threading
+    monkeypatch.setattr(_d, "_fleet_db_lock", threading.Lock(), raising=False)
+    monkeypatch.setattr(_d, "_fleet_db", lambda: _Db(), raising=False)
+
+    r = app.test_client().post("/api/alerts/rules", json={
+        "alert_type": "cost_daily", "name": "Daily spend",
+        "threshold_value": 50, "enabled": True, "channel_ids": [],
+    })
+    assert r.status_code == 200, r.get_json()
+    assert r.get_json().get("ok") is True
+    ins = [w for w in writes if "INSERT INTO alert_rules" in w[0]]
+    assert ins, "cloud-vocabulary rule must be stored locally"
+    assert ins[0][1][1] == "threshold", "cost_daily maps to the local threshold type"
+    assert ins[0][1][2] == 50
+
+
+def _js(rel):
+    with open(os.path.join(ROOT, rel), encoding="utf-8") as fh:
+        return fh.read()
+
+
+def test_alerts_js_resolves_local_entitlement_first():
+    src = _js("clawmetry/static/js/alerts.js")
+    assert "fetch('/api/entitlement')" in src, \
+        "resolveTier must consult the LOCAL entitlement before the cloud"
+    assert "alertsState.localMode = true" in src
+    assert "'/api/alerts/rules'" in src, \
+        "local mode must read and write the LOCAL rules routes"


### PR DESCRIPTION
The Alerts tab only recognized cloud accounts, so a valid self-hosted trial got the signup modal for a trial it already had. Local-first tier resolution, local rule CRUD in localMode, cloud-vocabulary mapping on the local POST, render shim. Live-verified on the affected machine: no signup modal, cost_daily rule saved locally. Guard tests included. Evaluator parity for unmapped rule types is a tracked follow-up; email delivery honestly remains cloud-only.