### PR TITLE
feat(license): license_features_at + /api/license/features-at{,-batch}

### DIFF
--- a/clawmetry/license.py
+++ b/clawmetry/license.py
@@ -3725,3 +3725,246 @@ def license_features() -> list[str] | None:
         out.append(norm)
     out.sort()
     return out
+
+
+def license_features_at(epoch: int) -> list[str] | None:
+    """Perspective-epoch flavour of :func:`license_features` -- "what
+    features would :func:`license_features` have surfaced evaluated as of
+    ``epoch``?" -- for a scheduled-audit / retrospective diagnostic tile
+    that wants to answer "which paid features was this node entitled to
+    on <date>?" without the caller having to snapshot the license state
+    at that time or compare ``exp`` to a caller-supplied epoch
+    themselves.
+
+    Returns:
+      * ``None`` when there is nothing trustworthy to surface AS OF
+        ``epoch``: no license file on disk, an invalid signature (an
+        attacker could stuff any ``features`` list into an unsigned body
+        -- refused for every perspective), a signed key whose ``exp``
+        claim has already lapsed at ``epoch`` (retrospective on a lapsed
+        key when ``epoch`` equals "now"; prospective on an active key
+        when ``epoch`` is in the future beyond ``exp``), OR a per-row
+        introspection failure. Matches the never-mis-gate posture of
+        :func:`license_features`: a lapsed key must not keep rendering
+        as "features unlocked" from ANY perspective epoch.
+      * ``[]`` when the license IS valid AS OF ``epoch`` but its payload
+        carries no explicit ``features`` claim (or the claim is present
+        but holds no usable string ids). Distinct from ``None``: a UI
+        binding this helper must render both branches -- ``None`` -> "no
+        entitlement at that time", ``[]`` -> "entitled but no features
+        itemised" -- without collapsing them, or a valid-key-with-empty-
+        list user will silently render as "unlicensed" for the audit
+        row.
+      * A sorted, deduplicated, normalised (lower-cased, whitespace-
+        stripped) ``list[str]`` of feature ids otherwise. Normalisation
+        matches :func:`license_features` byte-for-byte so a caller
+        zipping the two lists (perspective-at vs current-now) can't
+        catch them disagreeing on casing.
+
+    ``epoch`` is coerced through ``int()``; ``bool`` is explicitly
+    refused despite being an ``int`` subclass so a caller that passes
+    ``True`` / ``False`` gets ``None`` back rather than a spurious "was
+    feature X entitled at epoch 1?" classification. A non-numeric value
+    collapses to ``None`` so a caller cannot silently mis-gate on a
+    typo -- the conservative fallback since ``None`` implies no
+    entitlement, matching the never-mis-gate posture of the surrounding
+    ``_at`` family.
+
+    When ``epoch`` equals "now", this scalar must agree with
+    :func:`license_features` for the same install -- both derive from
+    the same signed ``features`` claim, refuse the invalid-signature
+    branch, and use the same ``exp <= cutoff`` boundary via
+    :func:`license_state_at` / the current-time ``valid`` classifier,
+    so the two scalars cannot disagree at the boundary. On any other
+    epoch this helper answers the retrospective / prospective question
+    :func:`license_features` cannot -- e.g. "which features was this
+    node entitled to last quarter?" (``None`` on a key that has since
+    been renewed but was already expired then) or "which features will
+    this node still have at our next audit?" (``None`` on an active key
+    whose ``exp`` falls before the audit date).
+
+    Never raises. Any underlying introspection failure (import error,
+    corrupt install, cryptography-lib mismatch) collapses to ``None``
+    -- same fallback as :func:`license_features` -- so a scheduled
+    audit tile bound to this helper never breaks on a partial install.
+
+    Note: the ``features`` claim is a SUPPLEMENTAL string list carried
+    on the license token; it is NOT the canonical open-core feature
+    catalogue. This helper surfaces the claim exactly as written on the
+    token (with the perspective-epoch validity gate on top), so
+    operator diagnostics can distinguish "feature X was entitled on
+    <date> because the key claimed it" from "feature X was entitled on
+    <date> because the tier granted it by default".
+
+    Pairs with the sibling ``_at`` scalars
+    (:func:`license_state_at`, :func:`license_tier_at`,
+    :func:`is_expired_at`, :func:`days_until_expiry_at`) at the row
+    level: for the same ``epoch``, a caller can zip the responses
+    index-for-index and hydrate the whole entitlement row for one
+    install without the scalars catching each other disagreeing on the
+    perspective-epoch classification.
+    """
+    if isinstance(epoch, bool):
+        return None
+    try:
+        wanted = int(epoch)
+    except (TypeError, ValueError):
+        return None
+    try:
+        info = current_license_info()
+    except Exception as exc:
+        logger.debug(
+            "license: license_features_at underlying read failed: %s", exc
+        )
+        return None
+    if not isinstance(info, dict):
+        return None
+    status = info.get("status")
+    if status == "invalid":
+        # Signature-bogus branch: an unsigned body is untrusted whatever
+        # the perspective, so the classification is time-independent.
+        # Mirrors :func:`license_features` -- payload-derived claims
+        # never get to influence the answer here.
+        return None
+    exp = info.get("exp")
+    if isinstance(exp, (int, float)) and int(exp) <= wanted:
+        # Signed key that has already lapsed AS OF ``epoch`` -- refuse
+        # for the same reason :func:`license_features` refuses the
+        # expired branch at "now": a lapsed customer must stop rendering
+        # as "features unlocked" once the perspective epoch is past
+        # ``exp``.
+        return None
+    # ``current_license_info`` does not surface the ``features`` claim
+    # in its envelope (kept intentionally narrow -- see its docstring),
+    # so re-open the license file and re-verify to pull the field. The
+    # gates above prove the file is on disk AND its signature verified
+    # once this call, so this second read cannot admit an unsigned
+    # body: any tamper between the two reads still fails
+    # :func:`verify_token`. Mirrors the same re-read pattern used by
+    # :func:`license_features`.
+    try:
+        if not os.path.isfile(LICENSE_PATH):
+            return None
+        with open(LICENSE_PATH, "r", encoding="utf-8") as fh:
+            payload = verify_token(fh.read().strip())
+    except Exception as exc:
+        logger.debug(
+            "license: license_features_at token re-read failed: %s", exc
+        )
+        return None
+    if not isinstance(payload, dict):
+        return None
+    raw = payload.get("features")
+    # A missing / non-list ``features`` claim collapses to the empty
+    # list (valid license, zero features itemised) -- distinct from
+    # ``None`` which means no valid license at all. See docstring.
+    if not isinstance(raw, (list, tuple)):
+        return []
+    seen: set[str] = set()
+    out: list[str] = []
+    for item in raw:
+        if not isinstance(item, str):
+            # Ignore non-string entries defensively. An attacker who
+            # can't forge the signature also can't smuggle a non-string
+            # feature id past ``json.loads`` here, but a legit server-
+            # side typo (e.g. an integer feature id) shouldn't blow up
+            # the tile -- skip it and keep going.
+            continue
+        norm = item.strip().lower()
+        if not norm or norm in seen:
+            continue
+        seen.add(norm)
+        out.append(norm)
+    out.sort()
+    return out
+
+
+def license_features_at_batch(epochs) -> list[dict]:
+    """Per-value perspective-epoch license-features scalar for N epochs
+    in ONE round-trip.
+
+    Per-value axis batch sibling of :func:`license_features_at`. Fills
+    the ``_at_batch`` slot on the license-features axis alongside the
+    singular :func:`license_features_at` and the "now" flavour
+    :func:`license_features`, so a scheduled-audit / retrospective tile
+    that wants to plot the ``features`` claim across a sequence of
+    perspective dates ("which features was this node entitled to on
+    each of these audit dates?") renders off ONE call instead of
+    fanning out N calls to the scalar.
+
+    Each item in ``epochs`` may be:
+
+      * an int (or int-parseable string) -- a perspective epoch. The
+        emitted row's ``features`` field is what
+        :func:`license_features_at` would return for that epoch alone.
+      * ``bool`` (subclass of ``int``) or any non-int-parseable value
+        (``None``, empty string, non-numeric string) -- collapses to a
+        row with ``features=None``, matching the never-mis-gate posture
+        :func:`license_features_at` uses for the same inputs. The raw
+        stringified token surfaces in ``epoch`` so a caller can still
+        identify the offending entry.
+
+    Row shape::
+
+        {
+          "epoch":    <int> | "<raw>",
+          "features": [<id>, ...] | None,
+        }
+
+    Semantics per row mirror :func:`license_features_at`:
+
+      * ``None`` on no license, invalid signature, an ``exp`` claim
+        that has already lapsed at ``epoch``, and ``bool`` / non-
+        numeric epochs.
+      * ``[]`` on a signature-valid license AS OF ``epoch`` whose
+        payload carries no explicit ``features`` claim (or holds no
+        usable string ids). Distinct from ``None``.
+      * A sorted, deduplicated, normalised (lower/strip) ``list[str]``
+        of feature ids on a signature-valid, non-expired-at-``epoch``
+        key that carries a well-formed ``features`` claim.
+
+    Duplicates by normalised int key (or ``repr(raw)`` for bad inputs)
+    are dropped preserving first-seen order for byte-stable output.
+    ``epochs is None`` or non-iterable -- returns ``[]``. Never raises:
+    per-row failures short-circuit to ``features=None`` so the batch
+    keeps building. Matches the never-mis-gate posture used by
+    :func:`license_features_at` -- a bad row cannot silently claim a
+    features list that would grant unearned entitlement.
+
+    When any row's ``epoch`` equals "now", the row's ``features`` field
+    must byte-equal :func:`license_features` for the same install --
+    both derive from the same signed ``features`` claim via
+    :func:`license_features_at` / :func:`license_features`, so a caller
+    binding both cannot catch them disagreeing at the boundary.
+
+    Pairs with :func:`license_state_at_batch` /
+    :func:`is_expired_at_batch` / :func:`days_until_expiry_at_batch` /
+    :func:`license_tier_at_batch` on the row-shape axis: for the same
+    epochs list, a caller can zip the responses index-for-index and
+    hydrate a whole entitlement timeline row for one install in a
+    handful of round-trips instead of ``N * M`` calls to the scalar
+    surface.
+    """
+    out: list[dict] = []
+    for raw, _key, parsed in _license_epoch_batch_keys(epochs):
+        if parsed is None:
+            try:
+                token = str(raw)
+            except Exception:
+                token = repr(raw)
+            out.append({"epoch": token, "features": None})
+            continue
+        try:
+            feats = license_features_at(parsed)
+        except Exception as exc:
+            logger.debug(
+                "license: license_features_at_batch per-row failed: %s", exc
+            )
+            feats = None
+        if feats is not None and not isinstance(feats, list):
+            # Defensive: the scalar contract is list[str] | None, but a
+            # future change that ever emitted a non-list would silently
+            # break the per-row parity guarantee. Collapse to None.
+            feats = None
+        out.append({"epoch": parsed, "features": feats})
+    return out

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -12132,6 +12132,265 @@ def api_license_tier_at_batch():
     )
 
 
+
+def _license_features_at_snapshot() -> dict:
+    """Shared one-shot read for the paired ``/api/license/features-at``
+    and ``/api/license/features-at-batch`` endpoints below.
+
+    Reads :func:`clawmetry.license.license_features` (current-time
+    features list), :func:`clawmetry.license.current_license_info` (for
+    ``has_license`` / ``valid`` NOW), and
+    :func:`clawmetry.license.license_expires_at` (for the ``expires_at``
+    field the sibling perspective-epoch tiles all carry) ONCE so a UI
+    binding both endpoints in the same tile can't catch them disagreeing
+    on ``features`` / ``expires_at`` / ``has_license`` / ``valid`` for
+    the same install -- mirrors the ``_license_state_at_snapshot``
+    pattern used by the state-derived perspective-epoch trio.
+
+    ``features`` here is the CURRENT-time features list (matches
+    :func:`clawmetry.license.license_features`); the perspective-epoch
+    features list (``features_at``) is derived per-request by each
+    endpoint via :func:`clawmetry.license.license_features_at` and
+    lives on top of this snapshot -- keeping ``features`` in the shared
+    read guarantees a UI that renders "as of <date> vs now" tiles
+    side-by-side can never catch them disagreeing on the current-time
+    reference.
+
+    Never raises. Any introspection failure collapses to the OSS-free
+    branch shape (``features=None``, ``expires_at=None``,
+    ``has_license=False``, ``valid=False``) so the endpoint stack never
+    5xxs -- same posture as the surrounding license endpoints.
+    """
+    try:
+        from clawmetry import license as _lic
+
+        feats = _lic.license_features()
+        info = _lic.current_license_info()
+        expires = _lic.license_expires_at()
+    except Exception as exc:
+        logger.debug(
+            "_license_features_at_snapshot: underlying read failed: %s", exc
+        )
+        return {
+            "features": None,
+            "expires_at": None,
+            "has_license": False,
+            "valid": False,
+        }
+    if feats is not None and not isinstance(feats, list):
+        feats = None
+    if info is None or not isinstance(info, dict):
+        return {
+            "features": feats,
+            "expires_at": None,
+            "has_license": False,
+            "valid": False,
+        }
+    return {
+        "features": feats,
+        "expires_at": expires,
+        "has_license": True,
+        "valid": bool(info.get("valid")),
+    }
+
+
+@bp_entitlement.route("/api/license/features-at")
+def api_license_features_at():
+    """``GET /api/license/features-at?epoch=<int>`` -- scalar view of
+    the installed license's ``features`` claim evaluated as of
+    ``epoch`` -- the perspective-epoch flavour of
+    ``/api/license/features``, for a scheduled-audit / retrospective
+    diagnostic tile that wants to answer "which paid features was this
+    node entitled to on <date>?" without the caller having to snapshot
+    the license state at that time or compare ``exp`` to a caller-
+    supplied epoch themselves.
+
+    Response shape (always HTTP 200)::
+
+        {
+          "features_at": [<id>, ...] | null,   # features as of epoch
+          "requested_epoch": <int|null>,       # int-coerced input, or null on typo
+          "features": [<id>, ...] | null,      # current-time features
+          "expires_at": <int|null>,            # on-disk exp for comparison
+          "has_license": <bool>,               # is a license file installed at all?
+          "valid": <bool>                      # signature-valid AND not expired NOW
+        }
+
+    ``features_at`` mirrors :func:`clawmetry.license.license_features_at`:
+
+      * ``null`` on no license, invalid signature, an ``exp`` claim
+        that has already lapsed at ``epoch``, or missing / non-integer
+        / bool ``epoch`` so a caller cannot silently mis-gate on a
+        typo.
+      * ``[]`` on a signature-valid license AS OF ``epoch`` whose
+        payload carries no explicit ``features`` claim. Distinct from
+        ``null``: a UI binding this endpoint must render both branches
+        (``null`` -> "no entitlement at that time", ``[]`` -> "entitled
+        but no features itemised") without collapsing them.
+      * A sorted, deduplicated, normalised (lower/strip) list of
+        feature ids otherwise.
+
+    Query parameter:
+
+      * ``epoch`` -- required. Unix epoch seconds as an integer. A
+        missing / non-integer / bool value collapses to
+        ``features_at=null`` with ``requested_epoch=null`` so a caller
+        cannot silently mis-gate on a typo. HTTP status is 200 either
+        way -- the "bad input" signal is ``requested_epoch=null`` plus
+        the ``null`` features, not a 4xx, matching the never-crash
+        posture of the surrounding license endpoints.
+
+    Pairs with ``/api/license/state-at`` / ``/api/license/tier-at`` /
+    ``/api/license/is-expired-at`` / ``/api/license/days-until-expiry-at``
+    -- all four share the perspective-epoch input pattern and the
+    ``_license_features_at_snapshot`` reader here carries
+    ``expires_at`` / ``has_license`` / ``valid`` on the same shape the
+    state-derived siblings carry, so a UI binding two for the same
+    install cannot catch them disagreeing on the current-time
+    reference fields.
+
+    When ``epoch`` equals "now", the ``features_at`` field must byte-
+    equal ``features`` (both derive from the same signed ``features``
+    claim, refuse the invalid-signature branch, and use the same
+    ``exp <= cutoff`` boundary via :func:`license_features_at` /
+    :func:`license_features`), so a UI binding both cannot catch them
+    disagreeing at the boundary.
+
+    Note: the ``features`` claim is a SUPPLEMENTAL string list carried
+    on the license token; it is NOT the canonical open-core feature
+    catalogue. For the resolved feature set actually enforced by
+    gates, read ``/api/entitlement`` (which layers this claim on top of
+    the FREE-tier baseline). This endpoint surfaces the claim exactly
+    as written on the token with the perspective-epoch validity gate on
+    top.
+
+    Never 5xxs -- any underlying failure degrades to
+    ``{features_at: null, requested_epoch: <echo>, features: null,
+    expires_at: null, has_license: false, valid: false}`` (the OSS-
+    free branch shape).
+    """
+    raw = request.args.get("epoch", "")
+    try:
+        requested = int(str(raw).strip())
+    except (TypeError, ValueError):
+        requested = None
+    try:
+        snap = _license_features_at_snapshot()
+    except Exception as exc:
+        logger.warning("api_license_features_at: snapshot error: %s", exc)
+        snap = {
+            "features": None,
+            "expires_at": None,
+            "has_license": False,
+            "valid": False,
+        }
+    features_at: list | None = None
+    if requested is not None:
+        try:
+            from clawmetry import license as _lic
+
+            features_at = _lic.license_features_at(requested)
+        except Exception as exc:
+            logger.warning("api_license_features_at: derive error: %s", exc)
+            features_at = None
+    if features_at is not None and not isinstance(features_at, list):
+        features_at = None
+    return jsonify(
+        {
+            "features_at": features_at,
+            "requested_epoch": requested,
+            "features": snap["features"],
+            "expires_at": snap["expires_at"],
+            "has_license": snap["has_license"],
+            "valid": snap["valid"],
+        }
+    )
+
+
+@bp_entitlement.route("/api/license/features-at-batch")
+def api_license_features_at_batch():
+    """``GET /api/license/features-at-batch?epochs=<int>,<int>,...`` --
+    per-value batch sibling of ``/api/license/features-at``.
+
+    Where the singular endpoint folds ONE perspective epoch to ONE
+    features answer, this preserves per-value rows so a scheduled-audit
+    tile that wants to plot the ``features`` claim across a sequence of
+    dates ("which features was this node entitled to on each of these
+    audit dates?") renders off ONE round-trip instead of N calls to
+    ``/api/license/features-at``. Wraps
+    :func:`clawmetry.license.license_features_at_batch`.
+
+    ``epochs=`` is required. Missing / blank / only-commas -> ``400
+    missing epochs``. Comma-separated tokens are normalised the way the
+    underlying batch helper normalises them: whitespace-stripped, then
+    handed to :func:`clawmetry.license.license_features_at_batch`,
+    which dedupes by parsed int key preserving first-seen order and
+    collapses non-int / ``bool`` / ``None`` tokens to a row with
+    ``features=null`` (never-mis-gate posture matching the scalar
+    endpoint). Never 5xxs: a resolver failure returns the empty-rows
+    envelope with the current-time snapshot fields intact.
+
+    Response shape (always HTTP 200)::
+
+        {
+          "kind":  "license_features_at",
+          "count": <int>,               # len(rows)
+          "rows":  [
+            {"epoch": <int|"<raw>">, "features": [<id>, ...]|null},
+            ...
+          ],
+          "features":    [<id>, ...] | null,   # current-time features
+          "expires_at":  <int|null>,           # on-disk exp for comparison
+          "has_license": <bool>,
+          "valid":       <bool>                # signature-valid AND not expired NOW
+        }
+
+    Per-row parity with ``/api/license/features-at?epoch=<n>`` is
+    pinned in the test suite so the batch cannot silently drift from
+    the scalar endpoint. Shares :func:`_license_features_at_snapshot`
+    with the scalar endpoint so the current-time reference fields
+    (``features`` / ``expires_at`` / ``has_license`` / ``valid``)
+    cannot disagree between the two for the same install.
+    """
+    tokens, err = _parse_license_epochs_csv("epochs")
+    if err == "missing":
+        return jsonify({"error": "missing epochs"}), 400
+    try:
+        snap = _license_features_at_snapshot()
+    except Exception as exc:
+        logger.warning(
+            "api_license_features_at_batch: snapshot error: %s", exc
+        )
+        snap = {
+            "features": None,
+            "expires_at": None,
+            "has_license": False,
+            "valid": False,
+        }
+    try:
+        from clawmetry import license as _lic
+
+        rows = _lic.license_features_at_batch(tokens)
+    except Exception as exc:
+        logger.warning(
+            "api_license_features_at_batch: derive error: %s", exc
+        )
+        rows = []
+    return jsonify(
+        {
+            "kind": "license_features_at",
+            "count": len(rows),
+            "rows": rows,
+            "features": snap["features"],
+            "expires_at": snap["expires_at"],
+            "has_license": snap["has_license"],
+            "valid": snap["valid"],
+        }
+    )
+
+
+
+
 @bp_entitlement.route("/api/paywall/event", methods=["POST"])
 def api_paywall_event():
     body: dict = {}

--- a/tests/test_license_features_at.py
+++ b/tests/test_license_features_at.py
@@ -1,0 +1,768 @@
+"""Tests for the ``license_features_at(epoch)`` scalar and
+``license_features_at_batch(epochs)`` batch helpers on
+``clawmetry.license`` and their paired ``/api/license/features-at`` /
+``/api/license/features-at-batch`` HTTP endpoints.
+
+The perspective-epoch flavour of the ``license_features`` scalar. Both
+derive from the same signed ``features`` claim and refuse the invalid-
+signature branch, so they cannot disagree at the boundary when the
+perspective epoch equals "now"; on any other epoch these helpers answer
+"which features would :func:`license_features` have surfaced evaluated as
+of ``epoch``?" without the caller having to snapshot the license state
+at that time or compare ``exp`` to a caller-supplied epoch themselves.
+
+Hermetic: each test mints tokens with its own ephemeral keypair and
+monkeypatches the module's embedded public key + ``LICENSE_PATH``,
+mirroring ``tests/test_license_features_accessor.py`` /
+``tests/test_license_state_at_scalar.py`` so nothing depends on the
+real production signing key or on real filesystem state.
+"""
+from __future__ import annotations
+
+import os
+import time
+from types import SimpleNamespace
+
+import pytest
+from flask import Flask
+
+
+# -- shared helpers (mirror test_license_features_accessor.py) ----------------
+
+
+def _keypair():
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+    priv = Ed25519PrivateKey.generate()
+    pub_pem = priv.public_key().public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    return priv, pub_pem
+
+
+def _payload(
+    tier="pro",
+    nodes=3,
+    exp_delta=365 * 86400,
+    features=("runtimes", "alerts", "fleet"),
+    drop_exp=False,
+    drop_features=False,
+    features_value=None,
+):
+    """Build a license payload with knobs for every branch under test."""
+    now = int(time.time())
+    p = {
+        "sub": "acct_test",
+        "tier": tier,
+        "nodes": nodes,
+        "iat": now,
+        "exp": now + exp_delta,
+        "features": list(features),
+    }
+    if features_value is not None:
+        p["features"] = features_value
+    if drop_features:
+        p.pop("features", None)
+    if drop_exp:
+        p.pop("exp", None)
+    return p
+
+
+@pytest.fixture
+def app(monkeypatch, tmp_path):
+    import clawmetry.license as _lic
+
+    priv, pub_pem = _keypair()
+    monkeypatch.setattr(_lic, "_PUBLIC_KEY_PEM", pub_pem)
+    license_path = str(tmp_path / "license.key")
+    monkeypatch.setattr(_lic, "LICENSE_PATH", license_path)
+    monkeypatch.setattr(_lic, "_CONFIG_PATH", str(tmp_path / "config.json"))
+    monkeypatch.delenv("CLAWMETRY_LICENSE_SERVER", raising=False)
+    monkeypatch.delenv("CLAWMETRY_INGEST_URL", raising=False)
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("CLAWMETRY_OFFLINE", "1")
+
+    from routes.entitlement import bp_entitlement
+
+    flask_app = Flask(__name__)
+    flask_app.register_blueprint(bp_entitlement)
+    flask_app.config["TESTING"] = True
+
+    return SimpleNamespace(
+        app=flask_app,
+        lic=_lic,
+        priv=priv,
+        license_path=license_path,
+    )
+
+
+def _write_direct(app, payload):
+    """Bypass :func:`activate` (which refuses expired tokens and phones
+    home) and write a raw signed token to the license file."""
+    tok = app.lic._encode_token(payload, app.priv)
+    os.makedirs(os.path.dirname(app.license_path), exist_ok=True)
+    with open(app.license_path, "w", encoding="utf-8") as fh:
+        fh.write(tok)
+
+
+def _write_bogus(app):
+    os.makedirs(os.path.dirname(app.license_path), exist_ok=True)
+    with open(app.license_path, "w", encoding="utf-8") as fh:
+        fh.write("CLAW1.garbage.garbage")
+
+
+# -- clawmetry.license.license_features_at() ---------------------------------
+
+
+def test_license_features_at_no_license(app):
+    """No license file on disk -> ``None`` regardless of epoch."""
+    assert app.lic.license_features_at(int(time.time())) is None
+    assert app.lic.license_features_at(0) is None
+    assert app.lic.license_features_at(2_000_000_000) is None
+
+
+def test_license_features_at_now_matches_license_features_active(app):
+    """When ``epoch`` equals "now", perspective scalar must agree with
+    :func:`license_features` on an active install. Both derive from the
+    same signed ``features`` claim, so a UI binding both cannot catch
+    them disagreeing at the boundary."""
+    _write_direct(app, _payload(features=("runtimes", "alerts", "fleet")))
+    now = int(time.time())
+    assert app.lic.license_features_at(now) == ["alerts", "fleet", "runtimes"]
+    assert app.lic.license_features() == ["alerts", "fleet", "runtimes"]
+
+
+def test_license_features_at_now_matches_license_features_lapsed(app):
+    """Lapsed-key parity: at "now", perspective scalar and base scalar
+    must both return ``None`` -- both refuse the expired branch."""
+    _write_direct(app, _payload(exp_delta=-5 * 86400))
+    now = int(time.time())
+    assert app.lic.license_features_at(now) is None
+    assert app.lic.license_features() is None
+
+
+def test_license_features_at_future_epoch_before_expiry(app):
+    """Future perspective still before ``exp`` -> features surface."""
+    _write_direct(app, _payload(exp_delta=30 * 86400))
+    epoch = int(time.time()) + 10 * 86400
+    assert app.lic.license_features_at(epoch) == ["alerts", "fleet", "runtimes"]
+
+
+def test_license_features_at_future_epoch_after_expiry(app):
+    """Future perspective AFTER ``exp`` on an active key -> ``None``
+    (the key WILL be expired at that perspective). Prospective "will we
+    still be entitled at the next audit?" scenario."""
+    _write_direct(app, _payload(exp_delta=30 * 86400))
+    epoch = int(time.time()) + 60 * 86400
+    assert app.lic.license_features_at(epoch) is None
+
+
+def test_license_features_at_past_epoch_still_active(app):
+    """Perspective BEFORE now on an active key -> features surface (the
+    key was not yet expired then)."""
+    _write_direct(app, _payload(exp_delta=30 * 86400))
+    epoch = int(time.time()) - 10 * 86400
+    assert app.lic.license_features_at(epoch) == ["alerts", "fleet", "runtimes"]
+
+
+def test_license_features_at_lapsed_key_pre_lapse_epoch_surfaces_features(app):
+    """Lapsed-but-signed key at a perspective BEFORE its ``exp`` ->
+    features surface (retrospective "which were unlocked on <date>?").
+    At "now" (past ``exp``) -> ``None``."""
+    _write_direct(app, _payload(exp_delta=-5 * 86400))  # exp = now - 5d
+    now = int(time.time())
+    assert app.lic.license_features_at(now - 20 * 86400) == [
+        "alerts",
+        "fleet",
+        "runtimes",
+    ]
+    assert app.lic.license_features_at(now - 3 * 86400) is None
+    assert app.lic.license_features_at(now) is None
+
+
+def test_license_features_at_exact_exp_boundary(app):
+    """At the exact ``exp`` second, features must collapse to ``None``
+    -- the ``<= epoch`` cutoff matches :func:`license_state_at`'s
+    ``exp <= epoch`` boundary."""
+    _write_direct(app, _payload(exp_delta=30 * 86400))
+    info = app.lic.current_license_info()
+    exp_epoch = int(info["exp"])
+    assert app.lic.license_features_at(exp_epoch - 1) == [
+        "alerts",
+        "fleet",
+        "runtimes",
+    ]
+    assert app.lic.license_features_at(exp_epoch) is None
+    assert app.lic.license_features_at(exp_epoch + 1) is None
+
+
+def test_license_features_at_perpetual_key(app):
+    """Perpetual (no ``exp``) key -> features surface at every epoch."""
+    _write_direct(app, _payload(drop_exp=True))
+    assert app.lic.license_features_at(0) == ["alerts", "fleet", "runtimes"]
+    assert app.lic.license_features_at(int(time.time())) == [
+        "alerts",
+        "fleet",
+        "runtimes",
+    ]
+    assert app.lic.license_features_at(2_000_000_000) == [
+        "alerts",
+        "fleet",
+        "runtimes",
+    ]
+
+
+def test_license_features_at_invalid_signature(app):
+    """Bogus-signature file -> ``None`` regardless of epoch (time-
+    independent, matches :func:`license_features`)."""
+    _write_bogus(app)
+    assert app.lic.license_features_at(0) is None
+    assert app.lic.license_features_at(int(time.time())) is None
+    assert app.lic.license_features_at(2_000_000_000) is None
+
+
+def test_license_features_at_normalises_case_and_whitespace(app):
+    """Server-side typos in casing / whitespace on the feature ids
+    normalise here, so gates comparing to lower-cased constants don't
+    silently miss."""
+    _write_direct(app, _payload(features=(" Alerts ", "FLEET", "runtimes ")))
+    assert app.lic.license_features_at(int(time.time())) == [
+        "alerts",
+        "fleet",
+        "runtimes",
+    ]
+
+
+def test_license_features_at_dedup(app):
+    """Duplicates on the claim (server-side typo) collapse to one
+    normalised id."""
+    _write_direct(
+        app, _payload(features=("alerts", "ALERTS", "alerts ", "fleet"))
+    )
+    assert app.lic.license_features_at(int(time.time())) == ["alerts", "fleet"]
+
+
+def test_license_features_at_missing_claim_returns_empty_list(app):
+    """Valid signed key with the ``features`` claim omitted -> ``[]``
+    (valid license, zero features itemised) -- distinct from ``None``
+    which means no valid license at all."""
+    _write_direct(app, _payload(drop_features=True))
+    assert app.lic.license_features_at(int(time.time())) == []
+
+
+def test_license_features_at_non_list_claim_returns_empty_list(app):
+    """Server-side typo where the ``features`` claim is not a list ->
+    ``[]``, matching :func:`license_features`. A non-list body cannot
+    smuggle entitlement through, but the key is still valid so the row
+    isn't ``None``."""
+    _write_direct(app, _payload(features_value="alerts"))
+    assert app.lic.license_features_at(int(time.time())) == []
+
+
+def test_license_features_at_ignores_non_string_entries(app):
+    """Non-string entries on the claim are skipped defensively. A legit
+    server-side typo (integer feature id) shouldn't blow up the tile."""
+    _write_direct(
+        app, _payload(features_value=["alerts", 123, None, "fleet", ""])
+    )
+    assert app.lic.license_features_at(int(time.time())) == ["alerts", "fleet"]
+
+
+def test_license_features_at_bool_epoch_refused(app):
+    """``bool`` is an ``int`` subclass but must be refused so a caller
+    passing ``True`` / ``False`` gets ``None`` back, not a spurious
+    "was feature X entitled at epoch 1?" answer."""
+    _write_direct(app, _payload(exp_delta=30 * 86400))
+    assert app.lic.license_features_at(True) is None
+    assert app.lic.license_features_at(False) is None
+
+
+def test_license_features_at_non_numeric_epoch(app):
+    """Non-numeric epoch -> ``None`` so a caller cannot silently mis-
+    gate on a typo -- conservative fallback since ``None`` implies no
+    entitlement."""
+    _write_direct(app, _payload(exp_delta=30 * 86400))
+    assert app.lic.license_features_at("not-a-number") is None
+    assert app.lic.license_features_at(None) is None
+    assert app.lic.license_features_at([]) is None
+
+
+def test_license_features_at_string_epoch_coerced(app):
+    """String epoch that ``int()`` accepts -> coerced and honoured,
+    matching :func:`license_state_at`."""
+    _write_direct(app, _payload(exp_delta=30 * 86400))
+    now = int(time.time())
+    assert app.lic.license_features_at(str(now)) == [
+        "alerts",
+        "fleet",
+        "runtimes",
+    ]
+
+
+def test_license_features_at_never_raises(app, monkeypatch):
+    """Any underlying failure -> ``None`` -- never propagates."""
+    _write_direct(app, _payload(exp_delta=30 * 86400))
+
+    def _boom():
+        raise RuntimeError("simulated corrupt install")
+
+    monkeypatch.setattr(app.lic, "current_license_info", _boom)
+    assert app.lic.license_features_at(int(time.time())) is None
+
+
+# -- clawmetry.license.license_features_at_batch() ---------------------------
+
+
+def test_license_features_at_batch_none_returns_empty(app):
+    """``epochs is None`` -> ``[]``. Mirrors the never-raise posture of
+    the sibling per-value axis batches."""
+    assert app.lic.license_features_at_batch(None) == []
+
+
+def test_license_features_at_batch_non_iterable_returns_empty(app):
+    """Non-iterable ``epochs`` (an int -- probable typo for a caller
+    that forgot to wrap it) -> ``[]`` rather than a crash."""
+    assert app.lic.license_features_at_batch(42) == []
+
+
+def test_license_features_at_batch_empty_returns_empty(app):
+    """Empty iterable -> ``[]``."""
+    assert app.lic.license_features_at_batch([]) == []
+    assert app.lic.license_features_at_batch(()) == []
+
+
+def test_license_features_at_batch_no_license(app):
+    """No license file on disk -> every row ``features=None`` regardless
+    of epoch. Time-independent, matches the scalar."""
+    epochs = [0, int(time.time()), 2_000_000_000]
+    rows = app.lic.license_features_at_batch(epochs)
+    assert [r["features"] for r in rows] == [None] * 3
+    assert [r["epoch"] for r in rows] == epochs
+
+
+def test_license_features_at_batch_active_key_mixed_epochs(app):
+    """Active key: perspectives before ``exp`` -> features surface;
+    after ``exp`` -> ``None``. Batch preserves per-row ordering."""
+    _write_direct(app, _payload(exp_delta=30 * 86400))
+    now = int(time.time())
+    epochs = [now, now + 10 * 86400, now + 60 * 86400, now + 90 * 86400]
+    rows = app.lic.license_features_at_batch(epochs)
+    assert [r["features"] for r in rows] == [
+        ["alerts", "fleet", "runtimes"],
+        ["alerts", "fleet", "runtimes"],
+        None,
+        None,
+    ]
+    assert [r["epoch"] for r in rows] == epochs
+
+
+def test_license_features_at_batch_per_row_parity_with_scalar(app):
+    """Per-row parity with :func:`license_features_at` -- the batch
+    cannot silently drift from the scalar. Pin every row against the
+    singular helper on the same install."""
+    _write_direct(app, _payload(exp_delta=30 * 86400))
+    now = int(time.time())
+    epochs = [
+        now - 10 * 86400,
+        now,
+        now + 5 * 86400,
+        now + 40 * 86400,
+        now + 200 * 86400,
+    ]
+    rows = app.lic.license_features_at_batch(epochs)
+    for row, epoch in zip(rows, epochs):
+        assert row["features"] == app.lic.license_features_at(epoch), epoch
+
+
+def test_license_features_at_batch_perpetual_key(app):
+    """Perpetual (no ``exp``) key -> features surface at every row."""
+    _write_direct(app, _payload(drop_exp=True))
+    epochs = [0, int(time.time()), 2_000_000_000]
+    rows = app.lic.license_features_at_batch(epochs)
+    assert [r["features"] for r in rows] == [
+        ["alerts", "fleet", "runtimes"]
+    ] * 3
+
+
+def test_license_features_at_batch_invalid_signature(app):
+    """Bogus-signature file -> every row ``None`` (time-independent)."""
+    _write_bogus(app)
+    rows = app.lic.license_features_at_batch([0, int(time.time()), 2_000_000_000])
+    assert [r["features"] for r in rows] == [None] * 3
+
+
+def test_license_features_at_batch_lapsed_key_flips_per_row(app):
+    """Lapsed-but-signed key at a perspective BEFORE its ``exp`` ->
+    features surface; at / after ``exp`` -> ``None``. Batch flips per
+    row."""
+    _write_direct(app, _payload(exp_delta=-5 * 86400))  # exp = now - 5d
+    now = int(time.time())
+    rows = app.lic.license_features_at_batch(
+        [now - 20 * 86400, now - 3 * 86400, now]
+    )
+    assert [r["features"] for r in rows] == [
+        ["alerts", "fleet", "runtimes"],
+        None,
+        None,
+    ]
+
+
+def test_license_features_at_batch_missing_claim_returns_empty_list_row(app):
+    """Valid signed key with the ``features`` claim omitted -> per-row
+    ``features=[]`` (valid license, zero features itemised) -- distinct
+    from ``None`` which means no valid license at all."""
+    _write_direct(app, _payload(drop_features=True))
+    now = int(time.time())
+    rows = app.lic.license_features_at_batch([now, now + 3600])
+    assert [r["features"] for r in rows] == [[], []]
+
+
+def test_license_features_at_batch_bad_epochs_collapse_per_row(app):
+    """``bool`` / non-numeric epochs collapse the corresponding row to
+    ``features=None`` with the raw token surfaced in ``epoch`` --
+    matches the never-mis-gate posture the scalar uses for the same
+    inputs."""
+    _write_direct(app, _payload(exp_delta=30 * 86400))
+    now = int(time.time())
+    rows = app.lic.license_features_at_batch(
+        [now, True, "nope", None, now + 3600]
+    )
+    assert len(rows) == 5
+    good_rows = [
+        r
+        for r in rows
+        if isinstance(r["epoch"], int) and r["features"] == [
+            "alerts",
+            "fleet",
+            "runtimes",
+        ]
+    ]
+    assert len(good_rows) == 2
+    bad_rows = [r for r in rows if r["features"] is None]
+    assert len(bad_rows) == 3
+
+
+def test_license_features_at_batch_dedup_preserves_first_seen(app):
+    """Duplicate epochs are dropped preserving first-seen order for
+    byte-stable output."""
+    _write_direct(app, _payload(exp_delta=30 * 86400))
+    now = int(time.time())
+    rows = app.lic.license_features_at_batch([now, now, now + 10, now])
+    assert [r["epoch"] for r in rows] == [now, now + 10]
+
+
+def test_license_features_at_batch_string_epochs_coerced(app):
+    """String tokens that ``int()`` accepts -> coerced and honoured,
+    matching the query-string surface (the batch endpoint hands the
+    helper stripped tokens)."""
+    _write_direct(app, _payload(exp_delta=30 * 86400))
+    now = int(time.time())
+    rows = app.lic.license_features_at_batch([str(now), str(now + 10)])
+    assert [r["features"] for r in rows] == [
+        ["alerts", "fleet", "runtimes"],
+        ["alerts", "fleet", "runtimes"],
+    ]
+
+
+def test_license_features_at_batch_never_raises(app, monkeypatch):
+    """Any per-row underlying failure of :func:`license_features_at` ->
+    ``features=None`` for THAT row. The batch never propagates."""
+    _write_direct(app, _payload(exp_delta=30 * 86400))
+
+    def _boom(_epoch):
+        raise RuntimeError("simulated corrupt install")
+
+    monkeypatch.setattr(app.lic, "license_features_at", _boom)
+    rows = app.lic.license_features_at_batch([1_700_000_000, 1_700_000_010])
+    assert [r["features"] for r in rows] == [None, None]
+    assert len(rows) == 2
+
+
+def test_license_features_at_batch_bytestable_across_calls(app):
+    """Same input -> byte-stable output across repeated calls (dedup
+    preserves first-seen order)."""
+    _write_direct(app, _payload(exp_delta=30 * 86400))
+    now = int(time.time())
+    a = app.lic.license_features_at_batch([now, now + 10, now + 20])
+    b = app.lic.license_features_at_batch([now, now + 10, now + 20])
+    assert a == b
+
+
+# -- GET /api/license/features-at --------------------------------------------
+
+
+def test_api_features_at_no_license(app):
+    """No license file on disk -> ``features_at=null``, current-time
+    reference fields all reflect the OSS-free branch."""
+    now = int(time.time())
+    with app.app.test_client() as client:
+        rv = client.get(f"/api/license/features-at?epoch={now}")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["features_at"] is None
+    assert body["requested_epoch"] == now
+    assert body["features"] is None
+    assert body["expires_at"] is None
+    assert body["has_license"] is False
+    assert body["valid"] is False
+
+
+def test_api_features_at_active_key_now(app):
+    """Active key at "now" -> ``features_at=features``, snapshot fields
+    intact."""
+    _write_direct(app, _payload(exp_delta=30 * 86400))
+    now = int(time.time())
+    with app.app.test_client() as client:
+        rv = client.get(f"/api/license/features-at?epoch={now}")
+    body = rv.get_json()
+    assert body["features_at"] == ["alerts", "fleet", "runtimes"]
+    assert body["features"] == ["alerts", "fleet", "runtimes"]
+    assert body["expires_at"] is not None
+    assert body["has_license"] is True
+    assert body["valid"] is True
+
+
+def test_api_features_at_missing_epoch_collapses(app):
+    """Missing / non-integer / bool ``epoch`` -> ``features_at=null``
+    and ``requested_epoch=null`` so a caller cannot silently mis-gate on
+    a typo. HTTP status stays 200."""
+    _write_direct(app, _payload(exp_delta=30 * 86400))
+    with app.app.test_client() as client:
+        for qs in ("", "?epoch=", "?epoch=nope", "?epoch=true"):
+            rv = client.get(f"/api/license/features-at{qs}")
+            assert rv.status_code == 200, qs
+            body = rv.get_json()
+            assert body["features_at"] is None, qs
+            assert body["requested_epoch"] is None, qs
+
+
+def test_api_features_at_future_after_expiry(app):
+    """Future perspective past ``exp`` on an active key ->
+    ``features_at=null`` even though ``features`` (current-time) still
+    surfaces the list."""
+    _write_direct(app, _payload(exp_delta=30 * 86400))
+    epoch = int(time.time()) + 60 * 86400
+    with app.app.test_client() as client:
+        rv = client.get(f"/api/license/features-at?epoch={epoch}")
+    body = rv.get_json()
+    assert body["features_at"] is None
+    assert body["features"] == ["alerts", "fleet", "runtimes"]
+
+
+def test_api_features_at_invalid_signature(app):
+    """Bogus-signature file -> ``features_at=null``. ``has_license=True``
+    (a file exists) but ``valid=False``. Time-independent."""
+    _write_bogus(app)
+    with app.app.test_client() as client:
+        rv = client.get(f"/api/license/features-at?epoch={int(time.time())}")
+    body = rv.get_json()
+    assert body["features_at"] is None
+    assert body["features"] is None
+    assert body["has_license"] is True
+    assert body["valid"] is False
+
+
+def test_api_features_at_missing_claim_returns_empty_list(app):
+    """Valid signed key with the ``features`` claim omitted ->
+    ``features_at=[]`` (distinct from ``null``)."""
+    _write_direct(app, _payload(drop_features=True))
+    now = int(time.time())
+    with app.app.test_client() as client:
+        rv = client.get(f"/api/license/features-at?epoch={now}")
+    body = rv.get_json()
+    assert body["features_at"] == []
+    assert body["features"] == []
+
+
+def test_api_features_at_scalar_parity_with_python(app):
+    """The endpoint must return exactly what ``license_features_at``
+    would return for the same epoch."""
+    _write_direct(app, _payload(exp_delta=30 * 86400))
+    now = int(time.time())
+    with app.app.test_client() as client:
+        for epoch in [now - 10 * 86400, now, now + 5 * 86400, now + 40 * 86400]:
+            rv = client.get(f"/api/license/features-at?epoch={epoch}")
+            body = rv.get_json()
+            assert body["features_at"] == app.lic.license_features_at(epoch), epoch
+
+
+# -- GET /api/license/features-at-batch --------------------------------------
+
+
+def test_api_features_at_batch_missing_epochs_400(app):
+    """Missing / blank / only-commas ``epochs=`` -> ``400 missing
+    epochs`` (matches the sibling ``/api/license/*-at-batch`` endpoints)."""
+    with app.app.test_client() as client:
+        for qs in ("", "?epochs=", "?epochs=,,"):
+            rv = client.get(f"/api/license/features-at-batch{qs}")
+            assert rv.status_code == 400, qs
+            assert rv.get_json() == {"error": "missing epochs"}
+
+
+def test_api_features_at_batch_no_license(app):
+    """No license file on disk -> every row ``features=null``. Reference
+    fields all reflect the OSS-free branch."""
+    now = int(time.time())
+    with app.app.test_client() as client:
+        rv = client.get(
+            f"/api/license/features-at-batch?epochs={now},{now + 3600}"
+        )
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["kind"] == "license_features_at"
+    assert body["count"] == 2
+    assert [r["features"] for r in body["rows"]] == [None, None]
+    assert body["features"] is None
+    assert body["has_license"] is False
+
+
+def test_api_features_at_batch_active_key_flips_per_row(app):
+    """Active key: rows before ``exp`` surface features, rows after
+    ``exp`` collapse to ``null``."""
+    _write_direct(app, _payload(exp_delta=30 * 86400))
+    now = int(time.time())
+    epochs = [now, now + 10 * 86400, now + 60 * 86400, now + 90 * 86400]
+    qs = ",".join(str(e) for e in epochs)
+    with app.app.test_client() as client:
+        rv = client.get(f"/api/license/features-at-batch?epochs={qs}")
+    body = rv.get_json()
+    assert body["count"] == 4
+    assert [r["features"] for r in body["rows"]] == [
+        ["alerts", "fleet", "runtimes"],
+        ["alerts", "fleet", "runtimes"],
+        None,
+        None,
+    ]
+    assert [r["epoch"] for r in body["rows"]] == epochs
+    assert body["features"] == ["alerts", "fleet", "runtimes"]
+    assert body["valid"] is True
+
+
+def test_api_features_at_batch_per_row_parity_with_scalar_endpoint(app):
+    """Per-row parity with ``/api/license/features-at?epoch=<n>`` -- the
+    batch cannot silently drift from the scalar."""
+    _write_direct(app, _payload(exp_delta=30 * 86400))
+    now = int(time.time())
+    epochs = [now - 5 * 86400, now, now + 3 * 86400, now + 40 * 86400]
+    qs = ",".join(str(e) for e in epochs)
+    with app.app.test_client() as client:
+        rv_batch = client.get(f"/api/license/features-at-batch?epochs={qs}")
+        rows = rv_batch.get_json()["rows"]
+        for row, epoch in zip(rows, epochs):
+            rv_scalar = client.get(f"/api/license/features-at?epoch={epoch}")
+            assert row["features"] == rv_scalar.get_json()["features_at"], epoch
+
+
+def test_api_features_at_batch_perpetual_key(app):
+    """Perpetual key -> every row surfaces the features list."""
+    _write_direct(app, _payload(drop_exp=True))
+    now = int(time.time())
+    with app.app.test_client() as client:
+        rv = client.get(
+            f"/api/license/features-at-batch?epochs=0,{now},2000000000"
+        )
+    body = rv.get_json()
+    assert [r["features"] for r in body["rows"]] == [
+        ["alerts", "fleet", "runtimes"]
+    ] * 3
+    assert body["valid"] is True
+
+
+def test_api_features_at_batch_invalid_signature(app):
+    """Bogus-signature file -> every row ``null`` (time-independent)."""
+    _write_bogus(app)
+    now = int(time.time())
+    with app.app.test_client() as client:
+        rv = client.get(
+            f"/api/license/features-at-batch?epochs=0,{now},2000000000"
+        )
+    body = rv.get_json()
+    assert [r["features"] for r in body["rows"]] == [None, None, None]
+    assert body["has_license"] is True
+    assert body["valid"] is False
+
+
+def test_api_features_at_batch_bad_tokens_collapse_per_row(app):
+    """Bad tokens (non-numeric) don't 400 the batch -- they collapse to
+    ``features=null`` rows so a caller can identify the offending
+    entry."""
+    _write_direct(app, _payload(exp_delta=30 * 86400))
+    now = int(time.time())
+    with app.app.test_client() as client:
+        rv = client.get(
+            f"/api/license/features-at-batch?epochs={now},nope,{now + 3600}"
+        )
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["count"] == 3
+    good = [r for r in body["rows"] if r["features"] == [
+        "alerts",
+        "fleet",
+        "runtimes",
+    ]]
+    bad = [r for r in body["rows"] if r["features"] is None]
+    assert len(good) == 2 and len(bad) == 1
+
+
+def test_api_features_at_batch_missing_claim_row(app):
+    """Valid signed key with the ``features`` claim omitted -> per-row
+    ``features=[]`` on the endpoint, matching the scalar."""
+    _write_direct(app, _payload(drop_features=True))
+    now = int(time.time())
+    with app.app.test_client() as client:
+        rv = client.get(f"/api/license/features-at-batch?epochs={now}")
+    body = rv.get_json()
+    assert body["rows"][0]["features"] == []
+
+
+def test_api_features_at_batch_shared_snapshot_agreement(app):
+    """The current-time reference fields on the batch response must
+    byte-equal the sibling ``/api/license/state-at-batch`` fields for
+    the same install -- both endpoints share the state snapshot pattern
+    (batch's ``expires_at`` / ``has_license`` / ``valid`` come from the
+    same underlying ``current_license_info`` / ``license_expires_at``
+    read)."""
+    _write_direct(app, _payload(exp_delta=30 * 86400))
+    now = int(time.time())
+    with app.app.test_client() as client:
+        rv_feats = client.get(
+            f"/api/license/features-at-batch?epochs={now}"
+        ).get_json()
+        rv_state = client.get(
+            f"/api/license/state-at-batch?epochs={now}"
+        ).get_json()
+    assert rv_feats["expires_at"] == rv_state["expires_at"]
+    assert rv_feats["has_license"] == rv_state["has_license"]
+    assert rv_feats["valid"] == rv_state["valid"]
+
+
+def test_api_features_at_batch_dedup_preserves_first_seen(app):
+    """Duplicate epochs are dropped preserving first-seen order --
+    matches the underlying batch helper."""
+    _write_direct(app, _payload(exp_delta=30 * 86400))
+    now = int(time.time())
+    with app.app.test_client() as client:
+        rv = client.get(
+            f"/api/license/features-at-batch?epochs={now},{now},{now + 10},{now}"
+        )
+    body = rv.get_json()
+    assert [r["epoch"] for r in body["rows"]] == [now, now + 10]
+
+
+# -- cross-endpoint agreement -------------------------------------------------
+
+
+def test_api_features_at_agrees_with_features_endpoint_at_now(app):
+    """At ``epoch=now``, the ``features_at`` field must byte-equal the
+    ``features`` returned by ``/api/license/features`` (the current-time
+    endpoint). Both derive from the same signed claim -- a UI binding
+    both cannot catch them disagreeing at the boundary."""
+    _write_direct(app, _payload(exp_delta=30 * 86400))
+    now = int(time.time())
+    with app.app.test_client() as client:
+        rv_now = client.get("/api/license/features").get_json()
+        rv_at = client.get(f"/api/license/features-at?epoch={now}").get_json()
+    assert rv_at["features_at"] == rv_now["features"]
+    assert rv_at["features"] == rv_now["features"]


### PR DESCRIPTION
## What

Perspective-epoch flavour of `license_features` / `/api/license/features`. Fills the `_at{,-batch}` gap on the license-features axis alongside the existing state / tier / expiry `_at` scalars.

Answers *"which features would `license_features` have surfaced evaluated as of `<epoch>`?"* so a scheduled-audit or retrospective diagnostic tile can render *"which features was this node entitled to on `<date>`?"* without the caller snapshotting license state at that time or comparing `exp` to a caller-supplied epoch themselves.

## Why

Complements the in-flight `license_tier_at` (#4275) and the shipped `license_state_at{,_batch}` / `is_expired_at{,_batch}` / `days_until_expiry_at{,_batch}` / `is_license_valid_at{,_batch}` scalars — a caller can now zip the whole entitlement row (state, tier, expiry, age, features) at the same perspective epoch in a handful of round-trips instead of hydrating each dimension separately.

## Changes

- **`clawmetry/license.py`**
  - `license_features_at(epoch) -> list[str] | None` — scalar. `None` on no license / invalid signature / lapsed-at-epoch / bool / non-numeric; `[]` on a valid-at-epoch key with no explicit `features` claim (distinct from `None`); sorted-deduped-normalised list otherwise. Never raises.
  - `license_features_at_batch(epochs) -> list[dict]` — per-value batch, re-uses `_license_epoch_batch_keys` for dedup/coercion parity with the existing `_at_batch` family. Per-row parity with the scalar pinned in tests.

- **`routes/entitlement.py`**
  - `GET /api/license/features-at?epoch=<int>` — `{features_at, requested_epoch, features, expires_at, has_license, valid}`.
  - `GET /api/license/features-at-batch?epochs=<int>,<int>,...` — `{kind:"license_features_at", count, rows:[{epoch, features}], features, expires_at, has_license, valid}`.
  - Shared `_license_features_at_snapshot` reader so the pair cannot disagree on the current-time reference fields, and matches the sibling `_license_state_at_snapshot` shape so `state-at{,-batch}` and `features-at{,-batch}` can be zipped without catching each other disagreeing on `expires_at` / `has_license` / `valid`.

- **`tests/test_license_features_at.py`** — 52 hermetic tests. Ephemeral Ed25519 keypair + monkeypatched `LICENSE_PATH` per test. Coverage:
  - scalar: no-license / active / lapsed / pre-lapse retrospective / future-past-exp prospective / exact-`exp` boundary / perpetual / bogus signature / casing+whitespace / dedup / missing claim / non-list claim / non-string entries / bool epoch / non-numeric epoch / string coercion / never-raises
  - batch: none / non-iterable / empty / no-license / active-mixed / perpetual / invalid-sig / lapsed-flips / missing-claim-row / bad epochs collapse / dedup preserves first-seen / string coercion / never-raises / byte-stable
  - endpoints: 400 posture, parity between scalar Python helper and HTTP scalar, parity between HTTP scalar and HTTP batch per row, shared-snapshot agreement with `/api/license/state-at-batch`, current-time agreement with `/api/license/features`.

Grace-only; no gate enforcement is added. All new behaviour is read-only observation.

## Local operator verification checklist

The scheduled autonomous fire has no access to the user's local daemon, live cloud snapshot, browser, or the private `clawmetry-cloud` / `clawmetry-pro` repos. Please verify locally before flipping this PR out of draft:

- [ ] `cp clawmetry/license.py routes/entitlement.py ~/.clawmetry/lib/python*/site-packages/clawmetry/` (adjust for `routes/` sub-package path)
- [ ] Clear caches: `find ~/.clawmetry/lib -name __pycache__ -exec rm -rf {} +`
- [ ] Restart daemon: `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
- [ ] Hit `/api/license/features-at?epoch=$(date +%s)` and confirm response includes `features_at`, `requested_epoch`, `features`, `expires_at`, `has_license`, `valid`.
- [ ] Hit `/api/license/features-at-batch?epochs=$(date +%s),$(date -v+1d +%s)` and confirm `kind:"license_features_at"`, `count:2`, per-row `features` fields.
- [ ] Decrypt the live cloud snapshot and confirm no schema drift in the response payload.
- [ ] Browser-check any UI binding `/api/license/features` — the new endpoints are additive; the existing endpoint is untouched.

## Not changed
- No `__version__` bump, no tag, no `[RELEASE]` PR — those stay with the operator.
- No enforcement gate flipped; the resolved entitlement still falls back to GRACE.

## Verification here

- `python -m py_compile` on all changed files: clean.
- `ruff check` on all changed files: clean.
- `pytest tests/test_license_features_at.py` — 52 passed.
- `pytest tests/test_license_features_accessor.py tests/test_license_state_at_scalar.py tests/test_license_state_at_batch.py tests/test_entitlement_api.py` — 149 passed (adjacent regression check).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code

---
_Generated by [Claude Code](https://claude.ai/code/session_015pUnKpfsrDiKhZPtsytcyN)_