### PR TITLE
fix(auto-deploy): pin from the latest PyPI version (the checkout's __version__ is permanently stale)

### DIFF
--- a/.github/workflows/auto-deploy-cloud.yml
+++ b/.github/workflows/auto-deploy-cloud.yml
@@ -20,10 +20,18 @@ jobs:
 
       - name: Get OSS version
         id: oss_version
+        # Source of truth is the LATEST PUBLISHED PyPI version, not the
+        # checkout's __version__: release-on-merge publishes the bump to
+        # PyPI without committing it back to dashboard.py, so the file is
+        # permanently one-or-more releases stale. Reading it here was the
+        # root cause of the 2026-07-31 stale-pin rollbacks (with the
+        # no-downgrade guard below, a stale source would instead mean the
+        # pin never advances at all). The Dockerfile installs from PyPI,
+        # so the published version is exactly what a pin means.
         run: |
-          VERSION=$(python3 -c "import re; m=re.search(r'__version__ = \"([^\"]+)\"', open('dashboard.py').read()); print(m.group(1))")
+          VERSION=$(curl -fsSL https://pypi.org/pypi/clawmetry/json | python3 -c "import sys,json; print(json.load(sys.stdin)['info']['version'])")
           echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "OSS version: $VERSION"
+          echo "Latest published OSS version: $VERSION"
 
       # The cloud Dockerfile does `pip install clawmetry==<version>`, and the
       # cloud PR's CI also installs it to audit routes. On a release commit this


### PR DESCRIPTION
Completes the auto-pin fix from #4340. release-on-merge publishes to PyPI without committing the bump back to dashboard.py, so `__version__` on main is permanently stale (0.12.597 in the file vs 0.12.610 on PyPI right now). Before #4340 that produced downgrade pins that rolled releases back; after #4340 it means the guard correctly refuses every pin and promotion never advances (verified in today's run logs: `target=0.12.597 cloud-main-pin=0.12.605 - refusing`).

Fix: the version source becomes the latest published PyPI version, which is exactly what the cloud Dockerfile installs. Combined with the no-downgrade guard this is monotonic and race-free. YAML validated; I'll workflow_dispatch a run after merge and watch it pin the current release end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)