### PR TITLE
fix(device): wire device-preview Approve/Deny buttons to the real /api/approvals/<id>/decide endpoint

### DIFF
--- a/routes/device.py
+++ b/routes/device.py
@@ -243,3 +243,192 @@ def api_device_snapshot():
             "approval": None,
         })
 
+
+@bp_device.route("/device-preview")
+def device_preview():
+    """A browser stand-in for the physical device — proves the whole data path
+    (DuckDB → /api/device/snapshot → rendered gauge) with no hardware. The same
+    JSON later drives the ESP32 firmware."""
+    return _DEVICE_PREVIEW_HTML, 200, {"Content-Type": "text/html; charset=utf-8"}
+
+
+# A single self-contained page (no build step, matching the repo convention).
+# It polls the snapshot, renders the all-runtime metrics, a health "LED", and —
+# when an approval is pending — Approve / Deny buttons that POST the decision,
+# the physical-button behaviour rendered in software.
+_DEVICE_PREVIEW_HTML = """<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>ClawMetry Device Preview</title>
+<style>
+  :root { color-scheme: dark; }
+  body { margin:0; min-height:100vh; display:flex; align-items:center;
+         justify-content:center; background:#0b0d12; font-family:-apple-system,
+         BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif; color:#e8eaf0; }
+  .device { width:280px; border-radius:28px; padding:22px 20px 26px;
+            background:linear-gradient(160deg,#181b22,#0e1015);
+            box-shadow:0 30px 80px rgba(0,0,0,.6), inset 0 1px 0 rgba(255,255,255,.05);
+            border:1px solid #23262f; }
+  .top { display:flex; align-items:center; justify-content:space-between; }
+  .brand { font-size:11px; letter-spacing:.14em; text-transform:uppercase;
+           color:#7c8190; }
+  .led { width:14px; height:14px; border-radius:50%; background:#3a3f4b;
+         transition:background .4s, box-shadow .4s; }
+  .led.green { background:#34d399; box-shadow:0 0 14px #34d39988; }
+  .led.amber { background:#fbbf24; box-shadow:0 0 14px #fbbf2488; }
+  .led.red   { background:#f87171; box-shadow:0 0 16px #f87171aa;
+               animation:pulse 1s infinite; }
+  @keyframes pulse { 50% { opacity:.45; } }
+  .mascot { font-size:62px; text-align:center; margin:14px 0 6px;
+            transition:transform .3s; }
+  .state { text-align:center; font-size:12px; color:#9aa0ad; margin-bottom:16px;
+           min-height:14px; }
+  .cost { text-align:center; font-size:40px; font-weight:700; letter-spacing:-.02em; }
+  .costlabel { text-align:center; font-size:10px; letter-spacing:.12em;
+               text-transform:uppercase; color:#7c8190; margin-top:2px; }
+  .grid { display:flex; gap:10px; margin:18px 0 4px; }
+  .cell { flex:1; background:#13161d; border:1px solid #23262f; border-radius:14px;
+          padding:10px 8px; text-align:center; }
+  .cell .v { font-size:18px; font-weight:600; }
+  .cell .k { font-size:9px; letter-spacing:.1em; text-transform:uppercase;
+             color:#7c8190; margin-top:3px; }
+  .runtimes { font-size:10px; color:#9aa0ad; text-align:center; margin-top:10px;
+              min-height:12px; word-break:break-word; }
+  .alert { margin-top:14px; background:#2a1d12; border:1px solid #5a3a1c;
+           color:#fcd9a8; border-radius:12px; padding:9px 11px; font-size:11px;
+           display:none; }
+  .approval { margin-top:14px; background:#161b2a; border:1px solid #2d3550;
+              border-radius:14px; padding:12px; display:none; }
+  .approval .ask { font-size:12px; margin-bottom:3px; }
+  .approval .tool { font-weight:700; }
+  .approval .meta { font-size:10px; color:#8a90a0; margin-bottom:10px; }
+  .btns { display:flex; gap:8px; }
+  .btns button { flex:1; border:0; border-radius:10px; padding:9px 0; font-size:12px;
+                 font-weight:600; cursor:pointer; }
+  .approve { background:#34d399; color:#06231a; }
+  .deny    { background:#f87171; color:#2a0c0c; }
+  .foot { text-align:center; font-size:9px; color:#5a5f6c; margin-top:16px; }
+  .foot b { color:#8a90a0; }
+</style>
+</head>
+<body>
+  <div class="device">
+    <div class="top">
+      <div class="brand">ClawMetry</div>
+      <div id="led" class="led"></div>
+    </div>
+    <div id="mascot" class="mascot">😴</div>
+    <div id="state" class="state">connecting…</div>
+    <div id="cost" class="cost">$0.00</div>
+    <div class="costlabel">spent today · all runtimes</div>
+    <div class="grid">
+      <div class="cell"><div id="tokens" class="v">0</div><div class="k">tokens</div></div>
+      <div class="cell"><div id="active" class="v">0</div><div class="k">active</div></div>
+      <div class="cell"><div id="rtcount" class="v">0</div><div class="k">runtimes</div></div>
+    </div>
+    <div id="runtimes" class="runtimes"></div>
+    <div id="alert" class="alert"></div>
+    <div id="approval" class="approval">
+      <div class="ask">Approve <span id="apTool" class="tool"></span>?</div>
+      <div id="apMeta" class="meta"></div>
+      <div class="btns">
+        <button class="approve" onclick="decide('approve')">Approve</button>
+        <button class="deny" onclick="decide('deny')">Deny</button>
+      </div>
+    </div>
+    <div class="foot">one device · <b>all 14 runtimes</b></div>
+  </div>
+<script>
+const MOODS = {
+  idle:   {emoji:'😺', text:'idle'},
+  busy:   {emoji:'😼', text:'working…'},
+  alert:  {emoji:'🙀', text:'needs you'},
+  approve:{emoji:'🐱', text:'waiting for approval'},
+  sleep:  {emoji:'😴', text:'sleeping'},
+};
+function fmtTokens(n){
+  if(n>=1e9) return (n/1e9).toFixed(1)+'B';
+  if(n>=1e6) return (n/1e6).toFixed(1)+'M';
+  if(n>=1e3) return (n/1e3).toFixed(1)+'k';
+  return String(n||0);
+}
+let last = null;
+let decided = {};  // approval ids already decided from this page
+async function tick(){
+  try{
+    const r = await fetch('/api/device/snapshot');
+    const d = await r.json();
+    last = d;
+    document.getElementById('led').className = 'led ' + (d.health||'green');
+    document.getElementById('cost').textContent =
+      '$' + (Number(d.cost_today_usd)||0).toFixed(2);
+    document.getElementById('tokens').textContent = fmtTokens(d.tokens_today);
+    document.getElementById('active').textContent = d.active_sessions||0;
+    const rts = d.runtimes_active||[];
+    document.getElementById('rtcount').textContent = rts.length;
+    document.getElementById('runtimes').textContent = rts.join(' · ');
+
+    const al = document.getElementById('alert');
+    if(d.alert){ al.style.display='block'; al.textContent='⚠ '+d.alert.message; }
+    else al.style.display='none';
+
+    const ap = document.getElementById('approval');
+    // A just-decided id can linger in the snapshot for one cache TTL (5 s);
+    // don't resurrect the buttons for a decision that's already been made.
+    if(d.approval && !decided[d.approval.id]){
+      ap.style.display='block';
+      document.getElementById('apTool').textContent = d.approval.action;
+      const w = d.approval.waiting_seconds;
+      document.getElementById('apMeta').textContent =
+        d.approval.runtime + (w!=null ? ' · waiting '+w+'s' : '');
+    } else ap.style.display='none';
+
+    let mood = 'idle';
+    if(d.approval) mood='approve';
+    else if(d.alert) mood='alert';
+    else if((d.active_sessions||0)>0) mood='busy';
+    else if((d.tokens_today||0)===0) mood='sleep';
+    document.getElementById('mascot').textContent = MOODS[mood].emoji;
+    document.getElementById('state').textContent = MOODS[mood].text;
+  }catch(e){
+    document.getElementById('state').textContent = 'daemon offline';
+  }
+}
+async function decide(decision){
+  // The physical Approve/Deny button. Writes through the same endpoint the
+  // dashboard queue uses — POST /api/approvals/<id>/decide with a JSON
+  // {"decision": "approve"|"deny"} body (routes/policy.py) — so a button
+  // press really flips the row. Success (or an already-decided row, which
+  // the endpoint reports idempotently) clears the card; a failure keeps it
+  // up and says why, so the button is never a silent no-op.
+  if(!last || !last.approval) return;
+  const id = last.approval.id;
+  const state = document.getElementById('state');
+  try{
+    const r = await fetch('/api/approvals/'+encodeURIComponent(id)+'/decide',
+      {method:'POST',
+       headers:{'Content-Type':'application/json'},
+       body:JSON.stringify({decision:decision, reason:'device button'})});
+    let d = {};
+    try{ d = await r.json(); }catch(e){}
+    if(r.ok && d.ok){
+      decided[id] = true;
+      document.getElementById('approval').style.display='none';
+      state.textContent = d.already
+        ? ('already '+d.status) : (decision==='approve'?'approved':'denied');
+      tick();
+    }else{
+      state.textContent =
+        'decision failed: '+(d.error || ('HTTP '+r.status));
+    }
+  }catch(e){
+    state.textContent = 'decision failed: daemon offline';
+  }
+}
+tick();
+setInterval(tick, 3000);
+</script>
+</body>
+</html>"""

--- a/tests/test_device_preview_decide.py
+++ b/tests/test_device_preview_decide.py
@@ -1,0 +1,158 @@
+"""Tests for the device-preview write path (routes/device.py → routes/policy.py).
+
+The /device-preview page is the software stand-in for the physical desk
+device: when an approval is pending it renders Approve / Deny buttons — the
+same buttons the hardware ships with. Those buttons MUST write through the
+real decision endpoint, ``POST /api/approvals/<id>/decide`` with a JSON
+``{"decision": "approve"|"deny"}`` body (routes/policy.py). An earlier
+draft POSTed to ``/api/approvals/<id>/approve`` / ``.../deny`` — routes
+that do not exist — making the buttons silent no-ops.
+
+These tests pin:
+  1. The page's JS targets the real ``/decide`` route with a JSON decision
+     body (and the phantom ``'/'+decision`` URL never comes back).
+  2. Driving that exact request against an app serving both blueprints
+     flips a pending approval row: approve → approved, deny → denied.
+
+Fixture shape mirrors tests/test_device_snapshot.py (hermetic tmp DuckDB,
+daemon discovery stubbed out) + tests/test_approvals_local_blocking.py
+(entitlement pinned so @gate("approval_queue") passes regardless of the
+dev machine's license / CLAWMETRY_ENFORCE).
+"""
+
+from __future__ import annotations
+
+import importlib
+import re
+import sys
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def preview_app(tmp_path, monkeypatch):
+    """Flask app serving BOTH bp_device (the page) and bp_policy (the decide
+    endpoint) over a hermetic tmp DuckDB store."""
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_BATCH", "1")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_READ", "1")
+
+    sys.modules.pop("clawmetry.local_store", None)
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    # Own the writer so the tmp store opens here, not via a dev daemon.
+    ls.mark_writer_owner()
+
+    # Stub daemon discovery so both read and write paths fall through to the
+    # in-process store (same as the device snapshot fixture).
+    import routes.local_query as lq
+    monkeypatch.setattr(lq, "_read_discovery", lambda: None)
+    monkeypatch.setattr(lq, "_cached_discovery", lambda: None)
+
+    # Pin entitlement so @gate("approval_queue") on the decide route passes.
+    import clawmetry.entitlements as ent
+    e = ent.Entitlement(
+        tier="pro", source="test", grace=False,
+        features=frozenset({"approval_queue"}), runtimes=frozenset(),
+    )
+    monkeypatch.setattr(ent, "get_entitlement", lambda force=False: e)
+
+    sys.modules.pop("routes.policy", None)
+    import routes.policy as pol
+    importlib.reload(pol)
+    import routes.device as dev
+    importlib.reload(dev)
+    dev._snapshot_cache["payload"] = None
+    dev._snapshot_cache["ts"] = 0.0
+
+    a = Flask(__name__)
+    a.register_blueprint(dev.bp_device)
+    a.register_blueprint(pol.bp_policy)
+    yield a, ls
+    try:
+        ls.get_store().stop(flush=True)
+    except Exception:
+        pass
+
+
+def _seed_pending(store, aid):
+    store.ingest_approval({
+        "id":                   aid,
+        "owner_hash":           "oh-device",
+        "requestor_session_id": "claude_code:sess-device",
+        "action":               "Bash: rm -rf /tmp/x",
+        "args":                 {"command": "rm -rf /tmp/x"},
+        "status":               "pending",
+        "created_at":           "2026-08-01T10:00:00Z",
+    })
+    return aid
+
+
+def test_preview_page_targets_real_decide_endpoint(preview_app):
+    """The page's JS must POST to /api/approvals/<id>/decide with a JSON
+    {"decision": ...} body — and the phantom per-verb routes must be gone."""
+    a, _ls = preview_app
+    r = a.test_client().get("/device-preview")
+    assert r.status_code == 200
+    html = r.get_data(as_text=True)
+
+    # The real route, with the decision in the JSON body.
+    assert re.search(r"/api/approvals/'\s*\+[^+]+\+\s*'/decide'", html), (
+        "device page must POST to /api/approvals/<id>/decide"
+    )
+    assert re.search(r"JSON\.stringify\(\{decision", html), (
+        "decision must travel in the JSON body, not the URL"
+    )
+    # The old broken shape: decision appended to the URL as the verb.
+    assert "+'/'+decision" not in html.replace(" ", ""), (
+        "phantom /api/approvals/<id>/<decision> route must not come back"
+    )
+    # And the phantom routes really don't exist on the served app.
+    for verb in ("approve", "deny"):
+        resp = a.test_client().post(f"/api/approvals/some-id/{verb}")
+        assert resp.status_code == 404
+
+
+def test_device_page_approve_flips_row_to_approved(preview_app):
+    """The exact request the page's Approve button sends flips the pending
+    row to approved (resolver 'local')."""
+    a, ls = preview_app
+    aid = _seed_pending(ls.get_store(), "device-approve-1")
+
+    resp = a.test_client().post(
+        f"/api/approvals/{aid}/decide",
+        json={"decision": "approve", "reason": "device button"},
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["ok"] is True
+    assert body["status"] == "approved"
+
+    row = next(r for r in ls.get_store().query_approvals(limit=10)
+               if r["id"] == aid)
+    assert row["status"] == "approved"
+    assert row["decision"] == "approve"
+    assert row["resolver"] == "local"
+
+
+def test_device_page_deny_flips_row_to_denied(preview_app):
+    """The exact request the page's Deny button sends flips the pending row
+    to denied."""
+    a, ls = preview_app
+    aid = _seed_pending(ls.get_store(), "device-deny-1")
+
+    resp = a.test_client().post(
+        f"/api/approvals/{aid}/decide",
+        json={"decision": "deny", "reason": "device button"},
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["ok"] is True
+    assert body["status"] == "denied"
+
+    row = next(r for r in ls.get_store().query_approvals(limit=10)
+               if r["id"] == aid)
+    assert row["status"] == "denied"
+    assert row["decision"] == "deny"


### PR DESCRIPTION
## Problem

The `/device-preview` page — the software stand-in for the physical desk device, whose selling point is approving/denying agent actions "right on it" — POSTed decisions to `/api/approvals/<id>/approve` and `/api/approvals/<id>/deny`. **Those routes do not exist.** The only decision writer is `POST /api/approvals/<id>/decide` with a JSON `{"decision": "approve"|"deny"}` body (`routes/policy.py`). A comment in the page's JS even admitted it: *"the preview stays useful even where the write path isn't wired yet."* Net effect: the Approve/Deny buttons were silent no-ops — the card hid itself, the row stayed pending.

## Fix (`routes/device.py`)

- `decide()` now POSTs to `/api/approvals/<id>/decide` with the JSON decision body (plus `reason: "device button"` for the audit trail), matching the dashboard queue's write path.
- The response is handled instead of swallowed: success and already-decided (the endpoint's idempotent "first click wins" answer) clear the card and show the resulting status; any failure (402 gate, 404, daemon offline) keeps the card up and reports why — the button can never be a silent no-op again.
- A just-decided approval id is suppressed client-side so the 5 s snapshot TTL cache can't resurrect the buttons for a decision already made.

Note: the `/device-preview` page previously existed only in an undeployed working tree; this PR carries it onto main together with the fix.

## Tests (`tests/test_device_preview_decide.py`, new)

- Pins the page's JS to the real route + JSON body shape, asserts the phantom `'/'+decision` URL never comes back, and that the per-verb routes 404 on an app serving both blueprints.
- Drives the exact request the buttons send: approve flips a pending approval row to `approved` (resolver `local`), deny flips it to `denied`.

## Test results

Hermetic run (isolated `HOME` so the dev machine's live daemon can't intercept the store proxy — same condition as CI):

- `tests/test_device_preview_decide.py` + `tests/test_device_snapshot.py` + `tests/test_approvals_local_blocking.py`: **22 passed**
- Baseline on untouched `origin/main`: 16 passed (no pre-existing failures)

## Shipping

Merging alone doesn't ship to users — this rides the next release ([RELEASE] carrier PR → PyPI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)