### PR TITLE
[RELEASE] fix(ci): build the merge commit — kills the ghost-wheel race (0.12.641)

### DIFF
--- a/.github/workflows/release-on-merge.yml
+++ b/.github/workflows/release-on-merge.yml
@@ -19,7 +19,11 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-          ref: main
+          # The MERGE COMMIT, not the branch ref: on pull_request-closed the
+          # `main` ref can lag the merge (replication race) — building it
+          # published GHOST wheels twice (0.12.636 + 0.12.640: version stamped,
+          # feature code absent). The merge_commit_sha is exact by definition.
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
 
       - uses: actions/setup-python@v7
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.12.641
+
+- Re-publish of 0.12.640 (same ghost-wheel race as 0.12.636: the release
+  workflow checked out the `main` ref before the merge commit propagated and
+  published without the runtime-scoped alerts/approvals code). Root cause
+  fixed: release-on-merge now builds the PR's merge_commit_sha exactly.
+
 ## 0.12.640
 
 - **Alerts and approvals are runtime-scoped by default.** Alert rules carry a

--- a/dashboard.py
+++ b/dashboard.py
@@ -267,7 +267,7 @@ def _otlp_service_name_to_agent_type(service_name):
     return slug or "custom"
 
 
-__version__ = "0.12.640"
+__version__ = "0.12.641"
 
 # Extensions (Phase 2): import the plugin host now, but defer the actual
 # load_plugins() call until after the Flask app is created below so we can


### PR DESCRIPTION
Two ghost wheels in one day (0.12.636, 0.12.640) from the same race: `release-on-merge.yml` checks out `ref: main` on the pull_request-closed event, and the `main` ref can lag the merge commit — so the workflow builds pre-merge content, self-bumps the version, and publishes a wheel that claims the feature but lacks the code. Crack-verification caught both.

- Fix: check out `github.event.pull_request.merge_commit_sha` (exact by definition; the workflow never pushes to the checked-out ref, so detached HEAD is safe — publishing + gh release + the version-bump PR all still work).
- Re-releases current main as **0.12.641** — the first artifact actually carrying the runtime-scoped alerts/approvals feature. Will crack-verify before any pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)