### PR TITLE
feat(license): license_subject_at_batch + /api/license/subject-at-batch

### DIFF
--- a/clawmetry/license.py
+++ b/clawmetry/license.py
@@ -4238,6 +4238,94 @@ def license_features_at_batch(epochs) -> list[dict]:
     return out
 
 
+def license_subject_at_batch(epochs) -> list[dict]:
+    """Per-value perspective-epoch license-subject scalar for N epochs in
+    ONE round-trip.
+
+    Per-value axis batch sibling of :func:`license_subject_at`. Fills the
+    ``_at_batch`` slot on the license-subject axis alongside the singular
+    :func:`license_subject_at` and the "now" flavour
+    :func:`license_subject`, so a scheduled-audit tile that wants to
+    render a per-epoch "who was this node licensed to on each of these
+    audit dates?" timeline stops fanning out N calls to
+    :func:`license_subject_at`. Matches the batch shape already established
+    by :func:`license_tier_at_batch` / :func:`license_state_at_batch` /
+    :func:`license_features_at_batch` on the other perspective-epoch
+    scalar axes.
+
+    Each item in ``epochs`` may be:
+
+      * an int (or int-parseable string) -- a perspective epoch. The
+        emitted row's ``subject`` is what :func:`license_subject_at` would
+        return for that epoch alone.
+      * ``bool`` (subclass of ``int``) or any non-int-parseable value
+        (``None``, empty string, non-numeric string) -- collapses to a
+        row with ``subject=None``, matching the never-mis-gate posture
+        :func:`license_subject_at` uses for the same inputs. The raw
+        stringified token surfaces in ``epoch`` so a caller can still
+        identify the offending entry.
+
+    Row shape::
+
+        {
+          "epoch":   <int> | "<raw>",
+          "subject": <str> | None,
+        }
+
+    Semantics per row mirror :func:`license_subject_at`: the stripped
+    subject string (casing preserved) when the license is signature-
+    valid, carries a string ``sub`` claim, AND (perpetual OR
+    ``exp > epoch``); ``None`` for no license, invalid signature, an
+    ``exp`` claim that has already lapsed at ``epoch``, a signed payload
+    with a missing / non-string / empty ``sub``, and ``bool`` /
+    non-numeric epochs.
+
+    Duplicates by normalised int key (or ``repr(raw)`` for bad inputs)
+    are dropped preserving first-seen order for byte-stable output.
+    ``epochs is None`` or non-iterable -- returns ``[]``. Never raises:
+    per-row failures short-circuit to ``subject=None`` so the batch
+    keeps building. Matches the never-mis-gate posture used by
+    :func:`license_subject_at` -- a bad row cannot silently claim a
+    subject that would grant unearned entitlement.
+
+    When any row's ``epoch`` equals "now", the row's ``subject`` field
+    must byte-equal :func:`license_subject` for the same install --
+    both derive from the same signed ``sub`` claim via
+    :func:`license_subject_at` / :func:`license_subject`, so a caller
+    binding both cannot catch them disagreeing at the boundary.
+
+    Pairs with :func:`license_tier_at_batch` /
+    :func:`license_state_at_batch` / :func:`license_features_at_batch`
+    on the row-shape axis: for the same ``epochs`` list, a caller can
+    zip the responses index-for-index and hydrate a whole entitlement
+    timeline row for one install in a handful of round-trips instead
+    of ``N * M`` calls to the scalar surface.
+    """
+    out: list[dict] = []
+    for raw, _key, parsed in _license_epoch_batch_keys(epochs):
+        if parsed is None:
+            try:
+                token = str(raw)
+            except Exception:
+                token = repr(raw)
+            out.append({"epoch": token, "subject": None})
+            continue
+        try:
+            subject = license_subject_at(parsed)
+        except Exception as exc:
+            logger.debug(
+                "license: license_subject_at_batch per-row failed: %s", exc
+            )
+            subject = None
+        if subject is not None and not isinstance(subject, str):
+            # Defensive: the scalar contract is str | None, but a future
+            # change that ever emitted a non-string would silently break
+            # the per-row parity guarantee. Collapse to None.
+            subject = None
+        out.append({"epoch": parsed, "subject": subject})
+    return out
+
+
 def has_feature(feature: str) -> bool:
     """Boolean gate for "is feature ``<X>`` claimed by my installed key?".
 

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -13024,6 +13024,90 @@ def api_license_has_feature_at():
         }
     )
 
+@bp_entitlement.route("/api/license/subject-at-batch")
+def api_license_subject_at_batch():
+    """``GET /api/license/subject-at-batch?epochs=<int>,<int>,...`` --
+    per-value batch sibling of ``/api/license/subject-at``.
+
+    Where the singular endpoint folds ONE perspective epoch to ONE
+    ``subject`` answer, this preserves per-value rows so a scheduled-
+    audit tile that wants to plot the ``sub`` claim across a sequence of
+    dates ("who was this node licensed to on each of these audit
+    dates?") renders off ONE round-trip instead of N calls to
+    ``/api/license/subject-at``. Wraps
+    :func:`clawmetry.license.license_subject_at_batch`. Same row-shape
+    axis as ``/api/license/tier-at-batch`` /
+    ``/api/license/state-at-batch`` / ``/api/license/features-at-batch``
+    so a caller assembling an audit timeline can zip the responses
+    index-for-index by epoch column.
+
+    ``epochs=`` is required. Missing / blank / only-commas -> ``400
+    missing epochs``. Comma-separated tokens are normalised the way the
+    underlying batch helper normalises them: whitespace-stripped, then
+    handed to :func:`clawmetry.license.license_subject_at_batch`, which
+    dedupes by parsed int key preserving first-seen order and collapses
+    non-int / ``bool`` / ``None`` tokens to a row with ``subject=null``
+    (never-mis-gate posture matching the scalar endpoint). Never 5xxs:
+    a resolver failure returns the empty-rows envelope with the
+    current-time snapshot fields intact.
+
+    Response shape (always HTTP 200)::
+
+        {
+          "kind":  "license_subject_at",
+          "count": <int>,               # len(rows)
+          "rows":  [
+            {"epoch": <int|"<raw>">, "subject": <str|null>},
+            ...
+          ],
+          "subject":     <str|null>,    # current-time subject
+          "expires_at":  <int|null>,    # on-disk exp for comparison
+          "has_license": <bool>,
+          "valid":       <bool>         # signature-valid AND not expired NOW
+        }
+
+    Per-row parity with ``/api/license/subject-at?epoch=<n>`` is pinned
+    in the test suite so the batch cannot silently drift from the scalar
+    endpoint. Shares :func:`_license_subject_at_snapshot` with the
+    scalar endpoint so the current-time reference fields (``subject`` /
+    ``expires_at`` / ``has_license`` / ``valid``) cannot disagree
+    between the two for the same install.
+    """
+    tokens, err = _parse_license_epochs_csv("epochs")
+    if err == "missing":
+        return jsonify({"error": "missing epochs"}), 400
+    try:
+        snap = _license_subject_at_snapshot()
+    except Exception as exc:
+        logger.warning(
+            "api_license_subject_at_batch: snapshot error: %s", exc
+        )
+        snap = {
+            "subject": None,
+            "expires_at": None,
+            "has_license": False,
+            "valid": False,
+        }
+    try:
+        from clawmetry import license as _lic
+
+        rows = _lic.license_subject_at_batch(tokens)
+    except Exception as exc:
+        logger.warning(
+            "api_license_subject_at_batch: derive error: %s", exc
+        )
+        rows = []
+    return jsonify(
+        {
+            "kind": "license_subject_at",
+            "count": len(rows),
+            "rows": rows,
+            "subject": snap["subject"],
+            "expires_at": snap["expires_at"],
+            "has_license": snap["has_license"],
+            "valid": snap["valid"],
+        }
+    )
 
 @bp_entitlement.route("/api/paywall/event", methods=["POST"])
 def api_paywall_event():

--- a/tests/test_license_subject_at_batch.py
+++ b/tests/test_license_subject_at_batch.py
@@ -1,0 +1,645 @@
+"""Tests for the ``clawmetry.license.license_subject_at_batch`` helper
+and its paired ``/api/license/subject-at-batch`` HTTP endpoint.
+
+Per-value batch flavour of :func:`clawmetry.license.license_subject_at`
+-- fills the ``_at_batch`` slot on the license-subject axis so a
+scheduled-audit tile that wants to plot the ``sub`` claim across a
+sequence of perspective dates hydrates the whole column in ONE
+round-trip instead of fanning out N calls to ``/api/license/subject-at``.
+Per-row parity with the singular scalar (both Python-level and
+HTTP-level) is pinned so the batch cannot silently drift from the
+scalar endpoint.
+
+Hermetic: each test mints tokens with its own ephemeral keypair and
+monkeypatches the module's embedded public key + ``LICENSE_PATH``,
+mirroring ``tests/test_license_subject_at.py`` /
+``tests/test_license_state_at_batch.py`` so nothing depends on the real
+production signing key or on real filesystem state.
+"""
+from __future__ import annotations
+
+import time
+from types import SimpleNamespace
+
+import pytest
+from flask import Flask
+
+
+# -- shared helpers (mirror tests/test_license_subject_at.py) ----------------
+
+
+def _keypair():
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+    priv = Ed25519PrivateKey.generate()
+    pub_pem = priv.public_key().public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    return priv, pub_pem
+
+
+def _payload(
+    sub="acct_test",
+    tier="pro",
+    nodes=3,
+    exp_delta=365 * 86400,
+    drop_exp=False,
+    drop_sub=False,
+):
+    now = int(time.time())
+    p = {
+        "sub": sub,
+        "tier": tier,
+        "nodes": nodes,
+        "iat": now,
+        "exp": now + exp_delta,
+        "features": ["runtimes"],
+    }
+    if drop_exp:
+        p.pop("exp", None)
+    if drop_sub:
+        p.pop("sub", None)
+    return p
+
+
+@pytest.fixture
+def app(monkeypatch, tmp_path):
+    import clawmetry.license as _lic
+
+    priv, pub_pem = _keypair()
+    monkeypatch.setattr(_lic, "_PUBLIC_KEY_PEM", pub_pem)
+    license_path = str(tmp_path / "license.key")
+    monkeypatch.setattr(_lic, "LICENSE_PATH", license_path)
+    monkeypatch.delenv("CLAWMETRY_LICENSE_SERVER", raising=False)
+    monkeypatch.delenv("CLAWMETRY_INGEST_URL", raising=False)
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("CLAWMETRY_OFFLINE", "1")
+
+    from routes.entitlement import bp_entitlement
+
+    flask_app = Flask(__name__)
+    flask_app.register_blueprint(bp_entitlement)
+    flask_app.config["TESTING"] = True
+
+    return SimpleNamespace(
+        app=flask_app,
+        lic=_lic,
+        priv=priv,
+        license_path=license_path,
+    )
+
+
+def _write_key_direct(app, exp_delta, sub="acct_test", drop_sub=False):
+    """Bypass activate() (which refuses expired tokens) and write a token
+    directly to the license file. Simulates a license that expired AFTER
+    it was installed."""
+    import os
+
+    tok = app.lic._encode_token(
+        _payload(sub=sub, exp_delta=exp_delta, drop_sub=drop_sub), app.priv
+    )
+    os.makedirs(os.path.dirname(app.license_path), exist_ok=True)
+    with open(app.license_path, "w", encoding="utf-8") as fh:
+        fh.write(tok)
+
+
+def _write_perpetual(app, sub="acct_test"):
+    import os
+
+    tok = app.lic._encode_token(_payload(sub=sub, drop_exp=True), app.priv)
+    os.makedirs(os.path.dirname(app.license_path), exist_ok=True)
+    with open(app.license_path, "w", encoding="utf-8") as fh:
+        fh.write(tok)
+
+
+def _write_bogus(app):
+    import os
+
+    os.makedirs(os.path.dirname(app.license_path), exist_ok=True)
+    with open(app.license_path, "w", encoding="utf-8") as fh:
+        fh.write("CLAW1.garbage.garbage")
+
+
+# -- clawmetry.license.license_subject_at_batch() ----------------------------
+
+
+def test_license_subject_at_batch_none_returns_empty(app):
+    """``epochs is None`` -> ``[]``. Mirrors the never-raise posture of
+    the sibling ``_at_batch`` helpers."""
+    assert app.lic.license_subject_at_batch(None) == []
+
+
+def test_license_subject_at_batch_non_iterable_returns_empty(app):
+    """Non-iterable ``epochs`` (an int -- probable typo for a caller
+    that forgot to wrap it) -> ``[]`` rather than a crash."""
+    assert app.lic.license_subject_at_batch(42) == []
+
+
+def test_license_subject_at_batch_empty_returns_empty(app):
+    """Empty iterable -> ``[]``."""
+    assert app.lic.license_subject_at_batch([]) == []
+    assert app.lic.license_subject_at_batch(()) == []
+
+
+def test_license_subject_at_batch_no_license(app):
+    """No license file on disk -> every row ``subject=None`` regardless
+    of epoch. Time-independent, matches the scalar."""
+    rows = app.lic.license_subject_at_batch(
+        [0, int(time.time()), 2_000_000_000]
+    )
+    assert [r["subject"] for r in rows] == [None, None, None]
+    assert [r["epoch"] for r in rows] == [0, int(time.time()), 2_000_000_000]
+
+
+def test_license_subject_at_batch_active_key_mixed_epochs(app):
+    """Active key: perspectives before ``exp`` -> subject string;
+    perspectives at/after ``exp`` -> ``None`` (retrospective view of the
+    lapsed side). The batch preserves per-row ordering."""
+    tok = app.lic._encode_token(
+        _payload(sub="acct_active", exp_delta=30 * 86400), app.priv
+    )
+    app.lic.activate(tok)
+    now = int(time.time())
+    epochs = [now, now + 10 * 86400, now + 60 * 86400, now + 90 * 86400]
+    rows = app.lic.license_subject_at_batch(epochs)
+    assert [r["subject"] for r in rows] == [
+        "acct_active",
+        "acct_active",
+        None,
+        None,
+    ]
+    assert [r["epoch"] for r in rows] == epochs
+
+
+def test_license_subject_at_batch_per_row_parity_with_scalar(app):
+    """Per-row parity with :func:`license_subject_at` -- the batch
+    cannot silently drift from the scalar. Pin every row against the
+    singular helper on the same install."""
+    tok = app.lic._encode_token(
+        _payload(sub="acct_parity", exp_delta=30 * 86400), app.priv
+    )
+    app.lic.activate(tok)
+    now = int(time.time())
+    epochs = [
+        now - 10 * 86400,
+        now,
+        now + 5 * 86400,
+        now + 40 * 86400,
+        now + 200 * 86400,
+    ]
+    rows = app.lic.license_subject_at_batch(epochs)
+    for row, epoch in zip(rows, epochs):
+        assert row["subject"] == app.lic.license_subject_at(epoch), epoch
+
+
+def test_license_subject_at_batch_perpetual_key(app):
+    """Perpetual (no ``exp``) key -> every row surfaces the subject
+    regardless of perspective. Mirrors the scalar."""
+    _write_perpetual(app, sub="acct_forever")
+    rows = app.lic.license_subject_at_batch(
+        [0, int(time.time()), 2_000_000_000]
+    )
+    assert [r["subject"] for r in rows] == ["acct_forever"] * 3
+
+
+def test_license_subject_at_batch_invalid_signature(app):
+    """Bogus-signature file -> every row ``None`` (an unsigned body is
+    untrusted whatever the perspective; matches the scalar)."""
+    _write_bogus(app)
+    rows = app.lic.license_subject_at_batch(
+        [0, int(time.time()), 2_000_000_000]
+    )
+    assert [r["subject"] for r in rows] == [None, None, None]
+
+
+def test_license_subject_at_batch_lapsed_key_pre_lapse_epoch(app):
+    """Lapsed-but-signed key at a perspective BEFORE its ``exp`` ->
+    subject string (retrospective "who was this licensed to on <date>");
+    at "now" -> ``None``. Batch flips per row."""
+    _write_key_direct(
+        app, exp_delta=-5 * 86400, sub="acct_lapsed"
+    )  # exp = now - 5d
+    now = int(time.time())
+    rows = app.lic.license_subject_at_batch(
+        [now - 20 * 86400, now - 3 * 86400, now]
+    )
+    assert [r["subject"] for r in rows] == ["acct_lapsed", None, None]
+
+
+def test_license_subject_at_batch_missing_sub_claim(app):
+    """Signed payload with no ``sub`` claim -> every row ``None``
+    (matches the scalar's `sub`-not-a-string branch)."""
+    _write_key_direct(app, exp_delta=30 * 86400, drop_sub=True)
+    now = int(time.time())
+    rows = app.lic.license_subject_at_batch([now, now + 5 * 86400])
+    assert [r["subject"] for r in rows] == [None, None]
+
+
+def test_license_subject_at_batch_dedupes_by_int_key_preserves_order(app):
+    """Duplicates by parsed int key are dropped preserving first-seen
+    order so the response is byte-stable across calls."""
+    tok = app.lic._encode_token(
+        _payload(sub="acct_dedup", exp_delta=30 * 86400), app.priv
+    )
+    app.lic.activate(tok)
+    now = int(time.time())
+    rows = app.lic.license_subject_at_batch(
+        [now, now + 100, now, str(now + 100), now + 200]
+    )
+    assert [r["epoch"] for r in rows] == [now, now + 100, now + 200]
+
+
+def test_license_subject_at_batch_string_int_tokens_parsed(app):
+    """Int-parseable strings coerce cleanly (matches the singular's
+    ``int()`` coercion)."""
+    tok = app.lic._encode_token(
+        _payload(sub="acct_strings", exp_delta=30 * 86400), app.priv
+    )
+    app.lic.activate(tok)
+    now = int(time.time())
+    rows = app.lic.license_subject_at_batch(
+        [str(now), str(now + 60 * 86400)]
+    )
+    assert [r["subject"] for r in rows] == ["acct_strings", None]
+
+
+def test_license_subject_at_batch_bad_tokens_collapse_to_none(app):
+    """``bool`` / non-numeric strings / ``None`` collapse to a
+    ``subject=None`` row. Row still keeps its slot (each bad token gets
+    its own bucket) so output length still matches N."""
+    tok = app.lic._encode_token(
+        _payload(sub="acct_bad", exp_delta=30 * 86400), app.priv
+    )
+    app.lic.activate(tok)
+    rows = app.lic.license_subject_at_batch(
+        [True, False, None, "garbage", ""]
+    )
+    assert len(rows) == 5
+    assert all(r["subject"] is None for r in rows)
+
+
+def test_license_subject_at_batch_mixed_good_and_bad(app):
+    """Bad tokens don't fail the whole batch. Good rows still resolve;
+    bad rows still slot in with ``subject=None``."""
+    tok = app.lic._encode_token(
+        _payload(sub="acct_mixed", exp_delta=30 * 86400), app.priv
+    )
+    app.lic.activate(tok)
+    now = int(time.time())
+    rows = app.lic.license_subject_at_batch(
+        [now, "garbage", now + 60 * 86400]
+    )
+    assert [r["subject"] for r in rows] == ["acct_mixed", None, None]
+
+
+def test_license_subject_at_batch_bad_tokens_stringified_in_epoch(app):
+    """Bad tokens surface as their stringified form in ``epoch`` so a
+    caller can identify the offending entry in the response."""
+    tok = app.lic._encode_token(
+        _payload(sub="acct_x", exp_delta=30 * 86400), app.priv
+    )
+    app.lic.activate(tok)
+    rows = app.lic.license_subject_at_batch(["garbage", None])
+    assert rows[0]["epoch"] == "garbage"
+    # ``None`` stringifies to "None" via ``str(None)``.
+    assert rows[1]["epoch"] == "None"
+
+
+def test_license_subject_at_batch_now_row_matches_current_subject(app):
+    """When any row's ``epoch`` equals "now", its ``subject`` field
+    must byte-equal :func:`license_subject` -- both derive from the
+    same signed ``sub`` claim, refuse the invalid-signature branch,
+    and use the same ``exp <= cutoff`` boundary."""
+    tok = app.lic._encode_token(
+        _payload(sub="acct_now_ref", exp_delta=30 * 86400), app.priv
+    )
+    app.lic.activate(tok)
+    now = int(time.time())
+    rows = app.lic.license_subject_at_batch([now])
+    assert rows[0]["subject"] == app.lic.license_subject()
+
+
+def test_license_subject_at_batch_never_raises(monkeypatch):
+    """Any per-row underlying failure of :func:`license_subject_at` ->
+    ``subject=None`` for THAT row. The batch never propagates."""
+    import clawmetry.license as _lic
+
+    def _boom(_epoch):
+        raise RuntimeError("simulated corrupt install")
+
+    monkeypatch.setattr(_lic, "license_subject_at", _boom)
+    rows = _lic.license_subject_at_batch([1_700_000_000, 1_800_000_000])
+    assert [r["subject"] for r in rows] == [None, None]
+    assert len(rows) == 2
+
+
+def test_license_subject_at_batch_bool_rejected_as_bad_input(app):
+    """``bool`` -- an ``int`` subclass -- is explicitly refused so a
+    caller who passes ``True`` / ``False`` doesn't silently get a
+    "was subject X at epoch 1?" classification. Matches
+    :func:`license_subject_at`."""
+    tok = app.lic._encode_token(
+        _payload(sub="acct_bool", exp_delta=30 * 86400), app.priv
+    )
+    app.lic.activate(tok)
+    rows = app.lic.license_subject_at_batch([True, False])
+    assert [r["subject"] for r in rows] == [None, None]
+    # Rows still slot in -- each bad token gets its own bucket.
+    assert len(rows) == 2
+
+
+def test_license_subject_at_batch_generator_input(app):
+    """Batch admits any iterable, not just ``list`` / ``tuple``.
+    Generator input works the same way."""
+    tok = app.lic._encode_token(
+        _payload(sub="acct_gen", exp_delta=30 * 86400), app.priv
+    )
+    app.lic.activate(tok)
+    now = int(time.time())
+
+    def _gen():
+        yield now
+        yield now + 60 * 86400
+
+    rows = app.lic.license_subject_at_batch(_gen())
+    assert [r["subject"] for r in rows] == ["acct_gen", None]
+
+
+# -- GET /api/license/subject-at-batch ---------------------------------------
+
+
+def test_endpoint_subject_at_batch_missing_epochs(app):
+    """``?epochs=`` absent -> 400 missing epochs (matches the sibling
+    ``/api/license/*-at-batch`` endpoints -- missing input is a real
+    error, unlike bad input)."""
+    with app.app.test_client() as c:
+        resp = c.get("/api/license/subject-at-batch")
+    assert resp.status_code == 400
+    data = resp.get_json()
+    assert data == {"error": "missing epochs"}
+
+
+def test_endpoint_subject_at_batch_blank_epochs(app):
+    """``?epochs=`` blank / only-commas -> 400 missing epochs."""
+    with app.app.test_client() as c:
+        resp = c.get("/api/license/subject-at-batch?epochs=")
+        resp2 = c.get("/api/license/subject-at-batch?epochs=,,,")
+    assert resp.status_code == 400
+    assert resp2.status_code == 400
+
+
+def test_endpoint_subject_at_batch_no_license(app):
+    """No license file -> every row ``subject=null``, HTTP 200,
+    current-time snapshot fields set to the OSS-free branch shape."""
+    now = int(time.time())
+    with app.app.test_client() as c:
+        resp = c.get(f"/api/license/subject-at-batch?epochs={now},0")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["kind"] == "license_subject_at"
+    assert data["count"] == 2
+    assert [r["subject"] for r in data["rows"]] == [None, None]
+    assert data["subject"] is None
+    assert data["expires_at"] is None
+    assert data["has_license"] is False
+    assert data["valid"] is False
+
+
+def test_endpoint_subject_at_batch_active_key_mixed_epochs(app):
+    """Active key at mixed perspectives -> per-row subjects match the
+    scalar. Snapshot reflects current install state."""
+    tok = app.lic._encode_token(
+        _payload(sub="acct_endpoint", exp_delta=30 * 86400), app.priv
+    )
+    app.lic.activate(tok)
+    now = int(time.time())
+    epochs = [now, now + 60 * 86400]
+    with app.app.test_client() as c:
+        resp = c.get(
+            f"/api/license/subject-at-batch?epochs={epochs[0]},{epochs[1]}"
+        )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["count"] == 2
+    assert [r["subject"] for r in data["rows"]] == ["acct_endpoint", None]
+    assert data["subject"] == "acct_endpoint"
+    assert data["has_license"] is True
+    assert data["valid"] is True
+    assert isinstance(data["expires_at"], int)
+
+
+def test_endpoint_subject_at_batch_per_row_parity_with_scalar_endpoint(app):
+    """Per-row parity with the singular
+    ``/api/license/subject-at?epoch=<n>`` endpoint -- the batch cannot
+    silently drift from the scalar endpoint. Pin every row."""
+    tok = app.lic._encode_token(
+        _payload(sub="acct_scalar_parity", exp_delta=45 * 86400), app.priv
+    )
+    app.lic.activate(tok)
+    now = int(time.time())
+    epochs = [now - 5 * 86400, now, now + 30 * 86400, now + 60 * 86400]
+    csv = ",".join(str(e) for e in epochs)
+    with app.app.test_client() as c:
+        batch = c.get(
+            f"/api/license/subject-at-batch?epochs={csv}"
+        ).get_json()
+        for row, epoch in zip(batch["rows"], epochs):
+            scalar = c.get(
+                f"/api/license/subject-at?epoch={epoch}"
+            ).get_json()
+            assert row["subject"] == scalar["subject_at"], epoch
+
+
+def test_endpoint_subject_at_batch_shared_snapshot_agrees_with_scalar(app):
+    """Batch envelope's current-time reference fields (``subject`` /
+    ``expires_at`` / ``has_license`` / ``valid``) share
+    :func:`_license_subject_at_snapshot` with the scalar endpoint --
+    a UI binding both cannot catch them disagreeing on the current-time
+    reference for the same install."""
+    tok = app.lic._encode_token(
+        _payload(sub="acct_shared", exp_delta=30 * 86400), app.priv
+    )
+    app.lic.activate(tok)
+    now = int(time.time())
+    with app.app.test_client() as c:
+        batch = c.get(
+            f"/api/license/subject-at-batch?epochs={now}"
+        ).get_json()
+        scalar = c.get(
+            f"/api/license/subject-at?epoch={now}"
+        ).get_json()
+    for key in ("subject", "expires_at", "has_license", "valid"):
+        assert batch[key] == scalar[key], key
+
+
+def test_endpoint_subject_at_batch_bad_tokens_do_not_400(app):
+    """Bad tokens don't fail the whole batch -- they slot in with
+    ``subject=null``. The 400 is reserved for ``?epochs=`` entirely
+    missing / blank."""
+    tok = app.lic._encode_token(
+        _payload(sub="acct_badtok", exp_delta=30 * 86400), app.priv
+    )
+    app.lic.activate(tok)
+    now = int(time.time())
+    with app.app.test_client() as c:
+        resp = c.get(
+            f"/api/license/subject-at-batch?epochs={now},garbage,true,"
+            f"{now + 60 * 86400}"
+        )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["count"] == 4
+    assert [r["subject"] for r in data["rows"]] == [
+        "acct_badtok",
+        None,
+        None,
+        None,
+    ]
+
+
+def test_endpoint_subject_at_batch_dedupe_preserves_order(app):
+    """Duplicates by parsed int key are dropped preserving first-seen
+    order for byte-stable output."""
+    tok = app.lic._encode_token(
+        _payload(sub="acct_order", exp_delta=30 * 86400), app.priv
+    )
+    app.lic.activate(tok)
+    now = int(time.time())
+    with app.app.test_client() as c:
+        resp = c.get(
+            f"/api/license/subject-at-batch?epochs={now},{now + 100},"
+            f"{now},{now + 100}"
+        )
+    data = resp.get_json()
+    assert data["count"] == 2
+    assert [r["epoch"] for r in data["rows"]] == [now, now + 100]
+
+
+def test_endpoint_subject_at_batch_perpetual_key(app):
+    """Perpetual key -> every row surfaces the subject regardless of
+    perspective. Snapshot reports ``has_license=True`` +
+    ``expires_at=None``."""
+    _write_perpetual(app, sub="acct_perp")
+    now = int(time.time())
+    with app.app.test_client() as c:
+        resp = c.get(
+            f"/api/license/subject-at-batch?epochs=0,{now},2000000000"
+        )
+    data = resp.get_json()
+    assert data["count"] == 3
+    assert [r["subject"] for r in data["rows"]] == ["acct_perp"] * 3
+    assert data["has_license"] is True
+    assert data["expires_at"] is None
+    assert data["subject"] == "acct_perp"
+
+
+def test_endpoint_subject_at_batch_bogus_signature_all_none(app):
+    """Bogus-signature file -> every row ``subject=null``. Envelope
+    snapshot reports ``valid=False`` / ``subject=None`` (matches the
+    scalar endpoint on the same install)."""
+    _write_bogus(app)
+    now = int(time.time())
+    with app.app.test_client() as c:
+        resp = c.get(f"/api/license/subject-at-batch?epochs={now},0")
+    data = resp.get_json()
+    assert data["count"] == 2
+    assert [r["subject"] for r in data["rows"]] == [None, None]
+    assert data["valid"] is False
+    assert data["subject"] is None
+
+
+def test_endpoint_subject_at_batch_never_5xxs_snapshot_blowup(app, monkeypatch):
+    """Even if the shared snapshot blows up mid-request, the endpoint
+    still returns HTTP 200 with the OSS-free snapshot fallback + honest
+    per-row derivation."""
+    from routes import entitlement as _routes
+
+    monkeypatch.setattr(
+        _routes,
+        "_license_subject_at_snapshot",
+        lambda: (_ for _ in ()).throw(RuntimeError("simulated blowup")),
+    )
+    now = int(time.time())
+    with app.app.test_client() as c:
+        resp = c.get(f"/api/license/subject-at-batch?epochs={now}")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["subject"] is None
+    assert data["has_license"] is False
+    assert data["valid"] is False
+    assert data["expires_at"] is None
+
+
+def test_endpoint_subject_at_batch_never_5xxs_derive_blowup(app, monkeypatch):
+    """Even if :func:`license_subject_at_batch` itself raises mid-
+    request, the endpoint still returns HTTP 200 with an empty rows
+    envelope + intact current-time snapshot."""
+    import clawmetry.license as _lic
+
+    def _boom(_epochs):
+        raise RuntimeError("simulated batch blowup")
+
+    tok = app.lic._encode_token(
+        _payload(sub="acct_5xx", exp_delta=30 * 86400), app.priv
+    )
+    app.lic.activate(tok)
+    monkeypatch.setattr(_lic, "license_subject_at_batch", _boom)
+    now = int(time.time())
+    with app.app.test_client() as c:
+        resp = c.get(f"/api/license/subject-at-batch?epochs={now}")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["count"] == 0
+    assert data["rows"] == []
+    # Snapshot still hydrates because it was read BEFORE the derive
+    # helper was called.
+    assert data["subject"] == "acct_5xx"
+    assert data["has_license"] is True
+    assert data["valid"] is True
+
+
+# -- cross-endpoint consistency ----------------------------------------------
+
+
+def test_endpoint_subject_at_batch_zips_index_for_index_with_tier_at_batch(app):
+    """All ``/api/license/*-at-batch`` endpoints admit the same input
+    schema (``?epochs=`` CSV) and emit the same row ordering, so a
+    caller assembling an audit timeline can zip the responses index-for-
+    index by epoch column. Sibling of the same guarantee held by
+    ``/api/license/state-at-batch`` / ``.../is-expired-at-batch`` /
+    ``.../days-until-expiry-at-batch`` in
+    ``tests/test_license_state_at_batch.py``."""
+    tok = app.lic._encode_token(
+        _payload(sub="acct_zip", exp_delta=30 * 86400), app.priv
+    )
+    app.lic.activate(tok)
+    now = int(time.time())
+    epochs = [now - 10 * 86400, now, now + 5 * 86400, now + 60 * 86400]
+    csv = ",".join(str(e) for e in epochs)
+    with app.app.test_client() as c:
+        subj = c.get(
+            f"/api/license/subject-at-batch?epochs={csv}"
+        ).get_json()
+        tier = c.get(
+            f"/api/license/tier-at-batch?epochs={csv}"
+        ).get_json()
+        state = c.get(
+            f"/api/license/state-at-batch?epochs={csv}"
+        ).get_json()
+    assert subj["count"] == tier["count"] == state["count"] == 4
+    for i, epoch in enumerate(epochs):
+        assert (
+            subj["rows"][i]["epoch"]
+            == tier["rows"][i]["epoch"]
+            == state["rows"][i]["epoch"]
+            == epoch
+        )
+        # A row with a non-null tier at ``epoch`` must also carry a
+        # non-null subject at the same epoch (both derive from the same
+        # signed payload; both refuse the same expired branch).
+        if tier["rows"][i]["tier"] is not None:
+            assert subj["rows"][i]["subject"] is not None, epoch
+        else:
+            assert subj["rows"][i]["subject"] is None, epoch


### PR DESCRIPTION
## Summary

- New `clawmetry.license.license_subject_at_batch(epochs) -> list[dict]` helper: per-value batch flavour of `license_subject_at(epoch)`. Fills the `_at_batch` slot on the license-subject axis alongside the sibling `license_tier_at_batch` / `license_state_at_batch` / `license_features_at_batch` on the other perspective-epoch scalar axes, so a scheduled-audit tile that wants to plot the `sub` claim across a sequence of perspective dates ("who was this node licensed to on each of these audit dates?") hydrates the whole column in ONE round-trip instead of fanning out N calls to `license_subject_at`. Reuses the shared `_license_epoch_batch_keys` pre-parser for byte-stable de-dup + bool/non-numeric rejection matching the surrounding `_at_batch` family; per-row failures short-circuit to `subject=None` so the batch never propagates a raise.

- New `GET /api/license/subject-at-batch?epochs=<int>,<int>,...` endpoint on `bp_entitlement` mirroring the shape of the sibling `/api/license/state-at-batch` / `/api/license/tier-at-batch` / `/api/license/features-at-batch`. Missing / blank / only-commas `?epochs=` returns `400 missing epochs` uniformly with the rest of the trio; every other input returns HTTP 200 (bad-token rows slot in with `subject=null` so a caller can identify the offending entry without the whole batch hidden behind a typo). Shares `_license_subject_at_snapshot` with the scalar `/api/license/subject-at` endpoint so the current-time reference fields (`subject`, `expires_at`, `has_license`, `valid`) cannot disagree between the two for the same install.

- 32 hermetic unit tests (ephemeral keypair per test, isolated `LICENSE_PATH`, `CLAWMETRY_OFFLINE=1`) covering every branch of the scalar and the HTTP endpoint, including per-response parity with the Python helper, per-row parity with `/api/license/subject-at`, envelope parity with the scalar snapshot, generator input, never-5xxs on both snapshot and derive blowups, and a cross-endpoint zip against `/api/license/tier-at-batch` / `/api/license/state-at-batch` on the same epochs list.

Behaviour is additive; nothing existing changes. Grace-mode posture is preserved (no gate enforcement is added; the batch only surfaces what the token's `sub` claim says at each perspective epoch).

## Test plan

- [x] `python3 -m py_compile clawmetry/license.py routes/entitlement.py tests/test_license_subject_at_batch.py` — passes
- [x] `python3 -m pytest tests/test_license_subject_at_batch.py` — 32 passed
- [x] `python3 -m pytest tests/test_license_subject_at.py tests/test_license_state_at_batch.py tests/test_license_tier_at.py tests/test_license_is_tier_at.py` — 187 passed (sibling regressions clean)

## Local operator verification checklist

The web agent cannot touch the live daemon, `~/.openclaw`, the cloud snapshot, or a browser. Please verify on-host before flipping this out of draft:

- [ ] Copy the changed source files (and the new test) into the installed package:
  - `cp clawmetry/license.py ~/.clawmetry/lib/python*/site-packages/clawmetry/license.py`
  - `cp routes/entitlement.py ~/.clawmetry/lib/python*/site-packages/routes/entitlement.py`
  - `find ~/.clawmetry/lib/python*/site-packages/{clawmetry,routes} -name __pycache__ -exec rm -rf {} +`
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` (or the equivalent supervisor kick on non-macOS hosts)
- [ ] `curl -s "http://localhost:8900/api/license/subject-at-batch?epochs=$(date +%s),$(($(date +%s) + 86400))" | jq` — envelope shape matches the docstring; row `subject` fields agree with `/api/license/subject-at?epoch=<n>` at each row.
- [ ] Retrospective / prospective sanity: pick epochs on either side of the installed license `exp` and confirm each row's `subject` flips at the boundary (rows with `epoch < exp` carry the real subject; rows with `epoch >= exp` carry `subject=null`).
- [ ] Bad-token sanity: `curl` with `?epochs=1,garbage,true,2` — 200 OK, four rows, positions 0 and 3 carry the real subject (for a valid install and epochs before exp), positions 1 and 2 carry `subject=null` with their raw token surfaced in `epoch`.
- [ ] Missing-input sanity: `curl` with `?epochs=` (blank) — 400 with `{"error":"missing epochs"}`.
- [ ] Browser check: open the entitlement diagnostics tile and confirm no regression on the current-time subject / features view.
- [ ] Decrypt the live cloud snapshot and confirm the new endpoint is reachable through the relay (should require no relay changes — it is a read-only handler on `bp_entitlement`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01QyG94WBYr8xeGuJDWiAPUw)_