### PR TITLE
fix(paywall): stop the price comment and its test contradicting the code

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -9743,10 +9743,17 @@ function _cmShowRuntimePaywall(harness, label) {
     + 'display:flex;align-items:center;justify-content:center;padding:24px;';
 
   // The plan ladder, mirroring the LIVE clawmetry.com/pricing page
-  // (verified 2026-06-09: Free $0 / Starter $9 / Pro $29 / self-hosted via
-  // license key / Enterprise; annual includes the desk device). Prices live
-  // in this ONE object so a reprice is a one-line change here plus the
-  // pricing page. Plain words for someone who has never compared plans.
+  // (Free $0 / Starter $9 / Pro $19 / self-hosted via license key /
+  // Enterprise; annual includes the desk device). Prices live in this ONE
+  // object so a reprice is a one-line change here plus the pricing page.
+  // Plain words for someone who has never compared plans.
+  //
+  // SOURCE OF TRUTH is the cloud Stripe catalog (cloud routes/api.py
+  // _SUB_PRICING: starter 900/9000, pro 1900/19000 cents). This comment
+  // said "Pro $29" for weeks after the values were correctly repriced to
+  // $19. Anyone trusting the prose over the code would have "fixed" a
+  // working paywall back to a price no checkout has ever charged. Read
+  // _SUB_PRICING before touching either.
   var _cmPlanPrices = { starter: '$9', starterYr: '$90', pro: '$19', proYr: '$190' };
   function _tierRow(accent, name, price, desc) {
     return '<div style="margin-bottom:10px;padding:11px 14px;border:1px solid ' + accent + ';'

--- a/tests/test_plan_ladder_modal.py
+++ b/tests/test_plan_ladder_modal.py
@@ -14,11 +14,33 @@ def _modal_block():
     return src[i:i + 6000]
 
 
+def _modal_copy():
+    """The modal block with // comments stripped.
+
+    test_modal_copy_rules asserts things about what the USER READS. Scanning
+    the raw block also scans the comments, so an em dash in a note to the next
+    engineer failed a test about user-facing copy. That is a false positive
+    that trains people to weaken the rule; strip the comments instead."""
+    out = []
+    for line in _modal_block().split("\n"):
+        # Naive but adequate here: these are single-line // notes, and a "//"
+        # inside a string in this block would only ever ADD text to scan.
+        idx = line.find("//")
+        out.append(line if idx == -1 else line[:idx])
+    return "\n".join(out)
+
+
 def test_modal_shows_all_three_tiers_with_prices():
     block = _modal_block()
     assert "'Free', '$0 forever'" in block
-    assert "starter: '$9'" in block and "pro: '$29'" in block, (
-        "prices must live in the single _cmPlanPrices object"
+    # Source of truth is the cloud Stripe catalog (cloud routes/api.py
+    # _SUB_PRICING): starter 900 cents, pro 1900 cents. This assertion said
+    # $29 for weeks after the values were correctly repriced to $19, so the
+    # test was red on main and stopped being a signal. If a reprice lands,
+    # change _SUB_PRICING first, then here.
+    assert "starter: '$9'" in block and "pro: '$19'" in block, (
+        "prices must live in the single _cmPlanPrices object and match "
+        "cloud _SUB_PRICING (starter $9, pro $19)"
     )
     assert "'Starter'" in block and "'Pro'" in block
 
@@ -32,7 +54,7 @@ def test_modal_mentions_self_hosted_license_and_pricing_link():
 
 def test_modal_copy_rules():
     block = _modal_block()
-    assert "—" not in block, "no em-dashes in user-facing copy"
+    assert "—" not in _modal_copy(), "no em-dashes in user-facing copy"
     assert "no credit card" in block
     # The trial CTA + telemetry wiring must survive the redesign.
     assert "_cmRtPaywallCTA" in block and "paywall_view" in block


### PR DESCRIPTION
The runtime paywall ladder was repriced to **Pro $19/$190** — matching the cloud Stripe catalog (`routes/api.py` `_SUB_PRICING`: `1900`/`19000` cents) — but two things were never updated with it.

### 1. The comment contradicted the code it documents

```js
// (verified 2026-06-09: Free $0 / Starter $9 / Pro $29 / ...)
var _cmPlanPrices = { starter: '$9', starterYr: '$90', pro: '$19', proYr: '$190' };
```

Anyone trusting the prose over the code would have "corrected" a working paywall back to a price no checkout has ever charged.

### 2. Its test has been red on main since the reprice

`tests/test_plan_ladder_modal.py` still asserted `pro: '$29'`. A permanently failing test is not a guard, it is noise that trains people to ignore the file. Verified by running it in a pristine worktree at `origin/main`:

```
FAILED tests/test_plan_ladder_modal.py::test_modal_shows_all_three_tiers_with_prices
FAILED tests/test_plan_ladder_modal.py::test_modal_copy_rules
2 failed, 1 passed
```

Both now name cloud `_SUB_PRICING` as the source of truth, so the next reprice has one obvious starting place.

### 3. A false positive in the same file (the second failure above)

`test_modal_copy_rules` asserts "no em-dashes in user-facing copy" but scanned the raw block **including `//` comments**, so an em dash in a note to the next engineer failed a test about what the user reads. That is the kind of false positive that gets a rule weakened rather than obeyed. It now strips comments first, which is what it always claimed to do.

## Result

`3 passed` where main has `2 failed, 1 passed`.

**No behaviour change** — the rendered prices were already correct. This PR makes the comment and the test tell the truth about them.

## Out of scope

`tests/test_tier_pro_paywall_no_flash.py` also has 2 failures on pristine main (alerts editor modal / fail-closed tier check). Unrelated to pricing, deliberately left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)