### PR TITLE
fix(brain): the full event log is visible, nothing stripped

### DIFF
--- a/clawmetry/static/css/dashboard.css
+++ b/clawmetry/static/css/dashboard.css
@@ -89,7 +89,7 @@
   /* Force the per-turn summary onto its own row, full-width, indented past
      the time column so it visually attaches to the event above. */
   .brain-event > .brain-turn-summary { flex-basis: 100%; width: 100%; margin-left: 80px; margin-top: 4px; }
-  .brain-event.expanded .brain-detail { white-space:pre-wrap; overflow:visible; text-overflow:unset; }
+  .brain-event.expanded .brain-detail { white-space:pre-wrap; overflow:visible; text-overflow:unset; -webkit-line-clamp:unset; display:block; }
   .brain-meta { display:contents; } /* Desktop: render children directly in brain-event flex row */
   .brain-time { color:var(--text-muted); min-width:70px; }
   .brain-source { min-width:120px; max-width:200px; font-weight:600; word-break:break-all; flex-shrink:0; }
@@ -105,6 +105,10 @@
   .badge-error { background:rgba(239,68,68,0.2); color:#ef4444; }
   .badge-tool { background:rgba(148,163,184,0.2); color:#94a3b8; }
   .brain-detail { color:var(--text-secondary); flex:1; min-width:0; white-space:pre-wrap; word-break:break-word; overflow-wrap:anywhere; }
+  /* The server now sends the FULL event body (no 200-char strip). Keep the
+     collapsed feed scannable by line-clamping unexpanded rows; a click
+     expands to the complete text (rule above unclamps). */
+  .brain-event:not(.expanded) .brain-detail { display:-webkit-box; -webkit-line-clamp:3; -webkit-box-orient:vertical; overflow:hidden; }
   /* Plumbing rows (QUEUE-OPERATION) when revealed via toggle:
      visibly de-emphasized so they don't compete with real content. */
   .brain-event.brain-plumbing { opacity:0.55; font-size:11px; padding:2px 0; }

--- a/routes/brain.py
+++ b/routes/brain.py
@@ -493,10 +493,23 @@ def _try_local_store_brain(limit, include_artifacts, since=None, until=None):
         # shapes (legacy, v3 mapper top-level, v3 mapper mirror).
         detail = _extract_brain_detail(r)
         evt_type = (r.get("event_type") or "").upper()
+        if evt_type == "THINKING" and not str(detail).strip():
+            # Claude Code (and siblings) persist extended thinking as an
+            # ENCRYPTED signature block — the text itself is never written to
+            # the transcript (live-verified: 633/633 thinking blocks on a real
+            # machine were signature-only). Label the row honestly instead of
+            # rendering an empty line that reads as a truncation bug.
+            detail = "(thinking encrypted by the runtime; no text stored)"
         row = {
             "time":       r.get("ts", ""),
             "type":       evt_type,
-            "detail":     str(detail)[:200],
+            # FULL detail — no serve-time cap. The founder hit MESSAGE rows cut
+            # at exactly 200 chars mid-word ("the full log should be visible
+            # without stripping anything"). Size is already bounded upstream:
+            # tool-result bodies are capped at ingest (64 KB) and message/
+            # thinking text is whatever the model actually wrote. Collapsed
+            # rows are line-clamped client-side; click expands to everything.
+            "detail":     str(detail),
             "src":        (r.get("session_id") or r.get("agent_id") or "")[:32],
             "sessionId":  r.get("session_id") or "",
             "agentId":    r.get("agent_id") or "main",
@@ -1011,7 +1024,7 @@ def api_brain_history():
                                 "source": source_id,
                                 "sourceLabel": source_label,
                                 "type": "RESULT",
-                                "detail": text[:300],
+                                "detail": text,
                                 "color": color,
                             }
                         )
@@ -1035,7 +1048,7 @@ def api_brain_history():
                                 "source": source_id,
                                 "sourceLabel": source_label,
                                 "type": "USER",
-                                "detail": text[:300],
+                                "detail": text,
                                 "color": color,
                                 "taskType": _classify_task_type(text),
                             }
@@ -1057,7 +1070,7 @@ def api_brain_history():
                                         "source": source_id,
                                         "sourceLabel": source_label,
                                         "type": "THINK",
-                                        "detail": thinking_text[:300],
+                                        "detail": thinking_text,
                                         "color": color,
                                     }
                                 )
@@ -1073,7 +1086,7 @@ def api_brain_history():
                                         "source": source_id,
                                         "sourceLabel": source_label,
                                         "type": "AGENT",
-                                        "detail": text[:300],
+                                        "detail": text,
                                         "color": color,
                                         "taskType": _classify_task_type(text),
                                     }
@@ -1727,27 +1740,27 @@ def api_brain_stream():
         return "TOOL"
 
     def extract_detail(tn, inp):
+        # FULL detail — no truncation (matches the brain-history copy; the
+        # founder asked for the full log with nothing stripped).
         tn = tn.lower()
         if not isinstance(inp, dict):
-            return str(inp)[:300]
+            return str(inp)
         if tn == "exec" or "shell" in tn or "bash" in tn or tn == "process":
-            return (inp.get("command") or inp.get("action") or "")[:300]
+            return inp.get("command") or inp.get("action") or ""
         if "read" in tn:
-            return (inp.get("path") or inp.get("file_path") or "")[:300]
+            return inp.get("path") or inp.get("file_path") or ""
         if "write" in tn or "edit" in tn:
-            return (inp.get("path") or inp.get("file_path") or "")[:300]
+            return inp.get("path") or inp.get("file_path") or ""
         if "browser" in tn:
-            return (inp.get("url") or inp.get("targetUrl") or inp.get("action") or "")[
-                :300
-            ]
+            return inp.get("url") or inp.get("targetUrl") or inp.get("action") or ""
         if tn == "message":
-            return (inp.get("message") or inp.get("target") or "")[:300]
+            return inp.get("message") or inp.get("target") or ""
         if "search" in tn or "fetch" in tn:
-            return (inp.get("query") or inp.get("url") or "")[:300]
+            return inp.get("query") or inp.get("url") or ""
         if "subagent" in tn or "spawn" in tn:
-            return (inp.get("label") or str(inp.get("message", "")))[:300]
+            return inp.get("label") or str(inp.get("message", ""))
         vals = list(inp.values())
-        return (str(vals[0]) if vals else "")[:300]
+        return str(vals[0]) if vals else ""
 
     def _parse_jsonl_event(obj, source_id, source_label, color):
         """Parse a JSONL line into a brain event dict, or return None."""
@@ -1778,7 +1791,7 @@ def api_brain_stream():
                             "source": source_id,
                             "sourceLabel": source_label,
                             "type": "THINK",
-                            "detail": thinking_text[:300],
+                            "detail": thinking_text,
                             "color": color,
                         }
                 if btype == "text":
@@ -1789,7 +1802,7 @@ def api_brain_stream():
                             "source": source_id,
                             "sourceLabel": source_label,
                             "type": "AGENT",
-                            "detail": text[:300],
+                            "detail": text,
                             "color": color,
                             "taskType": _classify_task_type(text),
                         }
@@ -1827,7 +1840,7 @@ def api_brain_stream():
                     "source": source_id,
                     "sourceLabel": source_label,
                     "type": "USER",
-                    "detail": text[:300],
+                    "detail": text,
                     "color": color,
                     "taskType": _classify_task_type(text),
                 }
@@ -1921,7 +1934,7 @@ def api_brain_stream():
                                 tool_kw = m.group(1).lower()
                                 rest = m.group(2).strip()
                                 ev_type = tool_to_type(tool_kw)
-                                detail = rest.split("\n")[0][:300]
+                                detail = rest.split("\n")[0]
                                 events.append(
                                     {
                                         "time": ts,

--- a/tests/test_brain_full_detail.py
+++ b/tests/test_brain_full_detail.py
@@ -1,0 +1,157 @@
+"""Brain feed serves the FULL event body — no serve-time truncation.
+
+Founder live-hit (2026-07-28): MESSAGE rows in the Activity/Brain feed were
+cut at exactly 200 characters mid-word ("the full log should be visible
+without stripping anything") and THINKING rows rendered as blank lines.
+
+Two guarantees, revert-proof against the old ``str(detail)[:200]`` cap in the
+local-store fast path:
+
+* a message event whose content is far longer than 200 chars is served
+  in full;
+* a thinking event with NO text (Claude Code persists extended thinking as
+  an encrypted signature block, so the text is genuinely absent from the
+  transcript) is served with an honest placeholder, not an empty string.
+"""
+
+from __future__ import annotations
+
+import importlib
+import time
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def app(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_BATCH", "5")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_READ", "1")
+
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    import routes.brain as br
+    importlib.reload(br)
+
+    import dashboard as _d
+    monkeypatch.setattr(_d, "_is_pro_user", lambda: True)
+
+    # Hermetic even on a dev machine with a LIVE daemon: force the daemon RPC
+    # to miss AND stop get_store() from returning a proxy to the live daemon,
+    # so the fast path direct-opens the tmp_path store (the CI shape).
+    import routes.local_query as lq
+    monkeypatch.setattr(lq, "local_store_via_daemon", lambda *a, **k: None)
+    monkeypatch.setattr(ls, "_daemon_registered", lambda: False, raising=False)
+
+    a = Flask(__name__)
+    a.register_blueprint(br.bp_brain)
+    yield a, ls
+    try:
+        ls.get_store().stop(flush=True)
+    except Exception:
+        pass
+
+
+def _wait_flush(store, t=2.0):
+    deadline = time.monotonic() + t
+    while time.monotonic() < deadline:
+        if store.health()["ring_depth"] == 0:
+            return
+        time.sleep(0.02)
+
+
+def test_message_detail_served_in_full(app):
+    a, ls = app
+    store = ls.get_store()
+    # 2,400 chars of distinct words: a [:200] (or any other silent cap) is
+    # guaranteed to drop the tail sentinel.
+    long_text = " ".join(f"word{i}" for i in range(300)) + " TAIL-SENTINEL"
+    assert len(long_text) > 2000
+    store.ingest({
+        "id": "ev-full-msg",
+        "node_id": "agent+test",
+        "agent_id": "main",
+        "session_id": "claude_code:sess-full",
+        "event_type": "message",
+        "ts": "2026-05-11T12:00:00Z",
+        "data": {"role": "assistant", "content": long_text,
+                 "_runtime": "claude_code"},
+        "cost_usd": 0.0,
+        "token_count": 10,
+        "model": "claude-opus-5",
+    })
+    _wait_flush(store)
+
+    c = a.test_client()
+    r = c.get("/api/brain-history?limit=10")
+    assert r.status_code == 200, r.get_data(as_text=True)[:300]
+    body = r.get_json()
+    assert body.get("_source") == "local_store"
+    rows = [ev for ev in body["events"] if ev["type"] == "MESSAGE"]
+    assert rows, body["events"]
+    detail = rows[0]["detail"]
+    # The old code served str(detail)[:200] — this is the revert trap.
+    assert len(detail) == len(long_text)
+    assert detail.endswith("TAIL-SENTINEL")
+
+
+def test_encrypted_thinking_gets_honest_placeholder(app):
+    a, ls = app
+    store = ls.get_store()
+    # Claude Code writes {"type":"thinking","thinking":"","signature":"…"} —
+    # the adapter's Event.content is "" and there is no text anywhere.
+    store.ingest({
+        "id": "ev-enc-think",
+        "node_id": "agent+test",
+        "agent_id": "main",
+        "session_id": "claude_code:sess-think",
+        "event_type": "thinking",
+        "ts": "2026-05-11T12:00:01Z",
+        "data": {"role": "assistant", "content": "",
+                 "_runtime": "claude_code"},
+        "cost_usd": 0.0,
+        "token_count": 0,
+        "model": "claude-opus-5",
+    })
+    _wait_flush(store)
+
+    c = a.test_client()
+    r = c.get("/api/brain-history?limit=10")
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body.get("_source") == "local_store"
+    rows = [ev for ev in body["events"] if ev["type"] == "THINKING"]
+    assert rows, body["events"]
+    assert rows[0]["detail"] == (
+        "(thinking encrypted by the runtime; no text stored)"
+    )
+
+
+def test_thinking_with_real_text_served_in_full(app):
+    """A runtime that DOES store thinking text gets it through untouched."""
+    a, ls = app
+    store = ls.get_store()
+    think = "let me reason about this " * 40  # 1,000 chars
+    store.ingest({
+        "id": "ev-real-think",
+        "node_id": "agent+test",
+        "agent_id": "main",
+        "session_id": "claude_code:sess-think2",
+        "event_type": "thinking",
+        "ts": "2026-05-11T12:00:02Z",
+        "data": {"role": "assistant", "content": think,
+                 "_runtime": "claude_code"},
+        "cost_usd": 0.0,
+        "token_count": 0,
+        "model": "claude-opus-5",
+    })
+    _wait_flush(store)
+
+    c = a.test_client()
+    r = c.get("/api/brain-history?limit=10")
+    body = r.get_json()
+    rows = [ev for ev in body["events"] if ev["type"] == "THINKING"]
+    assert rows
+    assert rows[0]["detail"] == think


### PR DESCRIPTION
## Why
Founder report: "why is full log not visible?? the full log should be visible without stripping anything". Every Activity/Brain feed row was cut at exactly 200 chars server-side (fast path) / 300 chars (legacy + SSE), mid-word, and clicking to expand showed the same stub because the server had already thrown the rest away. THINKING rows rendered blank.

## What
- `routes/brain.py`: full `detail` on the local-store fast path, the legacy JSONL path, and the SSE live stream. Size stays bounded upstream (64 KB ingest cap on tool-result bodies).
- Encrypted thinking (Claude Code stores only a signature; 633/633 blocks on the live machine) gets an honest placeholder instead of an empty line.
- `dashboard.css`: collapsed rows line-clamp to 3 lines so the feed stays scannable; the existing click-to-expand now actually reveals everything.

## Verified
- Live on the affected machine: `/api/brain-history` max detail length went 200 -> 3,622 (TOOL_RESULT), zero rows at exactly 200, THINKING rows labeled.
- `tests/test_brain_full_detail.py`: 3 tests green on the fix, red on the old code (`assert 200 == 2303`), hermetic against a live daemon (daemon RPC + proxy-store both neutralized).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
