### PR TITLE
fix(e2e-gate): raise MAX_WAIT from 8 min to 15 min, add timeout to e2e-critical

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -393,6 +393,7 @@ jobs:
     name: E2E Browser Tests (critical subset)
     needs: lint
     runs-on: ubuntu-latest
+    timeout-minutes: 12
 
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/e2e-gate.yml
+++ b/.github/workflows/e2e-gate.yml
@@ -7,7 +7,10 @@ name: E2E Gate (required)
 # Polls the Check Runs API every 30s until all required checks complete.
 # Fails immediately if any required check fails (fast-fail).
 # Passes only when all 4 required checks have a success conclusion.
-# Times out after 8 min (conservative -- E2E wall-clock max is 12 min).
+# Times out after 15 min (oss-golden-path budget is 12 min -- on a cold
+# runner Playwright download alone takes ~4.5 min, then C1+C5 sweeps add
+# ~5 min; the previous 8-min limit caused premature timeout before the
+# underlying check could pass).
 #
 # Required checks aggregated (keep in sync with REQUIRED_CHECKS in
 # scripts/apply_required_status_checks.py):
@@ -41,7 +44,7 @@ jobs:
   e2e-gate:
     name: E2E Gate (required)
     runs-on: ubuntu-latest
-    timeout-minutes: 12
+    timeout-minutes: 18
 
     steps:
       - name: Wait for required E2E checks and verify they passed
@@ -62,8 +65,11 @@ jobs:
           COMMIT_SHA = os.environ["COMMIT_SHA"].strip()
           REPO = os.environ["REPO"]
           POLL_INTERVAL = 30   # seconds between checks
-          MAX_WAIT = 480       # 8 minutes; E2E wall-clock max is ~12 min but
-                               # most checks finish within 5 min (cache hit)
+          MAX_WAIT = 900       # 15 minutes -- oss-golden-path runs for up to
+                               # 12 min on cold runners (4.5 min Playwright
+                               # download + C1 9-tab sweep + C5 33-tab sweep).
+                               # The prior 8-min limit timed out before the
+                               # slowest underlying check could complete.
 
           # Keep in sync with REQUIRED_CHECKS in
           # scripts/apply_required_status_checks.py and c6-schedule-heal.yml.


### PR DESCRIPTION
## Summary

- **`e2e-gate.yml`**: raise `MAX_WAIT` from 480 s (8 min) to 900 s (15 min) and `timeout-minutes` from 12 to 18. `oss-golden-path.yml` has a 12-minute budget; on a cold runner the Playwright chromium download alone takes up to 4.5 min, then the C1 9-tab sweep + C5 33-tab sweep add 5-7 min -- total 10-12 min. The old 8-min limit caused the aggregator to time out and report failure before the slowest underlying check could complete. Once C6 is configured in branch protection, this bug would produce spurious `TIMEOUT` gate failures on every cold-runner PR.
- **`ci.yml`**: add `timeout-minutes: 12` to the `e2e-critical` job (was unbounded -- a hung Playwright process would let the e2e-gate wait 15 min before surfacing a confusing "timed out" message with no diagnosis).

Tracking: vivekchand/clawmetry#4029 (C6 -- E2E Robustness epic)

## Test plan

- [ ] `e2e-gate.yml` job header shows `timeout-minutes: 18` in the Actions UI
- [ ] On a cold runner (no cached Playwright binary), OSS golden path completes within 12 min and the gate does not report TIMEOUT
- [ ] On a hot runner (cached), gate still exits before 15-min MAX_WAIT with PASS (no regression)
- [ ] `ci.yml` e2e-critical job header shows `timeout-minutes: 12` in Actions UI; a hung step gets killed at 12 min with a clear timeout error

---
_Generated by [Claude Code](https://claude.ai/code/session_015AaXHWbWhBsfzv92T8ymX8)_