### PR TITLE
feat(entitlement): has_feature_at / has_runtime_at + endpoints (what-if boolean-gate scalars)

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -5422,7 +5422,7 @@ def has_feature_at(perspective_tier: str, feature: str) -> bool:
     bind ONE boolean per cell off ONE URL each instead of fetching the
     full :func:`feature_catalog_at` payload and pulling out the
     ``allowed`` field client-side. Scalar-precise complement of
-    :func:`feature_spec_at`\ 's ``allowed`` bit -- a callsite that only
+    :func:`feature_spec_at`'s ``allowed`` bit -- a callsite that only
     needs the boolean does not have to hydrate the full spec row.
 
     Semantics diverge from the perspective-independent
@@ -5450,7 +5450,7 @@ def has_feature_at(perspective_tier: str, feature: str) -> bool:
       same ``.strip().lower()`` normalisation :func:`has_feature` uses.
       Unknown / empty / non-string -> ``False``.
     * All-free feature on any real tier -> ``True`` (the free floor is
-      part of :func:`_hypothetical_entitlement`\ 's synthesis).
+      part of :func:`_hypothetical_entitlement`'s synthesis).
     * Never raises: any hypothetical-build failure logs a warning and
       returns ``False`` so a pricing matrix cell keeps rendering.
     """

--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -5413,6 +5413,121 @@ def has_runtime(runtime: str) -> bool:
         return False
 
 
+def has_feature_at(perspective_tier: str, feature: str) -> bool:
+    """Hypothetical-perspective sibling of :func:`has_feature`: would tier
+    ``perspective_tier`` grant ``feature``?
+
+    Fills the missing ``_at`` slot in the boolean-gate family so a pricing
+    matrix ("does Starter grant fleet? does Pro? does Enterprise?") can
+    bind ONE boolean per cell off ONE URL each instead of fetching the
+    full :func:`feature_catalog_at` payload and pulling out the
+    ``allowed`` field client-side. Scalar-precise complement of
+    :func:`feature_spec_at`\ 's ``allowed`` bit -- a callsite that only
+    needs the boolean does not have to hydrate the full spec row.
+
+    Semantics diverge from the perspective-independent
+    :func:`min_tier_for_features_at` / :func:`tiers_for_feature_at`
+    convention deliberately: the boolean answer *is*
+    perspective-shaped. Backed by :func:`_hypothetical_entitlement`,
+    which forces ``grace`` off so the returned bit reflects the static
+    per-tier grant in :data:`_TIER_FEATURES` rather than the live
+    resolver's grace pass-through. That means, unlike :func:`has_feature`
+    (which returns ``True`` for every known feature in grace),
+    ``has_feature_at`` returns ``False`` even in grace for a
+    ``perspective_tier`` that does not statically grant ``feature`` --
+    the whole point of a what-if scalar.
+
+    Contract:
+
+    * ``perspective_tier`` is validated against :data:`_TIER_ORDER`
+      (including :data:`TIER_TRIAL`). Empty / non-string / unknown ->
+      ``False``. Same fail-closed posture as :func:`has_feature` on an
+      unknown ``feature``: the strict validity gate catches a typo like
+      ``has_feature_at("Pro", "fleet")`` (uppercase P, dropped by the
+      strip-lower) at the callsite instead of silently masquerading as
+      a grant.
+    * ``feature`` is validated against :data:`ALL_FEATURES` with the
+      same ``.strip().lower()`` normalisation :func:`has_feature` uses.
+      Unknown / empty / non-string -> ``False``.
+    * All-free feature on any real tier -> ``True`` (the free floor is
+      part of :func:`_hypothetical_entitlement`\ 's synthesis).
+    * Never raises: any hypothetical-build failure logs a warning and
+      returns ``False`` so a pricing matrix cell keeps rendering.
+    """
+    try:
+        p = (perspective_tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return False
+    if not p or p not in _TIER_ORDER:
+        return False
+    try:
+        f = (feature or "").strip().lower()
+    except (AttributeError, TypeError):
+        return False
+    if not f or f not in ALL_FEATURES:
+        return False
+    try:
+        return bool(_hypothetical_entitlement(p).allows_feature(f))
+    except Exception as exc:
+        logger.warning(
+            "entitlements: has_feature_at(%r, %r) failed: %s",
+            perspective_tier,
+            feature,
+            exc,
+        )
+        return False
+
+
+def has_runtime_at(perspective_tier: str, runtime: str) -> bool:
+    """Runtime-axis twin of :func:`has_feature_at`: would tier
+    ``perspective_tier`` grant ``runtime``?
+
+    Same relationship to :func:`has_runtime` that :func:`has_feature_at`
+    has to :func:`has_feature`. Backed by
+    :func:`_hypothetical_entitlement` (grace off), so the returned bit
+    reflects the static per-tier runtime grant -- runtimes in
+    :data:`FREE_RUNTIMES` always ``True``; runtimes in
+    :data:`PAID_RUNTIMES` ``True`` iff ``perspective_tier`` is one of
+    the paid tiers (:data:`_TIER_PAID_RUNTIMES`).
+
+    Alias posture matches the sibling :func:`has_runtime` scalar
+    exactly: no :func:`canonical_runtime` resolution here -- an alias
+    input (``has_runtime_at("pro", "claude-code")``) collapses to
+    ``False`` because ``"claude-code"`` is not in :data:`ALL_RUNTIMES`
+    after ``.strip().lower()``. Callers who want alias tolerance should
+    canonicalise upstream (which is what the paired
+    ``/api/entitlement/has-runtime-at`` endpoint does before delegating
+    to this scalar, matching the ``/has-runtime`` endpoint's own
+    upstream posture).
+
+    Contract otherwise mirrors :func:`has_feature_at`: perspective /
+    runtime validated fail-closed, hypothetical-build failure logged
+    and collapsed to ``False``, never raises.
+    """
+    try:
+        p = (perspective_tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return False
+    if not p or p not in _TIER_ORDER:
+        return False
+    try:
+        rt = (runtime or "").strip().lower()
+    except (AttributeError, TypeError):
+        return False
+    if not rt or rt not in ALL_RUNTIMES:
+        return False
+    try:
+        return bool(_hypothetical_entitlement(p).allows_runtime(rt))
+    except Exception as exc:
+        logger.warning(
+            "entitlements: has_runtime_at(%r, %r) failed: %s",
+            perspective_tier,
+            runtime,
+            exc,
+        )
+        return False
+
+
 def has_channel_count(count) -> bool:
     """Boolean-gate scalar: does the CURRENT install admit ``count`` chat-channel
     adapters concurrently?

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -3515,6 +3515,193 @@ def api_entitlement_has_runtime():
         return jsonify(_has_axis_fallback("runtime", key))
 
 
+def _has_axis_at_fallback(axis: str, tier: str, key: str) -> dict:
+    """OSS-free / never-5xx shape for ``/api/entitlement/has-feature-at`` /
+    ``/has-runtime-at``.
+
+    What-if sibling of :func:`_has_axis_fallback`. On any resolver / helper
+    blowup the endpoint still returns 200 with the same 12-key envelope as
+    the happy-path branch, but with ``has_<axis>_at`` and ``allowed``
+    strict-``False`` (matches the fail-closed posture the sibling
+    ``/has-feature`` / ``/has-runtime`` fallback uses -- a paywall matrix
+    tile that lost the resolver never silently renders a grant it can't
+    verify). ``tier`` and the axis slot echo the caller's canonicalised
+    input so the UI can still surface both in a diagnostics tooltip.
+    """
+    return {
+        "tier": tier,
+        axis: key,
+        f"has_{axis}_at": False,
+        "allowed": False,
+        "required_tier": None,
+        "required_tier_label": None,
+        "required_tier_rank": -1,
+        "perspective_tier_rank": -1,
+        "current_tier": "oss",
+        "current_tier_rank": 0,
+        "grace": True,
+        "enforced": False,
+    }
+
+
+def _has_axis_at_body(axis: str) -> dict:
+    """Happy-path body builder for ``/api/entitlement/has-feature-at`` /
+    ``/has-runtime-at`` -- scalar what-if boolean plus the surrounding
+    what-if envelope.
+
+    Perspective-shaped sibling of :func:`_has_axis_body`: where the live
+    variant folds :func:`has_feature` / :func:`has_runtime` against the
+    resolved entitlement, this folds :func:`has_feature_at` /
+    :func:`has_runtime_at` against a caller-supplied ``tier=`` perspective
+    so a pricing matrix ("does Starter grant fleet? Pro? Enterprise?")
+    can bind ONE boolean per cell off ONE URL each instead of
+    hydrating the full ``/feature-catalog-at`` payload and pulling out
+    the ``allowed`` field client-side.
+
+    12-key envelope (adds ``tier`` + ``perspective_tier_rank`` +
+    ``grace`` / ``enforced`` on top of the sibling ``/has-feature`` shape)::
+
+        {
+          "tier":                  "<perspective tier id>" | "",
+          "feature":               "<canonicalised id>"    | "",
+          "has_feature_at":        <bool>,
+          "allowed":               <bool>,             # alias of has_feature_at
+          "required_tier":         "<tier id>" | null, # min_tier_for_<axis>
+          "required_tier_label":   "<label>"  | null,
+          "required_tier_rank":    <int>,              # -1 when required_tier null
+          "perspective_tier_rank": <int>,              # -1 when tier unknown/blank
+          "current_tier":          "<live tier id>",
+          "current_tier_rank":     <int>,
+          "grace":                 <bool>,             # live resolver grace bit
+          "enforced":              <bool>,
+        }
+
+    Runtime-axis alias canonicalisation: the endpoint layer calls
+    :func:`canonical_runtime` on the raw ``runtime`` arg before delegating
+    to :func:`has_runtime_at`, matching the ``/has-runtime`` endpoint's
+    own upstream posture. This lets ``?runtime=claude-code`` collapse to
+    the granted ``claude_code`` at the URL layer even though the scalar
+    itself is strict (no alias resolution at scalar level -- see
+    :func:`has_runtime_at`).
+
+    Never 4xxs (missing / blank / unknown tier or axis id -> 200 with
+    ``has_<axis>_at=False``, mirroring the ``/has-feature`` posture). The
+    ``perspective_tier_rank`` slot is ``-1`` for an unknown perspective
+    so a UI can distinguish "typo perspective" from "valid perspective
+    that just doesn't grant this axis". Never 5xxs.
+    """
+    from clawmetry import entitlements as _ent
+
+    raw_tier = request.args.get("tier")
+    tier = (raw_tier or "").strip().lower()
+    if axis == "feature":
+        raw_key = request.args.get("feature")
+        key = (raw_key or "").strip().lower()
+    else:
+        raw_key = request.args.get("runtime")
+        # Canonicalise runtime alias upstream of the strict scalar
+        # (``has_runtime_at`` does not resolve aliases -- see the
+        # scalar docstring for rationale), matching the sibling
+        # ``/has-runtime`` endpoint's own upstream-canonicalise pattern.
+        raw_stripped = (raw_key or "").strip().lower()
+        try:
+            key = _ent.canonical_runtime(raw_stripped) or raw_stripped
+        except Exception:
+            key = raw_stripped
+    if axis == "feature":
+        has_flag = _ent.has_feature_at(tier, key)
+        required = _ent.min_tier_for_feature(key) if key else None
+    else:
+        has_flag = _ent.has_runtime_at(tier, key)
+        required = _ent.min_tier_for_runtime(key) if key else None
+    ent = _ent.get_entitlement()
+    cur_rank = _ent.tier_rank(ent.tier)
+    req_rank = _ent.tier_rank(required) if required else -1
+    required_label = _ent.tier_label(required) if required else None
+    # Rank of the perspective tier itself, so a paywall matrix can sort
+    # cells by tier without a follow-up ``/tier-rank`` call. ``-1`` when
+    # the perspective is unknown / blank (matches the ``required_tier_rank``
+    # sentinel for a not-resolved tier).
+    persp_rank = _ent.tier_rank(tier) if tier and tier in _ent._TIER_ORDER else -1
+    return {
+        "tier": tier,
+        axis: key,
+        f"has_{axis}_at": bool(has_flag),
+        "allowed": bool(has_flag),
+        "required_tier": required,
+        "required_tier_label": required_label,
+        "required_tier_rank": req_rank,
+        "perspective_tier_rank": persp_rank,
+        "current_tier": ent.tier,
+        "current_tier_rank": cur_rank,
+        "grace": bool(ent.grace),
+        "enforced": _ent.is_enforced(),
+    }
+
+
+@bp_entitlement.route("/api/entitlement/has-feature-at")
+def api_entitlement_has_feature_at():
+    """``GET /api/entitlement/has-feature-at?tier=<perspective>&feature=<id>``
+    -- what-if boolean-gate scalar sibling of ``/api/entitlement/has-feature``.
+
+    Returns ONE boolean (``has_feature_at``) plus a what-if envelope that
+    tells the caller which perspective they asked about, whether the
+    requested feature is admitted by that perspective, the cheapest tier
+    that would unlock it (``required_tier``, byte-parity with the sibling
+    ``/api/entitlement/min-tier-for-feature`` answer), and the LIVE
+    resolver context (``current_tier`` / ``grace`` / ``enforced``) so a
+    pricing matrix can render "you are here" alongside "would tier X
+    grant this?" off ONE URL per cell.
+
+    Unlike the live ``/has-feature`` sibling this endpoint is
+    perspective-shaped: even in grace ``has_feature_at="oss","fleet"`` is
+    ``False`` (because OSS-free does not statically grant ``fleet``),
+    whereas ``/has-feature?feature=fleet`` in grace returns ``True``.
+    That is the whole point of the ``_at`` slot -- render the
+    would-be-locked state alongside the live grant.
+
+    Never 4xxs (missing / blank / unknown tier or feature -> 200 with
+    ``has_feature_at=false``, matching the ``/has-feature`` posture --
+    a paywall matrix tile binds ``allowed`` directly without a
+    pre-validation round-trip). Never 5xxs: any helper blowup collapses
+    to :func:`_has_axis_at_fallback`.
+    """
+    try:
+        return jsonify(_has_axis_at_body("feature"))
+    except Exception as exc:
+        logger.warning("api_entitlement_has_feature_at: error: %s", exc)
+        tier = (request.args.get("tier") or "").strip().lower()
+        key = (request.args.get("feature") or "").strip().lower()
+        return jsonify(_has_axis_at_fallback("feature", tier, key))
+
+
+@bp_entitlement.route("/api/entitlement/has-runtime-at")
+def api_entitlement_has_runtime_at():
+    """``GET /api/entitlement/has-runtime-at?tier=<perspective>&runtime=<id>``
+    -- runtime-axis twin of ``/api/entitlement/has-feature-at``.
+
+    Same 12-key envelope with ``runtime`` / ``has_runtime_at`` in the
+    axis-specific slots. Runtime-alias canonicalisation
+    (``claude-code`` -> ``claude_code``) is applied upstream at the
+    endpoint layer so ``?runtime=claude-code`` collapses to the granted
+    ``claude_code`` -- matches the sibling ``/has-runtime`` endpoint's
+    own upstream-canonicalise pattern. Never 4xxs; never 5xxs.
+    """
+    try:
+        return jsonify(_has_axis_at_body("runtime"))
+    except Exception as exc:
+        logger.warning("api_entitlement_has_runtime_at: error: %s", exc)
+        tier = (request.args.get("tier") or "").strip().lower()
+        raw_key = (request.args.get("runtime") or "").strip().lower()
+        try:
+            from clawmetry import entitlements as _ent
+
+            key = _ent.canonical_runtime(raw_key) or raw_key
+        except Exception:
+            key = raw_key
+        return jsonify(_has_axis_at_fallback("runtime", tier, key))
+
+
 def _has_channel_count_fallback(count_raw: str) -> dict:
     """OSS-free / never-5xx shape for ``/api/entitlement/has-channel-count``.
 

--- a/tests/test_entitlement_has_feature_at_has_runtime_at.py
+++ b/tests/test_entitlement_has_feature_at_has_runtime_at.py
@@ -1,0 +1,713 @@
+"""Tests for the ``has_feature_at`` / ``has_runtime_at`` hypothetical-perspective
+boolean-gate scalar helpers and their paired
+``/api/entitlement/has-feature-at`` / ``/api/entitlement/has-runtime-at``
+endpoints.
+
+Hypothetical-perspective siblings of the live :func:`has_feature` /
+:func:`has_runtime` scalars: where those answer "does the LIVE resolved
+entitlement grant this?", these answer "would tier ``perspective_tier``
+grant this?" -- one boolean per pricing-matrix cell, decoupled from the
+live resolver's grace pass-through, so a "does Starter grant fleet? Pro?
+Enterprise?" matrix can bind ``allowed`` directly off ONE URL per cell
+without hydrating the full ``/feature-catalog-at`` payload.
+
+Semantics diverge deliberately from the perspective-independent
+:func:`min_tier_for_features_at` / :func:`tiers_for_feature_at` convention:
+the boolean answer *is* perspective-shaped. Backed by
+:func:`_hypothetical_entitlement`, which forces ``grace`` off so the
+returned bit reflects the static per-tier grant in :data:`_TIER_FEATURES` /
+:data:`_TIER_PAID_RUNTIMES` rather than the live resolver's grace
+pass-through.
+
+This file pins:
+
+1. Scalar semantics: empty / None / non-string / unknown perspective,
+   unknown axis-id, free / paid axis-id across every tier.
+2. Perspective-shaped grace-independence: ``has_feature_at("oss", "fleet")``
+   returns ``False`` in BOTH grace and enforce (unlike the live
+   :func:`has_feature` sibling which returns ``True`` in grace) -- the
+   whole point of the ``_at`` slot is to render the would-be-locked
+   state alongside the live grant.
+3. Runtime-axis alias posture: scalar is strict (no
+   :func:`canonical_runtime` resolution -- matches sibling
+   :func:`has_runtime`); endpoint canonicalises upstream (matches sibling
+   ``/has-runtime`` endpoint).
+4. Endpoint envelope shape (fixed 12-key set) across every input branch.
+5. Never-4xx / never-5xx guarantees on both endpoints.
+6. Cross-consistency with the sibling ``/api/entitlement/feature-spec-at``
+   / ``/runtime-spec-at`` endpoints -- same ``allowed`` bit for the same
+   perspective + axis id.
+7. Cross-consistency with the live ``/api/entitlement/has-feature`` /
+   ``/has-runtime`` endpoints on the ``current_tier`` / ``grace`` /
+   ``enforced`` envelope slots (both endpoints share the resolver
+   context; only the ``allowed`` bit differs by design).
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+# ── Fixtures ────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    """Fresh entitlements module in OSS-free-grace mode -- matches the
+    sibling ``test_entitlement_has_feature_has_runtime.py`` fixture so
+    the perspective assertions here reproduce the same install state the
+    live boolean gates are pinned against."""
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def enforced(monkeypatch, tmp_path):
+    """Enforcement-on fixture: ``CLAWMETRY_ENFORCE=1`` flips
+    ``ent.grace`` off. Included to pin the perspective-shaped
+    grace-independence invariant -- ``has_*_at`` returns the same
+    answer under grace vs enforce for the same (perspective, id)
+    pair."""
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    importlib.reload(e)
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+@pytest.fixture
+def enforced_client(enforced):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# ── Envelope shape ──────────────────────────────────────────────────────────
+
+_FEATURE_KEYS = {
+    "tier",
+    "feature",
+    "has_feature_at",
+    "allowed",
+    "required_tier",
+    "required_tier_label",
+    "required_tier_rank",
+    "perspective_tier_rank",
+    "current_tier",
+    "current_tier_rank",
+    "grace",
+    "enforced",
+}
+_RUNTIME_KEYS = {
+    "tier",
+    "runtime",
+    "has_runtime_at",
+    "allowed",
+    "required_tier",
+    "required_tier_label",
+    "required_tier_rank",
+    "perspective_tier_rank",
+    "current_tier",
+    "current_tier_rank",
+    "grace",
+    "enforced",
+}
+
+
+def _get_json(client, url: str) -> dict:
+    resp = client.get(url)
+    assert resp.status_code == 200, url
+    return resp.get_json()
+
+
+# ── has_feature_at scalar ─────────────────────────────────────────────────
+
+
+def test_has_feature_at_free_on_every_tier(ent):
+    """A free feature is granted from every real tier (the free floor
+    is baked into :func:`_hypothetical_entitlement`)."""
+    free = next(iter(ent.FREE_FEATURES))
+    for tier in ent._TIER_ORDER:
+        assert ent.has_feature_at(tier, free) is True, tier
+
+
+def test_has_feature_at_paid_only_on_granting_tiers(ent):
+    """A paid feature is granted only from tiers whose static
+    :data:`_TIER_FEATURES` map includes it."""
+    for feat in sorted(ent.PAID_FEATURES):
+        for tier in ent._TIER_ORDER:
+            granted = feat in ent._TIER_FEATURES.get(tier, frozenset())
+            assert ent.has_feature_at(tier, feat) is granted, (tier, feat)
+
+
+def test_has_feature_at_oss_never_grants_paid(ent):
+    """The OSS-free tier never statically grants a paid feature (the
+    whole point of the ``_at`` slot: renders locked even in grace)."""
+    for feat in sorted(ent.PAID_FEATURES):
+        assert ent.has_feature_at("oss", feat) is False, feat
+
+
+def test_has_feature_at_unknown_perspective_is_false(ent):
+    """Perspective not in :data:`_TIER_ORDER` -> fail-closed False.
+    Casing / whitespace normalises via ``.strip().lower()`` before the
+    membership check, so ``"Pro"`` is a valid perspective and does NOT
+    belong on this list (covered by the case-insensitive test)."""
+    for bad in ["", " ", "mars", "pro_plus", "unknown_tier"]:
+        assert ent.has_feature_at(bad, "fleet") is False, bad
+
+
+def test_has_feature_at_unknown_feature_is_false(ent):
+    """Feature id not in :data:`ALL_FEATURES` -> fail-closed False."""
+    for bad in ["", " ", "bogus_id", "Fleet"]:
+        # note: "Fleet" is uppercase, which the strict lower-normalise
+        # collapses; the resulting "fleet" IS in ALL_FEATURES so the
+        # scalar delegates to _hypothetical -- the typo does NOT
+        # fail-closed here (matches has_feature's behaviour: the strict
+        # gate is on the pre-normalised text after strip().lower(), not
+        # on the raw casing). The "Fleet" case is exercised below.
+        if bad == "Fleet":
+            assert ent.has_feature_at("pro", bad) is True  # normalises to "fleet"
+        else:
+            assert ent.has_feature_at("pro", bad) is False, bad
+
+
+def test_has_feature_at_non_string_perspective_is_false(ent):
+    for bad in [None, 123, object(), []]:
+        assert ent.has_feature_at(bad, "fleet") is False
+
+
+def test_has_feature_at_non_string_feature_is_false(ent):
+    for bad in [None, 123, object(), []]:
+        assert ent.has_feature_at("pro", bad) is False
+
+
+def test_has_feature_at_case_insensitive_normalises(ent):
+    """Casing / whitespace on both args normalises via ``strip().lower()``
+    -- a callsite passing raw config values doesn't have to pre-canonicalise."""
+    assert ent.has_feature_at("  PRO  ", "  fleet  ") is True
+    assert ent.has_feature_at("Pro", "FLEET") is True
+
+
+def test_has_feature_at_grace_independence(ent, enforced):
+    """The whole point of the ``_at`` slot: perspective-shaped answers
+    are IDENTICAL under grace vs enforce for the same (perspective, id)
+    pair. Diverges from the live :func:`has_feature` which flips from
+    ``True`` in grace to ``False`` in enforce for the same feature."""
+    for feat in sorted(ent.PAID_FEATURES):
+        for tier in ent._TIER_ORDER:
+            assert ent.has_feature_at(tier, feat) is enforced.has_feature_at(
+                tier, feat
+            ), (tier, feat)
+
+
+def test_has_feature_at_never_raises_on_hypothetical_blowup(monkeypatch, ent):
+    """Any blowup in the hypothetical-entitlement builder collapses to
+    ``False`` so a pricing matrix cell keeps rendering."""
+
+    def _boom(*a, **kw):
+        raise RuntimeError("hypothetical blew up")
+
+    monkeypatch.setattr(ent, "_hypothetical_entitlement", _boom)
+    for tier in ent._TIER_ORDER:
+        assert ent.has_feature_at(tier, "fleet") is False
+
+
+# ── has_runtime_at scalar ─────────────────────────────────────────────────
+
+
+def test_has_runtime_at_free_on_every_tier(ent):
+    """A free runtime is granted from every real tier."""
+    for rt in sorted(ent.FREE_RUNTIMES):
+        for tier in ent._TIER_ORDER:
+            assert ent.has_runtime_at(tier, rt) is True, (tier, rt)
+
+
+def test_has_runtime_at_paid_only_on_paid_tiers(ent):
+    """A paid runtime is granted only from tiers in
+    :data:`_TIER_PAID_RUNTIMES`."""
+    paid = next(iter(ent.PAID_RUNTIMES))
+    for tier in ent._TIER_ORDER:
+        granted = tier in ent._TIER_PAID_RUNTIMES
+        assert ent.has_runtime_at(tier, paid) is granted, (tier, paid)
+
+
+def test_has_runtime_at_oss_never_grants_paid(ent):
+    """OSS-free never statically grants any paid runtime."""
+    for rt in sorted(ent.PAID_RUNTIMES):
+        assert ent.has_runtime_at("oss", rt) is False, rt
+
+
+def test_has_runtime_at_unknown_perspective_is_false(ent):
+    for bad in ["", " ", "mars", "pro-plus", "unknown_tier"]:
+        assert ent.has_runtime_at(bad, "openclaw") is False, bad
+
+
+def test_has_runtime_at_unknown_runtime_is_false(ent):
+    for bad in ["", " ", "bogus_runtime"]:
+        assert ent.has_runtime_at("pro", bad) is False, bad
+
+
+def test_has_runtime_at_scalar_does_not_alias_resolve(ent):
+    """The scalar mirrors the sibling :func:`has_runtime` alias posture
+    exactly: ``"claude-code"`` is not in :data:`ALL_RUNTIMES` after
+    ``.strip().lower()``, so an alias input at the scalar layer
+    collapses to ``False``. Alias tolerance belongs to the endpoint,
+    which canonicalises upstream."""
+    assert ent.has_runtime_at("pro", "claude-code") is False
+
+
+def test_has_runtime_at_non_string_perspective_is_false(ent):
+    for bad in [None, 123, object(), []]:
+        assert ent.has_runtime_at(bad, "openclaw") is False
+
+
+def test_has_runtime_at_non_string_runtime_is_false(ent):
+    for bad in [None, 123, object(), []]:
+        assert ent.has_runtime_at("pro", bad) is False
+
+
+def test_has_runtime_at_case_insensitive_normalises(ent):
+    assert ent.has_runtime_at("  PRO  ", "  openclaw  ") is True
+    assert ent.has_runtime_at("Pro", "OPENCLAW") is True
+
+
+def test_has_runtime_at_grace_independence(ent, enforced):
+    """Grace-independence invariant for the runtime axis."""
+    for rt in sorted(ent.ALL_RUNTIMES):
+        for tier in ent._TIER_ORDER:
+            assert ent.has_runtime_at(tier, rt) is enforced.has_runtime_at(
+                tier, rt
+            ), (tier, rt)
+
+
+def test_has_runtime_at_never_raises_on_hypothetical_blowup(monkeypatch, ent):
+    def _boom(*a, **kw):
+        raise RuntimeError("hypothetical blew up")
+
+    monkeypatch.setattr(ent, "_hypothetical_entitlement", _boom)
+    for tier in ent._TIER_ORDER:
+        assert ent.has_runtime_at(tier, "openclaw") is False
+
+
+# ── Cross-consistency: has_*_at parity with feature_spec_at.allowed ────────
+
+
+def test_has_feature_at_parity_with_feature_spec_at(ent):
+    """The scalar bit byte-equals the sibling :func:`feature_spec_at`'s
+    ``allowed`` field for every (tier, feature) pair."""
+    for tier in ent._TIER_ORDER:
+        for feat in sorted(ent.ALL_FEATURES):
+            spec = ent.feature_spec_at(tier, feat)
+            assert spec is not None, (tier, feat)
+            assert ent.has_feature_at(tier, feat) is bool(spec["allowed"]), (
+                tier,
+                feat,
+            )
+
+
+def test_has_runtime_at_parity_with_runtime_spec_at(ent):
+    for tier in ent._TIER_ORDER:
+        for rt in sorted(ent.ALL_RUNTIMES):
+            spec = ent.runtime_spec_at(tier, rt)
+            assert spec is not None, (tier, rt)
+            assert ent.has_runtime_at(tier, rt) is bool(spec["allowed"]), (
+                tier,
+                rt,
+            )
+
+
+# ── /api/entitlement/has-feature-at endpoint ──────────────────────────────
+
+
+def test_endpoint_has_feature_at_shape_default(client):
+    """Missing all args -> 200 with 12-key envelope and fail-closed False."""
+    body = _get_json(client, "/api/entitlement/has-feature-at")
+    assert set(body.keys()) == _FEATURE_KEYS
+    assert body["tier"] == ""
+    assert body["feature"] == ""
+    assert body["has_feature_at"] is False
+    assert body["allowed"] is False
+    assert body["required_tier"] is None
+    assert body["required_tier_rank"] == -1
+    assert body["perspective_tier_rank"] == -1
+    assert body["current_tier"] == "oss"
+    assert body["current_tier_rank"] == 0
+
+
+def test_endpoint_has_feature_at_paid_on_granting_tier(client):
+    """Grace-independence at URL level: a paid feature on a granting tier
+    reports ``allowed=true`` even in grace."""
+    body = _get_json(client, "/api/entitlement/has-feature-at?tier=pro&feature=fleet")
+    assert body["tier"] == "pro"
+    assert body["feature"] == "fleet"
+    assert body["has_feature_at"] is True
+    assert body["allowed"] is True
+    assert body["perspective_tier_rank"] > 0
+    assert body["current_tier"] == "oss"
+
+
+def test_endpoint_has_feature_at_paid_on_oss_is_denied(client):
+    """The whole point of the ``_at`` slot: OSS reports ``allowed=false``
+    for a paid feature EVEN IN GRACE, unlike the live ``/has-feature``
+    sibling which returns ``true`` in grace on the same feature."""
+    body = _get_json(client, "/api/entitlement/has-feature-at?tier=oss&feature=fleet")
+    assert body["has_feature_at"] is False
+    assert body["allowed"] is False
+    assert body["perspective_tier_rank"] == 0
+    # Live sibling parity: same current_tier envelope (the live
+    # /has-feature endpoint's 8-key body does not carry ``grace`` /
+    # ``enforced``; those are what-if-only slots on the ``_at`` body).
+    live = _get_json(client, "/api/entitlement/has-feature?feature=fleet")
+    assert live["has_feature"] is True  # grace-passthrough on live
+    assert body["current_tier"] == live["current_tier"]
+    assert body["current_tier_rank"] == live["current_tier_rank"]
+
+
+def test_endpoint_has_feature_at_unknown_tier_never_4xx(client):
+    body = _get_json(client, "/api/entitlement/has-feature-at?tier=mars&feature=fleet")
+    assert set(body.keys()) == _FEATURE_KEYS
+    assert body["tier"] == "mars"
+    assert body["has_feature_at"] is False
+    assert body["perspective_tier_rank"] == -1
+
+
+def test_endpoint_has_feature_at_unknown_feature_never_4xx(client):
+    body = _get_json(client, "/api/entitlement/has-feature-at?tier=pro&feature=bogus_id")
+    assert set(body.keys()) == _FEATURE_KEYS
+    assert body["tier"] == "pro"
+    assert body["feature"] == "bogus_id"
+    assert body["has_feature_at"] is False
+    assert body["required_tier"] is None
+
+
+def test_endpoint_has_feature_at_case_insensitive(client):
+    body = _get_json(
+        client, "/api/entitlement/has-feature-at?tier=%20PRO%20&feature=%20FLEET%20"
+    )
+    assert body["tier"] == "pro"
+    assert body["feature"] == "fleet"
+    assert body["has_feature_at"] is True
+
+
+def test_endpoint_has_feature_at_required_tier_parity(client):
+    """``required_tier`` byte-equals the sibling
+    ``/api/entitlement/min-tier-for-feature`` answer for the same
+    feature id -- a UI wiring both URLs into the same paywall matrix
+    cannot see inconsistent tier state."""
+    body = _get_json(client, "/api/entitlement/has-feature-at?tier=pro&feature=fleet")
+    min_body = _get_json(client, "/api/entitlement/required-tier?feature=fleet")
+    assert body["required_tier"] == min_body["required_tier"]
+
+
+def test_endpoint_has_feature_at_never_5xx_on_resolver_blowup(monkeypatch, client):
+    from clawmetry import entitlements as _ent
+
+    def _boom(*a, **kw):
+        raise RuntimeError("resolver blew up")
+
+    monkeypatch.setattr(_ent, "get_entitlement", _boom)
+    resp = client.get("/api/entitlement/has-feature-at?tier=pro&feature=fleet")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert set(body.keys()) == _FEATURE_KEYS
+    assert body["has_feature_at"] is False
+    assert body["current_tier"] == "oss"
+
+
+def test_endpoint_has_feature_at_never_5xx_on_scalar_blowup(monkeypatch, client):
+    from clawmetry import entitlements as _ent
+
+    def _boom(*a, **kw):
+        raise RuntimeError("scalar blew up")
+
+    monkeypatch.setattr(_ent, "has_feature_at", _boom)
+    resp = client.get("/api/entitlement/has-feature-at?tier=pro&feature=fleet")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert set(body.keys()) == _FEATURE_KEYS
+    assert body["has_feature_at"] is False
+
+
+# ── /api/entitlement/has-runtime-at endpoint ──────────────────────────────
+
+
+def test_endpoint_has_runtime_at_shape_default(client):
+    body = _get_json(client, "/api/entitlement/has-runtime-at")
+    assert set(body.keys()) == _RUNTIME_KEYS
+    assert body["tier"] == ""
+    assert body["runtime"] == ""
+    assert body["has_runtime_at"] is False
+    assert body["perspective_tier_rank"] == -1
+
+
+def test_endpoint_has_runtime_at_paid_on_granting_tier(client):
+    body = _get_json(
+        client, "/api/entitlement/has-runtime-at?tier=pro&runtime=claude_code"
+    )
+    assert body["runtime"] == "claude_code"
+    assert body["has_runtime_at"] is True
+    assert body["allowed"] is True
+
+
+def test_endpoint_has_runtime_at_paid_on_oss_is_denied(client):
+    body = _get_json(
+        client, "/api/entitlement/has-runtime-at?tier=oss&runtime=claude_code"
+    )
+    assert body["has_runtime_at"] is False
+    assert body["perspective_tier_rank"] == 0
+
+
+def test_endpoint_has_runtime_at_alias_canonicalises_upstream(client):
+    """Alias input at URL level collapses to the granted canonical form
+    before delegating to the strict scalar. Matches the sibling
+    ``/has-runtime`` endpoint's own upstream canonicalise pattern."""
+    body = _get_json(
+        client, "/api/entitlement/has-runtime-at?tier=pro&runtime=claude-code"
+    )
+    assert body["runtime"] == "claude_code"
+    assert body["has_runtime_at"] is True
+
+
+def test_endpoint_has_runtime_at_unknown_tier_never_4xx(client):
+    body = _get_json(
+        client, "/api/entitlement/has-runtime-at?tier=mars&runtime=openclaw"
+    )
+    assert set(body.keys()) == _RUNTIME_KEYS
+    assert body["tier"] == "mars"
+    assert body["has_runtime_at"] is False
+
+
+def test_endpoint_has_runtime_at_unknown_runtime_never_4xx(client):
+    body = _get_json(
+        client, "/api/entitlement/has-runtime-at?tier=pro&runtime=bogus_rt"
+    )
+    assert set(body.keys()) == _RUNTIME_KEYS
+    assert body["has_runtime_at"] is False
+
+
+def test_endpoint_has_runtime_at_required_tier_parity(client):
+    body = _get_json(
+        client, "/api/entitlement/has-runtime-at?tier=pro&runtime=claude_code"
+    )
+    min_body = _get_json(client, "/api/entitlement/required-tier?runtime=claude_code")
+    assert body["required_tier"] == min_body["required_tier"]
+
+
+def test_endpoint_has_runtime_at_current_tier_parity_with_live(client):
+    """The what-if endpoint shares the live resolver context slots
+    (``current_tier`` / ``current_tier_rank``) with the sibling live
+    ``/has-runtime`` endpoint. The live endpoint's 8-key body does not
+    carry ``grace`` / ``enforced``; those are what-if-only slots on
+    the ``_at`` body (so a cell can render both bits alongside the
+    perspective-shaped ``allowed``)."""
+    at_body = _get_json(
+        client, "/api/entitlement/has-runtime-at?tier=oss&runtime=openclaw"
+    )
+    live_body = _get_json(client, "/api/entitlement/has-runtime?runtime=openclaw")
+    for k in ("current_tier", "current_tier_rank"):
+        assert at_body[k] == live_body[k], k
+
+
+def test_endpoint_has_runtime_at_never_5xx_on_resolver_blowup(monkeypatch, client):
+    from clawmetry import entitlements as _ent
+
+    def _boom(*a, **kw):
+        raise RuntimeError("resolver blew up")
+
+    monkeypatch.setattr(_ent, "get_entitlement", _boom)
+    resp = client.get(
+        "/api/entitlement/has-runtime-at?tier=pro&runtime=claude_code"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert set(body.keys()) == _RUNTIME_KEYS
+    assert body["has_runtime_at"] is False
+
+
+def test_endpoint_has_runtime_at_never_5xx_on_scalar_blowup(monkeypatch, client):
+    from clawmetry import entitlements as _ent
+
+    def _boom(*a, **kw):
+        raise RuntimeError("scalar blew up")
+
+    monkeypatch.setattr(_ent, "has_runtime_at", _boom)
+    resp = client.get(
+        "/api/entitlement/has-runtime-at?tier=pro&runtime=claude_code"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert set(body.keys()) == _RUNTIME_KEYS
+    assert body["has_runtime_at"] is False
+
+
+# ── Scalar-vs-endpoint parity ─────────────────────────────────────────────
+
+
+def test_endpoint_has_feature_at_scalar_vs_endpoint_parity(client, ent):
+    for tier in ("oss", "cloud_starter", "pro", "cloud_pro", "enterprise"):
+        if tier not in ent._TIER_ORDER:
+            continue
+        for feat in ("fleet", "nemo_governance", "sso"):
+            if feat not in ent.ALL_FEATURES:
+                continue
+            body = _get_json(
+                client,
+                f"/api/entitlement/has-feature-at?tier={tier}&feature={feat}",
+            )
+            assert body["has_feature_at"] is ent.has_feature_at(tier, feat), (
+                tier,
+                feat,
+            )
+
+
+def test_endpoint_has_runtime_at_scalar_vs_endpoint_parity(client, ent):
+    """Endpoint value equals the scalar for every (tier, canonical runtime)
+    pair -- the endpoint's own upstream canonicalisation is what makes
+    the alias-input variant work, so we test against canonical ids
+    here (aliases are covered by a separate test above)."""
+    for tier in ("oss", "cloud_starter", "pro", "cloud_pro", "enterprise"):
+        if tier not in ent._TIER_ORDER:
+            continue
+        for rt in ("openclaw", "claude_code", "codex"):
+            if rt not in ent.ALL_RUNTIMES:
+                continue
+            body = _get_json(
+                client,
+                f"/api/entitlement/has-runtime-at?tier={tier}&runtime={rt}",
+            )
+            assert body["has_runtime_at"] is ent.has_runtime_at(tier, rt), (
+                tier,
+                rt,
+            )
+
+
+# ── Envelope stability across many input branches ────────────────────────
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "/api/entitlement/has-feature-at",
+        "/api/entitlement/has-feature-at?tier=",
+        "/api/entitlement/has-feature-at?feature=",
+        "/api/entitlement/has-feature-at?tier=&feature=",
+        "/api/entitlement/has-feature-at?tier=pro",
+        "/api/entitlement/has-feature-at?feature=fleet",
+        "/api/entitlement/has-feature-at?tier=pro&feature=fleet",
+        "/api/entitlement/has-feature-at?tier=oss&feature=fleet",
+        "/api/entitlement/has-feature-at?tier=pro&feature=bogus",
+        "/api/entitlement/has-feature-at?tier=mars&feature=fleet",
+        "/api/entitlement/has-feature-at?tier=%20PRO%20&feature=%20FLEET%20",
+    ],
+)
+def test_endpoint_has_feature_at_envelope_stable(client, url):
+    body = _get_json(client, url)
+    assert set(body.keys()) == _FEATURE_KEYS
+    assert isinstance(body["tier"], str)
+    assert isinstance(body["feature"], str)
+    assert isinstance(body["has_feature_at"], bool)
+    assert isinstance(body["allowed"], bool)
+    assert body["has_feature_at"] == body["allowed"]
+    assert isinstance(body["perspective_tier_rank"], int)
+    assert isinstance(body["required_tier_rank"], int)
+    assert isinstance(body["current_tier"], str)
+    assert isinstance(body["current_tier_rank"], int)
+    assert isinstance(body["grace"], bool)
+    assert isinstance(body["enforced"], bool)
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "/api/entitlement/has-runtime-at",
+        "/api/entitlement/has-runtime-at?tier=",
+        "/api/entitlement/has-runtime-at?runtime=",
+        "/api/entitlement/has-runtime-at?tier=&runtime=",
+        "/api/entitlement/has-runtime-at?tier=pro",
+        "/api/entitlement/has-runtime-at?runtime=openclaw",
+        "/api/entitlement/has-runtime-at?tier=pro&runtime=openclaw",
+        "/api/entitlement/has-runtime-at?tier=oss&runtime=claude_code",
+        "/api/entitlement/has-runtime-at?tier=pro&runtime=claude-code",
+        "/api/entitlement/has-runtime-at?tier=pro&runtime=bogus_rt",
+        "/api/entitlement/has-runtime-at?tier=mars&runtime=openclaw",
+        "/api/entitlement/has-runtime-at?tier=%20PRO%20&runtime=%20OPENCLAW%20",
+    ],
+)
+def test_endpoint_has_runtime_at_envelope_stable(client, url):
+    body = _get_json(client, url)
+    assert set(body.keys()) == _RUNTIME_KEYS
+    assert isinstance(body["tier"], str)
+    assert isinstance(body["runtime"], str)
+    assert isinstance(body["has_runtime_at"], bool)
+    assert isinstance(body["allowed"], bool)
+    assert body["has_runtime_at"] == body["allowed"]
+    assert isinstance(body["perspective_tier_rank"], int)
+
+
+# ── Enforced-mode grace-independence at endpoint level ────────────────────
+
+
+def test_endpoint_has_feature_at_grace_independence(client, enforced_client):
+    """Endpoint answers for the SAME (perspective, feature) pair are
+    identical under grace vs enforce -- perspective-shaped by design.
+    Only the ``grace`` / ``enforced`` envelope slots differ."""
+    for tier in ("oss", "cloud_starter", "pro", "cloud_pro", "enterprise"):
+        for feat in ("fleet", "sso"):
+            grace_body = _get_json(
+                client,
+                f"/api/entitlement/has-feature-at?tier={tier}&feature={feat}",
+            )
+            enf_body = _get_json(
+                enforced_client,
+                f"/api/entitlement/has-feature-at?tier={tier}&feature={feat}",
+            )
+            assert grace_body["has_feature_at"] == enf_body["has_feature_at"], (
+                tier,
+                feat,
+            )
+            # The two envelopes should diverge ONLY on the resolver-shaped
+            # slots (grace / enforced / current_tier / current_tier_rank).
+            assert grace_body["required_tier"] == enf_body["required_tier"]
+            assert grace_body["required_tier_rank"] == enf_body["required_tier_rank"]
+            assert grace_body["perspective_tier_rank"] == enf_body["perspective_tier_rank"]
+
+
+def test_endpoint_has_runtime_at_grace_independence(client, enforced_client):
+    for tier in ("oss", "cloud_starter", "pro", "cloud_pro", "enterprise"):
+        for rt in ("openclaw", "claude_code"):
+            grace_body = _get_json(
+                client,
+                f"/api/entitlement/has-runtime-at?tier={tier}&runtime={rt}",
+            )
+            enf_body = _get_json(
+                enforced_client,
+                f"/api/entitlement/has-runtime-at?tier={tier}&runtime={rt}",
+            )
+            assert grace_body["has_runtime_at"] == enf_body["has_runtime_at"], (
+                tier,
+                rt,
+            )


### PR DESCRIPTION
## Summary

- New `clawmetry.entitlements.has_feature_at(perspective_tier, feature) -> bool` and `has_runtime_at(perspective_tier, runtime) -> bool` -- **hypothetical-perspective boolean-gate scalar siblings** of the live `has_feature` / `has_runtime`. Fill the missing `_at` slot in the boolean-gate family so a pricing matrix ("does Starter grant fleet? Pro? Enterprise?") can bind ONE boolean per cell off ONE URL each instead of hydrating the full `/feature-catalog-at` payload and pulling out the `allowed` field client-side.

  Semantics diverge deliberately from the perspective-independent `min_tier_for_features_at` / `tiers_for_feature_at` convention: the boolean answer *is* perspective-shaped, so these delegate to `_hypothetical_entitlement` (grace forced off) rather than passing through to the live-perspective helper. That means, unlike `has_feature` which returns `True` in grace for every known feature, `has_feature_at("oss", "fleet")` returns `False` even in grace: exactly the "render the would-be-locked state alongside the live grant" bit a pricing matrix needs.

  The scalars are the exact bit that lives inside `feature_spec_at.allowed` / `runtime_spec_at.allowed`; a parametrised parity test pins byte-equality across every `(tier, id)` pair so the thin scalar cannot drift from the full-row helper. Grace-independence pinned across every `(tier, feature)` and `(tier, runtime)` pair -- scalar returns the same answer under grace vs enforce for the same `(perspective, id)` pair. Alias posture matches the sibling `has_runtime` scalar exactly (strict -- no `canonical_runtime` resolution at scalar level; alias tolerance belongs to the endpoint, which canonicalises upstream). Never raises.

- New `GET /api/entitlement/has-feature-at?tier=<perspective>&feature=<id>` and `GET /api/entitlement/has-runtime-at?tier=<perspective>&runtime=<id>` on `bp_entitlement`. **12-key byte-stable envelope** across every input branch: `tier` (perspective) + `feature`/`runtime` + `has_<axis>_at` + `allowed` (alias) + `required_tier` (`min_tier_for_<axis>` cheapest unlock) + `required_tier_label` + `required_tier_rank` + `perspective_tier_rank` (-1 when the perspective is unknown/blank -- lets a UI distinguish "typo perspective" from "valid perspective that doesn't grant this axis") + standard `current_tier`/`current_tier_rank`/`grace`/`enforced` live resolver envelope. Runtime alias canonicalisation (`claude-code` -> `claude_code`) applied per token upstream so the strict `has_runtime_at` scalar's `ALL_RUNTIMES` membership check never rejects it. Never 4xxs (missing / blank / unknown tier or id -> 200 with `has_<axis>_at=false`, matching the `/has-feature` posture so a paywall matrix binds `allowed` directly without a pre-validation round-trip). Never 5xxs (resolver / scalar / hypothetical-build blowup -> fail-closed fallback envelope, matching sibling `_has_axis_fallback`).

- **69 hermetic unit tests** covering: scalar semantics across every `(tier, feature)` and `(tier, runtime)` pair (empty / `None` / non-string / unknown perspective / unknown axis-id / case-insensitive normalisation / alias posture divergence between scalar and endpoint); free axis-id granted on every real tier; paid axis-id granted only on statically-granting tiers; OSS never grants a paid axis-id; grace-independence invariant across `_TIER_ORDER x ALL_FEATURES` and `_TIER_ORDER x ALL_RUNTIMES`; `has_feature_at` byte-parity with `feature_spec_at.allowed` and `has_runtime_at` byte-parity with `runtime_spec_at.allowed` across the full matrix; endpoint envelope shape stability across 11 degenerate URL branches per axis; `required_tier` byte-parity with sibling `/api/entitlement/required-tier`; live-resolver-context slot parity with sibling `/has-feature` / `/has-runtime`; never-4xx / never-5xx guarantees via monkeypatched `_hypothetical_entitlement`, `get_entitlement`, and `has_*_at` blowups; alias-canonicalises-at-endpoint but strict-at-scalar posture pinned per axis; scalar-vs-endpoint parity across probe combinations.

Behaviour is additive; nothing existing changes. Grace-mode posture is preserved (no gate enforcement is added; the perspective-shaped answer only reflects the static per-tier grant in `_TIER_FEATURES` / `_TIER_PAID_RUNTIMES`). Uses only the already-permitted `flask` + stdlib import set.

Does **not** overlap with the currently-open drafts #4410 (`missing_features` / `missing_runtimes` -- live row-detail complement) or #4420 (`has_all` -- aggregate mixed-axis fold): both of those stay on the **LIVE-perspective** surface. `has_feature_at` / `has_runtime_at` are orthogonal -- the singular boolean at a **HYPOTHETICAL** perspective. No merge conflict with either open branch.

## Test plan

- [x] `python3 -m py_compile clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_has_feature_at_has_runtime_at.py` -- passes
- [x] `ruff check clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_has_feature_at_has_runtime_at.py` -- All checks passed
- [x] `python3 -m pytest tests/test_entitlement_has_feature_at_has_runtime_at.py` -- **69 passed** in 6.41s
- [x] `python3 -m pytest tests/test_entitlement_has_feature_has_runtime.py tests/test_entitlement_has_features_has_runtimes.py tests/test_entitlement_has_channel_count.py tests/test_entitlement_has_node_count.py tests/test_entitlement_has_retention_window.py tests/test_entitlement_has_batch.py` -- **365 passed** in 38.37s (sibling regressions clean)

## Local operator verification checklist

The web agent cannot touch the live daemon, `~/.openclaw`, the cloud snapshot, a browser, or the private `clawmetry-cloud` repo. Please verify on-host before flipping this out of draft:

- [ ] Copy the changed source files into the installed package:
  - `cp clawmetry/entitlements.py ~/.clawmetry/lib/python*/site-packages/clawmetry/entitlements.py`
  - `cp routes/entitlement.py ~/.clawmetry/lib/python*/site-packages/routes/entitlement.py`
  - `find ~/.clawmetry/lib/python*/site-packages/{clawmetry,routes} -name __pycache__ -exec rm -rf {} +`
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` (or the equivalent supervisor kick on non-macOS hosts)
- [ ] Happy-path envelope shape (grace mode, paid feature on granting perspective -- `has_feature_at` should be `true` even though the LIVE tier is `oss`):
  - `curl -s "http://localhost:8900/api/entitlement/has-feature-at?tier=pro&feature=fleet" | jq` -- 12 top-level keys (`tier`, `feature`, `has_feature_at`, `allowed`, `required_tier`, `required_tier_label`, `required_tier_rank`, `perspective_tier_rank`, `current_tier`, `current_tier_rank`, `grace`, `enforced`), `has_feature_at=true`, `allowed=true`, `tier="pro"`, `current_tier="oss"`, `grace=true`.
- [ ] Perspective-shaped grace divergence (the whole point of the `_at` slot -- OSS reports `allowed=false` for a paid feature EVEN IN GRACE):
  - `curl -s "http://localhost:8900/api/entitlement/has-feature-at?tier=oss&feature=fleet" | jq '{has_feature_at, grace}'` -- `has_feature_at=false`, `grace=true`.
  - `curl -s "http://localhost:8900/api/entitlement/has-feature?feature=fleet" | jq '{has_feature, grace: null}'` -- `has_feature=true` (live grace pass-through). The divergence between the two answers on the same feature is the "would-be-locked alongside live-grant" render.
- [ ] Runtime alias canonicalisation upstream (endpoint layer collapses `claude-code` -> `claude_code`):
  - `curl -s "http://localhost:8900/api/entitlement/has-runtime-at?tier=pro&runtime=claude-code" | jq '.runtime, .has_runtime_at'` -- `"claude_code"`, `true`.
- [ ] Perspective-tier-rank -1 sentinel on unknown perspective (lets a UI distinguish "typo" from "valid perspective doesn't grant"):
  - `curl -s "http://localhost:8900/api/entitlement/has-feature-at?tier=mars&feature=fleet" | jq '{perspective_tier_rank, has_feature_at}'` -- `perspective_tier_rank=-1`, `has_feature_at=false`.
- [ ] Never-4xx sanity for missing tier arg (matches `/has-feature` posture):
  - `curl -s -o /dev/null -w '%{http_code}\n' "http://localhost:8900/api/entitlement/has-feature-at"` -- `200`.
  - `curl -s -o /dev/null -w '%{http_code}\n' "http://localhost:8900/api/entitlement/has-runtime-at"` -- `200`.
- [ ] Cross-consistency with `/api/entitlement/feature-spec-at.allowed`:
  - `diff <(curl -s "http://localhost:8900/api/entitlement/has-feature-at?tier=pro&feature=fleet" | jq '.has_feature_at') <(curl -s "http://localhost:8900/api/entitlement/feature-spec-at?tier=pro&feature=fleet" | jq '.spec.allowed')` -- empty diff.
- [ ] Cross-consistency with `/api/entitlement/required-tier`:
  - `diff <(curl -s "http://localhost:8900/api/entitlement/has-feature-at?tier=pro&feature=fleet" | jq '.required_tier') <(curl -s "http://localhost:8900/api/entitlement/required-tier?feature=fleet" | jq '.required_tier')` -- empty diff.
- [ ] Grace-safe sanity: the LIVE resolver's `grace=true` bit still shows through in the envelope; wiring this into a pricing matrix today changes NO current behavior on the live axes -- it only enables what-if rendering on non-live perspectives.
- [ ] Browser check: open the entitlement diagnostics / paywall matrix (if wired) and confirm the pricing rows can now bind `allowed` off `/has-feature-at?tier=<row>&feature=<col>` and `/has-runtime-at?tier=<row>&runtime=<col>` per cell without changing behavior in grace on the LIVE `current_tier` row.
- [ ] Decrypt the live cloud snapshot and confirm the two new endpoints are reachable through the relay (should require no relay changes -- read-only handlers on `bp_entitlement`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01JuhptVMmLjPzxCMCrBAm4u)_