### PR TITLE
fix(overview): hero alive-state covers main sessions, not just subagents

### DIFF
--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -4464,7 +4464,8 @@ class LocalStore:
         Returns::
 
             {
-              "by_runtime": {rt: {sessions, tokens, cost_usd, events}},
+              "by_runtime": {rt: {sessions, tokens, cost_usd, events,
+                                  last_activity_ms}},
               "by_runtime_model": [
                   {runtime, model, turns, tokens, cost_usd, sessions}, ...
               ],  # model-bearing rows only
@@ -4511,7 +4512,8 @@ class LocalStore:
                 ev AS (
                     SELECT session_id,
                            SUM(COALESCE(token_count, 0)) AS tok,
-                           SUM(COALESCE(cost_usd, 0.0))  AS cost
+                           SUM(COALESCE(cost_usd, 0.0))  AS cost,
+                           MAX(epoch_ms(TRY_CAST(ts AS TIMESTAMPTZ))) AS last_ms
                     FROM deduped GROUP BY session_id
                 ),
                 combined AS (
@@ -4519,14 +4521,19 @@ class LocalStore:
                            GREATEST(COALESCE(s.total_tokens, 0),
                                     COALESCE(ev.tok, 0))         AS tokens,
                            GREATEST(COALESCE(s.cost_usd, 0.0),
-                                    COALESCE(ev.cost, 0.0))      AS cost_usd
+                                    COALESCE(ev.cost, 0.0))      AS cost_usd,
+                           GREATEST(
+                               COALESCE(ev.last_ms, 0),
+                               COALESCE(epoch_ms(TRY_CAST(s.last_active_at AS TIMESTAMPTZ)), 0)
+                           ) AS last_ms
                     FROM sessions s
                     FULL OUTER JOIN ev ON s.session_id = ev.session_id
                 )
                 SELECT {rt_case} AS runtime,
                        COUNT(*)      AS sessions,
                        SUM(tokens)   AS tokens,
-                       SUM(cost_usd) AS cost_usd
+                       SUM(cost_usd) AS cost_usd,
+                       MAX(last_ms)  AS last_activity_ms
                 FROM combined
                 GROUP BY 1
             """
@@ -4538,6 +4545,11 @@ class LocalStore:
                     "cost_usd": float(r[3] or 0.0),
                     "cost_24h_usd": 0.0,
                     "tokens_24h": 0,
+                    # Newest event ts / session last_active_at for this runtime
+                    # (epoch ms). Main terminal sessions never appear in
+                    # /api/subagents, so the Overview alive-state needs a
+                    # recency signal that covers ALL of a runtime's sessions.
+                    "last_activity_ms": int(r[4] or 0),
                 }
             # Rolling LAST-24h cost/tokens per runtime, from events in the trailing
             # 24 hours. (A rolling window, not a calendar "today" — a calendar day

--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -3070,7 +3070,8 @@ var _LOADALL_COALESCE_MS = 2000;
 // Human-first Overview hero (FLYWHEEL vision). Answers, in plain words a
 // first-timer gets in ~5s: is my agent alive, what did it just do, is it
 // healthy, what did it cost. Reads only already-fetched state (no new request):
-// alive-state from /api/subagents (window._cmAgentBusy), last reply from the
+// alive-state from /api/subagents (window._cmAgentBusy) plus main-session
+// recency from /api/runtime-summary (window._cmRtAct), last reply from the
 // transcript loadActivityStream already pulled (window._cmLastAgentSay), model
 // + session count from the cached /api/overview, cost from the rendered stat.
 // Idempotent + self-healing: called after each overview/active-tasks refresh.
@@ -3191,12 +3192,58 @@ function _renderOutLoopSources() {
   }).catch(function(){});
 }
 
+// Alive-state truthfulness: /api/subagents only lists SPAWNED children, so a
+// node whose main terminal sessions are hard at work read "It's idle right
+// now" (founder report 2026-08-02). Complement it with per-runtime recency
+// from /api/runtime-summary (`last_activity_ms`, snapshot-served on cloud):
+// working = an active subagent OR a main-session event within the last 3
+// minutes (window absorbs ingest + snapshot lag, stays honest after stop).
+var _CM_RT_ACTIVE_WINDOW_MS = 3 * 60 * 1000;
+function _cmNoteRtActivity(runtimes) {
+  try {
+    var map = {}, mx = 0;
+    Object.keys(runtimes || {}).forEach(function (k) {
+      var v = Number(runtimes[k] && runtimes[k].last_activity_ms) || 0;
+      map[k] = v; if (v > mx) mx = v;
+    });
+    window._cmRtAct = { ts: Date.now(), map: map, max: mx };
+  } catch (e) {}
+}
+function _cmRtRecentlyActive() {
+  var a = window._cmRtAct;
+  if (!a || !a.map) return false;
+  var rt = (typeof _cmRuntimeFilter === 'function') ? _cmRuntimeFilter() : 'all';
+  var ts = (rt && rt !== 'all') ? (a.map[rt] || 0) : (a.max || 0);
+  return ts > 0 && (Date.now() - ts) < _CM_RT_ACTIVE_WINDOW_MS;
+}
 function _renderOverviewHero() {
   var hero = document.getElementById('overview-hero');
   if (!hero) return;
   function _txt(id) { var e = document.getElementById(id); return e ? e.textContent.trim() : ''; }
   var ov = window._cmOverview || {};
-  var busy = !!window._cmAgentBusy;
+  var busy = !!window._cmAgentBusy || _cmRtRecentlyActive();
+  // Recency cache cold/stale → kick ONE runtime-summary load and repaint on
+  // arrival (same guard pattern as the efficiency chip below: the fresh
+  // cache never re-enters, so no render loop).
+  try {
+    var _ra = window._cmRtAct;
+    // Error entries retry after 5s (the cold-load request burst can time this
+    // fetch out; a 30s empty cache would pin the hero on "idle"), and keep any
+    // previously-good map rather than blanking it.
+    var _raTtl = (_ra && _ra.err) ? 5000 : 30000;
+    if (!(_ra && (Date.now() - _ra.ts) < _raTtl) && !window._cmRtActWait) {
+      window._cmRtActWait = true;
+      fetchJsonWithTimeout('/api/runtime-summary', 8000).then(function (d) {
+        _cmNoteRtActivity((d && d.runtimes) || {});
+      }).catch(function () {
+        var _old = window._cmRtAct || {};
+        window._cmRtAct = { ts: Date.now(), map: _old.map || {}, max: _old.max || 0, err: true };
+      }).then(function () {
+        window._cmRtActWait = false;
+        try { _renderOverviewHero(); } catch (e) {}
+      });
+    }
+  } catch (_e_act) {}
   var stateWord = busy ? 'working' : 'idle';
   var dot = busy ? '#22c55e' : '#3b82f6';
   // When a runtime is selected, the hero must mirror the (runtime-scoped) stat
@@ -3248,11 +3295,16 @@ function _renderOverviewHero() {
   // matches `clawmetry status --live`. Shown only while the agent is producing.
   try {
     var _nowMs = Date.now(), _tt = Number(window._cmTodayTokensRaw || 0), _prevT = window._cmHeroTpsPrev;
-    if (busy && _prevT && _nowMs > _prevT.t) {
+    var _tpsRt = (typeof _cmRuntimeFilter === 'function') ? _cmRuntimeFilter() : 'all';
+    // Same-scope samples only, plus a sanity ceiling: a runtime switch (or a
+    // node-wide -> scoped repaint) swaps the counter's SOURCE, so the delta is
+    // a scope jump, not throughput ("23,058,079 tok/s" shipped from exactly
+    // that once busy started being true for main sessions).
+    if (busy && _prevT && _prevT.rt === _tpsRt && _nowMs > _prevT.t) {
       var _tps = (_tt - _prevT.k) / ((_nowMs - _prevT.t) / 1000);
-      if (_tps > 0.5) stats.push('⚡ <strong style="color:var(--text-primary);">' + Math.round(_tps) + '</strong> tok/s');
+      if (_tps > 0.5 && _tps < 50000) stats.push('⚡ <strong style="color:var(--text-primary);">' + Math.round(_tps) + '</strong> tok/s');
     }
-    window._cmHeroTpsPrev = { k: _tt, t: _nowMs };
+    window._cmHeroTpsPrev = { k: _tt, t: _nowMs, rt: _tpsRt };
   } catch (_e) {}
 
   hero.innerHTML =
@@ -3456,6 +3508,9 @@ async function loadMiniWidgets(overview, usage) {
     var _ovRt = (typeof _cmRuntimeFilter === 'function') ? _cmRuntimeFilter() : 'all';
     if (_ovRt && _ovRt !== 'all') {
       var _rsd = await fetchJsonWithTimeout('/api/runtime-summary', 4000);
+      // Keep the hero's alive-state recency cache warm from this fetch so the
+      // scoped path never issues a second /api/runtime-summary request.
+      try { if (typeof _cmNoteRtActivity === 'function') _cmNoteRtActivity((_rsd && _rsd.runtimes) || {}); } catch (_e_act) {}
       var _rs = _rsd && _rsd.runtimes && _rsd.runtimes[_ovRt];
       _ovModel = (_rs && _rs.primary_model) ? _rs.primary_model : '—';
       // The SESSIONS card must match what the runtime switcher promises

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -12791,6 +12791,11 @@ def _build_runtime_summary(limit: int = 20000):
                 "total_turns": total,
                 "models": models_out,
                 "switch_count": rt_switches.get(rt, 0),
+                # Newest event / session-activity timestamp (epoch ms) so the
+                # Overview hero can say "working" for MAIN sessions too —
+                # /api/subagents only covers spawned children, so a node whose
+                # terminals were busy read as idle (founder report 2026-08-02).
+                "last_activity_ms": int(totals.get("last_activity_ms") or 0),
             }
         # Fold in foreign OTLP / OpenLLMetry apps (#2822/#2853 follow-up). These
         # derive ``agent_type`` from the resource ``service.name`` and have NO

--- a/routes/usage.py
+++ b/routes/usage.py
@@ -2951,10 +2951,19 @@ def api_runtime_summary():
             for ev in evs:
                 rt = _runtime_of(ev.get("session_id"))
                 a = agg.setdefault(rt, {"turns": 0, "tokens": 0, "cost": 0.0,
-                                        "models": {}, "sessions": set()})
+                                        "models": {}, "sessions": set(),
+                                        "last_ms": 0})
                 sid = ev.get("session_id") or ""
                 if sid:
                     a["sessions"].add(sid)
+                ts = str(ev.get("ts") or "")
+                if ts:
+                    try:
+                        _p = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+                        a["last_ms"] = max(a["last_ms"],
+                                           int(_p.timestamp() * 1000))
+                    except (ValueError, OSError, OverflowError):
+                        pass
                 try:
                     a["tokens"] += int(ev.get("token_count") or 0)
                 except (TypeError, ValueError):
@@ -2976,6 +2985,9 @@ def api_runtime_summary():
                     "cost_usd": round(a["cost"], 4),
                     "primary_model": sorted_models[0][0] if sorted_models else "",
                     "total_turns": sum(a["models"].values()),
+                    # Epoch-ms recency for the Overview hero alive-state (main
+                    # sessions don't appear in /api/subagents).
+                    "last_activity_ms": a["last_ms"],
                 }
         except Exception:
             out = {}

--- a/tests/test_hero_alive_state.py
+++ b/tests/test_hero_alive_state.py
@@ -1,0 +1,187 @@
+"""Alive-state truthfulness for the Overview hero (founder report 2026-08-02).
+
+The hero's "It's working / It's idle right now" used to read ONLY the
+subagent registry (``/api/subagents``), which lists SPAWNED children — main
+terminal sessions (Claude Code in N terminals) never appear there, so a node
+hard at work said "It's idle right now."
+
+The fix threads a per-runtime recency signal, ``last_activity_ms`` (epoch ms
+of the newest event ts / session ``last_active_at``), through every layer the
+hero can read:
+
+  store.query_model_rollup()["by_runtime"][rt]["last_activity_ms"]
+    -> sync._build_runtime_summary()[rt]["last_activity_ms"]   (cloud snapshot)
+    -> GET /api/runtime-summary  runtimes[rt]["last_activity_ms"] (local route)
+    -> app.js _cmRtRecentlyActive() OR-ed into the hero's ``busy``
+
+These tests pin each hop; the JS hop is guarded mechanically (the busy
+expression must reference the recency helper, and the helper must read
+``last_activity_ms``) so a frontend refactor can't silently drop it.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import re
+import time
+from datetime import datetime, timezone
+
+import pytest
+from flask import Flask
+
+
+def _iso(s: float) -> str:
+    return datetime.fromtimestamp(s, tz=timezone.utc).isoformat()
+
+
+def _wait_flush(store, t: float = 2.0) -> None:
+    deadline = time.monotonic() + t
+    while time.monotonic() < deadline:
+        if store.health()["ring_depth"] == 0:
+            return
+        time.sleep(0.02)
+
+
+@pytest.fixture
+def app_and_store(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_BATCH", "1")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_READ", "1")
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    ls.mark_writer_owner()
+    import routes.local_query as lq
+    importlib.reload(lq)
+    monkeypatch.setattr(lq, "local_store_via_daemon", lambda *a, **k: None)
+    monkeypatch.setattr(lq, "_read_discovery", lambda: None)
+    monkeypatch.setattr(lq, "_cached_discovery", lambda: None)
+    import routes.usage as usage_mod
+    importlib.reload(usage_mod)
+    a = Flask(__name__)
+    a.register_blueprint(usage_mod.bp_usage)
+    yield a, ls
+    try:
+        ls.get_store().stop(flush=True)
+    except Exception:
+        pass
+
+
+def _seed(store, sid: str, ts: float, *, model: str = "claude-opus-4-8") -> None:
+    store.ingest({
+        "id": sid + "-" + str(int(ts * 1000)),
+        "node_id": "agent+test",
+        "agent_id": "main",
+        "session_id": sid,
+        "event_type": "tool_call",
+        "ts": _iso(ts),
+        "data": {"tool_name": "X"},
+        "cost_usd": 0.01,
+        "token_count": 100,
+        "model": model,
+    })
+
+
+# ── 1. store rollup carries per-runtime recency ─────────────────────────────
+
+
+def test_rollup_carries_last_activity_ms(app_and_store):
+    _, ls = app_and_store
+    store = ls.get_store()
+    now = time.time()
+    _seed(store, "claude_code:c1", now - 3000)
+    _seed(store, "claude_code:c1", now - 30)          # fresh main-session event
+    _seed(store, "goose:g1", now - 7200)              # 2h old
+    _wait_flush(store)
+
+    by_rt = store.query_model_rollup()["by_runtime"]
+    cc = by_rt["claude_code"]["last_activity_ms"]
+    go = by_rt["goose"]["last_activity_ms"]
+    # Newest event wins, in epoch ms (±5s slack for flush timing).
+    assert abs(cc - (now - 30) * 1000) < 5000, cc
+    assert abs(go - (now - 7200) * 1000) < 5000, go
+
+
+def test_rollup_recency_falls_back_to_session_last_active(app_and_store):
+    """Family adapters keep activity on the sessions row (events may carry no
+    usable recency for them) — sessions.last_active_at must feed the signal."""
+    _, ls = app_and_store
+    store = ls.get_store()
+    now = time.time()
+    store.ingest_session({
+        "session_id": "cursor:k1", "agent_type": "cursor", "agent_id": "main",
+        "status": "active", "total_tokens": 500, "cost_usd": 0.05,
+        "last_active_at": _iso(now - 45),
+    })
+    _wait_flush(store)
+
+    by_rt = store.query_model_rollup()["by_runtime"]
+    k = by_rt["cursor"]["last_activity_ms"]
+    assert abs(k - (now - 45) * 1000) < 5000, k
+
+
+# ── 2. the snapshot builder emits it (the cloud hero's source) ──────────────
+
+
+def test_runtime_summary_snapshot_emits_last_activity(app_and_store, monkeypatch):
+    _, ls = app_and_store
+    store = ls.get_store()
+    now = time.time()
+    _seed(store, "claude_code:c1", now - 20)
+    _wait_flush(store)
+
+    import clawmetry.sync as sync
+    monkeypatch.setattr(ls, "get_store", lambda *a, **k: store)
+    rs = sync._build_runtime_summary()
+    assert "claude_code" in rs
+    ms = rs["claude_code"]["last_activity_ms"]
+    assert abs(ms - (now - 20) * 1000) < 5000, ms
+
+
+# ── 3. the local route serves it (self-hosted hero's source) ────────────────
+
+
+def test_local_runtime_summary_route_serves_last_activity(app_and_store):
+    a, ls = app_and_store
+    store = ls.get_store()
+    now = time.time()
+    _seed(store, "claude_code:c1", now - 20)
+    _wait_flush(store)
+
+    body = a.test_client().get("/api/runtime-summary").get_json() or {}
+    cc = (body.get("runtimes") or {}).get("claude_code") or {}
+    ms = int(cc.get("last_activity_ms") or 0)
+    assert abs(ms - (now - 20) * 1000) < 5000, body
+
+
+# ── 4. the frontend actually reads it (mechanical drift guard) ──────────────
+
+
+def _appjs() -> str:
+    path = os.path.join(os.path.dirname(__file__), "..",
+                        "clawmetry", "static", "js", "app.js")
+    with open(path, encoding="utf-8") as f:
+        return f.read()
+
+
+def test_hero_busy_ors_in_main_session_recency():
+    js = _appjs()
+    # The busy expression must OR the subagent flag with the recency helper —
+    # subagents alone regress to "idle while terminals are busy."
+    assert re.search(
+        r"var busy = !!window\._cmAgentBusy \|\| _cmRtRecentlyActive\(\)", js
+    ), "hero busy no longer includes main-session recency"
+    # And the helper must read the snapshot/route field by name.
+    assert "last_activity_ms" in js, "recency helper lost the last_activity_ms read"
+
+
+def test_hero_tps_chip_guards_scope_jumps():
+    """The live tok/s chip diffs _cmTodayTokensRaw between renders. A runtime
+    switch swaps that counter's source, so an unguarded delta rendered
+    '23,058,079 tok/s' the moment busy became true for main sessions. The
+    sample pair must be same-scope and the result bounded."""
+    js = _appjs()
+    assert "_prevT.rt === _tpsRt" in js, "tok/s chip lost the same-scope guard"
+    assert re.search(r"_tps > 0\.5 && _tps < 50000", js), \
+        "tok/s chip lost its sanity ceiling"


### PR DESCRIPTION
## Why

The Overview hero said **"It's idle right now."** while Claude Code was busy in multiple terminals (founder screenshot 2026-08-02, app.clawmetry.com claude_code view). The alive-state read only `/api/subagents`, which lists spawned Task-tool children. Main terminal sessions never appear there, so a node hard at work always read as idle. For the product whose whole promise is "is my agent alive, what is it doing", that headline was untruthful.

## What

Threads a per-runtime recency signal end to end:

- `local_store.query_model_rollup`: `by_runtime[rt].last_activity_ms` = MAX(event ts, sessions.last_active_at) in epoch ms. Same aggregate pass as the existing rollup, no extra table scan (FLYWHEEL 1e).
- `sync._build_runtime_summary`: emits `last_activity_ms` into the `runtimeSummary` snapshot slice. The cloud `cm-cloud-runtime-summary` interceptor returns the slice verbatim, so no cloud-repo change is needed for data flow.
- `routes/usage.py` `/api/runtime-summary`: same field for self-hosted.
- `app.js` hero: `busy = active subagent OR last activity within 3 min`, scoped to the runtime switcher (all-runtimes uses the max across runtimes). 30s cache, single in-flight, stale-kept with a 5s retry on fetch error so a cold-load timeout can't pin the hero on idle.

Also fixes a latent bug this exposed: the live tok/s chip diffed `_cmTodayTokensRaw` across renders without noticing the runtime scope changed sources between samples, rendering "23,058,079 tok/s" the moment busy became true for main sessions. Samples are now same-scope with a sanity ceiling.

## Verification

- `tests/test_hero_alive_state.py` (6 guards, all 4 hops + the tok/s guard): red on un-fixed code (revert-proven via stash), green with the fix.
- Adjacent suites green: model_rollup_uncapped, runtime_filter_no_leak, byruntime_slices, cost_rollup_dedup, otlp_rollup_cpu_budget, agent_inventory (2 pre-existing failures reproduce on clean origin/main under local Py3.9, unrelated).
- 207 JS unit tests pass; `node --check` clean.
- FLYWHEEL §3 live-daemon test: patched the running install; `/api/runtime-summary` served `claude_code` 42s fresh while other runtimes stayed hours/days old; decrypted the live cloud snapshot and confirmed `runtimeSummary.claude_code.last_activity_ms` 1.9 min fresh; browser on localhost:8900 shows **"It's working right now."** both node-wide and scoped to Claude Code, settling within 2s of load, while this very session was the activity source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)