### PR TITLE
feat(license): license_age_days_at_batch + /api/license/age-days-at-batch

### DIFF
--- a/clawmetry/license.py
+++ b/clawmetry/license.py
@@ -2820,3 +2820,84 @@ def days_until_expiry_at_batch(epochs) -> list[dict]:
             {"epoch": parsed, "days": int(days) if isinstance(days, int) else None}
         )
     return out
+
+
+def license_age_days_at_batch(epochs) -> list[dict]:
+    """Per-value perspective-epoch "how old was the license?" scalar for
+    N epochs in ONE round-trip.
+
+    Per-value axis batch sibling of :func:`license_age_days_at`. Fills
+    the ``_at_batch`` slot on the license-age axis alongside the
+    singular :func:`license_age_days_at` and the "now" flavour
+    :func:`license_age_days`, so a scheduled-audit / retrospective tile
+    that wants to plot age across a sequence of perspective dates (e.g.
+    "how old was the key when we shipped each of these builds?")
+    renders off ONE call instead of fanning out N calls to the scalar.
+
+    Pairs on the ``iat``-derived axis the way
+    :func:`days_until_expiry_at_batch` pairs on the ``exp``-derived
+    axis: both walk the same epochs list and derive a signed integer
+    day count against a claim on the on-disk key. A caller assembling
+    an audit timeline can zip the two responses index-for-index to
+    render "on <date>, the license was N days old and had M days
+    remaining".
+
+    Row shape::
+
+        {
+          "epoch": <int> | "<raw>",
+          "days":  <int> | None,
+        }
+
+    Semantics per row mirror :func:`license_age_days_at`: a signed
+    integer number of days (zero when ``epoch == iat``; positive when
+    ``epoch`` is after ``iat`` -- the normal "N days old as of <date>"
+    case; negative when ``epoch`` is BEFORE ``iat`` -- support
+    scenario for pre-issuance perspectives); ``None`` for no license,
+    invalid signature, a signed payload with no ``iat`` claim, and
+    ``bool`` / non-numeric epochs. Row shape mirrors
+    :func:`days_until_expiry_at_batch` so a caller assembling a
+    timeline can zip the two responses index-for-index.
+
+    Deliberately NOT clamped to ``max(0, ...)`` -- unlike the "now"
+    flavour :func:`license_age_days`, which clamps because clock-skew
+    is the only way ``iat`` can be in the future when reading against
+    ``time.time()``. Here the caller EXPLICITLY passes perspective
+    epochs, so a negative row is a real, actionable signal (they asked
+    a question that only makes sense pre-issuance), not clock skew to
+    be hidden.
+
+    Duplicates by normalised int key (or ``repr(raw)`` for bad inputs)
+    are dropped preserving first-seen order for byte-stable output.
+    ``epochs is None`` or non-iterable -- returns ``[]``. Never raises:
+    per-row failures short-circuit to ``days=None`` so the batch keeps
+    building.
+
+    Deliberately lenient on expiry, mirroring :func:`license_age_days_at`:
+    a signed-but-lapsed key still carries a meaningful ``iat`` and
+    callers would otherwise have to fall back to
+    :func:`current_license_info`. The :func:`is_expired` /
+    :func:`is_expiring_at` helpers independently carry the "past-
+    expiry" signals for callers that DO want to hide the row on
+    lapsed keys.
+    """
+    out: list[dict] = []
+    for raw, _key, parsed in _license_epoch_batch_keys(epochs):
+        if parsed is None:
+            try:
+                token = str(raw)
+            except Exception:
+                token = repr(raw)
+            out.append({"epoch": token, "days": None})
+            continue
+        try:
+            days = license_age_days_at(parsed)
+        except Exception as exc:
+            logger.debug(
+                "license: license_age_days_at_batch per-row failed: %s", exc
+            )
+            days = None
+        out.append(
+            {"epoch": parsed, "days": int(days) if isinstance(days, int) else None}
+        )
+    return out

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -11023,6 +11023,105 @@ def api_license_is_expiring_at_batch():
     )
 
 
+@bp_entitlement.route("/api/license/age-days-at-batch")
+def api_license_age_days_at_batch():
+    """``GET /api/license/age-days-at-batch?epochs=<int>,<int>,...`` --
+    per-value batch sibling of ``/api/license/age-days-at``.
+
+    License-age axis batch companion to the ``exp``-derived
+    ``/api/license/days-until-expiry-at-batch``. Where the singular
+    endpoint folds ONE perspective epoch to ONE signed "days from
+    ``iat`` to epoch" scalar, this preserves per-value rows so a
+    scheduled-audit / retrospective tile that wants to plot license
+    age across a sequence of perspective dates (e.g. "how old was the
+    key when we shipped each of these builds?") renders off ONE
+    round-trip instead of N calls to the scalar. Wraps
+    :func:`clawmetry.license.license_age_days_at_batch`.
+
+    Row shape mirrors ``/api/license/days-until-expiry-at-batch``
+    per-row so a caller assembling a full audit timeline can zip the
+    two responses index-for-index -- "N days old and M days
+    remaining" per epoch. Same query-string posture: ``epochs=``
+    required (missing / blank / only-commas -> ``400``), comma-
+    separated tokens deduped by parsed int key preserving first-seen
+    order, non-int / ``bool`` / ``None`` tokens collapse to
+    ``days=null``. Never 5xxs.
+
+    Response shape (always HTTP 200)::
+
+        {
+          "kind":  "license_age_days_at",
+          "count": <int>,
+          "rows":  [
+            {"epoch": <int|"<raw>">, "days": <int|null>},
+            ...
+          ],
+          "issued_at":   <int|null>,        # current on-disk iat
+          "age_days":    <int|null>,        # age NOW (clamped >= 0)
+          "has_license": <bool>,
+          "valid":       <bool>             # signature-valid AND not expired NOW
+        }
+
+    Snapshot fields are drawn from :func:`_license_issued_snapshot`
+    (the ``iat``-derived quartet), matching the singular
+    ``/api/license/age-days-at`` endpoint, so a UI binding both for
+    the same install cannot catch them disagreeing on ``issued_at`` /
+    ``has_license`` / ``valid`` / current-time ``age_days``. Note the
+    snapshot's ``age_days`` is the "now" flavour (clamped to ``>= 0``
+    for clock-skew), whereas per-row ``days`` in ``rows`` is the
+    signed perspective value -- deliberately different by design so
+    the retrospective column can render "N days before issuance" while
+    the header still hides clock-skew.
+
+    Deliberately lenient on expiry, mirroring
+    ``/api/license/age-days-at``: a signed-but-lapsed key still
+    surfaces its real per-row ``days`` and current ``age_days`` so a
+    support/audit tile can render "was 12 days old as of that date"
+    without special-casing the expired branch. The ``valid`` field
+    independently carries the "signature-valid AND not expired"
+    signal for callers that DO want to hide the row on lapsed keys.
+
+    Per-row parity with ``/api/license/age-days-at?epoch=<n>`` is
+    pinned in the test suite so the batch cannot silently drift from
+    the scalar endpoint.
+    """
+    tokens, err = _parse_license_epochs_csv("epochs")
+    if err == "missing":
+        return jsonify({"error": "missing epochs"}), 400
+    try:
+        snap = _license_issued_snapshot()
+    except Exception as exc:
+        logger.warning(
+            "api_license_age_days_at_batch: snapshot error: %s", exc
+        )
+        snap = {
+            "issued_at": None,
+            "age_days": None,
+            "has_license": False,
+            "valid": False,
+        }
+    try:
+        from clawmetry import license as _lic
+
+        rows = _lic.license_age_days_at_batch(tokens)
+    except Exception as exc:
+        logger.warning(
+            "api_license_age_days_at_batch: derive error: %s", exc
+        )
+        rows = []
+    return jsonify(
+        {
+            "kind": "license_age_days_at",
+            "count": len(rows),
+            "rows": rows,
+            "issued_at": snap["issued_at"],
+            "age_days": snap["age_days"],
+            "has_license": snap["has_license"],
+            "valid": snap["valid"],
+        }
+    )
+
+
 @bp_entitlement.route("/api/paywall/event", methods=["POST"])
 def api_paywall_event():
     body: dict = {}

--- a/tests/test_license_age_days_at_batch.py
+++ b/tests/test_license_age_days_at_batch.py
@@ -1,0 +1,454 @@
+"""Tests for :func:`clawmetry.license.license_age_days_at_batch` and
+the paired ``GET /api/license/age-days-at-batch`` endpoint.
+
+Per-value axis batch sibling of
+:func:`clawmetry.license.license_age_days_at` /
+``/api/license/age-days-at``. Fills the ``_at_batch`` slot on the
+``iat``-derived license-age axis alongside the ``exp``-derived
+``/api/license/days-until-expiry-at-batch``, so a scheduled-audit tile
+that wants to plot license age across a sequence of perspective dates
+can hydrate the whole column in ONE round-trip. Per-row parity with
+the singular scalar (both the helper and the HTTP endpoint) is pinned
+so the batch cannot silently drift.
+
+Hermetic: each test mints tokens with its own ephemeral keypair and
+monkeypatches the module's embedded public key + ``LICENSE_PATH``,
+mirroring ``tests/test_license_is_expiring_at_batch.py`` /
+``tests/test_license_state_at_batch.py``.
+"""
+from __future__ import annotations
+
+import time
+from types import SimpleNamespace
+
+import pytest
+from flask import Flask
+
+
+# -- shared helpers (mirror the sibling _at_batch tests) --------------------
+
+
+def _keypair():
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+    priv = Ed25519PrivateKey.generate()
+    pub_pem = priv.public_key().public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    return priv, pub_pem
+
+
+def _payload(tier="pro", nodes=3, exp_delta=365 * 86400, drop_exp=False, drop_iat=False):
+    now = int(time.time())
+    p = {
+        "sub": "acct_test",
+        "tier": tier,
+        "nodes": nodes,
+        "iat": now,
+        "exp": now + exp_delta,
+        "features": ["runtimes"],
+    }
+    if drop_exp:
+        p.pop("exp", None)
+    if drop_iat:
+        p.pop("iat", None)
+    return p
+
+
+@pytest.fixture
+def app(monkeypatch, tmp_path):
+    import clawmetry.license as _lic
+
+    priv, pub_pem = _keypair()
+    monkeypatch.setattr(_lic, "_PUBLIC_KEY_PEM", pub_pem)
+    license_path = str(tmp_path / "license.key")
+    monkeypatch.setattr(_lic, "LICENSE_PATH", license_path)
+    monkeypatch.delenv("CLAWMETRY_LICENSE_SERVER", raising=False)
+    monkeypatch.delenv("CLAWMETRY_INGEST_URL", raising=False)
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("CLAWMETRY_OFFLINE", "1")
+
+    from routes.entitlement import bp_entitlement
+
+    flask_app = Flask(__name__)
+    flask_app.register_blueprint(bp_entitlement)
+    flask_app.config["TESTING"] = True
+
+    return SimpleNamespace(
+        app=flask_app,
+        lic=_lic,
+        priv=priv,
+        license_path=license_path,
+    )
+
+
+def _write_perpetual(app):
+    import os
+
+    tok = app.lic._encode_token(_payload(drop_exp=True), app.priv)
+    os.makedirs(os.path.dirname(app.license_path), exist_ok=True)
+    with open(app.license_path, "w", encoding="utf-8") as fh:
+        fh.write(tok)
+
+
+def _write_no_iat(app):
+    """Write a signature-valid token whose payload has no ``iat`` claim.
+    ``activate()`` refuses this shape, so bypass it and write directly."""
+    import os
+
+    tok = app.lic._encode_token(_payload(drop_iat=True), app.priv)
+    os.makedirs(os.path.dirname(app.license_path), exist_ok=True)
+    with open(app.license_path, "w", encoding="utf-8") as fh:
+        fh.write(tok)
+
+
+def _write_bogus(app):
+    import os
+
+    os.makedirs(os.path.dirname(app.license_path), exist_ok=True)
+    with open(app.license_path, "w", encoding="utf-8") as fh:
+        fh.write("CLAW1.garbage.garbage")
+
+
+# -- clawmetry.license.license_age_days_at_batch() -----------------------
+
+
+def test_license_age_days_at_batch_none_returns_empty(app):
+    """``epochs is None`` -> ``[]``. Never-raise posture, matches the
+    ``_at_batch`` siblings."""
+    assert app.lic.license_age_days_at_batch(None) == []
+
+
+def test_license_age_days_at_batch_non_iterable_returns_empty(app):
+    """Non-iterable ``epochs`` (an int -- probable typo for a caller
+    that forgot to wrap it) -> ``[]`` rather than a crash."""
+    assert app.lic.license_age_days_at_batch(42) == []
+
+
+def test_license_age_days_at_batch_empty_returns_empty(app):
+    """Empty iterable -> ``[]``."""
+    assert app.lic.license_age_days_at_batch([]) == []
+    assert app.lic.license_age_days_at_batch(()) == []
+
+
+def test_license_age_days_at_batch_no_license(app):
+    """No license file -> every row ``days=None`` (nothing to derive an
+    age from). Time-independent, matches the scalar."""
+    rows = app.lic.license_age_days_at_batch([0, int(time.time()), 2_000_000_000])
+    assert [r["days"] for r in rows] == [None, None, None]
+
+
+def test_license_age_days_at_batch_active_key_signed_ages(app):
+    """Active key: rows carry a signed int day-count against ``iat``.
+    Zero on the ``iat`` second; positive N days after; negative N days
+    before -- perspective-epoch semantics preserved per row."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    info = app.lic.current_license_info()
+    iat = int(info["issued_at"])
+    rows = app.lic.license_age_days_at_batch(
+        [iat, iat + 5 * 86400, iat - 7 * 86400, iat + 86400]
+    )
+    assert [r["days"] for r in rows] == [0, 5, -7, 1]
+
+
+def test_license_age_days_at_batch_per_row_parity_with_scalar(app):
+    """Per-row parity with :func:`license_age_days_at` -- the batch
+    cannot silently drift from the scalar. Pin every row against the
+    singular helper on the same install."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    info = app.lic.current_license_info()
+    iat = int(info["issued_at"])
+    epochs = [iat - 10 * 86400, iat - 1, iat, iat + 1, iat + 60 * 86400]
+    rows = app.lic.license_age_days_at_batch(epochs)
+    for row, epoch in zip(rows, epochs):
+        assert row["days"] == app.lic.license_age_days_at(epoch), epoch
+
+
+def test_license_age_days_at_batch_perpetual_still_ages(app):
+    """Perpetual (no ``exp``) key still carries ``iat`` -- rows must
+    surface a real age. Mirrors :func:`license_age_days_at`, which is
+    deliberately lenient on expiry."""
+    _write_perpetual(app)
+    info = app.lic.current_license_info()
+    iat = int(info["issued_at"])
+    rows = app.lic.license_age_days_at_batch(
+        [iat, iat + 30 * 86400, iat - 3 * 86400]
+    )
+    assert [r["days"] for r in rows] == [0, 30, -3]
+
+
+def test_license_age_days_at_batch_invalid_signature(app):
+    """Bogus-signature file -> ``days=None`` at every epoch (an
+    unsigned body is untrusted whatever the perspective; the scalar
+    refuses to trust the payload's ``iat``)."""
+    _write_bogus(app)
+    rows = app.lic.license_age_days_at_batch([0, int(time.time()), 2_000_000_000])
+    assert [r["days"] for r in rows] == [None, None, None]
+
+
+def test_license_age_days_at_batch_missing_iat_returns_none(app):
+    """Signature-valid payload with no ``iat`` claim -> ``days=None`` at
+    every epoch (nothing to derive the age against). Matches the
+    scalar's fallback."""
+    _write_no_iat(app)
+    rows = app.lic.license_age_days_at_batch([0, int(time.time())])
+    assert [r["days"] for r in rows] == [None, None]
+
+
+def test_license_age_days_at_batch_string_int_tokens_parsed(app):
+    """Int-parseable strings coerce cleanly (matches the singular's
+    ``int()`` coercion)."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    info = app.lic.current_license_info()
+    iat = int(info["issued_at"])
+    rows = app.lic.license_age_days_at_batch([str(iat), str(iat + 86400)])
+    assert [r["days"] for r in rows] == [0, 1]
+
+
+def test_license_age_days_at_batch_dedupes_by_int_key_preserves_order(app):
+    """Duplicates by parsed int key are dropped preserving first-seen
+    order so the response is byte-stable across calls."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    info = app.lic.current_license_info()
+    iat = int(info["issued_at"])
+    rows = app.lic.license_age_days_at_batch(
+        [iat, iat + 100, iat, str(iat + 100), iat + 200]
+    )
+    assert [r["epoch"] for r in rows] == [iat, iat + 100, iat + 200]
+
+
+def test_license_age_days_at_batch_bad_tokens_collapse_to_none(app):
+    """``bool`` / non-numeric / ``None`` collapse to ``days=None``
+    (matches the scalar's rejection). Row still keeps its slot so
+    output length matches N -- each bad input gets its own bucket."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    rows = app.lic.license_age_days_at_batch([True, False, None, "garbage", ""])
+    assert len(rows) == 5
+    assert all(r["days"] is None for r in rows)
+
+
+def test_license_age_days_at_batch_mixed_good_and_bad(app):
+    """Bad tokens don't fail the whole batch. Good rows still resolve;
+    bad rows still slot in with ``days=None``."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    info = app.lic.current_license_info()
+    iat = int(info["issued_at"])
+    rows = app.lic.license_age_days_at_batch([iat + 86400, "garbage", iat - 86400])
+    assert [r["days"] for r in rows] == [1, None, -1]
+
+
+def test_license_age_days_at_batch_never_raises(monkeypatch):
+    """Any per-row underlying failure of :func:`license_age_days_at`
+    -> ``days=None`` for THAT row. The batch never propagates."""
+    import clawmetry.license as _lic
+
+    def _boom(_epoch):
+        raise RuntimeError("simulated corrupt install")
+
+    monkeypatch.setattr(_lic, "license_age_days_at", _boom)
+    rows = _lic.license_age_days_at_batch([1_700_000_000, 1_800_000_000])
+    assert [r["days"] for r in rows] == [None, None]
+    assert len(rows) == 2
+
+
+# -- GET /api/license/age-days-at-batch --------------------------------------
+
+
+def test_endpoint_age_days_at_batch_missing_epochs(app):
+    """``?epochs=`` absent -> 400 missing epochs (matches the other
+    ``/api/license/*-at-batch`` endpoints -- missing input is a real
+    error, unlike bad input)."""
+    with app.app.test_client() as c:
+        resp = c.get("/api/license/age-days-at-batch")
+    assert resp.status_code == 400
+    assert resp.get_json() == {"error": "missing epochs"}
+
+
+def test_endpoint_age_days_at_batch_blank_epochs(app):
+    """``?epochs=`` blank / only-commas -> 400 missing epochs."""
+    with app.app.test_client() as c:
+        resp = c.get("/api/license/age-days-at-batch?epochs=")
+        resp2 = c.get("/api/license/age-days-at-batch?epochs=,,,")
+    assert resp.status_code == 400
+    assert resp2.status_code == 400
+
+
+def test_endpoint_age_days_at_batch_no_license(app):
+    """No license file -> every row ``days=None``, HTTP 200, snapshot
+    fields set to the OSS-free branch shape."""
+    now = int(time.time())
+    with app.app.test_client() as c:
+        resp = c.get(f"/api/license/age-days-at-batch?epochs={now},0")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["kind"] == "license_age_days_at"
+    assert data["count"] == 2
+    assert [r["days"] for r in data["rows"]] == [None, None]
+    assert data["issued_at"] is None
+    assert data["age_days"] is None
+    assert data["has_license"] is False
+    assert data["valid"] is False
+
+
+def test_endpoint_age_days_at_batch_active_key_signed_rows(app):
+    """Active key: rows carry signed int day-counts. Snapshot reflects
+    current install state."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    info = app.lic.current_license_info()
+    iat = int(info["issued_at"])
+    csv = ",".join(str(e) for e in [iat, iat + 3 * 86400, iat - 2 * 86400])
+    with app.app.test_client() as c:
+        resp = c.get(f"/api/license/age-days-at-batch?epochs={csv}")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["kind"] == "license_age_days_at"
+    assert data["count"] == 3
+    assert [r["days"] for r in data["rows"]] == [0, 3, -2]
+    assert data["has_license"] is True
+    assert data["valid"] is True
+    assert data["issued_at"] == iat
+
+
+def test_endpoint_age_days_at_batch_per_row_parity_with_scalar_endpoint(app):
+    """Per-row parity with the singular
+    ``/api/license/age-days-at?epoch=<n>`` endpoint -- the batch
+    cannot silently drift from the scalar endpoint. Pin every row."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    info = app.lic.current_license_info()
+    iat = int(info["issued_at"])
+    epochs = [iat - 10 * 86400, iat - 1, iat, iat + 1, iat + 60 * 86400]
+    csv = ",".join(str(e) for e in epochs)
+    with app.app.test_client() as c:
+        batch = c.get(
+            f"/api/license/age-days-at-batch?epochs={csv}"
+        ).get_json()
+        for row, epoch in zip(batch["rows"], epochs):
+            scalar = c.get(
+                f"/api/license/age-days-at?epoch={epoch}"
+            ).get_json()
+            assert row["days"] == scalar["age_days"], epoch
+
+
+def test_endpoint_age_days_at_batch_bad_tokens_collapse_to_null(app):
+    """Bad tokens don't fail the whole batch. They slot in with
+    ``days=null`` (the never-mis-count posture)."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    info = app.lic.current_license_info()
+    iat = int(info["issued_at"])
+    with app.app.test_client() as c:
+        resp = c.get(
+            f"/api/license/age-days-at-batch?epochs=garbage,{iat + 86400}"
+        )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["count"] == 2
+    assert [r["days"] for r in data["rows"]] == [None, 1]
+
+
+def test_endpoint_age_days_at_batch_perpetual_still_ages(app):
+    """Perpetual key still carries ``iat`` -- rows must surface a real
+    age. Snapshot shows a valid install."""
+    _write_perpetual(app)
+    info = app.lic.current_license_info()
+    iat = int(info["issued_at"])
+    csv = ",".join(str(e) for e in [iat, iat + 30 * 86400, iat - 3 * 86400])
+    with app.app.test_client() as c:
+        resp = c.get(f"/api/license/age-days-at-batch?epochs={csv}")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["count"] == 3
+    assert [r["days"] for r in data["rows"]] == [0, 30, -3]
+    assert data["has_license"] is True
+    assert data["issued_at"] == iat
+
+
+def test_endpoint_age_days_at_batch_dedupe_preserves_order(app):
+    """Duplicates by parsed int key are dropped preserving first-seen
+    order for byte-stable output."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    info = app.lic.current_license_info()
+    iat = int(info["issued_at"])
+    with app.app.test_client() as c:
+        resp = c.get(
+            f"/api/license/age-days-at-batch?epochs={iat},{iat + 100},{iat},{iat + 100}"
+        )
+    data = resp.get_json()
+    assert data["count"] == 2
+    assert [r["epoch"] for r in data["rows"]] == [iat, iat + 100]
+
+
+def test_endpoint_age_days_at_batch_never_5xxs(app, monkeypatch):
+    """Even if the shared snapshot blows up mid-request, the endpoint
+    still returns HTTP 200 with the OSS-free snapshot fallback + honest
+    per-row derivation."""
+    from routes import entitlement as _routes
+
+    monkeypatch.setattr(
+        _routes,
+        "_license_issued_snapshot",
+        lambda: (_ for _ in ()).throw(RuntimeError("simulated blowup")),
+    )
+    now = int(time.time())
+    with app.app.test_client() as c:
+        resp = c.get(f"/api/license/age-days-at-batch?epochs={now}")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["issued_at"] is None
+    assert data["age_days"] is None
+    assert data["has_license"] is False
+    assert data["valid"] is False
+
+
+# -- cross-endpoint consistency: pairs with days-until-expiry-at-batch -----
+
+
+def test_endpoint_age_days_at_batch_rows_zip_with_days_until_expiry(app):
+    """The ``iat``-derived age batch and the ``exp``-derived days-
+    remaining batch admit the same input schema and emit rows in the
+    same order, so a caller can zip them index-for-index to render
+    "N days old, M days remaining" per perspective."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    info = app.lic.current_license_info()
+    iat = int(info["issued_at"])
+    epochs = [iat, iat + 5 * 86400, iat + 10 * 86400]
+    csv = ",".join(str(e) for e in epochs)
+    with app.app.test_client() as c:
+        age = c.get(f"/api/license/age-days-at-batch?epochs={csv}").get_json()
+        rem = c.get(
+            f"/api/license/days-until-expiry-at-batch?epochs={csv}"
+        ).get_json()
+    assert age["count"] == rem["count"] == 3
+    for i, epoch in enumerate(epochs):
+        assert age["rows"][i]["epoch"] == rem["rows"][i]["epoch"] == epoch
+        # Age counts up from iat; days-remaining counts down to exp.
+        # Their sum is a constant per install (the license's term in
+        # days), give or take one from floor-division rounding.
+        assert age["rows"][i]["days"] + rem["rows"][i]["days"] in (29, 30, 31)
+
+
+def test_endpoint_age_days_at_batch_shared_snapshot_fields_agree_with_scalar(app):
+    """Shares the snapshot fields (``issued_at`` / ``age_days`` /
+    ``has_license`` / ``valid``) with the singular
+    ``/api/license/age-days-at`` endpoint. A UI binding both for the
+    same install must not catch them disagreeing on those fields."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    now = int(time.time())
+    with app.app.test_client() as c:
+        scalar = c.get(f"/api/license/age-days-at?epoch={now}").get_json()
+        batch = c.get(f"/api/license/age-days-at-batch?epochs={now}").get_json()
+    for key in ("issued_at", "has_license", "valid"):
+        assert scalar[key] == batch[key], key


### PR DESCRIPTION
## Summary

Fills the `_at_batch` slot on the `iat`-derived license-age axis, rounding out the four-endpoint `_at_batch` license family:

| Axis | Singular `_at` | Batch `_at_batch` |
|---|---|---|
| state | `/api/license/state-at` | `/api/license/state-at-batch` |
| expired | `/api/license/is-expired-at` | `/api/license/is-expired-at-batch` |
| expiring (renewal detect) | `/api/license/is-expiring-at` | `/api/license/is-expiring-at-batch` |
| days-until-expiry | `/api/license/days-until-expiry-at` | `/api/license/days-until-expiry-at-batch` |
| **age (from iat)** | `/api/license/age-days-at` | **`/api/license/age-days-at-batch`** (new) |

Paired with `days_until_expiry_at_batch`, a caller can zip the two responses index-for-index to render "N days old, M days remaining" for a sequence of perspective epochs in one round-trip instead of `2 * N` scalar calls.

## Changes

- **`clawmetry/license.py`** — new `license_age_days_at_batch(epochs)` following the shape used by `days_until_expiry_at_batch`: per-row signed integer day count against `iat`, `None` on no/invalid/no-iat/`bool`/non-numeric-epoch, dedupe by parsed int key preserving first-seen order, never raises.
- **`routes/entitlement.py`** — new `GET /api/license/age-days-at-batch?epochs=<int>,<int>,...` on `bp_entitlement`. Shares `_license_issued_snapshot()` with the singular endpoint so a UI binding both cannot catch them disagreeing on `issued_at` / `has_license` / `valid`. Returns 400 only on missing/blank `epochs`; bad tokens collapse to `days=null` rows; never 5xxs.
- **`tests/test_license_age_days_at_batch.py`** — 25 tests covering the helper (empty / non-iterable / no license / active / perpetual / invalid signature / missing `iat` / bad tokens / dedupe / never-raises), the endpoint (400 on missing epochs, per-row parity pinned against the scalar endpoint, dedupe, `_license_issued_snapshot` blowup fallback), and cross-endpoint invariants (rows zip against `days-until-expiry-at-batch`; snapshot fields agree with the scalar endpoint).

House rules held: snake_case, deps unchanged (`cryptography` already available for the test key material), new endpoint on `bp_entitlement` in `routes/`, no `dashboard.py` edits, no `__version__` bump, no frontend touched.

## Test plan

- [x] `python -m py_compile` on all three files
- [x] `ruff check clawmetry/license.py routes/entitlement.py tests/test_license_age_days_at_batch.py` — all checks passed
- [x] `python -m pytest tests/test_license_age_days_at_batch.py` — 25 passed
- [x] Sibling tests still green: `test_license_is_expiring_at_batch.py`, `test_license_state_at_batch.py`, `test_license_age_days_at_scalar.py`, `test_license_days_until_expiry*.py` — 150 passed total

## Local operator verification checklist

Since I cannot reach the operator's machine, running daemon, `~/.openclaw`, live cloud snapshot, or the private `clawmetry-cloud` repo from this remote session, please after review:

1. **Sync the code into the running site-packages**
   ```bash
   cp clawmetry/license.py ~/.clawmetry/lib/python*/site-packages/clawmetry/
   cp routes/entitlement.py ~/.clawmetry/lib/python*/site-packages/routes/
   find ~/.clawmetry/lib/python*/site-packages/{clawmetry,routes} -name __pycache__ -exec rm -rf {} +
   ```
2. **Kickstart the daemon so it re-imports** — `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` (or the equivalent on Linux)
3. **Hit the new endpoint and confirm the shape** —
   ```bash
   curl -s "http://localhost:8900/api/license/age-days-at-batch?epochs=1700000000,1800000000,now" | jq
   curl -s "http://localhost:8900/api/license/age-days-at-batch" | jq   # -> 400 missing epochs
   ```
4. **Zip against the days-remaining batch** — confirm rows line up index-for-index:
   ```bash
   curl -s "http://localhost:8900/api/license/age-days-at-batch?epochs=<epoch1>,<epoch2>" | jq '.rows'
   curl -s "http://localhost:8900/api/license/days-until-expiry-at-batch?epochs=<epoch1>,<epoch2>" | jq '.rows'
   ```
5. **Decrypt the live cloud snapshot in the browser** — no schema change here, but confirm the dashboard still renders (nothing binds the new endpoint yet).
6. **Green CI, then flip DRAFT → ready-for-review**, then release-on-merge picks it up per FLYWHEEL.md.

This PR stays in GRACE mode (no behavior change to any existing gate) — it only adds an additive read-only endpoint + helper.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WPiASKx5N274c1yKjypCeY)_