### PR TITLE
feat(cli): clawmetry login + cloud-sync on/off toggles, shown in help

### DIFF
--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -5747,6 +5747,89 @@ def _cmd_verify_integrity(args) -> None:
         raise SystemExit(1)
 
 
+def _cmd_login(args) -> None:
+    """clawmetry login — sign in / sign up for ClawMetry Cloud.
+
+    Friendly front door over the existing machinery: already logged in →
+    show account info (same as `clawmetry account`); otherwise run the
+    interactive connect flow (email OTP or Google/GitHub, incl. the
+    headless paste-code path). `connect` stays for scripted/advanced use.
+    """
+    import json as _json
+
+    cfg_path = os.path.expanduser("~/.clawmetry/config.json")
+    api_key = ""
+    try:
+        with open(cfg_path, "r", encoding="utf-8") as f:
+            api_key = (_json.load(f) or {}).get("api_key") or ""
+    except Exception:
+        pass
+    if api_key:
+        print("Already logged in — your account:")
+        print()
+        _cmd_account(args)
+        print()
+        print("Not you? `clawmetry disconnect` first, then `clawmetry login`.")
+        return
+    _cmd_connect(args)
+
+
+def _cmd_cloud_toggle(enable: bool) -> int:
+    """--turn-on-cloud-sync / --turn-off-cloud-sync.
+
+    Pure marker flip: the daemon checks ``is_cloud_disabled()`` on every
+    cloud POST, so the switch takes effect within seconds WITHOUT a daemon
+    restart. OFF keeps the account key (unlike `clawmetry disconnect`) —
+    it only stops data egress; the local dashboard keeps working.
+    """
+    import json as _json
+    from clawmetry import config as _cfg
+
+    if enable:
+        removed = _cfg.enable_cloud()
+        env = os.environ.get("CLAWMETRY_NO_CLOUD", "").strip().lower()
+        if env in ("1", "true", "yes", "on"):
+            print("⚠️  CLAWMETRY_NO_CLOUD=" + env + " is set in the environment.")
+            print("   The marker was removed, but that env var still forces")
+            print("   local-only mode — unset it (and restart the daemon's")
+            print("   service) to actually resume cloud sync.")
+            return 1
+        api_key = ""
+        try:
+            with open(os.path.expanduser("~/.clawmetry/config.json"), "r",
+                      encoding="utf-8") as f:
+                api_key = (_json.load(f) or {}).get("api_key") or ""
+        except Exception:
+            pass
+        if not api_key:
+            print("✅  Cloud sync enabled — but no account is linked yet.")
+            print("    Run `clawmetry login` to sign in / sign up, then the")
+            print("    daemon starts syncing automatically.")
+            return 0
+        print("✅  Cloud sync is ON."
+              + ("  (removed local-only marker)" if removed else "  (was already on)"))
+        print("    The running daemon picks this up within seconds.")
+        print("    Daemon not running? Start it with: clawmetry sync")
+        print("    Dashboard: https://app.clawmetry.com/cloud")
+        return 0
+    # OFF: write the persistent marker (survives updates and restarts).
+    marker = _cfg.NOCLOUD_MARKER_PATH
+    try:
+        os.makedirs(os.path.dirname(marker), exist_ok=True)
+        with open(marker, "w", encoding="utf-8") as f:
+            f.write("cloud sync disabled via clawmetry --turn-off-cloud-sync\n")
+    except Exception as e:
+        print("❌  Could not write the local-only marker: %s" % e)
+        return 1
+    print("✅  Cloud sync is OFF (local-only mode).")
+    print("    • No data leaves this machine — heartbeats and snapshot")
+    print("      uploads stop within seconds (no restart needed).")
+    print("    • The local dashboard at http://localhost:8900 keeps working.")
+    print("    • Your account login is kept; turn back on any time with:")
+    print("        clawmetry --turn-on-cloud-sync")
+    return 0
+
+
 def main() -> None:
     import argparse
     # FAST PATH — `clawmetry hooks …` must dispatch before the dashboard
@@ -5765,6 +5848,13 @@ def main() -> None:
         configure_outbound_network(role="cli")
     except Exception:
         pass
+    # Cloud-sync toggles — plain flags so a non-engineer can flip sync from
+    # any docs snippet without learning subcommands. Handled before all
+    # parsing (position-independent), exit immediately.
+    if "--turn-on-cloud-sync" in sys.argv:
+        raise SystemExit(_cmd_cloud_toggle(True))
+    if "--turn-off-cloud-sync" in sys.argv:
+        raise SystemExit(_cmd_cloud_toggle(False))
     # --v2 opt-in flag for the React SPA scaffold (see clawmetry/v2/routes.py).
     # Strip it from argv so dashboard.main's argparse doesn't choke on it.
     # Sets the env var that dashboard.py checks at blueprint registration time.
@@ -5925,6 +6015,15 @@ def main() -> None:
     )
 
     # connect
+    p_login = sub.add_parser(
+        "login",
+        help="Log in / sign up for ClawMetry Cloud (email or Google/GitHub)",
+    )
+    p_login.add_argument(
+        "--force", action="store_true",
+        help="Offer cloud signup even in local-only mode",
+    )
+
     p_connect = sub.add_parser("connect", help="Activate cloud sync")
     p_connect.add_argument("--key", metavar="cm_xxx", help="API key (skip prompt)")
     p_connect.add_argument(
@@ -6535,6 +6634,7 @@ def main() -> None:
         "onboard",
         "setup",
         "account",
+        "login",
         "connect",
         "disconnect",
         "sync",
@@ -6570,6 +6670,8 @@ def main() -> None:
             _cmd_onboard(args)
         elif args.cmd == "account":
             _cmd_account(args)
+        elif args.cmd == "login":
+            _cmd_login(args)
         elif args.cmd == "connect":
             _cmd_connect(args)
         elif args.cmd == "disconnect":

--- a/dashboard.py
+++ b/dashboard.py
@@ -17876,6 +17876,16 @@ Commands:
   status         Show service status, port, and uptime
   uninstall      Remove the background service
 
+Cloud:
+  login                  Log in / sign up for ClawMetry Cloud (email or Google/GitHub)
+  connect                Activate cloud sync with an API key (scripted/advanced)
+  disconnect             Stop cloud sync and remove the account key
+  doctor                 Diagnose cloud connectivity (DNS/proxy/TLS, detects
+                         corporate TLS interception)
+  --turn-on-cloud-sync   Resume cloud sync (keeps your login)
+  --turn-off-cloud-sync  Pause cloud sync — nothing leaves this machine;
+                         the local dashboard keeps working
+
 Options:
   --port <port>        Port to listen on (default: 8900)
   --host <host>        Host to bind to (default: 127.0.0.1)

--- a/tests/test_cloud_toggles.py
+++ b/tests/test_cloud_toggles.py
@@ -1,0 +1,104 @@
+"""
+`clawmetry login` + `--turn-on-cloud-sync` / `--turn-off-cloud-sync` tests.
+
+The toggles are a pure flip of the ~/.clawmetry/nocloud marker — the daemon
+checks is_cloud_disabled() on every cloud POST, so no restart is involved.
+OFF must keep the account key (only `disconnect` removes it). The help text
+must advertise all of it (explicit product requirement).
+"""
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from clawmetry import cli
+from clawmetry import config as cm_config
+
+
+@pytest.fixture()
+def marker(tmp_path, monkeypatch):
+    path = tmp_path / "nocloud"
+    monkeypatch.setattr(cm_config, "NOCLOUD_MARKER_PATH", str(path))
+    monkeypatch.delenv("CLAWMETRY_NO_CLOUD", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))  # isolate ~/.clawmetry reads
+    return path
+
+
+def test_turn_off_creates_marker_and_keeps_config(marker, tmp_path, capsys):
+    cfg = tmp_path / ".clawmetry" / "config.json"
+    cfg.parent.mkdir(parents=True)
+    cfg.write_text('{"api_key": "cm_test", "node_id": "n1"}')
+    rc = cli._cmd_cloud_toggle(False)
+    assert rc == 0
+    assert marker.is_file()
+    assert cm_config.is_cloud_disabled()
+    # the login/key must survive the toggle (that's the disconnect difference)
+    assert "cm_test" in cfg.read_text()
+    out = capsys.readouterr().out
+    assert "OFF" in out
+    assert "--turn-on-cloud-sync" in out
+
+
+def test_turn_on_removes_marker(marker, tmp_path, capsys):
+    marker.write_text("x")
+    cfg = tmp_path / ".clawmetry" / "config.json"
+    cfg.parent.mkdir(parents=True)
+    cfg.write_text('{"api_key": "cm_test"}')
+    rc = cli._cmd_cloud_toggle(True)
+    assert rc == 0
+    assert not marker.exists()
+    assert not cm_config.is_cloud_disabled()
+    assert "ON" in capsys.readouterr().out
+
+
+def test_turn_on_without_login_points_to_login(marker, capsys):
+    marker.write_text("x")
+    rc = cli._cmd_cloud_toggle(True)
+    assert rc == 0
+    assert not marker.exists()
+    assert "clawmetry login" in capsys.readouterr().out
+
+
+def test_turn_on_warns_when_env_forces_local(marker, monkeypatch, capsys):
+    monkeypatch.setenv("CLAWMETRY_NO_CLOUD", "1")
+    rc = cli._cmd_cloud_toggle(True)
+    assert rc == 1
+    assert "CLAWMETRY_NO_CLOUD" in capsys.readouterr().out
+
+
+def test_toggle_flags_dispatch_from_main(marker, monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["clawmetry", "--turn-off-cloud-sync"])
+    with pytest.raises(SystemExit) as e:
+        cli.main()
+    assert e.value.code == 0
+    assert marker.is_file()
+    monkeypatch.setattr(sys, "argv", ["clawmetry", "--turn-on-cloud-sync"])
+    with pytest.raises(SystemExit) as e:
+        cli.main()
+    assert e.value.code == 0
+    assert not marker.exists()
+
+
+def test_login_subcommand_registered(monkeypatch, capsys):
+    monkeypatch.setattr(sys, "argv", ["clawmetry", "login", "--help"])
+    with pytest.raises(SystemExit) as e:
+        cli.main()
+    assert e.value.code == 0
+    out = capsys.readouterr().out.lower()
+    assert "usage: clawmetry login" in out
+    assert "signup" in out
+
+
+def test_help_text_advertises_cloud_commands():
+    import dashboard
+
+    for token in (
+        "login",
+        "connect",
+        "disconnect",
+        "doctor",
+        "--turn-on-cloud-sync",
+        "--turn-off-cloud-sync",
+    ):
+        assert token in dashboard.HELP_TEXT, token


### PR DESCRIPTION
## Why
Users need a friendly way to (1) sign in / sign up to their cloud account and (2) flip cloud sync on/off without learning the connect/disconnect/nocloud-marker machinery. (Founder request 2026-07-31.)

## What
- **`clawmetry login`** — already logged in → shows account info; otherwise runs the existing interactive connect flow (email OTP / Google/GitHub, incl. headless paste-code). `connect` remains for scripted use.
- **`clawmetry --turn-off-cloud-sync`** — writes the `~/.clawmetry/nocloud` marker; the daemon checks `is_cloud_disabled()` on **every** cloud POST, so egress stops within seconds with no restart. Keeps the account key (unlike `disconnect`); local dashboard keeps working.
- **`clawmetry --turn-on-cloud-sync`** — removes the marker via `config.enable_cloud()`; warns if `CLAWMETRY_NO_CLOUD` env still forces local-only; points at `clawmetry login` when no account is linked yet.
- **`clawmetry --help` / `clawmetry help`** now has a **Cloud** section listing `login` / `connect` / `disconnect` / `doctor` + both toggles — contract-tested so it can't silently regress.

## Verification
- 7 new unit tests (`tests/test_cloud_toggles.py`): marker create/remove, api_key survives OFF, env-force warning path, argv dispatch through `main()`, login parser registration, help-text contract. All green locally (py3.9).
- `clawmetry --help` output visually confirmed to render the Cloud section.
- ruff: zero new findings vs origin/main baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)