### PR TITLE
fix(brain): shared duplicate-collapse for local API + cloud blob; sender block in channel pill

### DIFF
--- a/clawmetry/brain_dedupe.py
+++ b/clawmetry/brain_dedupe.py
@@ -1,0 +1,277 @@
+"""
+Shared collapse for duplicate Brain-feed events.
+
+One logical agent/user turn legitimately lands in DuckDB as SEVERAL rows:
+the Claude-transcript copy (``cc-msg:*``, carries cost/tokens), the OpenClaw
+v3 ``model.completed`` sibling, a tokens=0 ``delivery-mirror`` echo, and for
+inbound channel messages both the gateway ``prompt.submitted`` and the
+transcript ``user`` turn (the latter prefixed with a ``Conversation info
+(untrusted metadata)`` JSON block the former lacks). They all carry distinct
+ids, so id-level dedup can never merge them — content-window collapse is the
+only honest answer.
+
+Historically that collapse lived ONLY in ``routes/brain.py`` (the local
+``/api/brain-history``), so the cloud blob built by
+``sync._build_brain_events`` shipped every sibling and the hosted Brain feed
+showed one reply three times (founder screenshot, 2026-07-31). This module is
+the single implementation both readers call, parameterised by accessors so it
+works on UI-shaped events and raw store rows alike.
+
+Two passes, mirroring the battle-tested ``routes/brain.py`` logic:
+
+* Pass 1 — same source, identical normalized text (>= ``MIN_DETAIL`` chars),
+  120 s window: collapses assistant/model.completed/delivery-mirror siblings.
+* Pass 2a — any source, identical normalized long text (>= ``MIN_DETAIL``),
+  tight 10 s window: the #3924 double-ingest safety net.
+* Pass 2b — same SESSION, identical normalized text of any length >=
+  ``MIN_DETAIL_SHORT``, 10 s window: catches the short inbound message
+  ("hello - I'm in a meeting" is 24 chars, under pass 2a's floor) that
+  arrives via both the gateway tap and the transcript. Keyed per session so
+  a short broadcast to several sessions is never merged.
+
+Text keys are NORMALIZED first: leading ``<label> (untrusted metadata):``
+fenced-JSON preambles are stripped and whitespace collapsed, so the
+transcript copy and the raw gateway copy of the same message finally share a
+key. Within a cluster the richest row wins (real message row over a
+model.completed echo, then cost, then tokens).
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import re
+
+WINDOW_S = 120.0
+CROSS_SRC_WINDOW_S = 10.0
+MIN_DETAIL = 40
+MIN_DETAIL_SHORT = 4
+
+# "Conversation info (untrusted metadata):\n```json\n{...}\n```" and friends.
+# Repeatedly stripped from the front so multi-block preambles normalize too.
+_META_PREAMBLE_RE = re.compile(
+    r"^\s*[^\n`]{0,80}\(untrusted metadata\):\s*```[a-zA-Z]*\s*.*?```\s*",
+    re.DOTALL,
+)
+
+_PRIO = {
+    "MESSAGE": 3, "ASSISTANT": 3, "AGENT": 3, "USER": 3, "RESULT": 3,
+    "THINK": 2,
+    "MODEL.COMPLETED": 1, "MODEL": 1, "PROMPT.SUBMITTED": 1,
+}
+
+
+def normalize_detail(text) -> str:
+    """Comparison key for a brain event's text.
+
+    Strips leading ``(untrusted metadata)`` fenced-JSON preambles (the
+    transcript copy of a channel message carries one, the gateway copy does
+    not) and collapses whitespace. Never raises; non-strings key as ""."""
+    try:
+        s = str(text or "")
+        for _ in range(4):
+            stripped = _META_PREAMBLE_RE.sub("", s, count=1)
+            if stripped == s:
+                break
+            s = stripped
+        return " ".join(s.split())
+    except Exception:
+        return ""
+
+
+def type_priority(type_name) -> int:
+    """Row-keeping priority for an event type (higher = richer)."""
+    return _PRIO.get(str(type_name or "").upper(), 2)
+
+
+def collapse_events(items, *, get_src, get_session, get_detail, get_time,
+                    get_richness) -> list:
+    """Return ``items`` with duplicate-content siblings collapsed.
+
+    Accessors receive one item and return: ``get_src`` a per-source key,
+    ``get_session`` a per-session key (may equal src), ``get_detail`` the
+    raw text (normalized here), ``get_time`` an ISO-8601 string, and
+    ``get_richness`` a sortable tuple (max wins). Order is preserved; on any
+    accessor failure the item is kept. Never raises.
+    """
+    try:
+        return _collapse(items or [], get_src, get_session, get_detail,
+                         get_time, get_richness)
+    except Exception:
+        return list(items or [])
+
+
+def _collapse(items, get_src, get_session, get_detail, get_time, get_richness):
+    def _parse(it):
+        try:
+            ts = get_time(it) or ""
+            return _dt.datetime.fromisoformat(str(ts).replace("Z", "+00:00"))
+        except Exception:
+            return None
+
+    def _safe(fn, it, default=""):
+        try:
+            return fn(it)
+        except Exception:
+            return default
+
+    def _collapse_groups(groups, window_s, drop):
+        for evs in groups.values():
+            if len(evs) < 2:
+                continue
+            ordered = sorted(evs, key=lambda e: (_parse(e) or _dt.datetime.min))
+            cluster = [ordered[0]]
+            clusters = [cluster]
+            for prev, cur in zip(ordered, ordered[1:]):
+                tp, tc = _parse(prev), _parse(cur)
+                if tp is None or tc is None or \
+                        abs((tc - tp).total_seconds()) <= window_s:
+                    cluster.append(cur)
+                else:
+                    cluster = [cur]
+                    clusters.append(cluster)
+            for cl in clusters:
+                if len(cl) < 2:
+                    continue
+                best = max(cl, key=lambda e: _safe(get_richness, e, (0,)))
+                for e in cl:
+                    if e is not best:
+                        drop.add(id(e))
+
+    norm = {}
+    for ev in items:
+        norm[id(ev)] = normalize_detail(_safe(get_detail, ev))
+
+    # Pass 1: same-source, substantial text, 120 s window.
+    groups: dict = {}
+    for ev in items:
+        detail = norm[id(ev)]
+        if len(detail) < MIN_DETAIL:
+            continue
+        groups.setdefault((_safe(get_src, ev), detail), []).append(ev)
+    drop: set = set()
+    _collapse_groups(groups, WINDOW_S, drop)
+
+    # Pass 2a: cross-source, substantial text, tight 10 s window (#3924).
+    cross: dict = {}
+    for ev in items:
+        if id(ev) in drop:
+            continue
+        detail = norm[id(ev)]
+        if len(detail) < MIN_DETAIL:
+            continue
+        cross.setdefault(detail, []).append(ev)
+    _collapse_groups(cross, CROSS_SRC_WINDOW_S, drop)
+
+    # Pass 2b: same-SESSION short text, 10 s window — the gateway
+    # prompt.submitted + transcript user copy of one inbound message.
+    # Session-scoped so identical short texts in different sessions
+    # (a broadcast "Done!") are never merged.
+    short: dict = {}
+    for ev in items:
+        if id(ev) in drop:
+            continue
+        detail = norm[id(ev)]
+        if not (MIN_DETAIL_SHORT <= len(detail) < MIN_DETAIL):
+            continue
+        sess = str(_safe(get_session, ev) or "")
+        if not sess:
+            continue
+        short.setdefault((sess, detail), []).append(ev)
+    _collapse_groups(short, CROSS_SRC_WINDOW_S, drop)
+
+    if not drop:
+        return list(items)
+    return [ev for ev in items if id(ev) not in drop]
+
+
+# ── Store-row adapter (used by sync._build_brain_events) ─────────────────────
+
+def row_text(row) -> str:
+    """Best-effort human text of a raw DuckDB event row, for keying only.
+
+    Mirrors what the cloud's ``transformEvents`` / ``_v3_chat_message`` will
+    eventually render: v3 completion/prompt text, Claude-transcript message
+    content (string or text blocks), or a plain string payload."""
+    try:
+        data = row.get("data")
+        if isinstance(data, str):
+            return data
+        if not isinstance(data, dict):
+            return ""
+        for key in ("completionText", "finalPromptText"):
+            v = data.get(key)
+            if isinstance(v, str) and v.strip():
+                return v
+        at = data.get("assistantTexts")
+        if isinstance(at, list) and at and isinstance(at[0], str):
+            return at[0]
+        inner = data.get("data")
+        if isinstance(inner, dict):
+            for key in ("completionText", "finalPromptText"):
+                v = inner.get(key)
+                if isinstance(v, str) and v.strip():
+                    return v
+            iat = inner.get("assistantTexts")
+            if isinstance(iat, list) and iat and isinstance(iat[0], str):
+                return iat[0]
+        msg = data.get("message")
+        if isinstance(msg, dict):
+            content = msg.get("content")
+            if isinstance(content, str):
+                return content
+            if isinstance(content, list):
+                parts = [b.get("text") for b in content
+                         if isinstance(b, dict) and b.get("type") == "text"
+                         and isinstance(b.get("text"), str)]
+                if parts:
+                    return "\n".join(parts)
+        content = data.get("content")
+        if isinstance(content, str):
+            return content
+        return ""
+    except Exception:
+        return ""
+
+
+def _bare_session(sid) -> str:
+    """Canonical per-session key: drop any ``runtime:`` namespace prefix."""
+    s = str(sid or "")
+    return s.rsplit(":", 1)[-1]
+
+
+def row_richness(row) -> tuple:
+    """Keep-priority of a store row: message-class beats model.completed
+    beats the tokens=0 delivery-mirror echo; then real cost wins (the
+    Claude-transcript copy carries it, the gateway copies do not)."""
+    try:
+        data = row.get("data") if isinstance(row.get("data"), dict) else {}
+        etype = str(row.get("event_type") or data.get("type") or "")
+        prio = type_priority(etype)
+        inner = data.get("data") if isinstance(data.get("data"), dict) else {}
+        model = ""
+        for d in (data, inner):
+            m = d.get("modelId") or d.get("model")
+            if isinstance(m, str) and m:
+                model = m
+                break
+        if "delivery-mirror" in model:
+            prio = 0
+        cost = row.get("cost_usd") or 0.0
+        try:
+            cost = float(cost)
+        except Exception:
+            cost = 0.0
+        return (prio, cost)
+    except Exception:
+        return (0, 0.0)
+
+
+def collapse_duplicate_brain_rows(rows) -> list:
+    """Collapse duplicate-content siblings in raw store rows (blob builder)."""
+    return collapse_events(
+        rows,
+        get_src=lambda r: _bare_session(r.get("session_id")),
+        get_session=lambda r: _bare_session(r.get("session_id")),
+        get_detail=row_text,
+        get_time=lambda r: r.get("ts") or "",
+        get_richness=row_richness,
+    )

--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -4460,7 +4460,16 @@ function _provenancePillHtml(meta, bodyHtml) {
       ? _channelDisplayName(prov)
       : (prov.charAt(0).toUpperCase() + prov.slice(1));
   }
-  var sender = meta.sender ? String(meta.sender) : '';
+  // meta.sender may be a BLOCK ({id, name, username, is_bot}) — Telegram's
+  // "Conversation info (untrusted metadata)" carries one. String() on it
+  // renders "[object Object]" in the pill (founder screenshot 2026-07-31);
+  // unwrap it the same way _extractChannelInfo does.
+  var senderVal = meta.sender;
+  if (senderVal && typeof senderVal === 'object') {
+    senderVal = senderVal.name || senderVal.username || senderVal.first_name
+      || senderVal.display_name || senderVal.id || '';
+  }
+  var sender = senderVal ? String(senderVal) : '';
   var ts = meta.timestamp;
   var tStr = '';
   if (ts) {

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -7945,6 +7945,16 @@ def _build_brain_events() -> list:
 
     picked.sort(key=lambda r: r.get("ts") or "", reverse=True)
     picked = picked[:BRAIN_CACHE_LIMIT]
+    # Collapse duplicate-content siblings (assistant + model.completed +
+    # delivery-mirror echo; gateway prompt.submitted + transcript user copy)
+    # with the SAME shared logic /api/brain-history uses. Without this the
+    # cloud feed showed each reply three times while the local API showed it
+    # once (founder screenshot, 2026-07-31).
+    try:
+        from clawmetry.brain_dedupe import collapse_duplicate_brain_rows
+        picked = collapse_duplicate_brain_rows(picked)
+    except Exception:
+        pass
     # Same translation as routes/brain.py:_try_local_store_brain (incl. the
     # hide_clawmetry_session filter + sessionId stamp + size cap).
     return _rows_to_brain_events(picked)[:BRAIN_CACHE_LIMIT]
@@ -7983,6 +7993,13 @@ def _build_brain_events_window(since=None, until=None, limit=BRAIN_WINDOW_LIMIT)
     except Exception:
         return []
     rows = [r for r in rows if _brain_row_renderable(r)][:lim]
+    # Same duplicate-sibling collapse as the live blob (_build_brain_events):
+    # a windowed investigation must not show one reply three times either.
+    try:
+        from clawmetry.brain_dedupe import collapse_duplicate_brain_rows
+        rows = collapse_duplicate_brain_rows(rows)
+    except Exception:
+        pass
     return _rows_to_brain_events(rows)[:lim]
 
 

--- a/routes/brain.py
+++ b/routes/brain.py
@@ -325,79 +325,29 @@ def _collapse_duplicate_brain_events(events):
     path but not the other), so the ``(src, detail)`` key from pass 1 misses them.
     A 10-second cross-source window is tight enough to avoid collapsing genuine
     re-utterances while reliably catching the ~2s ingest gap.
+
+    The implementation now lives in :mod:`clawmetry.brain_dedupe` so the cloud
+    blob builder (``sync._build_brain_events``) applies the SAME collapse —
+    previously it applied none, and the hosted Brain feed showed each reply
+    three times while the local API showed it once (founder screenshot,
+    2026-07-31). The shared version also normalizes the text key (stripping
+    ``(untrusted metadata)`` preambles) and adds a same-session short-text
+    pass, so the gateway ``prompt.submitted`` + transcript ``USER`` copies of
+    one inbound channel message collapse too.
     """
-    import datetime as _dt
+    from clawmetry.brain_dedupe import collapse_events, type_priority
 
-    WINDOW_S = 120.0
-    CROSS_SRC_WINDOW_S = 10.0
-    MIN_DETAIL = 40
-    _PRIO = {"MESSAGE": 3, "ASSISTANT": 3, "AGENT": 3, "USER": 3, "RESULT": 3,
-             "THINK": 2, "MODEL.COMPLETED": 1, "MODEL": 1}
-
-    def _src(ev):
-        return ev.get("src") or ev.get("source") or ev.get("sessionId") or ""
-
-    def _parse(ev):
-        ts = ev.get("time") or ""
-        try:
-            return _dt.datetime.fromisoformat(str(ts).replace("Z", "+00:00"))
-        except Exception:
-            return None
-
-    def _richness(ev):
-        return (_PRIO.get((ev.get("type") or "").upper(), 2), ev.get("tokens") or 0)
-
-    def _collapse_groups(groups, window_s, drop):
-        for evs in groups.values():
-            if len(evs) < 2:
-                continue
-            ordered = sorted(evs, key=lambda e: (_parse(e) or _dt.datetime.min))
-            cluster = [ordered[0]]
-            clusters = [cluster]
-            for prev, cur in zip(ordered, ordered[1:]):
-                tp, tc = _parse(prev), _parse(cur)
-                if tp is None or tc is None or abs((tc - tp).total_seconds()) <= window_s:
-                    cluster.append(cur)
-                else:
-                    cluster = [cur]
-                    clusters.append(cluster)
-            for cl in clusters:
-                if len(cl) < 2:
-                    continue
-                best = max(cl, key=_richness)
-                for e in cl:
-                    if e is not best:
-                        drop.add(id(e))
-
-    # Pass 1: same-source dedup — (src, detail) key, 120s window.
-    # Collapses model.completed-vs-assistant siblings from a single ingest path.
-    groups: dict = {}
-    for ev in events:
-        detail = (ev.get("detail") or "").strip()
-        if len(detail) < MIN_DETAIL:
-            continue
-        groups.setdefault((_src(ev), detail), []).append(ev)
-
-    drop: set = set()
-    _collapse_groups(groups, WINDOW_S, drop)
-
-    # Pass 2: cross-source content dedup — detail key only, tight 10s window.
-    # Catches the session-file + via-index double-ingest of the same reply (#3924).
-    # Events already eliminated by pass 1 are skipped to avoid id() aliasing.
-    cross_groups: dict = {}
-    for ev in events:
-        if id(ev) in drop:
-            continue
-        detail = (ev.get("detail") or "").strip()
-        if len(detail) < MIN_DETAIL:
-            continue
-        cross_groups.setdefault(detail, []).append(ev)
-
-    _collapse_groups(cross_groups, CROSS_SRC_WINDOW_S, drop)
-
-    if not drop:
-        return events
-    return [ev for ev in events if id(ev) not in drop]
+    return collapse_events(
+        events,
+        get_src=lambda ev: ev.get("src") or ev.get("source")
+        or ev.get("sessionId") or "",
+        get_session=lambda ev: str(ev.get("sessionId") or ev.get("src")
+                                   or "")[:32],
+        get_detail=lambda ev: ev.get("detail") or "",
+        get_time=lambda ev: ev.get("time") or "",
+        get_richness=lambda ev: (type_priority(ev.get("type")),
+                                 ev.get("tokens") or 0),
+    )
 
 
 def _try_local_store_brain(limit, include_artifacts, since=None, until=None):

--- a/tests/test_brain_dedupe.py
+++ b/tests/test_brain_dedupe.py
@@ -1,0 +1,227 @@
+"""
+Brain-feed duplicate collapse (clawmetry/brain_dedupe.py).
+
+Guards the 2026-07-31 founder screenshot: the hosted Brain feed showed one
+agent reply THREE times (assistant transcript row + v3 model.completed +
+delivery-mirror echo — the cloud blob builder applied no collapse) and one
+inbound Telegram message TWICE (gateway prompt.submitted + transcript user
+copy, whose "(untrusted metadata)" preamble defeated the exact-string key).
+
+Fixtures below are the REAL DuckDB rows from that incident (slimmed), not
+synthetic shapes — synthetic tests have missed real event shapes before.
+"""
+import copy
+
+from clawmetry.brain_dedupe import (
+    collapse_duplicate_brain_rows,
+    collapse_events,
+    normalize_detail,
+    row_text,
+)
+
+_SID = "62030919-c8b1-4963-acc4-69465f00c3d1"
+_REPLY = "Hey. Go do your meeting. I'm here when you're out."
+_USER_PREAMBLED = (
+    "Conversation info (untrusted metadata):\n```json\n{\n"
+    '  "chat_id": "telegram:1532693273",\n  "message_id": "42",\n'
+    '  "sender": {\n    "id": "1532693273",\n    "name": "Vivek Chand",\n'
+    '    "username": "vivekchand19",\n    "is_bot": false\n  },\n'
+    '  "timestamp": "Fri 2026-07-31 21:18:37 GMT+5:30",\n'
+    '  "inbound_event_kind": "user_request",\n'
+    '  "explicitly_mentioned_bot": false\n}\n```\n\n'
+    "hello - I'm in a meeting"
+)
+
+
+def _v3_reply_row(rid, ts, model):
+    return {
+        "id": rid, "session_id": _SID, "ts": ts,
+        "event_type": "model.completed", "cost_usd": 0.0,
+        "data": {
+            "type": "model.completed", "_v3_type": "message",
+            "completionText": _REPLY, "assistantTexts": [_REPLY],
+            "modelId": model, "timestamp": ts,
+            "data": {"completionText": _REPLY, "assistantTexts": [_REPLY],
+                     "modelId": model},
+        },
+    }
+
+
+def _real_rows():
+    """The five renderable rows of the real incident, newest first."""
+    return [
+        _v3_reply_row("1abd6d8b-36cd-471a-a6c7-f9a5616f3c62",
+                      "2026-07-31T15:48:42.786Z", "delivery-mirror"),
+        _v3_reply_row("745de276-6a7a-46a2-96f2-1e2fa4f87275",
+                      "2026-07-31T15:48:42.752Z", "claude-opus-4-8"),
+        {
+            "id": "cc-msg:23bba84e-615c-48ff-8acc-b58a97c2135b",
+            "session_id": _SID, "ts": "2026-07-31T15:48:41.657Z",
+            "event_type": "assistant", "cost_usd": 0.0342745,
+            "data": {
+                "type": "assistant", "timestamp": "2026-07-31T15:48:41.657Z",
+                "message": {"role": "assistant",
+                            "content": [{"text": _REPLY, "type": "text"}],
+                            "model": "claude-opus-4-8"},
+            },
+        },
+        {
+            "id": "cc-msg:baccb25c-75f7-46d1-bede-c96c6de0705b",
+            "session_id": _SID, "ts": "2026-07-31T15:48:39.551Z",
+            "event_type": "user", "cost_usd": None,
+            "data": {
+                "type": "user", "timestamp": "2026-07-31T15:48:39.551Z",
+                "message": {"role": "user", "content": _USER_PREAMBLED},
+            },
+        },
+        {
+            "id": "1e7cc85f-dc2d-4a18-aeec-41e550a32fbd",
+            "session_id": _SID, "ts": "2026-07-31T15:48:37.906Z",
+            "event_type": "prompt.submitted", "cost_usd": None,
+            "data": {
+                "type": "prompt.submitted", "_v3_type": "message",
+                "finalPromptText": "hello - I'm in a meeting",
+                "timestamp": "2026-07-31T15:48:37.906Z",
+                "data": {"finalPromptText": "hello - I'm in a meeting"},
+            },
+        },
+    ]
+
+
+# ── normalize_detail ─────────────────────────────────────────────────────────
+
+def test_normalize_strips_untrusted_metadata_preamble():
+    assert normalize_detail(_USER_PREAMBLED) == "hello - I'm in a meeting"
+
+
+def test_normalize_plain_text_only_collapses_whitespace():
+    assert normalize_detail("  hello \n world ") == "hello world"
+    assert normalize_detail(None) == ""
+
+
+# ── row_text extraction (real shapes) ────────────────────────────────────────
+
+def test_row_text_all_real_shapes():
+    rows = _real_rows()
+    assert row_text(rows[0]) == _REPLY            # v3 completionText
+    assert row_text(rows[2]) == _REPLY            # transcript text blocks
+    assert row_text(rows[3]) == _USER_PREAMBLED   # string content
+    assert row_text(rows[4]) == "hello - I'm in a meeting"  # finalPromptText
+
+
+# ── the incident: 5 visible rows must collapse to 2 ──────────────────────────
+
+def test_incident_rows_collapse_to_one_agent_one_user():
+    out = collapse_duplicate_brain_rows(_real_rows())
+    ids = [r["id"] for r in out]
+    assert len(out) == 2, ids
+    # richest survivors: the transcript copies (cost on the reply, the
+    # Telegram-card user turn), never the echoes
+    assert "cc-msg:23bba84e-615c-48ff-8acc-b58a97c2135b" in ids
+    assert "cc-msg:baccb25c-75f7-46d1-bede-c96c6de0705b" in ids
+
+
+def test_reply_trio_keeps_the_cost_bearing_transcript_row():
+    rows = _real_rows()[:3]
+    out = collapse_duplicate_brain_rows(rows)
+    assert len(out) == 1
+    assert out[0]["cost_usd"] == 0.0342745
+
+
+def test_user_pair_keeps_the_transcript_card_row():
+    rows = _real_rows()[3:]
+    out = collapse_duplicate_brain_rows(rows)
+    assert len(out) == 1
+    assert out[0]["event_type"] == "user"
+
+
+# ── must-NOT-collapse guards ─────────────────────────────────────────────────
+
+def test_distinct_texts_survive():
+    rows = _real_rows()
+    rows[4]["data"]["finalPromptText"] = "a totally different message"
+    rows[4]["data"]["data"]["finalPromptText"] = "a totally different message"
+    out = collapse_duplicate_brain_rows(rows)
+    assert any(r["event_type"] == "prompt.submitted" for r in out)
+
+
+def test_same_short_text_in_different_sessions_survives():
+    a = copy.deepcopy(_real_rows()[4])
+    b = copy.deepcopy(_real_rows()[4])
+    b["id"] = "other-id"
+    b["session_id"] = "ffffffff-0000-0000-0000-000000000000"
+    b["ts"] = "2026-07-31T15:48:38.906Z"
+    out = collapse_duplicate_brain_rows([a, b])
+    assert len(out) == 2
+
+
+def test_same_text_far_apart_survives():
+    a = copy.deepcopy(_real_rows()[4])
+    b = copy.deepcopy(_real_rows()[4])
+    b["id"] = "other-id"
+    b["ts"] = "2026-07-31T16:30:00.000Z"  # ~42 min later: a re-utterance
+    out = collapse_duplicate_brain_rows([a, b])
+    assert len(out) == 2
+
+
+def test_empty_and_broken_rows_never_raise():
+    assert collapse_duplicate_brain_rows([]) == []
+    # rows with missing/odd fields must pass through, never raise
+    out = collapse_duplicate_brain_rows([{"id": "x"}, {"data": 42}])
+    assert len(out) == 2
+
+
+# ── the /api/brain-history UI-shape path uses the same engine ────────────────
+
+def test_routes_collapse_handles_preambled_user_pair():
+    from routes.brain import _collapse_duplicate_brain_events
+    events = [
+        {"type": "USER", "src": _SID[:32], "sessionId": _SID,
+         "time": "2026-07-31T15:48:39.551Z", "detail": _USER_PREAMBLED,
+         "tokens": 0},
+        {"type": "PROMPT.SUBMITTED", "src": _SID[:32], "sessionId": _SID,
+         "time": "2026-07-31T15:48:37.906Z",
+         "detail": "hello - I'm in a meeting", "tokens": 0},
+    ]
+    out = _collapse_duplicate_brain_events(events)
+    assert len(out) == 1
+    assert out[0]["type"] == "USER"
+
+
+def test_routes_collapse_still_collapses_reply_trio():
+    from routes.brain import _collapse_duplicate_brain_events
+    def mk(t, typ, tok):
+        return {"type": typ, "src": _SID[:32], "sessionId": _SID,
+                "time": t, "detail": _REPLY, "tokens": tok}
+    events = [
+        mk("2026-07-31T15:48:42.786Z", "MODEL.COMPLETED", 0),
+        mk("2026-07-31T15:48:42.752Z", "MODEL.COMPLETED", 0),
+        mk("2026-07-31T15:48:41.657Z", "ASSISTANT", 25),
+    ]
+    out = _collapse_duplicate_brain_events(events)
+    assert len(out) == 1
+    assert out[0]["type"] == "ASSISTANT"
+
+
+# ── generic engine sanity ────────────────────────────────────────────────────
+
+def test_collapse_events_accessor_failure_keeps_items():
+    def boom(ev):
+        raise RuntimeError("boom")
+    items = [{"a": 1}, {"a": 2}]
+    out = collapse_events(items, get_src=boom, get_session=boom,
+                          get_detail=boom, get_time=boom, get_richness=boom)
+    assert out == items
+
+
+# ── frontend guard: the Telegram pill must unwrap sender blocks ──────────────
+
+def test_appjs_provenance_pill_unwraps_sender_object():
+    """String(meta.sender) on a sender BLOCK rendered "[object Object]" in
+    the channel pill. Assert the unwrap guard stays in _provenancePillHtml."""
+    import pathlib
+    js = (pathlib.Path(__file__).resolve().parents[1]
+          / "clawmetry" / "static" / "js" / "app.js").read_text()
+    fn = js.split("function _provenancePillHtml", 1)[1][:2500]
+    assert "typeof senderVal === 'object'" in fn
+    assert ".name || senderVal.username" in fn


### PR DESCRIPTION
## Why

Founder screenshot 2026-07-31: the hosted Brain feed showed one agent reply THREE times and one inbound Telegram message TWICE, with the Telegram pill reading [object Object].

One turn legitimately lands in DuckDB as several rows (transcript copy with cost, v3 model.completed, a tokens=0 delivery-mirror echo; inbound messages also as gateway prompt.submitted plus the transcript user turn carrying a Conversation info (untrusted metadata) preamble). Content-window collapse existed ONLY in routes/brain.py, so the local API showed 1 agent row while the cloud blob (sync._build_brain_events, no collapse at all) shipped all 3. The user pair escaped even locally because the preamble defeats the exact-string key, and the raw text (24 chars) is under the 40-char floor.

## What

- New clawmetry/brain_dedupe.py: the single collapse implementation, accessor-parameterised so it runs on UI-shaped events (routes/brain.py) and raw store rows (sync blob builders). Text keys are normalized (untrusted-metadata preambles stripped, whitespace collapsed). Adds a same-SESSION short-text pass (10 s window, >= 4 chars) so short inbound messages dedupe without ever merging cross-session broadcasts.
- routes/brain.py: _collapse_duplicate_brain_events now delegates to the shared engine (same windows, same richest-row preference).
- sync.py: _build_brain_events AND _build_brain_events_window apply the same collapse before building the blob, so hosted and local feeds finally agree.
- static/js/app.js: _provenancePillHtml unwraps a sender BLOCK (name/username/first_name/id) instead of String()-ing it to [object Object], mirroring _extractChannelInfo.

## Verification

- tests/test_brain_dedupe.py: 14 tests using the REAL rows from the incident (slimmed fixtures, not synthetic): trio collapses keeping the cost-bearing transcript row, user pair collapses keeping the Telegram-card row, distinct texts / cross-session same-text / far-apart re-utterances all survive, accessor failures never raise, and a source guard pins the app.js sender unwrap.
- Revert-proof: with origin/main routes/brain.py swapped in, test_routes_collapse_handles_preambled_user_pair goes red (duplicate survives) while the pre-existing trio collapse still passes; restored tree is 14/14.
- Live E2E against the real store: the incident window now returns exactly 2 rows through BOTH _try_local_store_brain and _build_brain_events_window (was 3 locally, 5 on cloud).
- Neighbor suites (test_brain_duplicate_collapse, test_brain_cache_push, test_brain_history_v3_event_detail, test_brain_full_detail): identical failure set on origin/main baseline and this branch in this environment (6 pre-existing local-env failures, 11 pass) - zero net-new.
- ruff clean on new/changed files I own; node --check clean on app.js.

🤖 Generated with [Claude Code](https://claude.com/claude-code)