### PR TITLE
Add ClawMetry Pro public README and migration checklist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/add-pro.md
+++ b/.github/PULL_REQUEST_TEMPLATE/add-pro.md
@@ -1,0 +1,26 @@
+---
+name: 'Pro extension / migration'
+about: PRs that add or migrate paid/enterprise code to clawmetry-pro
+---
+
+### Summary
+Brief description of what is being moved/added and reason.
+
+### Files moved/added
+- List of files or modules moved into `clawmetry-pro/`.
+
+### Checklist
+- [ ] Entitlement API implemented in OSS and unit-tested (entitlements.*)
+- [ ] OSS builds/tests pass without clawmetry-pro installed
+- [ ] Mock pro implementation added for CI smoke tests
+- [ ] Documentation updated (FLYWHEEL.md, MIGRATION_CHECKLIST.md)
+- [ ] Security checklist completed (no secrets, sanitized examples)
+- [ ] Release plan & packaging notes included
+
+### Testing
+Describe manual and automated tests performed.
+
+### Reviewers
+- @team-security (security review)
+- @team-platform (release/packaging)
+

--- a/clawmetry-pro/MIGRATION_CHECKLIST.md
+++ b/clawmetry-pro/MIGRATION_CHECKLIST.md
@@ -1,0 +1,36 @@
+# Migration checklist — Move proprietary code into clawmetry-pro
+
+Follow this checklist when extracting paid/enterprise code from the OSS repo into clawmetry-pro.
+
+1. Define entitlement surface
+   - Finalize `entitlements.*` API (types, behavior) in OSS and add minimal unit tests.
+   - Add feature flags in OSS using `entitlements.allows_feature(...)` guard calls.
+
+2. Create clawmetry-pro package
+   - Move runtime adapters, license server, billing, advanced analytics, and cloud relay into `clawmetry-pro/`.
+   - Implement entry point via `clawmetry.extensions` or setuptools entry_points to register the extension when installed.
+
+3. Provide mocks and SDK
+   - Add `clawmetry-pro/mock_pro.py` for CI/local smoke tests.
+   - Publish a lightweight SDK or interface package to allow integration tests without secrets.
+
+4. CI and build changes
+   - Ensure OSS CI builds and tests without `clawmetry-pro` installed.
+   - Add a separate CI workflow in `clawmetry-pro` repo that depends on OSS release tags.
+   - Add smoke tests in OSS that run when `clawmetry-pro` is present (use mocks otherwise).
+
+5. Documentation & examples
+   - Update FLYWHEEL.md and AGENTS.md with the split and extension install instructions.
+   - Add a short public README (already present) and link to migration checklist.
+
+6. Security & compliance
+   - Sanitize any example configs (no secrets in repo).
+   - Produce a security summary and testing notes; include contact for audit requests.
+
+7. Release & packaging
+   - Publish `clawmetry-pro` as a separate package/wheel; integrate with license server if applicable.
+   - Update OSS to detect and enable pro features when the extension is installed.
+
+Notes
+- Keep commits small and atomic. Use the migration checklist as a PR template for each major move.
+- Test all changes against the local dev flow `make dev` and `make test-api` before merging.

--- a/clawmetry-pro/README.md
+++ b/clawmetry-pro/README.md
@@ -1,0 +1,29 @@
+# ClawMetry Pro — enterprise runtime adapters & paid features
+
+ClawMetry Pro provides advanced, enterprise-grade adapters, licensing, and analytics built to integrate with the open-source ClawMetry core.
+
+What’s public
+- APIs, SDKs, schemas, and sanitized integration examples so customers and auditors can validate compatibility.
+
+What remains proprietary
+- Enterprise adapters and licensed runtime integrations (paid model runtimes)
+- License server, usage/billing integration, and prebuilt wheels
+- Advanced analytics, cloud relay, and admin panels that implement paid features and entitlements
+
+Security & trust
+- No customer secrets are stored in source. The product undergoes internal security reviews; contact security@clawmetry.com for audit summaries or to request an independent review.
+
+Evaluation & licensing
+- Trial licenses and evaluation images available on request. See LICENSE and PRICING.md for terms.
+
+Getting started
+- Use the OSS `clawmetry` package for local testing. To evaluate Pro features, request a trial key at sales@clawmetry.com.
+
+Contact & support
+- sales@clawmetry.com — trials & pricing
+- support@clawmetry.com — technical support
+- security@clawmetry.com — security & audit inquiries
+
+---
+
+This README is intended as a short public summary for the ClawMetry Pro repository. For implementation details and a migration checklist, see CONTRIBUTING.md or contact the team at sales@clawmetry.com.

--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -4781,6 +4781,15 @@ function renderBrainFilterChips(sources) {
 function renderBrainTypeChips(events) {
   var container = document.getElementById('brain-type-chips');
   if (!container || !events) return;
+  // Scope the counts to the header's runtime selection, exactly like the
+  // list (renderBrainStream) and chart (renderBrainChart) do. Node-wide
+  // counts over a runtime-scoped list read as a bug: a ?runtime=cursor tab
+  // showed "AGENT (84)" chips over a 1-row stream because the 84 were
+  // another runtime's events (live-hit 2026-07-25).
+  var _tcRt = (typeof _cmRuntimeFilter === 'function') ? _cmClientFilterRt(_cmRuntimeFilter()) : 'all';
+  if (_tcRt && _tcRt !== 'all' && typeof _cmRuntimeOf === 'function') {
+    events = events.filter(function(ev) { return _cmRuntimeOf(ev) === _tcRt; });
+  }
   var typeColors = {'USER':'#60a5fa','AGENT':'#a855f7','EXEC':'#f59e0b','THINK':'#94a3b8','TOOL':'#f97316','WRITE':'#10b981','SEARCH':'#06b6d4','BROWSER':'#ec4899','SPAWN':'#8b5cf6','MSG':'#22c55e','READ':'#6ee7b7','CONTEXT':'#64748b','RESULT':'#6ee7b7'};
   var typeCounts = {};
   events.forEach(function(ev) { typeCounts[ev.type] = (typeCounts[ev.type]||0) + 1; });

--- a/tests/test_brain_type_chips_scope.js
+++ b/tests/test_brain_type_chips_scope.js
@@ -1,0 +1,93 @@
+// renderBrainTypeChips must count only the selected runtime's events.
+//
+// The Brain LIST (renderBrainStream) and CHART (renderBrainChart) scope to
+// the header's runtime switcher, but the type-count chips counted the whole
+// node-wide event array. On a ?runtime=cursor tab whose window held mostly
+// Claude Code events, the user saw "AGENT (84)" chips above a 1-row stream
+// (live-hit 2026-07-25) — counts that contradict the list they label.
+//
+// Extraction pattern mirrors test_brain_time_range.js: pull the shipped
+// function out of app.js via regex + vm so the test tracks the real source.
+
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const APP_JS = path.join(__dirname, '..', 'clawmetry', 'static', 'js', 'app.js');
+const src = fs.readFileSync(APP_JS, 'utf8');
+
+let passed = 0;
+let failed = 0;
+
+function truthy(v, label) {
+  if (v) { passed++; console.log('  ok   ' + label); }
+  else { failed++; console.log('  FAIL ' + label + ' (got falsy)'); }
+}
+
+function extractFunction(name) {
+  const re = new RegExp('^function ' + name + '\\b[\\s\\S]*?^\\}', 'm');
+  const m = src.match(re);
+  if (!m) throw new Error('could not find function ' + name + ' in app.js');
+  return m[0];
+}
+
+function chipsHtmlFor(runtimeFilter, events) {
+  const container = { innerHTML: '' };
+  const sandbox = {
+    document: { getElementById: (id) => (id === 'brain-type-chips' ? container : null) },
+    _brainTypeFilter: 'all',
+    // Header switcher state + the same helpers the list/chart use.
+    _cmRuntimeFilter: () => runtimeFilter,
+    _cmClientFilterRt: (rt) => rt,
+    _cmRuntimeOf: (ev) => ev.runtime || 'openclaw',
+    console,
+  };
+  vm.createContext(sandbox);
+  vm.runInContext(extractFunction('renderBrainTypeChips'), sandbox);
+  vm.runInContext(
+    'renderBrainTypeChips(' + JSON.stringify(events) + ')', sandbox);
+  return container.innerHTML;
+}
+
+const MIXED = [
+  { type: 'AGENT', runtime: 'claude_code' },
+  { type: 'AGENT', runtime: 'claude_code' },
+  { type: 'EXEC',  runtime: 'claude_code' },
+  { type: 'USER',  runtime: 'cursor' },
+  { type: 'AGENT', runtime: 'cursor' },
+];
+
+{
+  const html = chipsHtmlFor('cursor', MIXED);
+  truthy(html.indexOf('USER (1)') >= 0,
+         'cursor scope: USER counts only cursor events');
+  truthy(html.indexOf('AGENT (1)') >= 0,
+         'cursor scope: AGENT count excludes claude_code AGENT rows');
+  truthy(html.indexOf('EXEC') < 0,
+         'cursor scope: other-runtime-only types disappear');
+}
+
+{
+  const html = chipsHtmlFor('all', MIXED);
+  truthy(html.indexOf('AGENT (3)') >= 0, 'all scope: node-wide AGENT count kept');
+  truthy(html.indexOf('EXEC (1)') >= 0, 'all scope: EXEC chip present');
+}
+
+{
+  // Helpers absent (old embeds, race at parse time): degrade to node-wide.
+  const container = { innerHTML: '' };
+  const sandbox = {
+    document: { getElementById: () => container },
+    _brainTypeFilter: 'all',
+    console,
+  };
+  vm.createContext(sandbox);
+  vm.runInContext(extractFunction('renderBrainTypeChips'), sandbox);
+  vm.runInContext('renderBrainTypeChips(' + JSON.stringify(MIXED) + ')', sandbox);
+  truthy(container.innerHTML.indexOf('AGENT (3)') >= 0,
+         'no helpers: falls back to unscoped counts, never throws');
+}
+
+console.log('');
+console.log('PASS ' + passed + ' / FAIL ' + failed);
+process.exit(failed === 0 ? 0 : 1);

--- a/tests/test_brain_type_chips_scope_js.py
+++ b/tests/test_brain_type_chips_scope_js.py
@@ -1,0 +1,37 @@
+"""Runner for the Node-based Brain type-chip runtime-scope unit tests.
+
+``tests/test_brain_type_chips_scope.js`` extracts ``renderBrainTypeChips``
+from the shipped app.js (vm + regex, same pattern as test_brain_time_range)
+and asserts the chip counts follow the header runtime switcher the same way
+the list and chart do — node-wide counts over a runtime-scoped stream read
+as a bug ("AGENT (84)" above a 1-row cursor feed, live-hit 2026-07-25).
+
+Skipped (not failed) when ``node`` is not on PATH.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+
+import pytest
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_JS_TEST = os.path.join(_HERE, "test_brain_type_chips_scope.js")
+
+
+@pytest.mark.skipif(
+    shutil.which("node") is None,
+    reason="node not on PATH; JS unit tests only run when Node is available",
+)
+def test_brain_type_chips_scope_js_suite() -> None:
+    proc = subprocess.run(
+        ["node", _JS_TEST],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert proc.returncode == 0, (
+        "JS suite failed:\n" + proc.stdout + "\n" + proc.stderr
+    )


### PR DESCRIPTION
Adds ClawMetry Pro README, MIGRATION_CHECKLIST.md, and a PR template for migrating paid/enterprise code into clawmetry-pro. Worktree branch: add-pro-readme-wt.