### PR TITLE
fix: recognise llama.cpp and lmstudio in sandbox inference routing

### DIFF
--- a/clawmetry/adapters/openclaw.py
+++ b/clawmetry/adapters/openclaw.py
@@ -374,6 +374,24 @@ def _resolve_minimax_base_url() -> str:
     return val or "https://api.minimax.chat/v1"
 
 
+def _resolve_llamacpp_base_url() -> str:
+    """Return the active llama.cpp server base URL from env var or the default.
+
+    LLAMA_CPP_HOST overrides; falls back to the llama.cpp server default port.
+    """
+    val = os.environ.get("LLAMA_CPP_HOST", "").strip()
+    return val or "http://localhost:8080/v1"
+
+
+def _resolve_lmstudio_base_url() -> str:
+    """Return the active LM Studio server base URL from env var or the default.
+
+    LMSTUDIO_HOST overrides; falls back to LM Studio's default port.
+    """
+    val = os.environ.get("LMSTUDIO_HOST", "").strip()
+    return val or "http://localhost:1234/v1"
+
+
 def _list_ollama_models(host: str) -> list:
     """Return available Ollama model names. Never raises; returns [] on failure.
 
@@ -914,6 +932,16 @@ def _sandbox_inference_configs() -> list:
                 provider_key = "minimax"
                 primary = f"minimax/{model}" if model else ""
                 base_url = _resolve_minimax_base_url()
+                compat = "openai"
+            elif provider == "llama.cpp":
+                provider_key = "llama-cpp"
+                primary = f"llama-cpp/{model}" if model else ""
+                base_url = _resolve_llamacpp_base_url()
+                compat = "openai"
+            elif provider in ("lmstudio", "lm-studio"):
+                provider_key = "lmstudio"
+                primary = f"lmstudio/{model}" if model else ""
+                base_url = _resolve_lmstudio_base_url()
                 compat = "openai"
             else:
                 provider_key = _MANAGED


### PR DESCRIPTION
Closes #4300

## Summary

- Adds `_resolve_llamacpp_base_url()` and `_resolve_lmstudio_base_url()` helper functions (mirroring the existing `_resolve_minimax_base_url()` pattern) — each reads an env-var override (`LLAMA_CPP_HOST` / `LMSTUDIO_HOST`) and falls back to the standard local ports (`8080/v1` and `1234/v1`).
- Adds `elif` branches for `provider == "llama.cpp"` and `provider in ("lmstudio", "lm-studio")` in `_sandbox_inference_configs()`, setting `providerKey` (`"llama-cpp"` / `"lmstudio"`), correct `primaryModelRef`, and the real `inferenceBaseUrl` — instead of falling through to `providerKey="inference"` and `inferenceBaseUrl="https://inference.local/v1"`.
- One file changed (`clawmetry/adapters/openclaw.py`, +28 lines).

## Test plan

- `python3 -c "from clawmetry.adapters.openclaw import _resolve_llamacpp_base_url, _resolve_lmstudio_base_url; assert _resolve_llamacpp_base_url() == 'http://localhost:8080/v1'; assert _resolve_lmstudio_base_url() == 'http://localhost:1234/v1'; print('ok')"` — passes.
- Verified `LLAMA_CPP_HOST` / `LMSTUDIO_HOST` env overrides are respected.
- No lint errors introduced in the changed file (`make lint` pre-existing failures are all in other files).

---
_Generated by [Claude Code](https://claude.ai/code/session_01YHc8RXRiakbMKKBuPDjPNS)_