### PR TITLE
fix: share eval judge status across processes via eval_status.json

### DIFF
--- a/clawmetry/eval_runner.py
+++ b/clawmetry/eval_runner.py
@@ -1050,6 +1050,10 @@ _LAST_JUDGE_STATUS: dict[str, Any] = {"ok": None, "error": None, "at": None,
                                       "provider": None, "model": None}
 _LAST_JUDGE_LOCK = threading.Lock()
 
+# Shared across processes (daemon writes, dashboard reads). No key material —
+# ok/error/provider/model/at only. Mirrors _EVAL_KEYS_PATH convention.
+_EVAL_STATUS_PATH = os.path.expanduser("~/.clawmetry/eval_status.json")
+
 
 def _record_judge_status(ok: bool, error: str | None, provider: str, model: str) -> None:
     with _LAST_JUDGE_LOCK:
@@ -1060,12 +1064,31 @@ def _record_judge_status(ok: bool, error: str | None, provider: str, model: str)
             "provider": provider,
             "model": model,
         })
+        snapshot = dict(_LAST_JUDGE_STATUS)
+    try:
+        Path(_EVAL_STATUS_PATH).parent.mkdir(parents=True, exist_ok=True)
+        Path(_EVAL_STATUS_PATH).write_text(json.dumps(snapshot))
+    except Exception:
+        pass
 
 
 def last_judge_status() -> dict[str, Any]:
-    """A copy of the most recent judge call outcome (never key material)."""
+    """A copy of the most recent judge call outcome (never key material).
+
+    Reads from the shared file when it's newer than the in-memory copy so that
+    the dashboard process reflects daemon-side judge outcomes without a restart
+    (fix for issue #4332: status was per-process, 401s from the daemon never
+    surfaced in the dashboard card until a dashboard-side call happened).
+    """
     with _LAST_JUDGE_LOCK:
-        return dict(_LAST_JUDGE_STATUS)
+        mem = dict(_LAST_JUDGE_STATUS)
+    try:
+        file_status = json.loads(Path(_EVAL_STATUS_PATH).read_text())
+        if (file_status.get("at") or 0) > (mem.get("at") or 0):
+            return file_status
+    except Exception:
+        pass
+    return mem
 
 
 def _classify_judge_error(exc: Exception) -> str:

--- a/tests/test_eval_judge_status_cross_process.py
+++ b/tests/test_eval_judge_status_cross_process.py
@@ -1,0 +1,94 @@
+"""Judge last-call status survives across processes (fix for issue #4332).
+
+The sync daemon updates _LAST_JUDGE_STATUS in its own process; the dashboard
+serves /api/evaluators from a separate process.  Before the fix, the dashboard
+always saw {"ok": None, ...}.  After the fix, last_judge_status() reads the
+shared file written by the daemon and returns the newer result.
+"""
+import json
+import time
+
+import clawmetry.eval_runner as er
+
+
+def _isolate(tmp_path, monkeypatch):
+    monkeypatch.setattr(er, "_EVAL_STATUS_PATH", str(tmp_path / "eval_status.json"))
+    # Reset in-memory state to "unset" (simulates a fresh dashboard process)
+    with er._LAST_JUDGE_LOCK:
+        er._LAST_JUDGE_STATUS.update({"ok": None, "error": None, "at": None,
+                                      "provider": None, "model": None})
+
+
+def test_file_written_on_record(tmp_path, monkeypatch):
+    _isolate(tmp_path, monkeypatch)
+    er._record_judge_status(True, None, "anthropic", "claude-haiku-4-5")
+    data = json.loads((tmp_path / "eval_status.json").read_text())
+    assert data["ok"] is True
+    assert data["provider"] == "anthropic"
+    assert data["model"] == "claude-haiku-4-5"
+    assert data["error"] is None
+    assert isinstance(data["at"], int)
+
+
+def test_file_written_on_auth_failure(tmp_path, monkeypatch):
+    _isolate(tmp_path, monkeypatch)
+    er._record_judge_status(False, "auth", "openai", "gpt-4o-mini")
+    data = json.loads((tmp_path / "eval_status.json").read_text())
+    assert data["ok"] is False
+    assert data["error"] == "auth"
+    assert data["provider"] == "openai"
+
+
+def test_last_judge_status_reads_file_when_newer(tmp_path, monkeypatch):
+    """Simulates daemon writing, dashboard reading from a separate process."""
+    _isolate(tmp_path, monkeypatch)
+    # Write status directly to file (as daemon would), bypassing in-memory dict
+    ts = int(time.time() * 1000) + 5000  # future ts so it's definitely newer
+    payload = {"ok": False, "error": "auth", "at": ts,
+               "provider": "anthropic", "model": "claude-haiku-4-5"}
+    (tmp_path / "eval_status.json").write_text(json.dumps(payload))
+
+    # In-memory is null (fresh process). last_judge_status() should return file.
+    result = er.last_judge_status()
+    assert result["ok"] is False
+    assert result["error"] == "auth"
+    assert result["at"] == ts
+
+
+def test_last_judge_status_prefers_memory_when_newer(tmp_path, monkeypatch):
+    """In-memory wins when it's more recent than the file."""
+    _isolate(tmp_path, monkeypatch)
+    old_ts = int(time.time() * 1000) - 10000
+    (tmp_path / "eval_status.json").write_text(json.dumps(
+        {"ok": True, "error": None, "at": old_ts,
+         "provider": "openai", "model": "gpt-4o-mini"}
+    ))
+    # In-memory is at a later timestamp
+    with er._LAST_JUDGE_LOCK:
+        er._LAST_JUDGE_STATUS.update({"ok": False, "error": "auth",
+                                      "at": int(time.time() * 1000),
+                                      "provider": "anthropic",
+                                      "model": "claude-haiku-4-5"})
+    result = er.last_judge_status()
+    assert result["provider"] == "anthropic"
+    assert result["ok"] is False
+
+
+def test_last_judge_status_tolerates_missing_file(tmp_path, monkeypatch):
+    _isolate(tmp_path, monkeypatch)
+    # No file written; should return in-memory null state without raising
+    result = er.last_judge_status()
+    assert result["ok"] is None
+
+
+def test_file_write_failure_is_silent(tmp_path, monkeypatch):
+    """A bad path must not crash _record_judge_status."""
+    monkeypatch.setattr(er, "_EVAL_STATUS_PATH", "/nonexistent_root/x/y/z.json")
+    with er._LAST_JUDGE_LOCK:
+        er._LAST_JUDGE_STATUS.update({"ok": None, "error": None, "at": None,
+                                      "provider": None, "model": None})
+    # Should not raise
+    er._record_judge_status(True, None, "anthropic", "claude-haiku-4-5")
+    # In-memory was still updated
+    with er._LAST_JUDGE_LOCK:
+        assert er._LAST_JUDGE_STATUS["ok"] is True


### PR DESCRIPTION
Closes #4332

## What

`_LAST_JUDGE_STATUS` was an in-memory dict per process. The sync daemon ran judge calls and recorded 401s there, but the Flask dashboard served `/api/evaluators` and `/api/evals/key` from its own copy — frozen at `{"ok": None, ...}` until something in the dashboard process itself happened to make a judge call (e.g. rescore, validate).

## Fix

- **`_record_judge_status`** — after updating `_LAST_JUDGE_STATUS` in-memory, best-effort writes the same dict to `~/.clawmetry/eval_status.json`. No key material (only `ok`, `error`, `provider`, `model`, `at`). Wrapped in `try/except`; a bad path or full disk never crashes the daemon.
- **`last_judge_status`** — reads the file on each call and returns whichever of {in-memory, file} has the newer `at`. Both processes converge within one scheduler tick (~30–60 s).

One file changed (`clawmetry/eval_runner.py`, +25/-2 LOC). No new dependencies.

## Test plan

- New test file `tests/test_eval_judge_status_cross_process.py` (6 tests, all pass):
  - File written on success and on auth failure
  - `last_judge_status()` returns file content when it's newer (simulates daemon → dashboard cross-process read)
  - In-memory wins when it's more recent than the file
  - Tolerates missing file (fresh install)
  - File write failure is silent (bad path → in-memory still updated)

---
_Generated by [Claude Code](https://claude.ai/code/session_013JE2jL6bTBKXbpgT9qy8Mc)_