### PR TITLE
feat(license): is_tier_at + /api/license/is-tier-at{,-batch}

### DIFF
--- a/clawmetry/license.py
+++ b/clawmetry/license.py
@@ -1467,6 +1467,77 @@ def license_tier_at(epoch: int) -> str | None:
     return normalized or None
 
 
+def is_tier_at(tier: str, epoch: int) -> bool:
+    """Perspective-epoch flavour of :func:`is_tier` -- "was the installed
+    license on tier <X> evaluated as of ``epoch``?" -- for a scheduled-
+    audit / retrospective tile that wants to answer "was this node Pro
+    on <date>?" without the caller having to snapshot the license state
+    at that time or compare ``exp`` to a caller-supplied epoch itself.
+
+    Compares :func:`license_tier_at` case-insensitively (after strip) to
+    the supplied ``tier``. Missing / empty / non-string input degrades
+    to ``False`` -- matches the never-raise posture of :func:`is_tier` /
+    :func:`is_state_at`.
+
+    Unlike :func:`is_state_at` (which validates against the closed
+    :data:`LICENSE_STATES` set), the tier axis is deliberately open-
+    ended -- a future tier lands without a code change here, exactly
+    the way :func:`license_tier` / :func:`is_tier` intentionally do not
+    whitelist ``tier`` values. So any non-empty normalised string is
+    accepted as a possible match; a typo like ``"pro__"`` simply
+    doesn't match any real tier and collapses to ``False``.
+
+    ``tier`` is coerced through ``str()`` and normalised the same way
+    :func:`license_tier_at` normalises the stored claim, so a caller
+    can pass ``"Pro"``, ``"pro"``, or ``"  PRO "`` and get the same
+    answer.
+
+    ``epoch`` is coerced through :func:`license_tier_at`; ``bool`` and
+    non-numeric epochs are refused there and collapse this predicate
+    to ``False`` (there is no tier to match against once the perspective
+    is unusable -- the conservative "no entitlement" fallback matching
+    the never-mis-gate posture of the surrounding ``_at`` family).
+
+    When ``epoch`` equals "now", this predicate must agree with
+    :func:`is_tier` for the same install and the same requested ``tier``
+    -- both derive from the same signed ``tier`` claim and use the same
+    ``exp <= cutoff`` boundary via :func:`license_tier_at` /
+    :func:`license_tier`, so the two scalars cannot disagree at the
+    boundary. On any other epoch this helper answers the retrospective
+    / prospective question :func:`is_tier` cannot -- e.g. "was this
+    node Pro last Friday?" (``False`` on a key that has since been
+    renewed but was already expired then) or "will this node still be
+    Pro at our next quarterly audit?" (``False`` on an active key whose
+    ``exp`` falls before the audit date).
+
+    Never raises. Any underlying failure of :func:`license_tier_at`
+    collapses this to ``False`` -- a scheduled audit job bound to this
+    gate stays "unclaimed" rather than falsely asserting an entitlement
+    it can't verify.
+
+    Pairs with :func:`is_state_at`, :func:`is_expired_at`, and
+    :func:`is_expiring_within_at` on the perspective-epoch predicate
+    axis: for the same ``epoch``, a caller can zip the boolean gates
+    index-for-index and render a whole entitlement audit row for one
+    install without the gates catching each other disagreeing on the
+    perspective-epoch classification.
+    """
+    try:
+        requested = str(tier).strip().lower() if tier is not None else ""
+    except Exception:
+        return False
+    if not requested:
+        return False
+    try:
+        actual = license_tier_at(epoch)
+    except Exception as exc:
+        logger.debug("license: is_tier_at underlying read failed: %s", exc)
+        return False
+    if actual is None:
+        return False
+    return actual == requested
+
+
 def is_expired() -> bool:
     """True iff an installed, signature-valid license has an ``exp`` claim in
     the past.
@@ -3610,6 +3681,95 @@ def license_tier_at_batch(epochs) -> list[dict]:
         out.append(
             {"epoch": parsed, "tier": tier if isinstance(tier, str) else None}
         )
+    return out
+
+
+def is_tier_at_batch(tier, epochs) -> list[dict]:
+    """Per-value perspective-epoch "was the license on tier <X> at each
+    of these epochs?" gate for N epochs in ONE round-trip.
+
+    Shared-threshold sibling of :func:`is_tier_at`. Where the singular
+    scalar folds ONE ``(tier, epoch)`` pair to ONE bool, this preserves
+    per-value rows for a fixed ``tier`` and a sequence of perspective
+    epochs so a scheduled-audit tile that wants to answer "was this
+    node Pro on each of these audit dates?" hydrates the whole column
+    in ONE round-trip instead of fanning out N calls to the scalar.
+    Same "shared threshold applied to EVERY row, per-row epoch" shape
+    as :func:`is_state_at_batch` / :func:`is_expiring_within_at_batch`
+    -- both take one gate parameter plus a batch of epochs.
+
+    ``tier`` is normalised (``str().strip().lower()``) the same way
+    :func:`is_tier_at` normalises it, so ``"Pro"``, ``"pro"``, and
+    ``"  PRO "`` collapse to the same query. A missing / empty /
+    non-string ``tier`` collapses EVERY row to ``is_tier=False`` while
+    preserving row slots so the output length still matches N.
+
+    Unlike :func:`is_state_at_batch` (which validates against the
+    closed :data:`LICENSE_STATES` set), the tier axis is deliberately
+    open-ended -- a future tier lands without a code change here,
+    matching the open-ended posture of :func:`is_tier` /
+    :func:`license_tier`. A typo like ``"pro__"`` simply doesn't match
+    any real tier and collapses every row to ``False``.
+
+    Row shape::
+
+        {
+          "epoch":   <int> | "<raw>",
+          "is_tier": <bool>,
+        }
+
+    Semantics per row mirror :func:`is_tier_at`: ``True`` iff the
+    perspective-epoch tier byte-equals the (normalised) ``tier``
+    requested. For a bad epoch token (``bool`` / non-numeric /
+    ``None``) the scalar collapses :func:`license_tier_at` to ``None``
+    so the row's ``is_tier`` is ``False`` -- exactly matching the
+    conservative "no entitlement" fallback of :func:`license_tier_at`
+    (unlike :func:`is_state_at_batch`, there is no meaningful "no-
+    license tier" the caller could ask for, since :func:`license_tier`
+    already returns ``None`` -- not a sentinel string -- on that
+    branch).
+
+    Duplicates by normalised int key (or ``repr(raw)`` for bad inputs)
+    are dropped preserving first-seen order for byte-stable output.
+    ``epochs is None`` or non-iterable -- returns ``[]``. Never raises:
+    per-row failures short-circuit to ``is_tier=False`` so the batch
+    keeps building. Matches the never-mis-gate posture used by
+    :func:`is_tier_at` -- a bad row cannot silently claim a tier that
+    would grant unearned entitlement.
+
+    When any row's ``epoch`` equals "now" and ``tier`` is a
+    normalisable string, this predicate must agree with :func:`is_tier`
+    for the same install and the same requested ``tier`` at that row
+    -- both derive from the same signed ``tier`` claim via
+    :func:`license_tier_at` / :func:`license_tier`, so a caller
+    binding both the singular and the batch cannot catch them
+    disagreeing at the boundary.
+    """
+    try:
+        requested = str(tier).strip().lower() if tier is not None else ""
+    except Exception:
+        requested = ""
+    have_query = bool(requested)
+    out: list[dict] = []
+    for raw, _key, parsed in _license_epoch_batch_keys(epochs):
+        if parsed is None:
+            try:
+                token = str(raw)
+            except Exception:
+                token = repr(raw)
+            out.append({"epoch": token, "is_tier": False})
+            continue
+        if not have_query:
+            out.append({"epoch": parsed, "is_tier": False})
+            continue
+        try:
+            matched = is_tier_at(requested, parsed)
+        except Exception as exc:
+            logger.debug(
+                "license: is_tier_at_batch per-row failed: %s", exc
+            )
+            matched = False
+        out.append({"epoch": parsed, "is_tier": bool(matched)})
     return out
 
 

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -12132,6 +12132,239 @@ def api_license_tier_at_batch():
     )
 
 
+@bp_entitlement.route("/api/license/is-tier-at")
+def api_license_is_tier_at():
+    """``GET /api/license/is-tier-at?tier=<name>&epoch=<int>`` -- boolean
+    gate for "was the installed license on tier <X> evaluated as of
+    ``epoch``?" -- the perspective-epoch flavour of ``/api/license/
+    is-tier``, for a scheduled-audit tile that wants to answer "was
+    this node Pro on <date>?" without the caller having to snapshot
+    the license state at that time or compare ``exp`` to a caller-
+    supplied epoch themselves.
+
+    Query parameters:
+      * ``tier`` (str, required in-spirit) -- the tier to test against.
+        Compared case-insensitively after strip, matching
+        :func:`clawmetry.license.is_tier_at`. Missing / empty / non-
+        string input degrades to ``is_tier_at=false`` rather than a
+        4xx, matching the surrounding endpoints' never-5xx / never-4xx
+        posture. Unlike ``/api/license/is-state-at`` (which validates
+        against the closed ``LICENSE_STATES`` set), the tier axis is
+        deliberately open-ended -- a future tier lands without a code
+        change here, matching :func:`clawmetry.license.is_tier`'s
+        open-ended posture.
+      * ``epoch`` (int, required in-spirit) -- Unix epoch seconds.
+        Missing / non-integer / bool input collapses ``tier_at`` to
+        ``null`` and the predicate to ``false`` (there is no tier to
+        match against once the perspective is unusable -- the
+        conservative "no entitlement" fallback matching the never-mis-
+        gate posture of the surrounding ``_at`` family).
+
+    Response shape (always HTTP 200)::
+
+        {
+          "is_tier_at":      <bool>,
+          "tier_at":         <str|null>,    # tier as of epoch
+          "requested_tier":  <str>,         # normalised echo of query
+          "requested_epoch": <int|null>,    # int-coerced input, or null on typo
+          "tier":            <str|null>,    # current-time tier
+          "expires_at":      <int|null>,
+          "has_license":     <bool>,
+          "valid":           <bool>         # signature-valid AND not expired NOW
+        }
+
+    ``is_tier_at`` is ``True`` iff the perspective-epoch tier byte-
+    equals ``requested_tier`` (after both are lower/stripped) AND the
+    requested value is a non-empty string -- an empty / missing
+    ``tier=`` query returns ``is_tier_at=false`` so a caller cannot
+    silently claim a tier that would grant unearned entitlement.
+
+    Mirrors :func:`clawmetry.license.is_tier_at` -- the HTTP shape
+    layers ``tier_at`` / ``requested_tier`` / ``requested_epoch`` /
+    ``tier`` / ``expires_at`` / ``has_license`` / ``valid`` on top of
+    that bool so a widget never needs a second call to
+    ``/api/license/tier-at`` (or ``/api/license/tier``) to render the
+    accompanying "you were on tier <X>" copy.
+
+    When ``epoch`` equals "now" and ``tier`` is a non-empty string,
+    this endpoint must agree with ``/api/license/is-tier`` at the
+    boundary for the same install -- both derive from the same signed
+    ``tier`` claim via :func:`license_tier_at` / :func:`license_tier`,
+    so a UI binding both cannot catch them disagreeing at the boundary.
+
+    Shares :func:`_license_tier_at_snapshot` with ``/api/license/
+    tier-at{,-batch}`` so the current-time reference fields (``tier``
+    / ``expires_at`` / ``has_license`` / ``valid``) cannot disagree
+    between the sibling endpoints for the same install.
+
+    Never 5xxs -- any underlying failure degrades to the OSS-free
+    branch shape (``is_tier_at=false``, ``tier_at=null``,
+    ``tier=null``, ``expires_at=null``, ``has_license=false``,
+    ``valid=false``), matching the never-crash posture of the
+    surrounding license endpoints.
+    """
+    raw_tier = request.args.get("tier", "") or ""
+    try:
+        requested_tier = str(raw_tier).strip().lower()
+    except Exception:
+        requested_tier = ""
+    raw_epoch = request.args.get("epoch", "")
+    try:
+        requested_epoch = int(str(raw_epoch).strip())
+    except (TypeError, ValueError):
+        requested_epoch = None
+    try:
+        snap = _license_tier_at_snapshot()
+    except Exception as exc:
+        logger.warning("api_license_is_tier_at: snapshot error: %s", exc)
+        snap = {
+            "tier": None,
+            "expires_at": None,
+            "has_license": False,
+            "valid": False,
+        }
+    tier_at: str | None = None
+    if requested_epoch is not None:
+        try:
+            from clawmetry import license as _lic
+
+            tier_at = _lic.license_tier_at(requested_epoch)
+        except Exception as exc:
+            logger.warning("api_license_is_tier_at: derive error: %s", exc)
+            tier_at = None
+    if tier_at is not None and not isinstance(tier_at, str):
+        tier_at = None
+    match = bool(
+        requested_tier
+        and isinstance(tier_at, str)
+        and tier_at == requested_tier
+    )
+    return jsonify(
+        {
+            "is_tier_at": match,
+            "tier_at": tier_at,
+            "requested_tier": requested_tier,
+            "requested_epoch": requested_epoch,
+            "tier": snap["tier"],
+            "expires_at": snap["expires_at"],
+            "has_license": snap["has_license"],
+            "valid": snap["valid"],
+        }
+    )
+
+
+@bp_entitlement.route("/api/license/is-tier-at-batch")
+def api_license_is_tier_at_batch():
+    """``GET /api/license/is-tier-at-batch?tier=<name>&epochs=<int>,<int>,...``
+    -- shared-``tier`` batch sibling of ``/api/license/is-tier-at``.
+
+    Where the singular endpoint folds ONE ``(tier, epoch)`` pair to
+    ONE "was the license on tier <X> as-of epoch?" bool, this
+    preserves per-value rows for a fixed ``tier`` across a sequence
+    of perspective epochs so a scheduled-audit tile answering "was
+    this node Pro on each of these audit dates?" hydrates the whole
+    column in ONE round-trip instead of fanning out N calls to the
+    scalar. Wraps :func:`clawmetry.license.is_tier_at_batch`. Same
+    "shared threshold applied to EVERY row, per-row epoch" shape as
+    ``/api/license/is-state-at-batch`` -- both take one gate query
+    parameter plus a batch of epochs.
+
+    Query parameters:
+      * ``tier`` (str, required in-spirit) -- the tier to test
+        against. Compared case-insensitively after strip, matching
+        :func:`clawmetry.license.is_tier_at`. Missing / empty / non-
+        string value degrades EVERY row to ``is_tier=false`` (matches
+        the never-mis-gate posture of the scalar) rather than a 4xx
+        -- a caller on a stale UI shouldn't have the whole batch
+        hidden behind a typo. Deliberately open-ended (no ``LICENSE_
+        STATES``-style whitelist) so a future tier lands without a
+        code change.
+      * ``epochs`` (CSV of ints, required) -- Missing / blank /
+        only-commas -> ``400 missing epochs``. Comma-separated tokens
+        are stripped, then handed to
+        :func:`clawmetry.license.is_tier_at_batch`, which dedupes by
+        parsed int key preserving first-seen order and collapses
+        non-int / ``bool`` / ``None`` tokens to a row with
+        ``is_tier=false`` (unlike ``/api/license/is-state-at-batch``,
+        there is no meaningful "no-license tier" the caller could
+        ask for, since :func:`license_tier` already returns ``None``
+        -- not a sentinel string -- on that branch).
+
+    Response shape (always HTTP 200)::
+
+        {
+          "kind":           "is_tier_at",
+          "count":          <int>,             # len(rows)
+          "requested_tier": <str>,             # normalised echo of query
+          "rows":  [
+            {"epoch": <int|"<raw>">, "is_tier": <bool>},
+            ...
+          ],
+          "tier":        <str|null>,           # current-time tier
+          "expires_at":  <int|null>,           # on-disk exp for comparison
+          "has_license": <bool>,
+          "valid":       <bool>                # signature-valid AND not expired NOW
+        }
+
+    Envelope carries the same current-time snapshot fields (``tier`` /
+    ``expires_at`` / ``has_license`` / ``valid``) as the surrounding
+    ``/api/license/tier-at{,-batch}`` and ``/api/license/is-tier-at``
+    endpoints so a UI binding several endpoints for the same install
+    cannot catch them disagreeing. Row shape mirrors ``/api/license/
+    is-state-at-batch`` so a caller assembling a timeline can zip the
+    responses index-for-index by epoch.
+
+    Per-row parity with ``/api/license/is-tier-at?tier=<X>&epoch=<n>``
+    is pinned in the test suite so the batch cannot silently drift
+    from the scalar endpoint.
+
+    Never 5xxs -- any underlying failure degrades to the OSS-free
+    branch shape (empty rows envelope with the OSS-free snapshot
+    fields intact).
+    """
+    raw_tier = request.args.get("tier", "") or ""
+    try:
+        requested_tier = str(raw_tier).strip().lower()
+    except Exception:
+        requested_tier = ""
+    tokens, err = _parse_license_epochs_csv("epochs")
+    if err == "missing":
+        return jsonify({"error": "missing epochs"}), 400
+    try:
+        snap = _license_tier_at_snapshot()
+    except Exception as exc:
+        logger.warning(
+            "api_license_is_tier_at_batch: snapshot error: %s", exc
+        )
+        snap = {
+            "tier": None,
+            "expires_at": None,
+            "has_license": False,
+            "valid": False,
+        }
+    try:
+        from clawmetry import license as _lic
+
+        rows = _lic.is_tier_at_batch(requested_tier, tokens)
+    except Exception as exc:
+        logger.warning(
+            "api_license_is_tier_at_batch: derive error: %s", exc
+        )
+        rows = []
+    return jsonify(
+        {
+            "kind": "is_tier_at",
+            "count": len(rows),
+            "requested_tier": requested_tier,
+            "rows": rows,
+            "tier": snap["tier"],
+            "expires_at": snap["expires_at"],
+            "has_license": snap["has_license"],
+            "valid": snap["valid"],
+        }
+    )
+
+
 
 def _license_features_at_snapshot() -> dict:
     """Shared one-shot read for the paired ``/api/license/features-at``

--- a/tests/test_license_is_tier_at.py
+++ b/tests/test_license_is_tier_at.py
@@ -1,0 +1,932 @@
+"""Tests for the ``is_tier_at(tier, epoch)`` predicate and
+``is_tier_at_batch(tier, epochs)`` batch on ``clawmetry.license`` and
+their paired ``/api/license/is-tier-at`` / ``/api/license/is-tier-at-batch``
+HTTP endpoints.
+
+The perspective-epoch predicate on the license-tier axis. Where
+:func:`clawmetry.license.is_tier` answers "am I on tier <X> right now?",
+this pair answers "was I on tier <X> as of ``epoch``?" -- the same
+retrospective / prospective question :func:`is_state_at` answers for
+license state. Both this pair and the sibling accessor
+:func:`license_tier_at` refuse the invalid-signature branch and use
+the same ``exp <= epoch`` cutoff, so they cannot disagree at the
+boundary when the perspective epoch equals "now".
+
+Hermetic: each test mints tokens with its own ephemeral keypair and
+monkeypatches the module's embedded public key + ``LICENSE_PATH``,
+mirroring ``tests/test_license_tier_at.py`` / ``tests/test_license_
+state_at_batch.py`` so nothing depends on the real production signing
+key or on real filesystem state.
+"""
+from __future__ import annotations
+
+import time
+from types import SimpleNamespace
+
+import pytest
+from flask import Flask
+
+
+# -- shared helpers (mirror test_license_tier_at.py) --------------------------
+
+
+def _keypair():
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+    priv = Ed25519PrivateKey.generate()
+    pub_pem = priv.public_key().public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    return priv, pub_pem
+
+
+def _payload(tier="pro", nodes=3, exp_delta=365 * 86400, drop_exp=False, drop_tier=False):
+    now = int(time.time())
+    p = {
+        "sub": "acct_test",
+        "tier": tier,
+        "nodes": nodes,
+        "iat": now,
+        "exp": now + exp_delta,
+        "features": ["runtimes"],
+    }
+    if drop_exp:
+        p.pop("exp", None)
+    if drop_tier:
+        p.pop("tier", None)
+    return p
+
+
+@pytest.fixture
+def app(monkeypatch, tmp_path):
+    import clawmetry.license as _lic
+
+    priv, pub_pem = _keypair()
+    monkeypatch.setattr(_lic, "_PUBLIC_KEY_PEM", pub_pem)
+    license_path = str(tmp_path / "license.key")
+    monkeypatch.setattr(_lic, "LICENSE_PATH", license_path)
+    monkeypatch.delenv("CLAWMETRY_LICENSE_SERVER", raising=False)
+    monkeypatch.delenv("CLAWMETRY_INGEST_URL", raising=False)
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("CLAWMETRY_OFFLINE", "1")
+
+    from routes.entitlement import bp_entitlement
+
+    flask_app = Flask(__name__)
+    flask_app.register_blueprint(bp_entitlement)
+    flask_app.config["TESTING"] = True
+
+    return SimpleNamespace(
+        app=flask_app,
+        lic=_lic,
+        priv=priv,
+        license_path=license_path,
+    )
+
+
+def _write_key_direct(app, exp_delta, tier="pro", drop_tier=False):
+    """Bypass activate() (which refuses expired tokens) and write a token
+    directly to the license file. Simulates a license that expired AFTER
+    it was installed."""
+    import os
+
+    tok = app.lic._encode_token(
+        _payload(tier=tier, exp_delta=exp_delta, drop_tier=drop_tier), app.priv
+    )
+    os.makedirs(os.path.dirname(app.license_path), exist_ok=True)
+    with open(app.license_path, "w", encoding="utf-8") as fh:
+        fh.write(tok)
+
+
+def _write_perpetual(app, tier="pro"):
+    import os
+
+    tok = app.lic._encode_token(_payload(tier=tier, drop_exp=True), app.priv)
+    os.makedirs(os.path.dirname(app.license_path), exist_ok=True)
+    with open(app.license_path, "w", encoding="utf-8") as fh:
+        fh.write(tok)
+
+
+def _write_bogus(app):
+    import os
+
+    os.makedirs(os.path.dirname(app.license_path), exist_ok=True)
+    with open(app.license_path, "w", encoding="utf-8") as fh:
+        fh.write("CLAW1.garbage.garbage")
+
+
+# -- clawmetry.license.is_tier_at() -------------------------------------------
+
+
+def test_is_tier_at_no_license(app):
+    """No license file on disk -> ``False`` regardless of tier / epoch.
+    Mirrors :func:`is_tier`'s no-license branch."""
+    now = int(time.time())
+    assert app.lic.is_tier_at("pro", now) is False
+    assert app.lic.is_tier_at("enterprise", now) is False
+    assert app.lic.is_tier_at("pro", 0) is False
+    assert app.lic.is_tier_at("pro", 2_000_000_000) is False
+
+
+def test_is_tier_at_now_matches_is_tier_active(app):
+    """When ``epoch`` equals "now", predicate must agree with
+    :func:`is_tier` on an active install. Both derive from the same
+    signed ``tier`` claim, so a UI binding both cannot catch them
+    disagreeing at the boundary."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    now = int(time.time())
+    assert app.lic.is_tier_at("pro", now) is True
+    assert app.lic.is_tier("pro") is True
+
+
+def test_is_tier_at_now_matches_is_tier_lapsed(app):
+    """Lapsed-key parity: at "now", both predicates must return
+    ``False`` -- both refuse the expired branch."""
+    _write_key_direct(app, exp_delta=-5 * 86400)
+    now = int(time.time())
+    assert app.lic.is_tier_at("pro", now) is False
+    assert app.lic.is_tier("pro") is False
+
+
+def test_is_tier_at_future_before_expiry(app):
+    """Future perspective still before ``exp`` -> ``True`` (key would
+    NOT yet be expired at that perspective)."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    epoch = int(time.time()) + 10 * 86400
+    assert app.lic.is_tier_at("pro", epoch) is True
+
+
+def test_is_tier_at_future_after_expiry(app):
+    """Future perspective AFTER ``exp`` on an active key -> ``False``
+    (the key WILL be expired at that perspective). This is the "will
+    this node still be Pro at our next audit?" prospective scenario."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    epoch = int(time.time()) + 60 * 86400
+    assert app.lic.is_tier_at("pro", epoch) is False
+
+
+def test_is_tier_at_past_still_active(app):
+    """Perspective BEFORE now on an active key -> ``True`` (the key was
+    not yet expired then, since ``exp`` is even further in the future)."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    epoch = int(time.time()) - 10 * 86400
+    assert app.lic.is_tier_at("pro", epoch) is True
+
+
+def test_is_tier_at_lapsed_key_pre_lapse_true(app):
+    """Lapsed-but-signed key at a perspective BEFORE its ``exp`` ->
+    ``True`` (retrospective "was this Pro on <date>?"). At/after ``exp``
+    -> ``False``."""
+    _write_key_direct(app, exp_delta=-5 * 86400)  # exp = now - 5d
+    now = int(time.time())
+    assert app.lic.is_tier_at("pro", now - 20 * 86400) is True
+    assert app.lic.is_tier_at("pro", now - 3 * 86400) is False
+    assert app.lic.is_tier_at("pro", now) is False
+
+
+def test_is_tier_at_exact_exp_boundary(app):
+    """At the exact ``exp`` second, the predicate must collapse to
+    ``False`` -- the ``<= epoch`` cutoff matches
+    :func:`license_tier_at`'s ``exp <= epoch`` boundary."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    from clawmetry import license as _lic
+
+    info = _lic.current_license_info()
+    exp_epoch = int(info["exp"])
+    assert app.lic.is_tier_at("pro", exp_epoch - 1) is True
+    assert app.lic.is_tier_at("pro", exp_epoch) is False
+    assert app.lic.is_tier_at("pro", exp_epoch + 1) is False
+
+
+def test_is_tier_at_perpetual_key(app):
+    """Perpetual (no ``exp``) key -> ``True`` at every epoch."""
+    _write_perpetual(app)
+    assert app.lic.is_tier_at("pro", 0) is True
+    assert app.lic.is_tier_at("pro", int(time.time())) is True
+    assert app.lic.is_tier_at("pro", 2_000_000_000) is True
+
+
+def test_is_tier_at_invalid_signature(app):
+    """Bogus-signature file -> ``False`` regardless of epoch (time-
+    independent, matching :func:`license_tier_at`)."""
+    _write_bogus(app)
+    assert app.lic.is_tier_at("pro", 0) is False
+    assert app.lic.is_tier_at("pro", int(time.time())) is False
+    assert app.lic.is_tier_at("pro", 2_000_000_000) is False
+
+
+def test_is_tier_at_wrong_tier(app):
+    """A tier that doesn't match the installed key -> ``False`` even
+    on an otherwise-active install. The predicate is exact-match on
+    the normalised tier."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    now = int(time.time())
+    assert app.lic.is_tier_at("enterprise", now) is False
+    assert app.lic.is_tier_at("trial", now) is False
+    assert app.lic.is_tier_at("free", now) is False
+
+
+def test_is_tier_at_normalises_query_casing(app):
+    """Query tier casing / whitespace is normalised -- ``"Pro"``,
+    ``"pro"``, and ``"  PRO  "`` all match a stored ``"pro"``."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    now = int(time.time())
+    assert app.lic.is_tier_at("Pro", now) is True
+    assert app.lic.is_tier_at("pro", now) is True
+    assert app.lic.is_tier_at("  PRO  ", now) is True
+
+
+def test_is_tier_at_normalises_token_casing(app):
+    """Token tier casing / whitespace is normalised the same way
+    :func:`license_tier_at` normalises it -- stored ``"  PRO  "``
+    matches a query ``"pro"``."""
+    tok = app.lic._encode_token(_payload(tier="  PRO  "), app.priv)
+    app.lic.activate(tok)
+    assert app.lic.is_tier_at("pro", int(time.time())) is True
+
+
+def test_is_tier_at_bool_epoch_refused(app):
+    """``bool`` is an ``int`` subclass but must be refused so a caller
+    passing ``True`` / ``False`` gets ``False`` back, not a spurious
+    "was tier X at epoch 1?" answer. Mirrors the ``_at`` family's
+    stance."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    assert app.lic.is_tier_at("pro", True) is False
+    assert app.lic.is_tier_at("pro", False) is False
+
+
+def test_is_tier_at_non_numeric_epoch(app):
+    """Non-numeric epoch -> ``False`` so a caller cannot silently
+    mis-gate on a typo."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    assert app.lic.is_tier_at("pro", "not-a-number") is False
+    assert app.lic.is_tier_at("pro", None) is False
+    assert app.lic.is_tier_at("pro", []) is False
+
+
+def test_is_tier_at_string_epoch_coerced(app):
+    """String epoch that ``int()`` accepts -> coerced and honoured,
+    matching :func:`license_tier_at`."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    now = int(time.time())
+    assert app.lic.is_tier_at("pro", str(now)) is True
+
+
+def test_is_tier_at_empty_tier_query(app):
+    """Empty / whitespace-only tier query -> ``False`` even on an
+    active install. A caller cannot silently claim "is on tier
+    empty-string"."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    now = int(time.time())
+    assert app.lic.is_tier_at("", now) is False
+    assert app.lic.is_tier_at("   ", now) is False
+
+
+def test_is_tier_at_none_tier_query(app):
+    """``None`` tier query -> ``False`` (never-raise posture)."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    assert app.lic.is_tier_at(None, int(time.time())) is False
+
+
+def test_is_tier_at_open_ended_tier(app):
+    """The tier axis is deliberately open-ended -- an unfamiliar tier
+    name simply doesn't match, but the predicate doesn't gate on a
+    whitelist (unlike :func:`is_state_at`). A future tier lands
+    without a code change."""
+    tok = app.lic._encode_token(_payload(tier="galactic", exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    now = int(time.time())
+    assert app.lic.is_tier_at("galactic", now) is True
+    assert app.lic.is_tier_at("pro", now) is False
+
+
+def test_is_tier_at_missing_tier_claim_matches_scalar(app):
+    """Signed payload with no ``tier`` claim: the predicate must agree
+    with :func:`license_tier_at` -- both derive from
+    :func:`current_license_info` which today defaults a missing
+    ``tier`` claim. Guards against the two silently diverging on the
+    same defect."""
+    _write_key_direct(app, exp_delta=30 * 86400, drop_tier=True)
+    now = int(time.time())
+    scalar_tier = app.lic.license_tier_at(now)
+    if scalar_tier is None:
+        assert app.lic.is_tier_at("pro", now) is False
+        assert app.lic.is_tier_at("anything", now) is False
+    else:
+        assert app.lic.is_tier_at(scalar_tier, now) is True
+
+
+def test_is_tier_at_parity_with_is_tier_at_now(app):
+    """At ``epoch=now``, ``is_tier_at(t, now)`` must byte-equal
+    ``is_tier(t)`` for every canonical tier. Both derive from the same
+    signed ``tier`` claim."""
+    tok = app.lic._encode_token(_payload(tier="enterprise", exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    now = int(time.time())
+    for t in ("pro", "enterprise", "trial", "free"):
+        assert app.lic.is_tier_at(t, now) == app.lic.is_tier(t), t
+
+
+def test_is_tier_at_parity_with_license_tier_at(app):
+    """For a canonical set of tiers, ``is_tier_at(t, e)`` must equal
+    ``license_tier_at(e) == t``. Pins the predicate to the scalar."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    now = int(time.time())
+    for epoch in [now - 10 * 86400, now, now + 10 * 86400, now + 60 * 86400]:
+        scalar_tier = app.lic.license_tier_at(epoch)
+        for t in ("pro", "enterprise", "trial"):
+            expected = scalar_tier is not None and scalar_tier == t
+            assert app.lic.is_tier_at(t, epoch) is expected, (t, epoch)
+
+
+def test_is_tier_at_never_raises(app, monkeypatch):
+    """If :func:`license_tier_at` blows up under this predicate, it
+    collapses to ``False`` rather than propagating. A scheduled audit
+    job bound to this gate cannot crash on a bad install."""
+    def _boom(_epoch):
+        raise RuntimeError("simulated corruption")
+
+    monkeypatch.setattr(app.lic, "license_tier_at", _boom)
+    assert app.lic.is_tier_at("pro", int(time.time())) is False
+
+
+# -- clawmetry.license.is_tier_at_batch() -------------------------------------
+
+
+def test_is_tier_at_batch_none_returns_empty(app):
+    """``epochs is None`` -> ``[]``. Mirrors the never-raise posture
+    of the sibling per-value axis batches."""
+    assert app.lic.is_tier_at_batch("pro", None) == []
+
+
+def test_is_tier_at_batch_non_iterable_returns_empty(app):
+    """Non-iterable ``epochs`` (an int -- probable typo for a caller
+    that forgot to wrap it) -> ``[]`` rather than a crash."""
+    assert app.lic.is_tier_at_batch("pro", 42) == []
+
+
+def test_is_tier_at_batch_empty_returns_empty(app):
+    """Empty iterable -> ``[]``."""
+    assert app.lic.is_tier_at_batch("pro", []) == []
+    assert app.lic.is_tier_at_batch("pro", ()) == []
+
+
+def test_is_tier_at_batch_no_license(app):
+    """No license file on disk -> every row ``False`` regardless of
+    epoch. Time-independent, matches the scalar."""
+    epochs = [0, int(time.time()), 2_000_000_000]
+    rows = app.lic.is_tier_at_batch("pro", epochs)
+    assert [r["is_tier"] for r in rows] == [False] * 3
+    assert [r["epoch"] for r in rows] == epochs
+
+
+def test_is_tier_at_batch_active_mixed(app):
+    """Active key: rows before ``exp`` -> ``True``; rows after -> ``False``."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    now = int(time.time())
+    epochs = [now, now + 10 * 86400, now + 60 * 86400, now + 90 * 86400]
+    rows = app.lic.is_tier_at_batch("pro", epochs)
+    assert [r["is_tier"] for r in rows] == [True, True, False, False]
+    assert [r["epoch"] for r in rows] == epochs
+
+
+def test_is_tier_at_batch_per_row_parity_with_scalar(app):
+    """Per-row parity with :func:`is_tier_at` -- the batch cannot
+    silently drift from the scalar. Pin every row against the singular
+    helper on the same install."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    now = int(time.time())
+    epochs = [
+        now - 10 * 86400,
+        now,
+        now + 5 * 86400,
+        now + 40 * 86400,
+        now + 200 * 86400,
+    ]
+    rows = app.lic.is_tier_at_batch("pro", epochs)
+    for row, epoch in zip(rows, epochs):
+        assert row["is_tier"] == app.lic.is_tier_at("pro", epoch), epoch
+
+
+def test_is_tier_at_batch_perpetual_key(app):
+    """Perpetual (no ``exp``) key -> ``True`` at every row."""
+    _write_perpetual(app)
+    epochs = [0, int(time.time()), 2_000_000_000]
+    rows = app.lic.is_tier_at_batch("pro", epochs)
+    assert [r["is_tier"] for r in rows] == [True] * 3
+
+
+def test_is_tier_at_batch_invalid_signature(app):
+    """Bogus-signature file -> every row ``False`` (time-independent)."""
+    _write_bogus(app)
+    rows = app.lic.is_tier_at_batch("pro", [0, int(time.time()), 2_000_000_000])
+    assert [r["is_tier"] for r in rows] == [False] * 3
+
+
+def test_is_tier_at_batch_lapsed_key_flips_per_row(app):
+    """Lapsed-but-signed key at a perspective BEFORE its ``exp`` ->
+    ``True``; at/after ``exp`` -> ``False``. Batch flips per row."""
+    _write_key_direct(app, exp_delta=-5 * 86400)  # exp = now - 5d
+    now = int(time.time())
+    rows = app.lic.is_tier_at_batch(
+        "pro", [now - 20 * 86400, now - 3 * 86400, now]
+    )
+    assert [r["is_tier"] for r in rows] == [True, False, False]
+
+
+def test_is_tier_at_batch_wrong_tier_all_false(app):
+    """A tier that doesn't match the installed key -> every row
+    ``False`` even on an otherwise-active install."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    now = int(time.time())
+    rows = app.lic.is_tier_at_batch("enterprise", [now, now + 3600, now + 86400])
+    assert [r["is_tier"] for r in rows] == [False, False, False]
+
+
+def test_is_tier_at_batch_bad_epochs_collapse_per_row(app):
+    """``bool`` / non-numeric epochs collapse to a row with
+    ``is_tier=False`` with the raw token surfaced in ``epoch`` --
+    matches the never-mis-gate posture the scalar uses for the same
+    inputs."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    now = int(time.time())
+    rows = app.lic.is_tier_at_batch(
+        "pro", [now, True, "nope", None, now + 3600]
+    )
+    assert len(rows) == 5
+    good = [r for r in rows if isinstance(r["epoch"], int) and r["is_tier"] is True]
+    assert len(good) == 2
+    bad = [r for r in rows if r["is_tier"] is False]
+    assert len(bad) == 3
+
+
+def test_is_tier_at_batch_dedup_preserves_first_seen(app):
+    """Duplicate epochs are dropped preserving first-seen order for
+    byte-stable output."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    now = int(time.time())
+    rows = app.lic.is_tier_at_batch("pro", [now, now, now + 10, now])
+    assert [r["epoch"] for r in rows] == [now, now + 10]
+
+
+def test_is_tier_at_batch_string_epochs_coerced(app):
+    """String tokens that ``int()`` accepts -> coerced and honoured,
+    matching the query-string surface (the batch endpoint hands the
+    helper stripped tokens)."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    now = int(time.time())
+    rows = app.lic.is_tier_at_batch("pro", [str(now), str(now + 10)])
+    assert [r["is_tier"] for r in rows] == [True, True]
+
+
+def test_is_tier_at_batch_normalises_query_casing(app):
+    """Query tier casing / whitespace is normalised on the batch the
+    same way the scalar normalises it. ``"  PRO  "`` matches a stored
+    ``"pro"`` across every row."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    now = int(time.time())
+    rows = app.lic.is_tier_at_batch("  PRO  ", [now, now + 3600])
+    assert [r["is_tier"] for r in rows] == [True, True]
+
+
+def test_is_tier_at_batch_empty_tier_all_false(app):
+    """Empty / whitespace-only tier collapses EVERY row to
+    ``is_tier=False`` while preserving row slots. A caller on a stale
+    UI shouldn't have the whole batch silently drop."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    now = int(time.time())
+    rows = app.lic.is_tier_at_batch("", [now, now + 3600])
+    assert [r["is_tier"] for r in rows] == [False, False]
+    assert len(rows) == 2
+
+
+def test_is_tier_at_batch_none_tier_all_false(app):
+    """``None`` tier query collapses every row to ``False``."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    now = int(time.time())
+    rows = app.lic.is_tier_at_batch(None, [now, now + 3600])
+    assert [r["is_tier"] for r in rows] == [False, False]
+
+
+def test_is_tier_at_batch_missing_tier_claim_matches_scalar(app):
+    """Signed payload with no ``tier`` claim: every row must byte-
+    equal the singular :func:`is_tier_at` for the same tier / epoch.
+    Guards the batch from silently diverging from the scalar on the
+    same defect."""
+    _write_key_direct(app, exp_delta=30 * 86400, drop_tier=True)
+    now = int(time.time())
+    epochs = [now, now + 3600, now + 86400]
+    for query_tier in ("pro", "enterprise"):
+        rows = app.lic.is_tier_at_batch(query_tier, epochs)
+        for row, epoch in zip(rows, epochs):
+            assert row["is_tier"] == app.lic.is_tier_at(query_tier, epoch), (
+                query_tier,
+                epoch,
+            )
+
+
+def test_is_tier_at_batch_byte_stable(app):
+    """Byte-stable output on the same input: two calls return the
+    same list. Guards against a stray non-deterministic path (e.g.
+    dict iteration order leaking into row shape)."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    now = int(time.time())
+    epochs = [now, True, "nope", now, None, now + 3600]
+    first = app.lic.is_tier_at_batch("pro", epochs)
+    second = app.lic.is_tier_at_batch("pro", epochs)
+    assert first == second
+
+
+def test_is_tier_at_batch_never_raises(app, monkeypatch):
+    """If :func:`is_tier_at` blows up under a batch row, the row
+    collapses to ``is_tier=False`` rather than crashing the batch."""
+    def _boom(_tier, _epoch):
+        raise RuntimeError("simulated corruption")
+
+    monkeypatch.setattr(app.lic, "is_tier_at", _boom)
+    rows = app.lic.is_tier_at_batch("pro", [int(time.time())])
+    assert rows == [{"epoch": int(time.time()), "is_tier": False}] or (
+        len(rows) == 1 and rows[0]["is_tier"] is False
+    )
+
+
+# -- GET /api/license/is-tier-at ----------------------------------------------
+
+
+def test_api_is_tier_at_no_license(app):
+    """No license file on disk -> ``is_tier_at=false``, current-time
+    reference fields all reflect the OSS-free branch."""
+    now = int(time.time())
+    with app.app.test_client() as client:
+        rv = client.get(f"/api/license/is-tier-at?tier=pro&epoch={now}")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["is_tier_at"] is False
+    assert body["tier_at"] is None
+    assert body["requested_tier"] == "pro"
+    assert body["requested_epoch"] == now
+    assert body["tier"] is None
+    assert body["expires_at"] is None
+    assert body["has_license"] is False
+    assert body["valid"] is False
+
+
+def test_api_is_tier_at_active_key_now(app):
+    """Active key, matching tier at "now" -> ``is_tier_at=true``,
+    snapshot fields intact."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    now = int(time.time())
+    with app.app.test_client() as client:
+        rv = client.get(f"/api/license/is-tier-at?tier=pro&epoch={now}")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["is_tier_at"] is True
+    assert body["tier_at"] == "pro"
+    assert body["tier"] == "pro"
+    assert body["has_license"] is True
+    assert body["valid"] is True
+
+
+def test_api_is_tier_at_missing_epoch_false(app):
+    """Missing / non-integer / bool ``epoch`` -> ``is_tier_at=false``
+    and ``requested_epoch=null`` so a caller cannot silently mis-gate
+    on a typo. HTTP status stays 200."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    with app.app.test_client() as client:
+        for qs in ("?tier=pro", "?tier=pro&epoch=", "?tier=pro&epoch=nope"):
+            rv = client.get(f"/api/license/is-tier-at{qs}")
+            assert rv.status_code == 200, qs
+            body = rv.get_json()
+            assert body["is_tier_at"] is False, qs
+            assert body["requested_epoch"] is None, qs
+
+
+def test_api_is_tier_at_missing_tier_false(app):
+    """Missing / empty ``tier`` -> ``is_tier_at=false`` and
+    ``requested_tier=""`` so a caller cannot silently claim "is on
+    tier empty-string". HTTP 200 (never 4xx)."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    now = int(time.time())
+    with app.app.test_client() as client:
+        for qs in (f"?epoch={now}", f"?tier=&epoch={now}", f"?tier=   &epoch={now}"):
+            rv = client.get(f"/api/license/is-tier-at{qs}")
+            assert rv.status_code == 200, qs
+            body = rv.get_json()
+            assert body["is_tier_at"] is False, qs
+            assert body["requested_tier"] == "", qs
+
+
+def test_api_is_tier_at_future_after_expiry(app):
+    """Future perspective past ``exp`` on an active key ->
+    ``is_tier_at=false`` even though ``tier`` (current-time) still
+    surfaces the tier."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    epoch = int(time.time()) + 60 * 86400
+    with app.app.test_client() as client:
+        rv = client.get(f"/api/license/is-tier-at?tier=pro&epoch={epoch}")
+    body = rv.get_json()
+    assert body["is_tier_at"] is False
+    assert body["tier_at"] is None
+    assert body["tier"] == "pro"
+
+
+def test_api_is_tier_at_invalid_signature(app):
+    """Bogus-signature file -> ``is_tier_at=false``. ``has_license=true``
+    (a file exists) but ``valid=false``. Time-independent."""
+    _write_bogus(app)
+    with app.app.test_client() as client:
+        rv = client.get(
+            f"/api/license/is-tier-at?tier=pro&epoch={int(time.time())}"
+        )
+    body = rv.get_json()
+    assert body["is_tier_at"] is False
+    assert body["tier_at"] is None
+    assert body["has_license"] is True
+    assert body["valid"] is False
+
+
+def test_api_is_tier_at_case_insensitive_query(app):
+    """Query ``tier`` is normalised the same way the scalar
+    normalises it -- ``"Pro"`` matches ``"pro"``."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    now = int(time.time())
+    with app.app.test_client() as client:
+        for query in ("Pro", "pro", "PRO"):
+            rv = client.get(f"/api/license/is-tier-at?tier={query}&epoch={now}")
+            body = rv.get_json()
+            assert body["is_tier_at"] is True, query
+            assert body["requested_tier"] == "pro", query
+
+
+def test_api_is_tier_at_parity_with_python_scalar(app):
+    """The endpoint must return exactly what
+    :func:`clawmetry.license.is_tier_at` would return for the same
+    (tier, epoch)."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    now = int(time.time())
+    epochs = [now - 10 * 86400, now, now + 5 * 86400, now + 40 * 86400]
+    tiers = ["pro", "enterprise", "trial"]
+    with app.app.test_client() as client:
+        for t in tiers:
+            for e in epochs:
+                rv = client.get(f"/api/license/is-tier-at?tier={t}&epoch={e}")
+                body = rv.get_json()
+                assert body["is_tier_at"] == app.lic.is_tier_at(t, e), (t, e)
+
+
+def test_api_is_tier_at_agrees_with_is_tier_at_now(app):
+    """At ``epoch=now``, the ``is_tier_at`` field must byte-equal the
+    ``is_tier`` field returned by ``/api/license/is-tier`` (the
+    current-time predicate endpoint). Both derive from the same signed
+    claim -- a UI binding both cannot catch them disagreeing at the
+    boundary."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    now = int(time.time())
+    with app.app.test_client() as client:
+        rv_now = client.get("/api/license/is-tier?tier=pro").get_json()
+        rv_at = client.get(f"/api/license/is-tier-at?tier=pro&epoch={now}").get_json()
+    assert rv_at["is_tier_at"] == rv_now["is_tier"]
+
+
+def test_api_is_tier_at_shared_snapshot_with_tier_at(app):
+    """The current-time reference fields (``tier`` / ``expires_at`` /
+    ``has_license`` / ``valid``) must byte-equal the fields returned
+    by ``/api/license/tier-at`` for the same install -- both share
+    :func:`_license_tier_at_snapshot` so a UI binding both cannot
+    catch them disagreeing on the current-time reference."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    now = int(time.time())
+    with app.app.test_client() as client:
+        rv_pred = client.get(
+            f"/api/license/is-tier-at?tier=pro&epoch={now}"
+        ).get_json()
+        rv_scalar = client.get(f"/api/license/tier-at?epoch={now}").get_json()
+    for field in ("tier", "expires_at", "has_license", "valid"):
+        assert rv_pred[field] == rv_scalar[field], field
+
+
+# -- GET /api/license/is-tier-at-batch ----------------------------------------
+
+
+def test_api_is_tier_at_batch_missing_epochs_400(app):
+    """Missing / blank / only-commas ``epochs=`` -> ``400 missing
+    epochs`` (matches the sibling ``/api/license/*-at-batch``
+    endpoints)."""
+    with app.app.test_client() as client:
+        for qs in ("?tier=pro", "?tier=pro&epochs=", "?tier=pro&epochs=,,"):
+            rv = client.get(f"/api/license/is-tier-at-batch{qs}")
+            assert rv.status_code == 400, qs
+            assert rv.get_json() == {"error": "missing epochs"}
+
+
+def test_api_is_tier_at_batch_missing_tier_all_false(app):
+    """Missing / empty ``tier`` -> every row ``is_tier=false``,
+    HTTP 200 (matches the scalar). A stale UI shouldn't have the whole
+    batch hidden behind a typo."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    now = int(time.time())
+    with app.app.test_client() as client:
+        for qs in (f"?epochs={now},{now + 3600}", f"?tier=&epochs={now},{now + 3600}"):
+            rv = client.get(f"/api/license/is-tier-at-batch{qs}")
+            assert rv.status_code == 200, qs
+            body = rv.get_json()
+            assert body["count"] == 2
+            assert body["requested_tier"] == "", qs
+            assert [r["is_tier"] for r in body["rows"]] == [False, False]
+
+
+def test_api_is_tier_at_batch_no_license(app):
+    """No license file on disk -> every row ``is_tier=false``.
+    Reference fields all reflect the OSS-free branch."""
+    now = int(time.time())
+    with app.app.test_client() as client:
+        rv = client.get(
+            f"/api/license/is-tier-at-batch?tier=pro&epochs={now},{now + 3600}"
+        )
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["kind"] == "is_tier_at"
+    assert body["count"] == 2
+    assert body["requested_tier"] == "pro"
+    assert [r["is_tier"] for r in body["rows"]] == [False, False]
+    assert body["tier"] is None
+    assert body["has_license"] is False
+
+
+def test_api_is_tier_at_batch_active_flips_per_row(app):
+    """Active key: rows before ``exp`` -> ``true``; rows after ->
+    ``false``. Batch preserves per-row ordering."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    now = int(time.time())
+    epochs = [now, now + 10 * 86400, now + 60 * 86400, now + 90 * 86400]
+    qs = ",".join(str(e) for e in epochs)
+    with app.app.test_client() as client:
+        rv = client.get(f"/api/license/is-tier-at-batch?tier=pro&epochs={qs}")
+    body = rv.get_json()
+    assert body["count"] == 4
+    assert [r["is_tier"] for r in body["rows"]] == [True, True, False, False]
+    assert [r["epoch"] for r in body["rows"]] == epochs
+    assert body["tier"] == "pro"
+    assert body["valid"] is True
+
+
+def test_api_is_tier_at_batch_per_row_parity_with_scalar_endpoint(app):
+    """Per-row parity with ``/api/license/is-tier-at?tier=<X>&epoch=<n>``
+    -- the batch cannot silently drift from the scalar."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    now = int(time.time())
+    epochs = [now - 5 * 86400, now, now + 3 * 86400, now + 40 * 86400]
+    qs = ",".join(str(e) for e in epochs)
+    with app.app.test_client() as client:
+        rv_batch = client.get(
+            f"/api/license/is-tier-at-batch?tier=pro&epochs={qs}"
+        )
+        rows = rv_batch.get_json()["rows"]
+        for row, epoch in zip(rows, epochs):
+            rv_scalar = client.get(
+                f"/api/license/is-tier-at?tier=pro&epoch={epoch}"
+            )
+            assert row["is_tier"] == rv_scalar.get_json()["is_tier_at"], epoch
+
+
+def test_api_is_tier_at_batch_perpetual_key(app):
+    """Perpetual key -> every row ``true``."""
+    _write_perpetual(app)
+    now = int(time.time())
+    with app.app.test_client() as client:
+        rv = client.get(
+            f"/api/license/is-tier-at-batch?tier=pro&epochs=0,{now},2000000000"
+        )
+    body = rv.get_json()
+    assert [r["is_tier"] for r in body["rows"]] == [True, True, True]
+    assert body["valid"] is True
+
+
+def test_api_is_tier_at_batch_invalid_signature(app):
+    """Bogus-signature file -> every row ``false`` (time-independent)."""
+    _write_bogus(app)
+    now = int(time.time())
+    with app.app.test_client() as client:
+        rv = client.get(
+            f"/api/license/is-tier-at-batch?tier=pro&epochs=0,{now},2000000000"
+        )
+    body = rv.get_json()
+    assert [r["is_tier"] for r in body["rows"]] == [False, False, False]
+    assert body["has_license"] is True
+    assert body["valid"] is False
+
+
+def test_api_is_tier_at_batch_bad_tokens_collapse_per_row(app):
+    """Bad tokens (non-numeric) don't 400 the batch -- they collapse
+    to ``is_tier=false`` rows so a caller can identify the offending
+    entry."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    now = int(time.time())
+    with app.app.test_client() as client:
+        rv = client.get(
+            f"/api/license/is-tier-at-batch?tier=pro&epochs={now},nope,{now + 3600}"
+        )
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["count"] == 3
+    good = [r for r in body["rows"] if r["is_tier"] is True]
+    bad = [r for r in body["rows"] if r["is_tier"] is False]
+    assert len(good) == 2 and len(bad) == 1
+
+
+def test_api_is_tier_at_batch_shared_snapshot_agreement(app):
+    """The current-time reference fields on the batch response must
+    byte-equal the sibling ``/api/license/tier-at-batch`` fields for
+    the same install -- both share :func:`_license_tier_at_snapshot`."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    now = int(time.time())
+    with app.app.test_client() as client:
+        rv_pred = client.get(
+            f"/api/license/is-tier-at-batch?tier=pro&epochs={now}"
+        ).get_json()
+        rv_scalar = client.get(
+            f"/api/license/tier-at-batch?epochs={now}"
+        ).get_json()
+    for field in ("tier", "expires_at", "has_license", "valid"):
+        assert rv_pred[field] == rv_scalar[field], field
+
+
+def test_api_is_tier_at_batch_dedup_preserves_first_seen(app):
+    """Duplicate epochs are dropped preserving first-seen order --
+    matches the underlying batch helper."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    now = int(time.time())
+    with app.app.test_client() as client:
+        rv = client.get(
+            f"/api/license/is-tier-at-batch?tier=pro&epochs={now},{now},{now + 10},{now}"
+        )
+    body = rv.get_json()
+    assert [r["epoch"] for r in body["rows"]] == [now, now + 10]
+
+
+def test_api_is_tier_at_batch_case_insensitive_query(app):
+    """Query ``tier`` is normalised the same way the scalar
+    normalises it -- ``"Pro"`` matches ``"pro"`` across every row."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    now = int(time.time())
+    with app.app.test_client() as client:
+        rv = client.get(
+            f"/api/license/is-tier-at-batch?tier=%20%20PRO%20%20&epochs={now},{now + 3600}"
+        )
+    body = rv.get_json()
+    assert body["requested_tier"] == "pro"
+    assert [r["is_tier"] for r in body["rows"]] == [True, True]
+
+
+def test_api_is_tier_at_batch_wrong_tier_all_false(app):
+    """A tier that doesn't match the installed key -> every row
+    ``false`` even on an otherwise-active install."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    now = int(time.time())
+    with app.app.test_client() as client:
+        rv = client.get(
+            f"/api/license/is-tier-at-batch?tier=enterprise&epochs={now},{now + 3600}"
+        )
+    body = rv.get_json()
+    assert [r["is_tier"] for r in body["rows"]] == [False, False]


### PR DESCRIPTION
## What

Perspective-epoch flavour of `is_tier` / `/api/license/is-tier`. Fills the `is_tier -> is_tier_at{,_batch}` seat on the license-tier axis alongside the shipped `is_state_at{,_batch}` pair — a scheduled-audit tile answering *"was this node Pro on <date>?"* no longer has to fetch `license_tier_at` and string-compare itself.

## Why

Every sibling accessor on the license axis has (or is getting) a paired perspective-epoch predicate:

- `license_state{,_at,_at_batch}` → `is_state{,_at,_at_batch}` ✓ (shipped)
- `license_tier{,_at,_at_batch}` ✓ + `is_tier` ✓ → **`is_tier_at{,_batch}`** ← this PR
- `license_features{,_at,_at_batch}` ✓ + `has_feature` (in flight on #4281)

Retrospective audit rows on the tier axis today have to fetch `license_tier_at` and re-do the lower/strip + equality check on every row; a fleet-node column that only wants a single-bit `is_tier_at=?` answer can now bind directly.

## Changes

- **`clawmetry/license.py`**
  - `is_tier_at(tier, epoch) -> bool` — perspective-epoch predicate. Coerces both sides through the same lower/strip pipeline `is_tier` / `license_tier_at` use, then compares. `False` on no-license / bogus-signature / lapsed-at-epoch / `bool` / non-numeric epoch / missing-or-empty tier / mismatch. Deliberately open-ended (no `LICENSE_STATES`-style whitelist) so a future tier lands without a code change here, matching `is_tier` / `license_tier`. Never raises.
  - `is_tier_at_batch(tier, epochs) -> list[dict]` — per-value batch. Same `(shared threshold, per-row epoch)` shape as `is_state_at_batch` / `is_expiring_within_at_batch`. Re-uses `_license_epoch_batch_keys` for dedup/coercion parity. Per-row parity with the scalar pinned in tests.

- **`routes/entitlement.py`**
  - `GET /api/license/is-tier-at?tier=&epoch=` — `{is_tier_at, tier_at, requested_tier, requested_epoch, tier, expires_at, has_license, valid}`. Shares `_license_tier_at_snapshot` with `/api/license/tier-at{,-batch}` so a UI binding both cannot catch them disagreeing on the current-time reference fields.
  - `GET /api/license/is-tier-at-batch?tier=&epochs=,,...` — `{kind:"is_tier_at", count, requested_tier, rows:[{epoch, is_tier}], tier, expires_at, has_license, valid}`. Missing/blank `epochs` → 400; missing `tier` degrades EVERY row to `is_tier=false` at 200 (matches the never-mis-gate posture of the scalar). Never 5xxs.

- **`tests/test_license_is_tier_at.py`** — 64 hermetic tests. Ephemeral Ed25519 keypair + monkeypatched `LICENSE_PATH` per test. Coverage:
  - **predicate**: no-license / active-now / lapsed-now / future-before-exp / future-after-exp / past-still-active / lapsed pre-lapse retrospective / exact-`exp` boundary / perpetual / invalid-sig / wrong-tier / query casing / token casing / bool epoch / non-numeric epoch / string epoch coerced / empty tier / None tier / open-ended tier / missing-tier-claim parity with scalar / parity with `is_tier` at now / parity with `license_tier_at` / never-raises.
  - **batch**: `None` / non-iterable / empty / no-license / active-mixed / per-row scalar parity / perpetual / invalid-sig / lapsed-flips / wrong-tier / bad epochs collapse / dedup / string coercion / query casing / empty tier / None tier / missing-tier-claim parity / byte-stable / never-raises.
  - **endpoints**: no-license / active-now / missing-epoch (200, not 4xx) / missing-tier (200) / future-after-exp / invalid-sig / case-insensitive-query / python-scalar parity / agreement with `/api/license/is-tier` at now / shared-snapshot with `/api/license/tier-at` / batch missing-epochs 400 / batch missing-tier 200 / batch no-license / batch active-flips / batch per-row parity / batch perpetual / batch invalid-sig / batch bad tokens collapse / batch shared snapshot with `/api/license/tier-at-batch` / batch dedup / batch case-insensitive query / batch wrong-tier.

Grace-only observation; no gate enforcement is added. Additive to the existing `/api/license/is-tier` and `/api/license/tier-at{,-batch}` endpoints, which stay unchanged.

## Local operator verification checklist

The scheduled autonomous fire has no access to the user's local daemon, live cloud snapshot, browser, or the private `clawmetry-cloud` / `clawmetry-pro` repos. Please verify locally before flipping this PR out of draft:

- [ ] `cp clawmetry/license.py routes/entitlement.py ~/.clawmetry/lib/python*/site-packages/clawmetry/` (adjust for `routes/` sub-package path)
- [ ] Clear caches: `find ~/.clawmetry/lib -name __pycache__ -exec rm -rf {} +`
- [ ] Restart daemon: `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
- [ ] Hit `/api/license/is-tier-at?tier=pro&epoch=$(date +%s)` on your local install and confirm the response shape (`is_tier_at`, `tier_at`, `requested_tier`, `requested_epoch`, `tier`, `expires_at`, `has_license`, `valid`). Compare `is_tier_at` against `/api/license/is-tier?tier=pro` — they must agree at `epoch=now`.
- [ ] Hit `/api/license/is-tier-at-batch?tier=pro&epochs=$(date +%s),$(date -v+1d +%s)` and confirm `kind:"is_tier_at"`, `count:2`, per-row `is_tier` fields.
- [ ] Hit `/api/license/is-tier-at` (no query) and `/api/license/is-tier-at?tier=&epoch=nope` — both must return HTTP 200 with `is_tier_at=false` (never 4xx).
- [ ] Decrypt the live cloud snapshot and confirm no schema drift in the response payload.
- [ ] Browser-check any UI binding `/api/license/is-tier` or `/api/license/tier-at` — the new endpoints are additive; the existing endpoints are untouched.

## Not changed

- No `__version__` bump, no tag, no `[RELEASE]` PR — those stay with the operator.
- No enforcement gate flipped; the resolved entitlement still falls back to GRACE.
- `/api/license/is-tier` and `/api/license/tier-at{,-batch}` are untouched — the new endpoints are purely additive.

## Verification here

- `python -m py_compile` on all changed files: clean.
- `ruff check` on all changed files: clean.
- `pytest tests/test_license_is_tier_at.py` — 64 passed.
- `pytest tests/test_license_tier_at.py tests/test_license_tier_scalar.py tests/test_license_state_at_batch.py tests/test_entitlement_api.py` — 163 passed (adjacent regression check).

---

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code

---
_Generated by [Claude Code](https://claude.ai/code/session_01BJRLeVGmQ9Tthm8u8reeEM)_