### PR TITLE
fix(connect): backfill local-only history to the cloud on connect

### DIFF
--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -759,6 +759,33 @@ def _keychain_set(node_id: str, key: str) -> None:
         pass
 
 
+def _reset_family_sync_marks() -> int:
+    """Drop the family-runtime high-water marks so the next daemon pass
+    re-ingests every session and pushes the full set to the cloud.
+
+    Sessions ingested during local-only operation are stamped "done" in
+    ``family_event_high_water``; without this reset, the first pass after
+    ``clawmetry connect`` skips them all and the cloud account never sees
+    the node's history. Local re-ingest is idempotent (PK upserts), so the
+    only cost is one full re-read. Returns the number of session marks
+    cleared (0 when there is nothing to backfill)."""
+    import json as _json
+    state_file = Path.home() / ".clawmetry" / "sync-state.json"
+    try:
+        with open(state_file, encoding="utf-8") as fh:
+            state = _json.load(fh)
+    except (FileNotFoundError, ValueError, OSError):
+        return 0
+    marks = state.pop("family_event_high_water", None)
+    if not marks:
+        return 0
+    tmp = state_file.with_suffix(".json.tmp")
+    with open(tmp, "w", encoding="utf-8") as fh:
+        _json.dump(state, fh)
+    os.replace(tmp, state_file)
+    return len(marks)
+
+
 def _cmd_connect(args) -> None:
     """clawmetry connect — validate key, save config, start daemon."""
     # #1937: respect the persistent local-only marker. If the user did
@@ -993,6 +1020,20 @@ def _cmd_connect(args) -> None:
             print("  Re-enabled cloud sync (was local-only)")
     except Exception:
         pass
+
+    # Backfill guarantee: sessions ingested while the node ran local-only are
+    # stamped "done" in the family high-water marks, so the first cloud-
+    # connected pass would skip them all and the cloud dashboard would sit at
+    # 0 sessions forever (founder live-hit 2026-07-29: local said Connected,
+    # cloud said "No machines connected yet"). Clearing the marks makes the
+    # next family pass re-ingest every session (idempotent PK upserts locally)
+    # and push the full set to the newly connected account.
+    try:
+        _cleared = _reset_family_sync_marks()
+        if _cleared:
+            print(f"  Queued {_cleared} existing session(s) for cloud backfill")
+    except Exception:
+        pass  # connect must never fail because of backfill housekeeping
 
     print()
     print(f"  Connected as: {node_id}")

--- a/tests/test_connect_cloud_backfill.py
+++ b/tests/test_connect_cloud_backfill.py
@@ -1,0 +1,59 @@
+"""``clawmetry connect`` queues local-only history for cloud backfill.
+
+Founder live-hit 2026-07-29: after running local-only (trial license, no
+cloud), Enable Cloud Sync connected the account but the cloud dashboard sat
+at "No machines connected yet / 0 sessions" forever. The family-runtime
+high-water marks were stamped "done" during local-only ingest, so the first
+cloud-connected pass skipped every session. ``_reset_family_sync_marks``
+clears them at connect time; the next daemon pass re-ingests (idempotent PK
+upserts) and pushes the full set to the newly connected account.
+"""
+from __future__ import annotations
+
+import json
+
+from clawmetry import cli as _cli
+
+
+def _write_state(home, state):
+    d = home / ".clawmetry"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "sync-state.json").write_text(json.dumps(state), encoding="utf-8")
+
+
+def test_reset_clears_marks_and_reports_count(tmp_path, monkeypatch):
+    monkeypatch.setattr(_cli.Path, "home", staticmethod(lambda: tmp_path))
+    _write_state(tmp_path, {
+        "family_event_high_water": {
+            "claude_code:s1": "2026-07-29T00:00:00+00:00@@0",
+            "cursor:s2": "2026-07-29T00:00:01+00:00@@0",
+        },
+        "other_state": {"keep": "me"},
+    })
+    assert _cli._reset_family_sync_marks() == 2
+    left = json.loads(
+        (tmp_path / ".clawmetry" / "sync-state.json").read_text(encoding="utf-8"))
+    assert "family_event_high_water" not in left
+    # Unrelated state survives untouched.
+    assert left["other_state"] == {"keep": "me"}
+
+
+def test_reset_is_a_noop_without_marks_or_state(tmp_path, monkeypatch):
+    monkeypatch.setattr(_cli.Path, "home", staticmethod(lambda: tmp_path))
+    # No state file at all.
+    assert _cli._reset_family_sync_marks() == 0
+    # State file without marks.
+    _write_state(tmp_path, {"other": 1})
+    assert _cli._reset_family_sync_marks() == 0
+    left = json.loads(
+        (tmp_path / ".clawmetry" / "sync-state.json").read_text(encoding="utf-8"))
+    assert left == {"other": 1}
+
+
+def test_connect_calls_the_backfill_reset():
+    """The reset must be wired into the connect flow itself (revert trap:
+    removing the call re-opens the never-backfills gap)."""
+    import inspect
+    src = inspect.getsource(_cli._cmd_connect)
+    assert "_reset_family_sync_marks" in src
+    assert "cloud backfill" in src


### PR DESCRIPTION
## Why
Founder live-hit (2026-07-29): after running local-only on a trial license, clicking Enable Cloud Sync connected the account — but the cloud dashboard sat at "No machines connected yet / 0 sessions" indefinitely. The family-runtime high-water marks were stamped "done" during local-only ingest, so the first cloud-connected pass skipped every session. Local said Connected; cloud stayed empty; only a manual sync-state edit unblocked it.

## What
`clawmetry connect` now clears `family_event_high_water` right after saving the config (same place it already clears the local-only marker). The next daemon pass re-ingests every session — idempotent PK upserts locally — and pushes the full set to the newly connected account. Prints `Queued N existing session(s) for cloud backfill`. No-op on fresh installs; best-effort so connect can never fail on housekeeping.

## Verified
- The manual equivalent of this fix (clearing the 7 marks on the affected machine) made the next family pass re-sync 3,948 events to the cloud.
- `tests/test_connect_cloud_backfill.py`: reset clears marks and preserves unrelated state; no-op paths; wiring test fails if the call is removed from `_cmd_connect` (revert-proof).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
