### PR TITLE
fix(entitlements): grace mode never covers an EXPIRED entitlement

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -576,7 +576,15 @@ class Entitlement:
         return remaining <= threshold
 
     def allows_runtime(self, runtime: str) -> bool:
-        if self.grace:
+        # Grace-mode permissiveness exists so the enforce-day rollout cannot
+        # break installs that never opted into anything. An EXPIRED paid
+        # entitlement is the opposite case: the user took a trial (or let a
+        # license lapse) and the deal is that it stops working — otherwise a
+        # 7-day trial is a permanent unlock while grace lasts (founder
+        # directive 2026-07-28: "it should stop working after the trial
+        # period"). Free runtimes/features stay allowed either way via the
+        # membership checks below.
+        if self.grace and not self.expired:
             return True
         return self.entitled_runtime(runtime)
 
@@ -589,7 +597,10 @@ class Entitlement:
         return rt in self.runtimes
 
     def allows_feature(self, feature: str) -> bool:
-        if self.grace:
+        # See allows_runtime: grace never covers an EXPIRED paid entitlement,
+        # or a trial would outlive its own expiry for as long as the grace
+        # rollout lasts.
+        if self.grace and not self.expired:
             return True
         if feature in FREE_FEATURES:
             return True

--- a/tests/test_trial_lifecycle_gates.py
+++ b/tests/test_trial_lifecycle_gates.py
@@ -1,0 +1,122 @@
+"""The self-hosted trial lifecycle, end to end through the REAL gates
+(founder directive 2026-07-28): a trial license key unlocks alerts and
+approvals; when the trial EXPIRES they stop working even in grace mode;
+a fully paid license keeps them working.
+
+Hermetic: ephemeral Ed25519 keypair, monkeypatched public key, real
+entitlement resolution over a real key file, real @gate decorators.
+"""
+from __future__ import annotations
+
+import time
+from types import SimpleNamespace
+
+import pytest
+
+
+def _keypair():
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+    priv = Ed25519PrivateKey.generate()
+    pub_pem = priv.public_key().public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    return priv, pub_pem
+
+
+@pytest.fixture
+def env(monkeypatch, tmp_path):
+    import clawmetry.license as L
+    from clawmetry import entitlements as E
+
+    priv, pub_pem = _keypair()
+    key_path = str(tmp_path / "license.key")
+    monkeypatch.setattr(L, "_PUBLIC_KEY_PEM", pub_pem)
+    monkeypatch.setattr(L, "LICENSE_PATH", key_path)
+    monkeypatch.setattr(E, "_LICENSE_PATH", key_path)
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)  # GRACE mode: the hard case
+    E.invalidate()
+
+    def install(tier, days):
+        now = int(time.time())
+        tok = L._encode_token({
+            "jti": "lic_t", "sub": "t@e.com", "tier": tier, "nodes": 2,
+            "iat": now, "exp": now + days * 86400,
+        }, priv)
+        with open(key_path, "w", encoding="utf-8") as fh:
+            fh.write(tok)
+        E.invalidate()
+
+    yield SimpleNamespace(install=install, E=E)
+    E.invalidate()
+
+
+def _gated_app():
+    from flask import Flask, jsonify
+
+    from clawmetry._gate import gate
+
+    app = Flask(__name__)
+
+    @app.route("/alerts")
+    @gate("custom_alerts")
+    def _alerts():
+        return jsonify({"ok": True})
+
+    @app.route("/approvals")
+    @gate("approval_queue")
+    def _approvals():
+        return jsonify({"ok": True})
+
+    return app.test_client()
+
+
+def test_active_trial_unlocks_alerts_and_approvals(env):
+    env.install("trial", days=6)
+    c = _gated_app()
+    assert c.get("/alerts").status_code == 200
+    assert c.get("/approvals").status_code == 200
+
+
+def test_expired_trial_locks_them_even_in_grace(env):
+    """The revert-proof: in grace mode the old gates returned True for
+    EVERYTHING, so an expired 7-day trial was a permanent unlock."""
+    env.install("trial", days=-1)
+    ent = env.E.get_entitlement(force=True)
+    assert ent.grace is True, "precondition: the rollout is in grace mode"
+    assert ent.expired is True, "precondition: the trial has lapsed"
+    c = _gated_app()
+    assert c.get("/alerts").status_code == 402, \
+        "an expired trial must stop unlocking alerts"
+    assert c.get("/approvals").status_code == 402, \
+        "an expired trial must stop unlocking approvals"
+
+
+def test_paid_license_keeps_them_working(env):
+    env.install("pro", days=365)
+    c = _gated_app()
+    assert c.get("/alerts").status_code == 200
+    assert c.get("/approvals").status_code == 200
+
+
+def test_expired_trial_also_locks_paid_runtimes(env):
+    env.install("trial", days=-1)
+    ent = env.E.get_entitlement(force=True)
+    assert ent.allows_runtime("claude_code") is False, \
+        "the trial ending must stop the paid runtime watch too"
+    assert ent.allows_runtime("openclaw") is True, \
+        "free runtimes stay free after a lapsed trial"
+
+
+def test_never_entitled_installs_keep_grace(env, tmp_path):
+    """The rollout safety is untouched: no license file at all means grace
+    still allows everything (enforce-day must not break bystanders)."""
+    import os
+
+    ent = env.E.get_entitlement(force=True)
+    assert ent.grace is True and ent.expired is False
+    c = _gated_app()
+    assert c.get("/alerts").status_code == 200
+    assert c.get("/approvals").status_code == 200


### PR DESCRIPTION
A lapsed trial was a permanent unlock: grace returned True before any expiry check. Grace now covers only non-expired entitlements, so a trial key works for its 7 days, dies on expiry (402 on alerts/approvals, paid runtimes unwatched), and a paid key works indefinitely - while never-entitled installs keep full grace (rollout safety intact). Lifecycle pinned end to end through the real gates with a real key file; revert-proof red on the old behaviour.