### PR TITLE
feat(license): is_expired_at(epoch) scalar + endpoint

### DIFF
--- a/clawmetry/license.py
+++ b/clawmetry/license.py
@@ -1343,6 +1343,73 @@ def is_expired() -> bool:
         return False
 
 
+
+def is_expired_at(epoch: int) -> bool:
+    """Boolean gate for "was the installed license expired evaluated as of
+    ``epoch``?" -- the perspective-epoch flavour of :func:`is_expired`, for
+    a scheduled-audit tile that wants to answer "would we have shown the
+    expired banner on <date>?" without the caller having to snapshot the
+    license state at that time or compare ``exp`` to a caller-supplied
+    epoch themselves.
+
+    Returns ``True`` iff a license is installed, signature-valid, carries
+    an ``exp`` claim, AND ``exp <= epoch``. Returns ``False`` for every
+    other state: no license file, invalid signature (an attacker could
+    stuff any ``exp`` into an unsigned body, so we refuse to trust it),
+    perpetual / no-``exp`` keys (nothing to compare against), and any
+    ``exp`` value strictly greater than ``epoch``.
+
+    When ``epoch`` equals "now", this predicate must agree with
+    :func:`is_expired` for the same install -- both derive from the same
+    signed ``exp`` claim and use the same ``<=`` cutoff, so the two
+    scalars cannot disagree at the boundary. On any other epoch this
+    helper answers the retrospective question that :func:`is_expired`
+    cannot -- e.g. "was this key already expired last Friday?" (positive
+    signal even on a key that has since been renewed) or "will this key
+    be expired at our next quarterly audit?" (positive signal on an
+    active key whose ``exp`` falls before the audit date).
+
+    Deliberately lenient on expiry NOW, unlike :func:`is_expiring_at`
+    (which refuses lapsed keys because a renewal-window predicate on a
+    lapsed key would push callers to gate the WRONG UI). A retrospective
+    "was this expired on <date>?" tile absolutely should keep firing
+    ``True`` on a lapsed key -- that is the entire support scenario --
+    so the "signature-valid" check here does NOT roll in the "not
+    expired now" clause the sibling :func:`is_expiring_at` uses.
+
+    ``epoch`` is coerced through ``int()``; ``bool`` is explicitly
+    refused despite being an ``int`` subclass so a caller that passes
+    ``True`` / ``False`` gets ``False`` back rather than a spurious
+    "was the key expired at epoch 1?" answer. A non-numeric value
+    collapses to ``False`` so a caller cannot silently mis-gate on a
+    typo.
+
+    Never raises. Any underlying introspection failure (import error,
+    corrupt install, cryptography-lib mismatch) collapses to ``False``
+    so a scheduled audit job never crashes on a bad install.
+    """
+    if isinstance(epoch, bool):
+        # ``bool`` is a subclass of ``int``; refuse it explicitly so a
+        # caller that passes ``True`` doesn't silently ask "was the key
+        # expired at epoch 1?" and get a positive answer back.
+        return False
+    try:
+        wanted = int(epoch)
+    except (TypeError, ValueError):
+        return False
+    try:
+        exp = license_expires_at()
+    except Exception as exc:
+        logger.debug("license: is_expired_at underlying read failed: %s", exc)
+        return False
+    if not isinstance(exp, int):
+        # ``license_expires_at`` returns None for no-license, invalid-
+        # signature, and perpetual branches. Nothing to compare against
+        # in any of those cases.
+        return False
+    return exp <= wanted
+
+
 def is_perpetual() -> bool:
     """True iff an installed, signature-valid license carries no ``exp`` claim.
 

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -10051,6 +10051,106 @@ def api_license_age_days_at():
     )
 
 
+@bp_entitlement.route("/api/license/is-expired-at")
+def api_license_is_expired_at():
+    """``GET /api/license/is-expired-at?epoch=<int>`` -- boolean gate
+    for "was the installed license expired evaluated as of ``epoch``?" --
+    the perspective-epoch flavour of ``/api/license/is-expired``, for a
+    scheduled-audit / retrospective tile that wants to answer "would we
+    have shown the expired banner on <date>?" without the caller having
+    to compare ``exp`` against a specific epoch themselves.
+
+    Response shape (always HTTP 200)::
+
+        {
+          "is_expired_at": <bool>,           # true iff exp <= epoch on a signed key
+          "requested_epoch": <int|null>,     # int-coerced input, or null on typo
+          "expires_at": <int|null>,          # current on-disk exp for comparison
+          "has_license": <bool>,             # is a license file installed at all?
+          "valid": <bool>                    # signature-valid AND not expired NOW
+        }
+
+    ``is_expired_at`` mirrors :func:`clawmetry.license.is_expired_at`:
+
+      * ``false`` when there is no license file, on the invalid-signature
+        branch (payload cannot be trusted -- an attacker could stuff any
+        ``exp`` into an unsigned body), on the perpetual-license branch
+        (no ``exp`` to compare against), when ``exp`` is strictly greater
+        than ``epoch`` (the key was not yet expired at that perspective),
+        OR when ``epoch`` doesn't parse as an integer.
+      * ``true`` iff the installed key is signature-valid, carries an
+        ``exp`` claim, AND ``exp <= epoch``.
+
+    Deliberately lenient on expiry NOW, unlike ``/api/license/is-expiring-at``
+    (which refuses lapsed keys because a renewal-window predicate on a
+    lapsed key would push callers to gate the WRONG UI). A retrospective
+    "was this expired on <date>?" tile absolutely should keep firing
+    ``true`` on a lapsed key -- that IS the support scenario -- so
+    ``is_expired_at`` still returns ``true`` on a signed-but-lapsed key
+    when ``epoch`` falls at or after ``exp``. The ``valid`` field
+    independently carries the "signature-valid AND not expired NOW"
+    signal for callers that DO want to gate off the current-state
+    validity.
+
+    Query parameter:
+
+      * ``epoch`` -- required. Unix epoch seconds as an integer. A
+        missing / non-integer value collapses to
+        ``is_expired_at=false`` with ``requested_epoch=null`` so a
+        caller cannot silently mis-gate on a typo. HTTP status is 200
+        either way -- the "bad input" signal is the ``false`` result,
+        not a 4xx, matching the never-crash posture of the surrounding
+        license endpoints.
+
+    Pairs with ``/api/license/is-expiring-at`` and
+    ``/api/license/days-until-expiry-at`` -- all three share the
+    perspective-epoch input pattern and the
+    :func:`_license_expires_snapshot` reader, so a UI binding any two
+    for the same install cannot catch them disagreeing on
+    ``expires_at`` / ``has_license`` / ``valid``. Together they let a
+    dashboard render "on <date>, the license would have been N days
+    from expiry, matched a specific ``exp`` value, and was expired?"
+    from three orthogonal one-shot GETs.
+
+    Never 5xxs -- any underlying failure degrades to
+    ``{is_expired_at: false, requested_epoch: null, expires_at: null,
+    has_license: false, valid: false}`` (the OSS-free branch shape).
+    """
+    raw = request.args.get("epoch", "")
+    try:
+        requested = int(str(raw).strip())
+    except (TypeError, ValueError):
+        requested = None
+    try:
+        snap = _license_expires_snapshot()
+    except Exception as exc:
+        logger.warning("api_license_is_expired_at: snapshot error: %s", exc)
+        snap = {
+            "expires_at": None,
+            "days_until_expiry": None,
+            "has_license": False,
+            "valid": False,
+        }
+    matched = False
+    if requested is not None:
+        try:
+            from clawmetry import license as _lic
+
+            matched = _lic.is_expired_at(requested)
+        except Exception as exc:
+            logger.warning("api_license_is_expired_at: derive error: %s", exc)
+            matched = False
+    return jsonify(
+        {
+            "is_expired_at": bool(matched),
+            "requested_epoch": requested,
+            "expires_at": snap["expires_at"],
+            "has_license": snap["has_license"],
+            "valid": snap["valid"],
+        }
+    )
+
+
 @bp_entitlement.route("/api/paywall/event", methods=["POST"])
 def api_paywall_event():
     body: dict = {}

--- a/tests/test_license_is_expired_at.py
+++ b/tests/test_license_is_expired_at.py
@@ -1,0 +1,478 @@
+"""Tests for the ``is_expired_at(epoch)`` scalar helper on
+``clawmetry.license`` and its paired ``/api/license/is-expired-at``
+HTTP endpoint.
+
+The perspective-epoch flavour of the ``is_expired`` boolean gate. Both
+derive from the same signed ``exp`` claim so they cannot disagree at
+the boundary when the perspective epoch equals "now"; on any other
+epoch this helper answers "was the license expired evaluated as of
+``epoch``?" without the caller having to snapshot the license state at
+that time or compare ``exp`` to a caller-supplied epoch themselves.
+
+Hermetic: each test mints tokens with its own ephemeral keypair and
+monkeypatches the module's embedded public key + LICENSE_PATH, mirroring
+``tests/test_license_days_until_expiry_at.py`` so nothing depends on the
+real production signing key or on real filesystem state.
+"""
+from __future__ import annotations
+
+import time
+from types import SimpleNamespace
+
+import pytest
+from flask import Flask
+
+
+# -- shared helpers (mirror test_license_days_until_expiry_at.py) -------------
+
+
+def _keypair():
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+    priv = Ed25519PrivateKey.generate()
+    pub_pem = priv.public_key().public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    return priv, pub_pem
+
+
+def _payload(tier="pro", nodes=3, exp_delta=365 * 86400, drop_exp=False):
+    now = int(time.time())
+    p = {
+        "sub": "acct_test",
+        "tier": tier,
+        "nodes": nodes,
+        "iat": now,
+        "exp": now + exp_delta,
+        "features": ["runtimes"],
+    }
+    if drop_exp:
+        p.pop("exp", None)
+    return p
+
+
+@pytest.fixture
+def app(monkeypatch, tmp_path):
+    import clawmetry.license as _lic
+
+    priv, pub_pem = _keypair()
+    monkeypatch.setattr(_lic, "_PUBLIC_KEY_PEM", pub_pem)
+    license_path = str(tmp_path / "license.key")
+    monkeypatch.setattr(_lic, "LICENSE_PATH", license_path)
+    monkeypatch.delenv("CLAWMETRY_LICENSE_SERVER", raising=False)
+    monkeypatch.delenv("CLAWMETRY_INGEST_URL", raising=False)
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("CLAWMETRY_OFFLINE", "1")
+
+    from routes.entitlement import bp_entitlement
+
+    flask_app = Flask(__name__)
+    flask_app.register_blueprint(bp_entitlement)
+    flask_app.config["TESTING"] = True
+
+    return SimpleNamespace(
+        app=flask_app,
+        lic=_lic,
+        priv=priv,
+        license_path=license_path,
+    )
+
+
+def _write_key_direct(app, exp_delta):
+    """Bypass activate() (which refuses expired tokens) and write a token
+    directly to the license file. Simulates a license that expired AFTER
+    it was installed."""
+    import os
+
+    tok = app.lic._encode_token(_payload(exp_delta=exp_delta), app.priv)
+    os.makedirs(os.path.dirname(app.license_path), exist_ok=True)
+    with open(app.license_path, "w", encoding="utf-8") as fh:
+        fh.write(tok)
+
+
+# -- clawmetry.license.is_expired_at() ----------------------------------------
+
+
+def test_is_expired_at_no_license(app):
+    """No license file on disk -> False (nothing to compare against)."""
+    assert app.lic.is_expired_at(int(time.time())) is False
+    assert app.lic.is_expired_at(0) is False
+    assert app.lic.is_expired_at(2_000_000_000) is False
+
+
+def test_is_expired_at_now_matches_is_expired_on_active(app):
+    """When ``epoch`` equals "now", the perspective-epoch gate must agree
+    with :func:`is_expired` on the same install. Both derive from the same
+    signed ``exp`` claim, so a UI binding both cannot catch them
+    disagreeing at the boundary for an active key."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    now = int(time.time())
+    assert app.lic.is_expired_at(now) is False
+    assert app.lic.is_expired() is False
+
+
+def test_is_expired_at_now_matches_is_expired_on_lapsed(app):
+    """A signed-but-lapsed key must return True on the "now" perspective,
+    matching :func:`is_expired` -- both use the ``exp <= now`` cutoff so
+    they cannot disagree at the boundary."""
+    _write_key_direct(app, exp_delta=-5 * 86400)  # expired 5 days ago
+    now = int(time.time())
+    assert app.lic.is_expired_at(now) is True
+    assert app.lic.is_expired() is True
+
+
+def test_is_expired_at_future_epoch_before_expiry(app):
+    """A perspective epoch in the future, but still before ``exp`` -> False
+    (the key would NOT yet be expired at that perspective)."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    epoch = int(time.time()) + 10 * 86400  # 20 days before exp
+    assert app.lic.is_expired_at(epoch) is False
+
+
+def test_is_expired_at_future_epoch_after_expiry(app):
+    """A perspective epoch AFTER ``exp`` on an active key -> True (the
+    key WILL be expired at that perspective). This is the "will this key
+    be expired at our next audit?" support scenario."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    epoch = int(time.time()) + 60 * 86400
+    assert app.lic.is_expired_at(epoch) is True
+
+
+def test_is_expired_at_past_epoch_before_issuance(app):
+    """A perspective epoch BEFORE the current time on an active key ->
+    False (the key was not yet expired then, since exp is even further
+    in the future)."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    epoch = int(time.time()) - 10 * 86400
+    assert app.lic.is_expired_at(epoch) is False
+
+
+def test_is_expired_at_exact_exp_epoch(app):
+    """At the exact ``exp`` second, the predicate must fire ``True`` --
+    the ``<= epoch`` cutoff matches :func:`is_expired`'s
+    ``status == "expired"`` derivation (which uses ``exp <= now``)."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    info = app.lic.current_license_info()
+    assert isinstance(info, dict)
+    exp = info["exp"]
+    assert app.lic.is_expired_at(exp) is True
+    assert app.lic.is_expired_at(exp - 1) is False
+
+
+def test_is_expired_at_lapsed_key_still_fires_true_at_now(app):
+    """A lapsed-but-signed key evaluated at "now" -> True (the current
+    support scenario). Deliberately lenient on expiry NOW, unlike
+    :func:`is_expiring_at`."""
+    _write_key_direct(app, exp_delta=-5 * 86400)
+    assert app.lic.is_expired_at(int(time.time())) is True
+
+
+def test_is_expired_at_lapsed_key_false_at_pre_lapse_epoch(app):
+    """A lapsed-but-signed key evaluated at a perspective epoch BEFORE
+    its ``exp`` -> False. The retrospective question "was this expired
+    on <date> a week before it lapsed?" is answerable without special-
+    casing the expired branch."""
+    _write_key_direct(app, exp_delta=-5 * 86400)  # exp = now - 5d
+    # Perspective 20 days before now = 15 days before exp -> not yet expired.
+    epoch = int(time.time()) - 20 * 86400
+    assert app.lic.is_expired_at(epoch) is False
+
+
+def test_is_expired_at_perpetual_license(app):
+    """Perpetual (no ``exp``) license -> False regardless of perspective
+    epoch. Nothing to compare against; matches :func:`is_expired`'s
+    False branch for perpetual keys."""
+    tok = app.lic._encode_token(_payload(drop_exp=True), app.priv)
+    import os
+
+    os.makedirs(os.path.dirname(app.license_path), exist_ok=True)
+    with open(app.license_path, "w", encoding="utf-8") as fh:
+        fh.write(tok)
+    assert app.lic.is_expired_at(int(time.time())) is False
+    assert app.lic.is_expired_at(0) is False
+    assert app.lic.is_expired_at(2_000_000_000) is False
+
+
+def test_is_expired_at_invalid_signature(app):
+    """File on disk but signature bogus -> False. We refuse to trust
+    ``exp`` on an unsigned payload -- an attacker could stuff any value
+    into it. Matches :func:`is_expired`'s untrusted-body posture."""
+    import os
+
+    os.makedirs(os.path.dirname(app.license_path), exist_ok=True)
+    with open(app.license_path, "w", encoding="utf-8") as fh:
+        fh.write("CLAW1.garbage.garbage")
+    assert app.lic.is_expired_at(int(time.time())) is False
+    assert app.lic.is_expired_at(2_000_000_000) is False
+
+
+def test_is_expired_at_non_numeric_epoch(app):
+    """A caller passing a typo must get False, not a crash."""
+    tok = app.lic._encode_token(_payload(exp_delta=-5 * 86400), app.priv)
+    import os
+
+    os.makedirs(os.path.dirname(app.license_path), exist_ok=True)
+    with open(app.license_path, "w", encoding="utf-8") as fh:
+        fh.write(tok)
+    assert app.lic.is_expired_at("garbage") is False  # type: ignore[arg-type]
+    assert app.lic.is_expired_at(None) is False  # type: ignore[arg-type]
+    assert app.lic.is_expired_at([1]) is False  # type: ignore[arg-type]
+    assert app.lic.is_expired_at({}) is False  # type: ignore[arg-type]
+
+
+def test_is_expired_at_bool_epoch_rejected(app):
+    """``bool`` is an ``int`` subclass -- explicitly refuse it so a
+    caller that passes ``True`` doesn't silently ask "was the key expired
+    at epoch 1?" and get a positive answer back."""
+    # Use a lapsed key so the question "expired at epoch 1?" would
+    # otherwise trivially answer True on the (exp <= 1) cutoff -- proving
+    # the refusal is real, not accidental.
+    _write_key_direct(app, exp_delta=-5 * 86400)
+    assert app.lic.is_expired_at(True) is False  # type: ignore[arg-type]
+    assert app.lic.is_expired_at(False) is False  # type: ignore[arg-type]
+
+
+def test_is_expired_at_float_epoch_coerced(app):
+    """Float epoch must coerce through ``int()`` rather than crash --
+    same posture as :func:`is_expiring_at` / :func:`days_until_expiry_at`."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    now_f = float(time.time())
+    assert app.lic.is_expired_at(now_f) is False
+
+
+def test_is_expired_at_never_raises(monkeypatch):
+    """Any underlying failure -> False. Even a fully-broken
+    license_expires_at() must not propagate."""
+    import clawmetry.license as _lic
+
+    def _boom():
+        raise RuntimeError("simulated corrupt install")
+
+    monkeypatch.setattr(_lic, "license_expires_at", _boom)
+    assert _lic.is_expired_at(int(time.time())) is False
+
+
+# -- GET /api/license/is-expired-at -------------------------------------------
+
+
+def test_endpoint_is_expired_at_no_license(app):
+    with app.app.test_client() as c:
+        resp = c.get(f"/api/license/is-expired-at?epoch={int(time.time())}")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["is_expired_at"] is False
+    assert isinstance(data["requested_epoch"], int)
+    assert data["expires_at"] is None
+    assert data["has_license"] is False
+    assert data["valid"] is False
+
+
+def test_endpoint_is_expired_at_active_at_now(app):
+    """Active key at "now" -> is_expired_at false, valid true, expires_at
+    populated for the sibling tile that renders the date."""
+    tok = app.lic._encode_token(_payload(exp_delta=45 * 86400), app.priv)
+    app.lic.activate(tok)
+    now = int(time.time())
+    with app.app.test_client() as c:
+        resp = c.get(f"/api/license/is-expired-at?epoch={now}")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["is_expired_at"] is False
+    assert data["requested_epoch"] == now
+    assert isinstance(data["expires_at"], int)
+    assert data["has_license"] is True
+    assert data["valid"] is True
+
+
+def test_endpoint_is_expired_at_active_at_future_after_exp(app):
+    """Active key evaluated at a perspective epoch AFTER ``exp`` ->
+    is_expired_at true, valid still true (the key is not expired NOW)."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    epoch = int(time.time()) + 60 * 86400
+    with app.app.test_client() as c:
+        resp = c.get(f"/api/license/is-expired-at?epoch={epoch}")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["is_expired_at"] is True
+    assert data["requested_epoch"] == epoch
+    assert isinstance(data["expires_at"], int)
+    assert data["has_license"] is True
+    assert data["valid"] is True
+
+
+def test_endpoint_is_expired_at_lapsed_key_at_now(app):
+    """Lapsed-but-signed key at "now" -> is_expired_at true, valid FALSE
+    (signature valid but expired now). Retrospective banner can bind
+    is_expired_at; a caller that wants to hide the row on lapsed keys
+    still has the ``valid`` signal."""
+    _write_key_direct(app, exp_delta=-5 * 86400)
+    now = int(time.time())
+    with app.app.test_client() as c:
+        resp = c.get(f"/api/license/is-expired-at?epoch={now}")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["is_expired_at"] is True
+    assert data["has_license"] is True
+    assert data["valid"] is False
+
+
+def test_endpoint_is_expired_at_lapsed_key_at_pre_lapse_epoch(app):
+    """Lapsed-but-signed key at a perspective epoch BEFORE its ``exp`` ->
+    is_expired_at false, valid still false (key is expired NOW). The
+    predicate flips independently of the current-state validity."""
+    _write_key_direct(app, exp_delta=-5 * 86400)
+    epoch = int(time.time()) - 20 * 86400
+    with app.app.test_client() as c:
+        resp = c.get(f"/api/license/is-expired-at?epoch={epoch}")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["is_expired_at"] is False
+    assert data["has_license"] is True
+    assert data["valid"] is False
+
+
+def test_endpoint_is_expired_at_perpetual_license(app):
+    """Perpetual license -> is_expired_at false at any epoch. expires_at
+    null because no ``exp`` claim; has_license true (there IS a file)."""
+    tok = app.lic._encode_token(_payload(drop_exp=True), app.priv)
+    import os
+
+    os.makedirs(os.path.dirname(app.license_path), exist_ok=True)
+    with open(app.license_path, "w", encoding="utf-8") as fh:
+        fh.write(tok)
+    with app.app.test_client() as c:
+        resp = c.get(f"/api/license/is-expired-at?epoch={int(time.time())}")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["is_expired_at"] is False
+    assert data["expires_at"] is None
+    assert data["has_license"] is True
+
+
+def test_endpoint_is_expired_at_missing_epoch_arg(app):
+    """No ``epoch=`` -> is_expired_at false, requested_epoch null, HTTP
+    200. The snapshot still populates expires_at from the on-disk key."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    with app.app.test_client() as c:
+        resp = c.get("/api/license/is-expired-at")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["is_expired_at"] is False
+    assert data["requested_epoch"] is None
+    assert isinstance(data["expires_at"], int)
+    assert data["has_license"] is True
+
+
+def test_endpoint_is_expired_at_non_integer_epoch(app):
+    """Typo epoch -> is_expired_at false, requested_epoch null, HTTP 200
+    (never a 4xx). Mirrors the ``/api/license/is-expiring-at`` posture."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    with app.app.test_client() as c:
+        resp = c.get("/api/license/is-expired-at?epoch=garbage")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["is_expired_at"] is False
+    assert data["requested_epoch"] is None
+    assert data["has_license"] is True
+
+
+def test_endpoint_is_expired_at_invalid_signature(app):
+    """File on disk but signature bogus -> is_expired_at false (we refuse
+    to trust ``exp``), has_license True (there IS a file), valid False."""
+    import os
+
+    os.makedirs(os.path.dirname(app.license_path), exist_ok=True)
+    with open(app.license_path, "w", encoding="utf-8") as fh:
+        fh.write("CLAW1.garbage.garbage")
+    with app.app.test_client() as c:
+        resp = c.get(f"/api/license/is-expired-at?epoch={int(time.time())}")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["is_expired_at"] is False
+    assert data["has_license"] is True
+    assert data["valid"] is False
+
+
+def test_endpoint_is_expired_at_never_5xxs(app, monkeypatch):
+    """Even if the shared snapshot blows up mid-request, the endpoint
+    must still return HTTP 200 with the OSS-free shape (snapshot fallback
+    kicks in, requested_epoch is still echoed, is_expired_at is false)."""
+    from routes import entitlement as _routes
+
+    monkeypatch.setattr(
+        _routes,
+        "_license_expires_snapshot",
+        lambda: (_ for _ in ()).throw(RuntimeError("simulated blowup")),
+    )
+    epoch = int(time.time())
+    with app.app.test_client() as c:
+        resp = c.get(f"/api/license/is-expired-at?epoch={epoch}")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["is_expired_at"] is False
+    assert data["requested_epoch"] == epoch
+    assert data["expires_at"] is None
+    assert data["has_license"] is False
+    assert data["valid"] is False
+
+
+# -- cross-endpoint consistency ------------------------------------------------
+
+
+def test_endpoint_agrees_with_is_expired_at_now(app):
+    """When ``epoch`` equals "now", the perspective endpoint must agree
+    with ``/api/license/is-expired`` at the boundary. Both derive from
+    the same signed ``exp`` claim and use the same ``<=`` cutoff so a
+    UI binding both cannot catch them disagreeing for the same install."""
+    tok = app.lic._encode_token(_payload(exp_delta=45 * 86400), app.priv)
+    app.lic.activate(tok)
+    now = int(time.time())
+    with app.app.test_client() as c:
+        a = c.get(f"/api/license/is-expired-at?epoch={now}").get_json()
+        b = c.get("/api/license/is-expired").get_json()
+    assert a["is_expired_at"] == b["expired"] == False  # noqa: E712
+
+
+def test_endpoint_agrees_with_is_expired_at_now_on_lapsed(app):
+    """Lapsed-key parity: the perspective endpoint at "now" and the base
+    endpoint must both fire ``true`` on a signed-but-lapsed key."""
+    _write_key_direct(app, exp_delta=-5 * 86400)
+    now = int(time.time())
+    with app.app.test_client() as c:
+        a = c.get(f"/api/license/is-expired-at?epoch={now}").get_json()
+        b = c.get("/api/license/is-expired").get_json()
+    assert a["is_expired_at"] is True
+    assert b["expired"] is True
+
+
+def test_endpoint_shared_snapshot_matches_days_until_expiry_at(app):
+    """All three perspective-epoch endpoints share
+    :func:`_license_expires_snapshot` -- they must surface identical
+    ``expires_at`` / ``has_license`` / ``valid`` for the same install
+    regardless of the epoch queried. If this test fails on ``expires_at``
+    or ``valid``, a UI binding two of the three could catch them
+    disagreeing on a shared field."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    epoch = int(time.time()) + 5 * 86400
+    with app.app.test_client() as c:
+        a = c.get(f"/api/license/is-expired-at?epoch={epoch}").get_json()
+        b = c.get(f"/api/license/days-until-expiry-at?epoch={epoch}").get_json()
+        d = c.get(f"/api/license/is-expiring-at?epoch={epoch}").get_json()
+    for key in ("expires_at", "has_license", "valid"):
+        assert a[key] == b[key] == d[key], (
+            f"mismatch on {key}: is-expired-at={a[key]!r} "
+            f"days-until-expiry-at={b[key]!r} is-expiring-at={d[key]!r}"
+        )
+    assert a["requested_epoch"] == b["requested_epoch"] == d["requested_epoch"] == epoch


### PR DESCRIPTION
## Summary

- Adds `clawmetry.license.is_expired_at(epoch: int) -> bool`, the perspective-epoch flavour of `is_expired()`. Answers "was the installed license expired evaluated as of `epoch`?" without the caller having to snapshot the license state at that time or compare `exp` against a caller-supplied epoch themselves. Mirrors the existing `is_expiring_at(epoch)` predicate and the `days_until_expiry_at(epoch)` scalar: same coerced-through-`int()` input handling, same `bool`-is-refused guard, same never-raise fallback.
- Adds `GET /api/license/is-expired-at?epoch=` on `bp_entitlement`. Envelope carries `is_expired_at` (bool), `requested_epoch` (echoed), `expires_at`, `has_license`, `valid` — same quartet-plus-echo as `/api/license/is-expiring-at` and `/api/license/days-until-expiry-at` so all three share the `_license_expires_snapshot()` reader and a UI binding any two cannot catch them disagreeing on install-state fields for the same install.

Posture notes (mirrors `is_expired()` and `days_until_expiry_at()`):
- **Deliberately lenient on expiry NOW**, unlike `is_expiring_at()` (which refuses lapsed keys because a renewal-window predicate on a lapsed key would gate the WRONG UI). A retrospective "was this expired on `<date>`?" tile absolutely should keep firing `true` on a lapsed key at any epoch past `exp` — that IS the entire support scenario — so the underlying "signature-valid" check does NOT roll in the "not expired now" clause the sibling `is_expiring_at()` uses. Callers that DO want to gate off the current-state validity still have the `valid` field on the endpoint envelope.
- **When `epoch` equals "now", the predicate must agree with `is_expired()`** for the same install — both derive from the same signed `exp` claim and use the same `<=` cutoff, so the two scalars cannot disagree at the boundary. Covered by two tests (active-key and lapsed-key parity).
- **`bool` is refused explicitly** despite being an `int` subclass, so a caller that passes `True` on a lapsed key doesn't silently ask "was the key expired at epoch 1?" and get a spurious positive answer back. The lapsed-key setup in the test proves the refusal is real, not accidental (the `exp <= 1` cutoff would otherwise trivially match).
- **Non-integer `epoch` collapses to `is_expired_at=false` + `requested_epoch=null`, HTTP 200**: the bad-input signal is the `false` result, not a 4xx, matching the never-crash posture of the surrounding license endpoints.
- **Invalid signature collapses to `false`**: the payload cannot be trusted (an attacker could stuff any `exp` into an unsigned body), matching how `license_expires_at()` refuses that branch.
- **Perpetual keys (no `exp` claim) collapse to `false`** regardless of `epoch` — nothing to compare against, mirroring `is_expired()`'s False branch for perpetual keys.

Cross-endpoint consistency covered by three tests: the perspective endpoint at `epoch=now` agrees with `/api/license/is-expired` on both active keys and lapsed keys (both use `exp <= now`), and the shared `_license_expires_snapshot()` guarantees `expires_at` / `has_license` / `valid` match `/api/license/is-expiring-at` and `/api/license/days-until-expiry-at` exactly for the same install (all three shape-endpoints tested together in a single query so a mismatch on any of the three is caught).

Zero behaviour change: purely additive, read-only. No new gate is enforced, no tier logic is altered.

## Test plan

- [x] `python3 -m pytest tests/test_license_is_expired_at.py -q` — **28 passed**
- [x] `python3 -m pytest tests/test_license_days_until_expiry_at.py tests/test_license_days_until_expiry.py tests/test_license_is_expired_is_perpetual.py tests/test_license_expires_at_scalar.py tests/test_license.py tests/test_license_api.py tests/test_entitlement_api.py tests/test_entitlement_api_fallback_shape.py -q` — **249 passed**, no regressions in adjacent license/entitlement suite
- [x] `ruff check clawmetry/license.py routes/entitlement.py tests/test_license_is_expired_at.py` — clean
- [x] `python3 -m py_compile clawmetry/license.py routes/entitlement.py tests/test_license_is_expired_at.py` — clean

### Local operator verification checklist (I can't reach the running daemon or a browser from this environment)

- [ ] Copy `clawmetry/license.py`, `routes/entitlement.py`, and `tests/test_license_is_expired_at.py` into `~/.clawmetry/lib/pythonX.Y/site-packages/clawmetry/` and `.../site-packages/routes/`.
- [ ] Clear `__pycache__` under both directories.
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` to restart the daemon.
- [ ] `curl -s "http://localhost:8900/api/license/is-expired-at?epoch=$(date +%s)" | jq .` — on an active install, expect `{"is_expired_at": false, "requested_epoch": <int>, "expires_at": <int>, "has_license": true, "valid": true}`; on OSS-free, expect `{"is_expired_at": false, "requested_epoch": <int>, "expires_at": null, "has_license": false, "valid": false}`.
- [ ] `curl -s "http://localhost:8900/api/license/is-expired-at?epoch=$(($(date +%s) + 86400*365*10))" | jq .` — perspective 10 years from now on an active key; `is_expired_at` should flip to `true` (assuming the key expires in less than 10 years), `valid` still `true` (not expired NOW). Confirms the retrospective/future predicate is decoupled from current-state validity.
- [ ] `curl -s "http://localhost:8900/api/license/is-expired-at?epoch=$(($(date +%s) - 86400*365*10))" | jq .` — perspective 10 years ago; expect `is_expired_at: false` on any signed key (`exp` is definitely > `epoch` there).
- [ ] `curl -s "http://localhost:8900/api/license/is-expired-at?epoch=garbage" | jq .` — expect `{"is_expired_at": false, "requested_epoch": null, ...}` with HTTP 200 (never a 4xx).
- [ ] `curl -s "http://localhost:8900/api/license/is-expired-at" | jq .` — no `epoch=` arg; expect `is_expired_at=false`, `requested_epoch=null`, HTTP 200.
- [ ] Cross-check: `expires_at` / `has_license` / `valid` on `/api/license/is-expired-at?epoch=<X>` must equal the same three fields on both `/api/license/is-expiring-at?epoch=<X>` and `/api/license/days-until-expiry-at?epoch=<X>` for the same install (they share `_license_expires_snapshot()`).
- [ ] Boundary check: on an active install, `/api/license/is-expired-at?epoch=$(date +%s)` must return the same value as `/api/license/is-expired`'s `expired` field (both compute `exp <= now`).
- [ ] Decrypt the live cloud snapshot and browser-check the dashboard still loads (this PR touches shared license helpers but does not change any existing behaviour).

Marked draft — the local operator handles daemon verification, cloud-snapshot verification, release, and merge per FLYWHEEL.md.

---
_Generated by [Claude Code](https://claude.ai/code/session_011H3jRi7i9Be97q5s48emwG)_