### PR TITLE
ci(c6): add concurrency group to prevent push-trigger queue flood

### DIFF
--- a/.github/workflows/c6-schedule-heal.yml
+++ b/.github/workflows/c6-schedule-heal.yml
@@ -57,6 +57,13 @@ on:
     - cron: '15 10 * * *'   # 10:15am UTC daily (kept for predictability)
   workflow_dispatch:
 
+# Cancel in-progress push runs when a newer push arrives so only the latest
+# push run executes. Uses a separate group per event type so schedule and
+# workflow_dispatch runs are never cancelled by a push event.
+concurrency:
+  group: c6-schedule-heal-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   issues: write


### PR DESCRIPTION
## Problem

`c6-schedule-heal.yml` has a `push: branches: [main]` trigger. When many PRs are merged to main in quick succession (as happened 2026-07-31 through 2026-08-01), each push queues a new workflow run faster than GitHub can start them. The overflow runs are immediately marked `conclusion: failure` with 0 jobs started -- no job ever ran, but the CI dashboard shows a red failure badge.

Observed: 30+ consecutive push-triggered runs with `conclusion: failure, total_jobs: 0` spanning 2026-07-31T21:53Z through 2026-08-01T08:49Z.

Secondary risk: a flooded run queue for this workflow can cause GitHub to silently skip the 2-hourly schedule triggers (the critical ones that auto-heal C6 and verify branch protection state).

## Fix

Add a `concurrency` block keyed on `event_name + ref`:

```yaml
concurrency:
  group: c6-schedule-heal-${{ github.event_name }}-${{ github.ref }}
  cancel-in-progress: true
```

With this, when multiple pushes arrive:
- The oldest in-progress push run is **cancelled cleanly** (`conclusion: cancelled`) when the next push arrives
- Only the **latest push** actually runs to completion
- Schedule and `workflow_dispatch` runs are in **separate concurrency groups** and are never cancelled by a push event

Net result: 1 push run executes per burst of commits (the most recent), schedule triggers are unaffected, and the CI dashboard shows `cancelled` (expected) instead of `failure` (alarming).

## What this does NOT change

- The 2-hourly schedule trigger and the 10:15 UTC daily trigger are unchanged
- The push guard (`&& github.event_name != 'push'`) on the "Error" step still prevents exit 1 on push events
- C6 branch-protection configuration logic is unchanged

Tracking: #4029

---
_Generated by [Claude Code](https://claude.ai/code/session_01EgTJiBhCYdpHCuogenpcjx)_