### PR TITLE
feat(enterprise): configurable endpoint, self-hosted server mode, OTLP config export, audit export CLI

### DIFF
--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -459,7 +459,8 @@ def _oauth_browser_login(provider: str, input_fn=input, api_call=None) -> str:
     import hashlib as _hashlib
     import base64 as _base64
 
-    app_base = os.environ.get("CLAWMETRY_APP_BASE", "https://app.clawmetry.com").rstrip("/")
+    from clawmetry.endpoints import app_url as _resolve_app_url
+    app_base = _resolve_app_url()
 
     # PKCE: the verifier stays in CLI memory only; only its SHA256 (the
     # challenge) ever leaves this process, in the start URL.
@@ -565,7 +566,8 @@ def _get_api_key_interactive() -> str:
             return line.rstrip("\n")
         return input(prompt)
 
-    INGEST_URL = os.environ.get("CLAWMETRY_INGEST_URL", "https://ingest.clawmetry.com")
+    from clawmetry.endpoints import ingest_url as _resolve_ingest_url
+    INGEST_URL = _resolve_ingest_url()
 
     def _api_call(path, body):
         result, status = _post_json(INGEST_URL.rstrip("/") + path, body)
@@ -719,7 +721,8 @@ def _verify_key_ownership(api_key: str) -> None:
             return _tty.readline().rstrip("\n")
         return input(prompt)
 
-    INGEST_URL = os.environ.get("CLAWMETRY_INGEST_URL", "https://ingest.clawmetry.com")
+    from clawmetry.endpoints import ingest_url as _resolve_ingest_url
+    INGEST_URL = _resolve_ingest_url()
 
     def _api(path, body):
         result, status = _post_json(INGEST_URL.rstrip("/") + path, body)
@@ -996,11 +999,16 @@ def _cmd_connect(args) -> None:
         elif getattr(args, "start_sync_now", False):
             pass  # Key from the authenticated dashboard command — already proven
         else:
-            _verify_key_ownership(api_key)
+            from clawmetry.endpoints import is_custom_endpoint as _is_custom_ep
+            if _is_custom_ep():
+                pass  # Self-hosted server — no email-OTP service; /auth is the gate
+            else:
+                _verify_key_ownership(api_key)
 
     custom_name = getattr(args, "custom_node_id", None) or ""
     machine_hostname = custom_name or socket.gethostname()
     _existing_node_id = _saved_node_id
+    _server_e2e = None
     print("Verifying your account… " if _keep_local_signin
           else "Connecting to ClawMetry Cloud… ", end="", flush=True)
     try:
@@ -1008,6 +1016,10 @@ def _cmd_connect(args) -> None:
             api_key, hostname=machine_hostname, existing_node_id=_existing_node_id
         )
         node_id = result.get("node_id") or machine_hostname
+        # Self-hosted servers may answer {"e2e": false} — data stays inside the
+        # customer deployment, so blob encryption is optional there and the
+        # server needs plaintext to serve fleet views / audit export.
+        _server_e2e = result.get("e2e") if isinstance(result, dict) else None
         print("✅")
     except Exception as e:
         err = str(e)
@@ -1047,11 +1059,20 @@ def _cmd_connect(args) -> None:
         # noise (and printing a "keep this safe" secret mid-Self-Hosted run
         # reads like a cloud signup; founder live-hit 2026-07-30).
         enc_key = _kc_key or _saved_enc_key or generate_encryption_key()
+    # A self-hosted server answering {"e2e": false} opts this node into
+    # plaintext ingest (data never leaves the deployment; the server needs
+    # plaintext for fleet views + audit export). An explicit --enc-key wins.
+    _server_plaintext = (
+        _server_e2e is False and not _enc_key_arg and not _keep_local_signin
+    )
     print()
-    if not _keep_local_signin:
+    if not _keep_local_signin and not _server_plaintext:
         print("🔐 Encryption key protects your data end-to-end.")
     if _keep_local_signin:
         pass  # enc_key already chosen above, silently
+    elif _server_plaintext:
+        enc_key = ""
+        print("🔓 Server requested plaintext ingest (self-hosted, E2E off).")
     elif _enc_key_arg:
         enc_key = _derive_key_for_storage(_enc_key_arg)
         print("  Using provided encryption key.")
@@ -1071,15 +1092,17 @@ def _cmd_connect(args) -> None:
         ).strip()
         enc_key = _derive_key_for_storage(custom_key) if custom_key else generate_encryption_key()
 
-    _keychain_set(node_id, enc_key)  # persist to OS keychain when available
+    if enc_key:
+        _keychain_set(node_id, enc_key)  # persist to OS keychain when available
 
     config = {
         "api_key": api_key,
         "node_id": node_id,
         "platform": platform.system(),
         "connected_at": __import__("datetime").datetime.now().isoformat(),
-        "encryption_key": enc_key,
     }
+    if enc_key:
+        config["encryption_key"] = enc_key
     save_config(config)
 
     # Explicit connect is an opt-in to cloud: clear any local-only marker so the
@@ -1212,7 +1235,9 @@ def _cmd_connect(args) -> None:
     # Open browser with encryption key in URL fragment (never sent to server)
     # The #key=... fragment stays client-side — true E2E encryption
     _node_id = config.get("node_id", "")
-    _dashboard_url = f"https://app.clawmetry.com/cloud?token={api_key}#key={enc_key}&node={_node_id}"
+    from clawmetry.endpoints import app_url as _resolve_app_url2
+    _app_base_done = _resolve_app_url2()
+    _dashboard_url = f"{_app_base_done}/cloud?token={api_key}#key={enc_key}&node={_node_id}"
 
     # Cloud includes the local dashboard too (the onboard copy promises
     # BOTH app.clawmetry.com and localhost:8900) — make it true, best-effort.
@@ -1220,7 +1245,7 @@ def _cmd_connect(args) -> None:
 
     print()
     print("  All done! Opening your dashboard...")
-    print(f"  https://app.clawmetry.com/cloud")
+    print(f"  {_app_base_done}/cloud")
     if _local_dash_up:
         print("  Also on this machine: http://localhost:8900")
     print()
@@ -2057,8 +2082,9 @@ def _cmd_uninstall() -> None:
                 def _purge_server():
                     try:
                         import urllib.request
+                        from clawmetry.endpoints import app_url as _resolve_app_url
                         _req = urllib.request.Request(
-                            "https://app.clawmetry.com/api/unregister",
+                            _resolve_app_url() + "/api/unregister",
                             data=_json_u.dumps({
                                 "node_id": _node_id,
                                 "hostname": _hostname,
@@ -2350,7 +2376,8 @@ def _resolve_account_email(api_key: str):
         import urllib.parse as _up
         import urllib.request as _ur
 
-        base = _os.environ.get("CLAWMETRY_APP_BASE", "https://app.clawmetry.com").rstrip("/")
+        from clawmetry.endpoints import app_url as _resolve_app_url
+        base = _resolve_app_url()
         url = base + "/api/cloud/account?token=" + _up.quote(api_key)
         with _ur.urlopen(url, timeout=2.5) as resp:
             data = _json.loads(resp.read() or b"{}")
@@ -3133,7 +3160,8 @@ def _instant_register(BOLD, GREEN, DIM):
     import socket
     import platform
 
-    INGEST_URL = os.environ.get("CLAWMETRY_INGEST_URL", "https://ingest.clawmetry.com")
+    from clawmetry.endpoints import ingest_url as _resolve_ingest_url
+    INGEST_URL = _resolve_ingest_url()
     url = INGEST_URL.rstrip("/") + "/api/register"
 
     hostname = socket.gethostname()
@@ -3573,7 +3601,8 @@ def _cmd_account(args) -> None:
     import urllib.error
     import json as _json
 
-    INGEST_URL = _os.environ.get("CLAWMETRY_INGEST_URL", "https://ingest.clawmetry.com")
+    from clawmetry.endpoints import ingest_url as _resolve_ingest_url
+    INGEST_URL = _resolve_ingest_url()
 
     def _api_call(path, body):
         result, status = _post_json(INGEST_URL.rstrip("/") + path, body)
@@ -3587,7 +3616,8 @@ def _cmd_account(args) -> None:
     print()
     print(f"  Node:      {node_id}")
     if dashboard_id:
-        print(f"  Dashboard: https://app.clawmetry.com/d/{dashboard_id}")
+        from clawmetry.endpoints import app_url as _resolve_app_url_d
+        print(f"  Dashboard: {_resolve_app_url_d()}/d/{dashboard_id}")
     print(f"  API key:   {api_key[:8]}...")
     print()
 
@@ -3657,7 +3687,8 @@ def _cmd_account(args) -> None:
         print(f" {GREEN('verified')}")
         print(f"\n  {GREEN(BOLD('Email linked to your account!'))}")
         if dashboard_id:
-            print(f"  Dashboard: https://app.clawmetry.com/d/{dashboard_id}")
+            from clawmetry.endpoints import app_url as _resolve_app_url_d
+        print(f"  Dashboard: {_resolve_app_url_d()}/d/{dashboard_id}")
         print()
         return
 
@@ -5830,6 +5861,110 @@ def _cmd_cloud_toggle(enable: bool) -> int:
     return 0
 
 
+def _cmd_export(args) -> None:
+    """``clawmetry export --from <date> --to <date> --format jsonl|csv``.
+
+    Audit/compliance dump of the immutable event log for a time range,
+    fetched from the configured endpoint (managed cloud or a self-hosted
+    Enterprise server — resolution: CLAWMETRY_ENDPOINT env > config
+    ``endpoint`` > cloud default) with the configured credentials.
+
+    The server side is ``GET /api/export/events?from=&to=`` returning JSONL
+    (one event per line). CSV conversion happens client-side so the server
+    contract stays minimal. Exit codes: 0 ok, 1 error.
+    """
+    import csv as _csv
+    import json
+    import urllib.error
+    import urllib.parse
+    import urllib.request
+
+    from clawmetry.endpoints import ingest_url as _resolve_ingest_url
+
+    api_key = os.environ.get("CLAWMETRY_API_KEY", "").strip()
+    if not api_key:
+        try:
+            from clawmetry.sync import CONFIG_FILE as _CFG
+            api_key = json.loads(_CFG.read_text()).get("api_key", "")
+        except Exception:
+            api_key = ""
+    if not api_key:
+        print("❌  No API key. Set CLAWMETRY_API_KEY or run `clawmetry connect` first.")
+        sys.exit(1)
+
+    base = _resolve_ingest_url()
+    query = []
+    if getattr(args, "date_from", None):
+        query.append("from=" + urllib.parse.quote(args.date_from))
+    if getattr(args, "date_to", None):
+        query.append("to=" + urllib.parse.quote(args.date_to))
+    url = base + "/api/export/events"
+    if query:
+        url += "?" + "&".join(query)
+
+    fmt = getattr(args, "format", "jsonl") or "jsonl"
+    out_path = getattr(args, "out", None)
+
+    req = urllib.request.Request(
+        url, headers={"X-Api-Key": api_key, "Accept": "application/x-ndjson"}
+    )
+    try:
+        resp = urllib.request.urlopen(req, timeout=120)
+    except urllib.error.HTTPError as e:
+        if e.code == 404:
+            print(f"❌  {base} does not implement /api/export/events.")
+            print("    Self-hosted servers support it from clawmetry 0.12.602;")
+            print("    for ClawMetry Cloud, contact support to enable audit export.")
+        elif e.code == 401:
+            print("❌  Unauthorized — check your API key against the configured endpoint.")
+        else:
+            print(f"❌  Export failed: HTTP {e.code} {e.reason}")
+        sys.exit(1)
+    except Exception as e:
+        print(f"❌  Could not reach {base}: {e}")
+        sys.exit(1)
+
+    sink = open(out_path, "w", encoding="utf-8", newline="") if out_path else sys.stdout
+    count = 0
+    try:
+        if fmt == "csv":
+            cols = (
+                "id", "node_id", "agent_type", "agent_id", "session_id",
+                "event_type", "ts", "model", "token_count", "cost_usd",
+                "data", "received_at",
+            )
+            writer = _csv.writer(sink)
+            writer.writerow(cols)
+            for raw in resp:
+                line = raw.decode("utf-8", errors="replace").strip()
+                if not line:
+                    continue
+                try:
+                    rec = json.loads(line)
+                except Exception:
+                    continue
+                data = rec.get("data")
+                if isinstance(data, (dict, list)):
+                    data = json.dumps(data, separators=(",", ":"), default=str)
+                writer.writerow(
+                    [rec.get(c) if c != "data" else data for c in cols]
+                )
+                count += 1
+        else:
+            for raw in resp:
+                line = raw.decode("utf-8", errors="replace").rstrip("\n")
+                if line.strip():
+                    sink.write(line + "\n")
+                    count += 1
+    finally:
+        resp.close()
+        if out_path:
+            sink.close()
+
+    dest = out_path or "stdout"
+    print(f"✅  Exported {count} events to {dest}", file=sys.stderr)
+
+
 def main() -> None:
     import argparse
     # FAST PATH — `clawmetry hooks …` must dispatch before the dashboard
@@ -6620,6 +6755,43 @@ def main() -> None:
         ),
     )
 
+    # export — audit/compliance dump of the immutable event log (enterprise)
+    p_export = sub.add_parser(
+        "export",
+        help=(
+            "Export the event log for a time range from the configured "
+            "endpoint (cloud or self-hosted) for compliance handoff"
+        ),
+    )
+    p_export.add_argument(
+        "--from",
+        dest="date_from",
+        default=None,
+        metavar="DATE",
+        help="Start of range (ISO date/datetime, e.g. 2026-07-01)",
+    )
+    p_export.add_argument(
+        "--to",
+        dest="date_to",
+        default=None,
+        metavar="DATE",
+        help="End of range (ISO date/datetime, inclusive)",
+    )
+    p_export.add_argument(
+        "--format",
+        dest="format",
+        choices=["jsonl", "csv"],
+        default="jsonl",
+        help="Output format (default: jsonl)",
+    )
+    p_export.add_argument(
+        "--out",
+        dest="out",
+        default=None,
+        metavar="FILE",
+        help="Write to FILE instead of stdout",
+    )
+
     # Parse just the first token to decide if it's a sub-command or dashboard flag
     # `hooks` is absent from this tuple ON PURPOSE: it's intercepted by the
     # fast path at the top of main() before the dashboard import. The parser
@@ -6658,6 +6830,7 @@ def main() -> None:
         "diagnose",
         "doctor",
         "verify-integrity",
+        "export",
         "nemoclaw-daemons",
     )
     if len(sys.argv) > 1 and sys.argv[1] in _subcmds:
@@ -6719,6 +6892,8 @@ def main() -> None:
             sys.exit(run_doctor(host=getattr(args, "doctor_host", None)))
         elif args.cmd == "verify-integrity":
             _cmd_verify_integrity(args)
+        elif args.cmd == "export":
+            _cmd_export(args)
         elif args.cmd == "nemoclaw-daemons":
             _register_nemoclaw_sandbox_daemons()
     else:

--- a/clawmetry/doctor.py
+++ b/clawmetry/doctor.py
@@ -12,7 +12,6 @@ Exit code 0 only when every check passes.
 """
 from __future__ import annotations
 
-import os
 import socket
 import ssl
 import urllib.error
@@ -183,9 +182,9 @@ def _windows_fix_text(issuer: str) -> str:
 
 def run_doctor(host: str = None, port: int = 443, out=print) -> int:
     """Run all connectivity checks. Returns process exit code (0 = all pass)."""
-    host = host or os.environ.get(
-        "CLAWMETRY_INGEST_URL", "https://" + INGEST_HOST_DEFAULT
-    )
+    if not host:
+        from clawmetry.endpoints import ingest_url as _resolve_ingest_url
+        host = _resolve_ingest_url()
     if "://" in host:
         parsed = urllib.parse.urlparse(host)
         port = parsed.port or 443

--- a/clawmetry/endpoints.py
+++ b/clawmetry/endpoints.py
@@ -1,0 +1,116 @@
+"""
+clawmetry.endpoints — single source of truth for cloud endpoint resolution.
+
+Every daemon/CLI/dashboard network call that targets ClawMetry Cloud must
+resolve its base URL through this module so that a self-hosted ClawMetry
+Enterprise deployment can repoint the whole client with one setting.
+
+Resolution order for the ingest base (first non-empty wins):
+
+    1. CLAWMETRY_ENDPOINT        (env — the enterprise knob)
+    2. CLAWMETRY_INGEST_URL      (env — legacy, kept for back-compat)
+    3. "endpoint" key in ~/.clawmetry/config.json
+    4. https://ingest.clawmetry.com
+
+The app base (OAuth pages, dashboard links, account/claim side-channels)
+follows the same custom endpoint when one is set — a self-hosted server is
+single-host — and only falls back to app.clawmetry.com for the managed cloud:
+
+    1. CLAWMETRY_APP_BASE        (env — legacy, explicit split override)
+    2. CLAWMETRY_ENDPOINT / CLAWMETRY_INGEST_URL (env)
+    3. "endpoint" key in ~/.clawmetry/config.json
+    4. https://app.clawmetry.com
+
+Note: several modules snapshot these values into module-level constants at
+import time (clawmetry.sync.INGEST_URL and friends). Changing the env vars
+after import does not repoint an already-running process — restart the
+daemon/dashboard after changing endpoint configuration. Tests should call
+these functions directly (they re-read env + config on every call).
+"""
+from __future__ import annotations
+
+import json
+import os
+from urllib.parse import urlparse
+
+DEFAULT_INGEST_URL = "https://ingest.clawmetry.com"
+DEFAULT_APP_URL = "https://app.clawmetry.com"
+
+CONFIG_PATH = os.path.expanduser("~/.clawmetry/config.json")
+
+# (mtime, endpoint-value) cache so hot paths (heartbeat every 3s) don't
+# re-parse the config file on every call.
+_cfg_cache: tuple[float, str] | None = None
+
+
+def _config_endpoint() -> str:
+    """The ``endpoint`` key from ~/.clawmetry/config.json, or "". Never raises."""
+    global _cfg_cache
+    try:
+        mtime = os.stat(CONFIG_PATH).st_mtime
+    except OSError:
+        return ""
+    if _cfg_cache is not None and _cfg_cache[0] == mtime:
+        return _cfg_cache[1]
+    value = ""
+    try:
+        with open(CONFIG_PATH, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        if isinstance(data, dict):
+            value = str(data.get("endpoint") or "").strip()
+    except Exception:
+        value = ""
+    _cfg_cache = (mtime, value)
+    return value
+
+
+def _env(name: str) -> str:
+    return os.environ.get(name, "").strip()
+
+
+def ingest_url() -> str:
+    """Base URL for the ingest/data-plane API (/auth, /ingest/*, /api/*)."""
+    return (
+        _env("CLAWMETRY_ENDPOINT")
+        or _env("CLAWMETRY_INGEST_URL")
+        or _config_endpoint()
+        or DEFAULT_INGEST_URL
+    ).rstrip("/")
+
+
+def app_url() -> str:
+    """Base URL for app-side calls (OAuth start, account lookup, dashboard links).
+
+    When a custom endpoint is configured, app-side traffic goes to the same
+    host — a self-hosted deployment is one server. CLAWMETRY_APP_BASE remains
+    an explicit override for split cloud deployments.
+    """
+    return (
+        _env("CLAWMETRY_APP_BASE")
+        or _env("CLAWMETRY_ENDPOINT")
+        or _env("CLAWMETRY_INGEST_URL")
+        or _config_endpoint()
+        or DEFAULT_APP_URL
+    ).rstrip("/")
+
+
+def is_custom_endpoint() -> bool:
+    """True when traffic is repointed away from the managed ClawMetry cloud.
+
+    Used to suppress cloud-only phone-homes (install telemetry, anonymous
+    funnel analytics) so a self-hosted deployment's data never leaves it.
+    """
+    return ingest_url() != DEFAULT_INGEST_URL
+
+
+def endpoint_hosts() -> set[str]:
+    """Hostnames of the configured endpoints (for interceptor self-exclusion)."""
+    hosts = set()
+    for url in (ingest_url(), app_url()):
+        try:
+            host = urlparse(url).hostname
+            if host:
+                hosts.add(host)
+        except Exception:
+            continue
+    return hosts

--- a/clawmetry/insights.py
+++ b/clawmetry/insights.py
@@ -32,6 +32,8 @@ from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any
 
+from clawmetry.endpoints import ingest_url as _resolve_ingest_url
+
 log = logging.getLogger("clawmetry.insights")
 
 # ── Config / paths ─────────────────────────────────────────────────────────
@@ -429,10 +431,10 @@ def _bind_params(now: datetime.datetime) -> dict:
 # error) we fall back to the same "<n> rows" stub that the no-key path
 # already produces. No new failure modes introduced.
 
-# Cloud-relay endpoint. Env override mirrors clawmetry/sync.py + cli.py.
-INGEST_URL = os.environ.get(
-    "CLAWMETRY_INGEST_URL", "https://ingest.clawmetry.com"
-)
+# Cloud-relay endpoint. Resolved via clawmetry.endpoints (CLAWMETRY_ENDPOINT >
+# CLAWMETRY_INGEST_URL > config "endpoint" > managed cloud), snapshotted at
+# import time like clawmetry/sync.py.
+INGEST_URL = _resolve_ingest_url()
 RELAY_SYNTHESIZE_URL = INGEST_URL.rstrip("/") + "/api/insights/synthesize"
 
 

--- a/clawmetry/interceptor.py
+++ b/clawmetry/interceptor.py
@@ -57,6 +57,20 @@ _EXCLUDED_HOST_DEFAULTS = frozenset([
 ])
 
 
+def _clawmetry_endpoint_hosts() -> frozenset:
+    """Hostnames of the *configured* ClawMetry endpoint (self-hosted installs
+    repoint sync away from *.clawmetry.com; those hosts must be excluded too
+    or the interceptor records our own sync traffic as external API calls)."""
+    try:
+        from clawmetry.endpoints import endpoint_hosts
+        return frozenset(endpoint_hosts())
+    except Exception:
+        return frozenset()
+
+
+_EXCLUDED_HOST_DEFAULTS = _EXCLUDED_HOST_DEFAULTS | _clawmetry_endpoint_hosts()
+
+
 # Output file — in ClawMetry's OWN data dir (~/.clawmetry), never inside the
 # agent's ~/.openclaw workspace. ClawMetry is read-only w.r.t. the agent: it
 # must not create or modify files under the agent's dir. The sync daemon tails

--- a/clawmetry/license.py
+++ b/clawmetry/license.py
@@ -300,11 +300,14 @@ def _cloud_base() -> str:
     wheel. ``CLAWMETRY_LICENSE_SERVER`` wins (self-hosted/air-gapped), else the
     cloud ingest app (which also hosts /api/license/*). Always HTTPS in prod;
     the only non-HTTPS values are explicit localhost overrides for tests."""
-    return (
-        os.environ.get("CLAWMETRY_LICENSE_SERVER", "").strip()
-        or os.environ.get("CLAWMETRY_INGEST_URL", "").strip()
-        or _DEFAULT_CLOUD_BASE
-    ).rstrip("/")
+    explicit = os.environ.get("CLAWMETRY_LICENSE_SERVER", "").strip()
+    if explicit:
+        return explicit.rstrip("/")
+    try:
+        from clawmetry.endpoints import ingest_url as _resolve_ingest_url
+        return _resolve_ingest_url()
+    except Exception:
+        return _DEFAULT_CLOUD_BASE
 
 
 def _offline_mode() -> bool:

--- a/clawmetry/otel_exporter.py
+++ b/clawmetry/otel_exporter.py
@@ -4,7 +4,24 @@ Outbound OTLP trace exporter for ClawMetry.
 Exports completed sessions as OpenTelemetry GenAI spans to a configurable
 remote endpoint (Datadog / Grafana / Honeycomb / any OTLP HTTP collector).
 
-Activated when CLAWMETRY_OTEL_EXPORT_ENDPOINT is set. Off by default.
+Activation (off by default):
+
+* env ``CLAWMETRY_OTEL_EXPORT_ENDPOINT`` — dashboard process starts the
+  exporter (``start_exporter()``, the historical path), OR
+* config ``otlp_endpoint`` in ~/.clawmetry/config.json — the sync daemon
+  starts it (``start_exporter(scope="config")``, the enterprise path for
+  headless nodes).
+
+The two scopes are disjoint on purpose: env activates only the dashboard's
+exporter, the config key activates only the daemon's, so a machine running
+both processes never double-exports. Headers/interval follow the same split
+(env CLAWMETRY_OTEL_EXPORT_HEADERS / CLAWMETRY_OTEL_EXPORT_INTERVAL vs
+config ``otlp_headers`` / ``otlp_export_interval``).
+
+This export is IN ADDITION to ClawMetry's own ingest protocol — it mirrors
+agent activity into a customer's Datadog/Grafana/Honeycomb without replacing
+the ClawMetry dashboard.
+
 No new dependencies — uses urllib.request (stdlib) and the DuckDB proxy
 that is already wired for the dashboard process.
 
@@ -12,9 +29,9 @@ GenAI semantic conventions: https://opentelemetry.io/docs/specs/semconv/gen-ai/
 """
 from __future__ import annotations
 
+import hashlib
 import json
 import os
-import secrets
 import threading
 import time
 import urllib.error
@@ -26,6 +43,20 @@ _EXPORT_ENDPOINT_ENV = "CLAWMETRY_OTEL_EXPORT_ENDPOINT"
 _EXPORT_HEADERS_ENV = "CLAWMETRY_OTEL_EXPORT_HEADERS"
 _EXPORT_INTERVAL_ENV = "CLAWMETRY_OTEL_EXPORT_INTERVAL"
 _DEFAULT_INTERVAL_S = 60
+
+_CONFIG_PATH = os.path.expanduser("~/.clawmetry/config.json")
+
+
+def _config_get(key: str, default=None):
+    """Best-effort read of one key from ~/.clawmetry/config.json."""
+    try:
+        with open(_CONFIG_PATH, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        if isinstance(data, dict):
+            return data.get(key, default)
+    except Exception:
+        pass
+    return default
 
 _stats: dict[str, Any] = {
     "endpoint": "",
@@ -68,19 +99,33 @@ def _iso_to_nano(ts: str | None) -> int:
 
 # ── Span builder ───────────────────────────────────────────────────────────
 
+def _trace_id(session_id: str) -> str:
+    """Deterministic 16-byte trace id per session, so tool spans exported in
+    later flushes still land in the same trace."""
+    return hashlib.sha256(("cm-trace:" + session_id).encode()).hexdigest()[:32]
+
+
+def _span_id(seed: str) -> str:
+    return hashlib.sha256(("cm-span:" + seed).encode()).hexdigest()[:16]
+
+
 def _session_to_span(session: dict[str, Any]) -> dict | None:
     """Build one OTLP span dict from a DuckDB session row."""
     sid = session.get("session_id") or ""
     if not sid:
         return None
 
+    system = str(session.get("agent_type") or "openclaw")
     attrs = [
-        _str_attr("gen_ai.system", "openclaw"),
-        _str_attr("gen_ai.operation.name", "session"),
+        _str_attr("gen_ai.system", system),
+        _str_attr("gen_ai.operation.name", "invoke_agent"),
         _str_attr("session.id", sid),
     ]
     if session.get("agent_id"):
+        attrs.append(_str_attr("gen_ai.agent.name", str(session["agent_id"])))
         attrs.append(_str_attr("agent.id", str(session["agent_id"])))
+    if session.get("model"):
+        attrs.append(_str_attr("gen_ai.request.model", str(session["model"])))
     token_count = int(session.get("token_count") or 0)
     if token_count:
         attrs.append(_int_attr("gen_ai.usage.input_tokens", token_count))
@@ -100,15 +145,74 @@ def _session_to_span(session: dict[str, Any]) -> dict | None:
         end_ns = now_ns
 
     return {
-        "traceId": secrets.token_hex(16),
-        "spanId": secrets.token_hex(8),
-        "name": "openclaw.session",
+        "traceId": _trace_id(sid),
+        "spanId": _span_id(sid),
+        "name": f"{system}.session",
         "kind": 2,  # SERVER
         "startTimeUnixNano": str(start_ns),
         "endTimeUnixNano": str(end_ns),
         "attributes": attrs,
         "status": {"code": 1},  # OK
     }
+
+
+def _tool_event_to_span(event: dict[str, Any]) -> list[dict]:
+    """Build child ``execute_tool`` spans from one tool-call event row.
+
+    Uses clawmetry.detectors' shape-tolerant extractor — the same code the
+    approvals watcher trusts — so all four tool-call payload shapes in the
+    wild (top-level, family data.tool_calls[], v3 toolMetas[], content
+    blocks) map correctly.
+    """
+    sid = str(event.get("session_id") or "")
+    if not sid:
+        return []
+    data = event.get("data")
+    if isinstance(data, (bytes, str)):
+        try:
+            data = json.loads(data)
+        except Exception:
+            data = {}
+    if not isinstance(data, dict):
+        data = {}
+    try:
+        from clawmetry.detectors import _iter_tool_calls_from_data
+        calls = list(_iter_tool_calls_from_data(str(event.get("event_type") or ""), data))
+    except Exception:
+        calls = []
+    if not calls:
+        return []
+
+    ts_ns = _iso_to_nano(event.get("ts")) or int(time.time() * 1_000_000_000)
+    system = str(event.get("agent_type") or "openclaw")
+    spans = []
+    for idx, call in enumerate(calls):
+        name = ""
+        if isinstance(call, dict):
+            name = str(
+                call.get("name") or call.get("tool") or call.get("tool_name") or ""
+            )
+        attrs = [
+            _str_attr("gen_ai.system", system),
+            _str_attr("gen_ai.operation.name", "execute_tool"),
+            _str_attr("session.id", sid),
+        ]
+        if name:
+            attrs.append(_str_attr("gen_ai.tool.name", name))
+        spans.append(
+            {
+                "traceId": _trace_id(sid),
+                "spanId": _span_id(f"{event.get('id')}:{idx}"),
+                "parentSpanId": _span_id(sid),
+                "name": f"execute_tool {name}".strip(),
+                "kind": 1,  # INTERNAL
+                "startTimeUnixNano": str(ts_ns),
+                "endTimeUnixNano": str(ts_ns),
+                "attributes": attrs,
+                "status": {"code": 1},
+            }
+        )
+    return spans
 
 
 def _build_payload(spans: list[dict]) -> bytes:
@@ -154,6 +258,19 @@ def _flush_once(endpoint: str, headers: dict) -> int:
     sessions: list[dict] = store.query_sessions(since=since, limit=200) or []
 
     spans = [s for s in (_session_to_span(r) for r in sessions) if s is not None]
+
+    # Child execute_tool spans for tool-call events in the same window.
+    events: list[dict] = []
+    try:
+        events = store.query_events(since=since, limit=500) or []
+    except Exception:
+        events = []
+    for ev in events:
+        try:
+            spans.extend(_tool_event_to_span(ev))
+        except Exception:
+            continue
+
     if not spans:
         return 0
 
@@ -174,9 +291,12 @@ def _flush_once(endpoint: str, headers: dict) -> int:
     except urllib.error.HTTPError as exc:
         raise RuntimeError(f"OTLP HTTP {exc.code}: {exc.reason}") from exc
 
-    # Advance watermark to the most-recent updated_at we just exported.
+    # Advance watermark to the most-recent timestamp we just exported.
     newest = max(
-        (r.get("updated_at") or r.get("started_at") or "" for r in sessions),
+        (
+            *(r.get("updated_at") or r.get("started_at") or "" for r in sessions),
+            *(str(e.get("ts") or "") for e in events),
+        ),
         default="",
     )
     if newest:
@@ -204,30 +324,41 @@ def _export_loop(endpoint: str, headers: dict, interval_s: int) -> None:
 
 # ── Public API ──────────────────────────────────────────────────────────────
 
-def start_exporter() -> bool:
+def start_exporter(scope: str = "env") -> bool:
     """Start the OTLP export daemon thread. Returns True if started.
 
-    Reads configuration from environment variables:
-      CLAWMETRY_OTEL_EXPORT_ENDPOINT  — required; OTLP HTTP/JSON traces URL
-                                         e.g. http://localhost:4318/v1/traces
-      CLAWMETRY_OTEL_EXPORT_HEADERS   — optional JSON dict of extra HTTP headers
-                                         e.g. {"X-API-Key": "tok_xxx"}
-      CLAWMETRY_OTEL_EXPORT_INTERVAL  — optional poll interval in seconds (default 60)
+    ``scope`` picks the activation source (see module docstring — the split
+    keeps a machine running both the dashboard and the daemon from
+    double-exporting):
+
+    * ``"env"``    — dashboard: CLAWMETRY_OTEL_EXPORT_ENDPOINT /
+                     CLAWMETRY_OTEL_EXPORT_HEADERS (JSON dict) /
+                     CLAWMETRY_OTEL_EXPORT_INTERVAL
+    * ``"config"`` — sync daemon: ``otlp_endpoint`` / ``otlp_headers`` /
+                     ``otlp_export_interval`` keys in ~/.clawmetry/config.json
     """
-    endpoint = os.environ.get(_EXPORT_ENDPOINT_ENV, "").strip()
+    if scope == "config":
+        endpoint = str(_config_get("otlp_endpoint") or "").strip()
+        headers = _config_get("otlp_headers") or {}
+        if not isinstance(headers, dict):
+            headers = {}
+        raw_interval = _config_get("otlp_export_interval", _DEFAULT_INTERVAL_S)
+    else:
+        endpoint = os.environ.get(_EXPORT_ENDPOINT_ENV, "").strip()
+        raw_headers = os.environ.get(_EXPORT_HEADERS_ENV, "").strip()
+        try:
+            headers = json.loads(raw_headers) if raw_headers else {}
+            if not isinstance(headers, dict):
+                headers = {}
+        except Exception:
+            headers = {}
+        raw_interval = os.environ.get(_EXPORT_INTERVAL_ENV, _DEFAULT_INTERVAL_S)
+
     if not endpoint:
         return False
 
-    raw_headers = os.environ.get(_EXPORT_HEADERS_ENV, "").strip()
     try:
-        headers: dict = json.loads(raw_headers) if raw_headers else {}
-        if not isinstance(headers, dict):
-            headers = {}
-    except Exception:
-        headers = {}
-
-    try:
-        interval_s = max(5, int(os.environ.get(_EXPORT_INTERVAL_ENV, _DEFAULT_INTERVAL_S)))
+        interval_s = max(5, int(raw_interval))
     except (ValueError, TypeError):
         interval_s = _DEFAULT_INTERVAL_S
 

--- a/clawmetry/selfhosted.py
+++ b/clawmetry/selfhosted.py
@@ -1,0 +1,194 @@
+"""
+clawmetry.selfhosted — ClawMetry Enterprise single-tenant server mode.
+
+Activated with ``SELF_HOSTED=true`` (or ``CLAWMETRY_SELF_HOSTED=true``).
+When on, the dashboard process additionally registers the self-hosted
+ingest blueprint (routes/selfhosted_ingest.py) so one container serves
+both the UI and the ingest API that the node daemons push to, and the
+cloud-only surfaces (managed-cloud signup CTA, install telemetry,
+anonymous analytics) are disabled.
+
+Auth model (deliberately simple, env-configured — no multi-tenant IdP):
+
+* ``CLAWMETRY_API_TOKENS``  — comma-separated node tokens. Daemons connect
+  with one of these (``clawmetry connect --key cm_...``). Tokens must start
+  with ``cm_`` (the CLI enforces that prefix).
+* ``CLAWMETRY_ADMIN_USER`` / ``CLAWMETRY_ADMIN_PASSWORD`` — HTTP Basic
+  credentials for admin/read endpoints (audit export, node list).
+
+Outbound traffic policy: a self-hosted deployment makes NO calls to
+clawmetry.com, with one optional, off-by-default exception — the
+license/version ping (``CLAWMETRY_LICENSE_PING=1``). The ping payload is
+exactly::
+
+    {
+      "kind":    "selfhosted_ping",
+      "version": "<clawmetry package version>",
+      "license": "<'sub' claim of the activated license, or ''>",
+      "tier":    "<license tier, or ''>",
+      "ts":      "<ISO-8601 UTC>"
+    }
+
+No hostnames, node ids, counts, or telemetry of any kind — just enough to
+check the license against revocation and surface available updates. It
+POSTs to https://app.clawmetry.com/api/license/ping once every 24h.
+"""
+from __future__ import annotations
+
+import base64
+import hmac
+import logging
+import os
+import threading
+
+log = logging.getLogger("clawmetry.selfhosted")
+
+_TRUTHY = frozenset({"1", "true", "yes", "on"})
+
+_LICENSE_PING_URL = "https://app.clawmetry.com/api/license/ping"
+_LICENSE_PING_INTERVAL_S = 24 * 3600
+
+
+def _env_truthy(name: str) -> bool:
+    return os.environ.get(name, "").strip().lower() in _TRUTHY
+
+
+def is_self_hosted() -> bool:
+    """True when this process runs as a ClawMetry Enterprise self-hosted server."""
+    return _env_truthy("SELF_HOSTED") or _env_truthy("CLAWMETRY_SELF_HOSTED")
+
+
+def e2e_enabled() -> bool:
+    """Whether this self-hosted server asks nodes to E2E-encrypt blobs.
+
+    Default OFF: data already stays inside the customer deployment, and
+    plaintext ingest is what makes server-side fleet views and audit export
+    meaningful. Set CLAWMETRY_SELF_HOSTED_E2E=1 to keep client-side blob
+    encryption (the server then stores opaque ciphertext and audit export
+    only contains envelope metadata).
+    """
+    return _env_truthy("CLAWMETRY_SELF_HOSTED_E2E")
+
+
+def api_tokens() -> list[str]:
+    """Node API tokens accepted by the ingest API (CLAWMETRY_API_TOKENS)."""
+    raw = os.environ.get("CLAWMETRY_API_TOKENS", "")
+    return [t.strip() for t in raw.split(",") if t.strip()]
+
+
+def check_api_key(key) -> bool:
+    """Constant-time membership check of ``key`` against CLAWMETRY_API_TOKENS."""
+    if not key:
+        return False
+    key = str(key)
+    ok = False
+    for token in api_tokens():
+        # No early exit — compare every configured token.
+        if hmac.compare_digest(key, token):
+            ok = True
+    return ok
+
+
+def admin_credentials() -> tuple[str, str]:
+    return (
+        os.environ.get("CLAWMETRY_ADMIN_USER", "").strip(),
+        os.environ.get("CLAWMETRY_ADMIN_PASSWORD", ""),
+    )
+
+
+def check_admin_basic_auth(header_value) -> bool:
+    """Validate an ``Authorization: Basic ...`` header against the env creds."""
+    user, password = admin_credentials()
+    if not user or not password:
+        return False
+    if not header_value or not str(header_value).startswith("Basic "):
+        return False
+    try:
+        decoded = base64.b64decode(str(header_value)[6:]).decode("utf-8")
+        got_user, _, got_pass = decoded.partition(":")
+    except Exception:
+        return False
+    return hmac.compare_digest(got_user, user) and hmac.compare_digest(
+        got_pass, password
+    )
+
+
+def check_admin_or_token(request) -> bool:
+    """Auth gate for read/export endpoints: admin Basic auth OR a node token."""
+    if check_admin_basic_auth(request.headers.get("Authorization")):
+        return True
+    return check_api_key(request.headers.get("X-Api-Key"))
+
+
+# ── Optional license/version ping (off by default) ──────────────────────────
+
+_ping_thread_started = False
+
+
+def _license_ping_payload() -> dict:
+    from datetime import datetime, timezone
+
+    version = ""
+    try:
+        import importlib.metadata
+
+        version = importlib.metadata.version("clawmetry")
+    except Exception:
+        pass
+    sub = tier = ""
+    try:
+        from clawmetry.license import load_license
+
+        lic = load_license() or {}
+        sub = str(lic.get("sub") or "")
+        tier = str(lic.get("tier") or "")
+    except Exception:
+        pass
+    return {
+        "kind": "selfhosted_ping",
+        "version": version,
+        "license": sub,
+        "tier": tier,
+        "ts": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+def _license_ping_loop() -> None:
+    import json
+    import time
+    import urllib.request
+
+    while True:
+        try:
+            body = json.dumps(_license_ping_payload()).encode("utf-8")
+            req = urllib.request.Request(
+                _LICENSE_PING_URL,
+                data=body,
+                method="POST",
+                headers={"Content-Type": "application/json"},
+            )
+            with urllib.request.urlopen(req, timeout=10) as resp:
+                resp.read()
+        except Exception as exc:
+            log.debug("license ping failed: %s", exc)
+        time.sleep(_LICENSE_PING_INTERVAL_S)
+
+
+def maybe_start_license_ping() -> bool:
+    """Start the daily license/version ping IF explicitly enabled.
+
+    Off by default: a self-hosted deployment phones home to nothing. The
+    exact payload is documented in the module docstring. Returns True when
+    the ping thread was started.
+    """
+    global _ping_thread_started
+    if _ping_thread_started:
+        return True
+    if not _env_truthy("CLAWMETRY_LICENSE_PING"):
+        return False
+    t = threading.Thread(
+        target=_license_ping_loop, daemon=True, name="selfhosted-license-ping"
+    )
+    t.start()
+    _ping_thread_started = True
+    return True

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -295,7 +295,12 @@ def _validate_log_offsets(state: dict, paths: dict) -> None:
             log.warning(f"Could not validate offset for {fname}: {e}")
 
 
-INGEST_URL = os.environ.get("CLAWMETRY_INGEST_URL", "https://ingest.clawmetry.com")
+# Resolved through clawmetry.endpoints (env CLAWMETRY_ENDPOINT >
+# env CLAWMETRY_INGEST_URL > config "endpoint" > managed cloud). Snapshotted
+# at import time — approvals.py and tests import this constant directly.
+from clawmetry.endpoints import ingest_url as _resolve_ingest_url
+
+INGEST_URL = _resolve_ingest_url()
 CONFIG_DIR = Path.home() / ".clawmetry"
 CONFIG_FILE = CONFIG_DIR / "config.json"
 STATE_FILE = CONFIG_DIR / "sync-state.json"
@@ -17609,7 +17614,9 @@ def start_event_streamer(config: dict, state: dict, paths: dict) -> threading.Th
     return t
 
 
-_APP_BASE = os.environ.get("CLAWMETRY_APP_BASE", "https://app.clawmetry.com").rstrip("/")
+from clawmetry.endpoints import app_url as _resolve_app_url
+
+_APP_BASE = _resolve_app_url()
 
 
 def _is_placeholder_email(email) -> bool:
@@ -17709,6 +17716,16 @@ def run_daemon() -> None:
         configure_outbound_network(role="daemon")
     except Exception as _net_e:
         log.warning("TLS/proxy bootstrap failed: %s", _net_e)
+    # Outbound OTLP exporter (enterprise): activated by the ``otlp_endpoint``
+    # key in ~/.clawmetry/config.json. scope="config" is daemon-only — the
+    # dashboard's env-var-activated exporter is a separate scope, so both
+    # processes never double-export. No-op when the key is unset.
+    try:
+        from clawmetry.otel_exporter import start_exporter as _start_otel
+        if _start_otel(scope="config"):
+            log.info("OTLP exporter started (config otlp_endpoint)")
+    except Exception as _otel_e:
+        log.warning("OTLP exporter not started: %s", _otel_e)
     # Windows: the daemon runs DETACHED (no console), so unpatched child
     # processes (pip update check, node --version, disk probes) each flash
     # a visible cmd window. Patch Popen once so children stay windowless.

--- a/clawmetry/telemetry.py
+++ b/clawmetry/telemetry.py
@@ -273,6 +273,24 @@ def _mark_pinged(install_id: str) -> None:
         pass
 
 
+def _resolve_telemetry_url() -> str:
+    """Telemetry URL to post to, or "" when pings must not fire.
+
+    A custom endpoint (self-hosted / enterprise, see clawmetry.endpoints)
+    means data stays inside the deployment: skip the managed-cloud install
+    pings entirely unless CLAWMETRY_TELEMETRY_URL is explicitly set."""
+    url = os.environ.get("CLAWMETRY_TELEMETRY_URL", "")
+    if url:
+        return url
+    try:
+        from clawmetry.endpoints import is_custom_endpoint
+        if is_custom_endpoint():
+            return ""
+    except Exception:
+        pass
+    return TELEMETRY_URL_DEFAULT
+
+
 def _send_in_background(version: str) -> None:
     """Worker that runs on the daemon thread. Fully isolated — no
     raised exception can bubble back to the caller."""
@@ -286,7 +304,9 @@ def _send_in_background(version: str) -> None:
         if event is None:
             return
         payload = _build_payload(version, event=event)
-        url = os.environ.get("CLAWMETRY_TELEMETRY_URL", TELEMETRY_URL_DEFAULT)
+        url = _resolve_telemetry_url()
+        if not url:
+            return
         _post(payload, url)
         _record_reported(install_id, version, event)
     except Exception as e:
@@ -304,7 +324,9 @@ def _send_event_in_background(event: str, version: str, extra: dict | None) -> N
         if not install_id:
             return
         payload = _build_payload(version, event=event, extra=extra)
-        url = os.environ.get("CLAWMETRY_TELEMETRY_URL", TELEMETRY_URL_DEFAULT)
+        url = _resolve_telemetry_url()
+        if not url:
+            return
         _post(payload, url)
     except Exception as e:
         log.debug("telemetry: event background failure: %s", e)

--- a/dashboard.py
+++ b/dashboard.py
@@ -11754,6 +11754,20 @@ def detect_config(args=None):
     app.register_blueprint(bp_reasoning)
     app.register_blueprint(bp_plugins)
     app.register_blueprint(bp_local_query)
+    # ClawMetry Enterprise self-hosted server mode: one process serves the
+    # dashboard AND the ingest API the node daemons push to. Gated hard on
+    # SELF_HOSTED=true — never registered for normal local/cloud installs.
+    try:
+        from clawmetry.selfhosted import is_self_hosted as _is_self_hosted
+        if _is_self_hosted():
+            from routes.selfhosted_ingest import bp_selfhosted
+            app.register_blueprint(bp_selfhosted)
+            from clawmetry.selfhosted import maybe_start_license_ping
+            if maybe_start_license_ping():
+                print("  SelfHosted: [ok] license/version ping enabled (daily)")
+            print("  SelfHosted: [ok] ingest API registered (/auth, /ingest/*)")
+    except Exception as _sh_exc:
+        print(f"  SelfHosted: [warn] not registered: {_sh_exc}")
     app.register_blueprint(bp_dives)
     app.register_blueprint(bp_reports)
     app.register_blueprint(bp_scheduler)
@@ -18228,7 +18242,8 @@ def _start_oauth_bridge(provider):
                          "node_id": "", "enc_key": "", "error": "Unsupported provider"}
         return None
 
-    app_base = os.environ.get("CLAWMETRY_APP_BASE", "https://app.clawmetry.com").rstrip("/")
+    from clawmetry.endpoints import app_url as _resolve_app_url
+    app_base = _resolve_app_url()
     captured = {}
 
     class _Handler(http.server.BaseHTTPRequestHandler):

--- a/deploy/self-hosted/README.md
+++ b/deploy/self-hosted/README.md
@@ -1,0 +1,132 @@
+# ClawMetry Enterprise, self-hosted deployment
+
+Single-tenant ClawMetry inside your VPC or on-prem box. One container serves
+the dashboard UI **and** the ingest API your node daemons push to. Data never
+leaves the deployment (see "What leaves the box" below).
+
+## Requirements
+
+- Docker + Docker Compose v2 (`docker compose`)
+- 1 vCPU / 1 GB RAM is plenty for tens of nodes; disk sized to your event
+  retention (events are small JSON rows; budget ~1 GB per 5M events)
+- A TLS-terminating reverse proxy (nginx/Caddy/ALB) in front of port 8900 if
+  nodes connect across the network, the container itself speaks plain HTTP
+
+## One-command start
+
+```bash
+cd deploy/self-hosted
+cat > .env <<'EOF'
+CLAWMETRY_API_TOKENS=cm_generate_a_long_random_token_here
+CLAWMETRY_ADMIN_USER=admin
+CLAWMETRY_ADMIN_PASSWORD=generate_a_long_random_password
+EOF
+docker compose up -d
+```
+
+Verify:
+
+```bash
+curl -u admin:...password... http://localhost:8900/api/selfhosted/status
+```
+
+## Connect nodes
+
+On each machine running agents:
+
+```bash
+pip install clawmetry
+CLAWMETRY_ENDPOINT=https://clawmetry.internal.example \
+  clawmetry connect --key cm_generate_a_long_random_token_here
+```
+
+`CLAWMETRY_ENDPOINT` can also be persisted as the `"endpoint"` key in
+`~/.clawmetry/config.json` on the node. Resolution order everywhere:
+`CLAWMETRY_ENDPOINT` env > `CLAWMETRY_INGEST_URL` env (legacy) > config
+`endpoint` > managed cloud default.
+
+Tokens must start with `cm_` (the CLI enforces the prefix). Multiple tokens
+are comma-separated in `CLAWMETRY_API_TOKENS`; rotate by adding the new token,
+re-connecting nodes, then removing the old one and restarting the server.
+
+Each node keeps its own full local dashboard at `localhost:8900` as usual.
+The self-hosted server records every node's heartbeats, sessions, and events
+(SQLite) and serves fleet-level APIs: `/api/selfhosted/nodes`,
+`/api/selfhosted/status`, `/api/export/events`.
+
+## E2E encryption trade-off
+
+By default the server answers `/auth` with `"e2e": false`, so nodes send
+events in plaintext **inside your deployment**, that is what makes
+server-side audit export and fleet queries meaningful. Set
+`CLAWMETRY_SELF_HOSTED_E2E=1` to keep client-side AES-256-GCM blob
+encryption instead; the server then stores opaque ciphertext and audit
+export contains only envelope metadata (node ids, timestamps, paths).
+
+## What leaves the box
+
+Outbound calls from a self-hosted deployment: **none**, with one optional
+exception. If you set `CLAWMETRY_LICENSE_PING=1`, the server POSTs once per
+24h to `https://app.clawmetry.com/api/license/ping` exactly this payload:
+
+```json
+{"kind": "selfhosted_ping", "version": "<package version>",
+ "license": "<license 'sub' claim or empty>", "tier": "<license tier or empty>",
+ "ts": "<ISO-8601>"}
+```
+
+No hostnames, node ids, counts, event data, or metrics, ever. The ping is
+off by default. Node daemons pointed at your endpoint make no calls to
+clawmetry.com either (install telemetry and anonymous analytics
+short-circuit when a custom endpoint is configured).
+
+## Audit export
+
+```bash
+# JSONL (one event per line)
+curl -u admin:... "http://localhost:8900/api/export/events?from=2026-07-01&to=2026-07-31" \
+  > events.jsonl
+
+# Or from any workstation with the CLI:
+CLAWMETRY_ENDPOINT=https://clawmetry.internal.example \
+CLAWMETRY_API_KEY=cm_... \
+  clawmetry export --from 2026-07-01 --to 2026-07-31 --format csv --out events.csv
+```
+
+The export reads the append-only event log (`ingest_log` + `events` tables);
+rows are never updated or deleted by the server.
+
+## Upgrade path
+
+```bash
+cd deploy/self-hosted
+git pull                      # or check out the release tag you validated
+docker compose build --pull
+docker compose up -d          # recreates the container; the volume persists
+```
+
+Schema migrations are additive (`CREATE TABLE IF NOT EXISTS`); downgrades are
+not supported, snapshot the volume before upgrading (see Backups).
+
+## Backups
+
+All state lives on the `clawmetry-data` volume (`/root/.clawmetry` in the
+container): `selfhosted.db` (SQLite ingest/audit store), `events.duckdb`
+(local event store), `config.json`. SQLite in WAL mode is safe to back up
+with:
+
+```bash
+docker compose exec clawmetry \
+  sqlite3 /root/.clawmetry/selfhosted.db ".backup /root/.clawmetry/backup.db"
+docker cp "$(docker compose ps -q clawmetry)":/root/.clawmetry/backup.db ./
+```
+
+or stop the container and snapshot the whole volume. Test restores by
+mounting the volume into a scratch compose project.
+
+## Scope notes (v1)
+
+- The fleet-level UI is intentionally minimal (JSON APIs); each node's own
+  dashboard remains the rich per-node UI. Full multi-node dashboard parity
+  with ClawMetry Cloud is on the Enterprise roadmap.
+- No Kubernetes/Helm yet, this compose file is the supported deployment.

--- a/deploy/self-hosted/docker-compose.yml
+++ b/deploy/self-hosted/docker-compose.yml
@@ -1,0 +1,50 @@
+# ClawMetry Enterprise, self-hosted, single-tenant deployment.
+#
+# One command:   docker compose up -d
+# Then point each node at this server:
+#   CLAWMETRY_ENDPOINT=https://clawmetry.internal.example clawmetry connect --key cm_...
+#
+# One container serves both the dashboard UI and the ingest API the node
+# daemons push to (SELF_HOSTED=true registers the ingest blueprint). The
+# database is embedded (SQLite for the ingest/audit store, DuckDB for the
+# local event store) and lives on the named volume, no external DB server
+# required. See README.md in this directory for auth setup, upgrades, and
+# backups.
+
+services:
+  clawmetry:
+    build:
+      context: ../..
+    image: clawmetry-selfhosted:latest
+    restart: unless-stopped
+    ports:
+      - "8900:8900"
+    environment:
+      SELF_HOSTED: "true"
+      # ── Auth (REQUIRED, set real values in .env or here) ────────────────
+      # Node tokens (comma-separated, each must start with cm_):
+      CLAWMETRY_API_TOKENS: "${CLAWMETRY_API_TOKENS:?set node tokens, e.g. cm_change_me}"
+      # Admin credentials for audit export / node list / relay reads:
+      CLAWMETRY_ADMIN_USER: "${CLAWMETRY_ADMIN_USER:?set admin user}"
+      CLAWMETRY_ADMIN_PASSWORD: "${CLAWMETRY_ADMIN_PASSWORD:?set admin password}"
+      # ── Privacy: nothing leaves this deployment ──────────────────────────
+      CLAWMETRY_NO_TELEMETRY: "1"
+      CLAWMETRY_NO_CLOUD: "1"
+      # Optional, OFF by default: daily license/version ping to
+      # app.clawmetry.com (payload documented in clawmetry/selfhosted.py).
+      # CLAWMETRY_LICENSE_PING: "1"
+      # ── Optional: ask nodes to E2E-encrypt blobs (server then stores
+      # opaque ciphertext; audit export contains envelope metadata only) ────
+      # CLAWMETRY_SELF_HOSTED_E2E: "1"
+    volumes:
+      # ~/.clawmetry inside the container (HOME=/root): SQLite ingest/audit
+      # store, DuckDB event store, config, logs.
+      - clawmetry-data:/root/.clawmetry
+    healthcheck:
+      test: ["CMD-SHELL", "python3 -c \"import urllib.request; urllib.request.urlopen('http://localhost:8900/api/health', timeout=5)\""]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
+volumes:
+  clawmetry-data:

--- a/docs/enterprise.md
+++ b/docs/enterprise.md
@@ -1,0 +1,138 @@
+# ClawMetry Enterprise
+
+Self-hosting, endpoint configuration, OpenTelemetry export, and audit export: the features that let ClawMetry run inside an enterprise boundary without
+touching the managed cloud.
+
+## Endpoint configuration
+
+Every daemon/CLI/dashboard call to ClawMetry Cloud resolves its base URL
+through `clawmetry/endpoints.py`. Resolution order (first non-empty wins):
+
+1. `CLAWMETRY_ENDPOINT` (env)
+2. `CLAWMETRY_INGEST_URL` (env, legacy, still honored)
+3. `"endpoint"` key in `~/.clawmetry/config.json`
+4. `https://ingest.clawmetry.com` (managed cloud default)
+
+App-side traffic (OAuth pages, account lookups, dashboard links) follows a
+custom endpoint too, a self-hosted server is one host. `CLAWMETRY_APP_BASE`
+remains an explicit override for split deployments;
+`CLAWMETRY_LICENSE_SERVER` still overrides the license/pro-wheel server
+specifically.
+
+```jsonc
+// ~/.clawmetry/config.json, only ADDS keys, existing format unchanged
+{
+  "api_key": "cm_...",
+  "node_id": "build-box-3",
+  "endpoint": "https://clawmetry.internal.example",  // NEW (optional)
+  "otlp_endpoint": "http://otel-collector:4318/v1/traces", // NEW (optional)
+  "otlp_headers": {"X-API-Key": "..."},                    // NEW (optional)
+  "otlp_export_interval": 60                                // NEW (optional)
+}
+```
+
+Endpoint values are snapshotted at process start (module constants): restart the daemon/dashboard after changing them.
+
+When a custom endpoint is configured, the cloud-only phone-homes
+short-circuit: install telemetry and anonymous funnel analytics are skipped
+entirely (see `clawmetry/telemetry.py`, `routes/meta.py:_anon_forward_cloud`).
+
+## Self-hosted deployment (ClawMetry Enterprise)
+
+Single-tenant server for a customer VPC or on-prem box. See
+[`deploy/self-hosted/README.md`](../deploy/self-hosted/README.md) for the
+runbook; short version:
+
+```bash
+cd deploy/self-hosted
+# set CLAWMETRY_API_TOKENS / CLAWMETRY_ADMIN_USER / CLAWMETRY_ADMIN_PASSWORD in .env
+docker compose up -d
+# on each node:
+CLAWMETRY_ENDPOINT=https://clawmetry.internal.example clawmetry connect --key cm_...
+```
+
+`SELF_HOSTED=true` makes the dashboard process additionally register
+`routes/selfhosted_ingest.py`, the server side of the daemon's sync
+protocol (`/auth`, `/ingest/heartbeat`, `/ingest/events`, `/ingest/cache`,
+relay read-back, approvals) backed by an append-only SQLite store, plus
+fleet endpoints (`/api/selfhosted/nodes`, `/api/selfhosted/status`) and the
+audit export API. Auth is deliberately simple and single-tenant: node
+tokens (`CLAWMETRY_API_TOKENS`) + one admin Basic-auth user
+(`CLAWMETRY_ADMIN_USER`/`CLAWMETRY_ADMIN_PASSWORD`). Open self-registration
+(`/api/register`) is disabled; heartbeats always answer `plan:
+"enterprise"` (no billing, no trials).
+
+E2E encryption is optional in self-hosted mode (`CLAWMETRY_SELF_HOSTED_E2E`,
+default off → plaintext inside the deployment, which enables server-side
+fleet queries and meaningful audit export).
+
+## OpenTelemetry export
+
+Two complementary OTLP surfaces, both **in addition to** ClawMetry's own
+ingest protocol, so a customer's Datadog/Grafana/Honeycomb sees agent
+activity without replacing the ClawMetry dashboard:
+
+* **Traces push** (`clawmetry/otel_exporter.py`), agent sessions as GenAI
+  `invoke_agent` spans (`gen_ai.system`, `gen_ai.agent.name`,
+  `gen_ai.request.model`, `gen_ai.usage.input_tokens`,
+  `clawmetry.cost_usd`) with `execute_tool` child spans per tool call
+  (`gen_ai.tool.name`). Deterministic trace/span ids per session. Activate
+  with the `otlp_endpoint` config key (daemon-hosted, headless-safe) or the
+  `CLAWMETRY_OTEL_EXPORT_ENDPOINT` env var (dashboard-hosted, the
+  historical path). The scopes are disjoint so both processes never
+  double-export.
+* **Logs push / pull**, existing Pro feature: OTLP `logRecords` push
+  (`CLAWMETRY_OTLP_ENDPOINT`, see `docs/OTEL_PUSH_EXPORTER.md`) and the
+  `GET /api/otel/export` pull endpoint.
+
+## Audit export
+
+```bash
+clawmetry export --from 2026-07-01 --to 2026-07-31 --format jsonl > events.jsonl
+clawmetry export --from 2026-07-01 --to 2026-07-31 --format csv --out events.csv
+```
+
+Dumps the immutable event log for a time range from the configured endpoint
+(cloud or self-hosted) using the configured credentials (`CLAWMETRY_API_KEY`
+env or config `api_key`). The wire contract is
+`GET <endpoint>/api/export/events?from=&to=` returning JSONL; CSV conversion
+is client-side. Self-hosted servers implement it natively; the export reads
+append-only tables that the server never updates or deletes.
+
+## Data flow
+
+**Managed cloud mode**, the sync daemon on each node ingests runtime
+artifacts (session JSONL, gateway WebSocket, optional OTLP) into local
+DuckDB, then pushes to `ingest.clawmetry.com` over HTTPS: plaintext
+heartbeat metadata (node id, versions, counters, cache keys) plus
+AES-256-GCM-encrypted blobs (events, logs, memory, snapshots) whose key
+never leaves the node, the browser decrypts client-side. Optional
+outbound extras: install telemetry ping (opt-out), OTLP export to a
+collector you configure.
+
+**Self-hosted mode**, identical daemon, but every byte goes to *your*
+endpoint instead: `CLAWMETRY_ENDPOINT` → your server → SQLite/DuckDB on
+your volume. Nothing is sent to clawmetry.com: telemetry and analytics
+short-circuit on a custom endpoint, and the only optional exception is the
+off-by-default daily license/version ping (`CLAWMETRY_LICENSE_PING=1`),
+whose exact 5-field payload (version, license id, tier, timestamp, kind) is
+documented in `clawmetry/selfhosted.py` and the deploy README. OTLP export,
+when configured, goes to the collector endpoint you set, also inside your
+boundary if you choose.
+
+```
+node (agents) ──daemon──► DuckDB (local dashboard :8900)
+     │                        │
+     │  HTTPS X-Api-Key       └─optional──► OTLP collector (your Datadog/Grafana)
+     ▼
+CLOUD MODE:  ingest.clawmetry.com (E2E-encrypted blobs; browser decrypts)
+SELF-HOSTED: your server (deploy/self-hosted, SQLite, plaintext by default)
+                 └──► /api/export/events (audit JSONL/CSV)
+```
+
+## Tests
+
+`tests/test_enterprise_endpoint.py` (resolution order),
+`tests/test_selfhosted_mode.py` (flag, auth, ingest protocol, export,
+phone-home gating), `tests/test_otel_exporter_spans.py` (span shape against
+an in-memory collector).

--- a/routes/meta.py
+++ b/routes/meta.py
@@ -1017,6 +1017,11 @@ def _anon_forward_cloud(payload: dict) -> None:
     OSS side starts feeding live data without another release.
     """
     try:
+        from clawmetry.endpoints import is_custom_endpoint as _is_custom_ep
+        if _is_custom_ep():
+            # Self-hosted / enterprise: anonymous analytics must not leave
+            # the deployment. The local JSONL remains the durable record.
+            return
         import urllib.request as _ur
         req = _ur.Request(
             "https://app.clawmetry.com/api/admin/anon-event",

--- a/routes/overview.py
+++ b/routes/overview.py
@@ -1719,7 +1719,8 @@ def cloud_proxy(cloud_path):
     if not token:
         return jsonify({"error": "cloud_not_connected"}), 401
 
-    url = "https://app.clawmetry.com/" + cloud_path
+    from clawmetry.endpoints import app_url as _resolve_app_url
+    url = _resolve_app_url() + "/" + cloud_path
     if request.query_string:
         url += "?" + request.query_string.decode("utf-8", errors="replace")
 
@@ -1795,9 +1796,10 @@ def cloud_cta_send_otp():
     if not email or "@" not in email:
         return jsonify({"ok": False, "error": "Invalid email"}), 400
     try:
+        from clawmetry.endpoints import app_url as _resolve_app_url
         _body = _jr.dumps({"email": email, "source": "dashboard"}).encode()
         _req = _ur.Request(
-            "https://app.clawmetry.com/api/otp/send",
+            _resolve_app_url() + "/api/otp/send",
             data=_body,
             headers={"Content-Type": "application/json"},
             method="POST",
@@ -1828,9 +1830,10 @@ def cloud_cta_verify_otp():
     if not email or not code:
         return jsonify({"ok": False, "error": "Missing email or code"}), 400
     try:
+        from clawmetry.endpoints import app_url as _resolve_app_url
         _body = _jr.dumps({"email": email, "code": code}).encode()
         _req = _ur.Request(
-            "https://app.clawmetry.com/api/otp/verify",
+            _resolve_app_url() + "/api/otp/verify",
             data=_body,
             headers={"Content-Type": "application/json"},
             method="POST",

--- a/routes/selfhosted_ingest.py
+++ b/routes/selfhosted_ingest.py
@@ -1,0 +1,785 @@
+"""
+routes/selfhosted_ingest.py — ClawMetry Enterprise self-hosted ingest API.
+
+Registered by dashboard.py ONLY when SELF_HOSTED=true (see
+clawmetry/selfhosted.py). Implements the server side of the daemon's cloud
+sync protocol (clawmetry/sync.py `_post` call sites) so `CLAWMETRY_ENDPOINT`
+can point a fleet of nodes at a single-tenant server inside a customer VPC:
+
+* ``POST /auth``                     — node token check (+ ``e2e`` policy)
+* ``POST /ingest/heartbeat``         — liveness + cache pushes + relay queries
+* ``POST /ingest/{events,sessions,logs,memory,system-snapshot,stream,autonomy}``
+* ``POST /api/ingest``               — legacy cron-events path
+* ``POST /ingest/cache``             — relay answers
+* ``POST /api/selfhosted/subscribe`` — queue a relay query for a node
+* ``GET  /api/cloud/cache/<key>``, ``GET /api/cloud/brain`` — relay read-back
+* ``GET  /api/cloud/policies``, ``POST /api/cloud/alerts/dispatch`` — stubs
+* ``POST /api/approvals/request``, ``GET /api/approvals/<id>`` + admin decision
+* ``GET  /api/export/events``        — audit export (JSONL/CSV, time-ranged)
+* ``GET  /api/selfhosted/nodes``, ``GET /api/selfhosted/status``
+
+Storage is a single SQLite database (stdlib, WAL) at
+``CLAWMETRY_SELF_HOSTED_DB`` (default ``~/.clawmetry/selfhosted.db``):
+
+* ``ingest_log``  — append-only raw record of every accepted POST (the
+  immutable audit log; rows are never updated or deleted)
+* ``events``      — plaintext events extracted for query/export (empty when
+  nodes E2E-encrypt; see CLAWMETRY_SELF_HOSTED_E2E)
+* ``nodes``, ``sessions``, ``cache``, ``pending_queries``, ``approvals``
+
+Auth: node endpoints take ``X-Api-Key`` ∈ CLAWMETRY_API_TOKENS; read/export
+endpoints take that or admin HTTP Basic (CLAWMETRY_ADMIN_USER/_PASSWORD).
+Encrypted envelopes (``{"encrypted": true, "blob": ...}``) are stored opaque —
+this server never sees an encryption key.
+"""
+from __future__ import annotations
+
+import csv
+import io
+import json
+import logging
+import os
+import sqlite3
+import threading
+import uuid
+from datetime import datetime, timezone
+
+from flask import Blueprint, Response, jsonify, request
+
+from clawmetry.selfhosted import (
+    check_admin_or_token,
+    check_api_key,
+    e2e_enabled,
+)
+
+logger = logging.getLogger("clawmetry.routes.selfhosted_ingest")
+
+bp_selfhosted = Blueprint("selfhosted_ingest", __name__)
+
+# RLock: handlers hold this around their whole read/write, and _db() re-enters
+# it for first-time DDL init.
+_DB_LOCK = threading.RLock()
+_INIT_DONE = False
+
+_DDL = """
+CREATE TABLE IF NOT EXISTS ingest_log (
+    seq         INTEGER PRIMARY KEY AUTOINCREMENT,
+    received_at TEXT NOT NULL,
+    node_id     TEXT,
+    path        TEXT NOT NULL,
+    encrypted   INTEGER NOT NULL DEFAULT 0,
+    payload     TEXT NOT NULL
+);
+CREATE TABLE IF NOT EXISTS events (
+    id          TEXT PRIMARY KEY,
+    node_id     TEXT,
+    agent_type  TEXT,
+    agent_id    TEXT,
+    session_id  TEXT,
+    event_type  TEXT,
+    ts          TEXT,
+    model       TEXT,
+    token_count INTEGER,
+    cost_usd    REAL,
+    data        TEXT,
+    received_at TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_sh_events_ts ON events(ts);
+CREATE TABLE IF NOT EXISTS nodes (
+    node_id    TEXT PRIMARY KEY,
+    hostname   TEXT,
+    platform   TEXT,
+    version    TEXT,
+    first_seen TEXT,
+    last_seen  TEXT
+);
+CREATE TABLE IF NOT EXISTS sessions (
+    node_id    TEXT,
+    session_id TEXT,
+    payload    TEXT,
+    updated_at TEXT,
+    PRIMARY KEY (node_id, session_id)
+);
+CREATE TABLE IF NOT EXISTS cache (
+    cache_key  TEXT PRIMARY KEY,
+    blob       TEXT,
+    shape      TEXT,
+    args_hash  TEXT,
+    ttl_s      INTEGER,
+    updated_at TEXT
+);
+CREATE TABLE IF NOT EXISTS pending_queries (
+    seq      INTEGER PRIMARY KEY AUTOINCREMENT,
+    node_id  TEXT NOT NULL,
+    query    TEXT NOT NULL,
+    added_at TEXT NOT NULL
+);
+CREATE TABLE IF NOT EXISTS approvals (
+    id         TEXT PRIMARY KEY,
+    node_id    TEXT,
+    payload    TEXT,
+    status     TEXT NOT NULL DEFAULT 'pending',
+    created_at TEXT NOT NULL,
+    decided_at TEXT
+);
+"""
+
+
+def _db_path() -> str:
+    return os.environ.get(
+        "CLAWMETRY_SELF_HOSTED_DB",
+        os.path.expanduser("~/.clawmetry/selfhosted.db"),
+    )
+
+
+def _db() -> sqlite3.Connection:
+    global _INIT_DONE
+    path = _db_path()
+    os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
+    conn = sqlite3.connect(path, timeout=10)
+    conn.row_factory = sqlite3.Row
+    if not _INIT_DONE:
+        with _DB_LOCK:
+            conn.executescript(_DDL)
+            try:
+                conn.execute("PRAGMA journal_mode=WAL")
+            except Exception:
+                pass
+            conn.commit()
+            _INIT_DONE = True
+    return conn
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _reset_for_tests() -> None:
+    """Test helper — forget DB-init state (tests repoint CLAWMETRY_SELF_HOSTED_DB)."""
+    global _INIT_DONE
+    _INIT_DONE = False
+
+
+# ── Auth helpers ────────────────────────────────────────────────────────────
+
+
+def _request_api_key():
+    key = request.headers.get("X-Api-Key", "")
+    if key:
+        return key
+    body = request.get_json(silent=True)
+    if isinstance(body, dict):
+        return body.get("api_key", "")
+    return ""
+
+
+def _node_auth_or_401():
+    if check_api_key(_request_api_key()):
+        return None
+    return jsonify({"ok": False, "error": "invalid_api_key"}), 401
+
+
+def _admin_auth_or_401():
+    if check_admin_or_token(request):
+        return None
+    return (
+        jsonify({"ok": False, "error": "unauthorized"}),
+        401,
+        {"WWW-Authenticate": 'Basic realm="clawmetry-selfhosted"'},
+    )
+
+
+# ── Ingest plumbing ─────────────────────────────────────────────────────────
+
+
+def _log_ingest(conn, path: str, payload: dict) -> None:
+    conn.execute(
+        "INSERT INTO ingest_log (received_at, node_id, path, encrypted, payload)"
+        " VALUES (?, ?, ?, ?, ?)",
+        (
+            _now(),
+            str(payload.get("node_id") or ""),
+            path,
+            1 if payload.get("encrypted") else 0,
+            json.dumps(payload, separators=(",", ":"), default=str),
+        ),
+    )
+
+
+def _touch_node(conn, node_id: str, hostname="", platform="", version="") -> None:
+    if not node_id:
+        return
+    now = _now()
+    conn.execute(
+        "INSERT INTO nodes (node_id, hostname, platform, version, first_seen, last_seen)"
+        " VALUES (?, ?, ?, ?, ?, ?)"
+        " ON CONFLICT(node_id) DO UPDATE SET"
+        "  hostname = CASE WHEN excluded.hostname != '' THEN excluded.hostname ELSE nodes.hostname END,"
+        "  platform = CASE WHEN excluded.platform != '' THEN excluded.platform ELSE nodes.platform END,"
+        "  version  = CASE WHEN excluded.version  != '' THEN excluded.version  ELSE nodes.version  END,"
+        "  last_seen = excluded.last_seen",
+        (node_id, hostname or "", platform or "", version or "", now, now),
+    )
+
+
+def _store_event(conn, node_id: str, ev: dict) -> None:
+    """Tolerantly extract one plaintext event into the queryable table."""
+    if not isinstance(ev, dict):
+        return
+    ev_id = str(
+        ev.get("id")
+        or ev.get("eventId")
+        or ev.get("messageId")
+        or uuid.uuid4().hex
+    )
+    data = ev.get("data")
+    conn.execute(
+        "INSERT OR IGNORE INTO events"
+        " (id, node_id, agent_type, agent_id, session_id, event_type, ts,"
+        "  model, token_count, cost_usd, data, received_at)"
+        " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            ev_id,
+            str(ev.get("node_id") or node_id or ""),
+            str(ev.get("agent_type") or ""),
+            str(ev.get("agent_id") or ""),
+            str(ev.get("session_id") or ""),
+            str(ev.get("event_type") or ev.get("type") or "unknown"),
+            str(ev.get("ts") or ev.get("timestamp") or ""),
+            str(ev.get("model") or ""),
+            ev.get("token_count"),
+            ev.get("cost_usd"),
+            json.dumps(data, separators=(",", ":"), default=str)
+            if data is not None
+            else None,
+            _now(),
+        ),
+    )
+
+
+def _accept_ingest(path: str, extract_events_key: str = None):
+    """Shared handler body for the fire-and-forget /ingest/* endpoints."""
+    err = _node_auth_or_401()
+    if err:
+        return err
+    payload = request.get_json(silent=True)
+    if not isinstance(payload, dict):
+        return jsonify({"ok": False, "error": "invalid_json"}), 400
+    node_id = str(payload.get("node_id") or "")
+    with _DB_LOCK:
+        conn = _db()
+        try:
+            _log_ingest(conn, path, payload)
+            _touch_node(conn, node_id)
+            if (
+                extract_events_key
+                and not payload.get("encrypted")
+                and isinstance(payload.get(extract_events_key), list)
+            ):
+                for ev in payload[extract_events_key]:
+                    _store_event(conn, node_id, ev)
+            conn.commit()
+        finally:
+            conn.close()
+    return jsonify({"ok": True})
+
+
+# ── Node-facing endpoints ───────────────────────────────────────────────────
+
+
+@bp_selfhosted.route("/auth", methods=["POST"])
+def sh_auth():
+    payload = request.get_json(silent=True) or {}
+    if not check_api_key(_request_api_key()):
+        return jsonify({"ok": False, "error": "invalid_api_key"}), 401
+    node_id = str(
+        payload.get("existing_node_id") or payload.get("hostname") or ""
+    ).strip()
+    with _DB_LOCK:
+        conn = _db()
+        try:
+            _touch_node(conn, node_id, hostname=str(payload.get("hostname") or ""))
+            conn.commit()
+        finally:
+            conn.close()
+    return jsonify(
+        {
+            "ok": True,
+            "valid": True,
+            "node_id": node_id,
+            "sync_allowed": True,
+            "plan": "enterprise",
+            "e2e": e2e_enabled(),
+        }
+    )
+
+
+@bp_selfhosted.route("/api/register", methods=["POST"])
+def sh_register():
+    # Self-hosted servers use operator-provisioned tokens (CLAWMETRY_API_TOKENS);
+    # open self-registration would let anyone who can reach the port mint access.
+    return (
+        jsonify(
+            {
+                "ok": False,
+                "error": "registration_disabled",
+                "message": "Self-hosted mode: connect with a configured token: "
+                "CLAWMETRY_ENDPOINT=<this server> clawmetry connect --key cm_...",
+            }
+        ),
+        403,
+    )
+
+
+@bp_selfhosted.route("/ingest/heartbeat", methods=["POST"])
+def sh_heartbeat():
+    err = _node_auth_or_401()
+    if err:
+        return err
+    payload = request.get_json(silent=True)
+    if not isinstance(payload, dict):
+        return jsonify({"ok": False, "error": "invalid_json"}), 400
+    node_id = str(payload.get("node_id") or "")
+    pending = []
+    with _DB_LOCK:
+        conn = _db()
+        try:
+            _touch_node(
+                conn,
+                node_id,
+                platform=str(payload.get("platform") or ""),
+                version=str(payload.get("version") or ""),
+            )
+            now = _now()
+            for push in payload.get("cache_pushes") or []:
+                if not isinstance(push, dict) or not push.get("key"):
+                    continue
+                conn.execute(
+                    "INSERT INTO cache (cache_key, blob, shape, args_hash, ttl_s, updated_at)"
+                    " VALUES (?, ?, ?, ?, ?, ?)"
+                    " ON CONFLICT(cache_key) DO UPDATE SET blob=excluded.blob,"
+                    "  ttl_s=excluded.ttl_s, updated_at=excluded.updated_at",
+                    (
+                        str(push["key"]),
+                        push.get("blob"),
+                        "",
+                        "",
+                        int(push.get("ttl_s") or 0),
+                        now,
+                    ),
+                )
+            if node_id:
+                rows = conn.execute(
+                    "SELECT seq, query FROM pending_queries WHERE node_id = ?"
+                    " ORDER BY seq LIMIT 20",
+                    (node_id,),
+                ).fetchall()
+                for row in rows:
+                    try:
+                        pending.append(json.loads(row["query"]))
+                    except Exception:
+                        pass
+                if rows:
+                    conn.execute(
+                        "DELETE FROM pending_queries WHERE seq <= ? AND node_id = ?",
+                        (rows[-1]["seq"], node_id),
+                    )
+            conn.commit()
+        finally:
+            conn.close()
+    return jsonify(
+        {
+            "ok": True,
+            "sync_allowed": True,
+            "plan": "enterprise",
+            "viewer_active": False,
+            "pending_queries": pending,
+        }
+    )
+
+
+@bp_selfhosted.route("/ingest/events", methods=["POST"])
+def sh_ingest_events():
+    return _accept_ingest("/ingest/events", extract_events_key="events")
+
+
+@bp_selfhosted.route("/api/ingest", methods=["POST"])
+def sh_api_ingest():
+    return _accept_ingest("/api/ingest", extract_events_key="events")
+
+
+@bp_selfhosted.route("/ingest/sessions", methods=["POST"])
+def sh_ingest_sessions():
+    err = _node_auth_or_401()
+    if err:
+        return err
+    payload = request.get_json(silent=True)
+    if not isinstance(payload, dict):
+        return jsonify({"ok": False, "error": "invalid_json"}), 400
+    node_id = str(payload.get("node_id") or "")
+    with _DB_LOCK:
+        conn = _db()
+        try:
+            _log_ingest(conn, "/ingest/sessions", payload)
+            _touch_node(conn, node_id)
+            now = _now()
+            for sess in payload.get("sessions") or []:
+                if not isinstance(sess, dict):
+                    continue
+                sid = str(sess.get("session_id") or "")
+                if not sid:
+                    continue
+                conn.execute(
+                    "INSERT INTO sessions (node_id, session_id, payload, updated_at)"
+                    " VALUES (?, ?, ?, ?)"
+                    " ON CONFLICT(node_id, session_id) DO UPDATE SET"
+                    "  payload=excluded.payload, updated_at=excluded.updated_at",
+                    (
+                        node_id,
+                        sid,
+                        json.dumps(sess, separators=(",", ":"), default=str),
+                        now,
+                    ),
+                )
+            conn.commit()
+        finally:
+            conn.close()
+    return jsonify({"ok": True})
+
+
+@bp_selfhosted.route("/ingest/logs", methods=["POST"])
+def sh_ingest_logs():
+    return _accept_ingest("/ingest/logs")
+
+
+@bp_selfhosted.route("/ingest/memory", methods=["POST"])
+def sh_ingest_memory():
+    return _accept_ingest("/ingest/memory")
+
+
+@bp_selfhosted.route("/ingest/system-snapshot", methods=["POST"])
+def sh_ingest_snapshot():
+    return _accept_ingest("/ingest/system-snapshot")
+
+
+@bp_selfhosted.route("/ingest/stream", methods=["POST"])
+def sh_ingest_stream():
+    return _accept_ingest("/ingest/stream")
+
+
+@bp_selfhosted.route("/ingest/autonomy", methods=["POST"])
+def sh_ingest_autonomy():
+    return _accept_ingest("/ingest/autonomy")
+
+
+@bp_selfhosted.route("/ingest/cache", methods=["POST"])
+def sh_ingest_cache():
+    err = _node_auth_or_401()
+    if err:
+        return err
+    payload = request.get_json(silent=True)
+    if not isinstance(payload, dict) or not payload.get("cache_key"):
+        return jsonify({"ok": False, "error": "invalid_json"}), 400
+    with _DB_LOCK:
+        conn = _db()
+        try:
+            conn.execute(
+                "INSERT INTO cache (cache_key, blob, shape, args_hash, ttl_s, updated_at)"
+                " VALUES (?, ?, ?, ?, ?, ?)"
+                " ON CONFLICT(cache_key) DO UPDATE SET blob=excluded.blob,"
+                "  shape=excluded.shape, args_hash=excluded.args_hash,"
+                "  ttl_s=excluded.ttl_s, updated_at=excluded.updated_at",
+                (
+                    str(payload["cache_key"]),
+                    payload.get("blob"),
+                    str(payload.get("shape") or ""),
+                    str(payload.get("args_hash") or ""),
+                    int(payload.get("ttl") or payload.get("ttl_s") or 0),
+                    _now(),
+                ),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+    return jsonify({"ok": True})
+
+
+# ── Relay read-back + stubs ─────────────────────────────────────────────────
+
+
+# NOTE: deliberately NOT /api/cloud/subscribe — the OSS dashboard already
+# owns that rule (routes/meta.py bp_cloud_relay, the local-daemon relay).
+# Fleet-level subscribe (queue a query for a REMOTE node's next heartbeat)
+# lives under the selfhosted namespace instead.
+@bp_selfhosted.route("/api/selfhosted/subscribe", methods=["POST"])
+def sh_subscribe():
+    err = _admin_auth_or_401()
+    if err:
+        return err
+    payload = request.get_json(silent=True) or {}
+    node_id = str(payload.get("node_id") or "")
+    if not node_id:
+        return jsonify({"ok": False, "error": "node_id required"}), 400
+    query = {k: v for k, v in payload.items() if k != "node_id"}
+    with _DB_LOCK:
+        conn = _db()
+        try:
+            conn.execute(
+                "INSERT INTO pending_queries (node_id, query, added_at) VALUES (?, ?, ?)",
+                (node_id, json.dumps(query, separators=(",", ":")), _now()),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+    return jsonify(
+        {"ok": True, "status": "queued", "cache_key": query.get("cache_key", "")}
+    )
+
+
+def _cache_lookup(cache_key: str):
+    with _DB_LOCK:
+        conn = _db()
+        try:
+            row = conn.execute(
+                "SELECT * FROM cache WHERE cache_key = ?", (cache_key,)
+            ).fetchone()
+        finally:
+            conn.close()
+    return row
+
+
+@bp_selfhosted.route("/api/cloud/cache/<path:cache_key>", methods=["GET"])
+def sh_cache_get(cache_key):
+    err = _admin_auth_or_401()
+    if err:
+        return err
+    row = _cache_lookup(cache_key)
+    if row is None:
+        return jsonify({"ok": False, "error": "not_found"}), 404
+    return jsonify(
+        {
+            "ok": True,
+            "cache_key": row["cache_key"],
+            "blob": row["blob"],
+            "shape": row["shape"],
+            "ttl_s": row["ttl_s"],
+            "updated_at": row["updated_at"],
+        }
+    )
+
+
+@bp_selfhosted.route("/api/cloud/brain", methods=["GET"])
+def sh_brain_get():
+    err = _admin_auth_or_401()
+    if err:
+        return err
+    key = request.args.get("key", "")
+    row = _cache_lookup(key) if key else None
+    if row is None:
+        return jsonify({"ok": False, "error": "not_found"}), 404
+    return jsonify({"ok": True, "blob": row["blob"], "updated_at": row["updated_at"]})
+
+
+@bp_selfhosted.route("/api/cloud/policies", methods=["GET"])
+def sh_policies():
+    return jsonify({"policies": []})
+
+
+@bp_selfhosted.route("/api/cloud/alerts/dispatch", methods=["POST"])
+def sh_alerts_dispatch():
+    err = _node_auth_or_401()
+    if err:
+        return err
+    # Sink delivery (Slack/PagerDuty/webhooks) is a customer-side decision;
+    # acknowledge so the daemon's alert evaluator doesn't retry forever.
+    return jsonify({"ok": True, "deduped": False, "dispatched": []})
+
+
+# ── Approvals (minimal single-tenant flow) ──────────────────────────────────
+
+
+@bp_selfhosted.route("/api/approvals/request", methods=["POST"])
+def sh_approval_request():
+    # Daemon authenticates with Authorization: Bearer <token> on /api/* paths.
+    bearer = (request.headers.get("Authorization") or "").removeprefix("Bearer ").strip()
+    if not check_api_key(bearer or _request_api_key()):
+        return jsonify({"ok": False, "error": "invalid_api_key"}), 401
+    payload = request.get_json(silent=True) or {}
+    approval_id = str(payload.get("id") or uuid.uuid4().hex)
+    with _DB_LOCK:
+        conn = _db()
+        try:
+            conn.execute(
+                "INSERT OR IGNORE INTO approvals (id, node_id, payload, status, created_at)"
+                " VALUES (?, ?, ?, 'pending', ?)",
+                (
+                    approval_id,
+                    str(payload.get("node_id") or ""),
+                    json.dumps(payload, separators=(",", ":"), default=str),
+                    _now(),
+                ),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+    return jsonify({"ok": True, "id": approval_id, "status": "pending"})
+
+
+@bp_selfhosted.route("/api/approvals/<approval_id>", methods=["GET"])
+def sh_approval_status(approval_id):
+    bearer = (request.headers.get("Authorization") or "").removeprefix("Bearer ").strip()
+    if not check_api_key(bearer or _request_api_key()):
+        return jsonify({"ok": False, "error": "invalid_api_key"}), 401
+    with _DB_LOCK:
+        conn = _db()
+        try:
+            row = conn.execute(
+                "SELECT status FROM approvals WHERE id = ?", (approval_id,)
+            ).fetchone()
+        finally:
+            conn.close()
+    if row is None:
+        return jsonify({"ok": False, "error": "not_found"}), 404
+    return jsonify({"ok": True, "status": row["status"]})
+
+
+@bp_selfhosted.route("/api/selfhosted/approvals/<approval_id>/decision", methods=["POST"])
+def sh_approval_decide(approval_id):
+    err = _admin_auth_or_401()
+    if err:
+        return err
+    decision = str((request.get_json(silent=True) or {}).get("status") or "").lower()
+    if decision not in ("approved", "denied"):
+        return jsonify({"ok": False, "error": "status must be approved|denied"}), 400
+    with _DB_LOCK:
+        conn = _db()
+        try:
+            cur = conn.execute(
+                "UPDATE approvals SET status = ?, decided_at = ? WHERE id = ?",
+                (decision, _now(), approval_id),
+            )
+            conn.commit()
+            updated = cur.rowcount
+        finally:
+            conn.close()
+    if not updated:
+        return jsonify({"ok": False, "error": "not_found"}), 404
+    return jsonify({"ok": True, "id": approval_id, "status": decision})
+
+
+# ── Audit export + admin reads ──────────────────────────────────────────────
+
+_EXPORT_COLS = (
+    "id",
+    "node_id",
+    "agent_type",
+    "agent_id",
+    "session_id",
+    "event_type",
+    "ts",
+    "model",
+    "token_count",
+    "cost_usd",
+    "data",
+    "received_at",
+)
+
+
+@bp_selfhosted.route("/api/export/events", methods=["GET"])
+def sh_export_events():
+    err = _admin_auth_or_401()
+    if err:
+        return err
+    date_from = request.args.get("from", "")
+    date_to = request.args.get("to", "")
+    fmt = request.args.get("format", "jsonl").lower()
+    if fmt not in ("jsonl", "csv"):
+        return jsonify({"ok": False, "error": "format must be jsonl|csv"}), 400
+
+    where, params = [], []
+    if date_from:
+        where.append("ts >= ?")
+        params.append(date_from)
+    if date_to:
+        where.append("ts <= ?")
+        params.append(date_to)
+    sql = "SELECT * FROM events"
+    if where:
+        sql += " WHERE " + " AND ".join(where)
+    sql += " ORDER BY ts"
+
+    def _rows():
+        with _DB_LOCK:
+            conn = _db()
+            try:
+                yield from conn.execute(sql, params).fetchall()
+            finally:
+                conn.close()
+
+    if fmt == "csv":
+        def _gen_csv():
+            buf = io.StringIO()
+            writer = csv.writer(buf)
+            writer.writerow(_EXPORT_COLS)
+            yield buf.getvalue()
+            for row in _rows():
+                buf.seek(0)
+                buf.truncate()
+                writer.writerow([row[c] for c in _EXPORT_COLS])
+                yield buf.getvalue()
+
+        return Response(_gen_csv(), mimetype="text/csv")
+
+    def _gen_jsonl():
+        for row in _rows():
+            rec = {c: row[c] for c in _EXPORT_COLS}
+            if rec.get("data"):
+                try:
+                    rec["data"] = json.loads(rec["data"])
+                except Exception:
+                    pass
+            yield json.dumps(rec, separators=(",", ":"), default=str) + "\n"
+
+    return Response(_gen_jsonl(), mimetype="application/x-ndjson")
+
+
+@bp_selfhosted.route("/api/selfhosted/nodes", methods=["GET"])
+def sh_nodes():
+    err = _admin_auth_or_401()
+    if err:
+        return err
+    with _DB_LOCK:
+        conn = _db()
+        try:
+            rows = conn.execute(
+                "SELECT * FROM nodes ORDER BY last_seen DESC"
+            ).fetchall()
+        finally:
+            conn.close()
+    return jsonify({"ok": True, "nodes": [dict(r) for r in rows]})
+
+
+@bp_selfhosted.route("/api/selfhosted/status", methods=["GET"])
+def sh_status():
+    err = _admin_auth_or_401()
+    if err:
+        return err
+    with _DB_LOCK:
+        conn = _db()
+        try:
+            counts = {
+                table: conn.execute(f"SELECT COUNT(*) AS n FROM {table}").fetchone()["n"]
+                for table in ("nodes", "events", "ingest_log", "sessions", "cache")
+            }
+        finally:
+            conn.close()
+    return jsonify(
+        {
+            "ok": True,
+            "self_hosted": True,
+            "e2e": e2e_enabled(),
+            "db_path": _db_path(),
+            "counts": counts,
+            "ts": _now(),
+        }
+    )

--- a/tests/test_cli_export_subcommand.py
+++ b/tests/test_cli_export_subcommand.py
@@ -1,0 +1,120 @@
+"""``clawmetry export`` — audit export CLI against a fixture HTTP endpoint.
+
+Regression note: the CSV branch once dropped every row because a NameError
+inside its per-line try/except was silently swallowed — these tests assert
+actual row content, not just exit codes.
+"""
+import argparse
+import http.server
+import json
+import threading
+
+import pytest
+
+from clawmetry import cli
+
+EVENTS = [
+    {
+        "id": "e1",
+        "node_id": "n1",
+        "agent_type": "claude_code",
+        "agent_id": "main",
+        "session_id": "s1",
+        "event_type": "tool.call",
+        "ts": "2026-07-30T10:00:00",
+        "model": "",
+        "token_count": 5,
+        "cost_usd": 0.01,
+        "data": {"name": "Bash"},
+        "received_at": "2026-07-30T10:00:01",
+    },
+    {
+        "id": "e2",
+        "node_id": "n1",
+        "agent_type": "claude_code",
+        "agent_id": "main",
+        "session_id": "s1",
+        "event_type": "message",
+        "ts": "2026-07-30T11:00:00",
+        "model": "m",
+        "token_count": None,
+        "cost_usd": None,
+        "data": None,
+        "received_at": "2026-07-30T11:00:01",
+    },
+]
+
+
+@pytest.fixture
+def export_server(monkeypatch):
+    requests_seen = []
+
+    class _Handler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self):  # noqa: N802
+            requests_seen.append(
+                {"path": self.path, "api_key": self.headers.get("X-Api-Key")}
+            )
+            if self.headers.get("X-Api-Key") != "cm_export_tok":
+                self.send_response(401)
+                self.end_headers()
+                return
+            body = "".join(json.dumps(e) + "\n" for e in EVENTS).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/x-ndjson")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, *a):
+            pass
+
+    server = http.server.HTTPServer(("127.0.0.1", 0), _Handler)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    monkeypatch.setenv(
+        "CLAWMETRY_ENDPOINT", f"http://127.0.0.1:{server.server_port}"
+    )
+    monkeypatch.setenv("CLAWMETRY_API_KEY", "cm_export_tok")
+    yield requests_seen
+    server.shutdown()
+    server.server_close()
+
+
+def _ns(**kw):
+    defaults = {
+        "date_from": None,
+        "date_to": None,
+        "format": "jsonl",
+        "out": None,
+    }
+    defaults.update(kw)
+    return argparse.Namespace(**defaults)
+
+
+def test_export_jsonl_to_file(export_server, tmp_path):
+    out = tmp_path / "events.jsonl"
+    cli._cmd_export(_ns(date_from="2026-07-01", date_to="2026-07-31", out=str(out)))
+    lines = [json.loads(ln) for ln in out.read_text().splitlines()]
+    assert [ln["id"] for ln in lines] == ["e1", "e2"]
+    assert lines[0]["data"] == {"name": "Bash"}
+    # Range params reached the server.
+    assert "from=2026-07-01" in export_server[0]["path"]
+    assert "to=2026-07-31" in export_server[0]["path"]
+
+
+def test_export_csv_has_all_rows(export_server, tmp_path):
+    out = tmp_path / "events.csv"
+    cli._cmd_export(_ns(format="csv", out=str(out)))
+    rows = out.read_text().splitlines()
+    assert rows[0].startswith("id,node_id,agent_type")
+    assert len(rows) == 1 + len(EVENTS)  # header + every event, none dropped
+    assert rows[1].startswith("e1,")
+    # dict data is embedded as a JSON string cell
+    assert '{""name"":""Bash""}' in rows[1]
+
+
+def test_export_bad_key_exits_nonzero(export_server, monkeypatch, capsys):
+    monkeypatch.setenv("CLAWMETRY_API_KEY", "cm_wrong")
+    with pytest.raises(SystemExit) as exc:
+        cli._cmd_export(_ns())
+    assert exc.value.code == 1
+    assert "Unauthorized" in capsys.readouterr().out

--- a/tests/test_enterprise_endpoint.py
+++ b/tests/test_enterprise_endpoint.py
@@ -1,0 +1,103 @@
+"""Endpoint resolution order for enterprise self-hosting (clawmetry/endpoints.py).
+
+Contract: env CLAWMETRY_ENDPOINT > env CLAWMETRY_INGEST_URL (legacy) >
+config-file "endpoint" key > managed cloud default. App-side calls follow a
+custom endpoint (single self-hosted host), with CLAWMETRY_APP_BASE as an
+explicit split override.
+"""
+import json
+
+import pytest
+
+from clawmetry import endpoints
+
+_ENV_VARS = ("CLAWMETRY_ENDPOINT", "CLAWMETRY_INGEST_URL", "CLAWMETRY_APP_BASE")
+
+
+@pytest.fixture
+def clean_endpoints(monkeypatch, tmp_path):
+    """No env overrides, config path sandboxed to tmp, resolver cache reset."""
+    for var in _ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+    cfg = tmp_path / "config.json"
+    monkeypatch.setattr(endpoints, "CONFIG_PATH", str(cfg))
+    monkeypatch.setattr(endpoints, "_cfg_cache", None)
+    return cfg
+
+
+def _write_cfg(cfg_path, data):
+    cfg_path.write_text(json.dumps(data), encoding="utf-8")
+    # Bust the mtime-keyed cache (same-second writes on coarse filesystems).
+    endpoints._cfg_cache = None
+
+
+def test_default_is_managed_cloud(clean_endpoints):
+    assert endpoints.ingest_url() == "https://ingest.clawmetry.com"
+    assert endpoints.app_url() == "https://app.clawmetry.com"
+    assert endpoints.is_custom_endpoint() is False
+
+
+def test_config_key_overrides_default(clean_endpoints):
+    _write_cfg(clean_endpoints, {"endpoint": "https://cm.corp.example/"})
+    assert endpoints.ingest_url() == "https://cm.corp.example"
+    # App-side traffic follows the single self-hosted host.
+    assert endpoints.app_url() == "https://cm.corp.example"
+    assert endpoints.is_custom_endpoint() is True
+
+
+def test_legacy_ingest_env_beats_config(clean_endpoints, monkeypatch):
+    _write_cfg(clean_endpoints, {"endpoint": "https://from-config.example"})
+    monkeypatch.setenv("CLAWMETRY_INGEST_URL", "https://from-legacy-env.example")
+    assert endpoints.ingest_url() == "https://from-legacy-env.example"
+
+
+def test_endpoint_env_beats_everything(clean_endpoints, monkeypatch):
+    _write_cfg(clean_endpoints, {"endpoint": "https://from-config.example"})
+    monkeypatch.setenv("CLAWMETRY_INGEST_URL", "https://from-legacy-env.example")
+    monkeypatch.setenv("CLAWMETRY_ENDPOINT", "https://from-env.example/")
+    assert endpoints.ingest_url() == "https://from-env.example"
+    assert endpoints.app_url() == "https://from-env.example"
+
+
+def test_app_base_env_is_explicit_split_override(clean_endpoints, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_ENDPOINT", "https://ingest.corp.example")
+    monkeypatch.setenv("CLAWMETRY_APP_BASE", "https://app.corp.example")
+    assert endpoints.ingest_url() == "https://ingest.corp.example"
+    assert endpoints.app_url() == "https://app.corp.example"
+
+
+def test_blank_config_key_falls_through(clean_endpoints):
+    _write_cfg(clean_endpoints, {"endpoint": "  "})
+    assert endpoints.ingest_url() == "https://ingest.clawmetry.com"
+
+
+def test_missing_or_broken_config_never_raises(clean_endpoints):
+    # Missing file
+    assert endpoints.ingest_url() == "https://ingest.clawmetry.com"
+    # Broken JSON
+    clean_endpoints.write_text("{not json", encoding="utf-8")
+    endpoints._cfg_cache = None
+    assert endpoints.ingest_url() == "https://ingest.clawmetry.com"
+
+
+def test_endpoint_hosts_for_interceptor_exclusion(clean_endpoints, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_ENDPOINT", "https://cm.corp.example:8443/base")
+    hosts = endpoints.endpoint_hosts()
+    assert "cm.corp.example" in hosts
+
+
+def test_sync_module_constant_uses_resolver(clean_endpoints, monkeypatch):
+    """sync.INGEST_URL snapshots the resolver at import — re-importing under a
+    custom env must repoint it (this is what a daemon restart does)."""
+    import importlib
+
+    import clawmetry.sync as sync_mod
+
+    monkeypatch.setenv("CLAWMETRY_ENDPOINT", "https://reimport.example")
+    try:
+        importlib.reload(sync_mod)
+        assert sync_mod.INGEST_URL == "https://reimport.example"
+    finally:
+        monkeypatch.delenv("CLAWMETRY_ENDPOINT")
+        importlib.reload(sync_mod)
+        assert sync_mod.INGEST_URL == "https://ingest.clawmetry.com"

--- a/tests/test_otel_exporter_spans.py
+++ b/tests/test_otel_exporter_spans.py
@@ -1,0 +1,180 @@
+"""OTLP exporter emits well-formed GenAI spans (clawmetry/otel_exporter.py).
+
+Uses an in-memory OTLP collector (stdlib HTTP server capturing request
+bodies) plus a fake store — no DuckDB, no network beyond localhost.
+"""
+import http.server
+import json
+import threading
+
+import pytest
+
+from clawmetry import otel_exporter as oe
+
+
+class _Collector:
+    """Minimal in-memory OTLP/HTTP collector."""
+
+    def __init__(self):
+        self.payloads = []
+        collector = self
+
+        class _Handler(http.server.BaseHTTPRequestHandler):
+            def do_POST(self):  # noqa: N802
+                length = int(self.headers.get("Content-Length", 0))
+                collector.payloads.append(json.loads(self.rfile.read(length)))
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.end_headers()
+                self.wfile.write(b"{}")
+
+            def log_message(self, *a):
+                pass
+
+        self.server = http.server.HTTPServer(("127.0.0.1", 0), _Handler)
+        self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+        self.thread.start()
+
+    @property
+    def endpoint(self):
+        return f"http://127.0.0.1:{self.server.server_port}/v1/traces"
+
+    def close(self):
+        self.server.shutdown()
+        self.server.server_close()
+
+
+class _FakeStore:
+    def __init__(self, sessions, events):
+        self._sessions = sessions
+        self._events = events
+
+    def query_sessions(self, **kwargs):
+        return self._sessions
+
+    def query_events(self, **kwargs):
+        return self._events
+
+
+SESSION = {
+    "session_id": "sess-1",
+    "agent_type": "claude_code",
+    "agent_id": "main",
+    "model": "claude-sonnet-5",
+    "token_count": 1234,
+    "cost_usd": 0.42,
+    "event_count": 7,
+    "started_at": "2026-07-30T10:00:00+00:00",
+    "updated_at": "2026-07-30T10:05:00+00:00",
+}
+
+TOOL_EVENT = {
+    "id": "ev-1",
+    "session_id": "sess-1",
+    "agent_type": "claude_code",
+    "event_type": "tool_call",
+    "ts": "2026-07-30T10:01:00+00:00",
+    "data": {"tool_calls": [{"name": "Bash", "args": {"command": "ls"}}]},
+}
+
+
+@pytest.fixture
+def collector():
+    c = _Collector()
+    yield c
+    c.close()
+
+
+@pytest.fixture
+def wired(monkeypatch, collector):
+    import clawmetry.local_store as ls
+
+    store = _FakeStore([SESSION], [TOOL_EVENT])
+    monkeypatch.setattr(ls, "get_store", lambda **kw: store)
+    monkeypatch.setattr(oe, "_last_watermark", None)
+    return collector
+
+
+def _attrs(span):
+    return {a["key"]: a["value"] for a in span["attributes"]}
+
+
+def test_flush_emits_wellformed_spans(wired):
+    sent = oe._flush_once(wired.endpoint, {"X-Test": "1"})
+    assert sent == 2  # 1 session span + 1 tool span
+
+    assert len(wired.payloads) == 1
+    payload = wired.payloads[0]
+    resource_spans = payload["resourceSpans"]
+    resource_attrs = {
+        a["key"]: a["value"] for a in resource_spans[0]["resource"]["attributes"]
+    }
+    assert resource_attrs["service.name"] == {"stringValue": "clawmetry"}
+
+    spans = resource_spans[0]["scopeSpans"][0]["spans"]
+    assert len(spans) == 2
+    session_span = next(s for s in spans if s["name"] == "claude_code.session")
+    tool_span = next(s for s in spans if s["name"] == "execute_tool Bash")
+
+    # Well-formed ids (hex, OTLP sizes) and a real time range.
+    assert len(session_span["traceId"]) == 32
+    assert len(session_span["spanId"]) == 16
+    int(session_span["traceId"], 16)
+    assert int(session_span["endTimeUnixNano"]) > int(
+        session_span["startTimeUnixNano"]
+    )
+
+    attrs = _attrs(session_span)
+    assert attrs["gen_ai.system"] == {"stringValue": "claude_code"}
+    assert attrs["gen_ai.operation.name"] == {"stringValue": "invoke_agent"}
+    assert attrs["gen_ai.agent.name"] == {"stringValue": "main"}
+    assert attrs["gen_ai.request.model"] == {"stringValue": "claude-sonnet-5"}
+    assert attrs["gen_ai.usage.input_tokens"] == {"intValue": "1234"}
+    assert attrs["clawmetry.cost_usd"] == {"doubleValue": 0.42}
+
+    # Tool span is a child of the session span, in the same trace.
+    assert tool_span["traceId"] == session_span["traceId"]
+    assert tool_span["parentSpanId"] == session_span["spanId"]
+    tool_attrs = _attrs(tool_span)
+    assert tool_attrs["gen_ai.operation.name"] == {"stringValue": "execute_tool"}
+    assert tool_attrs["gen_ai.tool.name"] == {"stringValue": "Bash"}
+
+
+def test_trace_ids_are_deterministic_across_flushes(wired):
+    oe._flush_once(wired.endpoint, {})
+    oe._last_watermark = None  # simulate a restart re-exporting the window
+    oe._flush_once(wired.endpoint, {})
+    first, second = wired.payloads
+    span_a = first["resourceSpans"][0]["scopeSpans"][0]["spans"][0]
+    span_b = second["resourceSpans"][0]["scopeSpans"][0]["spans"][0]
+    assert span_a["traceId"] == span_b["traceId"]
+    assert span_a["spanId"] == span_b["spanId"]
+
+
+def test_watermark_advances_past_exported_rows(wired):
+    oe._flush_once(wired.endpoint, {})
+    assert oe._last_watermark == "2026-07-30T10:05:00+00:00"
+
+
+def test_start_exporter_scopes(monkeypatch, tmp_path):
+    # Don't run real export loops from this test — resolution logic only.
+    monkeypatch.setattr(oe, "_export_loop", lambda *a, **k: None)
+    # Nothing configured -> neither scope starts.
+    monkeypatch.delenv("CLAWMETRY_OTEL_EXPORT_ENDPOINT", raising=False)
+    monkeypatch.setattr(oe, "_CONFIG_PATH", str(tmp_path / "config.json"))
+    assert oe.start_exporter() is False
+    assert oe.start_exporter(scope="config") is False
+
+    # Config key activates ONLY the config scope (daemon path)...
+    (tmp_path / "config.json").write_text(
+        json.dumps({"otlp_endpoint": "http://127.0.0.1:9/v1/traces",
+                    "otlp_headers": {"X-K": "v"},
+                    "otlp_export_interval": 3600})
+    )
+    assert oe.start_exporter() is False  # env scope still off
+    assert oe.start_exporter(scope="config") is True
+
+    # ...and the env var activates only the env scope (dashboard path).
+    monkeypatch.setenv("CLAWMETRY_OTEL_EXPORT_ENDPOINT", "http://127.0.0.1:9/v1/traces")
+    monkeypatch.setenv("CLAWMETRY_OTEL_EXPORT_INTERVAL", "3600")
+    assert oe.start_exporter() is True

--- a/tests/test_selfhosted_mode.py
+++ b/tests/test_selfhosted_mode.py
@@ -1,0 +1,302 @@
+"""ClawMetry Enterprise self-hosted mode (SELF_HOSTED=true).
+
+Covers: the flag, token/admin auth helpers, the ingest blueprint speaking the
+daemon's wire protocol against SQLite, audit export, and the cloud-only
+phone-homes short-circuiting when the endpoint is repointed.
+"""
+import base64
+import json
+
+import pytest
+
+flask = pytest.importorskip("flask")
+
+from clawmetry import endpoints, selfhosted  # noqa: E402
+from routes import selfhosted_ingest as shi  # noqa: E402
+
+TOKEN = "cm_test_token_1"
+ADMIN_AUTH = "Basic " + base64.b64encode(b"admin:pw").decode()
+
+
+@pytest.fixture
+def sh_app(monkeypatch, tmp_path):
+    monkeypatch.setenv("SELF_HOSTED", "true")
+    monkeypatch.setenv("CLAWMETRY_API_TOKENS", f"{TOKEN}, cm_second_token")
+    monkeypatch.setenv("CLAWMETRY_ADMIN_USER", "admin")
+    monkeypatch.setenv("CLAWMETRY_ADMIN_PASSWORD", "pw")
+    monkeypatch.delenv("CLAWMETRY_SELF_HOSTED_E2E", raising=False)
+    monkeypatch.setenv("CLAWMETRY_SELF_HOSTED_DB", str(tmp_path / "selfhosted.db"))
+    shi._reset_for_tests()
+    app = flask.Flask(__name__)
+    app.register_blueprint(shi.bp_selfhosted)
+    return app.test_client()
+
+
+# ── Flag + auth helpers ─────────────────────────────────────────────────────
+
+
+def test_self_hosted_flag_values(monkeypatch):
+    monkeypatch.delenv("SELF_HOSTED", raising=False)
+    monkeypatch.delenv("CLAWMETRY_SELF_HOSTED", raising=False)
+    assert selfhosted.is_self_hosted() is False
+    for value in ("1", "true", "TRUE", "yes", "on"):
+        monkeypatch.setenv("SELF_HOSTED", value)
+        assert selfhosted.is_self_hosted() is True
+    monkeypatch.setenv("SELF_HOSTED", "0")
+    assert selfhosted.is_self_hosted() is False
+    monkeypatch.delenv("SELF_HOSTED")
+    monkeypatch.setenv("CLAWMETRY_SELF_HOSTED", "true")
+    assert selfhosted.is_self_hosted() is True
+
+
+def test_check_api_key(monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_API_TOKENS", "cm_a, cm_b")
+    assert selfhosted.check_api_key("cm_a")
+    assert selfhosted.check_api_key("cm_b")
+    assert not selfhosted.check_api_key("cm_c")
+    assert not selfhosted.check_api_key("")
+    monkeypatch.delenv("CLAWMETRY_API_TOKENS")
+    assert not selfhosted.check_api_key("cm_a")
+
+
+def test_admin_basic_auth(monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_ADMIN_USER", "admin")
+    monkeypatch.setenv("CLAWMETRY_ADMIN_PASSWORD", "pw")
+    good = "Basic " + base64.b64encode(b"admin:pw").decode()
+    bad = "Basic " + base64.b64encode(b"admin:nope").decode()
+    assert selfhosted.check_admin_basic_auth(good)
+    assert not selfhosted.check_admin_basic_auth(bad)
+    assert not selfhosted.check_admin_basic_auth(None)
+    monkeypatch.delenv("CLAWMETRY_ADMIN_PASSWORD")
+    # No creds configured -> nothing authenticates (no default password).
+    assert not selfhosted.check_admin_basic_auth(good)
+
+
+# ── Ingest protocol ─────────────────────────────────────────────────────────
+
+
+def test_auth_endpoint(sh_app):
+    r = sh_app.post("/auth", json={"api_key": "cm_wrong", "hostname": "box1"})
+    assert r.status_code == 401
+    r = sh_app.post("/auth", json={"api_key": TOKEN, "hostname": "box1"})
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["ok"] is True
+    assert body["plan"] == "enterprise"
+    assert body["e2e"] is False  # plaintext-inside-VPC is the default
+
+
+def test_auth_e2e_flag(sh_app, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_SELF_HOSTED_E2E", "1")
+    r = sh_app.post("/auth", json={"api_key": TOKEN, "hostname": "box1"})
+    assert r.get_json()["e2e"] is True
+
+
+def test_register_disabled(sh_app):
+    r = sh_app.post("/api/register", json={"hostname": "x"})
+    assert r.status_code == 403
+    assert r.get_json()["error"] == "registration_disabled"
+
+
+def test_heartbeat_roundtrip_with_relay(sh_app):
+    headers = {"X-Api-Key": TOKEN}
+    # Queue a relay query for node-1 (admin API).
+    r = sh_app.post(
+        "/api/selfhosted/subscribe",
+        json={"node_id": "node-1", "shape": "events", "cache_key": "k1", "args": {}},
+        headers={"Authorization": ADMIN_AUTH},
+    )
+    assert r.status_code == 200
+
+    hb = {
+        "node_id": "node-1",
+        "platform": "Linux",
+        "version": "0.12.601",
+        "cache_pushes": [{"key": "brain:x:node-1:recent", "ttl_s": 60, "blob": "abc"}],
+    }
+    r = sh_app.post("/ingest/heartbeat", json=hb, headers=headers)
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["sync_allowed"] is True
+    assert body["plan"] == "enterprise"
+    assert body["pending_queries"] == [{"shape": "events", "cache_key": "k1", "args": {}}]
+
+    # Queue drained — second heartbeat gets nothing.
+    r = sh_app.post("/ingest/heartbeat", json=hb, headers=headers)
+    assert r.get_json()["pending_queries"] == []
+
+    # The cache push is readable back.
+    r = sh_app.get(
+        "/api/cloud/cache/brain:x:node-1:recent",
+        headers={"Authorization": ADMIN_AUTH},
+    )
+    assert r.status_code == 200
+    assert r.get_json()["blob"] == "abc"
+
+    # Node registered.
+    r = sh_app.get("/api/selfhosted/nodes", headers={"Authorization": ADMIN_AUTH})
+    nodes = r.get_json()["nodes"]
+    assert len(nodes) == 1 and nodes[0]["node_id"] == "node-1"
+    assert nodes[0]["version"] == "0.12.601"
+
+
+def test_heartbeat_requires_token(sh_app):
+    r = sh_app.post("/ingest/heartbeat", json={"node_id": "n"})
+    assert r.status_code == 401
+
+
+def test_events_plaintext_extracted_encrypted_opaque(sh_app):
+    headers = {"X-Api-Key": TOKEN}
+    plain = {
+        "node_id": "node-1",
+        "session_file": "s.jsonl",
+        "events": [
+            {
+                "id": "ev1",
+                "session_id": "sess-1",
+                "event_type": "tool.call",
+                "ts": "2026-07-30T10:00:00+00:00",
+                "agent_type": "openclaw",
+                "data": {"name": "Bash", "input": {"command": "ls"}},
+                "token_count": 12,
+            }
+        ],
+    }
+    assert sh_app.post("/ingest/events", json=plain, headers=headers).status_code == 200
+
+    encrypted = {"node_id": "node-1", "encrypted": True, "blob": "ZmFrZQ=="}
+    assert (
+        sh_app.post("/ingest/events", json=encrypted, headers=headers).status_code
+        == 200
+    )
+
+    # Export sees exactly the one plaintext event.
+    r = sh_app.get("/api/export/events", headers={"Authorization": ADMIN_AUTH})
+    lines = [json.loads(ln) for ln in r.get_data(as_text=True).splitlines() if ln]
+    assert len(lines) == 1
+    assert lines[0]["id"] == "ev1"
+    assert lines[0]["event_type"] == "tool.call"
+    assert lines[0]["data"] == {"name": "Bash", "input": {"command": "ls"}}
+
+
+def test_export_time_range_and_csv_and_auth(sh_app):
+    headers = {"X-Api-Key": TOKEN}
+    for i, ts in enumerate(
+        ["2026-07-01T00:00:00", "2026-07-15T00:00:00", "2026-07-31T00:00:00"]
+    ):
+        sh_app.post(
+            "/ingest/events",
+            json={
+                "node_id": "n",
+                "events": [
+                    {"id": f"e{i}", "session_id": "s", "event_type": "message", "ts": ts}
+                ],
+            },
+            headers=headers,
+        )
+
+    # Unauthenticated -> 401.
+    assert sh_app.get("/api/export/events").status_code == 401
+    # Node token is also accepted for export.
+    r = sh_app.get("/api/export/events?from=2026-07-10&to=2026-07-20", headers=headers)
+    lines = [json.loads(ln) for ln in r.get_data(as_text=True).splitlines() if ln]
+    assert [ln["id"] for ln in lines] == ["e1"]
+
+    r = sh_app.get(
+        "/api/export/events?format=csv", headers={"Authorization": ADMIN_AUTH}
+    )
+    rows = r.get_data(as_text=True).splitlines()
+    assert rows[0].startswith("id,node_id,agent_type")
+    assert len(rows) == 4  # header + 3 events
+
+
+def test_sessions_upsert_and_status(sh_app):
+    headers = {"X-Api-Key": TOKEN}
+    sess = {"session_id": "s1", "status": "active", "total_tokens": 10}
+    payload = {"node_id": "n1", "sessions": [sess]}
+    assert sh_app.post("/ingest/sessions", json=payload, headers=headers).status_code == 200
+    sess["total_tokens"] = 20
+    assert sh_app.post("/ingest/sessions", json=payload, headers=headers).status_code == 200
+
+    r = sh_app.get("/api/selfhosted/status", headers={"Authorization": ADMIN_AUTH})
+    counts = r.get_json()["counts"]
+    assert counts["sessions"] == 1  # upsert, not append
+    assert counts["ingest_log"] == 2  # immutable log keeps both
+
+
+def test_approvals_flow(sh_app):
+    bearer = {"Authorization": f"Bearer {TOKEN}"}
+    r = sh_app.post(
+        "/api/approvals/request", json={"id": "ap1", "node_id": "n"}, headers=bearer
+    )
+    assert r.status_code == 200
+    assert sh_app.get("/api/approvals/ap1", headers=bearer).get_json()["status"] == "pending"
+    r = sh_app.post(
+        "/api/selfhosted/approvals/ap1/decision",
+        json={"status": "approved"},
+        headers={"Authorization": ADMIN_AUTH},
+    )
+    assert r.status_code == 200
+    assert sh_app.get("/api/approvals/ap1", headers=bearer).get_json()["status"] == "approved"
+
+
+# ── Cloud-only phone-homes gate on custom endpoint ──────────────────────────
+
+
+def test_anon_analytics_skipped_on_custom_endpoint(monkeypatch, tmp_path):
+    from routes import meta as meta_mod
+
+    calls = []
+
+    class _FakeUrllib:
+        @staticmethod
+        def Request(*a, **k):
+            return object()
+
+        @staticmethod
+        def urlopen(*a, **k):
+            calls.append(a)
+
+            class _R:
+                def close(self):
+                    pass
+
+            return _R()
+
+    import urllib.request as _real_ur
+
+    monkeypatch.setattr(_real_ur, "Request", _FakeUrllib.Request)
+    monkeypatch.setattr(_real_ur, "urlopen", _FakeUrllib.urlopen)
+    monkeypatch.setattr(endpoints, "CONFIG_PATH", str(tmp_path / "config.json"))
+    monkeypatch.setattr(endpoints, "_cfg_cache", None)
+
+    monkeypatch.setenv("CLAWMETRY_ENDPOINT", "https://corp.example")
+    meta_mod._anon_forward_cloud({"k": "v"})
+    assert calls == []  # short-circuited before any network call
+
+    monkeypatch.delenv("CLAWMETRY_ENDPOINT")
+    meta_mod._anon_forward_cloud({"k": "v"})
+    assert len(calls) == 1  # managed cloud still forwards
+
+
+def test_telemetry_skipped_on_custom_endpoint(monkeypatch, tmp_path):
+    from clawmetry import telemetry as tel
+
+    monkeypatch.setattr(endpoints, "CONFIG_PATH", str(tmp_path / "config.json"))
+    monkeypatch.setattr(endpoints, "_cfg_cache", None)
+    monkeypatch.delenv("CLAWMETRY_TELEMETRY_URL", raising=False)
+    monkeypatch.delenv("CLAWMETRY_INGEST_URL", raising=False)
+
+    # Custom endpoint -> telemetry URL resolves to "" -> both send workers
+    # bail before posting anything.
+    monkeypatch.setenv("CLAWMETRY_ENDPOINT", "https://corp.example")
+    assert tel._resolve_telemetry_url() == ""
+
+    # Managed cloud -> default URL.
+    monkeypatch.delenv("CLAWMETRY_ENDPOINT")
+    assert tel._resolve_telemetry_url() == tel.TELEMETRY_URL_DEFAULT
+
+    # Explicit re-point always wins, even with a custom endpoint.
+    monkeypatch.setenv("CLAWMETRY_ENDPOINT", "https://corp.example")
+    monkeypatch.setenv("CLAWMETRY_TELEMETRY_URL", "https://tel.corp.example")
+    assert tel._resolve_telemetry_url() == "https://tel.corp.example"


### PR DESCRIPTION
## Why

Enterprise buyers need self-hosting and OpenTelemetry compatibility (the checkboxes LangWatch/Langfuse win on) without breaking the existing cloud path. This PR adds both, plus the prerequisite endpoint configurability and a compliance export.

## What

1. **Configurable ingest endpoint** (`clawmetry/endpoints.py`): resolution is `CLAWMETRY_ENDPOINT` env > `CLAWMETRY_INGEST_URL` env (legacy, still honored) > config `endpoint` key > managed cloud default. All daemon/CLI/dashboard call sites route through it, including four previously hardcoded ones (`/api/unregister`, cloud proxy, signup OTP, anon analytics). A custom endpoint suppresses install telemetry and anon analytics: a self-hosted deployment's data never leaves it. Config format only ADDS keys; cloud-path defaults unchanged.
2. **Self-hosted single-tenant server** (`SELF_HOSTED=true`): registers `routes/selfhosted_ingest.py`, the server side of the daemon sync protocol (auth, heartbeat + relay, all `/ingest/*`, cache read-back, minimal approvals) on an append-only SQLite store, plus `/api/export/events` and `/api/selfhosted/{nodes,status}`. Env-configured auth (node tokens + admin Basic). `/auth` answers `e2e: false` by default so nodes ingest plaintext inside the VPC (`CLAWMETRY_SELF_HOSTED_E2E=1` restores blob encryption). One-command deploy at `deploy/self-hosted/` with runbook. The only optional phone-home is an off-by-default daily license ping whose exact 5-field payload is documented.
3. **OTLP export via config**: `otlp_endpoint` starts the GenAI trace exporter in the sync daemon; the env var keeps the dashboard-hosted path. Scopes are disjoint so both processes never double-export. Deterministic per-session trace ids + `execute_tool` child spans.
4. **Audit export CLI**: `clawmetry export --from --to --format jsonl|csv` against the configured endpoint with configured credentials.

Docs: `docs/enterprise.md` (endpoint config, self-hosted, OTel, audit export, data-flow for both modes).

## Verification

- 30 new tests: endpoint resolution order, self-hosted flag/auth/protocol/export/phone-home gating, OTLP span shape against an in-memory collector, export CLI (incl. a regression test for a CSV row-drop bug caught during live smoke).
- 132 touched-area regression tests green locally (sync protocol, CLI subcommands, OTel export, TLS, relay e2e, trial gating).
- Live smoke: booted `SELF_HOSTED=true` dashboard, ran real `/auth` -> heartbeat (plan=enterprise, relay roundtrip) -> `/ingest/events` -> CSV+JSONL export via curl AND the new CLI.
- Known-unrelated: `test_heartbeat_envelope` / `test_moat_cloud_roundtrip` fail on the dev machine due to live-daemon data leaking into empty-store fixtures; confirmed failing on pristine origin/main too.

## Follow-ups (cloud repo)

- `/api/export/events` on the managed cloud (CLI prints an honest message until then).
- `/api/license/ping` receiver (opt-in ping is fail-silent until then).
- Route-policy passthrough entries when repinning cloud past this release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)