### PR TITLE
feat(nav): Notifications sits next to Approvals and Alerts

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -12233,6 +12233,14 @@ DASHBOARD_HTML = r"""
         <span class="left-nav-label" data-i18n="nav.alerts">Alerts</span>
         <span id="nav-alerts-badge" class="left-nav-badge" style="display:none;">0</span>
       </div>
+      {# Notifications sits directly under its two consumers (Approvals,
+         Alerts) - founder request 2026-07-29: buried in the Advanced drawer,
+         nobody could find where to connect a delivery channel, so enabled
+         alert rules dead-ended at "no channels". #}
+      <div class="left-nav-item" data-tab="notifications" onclick="switchTab('notifications')" data-i18n-title="nav.notifications_tooltip" title="Where Alerts and Approvals get delivered: Slack / Telegram / PagerDuty / Email">
+        <span class="left-nav-icon" aria-hidden="true">&#9993;</span>
+        <span class="left-nav-label" data-i18n="nav.notifications">Notifications</span>
+      </div>
 
       {# Developer drawer: the deep-dive views. Pure toggle (no data-tab: the
          header must not steal the overview highlight from Home). Collapsed by
@@ -12285,9 +12293,6 @@ DASHBOARD_HTML = r"""
       </div>
       <div class="left-nav-item left-nav-item-sub" data-tab="memory" onclick="switchTab('memory')" data-i18n-title="nav.memory_tooltip" title="Persistent memory files the agent reads on boot">
         <span class="left-nav-label" data-i18n="nav.memory">Memory</span>
-      </div>
-      <div class="left-nav-item left-nav-item-sub" data-tab="notifications" onclick="switchTab('notifications')">
-        <span class="left-nav-label" data-i18n="nav.notifications">Notifications</span>
       </div>
       <div class="left-nav-item left-nav-item-sub" data-tab="logs" onclick="switchTab('logs')" title="Live OpenClaw log stream">
         <span class="left-nav-label">Logs</span>

--- a/tests/test_beginner_nav_phase_a.py
+++ b/tests/test_beginner_nav_phase_a.py
@@ -41,11 +41,15 @@ def _ordered_tabs(html: str) -> list:
 def test_tier1_order_and_membership():
     nav = _nav_block()
     tabs = _ordered_tabs(nav)
-    tier1 = tabs[:7]
+    tier1 = tabs[:8]
+    # Notifications rides Tier-1 directly under its two consumers (Approvals,
+    # Alerts) - founder request 2026-07-29: buried in the Advanced drawer,
+    # nobody could find where to connect a delivery channel, so enabled alert
+    # rules dead-ended at "no channels".
     assert tier1 == [
         "overview", "inventory", "brain", "usage",
-        "transcripts", "approvals", "alerts",
-    ], f"Tier-1 must be the seven beginner items in order, got {tier1}"
+        "transcripts", "approvals", "alerts", "notifications",
+    ], f"Tier-1 must be the eight beginner items in order, got {tier1}"
 
 
 def test_group_header_has_no_data_tab():
@@ -70,9 +74,9 @@ def test_no_tab_lost_in_restructure():
     nav = _nav_block()
     tabs = set(_ordered_tabs(nav))
     expected = {
-        # Tier-1
+        # Tier-1 (notifications promoted from Advanced, founder 2026-07-29)
         "overview", "inventory", "brain", "usage", "transcripts",
-        "approvals", "alerts",
+        "approvals", "alerts", "notifications",
         # Developer drawer. Phase B (UX_AUDIT.md) deliberately moved the
         # session-scoped views (tracing, turn-anatomy, swimlane) OUT of the
         # nav and into the session drill-down - their pages and switchTab ids
@@ -80,7 +84,7 @@ def test_no_tab_lost_in_restructure():
         "flow", "models", "context", "agents",
         "tool-catalog", "context-economics", "harness", "dives",
         # Advanced
-        "crons", "memory", "notifications", "security", "policy", "skills",
+        "crons", "memory", "security", "policy", "skills",
         "selfevolve", "version-impact", "nemoclaw",
     }
     missing = expected - tabs


### PR DESCRIPTION
## Why
Founder request (2026-07-29, with screenshot): "place notifications tab next to alerts & approvals so that it can be easily discovered". The natural journey is "Alerts says no channels → where do I add one?" — and the answer was hidden in the collapsed Advanced drawer, two groups away from the tabs that consume it.

## What
- The Notifications item moves from the Advanced drawer to Tier-1, directly beneath Approvals and Alerts (envelope icon, tooltip naming Slack / Telegram / PagerDuty / Email).
- `data-tab` id and `switchTab('notifications')` are unchanged — deep links and all existing wiring keep working.
- Nav guard tests updated: Tier-1 is now the eight beginner items in order, `notifications` after `alerts`; the old nav fails the assertion (revert-proof).

## Verified
Live on the requesting machine (browser walk + screenshot): sidebar renders Home / Agents / Activity / Cost / Conversations / Approvals / Alerts / **Notifications** / Developer / Advanced, and clicking the promoted item opens the channel manager showing "1 channel configured · plan: trial". 8/8 nav tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
