### PR TITLE
chore(c6): daily issue ping when branch protection still unclosed

### DIFF
--- a/.github/workflows/c6-schedule-heal.yml
+++ b/.github/workflows/c6-schedule-heal.yml
@@ -53,6 +53,7 @@ on:
 
 permissions:
   contents: read
+  issues: write
 
 jobs:
   c6-auto-heal:
@@ -250,6 +251,25 @@ print(json.dumps(sorted(set(a) | set(b))))
           echo "C6 is GREEN -- all required E2E status checks are configured on clawmetry/main."
           echo "Branch protection is correctly set. E2E_ADMIN_PAT is not needed."
           echo "Tracking: https://github.com/vivekchand/clawmetry/issues/4029"
+
+      # Daily ping on the tracking issue when C6 is still unclosed.
+      # Runs only on the 10:15 UTC daily schedule (not every 2-hour run)
+      # so the issue thread does not flood with hourly noise.
+      # continue-on-error: true so a GitHub API hiccup does not shadow
+      # the mandatory exit-1 below.
+      - name: Daily ping on tracking issue (C6 still unclosed)
+        if: |
+          github.event_name == 'schedule'
+          && github.event.schedule == '15 10 * * *'
+          && steps.pat-check.outputs.has_pat == 'false'
+          && steps.read-state.outputs.checks_ok != 'true'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TODAY=$(date -u +%Y-%m-%d)
+          BODY="<!-- c6-daily-ping --> **C6 daily ping ${TODAY}:** clawmetry/main branch protection does not yet require E2E checks. 6/7 criteria green. Fastest close: [Settings > Branches > main](https://github.com/vivekchand/clawmetry/settings/branches) > Required status checks > add \`E2E Gate (required)\` (60 s, no token needed). Or run \`bash scripts/close-c6.sh\` from a terminal."
+          gh issue comment 3864 --repo vivekchand/clawmetry --body "$BODY"
 
       - name: Error: E2E_ADMIN_PAT not set
         if: steps.pat-check.outputs.has_pat == 'false' && steps.read-state.outputs.checks_ok != 'true'


### PR DESCRIPTION
## Summary

- **Problem:** `c6-schedule-heal.yml` emits a detailed job summary when C6 is unclosed, but that summary is only visible if you open the Actions tab. There is no signal that reaches the issue thread.
- **Fix:** On the 10:15 UTC daily schedule run (not the every-2-hour runs), when branch protection is still not configured and `E2E_ADMIN_PAT` is absent, the step posts one comment on tracking issue #3864 with the date and the 60-second close path. Comment flooding is avoided by scoping to the daily schedule only.

## Changes

- `.github/workflows/c6-schedule-heal.yml`
  - Added `issues: write` to the `permissions` block (required for `gh issue comment`)
  - Added "Daily ping on tracking issue (C6 still unclosed)" step with `continue-on-error: true` before the mandatory `exit 1` step

## Context

6/7 E2E robustness criteria are green. C6 (required status checks) is the only remaining blocker. All automated close paths are exhausted without an admin PAT. The owner needs to take one 60-second manual action:

[Settings > Branches > main](https://github.com/vivekchand/clawmetry/settings/branches) > Required status checks > add `E2E Gate (required)`

Tracking: #3864

## Test plan

- [x] YAML diff is minimal (20 lines added, no existing logic touched)
- [x] `issues: write` added to permissions so `gh issue comment` is authorized
- [x] Step's `if` condition scopes to the daily `'15 10 * * *'` schedule only
- [x] `continue-on-error: true` ensures a GitHub API blip cannot shadow the mandatory `exit 1` below it
- [ ] After merge: confirm the 10:15 UTC daily run posts a comment on #3864 (verify tomorrow)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NQdegZfmXCqJrtSe1qhzwg)_