### PR TITLE
feat(entitlement): has_channel_count + /api/entitlement/has-channel-count

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -5413,6 +5413,60 @@ def has_runtime(runtime: str) -> bool:
         return False
 
 
+def has_channel_count(count) -> bool:
+    """Boolean-gate scalar: does the CURRENT install admit ``count`` chat-channel
+    adapters concurrently?
+
+    Capacity-axis mirror of :func:`has_feature` / :func:`has_runtime`, wrapping
+    :meth:`Entitlement.allows_channel_count` on the resolved entitlement so the
+    ``channels`` capacity axis has the same scalar boolean gate the feature and
+    runtime axes already carry. Sibling of :func:`min_tier_for_channel_count`
+    on the same axis: that one answers "cheapest tier that would admit this
+    count"; this one answers "does the resolved entitlement admit it right
+    now?".
+
+    Grace semantics: :meth:`Entitlement.allows_channel_count` returns ``True``
+    for every count while ``ent.grace`` is ``True`` (the current rollout state
+    -- see the module-level "Rollout: GRACE vs ENFORCE" docstring), so wiring
+    this into a capacity gate today changes NO current behavior. Enforcement
+    flips on when :func:`is_enforced` returns ``True`` and the resolver stops
+    setting ``grace``. For a forward-looking "would this be locked once
+    enforcement is on?" gate, compare :func:`min_tier_for_channel_count`
+    against :attr:`Entitlement.tier` explicitly -- this scalar deliberately
+    reflects the LIVE grant so a UI wired off it doesn't render locks before
+    the enforce date.
+
+    Semantics on ``count``:
+
+    * ``count <= 0`` -- returns ``True``. A zero/negative count is either
+      "not measured yet" or trivially satisfied; either way the free floor
+      covers it (matches :meth:`Entitlement.allows_channel_count`'s
+      grace-on-zero contract and :func:`min_tier_for_channel_count`'s
+      ``TIER_OSS`` fallback).
+    * Non-int ``count`` (str, ``None``, list, ...) -- returns ``False``. This
+      DIFFERS from the underlying :meth:`Entitlement.allows_channel_count`
+      (which returns ``True`` on parse failure to stay "unmeasured=permissive")
+      because the scalar has a strict callsite-typo posture matching
+      :func:`has_feature` / :func:`has_runtime`. A caller that passes non-int
+      here has a bug -- fail-closed instead of silently granting.
+    * Positive int -- delegates to :meth:`Entitlement.allows_channel_count`,
+      returning ``True`` iff the resolved tier's ``channel_limit`` is ``None``
+      (unlimited) or ``>= count``.
+
+    Never raises: any resolver blowup collapses to ``False`` so a caller can
+    bind this into a boolean AND-chain without a try/except.
+    """
+    try:
+        n = int(count)
+    except (TypeError, ValueError):
+        return False
+    try:
+        return bool(get_entitlement().allows_channel_count(n))
+    except Exception as exc:
+        logger.warning("entitlements: has_channel_count(%r) failed: %s", count, exc)
+        return False
+
+
 def _tier_row(tier: str) -> dict:
     return {
         "id": tier,

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -3515,6 +3515,135 @@ def api_entitlement_has_runtime():
         return jsonify(_has_axis_fallback("runtime", key))
 
 
+def _has_channel_count_fallback(count_raw: str) -> dict:
+    """OSS-free / never-5xx shape for ``/api/entitlement/has-channel-count``.
+
+    Fail-closed on ``has_channel_count`` (matches the sibling
+    ``/api/entitlement/has-feature`` / ``/has-runtime`` fallback) so a paywall
+    tile that lost the resolver doesn't silently grant a capacity that might be
+    over-quota. ``count`` is echoed as ``None`` and ``count_raw`` as the
+    stripped input so a UI can still surface the offending value in a diagnostic
+    tooltip. 10-key envelope, byte-stable with the happy-path branch.
+    """
+    return {
+        "count": None,
+        "count_raw": count_raw,
+        "has_channel_count": False,
+        "allowed": False,
+        "required_tier": None,
+        "required_tier_label": None,
+        "required_tier_rank": -1,
+        "current_tier": "oss",
+        "current_tier_rank": 0,
+        "upgrade_required": False,
+    }
+
+
+@bp_entitlement.route("/api/entitlement/has-channel-count")
+def api_entitlement_has_channel_count():
+    """``GET /api/entitlement/has-channel-count?count=<N>`` -- capacity-axis
+    boolean-gate scalar sibling of ``/api/entitlement/has-feature`` /
+    ``/api/entitlement/has-runtime``.
+
+    Returns ONE boolean (``has_channel_count``) plus the surrounding tier
+    envelope (``current_tier``, ``required_tier``, ``upgrade_required``) so a
+    paywall tile on the channels surface can bind ``allowed`` directly off this
+    URL without parsing the full ``/api/entitlement/required-tier?channels=<N>``
+    body. Grace-safe: while :attr:`Entitlement.grace` is ``True`` (the current
+    rollout state) ``has_channel_count`` reports ``True`` for every finite
+    count, so wiring this into a gate today changes NO current behavior.
+
+    Envelope shape (10 keys, byte-stable across every input branch)::
+
+        {
+          "count": 5,                    # parsed int, null on missing/unparseable/blowup
+          "count_raw": "5",              # stripped raw string echo
+          "has_channel_count": True,
+          "allowed": True,               # mirror of has_channel_count
+          "required_tier": "cloud_starter",
+          "required_tier_label": "Starter",
+          "required_tier_rank": 1,
+          "current_tier": "oss",
+          "current_tier_rank": 0,
+          "upgrade_required": True,
+        }
+
+    Input semantics:
+
+    * ``?count=`` missing / blank / whitespace / unparseable -- ``count=null``,
+      ``has_channel_count=false``, ``required_tier=null``. Never 4xx (matches
+      the never-crash posture of ``/api/entitlement/required-tier`` and
+      ``/api/entitlement/lock-reason`` on their capacity axes).
+    * ``count <= 0`` -- ``has_channel_count=true``, ``required_tier="oss"``
+      (trivially satisfied by the free floor -- mirrors
+      :func:`min_tier_for_channel_count` and
+      :meth:`Entitlement.allows_channel_count`).
+    * Positive int -- ``has_channel_count`` reflects the resolver;
+      ``required_tier`` is the cheapest tier admitting ``count`` per
+      :func:`min_tier_for_channel_count`.
+
+    Cross-consistency: ``required_tier`` / ``required_tier_label`` /
+    ``required_tier_rank`` agree byte-for-byte with
+    ``/api/entitlement/required-tier?channels=<N>`` for the same ``count`` so a
+    UI wiring both endpoints for the same paywall tile can't see inconsistent
+    tier state.
+
+    Never 5xx: any resolver blowup collapses to :func:`_has_channel_count_fallback`.
+    """
+    count_raw = (request.args.get("count") or "").strip()
+    try:
+        from clawmetry import entitlements as _ent
+
+        try:
+            n = int(count_raw)
+            parsed_ok = True
+        except (TypeError, ValueError):
+            n = None
+            parsed_ok = False
+
+        ent = _ent.get_entitlement()
+        cur_tier = ent.tier
+        cur_rank = _ent.tier_rank(cur_tier)
+
+        if not parsed_ok:
+            return jsonify(
+                {
+                    "count": None,
+                    "count_raw": count_raw,
+                    "has_channel_count": False,
+                    "allowed": False,
+                    "required_tier": None,
+                    "required_tier_label": None,
+                    "required_tier_rank": -1,
+                    "current_tier": cur_tier,
+                    "current_tier_rank": cur_rank,
+                    "upgrade_required": False,
+                }
+            )
+
+        has_flag = _ent.has_channel_count(n)
+        required = _ent.min_tier_for_channel_count(n)
+        req_rank = _ent.tier_rank(required) if required else -1
+        required_label = _ent.tier_label(required) if required else None
+        return jsonify(
+            {
+                "count": n,
+                "count_raw": count_raw,
+                "has_channel_count": bool(has_flag),
+                "allowed": bool(has_flag),
+                "required_tier": required,
+                "required_tier_label": required_label,
+                "required_tier_rank": req_rank,
+                "current_tier": cur_tier,
+                "current_tier_rank": cur_rank,
+                "upgrade_required": bool(required) and req_rank > cur_rank,
+            }
+        )
+    except Exception as exc:
+        logger.warning("api_entitlement_has_channel_count: error: %s", exc)
+        return jsonify(_has_channel_count_fallback(count_raw))
+
+
 @bp_entitlement.route("/api/entitlement/lock-reason")
 def api_entitlement_lock_reason():
     try:

--- a/tests/test_entitlement_has_channel_count.py
+++ b/tests/test_entitlement_has_channel_count.py
@@ -1,0 +1,551 @@
+"""Tests for the ``has_channel_count`` boolean-gate scalar and its paired
+``/api/entitlement/has-channel-count`` endpoint -- the capacity-axis sibling of
+:func:`clawmetry.entitlements.has_feature` / :func:`~clawmetry.entitlements.has_runtime`.
+
+Where the string-id ``has_feature`` / ``has_runtime`` scalars answer "does the
+CURRENT resolved entitlement grant this feature/runtime?", ``has_channel_count``
+answers the same question on the ``channels`` capacity axis: "does the resolved
+entitlement admit this many chat-channel adapters concurrently?" -- one boolean
+plus the surrounding tier envelope so a paywall tile on the channels surface
+can bind ``allowed`` directly off the URL.
+
+This file pins:
+
+1. Scalar-helper behaviour under both rollout modes (grace vs enforce) for
+   zero / negative / positive / non-int / None input.
+2. Endpoint envelope shape parity (fixed 10-key set) across every input
+   branch so a frontend can bind fields off the URL without a branch on the
+   underlying resolver state.
+3. Never-5xx via monkeypatched blowup: happy-path body builder AND
+   :func:`min_tier_for_channel_count`.
+4. Cross-consistency with the sibling ``/api/entitlement/required-tier?channels=<N>``
+   endpoint -- same ``required_tier`` / ``current_tier`` for the same
+   ``count`` so a UI wiring both URLs into the same paywall tile can't see
+   inconsistent tier state.
+5. The grace-mode invariant: ``has_channel_count`` reports ``True`` for every
+   finite count while ``grace`` is on, so wiring this into a capacity gate
+   today changes no current behavior.
+6. Scalar-vs-endpoint parity: envelope ``has_channel_count`` matches the
+   module-level scalar byte-for-byte on the same input.
+"""
+from __future__ import annotations
+
+import importlib
+import json
+import time
+
+import pytest
+from flask import Flask
+
+
+# ── Fixtures ────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    """Fresh entitlements module with HOME pointed at an empty tmp dir so no
+    real ``~/.clawmetry/license.key`` or ``cloud_plan.json`` leaks in.
+    Enforcement off by default -- matches the project rollout posture and
+    reuses the same fixture shape ``tests/test_entitlement_channel_limit.py``
+    uses so the assertions here reproduce the same install state the
+    sibling :meth:`Entitlement.allows_channel_count` tests are pinned
+    against."""
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def enforced(monkeypatch, tmp_path):
+    """Enforcement-on fixture -- ``CLAWMETRY_ENFORCE=1`` flips ``ent.grace``
+    to False so the grace pass-through collapses and the paid axes report
+    their post-enforce answers. Matches ``enforced`` in
+    ``tests/test_entitlement_has_feature_has_runtime.py``."""
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    importlib.reload(e)
+    e.invalidate()
+
+
+@pytest.fixture
+def enforced_cloud_starter(monkeypatch, tmp_path):
+    """Enforcement on, cloud_starter plan wired via the disk cache the
+    resolver reads. Starter's ``_TIER_CHANNEL_LIMIT`` is ``None`` (unlimited)
+    so every count is admitted -- lets a test pin the "paid tier grants
+    everything" branch symmetrically with the OSS-cap branch."""
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cache = tmp_path / ".clawmetry" / "cloud_plan.json"
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    cache.write_text(json.dumps({"plan": "cloud_starter"}))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    importlib.reload(e)
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+@pytest.fixture
+def enforced_client(enforced):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# ── Envelope shape ──────────────────────────────────────────────────────────
+
+_ENVELOPE_KEYS = {
+    "count",
+    "count_raw",
+    "has_channel_count",
+    "allowed",
+    "required_tier",
+    "required_tier_label",
+    "required_tier_rank",
+    "current_tier",
+    "current_tier_rank",
+    "upgrade_required",
+}
+
+
+def _get_json(client, url: str) -> dict:
+    resp = client.get(url)
+    assert resp.status_code == 200, url
+    return resp.get_json()
+
+
+# ── has_channel_count scalar ────────────────────────────────────────────────
+
+
+def test_scalar_zero_is_true(ent):
+    """A zero count is trivially satisfied -- matches
+    :meth:`Entitlement.allows_channel_count`'s grace-on-zero contract and
+    :func:`min_tier_for_channel_count`'s ``TIER_OSS`` fallback."""
+    assert ent.has_channel_count(0) is True
+
+
+def test_scalar_negative_is_true(ent):
+    """Negative counts collapse to True (trivially satisfied)."""
+    for n in (-1, -100, -999):
+        assert ent.has_channel_count(n) is True, n
+
+
+def test_scalar_positive_true_in_grace(ent):
+    """Grace invariant on the count axis: every finite positive count
+    reports True while ``ent.grace`` is on. Wiring this into a gate today
+    changes no behavior."""
+    for n in (1, 3, 4, 21, 100, 10_000):
+        assert ent.has_channel_count(n) is True, n
+
+
+def test_scalar_positive_after_enforcement(enforced):
+    """Post-enforcement on OSS: counts within the free cap of 3 return True,
+    counts above collapse to False."""
+    assert enforced.has_channel_count(1) is True
+    assert enforced.has_channel_count(3) is True
+    assert enforced.has_channel_count(4) is False
+    assert enforced.has_channel_count(21) is False
+
+
+def test_scalar_positive_after_enforcement_paid_is_unlimited(enforced_cloud_starter):
+    """Post-enforcement on cloud_starter: unlimited channels."""
+    for n in (1, 3, 4, 21, 100, 10_000):
+        assert enforced_cloud_starter.has_channel_count(n) is True, n
+
+
+def test_scalar_non_int_is_false(ent):
+    """Non-int input collapses to False -- fail-closed matches
+    :func:`has_feature` / :func:`has_runtime` on unknown/junk input, even
+    though the underlying :meth:`Entitlement.allows_channel_count` is
+    permissive on parse failure (the scalar has a strict callsite-typo
+    posture that catches ``has_channel_count("five")`` at the callsite)."""
+    for arg in ("bogus", "  ", "", "5.5", "one", [], {}, (1,)):
+        assert ent.has_channel_count(arg) is False, arg
+
+
+def test_scalar_none_is_false(ent):
+    """None collapses to False (fail-closed) -- differs from
+    :meth:`Entitlement.allows_channel_count(None)` which is True; the scalar
+    surfaces the callsite bug instead of silently granting."""
+    assert ent.has_channel_count(None) is False  # type: ignore[arg-type]
+
+
+def test_scalar_bool_is_true_because_int_subclass(ent):
+    """Python bools ARE ints (``True == 1``, ``False == 0``): the scalar
+    delegates to ``int(count)`` so ``True`` -> 1 -> allowed (grace), ``False``
+    -> 0 -> trivially satisfied. Documented here to catch a future refactor
+    that adds a bool-rejection branch."""
+    assert ent.has_channel_count(True) is True
+    assert ent.has_channel_count(False) is True
+
+
+def test_scalar_string_int_is_accepted(ent):
+    """String-int (``"5"``) is accepted -- ``int("5")`` succeeds. Lets a
+    query-string caller (which always sees strings) hit the scalar without
+    manual pre-parsing."""
+    for n in ("1", "3", "21", "100"):
+        assert ent.has_channel_count(n) is True, n
+
+
+def test_scalar_never_raises_on_resolver_blowup(monkeypatch, ent):
+    """Any blowup in ``get_entitlement`` collapses to False so a caller can
+    bind this into a boolean AND-chain without a try/except."""
+    def _boom(*a, **kw):
+        raise RuntimeError("resolver blew up")
+
+    monkeypatch.setattr(ent, "get_entitlement", _boom)
+    for arg in (1, 3, 21, 100, 0, -5):
+        assert ent.has_channel_count(arg) is False, arg
+
+
+def test_scalar_never_raises_on_allows_channel_count_blowup(monkeypatch, ent):
+    """Blowup deeper in :meth:`Entitlement.allows_channel_count` also
+    collapses to False -- pin the outer never-raises contract."""
+    real_get = ent.get_entitlement
+
+    def _fake_get(*a, **kw):
+        en = real_get(*a, **kw)
+
+        def _boom(*_a, **_kw):
+            raise RuntimeError("allows_channel_count blew up")
+
+        en.allows_channel_count = _boom  # type: ignore[method-assign]
+        return en
+
+    monkeypatch.setattr(ent, "get_entitlement", _fake_get)
+    assert ent.has_channel_count(5) is False
+
+
+# ── /api/entitlement/has-channel-count envelope ─────────────────────────────
+
+
+def test_endpoint_positive_shape_grace(client):
+    """Grace-mode positive count: has_channel_count=True (grace grant) and
+    required_tier=None-or-oss (the free floor covers small counts, larger
+    counts route to Starter+ as their min tier)."""
+    body = _get_json(client, "/api/entitlement/has-channel-count?count=5")
+    assert set(body.keys()) == _ENVELOPE_KEYS
+    assert body["count"] == 5
+    assert body["count_raw"] == "5"
+    assert body["has_channel_count"] is True
+    assert body["allowed"] is True
+    assert body["required_tier"] == "cloud_starter"
+    assert body["required_tier_label"] == "Starter"
+    assert body["required_tier_rank"] == 1
+    assert body["current_tier"] == "oss"
+    assert body["current_tier_rank"] == 0
+    assert body["upgrade_required"] is True
+
+
+def test_endpoint_within_free_cap_shape(client):
+    """A count within the OSS free cap (<=3) routes to
+    ``required_tier="oss"`` (the free floor covers it)."""
+    body = _get_json(client, "/api/entitlement/has-channel-count?count=1")
+    assert set(body.keys()) == _ENVELOPE_KEYS
+    assert body["count"] == 1
+    assert body["required_tier"] == "oss"
+    assert body["required_tier_label"] == "OSS"
+    assert body["required_tier_rank"] == 0
+    assert body["has_channel_count"] is True
+    assert body["upgrade_required"] is False
+
+
+def test_endpoint_zero_shape(client):
+    """Zero collapses to trivially-satisfied: ``has_channel_count=True``
+    with ``required_tier="oss"``. Mirrors :func:`min_tier_for_channel_count`
+    and :meth:`Entitlement.allows_channel_count`."""
+    body = _get_json(client, "/api/entitlement/has-channel-count?count=0")
+    assert set(body.keys()) == _ENVELOPE_KEYS
+    assert body["count"] == 0
+    assert body["has_channel_count"] is True
+    assert body["required_tier"] == "oss"
+    assert body["required_tier_rank"] == 0
+    assert body["upgrade_required"] is False
+
+
+def test_endpoint_negative_shape(client):
+    """Negative counts route the same way zero does (trivially satisfied)."""
+    body = _get_json(client, "/api/entitlement/has-channel-count?count=-5")
+    assert set(body.keys()) == _ENVELOPE_KEYS
+    assert body["count"] == -5
+    assert body["has_channel_count"] is True
+    assert body["required_tier"] == "oss"
+    assert body["upgrade_required"] is False
+
+
+def test_endpoint_missing_param_shape(client):
+    """Missing ``?count=`` -- never 4xx (matches the never-crash posture of
+    ``/api/entitlement/required-tier?channels=`` on unparseable input).
+    ``count=null``, ``has_channel_count=false``, ``required_tier=null``."""
+    body = _get_json(client, "/api/entitlement/has-channel-count")
+    assert set(body.keys()) == _ENVELOPE_KEYS
+    assert body["count"] is None
+    assert body["count_raw"] == ""
+    assert body["has_channel_count"] is False
+    assert body["allowed"] is False
+    assert body["required_tier"] is None
+    assert body["required_tier_label"] is None
+    assert body["required_tier_rank"] == -1
+    assert body["upgrade_required"] is False
+
+
+def test_endpoint_blank_param_shape(client):
+    """Explicit blank ``?count=`` -- same shape as missing."""
+    body = _get_json(client, "/api/entitlement/has-channel-count?count=")
+    assert set(body.keys()) == _ENVELOPE_KEYS
+    assert body["count"] is None
+    assert body["count_raw"] == ""
+    assert body["has_channel_count"] is False
+
+
+def test_endpoint_whitespace_param_shape(client):
+    """Whitespace-only ``?count=%20%20`` strips to empty -- same shape."""
+    body = _get_json(client, "/api/entitlement/has-channel-count?count=%20%20")
+    assert set(body.keys()) == _ENVELOPE_KEYS
+    assert body["count"] is None
+    assert body["count_raw"] == ""
+    assert body["has_channel_count"] is False
+
+
+def test_endpoint_unparseable_shape(client):
+    """Non-int input (``?count=bogus``) -- never 4xx, echoes
+    ``count_raw="bogus"``, ``count=null``, ``has_channel_count=false``."""
+    body = _get_json(client, "/api/entitlement/has-channel-count?count=bogus")
+    assert set(body.keys()) == _ENVELOPE_KEYS
+    assert body["count"] is None
+    assert body["count_raw"] == "bogus"
+    assert body["has_channel_count"] is False
+    assert body["required_tier"] is None
+
+
+def test_endpoint_float_string_is_unparseable(client):
+    """A float-string like ``5.5`` fails ``int()`` -- unparseable shape."""
+    body = _get_json(client, "/api/entitlement/has-channel-count?count=5.5")
+    assert set(body.keys()) == _ENVELOPE_KEYS
+    assert body["count"] is None
+    assert body["count_raw"] == "5.5"
+    assert body["has_channel_count"] is False
+
+
+def test_endpoint_string_int_shape(client):
+    """Query-string ints (always strings) are accepted -- parity with
+    ``/required-tier?channels=5``."""
+    body = _get_json(client, "/api/entitlement/has-channel-count?count=21")
+    assert body["count"] == 21
+    assert body["count_raw"] == "21"
+    assert body["has_channel_count"] is True
+
+
+def test_endpoint_stripped_count_raw(client):
+    """Surrounding whitespace in the raw param is stripped before echo."""
+    body = _get_json(client, "/api/entitlement/has-channel-count?count=%20%205%20%20")
+    assert body["count"] == 5
+    assert body["count_raw"] == "5"
+
+
+# ── Never-5xx (monkeypatched blowup) ────────────────────────────────────────
+
+
+def test_endpoint_never_5xx_on_body_blowup(monkeypatch, client):
+    """A blowup deep in the min_tier resolver still returns 200 with the
+    fallback envelope."""
+    def _boom(*a, **kw):
+        raise RuntimeError("min_tier_for_channel_count blew up")
+
+    from clawmetry import entitlements as _ent
+
+    monkeypatch.setattr(_ent, "min_tier_for_channel_count", _boom)
+    resp = client.get("/api/entitlement/has-channel-count?count=5")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert set(body.keys()) == _ENVELOPE_KEYS
+    assert body["count"] is None
+    assert body["count_raw"] == "5"
+    assert body["has_channel_count"] is False
+    assert body["allowed"] is False
+
+
+def test_endpoint_never_5xx_on_entitlement_blowup(monkeypatch, client):
+    """A blowup in ``get_entitlement`` still returns 200 with the fallback
+    envelope."""
+    def _boom(*a, **kw):
+        raise RuntimeError("get_entitlement blew up")
+
+    from clawmetry import entitlements as _ent
+
+    monkeypatch.setattr(_ent, "get_entitlement", _boom)
+    resp = client.get("/api/entitlement/has-channel-count?count=5")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert set(body.keys()) == _ENVELOPE_KEYS
+    assert body["count"] is None
+    assert body["has_channel_count"] is False
+    assert body["allowed"] is False
+
+
+def test_fallback_shape_direct():
+    """Direct call of the fallback helper: fixed 10-key envelope, all fields
+    fail-closed / defaulted."""
+    from routes.entitlement import _has_channel_count_fallback
+
+    body = _has_channel_count_fallback("42")
+    assert set(body.keys()) == _ENVELOPE_KEYS
+    assert body["count"] is None
+    assert body["count_raw"] == "42"
+    assert body["has_channel_count"] is False
+    assert body["allowed"] is False
+    assert body["required_tier"] is None
+    assert body["required_tier_label"] is None
+    assert body["required_tier_rank"] == -1
+    assert body["current_tier"] == "oss"
+    assert body["current_tier_rank"] == 0
+    assert body["upgrade_required"] is False
+
+
+# ── Cross-consistency with /required-tier?channels=N ────────────────────────
+
+
+@pytest.mark.parametrize("n", [1, 3, 4, 5, 21, 100])
+def test_endpoint_cross_consistent_with_required_tier(client, n):
+    """Same input -> same tier answer on both endpoints. A UI wiring
+    ``/has-channel-count`` and ``/required-tier?channels=`` into the same
+    paywall tile can't see inconsistent tier state."""
+    has_body = _get_json(client, f"/api/entitlement/has-channel-count?count={n}")
+    req_body = _get_json(client, f"/api/entitlement/required-tier?channels={n}")
+    assert has_body["required_tier"] == req_body["required_tier"], n
+    assert has_body["required_tier_label"] == req_body["required_tier_label"], n
+    assert has_body["required_tier_rank"] == req_body["required_tier_rank"], n
+    assert has_body["current_tier"] == req_body["current_tier"], n
+    assert has_body["current_tier_rank"] == req_body["current_tier_rank"], n
+    assert has_body["upgrade_required"] == req_body["upgrade_required"], n
+    assert has_body["allowed"] == req_body["allowed"], n
+
+
+# ── Scalar-vs-endpoint parity ───────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("n", [0, 1, 3, 4, 5, 21, 100, -1])
+def test_endpoint_matches_scalar_int(client, ent, n):
+    """Envelope ``has_channel_count`` matches the module-level scalar
+    byte-for-byte -- no drift possible between the two."""
+    body = _get_json(client, f"/api/entitlement/has-channel-count?count={n}")
+    assert body["has_channel_count"] is ent.has_channel_count(n)
+    assert body["allowed"] is ent.has_channel_count(n)
+
+
+@pytest.mark.parametrize("raw", ["bogus", "", "  ", "5.5"])
+def test_endpoint_matches_scalar_bad_input(client, ent, raw):
+    """On unparseable input, both endpoint and scalar report False."""
+    # URL-encode manually so the whitespace-only case survives Werkzeug's
+    # query-string parser without being coalesced to an empty value.
+    import urllib.parse
+    url = f"/api/entitlement/has-channel-count?count={urllib.parse.quote(raw)}"
+    body = _get_json(client, url)
+    assert body["has_channel_count"] is False
+    # Scalar on the same raw input also reports False (strings that don't
+    # parse as int fail-close).
+    assert ent.has_channel_count(raw) is False
+
+
+# ── Grace invariant on the count axis ───────────────────────────────────────
+
+
+def test_grace_invariant_every_finite_count_true(ent):
+    """The headline grace invariant on the count axis: while grace is on,
+    every finite non-negative count reports ``has_channel_count=True``. This
+    is what makes wiring this into a gate today a no-op behavior change --
+    exactly parallel to the feature/runtime grace invariant on their axes."""
+    for n in (0, 1, 2, 3, 4, 5, 10, 21, 100, 1_000, 10_000):
+        assert ent.has_channel_count(n) is True, n
+
+
+def test_enforce_free_capped_at_three(enforced):
+    """Symmetric assertion on the enforcement side: on OSS-free, counts
+    above the free cap report False."""
+    assert enforced.has_channel_count(3) is True
+    assert enforced.has_channel_count(4) is False
+    assert enforced.has_channel_count(21) is False
+
+
+def test_enforce_expired_paid_collapses_to_free_cap(monkeypatch, tmp_path):
+    """Post-enforcement expired paid plan collapses to the free cap of 3 --
+    matches the expiry semantics of :meth:`Entitlement.allows_channel_count`."""
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cache = tmp_path / ".clawmetry" / "cloud_plan.json"
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    cache.write_text(json.dumps({
+        "plan": "cloud_pro",
+        "expiry": time.time() - 60,
+    }))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    try:
+        assert e.has_channel_count(3) is True
+        assert e.has_channel_count(4) is False
+    finally:
+        monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+        importlib.reload(e)
+        e.invalidate()
+
+
+# ── Envelope invariants across every branch ─────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "/api/entitlement/has-channel-count",
+        "/api/entitlement/has-channel-count?count=",
+        "/api/entitlement/has-channel-count?count=0",
+        "/api/entitlement/has-channel-count?count=1",
+        "/api/entitlement/has-channel-count?count=3",
+        "/api/entitlement/has-channel-count?count=4",
+        "/api/entitlement/has-channel-count?count=21",
+        "/api/entitlement/has-channel-count?count=100",
+        "/api/entitlement/has-channel-count?count=-1",
+        "/api/entitlement/has-channel-count?count=bogus",
+        "/api/entitlement/has-channel-count?count=5.5",
+        "/api/entitlement/has-channel-count?count=%20%20",
+    ],
+)
+def test_envelope_shape_invariant(client, url):
+    """Fixed 10-key envelope across every input branch -- a frontend can
+    bind fields off the URL without a branch on the resolver state."""
+    body = _get_json(client, url)
+    assert set(body.keys()) == _ENVELOPE_KEYS, url
+    assert isinstance(body["has_channel_count"], bool)
+    assert isinstance(body["allowed"], bool)
+    assert isinstance(body["upgrade_required"], bool)
+    assert isinstance(body["current_tier"], str)
+    assert isinstance(body["current_tier_rank"], int)
+    assert isinstance(body["required_tier_rank"], int)
+    assert body["count"] is None or isinstance(body["count"], int)
+    assert isinstance(body["count_raw"], str)


### PR DESCRIPTION
## Summary

- New `clawmetry.entitlements.has_channel_count(count) -> bool` module-scope scalar: capacity-axis mirror of `has_feature` / `has_runtime` on the `channels` axis, wrapping `Entitlement.allows_channel_count` on the resolved entitlement. Fills the boolean-gate seat sitting alongside `min_tier_for_channel_count` (which answers "cheapest tier that would admit this count") -- this one answers "does the resolved entitlement admit it right now?". Same never-raises + grace-safe posture the sibling `has_feature` / `has_runtime` scalars carry: while `ent.grace` is `True` (the current rollout state) every finite non-negative count reports `True`, so wiring this into a capacity gate today changes NO current behavior.

  Fail-closed on non-int / `None` input (differs deliberately from the underlying `Entitlement.allows_channel_count`, which is permissive on parse failure) so a caller passing `has_channel_count("five")` sees the typo at the callsite instead of a silent grant -- matches the existing `has_feature("Fleet")` posture.

- New `GET /api/entitlement/has-channel-count?count=<N>` endpoint on `bp_entitlement` mirroring the shape of `/api/entitlement/has-feature` / `/api/entitlement/has-runtime` for the numeric channels-count axis. **10-key envelope** (`count` + `count_raw` + `has_channel_count` + `allowed` + `required_tier` triad + `current_tier` pair + `upgrade_required`), byte-stable across every input branch so a paywall tile can bind fields off the URL without a branch on the resolver state. Cross-consistent with `/api/entitlement/required-tier?channels=<N>` on the same count -- `required_tier` / `required_tier_label` / `required_tier_rank` agree byte-for-byte so a UI wiring both endpoints for the same paywall tile can't see inconsistent tier state. Never 5xx: any resolver blowup collapses to the fail-closed fallback envelope.

- **58 hermetic unit tests** covering: scalar behaviour under grace vs enforce for zero / negative / positive / non-int / `None` / string-int / bool input; envelope-shape invariant across 12 URL branches (missing / blank / whitespace / unparseable / float-string / positive / zero / negative); never-5xx via monkeypatched blowup on both `get_entitlement` AND `min_tier_for_channel_count`; parametrised cross-endpoint parity against `/required-tier?channels=` on `[1, 3, 4, 5, 21, 100]`; scalar-vs-endpoint parity on `[0, 1, 3, 4, 5, 21, 100, -1]`; the headline grace invariant across `[0, 1, ..., 10000]`; and enforce-side expiry collapse (paid plan past expiry falls back to the OSS cap of 3).

Behaviour is additive; nothing existing changes. Grace-mode posture is preserved (no gate enforcement is added; the scalar only surfaces what the resolved entitlement's `channel_limit` admits at each count). Uses only the already-permitted `flask` + stdlib import set.

## Test plan

- [x] `python3 -m py_compile clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_has_channel_count.py` -- passes
- [x] `python3 -m pytest tests/test_entitlement_has_channel_count.py` -- **58 passed**
- [x] `python3 -m pytest tests/test_entitlement_has_feature_has_runtime.py tests/test_entitlement_channel_limit.py` -- 68 passed (sibling regressions clean)
- [x] `python3 -m ruff check clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_has_channel_count.py --select E9,F63,F7,F82` -- all critical checks pass; the file-wide BLE001 count is stable (my `except Exception` block matches the ~382 existing never-raises wrappers on sibling scalars, one per accessor).
- [x] `make lint-py` fails only on pre-existing warnings elsewhere in `dashboard.py` (same posture the sibling `has_feature` / `has_runtime` and `license_*_at` PRs are shipping with; CI runs ruff warnings-only with `|| true`).

## Local operator verification checklist

The web agent cannot touch the live daemon, `~/.openclaw`, the cloud snapshot, or a browser. Please verify on-host before flipping this out of draft:

- [ ] Copy the changed source files (and the new test) into the installed package:
  - `cp clawmetry/entitlements.py ~/.clawmetry/lib/python*/site-packages/clawmetry/entitlements.py`
  - `cp routes/entitlement.py ~/.clawmetry/lib/python*/site-packages/routes/entitlement.py`
  - `find ~/.clawmetry/lib/python*/site-packages/{clawmetry,routes} -name __pycache__ -exec rm -rf {} +`
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` (or the equivalent supervisor kick on non-macOS hosts)
- [ ] `curl -s "http://localhost:8900/api/entitlement/has-channel-count?count=5" | jq` -- envelope shape matches the docstring; `required_tier` matches `curl -s "http://localhost:8900/api/entitlement/required-tier?channels=5" | jq .required_tier`.
- [ ] Grace-safe sanity: `curl -s "http://localhost:8900/api/entitlement/has-channel-count?count=100" | jq .has_channel_count` -- should be `true` while grace is on (no change from today's `/required-tier?channels=100` `allowed=true`).
- [ ] Boundary sanity: pick a count within the OSS free cap (`?count=3`) vs above it (`?count=4`) and confirm `required_tier` flips at the boundary (`oss` -> `cloud_starter`) with `upgrade_required=true` on the `4` row.
- [ ] Bad-input sanity: `curl` with `?count=bogus`, `?count=5.5`, `?count=` -- all 200, all `has_channel_count=false`, `count=null`, `count_raw` echoes the raw string.
- [ ] Browser check: open the entitlement diagnostics tile and confirm no regression on the current-time channels/features view; the channels paywall tile (if wired) can bind `allowed` off `/has-channel-count?count=<live-count>` without changing behavior in grace.
- [ ] Decrypt the live cloud snapshot and confirm the new endpoint is reachable through the relay (should require no relay changes -- it is a read-only handler on `bp_entitlement`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01D9Byw4FzGkdhBQcnumHYDE)_