### PR TITLE
fix(ci): add push trigger to c6-schedule-heal so it exits 0 informatively on push

### DIFF
--- a/.github/workflows/c6-schedule-heal.yml
+++ b/.github/workflows/c6-schedule-heal.yml
@@ -4,10 +4,14 @@ name: C6 auto-heal (required-checks application)
 # Runs every 2 hours and once daily at 10:15am UTC.
 # Self-heals C6 within 2 hours after E2E_ADMIN_PAT secret is added.
 #
+# On push to main: runs in informational mode (exit 0 regardless of state).
+# Reads current branch protection and reports status in the job summary,
+# but never exits 1 -- push CI must never be blocked by this workflow.
+#
 # When E2E_ADMIN_PAT is NOT set:
 #   - reads current branch protection state (read-only, no admin needed)
 #   - if clawmetry/main checks already configured: exits 0 (C6 green)
-#   - if checks not yet configured: emits ::error:: annotation and exits 1
+#   - if checks not yet configured on schedule: emits ::error:: annotation and exits 1
 #     (red badge acts as a forcing signal until the admin acts)
 #
 # When E2E_ADMIN_PAT IS set:
@@ -46,6 +50,8 @@ name: C6 auto-heal (required-checks application)
 # Tracking: vivekchand/clawmetry#4029
 
 on:
+  push:
+    branches: [main]
   schedule:
     - cron: '0 */2 * * *'   # every 2 hours -- heals within 2h of E2E_ADMIN_PAT being set
     - cron: '15 10 * * *'   # 10:15am UTC daily (kept for predictability)
@@ -271,8 +277,13 @@ print(json.dumps(sorted(set(a) | set(b))))
           BODY="<!-- c6-daily-ping --> **C6 daily ping ${TODAY}:** clawmetry/main branch protection does not yet require E2E checks. 6/7 criteria green. Fastest close: [Settings > Branches > main](https://github.com/vivekchand/clawmetry/settings/branches) > Required status checks > add \`E2E Gate (required)\` (60 s, no token needed). Or run \`bash scripts/close-c6.sh\` from a terminal."
           gh issue comment 4029 --repo vivekchand/clawmetry --body "$BODY"
 
+      # Exit 1 only on schedule (never on push -- this workflow is informational on push).
+      # Signals to the admin that E2E_ADMIN_PAT is needed to auto-heal C6.
       - name: Error: E2E_ADMIN_PAT not set
-        if: steps.pat-check.outputs.has_pat == 'false' && steps.read-state.outputs.checks_ok != 'true'
+        if: |
+          steps.pat-check.outputs.has_pat == 'false'
+          && steps.read-state.outputs.checks_ok != 'true'
+          && github.event_name != 'push'
         run: |
           echo "::error::E2E_ADMIN_PAT secret is not set -- C6 (required-status-checks) cannot be applied automatically."
           echo ""


### PR DESCRIPTION
## Problem

`c6-schedule-heal.yml` only declared `schedule` and `workflow_dispatch` triggers. GitHub's required-workflow runner still fired it on every push to main, creating an empty run (0 jobs) that was immediately marked **failure**. This has been redding main's CI on every single merge — all 30+ historical runs show the same `event=push | failure | 0 jobs` pattern.

The FLYWHEEL explicitly says: "clawmetry's C6 'Apply required E2E status checks' job is informational on push and should exit 0."

## Fix

Two minimal changes:

1. **Add `push: {branches: [main]}` trigger** — so jobs actually execute on push instead of GitHub creating a no-job shell run.

2. **Guard `exit 1` with `github.event_name != 'push'`** — on push the workflow runs in purely informational mode: reads current branch-protection state, writes the status to the job summary, then exits 0. It never blocks a push. The schedule still exits 1 if `E2E_ADMIN_PAT` is unset and checks aren't configured (preserving its forcing-signal role).

No other logic changed. The Rulesets-based check path, the daily ping, and the auto-apply-on-PAT path are all untouched.

## Test plan

- [ ] After merge: push a trivial commit to main (or watch the next merge) and confirm `c6-schedule-heal` shows green (not "0 jobs, failure")
- [ ] On the next scheduled run (within 2 h): if `E2E_ADMIN_PAT` is still unset and checks aren't in classic protection, the schedule still exits 1 as expected

Tracking: #4029

---
_Generated by [Claude Code](https://claude.ai/code/session_01D1cvv5BnYWHfKTZMTzDGf3)_