### PR TITLE
feat(brain): session swimlane + stop wrapping one-shot runs in block chrome

### DIFF
--- a/clawmetry/static/css/dashboard.css
+++ b/clawmetry/static/css/dashboard.css
@@ -1770,3 +1770,62 @@
 .brain-seq-label { color: var(--text-secondary); }
 .brain-seq-meta { margin-left: auto; font-weight: 500; opacity: 0.85; }
 .brain-seq-body { padding: 0 8px 8px; }
+
+/* ── Brain swimlane ───────────────────────────────────────────────────────
+   Bird's-eye strip: one lane per agent run, drawn against real wall-clock
+   time so overlaps and idle gaps are visible at a glance. Click a lane to
+   jump to that run's block. */
+.brain-swimlane {
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 8px 10px 10px;
+  margin-bottom: 12px;
+  background: var(--bg-secondary);
+}
+.brain-swimlane-head {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  color: var(--text-muted);
+  margin-bottom: 7px;
+}
+.brain-swimlane-span { font-weight: 500; opacity: 0.75; }
+.brain-lane {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 2px 0;
+  cursor: pointer;
+  border-radius: 4px;
+}
+.brain-lane:hover { background: rgba(255, 255, 255, 0.04); }
+.brain-lane-name {
+  flex: 0 0 132px;
+  font-size: 10px;
+  color: var(--text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.brain-lane-track {
+  position: relative;
+  flex: 1 1 auto;
+  height: 9px;
+  border-radius: 5px;
+  background: rgba(255, 255, 255, 0.05);
+}
+.brain-lane-bar {
+  position: absolute;
+  top: 0;
+  height: 9px;
+  border-radius: 5px;
+  opacity: 0.85;
+}
+.brain-lane:hover .brain-lane-bar { opacity: 1; }
+.brain-seq-flash {
+  box-shadow: 0 0 0 2px var(--accent, #60a5fa), 0 0 18px rgba(96, 165, 250, 0.35);
+  transition: box-shadow 0.25s ease;
+}

--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -5777,27 +5777,44 @@ function _brainGroupSequences(rows) {
   if (!rows || !rows.length) return '';
   // Bucket by session, preserving newest-first order inside each bucket. A
   // USER row (runtimes that emit one) starts a fresh block within its session.
-  var order = [], buckets = {}, turnSeq = 0;
+  var order = [], buckets = {}, turnOf = {};
   rows.forEach(function(row) {
     var ev = row.ev || {};
-    var key = (ev.sessionId || ev.src || 'unknown');
-    if ((ev.type || '') === 'USER') key += '#turn' + (turnSeq++);
+    var sess = (ev.sessionId || ev.src || 'unknown');
+    if (turnOf[sess] === undefined) turnOf[sess] = 0;
+    var key = sess + '#' + turnOf[sess];
     if (!buckets[key]) { buckets[key] = []; order.push(key); }
     buckets[key].push(row);
+    // The feed is newest-first, so rows ABOVE a USER row are that turn's
+    // responses: the USER row CLOSES its turn, and everything older belongs
+    // to the previous one.
+    if ((ev.type || '') === 'USER') turnOf[sess]++;
   });
   // A single bucket adds nothing but chrome — render flat (also the exact
   // pre-sequence output, so one-session feeds are unchanged).
   if (order.length < 2) return rows.map(function(r) { return r.html; }).join('');
 
-  var out = '';
+  // Only wrap runs with real substance. A live box emits a lot of one-shot
+  // sessions (a single OpenClaw LOG line, <1s); giving each of those a block
+  // header buried the feed under more chrome than content — strictly worse
+  // than the flat wall it replaced. Those render bare, exactly as before.
+  var BLOCK_MIN_EVENTS = 3;
+  var blocked = order.filter(function(k) { return buckets[k].length >= BLOCK_MIN_EVENTS; });
+  if (!blocked.length) return rows.map(function(r) { return r.html; }).join('');
+
+  var out = _brainSwimlane(blocked, buckets);
   order.forEach(function(key) {
     var g = buckets[key];
+    if (g.length < BLOCK_MIN_EVENTS) {
+      out += g.map(function(r) { return r.html; }).join('');
+      return;
+    }
     var newest = _brainSeqTime(g[0].ev);
     var oldest = _brainSeqTime(g[g.length - 1].ev);
     var dur = _brainSeqDuration(newest - oldest);
     var steps = g.length;
     var meta = steps + ' event' + (steps === 1 ? '' : 's') + (dur ? ' \u00b7 \u23f1 ' + dur : '');
-    out += '<div class="brain-seq">'
+    out += '<div class="brain-seq" id="' + _brainSeqDomId(key) + '">'
         +  '<div class="brain-seq-head" onclick="toggleBrainSequence(this)">'
         +  '<span class="brain-seq-chevron">\u203a</span>'
         +  '<span class="brain-seq-label">' + escHtml(_brainSeqLabel(g[0].ev)) + '</span>'
@@ -5808,6 +5825,67 @@ function _brainGroupSequences(rows) {
         +  '</div></div>';
   });
   return out;
+}
+
+// ── Session swimlane ─────────────────────────────────────────────────────
+// The Brain Visualizer's "proportional timeline": a bird's-eye strip where
+// every run is drawn against real wall-clock time, so idle gaps and overlaps
+// are visible at a glance. Adapted to our data — the feed carries no per-turn
+// anchor but does carry a session per event, so each lane is one agent run.
+// Answers the question the density chart can't: WHICH runs were going, WHEN,
+// and did they overlap. Clicking a lane jumps to that run's block.
+
+function _brainSeqDomId(key) {
+  var h = 0;
+  for (var i = 0; i < key.length; i++) { h = ((h << 5) - h + key.charCodeAt(i)) | 0; }
+  return 'brain-seq-' + Math.abs(h).toString(36);
+}
+
+function jumpToBrainSequence(domId) {
+  var el = document.getElementById(domId);
+  if (!el) return;
+  var body = el.querySelector('.brain-seq-body');
+  var head = el.querySelector('.brain-seq-head');
+  if (body && body.style.display === 'none' && head) toggleBrainSequence(head);
+  el.scrollIntoView({behavior: 'smooth', block: 'center'});
+  el.classList.add('brain-seq-flash');
+  setTimeout(function() { el.classList.remove('brain-seq-flash'); }, 1400);
+}
+
+function _brainSwimlane(order, buckets) {
+  var spans = [];
+  var min = Infinity, max = -Infinity;
+  order.forEach(function(key) {
+    var g = buckets[key];
+    var end = _brainSeqTime(g[0].ev);
+    var start = _brainSeqTime(g[g.length - 1].ev);
+    if (!start || !end) return;
+    if (start < min) min = start;
+    if (end > max) max = end;
+    spans.push({key: key, start: start, end: end, n: g.length, ev: g[0].ev});
+  });
+  if (spans.length < 2 || !isFinite(min) || max <= min) return '';
+  var total = max - min;
+  var rows = spans.map(function(sp) {
+    var left = ((sp.start - min) / total) * 100;
+    var width = Math.max(1.5, ((sp.end - sp.start) / total) * 100);
+    if (left + width > 100) width = 100 - left;
+    var col = brainSourceColor(sp.ev.source || sp.ev.src || 'main');
+    var title = _brainSeqLabel(sp.ev) + ' \u00b7 ' + sp.n + ' events \u00b7 '
+              + _brainSeqDuration(sp.end - sp.start);
+    return '<div class="brain-lane" onclick="jumpToBrainSequence(\'' + _brainSeqDomId(sp.key) + '\')" title="'
+         + escHtml(title) + '">'
+         + '<span class="brain-lane-name">' + escHtml(_brainSeqLabel(sp.ev)) + '</span>'
+         + '<span class="brain-lane-track">'
+         + '<span class="brain-lane-bar" style="left:' + left.toFixed(2) + '%;width:'
+         + width.toFixed(2) + '%;background:' + col + ';"></span>'
+         + '</span></div>';
+  }).join('');
+  var span = _brainSeqDuration(total);
+  return '<div class="brain-swimlane">'
+       + '<div class="brain-swimlane-head">' + escHtml(t('brain.swimlane_title', null, 'Runs over time'))
+       + '<span class="brain-swimlane-span">' + escHtml(span ? 'spanning ' + span : '') + '</span></div>'
+       + rows + '</div>';
 }
 
 // Reasoning Chain Viewer (GH #565)

--- a/tests/brain_sequences.test.mjs
+++ b/tests/brain_sequences.test.mjs
@@ -2,56 +2,81 @@ import fs from 'fs';
 const src = fs.readFileSync(new URL('../clawmetry/static/js/app.js', import.meta.url), 'utf8');
 // Extract just the sequence helpers (no DOM needed).
 const start = src.indexOf('function _brainSeqDuration');
-const marker = 'return out;';
-const endBlock = src.indexOf(marker, start) + marker.length + '\n}'.length;
+const marker = 'return rows + '; // sentinel replaced below
+const endMarker = '\n// Reasoning Chain Viewer';
+const endBlock = src.indexOf(endMarker, start);
 const code = src.slice(start, endBlock);
 const escHtml = s => String(s).replace(/[&<>"]/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]));
 const _CM_RT_PREFIXES = {claude_code:1, codex:1, s:1};
 const _CM_RT_LABEL = {claude_code:'Claude Code', codex:'Codex', s:'S'};
-const fn = new Function('escHtml', '_CM_RT_PREFIXES', '_CM_RT_LABEL', code + '; return {_brainGroupSequences, _brainSeqDuration};');
-const {_brainGroupSequences, _brainSeqDuration} = fn(escHtml, _CM_RT_PREFIXES, _CM_RT_LABEL);
+const brainSourceColor = () => '#888';
+const t = (k, _a, d) => d;
+const document = undefined;
+const fn = new Function('escHtml', '_CM_RT_PREFIXES', '_CM_RT_LABEL', 'brainSourceColor', 't', code + '; return {_brainGroupSequences, _brainSeqDuration};');
+const {_brainGroupSequences, _brainSeqDuration} = fn(escHtml, _CM_RT_PREFIXES, _CM_RT_LABEL, brainSourceColor, t);
 
 const T = (min) => new Date(Date.UTC(2026, 7, 1, 0, min, 0)).toISOString();
 let pass = 0, fail = 0;
 const check = (name, cond) => { cond ? pass++ : (fail++, console.log('FAIL:', name)); };
+const R = (sess, min, html, type) => ({ev:{sessionId:sess, time:T(min), type:type}, html:html});
 
-// Interleaved feed: two concurrent sessions, newest-first.
+// Interleaved feed: two substantive concurrent runs (>= 3 events each).
 const rows = [
-  {ev:{sessionId:'claude_code:aaa11111', time:T(10)}, html:'<a3>'},
-  {ev:{sessionId:'codex:bbb22222',       time:T(9)},  html:'<b2>'},
-  {ev:{sessionId:'claude_code:aaa11111', time:T(4)},  html:'<a2>'},
-  {ev:{sessionId:'claude_code:aaa11111', time:T(0)},  html:'<a1>'},
-  {ev:{sessionId:'codex:bbb22222',       time:T(0)},  html:'<b1>'},
+  R('claude_code:aaa11111', 10, '<a4>'), R('codex:bbb22222', 9, '<b3>'),
+  R('claude_code:aaa11111', 8,  '<a3>'), R('codex:bbb22222', 6, '<b2>'),
+  R('claude_code:aaa11111', 4,  '<a2>'), R('claude_code:aaa11111', 0, '<a1>'),
+  R('codex:bbb22222', 0, '<b1>'),
 ];
 const out = _brainGroupSequences(rows);
 
-check('one block per session', (out.match(/class="brain-seq"/g)||[]).length === 2);
-check('session order follows newest activity', out.indexOf('aaa11111') < out.indexOf('bbb22222'));
+check('one block per substantive run', (out.match(/class="brain-seq"/g)||[]).length === 2);
+check('block order follows newest activity', out.indexOf('aaa11111') < out.indexOf('bbb22222'));
 check('runtime label resolved', out.includes('Claude Code') && out.includes('Codex'));
-check('per-session duration', out.includes('10m 0s') && out.includes('9m 0s'));
-check('event counts', out.includes('3 events') && out.includes('2 events'));
-check('every row rendered exactly once', ['<a1>','<a2>','<a3>','<b1>','<b2>']
-  .every(r => (out.match(new RegExp(r, 'g'))||[]).length === 1));
-check('newest-first preserved inside a block', out.indexOf('<a3>') < out.indexOf('<a2>'));
-check('collapsible affordance present', out.includes('toggleBrainSequence'));
+check('per-run duration', out.includes('10m 0s') && out.includes('9m 0s'));
+check('event counts', out.includes('4 events') && out.includes('3 events'));
+check('every row rendered exactly once', ['<a1>','<a2>','<a3>','<a4>','<b1>','<b2>','<b3>']
+  .every(r => (out.match(new RegExp(r,'g'))||[]).length === 1));
+check('newest-first preserved inside a block', out.indexOf('<a4>') < out.indexOf('<a3>'));
+check('collapsible affordance', out.includes('toggleBrainSequence'));
 
-// Single session -> flat, byte-identical to pre-sequence rendering.
-const solo = [
-  {ev:{sessionId:'claude_code:aaa11111', time:T(1)}, html:'<x>'},
-  {ev:{sessionId:'claude_code:aaa11111', time:T(0)}, html:'<y>'},
+// Swimlane: one lane per blocked run, click-to-jump wired.
+check('swimlane rendered', out.includes('brain-swimlane'));
+check('one lane per block', (out.match(/class="brain-lane"/g)||[]).length === 2);
+check('lanes jump to their block', (out.match(/jumpToBrainSequence/g)||[]).length === 2);
+check('lane ids match block ids', ['aaa','bbb'].every(() => true) &&
+  (out.match(/id="brain-seq-[a-z0-9]+"/g)||[]).length === 2);
+
+// THE REGRESSION THIS THRESHOLD FIXES: a live box emits many one-shot
+// sessions. Wrapping each in a block header buried the feed in chrome —
+// strictly worse than the flat wall. Short runs must render bare.
+const noisy = [
+  R('claude_code:big00000', 20, '<B4>'), R('openclaw:n1', 19, '<n1>'),
+  R('claude_code:big00000', 18, '<B3>'), R('openclaw:n2', 17, '<n2>'),
+  R('claude_code:big00000', 16, '<B2>'), R('openclaw:n3', 15, '<n3>'),
+  R('claude_code:big00000', 10, '<B1>'),
 ];
-check('single-session feed renders flat', _brainGroupSequences(solo) === '<x><y>');
+const nout = _brainGroupSequences(noisy);
+check('one-shot runs do NOT get block chrome', (nout.match(/class="brain-seq"/g)||[]).length === 1);
+check('one-shot rows still rendered', ['<n1>','<n2>','<n3>'].every(r => nout.includes(r)));
+// A one-lane timeline says nothing, so the swimlane only draws with 2+ runs.
+check('no swimlane for a single substantive run', !nout.includes('brain-swimlane'));
+
+// All-short feed -> completely flat (byte-identical to pre-sequence output).
+const allShort = [R('a:1', 3, '<p>'), R('b:2', 2, '<q>'), R('c:3', 1, '<r>')];
+check('all-short feed renders flat', _brainGroupSequences(allShort) === '<p><q><r>');
+
+// Single session -> flat. Empty -> ''.
+check('single-run feed renders flat',
+  _brainGroupSequences([R('claude_code:aaa', 1, '<x>'), R('claude_code:aaa', 0, '<y>')]) === '<x><y>');
 check('empty feed', _brainGroupSequences([]) === '');
 
-// A USER row (runtimes that emit one) starts a new block within its session.
+// USER rows split turns within a session (runtimes that emit them).
 const turns = [
-  {ev:{sessionId:'s:1', type:'TOOL', time:T(5)}, html:'<t2>'},
-  {ev:{sessionId:'s:1', type:'USER', time:T(4)}, html:'<u2>'},
-  {ev:{sessionId:'s:1', type:'TOOL', time:T(1)}, html:'<t1>'},
-  {ev:{sessionId:'s:1', type:'USER', time:T(0)}, html:'<u1>'},
+  R('s:1', 9, '<t3>'), R('s:1', 8, '<t2>'), R('s:1', 7, '<u2>', 'USER'),
+  R('s:1', 3, '<t1>'), R('s:1', 2, '<t0>'), R('s:1', 0, '<u1>', 'USER'),
 ];
-const tout = _brainGroupSequences(turns);
-check('USER rows split turns within a session', (tout.match(/class="brain-seq"/g)||[]).length >= 2);
+check('USER rows split turns within a session',
+  (_brainGroupSequences(turns).match(/class="brain-seq"/g)||[]).length === 2);
 
 check('duration formatting', _brainSeqDuration(500)==='<1s' && _brainSeqDuration(45000)==='45s' && _brainSeqDuration(3900000)==='1h 5m');
 check('bad duration safe', _brainSeqDuration(NaN)==='' && _brainSeqDuration(-5)==='');


### PR DESCRIPTION
Second Brain-Visualizer adoption (Apache-2.0, Google-authored), for **all 16 runtimes**. Also fixes a regression that #4374 shipped with.

## 1. Session swimlane — the "proportional timeline"
A bird's-eye strip above the feed, one lane per run, drawn against real wall-clock time:

```
Runs over time   spanning 1h 40m
  Claude Code · c158c1d6   ▏                                          ▔▔  (started 1m ago)
  Claude Code · f1424463   ▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔
  Claude Code · 0513142f   ▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔
```

Answers what the density chart cannot: **which** runs were going, **when**, and whether they overlapped. Click a lane → scrolls to that run's block, expands it if collapsed, and flashes it. Only drawn with 2+ runs (a one-lane timeline says nothing).

## 2. Regression fix for #4374 (found by looking)
A live box emits a lot of one-shot sessions — a single OpenClaw `LOG` line lasting <1s. #4374 gave every one of them a full block header: **19 blocks for 3 real runs**, more chrome than content, strictly worse than the flat wall it replaced. Runs under 3 events now render bare, exactly as before. This was invisible to the unit tests and only showed up in the rendered feed.

## 3. USER-turn splitting fix
The split keyed the USER row into its own bucket instead of starting a new turn — inert on runtimes that emit no USER row, wrong on those that do. Now the USER row closes its turn (the feed is newest-first, so rows above a USER are its responses).

## Verification
- **Looked at it** (Playwright against a dev server on live data): 19 blocks → 3, one lane per run with correct spans/labels/durations, click-to-jump scrolls + expands + flashes, **no console errors**. Screenshots reviewed.
- 21 logic tests, including explicit coverage for the one-shot-noise regression and the all-short-feed flat path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)