### PR TITLE
fix: distinguish offline vs busy-sync in Brain window give-up message

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -7499,7 +7499,7 @@ async function loadBrainPage(silent) {
         }, _bhTry < 12 ? Math.max(2000, (data.eta_sec || 3) * 1000) : 10000);
       } else {
         var sEl2 = document.getElementById('brain-stream');
-        if (sEl2) sEl2.innerHTML = '<div style="color:var(--text-muted);padding:20px;font-size:13px;">' + t('brain.window_node_offline', null, 'Could not reach your node for this window. Check that the machine is online, then retry.') + '</div>';
+        if (sEl2) sEl2.innerHTML = ‘<div style="color:var(--text-muted);padding:20px;font-size:13px;">’ + t(‘brain.window_node_offline’, null, ‘Could not fetch this window from your node. The node may be offline, or was mid-sync when the request was made — if it is online, retry in a moment.’) + ‘</div>’;
         if (stEl) stEl.textContent = '';
       }
       return;

--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -7499,7 +7499,7 @@ async function loadBrainPage(silent) {
         }, _bhTry < 12 ? Math.max(2000, (data.eta_sec || 3) * 1000) : 10000);
       } else {
         var sEl2 = document.getElementById('brain-stream');
-        if (sEl2) sEl2.innerHTML = ‘<div style="color:var(--text-muted);padding:20px;font-size:13px;">’ + t(‘brain.window_node_offline’, null, ‘Could not fetch this window from your node. The node may be offline, or was mid-sync when the request was made — if it is online, retry in a moment.’) + ‘</div>’;
+        if (sEl2) sEl2.innerHTML = '<div style="color:var(--text-muted);padding:20px;font-size:13px;">' + t('brain.window_node_offline', null, 'Could not fetch this window from your node. The node may be offline, or was mid-sync when the request was made — if it is online, retry in a moment.') + '</div>';
         if (stEl) stEl.textContent = '';
       }
       return;


### PR DESCRIPTION
Closes #4285

## What

One-line copy fix in `clawmetry/static/js/app.js`.

The terminal give-up message shown after the ~5 min relay-pending poll budget exhausts still said:

> "Could not reach your node for this window. Check that the machine is online, then retry."

This conflates two distinct root causes — node offline vs node mid-backfill — which the 2026-07-30 RCA (#4285) explicitly flags as a lesson: *"the give-up message must distinguish 'node offline' from 'node busy'"*. The interim polling banner already upgrades to "Your node is busy syncing — still fetching this window…" after 12 retries, but the terminal message reverted to the old online-only diagnosis.

**New message:**
> "Could not fetch this window from your node. The node may be offline, or was mid-sync when the request was made — if it is online, retry in a moment."

## Why

- The daemon fix (`_ingest_keepalive_heartbeat`) and the extended poll budget (~5 min) from the RCA are already in the codebase.
- This closes the last documented gap: the give-up copy.

## Test plan

- Trigger a Brain time-window fetch while the sync daemon is offline → confirm new message appears after retries exhaust.
- Confirm no JS syntax errors (no unescaped apostrophes; change uses "it is" not "it's").

---
_Generated by [Claude Code](https://claude.ai/code/session_013tUTTduso6Efh3begKMAZn)_