### PR TITLE
feat(license): license_tier_at + /api/license/tier-at{,-batch}

### DIFF
--- a/clawmetry/license.py
+++ b/clawmetry/license.py
@@ -1376,6 +1376,97 @@ def is_tier(tier: str) -> bool:
     return actual == requested
 
 
+def license_tier_at(epoch: int) -> str | None:
+    """Perspective-epoch flavour of :func:`license_tier` -- "what tier
+    would :func:`license_tier` have returned evaluated as of ``epoch``?"
+    -- for a scheduled-audit / retrospective badge that wants to answer
+    "what tier was this node on <date>?" without the caller having to
+    snapshot the license state at that time or compare ``exp`` to a
+    caller-supplied epoch themselves.
+
+    Returns:
+      * ``None`` when there is nothing trustworthy to surface AS OF
+        ``epoch``: no license file on disk, an invalid signature (an
+        attacker could stuff any tier into an unsigned body -- refused
+        for every perspective), a signed key whose ``exp`` claim has
+        already passed at ``epoch`` (retrospective on a lapsed key when
+        ``epoch`` equals "now"; prospective on an active key when
+        ``epoch`` is in the future beyond ``exp``), OR a signed payload
+        whose ``tier`` claim is absent / non-string / empty after strip.
+      * A lowercased, whitespace-stripped tier string otherwise. Casing
+        is normalised the same way :func:`license_tier` normalises it,
+        so a caller comparing against a hard-coded ``"pro"`` gets the
+        same answer whichever helper it binds.
+
+    ``epoch`` is coerced through ``int()``; ``bool`` is explicitly
+    refused despite being an ``int`` subclass so a caller that passes
+    ``True`` / ``False`` gets ``None`` back rather than a spurious "was
+    the tier X at epoch 1?" classification. A non-numeric value
+    collapses to ``None`` so a caller cannot silently mis-gate on a
+    typo -- the conservative fallback since ``None`` implies no
+    entitlement, matching the never-mis-gate posture of the
+    surrounding ``_at`` family.
+
+    When ``epoch`` equals "now", this scalar must agree with
+    :func:`license_tier` for the same install -- both derive from the
+    same signed ``tier`` claim, refuse the invalid-signature branch,
+    and use the same ``exp <= cutoff`` boundary via
+    :func:`license_state_at` / the current-time ``valid`` classifier,
+    so the two scalars cannot disagree at the boundary. On any other
+    epoch this helper answers the retrospective / prospective question
+    :func:`license_tier` cannot -- e.g. "was this node Pro last
+    Friday?" (``None`` on a key that has since been renewed but was
+    already expired then) or "will this node still be Pro at our next
+    quarterly audit?" (``None`` on an active key whose ``exp`` falls
+    before the audit date).
+
+    Never raises. Any underlying introspection failure (import error,
+    corrupt install, cryptography-lib mismatch) collapses to ``None``
+    -- same fallback as :func:`license_tier` -- so a scheduled audit
+    tile bound to this helper never breaks on a partial install.
+
+    Pairs with the sibling ``_at`` scalars
+    (:func:`license_state_at`, :func:`is_expired_at`,
+    :func:`days_until_expiry_at`, :func:`is_expiring_within_at`) at
+    the row level: for the same ``epoch``, a caller can zip the five
+    responses index-for-index and get the whole entitlement row for
+    one install without the scalars catching each other disagreeing
+    on the perspective-epoch classification.
+    """
+    if isinstance(epoch, bool):
+        return None
+    try:
+        wanted = int(epoch)
+    except (TypeError, ValueError):
+        return None
+    try:
+        info = current_license_info()
+    except Exception as exc:
+        logger.debug("license: license_tier_at underlying read failed: %s", exc)
+        return None
+    if not isinstance(info, dict):
+        return None
+    status = info.get("status")
+    if status == "invalid":
+        # Signature-bogus branch: an unsigned body is untrusted whatever
+        # the perspective, so the classification is time-independent.
+        # Mirrors :func:`license_tier` -- payload-derived claims never
+        # get to influence the answer here.
+        return None
+    exp = info.get("exp")
+    if isinstance(exp, (int, float)) and int(exp) <= wanted:
+        # Signed key that has already lapsed AS OF ``epoch`` -- refuse
+        # for the same reason :func:`license_tier` refuses the expired
+        # branch at "now": a lapsed Pro customer must stop rendering
+        # as "Pro" once the perspective epoch is past ``exp``.
+        return None
+    tier = info.get("tier")
+    if not isinstance(tier, str):
+        return None
+    normalized = tier.strip().lower()
+    return normalized or None
+
+
 def is_expired() -> bool:
     """True iff an installed, signature-valid license has an ``exp`` claim in
     the past.
@@ -3437,6 +3528,88 @@ def is_license_valid_at_batch(epochs) -> list[dict]:
             )
             valid = False
         out.append({"epoch": parsed, "is_valid": bool(valid)})
+    return out
+
+
+def license_tier_at_batch(epochs) -> list[dict]:
+    """Per-value perspective-epoch license-tier scalar for N epochs in
+    ONE round-trip.
+
+    Per-value axis batch sibling of :func:`license_tier_at`. Fills the
+    ``_at_batch`` slot on the license-tier axis alongside the singular
+    :func:`license_tier_at` and the "now" flavour :func:`license_tier`,
+    so a scheduled-audit / retrospective tile that wants to plot tier
+    across a sequence of perspective dates ("what tier was this node
+    on each of these audit dates?") renders off ONE call instead of
+    fanning out N calls to the scalar.
+
+    Each item in ``epochs`` may be:
+
+      * an int (or int-parseable string) -- a perspective epoch. The
+        emitted row's ``tier`` is what :func:`license_tier_at` would
+        return for that epoch alone.
+      * ``bool`` (subclass of ``int``) or any non-int-parseable value
+        (``None``, empty string, non-numeric string) -- collapses to a
+        row with ``tier=None``, matching the never-mis-gate posture
+        :func:`license_tier_at` uses for the same inputs. The raw
+        stringified token surfaces in ``epoch`` so a caller can still
+        identify the offending entry.
+
+    Row shape::
+
+        {
+          "epoch": <int> | "<raw>",
+          "tier":  <str> | None,
+        }
+
+    Semantics per row mirror :func:`license_tier_at`: a lowercased,
+    whitespace-stripped tier string when the license is signature-
+    valid, carries a string ``tier`` claim, AND (perpetual OR
+    ``exp > epoch``); ``None`` for no license, invalid signature, an
+    ``exp`` claim that has already lapsed at ``epoch``, a signed
+    payload with a missing / non-string / empty ``tier``, and
+    ``bool`` / non-numeric epochs.
+
+    Duplicates by normalised int key (or ``repr(raw)`` for bad inputs)
+    are dropped preserving first-seen order for byte-stable output.
+    ``epochs is None`` or non-iterable -- returns ``[]``. Never raises:
+    per-row failures short-circuit to ``tier=None`` so the batch keeps
+    building. Matches the never-mis-gate posture used by
+    :func:`license_tier_at` -- a bad row cannot silently claim a tier
+    that would grant unearned entitlement.
+
+    When any row's ``epoch`` equals "now", the row's ``tier`` field
+    must byte-equal :func:`license_tier` for the same install -- both
+    derive from the same signed ``tier`` claim via
+    :func:`license_tier_at` / :func:`license_tier`, so a caller
+    binding both cannot catch them disagreeing at the boundary.
+
+    Pairs with :func:`license_state_at_batch` /
+    :func:`is_expired_at_batch` / :func:`days_until_expiry_at_batch`
+    on the row-shape axis: for the same epochs list, a caller can zip
+    the responses index-for-index and hydrate a whole entitlement
+    timeline row for one install in a handful of round-trips instead
+    of ``N * M`` calls to the scalar surface.
+    """
+    out: list[dict] = []
+    for raw, _key, parsed in _license_epoch_batch_keys(epochs):
+        if parsed is None:
+            try:
+                token = str(raw)
+            except Exception:
+                token = repr(raw)
+            out.append({"epoch": token, "tier": None})
+            continue
+        try:
+            tier = license_tier_at(parsed)
+        except Exception as exc:
+            logger.debug(
+                "license: license_tier_at_batch per-row failed: %s", exc
+            )
+            tier = None
+        out.append(
+            {"epoch": parsed, "tier": tier if isinstance(tier, str) else None}
+        )
     return out
 
 

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -11901,6 +11901,237 @@ def api_license_age_days_at_batch():
     )
 
 
+def _license_tier_at_snapshot() -> dict:
+    """Shared one-shot read for the paired ``/api/license/tier-at`` and
+    ``/api/license/tier-at-batch`` endpoints below.
+
+    Reads :func:`clawmetry.license.license_tier` (current-time tier),
+    :func:`clawmetry.license.current_license_info` (for ``has_license`` /
+    ``valid`` NOW), and :func:`clawmetry.license.license_expires_at`
+    (for the ``expires_at`` field the sibling perspective-epoch tiles
+    all carry) ONCE so a UI binding both endpoints in the same tile
+    can't catch them disagreeing on ``tier`` / ``expires_at`` /
+    ``has_license`` / ``valid`` for the same install -- mirrors the
+    ``_license_tier_snapshot`` + ``_license_expires_snapshot`` /
+    ``_license_state_at_snapshot`` pattern used by the current-time
+    tier pair and the state-derived perspective-epoch trio.
+
+    ``tier`` here is the CURRENT-time tier (matches
+    :func:`clawmetry.license.license_tier`); the perspective-epoch
+    tier (``tier_at``) is derived per-request by each endpoint via
+    :func:`clawmetry.license.license_tier_at` and lives on top of this
+    snapshot -- keeping ``tier`` in the shared read guarantees a UI
+    that renders "as of <date> vs now" tiles side-by-side can never
+    catch them disagreeing on the current-time reference.
+
+    Never raises. Any introspection failure collapses to the OSS-free
+    branch shape (``tier=None``, ``expires_at=None``,
+    ``has_license=False``, ``valid=False``) so the endpoint stack
+    never 5xxs -- same posture as the surrounding license endpoints.
+    """
+    try:
+        from clawmetry import license as _lic
+
+        tier = _lic.license_tier()
+        info = _lic.current_license_info()
+        expires = _lic.license_expires_at()
+    except Exception as exc:
+        logger.debug("_license_tier_at_snapshot: underlying read failed: %s", exc)
+        return {
+            "tier": None,
+            "expires_at": None,
+            "has_license": False,
+            "valid": False,
+        }
+    if not isinstance(tier, str):
+        tier = None
+    if info is None or not isinstance(info, dict):
+        return {
+            "tier": tier,
+            "expires_at": None,
+            "has_license": False,
+            "valid": False,
+        }
+    return {
+        "tier": tier,
+        "expires_at": expires,
+        "has_license": True,
+        "valid": bool(info.get("valid")),
+    }
+
+
+@bp_entitlement.route("/api/license/tier-at")
+def api_license_tier_at():
+    """``GET /api/license/tier-at?epoch=<int>`` -- scalar view of the
+    installed license's tier claim evaluated as of ``epoch`` -- the
+    perspective-epoch flavour of ``/api/license/tier``, for a
+    scheduled-audit / retrospective badge that wants to answer "what
+    tier was this node on <date>?" without the caller having to
+    snapshot the license state at that time or compare ``exp`` to a
+    caller-supplied epoch themselves.
+
+    Response shape (always HTTP 200)::
+
+        {
+          "tier_at": <str|null>,          # tier as of epoch
+          "requested_epoch": <int|null>,  # int-coerced input, or null on typo
+          "tier": <str|null>,             # current-time tier
+          "expires_at": <int|null>,       # on-disk exp for comparison
+          "has_license": <bool>,          # is a license file installed at all?
+          "valid": <bool>                 # signature-valid AND not expired NOW
+        }
+
+    ``tier_at`` mirrors :func:`clawmetry.license.license_tier_at`:
+    ``None`` for no license, invalid signature, an ``exp`` claim
+    that has already lapsed at ``epoch``, or a signed payload whose
+    ``tier`` claim is absent / non-string / empty; otherwise the
+    normalised (lowercased, stripped) tier string.
+
+    Query parameter:
+
+      * ``epoch`` -- required. Unix epoch seconds as an integer. A
+        missing / non-integer / bool value collapses to
+        ``tier_at=null`` with ``requested_epoch=null`` so a caller
+        cannot silently mis-gate on a typo. HTTP status is 200 either
+        way -- the "bad input" signal is ``requested_epoch=null`` plus
+        the ``null`` tier, not a 4xx, matching the never-crash posture
+        of the surrounding license endpoints.
+
+    Pairs with ``/api/license/state-at`` / ``/api/license/is-expired-at``
+    / ``/api/license/days-until-expiry-at`` / ``/api/license/expiring-
+    within-at`` -- all five share the perspective-epoch input pattern
+    and the ``_license_tier_at_snapshot`` reader here carries
+    ``expires_at`` / ``has_license`` / ``valid`` on the same shape the
+    state-derived trio carries, so a UI binding two for the same
+    install cannot catch them disagreeing on the current-time
+    reference fields.
+
+    When ``epoch`` equals "now", the ``tier_at`` field must byte-equal
+    ``tier`` (both derive from the same signed ``tier`` claim, refuse
+    the invalid-signature branch, and use the same ``exp <= cutoff``
+    boundary via :func:`license_tier_at` / :func:`license_tier`), so
+    a UI binding both cannot catch them disagreeing at the boundary.
+
+    Never 5xxs -- any underlying failure degrades to
+    ``{tier_at: null, requested_epoch: <echo>, tier: null,
+    expires_at: null, has_license: false, valid: false}`` (the OSS-
+    free branch shape).
+    """
+    raw = request.args.get("epoch", "")
+    try:
+        requested = int(str(raw).strip())
+    except (TypeError, ValueError):
+        requested = None
+    try:
+        snap = _license_tier_at_snapshot()
+    except Exception as exc:
+        logger.warning("api_license_tier_at: snapshot error: %s", exc)
+        snap = {
+            "tier": None,
+            "expires_at": None,
+            "has_license": False,
+            "valid": False,
+        }
+    tier_at: str | None = None
+    if requested is not None:
+        try:
+            from clawmetry import license as _lic
+
+            tier_at = _lic.license_tier_at(requested)
+        except Exception as exc:
+            logger.warning("api_license_tier_at: derive error: %s", exc)
+            tier_at = None
+    if tier_at is not None and not isinstance(tier_at, str):
+        tier_at = None
+    return jsonify(
+        {
+            "tier_at": tier_at,
+            "requested_epoch": requested,
+            "tier": snap["tier"],
+            "expires_at": snap["expires_at"],
+            "has_license": snap["has_license"],
+            "valid": snap["valid"],
+        }
+    )
+
+
+@bp_entitlement.route("/api/license/tier-at-batch")
+def api_license_tier_at_batch():
+    """``GET /api/license/tier-at-batch?epochs=<int>,<int>,...`` --
+    per-value batch sibling of ``/api/license/tier-at``.
+
+    Where the singular endpoint folds ONE perspective epoch to ONE
+    license-tier answer, this preserves per-value rows so a scheduled-
+    audit tile that wants to plot tier across a sequence of dates
+    ("what tier was this node on each of these audit dates?") renders
+    off ONE round-trip instead of N calls to ``/api/license/tier-at``.
+    Wraps :func:`clawmetry.license.license_tier_at_batch`.
+
+    ``epochs=`` is required. Missing / blank / only-commas -> ``400
+    missing epochs``. Comma-separated tokens are normalised the way
+    the underlying batch helper normalises them: whitespace-stripped,
+    then handed to :func:`clawmetry.license.license_tier_at_batch`,
+    which dedupes by parsed int key preserving first-seen order and
+    collapses non-int / ``bool`` / ``None`` tokens to a row with
+    ``tier=null`` (never-mis-gate posture matching the scalar
+    endpoint). Never 5xxs: a resolver failure returns the empty-rows
+    envelope with the current-time snapshot fields intact.
+
+    Response shape (always HTTP 200)::
+
+        {
+          "kind":  "license_tier_at",
+          "count": <int>,               # len(rows)
+          "rows":  [
+            {"epoch": <int|"<raw>">, "tier": <str|null>},
+            ...
+          ],
+          "tier":        <str|null>,    # current-time tier
+          "expires_at":  <int|null>,    # on-disk exp for comparison
+          "has_license": <bool>,
+          "valid":       <bool>         # signature-valid AND not expired NOW
+        }
+
+    Per-row parity with ``/api/license/tier-at?epoch=<n>`` is pinned in
+    the test suite so the batch cannot silently drift from the scalar
+    endpoint. Shares :func:`_license_tier_at_snapshot` with the scalar
+    endpoint so the current-time reference fields (``tier`` /
+    ``expires_at`` / ``has_license`` / ``valid``) cannot disagree
+    between the two for the same install.
+    """
+    tokens, err = _parse_license_epochs_csv("epochs")
+    if err == "missing":
+        return jsonify({"error": "missing epochs"}), 400
+    try:
+        snap = _license_tier_at_snapshot()
+    except Exception as exc:
+        logger.warning("api_license_tier_at_batch: snapshot error: %s", exc)
+        snap = {
+            "tier": None,
+            "expires_at": None,
+            "has_license": False,
+            "valid": False,
+        }
+    try:
+        from clawmetry import license as _lic
+
+        rows = _lic.license_tier_at_batch(tokens)
+    except Exception as exc:
+        logger.warning("api_license_tier_at_batch: derive error: %s", exc)
+        rows = []
+    return jsonify(
+        {
+            "kind": "license_tier_at",
+            "count": len(rows),
+            "rows": rows,
+            "tier": snap["tier"],
+            "expires_at": snap["expires_at"],
+            "has_license": snap["has_license"],
+            "valid": snap["valid"],
+        }
+    )
+
+
 @bp_entitlement.route("/api/paywall/event", methods=["POST"])
 def api_paywall_event():
     body: dict = {}

--- a/tests/test_license_tier_at.py
+++ b/tests/test_license_tier_at.py
@@ -1,0 +1,660 @@
+"""Tests for the ``license_tier_at(epoch)`` scalar and
+``license_tier_at_batch(epochs)`` batch helpers on ``clawmetry.license``
+and their paired ``/api/license/tier-at`` / ``/api/license/tier-at-batch``
+HTTP endpoints.
+
+The perspective-epoch flavour of the ``license_tier`` scalar. Both
+derive from the same signed ``tier`` claim and refuse the invalid-
+signature branch, so they cannot disagree at the boundary when the
+perspective epoch equals "now"; on any other epoch these helpers answer
+"what tier would :func:`license_tier` have reported evaluated as of
+``epoch``?" without the caller having to snapshot the license state at
+that time or compare ``exp`` to a caller-supplied epoch themselves.
+
+Hermetic: each test mints tokens with its own ephemeral keypair and
+monkeypatches the module's embedded public key + ``LICENSE_PATH``,
+mirroring ``tests/test_license_state_at_scalar.py`` /
+``tests/test_license_state_at_batch.py`` so nothing depends on the real
+production signing key or on real filesystem state.
+"""
+from __future__ import annotations
+
+import time
+from types import SimpleNamespace
+
+import pytest
+from flask import Flask
+
+
+# -- shared helpers (mirror test_license_state_at_scalar.py) ------------------
+
+
+def _keypair():
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+    priv = Ed25519PrivateKey.generate()
+    pub_pem = priv.public_key().public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    return priv, pub_pem
+
+
+def _payload(tier="pro", nodes=3, exp_delta=365 * 86400, drop_exp=False, drop_tier=False):
+    now = int(time.time())
+    p = {
+        "sub": "acct_test",
+        "tier": tier,
+        "nodes": nodes,
+        "iat": now,
+        "exp": now + exp_delta,
+        "features": ["runtimes"],
+    }
+    if drop_exp:
+        p.pop("exp", None)
+    if drop_tier:
+        p.pop("tier", None)
+    return p
+
+
+@pytest.fixture
+def app(monkeypatch, tmp_path):
+    import clawmetry.license as _lic
+
+    priv, pub_pem = _keypair()
+    monkeypatch.setattr(_lic, "_PUBLIC_KEY_PEM", pub_pem)
+    license_path = str(tmp_path / "license.key")
+    monkeypatch.setattr(_lic, "LICENSE_PATH", license_path)
+    monkeypatch.delenv("CLAWMETRY_LICENSE_SERVER", raising=False)
+    monkeypatch.delenv("CLAWMETRY_INGEST_URL", raising=False)
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("CLAWMETRY_OFFLINE", "1")
+
+    from routes.entitlement import bp_entitlement
+
+    flask_app = Flask(__name__)
+    flask_app.register_blueprint(bp_entitlement)
+    flask_app.config["TESTING"] = True
+
+    return SimpleNamespace(
+        app=flask_app,
+        lic=_lic,
+        priv=priv,
+        license_path=license_path,
+    )
+
+
+def _write_key_direct(app, exp_delta, tier="pro", drop_tier=False):
+    """Bypass activate() (which refuses expired tokens) and write a token
+    directly to the license file. Simulates a license that expired AFTER
+    it was installed."""
+    import os
+
+    tok = app.lic._encode_token(
+        _payload(tier=tier, exp_delta=exp_delta, drop_tier=drop_tier), app.priv
+    )
+    os.makedirs(os.path.dirname(app.license_path), exist_ok=True)
+    with open(app.license_path, "w", encoding="utf-8") as fh:
+        fh.write(tok)
+
+
+def _write_perpetual(app, tier="pro"):
+    import os
+
+    tok = app.lic._encode_token(_payload(tier=tier, drop_exp=True), app.priv)
+    os.makedirs(os.path.dirname(app.license_path), exist_ok=True)
+    with open(app.license_path, "w", encoding="utf-8") as fh:
+        fh.write(tok)
+
+
+def _write_bogus(app):
+    import os
+
+    os.makedirs(os.path.dirname(app.license_path), exist_ok=True)
+    with open(app.license_path, "w", encoding="utf-8") as fh:
+        fh.write("CLAW1.garbage.garbage")
+
+
+# -- clawmetry.license.license_tier_at() --------------------------------------
+
+
+def test_license_tier_at_no_license(app):
+    """No license file on disk -> ``None`` regardless of epoch."""
+    assert app.lic.license_tier_at(int(time.time())) is None
+    assert app.lic.license_tier_at(0) is None
+    assert app.lic.license_tier_at(2_000_000_000) is None
+
+
+def test_license_tier_at_now_matches_license_tier_active(app):
+    """When ``epoch`` equals "now", perspective scalar must agree with
+    :func:`license_tier` on an active install. Both derive from the same
+    signed ``tier`` claim, so a UI binding both cannot catch them
+    disagreeing at the boundary."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    now = int(time.time())
+    assert app.lic.license_tier_at(now) == "pro"
+    assert app.lic.license_tier() == "pro"
+
+
+def test_license_tier_at_now_matches_license_tier_lapsed(app):
+    """Lapsed-key parity: at "now", perspective scalar and base scalar
+    must both return ``None`` -- both refuse the expired branch."""
+    _write_key_direct(app, exp_delta=-5 * 86400)
+    now = int(time.time())
+    assert app.lic.license_tier_at(now) is None
+    assert app.lic.license_tier() is None
+
+
+def test_license_tier_at_future_epoch_before_expiry(app):
+    """Future perspective still before ``exp`` -> tier surfaces (key would
+    NOT yet be expired at that perspective)."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    epoch = int(time.time()) + 10 * 86400
+    assert app.lic.license_tier_at(epoch) == "pro"
+
+
+def test_license_tier_at_future_epoch_after_expiry(app):
+    """Future perspective AFTER ``exp`` on an active key -> ``None`` (the
+    key WILL be expired at that perspective). This is the "will this
+    node still be Pro at our next audit?" prospective scenario."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    epoch = int(time.time()) + 60 * 86400
+    assert app.lic.license_tier_at(epoch) is None
+
+
+def test_license_tier_at_past_epoch_still_active(app):
+    """Perspective BEFORE now on an active key -> tier surfaces (the key
+    was not yet expired then, since ``exp`` is even further in the
+    future)."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    epoch = int(time.time()) - 10 * 86400
+    assert app.lic.license_tier_at(epoch) == "pro"
+
+
+def test_license_tier_at_lapsed_key_pre_lapse_epoch_surfaces_tier(app):
+    """Lapsed-but-signed key at a perspective BEFORE its ``exp`` -> tier
+    surfaces (retrospective "was this Pro on <date>?"). At "now" (past
+    ``exp``) -> ``None``."""
+    _write_key_direct(app, exp_delta=-5 * 86400)  # exp = now - 5d
+    now = int(time.time())
+    assert app.lic.license_tier_at(now - 20 * 86400) == "pro"
+    assert app.lic.license_tier_at(now - 3 * 86400) is None
+    assert app.lic.license_tier_at(now) is None
+
+
+def test_license_tier_at_exact_exp_boundary(app):
+    """At the exact ``exp`` second, the tier must collapse to ``None``
+    -- the ``<= epoch`` cutoff matches :func:`license_state_at`'s
+    ``exp <= epoch`` boundary."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    from clawmetry import license as _lic
+
+    info = _lic.current_license_info()
+    exp_epoch = int(info["exp"])
+    assert app.lic.license_tier_at(exp_epoch - 1) == "pro"
+    assert app.lic.license_tier_at(exp_epoch) is None
+    assert app.lic.license_tier_at(exp_epoch + 1) is None
+
+
+def test_license_tier_at_perpetual_key(app):
+    """Perpetual (no ``exp``) key -> tier surfaces at every epoch."""
+    _write_perpetual(app)
+    assert app.lic.license_tier_at(0) == "pro"
+    assert app.lic.license_tier_at(int(time.time())) == "pro"
+    assert app.lic.license_tier_at(2_000_000_000) == "pro"
+
+
+def test_license_tier_at_invalid_signature(app):
+    """Bogus-signature file -> ``None`` regardless of epoch (time-
+    independent, matching :func:`license_tier`)."""
+    _write_bogus(app)
+    assert app.lic.license_tier_at(0) is None
+    assert app.lic.license_tier_at(int(time.time())) is None
+    assert app.lic.license_tier_at(2_000_000_000) is None
+
+
+def test_license_tier_at_normalises_casing(app):
+    """Tier claim casing is normalised the same way :func:`license_tier`
+    normalises it -- callers can compare against a hard-coded ``"pro"``
+    without a .lower() on every read."""
+    tok = app.lic._encode_token(_payload(tier="  PRO  "), app.priv)
+    app.lic.activate(tok)
+    assert app.lic.license_tier_at(int(time.time())) == "pro"
+
+
+def test_license_tier_at_missing_tier_claim_matches_scalar(app):
+    """Signed payload with no ``tier`` claim: the perspective-epoch scalar
+    MUST match :func:`license_tier` on the same install (both derive from
+    :func:`current_license_info`, which today defaults a missing ``tier``
+    claim to ``"pro"``). This test pins parity with the base scalar --
+    it does NOT claim the default is desirable; it only guards against
+    the two scalars silently diverging on the same defect."""
+    _write_key_direct(app, exp_delta=30 * 86400, drop_tier=True)
+    now = int(time.time())
+    assert app.lic.license_tier_at(now) == app.lic.license_tier()
+
+
+def test_license_tier_at_bool_epoch_refused(app):
+    """``bool`` is an ``int`` subclass but must be refused so a caller
+    passing ``True`` / ``False`` gets ``None`` back, not a spurious
+    "was tier X at epoch 1?" answer."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    assert app.lic.license_tier_at(True) is None
+    assert app.lic.license_tier_at(False) is None
+
+
+def test_license_tier_at_non_numeric_epoch(app):
+    """Non-numeric epoch -> ``None`` so a caller cannot silently mis-gate
+    on a typo -- conservative fallback since ``None`` implies no
+    entitlement."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    assert app.lic.license_tier_at("not-a-number") is None
+    assert app.lic.license_tier_at(None) is None
+    assert app.lic.license_tier_at([]) is None
+
+
+def test_license_tier_at_string_epoch_coerced(app):
+    """String epoch that ``int()`` accepts -> coerced and honoured, matching
+    the behaviour of :func:`license_state_at`."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    now = int(time.time())
+    assert app.lic.license_tier_at(str(now)) == "pro"
+
+
+# -- clawmetry.license.license_tier_at_batch() --------------------------------
+
+
+def test_license_tier_at_batch_none_returns_empty(app):
+    """``epochs is None`` -> ``[]``. Mirrors the never-raise posture of the
+    sibling per-value axis batches."""
+    assert app.lic.license_tier_at_batch(None) == []
+
+
+def test_license_tier_at_batch_non_iterable_returns_empty(app):
+    """Non-iterable ``epochs`` (an int -- probable typo for a caller that
+    forgot to wrap it) -> ``[]`` rather than a crash."""
+    assert app.lic.license_tier_at_batch(42) == []
+
+
+def test_license_tier_at_batch_empty_returns_empty(app):
+    """Empty iterable -> ``[]``."""
+    assert app.lic.license_tier_at_batch([]) == []
+    assert app.lic.license_tier_at_batch(()) == []
+
+
+def test_license_tier_at_batch_no_license(app):
+    """No license file on disk -> every row ``None`` regardless of epoch.
+    Time-independent, matches the scalar."""
+    epochs = [0, int(time.time()), 2_000_000_000]
+    rows = app.lic.license_tier_at_batch(epochs)
+    assert [r["tier"] for r in rows] == [None] * 3
+    assert [r["epoch"] for r in rows] == epochs
+
+
+def test_license_tier_at_batch_active_key_mixed_epochs(app):
+    """Active key: perspectives before ``exp`` -> tier surfaces; after
+    ``exp`` -> ``None``. Batch preserves per-row ordering."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    now = int(time.time())
+    epochs = [now, now + 10 * 86400, now + 60 * 86400, now + 90 * 86400]
+    rows = app.lic.license_tier_at_batch(epochs)
+    assert [r["tier"] for r in rows] == ["pro", "pro", None, None]
+    assert [r["epoch"] for r in rows] == epochs
+
+
+def test_license_tier_at_batch_per_row_parity_with_scalar(app):
+    """Per-row parity with :func:`license_tier_at` -- the batch cannot
+    silently drift from the scalar. Pin every row against the singular
+    helper on the same install."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    now = int(time.time())
+    epochs = [
+        now - 10 * 86400,
+        now,
+        now + 5 * 86400,
+        now + 40 * 86400,
+        now + 200 * 86400,
+    ]
+    rows = app.lic.license_tier_at_batch(epochs)
+    for row, epoch in zip(rows, epochs):
+        assert row["tier"] == app.lic.license_tier_at(epoch), epoch
+
+
+def test_license_tier_at_batch_perpetual_key(app):
+    """Perpetual (no ``exp``) key -> tier surfaces at every row."""
+    _write_perpetual(app)
+    epochs = [0, int(time.time()), 2_000_000_000]
+    rows = app.lic.license_tier_at_batch(epochs)
+    assert [r["tier"] for r in rows] == ["pro"] * 3
+
+
+def test_license_tier_at_batch_invalid_signature(app):
+    """Bogus-signature file -> every row ``None`` (time-independent)."""
+    _write_bogus(app)
+    rows = app.lic.license_tier_at_batch([0, int(time.time()), 2_000_000_000])
+    assert [r["tier"] for r in rows] == [None] * 3
+
+
+def test_license_tier_at_batch_lapsed_key_flips_per_row(app):
+    """Lapsed-but-signed key at a perspective BEFORE its ``exp`` -> tier
+    surfaces; at / after ``exp`` -> ``None``. Batch flips per row."""
+    _write_key_direct(app, exp_delta=-5 * 86400)  # exp = now - 5d
+    now = int(time.time())
+    rows = app.lic.license_tier_at_batch(
+        [now - 20 * 86400, now - 3 * 86400, now]
+    )
+    assert [r["tier"] for r in rows] == ["pro", None, None]
+
+
+def test_license_tier_at_batch_bad_epochs_collapse_per_row(app):
+    """``bool`` / non-numeric epochs collapse the corresponding row to
+    ``tier=None`` with the raw token surfaced in ``epoch`` -- matches the
+    never-mis-gate posture the scalar uses for the same inputs."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    now = int(time.time())
+    rows = app.lic.license_tier_at_batch([now, True, "nope", None, now + 3600])
+    assert len(rows) == 5
+    good_rows = [r for r in rows if isinstance(r["epoch"], int) and r["tier"] == "pro"]
+    assert len(good_rows) == 2
+    bad_rows = [r for r in rows if r["tier"] is None]
+    assert len(bad_rows) == 3
+
+
+def test_license_tier_at_batch_dedup_preserves_first_seen(app):
+    """Duplicate epochs are dropped preserving first-seen order for
+    byte-stable output."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    now = int(time.time())
+    rows = app.lic.license_tier_at_batch([now, now, now + 10, now])
+    assert [r["epoch"] for r in rows] == [now, now + 10]
+
+
+def test_license_tier_at_batch_string_epochs_coerced(app):
+    """String tokens that ``int()`` accepts -> coerced and honoured,
+    matching the query-string surface (the batch endpoint hands the
+    helper stripped tokens)."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    now = int(time.time())
+    rows = app.lic.license_tier_at_batch([str(now), str(now + 10)])
+    assert [r["tier"] for r in rows] == ["pro", "pro"]
+
+
+def test_license_tier_at_batch_normalises_casing(app):
+    """Tier claim casing is normalised on every row the same way the
+    scalar normalises it."""
+    tok = app.lic._encode_token(_payload(tier="  PRO  "), app.priv)
+    app.lic.activate(tok)
+    now = int(time.time())
+    rows = app.lic.license_tier_at_batch([now, now + 3600])
+    assert [r["tier"] for r in rows] == ["pro", "pro"]
+
+
+def test_license_tier_at_batch_missing_tier_claim_matches_scalar(app):
+    """Signed payload with no ``tier`` claim: every row must byte-equal
+    the singular :func:`license_tier_at` for the same epoch (which in
+    turn pins parity with :func:`license_tier` -- see the scalar test).
+    Guards the batch from silently diverging from the scalar on the
+    same defect."""
+    _write_key_direct(app, exp_delta=30 * 86400, drop_tier=True)
+    now = int(time.time())
+    epochs = [now, now + 3600, now + 86400]
+    rows = app.lic.license_tier_at_batch(epochs)
+    for row, epoch in zip(rows, epochs):
+        assert row["tier"] == app.lic.license_tier_at(epoch), epoch
+
+
+# -- GET /api/license/tier-at -------------------------------------------------
+
+
+def test_api_tier_at_no_license(app):
+    """No license file on disk -> ``tier_at=null``, current-time
+    reference fields all reflect the OSS-free branch."""
+    now = int(time.time())
+    with app.app.test_client() as client:
+        rv = client.get(f"/api/license/tier-at?epoch={now}")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["tier_at"] is None
+    assert body["requested_epoch"] == now
+    assert body["tier"] is None
+    assert body["expires_at"] is None
+    assert body["has_license"] is False
+    assert body["valid"] is False
+
+
+def test_api_tier_at_active_key_now(app):
+    """Active key at "now" -> ``tier_at=tier``, snapshot fields intact."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    now = int(time.time())
+    with app.app.test_client() as client:
+        rv = client.get(f"/api/license/tier-at?epoch={now}")
+    body = rv.get_json()
+    assert body["tier_at"] == "pro"
+    assert body["tier"] == "pro"
+    assert body["expires_at"] is not None
+    assert body["has_license"] is True
+    assert body["valid"] is True
+
+
+def test_api_tier_at_missing_epoch_collapses(app):
+    """Missing / non-integer / bool ``epoch`` -> ``tier_at=null`` and
+    ``requested_epoch=null`` so a caller cannot silently mis-gate on a
+    typo. HTTP status stays 200."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    with app.app.test_client() as client:
+        for qs in ("", "?epoch=", "?epoch=nope", "?epoch=true"):
+            rv = client.get(f"/api/license/tier-at{qs}")
+            assert rv.status_code == 200, qs
+            body = rv.get_json()
+            assert body["tier_at"] is None, qs
+            assert body["requested_epoch"] is None, qs
+
+
+def test_api_tier_at_future_after_expiry(app):
+    """Future perspective past ``exp`` on an active key -> ``tier_at=null``
+    even though ``tier`` (current-time) still surfaces the tier."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    epoch = int(time.time()) + 60 * 86400
+    with app.app.test_client() as client:
+        rv = client.get(f"/api/license/tier-at?epoch={epoch}")
+    body = rv.get_json()
+    assert body["tier_at"] is None
+    assert body["tier"] == "pro"
+
+
+def test_api_tier_at_invalid_signature(app):
+    """Bogus-signature file -> ``tier_at=null``. ``has_license=True``
+    (a file exists) but ``valid=False``. Time-independent."""
+    _write_bogus(app)
+    with app.app.test_client() as client:
+        rv = client.get(f"/api/license/tier-at?epoch={int(time.time())}")
+    body = rv.get_json()
+    assert body["tier_at"] is None
+    assert body["tier"] is None
+    assert body["has_license"] is True
+    assert body["valid"] is False
+
+
+def test_api_tier_at_scalar_parity_with_python(app):
+    """The endpoint must return exactly what ``license_tier_at`` would
+    return for the same epoch."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    now = int(time.time())
+    with app.app.test_client() as client:
+        for epoch in [now - 10 * 86400, now, now + 5 * 86400, now + 40 * 86400]:
+            rv = client.get(f"/api/license/tier-at?epoch={epoch}")
+            body = rv.get_json()
+            assert body["tier_at"] == app.lic.license_tier_at(epoch), epoch
+
+
+# -- GET /api/license/tier-at-batch -------------------------------------------
+
+
+def test_api_tier_at_batch_missing_epochs_400(app):
+    """Missing / blank / only-commas ``epochs=`` -> ``400 missing epochs``
+    (matches the sibling ``/api/license/*-at-batch`` endpoints)."""
+    with app.app.test_client() as client:
+        for qs in ("", "?epochs=", "?epochs=,,"):
+            rv = client.get(f"/api/license/tier-at-batch{qs}")
+            assert rv.status_code == 400, qs
+            assert rv.get_json() == {"error": "missing epochs"}
+
+
+def test_api_tier_at_batch_no_license(app):
+    """No license file on disk -> every row ``tier=null``. Reference
+    fields all reflect the OSS-free branch."""
+    now = int(time.time())
+    with app.app.test_client() as client:
+        rv = client.get(
+            f"/api/license/tier-at-batch?epochs={now},{now + 3600}"
+        )
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["kind"] == "license_tier_at"
+    assert body["count"] == 2
+    assert [r["tier"] for r in body["rows"]] == [None, None]
+    assert body["tier"] is None
+    assert body["has_license"] is False
+
+
+def test_api_tier_at_batch_active_key_flips_per_row(app):
+    """Active key: rows before ``exp`` surface tier, rows after ``exp``
+    collapse to ``null``."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    now = int(time.time())
+    epochs = [now, now + 10 * 86400, now + 60 * 86400, now + 90 * 86400]
+    qs = ",".join(str(e) for e in epochs)
+    with app.app.test_client() as client:
+        rv = client.get(f"/api/license/tier-at-batch?epochs={qs}")
+    body = rv.get_json()
+    assert body["count"] == 4
+    assert [r["tier"] for r in body["rows"]] == ["pro", "pro", None, None]
+    assert [r["epoch"] for r in body["rows"]] == epochs
+    assert body["tier"] == "pro"
+    assert body["valid"] is True
+
+
+def test_api_tier_at_batch_per_row_parity_with_scalar_endpoint(app):
+    """Per-row parity with ``/api/license/tier-at?epoch=<n>`` -- the batch
+    cannot silently drift from the scalar."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    now = int(time.time())
+    epochs = [now - 5 * 86400, now, now + 3 * 86400, now + 40 * 86400]
+    qs = ",".join(str(e) for e in epochs)
+    with app.app.test_client() as client:
+        rv_batch = client.get(f"/api/license/tier-at-batch?epochs={qs}")
+        rows = rv_batch.get_json()["rows"]
+        for row, epoch in zip(rows, epochs):
+            rv_scalar = client.get(f"/api/license/tier-at?epoch={epoch}")
+            assert row["tier"] == rv_scalar.get_json()["tier_at"], epoch
+
+
+def test_api_tier_at_batch_perpetual_key(app):
+    """Perpetual key -> every row surfaces the tier."""
+    _write_perpetual(app)
+    now = int(time.time())
+    with app.app.test_client() as client:
+        rv = client.get(f"/api/license/tier-at-batch?epochs=0,{now},2000000000")
+    body = rv.get_json()
+    assert [r["tier"] for r in body["rows"]] == ["pro", "pro", "pro"]
+    assert body["valid"] is True
+
+
+def test_api_tier_at_batch_invalid_signature(app):
+    """Bogus-signature file -> every row ``null`` (time-independent)."""
+    _write_bogus(app)
+    now = int(time.time())
+    with app.app.test_client() as client:
+        rv = client.get(f"/api/license/tier-at-batch?epochs=0,{now},2000000000")
+    body = rv.get_json()
+    assert [r["tier"] for r in body["rows"]] == [None, None, None]
+    assert body["has_license"] is True
+    assert body["valid"] is False
+
+
+def test_api_tier_at_batch_bad_tokens_collapse_per_row(app):
+    """Bad tokens (non-numeric) don't 400 the batch -- they collapse to
+    ``tier=null`` rows so a caller can identify the offending entry."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    now = int(time.time())
+    with app.app.test_client() as client:
+        rv = client.get(
+            f"/api/license/tier-at-batch?epochs={now},nope,{now + 3600}"
+        )
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["count"] == 3
+    good = [r for r in body["rows"] if r["tier"] == "pro"]
+    bad = [r for r in body["rows"] if r["tier"] is None]
+    assert len(good) == 2 and len(bad) == 1
+
+
+def test_api_tier_at_batch_shared_snapshot_agreement(app):
+    """The current-time reference fields on the batch response must
+    byte-equal the sibling ``/api/license/state-at-batch`` fields for
+    the same install -- both endpoints share the state snapshot pattern
+    (batch's ``expires_at`` / ``has_license`` / ``valid`` come from the
+    same underlying ``current_license_info`` / ``license_expires_at``
+    read)."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    now = int(time.time())
+    with app.app.test_client() as client:
+        rv_tier = client.get(f"/api/license/tier-at-batch?epochs={now}").get_json()
+        rv_state = client.get(f"/api/license/state-at-batch?epochs={now}").get_json()
+    assert rv_tier["expires_at"] == rv_state["expires_at"]
+    assert rv_tier["has_license"] == rv_state["has_license"]
+    assert rv_tier["valid"] == rv_state["valid"]
+
+
+def test_api_tier_at_batch_dedup_preserves_first_seen(app):
+    """Duplicate epochs are dropped preserving first-seen order --
+    matches the underlying batch helper."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    now = int(time.time())
+    with app.app.test_client() as client:
+        rv = client.get(
+            f"/api/license/tier-at-batch?epochs={now},{now},{now + 10},{now}"
+        )
+    body = rv.get_json()
+    assert [r["epoch"] for r in body["rows"]] == [now, now + 10]
+
+
+# -- cross-endpoint agreement -------------------------------------------------
+
+
+def test_api_tier_at_agrees_with_license_tier_endpoint_at_now(app):
+    """At ``epoch=now``, the ``tier_at`` field must byte-equal the
+    ``tier`` returned by ``/api/license/tier`` (the current-time
+    endpoint). Both derive from the same signed claim -- a UI binding
+    both cannot catch them disagreeing at the boundary."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    now = int(time.time())
+    with app.app.test_client() as client:
+        rv_now = client.get("/api/license/tier").get_json()
+        rv_at = client.get(f"/api/license/tier-at?epoch={now}").get_json()
+    assert rv_at["tier_at"] == rv_now["tier"]
+    assert rv_at["tier"] == rv_now["tier"]


### PR DESCRIPTION
## Summary

- Adds `license_tier_at(epoch)` on `clawmetry.license` -- the perspective-epoch flavour of `license_tier()`, i.e. "what tier would `license_tier` have returned evaluated as of `epoch`?" for a scheduled-audit / retrospective badge that wants to answer "what tier was this node on <date>?" without the caller having to snapshot the license state at that time or compare `exp` to a caller-supplied epoch themselves. Returns the lowercased/stripped tier when a signed key is (perpetual OR `exp > epoch`) AND carries a string `tier` claim; `None` on no license, invalid signature, `exp <= epoch`, missing/non-string tier, and `bool` / non-numeric epochs.
- Adds `license_tier_at_batch(epochs)` -- the per-value axis batch sibling. Fills the `_at_batch` slot on the license-tier axis so a scheduled-audit tile that wants to plot tier across N perspective dates renders off ONE call instead of fanning out N calls to the scalar. Row shape mirrors the sibling `license_state_at_batch`: `{"epoch": <int>|"<raw>", "tier": <str>|null}`. Dedup preserving first-seen order via `_license_epoch_batch_keys`; bad tokens collapse per-row to `tier=null` with the raw token surfaced.
- Wires `GET /api/license/tier-at?epoch=<int>` and `/api/license/tier-at-batch?epochs=<csv>` on `bp_entitlement`. Both share a new `_license_tier_at_snapshot()` reader carrying `tier` / `expires_at` / `has_license` / `valid` (current-time reference fields) so a UI binding either alongside the sibling `state-at` / `is-expired-at` / `days-until-expiry-at` / `expiring-within-at` endpoints cannot catch them disagreeing on the current-time reference for the same install. Missing / non-int / bool `epoch=` on the scalar collapses to `tier_at=null` + `requested_epoch=null` (never 4xx / 5xx); missing `epochs=` on the batch returns `400 missing epochs` uniformly with the sibling `*-at-batch` endpoints.
- Ships a 45-test hermetic suite covering the no-license / active / lapsed / perpetual / invalid-signature branches, "now" boundary parity with `license_tier`, exact-`exp` boundary flip, `bool` / non-numeric / string epoch handling, per-row parity with the scalar helper AND the scalar HTTP endpoint, dedup preserving first-seen order, and shared-snapshot agreement with `state-at-batch`.

Zero behavior change to existing code paths (the resolved entitlement / paywall gate posture is unchanged). This fills the `_at` / `_at_batch` slot on the tier axis so callers stop composing "was this Pro on `<date>`?" client-side from `is_expired_at` + `license_tier` + custom `exp` comparison.

## Test plan

- [x] `python -m py_compile clawmetry/license.py routes/entitlement.py tests/test_license_tier_at.py`
- [x] `ruff check clawmetry/license.py routes/entitlement.py tests/test_license_tier_at.py` -- All checks passed
- [x] `python -m pytest tests/test_license_tier_at.py` -- 45 passed
- [x] Regression: `python -m pytest tests/test_license_state_at_scalar.py tests/test_license_state_at_batch.py tests/test_license_is_state_at_batch.py tests/test_license_is_expired_at.py` -- 160 passed
- [x] `make lint` -- 210 pre-existing errors on non-touched files (also fail on `origin/main`, confirmed via `git stash`); no lint errors introduced by this PR's files

### Local operator verification checklist

I cannot reach the running daemon or the live cloud snapshot from this environment. Before flipping to ready-for-review / merging:

- [ ] Copy the changed files into the installed package:
      `cp clawmetry/license.py ~/.clawmetry/lib/python3.*/site-packages/clawmetry/`
      `cp routes/entitlement.py ~/.clawmetry/lib/python3.*/site-packages/routes/`
      `cp tests/test_license_tier_at.py ~/.clawmetry/lib/python3.*/site-packages/tests/`  (if the local tree carries a tests/ dir)
- [ ] Clear `__pycache__` under the site-packages layout:
      `find ~/.clawmetry -name __pycache__ -exec rm -rf {} +`
- [ ] Restart the sync daemon so the new endpoints are registered:
      `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
- [ ] Hit `curl -sS "http://localhost:8900/api/license/tier-at?epoch=$(date +%s)" | jq` and confirm the response shape matches the endpoint docstring
- [ ] Hit `curl -sS "http://localhost:8900/api/license/tier-at-batch?epochs=$(date +%s),$(( $(date +%s) + 86400 )),$(( $(date +%s) + 400 * 86400 ))" | jq` and confirm the batch shape matches the docstring, with per-row parity vs the scalar endpoint at each epoch (and the last row collapses to `tier=null` on a 400-day-out perspective if the installed key expires before then)
- [ ] Confirm shared-snapshot agreement with the sibling `state-at-batch`: `curl "http://localhost:8900/api/license/state-at-batch?epochs=$(date +%s)"` -- `expires_at` / `has_license` / `valid` must match the new endpoint's response for the same install
- [ ] Decrypt the live cloud snapshot and confirm the daemon relay still forwards `/api/license/*` traffic unchanged
- [ ] Browser-check any paywall tile that already binds `license_tier` -- it should render identically (no rebinding was done in this PR)

## Rollout posture

- No `__version__` bump, no `[RELEASE]` PR, no tag.
- No enforce-mode change: the entitlement layer stays in GRACE. This helper only fills a query slot; no gate hardens as a result.
- Draft PR only. Operator drives the sequence above (site-packages copy -> daemon restart -> live verification -> ready-for-review / merge / release).

---
_Generated by [Claude Code](https://claude.ai/code/session_01AsoCfC2wZfpzrCwecP3X2y)_