### PR TITLE
feat(entitlement): has_node_count_batch + /api/entitlement/has-node-count-batch (per-value capacity-axis boolean-gate batch)

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -5989,6 +5989,121 @@ def has_node_count_at(perspective_tier: str, count) -> bool:
         return False
 
 
+def has_node_count_batch(counts) -> list[dict]:
+    """Per-value boolean-gate rows on the ``nodes`` capacity axis in ONE
+    round-trip. Batch sibling of :func:`has_node_count` and node-axis twin
+    of the not-yet-existing ``has_channel_count_batch`` /
+    ``has_retention_window_batch`` scalars.
+
+    Where :func:`has_node_count` answers "does the CURRENT install admit
+    ``count``?" as ONE boolean and :func:`min_tier_for_node_count_batch`
+    answers "cheapest tier that would admit each count?" as a list of
+    reverse-lookup rows, this scalar folds the two together: for every
+    supplied count it emits ONE row carrying both the live boolean
+    ``has`` gate (via :meth:`Entitlement.allows_node_count` on the
+    resolved entitlement) and the reverse-lookup ``required_tier``
+    answer. A fleet paywall matrix ("show me each requested node count
+    with its live grant AND the cheapest tier that would unlock it")
+    renders off ONE URL instead of ``N`` calls to
+    ``/api/entitlement/has-node-count?count=<N>``.
+
+    Row shape (byte-parity with :func:`_has_row` rows produced by
+    :func:`has_batch` on the ``"nodes"`` axis, so a UI already wired for
+    ``has_batch`` rows can rebind to this batch without reshaping)::
+
+        {
+          "key":                "<normalised int as str>",
+          "kind":               "nodes",
+          "has":                <bool>,
+          "unknown":            <bool>,   # True iff non-int input
+          "required_tier":      "<tier id>" | None,
+          "required_tier_label":"<label>"  | None,
+          "required_tier_rank": <int>,     # -1 when required_tier None
+        }
+
+    Delegates per-row to :func:`_has_row` so the boolean gate + reverse-
+    lookup answer stay byte-parity with the singular :func:`has_node_count`
+    + :func:`min_tier_for_node_count` pair and with the ``nodes`` axis
+    row emitted by :func:`has_batch`. That single delegation point means
+    any future contract change to the ``nodes`` row shape (e.g. adding a
+    ``label`` conjugation) lands in ONE place.
+
+    Contract:
+
+    * ``counts`` is any iterable. ``None`` -> ``[]``. Non-iterable ->
+      ``[]`` (mirrors :func:`min_tier_for_node_count_batch`).
+    * Per-value dedup by ``str(int(raw))`` when parseable, else
+      ``str(raw)``. First-seen order preserved (matches
+      :func:`min_tier_for_node_count_batch`).
+    * Non-int items surface as one row with ``unknown=True`` /
+      ``has=False`` (strict callsite-typo fail-closed posture matching
+      :func:`has_node_count` and :func:`_has_row`). A caller that passes
+      ``["five"]`` here has a bug -- fail-closed instead of silently
+      granting.
+    * ``count <= 0`` -- ``has=True`` (trivially satisfied by the free
+      floor via :meth:`Entitlement.allows_node_count`'s zero contract);
+      ``required_tier="oss"`` per :func:`min_tier_for_node_count`.
+    * Positive int -- ``has`` reflects the resolver's live grant
+      (grace-passthrough while ``ent.grace`` is ``True``, hard cap
+      thereafter); ``required_tier`` is the cheapest tier admitting
+      ``count`` per :func:`min_tier_for_node_count`.
+
+    Grace vs enforce: while ``ent.grace`` is ``True`` (the current
+    rollout state) every KNOWN row reports ``has=True``; unknown rows
+    still fail-closed to ``has=False`` (the typo-catches-at-callsite
+    contract). Post-enforcement each row reflects the underlying
+    :meth:`Entitlement.allows_node_count` answer.
+
+    Never raises: any resolver / row-shape failure short-circuits to the
+    fail-closed row shape so the paywall matrix keeps rendering.
+    """
+    try:
+        if counts is None:
+            return []
+        items = list(counts)
+    except TypeError:
+        return []
+    try:
+        ent = get_entitlement()
+    except Exception as exc:
+        logger.warning(
+            "entitlements: has_node_count_batch falling back to grace: %s", exc
+        )
+        ent = _oss_free()
+    out: list[dict] = []
+    seen: set[str] = set()
+    for raw in items:
+        try:
+            n = int(raw)
+            key = str(n)
+            passthrough = n
+        except (TypeError, ValueError):
+            key = str(raw)
+            passthrough = raw
+        if key in seen:
+            continue
+        seen.add(key)
+        try:
+            row = _has_row(ent, passthrough, "nodes")
+        except Exception as exc:
+            logger.warning(
+                "entitlements: has_node_count_batch row(%r) failed: %s",
+                raw,
+                exc,
+            )
+            row = {
+                "key": key,
+                "kind": "nodes",
+                "has": False,
+                "unknown": True,
+                "required_tier": None,
+                "required_tier_label": None,
+                "required_tier_rank": -1,
+            }
+        out.append(row)
+    return out
+
+
 def has_features(features) -> bool:
     """Boolean-gate scalar: does the CURRENT install allow **all** ``features``?
 

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -4623,6 +4623,175 @@ def api_entitlement_has_node_count_at():
         return jsonify(_has_node_count_at_fallback(tier, count_raw))
 
 
+def _has_node_count_batch_row_to_body(
+    row: dict, count_raw: str, cur_rank: int
+) -> dict:
+    """Translate a :func:`has_node_count_batch` scalar row into the endpoint
+    body row shape.
+
+    Rekeys ``has`` -> ``has_node_count`` / ``allowed`` (matches the
+    singular ``/api/entitlement/has-node-count`` body), replaces the
+    normalised-str ``key`` with an int ``count`` (or ``null`` on non-int
+    input) plus the caller's raw ``count_raw`` echo (matches the
+    singular endpoint's ``count`` / ``count_raw`` pair), and layers a
+    conjugated human ``label`` ("1 node" / "5 nodes"; matches
+    :func:`_capacity_batch_row_to_body`) plus a per-row
+    ``upgrade_required`` bit computed against the shared ``cur_rank`` so
+    a paywall matrix tile can bind it directly without a second lookup.
+
+    Never raises: missing keys / bad rows surface as the all-``None``
+    row shape (``count=null``, ``has_node_count=false``, ``allowed=false``,
+    ``required_tier=null``, ``upgrade_required=false``) so the batch keeps
+    building.
+    """
+    try:
+        n = int(row.get("key"))
+        count: int | None = n
+        label = f"{n} node" if n == 1 else f"{n} nodes"
+    except (TypeError, ValueError):
+        count = None
+        label = None
+    req_rank = row.get("required_tier_rank")
+    if req_rank is None:
+        req_rank = -1
+    has_flag = bool(row.get("has"))
+    required = row.get("required_tier")
+    return {
+        "count": count,
+        "count_raw": count_raw,
+        "kind": "node_count",
+        "label": label,
+        "has_node_count": has_flag,
+        "allowed": has_flag,
+        "unknown": bool(row.get("unknown")),
+        "required_tier": required,
+        "required_tier_label": row.get("required_tier_label"),
+        "required_tier_rank": req_rank,
+        "upgrade_required": bool(required) and req_rank > cur_rank,
+    }
+
+
+def _has_node_count_batch_fallback() -> dict:
+    """Grace-shape fallback body for ``/api/entitlement/has-node-count-batch``.
+
+    Sibling of :func:`_min_tier_for_capacity_batch_fallback` on the
+    same axis: on a resolver crash the pricing surface keeps rendering
+    with an empty ``rows`` list instead of a stack trace. Envelope
+    mirrors the happy-path body so a caller does not have to branch on
+    the error shape.
+    """
+    return {
+        "kind": "node_count",
+        "count": 0,
+        "rows": [],
+        "current_tier": "oss",
+        "current_tier_rank": 0,
+        "grace": True,
+        "enforced": False,
+    }
+
+
+@bp_entitlement.route("/api/entitlement/has-node-count-batch")
+def api_entitlement_has_node_count_batch():
+    """``GET /api/entitlement/has-node-count-batch?counts=1,5,100`` -- per-
+    value boolean-gate batch sibling of ``/api/entitlement/has-node-count``
+    on the ``nodes`` capacity axis.
+
+    Node-axis twin of the not-yet-existing has-channel-count-batch /
+    has-retention-window-batch endpoints. Where the singular
+    ``/has-node-count?count=<N>`` endpoint answers ONE
+    (``has_node_count``, ``required_tier``) pair per request, this batch
+    answers all requested counts in ONE round-trip so a fleet paywall
+    matrix ("does the current install admit 1? 5? 100 nodes?") binds
+    off one URL instead of ``N`` calls.
+
+    ``?counts=`` is a comma-separated list. Empty / whitespace tokens
+    are dropped, duplicates by normalised int key are dropped preserving
+    first-seen order, non-int tokens pass through as one row with
+    ``unknown=true`` / ``has_node_count=false`` (matches
+    :func:`has_node_count`'s strict callsite-typo posture). Missing /
+    blank ``?counts=`` -> ``400`` (matches the sibling
+    ``/api/entitlement/min-tier-for-node-count-batch`` posture).
+
+    Per-row body shape (extends the singular ``/has-node-count`` shape
+    with ``kind`` / ``label`` / ``unknown`` / ``count_raw`` so a UI
+    already rendering ``min-tier-for-node-count-batch`` rows can rebind
+    without reshaping)::
+
+        {
+          "count":              <int> | null,
+          "count_raw":          "<stripped raw token>",
+          "kind":               "node_count",
+          "label":              "1 node" | "5 nodes" | null,
+          "has_node_count":     <bool>,
+          "allowed":            <bool>,               # mirror of has_node_count
+          "unknown":            <bool>,               # true iff non-int input
+          "required_tier":      "<tier id>" | null,
+          "required_tier_label":"<label>"   | null,
+          "required_tier_rank": <int>,                # -1 when required_tier null
+          "upgrade_required":   <bool>,               # required_tier_rank > current_tier_rank
+        }
+
+    Envelope wraps ``rows`` with ``kind`` / ``count`` (row count) plus
+    the standard resolver envelope (``current_tier`` /
+    ``current_tier_rank`` / ``grace`` / ``enforced``) so a UI can render
+    "you are here" once alongside the per-row grants.
+
+    Grace-safe: while :attr:`Entitlement.grace` is ``True`` (the current
+    rollout state) every KNOWN row reports ``has_node_count=true``, so
+    wiring this into a fleet gate today changes NO current behavior.
+    Post-enforcement each row reflects the resolver's live grant.
+
+    Cross-consistency: the ``required_tier`` on each row agrees byte-for-
+    byte with ``/api/entitlement/required-tier?nodes=<count>`` and with
+    the per-row ``required_tier`` on the sibling
+    ``/api/entitlement/min-tier-for-node-count-batch`` -- a UI wiring
+    both for the same paywall matrix cannot see inconsistent tier state.
+
+    Never 5xx: any resolver blowup collapses to
+    :func:`_has_node_count_batch_fallback`.
+    """
+    values, err = _parse_capacity_batch_csv("counts", unlimited_ok=False)
+    if err == "missing":
+        return jsonify({"error": "missing counts"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        ent = _ent.get_entitlement()
+        cur_tier = ent.tier
+        cur_rank = _ent.tier_rank(cur_tier)
+        scalar_rows = _ent.has_node_count_batch(values)
+        raw_by_key: dict[str, str] = {}
+        for raw in values:
+            try:
+                key = str(int(raw))
+            except (TypeError, ValueError):
+                key = str(raw)
+            raw_by_key.setdefault(key, str(raw))
+        rows = [
+            _has_node_count_batch_row_to_body(
+                r, raw_by_key.get(str(r.get("key")), str(r.get("key"))), cur_rank
+            )
+            for r in scalar_rows
+        ]
+        return jsonify(
+            {
+                "kind": "node_count",
+                "count": len(rows),
+                "rows": rows,
+                "current_tier": cur_tier,
+                "current_tier_rank": cur_rank,
+                "grace": bool(ent.grace),
+                "enforced": _ent.is_enforced(),
+            }
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_has_node_count_batch: error: %s", exc
+        )
+        return jsonify(_has_node_count_batch_fallback())
+
+
 def _has_bundle_fallback(axis: str, tokens: list[str]) -> dict:
     """OSS-free / never-5xx envelope for the plural ``/api/entitlement/has-features``
     and ``/api/entitlement/has-runtimes`` endpoints.

--- a/tests/test_entitlement_has_node_count_batch.py
+++ b/tests/test_entitlement_has_node_count_batch.py
@@ -1,0 +1,517 @@
+"""Tests for the ``has_node_count_batch`` per-value boolean-gate scalar and
+its paired ``/api/entitlement/has-node-count-batch`` endpoint.
+
+Batch sibling of :func:`has_node_count` on the ``nodes`` capacity axis:
+where the singular ``has_node_count`` answers ONE (has_node_count,
+required_tier) pair per call, this batch answers all supplied counts in
+ONE round-trip -- a fleet paywall matrix ("does the current install admit
+1? 5? 100 nodes?") binds off one URL instead of N calls.
+
+Row shape is byte-parity with the ``nodes`` axis row emitted by
+:func:`has_batch` via the shared :func:`_has_row` row-shape helper so a
+UI already wired for ``has_batch`` rows can rebind to this per-axis batch
+without reshaping.
+
+This file pins:
+
+1. Scalar semantics: ``None`` / non-iterable input -> ``[]``; non-int
+   items surface as ``unknown=True`` / ``has=False`` rows; zero /
+   negative counts are trivially satisfied by the free floor; positive
+   counts reflect the resolver's grace-passthrough (True in grace) and
+   the underlying :meth:`Entitlement.allows_node_count` post-enforce.
+2. Per-value dedup by normalised int key, preserving first-seen order,
+   matching :func:`min_tier_for_node_count_batch`.
+3. Byte-parity per row with :func:`has_node_count` (live grant) and
+   :func:`min_tier_for_node_count` (reverse lookup) across a mixed grid.
+4. Byte-parity per row with the ``nodes`` row emitted by
+   :func:`has_batch` for the same count -- the shared ``_has_row``
+   helper produces both, so the invariant catches any drift in either.
+5. Endpoint envelope shape (fixed key set) across every input branch;
+   ``label`` conjugation matches the sibling
+   ``/min-tier-for-node-count-batch`` row shape ("1 node" / "5 nodes").
+6. Missing / blank ``?counts=`` -> 400; every other input branch is
+   never-4xx / never-5xx.
+7. Cross-consistency with the singular ``/api/entitlement/has-node-count``
+   and the sibling ``/api/entitlement/min-tier-for-node-count-batch``
+   endpoints on the ``required_tier`` slot -- byte-parity per row so
+   a paywall matrix wiring both can't see inconsistent tier state.
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+# ── Fixtures ────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    """Fresh entitlements module in OSS-free grace mode -- matches the
+    fixture shape in ``tests/test_entitlement_has_node_count.py`` so
+    per-row assertions here reproduce the same install state the
+    live singular scalar is pinned against."""
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def enforced(monkeypatch, tmp_path):
+    """Enforcement-on fixture: ``CLAWMETRY_ENFORCE=1`` flips
+    ``ent.grace`` off so per-row ``has`` reflects the underlying
+    :meth:`Entitlement.allows_node_count` answer instead of the grace
+    passthrough. Same shape as the sibling
+    ``test_entitlement_has_node_count.py::enforced`` fixture."""
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    importlib.reload(e)
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+@pytest.fixture
+def enforced_client(enforced):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# ── Envelope shape ──────────────────────────────────────────────────────────
+
+
+_ROW_KEYS = {
+    "count",
+    "count_raw",
+    "kind",
+    "label",
+    "has_node_count",
+    "allowed",
+    "unknown",
+    "required_tier",
+    "required_tier_label",
+    "required_tier_rank",
+    "upgrade_required",
+}
+
+_ENVELOPE_KEYS = {
+    "kind",
+    "count",
+    "rows",
+    "current_tier",
+    "current_tier_rank",
+    "grace",
+    "enforced",
+}
+
+
+def _get_json(client, url: str, expected_status: int = 200) -> dict:
+    resp = client.get(url)
+    assert resp.status_code == expected_status, (url, resp.status_code)
+    return resp.get_json()
+
+
+# ── Scalar-level tests ─────────────────────────────────────────────────────
+
+
+def test_scalar_none_returns_empty(ent):
+    assert ent.has_node_count_batch(None) == []
+
+
+def test_scalar_non_iterable_returns_empty(ent):
+    assert ent.has_node_count_batch(5) == []
+    assert ent.has_node_count_batch(True) == []
+
+
+def test_scalar_empty_iterable_returns_empty(ent):
+    assert ent.has_node_count_batch([]) == []
+    assert ent.has_node_count_batch(()) == []
+    assert ent.has_node_count_batch(set()) == []
+
+
+def test_scalar_zero_and_negative_are_free_floor(ent):
+    rows = ent.has_node_count_batch([0, -1, -100])
+    assert len(rows) == 3
+    for row in rows:
+        assert row["has"] is True
+        assert row["unknown"] is False
+        assert row["required_tier"] == "oss"
+
+
+def test_scalar_positive_grace_passthrough(ent):
+    rows = ent.has_node_count_batch([1, 5, 100, 10_000])
+    assert len(rows) == 4
+    for row in rows:
+        assert row["has"] is True, row
+        assert row["unknown"] is False, row
+
+
+def test_scalar_positive_after_enforcement(enforced):
+    """Post-enforce the OSS-free install caps at 1 node."""
+    rows = enforced.has_node_count_batch([1, 2, 5, 100])
+    by_key = {r["key"]: r for r in rows}
+    assert by_key["1"]["has"] is True
+    for k in ("2", "5", "100"):
+        assert by_key[k]["has"] is False, k
+        # Reverse-lookup tier is unchanged (perspective-independent).
+        assert by_key[k]["required_tier"] is not None
+        assert by_key[k]["required_tier_rank"] > 0
+
+
+def test_scalar_non_int_is_unknown_false(ent):
+    rows = ent.has_node_count_batch(["five", None, [], object()])
+    assert len(rows) == 4
+    for row in rows:
+        assert row["has"] is False, row
+        assert row["unknown"] is True, row
+        assert row["required_tier"] is None
+        assert row["required_tier_rank"] == -1
+
+
+def test_scalar_dedupes_by_int_key(ent):
+    """Duplicates by normalised int key collapse, first-seen order preserved."""
+    rows = ent.has_node_count_batch([5, 5, "5", 1, 1, 5])
+    keys = [r["key"] for r in rows]
+    assert keys == ["5", "1"]
+
+
+def test_scalar_dedupes_non_int_by_raw_string(ent):
+    rows = ent.has_node_count_batch(["five", "five", "six"])
+    assert [r["key"] for r in rows] == ["five", "six"]
+
+
+def test_scalar_string_int_parses(ent):
+    """``int("5")`` succeeds, so a string-int is treated as the int itself
+    (matches :func:`has_node_count`)."""
+    rows = ent.has_node_count_batch(["1", "5"])
+    assert [r["key"] for r in rows] == ["1", "5"]
+    for row in rows:
+        assert row["unknown"] is False
+        assert row["has"] is True  # grace
+
+
+def test_scalar_row_shape_keys(ent):
+    row = ent.has_node_count_batch([5])[0]
+    assert set(row.keys()) == {
+        "key",
+        "kind",
+        "has",
+        "unknown",
+        "required_tier",
+        "required_tier_label",
+        "required_tier_rank",
+    }
+    assert row["kind"] == "nodes"
+
+
+def test_scalar_parity_with_singular_has_node_count(ent):
+    """Every row's ``has`` byte-equals :func:`has_node_count` on the same
+    count."""
+    counts = [0, 1, 2, 5, 10, 100, 1_000]
+    rows = ent.has_node_count_batch(counts)
+    for row in rows:
+        n = int(row["key"])
+        assert row["has"] is ent.has_node_count(n), n
+
+
+def test_scalar_parity_with_min_tier_for_node_count(ent):
+    """Every row's ``required_tier`` byte-equals :func:`min_tier_for_node_count`
+    on the same count (perspective-independent)."""
+    counts = [0, 1, 2, 5, 100]
+    rows = ent.has_node_count_batch(counts)
+    for row in rows:
+        n = int(row["key"])
+        assert row["required_tier"] == ent.min_tier_for_node_count(n), n
+
+
+def test_scalar_parity_with_has_batch_nodes_row(ent):
+    """Row shape is byte-parity with the ``nodes`` axis row emitted by
+    :func:`has_batch` -- both delegate to :func:`_has_row`."""
+    for n in (0, 1, 5, 100):
+        batch_row = ent.has_node_count_batch([n])[0]
+        has_batch_row = ent.has_batch(nodes=n)["nodes"]
+        assert batch_row == has_batch_row, n
+
+
+def test_scalar_never_raises_on_resolver_blowup(monkeypatch, ent):
+    """A resolver blowup collapses to grace-shape fallback -- the batch
+    still returns rows built off the free-tier entitlement."""
+
+    def _boom():
+        raise RuntimeError("resolver blew up")
+
+    monkeypatch.setattr(ent, "get_entitlement", _boom)
+    rows = ent.has_node_count_batch([1, 5])
+    assert len(rows) == 2
+    for row in rows:
+        assert "has" in row and "required_tier" in row
+
+
+def test_scalar_never_raises_on_has_row_blowup(monkeypatch, ent):
+    """A per-row failure short-circuits to the fail-closed row shape so
+    the batch keeps building."""
+
+    def _boom(*_a, **_kw):
+        raise RuntimeError("row blew up")
+
+    monkeypatch.setattr(ent, "_has_row", _boom)
+    rows = ent.has_node_count_batch([1, 5])
+    assert len(rows) == 2
+    for row in rows:
+        assert row["has"] is False
+        assert row["unknown"] is True
+        assert row["required_tier"] is None
+
+
+# ── Endpoint envelope shape ────────────────────────────────────────────────
+
+
+def test_endpoint_missing_counts_400(client):
+    resp = client.get("/api/entitlement/has-node-count-batch")
+    assert resp.status_code == 400
+    assert resp.get_json() == {"error": "missing counts"}
+
+
+def test_endpoint_blank_counts_400(client):
+    resp = client.get("/api/entitlement/has-node-count-batch?counts=")
+    assert resp.status_code == 400
+    resp = client.get("/api/entitlement/has-node-count-batch?counts=%20%20")
+    assert resp.status_code == 400
+
+
+def test_endpoint_envelope_shape(client):
+    body = _get_json(client, "/api/entitlement/has-node-count-batch?counts=1,5,100")
+    assert set(body.keys()) == _ENVELOPE_KEYS
+    assert body["kind"] == "node_count"
+    assert body["count"] == 3
+    assert isinstance(body["rows"], list)
+    assert len(body["rows"]) == 3
+    assert body["current_tier"] == "oss"
+    assert body["current_tier_rank"] == 0
+    for row in body["rows"]:
+        assert set(row.keys()) == _ROW_KEYS
+
+
+def test_endpoint_row_types(client):
+    body = _get_json(client, "/api/entitlement/has-node-count-batch?counts=1,5")
+    for row in body["rows"]:
+        assert isinstance(row["count"], int) or row["count"] is None
+        assert isinstance(row["count_raw"], str)
+        assert row["kind"] == "node_count"
+        assert isinstance(row["label"], (str, type(None)))
+        assert isinstance(row["has_node_count"], bool)
+        assert isinstance(row["allowed"], bool)
+        assert row["has_node_count"] == row["allowed"]
+        assert isinstance(row["unknown"], bool)
+        assert isinstance(row["required_tier_rank"], int)
+        assert isinstance(row["upgrade_required"], bool)
+
+
+def test_endpoint_label_conjugation(client):
+    """Label matches the sibling ``/min-tier-for-node-count-batch`` shape."""
+    body = _get_json(client, "/api/entitlement/has-node-count-batch?counts=1,5,100")
+    by_count = {r["count"]: r for r in body["rows"]}
+    assert by_count[1]["label"] == "1 node"
+    assert by_count[5]["label"] == "5 nodes"
+    assert by_count[100]["label"] == "100 nodes"
+
+
+def test_endpoint_deduped(client):
+    body = _get_json(
+        client, "/api/entitlement/has-node-count-batch?counts=5,5,1,5,1"
+    )
+    counts = [r["count"] for r in body["rows"]]
+    assert counts == [5, 1]
+
+
+def test_endpoint_grace_all_positive_true(client):
+    body = _get_json(client, "/api/entitlement/has-node-count-batch?counts=1,5,100")
+    for row in body["rows"]:
+        assert row["has_node_count"] is True
+        assert row["allowed"] is True
+
+
+def test_endpoint_zero_and_negative_free_floor(client):
+    body = _get_json(client, "/api/entitlement/has-node-count-batch?counts=0,-1,-100")
+    for row in body["rows"]:
+        assert row["has_node_count"] is True
+        assert row["required_tier"] == "oss"
+
+
+def test_endpoint_non_int_tokens_unknown(client):
+    body = _get_json(
+        client, "/api/entitlement/has-node-count-batch?counts=five,ten,1"
+    )
+    by_raw = {r["count_raw"]: r for r in body["rows"]}
+    assert by_raw["five"]["unknown"] is True
+    assert by_raw["five"]["has_node_count"] is False
+    assert by_raw["five"]["count"] is None
+    assert by_raw["ten"]["unknown"] is True
+    assert by_raw["1"]["unknown"] is False
+    assert by_raw["1"]["count"] == 1
+
+
+def test_endpoint_whitespace_tokens_dropped(client):
+    body = _get_json(
+        client, "/api/entitlement/has-node-count-batch?counts=1,%20,5,%20%20"
+    )
+    counts = [r["count"] for r in body["rows"]]
+    assert counts == [1, 5]
+
+
+def test_endpoint_upgrade_required_grace(client):
+    """Grace-mode current tier is OSS (rank 0); any row with a paid
+    required_tier reports upgrade_required=True."""
+    body = _get_json(client, "/api/entitlement/has-node-count-batch?counts=1,5")
+    by_count = {r["count"]: r for r in body["rows"]}
+    # count=1 -> required_tier=oss (rank 0) -> not an upgrade
+    assert by_count[1]["upgrade_required"] is False
+    # count=5 -> required_tier=paid (rank > 0) -> upgrade needed from oss
+    assert by_count[5]["upgrade_required"] is True
+
+
+def test_endpoint_never_5xx_on_resolver_blowup(monkeypatch, client):
+    from clawmetry import entitlements as _ent
+
+    def _boom(*a, **kw):
+        raise RuntimeError("resolver blew up")
+
+    monkeypatch.setattr(_ent, "get_entitlement", _boom)
+    resp = client.get("/api/entitlement/has-node-count-batch?counts=1,5")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert set(body.keys()) == _ENVELOPE_KEYS
+    assert body["rows"] == []
+    assert body["count"] == 0
+
+
+def test_endpoint_never_5xx_on_scalar_blowup(monkeypatch, client):
+    from clawmetry import entitlements as _ent
+
+    def _boom(*a, **kw):
+        raise RuntimeError("scalar blew up")
+
+    monkeypatch.setattr(_ent, "has_node_count_batch", _boom)
+    resp = client.get("/api/entitlement/has-node-count-batch?counts=1,5")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["rows"] == []
+
+
+def test_endpoint_never_5xx_on_row_shape_blowup(monkeypatch, client):
+    import routes.entitlement as ent_route
+
+    def _boom(*a, **kw):
+        raise RuntimeError("row shape blew up")
+
+    monkeypatch.setattr(ent_route, "_has_node_count_batch_row_to_body", _boom)
+    resp = client.get("/api/entitlement/has-node-count-batch?counts=1,5")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["rows"] == []
+
+
+# ── Cross-consistency with sibling endpoints ──────────────────────────────
+
+
+def test_endpoint_required_tier_parity_with_min_tier_batch(client):
+    """``required_tier`` on each row byte-equals the sibling
+    ``/api/entitlement/min-tier-for-node-count-batch`` row for the same
+    count -- a UI wiring both cannot see inconsistent tier state."""
+    body_has = _get_json(
+        client, "/api/entitlement/has-node-count-batch?counts=1,5,100"
+    )
+    body_min = _get_json(
+        client, "/api/entitlement/min-tier-for-node-count-batch?counts=1,5,100"
+    )
+    has_rt = {r["count"]: r["required_tier"] for r in body_has["rows"]}
+    min_rt = {r["item"]: r["required_tier"] for r in body_min["rows"]}
+    assert has_rt == min_rt
+
+
+def test_endpoint_has_node_count_parity_with_singular(client):
+    """Every row's ``has_node_count`` byte-equals the singular
+    ``/api/entitlement/has-node-count`` endpoint for the same count."""
+    body = _get_json(
+        client, "/api/entitlement/has-node-count-batch?counts=1,5,100,0"
+    )
+    for row in body["rows"]:
+        n = row["count"]
+        singular = _get_json(
+            client, f"/api/entitlement/has-node-count?count={n}"
+        )
+        assert row["has_node_count"] == singular["has_node_count"], n
+        assert row["required_tier"] == singular["required_tier"], n
+        assert row["required_tier_rank"] == singular["required_tier_rank"], n
+
+
+def test_endpoint_scalar_vs_endpoint_parity(client, ent):
+    body = _get_json(client, "/api/entitlement/has-node-count-batch?counts=0,1,5,100")
+    scalar = ent.has_node_count_batch([0, 1, 5, 100])
+    assert len(body["rows"]) == len(scalar)
+    for row, s in zip(body["rows"], scalar):
+        assert row["has_node_count"] is s["has"]
+        assert row["required_tier"] == s["required_tier"]
+        assert row["unknown"] is s["unknown"]
+
+
+# ── Envelope stability across many input branches ────────────────────────
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "/api/entitlement/has-node-count-batch?counts=1",
+        "/api/entitlement/has-node-count-batch?counts=1,5,100",
+        "/api/entitlement/has-node-count-batch?counts=0",
+        "/api/entitlement/has-node-count-batch?counts=-1",
+        "/api/entitlement/has-node-count-batch?counts=five,1",
+        "/api/entitlement/has-node-count-batch?counts=1,1,1",
+        "/api/entitlement/has-node-count-batch?counts=%201%20,%205%20",
+    ],
+)
+def test_endpoint_envelope_stable(client, url):
+    body = _get_json(client, url)
+    assert set(body.keys()) == _ENVELOPE_KEYS
+    assert body["kind"] == "node_count"
+    assert isinstance(body["rows"], list)
+    assert body["count"] == len(body["rows"])
+    for row in body["rows"]:
+        assert set(row.keys()) == _ROW_KEYS
+
+
+def test_endpoint_enforced_mode_still_never_5xx(enforced_client):
+    """Post-enforce the OSS-free install caps at 1 node; the batch still
+    returns rows with byte-stable shape."""
+    body = _get_json(
+        enforced_client, "/api/entitlement/has-node-count-batch?counts=1,5,100"
+    )
+    by_count = {r["count"]: r for r in body["rows"]}
+    assert by_count[1]["has_node_count"] is True
+    assert by_count[5]["has_node_count"] is False
+    assert by_count[100]["has_node_count"] is False
+    assert body["grace"] is False
+    assert body["enforced"] is True


### PR DESCRIPTION
## Summary

Adds the per-value boolean-gate BATCH scalar on the `nodes` capacity axis, filling the batch slot alongside the existing `min_tier_for_node_count_batch` and the just-merged `has_node_count_at` (#4426) / `has_features_at` + `has_runtimes_at` (#4450). A fleet paywall matrix (&#34;does the current install admit 1? 5? 100 nodes?&#34;) now binds off ONE URL instead of N calls to `/api/entitlement/has-node-count?count=<N>`.

- **Scalar** `clawmetry/entitlements.py::has_node_count_batch(counts) -> list[dict]`
- **Endpoint** `routes/entitlement.py::/api/entitlement/has-node-count-batch?counts=1,5,100`
- **Tests** `tests/test_entitlement_has_node_count_batch.py` — 41 tests, all green

## Design notes

- **Delegates per-row to `_has_row(ent, count, "nodes")`** — the same helper that produces the `nodes` row for `has_batch`. That single delegation point means the batch is byte-parity with the singular `has_node_count` (live grant) and `min_tier_for_node_count` (reverse lookup), and with the `nodes` row on `has_batch` for the same input.
- **Per-value dedup** by normalised int key preserving first-seen order (matches `min_tier_for_node_count_batch`).
- **Non-int items surface as `unknown=True` / `has=False` rows** — strict callsite-typo fail-closed posture matching `has_node_count` and every other capacity-axis scalar. A caller that passes `["five"]` here has a bug, not a grant.
- **Endpoint layers `count` / `count_raw` / conjugated `label` (&#34;1 node&#34; / &#34;5 nodes&#34;) / `upgrade_required`** on top of the scalar row so the endpoint body byte-matches the singular `/has-node-count` and sibling `/min-tier-for-node-count-batch` shapes.
- **Missing / blank `?counts=` → 400** (matches the sibling `/min-tier-for-node-count-batch` posture). Every other input branch is never-4xx / never-5xx.
- **Grace-safe**: while `ent.grace` is True (the current rollout state) every known row reports `has_node_count=true`, so wiring this into a fleet gate today changes NO current behavior.
- Zero behavior change to any current callsite — additive, opt-in surface.

## Tests

`tests/test_entitlement_has_node_count_batch.py` pins:

1. Scalar semantics: `None` / non-iterable input → `[]`; non-int items → `unknown=True` / `has=False` rows; zero / negative counts trivially satisfied by the free floor; positive counts reflect grace-passthrough (True in grace) and the underlying `allows_node_count` post-enforce.
2. Per-value dedup by normalised int key, preserving first-seen order.
3. Byte-parity per row with `has_node_count` (live grant) and `min_tier_for_node_count` (reverse lookup) across a mixed grid.
4. Byte-parity per row with the `nodes` row emitted by `has_batch` for the same count.
5. Endpoint envelope shape (fixed 7-key envelope + 11-key row) across every input branch; `label` conjugation matches sibling.
6. Missing / blank `?counts=` → 400; never-4xx / never-5xx on every other branch (resolver blowup, scalar blowup, row-shape blowup).
7. Cross-consistency with `/api/entitlement/has-node-count` and `/api/entitlement/min-tier-for-node-count-batch` on `required_tier` and `has_node_count` slots.

Also ran `tests/test_entitlement_has_node_count.py`, `tests/test_entitlement_has_node_count_at.py`, `tests/test_entitlements.py`, `tests/test_entitlement_has_batch.py` — all 230 green, no regressions.

## Non-overlap with open PRs

Every open entitlement PR (#4450 `has_features_at + has_runtimes_at`, #4440 `has_retention_window_at`, #4435 `has_channel_count_at`, #4426 `has_node_count_at` — all merged as of this branch base) touches DIFFERENT function surfaces. Diff here is additive with no line-level overlap on any of them.

## Local operator verification checklist

The autonomous agent can&#39;t touch the live daemon, browser, or the encrypted cloud snapshot. Once this PR is ready for you:

- [ ] Copy the two changed source paths into `~/.clawmetry/lib/pythonX.Y/site-packages/clawmetry/` (mirror `clawmetry/entitlements.py` + `routes/entitlement.py`; the test file only needs to live in the repo)
- [ ] Clear the installed `__pycache__` under that site-packages tree
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` (or your platform&#39;s equivalent) to bounce the daemon
- [ ] `curl -s 'http://localhost:8900/api/entitlement/has-node-count-batch?counts=1,5,100' | jq` — expect envelope with `kind: "node_count"`, `count: 3`, three rows keyed by counts `1` / `5` / `100`
- [ ] Verify per-row shape: each row carries `count` / `count_raw` / `label` / `has_node_count` / `allowed` / `unknown` / `required_tier*` / `upgrade_required`
- [ ] `curl -s 'http://localhost:8900/api/entitlement/has-node-count-batch?counts=five,ten,1'` — expect `five` / `ten` rows with `unknown: true`, `has_node_count: false`, `count: null`, and `1` row parseable
- [ ] `curl -s 'http://localhost:8900/api/entitlement/has-node-count-batch?counts=1,1,1,5,5'` — expect deduped rows (only `1` and `5`), first-seen order
- [ ] `curl -s 'http://localhost:8900/api/entitlement/has-node-count-batch'` — expect `400 {"error": "missing counts"}`
- [ ] Cross-check row `required_tier` byte-equals `/api/entitlement/min-tier-for-node-count-batch?counts=1,5,100` on the same counts
- [ ] Cross-check row `has_node_count` byte-equals `/api/entitlement/has-node-count?count=<N>` for each count
- [ ] Verify no regression on existing `/api/entitlement/has-node-count`, `/api/entitlement/has-node-count-at`, and `/api/entitlement/min-tier-for-node-count-batch` endpoints
- [ ] Decrypt the live cloud snapshot and confirm the entitlement surface still round-trips
- [ ] Browser-check that no existing fleet paywall tile changes rendering (this PR adds only new surface; the wire-in comes later)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lq5FCkfgHH3UhwcSDf9CXL)_