### PR TITLE
[RELEASE] fix(onboarding): trial/license activation left the daemon dead on fresh installs

### DIFF
--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -845,6 +845,38 @@ def save_config(data: dict) -> None:
     os.replace(tmp_path, CONFIG_FILE)
 
 
+def ensure_local_config() -> bool:
+    """Write a local-only config if none exists so run_daemon() can boot.
+
+    Every daemon spawn path (dashboard trial/license activation, the CLI's
+    local onboard) requires CONFIG_FILE to exist — load_config() raises
+    otherwise and the daemon crash-loops without ever creating the DuckDB
+    store (live-hit 2026-08-01: trial activated from the gate on a fresh
+    machine left `clawmetry status` at "Daemon: Not running" and the
+    dashboard with no family runtimes). Shape mirrors cli._finish_local:
+    empty api_key is safe because is_cloud_disabled() gates all egress.
+
+    Returns True if a config was written, False if one already existed or
+    the write failed (best-effort; never raises).
+    """
+    try:
+        if CONFIG_FILE.exists():
+            return False
+        import platform as _plat
+        import socket as _sock
+
+        save_config({
+            "api_key": "",
+            "node_id": _sock.gethostname() or "local",
+            "platform": _plat.system(),
+            "connected_at": datetime.now().isoformat(),
+            "local_only": True,
+        })
+        return True
+    except Exception:
+        return False
+
+
 def load_state() -> dict:
     if STATE_FILE.exists():
         try:

--- a/dashboard.py
+++ b/dashboard.py
@@ -267,7 +267,7 @@ def _otlp_service_name_to_agent_type(service_name):
     return slug or "custom"
 
 
-__version__ = "0.12.628"
+__version__ = "0.12.630"
 
 # Extensions (Phase 2): import the plugin host now, but defer the actual
 # load_plugins() call until after the Flask app is created below so we can
@@ -18744,7 +18744,17 @@ def _start_daemon_background():
     import subprocess
     import pathlib as _pl
 
-    spawn_kwargs = {}
+    # Without a config the spawned daemon crash-loops (load_config raises)
+    # and the local store never fills; and `python -m` puts the CWD on
+    # sys.path, so a dashboard launched from a source checkout would spawn
+    # the repo's (possibly stale) sync.py instead of the installed wheel.
+    # Same two hazards as routes/trial.py _ensure_local_daemon.
+    try:
+        from clawmetry.sync import ensure_local_config
+        ensure_local_config()
+    except Exception:
+        pass
+    spawn_kwargs = {"cwd": os.path.expanduser("~")}
     if os.name == "nt":
         # start_new_session is POSIX-only and silently no-ops on Windows:
         # the daemon stayed tied to this console (killed when it closes)

--- a/routes/onboarding.py
+++ b/routes/onboarding.py
@@ -226,4 +226,14 @@ def api_onboarding_activate_license():
     _write_choice_file(state)
     _apply_marker_semantics(state)
     _ping_onboarded(state)
+    # A license without a running daemon is a dashboard with no data: on a
+    # fresh machine nothing ever ingests into DuckDB and every runtime tab
+    # stays empty (live-hit 2026-08-01, trial twin fixed the same day).
+    # _ensure_local_daemon bootstraps a local-only config when missing and
+    # no-ops if a daemon already holds the pid lock.
+    try:
+        from routes.trial import _ensure_local_daemon
+        _ensure_local_daemon()
+    except Exception:
+        log.debug("onboarding: daemon kick after activation failed", exc_info=True)
     return jsonify({"ok": True, "state": state, "message": msg})

--- a/routes/trial.py
+++ b/routes/trial.py
@@ -56,6 +56,16 @@ def _ensure_local_daemon() -> None:
         # real daemon out of the test runner's sandbox.
         return
     try:
+        # A daemon spawned without a config crash-loops: run_daemon() ->
+        # load_config() raises FileNotFoundError, so the trial activates but
+        # the DuckDB store is never created and every family runtime stays
+        # invisible (live-hit 2026-08-01). Bootstrap a local-only config
+        # first; no-op when one already exists.
+        try:
+            from clawmetry.sync import ensure_local_config
+            ensure_local_config()
+        except Exception:
+            pass
         log_dir = os.path.expanduser("~/.clawmetry")
         try:
             os.makedirs(log_dir, exist_ok=True)
@@ -63,7 +73,13 @@ def _ensure_local_daemon() -> None:
             pass
         log_fh = open(os.path.join(log_dir, "sync.log"), "a")
         kwargs = {"stdin": subprocess.DEVNULL, "stdout": log_fh,
-                  "stderr": subprocess.STDOUT, "close_fds": True}
+                  "stderr": subprocess.STDOUT, "close_fds": True,
+                  # `python -m clawmetry.sync` puts the CWD on sys.path. When
+                  # the dashboard was launched from a clawmetry source
+                  # checkout, the spawned daemon silently ran the (possibly
+                  # stale) repo copy instead of the installed wheel — pin the
+                  # CWD to a neutral directory so imports resolve normally.
+                  "cwd": os.path.expanduser("~")}
         if os.name == "nt":
             kwargs["creationflags"] = (
                 subprocess.DETACHED_PROCESS | subprocess.CREATE_NEW_PROCESS_GROUP

--- a/tests/test_local_trial_sync_gate.py
+++ b/tests/test_local_trial_sync_gate.py
@@ -101,11 +101,15 @@ def test_sync_allowed_cloud_yes_stays_yes(monkeypatch):
 
 
 def test_ensure_local_daemon_spawn_shape(monkeypatch):
-    """The spawn is detached per-OS and runs `python -m clawmetry.sync`."""
+    """The spawn is detached per-OS, runs `python -m clawmetry.sync` from a
+    neutral CWD, and bootstraps a local-only config first (a config-less
+    daemon crash-loops in load_config and the store never fills)."""
     import routes.trial as T
+    import clawmetry.sync as S
 
     monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
     captured = {}
+    calls = []
 
     def _fake_popen(cmd, **kwargs):
         captured["cmd"] = cmd
@@ -113,13 +117,39 @@ def test_ensure_local_daemon_spawn_shape(monkeypatch):
         return SimpleNamespace(pid=4242)
 
     monkeypatch.setattr(T.subprocess, "Popen", _fake_popen)
+    monkeypatch.setattr(S, "ensure_local_config",
+                        lambda: calls.append("config") or True)
     T._ensure_local_daemon()
+    assert calls == ["config"], "config must be bootstrapped before the spawn"
     assert captured["cmd"][-2:] == ["-m", "clawmetry.sync"]
     kw = captured["kwargs"]
+    assert kw.get("cwd") == os.path.expanduser("~"), \
+        "`python -m` puts the CWD on sys.path; a repo CWD runs stale source"
     if os.name == "nt":
         assert kw.get("creationflags"), "Windows spawn must be detached"
     else:
         assert kw.get("start_new_session") is True
+
+
+def test_ensure_local_config_writes_once(monkeypatch, tmp_path):
+    """Missing config -> local-only shape written 0600; existing -> no-op."""
+    import clawmetry.sync as S
+    import json as _json
+    import pathlib
+
+    cfg = pathlib.Path(tmp_path) / "config.json"
+    monkeypatch.setattr(S, "CONFIG_DIR", pathlib.Path(tmp_path))
+    monkeypatch.setattr(S, "CONFIG_FILE", cfg)
+
+    assert S.ensure_local_config() is True
+    data = _json.loads(cfg.read_text())
+    assert data["local_only"] is True
+    assert data["api_key"] == ""
+    assert data["node_id"]
+
+    cfg.write_text(_json.dumps({"api_key": "keep-me"}))
+    assert S.ensure_local_config() is False, "existing config must survive"
+    assert _json.loads(cfg.read_text()) == {"api_key": "keep-me"}
 
 
 def test_trial_activation_calls_ensure_daemon(monkeypatch, tmp_path):

--- a/tests/test_onboarding_gate.py
+++ b/tests/test_onboarding_gate.py
@@ -137,6 +137,34 @@ def test_activate_license_happy_path(ob, client, monkeypatch):
     assert pings == ["selfhost_license"]
 
 
+def test_activate_license_kicks_ingestion(ob, client, monkeypatch):
+    """A license without a running daemon is a dashboard with no data — the
+    handler must kick _ensure_local_daemon after a successful activation."""
+    import types
+    import routes.trial as T
+
+    fake_lic = types.SimpleNamespace(
+        activate=lambda key, actor="": (True, "activated"))
+    monkeypatch.setitem(sys.modules, "clawmetry.license", fake_lic)
+    import clawmetry
+    monkeypatch.setattr(clawmetry, "license", fake_lic, raising=False)
+    monkeypatch.setattr(ob, "_license_state", lambda: "selfhost_license")
+    kicks = []
+    monkeypatch.setattr(T, "_ensure_local_daemon", lambda: kicks.append(1))
+
+    r = client.post("/api/onboarding/activate-license",
+                    json={"key": "CLAW1.aaa.bbb"})
+    assert r.get_json()["ok"] is True
+    assert kicks == [1], "activation must start local ingestion"
+
+    # A failed activation must NOT spawn a daemon.
+    kicks.clear()
+    fake_lic.activate = lambda key, actor="": (False, "bad key")
+    r = client.post("/api/onboarding/activate-license",
+                    json={"key": "CLAW1.aaa.bbb"})
+    assert r.status_code == 400 and kicks == []
+
+
 def test_state_endpoint_fails_open(ob, client, monkeypatch):
     def boom():
         raise RuntimeError("disk on fire")


### PR DESCRIPTION
## What

Live-hit 2026-08-01: activating the free trial from the gate on a fresh machine wrote `license.key` but the node stayed dark — `clawmetry status` said "Daemon: Not running", the DuckDB store was never created, and every family runtime (Claude Code with 517 on-disk sessions included) was invisible in the dashboard. The sync.log showed the whole story: `Daemon crashed: No config at ~/.clawmetry/config.json`, a 15s restart, then `Another instance is already running. Exiting.`

## Three gaps, one class

1. **`routes/trial.py` `_ensure_local_daemon`** spawned `python -m clawmetry.sync` with no `config.json` — `run_daemon()` → `load_config()` raises `FileNotFoundError` and the daemon crash-loops without ingesting a byte. It also inherited the dashboard's CWD: `python -m` puts the CWD on `sys.path`, so a dashboard launched from a clawmetry source checkout spawned the (stale) repo copy instead of the installed wheel.
2. **`dashboard.py` `_start_daemon_background`** — same two hazards (five call sites).
3. **`routes/onboarding.py` activate-license** — never started ingestion at all; a license without a daemon is a dashboard with no data.

## Fix

- New `clawmetry.sync.ensure_local_config()`: writes the local-only config shape (mirrors `cli._finish_local`; empty `api_key` is egress-safe via `is_cloud_disabled`) iff none exists; best-effort, never raises.
- Both spawn sites call it before the spawn and pin `cwd` to `$HOME`.
- License activation kicks `_ensure_local_daemon` after success (no-op when a daemon already holds the pid lock); failed activation spawns nothing.

## Tests

- Spawn shape asserts config-bootstrap-before-spawn + neutral CWD (`tests/test_local_trial_sync_gate.py`).
- `ensure_local_config` write-once / no-clobber of an existing config.
- Activation kick fires on success, not on failure (`tests/test_onboarding_gate.py`).
- 31 passed locally across both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)