### PR TITLE
feat(adapter): surface gateway restart-handoff state in supervisor mode (#4302)

### DIFF
--- a/clawmetry/adapters/openclaw.py
+++ b/clawmetry/adapters/openclaw.py
@@ -89,7 +89,13 @@ def _d():
 
 def _gateway_live() -> bool:
     """True only if the OpenClaw gateway is actually up (pid alive or port
-    18789 listening). Never raises."""
+    18789 listening). Never raises.
+
+    When ``OPENCLAW_SUPERVISOR_MODE=external`` is set, a ``False`` return
+    during a restart-handoff is an expected transient, not a failure.
+    Callers should check ``gatewayInRestartHandoff`` in
+    ``DetectResult.meta`` (set by ``detect()``) for the full picture.
+    """
     home = os.environ.get("OPENCLAW_HOME") or os.path.expanduser("~/.openclaw")
     pid_file = os.path.join(home, "gateway", "gateway.pid")
     try:
@@ -1727,6 +1733,24 @@ def _gateway_supervisor_mode_env() -> dict:
         return {}
 
 
+def _gateway_is_in_restart_handoff(supervisor_mode: str, gateway_live: bool) -> bool:
+    """True when the gateway is briefly offline during an externally-supervised
+    restart-handoff (#4302).
+
+    An external lifecycle owner (e.g. OCM) manages gateway restarts when
+    ``OPENCLAW_SUPERVISOR_MODE=external``.  A ``False`` result from
+    ``_gateway_live()`` is then an expected transient — the supervisor will
+    bring the gateway back.  Callers surface "restarting (supervised)" rather
+    than "gateway offline" in the UI.
+
+    Never raises.
+    """
+    try:
+        return supervisor_mode == "external" and not gateway_live
+    except Exception:
+        return False
+
+
 def _gateway_presence_roster() -> dict:
     """Who's-online presence roster from the OpenClaw gateway.status RPC (#3884).
 
@@ -2108,6 +2132,13 @@ class OpenClawAdapter(AgentAdapter):
             # a supervised restart handoff). _gateway_host_status() below will
             # overwrite with the live RPC value when the gateway is up.
             meta.update(_gateway_supervisor_mode_env())
+            # During an externally-supervised restart-handoff the gateway is
+            # briefly down; flag this so callers show "restarting (supervised)"
+            # rather than "gateway offline" (#4302).
+            if _gateway_is_in_restart_handoff(
+                meta.get("gatewaySupervisorMode", ""), running
+            ):
+                meta["gatewayInRestartHandoff"] = True
             # Gateway plugin health (#3200): per-plugin state (loaded/errored/
             # disabled) added to gateway.status in harness 2026.6.9 (#93395).
             # Only meaningful — and safe to query — when the gateway is live.

--- a/tests/test_obs_gap_openclaw_supervisor_4302.py
+++ b/tests/test_obs_gap_openclaw_supervisor_4302.py
@@ -1,0 +1,99 @@
+"""Tests for #4302 — gateway liveness misreports during externally-supervised
+restart-handoff.
+
+``_gateway_live()`` probes PID + TCP only; it has no awareness that
+``OPENCLAW_SUPERVISOR_MODE=external`` means a gateway that appears down may
+simply be mid-handoff under an external lifecycle owner (e.g. OCM).
+
+Fixes:
+- ``_gateway_is_in_restart_handoff()`` — pure helper that infers the handoff
+  state from supervisor_mode + gateway_live.
+- ``detect()`` now sets ``meta["gatewayInRestartHandoff"] = True`` when the
+  helper returns True, so callers can surface "restarting (supervised)" rather
+  than "gateway offline".
+"""
+from __future__ import annotations
+
+import os
+
+
+def _adapter():
+    from clawmetry.adapters.openclaw import (
+        _gateway_is_in_restart_handoff,
+        _gateway_supervisor_mode_env,
+    )
+    return _gateway_is_in_restart_handoff, _gateway_supervisor_mode_env
+
+
+# ---------------------------------------------------------------------------
+# _gateway_supervisor_mode_env — env-var fallback already existed (#4023)
+# ---------------------------------------------------------------------------
+
+def test_supervisor_mode_env_unset(monkeypatch):
+    """No OPENCLAW_SUPERVISOR_MODE → empty dict."""
+    monkeypatch.delenv("OPENCLAW_SUPERVISOR_MODE", raising=False)
+    monkeypatch.delenv("OPENCLAW_SUPERVISOR_MODE_VERSION", raising=False)
+    _, _env = _adapter()
+    assert _env() == {}
+
+
+def test_supervisor_mode_env_external(monkeypatch):
+    """OPENCLAW_SUPERVISOR_MODE=external → gatewaySupervisorMode key present."""
+    monkeypatch.setenv("OPENCLAW_SUPERVISOR_MODE", "external")
+    monkeypatch.delenv("OPENCLAW_SUPERVISOR_MODE_VERSION", raising=False)
+    _, _env = _adapter()
+    result = _env()
+    assert result == {"gatewaySupervisorMode": "external"}
+
+
+def test_supervisor_mode_env_with_version(monkeypatch):
+    """Version env var is also surfaced when set."""
+    monkeypatch.setenv("OPENCLAW_SUPERVISOR_MODE", "external")
+    monkeypatch.setenv("OPENCLAW_SUPERVISOR_MODE_VERSION", "1.2")
+    _, _env = _adapter()
+    result = _env()
+    assert result["gatewaySupervisorMode"] == "external"
+    assert result["gatewaySupervisorModeVersion"] == "1.2"
+
+
+def test_supervisor_mode_env_non_external(monkeypatch):
+    """A supervisor mode value other than 'external' is still surfaced."""
+    monkeypatch.setenv("OPENCLAW_SUPERVISOR_MODE", "internal")
+    monkeypatch.delenv("OPENCLAW_SUPERVISOR_MODE_VERSION", raising=False)
+    _, _env = _adapter()
+    result = _env()
+    assert result["gatewaySupervisorMode"] == "internal"
+
+
+# ---------------------------------------------------------------------------
+# _gateway_is_in_restart_handoff — the new helper (#4302)
+# ---------------------------------------------------------------------------
+
+def test_handoff_external_and_gateway_down():
+    """external supervisor + gateway down → handoff in progress."""
+    _in_handoff, _ = _adapter()
+    assert _in_handoff("external", False) is True
+
+
+def test_handoff_external_and_gateway_up():
+    """external supervisor + gateway live → NOT in handoff (normal operation)."""
+    _in_handoff, _ = _adapter()
+    assert _in_handoff("external", True) is False
+
+
+def test_handoff_no_supervisor_and_gateway_down():
+    """No supervisor mode + gateway down → NOT a supervised handoff (real outage)."""
+    _in_handoff, _ = _adapter()
+    assert _in_handoff("", False) is False
+
+
+def test_handoff_no_supervisor_and_gateway_up():
+    """No supervisor mode + gateway up → not a handoff."""
+    _in_handoff, _ = _adapter()
+    assert _in_handoff("", True) is False
+
+
+def test_handoff_non_external_supervisor_and_gateway_down():
+    """Non-external supervisor mode + gateway down → not an external handoff."""
+    _in_handoff, _ = _adapter()
+    assert _in_handoff("internal", False) is False


### PR DESCRIPTION
## Summary

When `OPENCLAW_SUPERVISOR_MODE=external` is set, an OpenClaw gateway that appears offline may simply be mid-handoff under an external lifecycle owner (e.g. OCM). Before this fix, `_gateway_live()` returned `False` with no context, causing callers to display "gateway offline" during what is actually a managed, expected restart.

## Changes

- **`clawmetry/adapters/openclaw.py`**: Added `_gateway_is_in_restart_handoff(supervisor_mode, gateway_live)` — a pure helper that infers the restart-handoff state. Called in `detect()` to set `meta["gatewayInRestartHandoff"] = True` when the gateway is temporarily down in external supervisor mode. Updated `_gateway_live()` docstring to document the supervisor mode context.
- **`tests/test_obs_gap_openclaw_supervisor_4302.py`**: 9 unit tests covering `_gateway_supervisor_mode_env()` (env var set/unset/versioned) and `_gateway_is_in_restart_handoff()` (all four combinations of supervisor_mode × gateway_live).

## Test plan

- [ ] `python3 -m pytest tests/test_obs_gap_openclaw_supervisor_4302.py -v` — all 9 tests pass
- [ ] Verify no regressions: `python3 -c "import ast; ast.parse(open('clawmetry/adapters/openclaw.py').read()); print('OK')"`
- [ ] Optional: manually set `OPENCLAW_SUPERVISOR_MODE=external` with gateway down and confirm `DetectResult.meta["gatewayInRestartHandoff"]` is `True`

## Bot meta
<!-- bot-autofix -->
Draft PR opened autonomously based on the plan in #4302. Marked draft for human review — mark Ready for Review once happy.

Closes #4302

---
_Generated by [Claude Code](https://claude.ai/code/session_01UDBYhpv2EubDeeGuRpCGaL)_