### PR TITLE
fix: launchd dashboard plist uses python -m clawmetry, not console-script path

### DIFF
--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -1282,7 +1282,12 @@ def _ensure_local_dashboard(port: int = 8900, wait_secs: float = 12.0) -> bool:
 
             label = "com.clawmetry.dashboard"
             plist_path = _P.home() / "Library" / "LaunchAgents" / f"{label}.plist"
-            _args_xml = "\n".join(f"        <string>{a}</string>" for a in cmd)
+            # Use `python -m clawmetry` (not the console-script path) so the
+            # plist stays valid if the venv is rebuilt without entry points.
+            # The console-script path rots silently; the interpreter path is
+            # stable across venv rebuilds (#4297).
+            _launchd_cmd = [sys.executable, "-m", "clawmetry", "--port", str(port)]
+            _args_xml = "\n".join(f"        <string>{a}</string>" for a in _launchd_cmd)
             plist = f"""<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">

--- a/tests/test_onboard_local_default.py
+++ b/tests/test_onboard_local_default.py
@@ -372,3 +372,32 @@ def test_ensure_local_dashboard_spawns_then_polls(monkeypatch):
     assert cli._ensure_local_dashboard(wait_secs=2) is True
     assert len(spawned) == 1
     assert "--port" in spawned[0] and "8900" in spawned[0]
+
+
+def test_ensure_local_dashboard_launchd_plist_uses_python_m():
+    """The macOS launchd plist must use `python -m clawmetry`, not the
+    console-script path, so it survives venv rebuilds that drop entry points
+    (issue #4297: ~/.clawmetry/bin/clawmetry missing → launchd exits 78 loop).
+
+    The _register_launchd (sync daemon) already uses this pattern; the
+    dashboard launchd path must match. Verified by source inspection so the
+    test stays fast and platform-independent.
+    """
+    import inspect
+    src = inspect.getsource(cli._ensure_local_dashboard)
+
+    # The Darwin/launchd block must build its arg list from a variable named
+    # _launchd_cmd that contains "-m" (python -m clawmetry), not from `cmd`
+    # which may hold the console-script path.
+    assert "_launchd_cmd" in src, (
+        "_ensure_local_dashboard must use _launchd_cmd for the launchd plist "
+        "(not `cmd`, which may reference a stale console-script path)"
+    )
+    assert '"-m"' in src or "'-m'" in src, (
+        "_launchd_cmd must include '-m' to invoke via python -m clawmetry"
+    )
+    # _args_xml (the plist ProgramArguments) must reference _launchd_cmd, not cmd
+    launchd_block = src[src.find("_launchd_cmd"):]
+    assert "_args_xml" in launchd_block and "_launchd_cmd" in launchd_block, (
+        "_args_xml must be built from _launchd_cmd so the plist uses python -m"
+    )


### PR DESCRIPTION
Closes #4297

## What

The `com.clawmetry.dashboard` launchd job was baking the console-script path (`~/.clawmetry/bin/clawmetry`) into the plist at registration time. When the venv is rebuilt without entry points the path no longer exists — launchd exits 78 in a loop and `localhost:8900` is dead.

## Changes

- **`clawmetry/cli.py`** — `_ensure_local_dashboard`: build a separate `_launchd_cmd` using `[sys.executable, "-m", "clawmetry", "--port", port]` for the plist's `ProgramArguments`, instead of re-using `cmd` which may hold the console-script path. This matches the pattern `_register_launchd` already uses for the sync daemon (`python -m clawmetry.sync`). The subprocess-fallback path (non-launchd) is unchanged.

- **`tests/test_onboard_local_default.py`** — new test asserting `_ensure_local_dashboard`'s source uses `_launchd_cmd` with `-m` for the plist, so this regression can't silently re-appear.

## Test plan

- `python -m pytest tests/test_onboard_local_default.py -q` → 21 passed
- `python -m py_compile clawmetry/cli.py` → OK

---
_Generated by [Claude Code](https://claude.ai/code/session_01EHc3p7DrxW2xC1ExSXdaHJ)_