### PR TITLE
feat(license): pro_install_age_days_at_batch + /api/license/pro-install-age-days-at-batch

### DIFF
--- a/clawmetry/license.py
+++ b/clawmetry/license.py
@@ -2822,6 +2822,7 @@ def days_until_expiry_at_batch(epochs) -> list[dict]:
     return out
 
 
+
 def license_age_days_at_batch(epochs) -> list[dict]:
     """Per-value perspective-epoch "how old was the license?" scalar for
     N epochs in ONE round-trip.
@@ -2899,5 +2900,77 @@ def license_age_days_at_batch(epochs) -> list[dict]:
             days = None
         out.append(
             {"epoch": parsed, "days": int(days) if isinstance(days, int) else None}
+        )
+    return out
+
+
+def pro_install_age_days_at_batch(epochs) -> list[dict]:
+    """Per-value perspective-epoch "how old was the ``clawmetry-pro``
+    install at this epoch?" scalar for N epochs in ONE round-trip.
+
+    Per-value axis batch sibling of :func:`pro_install_age_days_at`. Fills
+    the ``_at_batch`` slot on the pro-install-age axis alongside the
+    singular :func:`pro_install_age_days_at` and the "now" flavour
+    :func:`pro_install_age_days`, so a scheduled-audit tile that wants to
+    plot the install-age across a sequence of perspective dates ("how old
+    was the pro wheel at each of these build timestamps?") hydrates the
+    full column in one call.
+
+    Twin of :func:`license_age_days_at_batch` for the ``installed_at`` axis
+    -- one derives from the signed ``iat`` claim, this one from the
+    on-disk provisioning marker -- so a caller assembling an install +
+    entitlement timeline can zip the two batch responses index-for-index.
+    Callers wanting the "N days old, still valid for M more days" pair for
+    the same sequence of epochs zip this with
+    :func:`days_until_expiry_at_batch`.
+
+    Row shape::
+
+        {
+          "epoch":    <int> | "<raw>",
+          "age_days": <int> | None,
+        }
+
+    Semantics per row mirror :func:`pro_install_age_days_at`: a signed
+    integer number of days (positive when ``epoch`` is after
+    ``installed_at`` -- the normal "N days old as of <date>" case, zero on
+    the day of provisioning, negative when ``epoch`` is BEFORE
+    ``installed_at`` -- the operator asked a pre-install question and the
+    negative is a real signal, not clock skew to be hidden); ``None`` when
+    there is no marker on disk, when the marker has no ``installed_at``
+    key, when ``installed_at`` is non-numeric / non-positive, or for
+    ``bool`` / non-numeric epochs.
+
+    Row shape mirrors :func:`license_age_days_at_batch` so a caller
+    assembling a two-axis age timeline (marker vs signed iat) can zip the
+    two responses index-for-index.
+
+    Duplicates by normalised int key (or ``repr(raw)`` for bad inputs)
+    are dropped preserving first-seen order for byte-stable output.
+    ``epochs is None`` or non-iterable -- returns ``[]``. Never raises:
+    per-row failures short-circuit to ``age_days=None`` so the batch keeps
+    building. Deliberately independent of live importability -- a marker
+    on disk yields an age even when Python cannot currently import
+    ``clawmetry-pro`` (wheel was pip-uninstalled since); pair with
+    :func:`pro_installed` for the live-import signal.
+    """
+    out: list[dict] = []
+    for raw, _key, parsed in _license_epoch_batch_keys(epochs):
+        if parsed is None:
+            try:
+                token = str(raw)
+            except Exception:
+                token = repr(raw)
+            out.append({"epoch": token, "age_days": None})
+            continue
+        try:
+            age = pro_install_age_days_at(parsed)
+        except Exception as exc:
+            logger.debug(
+                "license: pro_install_age_days_at_batch per-row failed: %s", exc
+            )
+            age = None
+        out.append(
+            {"epoch": parsed, "age_days": int(age) if isinstance(age, int) else None}
         )
     return out

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -8780,6 +8780,102 @@ def api_license_pro_install_age_days_at():
     )
 
 
+@bp_entitlement.route("/api/license/pro-install-age-days-at-batch")
+def api_license_pro_install_age_days_at_batch():
+    """``GET /api/license/pro-install-age-days-at-batch?epochs=<int>,<int>,...``
+    -- per-value batch sibling of ``/api/license/pro-install-age-days-at``.
+
+    Pro-install-age axis batch companion to
+    ``/api/license/pro-install-age-days`` (NOW) and
+    ``/api/license/pro-install-age-days-at`` (singular perspective epoch).
+    Where the singular endpoint folds ONE perspective epoch to ONE signed
+    day-count, this preserves per-value rows so a scheduled audit tile
+    that wants to plot install-age across a sequence of perspective dates
+    (build timestamps, release timestamps, "was the wheel present when we
+    shipped that?") hydrates the full column in one call. Wraps
+    :func:`clawmetry.license.pro_install_age_days_at_batch`.
+
+    Twin of ``/api/license/age-days-at-batch`` for the ``installed_at``
+    axis -- one derives from the signed ``iat`` claim, this one from the
+    on-disk provisioning marker -- so a caller assembling an install +
+    entitlement timeline can zip the two batch responses index-for-index.
+
+    Row shape::
+
+        {
+          "epoch":    <int|"<raw>">,
+          "age_days": <int|null>,
+        }
+
+    Query-string posture mirrors the other ``/api/license/*-at-batch``
+    endpoints: ``epochs=`` required (missing / blank / only-commas ->
+    ``400``), comma-separated tokens deduped by parsed int key preserving
+    first-seen order, non-int / ``bool`` / ``None`` tokens collapse to
+    ``age_days=null`` (rather than a 4xx hiding the whole batch on a
+    single typo -- callers can identify the offending entry in the
+    response). Never 5xxs.
+
+    Response shape (always HTTP 200)::
+
+        {
+          "kind":            "pro_install_age_days_at",
+          "count":           <int>,
+          "rows":            [
+            {"epoch": <int|"<raw>">, "age_days": <int|null>},
+            ...
+          ],
+          "installed_at":    <int|null>,   # current on-disk marker installed_at
+          "marker_present":  <bool>,       # is the marker file readable?
+          "installed":       <bool>        # can Python import clawmetry-pro right now?
+        }
+
+    Shares :func:`_pro_install_snapshot` with
+    ``/api/license/pro-install-age-days`` /
+    ``/api/license/pro-install-age-days-at`` /
+    ``/api/license/pro-installed-at`` so a UI binding any pair of them for
+    the same install cannot catch them disagreeing on ``installed_at`` /
+    ``marker_present`` / ``installed``.
+
+    Per-row parity with ``/api/license/pro-install-age-days-at?epoch=<n>``
+    is pinned in the test suite so the batch cannot silently drift from
+    the scalar endpoint.
+    """
+    tokens, err = _parse_license_epochs_csv("epochs")
+    if err == "missing":
+        return jsonify({"error": "missing epochs"}), 400
+    try:
+        snap = _pro_install_snapshot()
+    except Exception as exc:
+        logger.warning(
+            "api_license_pro_install_age_days_at_batch: snapshot error: %s", exc
+        )
+        snap = {
+            "installed_at": None,
+            "age_days": None,
+            "marker_present": False,
+            "installed": False,
+        }
+    try:
+        from clawmetry import license as _lic
+
+        rows = _lic.pro_install_age_days_at_batch(tokens)
+    except Exception as exc:
+        logger.warning(
+            "api_license_pro_install_age_days_at_batch: derive error: %s", exc
+        )
+        rows = []
+    return jsonify(
+        {
+            "kind": "pro_install_age_days_at",
+            "count": len(rows),
+            "rows": rows,
+            "installed_at": snap["installed_at"],
+            "marker_present": snap["marker_present"],
+            "installed": snap["installed"],
+        }
+    )
+
+
 def _license_nodes_snapshot() -> dict:
     """Shared helper: read once, derive the trio the two node-limit endpoints
     both need (``nodes``, ``has_license``, ``valid``). Lives in the handler

--- a/tests/test_license_pro_install_age_days_at_batch.py
+++ b/tests/test_license_pro_install_age_days_at_batch.py
@@ -1,0 +1,477 @@
+"""Tests for :func:`clawmetry.license.pro_install_age_days_at_batch` and
+the paired ``GET /api/license/pro-install-age-days-at-batch`` endpoint.
+
+Per-value batch sibling of :func:`clawmetry.license.pro_install_age_days_at`
+/ ``/api/license/pro-install-age-days-at``. Fills the ``_at_batch`` slot on
+the pro-install-age axis alongside the singular scalar and the "now"
+flavour, so a scheduled-audit tile can plot the install-age across a
+sequence of perspective dates in one call. Twin of
+``license_age_days_at_batch`` for the ``installed_at`` axis.
+
+Hermetic: marker path monkeypatched into ``tmp_path``,
+``_pro_installed_version`` stubbed so tests never touch site-packages --
+mirrors ``tests/test_license_pro_install_age_days_at_scalar.py``.
+"""
+from __future__ import annotations
+
+import json
+import os
+import time
+from types import SimpleNamespace
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def env(monkeypatch, tmp_path):
+    """Isolated pro-install env with the entitlement blueprint mounted.
+
+    Mirrors the fixture in
+    ``tests/test_license_pro_install_age_days_at_scalar.py`` so the two
+    suites can be read side-by-side.
+    """
+    import clawmetry.license as _lic
+
+    marker_path = str(tmp_path / "pro_installed.json")
+    monkeypatch.setattr(_lic, "_PRO_MARKER_PATH", marker_path)
+
+    state = {"version": None}
+    monkeypatch.setattr(_lic, "_pro_installed_version", lambda: state["version"])
+
+    from routes.entitlement import bp_entitlement
+
+    flask_app = Flask(__name__)
+    flask_app.register_blueprint(bp_entitlement)
+    flask_app.config["TESTING"] = True
+
+    return SimpleNamespace(
+        app=flask_app,
+        lic=_lic,
+        marker_path=marker_path,
+        state=state,
+    )
+
+
+def _write_marker(env, payload):
+    os.makedirs(os.path.dirname(env.marker_path), exist_ok=True)
+    with open(env.marker_path, "w", encoding="utf-8") as fh:
+        json.dump(payload, fh)
+
+
+# -- clawmetry.license.pro_install_age_days_at_batch() -----------------------
+
+
+def test_pro_install_age_days_at_batch_none_returns_empty(env):
+    """``epochs is None`` -> ``[]``. Never-raise posture, matches
+    :func:`license_state_at_batch` / :func:`is_expired_at_batch`."""
+    assert env.lic.pro_install_age_days_at_batch(None) == []
+
+
+def test_pro_install_age_days_at_batch_non_iterable_returns_empty(env):
+    """Non-iterable ``epochs`` (a bare int -- probable typo for a caller
+    that forgot to wrap it) -> ``[]`` rather than a crash."""
+    assert env.lic.pro_install_age_days_at_batch(42) == []
+
+
+def test_pro_install_age_days_at_batch_empty_returns_empty(env):
+    """Empty iterable -> ``[]``."""
+    assert env.lic.pro_install_age_days_at_batch([]) == []
+    assert env.lic.pro_install_age_days_at_batch(()) == []
+
+
+def test_pro_install_age_days_at_batch_no_marker(env):
+    """No marker file on disk -> every row ``age_days=None`` (nothing to
+    compute against). Time-independent, matches the scalar posture."""
+    rows = env.lic.pro_install_age_days_at_batch(
+        [0, int(time.time()), 2_000_000_000]
+    )
+    assert [r["age_days"] for r in rows] == [None, None, None]
+
+
+def test_pro_install_age_days_at_batch_active_marker_positive_days(env):
+    """Active marker, epochs after ``installed_at`` -> positive signed
+    day counts, floor-divided from seconds (matches the scalar)."""
+    installed = int(time.time())
+    _write_marker(env, {"installed_at": installed, "version": "0.3.4"})
+    env.state["version"] = "0.3.4"
+    epochs = [installed, installed + 10 * 86400, installed + 100 * 86400]
+    rows = env.lic.pro_install_age_days_at_batch(epochs)
+    assert [r["epoch"] for r in rows] == epochs
+    assert rows[0]["age_days"] == 0
+    assert rows[1]["age_days"] == 10
+    assert rows[2]["age_days"] == 100
+
+
+def test_pro_install_age_days_at_batch_negative_for_pre_install_epochs(env):
+    """Epoch BEFORE ``installed_at`` -> negative int, NOT clamped to 0
+    (unlike the "now" flavour, a caller explicitly asking a pre-install
+    question wants the signed answer). Matches the scalar."""
+    installed = int(time.time())
+    _write_marker(env, {"installed_at": installed, "version": "0.3.4"})
+    rows = env.lic.pro_install_age_days_at_batch(
+        [installed - 5 * 86400, installed - 1, installed, installed + 1]
+    )
+    ages = [r["age_days"] for r in rows]
+    assert ages[0] == -5
+    # ``installed - 1`` -> ``(-1) // 86400`` -> -1 (Python floor-div on
+    # a negative dividend rounds AWAY from zero).
+    assert ages[1] == -1
+    assert ages[2] == 0
+    assert ages[3] == 0
+
+
+def test_pro_install_age_days_at_batch_per_row_parity_with_scalar(env):
+    """Per-row parity with :func:`pro_install_age_days_at` -- the batch
+    cannot silently drift from the scalar. Pin every row."""
+    installed = int(time.time())
+    _write_marker(env, {"installed_at": installed, "version": "0.3.4"})
+    epochs = [
+        installed - 10 * 86400,
+        installed - 1,
+        installed,
+        installed + 1,
+        installed + 60 * 86400,
+    ]
+    rows = env.lic.pro_install_age_days_at_batch(epochs)
+    for row, epoch in zip(rows, epochs):
+        assert row["age_days"] == env.lic.pro_install_age_days_at(epoch), epoch
+
+
+def test_pro_install_age_days_at_batch_missing_installed_at(env):
+    """Marker exists but ``installed_at`` key absent -> every row
+    ``age_days=None`` regardless of epoch (matches the scalar)."""
+    _write_marker(env, {"version": "0.3.4"})
+    rows = env.lic.pro_install_age_days_at_batch(
+        [0, int(time.time()), 2_000_000_000]
+    )
+    assert [r["age_days"] for r in rows] == [None, None, None]
+
+
+def test_pro_install_age_days_at_batch_corrupt_marker(env):
+    """Corrupt marker JSON -> every row ``age_days=None`` (scalar
+    collapses too; batch inherits)."""
+    os.makedirs(os.path.dirname(env.marker_path), exist_ok=True)
+    with open(env.marker_path, "w", encoding="utf-8") as fh:
+        fh.write("{not valid json")
+    rows = env.lic.pro_install_age_days_at_batch([int(time.time()), 0])
+    assert [r["age_days"] for r in rows] == [None, None]
+
+
+def test_pro_install_age_days_at_batch_string_int_tokens_parsed(env):
+    """Int-parseable strings coerce cleanly (matches the singular's
+    ``int()`` coercion in :func:`_license_epoch_batch_keys`)."""
+    installed = int(time.time())
+    _write_marker(env, {"installed_at": installed, "version": "0.3.4"})
+    rows = env.lic.pro_install_age_days_at_batch(
+        [str(installed + 5 * 86400), str(installed - 3 * 86400)]
+    )
+    assert [r["age_days"] for r in rows] == [5, -3]
+
+
+def test_pro_install_age_days_at_batch_dedupes_by_int_key_preserves_order(env):
+    """Duplicates by parsed int key are dropped preserving first-seen
+    order so the response is byte-stable across calls."""
+    installed = int(time.time())
+    _write_marker(env, {"installed_at": installed, "version": "0.3.4"})
+    rows = env.lic.pro_install_age_days_at_batch(
+        [
+            installed,
+            installed + 100,
+            installed,
+            str(installed + 100),
+            installed + 200,
+        ]
+    )
+    assert [r["epoch"] for r in rows] == [
+        installed,
+        installed + 100,
+        installed + 200,
+    ]
+
+
+def test_pro_install_age_days_at_batch_bad_tokens_collapse_to_none(env):
+    """``bool`` / non-numeric / ``None`` collapse to ``age_days=None``
+    (matches the scalar's rejection). Row still keeps its slot so each
+    bad input gets its own bucket."""
+    installed = int(time.time())
+    _write_marker(env, {"installed_at": installed, "version": "0.3.4"})
+    rows = env.lic.pro_install_age_days_at_batch(
+        [True, False, None, "garbage", ""]
+    )
+    assert len(rows) == 5
+    assert all(r["age_days"] is None for r in rows)
+
+
+def test_pro_install_age_days_at_batch_mixed_good_and_bad(env):
+    """Bad tokens don't fail the whole batch. Good rows still resolve;
+    bad rows still slot in with ``age_days=None``."""
+    installed = int(time.time())
+    _write_marker(env, {"installed_at": installed, "version": "0.3.4"})
+    rows = env.lic.pro_install_age_days_at_batch(
+        [installed, "garbage", installed + 30 * 86400]
+    )
+    ages = [r["age_days"] for r in rows]
+    assert ages[0] == 0
+    assert ages[1] is None
+    assert ages[2] == 30
+
+
+def test_pro_install_age_days_at_batch_independent_of_live_import(env):
+    """Marker present but wheel not importable -> ``age_days`` still
+    surfaces (age tracks the marker, not live importability). Matches
+    the scalar."""
+    installed = int(time.time())
+    _write_marker(env, {"installed_at": installed, "version": "0.3.4"})
+    # state["version"] stays None -> pro_installed() is False.
+    assert env.lic.pro_installed() is False
+    rows = env.lic.pro_install_age_days_at_batch(
+        [installed, installed + 7 * 86400]
+    )
+    assert [r["age_days"] for r in rows] == [0, 7]
+
+
+def test_pro_install_age_days_at_batch_never_raises(env, monkeypatch):
+    """Any per-row underlying failure of :func:`pro_install_age_days_at`
+    -> ``age_days=None`` for THAT row. The batch never propagates."""
+    def _boom(_epoch):
+        raise RuntimeError("simulated corrupt install")
+
+    monkeypatch.setattr(env.lic, "pro_install_age_days_at", _boom)
+    rows = env.lic.pro_install_age_days_at_batch([1_700_000_000, 1_800_000_000])
+    assert [r["age_days"] for r in rows] == [None, None]
+    assert len(rows) == 2
+
+
+# -- GET /api/license/pro-install-age-days-at-batch --------------------------
+
+
+def test_endpoint_pro_install_age_days_at_batch_missing_epochs(env):
+    """``?epochs=`` absent -> 400 missing epochs (matches the other
+    ``/api/license/*-at-batch`` endpoints -- missing input is a real
+    error, unlike bad input)."""
+    with env.app.test_client() as c:
+        resp = c.get("/api/license/pro-install-age-days-at-batch")
+    assert resp.status_code == 400
+    assert resp.get_json() == {"error": "missing epochs"}
+
+
+def test_endpoint_pro_install_age_days_at_batch_blank_epochs(env):
+    """``?epochs=`` blank / only-commas -> 400 missing epochs."""
+    with env.app.test_client() as c:
+        resp1 = c.get("/api/license/pro-install-age-days-at-batch?epochs=")
+        resp2 = c.get("/api/license/pro-install-age-days-at-batch?epochs=,,,")
+    assert resp1.status_code == 400
+    assert resp2.status_code == 400
+
+
+def test_endpoint_pro_install_age_days_at_batch_no_marker(env):
+    """No marker file -> every row ``age_days=None``, HTTP 200, snapshot
+    fields set to the no-marker branch shape."""
+    now = int(time.time())
+    with env.app.test_client() as c:
+        resp = c.get(
+            f"/api/license/pro-install-age-days-at-batch?epochs={now},0"
+        )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["kind"] == "pro_install_age_days_at"
+    assert data["count"] == 2
+    assert [r["age_days"] for r in data["rows"]] == [None, None]
+    assert data["installed_at"] is None
+    assert data["marker_present"] is False
+    assert data["installed"] is False
+
+
+def test_endpoint_pro_install_age_days_at_batch_active_marker(env):
+    """Active marker: signed day counts, snapshot reflects live install."""
+    installed = int(time.time())
+    _write_marker(env, {"installed_at": installed, "version": "0.3.4"})
+    env.state["version"] = "0.3.4"
+    epochs = [installed + 5 * 86400, installed + 20 * 86400]
+    csv = ",".join(str(e) for e in epochs)
+    with env.app.test_client() as c:
+        resp = c.get(f"/api/license/pro-install-age-days-at-batch?epochs={csv}")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["kind"] == "pro_install_age_days_at"
+    assert data["count"] == 2
+    assert [r["age_days"] for r in data["rows"]] == [5, 20]
+    assert data["installed_at"] == installed
+    assert data["marker_present"] is True
+    assert data["installed"] is True
+
+
+def test_endpoint_pro_install_age_days_at_batch_per_row_parity_with_scalar(env):
+    """Per-row parity with the singular
+    ``/api/license/pro-install-age-days-at?epoch=<n>`` endpoint -- the
+    batch cannot silently drift from the scalar endpoint."""
+    installed = int(time.time())
+    _write_marker(env, {"installed_at": installed, "version": "0.3.4"})
+    env.state["version"] = "0.3.4"
+    epochs = [
+        installed - 10 * 86400,
+        installed - 1,
+        installed,
+        installed + 1,
+        installed + 60 * 86400,
+    ]
+    csv = ",".join(str(e) for e in epochs)
+    with env.app.test_client() as c:
+        batch = c.get(
+            f"/api/license/pro-install-age-days-at-batch?epochs={csv}"
+        ).get_json()
+        for row, epoch in zip(batch["rows"], epochs):
+            scalar = c.get(
+                f"/api/license/pro-install-age-days-at?epoch={epoch}"
+            ).get_json()
+            assert row["age_days"] == scalar["age_days"], epoch
+
+
+def test_endpoint_pro_install_age_days_at_batch_negative_pre_install(env):
+    """Epoch BEFORE ``installed_at`` -> negative ``age_days`` (matches
+    the scalar's signed-integer posture)."""
+    installed = int(time.time())
+    _write_marker(env, {"installed_at": installed, "version": "0.3.4"})
+    with env.app.test_client() as c:
+        resp = c.get(
+            f"/api/license/pro-install-age-days-at-batch?epochs={installed - 30 * 86400},{installed + 30 * 86400}"
+        )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    ages = [r["age_days"] for r in data["rows"]]
+    assert ages[0] == -30
+    assert ages[1] == 30
+    assert data["marker_present"] is True
+
+
+def test_endpoint_pro_install_age_days_at_batch_bad_tokens_collapse_to_none(env):
+    """Bad tokens don't fail the whole batch. They slot in with
+    ``age_days=null`` while good rows still resolve."""
+    installed = int(time.time())
+    _write_marker(env, {"installed_at": installed, "version": "0.3.4"})
+    with env.app.test_client() as c:
+        resp = c.get(
+            f"/api/license/pro-install-age-days-at-batch?epochs=garbage,{installed + 3 * 86400}"
+        )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["count"] == 2
+    assert data["rows"][0]["age_days"] is None
+    assert data["rows"][1]["age_days"] == 3
+
+
+def test_endpoint_pro_install_age_days_at_batch_marker_present_wheel_missing(env):
+    """The paywall-debug case: marker on disk, wheel pip-uninstalled.
+    ``age_days`` still surfaces (age tracks the marker, not live
+    import); ``installed`` is False so a caller that wants to hide the
+    row on a broken install has the signal."""
+    _write_marker(env, {"installed_at": 1_700_000_000, "version": "0.3.4"})
+    # state["version"] stays None -> pro_installed() is False.
+    epochs = [1_700_000_000, 1_700_000_000 + 12 * 86400]
+    csv = ",".join(str(e) for e in epochs)
+    with env.app.test_client() as c:
+        resp = c.get(f"/api/license/pro-install-age-days-at-batch?epochs={csv}")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert [r["age_days"] for r in data["rows"]] == [0, 12]
+    assert data["installed_at"] == 1_700_000_000
+    assert data["marker_present"] is True
+    assert data["installed"] is False
+
+
+def test_endpoint_pro_install_age_days_at_batch_dedupe_preserves_order(env):
+    """Duplicates by parsed int key are dropped preserving first-seen
+    order for byte-stable output."""
+    installed = int(time.time())
+    _write_marker(env, {"installed_at": installed, "version": "0.3.4"})
+    with env.app.test_client() as c:
+        resp = c.get(
+            f"/api/license/pro-install-age-days-at-batch?epochs={installed},{installed + 100},{installed},{installed + 100}"
+        )
+    data = resp.get_json()
+    assert data["count"] == 2
+    assert [r["epoch"] for r in data["rows"]] == [installed, installed + 100]
+
+
+def test_endpoint_pro_install_age_days_at_batch_corrupt_marker(env):
+    """Corrupt marker -> HTTP 200, every row ``age_days=null``, snapshot
+    fields reflect the no-marker branch."""
+    os.makedirs(os.path.dirname(env.marker_path), exist_ok=True)
+    with open(env.marker_path, "w", encoding="utf-8") as fh:
+        fh.write("{not json")
+    now = int(time.time())
+    with env.app.test_client() as c:
+        resp = c.get(
+            f"/api/license/pro-install-age-days-at-batch?epochs={now}"
+        )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["count"] == 1
+    assert data["rows"][0]["age_days"] is None
+    assert data["installed_at"] is None
+    assert data["marker_present"] is False
+    assert data["installed"] is False
+
+
+def test_endpoint_pro_install_age_days_at_batch_never_5xxs(env, monkeypatch):
+    """Even if the shared snapshot blows up mid-request, the endpoint
+    still returns HTTP 200 with the no-marker snapshot fallback + honest
+    per-row derivation."""
+    from routes import entitlement as _routes
+
+    monkeypatch.setattr(
+        _routes,
+        "_pro_install_snapshot",
+        lambda: (_ for _ in ()).throw(RuntimeError("simulated blowup")),
+    )
+    now = int(time.time())
+    with env.app.test_client() as c:
+        resp = c.get(
+            f"/api/license/pro-install-age-days-at-batch?epochs={now}"
+        )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["installed_at"] is None
+    assert data["marker_present"] is False
+    assert data["installed"] is False
+
+
+# -- cross-endpoint consistency ----------------------------------------------
+
+
+def test_endpoint_agrees_with_scalar_endpoint_on_shared_snapshot(env):
+    """The batch endpoint and the singular perspective endpoint share
+    :func:`_pro_install_snapshot`, so their common fields must match
+    exactly regardless of which epoch each is asked about."""
+    installed = int(time.time()) - 20 * 86400
+    _write_marker(env, {"installed_at": installed, "version": "0.3.4"})
+    env.state["version"] = "0.3.4"
+    epoch = int(time.time()) + 5 * 86400
+    with env.app.test_client() as c:
+        batch = c.get(
+            f"/api/license/pro-install-age-days-at-batch?epochs={epoch}"
+        ).get_json()
+        scalar = c.get(
+            f"/api/license/pro-install-age-days-at?epoch={epoch}"
+        ).get_json()
+    for key in ("installed_at", "marker_present", "installed"):
+        assert batch[key] == scalar[key], f"mismatch on {key}"
+    # And the per-row age_days for that epoch matches the scalar's.
+    assert batch["rows"][0]["age_days"] == scalar["age_days"]
+
+
+def test_endpoint_agrees_with_pro_installed_at_on_shared_snapshot(env):
+    """The batch endpoint and ``/api/license/pro-installed-at`` share
+    :func:`_pro_install_snapshot`, so their common fields must match
+    exactly."""
+    installed = int(time.time()) - 42 * 86400
+    _write_marker(env, {"installed_at": installed, "version": "0.3.4"})
+    env.state["version"] = "0.3.4"
+    with env.app.test_client() as c:
+        batch = c.get(
+            f"/api/license/pro-install-age-days-at-batch?epochs={int(time.time())}"
+        ).get_json()
+        installed_at_ep = c.get("/api/license/pro-installed-at").get_json()
+    for key in ("installed_at", "marker_present", "installed"):
+        assert batch[key] == installed_at_ep[key], f"mismatch on {key}"


### PR DESCRIPTION
## Summary

Fills the `_at_batch` slot on the pro-install-age axis, completing the marker-derived install-age family:

| Axis | Singular `_at` | Batch `_at_batch` |
|---|---|---|
| license age (from signed `iat`) | `/api/license/age-days-at` | `/api/license/age-days-at-batch` (#4213) |
| **pro install age (from marker `installed_at`)** | `/api/license/pro-install-age-days-at` | **`/api/license/pro-install-age-days-at-batch`** (new) |

Twin of `license_age_days_at_batch` for the `installed_at` axis (one derives from the signed `iat` claim, this one from the on-disk provisioning marker at `~/.clawmetry/pro_installed.json`), so a caller assembling an install + entitlement timeline can zip the two batch responses index-for-index instead of paying `2 * N` scalar calls per audit row.

## Changes

- **`clawmetry/license.py`** — new `pro_install_age_days_at_batch(epochs)` following the shape used by `days_until_expiry_at_batch`: per-row signed integer age against `installed_at`, `None` on no marker / no `installed_at` key / non-numeric marker / `bool` / non-numeric epoch. Dedupe by parsed int key preserving first-seen order via the shared `_license_epoch_batch_keys()` iterator. Never raises.
- **`routes/entitlement.py`** — new `GET /api/license/pro-install-age-days-at-batch?epochs=,,...` on `bp_entitlement`. Shares `_pro_install_snapshot()` with the singular perspective endpoint, the "now" endpoint, and `/api/license/pro-installed-at` so a UI binding any pair cannot catch them disagreeing on `installed_at` / `marker_present` / `installed`. Returns 400 only on missing/blank `epochs`; bad tokens collapse to `age_days=null` rows; never 5xxs.
- **`tests/test_license_pro_install_age_days_at_batch.py`** — 28 tests covering the helper (empty / non-iterable / no marker / active / negative pre-install / corrupt marker / missing `installed_at` / string-int / dedupe / bad tokens / mixed / marker-vs-import independence / never-raises), the endpoint (400 on missing/blank, per-row parity pinned against the scalar, dedupe, corrupt marker, `_pro_install_snapshot` blowup fallback), and cross-endpoint invariants (shared-snapshot fields agree with the scalar and `/api/license/pro-installed-at`).

House rules held: snake_case, deps unchanged (`cryptography` already available for the test key material used by sibling suites), new endpoint on `bp_entitlement` in `routes/`, no `dashboard.py` edits, no `__version__` bump, no frontend touched.

## Test plan

- [x] `python -m py_compile clawmetry/license.py routes/entitlement.py tests/test_license_pro_install_age_days_at_batch.py`
- [x] `python -m pytest tests/test_license_pro_install_age_days_at_batch.py` — 28 passed
- [x] Sibling tests still green: `test_license_is_expiring_at_batch.py`, `test_license_state_at_batch.py`, `test_license_pro_install_age_days_at_scalar.py` — 102 passed total

## Local operator verification checklist

Since I cannot reach the operator's machine, running daemon, `~/.openclaw`, live cloud snapshot, or the private `clawmetry-cloud` repo from this remote session, please after review:

1. **Sync the code into the running site-packages**
   ```bash
   cp clawmetry/license.py ~/.clawmetry/lib/python*/site-packages/clawmetry/
   cp routes/entitlement.py ~/.clawmetry/lib/python*/site-packages/routes/
   find ~/.clawmetry/lib/python*/site-packages/{clawmetry,routes} -name __pycache__ -exec rm -rf {} +
   ```
2. **Kickstart the daemon so it re-imports** — `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` (or the equivalent on Linux)
3. **Hit the new endpoint and confirm the shape** —
   ```bash
   curl -s "http://localhost:8900/api/license/pro-install-age-days-at-batch?epochs=1700000000,1800000000,now" | jq
   curl -s "http://localhost:8900/api/license/pro-install-age-days-at-batch" | jq   # -> 400 missing epochs
   ```
4. **Zip against the license-iat-age batch (PR #4213, once merged)** — rows should line up index-for-index by epoch so a UI can render "N days since provisioning, M days since license issue" from two GETs:
   ```bash
   curl -s "http://localhost:8900/api/license/pro-install-age-days-at-batch?epochs=,,," | jq '.rows'
   curl -s "http://localhost:8900/api/license/age-days-at-batch?epochs=,,,"           | jq '.rows'
   ```
5. **Shared-snapshot cross-check** — confirm `installed_at` / `marker_present` / `installed` match across the batch, the singular, and `/api/license/pro-installed-at`:
   ```bash
   curl -s "http://localhost:8900/api/license/pro-install-age-days-at-batch?epochs=$(date +%s)" | jq '{installed_at, marker_present, installed}'
   curl -s "http://localhost:8900/api/license/pro-install-age-days-at?epoch=$(date +%s)"        | jq '{installed_at, marker_present, installed}'
   curl -s "http://localhost:8900/api/license/pro-installed-at"                                 | jq '{installed_at, marker_present, installed}'
   ```
6. **Decrypt the live cloud snapshot in the browser** — no schema change here, but confirm the dashboard still renders (nothing binds the new endpoint yet).
7. **Green CI, then flip DRAFT → ready-for-review**, then release-on-merge picks it up per FLYWHEEL.md.

This PR stays in GRACE mode (no behavior change to any existing gate) — it only adds an additive read-only endpoint + helper.

---
_Generated by [Claude Code](https://claude.ai/code/session_01P5zmbfggb4DGC5rC7hU9gu)_