### PR TITLE
fix(sync): heartbeat watchdog respects opt-in egress gate (follow-up to #4329)

### DIFF
--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -18752,15 +18752,18 @@ def run_daemon() -> None:
 
             now = time.time()
             if now - last_heartbeat > heartbeat_interval:
-                from clawmetry.config import is_cloud_disabled as _hb_cloud_off
-                if _hb_cloud_off():
-                    # Local-only mode (#3281): there is no cloud to heart-beat.
+                from clawmetry.config import cloud_egress_enabled as _hb_egress
+                if not _hb_egress(config):
+                    # No cloud egress (#3281 local-only, or #4329 self-hosted
+                    # with no linked account): there is no cloud to heart-beat.
                     # Skip the attempt entirely. Otherwise send_heartbeat returns
                     # falsy every cycle, consecutive_hb_failures climbs without
                     # bound, and we log CRITICAL "node appears offline in cloud"
                     # every ~15s -- which the daemon-error tee (PRD #1133) writes
                     # into the capped events table, EVICTING the user's real
-                    # agent events from the Brain feed. Local-only must be silent.
+                    # agent events from the Brain feed. No-egress must be silent
+                    # (found live on the Windows node minutes after 0.12.606:
+                    # the 401 wall was replaced by a CRITICAL wall).
                     consecutive_hb_failures = 0
                     last_heartbeat = now
                     heartbeat_interval = HEARTBEAT_INTERVAL_SLOW

--- a/tests/test_optin_cloud_egress.py
+++ b/tests/test_optin_cloud_egress.py
@@ -95,3 +95,19 @@ def test_startup_banner_has_selfhosted_branch():
     src = inspect.getsource(cm_sync.run_daemon)
     assert "SELF-HOSTED: no cloud account linked" in src
     assert "clawmetry login" in src
+
+
+def test_heartbeat_watchdog_respects_opt_in_gate():
+    """The liveness watchdog must skip counting when egress is off — a
+    no-account node otherwise logs CRITICAL 'node appears offline' every
+    ~15s, and the daemon-error tee evicts real events from the Brain feed
+    (exact regression shipped in 0.12.606, caught live on a Windows node)."""
+    import inspect
+
+    src = inspect.getsource(cm_sync)
+    idx = src.find("consecutive heartbeat failures — node appears offline")
+    assert idx != -1
+    window = src[max(0, idx - 4000):idx]
+    assert "cloud_egress_enabled" in window, (
+        "heartbeat watchdog no longer gates on cloud_egress_enabled()"
+    )


### PR DESCRIPTION
Caught live on the Windows verification node minutes after 0.12.606 auto-rolled onto it: #4329 silenced the 401 wall but the heartbeat **liveness watchdog** replaced it with `CRITICAL: N consecutive heartbeat failures — node appears offline in cloud` every ~15s. Its skip-guard only knew the #3281 local-only marker, not the new no-account state — `send_heartbeat` returns False without attempting, `last_heartbeat` never advances, counter climbs forever. Per the #3281 comment this also feeds the daemon-error tee and **evicts real agent events from the Brain feed**, so it's worse than log noise.

One-line fix: the guard now keys on `cloud_egress_enabled(config)` (covers marker + no-account). Regression test pins the watchdog to that helper (6/6 green; ruff zero-delta).

Will re-verify on the same Windows node post-release: sync.log must show neither 401 warnings nor CRITICAL lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)