### PR TITLE
feat(cli): Agent CLI Phase 1 - sessions, activity, waste, progress, usage + selfevolve stub

### DIFF
--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -5839,6 +5839,20 @@ def main() -> None:
     if len(sys.argv) > 1 and sys.argv[1] == "hooks":
         from clawmetry.hooks_claude_code import cli_main as _hooks_cli
         raise SystemExit(_hooks_cli(sys.argv[2:]))
+    # FAST PATH — agent-facing read CLI (`clawmetry sessions|activity|waste|
+    # progress|usage|selfevolve`, see docs/CLI.md + clawmetry/cli_cmds/).
+    # Dispatches BEFORE the dashboard import (~300ms) and before this process
+    # tags itself CLAWMETRY_ROLE=dashboard, so local_store.get_store()
+    # resolves the transport ladder itself: daemon HTTP proxy when the sync
+    # daemon owns the writer, direct read-only DuckDB in single-process
+    # installs. These commands are read-only and never take the writer lock.
+    try:
+        from clawmetry.cli_cmds import AGENT_COMMANDS as _agent_cmds
+    except Exception:
+        _agent_cmds = ()
+    if len(sys.argv) > 1 and sys.argv[1] in _agent_cmds:
+        from clawmetry.cli_cmds import dispatch as _agent_dispatch
+        raise SystemExit(_agent_dispatch(sys.argv[1:]))
     # Enterprise TLS/proxy bootstrap — OS trust store (truststore), 3.13
     # strict-flag relax, CLAWMETRY_CA_BUNDLE, proxy env vars — so every
     # outbound HTTPS call from the CLI/dashboard (connect, OTP, telemetry,

--- a/clawmetry/cli_cmds/__init__.py
+++ b/clawmetry/cli_cmds/__init__.py
@@ -1,0 +1,58 @@
+"""Agent-facing read CLI — `clawmetry sessions|activity|waste|progress|usage|selfevolve`.
+
+Phase 1 of the Agent CLI (docs/CLI.md): the observability
+surface the UI serves, readable from a terminal by humans, CI, and AI agents
+closing a self-improve loop ("read my own telemetry, find waste, fix it").
+
+Dispatched from ``clawmetry.cli.main`` on a fast path BEFORE the dashboard
+import (~300 ms) so `clawmetry sessions --json` answers in tens of ms and the
+process never tags itself CLAWMETRY_ROLE=dashboard — which lets
+``local_store.get_store(read_only=True)`` pick the right transport on its own:
+daemon HTTP proxy when the sync daemon owns the writer lock, direct read-only
+DuckDB in single-process installs.
+
+Grammar (one rule, no exceptions): ``clawmetry NOUN [ID] [read-facet flags]``.
+Everything here is read-only; mutations stay in their existing commands.
+"""
+from __future__ import annotations
+
+# Nouns owned by this package. Checked against sys.argv[1] in cli.main's fast
+# path; must never collide with the legacy _subcmds tuple in cli.py.
+AGENT_COMMANDS = (
+    "sessions",
+    "activity",
+    "waste",
+    "progress",
+    "usage",
+    "selfevolve",
+)
+
+
+def dispatch(argv: list[str]) -> int:
+    """Parse + run one agent-CLI command. Returns the process exit code."""
+    from clawmetry.cli_cmds import _common
+
+    try:
+        parser = _common.build_parser()
+        args = parser.parse_args(argv)
+        handler = getattr(args, "_handler", None)
+        if handler is None:  # pragma: no cover - argparse enforces a command
+            parser.print_help()
+            return _common.EXIT_USAGE
+        return int(handler(args) or 0)
+    except _common.CliError as err:
+        return _common.fail(err)
+    except KeyboardInterrupt:
+        return _common.EXIT_OK
+    except BrokenPipeError:
+        # `clawmetry activity | head` — downstream closed the pipe; not an error.
+        return _common.EXIT_OK
+    except SystemExit as exc:  # argparse --help / usage errors
+        code = exc.code
+        if code is None:
+            return _common.EXIT_OK
+        return _common.EXIT_USAGE if code == 2 else int(code)
+    except Exception as exc:  # never crash on bad input (repo rule)
+        return _common.fail(
+            _common.CliError("internal", f"unexpected error: {exc}", _common.EXIT_ERROR)
+        )

--- a/clawmetry/cli_cmds/_common.py
+++ b/clawmetry/cli_cmds/_common.py
@@ -1,0 +1,283 @@
+"""Shared plumbing for the agent-facing read CLI.
+
+Interface contract (docs/CLI.md is the user-facing copy of this):
+
+* stdout carries DATA, stderr carries decoration (notes, hints, errors).
+* ``--json`` emits one JSON object per invocation — the same rows/dicts the
+  local store methods serve (the shape the ``/api/local`` read API returns),
+  no envelope. ``default=str`` so Decimal/datetime never crash the dump.
+* ``--follow`` (where offered) emits NDJSON: first line
+  ``{"type":"_meta",...}``, one event object per line, final line
+  ``{"type":"_end","reason":...,"next_cursor":...}`` so an agent can resume.
+* Exit codes are a stable contract:
+    0 success (including empty results)
+    1 internal/runtime error
+    2 usage error
+    3 no data source answered (no daemon, no local store) — retryable
+    4 entitlement-gated (the CLI's 402)
+    5 auth failure
+    6 not found (unknown session id, ...)
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from datetime import datetime, timedelta
+
+EXIT_OK = 0
+EXIT_ERROR = 1
+EXIT_USAGE = 2
+EXIT_UNAVAILABLE = 3
+EXIT_ENTITLEMENT = 4
+EXIT_AUTH = 5
+EXIT_NOT_FOUND = 6
+
+
+class CliError(Exception):
+    """Structured CLI failure. ``code`` is the machine-readable error code
+    (mirrors the API error vocabulary: unavailable / not_found /
+    upgrade_required / bad_request / internal), ``extra`` merges into the
+    JSON error body (used by the selfevolve stub to carry the full 402
+    shape)."""
+
+    def __init__(self, code: str, message: str, exit_code: int, extra: dict | None = None):
+        super().__init__(message)
+        self.code = code
+        self.message = message
+        self.exit_code = exit_code
+        self.extra = extra or {}
+
+
+def fail(err: CliError) -> int:
+    """Print the error to stderr (JSON when stdout is being parsed is the
+    caller's concern — the error body is always JSON so agents can parse it,
+    prefixed with a plain sentence for humans) and return the exit code."""
+    body = {"error": {"code": err.code, "message": err.message, **err.extra}}
+    print(f"clawmetry: {err.message}", file=sys.stderr)
+    print(json.dumps(body, default=str), file=sys.stderr)
+    return err.exit_code
+
+
+def note(msg: str) -> None:
+    """Decoration → stderr, never stdout."""
+    print(msg, file=sys.stderr)
+
+
+# ── Time handling ───────────────────────────────────────────────────────────
+
+_RELATIVE_RE = re.compile(r"^(\d+)\s*([smhdw])$")
+_UNIT_SECONDS = {"s": 1, "m": 60, "h": 3600, "d": 86400, "w": 604800}
+
+
+def utcnow_iso() -> str:
+    return datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def parse_when(value: str | None, flag: str = "--since") -> str | None:
+    """Accept ISO-8601 (passed through) or relative ``90s|15m|6h|7d|2w``
+    (converted to a UTC ISO timestamp that far in the past)."""
+    if not value:
+        return None
+    value = value.strip()
+    m = _RELATIVE_RE.match(value)
+    if m:
+        secs = int(m.group(1)) * _UNIT_SECONDS[m.group(2)]
+        return (datetime.utcnow() - timedelta(seconds=secs)).strftime(
+            "%Y-%m-%dT%H:%M:%SZ"
+        )
+    # ISO-ish: let the store's SQL comparison handle precision; just sanity-check.
+    if re.match(r"^\d{4}-\d{2}-\d{2}", value):
+        return value
+    raise CliError(
+        "bad_request",
+        f"{flag} must be ISO-8601 (2026-07-31T12:00:00Z) or relative (90s, 15m, 6h, 7d)",
+        EXIT_USAGE,
+    )
+
+
+# ── Shared flags ────────────────────────────────────────────────────────────
+
+def add_output_flags(p: argparse.ArgumentParser) -> None:
+    p.add_argument(
+        "--json", action="store_true", dest="as_json",
+        help="Emit JSON (the same shape the local read API serves) instead of the table",
+    )
+
+
+def add_window_flags(p: argparse.ArgumentParser, default_since: str | None = None) -> None:
+    p.add_argument(
+        "--since", metavar="WHEN", default=default_since,
+        help="Window start: ISO-8601 or relative (90s, 15m, 6h, 7d)"
+        + (f" (default: {default_since})" if default_since else ""),
+    )
+    p.add_argument("--until", metavar="WHEN", help="Window end (same formats)")
+    p.add_argument(
+        "--last", metavar="SPAN",
+        help="Sugar for --since <SPAN> (e.g. --last 24h)",
+    )
+
+
+def add_runtime_flag(p: argparse.ArgumentParser) -> None:
+    p.add_argument(
+        "--runtime", metavar="R",
+        help="Scope to one runtime (openclaw, claude_code, codex, cursor, ...)",
+    )
+
+
+def resolve_window(args) -> tuple[str | None, str | None]:
+    since = parse_when(getattr(args, "last", None), "--last") or parse_when(
+        getattr(args, "since", None)
+    )
+    until = parse_when(getattr(args, "until", None), "--until")
+    return since, until
+
+
+# ── Transport (the invisible ladder) ────────────────────────────────────────
+
+def get_read_store():
+    """Return ``(store, source)`` where source is ``daemon`` (HTTP proxy to
+    the sync daemon that owns the DuckDB writer) or ``direct`` (read-only
+    DuckDB open — single-process installs only).
+
+    ``local_store.get_store(read_only=True)`` already implements the ladder:
+    a registered daemon → ``_ProxyStore`` (never opens DuckDB here, which
+    would block the daemon's writer — the recurring lock bug); no daemon →
+    direct RO open. We only classify which rung answered so output can carry
+    ``source`` honestly.
+    """
+    try:
+        from clawmetry import local_store
+    except Exception as exc:
+        raise CliError(
+            "unavailable", f"clawmetry install is broken (cannot import local_store: {exc})",
+            EXIT_UNAVAILABLE,
+        )
+    daemon = False
+    try:
+        daemon = bool(local_store._daemon_registered())
+    except Exception:
+        daemon = False
+    try:
+        store = local_store.get_store(read_only=True)
+    except Exception as exc:
+        raise CliError(
+            "unavailable",
+            "no daemon, dashboard, or local store found "
+            f"({exc.__class__.__name__}); run `clawmetry sync` or `clawmetry onboard`",
+            EXIT_UNAVAILABLE,
+        )
+    return store, ("daemon" if daemon else "direct")
+
+
+def call(store, method: str, **kwargs):
+    """Invoke a store read method (kwargs only — the daemon proxy forwards
+    kwargs verbatim and every method must be in routes/local_query.py's
+    ``_DAEMON_METHODS`` allowlist). ``None`` from the proxy means the daemon
+    didn't answer (busy / restarting / method not allowlisted) — surfaced as
+    the retryable exit-3, never a silent empty table."""
+    fn = getattr(store, method, None)
+    if fn is None:
+        raise CliError("internal", f"store method {method} missing", EXIT_ERROR)
+    try:
+        result = fn(**kwargs)
+    except Exception as exc:
+        raise CliError("internal", f"{method} failed: {exc}", EXIT_ERROR)
+    if result is None:
+        raise CliError(
+            "unavailable",
+            f"the sync daemon did not answer {method} (busy or restarting); "
+            "retry in a few seconds",
+            EXIT_UNAVAILABLE,
+        )
+    return result
+
+
+# ── Output ──────────────────────────────────────────────────────────────────
+
+def emit_json(payload) -> None:
+    json.dump(payload, sys.stdout, default=str)
+    sys.stdout.write("\n")
+
+
+def emit_jsonl(obj) -> None:
+    sys.stdout.write(json.dumps(obj, default=str) + "\n")
+    sys.stdout.flush()
+
+
+def fmt_cell(value, width: int) -> str:
+    s = "" if value is None else str(value)
+    s = s.replace("\n", " ").replace("\t", " ")
+    if len(s) > width:
+        s = s[: width - 1] + "…"
+    return s.ljust(width)
+
+
+def print_table(rows: list[dict], columns: list[tuple[str, str, int]]) -> None:
+    """``columns`` = [(key, header, max_width)]. Whitespace-aligned, one
+    header line, awk/cut-safe. Empty input prints headers + a stderr note
+    and exits 0 upstream."""
+    widths = []
+    for key, header, max_w in columns:
+        w = len(header)
+        for r in rows:
+            w = max(w, min(max_w, len(str(r.get(key, "") or ""))))
+        widths.append(min(w, max_w))
+    header_line = "  ".join(
+        h.ljust(w) for (_, h, _), w in zip(columns, widths)
+    )
+    print(header_line)
+    for r in rows:
+        print("  ".join(
+            fmt_cell(r.get(k), w) for (k, _, _), w in zip(columns, widths)
+        ).rstrip())
+    if not rows:
+        note("(no data)")
+
+
+def fmt_cost(v) -> str:
+    try:
+        return f"${float(v):.4f}" if float(v) < 1 else f"${float(v):.2f}"
+    except (TypeError, ValueError):
+        return "$0.00"
+
+
+def fmt_tokens(v) -> str:
+    try:
+        n = int(v)
+    except (TypeError, ValueError):
+        return "0"
+    if n >= 1_000_000:
+        return f"{n / 1_000_000:.1f}M"
+    if n >= 1_000:
+        return f"{n / 1_000:.1f}k"
+    return str(n)
+
+
+def short_sid(sid: str, keep: int = 30) -> str:
+    sid = sid or ""
+    return sid if len(sid) <= keep else sid[: keep - 1] + "…"
+
+
+# ── Parser assembly ─────────────────────────────────────────────────────────
+
+def build_parser() -> argparse.ArgumentParser:
+    from clawmetry.cli_cmds import activity, progress, selfevolve, sessions, usage, waste
+
+    parser = argparse.ArgumentParser(
+        prog="clawmetry",
+        description="Agent-facing observability reads (see docs/CLI.md)",
+        epilog=(
+            "exit codes: 0 ok · 1 error · 2 usage · 3 no data source · "
+            "4 upgrade required · 5 auth · 6 not found"
+        ),
+    )
+    sub = parser.add_subparsers(dest="cmd")
+    sessions.register(sub)
+    activity.register(sub)
+    waste.register(sub)
+    progress.register(sub)
+    usage.register(sub)
+    selfevolve.register(sub)
+    return parser

--- a/clawmetry/cli_cmds/activity.py
+++ b/clawmetry/cli_cmds/activity.py
@@ -1,0 +1,142 @@
+"""`clawmetry activity` — the Brain event feed from the terminal.
+
+    clawmetry activity [--type T] [--session SID] [--runtime R] [--since 1h] [--json]
+    clawmetry activity --follow [--max-events N] [--idle-timeout S]
+
+History reads come straight off ``query_events`` through the daemon proxy.
+``--follow`` POLLS the same method (2 s cadence) and emits NDJSON with
+``_meta`` / ``_end`` frames — no dashboard process required, and the stream
+never hangs: idle-timeout (default 300 s), optional --max-events, Ctrl-C
+exits 0 with a resumable ``next_cursor``.
+"""
+from __future__ import annotations
+
+import time
+
+from clawmetry.cli_cmds import _common as c
+
+_POLL_SECS = 2.0
+
+
+def register(sub) -> None:
+    p = sub.add_parser(
+        "activity",
+        help="Recent agent events (reasoning, tool calls, errors); --follow to stream",
+    )
+    p.add_argument("--type", dest="event_type", metavar="T",
+                   help="Filter by event_type (exact match, e.g. tool.call)")
+    p.add_argument("--session", dest="session_id", metavar="SID",
+                   help="Scope to one session id")
+    c.add_runtime_flag(p)
+    c.add_window_flags(p, default_since="1h")
+    p.add_argument("--limit", type=int, default=100,
+                   help="Max events for a history read (default 100, max 1000)")
+    p.add_argument("--follow", action="store_true",
+                   help="Stream new events as NDJSON (poll-based; Ctrl-C to stop)")
+    p.add_argument("--max-events", type=int, default=0, metavar="N",
+                   help="With --follow: stop after N events (0 = unlimited)")
+    p.add_argument("--idle-timeout", type=int, default=300, metavar="S",
+                   help="With --follow: stop after S seconds with no events (default 300)")
+    c.add_output_flags(p)
+    p.set_defaults(_handler=run)
+
+
+def _fetch(store, args, since, until, limit):
+    return c.call(
+        store, "query_events",
+        session_id=args.session_id,
+        event_type=args.event_type,
+        since=since,
+        until=until,
+        runtime=args.runtime,
+        exclude_daemon=True,
+        limit=limit,
+    )
+
+
+def run(args) -> int:
+    store, source = c.get_read_store()
+    since, until = c.resolve_window(args)
+    if args.follow:
+        return _follow(store, source, args, since)
+
+    limit = max(1, min(int(args.limit or 100), 1000))
+    rows = _fetch(store, args, since, until, limit)
+    rows = sorted(rows, key=lambda e: str(e.get("ts", "")))
+    if args.as_json:
+        c.emit_json({"events": rows, "source": source})
+        return c.EXIT_OK
+    for ev in rows:
+        ts = str(ev.get("ts", ""))[:19]
+        sid = c.short_sid(str(ev.get("session_id", "") or ""), 28)
+        etype = str(ev.get("event_type", "") or "")
+        print(f"{ts}  {etype:26} {sid:28} {_snippet(ev)}")
+    if not rows:
+        c.note("(no events in window)")
+    c.note(f"{len(rows)} event(s) · source: {source}")
+    return c.EXIT_OK
+
+
+def _snippet(ev: dict, width: int = 90) -> str:
+    from clawmetry.cli_cmds.sessions import _event_snippet
+    return _event_snippet(ev, width)
+
+
+def _event_key(ev: dict) -> tuple:
+    return (str(ev.get("ts", "")), str(ev.get("session_id", "")),
+            str(ev.get("event_type", "")))
+
+
+def _follow(store, source, args, since) -> int:
+    cursor = since or c.utcnow_iso()
+    max_events = max(0, int(args.max_events or 0))
+    idle_timeout = max(1, int(args.idle_timeout or 300))
+    scope = {
+        "session_id": args.session_id,
+        "event_type": args.event_type,
+        "runtime": args.runtime,
+        "since": cursor,
+    }
+    c.emit_jsonl({"type": "_meta", "scope": scope, "source": source})
+
+    emitted = 0
+    last_seen_keys: set = set()
+    last_event_wall = time.time()
+    reason = "idle_timeout"
+    try:
+        while True:
+            rows = _fetch(store, args, cursor, None, 500)
+            rows = sorted(rows, key=lambda e: str(e.get("ts", "")))
+            fresh = [e for e in rows if _event_key(e) not in last_seen_keys]
+            for ev in fresh:
+                c.emit_jsonl(ev)
+                emitted += 1
+                if max_events and emitted >= max_events:
+                    reason = "max_events"
+                    cursor = str(ev.get("ts") or cursor)
+                    raise _Stop
+            if fresh:
+                last_event_wall = time.time()
+                cursor = str(fresh[-1].get("ts") or cursor)
+                # `since` comparisons are inclusive at second precision —
+                # remember what we already emitted at the cursor timestamp
+                # so the next poll doesn't duplicate it.
+                last_seen_keys = {
+                    _event_key(e) for e in fresh
+                    if str(e.get("ts", "")) == cursor
+                }
+            if time.time() - last_event_wall > idle_timeout:
+                reason = "idle_timeout"
+                break
+            time.sleep(_POLL_SECS)
+    except _Stop:
+        pass
+    except KeyboardInterrupt:
+        reason = "interrupted"
+    c.emit_jsonl({"type": "_end", "reason": reason, "events": emitted,
+                  "next_cursor": cursor})
+    return c.EXIT_OK
+
+
+class _Stop(Exception):
+    pass

--- a/clawmetry/cli_cmds/progress.py
+++ b/clawmetry/cli_cmds/progress.py
@@ -1,0 +1,93 @@
+"""`clawmetry progress` — is the agent actually getting anywhere?
+
+    clawmetry progress [SID] [--since 1h] [--json]
+
+Two signals, one command:
+  * ``query_forward_progress`` — tokens per state-delta per session. A high
+    ratio means burning tokens without producing new state (new tools, new
+    files, new outcomes).
+  * ``query_recent_loop_signals`` — the proxy's loop detector (repeated
+    near-identical calls).
+
+The self-improve hook: an agent that sees its own ratio spike + a loop
+signal should stop brute-forcing and change strategy.
+"""
+from __future__ import annotations
+
+from clawmetry.cli_cmds import _common as c
+
+
+def register(sub) -> None:
+    p = sub.add_parser(
+        "progress",
+        help="Forward-progress score + loop signals (is the agent spinning?)",
+    )
+    p.add_argument("session_id", nargs="?", metavar="SID",
+                   help="Scope to one session id (or prefix)")
+    c.add_window_flags(p, default_since="1h")
+    c.add_output_flags(p)
+    p.set_defaults(_handler=run)
+
+
+def run(args) -> int:
+    store, source = c.get_read_store()
+    since, until = c.resolve_window(args)
+
+    fp_kwargs = {"since": since, "until": until}
+    if args.session_id:
+        fp_kwargs["session_id"] = args.session_id
+    rows = c.call(store, "query_forward_progress", **fp_kwargs)
+
+    # since window → minutes for the loop-signal store (its native filter).
+    since_minutes = 60
+    if since:
+        try:
+            from datetime import datetime
+            dt = datetime.strptime(since[:19], "%Y-%m-%dT%H:%M:%S")
+            since_minutes = max(1, int((datetime.utcnow() - dt).total_seconds() // 60))
+        except ValueError:
+            pass
+    loops = c.call(store, "query_recent_loop_signals",
+                   limit=20, since_minutes=since_minutes)
+    if args.session_id:
+        loops = [sig for sig in loops
+                 if str(sig.get("session_id", "")).startswith(args.session_id)]
+
+    payload = {
+        "window_since": since,
+        "sessions": rows,
+        "loop_signals": loops,
+        "source": source,
+    }
+    if args.as_json:
+        c.emit_json(payload)
+        return c.EXIT_OK
+
+    view = [
+        {
+            "session": c.short_sid(str(r.get("session_id", "")), 40),
+            "tokens": c.fmt_tokens(r.get("tokens")),
+            "deltas": r.get("state_deltas"),
+            "ratio": f"{float(r.get('ratio') or 0):,.0f}",
+        }
+        for r in sorted(rows, key=lambda r: -float(r.get("ratio") or 0))
+    ]
+    c.print_table(view, [
+        ("session", "SESSION", 40),
+        ("tokens", "TOKENS", 8),
+        ("deltas", "STATE-DELTAS", 12),
+        ("ratio", "TOK/DELTA", 10),
+    ])
+    if not rows:
+        c.note("(no sessions with billable tokens in window)")
+    if loops:
+        print()
+        print(f"loop signals ({len(loops)}):")
+        for sig in loops:
+            print(f"  {c.short_sid(str(sig.get('session_id', '') or '?'), 36)}  "
+                  f"{sig.get('pattern') or sig.get('kind') or 'loop'}  "
+                  f"count={sig.get('count', '?')}")
+    else:
+        c.note("no loop signals in window")
+    c.note(f"high TOK/DELTA = spinning · window since {since} · source: {source}")
+    return c.EXIT_OK

--- a/clawmetry/cli_cmds/selfevolve.py
+++ b/clawmetry/cli_cmds/selfevolve.py
@@ -62,6 +62,7 @@ def _record_paywall_event(action: str) -> None:
     the same telemetry the UI's upgrade CTAs feed. Never blocks, never
     raises; 1 s budget."""
     try:
+        import os
         import urllib.request
         payload = json.dumps({
             "event": "paywall_view",
@@ -69,8 +70,9 @@ def _record_paywall_event(action: str) -> None:
             "source": "cli",
             "harness": f"selfevolve_{action}",
         }).encode("utf-8")
+        base = (os.environ.get("CLAWMETRY_URL") or "http://127.0.0.1:8900").rstrip("/")
         req = urllib.request.Request(
-            "http://127.0.0.1:8900/api/paywall/event",
+            f"{base}/api/paywall/event",
             data=payload,
             headers={"Content-Type": "application/json"},
             method="POST",

--- a/clawmetry/cli_cmds/selfevolve.py
+++ b/clawmetry/cli_cmds/selfevolve.py
@@ -1,0 +1,108 @@
+"""`clawmetry selfevolve` — OSS 402 stub for the Pro self-improvement engine.
+
+    clawmetry selfevolve analyze|status|fix [--json]
+
+The command EXISTS in OSS so an agent that just diagnosed its own failure
+(via `clawmetry progress` / `clawmetry waste`) discovers the next step. On
+an install without the entitlement it exits 4 with the same
+``upgrade_required`` body the HTTP API's 402 carries (plus ``upgrade_url``),
+and records a paywall event — that moment is the product's peak-intent
+second, not an error to hide.
+
+The real implementation ships in the closed-source ``clawmetry-pro``
+package (repo rule: Pro code never lands here) and fulfils via the
+``clawmetry.extensions`` entry-point group, attr ``selfevolve_cli``.
+"""
+from __future__ import annotations
+
+import json
+
+from clawmetry.cli_cmds import _common as c
+
+_FEATURE = "self_evolve"
+_UPGRADE_URL = "https://clawmetry.com/upgrade?feature=self_evolve&src=cli"
+
+
+def register(sub) -> None:
+    p = sub.add_parser(
+        "selfevolve",
+        help="[pro] Analyze telemetry and propose/apply agent improvements",
+    )
+    p.add_argument("action", choices=["analyze", "status", "fix"],
+                   help="analyze: find improvements · status: engine state · fix: apply one")
+    c.add_output_flags(p)
+    p.set_defaults(_handler=run)
+
+
+def _pro_impl():
+    """Return the Pro package's CLI hook when installed, else None."""
+    try:
+        from clawmetry.extensions import _select_entry_points
+    except Exception:
+        return None
+    try:
+        for ep in _select_entry_points("clawmetry.extensions"):
+            if ep.name == "selfevolve_cli":
+                return ep.load()
+    except Exception:
+        return None
+    return None
+
+
+def _allowed() -> bool:
+    try:
+        from clawmetry import entitlements
+        return bool(entitlements.get_entitlement().allows_feature(_FEATURE))
+    except Exception:
+        return False
+
+
+def _record_paywall_event(action: str) -> None:
+    """Best-effort beacon to the local dashboard's rolling paywall store —
+    the same telemetry the UI's upgrade CTAs feed. Never blocks, never
+    raises; 1 s budget."""
+    try:
+        import urllib.request
+        payload = json.dumps({
+            "event": "paywall_view",
+            "feature": _FEATURE,
+            "source": "cli",
+            "harness": f"selfevolve_{action}",
+        }).encode("utf-8")
+        req = urllib.request.Request(
+            "http://127.0.0.1:8900/api/paywall/event",
+            data=payload,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        urllib.request.urlopen(req, timeout=1.0).close()
+    except Exception:
+        pass
+
+
+def run(args) -> int:
+    impl = _pro_impl()
+    if impl is not None and _allowed():
+        try:
+            return int(impl(args) or 0)
+        except Exception as exc:
+            raise c.CliError("internal", f"selfevolve ({args.action}) failed: {exc}",
+                             c.EXIT_ERROR)
+
+    _record_paywall_event(args.action)
+    try:
+        from clawmetry._paywall import upgrade_required_body
+        body = upgrade_required_body(_FEATURE)
+    except Exception:
+        body = {"error": "upgrade_required", "feature": _FEATURE,
+                "tier": "oss", "required_tier": None,
+                "hint": "Self-Evolve ships in clawmetry-pro."}
+    body["upgrade_url"] = _UPGRADE_URL
+    raise c.CliError(
+        "upgrade_required",
+        f"selfevolve {args.action} requires the Self-Evolve feature "
+        f"(tier: {body.get('tier')}, unlocks at: {body.get('required_tier') or 'pro'}). "
+        f"Upgrade: {_UPGRADE_URL}",
+        c.EXIT_ENTITLEMENT,
+        extra=body,
+    )

--- a/clawmetry/cli_cmds/sessions.py
+++ b/clawmetry/cli_cmds/sessions.py
@@ -1,0 +1,265 @@
+"""`clawmetry sessions` — list sessions; drill into one with facets.
+
+    clawmetry sessions [--active] [--runtime R] [--limit N] [--json]
+    clawmetry sessions <SID> [--transcript|--cost|--errors|--lineage|--journey|--export {json,md}]
+
+Read-only. Backed by the daemon-proxy store methods the Sessions tab uses:
+query_sessions_table, query_events, query_cost_split_with_subagents,
+query_session_errors, query_session_lineage,
+query_session_model_journey_with_subagents.
+"""
+from __future__ import annotations
+
+from clawmetry.cli_cmds import _common as c
+
+
+def register(sub) -> None:
+    p = sub.add_parser(
+        "sessions",
+        help="List agent sessions, or inspect one (transcript, cost, errors, lineage)",
+    )
+    p.add_argument("session_id", nargs="?", metavar="SID",
+                   help="Session id (or unique prefix) to inspect")
+    p.add_argument("--active", action="store_true",
+                   help="Only sessions currently marked active")
+    c.add_runtime_flag(p)
+    p.add_argument("--limit", type=int, default=50,
+                   help="Max rows (default 50, max 1000)")
+    c.add_window_flags(p)
+    # Facets (pure reads; mutually exclusive with each other).
+    facet = p.add_mutually_exclusive_group()
+    facet.add_argument("--transcript", action="store_true",
+                       help="Event-level transcript of the session")
+    facet.add_argument("--cost", action="store_true",
+                       help="Cost split incl. sub-agents")
+    facet.add_argument("--errors", action="store_true", help="Error events")
+    facet.add_argument("--lineage", action="store_true",
+                       help="Sub-agent lineage tree")
+    facet.add_argument("--journey", action="store_true",
+                       help="Model journey (mid-session model switches)")
+    facet.add_argument("--export", choices=["json", "md"],
+                       help="Full bundle (summary+transcript+cost+errors) to stdout")
+    c.add_output_flags(p)
+    p.set_defaults(_handler=run)
+
+
+def _runtime_of(row: dict) -> str:
+    """Runtime id for a session row — the session-id prefix before ``:`` when
+    present, else the adapter's agent_type (mirrors sync._runtime_of_session;
+    the sessions table's agent_type says which ADAPTER ingested the row, which
+    is 'openclaw' even for claude_code:-prefixed family sessions)."""
+    sid = str(row.get("session_id", "") or "")
+    if ":" in sid:
+        return sid.split(":", 1)[0]
+    return str(row.get("agent_type") or "openclaw")
+
+
+def _load_rows(store, args, limit: int = 1000):
+    rows = c.call(store, "query_sessions_table", limit=limit)
+    if getattr(args, "runtime", None):
+        rows = [r for r in rows if _runtime_of(r) == args.runtime]
+    return rows
+
+
+def _resolve(store, args, sid: str) -> dict:
+    rows = _load_rows(store, args)
+    exact = [r for r in rows if r.get("session_id") == sid]
+    if exact:
+        return exact[0]
+    prefixed = [r for r in rows if str(r.get("session_id", "")).startswith(sid)]
+    if len(prefixed) == 1:
+        return prefixed[0]
+    if len(prefixed) > 1:
+        raise c.CliError(
+            "bad_request",
+            f"session prefix {sid!r} is ambiguous ({len(prefixed)} matches); "
+            "use more characters",
+            c.EXIT_USAGE,
+        )
+    raise c.CliError("not_found", f"no session matching {sid!r}", c.EXIT_NOT_FOUND)
+
+
+def run(args) -> int:
+    store, source = c.get_read_store()
+    if args.session_id:
+        return _run_detail(store, source, args)
+    return _run_list(store, source, args)
+
+
+def _run_list(store, source, args) -> int:
+    limit = max(1, min(int(args.limit or 50), 1000))
+    since, _until = c.resolve_window(args)
+    rows = _load_rows(store, args, limit=max(limit, 200))
+    if args.active:
+        rows = [r for r in rows if str(r.get("status", "")).lower() == "active"]
+    if since:
+        rows = [r for r in rows if str(r.get("last_active_at") or "") >= since]
+    rows = rows[:limit]
+    if args.as_json:
+        c.emit_json({"sessions": rows, "source": source})
+        return c.EXIT_OK
+    view = [
+        {
+            "session_id": c.short_sid(str(r.get("session_id", "")), 44),
+            "runtime": _runtime_of(r),
+            "status": r.get("status"),
+            "title": r.get("title"),
+            "tokens": c.fmt_tokens(r.get("total_tokens")),
+            "cost": c.fmt_cost(r.get("cost_usd")),
+            "last_active": str(r.get("last_active_at") or "")[:19],
+        }
+        for r in rows
+    ]
+    c.print_table(view, [
+        ("session_id", "SESSION", 44),
+        ("runtime", "RUNTIME", 12),
+        ("status", "STATUS", 8),
+        ("tokens", "TOKENS", 8),
+        ("cost", "COST", 10),
+        ("last_active", "LAST ACTIVE", 19),
+        ("title", "TITLE", 40),
+    ])
+    c.note(f"{len(view)} session(s) · source: {source}")
+    return c.EXIT_OK
+
+
+def _facet_payload(store, args, sid: str) -> tuple[str, object]:
+    since, until = c.resolve_window(args)
+    if args.transcript:
+        return "transcript", c.call(
+            store, "query_events",
+            session_id=sid, since=since, until=until, limit=2000,
+        )
+    if args.cost:
+        return "cost", c.call(
+            store, "query_cost_split_with_subagents", session_id=sid,
+        )
+    if args.errors:
+        return "errors", c.call(
+            store, "query_session_errors", session_id=sid, limit=200,
+        )
+    if args.lineage:
+        return "lineage", c.call(
+            store, "query_session_lineage", session_id=sid,
+        )
+    if args.journey:
+        return "journey", c.call(
+            store, "query_session_model_journey_with_subagents", session_id=sid,
+        )
+    return "", None
+
+
+def _run_detail(store, source, args) -> int:
+    row = _resolve(store, args, args.session_id)
+    sid = row["session_id"]
+
+    if args.export:
+        bundle = {
+            "session": row,
+            "transcript": c.call(store, "query_events", session_id=sid, limit=5000),
+            "cost": c.call(store, "query_cost_split_with_subagents", session_id=sid),
+            "errors": c.call(store, "query_session_errors", session_id=sid, limit=200),
+            "source": source,
+        }
+        if args.export == "json":
+            c.emit_json(bundle)
+        else:
+            _print_markdown_bundle(bundle)
+        return c.EXIT_OK
+
+    facet, payload = _facet_payload(store, args, sid)
+    if facet:
+        if args.as_json:
+            c.emit_json({facet: payload, "session_id": sid, "source": source})
+            return c.EXIT_OK
+        _print_facet_human(facet, payload)
+        c.note(f"session {sid} · source: {source}")
+        return c.EXIT_OK
+
+    # Default detail: the session row + cost headline.
+    if args.as_json:
+        c.emit_json({"session": row, "source": source})
+        return c.EXIT_OK
+    for key in ("session_id", "agent_type", "status", "title", "started_at",
+                "last_active_at", "ended_at", "message_count"):
+        if row.get(key) not in (None, ""):
+            print(f"{key:16} {row.get(key)}")
+    print(f"{'total_tokens':16} {c.fmt_tokens(row.get('total_tokens'))}")
+    print(f"{'cost_usd':16} {c.fmt_cost(row.get('cost_usd'))}")
+    c.note("facets: --transcript --cost --errors --lineage --journey --export json|md")
+    return c.EXIT_OK
+
+
+def _event_snippet(ev: dict, width: int = 100) -> str:
+    data = ev.get("data")
+    if isinstance(data, dict):
+        # Family tool_call events: show the tool + its key argument, not the
+        # raw envelope dict.
+        calls = data.get("tool_calls")
+        if isinstance(calls, list) and calls:
+            parts = []
+            for blk in calls[:3]:
+                if not isinstance(blk, dict):
+                    continue
+                inp = blk.get("input") or {}
+                arg = ""
+                if isinstance(inp, dict):
+                    arg = str(
+                        inp.get("file_path") or inp.get("command")
+                        or inp.get("path") or inp.get("pattern") or ""
+                    )
+                parts.append(f"{blk.get('name', 'tool')}({arg})" if arg
+                             else str(blk.get("name", "tool")))
+            return " ".join(parts)[:width]
+        if data.get("tool_name"):
+            return str(data["tool_name"])[:width]
+        for key in ("text", "content", "message", "error", "tool", "name"):
+            v = data.get(key)
+            if isinstance(v, str) and v.strip():
+                return v.strip()[:width]
+        return str({k: data[k] for k in list(data)[:3]})[:width]
+    return str(data or "")[:width]
+
+
+def _print_facet_human(facet: str, payload) -> None:
+    if facet == "transcript":
+        events = sorted(payload or [], key=lambda e: str(e.get("ts", "")))
+        for ev in events:
+            ts = str(ev.get("ts", ""))[:19]
+            print(f"{ts}  {str(ev.get('event_type', '') or ''):24} {_event_snippet(ev)}")
+        if not events:
+            c.note("(no events)")
+        return
+    if facet == "errors":
+        for ev in payload or []:
+            ts = str(ev.get("ts", ""))[:19]
+            print(f"{ts}  {str(ev.get('event_type', '') or ''):24} {_event_snippet(ev)}")
+        if not payload:
+            c.note("(no errors)")
+        return
+    # cost / lineage / journey: structured dicts/lists — render as indented JSON
+    # (still data → stdout; these shapes vary too much for a fixed table).
+    import json as _json
+    print(_json.dumps(payload, indent=2, default=str))
+
+
+def _print_markdown_bundle(bundle: dict) -> None:
+    row = bundle["session"]
+    print(f"# Session {row.get('session_id')}")
+    print()
+    for key in ("agent_type", "status", "title", "started_at", "last_active_at"):
+        if row.get(key):
+            print(f"- **{key}**: {row.get(key)}")
+    print(f"- **total_tokens**: {row.get('total_tokens')}")
+    print(f"- **cost_usd**: {row.get('cost_usd')}")
+    print()
+    print("## Transcript")
+    for ev in sorted(bundle.get("transcript") or [], key=lambda e: str(e.get("ts", ""))):
+        print(f"- `{str(ev.get('ts', ''))[:19]}` **{ev.get('event_type', '')}** "
+              f"{_event_snippet(ev, 200)}")
+    errors = bundle.get("errors") or []
+    if errors:
+        print()
+        print("## Errors")
+        for ev in errors:
+            print(f"- `{str(ev.get('ts', ''))[:19]}` {_event_snippet(ev, 200)}")

--- a/clawmetry/cli_cmds/sessions.py
+++ b/clawmetry/cli_cmds/sessions.py
@@ -176,11 +176,15 @@ def _run_detail(store, source, args) -> int:
         c.note(f"session {sid} · source: {source}")
         return c.EXIT_OK
 
-    # Default detail: the session row + cost headline.
+    # Default detail: the session row + cost headline. Human view shows the
+    # DERIVED runtime (session-id prefix rule) — agent_type says which
+    # adapter ingested the row and stays in --json only, so the detail and
+    # list views tell one story.
     if args.as_json:
         c.emit_json({"session": row, "source": source})
         return c.EXIT_OK
-    for key in ("session_id", "agent_type", "status", "title", "started_at",
+    print(f"{'runtime':16} {_runtime_of(row)}")
+    for key in ("session_id", "status", "title", "started_at",
                 "last_active_at", "ended_at", "message_count"):
         if row.get(key) not in (None, ""):
             print(f"{key:16} {row.get(key)}")
@@ -239,6 +243,9 @@ def _print_facet_human(facet: str, payload) -> None:
         return
     # cost / lineage / journey: structured dicts/lists — render as indented JSON
     # (still data → stdout; these shapes vary too much for a fixed table).
+    if payload in ([], {}):
+        c.note(f"(no {facet} rows recorded for this session)")
+        return
     import json as _json
     print(_json.dumps(payload, indent=2, default=str))
 

--- a/clawmetry/cli_cmds/usage.py
+++ b/clawmetry/cli_cmds/usage.py
@@ -1,0 +1,174 @@
+"""`clawmetry usage` — token/cost analytics from the terminal.
+
+    clawmetry usage [--since 7d] [--runtime R] [--json]
+    clawmetry usage --by model|day|team [--export csv]
+    clawmetry usage --efficiency [--days 30]
+
+Backed by the same store methods the Cost/Models tabs read through the
+daemon proxy: query_aggregates, query_rollup_model_daily,
+query_daily_usage_splits, query_usage_by_team, query_efficiency_rollup
+(+ clawmetry.efficiency.build_efficiency_slice for the A-F grade).
+"""
+from __future__ import annotations
+
+import csv
+import sys
+from collections import defaultdict
+
+from clawmetry.cli_cmds import _common as c
+
+
+def register(sub) -> None:
+    p = sub.add_parser(
+        "usage",
+        help="Token + cost rollups; --by model|day|team; --efficiency for the A-F grade",
+    )
+    p.add_argument("--by", choices=["model", "day", "team"],
+                   help="Break the rollup down by one dimension")
+    p.add_argument("--efficiency", action="store_true",
+                   help="Efficiency grade (A-F) + measured savings")
+    p.add_argument("--days", type=int, default=30,
+                   help="Window for --efficiency / --by team (default 30)")
+    c.add_runtime_flag(p)
+    c.add_window_flags(p, default_since="7d")
+    p.add_argument("--export", choices=["csv"],
+                   help="With --by: emit the table as CSV to stdout")
+    c.add_output_flags(p)
+    p.set_defaults(_handler=run)
+
+
+def run(args) -> int:
+    store, source = c.get_read_store()
+    since, until = c.resolve_window(args)
+
+    if args.efficiency:
+        return _run_efficiency(store, source, args)
+    if args.by == "model":
+        return _run_by_model(store, source, args, since, until)
+    if args.by == "day":
+        return _run_by_day(store, source, args, since, until)
+    if args.by == "team":
+        return _run_by_team(store, source, args)
+    return _run_totals(store, source, args, since, until)
+
+
+def _run_totals(store, source, args, since, until) -> int:
+    days = c.call(store, "query_aggregates",
+                  since=since, until=until, runtime=args.runtime)
+    total_tokens = sum(int(d.get("token_count") or 0) for d in days)
+    total_cost = sum(float(d.get("cost_usd") or 0) for d in days)
+    payload = {
+        "window_since": since,
+        "runtime": args.runtime,
+        "total_tokens": total_tokens,
+        "total_cost_usd": round(total_cost, 4),
+        "daily": days,
+        "source": source,
+    }
+    if args.as_json:
+        c.emit_json(payload)
+        return c.EXIT_OK
+    scope = args.runtime or "all runtimes"
+    print(f"tokens   {c.fmt_tokens(total_tokens)}")
+    print(f"cost     {c.fmt_cost(total_cost)}")
+    print(f"days     {len(days)}")
+    c.note(f"scope: {scope} · window since {since} · source: {source}")
+    c.note("breakdowns: --by model|day|team · grade: --efficiency")
+    return c.EXIT_OK
+
+
+def _emit_rows(args, rows: list[dict], columns: list[tuple[str, str, int]],
+               json_key: str, source: str) -> int:
+    if args.export == "csv":
+        keys = [k for k, _, _ in columns]
+        w = csv.DictWriter(sys.stdout, fieldnames=keys, extrasaction="ignore")
+        w.writeheader()
+        for r in rows:
+            w.writerow({k: r.get(k) for k in keys})
+        return c.EXIT_OK
+    if args.as_json:
+        c.emit_json({json_key: rows, "source": source})
+        return c.EXIT_OK
+    c.print_table(rows, columns)
+    c.note(f"{len(rows)} row(s) · source: {source}")
+    return c.EXIT_OK
+
+
+def _run_by_model(store, source, args, since, until) -> int:
+    daily = c.call(store, "query_rollup_model_daily",
+                   runtime=args.runtime, since=since, until=until, limit=1000)
+    agg: dict = defaultdict(lambda: {"tokens": 0, "cost_usd": 0.0, "calls": 0})
+    for r in daily:
+        key = (r.get("runtime"), r.get("model"))
+        b = agg[key]
+        b["tokens"] += int(r.get("tokens_in") or 0) + int(r.get("tokens_out") or 0)
+        b["cost_usd"] += float(r.get("cost_usd") or 0)
+        b["calls"] += int(r.get("calls") or 0)
+    rows = [
+        {"runtime": rt, "model": m, "tokens": b["tokens"],
+         "cost_usd": round(b["cost_usd"], 4), "calls": b["calls"]}
+        for (rt, m), b in sorted(agg.items(), key=lambda kv: -kv[1]["cost_usd"])
+    ]
+    return _emit_rows(args, rows, [
+        ("runtime", "RUNTIME", 12),
+        ("model", "MODEL", 34),
+        ("tokens", "TOKENS", 12),
+        ("cost_usd", "COST_USD", 10),
+        ("calls", "CALLS", 8),
+    ], "by_model", source)
+
+
+def _run_by_day(store, source, args, since, until) -> int:
+    rows = c.call(store, "query_daily_usage_splits",
+                  since=since, until=until, runtime=args.runtime)
+    if isinstance(rows, dict):
+        rows = rows.get("daily") or rows.get("days") or [rows]
+    return _emit_rows(args, list(rows), [
+        ("date", "DATE", 10),
+        ("input_tokens", "INPUT", 12),
+        ("output_tokens", "OUTPUT", 12),
+        ("cache_read_tokens", "CACHE_READ", 12),
+        ("cache_write_tokens", "CACHE_WRITE", 12),
+    ], "daily", source)
+
+
+def _run_by_team(store, source, args) -> int:
+    rows = c.call(store, "query_usage_by_team",
+                  window_days=max(1, int(args.days or 30)))
+    return _emit_rows(args, list(rows), [
+        ("team", "TEAM", 24),
+        ("tokens", "TOKENS", 12),
+        ("cost_usd", "COST_USD", 10),
+        ("sessions", "SESSIONS", 8),
+    ], "by_team", source)
+
+
+def _run_efficiency(store, source, args) -> int:
+    days = max(1, int(args.days or 30))
+    rows = c.call(store, "query_efficiency_rollup", days=days)
+    try:
+        from clawmetry.efficiency import build_efficiency_slice
+        slice_ = build_efficiency_slice(rows, days=days)
+    except Exception as exc:
+        raise c.CliError("internal", f"efficiency grading failed: {exc}", c.EXIT_ERROR)
+    slice_["source"] = source
+    if args.as_json:
+        c.emit_json(slice_)
+        return c.EXIT_OK
+    grade = slice_.get("grade") or slice_.get("status") or "?"
+    print(f"grade    {grade}")
+    for key in ("cache_hit_rate", "cacheHitRate", "measured_savings_usd",
+                "measuredSavingsUsd", "potential_savings_usd",
+                "potentialSavingsUsd"):
+        if key in slice_:
+            print(f"{key:24} {slice_[key]}")
+    by_rt = slice_.get("byRuntime") or {}
+    if by_rt:
+        print()
+        view = [
+            {"runtime": rt, "grade": (v or {}).get("grade", "?")}
+            for rt, v in sorted(by_rt.items())
+        ]
+        c.print_table(view, [("runtime", "RUNTIME", 14), ("grade", "GRADE", 6)])
+    c.note(f"window {days}d · source: {source} · full detail: --json")
+    return c.EXIT_OK

--- a/clawmetry/cli_cmds/usage.py
+++ b/clawmetry/cli_cmds/usage.py
@@ -166,7 +166,7 @@ def _run_efficiency(store, source, args) -> int:
     if by_rt:
         print()
         view = [
-            {"runtime": rt, "grade": (v or {}).get("grade", "?")}
+            {"runtime": rt, "grade": (v or {}).get("grade") or "-"}
             for rt, v in sorted(by_rt.items())
         ]
         c.print_table(view, [("runtime", "RUNTIME", 14), ("grade", "GRADE", 6)])

--- a/clawmetry/cli_cmds/waste.py
+++ b/clawmetry/cli_cmds/waste.py
@@ -1,0 +1,90 @@
+"""`clawmetry waste` — the re-read tax, from the terminal.
+
+    clawmetry waste [--session SID] [--since 7d] [--json]
+
+Aggregates ``query_recent_read_tool_calls`` rows (one per Read-tool
+invocation: {ts, session_id, file_path}) into the number an agent can act
+on mid-task: which files it read more than once, per session. A file read
+14 times is context the agent already paid for 13 times.
+"""
+from __future__ import annotations
+
+from collections import Counter
+
+from clawmetry.cli_cmds import _common as c
+
+
+def register(sub) -> None:
+    p = sub.add_parser(
+        "waste",
+        help="Re-read tax: files read repeatedly in the same session",
+    )
+    p.add_argument("--session", dest="session_id", metavar="SID",
+                   help="Scope to one session id (or unique prefix)")
+    c.add_window_flags(p, default_since="7d")
+    p.add_argument("--top", type=int, default=15,
+                   help="Show the N worst offenders (default 15)")
+    c.add_output_flags(p)
+    p.set_defaults(_handler=run)
+
+
+def run(args) -> int:
+    store, source = c.get_read_store()
+    since, _until = c.resolve_window(args)
+    rows = c.call(store, "query_recent_read_tool_calls", since=since, limit=50_000)
+
+    sid_filter = args.session_id
+    if sid_filter:
+        rows = [r for r in rows
+                if str(r.get("session_id", "")).startswith(sid_filter)]
+
+    per_pair: Counter = Counter()
+    for r in rows:
+        fp = r.get("file_path")
+        sid = r.get("session_id")
+        if fp and sid:
+            per_pair[(sid, fp)] += 1
+
+    rereads = [
+        {"session_id": sid, "file_path": fp, "reads": n, "wasted_reads": n - 1}
+        for (sid, fp), n in per_pair.items() if n > 1
+    ]
+    rereads.sort(key=lambda r: -r["wasted_reads"])
+    total_reads = sum(per_pair.values())
+    wasted = sum(r["wasted_reads"] for r in rereads)
+    summary = {
+        "window_since": since,
+        "total_reads": total_reads,
+        "wasted_reads": wasted,
+        "reread_ratio": round(wasted / total_reads, 3) if total_reads else 0.0,
+        "files_reread": len(rereads),
+        "sessions_affected": len({r["session_id"] for r in rereads}),
+        "top": rereads[: max(1, int(args.top or 15))],
+        "source": source,
+    }
+    if args.as_json:
+        c.emit_json(summary)
+        return c.EXIT_OK
+
+    print(f"reads          {total_reads}")
+    print(f"wasted reads   {wasted}  (same file re-read in the same session)")
+    print(f"reread ratio   {summary['reread_ratio']:.0%}" if total_reads else "reread ratio   0%")
+    print(f"files reread   {summary['files_reread']}")
+    print()
+    view = [
+        {
+            "reads": r["reads"],
+            "session": c.short_sid(str(r["session_id"]), 30),
+            "file": r["file_path"],
+        }
+        for r in summary["top"]
+    ]
+    c.print_table(view, [
+        ("reads", "READS", 6),
+        ("session", "SESSION", 30),
+        ("file", "FILE", 80),
+    ])
+    c.note(f"window since {since} · source: {source}")
+    if wasted:
+        c.note("tip: read a file once, keep notes; use offset-ranged reads for big files")
+    return c.EXIT_OK

--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -11811,6 +11811,21 @@ def _extract_usage_cost_split(data: dict) -> dict[str, float]:
 _READ_TOOL_NAMES = frozenset({"read", "readfile", "read_file"})
 
 
+def _iter_family_tool_call_blocks(data: dict) -> Iterable[dict]:
+    """Yield the ``data.tool_calls[*]`` blocks family adapters emit
+    (claude_code / codex / cursor … via clawmetry-pro): each block is
+    ``{id, name, input}``. This is a FOURTH on-the-wire shape the three
+    ``_iter_*`` tool extractors below must all probe — same bug class as
+    the 2026-06-11 ``tool_name`` fix in ``_iter_tool_invocation_names``:
+    without it every family Read/tool path is invisible (found 2026-07-31
+    when `clawmetry waste` returned 0 rows on a Claude-Code-heavy node)."""
+    blocks = data.get("tool_calls")
+    if isinstance(blocks, list):
+        for blk in blocks:
+            if isinstance(blk, dict):
+                yield blk
+
+
 def _iter_read_tool_paths(event_type: str | None, data: dict) -> Iterable[str]:
     """Yield ``file_path`` arguments for every Read-like tool invocation
     described by ``data``. Handles all three on-the-wire shapes the
@@ -11839,13 +11854,21 @@ def _iter_read_tool_paths(event_type: str | None, data: dict) -> Iterable[str]:
 
     et = (event_type or "").lower()
 
-    # Shape 1: top-level tool.call / toolCall / tool_use event.
-    if et in ("tool.call", "toolcall", "tool_use"):
+    # Shape 1: top-level tool.call / toolCall / tool_use / tool_call event.
+    if et in ("tool.call", "toolcall", "tool_use", "tool_call"):
         name = (data.get("name") or "").lower()
         if name in _READ_TOOL_NAMES:
             p = _path_from_input(data.get("input") or data.get("arguments"))
             if p:
                 yield p
+        # Shape 4: family-adapter ``tool_call`` events carry the actual
+        # blocks under ``data.tool_calls[*]`` ({name, input}) with only a
+        # ``tool_name`` summary at the top level.
+        for blk in _iter_family_tool_call_blocks(data):
+            if (blk.get("name") or "").lower() in _READ_TOOL_NAMES:
+                p = _path_from_input(blk.get("input") or blk.get("arguments"))
+                if p:
+                    yield p
         return
 
     # Shape 2: assistant ``message`` event with ``toolMetas`` projection
@@ -11905,10 +11928,15 @@ def _iter_tool_file_paths(event_type: str | None, data: dict) -> Iterable[str]:
                 return v
         return ""
 
-    if et in ("tool.call", "toolcall", "tool_use"):
+    if et in ("tool.call", "toolcall", "tool_use", "tool_call"):
         p = _path(data.get("input") or data.get("arguments"))
         if p:
             yield p
+        # Family-adapter shape: blocks under ``data.tool_calls[*]``.
+        for blk in _iter_family_tool_call_blocks(data):
+            p = _path(blk.get("input") or blk.get("arguments"))
+            if p:
+                yield p
         return
     for m in (data.get("toolMetas") or []):
         if isinstance(m, dict):
@@ -11950,6 +11978,13 @@ def _iter_tool_invocation_names(event_type: str | None, data: dict) -> Iterable[
                 or data.get("tool_name"))
         if isinstance(name, str) and name:
             yield name
+        # Family-adapter shape: a single event can carry MULTIPLE blocks
+        # under ``data.tool_calls[*]``; ``tool_name`` above only names the
+        # first. Yield the rest so parallel tool calls count.
+        for blk in _iter_family_tool_call_blocks(data):
+            bname = blk.get("name")
+            if isinstance(bname, str) and bname and bname != name:
+                yield bname
         return
 
     # Shape 2: assistant ``message`` event with ``toolMetas`` projection

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -1,0 +1,105 @@
+# ClawMetry Agent CLI
+
+Everything the dashboard shows, readable from a terminal. Built for three
+consumers: humans debugging an agent, CI gating on agent health, and AI
+agents reading their own telemetry to improve themselves mid-task.
+
+Phase 1 ships the self-improve loop core. Setup/ops commands
+(`clawmetry status`, `connect`, `sync`, `proxy`, ...) are documented in the
+README; this page covers the observability reads.
+
+## Commands
+
+| Command | What it answers |
+|---|---|
+| `clawmetry sessions` | What sessions ran? `sessions <SID> --transcript/--cost/--errors/--lineage/--journey` drills in. |
+| `clawmetry activity` | What is the agent doing right now? (`--follow` streams; `--type`, `--session` filter) |
+| `clawmetry waste` | Which files did the agent pay to re-read? (the re-read tax) |
+| `clawmetry progress` | Is the agent making forward progress or spinning? (+ loop signals) |
+| `clawmetry usage` | Tokens and cost. `--by model\|day\|team`, `--efficiency` for the A-F grade. |
+| `clawmetry selfevolve` | [pro] Analyze and apply agent improvements. OSS prints the upgrade path (exit 4). |
+
+## Interface contract
+
+- **stdout is data, stderr is decoration.** Row counts, hints, and source
+  notes go to stderr so `clawmetry sessions | awk '{print $1}'` just works.
+- **`--json`** emits one JSON object: the same rows the local read API
+  serves, no envelope.
+- **`--follow`** (on `activity`) emits NDJSON: a `{"type":"_meta",...}`
+  first line, one event per line, and a final
+  `{"type":"_end","reason":...,"next_cursor":...}` so a consumer can resume
+  exactly where it stopped. It never hangs: `--idle-timeout` (default 300s),
+  `--max-events`, and Ctrl-C all end the stream cleanly with `_end`.
+- **Time windows**: `--since`/`--until` take ISO-8601 or relative
+  (`90s`, `15m`, `6h`, `7d`); `--last 24h` is sugar for `--since 24h`.
+- **Runtime scoping**: `--runtime claude_code` (same ids as the dashboard
+  runtime switcher: `openclaw`, `claude_code`, `codex`, `cursor`, ...).
+
+### Exit codes (stable)
+
+| Code | Meaning |
+|---|---|
+| 0 | Success (including empty results) |
+| 1 | Internal error |
+| 2 | Usage error |
+| 3 | No data source answered (no daemon, no local store); retryable |
+| 4 | Entitlement-gated (the CLI's 402; stderr carries the JSON upgrade body) |
+| 5 | Auth failure |
+| 6 | Not found (unknown session id) |
+
+Errors print a one-line human sentence plus a JSON body on stderr:
+`{"error":{"code":"...","message":"...", ...}}`.
+
+## Transport (invisible)
+
+Reads go through the sync daemon's local query server when the daemon is
+running (the daemon owns the DuckDB writer lock), and fall back to a direct
+read-only DuckDB open on single-process installs. No dashboard process is
+required for any read, including `activity --follow`. Every JSON payload
+carries a `source` field (`daemon` or `direct`) so consumers know which rung
+answered.
+
+## The self-improve loop
+
+An agent finds its own session, checks what it wasted, and verifies the fix:
+
+```bash
+# 1. Find myself (newest active session for my runtime)
+SID=$(clawmetry sessions --runtime claude_code --active --json \
+      | python3 -c "import json,sys; print(json.load(sys.stdin)['sessions'][0]['session_id'])")
+
+# 2. What am I wasting?
+clawmetry waste --session "$SID" --json
+# → {"top":[{"file_path":"routes/sessions.py","reads":14,"wasted_reads":13}], ...}
+
+# 3. Am I spinning?
+clawmetry progress "$SID" --json
+# → {"sessions":[{"ratio":48210, ...}], "loop_signals":[...]}
+
+# 4. Act: stop re-reading that file (keep notes), change strategy if looping.
+# 5. Verify next turn: wasted_reads flat, ratio down, grade up:
+clawmetry usage --efficiency
+```
+
+CI health gate example:
+
+```bash
+clawmetry progress --since 1h --json | python3 -c "
+import json,sys
+d = json.load(sys.stdin)
+spinning = [s for s in d['sessions'] if s['ratio'] > 100000]
+sys.exit(1 if spinning or d['loop_signals'] else 0)"
+```
+
+### Drop-in agent instructions
+
+Paste into your project's `AGENTS.md` / `CLAUDE.md` on machines running
+ClawMetry:
+
+> This machine runs ClawMetry (agent observability). Before finishing a
+> task, run `clawmetry waste --since 6h --json` and
+> `clawmetry progress --json`. If a file shows repeated re-reads, stop
+> re-reading it and keep notes instead. If forward-progress ratio is high or
+> loop signals fire, stop brute-forcing and change approach. Check spend
+> with `clawmetry usage --json`. All commands exit 3 when ClawMetry isn't
+> running (safe to skip), and are read-only.

--- a/docs/skills/clawmetry-selfcheck/SKILL.md
+++ b/docs/skills/clawmetry-selfcheck/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: clawmetry-selfcheck
+description: Read your own agent telemetry from ClawMetry (waste, progress, cost) and act on it before finishing a task. Use when ClawMetry is installed on this machine and you want to check whether you are re-reading files, spinning in loops, or burning budget.
+---
+
+# ClawMetry self-check
+
+ClawMetry observes AI agent sessions on this machine (read-only). Use its
+CLI to see your own telemetry and improve your behaviour mid-task.
+
+All commands are read-only, exit `3` when ClawMetry has no data source
+running (safe to skip silently), and support `--json`.
+
+## The 3-step check (run before finishing a task)
+
+```bash
+# 1. Re-read tax: files you paid to read more than once
+clawmetry waste --since 6h --json
+
+# 2. Spinning check: forward progress + loop signals
+clawmetry progress --json
+
+# 3. Spend check
+clawmetry usage --json
+```
+
+## How to act on what you find
+
+| Signal | Action |
+|---|---|
+| A file with `reads > 3` in `waste` | Stop re-reading it. Write its structure into your working notes once; use offset-ranged reads for big files. |
+| High `ratio` (tokens per state-delta) in `progress` | You are burning tokens without producing new state. Write down what you tried, change strategy. |
+| `loop_signals` non-empty | You repeated near-identical calls. Do not retry the same thing; diagnose instead. |
+| Cost spike in `usage` | Check `usage --by model`: are you using a bigger model than the task needs? |
+
+## Digging deeper
+
+```bash
+clawmetry sessions --active                  # who is running
+clawmetry sessions <SID> --transcript        # what actually happened
+clawmetry sessions <SID> --cost              # where the money went (incl. sub-agents)
+clawmetry sessions <SID> --errors            # error events only
+clawmetry activity --follow --max-events 50  # live NDJSON event stream
+clawmetry usage --efficiency                 # A-F efficiency grade
+```
+
+Exit codes: `0` ok, `3` no data source (skip), `4` feature needs an upgrade
+(stderr carries a JSON body with `upgrade_url`; surface it to your human).

--- a/routes/local_query.py
+++ b/routes/local_query.py
@@ -813,6 +813,10 @@ _DAEMON_METHODS = frozenset({
     "query_ar_history",
     # Issue #3696 — OpenClaw backup/snapshot lifecycle observability.
     "query_backups",
+    # Agent CLI Phase 1 (docs/CLI.md): `clawmetry usage --by team`
+    # reads the per-team rollup through the daemon proxy. Every other method
+    # the agent CLI calls was already allowlisted; guards-in-same-PR rule.
+    "query_usage_by_team",
 })
 
 

--- a/tests/test_agent_cli.py
+++ b/tests/test_agent_cli.py
@@ -1,0 +1,257 @@
+"""Agent CLI Phase 1 (docs/CLI.md) regression tests.
+
+Covers:
+  * the family-adapter ``data.tool_calls[*]`` extractor fix in
+    clawmetry/local_store.py (the `clawmetry waste` == 0 bug: family
+    Read calls were invisible to all three ``_iter_*`` tool extractors)
+  * the CLI exit-code contract (0 ok / 3 no source / 4 entitlement /
+    6 not found) and the --json output shapes
+  * the --follow NDJSON frame contract (_meta first, _end last, resume
+    cursor)
+
+Hermetic: a FakeStore stands in for the daemon proxy — no DuckDB, no
+server. The extractor tests import clawmetry.local_store directly (pure
+functions).
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from clawmetry.cli_cmds import dispatch
+from clawmetry.cli_cmds import _common
+from clawmetry.local_store import (
+    _iter_read_tool_paths,
+    _iter_tool_file_paths,
+    _iter_tool_invocation_names,
+)
+
+
+# ── The family tool_calls[*] shape (claude_code / codex / cursor …) ────────
+
+FAMILY_TOOL_CALL_EVENT = {
+    "_runtime": "claude_code",
+    "content": "",
+    "role": "assistant",
+    "tool_name": "Read",
+    "tool_calls": [
+        {
+            "id": "toolu_01",
+            "name": "Read",
+            "input": {"file_path": "/repo/routes/sessions.py"},
+        },
+        {
+            "id": "toolu_02",
+            "name": "Bash",
+            "input": {"command": "ls"},
+        },
+    ],
+}
+
+
+def test_read_paths_extracted_from_family_tool_calls():
+    # Un-fixed code yields [] here (shape-1 set lacked 'tool_call' and nobody
+    # walked data.tool_calls) — the `clawmetry waste` == 0 regression.
+    paths = list(_iter_read_tool_paths("tool_call", FAMILY_TOOL_CALL_EVENT))
+    assert paths == ["/repo/routes/sessions.py"]
+
+
+def test_tool_file_paths_extracted_from_family_tool_calls():
+    paths = list(_iter_tool_file_paths("tool_call", FAMILY_TOOL_CALL_EVENT))
+    assert "/repo/routes/sessions.py" in paths
+
+
+def test_invocation_names_count_every_family_block():
+    names = list(_iter_tool_invocation_names("tool_call", FAMILY_TOOL_CALL_EVENT))
+    # tool_name names the first block; the Bash block must ALSO count.
+    assert "Read" in names and "Bash" in names
+
+
+def test_legacy_shapes_still_extract():
+    # Guard the pre-existing shapes against regression by the family fix.
+    top_level = {"name": "Read", "input": {"file_path": "/a.py"}}
+    assert list(_iter_read_tool_paths("tool.call", top_level)) == ["/a.py"]
+    metas = {"toolMetas": [{"name": "read_file", "input": {"path": "/b.py"}}]}
+    assert list(_iter_read_tool_paths("assistant", metas)) == ["/b.py"]
+
+
+# ── CLI harness ─────────────────────────────────────────────────────────────
+
+class FakeStore:
+    """Read-only stand-in for the daemon proxy store."""
+
+    def __init__(self):
+        self.sessions = [
+            {
+                "session_id": "claude_code:abc123",
+                "agent_type": "openclaw",
+                "status": "active",
+                "title": "fix the tests",
+                "total_tokens": 1000,
+                "cost_usd": 0.5,
+                "last_active_at": "2099-01-01T00:00:00Z",
+            },
+            {
+                "session_id": "openclaw-uuid-1",
+                "agent_type": "openclaw",
+                "status": "ended",
+                "title": "telegram chat",
+                "total_tokens": 200,
+                "cost_usd": 0.1,
+                "last_active_at": "2099-01-01T00:00:00Z",
+            },
+        ]
+
+    def query_sessions_table(self, *, limit=200, **kw):
+        return self.sessions[:limit]
+
+    def query_events(self, **kw):
+        return []
+
+    def query_recent_read_tool_calls(self, **kw):
+        return [
+            {"ts": "t1", "session_id": "claude_code:abc123", "file_path": "/x.py"},
+            {"ts": "t2", "session_id": "claude_code:abc123", "file_path": "/x.py"},
+            {"ts": "t3", "session_id": "claude_code:abc123", "file_path": "/y.py"},
+        ]
+
+    def query_forward_progress(self, **kw):
+        return [{"session_id": "claude_code:abc123", "tokens": 5000,
+                 "state_deltas": 1, "ratio": 5000.0}]
+
+    def query_recent_loop_signals(self, **kw):
+        return []
+
+    def query_aggregates(self, **kw):
+        return [{"day": "2099-01-01", "token_count": 42, "cost_usd": 1.5,
+                 "event_count": 7, "agent_id": "main"}]
+
+
+@pytest.fixture
+def fake_store(monkeypatch):
+    store = FakeStore()
+    monkeypatch.setattr(_common, "get_read_store", lambda: (store, "daemon"))
+    return store
+
+
+def run_cli(argv, capsys):
+    code = dispatch(argv)
+    out = capsys.readouterr()
+    return code, out.out, out.err
+
+
+# ── Exit codes + shapes ─────────────────────────────────────────────────────
+
+def test_sessions_json_shape(fake_store, capsys):
+    code, out, _err = run_cli(["sessions", "--json"], capsys)
+    assert code == 0
+    payload = json.loads(out)
+    assert payload["source"] == "daemon"
+    assert payload["sessions"][0]["session_id"] == "claude_code:abc123"
+
+
+def test_sessions_runtime_filter_uses_prefix_not_agent_type(fake_store, capsys):
+    # agent_type is 'openclaw' for BOTH rows; the claude_code row must be
+    # selected by its session-id prefix (the _runtime_of_session rule).
+    code, out, _ = run_cli(["sessions", "--runtime", "claude_code", "--json"], capsys)
+    assert code == 0
+    rows = json.loads(out)["sessions"]
+    assert [r["session_id"] for r in rows] == ["claude_code:abc123"]
+    code, out, _ = run_cli(["sessions", "--runtime", "openclaw", "--json"], capsys)
+    assert [r["session_id"] for r in json.loads(out)["sessions"]] == ["openclaw-uuid-1"]
+
+
+def test_unknown_session_exits_6(fake_store, capsys):
+    code, _out, err = run_cli(["sessions", "nope-such-id"], capsys)
+    assert code == _common.EXIT_NOT_FOUND
+    assert "not_found" in err
+
+
+def test_no_data_source_exits_3(monkeypatch, capsys):
+    def boom():
+        raise _common.CliError("unavailable", "no store", _common.EXIT_UNAVAILABLE)
+    monkeypatch.setattr(_common, "get_read_store", boom)
+    code, _out, err = run_cli(["sessions"], capsys)
+    assert code == _common.EXIT_UNAVAILABLE
+    assert "unavailable" in err
+
+
+def test_selfevolve_stub_exits_4_with_upgrade_body(monkeypatch, capsys):
+    # Force the un-entitled path regardless of the dev machine's license.
+    from clawmetry.cli_cmds import selfevolve as se
+    monkeypatch.setattr(se, "_allowed", lambda: False)
+    monkeypatch.setattr(se, "_pro_impl", lambda: None)
+    monkeypatch.setattr(se, "_record_paywall_event", lambda action: None)
+    code, _out, err = run_cli(["selfevolve", "fix"], capsys)
+    assert code == _common.EXIT_ENTITLEMENT
+    body = json.loads(err.splitlines()[-1])
+    assert body["error"]["code"] == "upgrade_required"
+    assert body["error"]["feature"] == "self_evolve"
+    assert body["error"]["upgrade_url"].startswith("https://clawmetry.com/upgrade")
+
+
+def test_waste_counts_rereads(fake_store, capsys):
+    code, out, _ = run_cli(["waste", "--json"], capsys)
+    assert code == 0
+    payload = json.loads(out)
+    assert payload["total_reads"] == 3
+    assert payload["wasted_reads"] == 1  # /x.py read twice
+    assert payload["top"][0]["file_path"] == "/x.py"
+
+
+def test_usage_totals_use_token_count_key(fake_store, capsys):
+    # Regression: query_aggregates rows carry token_count (not tokens);
+    # the totals rendered 0 until the key was fixed.
+    code, out, _ = run_cli(["usage", "--json"], capsys)
+    assert code == 0
+    payload = json.loads(out)
+    assert payload["total_tokens"] == 42
+    assert payload["total_cost_usd"] == 1.5
+
+
+def test_progress_json(fake_store, capsys):
+    code, out, _ = run_cli(["progress", "--json"], capsys)
+    assert code == 0
+    payload = json.loads(out)
+    assert payload["sessions"][0]["ratio"] == 5000.0
+    assert payload["loop_signals"] == []
+
+
+def test_stdout_is_awk_safe(fake_store, capsys):
+    # Human output: data on stdout, decoration on stderr.
+    code, out, err = run_cli(["sessions"], capsys)
+    assert code == 0
+    assert "session(s)" in err and "session(s)" not in out
+    header = out.splitlines()[0]
+    assert header.split()[0] == "SESSION"
+
+
+# ── --follow frame contract ─────────────────────────────────────────────────
+
+def test_follow_emits_meta_and_end_frames(fake_store, monkeypatch, capsys):
+    events = [{"ts": "2099-01-01T00:00:01Z", "session_id": "s", "event_type": "x",
+               "data": {}}]
+    monkeypatch.setattr(FakeStore, "query_events", lambda self, **kw: list(events))
+    code, out, _ = run_cli(
+        ["activity", "--follow", "--max-events", "1", "--idle-timeout", "5"],
+        capsys,
+    )
+    assert code == 0
+    lines = [json.loads(line) for line in out.splitlines()]
+    assert lines[0]["type"] == "_meta"
+    assert lines[0]["source"] == "daemon"
+    assert lines[-1]["type"] == "_end"
+    assert lines[-1]["reason"] == "max_events"
+    assert lines[-1]["next_cursor"] == "2099-01-01T00:00:01Z"
+
+
+# ── parse_when ──────────────────────────────────────────────────────────────
+
+def test_parse_when_relative_and_iso():
+    iso = _common.parse_when("2026-07-31T00:00:00Z")
+    assert iso == "2026-07-31T00:00:00Z"
+    rel = _common.parse_when("15m")
+    assert rel.endswith("Z") and rel != iso
+    with pytest.raises(_common.CliError):
+        _common.parse_when("next tuesday")


### PR DESCRIPTION
## Why

Everything the dashboard shows becomes readable from a terminal, so humans can test every feature without a browser, CI can gate on agent health, and AI agents (Claude Code, Codex, Cursor, ...) can read their own telemetry mid-task and close a self-improve loop: observe, diagnose, change behavior, verify. Design doc: `docs/CLI.md` (full internal plan reviewed via UX + product review passes).

Shipped as one PR instead of four stacked ones: 1b-1d all depend on 1a's plumbing, everything is new files plus a 15-line fast-path hook, so serializing four CI cycles bought nothing.

## What

- **New package `clawmetry/cli_cmds/`** with a fast path in `cli.py` that dispatches before the dashboard import (~40ms) and before `CLAWMETRY_ROLE=dashboard` is set, so `get_store(read_only=True)` resolves transport by itself: **daemon proxy when the sync daemon runs, direct read-only DuckDB otherwise**. No dashboard process needed for any read. Read-only by construction: no command can take the writer lock.
- **Commands**: `sessions` (list + `--transcript/--cost/--errors/--lineage/--journey/--export json|md`), `activity` (history + poll-based `--follow` NDJSON with `_meta`/`_end` frames and a resume cursor; `--max-events`/`--idle-timeout` never-hang rails), `waste` (re-read tax), `progress` (forward-progress ratio + loop signals), `usage` (`--by model|day|team`, `--efficiency` A-F grade, `--export csv`), `selfevolve` (OSS 402 stub: exit 4 with the canonical `upgrade_required` body + `upgrade_url`, records a paywall beacon).
- **Stable exit codes**: 0 ok / 1 error / 2 usage / 3 no data source (retryable) / 4 entitlement / 5 auth / 6 not found. stdout = data, stderr = decoration; `--json` shapes are the store-method shapes (no envelope).
- **Bug fix (class, not instance)**: all three `_iter_*` tool extractors in `local_store.py` missed the family-adapter shape `data.tool_calls[*]` (two also missed the `tool_call` event_type), making every Read by claude_code/codex/cursor/... invisible: `clawmetry waste` and `/api/skills` fidelity returned 0 on family-heavy nodes. Fixed via one shared block iterator probed by all three.
- **Allowlist**: `query_usage_by_team` added to `_DAEMON_METHODS` (guards-in-same-PR; every other method used was already listed).
- **Docs**: `docs/CLI.md` (interface contract + self-improve recipes + drop-in AGENTS.md snippet), `docs/skills/clawmetry-selfcheck/SKILL.md` (Claude Code skill teaching the 3-step self-check).

## Verification

- 15 hermetic tests in `tests/test_agent_cli.py` (extractor family fix, exit-code contract, runtime prefix filtering, waste math, `--follow` frame contract). `ruff` clean on all new files.
- **Live E2E on a real install** (daemon proxy, real Claude Code data): all commands serve real numbers; `usage` totals (2.9M tok / $377.87) reconcile with `--by model` (2.85M / $377.86); `--follow` emits `_meta` / events / `_end` with `next_cursor`; `selfevolve fix` exits 4 with tier-correct body. Extractor fix proven on the same live store: **0 Read rows before, 208 after** (with `clawmetry waste` then surfacing 34 wasted reads, including this very agent re-reading `local_store.py` 4 times while building the feature).

🤖 Generated with [Claude Code](https://claude.com/claude-code)