### PR TITLE
feat(onboard): sign-in-first menu with automatic 7-day Pro trial license

### DIFF
--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -2977,11 +2977,11 @@ def _cmd_onboard(args) -> None:
     print()
     print(f"  {BOLD('How do you want to run ClawMetry?')}")
     print()
-    print(f"    {BOLD('[1] Local only')}    {DIM('Free. No account, nothing leaves this machine.')}")
-    print(f"                     {DIM('Watch OpenClaw and NeMo at http://localhost:8900.')}")
-    print(f"    {BOLD('[2] Cloud')}         {DIM('Free trial. A dashboard you can open from anywhere.')}")
-    print(f"                     {DIM('Creates an account for this machine. No card needed.')}")
-    print(f"    {BOLD('[3] License key')}   {DIM('Self-Hosted Pro: all 14 runtimes, offline. Paste a key.')}")
+    print(f"    {BOLD('[1] Sign in / Sign up')}  {DIM('Google, GitHub, or an email code. No card needed.')}")
+    print(f"                           {DIM('Starts your free 7-day Pro trial: every detected')}")
+    print(f"                           {DIM('runtime, right here plus a dashboard from anywhere.')}")
+    print(f"    {BOLD('[2] License key')}        {DIM('Self-Hosted Pro: all 14 runtimes, offline.')}")
+    print(f"    {BOLD('[3] Skip for now')}       {DIM('No account. OpenClaw + NeMo free at localhost:8900.')}")
     print()
 
     def _write_nocloud_marker():
@@ -3031,12 +3031,13 @@ def _cmd_onboard(args) -> None:
 
     # Scriptable / non-interactive overrides. A headless install (curl | bash
     # with no /dev/tty) must NEVER silently create a cloud account, so the
-    # default AND the EOF fallback are both LOCAL.
+    # EOF fallback is LOCAL ([3] Skip) even though the interactive default
+    # keypress is [1] Sign in.
     _env_local = _os.environ.get("CLAWMETRY_LOCAL_ONLY", "").strip().lower() in ("1", "true", "yes", "on")
     if getattr(args, "local", False) or _env_local:
-        choice = "1"
+        choice = "3"
     elif getattr(args, "cloud", False):
-        choice = "2"
+        choice = "1"
     else:
         # When already connected, the default on an empty Enter is "keep current
         # setup" (return without changes) so re-running onboard never silently
@@ -3046,8 +3047,13 @@ def _cmd_onboard(args) -> None:
         try:
             choice = _input(_prompt).strip()
         except (EOFError, KeyboardInterrupt):
-            choice = ""
+            # No interactive answer possible: never mint an account. A
+            # connected node keeps its setup; a fresh one goes local ([3]).
             print()
+            if already_connected:
+                print(f"\n  {DIM('Keeping your current setup. Run  clawmetry status  to check sync health.')}\n")
+                return
+            choice = "3"
         if not choice:
             if already_connected:
                 print(f"\n  {DIM('Keeping your current setup. Run  clawmetry status  to check sync health.')}\n")
@@ -3056,15 +3062,23 @@ def _cmd_onboard(args) -> None:
 
     print()
 
-    if choice == "3":
-        # ── Self-Hosted Pro license (local, offline, all 14 runtimes) ──────
+    if choice == "2":
+        # ── Self-Hosted license key (local, offline, all 14 runtimes) ──────
         _write_nocloud_marker()
         try:
-            _lic_key = _input("  Paste your license key (CLAW1...), or press Enter to do it later: ").strip()
+            _has_key = (_input("  Do you already have a license key? [y/N]: ").strip().lower() or "n")
         except (EOFError, KeyboardInterrupt):
-            _lic_key = ""
+            _has_key = "n"
             print()
         print()
+        _lic_key = ""
+        if _has_key in ("y", "yes"):
+            try:
+                _lic_key = _input("  Paste your license key (CLAW1...), or press Enter to do it later: ").strip()
+            except (EOFError, KeyboardInterrupt):
+                _lic_key = ""
+                print()
+            print()
         if _lic_key:
             try:
                 from clawmetry import license as _lic
@@ -3076,116 +3090,102 @@ def _cmd_onboard(args) -> None:
                 print(f"  ⚠️  Activation failed: {_e}")
                 print(f"     {DIM('Try again later:')} {CYAN('clawmetry activate <key>')}")
         else:
-            print(f"  {DIM('No problem. Buy a key at')} {CYAN('https://clawmetry.com/pricing')}")
-            print(f"  {DIM('then run')} {CYAN('clawmetry activate <key>')}")
+            # No key yet: hand them license pricing with the Self-Hosted
+            # toggle preselected (?deploy=self is honored by the pricing page).
+            _pricing_url = "https://clawmetry.com/pricing?deploy=self"
+            print(f"  {DIM('Get one at')} {CYAN(_pricing_url)}")
+            print(f"  {DIM('then run')} {CYAN('clawmetry activate <key>')} {DIM('on this machine.')}")
+            try:
+                import webbrowser
+                if webbrowser.open(_pricing_url):
+                    print(f"  {DIM('(opened in your browser)')}")
+            except Exception:
+                pass
         print()
         _maybe_apply_nemoclaw_preset(_input, BOLD, CYAN, DIM)
         _finish_local()
         return
 
-    if choice == "2":
-        # ── Cloud (free trial) ────────────────────────────────────────────
-        try:
-            has_acct = (_input("  Already have a ClawMetry account? [y/N]: ").strip().lower() or "n")
-        except (EOFError, KeyboardInterrupt):
-            has_acct = "n"
-            print()
+    if choice == "3":
+        # ── [3] Skip for now: local only, no account ──────────────────────
+        print(f"  {GREEN(BOLD('Local only.'))} {DIM('No account, no cloud.')}")
         print()
-        if has_acct in ("y", "yes"):
-            # Existing user: email -> OTP -> connect
-            import argparse as _ap
-
-            _fake_args = _ap.Namespace(
-                key=None, foreground=False, custom_node_id=None,
-                enc_key=None, key_only=False, no_daemon=False,
-            )
-            _cmd_connect(_fake_args)
-
-            print()
-            _maybe_apply_nemoclaw_preset(_input, BOLD, CYAN, DIM)
-            return
-
-        # New user: instant registration (no OTP)
-        print(f"  Setting up your cloud dashboard...")
-        print()
-
-        result = _instant_register(BOLD, GREEN, DIM)
-        if result is None:
-            # Registration failed -- fall back to local mode
-            print(f"  {GREEN('Installed')} (local mode)\n")
-            print("  Start your dashboard:")
-            print(
-                f"    {CYAN('clawmetry --host 0.0.0.0 --port 8900')}          {DIM('# foreground (LAN)')}"
-            )
-            print(f"\n  {DIM('Connect to cloud later: clawmetry setup')}\n")
-            _print_nemoclaw_preset_hint(BOLD, CYAN, DIM)
-            return
-
-        api_key = result.get("api_key", "")
-        dashboard_url = result.get("dashboard_url", "")
-        dashboard_id = result.get("dashboard_id", "")
-        node_id = result.get("node_id", "")
-
-        # Build the bookmarkable URL
-        if dashboard_id:
-            bookmark_url = f"https://app.clawmetry.com/d/{dashboard_id}"
-        else:
-            bookmark_url = dashboard_url
-
-        # Generate E2E encryption key and save config
-        from clawmetry.sync import generate_encryption_key, save_config
-        import platform
-
-        enc_key = generate_encryption_key()
-        config = {
-            "api_key": api_key,
-            "node_id": node_id,
-            "platform": platform.system(),
-            "connected_at": __import__("datetime").datetime.now().isoformat(),
-            "encryption_key": enc_key,
-            "dashboard_id": dashboard_id,
-        }
-        save_config(config)
-
-        print(f"  {GREEN(BOLD('Dashboard ready!'))}")
-        print()
-        print(f"     {BOLD(bookmark_url)}")
-        print()
-        print(f"     Bookmark this URL -- it's your private dashboard.")
-        print(f"     Data is E2E encrypted. Only you can read it.")
-        print()
-        print(f"  {BOLD('Your secret key')} (paste this when opening the dashboard):")
-        print()
-        print(f"     {CYAN(enc_key)}")
-        print()
-        print(f"     {DIM('Keep this safe -- you need it to view your data.')}")
-        print(f"     {DIM('Run')} {CYAN('clawmetry status --show-key')} {DIM('to see it again.')}")
-
-        # Auto-open the dashboard in browser
-        try:
-            import webbrowser
-            webbrowser.open(bookmark_url)
-            print(f"     {DIM('(opened in your browser)')}")
-        except Exception:
-            pass
-        print()
-        print(f"  {DIM('Want to add more nodes or never lose access?')}")
-        print(f"  {DIM('Run:')} {CYAN('clawmetry account')}")
-        print(f"  {DIM('(creates an email-based account to manage all your nodes)')}")
-        print()
-
+        _write_nocloud_marker()
         _maybe_apply_nemoclaw_preset(_input, BOLD, CYAN, DIM)
-
-        # Start sync daemon
-        print(f"  Starting sync daemon...")
-        _stop_existing_daemon()
-        _start_daemon(config, args)
-        print(f"  {GREEN(BOLD('Your agent is now being monitored!'))}")
-        print()
+        _finish_local()
         return
 
-    # ── [1] Local only (default) ──────────────────────────────────────────
-    print(f"  {GREEN(BOLD('Local only.'))} {DIM('No account, no cloud.')}")
+    # ── [1] Sign in / Sign up (default): identify first, trial second ────────
+    # Auth rides the existing connect flow (GitHub / Google OAuth incl. the
+    # headless paste-code path, or email OTP). Success is a cm_ api_key in
+    # ~/.clawmetry/config.json; then the account's ONE 7-day Pro trial
+    # license is minted-or-reused server-side and activated locally, so
+    # every runtime unlocks on the same rail Self-Hosted Pro uses.
+
+    def _config_api_key() -> str:
+        try:
+            import json as _jk
+            with open(_os.path.expanduser("~/.clawmetry/config.json"), "r", encoding="utf-8") as _fh:
+                return (_jk.load(_fh).get("api_key") or "").strip()
+        except Exception:
+            return ""
+
+    def _activate_signup_trial() -> None:
+        """Mint-or-reuse this account's 7-day Pro trial license and activate
+        it locally. Best-effort: any failure leaves onboarding as it was
+        (the account still works, runtimes just stay tier-gated). Never
+        raises; re-runs never reset a trial (server reissues the original
+        expiry)."""
+        api_key = _config_api_key()
+        if not api_key.startswith("cm_"):
+            return
+        try:
+            import json as _jk
+            import time as _tm
+            import urllib.request as _ur
+
+            from clawmetry import license as _lic
+
+            req = _ur.Request(
+                _lic._cloud_base() + "/api/license/trial/signup",
+                data=_jk.dumps({"api_key": api_key}).encode(),
+                headers={"Content-Type": "application/json"},
+                method="POST",
+            )
+            with _ur.urlopen(req, timeout=15) as resp:
+                body = _jk.loads(resp.read().decode())
+            if not (isinstance(body, dict) and body.get("ok") and body.get("key")):
+                return
+            if body.get("expired"):
+                print(f"  {DIM('Your 7-day Pro trial has ended. Keep every runtime:')} {CYAN('https://clawmetry.com/pricing')}")
+                print()
+                return
+            ok, _msg = _lic.activate(body["key"], node_id=_lic._node_id())
+            if not ok:
+                return
+            _left = max(1, int((float(body.get("expires_at", 0)) - _tm.time() + 86399) // 86400))
+            _days = "day" if _left == 1 else "days"
+            print(f"  {GREEN(BOLD('Pro trial active:'))} {DIM(f'every runtime unlocked on this machine, {_left} {_days} left.')}")
+            print()
+        except Exception:
+            return
+
+    import argparse as _ap
+
+    _fake_args = _ap.Namespace(
+        key=None, foreground=False, custom_node_id=None,
+        enc_key=None, key_only=False, no_daemon=False,
+    )
+    _cmd_connect(_fake_args)
+    print()
+
+    if _config_api_key():
+        _activate_signup_trial()
+        _maybe_apply_nemoclaw_preset(_input, BOLD, CYAN, DIM)
+        return
+
+    # Sign-in didn't complete: keep the machine useful locally, no account.
+    print(f"  {DIM('No account connected. Running local-only; try again anytime:')} {CYAN('clawmetry onboard')}")
     print()
     _write_nocloud_marker()
     _maybe_apply_nemoclaw_preset(_input, BOLD, CYAN, DIM)

--- a/clawmetry/runtime_probe.py
+++ b/clawmetry/runtime_probe.py
@@ -124,10 +124,10 @@ def render_detection_lines(probes: list) -> list:
     paid = [p for p in found if not p.get("free")]
     if len(paid) == 1:
         lines.append(
-            f"{paid[0]['label']} unlocks with Cloud [2] below or a license key [3] (clawmetry activate <key>)."
+            f"Sign in [1] below for a free 7-day Pro trial that unlocks {paid[0]['label']} too, or paste a license key [2]."
         )
     elif paid:
         lines.append(
-            f"The other {len(paid)} unlock with Cloud [2] below or a license key [3] (clawmetry activate <key>)."
+            f"Sign in [1] below for a free 7-day Pro trial of the other {len(paid)}, or paste a license key [2]."
         )
     return lines

--- a/tests/test_onboard_local_default.py
+++ b/tests/test_onboard_local_default.py
@@ -4,11 +4,17 @@ The pre-fork onboard defaulted a no-account / EOF answer to _instant_register,
 so a headless `curl | bash` (no /dev/tty) silently created a cloud account.
 That is exactly the surprise-account complaint that triggered a GDPR deletion.
 
-These tests pin the new 3-way fork (default = local):
-  * no-TTY / EOF  -> local only, marker written, _instant_register NOT called
-  * --local flag  -> local only (no prompt read)
-  * CLAWMETRY_LOCAL_ONLY=1 env -> local only
-  * choosing [2]  -> cloud registration IS reached
+These tests pin the sign-in-first fork (founder, 2026-07-29). "Silently" is
+the load-bearing word: the interactive default keypress is now [1] Sign in
+(a human pressing Enter at a visible menu), but every NON-interactive path
+stays account-free:
+  * no-TTY / EOF  -> local only, marker written, no account flow reached
+  * --local flag / CLAWMETRY_LOCAL_ONLY=1 -> local only (no prompt read)
+  * [1] / Enter   -> the AUTHENTICATED connect flow (never _instant_register;
+                     anonymous instant registration is no longer reachable
+                     from onboard) and, on success, the 7-day trial license
+  * [2]           -> license key (have/need fork)
+  * [3]           -> local only
 """
 import argparse
 import os
@@ -32,13 +38,29 @@ def onboard_env(monkeypatch, tmp_path):
     marker = home / ".clawmetry" / "nocloud"
     monkeypatch.setattr("clawmetry.config.NOCLOUD_MARKER_PATH", str(marker))
 
-    state = {"instant_register": 0, "start_daemon": 0}
+    state = {"instant_register": 0, "start_daemon": 0, "connect": 0}
 
     def _fake_instant_register(*a, **k):
         state["instant_register"] += 1
         return None  # registration "fails" -> harmless local fallback
 
+    def _fake_connect(*a, **k):
+        # Default stub: sign-in attempted but NOT completed (no config
+        # written) -> onboard must fall back to local. Tests that need a
+        # successful sign-in override this with a config-writing stub.
+        state["connect"] += 1
+        return None
+
     monkeypatch.setattr(cli, "_instant_register", _fake_instant_register)
+    monkeypatch.setattr(cli, "_cmd_connect", _fake_connect)
+    monkeypatch.setattr("webbrowser.open", lambda *a, **k: False)
+
+    def _no_network(*a, **k):
+        raise OSError("no network in tests")
+
+    # The signup-trial helper swallows this -> trial becomes a no-op unless a
+    # test overrides urlopen with a fake response.
+    monkeypatch.setattr("urllib.request.urlopen", _no_network)
     monkeypatch.setattr(cli, "_start_daemon", lambda *a, **k: state.__setitem__("start_daemon", state["start_daemon"] + 1))
     monkeypatch.setattr(cli, "_stop_existing_daemon", lambda *a, **k: None)
     monkeypatch.setattr(cli, "_maybe_apply_nemoclaw_preset", lambda *a, **k: None)
@@ -87,24 +109,93 @@ def test_env_local_only_forces_local(onboard_env, monkeypatch):
     assert marker.exists()
 
 
-def test_choice_2_reaches_cloud_registration(onboard_env, monkeypatch):
-    state, _marker = onboard_env
-    answers = iter(["2", "n"])  # [2] Cloud, then "no existing account" -> instant register
-
-    def _ans(_prompt=""):
-        return next(answers)
-
-    monkeypatch.setattr("builtins.input", _ans)
+def test_choice_1_reaches_authenticated_connect(onboard_env, monkeypatch):
+    state, marker = onboard_env
+    monkeypatch.setattr("builtins.input", lambda _p="": "1")
     cli._cmd_onboard(_args())
-    assert state["instant_register"] == 1, "[2] Cloud must reach instant registration"
+    assert state["connect"] == 1, "[1] Sign in must reach the authenticated connect flow"
+    assert state["instant_register"] == 0, "anonymous instant registration must be unreachable"
+    # Connect stub wrote no config -> sign-in incomplete -> local fallback.
+    assert marker.exists() and state["start_daemon"] == 1
 
 
-def test_empty_enter_defaults_to_local(onboard_env, monkeypatch):
+def test_empty_enter_defaults_to_sign_in(onboard_env, monkeypatch):
+    """The interactive default keypress is [1] Sign in (founder 2026-07-29).
+    A human pressing Enter at the visible menu is not a silent mint."""
     state, marker = onboard_env
     monkeypatch.setattr("builtins.input", lambda _p="": "")  # just press Enter
     cli._cmd_onboard(_args())
+    assert state["connect"] == 1
     assert state["instant_register"] == 0
-    assert marker.exists()
+    assert marker.exists(), "incomplete sign-in must fall back to local"
+
+
+def test_choice_2_no_key_points_at_selfhosted_pricing(onboard_env, monkeypatch, capsys):
+    state, marker = onboard_env
+    opened = []
+    monkeypatch.setattr("webbrowser.open", lambda url, *a, **k: opened.append(url) or True)
+    answers = iter(["2", "n"])  # [2] License key, then "don't have one yet"
+    monkeypatch.setattr("builtins.input", lambda _p="": next(answers))
+    cli._cmd_onboard(_args())
+    out = capsys.readouterr().out
+    assert "clawmetry.com/pricing?deploy=self" in out
+    assert opened == ["https://clawmetry.com/pricing?deploy=self"]
+    assert state["connect"] == 0 and state["instant_register"] == 0
+    assert marker.exists() and state["start_daemon"] == 1
+
+
+def test_choice_1_success_activates_signup_trial(onboard_env, monkeypatch, tmp_path, capsys):
+    """Connect success (api_key in config) must fetch the signup trial and
+    activate the returned key locally."""
+    import io
+    import json as _json
+
+    state, marker = onboard_env
+    home = tmp_path / "home"
+
+    def _connect_writes_config(*a, **k):
+        state["connect"] += 1
+        (home / ".clawmetry" / "config.json").write_text(
+            _json.dumps({"api_key": "cm_fresh_signup", "node_id": "n1"}))
+
+    monkeypatch.setattr(cli, "_cmd_connect", _connect_writes_config)
+
+    posted = {}
+
+    class _FakeResp(io.BytesIO):
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    def _fake_urlopen(req, timeout=0):
+        posted["url"] = req.full_url
+        posted["body"] = _json.loads(req.data.decode())
+        import time as _t
+        return _FakeResp(_json.dumps({
+            "ok": True, "key": "CLAW1.trial.key", "tier": "trial",
+            "expires_at": int(_t.time()) + 7 * 86400,
+            "reused": False, "expired": False,
+        }).encode())
+
+    monkeypatch.setattr("urllib.request.urlopen", _fake_urlopen)
+
+    activated = {}
+    import clawmetry.license as _lic
+    monkeypatch.setattr(_lic, "activate",
+                        lambda key, node_id=None, actor="": activated.__setitem__("key", key) or (True, "ok"))
+    monkeypatch.setattr(_lic, "_node_id", lambda: "n1")
+
+    monkeypatch.setattr("builtins.input", lambda _p="": "1")
+    cli._cmd_onboard(_args())
+
+    assert posted["url"].endswith("/api/license/trial/signup")
+    assert posted["body"] == {"api_key": "cm_fresh_signup"}
+    assert activated.get("key") == "CLAW1.trial.key"
+    out = capsys.readouterr().out
+    assert "Pro trial active" in out
+    assert not marker.exists(), "successful sign-in is a cloud setup, not local-only"
 
 
 # ── `clawmetry onboard` always shows the options (founder ask 2026-06-30) ────
@@ -128,20 +219,20 @@ def test_already_connected_empty_enter_keeps_current(onboard_env, monkeypatch, t
     assert not marker.exists(), "must NOT switch a connected user to local on empty Enter"
 
 
-def test_already_connected_shows_options_and_choice_1_goes_local(onboard_env, monkeypatch, tmp_path, capsys):
+def test_already_connected_shows_options_and_choice_3_goes_local(onboard_env, monkeypatch, tmp_path, capsys):
     state, marker = onboard_env
+    _make_connected(tmp_path / "home")
+    monkeypatch.setattr("builtins.input", lambda _p="": "3")
+    cli._cmd_onboard(_args())
+    out = capsys.readouterr().out
+    assert "[1] Sign in / Sign up" in out and "[2] License key" in out and "[3] Skip for now" in out
+    assert marker.exists(), "explicit [3] reconfigures a connected user to local"
+
+
+def test_already_connected_choice_1_reaches_connect(onboard_env, monkeypatch, tmp_path):
+    state, _marker = onboard_env
     _make_connected(tmp_path / "home")
     monkeypatch.setattr("builtins.input", lambda _p="": "1")
     cli._cmd_onboard(_args())
-    out = capsys.readouterr().out
-    assert "[1] Local only" in out and "[2] Cloud" in out and "[3] License key" in out
-    assert marker.exists(), "explicit [1] reconfigures a connected user to local"
-
-
-def test_already_connected_choice_2_reaches_cloud(onboard_env, monkeypatch, tmp_path):
-    state, _marker = onboard_env
-    _make_connected(tmp_path / "home")
-    answers = iter(["2", "n"])  # [2] Cloud, then "no existing account" -> instant register
-    monkeypatch.setattr("builtins.input", lambda _p="": next(answers))
-    cli._cmd_onboard(_args())
-    assert state["instant_register"] == 1
+    assert state["connect"] == 1
+    assert state["instant_register"] == 0

--- a/tests/test_onboard_runtime_detection.py
+++ b/tests/test_onboard_runtime_detection.py
@@ -70,7 +70,7 @@ def test_render_free_only_machine_has_no_pro_cta():
 
 def test_render_paid_detected_names_runtime_and_both_paths():
     """The founder's exact ask: show detections, state the free tier,
-    offer the license key AND the cloud signup for the rest."""
+    offer sign-in (trial) AND the license key for the rest."""
     probes = [
         {"id": "claude_code", "label": "Claude Code", "free": False, "found": True},
         {"id": "cursor", "label": "Cursor", "free": False, "found": True},
@@ -80,8 +80,8 @@ def test_render_paid_detected_names_runtime_and_both_paths():
     joined = "\n".join(lines)
     assert "Claude Code" in joined and "Cursor" in joined
     assert "Free forever: OpenClaw and NVIDIA NemoClaw." in joined
-    assert "clawmetry activate" in joined
-    assert "Cloud" in joined
+    assert "Sign in [1]" in joined and "7-day Pro trial" in joined
+    assert "license key [2]" in joined
     # The em-dash/double-dash ban applies to user-facing copy.
     assert "—" not in joined and "--" not in joined
 
@@ -105,7 +105,7 @@ def test_render_grid_compact_no_per_line_tier_labels():
     assert len(grid) == 4  # 3 + 3 + 3 + 1
     assert grid[0].count("[x]") == 3
     assert "Detected 10 AI agent runtimes" in lines[0]
-    assert "The other 9 unlock" in joined
+    assert "trial of the other 9" in joined
 
 
 def test_render_single_paid_runtime_named_in_unlock_line():
@@ -113,8 +113,8 @@ def test_render_single_paid_runtime_named_in_unlock_line():
         {"id": "cursor", "label": "Cursor", "free": False, "found": True},
     ]
     joined = "\n".join(render_detection_lines(probes))
-    assert "Cursor unlocks with Cloud" in joined
-    assert "clawmetry activate" in joined
+    assert "unlocks Cursor too" in joined
+    assert "Sign in [1]" in joined and "license key [2]" in joined
 
 
 def test_render_nothing_detected_is_silent():


### PR DESCRIPTION
## What
Onboard's fork now leads with identity, per the founder's spec: authenticate first (any of Google / GitHub / email OTP — the existing connect machinery), then unlock all runtimes locally via a **trial license key** minted server-side, the same rail Self-Hosted Pro rides.

```
  Free forever: OpenClaw and NVIDIA NemoClaw.
  Sign in [1] below for a free 7-day Pro trial of the other 9, or paste a license key [2].

  How do you want to run ClawMetry?

    [1] Sign in / Sign up  Google, GitHub, or an email code. No card needed.
                           Starts your free 7-day Pro trial: every detected
                           runtime, right here plus a dashboard from anywhere.
    [2] License key        Self-Hosted Pro: all 14 runtimes, offline.
    [3] Skip for now       No account. OpenClaw + NeMo free at localhost:8900.

  Choose [1]:
```

- **[1]** (default): `_cmd_connect` → on success, `POST /api/license/trial/signup` with the fresh api_key → `license.activate()` locally → "Pro trial active: every runtime unlocked on this machine, 7 days left." Server reissues the same trial on re-runs (original expiry); expired trials print an honest notice + pricing link. Incomplete sign-in falls back to local-only.
- **[2]**: "Do you already have a license key? [y/N]" — yes → paste/activate; no → `clawmetry.com/pricing?deploy=self` (Self-Hosted toggle preselected, landing #582, live) printed + opened in browser.
- **[3]**: the old local-only path, unchanged.

## Safety rails (pinned by tests)
- EOF / no-TTY / `--local` / `CLAWMETRY_LOCAL_ONLY=1` never mint an account; EOF on a connected node keeps its setup.
- Anonymous `_instant_register` is **no longer reachable** from onboard — every account now has a verified identity.
- 22 tests green across `test_onboard_local_default.py` (rewritten to the new contract + 2 new: pricing redirect, full sign-in→trial→activate wiring with fake urlopen), `test_onboard_runtime_detection.py`, `test_local_only_config_normalize.py`.

## Sequencing
**Do not [RELEASE] until cloud #1812 (the `/api/license/trial/signup` endpoint + route-collision fix) is deployed** — the trial call is best-effort so nothing breaks, but the trial wouldn't activate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)