### PR TITLE
fix(c6): daily ping targets canonical tracking issue #4029 not stale #3864

### DIFF
--- a/.github/workflows/c6-schedule-heal.yml
+++ b/.github/workflows/c6-schedule-heal.yml
@@ -269,7 +269,7 @@ print(json.dumps(sorted(set(a) | set(b))))
         run: |
           TODAY=$(date -u +%Y-%m-%d)
           BODY="<!-- c6-daily-ping --> **C6 daily ping ${TODAY}:** clawmetry/main branch protection does not yet require E2E checks. 6/7 criteria green. Fastest close: [Settings > Branches > main](https://github.com/vivekchand/clawmetry/settings/branches) > Required status checks > add \`E2E Gate (required)\` (60 s, no token needed). Or run \`bash scripts/close-c6.sh\` from a terminal."
-          gh issue comment 3864 --repo vivekchand/clawmetry --body "$BODY"
+          gh issue comment 4029 --repo vivekchand/clawmetry --body "$BODY"
 
       - name: Error: E2E_ADMIN_PAT not set
         if: steps.pat-check.outputs.has_pat == 'false' && steps.read-state.outputs.checks_ok != 'true'


### PR DESCRIPTION
## Summary

`c6-schedule-heal.yml` runs every 2h and posts a daily C6 reminder at 10:15 UTC to nudge the admin to configure required status checks. The `gh issue comment` call was targeting stale issue **#3864** instead of the canonical tracking issue **#4029**.

Result: the daily C6 ping was landing in a stale/duplicate tracker that nobody watches, and issue #4029 (which the cron driver and fire log use) never received those reminders.

**Change:** one-line fix — `3864` → `4029`.

## What changed

`.github/workflows/c6-schedule-heal.yml` line 272:
```diff
-          gh issue comment 3864 --repo vivekchand/clawmetry --body "$BODY"
+          gh issue comment 4029 --repo vivekchand/clawmetry --body "$BODY"
```

No logic changes. All other #4029 references in this file were already correct.

## Acceptance test

After merge, the next 10:15 UTC schedule run of `c6-schedule-heal` (when C6 is still open) will post its daily reminder as a comment on #4029, not #3864.

## Context

- Tracking issue: #4029 (canonical C6 tracker, 6/7 E2E criteria green)
- All other C6 workflows (`c6-health.yml`, `c6-apply-ruleset.yml`, `c6-pr-gate.yml`, `apply-required-checks.yml`) already use #4029 correctly. This was the sole stale reference.
- E2E Robustness cron fire: 2026-07-30T12:45Z

---
_Generated by [Claude Code](https://claude.ai/code/session_017NaBnnFx8iAQeVyqzCRwND)_