### PR TITLE
fix(health): surface trusted-proxy device pairing data in /api/system-health

### DIFF
--- a/routes/health.py
+++ b/routes/health.py
@@ -1317,6 +1317,18 @@ def api_system_health():
     else:
         top_source = "gateway"
 
+    # Trusted-proxy device pairing (#4431): surface auto-approved vs
+    # manually-approved device grants from the gateway in the health view.
+    # _gateway_trusted_proxy_devices() reads gateway.status (+ fallback
+    # gateway.devices RPC); returns {} when the gateway is down or the
+    # feature hasn't shipped yet — never raises.
+    trusted_devices: dict = {}
+    try:
+        from clawmetry.adapters.openclaw import _gateway_trusted_proxy_devices
+        trusted_devices = _gateway_trusted_proxy_devices()
+    except Exception:
+        pass
+
     return jsonify(
         {
             "services": services,
@@ -1337,6 +1349,7 @@ def api_system_health():
             "sandbox": _d._detect_sandbox_metadata(),
             "inference": _d._detect_inference_metadata(),
             "security": _d._detect_security_metadata(),
+            "trusted_devices": trusted_devices,
             "service_status": service_status,
             "daemon": daemon_health,
             "daemon_error_rate_per_min": round(


### PR DESCRIPTION
## Summary

- `_gateway_trusted_proxy_devices()` in `clawmetry/adapters/openclaw.py` already reads auto-approved vs manually-approved device grants from the gateway RPC, but the result lived only in `DetectResult.meta` — never stored in DuckDB or returned by any route
- Add a `trusted_devices` key to `/api/system-health` by calling the existing adapter function from the route (same import pattern used for `_openclaw_doctor_findings` at health.py:3623)
- Returns `{}` defensively when the gateway is down or the trusted-proxy pairing feature hasn't shipped yet — never raises

## Test plan

- [ ] `make test-api` passes (142 passed, 6 skipped locally)
- [ ] `curl /api/system-health | jq .trusted_devices` returns `{}` on installs without a gateway; returns `{gatewayTrustedProxyDevices: [...], gatewayTrustedProxyDeviceSummary: {auto: N, manual: N}}` when the gateway exposes paired devices

Closes #4431

---
_Generated by [Claude Code](https://claude.ai/code/session_01F4YQZPQNTrwDoybHA5Yhxr)_