### PR TITLE
fix(connect): Self-Hosted sign-in never touches the cloud dashboard

### DIFF
--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -962,7 +962,8 @@ def _cmd_connect(args) -> None:
     custom_name = getattr(args, "custom_node_id", None) or ""
     machine_hostname = custom_name or socket.gethostname()
     _existing_node_id = _saved_node_id
-    print("Connecting to ClawMetry Cloud… ", end="", flush=True)
+    print("Verifying your account… " if _keep_local_signin
+          else "Connecting to ClawMetry Cloud… ", end="", flush=True)
     try:
         result = validate_key(
             api_key, hostname=machine_hostname, existing_node_id=_existing_node_id
@@ -1002,9 +1003,17 @@ def _cmd_connect(args) -> None:
     _enc_key_arg = getattr(args, "enc_key", None) or ""
     _kc_key = _keychain_get(node_id)  # '' when keyring not installed
 
+    if _keep_local_signin:
+        # No snapshots ever leave on this path — the E2E key ceremony is
+        # noise (and printing a "keep this safe" secret mid-Self-Hosted run
+        # reads like a cloud signup; founder live-hit 2026-07-30).
+        enc_key = _kc_key or _saved_enc_key or generate_encryption_key()
     print()
-    print("🔐 Encryption key protects your data end-to-end.")
-    if _enc_key_arg:
+    if not _keep_local_signin:
+        print("🔐 Encryption key protects your data end-to-end.")
+    if _keep_local_signin:
+        pass  # enc_key already chosen above, silently
+    elif _enc_key_arg:
         enc_key = _derive_key_for_storage(_enc_key_arg)
         print("  Using provided encryption key.")
     elif _kc_key:
@@ -1117,7 +1126,9 @@ def _cmd_connect(args) -> None:
         return
 
     # Skip enc key reminder when --enc-key was passed (automated/sandbox use)
-    if not _enc_key_arg:
+    # and on keep-local sign-ins (no snapshot ever leaves; the secret is
+    # cloud-viewer material and printing it reads like a cloud signup).
+    if not _enc_key_arg and not _keep_local_signin:
         print("  Keep this secret key safe (like a password):")
         print(f"  {enc_key}")
         print()
@@ -1142,6 +1153,22 @@ def _cmd_connect(args) -> None:
         print()
     else:
         _start_daemon(config, args)
+
+    if _keep_local_signin:
+        # Self-Hosted stays self-hosted: no cloud dashboard URL, no secret
+        # in a URL fragment, no browser hand-off to app.clawmetry.com
+        # (founder live-hit 2026-07-30: the keep-local run ended by OPENING
+        # the cloud fleet page — a betrayal of "everything stays on your
+        # devices" even though zero data had synced).
+        print()
+        print("  All done! Your dashboard: http://localhost:8900")
+        print()
+        try:
+            import webbrowser
+            webbrowser.open("http://localhost:8900")
+        except Exception:
+            pass
+        return
 
     # Open browser with encryption key in URL fragment (never sent to server)
     # The #key=... fragment stays client-side — true E2E encryption

--- a/tests/test_onboard_runtime_detection.py
+++ b/tests/test_onboard_runtime_detection.py
@@ -25,9 +25,9 @@ def test_probe_catalogue_covers_all_supported_runtimes():
     """One probe per supported runtime, ids unique, free set exact."""
     ids = [p.id for p in RUNTIME_PROBES]
     assert len(ids) == len(set(ids))
-    assert len(ids) == 14
+    assert len(ids) == 15  # n8n joined 2026-07-30
     assert FREE_RUNTIMES == {"openclaw", "nemoclaw"}
-    for rt in ("claude_code", "cursor", "codex", "qwen_code", "picoclaw"):
+    for rt in ("claude_code", "cursor", "codex", "qwen_code", "picoclaw", "n8n"):
         assert rt in ids
 
 
@@ -130,5 +130,5 @@ def test_probes_never_raise_when_probe_explodes(monkeypatch):
         lambda self: (_ for _ in ()).throw(OSError("boom")),
     )
     results = probe_runtimes()
-    assert len(results) == 14
+    assert len(results) == 15
     assert all(p["found"] is False for p in results)


### PR DESCRIPTION
Founder live-run: Self-Hosted → trial sign-in **worked** (trial active, nocloud marker kept, cloud shows 0 nodes — no data synced) but the finale betrayed it: the E2E key ceremony ran, the secret was printed, and the run ended by **opening app.clawmetry.com/cloud with the key in the URL fragment**. Unacceptable on a path promising "everything stays on your devices" — regardless of zero data leaving.

## Keep-local sign-in now
- "Verifying your account…" instead of "Connecting to ClawMetry Cloud…"
- **No encryption-key ceremony** (nothing is ever encrypted for upload on this path; a key is auto-generated silently for config-shape completeness)
- **No secret printed, no cloud URL, no browser hand-off** — ends at `All done! Your dashboard: http://localhost:8900` and opens localhost instead

## Drive-by
Probe-count asserts 14→15 (n8n joined in #4251; `test_probe_catalogue_covers_all_supported_runtimes` and `test_probes_never_raise_when_probe_explodes` were red on main).

29 onboard/probe tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)