### PR TITLE
feat(entitlement): has_features / has_runtimes plural scalars + endpoints

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -5601,6 +5601,92 @@ def has_node_count(count) -> bool:
         return False
 
 
+def has_features(features) -> bool:
+    """Boolean-gate scalar: does the CURRENT install allow **all** ``features``?
+
+    Plural sibling of :func:`has_feature`. A paywall tile that gates on a
+    bundle ("you are using fleet + otel_export + sso") needs one boolean off
+    the whole set; this scalar folds the per-item :func:`has_feature` walk in
+    one place so callers don't reinvent the AND-chain (and so the feature axis
+    reads symmetric to :func:`min_tier_for_features`: min-tier picks the
+    most-constraining item, this one picks the most-restrictive grant).
+
+    Fold rule: returns ``True`` iff :func:`has_feature` returns ``True`` for
+    **every** item in the iterable, i.e. the tightest single-item denial wins.
+    Consequences of that fold, all deliberate:
+
+    * Empty / ``None`` iterable -- returns ``False``. The vacuous-truth answer
+      would silently render "granted" on a caller who forgot to pass the
+      bundle, which is exactly the callsite-typo posture the singular helper
+      catches with its empty-id ``False``. Mirrors the ``None`` return of
+      :func:`min_tier_for_features` on empty (nothing to compute), collapsed
+      to a strict-``False`` for the boolean seat.
+    * Any unknown / empty / non-string item -- returns ``False``. The singular
+      :func:`has_feature` fails-closed on typos so the bundle fold inherits
+      that: ``has_features(["fleet", "Fleeet"])`` is ``False`` even in grace,
+      surfacing the typo instead of silently granting.
+    * Grace pass-through: while ``ent.grace`` is ``True`` and every item is a
+      known id, the scalar reports ``True`` (each :func:`has_feature` reports
+      ``True`` in grace), so wiring this into a gate today changes NO current
+      behavior.
+    * Non-iterable input (int, ``None`` handled above, arbitrary object) --
+      returns ``False`` without raising.
+
+    Never raises: a delegate failure logs a warning and returns ``False`` so
+    a caller can bind this into a boolean AND-chain without a try/except.
+    """
+    try:
+        if features is None:
+            return False
+        items = list(features)
+    except TypeError:
+        return False
+    if not items:
+        return False
+    try:
+        for f in items:
+            if not has_feature(f):
+                return False
+        return True
+    except Exception as exc:
+        logger.warning("entitlements: has_features(%r) failed: %s", features, exc)
+        return False
+
+
+def has_runtimes(runtimes) -> bool:
+    """Boolean-gate scalar: does the CURRENT install allow **all** ``runtimes``?
+
+    Runtime-axis twin of :func:`has_features`. Delegates to :func:`has_runtime`
+    per item so runtime-alias canonicalisation (``claude-code`` ->
+    ``claude_code``) and the same unknown/empty/non-string strict-``False``
+    posture are inherited from the singular helper.
+
+    Fold semantics mirror :func:`has_features` exactly: ``True`` iff every
+    item is granted; empty / ``None`` iterable / non-iterable input /
+    any-unknown-item all collapse to ``False``. Grace pass-through applies
+    per item, so a fully-known bundle reads ``True`` in grace and wires in as
+    a no-op behavior change today.
+
+    Never raises: delegate failure -> logged warning -> ``False``.
+    """
+    try:
+        if runtimes is None:
+            return False
+        items = list(runtimes)
+    except TypeError:
+        return False
+    if not items:
+        return False
+    try:
+        for rt in items:
+            if not has_runtime(rt):
+                return False
+        return True
+    except Exception as exc:
+        logger.warning("entitlements: has_runtimes(%r) failed: %s", runtimes, exc)
+        return False
+
+
 def _tier_row(tier: str) -> dict:
     return {
         "id": tier,

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -3924,6 +3924,184 @@ def api_entitlement_has_node_count():
         return jsonify(_has_node_count_fallback(count_raw))
 
 
+def _has_bundle_fallback(axis: str, tokens: list[str]) -> dict:
+    """OSS-free / never-5xx envelope for the plural ``/api/entitlement/has-features``
+    and ``/api/entitlement/has-runtimes`` endpoints.
+
+    Mirrors the fail-closed posture the singular ``/api/entitlement/has-feature``
+    / ``/has-runtime`` and ``/api/entitlement/has-channel-count`` fallbacks
+    carry: on a resolver blowup the endpoint still returns 200 with the same
+    envelope shape as the happy path, but with ``has_<axis>``/``allowed`` False
+    so a paywall tile that lost the resolver doesn't silently grant a bundle
+    it can't evaluate. ``tokens`` echoes the caller's raw input list into
+    ``unknown`` so a diagnostics tooltip can still surface the offending set.
+    """
+    key = f"has_{axis}"
+    return {
+        axis: [],
+        "unknown": list(tokens),
+        "kind": axis,
+        "count": 0,
+        key: False,
+        "allowed": False,
+        "required_tier": None,
+        "required_tier_label": None,
+        "required_tier_rank": -1,
+        "current_tier": "oss",
+        "current_tier_rank": 0,
+        "grace": True,
+        "enforced": False,
+        "upgrade_required": False,
+    }
+
+
+def _has_bundle_body(axis: str) -> dict:
+    """Happy-path body builder for ``/api/entitlement/has-features`` /
+    ``/api/entitlement/has-runtimes``.
+
+    Splits the caller's CSV into ``known`` / ``unknown`` against the
+    entitlement's ``ALL_FEATURES`` / ``ALL_RUNTIMES`` id set (with runtime-
+    alias canonicalisation for the runtimes axis) so the UI can surface a
+    diagnostics list of tokens the resolver couldn't place. The scalar
+    boolean ``has_<axis>`` is delegated to :func:`has_features` /
+    :func:`has_runtimes` against the ORIGINAL CSV -- unknown tokens
+    collapse the bundle to ``False`` there so the endpoint stays byte-parity
+    with the scalar's typo-catches-at-callsite posture (a UI that binds
+    ``allowed`` off this URL can't accidentally render "granted" for a
+    typo'd feature id). ``required_tier`` is resolved against the ``known``
+    subset for parity with the ``/api/entitlement/min-tier-for-<axis>``
+    envelope (which does the same known/unknown split).
+    """
+    from clawmetry import entitlements as _ent
+
+    param = "features" if axis == "features" else "runtimes"
+    tokens = _parse_csv_arg(param)
+
+    known: list[str] = []
+    unknown: list[str] = []
+    if axis == "features":
+        for fid in tokens:
+            if fid in _ent.ALL_FEATURES:
+                if fid not in known:
+                    known.append(fid)
+            elif fid not in unknown:
+                unknown.append(fid)
+        required = _ent.min_tier_for_features(known) if known else None
+    else:
+        for rid_raw in tokens:
+            rid = _ent.canonical_runtime(rid_raw) or rid_raw
+            if rid in _ent.ALL_RUNTIMES:
+                if rid not in known:
+                    known.append(rid)
+            elif rid not in unknown:
+                unknown.append(rid_raw)
+        required = _ent.min_tier_for_runtimes(known) if known else None
+
+    # Scalar boolean: only ``True`` when every input token resolved to a
+    # granted known id (delegates to the plural scalars on the canonicalised
+    # ``known`` list). ``unknown`` tokens collapse the bundle to ``False``
+    # for the same typo-catches-at-callsite reason the singular
+    # ``has_feature("BOGUS")`` returns ``False`` -- a UI can still surface
+    # the offending set via the ``unknown`` slot.
+    if tokens and not unknown and known:
+        has_flag = (
+            _ent.has_features(known)
+            if axis == "features"
+            else _ent.has_runtimes(known)
+        )
+    else:
+        has_flag = False
+
+    env = _resolver_envelope(_ent)
+    cur_rank = env["current_tier_rank"]
+    req_rank = _ent.tier_rank(required) if required else -1
+    required_label = _ent.tier_label(required) if required else None
+    return {
+        axis: known,
+        "unknown": unknown,
+        "kind": axis,
+        "count": len(known),
+        f"has_{axis}": bool(has_flag),
+        "allowed": bool(has_flag),
+        "required_tier": required,
+        "required_tier_label": required_label,
+        "required_tier_rank": req_rank,
+        "current_tier": env["current_tier"],
+        "current_tier_rank": cur_rank,
+        "grace": env["grace"],
+        "enforced": env["enforced"],
+        "upgrade_required": bool(required) and req_rank > cur_rank,
+    }
+
+
+@bp_entitlement.route("/api/entitlement/has-features")
+def api_entitlement_has_features():
+    """``GET /api/entitlement/has-features?features=a,b,c`` -- plural
+    boolean-gate scalar sibling of ``/api/entitlement/has-feature?feature=<id>``.
+
+    Returns ONE boolean (``has_features``) plus the surrounding tier envelope
+    (``current_tier``, ``required_tier``, ``upgrade_required``) and a
+    known/unknown split of the caller's CSV, so a paywall tile that gates on
+    a bundle (``fleet + otel_export + sso -- Available in Enterprise``) can
+    bind ``allowed`` directly off this URL without parsing the fuller
+    ``/api/entitlement/min-tier-for-features`` body plus a follow-up hit to
+    the singular ``/has-feature`` endpoint per item.
+
+    Grace-safe: while :attr:`Entitlement.grace` is ``True`` (the current
+    rollout state) ``has_features`` reports ``True`` for every fully-known
+    bundle, so wiring this into a gate today changes NO current behavior.
+    Unknown tokens collapse the bundle to ``has_features=False`` (matches
+    the scalar's typo-catches-at-callsite posture -- a UI can still show
+    ``unknown`` in a diagnostics tooltip). Missing / blank / all-unknown
+    CSV -> 200 with ``has_features=False``, ``features=[]``, ``count=0``
+    (never 4xx, matching the singular ``/has-feature`` envelope). Never
+    5xx.
+
+    Envelope shape (14 keys, byte-stable across every input branch)::
+
+        {
+          "features":            ["fleet", "sso"],   # known ids only, dedup, first-seen order
+          "unknown":             ["bogus"],           # tokens not in ALL_FEATURES, echoed raw
+          "kind":                "features",
+          "count":               2,                   # len(features)
+          "has_features":        false,               # scalar over the ORIGINAL CSV (unknowns collapse)
+          "allowed":             false,               # alias of has_features
+          "required_tier":       "enterprise" | null, # min_tier_for_features(known); null if empty
+          "required_tier_label": "Enterprise" | null,
+          "required_tier_rank":  <int>,               # -1 when required_tier is null
+          "current_tier":        "oss",
+          "current_tier_rank":   0,
+          "grace":               true,
+          "enforced":            false,
+          "upgrade_required":    <bool>               # required_rank > current_rank
+        }
+    """
+    try:
+        return jsonify(_has_bundle_body("features"))
+    except Exception as exc:
+        logger.warning("api_entitlement_has_features: error: %s", exc)
+        return jsonify(_has_bundle_fallback("features", _parse_csv_arg("features")))
+
+
+@bp_entitlement.route("/api/entitlement/has-runtimes")
+def api_entitlement_has_runtimes():
+    """``GET /api/entitlement/has-runtimes?runtimes=x,y,z`` -- runtime-axis
+    twin of ``/api/entitlement/has-features``.
+
+    Same 14-key envelope with ``runtimes`` / ``has_runtimes`` in the
+    axis-specific slots. Runtime-alias canonicalisation (``claude-code`` ->
+    ``claude_code``) is applied per token before the known/unknown split so
+    a caller doesn't need to normalise before hitting the URL. Grace
+    pass-through, unknown-collapses-bundle, never-4xx, never-5xx
+    guarantees mirror the features sibling exactly.
+    """
+    try:
+        return jsonify(_has_bundle_body("runtimes"))
+    except Exception as exc:
+        logger.warning("api_entitlement_has_runtimes: error: %s", exc)
+        return jsonify(_has_bundle_fallback("runtimes", _parse_csv_arg("runtimes")))
+
+
 @bp_entitlement.route("/api/entitlement/lock-reason")
 def api_entitlement_lock_reason():
     try:

--- a/tests/test_entitlement_has_features_has_runtimes.py
+++ b/tests/test_entitlement_has_features_has_runtimes.py
@@ -1,0 +1,649 @@
+"""Tests for the plural ``has_features`` / ``has_runtimes`` boolean-gate
+scalar helpers and their paired ``/api/entitlement/has-features`` /
+``/api/entitlement/has-runtimes`` endpoints.
+
+Plural siblings of ``has_feature`` / ``has_runtime`` on the same axis: where
+the singular scalars answer "does the CURRENT resolved entitlement grant
+THIS id?", these fold the answer across a whole bundle -- ``True`` iff every
+item is granted (the tightest single-item denial wins). One boolean off the
+whole set plus a surrounding tier envelope so a paywall tile gating on a
+mixed bundle (``fleet + otel_export + sso``) can bind ``allowed`` directly
+off ONE URL instead of parsing the fuller ``/api/entitlement/min-tier-for-
+features`` body plus a follow-up hit to ``/has-feature`` per item.
+
+This file pins:
+
+1. Scalar behaviour under grace vs enforce for empty / non-iterable /
+   None / unknown / mixed known+unknown / all-free / all-paid bundles.
+2. Endpoint envelope shape parity (fixed 14-key set) across every input
+   branch so a frontend can bind fields off the URL without a branch on
+   the underlying resolver state.
+3. Never-5xx via monkeypatched blowup on both endpoints.
+4. Cross-consistency with the sibling
+   ``/api/entitlement/min-tier-for-features`` /
+   ``/min-tier-for-runtimes`` endpoints -- same ``required_tier`` /
+   ``current_tier`` for the same bundle, so a UI wiring both URLs into
+   the same paywall tile can't see inconsistent tier state.
+5. The grace-mode invariant: ``has_features`` / ``has_runtimes`` report
+   ``True`` for every fully-known bundle while ``grace`` is on, so
+   wiring these into a gate today changes NO current behavior.
+6. Scalar-vs-endpoint parity: the URL ``has_<axis>`` value equals the
+   module-level scalar byte-for-byte on the same input.
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+# ── Fixtures ───────────────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    """Fresh entitlements module in OSS-free-grace mode -- same fixture the
+    sibling ``test_entitlement_has_feature_has_runtime.py`` uses so the
+    plural-helper assertions here reproduce the same install state the
+    singular ones are pinned against."""
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def enforced(monkeypatch, tmp_path):
+    """Enforcement-on fixture: ``CLAWMETRY_ENFORCE=1`` flips ``ent.grace``
+    off so the grace pass-through collapses and paid axes report their
+    post-enforce answers."""
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    importlib.reload(e)
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# ── Envelope shape ────────────────────────────────────────────────────────────────────────
+
+_FEATURES_KEYS = {
+    "features",
+    "unknown",
+    "kind",
+    "count",
+    "has_features",
+    "allowed",
+    "required_tier",
+    "required_tier_label",
+    "required_tier_rank",
+    "current_tier",
+    "current_tier_rank",
+    "grace",
+    "enforced",
+    "upgrade_required",
+}
+_RUNTIMES_KEYS = {
+    "runtimes",
+    "unknown",
+    "kind",
+    "count",
+    "has_runtimes",
+    "allowed",
+    "required_tier",
+    "required_tier_label",
+    "required_tier_rank",
+    "current_tier",
+    "current_tier_rank",
+    "grace",
+    "enforced",
+    "upgrade_required",
+}
+
+
+def _get_json(client, url: str) -> dict:
+    resp = client.get(url)
+    assert resp.status_code == 200, url
+    return resp.get_json()
+
+
+# ── has_features scalar ──────────────────────────────────────────────────────────────────────────
+
+
+def test_has_features_all_free_is_true(ent):
+    """A bundle of ONLY free features reports True regardless of rollout
+    state -- the OSS-free entitlement grants ``FREE_FEATURES``
+    unconditionally per item, so the AND-fold is True."""
+    free = sorted(ent.FREE_FEATURES)
+    assert ent.has_features(free) is True
+
+
+def test_has_features_all_paid_is_true_in_grace(ent):
+    """Grace invariant on the plural fold: while ``ent.grace`` is True,
+    every paid feature reports True per item, so the AND-fold is True."""
+    paid = sorted(ent.PAID_FEATURES)
+    assert ent.has_features(paid) is True
+
+
+def test_has_features_all_paid_is_false_after_enforcement(enforced):
+    """Post-enforcement, any paid feature on OSS collapses the fold to
+    False -- the tightest single-item denial wins."""
+    paid = sorted(enforced.PAID_FEATURES)
+    assert enforced.has_features(paid) is False
+
+
+def test_has_features_mixed_free_and_paid_is_true_in_grace(ent):
+    """A mixed bundle (free + paid) reports True in grace because each
+    per-item ``has_feature`` reports True."""
+    mixed = [next(iter(ent.FREE_FEATURES)), next(iter(ent.PAID_FEATURES))]
+    assert ent.has_features(mixed) is True
+
+
+def test_has_features_mixed_free_and_paid_is_false_after_enforcement(enforced):
+    """Post-enforcement, a mixed bundle collapses to False -- the paid
+    item denies the whole fold."""
+    mixed = [
+        next(iter(enforced.FREE_FEATURES)),
+        next(iter(enforced.PAID_FEATURES)),
+    ]
+    assert enforced.has_features(mixed) is False
+
+
+def test_has_features_any_unknown_is_false_in_grace(ent):
+    """Even in grace, an unknown item collapses the fold to False --
+    ``has_feature("bogus")`` is False and the AND-fold inherits that. Catches
+    typos at the callsite before enforcement flips on."""
+    assert ent.has_features(["fleet", "bogus_id"]) is False
+    assert ent.has_features(["bogus_id"]) is False
+
+
+def test_has_features_all_unknown_is_false(ent):
+    """A bundle of only-unknown items reports False."""
+    assert ent.has_features(["bogus_a", "bogus_b"]) is False
+
+
+def test_has_features_empty_iterable_is_false(ent):
+    """Empty iterable collapses to False (strict callsite-typo posture) --
+    matches the singular ``has_feature("")`` empty-input False."""
+    assert ent.has_features([]) is False
+    assert ent.has_features(()) is False
+    assert ent.has_features(iter(())) is False
+
+
+def test_has_features_none_is_false(ent):
+    """``None`` collapses to False without raising."""
+    assert ent.has_features(None) is False  # type: ignore[arg-type]
+
+
+def test_has_features_non_iterable_is_false(ent):
+    """Non-iterable input (int, arbitrary object) collapses to False."""
+    assert ent.has_features(123) is False  # type: ignore[arg-type]
+    assert ent.has_features(object()) is False  # type: ignore[arg-type]
+
+
+def test_has_features_case_insensitive(ent):
+    """Casing / whitespace on known ids normalises via the per-item
+    delegate."""
+    known = next(iter(sorted(ent.PAID_FEATURES)))
+    assert ent.has_features([known.upper(), f"  {known}  "]) is True
+
+
+def test_has_features_never_raises_on_resolver_blowup(monkeypatch, ent):
+    """Any blowup in the underlying delegate collapses the fold to
+    False so a caller can bind this into a boolean AND-chain without a
+    try/except."""
+    def _boom(*a, **kw):
+        raise RuntimeError("resolver blew up")
+
+    monkeypatch.setattr(ent, "get_entitlement", _boom)
+    for arg in [
+        ["fleet"],
+        ["fleet", "nemo_governance"],
+        [],
+        None,
+        123,
+    ]:
+        assert ent.has_features(arg) is False  # type: ignore[arg-type]
+
+
+# ── has_runtimes scalar ──────────────────────────────────────────────────────────────────────────
+
+
+def test_has_runtimes_all_free_is_true(ent):
+    """A bundle of ONLY free runtimes reports True regardless of rollout
+    state."""
+    free = sorted(ent.FREE_RUNTIMES)
+    assert ent.has_runtimes(free) is True
+
+
+def test_has_runtimes_all_paid_is_true_in_grace(ent):
+    """Grace invariant on the runtime axis."""
+    paid = sorted(ent.PAID_RUNTIMES)
+    assert ent.has_runtimes(paid) is True
+
+
+def test_has_runtimes_all_paid_is_false_after_enforcement(enforced):
+    """Post-enforcement, any paid runtime on OSS collapses the fold."""
+    paid = sorted(enforced.PAID_RUNTIMES)
+    assert enforced.has_runtimes(paid) is False
+
+
+def test_has_runtimes_mixed_free_and_paid_is_false_after_enforcement(enforced):
+    """Post-enforcement, a mixed bundle collapses to False."""
+    mixed = [
+        next(iter(enforced.FREE_RUNTIMES)),
+        next(iter(enforced.PAID_RUNTIMES)),
+    ]
+    assert enforced.has_runtimes(mixed) is False
+
+
+def test_has_runtimes_any_unknown_is_false(ent):
+    """Unknown runtime id in the bundle collapses to False even in grace."""
+    assert ent.has_runtimes(["openclaw", "bogus_runtime"]) is False
+
+
+def test_has_runtimes_empty_iterable_is_false(ent):
+    """Empty iterable collapses to False."""
+    assert ent.has_runtimes([]) is False
+
+
+def test_has_runtimes_none_is_false(ent):
+    assert ent.has_runtimes(None) is False  # type: ignore[arg-type]
+
+
+def test_has_runtimes_non_iterable_is_false(ent):
+    assert ent.has_runtimes(42) is False  # type: ignore[arg-type]
+
+
+def test_has_runtimes_case_insensitive(ent):
+    """Casing / whitespace normalises via ``has_runtime``."""
+    assert ent.has_runtimes(["OPENCLAW", "  nemoclaw  "]) is True
+
+
+def test_has_runtimes_never_raises_on_resolver_blowup(monkeypatch, ent):
+    def _boom(*a, **kw):
+        raise RuntimeError("resolver blew up")
+
+    monkeypatch.setattr(ent, "get_entitlement", _boom)
+    for arg in [["openclaw"], ["openclaw", "claude_code"], [], None]:
+        assert ent.has_runtimes(arg) is False  # type: ignore[arg-type]
+
+
+# ── /api/entitlement/has-features envelope ────────────────────────────────────────────────
+
+
+def test_has_features_endpoint_all_free_shape(client):
+    body = _get_json(
+        client, "/api/entitlement/has-features?features=nemo_governance"
+    )
+    assert set(body.keys()) == _FEATURES_KEYS
+    assert body["features"] == ["nemo_governance"]
+    assert body["unknown"] == []
+    assert body["kind"] == "features"
+    assert body["count"] == 1
+    assert body["has_features"] is True
+    assert body["allowed"] is True
+    assert body["required_tier"] == "oss"
+    assert body["required_tier_label"] == "OSS"
+    assert body["required_tier_rank"] == 0
+    assert body["current_tier"] == "oss"
+    assert body["current_tier_rank"] == 0
+    assert body["grace"] is True
+    assert body["enforced"] is False
+    assert body["upgrade_required"] is False
+
+
+def test_has_features_endpoint_mixed_paid_grace_shape(client):
+    """Mixed free+paid bundle under grace: has_features=True (grace grants
+    every known id) but upgrade_required=True (post-enforce needs Starter)."""
+    body = _get_json(
+        client,
+        "/api/entitlement/has-features?features=nemo_governance,fleet",
+    )
+    assert set(body.keys()) == _FEATURES_KEYS
+    assert body["features"] == ["nemo_governance", "fleet"]
+    assert body["unknown"] == []
+    assert body["count"] == 2
+    assert body["has_features"] is True
+    assert body["allowed"] is True
+    assert body["required_tier"] == "cloud_starter"
+    assert body["required_tier_label"] == "Starter"
+    assert body["required_tier_rank"] == 1
+    assert body["current_tier"] == "oss"
+    assert body["upgrade_required"] is True
+
+
+def test_has_features_endpoint_unknown_collapses_bundle(client):
+    """An unknown token collapses has_features to False even in grace,
+    but the known part still routes ``required_tier`` correctly."""
+    body = _get_json(
+        client, "/api/entitlement/has-features?features=fleet,bogus_id"
+    )
+    assert set(body.keys()) == _FEATURES_KEYS
+    assert body["features"] == ["fleet"]
+    assert body["unknown"] == ["bogus_id"]
+    assert body["count"] == 1
+    assert body["has_features"] is False
+    assert body["allowed"] is False
+    assert body["required_tier"] == "cloud_starter"
+    assert body["upgrade_required"] is True
+
+
+def test_has_features_endpoint_all_unknown_shape(client):
+    body = _get_json(
+        client, "/api/entitlement/has-features?features=bogus_a,bogus_b"
+    )
+    assert set(body.keys()) == _FEATURES_KEYS
+    assert body["features"] == []
+    assert body["unknown"] == ["bogus_a", "bogus_b"]
+    assert body["count"] == 0
+    assert body["has_features"] is False
+    assert body["required_tier"] is None
+    assert body["required_tier_label"] is None
+    assert body["required_tier_rank"] == -1
+    assert body["upgrade_required"] is False
+
+
+def test_has_features_endpoint_missing_param_shape(client):
+    body = _get_json(client, "/api/entitlement/has-features")
+    assert set(body.keys()) == _FEATURES_KEYS
+    assert body["features"] == []
+    assert body["unknown"] == []
+    assert body["count"] == 0
+    assert body["has_features"] is False
+    assert body["allowed"] is False
+
+
+def test_has_features_endpoint_blank_param_shape(client):
+    body = _get_json(client, "/api/entitlement/has-features?features=")
+    assert set(body.keys()) == _FEATURES_KEYS
+    assert body["features"] == []
+    assert body["unknown"] == []
+    assert body["has_features"] is False
+
+
+def test_has_features_endpoint_whitespace_and_dupe_stripping(client):
+    """CSV normalisation strips whitespace, drops empties, dedupes
+    (first-seen order preserved) via ``_parse_csv_arg`` -- same rule the
+    ``/api/entitlement/min-tier-for-features`` endpoint uses."""
+    body = _get_json(
+        client,
+        "/api/entitlement/has-features?features=%20fleet%20,,fleet,%20sso%20",
+    )
+    assert body["features"] == ["fleet", "sso"]
+    assert body["unknown"] == []
+    assert body["count"] == 2
+
+
+def test_has_features_endpoint_case_normalises(client):
+    body = _get_json(client, "/api/entitlement/has-features?features=Fleet,SSO")
+    assert body["features"] == ["fleet", "sso"]
+    assert body["has_features"] is True
+
+
+# ── /api/entitlement/has-runtimes envelope ────────────────────────────────────────────────
+
+
+def test_has_runtimes_endpoint_all_free_shape(client):
+    body = _get_json(
+        client, "/api/entitlement/has-runtimes?runtimes=openclaw,nemoclaw"
+    )
+    assert set(body.keys()) == _RUNTIMES_KEYS
+    assert body["runtimes"] == ["openclaw", "nemoclaw"]
+    assert body["unknown"] == []
+    assert body["kind"] == "runtimes"
+    assert body["count"] == 2
+    assert body["has_runtimes"] is True
+    assert body["allowed"] is True
+    assert body["required_tier"] == "oss"
+    assert body["required_tier_rank"] == 0
+    assert body["upgrade_required"] is False
+
+
+def test_has_runtimes_endpoint_paid_grace_shape(client):
+    body = _get_json(
+        client, "/api/entitlement/has-runtimes?runtimes=claude_code,codex"
+    )
+    assert set(body.keys()) == _RUNTIMES_KEYS
+    assert body["runtimes"] == ["claude_code", "codex"]
+    assert body["unknown"] == []
+    assert body["count"] == 2
+    assert body["has_runtimes"] is True
+    assert body["required_tier"] == "cloud_starter"
+    assert body["required_tier_label"] == "Starter"
+    assert body["required_tier_rank"] == 1
+    assert body["upgrade_required"] is True
+
+
+def test_has_runtimes_endpoint_unknown_collapses_bundle(client):
+    body = _get_json(
+        client,
+        "/api/entitlement/has-runtimes?runtimes=openclaw,bogus_runtime",
+    )
+    assert set(body.keys()) == _RUNTIMES_KEYS
+    assert body["runtimes"] == ["openclaw"]
+    assert body["unknown"] == ["bogus_runtime"]
+    assert body["count"] == 1
+    assert body["has_runtimes"] is False
+    assert body["allowed"] is False
+
+
+def test_has_runtimes_endpoint_missing_param_shape(client):
+    body = _get_json(client, "/api/entitlement/has-runtimes")
+    assert set(body.keys()) == _RUNTIMES_KEYS
+    assert body["runtimes"] == []
+    assert body["unknown"] == []
+    assert body["has_runtimes"] is False
+
+
+def test_has_runtimes_endpoint_case_normalises(client):
+    body = _get_json(
+        client, "/api/entitlement/has-runtimes?runtimes=OPENCLAW,CLAUDE_CODE"
+    )
+    assert body["runtimes"] == ["openclaw", "claude_code"]
+    assert body["has_runtimes"] is True
+
+
+def test_has_runtimes_endpoint_alias_canonicalises(client):
+    """Runtime aliases (``claude-code`` -> ``claude_code``) canonicalise via
+    :func:`clawmetry.entitlements.canonical_runtime` before the known/unknown
+    split, so a caller doesn't need to normalise before hitting the URL."""
+    body = _get_json(
+        client, "/api/entitlement/has-runtimes?runtimes=claude-code"
+    )
+    assert body["runtimes"] == ["claude_code"]
+    assert body["unknown"] == []
+    assert body["has_runtimes"] is True
+
+
+# ── Never-5xx (monkeypatched blowup) ──────────────────────────────────────────────────────────────────
+
+
+def test_has_features_endpoint_never_5xx(monkeypatch, client):
+    def _boom(*a, **kw):
+        raise RuntimeError("blowup in body builder")
+
+    monkeypatch.setattr("routes.entitlement._has_bundle_body", _boom)
+    resp = client.get("/api/entitlement/has-features?features=fleet,sso")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert set(body.keys()) == _FEATURES_KEYS
+    assert body["features"] == []
+    assert body["unknown"] == ["fleet", "sso"]
+    assert body["has_features"] is False
+    assert body["allowed"] is False
+
+
+def test_has_runtimes_endpoint_never_5xx(monkeypatch, client):
+    def _boom(*a, **kw):
+        raise RuntimeError("blowup in body builder")
+
+    monkeypatch.setattr("routes.entitlement._has_bundle_body", _boom)
+    resp = client.get(
+        "/api/entitlement/has-runtimes?runtimes=claude_code,codex"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert set(body.keys()) == _RUNTIMES_KEYS
+    assert body["runtimes"] == []
+    assert body["unknown"] == ["claude_code", "codex"]
+    assert body["has_runtimes"] is False
+
+
+# ── Cross-consistency with /min-tier-for-features and /min-tier-for-runtimes
+
+
+@pytest.mark.parametrize(
+    "features_csv",
+    [
+        "nemo_governance",
+        "fleet",
+        "fleet,otel_export",
+        "nemo_governance,fleet",
+    ],
+)
+def test_has_features_cross_consistent_with_min_tier_for_features(
+    client, features_csv
+):
+    """Same input -> same tier answer on both endpoints. A UI wiring
+    ``/has-features`` and ``/min-tier-for-features`` into the same
+    paywall tile can't see inconsistent tier state."""
+    has_body = _get_json(
+        client, f"/api/entitlement/has-features?features={features_csv}"
+    )
+    req_body = _get_json(
+        client, f"/api/entitlement/min-tier-for-features?features={features_csv}"
+    )
+    assert has_body["required_tier"] == req_body["required_tier"]
+    assert has_body["required_tier_label"] == req_body["required_tier_label"]
+    assert has_body["required_tier_rank"] == req_body["required_tier_rank"]
+    assert has_body["current_tier"] == req_body["current_tier"]
+    assert has_body["current_tier_rank"] == req_body["current_tier_rank"]
+    assert has_body["features"] == req_body["features"]
+    assert has_body["unknown"] == req_body["unknown"]
+
+
+@pytest.mark.parametrize(
+    "runtimes_csv",
+    [
+        "openclaw",
+        "claude_code",
+        "openclaw,nemoclaw",
+        "claude_code,codex",
+        "openclaw,claude_code",
+    ],
+)
+def test_has_runtimes_cross_consistent_with_min_tier_for_runtimes(
+    client, runtimes_csv
+):
+    has_body = _get_json(
+        client, f"/api/entitlement/has-runtimes?runtimes={runtimes_csv}"
+    )
+    req_body = _get_json(
+        client, f"/api/entitlement/min-tier-for-runtimes?runtimes={runtimes_csv}"
+    )
+    assert has_body["required_tier"] == req_body["required_tier"]
+    assert has_body["required_tier_label"] == req_body["required_tier_label"]
+    assert has_body["required_tier_rank"] == req_body["required_tier_rank"]
+    assert has_body["current_tier"] == req_body["current_tier"]
+    assert has_body["runtimes"] == req_body["runtimes"]
+
+
+# ── Scalar-vs-endpoint parity ─────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "features_csv",
+    [
+        "nemo_governance",
+        "fleet",
+        "nemo_governance,fleet",
+        "fleet,bogus",
+        "bogus_a,bogus_b",
+        "",
+    ],
+)
+def test_has_features_endpoint_matches_scalar(client, ent, features_csv):
+    """Envelope ``has_features`` value matches the module-level scalar
+    byte-for-byte on the ORIGINAL CSV (unknowns collapse both sides)."""
+    body = _get_json(
+        client, f"/api/entitlement/has-features?features={features_csv}"
+    )
+    tokens = [
+        t.strip().lower() for t in features_csv.split(",") if t.strip()
+    ]
+    assert body["has_features"] is ent.has_features(tokens)
+    assert body["allowed"] is ent.has_features(tokens)
+
+
+@pytest.mark.parametrize(
+    "runtimes_csv",
+    [
+        "openclaw",
+        "claude_code",
+        "openclaw,claude_code",
+        "openclaw,bogus",
+        "bogus_a,bogus_b",
+        "",
+    ],
+)
+def test_has_runtimes_endpoint_matches_scalar(client, ent, runtimes_csv):
+    body = _get_json(
+        client, f"/api/entitlement/has-runtimes?runtimes={runtimes_csv}"
+    )
+    tokens = [
+        t.strip().lower() for t in runtimes_csv.split(",") if t.strip()
+    ]
+    assert body["has_runtimes"] is ent.has_runtimes(tokens)
+    assert body["allowed"] is ent.has_runtimes(tokens)
+
+
+# ── Grace invariant on both axes ───────────────────────────────────────────────────────────────────────
+
+
+def test_grace_invariant_all_known_features_bundle_reports_true(ent):
+    """Headline grace invariant: while grace is on, the WHOLE
+    ``ALL_FEATURES`` set is granted -- wiring the plural gate into a UI
+    today is a no-op behavior change."""
+    assert ent.has_features(sorted(ent.ALL_FEATURES)) is True
+
+
+def test_grace_invariant_all_known_runtimes_bundle_reports_true(ent):
+    assert ent.has_runtimes(sorted(ent.ALL_RUNTIMES)) is True
+
+
+def test_enforce_all_paid_features_bundle_locked_on_oss(enforced):
+    """Symmetric enforcement assertion: post-enforce, the paid-feature
+    bundle collapses to False on OSS."""
+    assert enforced.has_features(sorted(enforced.PAID_FEATURES)) is False
+
+
+def test_enforce_all_paid_runtimes_bundle_locked_on_oss(enforced):
+    assert enforced.has_runtimes(sorted(enforced.PAID_RUNTIMES)) is False
+
+
+def test_enforce_free_features_bundle_still_true(enforced):
+    """FREE_FEATURES stay granted post-enforce."""
+    assert enforced.has_features(sorted(enforced.FREE_FEATURES)) is True
+
+
+def test_enforce_free_runtimes_bundle_still_true(enforced):
+    assert enforced.has_runtimes(sorted(enforced.FREE_RUNTIMES)) is True


### PR DESCRIPTION
## Summary

- New `clawmetry.entitlements.has_features(features) -> bool` and `has_runtimes(runtimes) -> bool` module-scope scalars: plural boolean-gate siblings of `has_feature` / `has_runtime` that fold the answer across a whole bundle -- `True` iff every item is granted (tightest single-item denial wins). Fills the plural seat sitting alongside `min_tier_for_features` / `min_tier_for_runtimes` (which answer "cheapest tier that would admit this bundle") -- these answer "does the resolved entitlement grant every item right now?".

  Same never-raises + grace-safe posture the singular helpers carry: while `ent.grace` is `True` (the current rollout state) every fully-known bundle reports `True`, so wiring these into a paywall gate today changes NO current behavior. Empty iterable / `None` / non-iterable / any-unknown-item collapse to `False` (strict callsite-typo posture -- matches the singular `has_feature("Fleeet")` fail-closed behavior; a UI can still surface the unknown set separately via the endpoint envelope).

- New endpoints `GET /api/entitlement/has-features?features=a,b,c` and `GET /api/entitlement/has-runtimes?runtimes=x,y,z` on `bp_entitlement`, mirroring the shape of `/api/entitlement/min-tier-for-features` and its runtime twin plus the `has_<axis>` boolean gate. **14-key envelope** byte-stable across every input branch (`<axis>`, `unknown`, `kind`, `count`, `has_<axis>`, `allowed`, `required_tier` triad, `current_tier` pair, `grace`, `enforced`, `upgrade_required`) so a paywall tile that gates on a bundle can bind `allowed` directly off the URL without a branch on the resolver state. Runtime-alias canonicalisation (`claude-code` → `claude_code`) is applied per token at the endpoint layer before the known/unknown split so a caller does not need to normalise before hitting the URL. Cross-consistent with `/api/entitlement/min-tier-for-features` / `/min-tier-for-runtimes` on the same bundle -- `required_tier` / `required_tier_label` / `required_tier_rank` agree byte-for-byte. Never 5xx: any resolver blowup collapses to the fail-closed fallback envelope.

- **65 hermetic unit tests** covering: scalar behaviour under grace vs enforce for empty / non-iterable / `None` / unknown / mixed known+unknown / all-free / all-paid bundles; envelope-shape invariant across 8+ URL branches (missing / blank / whitespace / dedup / mixed / all-unknown / alias-canonicalising); never-5xx via monkeypatched blowup on both endpoints; parametrised cross-endpoint parity against `/min-tier-for-features` / `/min-tier-for-runtimes` on 4 feature bundles + 5 runtime bundles; scalar-vs-endpoint parity so the URL boolean cannot drift from the module scalar; the headline grace invariant on both axes (all-known bundle reports `True`); and enforce-side collapse (paid-features / paid-runtimes bundle → `False` on OSS).

Behaviour is additive; nothing existing changes. Grace-mode posture is preserved (no gate enforcement is added; the scalars only surface what the resolved entitlement's per-item grant admits over the bundle). Uses only the already-permitted `flask` + stdlib import set.

## Test plan

- [x] `python3 -m py_compile clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_has_features_has_runtimes.py` -- passes
- [x] `python3 -m pytest tests/test_entitlement_has_features_has_runtimes.py` -- **65 passed**
- [x] `python3 -m pytest tests/test_entitlement_has_feature_has_runtime.py tests/test_entitlement_has_channel_count.py` -- **111 passed** (sibling regressions clean)
- [x] `python3 -m pytest tests/ -k entitlement` -- **7764 passed** (2 pre-existing errors from missing optional `duckdb` dep, unrelated)
- [x] `python3 -m ruff check clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_has_features_has_runtimes.py --select E9,F63,F7,F82` -- all critical checks pass

## Local operator verification checklist

The web agent cannot touch the live daemon, `~/.openclaw`, the cloud snapshot, or a browser. Please verify on-host before flipping this out of draft:

- [ ] Copy the changed source files (and the new test) into the installed package:
  - `cp clawmetry/entitlements.py ~/.clawmetry/lib/python*/site-packages/clawmetry/entitlements.py`
  - `cp routes/entitlement.py ~/.clawmetry/lib/python*/site-packages/routes/entitlement.py`
  - `find ~/.clawmetry/lib/python*/site-packages/{clawmetry,routes} -name __pycache__ -exec rm -rf {} +`
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` (or the equivalent supervisor kick on non-macOS hosts)
- [ ] `curl -s "http://localhost:8900/api/entitlement/has-features?features=nemo_governance,fleet" | jq` -- 14-key envelope matches the docstring; `required_tier` matches `curl -s "http://localhost:8900/api/entitlement/min-tier-for-features?features=nemo_governance,fleet" | jq .required_tier`.
- [ ] `curl -s "http://localhost:8900/api/entitlement/has-runtimes?runtimes=openclaw,claude_code" | jq` -- same envelope, `required_tier=cloud_starter`, `has_runtimes=true` in grace.
- [ ] Grace-safe sanity: both endpoints report `has_<axis>=true` for every fully-known bundle while grace is on (no change from today's `/min-tier-for-<axis>` `required_tier` answer).
- [ ] Unknown-token sanity: `curl -s "http://localhost:8900/api/entitlement/has-features?features=fleet,bogus_id" | jq` -- `has_features=false`, `features=["fleet"]`, `unknown=["bogus_id"]`, `required_tier="cloud_starter"` (still routes off the known subset).
- [ ] Alias sanity: `curl -s "http://localhost:8900/api/entitlement/has-runtimes?runtimes=claude-code" | jq .runtimes` -- resolves to `["claude_code"]` via `canonical_runtime`.
- [ ] Missing / blank param sanity: `curl` with no `features=` and with `?features=` -- both 200, `has_features=false`, empty lists.
- [ ] Browser check: open the entitlement diagnostics tile and confirm no regression; the mixed-axis paywall tile (if wired) can bind `allowed` off `/has-features?features=` without changing behavior in grace.
- [ ] Decrypt the live cloud snapshot and confirm the new endpoints are reachable through the relay (should require no relay changes -- both are read-only handlers on `bp_entitlement`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01BNyi8DzWcKwDsqzJzM5RTg)_