### PR TITLE
feat(entitlement): has_batch + /api/entitlement/has-batch (per-item plural has-* sibling)

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -8812,6 +8812,269 @@ def lock_reasons_batch(
     return out
 
 
+def _has_row(ent, key, kind: str) -> dict:
+    """Per-item boolean-gate row for :func:`has_batch`.
+
+    Row-shape sibling of :func:`_min_tier_row` (which carries the reverse-
+    lookup cheapest-tier answer per item) and :func:`_lock_row` (which
+    carries the current-resolver lock reason per item): mirrors the same
+    ``key`` + ``kind`` + normalised value contract but carries the
+    boolean-gate answer (``has`` + ``unknown``) on the resolved
+    entitlement, matching the strict callsite-typo posture of the singular
+    :func:`has_feature` / :func:`has_runtime` / :func:`has_channel_count`
+    scalars.
+
+    ``unknown`` is the key differentiator from :func:`_lock_row`: an
+    unrecognised feature/runtime id or a non-int capacity value flips
+    ``unknown=True`` and ``has=False`` (fail-closed), where the lock-
+    reasons row would report ``allowed=True`` with a ``None`` reason and
+    silently render the mystery id as granted. A paywall matrix wiring
+    off this row cannot mistake a typo (``fleeet``) for a granted
+    feature.
+
+    Kind semantics mirror :func:`_min_tier_row` exactly:
+
+    * ``"feature"`` / ``"runtime"`` -- ``key`` is a normalised id
+      (whitespace stripped, lowercased; runtimes additionally
+      canonicalised via :func:`canonical_runtime` so ``claude-code`` ->
+      ``claude_code``). Unknown ids get ``unknown=True`` / ``has=False``
+      / ``required_tier=None`` / ``required_tier_rank=-1``.
+    * ``"channels"`` / ``"retention_days"`` / ``"nodes"`` -- ``key``
+      is int-parseable; non-int input collapses to
+      ``unknown=True`` / ``has=False``. Non-negative ints are considered
+      "known"; the underlying :meth:`Entitlement.allows_*` decides
+      ``has``.
+
+    ``required_tier`` on this row reports the cheapest tier that would
+    admit the item -- the same tier :func:`min_tier_for_feature` /
+    :func:`min_tier_for_runtime` / :func:`min_tier_for_channel_count` /
+    :func:`min_tier_for_retention_window` / :func:`min_tier_for_node_count`
+    return -- so a UI showing "you don't have this; buy tier X to unlock"
+    reads off the same row without a second call.
+
+    Never raises: any resolver failure short-circuits to the fail-closed
+    row shape so the caller keeps rendering.
+    """
+    try:
+        if kind == "feature":
+            fid = str(key or "").strip().lower()
+            if not fid or fid not in ALL_FEATURES:
+                return {
+                    "key": fid,
+                    "kind": kind,
+                    "has": False,
+                    "unknown": True,
+                    "required_tier": None,
+                    "required_tier_label": None,
+                    "required_tier_rank": -1,
+                }
+            has_flag = bool(ent.allows_feature(fid))
+            req = min_tier_for_feature(fid)
+            return {
+                "key": fid,
+                "kind": kind,
+                "has": has_flag,
+                "unknown": False,
+                "required_tier": req,
+                "required_tier_label": tier_label(req) if req else None,
+                "required_tier_rank": tier_rank(req) if req else -1,
+            }
+        if kind == "runtime":
+            raw = str(key or "").strip().lower()
+            rt = canonical_runtime(raw)
+            if not rt or rt not in ALL_RUNTIMES:
+                return {
+                    "key": raw,
+                    "kind": kind,
+                    "has": False,
+                    "unknown": True,
+                    "required_tier": None,
+                    "required_tier_label": None,
+                    "required_tier_rank": -1,
+                }
+            has_flag = bool(ent.allows_runtime(rt))
+            req = min_tier_for_runtime(rt)
+            return {
+                "key": rt,
+                "kind": kind,
+                "has": has_flag,
+                "unknown": False,
+                "required_tier": req,
+                "required_tier_label": tier_label(req) if req else None,
+                "required_tier_rank": tier_rank(req) if req else -1,
+            }
+        if kind in ("channels", "retention_days", "nodes"):
+            try:
+                n = int(key)
+            except (TypeError, ValueError):
+                return {
+                    "key": str(key),
+                    "kind": kind,
+                    "has": False,
+                    "unknown": True,
+                    "required_tier": None,
+                    "required_tier_label": None,
+                    "required_tier_rank": -1,
+                }
+            if kind == "channels":
+                has_flag = bool(ent.allows_channel_count(n))
+                req = min_tier_for_channel_count(n)
+            elif kind == "retention_days":
+                has_flag = bool(ent.allows_retention_window(n))
+                req = min_tier_for_retention_window(n)
+            else:
+                has_flag = bool(ent.allows_node_count(n))
+                req = min_tier_for_node_count(n)
+            return {
+                "key": str(n),
+                "kind": kind,
+                "has": has_flag,
+                "unknown": False,
+                "required_tier": req,
+                "required_tier_label": tier_label(req) if req else None,
+                "required_tier_rank": tier_rank(req) if req else -1,
+            }
+    except Exception:
+        pass
+    return {
+        "key": str(key),
+        "kind": kind,
+        "has": False,
+        "unknown": True,
+        "required_tier": None,
+        "required_tier_label": None,
+        "required_tier_rank": -1,
+    }
+
+
+def has_batch(
+    *,
+    features=None,
+    runtimes=None,
+    channels: int | None = None,
+    retention_days: int | None = None,
+    nodes: int | None = None,
+) -> dict:
+    """Per-item boolean-gate rows for every supplied item across all five
+    capacity axes in one pass.
+
+    Per-item plural sibling of :func:`has_feature` / :func:`has_runtime`
+    / :func:`has_channel_count` (singular) and :func:`has_features` /
+    :func:`has_runtimes` (plural bundle fold). Where the plural fold
+    collapses a bundle to ONE boolean (``True`` iff every item is
+    granted), this helper preserves per-item detail so a paywall matrix
+    UI ("show me each requested feature + runtime + capacity row with
+    its individual granted flag AND the cheapest tier that would unlock
+    it") renders off ONE round-trip instead of N calls to
+    ``/api/entitlement/has-feature`` + ``/api/entitlement/has-runtime`` +
+    ``/api/entitlement/has-channel-count`` etc.
+
+    Envelope shape mirrors :func:`min_tier_batch` and
+    :func:`lock_reasons_batch` exactly (same five-axis kwargs, same per-
+    axis ``None`` "not supplied" sentinel, same never-raise contract)::
+
+        {
+          "features":       [<row>, ...],
+          "runtimes":       [<row>, ...],
+          "channels":       <row> | None,
+          "retention_days": <row> | None,
+          "nodes":          <row> | None,
+        }
+
+    Each ``<row>`` carries ``key``, ``kind``, ``has`` (bool),
+    ``unknown`` (True iff the id was not in :data:`ALL_FEATURES` /
+    :data:`ALL_RUNTIMES` or was non-int for the capacity axes),
+    ``required_tier`` (cheapest tier that would unlock the item; the
+    same answer :func:`min_tier_for_feature` / ...runtime /
+    ...channel_count / ...retention_window / ...node_count would return),
+    ``required_tier_label`` and ``required_tier_rank`` (``-1`` when
+    ``required_tier`` is ``None``).
+
+    Strict-typo-fail-closed posture matches the singular scalars: a
+    typo like ``has_batch(features=["Fleeet"])`` (uppercase, dropped by
+    strip-lower, then unmatched against :data:`ALL_FEATURES`) surfaces
+    as ``unknown=True`` / ``has=False`` -- NOT silently granted in
+    grace. This is DIFFERENT from :func:`lock_reasons_batch`, which
+    treats unknown ids as ``allowed=True`` with a ``None`` reason (the
+    lock-reasons axis is diagnostic, not gate-shaped). A callsite that
+    binds a gate off this batch cannot mistake a typo for a grant.
+
+    Per-row parity with the singular helpers is pinned in the test
+    suite: for every feature id ``f`` in :data:`ALL_FEATURES`,
+    ``has_batch(features=[f])['features'][0]['has']`` byte-equals
+    :func:`has_feature`; ditto for every id in :data:`ALL_RUNTIMES`
+    against :func:`has_runtime`, and for the ``channels`` axis against
+    :func:`has_channel_count`.
+
+    Feature ids are normalised via :func:`_normalise_csv` (whitespace
+    stripped, lowercased, duplicates dropped while preserving first-
+    seen order). Runtime ids additionally canonicalise via
+    :func:`canonical_runtime` so aliases (``claude-code`` ->
+    ``claude_code``) resolve the same way they do on the singular
+    ``has_runtime`` scalar; duplicates that collapse after
+    canonicalisation only contribute one row.
+
+    Critically, ``retention_days=None`` here means *unset* -- NOT
+    *unlimited*. Same posture as :func:`min_tier_batch` /
+    :func:`lock_reasons_batch`: asking about the unlimited-retention
+    tier is the singular :meth:`Entitlement.allows_retention_window`
+    (``days=None``) call's job and would collapse the batch row
+    kwarg-branch to "not supplied" otherwise.
+
+    Grace vs enforce: while ``ent.grace`` is ``True`` (the current
+    rollout state) every KNOWN row reports ``has=True``; unknown rows
+    still fail-closed to ``has=False`` (the typo-catches-at-callsite
+    contract). Post-enforcement each row reflects the underlying
+    :meth:`Entitlement.allows_*` answer.
+
+    Never raises: a per-row failure short-circuits to the fail-closed
+    row shape so the paywall matrix keeps rendering.
+    """
+    try:
+        ent = get_entitlement()
+    except Exception as exc:
+        logger.warning("entitlements: has_batch falling back to grace: %s", exc)
+        ent = _oss_free()
+    try:
+        feats = _normalise_csv(features)
+        raw_rts = _normalise_csv(runtimes)
+        seen: set[str] = set()
+        rt_rows: list[dict] = []
+        for raw in raw_rts:
+            rt = canonical_runtime(raw)
+            key = rt if rt else raw
+            if key in seen:
+                continue
+            seen.add(key)
+            rt_rows.append(_has_row(ent, raw, "runtime"))
+        return {
+            "features": [_has_row(ent, f, "feature") for f in feats],
+            "runtimes": rt_rows,
+            "channels": (
+                _has_row(ent, channels, "channels")
+                if channels is not None
+                else None
+            ),
+            "retention_days": (
+                _has_row(ent, retention_days, "retention_days")
+                if retention_days is not None
+                else None
+            ),
+            "nodes": (
+                _has_row(ent, nodes, "nodes") if nodes is not None else None
+            ),
+        }
+    except Exception as exc:
+        logger.warning("entitlements: has_batch failed: %s", exc)
+        return {
+            "features": [],
+            "runtimes": [],
+            "channels": None,
+            "retention_days": None,
+            "nodes": None,
+        }
+
+
 def feature_label(feature: str) -> str:
     fid = (feature or "").strip().lower()
     return FEATURE_LABELS.get(fid, fid)

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -6691,6 +6691,162 @@ def api_entitlement_min_tier_batch():
         )
 
 
+def _has_batch_fallback() -> dict:
+    """OSS-free / never-5xx envelope for ``/api/entitlement/has-batch``.
+
+    Fail-closed on the ``has_all`` rollup (matches the singular
+    ``/api/entitlement/has-feature`` / ``/has-runtime`` fallbacks): a paywall
+    matrix that lost the resolver must not silently render every row as
+    granted. All axis slots collapse to the "not supplied" sentinel so a UI
+    can still diff against the request shape.
+    """
+    return {
+        "features": [],
+        "runtimes": [],
+        "channels": None,
+        "retention_days": None,
+        "nodes": None,
+        "has_all": False,
+        "current_tier": "oss",
+        "current_tier_rank": 0,
+        "grace": True,
+        "enforced": False,
+    }
+
+
+def _has_batch_rollup(batch: dict) -> bool:
+    """Fold every emitted row in ``batch`` to ONE ``has_all`` boolean.
+
+    ``True`` iff every emitted row is ``has=True`` AND ``unknown=False`` --
+    matches the strict-typo-fail-closed posture of :func:`has_features` /
+    :func:`has_runtimes` in the plural fold sibling (a single unknown-id
+    row flips the rollup to ``False`` so a typo does not silently render
+    as granted). A batch with no rows at all (every axis was "not
+    supplied") returns ``True`` vacuously -- the endpoint 400s on that
+    input before this rollup runs, so callers never see the vacuous case
+    on a live URL.
+    """
+    for axis in ("features", "runtimes"):
+        for row in batch.get(axis) or []:
+            if row.get("unknown") or not row.get("has"):
+                return False
+    for axis in ("channels", "retention_days", "nodes"):
+        row = batch.get(axis)
+        if row is None:
+            continue
+        if row.get("unknown") or not row.get("has"):
+            return False
+    return True
+
+
+@bp_entitlement.route("/api/entitlement/has-batch")
+def api_entitlement_has_batch():
+    """``GET /api/entitlement/has-batch?features=a,b,c&runtimes=x,y
+    &channels=N&retention_days=K&nodes=M`` -- per-item plural sibling of
+    ``/api/entitlement/has-feature`` / ``/has-runtime`` /
+    ``/has-channel-count``.
+
+    Where ``/api/entitlement/has-features`` / ``/has-runtimes`` fold a
+    bundle to ONE boolean, this preserves the per-item detail so a
+    paywall MATRIX UI ("show every requested feature + runtime + capacity
+    row with its individual granted flag AND the cheapest tier that
+    would unlock it") renders off ONE round-trip instead of N calls to
+    ``/has-feature`` / ``/has-runtime`` / ``/has-channel-count``. Wraps
+    :func:`clawmetry.entitlements.has_batch` and appends the same
+    ``current_tier`` / ``grace`` / ``enforced`` resolver envelope
+    ``/min-tier-batch`` and ``/lock-reasons-batch`` return so a caller
+    sees the same resolver context alongside the per-item answers.
+
+    At least one of ``features=`` / ``runtimes=`` / ``channels=`` /
+    ``retention_days=`` / ``nodes=`` must be supplied (non-empty /
+    parseable after normalisation). ``features=`` / ``runtimes=`` take
+    comma-separated tokens (whitespace and duplicates are normalised
+    away; runtime aliases like ``claude-code`` canonicalise to
+    ``claude_code``; unknown ids contribute a fail-closed
+    ``unknown=True`` / ``has=False`` row -- they do NOT silently render
+    as granted the way ``/lock-reasons-batch``'s ``allowed`` slot does).
+    The three capacity axes take a single int each; a blank or non-int
+    value is treated as "not supplied" (matches the singular endpoint's
+    never-crash posture rather than fabricating a row for garbage
+    input). Never 5xxs: the fail-closed envelope is returned on any
+    resolver failure.
+
+    Response shape (10 keys, byte-stable across every input branch)::
+
+        {
+          "features":       [<row>, ...],
+          "runtimes":       [<row>, ...],
+          "channels":       <row> | None,
+          "retention_days": <row> | None,
+          "nodes":          <row> | None,
+          "has_all":            <bool>,   # True iff every emitted row is has=True AND unknown=False
+          "current_tier":       "...",
+          "current_tier_rank":  <int>,
+          "grace":              <bool>,
+          "enforced":           <bool>,
+        }
+
+    Each ``<row>`` carries ``key``, ``kind``, ``has``, ``unknown``,
+    ``required_tier``, ``required_tier_label`` and ``required_tier_rank``
+    (``-1`` when ``required_tier`` is ``None``). Per-row parity with the
+    singular ``/has-feature?feature=`` / ``/has-runtime?runtime=`` /
+    ``/has-channel-count?count=`` endpoints is pinned in the test suite
+    so the batch cannot silently drift from the scalar.
+
+    ``has_all`` cross-consistency with the sibling
+    ``/api/entitlement/has-features`` / ``/has-runtimes`` plural-fold
+    endpoints is pinned: for a single-axis batch of features, this
+    endpoint's ``has_all`` byte-equals the ``/has-features`` endpoint's
+    ``has_features`` for the same bundle; ditto for runtimes.
+    """
+    try:
+        from clawmetry import entitlements as _ent
+
+        features = _parse_csv_arg("features")
+        runtimes = _parse_csv_arg("runtimes")
+        (_, channels_ok, channels_n, _) = _parse_capacity_arg("channels")
+        (_, retention_ok, retention_n, _) = _parse_capacity_arg("retention_days")
+        (_, nodes_ok, nodes_n, _) = _parse_capacity_arg("nodes")
+
+        if (
+            not features
+            and not runtimes
+            and not channels_ok
+            and not retention_ok
+            and not nodes_ok
+        ):
+            return (
+                jsonify(
+                    {
+                        "error": (
+                            "supply at least one of features=<csv>, "
+                            "runtimes=<csv>, channels=<int>, "
+                            "retention_days=<int>, or nodes=<int>"
+                        )
+                    }
+                ),
+                400,
+            )
+
+        batch = _ent.has_batch(
+            features=features or None,
+            runtimes=runtimes or None,
+            channels=channels_n if channels_ok else None,
+            retention_days=retention_n if retention_ok else None,
+            nodes=nodes_n if nodes_ok else None,
+        )
+        ent = _ent.get_entitlement()
+        batch["has_all"] = _has_batch_rollup(batch)
+        batch["current_tier"] = ent.tier
+        batch["current_tier_rank"] = _ent.tier_rank(ent.tier)
+        batch["grace"] = bool(ent.grace)
+        batch["enforced"] = _ent.is_enforced()
+        return jsonify(batch)
+    except Exception as exc:
+        logger.warning("api_entitlement_has_batch: error: %s", exc)
+        return jsonify(_has_batch_fallback())
+
+
 @bp_entitlement.route("/api/entitlement/min-tier-batch-at")
 def api_entitlement_min_tier_batch_at():
     """``GET /api/entitlement/min-tier-batch-at?tier=<perspective>

--- a/tests/test_entitlement_has_batch.py
+++ b/tests/test_entitlement_has_batch.py
@@ -1,0 +1,804 @@
+"""Tests for the ``has_batch`` per-item boolean-gate helper and its paired
+``/api/entitlement/has-batch`` endpoint -- per-item plural sibling of
+:func:`clawmetry.entitlements.has_feature` / :func:`~clawmetry.entitlements.has_runtime`
+/ :func:`~clawmetry.entitlements.has_channel_count`.
+
+Where the singular ``has_*`` scalars answer "does the resolved entitlement
+grant this ONE item?", ``has_batch`` answers the same question for every
+item in a caller-supplied bundle across all five capacity axes at once so a
+paywall MATRIX UI ("show every requested feature + runtime + capacity row
+with its individual granted flag AND the cheapest tier that would unlock
+it") renders off ONE round-trip instead of N calls to the singular
+endpoints.
+
+This file pins:
+
+1. Envelope shape parity (fixed key set) on the ``/has-batch`` endpoint
+   across every input branch so a frontend can bind fields off the URL
+   without a branch on the underlying resolver state.
+2. Per-row shape parity across every axis (fixed row-key set).
+3. Per-row parity with the singular ``has_feature`` / ``has_runtime`` /
+   ``has_channel_count`` scalars: the batch cannot silently drift from the
+   singular scalar on the same input.
+4. Strict-typo-fail-closed posture: unknown feature/runtime ids and non-int
+   capacity values flip ``unknown=True`` / ``has=False`` -- NOT silently
+   granted in grace (matches the singular scalars, differs from
+   ``lock_reasons_batch`` which is diagnostic, not gate-shaped).
+5. Grace-mode invariant: every KNOWN row reports ``has=True`` while grace
+   is on, so wiring this into a matrix gate today changes no current
+   behaviour.
+6. Runtime alias canonicalisation (``claude-code`` -> ``claude_code``) and
+   dedup after canonicalisation.
+7. ``retention_days=None`` means *unset*, NOT *unlimited* (matches
+   ``min_tier_batch`` / ``lock_reasons_batch``).
+8. Never-5xx: any resolver blowup collapses to the fail-closed envelope.
+9. Endpoint 400 when no axis is supplied (matches ``/min-tier-batch``).
+10. ``has_all`` rollup: True iff every emitted row is ``has=True`` AND
+    ``unknown=False`` (single unknown or single missing flips it False).
+"""
+from __future__ import annotations
+
+import importlib
+import json
+
+import pytest
+from flask import Flask
+
+
+# ── Fixtures ────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    """Fresh entitlements module with HOME pointed at an empty tmp dir so no
+    real ``~/.clawmetry/license.key`` or ``cloud_plan.json`` leaks in.
+    Enforcement off by default -- matches the project rollout posture."""
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def enforced(monkeypatch, tmp_path):
+    """Enforcement-on fixture -- ``CLAWMETRY_ENFORCE=1`` flips ``ent.grace``
+    to False so the grace pass-through collapses and paid axes report their
+    post-enforce answers."""
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    importlib.reload(e)
+    e.invalidate()
+
+
+@pytest.fixture
+def enforced_cloud_pro(monkeypatch, tmp_path):
+    """Enforcement on, cloud_pro plan wired via the disk cache the resolver
+    reads. Grants every paid runtime + most features so the batch on OSS-
+    denied items flips to has=True."""
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cache = tmp_path / ".clawmetry" / "cloud_plan.json"
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    cache.write_text(json.dumps({"plan": "cloud_pro"}))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    importlib.reload(e)
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+@pytest.fixture
+def enforced_client(enforced):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# ── Envelope + row-shape constants ──────────────────────────────────────────
+
+
+_ENVELOPE_KEYS = {
+    "features",
+    "runtimes",
+    "channels",
+    "retention_days",
+    "nodes",
+    "has_all",
+    "current_tier",
+    "current_tier_rank",
+    "grace",
+    "enforced",
+}
+
+_ROW_KEYS = {
+    "key",
+    "kind",
+    "has",
+    "unknown",
+    "required_tier",
+    "required_tier_label",
+    "required_tier_rank",
+}
+
+
+def _get_json(client, url: str, expected_status: int = 200) -> dict:
+    resp = client.get(url)
+    assert resp.status_code == expected_status, (url, resp.status_code, resp.data)
+    return resp.get_json()
+
+
+def _pick_paid_feature(ent) -> str:
+    """Return one feature id that lives above the OSS tier so ``required_tier``
+    is a real paid tier (Starter+). Picked at runtime from PAID_FEATURES so the
+    test is not brittle against catalogue reshuffles."""
+    for f in sorted(ent.PAID_FEATURES):
+        return f
+    raise RuntimeError("no PAID_FEATURES ids available in the catalogue")
+
+
+def _pick_paid_runtime(ent) -> str:
+    """Return one runtime id above OSS -- Starter+ at least."""
+    for r in sorted(ent.PAID_RUNTIMES):
+        return r
+    raise RuntimeError("no PAID_RUNTIMES ids available in the catalogue")
+
+
+# ── has_batch scalar: envelope shape ────────────────────────────────────────
+
+
+def test_scalar_empty_call_shape(ent):
+    """No axes supplied -- returns the all-empty envelope (no rows, three
+    axis slots None). Matches ``min_tier_batch()``'s empty-call shape."""
+    out = ent.has_batch()
+    assert out == {
+        "features": [],
+        "runtimes": [],
+        "channels": None,
+        "retention_days": None,
+        "nodes": None,
+    }
+
+
+def test_scalar_shape_top_level_keys(ent):
+    """Envelope keys are byte-stable regardless of axis mix."""
+    for kwargs in (
+        {"features": ["fleet"]},
+        {"runtimes": ["openclaw"]},
+        {"channels": 3},
+        {"retention_days": 7},
+        {"nodes": 2},
+        {"features": ["fleet"], "runtimes": ["openclaw"], "channels": 3},
+    ):
+        out = ent.has_batch(**kwargs)
+        assert set(out.keys()) == {
+            "features",
+            "runtimes",
+            "channels",
+            "retention_days",
+            "nodes",
+        }, kwargs
+
+
+def test_scalar_row_shape_across_axes(ent):
+    """Every emitted row (feature, runtime, channels, retention_days, nodes)
+    carries the same 7-key set."""
+    out = ent.has_batch(
+        features=["fleet"],
+        runtimes=["openclaw"],
+        channels=3,
+        retention_days=7,
+        nodes=2,
+    )
+    assert set(out["features"][0].keys()) == _ROW_KEYS
+    assert set(out["runtimes"][0].keys()) == _ROW_KEYS
+    assert set(out["channels"].keys()) == _ROW_KEYS
+    assert set(out["retention_days"].keys()) == _ROW_KEYS
+    assert set(out["nodes"].keys()) == _ROW_KEYS
+
+
+# ── has_batch scalar: grace vs enforce ──────────────────────────────────────
+
+
+def test_scalar_grace_every_known_row_is_true(ent):
+    """Grace invariant: every KNOWN feature id, KNOWN runtime id, and every
+    finite capacity value reports ``has=True`` in grace. Wiring this into a
+    matrix gate today changes no behaviour."""
+    feats = sorted(ent.ALL_FEATURES)[:3]
+    rts = sorted(ent.ALL_RUNTIMES)[:3]
+    out = ent.has_batch(
+        features=feats,
+        runtimes=rts,
+        channels=21,
+        retention_days=365,
+        nodes=100,
+    )
+    for row in out["features"] + out["runtimes"]:
+        assert row["has"] is True, row
+        assert row["unknown"] is False, row
+    assert out["channels"]["has"] is True
+    assert out["retention_days"]["has"] is True
+    assert out["nodes"]["has"] is True
+
+
+def test_scalar_enforce_paid_feature_is_false_on_oss(enforced):
+    """Post-enforcement on OSS: a paid feature reports ``has=False`` with
+    ``required_tier`` naming the cheapest unlocking tier."""
+    paid = _pick_paid_feature(enforced)
+    out = enforced.has_batch(features=[paid])
+    row = out["features"][0]
+    assert row["key"] == paid
+    assert row["kind"] == "feature"
+    assert row["has"] is False, row
+    assert row["unknown"] is False, row
+    assert row["required_tier"] is not None
+    assert row["required_tier"] != enforced.TIER_OSS
+    assert row["required_tier_rank"] > 0
+
+
+def test_scalar_enforce_paid_runtime_is_false_on_oss(enforced):
+    """Post-enforcement on OSS: a paid runtime reports has=False."""
+    paid = _pick_paid_runtime(enforced)
+    out = enforced.has_batch(runtimes=[paid])
+    row = out["runtimes"][0]
+    assert row["key"] == paid
+    assert row["has"] is False, row
+    assert row["unknown"] is False, row
+    assert row["required_tier"] is not None
+
+
+def test_scalar_enforce_free_runtime_is_true_on_oss(enforced):
+    """A FREE runtime (openclaw) stays granted post-enforcement -- the free
+    floor covers it."""
+    out = enforced.has_batch(runtimes=["openclaw"])
+    row = out["runtimes"][0]
+    assert row["has"] is True, row
+    assert row["unknown"] is False, row
+    assert row["required_tier"] == enforced.TIER_OSS
+
+
+def test_scalar_enforce_cloud_pro_grants_paid_feature(enforced_cloud_pro):
+    """Post-enforcement on cloud_pro: a Pro-covered feature flips to has=True."""
+    # Pick a feature that Pro covers -- fleet is a canonical starter/pro feature
+    # in the catalogue.
+    out = enforced_cloud_pro.has_batch(features=["fleet"])
+    row = out["features"][0]
+    assert row["has"] is True, row
+    assert row["unknown"] is False, row
+
+
+# ── has_batch scalar: strict-typo-fail-closed posture ───────────────────────
+
+
+def test_scalar_unknown_feature_is_fail_closed(ent):
+    """Unknown feature id: ``unknown=True`` / ``has=False`` even in grace.
+    This is DIFFERENT from ``lock_reasons_batch`` which reports ``allowed=True``
+    for unknown ids (diagnostic axis, not gate-shaped)."""
+    out = ent.has_batch(features=["totally_fake_feature_xyz"])
+    row = out["features"][0]
+    assert row["unknown"] is True, row
+    assert row["has"] is False, row
+    assert row["required_tier"] is None
+    assert row["required_tier_rank"] == -1
+
+
+def test_scalar_unknown_runtime_is_fail_closed(ent):
+    """Unknown runtime id: fail-closed."""
+    out = ent.has_batch(runtimes=["totally_fake_runtime_xyz"])
+    row = out["runtimes"][0]
+    assert row["unknown"] is True, row
+    assert row["has"] is False, row
+
+
+def test_scalar_empty_feature_id_is_fail_closed(ent):
+    """Whitespace / empty feature id after normalisation drops from the row list
+    (``_normalise_csv`` strips empty tokens). No row emitted for
+    ``features=[' ', '', '  ']``."""
+    out = ent.has_batch(features=["  ", "", "\t"])
+    assert out["features"] == []
+
+
+def test_scalar_capacity_non_int_is_fail_closed(ent):
+    """Non-int capacity value: ``unknown=True`` / ``has=False`` (matches
+    ``has_channel_count("bogus")`` -> False strict posture)."""
+    out = ent.has_batch(channels="bogus")
+    assert out["channels"] == {
+        "key": "bogus",
+        "kind": "channels",
+        "has": False,
+        "unknown": True,
+        "required_tier": None,
+        "required_tier_label": None,
+        "required_tier_rank": -1,
+    }
+
+
+def test_scalar_capacity_none_is_axis_absent(ent):
+    """``channels=None`` at the kwarg means AXIS NOT SUPPLIED, not
+    ``allows_channel_count(None)`` -- matches ``min_tier_batch`` and
+    ``lock_reasons_batch``. The axis slot in the envelope is None."""
+    out = ent.has_batch(channels=None)
+    assert out["channels"] is None
+
+
+def test_scalar_retention_days_none_is_axis_absent_not_unlimited(ent):
+    """``retention_days=None`` at the kwarg does NOT hit the unlimited
+    sentinel branch of :meth:`Entitlement.allows_retention_window`. Same
+    "not supplied" posture as the sibling batches. Verifying explicitly
+    because unlimited is a legitimate call on the singular helper."""
+    out = ent.has_batch(retention_days=None)
+    assert out["retention_days"] is None
+
+
+def test_scalar_retention_days_int_is_supplied(ent):
+    """A finite int on retention_days emits a row."""
+    out = ent.has_batch(retention_days=30)
+    assert out["retention_days"] is not None
+    assert out["retention_days"]["kind"] == "retention_days"
+    assert out["retention_days"]["key"] == "30"
+    assert out["retention_days"]["has"] is True  # grace
+
+
+# ── has_batch scalar: runtime alias + dedup ─────────────────────────────────
+
+
+def test_scalar_runtime_alias_canonicalises(ent):
+    """``claude-code`` (hyphen) canonicalises to ``claude_code`` (underscore)
+    on the singular ``has_runtime`` scalar; the batch does the same."""
+    out = ent.has_batch(runtimes=["claude-code"])
+    assert len(out["runtimes"]) == 1
+    row = out["runtimes"][0]
+    assert row["key"] == "claude_code"
+    assert row["unknown"] is False, row
+
+
+def test_scalar_runtime_alias_dedups_after_canonicalisation(ent):
+    """Both aliases of the same runtime (``claude-code`` and ``claude_code``)
+    collapse to ONE row after canonicalisation."""
+    out = ent.has_batch(runtimes=["claude-code", "claude_code"])
+    assert len(out["runtimes"]) == 1
+    assert out["runtimes"][0]["key"] == "claude_code"
+
+
+def test_scalar_feature_dedup_preserves_first_seen_order(ent):
+    """``_normalise_csv`` drops duplicates while preserving first-seen order."""
+    out = ent.has_batch(features=["fleet", "sso", "fleet", "otel_export"])
+    keys = [r["key"] for r in out["features"]]
+    # Only unique ids, in first-seen order.
+    assert len(keys) == len(set(keys))
+    # ``fleet`` appears before ``sso`` because it was first seen first.
+    assert keys.index("fleet") < keys.index("sso")
+
+
+# ── has_batch scalar: per-row parity with singular scalars ──────────────────
+
+
+def test_scalar_row_has_parity_features(ent):
+    """For every id in ALL_FEATURES, the batch's per-row ``has`` byte-equals
+    the singular :func:`has_feature` scalar. Pins that the batch cannot
+    silently drift from the scalar."""
+    for f in sorted(ent.ALL_FEATURES):
+        row = ent.has_batch(features=[f])["features"][0]
+        assert row["has"] is ent.has_feature(f), f
+        assert row["unknown"] is False, f
+
+
+def test_scalar_row_has_parity_runtimes(ent):
+    """For every id in ALL_RUNTIMES, per-row ``has`` byte-equals
+    :func:`has_runtime`."""
+    for r in sorted(ent.ALL_RUNTIMES):
+        row = ent.has_batch(runtimes=[r])["runtimes"][0]
+        assert row["has"] is ent.has_runtime(r), r
+
+
+def test_scalar_row_has_parity_channels(ent):
+    """Per-row ``has`` on the channels axis byte-equals
+    :func:`has_channel_count`."""
+    for n in (0, 1, 3, 4, 21, 100):
+        row = ent.has_batch(channels=n)["channels"]
+        assert row["has"] is ent.has_channel_count(n), n
+
+
+def test_scalar_row_required_tier_parity_features(ent):
+    """Per-row ``required_tier`` on the features axis byte-equals
+    :func:`min_tier_for_feature` on the same input."""
+    for f in sorted(ent.ALL_FEATURES):
+        row = ent.has_batch(features=[f])["features"][0]
+        assert row["required_tier"] == ent.min_tier_for_feature(f), f
+
+
+def test_scalar_row_required_tier_parity_runtimes(ent):
+    """Per-row ``required_tier`` on the runtimes axis byte-equals
+    :func:`min_tier_for_runtime`."""
+    for r in sorted(ent.ALL_RUNTIMES):
+        row = ent.has_batch(runtimes=[r])["runtimes"][0]
+        assert row["required_tier"] == ent.min_tier_for_runtime(r), r
+
+
+def test_scalar_row_required_tier_parity_channels(ent):
+    """Per-row ``required_tier`` on the channels axis byte-equals
+    :func:`min_tier_for_channel_count`."""
+    for n in (0, 1, 3, 4, 21, 100):
+        row = ent.has_batch(channels=n)["channels"]
+        assert row["required_tier"] == ent.min_tier_for_channel_count(n), n
+
+
+# ── has_batch scalar: never-raises ──────────────────────────────────────────
+
+
+def test_scalar_never_raises_on_resolver_blowup(monkeypatch, ent):
+    """A blowup in :func:`get_entitlement` collapses to the OSS-free
+    fallback resolver so per-row rendering keeps going (matches the
+    ``lock_reasons_batch`` posture)."""
+    def _boom(*a, **kw):
+        raise RuntimeError("resolver blew up")
+
+    monkeypatch.setattr(ent, "get_entitlement", _boom)
+    out = ent.has_batch(features=["fleet"])
+    # Fallback OSS-free resolver: grace still True on the fallback shape, so
+    # the row's has flag reflects the OSS-free grant (True in grace).
+    assert isinstance(out["features"], list)
+    assert len(out["features"]) == 1
+
+
+def test_scalar_never_raises_on_normalise_blowup(monkeypatch, ent):
+    """A blowup mid-normalisation collapses to the empty envelope."""
+    def _boom(*a, **kw):
+        raise RuntimeError("normalise blew up")
+
+    monkeypatch.setattr(ent, "_normalise_csv", _boom)
+    out = ent.has_batch(features=["fleet"])
+    assert out == {
+        "features": [],
+        "runtimes": [],
+        "channels": None,
+        "retention_days": None,
+        "nodes": None,
+    }
+
+
+# ── /api/entitlement/has-batch endpoint ─────────────────────────────────────
+
+
+def test_endpoint_no_args_400s(client):
+    """Missing every axis -- 400 (matches ``/min-tier-batch``'s posture)."""
+    resp = client.get("/api/entitlement/has-batch")
+    assert resp.status_code == 400
+    body = resp.get_json()
+    assert "error" in body
+
+
+def test_endpoint_features_only_shape(client):
+    """Features-only call: envelope key set is byte-stable."""
+    body = _get_json(client, "/api/entitlement/has-batch?features=fleet")
+    assert set(body.keys()) == _ENVELOPE_KEYS
+    assert len(body["features"]) == 1
+    assert body["runtimes"] == []
+    assert body["channels"] is None
+    assert body["retention_days"] is None
+    assert body["nodes"] is None
+    assert set(body["features"][0].keys()) == _ROW_KEYS
+
+
+def test_endpoint_runtimes_only_shape(client):
+    """Runtimes-only call: envelope stable, only runtimes list populated."""
+    body = _get_json(client, "/api/entitlement/has-batch?runtimes=openclaw")
+    assert set(body.keys()) == _ENVELOPE_KEYS
+    assert body["features"] == []
+    assert len(body["runtimes"]) == 1
+    assert body["channels"] is None
+    assert set(body["runtimes"][0].keys()) == _ROW_KEYS
+
+
+def test_endpoint_channels_only_shape(client):
+    """Channels-only capacity call."""
+    body = _get_json(client, "/api/entitlement/has-batch?channels=3")
+    assert set(body.keys()) == _ENVELOPE_KEYS
+    assert body["features"] == []
+    assert body["runtimes"] == []
+    assert body["channels"] is not None
+    assert body["channels"]["kind"] == "channels"
+    assert set(body["channels"].keys()) == _ROW_KEYS
+
+
+def test_endpoint_retention_days_only_shape(client):
+    """Retention-days-only capacity call."""
+    body = _get_json(client, "/api/entitlement/has-batch?retention_days=30")
+    assert set(body.keys()) == _ENVELOPE_KEYS
+    assert body["retention_days"] is not None
+    assert body["retention_days"]["kind"] == "retention_days"
+    assert body["retention_days"]["key"] == "30"
+
+
+def test_endpoint_nodes_only_shape(client):
+    """Nodes-only capacity call."""
+    body = _get_json(client, "/api/entitlement/has-batch?nodes=2")
+    assert set(body.keys()) == _ENVELOPE_KEYS
+    assert body["nodes"] is not None
+    assert body["nodes"]["kind"] == "nodes"
+
+
+def test_endpoint_mixed_axes_shape(client):
+    """All 5 axes at once: envelope stable, every axis populated."""
+    body = _get_json(
+        client,
+        "/api/entitlement/has-batch?features=fleet,sso"
+        "&runtimes=openclaw,claude_code&channels=3&retention_days=7&nodes=2",
+    )
+    assert set(body.keys()) == _ENVELOPE_KEYS
+    assert len(body["features"]) == 2
+    assert len(body["runtimes"]) == 2
+    assert body["channels"] is not None
+    assert body["retention_days"] is not None
+    assert body["nodes"] is not None
+
+
+def test_endpoint_blank_capacity_is_axis_absent(client):
+    """A blank capacity arg (``?channels=``) counts as SUPPLIED (present) but
+    UNPARSEABLE, and drops through to axis-absent shape -- matches
+    ``/min-tier-batch``'s posture. Since blank-only means no other axis is
+    populated either, the endpoint 400s (no axis successfully parsed)."""
+    resp = client.get("/api/entitlement/has-batch?channels=")
+    assert resp.status_code == 400
+
+
+def test_endpoint_features_present_blank_capacity_ok(client):
+    """A blank capacity arg alongside a real feature works: the blank axis
+    drops out (None), the feature row is emitted."""
+    body = _get_json(
+        client, "/api/entitlement/has-batch?features=fleet&channels="
+    )
+    assert set(body.keys()) == _ENVELOPE_KEYS
+    assert len(body["features"]) == 1
+    assert body["channels"] is None
+
+
+def test_endpoint_unparseable_capacity_is_axis_absent(client):
+    """Non-int capacity (``?channels=bogus``) drops that axis to None. Since
+    nothing else is supplied, the endpoint 400s."""
+    resp = client.get("/api/entitlement/has-batch?channels=bogus")
+    assert resp.status_code == 400
+
+
+def test_endpoint_unknown_feature_row_is_fail_closed(client):
+    """Unknown feature id emits a fail-closed row (unknown=True, has=False)."""
+    body = _get_json(
+        client, "/api/entitlement/has-batch?features=totally_fake_xyz"
+    )
+    row = body["features"][0]
+    assert row["unknown"] is True, row
+    assert row["has"] is False, row
+    assert row["required_tier"] is None
+    assert row["required_tier_rank"] == -1
+
+
+def test_endpoint_alias_canonicalises(client):
+    """``runtimes=claude-code`` canonicalises to ``claude_code``."""
+    body = _get_json(
+        client, "/api/entitlement/has-batch?runtimes=claude-code"
+    )
+    assert body["runtimes"][0]["key"] == "claude_code"
+
+
+def test_endpoint_alias_dedups(client):
+    """Both aliases collapse to one row after canonicalisation."""
+    body = _get_json(
+        client,
+        "/api/entitlement/has-batch?runtimes=claude-code,claude_code",
+    )
+    assert len(body["runtimes"]) == 1
+
+
+def test_endpoint_feature_dedup(client):
+    """CSV-level feature dedup preserves first-seen order."""
+    body = _get_json(
+        client, "/api/entitlement/has-batch?features=fleet,sso,fleet"
+    )
+    keys = [r["key"] for r in body["features"]]
+    assert len(keys) == 2
+    assert keys[0] == "fleet"
+    assert keys[1] == "sso"
+
+
+def test_endpoint_current_tier_present(client):
+    """Envelope carries the resolver-context columns so the frontend does
+    not have to re-hit ``/api/entitlement`` for tier metadata."""
+    body = _get_json(client, "/api/entitlement/has-batch?features=fleet")
+    assert body["current_tier"] == "oss"
+    assert body["current_tier_rank"] == 0
+    assert body["grace"] is True
+    assert body["enforced"] is False
+
+
+def test_endpoint_enforced_flag_reflects_env(enforced_client):
+    """``CLAWMETRY_ENFORCE=1`` flips ``enforced=True`` and ``grace=False``."""
+    body = _get_json(
+        enforced_client, "/api/entitlement/has-batch?features=fleet"
+    )
+    assert body["enforced"] is True
+    assert body["grace"] is False
+
+
+# ── /has-batch endpoint: has_all rollup ─────────────────────────────────────
+
+
+def test_endpoint_has_all_true_when_every_known_row_is_granted(client):
+    """Grace invariant on the rollup: every known-id bundle reports
+    ``has_all=True`` while grace is on."""
+    body = _get_json(
+        client,
+        "/api/entitlement/has-batch?features=fleet,sso&runtimes=openclaw"
+        "&channels=3&retention_days=7&nodes=2",
+    )
+    assert body["has_all"] is True
+
+
+def test_endpoint_has_all_false_on_any_unknown(client):
+    """A single unknown id in the bundle flips ``has_all`` to False -- even
+    while grace grants the known rows -- because ``unknown`` is a callsite-
+    typo signal (never grant a mystery id)."""
+    body = _get_json(
+        client,
+        "/api/entitlement/has-batch?features=fleet,totally_fake_xyz"
+        "&runtimes=openclaw",
+    )
+    assert body["has_all"] is False
+
+
+def test_endpoint_has_all_false_on_enforce_denied(enforced_client, enforced):
+    """Post-enforcement: a paid runtime on OSS flips ``has_all`` to False."""
+    paid = _pick_paid_runtime(enforced)
+    body = _get_json(
+        enforced_client,
+        f"/api/entitlement/has-batch?runtimes=openclaw,{paid}",
+    )
+    assert body["has_all"] is False
+
+
+def test_endpoint_has_all_true_all_free(enforced_client):
+    """Post-enforcement: an all-free bundle stays granted."""
+    body = _get_json(
+        enforced_client, "/api/entitlement/has-batch?runtimes=openclaw"
+    )
+    assert body["has_all"] is True
+
+
+def test_endpoint_has_all_folds_capacity_axes(client):
+    """Rollup includes capacity axes: a non-int capacity value 400s
+    upstream (unparseable), but a supplied+parseable capacity value with
+    ``has=True`` contributes to ``has_all``."""
+    body = _get_json(client, "/api/entitlement/has-batch?channels=3")
+    assert body["has_all"] is True
+
+
+def test_endpoint_scalar_endpoint_parity(client, ent):
+    """Endpoint per-row ``has`` byte-equals module scalar ``has_batch``
+    per-row ``has`` on the same input."""
+    body = _get_json(
+        client,
+        "/api/entitlement/has-batch?features=fleet,sso&runtimes=openclaw",
+    )
+    scalar = ent.has_batch(
+        features=["fleet", "sso"], runtimes=["openclaw"]
+    )
+    assert [r["has"] for r in body["features"]] == [
+        r["has"] for r in scalar["features"]
+    ]
+    assert [r["has"] for r in body["runtimes"]] == [
+        r["has"] for r in scalar["runtimes"]
+    ]
+
+
+def test_endpoint_singular_row_parity_feature(client, ent):
+    """Endpoint per-row ``has`` byte-equals the singular ``has_feature``
+    scalar on the same input -- pins that the batch endpoint cannot silently
+    drift from the singular scalar."""
+    body = _get_json(client, "/api/entitlement/has-batch?features=fleet")
+    assert body["features"][0]["has"] is ent.has_feature("fleet")
+
+
+def test_endpoint_singular_row_parity_runtime(client, ent):
+    """Endpoint per-row ``has`` byte-equals singular ``has_runtime``."""
+    body = _get_json(
+        client, "/api/entitlement/has-batch?runtimes=claude_code"
+    )
+    assert body["runtimes"][0]["has"] is ent.has_runtime("claude_code")
+
+
+def test_endpoint_singular_row_parity_channels(client, ent):
+    """Endpoint per-row ``has`` byte-equals singular ``has_channel_count``."""
+    body = _get_json(client, "/api/entitlement/has-batch?channels=21")
+    assert body["channels"]["has"] is ent.has_channel_count(21)
+
+
+# ── /has-batch endpoint: never-5xx ──────────────────────────────────────────
+
+
+def test_endpoint_never_5xx_on_resolver_blowup(monkeypatch, client):
+    """A blowup in :func:`has_batch` collapses to the fail-closed envelope
+    (matches sibling ``/has-feature`` / ``/has-runtime`` fallbacks). Never
+    5xxs."""
+    from clawmetry import entitlements as _ent
+
+    def _boom(*a, **kw):
+        raise RuntimeError("has_batch blew up")
+
+    monkeypatch.setattr(_ent, "has_batch", _boom)
+    body = _get_json(client, "/api/entitlement/has-batch?features=fleet")
+    assert set(body.keys()) == _ENVELOPE_KEYS
+    assert body["features"] == []
+    assert body["runtimes"] == []
+    assert body["has_all"] is False
+    assert body["current_tier"] == "oss"
+    assert body["grace"] is True
+    assert body["enforced"] is False
+
+
+def test_endpoint_never_5xx_on_get_entitlement_blowup(monkeypatch, client):
+    """A blowup in :func:`get_entitlement` (after ``has_batch`` returns) also
+    collapses to the fail-closed envelope."""
+    from clawmetry import entitlements as _ent
+
+    def _boom(*a, **kw):
+        raise RuntimeError("get_entitlement blew up")
+
+    monkeypatch.setattr(_ent, "get_entitlement", _boom)
+    body = _get_json(client, "/api/entitlement/has-batch?features=fleet")
+    assert set(body.keys()) == _ENVELOPE_KEYS
+    assert body["has_all"] is False
+
+
+# ── Endpoint cross-consistency with sibling batches ─────────────────────────
+
+
+def test_endpoint_current_tier_matches_entitlement_endpoint(client):
+    """``current_tier`` on this envelope byte-equals the top-level
+    ``/api/entitlement`` endpoint's ``tier`` field."""
+    body_has = _get_json(
+        client, "/api/entitlement/has-batch?features=fleet"
+    )
+    body_ent = _get_json(client, "/api/entitlement")
+    assert body_has["current_tier"] == body_ent["tier"]
+
+
+def test_endpoint_required_tier_matches_min_tier_batch(client):
+    """Per-row ``required_tier`` on ``/has-batch`` byte-equals the
+    corresponding row's ``min_tier`` on ``/min-tier-batch`` for the same
+    input (both wrap the same underlying ``min_tier_for_*`` helpers)."""
+    body_has = _get_json(
+        client,
+        "/api/entitlement/has-batch?features=fleet,sso&runtimes=openclaw",
+    )
+    body_min = _get_json(
+        client,
+        "/api/entitlement/min-tier-batch?features=fleet,sso&runtimes=openclaw",
+    )
+    has_features = {r["key"]: r["required_tier"] for r in body_has["features"]}
+    min_features = {r["key"]: r["min_tier"] for r in body_min["features"]}
+    assert has_features == min_features
+    has_runtimes = {r["key"]: r["required_tier"] for r in body_has["runtimes"]}
+    min_runtimes = {r["key"]: r["min_tier"] for r in body_min["runtimes"]}
+    assert has_runtimes == min_runtimes


### PR DESCRIPTION
## Summary

- New `clawmetry.entitlements.has_batch(*, features=None, runtimes=None, channels=None, retention_days=None, nodes=None) -> dict` -- **per-item plural** sibling of `has_feature` / `has_runtime` / `has_channel_count` (singular) and `has_features` / `has_runtimes` (plural bundle fold, #4389). Where the plural fold collapses a bundle to ONE boolean, this preserves per-item detail so a paywall MATRIX UI ("show every requested feature + runtime + capacity row with its individual granted flag AND the cheapest tier that would unlock it") renders off ONE round-trip instead of N calls to the singular endpoints. Envelope shape mirrors `min_tier_batch` and `lock_reasons_batch` exactly (same five-axis kwargs, same per-axis `None` "not supplied" sentinel, same never-raise contract). Each row carries `key`, `kind`, `has` (bool), `unknown` (True iff unrecognised id or non-int capacity), `required_tier` + `required_tier_label` + `required_tier_rank`.

  Strict-typo-fail-closed posture matches the singular scalars: unknown ids surface as `unknown=True` / `has=False`, NOT silently granted in grace. This is DIFFERENT from `lock_reasons_batch` which treats unknown ids as `allowed=True` (the lock-reasons axis is diagnostic, not gate-shaped). A callsite that binds a gate off this batch cannot mistake a typo (`fleeet`) for a grant. Runtime aliases (`claude-code` → `claude_code`) canonicalise per row and dedup collapses to one row. `retention_days=None` kwarg means "not supplied", NOT unlimited (matches sibling batches).

- New `GET /api/entitlement/has-batch?features=a,b,c&runtimes=x,y&channels=N&retention_days=K&nodes=M` on `bp_entitlement`. **10-key envelope** byte-stable across every input branch: the `has_batch` payload plus `has_all` (True iff every emitted row is `has=True` AND `unknown=False`; a single unknown or single missing flips it False -- matches the `has_features` / `has_runtimes` plural-fold posture from #4389 exactly), `current_tier` / `current_tier_rank` / `grace` / `enforced` resolver context. Requires at least one axis (400 otherwise, matches `/min-tier-batch`). Never 5xxs: any resolver blowup collapses to the fail-closed envelope.

- **55 hermetic unit tests** covering: scalar behaviour under grace vs enforce for empty / single-axis / mixed-axis / unknown-id / non-int-capacity / alias-canonicalising / dedup-preserving bundles; envelope-shape invariant across 15+ URL branches (features-only / runtimes-only / per-capacity-only / mixed / blank / unparseable / all-unknown); never-5xx via monkeypatched blowup on both `has_batch` and `get_entitlement`; parametrised per-row parity against `has_feature` / `has_runtime` / `has_channel_count` for every id in `ALL_FEATURES` / `ALL_RUNTIMES`; scalar-vs-endpoint parity so the URL boolean cannot drift from the module scalar; cross-consistency with `/api/entitlement` (`current_tier` field) and `/api/entitlement/min-tier-batch` (per-row `required_tier` byte-equals per-row `min_tier`); `has_all` rollup semantics (grace all-True, single-unknown-flips-False, enforce-denied-flips-False, all-free-stays-True).

Behaviour is additive; nothing existing changes. Grace-mode posture is preserved (no gate enforcement is added; the batch only surfaces what the resolved entitlement's per-item grant admits). Uses only the already-permitted `flask` + stdlib import set.

Does NOT overlap with the three currently-open draft PRs (`has_features` / `has_runtimes` in #4389, `has_node_count` in #4381, `has_retention_window` in #4371): this is the *per-item* row axis those PRs' *bundle-fold* singulars are missing.

## Test plan

- [x] `python3 -m py_compile clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_has_batch.py` -- passes
- [x] `python3 -m pytest tests/test_entitlement_has_batch.py` -- **55 passed** in 4.31s
- [x] `python3 -m pytest tests/test_entitlement_has_channel_count.py tests/test_entitlement_channel_limit.py tests/test_entitlements_min_tier.py tests/test_entitlements.py tests/test_entitlement_capacity_diff.py` -- **207 passed** (sibling regressions clean)
- [x] `python3 -m pytest tests/ -k entitlement --ignore=<pre-existing-collection-failures>` -- **7751 passed** (5 pre-existing errors are unrelated `ModuleNotFoundError: No module named '_cffi_backend'` in `test_local_trial.py` etc., not caused by this change)

## Local operator verification checklist

The web agent cannot touch the live daemon, `~/.openclaw`, the cloud snapshot, a browser, or the private `clawmetry-cloud` repo. Please verify on-host before flipping this out of draft:

- [ ] Copy the changed source files (and the new test) into the installed package:
  - `cp clawmetry/entitlements.py ~/.clawmetry/lib/python*/site-packages/clawmetry/entitlements.py`
  - `cp routes/entitlement.py ~/.clawmetry/lib/python*/site-packages/routes/entitlement.py`
  - `find ~/.clawmetry/lib/python*/site-packages/{clawmetry,routes} -name __pycache__ -exec rm -rf {} +`
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` (or the equivalent supervisor kick on non-macOS hosts)
- [ ] Happy-path envelope shape (grace mode):
  - `curl -s "http://localhost:8900/api/entitlement/has-batch?features=fleet,sso&runtimes=openclaw,claude_code&channels=3&retention_days=7&nodes=2" | jq` -- 10 top-level keys (`features`, `runtimes`, `channels`, `retention_days`, `nodes`, `has_all`, `current_tier`, `current_tier_rank`, `grace`, `enforced`), every row has 7 keys, `has_all=true` in grace.
- [ ] Per-row parity against the singulars:
  - `curl -s "http://localhost:8900/api/entitlement/has-batch?features=fleet" | jq '.features[0].has'` byte-equals `curl -s "http://localhost:8900/api/entitlement/has-feature?feature=fleet" | jq '.has_feature'`.
  - Same for `?runtimes=claude_code` vs `/has-runtime?runtime=claude_code`, and `?channels=21` vs `/has-channel-count?count=21`.
- [ ] `required_tier` parity against `/min-tier-batch`:
  - `diff <(curl -s "http://localhost:8900/api/entitlement/has-batch?features=fleet,sso&runtimes=openclaw" | jq '{f: [.features[].required_tier], r: [.runtimes[].required_tier]}') <(curl -s "http://localhost:8900/api/entitlement/min-tier-batch?features=fleet,sso&runtimes=openclaw" | jq '{f: [.features[].min_tier], r: [.runtimes[].min_tier]}')` -- empty diff.
- [ ] Strict-typo-fail-closed sanity:
  - `curl -s "http://localhost:8900/api/entitlement/has-batch?features=fleet,totally_fake_xyz" | jq` -- fake row has `unknown=true` / `has=false` / `required_tier=null`; `has_all=false` even though `fleet` is granted in grace (single-unknown-flips-False).
- [ ] Alias canonicalisation sanity:
  - `curl -s "http://localhost:8900/api/entitlement/has-batch?runtimes=claude-code,claude_code" | jq '.runtimes'` -- single row, `key="claude_code"`.
- [ ] No-axis 400 sanity:
  - `curl -s -o /dev/null -w '%{http_code}\n' "http://localhost:8900/api/entitlement/has-batch"` -- `400`.
- [ ] Grace-safe sanity: `has_all=true` for every fully-known bundle while grace is on (no change from today's `/lock-reasons-batch` `allowed` answer aggregated over the same bundle).
- [ ] Retention-days-is-unset-not-unlimited sanity:
  - `curl -s "http://localhost:8900/api/entitlement/has-batch?features=fleet" | jq '.retention_days'` -- `null` (axis not supplied), does NOT emit an unlimited-sentinel row.
- [ ] Browser check: open the entitlement diagnostics tile and confirm no regression; the mixed-axis paywall matrix (if wired) can bind per-row `has` off `/has-batch?features=...&runtimes=...&channels=...` in one round-trip without changing behavior in grace.
- [ ] Decrypt the live cloud snapshot and confirm the new endpoint is reachable through the relay (should require no relay changes -- read-only handler on `bp_entitlement`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01LFVZpjuvc2LhEGqFJ9e2Dn)_