### PR TITLE
fix(c6): schedule-heal detects required checks in Rulesets API (fixes false-negative failures)

### DIFF
--- a/.github/workflows/c6-schedule-heal.yml
+++ b/.github/workflows/c6-schedule-heal.yml
@@ -129,6 +129,44 @@ try:
 except Exception:
     print('[]')
 " || echo "[]")
+            # Also gather checks from the Rulesets API.
+            # c6-apply-ruleset.yml enforces required checks via the Rulesets API
+            # when GITHUB_TOKEN has ruleset-write rights, bypassing the admin-PAT
+            # requirement of classic branch protection. Union both sources so a
+            # check configured via EITHER path counts as present.
+            _RULESET_CHECKS=$(_CURR_REPO="${REPO}" python3 - 2>/dev/null <<"RSPY"
+import json, os, subprocess
+OWNER = os.environ.get('OWNER', 'vivekchand')
+REPO  = os.environ.get('_CURR_REPO', 'clawmetry')
+ctx   = set()
+hdrs  = ['--header', 'Accept: application/vnd.github+json']
+try:
+    r = subprocess.run(['gh', 'api', f'/repos/{OWNER}/{REPO}/rulesets'] + hdrs,
+                       capture_output=True, text=True, timeout=15)
+    if r.returncode == 0:
+        for rs in json.loads(r.stdout):
+            if rs.get('enforcement') == 'active':
+                r2 = subprocess.run(
+                    ['gh', 'api', f"/repos/{OWNER}/{REPO}/rulesets/{rs['id']}"] + hdrs,
+                    capture_output=True, text=True, timeout=15)
+                if r2.returncode == 0:
+                    detail = json.loads(r2.stdout)
+                    for rule in (detail.get('rules') or []):
+                        if rule.get('type') == 'required_status_checks':
+                            for c in (rule.get('parameters', {})
+                                       .get('required_status_checks') or []):
+                                if c.get('context'):
+                                    ctx.add(c['context'])
+except Exception:
+    pass
+print(json.dumps(sorted(ctx)))
+RSPY
+)
+            PROTECTION=$(python3 -c "
+import json, sys
+a = json.loads(sys.argv[1]); b = json.loads(sys.argv[2])
+print(json.dumps(sorted(set(a) | set(b))))
+" "$PROTECTION" "${_RULESET_CHECKS:-[]}" 2>/dev/null || echo "$PROTECTION")
             IFS='|' read -ra EXPECTED_CHECKS <<< "${EXPECTED[$REPO]}"
             for CHECK in "${EXPECTED_CHECKS[@]}"; do
               if echo "$PROTECTION" | python3 -c \


### PR DESCRIPTION
## What

`c6-schedule-heal.yml` was only reading **classic branch protection** to detect whether `E2E Gate (required)` was configured on `clawmetry/main`. It produced a false negative (ALL_OK=false) whenever the required checks were configured via the **GitHub Rulesets API** instead — which is exactly what `c6-apply-ruleset.yml` does on every push to main.

This caused `c6-schedule-heal.yml` to perpetually exit 1 even when `c6-apply-ruleset.yml` had successfully created the ruleset, generating red noise in the actions tab.

## Fix

After reading classic branch protection, also query `/repos/{owner}/{repo}/rulesets` for any active ruleset with a `required_status_checks` rule. The **union** of classic + ruleset contexts is used for the membership test:

- Check configured via classic BP only: detected
- Check configured via rulesets only (c6-apply-ruleset.yml path): detected
- Neither: ALL_OK=false and ::error:: fires as before (correct)
- /rulesets returns 403 or empty: falls through to classic-only result (no regression)

## Why this matters

`c6-apply-ruleset.yml` was correctly applying the ruleset and exiting 0, while `c6-schedule-heal.yml` kept failing on the next scheduled run because it couldn't see rulesets. Fixing detection makes the schedule self-consistent with the apply workflow.

The `::error::` + exit 1 path when checks genuinely aren't configured is preserved.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XueUARhdMN9xFeFmEsgw52)_