### PR TITLE
feat(license): license_tier + license_expires_at scalar accessors + endpoints

### DIFF
--- a/clawmetry/license.py
+++ b/clawmetry/license.py
@@ -981,3 +981,93 @@ def current_license_info() -> dict | None:
     except Exception as exc:
         logger.warning("license: info read failed: %s", exc)
         return None
+
+
+def license_tier() -> str | None:
+    """Scalar accessor for the ``tier`` claim on the installed license.
+
+    Thin wrapper over :func:`current_license_info` for callers (a status
+    tile, a CLI ``clawmetry status`` row, a fleet-node column) that only
+    need the tier string and don't want to unpack the full envelope.
+
+    Returns the normalised tier string (lower-cased, whitespace-stripped)
+    on a signature-valid, non-expired license. Returns ``None`` in every
+    other branch:
+
+      * no license file on disk (OSS free)
+      * file exists but signature is bogus (``info["valid"] is False``
+        AND ``info["tier"] is None`` -- we never surface tier from an
+        unsigned body)
+      * signed-but-lapsed key (``info["valid"] is False`` -- the ``tier``
+        claim is still readable but the license no longer grants
+        entitlement, so a gate binding this helper cannot silently keep
+        rendering "Pro" on an expired key)
+      * any per-row failure inside :func:`current_license_info`
+
+    Never raises -- matches the ``never surface a paid tier we can't
+    trust`` posture of the surrounding license helpers.
+    """
+    try:
+        info = current_license_info()
+    except Exception as exc:
+        logger.debug("license: license_tier underlying read failed: %s", exc)
+        return None
+    if not isinstance(info, dict):
+        return None
+    if not info.get("valid"):
+        return None
+    tier = info.get("tier")
+    if not isinstance(tier, str):
+        return None
+    tier = tier.strip().lower()
+    return tier or None
+
+
+def license_expires_at() -> int | None:
+    """Scalar accessor for the ``exp`` claim on the installed license.
+
+    Thin wrapper over :func:`current_license_info` for callers (a renewal
+    banner, a "Pro expires <date>" chip, an operator-audit tile) that
+    only need the raw expiry epoch and don't want to unpack the full
+    envelope OR re-derive ``days_left`` from ``exp`` themselves.
+
+    Returns the ``exp`` claim as an ``int`` (Unix epoch seconds) on any
+    signature-valid license file -- INCLUDING signed-but-lapsed keys, so
+    a support tile can render "expired on <date>" without falling back to
+    :func:`current_license_info` just for that one field. Returns
+    ``None`` in every other branch:
+
+      * no license file on disk (OSS free)
+      * file exists but signature is bogus (``exp`` collapses to
+        ``None`` in :func:`current_license_info` -- we never trust an
+        unsigned body's ``exp``)
+      * perpetual license (payload has no ``exp`` claim -- the license
+        never expires and there is no epoch to return)
+      * non-numeric ``exp`` claim (defensively coerced to ``None`` rather
+        than surfacing a bogus datetime)
+      * any per-row failure inside :func:`current_license_info`
+
+    Deliberately lenient on expiry, matching the ``current_license_info``
+    posture: a signed-but-lapsed key still carries a meaningful ``exp``
+    that a support/audit tile needs. Callers wanting to hide the row on
+    lapsed keys should independently check :func:`license_tier` (which
+    returns ``None`` on lapsed keys) or ``current_license_info()["valid"]``.
+    """
+    try:
+        info = current_license_info()
+    except Exception as exc:
+        logger.debug("license: license_expires_at underlying read failed: %s", exc)
+        return None
+    if not isinstance(info, dict):
+        return None
+    exp = info.get("exp")
+    if isinstance(exp, bool):  # bool is a subclass of int -- refuse it
+        return None
+    if isinstance(exp, int):
+        return exp
+    if isinstance(exp, float):
+        try:
+            return int(exp)
+        except (TypeError, ValueError, OverflowError):
+            return None
+    return None

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -7123,6 +7123,118 @@ def api_license_pubkey():
         )
 
 
+@bp_entitlement.route("/api/license/tier")
+def api_license_tier():
+    """``GET /api/license/tier`` -- scalar accessor for the ``tier`` claim
+    on the currently-installed license, so a status tile / fleet-node
+    column that only needs the tier string doesn't have to unpack the
+    full ``/api/license/status`` envelope (or worse, re-implement the
+    "don't trust an unsigned body" rule client-side).
+
+    Wraps :func:`clawmetry.license.license_tier`.
+
+    Response shape (always HTTP 200)::
+
+        {
+          "tier":        "<pro|enterprise|starter|...>" | null,
+          "has_license": <bool>,   # a license file is on disk (regardless of validity)
+          "valid":       <bool>    # signature-valid AND not expired NOW
+        }
+
+    ``tier`` is ``null`` on OSS-free installs, invalid-signature files
+    (we never surface tier from an unsigned body), and signed-but-lapsed
+    keys (so a gate binding this endpoint cannot silently keep rendering
+    "Pro" on an expired key). Callers wanting to render "was Pro,
+    expired" copy should read ``valid`` alongside ``has_license`` and
+    hit ``/api/license/status`` for the full envelope.
+
+    Never 5xxs -- any underlying failure degrades to the OSS-free branch
+    shape (``tier=null``, ``has_license=false``, ``valid=false``),
+    matching the never-crash posture of the surrounding license
+    endpoints.
+    """
+    try:
+        from clawmetry import license as _lic
+
+        tier = _lic.license_tier()
+        try:
+            info = _lic.current_license_info()
+        except Exception as exc:
+            logger.debug("api_license_tier: info read failed: %s", exc)
+            info = None
+        has_license = isinstance(info, dict)
+        valid = bool(has_license and info.get("valid"))
+        return jsonify(
+            {
+                "tier": tier,
+                "has_license": has_license,
+                "valid": valid,
+            }
+        )
+    except Exception as exc:
+        logger.warning("api_license_tier: error: %s", exc)
+        return jsonify({"tier": None, "has_license": False, "valid": False})
+
+
+@bp_entitlement.route("/api/license/expires-at")
+def api_license_expires_at():
+    """``GET /api/license/expires-at`` -- scalar accessor for the ``exp``
+    claim on the currently-installed license, so a renewal banner /
+    "Pro expires <date>" chip / operator-audit tile that only needs the
+    raw expiry epoch doesn't have to unpack the full
+    ``/api/license/status`` envelope.
+
+    Wraps :func:`clawmetry.license.license_expires_at`.
+
+    Response shape (always HTTP 200)::
+
+        {
+          "expires_at":  <int> | null,   # Unix epoch seconds
+          "has_license": <bool>,         # a license file is on disk
+          "valid":       <bool>          # signature-valid AND not expired NOW
+        }
+
+    ``expires_at`` is ``null`` on OSS-free installs, invalid-signature
+    files (we never trust an unsigned body's ``exp``), perpetual keys
+    (payload has no ``exp`` -- the license never expires), and any non-
+    numeric ``exp`` claim.
+
+    Deliberately lenient on expiry, matching
+    :func:`clawmetry.license.license_expires_at`: a signed-but-lapsed
+    key still surfaces its ``exp`` so a support tile can render
+    "expired on <date>" without a second call to
+    ``/api/license/status``. The ``valid`` field independently carries
+    the "signature-valid AND not expired NOW" signal for callers that
+    DO want to hide the row on lapsed keys.
+
+    Never 5xxs -- any underlying failure degrades to the OSS-free branch
+    shape (``expires_at=null``, ``has_license=false``, ``valid=false``),
+    matching the never-crash posture of the surrounding license
+    endpoints.
+    """
+    try:
+        from clawmetry import license as _lic
+
+        exp = _lic.license_expires_at()
+        try:
+            info = _lic.current_license_info()
+        except Exception as exc:
+            logger.debug("api_license_expires_at: info read failed: %s", exc)
+            info = None
+        has_license = isinstance(info, dict)
+        valid = bool(has_license and info.get("valid"))
+        return jsonify(
+            {
+                "expires_at": exp,
+                "has_license": has_license,
+                "valid": valid,
+            }
+        )
+    except Exception as exc:
+        logger.warning("api_license_expires_at: error: %s", exc)
+        return jsonify({"expires_at": None, "has_license": False, "valid": False})
+
+
 @bp_entitlement.route("/api/paywall/event", methods=["POST"])
 def api_paywall_event():
     body: dict = {}

--- a/tests/test_license_scalar_accessors.py
+++ b/tests/test_license_scalar_accessors.py
@@ -1,0 +1,371 @@
+"""Tests for the two ``clawmetry.license`` scalar accessors
+(:func:`license_tier`, :func:`license_expires_at`) and their paired
+``/api/license/tier`` / ``/api/license/expires-at`` HTTP endpoints.
+
+Thin scalar-accessor flavour of :func:`current_license_info` -- for a
+status tile / fleet-node column that only needs the tier string or the
+raw expiry epoch, so it doesn't have to unpack the full envelope OR
+re-implement the "don't trust an unsigned body" rule client-side.
+
+Hermetic: each test mints tokens with its own ephemeral keypair and
+monkeypatches the module's embedded public key + ``LICENSE_PATH``,
+mirroring ``tests/test_license.py`` so nothing depends on the real
+production signing key or on real filesystem state. No network calls;
+``CLAWMETRY_OFFLINE=1`` and the ``clawmetry activate`` phone-home is
+opted out.
+"""
+from __future__ import annotations
+
+import time
+from types import SimpleNamespace
+
+import pytest
+from flask import Flask
+
+
+# -- shared helpers (mirror tests/test_license.py) ---------------------------
+
+
+def _keypair():
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+    priv = Ed25519PrivateKey.generate()
+    pub_pem = priv.public_key().public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    return priv, pub_pem
+
+
+def _payload(tier="pro", nodes=3, exp_delta=365 * 86400, drop_exp=False):
+    now = int(time.time())
+    p = {
+        "sub": "acct_test",
+        "tier": tier,
+        "nodes": nodes,
+        "iat": now,
+        "exp": now + exp_delta,
+        "features": ["runtimes"],
+    }
+    if drop_exp:
+        p.pop("exp", None)
+    return p
+
+
+@pytest.fixture
+def lic(monkeypatch, tmp_path):
+    import clawmetry.license as _lic
+
+    priv, pub_pem = _keypair()
+    monkeypatch.setattr(_lic, "_PUBLIC_KEY_PEM", pub_pem)
+    license_path = str(tmp_path / "license.key")
+    monkeypatch.setattr(_lic, "LICENSE_PATH", license_path)
+    monkeypatch.setattr(_lic, "_CONFIG_PATH", str(tmp_path / "config.json"))
+    monkeypatch.delenv("CLAWMETRY_LICENSE_SERVER", raising=False)
+    monkeypatch.delenv("CLAWMETRY_INGEST_URL", raising=False)
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("CLAWMETRY_OFFLINE", "1")
+    return SimpleNamespace(lic=_lic, priv=priv, license_path=license_path)
+
+
+@pytest.fixture
+def client(lic):
+    """Flask test client with only ``bp_entitlement`` registered."""
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    app.config["TESTING"] = True
+    return app.test_client()
+
+
+def _write_key_direct(lic, exp_delta, tier="pro"):
+    """Bypass ``activate()`` (which refuses expired tokens) and write a token
+    directly to the license file. Simulates a license that expired AFTER it
+    was installed."""
+    import os
+
+    tok = lic.lic._encode_token(_payload(tier=tier, exp_delta=exp_delta), lic.priv)
+    os.makedirs(os.path.dirname(lic.license_path), exist_ok=True)
+    with open(lic.license_path, "w", encoding="utf-8") as fh:
+        fh.write(tok)
+
+
+def _write_perpetual(lic, tier="enterprise"):
+    import os
+
+    tok = lic.lic._encode_token(_payload(tier=tier, drop_exp=True), lic.priv)
+    os.makedirs(os.path.dirname(lic.license_path), exist_ok=True)
+    with open(lic.license_path, "w", encoding="utf-8") as fh:
+        fh.write(tok)
+
+
+def _write_bogus(lic):
+    import os
+
+    os.makedirs(os.path.dirname(lic.license_path), exist_ok=True)
+    with open(lic.license_path, "w", encoding="utf-8") as fh:
+        fh.write("CLAW1.garbage.garbage")
+
+
+# -- clawmetry.license.license_tier() ----------------------------------------
+
+
+def test_license_tier_no_file_returns_none(lic):
+    """OSS-free install (no license file on disk) -> ``None``. Matches
+    the never-mis-gate posture of the surrounding helpers -- a paid tier
+    can never be silently claimed without a key."""
+    assert lic.lic.license_tier() is None
+
+
+def test_license_tier_active_key_returns_normalised_tier(lic):
+    """A signature-valid, non-expired key surfaces its tier claim
+    lower-cased and whitespace-stripped."""
+    tok = lic.lic._encode_token(_payload(tier="pro"), lic.priv)
+    lic.lic.activate(tok)
+    assert lic.lic.license_tier() == "pro"
+
+
+def test_license_tier_enterprise_key(lic):
+    """Alternate paid tier -- confirm the accessor doesn't hard-code
+    "pro"."""
+    tok = lic.lic._encode_token(_payload(tier="enterprise"), lic.priv)
+    lic.lic.activate(tok)
+    assert lic.lic.license_tier() == "enterprise"
+
+
+def test_license_tier_case_and_whitespace_normalised(lic):
+    """Server-side typos in casing / whitespace on the ``tier`` claim
+    normalise here, so gates comparing to lower-cased constants don't
+    silently miss."""
+    tok = lic.lic._encode_token(_payload(tier=" Pro "), lic.priv)
+    lic.lic.activate(tok)
+    assert lic.lic.license_tier() == "pro"
+
+
+def test_license_tier_expired_key_returns_none(lic):
+    """Signed-but-lapsed key -> ``None``. A gate binding this helper
+    cannot silently keep rendering "Pro" on an expired key -- the copy
+    that says "was Pro, expired" must go through ``current_license_info``
+    which surfaces ``valid=false`` alongside the ``tier`` claim."""
+    _write_key_direct(lic, exp_delta=-5 * 86400, tier="pro")
+    assert lic.lic.license_tier() is None
+
+
+def test_license_tier_invalid_signature_returns_none(lic):
+    """Bogus-signature file -> ``None``. We never surface a tier claim
+    from an unsigned body: an attacker who could edit the payload could
+    otherwise claim any tier."""
+    _write_bogus(lic)
+    assert lic.lic.license_tier() is None
+
+
+def test_license_tier_perpetual_key_returns_tier(lic):
+    """Perpetual (no ``exp``) key -> the tier claim still surfaces (the
+    key is signature-valid and never expires)."""
+    _write_perpetual(lic, tier="enterprise")
+    assert lic.lic.license_tier() == "enterprise"
+
+
+def test_license_tier_never_raises_on_underlying_failure(monkeypatch):
+    """Any per-row failure of :func:`current_license_info` -> ``None``.
+    The helper never propagates -- matches the never-crash posture of
+    the surrounding license helpers."""
+    import clawmetry.license as _lic
+
+    def _boom():
+        raise RuntimeError("simulated corrupt install")
+
+    monkeypatch.setattr(_lic, "current_license_info", _boom)
+    assert _lic.license_tier() is None
+
+
+# -- clawmetry.license.license_expires_at() ----------------------------------
+
+
+def test_license_expires_at_no_file_returns_none(lic):
+    """OSS-free install -> ``None``."""
+    assert lic.lic.license_expires_at() is None
+
+
+def test_license_expires_at_active_key_returns_exp(lic):
+    """Signature-valid key -> the ``exp`` claim as an ``int`` (Unix
+    epoch seconds)."""
+    tok = lic.lic._encode_token(_payload(exp_delta=30 * 86400), lic.priv)
+    lic.lic.activate(tok)
+    exp = lic.lic.license_expires_at()
+    assert isinstance(exp, int)
+    now = int(time.time())
+    # Bounded by the exp_delta above (30 days), so must be in the
+    # (now, now + 31d] window -- doesn't rely on wall-clock stability.
+    assert now < exp <= now + 31 * 86400
+
+
+def test_license_expires_at_perpetual_key_returns_none(lic):
+    """Perpetual (no ``exp``) key -> ``None``. There is no epoch to
+    return -- a renewal banner binding this endpoint must render "never
+    expires" copy instead."""
+    _write_perpetual(lic)
+    assert lic.lic.license_expires_at() is None
+
+
+def test_license_expires_at_lapsed_key_still_returns_exp(lic):
+    """Deliberately lenient on expiry (matches the ``current_license_info``
+    posture): a signed-but-lapsed key still surfaces its ``exp`` so a
+    support tile can render "expired on <date>" without a second call to
+    :func:`current_license_info`. Callers wanting to hide the row must
+    independently check :func:`license_tier` (which returns ``None`` on
+    lapsed keys)."""
+    _write_key_direct(lic, exp_delta=-5 * 86400)
+    exp = lic.lic.license_expires_at()
+    assert isinstance(exp, int)
+    now = int(time.time())
+    assert exp <= now  # already past
+
+
+def test_license_expires_at_invalid_signature_returns_none(lic):
+    """Bogus-signature file -> ``None``. We never trust an unsigned
+    body's ``exp`` -- a forger who could edit the payload could claim
+    a bogus expiry."""
+    _write_bogus(lic)
+    assert lic.lic.license_expires_at() is None
+
+
+def test_license_expires_at_never_raises_on_underlying_failure(monkeypatch):
+    """Any per-row failure of :func:`current_license_info` -> ``None``.
+    Never propagates."""
+    import clawmetry.license as _lic
+
+    def _boom():
+        raise RuntimeError("simulated corrupt install")
+
+    monkeypatch.setattr(_lic, "current_license_info", _boom)
+    assert _lic.license_expires_at() is None
+
+
+# -- /api/license/tier -------------------------------------------------------
+
+
+def test_api_license_tier_no_file(client, lic):
+    """OSS-free install -> ``{"tier": null, "has_license": false, "valid":
+    false}``. HTTP 200 -- the endpoint never 5xxs on a missing file."""
+    resp = client.get("/api/license/tier")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body == {"tier": None, "has_license": False, "valid": False}
+
+
+def test_api_license_tier_active_key(client, lic):
+    """Active key -> tier surfaces AND ``valid`` is ``True``."""
+    tok = lic.lic._encode_token(_payload(tier="pro"), lic.priv)
+    lic.lic.activate(tok)
+    resp = client.get("/api/license/tier")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["tier"] == "pro"
+    assert body["has_license"] is True
+    assert body["valid"] is True
+
+
+def test_api_license_tier_expired_key(client, lic):
+    """Signed-but-lapsed key -> ``tier`` is ``null`` (matches
+    :func:`license_tier`) AND ``valid`` is ``False`` AND
+    ``has_license`` is ``True`` -- the trio lets a UI render "was Pro,
+    expired" copy without falling back to ``/api/license/status``."""
+    _write_key_direct(lic, exp_delta=-5 * 86400, tier="pro")
+    resp = client.get("/api/license/tier")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body == {"tier": None, "has_license": True, "valid": False}
+
+
+def test_api_license_tier_invalid_signature(client, lic):
+    """Bogus-signature file -> ``tier=null``, ``valid=false``, but
+    ``has_license=true`` -- the file exists, we just don't trust its
+    payload."""
+    _write_bogus(lic)
+    resp = client.get("/api/license/tier")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body == {"tier": None, "has_license": True, "valid": False}
+
+
+def test_api_license_tier_agrees_with_helper(client, lic):
+    """Per-response parity with :func:`license_tier` -- the HTTP shape
+    layers ``has_license`` / ``valid`` on top of the scalar, but ``tier``
+    itself must byte-equal the underlying helper."""
+    tok = lic.lic._encode_token(_payload(tier="enterprise"), lic.priv)
+    lic.lic.activate(tok)
+    resp = client.get("/api/license/tier")
+    assert resp.get_json()["tier"] == lic.lic.license_tier()
+
+
+# -- /api/license/expires-at -------------------------------------------------
+
+
+def test_api_license_expires_at_no_file(client, lic):
+    """OSS-free install -> neutral envelope."""
+    resp = client.get("/api/license/expires-at")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body == {"expires_at": None, "has_license": False, "valid": False}
+
+
+def test_api_license_expires_at_active_key(client, lic):
+    """Active key -> ``expires_at`` surfaces AND ``valid`` is ``True``."""
+    tok = lic.lic._encode_token(_payload(exp_delta=60 * 86400), lic.priv)
+    lic.lic.activate(tok)
+    resp = client.get("/api/license/expires-at")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    now = int(time.time())
+    assert isinstance(body["expires_at"], int)
+    assert now < body["expires_at"] <= now + 61 * 86400
+    assert body["has_license"] is True
+    assert body["valid"] is True
+
+
+def test_api_license_expires_at_perpetual(client, lic):
+    """Perpetual key -> ``expires_at=null``, ``valid=true``,
+    ``has_license=true`` -- a renewal banner binding this endpoint
+    should render "never expires" copy on this shape."""
+    _write_perpetual(lic)
+    resp = client.get("/api/license/expires-at")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body == {"expires_at": None, "has_license": True, "valid": True}
+
+
+def test_api_license_expires_at_lapsed_key(client, lic):
+    """Signed-but-lapsed key -> ``expires_at`` still surfaces (matches
+    :func:`license_expires_at`) AND ``valid`` is ``False`` -- a support
+    tile can render "expired on <date>" off this one shape."""
+    _write_key_direct(lic, exp_delta=-5 * 86400)
+    resp = client.get("/api/license/expires-at")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    now = int(time.time())
+    assert isinstance(body["expires_at"], int) and body["expires_at"] <= now
+    assert body["has_license"] is True
+    assert body["valid"] is False
+
+
+def test_api_license_expires_at_invalid_signature(client, lic):
+    """Bogus-signature file -> ``expires_at=null`` (we never trust an
+    unsigned body's ``exp``)."""
+    _write_bogus(lic)
+    resp = client.get("/api/license/expires-at")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body == {"expires_at": None, "has_license": True, "valid": False}
+
+
+def test_api_license_expires_at_agrees_with_helper(client, lic):
+    """Per-response parity with :func:`license_expires_at` -- the HTTP
+    shape layers ``has_license`` / ``valid`` on top of the scalar, but
+    ``expires_at`` itself must byte-equal the underlying helper."""
+    tok = lic.lic._encode_token(_payload(exp_delta=90 * 86400), lic.priv)
+    lic.lic.activate(tok)
+    resp = client.get("/api/license/expires-at")
+    assert resp.get_json()["expires_at"] == lic.lic.license_expires_at()


### PR DESCRIPTION
## Summary

Two thin scalar accessors over `current_license_info()` for callers (a status tile, a fleet-node column, a renewal banner, a CLI `clawmetry status` row) that only need one field and don't want to unpack the full envelope — or re-implement the "never surface a tier from an unsigned body" rule client-side.

- `clawmetry.license.license_tier() -> str | None` — normalised (lower/strip) `tier` claim on a signature-valid, non-expired license; `None` on OSS free, invalid-signature files (we never trust an unsigned body's `tier`), and signed-but-lapsed keys (a gate binding this cannot silently keep rendering "Pro" on an expired key).
- `clawmetry.license.license_expires_at() -> int | None` — the `exp` claim on any signature-valid license, **including signed-but-lapsed keys** so a support tile can render "expired on `<date>`" off the scalar; `None` for OSS free, invalid-signature, perpetual (no `exp`) keys, and non-numeric `exp`.

Paired HTTP endpoints on `bp_entitlement`:

- `GET /api/license/tier`       → `{tier, has_license, valid}`
- `GET /api/license/expires-at` → `{expires_at, has_license, valid}`

Both layer `has_license` + `valid` on top of the scalar so a UI binding either one can render "was Pro, expired" copy without a second call to `/api/license/status`.

Ships in **GRACE** — no behaviour change to any existing gate; purely additive scalar accessors on top of the existing signed-license read path. Never 5xxs: any underlying failure degrades to the OSS-free branch shape.

## Test plan

- [x] `python3 -m pytest tests/test_license_scalar_accessors.py` — 25/25 passing (hermetic; mints ephemeral Ed25519 keys per test, monkeypatches `_PUBLIC_KEY_PEM` + `LICENSE_PATH`, `CLAWMETRY_OFFLINE=1` — no network)
- [x] `python3 -m pytest tests/test_license.py` — 53/53 still passing (no regression on the surrounding license helpers)
- [x] `ruff check clawmetry/license.py routes/entitlement.py tests/test_license_scalar_accessors.py` — clean
- [x] `python3 -m py_compile clawmetry/license.py routes/entitlement.py tests/test_license_scalar_accessors.py` — clean

Per-response parity with the underlying scalar is pinned for both endpoints so the HTTP shape cannot silently drift from the Python helper.

## Local operator verification checklist

The automation agent has no access to your host, running daemon, `~/.openclaw`, live cloud snapshot, or a browser — so these steps have to happen on your machine before flipping the PR to ready-for-review or merging:

- [ ] Copy the three changed files into the running site-packages:
      `cp clawmetry/license.py ~/.clawmetry/lib/python3.11/site-packages/clawmetry/`
      `cp routes/entitlement.py ~/.clawmetry/lib/python3.11/site-packages/routes/`
- [ ] Clear `__pycache__` under both: `find ~/.clawmetry/lib -name __pycache__ -exec rm -rf {} +`
- [ ] Kick the daemon: `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
- [ ] Hit the new endpoints locally on a machine WITHOUT a license key installed:
      `curl -sS http://localhost:8900/api/license/tier` → expect `{"tier": null, "has_license": false, "valid": false}`
      `curl -sS http://localhost:8900/api/license/expires-at` → expect `{"expires_at": null, "has_license": false, "valid": false}`
- [ ] If you have a signed test key handy, `clawmetry activate <KEY>` and re-hit both endpoints — expect the tier string + integer epoch back with `valid: true`.
- [ ] Decrypt the live cloud snapshot in the browser and confirm no rendering regressions on the license status tile (this PR doesn't touch the UI, but the paired endpoints share the `current_license_info` read path).

The PR is intentionally left DRAFT — no `__version__` bump, no `[RELEASE]` prefix, no tag. Once verified locally, flip to ready-for-review + squash-merge on your usual flywheel.

---
_Generated by [Claude Code](https://claude.ai/code/session_0135VWUw7pLhGqzJBHAYFGL7)_