### PR TITLE
feat(license): license_features() scalar accessor + /api/license/features endpoint

### DIFF
--- a/clawmetry/license.py
+++ b/clawmetry/license.py
@@ -2974,3 +2974,117 @@ def pro_install_age_days_at_batch(epochs) -> list[dict]:
             {"epoch": parsed, "age_days": int(age) if isinstance(age, int) else None}
         )
     return out
+
+
+def license_features() -> list[str] | None:
+    """Scalar accessor for the ``features`` claim on the installed license.
+
+    Thin scalar-shape helper for callers (an operator entitlement-diagnostic
+    tile, a "features unlocked by your key" chip row, a fleet-node column
+    that only needs the string list) that want the features list on its
+    own and don't want to unpack the full :func:`current_license_info`
+    envelope OR re-implement the "don't trust an unsigned body" rule
+    client-side.
+
+    Returns a sorted, deduplicated, normalised (lower-cased, whitespace-
+    stripped) ``list[str]`` of feature ids on a signature-valid,
+    non-expired license. Returns ``None`` in every other branch:
+
+      * no license file on disk (OSS free)
+      * file exists but signature is bogus (an attacker who could edit
+        the payload could otherwise smuggle any ``features`` list into
+        an unsigned body -- we never surface it)
+      * signed-but-lapsed key (a gate binding this helper cannot silently
+        keep granting features on an expired key)
+      * any per-row failure inside the underlying read path
+
+    An empty list (``[]``) means the license IS valid but its payload
+    carries no explicit ``features`` claim (or the claim is present but
+    holds no usable string ids). ``[]`` is deliberately DISTINCT from
+    ``None``:
+
+      * ``[]``   -> "valid license, zero features itemised on the token"
+                    (the tier still grants coverage; the license just
+                    doesn't spell out per-feature entitlement)
+      * ``None`` -> "no valid license at all"
+
+    A caller binding this scalar to a "features unlocked" UI must render
+    both branches -- ``None`` -> "no license", ``[]`` -> "no features
+    itemised" -- without collapsing them, or a valid-key-with-empty-list
+    user will silently get the same "unlicensed" copy as an OSS install.
+
+    Note: the ``features`` claim is a SUPPLEMENTAL string list carried
+    on the license token; it is NOT the canonical open-core feature
+    catalogue. For the resolved feature set actually enforced by gates,
+    callers should read :func:`clawmetry.entitlements.get_entitlement`
+    (which layers this claim on top of the FREE-tier baseline). This
+    scalar surfaces the claim exactly as written on the token, so
+    operator diagnostics can distinguish "gate says X is unlocked
+    because the key claims it" from "gate says X is unlocked because
+    the tier grants it by default".
+
+    Mirrors the "refuse expired keys" posture already used by
+    :func:`license_tier` / :func:`license_nodes`: a lapsed key must not
+    keep rendering as "features unlocked". A caller wanting to surface
+    the CLAIM even on an expired key (support: "what features was this
+    key SUPPOSED to grant?") should re-verify the token directly with
+    :func:`verify_token`.
+
+    Never raises. Any exception under the hood degrades to ``None`` so a
+    diagnostic tile bound to this helper never breaks on a partial or
+    corrupt install.
+    """
+    try:
+        info = current_license_info()
+    except Exception as exc:
+        logger.debug("license: license_features underlying read failed: %s", exc)
+        return None
+    if not isinstance(info, dict):
+        return None
+    if not info.get("valid"):
+        # Invalid-signature and signed-but-lapsed branches both collapse
+        # to None on purpose -- see docstring for the never-mis-gate
+        # rationale. Neither branch may surface a features list.
+        return None
+    # ``current_license_info`` does not surface the ``features`` claim in
+    # its envelope (kept intentionally narrow -- see its docstring), so
+    # re-open the license file and re-verify to pull the field. The
+    # ``valid`` gate above proves the file is on disk AND its signature
+    # verified once this call, so this second read cannot admit an
+    # unsigned body: any tamper between the two reads still fails
+    # ``verify_token``.
+    try:
+        if not os.path.isfile(LICENSE_PATH):
+            return None
+        with open(LICENSE_PATH, "r", encoding="utf-8") as fh:
+            payload = verify_token(fh.read().strip())
+    except Exception as exc:
+        logger.debug(
+            "license: license_features token re-read failed: %s", exc
+        )
+        return None
+    if not isinstance(payload, dict):
+        return None
+    raw = payload.get("features")
+    # A missing / non-list ``features`` claim collapses to the empty list
+    # (valid license, zero features itemised) -- distinct from ``None``
+    # which means no valid license at all. See docstring.
+    if not isinstance(raw, (list, tuple)):
+        return []
+    seen: set[str] = set()
+    out: list[str] = []
+    for item in raw:
+        if not isinstance(item, str):
+            # Ignore non-string entries defensively. An attacker who
+            # can't forge the signature also can't smuggle a non-string
+            # feature id past ``json.loads`` here, but a legit server-
+            # side typo (e.g. an integer feature id) shouldn't blow up
+            # the tile -- skip it and keep going.
+            continue
+        norm = item.strip().lower()
+        if not norm or norm in seen:
+            continue
+        seen.add(norm)
+        out.append(norm)
+    out.sort()
+    return out

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -8040,6 +8040,84 @@ def api_license_pubkey():
         )
 
 
+@bp_entitlement.route("/api/license/features")
+def api_license_features():
+    """``GET /api/license/features`` -- scalar accessor for the
+    ``features`` claim on the currently-installed license, so an
+    operator entitlement-diagnostic tile, a fleet-node column, or a
+    "features unlocked by your key" chip row can render off ONE cheap
+    endpoint without unpacking the full ``/api/license/status``
+    envelope (or re-implementing the "don't trust an unsigned body"
+    rule client-side).
+
+    Wraps :func:`clawmetry.license.license_features`.
+
+    Response shape (always HTTP 200)::
+
+        {
+          "features":    [<id>, ...] | null,
+          "has_license": <bool>,   # a license file is on disk
+          "valid":       <bool>    # signature-valid AND not expired NOW
+        }
+
+    ``features`` is:
+
+      * ``null``    on OSS-free installs, invalid-signature files, and
+                    signed-but-lapsed keys (a gate binding this endpoint
+                    cannot silently keep granting features on an expired
+                    key)
+      * ``[]``      when the license IS valid but its payload carries no
+                    explicit ``features`` claim -- distinct from ``null``
+                    which means no valid license at all
+      * a sorted, deduplicated, normalised (lower/strip) list of feature
+        ids on a signature-valid, non-expired license
+
+    ``has_license`` + ``valid`` are layered on top so a UI binding this
+    endpoint can distinguish "no key" (``has_license=false``) from
+    "valid key without a features list" (``valid=true, features=[]``)
+    from "expired key" (``has_license=true, valid=false,
+    features=null``) in one round-trip, without a second call to
+    ``/api/license/status``.
+
+    Note: the ``features`` claim is a SUPPLEMENTAL string list carried
+    on the license token; it is NOT the canonical open-core feature
+    catalogue. For the resolved feature set actually enforced by gates,
+    read ``/api/entitlement`` (which layers this claim on top of the
+    FREE-tier baseline). This endpoint surfaces the claim exactly as
+    written on the token, so operator diagnostics can distinguish
+    "feature X unlocked because the key claims it" from "feature X
+    unlocked because the tier grants it by default".
+
+    Never 5xxs -- any underlying failure degrades to the OSS-free
+    branch shape (``features=null``, ``has_license=false``,
+    ``valid=false``), matching the never-crash posture of the
+    surrounding license endpoints.
+    """
+    try:
+        from clawmetry import license as _lic
+
+        feats = _lic.license_features()
+        try:
+            info = _lic.current_license_info()
+        except Exception as exc:
+            logger.debug("api_license_features: info read failed: %s", exc)
+            info = None
+        has_license = isinstance(info, dict)
+        valid = bool(has_license and info.get("valid"))
+        return jsonify(
+            {
+                "features": feats,
+                "has_license": has_license,
+                "valid": valid,
+            }
+        )
+    except Exception as exc:
+        logger.warning("api_license_features: error: %s", exc)
+        return jsonify(
+            {"features": None, "has_license": False, "valid": False}
+        )
+
+
 def _license_expiry_snapshot() -> dict:
     """Shared helper: read once, derive the trio the two expiry endpoints
     both need (``days_left``, ``has_license``, ``expired``). Lives in the

--- a/tests/test_license_features_accessor.py
+++ b/tests/test_license_features_accessor.py
@@ -1,0 +1,384 @@
+"""Tests for the ``clawmetry.license.license_features`` scalar accessor
+and its paired ``GET /api/license/features`` HTTP endpoint.
+
+Thin scalar-accessor flavour of :func:`clawmetry.license.current_license_info`
+for callers (an operator entitlement-diagnostic tile, a fleet-node column,
+a "features unlocked by your key" chip row) that only need the ``features``
+claim as a list of strings and don't want to unpack the full envelope OR
+re-implement the "don't trust an unsigned body" rule client-side.
+
+Hermetic: each test mints tokens with its own ephemeral keypair and
+monkeypatches the module's embedded public key + ``LICENSE_PATH``,
+mirroring ``tests/test_license.py`` so nothing depends on the real
+production signing key or on real filesystem state. No network calls;
+``CLAWMETRY_OFFLINE=1`` opts out of the ``clawmetry activate``
+phone-home.
+"""
+from __future__ import annotations
+
+import os
+import time
+from types import SimpleNamespace
+
+import pytest
+from flask import Flask
+
+
+# -- shared helpers (mirror tests/test_license.py) ---------------------------
+
+
+def _keypair():
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+    priv = Ed25519PrivateKey.generate()
+    pub_pem = priv.public_key().public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    return priv, pub_pem
+
+
+def _payload(
+    tier="pro",
+    nodes=3,
+    exp_delta=365 * 86400,
+    features=("runtimes", "alerts", "fleet"),
+    drop_exp=False,
+    drop_features=False,
+    features_value=None,
+):
+    """Build a license payload with knobs for every branch under test.
+
+    ``drop_features``   -> omit the ``features`` claim entirely (missing).
+    ``features_value``  -> override the claim with an arbitrary value
+                           (used to exercise non-list / non-string
+                           branches). ``None`` = use ``features``.
+    """
+    now = int(time.time())
+    p = {
+        "sub": "acct_test",
+        "tier": tier,
+        "nodes": nodes,
+        "iat": now,
+        "exp": now + exp_delta,
+        "features": list(features),
+    }
+    if features_value is not None:
+        p["features"] = features_value
+    if drop_features:
+        p.pop("features", None)
+    if drop_exp:
+        p.pop("exp", None)
+    return p
+
+
+@pytest.fixture
+def lic(monkeypatch, tmp_path):
+    """Ephemeral keypair + isolated ``LICENSE_PATH`` per test."""
+    import clawmetry.license as _lic
+
+    priv, pub_pem = _keypair()
+    monkeypatch.setattr(_lic, "_PUBLIC_KEY_PEM", pub_pem)
+    license_path = str(tmp_path / "license.key")
+    monkeypatch.setattr(_lic, "LICENSE_PATH", license_path)
+    monkeypatch.setattr(_lic, "_CONFIG_PATH", str(tmp_path / "config.json"))
+    monkeypatch.delenv("CLAWMETRY_LICENSE_SERVER", raising=False)
+    monkeypatch.delenv("CLAWMETRY_INGEST_URL", raising=False)
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("CLAWMETRY_OFFLINE", "1")
+    return SimpleNamespace(lic=_lic, priv=priv, license_path=license_path)
+
+
+@pytest.fixture
+def client(lic):
+    """Flask test client with only ``bp_entitlement`` registered."""
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    app.config["TESTING"] = True
+    return app.test_client()
+
+
+def _write_direct(lic, payload):
+    """Bypass :func:`activate` (which refuses expired tokens and phones home)
+    and write a raw signed token to the license file. Lets a test build any
+    payload shape -- expired, perpetual, features-list variants -- without
+    round-tripping through the activation code path."""
+    tok = lic.lic._encode_token(payload, lic.priv)
+    os.makedirs(os.path.dirname(lic.license_path), exist_ok=True)
+    with open(lic.license_path, "w", encoding="utf-8") as fh:
+        fh.write(tok)
+
+
+def _write_bogus(lic):
+    """Write a syntactically-valid but signature-invalid token so the file
+    exists on disk but ``verify_token`` refuses it."""
+    os.makedirs(os.path.dirname(lic.license_path), exist_ok=True)
+    with open(lic.license_path, "w", encoding="utf-8") as fh:
+        fh.write("CLAW1.garbage.garbage")
+
+
+# -- clawmetry.license.license_features() ------------------------------------
+
+
+def test_license_features_no_file_returns_none(lic):
+    """OSS-free install (no license file on disk) -> ``None``. Matches
+    the never-mis-gate posture of the surrounding license helpers -- a
+    paid feature can never be silently claimed without a key."""
+    assert lic.lic.license_features() is None
+
+
+def test_license_features_active_key_returns_sorted_list(lic):
+    """A signature-valid, non-expired key surfaces its ``features``
+    claim as a sorted, deduplicated, normalised list of strings."""
+    _write_direct(lic, _payload(features=("runtimes", "alerts", "fleet")))
+    assert lic.lic.license_features() == ["alerts", "fleet", "runtimes"]
+
+
+def test_license_features_normalises_case_and_whitespace(lic):
+    """Server-side typos in casing / whitespace on the feature ids
+    normalise here, so gates comparing to lower-cased constants don't
+    silently miss (``Alerts`` and `` alerts `` and ``ALERTS`` all
+    collapse to the same id)."""
+    _write_direct(
+        lic, _payload(features=(" Alerts ", "FLEET", "runtimes "))
+    )
+    assert lic.lic.license_features() == ["alerts", "fleet", "runtimes"]
+
+
+def test_license_features_dedupes_after_normalisation(lic):
+    """After case/whitespace normalisation, duplicate ids collapse. A
+    payload of ``["Alerts", "alerts", "ALERTS"]`` surfaces once."""
+    _write_direct(
+        lic, _payload(features=("Alerts", "alerts", "ALERTS", "fleet"))
+    )
+    assert lic.lic.license_features() == ["alerts", "fleet"]
+
+
+def test_license_features_missing_claim_returns_empty_list(lic):
+    """A signature-valid license with NO ``features`` claim surfaces
+    ``[]`` (valid key, zero features itemised) -- distinct from ``None``
+    (no valid license at all). Callers rendering "features unlocked"
+    must NOT collapse these two branches."""
+    _write_direct(lic, _payload(drop_features=True))
+    assert lic.lic.license_features() == []
+
+
+def test_license_features_non_list_claim_returns_empty_list(lic):
+    """Malformed ``features`` claim (non-list) -> ``[]``. Never crash on
+    bad server-side data: an operator diagnostic tile is more useful
+    surfacing "valid key, features list malformed" than 500-ing."""
+    _write_direct(lic, _payload(features_value="alerts,fleet"))
+    assert lic.lic.license_features() == []
+
+
+def test_license_features_empty_list_claim_returns_empty_list(lic):
+    """An explicit empty list on the token surfaces as ``[]``. This is
+    the same shape as a missing claim (both -> ``[]``) since a caller
+    can't act differently on the two branches anyway."""
+    _write_direct(lic, _payload(features=()))
+    assert lic.lic.license_features() == []
+
+
+def test_license_features_ignores_non_string_entries(lic):
+    """Non-string entries in the ``features`` list (integer, bool, dict,
+    None) are silently skipped rather than blowing up the tile.
+    Legit string entries alongside still surface."""
+    _write_direct(
+        lic,
+        _payload(features_value=["alerts", 42, None, {"k": "v"}, "fleet"]),
+    )
+    assert lic.lic.license_features() == ["alerts", "fleet"]
+
+
+def test_license_features_all_non_string_returns_empty_list(lic):
+    """A ``features`` list that holds only non-string entries collapses
+    to ``[]`` (nothing usable) -- NOT ``None`` (the license is still
+    signature-valid, we just can't surface any ids)."""
+    _write_direct(lic, _payload(features_value=[1, 2, 3, None, True]))
+    assert lic.lic.license_features() == []
+
+
+def test_license_features_ignores_blank_strings(lic):
+    """Blank / whitespace-only feature ids are dropped -- the sort
+    order doesn't get polluted with empty leading rows."""
+    _write_direct(lic, _payload(features=("", "   ", "alerts", "fleet")))
+    assert lic.lic.license_features() == ["alerts", "fleet"]
+
+
+def test_license_features_expired_key_returns_none(lic):
+    """Signed-but-lapsed key -> ``None``. A gate binding this helper
+    cannot silently keep granting features on an expired key. The copy
+    that says "was Pro, features expired" must go through
+    :func:`current_license_info` which surfaces ``valid=false`` alongside
+    the ``tier`` claim."""
+    _write_direct(lic, _payload(exp_delta=-5 * 86400))
+    assert lic.lic.license_features() is None
+
+
+def test_license_features_invalid_signature_returns_none(lic):
+    """Bogus-signature file -> ``None``. We never surface a features
+    list from an unsigned body: an attacker who could edit the payload
+    could otherwise smuggle any features into the list."""
+    _write_bogus(lic)
+    assert lic.lic.license_features() is None
+
+
+def test_license_features_perpetual_key_returns_list(lic):
+    """Perpetual (no ``exp``) key -> the ``features`` claim still
+    surfaces (the key is signature-valid and never expires)."""
+    _write_direct(
+        lic, _payload(drop_exp=True, features=("alerts", "runtimes"))
+    )
+    assert lic.lic.license_features() == ["alerts", "runtimes"]
+
+
+def test_license_features_never_raises_on_underlying_failure(monkeypatch):
+    """Any per-row failure of :func:`current_license_info` -> ``None``.
+    The helper never propagates -- matches the never-crash posture of
+    the surrounding license helpers."""
+    import clawmetry.license as _lic
+
+    def _boom():
+        raise RuntimeError("simulated corrupt install")
+
+    monkeypatch.setattr(_lic, "current_license_info", _boom)
+    assert _lic.license_features() is None
+
+
+def test_license_features_never_raises_on_token_reread_failure(lic, monkeypatch):
+    """A failure on the second read (``verify_token`` re-open after the
+    ``valid`` gate passes) still degrades to ``None`` rather than
+    propagating. Simulates a race where the file is deleted between the
+    two reads."""
+    _write_direct(lic, _payload())
+
+    # Force ``verify_token`` to blow up on the second read only. The
+    # first read (inside ``current_license_info``) uses ``verify_token``
+    # via the module import; we shadow it AFTER the ``valid`` gate has
+    # already been resolved on the fresh info dict.
+    real_info = lic.lic.current_license_info
+
+    def _stubbed_info():
+        info = real_info()
+        return info
+
+    monkeypatch.setattr(lic.lic, "current_license_info", _stubbed_info)
+
+    def _boom(_):
+        raise RuntimeError("simulated re-read race")
+
+    monkeypatch.setattr(lic.lic, "verify_token", _boom)
+    # The second read raises -> the helper returns None, doesn't
+    # propagate. A UI tile bound to this scalar keeps rendering.
+    assert lic.lic.license_features() is None
+
+
+# -- /api/license/features endpoint parity ----------------------------------
+
+
+def test_endpoint_no_license_returns_null_features_shape(lic, client):
+    """OSS-free install (no license) -> ``{features: null, has_license:
+    false, valid: false}``. Never 5xxs; the endpoint must always answer
+    with the standard three-field envelope so a UI binding can render
+    without special-casing HTTP status codes."""
+    resp = client.get("/api/license/features")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body == {"features": None, "has_license": False, "valid": False}
+
+
+def test_endpoint_active_key_returns_features_and_valid_true(lic, client):
+    """A signature-valid key -> ``features`` populated, ``has_license``
+    and ``valid`` both ``true``. Per-response parity with
+    :func:`clawmetry.license.license_features` is pinned so the HTTP
+    shape cannot silently drift from the Python helper."""
+    _write_direct(lic, _payload(features=("alerts", "fleet", "runtimes")))
+    resp = client.get("/api/license/features")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["features"] == ["alerts", "fleet", "runtimes"]
+    assert body["has_license"] is True
+    assert body["valid"] is True
+    # Endpoint MUST equal the underlying Python helper for the features
+    # slot -- this is the drift guard.
+    assert body["features"] == lic.lic.license_features()
+
+
+def test_endpoint_expired_key_features_null_valid_false(lic, client):
+    """Signed-but-lapsed key -> ``features=null`` (matching
+    :func:`license_features` refusing to surface features on lapsed
+    keys), but ``has_license=true`` and ``valid=false`` so a UI can
+    render "was Pro, expired" copy without a second call to
+    ``/api/license/status``."""
+    _write_direct(lic, _payload(exp_delta=-5 * 86400))
+    resp = client.get("/api/license/features")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["features"] is None
+    assert body["has_license"] is True
+    assert body["valid"] is False
+
+
+def test_endpoint_invalid_signature_features_null(lic, client):
+    """Bogus-signature file -> ``features=null``, ``has_license=true``
+    (the file IS on disk), ``valid=false`` (signature failed). Matches
+    the never-trust-an-unsigned-body posture of the underlying helper."""
+    _write_bogus(lic)
+    resp = client.get("/api/license/features")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["features"] is None
+    assert body["has_license"] is True
+    assert body["valid"] is False
+
+
+def test_endpoint_missing_features_claim_returns_empty_list(lic, client):
+    """A signature-valid license without a ``features`` claim ->
+    ``features=[]`` (distinct from ``null``), ``has_license=true``,
+    ``valid=true``. A UI binding must NOT collapse ``[]`` and ``null``:
+    the former is "no features itemised on a valid key", the latter is
+    "no valid key at all"."""
+    _write_direct(lic, _payload(drop_features=True))
+    resp = client.get("/api/license/features")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["features"] == []
+    assert body["has_license"] is True
+    assert body["valid"] is True
+
+
+def test_endpoint_perpetual_key_returns_features(lic, client):
+    """Perpetual (no ``exp``) key -> ``features`` populated,
+    ``valid=true``. The token never expires so the endpoint surfaces
+    its claim indefinitely."""
+    _write_direct(
+        lic, _payload(drop_exp=True, features=("alerts", "runtimes"))
+    )
+    resp = client.get("/api/license/features")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["features"] == ["alerts", "runtimes"]
+    assert body["has_license"] is True
+    assert body["valid"] is True
+
+
+def test_endpoint_never_5xxs_on_underlying_failure(lic, client, monkeypatch):
+    """Any exception under the hood -> HTTP 200 with the OSS-free
+    branch shape (``features=null``, ``has_license=false``,
+    ``valid=false``). The endpoint must never propagate a 500 -- a
+    diagnostic tile bound to it stays rendered even on a partially-
+    broken install."""
+    import clawmetry.license as _lic
+
+    def _boom():
+        raise RuntimeError("simulated corrupt install")
+
+    monkeypatch.setattr(_lic, "license_features", _boom)
+    monkeypatch.setattr(_lic, "current_license_info", _boom)
+    resp = client.get("/api/license/features")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body == {"features": None, "has_license": False, "valid": False}


### PR DESCRIPTION
## Summary

Thin scalar-accessor sibling to `license_tier()` / `license_expires_at()` (PR #4230, still in flight) for callers — an operator entitlement-diagnostic tile, a fleet-node column, a "features unlocked by your key" chip row — that only need the `features` claim as a list of strings and don't want to unpack the full `current_license_info` envelope or re-implement the "don't trust an unsigned body" rule client-side.

- `clawmetry.license.license_features() -> list[str] | None` — sorted, deduplicated, normalised (lower/strip) list of feature ids on a signature-valid, non-expired license. Returns `None` on OSS free, invalid-signature files (we never surface features from an unsigned body), and signed-but-lapsed keys (a gate binding this helper cannot silently keep granting features on an expired key).
- Empty list (`[]`) means "valid license, zero features itemised on the token" — **deliberately distinct** from `None` so a UI can render "no key" vs "valid key, no features listed" without collapsing the two branches into the same "unlicensed" copy.
- `GET /api/license/features` on `bp_entitlement` — paired HTTP endpoint returning `{features, has_license, valid}`. Always HTTP 200; degrades to the OSS-free branch shape on any underlying failure. Per-response parity with the Python helper is pinned in the test suite so the HTTP shape cannot silently drift from the scalar.

Note: the `features` claim is a **supplemental** string list carried on the license token — NOT the canonical open-core feature catalogue. For the resolved feature set actually enforced by gates, callers should keep reading `/api/entitlement` (which layers this claim on top of the FREE-tier baseline). This scalar surfaces the claim exactly as written on the token so operator diagnostics can distinguish "feature X unlocked because the key claims it" from "feature X unlocked because the tier grants it by default".

Ships in **GRACE** — no behaviour change to any existing gate; purely additive scalar accessor on top of the existing signed-license read path. No `__version__` bump, no `[RELEASE]` prefix, no tag. Never 5xxs: any underlying failure degrades to the OSS-free branch shape.

## Test plan

- [x] `python3 -m pytest tests/test_license_features_accessor.py` — 22/22 passing (hermetic; mints ephemeral Ed25519 keys per test, monkeypatches `_PUBLIC_KEY_PEM` + `LICENSE_PATH`, `CLAWMETRY_OFFLINE=1` — no network)
- [x] `python3 -m pytest tests/test_license.py` — 53/53 still passing (no regression on the surrounding license helpers)
- [x] `python3 -m pytest tests/test_entitlement_api.py tests/test_entitlement_api_fallback_shape.py` — 39/39 still passing (no regression on neighbour endpoints on `bp_entitlement`)
- [x] `ruff check clawmetry/license.py routes/entitlement.py tests/test_license_features_accessor.py` — clean
- [x] `python3 -m py_compile clawmetry/license.py routes/entitlement.py tests/test_license_features_accessor.py` — clean

Branches covered by the suite: no-file, active key, expired, invalid-signature, perpetual, missing-features-claim, non-list features, empty-list features, non-string entries (dropped), all-non-string (`[]`), blank strings (dropped), case+whitespace normalisation, dedup after normalisation, endpoint parity with the underlying scalar, and never-raises on `current_license_info` / `verify_token` re-read failure.

## Local operator verification checklist

The automation agent has no access to your host, the running daemon, `~/.openclaw`, the live cloud snapshot, or a browser — so these steps have to happen on your machine before flipping the PR to ready-for-review or merging:

- [ ] Copy the changed files into the running site-packages:
      `cp clawmetry/license.py ~/.clawmetry/lib/python3.11/site-packages/clawmetry/`
      `cp routes/entitlement.py ~/.clawmetry/lib/python3.11/site-packages/routes/`
- [ ] Clear `__pycache__` under both: `find ~/.clawmetry/lib -name __pycache__ -exec rm -rf {} +`
- [ ] Kick the daemon: `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
- [ ] Hit the new endpoint locally on a machine **without** a license key installed:
      `curl -sS http://localhost:8900/api/license/features` → expect `{"features": null, "has_license": false, "valid": false}`
- [ ] If you have a signed test key handy, `clawmetry activate <key>` and re-hit:
      `curl -sS http://localhost:8900/api/license/features` → expect a sorted `features` list back with `has_license: true, valid: true`
- [ ] Decrypt the live cloud snapshot in the browser and confirm no rendering regressions on the license status tile (this PR doesn't touch the UI, but the endpoint shares the `current_license_info` read path).

The PR is intentionally left **DRAFT** — no `__version__` bump, no `[RELEASE]` prefix, no tag. Once verified locally, flip to ready-for-review + squash-merge on your usual flywheel. If PR #4230 (the sibling `license_tier` / `license_expires_at` accessors) merges first this branch will need a rebase; the additions are purely additive-append so any conflict resolves cleanly.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GvJ4G1ezDDyijKsvPpdojH)_