### PR TITLE
[RELEASE] chore: 0.12.637 — re-publish, 0.12.636 wheel raced the copilot merge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.12.637
+
+- Re-publish of 0.12.636: the published 0.12.636 wheel raced the merge commit
+  and was built without the GitHub Copilot runtime changes (the release
+  workflow self-bumped from pre-merge main). 0.12.637 is the first PyPI
+  artifact actually containing the 17th-runtime support described under
+  0.12.636 below.
+
 ## 0.12.636
 
 - **GitHub Copilot is the 17th observed runtime.** Copilot CLI sessions under

--- a/dashboard.py
+++ b/dashboard.py
@@ -267,7 +267,7 @@ def _otlp_service_name_to_agent_type(service_name):
     return slug or "custom"
 
 
-__version__ = "0.12.636"
+__version__ = "0.12.637"
 
 # Extensions (Phase 2): import the plugin host now, but defer the actual
 # load_plugins() call until after the Flask app is created below so we can


### PR DESCRIPTION
The published 0.12.636 wheel was crack-verified to contain NO copilot changes: the release workflow (pull_request-triggered) checked out main before the #4460 merge commit was visible, self-bumped 0.12.635→0.12.636, and published — the exact version-claim race from 0.12.622. Main is correct; this PR just re-releases it as 0.12.637 so a PyPI artifact actually carries the 17th runtime. Will crack-verify the 0.12.637 wheel for `CopilotAdapter` markers before pinning cloud.

🤖 Generated with [Claude Code](https://claude.com/claude-code)