### PR TITLE
fix(auth): OTP sign-in is recoverable — typo'd email or missing code never restarts the wizard

### DIFF
--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -600,56 +600,95 @@ def _get_api_key_interactive() -> str:
 
     if not _re.match(r"^[^@]+@[^@]+\.[^@]+$", entry):
         print("  ❌  That doesn't look like a valid email.")
-        return getpass.getpass("  API key (cm_…): ").strip()
+        entry = _input("  📧 Try again — your email: ").strip()
+        if not _re.match(r"^[^@]+@[^@]+\.[^@]+$", entry):
+            return getpass.getpass("  API key (cm_…): ").strip()
 
     email = entry.lower()
-    print(f"\n  📨 Sending code to {email}…", end="", flush=True)
-    r = _api_call("/api/auth/email-otp", {"action": "send", "email": email})
-    if r.get("_status") == 503:
-        import time as _time
 
-        retry_after = r.get("retry_after") or 5
-        try:
-            retry_after = max(1, min(int(retry_after), 30))
-        except (TypeError, ValueError):
-            retry_after = 5
-        print(f"\n  ⏳ Server's busy — retrying in {retry_after}s…", flush=True)
-        _time.sleep(retry_after)
-        print(f"  📨 Sending code to {email}…", end="", flush=True)
-        r = _api_call("/api/auth/email-otp", {"action": "send", "email": email})
+    def _send_code(addr):
+        """Send an OTP to ``addr`` with the 503 backoff. Returns the response."""
+        print(f"\n  📨 Sending code to {addr}…", end="", flush=True)
+        rr = _api_call("/api/auth/email-otp", {"action": "send", "email": addr})
+        if rr.get("_status") == 503:
+            import time as _time
+
+            retry_after = rr.get("retry_after") or 5
+            try:
+                retry_after = max(1, min(int(retry_after), 30))
+            except (TypeError, ValueError):
+                retry_after = 5
+            print(f"\n  ⏳ Server's busy — retrying in {retry_after}s…", flush=True)
+            _time.sleep(retry_after)
+            print(f"  📨 Sending code to {addr}…", end="", flush=True)
+            rr = _api_call("/api/auth/email-otp", {"action": "send", "email": addr})
+        return rr
+
+    # OTP loop with RECOVERY: a typo'd email or a code that never arrives must
+    # never force a restart of the whole wizard (founder live-hit 2026-07-30).
+    # At the code prompt: `r` resends, typing a different email switches to it,
+    # blank input never burns an attempt; even three wrong codes offer a way
+    # back before falling to the paste-an-API-key exit.
+    while True:
+        r = _send_code(email)
         if r.get("_status") == 503:
             print(" ❌")
             print("\n  Couldn't reach our servers right now.")
             print("  Please try `clawmetry connect` again in a minute.\n")
             sys.exit(1)
-    if r.get("error"):
-        print(f" ❌  {r['error']}")
-        print("  Visit https://clawmetry.com/connect to get your API key.")
-        return getpass.getpass("  API key (cm_…): ").strip()
-    print(" ✅")
-    print()
+        if r.get("error"):
+            print(f" ❌  {r['error']}")
+            fix = _input("  Type a corrected email to retry, or press Enter to use an API key instead: ").strip()
+            if "@" in fix:
+                email = fix.lower()
+                continue
+            print("  Visit https://clawmetry.com/connect to get your API key.")
+            return getpass.getpass("  API key (cm_…): ").strip()
+        print(" ✅")
+        print("  Typo in the email, or no code arriving? Type r to resend, or just type the right email.")
+        print()
 
-    # Ask for OTP
-    for attempt in range(3):
-        otp = _input("  🔑 Enter the 6-digit code: ").strip()
-        if not otp:
+        wrong = 0
+        switched = False
+        while wrong < 3:
+            otp = _input("  🔑 Enter the 6-digit code (r = resend): ").strip()
+            if not otp:
+                continue  # a stray Enter must not burn an attempt
+            if otp.lower() in ("r", "resend"):
+                rr = _send_code(email)
+                print(" ✅" if not rr.get("error") and rr.get("_status") != 503 else f" ❌  {rr.get('error', 'server busy')}")
+                continue
+            if "@" in otp:
+                # They typed an email at the code prompt: that IS the typo fix.
+                email = otp.lower()
+                switched = True
+                break
+            print("  Verifying…", end="", flush=True)
+            r2 = _api_call(
+                "/api/auth/email-otp", {"action": "verify", "email": email, "otp": otp}
+            )
+            if r2.get("error"):
+                print(f" ❌  {r2['error']}")
+                wrong += 1
+                if wrong < 3:
+                    print("  Try again (r = resend, or type a different email).")
+                continue
+            api_key = r2.get("api_key", "")
+            if api_key.startswith("cm_"):
+                is_new = r2.get("is_new", False)
+                print(f" ✅  {'Account created' if is_new else 'Welcome back'}!")
+                print()
+                return api_key
+            print(" ❌  Server returned an unexpected response.")
+            wrong += 1
+        if switched:
+            continue  # send a code to the corrected address
+        fix = _input("  Still stuck? Type a different email, r to resend, or press Enter to stop: ").strip()
+        if fix.lower() in ("r", "resend"):
             continue
-        print("  Verifying…", end="", flush=True)
-        r2 = _api_call(
-            "/api/auth/email-otp", {"action": "verify", "email": email, "otp": otp}
-        )
-        if r2.get("error"):
-            print(f" ❌  {r2['error']}")
-            if attempt < 2:
-                print("  Try again.")
+        if "@" in fix:
+            email = fix.lower()
             continue
-        api_key = r2.get("api_key", "")
-        if api_key.startswith("cm_"):
-            is_new = r2.get("is_new", False)
-            print(f" ✅  {'Account created' if is_new else 'Welcome back'}!")
-            print()
-            return api_key
-        print(" ❌  Server returned an unexpected response.")
         break
 
     print()

--- a/tests/test_otp_recovery.py
+++ b/tests/test_otp_recovery.py
@@ -1,0 +1,84 @@
+"""OTP sign-in recovery (founder live-hit 2026-07-30).
+
+A typo'd email or a code that never arrives used to dead-end the wizard:
+no resend, no change-email, a stray Enter burned one of the 3 attempts,
+and three failures dropped to a raw paste-an-API-key prompt. These tests
+drive _get_api_key_interactive with a scripted server + scripted input and
+pin every recovery path.
+"""
+import pytest
+
+import clawmetry.cli as cli
+
+
+class _Server:
+    """Scripted /api/auth/email-otp endpoint; records every call."""
+
+    def __init__(self, good_email="right@x.com", good_otp="123456"):
+        self.calls = []
+        self.good_email = good_email
+        self.good_otp = good_otp
+
+    def post(self, url, body, timeout=15):
+        action = body.get("action")
+        self.calls.append((action, body.get("email"), body.get("otp")))
+        if action == "send":
+            return {}, 200
+        if action == "verify":
+            if body.get("email") == self.good_email and body.get("otp") == self.good_otp:
+                return {"api_key": "cm_recovered", "is_new": True}, 200
+            return {"error": "Invalid code."}, 401
+        return {"error": "unexpected"}, 400
+
+
+@pytest.fixture
+def wizard(monkeypatch):
+    server = _Server()
+    monkeypatch.setattr(cli, "_post_json", server.post)
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+
+    def run(inputs):
+        feed = iter(inputs)
+        monkeypatch.setattr("builtins.input", lambda _p="": next(feed))
+        return cli._get_api_key_interactive(), server
+
+    return run
+
+
+def test_corrected_email_at_code_prompt_resends_and_signs_in(wizard):
+    """Typing the right email AT THE CODE PROMPT switches to it: a new code
+    is sent there and verification succeeds — no restart."""
+    key, server = wizard(["typo@x.com", "right@x.com", "123456"])
+    assert key == "cm_recovered"
+    sends = [c[1] for c in server.calls if c[0] == "send"]
+    assert sends == ["typo@x.com", "right@x.com"]
+    assert ("verify", "right@x.com", "123456") in server.calls
+
+
+def test_r_resends_code_without_burning_attempts(wizard):
+    key, server = wizard(["right@x.com", "r", "r", "123456"])
+    assert key == "cm_recovered"
+    assert [c[0] for c in server.calls].count("send") == 3  # initial + 2 resends
+    assert ("verify", "right@x.com", "123456") in server.calls
+
+
+def test_blank_enter_never_burns_an_attempt(wizard):
+    key, server = wizard(["right@x.com", "", "", "", "", "123456"])
+    assert key == "cm_recovered"
+    assert [c[0] for c in server.calls].count("verify") == 1
+
+
+def test_three_wrong_codes_still_recoverable_with_new_email(wizard):
+    key, server = wizard([
+        "typo@x.com", "000000", "000001", "000002",  # 3 wrong codes
+        "right@x.com",                                # recovery prompt: new email
+        "123456",
+    ])
+    assert key == "cm_recovered"
+    sends = [c[1] for c in server.calls if c[0] == "send"]
+    assert sends == ["typo@x.com", "right@x.com"]
+
+
+def test_invalid_email_gets_one_retry(wizard):
+    key, server = wizard(["not-an-email", "right@x.com", "123456"])
+    assert key == "cm_recovered"


### PR DESCRIPTION
Founder hit it live at the `🔑 Enter the 6-digit code:` prompt: typo'd email / code never arrives → dead end (no resend, no change-email, stray Enter burns an attempt, then a raw API-key prompt). This is the classic OTP abandonment point.

## Recovery loop
- **`r` = resend** at the code prompt (doesn't burn attempts)
- **Typing an email at the code prompt IS the typo fix** — switches to it and sends a fresh code there
- **Blank Enter never burns an attempt** (previously it consumed one of three)
- **Three wrong codes** → one more fork (different email / resend / stop) before the API-key exit
- Send failure → corrected-email retry; invalid email at the chooser → one re-prompt
- A hint line right after send: *"Typo in the email, or no code arriving? Type r to resend, or just type the right email."*

## Tests
5 new in `tests/test_otp_recovery.py`, driving `_get_api_key_interactive` end-to-end against a scripted server: typo→fix-at-code-prompt→signed-in, double-resend, blanks-don't-burn, 3-wrong→new-email→signed-in, invalid-email retry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)