### PR TITLE
fix(update): CI runners never self-update mid-job (kills the visual-diff flake)

### DIFF
--- a/routes/update_check.py
+++ b/routes/update_check.py
@@ -41,9 +41,26 @@ CHANGELOG_URL = "https://github.com/vivekchand/clawmetry/blob/main/CHANGELOG.md"
 
 def _env_auto_update_disabled():
     """Kill switch: ``CLAWMETRY_AUTO_UPDATE=0`` disables unattended upgrades
-    regardless of the stored config (fleet operators / CI / debugging)."""
+    regardless of the stored config (fleet operators / CI / debugging).
+
+    CI runners are implicitly disabled: an ephemeral runner must render the
+    code it was started with, never swap itself for the newest wheel mid-job.
+    The visual-diff harness proved why — whenever a [RELEASE] had just
+    published, the PR-branch dashboard (versioned one release behind) saw the
+    newer wheel on PyPI ~60s after boot, pip-updated, and exec-restarted in
+    the middle of the screenshot sweep; every subsequent page logged
+    ``base=200 head=0`` and the job failed. The failure rate tracked release
+    cadence, and the flywheel releases constantly (diagnosed 2026-07-29 after
+    three consecutive kills on #4181/#4182). ``CI`` is set by GitHub Actions,
+    GitLab, CircleCI, Travis, and Azure; explicit ``CLAWMETRY_AUTO_UPDATE=1``
+    re-arms it for anyone who genuinely wants in-CI self-update."""
     val = os.environ.get("CLAWMETRY_AUTO_UPDATE", "").strip().lower()
-    return val in ("0", "false", "no", "off")
+    if val in ("1", "true", "yes", "on"):
+        return False
+    if val in ("0", "false", "no", "off"):
+        return True
+    ci = os.environ.get("CI", "").strip().lower()
+    return ci not in ("", "0", "false")
 
 
 def _daemon_supervised():
@@ -668,7 +685,7 @@ def _maybe_auto_update(current, target, latest=None):
     if _auto_update_in_progress:
         return
     if _env_auto_update_disabled():
-        log.info("auto-update: disabled via CLAWMETRY_AUTO_UPDATE env")
+        log.info("auto-update: disabled (CLAWMETRY_AUTO_UPDATE=0 or CI env)")
         return
     cfg = _get_update_check_config()
     if not cfg.get("auto_update"):

--- a/tests/test_auto_update.py
+++ b/tests/test_auto_update.py
@@ -28,6 +28,10 @@ def _as_daemon(uc, monkeypatch):
     pip), which is covered by its own dedicated tests below.
     """
     monkeypatch.delenv("CLAWMETRY_AUTO_UPDATE", raising=False)
+    # These tests simulate a USER machine; GitHub Actions exports CI=true,
+    # which now implicitly disables auto-update (ephemeral runners must
+    # never swap themselves for a newer wheel mid-job).
+    monkeypatch.delenv("CI", raising=False)
     uc._process_role = "daemon"
     monkeypatch.setattr(uc, "_daemon_supervised", lambda: True)
     monkeypatch.setattr(uc, "_restart_plan", lambda r, p, s: "exit")
@@ -227,6 +231,10 @@ def test_dashboard_role_default_on_installs(monkeypatch):
     update_available=true.)"""
     uc = _uc()
     monkeypatch.delenv("CLAWMETRY_AUTO_UPDATE", raising=False)
+    # These tests simulate a USER machine; GitHub Actions exports CI=true,
+    # which now implicitly disables auto-update (ephemeral runners must
+    # never swap themselves for a newer wheel mid-job).
+    monkeypatch.delenv("CI", raising=False)
     assert uc._process_role == "dashboard"  # reload resets the role
     monkeypatch.setattr(uc, "_get_update_check_config", lambda: {"auto_update": True})
     monkeypatch.setattr(uc, "_dashboard_supervised", lambda: False)
@@ -305,6 +313,10 @@ def test_dashboard_fast_loop_gating(monkeypatch):
     """The dashboard polls on the fast cadence iff auto-update is on."""
     uc = _uc()
     monkeypatch.delenv("CLAWMETRY_AUTO_UPDATE", raising=False)
+    # These tests simulate a USER machine; GitHub Actions exports CI=true,
+    # which now implicitly disables auto-update (ephemeral runners must
+    # never swap themselves for a newer wheel mid-job).
+    monkeypatch.delenv("CI", raising=False)
     assert uc._process_role == "dashboard"
     monkeypatch.setattr(uc, "_get_update_check_config", lambda: {"auto_update": True})
     assert uc._fast_loop_active() is True, \
@@ -324,6 +336,10 @@ def test_unsupervised_daemon_execs_in_place(monkeypatch):
     process image in place instead (POSIX plan)."""
     uc = _uc()
     monkeypatch.delenv("CLAWMETRY_AUTO_UPDATE", raising=False)
+    # These tests simulate a USER machine; GitHub Actions exports CI=true,
+    # which now implicitly disables auto-update (ephemeral runners must
+    # never swap themselves for a newer wheel mid-job).
+    monkeypatch.delenv("CI", raising=False)
     uc._process_role = "daemon"
     monkeypatch.setattr(uc, "_daemon_supervised", lambda: False)
     monkeypatch.setattr(uc, "_restart_plan", lambda r, p, s: "exec")
@@ -359,6 +375,10 @@ def test_windows_hands_off_to_out_of_process_helper(monkeypatch):
     process exits."""
     uc = _uc()
     monkeypatch.delenv("CLAWMETRY_AUTO_UPDATE", raising=False)
+    # These tests simulate a USER machine; GitHub Actions exports CI=true,
+    # which now implicitly disables auto-update (ephemeral runners must
+    # never swap themselves for a newer wheel mid-job).
+    monkeypatch.delenv("CI", raising=False)
     uc._process_role = "daemon"
     monkeypatch.setattr(uc, "_daemon_supervised", lambda: True)
     monkeypatch.setattr(uc, "_restart_plan", lambda r, p, s: "respawn")
@@ -429,6 +449,10 @@ def test_entitled_plan_enables_auto_update(monkeypatch):
     monkeypatch.setattr(uc, "_get_update_check_config", lambda: dict(state))
     monkeypatch.setattr(uc, "_set_update_check_config", lambda upd: state.update(upd))
     monkeypatch.delenv("CLAWMETRY_AUTO_UPDATE", raising=False)
+    # These tests simulate a USER machine; GitHub Actions exports CI=true,
+    # which now implicitly disables auto-update (ephemeral runners must
+    # never swap themselves for a newer wheel mid-job).
+    monkeypatch.delenv("CI", raising=False)
     # free / inactive → unchanged
     S._sync_auto_update_with_plan("cloud_free"); assert state["auto_update"] is False
     S._sync_auto_update_with_plan(None);         assert state["auto_update"] is False
@@ -447,6 +471,10 @@ def test_entitled_plan_respects_optout_and_never_disables(monkeypatch):
     S._sync_auto_update_with_plan("cloud_pro");  assert state["auto_update"] is False  # opt-out
     # never auto-DISABLES a user's manual choice on downgrade
     monkeypatch.delenv("CLAWMETRY_AUTO_UPDATE", raising=False)
+    # These tests simulate a USER machine; GitHub Actions exports CI=true,
+    # which now implicitly disables auto-update (ephemeral runners must
+    # never swap themselves for a newer wheel mid-job).
+    monkeypatch.delenv("CI", raising=False)
     state["auto_update"] = True
     S._sync_auto_update_with_plan("cloud_free"); assert state["auto_update"] is True
 
@@ -480,6 +508,10 @@ def test_windows_handoff_keeps_update_lock(monkeypatch, tmp_path):
     metadata (live-hit on the 0.12.580 run)."""
     uc = _uc()
     monkeypatch.delenv("CLAWMETRY_AUTO_UPDATE", raising=False)
+    # These tests simulate a USER machine; GitHub Actions exports CI=true,
+    # which now implicitly disables auto-update (ephemeral runners must
+    # never swap themselves for a newer wheel mid-job).
+    monkeypatch.delenv("CI", raising=False)
     uc._process_role = "daemon"
     monkeypatch.setattr(uc, "_daemon_supervised", lambda: True)
     monkeypatch.setattr(uc, "_restart_plan", lambda r, p, s: "respawn")
@@ -518,3 +550,38 @@ def test_update_respawn_helper_releases_lock(monkeypatch, tmp_path):
     monkeypatch.setattr(ur.subprocess, "Popen", lambda cmd, **k: None)
     ur.main(["1234", "0.12.99", str(tmp_path / "r.log"), "x.exe"])
     assert not lock.exists(), "helper must release the lock even on pip failure"
+
+
+# ── CI runners never self-update ─────────────────────────────────────────────
+# The visual-diff harness death (2026-07-29, #4181/#4182): whenever a
+# [RELEASE] had just published, the PR-branch dashboard saw the newer wheel
+# ~60s after boot, pip-updated, and exec-restarted mid-screenshot-sweep.
+# An ephemeral CI runner must render the code it was started with.
+
+
+def test_ci_env_implicitly_disables_auto_update(monkeypatch):
+    uc = _uc()
+    monkeypatch.delenv("CLAWMETRY_AUTO_UPDATE", raising=False)
+    monkeypatch.setenv("CI", "true")
+    assert uc._env_auto_update_disabled() is True
+
+
+def test_explicit_opt_in_beats_ci_env(monkeypatch):
+    uc = _uc()
+    monkeypatch.setenv("CI", "true")
+    monkeypatch.setenv("CLAWMETRY_AUTO_UPDATE", "1")
+    assert uc._env_auto_update_disabled() is False
+
+
+def test_user_machine_stays_enabled_without_ci(monkeypatch):
+    uc = _uc()
+    monkeypatch.delenv("CLAWMETRY_AUTO_UPDATE", raising=False)
+    monkeypatch.delenv("CI", raising=False)
+    assert uc._env_auto_update_disabled() is False
+
+
+def test_kill_switch_still_wins_everywhere(monkeypatch):
+    uc = _uc()
+    monkeypatch.delenv("CI", raising=False)
+    monkeypatch.setenv("CLAWMETRY_AUTO_UPDATE", "0")
+    assert uc._env_auto_update_disabled() is True

--- a/tests/test_auto_update_fast_loop.py
+++ b/tests/test_auto_update_fast_loop.py
@@ -87,6 +87,10 @@ def test_dashboard_worker_fast_by_default(monkeypatch):
     uc = _uc()
     uc._process_role = "dashboard"
     monkeypatch.delenv("CLAWMETRY_AUTO_UPDATE", raising=False)
+    # These tests simulate a USER machine; GitHub Actions exports CI=true,
+    # which now implicitly disables auto-update (ephemeral runners must
+    # never swap themselves for a newer wheel mid-job).
+    monkeypatch.delenv("CI", raising=False)
     monkeypatch.setattr(uc, "_get_update_check_config",
                         lambda: {"enabled": True, "check_on_startup": False,
                                  "check_daily": True, "auto_update": True})
@@ -119,6 +123,10 @@ def test_dashboard_worker_keeps_daily_cadence_when_opted_out(monkeypatch):
     uc = _uc()
     uc._process_role = "dashboard"
     monkeypatch.delenv("CLAWMETRY_AUTO_UPDATE", raising=False)
+    # These tests simulate a USER machine; GitHub Actions exports CI=true,
+    # which now implicitly disables auto-update (ephemeral runners must
+    # never swap themselves for a newer wheel mid-job).
+    monkeypatch.delenv("CI", raising=False)
     monkeypatch.setattr(uc, "_get_update_check_config",
                         lambda: {"enabled": True, "check_on_startup": False,
                                  "check_daily": True, "auto_update": False})
@@ -191,6 +199,10 @@ def test_sync_daemon_starts_checker_with_daemon_role():
 
 def _gate(monkeypatch, uc, supervised, platform="darwin", kill=None):
     monkeypatch.delenv("CLAWMETRY_AUTO_UPDATE", raising=False)
+    # These tests simulate a USER machine; GitHub Actions exports CI=true,
+    # which now implicitly disables auto-update (ephemeral runners must
+    # never swap themselves for a newer wheel mid-job).
+    monkeypatch.delenv("CI", raising=False)
     if kill is None:
         monkeypatch.delenv("CLAWMETRY_AUTOUPDATE_EXEC_RESTART", raising=False)
     else:
@@ -267,6 +279,10 @@ def test_status_endpoint_reports_updater_posture(monkeypatch):
     uc = _uc()
     uc._process_role = "daemon"
     monkeypatch.delenv("CLAWMETRY_AUTO_UPDATE", raising=False)
+    # These tests simulate a USER machine; GitHub Actions exports CI=true,
+    # which now implicitly disables auto-update (ephemeral runners must
+    # never swap themselves for a newer wheel mid-job).
+    monkeypatch.delenv("CI", raising=False)
     monkeypatch.delenv("CLAWMETRY_UPDATE_CHECK_SECS", raising=False)
     monkeypatch.delenv("CLAWMETRY_AUTOUPDATE_MIN_AGE_HOURS", raising=False)
     monkeypatch.setattr(uc, "_get_update_check_config",


### PR DESCRIPTION
## Why
The recurring visual-diff "flake" was never chance. The updater's startup check fires 60s after boot (`CLAWMETRY_UPDATE_CHECK_SECS` default 60). Whenever a `[RELEASE]` had just published, the PR-branch HEAD dashboard in CI (versioned one release behind main) saw the newer wheel on PyPI, pip-updated, and exec-restarted itself ~60s into the screenshot sweep - every subsequent tab logged `[render-error] base=200 head=0` while the BASE server (already on the bumped version) sailed through. Failure rate tracked release cadence, and the flywheel releases constantly. Diagnosed 2026-07-29 after three consecutive identical kills on #4181/#4182 (last head-server log line: the store's RO handle evicted by the updater's writer, then process exit).

## What
`_env_auto_update_disabled()` now treats a truthy `CI` env (set by GitHub Actions, GitLab, CircleCI, Travis, Azure) as implicit disable: an ephemeral runner must render the code it was started with. Explicit `CLAWMETRY_AUTO_UPDATE=1` re-arms it; `=0` still hard-disables everywhere. The guard covers `_maybe_auto_update`, the fast loop, and is visible in `/api/update-check/status` as `env_disabled`.

Auto-update tests that simulate user machines now clear `CI` alongside the kill switch (they run inside GitHub Actions, where `CI=true` would otherwise trip the new guard).

Note: an equivalent belt-and-suspenders env line for `.github/workflows/pr-screenshots.yml` (`CLAWMETRY_AUTO_UPDATE: "0"`) could not be pushed - the gh token lacks `workflow` scope. This Python-side guard alone fixes the harness; add the workflow line at your leisure if you want the explicit marker.

## Verified
- 28/28 in tests/test_auto_update.py locally (4 new: CI implicit disable, explicit opt-in override, user-machine default unchanged, kill switch precedence).
- Revert-proof: the CI-guard test asserts behavior the old code cannot produce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
