### PR TITLE
feat(onboarding): mandatory first-run gate — managed cloud vs self-host (license / 7-day trial)

### DIFF
--- a/clawmetry/static/js/onboarding.js
+++ b/clawmetry/static/js/onboarding.js
@@ -1,0 +1,283 @@
+// onboarding.js — first-run onboarding gate (hard gate, no skip).
+//
+// Shows templates/partials/onboarding-modal.html when
+// GET /api/onboarding/state says {required:true}. Three ways out, each
+// recorded via POST /api/onboarding/complete (or the combined
+// activate-license endpoint):
+//   managed          — existing cloud modal (OTP / Google / GitHub), we
+//                      poll /api/cloud-cta/status until connected
+//   selfhost_trial   — email + 6-digit code, the flow /api/trial/activate
+//                      already implements (same as the gw-setup teaser)
+//   selfhost_license — CLAW1 key via /api/onboarding/activate-license
+//
+// Never runs on the hosted cloud dashboard (window.CLOUD_MODE) and defers
+// to the mandatory gateway-setup overlay when that is on screen.
+
+(function () {
+  'use strict';
+
+  var _pollTimer = null;
+  var _trialEmail = '';
+
+  function $(id) { return document.getElementById(id); }
+
+  function _overlay() { return $('onboarding-gate-overlay'); }
+
+  function _show() {
+    var o = _overlay();
+    if (o) o.style.display = 'flex';
+  }
+
+  function _hide() {
+    var o = _overlay();
+    if (o) o.style.display = 'none';
+    if (_pollTimer) { clearInterval(_pollTimer); _pollTimer = null; }
+  }
+
+  function _err(id, msg) {
+    var e = $(id);
+    if (e) { e.textContent = msg || ''; e.style.display = msg ? 'block' : 'none'; }
+  }
+
+  function _gwSetupMandatoryVisible() {
+    var gw = $('gw-setup-overlay');
+    return !!(gw && gw.style.display && gw.style.display !== 'none'
+      && gw.dataset && gw.dataset.mandatory === 'true');
+  }
+
+  function _complete(choice, onFail) {
+    fetch('/api/onboarding/complete', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ choice: choice }),
+    }).then(function (r) { return r.json(); }).then(function (d) {
+      if (d && d.ok) {
+        _hide();
+        location.reload();
+      } else if (onFail) {
+        onFail((d && d.error) || 'Could not save your choice. Try again.');
+      }
+    }).catch(function () {
+      if (onFail) onFail('Network error. Try again.');
+    });
+  }
+
+  // ── Managed cloud branch ─────────────────────────────────────────────
+  function _startManaged() {
+    _err('obg-managed-err', '');
+    if (typeof openCloudModal !== 'function') {
+      _err('obg-managed-err', 'Cloud sign-in is unavailable in this build.');
+      return;
+    }
+    openCloudModal();
+    if (_pollTimer) clearInterval(_pollTimer);
+    _pollTimer = setInterval(function () {
+      fetch('/api/cloud-cta/status').then(function (r) { return r.json(); })
+        .then(function (d) {
+          if (d && d.connected) {
+            clearInterval(_pollTimer); _pollTimer = null;
+            _complete('managed', function (msg) { _err('obg-managed-err', msg); });
+          }
+        }).catch(function () {});
+    }, 2000);
+  }
+
+  // ── Self-host: free trial (email → code → activate) ─────────────────
+  function _trialEmailStep() {
+    var body = $('obg-selfhost-body');
+    if (!body) return;
+    body.innerHTML =
+      '<input class="obg-input" id="obg-trial-email" type="email" placeholder="you@company.com" autocomplete="email">' +
+      '<div class="obg-err" id="obg-trial-err"></div>' +
+      '<button class="obg-btn obg-btn-quiet" id="obg-trial-send" type="button">Email me a code</button>' +
+      '<a class="obg-alt" href="#" id="obg-trial-back">Back</a>';
+    $('obg-trial-send').addEventListener('click', _trialSendCode);
+    $('obg-trial-email').addEventListener('keydown', function (ev) {
+      if (ev.key === 'Enter') _trialSendCode();
+    });
+    $('obg-trial-back').addEventListener('click', function (ev) {
+      ev.preventDefault(); _selfhostHome();
+    });
+    setTimeout(function () { var el = $('obg-trial-email'); if (el) el.focus(); }, 50);
+  }
+
+  function _trialSendCode() {
+    var email = (($('obg-trial-email') || {}).value || '').trim();
+    if (!email || email.indexOf('@') < 0) {
+      _err('obg-trial-err', 'Enter a valid email.');
+      return;
+    }
+    _trialEmail = email;
+    _err('obg-trial-err', '');
+    var btn = $('obg-trial-send');
+    if (btn) { btn.textContent = 'Sending code'; btn.disabled = true; }
+    fetch('/api/cloud-cta/send-otp', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: email }),
+    }).then(function (r) { return r.json(); }).then(function (d) {
+      if (d && d.ok === false) {
+        _err('obg-trial-err', d.error || 'Could not send the code. Try again.');
+        if (btn) { btn.textContent = 'Email me a code'; btn.disabled = false; }
+        return;
+      }
+      _trialCodeStep();
+    }).catch(function () {
+      _err('obg-trial-err', 'Network error. Try again.');
+      if (btn) { btn.textContent = 'Email me a code'; btn.disabled = false; }
+    });
+  }
+
+  function _trialCodeStep() {
+    var body = $('obg-selfhost-body');
+    if (!body) return;
+    body.innerHTML =
+      '<p style="color:#94a3b8;font-size:12px;margin:0 0 8px;">We emailed a 6-digit code to <b style="color:#e2e8f0;">' +
+        _trialEmail.replace(/&/g, '&amp;').replace(/</g, '&lt;') + '</b>.</p>' +
+      '<input class="obg-input" id="obg-trial-code" type="text" inputmode="numeric" maxlength="6" placeholder="123456" style="letter-spacing:6px;text-align:center;font-family:monospace;font-size:16px;">' +
+      '<div class="obg-err" id="obg-trial-err"></div>' +
+      '<button class="obg-btn obg-btn-quiet" id="obg-trial-activate" type="button">Activate trial</button>' +
+      '<a class="obg-alt" href="#" id="obg-trial-redo">Use a different email</a>';
+    $('obg-trial-activate').addEventListener('click', _trialActivate);
+    $('obg-trial-code').addEventListener('keydown', function (ev) {
+      if (ev.key === 'Enter') _trialActivate();
+    });
+    $('obg-trial-redo').addEventListener('click', function (ev) {
+      ev.preventDefault(); _trialEmailStep();
+    });
+    setTimeout(function () { var el = $('obg-trial-code'); if (el) el.focus(); }, 50);
+  }
+
+  function _trialActivate() {
+    var code = ((($('obg-trial-code') || {}).value) || '').replace(/\s/g, '');
+    if (code.length !== 6) {
+      _err('obg-trial-err', 'Enter the 6-digit code from your email.');
+      return;
+    }
+    _err('obg-trial-err', '');
+    var btn = $('obg-trial-activate');
+    if (btn) { btn.textContent = 'Activating'; btn.disabled = true; }
+    fetch('/api/trial/activate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: _trialEmail, code: code }),
+    }).then(function (r) { return r.json(); }).then(function (d) {
+      if (!d || !d.ok) {
+        _err('obg-trial-err', (d && d.error) || 'Activation failed. Try again.');
+        if (btn) { btn.textContent = 'Activate trial'; btn.disabled = false; }
+        return;
+      }
+      _complete('selfhost_trial', function (msg) { _err('obg-trial-err', msg); });
+    }).catch(function () {
+      _err('obg-trial-err', 'Network error. Try again.');
+      if (btn) { btn.textContent = 'Activate trial'; btn.disabled = false; }
+    });
+  }
+
+  // ── Self-host: license key ───────────────────────────────────────────
+  function _licenseStep() {
+    var body = $('obg-selfhost-body');
+    if (!body) return;
+    body.innerHTML =
+      '<input class="obg-input" id="obg-license-key" type="text" placeholder="CLAW1.xxxx.xxxx" autocomplete="off" spellcheck="false">' +
+      '<div class="obg-err" id="obg-license-err"></div>' +
+      '<button class="obg-btn obg-btn-quiet" id="obg-license-activate" type="button">Activate license</button>' +
+      '<a class="obg-alt" href="#" id="obg-license-back">Back</a>';
+    $('obg-license-activate').addEventListener('click', _licenseActivate);
+    $('obg-license-key').addEventListener('keydown', function (ev) {
+      if (ev.key === 'Enter') _licenseActivate();
+    });
+    $('obg-license-back').addEventListener('click', function (ev) {
+      ev.preventDefault(); _selfhostHome();
+    });
+    setTimeout(function () { var el = $('obg-license-key'); if (el) el.focus(); }, 50);
+  }
+
+  function _licenseActivate() {
+    var key = ((($('obg-license-key') || {}).value) || '').trim();
+    if (!key) { _err('obg-license-err', 'Paste your license key.'); return; }
+    _err('obg-license-err', '');
+    var btn = $('obg-license-activate');
+    if (btn) { btn.textContent = 'Activating'; btn.disabled = true; }
+    fetch('/api/onboarding/activate-license', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ key: key }),
+    }).then(function (r) { return r.json(); }).then(function (d) {
+      if (!d || !d.ok) {
+        _err('obg-license-err', (d && d.error) || 'Activation failed. Try again.');
+        if (btn) { btn.textContent = 'Activate license'; btn.disabled = false; }
+        return;
+      }
+      _hide();
+      location.reload();
+    }).catch(function () {
+      _err('obg-license-err', 'Network error. Try again.');
+      if (btn) { btn.textContent = 'Activate license'; btn.disabled = false; }
+    });
+  }
+
+  function _selfhostHome() {
+    var body = $('obg-selfhost-body');
+    if (!body) return;
+    body.innerHTML =
+      '<button class="obg-btn obg-btn-quiet" id="obg-trial-btn" type="button">Start free 7-day trial</button>' +
+      '<a class="obg-alt" href="#" id="obg-license-link">I have a license key</a>';
+    _wireSelfhostHome();
+  }
+
+  function _wireSelfhostHome() {
+    var t = $('obg-trial-btn');
+    if (t) t.addEventListener('click', _trialEmailStep);
+    var l = $('obg-license-link');
+    if (l) l.addEventListener('click', function (ev) { ev.preventDefault(); _licenseStep(); });
+  }
+
+  // ── Greeting: lead with what ClawMetry can already see ───────────────
+  function _fillDetection() {
+    fetch('/api/entitlement/runtime-detection')
+      .then(function (r) { return r.json(); })
+      .then(function (d) {
+        var found = ((d && d.probes) || []).filter(function (p) { return p.found; });
+        if (!found.length) return;
+        var names = found.slice(0, 3).map(function (p) { return p.label || p.id; });
+        var extra = found.length - names.length;
+        var el = $('obg-detect');
+        if (!el) return;
+        el.innerHTML = 'We found <b>' + names.map(function (n) {
+          return String(n).replace(/&/g, '&amp;').replace(/</g, '&lt;');
+        }).join('</b>, <b>') + '</b>' +
+          (extra > 0 ? ' and ' + extra + ' more runtime' + (extra > 1 ? 's' : '') : '') +
+          ' on this machine. One quick choice and your dashboard is ready.';
+      }).catch(function () {});
+  }
+
+  function _boot() {
+    if (window.CLOUD_MODE) return;
+    if (!_overlay()) return;
+    fetch('/api/onboarding/state')
+      .then(function (r) { return r.json(); })
+      .then(function (d) {
+        if (!d || !d.required) return;
+        // The gateway-setup overlay (no auth configured) is more
+        // fundamental; let it win this page load — we gate the next one.
+        if (_gwSetupMandatoryVisible()) return;
+        var m = $('obg-managed-btn');
+        if (m) m.addEventListener('click', _startManaged);
+        _wireSelfhostHome();
+        _fillDetection();
+        _show();
+      })
+      .catch(function () {});
+  }
+
+  if (document.readyState === 'loading') {
+    // Run after gw-setup's own DOMContentLoaded check so the mandatory
+    // gateway overlay is already visible when we look for it.
+    document.addEventListener('DOMContentLoaded', function () {
+      setTimeout(_boot, 400);
+    });
+  } else {
+    setTimeout(_boot, 400);
+  }
+})();

--- a/clawmetry/templates/partials/onboarding-modal.html
+++ b/clawmetry/templates/partials/onboarding-modal.html
@@ -1,0 +1,60 @@
+<!-- First-run onboarding gate (hard gate: no close). Shown by
+     static/js/onboarding.js when /api/onboarding/state says required.
+     The cloud OTP/OAuth modal (z-index 2000) opens ABOVE this overlay
+     for the managed branch; this overlay sits at 1900. -->
+<div id="onboarding-gate-overlay" role="dialog" aria-modal="true" aria-labelledby="obg-title">
+  <style>
+    #onboarding-gate-overlay{display:none;position:fixed;inset:0;z-index:1900;background:rgba(4,8,16,0.82);backdrop-filter:blur(6px);align-items:center;justify-content:center;overflow:auto;padding:24px}
+    #onboarding-gate-overlay .obg-card{background:#0f1623;border:1px solid rgba(255,255,255,0.08);border-radius:16px;width:100%;max-width:680px;padding:36px;box-shadow:0 25px 60px rgba(0,0,0,0.55);margin:auto}
+    #onboarding-gate-overlay .obg-head{display:flex;align-items:center;gap:10px;margin-bottom:6px}
+    #onboarding-gate-overlay .obg-head span{font-size:19px;font-weight:700;color:#fff}
+    #onboarding-gate-overlay .obg-detect{color:#94a3b8;font-size:13.5px;line-height:1.55;margin:0 0 22px}
+    #onboarding-gate-overlay .obg-detect b{color:#e2e8f0;font-weight:600}
+    #onboarding-gate-overlay .obg-q{color:#e2e8f0;font-size:15px;font-weight:600;margin:0 0 14px}
+    #onboarding-gate-overlay .obg-choices{display:flex;gap:14px}
+    #onboarding-gate-overlay .obg-opt{flex:1;background:#111b2c;border:1px solid rgba(255,255,255,0.09);border-radius:12px;padding:20px}
+    #onboarding-gate-overlay .obg-opt h3{margin:0 0 2px;font-size:14.5px;color:#fff}
+    #onboarding-gate-overlay .obg-opt .obg-rec{display:inline-block;margin-left:6px;font-size:10.5px;font-weight:700;letter-spacing:0.4px;color:#f0b429;text-transform:uppercase}
+    #onboarding-gate-overlay .obg-opt p{color:#94a3b8;font-size:12.5px;line-height:1.55;margin:8px 0 14px;min-height:58px}
+    #onboarding-gate-overlay .obg-btn{display:block;width:100%;padding:11px 14px;border:none;border-radius:8px;font-size:13.5px;font-weight:600;cursor:pointer;box-sizing:border-box;text-align:center}
+    #onboarding-gate-overlay .obg-btn-primary{background:#E5443A;color:#fff}
+    #onboarding-gate-overlay .obg-btn-primary:hover{background:#d13a30}
+    #onboarding-gate-overlay .obg-btn-quiet{background:#1a2235;color:#fff;border:1px solid rgba(255,255,255,0.12)}
+    #onboarding-gate-overlay .obg-btn-quiet:hover{background:#202a42}
+    #onboarding-gate-overlay .obg-alt{display:block;text-align:center;color:#7c8aa0;font-size:11.5px;margin-top:10px;text-decoration:none}
+    #onboarding-gate-overlay .obg-alt:hover{color:#aab6c8;text-decoration:underline}
+    #onboarding-gate-overlay .obg-input{width:100%;padding:10px 12px;border:1px solid rgba(255,255,255,0.14);border-radius:8px;background:#0b111d;color:#fff;font-size:13px;box-sizing:border-box;outline:none;margin-bottom:8px}
+    #onboarding-gate-overlay .obg-input:focus-visible,#onboarding-gate-overlay .obg-btn:focus-visible,#onboarding-gate-overlay .obg-alt:focus-visible{outline:2px solid #E5443A;outline-offset:2px}
+    #onboarding-gate-overlay .obg-err{display:none;color:#f87171;font-size:12px;margin:0 0 8px}
+    #onboarding-gate-overlay .obg-foot{color:#64748b;font-size:11.5px;line-height:1.6;margin:22px 0 0;text-align:center}
+    #onboarding-gate-overlay .obg-foot a{color:#7c8aa0}
+    @media (max-width:700px){ #onboarding-gate-overlay .obg-choices{flex-direction:column} #onboarding-gate-overlay .obg-card{padding:24px} #onboarding-gate-overlay .obg-opt p{min-height:0}}
+    @media (prefers-reduced-motion:no-preference){ #onboarding-gate-overlay .obg-card{animation:obgIn .28s ease-out}@keyframes obgIn{from{opacity:0;transform:translateY(10px)}to{opacity:1;transform:none}}}
+  </style>
+  <div class="obg-card">
+    <div class="obg-head">
+      <img src="/static/img/logo.svg" width="28" height="28" style="border-radius:6px;" alt="">
+      <span id="obg-title">Welcome to ClawMetry</span>
+    </div>
+    <p class="obg-detect" id="obg-detect">One quick choice and your dashboard is ready.</p>
+    <p class="obg-q">Where should ClawMetry keep an eye on your agents?</p>
+    <div class="obg-choices">
+      <div class="obg-opt">
+        <h3>Managed cloud<span class="obg-rec">Recommended</span></h3>
+        <p>See your agents from any browser at app.clawmetry.com. End-to-end encrypted: only your browser holds the key, we never see your data. Includes a free 7-day Pro trial, no card needed.</p>
+        <button class="obg-btn obg-btn-primary" id="obg-managed-btn" type="button">Connect ClawMetry Cloud</button>
+        <div class="obg-err" id="obg-managed-err"></div>
+      </div>
+      <div class="obg-opt">
+        <h3>Self-host</h3>
+        <p>Everything stays on this machine. Sign in once by email to start the same free 7-day Pro trial and unlock every runtime, or activate a license key you already have.</p>
+        <div id="obg-selfhost-body">
+          <button class="obg-btn obg-btn-quiet" id="obg-trial-btn" type="button">Start free 7-day trial</button>
+          <a class="obg-alt" href="#" id="obg-license-link">I have a license key</a>
+        </div>
+      </div>
+    </div>
+    <p class="obg-foot">Read-only by design: ClawMetry watches your agents, it never changes them.<br>
+    You can switch between cloud and self-host any time from Settings.</p>
+  </div>
+</div>

--- a/dashboard.py
+++ b/dashboard.py
@@ -105,6 +105,7 @@ from routes.alerts import bp_alerts, bp_budget
 from routes.channels import bp_channels
 from routes.overview import bp_overview
 from routes.trial import bp_trial
+from routes.onboarding import bp_onboarding
 from routes.components import bp_components
 from routes.fleet_history import bp_fleet
 from routes.infra import bp_logs, bp_memory, bp_security, bp_config
@@ -11725,6 +11726,7 @@ def detect_config(args=None):
     app.register_blueprint(bp_otlp_traces)
     app.register_blueprint(bp_overview)
     app.register_blueprint(bp_trial)
+    app.register_blueprint(bp_onboarding)
     app.register_blueprint(bp_security)
     app.register_blueprint(bp_sessions)
     app.register_blueprint(bp_sla)
@@ -12183,6 +12185,7 @@ DASHBOARD_HTML = r"""
   {% endif %}
 </div>
 {% include 'partials/cloud-modal.html' %}
+{% include 'partials/onboarding-modal.html' %}
 
 
 {% include 'partials/banners.html' %}
@@ -12540,6 +12543,7 @@ DASHBOARD_HTML = r"""
 </div>
 
 <script src="{{ url_for('static', filename='js/gw-setup.js', v=version) }}"></script>
+<script src="{{ url_for('static', filename='js/onboarding.js', v=version) }}"></script>
 
 </body>
 </html>

--- a/routes/onboarding.py
+++ b/routes/onboarding.py
@@ -144,6 +144,22 @@ def api_onboarding_state():
             # Hosted dashboard: signing up WAS the onboarding.
             return jsonify({"required": False, "state": "managed",
                             "source": "cloud_mode"})
+        # Fleet-managed / scripted installs get an explicit escape: the
+        # operator made the choice for the machine, a modal can't.
+        if os.environ.get("CLAWMETRY_SKIP_ONBOARDING", "").strip() \
+                not in ("", "0", "false", "False"):
+            return jsonify({"required": False, "state": "none",
+                            "source": "env_skip"})
+        # CI runs (our own E2E suites included) boot fresh dashboards with
+        # no human present; a mandatory modal there only breaks automation.
+        try:
+            from clawmetry.telemetry import _detect_ci
+
+            if _detect_ci()[0]:
+                return jsonify({"required": False, "state": "none",
+                                "source": "ci"})
+        except Exception:
+            pass
         return jsonify(_resolve_state())
     except Exception as exc:
         # Never let gate plumbing brick the dashboard: fail open.

--- a/routes/onboarding.py
+++ b/routes/onboarding.py
@@ -1,0 +1,197 @@
+"""
+routes/onboarding.py — the first-run onboarding gate state machine.
+
+Owns ``bp_onboarding``:
+
+  GET  /api/onboarding/state            — does this install still owe an
+                                          onboarding choice, and what is it?
+  POST /api/onboarding/complete         — record the choice after its flow
+                                          finished (managed cloud connect,
+                                          trial activation, license key)
+  POST /api/onboarding/activate-license — activate a CLAW1 key and record
+                                          the selfhost_license choice in one
+                                          call (the gate's license branch)
+
+Why a gate: ``pip install clawmetry && clawmetry`` used to land straight on
+the dashboard with no identity and no explicit choice, so the funnel had no
+idea whether an install ever chose anything (founder decision 2026-07-31:
+hard gate, everyone chooses managed cloud or self-host; self-host offers a
+license key or the free 7-day Pro trial).
+
+State resolution — an install is already onboarded when ANY of:
+  1. ``~/.clawmetry/onboarding.json`` records an explicit choice (this gate).
+  2. A local license key is activated (self-host, license or trial: the CLI
+     ``clawmetry activate`` / ``clawmetry onboard`` path predates the gate).
+  3. A cloud token exists (managed: ``clawmetry connect`` / the cloud CTA).
+Derived states (2)/(3) mean existing installs that already chose through
+the CLI are never re-prompted; installs with no choice on record are gated
+regardless of age.
+
+The gate is UX, not security: this is the user's own machine and an open
+package, so "hard" means no path in the UI, not tamper-proofing. The
+hosted cloud dashboard (CLOUD_MODE) never gates — accounts there already
+chose managed by signing up.
+"""
+
+import json
+import logging
+import os
+import time
+
+from flask import Blueprint, jsonify, request
+
+bp_onboarding = Blueprint("onboarding", __name__)
+
+log = logging.getLogger(__name__)
+
+_STATE_PATH = os.path.expanduser("~/.clawmetry/onboarding.json")
+
+_CHOICES = ("managed", "selfhost_license", "selfhost_trial")
+
+
+def _read_choice_file() -> dict:
+    try:
+        with open(_STATE_PATH, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+        return data if isinstance(data, dict) else {}
+    except Exception:
+        return {}
+
+
+def _write_choice_file(choice: str) -> bool:
+    try:
+        os.makedirs(os.path.dirname(_STATE_PATH), exist_ok=True)
+        with open(_STATE_PATH, "w", encoding="utf-8") as fh:
+            json.dump({"choice": choice, "completed_at": int(time.time())}, fh)
+        return True
+    except Exception as exc:
+        log.warning("onboarding: cannot persist choice: %s", exc)
+        return False
+
+
+def _license_state() -> str:
+    """'' | 'selfhost_trial' | 'selfhost_license' from the local key."""
+    try:
+        from clawmetry import license as _lic
+
+        payload = _lic.load_license()
+        if not payload:
+            return ""
+        tier = str(payload.get("tier", "")).strip().lower()
+        return "selfhost_trial" if tier == "trial" else "selfhost_license"
+    except Exception:
+        return ""
+
+
+def _cloud_connected() -> bool:
+    try:
+        import dashboard as _d
+
+        return bool(_d._read_cloud_token())
+    except Exception:
+        return False
+
+
+def _resolve_state() -> dict:
+    """The single source of truth the gate JS renders from."""
+    recorded = _read_choice_file()
+    choice = str(recorded.get("choice", "")).strip().lower()
+    if choice in _CHOICES:
+        return {"required": False, "state": choice, "source": "gate"}
+    lic = _license_state()
+    if lic:
+        return {"required": False, "state": lic, "source": "license"}
+    if _cloud_connected():
+        return {"required": False, "state": "managed", "source": "cloud"}
+    return {"required": True, "state": "none", "source": "none"}
+
+
+def _ping_onboarded(choice: str) -> None:
+    """Best-effort lifecycle ping (anonymous, opt-out — clawmetry/telemetry)."""
+    try:
+        from clawmetry import telemetry as _telemetry
+
+        try:
+            from dashboard import __version__ as _ver
+        except Exception:
+            _ver = "unknown"
+        _telemetry.ping_event("onboarded", _ver,
+                              {"onboarding_state": choice})
+    except Exception:
+        pass
+
+
+def _apply_marker_semantics(choice: str) -> None:
+    """Managed clears the local-only marker (the June '0 nodes' bug class:
+    connect without enable_cloud() silently no-ops sync). Self-host writes
+    it so identity/trial never turns into an unasked-for data upload."""
+    try:
+        from clawmetry import config as _cfg
+
+        if choice == "managed":
+            _cfg.enable_cloud()
+        else:
+            _cfg.NOCLOUD_MARKER_PATH.parent.mkdir(parents=True, exist_ok=True)
+            _cfg.NOCLOUD_MARKER_PATH.touch(exist_ok=True)
+    except Exception as exc:
+        log.warning("onboarding: marker update failed: %s", exc)
+
+
+@bp_onboarding.route("/api/onboarding/state")
+def api_onboarding_state():
+    try:
+        if os.environ.get("CLAWMETRY_CLOUD", "").strip():
+            # Hosted dashboard: signing up WAS the onboarding.
+            return jsonify({"required": False, "state": "managed",
+                            "source": "cloud_mode"})
+        return jsonify(_resolve_state())
+    except Exception as exc:
+        # Never let gate plumbing brick the dashboard: fail open.
+        log.warning("onboarding: state resolution failed: %s", exc)
+        return jsonify({"required": False, "state": "none",
+                        "source": "error"})
+
+
+@bp_onboarding.route("/api/onboarding/complete", methods=["POST"])
+def api_onboarding_complete():
+    data = request.get_json(silent=True) or {}
+    choice = str(data.get("choice", "")).strip().lower()
+    if choice not in _CHOICES:
+        return jsonify({"ok": False, "error": "Unknown choice."}), 400
+    # The choice must be backed by its finished flow — recording "managed"
+    # with no cloud token (or a self-host state with no key) would strand
+    # the install in a half-onboarded limbo the gate can no longer fix.
+    if choice == "managed" and not _cloud_connected():
+        return jsonify({"ok": False,
+                        "error": "Connect to ClawMetry Cloud first."}), 409
+    if choice in ("selfhost_license", "selfhost_trial") and not _license_state():
+        return jsonify({"ok": False,
+                        "error": "Activate a license or trial first."}), 409
+    _write_choice_file(choice)
+    _apply_marker_semantics(choice)
+    _ping_onboarded(choice)
+    return jsonify({"ok": True, "state": choice})
+
+
+@bp_onboarding.route("/api/onboarding/activate-license", methods=["POST"])
+def api_onboarding_activate_license():
+    data = request.get_json(silent=True) or {}
+    key = str(data.get("key", "")).strip()
+    if not key.startswith("CLAW1."):
+        return jsonify({"ok": False,
+                        "error": "That doesn't look like a ClawMetry key "
+                                 "(they start with CLAW1)."}), 400
+    try:
+        from clawmetry import license as _lic
+
+        ok, msg = _lic.activate(key, actor="onboarding-gate")
+    except Exception as exc:
+        log.warning("onboarding: activate failed: %s", exc)
+        ok, msg = False, "Activation failed. Try again."
+    if not ok:
+        return jsonify({"ok": False, "error": msg}), 400
+    state = _license_state() or "selfhost_license"
+    _write_choice_file(state)
+    _apply_marker_semantics(state)
+    _ping_onboarded(state)
+    return jsonify({"ok": True, "state": state, "message": msg})

--- a/tests/test_onboarding_gate.py
+++ b/tests/test_onboarding_gate.py
@@ -28,7 +28,15 @@ def ob(monkeypatch, tmp_path):
     monkeypatch.setattr(mod, "_cloud_connected", lambda: False)
     monkeypatch.setattr(mod, "_ping_onboarded", lambda choice: None)
     monkeypatch.setattr(mod, "_apply_marker_semantics", lambda choice: None)
-    monkeypatch.delenv("CLAWMETRY_CLOUD", raising=False)
+    # Strip every env that legitimately suppresses the gate — including
+    # the CI vars GitHub Actions itself sets, or the "fresh install
+    # requires onboarding" tests would pass locally and fail in CI.
+    for k in ("CLAWMETRY_CLOUD", "CLAWMETRY_SKIP_ONBOARDING", "CI",
+              "GITHUB_ACTIONS", "GITLAB_CI", "CIRCLECI", "TRAVIS",
+              "BUILDKITE", "JENKINS_URL", "TEAMCITY_VERSION",
+              "BITBUCKET_BUILD_NUMBER", "CODEBUILD_BUILD_ID", "DRONE",
+              "AGENT_NAME"):
+        monkeypatch.delenv(k, raising=False)
     return mod
 
 
@@ -60,6 +68,18 @@ def test_cloud_mode_never_gates(client, monkeypatch):
     monkeypatch.setenv("CLAWMETRY_CLOUD", "1")
     d = client.get("/api/onboarding/state").get_json()
     assert d["required"] is False and d["source"] == "cloud_mode"
+
+
+def test_env_skip_never_gates(client, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_SKIP_ONBOARDING", "1")
+    d = client.get("/api/onboarding/state").get_json()
+    assert d["required"] is False and d["source"] == "env_skip"
+
+
+def test_ci_never_gates(client, monkeypatch):
+    monkeypatch.setenv("GITHUB_ACTIONS", "true")
+    d = client.get("/api/onboarding/state").get_json()
+    assert d["required"] is False and d["source"] == "ci"
 
 
 def test_complete_managed_requires_cloud_connection(client):

--- a/tests/test_onboarding_gate.py
+++ b/tests/test_onboarding_gate.py
@@ -1,0 +1,162 @@
+"""First-run onboarding gate (routes/onboarding.py + the overlay partial).
+
+Route logic runs against a minimal Flask app with the license/cloud/
+telemetry helpers monkeypatched; the wiring checks assert the partial and
+script land in the LIVE (second) DASHBOARD_HTML, per the dead-UI rule.
+"""
+from __future__ import annotations
+
+import importlib
+import json
+import os
+import sys
+
+import pytest
+from flask import Flask
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+@pytest.fixture
+def ob(monkeypatch, tmp_path):
+    import routes.onboarding as mod
+    importlib.reload(mod)
+    monkeypatch.setattr(mod, "_STATE_PATH", str(tmp_path / "onboarding.json"))
+    monkeypatch.setattr(mod, "_license_state", lambda: "")
+    monkeypatch.setattr(mod, "_cloud_connected", lambda: False)
+    monkeypatch.setattr(mod, "_ping_onboarded", lambda choice: None)
+    monkeypatch.setattr(mod, "_apply_marker_semantics", lambda choice: None)
+    monkeypatch.delenv("CLAWMETRY_CLOUD", raising=False)
+    return mod
+
+
+@pytest.fixture
+def client(ob):
+    app = Flask(__name__)
+    app.register_blueprint(ob.bp_onboarding)
+    return app.test_client()
+
+
+def test_fresh_install_requires_onboarding(client):
+    d = client.get("/api/onboarding/state").get_json()
+    assert d["required"] is True and d["state"] == "none"
+
+
+def test_license_derives_completion(ob, client, monkeypatch):
+    monkeypatch.setattr(ob, "_license_state", lambda: "selfhost_trial")
+    d = client.get("/api/onboarding/state").get_json()
+    assert d == {"required": False, "state": "selfhost_trial", "source": "license"}
+
+
+def test_cloud_token_derives_managed(ob, client, monkeypatch):
+    monkeypatch.setattr(ob, "_cloud_connected", lambda: True)
+    d = client.get("/api/onboarding/state").get_json()
+    assert d == {"required": False, "state": "managed", "source": "cloud"}
+
+
+def test_cloud_mode_never_gates(client, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_CLOUD", "1")
+    d = client.get("/api/onboarding/state").get_json()
+    assert d["required"] is False and d["source"] == "cloud_mode"
+
+
+def test_complete_managed_requires_cloud_connection(client):
+    r = client.post("/api/onboarding/complete", json={"choice": "managed"})
+    assert r.status_code == 409
+
+
+def test_complete_selfhost_requires_license(client):
+    r = client.post("/api/onboarding/complete", json={"choice": "selfhost_trial"})
+    assert r.status_code == 409
+
+
+def test_complete_unknown_choice_rejected(client):
+    r = client.post("/api/onboarding/complete", json={"choice": "yolo"})
+    assert r.status_code == 400
+
+
+def test_complete_records_choice_and_markers(ob, client, monkeypatch):
+    monkeypatch.setattr(ob, "_cloud_connected", lambda: True)
+    markers = []
+    pings = []
+    monkeypatch.setattr(ob, "_apply_marker_semantics", markers.append)
+    monkeypatch.setattr(ob, "_ping_onboarded", pings.append)
+    r = client.post("/api/onboarding/complete", json={"choice": "managed"})
+    assert r.get_json() == {"ok": True, "state": "managed"}
+    assert markers == ["managed"] and pings == ["managed"]
+    with open(ob._STATE_PATH, encoding="utf-8") as fh:
+        assert json.load(fh)["choice"] == "managed"
+    # The gate must not re-appear after the choice is recorded.
+    d = client.get("/api/onboarding/state").get_json()
+    assert d == {"required": False, "state": "managed", "source": "gate"}
+
+
+def test_activate_license_rejects_non_claw_keys(client):
+    r = client.post("/api/onboarding/activate-license", json={"key": "hunter2"})
+    assert r.status_code == 400
+
+
+def test_activate_license_happy_path(ob, client, monkeypatch):
+    import types
+    fake_lic = types.SimpleNamespace(
+        activate=lambda key, actor="": (True, "activated"))
+    monkeypatch.setitem(sys.modules, "clawmetry.license", fake_lic)
+    monkeypatch.setattr(ob, "_license_state", lambda: "selfhost_license")
+    pings = []
+    monkeypatch.setattr(ob, "_ping_onboarded", pings.append)
+    r = client.post("/api/onboarding/activate-license",
+                    json={"key": "CLAW1.aaa.bbb"})
+    d = r.get_json()
+    assert d["ok"] is True and d["state"] == "selfhost_license"
+    assert pings == ["selfhost_license"]
+
+
+def test_state_endpoint_fails_open(ob, client, monkeypatch):
+    def boom():
+        raise RuntimeError("disk on fire")
+    monkeypatch.setattr(ob, "_resolve_state", boom)
+    d = client.get("/api/onboarding/state").get_json()
+    assert d["required"] is False, "gate plumbing failure must never brick the dashboard"
+
+
+# ── Wiring: the gate exists in the SERVED artifact, not just in routes ──────
+
+def _dash_src():
+    return open(os.path.join(_ROOT, "dashboard.py"), encoding="utf-8").read()
+
+
+def test_gate_partial_and_js_are_in_live_dashboard_html():
+    src = _dash_src()
+    live = src.rfind("DASHBOARD_HTML = ")
+    assert src.find("partials/onboarding-modal.html", live) > live, \
+        "gate partial missing from the LIVE (second) DASHBOARD_HTML"
+    assert src.find("js/onboarding.js", live) > live, \
+        "onboarding.js script tag missing from the LIVE DASHBOARD_HTML"
+    assert "app.register_blueprint(bp_onboarding)" in src
+
+
+def test_gate_partial_renders():
+    from jinja2 import Environment, FileSystemLoader
+    env = Environment(loader=FileSystemLoader(
+        os.path.join(_ROOT, "clawmetry", "templates")))
+    html = env.get_template("partials/onboarding-modal.html").render()
+    assert 'id="onboarding-gate-overlay"' in html
+    assert "Managed cloud" in html and "Self-host" in html
+    # Hard gate: the overlay ships no close/skip affordance (no close
+    # button glyph, no dismiss id, no overlay-click handler).
+    assert "&times;" not in html and "×" not in html
+    assert "obg-close" not in html and "skip" not in html.lower()
+    assert "onclick" not in html.split("<style>")[0] + html.split("</style>")[1]
+
+
+def test_gate_js_is_hard_gate_and_cloud_safe():
+    js = open(os.path.join(
+        _ROOT, "clawmetry", "static", "js", "onboarding.js"),
+        encoding="utf-8").read()
+    assert "window.CLOUD_MODE" in js, "hosted dashboard must never gate"
+    assert "/api/onboarding/state" in js
+    assert "/api/trial/activate" in js
+    assert "/api/onboarding/activate-license" in js
+    assert "openCloudModal" in js


### PR DESCRIPTION
Stacked on #4286 (needs its telemetry.ping_event). Part 2 of 3 of the install-registry work; cloud counterpart: clawmetry-cloud#1830.

## What
Hard first-run gate (founder decision 2026-07-31: no free escape, everyone chooses; applies to existing installs with no recorded choice):

- **Managed cloud** (recommended): reuses the existing cloud modal (OTP / Google / GitHub). Gate polls cloud-cta status, records the choice when connected, and calls enable_cloud() so a stale nocloud marker can't silently no-op sync.
- **Self-host**: free 7-day Pro trial via the existing /api/trial/activate email+OTP flow, or a CLAW1 license key. Both record the choice and write the nocloud marker (identity unlocks runtimes, data stays local).

Derived completion means anyone already cloud-connected or license-activated never sees the gate. The hosted cloud dashboard never gates (window.CLOUD_MODE). State endpoint fails open so gate plumbing can never brick the dashboard. Every completion fires the `onboarded` lifecycle ping so the Founder Console installs board shows onboarding state per install.

## Screenshot
Headless-rendered gate (detection line simulated):
- calm dark card matching dashboard tokens, single accent on the recommended CTA, detected-runtimes greeting, honest read-only footer.

## Tests
14 new in tests/test_onboarding_gate.py — state derivation (fresh/license/cloud/cloud-mode), 409 guards for unbacked choices, choice persistence + marker semantics + onboarded ping, fail-open behavior, live-DASHBOARD_HTML wiring proof, Jinja render proof, hard-gate (no close affordance) proof, JS cloud-safety contract. All pass; telemetry suite still 24/24.

## Cloud follow-ups (noted in #1830)
- /api/onboarding/* needs a cloud_route_policy classification entry when the cloud repins OSS past this route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)