### PR TITLE
[RELEASE] fix(trial): email-OTP trial activated but gate said 'Activate a license or trial first' (Entitlement vs dict drift)

### DIFF
--- a/clawmetry/selfhosted.py
+++ b/clawmetry/selfhosted.py
@@ -139,9 +139,11 @@ def _license_ping_payload() -> dict:
     try:
         from clawmetry.license import load_license
 
-        lic = load_license() or {}
-        sub = str(lic.get("sub") or "")
-        tier = str(lic.get("tier") or "")
+        lic = load_license()
+        # Entitlement object on current builds, dict on older ones.
+        data = lic.to_dict() if hasattr(lic, "to_dict") else (lic or {})
+        sub = str(data.get("sub") or "")
+        tier = str(data.get("tier") or "")
     except Exception:
         pass
     return {

--- a/clawmetry/static/js/onboarding.js
+++ b/clawmetry/static/js/onboarding.js
@@ -167,7 +167,10 @@
         if (btn) { btn.textContent = 'Activate trial'; btn.disabled = false; }
         return;
       }
-      _complete('selfhost_trial', function (msg) { _err('obg-trial-err', msg); });
+      _complete('selfhost_trial', function (msg) {
+        _err('obg-trial-err', msg);
+        if (btn) { btn.textContent = 'Activate trial'; btn.disabled = false; }
+      });
     }).catch(function () {
       _err('obg-trial-err', 'Network error. Try again.');
       if (btn) { btn.textContent = 'Activate trial'; btn.disabled = false; }

--- a/dashboard.py
+++ b/dashboard.py
@@ -267,7 +267,7 @@ def _otlp_service_name_to_agent_type(service_name):
     return slug or "custom"
 
 
-__version__ = "0.12.618"
+__version__ = "0.12.620"
 
 # Extensions (Phase 2): import the plugin host now, but defer the actual
 # load_plugins() call until after the Flask app is created below so we can

--- a/routes/onboarding.py
+++ b/routes/onboarding.py
@@ -77,7 +77,17 @@ def _license_state() -> str:
         payload = _lic.load_license()
         if not payload:
             return ""
-        tier = str(payload.get("tier", "")).strip().lower()
+        # load_license() returns an Entitlement object (older builds returned
+        # a dict). A .get() call on the object raised AttributeError into the
+        # broad except below, so an ACTIVE trial read as "no license" and
+        # /api/onboarding/complete 409'd right after a successful activation.
+        if isinstance(payload, dict):
+            tier = payload.get("tier", "")
+        else:
+            tier = getattr(payload, "tier", "")
+        tier = str(tier or "").strip().lower()
+        if not tier or tier in ("oss", "free"):
+            return ""
         return "selfhost_trial" if tier == "trial" else "selfhost_license"
     except Exception:
         return ""


### PR DESCRIPTION
## What the user saw

Walked the new onboarding gate's self-host path: email → 6-digit code → **Activate trial**. The license key was minted and written (`~/.clawmetry/license.key`, tier=trial), but the modal errored "Activate a license or trial first." with the button stuck on "Activating", and the welcome gate kept re-appearing on every load despite the active trial.

## Root cause

`clawmetry.license.load_license()` returns an `Entitlement` object; `_license_state()` in `routes/onboarding.py` still called `payload.get("tier")` (dict-era API), the `AttributeError` fell into the broad `except` and an active trial read as "no license". So `/api/onboarding/complete` 409'd right after successful activation and `/api/onboarding/state` stayed `required:true` forever.

Family sweep: `clawmetry/selfhosted.py` had the same dict assumption (ping silently lost `tier`). Also reset the trial button when completion fails so users can retry without a reload.

## Evidence

Against the real activated trial on this node, `/api/onboarding/state` now returns `{"required": false, "source": "license", "state": "selfhost_trial"}` (was `required:true`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)