### PR TITLE
feat(telemetry): install-lifecycle events (install/update/onboarded) + install_id linkage

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,17 +372,21 @@ This project is tested with BrowserStack.
 
 ## Telemetry
 
-ClawMetry sends a single anonymous "first run" ping to
-`https://app.clawmetry.com/api/install` the first time you run the
-`clawmetry` CLI on a new machine. We use this to count installs (the
-only marketing metric we have for an OSS project) and to learn which
-agent frameworks our users have installed.
+ClawMetry sends anonymous install-lifecycle pings to
+`https://app.clawmetry.com/api/install`: one `install` ping the first
+time you run the `clawmetry` CLI on a new machine, one `update` ping
+the first run after upgrading to a new version, and one `onboarded`
+ping when you complete the in-dashboard onboarding choice. We use this
+to count real installs (raw PyPI download numbers are ~98% mirrors, CI,
+and auto-update re-downloads) and to learn which agent frameworks and
+versions are actually in the wild.
 
-**Exactly one POST per install**, containing:
+**At most one POST per lifecycle event per version**, containing:
 
 | Field | Example | Why |
 |---|---|---|
-| `install_id` | random UUID stored at `~/.clawmetry/install_id` | dedup; not linked to your email or api_key |
+| `install_id` | random UUID stored at `~/.clawmetry/install_id` | dedup; anonymous until you explicitly connect Cloud sync (the authenticated daemon heartbeat then carries it, linking this install to your account) |
+| `event` | `install` / `update` / `onboarded` | fresh install vs upgrade of an existing one |
 | `version` | `0.12.167` | what versions are in the wild |
 | `os` / `os_version` | `Darwin` / `25.3.0` | platform support priorities |
 | `python` | `3.11.15` | Python version support matrix |

--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -5815,10 +5815,11 @@ def main() -> None:
     os.environ["CLAWMETRY_ROLE"] = "dashboard"
     from dashboard import main as dashboard_main
 
-    # Anonymous, opt-out, once-per-install ping. See clawmetry/telemetry.py
-    # for the privacy contract. Fires on a daemon thread so a network
-    # failure can't slow CLI startup; honours CLAWMETRY_NO_TELEMETRY=1
-    # and ~/.clawmetry/notelemetry.
+    # Anonymous, opt-out install-lifecycle ping (install once ever, update
+    # once per new version). See clawmetry/telemetry.py for the privacy
+    # contract. Fires on a daemon thread so a network failure can't slow
+    # CLI startup; honours CLAWMETRY_NO_TELEMETRY=1 and
+    # ~/.clawmetry/notelemetry.
     try:
         from clawmetry import telemetry as _telemetry
         try:

--- a/clawmetry/license.py
+++ b/clawmetry/license.py
@@ -645,7 +645,16 @@ def _download_and_install_pro(payload: dict) -> str:
             token = ""
         if not token:
             return "clawmetry-pro install deferred (no license on disk)"
-        body = json.dumps({"key": token, "node_id": node_id}).encode()
+        # install_id links this activation to the cloud install registry
+        # (best-effort; server ignores unknown fields on older deploys).
+        try:
+            from clawmetry.telemetry import _ensure_install_id
+            install_id = _ensure_install_id() or ""
+        except Exception:
+            install_id = ""
+        body = json.dumps(
+            {"key": token, "node_id": node_id, "install_id": install_id}
+        ).encode()
         req = urllib.request.Request(
             base + "/api/license/activate", data=body,
             headers={"Content-Type": "application/json"}, method="POST",

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -7125,6 +7125,17 @@ def _heartbeat_limits_payload():
     return _LIMITS_CACHE["payload"]
 
 
+def _install_id_for_heartbeat() -> str:
+    """The persistent install_id (creating it if this daemon is the first
+    process to run on a fresh install). Empty string on any failure —
+    the heartbeat must never be blocked by identity plumbing."""
+    try:
+        from clawmetry import telemetry as _telemetry
+        return _telemetry._ensure_install_id() or ""
+    except Exception:
+        return ""
+
+
 def send_heartbeat(config: dict) -> bool:
     """Send heartbeat to cloud. Returns True on success, False on failure.
 
@@ -7151,6 +7162,11 @@ def send_heartbeat(config: dict) -> bool:
         "e2e": bool(config.get("encryption_key")),
         "ollama": _detect_ollama_for_heartbeat(),
         "node_meta": _build_node_meta(),
+        # Persistent per-install identity (~/.clawmetry/install_id) so the
+        # cloud can join this node to its row in the install registry.
+        # Part of authenticated cloud sync, not the anonymous telemetry
+        # channel — the node already identifies itself by node_id here.
+        "install_id": _install_id_for_heartbeat(),
         # Runtimes DETECTED on this machine (Claude Code, Codex, …) — reported
         # even when not synced, so the Fleet can show "you're running these,
         # upgrade to observe them". Free lite-detection so the nudge reaches
@@ -17722,6 +17738,18 @@ def run_daemon() -> None:
         _ext_load()
     except Exception as _ext_e:
         log.warning("extensions load_plugins failed: %s", _ext_e)
+
+    # Install-lifecycle ping (install/update, anonymous, opt-out — see
+    # clawmetry/telemetry.py). The daemon is the only process guaranteed
+    # to run after an unattended auto-update (os.execv re-exec), so
+    # without this call headless nodes would never report upgrades and
+    # the cloud install registry would silently go stale for exactly the
+    # most-engaged installs.
+    try:
+        from clawmetry import telemetry as _telemetry
+        _telemetry.maybe_ping(_get_version())
+    except Exception:
+        pass
 
     try:
         config = load_config()

--- a/clawmetry/telemetry.py
+++ b/clawmetry/telemetry.py
@@ -1,10 +1,12 @@
-"""clawmetry/telemetry.py — anonymous, opt-out, first-run install ping.
+"""clawmetry/telemetry.py — anonymous, opt-out, install-lifecycle pings.
 
-What we send (one POST, max once per install):
+What we send (one POST per lifecycle event — ``install`` once ever,
+``update`` at most once per new version, ``onboarded`` once per explicit
+onboarding choice):
 
   {
     "install_id":  "<random uuid4 stored in ~/.clawmetry/install_id>",
-    "event":       "first_run",
+    "event":       "install" | "update" | "onboarded",
     "version":     "0.12.167",
     "os":          "Darwin",       # platform.system()
     "os_version":  "25.3.0",       # platform.release()
@@ -12,6 +14,8 @@ What we send (one POST, max once per install):
     "agent":       "openclaw" | "nemoclaw" | "hermes" | "none",
     "is_ci":       true / false,
     "ci_provider": "github_actions" | "gitlab_ci" | …  (only if is_ci)
+    "onboarding_state": "managed" | "selfhost_license" | "selfhost_trial"
+                                   (only on event="onboarded")
   }
 
 What we DO NOT send: hostname, username, IP (cloud derives country from
@@ -29,8 +33,10 @@ network failure, DNS hijack, or the cloud being down NEVER affects
 
 Why first-run instead of pip-install: PyPI removed install hooks years
 ago for supply-chain safety, so ``pip install clawmetry`` cannot phone
-home directly. We instead fire on first ``clawmetry`` CLI invocation,
-gated by ``~/.clawmetry/install_id`` so subsequent runs are silent.
+home directly. We instead fire on ``clawmetry`` CLI / daemon startup,
+deduped through ``~/.clawmetry/telemetry_state.json`` (the last version
+we reported): a restart on an already-reported version sends nothing, a
+version change sends one ``update``.
 """
 from __future__ import annotations
 
@@ -51,6 +57,7 @@ TELEMETRY_TIMEOUT_SEC = 3
 CONFIG_DIR = Path.home() / ".clawmetry"
 INSTALL_ID_FILE = CONFIG_DIR / "install_id"
 OPTOUT_MARKER = CONFIG_DIR / "notelemetry"
+STATE_FILE = CONFIG_DIR / "telemetry_state.json"
 
 # CI env-var → provider name. Order matters when more than one is set
 # (some providers leave others' vars in for back-compat); pick the most
@@ -145,13 +152,13 @@ def _ensure_install_id() -> str | None:
         return None
 
 
-def _build_payload(version: str) -> dict:
+def _build_payload(version: str, event: str = "install", extra: dict | None = None) -> dict:
     """Assemble the JSON body. Pure function — no I/O — so tests can
     stub the small helpers and assert the shape independently."""
     is_ci, ci_provider = _detect_ci()
-    return {
+    payload = {
         "install_id":  _ensure_install_id() or "",
-        "event":       "first_run",
+        "event":       event,
         "version":     version,
         "os":          platform.system() or "unknown",
         "os_version":  platform.release() or "",
@@ -160,6 +167,9 @@ def _build_payload(version: str) -> dict:
         "is_ci":       is_ci,
         "ci_provider": ci_provider,
     }
+    if extra:
+        payload.update(extra)
+    return payload
 
 
 def _post(payload: dict, url: str) -> None:
@@ -180,6 +190,64 @@ def _post(payload: dict, url: str) -> None:
             r.read()  # drain so the connection releases cleanly
     except Exception as e:
         log.debug("telemetry: post failed: %s", e)
+
+
+def _read_state() -> dict:
+    """Lifecycle state: {install_id, first_version, last_version,
+    first_ts, last_ts}. Empty dict when absent/corrupt — never raises."""
+    try:
+        with open(STATE_FILE, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+        return data if isinstance(data, dict) else {}
+    except Exception:
+        return {}
+
+
+def _write_state(state: dict) -> None:
+    try:
+        CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+        STATE_FILE.write_text(json.dumps(state), encoding="utf-8")
+    except Exception as e:
+        log.debug("telemetry: cannot persist state: %s", e)
+
+
+def _derive_event(install_id: str, version: str) -> str | None:
+    """What (if anything) to report for this startup.
+
+    - state file says we already reported this version  → nothing
+    - state file has a different version                → "update"
+    - no state file, but the legacy ``.pinged`` marker  → "update"
+      (an existing install that just upgraded onto the first version
+      that ships lifecycle state — its first_run row is already in the
+      cloud, so "install" would double-count it)
+    - nothing on disk at all                            → "install"
+    """
+    state = _read_state()
+    last = state.get("last_version")
+    if last == version:
+        return None
+    if last:
+        return "update"
+    if _has_pinged_this_install(install_id):
+        return "update"
+    return "install"
+
+
+def _record_reported(install_id: str, version: str, event: str) -> None:
+    """Persist that ``version`` has been reported, after a post attempt.
+    Also writes the legacy ``.pinged`` marker so a downgrade to an older
+    clawmetry (which only knows the marker) stays silent."""
+    state = _read_state()
+    now = int(time.time())
+    if not state.get("first_version"):
+        state["first_version"] = version
+        state["first_ts"] = now
+    state["install_id"] = install_id
+    state["last_version"] = version
+    state["last_ts"] = now
+    state["last_event"] = event
+    _write_state(state)
+    _mark_pinged(install_id)
 
 
 def _has_pinged_this_install(install_id: str) -> bool:
@@ -211,16 +279,35 @@ def _send_in_background(version: str) -> None:
     try:
         if _is_optout():
             return
-        payload = _build_payload(version)
-        if not payload.get("install_id"):
+        install_id = _ensure_install_id()
+        if not install_id:
             return
-        if _has_pinged_this_install(payload["install_id"]):
+        event = _derive_event(install_id, version)
+        if event is None:
             return
+        payload = _build_payload(version, event=event)
         url = os.environ.get("CLAWMETRY_TELEMETRY_URL", TELEMETRY_URL_DEFAULT)
         _post(payload, url)
-        _mark_pinged(payload["install_id"])
+        _record_reported(install_id, version, event)
     except Exception as e:
         log.debug("telemetry: background failure: %s", e)
+
+
+def _send_event_in_background(event: str, version: str, extra: dict | None) -> None:
+    """Worker for explicit lifecycle events (e.g. ``onboarded``).
+    No version-dedup — the caller decides when the event happened; the
+    cloud's UNIQUE(install_id, event, version) still absorbs repeats."""
+    try:
+        if _is_optout():
+            return
+        install_id = _ensure_install_id()
+        if not install_id:
+            return
+        payload = _build_payload(version, event=event, extra=extra)
+        url = os.environ.get("CLAWMETRY_TELEMETRY_URL", TELEMETRY_URL_DEFAULT)
+        _post(payload, url)
+    except Exception as e:
+        log.debug("telemetry: event background failure: %s", e)
 
 
 def maybe_ping(version: str = "unknown") -> threading.Thread | None:
@@ -241,6 +328,23 @@ def maybe_ping(version: str = "unknown") -> threading.Thread | None:
         args=(version,),
         daemon=True,
         name="clawmetry-telemetry",
+    )
+    t.start()
+    return t
+
+
+def ping_event(event: str, version: str = "unknown",
+               extra: dict | None = None) -> threading.Thread | None:
+    """Fire one explicit lifecycle event (e.g. ``onboarded`` with
+    ``extra={"onboarding_state": "managed"}``). Same opt-out and
+    fire-and-forget contract as :func:`maybe_ping`."""
+    if _is_optout():
+        return None
+    t = threading.Thread(
+        target=_send_event_in_background,
+        args=(event, version, extra),
+        daemon=True,
+        name="clawmetry-telemetry-event",
     )
     t.start()
     return t

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -24,6 +24,7 @@ def telemetry(monkeypatch, tmp_path):
     monkeypatch.setattr(t, "CONFIG_DIR", tmp_path)
     monkeypatch.setattr(t, "INSTALL_ID_FILE", tmp_path / "install_id")
     monkeypatch.setattr(t, "OPTOUT_MARKER", tmp_path / "notelemetry")
+    monkeypatch.setattr(t, "STATE_FILE", tmp_path / "telemetry_state.json")
     # Strip any CI env vars the test runner might have set so detection
     # tests aren't poisoned by GitHub Actions itself.
     for k in ("CI", "GITHUB_ACTIONS", "GITLAB_CI", "CIRCLECI", "TRAVIS",
@@ -110,7 +111,7 @@ def test_payload_shape(telemetry):
     # Required fields
     assert set(p) == {"install_id", "event", "version", "os", "os_version",
                       "python", "agent", "is_ci", "ci_provider"}
-    assert p["event"] == "first_run"
+    assert p["event"] == "install"
     assert p["version"] == "9.9.9"
     assert p["os"]  # platform.system() always returns something
     # PII NOT in payload
@@ -163,3 +164,79 @@ def test_payload_omits_ci_provider_when_not_ci(telemetry):
     p = telemetry._build_payload("0.0.0")
     if not p["is_ci"]:
         assert p["ci_provider"] is None
+
+
+# ---------------------------------------------------------------------------
+# Install-lifecycle state machine (install → silent → update)
+# ---------------------------------------------------------------------------
+
+def _run_send(telemetry, version):
+    """Run the background worker synchronously, capturing posted payloads."""
+    sent = []
+    with patch.object(telemetry, "_post", side_effect=lambda p, u: sent.append(p)):
+        telemetry._send_in_background(version)
+    return sent
+
+
+def test_fresh_install_sends_install_event(telemetry):
+    sent = _run_send(telemetry, "1.0.0")
+    assert [p["event"] for p in sent] == ["install"]
+    state = telemetry._read_state()
+    assert state["last_version"] == "1.0.0"
+    assert state["first_version"] == "1.0.0"
+
+
+def test_same_version_second_run_is_silent(telemetry):
+    _run_send(telemetry, "1.0.0")
+    sent = _run_send(telemetry, "1.0.0")
+    assert sent == []
+
+
+def test_version_change_sends_update(telemetry):
+    _run_send(telemetry, "1.0.0")
+    sent = _run_send(telemetry, "1.1.0")
+    assert [p["event"] for p in sent] == ["update"]
+    state = telemetry._read_state()
+    assert state["last_version"] == "1.1.0"
+    assert state["first_version"] == "1.0.0", "first_version must not move"
+
+
+def test_legacy_pinged_install_reports_update_not_install(telemetry):
+    """Pre-state installs (only the .pinged marker on disk) already have
+    a first_run row in the cloud — their next report must be an update,
+    never a second install."""
+    install_id = telemetry._ensure_install_id()
+    telemetry._mark_pinged(install_id)
+    sent = _run_send(telemetry, "2.0.0")
+    assert [p["event"] for p in sent] == ["update"]
+
+
+def test_corrupt_state_file_does_not_crash(telemetry):
+    telemetry.STATE_FILE.write_text("{not json!!", encoding="utf-8")
+    sent = _run_send(telemetry, "1.0.0")
+    assert [p["event"] for p in sent] == ["install"]
+
+
+def test_state_write_also_writes_legacy_marker(telemetry):
+    """Downgrade safety: an older clawmetry only knows the .pinged
+    marker; it must stay silent after this version has reported."""
+    _run_send(telemetry, "1.0.0")
+    install_id = telemetry._ensure_install_id()
+    assert telemetry._has_pinged_this_install(install_id) is True
+
+
+def test_ping_event_onboarded_payload(telemetry):
+    sent = []
+    with patch.object(telemetry, "_post", side_effect=lambda p, u: sent.append(p)):
+        telemetry._send_event_in_background(
+            "onboarded", "1.0.0", {"onboarding_state": "selfhost_trial"})
+    assert len(sent) == 1
+    assert sent[0]["event"] == "onboarded"
+    assert sent[0]["onboarding_state"] == "selfhost_trial"
+
+
+def test_ping_event_respects_optout(telemetry, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_NO_TELEMETRY", "1")
+    with patch("urllib.request.urlopen") as urlopen:
+        assert telemetry.ping_event("onboarded", "1.0.0") is None
+        urlopen.assert_not_called()


### PR DESCRIPTION
## Why

PyPI download counts are ~98% noise (mirrors, our own CI, auto-update re-downloads: 7,376 downloads on Jul 30 vs roughly 50-100 real new installs). The founder console needs a truthful install registry: one record per install, updated in place across upgrades, with onboarding status traceable per install.

The cloud side already half-exists: the installs table has UNIQUE(install_id, event, version) and accepts install/update events, but the client pings exactly once per install (a .pinged marker short-circuits forever), so update rows never arrive and installs can never be joined to nodes or accounts.

## What

- clawmetry/telemetry.py: versioned state file (~/.clawmetry/telemetry_state.json) replaces the ping-once marker.
  - install: first run ever
  - update: first run on each new version (at most once per version; legacy .pinged installs report update, never a second install; downgrade-safe: still writes the legacy marker)
  - onboarded: new ping_event(event, version, extra) public API carrying onboarding_state, for the upcoming in-dashboard onboarding gate (PR 2)
- clawmetry/sync.py: daemon startup calls maybe_ping() so headless nodes report upgrades after unattended auto-updates (the dashboard-launch call site missed exactly the most-engaged installs). Authenticated heartbeat now carries install_id so the cloud can join installs -> nodes -> accounts. Cloud logs it as an unknown field until the cloud PR lands; harmless.
- clawmetry/license.py: /api/license/activate body carries install_id (server ignores unknown fields on older deploys).
- README: telemetry section updated honestly (event field; disclosure that connecting Cloud sync links install_id to your account via the authenticated heartbeat).

Opt-out contract unchanged: CLAWMETRY_NO_TELEMETRY / DO_NOT_TRACK / ~/.clawmetry/notelemetry disable everything including ping_event.

## Tests

- tests/test_telemetry.py extended from 15 to 24 tests: full lifecycle state machine (fresh install, silent restart, update on version change, legacy-marker upgrade, corrupt state file, downgrade marker, onboarded payload, opt-out for ping_event). All 24 pass locally.
- Heartbeat suites: 16 passed; the 4 failures in test_heartbeat_envelope/test_heartbeat_agent_install_piggyback are pre-existing on clean origin/main (environment-dependent: this dev machine has agents installed) and unrelated.

Part 1 of 3 (part 2: mandatory in-dashboard onboarding gate; part 3: cloud installs registry + founder console + trial linkage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)