### PR TITLE
fix(harness): abort filing when fingerprint lookup fails (#4301)

### DIFF
--- a/scripts/harness/audit.py
+++ b/scripts/harness/audit.py
@@ -193,9 +193,13 @@ def _fingerprint(runtime: str, gap: dict) -> str:
     return "hgap-" + hashlib.sha1(key.encode()).hexdigest()[:10]
 
 
-def _existing_fingerprints() -> set:
+def _existing_fingerprints():
     """Fingerprints of already-filed gaps (from issue bodies), so a daily run
-    never re-files the same gap. Matches the `hgap-<10hex>` token we embed."""
+    never re-files the same gap. Matches the `hgap-<10hex>` token we embed.
+
+    Returns None when the lookup fails so callers can skip filing entirely
+    rather than treating every gap as new (which would re-file duplicates).
+    """
     import re
     try:
         out = subprocess.check_output(
@@ -205,8 +209,9 @@ def _existing_fingerprints() -> set:
         for it in json.loads(out):
             fps.update(re.findall(r"hgap-[0-9a-f]{10}", it.get("body") or ""))
         return fps
-    except Exception:
-        return set()
+    except Exception as exc:
+        print(f"  [warn] fingerprint lookup failed ({exc}); skipping --file-issues to avoid duplicates")
+        return None
 
 
 def _file_issue(runtime: str, gap: dict, fp: str, dry: bool) -> None:
@@ -253,7 +258,14 @@ def main() -> int:
     manifest = _load_manifest()
     clone_base = _clone_dir(manifest)
     caps = _capabilities_enum()
-    existing = _existing_fingerprints() if args.file_issues else set()
+    if args.file_issues:
+        existing = _existing_fingerprints()
+        if existing is None:
+            print("[abort] could not verify existing fingerprints — not filing to avoid duplicates."
+                  " Re-run when the gh API is reachable.")
+            return 1
+    else:
+        existing = set()
     total_gaps = 0
 
     for h in manifest["harnesses"]:


### PR DESCRIPTION
## Summary

`_existing_fingerprints()` in `scripts/harness/audit.py` was silently returning an empty `set()` when the `gh issue list` API call failed (rate limit, auth error, network timeout). An empty set causes every gap fingerprint to pass the dedup check, so a single transient API failure causes the next audit run to re-file all gaps — including issues that are already open with identical fingerprints.

This is the root cause of issues #4103 and #4301 both existing with the same fingerprint `hgap-ffe226c286` (ClickClack channel, which is fully implemented in `main`).

## Changes

- `_existing_fingerprints()` now returns `None` on failure (with a logged warning) instead of `set()`, making the failure visible rather than silently corrupting dedup state.
- `main()` treats a `None` return as an abort signal: when `--file-issues` is passed and fingerprints can't be verified, the filing step is skipped entirely with a clear message. Dry-run mode is unaffected.

## Test plan

- [ ] `python3 scripts/harness/audit.py` (dry-run, no `gh` required) still works and prints gaps
- [ ] `python3 scripts/harness/audit.py --file-issues` with `gh` unavailable prints the `[abort]` message and exits 1 instead of filing
- [ ] `python3 scripts/harness/audit.py --file-issues` with `gh` available works as before (fingerprints fetched, dups skipped)

## Bot meta
<!-- bot-autofix -->
Draft PR opened autonomously based on the plan in #4301. Marked draft for human review — mark Ready for Review once happy.

Closes #4301

---
_Generated by [Claude Code](https://claude.ai/code/session_01XWXmtGWbgefUrGBe5LR9rv)_