### PR TITLE
fix(sync): keepalive heartbeat during long ingest — Brain time-window relay starvation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,4 +179,5 @@ DEBUG=1                                # Enable debug logging
 - **Read-only by default** — ClawMetry observes, it doesn't modify agent behavior (except cron management via gateway RPC).
 - **Auto-detect everything** — users should never need to configure anything manually.
 - **Never crash on bad input** — graceful fallbacks for missing data, log warnings but continue.
+- **Never starve the heartbeat** — the cloud relay drains and answers `pending_queries` (Brain time-window fetches, transcript reads, approvals) only when the daemon heart-beats, and the heartbeat fires at the end of a main-loop iteration. Any ingest pass that can run long (deep `runtime_backfill`, first-run ingest of hundreds of sessions) must call `_ingest_keepalive_heartbeat(config)` between items, or every hosted relay read sits on `relay_pending` until the browser gives up (2026-07-30 Brain-window RCA: a 465-session backfill blocked heartbeats for ~2m40s).
 - **snake_case** functions, **PascalCase** classes, **SCREAMING_SNAKE_CASE** constants.

--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -7091,15 +7091,22 @@ async function loadBrainPage(silent) {
     var data = await _bhRaw.json();
     if (_bhRange !== _brainRange) return; // stale response for an old range
     // Hosted relay warm-up: the cloud answered "asked your node, poll me
-    // again" — show an honest status and retry a few times (the node
-    // answers within one heartbeat when it is online).
+    // again" — show an honest status and keep polling. Budget: a node
+    // mid-ingest (e.g. a deep runtime backfill) can hold its next heartbeat
+    // for 2-3 minutes, so allow ~5 min (12 quick polls, then 10s apart)
+    // before declaring failure. The old 12-poll (~40s) budget was shorter
+    // than one busy heartbeat and produced false "could not reach your
+    // node" errors while the node was fine (2026-07-30 window RCA).
     if (_bhRange && data && data._source === 'relay_pending') {
       var stEl = document.getElementById('brain-history-banner-status');
-      if (stEl) stEl.textContent = t('brain.window_fetching', null, 'Fetching this window from your node…');
-      if (_brainRangeRetries++ < 12) {
+      var _bhTry = _brainRangeRetries++;
+      if (stEl) stEl.textContent = _bhTry < 12
+        ? t('brain.window_fetching', null, 'Fetching this window from your node…')
+        : t('brain.window_fetching_busy', null, 'Your node is busy syncing — still fetching this window…');
+      if (_bhTry < 36) {
         setTimeout(function() {
           if (_bhRange === _brainRange) loadBrainPage(true);
-        }, Math.max(2000, (data.eta_sec || 3) * 1000));
+        }, _bhTry < 12 ? Math.max(2000, (data.eta_sec || 3) * 1000) : 10000);
       } else {
         var sEl2 = document.getElementById('brain-stream');
         if (sEl2) sEl2.innerHTML = '<div style="color:var(--text-muted);padding:20px;font-size:13px;">' + t('brain.window_node_offline', null, 'Could not reach your node for this window. Check that the machine is online, then retry.') + '</div>';

--- a/clawmetry/static/locales/en.json
+++ b/clawmetry/static/locales/en.json
@@ -549,6 +549,7 @@
   "brain.view_toggle_tooltip": "Switch between list view and neural-network view",
   "brain.viewing_history": "Viewing history",
   "brain.window_fetching": "Fetching this window from your node…",
+  "brain.window_fetching_busy": "Your node is busy syncing — still fetching this window…",
   "brain.window_node_offline": "Could not reach your node for this window. Check that the machine is online, then retry.",
   "budget.add_alert_rule": "+ Add Alert Rule",
   "budget.agent_error_alerts": "Agent error rate alerts",

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -11929,6 +11929,42 @@ def _session_idle_gaps(events, ttl_sec: int = 300) -> dict:
     return out
 
 
+# ── Ingest keepalive heartbeat ──────────────────────────────────────────────
+# The cloud relay drains `pending_queries` (Brain time-window fetches,
+# transcript reads, approvals) ONLY when this daemon heart-beats, but the
+# heartbeat fires at the END of a main-loop iteration. A long synchronous
+# ingest pass — e.g. a `runtime_backfill` action raising the claude_code depth
+# from 50 to 465 sessions (~47k events, minutes of work) — therefore starved
+# the heartbeat and every hosted relay read sat on `relay_pending` until the
+# browser gave up ("Could not fetch this window from your node yet",
+# 2026-07-30). Heavy per-item loops call this between items; it re-sends the
+# heartbeat (which drains + answers pending queries as a side effect) at most
+# every _INGEST_KEEPALIVE_SEC.
+
+_INGEST_KEEPALIVE_SEC = 20.0
+_last_ingest_keepalive = 0.0
+
+
+def _ingest_keepalive_heartbeat(config: dict) -> bool:
+    """Throttled mid-ingest heartbeat. Returns True when a heartbeat was
+    actually attempted (test hook). Never raises — a keepalive failure must
+    not break the ingest pass it is protecting."""
+    global _last_ingest_keepalive
+    now = time.time()
+    if now - _last_ingest_keepalive < _INGEST_KEEPALIVE_SEC:
+        return False
+    _last_ingest_keepalive = now
+    try:
+        from clawmetry.config import is_cloud_disabled
+        if is_cloud_disabled():
+            return False
+        send_heartbeat(config)
+        return True
+    except Exception as e:
+        log.debug("ingest keepalive heartbeat failed (non-fatal): %s", e)
+        return True
+
+
 def sync_family_runtimes(config: dict, state: dict, paths: dict) -> int:
     """Ingest PicoClaw + NanoClaw sessions into DuckDB (and the cloud) so they
     appear in the sessions list + transcripts the same way OpenClaw does.
@@ -11982,6 +12018,9 @@ def sync_family_runtimes(config: dict, state: dict, paths: dict) -> int:
                 continue
             runtime = adapter.name
             for s in adapter.list_sessions(limit=_effective_family_limit(runtime)):
+                # A deep pass (runtime_backfill) makes this loop run for
+                # minutes; keep the relay responsive between sessions.
+                _ingest_keepalive_heartbeat(config)
                 if runtime == "claude_code" and s.id in openclaw_spawned_claude:
                     continue  # owned by OpenClaw; avoid the double-count
                 ns_id = f"{runtime}:{s.id}"

--- a/tests/test_ingest_keepalive.py
+++ b/tests/test_ingest_keepalive.py
@@ -1,0 +1,96 @@
+"""Ingest keepalive heartbeat (2026-07-30 Brain-window RCA).
+
+A long synchronous ingest pass (e.g. a `runtime_backfill` raising the
+claude_code depth from 50 to 465 sessions ≈ minutes of work) used to starve
+the heartbeat, so the cloud relay's pending_queries (Brain time-window
+fetches) sat undrained until the browser gave up with "Could not fetch this
+window from your node yet". `_ingest_keepalive_heartbeat` re-sends the
+heartbeat mid-loop, throttled to `_INGEST_KEEPALIVE_SEC`.
+"""
+from __future__ import annotations
+
+import types
+
+import pytest
+
+import clawmetry.sync as sync
+
+
+@pytest.fixture(autouse=True)
+def _reset_keepalive_clock():
+    sync._last_ingest_keepalive = 0.0
+    yield
+    sync._last_ingest_keepalive = 0.0
+
+
+def test_keepalive_sends_heartbeat_and_throttles(monkeypatch):
+    calls = []
+    monkeypatch.setattr(sync, "send_heartbeat", lambda cfg: calls.append(cfg) or True)
+    import clawmetry.config as cm_config
+    monkeypatch.setattr(cm_config, "is_cloud_disabled", lambda: False)
+
+    cfg = {"node_id": "n1"}
+    assert sync._ingest_keepalive_heartbeat(cfg) is True
+    # Immediately again: inside the throttle window — no second heartbeat.
+    assert sync._ingest_keepalive_heartbeat(cfg) is False
+    assert len(calls) == 1
+
+    # Simulate the interval elapsing — fires again.
+    sync._last_ingest_keepalive -= sync._INGEST_KEEPALIVE_SEC + 1
+    assert sync._ingest_keepalive_heartbeat(cfg) is True
+    assert len(calls) == 2
+
+
+def test_keepalive_skips_when_cloud_disabled(monkeypatch):
+    calls = []
+    monkeypatch.setattr(sync, "send_heartbeat", lambda cfg: calls.append(cfg) or True)
+    import clawmetry.config as cm_config
+    monkeypatch.setattr(cm_config, "is_cloud_disabled", lambda: True)
+
+    assert sync._ingest_keepalive_heartbeat({}) is False
+    assert calls == []
+
+
+def test_keepalive_never_raises(monkeypatch):
+    def _boom(cfg):
+        raise RuntimeError("cloud unreachable")
+
+    monkeypatch.setattr(sync, "send_heartbeat", _boom)
+    import clawmetry.config as cm_config
+    monkeypatch.setattr(cm_config, "is_cloud_disabled", lambda: False)
+
+    # Must swallow the error (the ingest pass it protects goes on).
+    assert sync._ingest_keepalive_heartbeat({}) is True
+
+
+def test_family_loop_calls_keepalive_per_session(monkeypatch):
+    """sync_family_runtimes must tick the keepalive for EVERY session it
+    walks — including ones it skips — so a deep backfill pass can never
+    hold the heartbeat for minutes again."""
+    session_ids = ["a", "b", "c"]
+
+    class _FakeDetect:
+        detected = True
+
+    class _FakeAdapter:
+        name = "claude_code"
+
+        def detect(self):
+            return _FakeDetect()
+
+        def list_sessions(self, limit=None):
+            for sid in session_ids:
+                yield types.SimpleNamespace(id=sid)
+
+    ticks = []
+    monkeypatch.setattr(sync, "_ingest_keepalive_heartbeat",
+                        lambda cfg: ticks.append(1))
+    monkeypatch.setattr(sync, "_sync_allowed", lambda: True)
+    monkeypatch.setattr(sync, "_family_adapter_classes", lambda: [_FakeAdapter])
+    # Every session is "OpenClaw-spawned" → skipped before any store work,
+    # keeping this test free of DuckDB/adapters while still walking the loop.
+    monkeypatch.setattr(sync, "_openclaw_spawned_claude_ids",
+                        lambda: set(session_ids))
+
+    assert sync.sync_family_runtimes({"node_id": "n1"}, {}, {}) == 0
+    assert len(ticks) == len(session_ids)


### PR DESCRIPTION
## RCA (2026-07-30, founder-hit)

Hosted Brain history window showed **"Could not fetch this window from your node yet. Pick the window again to retry."** while the node was online and healthy.

**Timeline (from Cloud Run request logs + the node's sync.log):**
1. `22:20:17` — switching the hosted dashboard to Claude Code triggered `runtime_backfill: claude_code ingest depth raised to 465 (was 0)`.
2. `22:20:48–22:21:34` — browser polled the picked window 16× (3s apart), all `relay_pending`, then gave up with the terminal error.
3. `22:21:21 → 22:24:02` — the main sync loop spent **~2m40s synchronously ingesting 47,495 backfill events**. The heartbeat fires at the END of a loop iteration, and the cloud relay drains `pending_queries` **only on a heartbeat** → the window query sat undrained the whole time.
4. `22:24:02` — next heartbeat drained + answered the query; the 'failed' window was verified sitting in the relay cache minutes later (cache-hit with matching age). The UI had already given up — and re-picking generates a fresh `until` → a different cache key → another doomed 45s.

**Root cause:** long synchronous ingest passes starve the heartbeat (and with it the whole pending-query relay), while the frontend's relay poll budget (~40–70s) is shorter than one busy heartbeat.

## Fix
- **`clawmetry/sync.py`** — `_ingest_keepalive_heartbeat(config)`: throttled (20s) heartbeat called per session inside `sync_family_runtimes`, so a deep backfill keeps answering relay queries mid-pass. Never raises; skips in local-only mode.
- **`static/js/app.js`** — Brain window `relay_pending` budget: 12 quick polls then 10s apart up to ~5 min, honest "Your node is busy syncing — still fetching this window…" status after the quick phase.
- **`en.json`** — new `brain.window_fetching_busy` key (autotranslate bot fills locales).
- **`CLAUDE.md`** — "Never starve the heartbeat" convention.
- **`tests/test_ingest_keepalive.py`** — throttle, local-only skip, non-fatal-on-error, and per-session call in the family loop (fails if the call site is removed).

Companion cloud-side PR extends the hosted patch's window poll budget (`_cmBrainWindowLoad`, currently 15×3s).

Note: `tests/test_heartbeat_dispatch.py` has 2 dev-box-only failures on clean main (store isolation leaks to the live daemon); unrelated, green in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)