### PR TITLE
fix(sync): cloud egress is opt-in — no linked account, no ingest

### DIFF
--- a/clawmetry/config.py
+++ b/clawmetry/config.py
@@ -111,6 +111,26 @@ def is_cloud_disabled() -> bool:
         return False
 
 
+def cloud_egress_enabled(config: dict = None) -> bool:
+    """Cloud egress is OPT-IN — True only when the user explicitly linked an
+    account AND has not opted out.
+
+    Product rule (founder, 2026-07-31): a default install is SELF-HOSTED —
+    nothing leaves the machine until the user runs `clawmetry login` /
+    `clawmetry connect` (or picks the managed/cloud onboarding path), all of
+    which persist an ``api_key``. Before this, gating was opt-OUT only
+    (the nocloud marker), so a self-hosted node with a license key but no
+    account heart-beat ``X-Api-Key: ""`` to ingest every cycle and logged a
+    wall of 401 warnings (found live on a Windows node, 2026-07-31).
+
+    The nocloud marker / CLAWMETRY_NO_CLOUD still hard-disable egress even
+    when a key exists.
+    """
+    if is_cloud_disabled():
+        return False
+    return bool((config or {}).get("api_key"))
+
+
 def enable_cloud() -> bool:
     """Clear the local-only marker so the daemon resumes cloud sync.
 

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -1051,6 +1051,13 @@ def _post(path: str, payload: dict, api_key: str, timeout: int = 45) -> dict:
             return {"_cloud_disabled": True, "sync_allowed": False}
     except Exception:
         pass
+    # Opt-in gate: cloud egress requires an explicitly linked account.
+    # A self-hosted node (e.g. license-key onboarding, never connected) has
+    # api_key="" — previously every cycle POSTed X-Api-Key:"" and got a 401
+    # (3 retries each), spamming both ingest and the local log. Default =
+    # nothing leaves the machine until `clawmetry login`/`connect`.
+    if not api_key:
+        return {"_no_account": True, "sync_allowed": False}
     url = INGEST_URL.rstrip("/") + path
     body = json.dumps(payload).encode()
     headers = {"Content-Type": "application/json", "X-Api-Key": api_key}
@@ -7159,6 +7166,10 @@ def send_heartbeat(config: dict) -> bool:
             return False
     except Exception:
         pass
+    # Opt-in gate: no linked account -> no heartbeat (and no payload-build
+    # cost). Mirrors the _post() gate; see cloud_egress_enabled().
+    if not (config or {}).get("api_key"):
+        return False
     global _LAST_HEARTBEAT_RESPONSE
     payload = {
         "node_id": config["node_id"],
@@ -17858,6 +17869,14 @@ def run_daemon() -> None:
             f"(LOCAL-ONLY mode: cloud sync disabled, "
             f"ingesting into local DuckDB only)"
         )
+    elif not config.get("api_key"):
+        # Opt-in gate: no linked account. Say it ONCE here instead of a 401
+        # warning per heartbeat cycle (the pre-2026-07-31 behaviour).
+        log.info(
+            f"Starting sync daemon — node={config['node_id']} "
+            f"(SELF-HOSTED: no cloud account linked, nothing leaves this "
+            f"machine; run `clawmetry login` to enable cloud sync)"
+        )
     else:
         log.info(f"Starting sync daemon — node={config['node_id']} → {INGEST_URL} ({enc})")
 
@@ -18599,8 +18618,8 @@ def run_daemon() -> None:
             save_state(state)
             if ev or lg or mem or crons or sm or snap or cron_runs or tg or oc_cc:
                 try:
-                    from clawmetry.config import is_cloud_disabled as _icd_cycle
-                    _cycle_local_only = _icd_cycle()
+                    from clawmetry.config import cloud_egress_enabled as _cee
+                    _cycle_local_only = not _cee(config)
                 except Exception:
                     _cycle_local_only = False
                 if _cycle_local_only:
@@ -18609,7 +18628,7 @@ def run_daemon() -> None:
                     # founder believe data was leaving a machine whose whole
                     # promise was that it never would (2026-07-30).
                     log.info(
-                        f"Ingested locally (local-only, nothing sent): {ev} events ({oc_cc} from claude-cc), {lg} log lines, {mem} memory files, {crons} crons, {cron_runs} cron-runs, {sm} session rows, {tg} telegram-out"
+                        f"Ingested locally (self-hosted, nothing sent): {ev} events ({oc_cc} from claude-cc), {lg} log lines, {mem} memory files, {crons} crons, {cron_runs} cron-runs, {sm} session rows, {tg} telegram-out"
                     )
                 else:
                     log.info(

--- a/tests/test_optin_cloud_egress.py
+++ b/tests/test_optin_cloud_egress.py
@@ -1,0 +1,97 @@
+"""
+Opt-in-only cloud egress (founder rule 2026-07-31).
+
+Default install = SELF-HOSTED: nothing leaves the machine until the user
+explicitly links an account (`clawmetry login` / `connect` / the managed
+onboarding path), which persists an api_key. Previously gating was
+opt-OUT only (the nocloud marker), so a self-hosted node with no account
+POSTed X-Api-Key:"" heartbeats every ~55s and logged endless 401
+warnings (found live on a Windows node).
+
+These tests are the regression guard: with an empty api_key, _post() and
+send_heartbeat() must return without ever touching the network. The
+network-off proof is a monkeypatched urlopen that fails the test if
+called — on the un-fixed code these tests go red (revert-proven).
+"""
+from __future__ import annotations
+
+import urllib.request
+
+import pytest
+
+from clawmetry import config as cm_config
+from clawmetry import sync as cm_sync
+
+
+@pytest.fixture(autouse=True)
+def _no_network(monkeypatch, tmp_path):
+    """Fail loudly if anything tries real network; isolate the marker."""
+    def _boom(*a, **kw):
+        raise AssertionError("network egress attempted despite empty api_key")
+
+    monkeypatch.setattr(urllib.request, "urlopen", _boom)
+    monkeypatch.setattr(cm_config, "NOCLOUD_MARKER_PATH",
+                        str(tmp_path / "nocloud"))
+    monkeypatch.delenv("CLAWMETRY_NO_CLOUD", raising=False)
+    yield
+
+
+def test_post_without_api_key_is_silent():
+    resp = cm_sync._post("/ingest/heartbeat", {"node_id": "n1"}, api_key="")
+    assert resp.get("_no_account") is True
+    assert resp.get("sync_allowed") is False
+
+
+def test_post_with_api_key_still_reaches_network(monkeypatch):
+    """The gate must not swallow legitimate opted-in traffic."""
+    calls = {}
+
+    class _Resp:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def read(self):
+            return b'{"ok": true}'
+
+    def _fake_urlopen(req, timeout=None):
+        calls["url"] = req.full_url
+        calls["key"] = req.headers.get("X-api-key")
+        return _Resp()
+
+    monkeypatch.setattr(urllib.request, "urlopen", _fake_urlopen)
+    resp = cm_sync._post("/ingest/heartbeat", {"node_id": "n1"}, api_key="cm_k")
+    assert resp == {"ok": True}
+    assert calls["key"] == "cm_k"
+
+
+def test_heartbeat_without_api_key_is_silent():
+    assert cm_sync.send_heartbeat({"node_id": "n1", "api_key": ""}) is False
+    assert cm_sync.send_heartbeat({"node_id": "n1"}) is False
+
+
+def test_cloud_egress_enabled_truth_table(tmp_path):
+    assert cm_config.cloud_egress_enabled({}) is False
+    assert cm_config.cloud_egress_enabled({"api_key": ""}) is False
+    assert cm_config.cloud_egress_enabled({"api_key": "cm_k"}) is True
+    # nocloud marker hard-disables even with a key
+    marker = tmp_path / "nocloud"
+    marker.write_text("x")
+    orig = cm_config.NOCLOUD_MARKER_PATH
+    cm_config.NOCLOUD_MARKER_PATH = str(marker)
+    try:
+        assert cm_config.cloud_egress_enabled({"api_key": "cm_k"}) is False
+    finally:
+        cm_config.NOCLOUD_MARKER_PATH = orig
+
+
+def test_startup_banner_has_selfhosted_branch():
+    """The one-line startup notice replaced the per-cycle 401 warning wall —
+    keep it (and its login pointer) from silently disappearing."""
+    import inspect
+
+    src = inspect.getsource(cm_sync.run_daemon)
+    assert "SELF-HOSTED: no cloud account linked" in src
+    assert "clawmetry login" in src


### PR DESCRIPTION
## Why
Founder rule: **a default install is self-hosted — nothing leaves the machine unless the user explicitly connected to cloud or chose the managed option.** Gating was opt-OUT only (the `nocloud` marker), so a self-hosted node (license-key onboarding, never connected) had `api_key=""` + no marker and fell into an unmodeled third state: it POSTed `X-Api-Key: ""` heartbeats every ~55s, got HTTP 401, burned 3 retries per cycle, and filled sync.log with a warning wall. Found live on a real Windows node minutes after 0.12.603 auto-rolled onto it. A dozen sibling call sites already guard `if not (api_key and node_id)` — the two highest-frequency paths didn't.

## What
- `config.cloud_egress_enabled(config)` — the single opt-in truth: non-empty api_key AND not cloud-disabled.
- `_post()`: empty api_key → `{_no_account, sync_allowed: False}` sentinel (mirrors the existing `_cloud_disabled` short-circuit) — one gate covers every `/ingest/*` write.
- `send_heartbeat()`: early-return before the payload-build cost.
- Startup banner: one INFO line — "SELF-HOSTED: no cloud account linked, nothing leaves this machine; run `clawmetry login`" — instead of per-cycle 401 warnings.
- Cycle summary keys on the new helper and reads "Ingested locally (self-hosted, nothing sent)" — no more misleading "(⚠️ unencrypted)" suffix on nodes that egress nothing.

**Scope note:** anonymous install/update telemetry pings are deliberately unchanged — separate channel feeding the install-registry funnel (0.12.600); flag if you want those opt-in too.

## Verification
- 5 guard tests with a **network-off proof** (urlopen monkeypatched to fail the test if touched). Revert-proven: 3 red on un-fixed origin/main files, 5/5 green with the fix.
- Neighbors green (enterprise-TLS + cloud-toggles suites, 33 tests); ruff zero-delta vs main.
- Post-release plan: the affected Windows node auto-updates within minutes — will verify its sync.log flips to the one-line SELF-HOSTED banner and the 401 wall stops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)