### PR TITLE
feat(entitlement): has_all + /api/entitlement/has-all (aggregate mixed-axis boolean fold)

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -5828,6 +5828,110 @@ def missing_runtimes(runtimes) -> list:
         return []
 
 
+def has_all(
+    *,
+    features=None,
+    runtimes=None,
+    channels: int | None = None,
+    retention_days: int | None = None,
+    nodes: int | None = None,
+) -> bool:
+    """Boolean-gate scalar: does the CURRENT install grant **every** supplied
+    axis in ONE mixed-bundle fold?
+
+    Aggregate boolean sibling of :func:`min_tier_for_all` (which folds the
+    same five kwargs to ONE tier id). A paywall diagnostics tile that gates
+    on the full subscription state ("fleet + claude_code + 5 channels +
+    30-day retention + 2 nodes -- does the resolved entitlement grant all
+    of this right now?") gets ONE boolean back off ONE call instead of
+    five singular ``has_*`` round-trips + a client-side AND-chain, and
+    reads symmetric to :func:`min_tier_for_all`: min-tier picks the most-
+    constraining axis, this one picks the most-restrictive per-axis grant.
+
+    Fold rule: returns ``True`` iff every SUPPLIED axis' per-item
+    ``has_*`` gate returns ``True``. Delegates per axis to the singular
+    scalars (:func:`has_features` / :func:`has_runtimes` /
+    :func:`has_channel_count` / :func:`has_retention_window` /
+    :func:`has_node_count`) so each axis inherits that scalar's typo /
+    empty / non-int posture without a divergent code path here. Grace
+    pass-through: while ``ent.grace`` is ``True`` every delegate returns
+    ``True`` for its fully-known input, so this scalar reports ``True``
+    for every fully-known mixed bundle -- wiring this into a gate today
+    changes NO current behavior.
+
+    Kwarg semantics (mirror :func:`min_tier_for_all` exactly so a caller
+    can pass the same kwargs to both helpers without a re-normalise):
+
+    * ``features=None`` / ``runtimes=None`` -- axis unsupplied, skipped
+      entirely (contributes ``True`` to the fold).
+    * ``features=[]`` / ``runtimes=[]`` -- axis supplied but empty. This
+      COLLAPSES the fold to ``False`` for the same callsite-typo posture
+      :func:`has_features` / :func:`has_runtimes` carry on their empty
+      inputs (a caller who passed an empty iterable was asking about
+      something and the answer to "does the install grant this empty
+      bundle?" is deliberately ``False``, not vacuous-``True``).
+    * ``channels=None`` / ``retention_days=None`` / ``nodes=None`` --
+      axis unsupplied, skipped. Critically, ``retention_days=None`` here
+      means *unset*, NOT *unlimited* -- asking about the unlimited-
+      retention grant is the singular :func:`has_retention_window`
+      (``days=None``) call's job and would mis-route the aggregate to
+      Enterprise-only through a wrong delegate.
+    * Non-int capacity value (str, list, ...) on ``channels`` / ``nodes``
+      / ``retention_days`` -- collapses the fold to ``False`` (mirrors
+      the singular capacity scalars' strict-``False`` typo posture).
+    * No axes supplied at all -- returns ``False``. Matches
+      :func:`has_features` / :func:`has_runtimes` empty-``False`` posture
+      so a caller who forgot to pass any of the five kwargs sees the
+      typo at the callsite instead of a silent grant. Distinct from
+      :func:`min_tier_for_all` which returns ``None`` on the same input
+      (nothing-to-compute); here the boolean seat collapses to strict
+      ``False``.
+    * Unknown / typo'd feature or runtime id in an otherwise-known
+      bundle -- collapses the whole fold to ``False`` via the singular
+      :func:`has_features` / :func:`has_runtimes` typo posture. A UI
+      wanting to distinguish "denied by tier" from "typo" should call
+      the per-axis scalars (or :func:`min_tier_for_all_breakdown`) for
+      the per-axis story.
+
+    Post-enforcement: returns ``True`` iff every supplied axis' delegate
+    would return ``True`` under the resolved entitlement's live grant --
+    an expired paid tier that collapses the fleet cap to 1 (per
+    :func:`has_node_count`'s free-floor fallback) will flip this scalar
+    to ``False`` the moment the license lapses if the caller supplied
+    ``nodes >= 2``.
+
+    Never raises: any delegate failure logs a warning and returns
+    ``False`` so a caller can bind this into a boolean AND-chain without
+    a try/except.
+    """
+    try:
+        supplied_any = False
+        if features is not None:
+            supplied_any = True
+            if not has_features(features):
+                return False
+        if runtimes is not None:
+            supplied_any = True
+            if not has_runtimes(runtimes):
+                return False
+        if channels is not None:
+            supplied_any = True
+            if not has_channel_count(channels):
+                return False
+        if retention_days is not None:
+            supplied_any = True
+            if not has_retention_window(retention_days):
+                return False
+        if nodes is not None:
+            supplied_any = True
+            if not has_node_count(nodes):
+                return False
+        return supplied_any
+    except Exception as exc:
+        logger.warning("entitlements: has_all failed: %s", exc)
+        return False
+
+
 def _tier_row(tier: str) -> dict:
     return {
         "id": tier,

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -4289,6 +4289,267 @@ def api_entitlement_missing_runtimes():
         return jsonify(_missing_bundle_fallback("runtimes", _parse_csv_arg("runtimes")))
 
 
+def _has_all_fallback() -> dict:
+    """Never-5xx envelope for ``/api/entitlement/has-all``.
+
+    Mirrors the fail-closed posture the sibling ``_has_bundle_fallback``
+    carries: on a resolver blowup the endpoint still returns 200 with the
+    same envelope shape as the happy path, but ``has_all`` / ``allowed``
+    ``False`` and every axis marked ``supplied=False`` so a paywall tile
+    that lost the resolver doesn't silently grant a mixed bundle it can
+    no longer evaluate.
+    """
+    return {
+        "features": [],
+        "runtimes": [],
+        "channels": None,
+        "retention_days": None,
+        "nodes": None,
+        "unknown_features": [],
+        "unknown_runtimes": [],
+        "supplied_axes": [],
+        "supplied_count": 0,
+        "has_all": False,
+        "allowed": False,
+        "required_tier": None,
+        "required_tier_label": None,
+        "required_tier_rank": -1,
+        "current_tier": "oss",
+        "current_tier_rank": 0,
+        "grace": True,
+        "enforced": False,
+        "upgrade_required": False,
+    }
+
+
+def _has_all_body() -> dict:
+    """Happy-path body builder for ``/api/entitlement/has-all``.
+
+    Aggregate mixed-axis fold sibling of ``_has_bundle_body`` (which folds
+    ONE single-axis CSV). Applies the same per-axis normalisation each
+    single-axis endpoint already does -- CSV known/unknown split for
+    features and runtimes (runtime-alias canonicalisation upstream so
+    ``claude-code`` -> ``claude_code``); capacity axes parsed via
+    :func:`_parse_capacity_arg` so a blank / non-int value collapses the
+    axis to ``False`` in the fold rather than short-circuiting through
+    the underlying scalar's ``retention_days=None`` "unlimited" branch
+    (which would mis-route the aggregate to Enterprise-only).
+
+    Every axis is OPTIONAL -- a caller can supply any non-empty subset
+    of the five kwargs and the fold answers off just those axes. The
+    envelope always carries every axis' slot for byte-stable shape
+    across every URL branch (``None`` / ``[]`` for unsupplied axes).
+
+    The scalar boolean ``has_all`` is delegated to
+    :func:`clawmetry.entitlements.has_all` against the SUPPLIED axis
+    values (unsupplied axes pass ``None`` verbatim), so this endpoint
+    stays byte-parity with the module scalar. Unknown feature / runtime
+    tokens collapse ``has_all`` to ``False`` (matches
+    :func:`has_features` / :func:`has_runtimes` typo posture); a caller
+    can still surface the offending tokens via ``unknown_features`` /
+    ``unknown_runtimes``. Missing / blank / non-int capacity value on a
+    SUPPLIED axis collapses ``has_all`` to ``False`` (matches the
+    singular capacity scalars' strict-``False`` typo posture); a UI can
+    distinguish "supplied but blank" from "unsupplied" via the
+    ``supplied_axes`` list.
+
+    ``required_tier`` folds through
+    :func:`clawmetry.entitlements.min_tier_for_all` against the same
+    supplied axes (known ids only on the grant axes) for parity with
+    the singular ``/api/entitlement/required-tier`` envelope.
+    """
+    from clawmetry import entitlements as _ent
+
+    features_raw = request.args.get("features")
+    runtimes_raw = request.args.get("runtimes")
+
+    known_features: list[str] = []
+    unknown_features: list[str] = []
+    features_supplied = features_raw is not None
+    if features_supplied:
+        for fid in _parse_csv_arg("features"):
+            if fid in _ent.ALL_FEATURES:
+                if fid not in known_features:
+                    known_features.append(fid)
+            elif fid not in unknown_features:
+                unknown_features.append(fid)
+
+    known_runtimes: list[str] = []
+    unknown_runtimes: list[str] = []
+    runtimes_supplied = runtimes_raw is not None
+    if runtimes_supplied:
+        for rid_raw in _parse_csv_arg("runtimes"):
+            rid = _ent.canonical_runtime(rid_raw) or rid_raw
+            if rid in _ent.ALL_RUNTIMES:
+                if rid not in known_runtimes:
+                    known_runtimes.append(rid)
+            elif rid_raw not in unknown_runtimes:
+                unknown_runtimes.append(rid_raw)
+
+    (
+        channels_present,
+        channels_ok,
+        channels_n,
+        _channels_raw,
+    ) = _parse_capacity_arg("channels")
+    (
+        retention_present,
+        retention_ok,
+        retention_n,
+        _retention_raw,
+    ) = _parse_capacity_arg("retention_days")
+    (
+        nodes_present,
+        nodes_ok,
+        nodes_n,
+        _nodes_raw,
+    ) = _parse_capacity_arg("nodes")
+
+    supplied_axes: list[str] = []
+    if features_supplied:
+        supplied_axes.append("features")
+    if runtimes_supplied:
+        supplied_axes.append("runtimes")
+    if channels_present:
+        supplied_axes.append("channels")
+    if retention_present:
+        supplied_axes.append("retention_days")
+    if nodes_present:
+        supplied_axes.append("nodes")
+
+    # Endpoint-layer short-circuits to ``False`` (matches the singular
+    # scalars' strict-``False`` typo posture without handing the module
+    # scalar a sentinel):
+    #   * a supplied-but-unparseable capacity axis
+    #   * unknown feature / runtime tokens on a supplied grant axis
+    #   * a supplied grant axis whose CSV was empty / all-unknown
+    # Otherwise delegate to the module scalar off the CANONICALISED
+    # known-only lists so envelope-vs-scalar parity holds byte-exact
+    # (runtime-alias canonicalisation is an endpoint-layer concern; the
+    # singular :func:`has_runtime` scalar strict-checks against
+    # :data:`ALL_RUNTIMES` and would otherwise reject ``claude-code``).
+    if (
+        (channels_present and not channels_ok)
+        or (retention_present and not retention_ok)
+        or (nodes_present and not nodes_ok)
+        or (features_supplied and (unknown_features or not known_features))
+        or (runtimes_supplied and (unknown_runtimes or not known_runtimes))
+    ):
+        has_flag = False
+    else:
+        has_flag = _ent.has_all(
+            features=known_features if features_supplied else None,
+            runtimes=known_runtimes if runtimes_supplied else None,
+            channels=channels_n if channels_present else None,
+            retention_days=retention_n if retention_present else None,
+            nodes=nodes_n if nodes_present else None,
+        )
+
+    # ``required_tier`` folds through ``min_tier_for_all`` against the
+    # KNOWN-only subsets for parity with ``/api/entitlement/required-tier``
+    # (which resolves off the known/unknown split, not raw input).
+    required = _ent.min_tier_for_all(
+        features=known_features or None,
+        runtimes=known_runtimes or None,
+        channels=channels_n if channels_present and channels_ok else None,
+        retention_days=(
+            retention_n if retention_present and retention_ok else None
+        ),
+        nodes=nodes_n if nodes_present and nodes_ok else None,
+    )
+
+    env = _resolver_envelope(_ent)
+    cur_rank = env["current_tier_rank"]
+    req_rank = _ent.tier_rank(required) if required else -1
+    required_label = _ent.tier_label(required) if required else None
+
+    return {
+        "features": known_features,
+        "runtimes": known_runtimes,
+        "channels": channels_n if channels_present and channels_ok else None,
+        "retention_days": (
+            retention_n if retention_present and retention_ok else None
+        ),
+        "nodes": nodes_n if nodes_present and nodes_ok else None,
+        "unknown_features": unknown_features,
+        "unknown_runtimes": unknown_runtimes,
+        "supplied_axes": supplied_axes,
+        "supplied_count": len(supplied_axes),
+        "has_all": bool(has_flag),
+        "allowed": bool(has_flag),
+        "required_tier": required,
+        "required_tier_label": required_label,
+        "required_tier_rank": req_rank,
+        "current_tier": env["current_tier"],
+        "current_tier_rank": cur_rank,
+        "grace": env["grace"],
+        "enforced": env["enforced"],
+        "upgrade_required": bool(required) and req_rank > cur_rank,
+    }
+
+
+@bp_entitlement.route("/api/entitlement/has-all")
+def api_entitlement_has_all():
+    """``GET /api/entitlement/has-all?features=a,b&runtimes=x,y&channels=5&retention_days=30&nodes=2``
+    -- aggregate mixed-axis boolean-gate scalar.
+
+    Aggregate boolean sibling of ``/api/entitlement/required-tier`` (which
+    resolves the cheapest tier that covers a mixed bundle across all five
+    axes) and ``/api/entitlement/has-features`` / ``/has-runtimes`` (which
+    fold ONE single-axis CSV to ONE boolean). A paywall diagnostics tile
+    that gates on the full subscription state ("fleet + claude_code + 5
+    channels + 30-day retention + 2 nodes -- does the resolved
+    entitlement grant everything?") binds ``allowed`` directly off this
+    URL without five singular ``/has-*`` round-trips + a client-side
+    AND-chain.
+
+    Every axis is OPTIONAL. Supply any non-empty subset; the fold
+    answers off just those axes and every unsupplied axis is skipped
+    (contributes ``True`` to the fold). Runtime-alias canonicalisation
+    (``claude-code`` -> ``claude_code``) is applied per token before the
+    known/unknown split. Capacity axes accept a single int (``5``);
+    blank / non-int values collapse ``has_all`` to ``False`` (matches
+    the singular capacity scalars' strict-``False`` typo posture).
+
+    Grace-safe: while :attr:`Entitlement.grace` is ``True`` (the current
+    rollout state) ``has_all`` reports ``True`` for every fully-known
+    bundle, so wiring this into a gate today changes NO current
+    behavior. Never 4xxs (no axes supplied -> 200 with ``has_all=False``,
+    matching the singular ``/has-features`` empty-``False`` posture).
+    Never 5xxs (resolver blowup -> fallback envelope with
+    ``has_all=False``).
+
+    Envelope shape (19 keys, byte-stable across every input branch)::
+
+        {
+          "features":            ["fleet"],           # known ids only
+          "runtimes":            ["claude_code"],     # canonicalised, known only
+          "channels":            5 | null,            # parsed int or null
+          "retention_days":      30 | null,
+          "nodes":               2 | null,
+          "unknown_features":    ["bogus"],           # tokens not in ALL_FEATURES
+          "unknown_runtimes":    [],                  # tokens not in ALL_RUNTIMES
+          "supplied_axes":       ["features", "channels"],
+          "supplied_count":      2,
+          "has_all":             true,                # aggregate boolean
+          "allowed":             true,                # alias of has_all
+          "required_tier":       "cloud_pro" | null,
+          "required_tier_label": "Pro" | null,
+          "required_tier_rank":  <int>,               # -1 when null
+          "current_tier":        "oss",
+          "current_tier_rank":   0,
+          "grace":               true,
+          "enforced":            false,
+          "upgrade_required":    <bool>
+        }
+    """
+    try:
+        return jsonify(_has_all_body())
+    except Exception as exc:
+        logger.warning("api_entitlement_has_all: error: %s", exc)
+        return jsonify(_has_all_fallback())
+
+
 @bp_entitlement.route("/api/entitlement/lock-reason")
 def api_entitlement_lock_reason():
     try:

--- a/tests/test_entitlement_has_all.py
+++ b/tests/test_entitlement_has_all.py
@@ -1,0 +1,712 @@
+"""Tests for the aggregate mixed-axis ``has_all(...)`` boolean-gate scalar and
+its paired ``/api/entitlement/has-all`` endpoint.
+
+Aggregate boolean sibling of :func:`clawmetry.entitlements.min_tier_for_all`
+(which folds the same five kwargs to ONE tier id): a paywall diagnostics tile
+that gates on the FULL subscription state ("fleet + claude_code + 5 channels
++ 30-day retention + 2 nodes -- does the resolved entitlement grant
+everything?") binds ONE boolean off ONE call instead of five singular
+``has_*`` round-trips + a client-side AND-chain.
+
+This file pins:
+
+1. Scalar fold under grace vs enforce for every combination of the five
+   axes (features / runtimes / channels / retention_days / nodes),
+   including per-axis empty / None / unknown / non-int inputs.
+2. The "no axes supplied" strict-``False`` posture (matches the singular
+   ``has_features([])`` empty-``False`` scalar; distinct from
+   :func:`min_tier_for_all` which returns ``None`` on the same input).
+3. Endpoint envelope shape parity (fixed 19-key set) across every input
+   branch so a frontend can bind fields off the URL without a branch on
+   the underlying resolver state.
+4. Never-4xx / never-5xx guarantees on the endpoint.
+5. Cross-consistency with ``/api/entitlement/required-tier-batch``: same
+   ``required_tier`` for the same fully-parseable bundle, so a UI wiring
+   both URLs into the same paywall tile can't see inconsistent tier
+   state (documented posture divergence on unparseable-capacity is a
+   separate assertion).
+6. Scalar-vs-endpoint parity: the URL ``has_all`` value equals the
+   module-level scalar byte-for-byte on the same (parseable) input.
+7. Grace invariant: fully-known mixed bundles report ``True`` while
+   ``ent.grace`` is on -- wiring this into a gate today changes NO
+   current behavior.
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+# -- Fixtures ------------------------------------------------------------------
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    """Fresh entitlements module in OSS-free-grace mode -- the same fixture
+    the sibling ``test_entitlement_has_features_has_runtimes.py`` uses so the
+    aggregate-fold assertions here reproduce the same install state the
+    per-axis ones are pinned against."""
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def enforced(monkeypatch, tmp_path):
+    """Enforcement-on fixture: ``CLAWMETRY_ENFORCE=1`` flips ``ent.grace``
+    off so the grace pass-through collapses and paid axes report their
+    post-enforce answers."""
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    importlib.reload(e)
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# -- Envelope shape ------------------------------------------------------------
+
+_HAS_ALL_KEYS = {
+    "features",
+    "runtimes",
+    "channels",
+    "retention_days",
+    "nodes",
+    "unknown_features",
+    "unknown_runtimes",
+    "supplied_axes",
+    "supplied_count",
+    "has_all",
+    "allowed",
+    "required_tier",
+    "required_tier_label",
+    "required_tier_rank",
+    "current_tier",
+    "current_tier_rank",
+    "grace",
+    "enforced",
+    "upgrade_required",
+}
+
+
+def _get_json(client, url: str) -> dict:
+    resp = client.get(url)
+    assert resp.status_code == 200, url
+    return resp.get_json()
+
+
+# -- Scalar: no axes supplied --------------------------------------------------
+
+
+def test_has_all_no_axes_supplied_is_false(ent):
+    """Nothing supplied collapses to False."""
+    assert ent.has_all() is False
+
+
+def test_has_all_no_axes_supplied_is_false_after_enforcement(enforced):
+    assert enforced.has_all() is False
+
+
+# -- Scalar: single axis -------------------------------------------------------
+
+
+def test_has_all_features_only_free_is_true(ent):
+    free = sorted(ent.FREE_FEATURES)
+    assert ent.has_all(features=free) is True
+
+
+def test_has_all_features_only_paid_true_in_grace(ent):
+    paid = sorted(ent.PAID_FEATURES)
+    assert ent.has_all(features=paid) is True
+
+
+def test_has_all_features_only_paid_false_after_enforcement(enforced):
+    paid = sorted(enforced.PAID_FEATURES)
+    assert enforced.has_all(features=paid) is False
+
+
+def test_has_all_runtimes_only_free_is_true(ent):
+    free = sorted(ent.FREE_RUNTIMES)
+    assert ent.has_all(runtimes=free) is True
+
+
+def test_has_all_runtimes_only_paid_true_in_grace(ent):
+    paid = sorted(ent.PAID_RUNTIMES)
+    assert ent.has_all(runtimes=paid) is True
+
+
+def test_has_all_runtimes_only_paid_false_after_enforcement(enforced):
+    paid = sorted(enforced.PAID_RUNTIMES)
+    assert enforced.has_all(runtimes=paid) is False
+
+
+def test_has_all_channels_only_one_is_true(ent):
+    assert ent.has_all(channels=1) is True
+
+
+def test_has_all_channels_only_big_true_in_grace(ent):
+    assert ent.has_all(channels=999) is True
+
+
+def test_has_all_channels_only_big_false_after_enforcement(enforced):
+    assert enforced.has_all(channels=999) is False
+
+
+def test_has_all_nodes_only_one_is_true(ent):
+    assert ent.has_all(nodes=1) is True
+
+
+def test_has_all_nodes_only_big_true_in_grace(ent):
+    assert ent.has_all(nodes=42) is True
+
+
+def test_has_all_nodes_only_big_false_after_enforcement(enforced):
+    assert enforced.has_all(nodes=42) is False
+
+
+def test_has_all_retention_days_only_short_is_true(ent):
+    assert ent.has_all(retention_days=1) is True
+
+
+def test_has_all_retention_days_only_long_true_in_grace(ent):
+    assert ent.has_all(retention_days=999) is True
+
+
+def test_has_all_retention_days_only_long_false_after_enforcement(enforced):
+    assert enforced.has_all(retention_days=999) is False
+
+
+# -- Scalar: mixed axes --------------------------------------------------------
+
+
+def test_has_all_mixed_free_bundle_is_true(ent):
+    free_f = next(iter(ent.FREE_FEATURES))
+    free_r = next(iter(ent.FREE_RUNTIMES))
+    assert (
+        ent.has_all(
+            features=[free_f],
+            runtimes=[free_r],
+            channels=1,
+            retention_days=1,
+            nodes=1,
+        )
+        is True
+    )
+
+
+def test_has_all_mixed_free_bundle_still_true_after_enforcement(enforced):
+    free_f = next(iter(enforced.FREE_FEATURES))
+    free_r = next(iter(enforced.FREE_RUNTIMES))
+    assert (
+        enforced.has_all(
+            features=[free_f],
+            runtimes=[free_r],
+            channels=1,
+            retention_days=1,
+            nodes=1,
+        )
+        is True
+    )
+
+
+def test_has_all_mixed_paid_bundle_true_in_grace(ent):
+    paid_f = next(iter(ent.PAID_FEATURES))
+    paid_r = next(iter(ent.PAID_RUNTIMES))
+    assert (
+        ent.has_all(
+            features=[paid_f],
+            runtimes=[paid_r],
+            channels=5,
+            retention_days=30,
+            nodes=2,
+        )
+        is True
+    )
+
+
+def test_has_all_mixed_paid_bundle_false_after_enforcement(enforced):
+    paid_f = next(iter(enforced.PAID_FEATURES))
+    paid_r = next(iter(enforced.PAID_RUNTIMES))
+    assert (
+        enforced.has_all(
+            features=[paid_f],
+            runtimes=[paid_r],
+            channels=5,
+            retention_days=30,
+            nodes=2,
+        )
+        is False
+    )
+
+
+def test_has_all_mixed_free_features_but_paid_runtime_false_after_enforcement(
+    enforced,
+):
+    free_f = next(iter(enforced.FREE_FEATURES))
+    paid_r = next(iter(enforced.PAID_RUNTIMES))
+    assert (
+        enforced.has_all(features=[free_f], runtimes=[paid_r], channels=1)
+        is False
+    )
+
+
+# -- Scalar: empty inputs on supplied axes -------------------------------------
+
+
+def test_has_all_features_empty_iterable_is_false(ent):
+    assert ent.has_all(features=[]) is False
+    assert ent.has_all(features=()) is False
+
+
+def test_has_all_runtimes_empty_iterable_is_false(ent):
+    assert ent.has_all(runtimes=[]) is False
+
+
+def test_has_all_empty_features_supplied_denies_even_with_other_axes(ent):
+    assert ent.has_all(features=[], channels=1) is False
+
+
+# -- Scalar: unknown / typo'd inputs -------------------------------------------
+
+
+def test_has_all_unknown_feature_collapses_fold(ent):
+    assert ent.has_all(features=["fleet", "totally_fake_xyz"]) is False
+
+
+def test_has_all_unknown_runtime_collapses_fold(ent):
+    assert ent.has_all(runtimes=["openclaw", "totally_fake_rt"]) is False
+
+
+def test_has_all_unknown_feature_wins_over_other_axes(ent):
+    assert (
+        ent.has_all(features=["bogus_xyz"], runtimes=["openclaw"], channels=1)
+        is False
+    )
+
+
+# -- Scalar: non-int capacity --------------------------------------------------
+
+
+def test_has_all_non_int_channels_is_false(ent):
+    assert ent.has_all(channels="five") is False  # type: ignore[arg-type]
+
+
+def test_has_all_non_int_nodes_is_false(ent):
+    assert ent.has_all(nodes="two") is False  # type: ignore[arg-type]
+
+
+def test_has_all_non_int_retention_is_false(ent):
+    assert ent.has_all(retention_days="seven") is False  # type: ignore[arg-type]
+
+
+# -- Scalar: retention_days=None means unsupplied ------------------------------
+
+
+def test_has_all_retention_none_is_unsupplied_not_unlimited(ent):
+    assert ent.has_all(channels=1, retention_days=None) is True
+    assert ent.has_all(channels=1) is True
+
+
+# -- Scalar: never raises ------------------------------------------------------
+
+
+def test_has_all_never_raises_on_resolver_blowup(monkeypatch, ent):
+    def _boom(*a, **kw):
+        raise RuntimeError("resolver blowup")
+
+    monkeypatch.setattr(ent, "has_features", _boom)
+    assert ent.has_all(features=["fleet"]) is False
+
+
+def test_has_all_never_raises_on_capacity_delegate_blowup(monkeypatch, ent):
+    def _boom(*a, **kw):
+        raise RuntimeError("blowup")
+
+    monkeypatch.setattr(ent, "has_channel_count", _boom)
+    assert ent.has_all(channels=1) is False
+
+
+# -- Endpoint: envelope shape --------------------------------------------------
+
+
+def test_endpoint_no_params_shape(client):
+    body = _get_json(client, "/api/entitlement/has-all")
+    assert set(body.keys()) == _HAS_ALL_KEYS
+    assert body["features"] == []
+    assert body["runtimes"] == []
+    assert body["channels"] is None
+    assert body["retention_days"] is None
+    assert body["nodes"] is None
+    assert body["unknown_features"] == []
+    assert body["unknown_runtimes"] == []
+    assert body["supplied_axes"] == []
+    assert body["supplied_count"] == 0
+    assert body["has_all"] is False
+    assert body["allowed"] is False
+
+
+def test_endpoint_all_free_axes_shape(client):
+    body = _get_json(
+        client,
+        "/api/entitlement/has-all?"
+        "features=nemo_governance&runtimes=openclaw"
+        "&channels=1&retention_days=1&nodes=1",
+    )
+    assert set(body.keys()) == _HAS_ALL_KEYS
+    assert body["features"] == ["nemo_governance"]
+    assert body["runtimes"] == ["openclaw"]
+    assert body["channels"] == 1
+    assert body["retention_days"] == 1
+    assert body["nodes"] == 1
+    assert body["supplied_axes"] == [
+        "features",
+        "runtimes",
+        "channels",
+        "retention_days",
+        "nodes",
+    ]
+    assert body["supplied_count"] == 5
+    assert body["has_all"] is True
+    assert body["allowed"] is True
+    assert body["required_tier"] == "oss"
+    assert body["required_tier_rank"] == 0
+    assert body["upgrade_required"] is False
+
+
+def test_endpoint_paid_bundle_grace_shape(client):
+    body = _get_json(
+        client,
+        "/api/entitlement/has-all?features=fleet&runtimes=claude_code"
+        "&channels=5&retention_days=30&nodes=2",
+    )
+    assert set(body.keys()) == _HAS_ALL_KEYS
+    assert body["has_all"] is True
+    assert body["allowed"] is True
+    assert body["required_tier"] is not None
+    assert body["required_tier"] != "oss"
+    assert body["required_tier_rank"] > 0
+    assert body["upgrade_required"] is True
+
+
+def test_endpoint_features_only_shape(client):
+    body = _get_json(client, "/api/entitlement/has-all?features=fleet")
+    assert body["supplied_axes"] == ["features"]
+    assert body["supplied_count"] == 1
+    assert body["features"] == ["fleet"]
+    assert body["runtimes"] == []
+    assert body["channels"] is None
+    assert body["has_all"] is True  # grace
+
+
+def test_endpoint_runtimes_only_shape(client):
+    body = _get_json(client, "/api/entitlement/has-all?runtimes=claude_code")
+    assert body["supplied_axes"] == ["runtimes"]
+    assert body["runtimes"] == ["claude_code"]
+    assert body["has_all"] is True  # grace
+
+
+def test_endpoint_channels_only_shape(client):
+    body = _get_json(client, "/api/entitlement/has-all?channels=5")
+    assert body["supplied_axes"] == ["channels"]
+    assert body["channels"] == 5
+    assert body["has_all"] is True  # grace
+
+
+# -- Endpoint: unknown tokens --------------------------------------------------
+
+
+def test_endpoint_unknown_feature_collapses_bundle(client):
+    body = _get_json(
+        client, "/api/entitlement/has-all?features=fleet,totally_fake_xyz"
+    )
+    assert body["features"] == ["fleet"]
+    assert body["unknown_features"] == ["totally_fake_xyz"]
+    assert body["has_all"] is False
+    assert body["allowed"] is False
+
+
+def test_endpoint_unknown_runtime_collapses_bundle(client):
+    body = _get_json(
+        client, "/api/entitlement/has-all?runtimes=openclaw,totally_fake_rt"
+    )
+    assert body["runtimes"] == ["openclaw"]
+    assert body["unknown_runtimes"] == ["totally_fake_rt"]
+    assert body["has_all"] is False
+
+
+def test_endpoint_runtime_alias_canonicalises(client):
+    body = _get_json(
+        client, "/api/entitlement/has-all?runtimes=claude-code,claude_code"
+    )
+    assert body["runtimes"] == ["claude_code"]
+    assert body["unknown_runtimes"] == []
+    assert body["has_all"] is True  # grace
+
+
+# -- Endpoint: capacity axes ---------------------------------------------------
+
+
+def test_endpoint_non_int_channels_collapses_bundle(client):
+    body = _get_json(client, "/api/entitlement/has-all?channels=five")
+    assert body["supplied_axes"] == ["channels"]
+    assert body["channels"] is None
+    assert body["has_all"] is False
+
+
+def test_endpoint_blank_channels_collapses_bundle(client):
+    body = _get_json(client, "/api/entitlement/has-all?channels=")
+    assert body["supplied_axes"] == ["channels"]
+    assert body["channels"] is None
+    assert body["has_all"] is False
+
+
+def test_endpoint_zero_channels_is_true(client):
+    body = _get_json(client, "/api/entitlement/has-all?channels=0")
+    assert body["supplied_axes"] == ["channels"]
+    assert body["channels"] == 0
+    assert body["has_all"] is True
+
+
+# -- Endpoint: enforce mode ----------------------------------------------------
+
+
+def test_endpoint_paid_bundle_denied_after_enforcement(monkeypatch, tmp_path):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    try:
+        from routes.entitlement import bp_entitlement
+
+        app = Flask(__name__)
+        app.register_blueprint(bp_entitlement)
+        client = app.test_client()
+        resp = client.get(
+            "/api/entitlement/has-all?features=fleet&runtimes=claude_code"
+            "&channels=5&retention_days=30&nodes=2"
+        )
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body["grace"] is False
+        assert body["enforced"] is True
+        assert body["has_all"] is False
+        assert body["allowed"] is False
+    finally:
+        monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+        importlib.reload(e)
+        e.invalidate()
+
+
+# -- Endpoint: never 5xx -------------------------------------------------------
+
+
+def test_endpoint_never_5xx_on_body_blowup(monkeypatch, client):
+    def _boom(*a, **kw):
+        raise RuntimeError("blowup in body builder")
+
+    monkeypatch.setattr("routes.entitlement._has_all_body", _boom)
+    resp = client.get(
+        "/api/entitlement/has-all?features=fleet&channels=5"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert set(body.keys()) == _HAS_ALL_KEYS
+    assert body["has_all"] is False
+    assert body["allowed"] is False
+
+
+def test_endpoint_never_5xx_on_scalar_blowup(monkeypatch, client):
+    from clawmetry import entitlements as _ent
+
+    def _boom(*a, **kw):
+        raise RuntimeError("boom in scalar")
+
+    monkeypatch.setattr(_ent, "has_all", _boom)
+    resp = client.get("/api/entitlement/has-all?features=fleet")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert set(body.keys()) == _HAS_ALL_KEYS
+    assert body["has_all"] is False
+
+
+# -- Endpoint: never 4xx -------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "/api/entitlement/has-all",
+        "/api/entitlement/has-all?features=",
+        "/api/entitlement/has-all?runtimes=",
+        "/api/entitlement/has-all?channels=",
+        "/api/entitlement/has-all?features=fleet&channels=notanint",
+        "/api/entitlement/has-all?features=bogus_only",
+        "/api/entitlement/has-all?features=fleet,,,",
+    ],
+)
+def test_endpoint_never_4xx(client, url):
+    resp = client.get(url)
+    assert resp.status_code == 200, url
+    body = resp.get_json()
+    assert set(body.keys()) == _HAS_ALL_KEYS
+
+
+# -- Endpoint: scalar-vs-endpoint parity ---------------------------------------
+
+
+@pytest.mark.parametrize(
+    "url,features,runtimes,channels,retention_days,nodes",
+    [
+        ("/api/entitlement/has-all?features=fleet", ["fleet"], None, None, None, None),
+        (
+            "/api/entitlement/has-all?features=fleet&runtimes=claude_code",
+            ["fleet"],
+            ["claude_code"],
+            None,
+            None,
+            None,
+        ),
+        (
+            "/api/entitlement/has-all?channels=5&nodes=2",
+            None,
+            None,
+            5,
+            None,
+            2,
+        ),
+        (
+            "/api/entitlement/has-all?features=nemo_governance"
+            "&runtimes=openclaw&channels=1&retention_days=1&nodes=1",
+            ["nemo_governance"],
+            ["openclaw"],
+            1,
+            1,
+            1,
+        ),
+        (
+            "/api/entitlement/has-all?features=fleet,bogus_xyz",
+            ["fleet", "bogus_xyz"],
+            None,
+            None,
+            None,
+            None,
+        ),
+    ],
+)
+def test_endpoint_matches_scalar(
+    client, ent, url, features, runtimes, channels, retention_days, nodes
+):
+    body = _get_json(client, url)
+    expected = ent.has_all(
+        features=features,
+        runtimes=runtimes,
+        channels=channels,
+        retention_days=retention_days,
+        nodes=nodes,
+    )
+    assert body["has_all"] is expected
+    assert body["allowed"] is expected
+
+
+# -- Cross-consistency with /required-tier-batch --------------------------------
+
+
+@pytest.mark.parametrize(
+    "query,expect_required",
+    [
+        ("features=nemo_governance", True),
+        ("features=fleet", True),
+        ("runtimes=claude_code", True),
+        ("features=fleet&runtimes=claude_code", True),
+        ("channels=5&nodes=2", True),
+    ],
+)
+def test_cross_consistent_with_required_tier_batch(
+    client, query, expect_required
+):
+    has = _get_json(client, f"/api/entitlement/has-all?{query}")
+    rtb = _get_json(client, f"/api/entitlement/required-tier-batch?{query}")
+    assert has["required_tier"] == rtb["required_tier"]
+    assert has["required_tier_label"] == rtb["required_tier_label"]
+    assert has["required_tier_rank"] == rtb["required_tier_rank"]
+    assert has["current_tier"] == rtb["current_tier"]
+    assert has["current_tier_rank"] == rtb["current_tier_rank"]
+    if expect_required:
+        assert has["required_tier"] is not None
+
+
+def test_documented_divergence_from_required_tier_batch_on_no_axes(client):
+    has_resp = client.get("/api/entitlement/has-all")
+    assert has_resp.status_code == 200
+    rtb_resp = client.get("/api/entitlement/required-tier-batch")
+    assert rtb_resp.status_code == 400
+
+
+# -- Grace / enforce invariants ------------------------------------------------
+
+
+def test_grace_invariant_full_known_paid_bundle_reports_true(ent):
+    paid_f = next(iter(ent.PAID_FEATURES))
+    paid_r = next(iter(ent.PAID_RUNTIMES))
+    assert (
+        ent.has_all(
+            features=[paid_f],
+            runtimes=[paid_r],
+            channels=999,
+            retention_days=999,
+            nodes=999,
+        )
+        is True
+    )
+
+
+def test_enforce_full_known_paid_bundle_locked_on_oss(enforced):
+    paid_f = next(iter(enforced.PAID_FEATURES))
+    paid_r = next(iter(enforced.PAID_RUNTIMES))
+    assert (
+        enforced.has_all(
+            features=[paid_f],
+            runtimes=[paid_r],
+            channels=999,
+            retention_days=999,
+            nodes=999,
+        )
+        is False
+    )
+
+
+def test_enforce_free_bundle_still_true(enforced):
+    free_f = next(iter(enforced.FREE_FEATURES))
+    free_r = next(iter(enforced.FREE_RUNTIMES))
+    assert (
+        enforced.has_all(
+            features=[free_f],
+            runtimes=[free_r],
+            channels=1,
+            retention_days=1,
+            nodes=1,
+        )
+        is True
+    )


### PR DESCRIPTION
## Summary

- New `clawmetry.entitlements.has_all(*, features=None, runtimes=None, channels=None, retention_days=None, nodes=None) -> bool` -- **aggregate boolean sibling** of the existing `min_tier_for_all(...)`. Where `min_tier_for_all` folds the same five kwargs to ONE tier id (most-constraining axis wins), this folds them to ONE boolean (tightest per-axis denial wins). A paywall diagnostics tile that gates on the full subscription state ("fleet + claude_code + 5 channels + 30-day retention + 2 nodes -- does the resolved entitlement grant everything?") binds ONE boolean off ONE call instead of five singular `has_*` round-trips + a client-side AND-chain.

  Kwarg semantics mirror `min_tier_for_all` exactly: `features=None` / `runtimes=None` -> axis unsupplied; `retention_days=None` means *unset*, NOT *unlimited*; non-int capacity value -> `False`; unknown feature / runtime id collapses the fold. **Empty-input strict-`False`** matches `has_features([])` / `has_runtimes([])` posture. Grace pass-through preserved. Never raises.

- New `GET /api/entitlement/has-all?features=a,b&runtimes=x,y&channels=N&retention_days=K&nodes=M` on `bp_entitlement`. **19-key byte-stable envelope** across every input branch.

- **70 hermetic unit tests** in `tests/test_entitlement_has_all.py` covering: scalar fold across all axes under grace vs enforce; empty/None/unknown/non-int inputs; never-raises; envelope shape stability; alias canonicalisation; never-4xx/never-5xx guarantees; scalar-vs-endpoint parity; cross-consistency with `/required-tier-batch`.

Behaviour is additive; nothing existing changes. Rebased cleanly on top of #4410 (missing_features/missing_runtimes) which merged first.

## Test plan

- [x] `python3 -m py_compile clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_has_all.py` -- passes
- [x] `ruff check clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_has_all.py` -- All checks passed
- [x] `python3 -m pytest tests/test_entitlement_has_all.py` -- **70 passed**
- [x] Sibling regression suites (289 tests) -- all passed on the original branch

## Local operator verification checklist

The web agent cannot touch the live daemon, `~/.openclaw`, the cloud snapshot, a browser, or the private `clawmetry-cloud` repo. Please verify on-host:

- [ ] `curl -s "http://localhost:8900/api/entitlement/has-all?features=fleet&runtimes=claude_code&channels=5&retention_days=30&nodes=2" | jq` -- 19 keys, `has_all=true`, `grace=true`
- [ ] `curl -s "http://localhost:8900/api/entitlement/has-all?runtimes=claude-code,claude_code" | jq '.runtimes'` -- single row `["claude_code"]`
- [ ] `curl -s "http://localhost:8900/api/entitlement/has-all?features=fleet,totally_fake_xyz" | jq '{has_all, unknown_features}'` -- `has_all=false`
- [ ] `curl -s "http://localhost:8900/api/entitlement/has-all?channels=five" | jq '{has_all, supplied_axes, channels}'` -- `has_all=false`
- [ ] Never-4xx: `curl -s -o /dev/null -w '%{http_code}\n' "http://localhost:8900/api/entitlement/has-all"` -- `200`
- [ ] Decrypt the live cloud snapshot and confirm the endpoint is reachable through the relay.

---
_Generated by [Claude Code](https://claude.ai/code/session_018NZMQyPSfkQJA9y5rqytYP)_