### PR TITLE
feat(net): enterprise TLS — OS trust store, corporate-CA support, proxy env, clawmetry doctor

### DIFF
--- a/.github/workflows/windows-enterprise-tls.yml
+++ b/.github/workflows/windows-enterprise-tls.yml
@@ -66,6 +66,9 @@ jobs:
           if ($out -notmatch 'TLS interception detected') { throw "missing 'TLS interception detected' guidance" }
           if ($out -notmatch 'certmgr.msc') { throw "missing certmgr.msc walkthrough" }
           Write-Host "PASS: interception detected, guidance printed, exit=1"
+          # doctor exiting 1 is the ASSERTED behaviour here; without this the
+          # step inherits $LASTEXITCODE from the native command and fails.
+          exit 0
 
       - name: "Scenario B: CA in Windows Root store -> truststore validates"
         shell: pwsh

--- a/.github/workflows/windows-enterprise-tls.yml
+++ b/.github/workflows/windows-enterprise-tls.yml
@@ -38,7 +38,8 @@ jobs:
         shell: pwsh
         run: |
           python -m pip install --quiet .
-          python -m pip install --quiet pytest mitmproxy
+          # requests: not a package dep, but tests/conftest.py imports it
+          python -m pip install --quiet pytest mitmproxy requests
           python -c "import truststore; print('truststore OK')"
 
       - name: Unit tests (py3.13, VERIFY_X509_STRICT default-on)

--- a/.github/workflows/windows-enterprise-tls.yml
+++ b/.github/workflows/windows-enterprise-tls.yml
@@ -1,0 +1,91 @@
+name: Windows Enterprise TLS E2E
+# End-to-end proof of the corporate TLS-interception support on a REAL
+# Windows box (the customer environment: Windows 11 + Python 3.13 behind a
+# Zscaler-style re-signing proxy). mitmproxy plays the interception proxy;
+# its root CA goes into the actual Windows certificate store, exactly like
+# an IT-pushed corporate CA.
+#
+# Scenario A: interception, CA trusted nowhere  -> `clawmetry doctor` must
+#             FAIL (exit 1) and print the "TLS interception detected"
+#             guidance with the certmgr.msc walkthrough.
+# Scenario B: CA imported into the Windows Root store -> truststore reads
+#             the OS store, doctor must PASS (exit 0) through the proxy.
+# Scenario C: CA removed from the store, CLAWMETRY_CA_BUNDLE pointed at
+#             the PEM -> doctor must PASS (exit 0).
+on:
+  pull_request:
+    paths:
+      - clawmetry/net.py
+      - clawmetry/doctor.py
+      - clawmetry/winconsole.py
+      - tests/test_enterprise_tls.py
+      - tests/test_winconsole.py
+      - .github/workflows/windows-enterprise-tls.yml
+  workflow_dispatch:
+
+jobs:
+  e2e:
+    runs-on: windows-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
+
+      - name: Install clawmetry (this checkout) + test deps
+        shell: pwsh
+        run: |
+          python -m pip install --quiet .
+          python -m pip install --quiet pytest mitmproxy
+          python -c "import truststore; print('truststore OK')"
+
+      - name: Unit tests (py3.13, VERIFY_X509_STRICT default-on)
+        shell: pwsh
+        run: python -m pytest tests/test_enterprise_tls.py tests/test_winconsole.py -q
+
+      - name: Start mitmproxy interception proxy
+        shell: pwsh
+        run: |
+          Start-Process mitmdump -ArgumentList '--listen-port','8080' -WindowStyle Hidden
+          $ca = "$env:USERPROFILE\.mitmproxy\mitmproxy-ca-cert.cer"
+          for ($i = 0; $i -lt 30 -and -not (Test-Path $ca); $i++) { Start-Sleep 1 }
+          if (-not (Test-Path $ca)) { throw "mitmproxy CA never generated" }
+          Write-Host "mitmproxy up, CA at $ca"
+
+      - name: "Scenario A: untrusted interception -> doctor detects + fails"
+        shell: pwsh
+        env:
+          HTTPS_PROXY: http://127.0.0.1:8080
+        run: |
+          $out = (clawmetry doctor 2>&1 | Out-String)
+          Write-Host $out
+          if ($LASTEXITCODE -eq 0) { throw "doctor must FAIL through an untrusted interception proxy" }
+          if ($out -notmatch 'TLS interception detected') { throw "missing 'TLS interception detected' guidance" }
+          if ($out -notmatch 'certmgr.msc') { throw "missing certmgr.msc walkthrough" }
+          Write-Host "PASS: interception detected, guidance printed, exit=1"
+
+      - name: "Scenario B: CA in Windows Root store -> truststore validates"
+        shell: pwsh
+        env:
+          HTTPS_PROXY: http://127.0.0.1:8080
+        run: |
+          certutil -addstore -f Root "$env:USERPROFILE\.mitmproxy\mitmproxy-ca-cert.cer"
+          $out = (clawmetry doctor 2>&1 | Out-String)
+          Write-Host $out
+          if ($LASTEXITCODE -ne 0) { throw "doctor must PASS with the corporate CA in the OS store" }
+          Write-Host "PASS: OS trust store honored through interception proxy"
+
+      - name: "Scenario C: CLAWMETRY_CA_BUNDLE fallback"
+        shell: pwsh
+        env:
+          HTTPS_PROXY: http://127.0.0.1:8080
+          CLAWMETRY_CA_BUNDLE: ${{ github.workspace }}\mitm-ca.pem
+        run: |
+          certutil -delstore Root mitmproxy
+          Copy-Item "$env:USERPROFILE\.mitmproxy\mitmproxy-ca-cert.pem" "$env:CLAWMETRY_CA_BUNDLE"
+          $out = (clawmetry doctor 2>&1 | Out-String)
+          Write-Host $out
+          if ($LASTEXITCODE -ne 0) { throw "doctor must PASS with CLAWMETRY_CA_BUNDLE set" }
+          Write-Host "PASS: custom CA bundle honored"

--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -5751,6 +5751,15 @@ def main() -> None:
     if len(sys.argv) > 1 and sys.argv[1] == "hooks":
         from clawmetry.hooks_claude_code import cli_main as _hooks_cli
         raise SystemExit(_hooks_cli(sys.argv[2:]))
+    # Enterprise TLS/proxy bootstrap — OS trust store (truststore), 3.13
+    # strict-flag relax, CLAWMETRY_CA_BUNDLE, proxy env vars — so every
+    # outbound HTTPS call from the CLI/dashboard (connect, OTP, telemetry,
+    # update check) works behind corporate TLS-intercepting proxies.
+    try:
+        from clawmetry.net import configure_outbound_network
+        configure_outbound_network(role="cli")
+    except Exception:
+        pass
     # --v2 opt-in flag for the React SPA scaffold (see clawmetry/v2/routes.py).
     # Strip it from argv so dashboard.main's argparse doesn't choke on it.
     # Sets the env var that dashboard.py checks at blueprint registration time.
@@ -6470,6 +6479,21 @@ def main() -> None:
         ),
     )
 
+    # doctor — enterprise network/TLS connectivity diagnostics
+    p_doctor = sub.add_parser(
+        "doctor",
+        help=(
+            "Diagnose cloud connectivity: DNS, TCP, proxy, TLS "
+            "(detects corporate TLS interception), heartbeat POST"
+        ),
+    )
+    p_doctor.add_argument(
+        "--host",
+        dest="doctor_host",
+        default=None,
+        help="Override target (default: ingest.clawmetry.com / CLAWMETRY_INGEST_URL)",
+    )
+
     # verify-integrity — walk hash chain and report validity (Issue #2200)
     p_verify = sub.add_parser(
         "verify-integrity",
@@ -6527,6 +6551,7 @@ def main() -> None:
         "bundle",
         "extensions",
         "diagnose",
+        "doctor",
         "verify-integrity",
         "nemoclaw-daemons",
     )
@@ -6582,6 +6607,9 @@ def main() -> None:
             _cmd_extensions(args)
         elif args.cmd == "diagnose":
             _cmd_diagnose(args)
+        elif args.cmd == "doctor":
+            from clawmetry.doctor import run_doctor
+            sys.exit(run_doctor(host=getattr(args, "doctor_host", None)))
         elif args.cmd == "verify-integrity":
             _cmd_verify_integrity(args)
         elif args.cmd == "nemoclaw-daemons":

--- a/clawmetry/doctor.py
+++ b/clawmetry/doctor.py
@@ -1,0 +1,328 @@
+"""
+clawmetry doctor — enterprise network connectivity diagnostics.
+
+Runs the exact chain a heartbeat needs (DNS → TCP → TLS → HTTP POST) against
+ingest.clawmetry.com and prints pass/fail per step in plain language, so a
+non-engineer on a screen-share can read it. Detects TLS-intercepting
+proxies (Zscaler/Netskope/Palo Alto/…) by fetching the peer certificate
+with verification off and classifying its issuer, then prints the exact
+fix (export the corporate root CA → CLAWMETRY_CA_BUNDLE).
+
+Exit code 0 only when every check passes.
+"""
+from __future__ import annotations
+
+import os
+import socket
+import ssl
+import urllib.error
+import urllib.parse
+import urllib.request
+
+from clawmetry import net as _net
+
+INGEST_HOST_DEFAULT = "ingest.clawmetry.com"
+TIMEOUT_S = 10
+
+PASS = "[ OK ]"
+FAIL = "[FAIL]"
+WARN = "[WARN]"
+
+# Issuer organizations of the public CAs that could plausibly sign
+# clawmetry.com (or anything else on the public internet). If the issuer of
+# the cert we receive matches none of these, the traffic is being re-signed
+# on the customer's network. Matching is case-insensitive substring over the
+# issuer RDNs (org + CN), so "DigiCert Global Root G2" matches "digicert".
+WELL_KNOWN_PUBLIC_CAS = (
+    "let's encrypt", "isrg", "digicert", "google trust services", "gts ",
+    "amazon", "globalsign", "sectigo", "comodo", "usertrust", "godaddy",
+    "go daddy", "starfield", "entrust", "identrust", "baltimore",
+    "verisign", "thawte", "geotrust", "rapidssl", "cloudflare", "zerossl",
+    "buypass", "ssl.com", "actalis", "certum", "quovadis", "harica",
+    "telekom", "d-trust", "swisssign", "microsoft rsa", "microsoft ecc",
+    "apple public", "certainly", "trustasia",
+)
+
+# Vendors whose names commonly appear in interception-proxy issuers. Only
+# used to make the message friendlier — anything not in the public list is
+# reported as interception either way.
+KNOWN_INTERCEPT_VENDORS = (
+    "zscaler", "netskope", "palo alto", "forcepoint", "bluecoat",
+    "blue coat", "fortinet", "fortigate", "sophos", "mcafee", "cisco",
+    "umbrella", "checkpoint", "check point", "watchguard", "mitmproxy",
+    "broadcom", "symantec blue",
+)
+
+
+def issuer_name_from_der(der: bytes) -> str:
+    """Human-readable issuer from a DER certificate.
+
+    Uses ``cryptography`` (already a hard dependency for cloud sync);
+    falls back to "" if parsing fails — never raises.
+    """
+    try:
+        from cryptography import x509
+
+        cert = x509.load_der_x509_certificate(der)
+        return cert.issuer.rfc4514_string()
+    except Exception:
+        return ""
+
+
+def classify_issuer(issuer: str) -> str:
+    """'public' when the issuer looks like a well-known public CA, else 'corporate'.
+
+    Matches against the issuer's O= (organization) values, not the full RDN
+    string — a CN like ``*.badssl.com`` must not substring-match the
+    "ssl.com" public-CA entry. Falls back to the full string only when no
+    O= component exists.
+    """
+    low = (issuer or "").lower()
+    if not low:
+        return "corporate"
+    import re
+
+    orgs = re.findall(r"(?:^|,)\s*o=([^,]+)", low)
+    haystack = " | ".join(orgs) if orgs else low
+    for known in WELL_KNOWN_PUBLIC_CAS:
+        if known in haystack:
+            return "public"
+    return "corporate"
+
+
+def intercept_vendor(issuer: str) -> str:
+    import re
+
+    low = (issuer or "").lower()
+    for vendor in KNOWN_INTERCEPT_VENDORS:
+        # Word-boundary match: "cisco" must not hit "San Francisco".
+        if re.search(r"\b" + re.escape(vendor) + r"\b", low):
+            return vendor
+    return ""
+
+
+def _proxy_for_https() -> str:
+    """The proxy URL urllib would use for https, or ""."""
+    try:
+        return urllib.request.getproxies().get("https", "") or ""
+    except Exception:
+        return ""
+
+
+def _fetch_peer_cert_unverified(host: str, port: int, proxy: str = "") -> bytes:
+    """TLS-handshake with verification OFF purely to grab the peer cert.
+
+    This never carries application data — it exists so we can show the
+    user WHO is actually terminating their TLS.
+    """
+    ctx = ssl._create_unverified_context()  # noqa: S323 — diagnostic fetch only
+    _net.relax_strict_verification(ctx)
+    sock = _open_tcp(host, port, proxy)
+    try:
+        with ctx.wrap_socket(sock, server_hostname=host) as tls:
+            return tls.getpeercert(True) or b""
+    finally:
+        try:
+            sock.close()
+        except Exception:
+            pass
+
+
+def _open_tcp(host: str, port: int, proxy: str = "") -> socket.socket:
+    """TCP connection to host:port, tunnelling CONNECT through proxy if set."""
+    if not proxy:
+        return socket.create_connection((host, port), timeout=TIMEOUT_S)
+    p = urllib.parse.urlparse(proxy if "://" in proxy else "http://" + proxy)
+    sock = socket.create_connection((p.hostname, p.port or 3128), timeout=TIMEOUT_S)
+    try:
+        connect = "CONNECT {0}:{1} HTTP/1.1\r\nHost: {0}:{1}\r\n\r\n".format(host, port)
+        sock.sendall(connect.encode())
+        resp = b""
+        while b"\r\n\r\n" not in resp:
+            chunk = sock.recv(4096)
+            if not chunk:
+                break
+            resp = resp + chunk
+        status_line = resp.split(b"\r\n", 1)[0].decode("latin-1", "replace")
+        if " 200" not in status_line:
+            raise OSError("proxy CONNECT refused: " + status_line)
+        return sock
+    except Exception:
+        sock.close()
+        raise
+
+
+def _windows_fix_text(issuer: str) -> str:
+    vendor = intercept_vendor(issuer)
+    vendor_note = (
+        "  (That issuer is a {0} appliance — your IT team runs it.)\n".format(vendor)
+        if vendor else ""
+    )
+    return (
+        'TLS interception detected (issuer: {0}). Your network re-signs\n'
+        "HTTPS traffic.\n"
+        "{1}"
+        "\n"
+        "How to fix (Windows):\n"
+        "  1. Press Win+R, run: certmgr.msc\n"
+        "  2. Open: Trusted Root Certification Authorities > Certificates\n"
+        "  3. Find your company's root CA (often named after your company\n"
+        "     or the proxy vendor, e.g. the issuer shown above)\n"
+        "  4. Right-click it > All Tasks > Export... > choose\n"
+        '     "Base-64 encoded X.509 (.CER)" > save e.g. C:\\corp-root.cer\n'
+        "  5. Point ClawMetry at it:\n"
+        "       setx CLAWMETRY_CA_BUNDLE C:\\corp-root.cer\n"
+        "     then restart the daemon (clawmetry sync restart).\n"
+        "\n"
+        "If ClawMetry was installed with the 'truststore' package (Python\n"
+        "3.10+), the OS trust store is used automatically and this step is\n"
+        "usually unnecessary — run doctor again after upgrading:\n"
+        "  pip install --upgrade clawmetry truststore\n"
+    ).format(issuer or "<unknown>", vendor_note)
+
+
+def run_doctor(host: str = None, port: int = 443, out=print) -> int:
+    """Run all connectivity checks. Returns process exit code (0 = all pass)."""
+    host = host or os.environ.get(
+        "CLAWMETRY_INGEST_URL", "https://" + INGEST_HOST_DEFAULT
+    )
+    if "://" in host:
+        parsed = urllib.parse.urlparse(host)
+        port = parsed.port or 443
+        host = parsed.hostname or INGEST_HOST_DEFAULT
+
+    failures = 0
+    out("ClawMetry network doctor")
+    out("Target: {0}:{1}".format(host, port))
+    st = _net.state()
+    if st.get("configured"):
+        trust = "OS trust store (truststore)" if st.get("truststore") \
+            else "Python default (certifi/OpenSSL)"
+        out("Trust source: " + trust)
+        if st.get("ca_bundle"):
+            out("Extra CA bundle: " + st["ca_bundle"])
+        if st.get("verify_disabled"):
+            out(WARN + " TLS verification is DISABLED (CLAWMETRY_TLS_NO_VERIFY /"
+                " tls_verify:false) — insecure, pilot use only")
+    out("")
+
+    # ── 1. DNS ────────────────────────────────────────────────────────────
+    try:
+        infos = socket.getaddrinfo(host, port, proto=socket.IPPROTO_TCP)
+        addrs = sorted({i[4][0] for i in infos})
+        out("{0} DNS: {1} resolves to {2}".format(PASS, host, ", ".join(addrs[:4])))
+    except Exception as e:
+        failures += 1
+        out("{0} DNS: could not resolve {1} ({2})".format(FAIL, host, e))
+        out("       Check your internet connection / VPN, or ask IT whether")
+        out("       this hostname is blocked by a web filter.")
+        out("\nResult: FAIL — fix the items above and re-run `clawmetry doctor`.")
+        return 1  # nothing further can work without DNS
+
+    # ── 2. TCP ────────────────────────────────────────────────────────────
+    proxy = _proxy_for_https()
+    try:
+        socket.create_connection((host, port), timeout=TIMEOUT_S).close()
+        out("{0} TCP: direct connection to {1}:{2} works".format(PASS, host, port))
+        direct_tcp = True
+    except Exception as e:
+        direct_tcp = False
+        level = WARN if proxy else FAIL
+        if not proxy:
+            failures += 1
+        out("{0} TCP: direct connection to {1}:{2} failed ({3})".format(
+            level, host, port, e))
+        if not proxy:
+            out("       No HTTPS_PROXY is set. If your company requires a proxy,")
+            out("       set HTTPS_PROXY (ask IT for the address) and re-run.")
+    if proxy:
+        try:
+            _open_tcp(host, port, proxy).close()
+            out("{0} TCP via proxy: {1} tunnels to {2}:{3}".format(
+                PASS, proxy, host, port))
+        except Exception as e:
+            failures += 1
+            out("{0} TCP via proxy: {1} could not reach {2}:{3} ({4})".format(
+                FAIL, proxy, host, port, e))
+
+    # ── 3. TLS handshake with our configured context ──────────────────────
+    tls_ok = False
+    tls_route = proxy if not direct_tcp else ""
+    ctx = _net.build_ssl_context(allow_insecure=True)
+    try:
+        raw = _open_tcp(host, port, tls_route)
+        try:
+            with ctx.wrap_socket(raw, server_hostname=host) as tls:
+                issuer = ""
+                try:
+                    der = tls.getpeercert(True)
+                    issuer = issuer_name_from_der(der) if der else ""
+                except Exception:
+                    pass
+        finally:
+            try:
+                raw.close()
+            except Exception:
+                pass
+        tls_ok = True
+        out("{0} TLS: certificate verified (issuer: {1})".format(
+            PASS, issuer or "unknown"))
+        if issuer and classify_issuer(issuer) == "corporate":
+            out("       Note: that issuer is not a public CA — your network")
+            out("       re-signs HTTPS, but its root CA is trusted here. Good.")
+    except Exception as e:
+        failures += 1
+        out("{0} TLS: handshake failed ({1})".format(FAIL, e))
+        # Verification-off retry purely to FETCH the cert and show who signed it.
+        issuer = ""
+        try:
+            der = _fetch_peer_cert_unverified(host, port, tls_route)
+            issuer = issuer_name_from_der(der) if der else ""
+        except Exception as e2:
+            out("       (could not fetch the server certificate either: {0})".format(e2))
+        if issuer:
+            out("       Certificate issuer chain: " + issuer)
+            if classify_issuer(issuer) == "corporate":
+                out("")
+                for line in _windows_fix_text(issuer).splitlines():
+                    out("  " + line)
+            else:
+                out("       The issuer looks like a public CA — your Python")
+                out("       CA bundle may be outdated. Try: pip install -U certifi")
+
+    # ── 4. Heartbeat POST ────────────────────────────────────────────────
+    if tls_ok:
+        url = "https://{0}:{1}/ingest/heartbeat".format(host, port) \
+            if port != 443 else "https://{0}/ingest/heartbeat".format(host)
+        req = urllib.request.Request(
+            url,
+            data=b'{"doctor": true}',
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        try:
+            # Global opener installed by configure_outbound_network() — this
+            # exercises the exact transport the daemon heartbeat uses.
+            with urllib.request.urlopen(req, timeout=TIMEOUT_S) as resp:
+                status = getattr(resp, "status", 200)
+            out("{0} POST {1} -> HTTP {2}".format(PASS, url, status))
+        except urllib.error.HTTPError as e:
+            # An HTTP status (even 4xx) means the network path works —
+            # the server just rejected our unauthenticated test payload.
+            out("{0} POST {1} -> HTTP {2} (transport works; the server".format(
+                PASS, url, e.code))
+            out("       rejected the unauthenticated test payload, as expected)")
+        except Exception as e:
+            failures += 1
+            out("{0} POST {1} failed ({2})".format(FAIL, url, e))
+    else:
+        failures += 1
+        out("{0} POST skipped — TLS must pass first".format(FAIL))
+
+    out("")
+    if failures == 0:
+        out("Result: ALL CHECKS PASSED — ClawMetry can reach the cloud.")
+        return 0
+    out("Result: {0} check(s) FAILED — fix the items above and re-run"
+        " `clawmetry doctor`.".format(failures))
+    return 1

--- a/clawmetry/doctor.py
+++ b/clawmetry/doctor.py
@@ -224,9 +224,7 @@ def run_doctor(host: str = None, port: int = 443, out=print) -> int:
     try:
         socket.create_connection((host, port), timeout=TIMEOUT_S).close()
         out("{0} TCP: direct connection to {1}:{2} works".format(PASS, host, port))
-        direct_tcp = True
     except Exception as e:
-        direct_tcp = False
         level = WARN if proxy else FAIL
         if not proxy:
             failures += 1
@@ -247,7 +245,11 @@ def run_doctor(host: str = None, port: int = 443, out=print) -> int:
 
     # ── 3. TLS handshake with our configured context ──────────────────────
     tls_ok = False
-    tls_route = proxy if not direct_tcp else ""
+    # Mirror urllib's routing: when an HTTPS proxy is configured the real
+    # heartbeat traffic tunnels through it, so the TLS check must too —
+    # a direct handshake could pass while proxied traffic fails on the
+    # proxy's re-signed certificate.
+    tls_route = proxy
     ctx = _net.build_ssl_context(allow_insecure=True)
     try:
         raw = _open_tcp(host, port, tls_route)
@@ -265,8 +267,9 @@ def run_doctor(host: str = None, port: int = 443, out=print) -> int:
             except Exception:
                 pass
         tls_ok = True
-        out("{0} TLS: certificate verified (issuer: {1})".format(
-            PASS, issuer or "unknown"))
+        via = " via proxy" if tls_route else ""
+        out("{0} TLS{1}: certificate verified (issuer: {2})".format(
+            PASS, via, issuer or "unknown"))
         if issuer and classify_issuer(issuer) == "corporate":
             out("       Note: that issuer is not a public CA — your network")
             out("       re-signs HTTPS, but its root CA is trusted here. Good.")

--- a/clawmetry/net.py
+++ b/clawmetry/net.py
@@ -1,0 +1,223 @@
+"""
+clawmetry.net — outbound TLS + proxy bootstrap for enterprise networks.
+
+Enterprise Windows machines commonly sit behind TLS-intercepting proxies
+(Zscaler, Netskope, Palo Alto, …) that re-sign HTTPS with an internal root
+CA. That CA lives in the OS trust store but not in certifi's bundle, and on
+Python 3.13+ ``VERIFY_X509_STRICT`` (default-on) additionally rejects
+corporate MITM CAs that lack the keyUsage extension. Result: every POST to
+ingest.clawmetry.com dies with CERTIFICATE_VERIFY_FAILED.
+
+Every outbound HTTPS call in this package goes through
+``urllib.request.urlopen`` with the process-default opener, so one
+``configure_outbound_network()`` call at process start fixes all of them:
+
+1. ``truststore.inject_into_ssl()`` — validate against the OS trust store
+   (Windows CryptoAPI / macOS Security.framework / Linux CA dir) instead of
+   only certifi. Guarded: falls back to stock OpenSSL trust when the
+   package is missing (Python < 3.10) or injection fails.
+2. Clear ``VERIFY_X509_STRICT`` on the context we install — hostname
+   checking and chain validation stay ON.
+3. Load an extra CA bundle from CLAWMETRY_CA_BUNDLE / config ``ca_bundle``
+   / SSL_CERT_FILE / REQUESTS_CA_BUNDLE (first match wins, env before
+   config).
+4. Install a global urllib opener whose ProxyHandler snapshots
+   HTTPS_PROXY / HTTP_PROXY / NO_PROXY *now* — the daemon is started by
+   launchd/systemd/Task Scheduler, not the user's shell, so the env must
+   be read at daemon start rather than assumed inherited.
+5. Last-resort escape hatch: config ``tls_verify: false`` or
+   CLAWMETRY_TLS_NO_VERIFY=1 disables verification entirely, with a loud
+   warning on every start. Pilot use only.
+
+See docs/enterprise-networking.md and ``clawmetry doctor``.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import ssl
+import urllib.request
+
+log = logging.getLogger("clawmetry.net")
+
+_TRUTHY = frozenset({"1", "true", "yes", "on"})
+
+CONFIG_PATH = os.path.expanduser("~/.clawmetry/config.json")
+
+# Set by configure_outbound_network() so `clawmetry doctor` / `clawmetry
+# status` can report which trust source is active.
+_STATE = {
+    "configured": False,
+    "truststore": False,
+    "ca_bundle": None,
+    "verify_disabled": False,
+}
+
+
+def _env_truthy(name: str) -> bool:
+    return os.environ.get(name, "").strip().lower() in _TRUTHY
+
+
+def _load_config_file() -> dict:
+    """Best-effort read of ~/.clawmetry/config.json. Never raises."""
+    try:
+        with open(CONFIG_PATH, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        return data if isinstance(data, dict) else {}
+    except Exception:
+        return {}
+
+
+def tls_verify_disabled(config: dict = None) -> bool:
+    """True when the operator explicitly opted out of TLS verification.
+
+    Env CLAWMETRY_TLS_NO_VERIFY=1 or config ``tls_verify: false``. This is
+    the last-resort escape hatch for pilots stuck behind an interception
+    proxy whose root CA can't be exported yet — NOT a recommended mode.
+    """
+    if _env_truthy("CLAWMETRY_TLS_NO_VERIFY"):
+        return True
+    if config is None:
+        config = _load_config_file()
+    return config.get("tls_verify") is False
+
+
+def ca_bundle_path(config: dict = None) -> str:
+    """Resolve the extra CA bundle to load, or "" when none is configured.
+
+    Precedence: CLAWMETRY_CA_BUNDLE > config ``ca_bundle`` > SSL_CERT_FILE
+    > REQUESTS_CA_BUNDLE. A configured-but-missing file is logged and
+    skipped so a stale path can't take the daemon offline.
+    """
+    if config is None:
+        config = _load_config_file()
+    candidates = (
+        ("CLAWMETRY_CA_BUNDLE (env)", os.environ.get("CLAWMETRY_CA_BUNDLE", "")),
+        ("ca_bundle (config)", str(config.get("ca_bundle") or "")),
+        ("SSL_CERT_FILE (env)", os.environ.get("SSL_CERT_FILE", "")),
+        ("REQUESTS_CA_BUNDLE (env)", os.environ.get("REQUESTS_CA_BUNDLE", "")),
+    )
+    for source, path in candidates:
+        path = os.path.expanduser(path.strip()) if path else ""
+        if not path:
+            continue
+        if os.path.isfile(path):
+            return path
+        log.warning("CA bundle from %s does not exist, skipping: %s", source, path)
+    return ""
+
+
+def relax_strict_verification(ctx: "ssl.SSLContext") -> "ssl.SSLContext":
+    """Clear VERIFY_X509_STRICT (Python 3.13 default-on) on ``ctx``.
+
+    Corporate interception CAs frequently lack the keyUsage extension the
+    strict profile requires ("CA cert does not include key usage
+    extension"). Hostname checking and chain validation are untouched.
+    hasattr-guarded: the flag exists back to 3.4 but only defaults on in
+    3.13, and some vendored ssl builds omit it.
+    """
+    if hasattr(ssl, "VERIFY_X509_STRICT"):
+        try:
+            ctx.verify_flags &= ~ssl.VERIFY_X509_STRICT
+        except Exception as e:
+            log.debug("could not clear VERIFY_X509_STRICT: %s", e)
+    return ctx
+
+
+def inject_truststore() -> bool:
+    """Swap ssl.SSLContext for the OS-trust-store-backed one. Never raises."""
+    try:
+        import truststore  # type: ignore
+
+        truststore.inject_into_ssl()
+        _STATE["truststore"] = True
+        log.info("TLS: using OS trust store via truststore")
+        return True
+    except ImportError:
+        log.info(
+            "TLS: truststore not available (needs Python 3.10+); "
+            "falling back to Python's default certifi/OpenSSL trust"
+        )
+    except Exception as e:
+        log.warning(
+            "TLS: truststore.inject_into_ssl() failed (%s); "
+            "falling back to Python's default certifi/OpenSSL trust", e
+        )
+    return False
+
+
+def build_ssl_context(config: dict = None, allow_insecure: bool = True) -> "ssl.SSLContext":
+    """Build the SSL context used for all outbound HTTPS.
+
+    OS-store-backed when truststore is injected, strict flag cleared,
+    extra CA bundle loaded on top. ``allow_insecure=False`` ignores the
+    tls_verify escape hatch (doctor uses that to test the real posture).
+    """
+    if config is None:
+        config = _load_config_file()
+    ctx = ssl.create_default_context()
+    relax_strict_verification(ctx)
+    bundle = ca_bundle_path(config)
+    if bundle:
+        try:
+            ctx.load_verify_locations(cafile=bundle)
+            _STATE["ca_bundle"] = bundle
+            log.info("TLS: loaded extra CA bundle %s", bundle)
+        except Exception as e:
+            log.warning("TLS: failed to load CA bundle %s: %s", bundle, e)
+    if allow_insecure and tls_verify_disabled(config):
+        ctx.check_hostname = False
+        ctx.verify_mode = ssl.CERT_NONE
+        _STATE["verify_disabled"] = True
+        log.warning(
+            "!!! TLS CERTIFICATE VERIFICATION IS DISABLED "
+            "(tls_verify:false / CLAWMETRY_TLS_NO_VERIFY=1). Traffic to "
+            "clawmetry.com can be read or tampered with in transit. This "
+            "is for temporary pilot use ONLY — export your corporate root "
+            "CA and set CLAWMETRY_CA_BUNDLE instead (see `clawmetry "
+            "doctor` and docs/enterprise-networking.md)."
+        )
+    return ctx
+
+
+def configure_outbound_network(config: dict = None, role: str = "") -> "ssl.SSLContext":
+    """Process-wide outbound TLS/proxy bootstrap. Call once at startup.
+
+    Installs a global urllib opener so every ``urllib.request.urlopen``
+    call in the process (heartbeat, snapshot push, telemetry, license,
+    update check, …) validates against the OS trust store, honors the
+    proxy env vars, and tolerates 3.13 strict-mode corporate CAs.
+    Never raises — a broken TLS bootstrap must not stop the daemon from
+    ingesting locally.
+    """
+    try:
+        inject_truststore()
+        ctx = build_ssl_context(config)
+        opener = urllib.request.build_opener(
+            # ProxyHandler() reads HTTPS_PROXY/HTTP_PROXY/NO_PROXY at
+            # construction — i.e. at daemon start, not the parent shell.
+            urllib.request.ProxyHandler(),
+            urllib.request.HTTPSHandler(context=ctx),
+        )
+        urllib.request.install_opener(opener)
+        _STATE["configured"] = True
+        proxies = urllib.request.getproxies()
+        if proxies:
+            log.info(
+                "%soutbound proxy config: %s",
+                (role + ": ") if role else "",
+                {k: v for k, v in proxies.items() if k in ("http", "https", "no")},
+            )
+        return ctx
+    except Exception as e:
+        log.warning("outbound network bootstrap failed (%s); using stdlib defaults", e)
+        try:
+            return ssl.create_default_context()
+        except Exception:
+            return None
+
+
+def state() -> dict:
+    """Snapshot of the active trust configuration (for doctor/status)."""
+    return dict(_STATE)

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -17709,6 +17709,14 @@ def run_daemon() -> None:
         configure_outbound_network(role="daemon")
     except Exception as _net_e:
         log.warning("TLS/proxy bootstrap failed: %s", _net_e)
+    # Windows: the daemon runs DETACHED (no console), so unpatched child
+    # processes (pip update check, node --version, disk probes) each flash
+    # a visible cmd window. Patch Popen once so children stay windowless.
+    try:
+        from clawmetry.winconsole import hide_child_console_windows
+        hide_child_console_windows()
+    except Exception:
+        pass
     if not _acquire_pid_lock():
         print(
             "[clawmetry-sync] Another instance is already running. Exiting.", flush=True

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -17698,6 +17698,17 @@ def start_claim_watcher(config: dict):
 
 
 def run_daemon() -> None:
+    # Enterprise TLS/proxy bootstrap FIRST — before any cloud call. Installs
+    # the OS-trust-store (truststore) SSL context + proxy-env opener that
+    # every urlopen in this process (heartbeat, snapshot push, telemetry)
+    # rides on. launchd/systemd/Task Scheduler don't inherit the user's
+    # shell env, so proxy vars are re-read here at daemon start. Never
+    # raises; local DuckDB ingestion is unaffected if this fails.
+    try:
+        from clawmetry.net import configure_outbound_network
+        configure_outbound_network(role="daemon")
+    except Exception as _net_e:
+        log.warning("TLS/proxy bootstrap failed: %s", _net_e)
     if not _acquire_pid_lock():
         print(
             "[clawmetry-sync] Another instance is already running. Exiting.", flush=True

--- a/clawmetry/winconsole.py
+++ b/clawmetry/winconsole.py
@@ -1,0 +1,92 @@
+"""
+clawmetry.winconsole — stop Windows console windows flashing.
+
+The Windows sync daemon is started with DETACHED_PROCESS (cli.py
+_start_subprocess), so it has NO console. Every subprocess it spawns —
+the pip self-update check, ``node --version``, disk/gateway probes,
+40+ call sites across sync.py — is a console program, and Windows
+allocates a brand-new VISIBLE console window for each one because the
+parent has none to inherit. Users see cmd windows randomly popping open
+and closing while the daemon runs. Scary, and rightly flagged by
+enterprise pilots.
+
+``hide_child_console_windows()`` patches ``subprocess.Popen`` once, at
+process start, to pass CREATE_NO_WINDOW (+ a SW_HIDE STARTUPINFO) to
+every child that didn't explicitly ask for a console — one fix at the
+spawn layer instead of touching every call site. No-op on macOS/Linux.
+
+Children that explicitly request DETACHED_PROCESS or CREATE_NEW_CONSOLE
+(e.g. the daemon relaunch itself) are left untouched: CREATE_NO_WINDOW
+is mutually exclusive with those flags at the Win32 level.
+"""
+from __future__ import annotations
+
+import logging
+import os
+
+log = logging.getLogger("clawmetry.winconsole")
+
+# Win32 process-creation constants (stable ABI; subprocess only defines
+# them on Windows, and the injector must be unit-testable everywhere).
+CREATE_NO_WINDOW = 0x08000000
+DETACHED_PROCESS = 0x00000008
+CREATE_NEW_CONSOLE = 0x00000010
+STARTF_USESHOWWINDOW = 0x00000001
+SW_HIDE = 0
+
+_CALLER_CONSOLE_FLAGS = DETACHED_PROCESS | CREATE_NEW_CONSOLE
+
+
+def inject_no_window(kwargs, startupinfo_factory=None):
+    """Add CREATE_NO_WINDOW (+ hidden STARTUPINFO) to Popen kwargs.
+
+    Pure function so the logic is testable on any OS. Leaves kwargs
+    untouched when the caller explicitly chose a console mode
+    (DETACHED_PROCESS / CREATE_NEW_CONSOLE) or already passed a
+    startupinfo of their own.
+    """
+    flags = kwargs.get("creationflags") or 0
+    if flags & _CALLER_CONSOLE_FLAGS:
+        return kwargs
+    kwargs["creationflags"] = flags | CREATE_NO_WINDOW
+    if kwargs.get("startupinfo") is None and startupinfo_factory is not None:
+        try:
+            si = startupinfo_factory()
+            si.dwFlags |= STARTF_USESHOWWINDOW
+            si.wShowWindow = SW_HIDE
+            kwargs["startupinfo"] = si
+        except Exception:
+            pass
+    return kwargs
+
+
+def hide_child_console_windows() -> bool:
+    """Patch subprocess.Popen so daemon children never open console windows.
+
+    Windows-only; returns True when the patch is (already) active.
+    Idempotent and never raises — a failed patch must not stop the daemon.
+    """
+    if os.name != "nt":
+        return False
+    try:
+        import subprocess
+
+        if getattr(subprocess.Popen.__init__, "_clawmetry_no_window", False):
+            return True
+        orig_init = subprocess.Popen.__init__
+        si_factory = getattr(subprocess, "STARTUPINFO", None)
+
+        def _no_window_init(self, *args, **kwargs):
+            try:
+                inject_no_window(kwargs, startupinfo_factory=si_factory)
+            except Exception:
+                pass
+            return orig_init(self, *args, **kwargs)
+
+        _no_window_init._clawmetry_no_window = True
+        subprocess.Popen.__init__ = _no_window_init
+        log.info("Windows: child console windows hidden (CREATE_NO_WINDOW)")
+        return True
+    except Exception as e:
+        log.warning("could not hide child console windows: %s", e)
+        return False

--- a/dashboard.py
+++ b/dashboard.py
@@ -19099,6 +19099,14 @@ def _init_data_provider():
 
 
 def main():
+    # Enterprise TLS/proxy bootstrap (idempotent; also runs in cli.main).
+    # Covers direct `python3 dashboard.py` runs so telemetry/cloud-proxy
+    # POSTs work behind corporate TLS-intercepting proxies.
+    try:
+        from clawmetry.net import configure_outbound_network
+        configure_outbound_network(role="dashboard")
+    except Exception:
+        pass
     # -----------------------------------------------------------------------
     # Build a shared parent parser for options that apply to all subcommands
     # (and to foreground mode when no subcommand is given).

--- a/dashboard.py
+++ b/dashboard.py
@@ -18601,11 +18601,22 @@ def _start_daemon_background():
     import subprocess
     import pathlib as _pl
 
+    spawn_kwargs = {}
+    if os.name == "nt":
+        # start_new_session is POSIX-only and silently no-ops on Windows:
+        # the daemon stayed tied to this console (killed when it closes)
+        # and, when the dashboard itself runs hidden, python.exe popped a
+        # visible console window. Mirror cli.py _start_subprocess.
+        spawn_kwargs["creationflags"] = (
+            subprocess.DETACHED_PROCESS | subprocess.CREATE_NEW_PROCESS_GROUP
+        )
+    else:
+        spawn_kwargs["start_new_session"] = True
     proc = subprocess.Popen(
         [sys.executable, "-m", "clawmetry.sync"],
         stdout=open(os.devnull, "w"),
         stderr=open(os.devnull, "w"),
-        start_new_session=True,
+        **spawn_kwargs,
     )
     pid_file = _pl.Path.home() / ".clawmetry" / "sync.pid"
     pid_file.parent.mkdir(parents=True, exist_ok=True)
@@ -19105,6 +19116,11 @@ def main():
     try:
         from clawmetry.net import configure_outbound_network
         configure_outbound_network(role="dashboard")
+    except Exception:
+        pass
+    try:
+        from clawmetry.winconsole import hide_child_console_windows
+        hide_child_console_windows()
     except Exception:
         pass
     # -----------------------------------------------------------------------

--- a/docs/enterprise-networking.md
+++ b/docs/enterprise-networking.md
@@ -1,0 +1,135 @@
+# Enterprise Networking: Corporate Proxies & TLS Interception
+
+If ClawMetry works at home but on a corporate machine the daemon logs
+something like:
+
+```
+WARNING Heartbeat failed: network error POSTing
+https://ingest.clawmetry.com/ingest/heartbeat: <urlopen error
+[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed:
+CA cert does not include key usage extension (_ssl.c:1032)>
+```
+
+this page is for you. **Start with:**
+
+```
+clawmetry doctor
+```
+
+It checks DNS → TCP → proxy → TLS → a heartbeat POST, prints pass/fail per
+step in plain language, and — when your network re-signs HTTPS — tells you
+exactly which certificate authority is doing it and how to fix it. Exit
+code is 0 only when everything passes, so it also works in scripts.
+
+## What is TLS interception?
+
+Many companies route all HTTPS traffic through a security proxy (Zscaler,
+Netskope, Palo Alto, Forcepoint, Fortinet, …). The proxy decrypts your
+traffic for inspection and re-encrypts it with a certificate signed by the
+**company's own root CA** instead of a public one. That root CA is
+installed in the operating system's trust store by your IT team — but:
+
+1. Python does not always use the OS trust store, so the corporate CA
+   looks untrusted, and
+2. Python 3.13 turned on strict X.509 validation
+   (`VERIFY_X509_STRICT`) by default, which rejects many corporate CAs
+   outright because they lack the `keyUsage` extension.
+
+Either one produces `CERTIFICATE_VERIFY_FAILED`.
+
+## What ClawMetry does automatically
+
+Since this release, the daemon, the CLI, and the dashboard all run a TLS
+bootstrap at startup (`clawmetry/net.py`):
+
+* **OS trust store** — via the [`truststore`](https://pypi.org/project/truststore/)
+  package (installed automatically on Python 3.10+), certificate validation
+  uses the Windows certificate store / macOS Keychain / Linux CA directory.
+  If IT already pushed the corporate root CA to your machine (they almost
+  always have), things just work. On Python 3.8/3.9, or if injection
+  fails, ClawMetry logs a line and falls back to Python's default trust.
+* **Relaxed strict validation** — `VERIFY_X509_STRICT` is cleared on the
+  contexts ClawMetry creates. Certificate **verification itself stays on**:
+  hostname checking and chain validation are untouched.
+* **Proxy environment variables** — `HTTPS_PROXY`, `HTTP_PROXY`, and
+  `NO_PROXY` are honored by every outbound call, and re-read at **daemon**
+  start (the daemon is launched by launchd/systemd/Task Scheduler, not
+  your shell, so it can't assume it inherited them).
+
+## Custom CA bundle
+
+If the OS trust store doesn't have your corporate root CA, point ClawMetry
+at a PEM file. It is loaded **in addition to** the normal trust store:
+
+* `CLAWMETRY_CA_BUNDLE=/path/to/corp-root.pem` (env var — wins), or
+* `"ca_bundle": "/path/to/corp-root.pem"` in `~/.clawmetry/config.json`.
+
+The standard `SSL_CERT_FILE` and `REQUESTS_CA_BUNDLE` env vars are also
+honored if already set (precedence: `CLAWMETRY_CA_BUNDLE` > config
+`ca_bundle` > `SSL_CERT_FILE` > `REQUESTS_CA_BUNDLE`).
+
+### Windows walkthrough: exporting the corporate root CA
+
+1. Press <kbd>Win</kbd>+<kbd>R</kbd>, type `certmgr.msc`, press Enter.
+2. Open **Trusted Root Certification Authorities → Certificates**.
+3. Find your company's root CA. It is usually named after your company or
+   the proxy vendor — `clawmetry doctor` prints the exact issuer name to
+   look for.
+4. Right-click it → **All Tasks → Export…** → choose
+   **"Base-64 encoded X.509 (.CER)"** → save it, e.g. `C:\corp-root.cer`.
+5. Set the env var (persistently) and restart the daemon:
+
+   ```bat
+   setx CLAWMETRY_CA_BUNDLE C:\corp-root.cer
+   clawmetry sync restart
+   ```
+
+6. Verify: `clawmetry doctor` should now show all checks green.
+
+On Python 3.10+ with `truststore` active this is usually unnecessary —
+step 0 is simply `pip install --upgrade clawmetry` and re-running doctor.
+
+## Proxy configuration
+
+If your network requires an explicit proxy (doctor's "TCP: direct
+connection failed" + no `HTTPS_PROXY` hint), ask IT for the proxy address
+and set:
+
+```bat
+:: Windows (persistent)
+setx HTTPS_PROXY http://proxy.corp.example:8080
+setx NO_PROXY localhost,127.0.0.1
+```
+
+```bash
+# macOS / Linux
+export HTTPS_PROXY=http://proxy.corp.example:8080
+export NO_PROXY=localhost,127.0.0.1
+```
+
+Then restart the daemon (`clawmetry sync restart`) — the daemon reads
+these at its own startup, so a var set only in your terminal session won't
+reach an already-running daemon.
+
+## Last resort: disabling TLS verification
+
+For a time-boxed pilot where the root CA can't be exported yet:
+
+* `CLAWMETRY_TLS_NO_VERIFY=1` (env), or
+* `"tls_verify": false` in `~/.clawmetry/config.json`.
+
+This disables certificate verification entirely — traffic to
+clawmetry.com can be read or tampered with by anyone on the network path.
+The daemon logs a loud warning on every start while it's active. Use the
+CA-bundle route above instead as soon as possible.
+
+## Quick reference
+
+| Setting | Where | Effect |
+|---|---|---|
+| `clawmetry doctor` | CLI | Diagnose DNS/TCP/proxy/TLS/heartbeat, detect interception |
+| `CLAWMETRY_CA_BUNDLE` | env | Extra PEM CA bundle (highest precedence) |
+| `ca_bundle` | `~/.clawmetry/config.json` | Extra PEM CA bundle |
+| `SSL_CERT_FILE`, `REQUESTS_CA_BUNDLE` | env | Honored if already set |
+| `HTTPS_PROXY` / `HTTP_PROXY` / `NO_PROXY` | env | Outbound proxy routing |
+| `CLAWMETRY_TLS_NO_VERIFY=1` / `tls_verify: false` | env / config | **Insecure** — disable verification (pilot only) |

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 flask>=3.1.3,<4
 duckdb>=1.5.5  # local event store (epic #964 phase 1)
+truststore>=0.8; python_version >= "3.10"  # OS trust store for corporate TLS-interception CAs
 
 # Testing dependencies
 pytest>=9.1.1

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,11 @@ setup(
         # made cloud users silently miss the relay. Now base install so
         # `pip install clawmetry && clawmetry connect` "just works".
         "websocket-client>=1.6",
+        # OS trust store for TLS (Windows CryptoAPI / macOS Security /
+        # Linux CA dir) — makes corporate TLS-interception root CAs
+        # (Zscaler/Netskope/Palo Alto) "just work" without certifi hacks.
+        # Needs 3.10+; on 3.8/3.9 clawmetry.net falls back to stock trust.
+        'truststore>=0.8; python_version >= "3.10"',
     ],
     extras_require={
         "otel": ["opentelemetry-proto>=1.20.0", "protobuf>=4.21.0"],

--- a/tests/test_enterprise_tls.py
+++ b/tests/test_enterprise_tls.py
@@ -1,0 +1,259 @@
+"""
+Enterprise TLS bootstrap tests (clawmetry/net.py + clawmetry/doctor.py).
+
+Covers the corporate TLS-interception fixes:
+  * VERIFY_X509_STRICT (Python 3.13 default-on) is cleared on every context
+    we build — while hostname checking and chain validation stay ON.
+  * CLAWMETRY_CA_BUNDLE env / config ``ca_bundle`` / SSL_CERT_FILE /
+    REQUESTS_CA_BUNDLE are honored, env winning over config.
+  * tls_verify:false / CLAWMETRY_TLS_NO_VERIFY=1 escape hatch.
+  * doctor's issuer classification (public CA vs corporate interception
+    CA) using real DER certificates generated as fixtures.
+
+Pure unit tests — no running server, no network.
+"""
+from __future__ import annotations
+
+import datetime
+import ssl
+
+import pytest
+
+from clawmetry import net
+from clawmetry import doctor
+
+
+# ── fixtures ───────────────────────────────────────────────────────────────
+
+_ENV_VARS = (
+    "CLAWMETRY_CA_BUNDLE", "SSL_CERT_FILE", "REQUESTS_CA_BUNDLE",
+    "CLAWMETRY_TLS_NO_VERIFY",
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch, tmp_path):
+    """Isolate from the developer machine: no TLS env vars, no real config."""
+    for var in _ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setattr(net, "CONFIG_PATH", str(tmp_path / "config.json"))
+    yield
+
+
+def _make_self_signed_pem(tmp_path, name, org, cn):
+    """Generate a self-signed cert PEM; returns (path, cert)."""
+    from cryptography import x509
+    from cryptography.hazmat.primitives import hashes, serialization
+    from cryptography.hazmat.primitives.asymmetric import ec
+    from cryptography.x509.oid import NameOID
+
+    key = ec.generate_private_key(ec.SECP256R1())
+    subject = x509.Name([
+        x509.NameAttribute(NameOID.ORGANIZATION_NAME, org),
+        x509.NameAttribute(NameOID.COMMON_NAME, cn),
+    ])
+    now = datetime.datetime.now(datetime.timezone.utc)
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(subject)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - datetime.timedelta(days=1))
+        .not_valid_after(now + datetime.timedelta(days=365))
+        .add_extension(x509.BasicConstraints(ca=True, path_length=None),
+                       critical=True)
+        .sign(key, hashes.SHA256())
+    )
+    path = tmp_path / (name + ".pem")
+    path.write_bytes(cert.public_bytes(serialization.Encoding.PEM))
+    return str(path), cert
+
+
+def _loaded_ca_subjects(ctx):
+    return {
+        tuple(rdn[0] for rdn in c.get("subject", ()))
+        for c in ctx.get_ca_certs()
+    }
+
+
+def _has_org(ctx, org):
+    return any(
+        ("organizationName", org) in subj for subj in _loaded_ca_subjects(ctx)
+    )
+
+
+# ── strict flag ────────────────────────────────────────────────────────────
+
+@pytest.mark.skipif(not hasattr(ssl, "VERIFY_X509_STRICT"),
+                    reason="ssl build lacks VERIFY_X509_STRICT")
+def test_strict_flag_cleared_on_built_context():
+    ctx = net.build_ssl_context(config={})
+    assert not (ctx.verify_flags & ssl.VERIFY_X509_STRICT)
+
+
+def test_built_context_still_verifies():
+    """Relaxing strict mode must NOT weaken real verification."""
+    ctx = net.build_ssl_context(config={})
+    assert ctx.check_hostname is True
+    assert ctx.verify_mode == ssl.CERT_REQUIRED
+
+
+@pytest.mark.skipif(not hasattr(ssl, "VERIFY_X509_STRICT"),
+                    reason="ssl build lacks VERIFY_X509_STRICT")
+def test_relax_strict_verification_helper():
+    ctx = ssl.create_default_context()
+    ctx.verify_flags |= ssl.VERIFY_X509_STRICT
+    net.relax_strict_verification(ctx)
+    assert not (ctx.verify_flags & ssl.VERIFY_X509_STRICT)
+
+
+# ── CA bundle resolution + loading ────────────────────────────────────────
+
+def test_ca_bundle_env_var(tmp_path, monkeypatch):
+    path, _ = _make_self_signed_pem(tmp_path, "corp", "Contoso IT", "Contoso Root CA")
+    monkeypatch.setenv("CLAWMETRY_CA_BUNDLE", path)
+    ctx = net.build_ssl_context(config={})
+    assert _has_org(ctx, "Contoso IT")
+
+
+def test_ca_bundle_config_key(tmp_path):
+    path, _ = _make_self_signed_pem(tmp_path, "corp", "Initech Sec", "Initech Root")
+    ctx = net.build_ssl_context(config={"ca_bundle": path})
+    assert _has_org(ctx, "Initech Sec")
+
+
+def test_env_wins_over_config(tmp_path, monkeypatch):
+    env_path, _ = _make_self_signed_pem(tmp_path, "env", "EnvCorp", "EnvCorp Root")
+    cfg_path, _ = _make_self_signed_pem(tmp_path, "cfg", "CfgCorp", "CfgCorp Root")
+    monkeypatch.setenv("CLAWMETRY_CA_BUNDLE", env_path)
+    assert net.ca_bundle_path(config={"ca_bundle": cfg_path}) == env_path
+    ctx = net.build_ssl_context(config={"ca_bundle": cfg_path})
+    assert _has_org(ctx, "EnvCorp")
+    assert not _has_org(ctx, "CfgCorp")
+
+
+@pytest.mark.parametrize("var", ["SSL_CERT_FILE", "REQUESTS_CA_BUNDLE"])
+def test_standard_ca_env_vars_honored(tmp_path, monkeypatch, var):
+    path, _ = _make_self_signed_pem(tmp_path, "std", "StdCorp", "StdCorp Root")
+    monkeypatch.setenv(var, path)
+    assert net.ca_bundle_path(config={}) == path
+
+
+def test_missing_bundle_is_skipped_not_fatal(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_CA_BUNDLE", str(tmp_path / "nope.pem"))
+    assert net.ca_bundle_path(config={}) == ""
+    # And building a context with the bad path still succeeds.
+    ctx = net.build_ssl_context(config={})
+    assert ctx.verify_mode == ssl.CERT_REQUIRED
+
+
+# ── escape hatch ───────────────────────────────────────────────────────────
+
+def test_tls_verify_false_config_disables_verification():
+    ctx = net.build_ssl_context(config={"tls_verify": False})
+    assert ctx.check_hostname is False
+    assert ctx.verify_mode == ssl.CERT_NONE
+
+
+def test_tls_no_verify_env_disables_verification(monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_TLS_NO_VERIFY", "1")
+    ctx = net.build_ssl_context(config={})
+    assert ctx.verify_mode == ssl.CERT_NONE
+
+
+def test_verification_on_by_default():
+    assert not net.tls_verify_disabled(config={})
+    ctx = net.build_ssl_context(config={})
+    assert ctx.verify_mode == ssl.CERT_REQUIRED
+
+
+def test_doctor_can_ignore_escape_hatch(monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_TLS_NO_VERIFY", "1")
+    ctx = net.build_ssl_context(config={}, allow_insecure=False)
+    assert ctx.verify_mode == ssl.CERT_REQUIRED
+
+
+# ── bootstrap resilience ───────────────────────────────────────────────────
+
+def test_configure_survives_missing_truststore(monkeypatch):
+    import builtins
+    real_import = builtins.__import__
+
+    def _no_truststore(name, *a, **kw):
+        if name == "truststore":
+            raise ImportError("simulated: no truststore")
+        return real_import(name, *a, **kw)
+
+    monkeypatch.setattr(builtins, "__import__", _no_truststore)
+    ctx = net.configure_outbound_network(config={})
+    assert ctx is not None
+    assert ctx.verify_mode == ssl.CERT_REQUIRED
+
+
+# ── doctor issuer classification (fake cert fixtures) ─────────────────────
+
+CORPORATE_ISSUERS = [
+    ("Zscaler Inc.", "Zscaler Root CA"),
+    ("Netskope Inc", "ca.netskope.com"),
+    ("Palo Alto Networks", "decrypt.paloaltonetworks.com"),
+    ("Contoso Ltd", "Contoso Corporate Proxy CA"),
+]
+
+PUBLIC_ISSUERS = [
+    ("Let's Encrypt", "R11"),
+    ("DigiCert Inc", "DigiCert Global Root G2"),
+    ("Google Trust Services", "WR2"),
+    ("Amazon", "Amazon RSA 2048 M02"),
+]
+
+
+@pytest.mark.parametrize("org,cn", CORPORATE_ISSUERS)
+def test_classify_corporate_issuer_from_der(tmp_path, org, cn):
+    from cryptography.hazmat.primitives import serialization
+    _, cert = _make_self_signed_pem(tmp_path, "c", org, cn)
+    der = cert.public_bytes(serialization.Encoding.DER)
+    issuer = doctor.issuer_name_from_der(der)
+    assert org.split()[0].lower() in issuer.lower()
+    assert doctor.classify_issuer(issuer) == "corporate"
+
+
+@pytest.mark.parametrize("org,cn", PUBLIC_ISSUERS)
+def test_classify_public_issuer_from_der(tmp_path, org, cn):
+    from cryptography.hazmat.primitives import serialization
+    _, cert = _make_self_signed_pem(tmp_path, "p", org, cn)
+    der = cert.public_bytes(serialization.Encoding.DER)
+    issuer = doctor.issuer_name_from_der(der)
+    assert doctor.classify_issuer(issuer) == "public"
+
+
+def test_classify_unknown_or_empty_is_corporate():
+    assert doctor.classify_issuer("") == "corporate"
+    assert doctor.classify_issuer("O=Random Startup MITM,CN=proxy") == "corporate"
+
+
+def test_classify_matches_org_not_cn():
+    """A CN like *.badssl.com must not substring-match the 'ssl.com' entry."""
+    assert doctor.classify_issuer(
+        "CN=*.badssl.com,O=BadSSL,L=San Francisco,ST=California,C=US"
+    ) == "corporate"
+    # But a genuine SSL.com issuer org still classifies public.
+    assert doctor.classify_issuer(
+        "CN=SSL.com TLS RSA Root CA 2022,O=SSL.com,C=US"
+    ) == "public"
+
+
+def test_intercept_vendor_detection():
+    assert doctor.intercept_vendor("O=Zscaler Inc.,CN=Zscaler Root CA") == "zscaler"
+    assert doctor.intercept_vendor("O=Let's Encrypt,CN=R11") == ""
+    # Word boundaries: "cisco" must not match "San Francisco".
+    assert doctor.intercept_vendor("O=BadSSL,L=San Francisco,C=US") == ""
+
+
+def test_windows_fix_text_mentions_export_steps():
+    txt = doctor._windows_fix_text("O=Zscaler Inc.,CN=Zscaler Root CA")
+    assert "TLS interception detected" in txt
+    assert "certmgr.msc" in txt
+    assert "Trusted Root Certification Authorities" in txt
+    assert "Base-64" in txt
+    assert "CLAWMETRY_CA_BUNDLE" in txt

--- a/tests/test_winconsole.py
+++ b/tests/test_winconsole.py
@@ -1,0 +1,75 @@
+"""
+Windows console-window suppression tests (clawmetry/winconsole.py).
+
+The injector is a pure function over Popen kwargs so its logic is
+testable on any OS; the Popen patch itself is exercised on Windows CI
+(sync matrix runs windows-latest).
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+
+from clawmetry import winconsole
+
+
+class _FakeStartupInfo:
+    def __init__(self):
+        self.dwFlags = 0
+        self.wShowWindow = 99
+
+
+def test_inject_adds_no_window_flag():
+    kwargs = {}
+    winconsole.inject_no_window(kwargs, startupinfo_factory=_FakeStartupInfo)
+    assert kwargs["creationflags"] & winconsole.CREATE_NO_WINDOW
+    si = kwargs["startupinfo"]
+    assert si.dwFlags & winconsole.STARTF_USESHOWWINDOW
+    assert si.wShowWindow == winconsole.SW_HIDE
+
+
+def test_inject_preserves_existing_flags():
+    kwargs = {"creationflags": 0x00000200}  # CREATE_NEW_PROCESS_GROUP
+    winconsole.inject_no_window(kwargs, startupinfo_factory=_FakeStartupInfo)
+    assert kwargs["creationflags"] & 0x00000200
+    assert kwargs["creationflags"] & winconsole.CREATE_NO_WINDOW
+
+
+def test_inject_respects_explicit_console_modes():
+    """DETACHED_PROCESS / CREATE_NEW_CONSOLE callers are left alone —
+    CREATE_NO_WINDOW is mutually exclusive with them at the Win32 level
+    (the daemon relaunch in cli._start_subprocess relies on this)."""
+    for explicit in (winconsole.DETACHED_PROCESS, winconsole.CREATE_NEW_CONSOLE):
+        kwargs = {"creationflags": explicit}
+        winconsole.inject_no_window(kwargs, startupinfo_factory=_FakeStartupInfo)
+        assert kwargs["creationflags"] == explicit
+        assert "startupinfo" not in kwargs
+
+
+def test_inject_keeps_caller_startupinfo():
+    mine = _FakeStartupInfo()
+    kwargs = {"startupinfo": mine}
+    winconsole.inject_no_window(kwargs, startupinfo_factory=_FakeStartupInfo)
+    assert kwargs["startupinfo"] is mine
+
+
+def test_hide_is_noop_off_windows():
+    if os.name == "nt":
+        return
+    assert winconsole.hide_child_console_windows() is False
+    assert not getattr(subprocess.Popen.__init__, "_clawmetry_no_window", False)
+
+
+def test_hide_patches_and_is_idempotent_on_windows():
+    if os.name != "nt":
+        return
+    assert winconsole.hide_child_console_windows() is True
+    assert winconsole.hide_child_console_windows() is True  # idempotent
+    assert getattr(subprocess.Popen.__init__, "_clawmetry_no_window", False)
+    # A real child spawns fine through the patched Popen and its
+    # creationflags carried CREATE_NO_WINDOW (no console window).
+    out = subprocess.run(
+        ["cmd", "/c", "echo", "hi"], capture_output=True, text=True, timeout=15
+    )
+    assert out.returncode == 0
+    assert "hi" in out.stdout


### PR DESCRIPTION
## Why

Enterprise Windows machines behind TLS-intercepting proxies (Zscaler/Netskope/Palo Alto) fail every cloud call:

```
WARNING Heartbeat failed: network error POSTing https://ingest.clawmetry.com/ingest/heartbeat:
<urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed:
CA cert does not include key usage extension (_ssl.c:1032)>
```

Two root causes: (1) the proxy re-signs TLS with an internal root CA that's in the Windows cert store but not certifi's bundle; (2) Python 3.13 enables `VERIFY_X509_STRICT` by default, rejecting corporate CAs that lack the keyUsage extension.

## What

Every outbound HTTPS call in the package uses urllib's default opener, so one process-wide bootstrap (**`clawmetry/net.py`**, called at daemon/CLI/dashboard start) covers heartbeat, snapshot push, telemetry, license, connect, update-check:

- **OS trust store** via `truststore.inject_into_ssl()` — guarded, clear fallback log; dep marker `python_version >= "3.10"` so 3.8/3.9 installs are untouched
- **Strict-flag relax**: `ctx.verify_flags &= ~ssl.VERIFY_X509_STRICT` (hasattr-guarded). Hostname checking + chain validation stay ON
- **Custom CA bundle**: `CLAWMETRY_CA_BUNDLE` env / config `ca_bundle` (env wins), plus standard `SSL_CERT_FILE` / `REQUESTS_CA_BUNDLE`; loaded *in addition to* system trust
- **Proxy env**: global opener re-reads `HTTPS_PROXY`/`HTTP_PROXY`/`NO_PROXY` at daemon start (service managers don't inherit the shell env)
- **Escape hatch**: `tls_verify:false` / `CLAWMETRY_TLS_NO_VERIFY=1` with a loud insecure warning on every start
- **`clawmetry doctor`**: DNS → TCP (direct + proxy CONNECT) → TLS → heartbeat POST, pass/fail per step readable on a screen-share; on TLS failure fetches the peer cert (verification off, fetch-only) and prints the issuer chain + "TLS interception detected" with the exact certmgr.msc Base-64 export walkthrough. Exit 0 only when all pass
- **docs/enterprise-networking.md** with the Windows walkthrough

## Verification

- 26 unit tests (`tests/test_enterprise_tls.py`), green on **py3.9 and py3.13**: strict flag cleared while verification stays CERT_REQUIRED, all 4 CA-bundle sources + precedence, escape hatch, bootstrap survives missing truststore, issuer classification vs real DER fixtures (Zscaler/Netskope/PA/Contoso vs Let's Encrypt/DigiCert/GTS/Amazon)
- On py3.13 confirmed: default context has strict ON (repros the customer precondition); our context clears it; truststore injects; global opener installed
- Live `clawmetry doctor` against ingest.clawmetry.com: all green, heartbeat POST → 401 (transport works), exit 0
- Failure path against self-signed.badssl.com: issuer chain printed, interception guidance shown, exit 1. This caught two classifier bugs pre-merge (`*.badssl.com` substring-matching the "ssl.com" public-CA entry; "cisco" matching "San Francisco") — both fixed with regression tests
- `ruff` clean on all new files; changed files compile on 3.9

🤖 Generated with [Claude Code](https://claude.com/claude-code)