### PR TITLE
fix(cloud-contract): Context tab key is context-economics after the #4375 merge

### DIFF
--- a/tests/e2e/cloud-contract.mjs
+++ b/tests/e2e/cloud-contract.mjs
@@ -310,7 +310,10 @@ async function testNormalUser() {
     { label: 'Approvals',     key: 'approvals' },
     { label: 'Alerts',        key: 'alerts' },
     { label: 'Notifications', key: 'notifications' },
-    { label: 'Context',       key: 'context' },
+    // "LLM Context" merged into Context usage (#4375, 0.12.617): the old
+    // data-tab="context" nav item is gone; the surviving tab is
+    // context-economics (the legacy .nav-tab fallback label stays "Context").
+    { label: 'Context',       key: 'context-economics' },
     { label: 'Tokens',        key: 'usage' },
     { label: 'Crons',         key: 'crons' },
     { label: 'Memory',        key: 'memory' },


### PR DESCRIPTION
The cloud deploy gate clones tests/e2e/cloud-contract.mjs from OSS main and asserts every free-tier tab is visible on the candidate revision. #4375 removed the old data-tab="context" nav item (LLM Context merged into Context usage), so the gate did its job and blocked promotion of the clawmetry-cloud 0.12.617 pin: 56 passed, 1 failed on "Context: tab visible", traffic stayed on the previous revision.

One-line fix: the contract's Context entry now resolves data-tab="context-economics" (the surviving tab). The legacy .nav-tab:has-text("Context") fallback still covers pre-IA cloud pins, whose legacy strip keeps the "Context" label.

Class sweep done: no other OSS or clawmetry-cloud pipeline file asserts the removed tab (the v2/dist bundle hits are minified React internals; cloud routes' 'context' fields are approval payloads).

After merge, re-running the failed Deploy to Cloud Run run picks the updated spec up automatically (it clones OSS main at run time).

🤖 Generated with [Claude Code](https://claude.com/claude-code)