### PR TITLE
fix(sessions): render workspace.conflict events in transcript view

### DIFF
--- a/routes/sessions.py
+++ b/routes/sessions.py
@@ -3494,6 +3494,9 @@ _RENDERABLE_TRANSCRIPT_EVENT_TYPES = frozenset({
     "prompt.submitted", "trace.artifacts", "model.completed",
     "tool.call", "tool.invoked", "tool.result", "tool.completed",
     "compaction",
+    # Cloud workspace conflict marker — sync.py normalises all aliases to this
+    # type so the transcript view can surface a visible inline notification (#3928).
+    "workspace.conflict",
     # Subagent fan-out — child turns surface in the parent's transcript
     # via ``query_events_with_subagents`` (#1597).
     "subagent:assistant", "subagent:user",
@@ -4039,6 +4042,25 @@ def _expand_openclaw_event(obj: dict, ts_ms):
                 "content": f"[Tool result: {tname}]\n{body}",
                 "timestamp": ts_ms,
             })
+        return turns
+
+    if etype == "workspace.conflict":
+        # Cloud workspace conflict event (#3928): OpenClaw emits this when the
+        # Control UI detects a conflict between local and cloud workspace state.
+        # Render as a system-role notification so it appears inline in the
+        # transcript at the right point without disrupting the message flow.
+        paths = obj.get("conflictedPaths") or data.get("conflictedPaths") or []
+        resolution = obj.get("resolution") or data.get("resolution") or ""
+        staged_ref = obj.get("stagedRef") or data.get("stagedRef") or ""
+        n = len(paths) if isinstance(paths, list) else 0
+        parts = [f"⚠ Cloud workspace conflict ({n} conflicted path{'s' if n != 1 else ''})"]
+        if resolution:
+            parts.append(f"Resolution: {resolution}")
+        if staged_ref:
+            parts.append(f"Staged ref: {staged_ref}")
+        if isinstance(paths, list) and paths:
+            parts.append("Paths:\n" + "\n".join(f"  • {p}" for p in paths[:20]))
+        turns.append({"role": "system", "content": "\n".join(parts), "timestamp": ts_ms})
         return turns
 
     # Unknown OpenClaw event — silently skip rather than emit "x.y" role trash.

--- a/tests/test_obs_gap_openclaw_workspace_conflict_4148.py
+++ b/tests/test_obs_gap_openclaw_workspace_conflict_4148.py
@@ -117,3 +117,64 @@ def test_unknown_v3_type_still_dropped():
     # the parser must still drop it cleanly.
     # Verify _is_v3_event rejects it:
     assert sync._is_v3_event(obj) is False
+
+
+# ---------------------------------------------------------------------------
+# Transcript-rendering tests (#3928): workspace.conflict must surface in the
+# Sessions transcript view, not be silently dropped by the renderable gate.
+# ---------------------------------------------------------------------------
+
+def _sessions():
+    import routes.sessions as sess
+    return sess
+
+
+def test_workspace_conflict_is_renderable():
+    """'workspace.conflict' must appear in _RENDERABLE_TRANSCRIPT_EVENT_TYPES."""
+    sess = _sessions()
+    assert "workspace.conflict" in sess._RENDERABLE_TRANSCRIPT_EVENT_TYPES
+
+
+def test_expand_workspace_conflict_returns_turn():
+    """_expand_openclaw_event must produce a non-empty system turn."""
+    sess = _sessions()
+    obj = {
+        "type": "workspace.conflict",
+        "conflictedPaths": ["/src/app.py", "/src/utils.py"],
+        "resolution": "use_remote",
+        "stagedRef": "refs/heads/main",
+        "data": {
+            "conflictedPaths": ["/src/app.py", "/src/utils.py"],
+            "resolution": "use_remote",
+            "stagedRef": "refs/heads/main",
+        },
+    }
+    turns = sess._expand_openclaw_event(obj, ts_ms=1700000000000)
+    assert len(turns) == 1
+    turn = turns[0]
+    assert turn["role"] == "system"
+    assert "/src/app.py" in turn["content"]
+    assert "use_remote" in turn["content"]
+    assert "refs/heads/main" in turn["content"]
+
+
+def test_expand_workspace_conflict_empty_paths():
+    """Missing paths must not crash — content still meaningful."""
+    sess = _sessions()
+    obj = {"type": "workspace.conflict", "data": {}}
+    turns = sess._expand_openclaw_event(obj, ts_ms=None)
+    assert len(turns) == 1
+    assert "workspace conflict" in turns[0]["content"].lower()
+
+
+def test_model_completed_not_broken():
+    """Regression: model.completed must still produce an assistant turn."""
+    sess = _sessions()
+    obj = {
+        "type": "model.completed",
+        "data": {"completionText": "Hello world"},
+    }
+    turns = sess._expand_openclaw_event(obj, ts_ms=None)
+    assert len(turns) == 1
+    assert turns[0]["role"] == "assistant"
+    assert "Hello world" in turns[0]["content"]


### PR DESCRIPTION
Closes #3928

## What was broken

`workspace.conflict` events (cloud workspace conflicts) were silently dropped from the Sessions transcript view even though `clawmetry/sync.py` (shipped in #4148) already correctly normalises all four type-string aliases to `event_type = "workspace.conflict"` with `conflictedPaths`, `resolution`, and `stagedRef` fields.

Two gates in `routes/sessions.py` blocked them:

1. `_RENDERABLE_TRANSCRIPT_EVENT_TYPES` didn't include `"workspace.conflict"`, so the renderable predicate at line 4246 short-circuited with `continue` before the event reached any further processing.
2. `_expand_openclaw_event` had no arm for `etype == "workspace.conflict"`, so even if gate 1 had passed, the function would have returned `[]` and produced no transcript turns.

## Changes

- **`routes/sessions.py`** (~20 lines): adds `"workspace.conflict"` to `_RENDERABLE_TRANSCRIPT_EVENT_TYPES` and adds a new arm in `_expand_openclaw_event` that formats `conflictedPaths`, `resolution`, and `stagedRef` into a `system`-role inline notification.
- **`tests/test_obs_gap_openclaw_workspace_conflict_4148.py`** (~60 lines): adds 4 new transcript-rendering tests (renderable gate, expand with full data, expand with empty paths, regression guard on `model.completed`). The 8 existing sync-side tests are untouched and continue to pass.

## Test plan

```
python3 -m pytest tests/test_obs_gap_openclaw_workspace_conflict_4148.py -v
# 12 passed
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q5m3YiAcJpfB4X3SfYAtgG)_