### PR TITLE
[RELEASE] feat(parity): runtime feature parity — Agent Graph, Approvals, Logs, Security across all runtimes (0.12.639)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,37 @@
+## 0.12.639
+
+- **Runtime feature parity: the dashboard stops being OpenClaw-first.** Every
+  advertised surface now runs on real per-runtime logic or gates honestly:
+  - **Agent Graph for every runtime.** Spans are reconstructed from each family
+    runtime's normalized events at ingest (session root, llm.call, tool.<n>,
+    agent.spawn from Task tool-calls + subagent records) with the real
+    agent_type/agent_id, so "who spawned whom" renders with real cost/token
+    rollups — Claude Code shows main → Explore/general-purpose/... instead of
+    an empty panel. Graph honours the runtime switcher (?runtime=).
+  - **Approvals works locally for all runtimes — and Claude Code gets a real
+    pre-tool gate.** The tab now reads the local DuckDB queue and writes
+    policies.yml through validated endpoints; a generic gate-handler seam
+    turns the OpenClaw exec-policy flip into one handler and adds a Claude
+    Code PreToolUse hook (merge-safe installer, `clawmetry hook claude-code`
+    client, sliced long-poll receiver, fail-open, loopback-only) so a policy
+    match parks the tool call until you decide from the dashboard.
+  - **Logs are runtime-aware.** /api/logs + /api/logs-stream take ?runtime=
+    and serve the adapter's declared LogSource (hermes errors.log, nanoclaw
+    docker logs, codex codex-tui.log, n8n event log) or say honestly that a
+    runtime has no daemon log stream — never another runtime's logs under the
+    selected runtime's name.
+  - **Security posture scans the selected runtime.** Provider registry with
+    the full OpenClaw scan moved intact, a real Claude Code provider
+    (settings.json permissions/hooks/MCP auto-trust/dangerous grants), a
+    Codex provider (approval_policy/sandbox_mode), and a neutral
+    "not available yet" envelope instead of a red openclaw.json failure.
+  - **Tab visibility can no longer lie.** The sidebar derives from each
+    adapter's declared capabilities served by /api/agents (static map is just
+    the fallback), the dead 'cost' tab id is fixed so no-cost runtimes hide
+    the Cost tab, and logs/version-impact leave the false "node-wide" set.
+  Pairs with clawmetry-pro 0.7.2 (claude_code declares SUBAGENTS; hermes/
+  nanoclaw/codex/n8n declare real log sources).
+
 ## 0.12.637
 
 - Re-publish of 0.12.636: the published 0.12.636 wheel raced the merge commit

--- a/dashboard.py
+++ b/dashboard.py
@@ -267,7 +267,7 @@ def _otlp_service_name_to_agent_type(service_name):
     return slug or "custom"
 
 
-__version__ = "0.12.637"
+__version__ = "0.12.639"
 
 # Extensions (Phase 2): import the plugin host now, but defer the actual
 # load_plugins() call until after the Flask app is created below so we can


### PR DESCRIPTION
Carrier PR to publish 0.12.639 — the first PyPI artifact carrying #4464 (runtime feature parity: real Agent Graph spans for every family runtime, local-first Approvals + Claude Code PreToolUse gate, runtime-aware Logs and Security posture, server-authoritative capability gating).

Companion clawmetry-pro 0.7.2 is merged (#116): claude_code declares SUBAGENTS, hermes/nanoclaw/codex/n8n declare real log sources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)