### PR TITLE
feat(license): is_expiring_within_at + /api/license/expiring-within-at

### DIFF
--- a/clawmetry/license.py
+++ b/clawmetry/license.py
@@ -1239,6 +1239,68 @@ def days_until_expiry_at(epoch: int) -> int | None:
         return None
 
 
+def is_expiring_within_at(days: int, epoch: int) -> bool:
+    """Boolean gate for "would we have shown a renewal warning as of
+    ``epoch``?" -- the perspective-epoch flavour of
+    :func:`is_expiring_within`, for a scheduled-audit / retrospective
+    tile that wants to answer "was the license inside the ``days``-day
+    renewal window on <date>?" without having to snapshot the license
+    state at that time.
+
+    Returns ``True`` iff a license is installed, signature-valid,
+    carries an ``exp`` claim, AND the days from ``epoch`` until ``exp``
+    fall between 0 and ``days`` inclusive. An already-lapsed-at-epoch
+    key returns ``False`` on purpose -- the caller wants to distinguish
+    "renewal window" (warn) from "already expired at that time" (a
+    different, louder banner), and :func:`days_until_expiry_at` /
+    :func:`is_expired_at` independently carry those signals for callers
+    that DO want to distinguish them. Perpetual licenses (no ``exp``
+    claim) and the no-license path both return ``False``: nothing to
+    warn about.
+
+    ``days`` is coerced through ``int()``; negative or non-numeric input
+    collapses to ``False`` (nothing "expires within -5 days"). ``epoch``
+    is coerced through ``int()``; ``bool`` is explicitly refused despite
+    being an ``int`` subclass so a caller that passes ``True`` doesn't
+    silently ask "is this expiring within N days as of epoch 1?" and
+    get an ancient-history answer. A non-numeric ``epoch`` collapses to
+    ``False`` so a caller cannot silently mis-gate on a typo.
+
+    Days are floor-divided from seconds ``(exp - epoch) // 86400``,
+    matching :func:`days_until_expiry_at` so the two helpers cannot
+    disagree at the day boundary for the same install / epoch. When
+    ``epoch`` equals the current time, this predicate must agree with
+    :func:`is_expiring_within` at that day boundary (+/- 1 for the
+    fractional-second drift between the two calls: the bare helper reads
+    ``time.time()`` inside :func:`current_license_info` with sub-second
+    precision, while the perspective helper receives an already-
+    truncated integer).
+
+    Never raises; every underlying failure returns ``False`` so a
+    scheduled audit job never crashes on a bad install.
+    """
+    try:
+        threshold = int(days)
+    except (TypeError, ValueError):
+        return False
+    if threshold < 0:
+        return False
+    if isinstance(epoch, bool):
+        return False
+    try:
+        int(epoch)
+    except (TypeError, ValueError):
+        return False
+    try:
+        remaining = days_until_expiry_at(epoch)
+    except Exception as exc:
+        logger.debug("license: is_expiring_within_at underlying read failed: %s", exc)
+        return False
+    if remaining is None:
+        return False
+    return 0 <= remaining <= threshold
+
+
 def license_tier() -> str | None:
     """Scalar view onto the installed license's ``tier`` claim -- for a
     paywall tile / tier badge that wants ONE string rather than the whole

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -10055,6 +10055,141 @@ def api_license_days_until_expiry_at():
     )
 
 
+@bp_entitlement.route("/api/license/expiring-within-at")
+def api_license_expiring_within_at():
+    """``GET /api/license/expiring-within-at?days=<N>&epoch=<int>`` --
+    boolean gate for "would we have shown a renewal warning as of
+    ``epoch``?" -- the perspective-epoch flavour of
+    ``/api/license/expiring-within``, for a scheduled-audit /
+    retrospective tile that wants to answer "was the license inside the
+    ``days``-day renewal window on <date>?" without having to snapshot
+    the license state at that time.
+
+    Response shape (always HTTP 200)::
+
+        {
+          "expiring_within": <bool>,
+          "days_left": <int|null>,           # signed days from epoch to exp
+          "threshold_days": <int>,           # normalised threshold echo
+          "requested_epoch": <int|null>,     # int-coerced input, or null on typo
+          "expires_at": <int|null>,          # current on-disk exp
+          "has_license": <bool>,             # is a license file installed at all?
+          "valid": <bool>                    # signature-valid AND not expired
+        }
+
+    ``expiring_within`` mirrors
+    :func:`clawmetry.license.is_expiring_within_at`:
+
+      * ``true`` iff a license is installed, signature-valid, carries an
+        ``exp`` claim, AND the days from ``epoch`` until ``exp`` fall
+        between 0 and ``threshold_days`` inclusive.
+      * ``false`` when there is no license file, on the invalid-signature
+        branch (payload cannot be trusted -- an attacker could stuff any
+        ``exp`` into an unsigned body), on the perpetual-license branch
+        (no ``exp`` to gate against), on the already-lapsed-at-epoch
+        branch (a caller wants "renewal window" separate from "already
+        expired at that time"), OR when either query argument doesn't
+        parse.
+
+    ``days_left`` is layered on top of the bool so a paywall widget
+    never needs a second call to
+    ``/api/license/days-until-expiry-at`` to render the accompanying
+    "expires in N days as of that date" copy. It mirrors
+    :func:`clawmetry.license.days_until_expiry_at` -- lenient on
+    expiry, so an already-lapsed-at-epoch key still surfaces its real
+    (negative) ``days_left`` even though ``expiring_within`` collapses
+    to ``false``. Callers that want to hide the row on lapsed keys have
+    the ``valid`` signal.
+
+    Query parameters:
+
+      * ``days`` (int, optional) -- the renewal-window threshold.
+        Defaults to ``30``. Negative input clamps to ``0``; non-numeric
+        input collapses to ``expiring_within=false`` with
+        ``threshold_days=0`` rather than a 4xx, matching the surrounding
+        endpoints' never-5xx / never-4xx posture.
+      * ``epoch`` (int, required) -- perspective epoch (Unix seconds).
+        A missing / non-integer value collapses to
+        ``expiring_within=false`` with ``requested_epoch=null`` and
+        ``days_left=null`` so a caller cannot silently mis-gate on a
+        typo.
+
+    Pairs with ``/api/license/days-until-expiry-at`` /
+    ``/api/license/is-expiring-at`` -- all three share the
+    :func:`_license_expires_snapshot` reader so a UI binding any two
+    endpoints for the same install cannot catch them disagreeing on
+    ``expires_at`` / ``has_license`` / ``valid``. Together they let a
+    dashboard render "on <date>, the license would have been N days
+    from expiry -- and would we have warned?" from two orthogonal
+    one-shot GETs.
+
+    Never 5xxs -- any underlying failure degrades to
+    ``{expiring_within: false, days_left: null, threshold_days: 0,
+    requested_epoch: null, expires_at: null, has_license: false,
+    valid: false}`` (the OSS-free branch shape).
+    """
+    raw_days = request.args.get("days", "30")
+    try:
+        threshold = int(raw_days)
+        threshold_ok = True
+    except (TypeError, ValueError):
+        threshold = 0
+        threshold_ok = False
+    if threshold < 0:
+        threshold = 0
+    raw_epoch = request.args.get("epoch", "")
+    try:
+        requested = int(str(raw_epoch).strip())
+    except (TypeError, ValueError):
+        requested = None
+    try:
+        snap = _license_expires_snapshot()
+    except Exception as exc:
+        logger.warning("api_license_expiring_within_at: snapshot error: %s", exc)
+        snap = {
+            "expires_at": None,
+            "days_until_expiry": None,
+            "has_license": False,
+            "valid": False,
+        }
+    days_left: int | None
+    within = False
+    if requested is not None and threshold_ok:
+        try:
+            from clawmetry import license as _lic
+
+            days_left = _lic.days_until_expiry_at(requested)
+            within = _lic.is_expiring_within_at(threshold, requested)
+        except Exception as exc:
+            logger.warning("api_license_expiring_within_at: derive error: %s", exc)
+            days_left = None
+            within = False
+    elif requested is not None:
+        # Threshold garbage but epoch parsed: still surface days_left for
+        # the accompanying "expires in N days" copy so the widget can
+        # render even with the gate off. Matches the never-crash posture.
+        try:
+            from clawmetry import license as _lic
+
+            days_left = _lic.days_until_expiry_at(requested)
+        except Exception as exc:
+            logger.warning("api_license_expiring_within_at: derive error: %s", exc)
+            days_left = None
+    else:
+        days_left = None
+    return jsonify(
+        {
+            "expiring_within": bool(within),
+            "days_left": days_left,
+            "threshold_days": threshold,
+            "requested_epoch": requested,
+            "expires_at": snap["expires_at"],
+            "has_license": snap["has_license"],
+            "valid": snap["valid"],
+        }
+    )
+
+
 @bp_entitlement.route("/api/license/age-days-at")
 def api_license_age_days_at():
     """``GET /api/license/age-days-at?epoch=<int>`` -- scalar view of the

--- a/tests/test_license_expiring_within_at.py
+++ b/tests/test_license_expiring_within_at.py
@@ -1,0 +1,550 @@
+"""Tests for the ``is_expiring_within_at(days, epoch)`` boolean helper on
+``clawmetry.license`` and its paired ``/api/license/expiring-within-at``
+HTTP endpoint.
+
+The perspective-epoch flavour of the ``is_expiring_within`` gate. Both
+derive from the same signed ``exp`` claim so they cannot disagree at the
+day boundary when the perspective epoch equals "now"; on any other
+epoch this helper answers "was the license inside the ``days``-day
+renewal window on <date>?" without the caller having to snapshot the
+license state at that time.
+
+Hermetic: each test mints tokens with its own ephemeral keypair and
+monkeypatches the module's embedded public key + LICENSE_PATH, mirroring
+``tests/test_license_days_until_expiry_at.py`` so nothing depends on the
+real production signing key or on real filesystem state.
+"""
+from __future__ import annotations
+
+import time
+from types import SimpleNamespace
+
+import pytest
+from flask import Flask
+
+
+# ── shared helpers (mirror test_license_days_until_expiry_at.py) ─────────────
+
+
+def _keypair():
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+    priv = Ed25519PrivateKey.generate()
+    pub_pem = priv.public_key().public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    return priv, pub_pem
+
+
+def _payload(tier="pro", nodes=3, exp_delta=365 * 86400, drop_exp=False):
+    now = int(time.time())
+    p = {
+        "sub": "acct_test",
+        "tier": tier,
+        "nodes": nodes,
+        "iat": now,
+        "exp": now + exp_delta,
+        "features": ["runtimes"],
+    }
+    if drop_exp:
+        p.pop("exp", None)
+    return p
+
+
+@pytest.fixture
+def app(monkeypatch, tmp_path):
+    import clawmetry.license as _lic
+
+    priv, pub_pem = _keypair()
+    monkeypatch.setattr(_lic, "_PUBLIC_KEY_PEM", pub_pem)
+    license_path = str(tmp_path / "license.key")
+    monkeypatch.setattr(_lic, "LICENSE_PATH", license_path)
+    monkeypatch.delenv("CLAWMETRY_LICENSE_SERVER", raising=False)
+    monkeypatch.delenv("CLAWMETRY_INGEST_URL", raising=False)
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("CLAWMETRY_OFFLINE", "1")
+
+    from routes.entitlement import bp_entitlement
+
+    flask_app = Flask(__name__)
+    flask_app.register_blueprint(bp_entitlement)
+    flask_app.config["TESTING"] = True
+
+    return SimpleNamespace(
+        app=flask_app,
+        lic=_lic,
+        priv=priv,
+        license_path=license_path,
+    )
+
+
+def _write_key_direct(app, exp_delta):
+    """Bypass activate() (which refuses expired tokens) and write a token
+    directly to the license file. Simulates a license that expired AFTER
+    it was installed."""
+    import os
+
+    tok = app.lic._encode_token(_payload(exp_delta=exp_delta), app.priv)
+    os.makedirs(os.path.dirname(app.license_path), exist_ok=True)
+    with open(app.license_path, "w", encoding="utf-8") as fh:
+        fh.write(tok)
+
+
+# ── clawmetry.license.is_expiring_within_at() ────────────────────────────────
+
+
+def test_is_expiring_within_at_no_license(app):
+    """No license file on disk -> False regardless of threshold / epoch."""
+    now = int(time.time())
+    assert app.lic.is_expiring_within_at(30, now) is False
+    assert app.lic.is_expiring_within_at(0, now) is False
+
+
+def test_is_expiring_within_at_now_matches_bare(app):
+    """When ``epoch`` equals "now", the perspective helper must agree
+    with :func:`is_expiring_within` for the same threshold. Both derive
+    from the same signed ``exp`` claim; the sub-second drift between the
+    two calls is at most one day (matching the day-boundary jitter that
+    also affects ``days_until_expiry`` vs ``days_until_expiry_at``)."""
+    tok = app.lic._encode_token(_payload(exp_delta=15 * 86400), app.priv)
+    app.lic.activate(tok)
+    now = int(time.time())
+    # Threshold well inside the window: both must fire True.
+    assert app.lic.is_expiring_within_at(30, now) is True
+    assert app.lic.is_expiring_within(30) is True
+    # Threshold outside the window: both must be False.
+    assert app.lic.is_expiring_within_at(5, now) is False
+    assert app.lic.is_expiring_within(5) is False
+
+
+def test_is_expiring_within_at_future_perspective_pulls_into_window(app):
+    """A perspective epoch 20 days from now pulls an exp 45 days from
+    now down to 25 days remaining, so a 30-day threshold fires True
+    while a 20-day threshold fires False."""
+    tok = app.lic._encode_token(_payload(exp_delta=45 * 86400), app.priv)
+    app.lic.activate(tok)
+    epoch = int(time.time()) + 20 * 86400
+    assert app.lic.is_expiring_within_at(30, epoch) is True
+    assert app.lic.is_expiring_within_at(20, epoch) is False
+
+
+def test_is_expiring_within_at_past_perspective_pushes_out_of_window(app):
+    """A perspective epoch 20 days ago pushes an exp 15 days from now
+    to 35 days remaining, so a 30-day threshold that fires True at
+    "now" fires False at that older perspective."""
+    tok = app.lic._encode_token(_payload(exp_delta=15 * 86400), app.priv)
+    app.lic.activate(tok)
+    now = int(time.time())
+    assert app.lic.is_expiring_within_at(30, now) is True
+    epoch = now - 20 * 86400
+    assert app.lic.is_expiring_within_at(30, epoch) is False
+
+
+def test_is_expiring_within_at_already_lapsed_at_epoch_returns_false(app):
+    """A perspective epoch AFTER ``exp`` means the key had already
+    lapsed at that time -- the renewal-window gate must return False
+    (that's the "already expired then" branch, not the "warn" branch).
+    Callers wanting the negative day-count signal go through
+    :func:`days_until_expiry_at`."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    epoch = int(time.time()) + 45 * 86400  # 15 days past exp
+    assert app.lic.is_expiring_within_at(30, epoch) is False
+    # Even an enormous threshold cannot rescue a lapsed-at-epoch state.
+    assert app.lic.is_expiring_within_at(10_000, epoch) is False
+
+
+def test_is_expiring_within_at_perpetual_license(app):
+    """Perpetual (no ``exp``) license -> False regardless of epoch.
+    Nothing to warn about."""
+    tok = app.lic._encode_token(_payload(drop_exp=True), app.priv)
+    import os
+
+    os.makedirs(os.path.dirname(app.license_path), exist_ok=True)
+    with open(app.license_path, "w", encoding="utf-8") as fh:
+        fh.write(tok)
+    now = int(time.time())
+    assert app.lic.is_expiring_within_at(30, now) is False
+    assert app.lic.is_expiring_within_at(30, 0) is False
+    assert app.lic.is_expiring_within_at(30, 2_000_000_000) is False
+
+
+def test_is_expiring_within_at_invalid_signature(app):
+    """File on disk but signature bogus -> False. current_license_info()
+    collapses the payload on this branch; the gate must reflect that."""
+    import os
+
+    os.makedirs(os.path.dirname(app.license_path), exist_ok=True)
+    with open(app.license_path, "w", encoding="utf-8") as fh:
+        fh.write("CLAW1.garbage.garbage")
+    assert app.lic.is_expiring_within_at(30, int(time.time())) is False
+
+
+def test_is_expiring_within_at_negative_threshold(app):
+    """Negative / non-numeric threshold -> False (nothing "expires
+    within -5 days"). Mirrors :func:`is_expiring_within`."""
+    tok = app.lic._encode_token(_payload(exp_delta=15 * 86400), app.priv)
+    app.lic.activate(tok)
+    now = int(time.time())
+    assert app.lic.is_expiring_within_at(-1, now) is False
+    assert app.lic.is_expiring_within_at("garbage", now) is False  # type: ignore[arg-type]
+    assert app.lic.is_expiring_within_at(None, now) is False  # type: ignore[arg-type]
+
+
+def test_is_expiring_within_at_threshold_zero_day_of_expiry(app):
+    """``days=0`` should fire True only when perspective epoch falls
+    within the same day as ``exp`` (``days_left == 0``). Mirrors the
+    ``is_expiring_within(0)`` semantics."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    info = app.lic.current_license_info()
+    assert isinstance(info, dict)
+    exp = info["exp"]
+    assert app.lic.is_expiring_within_at(0, exp) is True
+    assert app.lic.is_expiring_within_at(0, exp - 3600) is True  # <24h before
+    # 5 days before exp -> outside the zero-day window.
+    assert app.lic.is_expiring_within_at(0, exp - 5 * 86400) is False
+
+
+def test_is_expiring_within_at_bool_epoch_rejected(app):
+    """``bool`` is a subclass of ``int``; refuse it explicitly so a
+    caller that passes ``True`` doesn't silently ask "is this expiring
+    within N days as of epoch 1?" and get an ancient-history answer
+    back. Mirrors :func:`days_until_expiry_at`."""
+    tok = app.lic._encode_token(_payload(exp_delta=15 * 86400), app.priv)
+    app.lic.activate(tok)
+    assert app.lic.is_expiring_within_at(30, True) is False  # type: ignore[arg-type]
+    assert app.lic.is_expiring_within_at(30, False) is False  # type: ignore[arg-type]
+
+
+def test_is_expiring_within_at_non_numeric_epoch(app):
+    """A caller passing a typo must get False, not a crash."""
+    tok = app.lic._encode_token(_payload(exp_delta=15 * 86400), app.priv)
+    app.lic.activate(tok)
+    assert app.lic.is_expiring_within_at(30, "garbage") is False  # type: ignore[arg-type]
+    assert app.lic.is_expiring_within_at(30, None) is False  # type: ignore[arg-type]
+    assert app.lic.is_expiring_within_at(30, [1]) is False  # type: ignore[arg-type]
+
+
+def test_is_expiring_within_at_float_epoch_coerced(app):
+    """Float epoch must coerce through ``int()`` rather than crash --
+    same posture as :func:`is_expiring_at` / :func:`days_until_expiry_at`."""
+    tok = app.lic._encode_token(_payload(exp_delta=15 * 86400), app.priv)
+    app.lic.activate(tok)
+    now_f = float(time.time())
+    assert isinstance(app.lic.is_expiring_within_at(30, now_f), bool)
+
+
+def test_is_expiring_within_at_never_raises(monkeypatch):
+    """Any underlying failure -> False. Even a fully-broken
+    days_until_expiry_at() must not propagate."""
+    import clawmetry.license as _lic
+
+    def _boom(_epoch):
+        raise RuntimeError("simulated corrupt install")
+
+    monkeypatch.setattr(_lic, "days_until_expiry_at", _boom)
+    assert _lic.is_expiring_within_at(30, int(time.time())) is False
+
+
+# ── GET /api/license/expiring-within-at ──────────────────────────────────────
+
+
+def test_endpoint_expiring_within_at_no_license(app):
+    with app.app.test_client() as c:
+        resp = c.get(
+            f"/api/license/expiring-within-at?days=30&epoch={int(time.time())}"
+        )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["expiring_within"] is False
+    assert data["days_left"] is None
+    assert data["threshold_days"] == 30
+    assert isinstance(data["requested_epoch"], int)
+    assert data["expires_at"] is None
+    assert data["has_license"] is False
+    assert data["valid"] is False
+
+
+def test_endpoint_expiring_within_at_inside_window(app):
+    """Active key with 15 days left, threshold 30 -> True; days_left
+    layered on for the "expires in N days" copy."""
+    tok = app.lic._encode_token(_payload(exp_delta=15 * 86400), app.priv)
+    app.lic.activate(tok)
+    now = int(time.time())
+    with app.app.test_client() as c:
+        resp = c.get(f"/api/license/expiring-within-at?days=30&epoch={now}")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["expiring_within"] is True
+    assert isinstance(data["days_left"], int)
+    assert 14 <= data["days_left"] <= 15
+    assert data["threshold_days"] == 30
+    assert data["requested_epoch"] == now
+    assert isinstance(data["expires_at"], int)
+    assert data["has_license"] is True
+    assert data["valid"] is True
+
+
+def test_endpoint_expiring_within_at_outside_window(app):
+    """Active key with 45 days left, threshold 30 -> False, but the
+    days_left / expires_at payload still populates so the widget can
+    render "expires in 45 days"."""
+    tok = app.lic._encode_token(_payload(exp_delta=45 * 86400), app.priv)
+    app.lic.activate(tok)
+    now = int(time.time())
+    with app.app.test_client() as c:
+        resp = c.get(f"/api/license/expiring-within-at?days=30&epoch={now}")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["expiring_within"] is False
+    assert isinstance(data["days_left"], int)
+    assert 43 <= data["days_left"] <= 45
+    assert data["threshold_days"] == 30
+    assert data["has_license"] is True
+    assert data["valid"] is True
+
+
+def test_endpoint_expiring_within_at_future_perspective_pulls_into_window(app):
+    """Perspective epoch 20 days from now pulls an exp 45 days out into
+    the 30-day window -> gate fires True."""
+    tok = app.lic._encode_token(_payload(exp_delta=45 * 86400), app.priv)
+    app.lic.activate(tok)
+    epoch = int(time.time()) + 20 * 86400
+    with app.app.test_client() as c:
+        resp = c.get(f"/api/license/expiring-within-at?days=30&epoch={epoch}")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["expiring_within"] is True
+    assert isinstance(data["days_left"], int)
+    assert 24 <= data["days_left"] <= 25
+    assert data["requested_epoch"] == epoch
+
+
+def test_endpoint_expiring_within_at_lapsed_at_epoch_gate_false_days_negative(app):
+    """Perspective epoch AFTER ``exp`` -> gate collapses to False (the
+    key had already lapsed then), BUT days_left still surfaces the
+    (negative) real value so a support tile can render the pair. Mirrors
+    the lenient posture of ``/api/license/days-until-expiry-at``."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    epoch = int(time.time()) + 60 * 86400
+    with app.app.test_client() as c:
+        resp = c.get(f"/api/license/expiring-within-at?days=30&epoch={epoch}")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["expiring_within"] is False
+    assert isinstance(data["days_left"], int)
+    assert data["days_left"] < 0
+    assert isinstance(data["expires_at"], int)
+    assert data["has_license"] is True
+
+
+def test_endpoint_expiring_within_at_perpetual_license(app):
+    """Perpetual license -> gate False, days_left null, expires_at
+    null, has_license True (there IS a file)."""
+    tok = app.lic._encode_token(_payload(drop_exp=True), app.priv)
+    import os
+
+    os.makedirs(os.path.dirname(app.license_path), exist_ok=True)
+    with open(app.license_path, "w", encoding="utf-8") as fh:
+        fh.write(tok)
+    with app.app.test_client() as c:
+        resp = c.get(
+            f"/api/license/expiring-within-at?days=30&epoch={int(time.time())}"
+        )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["expiring_within"] is False
+    assert data["days_left"] is None
+    assert data["expires_at"] is None
+    assert data["has_license"] is True
+
+
+def test_endpoint_expiring_within_at_default_threshold_is_30(app):
+    """No ``days=`` -> threshold defaults to 30. Matches the bare
+    ``/api/license/expiring-within`` posture."""
+    tok = app.lic._encode_token(_payload(exp_delta=15 * 86400), app.priv)
+    app.lic.activate(tok)
+    now = int(time.time())
+    with app.app.test_client() as c:
+        resp = c.get(f"/api/license/expiring-within-at?epoch={now}")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["threshold_days"] == 30
+    assert data["expiring_within"] is True
+
+
+def test_endpoint_expiring_within_at_missing_epoch_arg(app):
+    """No ``epoch=`` -> gate False, requested_epoch null, days_left
+    null. The snapshot still populates expires_at from the on-disk
+    key."""
+    tok = app.lic._encode_token(_payload(exp_delta=15 * 86400), app.priv)
+    app.lic.activate(tok)
+    with app.app.test_client() as c:
+        resp = c.get("/api/license/expiring-within-at?days=30")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["expiring_within"] is False
+    assert data["days_left"] is None
+    assert data["requested_epoch"] is None
+    assert isinstance(data["expires_at"], int)
+    assert data["has_license"] is True
+
+
+def test_endpoint_expiring_within_at_non_integer_epoch(app):
+    """Typo epoch -> gate False, requested_epoch null, HTTP 200 (never
+    a 4xx). Mirrors the ``/api/license/is-expiring-at`` posture."""
+    tok = app.lic._encode_token(_payload(exp_delta=15 * 86400), app.priv)
+    app.lic.activate(tok)
+    with app.app.test_client() as c:
+        resp = c.get("/api/license/expiring-within-at?days=30&epoch=garbage")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["expiring_within"] is False
+    assert data["days_left"] is None
+    assert data["requested_epoch"] is None
+    assert data["has_license"] is True
+
+
+def test_endpoint_expiring_within_at_non_integer_days_collapses(app):
+    """Typo threshold -> gate False, threshold_days 0, but days_left
+    still populates (widget can still render the "expires in N days"
+    copy even with the gate off)."""
+    tok = app.lic._encode_token(_payload(exp_delta=15 * 86400), app.priv)
+    app.lic.activate(tok)
+    now = int(time.time())
+    with app.app.test_client() as c:
+        resp = c.get(
+            f"/api/license/expiring-within-at?days=garbage&epoch={now}"
+        )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["expiring_within"] is False
+    assert data["threshold_days"] == 0
+    assert isinstance(data["days_left"], int)
+    assert data["requested_epoch"] == now
+
+
+def test_endpoint_expiring_within_at_negative_days_clamps_to_zero(app):
+    """Negative threshold clamps to 0 -- gate fires True only on the
+    exact day of expiry. Matches the bare ``/api/license/expiring-within``
+    posture."""
+    tok = app.lic._encode_token(_payload(exp_delta=15 * 86400), app.priv)
+    app.lic.activate(tok)
+    now = int(time.time())
+    with app.app.test_client() as c:
+        resp = c.get(f"/api/license/expiring-within-at?days=-30&epoch={now}")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["threshold_days"] == 0
+    assert data["expiring_within"] is False  # 15 days away, not the day-of
+
+
+def test_endpoint_expiring_within_at_invalid_signature(app):
+    """File on disk but signature bogus -> gate False, has_license True
+    (there IS a file), valid False."""
+    import os
+
+    os.makedirs(os.path.dirname(app.license_path), exist_ok=True)
+    with open(app.license_path, "w", encoding="utf-8") as fh:
+        fh.write("CLAW1.garbage.garbage")
+    with app.app.test_client() as c:
+        resp = c.get(
+            f"/api/license/expiring-within-at?days=30&epoch={int(time.time())}"
+        )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["expiring_within"] is False
+    assert data["days_left"] is None
+    assert data["has_license"] is True
+    assert data["valid"] is False
+
+
+def test_endpoint_expiring_within_at_never_5xxs(app, monkeypatch):
+    """Even if the shared snapshot blows up mid-request, the endpoint
+    must still return HTTP 200 with the OSS-free shape (snapshot
+    fallback kicks in; requested_epoch / threshold_days still echoed)."""
+    from routes import entitlement as _routes
+
+    monkeypatch.setattr(
+        _routes,
+        "_license_expires_snapshot",
+        lambda: (_ for _ in ()).throw(RuntimeError("simulated blowup")),
+    )
+    epoch = int(time.time())
+    with app.app.test_client() as c:
+        resp = c.get(f"/api/license/expiring-within-at?days=30&epoch={epoch}")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["expiring_within"] is False
+    assert data["days_left"] is None
+    assert data["threshold_days"] == 30
+    assert data["requested_epoch"] == epoch
+    assert data["expires_at"] is None
+    assert data["has_license"] is False
+    assert data["valid"] is False
+
+
+# ── cross-endpoint consistency ───────────────────────────────────────────────
+
+
+def test_endpoint_agrees_with_expiring_within_at_now(app):
+    """When ``epoch`` equals "now", the perspective endpoint must agree
+    with ``/api/license/expiring-within`` for the same threshold. Both
+    derive from the same signed ``exp`` claim; the sub-second drift
+    between the two request handlers is at most one day (jitter also
+    affects the paired ``days-until-expiry`` / ``days-until-expiry-at``
+    endpoints)."""
+    tok = app.lic._encode_token(_payload(exp_delta=15 * 86400), app.priv)
+    app.lic.activate(tok)
+    now = int(time.time())
+    with app.app.test_client() as c:
+        a = c.get(
+            f"/api/license/expiring-within-at?days=30&epoch={now}"
+        ).get_json()
+        b = c.get("/api/license/expiring-within?days=30").get_json()
+    assert a["expiring_within"] == b["expiring_within"] is True
+    assert isinstance(a["days_left"], int)
+    assert isinstance(b["days_left"], int)
+    assert abs(a["days_left"] - b["days_left"]) <= 1
+
+
+def test_endpoint_agrees_with_days_until_expiry_at_on_shared_snapshot(app):
+    """Both perspective-epoch endpoints share
+    :func:`_license_expires_snapshot` -- they must surface identical
+    ``expires_at`` / ``has_license`` / ``valid`` / ``days_left`` /
+    ``requested_epoch`` for the same install & epoch. A UI binding
+    both cannot catch them disagreeing on the shared quartet."""
+    tok = app.lic._encode_token(_payload(exp_delta=45 * 86400), app.priv)
+    app.lic.activate(tok)
+    epoch = int(time.time()) + 5 * 86400
+    with app.app.test_client() as c:
+        a = c.get(
+            f"/api/license/expiring-within-at?days=60&epoch={epoch}"
+        ).get_json()
+        b = c.get(
+            f"/api/license/days-until-expiry-at?epoch={epoch}"
+        ).get_json()
+    for key in ("expires_at", "has_license", "valid", "days_left", "requested_epoch"):
+        assert a[key] == b[key], f"mismatch on {key}: {a[key]!r} vs {b[key]!r}"
+
+
+def test_endpoint_agrees_with_is_expiring_at_on_shared_snapshot(app):
+    """The renewal-window gate and the exact-match predicate share the
+    same snapshot reader -- ``expires_at`` / ``has_license`` / ``valid``
+    must be identical for the same install regardless of the epoch
+    queried."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    epoch = int(time.time()) + 5 * 86400
+    with app.app.test_client() as c:
+        a = c.get(
+            f"/api/license/expiring-within-at?days=30&epoch={epoch}"
+        ).get_json()
+        b = c.get(f"/api/license/is-expiring-at?epoch={epoch}").get_json()
+    for key in ("expires_at", "has_license", "valid"):
+        assert a[key] == b[key], f"mismatch on {key}: {a[key]!r} vs {b[key]!r}"
+    assert a["requested_epoch"] == b["requested_epoch"] == epoch


### PR DESCRIPTION
## Summary

- Adds the missing perspective-epoch (`_at`) sibling of `is_expiring_within(days)` on `clawmetry.license`. Every other license expiry / renewal helper already has one; this closes the last hole in the family.
- Adds the paired `GET /api/license/expiring-within-at?days=<N>&epoch=<int>` endpoint on `bp_entitlement`. Reuses the existing `_license_expires_snapshot()` reader so the shared quartet (`expires_at` / `has_license` / `valid` / `days_left`) stays byte-identical to `/api/license/days-until-expiry-at` and `/api/license/is-expiring-at`.
- No behavior change to existing helpers or endpoints. Never 5xxs / never 4xxs; bad input degrades to the OSS-free branch shape.

The `_at` gap this closes:

| bare helper | `_at` sibling |
|---|---|
| `days_until_expiry()` | `days_until_expiry_at(epoch)` ✓ |
| `is_expired()` | `is_expired_at(epoch)` ✓ |
| `license_age_days()` | `license_age_days_at(epoch)` ✓ |
| `pro_install_age_days()` | `pro_install_age_days_at(epoch)` ✓ |
| **`is_expiring_within(days)`** | **added here** |

Semantics: `is_expiring_within_at(days, epoch)` delegates to `days_until_expiry_at(epoch)` so the two helpers cannot disagree at the day boundary. `bool` epoch is rejected (matches `days_until_expiry_at`). Every underlying failure returns `False`. The endpoint's `days` defaults to `30` (matches `/api/license/expiring-within`); negative `days` clamps to `0`; a typo threshold degrades to `expiring_within=false` with `threshold_days=0` but still surfaces `days_left` so the widget can render the accompanying "expires in N days" copy.

## Test plan

- [x] `tests/test_license_expiring_within_at.py` — 29 hermetic tests mirroring `tests/test_license_days_until_expiry_at.py` (each mints its own Ed25519 keypair and monkeypatches the module's embedded public key + `LICENSE_PATH`, so nothing depends on the real production signing key). Covers: no-license / active / perpetual / invalid-signature / lapsed-at-epoch / future-perspective / past-perspective / bool-epoch / typo-epoch / typo-days / negative-days / `days=0` day-of-expiry / snapshot-blowup never-5xx / cross-endpoint consistency against `/api/license/expiring-within` (agrees at "now"), `/api/license/days-until-expiry-at` (shared quintet), `/api/license/is-expiring-at` (shared trio).
- [x] `python -m pytest tests/test_license_expiring_within_at.py -x -q` → **29 passed**.
- [x] Regression check on neighbouring suites: `python -m pytest tests/test_license_days_until_expiry.py tests/test_license_days_until_expiry_at.py tests/test_license_is_expired_at.py -q` → **80 passed**.
- [x] `python -m py_compile clawmetry/license.py routes/entitlement.py tests/test_license_expiring_within_at.py` → OK.

## Local operator verification checklist

Since this agent cannot reach the running daemon, the live cloud snapshot, or a browser, the operator handles the on-host verification:

- [ ] Copy the three changed files into the site-packages install:
  ```bash
  V=$(python -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')
  cp clawmetry/license.py         ~/.clawmetry/lib/python${V}/site-packages/clawmetry/license.py
  cp routes/entitlement.py        ~/.clawmetry/lib/python${V}/site-packages/routes/entitlement.py
  find ~/.clawmetry/lib -name __pycache__ -type d -exec rm -rf {} +
  ```
- [ ] Restart the daemon: `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
- [ ] Hit the new endpoint against the live install (perspective = now):
  ```bash
  NOW=$(date +%s)
  curl -s "http://localhost:8900/api/license/expiring-within-at?days=30&epoch=${NOW}" | jq .
  ```
  Expected keys: `expiring_within` (bool), `days_left` (int|null), `threshold_days` (int), `requested_epoch` (int|null), `expires_at` (int|null), `has_license` (bool), `valid` (bool). Never 5xx.
- [ ] Cross-check the shared quartet against the neighbouring endpoints for the SAME install & epoch:
  ```bash
  curl -s "http://localhost:8900/api/license/expiring-within-at?days=60&epoch=${NOW}" | jq '.expires_at, .has_license, .valid, .days_left'
  curl -s "http://localhost:8900/api/license/days-until-expiry-at?epoch=${NOW}"      | jq '.expires_at, .has_license, .valid, .days_left'
  curl -s "http://localhost:8900/api/license/is-expiring-at?epoch=${NOW}"            | jq '.expires_at, .has_license, .valid'
  ```
  The overlapping fields must be byte-identical (they share `_license_expires_snapshot()`).
- [ ] Bad-input sweep — none should 5xx / 4xx:
  ```bash
  curl -s -o /dev/null -w '%{http_code}\n' "http://localhost:8900/api/license/expiring-within-at"                                # 200
  curl -s -o /dev/null -w '%{http_code}\n' "http://localhost:8900/api/license/expiring-within-at?days=garbage&epoch=${NOW}"     # 200
  curl -s -o /dev/null -w '%{http_code}\n' "http://localhost:8900/api/license/expiring-within-at?days=30&epoch=garbage"         # 200
  curl -s -o /dev/null -w '%{http_code}\n' "http://localhost:8900/api/license/expiring-within-at?days=-30&epoch=${NOW}"         # 200; threshold_days=0
  ```
- [ ] Decrypt the live cloud snapshot in the browser and confirm no console errors on any tile that binds to the license-expiry endpoints (this PR does not touch the frontend, so the existing tiles should be unaffected).

---
_Generated by [Claude Code](https://claude.ai/code/session_01K8rcv8dgJReY5Kb7yPhRj9)_