### PR TITLE
[RELEASE] fix(plugins): pro-only routes 404'd on licensed installs — second app = Flask() orphaned plugin blueprints

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -284,16 +284,16 @@ except ImportError:
         pass  # noqa
 
 
-app = Flask(
-    __name__,
-    static_folder=os.path.join(os.path.dirname(__file__), 'clawmetry', 'static'),
-    template_folder=os.path.join(os.path.dirname(__file__), 'clawmetry', 'templates'),
-)
-
-# Plugins (e.g. ``clawmetry-pro``) can now register Blueprints on ``app``.
-# Older plugins with ``register_all()`` (no args) keep working unchanged:
-# the loader inspects the signature and only passes ``app`` when accepted.
-_ext_load(app)
+# NOTE: the Flask app is constructed ONCE, further down this module (search
+# for ``app = Flask(``). A second, earlier construction used to live here and
+# silently orphaned every plugin Blueprint: clawmetry-pro registered its
+# routes on the early app, then the later ``app = Flask(...)`` replaced it and
+# every pro-only endpoint (nemoclaw, selfevolve, assets, compliance, ...)
+# 404'd on licensed installs while the OSS 402 stubs skipped registration
+# because ``clawmetry_pro.is_loaded()`` was True. ``_ext_load(app)`` must be
+# invoked on the app instance that actually serves — it is called immediately
+# after the real construction below. Guarded by
+# tests/test_plugin_load_on_served_app.py.
 
 # ── Cross-platform helpers ──────────────────────────────────────────────
 import re as _re
@@ -8646,6 +8646,14 @@ app = Flask(
     static_folder=os.path.join(os.path.dirname(__file__), 'clawmetry', 'static'),
     template_folder=os.path.join(os.path.dirname(__file__), 'clawmetry', 'templates'),
 )
+
+# Plugins (e.g. ``clawmetry-pro``) register their Blueprints on ``app`` HERE —
+# this must stay immediately after the one-and-only Flask() construction (see
+# the note near the top of this module: a second construction once orphaned
+# every plugin route). Older plugins with ``register_all()`` (no args) keep
+# working unchanged: the loader inspects the signature and only passes
+# ``app`` when accepted.
+_ext_load(app)
 
 # Cap request body size (DoS guard). OTLP/JSON batches and config posts are
 # small; a 32 MB ceiling lets Flask reject oversized bodies (413) before they

--- a/tests/test_plugin_load_on_served_app.py
+++ b/tests/test_plugin_load_on_served_app.py
@@ -1,0 +1,39 @@
+"""Guard: plugin blueprints must register on the Flask app that serves.
+
+Regression test for the double-``app = Flask(...)`` bug: an early app
+construction consumed ``_ext_load(app)`` (clawmetry-pro registered all its
+Blueprints there), then a later construction replaced ``app`` and every
+pro-only endpoint 404'd on licensed installs — while the OSS 402 stubs
+skipped registration because ``clawmetry_pro.is_loaded()`` was True.
+
+Source-level lint (no pro package needed in CI):
+  1. ``dashboard.py`` constructs ``app = Flask(`` exactly once.
+  2. ``_ext_load(app)`` is called after that construction.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+DASHBOARD = Path(__file__).resolve().parent.parent / "dashboard.py"
+
+
+def test_single_flask_app_construction():
+    src = DASHBOARD.read_text(encoding="utf-8")
+    sites = [m.start() for m in re.finditer(r"^app = Flask\(", src, re.M)]
+    assert len(sites) == 1, (
+        f"dashboard.py constructs `app = Flask(` {len(sites)} times; a second "
+        "construction orphans every plugin Blueprint registered on the first "
+        "(pro-only routes 404 on licensed installs). Keep exactly one."
+    )
+
+
+def test_ext_load_called_after_app_construction():
+    src = DASHBOARD.read_text(encoding="utf-8")
+    app_at = src.index("app = Flask(")
+    calls = [m.start() for m in re.finditer(r"^_ext_load\(app\)", src, re.M)]
+    assert calls, "dashboard.py never calls _ext_load(app) at module scope"
+    assert all(c > app_at for c in calls), (
+        "_ext_load(app) runs before the served app is constructed — plugin "
+        "blueprints would land on a dead app object."
+    )


### PR DESCRIPTION
## What

`dashboard.py` constructed `app = Flask(...)` twice. Plugins loaded via `_ext_load(app)` after the FIRST construction; the second (≈8,300 lines later) replaced `app`, so every clawmetry-pro Blueprint — nemoclaw governance, selfevolve, assets, runtime_ingest, otel_push, and the new compliance routes — was registered on a dead object. Licensed local installs got **404** on every pro-only endpoint (worse than OSS, whose 402 stubs at least answer), because the OSS stubs skip registration when `clawmetry_pro.is_loaded()` is True.

Nothing referenced the first app (0 `@app.` decorators / attribute uses between the two constructions) — it was pure dead scaffolding, same pattern as the historical double `DASHBOARD_HTML`.

## Fix

- Remove the dead first construction; call `_ext_load(app)` immediately after the real one.
- `tests/test_plugin_load_on_served_app.py`: source-lint pinning (1) exactly one `app = Flask(` and (2) `_ext_load(app)` after it.

## Verification

Pro-installed venv (clawmetry-pro 0.7.0) importing this dashboard: 3 `/api/compliance/*` + 12 `/api/nemoclaw/*` rules present on `dashboard.app`; all of them 404 on 0.12.615.

Found while walking the Compliance Pack E2E (`clawmetry compliance bundle` against a licensed local install).

🤖 Generated with [Claude Code](https://claude.com/claude-code)