### PR TITLE
feat(onboard): compact runtime-detection grid, retire the 9x (Pro) label wall

### DIFF
--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -2968,8 +2968,10 @@ def _cmd_onboard(args) -> None:
         for _i, _line in enumerate(_detect_lines):
             if _i == 0:
                 print(f"  {BOLD(_line)}")
-            elif _line.startswith("  [x]"):
-                print(f"  {GREEN('✓')} {_line[6:]}")
+            elif "[x]" in _line:
+                # Grid rows carry several "[x] Label" cells; the uniform
+                # marker swap keeps the pure renderer's column padding intact.
+                print(f"  {_line.replace('[x]', GREEN('✓'))}")
             else:
                 print(f"  {DIM(_line)}" if _line else "")
     print()

--- a/clawmetry/runtime_probe.py
+++ b/clawmetry/runtime_probe.py
@@ -109,19 +109,25 @@ def render_detection_lines(probes: list) -> list:
     found = [p for p in probes if p.get("found")]
     if not found:
         return []
-    lines = ["Detected AI agent runtimes on this machine:"]
-    for p in found:
-        tier = "free" if p.get("free") else "Pro"
-        lines.append(f"  [x] {p['label']}  ({tier})")
+    n = len(found)
+    plural = "runtime" if n == 1 else "runtimes"
+    lines = [f"Detected {n} AI agent {plural} on this machine:"]
+    # Compact grid, 3 per row: ten detections should read as one confident
+    # block of checkmarks, not a ten-line paywall ledger (per-line tier
+    # labels moved into the two summary lines below).
+    cell = max(len(p["label"]) for p in found) + 3
+    for i in range(0, n, 3):
+        row = "".join(f"[x] {p['label']:<{cell}}" for p in found[i : i + 3])
+        lines.append("  " + row.rstrip())
     lines.append("")
     lines.append("Free forever: OpenClaw and NVIDIA NemoClaw.")
     paid = [p for p in found if not p.get("free")]
-    if paid:
-        names = ", ".join(p["label"] for p in paid)
+    if len(paid) == 1:
         lines.append(
-            f"To watch {names}: enter a license key (clawmetry activate <key>,"
+            f"{paid[0]['label']} unlocks with Cloud [2] below or a license key [3] (clawmetry activate <key>)."
         )
+    elif paid:
         lines.append(
-            "purchase at clawmetry.com/pricing) or pick [2] Cloud below to sign up."
+            f"The other {len(paid)} unlock with Cloud [2] below or a license key [3] (clawmetry activate <key>)."
         )
     return lines

--- a/tests/test_onboard_runtime_detection.py
+++ b/tests/test_onboard_runtime_detection.py
@@ -86,6 +86,37 @@ def test_render_paid_detected_names_runtime_and_both_paths():
     assert "—" not in joined and "--" not in joined
 
 
+def test_render_grid_compact_no_per_line_tier_labels():
+    """Ten detections read as a 3-per-row checkmark grid; the tier story is
+    told once in the summary lines, not as nine "(Pro)" labels (#4216)."""
+    labels = [
+        "OpenClaw", "Claude Code", "Codex", "Cursor", "Aider",
+        "Goose", "opencode", "Qwen Code", "Hermes", "PicoClaw",
+    ]
+    probes = [
+        {"id": lbl.lower().replace(" ", "_"), "label": lbl,
+         "free": lbl == "OpenClaw", "found": True}
+        for lbl in labels
+    ]
+    lines = render_detection_lines(probes)
+    joined = "\n".join(lines)
+    assert "(Pro)" not in joined and "(free)" not in joined
+    grid = [ln for ln in lines if "[x]" in ln]
+    assert len(grid) == 4  # 3 + 3 + 3 + 1
+    assert grid[0].count("[x]") == 3
+    assert "Detected 10 AI agent runtimes" in lines[0]
+    assert "The other 9 unlock" in joined
+
+
+def test_render_single_paid_runtime_named_in_unlock_line():
+    probes = [
+        {"id": "cursor", "label": "Cursor", "free": False, "found": True},
+    ]
+    joined = "\n".join(render_detection_lines(probes))
+    assert "Cursor unlocks with Cloud" in joined
+    assert "clawmetry activate" in joined
+
+
 def test_render_nothing_detected_is_silent():
     probes = [
         {"id": "openclaw", "label": "OpenClaw", "free": True, "found": False},


### PR DESCRIPTION
## What
The onboard detection block printed one line per detected runtime, each tagged `(free)` or `(Pro)` — on a typical dev machine that's **nine "(Pro)" labels plus a 3-line license paragraph** before the menu. First impression: a paywall ledger.

### Before (12 lines)
```
Detected AI agent runtimes on this machine:
✓ OpenClaw     (free)
✓ Claude Code  (Pro)
✓ Codex        (Pro)
… 7 more (Pro) lines …

Free forever: OpenClaw and NVIDIA NemoClaw.
To watch Claude Code, Codex, …: enter a license key (clawmetry activate <key>,
purchase at clawmetry.com/pricing) or pick [2] Cloud below to sign up.
```

### After (7 lines)
```
Detected 10 AI agent runtimes on this machine:
  ✓ OpenClaw      ✓ Claude Code   ✓ Codex
  ✓ Cursor        ✓ Aider         ✓ Goose
  ✓ opencode      ✓ Qwen Code     ✓ Hermes
  ✓ PicoClaw

Free forever: OpenClaw and NVIDIA NemoClaw.
The other 9 unlock with Cloud [2] below or a license key [3] (clawmetry activate <key>).
```

## Why this preserves #3917
The conversion-moment requirement (founder request 2026-07-22) was: name the detections, state the free tier, offer both unlock paths. All three survive — the tier story is just told **once** instead of nine times. `Free forever: OpenClaw and NVIDIA NemoClaw.` and `clawmetry activate` are kept verbatim (pinned by tests).

## Changes
- `runtime_probe.render_detection_lines`: 3-per-row grid + single unlock line (singular form when exactly one paid runtime is detected).
- `cli.py` wizard styling: uniform `[x]` → green ✓ swap so column padding survives ANSI.
- Tests: 2 new (grid shape + singular unlock), all 7 existing pass unchanged — including the em-dash/`--` copy ban.

## Verification
- `tests/test_onboard_runtime_detection.py`: 9 passed; `test_entitlement_api_runtime_detection.py`: 12 passed.
- Rendered live on this 10-runtime machine with the wizard's exact styling: columns aligned, 12 → 7 lines.

Entitlements, pricing, and the [1]/[2]/[3] menu are untouched — output cleanup only (/$19 tiers stay as marketed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)