### PR TITLE
[RELEASE] feat(alerts,approvals): runtime-scoped by default, node-wide by choice (0.12.640)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+## 0.12.640
+
+- **Alerts and approvals are runtime-scoped by default.** Alert rules carry a
+  per-rule scope: creating a rule while the runtime switcher is set inherits
+  that runtime, and "All runtimes (node-wide)" is the explicit opt-in (rule
+  rows show a scope chip either way). Scoped rules evaluate per-runtime
+  slices end to end: daily-spend and token-velocity read the per-runtime
+  DuckDB rollups, event-stream rules filter by the session-id prefix, and
+  quality rules (score drop / failure rate) read a per-runtime quality
+  window — a scoped rule never fires on a node-wide number.
+- **The Approvals tab now shows for every runtime** (it was hidden behind the
+  OpenClaw gateway capability) and scopes its pending + history rows to the
+  selected runtime; /api/approvals and /api/approvals-audit accept
+  ?runtime=. The stale "node-wide" banner is gone from both tabs.
+
 ## 0.12.639
 
 - **Runtime feature parity: the dashboard stops being OpenClaw-first.** Every

--- a/clawmetry/alert_evaluator.py
+++ b/clawmetry/alert_evaluator.py
@@ -102,11 +102,42 @@ DEFAULT_QUALITY_MIN_SESSIONS = 3
 # ── Public API ────────────────────────────────────────────────────────────────
 
 
+# Session-id prefix -> runtime scoping (founder 2026-08-03: rules are
+# runtime-scoped by default). Pure helper: a namespaced session id like
+# "copilot:<uuid>" belongs to that runtime; anything without a known family
+# prefix is OpenClaw. The known-prefix set comes from
+# ``clawmetry.entitlements.ALL_RUNTIMES`` (a constants frozenset, no I/O);
+# if that import ever fails the helper degrades to "prefix as-is".
+def _session_runtime(sid: Any) -> str:
+    sid = str(sid or "")
+    if ":" not in sid:
+        return "openclaw"
+    head = sid.split(":", 1)[0]
+    try:
+        from clawmetry.entitlements import ALL_RUNTIMES
+        return head if head in ALL_RUNTIMES else "openclaw"
+    except ImportError:
+        return head or "openclaw"
+
+
+def _rule_runtime(raw_rule: dict[str, Any]) -> str:
+    """A rule's runtime scope: the row's ``runtime`` column (local SQLite
+    bridge) or ``condition_json.runtime`` (cloud-authored), else 'all'."""
+    rt = raw_rule.get("runtime")
+    if not rt:
+        cond = raw_rule.get("condition_json")
+        if isinstance(cond, dict):
+            rt = cond.get("runtime")
+    rt = str(rt or "all").strip().lower()
+    return rt or "all"
+
+
 def evaluate(
     rules: list[dict[str, Any]] | None,
     events: list[dict[str, Any]] | None,
     last_eval_state: dict[str, Any] | None,
     quality: dict[str, Any] | None = None,
+    quality_by_runtime: dict[str, dict[str, Any]] | None = None,
 ) -> list[dict[str, Any]]:
     """Pure evaluator. Walks ``events`` against ``rules``, returns matches.
 
@@ -175,8 +206,22 @@ def evaluate(
             # protects channels from notification storms.
             continue
 
+        rule_rt = _rule_runtime(raw_rule)
+        if rule_rt != "all":
+            rule_events = [e for e in events_chrono
+                           if _session_runtime(e.get("session_id")) == rule_rt]
+            # Quality slices are AGGREGATES (no session ids), so a scoped
+            # rule needs a per-runtime slice pre-fetched by the caller.
+            # Missing slice -> None -> quality rule types no-fire for that
+            # tick (honest under-fire; never a node-wide number under a
+            # runtime label).
+            rule_quality = (quality_by_runtime or {}).get(rule_rt)
+        else:
+            rule_events = events_chrono
+            rule_quality = quality
+
         try:
-            match = _evaluate_one(rule, events_chrono, quality)
+            match = _evaluate_one(rule, rule_events, rule_quality)
         except Exception as e:
             log.warning("alerts: rule %s evaluator errored: %s", rid, e)
             continue

--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -8367,6 +8367,7 @@ class LocalStore:
         self,
         *,
         window_minutes: int = 60,
+        runtime: str | None = None,
     ) -> dict[str, Any]:
         """Quality snapshot over a recent window for the eval->monitor alert
         loop (``eval_score_below`` + ``outcome_failure_rate`` rule types).
@@ -8399,6 +8400,11 @@ class LocalStore:
             window_minutes = 60
         now_ms = int(time.time() * 1000)
         cutoff_ms = now_ms - window_minutes * 60 * 1000
+        # Optional per-runtime scope (runtime-scoped alert rules): reuse the
+        # shared session-id prefix clause so scoped quality reconciles with
+        # the other per-runtime slices by construction.
+        _rt_clause, _rt_params = _runtime_session_id_clause(runtime)
+        _rt_sql = f" AND {_rt_clause}" if _rt_clause else ""
 
         # ── Eval-score window ────────────────────────────────────────────────
         eval_scores: list[float] = []
@@ -8409,9 +8415,9 @@ class LocalStore:
                   FROM sessions
                  WHERE eval_score IS NOT NULL
                    AND eval_scored_at IS NOT NULL
-                   AND eval_scored_at >= ?
+                   AND eval_scored_at >= ?""" + _rt_sql + """
                 """,
-                [cutoff_ms],
+                [cutoff_ms, *_rt_params],
             )
             for r in rows:
                 if r and r[0] is not None:
@@ -8440,10 +8446,10 @@ class LocalStore:
                  WHERE outcome IS NOT NULL
                    AND outcome <> 'ongoing'
                    AND outcome_classified_at IS NOT NULL
-                   AND outcome_classified_at >= ?
+                   AND outcome_classified_at >= ?""" + _rt_sql + """
                  GROUP BY outcome
                 """,
-                [cutoff_ms],
+                [cutoff_ms, *_rt_params],
             )
             for r in rows:
                 label = (r[0] or "").strip()

--- a/clawmetry/static/js/alerts.js
+++ b/clawmetry/static/js/alerts.js
@@ -271,8 +271,16 @@
     // alert_type so the toggle reflects its real state; an OFF row uses the
     // example template and creates the rule on toggle-on. This keeps all
     // types visible after you enable one (the old render hid the rest).
+    const activeRt = (typeof _cmRuntimeFilter === 'function') ? _cmRuntimeFilter() : 'all';
+    const ruleRt = r => String(r.runtime || 'all').toLowerCase();
+    const rtLabel = rt => (typeof _CM_RT_LABEL === 'object' && _CM_RT_LABEL[rt]) || rt;
     wrap.innerHTML = EXAMPLE_RULES.map(ex => {
-      const real = alertsState.rules.find(r => r.alert_type === ex.alert_type);
+      // Per-runtime scope: under a runtime filter, that runtime's own rule
+      // wins the row; a node-wide rule still shows but is labeled as such.
+      const candidates = alertsState.rules.filter(r => r.alert_type === ex.alert_type
+        && (activeRt === 'all' || ruleRt(r) === activeRt || ruleRt(r) === 'all'));
+      const real = candidates.find(r => activeRt !== 'all' && ruleRt(r) === activeRt)
+        || candidates[0];
       const on = !!(real && real.enabled);
       const id = real ? real.id : ex.id;
       const meta = RULE_TYPE_LABELS[ex.alert_type] || { icon: '🔔', verb: ex.alert_type };
@@ -293,11 +301,16 @@
           }).join('')
         : `<span class="alerts-chan-pill off">${ex._exampleChannels}</span>`;
       const badge = real ? '' : '<span class="alerts-rule-example-badge">example</span>';
+      const scopeChip = real
+        ? (ruleRt(real) === 'all'
+            ? '<span class="alerts-chan-pill off" title="Evaluates across all runtimes on this node">node-wide</span>'
+            : '<span class="alerts-chan-pill" title="Evaluates only this runtime">' + escape(rtLabel(ruleRt(real))) + '</span>')
+        : '';
       return `
         <div class="alerts-rule-row${real ? '' : ' alerts-rule-example'}" data-rule-id="${id}">
           <div class="alerts-rule-dot ${on ? 'on' : 'off'}" title="${on ? 'Enabled' : 'Disabled'}"></div>
           <div class="alerts-rule-main">
-            <div class="alerts-rule-title">${meta.icon} ${escape(name)} ${badge}</div>
+            <div class="alerts-rule-title">${meta.icon} ${escape(name)} ${badge} ${scopeChip}</div>
             <div class="alerts-rule-meta">${metaLine}</div>
           </div>
           <div class="alerts-rule-chan">${channelPills || '<span class="alerts-chan-pill off">no channels</span>'}</div>
@@ -640,6 +653,16 @@
     };
     const p = presets[t] || { unit: '', placeholder: 0, label: 'Threshold', name: 'Custom alert' };
     const val = r.threshold_value ?? p.placeholder;
+    // Scope: runtime-scoped by default (founder 2026-08-03) — a new rule
+    // inherits the active runtime filter; node-wide is the explicit opt-in.
+    const activeRt = (typeof _cmRuntimeFilter === 'function') ? _cmRuntimeFilter() : 'all';
+    const curScope = String(r.runtime || (activeRt !== 'all' ? activeRt : 'all')).toLowerCase();
+    const rtLabel = rt => (typeof _CM_RT_LABEL === 'object' && _CM_RT_LABEL[rt]) || rt;
+    const known = (typeof _CM_RT_LABEL === 'object') ? Object.keys(_CM_RT_LABEL) : [];
+    const scopeOpts = ['all'].concat(known).map(rt => {
+      const label = rt === 'all' ? 'All runtimes (node-wide)' : rtLabel(rt);
+      return `<option value="${rt}" ${rt === curScope ? 'selected' : ''}>${escape(label)}</option>`;
+    }).join('');
     document.getElementById('alerts-editor-form').innerHTML = `
       <div class="alerts-form-row">
         <label>Name</label>
@@ -649,6 +672,10 @@
         <label>${p.label}</label>
         <input type="number" id="alerts-rule-threshold" value="${val}" step="any" style="width:120px;" />
         <span class="alerts-form-unit">${p.unit}</span>
+      </div>
+      <div class="alerts-form-row">
+        <label>Applies to</label>
+        <select id="alerts-rule-scope">${scopeOpts}</select>
       </div>
     `;
   }
@@ -693,6 +720,10 @@
       return openPaywall();
     }
 
+    const scopeSel = document.getElementById('alerts-rule-scope');
+    const runtime = scopeSel ? (scopeSel.value || 'all')
+      : ((typeof _cmRuntimeFilter === 'function' && _cmRuntimeFilter() !== 'all')
+          ? _cmRuntimeFilter() : 'all');
     const body = {
       alert_type: alertsState.editorType,
       name,
@@ -700,6 +731,7 @@
       enabled: true,
       channel_ids: channelIds,
       re_alert_policy: policy,
+      runtime,
     };
 
     const isEdit = !!alertsState.editorRule;

--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -9047,8 +9047,11 @@ var _CM_RT_AGGREGATE = {};
 // memory/skills are workspace-level, security is machine posture, self-evolve is
 // node findings. The runtime selector simply does not apply to these.
 var _CM_RT_NODEWIDE = {
-  crons: 1, memory: 1, security: 1, skills: 1, selfevolve: 1, approvals: 1,
-  alerts: 1, policy: 1, nemoclaw: 1, notifications: 1, dives: 1,
+  // approvals + alerts left this map 2026-08-03: approvals rows filter by
+  // the requesting session's runtime prefix, and alert rules carry their own
+  // per-rule scope (runtime column, node-wide chip when 'all').
+  crons: 1, memory: 1, security: 1, skills: 1, selfevolve: 1,
+  policy: 1, nemoclaw: 1, notifications: 1, dives: 1,
   clusters: 1, actions: 1,
   // logs + version-impact are NOT node-wide: logs stream a specific runtime's
   // log source (LOGS capability), version-impact correlates OpenClaw releases.
@@ -9109,8 +9112,9 @@ var _CM_CAP_TABS = {
   LOGS:        ['logs'],
   // approvals moved out of GATEWAY_RPC: the queue is local + runtime-agnostic
   // (event watcher covers every adapter; pre-tool gates are per-runtime
-  // handlers), so it is a node tab now. policy/selfevolve/version-impact stay
-  // OpenClaw gateway/admin concepts.
+  // handlers), so it is a node tab now — and it SCOPES its rows to the
+  // selected runtime via the requesting session-id prefix.
+  // policy/selfevolve/version-impact stay OpenClaw gateway/admin concepts.
   GATEWAY_RPC: ['policy','selfevolve','version-impact'],
   CHANNELS:    ['flow']
 };

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -20466,6 +20466,7 @@ def _evaluate_alerts_local(config: dict, state: dict) -> int:
         state["alerts_eval_memo"] = last_eval_state
 
     quality = None
+    quality_by_runtime = None
     try:
         quality_window = _alerts_quality_window_minutes(rules)
     except Exception:
@@ -20480,10 +20481,29 @@ def _evaluate_alerts_local(config: dict, state: dict) -> int:
                 "alerts(local): query_session_quality_window failed: %s", e
             )
             quality = None
+        # Runtime-scoped rules read a per-runtime quality slice (the node
+        # slice is an aggregate a scoped rule must never fire on).
+        try:
+            scoped_rts = sorted({
+                alert_evaluator._rule_runtime(r) for r in rules
+            } - {"all"})
+            if scoped_rts:
+                quality_by_runtime = {}
+                for _rt in scoped_rts:
+                    try:
+                        quality_by_runtime[_rt] = (
+                            store.query_session_quality_window(
+                                window_minutes=quality_window, runtime=_rt,
+                            ))
+                    except Exception:
+                        continue
+        except Exception:
+            quality_by_runtime = None
 
     try:
         matches = alert_evaluator.evaluate(
-            rules, events, last_eval_state, quality
+            rules, events, last_eval_state, quality,
+            quality_by_runtime=quality_by_runtime,
         )
     except Exception as e:
         log.warning("alerts(local): evaluator errored: %s", e)

--- a/clawmetry/templates/tabs/approvals.html
+++ b/clawmetry/templates/tabs/approvals.html
@@ -552,6 +552,17 @@
         p = (pending.approvals || []).filter(function(r){return r.status==='pending';});
         h = (history.approvals || []).filter(function(r){return r.status!=='pending';});
       }
+      // Runtime scope (founder 2026-08-03): approvals are per-runtime by
+      // default — rows carry the requesting session id, whose prefix names
+      // the runtime. BOTH renders (pending + history) filter identically.
+      var _rt = (typeof _cmRuntimeFilter === 'function') ? _cmRuntimeFilter() : 'all';
+      if (_rt && _rt !== 'all' && typeof _cmRuntimeOf === 'function') {
+        var _match = function(r){
+          return _cmRuntimeOf({session_id: r.session_id || r.requestor_session_id}) === _rt;
+        };
+        p = p.filter(_match);
+        h = h.filter(_match);
+      }
 
       // Pending
       var pe = document.getElementById('approvals-pending-list');

--- a/dashboard.py
+++ b/dashboard.py
@@ -626,6 +626,7 @@ def _budget_init_db():
             channels TEXT NOT NULL,
             cooldown_min INTEGER DEFAULT 30,
             enabled INTEGER DEFAULT 1,
+            runtime TEXT DEFAULT 'all',
             created_at REAL NOT NULL,
             updated_at REAL NOT NULL
         );
@@ -645,6 +646,13 @@ def _budget_init_db():
         CREATE INDEX IF NOT EXISTS idx_alert_history_rule
             ON alert_history(rule_id, fired_at DESC);
     """)
+    try:
+        # Pre-0.12.639 DBs lack the per-runtime scope column. SQLite has no
+        # IF-NOT-EXISTS for columns; the duplicate-column error is the no-op.
+        db.execute("ALTER TABLE alert_rules ADD COLUMN runtime TEXT DEFAULT 'all'")
+        db.commit()
+    except Exception:
+        pass
     db.close()
 
 
@@ -2076,6 +2084,10 @@ def _budget_monitor_loop():
                 threshold = rule["threshold"]
                 channels = json.loads(rule.get("channels", '["banner"]'))
                 cooldown = rule.get("cooldown_min", 30) * 60
+                # Per-runtime scope: 'all' (node-wide) or one runtime id.
+                # Scoped rules read per-runtime slices from DuckDB via the
+                # daemon proxy; node-wide rules keep the legacy aggregates.
+                rt_scope = str(rule.get("runtime") or "all").lower()
 
                 last_fired = _budget_alert_cooldowns.get(rule_id, 0)
                 if now - last_fired < cooldown:
@@ -2085,8 +2097,12 @@ def _budget_monitor_loop():
                 msg = ""
 
                 if rtype == "threshold":
-                    if status["daily_spent"] >= threshold:
-                        msg = f"Daily spending ${status['daily_spent']:.2f} exceeded threshold ${threshold:.2f}"
+                    _spent = status["daily_spent"]
+                    if rt_scope != "all":
+                        _spent = _runtime_daily_spend(rt_scope)
+                    if _spent is not None and _spent >= threshold:
+                        _scope_lbl = "" if rt_scope == "all" else f" [{rt_scope}]"
+                        msg = f"Daily spending{_scope_lbl} ${_spent:.2f} exceeded threshold ${threshold:.2f}"
                         fired = True
                 elif rtype == "spike":
                     # Spike: cost in last hour > threshold x average hourly rate
@@ -2110,20 +2126,29 @@ def _budget_monitor_loop():
                         msg = f"Spending spike: ${hour_cost:.2f} in last hour ({(hour_cost / avg_hourly):.1f}x average)"
                         fired = True
                 elif rtype == "token_spike":
-                    try:
-                        vel = _compute_velocity_status()
-                    except Exception:
-                        vel = None
-                    if vel:
-                        tokens_per_min = vel.get("tokensIn2Min", 0) / 2.0
-                        if tokens_per_min >= threshold:
-                            sid = vel.get("triggeringSession") or ""
-                            sid_hint = f" (session: {sid[:12]}...)" if sid else ""
+                    if rt_scope != "all":
+                        _tpm = _runtime_tokens_per_min(rt_scope)
+                        if _tpm is not None and _tpm >= threshold:
                             msg = (
-                                f"Token spike: {int(tokens_per_min):,} tokens/min "
-                                f"(threshold: {int(threshold):,}/min){sid_hint}"
+                                f"Token spike [{rt_scope}]: {int(_tpm):,} tokens/min "
+                                f"(threshold: {int(threshold):,}/min)"
                             )
                             fired = True
+                    else:
+                        try:
+                            vel = _compute_velocity_status()
+                        except Exception:
+                            vel = None
+                        if vel:
+                            tokens_per_min = vel.get("tokensIn2Min", 0) / 2.0
+                            if tokens_per_min >= threshold:
+                                sid = vel.get("triggeringSession") or ""
+                                sid_hint = f" (session: {sid[:12]}...)" if sid else ""
+                                msg = (
+                                    f"Token spike: {int(tokens_per_min):,} tokens/min "
+                                    f"(threshold: {int(threshold):,}/min){sid_hint}"
+                                )
+                                fired = True
                 elif rtype == "unproductive_burn":
                     # Issue #1707 — forward-progress signal. Fires when any
                     # session burns >= ``threshold`` tokens per state delta
@@ -2141,6 +2166,9 @@ def _budget_monitor_loop():
                         worst = None
                         for r in rows:
                             try:
+                                if rt_scope != "all" and _session_runtime_of(
+                                        r.get("session_id") or "") != rt_scope:
+                                    continue
                                 if float(r.get("ratio") or 0) >= float(threshold):
                                     if worst is None or r["ratio"] > worst["ratio"]:
                                         worst = r
@@ -9516,6 +9544,7 @@ def _budget_init_db():
             channels TEXT NOT NULL,
             cooldown_min INTEGER DEFAULT 30,
             enabled INTEGER DEFAULT 1,
+            runtime TEXT DEFAULT 'all',
             created_at REAL NOT NULL,
             updated_at REAL NOT NULL
         );
@@ -9535,6 +9564,13 @@ def _budget_init_db():
         CREATE INDEX IF NOT EXISTS idx_alert_history_rule
             ON alert_history(rule_id, fired_at DESC);
     """)
+    try:
+        # Pre-0.12.639 DBs lack the per-runtime scope column. SQLite has no
+        # IF-NOT-EXISTS for columns; the duplicate-column error is the no-op.
+        db.execute("ALTER TABLE alert_rules ADD COLUMN runtime TEXT DEFAULT 'all'")
+        db.commit()
+    except Exception:
+        pass
     db.close()
 
 
@@ -10098,6 +10134,54 @@ def _dispatch_alert_to_all_sinks(alert_data: dict) -> list[str]:
     return sent
 
 
+
+
+def _session_runtime_of(sid):
+    """Runtime id for a namespaced session id ('copilot:...' -> 'copilot');
+    anything without a known family prefix is OpenClaw."""
+    sid = str(sid or "")
+    if ":" in sid:
+        head = sid.split(":", 1)[0]
+        try:
+            from clawmetry.entitlements import ALL_RUNTIMES
+            if head in ALL_RUNTIMES:
+                return head
+        except ImportError:
+            pass
+    return "openclaw"
+
+
+def _runtime_daily_spend(runtime):
+    """Today's spend (USD) for ONE runtime from the per-(day, runtime)
+    DuckDB rollup, via the daemon proxy. None on any failure so a scoped
+    rule silently skips a tick rather than firing on a node-wide number."""
+    try:
+        from datetime import datetime as _dt, timezone as _tz
+        from routes.local_query import local_store_via_daemon
+        today = _dt.now(_tz.utc).strftime("%Y-%m-%d")
+        rows = local_store_via_daemon(
+            "query_rollup_runtime_daily", since=today) or []
+        return float(sum(
+            (r.get("cost_usd") or 0) for r in rows
+            if r.get("day") == today and r.get("runtime") == runtime))
+    except Exception:
+        return None
+
+
+def _runtime_tokens_per_min(runtime):
+    """Tokens/min over the last 2 minutes for ONE runtime (DuckDB events
+    filtered by session-id prefix via the daemon proxy). None on failure."""
+    try:
+        from datetime import datetime as _dt, timedelta as _td, timezone as _tz
+        from routes.local_query import local_store_via_daemon
+        since = (_dt.now(_tz.utc) - _td(minutes=2)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        rows = local_store_via_daemon(
+            "query_events", since=since, runtime=runtime, limit=20000) or []
+        return sum(int(r.get("token_count") or 0) for r in rows) / 2.0
+    except Exception:
+        return None
+
+
 def _get_alert_rules():
     """Get all alert rules."""
     try:
@@ -10457,6 +10541,10 @@ def _budget_monitor_loop():
                 threshold = rule["threshold"]
                 channels = json.loads(rule.get("channels", '["banner"]'))
                 cooldown = rule.get("cooldown_min", 30) * 60
+                # Per-runtime scope: 'all' (node-wide) or one runtime id.
+                # Scoped rules read per-runtime slices from DuckDB via the
+                # daemon proxy; node-wide rules keep the legacy aggregates.
+                rt_scope = str(rule.get("runtime") or "all").lower()
 
                 last_fired = _budget_alert_cooldowns.get(rule_id, 0)
                 if now - last_fired < cooldown:
@@ -10466,8 +10554,12 @@ def _budget_monitor_loop():
                 msg = ""
 
                 if rtype == "threshold":
-                    if status["daily_spent"] >= threshold:
-                        msg = f"Daily spending ${status['daily_spent']:.2f} exceeded threshold ${threshold:.2f}"
+                    _spent = status["daily_spent"]
+                    if rt_scope != "all":
+                        _spent = _runtime_daily_spend(rt_scope)
+                    if _spent is not None and _spent >= threshold:
+                        _scope_lbl = "" if rt_scope == "all" else f" [{rt_scope}]"
+                        msg = f"Daily spending{_scope_lbl} ${_spent:.2f} exceeded threshold ${threshold:.2f}"
                         fired = True
                 elif rtype == "spike":
                     # Spike: cost in last hour > threshold x average hourly rate
@@ -10491,20 +10583,29 @@ def _budget_monitor_loop():
                         msg = f"Spending spike: ${hour_cost:.2f} in last hour ({(hour_cost / avg_hourly):.1f}x average)"
                         fired = True
                 elif rtype == "token_spike":
-                    try:
-                        vel = _compute_velocity_status()
-                    except Exception:
-                        vel = None
-                    if vel:
-                        tokens_per_min = vel.get("tokensIn2Min", 0) / 2.0
-                        if tokens_per_min >= threshold:
-                            sid = vel.get("triggeringSession") or ""
-                            sid_hint = f" (session: {sid[:12]}...)" if sid else ""
+                    if rt_scope != "all":
+                        _tpm = _runtime_tokens_per_min(rt_scope)
+                        if _tpm is not None and _tpm >= threshold:
                             msg = (
-                                f"Token spike: {int(tokens_per_min):,} tokens/min "
-                                f"(threshold: {int(threshold):,}/min){sid_hint}"
+                                f"Token spike [{rt_scope}]: {int(_tpm):,} tokens/min "
+                                f"(threshold: {int(threshold):,}/min)"
                             )
                             fired = True
+                    else:
+                        try:
+                            vel = _compute_velocity_status()
+                        except Exception:
+                            vel = None
+                        if vel:
+                            tokens_per_min = vel.get("tokensIn2Min", 0) / 2.0
+                            if tokens_per_min >= threshold:
+                                sid = vel.get("triggeringSession") or ""
+                                sid_hint = f" (session: {sid[:12]}...)" if sid else ""
+                                msg = (
+                                    f"Token spike: {int(tokens_per_min):,} tokens/min "
+                                    f"(threshold: {int(threshold):,}/min){sid_hint}"
+                                )
+                                fired = True
                 elif rtype == "unproductive_burn":
                     # Issue #1707 — forward-progress signal. Fires when any
                     # session burns >= ``threshold`` tokens per state delta
@@ -10522,6 +10623,9 @@ def _budget_monitor_loop():
                         worst = None
                         for r in rows:
                             try:
+                                if rt_scope != "all" and _session_runtime_of(
+                                        r.get("session_id") or "") != rt_scope:
+                                    continue
                                 if float(r.get("ratio") or 0) >= float(threshold):
                                     if worst is None or r["ratio"] > worst["ratio"]:
                                         worst = r

--- a/dashboard.py
+++ b/dashboard.py
@@ -267,7 +267,7 @@ def _otlp_service_name_to_agent_type(service_name):
     return slug or "custom"
 
 
-__version__ = "0.12.639"
+__version__ = "0.12.640"
 
 # Extensions (Phase 2): import the plugin host now, but defer the actual
 # load_plugins() call until after the Flask app is created below so we can

--- a/routes/alerts.py
+++ b/routes/alerts.py
@@ -689,6 +689,18 @@ def api_alert_rules():
         channels = data.get("channels", ["banner"])
         cooldown = data.get("cooldown_min", 30)
         enabled = data.get("enabled", True)
+        # Per-runtime scope (founder 2026-08-03): rules are runtime-scoped by
+        # default — the Alerts tab sends the active runtime filter — and
+        # "all" is the explicit node-wide opt-in. Unknown runtime ids are
+        # rejected rather than silently widened to node-wide.
+        runtime = str(data.get("runtime") or "all").strip().lower()
+        if runtime != "all":
+            try:
+                from clawmetry.entitlements import ALL_RUNTIMES
+                if runtime not in ALL_RUNTIMES:
+                    return jsonify({"error": f"Unknown runtime '{runtime}'"}), 400
+            except ImportError:
+                pass
         # Self-hosted bridge (founder 2026-07-28: "alerts should work in the
         # self-hosted setup"): the Alerts tab speaks the cloud vocabulary
         # (alert_type / threshold_value / channel_ids). A locally-entitled
@@ -720,8 +732,8 @@ def api_alert_rules():
         with _d._fleet_db_lock:
             db = _d._fleet_db()
             db.execute(
-                "INSERT INTO alert_rules (id, type, threshold, channels, cooldown_min, enabled, created_at, updated_at) "
-                "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                "INSERT INTO alert_rules (id, type, threshold, channels, cooldown_min, enabled, runtime, created_at, updated_at) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 (
                     rule_id,
                     rtype,
@@ -729,6 +741,7 @@ def api_alert_rules():
                     json.dumps(channels),
                     cooldown,
                     1 if enabled else 0,
+                    runtime,
                     now,
                     now,
                 ),
@@ -738,7 +751,8 @@ def api_alert_rules():
         _audit("alert_rule.create", actor=_actor(), target=rule_id,
                result="created", source="dashboard",
                metadata={"type": rtype, "threshold": threshold,
-                         "channels": channels, "enabled": bool(enabled)})
+                         "channels": channels, "enabled": bool(enabled),
+                         "runtime": runtime})
         return jsonify({"ok": True, "id": rule_id})
     # Phase 3 of #1032 — local DuckDB fast path. Opt-in via
     # CLAWMETRY_LOCAL_STORE_READ=1; falls through to the legacy fleet-DB
@@ -798,6 +812,17 @@ def api_alert_rule(rule_id):
     if "channels" in data:
         sets.append("channels = ?")
         vals.append(json.dumps(data["channels"]))
+    if "runtime" in data:
+        _rt = str(data.get("runtime") or "all").strip().lower()
+        if _rt != "all":
+            try:
+                from clawmetry.entitlements import ALL_RUNTIMES
+                if _rt not in ALL_RUNTIMES:
+                    return jsonify({"error": f"Unknown runtime '{_rt}'"}), 400
+            except ImportError:
+                pass
+        sets.append("runtime = ?")
+        vals.append(_rt)
     if not sets:
         return jsonify({"error": "No fields to update"}), 400
     sets.append("updated_at = ?")
@@ -812,7 +837,7 @@ def api_alert_rule(rule_id):
            result="updated", source="dashboard",
            metadata={"fields": {k: data[k] for k in data
                                  if k in ("threshold", "cooldown_min",
-                                          "enabled", "channels")}})
+                                          "enabled", "channels", "runtime")}})
     return jsonify({"ok": True})
 
 

--- a/routes/policy.py
+++ b/routes/policy.py
@@ -141,7 +141,32 @@ def api_approvals_audit():
         limit = 100
     status = (request.args.get("status") or "").strip() or None
 
-    return jsonify(_approvals_audit_payload(status=status, limit=limit))
+    return jsonify(_approvals_audit_payload(
+        status=status, limit=limit, runtime=request.args.get("runtime")))
+
+
+def _session_runtime(sid):
+    """Runtime id from a namespaced session id; no known prefix -> openclaw."""
+    sid = str(sid or "")
+    if ":" in sid:
+        head = sid.split(":", 1)[0]
+        try:
+            from clawmetry.entitlements import ALL_RUNTIMES
+            if head in ALL_RUNTIMES:
+                return head
+        except ImportError:
+            return head
+    return "openclaw"
+
+
+def _filter_rows_by_runtime(rows, runtime):
+    """Scope approval rows to one runtime via requestor_session_id prefix.
+    runtime in (None, '', 'all') -> unfiltered."""
+    rt = (runtime or "").strip().lower()
+    if not rt or rt == "all":
+        return rows
+    return [r for r in rows
+            if _session_runtime(r.get("requestor_session_id")) == rt]
 
 
 @bp_policy.route("/api/approvals")
@@ -160,6 +185,7 @@ def api_approvals_queue():
     except (TypeError, ValueError):
         limit = 50
     rows = _coerce_rows(_ls_call("query_approvals", status="pending", limit=limit))
+    rows = _filter_rows_by_runtime(rows, request.args.get("runtime"))
     approvals = [
         {
             "id":                   r.get("id"),
@@ -175,11 +201,13 @@ def api_approvals_queue():
     return jsonify({"approvals": approvals, "count": len(approvals), "_source": "local_store"})
 
 
-def _approvals_audit_payload(status=None, limit=100):
+def _approvals_audit_payload(status=None, limit=100, runtime=None):
     """Exec-approval decision audit payload, shared by the HTTP route and the
     cloud snapshot builder (trial-bug #22: the Policy tab audit was blank on the
-    hosted dashboard). Returns {decisions, summary, _source}."""
+    hosted dashboard). Returns {decisions, summary, _source}. ``runtime``
+    scopes rows to one runtime via the session-id prefix (None/'all' = node)."""
     rows = _coerce_rows(_ls_call("query_approvals", status=status, limit=limit))
+    rows = _filter_rows_by_runtime(rows, runtime)
 
     decisions = []
     pending = approved = denied = simulated = 0

--- a/tests/test_alert_runtime_scope.py
+++ b/tests/test_alert_runtime_scope.py
@@ -1,0 +1,224 @@
+"""Runtime-scoped alert rules + approvals filtering (founder 2026-08-03:
+"each alert / approval should be runtime-wise by default, with a node-wide
+option").
+
+Three surfaces, all covered here:
+  * ``clawmetry.alert_evaluator`` — a rule carrying ``runtime`` (row column
+    or ``condition_json.runtime``) only sees that runtime's events (session-id
+    prefix), and quality-type rules read the per-runtime slice from
+    ``quality_by_runtime`` — NEVER the node aggregate.
+  * ``routes/alerts.py`` CRUD — ``runtime`` persists on create, updates on
+    PUT, defaults to node-wide ('all') for legacy callers, and unknown
+    runtime ids are rejected (never silently widened to node-wide).
+  * ``routes/policy.py`` — ``?runtime=`` scopes the approvals queue + audit
+    by the requesting session's prefix.
+
+Pure-unit for the evaluator; Flask test client + tmp fleet DB for the routes.
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+from clawmetry import alert_evaluator  # noqa: E402
+
+
+def _rule(rid, runtime=None, **cond):
+    row = {
+        "id": rid,
+        "name": f"rule {rid}",
+        "enabled": True,
+        "condition_json": cond,
+    }
+    if runtime is not None:
+        row["runtime"] = runtime
+    return row
+
+
+def _evt(i, session_id, et="error", ts="2026-08-03T01:00:00+00:00"):
+    return {"id": f"e{i}", "event_type": et, "ts": ts,
+            "session_id": session_id, "data": {}}
+
+
+# ── evaluator: event-stream rules ─────────────────────────────────────────
+
+
+def test_scoped_rule_only_sees_its_runtime_events():
+    rule = _rule("r1", runtime="copilot", type="count_over_threshold",
+                 event_type="error", threshold=2, window_sec=3600,
+                 cooldown_sec=0)
+    events = [
+        _evt(1, "copilot:aaa"), _evt(2, "copilot:bbb"),
+        _evt(3, "claude_code:ccc"), _evt(4, "bare-uuid-openclaw"),
+    ]
+    matches = alert_evaluator.evaluate([rule], events, {})
+    assert len(matches) == 1  # 2 copilot errors >= threshold 2
+
+    rule_hi = _rule("r2", runtime="copilot", type="count_over_threshold",
+                    event_type="error", threshold=3, window_sec=3600,
+                    cooldown_sec=0)
+    assert alert_evaluator.evaluate([rule_hi], events, {}) == []
+    # ...while an unscoped rule at the same threshold fires on all 4.
+    rule_all = _rule("r3", type="count_over_threshold", event_type="error",
+                     threshold=3, window_sec=3600, cooldown_sec=0)
+    assert len(alert_evaluator.evaluate([rule_all], events, {})) == 1
+
+
+def test_scope_via_condition_json_matches_row_column():
+    events = [_evt(1, "copilot:aaa"), _evt(2, "copilot:bbb")]
+    via_cond = _rule("rc", type="count_over_threshold", event_type="error",
+                     threshold=2, window_sec=3600, cooldown_sec=0,
+                     runtime="copilot")
+    assert len(alert_evaluator.evaluate([via_cond], events, {})) == 1
+
+
+def test_openclaw_scope_means_no_family_prefix():
+    rule = _rule("r4", runtime="openclaw", type="count_over_threshold",
+                 event_type="error", threshold=1, window_sec=3600,
+                 cooldown_sec=0)
+    matches = alert_evaluator.evaluate(
+        [rule], [_evt(1, "copilot:aaa"), _evt(2, "bare-uuid")], {})
+    assert len(matches) == 1
+    assert matches[0]["event"]["session_id"] == "bare-uuid"
+
+
+def test_scoped_quality_rule_never_reads_node_aggregate():
+    rule = _rule("q1", runtime="copilot", alert_type="eval_score_below",
+                 threshold=3, cooldown_sec=0)
+    node_quality = {"eval_count": 10, "eval_avg": 1.0,
+                    "outcome_classified": 0, "outcome_failed": 0,
+                    "window_minutes": 60}
+    # Node aggregate is WAY below threshold, but no per-runtime slice was
+    # provided -> the scoped rule must NOT fire on the node number.
+    assert alert_evaluator.evaluate([rule], [], {}, node_quality) == []
+    # With a per-runtime slice, it evaluates that slice.
+    per_rt = {"copilot": node_quality}
+    fired = alert_evaluator.evaluate(
+        [rule], [], {}, node_quality, quality_by_runtime=per_rt)
+    assert len(fired) == 1
+
+
+# ── routes: alert rule CRUD ───────────────────────────────────────────────
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    """Blueprint-only Flask app (the gate-test pattern) with a REAL sqlite
+    fleet DB in tmp so the runtime column round-trips end to end."""
+    import sqlite3
+    from flask import Flask
+    from routes.alerts import bp_alerts
+    from routes.policy import bp_policy
+    import dashboard as d
+
+    db_path = str(tmp_path / "fleet.db")
+
+    def _mk_db():
+        conn = sqlite3.connect(db_path)
+        conn.row_factory = sqlite3.Row
+        conn.execute(
+            """CREATE TABLE IF NOT EXISTS alert_rules (
+                id TEXT PRIMARY KEY, type TEXT NOT NULL,
+                threshold REAL NOT NULL, channels TEXT NOT NULL,
+                cooldown_min INTEGER DEFAULT 30, enabled INTEGER DEFAULT 1,
+                runtime TEXT DEFAULT 'all',
+                created_at REAL NOT NULL, updated_at REAL NOT NULL)""")
+        return conn
+
+    class _NoopLock:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    monkeypatch.setattr(d, "_fleet_db", _mk_db)
+    monkeypatch.setattr(d, "_fleet_db_lock", _NoopLock())
+
+    def _rules_from_db():
+        conn = _mk_db()
+        rows = [dict(r) for r in conn.execute(
+            "SELECT * FROM alert_rules ORDER BY created_at DESC").fetchall()]
+        conn.close()
+        return rows
+
+    monkeypatch.setattr(d, "_get_alert_rules", _rules_from_db)
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_READ", "0")
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_alerts)
+    app.register_blueprint(bp_policy)
+    app.config["TESTING"] = True
+    with app.test_client() as c:
+        yield c
+
+
+def _auth_post(client, url, json_body):
+    return client.post(url, json=json_body)
+
+
+def test_rule_create_persists_runtime(client):
+    r = _auth_post(client, "/api/alerts/rules",
+                   {"type": "threshold", "threshold": 5,
+                    "runtime": "copilot"})
+    assert r.status_code == 200, r.get_json()
+    rid = r.get_json()["id"]
+    rules = client.get("/api/alerts/rules").get_json()["rules"]
+    mine = [x for x in rules if x["id"] == rid]
+    assert mine and mine[0].get("runtime") == "copilot"
+    # PUT can rescope to node-wide.
+    r2 = client.put(f"/api/alerts/rules/{rid}", json={"runtime": "all"})
+    assert r2.status_code == 200
+    rules = client.get("/api/alerts/rules").get_json()["rules"]
+    assert [x for x in rules if x["id"] == rid][0].get("runtime") == "all"
+
+
+def test_rule_create_defaults_node_wide(client):
+    r = _auth_post(client, "/api/alerts/rules",
+                   {"type": "threshold", "threshold": 5})
+    assert r.status_code == 200
+    rid = r.get_json()["id"]
+    rules = client.get("/api/alerts/rules").get_json()["rules"]
+    assert [x for x in rules if x["id"] == rid][0].get("runtime") == "all"
+
+
+def test_rule_create_rejects_unknown_runtime(client):
+    r = _auth_post(client, "/api/alerts/rules",
+                   {"type": "threshold", "threshold": 5,
+                    "runtime": "notaruntime"})
+    assert r.status_code == 400
+
+
+# ── routes: approvals runtime filter ──────────────────────────────────────
+
+
+def test_approvals_queue_scopes_by_runtime(client, monkeypatch):
+    import routes.policy as pol
+    rows = [
+        {"id": "a1", "action": "exec", "status": "pending",
+         "requestor_session_id": "copilot:xyz", "args": "{}",
+         "created_at": "2026-08-03T00:00:00Z"},
+        {"id": "a2", "action": "exec", "status": "pending",
+         "requestor_session_id": "claude_code:abc", "args": "{}",
+         "created_at": "2026-08-03T00:00:00Z"},
+        {"id": "a3", "action": "exec", "status": "pending",
+         "requestor_session_id": "bare-openclaw-uuid", "args": "{}",
+         "created_at": "2026-08-03T00:00:00Z"},
+    ]
+    monkeypatch.setattr(pol, "_ls_call", lambda *a, **k: rows)
+
+    body = client.get("/api/approvals?runtime=copilot").get_json()
+    assert [a["id"] for a in body["approvals"]] == ["a1"]
+    body = client.get("/api/approvals?runtime=openclaw").get_json()
+    assert [a["id"] for a in body["approvals"]] == ["a3"]
+    body = client.get("/api/approvals").get_json()
+    assert len(body["approvals"]) == 3
+
+    audit = client.get("/api/approvals-audit?runtime=claude_code").get_json()
+    assert [d["id"] for d in audit["decisions"]] == ["a2"]


### PR DESCRIPTION
Answers the founder's report on the Alerts tab screenshot: alerts/approvals were node-wide relics from before multi-runtime, and the Approvals nav item vanished under a runtime filter because it was gated on the OpenClaw-only `GATEWAY_RPC` capability.

## Alerts
- `alert_rules.runtime` column ('all' default = node-wide back-compat; guarded ALTER for existing fleet DBs).
- **Default = the active runtime filter** when creating a rule; "All runtimes (node-wide)" is the explicit opt-in. Editor gets an *Applies to* selector; rows get a scope chip — a node-wide rule under a runtime filter is labeled, never silent.
- Scoped evaluation end to end, honestly: daily-spend via the per-runtime DuckDB rollup, token-velocity + unproductive-burn via session-prefix-filtered events, event-stream rules filtered in the shared evaluator, and quality rules via NEW per-runtime quality windows (`query_session_quality_window(runtime=…)` + `quality_by_runtime`) — **a scoped rule never fires on a node-wide number**; missing slice = honest under-fire.
- Unknown runtime ids are 400s — never silently widened.

## Approvals
- `?runtime=` on `/api/approvals` + `/api/approvals-audit` (session-prefix scoping); the tab filters pending + history identically. Composes with #4464 (which made the tab a node tab + added hook gates) — this PR makes it **scope**.
- Stale "node-wide" banners removed from both tabs.

## Tests
8 new in `tests/test_alert_runtime_scope.py` — evaluator scoping (incl. openclaw = no-family-prefix semantics and the quality-slice honesty contract), CRUD round-trip/validation, approvals filtering. Battery run: only failures are pre-existing on main (verified against pristine `origin/main`). Zero new lint findings on touched files.

Cloud follow-up (separate PR): the cloud alert API should persist `runtime` from the rule body so cloud-authored scoped rules relay to daemons with scope intact (`condition_json.runtime` is already read by the evaluator).

🤖 Generated with [Claude Code](https://claude.com/claude-code)