### PR TITLE
[RELEASE] feat(compliance): Compliance Pack — auditor-ready agent evidence bundles (NIST AI RMF / SOC 2), Pro & Enterprise

### DIFF
--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -5898,6 +5898,66 @@ def _cmd_cloud_toggle(enable: bool) -> int:
     return 0
 
 
+def _cmd_compliance(args) -> None:
+    """``clawmetry compliance bundle --framework <id> --from --to --out``.
+
+    Fetches an auditor-ready evidence bundle (zip) from the running local
+    dashboard's Compliance Pack endpoint. The engine lives in clawmetry-pro;
+    vanilla OSS answers HTTP 402 and we explain the upgrade path.
+    """
+    import urllib.error
+    import urllib.parse
+    import urllib.request
+
+    verb = getattr(args, "compliance_cmd", None)
+    if verb != "bundle":
+        print("Usage: clawmetry compliance bundle "
+              "[--framework nist-ai-rmf|soc2-cc] [--from DATE] [--to DATE] "
+              "[--out FILE] [--port PORT]")
+        sys.exit(2)
+    port = getattr(args, "port", None) or 8900
+    query = {"framework": getattr(args, "framework", None) or "nist-ai-rmf"}
+    if getattr(args, "date_from", None):
+        query["from"] = args.date_from
+    if getattr(args, "date_to", None):
+        query["to"] = args.date_to
+    url = (f"http://127.0.0.1:{port}/api/compliance/bundle?"
+           + urllib.parse.urlencode(query))
+    req = urllib.request.Request(url, method="POST")
+    try:
+        resp = urllib.request.urlopen(req, timeout=120)
+    except urllib.error.HTTPError as e:
+        if e.code == 402:
+            print("❌  The Compliance Pack is a paid feature (Enterprise).")
+            print("    Install clawmetry-pro with a license key, or see "
+                  "clawmetry.com/pricing.")
+        elif e.code == 404:
+            print(f"❌  Unknown framework {query['framework']!r} (or the "
+                  "dashboard predates the Compliance Pack — update it).")
+        else:
+            print(f"❌  Bundle request failed: HTTP {e.code}")
+        sys.exit(1)
+    except (urllib.error.URLError, OSError):
+        print(f"❌  No dashboard at http://127.0.0.1:{port} — start it with "
+              "`clawmetry` first (or pass --port).")
+        sys.exit(1)
+    blob = resp.read()
+    out = getattr(args, "out", None)
+    if not out:
+        frm = (query.get("from") or "start")[:10]
+        to = (query.get("to") or "now")[:10]
+        out = f"clawmetry-compliance_{query['framework']}_{frm}_{to}.zip"
+    with open(out, "wb") as fh:
+        fh.write(blob)
+    sha = resp.headers.get("X-Clawmetry-Bundle-Sha256", "")
+    n_controls = resp.headers.get("X-Clawmetry-Bundle-Controls", "?")
+    print(f"✅  Wrote {out} ({len(blob):,} bytes, {n_controls} controls)")
+    if sha:
+        print(f"    sha256: {sha}")
+    print("    Contents: manifest, integrity proof, controls.json, "
+          "approvals.csv, violations.csv, audit_log.csv, attestation.md")
+
+
 def _cmd_export(args) -> None:
     """``clawmetry export --from <date> --to <date> --format jsonl|csv``.
 
@@ -6858,6 +6918,55 @@ def main() -> None:
         help="Write to FILE instead of stdout",
     )
 
+    p_compliance = sub.add_parser(
+        "compliance",
+        help=(
+            "Compliance Pack — generate an auditor-ready evidence bundle "
+            "from the running dashboard (Enterprise)"
+        ),
+    )
+    comp_sub = p_compliance.add_subparsers(dest="compliance_cmd")
+    p_comp_bundle = comp_sub.add_parser(
+        "bundle",
+        help="Build and download the evidence bundle zip",
+    )
+    p_comp_bundle.add_argument(
+        "--framework",
+        dest="framework",
+        default="nist-ai-rmf",
+        metavar="ID",
+        help="Control map to evaluate (default: nist-ai-rmf; also: soc2-cc)",
+    )
+    p_comp_bundle.add_argument(
+        "--from",
+        dest="date_from",
+        default=None,
+        metavar="DATE",
+        help="Start of reporting period (ISO date; default: 30 days ago)",
+    )
+    p_comp_bundle.add_argument(
+        "--to",
+        dest="date_to",
+        default=None,
+        metavar="DATE",
+        help="End of reporting period (ISO date; default: now)",
+    )
+    p_comp_bundle.add_argument(
+        "--out",
+        dest="out",
+        default=None,
+        metavar="FILE",
+        help="Write the zip to FILE (default: derived name in cwd)",
+    )
+    p_comp_bundle.add_argument(
+        "--port",
+        dest="port",
+        type=int,
+        default=None,
+        metavar="PORT",
+        help="Local dashboard port (default: 8900)",
+    )
+
     # Parse just the first token to decide if it's a sub-command or dashboard flag
     # `hooks` is absent from this tuple ON PURPOSE: it's intercepted by the
     # fast path at the top of main() before the dashboard import. The parser
@@ -6897,6 +7006,7 @@ def main() -> None:
         "doctor",
         "verify-integrity",
         "export",
+        "compliance",
         "nemoclaw-daemons",
     )
     if len(sys.argv) > 1 and sys.argv[1] in _subcmds:
@@ -6960,6 +7070,8 @@ def main() -> None:
             _cmd_verify_integrity(args)
         elif args.cmd == "export":
             _cmd_export(args)
+        elif args.cmd == "compliance":
+            _cmd_compliance(args)
         elif args.cmd == "nemoclaw-daemons":
             _register_nemoclaw_sandbox_daemons()
     else:

--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -5928,7 +5928,7 @@ def _cmd_compliance(args) -> None:
         resp = urllib.request.urlopen(req, timeout=120)
     except urllib.error.HTTPError as e:
         if e.code == 402:
-            print("❌  The Compliance Pack is a paid feature (Enterprise).")
+            print("❌  The Compliance Pack is a paid feature (Pro and up).")
             print("    Install clawmetry-pro with a license key, or see "
                   "clawmetry.com/pricing.")
         elif e.code == 404:
@@ -6922,7 +6922,7 @@ def main() -> None:
         "compliance",
         help=(
             "Compliance Pack — generate an auditor-ready evidence bundle "
-            "from the running dashboard (Enterprise)"
+            "from the running dashboard (Pro)"
         ),
     )
     comp_sub = p_compliance.add_subparsers(dest="compliance_cmd")

--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -315,6 +315,7 @@ PRO_ONLY_FEATURES = frozenset(
         "alert_webhooks",
         "anomaly_detection",
         "cost_optimizer",
+        "compliance_pack",
     }
 )
 
@@ -328,7 +329,6 @@ ENTERPRISE_FEATURES = frozenset(
         "rbac",
         "air_gapped_license",
         "custom_data_residency",
-        "compliance_pack",
     }
 )
 

--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -261,6 +261,7 @@ FEATURE_LABELS = {
     "rbac": "RBAC",
     "air_gapped_license": "Air-gapped license",
     "custom_data_residency": "Custom data residency",
+    "compliance_pack": "Compliance pack",
 }
 
 _ALIAS_FEATURES = frozenset(
@@ -327,6 +328,7 @@ ENTERPRISE_FEATURES = frozenset(
         "rbac",
         "air_gapped_license",
         "custom_data_residency",
+        "compliance_pack",
     }
 )
 

--- a/dashboard.py
+++ b/dashboard.py
@@ -110,6 +110,7 @@ from routes.components import bp_components
 from routes.fleet_history import bp_fleet
 from routes.infra import bp_logs, bp_memory, bp_security, bp_config
 from routes.meta import bp_auth, bp_cloud_relay, bp_gateway, bp_otel, bp_otlp_traces, bp_version, bp_version_impact
+from routes.compliance import bp_compliance
 from routes.nemoclaw import bp_nemoclaw
 from routes.skills import bp_skills
 from routes.heartbeat import bp_heartbeat
@@ -11744,6 +11745,7 @@ def detect_config(args=None):
     # the OSS stub registers and returns HTTP 402 ``upgrade_required``.
     if not _pro_loaded:
         app.register_blueprint(bp_nemoclaw)
+        app.register_blueprint(bp_compliance)
     app.register_blueprint(bp_skills)
     app.register_blueprint(bp_heartbeat)
     app.register_blueprint(bp_selfconfig)

--- a/routes/compliance.py
+++ b/routes/compliance.py
@@ -1,0 +1,40 @@
+"""routes/compliance.py: OSS stub after the impl lives in clawmetry-pro.
+
+The real Compliance Pack (control-map engine + auditor-ready evidence
+bundles, NIST AI RMF / SOC 2) ships in the closed-source ``clawmetry-pro``
+package as ``clawmetry_pro/routes/compliance.py``. When that package is
+installed its blueprint registers via ``clawmetry_pro.register_all()`` at
+app startup and wins the URL routes.
+
+When clawmetry-pro is NOT installed (vanilla OSS), this stub registers in
+its place and returns HTTP 402 ``upgrade_required`` on every compliance
+endpoint. Mirrors the precedent set by ``routes/nemoclaw.py`` and the other
+OSS 402-stubs. Blueprint name + URL rules match the real impl exactly so
+the swap is transparent.
+"""
+from __future__ import annotations
+
+from flask import Blueprint, jsonify
+
+from clawmetry._paywall import upgrade_required_body
+
+bp_compliance = Blueprint("compliance", __name__)
+
+
+def _upgrade():
+    return jsonify(upgrade_required_body("compliance_pack")), 402
+
+
+@bp_compliance.route('/api/compliance/frameworks')
+def api_compliance_frameworks():
+    return _upgrade()
+
+
+@bp_compliance.route('/api/compliance/controls')
+def api_compliance_controls():
+    return _upgrade()
+
+
+@bp_compliance.route('/api/compliance/bundle', methods=['POST'])
+def api_compliance_bundle():
+    return _upgrade()

--- a/tests/test_entitlements_catalogue.py
+++ b/tests/test_entitlements_catalogue.py
@@ -70,6 +70,13 @@ def test_enterprise_features_match_pricing(ent):
     assert ent.ENTERPRISE_FEATURES == expected
 
 
+def test_compliance_pack_is_pro_and_enterprise(ent):
+    """Compliance Pack ships in Pro AND Enterprise (decision 2026-07-31)."""
+    assert "compliance_pack" in ent.PRO_ONLY_FEATURES
+    assert "compliance_pack" not in ent.ENTERPRISE_FEATURES
+    assert "compliance_pack" in ent.PAID_FEATURES
+
+
 def test_paid_features_is_starter_plus_pro_only(ent):
     assert ent.PAID_FEATURES == ent.STARTER_FEATURES | ent.PRO_ONLY_FEATURES
 


### PR DESCRIPTION
## What

OSS half of the Compliance Pack (auditor-ready agent evidence bundles, NIST AI RMF / SOC 2). The engine + control maps + real routes live in clawmetry-pro (#111 there); this PR adds the open-core seam:

- **`routes/compliance.py`** — 402 `upgrade_required` stub for `GET /api/compliance/frameworks`, `GET /api/compliance/controls`, `POST /api/compliance/bundle` (same blueprint name + URLs as the pro impl; nemoclaw stub pattern, registered only when `clawmetry_pro.is_loaded()` is false).
- **`clawmetry/entitlements.py`** — `compliance_pack` added to `ENTERPRISE_FEATURES` + `FEATURE_LABELS` (gate blocks unknown keys in enforce mode, so this must land before/with the pro wheel).
- **`clawmetry/cli.py`** — `clawmetry compliance bundle --framework nist-ai-rmf --from --to --out`: downloads the evidence zip from the running local dashboard; explains the upgrade path on 402.
- **`dashboard.py`** — import + conditional stub registration.

## Verification (local)

- `tests/test_blueprint_uniqueness.py`, `test_entitlements_feature_catalog.py`, `test_no_direct_get_store_in_routes.py`: 25 passed.
- Vanilla OSS: all three endpoints return 402 `{error: upgrade_required, feature: compliance_pack}`.
- With the pro package mounted: frameworks/controls/bundle return 200; bundle is a valid zip (manifest + integrity proof + controls.json + approvals/violations/audit CSVs + attestation.md); unknown framework → 404.
- CLI parses and fails gracefully when no dashboard is running.
- Engine unit tests (pro repo): 6 passed.

No new dependencies in OSS. No behavior change for existing users (stub only adds 402 endpoints).

🤖 Generated with [Claude Code](https://claude.com/claude-code)