### PR TITLE
fix(notifications): a connected channel actually shows as connected

### DIFF
--- a/clawmetry/templates/tabs/notifications.html
+++ b/clawmetry/templates/tabs/notifications.html
@@ -393,7 +393,12 @@
       var resp = state.localMode
         ? await fetch('/api/alert-channels').then(function(r){return r.json();}).then(function(cfg){return { channels: _localRows(cfg) };})
         : await fetch('/api/cloud-proxy/api/channels').then(function(r){return r.json();});
-      state.rows = (data && data.channels) || [];
+      // Read the SAME variable the fetch assigned. This line briefly read a
+      // stale `data` name after a refactor: the ReferenceError was swallowed
+      // by the catch below, rows stayed [], and a freshly connected channel
+      // still rendered as "Connect" with the status stuck on "No channels
+      // configured yet" (live-hit 2026-07-29 on a saved Telegram config).
+      state.rows = (resp && resp.channels) || [];
     } catch (e) {
       state.rows = [];
     }

--- a/dashboard.py
+++ b/dashboard.py
@@ -703,10 +703,16 @@ def _set_budget_config(updates):
 
 
 def _default_alerts_webhook_config():
+    # NOTE: dashboard.py defines this trio (default/load/save) TWICE; the
+    # LATER definitions (~line 9600) win at import time and carry the full
+    # schema (pagerduty/opsgenie/telegram/min_severity). This early copy is
+    # shadowed dead code kept in sync so nobody "fixes" the wrong one again.
     return {
         "webhook_url": "",
         "slack_webhook_url": "",
         "discord_webhook_url": "",
+        "telegram_bot_token": "",
+        "telegram_chat_id": "",
         "cost_spike_alerts": True,
         "agent_error_rate_alerts": True,
         "security_posture_changes": True,
@@ -9591,6 +9597,13 @@ def _default_alerts_webhook_config():
         "opsgenie_api_key": "",
         # Optional EU host override for OpsGenie ("https://api.eu.opsgenie.com").
         "opsgenie_api_url": "",
+        # Telegram bot delivery (self-hosted Notifications tab). Both keys
+        # required for a send. The /api/alert-channels ROUTE accepted these
+        # since the notifications-local work, but this schema (and the save
+        # allowlist below) silently dropped them — a "saved" Telegram channel
+        # never persisted, so its card stayed on "Connect" forever.
+        "telegram_bot_token": "",
+        "telegram_chat_id": "",
         "cost_spike_alerts": True,
         "agent_error_rate_alerts": True,
         "security_posture_changes": True,
@@ -9620,6 +9633,7 @@ def _save_alerts_webhook_config(updates):
     allowed = {
         "webhook_url", "slack_webhook_url", "discord_webhook_url",
         "pagerduty_routing_key", "opsgenie_api_key", "opsgenie_api_url",
+        "telegram_bot_token", "telegram_chat_id",
         "cost_spike_alerts", "agent_error_rate_alerts", "security_posture_changes",
         "min_severity",
     }

--- a/tests/test_notifications_local.py
+++ b/tests/test_notifications_local.py
@@ -33,3 +33,35 @@ def test_alerts_tab_reads_local_channels_in_local_mode():
     assert "alertsState.localMode" in src
     assert "'/api/alert-channels'" in src, \
         "alerts channel chips must come from the local config in local mode"
+
+
+def test_channel_loader_reads_the_variable_it_declared():
+    """Regression: the loader assigned the fetch to `resp` but the next line
+    read a stale `data` name. The ReferenceError was swallowed by the
+    surrounding catch, state.rows stayed [], and a freshly connected channel
+    kept rendering as "Connect" with the status stuck on "No channels
+    configured yet" (live-hit 2026-07-29 with a saved Telegram config)."""
+    src = _read("clawmetry/templates/tabs/notifications.html")
+    assert "state.rows = (resp && resp.channels) || [];" in src
+    assert "state.rows = (data && data.channels) || [];" not in src
+
+
+def test_telegram_keys_survive_the_effective_save_load_round_trip(tmp_path, monkeypatch):
+    """Regression: the /api/alert-channels ROUTE allowlisted telegram keys but
+    dashboard._save_alerts_webhook_config (the LATER, winning definition of a
+    duplicated trio) silently dropped them - a "saved" Telegram channel never
+    persisted, its card stayed on "Connect", and the Alerts tab kept saying
+    "no channels" (live-hit 2026-07-29). This exercises the EFFECTIVE
+    functions on the imported module, so a revert of either duplicate fails."""
+    import dashboard as _d
+    monkeypatch.setattr(_d, "_ALERTS_CONFIG_FILE",
+                        str(tmp_path / "alerts_webhook.json"))
+    saved = _d._save_alerts_webhook_config({
+        "telegram_bot_token": "12345:abcde",
+        "telegram_chat_id": "-100999",
+    })
+    assert saved.get("telegram_bot_token") == "12345:abcde"
+    assert saved.get("telegram_chat_id") == "-100999"
+    loaded = _d._load_alerts_webhook_config()
+    assert loaded.get("telegram_bot_token") == "12345:abcde"
+    assert loaded.get("telegram_chat_id") == "-100999"


### PR DESCRIPTION
## Why
Follow-through on the self-hosted notifications goal: the tab unlocked locally (#4178), but a channel you connected never showed as connected - the card stayed on Connect, the status said "No channels configured yet", and an enabled alert rule stayed at "no channels".

## Root causes
1. **notifications.html**: the loader assigned its fetch to `resp` but the next line read a stale `data` name; the ReferenceError was swallowed by the catch and `state.rows` stayed empty.
2. **dashboard.py**: the alerts-webhook config trio (default/load/save) is defined TWICE; the later, winning copy never learned the telegram keys the route allowlists, so a saved Telegram channel was silently dropped on write.

## Verified
Live on the reporting machine: saving a Telegram channel echoes the token, persists across reload, and the tab renders "1 channel configured - plan: trial" with the Telegram card showing Edit + Test. `tests/test_notifications_local.py`: 5/5 green on the fix; the two new tests (loader variable consistency, telegram save/load round-trip on the EFFECTIVE functions) fail on the old code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
