### PR TITLE
feat(cli): detect stale duplicate installs; warn with the exact fix

### DIFF
--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -2708,6 +2708,24 @@ def _status_snapshot(args) -> dict:
     except Exception:
         pass
 
+    # Installs — this CLI copy vs the daemon environment the auto-updater
+    # keeps current. ``version`` (above) is THIS process's package version,
+    # which on a machine with a stale duplicate install (a pre-venv
+    # ``pip install --user`` shadowing ``~/.clawmetry/bin`` on PATH) is NOT
+    # the version the daemon runs — that mismatch read as "auto-update is
+    # broken" (founder live-hit 2026-07-31). ``daemon.installed_version`` is
+    # the on-disk truth for the daemon env; ``installs.stale_cli`` is the
+    # one-bit answer scripts can alert on.
+    try:
+        from clawmetry.installs import installs_snapshot as _installs_snap
+        _inst = _installs_snap()
+        snap["installs"] = _inst
+        _dver = (_inst.get("daemon_env") or {}).get("version")
+        if _dver and isinstance(snap.get("daemon"), dict):
+            snap["daemon"]["installed_version"] = _dver
+    except Exception:
+        snap["installs"] = None
+
     return snap
 
 
@@ -2738,6 +2756,21 @@ def _cmd_status(args) -> None:
         _cm_ver = ""
     if _cm_ver:
         print(f"  Version:     {_cm_ver}")
+    # Stale-duplicate guard: when this CLI is a separate copy that is OLDER
+    # than the daemon's auto-updated install, the version above is misleading
+    # (the node itself IS current). Say so, with the daemon's real version.
+    try:
+        from clawmetry.installs import installs_snapshot as _inst_snap, \
+            stale_warning_lines as _stale_lines
+        _inst = _inst_snap()
+        _dver = (_inst.get("daemon_env") or {}).get("version")
+        if _dver and _dver != _cm_ver:
+            print(f"  Daemon ver:  {_dver}  (auto-updated install at "
+                  f"{(_inst.get('daemon_env') or {}).get('home')})")
+        for _ln in _stale_lines(_inst):
+            print("  " + _ln)
+    except Exception:
+        pass
 
     # Config
     if CONFIG_FILE.exists():
@@ -5995,6 +6028,21 @@ def main() -> None:
     try:
         from clawmetry.net import configure_outbound_network
         configure_outbound_network(role="cli")
+    except Exception:
+        pass
+    # Stale-duplicate guard: the auto-updater keeps the DAEMON's environment
+    # (~/.clawmetry venv) current, not every stray pip copy on the machine.
+    # When this process is such a stray copy and it's older than the daemon
+    # install, every version this CLI prints is misleading — warn once, on
+    # stderr, with the exact upgrade command. Cheap (directory glob, no
+    # subprocess, no network); skipped for JSON output so wrapper scripts
+    # stay parseable on stdout AND quiet on stderr. CLAWMETRY_NO_STALE_WARN=1
+    # silences it. The hooks / agent-read fast paths above return before this
+    # line on purpose — they are latency-critical.
+    try:
+        if "--json" not in sys.argv:
+            from clawmetry.installs import maybe_warn_stale_cli
+            maybe_warn_stale_cli()
     except Exception:
         pass
     # Cloud-sync toggles — plain flags so a non-engineer can flip sync from

--- a/clawmetry/doctor.py
+++ b/clawmetry/doctor.py
@@ -180,6 +180,81 @@ def _windows_fix_text(issuer: str) -> str:
     ).format(issuer or "<unknown>", vendor_note)
 
 
+def check_installs(out=print) -> int:
+    """Census every clawmetry copy on this machine; warn about stale ones.
+
+    The auto-updater keeps ONE environment current: the daemon's
+    (``~/.clawmetry``). A duplicate copy elsewhere on PATH (an old
+    ``pip install --user``) never updates and, when it shadows the daemon's
+    binary, makes the whole node LOOK stale while the daemon is current.
+    Returns the number of warnings (informational; doctor's exit code stays
+    about connectivity). Never raises.
+    """
+    warnings = 0
+    try:
+        from clawmetry import installs as _inst
+
+        snap = _inst.installs_snapshot()
+        denv = snap.get("daemon_env") or {}
+        out("Installs on this machine:")
+        if denv.get("version"):
+            out("{0} daemon environment: {1} (v{2}, kept current by "
+                "auto-update)".format(PASS, denv.get("home"), denv.get("version")))
+        elif denv.get("present"):
+            out("{0} daemon environment: {1} (clawmetry package not found "
+                "inside it)".format(WARN, denv.get("home")))
+            warnings += 1
+        else:
+            out("{0} daemon environment: none at {1} (single-environment "
+                "install; auto-update runs in the daemon's own env)".format(
+                    PASS, denv.get("home")))
+
+        exes = _inst.path_executables()
+        dver = denv.get("version")
+        for i, exe in enumerate(exes):
+            ver = _inst.executable_version(exe)
+            shadows = " <- what a bare `clawmetry` runs" if i == 0 and len(exes) > 1 else ""
+            if ver and dver and _inst.version_gt(dver, ver):
+                warnings += 1
+                out("{0} PATH: {1} (v{2}, STALE){3}".format(WARN, exe, ver, shadows))
+                out("       This copy is a separate install the auto-updater "
+                    "never touches.")
+                out("       Fix: {0}".format(_pip_hint_for(exe)))
+            else:
+                out("{0} PATH: {1} (v{2}){3}".format(
+                    PASS, exe, ver or "unknown", shadows))
+        if not exes:
+            out("{0} PATH: no `clawmetry` executable found on PATH".format(WARN))
+            warnings += 1
+        out("")
+    except Exception as e:  # never let the census break connectivity checks
+        out("{0} install census skipped ({1})".format(WARN, e))
+        out("")
+    return warnings
+
+
+def _pip_hint_for(exe) -> str:
+    """The upgrade command for the environment that owns console script ``exe``.
+
+    Console scripts carry their interpreter in the shebang on POSIX; that
+    interpreter's pip is the one that can actually upgrade (or remove) the
+    copy. Falls back to a generic hint when unreadable (e.g. Windows .exe
+    launchers embed the interpreter instead).
+    """
+    try:
+        with open(exe, "rb") as fh:
+            first = fh.readline(200)
+        if first.startswith(b"#!"):
+            py = first[2:].strip().decode("utf-8", "replace")
+            if py:
+                return "{0} -m pip install -U clawmetry   (or remove it: " \
+                    "{0} -m pip uninstall clawmetry)".format(py)
+    except Exception:
+        pass
+    return "python3 -m pip install -U clawmetry (from the environment that " \
+        "owns {0})".format(exe)
+
+
 def run_doctor(host: str = None, port: int = 443, out=print) -> int:
     """Run all connectivity checks. Returns process exit code (0 = all pass)."""
     if not host:
@@ -204,6 +279,9 @@ def run_doctor(host: str = None, port: int = 443, out=print) -> int:
             out(WARN + " TLS verification is DISABLED (CLAWMETRY_TLS_NO_VERIFY /"
                 " tls_verify:false) — insecure, pilot use only")
     out("")
+
+    # ── 0. Install census (stale duplicate copies) ────────────────────────
+    check_installs(out)
 
     # ── 1. DNS ────────────────────────────────────────────────────────────
     try:

--- a/clawmetry/installs.py
+++ b/clawmetry/installs.py
@@ -1,0 +1,249 @@
+"""
+Install census — find every clawmetry copy on this machine and flag stale ones.
+
+The auto-updater keeps exactly ONE environment current: the one the supervised
+sync daemon runs from (the installer's venv at ``~/.clawmetry``). Any other
+copy (a ``pip install --user`` from before the venv existed, a system-python
+install, a stray pyenv shim) is inert files that no updater thread ever runs
+in — and when such a copy shadows the venv binary on PATH, ``clawmetry
+--version`` / ``clawmetry status`` report a stale version while the daemon is
+actually up to date. That mismatch reads as "auto-update is broken" (founder
+live-hit 2026-07-31: PATH resolved to a Python 3.9 user install at 0.12.601
+while the daemon venv ran 0.12.606).
+
+This module detects that state cheaply (directory globs, no subprocess) so the
+CLI can warn on startup, ``status`` can report both versions honestly, and
+``clawmetry doctor`` can print the exact fix. Never raises — every helper
+degrades to ``None`` / empty on any error.
+"""
+from __future__ import annotations
+
+import os
+import re
+import sys
+from pathlib import Path
+
+_DIST_INFO_RE = re.compile(r"^clawmetry-(\d[\w.]*)\.dist-info$")
+
+
+def daemon_home() -> Path:
+    """The daemon's install root (the installer venv), ``~/.clawmetry``."""
+    return Path.home() / ".clawmetry"
+
+
+def parse_version(v) -> tuple:
+    """Tolerant version tuple for comparison; non-numeric parts become 0."""
+    parts = []
+    for piece in str(v or "").split("."):
+        m = re.match(r"\d+", piece)
+        parts.append(int(m.group(0)) if m else 0)
+    return tuple(parts) if parts else (0,)
+
+
+def version_gt(a, b) -> bool:
+    """True when version string ``a`` is strictly newer than ``b``."""
+    return parse_version(a) > parse_version(b)
+
+
+def daemon_env_version(home: Path = None) -> str | None:
+    """clawmetry version installed in the daemon venv, from dist-info dirs.
+
+    Reads the ``clawmetry-<version>.dist-info`` directory name under the
+    venv's site-packages (POSIX ``lib/python*/site-packages`` and Windows
+    ``Lib/site-packages``) — a pure filesystem read, safe to run on every CLI
+    start. Multiple dist-info dirs (debris from an interrupted pip run) pick
+    the newest. ``None`` when the venv or the package is absent.
+    """
+    try:
+        root = home or daemon_home()
+        candidates = []
+        site_dirs = list(root.glob("lib/python*/site-packages"))
+        site_dirs += [root / "Lib" / "site-packages"]
+        for sp in site_dirs:
+            try:
+                if not sp.is_dir():
+                    continue
+                for entry in sp.iterdir():
+                    m = _DIST_INFO_RE.match(entry.name)
+                    if m:
+                        candidates.append(m.group(1))
+            except Exception:
+                continue
+        if not candidates:
+            return None
+        return max(candidates, key=parse_version)
+    except Exception:
+        return None
+
+
+def running_in_daemon_env(home: Path = None) -> bool:
+    """True when THIS process's interpreter lives inside the daemon venv."""
+    try:
+        root = (home or daemon_home()).resolve()
+        prefix = Path(sys.prefix).resolve()
+        return prefix == root or root in prefix.parents
+    except Exception:
+        return False
+
+
+def cli_version() -> str | None:
+    """This process's clawmetry version (package metadata; never raises)."""
+    try:
+        import importlib.metadata as _md
+        return _md.version("clawmetry") or None
+    except Exception:
+        return None
+
+
+def cli_entry_path() -> str | None:
+    """The script the user invoked (argv[0]), best-effort."""
+    try:
+        p = sys.argv[0] or ""
+        # `-c` / `-m` style invocations have no meaningful script path.
+        return p if p and not p.startswith("-") else None
+    except Exception:
+        return None
+
+
+def _pip_for_current_env() -> str:
+    """The pip invocation that upgrades THIS process's environment."""
+    py = sys.executable or "python3"
+    user_flag = " --user" if _is_user_site_install() else ""
+    return "{0} -m pip install{1} -U clawmetry".format(py, user_flag)
+
+
+def _is_user_site_install() -> bool:
+    """True when this clawmetry import resolves from the user site-packages
+    (a ``pip install --user`` copy needs ``--user`` on the upgrade too, or
+    pip targets the system site and the stale copy keeps shadowing it)."""
+    try:
+        import site
+        base = site.getusersitepackages()
+        import clawmetry
+        return bool(base) and Path(clawmetry.__file__).is_relative_to(base)
+    except Exception:
+        return False
+
+
+def installs_snapshot(home: Path = None) -> dict:
+    """Cheap (no-subprocess) view of this CLI vs the daemon environment.
+
+    Shape::
+
+        {"cli": {"version": str|None, "path": str|None,
+                 "in_daemon_env": bool},
+         "daemon_env": {"home": str, "present": bool, "version": str|None},
+         "stale_cli": bool}
+
+    ``stale_cli`` is True only in the confusing state worth warning about:
+    this process runs OUTSIDE the daemon venv and its version is OLDER than
+    what the auto-updater installed there.
+    """
+    root = home or daemon_home()
+    cver = cli_version()
+    dver = daemon_env_version(root)
+    in_env = running_in_daemon_env(root)
+    stale = bool(cver and dver and not in_env and version_gt(dver, cver))
+    return {
+        "cli": {
+            "version": cver,
+            "path": cli_entry_path(),
+            "in_daemon_env": in_env,
+        },
+        "daemon_env": {
+            "home": str(root),
+            "present": bool(dver) or (root / "bin").is_dir()
+            or (root / "Scripts").is_dir(),
+            "version": dver,
+        },
+        "stale_cli": stale,
+    }
+
+
+def stale_warning_lines(snap: dict = None) -> list:
+    """Human warning for a stale CLI copy, or ``[]`` when everything is fine."""
+    try:
+        snap = snap or installs_snapshot()
+        if not snap.get("stale_cli"):
+            return []
+        cli = snap.get("cli") or {}
+        denv = snap.get("daemon_env") or {}
+        where = cli.get("path") or sys.executable or "this copy"
+        return [
+            "⚠ This clawmetry CLI is v{0}, but the ClawMetry daemon on this "
+            "machine runs v{1}.".format(cli.get("version"), denv.get("version")),
+            "  You are using a stale, separate copy at {0}. The daemon keeps "
+            "its own install".format(where),
+            "  ({0}) current automatically; copies outside it never "
+            "auto-update.".format(denv.get("home")),
+            "  Bring this copy up to date:  {0}".format(_pip_for_current_env()),
+        ]
+    except Exception:
+        return []
+
+
+def maybe_warn_stale_cli(stream=None) -> bool:
+    """Print the stale-CLI warning to ``stream`` (default stderr) if needed.
+
+    Returns True when a warning was printed. Honours
+    ``CLAWMETRY_NO_STALE_WARN=1``. Never raises.
+    """
+    try:
+        if os.environ.get("CLAWMETRY_NO_STALE_WARN", "").strip() == "1":
+            return False
+        lines = stale_warning_lines()
+        if not lines:
+            return False
+        out = stream if stream is not None else sys.stderr
+        for ln in lines:
+            print(ln, file=out)
+        return True
+    except Exception:
+        return False
+
+
+# ── PATH census (subprocess-backed; doctor only) ─────────────────────────────
+
+def path_executables() -> list:
+    """Every distinct ``clawmetry`` executable on PATH, resolution order.
+
+    Dedups by resolved real path (a symlink and its target count once) while
+    keeping first-seen order — index 0 is what a bare ``clawmetry`` runs.
+    """
+    found = []
+    seen = set()
+    names = ("clawmetry", "clawmetry.exe", "clawmetry.cmd") \
+        if sys.platform.startswith("win") else ("clawmetry",)
+    try:
+        for d in (os.environ.get("PATH") or "").split(os.pathsep):
+            if not d:
+                continue
+            for name in names:
+                p = Path(d) / name
+                try:
+                    if not (p.is_file() and os.access(str(p), os.X_OK)):
+                        continue
+                    real = str(p.resolve())
+                except Exception:
+                    continue
+                if real in seen:
+                    continue
+                seen.add(real)
+                found.append(p)
+    except Exception:
+        pass
+    return found
+
+
+def executable_version(path, timeout: float = 10.0) -> str | None:
+    """Run ``<path> --version`` and parse the version. ``None`` on any failure."""
+    try:
+        import subprocess
+        r = subprocess.run(
+            [str(path), "--version"], capture_output=True, text=True,
+            timeout=timeout,
+        )
+        m = re.search(r"clawmetry\s+(\d[\w.]*)", (r.stdout or "") + (r.stderr or ""))
+        return m.group(1) if m else None
+    except Exception:
+        return None

--- a/tests/test_stale_cli_detection.py
+++ b/tests/test_stale_cli_detection.py
@@ -1,0 +1,225 @@
+"""
+Stale-CLI detection (clawmetry/installs.py).
+
+Guards the 2026-07-31 founder live-hit: a pre-venv ``pip install --user``
+copy shadowed ``~/.clawmetry/bin`` on PATH, so ``clawmetry --version`` /
+``status`` reported 0.12.601 while the daemon's auto-updated venv ran
+0.12.606 — which read as "auto-update is broken". The fix is detection +
+an honest warning; these tests pin every branch of that detection.
+
+Pure unit tests: temp dirs only, no network, no running server.
+"""
+import io
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+from clawmetry import installs
+
+
+def _mk_daemon_home(tmp_path, version="0.12.606", layout="posix", extra=()):
+    """Fake ``~/.clawmetry`` venv with a clawmetry dist-info of ``version``."""
+    home = tmp_path / ".clawmetry"
+    if layout == "posix":
+        sp = home / "lib" / "python3.12" / "site-packages"
+        (home / "bin").mkdir(parents=True)
+    else:
+        sp = home / "Lib" / "site-packages"
+        (home / "Scripts").mkdir(parents=True)
+    sp.mkdir(parents=True, exist_ok=True)
+    for v in (version, *extra):
+        (sp / "clawmetry-{0}.dist-info".format(v)).mkdir()
+    return home
+
+
+# ── version parsing / comparison ─────────────────────────────────────────────
+
+def test_version_gt_basic():
+    assert installs.version_gt("0.12.606", "0.12.601")
+    assert not installs.version_gt("0.12.601", "0.12.606")
+    assert not installs.version_gt("0.12.606", "0.12.606")
+    # multi-digit segments compare numerically, not lexically
+    assert installs.version_gt("0.12.610", "0.12.69")
+
+
+def test_parse_version_tolerates_garbage():
+    assert installs.parse_version(None) == (0,)
+    assert installs.parse_version("0.12.5rc1") == (0, 12, 5)
+
+
+# ── daemon env discovery ─────────────────────────────────────────────────────
+
+def test_daemon_env_version_posix_layout(tmp_path):
+    home = _mk_daemon_home(tmp_path, "0.12.606", layout="posix")
+    assert installs.daemon_env_version(home) == "0.12.606"
+
+
+def test_daemon_env_version_windows_layout(tmp_path):
+    home = _mk_daemon_home(tmp_path, "0.12.606", layout="windows")
+    assert installs.daemon_env_version(home) == "0.12.606"
+
+
+def test_daemon_env_version_picks_newest_of_debris(tmp_path):
+    home = _mk_daemon_home(tmp_path, "0.12.606", extra=("0.12.599",))
+    assert installs.daemon_env_version(home) == "0.12.606"
+
+
+def test_daemon_env_version_ignores_pro_wheel_and_debris(tmp_path):
+    home = _mk_daemon_home(tmp_path, "0.12.606")
+    sp = next(home.glob("lib/python*/site-packages"))
+    # clawmetry_pro must not match; ~lawmetry debris must not match
+    (sp / "clawmetry_pro-0.5.0.dist-info").mkdir()
+    (sp / "~lawmetry").mkdir()
+    assert installs.daemon_env_version(home) == "0.12.606"
+
+
+def test_daemon_env_version_absent(tmp_path):
+    assert installs.daemon_env_version(tmp_path / "nope") is None
+
+
+# ── stale detection ──────────────────────────────────────────────────────────
+
+def test_snapshot_flags_stale_cli(tmp_path, monkeypatch):
+    home = _mk_daemon_home(tmp_path, "0.12.606")
+    monkeypatch.setattr(installs, "cli_version", lambda: "0.12.601")
+    monkeypatch.setattr(installs, "running_in_daemon_env", lambda home=None: False)
+    snap = installs.installs_snapshot(home)
+    assert snap["stale_cli"] is True
+    assert snap["daemon_env"]["version"] == "0.12.606"
+    assert snap["cli"]["version"] == "0.12.601"
+
+
+def test_snapshot_not_stale_when_versions_match(tmp_path, monkeypatch):
+    home = _mk_daemon_home(tmp_path, "0.12.606")
+    monkeypatch.setattr(installs, "cli_version", lambda: "0.12.606")
+    monkeypatch.setattr(installs, "running_in_daemon_env", lambda home=None: False)
+    assert installs.installs_snapshot(home)["stale_cli"] is False
+
+
+def test_snapshot_not_stale_inside_daemon_env(tmp_path, monkeypatch):
+    """The daemon venv's own CLI is never 'stale' even mid-upgrade."""
+    home = _mk_daemon_home(tmp_path, "0.12.606")
+    monkeypatch.setattr(installs, "cli_version", lambda: "0.12.601")
+    monkeypatch.setattr(installs, "running_in_daemon_env", lambda home=None: True)
+    assert installs.installs_snapshot(home)["stale_cli"] is False
+
+
+def test_snapshot_not_stale_without_daemon_env(tmp_path, monkeypatch):
+    """Single-environment installs (no ~/.clawmetry venv) never warn."""
+    monkeypatch.setattr(installs, "cli_version", lambda: "0.12.601")
+    snap = installs.installs_snapshot(tmp_path / "absent")
+    assert snap["stale_cli"] is False
+    assert snap["daemon_env"]["present"] is False
+
+
+def test_snapshot_not_stale_when_cli_newer(tmp_path, monkeypatch):
+    """A dev checkout newer than the venv is fine — only OLDER warns."""
+    home = _mk_daemon_home(tmp_path, "0.12.606")
+    monkeypatch.setattr(installs, "cli_version", lambda: "0.13.0")
+    monkeypatch.setattr(installs, "running_in_daemon_env", lambda home=None: False)
+    assert installs.installs_snapshot(home)["stale_cli"] is False
+
+
+def test_running_in_daemon_env_detects_prefix(tmp_path, monkeypatch):
+    home = _mk_daemon_home(tmp_path, "0.12.606")
+    monkeypatch.setattr(installs.sys, "prefix", str(home))
+    assert installs.running_in_daemon_env(home) is True
+    monkeypatch.setattr(installs.sys, "prefix", str(tmp_path / "other"))
+    assert installs.running_in_daemon_env(home) is False
+
+
+# ── warning output ───────────────────────────────────────────────────────────
+
+def test_warning_prints_versions_and_fix(tmp_path, monkeypatch):
+    home = _mk_daemon_home(tmp_path, "0.12.606")
+    monkeypatch.setattr(installs, "cli_version", lambda: "0.12.601")
+    monkeypatch.setattr(installs, "running_in_daemon_env", lambda home=None: False)
+    monkeypatch.setattr(installs, "daemon_home", lambda: home)
+    buf = io.StringIO()
+    assert installs.maybe_warn_stale_cli(stream=buf) is True
+    text = buf.getvalue()
+    assert "0.12.601" in text and "0.12.606" in text
+    assert "pip install" in text
+    # user-facing copy rule: no em-dashes
+    assert "—" not in text
+
+
+def test_warning_silent_when_current(tmp_path, monkeypatch):
+    home = _mk_daemon_home(tmp_path, "0.12.606")
+    monkeypatch.setattr(installs, "cli_version", lambda: "0.12.606")
+    monkeypatch.setattr(installs, "daemon_home", lambda: home)
+    buf = io.StringIO()
+    assert installs.maybe_warn_stale_cli(stream=buf) is False
+    assert buf.getvalue() == ""
+
+
+def test_warning_env_kill_switch(tmp_path, monkeypatch):
+    home = _mk_daemon_home(tmp_path, "0.12.606")
+    monkeypatch.setattr(installs, "cli_version", lambda: "0.12.601")
+    monkeypatch.setattr(installs, "running_in_daemon_env", lambda home=None: False)
+    monkeypatch.setattr(installs, "daemon_home", lambda: home)
+    monkeypatch.setenv("CLAWMETRY_NO_STALE_WARN", "1")
+    buf = io.StringIO()
+    assert installs.maybe_warn_stale_cli(stream=buf) is False
+    assert buf.getvalue() == ""
+
+
+# ── PATH census ──────────────────────────────────────────────────────────────
+
+@pytest.mark.skipif(sys.platform.startswith("win"), reason="POSIX exec bits")
+def test_path_executables_dedups_symlinks(tmp_path, monkeypatch):
+    d1 = tmp_path / "bin1"
+    d2 = tmp_path / "bin2"
+    d1.mkdir(); d2.mkdir()
+    real = d1 / "clawmetry"
+    real.write_text("#!/bin/sh\necho clawmetry 0.0.1\n")
+    real.chmod(0o755)
+    (d2 / "clawmetry").symlink_to(real)
+    monkeypatch.setenv("PATH", os.pathsep.join([str(d1), str(d2)]))
+    exes = installs.path_executables()
+    assert len(exes) == 1
+    assert exes[0] == real
+
+
+@pytest.mark.skipif(sys.platform.startswith("win"), reason="POSIX shebang")
+def test_executable_version_parses_output(tmp_path):
+    exe = tmp_path / "clawmetry"
+    exe.write_text("#!/bin/sh\necho 'clawmetry 0.12.601'\n")
+    exe.chmod(0o755)
+    assert installs.executable_version(exe) == "0.12.601"
+    assert installs.executable_version(tmp_path / "missing") is None
+
+
+# ── doctor census never breaks connectivity checks ───────────────────────────
+
+def test_doctor_check_installs_never_raises(monkeypatch):
+    from clawmetry import doctor
+    monkeypatch.setattr(installs, "installs_snapshot",
+                        lambda: (_ for _ in ()).throw(RuntimeError("boom")))
+    lines = []
+    # Must swallow the error and return, not raise.
+    doctor.check_installs(out=lines.append)
+    assert any("skipped" in ln for ln in lines)
+
+
+def test_doctor_census_flags_stale_path_copy(tmp_path, monkeypatch):
+    """End-to-end census: stale PATH copy + current daemon env -> WARN + fix."""
+    from clawmetry import doctor
+    home = _mk_daemon_home(tmp_path, "0.12.606")
+    bin_dir = tmp_path / "userbin"
+    bin_dir.mkdir()
+    exe = bin_dir / "clawmetry"
+    exe.write_text("#!/bin/sh\necho 'clawmetry 0.12.601'\n")
+    exe.chmod(0o755)
+    monkeypatch.setattr(installs, "daemon_home", lambda: home)
+    monkeypatch.setenv("PATH", str(bin_dir))
+    lines = []
+    warnings = doctor.check_installs(out=lines.append)
+    text = "\n".join(lines)
+    if not sys.platform.startswith("win"):
+        assert warnings >= 1
+        assert "STALE" in text
+        assert "pip install" in text
+    assert "0.12.606" in text  # daemon env always reported

--- a/tests/test_stale_cli_detection.py
+++ b/tests/test_stale_cli_detection.py
@@ -12,7 +12,6 @@ Pure unit tests: temp dirs only, no network, no running server.
 import io
 import os
 import sys
-from pathlib import Path
 
 import pytest
 
@@ -172,7 +171,8 @@ def test_warning_env_kill_switch(tmp_path, monkeypatch):
 def test_path_executables_dedups_symlinks(tmp_path, monkeypatch):
     d1 = tmp_path / "bin1"
     d2 = tmp_path / "bin2"
-    d1.mkdir(); d2.mkdir()
+    d1.mkdir()
+    d2.mkdir()
     real = d1 / "clawmetry"
     real.write_text("#!/bin/sh\necho clawmetry 0.0.1\n")
     real.chmod(0o755)


### PR DESCRIPTION
## Why

Auto-update keeps exactly one environment current: the daemon's (~/.clawmetry venv). A leftover pip copy elsewhere on PATH (e.g. a pre-venv pip install --user) never updates, and when it shadows the venv binary, clawmetry --version and clawmetry status report a stale version while the node is actually current. Founder live-hit 2026-07-31: PATH CLI at 0.12.601, daemon venv at 0.12.606; it read as "auto-update is broken / cheating".

## What

- New clawmetry/installs.py: cheap install census (dist-info directory globs, no subprocess) plus a PATH census (subprocess, doctor only). Never raises.
- CLI startup: stderr warning when this process is a stale copy outside the daemon env, with the exact pip command for the environment that owns the copy (parsed from the console-script shebang). Skipped for --json output and the hooks/agent fast paths; CLAWMETRY_NO_STALE_WARN=1 silences.
- clawmetry status: human output shows "Daemon ver: X (auto-updated install at ~/.clawmetry)" when it differs from the CLI version; --json adds an installs block and daemon.installed_version (additive, contract-compatible).
- clawmetry doctor: new "Installs on this machine" census listing the daemon env and every distinct clawmetry on PATH with versions, flagging STALE copies with the fix. Warnings do not affect doctor's connectivity exit code.

## Verification

- tests/test_stale_cli_detection.py: 20 unit tests covering dist-info parsing (posix + windows layouts, debris, clawmetry_pro non-match), stale-flag branches (stale / equal / newer / in-env / no-venv), warning copy (versions + fix present, no em-dashes), env kill switch, PATH dedup via symlink, doctor census never-raises and stale-flagging. All pass locally.
- Live on the affected machine: census correctly reports the daemon env and the PATH copy; simulated stale state (fake daemon home at 0.99.0) fires the warning with the correct interpreter-specific pip command; real status --json emits installs + daemon.installed_version.
- ruff clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)