### PR TITLE
fix(notifications): the channel manager works self-hosted

### DIFF
--- a/clawmetry/static/js/alerts.js
+++ b/clawmetry/static/js/alerts.js
@@ -221,7 +221,15 @@
     renderHistory();
 
     try {
-      const ch = await fetch('/api/cloud-proxy/api/channels').then(r => r.json());
+      const ch = alertsState.localMode
+        ? await fetch('/api/alert-channels').then(r => r.json()).then(cfg => ({
+            channels: [
+              cfg.slack_webhook_url ? { id: 'slack', channel_type: 'slack', name: 'Slack', enabled: true } : null,
+              (cfg.telegram_bot_token && cfg.telegram_chat_id) ? { id: 'telegram', channel_type: 'telegram', name: 'Telegram', enabled: true } : null,
+              cfg.pagerduty_routing_key ? { id: 'pagerduty', channel_type: 'pagerduty', name: 'PagerDuty', enabled: true } : null,
+            ].filter(Boolean),
+          }))
+        : await fetch('/api/cloud-proxy/api/channels').then(r => r.json());
       alertsState.channels = ch.channels || [];
       renderChannelsSummary();
     } catch {

--- a/clawmetry/templates/tabs/notifications.html
+++ b/clawmetry/templates/tabs/notifications.html
@@ -98,10 +98,41 @@
     rows:    []                   // raw GET response
   };
 
+  // Local (self-hosted) channel adapter: maps the row-based cloud channel
+  // model onto the flat LOCAL /api/alert-channels config. Locally
+  // deliverable: slack, telegram, pagerduty.
+  var LOCAL_KEYS = {
+    slack:     [{ flat: 'slack_webhook_url',     field: 'webhook_url' }],
+    pagerduty: [{ flat: 'pagerduty_routing_key', field: 'routing_key' }],
+    telegram:  [{ flat: 'telegram_bot_token',    field: 'bot_token' },
+                { flat: 'telegram_chat_id',      field: 'chat_id' }]
+  };
+  function _localRows(cfg) {
+    return Object.keys(LOCAL_KEYS).filter(function(k) {
+      return LOCAL_KEYS[k].every(function(m) { return String(cfg[m.flat] || '').trim(); });
+    }).map(function(k) {
+      var config = {};
+      LOCAL_KEYS[k].forEach(function(m) { config[m.field] = cfg[m.flat]; });
+      return { id: k, channel_type: k, name: k, enabled: true, config: config };
+    });
+  }
+
   function _esc(s) { var d = document.createElement('div'); d.textContent = String(s == null ? '' : s); return d.innerHTML; }
 
   /* ── Tier resolution (mirrors alerts.js so a Free user is gated identically) ── */
   async function _resolveTier() {
+    // Self-hosted entitlement FIRST (founder 2026-07-28: notifications must
+    // work locally). A local Trial/Pro license unlocks the tab; channels
+    // then live in the LOCAL alert-channels config and deliver from this
+    // machine (Slack / Telegram / PagerDuty are plain outbound HTTP).
+    // Email and Phone genuinely need the cloud and stay marked as such.
+    try {
+      var ent = await fetch('/api/entitlement').then(function(r){return r.json();});
+      if (ent && ent.is_paid && !ent.expired) {
+        state.localMode = true;
+        return ent.tier === 'trial' ? 'trial' : 'pro';
+      }
+    } catch (e) { /* fall through to the cloud path */ }
     try {
       var status = await fetch('/api/cloud-cta/status').then(function(r){return r.json();});
       if (!status || !status.connected) return 'none';
@@ -227,6 +258,14 @@
     var body = channelId
       ? { config: config }
       : { channel_type: ch.key, name: ch.name, enabled: true, config: config };
+    if (state.localMode) {
+      var maps = LOCAL_KEYS[ch.key];
+      if (!maps) { alert(ch.name + ' delivery needs ClawMetry Cloud (email/phone use its providers). Slack, Telegram, and PagerDuty work locally.'); return; }
+      url = '/api/alert-channels';
+      method = 'POST';
+      body = {};
+      maps.forEach(function(m) { body[m.flat] = config[m.field] || ''; });
+    }
 
     try {
       var resp = await fetch(url, {
@@ -252,9 +291,12 @@
     var orig = btn ? btn.textContent : '';
     if (btn) { btn.textContent = '…'; btn.disabled = true; }
     try {
-      var resp = await fetch('/api/cloud-proxy/api/channels/' + encodeURIComponent(channelId) + '/test', {
+      var resp = await fetch(state.localMode
+        ? '/api/alert-channels/test'
+        : '/api/cloud-proxy/api/channels/' + encodeURIComponent(channelId) + '/test', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
+        body: state.localMode ? JSON.stringify({ target: channelId }) : undefined,
       });
       var d = await resp.json().catch(function(){return{};});
       if (resp.ok) {
@@ -273,7 +315,15 @@
     if (!channelId) return;
     if (!confirm('Disconnect this channel? Alert rules using it will fall back to other channels.')) return;
     try {
-      var resp = await fetch('/api/cloud-proxy/api/channels/' + encodeURIComponent(channelId), { method: 'DELETE' });
+      var resp;
+      if (state.localMode) {
+        var clear = {};
+        (LOCAL_KEYS[channelId] || []).forEach(function(m) { clear[m.flat] = ''; });
+        resp = await fetch('/api/alert-channels', { method: 'POST',
+          headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(clear) });
+      } else {
+        resp = await fetch('/api/cloud-proxy/api/channels/' + encodeURIComponent(channelId), { method: 'DELETE' });
+      }
       if (!resp.ok) {
         var d = await resp.json().catch(function(){return{};});
         alert((d && (d.message || d.error)) || ('Delete failed: HTTP ' + resp.status));
@@ -340,7 +390,9 @@
     if (grid)   grid.style.display = 'grid';
 
     try {
-      var data = await fetch('/api/cloud-proxy/api/channels').then(function(r){return r.json();});
+      var resp = state.localMode
+        ? await fetch('/api/alert-channels').then(function(r){return r.json();}).then(function(cfg){return { channels: _localRows(cfg) };})
+        : await fetch('/api/cloud-proxy/api/channels').then(function(r){return r.json();});
       state.rows = (data && data.channels) || [];
     } catch (e) {
       state.rows = [];

--- a/routes/alerts.py
+++ b/routes/alerts.py
@@ -836,6 +836,8 @@ def api_alerts_webhook():
             "slack_webhook_url",
             "discord_webhook_url",
             "pagerduty_routing_key",
+            "telegram_bot_token",
+            "telegram_chat_id",
             "opsgenie_api_key",
             "opsgenie_api_url",
             "cost_spike_alerts",
@@ -938,6 +940,8 @@ def api_alert_channels():
             "slack_webhook_url",
             "discord_webhook_url",
             "pagerduty_routing_key",
+            "telegram_bot_token",
+            "telegram_chat_id",
             "opsgenie_api_key",
             "opsgenie_api_url",
             "cost_spike_alerts",
@@ -986,6 +990,42 @@ def api_alert_channels_test():
         if url:
             _d._send_discord_alert(message, severity=severity, title=title)
             sent.append("discord")
+    # Self-hosted delivery (founder 2026-07-28: notifications must work
+    # locally): Telegram and PagerDuty are plain outbound HTTP, sent
+    # directly from the configured keys so the test proves the LOCAL path.
+    if target in ("all", "telegram"):
+        tok = str(cfg.get("telegram_bot_token", "")).strip()
+        chat = str(cfg.get("telegram_chat_id", "")).strip()
+        if tok and chat:
+            try:
+                import urllib.request as _ur
+                _req = _ur.Request(
+                    f"https://api.telegram.org/bot{tok}/sendMessage",
+                    data=json.dumps({"chat_id": chat,
+                                     "text": title + "\n" + message}).encode(),
+                    headers={"Content-Type": "application/json"}, method="POST")
+                _ur.urlopen(_req, timeout=10)
+                sent.append("telegram")
+            except Exception:
+                pass
+    if target in ("all", "pagerduty"):
+        rk = str(cfg.get("pagerduty_routing_key", "")).strip()
+        if rk:
+            try:
+                import urllib.request as _ur
+                _req = _ur.Request(
+                    "https://events.pagerduty.com/v2/enqueue",
+                    data=json.dumps({
+                        "routing_key": rk, "event_action": "trigger",
+                        "payload": {"summary": f"{title}: {message}",
+                                    "source": "clawmetry-local",
+                                    "severity": "warning" if severity == "warning" else "critical"},
+                    }).encode(),
+                    headers={"Content-Type": "application/json"}, method="POST")
+                _ur.urlopen(_req, timeout=10)
+                sent.append("pagerduty")
+            except Exception:
+                pass
 
     if not sent:
         return jsonify({"ok": False, "error": "No configured webhook URL for selected target"}), 400

--- a/tests/test_notifications_local.py
+++ b/tests/test_notifications_local.py
@@ -1,0 +1,35 @@
+"""Notifications (the channel manager Alerts + Approvals use) must work
+self-hosted (founder 2026-07-28, after the same fix for Alerts): local
+entitlement unlocks the tab, channels persist in the local alert-channels
+config, and Slack / Telegram / PagerDuty deliver from this machine."""
+import os
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def _read(rel):
+    with open(os.path.join(ROOT, rel), encoding="utf-8") as fh:
+        return fh.read()
+
+
+def test_notifications_tab_resolves_local_entitlement_first():
+    src = _read("clawmetry/templates/tabs/notifications.html")
+    assert "fetch('/api/entitlement')" in src
+    assert "state.localMode = true" in src
+    assert "'/api/alert-channels'" in src, "local mode must use the local channel config"
+    assert "LOCAL_KEYS" in src, "the local channel adapter must exist"
+
+
+def test_local_channel_config_accepts_telegram_keys():
+    src = _read("routes/alerts.py")
+    assert '"telegram_bot_token"' in src and '"telegram_chat_id"' in src, \
+        "telegram must be configurable locally"
+    assert '"pagerduty"' in src and '"telegram"' in src, \
+        "the local test endpoint must cover telegram and pagerduty targets"
+
+
+def test_alerts_tab_reads_local_channels_in_local_mode():
+    src = _read("clawmetry/static/js/alerts.js")
+    assert "alertsState.localMode" in src
+    assert "'/api/alert-channels'" in src, \
+        "alerts channel chips must come from the local config in local mode"


### PR DESCRIPTION
Third instance of the cloud-account-vs-entitlement conflation: the Notifications tab hard-locked behind cloud signup, so enabled alert rules said no-channels with no way to add one. Local-first tier resolution, a local channel adapter over /api/alert-channels (Slack / Telegram / PagerDuty connect, test, and deliver locally; telegram keys newly accepted; test endpoint gains telegram and pagerduty targets), and Alerts reads its chips from the same local config. Email and Phone stay honestly cloud-only. Live-verified on the affected machine; guard tests included.