### PR TITLE
feat(license): pro_install_age_days_at(epoch) scalar + endpoint

### DIFF
--- a/clawmetry/license.py
+++ b/clawmetry/license.py
@@ -1555,6 +1555,89 @@ def pro_install_age_days() -> int | None:
     return age if age >= 0 else 0
 
 
+def pro_install_age_days_at(epoch: int) -> int | None:
+    """Scalar view of "how many days from ``installed_at`` to ``epoch``?" --
+    the perspective-epoch flavour of :func:`pro_install_age_days`, for a
+    scheduled-audit / retrospective tile that wants to answer "how old
+    was the ``clawmetry-pro`` install as of <date>?" without the caller
+    having to snapshot the marker state at that time or compute
+    ``(epoch - installed_at) // 86400`` at every call site.
+
+    Returns:
+      * ``None`` when there is nothing meaningful to derive: no marker
+        file on disk, a marker with no ``installed_at`` key, a marker
+        whose ``installed_at`` value is non-numeric / non-positive, OR
+        a non-numeric / bool ``epoch`` argument.
+      * A signed integer number of days otherwise. Zero when ``epoch``
+        equals the ``installed_at`` second; positive when ``epoch`` is
+        after ``installed_at`` (the normal case -- "N days old as of
+        <date>"); negative when ``epoch`` is BEFORE ``installed_at``
+        (support scenario: "the operator rolled a machine back to a
+        pre-provisioning timestamp -- how far before install were we?").
+
+    Deliberately NOT clamped to ``max(0, ...)`` -- unlike the "now"
+    flavour :func:`pro_install_age_days`, which clamps because clock-
+    skew is the only way ``installed_at`` can be in the future when
+    reading against ``time.time()``. Here the caller EXPLICITLY passes
+    a perspective epoch, so a negative result is a real, actionable
+    signal (they asked a question that only makes sense pre-install),
+    not clock skew to be hidden. Mirrors the signed-integer posture of
+    :func:`license_age_days_at`, which returns negative days when the
+    perspective epoch is before ``iat``.
+
+    Days are floor-divided from seconds ``(epoch - installed_at) //
+    86400``, matching how :func:`pro_install_age_days` derives its
+    "now" counterpart from ``(now - installed_at)`` so the two scalars
+    never disagree at the day boundary when ``epoch`` equals the
+    current time.
+
+    ``epoch`` is coerced through ``int()``; ``bool`` is explicitly
+    refused despite being an ``int`` subclass so a caller that passes
+    ``True`` / ``False`` gets ``None`` rather than a spurious "days
+    from installed_at to epoch 1" number. A non-numeric value collapses
+    to ``None`` so a caller cannot silently miscount on a typo.
+
+    Pairs with :func:`pro_installed_at` the way
+    :func:`license_age_days_at` pairs with :func:`license_issued_at`:
+    both derive from the same marker so they cannot disagree at the
+    day boundary. The perspective-epoch flavour lets a scheduled audit
+    tile answer "how old was the pro wheel when we shipped that build
+    last Friday?" without having to snapshot the marker state at those
+    times.
+
+    Independent of live importability -- an operator can have the
+    marker on disk (wheel was provisioned yesterday) even when Python
+    cannot currently import ``clawmetry-pro`` (wheel was pip-
+    uninstalled since), and the age still refers to the marker. Use
+    :func:`pro_installed` alongside this scalar for the live-import
+    signal.
+
+    Never raises. Any exception under the hood degrades to ``None`` so
+    a scheduled audit job never crashes on a bad install.
+    """
+    if isinstance(epoch, bool):
+        # ``bool`` is a subclass of ``int``; refuse it explicitly so a
+        # caller that passes ``True`` doesn't silently ask "days from
+        # installed_at to epoch 1?" and get a very negative number back.
+        return None
+    try:
+        wanted = int(epoch)
+    except (TypeError, ValueError):
+        return None
+    try:
+        installed = pro_installed_at()
+    except Exception as exc:
+        logger.debug("license: pro_install_age_days_at underlying read failed: %s", exc)
+        return None
+    if not isinstance(installed, int):
+        return None
+    try:
+        return (wanted - installed) // 86400
+    except Exception as exc:
+        logger.debug("license: pro_install_age_days_at arithmetic failed: %s", exc)
+        return None
+
+
 def license_nodes() -> int | None:
     """Scalar view onto the installed license's ``nodes`` claim -- the paid
     node-coverage count -- for a fleet/capacity tile that wants ONE integer

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -8670,6 +8670,116 @@ def api_license_pro_install_age_days():
         )
 
 
+@bp_entitlement.route("/api/license/pro-install-age-days-at")
+def api_license_pro_install_age_days_at():
+    """``GET /api/license/pro-install-age-days-at?epoch=<int>`` -- scalar
+    view of how old the ``clawmetry-pro`` install was at an operator-
+    supplied perspective epoch, for a scheduled-audit / retrospective
+    tile that wants to answer "how old was the pro wheel as of <date>?"
+    without the caller having to snapshot the marker state at that
+    time or compute ``(epoch - installed_at) // 86400`` at the call
+    site.
+
+    Response shape (always HTTP 200)::
+
+        {
+          "age_days": <int|null>,        # signed days from installed_at to epoch
+          "requested_epoch": <int|null>, # int-coerced input, or null on typo
+          "installed_at": <int|null>,    # current on-disk marker installed_at
+          "marker_present": <bool>,      # is the marker file readable?
+          "installed": <bool>            # can Python import clawmetry-pro right now?
+        }
+
+    ``age_days`` mirrors :func:`clawmetry.license.pro_install_age_days_at`:
+
+      * ``null`` when there is no marker file, when the marker has no
+        ``installed_at`` key, when ``installed_at`` is non-numeric /
+        non-positive, OR when ``epoch`` doesn't parse as an integer.
+      * A signed integer number of days otherwise. Zero when ``epoch``
+        equals the ``installed_at`` second; positive when ``epoch`` is
+        after ``installed_at`` (the normal case -- "N days old as of
+        <date>"); negative when ``epoch`` is BEFORE ``installed_at``
+        (support scenario: "the operator rolled a machine back to a
+        pre-provisioning timestamp -- how far before install were
+        we?").
+
+    Deliberately NOT clamped to ``max(0, ...)`` -- unlike the "now"
+    endpoint ``/api/license/pro-install-age-days``, which clamps
+    because clock-skew is the only way ``installed_at`` can be in the
+    future when reading against ``time.time()``. Here the caller
+    EXPLICITLY passes a perspective epoch, so a negative result is a
+    real, actionable signal (they asked a question that only makes
+    sense pre-install), not clock skew to be hidden. Mirrors the
+    signed-integer posture of ``/api/license/age-days-at``.
+
+    Deliberately independent of ``installed``: an operator can have
+    the marker on disk yet Python cannot currently import
+    ``clawmetry-pro`` (wheel was pip-uninstalled since), and that
+    disagreement is exactly what a paywall-debug / audit tile needs
+    to see rather than collapsing both facts into one boolean. The
+    ``installed`` field independently carries the live-importability
+    signal for callers that DO want to hide the row on a broken
+    install.
+
+    Query parameter:
+
+      * ``epoch`` -- required. Unix epoch seconds as an integer. A
+        missing / non-integer value collapses to ``age_days=null`` with
+        ``requested_epoch=null`` so a caller cannot silently miscount on
+        a typo. HTTP status is 200 either way -- the "bad input" signal
+        is the ``null`` result, not a 4xx, matching the never-crash
+        posture of the surrounding license endpoints.
+
+    Pairs with ``/api/license/pro-installed-at`` and
+    ``/api/license/pro-install-age-days`` -- all three share
+    :func:`_pro_install_snapshot`, so a UI binding any pair of them for
+    the same install cannot catch them disagreeing on ``installed_at``
+    / ``marker_present`` / ``installed``. Together they let a
+    dashboard render "on <date>, the pro install was N days old,
+    provisioned at epoch E" from two orthogonal one-shot GETs.
+
+    Never 5xxs -- any underlying failure degrades to
+    ``{age_days: null, requested_epoch: <echoed|null>, installed_at: null,
+    marker_present: false, installed: false}`` (the "no marker" branch
+    shape).
+    """
+    raw = request.args.get("epoch", "")
+    try:
+        requested = int(str(raw).strip())
+    except (TypeError, ValueError):
+        requested = None
+    try:
+        snap = _pro_install_snapshot()
+    except Exception as exc:
+        logger.warning("api_license_pro_install_age_days_at: snapshot error: %s", exc)
+        snap = {
+            "installed_at": None,
+            "age_days": None,
+            "marker_present": False,
+            "installed": False,
+        }
+    age_days: int | None
+    if requested is None:
+        age_days = None
+    else:
+        try:
+            from clawmetry import license as _lic
+
+            age_days = _lic.pro_install_age_days_at(requested)
+        except Exception as exc:
+            logger.warning("api_license_pro_install_age_days_at: derive error: %s", exc)
+            age_days = None
+    return jsonify(
+        {
+            "age_days": age_days,
+            "requested_epoch": requested,
+            "installed_at": snap["installed_at"],
+            "marker_present": snap["marker_present"],
+            "installed": snap["installed"],
+        }
+    )
+
+
 def _license_nodes_snapshot() -> dict:
     """Shared helper: read once, derive the trio the two node-limit endpoints
     both need (``nodes``, ``has_license``, ``valid``). Lives in the handler

--- a/tests/test_license_pro_install_age_days_at_scalar.py
+++ b/tests/test_license_pro_install_age_days_at_scalar.py
@@ -1,0 +1,450 @@
+"""Tests for the ``pro_install_age_days_at(epoch)`` scalar helper on
+``clawmetry.license`` and its paired ``/api/license/pro-install-age-days-at``
+HTTP endpoint.
+
+The perspective-epoch flavour of :func:`clawmetry.license.pro_install_age_days`.
+Both derive from the same marker ``installed_at`` so they cannot disagree at
+the day boundary when the perspective epoch equals "now"; on any other epoch
+this helper answers "how old was the pro install as of ``epoch``?" without the
+caller having to snapshot the marker state at that time or compute
+``(epoch - installed_at) // 86400`` themselves.
+
+Mirrors ``tests/test_license_age_days_at_scalar.py`` line-for-line where the
+two scalars share posture (bool-refused, non-numeric coerced to None, never-
+raises, independent of expiry / live importability), and diverges on the one
+axis they must differ on: this scalar is intentionally NOT clamped to
+``max(0, ...)`` because a perspective epoch BEFORE ``installed_at`` is a real
+signal the caller asked for (as opposed to clock skew, which is the only way
+``installed_at`` can be in the future when reading against ``time.time()``
+from :func:`pro_install_age_days`).
+
+Hermetic: the marker path is monkeypatched into ``tmp_path`` and
+``_pro_installed_version`` is stubbed so tests never touch the real
+site-packages -- same env fixture as
+``tests/test_license_pro_install_age_scalar.py``.
+"""
+from __future__ import annotations
+
+import json
+import os
+import time
+from types import SimpleNamespace
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def env(monkeypatch, tmp_path):
+    """Isolated license env mirroring
+    ``tests/test_license_pro_install_age_scalar.py``: tmp marker path,
+    controllable pro-version reader, Flask app with the entitlement
+    blueprint mounted."""
+    import clawmetry.license as _lic
+
+    marker_path = str(tmp_path / "pro_installed.json")
+    monkeypatch.setattr(_lic, "_PRO_MARKER_PATH", marker_path)
+
+    state = {"version": None}
+    monkeypatch.setattr(_lic, "_pro_installed_version", lambda: state["version"])
+
+    from routes.entitlement import bp_entitlement
+
+    flask_app = Flask(__name__)
+    flask_app.register_blueprint(bp_entitlement)
+    flask_app.config["TESTING"] = True
+
+    return SimpleNamespace(
+        app=flask_app,
+        lic=_lic,
+        marker_path=marker_path,
+        state=state,
+    )
+
+
+def _write_marker(env, payload):
+    os.makedirs(os.path.dirname(env.marker_path), exist_ok=True)
+    with open(env.marker_path, "w", encoding="utf-8") as fh:
+        json.dump(payload, fh)
+
+
+# ── clawmetry.license.pro_install_age_days_at() ──────────────────────────────
+
+
+def test_pro_install_age_days_at_none_when_no_marker(env):
+    """No marker file on disk -> None (nothing to compute against)."""
+    assert env.lic.pro_install_age_days_at(int(time.time())) is None
+
+
+def test_pro_install_age_days_at_now_matches_pro_install_age_days(env):
+    """When ``epoch`` equals "now", the perspective-epoch scalar must
+    agree with :func:`pro_install_age_days` at the day boundary (+/- 1
+    for the fractional-second drift between the two calls: the base
+    scalar reads ``time.time()`` with sub-second precision inside
+    itself, while the caller here passes an ``int(time.time())`` that
+    already truncated the fraction)."""
+    _write_marker(
+        env,
+        {"installed_at": int(time.time()) - 7 * 86400, "version": "0.3.4"},
+    )
+    now = int(time.time())
+    at_now = env.lic.pro_install_age_days_at(now)
+    scalar_now = env.lic.pro_install_age_days()
+    assert isinstance(at_now, int)
+    assert isinstance(scalar_now, int)
+    assert abs(at_now - scalar_now) <= 1
+
+
+def test_pro_install_age_days_at_future_epoch(env):
+    """A perspective epoch 10 days from now against a just-provisioned
+    marker should render age ~10 days."""
+    _write_marker(env, {"installed_at": int(time.time()), "version": "0.3.4"})
+    epoch = int(time.time()) + 10 * 86400
+    days = env.lic.pro_install_age_days_at(epoch)
+    assert isinstance(days, int)
+    # Floor-divided; allow +/- 1 for day-boundary jitter.
+    assert 9 <= days <= 10
+
+
+def test_pro_install_age_days_at_far_future_epoch(env):
+    """Perspective epoch 100 days from now against a just-provisioned
+    marker should render age ~100 days -- unlike the "now" flavour, no
+    cap on how old the caller may ask about."""
+    _write_marker(env, {"installed_at": int(time.time()), "version": "0.3.4"})
+    epoch = int(time.time()) + 100 * 86400
+    days = env.lic.pro_install_age_days_at(epoch)
+    assert isinstance(days, int)
+    assert 99 <= days <= 100
+
+
+def test_pro_install_age_days_at_negative_when_epoch_before_installed_at(env):
+    """An operator asking "how old was the pro install on <date>?"
+    where <date> is BEFORE provisioning -- perspective epoch BEFORE
+    ``installed_at`` -> negative int, NOT None and NOT clamped to 0.
+    Distinct from :func:`pro_install_age_days`, which clamps because it
+    can only reach the future-``installed_at`` branch via clock skew
+    (nothing to hide here -- the caller explicitly asked a pre-
+    provisioning question)."""
+    _write_marker(env, {"installed_at": int(time.time()), "version": "0.3.4"})
+    epoch = int(time.time()) - 15 * 86400
+    days = env.lic.pro_install_age_days_at(epoch)
+    assert isinstance(days, int)
+    assert days < 0
+    # epoch - installed_at = -15d.
+    assert -16 <= days <= -14
+
+
+def test_pro_install_age_days_at_zero_on_day_of_install(env):
+    """Perspective epoch on the day of provisioning -> 0."""
+    installed = int(time.time())
+    _write_marker(env, {"installed_at": installed, "version": "0.3.4"})
+    assert env.lic.pro_install_age_days_at(installed) == 0
+    # Sub-day AFTER installed_at still floor-divides to 0.
+    assert env.lic.pro_install_age_days_at(installed + 3600) == 0
+    # Sub-day BEFORE installed_at floor-divides to -1 (Python's floor
+    # division on a negative dividend rounds AWAY from zero).
+    assert env.lic.pro_install_age_days_at(installed - 3600) == -1
+
+
+def test_pro_install_age_days_at_independent_of_live_import(env):
+    """Marker present but wheel not importable -> still returns age.
+    Age tracks the marker, not live importability -- ``installed`` is
+    the separate signal for that."""
+    _write_marker(
+        env,
+        {"installed_at": int(time.time()) - 5 * 86400, "version": "0.3.4"},
+    )
+    # state["version"] stays None -> pro_installed() is False.
+    assert env.lic.pro_installed() is False
+    days = env.lic.pro_install_age_days_at(int(time.time()))
+    assert isinstance(days, int)
+    assert 4 <= days <= 6
+
+
+def test_pro_install_age_days_at_missing_installed_at(env):
+    """Marker exists but ``installed_at`` key absent -> None regardless
+    of epoch."""
+    _write_marker(env, {"version": "0.3.4"})
+    assert env.lic.pro_install_age_days_at(int(time.time())) is None
+    assert env.lic.pro_install_age_days_at(0) is None
+    assert env.lic.pro_install_age_days_at(2_000_000_000) is None
+
+
+def test_pro_install_age_days_at_non_numeric_installed_at(env):
+    """``installed_at`` is a string -> None."""
+    _write_marker(env, {"installed_at": "yesterday", "version": "0.3.4"})
+    assert env.lic.pro_install_age_days_at(int(time.time())) is None
+
+
+def test_pro_install_age_days_at_zero_installed_at_rejected(env):
+    """Non-positive ``installed_at`` is meaningless -> None (marker's
+    scalar refuses it, so the perspective flavour must too)."""
+    _write_marker(env, {"installed_at": 0, "version": "0.3.4"})
+    assert env.lic.pro_install_age_days_at(int(time.time())) is None
+
+
+def test_pro_install_age_days_at_bool_installed_at_rejected(env):
+    """``bool`` marker value is refused by :func:`pro_installed_at`,
+    so the perspective flavour collapses too."""
+    _write_marker(env, {"installed_at": True, "version": "0.3.4"})
+    assert env.lic.pro_install_age_days_at(int(time.time())) is None
+
+
+def test_pro_install_age_days_at_corrupt_marker(env):
+    """Marker file is not JSON -> None."""
+    os.makedirs(os.path.dirname(env.marker_path), exist_ok=True)
+    with open(env.marker_path, "w", encoding="utf-8") as fh:
+        fh.write("{not valid json")
+    assert env.lic.pro_install_age_days_at(int(time.time())) is None
+
+
+def test_pro_install_age_days_at_non_numeric_epoch(env):
+    """A caller passing a typo must get None, not a crash."""
+    _write_marker(env, {"installed_at": int(time.time()), "version": "0.3.4"})
+    assert env.lic.pro_install_age_days_at("garbage") is None  # type: ignore[arg-type]
+    assert env.lic.pro_install_age_days_at(None) is None  # type: ignore[arg-type]
+    assert env.lic.pro_install_age_days_at([1]) is None  # type: ignore[arg-type]
+
+
+def test_pro_install_age_days_at_bool_epoch_rejected(env):
+    """``bool`` is an ``int`` subclass -- explicitly refuse it so a
+    caller that passes ``True`` doesn't silently get "days from
+    installed_at to epoch 1" back."""
+    _write_marker(env, {"installed_at": int(time.time()), "version": "0.3.4"})
+    assert env.lic.pro_install_age_days_at(True) is None  # type: ignore[arg-type]
+    assert env.lic.pro_install_age_days_at(False) is None  # type: ignore[arg-type]
+
+
+def test_pro_install_age_days_at_float_epoch_coerced(env):
+    """Float epoch must coerce through ``int()`` rather than crash --
+    same posture as :func:`license_age_days_at`."""
+    _write_marker(env, {"installed_at": int(time.time()), "version": "0.3.4"})
+    now_f = float(time.time())
+    days = env.lic.pro_install_age_days_at(now_f)
+    assert isinstance(days, int)
+
+
+def test_pro_install_age_days_at_never_raises(env, monkeypatch):
+    """Any underlying failure -> None. Even a fully-broken
+    :func:`pro_installed_at` must not propagate."""
+    def _boom():
+        raise RuntimeError("simulated corrupt install")
+
+    monkeypatch.setattr(env.lic, "pro_installed_at", _boom)
+    assert env.lic.pro_install_age_days_at(int(time.time())) is None
+
+
+# ── GET /api/license/pro-install-age-days-at ─────────────────────────────────
+
+
+def test_endpoint_pro_install_age_days_at_no_marker(env):
+    with env.app.test_client() as c:
+        resp = c.get(f"/api/license/pro-install-age-days-at?epoch={int(time.time())}")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["age_days"] is None
+    assert isinstance(data["requested_epoch"], int)
+    assert data["installed_at"] is None
+    assert data["marker_present"] is False
+    assert data["installed"] is False
+
+
+def test_endpoint_pro_install_age_days_at_active(env):
+    now = int(time.time())
+    _write_marker(env, {"installed_at": now, "version": "0.3.4"})
+    env.state["version"] = "0.3.4"
+    epoch = now + 45 * 86400
+    with env.app.test_client() as c:
+        resp = c.get(f"/api/license/pro-install-age-days-at?epoch={epoch}")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert isinstance(data["age_days"], int)
+    assert 44 <= data["age_days"] <= 45
+    assert data["requested_epoch"] == epoch
+    assert isinstance(data["installed_at"], int)
+    assert data["marker_present"] is True
+    assert data["installed"] is True
+
+
+def test_endpoint_pro_install_age_days_at_negative_for_pre_install_epoch(env):
+    """Perspective epoch BEFORE ``installed_at`` -> negative age_days,
+    installed_at still populated so a support tile can render the pair
+    without a second call."""
+    _write_marker(env, {"installed_at": int(time.time()), "version": "0.3.4"})
+    env.state["version"] = "0.3.4"
+    epoch = int(time.time()) - 30 * 86400
+    with env.app.test_client() as c:
+        resp = c.get(f"/api/license/pro-install-age-days-at?epoch={epoch}")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert isinstance(data["age_days"], int)
+    assert data["age_days"] < 0
+    assert isinstance(data["installed_at"], int)
+    assert data["marker_present"] is True
+
+
+def test_endpoint_pro_install_age_days_at_marker_present_wheel_missing(env):
+    """The paywall-debug case: marker on disk, wheel pip-uninstalled.
+    ``age_days`` still surfaces (age tracks the marker, not live
+    import); ``installed`` is False so a caller that wants to hide the
+    row on a broken install has the signal."""
+    _write_marker(env, {"installed_at": 1_700_000_000, "version": "0.3.4"})
+    # state["version"] stays None -> pro_installed() is False.
+    epoch = 1_700_000_000 + 12 * 86400
+    with env.app.test_client() as c:
+        resp = c.get(f"/api/license/pro-install-age-days-at?epoch={epoch}")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["age_days"] == 12
+    assert data["installed_at"] == 1_700_000_000
+    assert data["marker_present"] is True
+    assert data["installed"] is False
+
+
+def test_endpoint_pro_install_age_days_at_missing_installed_at(env):
+    """Marker exists but ``installed_at`` key absent -> age_days null,
+    installed_at null, marker_present false (mirrors the "nothing to
+    date" branch of :func:`pro_installed_at`)."""
+    _write_marker(env, {"version": "0.3.4"})
+    with env.app.test_client() as c:
+        resp = c.get(f"/api/license/pro-install-age-days-at?epoch={int(time.time())}")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["age_days"] is None
+    assert data["installed_at"] is None
+    assert data["marker_present"] is False
+
+
+def test_endpoint_pro_install_age_days_at_missing_epoch_arg(env):
+    """No ``epoch=`` -> age_days null, requested_epoch null, HTTP 200.
+    The snapshot still populates installed_at / marker_present /
+    installed from the on-disk marker."""
+    _write_marker(
+        env,
+        {"installed_at": int(time.time()) - 3 * 86400, "version": "0.3.4"},
+    )
+    env.state["version"] = "0.3.4"
+    with env.app.test_client() as c:
+        resp = c.get("/api/license/pro-install-age-days-at")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["age_days"] is None
+    assert data["requested_epoch"] is None
+    assert isinstance(data["installed_at"], int)
+    assert data["marker_present"] is True
+    assert data["installed"] is True
+
+
+def test_endpoint_pro_install_age_days_at_non_integer_epoch(env):
+    """Typo epoch -> age_days null, requested_epoch null, HTTP 200
+    (never a 4xx). Mirrors the ``/api/license/age-days-at`` posture."""
+    _write_marker(env, {"installed_at": int(time.time()), "version": "0.3.4"})
+    with env.app.test_client() as c:
+        resp = c.get("/api/license/pro-install-age-days-at?epoch=garbage")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["age_days"] is None
+    assert data["requested_epoch"] is None
+    assert data["marker_present"] is True
+
+
+def test_endpoint_pro_install_age_days_at_corrupt_marker(env):
+    os.makedirs(os.path.dirname(env.marker_path), exist_ok=True)
+    with open(env.marker_path, "w", encoding="utf-8") as fh:
+        fh.write("{not json")
+    with env.app.test_client() as c:
+        resp = c.get(f"/api/license/pro-install-age-days-at?epoch={int(time.time())}")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["age_days"] is None
+    assert data["installed_at"] is None
+    assert data["marker_present"] is False
+    assert data["installed"] is False
+
+
+def test_endpoint_pro_install_age_days_at_never_5xxs(env, monkeypatch):
+    """Even if the shared snapshot blows up mid-request, the endpoint
+    must still return HTTP 200 with the no-marker shape (snapshot
+    fallback kicks in, requested_epoch is still echoed, age_days is
+    null)."""
+    from routes import entitlement as _routes
+
+    monkeypatch.setattr(
+        _routes,
+        "_pro_install_snapshot",
+        lambda: (_ for _ in ()).throw(RuntimeError("simulated blowup")),
+    )
+    epoch = int(time.time())
+    with env.app.test_client() as c:
+        resp = c.get(f"/api/license/pro-install-age-days-at?epoch={epoch}")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["age_days"] is None
+    assert data["requested_epoch"] == epoch
+    assert data["installed_at"] is None
+    assert data["marker_present"] is False
+    assert data["installed"] is False
+
+
+# ── cross-endpoint consistency ───────────────────────────────────────────────
+
+
+def test_endpoint_agrees_with_pro_install_age_days_at_now(env):
+    """When ``epoch`` equals "now", the perspective endpoint must agree
+    with ``/api/license/pro-install-age-days`` at the day boundary
+    (+/- 1 for the fractional-second drift between the two request
+    handlers: the base endpoint reads ``time.time()`` with sub-second
+    precision inside :func:`pro_install_age_days` at handle-time, while
+    the perspective endpoint receives an ``int(time.time())`` from the
+    caller that already truncated the fraction). Both derive from the
+    same marker, so a UI binding both cannot catch them disagreeing by
+    more than a day for the same install."""
+    _write_marker(
+        env,
+        {"installed_at": int(time.time()) - 8 * 86400, "version": "0.3.4"},
+    )
+    env.state["version"] = "0.3.4"
+    now = int(time.time())
+    with env.app.test_client() as c:
+        a = c.get(f"/api/license/pro-install-age-days-at?epoch={now}").get_json()
+        b = c.get("/api/license/pro-install-age-days").get_json()
+    assert isinstance(a["age_days"], int)
+    assert isinstance(b["age_days"], int)
+    assert abs(a["age_days"] - b["age_days"]) <= 1
+
+
+def test_endpoint_agrees_with_pro_installed_at_on_shared_snapshot(env):
+    """Both endpoints share :func:`_pro_install_snapshot` -- they must
+    surface identical ``installed_at`` / ``marker_present`` /
+    ``installed`` values for the same install regardless of the epoch
+    queried."""
+    _write_marker(
+        env,
+        {"installed_at": int(time.time()) - 42 * 86400, "version": "0.3.4"},
+    )
+    env.state["version"] = "0.3.4"
+    epoch = int(time.time()) + 5 * 86400
+    with env.app.test_client() as c:
+        a = c.get(f"/api/license/pro-install-age-days-at?epoch={epoch}").get_json()
+        b = c.get("/api/license/pro-installed-at").get_json()
+    for key in ("installed_at", "marker_present", "installed"):
+        assert a[key] == b[key], f"mismatch on {key}: {a[key]!r} vs {b[key]!r}"
+    assert a["requested_epoch"] == epoch
+
+
+def test_endpoint_agrees_with_pro_install_age_days_on_shared_snapshot(env):
+    """The perspective endpoint and the "now" endpoint share
+    :func:`_pro_install_snapshot`, so their common fields must match
+    exactly regardless of which epoch the perspective one is asked
+    about."""
+    _write_marker(
+        env,
+        {"installed_at": int(time.time()) - 20 * 86400, "version": "0.3.4"},
+    )
+    env.state["version"] = "0.3.4"
+    epoch = int(time.time()) + 90 * 86400
+    with env.app.test_client() as c:
+        a = c.get(f"/api/license/pro-install-age-days-at?epoch={epoch}").get_json()
+        b = c.get("/api/license/pro-install-age-days").get_json()
+    for key in ("installed_at", "marker_present", "installed"):
+        assert a[key] == b[key], f"mismatch on {key}: {a[key]!r} vs {b[key]!r}"


### PR DESCRIPTION
## Summary

- Adds `clawmetry.license.pro_install_age_days_at(epoch: int) -> int | None`, the perspective-epoch flavour of `pro_install_age_days()`. Answers "how old was the `clawmetry-pro` install evaluated as of `epoch`?" without the caller having to snapshot the marker state at that time or compute `(epoch - installed_at) // 86400` themselves. Pairs with `pro_installed_at()` the same way `license_age_days_at(epoch)` pairs with `license_issued_at()`.
- Adds `GET /api/license/pro-install-age-days-at?epoch=<int>` on `bp_entitlement`. Envelope carries `age_days` (int|null), `requested_epoch` (echoed int|null), `installed_at`, `marker_present`, `installed` — same shape as `/api/license/age-days-at` but sourced from the marker rather than the signed `iat` claim. Shares `_pro_install_snapshot()` with `/api/license/pro-installed-at` and `/api/license/pro-install-age-days` so all three necessarily agree on `installed_at` / `marker_present` / `installed` for the same install.

Posture notes (mirrors `license_age_days_at(epoch)` on the signed-license side of the fence):

- **Deliberately NOT clamped to `max(0, ...)`**, unlike the "now" flavour `pro_install_age_days()` (which clamps because clock-skew is the only way `installed_at` can be in the future when reading against `time.time()`). Here the caller EXPLICITLY passes a perspective epoch, so a negative result is a real, actionable signal (they asked a question that only makes sense pre-provisioning), not clock skew to be hidden. Mirrors the signed-integer posture of `/api/license/age-days-at`.
- **When `epoch` equals "now", the perspective scalar must agree with `pro_install_age_days()`** for the same install within one day (fractional-second drift between the two calls: the base scalar reads `time.time()` with sub-second precision inside itself; the caller here passes an `int(time.time())` that already truncated the fraction). Boundary parity is guarded by a paired test on both the scalar and the endpoint.
- **`bool` is refused explicitly** despite being an `int` subclass so a caller that passes `True` doesn't silently ask "days from installed_at to epoch 1?" and get a very negative number back. `False` is also refused for the same reason (both surface as `None`, not `-installed_at // 86400`).
- **Non-integer `epoch` collapses to `age_days=null` + `requested_epoch=null`, HTTP 200**: the bad-input signal is the `null` result, not a 4xx, matching the never-crash posture of the surrounding license endpoints (`/api/license/age-days-at`, `/api/license/days-until-expiry-at`, `/api/license/is-expiring-at`).
- **Independent of live importability**: an operator can have the marker on disk yet Python cannot currently import `clawmetry-pro` (wheel was pip-uninstalled since). That disagreement is exactly what a paywall-debug tile needs to surface rather than collapse both facts into one boolean. `age_days` still surfaces from the marker in that case; the `installed` field independently carries the live-import signal for callers that DO want to hide the row on a broken install.
- **Never 5xxs**: any underlying failure (corrupt marker, blown-up snapshot helper) degrades to `{age_days: null, requested_epoch: <echoed|null>, installed_at: null, marker_present: false, installed: false}` — the "no marker" branch shape, matching the pattern used by every other license endpoint on this Blueprint.

Cross-endpoint consistency is covered by three tests: the perspective endpoint at `epoch=now` agrees with `/api/license/pro-install-age-days` within one day (both compute from the same marker); and the shared `_pro_install_snapshot()` guarantees `installed_at` / `marker_present` / `installed` match `/api/license/pro-installed-at` and `/api/license/pro-install-age-days` exactly for the same install, regardless of which perspective epoch the new endpoint is queried at.

Zero behaviour change: purely additive, read-only. No new gate is enforced, no tier logic is altered, no existing route or scalar is touched.

## Test plan

- [x] `python3 -m pytest tests/test_license_pro_install_age_days_at_scalar.py -q` — **28 passed** (scalar unit tests + endpoint tests + cross-endpoint consistency)
- [x] `python3 -m pytest tests/test_license_pro_install_age_scalar.py tests/test_license_age_days_at_scalar.py tests/test_license.py tests/test_license_api.py tests/test_entitlement_api.py tests/test_license_pro_installation.py -q` — **191 passed**, no regressions in the sibling suite
- [x] `python3 -m pytest tests/test_license_days_until_expiry_at.py tests/test_license_days_until_expiry.py tests/test_license_is_expired_is_perpetual.py tests/test_license_expires_at_scalar.py tests/test_license_issued_scalar.py tests/test_license_age_days_at_scalar.py -q` — **182 passed**, no regressions in adjacent scalar-endpoint parity suites
- [x] `ruff check clawmetry/license.py routes/entitlement.py tests/test_license_pro_install_age_days_at_scalar.py` — clean
- [x] `python3 -m py_compile clawmetry/license.py routes/entitlement.py tests/test_license_pro_install_age_days_at_scalar.py` — clean

### Local operator verification checklist (I can't reach the running daemon or a browser from this environment)

- [ ] Copy `clawmetry/license.py`, `routes/entitlement.py`, and `tests/test_license_pro_install_age_days_at_scalar.py` into `~/.clawmetry/lib/pythonX.Y/site-packages/clawmetry/`, `.../site-packages/routes/`, and `.../site-packages/tests/`.
- [ ] Clear `__pycache__` under all three directories.
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` to restart the daemon so a future request loads the new endpoint.
- [ ] Active install — `curl -s "http://localhost:8900/api/license/pro-install-age-days-at?epoch=$(date +%s)" | jq .` — expect `{"age_days": <int>, "requested_epoch": <int>, "installed_at": <int>, "marker_present": true, "installed": true}`; on OSS-free (no marker), expect all four value fields null / false as documented.
- [ ] Future perspective — `curl -s "http://localhost:8900/api/license/pro-install-age-days-at?epoch=$(($(date +%s) + 86400*30))" | jq .age_days` — should be ~30 higher than the "now" value from `/api/license/pro-install-age-days`.
- [ ] Pre-install perspective — `curl -s "http://localhost:8900/api/license/pro-install-age-days-at?epoch=$(($(date +%s) - 86400*365*10))" | jq .` — expect `age_days` to be negative (perspective epoch 10 years before install; the endpoint deliberately does NOT clamp to 0 here, unlike `/api/license/pro-install-age-days`).
- [ ] Typo — `curl -s "http://localhost:8900/api/license/pro-install-age-days-at?epoch=garbage" | jq .` — expect `{"age_days": null, "requested_epoch": null, ...}` with HTTP 200 (never a 4xx).
- [ ] Missing arg — `curl -s "http://localhost:8900/api/license/pro-install-age-days-at" | jq .` — expect `age_days=null`, `requested_epoch=null`, `installed_at`/`marker_present`/`installed` still populated from the on-disk marker.
- [ ] Cross-check: `installed_at` / `marker_present` / `installed` on `/api/license/pro-install-age-days-at?epoch=<any>` must equal the same three fields on both `/api/license/pro-installed-at` and `/api/license/pro-install-age-days` for the same install (they share `_pro_install_snapshot()`).
- [ ] Boundary check: on an active install, `/api/license/pro-install-age-days-at?epoch=$(date +%s)` must return `age_days` within one day of `/api/license/pro-install-age-days`'s `age_days` field (both compute from the same marker; the ±1 tolerance is the fractional-second drift between the two handlers).
- [ ] Decrypt the live cloud snapshot and browser-check the dashboard still loads (this PR only adds a new read-only endpoint; no runtime handler is modified, no gate change, no cloud path is affected, but the safety check is cheap).

Marked draft — the local operator handles daemon verification, cloud-snapshot verification, release, and merge per FLYWHEEL.md.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GE593XQgSqj86YcgfQ7SFK)_