### PR TITLE
feat(onboard): two-option fork (Self-Hosted / Cloud) with plans stated once

### DIFF
--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -794,9 +794,11 @@ def _cmd_connect(args) -> None:
     # `--force` flag lets the user override after explicit confirmation.
     from clawmetry.config import is_cloud_disabled, NOCLOUD_MARKER_PATH
     # Sign in while KEEPING the nocloud marker: account + trial license yes,
-    # data egress no (set by the Case-B "keep local-only" answer below).
-    _keep_local_signin = False
-    if is_cloud_disabled() and not getattr(args, "force", False):
+    # data egress no. Set by the Case-B "keep local-only" answer below, or
+    # passed in directly by onboard's Self-Hosted trial path (args.keep_local),
+    # which has already asked its own questions and must not be re-prompted.
+    _keep_local_signin = bool(getattr(args, "keep_local", False))
+    if is_cloud_disabled() and not getattr(args, "force", False) and not _keep_local_signin:
         # Two cases here:
         #
         # (A) AUTOMATED invocation -- install.sh / curl|bash / wrappers that
@@ -3192,13 +3194,19 @@ def _cmd_onboard(args) -> None:
             else:
                 print(f"  {DIM(_line)}" if _line else "")
     print()
+    print(f"  {BOLD('Plans')} {DIM('(same either way):')}")
+    print(f"    {DIM('Free $0: watch OpenClaw + NVIDIA NemoClaw, forever')}")
+    print(f"    {DIM('Starter $9/node/mo: observability for all 14 runtimes')}")
+    print(f"    {DIM('Pro $19/node/mo: the governance layer (alerts, approvals, evals)')}")
+    print()
     print(f"  {BOLD('How do you want to run ClawMetry?')}")
     print()
-    print(f"    {BOLD('[1] Sign in / Sign up')}  {DIM('Google, GitHub, or an email code. No card needed.')}")
-    print(f"                           {DIM('Starts your free 7-day Pro trial: every detected')}")
-    print(f"                           {DIM('runtime, right here plus a dashboard from anywhere.')}")
-    print(f"    {BOLD('[2] License key')}        {DIM('Self-Hosted Pro: all 14 runtimes, offline.')}")
-    print(f"    {BOLD('[3] Skip for now')}       {DIM('No account. OpenClaw + NeMo free at localhost:8900.')}")
+    print(f"    {BOLD('[1] Self-Hosted')}  {DIM('Everything runs and stays on your devices.')}")
+    print(f"                     {DIM('Dashboard at http://localhost:8900.')}")
+    print(f"    {BOLD('[2] Cloud')}        {DIM('Your whole fleet in one dashboard, from anywhere')}")
+    print(f"                     {DIM('(app.clawmetry.com), plus the desk device')}")
+    print(f"                     {DIM('(clawmetry.com/device). E2E-encrypted: snapshots are')}")
+    print(f"                     {DIM('sealed on your machine and only you hold the key.')}")
     print()
 
     def _write_nocloud_marker():
@@ -3257,13 +3265,13 @@ def _cmd_onboard(args) -> None:
 
     # Scriptable / non-interactive overrides. A headless install (curl | bash
     # with no /dev/tty) must NEVER silently create a cloud account, so the
-    # EOF fallback is LOCAL ([3] Skip) even though the interactive default
-    # keypress is [1] Sign in.
+    # EOF fallback is the free local tier ("0"), even though the interactive
+    # default keypress is [1] Self-Hosted (whose trial sub-prompt signs in).
     _env_local = _os.environ.get("CLAWMETRY_LOCAL_ONLY", "").strip().lower() in ("1", "true", "yes", "on")
     if getattr(args, "local", False) or _env_local:
-        choice = "3"
+        choice = "0"
     elif getattr(args, "cloud", False):
-        choice = "1"
+        choice = "2"
     else:
         # When already connected, the default on an empty Enter is "keep current
         # setup" (return without changes) so re-running onboard never silently
@@ -3274,12 +3282,12 @@ def _cmd_onboard(args) -> None:
             choice = _input(_prompt).strip()
         except (EOFError, KeyboardInterrupt):
             # No interactive answer possible: never mint an account. A
-            # connected node keeps its setup; a fresh one goes local ([3]).
+            # connected node keeps its setup; a fresh one goes free-local.
             print()
             if already_connected:
                 print(f"\n  {DIM('Keeping your current setup. Run  clawmetry status  to check sync health.')}\n")
                 return
-            choice = "3"
+            choice = "0"
         if not choice:
             if already_connected:
                 print(f"\n  {DIM('Keeping your current setup. Run  clawmetry status  to check sync health.')}\n")
@@ -3288,65 +3296,14 @@ def _cmd_onboard(args) -> None:
 
     print()
 
-    if choice == "2":
-        # ── Self-Hosted license key (local, offline, all 14 runtimes) ──────
-        _write_nocloud_marker()
-        try:
-            _has_key = (_input("  Do you already have a license key? [y/N]: ").strip().lower() or "n")
-        except (EOFError, KeyboardInterrupt):
-            _has_key = "n"
-            print()
-        print()
-        _lic_key = ""
-        if _has_key in ("y", "yes"):
-            try:
-                _lic_key = _input("  Paste your license key (CLAW1...), or press Enter to do it later: ").strip()
-            except (EOFError, KeyboardInterrupt):
-                _lic_key = ""
-                print()
-            print()
-        if _lic_key:
-            try:
-                from clawmetry import license as _lic
-                ok, msg = _lic.activate(_lic_key, node_id=_lic._node_id())
-                print(f"  {GREEN('Activated.') if ok else '⚠️  '}{msg}")
-                if not ok:
-                    print(f"     {DIM('Try again later:')} {CYAN('clawmetry activate <key>')}")
-            except Exception as _e:
-                print(f"  ⚠️  Activation failed: {_e}")
-                print(f"     {DIM('Try again later:')} {CYAN('clawmetry activate <key>')}")
-        else:
-            # No key yet: hand them license pricing with the Self-Hosted
-            # toggle preselected (?deploy=self is honored by the pricing page).
-            _pricing_url = "https://clawmetry.com/pricing?deploy=self"
-            print(f"  {DIM('Get one at')} {CYAN(_pricing_url)}")
-            print(f"  {DIM('then run')} {CYAN('clawmetry activate <key>')} {DIM('on this machine.')}")
-            try:
-                import webbrowser
-                if webbrowser.open(_pricing_url):
-                    print(f"  {DIM('(opened in your browser)')}")
-            except Exception:
-                pass
-        print()
-        _maybe_apply_nemoclaw_preset(_input, BOLD, CYAN, DIM)
-        _finish_local()
-        return
-
-    if choice == "3":
-        # ── [3] Skip for now: local only, no account ──────────────────────
+    if choice == "0":
+        # ── Free local tier (no account): --local / env / EOF fallback ────
         print(f"  {GREEN(BOLD('Local only.'))} {DIM('No account, no cloud.')}")
         print()
         _write_nocloud_marker()
         _maybe_apply_nemoclaw_preset(_input, BOLD, CYAN, DIM)
         _finish_local()
         return
-
-    # ── [1] Sign in / Sign up (default): identify first, trial second ────────
-    # Auth rides the existing connect flow (GitHub / Google OAuth incl. the
-    # headless paste-code path, or email OTP). Success is a cm_ api_key in
-    # ~/.clawmetry/config.json; then the account's ONE 7-day Pro trial
-    # license is minted-or-reused server-side and activated locally, so
-    # every runtime unlocks on the same rail Self-Hosted Pro uses.
 
     def _config_api_key() -> str:
         try:
@@ -3358,35 +3315,103 @@ def _cmd_onboard(args) -> None:
 
     import argparse as _ap
 
-    # The user's [1] keypress IS the local-only conversion answer: clear the
-    # nocloud marker so connect goes straight to sign-in instead of
-    # re-asking "keep local-only?" and silently dropping the auth on [2]
-    # (founder report 2026-07-29). An incomplete sign-in below re-writes it.
-    try:
-        from clawmetry.config import NOCLOUD_MARKER_PATH as _nocloud_path
+    if choice == "2":
+        # ── [2] Cloud: sign in, fleet dashboard from anywhere ─────────────
+        # The keypress IS the cloud consent: clear the marker so connect goes
+        # straight to sign-in; an incomplete sign-in re-writes it below.
+        try:
+            from clawmetry.config import NOCLOUD_MARKER_PATH as _nocloud_path
 
-        _os.unlink(_nocloud_path)
-    except Exception:
-        pass
+            _os.unlink(_nocloud_path)
+        except Exception:
+            pass
+        _fake_args = _ap.Namespace(
+            key=None, foreground=False, custom_node_id=None,
+            enc_key=None, key_only=False, no_daemon=False,
+        )
+        _cmd_connect(_fake_args)
+        print()
+        if _config_api_key():
+            # Trial mint + local activation already happened inside connect.
+            _maybe_apply_nemoclaw_preset(_input, BOLD, CYAN, DIM)
+            return
+        print(f"  {DIM('No account connected. Running local-only; try again anytime:')} {CYAN('clawmetry onboard')}")
+        print()
+        _write_nocloud_marker()
+        _maybe_apply_nemoclaw_preset(_input, BOLD, CYAN, DIM)
+        _finish_local()
+        return
+
+    # ── [1] Self-Hosted (default): key if you have one, else trial sign-in ──
+    # Data never leaves the machine on this path (nocloud marker). Identity
+    # is still how the trial unlocks runtimes: no key -> sign in (Google /
+    # GitHub / email OTP) via connect's keep-local mode, which mints and
+    # activates the 7-day trial license with the marker KEPT.
+    _write_nocloud_marker()
+    try:
+        _has_key = (_input("  Do you already have a license key? [y/N]: ").strip().lower() or "n")
+    except (EOFError, KeyboardInterrupt):
+        _has_key = "n"
+        print()
+    print()
+    if _has_key in ("y", "yes"):
+        try:
+            _lic_key = _input("  Paste your license key (CLAW1...), or press Enter to do it later: ").strip()
+        except (EOFError, KeyboardInterrupt):
+            _lic_key = ""
+            print()
+        print()
+        if _lic_key:
+            try:
+                from clawmetry import license as _lic
+                ok, msg = _lic.activate(_lic_key, node_id=_lic._node_id())
+                print(f"  {GREEN('Activated.') if ok else '⚠️  '}{msg}")
+                if not ok:
+                    print(f"     {DIM('Try again later:')} {CYAN('clawmetry activate <key>')}")
+            except Exception as _e:
+                print(f"  ⚠️  Activation failed: {_e}")
+                print(f"     {DIM('Try again later:')} {CYAN('clawmetry activate <key>')}")
+        else:
+            _pricing_url = "https://clawmetry.com/pricing?deploy=self"
+            print(f"  {DIM('Get one at')} {CYAN(_pricing_url)} {DIM('then run')} {CYAN('clawmetry activate <key>')}")
+        print()
+        _maybe_apply_nemoclaw_preset(_input, BOLD, CYAN, DIM)
+        _finish_local()
+        return
+
+    # No key: offer the trial (the default), free tier if declined.
+    try:
+        _want_trial = (_input(
+            "  Start your free 7-day Pro trial? Sign in with Google, GitHub, or an\n"
+            "  email code; your data still stays on this machine. [Y/n]: "
+        ).strip().lower() or "y")
+    except (EOFError, KeyboardInterrupt):
+        _want_trial = "n"
+        print()
+    print()
+    if _want_trial in ("n", "no"):
+        print(f"  {DIM('Free plan: OpenClaw + NeMo at http://localhost:8900.')}")
+        print(f"  {DIM('Trial or license anytime:')} {CYAN('clawmetry onboard')} {DIM('·')} {CYAN('https://clawmetry.com/pricing?deploy=self')}")
+        print()
+        _maybe_apply_nemoclaw_preset(_input, BOLD, CYAN, DIM)
+        _finish_local()
+        return
 
     _fake_args = _ap.Namespace(
         key=None, foreground=False, custom_node_id=None,
-        enc_key=None, key_only=False, no_daemon=False,
+        enc_key=None, key_only=False, no_daemon=False, keep_local=True,
     )
     _cmd_connect(_fake_args)
     print()
-
     if _config_api_key():
-        # Trial mint + local activation already happened inside connect
-        # (every successful sign-in does it; a second call here would just
-        # double-print the reissue).
+        # Connect (keep-local mode) minted + activated the trial, kept the
+        # marker, and ensured the local dashboard.
         _maybe_apply_nemoclaw_preset(_input, BOLD, CYAN, DIM)
         return
 
-    # Sign-in didn't complete: keep the machine useful locally, no account.
-    print(f"  {DIM('No account connected. Running local-only; try again anytime:')} {CYAN('clawmetry onboard')}")
+    # Sign-in didn't complete: free local tier, no account.
+    print(f"  {DIM('No account connected. Running the free plan; try again anytime:')} {CYAN('clawmetry onboard')}")
     print()
-    _write_nocloud_marker()
     _maybe_apply_nemoclaw_preset(_input, BOLD, CYAN, DIM)
     _finish_local()
     return

--- a/clawmetry/runtime_probe.py
+++ b/clawmetry/runtime_probe.py
@@ -119,15 +119,15 @@ def render_detection_lines(probes: list) -> list:
     for i in range(0, n, 3):
         row = "".join(f"[x] {p['label']:<{cell}}" for p in found[i : i + 3])
         lines.append("  " + row.rstrip())
-    lines.append("")
-    lines.append("Free forever: OpenClaw and NVIDIA NemoClaw.")
     paid = [p for p in found if not p.get("free")]
+    if paid:
+        lines.append("")
     if len(paid) == 1:
         lines.append(
-            f"Sign in [1] below for a free 7-day Pro trial that unlocks {paid[0]['label']} too, or paste a license key [2]."
+            f"A free 7-day Pro trial (sign in below) unlocks {paid[0]['label']} too, or paste a license key."
         )
     elif paid:
         lines.append(
-            f"Sign in [1] below for a free 7-day Pro trial of the other {len(paid)}, or paste a license key [2]."
+            f"A free 7-day Pro trial (sign in below) unlocks the other {len(paid)}, or paste a license key."
         )
     return lines

--- a/tests/test_onboard_local_default.py
+++ b/tests/test_onboard_local_default.py
@@ -49,6 +49,9 @@ def onboard_env(monkeypatch, tmp_path):
         # written) -> onboard must fall back to local. Tests that need a
         # successful sign-in override this with a config-writing stub.
         state["connect"] += 1
+        _ns = a[0] if a else None
+        state["connect_keep_local"] = bool(getattr(_ns, "keep_local", False))
+        state["marker_at_connect"] = marker.exists()
         return None
 
     monkeypatch.setattr(cli, "_instant_register", _fake_instant_register)
@@ -114,37 +117,49 @@ def test_env_local_only_forces_local(onboard_env, monkeypatch):
     assert marker.exists()
 
 
-def test_choice_1_reaches_authenticated_connect(onboard_env, monkeypatch):
+def test_selfhosted_trial_reaches_connect_keep_local(onboard_env, monkeypatch):
     state, marker = onboard_env
-    monkeypatch.setattr("builtins.input", lambda _p="": "1")
+    answers = iter(["1", "n", "y"])  # Self-Hosted -> no key -> yes, trial sign-in
+    monkeypatch.setattr("builtins.input", lambda _p="": next(answers))
     cli._cmd_onboard(_args())
-    assert state["connect"] == 1, "[1] Sign in must reach the authenticated connect flow"
+    assert state["connect"] == 1, "the trial path must reach the authenticated connect flow"
+    assert state.get("connect_keep_local") is True, "connect must run in keep-local mode"
+    assert state.get("marker_at_connect") is True, "self-hosted trial keeps the nocloud marker"
     assert state["instant_register"] == 0, "anonymous instant registration must be unreachable"
-    # Connect stub wrote no config -> sign-in incomplete -> local fallback.
+    # Connect stub wrote no config -> sign-in incomplete -> free-local fallback.
     assert marker.exists() and state["start_daemon"] == 1
 
 
-def test_empty_enter_defaults_to_sign_in(onboard_env, monkeypatch):
-    """The interactive default keypress is [1] Sign in (founder 2026-07-29).
-    A human pressing Enter at the visible menu is not a silent mint."""
+def test_selfhosted_trial_declined_is_free_local(onboard_env, monkeypatch, capsys):
     state, marker = onboard_env
-    monkeypatch.setattr("builtins.input", lambda _p="": "")  # just press Enter
+    answers = iter(["1", "n", "n"])  # Self-Hosted -> no key -> no trial
+    monkeypatch.setattr("builtins.input", lambda _p="": next(answers))
+    cli._cmd_onboard(_args())
+    assert state["connect"] == 0 and state["instant_register"] == 0
+    assert marker.exists() and state["start_daemon"] == 1
+    assert "Free plan: OpenClaw + NeMo" in capsys.readouterr().out
+
+
+def test_empty_enters_default_to_selfhosted_trial_signin(onboard_env, monkeypatch):
+    """Enter-Enter-Enter = Self-Hosted -> no key -> trial (founder 2026-07-30):
+    the default path signs in, keep-local. A human pressing Enter at visible
+    prompts is not a silent mint."""
+    state, marker = onboard_env
+    monkeypatch.setattr("builtins.input", lambda _p="": "")  # Enter everywhere
     cli._cmd_onboard(_args())
     assert state["connect"] == 1
+    assert state.get("connect_keep_local") is True
     assert state["instant_register"] == 0
-    assert marker.exists(), "incomplete sign-in must fall back to local"
+    assert marker.exists(), "incomplete sign-in must fall back to free local"
 
 
-def test_choice_2_no_key_points_at_selfhosted_pricing(onboard_env, monkeypatch, capsys):
+def test_selfhosted_key_later_points_at_selfhosted_pricing(onboard_env, monkeypatch, capsys):
     state, marker = onboard_env
-    opened = []
-    monkeypatch.setattr("webbrowser.open", lambda url, *a, **k: opened.append(url) or True)
-    answers = iter(["2", "n"])  # [2] License key, then "don't have one yet"
+    answers = iter(["1", "y", ""])  # Self-Hosted -> have a key -> paste later
     monkeypatch.setattr("builtins.input", lambda _p="": next(answers))
     cli._cmd_onboard(_args())
     out = capsys.readouterr().out
     assert "clawmetry.com/pricing?deploy=self" in out
-    assert opened == ["https://clawmetry.com/pricing?deploy=self"]
     assert state["connect"] == 0 and state["instant_register"] == 0
     assert marker.exists() and state["start_daemon"] == 1
 
@@ -164,10 +179,10 @@ def test_choice_1_success_skips_local_fallback(onboard_env, monkeypatch, tmp_pat
             _json.dumps({"api_key": "cm_fresh_signup", "node_id": "n1"}))
 
     monkeypatch.setattr(cli, "_cmd_connect", _connect_writes_config)
-    monkeypatch.setattr("builtins.input", lambda _p="": "1")
+    monkeypatch.setattr("builtins.input", lambda _p="": "2")
     cli._cmd_onboard(_args())
     assert state["connect"] == 1
-    assert not marker.exists(), "successful sign-in is a cloud setup, not local-only"
+    assert not marker.exists(), "successful cloud sign-in clears local-only"
     assert state["start_daemon"] == 0, "connect owns the daemon on this path"
 
 
@@ -256,20 +271,24 @@ def test_already_connected_empty_enter_keeps_current(onboard_env, monkeypatch, t
     assert not marker.exists(), "must NOT switch a connected user to local on empty Enter"
 
 
-def test_already_connected_shows_options_and_choice_3_goes_local(onboard_env, monkeypatch, tmp_path, capsys):
+def test_already_connected_shows_two_options_and_shared_plans(onboard_env, monkeypatch, tmp_path, capsys):
     state, marker = onboard_env
     _make_connected(tmp_path / "home")
-    monkeypatch.setattr("builtins.input", lambda _p="": "3")
+    answers = iter(["1", "y", ""])  # Self-Hosted -> have key -> later
+    monkeypatch.setattr("builtins.input", lambda _p="": next(answers))
     cli._cmd_onboard(_args())
     out = capsys.readouterr().out
-    assert "[1] Sign in / Sign up" in out and "[2] License key" in out and "[3] Skip for now" in out
-    assert marker.exists(), "explicit [3] reconfigures a connected user to local"
+    assert "[1] Self-Hosted" in out and "[2] Cloud" in out
+    assert "Plans" in out and "Starter $9/node/mo" in out and "Pro $19/node/mo" in out
+    assert out.count("$9") == 1 and out.count("$19") == 1, "plans stated once, not per option"
+    assert "watch OpenClaw + NVIDIA NemoClaw" in out
+    assert marker.exists(), "explicit Self-Hosted reconfigures a connected user to local"
 
 
-def test_already_connected_choice_1_reaches_connect(onboard_env, monkeypatch, tmp_path):
+def test_already_connected_choice_2_reaches_connect(onboard_env, monkeypatch, tmp_path):
     state, _marker = onboard_env
     _make_connected(tmp_path / "home")
-    monkeypatch.setattr("builtins.input", lambda _p="": "1")
+    monkeypatch.setattr("builtins.input", lambda _p="": "2")
     cli._cmd_onboard(_args())
     assert state["connect"] == 1
     assert state["instant_register"] == 0
@@ -284,8 +303,7 @@ def test_already_connected_choice_1_reaches_connect(onboard_env, monkeypatch, tm
 
 def test_local_finish_health_checks_dashboard(onboard_env, monkeypatch, capsys):
     state, marker = onboard_env
-    monkeypatch.setattr("builtins.input", lambda _p="": "3")
-    cli._cmd_onboard(_args())
+    cli._cmd_onboard(_args(local=True))
     assert state.get("dash") == 1, "local finish must health-check/start the dashboard"
     out = capsys.readouterr().out
     assert "http://localhost:8900" in out and "live now" in out
@@ -294,28 +312,22 @@ def test_local_finish_health_checks_dashboard(onboard_env, monkeypatch, capsys):
 def test_local_finish_admits_when_dashboard_is_down(onboard_env, monkeypatch, capsys):
     state, marker = onboard_env
     monkeypatch.setattr(cli, "_ensure_local_dashboard", lambda *a, **k: False)
-    monkeypatch.setattr("builtins.input", lambda _p="": "3")
-    cli._cmd_onboard(_args())
+    cli._cmd_onboard(_args(local=True))
     out = capsys.readouterr().out
     assert "did not come up" in out, "a dead port must never be presented as a live URL"
     assert "dashboard.log" in out
 
 
-def test_choice_1_clears_nocloud_marker_before_connect(onboard_env, monkeypatch):
-    """[1] Sign in must not be re-asked 'keep local-only?': the marker is
+def test_cloud_choice_clears_marker_before_connect(onboard_env, monkeypatch):
+    """[2] Cloud must not be re-asked 'keep local-only?': the marker is
     cleared before connect runs (an incomplete sign-in re-writes it)."""
     state, marker = onboard_env
     marker.write_text("")
-    seen = {}
-
-    def _connect_records_marker(*a, **k):
-        state["connect"] += 1
-        seen["marker_at_connect"] = marker.exists()
-
-    monkeypatch.setattr(cli, "_cmd_connect", _connect_records_marker)
-    monkeypatch.setattr("builtins.input", lambda _p="": "1")
+    monkeypatch.setattr("builtins.input", lambda _p="": "2")
     cli._cmd_onboard(_args())
-    assert seen["marker_at_connect"] is False
+    assert state["connect"] == 1
+    assert state.get("marker_at_connect") is False
+    assert not state.get("connect_keep_local")
     assert marker.exists(), "failed sign-in must restore the local-only marker"
 
 

--- a/tests/test_onboard_runtime_detection.py
+++ b/tests/test_onboard_runtime_detection.py
@@ -63,8 +63,7 @@ def test_render_free_only_machine_has_no_pro_cta():
     lines = render_detection_lines(probes)
     joined = "\n".join(lines)
     assert "OpenClaw" in joined
-    assert "Free forever" in joined
-    assert "license key" not in joined
+    assert "license key" not in joined, "a free-only machine gets no upsell line"
     assert "Cursor" not in joined
 
 
@@ -79,9 +78,8 @@ def test_render_paid_detected_names_runtime_and_both_paths():
     lines = render_detection_lines(probes)
     joined = "\n".join(lines)
     assert "Claude Code" in joined and "Cursor" in joined
-    assert "Free forever: OpenClaw and NVIDIA NemoClaw." in joined
-    assert "Sign in [1]" in joined and "7-day Pro trial" in joined
-    assert "license key [2]" in joined
+    assert "sign in below" in joined and "7-day Pro trial" in joined
+    assert "license key" in joined
     # The em-dash/double-dash ban applies to user-facing copy.
     assert "—" not in joined and "--" not in joined
 
@@ -105,7 +103,7 @@ def test_render_grid_compact_no_per_line_tier_labels():
     assert len(grid) == 4  # 3 + 3 + 3 + 1
     assert grid[0].count("[x]") == 3
     assert "Detected 10 AI agent runtimes" in lines[0]
-    assert "trial of the other 9" in joined
+    assert "unlocks the other 9" in joined
 
 
 def test_render_single_paid_runtime_named_in_unlock_line():
@@ -114,7 +112,7 @@ def test_render_single_paid_runtime_named_in_unlock_line():
     ]
     joined = "\n".join(render_detection_lines(probes))
     assert "unlocks Cursor too" in joined
-    assert "Sign in [1]" in joined and "license key [2]" in joined
+    assert "sign in below" in joined and "license key" in joined
 
 
 def test_render_nothing_detected_is_silent():


### PR DESCRIPTION
Founder redesign: collapse to two options — the fork is purely **where it runs**; sign-in is just how the trial starts on either path.

```
  Plans (same either way):
    Free $0: watch OpenClaw + NVIDIA NemoClaw, forever
    Starter $9/node/mo: observability for all 14 runtimes
    Pro $19/node/mo: the governance layer (alerts, approvals, evals)

  How do you want to run ClawMetry?

    [1] Self-Hosted  Everything runs and stays on your devices.
                     Dashboard at http://localhost:8900.
    [2] Cloud        Your whole fleet in one dashboard, from anywhere
                     (app.clawmetry.com), plus the desk device
                     (clawmetry.com/device). E2E-encrypted: snapshots are
                     sealed on your machine and only you hold the key.

  Choose [1]: 1
  Do you already have a license key? [y/N]: n
  Start your free 7-day Pro trial? Sign in with Google, GitHub, or an
  email code; your data still stays on this machine. [Y/n]:
```

- **Plans once** — no repetition per option (test-pinned: $9/$19 appear exactly once), Free correctly says OpenClaw + NVIDIA NemoClaw, detection block's duplicate free line removed.
- **[1] Self-Hosted** (default): have-key → paste/activate; no key → trial sign-in via connect's keep-local mode (new `args.keep_local` bypasses the Case-B re-prompt; marker kept, trial minted+activated by #4237's rail, dashboard ensured); trial declined → free tier with pricing pointer.
- **[2] Cloud**: full connect (marker cleared = the consent), trial minted by connect; E2E encryption named in the copy per founder.
- Headless/EOF/`--local`/env: free local tier, no account — unchanged.

32 tests green (contract rewritten: plans-once, keep_local propagation, per-path marker semantics, free-only machines get no upsell line).

🤖 Generated with [Claude Code](https://claude.com/claude-code)