### PR TITLE
feat(entitlement): has_features_at + has_runtimes_at + /api/entitlement/has-{features,runtimes}-at (plural what-if boolean-gate scalars)

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -5802,6 +5802,133 @@ def has_runtimes(runtimes) -> bool:
         return False
 
 
+def has_features_at(perspective_tier: str, features) -> bool:
+    """Hypothetical-perspective sibling of :func:`has_features`: would tier
+    ``perspective_tier`` grant **all** ``features``?
+
+    Plural-fold twin of :func:`has_feature_at` on the same axis, in the same
+    relationship :func:`has_features` has to :func:`has_feature`. Fills the
+    plural ``_at`` slot in the grant-axis boolean-gate family so a pricing
+    matrix that gates on a BUNDLE (``fleet + otel_export + sso -- Available
+    in Enterprise``) can bind ONE boolean per (perspective, bundle) cell off
+    ONE URL each, instead of walking the singular :func:`has_feature_at` per
+    item and AND-ing on the client.
+
+    Fold rule mirrors :func:`has_features` exactly: returns ``True`` iff
+    :func:`has_feature_at` returns ``True`` for **every** item in the
+    iterable, i.e. the tightest single-item denial wins. Consequences of
+    that fold, all deliberate:
+
+    * Empty / ``None`` / non-iterable ``features`` -- returns ``False``.
+      The vacuous-truth answer would silently render "granted" on a caller
+      who forgot to pass the bundle, which is exactly the callsite-typo
+      posture the singular :func:`has_feature_at` catches with its empty-id
+      ``False``. Matches the plural :func:`has_features` empty-fold posture
+      byte-for-byte.
+    * Unknown / empty / non-string ``perspective_tier`` -- returns ``False``.
+      Perspective validation lives on the OUTER helper (once per call) rather
+      than folding into per-item :func:`has_feature_at` calls, so a bogus
+      perspective fails-closed in one place instead of re-parsing the tier
+      per item. Same fail-closed posture as :func:`has_feature_at` on an
+      unknown perspective.
+    * Unknown / empty / non-string item id -- returns ``False``. The singular
+      :func:`has_feature_at` fails-closed on typos so the bundle fold
+      inherits that: ``has_features_at("pro", ["fleet", "Fleeet"])`` is
+      ``False`` even in grace, surfacing the typo instead of silently
+      granting the bundle.
+    * Grace-independence: the answer is derived from the static per-tier
+      grant map via :func:`has_feature_at`'s :func:`_hypothetical_entitlement`
+      backing, so the returned bit is IDENTICAL under grace vs enforce for
+      the same (perspective, bundle) pair. Diverges deliberately from
+      :func:`has_features` (which reports ``True`` for every fully-known
+      bundle in grace via the live resolver's grace pass-through) -- the
+      whole point of the ``_at`` slot is to render the would-be-locked
+      state alongside the live grant.
+
+    Never raises: any delegate failure logs a warning and returns ``False``
+    so a pricing-matrix cell keeps rendering instead of breaking.
+    """
+    try:
+        p = (perspective_tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return False
+    if not p or p not in _TIER_ORDER:
+        return False
+    try:
+        if features is None:
+            return False
+        items = list(features)
+    except TypeError:
+        return False
+    if not items:
+        return False
+    try:
+        for f in items:
+            if not has_feature_at(p, f):
+                return False
+        return True
+    except Exception as exc:
+        logger.warning(
+            "entitlements: has_features_at(%r, %r) failed: %s",
+            perspective_tier,
+            features,
+            exc,
+        )
+        return False
+
+
+def has_runtimes_at(perspective_tier: str, runtimes) -> bool:
+    """Runtime-axis twin of :func:`has_features_at`: would tier
+    ``perspective_tier`` grant **all** ``runtimes``?
+
+    Same relationship to :func:`has_runtime_at` that :func:`has_features_at`
+    has to :func:`has_feature_at`. Delegates to :func:`has_runtime_at` per
+    item, so the strict alias posture the singular helper carries (no
+    :func:`canonical_runtime` resolution at scalar layer; a raw
+    ``"claude-code"`` collapses to ``False`` because it is not in
+    :data:`ALL_RUNTIMES` after ``.strip().lower()``) is inherited. Alias
+    tolerance belongs to the endpoint, which canonicalises per-token upstream
+    -- matching the sibling :func:`has_runtimes` scalar / ``/has-runtimes``
+    endpoint split exactly.
+
+    Fold semantics mirror :func:`has_features_at` byte-for-byte: perspective
+    validated once against :data:`_TIER_ORDER` (fail-closed on empty /
+    unknown / non-string); empty / ``None`` / non-iterable bundle collapses
+    to ``False``; unknown / empty / non-string item collapses the whole fold
+    to ``False``; grace-independent by construction (backed by
+    :func:`_hypothetical_entitlement` via the singular delegate).
+
+    Never raises: delegate failure -> logged warning -> ``False``.
+    """
+    try:
+        p = (perspective_tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return False
+    if not p or p not in _TIER_ORDER:
+        return False
+    try:
+        if runtimes is None:
+            return False
+        items = list(runtimes)
+    except TypeError:
+        return False
+    if not items:
+        return False
+    try:
+        for rt in items:
+            if not has_runtime_at(p, rt):
+                return False
+        return True
+    except Exception as exc:
+        logger.warning(
+            "entitlements: has_runtimes_at(%r, %r) failed: %s",
+            perspective_tier,
+            runtimes,
+            exc,
+        )
+        return False
+
+
 def missing_features(features) -> list:
     """Row-level complement of :func:`has_features`: return the subset of
     ``features`` NOT granted by the resolved entitlement.

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -4289,6 +4289,211 @@ def api_entitlement_has_runtimes():
         return jsonify(_has_bundle_fallback("runtimes", _parse_csv_arg("runtimes")))
 
 
+def _has_bundle_at_fallback(axis: str, tier: str, tokens: list[str]) -> dict:
+    """OSS-free / never-5xx envelope for the plural what-if endpoints
+    ``/api/entitlement/has-features-at`` and ``/has-runtimes-at``.
+
+    What-if sibling of :func:`_has_bundle_fallback`, in the same relationship
+    :func:`_has_axis_at_fallback` has to :func:`_has_axis_fallback`. On any
+    resolver / helper blowup the endpoint still returns 200 with the same
+    15-key envelope as the happy path, but with ``has_<axis>_at`` and
+    ``allowed`` strict-``False`` (matches the fail-closed posture the sibling
+    ``/has-feature-at`` / ``/has-runtime-at`` fallback uses -- a paywall
+    matrix tile that lost the resolver never silently renders a bundle grant
+    it can't verify). ``tier`` and ``tokens`` echo the caller's canonicalised
+    input so the UI can still surface both in a diagnostics tooltip.
+    """
+    key = f"has_{axis}_at"
+    return {
+        "tier": tier,
+        axis: [],
+        "unknown": list(tokens),
+        "kind": axis,
+        "count": 0,
+        key: False,
+        "allowed": False,
+        "required_tier": None,
+        "required_tier_label": None,
+        "required_tier_rank": -1,
+        "perspective_tier_rank": -1,
+        "current_tier": "oss",
+        "current_tier_rank": 0,
+        "grace": True,
+        "enforced": False,
+    }
+
+
+def _has_bundle_at_body(axis: str) -> dict:
+    """Happy-path body builder for the plural what-if endpoints
+    ``/api/entitlement/has-features-at`` and ``/has-runtimes-at``.
+
+    Perspective-shaped sibling of :func:`_has_bundle_body`: where the live
+    variant folds :func:`has_features` / :func:`has_runtimes` against the
+    resolved entitlement, this folds :func:`has_features_at` /
+    :func:`has_runtimes_at` against a caller-supplied ``tier=`` perspective
+    so a pricing matrix that gates on a bundle ("does Starter grant fleet +
+    otel_export + sso? Pro? Enterprise?") can bind ONE boolean per cell off
+    ONE URL each, instead of hydrating the full ``/feature-catalog-at``
+    payload and AND-folding the ``allowed`` fields client-side.
+
+    Envelope shape (15 keys, byte-stable across every input branch)::
+
+        {
+          "tier":                  "<perspective tier id>" | "",
+          "features"/"runtimes":   [<known ids>],       # known-only, dedup, first-seen
+          "unknown":               [<tokens>],           # dropped tokens, echoed raw
+          "kind":                  "features"/"runtimes",
+          "count":                 <int>,               # len(known)
+          "has_<axis>_at":         <bool>,              # scalar over the ORIGINAL CSV
+          "allowed":               <bool>,              # alias of has_<axis>_at
+          "required_tier":         "<tier id>" | null,  # min_tier_for_<axis>(known)
+          "required_tier_label":   "<label>"  | null,
+          "required_tier_rank":    <int>,               # -1 when null
+          "perspective_tier_rank": <int>,               # -1 when tier unknown/blank
+          "current_tier":          "<live tier id>",
+          "current_tier_rank":     <int>,
+          "grace":                 <bool>,              # LIVE resolver grace bit
+          "enforced":              <bool>,
+        }
+
+    Runtime-axis alias canonicalisation is applied per-token upstream of the
+    strict scalar (:func:`has_runtimes_at` does not resolve aliases -- see
+    the scalar docstring), matching the sibling :func:`_has_bundle_body`
+    posture on the ``/has-runtimes`` endpoint exactly.
+
+    Never 4xxs (missing / blank / unknown tier or all-unknown CSV -> 200
+    with ``has_<axis>_at=false``, matching the sibling ``/has-features``
+    posture -- a paywall matrix tile binds ``allowed`` directly without a
+    pre-validation round-trip). The ``perspective_tier_rank`` slot is ``-1``
+    for an unknown perspective so a UI can distinguish "typo perspective"
+    from "valid perspective that just doesn't grant this bundle". Never
+    5xxs.
+    """
+    from clawmetry import entitlements as _ent
+
+    raw_tier = request.args.get("tier")
+    tier = (raw_tier or "").strip().lower()
+    param = "features" if axis == "features" else "runtimes"
+    tokens = _parse_csv_arg(param)
+
+    known: list[str] = []
+    unknown: list[str] = []
+    if axis == "features":
+        for fid in tokens:
+            if fid in _ent.ALL_FEATURES:
+                if fid not in known:
+                    known.append(fid)
+            elif fid not in unknown:
+                unknown.append(fid)
+        required = _ent.min_tier_for_features(known) if known else None
+    else:
+        for rid_raw in tokens:
+            rid = _ent.canonical_runtime(rid_raw) or rid_raw
+            if rid in _ent.ALL_RUNTIMES:
+                if rid not in known:
+                    known.append(rid)
+            elif rid not in unknown:
+                unknown.append(rid_raw)
+        required = _ent.min_tier_for_runtimes(known) if known else None
+
+    # Scalar what-if: only ``True`` when every input token resolved to a
+    # granted known id under ``tier``'s static grant map. ``unknown`` tokens
+    # collapse the bundle to ``False`` for the same typo-catches-at-callsite
+    # reason the singular ``has_feature_at("pro", "BOGUS")`` returns ``False``
+    # -- a UI can still surface the offending set via the ``unknown`` slot.
+    if tokens and not unknown and known and tier and tier in _ent._TIER_ORDER:
+        has_flag = (
+            _ent.has_features_at(tier, known)
+            if axis == "features"
+            else _ent.has_runtimes_at(tier, known)
+        )
+    else:
+        has_flag = False
+
+    ent = _ent.get_entitlement()
+    cur_rank = _ent.tier_rank(ent.tier)
+    req_rank = _ent.tier_rank(required) if required else -1
+    required_label = _ent.tier_label(required) if required else None
+    persp_rank = _ent.tier_rank(tier) if tier and tier in _ent._TIER_ORDER else -1
+    return {
+        "tier": tier,
+        axis: known,
+        "unknown": unknown,
+        "kind": axis,
+        "count": len(known),
+        f"has_{axis}_at": bool(has_flag),
+        "allowed": bool(has_flag),
+        "required_tier": required,
+        "required_tier_label": required_label,
+        "required_tier_rank": req_rank,
+        "perspective_tier_rank": persp_rank,
+        "current_tier": ent.tier,
+        "current_tier_rank": cur_rank,
+        "grace": bool(ent.grace),
+        "enforced": _ent.is_enforced(),
+    }
+
+
+@bp_entitlement.route("/api/entitlement/has-features-at")
+def api_entitlement_has_features_at():
+    """``GET /api/entitlement/has-features-at?tier=<perspective>&features=a,b,c``
+    -- plural what-if boolean-gate scalar sibling of
+    ``/api/entitlement/has-features``.
+
+    Returns ONE boolean (``has_features_at``) plus a what-if envelope that
+    tells the caller which perspective they asked about, whether the whole
+    bundle is admitted by that perspective, the cheapest tier that would
+    unlock it (``required_tier``, byte-parity with the sibling
+    ``/api/entitlement/min-tier-for-features`` answer), and the LIVE
+    resolver context (``current_tier`` / ``grace`` / ``enforced``) so a
+    pricing matrix can render "you are here" alongside "would tier X grant
+    this bundle?" off ONE URL per cell.
+
+    Unlike the live ``/has-features`` sibling this endpoint is
+    perspective-shaped: even in grace ``has_features_at?tier=oss&features=fleet,sso``
+    is ``False`` (because OSS-free does not statically grant ``fleet`` /
+    ``sso``), whereas ``/has-features?features=fleet,sso`` in grace returns
+    ``True``. That is the whole point of the ``_at`` slot -- render the
+    would-be-locked state alongside the live grant.
+
+    Never 4xxs (missing / blank / unknown tier or all-unknown CSV -> 200
+    with ``has_features_at=false``, matching the sibling ``/has-features``
+    posture). Never 5xxs: any helper blowup collapses to
+    :func:`_has_bundle_at_fallback`.
+    """
+    try:
+        return jsonify(_has_bundle_at_body("features"))
+    except Exception as exc:
+        logger.warning("api_entitlement_has_features_at: error: %s", exc)
+        tier = (request.args.get("tier") or "").strip().lower()
+        return jsonify(
+            _has_bundle_at_fallback("features", tier, _parse_csv_arg("features"))
+        )
+
+
+@bp_entitlement.route("/api/entitlement/has-runtimes-at")
+def api_entitlement_has_runtimes_at():
+    """``GET /api/entitlement/has-runtimes-at?tier=<perspective>&runtimes=x,y,z``
+    -- runtime-axis twin of ``/api/entitlement/has-features-at``.
+
+    Same 15-key envelope with ``runtimes`` / ``has_runtimes_at`` in the
+    axis-specific slots. Runtime-alias canonicalisation
+    (``claude-code`` -> ``claude_code``) is applied per-token upstream at
+    the endpoint layer so ``?runtimes=claude-code,openclaw`` collapses to
+    the granted ``claude_code,openclaw`` -- matches the sibling
+    ``/has-runtimes`` endpoint's own upstream-canonicalise pattern.
+    Never 4xxs; never 5xxs.
+    """
+    try:
+        return jsonify(_has_bundle_at_body("runtimes"))
+    except Exception as exc:
+        logger.warning("api_entitlement_has_runtimes_at: error: %s", exc)
+        tier = (request.args.get("tier") or "").strip().lower()
+        return jsonify(
+            _has_bundle_at_fallback("runtimes", tier, _parse_csv_arg("runtimes"))
+        )
+
+
 def _missing_bundle_fallback(axis: str, tokens: list) -> dict:
     """OSS-free / never-5xx envelope for the ``/api/entitlement/missing-features``
     and ``/api/entitlement/missing-runtimes`` endpoints.

--- a/tests/test_entitlement_has_features_at_has_runtimes_at.py
+++ b/tests/test_entitlement_has_features_at_has_runtimes_at.py
@@ -1,0 +1,841 @@
+"""Tests for the plural ``has_features_at`` / ``has_runtimes_at`` hypothetical
+-perspective boolean-gate scalar helpers and their paired
+``/api/entitlement/has-features-at`` / ``/api/entitlement/has-runtimes-at``
+endpoints.
+
+Plural what-if siblings of :func:`has_feature_at` / :func:`has_runtime_at` on
+the same axis, in the same relationship :func:`has_features` /
+:func:`has_runtimes` have to :func:`has_feature` / :func:`has_runtime`. Fills
+the plural ``_at`` slot in the grant-axis boolean-gate family so a pricing
+matrix that gates on a BUNDLE (``fleet + otel_export + sso -- Available in
+Enterprise``) can bind ONE boolean per (perspective, bundle) cell off ONE URL
+each, instead of walking the singular :func:`has_feature_at` per item and AND
+-ing on the client.
+
+This file pins:
+
+1. Scalar semantics: empty / None / non-iterable bundle, unknown
+   perspective, unknown / non-string / empty item id, all-free / all-paid /
+   mixed bundle across every tier.
+2. Perspective-shaped grace-independence: ``has_features_at("oss",
+   [<paid>...])`` is ``False`` in BOTH grace and enforce (unlike the live
+   plural :func:`has_features` sibling which returns ``True`` in grace) --
+   the whole point of the ``_at`` slot is to render the would-be-locked
+   state alongside the live grant.
+3. Runtime-axis alias posture: scalar is strict (no
+   :func:`canonical_runtime` resolution -- matches sibling
+   :func:`has_runtime_at`); endpoint canonicalises per-token upstream
+   (matches sibling ``/has-runtimes`` endpoint).
+4. Endpoint envelope shape (fixed 15-key set) across every input branch.
+5. Never-4xx / never-5xx guarantees on both endpoints.
+6. Cross-consistency with the sibling
+   ``/api/entitlement/min-tier-for-features`` /
+   ``/api/entitlement/min-tier-for-runtimes`` endpoints -- same
+   ``required_tier`` for the same bundle.
+7. Cross-consistency with the singular
+   ``/api/entitlement/has-feature-at`` / ``/has-runtime-at`` endpoints on
+   the ``current_tier`` / ``perspective_tier_rank`` slots and on the AND-
+   fold of per-item ``allowed`` bits.
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+# ── Fixtures ────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    """Fresh entitlements module in OSS-free-grace mode -- matches the
+    sibling ``test_entitlement_has_feature_at_has_runtime_at.py`` fixture
+    so the plural perspective assertions here reproduce the same install
+    state the singular ``_at`` gates are pinned against."""
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def enforced(monkeypatch, tmp_path):
+    """Enforcement-on fixture: ``CLAWMETRY_ENFORCE=1`` flips
+    ``ent.grace`` off. Included to pin the perspective-shaped grace
+    -independence invariant -- the plural ``_at`` scalars return the same
+    answer under grace vs enforce for the same (perspective, bundle) pair."""
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    importlib.reload(e)
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+@pytest.fixture
+def enforced_client(enforced):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# ── Envelope shape ──────────────────────────────────────────────────────────
+
+_FEATURES_KEYS = {
+    "tier",
+    "features",
+    "unknown",
+    "kind",
+    "count",
+    "has_features_at",
+    "allowed",
+    "required_tier",
+    "required_tier_label",
+    "required_tier_rank",
+    "perspective_tier_rank",
+    "current_tier",
+    "current_tier_rank",
+    "grace",
+    "enforced",
+}
+_RUNTIMES_KEYS = {
+    "tier",
+    "runtimes",
+    "unknown",
+    "kind",
+    "count",
+    "has_runtimes_at",
+    "allowed",
+    "required_tier",
+    "required_tier_label",
+    "required_tier_rank",
+    "perspective_tier_rank",
+    "current_tier",
+    "current_tier_rank",
+    "grace",
+    "enforced",
+}
+
+
+def _get_json(client, url: str) -> dict:
+    resp = client.get(url)
+    assert resp.status_code == 200, url
+    return resp.get_json()
+
+
+# ── has_features_at scalar ────────────────────────────────────────────────
+
+
+def test_has_features_at_all_free_is_true_on_every_tier(ent):
+    """A bundle of ONLY free features is granted from every real tier
+    (the free floor is baked into ``_hypothetical_entitlement``)."""
+    free = sorted(ent.FREE_FEATURES)
+    if not free:
+        pytest.skip("no FREE_FEATURES configured")
+    for tier in ent._TIER_ORDER:
+        assert ent.has_features_at(tier, free) is True, tier
+
+
+def test_has_features_at_all_paid_is_false_on_oss(ent):
+    """OSS never statically grants any paid feature (perspective-shaped:
+    ``False`` even in grace, whereas the live sibling :func:`has_features`
+    reports ``True`` in grace for the same bundle)."""
+    paid = sorted(ent.PAID_FEATURES)
+    if not paid:
+        pytest.skip("no PAID_FEATURES configured")
+    assert ent.has_features_at("oss", paid) is False
+
+
+def test_has_features_at_all_paid_matches_per_item_and_fold(ent):
+    """The plural fold equals the per-item AND-fold of the singular
+    :func:`has_feature_at` for every tier + all-paid bundle."""
+    paid = sorted(ent.PAID_FEATURES)
+    if not paid:
+        pytest.skip("no PAID_FEATURES configured")
+    for tier in ent._TIER_ORDER:
+        expected = all(ent.has_feature_at(tier, f) for f in paid)
+        assert ent.has_features_at(tier, paid) is expected, tier
+
+
+def test_has_features_at_mixed_free_and_paid_on_oss_is_false(ent):
+    """Mixed bundle on OSS collapses to False -- the paid item denies
+    the whole fold even though the free item is granted."""
+    free = next(iter(ent.FREE_FEATURES), None)
+    paid = next(iter(ent.PAID_FEATURES), None)
+    if free is None or paid is None:
+        pytest.skip("need at least one FREE and one PAID feature")
+    assert ent.has_features_at("oss", [free, paid]) is False
+
+
+def test_has_features_at_any_unknown_is_false_in_grace(ent):
+    """Even in grace, an unknown item collapses the fold to False --
+    catches typos at the callsite before enforcement flips on."""
+    assert ent.has_features_at("pro", ["fleet", "bogus_id"]) is False
+    assert ent.has_features_at("pro", ["bogus_id"]) is False
+
+
+def test_has_features_at_empty_iterable_is_false(ent):
+    """Empty iterable collapses to False (strict callsite-typo posture) --
+    matches the plural :func:`has_features` empty-fold posture."""
+    assert ent.has_features_at("pro", []) is False
+    assert ent.has_features_at("pro", ()) is False
+    assert ent.has_features_at("pro", iter(())) is False
+
+
+def test_has_features_at_none_is_false(ent):
+    assert ent.has_features_at("pro", None) is False  # type: ignore[arg-type]
+
+
+def test_has_features_at_non_iterable_is_false(ent):
+    assert ent.has_features_at("pro", 123) is False  # type: ignore[arg-type]
+    assert ent.has_features_at("pro", object()) is False  # type: ignore[arg-type]
+
+
+def test_has_features_at_unknown_perspective_is_false(ent):
+    """Perspective not in :data:`_TIER_ORDER` -> fail-closed False."""
+    for bad in ["", " ", "mars", "pro_plus", "unknown_tier"]:
+        assert ent.has_features_at(bad, ["fleet"]) is False, bad
+
+
+def test_has_features_at_non_string_perspective_is_false(ent):
+    for bad in [None, 123, object(), []]:
+        assert ent.has_features_at(bad, ["fleet"]) is False
+
+
+def test_has_features_at_case_insensitive_perspective(ent):
+    """Whitespace / casing on the perspective normalises via
+    ``strip().lower()``."""
+    paid = next(iter(ent.PAID_FEATURES), None)
+    if paid is None:
+        pytest.skip("no PAID_FEATURES configured")
+    live = ent.has_features_at("pro", [paid])
+    assert ent.has_features_at("  PRO  ", [paid]) is live
+    assert ent.has_features_at("Pro", [paid]) is live
+
+
+def test_has_features_at_grace_independence(ent, enforced):
+    """The plural ``_at`` scalar is IDENTICAL under grace vs enforce for
+    the same (perspective, bundle) pair. Diverges from the live plural
+    :func:`has_features` which flips from True in grace to False in
+    enforce for a paid bundle."""
+    paid = sorted(ent.PAID_FEATURES)
+    if not paid:
+        pytest.skip("no PAID_FEATURES configured")
+    for tier in ent._TIER_ORDER:
+        assert ent.has_features_at(tier, paid) is enforced.has_features_at(
+            tier, paid
+        ), tier
+
+
+def test_has_features_at_never_raises_on_delegate_blowup(monkeypatch, ent):
+    """Any blowup in the per-item :func:`has_feature_at` collapses to
+    ``False`` so a pricing matrix cell keeps rendering."""
+
+    def _boom(*a, **kw):
+        raise RuntimeError("scalar blew up")
+
+    monkeypatch.setattr(ent, "has_feature_at", _boom)
+    assert ent.has_features_at("pro", ["fleet", "sso"]) is False
+
+
+# ── has_runtimes_at scalar ────────────────────────────────────────────────
+
+
+def test_has_runtimes_at_all_free_is_true_on_every_tier(ent):
+    free = sorted(ent.FREE_RUNTIMES)
+    if not free:
+        pytest.skip("no FREE_RUNTIMES configured")
+    for tier in ent._TIER_ORDER:
+        assert ent.has_runtimes_at(tier, free) is True, tier
+
+
+def test_has_runtimes_at_all_paid_is_false_on_oss(ent):
+    paid = sorted(ent.PAID_RUNTIMES)
+    if not paid:
+        pytest.skip("no PAID_RUNTIMES configured")
+    assert ent.has_runtimes_at("oss", paid) is False
+
+
+def test_has_runtimes_at_all_paid_matches_per_item_fold(ent):
+    paid = sorted(ent.PAID_RUNTIMES)
+    if not paid:
+        pytest.skip("no PAID_RUNTIMES configured")
+    for tier in ent._TIER_ORDER:
+        expected = all(ent.has_runtime_at(tier, rt) for rt in paid)
+        assert ent.has_runtimes_at(tier, paid) is expected, tier
+
+
+def test_has_runtimes_at_mixed_free_and_paid_on_oss_is_false(ent):
+    free = next(iter(ent.FREE_RUNTIMES), None)
+    paid = next(iter(ent.PAID_RUNTIMES), None)
+    if free is None or paid is None:
+        pytest.skip("need at least one FREE and one PAID runtime")
+    assert ent.has_runtimes_at("oss", [free, paid]) is False
+
+
+def test_has_runtimes_at_scalar_does_not_alias_resolve(ent):
+    """Strict alias posture mirrors the singular :func:`has_runtime_at`
+    exactly: ``"claude-code"`` is not in :data:`ALL_RUNTIMES` after
+    ``.strip().lower()``, so an alias input at scalar layer collapses
+    the fold to ``False``."""
+    if "claude_code" not in ent.ALL_RUNTIMES:
+        pytest.skip("claude_code runtime not registered")
+    assert ent.has_runtimes_at("pro", ["claude-code"]) is False
+
+
+def test_has_runtimes_at_any_unknown_is_false_in_grace(ent):
+    assert ent.has_runtimes_at("pro", ["openclaw", "bogus_rt"]) is False
+    assert ent.has_runtimes_at("pro", ["bogus_rt"]) is False
+
+
+def test_has_runtimes_at_empty_iterable_is_false(ent):
+    assert ent.has_runtimes_at("pro", []) is False
+    assert ent.has_runtimes_at("pro", ()) is False
+
+
+def test_has_runtimes_at_none_is_false(ent):
+    assert ent.has_runtimes_at("pro", None) is False  # type: ignore[arg-type]
+
+
+def test_has_runtimes_at_non_iterable_is_false(ent):
+    assert ent.has_runtimes_at("pro", 123) is False  # type: ignore[arg-type]
+
+
+def test_has_runtimes_at_unknown_perspective_is_false(ent):
+    for bad in ["", " ", "mars", "pro-plus", "unknown_tier"]:
+        assert ent.has_runtimes_at(bad, ["openclaw"]) is False, bad
+
+
+def test_has_runtimes_at_non_string_perspective_is_false(ent):
+    for bad in [None, 123, object(), []]:
+        assert ent.has_runtimes_at(bad, ["openclaw"]) is False
+
+
+def test_has_runtimes_at_grace_independence(ent, enforced):
+    paid = sorted(ent.PAID_RUNTIMES)
+    if not paid:
+        pytest.skip("no PAID_RUNTIMES configured")
+    for tier in ent._TIER_ORDER:
+        assert ent.has_runtimes_at(tier, paid) is enforced.has_runtimes_at(
+            tier, paid
+        ), tier
+
+
+def test_has_runtimes_at_never_raises_on_delegate_blowup(monkeypatch, ent):
+    def _boom(*a, **kw):
+        raise RuntimeError("scalar blew up")
+
+    monkeypatch.setattr(ent, "has_runtime_at", _boom)
+    assert ent.has_runtimes_at("pro", ["openclaw"]) is False
+
+
+# ── /api/entitlement/has-features-at endpoint ────────────────────────────
+
+
+def test_endpoint_has_features_at_shape_default(client):
+    """Missing all args -> 200 with 15-key envelope and fail-closed False."""
+    body = _get_json(client, "/api/entitlement/has-features-at")
+    assert set(body.keys()) == _FEATURES_KEYS
+    assert body["tier"] == ""
+    assert body["features"] == []
+    assert body["unknown"] == []
+    assert body["kind"] == "features"
+    assert body["count"] == 0
+    assert body["has_features_at"] is False
+    assert body["allowed"] is False
+    assert body["required_tier"] is None
+    assert body["required_tier_rank"] == -1
+    assert body["perspective_tier_rank"] == -1
+    assert body["current_tier"] == "oss"
+    assert body["current_tier_rank"] == 0
+
+
+def test_endpoint_has_features_at_all_free_on_every_tier(client, ent):
+    free = sorted(ent.FREE_FEATURES)
+    if not free:
+        pytest.skip("no FREE_FEATURES configured")
+    csv = ",".join(free)
+    for tier in ("oss", "cloud_starter", "pro", "cloud_pro", "enterprise"):
+        if tier not in ent._TIER_ORDER:
+            continue
+        body = _get_json(
+            client,
+            f"/api/entitlement/has-features-at?tier={tier}&features={csv}",
+        )
+        assert body["tier"] == tier
+        assert body["has_features_at"] is True, tier
+        assert body["allowed"] is True
+        assert body["count"] == len(free)
+        assert body["unknown"] == []
+
+
+def test_endpoint_has_features_at_paid_on_oss_is_denied(client, ent):
+    """The whole point of the plural ``_at`` slot: OSS reports
+    ``allowed=false`` for a paid bundle EVEN IN GRACE, unlike the live
+    ``/has-features`` sibling which returns ``true`` in grace on the
+    same bundle."""
+    paid = sorted(ent.PAID_FEATURES)
+    if not paid:
+        pytest.skip("no PAID_FEATURES configured")
+    csv = ",".join(paid)
+    body = _get_json(
+        client, f"/api/entitlement/has-features-at?tier=oss&features={csv}"
+    )
+    assert body["has_features_at"] is False
+    assert body["allowed"] is False
+    assert body["perspective_tier_rank"] == 0
+    # Live sibling grace divergence: same bundle on the live endpoint reports
+    # True in grace via the resolver's grace pass-through.
+    live = _get_json(client, f"/api/entitlement/has-features?features={csv}")
+    assert live["has_features"] is True
+    assert body["current_tier"] == live["current_tier"]
+    assert body["current_tier_rank"] == live["current_tier_rank"]
+
+
+def test_endpoint_has_features_at_unknown_token_collapses(client):
+    """Unknown token echoes into ``unknown`` and collapses the bundle
+    to ``has_features_at=False`` -- matches the sibling
+    :func:`_has_bundle_body` typo posture."""
+    body = _get_json(
+        client,
+        "/api/entitlement/has-features-at?tier=pro&features=fleet,bogus_id",
+    )
+    assert set(body.keys()) == _FEATURES_KEYS
+    assert body["has_features_at"] is False
+    assert "bogus_id" in body["unknown"]
+
+
+def test_endpoint_has_features_at_unknown_tier_never_4xx(client):
+    body = _get_json(
+        client,
+        "/api/entitlement/has-features-at?tier=mars&features=fleet",
+    )
+    assert set(body.keys()) == _FEATURES_KEYS
+    assert body["tier"] == "mars"
+    assert body["has_features_at"] is False
+    assert body["perspective_tier_rank"] == -1
+
+
+def test_endpoint_has_features_at_case_insensitive_tier(client, ent):
+    paid = next(iter(ent.PAID_FEATURES), None)
+    if paid is None:
+        pytest.skip("no PAID_FEATURES configured")
+    canonical = _get_json(
+        client, f"/api/entitlement/has-features-at?tier=pro&features={paid}"
+    )
+    upper = _get_json(
+        client, f"/api/entitlement/has-features-at?tier=%20PRO%20&features={paid}"
+    )
+    assert upper["tier"] == "pro"
+    assert upper["has_features_at"] is canonical["has_features_at"]
+
+
+def test_endpoint_has_features_at_required_tier_parity(client, ent):
+    """``required_tier`` byte-equals the sibling
+    ``/api/entitlement/min-tier-for-features`` answer for the same
+    bundle -- a UI wiring both URLs into the same paywall matrix
+    cannot see inconsistent tier state."""
+    paid = sorted(ent.PAID_FEATURES)
+    if not paid:
+        pytest.skip("no PAID_FEATURES configured")
+    csv = ",".join(paid)
+    body = _get_json(
+        client, f"/api/entitlement/has-features-at?tier=pro&features={csv}"
+    )
+    min_body = _get_json(
+        client, f"/api/entitlement/min-tier-for-features?features={csv}"
+    )
+    assert body["required_tier"] == min_body["required_tier"]
+
+
+def test_endpoint_has_features_at_never_5xx_on_resolver_blowup(monkeypatch, client):
+    from clawmetry import entitlements as _ent
+
+    def _boom(*a, **kw):
+        raise RuntimeError("resolver blew up")
+
+    monkeypatch.setattr(_ent, "get_entitlement", _boom)
+    resp = client.get(
+        "/api/entitlement/has-features-at?tier=pro&features=fleet"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert set(body.keys()) == _FEATURES_KEYS
+    assert body["has_features_at"] is False
+    assert body["current_tier"] == "oss"
+
+
+def test_endpoint_has_features_at_never_5xx_on_scalar_blowup(monkeypatch, client):
+    from clawmetry import entitlements as _ent
+
+    def _boom(*a, **kw):
+        raise RuntimeError("scalar blew up")
+
+    monkeypatch.setattr(_ent, "has_features_at", _boom)
+    resp = client.get(
+        "/api/entitlement/has-features-at?tier=pro&features=fleet"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert set(body.keys()) == _FEATURES_KEYS
+    assert body["has_features_at"] is False
+
+
+# ── /api/entitlement/has-runtimes-at endpoint ────────────────────────────
+
+
+def test_endpoint_has_runtimes_at_shape_default(client):
+    body = _get_json(client, "/api/entitlement/has-runtimes-at")
+    assert set(body.keys()) == _RUNTIMES_KEYS
+    assert body["tier"] == ""
+    assert body["runtimes"] == []
+    assert body["kind"] == "runtimes"
+    assert body["has_runtimes_at"] is False
+    assert body["perspective_tier_rank"] == -1
+
+
+def test_endpoint_has_runtimes_at_all_free_on_every_tier(client, ent):
+    free = sorted(ent.FREE_RUNTIMES)
+    if not free:
+        pytest.skip("no FREE_RUNTIMES configured")
+    csv = ",".join(free)
+    for tier in ("oss", "cloud_starter", "pro", "cloud_pro", "enterprise"):
+        if tier not in ent._TIER_ORDER:
+            continue
+        body = _get_json(
+            client,
+            f"/api/entitlement/has-runtimes-at?tier={tier}&runtimes={csv}",
+        )
+        assert body["has_runtimes_at"] is True, tier
+
+
+def test_endpoint_has_runtimes_at_paid_on_oss_is_denied(client, ent):
+    paid = sorted(ent.PAID_RUNTIMES)
+    if not paid:
+        pytest.skip("no PAID_RUNTIMES configured")
+    csv = ",".join(paid)
+    body = _get_json(
+        client, f"/api/entitlement/has-runtimes-at?tier=oss&runtimes={csv}"
+    )
+    assert body["has_runtimes_at"] is False
+    assert body["perspective_tier_rank"] == 0
+
+
+def test_endpoint_has_runtimes_at_alias_canonicalises_upstream(client, ent):
+    """Alias input at URL level collapses per-token to the canonical form
+    BEFORE delegating to the strict scalar. Matches the sibling
+    ``/has-runtimes`` endpoint's own upstream canonicalise pattern."""
+    if "claude_code" not in ent.ALL_RUNTIMES:
+        pytest.skip("claude_code runtime not registered")
+    body = _get_json(
+        client,
+        "/api/entitlement/has-runtimes-at?tier=pro&runtimes=claude-code,openclaw",
+    )
+    # Canonicalised into the known list.
+    assert "claude_code" in body["runtimes"]
+    assert "openclaw" in body["runtimes"]
+    assert body["unknown"] == []
+    # And Pro grants claude_code (all-known bundle on granting tier).
+    assert body["has_runtimes_at"] is True
+
+
+def test_endpoint_has_runtimes_at_unknown_token_collapses(client):
+    body = _get_json(
+        client,
+        "/api/entitlement/has-runtimes-at?tier=pro&runtimes=openclaw,bogus_rt",
+    )
+    assert set(body.keys()) == _RUNTIMES_KEYS
+    assert body["has_runtimes_at"] is False
+    assert "bogus_rt" in body["unknown"]
+
+
+def test_endpoint_has_runtimes_at_unknown_tier_never_4xx(client):
+    body = _get_json(
+        client,
+        "/api/entitlement/has-runtimes-at?tier=mars&runtimes=openclaw",
+    )
+    assert set(body.keys()) == _RUNTIMES_KEYS
+    assert body["has_runtimes_at"] is False
+
+
+def test_endpoint_has_runtimes_at_required_tier_parity(client, ent):
+    paid = sorted(ent.PAID_RUNTIMES)
+    if not paid:
+        pytest.skip("no PAID_RUNTIMES configured")
+    csv = ",".join(paid)
+    body = _get_json(
+        client, f"/api/entitlement/has-runtimes-at?tier=pro&runtimes={csv}"
+    )
+    min_body = _get_json(
+        client, f"/api/entitlement/min-tier-for-runtimes?runtimes={csv}"
+    )
+    assert body["required_tier"] == min_body["required_tier"]
+
+
+def test_endpoint_has_runtimes_at_current_tier_parity_with_live(client):
+    """Shares the live resolver context slots with the sibling live
+    ``/has-runtimes`` endpoint."""
+    at_body = _get_json(
+        client,
+        "/api/entitlement/has-runtimes-at?tier=oss&runtimes=openclaw",
+    )
+    live = _get_json(
+        client, "/api/entitlement/has-runtimes?runtimes=openclaw"
+    )
+    for k in ("current_tier", "current_tier_rank"):
+        assert at_body[k] == live[k], k
+
+
+def test_endpoint_has_runtimes_at_never_5xx_on_resolver_blowup(monkeypatch, client):
+    from clawmetry import entitlements as _ent
+
+    def _boom(*a, **kw):
+        raise RuntimeError("resolver blew up")
+
+    monkeypatch.setattr(_ent, "get_entitlement", _boom)
+    resp = client.get(
+        "/api/entitlement/has-runtimes-at?tier=pro&runtimes=openclaw"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert set(body.keys()) == _RUNTIMES_KEYS
+    assert body["has_runtimes_at"] is False
+
+
+def test_endpoint_has_runtimes_at_never_5xx_on_scalar_blowup(monkeypatch, client):
+    from clawmetry import entitlements as _ent
+
+    def _boom(*a, **kw):
+        raise RuntimeError("scalar blew up")
+
+    monkeypatch.setattr(_ent, "has_runtimes_at", _boom)
+    resp = client.get(
+        "/api/entitlement/has-runtimes-at?tier=pro&runtimes=openclaw"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert set(body.keys()) == _RUNTIMES_KEYS
+    assert body["has_runtimes_at"] is False
+
+
+# ── Scalar-vs-endpoint parity ─────────────────────────────────────────────
+
+
+def test_endpoint_has_features_at_scalar_vs_endpoint_parity(client, ent):
+    paid = sorted(ent.PAID_FEATURES)
+    if not paid:
+        pytest.skip("no PAID_FEATURES configured")
+    csv = ",".join(paid[:3])
+    subset = paid[:3]
+    for tier in ("oss", "cloud_starter", "pro", "cloud_pro", "enterprise"):
+        if tier not in ent._TIER_ORDER:
+            continue
+        body = _get_json(
+            client,
+            f"/api/entitlement/has-features-at?tier={tier}&features={csv}",
+        )
+        assert body["has_features_at"] is ent.has_features_at(tier, subset), tier
+
+
+def test_endpoint_has_runtimes_at_scalar_vs_endpoint_parity(client, ent):
+    paid = sorted(ent.PAID_RUNTIMES)
+    if not paid:
+        pytest.skip("no PAID_RUNTIMES configured")
+    csv = ",".join(paid[:3])
+    subset = paid[:3]
+    for tier in ("oss", "cloud_starter", "pro", "cloud_pro", "enterprise"):
+        if tier not in ent._TIER_ORDER:
+            continue
+        body = _get_json(
+            client,
+            f"/api/entitlement/has-runtimes-at?tier={tier}&runtimes={csv}",
+        )
+        assert body["has_runtimes_at"] is ent.has_runtimes_at(tier, subset), tier
+
+
+# ── Envelope stability across many input branches ────────────────────────
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "/api/entitlement/has-features-at",
+        "/api/entitlement/has-features-at?tier=",
+        "/api/entitlement/has-features-at?features=",
+        "/api/entitlement/has-features-at?tier=&features=",
+        "/api/entitlement/has-features-at?tier=pro",
+        "/api/entitlement/has-features-at?features=fleet",
+        "/api/entitlement/has-features-at?tier=pro&features=fleet",
+        "/api/entitlement/has-features-at?tier=oss&features=fleet",
+        "/api/entitlement/has-features-at?tier=pro&features=fleet,sso",
+        "/api/entitlement/has-features-at?tier=pro&features=bogus",
+        "/api/entitlement/has-features-at?tier=mars&features=fleet",
+        "/api/entitlement/has-features-at?tier=%20PRO%20&features=%20FLEET%20",
+    ],
+)
+def test_endpoint_has_features_at_envelope_stable(client, url):
+    body = _get_json(client, url)
+    assert set(body.keys()) == _FEATURES_KEYS
+    assert isinstance(body["tier"], str)
+    assert isinstance(body["features"], list)
+    assert isinstance(body["unknown"], list)
+    assert isinstance(body["kind"], str)
+    assert isinstance(body["count"], int)
+    assert isinstance(body["has_features_at"], bool)
+    assert isinstance(body["allowed"], bool)
+    assert body["has_features_at"] == body["allowed"]
+    assert isinstance(body["perspective_tier_rank"], int)
+    assert isinstance(body["required_tier_rank"], int)
+    assert isinstance(body["current_tier"], str)
+    assert isinstance(body["current_tier_rank"], int)
+    assert isinstance(body["grace"], bool)
+    assert isinstance(body["enforced"], bool)
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "/api/entitlement/has-runtimes-at",
+        "/api/entitlement/has-runtimes-at?tier=",
+        "/api/entitlement/has-runtimes-at?runtimes=",
+        "/api/entitlement/has-runtimes-at?tier=&runtimes=",
+        "/api/entitlement/has-runtimes-at?tier=pro",
+        "/api/entitlement/has-runtimes-at?runtimes=openclaw",
+        "/api/entitlement/has-runtimes-at?tier=pro&runtimes=openclaw",
+        "/api/entitlement/has-runtimes-at?tier=oss&runtimes=claude_code",
+        "/api/entitlement/has-runtimes-at?tier=pro&runtimes=openclaw,claude_code",
+        "/api/entitlement/has-runtimes-at?tier=pro&runtimes=claude-code",
+        "/api/entitlement/has-runtimes-at?tier=pro&runtimes=bogus_rt",
+        "/api/entitlement/has-runtimes-at?tier=mars&runtimes=openclaw",
+        "/api/entitlement/has-runtimes-at?tier=%20PRO%20&runtimes=%20OPENCLAW%20",
+    ],
+)
+def test_endpoint_has_runtimes_at_envelope_stable(client, url):
+    body = _get_json(client, url)
+    assert set(body.keys()) == _RUNTIMES_KEYS
+    assert isinstance(body["tier"], str)
+    assert isinstance(body["runtimes"], list)
+    assert isinstance(body["unknown"], list)
+    assert isinstance(body["has_runtimes_at"], bool)
+    assert isinstance(body["allowed"], bool)
+    assert body["has_runtimes_at"] == body["allowed"]
+    assert isinstance(body["perspective_tier_rank"], int)
+
+
+# ── Enforced-mode grace-independence at endpoint level ────────────────────
+
+
+def test_endpoint_has_features_at_grace_independence(client, enforced_client, ent):
+    """Endpoint answers for the SAME (perspective, bundle) pair are
+    identical under grace vs enforce -- perspective-shaped by design.
+    Only the ``grace`` / ``enforced`` envelope slots differ."""
+    paid = sorted(ent.PAID_FEATURES)[:2]
+    if not paid:
+        pytest.skip("no PAID_FEATURES configured")
+    csv = ",".join(paid)
+    for tier in ("oss", "cloud_starter", "pro", "cloud_pro", "enterprise"):
+        if tier not in ent._TIER_ORDER:
+            continue
+        grace_body = _get_json(
+            client,
+            f"/api/entitlement/has-features-at?tier={tier}&features={csv}",
+        )
+        enf_body = _get_json(
+            enforced_client,
+            f"/api/entitlement/has-features-at?tier={tier}&features={csv}",
+        )
+        assert grace_body["has_features_at"] == enf_body["has_features_at"], tier
+        assert grace_body["required_tier"] == enf_body["required_tier"]
+        assert grace_body["required_tier_rank"] == enf_body["required_tier_rank"]
+        assert (
+            grace_body["perspective_tier_rank"] == enf_body["perspective_tier_rank"]
+        )
+
+
+def test_endpoint_has_runtimes_at_grace_independence(client, enforced_client, ent):
+    paid = sorted(ent.PAID_RUNTIMES)[:2]
+    if not paid:
+        pytest.skip("no PAID_RUNTIMES configured")
+    csv = ",".join(paid)
+    for tier in ("oss", "cloud_starter", "pro", "cloud_pro", "enterprise"):
+        if tier not in ent._TIER_ORDER:
+            continue
+        grace_body = _get_json(
+            client,
+            f"/api/entitlement/has-runtimes-at?tier={tier}&runtimes={csv}",
+        )
+        enf_body = _get_json(
+            enforced_client,
+            f"/api/entitlement/has-runtimes-at?tier={tier}&runtimes={csv}",
+        )
+        assert grace_body["has_runtimes_at"] == enf_body["has_runtimes_at"], tier
+
+
+# ── Cross-consistency with singular /has-feature-at / /has-runtime-at ─────
+
+
+def test_endpoint_has_features_at_matches_singular_and_fold(client, ent):
+    """Plural URL's ``allowed`` bit equals the per-item AND-fold of the
+    singular ``/has-feature-at`` ``allowed`` bits for the same bundle."""
+    paid = sorted(ent.PAID_FEATURES)[:3]
+    if not paid:
+        pytest.skip("no PAID_FEATURES configured")
+    csv = ",".join(paid)
+    for tier in ("oss", "cloud_starter", "pro", "cloud_pro", "enterprise"):
+        if tier not in ent._TIER_ORDER:
+            continue
+        plural = _get_json(
+            client,
+            f"/api/entitlement/has-features-at?tier={tier}&features={csv}",
+        )
+        singular_bits = []
+        for f in paid:
+            s = _get_json(
+                client,
+                f"/api/entitlement/has-feature-at?tier={tier}&feature={f}",
+            )
+            singular_bits.append(bool(s["has_feature_at"]))
+        assert plural["has_features_at"] is all(singular_bits), tier
+
+
+def test_endpoint_has_runtimes_at_matches_singular_and_fold(client, ent):
+    paid = sorted(ent.PAID_RUNTIMES)[:3]
+    if not paid:
+        pytest.skip("no PAID_RUNTIMES configured")
+    csv = ",".join(paid)
+    for tier in ("oss", "cloud_starter", "pro", "cloud_pro", "enterprise"):
+        if tier not in ent._TIER_ORDER:
+            continue
+        plural = _get_json(
+            client,
+            f"/api/entitlement/has-runtimes-at?tier={tier}&runtimes={csv}",
+        )
+        singular_bits = []
+        for rt in paid:
+            s = _get_json(
+                client,
+                f"/api/entitlement/has-runtime-at?tier={tier}&runtime={rt}",
+            )
+            singular_bits.append(bool(s["has_runtime_at"]))
+        assert plural["has_runtimes_at"] is all(singular_bits), tier


### PR DESCRIPTION
## What

Fills the plural `_at` slot in the grant-axis boolean-gate family:

**Scalars (`clawmetry/entitlements.py`)**
- `has_features_at(perspective_tier, features) -> bool`
- `has_runtimes_at(perspective_tier, runtimes) -> bool`

**Endpoints (`routes/entitlement.py`)**
- `GET /api/entitlement/has-features-at?tier=<perspective>&features=a,b,c`
- `GET /api/entitlement/has-runtimes-at?tier=<perspective>&runtimes=x,y,z`

Plural what-if siblings of `has_feature_at` / `has_runtime_at` in the same
relationship the existing `has_features` / `has_runtimes` have to
`has_feature` / `has_runtime`. So a pricing matrix that gates on a BUNDLE
(`fleet + otel_export + sso`) can bind ONE boolean per (perspective, bundle)
cell off ONE URL each, instead of walking the singular `has_feature_at` per
item and AND-ing on the client.

## Semantics

Both scalars delegate per-item to the existing singular `_at` helpers, which
are already backed by `_hypothetical_entitlement(grace=off)`. So the plural
answer is **grace-independent by construction**:

- `has_features_at("oss", ["fleet"])` -> `False` in both grace AND enforce
  (whereas the live `has_features(["fleet"])` returns `True` in grace).
- Fold rule mirrors `has_features` / `has_runtimes` exactly: `True` iff every
  item is granted; empty / None / non-iterable bundle -> `False`; any unknown
  / non-string item collapses the fold to `False` (typo catches at callsite).
- Perspective validated once on the outer helper against `_TIER_ORDER`;
  unknown / empty / non-string perspective -> `False`. Never raise.

Endpoint envelope (15 keys, byte-stable across every input branch): adds
`tier` + `perspective_tier_rank` on top of the sibling plural non-`_at`
shape, matching the singular `_at` envelope pattern (skips `upgrade_required`
— a caller compares `required_tier_rank > perspective_tier_rank` themselves).
Runtime alias canonicalisation happens per-token upstream at the endpoint
layer (`claude-code` → `claude_code`), matching `/has-runtimes` exactly.
Missing / blank / all-unknown CSV or unknown tier → 200 with
`has_<axis>_at=false`; resolver / scalar blowup collapses to the OSS-free
fallback. **Never 4xx, never 5xx.**

## Rollout

Perspective-shaped by design so the `_at` answers do not change with the
resolver's grace pass-through. Wiring these into a pricing matrix today
changes **no current behavior** — this is a GRACE-only fire that adds
surface area without touching any enforcement path.

## Tests

76 new hermetic tests in `tests/test_entitlement_has_features_at_has_runtimes_at.py`:

- Scalar semantics: empty / None / non-iterable / unknown / mixed bundles
  across every tier, including grace-independence invariant (grace vs
  enforce yields the same `has_<axis>_at` for the same perspective+bundle).
- Endpoint envelope shape: 15 keys, byte-stable across 12 parametrised URLs
  per axis; never-4xx / never-5xx via monkeypatched resolver and scalar
  blowup.
- Cross-consistency: `required_tier` byte-parity with `/min-tier-for-<axis>`,
  `current_tier` byte-parity with the live `/has-<axis>` sibling, and the
  plural `allowed` bit equals the per-item AND-fold of the singular
  `/has-<axis>-at` sibling.
- Alias canonicalisation upstream at endpoint layer with strict-scalar
  pass-through.

Full new suite: **76 passed**. Sibling suites (`has_feature_has_runtime`,
`has_feature_at_has_runtime_at`, `has_features_has_runtimes`): **187 passed**
after the change.

## Local operator verification checklist

Only the operator can verify against the live daemon / snapshot / browser —
please run:

1. Copy the three changed files into your live install:
   ```
   cp clawmetry/entitlements.py ~/.clawmetry/lib/python*/site-packages/clawmetry/
   cp routes/entitlement.py     ~/.clawmetry/lib/python*/site-packages/routes/
   ```
2. Clear caches:
   `find ~/.clawmetry/lib -name __pycache__ -exec rm -rf {} +`
3. Restart the daemon:
   `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
4. Hit the new endpoints and confirm 200 + expected boolean:
   ```
   curl -s 'http://localhost:8900/api/entitlement/has-features-at?tier=pro&features=fleet' | jq
   curl -s 'http://localhost:8900/api/entitlement/has-runtimes-at?tier=oss&runtimes=claude_code' | jq
   ```
5. Decrypt the live snapshot and browser-check that no pricing surface
   regresses (no UI is wired to these URLs yet — they are net-new).
6. Confirm `/api/entitlement` still returns the OSS-free grace envelope
   unchanged (this fire adds NO behavior gate).


---
_Generated by [Claude Code](https://claude.ai/code/session_01Fzcdqb7gToA4qifAoMGZUb)_