### PR TITLE
[RELEASE] feat(onboarding): self-host card folds into a modal, twin of the cloud one

### DIFF
--- a/clawmetry/static/js/onboarding.js
+++ b/clawmetry/static/js/onboarding.js
@@ -1,16 +1,17 @@
 // onboarding.js — first-run onboarding gate (hard gate, no skip).
 //
 // Shows templates/partials/onboarding-modal.html when
-// GET /api/onboarding/state says {required:true}. Three ways out, each
-// recorded via POST /api/onboarding/complete (or the combined
-// activate-license endpoint):
-//   managed          — existing cloud modal (OTP / Google / GitHub), we
-//                      poll /api/cloud-cta/status until connected
-//   selfhost_trial   — Google/GitHub OAuth (mode=selfhost bridge: identity
-//                      + trial license, data stays local) or email +
-//                      6-digit code via /api/trial/activate (same as the
-//                      gw-setup teaser)
-//   selfhost_license — CLAW1 key via /api/onboarding/activate-license
+// GET /api/onboarding/state says {required:true}. The gate itself is just
+// two cards with one button each; the details live in modals:
+//   managed  — cloud modal (gw-setup.js openCloudModal: OTP / Google /
+//              GitHub), we poll /api/cloud-cta/status until connected
+//   selfhost — self-host modal (partials/selfhost-modal.html, the shm*
+//              globals below): Google/GitHub OAuth via the mode=selfhost
+//              bridge (identity + trial license, data stays local), email
+//              + 6-digit code via /api/trial/activate, or a CLAW1 key via
+//              /api/onboarding/activate-license
+// Every way out is recorded via POST /api/onboarding/complete (or the
+// combined activate-license endpoint).
 //
 // Never runs on the hosted cloud dashboard (window.CLOUD_MODE) and defers
 // to the mandatory gateway-setup overlay when that is on screen.
@@ -18,9 +19,9 @@
 (function () {
   'use strict';
 
-  var _pollTimer = null;
-  var _oauthTimer = null;
-  var _trialEmail = '';
+  var _pollTimer = null;   // managed-connect status poll
+  var _oauthTimer = null;  // self-host OAuth bridge poll
+  var _email = '';
 
   function $(id) { return document.getElementById(id); }
 
@@ -56,6 +57,7 @@
       body: JSON.stringify({ choice: choice }),
     }).then(function (r) { return r.json(); }).then(function (d) {
       if (d && d.ok) {
+        window.closeSelfhostModal();
         _hide();
         location.reload();
       } else if (onFail) {
@@ -86,125 +88,178 @@
     }, 2000);
   }
 
-  // ── Self-host: free trial (email → code → activate) ─────────────────
-  function _trialEmailStep() {
-    var body = $('obg-selfhost-body');
-    if (!body) return;
-    body.innerHTML =
-      '<input class="obg-input" id="obg-trial-email" type="email" placeholder="you@company.com" autocomplete="email">' +
-      '<div class="obg-err" id="obg-trial-err"></div>' +
-      '<button class="obg-btn obg-btn-quiet" id="obg-trial-send" type="button">Email me a code</button>' +
-      '<a class="obg-alt" href="#" id="obg-trial-back">Back</a>';
-    $('obg-trial-send').addEventListener('click', _trialSendCode);
-    $('obg-trial-email').addEventListener('keydown', function (ev) {
-      if (ev.key === 'Enter') _trialSendCode();
+  // ── Self-host modal (partials/selfhost-modal.html) ───────────────────
+  var _SHM_STEPS = ['home', 'otp', 'wait', 'license', 'ended'];
+  var _SHM_ERRS = ['shm-home-error', 'shm-otp-error', 'shm-wait-error', 'shm-license-error'];
+
+  function _shmStep(name) {
+    _SHM_STEPS.forEach(function (s) {
+      var el = $('shm-step-' + s);
+      if (el) el.style.display = s === name ? 'block' : 'none';
     });
-    $('obg-trial-back').addEventListener('click', function (ev) {
-      ev.preventDefault(); _selfhostHome();
-    });
-    setTimeout(function () { var el = $('obg-trial-email'); if (el) el.focus(); }, 50);
   }
 
-  function _trialSendCode() {
-    var email = (($('obg-trial-email') || {}).value || '').trim();
+  function _shmStopPoll() {
+    if (_oauthTimer) { clearInterval(_oauthTimer); _oauthTimer = null; }
+  }
+
+  window.openSelfhostModal = function () {
+    var o = $('selfhost-modal-overlay');
+    if (!o) return;
+    _SHM_ERRS.forEach(function (id) { _err(id, ''); });
+    _shmStep('home');
+    o.style.display = 'flex';
+    setTimeout(function () { var el = $('shm-email-input'); if (el) el.focus(); }, 60);
+  };
+
+  window.closeSelfhostModal = function () {
+    var o = $('selfhost-modal-overlay');
+    if (o) o.style.display = 'none';
+    _shmStopPoll();
+  };
+
+  window.shmBackHome = function () {
+    _shmStopPoll();
+    _SHM_ERRS.forEach(function (id) { _err(id, ''); });
+    _shmStep('home');
+  };
+
+  window.shmShowLicense = function () {
+    _shmStopPoll();
+    _err('shm-license-error', '');
+    _shmStep('license');
+    setTimeout(function () { var el = $('shm-license-input'); if (el) el.focus(); }, 60);
+  };
+
+  // Google/GitHub → mode=selfhost bridge: identity + trial, egress stays off.
+  window.shmOauth = function (provider) {
+    _err('shm-home-error', '');
+    fetch('/api/cloud-cta/oauth-start', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ provider: provider, mode: 'selfhost' }),
+    }).then(function (r) { return r.json(); }).then(function (d) {
+      if (!d || !d.ok || !d.url) {
+        _err('shm-home-error', (d && d.error) || 'Could not start sign-in. Try email instead.');
+        return;
+      }
+      window.open(d.url, '_blank');
+      _err('shm-wait-error', '');
+      _shmStep('wait');
+      var tries = 0;
+      _shmStopPoll();
+      _oauthTimer = setInterval(function () {
+        tries += 1;
+        if (tries > 150) {
+          _shmStopPoll();
+          _err('shm-wait-error', 'Sign-in timed out. Try again.');
+          return;
+        }
+        fetch('/api/cloud-cta/oauth-status').then(function (r) { return r.json(); })
+          .then(function (s) {
+            if (!s) return;
+            if (s.status === 'connected') {
+              _shmStopPoll();
+              if (s.trial === 'active') {
+                _complete('selfhost_trial', function (msg) { _err('shm-wait-error', msg); });
+              } else if (s.trial === 'expired') {
+                _shmStep('ended');
+              } else {
+                _err('shm-wait-error',
+                  "You're signed in, but we couldn't start your trial. Try again or use email.");
+              }
+            } else if (s.status === 'error') {
+              _shmStopPoll();
+              _err('shm-wait-error', s.error || 'Sign-in failed. Try email instead.');
+            }
+          }).catch(function () {});
+      }, 2000);
+    }).catch(function () {
+      _err('shm-home-error', 'Network error. Try again.');
+    });
+  };
+
+  // Email → 6-digit code → /api/trial/activate (same rail as the CLI).
+  window.shmSendOtp = function () {
+    var email = (($('shm-email-input') || {}).value || '').trim();
     if (!email || email.indexOf('@') < 0) {
-      _err('obg-trial-err', 'Enter a valid email.');
+      _err('shm-home-error', 'Enter a valid email.');
       return;
     }
-    _trialEmail = email;
-    _err('obg-trial-err', '');
-    var btn = $('obg-trial-send');
-    if (btn) { btn.textContent = 'Sending code'; btn.disabled = true; }
+    _email = email;
+    _err('shm-home-error', '');
+    var btn = $('shm-send-btn');
+    if (btn) { btn.textContent = 'Sending'; btn.disabled = true; }
     fetch('/api/cloud-cta/send-otp', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ email: email }),
     }).then(function (r) { return r.json(); }).then(function (d) {
+      if (btn) { btn.textContent = 'Get Started'; btn.disabled = false; }
       if (d && d.ok === false) {
-        _err('obg-trial-err', d.error || 'Could not send the code. Try again.');
-        if (btn) { btn.textContent = 'Email me a code'; btn.disabled = false; }
+        _err('shm-home-error', d.error || 'Could not send the code. Try again.');
         return;
       }
-      _trialCodeStep();
+      var em = $('shm-otp-email');
+      if (em) em.textContent = _email;
+      _err('shm-otp-error', '');
+      _shmStep('otp');
+      setTimeout(function () { var el = $('shm-otp-input'); if (el) { el.value = ''; el.focus(); } }, 60);
     }).catch(function () {
-      _err('obg-trial-err', 'Network error. Try again.');
-      if (btn) { btn.textContent = 'Email me a code'; btn.disabled = false; }
+      if (btn) { btn.textContent = 'Get Started'; btn.disabled = false; }
+      _err('shm-home-error', 'Network error. Try again.');
     });
-  }
+  };
 
-  function _trialCodeStep() {
-    var body = $('obg-selfhost-body');
-    if (!body) return;
-    body.innerHTML =
-      '<p style="color:#94a3b8;font-size:12px;margin:0 0 8px;">We emailed a 6-digit code to <b style="color:#e2e8f0;">' +
-        _trialEmail.replace(/&/g, '&amp;').replace(/</g, '&lt;') + '</b>.</p>' +
-      '<input class="obg-input" id="obg-trial-code" type="text" inputmode="numeric" maxlength="6" placeholder="123456" style="letter-spacing:6px;text-align:center;font-family:monospace;font-size:16px;">' +
-      '<div class="obg-err" id="obg-trial-err"></div>' +
-      '<button class="obg-btn obg-btn-quiet" id="obg-trial-activate" type="button">Activate trial</button>' +
-      '<a class="obg-alt" href="#" id="obg-trial-redo">Use a different email</a>';
-    $('obg-trial-activate').addEventListener('click', _trialActivate);
-    $('obg-trial-code').addEventListener('keydown', function (ev) {
-      if (ev.key === 'Enter') _trialActivate();
+  window.shmResendOtp = function () {
+    if (!_email) { window.shmBackHome(); return; }
+    fetch('/api/cloud-cta/send-otp', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: _email }),
+    }).then(function (r) { return r.json(); }).then(function (d) {
+      _err('shm-otp-error', (d && d.ok === false)
+        ? (d.error || 'Could not resend the code.')
+        : 'Code re-sent. Check your inbox.');
+    }).catch(function () {
+      _err('shm-otp-error', 'Network error. Try again.');
     });
-    $('obg-trial-redo').addEventListener('click', function (ev) {
-      ev.preventDefault(); _trialEmailStep();
-    });
-    setTimeout(function () { var el = $('obg-trial-code'); if (el) el.focus(); }, 50);
-  }
+  };
 
-  function _trialActivate() {
-    var code = ((($('obg-trial-code') || {}).value) || '').replace(/\s/g, '');
+  window.shmVerifyOtp = function () {
+    var code = ((($('shm-otp-input') || {}).value) || '').replace(/\s/g, '');
     if (code.length !== 6) {
-      _err('obg-trial-err', 'Enter the 6-digit code from your email.');
+      _err('shm-otp-error', 'Enter the 6-digit code from your email.');
       return;
     }
-    _err('obg-trial-err', '');
-    var btn = $('obg-trial-activate');
+    _err('shm-otp-error', '');
+    var btn = $('shm-verify-btn');
     if (btn) { btn.textContent = 'Activating'; btn.disabled = true; }
     fetch('/api/trial/activate', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ email: _trialEmail, code: code }),
+      body: JSON.stringify({ email: _email, code: code }),
     }).then(function (r) { return r.json(); }).then(function (d) {
       if (!d || !d.ok) {
-        _err('obg-trial-err', (d && d.error) || 'Activation failed. Try again.');
+        _err('shm-otp-error', (d && d.error) || 'Activation failed. Try again.');
         if (btn) { btn.textContent = 'Activate trial'; btn.disabled = false; }
         return;
       }
       _complete('selfhost_trial', function (msg) {
-        _err('obg-trial-err', msg);
+        _err('shm-otp-error', msg);
         if (btn) { btn.textContent = 'Activate trial'; btn.disabled = false; }
       });
     }).catch(function () {
-      _err('obg-trial-err', 'Network error. Try again.');
+      _err('shm-otp-error', 'Network error. Try again.');
       if (btn) { btn.textContent = 'Activate trial'; btn.disabled = false; }
     });
-  }
+  };
 
-  // ── Self-host: license key ───────────────────────────────────────────
-  function _licenseStep() {
-    var body = $('obg-selfhost-body');
-    if (!body) return;
-    body.innerHTML =
-      '<input class="obg-input" id="obg-license-key" type="text" placeholder="CLAW1.xxxx.xxxx" autocomplete="off" spellcheck="false">' +
-      '<div class="obg-err" id="obg-license-err"></div>' +
-      '<button class="obg-btn obg-btn-quiet" id="obg-license-activate" type="button">Activate license</button>' +
-      '<a class="obg-alt" href="#" id="obg-license-back">Back</a>';
-    $('obg-license-activate').addEventListener('click', _licenseActivate);
-    $('obg-license-key').addEventListener('keydown', function (ev) {
-      if (ev.key === 'Enter') _licenseActivate();
-    });
-    $('obg-license-back').addEventListener('click', function (ev) {
-      ev.preventDefault(); _selfhostHome();
-    });
-    setTimeout(function () { var el = $('obg-license-key'); if (el) el.focus(); }, 50);
-  }
-
-  function _licenseActivate() {
-    var key = ((($('obg-license-key') || {}).value) || '').trim();
-    if (!key) { _err('obg-license-err', 'Paste your license key.'); return; }
-    _err('obg-license-err', '');
-    var btn = $('obg-license-activate');
+  window.shmActivateLicense = function () {
+    var key = ((($('shm-license-input') || {}).value) || '').trim();
+    if (!key) { _err('shm-license-error', 'Paste your license key.'); return; }
+    _err('shm-license-error', '');
+    var btn = $('shm-license-btn');
     if (btn) { btn.textContent = 'Activating'; btn.disabled = true; }
     fetch('/api/onboarding/activate-license', {
       method: 'POST',
@@ -212,116 +267,18 @@
       body: JSON.stringify({ key: key }),
     }).then(function (r) { return r.json(); }).then(function (d) {
       if (!d || !d.ok) {
-        _err('obg-license-err', (d && d.error) || 'Activation failed. Try again.');
-        if (btn) { btn.textContent = 'Activate license'; btn.disabled = false; }
+        _err('shm-license-error', (d && d.error) || 'Activation failed. Try again.');
+        if (btn) { btn.textContent = 'Activate'; btn.disabled = false; }
         return;
       }
+      window.closeSelfhostModal();
       _hide();
       location.reload();
     }).catch(function () {
-      _err('obg-license-err', 'Network error. Try again.');
-      if (btn) { btn.textContent = 'Activate license'; btn.disabled = false; }
+      _err('shm-license-error', 'Network error. Try again.');
+      if (btn) { btn.textContent = 'Activate'; btn.disabled = false; }
     });
-  }
-
-  // Keep this markup mirrored with the initial #obg-selfhost-body in
-  // templates/partials/onboarding-modal.html — both renders must offer
-  // the same options.
-  function _selfhostHome() {
-    var body = $('obg-selfhost-body');
-    if (!body) return;
-    body.innerHTML =
-      '<button class="obg-btn obg-btn-quiet" id="obg-oauth-github" type="button">Continue with GitHub</button>' +
-      '<button class="obg-btn obg-btn-quiet" id="obg-oauth-google" type="button" style="margin-top:8px;">Continue with Google</button>' +
-      '<button class="obg-btn obg-btn-quiet" id="obg-trial-btn" type="button" style="margin-top:8px;">Continue with email</button>' +
-      '<div class="obg-err" id="obg-oauth-err"></div>' +
-      '<a class="obg-alt" href="#" id="obg-license-link">I have a license key</a>';
-    _wireSelfhostHome();
-  }
-
-  function _wireSelfhostHome() {
-    var gh = $('obg-oauth-github');
-    if (gh) gh.addEventListener('click', function () { _selfhostOauth('github'); });
-    var go = $('obg-oauth-google');
-    if (go) go.addEventListener('click', function () { _selfhostOauth('google'); });
-    var t = $('obg-trial-btn');
-    if (t) t.addEventListener('click', _trialEmailStep);
-    var l = $('obg-license-link');
-    if (l) l.addEventListener('click', function (ev) { ev.preventDefault(); _licenseStep(); });
-  }
-
-  // ── Self-host: Google/GitHub OAuth (identity + trial, data stays local) ──
-  function _selfhostOauth(provider) {
-    _err('obg-oauth-err', '');
-    var pretty = provider === 'github' ? 'GitHub' : 'Google';
-    fetch('/api/cloud-cta/oauth-start', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ provider: provider, mode: 'selfhost' }),
-    }).then(function (r) { return r.json(); }).then(function (d) {
-      if (!d || !d.ok || !d.url) {
-        _err('obg-oauth-err', (d && d.error) || 'Could not start sign-in. Try email instead.');
-        return;
-      }
-      window.open(d.url, '_blank');
-      _selfhostOauthWait(pretty);
-    }).catch(function () {
-      _err('obg-oauth-err', 'Network error. Try again.');
-    });
-  }
-
-  function _selfhostOauthWait(pretty) {
-    var body = $('obg-selfhost-body');
-    if (!body) return;
-    body.innerHTML =
-      '<p style="color:#94a3b8;font-size:12px;margin:0 0 8px;">Finish signing in with ' + pretty +
-      ' in the tab we just opened. Your trial activates here automatically.</p>' +
-      '<div class="obg-err" id="obg-oauth-err"></div>' +
-      '<a class="obg-alt" href="#" id="obg-oauth-cancel">Cancel</a>';
-    $('obg-oauth-cancel').addEventListener('click', function (ev) {
-      ev.preventDefault();
-      if (_oauthTimer) { clearInterval(_oauthTimer); _oauthTimer = null; }
-      _selfhostHome();
-    });
-    var tries = 0;
-    if (_oauthTimer) clearInterval(_oauthTimer);
-    _oauthTimer = setInterval(function () {
-      tries += 1;
-      if (tries > 150) {
-        clearInterval(_oauthTimer); _oauthTimer = null;
-        _err('obg-oauth-err', 'Sign-in timed out. Try again.');
-        return;
-      }
-      fetch('/api/cloud-cta/oauth-status').then(function (r) { return r.json(); })
-        .then(function (d) {
-          if (!d) return;
-          if (d.status === 'connected') {
-            clearInterval(_oauthTimer); _oauthTimer = null;
-            if (d.trial === 'active') {
-              _complete('selfhost_trial', function (msg) { _err('obg-oauth-err', msg); });
-            } else if (d.trial === 'expired') {
-              _selfhostTrialEnded();
-            } else {
-              _err('obg-oauth-err',
-                "You're signed in, but we couldn't start your trial. Try again or use email.");
-            }
-          } else if (d.status === 'error') {
-            clearInterval(_oauthTimer); _oauthTimer = null;
-            _err('obg-oauth-err', d.error || 'Sign-in failed. Try email instead.');
-          }
-        }).catch(function () {});
-    }, 2000);
-  }
-
-  function _selfhostTrialEnded() {
-    var body = $('obg-selfhost-body');
-    if (!body) return;
-    body.innerHTML =
-      '<p style="color:#94a3b8;font-size:12px;margin:0 0 8px;">You\'re signed in, but your 7-day trial has already ended. ' +
-      'Keep every runtime with a license: <a href="https://clawmetry.com/pricing?deploy=self" target="_blank" rel="noopener" style="color:#e2e8f0;">clawmetry.com/pricing</a></p>' +
-      '<button class="obg-btn obg-btn-quiet" id="obg-license-btn2" type="button">I have a license key</button>';
-    $('obg-license-btn2').addEventListener('click', _licenseStep);
-  }
+  };
 
   // ── Greeting: lead with what ClawMetry can already see ───────────────
   function _fillDetection() {
@@ -354,7 +311,8 @@
         if (_gwSetupMandatoryVisible()) return;
         var m = $('obg-managed-btn');
         if (m) m.addEventListener('click', _startManaged);
-        _wireSelfhostHome();
+        var s = $('obg-selfhost-btn');
+        if (s) s.addEventListener('click', window.openSelfhostModal);
         _fillDetection();
         _show();
       })

--- a/clawmetry/templates/partials/onboarding-modal.html
+++ b/clawmetry/templates/partials/onboarding-modal.html
@@ -48,14 +48,8 @@
       <div class="obg-opt">
         <h3>Self-host</h3>
         <p>Everything stays on this machine. Sign in once with Google, GitHub, or email to start the same free 7-day Pro trial and unlock every runtime, or activate a license key you already have.</p>
-        <!-- Keep this initial body mirrored with _selfhostHome() in
-             static/js/onboarding.js — both renders must offer the same options. -->
         <div id="obg-selfhost-body">
-          <button class="obg-btn obg-btn-quiet" id="obg-oauth-github" type="button">Continue with GitHub</button>
-          <button class="obg-btn obg-btn-quiet" id="obg-oauth-google" type="button" style="margin-top:8px;">Continue with Google</button>
-          <button class="obg-btn obg-btn-quiet" id="obg-trial-btn" type="button" style="margin-top:8px;">Continue with email</button>
-          <div class="obg-err" id="obg-oauth-err"></div>
-          <a class="obg-alt" href="#" id="obg-license-link">I have a license key</a>
+          <button class="obg-btn obg-btn-quiet" id="obg-selfhost-btn" type="button">Set up Self-Host</button>
         </div>
       </div>
     </div>

--- a/clawmetry/templates/partials/selfhost-modal.html
+++ b/clawmetry/templates/partials/selfhost-modal.html
@@ -1,0 +1,201 @@
+<!-- Self-Host sign-in modal — the self-host twin of cloud-modal.html.
+     Opened by the onboarding gate's "Set up Self-Host" button; driven by
+     static/js/onboarding.js (window.openSelfhostModal / shm* globals).
+     Same visual language as the cloud modal: logo header, provider
+     buttons, OR divider, inline email. Dismissible — closing returns to
+     the gate. -->
+<div id="selfhost-modal-overlay" onclick="if(event.target===this)closeSelfhostModal()" style="
+  display:none;
+  position:fixed;
+  inset:0;
+  z-index:2000;
+  background:rgba(0,0,0,0.6);
+  backdrop-filter:blur(4px);
+  align-items:center;
+  justify-content:center;
+  ">
+  <div style="
+    background:#0f1623;
+    border:1px solid rgba(229,68,58,0.2);
+    border-radius:16px;
+    width:90%;
+    max-width:440px;
+    padding:32px;
+    box-shadow:0 25px 60px rgba(0,0,0,0.5);
+    position:relative;
+    margin:auto;
+    ">
+    <button onclick="closeSelfhostModal()" style="
+      position:absolute;
+      top:16px;
+      right:16px;
+      background:rgba(255,255,255,0.05);
+      border:none;
+      border-radius:8px;
+      width:32px;
+      height:32px;
+      cursor:pointer;
+      font-size:18px;
+      color:#888;
+      ">×</button>
+    <div style="display:flex;align-items:center;gap:10px;margin-bottom:8px;">
+      <img src="/static/img/logo.svg" width="28" height="28" style="border-radius:6px;">
+      <span style="font-size:18px;font-weight:700;color:#fff;" data-i18n="selfhost.title">Self-Host</span>
+    </div>
+    <p style="
+      color:#94a3b8;
+      font-size:14px;
+      margin:0 0 24px;
+      line-height:1.5;
+      " data-i18n="selfhost.tagline">Everything stays on this machine. Sign in once for a free 7-day Pro trial that unlocks every runtime.</p>
+    <div id="shm-step-home">
+      <div style="display:flex;flex-direction:column;gap:8px;margin-bottom:18px;">
+        <button onclick="shmOauth('github')" style="
+          display:flex;
+          align-items:center;
+          justify-content:center;
+          gap:10px;
+          width:100%;
+          padding:11px 14px;
+          background:#1a2235;
+          border:1px solid rgba(255,255,255,0.12);
+          border-radius:8px;
+          color:#fff;
+          font-size:14px;
+          font-weight:600;
+          cursor:pointer;
+          " onmouseover="this.style.background='#222c44'" onmouseout="this.style.background='#1a2235'">
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.37.5 0 5.87 0 12.5c0 5.3 3.44 9.8 8.21 11.39.6.11.82-.26.82-.58 0-.29-.01-1.04-.02-2.05-3.34.73-4.04-1.61-4.04-1.61-.55-1.39-1.34-1.76-1.34-1.76-1.09-.75.08-.73.08-.73 1.2.09 1.84 1.24 1.84 1.24 1.07 1.83 2.81 1.3 3.49.99.11-.78.42-1.3.76-1.6-2.66-.3-5.47-1.33-5.47-5.93 0-1.31.47-2.38 1.24-3.22-.12-.31-.54-1.52.12-3.18 0 0 1.01-.32 3.3 1.23a11.5 11.5 0 0 1 6 0c2.29-1.55 3.3-1.23 3.3-1.23.66 1.66.24 2.87.12 3.18.77.84 1.24 1.91 1.24 3.22 0 4.61-2.81 5.62-5.49 5.92.43.37.81 1.1.81 2.22 0 1.6-.01 2.89-.01 3.29 0 .32.22.7.83.58A12.01 12.01 0 0 0 24 12.5C24 5.87 18.63.5 12 .5z"/></svg>
+          <span data-i18n="selfhost.continue_github">Continue with GitHub</span>
+        </button>
+        <button onclick="shmOauth('google')" style="
+          display:flex;
+          align-items:center;
+          justify-content:center;
+          gap:10px;
+          width:100%;
+          padding:11px 14px;
+          background:#fff;
+          border:1px solid rgba(255,255,255,0.12);
+          border-radius:8px;
+          color:#1f2937;
+          font-size:14px;
+          font-weight:600;
+          cursor:pointer;
+          " onmouseover="this.style.background='#f1f5f9'" onmouseout="this.style.background='#fff'">
+          <svg width="18" height="18" viewBox="0 0 24 24" aria-hidden="true"><path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.27-4.74 3.27-8.1z"/><path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.99.66-2.26 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84A11 11 0 0 0 12 23z"/><path fill="#FBBC05" d="M5.84 14.1a6.6 6.6 0 0 1 0-4.2V7.06H2.18a11 11 0 0 0 0 9.88l3.66-2.84z"/><path fill="#EA4335" d="M12 4.75c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 1.4 14.97.5 12 .5A11 11 0 0 0 2.18 7.06l3.66 2.84C6.71 6.68 9.14 4.75 12 4.75z"/></svg>
+          <span data-i18n="selfhost.continue_google">Continue with Google</span>
+        </button>
+        <div style="display:flex;align-items:center;gap:10px;margin-top:4px;">
+          <div style="flex:1;height:1px;background:rgba(255,255,255,0.08);"></div>
+          <span style="color:#64748b;font-size:11px;text-transform:uppercase;letter-spacing:0.5px;" data-i18n="selfhost.or">or</span>
+          <div style="flex:1;height:1px;background:rgba(255,255,255,0.08);"></div>
+        </div>
+      </div>
+      <label style="font-size:12px;font-weight:600;color:#94a3b8;display:block;margin-bottom:6px;" data-i18n="selfhost.your_email">YOUR EMAIL</label>
+      <div style="display:flex;gap:8px;">
+        <input id="shm-email-input" type="email" placeholder="you@example.com" autocomplete="email" style="
+          flex:1;
+          padding:10px 14px;
+          background:#1a2235;
+          border:1px solid rgba(255,255,255,0.1);
+          border-radius:8px;
+          color:#fff;
+          font-size:14px;
+          outline:none;
+          " onkeydown="if(event.key==='Enter')shmSendOtp()">
+        <button id="shm-send-btn" onclick="shmSendOtp()" style="
+          padding:10px 18px;
+          background:#E5443A;
+          color:#fff;
+          border:none;
+          border-radius:8px;
+          font-size:14px;
+          font-weight:600;
+          cursor:pointer;
+          white-space:nowrap;
+          " data-i18n="selfhost.get_started">Get Started</button>
+      </div>
+      <p id="shm-home-error" style="color:#E5443A;font-size:12px;margin:6px 0 0;display:none;"></p>
+      <div style="margin-top:20px;padding-top:20px;border-top:1px solid rgba(255,255,255,0.06);text-align:center;">
+        <a href="#" onclick="shmShowLicense();return false;" style="color:#94a3b8;font-size:12px;text-decoration:none;" data-i18n="selfhost.have_license">I have a license key</a>
+        <span style="color:#334155;font-size:12px;margin:0 8px;">·</span>
+        <span style="color:#64748b;font-size:12px;" data-i18n="selfhost.or_run">or run </span><code style="color:#94a3b8;font-size:12px;background:rgba(255,255,255,0.05);padding:2px 8px;border-radius:4px;">clawmetry login</code>
+      </div>
+    </div>
+    <div id="shm-step-otp" style="display:none;">
+      <p style="color:#94a3b8;font-size:13px;margin:0 0 16px;"><span data-i18n="selfhost.check_email">Check your email for a 6-digit code</span> <b id="shm-otp-email" style="color:#e2e8f0;"></b></p>
+      <div style="display:flex;gap:8px;">
+        <input id="shm-otp-input" type="text" inputmode="numeric" maxlength="6" placeholder="_ _ _ _ _ _" style="
+          flex:1;
+          padding:10px 14px;
+          background:#1a2235;
+          border:1px solid rgba(255,255,255,0.1);
+          border-radius:8px;
+          color:#fff;
+          font-size:18px;
+          letter-spacing:6px;
+          text-align:center;
+          outline:none;
+          " onkeydown="if(event.key==='Enter')shmVerifyOtp()">
+        <button id="shm-verify-btn" onclick="shmVerifyOtp()" style="
+          padding:10px 18px;
+          background:#E5443A;
+          color:#fff;
+          border:none;
+          border-radius:8px;
+          font-size:14px;
+          font-weight:600;
+          cursor:pointer;
+          " data-i18n="selfhost.activate_trial">Activate trial</button>
+      </div>
+      <p id="shm-otp-error" style="color:#E5443A;font-size:12px;margin:6px 0 0;display:none;"></p>
+      <p style="color:#64748b;font-size:12px;margin:10px 0 0;text-align:center;">
+        <span style="cursor:pointer;" onclick="shmResendOtp()" data-i18n="selfhost.resend_code">Resend code</span>
+        <span style="color:#334155;margin:0 8px;">·</span>
+        <span style="cursor:pointer;" onclick="shmBackHome()" data-i18n="selfhost.different_email">Use a different email</span>
+      </p>
+    </div>
+    <div id="shm-step-wait" style="display:none;text-align:center;padding:16px 0;">
+      <div style="width:32px;height:32px;border:3px solid rgba(255,255,255,0.15);border-top-color:#60a5fa;border-radius:50%;margin:0 auto 14px;animation:shmspin 0.8s linear infinite;"></div>
+      <p style="color:#cbd5e1;font-size:14px;font-weight:600;margin:0 0 6px;" data-i18n="selfhost.finish_in_browser">Finish sign-in in the new browser tab</p>
+      <p style="color:#64748b;font-size:12px;margin:0;" data-i18n="selfhost.waiting_oauth">Your trial activates here automatically. Your data never leaves this machine.</p>
+      <p id="shm-wait-error" style="color:#E5443A;font-size:12px;margin:10px 0 0;display:none;"></p>
+      <p style="color:#64748b;font-size:12px;margin:10px 0 0;cursor:pointer;" onclick="shmBackHome()" data-i18n="selfhost.cancel">Cancel</p>
+      <style>@keyframes shmspin{to{transform:rotate(360deg)}}</style>
+    </div>
+    <div id="shm-step-license" style="display:none;">
+      <p style="color:#94a3b8;font-size:13px;margin:0 0 16px;" data-i18n="selfhost.paste_key">Paste the license key from your purchase email.</p>
+      <div style="display:flex;gap:8px;">
+        <input id="shm-license-input" type="text" placeholder="CLAW1.xxxx.xxxx" autocomplete="off" spellcheck="false" style="
+          flex:1;
+          padding:10px 14px;
+          background:#1a2235;
+          border:1px solid rgba(255,255,255,0.1);
+          border-radius:8px;
+          color:#fff;
+          font-size:14px;
+          outline:none;
+          " onkeydown="if(event.key==='Enter')shmActivateLicense()">
+        <button id="shm-license-btn" onclick="shmActivateLicense()" style="
+          padding:10px 18px;
+          background:#E5443A;
+          color:#fff;
+          border:none;
+          border-radius:8px;
+          font-size:14px;
+          font-weight:600;
+          cursor:pointer;
+          " data-i18n="selfhost.activate_license">Activate</button>
+      </div>
+      <p id="shm-license-error" style="color:#E5443A;font-size:12px;margin:6px 0 0;display:none;"></p>
+      <p style="color:#64748b;font-size:12px;margin:10px 0 0;text-align:center;cursor:pointer;" onclick="shmBackHome()" data-i18n="selfhost.back">Back</p>
+    </div>
+    <div id="shm-step-ended" style="display:none;text-align:center;padding:8px 0;">
+      <p style="color:#cbd5e1;font-size:14px;font-weight:600;margin:0 0 6px;" data-i18n="selfhost.trial_ended_title">Your 7-day trial has ended</p>
+      <p style="color:#94a3b8;font-size:13px;margin:0 0 16px;" data-i18n="selfhost.trial_ended_body">You're signed in. Keep every runtime with a license.</p>
+      <a href="https://clawmetry.com/pricing?deploy=self" target="_blank" rel="noopener" style="display:block;padding:10px 14px;background:#E5443A;color:#fff;border-radius:8px;font-size:14px;font-weight:600;text-decoration:none;" data-i18n="selfhost.see_pricing">See pricing</a>
+      <p style="color:#64748b;font-size:12px;margin:12px 0 0;cursor:pointer;" onclick="shmShowLicense()" data-i18n="selfhost.have_license">I have a license key</p>
+    </div>
+  </div>
+</div>

--- a/dashboard.py
+++ b/dashboard.py
@@ -267,7 +267,7 @@ def _otlp_service_name_to_agent_type(service_name):
     return slug or "custom"
 
 
-__version__ = "0.12.622"
+__version__ = "0.12.627"
 
 # Extensions (Phase 2): import the plugin host now, but defer the actual
 # load_plugins() call until after the Flask app is created below so we can
@@ -12472,6 +12472,7 @@ DASHBOARD_HTML = r"""
    blurred dashboard on first run). #}
 {% include 'partials/cloud-modal.html' %}
 {% include 'partials/onboarding-modal.html' %}
+{% include 'partials/selfhost-modal.html' %}
 {% include 'partials/budget-modal.html' %}
 
 <!-- Component Detail Modal -->

--- a/tests/test_onboarding_gate.py
+++ b/tests/test_onboarding_gate.py
@@ -186,21 +186,47 @@ def test_gate_js_is_hard_gate_and_cloud_safe():
     assert "openCloudModal" in js
 
 
-def test_selfhost_card_offers_oauth_in_both_renders():
-    """The self-host card must offer Google/GitHub in BOTH renders: the
-    template's initial body and the JS re-render (_selfhostHome). One
-    without the other means the options vanish after any back-navigation."""
+def test_selfhost_modal_offers_oauth_email_and_license():
+    """The self-host side mirrors the cloud side: one button on the gate
+    card opens a modal offering GitHub/Google OAuth (mode=selfhost bridge),
+    email OTP, and a license key. The gate card itself must stay a single
+    button — the options live in the modal, not the card."""
     js = open(os.path.join(
         _ROOT, "clawmetry", "static", "js", "onboarding.js"),
         encoding="utf-8").read()
     assert "mode: 'selfhost'" in js, "self-host OAuth must use the selfhost bridge mode"
     assert "/api/cloud-cta/oauth-start" in js
-    assert js.count("obg-oauth-github") >= 2 and js.count("obg-oauth-google") >= 2, \
-        "OAuth buttons must be both rendered (_selfhostHome) and wired (_wireSelfhostHome)"
-    html = open(os.path.join(
+    assert "openSelfhostModal" in js and "closeSelfhostModal" in js
+    for fn in ("shmOauth", "shmSendOtp", "shmVerifyOtp", "shmActivateLicense"):
+        assert fn in js, "modal driver %s missing from onboarding.js" % fn
+
+    card = open(os.path.join(
         _ROOT, "clawmetry", "templates", "partials", "onboarding-modal.html"),
         encoding="utf-8").read()
-    assert 'id="obg-oauth-github"' in html and 'id="obg-oauth-google"' in html
+    assert 'id="obg-selfhost-btn"' in card, "gate card needs its single button"
+    assert "obg-oauth-github" not in card, \
+        "OAuth buttons moved to the self-host modal; the card is one button"
+
+    modal = open(os.path.join(
+        _ROOT, "clawmetry", "templates", "partials", "selfhost-modal.html"),
+        encoding="utf-8").read()
+    assert 'id="selfhost-modal-overlay"' in modal
+    for probe in ("shmOauth('github')", "shmOauth('google')", "shmSendOtp()",
+                  "shmActivateLicense()", 'id="shm-step-wait"',
+                  'id="shm-step-ended"'):
+        assert probe in modal, "self-host modal missing %s" % probe
+
+
+def test_selfhost_modal_is_in_live_dashboard_html():
+    """The modal partial must be included OUTSIDE #zoom-wrapper in the LIVE
+    (second) DASHBOARD_HTML, next to cloud-modal (the #4386 overlay rule)."""
+    src = _dash_src()
+    live = src.rfind("DASHBOARD_HTML = ")
+    idx = src.find("partials/selfhost-modal.html", live)
+    assert idx > live, "selfhost-modal partial missing from the LIVE DASHBOARD_HTML"
+    wrapper_end = src.find("end zoom-wrapper", live)
+    assert wrapper_end != -1 and idx > wrapper_end, \
+        "selfhost-modal must be included after #zoom-wrapper closes (fixed overlay rule)"
 
 
 def test_marker_semantics_selfhost_writes_nocloud(monkeypatch, tmp_path):


### PR DESCRIPTION
## What

The gate's self-host card listed every option inline (GitHub, Google, email OTP, license link) while the cloud card is a single button that opens a modal. After #4393 added OAuth, the card grew four actions tall and pushed the gate below the fold again — the exact regression #4386 fixed. This folds the self-host side the same way the cloud side works.

## Changes

- **onboarding-modal.html** — the self-host card body is one "Set up Self-Host" button.
- **selfhost-modal.html** (new) — home (GitHub / Google / email / license), OTP entry, license entry, wait and ended states; same states and chrome as the cloud modal, driven by `shm*` globals in onboarding.js (`shmOauth` uses the `mode: 'selfhost'` loopback bridge from #4393, so egress stays off and the nocloud marker is written before any key persists).
- **dashboard.py** — includes the partial OUTSIDE `#zoom-wrapper` in the live `DASHBOARD_HTML` (fixed-overlay rule, #4386); version bump to 0.12.627.
- **tests/test_onboarding_gate.py** — card must stay a single button, modal must carry all four flows plus wait/ended states, partial must sit past the zoom-wrapper close.

## Verification

- `tests/test_onboarding_gate.py`: 20 passed.
- Full flow exercised locally in the prior session with screenshots across home, license, wait, and error states — modal renders as a faithful twin of the cloud one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)