### PR TITLE
feat(brain): surface failed tool calls — ERROR events, per-run issue badges, error-only filter

### DIFF
--- a/clawmetry/static/css/dashboard.css
+++ b/clawmetry/static/css/dashboard.css
@@ -1770,6 +1770,22 @@
 .brain-seq-label { color: var(--text-secondary); }
 .brain-seq-meta { margin-left: auto; font-weight: 500; opacity: 0.85; }
 .brain-seq-body { padding: 0 8px 8px; }
+/* Per-run error badge + error row tint (Brain-visualizer adoption #3). */
+.brain-seq-errs {
+  flex-shrink: 0;
+  padding: 0 7px;
+  border-radius: 10px;
+  background: rgba(239, 68, 68, 0.14);
+  color: #ef4444;
+  font-size: 10px;
+  font-weight: 700;
+  white-space: nowrap;
+}
+.brain-event.brain-error-row {
+  border-left: 2px solid rgba(239, 68, 68, 0.6);
+  padding-left: 6px;
+  background: rgba(239, 68, 68, 0.05);
+}
 
 /* ── Brain swimlane ───────────────────────────────────────────────────────
    Bird's-eye strip: one lane per agent run, drawn against real wall-clock
@@ -1825,6 +1841,9 @@
   opacity: 0.85;
 }
 .brain-lane:hover .brain-lane-bar { opacity: 1; }
+/* A run that hit failed tool calls gets a red ring so problems are
+   visible from the bird's-eye strip before expanding anything. */
+.brain-lane-bar.brain-lane-bar-err { box-shadow: 0 0 0 1.5px rgba(239, 68, 68, 0.85); }
 .brain-seq-flash {
   box-shadow: 0 0 0 2px var(--accent, #60a5fa), 0 0 18px rgba(96, 165, 250, 0.35);
   transition: box-shadow 0.25s ease;

--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -5053,7 +5053,9 @@ function setBrainTypeFilter(type, btn) {
     b.style.background = isActive ? 'rgba(168,85,247,0.2)' : 'transparent';
     b.style.fontWeight = isActive ? '600' : '400';
   });
-  renderBrainFeed();
+  // Was renderBrainFeed() — a function that never existed, so every type-chip
+  // click died on a ReferenceError and the filter silently did nothing.
+  renderBrainStream(_brainAllEvents);
   _brainRefreshGraphIfActive();
 }
 function setBrainFilter(source, btn) {
@@ -5184,7 +5186,7 @@ function renderBrainTypeChips(events) {
   if (_tcRt && _tcRt !== 'all' && typeof _cmRuntimeOf === 'function') {
     events = events.filter(function(ev) { return _cmRuntimeOf(ev) === _tcRt; });
   }
-  var typeColors = {'USER':'#60a5fa','AGENT':'#a855f7','EXEC':'#f59e0b','THINK':'#94a3b8','TOOL':'#f97316','WRITE':'#10b981','SEARCH':'#06b6d4','BROWSER':'#ec4899','SPAWN':'#8b5cf6','MSG':'#22c55e','READ':'#6ee7b7','CONTEXT':'#64748b','RESULT':'#6ee7b7'};
+  var typeColors = {'USER':'#60a5fa','AGENT':'#a855f7','EXEC':'#f59e0b','THINK':'#94a3b8','TOOL':'#f97316','WRITE':'#10b981','SEARCH':'#06b6d4','BROWSER':'#ec4899','SPAWN':'#8b5cf6','MSG':'#22c55e','READ':'#6ee7b7','CONTEXT':'#64748b','RESULT':'#6ee7b7','ERROR':'#ef4444'};
   var typeCounts = {};
   events.forEach(function(ev) { typeCounts[ev.type] = (typeCounts[ev.type]||0) + 1; });
   var types = Object.keys(typeCounts).sort();
@@ -5694,6 +5696,7 @@ function renderBrainStream(events) {
     var rowCls = '';
     if (_isPlumbingEvent(ev)) rowCls += ' brain-plumbing';
     if (chInfo && chInfo.bodyMissing) rowCls += ' brain-relay-only';
+    if (evType === 'ERROR' || ev.isError) rowCls += ' brain-error-row';
     html += '<div class="brain-event' + _evExpCls + rowCls + '" data-evkey="' + escHtml(_evKey) + '" onclick="_toggleBrainEvent(this, this.dataset.evkey)">';
     html += '<div class="brain-meta">';
     html += '<span class="brain-time">' + formatBrainTime(ev.time) + '</span>';
@@ -5814,10 +5817,19 @@ function _brainGroupSequences(rows) {
     var dur = _brainSeqDuration(newest - oldest);
     var steps = g.length;
     var meta = steps + ' event' + (steps === 1 ? '' : 's') + (dur ? ' \u00b7 \u23f1 ' + dur : '');
+    // Per-run error badge (Brain-visualizer adoption #3): failed tool
+    // results arrive typed ERROR, so a collapsed block still tells you
+    // which run hit problems before you expand it.
+    var errs = 0;
+    g.forEach(function(r) { var e = r.ev || {}; if ((e.type || '') === 'ERROR' || e.isError) errs++; });
+    var errBadge = errs
+      ? '<span class="brain-seq-errs" title="' + errs + ' failed tool call' + (errs === 1 ? '' : 's') + ' in this run">\u26a0 ' + errs + '</span>'
+      : '';
     out += '<div class="brain-seq" id="' + _brainSeqDomId(key) + '">'
         +  '<div class="brain-seq-head" onclick="toggleBrainSequence(this)">'
         +  '<span class="brain-seq-chevron">\u203a</span>'
         +  '<span class="brain-seq-label">' + escHtml(_brainSeqLabel(g[0].ev)) + '</span>'
+        +  errBadge
         +  '<span class="brain-seq-meta">' + escHtml(meta) + '</span>'
         +  '</div>'
         +  '<div class="brain-seq-body">'
@@ -5862,7 +5874,9 @@ function _brainSwimlane(order, buckets) {
     if (!start || !end) return;
     if (start < min) min = start;
     if (end > max) max = end;
-    spans.push({key: key, start: start, end: end, n: g.length, ev: g[0].ev});
+    var errs = 0;
+    g.forEach(function(r) { var e = r.ev || {}; if ((e.type || '') === 'ERROR' || e.isError) errs++; });
+    spans.push({key: key, start: start, end: end, n: g.length, ev: g[0].ev, errs: errs});
   });
   if (spans.length < 2 || !isFinite(min) || max <= min) return '';
   var total = max - min;
@@ -5872,12 +5886,13 @@ function _brainSwimlane(order, buckets) {
     if (left + width > 100) width = 100 - left;
     var col = brainSourceColor(sp.ev.source || sp.ev.src || 'main');
     var title = _brainSeqLabel(sp.ev) + ' \u00b7 ' + sp.n + ' events \u00b7 '
-              + _brainSeqDuration(sp.end - sp.start);
+              + _brainSeqDuration(sp.end - sp.start)
+              + (sp.errs ? ' \u00b7 \u26a0 ' + sp.errs + ' error' + (sp.errs === 1 ? '' : 's') : '');
     return '<div class="brain-lane" onclick="jumpToBrainSequence(\'' + _brainSeqDomId(sp.key) + '\')" title="'
          + escHtml(title) + '">'
          + '<span class="brain-lane-name">' + escHtml(_brainSeqLabel(sp.ev)) + '</span>'
          + '<span class="brain-lane-track">'
-         + '<span class="brain-lane-bar" style="left:' + left.toFixed(2) + '%;width:'
+         + '<span class="brain-lane-bar' + (sp.errs ? ' brain-lane-bar-err' : '') + '" style="left:' + left.toFixed(2) + '%;width:'
          + width.toFixed(2) + '%;background:' + col + ';"></span>'
          + '</span></div>';
   }).join('');

--- a/routes/brain.py
+++ b/routes/brain.py
@@ -350,6 +350,30 @@ def _collapse_duplicate_brain_events(events):
     )
 
 
+def _row_is_error(row: dict) -> bool:
+    """True when a stored tool-result row carries a real error flag.
+
+    The flag lives in different spots per ingest path: family adapters
+    (Claude Code, Codex, …) stamp ``data.extra.isError``; the OpenClaw v3
+    mapper stamps ``data.is_error`` plus the ``data.data`` mirror. Benign
+    failures (read-guards, transient timeouts) are already downgraded at
+    ingest and marked ``benign_error`` — those must not resurface here.
+    """
+    data = row.get("data")
+    if not isinstance(data, dict):
+        return False
+    inner = data.get("data") if isinstance(data.get("data"), dict) else {}
+    if data.get("benign_error") or inner.get("benign_error"):
+        return False
+    extra = data.get("extra") if isinstance(data.get("extra"), dict) else {}
+    return bool(
+        data.get("is_error")
+        or inner.get("is_error")
+        or extra.get("isError")
+        or extra.get("is_error")
+    )
+
+
 def _try_local_store_brain(limit, include_artifacts, since=None, until=None):
     """Epic #964 phase 1b fast path. Returns a brain-history-shaped dict
     when CLAWMETRY_LOCAL_STORE_READ=1 AND the local DuckDB store has
@@ -443,6 +467,14 @@ def _try_local_store_brain(limit, include_artifacts, since=None, until=None):
         # shapes (legacy, v3 mapper top-level, v3 mapper mirror).
         detail = _extract_brain_detail(r)
         evt_type = (r.get("event_type") or "").upper()
+        # Error surfacing (Brain-visualizer adoption #3): a failed tool
+        # result becomes a first-class ERROR event so the ❌ icon, the
+        # type chips, and the type filter all pick it up with no extra
+        # client plumbing. The store has carried the flag since ingest;
+        # this mapper just dropped it.
+        is_err = evt_type in ("TOOL_RESULT", "TOOL.RESULT") and _row_is_error(r)
+        if is_err:
+            evt_type = "ERROR"
         if evt_type == "THINKING" and not str(detail).strip():
             # Claude Code (and siblings) persist extended thinking as an
             # ENCRYPTED signature block — the text itself is never written to
@@ -472,6 +504,8 @@ def _try_local_store_brain(limit, include_artifacts, since=None, until=None):
             # carries one extra short string per row.
             "eventId":    r.get("id") or "",
         }
+        if is_err:
+            row["isError"] = True
         # ── Channel-event enrichment (PR aca53ec8 / Telegram ingest) ─────
         # Channel turns land here as event_type=channel.in|channel.out with
         # the raw provider payload under ``data``. Surface a few flat fields

--- a/tests/brain_sequences.test.mjs
+++ b/tests/brain_sequences.test.mjs
@@ -81,5 +81,21 @@ check('USER rows split turns within a session',
 check('duration formatting', _brainSeqDuration(500)==='<1s' && _brainSeqDuration(45000)==='45s' && _brainSeqDuration(3900000)==='1h 5m');
 check('bad duration safe', _brainSeqDuration(NaN)==='' && _brainSeqDuration(-5)==='');
 
+// Error surfacing (adoption #3): failed tool results arrive typed ERROR.
+// The run that contains them gets a ⚠ badge on its block header and a red
+// ring on its swimlane bar; clean runs get neither.
+const errRows = [
+  R('claude_code:err11111', 10, '<e4>'), R('codex:ok222222', 9, '<o3>'),
+  R('claude_code:err11111', 8,  '<e3>', 'ERROR'), R('codex:ok222222', 6, '<o2>'),
+  R('claude_code:err11111', 4,  '<e2>', 'ERROR'), R('claude_code:err11111', 0, '<e1>'),
+  R('codex:ok222222', 0, '<o1>'),
+];
+const eout = _brainGroupSequences(errRows);
+check('error run gets a ⚠ badge with the count', eout.includes('brain-seq-errs') && eout.includes('⚠ 2'));
+check('exactly one block is badged', (eout.match(/brain-seq-errs/g)||[]).length === 1);
+check('error lane gets the red ring', (eout.match(/brain-lane-bar-err/g)||[]).length === 1);
+check('lane tooltip carries the error count', eout.includes('2 errors'));
+check('clean feed has no error chrome', !out.includes('brain-seq-errs') && !out.includes('brain-lane-bar-err'));
+
 console.log(`\n${pass} passed, ${fail} failed`);
 process.exit(fail ? 1 : 0);

--- a/tests/test_brain_error_surfacing.py
+++ b/tests/test_brain_error_surfacing.py
@@ -1,0 +1,116 @@
+"""Brain error surfacing (Brain-visualizer adoption #3).
+
+The store has carried per-tool-result error flags since ingest — family
+adapters stamp ``data.extra.isError`` and the OpenClaw v3 mapper stamps
+``data.is_error`` — but ``/api/brain-history`` dropped them, so the feed
+showed a failed Bash call and a clean one identically (and the UI's ❌
+ERROR icon was unreachable dead weight). These tests pin the mapper
+contract: a real error becomes a first-class ``type: ERROR`` event with
+``isError: true``; benign errors (downgraded at ingest) and clean results
+stay ``TOOL_RESULT``.
+"""
+
+from __future__ import annotations
+
+import importlib
+import time
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def app(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_BATCH", "5")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_READ", "1")
+
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    import routes.brain as br
+    importlib.reload(br)
+
+    import dashboard as _d
+    monkeypatch.setattr(_d, "_is_pro_user", lambda: True)
+
+    a = Flask(__name__)
+    a.register_blueprint(br.bp_brain)
+    yield a, ls
+    try:
+        ls.get_store().stop(flush=True)
+    except Exception:
+        pass
+
+
+def _wait_flush(store, t=2.0):
+    deadline = time.monotonic() + t
+    while time.monotonic() < deadline:
+        if store.health()["ring_depth"] == 0:
+            return
+        time.sleep(0.02)
+
+
+def _ingest(store, i, data):
+    store.ingest({
+        "id": f"ev-err-{i}",
+        "node_id": "agent+test",
+        "agent_id": "main",
+        "session_id": "claude_code:sess-err",
+        "event_type": "tool_result",
+        "ts": f"2026-05-11T12:00:0{i}Z",
+        "data": data,
+        "cost_usd": 0.0,
+        "token_count": 0,
+        "model": "",
+    })
+
+
+def test_error_flags_become_error_events(app):
+    a, ls = app
+    store = ls.get_store()
+    # Family-adapter shape (Claude Code, Codex, …): flag under extra.isError.
+    _ingest(store, 0, {"role": "toolResult", "content": "Exit code 1: boom",
+                       "_runtime": "claude_code",
+                       "extra": {"isError": True, "toolUseId": "t1"}})
+    # OpenClaw v3 shape: flag at data.is_error (+ data.data mirror).
+    _ingest(store, 1, {"output": "command not found", "is_error": True,
+                       "data": {"output": "command not found", "is_error": True}})
+    # Benign error, downgraded at ingest — must NOT resurface as ERROR.
+    _ingest(store, 2, {"role": "toolResult", "content": "read guard tripped",
+                       "_runtime": "claude_code", "benign_error": True,
+                       "extra": {"isError": False, "toolUseId": "t3"}})
+    # Clean result.
+    _ingest(store, 3, {"role": "toolResult", "content": "21 passed, 0 failed",
+                       "_runtime": "claude_code",
+                       "extra": {"isError": False, "toolUseId": "t4"}})
+    _wait_flush(store)
+
+    c = a.test_client()
+    r = c.get("/api/brain-history?limit=10")
+    assert r.status_code == 200, r.get_data(as_text=True)[:300]
+    body = r.get_json()
+    assert body.get("_source") == "local_store"
+
+    by_id = {ev["eventId"]: ev for ev in body["events"]}
+    assert by_id["ev-err-0"]["type"] == "ERROR"
+    assert by_id["ev-err-0"]["isError"] is True
+    assert by_id["ev-err-1"]["type"] == "ERROR"
+    assert by_id["ev-err-1"]["isError"] is True
+    # "0 failed" in a clean result must not be flagged (text is never
+    # inspected — only the stored structured flag counts).
+    assert by_id["ev-err-3"]["type"] == "TOOL_RESULT"
+    assert "isError" not in by_id["ev-err-3"]
+    assert by_id["ev-err-2"]["type"] == "TOOL_RESULT"
+    assert "isError" not in by_id["ev-err-2"]
+
+
+def test_row_is_error_never_raises_on_junk(app):
+    _a, _ls = app
+    import routes.brain as br
+    assert br._row_is_error({}) is False
+    assert br._row_is_error({"data": None}) is False
+    assert br._row_is_error({"data": "not a dict"}) is False
+    assert br._row_is_error({"data": {"extra": "not a dict"}}) is False
+    assert br._row_is_error({"data": {"extra": {"isError": True}}}) is True
+    assert br._row_is_error({"data": {"is_error": True, "benign_error": True}}) is False


### PR DESCRIPTION
## What

**Brain-visualizer adoption #3: error surfacing per run — for all 16 runtimes.**

The DuckDB store has carried per-tool-result error flags since ingest (family adapters stamp `extra.isError`, the OpenClaw v3 mapper stamps `is_error`; benign read-guards/timeouts are already downgraded at ingest). But `/api/brain-history` dropped the flag, so the Brain feed showed a failed Bash call and a clean one identically — and the UI's ❌ ERROR icon in `_brainTypeIcons` was unreachable dead weight.

- **Backend** (`routes/brain.py`): the local-store mapper retypes flagged tool results to first-class `ERROR` events (+ `isError: true`). Text is never inspected — only the stored structured flag counts, so "21 passed, 0 failed" can't false-positive.
- **Rows**: red tint + left border, ❌ ERROR pill.
- **Per-run badges**: sequence block headers get `⚠ N`; swimlane lanes with failures get a red ring + error count in the tooltip — problems visible from the bird's-eye strip before expanding anything.
- **Issues-only filter**: the type chip strip now grows a red `ERROR (N)` chip; clicking it shows only failures. Chart mirrors via the existing type filter.

## Bug found along the way

`setBrainTypeFilter` called `renderBrainFeed()` — **a function that never existed**. Every type-chip click died on a ReferenceError, so type filtering has been silently broken. Fixed to `renderBrainStream(_brainAllEvents)`.

## Verified live (real DuckDB data on the founder node)

4 real failures (exit-code-1 tracebacks, blocked commands, permission denials) surfaced, badged `⚠ 4` on their run's block, red-ringed on the swimlane, and isolated by the ERROR chip. Screenshots in thread.

## Tests

- `tests/brain_sequences.test.mjs`: 26 checks (5 new — badge count, single-badged-block, lane ring, tooltip, clean-feed-no-chrome)
- `tests/test_brain_error_surfacing.py` (new): mapper contract for family/v3/benign/clean shapes + `_row_is_error` junk-safety

🤖 Generated with [Claude Code](https://claude.com/claude-code)