### PR TITLE
fix(gateway): exponential backoff in _gw_ws_connect to stop reconnect storms

### DIFF
--- a/helpers/gateway.py
+++ b/helpers/gateway.py
@@ -1,5 +1,4 @@
-"""
-helpers/gateway.py — OpenClaw gateway WebSocket RPC + HTTP invoke client.
+"""helpers/gateway.py — OpenClaw gateway WebSocket RPC + HTTP invoke client.
 
 Extracted from dashboard.py as Phase 6.5. Owns the persistent WebSocket
 JSON-RPC client used for live gateway queries (sessions.list, cron.list,
@@ -28,9 +27,10 @@ from clawmetry.gateway_protocol import (
 import json
 import subprocess
 import threading
+import time
 
 
-# ── WebSocket RPC Client ────────────────────────────────────────────────
+# ── WebSocket RPC Client ───────────────────────────────────────────────────────
 # Persistent connection state. Shared by all threads that call
 # `_gw_ws_rpc`; the lock serialises send/recv pairs so responses don't
 # get scrambled across concurrent callers.
@@ -38,10 +38,24 @@ _ws_client = None
 _ws_lock = threading.Lock()
 _ws_connected = False
 
+# Backoff state — updated inside _gw_ws_connect(), which is always called
+# under _ws_lock, so no separate lock is needed for these variables.
+_ws_fail_count = 0
+_ws_next_retry_time = 0.0
+# Delays in seconds: 2, 4, 8, 16, 30, 60 (capped at 60).
+_WS_BACKOFF_DELAYS = (2, 4, 8, 16, 30, 60)
+
 
 def _gw_ws_connect(url=None, token=None):
     """Connect to the OpenClaw gateway via WebSocket JSON-RPC."""
-    global _ws_client, _ws_connected
+    global _ws_client, _ws_connected, _ws_fail_count, _ws_next_retry_time
+
+    # Honour exponential backoff — don't hammer a gateway that keeps
+    # rejecting us (issue #4356: v4 gateways reject immediately, producing
+    # bursts of ~5 reconnect attempts per 100ms in the gateway log).
+    if _ws_next_retry_time and time.monotonic() < _ws_next_retry_time:
+        return False
+
     try:
         import websocket
     except ImportError:
@@ -60,6 +74,7 @@ def _gw_ws_connect(url=None, token=None):
     if not ws_url or not tok:
         return False
 
+    _ok = False
     try:
         # timeout=5 applies to the initial TCP/WS handshake; we also set
         # ws.settimeout(5) below so per-message recv() can't hang forever if
@@ -113,14 +128,27 @@ def _gw_ws_connect(url=None, token=None):
                 if r.get("ok"):
                     _ws_client = ws
                     _ws_connected = True
-                    return True
+                    _ok = True
                 else:
                     ws.close()
-                    return False
-        ws.close()
+                break
+        if not _ok:
+            try:
+                ws.close()
+            except Exception:
+                pass
     except Exception:
         pass
-    return False
+
+    if _ok:
+        _ws_fail_count = 0
+        _ws_next_retry_time = 0.0
+    else:
+        _ws_fail_count += 1
+        _ws_next_retry_time = time.monotonic() + _WS_BACKOFF_DELAYS[
+            min(len(_WS_BACKOFF_DELAYS) - 1, _ws_fail_count - 1)
+        ]
+    return _ok
 
 
 def _gw_ws_rpc(method, params=None):

--- a/tests/test_gateway_rpc_backoff.py
+++ b/tests/test_gateway_rpc_backoff.py
@@ -1,0 +1,140 @@
+"""Issue #4356: _gw_ws_connect must back off after gateway rejections.
+
+When the gateway rejects the handshake (e.g. protocol-4 with mismatched
+maxProtocol), the dashboard polled endpoints (/api/sessions, /api/crons)
+each call _gw_ws_connect() on every HTTP request. Without backoff, fast
+concurrent requests produce bursts of reconnect attempts — gateway logs
+fill with warnings at ~5/100ms. This regression guard confirms the
+exponential-backoff gate fires correctly.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, call
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import helpers.gateway as gw  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _reset_gateway_state():
+    """Reset all WS singleton state between tests."""
+    gw._ws_client = None
+    gw._ws_connected = False
+    gw._ws_fail_count = 0
+    gw._ws_next_retry_time = 0.0
+    yield
+    gw._ws_client = None
+    gw._ws_connected = False
+    gw._ws_fail_count = 0
+    gw._ws_next_retry_time = 0.0
+
+
+def _make_fake_dashboard(monkeypatch):
+    fake = MagicMock()
+    fake._load_gw_config.return_value = {
+        "url": "http://127.0.0.1:18789", "token": "test-token"
+    }
+    fake.__version__ = "0.0.0-test"
+    fake._CURRENT_PLATFORM = "test"
+    fake._uuid = __import__("uuid")
+    monkeypatch.setitem(sys.modules, "dashboard", fake)
+    return fake
+
+
+def _ws_rejecting(monkeypatch):
+    """Stub websocket whose connect response is ok=False."""
+    fake_ws = MagicMock()
+    fake_ws.recv.side_effect = [
+        json.dumps({"type": "event", "event": "connect.challenge", "payload": {}}),
+        json.dumps({"type": "res", "id": "clawmetry-connect", "ok": False,
+                    "error": {"message": "protocol-mismatch"}}),
+    ]
+    fake_websocket = MagicMock()
+    fake_websocket.create_connection.return_value = fake_ws
+    monkeypatch.setitem(sys.modules, "websocket", fake_websocket)
+    return fake_websocket, fake_ws
+
+
+def _ws_accepting(monkeypatch):
+    """Stub websocket whose connect response is ok=True."""
+    fake_ws = MagicMock()
+    fake_ws.recv.side_effect = [
+        json.dumps({"type": "event", "event": "connect.challenge", "payload": {}}),
+        json.dumps({"type": "res", "id": "clawmetry-connect", "ok": True,
+                    "payload": {"auth": {"scopes": ["operator.admin", "operator.read"]}}}),
+    ]
+    fake_websocket = MagicMock()
+    fake_websocket.create_connection.return_value = fake_ws
+    monkeypatch.setitem(sys.modules, "websocket", fake_websocket)
+    return fake_websocket, fake_ws
+
+
+def test_backoff_blocks_retry_after_rejection(monkeypatch):
+    """A rejected handshake must block the next attempt until the backoff window expires."""
+    fake_wm, _ = _ws_rejecting(monkeypatch)
+    _make_fake_dashboard(monkeypatch)
+
+    # First call: gateway rejects — should return False and record next_retry_time.
+    assert gw._gw_ws_connect() is False
+    assert gw._ws_fail_count == 1
+    assert gw._ws_next_retry_time > 0.0
+    first_create_calls = fake_wm.create_connection.call_count
+    assert first_create_calls == 1
+
+    # Second call immediately after: backoff window is active — must NOT call
+    # create_connection again (that would re-hammer the gateway).
+    assert gw._gw_ws_connect() is False
+    assert fake_wm.create_connection.call_count == 1, (
+        "create_connection was called again during the backoff window — "
+        "this is the reconnect-storm bug from issue #4356."
+    )
+
+
+def test_backoff_delay_grows_with_each_failure(monkeypatch):
+    """Each successive failure must schedule a longer retry delay (exponential)."""
+    import time as _time
+
+    _make_fake_dashboard(monkeypatch)
+    delays = []
+
+    for i, delay in enumerate(gw._WS_BACKOFF_DELAYS):
+        # Force _ws_next_retry_time to zero so the guard passes each time.
+        gw._ws_next_retry_time = 0.0
+        gw._ws_fail_count = i
+
+        fake_wm, _ = _ws_rejecting(monkeypatch)
+        before = _time.monotonic()
+        gw._gw_ws_connect()
+        scheduled = gw._ws_next_retry_time - before
+        delays.append(scheduled)
+
+    for i, (actual, expected) in enumerate(zip(delays, gw._WS_BACKOFF_DELAYS)):
+        assert actual >= expected - 0.1, (
+            f"Backoff delay at failure {i} is {actual:.1f}s, expected ≥{expected}s."
+        )
+    # Verify the ladder is monotonically increasing (no regression to flat retry).
+    assert delays[0] < delays[-1], "Backoff delays must grow across retries."
+
+
+def test_success_resets_backoff(monkeypatch):
+    """A successful connection must clear fail_count and next_retry_time."""
+    _make_fake_dashboard(monkeypatch)
+
+    # Prime the backoff state as if we had a prior failure.
+    gw._ws_fail_count = 3
+    gw._ws_next_retry_time = 0.0  # allow through for this test
+
+    _ws_accepting(monkeypatch)
+    assert gw._gw_ws_connect() is True
+    assert gw._ws_fail_count == 0, "fail_count must reset to 0 after success."
+    assert gw._ws_next_retry_time == 0.0, "next_retry_time must reset to 0 after success."
+    assert gw._ws_connected is True


### PR DESCRIPTION
Closes #4356\n\n## What & Why\n\nOn v4 gateways that reject the handshake immediately, `_gw_ws_connect()` in `helpers/gateway.py` had no backoff: every HTTP request to `/api/sessions` or `/api/crons` would call it when `_ws_connected == False`, producing bursts of 5+ reconnect attempts per 100ms in the gateway log (observed live as described in #4356).\n\n## Changes\n\n- **`helpers/gateway.py`** -- Add three module-level backoff variables (`_ws_fail_count`, `_ws_next_retry_time`, `_WS_BACKOFF_DELAYS = (2, 4, 8, 16, 30, 60)`). Guard the top of `_gw_ws_connect()` with an early `return False` while inside the backoff window. Reset state to zero on a successful connect; increment/advance delay on any failure. Switch to `_ok` flag so backoff state is updated after the try block in all exit paths. The existing `_ws_lock` in `_gw_ws_rpc()` already serialises all callers so no extra locking is needed.\n- **`tests/test_gateway_rpc_backoff.py`** (new) -- Three regression tests: (1) second call within window hits the guard without retrying `create_connection`; (2) delay grows monotonically across failures; (3) a successful connect resets both `_ws_fail_count` and `_ws_next_retry_time`.\n\n## Test Plan\n\n```\npython -m pytest tests/test_gateway_rpc_backoff.py tests/test_gateway_ws_handshake_client_id.py -v\n```\nAll 4 tests pass (3 new + existing regression for client identity).\n\nBuilt on top of #4355 (already merged): uses `_GW_MIN_PROTO`/`_GW_MAX_PROTO` constants and `cli` identity so `test_no_hardcoded_protocol_literals_in_connect_frames` and `test_no_control_ui_impersonation` pass.\n\nThe scope acquisition problem (item 1 in #4356, v4 gateways grant `scopes: []` to `cli` clients) is a separate follow-on fix requiring the device-pairing flow and is not in this PR.\n\n_Replaces #4359 (that branch went dirty after #4355 squash-merged to main)._\n\n---\n_Generated by [Claude Code](https://claude.ai/code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01GRJ7XUr7pMM1u7PZQ2vBBM)_