### PR TITLE
feat(license): license_subject_at + /api/license/subject-at

### DIFF
--- a/clawmetry/license.py
+++ b/clawmetry/license.py
@@ -2178,6 +2178,102 @@ def is_subject(subject: str) -> bool:
     return actual.lower() == requested
 
 
+def license_subject_at(epoch: int) -> str | None:
+    """Perspective-epoch flavour of :func:`license_subject` -- "what
+    subject would :func:`license_subject` have returned evaluated as of
+    ``epoch``?" -- for a scheduled-audit / retrospective badge that wants
+    to answer "who was this node licensed to on <date>?" without the
+    caller having to snapshot the license state at that time or compare
+    ``exp`` to a caller-supplied epoch themselves.
+
+    Returns:
+      * ``None`` when there is nothing trustworthy to surface AS OF
+        ``epoch``: no license file on disk, an invalid signature (an
+        attacker could stuff any ``sub`` into an unsigned body -- refused
+        for every perspective, matching :func:`license_subject`), a
+        signed key whose ``exp`` claim has already passed at ``epoch``
+        (retrospective on a lapsed key when ``epoch`` equals "now";
+        prospective on an active key when ``epoch`` is in the future
+        beyond ``exp``), OR a signed payload whose ``sub`` claim is
+        absent / non-string / empty after strip.
+      * The stripped subject string otherwise. Casing is preserved --
+        subjects are typically email addresses / account ids where case
+        can matter for exact-match comparisons, matching the
+        current-time :func:`license_subject` accessor. :func:`is_subject`
+        handles case-insensitive matching on top for callers that want
+        it.
+
+    ``epoch`` is coerced through ``int()``; ``bool`` is explicitly
+    refused despite being an ``int`` subclass so a caller that passes
+    ``True`` / ``False`` gets ``None`` back rather than a spurious "was
+    the subject X at epoch 1?" classification. A non-numeric value
+    collapses to ``None`` so a caller cannot silently mis-gate on a
+    typo -- the conservative fallback since ``None`` implies no
+    trustworthy subject, matching the never-mis-gate posture of the
+    surrounding ``_at`` family.
+
+    When ``epoch`` equals "now", this scalar must agree with
+    :func:`license_subject` for the same install -- both derive from
+    the same signed ``sub`` claim, refuse the invalid-signature branch,
+    and use the same ``exp <= cutoff`` boundary via the shared
+    :func:`current_license_info` / :func:`license_state_at` reader, so
+    the two scalars cannot disagree at the boundary. On any other
+    epoch this helper answers the retrospective / prospective question
+    :func:`license_subject` cannot -- e.g. "who was this node licensed
+    to last Friday?" (``None`` on a key that has since been renewed but
+    was already expired then) or "will this node still be bound to
+    <X> at our next quarterly audit?" (``None`` on an active key whose
+    ``exp`` falls before the audit date).
+
+    Never raises. Any underlying introspection failure (import error,
+    corrupt install, cryptography-lib mismatch) collapses to ``None``
+    -- same fallback as :func:`license_subject` -- so a scheduled audit
+    tile bound to this helper never breaks on a partial install.
+
+    Pairs with the sibling ``_at`` scalars
+    (:func:`license_tier_at`, :func:`license_state_at`,
+    :func:`is_expired_at`, :func:`days_until_expiry_at`,
+    :func:`is_expiring_within_at`) at the row level: for the same
+    ``epoch``, a caller can zip the responses index-for-index and get
+    the whole entitlement row for one install without the scalars
+    catching each other disagreeing on the perspective-epoch
+    classification.
+    """
+    if isinstance(epoch, bool):
+        return None
+    try:
+        wanted = int(epoch)
+    except (TypeError, ValueError):
+        return None
+    try:
+        info = current_license_info()
+    except Exception as exc:
+        logger.debug("license: license_subject_at underlying read failed: %s", exc)
+        return None
+    if not isinstance(info, dict):
+        return None
+    status = info.get("status")
+    if status == "invalid":
+        # Signature-bogus branch: an unsigned body is untrusted whatever
+        # the perspective, so the classification is time-independent.
+        # Mirrors :func:`license_subject` -- payload-derived claims never
+        # get to influence the answer here.
+        return None
+    exp = info.get("exp")
+    if isinstance(exp, (int, float)) and int(exp) <= wanted:
+        # Signed key that has already lapsed AS OF ``epoch`` -- refuse
+        # for the same reason :func:`license_subject` refuses the
+        # expired branch at "now": a lapsed customer's subject must
+        # stop rendering as the account holder once the perspective
+        # epoch is past ``exp``.
+        return None
+    sub = info.get("sub")
+    if not isinstance(sub, str):
+        return None
+    stripped = sub.strip()
+    return stripped or None
+
+
 def license_permissions_safe() -> bool | None:
     """Scalar view onto the installed license file's on-disk permission
     hygiene -- for a security-posture tile that wants ONE tri-state

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -9355,6 +9355,170 @@ def api_license_is_subject():
     )
 
 
+def _license_subject_at_snapshot() -> dict:
+    """Shared one-shot read for the ``/api/license/subject-at`` endpoint
+    below.
+
+    Reads :func:`clawmetry.license.license_subject` (current-time
+    subject), :func:`clawmetry.license.current_license_info` (for
+    ``has_license`` / ``valid`` NOW), and
+    :func:`clawmetry.license.license_expires_at` (for the
+    ``expires_at`` field the sibling perspective-epoch tiles all carry)
+    ONCE so a UI binding both the current-time endpoint and this
+    perspective-epoch endpoint in the same tile can't catch them
+    disagreeing on ``subject`` / ``expires_at`` / ``has_license`` /
+    ``valid`` for the same install -- mirrors the
+    ``_license_subject_snapshot`` + ``_license_tier_at_snapshot``
+    pattern used by the current-time subject pair and the
+    perspective-epoch tier scalar.
+
+    ``subject`` here is the CURRENT-time subject (matches
+    :func:`clawmetry.license.license_subject`); the perspective-epoch
+    subject (``subject_at``) is derived per-request by the endpoint via
+    :func:`clawmetry.license.license_subject_at` and lives on top of
+    this snapshot -- keeping ``subject`` in the shared read guarantees
+    a UI that renders "as of <date> vs now" tiles side-by-side can
+    never catch them disagreeing on the current-time reference.
+
+    Never raises. Any introspection failure collapses to the OSS-free
+    branch shape (``subject=None``, ``expires_at=None``,
+    ``has_license=False``, ``valid=False``) so the endpoint never 5xxs
+    -- same posture as the surrounding license endpoints.
+    """
+    try:
+        from clawmetry import license as _lic
+
+        subject = _lic.license_subject()
+        info = _lic.current_license_info()
+        expires = _lic.license_expires_at()
+    except Exception as exc:
+        logger.debug("_license_subject_at_snapshot: underlying read failed: %s", exc)
+        return {
+            "subject": None,
+            "expires_at": None,
+            "has_license": False,
+            "valid": False,
+        }
+    if not isinstance(subject, str):
+        subject = None
+    if info is None or not isinstance(info, dict):
+        return {
+            "subject": subject,
+            "expires_at": None,
+            "has_license": False,
+            "valid": False,
+        }
+    return {
+        "subject": subject,
+        "expires_at": expires,
+        "has_license": True,
+        "valid": bool(info.get("valid")),
+    }
+
+
+@bp_entitlement.route("/api/license/subject-at")
+def api_license_subject_at():
+    """``GET /api/license/subject-at?epoch=<int>`` -- scalar view of the
+    installed license's ``sub`` claim evaluated as of ``epoch`` -- the
+    perspective-epoch flavour of ``/api/license/subject``, for a
+    scheduled-audit / retrospective badge that wants to answer "who was
+    this node licensed to on <date>?" without the caller having to
+    snapshot the license state at that time or compare ``exp`` to a
+    caller-supplied epoch themselves.
+
+    Response shape (always HTTP 200)::
+
+        {
+          "subject_at": <str|null>,       # subject as of epoch
+          "requested_epoch": <int|null>,  # int-coerced input, or null on typo
+          "subject": <str|null>,          # current-time subject
+          "expires_at": <int|null>,       # on-disk exp for comparison
+          "has_license": <bool>,          # is a license file installed at all?
+          "valid": <bool>                 # signature-valid AND not expired NOW
+        }
+
+    ``subject_at`` mirrors :func:`clawmetry.license.license_subject_at`:
+    ``None`` for no license, invalid signature, an ``exp`` claim that
+    has already lapsed at ``epoch``, or a signed payload whose ``sub``
+    claim is absent / non-string / empty; otherwise the
+    whitespace-stripped subject string (casing preserved).
+
+    Query parameter:
+
+      * ``epoch`` -- required. Unix epoch seconds as an integer. A
+        missing / non-integer / bool value collapses to
+        ``subject_at=null`` with ``requested_epoch=null`` so a caller
+        cannot silently mis-gate on a typo. HTTP status is 200 either
+        way -- the "bad input" signal is ``requested_epoch=null`` plus
+        the ``null`` subject, not a 4xx, matching the never-crash
+        posture of the surrounding license endpoints.
+
+    Pairs with ``/api/license/tier-at`` / ``/api/license/state-at`` /
+    ``/api/license/is-expired-at`` / ``/api/license/days-until-expiry-
+    at`` / ``/api/license/expiring-within-at`` -- all share the
+    perspective-epoch input pattern, and the
+    ``_license_subject_at_snapshot`` reader here carries ``expires_at``
+    / ``has_license`` / ``valid`` on the same shape the tier / state
+    perspective-epoch scalars carry, so a UI binding two for the same
+    install cannot catch them disagreeing on the current-time
+    reference fields.
+
+    When ``epoch`` equals "now", the ``subject_at`` field must byte-
+    equal ``subject`` (both derive from the same signed ``sub`` claim,
+    refuse the invalid-signature branch, and use the same
+    ``exp <= cutoff`` boundary via :func:`license_subject_at` /
+    :func:`license_subject`), so a UI binding both cannot catch them
+    disagreeing at the boundary.
+
+    Never 5xxs -- any underlying failure degrades to
+    ``{subject_at: null, requested_epoch: <echo>, subject: null,
+    expires_at: null, has_license: false, valid: false}`` (the OSS-
+    free branch shape).
+    """
+    raw = request.args.get("epoch", "")
+    try:
+        requested = int(str(raw).strip())
+    except (TypeError, ValueError):
+        requested = None
+    if isinstance(requested, bool):
+        # Guard against ``bool`` subclassing ``int`` -- ``int("1")`` isn't
+        # bool, but a query like ``?epoch=True`` gets coerced through the
+        # same path the scalar predicate refuses on purpose. Belt-and-
+        # braces symmetry with :func:`clawmetry.license.license_subject_at`.
+        requested = None
+    try:
+        snap = _license_subject_at_snapshot()
+    except Exception as exc:
+        logger.warning("api_license_subject_at: snapshot error: %s", exc)
+        snap = {
+            "subject": None,
+            "expires_at": None,
+            "has_license": False,
+            "valid": False,
+        }
+    subject_at: str | None = None
+    if requested is not None:
+        try:
+            from clawmetry import license as _lic
+
+            subject_at = _lic.license_subject_at(requested)
+        except Exception as exc:
+            logger.warning("api_license_subject_at: derive error: %s", exc)
+            subject_at = None
+    if subject_at is not None and not isinstance(subject_at, str):
+        subject_at = None
+    return jsonify(
+        {
+            "subject_at": subject_at,
+            "requested_epoch": requested,
+            "subject": snap["subject"],
+            "expires_at": snap["expires_at"],
+            "has_license": snap["has_license"],
+            "valid": snap["valid"],
+        }
+    )
+
+
 def _license_permissions_snapshot() -> dict:
     """Shared helper: read once, derive the trio the two permission-hygiene
     endpoints both need (``permissions_safe``, ``file_mode``,

--- a/tests/test_license_subject_at.py
+++ b/tests/test_license_subject_at.py
@@ -1,0 +1,495 @@
+"""Tests for the ``license_subject_at(epoch)`` scalar on
+``clawmetry.license`` and its paired ``/api/license/subject-at`` HTTP
+endpoint.
+
+The perspective-epoch flavour of the ``license_subject`` scalar. Both
+derive from the same signed ``sub`` claim and refuse the invalid-
+signature branch, so they cannot disagree at the boundary when the
+perspective epoch equals "now"; on any other epoch these helpers answer
+"who would :func:`license_subject` have reported evaluated as of
+``epoch``?" without the caller having to snapshot the license state at
+that time or compare ``exp`` to a caller-supplied epoch themselves.
+
+Hermetic: each test mints tokens with its own ephemeral keypair and
+monkeypatches the module's embedded public key + ``LICENSE_PATH``,
+mirroring ``tests/test_license_tier_at.py`` /
+``tests/test_license_subject_scalar.py`` so nothing depends on the real
+production signing key or on real filesystem state.
+"""
+from __future__ import annotations
+
+import time
+from types import SimpleNamespace
+
+import pytest
+from flask import Flask
+
+
+# -- shared helpers (mirror tests/test_license_tier_at.py) --------------------
+
+
+def _keypair():
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+    priv = Ed25519PrivateKey.generate()
+    pub_pem = priv.public_key().public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    return priv, pub_pem
+
+
+def _payload(
+    sub="acct_test",
+    tier="pro",
+    nodes=3,
+    exp_delta=365 * 86400,
+    drop_exp=False,
+    drop_sub=False,
+):
+    now = int(time.time())
+    p = {
+        "sub": sub,
+        "tier": tier,
+        "nodes": nodes,
+        "iat": now,
+        "exp": now + exp_delta,
+        "features": ["runtimes"],
+    }
+    if drop_exp:
+        p.pop("exp", None)
+    if drop_sub:
+        p.pop("sub", None)
+    return p
+
+
+@pytest.fixture
+def app(monkeypatch, tmp_path):
+    import clawmetry.license as _lic
+
+    priv, pub_pem = _keypair()
+    monkeypatch.setattr(_lic, "_PUBLIC_KEY_PEM", pub_pem)
+    license_path = str(tmp_path / "license.key")
+    monkeypatch.setattr(_lic, "LICENSE_PATH", license_path)
+    monkeypatch.delenv("CLAWMETRY_LICENSE_SERVER", raising=False)
+    monkeypatch.delenv("CLAWMETRY_INGEST_URL", raising=False)
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("CLAWMETRY_OFFLINE", "1")
+
+    from routes.entitlement import bp_entitlement
+
+    flask_app = Flask(__name__)
+    flask_app.register_blueprint(bp_entitlement)
+    flask_app.config["TESTING"] = True
+
+    return SimpleNamespace(
+        app=flask_app,
+        lic=_lic,
+        priv=priv,
+        license_path=license_path,
+    )
+
+
+def _write_key_direct(app, exp_delta, sub="acct_test", drop_sub=False):
+    """Bypass activate() (which refuses expired tokens) and write a token
+    directly to the license file. Simulates a license that expired AFTER
+    it was installed."""
+    import os
+
+    tok = app.lic._encode_token(
+        _payload(sub=sub, exp_delta=exp_delta, drop_sub=drop_sub), app.priv
+    )
+    os.makedirs(os.path.dirname(app.license_path), exist_ok=True)
+    with open(app.license_path, "w", encoding="utf-8") as fh:
+        fh.write(tok)
+
+
+def _write_perpetual(app, sub="acct_test"):
+    import os
+
+    tok = app.lic._encode_token(_payload(sub=sub, drop_exp=True), app.priv)
+    os.makedirs(os.path.dirname(app.license_path), exist_ok=True)
+    with open(app.license_path, "w", encoding="utf-8") as fh:
+        fh.write(tok)
+
+
+def _write_bogus(app):
+    import os
+
+    os.makedirs(os.path.dirname(app.license_path), exist_ok=True)
+    with open(app.license_path, "w", encoding="utf-8") as fh:
+        fh.write("CLAW1.garbage.garbage")
+
+
+# -- clawmetry.license.license_subject_at() -----------------------------------
+
+
+def test_license_subject_at_no_license(app):
+    """No license file on disk -> ``None`` regardless of epoch."""
+    assert app.lic.license_subject_at(int(time.time())) is None
+    assert app.lic.license_subject_at(0) is None
+    assert app.lic.license_subject_at(2_000_000_000) is None
+
+
+def test_license_subject_at_now_matches_license_subject_active(app):
+    """When ``epoch`` equals "now", perspective scalar must agree with
+    :func:`license_subject` on an active install. Both derive from the
+    same signed ``sub`` claim, so a UI binding both cannot catch them
+    disagreeing at the boundary."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    now = int(time.time())
+    assert app.lic.license_subject_at(now) == "acct_test"
+    assert app.lic.license_subject() == "acct_test"
+
+
+def test_license_subject_at_now_matches_license_subject_lapsed(app):
+    """Lapsed-key parity: at "now", perspective scalar and base scalar
+    must both return ``None`` -- both refuse the expired branch."""
+    _write_key_direct(app, exp_delta=-5 * 86400)
+    now = int(time.time())
+    assert app.lic.license_subject_at(now) is None
+    assert app.lic.license_subject() is None
+
+
+def test_license_subject_at_future_epoch_before_expiry(app):
+    """Future perspective still before ``exp`` -> subject surfaces (key
+    would NOT yet be expired at that perspective)."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    epoch = int(time.time()) + 10 * 86400
+    assert app.lic.license_subject_at(epoch) == "acct_test"
+
+
+def test_license_subject_at_future_epoch_after_expiry(app):
+    """Future perspective AFTER ``exp`` on an active key -> ``None``
+    (the key WILL be expired at that perspective). This is the "will
+    this node still be bound to <X> at our next audit?" prospective
+    scenario."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    epoch = int(time.time()) + 60 * 86400
+    assert app.lic.license_subject_at(epoch) is None
+
+
+def test_license_subject_at_past_epoch_still_active(app):
+    """Perspective BEFORE now on an active key -> subject surfaces (the
+    key was not yet expired then, since ``exp`` is even further in the
+    future)."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    epoch = int(time.time()) - 10 * 86400
+    assert app.lic.license_subject_at(epoch) == "acct_test"
+
+
+def test_license_subject_at_lapsed_key_pre_lapse_epoch_surfaces_subject(app):
+    """Lapsed-but-signed key at a perspective BEFORE its ``exp`` ->
+    subject surfaces (retrospective "who was this licensed to on
+    <date>?"). At "now" (past ``exp``) -> ``None``."""
+    _write_key_direct(app, exp_delta=-5 * 86400)  # exp = now - 5d
+    now = int(time.time())
+    assert app.lic.license_subject_at(now - 20 * 86400) == "acct_test"
+    assert app.lic.license_subject_at(now - 3 * 86400) is None
+    assert app.lic.license_subject_at(now) is None
+
+
+def test_license_subject_at_exact_exp_boundary(app):
+    """At the exact ``exp`` second, the subject must collapse to
+    ``None`` -- the ``<= epoch`` cutoff matches :func:`license_tier_at`
+    and :func:`license_state_at`'s ``exp <= epoch`` boundary."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    from clawmetry import license as _lic
+
+    info = _lic.current_license_info()
+    exp_epoch = int(info["exp"])
+    assert app.lic.license_subject_at(exp_epoch - 1) == "acct_test"
+    assert app.lic.license_subject_at(exp_epoch) is None
+    assert app.lic.license_subject_at(exp_epoch + 1) is None
+
+
+def test_license_subject_at_perpetual_key(app):
+    """Perpetual (no ``exp``) key -> subject surfaces at every epoch."""
+    _write_perpetual(app)
+    assert app.lic.license_subject_at(0) == "acct_test"
+    assert app.lic.license_subject_at(int(time.time())) == "acct_test"
+    assert app.lic.license_subject_at(2_000_000_000) == "acct_test"
+
+
+def test_license_subject_at_invalid_signature(app):
+    """Bogus-signature file -> ``None`` regardless of epoch (time-
+    independent, matching :func:`license_subject`)."""
+    _write_bogus(app)
+    assert app.lic.license_subject_at(0) is None
+    assert app.lic.license_subject_at(int(time.time())) is None
+    assert app.lic.license_subject_at(2_000_000_000) is None
+
+
+def test_license_subject_at_preserves_casing(app):
+    """Subject casing is PRESERVED -- unlike :func:`license_tier_at`
+    which lowercases. Subjects are typically email addresses / account
+    ids where case can matter for exact-match comparisons, so the
+    perspective-epoch accessor must render the customer-facing form
+    verbatim, matching :func:`license_subject`. Whitespace IS
+    stripped."""
+    tok = app.lic._encode_token(_payload(sub="  Acct_Test  "), app.priv)
+    app.lic.activate(tok)
+    assert app.lic.license_subject_at(int(time.time())) == "Acct_Test"
+
+
+def test_license_subject_at_missing_sub_claim_matches_scalar(app):
+    """Signed payload with no ``sub`` claim: the perspective-epoch
+    scalar MUST match :func:`license_subject` on the same install (both
+    derive from :func:`current_license_info`). This test pins parity
+    with the base scalar -- guards against the two scalars silently
+    diverging on the same defect."""
+    _write_key_direct(app, exp_delta=30 * 86400, drop_sub=True)
+    now = int(time.time())
+    assert app.lic.license_subject_at(now) == app.lic.license_subject()
+
+
+def test_license_subject_at_empty_sub_claim(app):
+    """Signed payload with an empty / whitespace-only ``sub`` -> ``None``
+    (matches :func:`license_subject`: an empty string is nothing to
+    surface)."""
+    tok = app.lic._encode_token(_payload(sub="   "), app.priv)
+    app.lic.activate(tok)
+    now = int(time.time())
+    assert app.lic.license_subject_at(now) is None
+    assert app.lic.license_subject() is None
+
+
+def test_license_subject_at_bool_epoch_refused(app):
+    """``bool`` is an ``int`` subclass but must be refused so a caller
+    passing ``True`` / ``False`` gets ``None`` back, not a spurious
+    "was subject X at epoch 1?" answer."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    assert app.lic.license_subject_at(True) is None
+    assert app.lic.license_subject_at(False) is None
+
+
+def test_license_subject_at_non_numeric_epoch(app):
+    """Non-numeric epoch -> ``None`` so a caller cannot silently mis-
+    gate on a typo -- conservative fallback since ``None`` implies no
+    trustworthy subject."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    assert app.lic.license_subject_at("not-a-number") is None
+    assert app.lic.license_subject_at(None) is None
+    assert app.lic.license_subject_at([]) is None
+
+
+def test_license_subject_at_string_epoch_coerced(app):
+    """String epoch that ``int()`` accepts -> coerced and honoured,
+    matching the behaviour of :func:`license_tier_at`."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    now = int(time.time())
+    assert app.lic.license_subject_at(str(now)) == "acct_test"
+
+
+def test_license_subject_at_never_raises(app, monkeypatch):
+    """Any underlying introspection failure collapses to ``None`` --
+    a scheduled audit tile bound to this helper never crashes on a
+    partial install."""
+    def _boom():
+        raise RuntimeError("simulated introspection failure")
+
+    monkeypatch.setattr(app.lic, "current_license_info", _boom)
+    # Must not raise on any input.
+    assert app.lic.license_subject_at(int(time.time())) is None
+    assert app.lic.license_subject_at(0) is None
+
+
+# -- GET /api/license/subject-at ----------------------------------------------
+
+
+def test_api_subject_at_no_license(app):
+    """No license file on disk -> ``subject_at=null``, current-time
+    reference fields all reflect the OSS-free branch."""
+    now = int(time.time())
+    with app.app.test_client() as client:
+        rv = client.get(f"/api/license/subject-at?epoch={now}")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["subject_at"] is None
+    assert body["requested_epoch"] == now
+    assert body["subject"] is None
+    assert body["expires_at"] is None
+    assert body["has_license"] is False
+    assert body["valid"] is False
+
+
+def test_api_subject_at_active_key_now(app):
+    """Active key at "now" -> ``subject_at=subject``, snapshot fields
+    intact."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    now = int(time.time())
+    with app.app.test_client() as client:
+        rv = client.get(f"/api/license/subject-at?epoch={now}")
+    body = rv.get_json()
+    assert body["subject_at"] == "acct_test"
+    assert body["subject"] == "acct_test"
+    assert body["expires_at"] is not None
+    assert body["has_license"] is True
+    assert body["valid"] is True
+
+
+def test_api_subject_at_missing_epoch_collapses(app):
+    """Missing / non-integer / bool ``epoch`` -> ``subject_at=null`` and
+    ``requested_epoch=null`` so a caller cannot silently mis-gate on a
+    typo. HTTP status stays 200."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    with app.app.test_client() as client:
+        for qs in ("", "?epoch=", "?epoch=nope", "?epoch=true"):
+            rv = client.get(f"/api/license/subject-at{qs}")
+            assert rv.status_code == 200, qs
+            body = rv.get_json()
+            assert body["subject_at"] is None, qs
+            assert body["requested_epoch"] is None, qs
+
+
+def test_api_subject_at_future_after_expiry(app):
+    """Future perspective past ``exp`` on an active key ->
+    ``subject_at=null`` even though ``subject`` (current-time) still
+    surfaces the account."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    epoch = int(time.time()) + 60 * 86400
+    with app.app.test_client() as client:
+        rv = client.get(f"/api/license/subject-at?epoch={epoch}")
+    body = rv.get_json()
+    assert body["subject_at"] is None
+    assert body["subject"] == "acct_test"
+
+
+def test_api_subject_at_invalid_signature(app):
+    """Bogus-signature file -> ``subject_at=null``. ``has_license=True``
+    (a file exists) but ``valid=False``. Time-independent."""
+    _write_bogus(app)
+    with app.app.test_client() as client:
+        rv = client.get(f"/api/license/subject-at?epoch={int(time.time())}")
+    body = rv.get_json()
+    assert body["subject_at"] is None
+    assert body["subject"] is None
+    assert body["has_license"] is True
+    assert body["valid"] is False
+
+
+def test_api_subject_at_scalar_parity_with_python(app):
+    """The endpoint must return exactly what
+    :func:`license_subject_at` would return for the same epoch."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    now = int(time.time())
+    with app.app.test_client() as client:
+        for epoch in [now - 10 * 86400, now, now + 5 * 86400, now + 40 * 86400]:
+            rv = client.get(f"/api/license/subject-at?epoch={epoch}")
+            body = rv.get_json()
+            assert body["subject_at"] == app.lic.license_subject_at(epoch), epoch
+
+
+def test_api_subject_at_lapsed_key_pre_lapse_epoch(app):
+    """Endpoint mirrors the scalar retrospective behaviour: on a lapsed
+    key at a perspective BEFORE its ``exp`` -> ``subject_at`` surfaces;
+    at "now" (past ``exp``) -> ``null``. The current-time reference
+    ``subject`` field stays ``null`` on the lapsed install throughout."""
+    _write_key_direct(app, exp_delta=-5 * 86400)  # exp = now - 5d
+    now = int(time.time())
+    with app.app.test_client() as client:
+        rv_pre = client.get(
+            f"/api/license/subject-at?epoch={now - 20 * 86400}"
+        ).get_json()
+        rv_now = client.get(f"/api/license/subject-at?epoch={now}").get_json()
+    assert rv_pre["subject_at"] == "acct_test"
+    assert rv_pre["subject"] is None  # current-time still lapsed
+    assert rv_now["subject_at"] is None
+
+
+def test_api_subject_at_perpetual_key(app):
+    """Perpetual (no ``exp``) key -> subject surfaces at every epoch."""
+    _write_perpetual(app)
+    now = int(time.time())
+    with app.app.test_client() as client:
+        for epoch in (0, now, 2_000_000_000):
+            rv = client.get(f"/api/license/subject-at?epoch={epoch}")
+            body = rv.get_json()
+            assert body["subject_at"] == "acct_test", epoch
+            assert body["subject"] == "acct_test", epoch
+
+
+def test_api_subject_at_preserves_casing(app):
+    """Subject casing is preserved -- endpoint must render the customer-
+    facing form verbatim, matching :func:`license_subject_at`."""
+    tok = app.lic._encode_token(_payload(sub="  Acct_Test  "), app.priv)
+    app.lic.activate(tok)
+    now = int(time.time())
+    with app.app.test_client() as client:
+        rv = client.get(f"/api/license/subject-at?epoch={now}")
+    body = rv.get_json()
+    assert body["subject_at"] == "Acct_Test"
+    assert body["subject"] == "Acct_Test"
+
+
+# -- cross-endpoint agreement -------------------------------------------------
+
+
+def test_api_subject_at_agrees_with_license_subject_endpoint_at_now(app):
+    """At ``epoch=now``, the ``subject_at`` field must byte-equal the
+    ``subject`` returned by ``/api/license/subject`` (the current-time
+    endpoint). Both derive from the same signed claim -- a UI binding
+    both cannot catch them disagreeing at the boundary."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    now = int(time.time())
+    with app.app.test_client() as client:
+        rv_now = client.get("/api/license/subject").get_json()
+        rv_at = client.get(f"/api/license/subject-at?epoch={now}").get_json()
+    assert rv_at["subject_at"] == rv_now["subject"]
+    assert rv_at["subject"] == rv_now["subject"]
+
+
+def test_api_subject_at_shared_snapshot_agreement_with_tier_at(app):
+    """The current-time reference fields (``expires_at``,
+    ``has_license``, ``valid``) on this response must byte-equal the
+    same fields on the sibling ``/api/license/tier-at`` response for
+    the same install -- both endpoints derive them from the same
+    underlying ``current_license_info`` / ``license_expires_at`` read,
+    so a UI binding both for the same install cannot catch them
+    disagreeing on the reference fields."""
+    tok = app.lic._encode_token(_payload(exp_delta=30 * 86400), app.priv)
+    app.lic.activate(tok)
+    now = int(time.time())
+    with app.app.test_client() as client:
+        rv_subject = client.get(
+            f"/api/license/subject-at?epoch={now}"
+        ).get_json()
+        rv_tier = client.get(f"/api/license/tier-at?epoch={now}").get_json()
+    assert rv_subject["expires_at"] == rv_tier["expires_at"]
+    assert rv_subject["has_license"] == rv_tier["has_license"]
+    assert rv_subject["valid"] == rv_tier["valid"]
+
+
+def test_api_subject_at_never_5xxs_on_snapshot_failure(app, monkeypatch):
+    """Underlying snapshot failure -> endpoint still returns HTTP 200
+    with the OSS-free branch shape (never 5xxs), matching the surround-
+    ing license endpoints."""
+    def _boom():
+        raise RuntimeError("simulated snapshot failure")
+
+    monkeypatch.setattr(app.lic, "current_license_info", _boom)
+    monkeypatch.setattr(app.lic, "license_subject", _boom)
+    monkeypatch.setattr(app.lic, "license_expires_at", _boom)
+    with app.app.test_client() as client:
+        rv = client.get(f"/api/license/subject-at?epoch={int(time.time())}")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["subject_at"] is None
+    assert body["subject"] is None
+    assert body["expires_at"] is None
+    assert body["has_license"] is False
+    assert body["valid"] is False


### PR DESCRIPTION
## What

Perspective-epoch flavour of `license_subject` / `/api/license/subject`. Fills the subject-axis `_at` seat alongside the shipped `license_tier_at` / `license_state_at` scalars — a scheduled-audit tile answering *"who was this node licensed to on <date>?"* no longer has to snapshot license state at that time or compare `exp` to a caller-supplied epoch itself.

## Why

Every sibling accessor on the license axis has (or is getting) a paired perspective-epoch variant:

- `license_state{,_at,_at_batch}` ✓ + `is_state{,_at,_at_batch}` ✓
- `license_tier{,_at,_at_batch}` ✓ + `is_tier` ✓ (`is_tier_at{,_batch}` in flight on #4282)
- `license_features{,_at,_at_batch}` ✓ (`has_feature` in flight on #4281)
- `license_subject` ✓ + `is_subject` ✓ → **`license_subject_at`** ← this PR

Retrospective audit rows on the subject axis today have no accessor at all — a "who was this node licensed to on each of these audit dates?" tile has to fetch the full `/api/license/status` envelope, re-do the expired-branch classification per row itself, and pluck `sub`. This PR closes the scalar half of the gap without waiting on the axis batch (`license_subject_at_batch`) or the perspective-epoch predicate (`is_subject_at`) — it is orthogonal to both and to #4281 / #4282.

## Changes

- **`clawmetry/license.py`**
  - `license_subject_at(epoch) -> str | None` — perspective-epoch accessor. Coerces `epoch` through `int()`; refuses `bool` explicitly despite being an `int` subclass so a caller passing `True` / `False` gets `None` rather than a spurious "was subject X at epoch 1?" answer. `None` on no-license / bogus-signature / lapsed-at-epoch / missing-or-empty `sub` claim / non-numeric epoch. Casing is PRESERVED (subjects are typically emails / account ids where case can matter), matching `license_subject`; whitespace is stripped. Never raises.

- **`routes/entitlement.py`**
  - `GET /api/license/subject-at?epoch=` — `{subject_at, requested_epoch, subject, expires_at, has_license, valid}`. Shares a new `_license_subject_at_snapshot` reader with the current-time `/api/license/subject` and the perspective-epoch tier / state endpoints so a UI binding both cannot catch them disagreeing on the current-time reference fields. Missing / non-integer / `bool` `epoch` collapses to `subject_at=null` with `requested_epoch=null` (never 4xx). Never 5xxs.

- **`tests/test_license_subject_at.py`** — 29 hermetic tests. Ephemeral Ed25519 keypair + monkeypatched `LICENSE_PATH` per test. Coverage:
  - **scalar**: no-license / active-now / lapsed-now / future-before-exp / future-after-exp / past-still-active / lapsed pre-lapse retrospective / exact-`exp` boundary / perpetual / invalid-sig / casing-preserved / missing-`sub`-claim parity with scalar / empty-`sub` / bool-epoch-refused / non-numeric-epoch / string-epoch-coerced / never-raises.
  - **endpoint**: no-license / active-now / missing-epoch (200, not 4xx) / future-after-exp / invalid-sig / python-scalar parity / lapsed-pre-lapse retrospective / perpetual / casing-preserved / agreement with `/api/license/subject` at now / shared snapshot with `/api/license/tier-at` (current-time reference fields byte-equal) / never-5xxs on snapshot failure.

Grace-only observation; no gate enforcement is added. Additive to the existing `/api/license/subject` and `/api/license/is-subject` endpoints, which stay unchanged.

## Local operator verification checklist

The scheduled autonomous fire has no access to the user's local daemon, live cloud snapshot, browser, or the private `clawmetry-cloud` / `clawmetry-pro` repos. Please verify locally before flipping this PR out of draft:

- [ ] `cp clawmetry/license.py routes/entitlement.py ~/.clawmetry/lib/python*/site-packages/clawmetry/` (adjust for `routes/` sub-package path)
- [ ] Clear caches: `find ~/.clawmetry/lib -name __pycache__ -exec rm -rf {} +`
- [ ] Restart daemon: `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
- [ ] Hit `/api/license/subject-at?epoch=$(date +%s)` on your local install and confirm the response shape (`subject_at`, `requested_epoch`, `subject`, `expires_at`, `has_license`, `valid`). Compare `subject_at` against `/api/license/subject` — they must agree at `epoch=now`.
- [ ] Hit `/api/license/subject-at?epoch=$(( $(date +%s) + 60*86400 ))` (well past `exp`) and confirm `subject_at=null` while `subject` still surfaces the account.
- [ ] Hit `/api/license/subject-at` (no query) and `/api/license/subject-at?epoch=nope` — both must return HTTP 200 with `subject_at=null` and `requested_epoch=null` (never 4xx).
- [ ] Decrypt the live cloud snapshot and confirm no schema drift in the response payload.
- [ ] Browser-check any UI binding `/api/license/subject` or `/api/license/tier-at` — the new endpoint is additive; the existing endpoints are untouched.

## Not changed

- No `__version__` bump, no tag, no `[RELEASE]` PR — those stay with the operator.
- No enforcement gate flipped; the resolved entitlement still falls back to GRACE.
- `/api/license/subject` and `/api/license/is-subject` are untouched — the new endpoint is purely additive.
- No batch (`license_subject_at_batch`) and no perspective-epoch predicate (`is_subject_at`) in this PR — deliberate scope split so the scalar half lands independently, matching the `license_tier_at` → `is_tier_at` staged progression on the tier axis.

## Verification here

- `python -m py_compile` on all changed files: clean.
- `ruff check` on all changed files: clean.
- `pytest tests/test_license_subject_at.py` — 29 passed.
- `pytest tests/test_license_subject_scalar.py tests/test_license_tier_at.py tests/test_license_tier_scalar.py tests/test_license_state_at_scalar.py tests/test_entitlement_api.py` — 198 passed (adjacent regression check).

---

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code

---
_Generated by [Claude Code](https://claude.ai/code/session_018ArWrmSDARUDfzhiCACfXz)_