### PR TITLE
[RELEASE] numbat findings ingest (carries #4399)

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,8 @@ The production bundle is written to `clawmetry/static/v2/dist/`.
 
 ClawMetry observes many AI-agent runtimes, not just OpenClaw. Each non-OpenClaw runtime ships a dedicated reader adapter that translates its native session format into ClawMetry's unified shapes; the daemon ingests them into the same DuckDB store + cloud snapshot, tagged with the runtime, and the Session replay tab shows a **runtime switcher** when more than one is present. See [`docs/compatibility.md`](docs/compatibility.md) for the full matrix + a guide to adding runtimes, and [`docs/RUNTIME_FAMILY.md`](docs/RUNTIME_FAMILY.md) for the OpenClaw-family primer.
 
+Running [Perplexity's numbat](https://github.com/perplexityai/numbat) agent-security tool? ClawMetry ingests its findings and enforcement decisions out of the box — see [`docs/NUMBAT.md`](docs/NUMBAT.md).
+
 | Runtime / Agent | Status | Notes |
 |---|---|---|
 | **OpenClaw** | Native | Reference runtime, auto-detected |


### PR DESCRIPTION
Release PR for the numbat integration that merged in #4399 — that PR's *title* lacked the `[RELEASE]` marker (only the squash subject carried it), so the auto-release workflow skipped. This PR follows the #4398 precedent (`release/…` branch, `[RELEASE]` title, carries-reference) to run the publish train.

Content: one-line README pointer to `docs/NUMBAT.md`.

Feature + evidence: see #4399 (13 unit tests, real-binary E2E — 942 real findings from an actual numbat scan ingested with replay dedupe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)