### PR TITLE
feat(license): is_license_valid_at + /api/license/is-valid-at{,-batch}

### DIFF
--- a/clawmetry/license.py
+++ b/clawmetry/license.py
@@ -1912,6 +1912,85 @@ def is_license_valid() -> bool:
     return bool(info.get("valid"))
 
 
+def is_license_valid_at(epoch: int) -> bool:
+    """Boolean gate for "would the installed license have been valid
+    evaluated as of ``epoch``?" -- the perspective-epoch flavour of
+    :func:`is_license_valid`, for a scheduled-audit / retrospective
+    paywall tile that wants to answer "would this node have been
+    entitled on <date>?" without the caller having to snapshot the
+    license state at that time or fold the ``exp`` claim against a
+    caller-supplied epoch themselves.
+
+    Returns ``True`` iff a license is installed, signature-valid, AND
+    either carries no ``exp`` claim (perpetual key) OR ``exp > epoch``.
+    Returns ``False`` for every other state: no license file, invalid
+    signature (an attacker could stuff any tier/nodes/exp into an
+    unsigned body, so we refuse to trust it), and any signed key whose
+    ``exp`` value is at or before ``epoch``.
+
+    Semantics rest on :func:`license_state_at` -- ``"active"`` at the
+    perspective epoch means exactly "signature-valid AND (perpetual OR
+    ``exp > epoch``)", which is the whole is-this-entitled question this
+    predicate answers. So per-value parity with the sibling ``_at``
+    trio (:func:`is_expired_at`, :func:`license_state_at`,
+    :func:`days_until_expiry_at`) is guaranteed at the row level: a UI
+    can zip the four responses index-for-index without ever catching
+    them disagreeing on the same epoch for the same install.
+
+    When ``epoch`` equals "now", this predicate must agree with
+    :func:`is_license_valid` for the same install -- both derive from
+    the same signed ``exp`` claim and share the same signature-check
+    path via :func:`current_license_info`, so the two scalars cannot
+    disagree at the boundary. On any other epoch this helper answers
+    the retrospective / prospective question :func:`is_license_valid`
+    cannot -- e.g. "was this key entitled last Friday?" (positive
+    signal even on a key that has since lapsed) or "will this key be
+    entitled at our next quarterly audit?" (negative signal on an
+    active key whose ``exp`` falls before the audit date).
+
+    ``epoch`` is coerced through ``int()``; ``bool`` is explicitly
+    refused despite being an ``int`` subclass so a caller that passes
+    ``True`` / ``False`` gets ``False`` back rather than a spurious
+    "was the key valid at epoch 1?" answer. A non-numeric value
+    collapses to ``False`` -- the conservative "no entitlement"
+    fallback, matching the never-mis-gate posture of the surrounding
+    ``_at`` family: a mis-typed epoch cannot silently unlock a Pro
+    feature.
+
+    Never raises. Any underlying introspection failure (import error,
+    corrupt install, cryptography-lib mismatch) collapses to ``False``
+    so a scheduled audit job never crashes on a bad install AND never
+    falsely asserts entitlement it can't verify.
+
+    Pairs with :func:`is_expired_at` at the singular level -- the two
+    are complementary on a signature-valid, non-perpetual key
+    (``is_expired_at(e) == not is_license_valid_at(e)``) but diverge on
+    the invalid-signature and no-license branches: those collapse BOTH
+    to ``False`` on purpose, because "not expired" on an unsigned body
+    is not the same as "still entitled". A UI wanting to distinguish
+    "no license" / "broken license" / "lapsed at that time" / "valid
+    at that time" reads this helper together with :func:`is_expired_at`
+    and :func:`license_state_at`.
+    """
+    if isinstance(epoch, bool):
+        # ``bool`` is a subclass of ``int``; refuse it explicitly so a
+        # caller that passes ``True`` doesn't silently ask "was the key
+        # valid at epoch 1?" and get a positive answer back.
+        return False
+    try:
+        wanted = int(epoch)
+    except (TypeError, ValueError):
+        return False
+    try:
+        state = license_state_at(wanted)
+    except Exception as exc:
+        logger.debug(
+            "license: is_license_valid_at underlying read failed: %s", exc
+        )
+        return False
+    return state == "active"
+
+
 def license_subject() -> str | None:
     """Scalar view onto the installed license's ``sub`` claim -- the customer
     identifier the license was issued to (typically an account id or a
@@ -3148,6 +3227,65 @@ def pro_install_age_days_at_batch(epochs) -> list[dict]:
         out.append(
             {"epoch": parsed, "age_days": int(age) if isinstance(age, int) else None}
         )
+    return out
+
+
+def is_license_valid_at_batch(epochs) -> list[dict]:
+    """Per-value perspective-epoch "would the installed license have been
+    valid at each of these epochs?" gate for N epochs in ONE round-trip.
+
+    Per-value axis batch sibling of :func:`is_license_valid_at`. Fills
+    the ``_at_batch`` slot on the entitlement-boolean axis alongside the
+    singular :func:`is_license_valid_at` and the "now" flavour
+    :func:`is_license_valid`, so a scheduled-audit tile that wants to
+    render "was this node entitled on each of these audit dates?" across
+    a sequence of perspective epochs hydrates the whole column in ONE
+    call instead of fanning out N calls to :func:`is_license_valid_at`.
+
+    Row shape::
+
+        {
+          "epoch":    <int> | "<raw>",
+          "is_valid": <bool>,
+        }
+
+    Semantics per row mirror :func:`is_license_valid_at`: ``True`` iff a
+    license is installed, signature-valid, AND either carries no ``exp``
+    claim (perpetual) OR ``exp > epoch``. Every other state -- no
+    license, invalid signature, ``exp <= epoch``, ``bool`` / non-numeric
+    epoch -- yields ``False``. Row shape mirrors
+    :func:`is_expired_at_batch` / :func:`is_state_at_batch` so a caller
+    assembling an entitlement timeline can zip the responses index-for-
+    index; per-row ``is_valid`` is exactly the complement of the
+    matching :func:`is_expired_at_batch` ``expired`` field on a
+    signature-valid, non-perpetual key, and both collapse to ``False``
+    together on the no-license / invalid-signature branches.
+
+    Duplicates by normalised int key (or ``repr(raw)`` for bad inputs)
+    are dropped preserving first-seen order for byte-stable output.
+    ``epochs is None`` or non-iterable -- returns ``[]``. Never raises:
+    per-row failures short-circuit to ``is_valid=False`` so the batch
+    keeps building. Matches the never-mis-gate posture used by
+    :func:`is_license_valid_at` -- a bad row cannot silently unlock a
+    Pro feature retroactively.
+    """
+    out: list[dict] = []
+    for raw, _key, parsed in _license_epoch_batch_keys(epochs):
+        if parsed is None:
+            try:
+                token = str(raw)
+            except Exception:
+                token = repr(raw)
+            out.append({"epoch": token, "is_valid": False})
+            continue
+        try:
+            valid = is_license_valid_at(parsed)
+        except Exception as exc:
+            logger.debug(
+                "license: is_license_valid_at_batch per-row failed: %s", exc
+            )
+            valid = False
+        out.append({"epoch": parsed, "is_valid": bool(valid)})
     return out
 
 

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -10570,6 +10570,106 @@ def api_license_is_expired_at():
     )
 
 
+@bp_entitlement.route("/api/license/is-valid-at")
+def api_license_is_valid_at():
+    """``GET /api/license/is-valid-at?epoch=<int>`` -- boolean gate for
+    "would the installed license have been valid evaluated as of
+    ``epoch``?" -- the perspective-epoch flavour of
+    ``/api/license/status``'s ``valid`` field, for a scheduled-audit /
+    retrospective paywall tile that wants to answer "would this node
+    have been entitled on <date>?" without the caller having to snapshot
+    the license state at that time or fold the ``exp`` claim against a
+    specific epoch themselves.
+
+    Response shape (always HTTP 200)::
+
+        {
+          "is_valid_at": <bool>,             # signature-valid AND (perpetual OR exp > epoch)
+          "requested_epoch": <int|null>,     # int-coerced input, or null on typo
+          "expires_at": <int|null>,          # current on-disk exp for comparison
+          "has_license": <bool>,             # is a license file installed at all?
+          "valid": <bool>                    # signature-valid AND not expired NOW
+        }
+
+    ``is_valid_at`` mirrors :func:`clawmetry.license.is_license_valid_at`:
+
+      * ``false`` when there is no license file, on the invalid-signature
+        branch (payload cannot be trusted -- an attacker could stuff any
+        ``exp`` into an unsigned body), when ``exp <= epoch`` (the key
+        was not yet -- or no longer -- entitled at that perspective), OR
+        when ``epoch`` doesn't parse as an integer.
+      * ``true`` iff the installed key is signature-valid AND either
+        carries no ``exp`` claim (perpetual key) OR ``exp > epoch``.
+
+    Perfect complement to ``/api/license/is-expired-at`` on a signature-
+    valid, non-perpetual key (``is_valid_at`` is the strict negation of
+    ``is_expired_at``), but the two DIVERGE on the invalid-signature and
+    no-license branches: both collapse to ``false`` on purpose, because
+    "not expired" on an unsigned body is not the same as "still
+    entitled". A UI wanting to distinguish "no license" / "broken
+    license" / "lapsed at that time" / "valid at that time" reads this
+    endpoint together with ``/api/license/is-expired-at`` and
+    ``/api/license/state-at``.
+
+    Query parameter:
+
+      * ``epoch`` -- required. Unix epoch seconds as an integer. A
+        missing / non-integer value collapses to ``is_valid_at=false``
+        with ``requested_epoch=null`` so a caller cannot silently mis-
+        gate on a typo. HTTP status is 200 either way -- the "bad input"
+        signal is the ``false`` result, not a 4xx, matching the never-
+        crash posture of the surrounding license endpoints.
+
+    Pairs with ``/api/license/is-expired-at``,
+    ``/api/license/is-expiring-at``, and
+    ``/api/license/days-until-expiry-at`` -- all four share the
+    perspective-epoch input pattern and the
+    :func:`_license_expires_snapshot` reader, so a UI binding any two
+    for the same install cannot catch them disagreeing on ``expires_at``
+    / ``has_license`` / ``valid``. Together they let a dashboard render
+    "on <date>, the license would have been entitled, N days from
+    expiry, matched a specific ``exp`` value, and not yet expired?" from
+    four orthogonal one-shot GETs.
+
+    Never 5xxs -- any underlying failure degrades to
+    ``{is_valid_at: false, requested_epoch: null, expires_at: null,
+    has_license: false, valid: false}`` (the OSS-free branch shape).
+    """
+    raw = request.args.get("epoch", "")
+    try:
+        requested = int(str(raw).strip())
+    except (TypeError, ValueError):
+        requested = None
+    try:
+        snap = _license_expires_snapshot()
+    except Exception as exc:
+        logger.warning("api_license_is_valid_at: snapshot error: %s", exc)
+        snap = {
+            "expires_at": None,
+            "days_until_expiry": None,
+            "has_license": False,
+            "valid": False,
+        }
+    matched = False
+    if requested is not None:
+        try:
+            from clawmetry import license as _lic
+
+            matched = _lic.is_license_valid_at(requested)
+        except Exception as exc:
+            logger.warning("api_license_is_valid_at: derive error: %s", exc)
+            matched = False
+    return jsonify(
+        {
+            "is_valid_at": bool(matched),
+            "requested_epoch": requested,
+            "expires_at": snap["expires_at"],
+            "has_license": snap["has_license"],
+            "valid": snap["valid"],
+        }
+    )
+
+
 def _license_state_at_snapshot() -> dict:
     """Shared one-shot read for the paired ``/api/license/state-at`` and
     ``/api/license/is-state-at`` endpoints below.
@@ -11141,6 +11241,90 @@ def api_license_is_expired_at_batch():
     return jsonify(
         {
             "kind": "is_expired_at",
+            "count": len(rows),
+            "rows": rows,
+            "state": snap["state"],
+            "expires_at": snap["expires_at"],
+            "has_license": snap["has_license"],
+            "valid": snap["valid"],
+        }
+    )
+
+
+@bp_entitlement.route("/api/license/is-valid-at-batch")
+def api_license_is_valid_at_batch():
+    """``GET /api/license/is-valid-at-batch?epochs=<int>,<int>,...``
+    -- per-value batch sibling of ``/api/license/is-valid-at``.
+
+    Entitlement-boolean axis batch companion to
+    ``/api/license/state-at-batch`` /
+    ``/api/license/is-expired-at-batch`` /
+    ``/api/license/days-until-expiry-at-batch``. Where the singular
+    endpoint folds ONE perspective epoch to ONE "was this node
+    entitled?" bool, this preserves per-value rows so a scheduled-audit
+    tile can hydrate a "would we have granted Pro on each of these
+    dates?" column in ONE call instead of fanning out N calls to the
+    scalar endpoint. Wraps :func:`clawmetry.license.is_license_valid_at_batch`.
+
+    Row shape mirrors ``/api/license/is-expired-at-batch`` per-row so a
+    caller assembling an entitlement timeline can zip the two responses
+    index-for-index; ``is_valid`` is exactly the complement of the
+    matching ``expired`` field on a signature-valid, non-perpetual key
+    and both collapse to ``false`` together on the no-license /
+    invalid-signature branches. Same query-string posture: ``epochs=``
+    required (missing / blank / only-commas -> ``400``), comma-separated
+    tokens deduped by parsed int key preserving first-seen order,
+    non-int / ``bool`` / ``None`` tokens collapse to ``is_valid=false``.
+    Never 5xxs.
+
+    Response shape (always HTTP 200)::
+
+        {
+          "kind":  "is_license_valid_at",
+          "count": <int>,
+          "rows":  [
+            {"epoch": <int|"<raw>">, "is_valid": <bool>},
+            ...
+          ],
+          "state":       "<active|expired|invalid|no_license>",  # NOW
+          "expires_at":  <int|null>,
+          "has_license": <bool>,
+          "valid":       <bool>
+        }
+
+    Per-row parity with ``/api/license/is-valid-at?epoch=<n>`` is pinned
+    in the test suite so the batch cannot silently drift from the scalar
+    endpoint. The never-mis-gate posture matches
+    :func:`clawmetry.license.is_license_valid_at`: a bad row cannot
+    silently unlock a Pro feature retroactively.
+    """
+    tokens, err = _parse_license_epochs_csv("epochs")
+    if err == "missing":
+        return jsonify({"error": "missing epochs"}), 400
+    try:
+        snap = _license_state_at_snapshot()
+    except Exception as exc:
+        logger.warning(
+            "api_license_is_valid_at_batch: snapshot error: %s", exc
+        )
+        snap = {
+            "state": "no_license",
+            "expires_at": None,
+            "has_license": False,
+            "valid": False,
+        }
+    try:
+        from clawmetry import license as _lic
+
+        rows = _lic.is_license_valid_at_batch(tokens)
+    except Exception as exc:
+        logger.warning(
+            "api_license_is_valid_at_batch: derive error: %s", exc
+        )
+        rows = []
+    return jsonify(
+        {
+            "kind": "is_license_valid_at",
             "count": len(rows),
             "rows": rows,
             "state": snap["state"],

--- a/tests/test_license_is_valid_at.py
+++ b/tests/test_license_is_valid_at.py
@@ -1,0 +1,762 @@
+"""Tests for the ``is_license_valid_at(epoch)`` scalar helper on
+``clawmetry.license``, the paired ``is_license_valid_at_batch(epochs)``
+batch helper, and the two matching HTTP endpoints
+``GET /api/license/is-valid-at`` and
+``GET /api/license/is-valid-at-batch``.
+
+The perspective-epoch flavour of the ``is_license_valid`` entitlement
+gate. Both derive from the same signed ``exp`` claim so they cannot
+disagree at the boundary when the perspective epoch equals "now"; on
+any other epoch this helper answers "would this node have been entitled
+at ``epoch``?" without the caller having to snapshot the license state
+at that time or fold ``exp`` against a specific epoch themselves.
+
+Hermetic: each test mints tokens with its own ephemeral keypair and
+monkeypatches the module's embedded public key + LICENSE_PATH, mirroring
+``tests/test_license_is_expired_at.py`` and
+``tests/test_license_is_expiring_at_batch.py`` so nothing depends on the
+real production signing key or on real filesystem state.
+"""
+from __future__ import annotations
+
+import time
+from types import SimpleNamespace
+
+import pytest
+from flask import Flask
+
+
+# -- shared helpers (mirror test_license_is_expired_at.py) --------------------
+
+
+def _keypair():
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+    priv = Ed25519PrivateKey.generate()
+    pub_pem = priv.public_key().public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    return priv, pub_pem
+
+
+def _payload(tier="pro", nodes=3, exp_delta=365 * 86400, drop_exp=False):
+    now = int(time.time())
+    p = {
+        "sub": "acct_test",
+        "tier": tier,
+        "nodes": nodes,
+        "iat": now,
+        "exp": now + exp_delta,
+        "features": ["runtimes"],
+    }
+    if drop_exp:
+        p.pop("exp", None)
+    return p
+
+
+@pytest.fixture
+def app(monkeypatch, tmp_path):
+    import clawmetry.license as _lic
+
+    priv, pub_pem = _keypair()
+    monkeypatch.setattr(_lic, "_PUBLIC_KEY_PEM", pub_pem)
+    license_path = str(tmp_path / "license.key")
+    monkeypatch.setattr(_lic, "LICENSE_PATH", license_path)
+    monkeypatch.delenv("CLAWMETRY_LICENSE_SERVER", raising=False)
+    monkeypatch.delenv("CLAWMETRY_INGEST_URL", raising=False)
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("CLAWMETRY_OFFLINE", "1")
+
+    from routes.entitlement import bp_entitlement
+
+    flask_app = Flask(__name__)
+    flask_app.register_blueprint(bp_entitlement)
+    flask_app.config["TESTING"] = True
+
+    return SimpleNamespace(
+        app=flask_app,
+        lic=_lic,
+        priv=priv,
+        license_path=license_path,
+    )
+
+
+def _write_key_direct(app, exp_delta):
+    """Bypass activate() (which refuses expired tokens) and write a token
+    directly to the license file. Simulates a license that expired AFTER
+    it was installed."""
+    import os
+
+    tok = app.lic._encode_token(_payload(exp_delta=exp_delta), app.priv)
+    os.makedirs(os.path.dirname(app.license_path), exist_ok=True)
+    with open(app.license_path, "w", encoding="utf-8") as fh:
+        fh.write(tok)
+
+
+def _write_perpetual(app):
+    import os
+
+    tok = app.lic._encode_token(_payload(drop_exp=True), app.priv)
+    os.makedirs(os.path.dirname(app.license_path), exist_ok=True)
+    with open(app.license_path, "w", encoding="utf-8") as fh:
+        fh.write(tok)
+
+
+def _write_bogus(app):
+    import os
+
+    os.makedirs(os.path.dirname(app.license_path), exist_ok=True)
+    with open(app.license_path, "w", encoding="utf-8") as fh:
+        fh.write("CLAW1.garbage.garbage")
+
+
+# -- clawmetry.license.is_license_valid_at() ---------------------------------
+
+
+def test_is_license_valid_at_no_license(app):
+    """No license file on disk -> False (nothing to trust)."""
+    assert app.lic.is_license_valid_at(int(time.time())) is False
+    assert app.lic.is_license_valid_at(0) is False
+    assert app.lic.is_license_valid_at(2_000_000_000) is False
+
+
+def test_is_license_valid_at_now_matches_is_license_valid_on_active(app):
+    """When ``epoch`` equals "now", the perspective-epoch gate must
+    agree with :func:`is_license_valid` on the same install. Both derive
+    from the same signed ``exp`` claim through :func:`license_state_at`
+    / :func:`current_license_info`, so a UI binding both cannot catch
+    them disagreeing at the boundary."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    now = int(time.time())
+    assert app.lic.is_license_valid_at(now) is True
+    assert app.lic.is_license_valid() is True
+
+
+def test_is_license_valid_at_now_matches_is_license_valid_on_lapsed(app):
+    """A signed-but-lapsed key must return False on the "now"
+    perspective, matching :func:`is_license_valid` -- both use the same
+    ``exp <= now`` cutoff so they cannot disagree at the boundary."""
+    _write_key_direct(app, exp_delta=-5 * 86400)
+    now = int(time.time())
+    assert app.lic.is_license_valid_at(now) is False
+    assert app.lic.is_license_valid() is False
+
+
+def test_is_license_valid_at_future_before_exp(app):
+    """A perspective epoch in the future but still before ``exp`` ->
+    True (the key IS entitled at that perspective)."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    epoch = int(time.time()) + 10 * 86400  # 20 days before exp
+    assert app.lic.is_license_valid_at(epoch) is True
+
+
+def test_is_license_valid_at_future_after_exp(app):
+    """A perspective epoch AFTER ``exp`` on an active key -> False (the
+    key will NOT be entitled at that perspective). Prospective "will
+    this key still be entitled at our next audit?" support scenario."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    epoch = int(time.time()) + 60 * 86400
+    assert app.lic.is_license_valid_at(epoch) is False
+
+
+def test_is_license_valid_at_past_epoch_before_now(app):
+    """A perspective epoch BEFORE the current time on an active key ->
+    True (the key was entitled then, since exp is even further in the
+    future)."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    epoch = int(time.time()) - 10 * 86400
+    assert app.lic.is_license_valid_at(epoch) is True
+
+
+def test_is_license_valid_at_exact_exp_epoch(app):
+    """At the exact ``exp`` second, the predicate must NOT fire -- the
+    ``exp <= epoch`` boundary in :func:`license_state_at` flips ``state``
+    from ``"active"`` to ``"expired"`` at that second inclusive, so
+    ``is_license_valid_at(exp)`` is ``False`` while
+    ``is_license_valid_at(exp - 1)`` is ``True``. This is the exact
+    complement of :func:`is_expired_at` at the boundary."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    info = app.lic.current_license_info()
+    assert isinstance(info, dict)
+    exp = info["exp"]
+    assert app.lic.is_license_valid_at(exp) is False
+    assert app.lic.is_license_valid_at(exp - 1) is True
+
+
+def test_is_license_valid_at_lapsed_key_true_at_pre_lapse_epoch(app):
+    """A lapsed-but-signed key evaluated at a perspective epoch BEFORE
+    its ``exp`` -> True. The retrospective question "was this key
+    entitled a week before it lapsed?" is answerable without special-
+    casing the currently-expired branch, exactly like
+    :func:`is_expired_at` returns False on that same row."""
+    _write_key_direct(app, exp_delta=-5 * 86400)  # exp = now - 5d
+    # Perspective 20 days before now = 15 days before exp -> still entitled.
+    epoch = int(time.time()) - 20 * 86400
+    assert app.lic.is_license_valid_at(epoch) is True
+
+
+def test_is_license_valid_at_perpetual_license(app):
+    """Perpetual (no ``exp``) license -> True regardless of perspective
+    epoch. Matches :func:`license_state_at`'s "``active`` always" branch
+    for perpetual keys (nothing to expire against)."""
+    _write_perpetual(app)
+    assert app.lic.is_license_valid_at(int(time.time())) is True
+    assert app.lic.is_license_valid_at(0) is True
+    assert app.lic.is_license_valid_at(2_000_000_000) is True
+
+
+def test_is_license_valid_at_invalid_signature(app):
+    """File on disk but signature bogus -> False on every epoch. An
+    unsigned body is untrusted whatever the perspective. Deliberately
+    the same False verdict as :func:`is_expired_at` on this branch --
+    both fold to False, but "not expired" is NOT the same as "entitled"
+    on an unsigned body, and callers must distinguish the two via
+    :func:`has_license` / :func:`license_state_at`."""
+    _write_bogus(app)
+    assert app.lic.is_license_valid_at(int(time.time())) is False
+    assert app.lic.is_license_valid_at(2_000_000_000) is False
+
+
+def test_is_license_valid_at_complementary_to_is_expired_at_on_signed_key(app):
+    """On a signature-valid, non-perpetual key,
+    ``is_license_valid_at(e) == not is_expired_at(e)`` at every epoch.
+    Pinned so the two predicates cannot silently drift apart on the
+    happy-path branch a paywall renders every request."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    info = app.lic.current_license_info()
+    exp = int(info["exp"])
+    for epoch in (exp - 10 * 86400, exp - 1, exp, exp + 1, exp + 60 * 86400):
+        assert app.lic.is_license_valid_at(epoch) == (
+            not app.lic.is_expired_at(epoch)
+        ), epoch
+
+
+def test_is_license_valid_at_non_numeric_epoch(app):
+    """A caller passing a typo must get False, not a crash."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    assert app.lic.is_license_valid_at("garbage") is False  # type: ignore[arg-type]
+    assert app.lic.is_license_valid_at(None) is False  # type: ignore[arg-type]
+    assert app.lic.is_license_valid_at([1]) is False  # type: ignore[arg-type]
+    assert app.lic.is_license_valid_at({}) is False  # type: ignore[arg-type]
+
+
+def test_is_license_valid_at_bool_epoch_rejected(app):
+    """``bool`` is an ``int`` subclass -- explicitly refuse it so a
+    caller that passes ``True`` doesn't silently ask "was the key valid
+    at epoch 1?" on a perpetual key and get True back."""
+    _write_perpetual(app)  # perpetual would answer True at epoch=1
+    assert app.lic.is_license_valid_at(True) is False  # type: ignore[arg-type]
+    assert app.lic.is_license_valid_at(False) is False  # type: ignore[arg-type]
+
+
+def test_is_license_valid_at_float_epoch_coerced(app):
+    """Float epoch coerces through ``int()`` -- same posture as
+    :func:`is_expired_at` / :func:`is_expiring_at`."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    now_f = float(time.time())
+    assert app.lic.is_license_valid_at(now_f) is True
+
+
+def test_is_license_valid_at_never_raises(monkeypatch):
+    """Any underlying failure -> False. Even a fully-broken
+    :func:`license_state_at` must not propagate."""
+    import clawmetry.license as _lic
+
+    def _boom(_epoch):
+        raise RuntimeError("simulated corrupt install")
+
+    monkeypatch.setattr(_lic, "license_state_at", _boom)
+    assert _lic.is_license_valid_at(int(time.time())) is False
+
+
+# -- clawmetry.license.is_license_valid_at_batch() ----------------------------
+
+
+def test_batch_none_returns_empty(app):
+    """``epochs is None`` -> ``[]``. Never-raise posture, matches
+    :func:`is_expired_at_batch` / :func:`license_state_at_batch`."""
+    assert app.lic.is_license_valid_at_batch(None) == []
+
+
+def test_batch_non_iterable_returns_empty(app):
+    """Non-iterable ``epochs`` -> ``[]`` rather than a crash."""
+    assert app.lic.is_license_valid_at_batch(42) == []
+
+
+def test_batch_empty_returns_empty(app):
+    """Empty iterable -> ``[]``."""
+    assert app.lic.is_license_valid_at_batch([]) == []
+    assert app.lic.is_license_valid_at_batch(()) == []
+
+
+def test_batch_no_license(app):
+    """No license file -> every row ``is_valid=False`` (nothing to
+    trust). Time-independent, matches the never-mis-gate scalar
+    posture."""
+    rows = app.lic.is_license_valid_at_batch([0, int(time.time()), 2_000_000_000])
+    assert [r["is_valid"] for r in rows] == [False, False, False]
+
+
+def test_batch_active_key_before_and_after_exp(app):
+    """Active key: rows whose ``epoch`` is strictly before ``exp`` fire
+    True; ``epoch == exp`` and rows after fire False. Boundary matches
+    :func:`is_expired_at`'s ``exp <= epoch`` cutoff exactly."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    info = app.lic.current_license_info()
+    exp = int(info["exp"])
+    rows = app.lic.is_license_valid_at_batch(
+        [exp - 86400, exp - 1, exp, exp + 1, exp + 86400]
+    )
+    assert [r["is_valid"] for r in rows] == [True, True, False, False, False]
+
+
+def test_batch_per_row_parity_with_scalar(app):
+    """Per-row parity with :func:`is_license_valid_at` -- the batch
+    cannot silently drift from the scalar. Pin every row against the
+    singular helper on the same install."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    info = app.lic.current_license_info()
+    exp = int(info["exp"])
+    epochs = [exp - 10 * 86400, exp - 1, exp, exp + 1, exp + 60 * 86400]
+    rows = app.lic.is_license_valid_at_batch(epochs)
+    for row, epoch in zip(rows, epochs):
+        assert row["is_valid"] == app.lic.is_license_valid_at(epoch), epoch
+
+
+def test_batch_perpetual_always_fires(app):
+    """Perpetual (no ``exp``) key -> ``is_valid=True`` at every epoch.
+    Mirrors :func:`is_license_valid_at`'s perpetual branch."""
+    _write_perpetual(app)
+    rows = app.lic.is_license_valid_at_batch([0, int(time.time()), 2_000_000_000])
+    assert [r["is_valid"] for r in rows] == [True, True, True]
+
+
+def test_batch_invalid_signature(app):
+    """Bogus-signature file -> ``is_valid=False`` at every epoch (an
+    unsigned body is untrusted whatever the perspective)."""
+    _write_bogus(app)
+    rows = app.lic.is_license_valid_at_batch(
+        [0, int(time.time()), 2_000_000_000]
+    )
+    assert [r["is_valid"] for r in rows] == [False, False, False]
+
+
+def test_batch_lapsed_key_split_around_exp(app):
+    """A signature-valid but currently-lapsed key: rows BEFORE ``exp``
+    still fire True (retrospective "was it entitled then?"), rows AT/
+    after fire False. The batch stays sensitive to the perspective
+    axis rather than folding to a single current-state answer."""
+    _write_key_direct(app, exp_delta=-5 * 86400)  # exp = now - 5d
+    info = app.lic.current_license_info()
+    exp = int(info["exp"])
+    rows = app.lic.is_license_valid_at_batch(
+        [exp - 86400, exp, exp + 1, int(time.time())]
+    )
+    assert [r["is_valid"] for r in rows] == [True, False, False, False]
+
+
+def test_batch_string_int_tokens_parsed(app):
+    """Int-parseable strings coerce cleanly (matches the singular's
+    ``int()`` coercion)."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    info = app.lic.current_license_info()
+    exp = int(info["exp"])
+    rows = app.lic.is_license_valid_at_batch([str(exp - 1), str(exp)])
+    assert [r["is_valid"] for r in rows] == [True, False]
+
+
+def test_batch_dedupes_by_int_key_preserves_order(app):
+    """Duplicates by parsed int key are dropped preserving first-seen
+    order so the response is byte-stable across calls."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    info = app.lic.current_license_info()
+    exp = int(info["exp"])
+    rows = app.lic.is_license_valid_at_batch(
+        [exp - 100, exp - 50, exp - 100, str(exp - 50), exp - 10]
+    )
+    assert [r["epoch"] for r in rows] == [exp - 100, exp - 50, exp - 10]
+
+
+def test_batch_bad_tokens_collapse_to_false(app):
+    """``bool`` / non-numeric / ``None`` collapse to ``is_valid=False``
+    (matches the scalar's rejection). Each bad input keeps its own slot
+    so output length matches N."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    rows = app.lic.is_license_valid_at_batch([True, False, None, "garbage", ""])
+    assert len(rows) == 5
+    assert all(r["is_valid"] is False for r in rows)
+
+
+def test_batch_mixed_good_and_bad(app):
+    """Bad tokens don't fail the whole batch. Good rows resolve; bad
+    rows still slot in with ``is_valid=False``."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    info = app.lic.current_license_info()
+    exp = int(info["exp"])
+    rows = app.lic.is_license_valid_at_batch(
+        [exp - 1, "garbage", exp + 60 * 86400]
+    )
+    assert [r["is_valid"] for r in rows] == [True, False, False]
+
+
+def test_batch_never_raises(monkeypatch):
+    """Any per-row underlying failure of :func:`is_license_valid_at`
+    -> ``is_valid=False`` for THAT row. The batch never propagates."""
+    import clawmetry.license as _lic
+
+    def _boom(_epoch):
+        raise RuntimeError("simulated corrupt install")
+
+    monkeypatch.setattr(_lic, "is_license_valid_at", _boom)
+    rows = _lic.is_license_valid_at_batch([1_700_000_000, 1_800_000_000])
+    assert [r["is_valid"] for r in rows] == [False, False]
+    assert len(rows) == 2
+
+
+def test_batch_complementary_to_is_expired_at_batch_on_signed_key(app):
+    """Per-row: on a signature-valid, non-perpetual key,
+    ``is_valid`` is the strict complement of ``expired`` from
+    :func:`is_expired_at_batch`. Pinned so the two batches cannot drift
+    apart on the happy-path branch that hydrates most paywall tiles."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    info = app.lic.current_license_info()
+    exp = int(info["exp"])
+    epochs = [exp - 10 * 86400, exp - 1, exp, exp + 1, exp + 60 * 86400]
+    valid_rows = app.lic.is_license_valid_at_batch(epochs)
+    expired_rows = app.lic.is_expired_at_batch(epochs)
+    for v_row, e_row in zip(valid_rows, expired_rows):
+        assert v_row["epoch"] == e_row["epoch"]
+        assert v_row["is_valid"] == (not e_row["expired"])
+
+
+# -- GET /api/license/is-valid-at --------------------------------------------
+
+
+def test_endpoint_no_license(app):
+    with app.app.test_client() as c:
+        resp = c.get(f"/api/license/is-valid-at?epoch={int(time.time())}")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["is_valid_at"] is False
+    assert isinstance(data["requested_epoch"], int)
+    assert data["expires_at"] is None
+    assert data["has_license"] is False
+    assert data["valid"] is False
+
+
+def test_endpoint_active_at_now(app):
+    """Active key at "now" -> is_valid_at true, valid true, expires_at
+    populated for the sibling tile that renders the date."""
+    tok = app.lic._encode_token(_payload(exp_delta=45 * 86400), app.priv)
+    app.lic.activate(tok)
+    now = int(time.time())
+    with app.app.test_client() as c:
+        resp = c.get(f"/api/license/is-valid-at?epoch={now}")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["is_valid_at"] is True
+    assert data["requested_epoch"] == now
+    assert isinstance(data["expires_at"], int)
+    assert data["has_license"] is True
+    assert data["valid"] is True
+
+
+def test_endpoint_active_at_future_after_exp(app):
+    """Active key evaluated at a perspective epoch AFTER ``exp`` ->
+    is_valid_at false, valid still true (the key is not expired NOW)."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    epoch = int(time.time()) + 60 * 86400
+    with app.app.test_client() as c:
+        resp = c.get(f"/api/license/is-valid-at?epoch={epoch}")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["is_valid_at"] is False
+    assert data["requested_epoch"] == epoch
+    assert isinstance(data["expires_at"], int)
+    assert data["has_license"] is True
+    assert data["valid"] is True
+
+
+def test_endpoint_lapsed_key_at_now(app):
+    """Lapsed-but-signed key at "now" -> is_valid_at false, valid FALSE.
+    Both signals collapse together on the currently-expired branch."""
+    _write_key_direct(app, exp_delta=-5 * 86400)
+    now = int(time.time())
+    with app.app.test_client() as c:
+        resp = c.get(f"/api/license/is-valid-at?epoch={now}")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["is_valid_at"] is False
+    assert data["has_license"] is True
+    assert data["valid"] is False
+
+
+def test_endpoint_lapsed_key_at_pre_lapse_epoch(app):
+    """Lapsed-but-signed key at a perspective epoch BEFORE its ``exp``
+    -> is_valid_at true (retrospective entitlement), valid still false
+    (key is expired NOW). The predicate flips independently of the
+    current-state validity."""
+    _write_key_direct(app, exp_delta=-5 * 86400)
+    epoch = int(time.time()) - 20 * 86400
+    with app.app.test_client() as c:
+        resp = c.get(f"/api/license/is-valid-at?epoch={epoch}")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["is_valid_at"] is True
+    assert data["has_license"] is True
+    assert data["valid"] is False
+
+
+def test_endpoint_perpetual_license(app):
+    """Perpetual license -> is_valid_at true at any epoch. expires_at
+    null because no ``exp`` claim; has_license true (there IS a file)."""
+    _write_perpetual(app)
+    with app.app.test_client() as c:
+        resp = c.get(f"/api/license/is-valid-at?epoch={int(time.time())}")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["is_valid_at"] is True
+    assert data["expires_at"] is None
+    assert data["has_license"] is True
+
+
+def test_endpoint_missing_epoch_arg(app):
+    """No ``epoch=`` -> is_valid_at false, requested_epoch null, HTTP
+    200. The snapshot still populates expires_at from the on-disk key."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    with app.app.test_client() as c:
+        resp = c.get("/api/license/is-valid-at")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["is_valid_at"] is False
+    assert data["requested_epoch"] is None
+    assert isinstance(data["expires_at"], int)
+    assert data["has_license"] is True
+
+
+def test_endpoint_non_integer_epoch(app):
+    """Typo epoch -> is_valid_at false, requested_epoch null, HTTP 200
+    (never a 4xx). Mirrors the ``/api/license/is-expired-at`` posture."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    with app.app.test_client() as c:
+        resp = c.get("/api/license/is-valid-at?epoch=garbage")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["is_valid_at"] is False
+    assert data["requested_epoch"] is None
+    assert data["has_license"] is True
+
+
+def test_endpoint_invalid_signature(app):
+    """File on disk but signature bogus -> is_valid_at false, has_license
+    True (there IS a file), valid False."""
+    _write_bogus(app)
+    with app.app.test_client() as c:
+        resp = c.get(f"/api/license/is-valid-at?epoch={int(time.time())}")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["is_valid_at"] is False
+    assert data["has_license"] is True
+    assert data["valid"] is False
+
+
+def test_endpoint_never_5xxs(app, monkeypatch):
+    """Even if the shared snapshot blows up mid-request, the endpoint
+    must still return HTTP 200 with the OSS-free shape."""
+    from routes import entitlement as _routes
+
+    monkeypatch.setattr(
+        _routes,
+        "_license_expires_snapshot",
+        lambda: (_ for _ in ()).throw(RuntimeError("simulated blowup")),
+    )
+    epoch = int(time.time())
+    with app.app.test_client() as c:
+        resp = c.get(f"/api/license/is-valid-at?epoch={epoch}")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["is_valid_at"] is False
+    assert data["requested_epoch"] == epoch
+    assert data["expires_at"] is None
+    assert data["has_license"] is False
+    assert data["valid"] is False
+
+
+# -- GET /api/license/is-valid-at-batch --------------------------------------
+
+
+def test_endpoint_batch_missing_epochs(app):
+    """``?epochs=`` absent -> 400 missing epochs (matches the other
+    ``/api/license/*-at-batch`` endpoints)."""
+    with app.app.test_client() as c:
+        resp = c.get("/api/license/is-valid-at-batch")
+    assert resp.status_code == 400
+    assert resp.get_json() == {"error": "missing epochs"}
+
+
+def test_endpoint_batch_blank_epochs(app):
+    """``?epochs=`` blank / only-commas -> 400 missing epochs."""
+    with app.app.test_client() as c:
+        resp = c.get("/api/license/is-valid-at-batch?epochs=")
+        resp2 = c.get("/api/license/is-valid-at-batch?epochs=,,,")
+    assert resp.status_code == 400
+    assert resp2.status_code == 400
+
+
+def test_endpoint_batch_no_license(app):
+    """No license file -> every row ``is_valid=False``, HTTP 200,
+    current-time snapshot fields set to the OSS-free branch shape."""
+    now = int(time.time())
+    with app.app.test_client() as c:
+        resp = c.get(f"/api/license/is-valid-at-batch?epochs={now},0")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["kind"] == "is_license_valid_at"
+    assert data["count"] == 2
+    assert [r["is_valid"] for r in data["rows"]] == [False, False]
+    assert data["state"] == "no_license"
+    assert data["expires_at"] is None
+    assert data["has_license"] is False
+    assert data["valid"] is False
+
+
+def test_endpoint_batch_active_key_boundary(app):
+    """Active key: only rows strictly before ``exp`` fire True. Snapshot
+    reflects current install state."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    info = app.lic.current_license_info()
+    exp = int(info["exp"])
+    csv = ",".join(str(e) for e in [exp - 1, exp, exp + 1])
+    with app.app.test_client() as c:
+        resp = c.get(f"/api/license/is-valid-at-batch?epochs={csv}")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["kind"] == "is_license_valid_at"
+    assert data["count"] == 3
+    assert [r["is_valid"] for r in data["rows"]] == [True, False, False]
+    assert data["state"] == "active"
+    assert isinstance(data["expires_at"], int)
+    assert data["has_license"] is True
+    assert data["valid"] is True
+
+
+def test_endpoint_batch_perpetual_all_true(app):
+    """Perpetual license -> is_valid=True at every epoch."""
+    _write_perpetual(app)
+    csv = ",".join(str(e) for e in [0, int(time.time()), 2_000_000_000])
+    with app.app.test_client() as c:
+        resp = c.get(f"/api/license/is-valid-at-batch?epochs={csv}")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert [r["is_valid"] for r in data["rows"]] == [True, True, True]
+    assert data["expires_at"] is None
+    assert data["has_license"] is True
+
+
+def test_endpoint_batch_per_row_matches_scalar_endpoint(app):
+    """Per-row parity with the scalar endpoint: for every epoch in the
+    batch, ``rows[i].is_valid`` must equal what
+    ``/api/license/is-valid-at?epoch=<epoch>`` returns for that same
+    epoch alone. Pins the batch against the singular endpoint so it
+    cannot drift silently."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    info = app.lic.current_license_info()
+    exp = int(info["exp"])
+    epochs = [exp - 5 * 86400, exp - 1, exp, exp + 1, exp + 30 * 86400]
+    csv = ",".join(str(e) for e in epochs)
+    with app.app.test_client() as c:
+        batch = c.get(f"/api/license/is-valid-at-batch?epochs={csv}").get_json()
+        for row, epoch in zip(batch["rows"], epochs):
+            scalar = c.get(
+                f"/api/license/is-valid-at?epoch={epoch}"
+            ).get_json()
+            assert row["is_valid"] == scalar["is_valid_at"], epoch
+
+
+def test_endpoint_batch_shared_snapshot_matches_is_expired_at_batch(app):
+    """Both ``/api/license/is-valid-at-batch`` and
+    ``/api/license/is-expired-at-batch`` share
+    :func:`_license_state_at_snapshot` -- they must surface identical
+    ``state`` / ``expires_at`` / ``has_license`` / ``valid`` snapshot
+    fields for the same install. Guards a UI that renders the two batch
+    tiles side-by-side from catching them disagreeing on shared fields."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    info = app.lic.current_license_info()
+    exp = int(info["exp"])
+    csv = ",".join(str(e) for e in [exp - 1, exp, exp + 1])
+    with app.app.test_client() as c:
+        a = c.get(f"/api/license/is-valid-at-batch?epochs={csv}").get_json()
+        b = c.get(f"/api/license/is-expired-at-batch?epochs={csv}").get_json()
+    for key in ("state", "expires_at", "has_license", "valid"):
+        assert a[key] == b[key], (
+            f"mismatch on {key}: is-valid-at-batch={a[key]!r} "
+            f"is-expired-at-batch={b[key]!r}"
+        )
+
+
+def test_endpoint_batch_bad_tokens_collapse_to_false(app):
+    """Non-numeric / ``bool``-ish CSV tokens collapse to
+    ``is_valid=false`` with the raw token echoed in ``epoch``. Each row
+    keeps its slot so ``count`` still matches the number of usable
+    tokens after de-dup."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    with app.app.test_client() as c:
+        resp = c.get("/api/license/is-valid-at-batch?epochs=garbage,also-bad")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["count"] == 2
+    assert all(r["is_valid"] is False for r in data["rows"])
+
+
+def test_endpoint_batch_never_5xxs(app, monkeypatch):
+    """Snapshot blowup + underlying batch blowup -> HTTP 200 with the
+    OSS-free branch shape and an empty ``rows`` list rather than a 5xx."""
+    from routes import entitlement as _routes
+    import clawmetry.license as _lic
+
+    monkeypatch.setattr(
+        _routes,
+        "_license_state_at_snapshot",
+        lambda: (_ for _ in ()).throw(RuntimeError("simulated blowup")),
+    )
+
+    def _boom(_epochs):
+        raise RuntimeError("simulated batch blowup")
+
+    monkeypatch.setattr(_lic, "is_license_valid_at_batch", _boom)
+    now = int(time.time())
+    with app.app.test_client() as c:
+        resp = c.get(f"/api/license/is-valid-at-batch?epochs={now}")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["kind"] == "is_license_valid_at"
+    assert data["count"] == 0
+    assert data["rows"] == []
+    assert data["state"] == "no_license"
+    assert data["expires_at"] is None
+    assert data["has_license"] is False
+    assert data["valid"] is False


### PR DESCRIPTION
## Summary

- Adds `is_license_valid_at(epoch)` on `clawmetry.license` -- the perspective-epoch flavour of `is_license_valid()`, i.e. the single "is this node entitled at time T?" gate every paywall tile already binds. Returns `True` iff a license is installed, signature-valid, AND either carries no `exp` claim (perpetual) OR `exp > epoch`. Built on top of `license_state_at()` so per-row parity with the sibling `_at` trio (`is_expired_at`, `license_state_at`, `days_until_expiry_at`) is guaranteed at the row level -- a UI can zip the four responses index-for-index for the same install without catching them disagreeing.
- Adds `is_license_valid_at_batch(epochs)` -- the per-value axis batch sibling. Hydrates N epochs in one call; row shape mirrors `is_expired_at_batch` so a caller assembling an entitlement timeline zips the two responses index-for-index. Never-mis-gate posture matches the rest of the `_at` family: bad epoch (`bool` / non-numeric / `None`) collapses to `is_valid=False` with the row slot preserved; `None` / non-iterable `epochs` -> `[]`.
- Wires `GET /api/license/is-valid-at?epoch=<int>` and `GET /api/license/is-valid-at-batch?epochs=<int>,<int>,...` on `bp_entitlement`. Both share `_license_expires_snapshot` / `_license_state_at_snapshot` with the existing perspective-epoch license endpoints so a UI binding any pair for the same install cannot catch them disagreeing on `expires_at` / `has_license` / `valid`. Never 5xx -- underlying failures degrade to the OSS-free branch shape. Missing / blank / only-commas `epochs=` on the batch endpoint -> `400`, matching the sibling `/api/license/*-at-batch` endpoints.
- Ships a 49-test hermetic suite covering the no-license / active / lapsed / perpetual / invalid-signature branches, "now" boundary parity with `is_license_valid`, exact-`exp` boundary complement with `is_expired_at`, `bool` / non-numeric / float epoch handling, per-row parity with the scalar helper AND the scalar endpoint, shared-snapshot consistency with `/api/license/is-expired-at-batch`, and never-5xxs under shared-snapshot + batch blowup.

Zero behavior change to existing code paths (the resolved entitlement / paywall gate posture is unchanged). This just fills the `_at` / `_at_batch` slot on the entitlement-boolean axis so callers stop composing the answer client-side from `is_expired_at` + `has_license` + signature-check.

## Test plan

- [x] `python -m py_compile clawmetry/license.py routes/entitlement.py tests/test_license_is_valid_at.py`
- [x] `ruff check clawmetry/license.py routes/entitlement.py tests/test_license_is_valid_at.py` -- All checks passed
- [x] `python -m pytest tests/test_license_is_valid_at.py` -- 49 passed
- [x] Regression: `python -m pytest tests/test_license_is_expired_at.py tests/test_license_is_expiring_at_batch.py tests/test_license_state_at_batch.py tests/test_license_is_state_at_batch.py` -- 139 passed
- [x] `make lint-daemon-allowlist` failure noted on the base branch as well (unrelated: `query_cache_metrics` / `query_channel_delivery_health` on routes/usage.py / routes/channels.py) -- not touched by this PR

### Local operator verification checklist

I cannot reach the running daemon or the live snapshot from this environment. Before flipping to ready-for-review / merging:

- [ ] Copy the changed files into the installed package:
      `cp clawmetry/license.py routes/entitlement.py tests/test_license_is_valid_at.py ~/.clawmetry/lib/python3.<X>/site-packages/clawmetry/` (adjust path for the license.py -> package layout; `routes/entitlement.py` lands under the `routes/` package on the same prefix)
- [ ] Clear `__pycache__` under the site-packages layout:
      `find ~/.clawmetry -name __pycache__ -exec rm -rf {} +`
- [ ] Restart the sync daemon so the new endpoint is registered:
      `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
- [ ] Hit `curl -sS http://localhost:8900/api/license/is-valid-at?epoch=$(date +%s) | jq` and confirm the response shape matches the scalar docstring
- [ ] Hit `curl -sS "http://localhost:8900/api/license/is-valid-at-batch?epochs=$(date +%s),$(( $(date +%s) + 86400 ))" | jq` and confirm the batch shape matches the batch docstring, with per-row parity vs the scalar endpoint
- [ ] Decrypt the live cloud snapshot and confirm the daemon relay still forwards `/api/license/*` traffic unchanged
- [ ] Browser-check the paywall tile that already binds `is_license_valid` -- it should render identically (no rebinding was done in this PR)

## Rollout posture

- No `__version__` bump, no `[RELEASE]` PR, no tag.
- No enforce-mode change: the entitlement layer stays in GRACE. This helper only fills a query slot; no gate hardens as a result.
- Draft PR only. Operator drives the sequence above (site-packages copy -> daemon restart -> live verification -> ready-for-review / merge / release).

---
_Generated by [Claude Code](https://claude.ai/code/session_01JKjCY4WZFJNm5ipzf7X8No)_