### PR TITLE
feat(license): is_expiring_within_at_batch + /api/license/expiring-within-at-batch

### DIFF
--- a/clawmetry/license.py
+++ b/clawmetry/license.py
@@ -2767,6 +2767,94 @@ def is_expiring_at_batch(epochs) -> list[dict]:
     return out
 
 
+def is_expiring_within_at_batch(days: int, epochs) -> list[dict]:
+    """Per-value perspective-epoch "would we have shown a renewal warning
+    as of this epoch?" gate for N epochs in ONE round-trip.
+
+    Per-value axis batch sibling of :func:`is_expiring_within_at`. Fills
+    the ``_at_batch`` slot on the renewal-window axis alongside the
+    existing ``exp``-derived batches (:func:`is_expired_at_batch`,
+    :func:`is_expiring_at_batch`, :func:`days_until_expiry_at_batch`) so
+    a scheduled-audit tile that wants to render "would the renewal
+    banner have fired on each of these dates?" across a sequence of
+    perspective epochs hydrates the whole column in ONE call instead of
+    fanning out N calls to :func:`is_expiring_within_at`.
+
+    ``days`` is the renewal-window threshold. It is applied to EVERY
+    row -- callers wanting per-row thresholds should call the singular
+    scalar N times. The threshold is coerced through ``int()`` once at
+    the top of the call, matching the scalar helper. A ``bool`` /
+    non-numeric / negative ``days`` collapses to ``is_expiring_within=
+    False`` on every row (the scalar collapses to ``False`` on the same
+    inputs, so the batch cannot silently diverge from a full N-call
+    fan-out).
+
+    Row shape::
+
+        {
+          "epoch":                <int> | "<raw>",
+          "is_expiring_within":   <bool>,
+        }
+
+    Semantics per row mirror :func:`is_expiring_within_at`: ``True``
+    iff a license is installed, signature-valid, carries an ``exp``
+    claim, AND the days from ``epoch`` until ``exp`` fall between 0 and
+    ``days`` inclusive. An already-lapsed-at-epoch key returns
+    ``False`` on purpose -- the caller wants to distinguish "renewal
+    window" (warn) from "already expired at that time" (a different,
+    louder banner), and :func:`is_expired_at_batch` /
+    :func:`days_until_expiry_at_batch` independently carry those
+    signals index-for-index for callers that DO want to distinguish
+    them. Perpetual licenses (no ``exp`` claim) and the no-license path
+    both yield ``False`` on every row: nothing to warn about.
+
+    Row shape mirrors :func:`is_expired_at_batch` /
+    :func:`is_expiring_at_batch` per-row so a caller assembling a full
+    renewal timeline can zip the batches index-for-index.
+
+    Duplicates by normalised int key (or ``repr(raw)`` for bad inputs)
+    are dropped preserving first-seen order for byte-stable output.
+    ``epochs is None`` or non-iterable -- returns ``[]``. Never raises:
+    per-row failures short-circuit to ``is_expiring_within=False`` so
+    the batch keeps building. Matches the never-mis-gate posture used
+    by :func:`is_expiring_within_at` -- a bad row cannot silently fire
+    a renewal prompt.
+    """
+    if isinstance(days, bool):
+        threshold_ok = False
+        threshold = 0
+    else:
+        try:
+            threshold = int(days)
+            threshold_ok = threshold >= 0
+        except (TypeError, ValueError):
+            threshold = 0
+            threshold_ok = False
+    out: list[dict] = []
+    for raw, _key, parsed in _license_epoch_batch_keys(epochs):
+        if parsed is None:
+            try:
+                token = str(raw)
+            except Exception:
+                token = repr(raw)
+            out.append({"epoch": token, "is_expiring_within": False})
+            continue
+        if not threshold_ok:
+            out.append({"epoch": parsed, "is_expiring_within": False})
+            continue
+        try:
+            matched = is_expiring_within_at(threshold, parsed)
+        except Exception as exc:
+            logger.debug(
+                "license: is_expiring_within_at_batch per-row failed: %s", exc
+            )
+            matched = False
+        out.append(
+            {"epoch": parsed, "is_expiring_within": bool(matched)}
+        )
+    return out
+
+
 def days_until_expiry_at_batch(epochs) -> list[dict]:
     """Per-value perspective-epoch "days until expiry" scalar for N
     epochs in ONE round-trip.

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -11119,6 +11119,144 @@ def api_license_is_expiring_at_batch():
     )
 
 
+@bp_entitlement.route("/api/license/expiring-within-at-batch")
+def api_license_expiring_within_at_batch():
+    """``GET /api/license/expiring-within-at-batch?days=<int>&epochs=
+    <int>,<int>,...`` -- per-value batch sibling of
+    ``/api/license/expiring-within-at``.
+
+    Renewal-window axis batch companion to the existing ``exp``-derived
+    ``/api/license/*-at-batch`` quartet
+    (``state-at-batch`` / ``is-expired-at-batch`` /
+    ``days-until-expiry-at-batch`` / ``is-expiring-at-batch``). Where
+    the singular endpoint folds ONE perspective epoch to ONE "would we
+    have shown a renewal warning as of that date?" bool, this preserves
+    per-value rows so a scheduled-audit tile that wants to plot the
+    renewal-window banner across a sequence of perspective dates
+    ("would the renewal banner have fired on each of these audit
+    dates?") renders off ONE round-trip instead of N calls to the
+    scalar. Wraps :func:`clawmetry.license.is_expiring_within_at_batch`.
+
+    Row shape mirrors ``/api/license/is-expiring-at-batch`` per-row so
+    a caller assembling a full renewal timeline can zip the batches
+    index-for-index. Same query-string posture on ``epochs=`` as the
+    surrounding quartet: required (missing / blank / only-commas ->
+    ``400 missing epochs``), comma-separated tokens deduped by parsed
+    int key preserving first-seen order, non-int / ``bool`` / ``None``
+    tokens collapse to ``expiring_within=false``. Never 5xxs.
+
+    Query parameters:
+
+      * ``days`` (int, optional) -- the renewal-window threshold applied
+        to EVERY row. Defaults to ``30`` (matches the singular
+        ``/api/license/expiring-within-at`` default). Negative input
+        clamps to ``0``; non-numeric / ``bool`` input collapses to
+        ``expiring_within=false`` on every row with
+        ``threshold_days=0`` rather than a 4xx, matching the surrounding
+        endpoints' never-5xx / never-4xx posture. Callers wanting
+        per-row thresholds should call the scalar N times.
+      * ``epochs`` (CSV, required) -- perspective epochs (Unix seconds).
+
+    Response shape (always HTTP 200)::
+
+        {
+          "kind":          "expiring_within_at",
+          "count":         <int>,               # len(rows)
+          "threshold_days": <int>,              # int-coerced days, clamped >= 0
+          "rows":  [
+            {"epoch": <int|"<raw>">, "expiring_within": <bool>},
+            ...
+          ],
+          "state":       "<active|expired|invalid|no_license>",  # NOW
+          "expires_at":  <int|null>,
+          "has_license": <bool>,
+          "valid":       <bool>
+        }
+
+    Deliberately strict on validity, mirroring the singular
+    ``/api/license/expiring-within-at`` and the sibling
+    ``/api/license/is-expiring-at-batch``: a predicate that fired
+    ``true`` on a lapsed key would push callers to gate renewal UI on a
+    value that no longer implies entitlement. See
+    :func:`clawmetry.license.is_expiring_within_at` for the rationale.
+
+    Per-row parity with ``/api/license/expiring-within-at?days=<d>
+    &epoch=<n>`` is pinned in the test suite so the batch cannot
+    silently drift from the scalar endpoint.
+    """
+    raw_days = request.args.get("days", "30")
+    if isinstance(raw_days, bool):
+        threshold = 0
+        threshold_ok = False
+    else:
+        try:
+            threshold = int(raw_days)
+            threshold_ok = True
+        except (TypeError, ValueError):
+            threshold = 0
+            threshold_ok = False
+    if threshold < 0:
+        threshold = 0
+    tokens, err = _parse_license_epochs_csv("epochs")
+    if err == "missing":
+        return jsonify({"error": "missing epochs"}), 400
+    try:
+        snap = _license_state_at_snapshot()
+    except Exception as exc:
+        logger.warning(
+            "api_license_expiring_within_at_batch: snapshot error: %s",
+            exc,
+        )
+        snap = {
+            "state": "no_license",
+            "expires_at": None,
+            "has_license": False,
+            "valid": False,
+        }
+    try:
+        from clawmetry import license as _lic
+
+        if threshold_ok:
+            rows = _lic.is_expiring_within_at_batch(threshold, tokens)
+        else:
+            # Bad ``days=`` collapses every row to False while preserving
+            # the row slots so the response length still matches the input
+            # (mirrors the singular endpoint's never-4xx posture on a
+            # typo). Delegate to the same batch helper with a sentinel
+            # bool that the helper refuses -- keeps the dedup / bad-token
+            # bucketing consistent with the "good" path.
+            rows = _lic.is_expiring_within_at_batch(True, tokens)
+    except Exception as exc:
+        logger.warning(
+            "api_license_expiring_within_at_batch: derive error: %s", exc
+        )
+        rows = []
+    # Batch helper emits ``is_expiring_within`` per row; rename to
+    # ``expiring_within`` here so the HTTP row field matches the
+    # scalar endpoint's ``/api/license/expiring-within-at`` response
+    # shape (``expiring_within``) and a caller can hydrate a paywall
+    # tile off either endpoint interchangeably.
+    rows = [
+        {
+            "epoch": row["epoch"],
+            "expiring_within": bool(row["is_expiring_within"]),
+        }
+        for row in rows
+    ]
+    return jsonify(
+        {
+            "kind": "expiring_within_at",
+            "count": len(rows),
+            "threshold_days": threshold,
+            "rows": rows,
+            "state": snap["state"],
+            "expires_at": snap["expires_at"],
+            "has_license": snap["has_license"],
+            "valid": snap["valid"],
+        }
+    )
+
+
 @bp_entitlement.route("/api/license/age-days-at-batch")
 def api_license_age_days_at_batch():
     """``GET /api/license/age-days-at-batch?epochs=<int>,<int>,...`` --

--- a/tests/test_license_is_expiring_within_at_batch.py
+++ b/tests/test_license_is_expiring_within_at_batch.py
@@ -1,0 +1,654 @@
+"""Tests for :func:`clawmetry.license.is_expiring_within_at_batch` and the
+paired ``GET /api/license/expiring-within-at-batch`` endpoint.
+
+Per-value axis batch sibling of
+:func:`clawmetry.license.is_expiring_within_at` /
+``/api/license/expiring-within-at``. Rounds out the renewal-window
+axis alongside the existing ``exp``-derived quartet
+(``state-at-batch`` / ``is-expired-at-batch`` /
+``days-until-expiry-at-batch`` / ``is-expiring-at-batch``): given a list
+of perspective dates, ONE round-trip answers "would the renewal banner
+have fired on each of them?" instead of N calls to the scalar. Per-row
+parity with the singular scalar (both the helper and the HTTP endpoint)
+is pinned so the batch cannot silently drift.
+
+Hermetic: each test mints tokens with its own ephemeral keypair and
+monkeypatches the module's embedded public key + ``LICENSE_PATH``,
+mirroring ``tests/test_license_is_expiring_at_batch.py``.
+"""
+from __future__ import annotations
+
+import time
+from types import SimpleNamespace
+
+import pytest
+from flask import Flask
+
+
+# -- shared helpers (mirror test_license_is_expiring_at_batch.py) -------------
+
+
+def _keypair():
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+    priv = Ed25519PrivateKey.generate()
+    pub_pem = priv.public_key().public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    return priv, pub_pem
+
+
+def _payload(tier="pro", nodes=3, exp_delta=365 * 86400, drop_exp=False):
+    now = int(time.time())
+    p = {
+        "sub": "acct_test",
+        "tier": tier,
+        "nodes": nodes,
+        "iat": now,
+        "exp": now + exp_delta,
+        "features": ["runtimes"],
+    }
+    if drop_exp:
+        p.pop("exp", None)
+    return p
+
+
+@pytest.fixture
+def app(monkeypatch, tmp_path):
+    import clawmetry.license as _lic
+
+    priv, pub_pem = _keypair()
+    monkeypatch.setattr(_lic, "_PUBLIC_KEY_PEM", pub_pem)
+    license_path = str(tmp_path / "license.key")
+    monkeypatch.setattr(_lic, "LICENSE_PATH", license_path)
+    monkeypatch.delenv("CLAWMETRY_LICENSE_SERVER", raising=False)
+    monkeypatch.delenv("CLAWMETRY_INGEST_URL", raising=False)
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("CLAWMETRY_OFFLINE", "1")
+
+    from routes.entitlement import bp_entitlement
+
+    flask_app = Flask(__name__)
+    flask_app.register_blueprint(bp_entitlement)
+    flask_app.config["TESTING"] = True
+
+    return SimpleNamespace(
+        app=flask_app,
+        lic=_lic,
+        priv=priv,
+        license_path=license_path,
+    )
+
+
+def _write_key_direct(app, exp_delta):
+    """Bypass activate() (which refuses expired tokens) and write a token
+    directly to the license file. Simulates a license that expired AFTER
+    it was installed."""
+    import os
+
+    tok = app.lic._encode_token(_payload(exp_delta=exp_delta), app.priv)
+    os.makedirs(os.path.dirname(app.license_path), exist_ok=True)
+    with open(app.license_path, "w", encoding="utf-8") as fh:
+        fh.write(tok)
+
+
+def _write_perpetual(app):
+    import os
+
+    tok = app.lic._encode_token(_payload(drop_exp=True), app.priv)
+    os.makedirs(os.path.dirname(app.license_path), exist_ok=True)
+    with open(app.license_path, "w", encoding="utf-8") as fh:
+        fh.write(tok)
+
+
+def _write_bogus(app):
+    import os
+
+    os.makedirs(os.path.dirname(app.license_path), exist_ok=True)
+    with open(app.license_path, "w", encoding="utf-8") as fh:
+        fh.write("CLAW1.garbage.garbage")
+
+
+# -- clawmetry.license.is_expiring_within_at_batch() -------------------------
+
+
+def test_batch_none_returns_empty(app):
+    """``epochs is None`` -> ``[]``. Never-raise posture, matches
+    :func:`is_expiring_at_batch`."""
+    assert app.lic.is_expiring_within_at_batch(30, None) == []
+
+
+def test_batch_non_iterable_returns_empty(app):
+    """Non-iterable ``epochs`` -> ``[]`` rather than a crash."""
+    assert app.lic.is_expiring_within_at_batch(30, 42) == []
+
+
+def test_batch_empty_returns_empty(app):
+    """Empty iterable -> ``[]``."""
+    assert app.lic.is_expiring_within_at_batch(30, []) == []
+    assert app.lic.is_expiring_within_at_batch(30, ()) == []
+
+
+def test_batch_no_license(app):
+    """No license file on disk -> every row False (nothing to compare
+    against). Time-independent, matches the never-mis-gate scalar."""
+    rows = app.lic.is_expiring_within_at_batch(
+        30, [0, int(time.time()), 2_000_000_000]
+    )
+    assert [r["is_expiring_within"] for r in rows] == [False, False, False]
+
+
+def test_batch_active_key_inside_window_fires(app):
+    """Active key with ``exp`` 10 days out: threshold 30 -> row for
+    now fires; a row 40 days ago (60 days from exp) -> False."""
+    tok = app.lic._encode_token(_payload(exp_delta=10 * 86400), app.priv)
+    app.lic.activate(tok)
+    now = int(time.time())
+    rows = app.lic.is_expiring_within_at_batch(
+        30, [now, now - 40 * 86400, now + 5 * 86400]
+    )
+    # now: 10d from exp, inside window -> True
+    # now - 40d: 50d from exp, outside 30d window -> False
+    # now + 5d: 5d from exp, inside window -> True
+    assert [r["is_expiring_within"] for r in rows] == [True, False, True]
+
+
+def test_batch_per_row_parity_with_scalar(app):
+    """Per-row parity with :func:`is_expiring_within_at` -- the batch
+    cannot silently drift from the scalar. Pin every row against the
+    singular helper on the same install."""
+    tok = app.lic._encode_token(_payload(exp_delta=15 * 86400), app.priv)
+    app.lic.activate(tok)
+    now = int(time.time())
+    epochs = [
+        now - 30 * 86400,
+        now - 1,
+        now,
+        now + 1,
+        now + 10 * 86400,
+        now + 20 * 86400,
+    ]
+    rows = app.lic.is_expiring_within_at_batch(30, epochs)
+    for row, epoch in zip(rows, epochs):
+        assert row["is_expiring_within"] == app.lic.is_expiring_within_at(
+            30, epoch
+        ), epoch
+
+
+def test_batch_perpetual_never_fires(app):
+    """Perpetual (no ``exp``) key -> False at every epoch (no claim to
+    gate against). Mirrors the scalar."""
+    _write_perpetual(app)
+    rows = app.lic.is_expiring_within_at_batch(
+        30, [0, int(time.time()), 2_000_000_000]
+    )
+    assert [r["is_expiring_within"] for r in rows] == [False, False, False]
+
+
+def test_batch_invalid_signature(app):
+    """Bogus-signature file -> False at every epoch (an unsigned body
+    is untrusted whatever the perspective)."""
+    _write_bogus(app)
+    rows = app.lic.is_expiring_within_at_batch(
+        30, [0, int(time.time()), 2_000_000_000]
+    )
+    assert [r["is_expiring_within"] for r in rows] == [False, False, False]
+
+
+def test_batch_lapsed_at_epoch_returns_false(app):
+    """A signature-valid key seen from a perspective where it has ALREADY
+    lapsed -> False (negative remaining collapses; a different, louder
+    ``is_expired_at`` banner covers that state).
+
+    A row where the SAME key had NOT yet lapsed at that epoch (perspective
+    epoch before exp) DOES fire True on purpose -- retrospectively, the
+    renewal banner WOULD have fired at that time. Mirrors
+    :func:`is_expiring_within_at`."""
+    _write_key_direct(app, exp_delta=-5 * 86400)  # exp = now - 5d
+    now = int(time.time())
+    # now:        exp - 5d ago, remaining=-5 -> already-lapsed -> False
+    # now - 10d:  10d before now, so 5d BEFORE exp, remaining=5 -> True
+    # now + 10d:  after exp, remaining=-15 -> already-lapsed -> False
+    rows = app.lic.is_expiring_within_at_batch(
+        30, [now, now - 10 * 86400, now + 10 * 86400]
+    )
+    assert [r["is_expiring_within"] for r in rows] == [False, True, False]
+
+
+def test_batch_string_int_tokens_parsed(app):
+    """Int-parseable strings coerce cleanly (matches the scalar's
+    ``int()`` coercion)."""
+    tok = app.lic._encode_token(_payload(exp_delta=10 * 86400), app.priv)
+    app.lic.activate(tok)
+    now = int(time.time())
+    rows = app.lic.is_expiring_within_at_batch(30, [str(now), str(now - 60 * 86400)])
+    # str(now): 10d from exp -> True
+    # str(now - 60d): 70d from exp -> False
+    assert [r["is_expiring_within"] for r in rows] == [True, False]
+
+
+def test_batch_dedupes_by_int_key_preserves_order(app):
+    """Duplicates by parsed int key are dropped preserving first-seen
+    order so the response is byte-stable across calls."""
+    tok = app.lic._encode_token(_payload(exp_delta=10 * 86400), app.priv)
+    app.lic.activate(tok)
+    now = int(time.time())
+    rows = app.lic.is_expiring_within_at_batch(
+        30, [now, now + 100, now, str(now + 100), now + 200]
+    )
+    assert [r["epoch"] for r in rows] == [now, now + 100, now + 200]
+
+
+def test_batch_bad_tokens_collapse_to_false(app):
+    """``bool`` / non-numeric / ``None`` collapse to
+    ``is_expiring_within=False`` (matches the scalar). Row still keeps
+    its slot so output length matches N -- each bad input gets its
+    own bucket."""
+    tok = app.lic._encode_token(_payload(exp_delta=10 * 86400), app.priv)
+    app.lic.activate(tok)
+    rows = app.lic.is_expiring_within_at_batch(30, [True, False, None, "garbage", ""])
+    assert len(rows) == 5
+    assert all(r["is_expiring_within"] is False for r in rows)
+
+
+def test_batch_mixed_good_and_bad(app):
+    """Bad tokens don't fail the whole batch. Good rows still resolve;
+    bad rows still slot in with ``is_expiring_within=False``."""
+    tok = app.lic._encode_token(_payload(exp_delta=10 * 86400), app.priv)
+    app.lic.activate(tok)
+    now = int(time.time())
+    rows = app.lic.is_expiring_within_at_batch(
+        30, [now, "garbage", now + 60 * 86400]
+    )
+    assert [r["is_expiring_within"] for r in rows] == [True, False, False]
+
+
+def test_batch_bad_days_collapses_every_row_to_false(app):
+    """``days=`` non-numeric / ``bool`` / negative -> every row
+    collapses to ``is_expiring_within=False``. Row slots are still
+    preserved so the output length matches N (the bad-input rows keep
+    the never-mis-gate posture on the ``days`` axis, mirroring the
+    ``epochs`` axis)."""
+    tok = app.lic._encode_token(_payload(exp_delta=10 * 86400), app.priv)
+    app.lic.activate(tok)
+    now = int(time.time())
+    for bad_days in ("garbage", None, True, False, -1, -365):
+        rows = app.lic.is_expiring_within_at_batch(
+            bad_days, [now, now + 5 * 86400, now + 60 * 86400]
+        )
+        assert len(rows) == 3, bad_days
+        assert all(r["is_expiring_within"] is False for r in rows), bad_days
+
+
+def test_batch_zero_days_only_fires_on_day_of_expiry(app):
+    """``days=0`` fires only when remaining == 0 -- the "expires
+    today" boundary. Callers wanting a wider window supply a larger
+    threshold."""
+    tok = app.lic._encode_token(_payload(exp_delta=10 * 86400), app.priv)
+    app.lic.activate(tok)
+    info = app.lic.current_license_info()
+    exp = int(info["exp"])
+    # exp - 86400 = 1 day out, days_until_expiry_at ~ 1 -> False
+    # exp = 0 days out, remaining=0 -> True
+    # exp - 1 = same-day boundary, remaining=0 -> True (floor div)
+    rows = app.lic.is_expiring_within_at_batch(
+        0, [exp - 86400, exp - 1, exp, exp + 1]
+    )
+    assert rows[0]["is_expiring_within"] is False
+    assert rows[1]["is_expiring_within"] is True
+    assert rows[2]["is_expiring_within"] is True
+    # 1s past exp -> remaining=-1 -> False (already lapsed at epoch)
+    assert rows[3]["is_expiring_within"] is False
+
+
+def test_batch_threshold_applies_uniformly(app):
+    """The ``days`` threshold applies to EVERY row uniformly; wider
+    windows admit more rows."""
+    tok = app.lic._encode_token(_payload(exp_delta=100 * 86400), app.priv)
+    app.lic.activate(tok)
+    now = int(time.time())
+    epochs = [
+        now,                  # 100 days out
+        now + 30 * 86400,     # 70 days out
+        now + 60 * 86400,     # 40 days out
+        now + 80 * 86400,     # 20 days out
+        now + 95 * 86400,     # 5 days out
+    ]
+    narrow = app.lic.is_expiring_within_at_batch(30, epochs)
+    wide = app.lic.is_expiring_within_at_batch(90, epochs)
+    # Narrow (30d): only the 20d and 5d rows fire
+    assert [r["is_expiring_within"] for r in narrow] == [
+        False,
+        False,
+        False,
+        True,
+        True,
+    ]
+    # Wide (90d): all rows within 90d fire; the "100 days out" one
+    # does NOT because 100 > 90.
+    assert [r["is_expiring_within"] for r in wide] == [
+        False,
+        True,
+        True,
+        True,
+        True,
+    ]
+
+
+def test_batch_never_raises(monkeypatch):
+    """Any per-row underlying failure of :func:`is_expiring_within_at`
+    -> ``is_expiring_within=False`` for THAT row. The batch never
+    propagates."""
+    import clawmetry.license as _lic
+
+    def _boom(_days, _epoch):
+        raise RuntimeError("simulated corrupt install")
+
+    monkeypatch.setattr(_lic, "is_expiring_within_at", _boom)
+    rows = _lic.is_expiring_within_at_batch(30, [1_700_000_000, 1_800_000_000])
+    assert [r["is_expiring_within"] for r in rows] == [False, False]
+    assert len(rows) == 2
+
+
+# -- GET /api/license/expiring-within-at-batch ----------------------------
+
+
+def test_endpoint_missing_epochs(app):
+    """``?epochs=`` absent -> 400 missing epochs."""
+    with app.app.test_client() as c:
+        resp = c.get("/api/license/expiring-within-at-batch")
+    assert resp.status_code == 400
+    assert resp.get_json() == {"error": "missing epochs"}
+
+
+def test_endpoint_missing_epochs_with_days(app):
+    """``?days=`` present but ``?epochs=`` absent -> 400 missing
+    epochs. The days-only knob doesn't imply epoch."""
+    with app.app.test_client() as c:
+        resp = c.get("/api/license/expiring-within-at-batch?days=30")
+    assert resp.status_code == 400
+
+
+def test_endpoint_blank_epochs(app):
+    """``?epochs=`` blank / only-commas -> 400 missing epochs."""
+    with app.app.test_client() as c:
+        resp = c.get("/api/license/expiring-within-at-batch?epochs=")
+        resp2 = c.get("/api/license/expiring-within-at-batch?epochs=,,,")
+    assert resp.status_code == 400
+    assert resp2.status_code == 400
+
+
+def test_endpoint_no_license(app):
+    """No license file -> every row ``is_expiring_within=False``, HTTP
+    200, current-time snapshot fields set to the OSS-free branch
+    shape."""
+    now = int(time.time())
+    with app.app.test_client() as c:
+        resp = c.get(
+            f"/api/license/expiring-within-at-batch?epochs={now},0"
+        )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["kind"] == "expiring_within_at"
+    assert data["count"] == 2
+    assert data["threshold_days"] == 30
+    assert [r["expiring_within"] for r in data["rows"]] == [False, False]
+    assert data["state"] == "no_license"
+    assert data["expires_at"] is None
+    assert data["has_license"] is False
+    assert data["valid"] is False
+
+
+def test_endpoint_default_days_is_30(app):
+    """Default ``?days=`` -> 30 (matches the singular endpoint's
+    default). A key 40 days out doesn't fire; a key 10 days out
+    does."""
+    tok = app.lic._encode_token(_payload(exp_delta=10 * 86400), app.priv)
+    app.lic.activate(tok)
+    now = int(time.time())
+    with app.app.test_client() as c:
+        resp = c.get(
+            f"/api/license/expiring-within-at-batch?epochs={now}"
+        )
+    data = resp.get_json()
+    assert data["threshold_days"] == 30
+    assert data["rows"][0]["expiring_within"] is True
+
+
+def test_endpoint_active_key_inside_window(app):
+    """Active key with ``exp`` 10 days out and ``days=30``: current
+    epoch fires; 40 days-ago perspective does not."""
+    tok = app.lic._encode_token(_payload(exp_delta=10 * 86400), app.priv)
+    app.lic.activate(tok)
+    info = app.lic.current_license_info()
+    exp = int(info["exp"])
+    now = int(time.time())
+    csv = ",".join(str(e) for e in [now, now - 40 * 86400, now + 5 * 86400])
+    with app.app.test_client() as c:
+        resp = c.get(
+            f"/api/license/expiring-within-at-batch?days=30&epochs={csv}"
+        )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["kind"] == "expiring_within_at"
+    assert data["count"] == 3
+    assert data["threshold_days"] == 30
+    assert [r["expiring_within"] for r in data["rows"]] == [
+        True,
+        False,
+        True,
+    ]
+    assert data["state"] == "active"
+    assert data["has_license"] is True
+    assert data["valid"] is True
+    assert data["expires_at"] == exp
+
+
+def test_endpoint_per_row_parity_with_scalar_endpoint(app):
+    """Per-row parity with the singular
+    ``/api/license/is-expiring-within-at?days=<d>&epoch=<n>`` endpoint
+    -- the batch cannot silently drift from the scalar endpoint. Pin
+    every row."""
+    tok = app.lic._encode_token(_payload(exp_delta=15 * 86400), app.priv)
+    app.lic.activate(tok)
+    now = int(time.time())
+    epochs = [
+        now - 30 * 86400,
+        now - 1,
+        now,
+        now + 1,
+        now + 10 * 86400,
+        now + 20 * 86400,
+    ]
+    csv = ",".join(str(e) for e in epochs)
+    with app.app.test_client() as c:
+        batch = c.get(
+            f"/api/license/expiring-within-at-batch?days=30&epochs={csv}"
+        ).get_json()
+        for row, epoch in zip(batch["rows"], epochs):
+            scalar = c.get(
+                f"/api/license/expiring-within-at?days=30&epoch={epoch}"
+            ).get_json()
+            assert row["expiring_within"] == scalar["expiring_within"], epoch
+
+
+def test_endpoint_bad_tokens_collapse_to_false(app):
+    """Bad tokens don't fail the whole batch. They slot in with
+    ``is_expiring_within=False`` (the never-mis-gate posture)."""
+    tok = app.lic._encode_token(_payload(exp_delta=10 * 86400), app.priv)
+    app.lic.activate(tok)
+    now = int(time.time())
+    with app.app.test_client() as c:
+        resp = c.get(
+            f"/api/license/expiring-within-at-batch?days=30&epochs=garbage,{now}"
+        )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["count"] == 2
+    assert [r["expiring_within"] for r in data["rows"]] == [False, True]
+
+
+def test_endpoint_bad_days_collapses_every_row_to_false(app):
+    """``?days=`` non-numeric -> every row False,
+    ``threshold_days=0``. Row slots preserved (matches the singular
+    ``/api/license/is-expiring-within-at``'s never-4xx posture on a
+    ``days`` typo)."""
+    tok = app.lic._encode_token(_payload(exp_delta=10 * 86400), app.priv)
+    app.lic.activate(tok)
+    now = int(time.time())
+    with app.app.test_client() as c:
+        resp = c.get(
+            f"/api/license/expiring-within-at-batch?days=garbage&epochs={now},{now + 5 * 86400}"
+        )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["threshold_days"] == 0
+    assert data["count"] == 2
+    assert all(r["expiring_within"] is False for r in data["rows"])
+
+
+def test_endpoint_negative_days_clamps_to_zero(app):
+    """``?days=-5`` clamps to 0 (matches the singular endpoint)."""
+    tok = app.lic._encode_token(_payload(exp_delta=10 * 86400), app.priv)
+    app.lic.activate(tok)
+    now = int(time.time())
+    with app.app.test_client() as c:
+        resp = c.get(
+            f"/api/license/expiring-within-at-batch?days=-5&epochs={now}"
+        )
+    data = resp.get_json()
+    assert data["threshold_days"] == 0
+    # Threshold 0 -> current epoch (10 days from exp) is outside window
+    assert data["rows"][0]["expiring_within"] is False
+
+
+def test_endpoint_perpetual_never_fires(app):
+    """Perpetual key -> every row False, but the current-time snapshot
+    fields still reflect a valid install."""
+    _write_perpetual(app)
+    now = int(time.time())
+    with app.app.test_client() as c:
+        resp = c.get(
+            f"/api/license/expiring-within-at-batch?days=30&epochs=0,{now},2000000000"
+        )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["count"] == 3
+    assert [r["expiring_within"] for r in data["rows"]] == [
+        False,
+        False,
+        False,
+    ]
+    assert data["has_license"] is True
+    assert data["expires_at"] is None
+
+
+def test_endpoint_dedupe_preserves_order(app):
+    """Duplicates by parsed int key are dropped preserving first-seen
+    order for byte-stable output."""
+    tok = app.lic._encode_token(_payload(exp_delta=10 * 86400), app.priv)
+    app.lic.activate(tok)
+    now = int(time.time())
+    with app.app.test_client() as c:
+        resp = c.get(
+            f"/api/license/expiring-within-at-batch?days=30"
+            f"&epochs={now},{now + 100},{now},{now + 100}"
+        )
+    data = resp.get_json()
+    assert data["count"] == 2
+    assert [r["epoch"] for r in data["rows"]] == [now, now + 100]
+
+
+def test_endpoint_never_5xxs(app, monkeypatch):
+    """Even if the shared snapshot blows up mid-request, the endpoint
+    still returns HTTP 200 with the OSS-free snapshot fallback + honest
+    per-row derivation."""
+    from routes import entitlement as _routes
+
+    monkeypatch.setattr(
+        _routes,
+        "_license_state_at_snapshot",
+        lambda: (_ for _ in ()).throw(RuntimeError("simulated blowup")),
+    )
+    now = int(time.time())
+    with app.app.test_client() as c:
+        resp = c.get(
+            f"/api/license/expiring-within-at-batch?days=30&epochs={now}"
+        )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["state"] == "no_license"
+    assert data["has_license"] is False
+    assert data["valid"] is False
+    assert data["expires_at"] is None
+    assert data["threshold_days"] == 30
+
+
+# -- cross-endpoint consistency: shared snapshot + row alignment -------------
+
+
+def test_endpoint_shared_snapshot_fields_agree_with_siblings(app):
+    """Shares the current-time snapshot fields (``state`` /
+    ``expires_at`` / ``has_license`` / ``valid``) with the existing
+    ``/api/license/*-at-batch`` quartet. A UI binding several for the
+    same install must not catch them disagreeing on those fields."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    now = int(time.time())
+    with app.app.test_client() as c:
+        s = c.get(f"/api/license/state-at-batch?epochs={now}").get_json()
+        ex = c.get(f"/api/license/is-expired-at-batch?epochs={now}").get_json()
+        d = c.get(
+            f"/api/license/days-until-expiry-at-batch?epochs={now}"
+        ).get_json()
+        it = c.get(
+            f"/api/license/is-expiring-at-batch?epochs={now}"
+        ).get_json()
+        itw = c.get(
+            f"/api/license/expiring-within-at-batch?days=30&epochs={now}"
+        ).get_json()
+    for key in ("state", "expires_at", "has_license", "valid"):
+        assert s[key] == ex[key] == d[key] == it[key] == itw[key], key
+
+
+def test_endpoint_rows_zip_with_siblings(app):
+    """All five ``/api/license/*-at-batch`` endpoints admit the same
+    input schema (``?epochs=`` CSV) and emit the same row ordering,
+    so a caller can zip the responses index-for-index by epoch."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    info = app.lic.current_license_info()
+    exp = int(info["exp"])
+    epochs = [exp - 60 * 86400, exp - 10 * 86400, exp - 1, exp + 5 * 86400]
+    csv = ",".join(str(e) for e in epochs)
+    with app.app.test_client() as c:
+        s = c.get(f"/api/license/state-at-batch?epochs={csv}").get_json()
+        ex = c.get(f"/api/license/is-expired-at-batch?epochs={csv}").get_json()
+        d = c.get(
+            f"/api/license/days-until-expiry-at-batch?epochs={csv}"
+        ).get_json()
+        it = c.get(
+            f"/api/license/is-expiring-at-batch?epochs={csv}"
+        ).get_json()
+        itw = c.get(
+            f"/api/license/expiring-within-at-batch?days=30&epochs={csv}"
+        ).get_json()
+    assert s["count"] == ex["count"] == d["count"] == it["count"] == itw[
+        "count"
+    ] == 4
+    for i, epoch in enumerate(epochs):
+        assert (
+            s["rows"][i]["epoch"]
+            == ex["rows"][i]["epoch"]
+            == d["rows"][i]["epoch"]
+            == it["rows"][i]["epoch"]
+            == itw["rows"][i]["epoch"]
+            == epoch
+        )
+        # is_expiring_within fires on rows where 0 <= days_until <= 30
+        # per-row; pin against the days batch so the two cannot drift.
+        remaining = d["rows"][i]["days"]
+        expected = remaining is not None and 0 <= remaining <= 30
+        assert itw["rows"][i]["expiring_within"] is bool(expected), epoch


### PR DESCRIPTION
## Summary

Per-value axis batch sibling of `is_expiring_within_at` / `/api/license/expiring-within-at`. Fills the `_at_batch` slot on the renewal-window axis alongside the existing `exp`-derived quartet (`state-at-batch` / `is-expired-at-batch` / `days-until-expiry-at-batch` / `is-expiring-at-batch`) so a scheduled-audit tile that plots "would the renewal banner have fired on each of these audit dates?" across N perspective epochs hydrates the whole column in ONE call instead of fanning out N calls to the scalar.

- `clawmetry.license.is_expiring_within_at_batch(days, epochs) -> list[dict]` — shared `days` threshold applied to EVERY row, per-row `{epoch, is_expiring_within}`. Bad `days` (`bool` / non-numeric / negative) collapses every row to `False` while preserving row slots so the response length still matches N. Bad epoch tokens keep their own bucket (matches the surrounding `_at_batch` family so a caller cannot silently mis-gate on a typo).
- `GET /api/license/expiring-within-at-batch?days=<N>&epochs=<CSV>` on `bp_entitlement`. Row field renamed to `expiring_within` so it matches the scalar endpoint's response field — a caller can hydrate a paywall tile off either endpoint interchangeably. Envelope carries the same current-time snapshot fields (`state` / `expires_at` / `has_license` / `valid`) as the surrounding batch quartet so a UI binding several endpoints for the same install cannot catch them disagreeing.
- Per-row parity with `is_expiring_within_at` (helper) and `/api/license/expiring-within-at` (scalar endpoint) pinned in the test suite so the batch cannot silently drift from the scalar.

Ships in **GRACE** — no behaviour change to any existing gate; purely additive scalar-batch accessor on top of the existing signed-license read path. No `__version__` bump, no `[RELEASE]` prefix, no tag. Never 5xxs: any underlying failure degrades to the OSS-free branch shape and per-row failures short-circuit to `is_expiring_within=false` for THAT row so the batch keeps building.

Deliberately strict on validity, mirroring the scalar: a predicate that fired `true` on a lapsed key would push callers to gate renewal UI on a value that no longer implies entitlement. A signed key seen from a perspective epoch where it had NOT yet lapsed still fires `true` on purpose — retrospectively the renewal banner would have shown then; the "already-lapsed-at-that-epoch" branch has the louder `is_expired_at_batch` signal alongside it.

## Test plan

- [x] `python3 -m pytest tests/test_license_is_expiring_within_at_batch.py` — 32/32 passing (hermetic; mints ephemeral Ed25519 keys per test, monkeypatches `_PUBLIC_KEY_PEM` + `LICENSE_PATH`, `CLAWMETRY_OFFLINE=1` — no network)
- [x] `python3 -m pytest tests/test_license.py tests/test_license_is_expiring_at_batch.py tests/test_license_days_until_expiry_at.py tests/test_license_expiring_within_at.py` — 134/134 still passing (no regression on surrounding renewal-window / expiry helpers)
- [x] `python3 -m pytest tests/test_entitlement_api.py tests/test_entitlement_api_fallback_shape.py` — 39/39 still passing (no regression on neighbour endpoints on `bp_entitlement`)
- [x] `ruff check clawmetry/license.py routes/entitlement.py tests/test_license_is_expiring_within_at_batch.py` — clean
- [x] `python3 -m py_compile clawmetry/license.py routes/entitlement.py tests/test_license_is_expiring_within_at_batch.py` — clean

Branches covered by the suite: `epochs=None` / non-iterable / empty; no-license; active key with the row inside vs outside the window; per-row parity with the singular helper; perpetual key (no `exp`); invalid-signature file; signed-but-lapsed key with pre-lapse and post-lapse perspectives; string-int coercion; dedupe-by-int-key with order preservation; bad tokens collapse to False but keep their slot; mixed good + bad tokens; bad `days` (garbage / `None` / `True` / `False` / negative) collapses every row while preserving slots; `days=0` "expires today" boundary; uniform threshold applied across a spread of remaining-days; never-raises on per-row failure; endpoint 400 on missing / blank / only-commas `epochs`; endpoint default `days=30`; endpoint per-row parity with the scalar endpoint; endpoint shared-snapshot agreement with the four sibling `_at_batch` endpoints; endpoint row alignment with siblings so a caller can zip index-for-index; endpoint never-5xx even on snapshot blowup.

## Local operator verification checklist

The automation agent has no access to your host, the running daemon, `~/.openclaw`, the live cloud snapshot, or a browser — so these steps have to happen on your machine before flipping the PR to ready-for-review or merging:

- [ ] Copy the changed files into the running site-packages:
      `cp clawmetry/license.py ~/.clawmetry/lib/python3.11/site-packages/clawmetry/`
      `cp routes/entitlement.py ~/.clawmetry/lib/python3.11/site-packages/routes/`
- [ ] Clear `__pycache__` under both: `find ~/.clawmetry/lib -name __pycache__ -exec rm -rf {} +`
- [ ] Kick the daemon: `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
- [ ] Hit the new endpoint locally on a machine **without** a license key installed:
      `curl -sS "http://localhost:8900/api/license/expiring-within-at-batch?days=30&epochs=$(date +%s)"` → expect `{"kind":"expiring_within_at","count":1,"threshold_days":30,"rows":[{"epoch":<now>,"expiring_within":false}],"state":"no_license","expires_at":null,"has_license":false,"valid":false}`
- [ ] If you have a signed test key handy with `exp` ~10 days out, `clawmetry activate <key>` and re-hit:
      `curl -sS "http://localhost:8900/api/license/expiring-within-at-batch?days=30&epochs=$(date +%s),$(( $(date +%s) - 40*86400 ))"` → expect the current-time row to have `expiring_within:true` (10d < 30d window) and the 40d-ago row to have `expiring_within:false` (50d > 30d).
- [ ] Zip the new batch against `/api/license/is-expiring-at-batch` / `/api/license/days-until-expiry-at-batch` on the same `epochs=` CSV and confirm the snapshot fields (`state` / `expires_at` / `has_license` / `valid`) agree — a UI binding both should never see them disagree for the same install.
- [ ] Decrypt the live cloud snapshot in the browser and confirm no rendering regressions on the license status tile (this PR doesn't touch the UI, but the endpoint shares the `_license_state_at_snapshot` reader).

The PR is intentionally left **DRAFT** — no `__version__` bump, no `[RELEASE]` prefix, no tag. Once verified locally, flip to ready-for-review + squash-merge on your usual flywheel.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XYi1B6DZjRtBvAk27vMchc)_