### PR TITLE
feat(license): license_state_at + is_state_at perspective-epoch scalars + endpoints

### DIFF
--- a/clawmetry/license.py
+++ b/clawmetry/license.py
@@ -2332,3 +2332,145 @@ def is_state(state: str) -> bool:
         logger.debug("license: is_state underlying read failed: %s", exc)
         return False
     return current == requested
+
+
+def license_state_at(epoch: int) -> str:
+    """Perspective-epoch flavour of :func:`license_state` -- "what state
+    would the installed license have reported evaluated as of ``epoch``?"
+    -- for a scheduled-audit / retrospective status tile that wants to
+    answer "would we have shown the expired banner on <date>?" without
+    the caller having to snapshot the license state at that time or
+    compare ``exp`` to a caller-supplied epoch themselves.
+
+    Returns one of :data:`LICENSE_STATES` -- never ``None``. Like
+    :func:`license_state`, "no license installed" is a real answer here
+    (``"no_license"``), not a missing answer, so callers can bind a
+    switch without a ``None`` branch:
+
+      * ``"active"``   -- signature-valid AND (perpetual OR ``exp > epoch``).
+      * ``"expired"``  -- signature-valid, carries an ``exp`` claim, AND
+        ``exp <= epoch``. Retrospective on a lapsed key when ``epoch``
+        equals "now"; prospective on an active key when ``epoch`` is in
+        the future beyond ``exp``.
+      * ``"invalid"``  -- file exists but signature is bogus (time-
+        independent: the classification never changes with epoch, since
+        an unsigned body is untrusted whatever the perspective).
+      * ``"no_license"`` -- no license file on disk (also time-
+        independent). Missing / non-numeric / bool ``epoch`` also
+        degrades to ``"no_license"`` so a UI switch bound to a typo cannot
+        silently mis-render as ``"active"``.
+
+    When ``epoch`` equals "now", this scalar must agree with
+    :func:`license_state` for the same install -- both derive from the
+    same signed ``exp`` claim and use the same ``exp <= cutoff``
+    boundary, so the two scalars cannot disagree. On any other epoch
+    this helper answers the retrospective / prospective question
+    :func:`license_state` cannot -- e.g. "was this key already expired
+    last Friday?" (``"expired"`` even on a key that has since been
+    renewed) or "will this key be expired at our next quarterly audit?"
+    (``"expired"`` on an active key whose ``exp`` falls before the audit
+    date).
+
+    ``epoch`` is coerced through ``int()``; ``bool`` is explicitly
+    refused despite being an ``int`` subclass so a caller that passes
+    ``True`` / ``False`` gets ``"no_license"`` back rather than a
+    spurious "was the key expired at epoch 1?" classification. A non-
+    numeric value collapses to ``"no_license"`` so a caller cannot
+    silently mis-gate on a typo -- the conservative fallback since
+    ``"no_license"`` implies no entitlement, matching the never-mis-gate
+    posture of the surrounding ``_at`` family.
+
+    Never raises. Any underlying introspection failure (import error,
+    corrupt install, cryptography-lib mismatch) collapses to
+    ``"no_license"`` -- same fallback as :func:`license_state` -- so a
+    scheduled audit tile bound to this helper never breaks on a partial
+    install.
+
+    Pairs with :func:`is_state_at` the way :func:`license_state` pairs
+    with :func:`is_state`: this getter surfaces the perspective-epoch
+    state string for an audit row, that matcher answers the "was the
+    install in state <X> at <date>?" gate without the caller having to
+    string-compare themselves.
+    """
+    if isinstance(epoch, bool):
+        return "no_license"
+    try:
+        wanted = int(epoch)
+    except (TypeError, ValueError):
+        return "no_license"
+    try:
+        info = current_license_info()
+    except Exception as exc:
+        logger.debug("license: license_state_at underlying read failed: %s", exc)
+        return "no_license"
+    if info is None:
+        return "no_license"
+    if not isinstance(info, dict):
+        return "no_license"
+    status = info.get("status")
+    if status == "invalid":
+        # Signature-bogus branch: an unsigned body is untrusted whatever
+        # the perspective, so the classification is time-independent.
+        # Mirrors :func:`license_state` -- payload-derived claims never
+        # get to influence the answer here.
+        return "invalid"
+    exp = info.get("exp")
+    if not isinstance(exp, (int, float)):
+        # Perpetual (no ``exp``) signed key -- never expires, so always
+        # ``"active"`` regardless of epoch. Matches how
+        # :func:`current_license_info` sets ``status="active"`` for a
+        # perpetual key at "now".
+        return "active"
+    return "expired" if int(exp) <= wanted else "active"
+
+
+def is_state_at(state: str, epoch: int) -> bool:
+    """Perspective-epoch flavour of :func:`is_state` -- "was the installed
+    license in state <X> evaluated as of ``epoch``?" -- for a scheduled-
+    audit tile that wants to answer "would we have shown the expired
+    banner on <date>?" without the caller having to snapshot the license
+    state at that time.
+
+    Compares :func:`license_state_at` case-insensitively (after strip)
+    to the supplied ``state``. Missing / empty / non-string input
+    degrades to ``False`` -- matches the never-raise posture of
+    :func:`is_state` / :func:`is_expired_at`.
+
+    Only values in :data:`LICENSE_STATES` can ever return ``True``; a
+    typo like ``"actiev"`` collapses to ``False`` so a caller cannot
+    silently mis-gate on a mis-spelled state name. Callers wanting to
+    validate their input up-front can ``if requested in LICENSE_STATES:``
+    against the same source of truth.
+
+    ``epoch`` is coerced through :func:`license_state_at`; ``bool`` and
+    non-numeric epochs are refused there and collapse this predicate to
+    ``False`` (unless the caller also asked ``state="no_license"``, in
+    which case the answer is truthfully ``True``: the perspective is
+    unusable so we cannot claim any richer state -- exactly matching the
+    conservative "no entitlement" fallback of :func:`license_state_at`).
+
+    When ``epoch`` equals "now", this predicate must agree with
+    :func:`is_state` for the same install and the same requested
+    ``state`` -- both derive from the same signed ``exp`` claim and use
+    the same ``<=`` cutoff via :func:`license_state_at` /
+    :func:`license_state`, so the two scalars cannot disagree at the
+    boundary. On any other epoch this helper answers the retrospective /
+    prospective question :func:`is_state` cannot.
+
+    Never raises. Any underlying failure of :func:`license_state_at`
+    collapses this to ``False`` -- a scheduled audit job bound to this
+    gate stays "unclaimed" rather than falsely asserting an entitlement
+    it can't verify.
+    """
+    try:
+        requested = str(state).strip().lower() if state is not None else ""
+    except Exception:
+        return False
+    if not requested or requested not in LICENSE_STATES:
+        return False
+    try:
+        current = license_state_at(epoch)
+    except Exception as exc:
+        logger.debug("license: is_state_at underlying read failed: %s", exc)
+        return False
+    return current == requested

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -10261,6 +10261,293 @@ def api_license_is_expired_at():
     )
 
 
+def _license_state_at_snapshot() -> dict:
+    """Shared one-shot read for the paired ``/api/license/state-at`` and
+    ``/api/license/is-state-at`` endpoints below.
+
+    Reads :func:`clawmetry.license.license_state` (current-time state),
+    :func:`clawmetry.license.current_license_info` (for ``has_license`` /
+    ``valid`` NOW), and :func:`clawmetry.license.license_expires_at`
+    (for the ``expires_at`` field the sibling perspective-epoch tiles
+    all carry) ONCE so a UI binding both endpoints in the same tile
+    can't catch them disagreeing on ``state`` / ``expires_at`` /
+    ``has_license`` / ``valid`` for the same install -- mirrors the
+    ``_license_state_snapshot`` + ``_license_expires_snapshot`` pattern
+    used by the current-time state pair and the ``exp``-derived
+    perspective-epoch trio.
+
+    ``state`` here is the CURRENT-time state (matches
+    :func:`clawmetry.license.license_state`); the perspective-epoch
+    state (``state_at``) is derived per-request by each endpoint via
+    :func:`clawmetry.license.license_state_at` and lives on top of this
+    snapshot -- keeping ``state`` in the shared read guarantees a UI
+    that renders "as of <date> vs now" tiles side-by-side can never
+    catch them disagreeing on the current-time reference.
+
+    Never raises. Any introspection failure collapses to the OSS-free
+    branch shape (``state="no_license"``, ``expires_at=None``,
+    ``has_license=False``, ``valid=False``) so the endpoint stack never
+    5xxs -- same posture as the surrounding license endpoints.
+    """
+    try:
+        from clawmetry import license as _lic
+
+        state = _lic.license_state()
+        info = _lic.current_license_info()
+        expires = _lic.license_expires_at()
+    except Exception as exc:
+        logger.debug("_license_state_at_snapshot: underlying read failed: %s", exc)
+        return {
+            "state": "no_license",
+            "expires_at": None,
+            "has_license": False,
+            "valid": False,
+        }
+    if not isinstance(state, str):
+        state = "no_license"
+    if info is None:
+        return {
+            "state": state,
+            "expires_at": None,
+            "has_license": False,
+            "valid": False,
+        }
+    if not isinstance(info, dict):
+        return {
+            "state": state,
+            "expires_at": None,
+            "has_license": False,
+            "valid": False,
+        }
+    return {
+        "state": state,
+        "expires_at": expires,
+        "has_license": True,
+        "valid": bool(info.get("valid")),
+    }
+
+
+@bp_entitlement.route("/api/license/state-at")
+def api_license_state_at():
+    """``GET /api/license/state-at?epoch=<int>`` -- scalar view of the
+    installed license's high-level lifecycle state evaluated as of
+    ``epoch`` -- the perspective-epoch flavour of ``/api/license/state``,
+    for a scheduled-audit / retrospective status badge that wants to
+    answer "would we have shown the expired banner on <date>?" without
+    the caller having to snapshot the license state at that time.
+
+    Response shape (always HTTP 200)::
+
+        {
+          "state_at": "<active|expired|invalid|no_license>",  # evaluated at epoch
+          "requested_epoch": <int|null>,      # int-coerced input, or null on typo
+          "state": "<active|expired|invalid|no_license>",     # current-time state
+          "expires_at": <int|null>,           # on-disk exp for comparison
+          "has_license": <bool>,              # is a license file installed at all?
+          "valid": <bool>                     # signature-valid AND not expired NOW
+        }
+
+    ``state_at`` mirrors :func:`clawmetry.license.license_state_at`
+    exactly:
+
+      * ``"active"``   -- signature-valid AND (perpetual OR ``exp > epoch``).
+      * ``"expired"``  -- signature-valid, carries an ``exp`` claim, AND
+        ``exp <= epoch``. Retrospective on a lapsed key when ``epoch``
+        equals "now"; prospective on an active key when ``epoch`` is in
+        the future beyond ``exp``.
+      * ``"invalid"``  -- file exists but signature is bogus (time-
+        independent).
+      * ``"no_license"`` -- no license file on disk (also time-
+        independent, and the fallback on missing / non-integer ``epoch``
+        so a caller cannot silently mis-gate on a typo).
+
+    Unlike ``/api/license/tier`` / ``/api/license/subject`` /
+    ``/api/license/nodes`` (which surface ``null`` on the invalid /
+    expired / no-license branches), this endpoint always carries a
+    non-null string for ``state_at`` -- "no license" is a real answer
+    here, not a missing answer, so a UI switch can bind directly on
+    ``data.state_at`` without a null branch.
+
+    Query parameter:
+
+      * ``epoch`` -- required. Unix epoch seconds as an integer. A
+        missing / non-integer / bool value collapses to
+        ``state_at="no_license"`` with ``requested_epoch=null`` so a
+        caller cannot silently mis-gate on a typo. HTTP status is 200
+        either way -- the "bad input" signal is ``requested_epoch=null``
+        plus the ``"no_license"`` state, not a 4xx, matching the never-
+        crash posture of the surrounding license endpoints.
+
+    Pairs with ``/api/license/is-expired-at`` /
+    ``/api/license/is-expiring-at`` / ``/api/license/days-until-expiry-at``
+    -- all four share the perspective-epoch input pattern and the
+    ``_license_state_at_snapshot`` reader here carries ``expires_at`` /
+    ``has_license`` / ``valid`` on the same shape those three carry, so
+    a UI binding two for the same install cannot catch them
+    disagreeing on the current-time reference fields.
+
+    When ``epoch`` equals "now", the ``state_at`` field must byte-equal
+    ``state`` (both derive from the same signed ``exp`` claim and use
+    the same ``exp <= cutoff`` boundary via :func:`license_state_at` /
+    :func:`license_state`), so a UI binding both cannot catch them
+    disagreeing at the boundary.
+
+    Never 5xxs -- any underlying failure degrades to
+    ``{state_at: "no_license", requested_epoch: <echo>, state:
+    "no_license", expires_at: null, has_license: false, valid: false}``
+    (the OSS-free branch shape).
+    """
+    raw = request.args.get("epoch", "")
+    try:
+        requested = int(str(raw).strip())
+    except (TypeError, ValueError):
+        requested = None
+    try:
+        snap = _license_state_at_snapshot()
+    except Exception as exc:
+        logger.warning("api_license_state_at: snapshot error: %s", exc)
+        snap = {
+            "state": "no_license",
+            "expires_at": None,
+            "has_license": False,
+            "valid": False,
+        }
+    state_at = "no_license"
+    if requested is not None:
+        try:
+            from clawmetry import license as _lic
+
+            state_at = _lic.license_state_at(requested)
+        except Exception as exc:
+            logger.warning("api_license_state_at: derive error: %s", exc)
+            state_at = "no_license"
+    if not isinstance(state_at, str):
+        state_at = "no_license"
+    return jsonify(
+        {
+            "state_at": state_at,
+            "requested_epoch": requested,
+            "state": snap["state"],
+            "expires_at": snap["expires_at"],
+            "has_license": snap["has_license"],
+            "valid": snap["valid"],
+        }
+    )
+
+
+@bp_entitlement.route("/api/license/is-state-at")
+def api_license_is_state_at():
+    """``GET /api/license/is-state-at?state=<name>&epoch=<int>`` --
+    boolean gate for "was the installed license in state <X> evaluated
+    as of ``epoch``?" -- the perspective-epoch flavour of
+    ``/api/license/is-state``, for a scheduled-audit tile that wants to
+    answer "would we have shown the expired banner on <date>?" without
+    the caller having to snapshot the license state at that time or
+    string-compare themselves.
+
+    Query parameters:
+      * ``state`` (str, required) -- the state to test against. One of
+        ``"active"``, ``"expired"``, ``"invalid"``, ``"no_license"``.
+        Compared case-insensitively after strip, matching
+        :func:`clawmetry.license.is_state_at`. Missing / empty / unknown
+        input degrades to ``is_state_at=false`` rather than a 4xx.
+      * ``epoch`` (int, required) -- Unix epoch seconds. Missing / non-
+        integer / bool input collapses ``state_at`` to ``"no_license"``
+        and the predicate to ``false`` (unless ``state=no_license`` is
+        also requested, in which case the answer is truthfully ``true``
+        -- the perspective is unusable so the conservative "no
+        entitlement" fallback holds).
+
+    Response shape (always HTTP 200)::
+
+        {
+          "is_state_at": <bool>,
+          "state_at": "<active|expired|invalid|no_license>",  # evaluated at epoch
+          "requested_state": <str>,          # normalised echo of query
+          "requested_epoch": <int|null>,     # int-coerced input, or null on typo
+          "state": "<active|expired|invalid|no_license>",     # current-time state
+          "expires_at": <int|null>,
+          "has_license": <bool>,
+          "valid": <bool>                    # signature-valid AND not expired NOW
+        }
+
+    ``is_state_at`` is ``True`` iff the perspective-epoch state
+    byte-equals ``requested_state`` (after both are lower/stripped) AND
+    the requested value is one of the four canonical states -- a typo
+    like ``?state=actiev`` returns ``is_state_at=false`` so a caller
+    cannot silently mis-gate on a mis-spelled state name.
+
+    Mirrors :func:`clawmetry.license.is_state_at` -- the HTTP shape
+    layers ``state_at`` / ``requested_state`` / ``requested_epoch`` /
+    ``state`` / ``expires_at`` / ``has_license`` / ``valid`` on top of
+    that bool so a widget never needs a second call to
+    ``/api/license/state-at`` (or ``/api/license/state``) to render the
+    accompanying "you're in state <X>" copy.
+
+    When ``epoch`` equals "now" and ``state`` is a canonical value, this
+    endpoint must agree with ``/api/license/is-state`` at the boundary
+    for the same install -- both derive from the same signed ``exp``
+    claim via :func:`license_state_at` / :func:`license_state`, so a UI
+    binding both cannot catch them disagreeing at the boundary.
+
+    Never 5xxs -- any underlying failure degrades to the OSS-free
+    branch shape (``is_state_at=false``, ``state_at="no_license"``,
+    ``state="no_license"``, ``expires_at=null``, ``has_license=false``,
+    ``valid=false``), matching the never-crash posture of the
+    surrounding license endpoints.
+    """
+    from clawmetry.license import LICENSE_STATES
+
+    raw_state = request.args.get("state", "") or ""
+    try:
+        requested_state = str(raw_state).strip().lower()
+    except Exception:
+        requested_state = ""
+    raw_epoch = request.args.get("epoch", "")
+    try:
+        requested_epoch = int(str(raw_epoch).strip())
+    except (TypeError, ValueError):
+        requested_epoch = None
+    try:
+        snap = _license_state_at_snapshot()
+    except Exception as exc:
+        logger.warning("api_license_is_state_at: snapshot error: %s", exc)
+        snap = {
+            "state": "no_license",
+            "expires_at": None,
+            "has_license": False,
+            "valid": False,
+        }
+    state_at = "no_license"
+    if requested_epoch is not None:
+        try:
+            from clawmetry import license as _lic
+
+            state_at = _lic.license_state_at(requested_epoch)
+        except Exception as exc:
+            logger.warning("api_license_is_state_at: derive error: %s", exc)
+            state_at = "no_license"
+    if not isinstance(state_at, str):
+        state_at = "no_license"
+    match = bool(
+        requested_state
+        and requested_state in LICENSE_STATES
+        and state_at == requested_state
+    )
+    return jsonify(
+        {
+            "is_state_at": match,
+            "state_at": state_at,
+            "requested_state": requested_state,
+            "requested_epoch": requested_epoch,
+            "state": snap["state"],
+            "expires_at": snap["expires_at"],
+            "has_license": snap["has_license"],
+            "valid": snap["valid"],
+        }
+    )
+
+
 @bp_entitlement.route("/api/paywall/event", methods=["POST"])
 def api_paywall_event():
     body: dict = {}

--- a/tests/test_license_state_at_scalar.py
+++ b/tests/test_license_state_at_scalar.py
@@ -1,0 +1,745 @@
+"""Tests for the ``license_state_at(epoch)`` / ``is_state_at(state, epoch)``
+scalar helpers on ``clawmetry.license`` and their paired
+``/api/license/state-at`` and ``/api/license/is-state-at`` HTTP endpoints.
+
+The perspective-epoch flavour of the ``license_state`` / ``is_state`` pair.
+Both derive from the same signed ``exp`` claim so they cannot disagree at
+the boundary when the perspective epoch equals "now"; on any other epoch
+these helpers answer "what state would the installed license have
+reported evaluated as of ``epoch``?" without the caller having to
+snapshot the license state at that time or compare ``exp`` to a caller-
+supplied epoch themselves.
+
+Hermetic: each test mints tokens with its own ephemeral keypair and
+monkeypatches the module's embedded public key + ``LICENSE_PATH``,
+mirroring ``tests/test_license_is_expired_at.py`` /
+``tests/test_license_state_scalar.py`` so nothing depends on the real
+production signing key or on real filesystem state.
+"""
+from __future__ import annotations
+
+import time
+from types import SimpleNamespace
+
+import pytest
+from flask import Flask
+
+
+# -- shared helpers (mirror test_license_is_expired_at.py) --------------------
+
+
+def _keypair():
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+    priv = Ed25519PrivateKey.generate()
+    pub_pem = priv.public_key().public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    return priv, pub_pem
+
+
+def _payload(tier="pro", nodes=3, exp_delta=365 * 86400, drop_exp=False):
+    now = int(time.time())
+    p = {
+        "sub": "acct_test",
+        "tier": tier,
+        "nodes": nodes,
+        "iat": now,
+        "exp": now + exp_delta,
+        "features": ["runtimes"],
+    }
+    if drop_exp:
+        p.pop("exp", None)
+    return p
+
+
+@pytest.fixture
+def app(monkeypatch, tmp_path):
+    import clawmetry.license as _lic
+
+    priv, pub_pem = _keypair()
+    monkeypatch.setattr(_lic, "_PUBLIC_KEY_PEM", pub_pem)
+    license_path = str(tmp_path / "license.key")
+    monkeypatch.setattr(_lic, "LICENSE_PATH", license_path)
+    monkeypatch.delenv("CLAWMETRY_LICENSE_SERVER", raising=False)
+    monkeypatch.delenv("CLAWMETRY_INGEST_URL", raising=False)
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("CLAWMETRY_OFFLINE", "1")
+
+    from routes.entitlement import bp_entitlement
+
+    flask_app = Flask(__name__)
+    flask_app.register_blueprint(bp_entitlement)
+    flask_app.config["TESTING"] = True
+
+    return SimpleNamespace(
+        app=flask_app,
+        lic=_lic,
+        priv=priv,
+        license_path=license_path,
+    )
+
+
+def _write_key_direct(app, exp_delta):
+    """Bypass activate() (which refuses expired tokens) and write a token
+    directly to the license file. Simulates a license that expired AFTER
+    it was installed."""
+    import os
+
+    tok = app.lic._encode_token(_payload(exp_delta=exp_delta), app.priv)
+    os.makedirs(os.path.dirname(app.license_path), exist_ok=True)
+    with open(app.license_path, "w", encoding="utf-8") as fh:
+        fh.write(tok)
+
+
+def _write_perpetual(app):
+    import os
+
+    tok = app.lic._encode_token(_payload(drop_exp=True), app.priv)
+    os.makedirs(os.path.dirname(app.license_path), exist_ok=True)
+    with open(app.license_path, "w", encoding="utf-8") as fh:
+        fh.write(tok)
+
+
+def _write_bogus(app):
+    import os
+
+    os.makedirs(os.path.dirname(app.license_path), exist_ok=True)
+    with open(app.license_path, "w", encoding="utf-8") as fh:
+        fh.write("CLAW1.garbage.garbage")
+
+
+# -- clawmetry.license.license_state_at() -------------------------------------
+
+
+def test_license_state_at_no_license(app):
+    """No license file on disk -> ``"no_license"`` regardless of epoch."""
+    assert app.lic.license_state_at(int(time.time())) == "no_license"
+    assert app.lic.license_state_at(0) == "no_license"
+    assert app.lic.license_state_at(2_000_000_000) == "no_license"
+
+
+def test_license_state_at_now_matches_license_state_active(app):
+    """When ``epoch`` equals "now", the perspective-epoch scalar must agree
+    with :func:`license_state` on the same install. Both derive from the
+    same signed ``exp`` claim, so a UI binding both cannot catch them
+    disagreeing at the boundary for an active key."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    now = int(time.time())
+    assert app.lic.license_state_at(now) == "active"
+    assert app.lic.license_state() == "active"
+
+
+def test_license_state_at_now_matches_license_state_lapsed(app):
+    """Lapsed-key parity: at "now", perspective scalar and base scalar
+    must agree on ``"expired"`` -- both use the ``exp <= cutoff`` boundary."""
+    _write_key_direct(app, exp_delta=-5 * 86400)
+    now = int(time.time())
+    assert app.lic.license_state_at(now) == "expired"
+    assert app.lic.license_state() == "expired"
+
+
+def test_license_state_at_future_epoch_before_expiry(app):
+    """Future perspective still before ``exp`` -> ``"active"`` (key would
+    NOT yet be expired at that perspective)."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    epoch = int(time.time()) + 10 * 86400
+    assert app.lic.license_state_at(epoch) == "active"
+
+
+def test_license_state_at_future_epoch_after_expiry(app):
+    """Future perspective AFTER ``exp`` on an active key -> ``"expired"``
+    (the key WILL be expired at that perspective). This is the "will the
+    key be expired at our next audit?" prospective scenario."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    epoch = int(time.time()) + 60 * 86400
+    assert app.lic.license_state_at(epoch) == "expired"
+
+
+def test_license_state_at_past_epoch_still_active(app):
+    """Perspective BEFORE now on an active key -> ``"active"`` (the key
+    was not yet expired then, since ``exp`` is even further in the future)."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    epoch = int(time.time()) - 10 * 86400
+    assert app.lic.license_state_at(epoch) == "active"
+
+
+def test_license_state_at_exact_exp_boundary(app):
+    """At the exact ``exp`` second, the classification must flip to
+    ``"expired"`` -- the ``<= epoch`` cutoff matches
+    :func:`current_license_info`'s ``status`` derivation (which uses
+    ``exp <= now``)."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    info = app.lic.current_license_info()
+    assert isinstance(info, dict)
+    exp = info["exp"]
+    assert app.lic.license_state_at(exp) == "expired"
+    assert app.lic.license_state_at(exp - 1) == "active"
+
+
+def test_license_state_at_lapsed_key_pre_lapse_epoch(app):
+    """Lapsed-but-signed key evaluated at a perspective epoch BEFORE its
+    ``exp`` -> ``"active"``. Retrospective "was this active on <date>
+    before it lapsed?" is answerable without special-casing the expired
+    branch."""
+    _write_key_direct(app, exp_delta=-5 * 86400)  # exp = now - 5d
+    epoch = int(time.time()) - 20 * 86400  # 15 days before exp
+    assert app.lic.license_state_at(epoch) == "active"
+
+
+def test_license_state_at_perpetual_license(app):
+    """Perpetual (no ``exp``) license -> ``"active"`` regardless of
+    perspective epoch. Nothing to compare against; matches
+    :func:`license_state`'s ``"active"`` classification for perpetual
+    keys."""
+    _write_perpetual(app)
+    assert app.lic.license_state_at(int(time.time())) == "active"
+    assert app.lic.license_state_at(0) == "active"
+    assert app.lic.license_state_at(2_000_000_000) == "active"
+
+
+def test_license_state_at_invalid_signature_time_independent(app):
+    """File on disk but signature bogus -> ``"invalid"`` regardless of
+    epoch (an unsigned body is untrusted whatever the perspective)."""
+    _write_bogus(app)
+    assert app.lic.license_state_at(int(time.time())) == "invalid"
+    assert app.lic.license_state_at(0) == "invalid"
+    assert app.lic.license_state_at(2_000_000_000) == "invalid"
+
+
+def test_license_state_at_non_numeric_epoch(app):
+    """A caller passing a typo must get ``"no_license"`` (the conservative
+    fallback), not a crash. Mirrors :func:`is_expired_at` / typo posture."""
+    tok = app.lic._encode_token(_payload(exp_delta=-5 * 86400), app.priv)
+    _write_key_direct(app, exp_delta=-5 * 86400)
+    assert app.lic.license_state_at("garbage") == "no_license"  # type: ignore[arg-type]
+    assert app.lic.license_state_at(None) == "no_license"  # type: ignore[arg-type]
+    assert app.lic.license_state_at([1]) == "no_license"  # type: ignore[arg-type]
+    assert app.lic.license_state_at({}) == "no_license"  # type: ignore[arg-type]
+
+
+def test_license_state_at_bool_epoch_rejected(app):
+    """``bool`` is an ``int`` subclass -- explicitly refuse it so a
+    caller that passes ``True`` doesn't silently ask "state at epoch 1?"
+    and get a spurious classification. Mirrors :func:`is_expired_at`."""
+    _write_key_direct(app, exp_delta=-5 * 86400)
+    assert app.lic.license_state_at(True) == "no_license"  # type: ignore[arg-type]
+    assert app.lic.license_state_at(False) == "no_license"  # type: ignore[arg-type]
+
+
+def test_license_state_at_float_epoch_coerced(app):
+    """Float epoch must coerce through ``int()`` rather than crash --
+    matches :func:`is_expired_at` / :func:`days_until_expiry_at`."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    assert app.lic.license_state_at(float(time.time())) == "active"
+
+
+def test_license_state_at_never_raises(monkeypatch):
+    """Any underlying failure -> ``"no_license"``. Even a fully-broken
+    current_license_info() must not propagate."""
+    import clawmetry.license as _lic
+
+    def _boom():
+        raise RuntimeError("simulated corrupt install")
+
+    monkeypatch.setattr(_lic, "current_license_info", _boom)
+    assert _lic.license_state_at(int(time.time())) == "no_license"
+
+
+# -- clawmetry.license.is_state_at() ------------------------------------------
+
+
+def test_is_state_at_no_license_matches_no_license(app):
+    """No file -> is_state_at('no_license', epoch) is True; every other
+    canonical state is False. Boundary case for the OSS-free branch."""
+    epoch = int(time.time())
+    assert app.lic.is_state_at("no_license", epoch) is True
+    assert app.lic.is_state_at("active", epoch) is False
+    assert app.lic.is_state_at("expired", epoch) is False
+    assert app.lic.is_state_at("invalid", epoch) is False
+
+
+def test_is_state_at_now_matches_is_state_active(app):
+    """At "now", the perspective-epoch predicate must agree with
+    :func:`is_state` for every canonical requested state -- both derive
+    from the same signed ``exp`` claim."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    now = int(time.time())
+    for state in ("active", "expired", "invalid", "no_license"):
+        assert app.lic.is_state_at(state, now) == app.lic.is_state(state), state
+
+
+def test_is_state_at_now_matches_is_state_lapsed(app):
+    """Lapsed-key parity at "now": perspective predicate and base
+    predicate must both fire ``True`` on ``state="expired"``."""
+    _write_key_direct(app, exp_delta=-5 * 86400)
+    now = int(time.time())
+    for state in ("active", "expired", "invalid", "no_license"):
+        assert app.lic.is_state_at(state, now) == app.lic.is_state(state), state
+
+
+def test_is_state_at_future_epoch_flips_active_to_expired(app):
+    """An active key at a perspective epoch beyond ``exp`` flips the
+    ``"expired"`` predicate to True and the ``"active"`` predicate to
+    False -- the prospective question :func:`is_state` cannot answer."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    epoch = int(time.time()) + 60 * 86400
+    assert app.lic.is_state_at("expired", epoch) is True
+    assert app.lic.is_state_at("active", epoch) is False
+
+
+def test_is_state_at_case_insensitive(app):
+    """Requested state is compared case-insensitively after strip --
+    mirrors :func:`is_state`."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    now = int(time.time())
+    for cased in ("ACTIVE", "Active", " active ", "aCtIvE"):
+        assert app.lic.is_state_at(cased, now) is True
+
+
+def test_is_state_at_typo_state_rejected(app):
+    """A typo like 'actiev' collapses to False -- a caller cannot
+    silently mis-gate on a mis-spelled state name."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    now = int(time.time())
+    for bad in ("actiev", "expiring", "grace", "invalidated", ""):
+        assert app.lic.is_state_at(bad, now) is False, bad
+
+
+def test_is_state_at_bad_state_input_rejected(app):
+    """Non-string / None state -> False, never a crash."""
+    now = int(time.time())
+    assert app.lic.is_state_at(None, now) is False  # type: ignore[arg-type]
+    assert app.lic.is_state_at(123, now) is False  # type: ignore[arg-type]
+    assert app.lic.is_state_at([], now) is False  # type: ignore[arg-type]
+
+
+def test_is_state_at_bad_epoch_falls_back_to_no_license(app):
+    """A bad epoch collapses ``license_state_at`` to ``"no_license"``, so
+    the predicate answers truthfully for that fallback: True only when
+    the caller also asks ``state="no_license"``. Documents the
+    conservative "no entitlement" contract."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    assert app.lic.is_state_at("no_license", "garbage") is True  # type: ignore[arg-type]
+    assert app.lic.is_state_at("active", "garbage") is False  # type: ignore[arg-type]
+    assert app.lic.is_state_at("no_license", True) is True  # type: ignore[arg-type]
+    assert app.lic.is_state_at("active", True) is False  # type: ignore[arg-type]
+
+
+def test_is_state_at_never_raises(monkeypatch):
+    """Any underlying failure of license_state_at -> False. Even a fully-
+    broken helper must not propagate."""
+    import clawmetry.license as _lic
+
+    def _boom(_epoch):
+        raise RuntimeError("simulated corrupt install")
+
+    monkeypatch.setattr(_lic, "license_state_at", _boom)
+    assert _lic.is_state_at("active", int(time.time())) is False
+
+
+# -- GET /api/license/state-at -------------------------------------------------
+
+
+def test_endpoint_state_at_no_license(app):
+    epoch = int(time.time())
+    with app.app.test_client() as c:
+        resp = c.get(f"/api/license/state-at?epoch={epoch}")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["state_at"] == "no_license"
+    assert data["requested_epoch"] == epoch
+    assert data["state"] == "no_license"
+    assert data["expires_at"] is None
+    assert data["has_license"] is False
+    assert data["valid"] is False
+
+
+def test_endpoint_state_at_active_at_now(app):
+    """Active key at "now" -> state_at "active", state "active", valid
+    True, expires_at populated for the sibling perspective-epoch tiles."""
+    tok = app.lic._encode_token(_payload(exp_delta=45 * 86400), app.priv)
+    app.lic.activate(tok)
+    now = int(time.time())
+    with app.app.test_client() as c:
+        resp = c.get(f"/api/license/state-at?epoch={now}")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["state_at"] == "active"
+    assert data["state"] == "active"
+    assert data["requested_epoch"] == now
+    assert isinstance(data["expires_at"], int)
+    assert data["has_license"] is True
+    assert data["valid"] is True
+
+
+def test_endpoint_state_at_active_at_future_after_exp(app):
+    """Active key evaluated at a perspective epoch AFTER ``exp`` ->
+    state_at "expired" (prospective), state STILL "active" (the key is
+    not expired NOW). This is the whole point of the perspective-epoch
+    scalar."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    epoch = int(time.time()) + 60 * 86400
+    with app.app.test_client() as c:
+        resp = c.get(f"/api/license/state-at?epoch={epoch}")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["state_at"] == "expired"
+    assert data["state"] == "active"
+    assert data["valid"] is True
+    assert data["has_license"] is True
+
+
+def test_endpoint_state_at_lapsed_at_now(app):
+    """Lapsed-but-signed key at "now" -> state_at "expired", state
+    "expired", valid False. Retrospective banner can bind on state_at."""
+    _write_key_direct(app, exp_delta=-5 * 86400)
+    now = int(time.time())
+    with app.app.test_client() as c:
+        resp = c.get(f"/api/license/state-at?epoch={now}")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["state_at"] == "expired"
+    assert data["state"] == "expired"
+    assert data["has_license"] is True
+    assert data["valid"] is False
+
+
+def test_endpoint_state_at_lapsed_at_pre_lapse_epoch(app):
+    """Lapsed-but-signed key at a perspective epoch BEFORE its ``exp`` ->
+    state_at "active" (retrospective), state "expired" (the key is
+    expired NOW). state_at flips independently of the current-state."""
+    _write_key_direct(app, exp_delta=-5 * 86400)
+    epoch = int(time.time()) - 20 * 86400
+    with app.app.test_client() as c:
+        resp = c.get(f"/api/license/state-at?epoch={epoch}")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["state_at"] == "active"
+    assert data["state"] == "expired"
+    assert data["has_license"] is True
+    assert data["valid"] is False
+
+
+def test_endpoint_state_at_perpetual_license(app):
+    """Perpetual license -> state_at "active" at any epoch. expires_at
+    null because no ``exp`` claim; has_license True."""
+    _write_perpetual(app)
+    with app.app.test_client() as c:
+        resp = c.get(f"/api/license/state-at?epoch={int(time.time())}")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["state_at"] == "active"
+    assert data["state"] == "active"
+    assert data["expires_at"] is None
+    assert data["has_license"] is True
+    assert data["valid"] is True
+
+
+def test_endpoint_state_at_invalid_signature_time_independent(app):
+    """File on disk but signature bogus -> state_at "invalid" at any
+    epoch (time-independent), state "invalid", has_license True, valid
+    False."""
+    _write_bogus(app)
+    for epoch in (0, int(time.time()), 2_000_000_000):
+        with app.app.test_client() as c:
+            resp = c.get(f"/api/license/state-at?epoch={epoch}")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["state_at"] == "invalid", epoch
+        assert data["state"] == "invalid"
+        assert data["has_license"] is True
+        assert data["valid"] is False
+
+
+def test_endpoint_state_at_missing_epoch(app):
+    """No ``epoch=`` -> state_at "no_license" (fallback), requested_epoch
+    null, HTTP 200. The snapshot still populates state/expires_at from
+    the on-disk key."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    with app.app.test_client() as c:
+        resp = c.get("/api/license/state-at")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["state_at"] == "no_license"
+    assert data["requested_epoch"] is None
+    assert data["state"] == "active"
+    assert isinstance(data["expires_at"], int)
+    assert data["has_license"] is True
+
+
+def test_endpoint_state_at_non_integer_epoch(app):
+    """Typo epoch -> state_at "no_license", requested_epoch null, HTTP
+    200 (never a 4xx). Mirrors ``/api/license/is-expired-at``."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    with app.app.test_client() as c:
+        resp = c.get("/api/license/state-at?epoch=garbage")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["state_at"] == "no_license"
+    assert data["requested_epoch"] is None
+    assert data["state"] == "active"
+    assert data["has_license"] is True
+
+
+def test_endpoint_state_at_never_5xxs(app, monkeypatch):
+    """Even if the shared snapshot blows up mid-request, the endpoint
+    must still return HTTP 200 with the OSS-free shape (snapshot fallback
+    kicks in, requested_epoch is still echoed)."""
+    from routes import entitlement as _routes
+
+    monkeypatch.setattr(
+        _routes,
+        "_license_state_at_snapshot",
+        lambda: (_ for _ in ()).throw(RuntimeError("simulated blowup")),
+    )
+    epoch = int(time.time())
+    with app.app.test_client() as c:
+        resp = c.get(f"/api/license/state-at?epoch={epoch}")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    # Snapshot fell back; the derive() step still ran fine, so state_at
+    # is honestly derived from the underlying (no-file) install.
+    assert data["state_at"] == "no_license"
+    assert data["requested_epoch"] == epoch
+    assert data["state"] == "no_license"
+    assert data["expires_at"] is None
+    assert data["has_license"] is False
+    assert data["valid"] is False
+
+
+# -- GET /api/license/is-state-at ---------------------------------------------
+
+
+def test_endpoint_is_state_at_no_license_matches_no_license(app):
+    """No file -> is_state_at true for state=no_license, false for the
+    other three canonical values."""
+    epoch = int(time.time())
+    with app.app.test_client() as c:
+        yes = c.get(f"/api/license/is-state-at?state=no_license&epoch={epoch}").get_json()
+        no = c.get(f"/api/license/is-state-at?state=active&epoch={epoch}").get_json()
+    assert yes["is_state_at"] is True
+    assert yes["state_at"] == "no_license"
+    assert no["is_state_at"] is False
+    assert no["state_at"] == "no_license"
+
+
+def test_endpoint_is_state_at_active_at_now(app):
+    """Active key at "now" -> is_state_at true for state=active."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    now = int(time.time())
+    with app.app.test_client() as c:
+        resp = c.get(f"/api/license/is-state-at?state=active&epoch={now}")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["is_state_at"] is True
+    assert data["state_at"] == "active"
+    assert data["state"] == "active"
+    assert data["requested_state"] == "active"
+    assert data["requested_epoch"] == now
+    assert data["has_license"] is True
+    assert data["valid"] is True
+
+
+def test_endpoint_is_state_at_flips_active_to_expired_at_future(app):
+    """Active key at future epoch beyond ``exp`` -> state_at "expired",
+    state STILL "active" (key is not expired NOW). is_state_at true for
+    state=expired, false for state=active."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    epoch = int(time.time()) + 60 * 86400
+    with app.app.test_client() as c:
+        exp_data = c.get(f"/api/license/is-state-at?state=expired&epoch={epoch}").get_json()
+        act_data = c.get(f"/api/license/is-state-at?state=active&epoch={epoch}").get_json()
+    assert exp_data["is_state_at"] is True
+    assert act_data["is_state_at"] is False
+    assert exp_data["state_at"] == "expired"
+    assert exp_data["state"] == "active"
+
+
+def test_endpoint_is_state_at_case_insensitive(app):
+    """Requested state compared case-insensitively (matches
+    ``/api/license/is-state``)."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    now = int(time.time())
+    with app.app.test_client() as c:
+        for cased in ("ACTIVE", "Active", " active "):
+            data = c.get(
+                f"/api/license/is-state-at?state={cased}&epoch={now}"
+            ).get_json()
+            assert data["is_state_at"] is True, cased
+            assert data["requested_state"] == "active"
+
+
+def test_endpoint_is_state_at_typo_state(app):
+    """Typo state -> is_state_at false. The endpoint STILL echoes state_at
+    honestly (perspective-epoch state) so a UI can render the actual state
+    alongside the "your state=<typo> is not matched" copy."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    now = int(time.time())
+    with app.app.test_client() as c:
+        data = c.get(
+            f"/api/license/is-state-at?state=actiev&epoch={now}"
+        ).get_json()
+    assert data["is_state_at"] is False
+    assert data["state_at"] == "active"
+    assert data["requested_state"] == "actiev"
+
+
+def test_endpoint_is_state_at_missing_args(app):
+    """No state, no epoch -> is_state_at false, state_at "no_license"
+    (bad epoch), requested_epoch null, requested_state '', HTTP 200."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    with app.app.test_client() as c:
+        resp = c.get("/api/license/is-state-at")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["is_state_at"] is False
+    assert data["state_at"] == "no_license"
+    assert data["requested_epoch"] is None
+    assert data["requested_state"] == ""
+    assert data["state"] == "active"
+
+
+def test_endpoint_is_state_at_bad_epoch(app):
+    """Typo epoch -> state_at "no_license"; requesting state=no_license
+    against a real install is thus truthfully true. Documents the
+    conservative "no entitlement" fallback."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    with app.app.test_client() as c:
+        good = c.get(
+            "/api/license/is-state-at?state=no_license&epoch=garbage"
+        ).get_json()
+        bad = c.get(
+            "/api/license/is-state-at?state=active&epoch=garbage"
+        ).get_json()
+    assert good["is_state_at"] is True
+    assert good["state_at"] == "no_license"
+    assert good["requested_epoch"] is None
+    assert bad["is_state_at"] is False
+    assert bad["state_at"] == "no_license"
+
+
+def test_endpoint_is_state_at_never_5xxs(app, monkeypatch):
+    """Snapshot blowup -> OSS-free shape, HTTP 200. Mirrors
+    ``/api/license/is-expired-at`` never-5xx invariant."""
+    from routes import entitlement as _routes
+
+    monkeypatch.setattr(
+        _routes,
+        "_license_state_at_snapshot",
+        lambda: (_ for _ in ()).throw(RuntimeError("simulated blowup")),
+    )
+    epoch = int(time.time())
+    with app.app.test_client() as c:
+        resp = c.get(f"/api/license/is-state-at?state=active&epoch={epoch}")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["is_state_at"] is False
+    assert data["state_at"] == "no_license"
+    assert data["state"] == "no_license"
+    assert data["requested_epoch"] == epoch
+    assert data["requested_state"] == "active"
+    assert data["has_license"] is False
+    assert data["valid"] is False
+
+
+# -- cross-endpoint consistency ------------------------------------------------
+
+
+def test_endpoint_state_at_now_agrees_with_state(app):
+    """At "now", ``/api/license/state-at`` must byte-equal
+    ``/api/license/state`` for the same install. Both derive from the
+    same signed ``exp`` claim so a UI binding both cannot catch them
+    disagreeing at the boundary."""
+    tok = app.lic._encode_token(_payload(exp_delta=45 * 86400), app.priv)
+    app.lic.activate(tok)
+    now = int(time.time())
+    with app.app.test_client() as c:
+        a = c.get(f"/api/license/state-at?epoch={now}").get_json()
+        b = c.get("/api/license/state").get_json()
+    assert a["state_at"] == a["state"] == b["state"] == "active"
+    assert a["has_license"] == b["has_license"] is True
+    assert a["valid"] == b["valid"] is True
+
+
+def test_endpoint_state_at_now_agrees_with_state_lapsed(app):
+    """Lapsed-key parity: perspective endpoint at "now" and base endpoint
+    must both classify as ``"expired"``."""
+    _write_key_direct(app, exp_delta=-5 * 86400)
+    now = int(time.time())
+    with app.app.test_client() as c:
+        a = c.get(f"/api/license/state-at?epoch={now}").get_json()
+        b = c.get("/api/license/state").get_json()
+    assert a["state_at"] == a["state"] == b["state"] == "expired"
+
+
+def test_endpoint_is_state_at_now_agrees_with_is_state(app):
+    """At "now", is-state-at must byte-match is-state for every canonical
+    requested state. Boundary check for the UI binding both."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    now = int(time.time())
+    with app.app.test_client() as c:
+        for state in ("active", "expired", "invalid", "no_license"):
+            a = c.get(
+                f"/api/license/is-state-at?state={state}&epoch={now}"
+            ).get_json()
+            b = c.get(f"/api/license/is-state?state={state}").get_json()
+            assert a["is_state_at"] == b["is_state"], state
+
+
+def test_endpoint_state_at_shares_expires_with_is_expired_at(app):
+    """``/api/license/state-at`` and ``/api/license/is-expired-at`` both
+    surface ``expires_at`` / ``has_license`` / ``valid`` from an on-disk
+    read. A UI binding both for the same install must not catch them
+    disagreeing on those shared fields."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    epoch = int(time.time()) + 5 * 86400
+    with app.app.test_client() as c:
+        a = c.get(f"/api/license/state-at?epoch={epoch}").get_json()
+        b = c.get(f"/api/license/is-expired-at?epoch={epoch}").get_json()
+    for key in ("expires_at", "has_license", "valid"):
+        assert a[key] == b[key], (
+            f"mismatch on {key}: state-at={a[key]!r} "
+            f"is-expired-at={b[key]!r}"
+        )
+    assert a["requested_epoch"] == b["requested_epoch"] == epoch
+
+
+def test_endpoint_is_state_at_agrees_with_state_at(app):
+    """``is-state-at`` must fire ``True`` on the canonical value that
+    ``state-at`` returned, and only that value. Boundary check for the UI
+    binding the pair."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    epoch = int(time.time()) + 60 * 86400  # active-now, expired-at-perspective
+    with app.app.test_client() as c:
+        sa = c.get(f"/api/license/state-at?epoch={epoch}").get_json()
+        for state in ("active", "expired", "invalid", "no_license"):
+            data = c.get(
+                f"/api/license/is-state-at?state={state}&epoch={epoch}"
+            ).get_json()
+            assert data["is_state_at"] is (state == sa["state_at"]), state


### PR DESCRIPTION
## Summary

- Adds the missing perspective-epoch (`_at`) siblings of `license_state()` and `is_state()` on `clawmetry.license`. Every other license lifecycle helper on the module already has one; this closes the last non-boolean hole in the family.
- Adds the paired `GET /api/license/state-at` and `GET /api/license/is-state-at` endpoints on `bp_entitlement`. A new `_license_state_at_snapshot()` reader keeps the shared six-field shape (`state_at` / `state` / `expires_at` / `has_license` / `valid` / `requested_epoch`) byte-identical to `/api/license/is-expired-at` / `/api/license/is-expiring-at` / `/api/license/days-until-expiry-at` — a UI binding any two of the four for the same install cannot catch them disagreeing on the shared fields.
- No behavior change to existing helpers or endpoints. Never 5xxs / never 4xxs; bad input degrades to the OSS-free branch shape.

The `_at` gap this closes:

| bare helper | `_at` sibling |
|---|---|
| `days_until_expiry()` | `days_until_expiry_at(epoch)` ✓ |
| `is_expired()` | `is_expired_at(epoch)` ✓ |
| `is_expiring_within(days)` | `is_expiring_within_at(days, epoch)` (#4198, pending) |
| `license_age_days()` | `license_age_days_at(epoch)` ✓ |
| `pro_install_age_days()` | `pro_install_age_days_at(epoch)` ✓ |
| **`license_state()`** | **added here** |
| **`is_state(state)`** | **added here** |

Semantics: `license_state_at(epoch)` returns one of `LICENSE_STATES`:

- `"active"`   — signature-valid AND (perpetual OR `exp > epoch`)
- `"expired"`  — signature-valid, has `exp`, AND `exp <= epoch`. Retrospective on a lapsed key when `epoch` equals "now"; prospective on an active key when `epoch` is in the future beyond `exp`.
- `"invalid"`  — file exists but signature is bogus (time-independent — an unsigned body is untrusted whatever the perspective)
- `"no_license"` — no file on disk, OR bad/`bool`/typo `epoch` (conservative fallback matching the never-mis-gate posture of the surrounding `_at` family — `"no_license"` implies no entitlement, so a UI switch bound to a typo cannot silently mis-render as `"active"`)

`is_state_at(state, epoch)` delegates to `license_state_at()` so the two helpers cannot disagree at the day boundary. When `epoch` equals "now", both must byte-match `license_state()` / `is_state()` — same signed `exp` claim, same `<=` cutoff. `bool` epoch is rejected explicitly despite being an `int` subclass. Every underlying failure of `license_state_at()` collapses `is_state_at()` to `False`.

Endpoint contracts (both always HTTP 200):

- `GET /api/license/state-at?epoch=<int>` → `{state_at, requested_epoch, state, expires_at, has_license, valid}`
- `GET /api/license/is-state-at?state=<name>&epoch=<int>` → `{is_state_at, state_at, requested_state, requested_epoch, state, expires_at, has_license, valid}`

## Test plan

- [x] `tests/test_license_state_at_scalar.py` — 46 hermetic tests mirroring `tests/test_license_is_expired_at.py` (each mints its own Ed25519 keypair and monkeypatches the module's embedded public key + `LICENSE_PATH`, so nothing depends on the real production signing key). Covers: no-license / active-at-now / active-at-future-before-exp / active-at-future-after-exp / lapsed-at-now / lapsed-at-pre-lapse / perpetual / invalid-signature-time-independent / typo-epoch / `bool`-epoch / float-epoch / never-raises / typo-state / case-insensitive / bad-state-input / bad-epoch-falls-back-to-`no_license` / boundary-agrees-with-`license_state` / `is_state_at`-agrees-with-`is_state` / shared `expires_at`/`has_license`/`valid` with `is-expired-at` / snapshot-blowup never-5xx.
- [x] `python -m pytest tests/test_license_state_at_scalar.py -x -q` → **46 passed**.
- [x] Regression check on neighbouring suites: `python -m pytest tests/test_license_state_scalar.py tests/test_license_is_expired_at.py tests/test_license_days_until_expiry_at.py tests/test_license_expires_at_scalar.py -q` → **124 passed**.
- [x] `python -m py_compile clawmetry/license.py routes/entitlement.py tests/test_license_state_at_scalar.py` → OK.
- [x] `ruff check clawmetry/license.py routes/entitlement.py` → All checks passed.

## Local operator verification checklist

Since this agent cannot reach the running daemon, the live cloud snapshot, or a browser, the operator handles the on-host verification:

- [ ] Copy the three changed files into the site-packages install:
  ```bash
  V=$(python -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')
  cp clawmetry/license.py         ~/.clawmetry/lib/python${V}/site-packages/clawmetry/license.py
  cp routes/entitlement.py        ~/.clawmetry/lib/python${V}/site-packages/routes/entitlement.py
  find ~/.clawmetry/lib -name __pycache__ -type d -exec rm -rf {} +
  ```
- [ ] Restart the daemon: `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
- [ ] Hit the new endpoints against the live install (perspective = now):
  ```bash
  NOW=$(date +%s)
  curl -s "http://localhost:8900/api/license/state-at?epoch=${NOW}" | jq .
  curl -s "http://localhost:8900/api/license/is-state-at?state=active&epoch=${NOW}" | jq .
  ```
  Expected keys for `state-at`: `state_at`, `requested_epoch`, `state`, `expires_at`, `has_license`, `valid`. For `is-state-at`: adds `is_state_at`, `requested_state`. Never 5xx.
- [ ] Boundary check — `state_at` at "now" must byte-equal `state` from `/api/license/state`:
  ```bash
  curl -s "http://localhost:8900/api/license/state-at?epoch=${NOW}" | jq '.state_at, .state'
  curl -s "http://localhost:8900/api/license/state"                | jq '.state'
  ```
- [ ] Cross-check the shared trio (`expires_at` / `has_license` / `valid`) against `is-expired-at` for the SAME install and epoch — the shared fields must be byte-identical:
  ```bash
  curl -s "http://localhost:8900/api/license/state-at?epoch=${NOW}"      | jq '.expires_at, .has_license, .valid'
  curl -s "http://localhost:8900/api/license/is-expired-at?epoch=${NOW}" | jq '.expires_at, .has_license, .valid'
  ```
- [ ] Prospective probe — pick an epoch beyond the current `exp` and confirm `state_at="expired"` while `state="active"` (the whole point of the perspective-epoch scalar):
  ```bash
  EXP=$(curl -s http://localhost:8900/api/license/expires-at | jq -r '.expires_at // empty')
  if [ -n "$EXP" ]; then
    curl -s "http://localhost:8900/api/license/state-at?epoch=$((EXP + 86400))" | jq '.state_at, .state, .valid'
  fi
  ```
- [ ] Bad-input sweep — none should 5xx / 4xx:
  ```bash
  curl -s -o /dev/null -w '%{http_code}\n' "http://localhost:8900/api/license/state-at"                                 # 200
  curl -s -o /dev/null -w '%{http_code}\n' "http://localhost:8900/api/license/state-at?epoch=garbage"                   # 200; state_at=no_license
  curl -s -o /dev/null -w '%{http_code}\n' "http://localhost:8900/api/license/is-state-at"                              # 200
  curl -s -o /dev/null -w '%{http_code}\n' "http://localhost:8900/api/license/is-state-at?state=actiev&epoch=${NOW}"    # 200; is_state_at=false
  curl -s -o /dev/null -w '%{http_code}\n' "http://localhost:8900/api/license/is-state-at?state=no_license&epoch=junk"  # 200; is_state_at=true (bad-epoch fallback)
  ```
- [ ] Decrypt the live cloud snapshot in the browser and confirm no console errors on any tile that binds to `/api/license/state` or the perspective-epoch license endpoints (this PR does not touch the frontend, so existing tiles should be unaffected).

---
_Generated by [Claude Code](https://claude.ai/code/session_01KUUPqXUMAF328rZkAdYBcE)_