### PR TITLE
fix(install): self-heal ghost installs with missing console script + timeout rollback

### DIFF
--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -15,6 +15,16 @@ jobs:
         run: bash install.sh
       - name: Verify clawmetry binary
         run: clawmetry --version
+      # Ghost-install repair: a pip/uv killed mid-install leaves site-packages
+      # claiming "latest" while the console script is missing, so a plain
+      # --upgrade re-run no-ops and the symlink dangles (seen live 2026-07-30).
+      # The installer must detect the missing entry point and force-reinstall.
+      - name: Simulate ghost install (delete entry point)
+        run: sudo rm /opt/clawmetry/bin/clawmetry
+      - name: Re-run install script (must self-heal)
+        run: bash install.sh
+      - name: Verify clawmetry binary healed
+        run: clawmetry --version
 
   test-macos:
     runs-on: macos-latest
@@ -25,6 +35,13 @@ jobs:
       - name: Add bin to PATH
         run: echo "$HOME/.local/bin" >> $GITHUB_PATH
       - name: Verify clawmetry binary
+        run: clawmetry --version
+      # Same ghost-install repair check as test-linux (macOS install dir).
+      - name: Simulate ghost install (delete entry point)
+        run: rm "$HOME/.clawmetry/bin/clawmetry"
+      - name: Re-run install script (must self-heal)
+        run: bash install.sh
+      - name: Verify clawmetry binary healed
         run: clawmetry --version
 
   test-windows-ps:

--- a/install.sh
+++ b/install.sh
@@ -284,12 +284,32 @@ if [ -n "$_CM_CFG_BAK" ] && [ -f "$_CM_CFG_BAK" ]; then
   rm -f "$_CM_CFG_BAK"
 fi
 
+# ── Self-heal: console script missing despite "latest" metadata ─────────────
+# A pip/uv install killed mid-flight (daemon self-update timeout, Ctrl-C'd
+# installer) can leave site-packages claiming the latest version is installed
+# while bin/clawmetry is GONE — the wheel's files land before entry points are
+# generated. The --upgrade installs above then no-op ("already latest") and
+# the symlink below dangles (bash: ~/.local/bin/clawmetry: No such file or
+# directory — seen live 2026-07-30). Force-reinstall regenerates the scripts.
+if [ ! -x "$INSTALL_DIR/bin/clawmetry" ]; then
+  if [ -n "${_UV_BIN:-}" ]; then
+    _step "Repairing clawmetry entry point (force reinstall)" 5 \
+      $USE_SUDO "$_UV_BIN" pip install --python "$INSTALL_DIR/bin/python3" --quiet --force-reinstall --no-deps clawmetry
+  else
+    $USE_SUDO "$INSTALL_DIR/bin/python3" -m ensurepip --upgrade --default-pip >/dev/null 2>&1 || true
+    _step "Repairing clawmetry entry point (force reinstall)" 15 \
+      $USE_SUDO "$INSTALL_DIR/bin/python3" -m pip install --no-cache-dir --force-reinstall --no-deps clawmetry
+  fi
+fi
+
 # Create symlink
 mkdir -p "$BIN_DIR" 2>/dev/null || $USE_SUDO mkdir -p "$BIN_DIR"
 $USE_SUDO ln -sf "$INSTALL_DIR/bin/clawmetry" "$BIN_DIR/clawmetry"
 
 CLAWMETRY_BIN="$BIN_DIR/clawmetry"
-CLAWMETRY_VERSION=$("$INSTALL_DIR/bin/python3" -c "import importlib.metadata; print(importlib.metadata.version('clawmetry'))" 2>/dev/null || echo "installed")
+# -I (isolated) keeps CWD off sys.path — run from a source checkout, the
+# repo's stale egg-info otherwise shadows the venv and misreports the version.
+CLAWMETRY_VERSION=$("$INSTALL_DIR/bin/python3" -I -c "import importlib.metadata; print(importlib.metadata.version('clawmetry'))" 2>/dev/null || echo "installed")
 
 # ── Restart launchd jobs (macOS) ─────────────────────────────────────────────
 # After a venv reinstall, the dashboard/sync daemons launched at boot are

--- a/routes/meta.py
+++ b/routes/meta.py
@@ -445,6 +445,32 @@ def perform_self_update(reason: str = "manual", restart: bool = True,
     # Also clean up any .exe.old stubs from a prior failed attempt first.
     _win_cleanup_old_exe_stubs()
     _exe_orig, _exe_old = _win_rename_exe_before_pip()
+    def _restore_old_install():
+        # Roll the node back to a known-good state after a failed/killed pip.
+        # Windows: restore the renamed exe so the launcher still works. All
+        # platforms: pip-reinstall the old version so the node is never left
+        # with zero working installs. A pip KILLED mid-install (timeout below)
+        # lays down the new wheel's files but never generates the console
+        # scripts — site-packages then claims "latest" while bin/clawmetry is
+        # gone, and every later plain `pip install --upgrade` no-ops on that
+        # metadata (ghost-install, seen live 2026-07-30). --force-reinstall
+        # regenerates the entry points regardless of what metadata claims.
+        if _exe_old is not None:
+            try:
+                if _exe_old.exists() and not _exe_orig.exists():
+                    _exe_old.rename(_exe_orig)
+            except Exception:
+                pass
+        try:
+            _sp.run(
+                [py, "-m", "pip", "install", "--no-cache-dir",
+                 "--force-reinstall", "--no-deps",
+                 f"clawmetry=={old_version}"],
+                timeout=180, capture_output=True, text=True,
+            )
+        except Exception:
+            pass
+
     try:
         proc = _sp.run(
             # --no-cache-dir dodges the uv-cache-stale-after-[RELEASE] race
@@ -457,28 +483,15 @@ def perform_self_update(reason: str = "manual", restart: bool = True,
             # Surface pip's actual last lines so the banner is actionable —
             # the old code swallowed everything into DEVNULL.
             tail = ((proc.stdout or "") + (proc.stderr or "")).strip()[-800:]
-            # Windows: restore the renamed exe so the launcher still works,
-            # then pip-reinstall the old version so the node is never left with
-            # zero working installs after a partial uninstall-then-failed-install.
-            if _exe_old is not None:
-                try:
-                    if _exe_old.exists() and not _exe_orig.exists():
-                        _exe_old.rename(_exe_orig)
-                except Exception:
-                    pass
-            try:
-                _sp.run(
-                    [py, "-m", "pip", "install", "--no-cache-dir",
-                     f"clawmetry=={old_version}"],
-                    timeout=180, capture_output=True, text=True,
-                )
-            except Exception:
-                pass
+            _restore_old_install()
             return {"ok": False,
                     "error": f"pip exit {proc.returncode}: {tail or '(no output)'}"}, 500
     except _sp.TimeoutExpired:
+        # The killed pip may have left a scriptless half-install — roll back.
+        _restore_old_install()
         return {"ok": False, "error": "pip install timed out after 180s"}, 500
     except Exception as exc:
+        _restore_old_install()
         return {"ok": False, "error": str(exc)}, 500
     # Re-read new version from pip metadata
     new_version = old_version

--- a/tests/test_install_script_ghost_selfheal.py
+++ b/tests/test_install_script_ghost_selfheal.py
@@ -1,0 +1,94 @@
+"""Regression tests for install.sh ghost-install self-heal (2026-07-30).
+
+A pip/uv install killed mid-flight (the daemon self-update's 180s timeout, a
+Ctrl-C'd installer) lays down the new wheel's package files but never
+generates the console scripts: site-packages then claims the latest version
+is installed while ``$INSTALL_DIR/bin/clawmetry`` is gone. Every later plain
+``pip/uv install --upgrade`` no-ops against that metadata, so install.sh used
+to "succeed" while leaving the ``$BIN_DIR/clawmetry`` symlink dangling
+(``bash: ~/.local/bin/clawmetry: No such file or directory`` — seen live on
+the founder's machine, forensics: dist-info with no INSTALLER file and no
+``bin/`` entries in RECORD).
+
+install.sh must therefore check for the entry point after the install step
+and force-reinstall when it is missing. The behavioural proof lives in
+``.github/workflows/install-test.yml`` (delete the entry point, re-run the
+installer, assert ``clawmetry --version`` works); these tests pin the code
+paths so they don't silently regress on a refactor.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+INSTALL_SH = REPO_ROOT / "install.sh"
+
+
+def _read_install_sh() -> str:
+    assert INSTALL_SH.exists(), f"install.sh missing at {INSTALL_SH}"
+    return INSTALL_SH.read_text()
+
+
+def test_install_sh_syntax_is_valid() -> None:
+    bash = shutil.which("bash")
+    assert bash, "bash not found on PATH — required to syntax-check install.sh"
+    result = subprocess.run(
+        [bash, "-n", str(INSTALL_SH)], capture_output=True, text=True,
+    )
+    assert result.returncode == 0, f"bash -n failed: {result.stderr}"
+
+
+def test_selfheal_block_force_reinstalls_missing_entry_point() -> None:
+    body = _read_install_sh()
+    assert 'if [ ! -x "$INSTALL_DIR/bin/clawmetry" ]; then' in body, (
+        "self-heal guard missing: install.sh must check the console script "
+        "exists after the install step (a pip killed mid-install leaves "
+        "metadata claiming latest with no bin/clawmetry)"
+    )
+    assert "--force-reinstall" in body, (
+        "self-heal must use --force-reinstall — a plain install/--upgrade "
+        "no-ops against the ghost install's (lying) 'latest' metadata"
+    )
+
+
+def test_selfheal_runs_before_symlink_creation() -> None:
+    """The $BIN_DIR/clawmetry symlink must be created AFTER the self-heal so
+    it can never point at a still-missing target."""
+    body = _read_install_sh()
+    heal_idx = body.find('if [ ! -x "$INSTALL_DIR/bin/clawmetry" ]; then')
+    link_idx = body.find('ln -sf "$INSTALL_DIR/bin/clawmetry"')
+    assert heal_idx != -1 and link_idx != -1
+    assert heal_idx < link_idx, (
+        "self-heal block must run before the $BIN_DIR/clawmetry symlink is "
+        "created"
+    )
+
+
+def test_selfheal_covers_both_uv_and_pip_paths() -> None:
+    """The repair must work whether or not uv is available: uv venvs ship
+    without pip, so the pip fallback must bootstrap it via ensurepip."""
+    body = _read_install_sh()
+    heal = body[body.find('if [ ! -x "$INSTALL_DIR/bin/clawmetry" ]; then'):]
+    heal = heal[: heal.find("# Create symlink")]
+    assert '"$_UV_BIN" pip install' in heal, "uv repair path missing"
+    assert "-m ensurepip" in heal, (
+        "pip repair path must bootstrap pip via ensurepip (uv venvs have none)"
+    )
+    assert '"$INSTALL_DIR/bin/python3" -m pip install' in heal, (
+        "pip repair fallback missing"
+    )
+
+
+def test_version_probe_uses_isolated_mode() -> None:
+    """The installed-version banner must probe with ``python3 -I`` — run from
+    a source checkout, CWD lands on sys.path and the repo's stale egg-info
+    shadows the venv (the installer printed 0.12.552 while 0.12.595 was on
+    disk, 2026-07-30)."""
+    body = _read_install_sh()
+    assert '-I -c "import importlib.metadata' in body, (
+        "CLAWMETRY_VERSION probe must pass -I (isolated mode) so a source "
+        "checkout's egg-info can't misreport the installed version"
+    )

--- a/tests/test_self_update_timeout_rollback.py
+++ b/tests/test_self_update_timeout_rollback.py
@@ -1,0 +1,123 @@
+"""perform_self_update must roll back to a known-good install when pip fails
+OR is killed by its 180s timeout (ghost-install fix, 2026-07-30).
+
+A pip KILLED mid-install (TimeoutExpired) lays down the new wheel's package
+files but never generates the console scripts: site-packages then claims the
+new version is installed while ``bin/clawmetry`` is gone, and every later
+plain ``pip install --upgrade`` no-ops against that metadata. The node is
+left with a dangling ``~/.local/bin/clawmetry`` symlink (seen live on the
+founder's machine: dist-info with no INSTALLER file and no ``bin/`` entries
+in RECORD, created the second the auto-updater fired).
+
+Before this fix only the pip-exit-nonzero branch rolled back; the
+TimeoutExpired branch returned without any repair — and the timeout kill is
+exactly the failure mode that strands the ghost state. The rollback must use
+``--force-reinstall`` so the entry points are regenerated regardless of what
+the (lying) metadata claims.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import types
+
+
+def _fake_completed(returncode=0, stdout="", stderr=""):
+    return types.SimpleNamespace(
+        returncode=returncode, stdout=stdout, stderr=stderr,
+    )
+
+
+def _patched_run(calls, upgrade_behaviour):
+    """A subprocess.run stand-in: records every command, applies
+    ``upgrade_behaviour`` to the main ``pip install --upgrade`` call and
+    succeeds everything else (ensurepip, the rollback install)."""
+
+    def _run(cmd, *a, **k):
+        cmd = list(cmd)
+        calls.append(cmd)
+        if "--upgrade" in cmd and "ensurepip" not in cmd:
+            return upgrade_behaviour(cmd)
+        return _fake_completed()
+
+    return _run
+
+
+def _rollback_calls(calls, old_version):
+    return [
+        c for c in calls
+        if "--force-reinstall" in c and f"clawmetry=={old_version}" in c
+    ]
+
+
+def test_timeout_rolls_back_with_force_reinstall(monkeypatch):
+    import dashboard
+    from routes import meta
+
+    calls = []
+
+    def _timeout(cmd):
+        raise subprocess.TimeoutExpired(cmd, 180)
+
+    monkeypatch.setattr(subprocess, "run", _patched_run(calls, _timeout))
+    payload, status = meta.perform_self_update(reason="test-timeout")
+
+    assert payload["ok"] is False
+    assert status == 500
+    assert "timed out" in payload["error"]
+    rollbacks = _rollback_calls(calls, dashboard.__version__)
+    assert rollbacks, (
+        "TimeoutExpired must trigger a pip rollback to the old version with "
+        "--force-reinstall — a pip killed mid-install leaves a scriptless "
+        f"half-install that a plain install can't repair. Calls seen: {calls}"
+    )
+
+
+def test_pip_failure_rolls_back_with_force_reinstall(monkeypatch):
+    import dashboard
+    from routes import meta
+
+    calls = []
+
+    def _fail(cmd):
+        return _fake_completed(returncode=1, stderr="boom")
+
+    monkeypatch.setattr(subprocess, "run", _patched_run(calls, _fail))
+    payload, status = meta.perform_self_update(reason="test-pip-fail")
+
+    assert payload["ok"] is False
+    assert status == 500
+    rollbacks = _rollback_calls(calls, dashboard.__version__)
+    assert rollbacks, (
+        "a nonzero pip exit must trigger a --force-reinstall rollback to the "
+        f"old version. Calls seen: {calls}"
+    )
+
+
+def test_success_does_not_roll_back(monkeypatch):
+    import dashboard
+    from routes import meta
+
+    calls = []
+    monkeypatch.setattr(
+        subprocess, "run",
+        _patched_run(calls, lambda cmd: _fake_completed()),
+    )
+    # The pip-show version re-read uses check_output; stub it. Keep the
+    # crash-loop rollback guard from touching real ~/.clawmetry state.
+    monkeypatch.setattr(
+        subprocess, "check_output",
+        lambda *a, **k: b"Version: 0.0.0\n",
+    )
+    from clawmetry import update_guard
+    monkeypatch.setattr(
+        update_guard, "arm_rollback_guard", lambda *a, **k: None,
+    )
+    payload, status = meta.perform_self_update(
+        reason="test-ok", restart=False,
+    )
+    assert payload["ok"] is True
+    assert status == 200
+    assert not _rollback_calls(calls, dashboard.__version__), (
+        "a successful upgrade must not trigger a rollback"
+    )


### PR DESCRIPTION
## Why

Live failure on 2026-07-30: `curl clawmetry.com/install.sh | bash` printed success but ended with `bash: line 792: ~/.local/bin/clawmetry: No such file or directory`, and the dashboard launchd job could not start.

Root cause: a pip killed mid-install (the daemon self-update's 180s timeout; PyPI propagation lag made it retry) lays down the new wheel's package files but never generates console scripts. site-packages then claims the latest version is installed while `bin/clawmetry` is GONE (forensics: dist-info with no `INSTALLER` file, RECORD with no `bin/` entries). Every later plain `pip/uv install --upgrade` no-ops against that metadata, so the installer could not repair the state and its `~/.local/bin/clawmetry` symlink dangled.

## What

- **install.sh self-heal**: after the install step, if `$INSTALL_DIR/bin/clawmetry` is missing, force-reinstall (`--force-reinstall --no-deps`) to regenerate entry points. uv path + ensurepip/pip fallback (uv venvs ship without pip). Runs before the symlink is created.
- **install.sh version probe**: `python3 -I` so a source checkout's stale egg-info can't shadow the venv (the banner printed 0.12.552 while 0.12.595 was on disk).
- **routes/meta.py**: `perform_self_update` now rolls back on `TimeoutExpired` and generic exceptions too — previously only the nonzero-exit branch did, and the timeout kill is exactly the failure mode that strands the ghost state. Rollback upgraded to `--force-reinstall --no-deps`.
- **Guards (same PR)**:
  - `install-test.yml`: behavioural check on linux+macos — install, delete the entry point, re-run `install.sh`, assert `clawmetry --version` works.
  - `tests/test_install_script_ghost_selfheal.py`: pins the self-heal block, its ordering before the symlink, both uv/pip paths, and the `-I` probe.
  - `tests/test_self_update_timeout_rollback.py`: rollback fires on timeout and pip failure with `--force-reinstall`; success path does not roll back.

## Verification

- Reproduced the ghost state on the affected machine (deleted `~/.clawmetry/bin/clawmetry`), ran the patched installer: the "Repairing clawmetry entry point (force reinstall)" step fired and `clawmetry --version` → 0.12.595, dashboard back to HTTP 200.
- Revert-proof: with the fix stashed, 6 of the 8 new tests fail; with it restored, 8/8 pass.
- `shellcheck install.sh` clean; neighboring suites (`test_auto_update*`, `test_install_script_*`) pass except `test_auto_update_fast_loop.py::test_exec_restart_kill_switch`, which fails identically on clean `origin/main` (pre-existing, unrelated).

Note for deploy: `clawmetry.com/install.sh` is served from clawmetry-landing's copy — I'll sync it there after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)