### PR TITLE
[RELEASE] feat(onboarding): Google/GitHub sign-in on the self-host card, same rail as clawmetry login

### DIFF
--- a/clawmetry/static/js/onboarding.js
+++ b/clawmetry/static/js/onboarding.js
@@ -6,8 +6,10 @@
 // activate-license endpoint):
 //   managed          — existing cloud modal (OTP / Google / GitHub), we
 //                      poll /api/cloud-cta/status until connected
-//   selfhost_trial   — email + 6-digit code, the flow /api/trial/activate
-//                      already implements (same as the gw-setup teaser)
+//   selfhost_trial   — Google/GitHub OAuth (mode=selfhost bridge: identity
+//                      + trial license, data stays local) or email +
+//                      6-digit code via /api/trial/activate (same as the
+//                      gw-setup teaser)
 //   selfhost_license — CLAW1 key via /api/onboarding/activate-license
 //
 // Never runs on the hosted cloud dashboard (window.CLOUD_MODE) and defers
@@ -17,6 +19,7 @@
   'use strict';
 
   var _pollTimer = null;
+  var _oauthTimer = null;
   var _trialEmail = '';
 
   function $(id) { return document.getElementById(id); }
@@ -32,6 +35,7 @@
     var o = _overlay();
     if (o) o.style.display = 'none';
     if (_pollTimer) { clearInterval(_pollTimer); _pollTimer = null; }
+    if (_oauthTimer) { clearInterval(_oauthTimer); _oauthTimer = null; }
   }
 
   function _err(id, msg) {
@@ -220,20 +224,103 @@
     });
   }
 
+  // Keep this markup mirrored with the initial #obg-selfhost-body in
+  // templates/partials/onboarding-modal.html — both renders must offer
+  // the same options.
   function _selfhostHome() {
     var body = $('obg-selfhost-body');
     if (!body) return;
     body.innerHTML =
-      '<button class="obg-btn obg-btn-quiet" id="obg-trial-btn" type="button">Start free 7-day trial</button>' +
+      '<button class="obg-btn obg-btn-quiet" id="obg-oauth-github" type="button">Continue with GitHub</button>' +
+      '<button class="obg-btn obg-btn-quiet" id="obg-oauth-google" type="button" style="margin-top:8px;">Continue with Google</button>' +
+      '<button class="obg-btn obg-btn-quiet" id="obg-trial-btn" type="button" style="margin-top:8px;">Continue with email</button>' +
+      '<div class="obg-err" id="obg-oauth-err"></div>' +
       '<a class="obg-alt" href="#" id="obg-license-link">I have a license key</a>';
     _wireSelfhostHome();
   }
 
   function _wireSelfhostHome() {
+    var gh = $('obg-oauth-github');
+    if (gh) gh.addEventListener('click', function () { _selfhostOauth('github'); });
+    var go = $('obg-oauth-google');
+    if (go) go.addEventListener('click', function () { _selfhostOauth('google'); });
     var t = $('obg-trial-btn');
     if (t) t.addEventListener('click', _trialEmailStep);
     var l = $('obg-license-link');
     if (l) l.addEventListener('click', function (ev) { ev.preventDefault(); _licenseStep(); });
+  }
+
+  // ── Self-host: Google/GitHub OAuth (identity + trial, data stays local) ──
+  function _selfhostOauth(provider) {
+    _err('obg-oauth-err', '');
+    var pretty = provider === 'github' ? 'GitHub' : 'Google';
+    fetch('/api/cloud-cta/oauth-start', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ provider: provider, mode: 'selfhost' }),
+    }).then(function (r) { return r.json(); }).then(function (d) {
+      if (!d || !d.ok || !d.url) {
+        _err('obg-oauth-err', (d && d.error) || 'Could not start sign-in. Try email instead.');
+        return;
+      }
+      window.open(d.url, '_blank');
+      _selfhostOauthWait(pretty);
+    }).catch(function () {
+      _err('obg-oauth-err', 'Network error. Try again.');
+    });
+  }
+
+  function _selfhostOauthWait(pretty) {
+    var body = $('obg-selfhost-body');
+    if (!body) return;
+    body.innerHTML =
+      '<p style="color:#94a3b8;font-size:12px;margin:0 0 8px;">Finish signing in with ' + pretty +
+      ' in the tab we just opened. Your trial activates here automatically.</p>' +
+      '<div class="obg-err" id="obg-oauth-err"></div>' +
+      '<a class="obg-alt" href="#" id="obg-oauth-cancel">Cancel</a>';
+    $('obg-oauth-cancel').addEventListener('click', function (ev) {
+      ev.preventDefault();
+      if (_oauthTimer) { clearInterval(_oauthTimer); _oauthTimer = null; }
+      _selfhostHome();
+    });
+    var tries = 0;
+    if (_oauthTimer) clearInterval(_oauthTimer);
+    _oauthTimer = setInterval(function () {
+      tries += 1;
+      if (tries > 150) {
+        clearInterval(_oauthTimer); _oauthTimer = null;
+        _err('obg-oauth-err', 'Sign-in timed out. Try again.');
+        return;
+      }
+      fetch('/api/cloud-cta/oauth-status').then(function (r) { return r.json(); })
+        .then(function (d) {
+          if (!d) return;
+          if (d.status === 'connected') {
+            clearInterval(_oauthTimer); _oauthTimer = null;
+            if (d.trial === 'active') {
+              _complete('selfhost_trial', function (msg) { _err('obg-oauth-err', msg); });
+            } else if (d.trial === 'expired') {
+              _selfhostTrialEnded();
+            } else {
+              _err('obg-oauth-err',
+                "You're signed in, but we couldn't start your trial. Try again or use email.");
+            }
+          } else if (d.status === 'error') {
+            clearInterval(_oauthTimer); _oauthTimer = null;
+            _err('obg-oauth-err', d.error || 'Sign-in failed. Try email instead.');
+          }
+        }).catch(function () {});
+    }, 2000);
+  }
+
+  function _selfhostTrialEnded() {
+    var body = $('obg-selfhost-body');
+    if (!body) return;
+    body.innerHTML =
+      '<p style="color:#94a3b8;font-size:12px;margin:0 0 8px;">You\'re signed in, but your 7-day trial has already ended. ' +
+      'Keep every runtime with a license: <a href="https://clawmetry.com/pricing?deploy=self" target="_blank" rel="noopener" style="color:#e2e8f0;">clawmetry.com/pricing</a></p>' +
+      '<button class="obg-btn obg-btn-quiet" id="obg-license-btn2" type="button">I have a license key</button>';
+    $('obg-license-btn2').addEventListener('click', _licenseStep);
   }
 
   // ── Greeting: lead with what ClawMetry can already see ───────────────

--- a/clawmetry/templates/partials/onboarding-modal.html
+++ b/clawmetry/templates/partials/onboarding-modal.html
@@ -47,9 +47,14 @@
       </div>
       <div class="obg-opt">
         <h3>Self-host</h3>
-        <p>Everything stays on this machine. Sign in once by email to start the same free 7-day Pro trial and unlock every runtime, or activate a license key you already have.</p>
+        <p>Everything stays on this machine. Sign in once with Google, GitHub, or email to start the same free 7-day Pro trial and unlock every runtime, or activate a license key you already have.</p>
+        <!-- Keep this initial body mirrored with _selfhostHome() in
+             static/js/onboarding.js — both renders must offer the same options. -->
         <div id="obg-selfhost-body">
-          <button class="obg-btn obg-btn-quiet" id="obg-trial-btn" type="button">Start free 7-day trial</button>
+          <button class="obg-btn obg-btn-quiet" id="obg-oauth-github" type="button">Continue with GitHub</button>
+          <button class="obg-btn obg-btn-quiet" id="obg-oauth-google" type="button" style="margin-top:8px;">Continue with Google</button>
+          <button class="obg-btn obg-btn-quiet" id="obg-trial-btn" type="button" style="margin-top:8px;">Continue with email</button>
+          <div class="obg-err" id="obg-oauth-err"></div>
           <a class="obg-alt" href="#" id="obg-license-link">I have a license key</a>
         </div>
       </div>

--- a/dashboard.py
+++ b/dashboard.py
@@ -267,7 +267,7 @@ def _otlp_service_name_to_agent_type(service_name):
     return slug or "custom"
 
 
-__version__ = "0.12.621"
+__version__ = "0.12.622"
 
 # Extensions (Phase 2): import the plugin host now, but defer the actual
 # load_plugins() call until after the Flask app is created below so we can
@@ -18156,20 +18156,25 @@ def _write_cloud_token(token):
 # in one click. We reuse the same loopback browser-bridge as `clawmetry connect`:
 # start a one-shot 127.0.0.1 listener, hand the cloud OAuth flow our port via
 # cli_port=<port>, and the cloud callback redirects the freshly-minted cm_ key
-# back to loopback. The key only ever travels over 127.0.0.1. On capture we run
-# the full connect (register node -> ~/.clawmetry/config.json -> start daemon).
-# The dashboard polls _OAUTH_BRIDGE for status.
-_OAUTH_BRIDGE = {"status": "idle", "provider": "", "node_id": "", "enc_key": "", "error": ""}
+# back to loopback. The key only ever travels over 127.0.0.1. What happens on
+# capture depends on the bridge mode: "managed" runs the full connect (register
+# node -> ~/.clawmetry/config.json -> enable cloud -> start daemon); "selfhost"
+# (the onboarding gate's self-host card) keeps egress off and rides the trial
+# rail instead. The dashboard polls _OAUTH_BRIDGE for status.
+_OAUTH_BRIDGE = {"status": "idle", "provider": "", "mode": "", "node_id": "",
+                 "enc_key": "", "trial": "", "error": ""}
 
 
-def _full_connect_with_key(api_key):
-    """Register this node with a verified cm_ key and start syncing.
+def _persist_identity_with_key(api_key):
+    """Register the account/node for a verified cm_ key and persist it.
 
-    Mirrors the non-interactive parts of `clawmetry connect`: validate/register
-    the node, preserve or auto-generate the E2E encryption key, write
-    ~/.clawmetry/config.json, mirror the token into openclaw.json (so the
-    dashboard cloud-proxy works), and ensure the sync daemon is running.
-    Returns (node_id, enc_key). Never raises for non-fatal issues.
+    The shared identity half of both connect flavours: validate/register the
+    node (best-effort — network hiccups still save config so it syncs once
+    reachable), preserve or auto-generate the E2E encryption key, write
+    ~/.clawmetry/config.json, and mirror the token into openclaw.json (so
+    the dashboard cloud-proxy works). Deliberately does NOT touch the
+    nocloud marker or the daemon — callers own the egress decision.
+    Returns (node_id, enc_key).
     """
     import platform
     import socket
@@ -18190,7 +18195,6 @@ def _full_connect_with_key(api_key):
         result = validate_key(api_key, hostname=hostname, existing_node_id=saved_node_id)
         node_id = result.get("node_id") or saved_node_id or hostname
     except Exception:
-        # Network/server hiccup: save config anyway so it syncs once reachable.
         node_id = saved_node_id or hostname
 
     enc_key = saved_enc or generate_encryption_key()
@@ -18206,6 +18210,18 @@ def _full_connect_with_key(api_key):
         _write_cloud_token(api_key)
     except Exception:
         pass
+    return node_id, enc_key
+
+
+def _full_connect_with_key(api_key):
+    """Register this node with a verified cm_ key and start syncing.
+
+    Mirrors the non-interactive parts of `clawmetry connect`: persist the
+    identity (_persist_identity_with_key), then opt into egress and ensure
+    the sync daemon is running. Returns (node_id, enc_key). Never raises
+    for non-fatal issues.
+    """
+    node_id, enc_key = _persist_identity_with_key(api_key)
 
     # Clear the local-only marker so the daemon actually pushes to cloud. A
     # local-only install writes ~/.clawmetry/nocloud; without this the connect
@@ -18241,12 +18257,73 @@ def _full_connect_with_key(api_key):
     return node_id, enc_key
 
 
-def _start_oauth_bridge(provider):
+def _selfhost_signin_with_key(api_key):
+    """Self-host sign-in: identity without egress, then the trial rail.
+
+    Mirrors `clawmetry connect` answered with keep-local (identity is what
+    unlocks runtimes; egress is a separate choice): touch the nocloud
+    marker BEFORE persisting the key — the daemon must never observe a
+    cm_ key without the marker, or it would happily start pushing — then
+    register the identity and mint-or-reuse the account's 7-day trial via
+    /api/license/trial/signup (idempotent server-side, same rail as the
+    CLI) and activate it locally. Returns (node_id, trial) where trial is
+    'active' | 'expired' | 'unavailable'.
+    """
+    try:
+        from clawmetry.config import NOCLOUD_MARKER_PATH as _marker
+        import pathlib as _pl
+
+        _p = _pl.Path(str(_marker))
+        _p.parent.mkdir(parents=True, exist_ok=True)
+        _p.touch(exist_ok=True)
+    except Exception:
+        pass
+
+    node_id, _enc = _persist_identity_with_key(api_key)
+
+    trial = "unavailable"
+    try:
+        import urllib.request as _ur
+        from clawmetry import license as _lic
+
+        req = _ur.Request(
+            _lic._cloud_base() + "/api/license/trial/signup",
+            data=json.dumps({"api_key": api_key}).encode(),
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with _ur.urlopen(req, timeout=15) as resp:
+            body = json.loads(resp.read().decode())
+        if isinstance(body, dict) and body.get("ok"):
+            if body.get("expired"):
+                trial = "expired"
+            elif body.get("key"):
+                ok, _msg = _lic.activate(body["key"], node_id=_lic._node_id())
+                if ok:
+                    trial = "active"
+    except Exception:
+        pass
+
+    # Same as the email-OTP trial path: make sure the local ingest daemon is
+    # running (it stays local-only under the marker written above).
+    try:
+        from routes.trial import _ensure_local_daemon
+
+        _ensure_local_daemon()
+    except Exception:
+        pass
+    return node_id, trial
+
+
+def _start_oauth_bridge(provider, mode="managed"):
     """Start the loopback OAuth bridge and return the cloud start URL (or None).
 
     The caller (dashboard JS) opens the returned URL in a new browser tab. A
-    background thread captures the loopback callback, runs _full_connect_with_key,
-    and updates the module-level _OAUTH_BRIDGE the status route reports.
+    background thread captures the loopback callback and updates the
+    module-level _OAUTH_BRIDGE the status route reports. mode picks what
+    happens with the captured key: "managed" runs _full_connect_with_key
+    (register node + enable cloud sync); "selfhost" runs
+    _selfhost_signin_with_key (identity + local trial, egress stays off).
     """
     import http.server
     import threading
@@ -18255,9 +18332,11 @@ def _start_oauth_bridge(provider):
 
     global _OAUTH_BRIDGE
     provider = (provider or "").lower()
+    mode = "selfhost" if (mode or "").lower() == "selfhost" else "managed"
     if provider not in ("github", "google"):
-        _OAUTH_BRIDGE = {"status": "error", "provider": provider,
-                         "node_id": "", "enc_key": "", "error": "Unsupported provider"}
+        _OAUTH_BRIDGE = {"status": "error", "provider": provider, "mode": mode,
+                         "node_id": "", "enc_key": "", "trial": "",
+                         "error": "Unsupported provider"}
         return None
 
     from clawmetry.endpoints import app_url as _resolve_app_url
@@ -18288,13 +18367,14 @@ def _start_oauth_bridge(provider):
     try:
         srv = http.server.HTTPServer(("127.0.0.1", 0), _Handler)
     except OSError:
-        _OAUTH_BRIDGE = {"status": "error", "provider": provider,
-                         "node_id": "", "enc_key": "", "error": "Could not start local listener"}
+        _OAUTH_BRIDGE = {"status": "error", "provider": provider, "mode": mode,
+                         "node_id": "", "enc_key": "", "trial": "",
+                         "error": "Could not start local listener"}
         return None
 
     port = srv.server_address[1]
-    _OAUTH_BRIDGE = {"status": "waiting", "provider": provider,
-                     "node_id": "", "enc_key": "", "error": ""}
+    _OAUTH_BRIDGE = {"status": "waiting", "provider": provider, "mode": mode,
+                     "node_id": "", "enc_key": "", "trial": "", "error": ""}
 
     def _run():
         global _OAUTH_BRIDGE
@@ -18307,16 +18387,25 @@ def _start_oauth_bridge(provider):
             srv.server_close()
         tok = captured.get("token", "")
         if not tok.startswith("cm_"):
-            _OAUTH_BRIDGE = {"status": "error", "provider": provider, "node_id": "",
-                             "enc_key": "", "error": "Sign-in was not completed."}
+            _OAUTH_BRIDGE = {"status": "error", "provider": provider, "mode": mode,
+                             "node_id": "", "enc_key": "", "trial": "",
+                             "error": "Sign-in was not completed."}
             return
         try:
-            node_id, enc_key = _full_connect_with_key(tok)
-            _OAUTH_BRIDGE = {"status": "connected", "provider": provider,
-                             "node_id": node_id, "enc_key": enc_key, "error": ""}
+            if mode == "selfhost":
+                node_id, trial = _selfhost_signin_with_key(tok)
+                _OAUTH_BRIDGE = {"status": "connected", "provider": provider,
+                                 "mode": mode, "node_id": node_id, "enc_key": "",
+                                 "trial": trial, "error": ""}
+            else:
+                node_id, enc_key = _full_connect_with_key(tok)
+                _OAUTH_BRIDGE = {"status": "connected", "provider": provider,
+                                 "mode": mode, "node_id": node_id,
+                                 "enc_key": enc_key, "trial": "", "error": ""}
         except Exception as e:  # pragma: no cover - defensive
-            _OAUTH_BRIDGE = {"status": "error", "provider": provider, "node_id": "",
-                             "enc_key": "", "error": str(e)[:200]}
+            _OAUTH_BRIDGE = {"status": "error", "provider": provider, "mode": mode,
+                             "node_id": "", "enc_key": "", "trial": "",
+                             "error": str(e)[:200]}
 
     threading.Thread(target=_run, daemon=True).start()
     return f"{app_base}/api/oauth/{provider}/start?cli_port={port}"

--- a/routes/onboarding.py
+++ b/routes/onboarding.py
@@ -136,13 +136,19 @@ def _apply_marker_semantics(choice: str) -> None:
     connect without enable_cloud() silently no-ops sync). Self-host writes
     it so identity/trial never turns into an unasked-for data upload."""
     try:
+        import pathlib
+
         from clawmetry import config as _cfg
 
         if choice == "managed":
             _cfg.enable_cloud()
         else:
-            _cfg.NOCLOUD_MARKER_PATH.parent.mkdir(parents=True, exist_ok=True)
-            _cfg.NOCLOUD_MARKER_PATH.touch(exist_ok=True)
+            # NOCLOUD_MARKER_PATH is a plain str; the old .parent/.touch
+            # calls raised AttributeError into this except, so the marker
+            # was silently never written for self-host choices.
+            marker = pathlib.Path(str(_cfg.NOCLOUD_MARKER_PATH))
+            marker.parent.mkdir(parents=True, exist_ok=True)
+            marker.touch(exist_ok=True)
     except Exception as exc:
         log.warning("onboarding: marker update failed: %s", exc)
 

--- a/routes/overview.py
+++ b/routes/overview.py
@@ -1750,12 +1750,14 @@ def cloud_proxy(cloud_path):
 
 @bp_overview.route("/api/cloud-cta/oauth-start", methods=["POST"])
 def cloud_cta_oauth_start():
-    """One-click cloud sign-up + node connect via GitHub/Google OAuth.
+    """One-click sign-up via GitHub/Google OAuth (managed or self-host).
 
     Starts a loopback browser-bridge and returns the cloud OAuth start URL for
     the dashboard to open in a new tab. The cm_ key the cloud mints rides back
-    over 127.0.0.1 only; the bridge thread then registers this node and starts
-    the sync daemon. The dashboard polls /api/cloud-cta/oauth-status.
+    over 127.0.0.1 only. mode="managed" (default) then registers this node and
+    starts the sync daemon; mode="selfhost" keeps data local (nocloud marker)
+    and activates the account's 7-day trial license instead. The dashboard
+    polls /api/cloud-cta/oauth-status.
     """
     import dashboard as _d
 
@@ -1763,7 +1765,10 @@ def cloud_cta_oauth_start():
     provider = (data.get("provider") or "").strip().lower()
     if provider not in ("github", "google"):
         return jsonify({"ok": False, "error": "Unsupported provider"}), 400
-    url = _d._start_oauth_bridge(provider)
+    mode = (data.get("mode") or "managed").strip().lower()
+    if mode not in ("managed", "selfhost"):
+        return jsonify({"ok": False, "error": "Unsupported mode"}), 400
+    url = _d._start_oauth_bridge(provider, mode=mode)
     if not url:
         err = (_d._OAUTH_BRIDGE or {}).get("error") or "Could not start sign-in"
         return jsonify({"ok": False, "error": err}), 500
@@ -1779,8 +1784,10 @@ def cloud_cta_oauth_status():
         {
             "status": st.get("status", "idle"),
             "provider": st.get("provider", ""),
+            "mode": st.get("mode", ""),
             "node_id": st.get("node_id", ""),
             "enc_key": st.get("enc_key", ""),
+            "trial": st.get("trial", ""),
             "error": st.get("error", ""),
         }
     )

--- a/tests/test_cloud_cta_oauth.py
+++ b/tests/test_cloud_cta_oauth.py
@@ -42,7 +42,8 @@ def test_oauth_start_returns_url_for_valid_provider(cta_app, monkeypatch):
 
     monkeypatch.setattr(
         _d, "_start_oauth_bridge",
-        lambda provider: "https://app.clawmetry.com/api/oauth/%s/start?cli_port=51234" % provider,
+        lambda provider, mode="managed":
+            "https://app.clawmetry.com/api/oauth/%s/start?cli_port=51234" % provider,
     )
     c = cta_app.test_client()
     for provider in ("github", "google"):
@@ -52,6 +53,34 @@ def test_oauth_start_returns_url_for_valid_provider(cta_app, monkeypatch):
         assert body["ok"] is True
         assert provider in body["url"]
         assert "cli_port=" in body["url"]
+
+
+def test_oauth_start_rejects_bad_mode(cta_app):
+    c = cta_app.test_client()
+    r = c.post("/api/cloud-cta/oauth-start",
+               json={"provider": "github", "mode": "sideways"})
+    assert r.status_code == 400
+    assert r.get_json()["ok"] is False
+
+
+def test_oauth_start_passes_mode_to_bridge(cta_app, monkeypatch):
+    import dashboard as _d
+
+    seen = {}
+
+    def _fake(provider, mode="managed"):
+        seen["provider"], seen["mode"] = provider, mode
+        return "https://app.clawmetry.com/api/oauth/%s/start?cli_port=51234" % provider
+
+    monkeypatch.setattr(_d, "_start_oauth_bridge", _fake)
+    c = cta_app.test_client()
+    r = c.post("/api/cloud-cta/oauth-start",
+               json={"provider": "github", "mode": "selfhost"})
+    assert r.status_code == 200, r.data
+    assert seen == {"provider": "github", "mode": "selfhost"}
+    # Callers that omit mode (the existing cloud modal) stay managed.
+    c.post("/api/cloud-cta/oauth-start", json={"provider": "google"})
+    assert seen["mode"] == "managed"
 
 
 def test_oauth_status_shape(cta_app, monkeypatch):
@@ -69,6 +98,21 @@ def test_oauth_status_shape(cta_app, monkeypatch):
     assert body["status"] == "connected"
     assert body["node_id"] == "host-1"
     assert body["enc_key"] == "abc123"
+
+
+def test_oauth_status_includes_mode_and_trial(cta_app, monkeypatch):
+    import dashboard as _d
+
+    monkeypatch.setattr(
+        _d, "_OAUTH_BRIDGE",
+        {"status": "connected", "provider": "github", "mode": "selfhost",
+         "node_id": "host-1", "enc_key": "", "trial": "active", "error": ""},
+    )
+    c = cta_app.test_client()
+    body = c.get("/api/cloud-cta/oauth-status").get_json()
+    assert body["mode"] == "selfhost"
+    assert body["trial"] == "active"
+    assert body["enc_key"] == ""
 
 
 def test_start_oauth_bridge_rejects_bad_provider():
@@ -131,3 +175,118 @@ def test_enable_cloud_removes_marker(tmp_path, monkeypatch):
     assert _cfg.enable_cloud() is True
     assert _cfg.is_cloud_disabled() is False
     assert _cfg.enable_cloud() is False  # idempotent: nothing left to remove
+
+
+# ── Self-host OAuth rail (identity + trial, egress stays off) ──────────────
+
+class _FakeResp:
+    def __init__(self, payload):
+        self._data = json.dumps(payload).encode()
+
+    def read(self):
+        return self._data
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+
+def _selfhost_env(tmp_path, monkeypatch):
+    """Common monkeypatching for _selfhost_signin_with_key tests."""
+    import urllib.request as _ur
+
+    import dashboard as _d
+    from clawmetry import config as _cfg
+    from clawmetry import license as _lic
+    from clawmetry import sync as _sync
+
+    home = tmp_path / "home"
+    (home / ".clawmetry").mkdir(parents=True)
+    nocloud = home / ".clawmetry" / "nocloud"
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setattr(_d.os.path, "expanduser",
+                        lambda p: p.replace("~", str(home)))
+    monkeypatch.setattr(_sync, "CONFIG_DIR", home / ".clawmetry")
+    monkeypatch.setattr(_sync, "CONFIG_FILE", home / ".clawmetry" / "config.json")
+    monkeypatch.setattr(_sync, "validate_key",
+                        lambda *a, **k: {"node_id": "node-sh"})
+    monkeypatch.setattr(_cfg, "NOCLOUD_MARKER_PATH", str(nocloud))
+    monkeypatch.setattr(_d, "_write_cloud_token", lambda tok: None)
+    monkeypatch.setattr(_lic, "_node_id", lambda: "node-sh")
+    import routes.trial as _rt
+    monkeypatch.setattr(_rt, "_ensure_local_daemon", lambda: None)
+    return _d, _lic, _ur, home, nocloud
+
+
+def test_selfhost_signin_keeps_marker_and_activates_trial(tmp_path, monkeypatch):
+    """The self-host OAuth rail must never enable egress: the nocloud marker
+    is written before the key is persisted (the daemon must not observe a
+    cm_ key without it), and the account's trial is minted server-side then
+    activated locally — same rail as `clawmetry connect` keep-local."""
+    _d, _lic, _ur, home, nocloud = _selfhost_env(tmp_path, monkeypatch)
+
+    activated = {}
+
+    def _fake_activate(key, node_id=None, **k):
+        activated["key"] = key
+        return True, "ok"
+
+    monkeypatch.setattr(_lic, "activate", _fake_activate)
+    monkeypatch.setattr(_lic, "_cloud_base", lambda: "https://ingest.example")
+    monkeypatch.setattr(
+        _ur, "urlopen",
+        lambda req, timeout=0: _FakeResp(
+            {"ok": True, "key": "CLAW1.test.key", "expires_at": 9999999999}),
+    )
+
+    node_id, trial = _d._selfhost_signin_with_key("cm_selfhost123")
+    assert node_id == "node-sh"
+    assert trial == "active"
+    assert activated["key"] == "CLAW1.test.key"
+    assert nocloud.exists(), \
+        "self-host sign-in must keep egress off (nocloud marker)"
+    cfg = json.loads((home / ".clawmetry" / "config.json").read_text())
+    assert cfg["api_key"] == "cm_selfhost123"
+    assert cfg["node_id"] == "node-sh"
+
+
+def test_selfhost_signin_expired_trial_never_activates(tmp_path, monkeypatch):
+    _d, _lic, _ur, home, nocloud = _selfhost_env(tmp_path, monkeypatch)
+
+    def _boom(*a, **k):
+        raise AssertionError("expired trial must not call license.activate")
+
+    monkeypatch.setattr(_lic, "activate", _boom)
+    monkeypatch.setattr(_lic, "_cloud_base", lambda: "https://ingest.example")
+    monkeypatch.setattr(
+        _ur, "urlopen",
+        lambda req, timeout=0: _FakeResp({"ok": True, "expired": True}),
+    )
+
+    node_id, trial = _d._selfhost_signin_with_key("cm_selfhost123")
+    assert trial == "expired"
+    assert nocloud.exists()
+    # Identity still persisted: the user is signed in even without a trial.
+    cfg = json.loads((home / ".clawmetry" / "config.json").read_text())
+    assert cfg["api_key"] == "cm_selfhost123"
+
+
+def test_selfhost_signin_survives_trial_server_outage(tmp_path, monkeypatch):
+    """A trial-mint outage must not lose the sign-in: identity persists,
+    egress stays off, trial reports 'unavailable'."""
+    _d, _lic, _ur, home, nocloud = _selfhost_env(tmp_path, monkeypatch)
+
+    monkeypatch.setattr(_lic, "_cloud_base", lambda: "https://ingest.example")
+
+    def _down(req, timeout=0):
+        raise OSError("connection refused")
+
+    monkeypatch.setattr(_ur, "urlopen", _down)
+
+    node_id, trial = _d._selfhost_signin_with_key("cm_selfhost123")
+    assert trial == "unavailable"
+    assert nocloud.exists()
+    cfg = json.loads((home / ".clawmetry" / "config.json").read_text())
+    assert cfg["api_key"] == "cm_selfhost123"

--- a/tests/test_onboarding_gate.py
+++ b/tests/test_onboarding_gate.py
@@ -123,6 +123,10 @@ def test_activate_license_happy_path(ob, client, monkeypatch):
     fake_lic = types.SimpleNamespace(
         activate=lambda key, actor="": (True, "activated"))
     monkeypatch.setitem(sys.modules, "clawmetry.license", fake_lic)
+    # `from clawmetry import license` prefers the package attribute once the
+    # real module has been imported anywhere in the session, so shim both.
+    import clawmetry
+    monkeypatch.setattr(clawmetry, "license", fake_lic, raising=False)
     monkeypatch.setattr(ob, "_license_state", lambda: "selfhost_license")
     pings = []
     monkeypatch.setattr(ob, "_ping_onboarded", pings.append)
@@ -180,3 +184,46 @@ def test_gate_js_is_hard_gate_and_cloud_safe():
     assert "/api/trial/activate" in js
     assert "/api/onboarding/activate-license" in js
     assert "openCloudModal" in js
+
+
+def test_selfhost_card_offers_oauth_in_both_renders():
+    """The self-host card must offer Google/GitHub in BOTH renders: the
+    template's initial body and the JS re-render (_selfhostHome). One
+    without the other means the options vanish after any back-navigation."""
+    js = open(os.path.join(
+        _ROOT, "clawmetry", "static", "js", "onboarding.js"),
+        encoding="utf-8").read()
+    assert "mode: 'selfhost'" in js, "self-host OAuth must use the selfhost bridge mode"
+    assert "/api/cloud-cta/oauth-start" in js
+    assert js.count("obg-oauth-github") >= 2 and js.count("obg-oauth-google") >= 2, \
+        "OAuth buttons must be both rendered (_selfhostHome) and wired (_wireSelfhostHome)"
+    html = open(os.path.join(
+        _ROOT, "clawmetry", "templates", "partials", "onboarding-modal.html"),
+        encoding="utf-8").read()
+    assert 'id="obg-oauth-github"' in html and 'id="obg-oauth-google"' in html
+
+
+def test_marker_semantics_selfhost_writes_nocloud(monkeypatch, tmp_path):
+    """NOCLOUD_MARKER_PATH is a plain str; the old .parent/.touch calls
+    raised AttributeError into the broad except, so the marker was silently
+    never written for self-host choices (identity risked becoming an
+    unasked-for upload once a cm_ key landed on disk)."""
+    import routes.onboarding as mod
+    from clawmetry import config as _cfg
+
+    marker = tmp_path / "clawmetry-home" / "nocloud"
+    monkeypatch.setattr(_cfg, "NOCLOUD_MARKER_PATH", str(marker))
+    mod._apply_marker_semantics("selfhost_trial")
+    assert marker.exists(), "self-host choice must write the nocloud marker"
+
+
+def test_marker_semantics_managed_clears_nocloud(monkeypatch, tmp_path):
+    import routes.onboarding as mod
+    from clawmetry import config as _cfg
+
+    marker = tmp_path / "nocloud"
+    marker.write_text("")
+    monkeypatch.setattr(_cfg, "NOCLOUD_MARKER_PATH", str(marker))
+    monkeypatch.delenv("CLAWMETRY_NO_CLOUD", raising=False)
+    mod._apply_marker_semantics("managed")
+    assert not marker.exists()


### PR DESCRIPTION
## Why

Founder report: "google github on self-host works via terminal but difficult via localhost". `clawmetry login` has had Google/GitHub OAuth (loopback + paste-code) since 0.12.532, decoupled from cloud sync. The dashboard's onboarding gate self-host card only offered email OTP; the only OAuth on localhost was the managed path, which registers the node, clears `nocloud`, and starts the sync daemon - not what a self-host user asked for.

## What

**Same rail as the CLI, now from the gate's self-host card:**

- The existing loopback OAuth bridge (`_start_oauth_bridge`) gains `mode="selfhost"`: capture the `cm_` key over 127.0.0.1 exactly like `clawmetry connect`, then instead of the full cloud connect it
  1. touches the `nocloud` marker **before** persisting the key (the daemon must never observe a key without the marker),
  2. registers identity (`validate_key` best-effort, `config.json`, cloud-token mirror),
  3. mints-or-reuses the account's 7-day trial via `POST /api/license/trial/signup` (the endpoint that exists precisely for OAuth sign-ins with no OTP in hand) and activates it locally,
  4. ensures the local ingest daemon is running (local-only under the marker).
- Self-host card now offers **Continue with GitHub / Google / email** plus the license-key link, in both the template render and the JS re-render. Honest states for trial expired (pricing + license key) and trial-mint outage (signed in, retry or email).
- `/api/cloud-cta/oauth-start` accepts `mode` (default `managed`, existing callers unchanged); `oauth-status` reports `mode` + `trial`.
- No cloud-side change needed: prod already accepts any 1024-65535 loopback port and serves `/api/license/trial/signup` (probed live, 400 "valid api_key required" on empty body).

**Bug fix found on the way:** `_apply_marker_semantics` called `.parent`/`.touch` on `NOCLOUD_MARKER_PATH`, which is a plain `str` - `AttributeError` swallowed by the broad except, so the self-host `nocloud` marker was silently never written. Fixed + regression test.

## Verification

- 31 tests green across `test_cloud_cta_oauth.py` + `test_onboarding_gate.py` (new: selfhost rail keeps marker + activates trial, expired never activates, outage keeps identity, mode passthrough, marker semantics, both-renders guard). The 3 failures in `test_oauth_detection.py`/`test_local_trial.py` pre-exist on main in this env.
- Playwright E2E against a fresh-HOME dashboard on :8905: card renders all options; Continue with GitHub opens `https://app.clawmetry.com/api/oauth/github/start?cli_port=<port>`; simulated loopback callback drove the full selfhost rail - bridge `{mode: selfhost, status: connected}`, `nocloud` marker written, `config.json` persisted, honest "couldn't start your trial" copy for the fake key.


🤖 Generated with [Claude Code](https://claude.com/claude-code)