### PR TITLE
feat(license): license_features_at + /api/license/features-at

### DIFF
--- a/clawmetry/license.py
+++ b/clawmetry/license.py
@@ -3263,3 +3263,159 @@ def license_features() -> list[str] | None:
         out.append(norm)
     out.sort()
     return out
+
+
+def license_features_at(epoch: int) -> list[str] | None:
+    """Perspective-epoch flavour of :func:`license_features` -- "what
+    ``features`` claim would the installed license have surfaced
+    evaluated as of ``epoch``?" -- for a scheduled-audit / retrospective
+    diagnostic tile that wants to answer "which paid features was this
+    node entitled to on <date>?" without the caller having to snapshot
+    the license state at that time or compare ``exp`` to a caller-
+    supplied epoch themselves.
+
+    Returns a sorted, deduplicated, normalised (lower-cased, whitespace-
+    stripped) ``list[str]`` of feature ids on a signature-valid license
+    whose ``exp`` claim was still in the future as of ``epoch`` (or a
+    perpetual key, which is always active). Returns ``None`` in every
+    other branch:
+
+      * no license file on disk (OSS free -- time-independent)
+      * file exists but signature is bogus (time-independent: an
+        unsigned body is untrusted whatever the perspective; an attacker
+        who could edit the payload could otherwise smuggle any
+        ``features`` list into an unsigned body -- we never surface it)
+      * signed key whose ``exp`` claim has lapsed at ``epoch``.
+        Retrospective on a lapsed key when ``epoch`` equals "now";
+        prospective on an active key when ``epoch`` is in the future
+        beyond ``exp``. Matches :func:`license_features`'s "not entitled
+        AT THAT TIME" posture -- a gate binding this helper cannot
+        silently keep granting features on a key that had already
+        lapsed by ``epoch``.
+      * missing / non-numeric / ``bool`` ``epoch`` (the perspective is
+        unusable; conservative "no entitlement" fallback matching the
+        never-mis-gate posture of the surrounding ``_at`` family)
+      * any per-row failure inside the underlying read path
+
+    An empty list (``[]``) means the license IS signature-valid AS OF
+    ``epoch`` but its payload carries no explicit ``features`` claim
+    (or the claim is present but holds no usable string ids). ``[]`` is
+    deliberately DISTINCT from ``None``:
+
+      * ``[]``   -> "valid license as of that time, zero features
+                    itemised on the token"
+      * ``None`` -> "no valid license as of that time"
+
+    A caller binding this scalar to a "features unlocked at <date>" UI
+    must render both branches without collapsing them, or a valid-key-
+    with-empty-list user will silently get the same "unlicensed" copy
+    as an OSS install.
+
+    ``epoch`` is coerced through ``int()``; ``bool`` is explicitly
+    refused despite being an ``int`` subclass so a caller that passes
+    ``True`` / ``False`` gets ``None`` back rather than a spurious "was
+    the key expired at epoch 1?" classification. A non-numeric value
+    collapses to ``None`` so a caller cannot silently mis-gate on a
+    typo.
+
+    When ``epoch`` equals "now", this scalar must agree with
+    :func:`license_features` for the same install -- both derive from
+    the same signed ``features`` claim, refuse the invalid-signature
+    branch, and use the same ``exp <= cutoff`` boundary, so the two
+    scalars cannot disagree at the boundary. On any other epoch this
+    helper answers the retrospective / prospective question
+    :func:`license_features` cannot -- e.g. "was this node entitled to
+    alerts last quarter?" (``[]`` or ``None`` on a key that has since
+    been renewed but was already expired then) or "will this node still
+    have alerts at our next audit?" (``None`` on an active key whose
+    ``exp`` falls before the audit date).
+
+    Note: the ``features`` claim is a SUPPLEMENTAL string list carried
+    on the license token; it is NOT the canonical open-core feature
+    catalogue. This scalar surfaces the claim as it stood at ``epoch``.
+    For the resolved feature set actually enforced by gates, callers
+    should read :func:`clawmetry.entitlements.get_entitlement` (which
+    layers this claim on top of the FREE-tier baseline).
+
+    Pairs with :func:`license_state_at` / :func:`license_tier` /
+    :func:`license_subject` on the perspective-epoch accessor axis: for
+    the same ``epoch``, a caller can zip the responses and render a
+    whole entitlement audit row for one install without the accessors
+    catching each other disagreeing on the perspective-epoch
+    classification.
+
+    Never raises. Any underlying introspection failure (import error,
+    corrupt install, cryptography-lib mismatch) collapses to ``None`` --
+    matches the never-mis-gate fallback of :func:`license_features` -- so
+    a scheduled audit job bound to this helper stays "unclaimed" rather
+    than falsely asserting an entitlement it can't verify.
+    """
+    if isinstance(epoch, bool):
+        return None
+    try:
+        wanted = int(epoch)
+    except (TypeError, ValueError):
+        return None
+    try:
+        info = current_license_info()
+    except Exception as exc:
+        logger.debug(
+            "license: license_features_at underlying read failed: %s", exc
+        )
+        return None
+    if not isinstance(info, dict):
+        return None
+    # Invalid signature: never trust an unsigned body whatever the
+    # perspective. Matches :func:`license_state_at`'s time-independent
+    # "invalid" branch -- an attacker who could edit the payload could
+    # otherwise smuggle any ``features`` list into an unsigned body, for
+    # any epoch.
+    if info.get("status") == "invalid":
+        return None
+    exp = info.get("exp")
+    if isinstance(exp, (int, float)) and int(exp) <= wanted:
+        # Signed key that had already lapsed at ``epoch``. Matches
+        # :func:`license_features`'s refusal to surface a features list
+        # from a signed-but-lapsed key -- the "not entitled AT THAT
+        # TIME" posture.
+        return None
+    # ``current_license_info`` does not surface the ``features`` claim in
+    # its envelope (kept intentionally narrow -- see its docstring), so
+    # re-open the license file and re-verify to pull the field. The
+    # ``status != "invalid"`` gate above proves the file's signature
+    # verified once this call, so this second read cannot admit an
+    # unsigned body: any tamper between the two reads still fails
+    # ``verify_token``.
+    try:
+        if not os.path.isfile(LICENSE_PATH):
+            return None
+        with open(LICENSE_PATH, "r", encoding="utf-8") as fh:
+            payload = verify_token(fh.read().strip())
+    except Exception as exc:
+        logger.debug(
+            "license: license_features_at token re-read failed: %s", exc
+        )
+        return None
+    if not isinstance(payload, dict):
+        return None
+    raw = payload.get("features")
+    # A missing / non-list ``features`` claim collapses to the empty list
+    # (valid license as of that time, zero features itemised) -- distinct
+    # from ``None`` which means no valid license as of that time. Matches
+    # :func:`license_features`.
+    if not isinstance(raw, (list, tuple)):
+        return []
+    seen: set[str] = set()
+    out: list[str] = []
+    for item in raw:
+        if not isinstance(item, str):
+            # Ignore non-string entries defensively -- matches the
+            # scalar's handling.
+            continue
+        norm = item.strip().lower()
+        if not norm or norm in seen:
+            continue
+        seen.add(norm)
+        out.append(norm)
+    out.sort()
+    return out

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -8118,6 +8118,186 @@ def api_license_features():
         )
 
 
+def _license_features_at_snapshot() -> dict:
+    """Shared one-shot read for the paired ``/api/license/features`` /
+    ``/api/license/features-at`` endpoints.
+
+    Reads :func:`clawmetry.license.license_features` (current-time
+    features list), :func:`clawmetry.license.current_license_info` (for
+    ``has_license`` / ``valid`` NOW), and
+    :func:`clawmetry.license.license_expires_at` (for the ``expires_at``
+    field the sibling perspective-epoch tiles all carry) ONCE so a UI
+    binding both endpoints in the same tile can't catch them disagreeing
+    on ``features`` / ``expires_at`` / ``has_license`` / ``valid`` for
+    the same install -- mirrors the ``_license_state_at_snapshot``
+    pattern used by the state-derived perspective-epoch trio.
+
+    ``features`` here is the CURRENT-time features list (matches
+    :func:`clawmetry.license.license_features`); the perspective-epoch
+    features list (``features_at``) is derived per-request by the
+    endpoint via :func:`clawmetry.license.license_features_at` and
+    lives on top of this snapshot -- keeping ``features`` in the shared
+    read guarantees a UI that renders "as of <date> vs now" tiles
+    side-by-side can never catch them disagreeing on the current-time
+    reference.
+
+    Never raises. Any introspection failure collapses to the OSS-free
+    branch shape (``features=None``, ``expires_at=None``,
+    ``has_license=False``, ``valid=False``) so the endpoint stack never
+    5xxs -- same posture as the surrounding license endpoints.
+    """
+    try:
+        from clawmetry import license as _lic
+
+        feats = _lic.license_features()
+        info = _lic.current_license_info()
+        expires = _lic.license_expires_at()
+    except Exception as exc:
+        logger.debug(
+            "_license_features_at_snapshot: underlying read failed: %s", exc
+        )
+        return {
+            "features": None,
+            "expires_at": None,
+            "has_license": False,
+            "valid": False,
+        }
+    if feats is not None and not isinstance(feats, list):
+        feats = None
+    if not isinstance(info, dict):
+        return {
+            "features": feats,
+            "expires_at": None,
+            "has_license": False,
+            "valid": False,
+        }
+    return {
+        "features": feats,
+        "expires_at": expires,
+        "has_license": True,
+        "valid": bool(info.get("valid")),
+    }
+
+
+@bp_entitlement.route("/api/license/features-at")
+def api_license_features_at():
+    """``GET /api/license/features-at?epoch=<int>`` -- scalar view of
+    the installed license's ``features`` claim evaluated as of ``epoch``
+    -- the perspective-epoch flavour of ``/api/license/features``, for
+    a scheduled-audit / retrospective diagnostic tile that wants to
+    answer "which paid features was this node entitled to on <date>?"
+    without the caller having to snapshot the license state at that
+    time or compare ``exp`` to a caller-supplied epoch themselves.
+
+    Wraps :func:`clawmetry.license.license_features_at`.
+
+    Response shape (always HTTP 200)::
+
+        {
+          "features_at":     [<id>, ...] | null,   # features as of epoch
+          "requested_epoch": <int|null>,           # int-coerced input, or null on typo
+          "features":        [<id>, ...] | null,   # current-time features
+          "expires_at":      <int|null>,           # on-disk exp for comparison
+          "has_license":     <bool>,               # is a license file installed at all?
+          "valid":           <bool>                # signature-valid AND not expired NOW
+        }
+
+    ``features_at`` mirrors :func:`clawmetry.license.license_features_at`
+    exactly:
+
+      * ``null`` on no license, invalid signature, an ``exp`` claim
+        that has already lapsed at ``epoch``, or missing / non-integer
+        / bool ``epoch`` so a caller cannot silently mis-gate on a
+        typo.
+      * ``[]`` on a signature-valid license AS OF ``epoch`` whose
+        payload carries no explicit ``features`` claim. Distinct from
+        ``null``: a UI binding this endpoint must render both branches
+        (``null`` -> "no entitlement at that time", ``[]`` -> "entitled
+        but no features itemised") without collapsing them.
+      * A sorted, deduplicated, normalised (lower/strip) list of
+        feature ids otherwise.
+
+    Query parameter:
+
+      * ``epoch`` -- required. Unix epoch seconds as an integer. A
+        missing / non-integer / bool value collapses to
+        ``features_at=null`` with ``requested_epoch=null`` so a caller
+        cannot silently mis-gate on a typo. HTTP status is 200 either
+        way -- the "bad input" signal is ``requested_epoch=null`` plus
+        the ``null`` features, not a 4xx, matching the never-crash
+        posture of the surrounding license endpoints.
+
+    Pairs with ``/api/license/state-at`` / ``/api/license/is-expired-at``
+    / ``/api/license/days-until-expiry-at`` -- all share the
+    perspective-epoch input pattern and the
+    :func:`_license_features_at_snapshot` reader here carries
+    ``expires_at`` / ``has_license`` / ``valid`` on the same shape the
+    state-derived siblings carry, so a UI binding two for the same
+    install cannot catch them disagreeing on the current-time reference
+    fields.
+
+    When ``epoch`` equals "now", the ``features_at`` field must byte-
+    equal ``features`` (both derive from the same signed ``features``
+    claim, refuse the invalid-signature branch, and use the same
+    ``exp <= cutoff`` boundary via :func:`license_features_at` /
+    :func:`license_features`), so a UI binding both cannot catch them
+    disagreeing at the boundary.
+
+    Note: the ``features`` claim is a SUPPLEMENTAL string list carried
+    on the license token; it is NOT the canonical open-core feature
+    catalogue. This endpoint surfaces the claim as it stood at
+    ``epoch``. For the resolved feature set actually enforced by gates,
+    callers should read ``/api/entitlement`` (which layers this claim
+    on top of the FREE-tier baseline).
+
+    Never 5xxs -- any underlying failure degrades to the OSS-free
+    branch shape (``features_at=null``, ``features=null``,
+    ``expires_at=null``, ``has_license=false``, ``valid=false``),
+    matching the never-crash posture of the surrounding license
+    endpoints.
+    """
+    raw = request.args.get("epoch", "")
+    try:
+        requested = int(str(raw).strip())
+    except (TypeError, ValueError):
+        requested = None
+    try:
+        snap = _license_features_at_snapshot()
+    except Exception as exc:
+        logger.warning(
+            "api_license_features_at: snapshot error: %s", exc
+        )
+        snap = {
+            "features": None,
+            "expires_at": None,
+            "has_license": False,
+            "valid": False,
+        }
+    features_at: list | None = None
+    if requested is not None:
+        try:
+            from clawmetry import license as _lic
+
+            features_at = _lic.license_features_at(requested)
+        except Exception as exc:
+            logger.warning(
+                "api_license_features_at: derive error: %s", exc
+            )
+            features_at = None
+    if features_at is not None and not isinstance(features_at, list):
+        features_at = None
+    return jsonify(
+        {
+            "features_at": features_at,
+            "requested_epoch": requested,
+            "features": snap["features"],
+            "expires_at": snap["expires_at"],
+            "has_license": snap["has_license"],
+            "valid": snap["valid"],
+        }
+    )
+
+
 def _license_expiry_snapshot() -> dict:
     """Shared helper: read once, derive the trio the two expiry endpoints
     both need (``days_left``, ``has_license``, ``expired``). Lives in the

--- a/tests/test_license_features_at.py
+++ b/tests/test_license_features_at.py
@@ -1,0 +1,433 @@
+"""Tests for :func:`clawmetry.license.license_features_at` and the
+paired ``GET /api/license/features-at`` HTTP endpoint.
+
+Perspective-epoch flavour of :func:`clawmetry.license.license_features`
+/ ``/api/license/features``. Where the scalar answers "which paid
+features does the KEY claim right now?", this pair answers "which paid
+features would the KEY have claimed as of ``epoch``?" -- the same
+retrospective / prospective question :func:`license_state_at` answers
+for the license state. Both this pair and the scalar derive from the
+same signed ``features`` / ``exp`` claim, refuse the invalid-signature
+branch, and use the same ``exp <= cutoff`` boundary, so they cannot
+disagree at the boundary when the perspective epoch equals "now".
+
+Hermetic: each test mints tokens with its own ephemeral keypair and
+monkeypatches the module's embedded public key + ``LICENSE_PATH``,
+mirroring ``tests/test_license_state_at_scalar.py`` /
+``tests/test_license_features_accessor.py`` so nothing depends on the
+real production signing key or on real filesystem state. No network
+calls; ``CLAWMETRY_OFFLINE=1`` opts out of the ``clawmetry activate``
+phone-home.
+"""
+from __future__ import annotations
+
+import os
+import time
+from types import SimpleNamespace
+
+import pytest
+from flask import Flask
+
+
+# -- shared helpers ---------------------------------------------------------
+
+
+def _keypair():
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+    priv = Ed25519PrivateKey.generate()
+    pub_pem = priv.public_key().public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    return priv, pub_pem
+
+
+def _payload(
+    tier="pro",
+    nodes=3,
+    exp_delta=365 * 86400,
+    features=("runtimes", "alerts", "fleet"),
+    drop_exp=False,
+    drop_features=False,
+    features_value=None,
+):
+    now = int(time.time())
+    p = {
+        "sub": "acct_test",
+        "tier": tier,
+        "nodes": nodes,
+        "iat": now,
+        "exp": now + exp_delta,
+        "features": list(features),
+    }
+    if features_value is not None:
+        p["features"] = features_value
+    if drop_features:
+        p.pop("features", None)
+    if drop_exp:
+        p.pop("exp", None)
+    return p
+
+
+@pytest.fixture
+def app(monkeypatch, tmp_path):
+    import clawmetry.license as _lic
+
+    priv, pub_pem = _keypair()
+    monkeypatch.setattr(_lic, "_PUBLIC_KEY_PEM", pub_pem)
+    license_path = str(tmp_path / "license.key")
+    monkeypatch.setattr(_lic, "LICENSE_PATH", license_path)
+    monkeypatch.delenv("CLAWMETRY_LICENSE_SERVER", raising=False)
+    monkeypatch.delenv("CLAWMETRY_INGEST_URL", raising=False)
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("CLAWMETRY_OFFLINE", "1")
+
+    from routes.entitlement import bp_entitlement
+
+    flask_app = Flask(__name__)
+    flask_app.register_blueprint(bp_entitlement)
+    flask_app.config["TESTING"] = True
+
+    return SimpleNamespace(
+        app=flask_app,
+        client=flask_app.test_client(),
+        lic=_lic,
+        priv=priv,
+        license_path=license_path,
+    )
+
+
+def _write_direct(app, payload):
+    """Bypass :func:`activate` (which refuses expired tokens and phones
+    home) and write a raw signed token to the license file. Lets a test
+    build any payload shape -- expired, perpetual, features-list
+    variants -- without round-tripping through the activation code
+    path."""
+    tok = app.lic._encode_token(payload, app.priv)
+    os.makedirs(os.path.dirname(app.license_path), exist_ok=True)
+    with open(app.license_path, "w", encoding="utf-8") as fh:
+        fh.write(tok)
+
+
+def _write_bogus(app):
+    os.makedirs(os.path.dirname(app.license_path), exist_ok=True)
+    with open(app.license_path, "w", encoding="utf-8") as fh:
+        fh.write("CLAW1.garbage.garbage")
+
+
+# -- clawmetry.license.license_features_at() --------------------------------
+
+
+def test_features_at_no_license(app):
+    """No license file -> ``None`` at every epoch. Mirrors
+    :func:`license_features`'s no-license branch."""
+    now = int(time.time())
+    assert app.lic.license_features_at(now) is None
+    assert app.lic.license_features_at(0) is None
+    assert app.lic.license_features_at(2_000_000_000) is None
+
+
+def test_features_at_now_matches_features_active(app):
+    """When ``epoch`` equals "now", the perspective-epoch scalar must
+    agree with :func:`license_features` for the same install -- pins the
+    boundary the docstring guarantees."""
+    _write_direct(app, _payload(features=("runtimes", "alerts", "fleet")))
+    now = int(time.time())
+    assert app.lic.license_features_at(now) == ["alerts", "fleet", "runtimes"]
+    assert app.lic.license_features_at(now) == app.lic.license_features()
+
+
+def test_features_at_now_matches_features_lapsed(app):
+    """Lapsed-key parity: at "now", perspective scalar and base scalar
+    both refuse the lapsed key and return ``None`` -- both use the
+    ``exp <= cutoff`` boundary."""
+    _write_direct(app, _payload(exp_delta=-5 * 86400))
+    now = int(time.time())
+    assert app.lic.license_features_at(now) is None
+    assert app.lic.license_features() is None
+
+
+def test_features_at_retrospective_lapsed_key_valid_then(app):
+    """A key that has since lapsed WAS valid earlier -- pick an epoch
+    before its ``exp`` and the retrospective scalar surfaces the
+    features list. Answers the retrospective question
+    :func:`license_features` cannot ("was this node entitled to alerts
+    last quarter?")."""
+    exp_delta = -5 * 86400  # expired 5 days ago
+    _write_direct(app, _payload(exp_delta=exp_delta, features=("alerts",)))
+    info = app.lic.current_license_info()
+    exp = int(info["exp"])
+    # Ten days before the token was issued/expired: still valid then.
+    long_ago = exp - 30 * 86400
+    assert app.lic.license_features_at(long_ago) == ["alerts"]
+    # But NOW (past exp) -> None (matches license_features).
+    assert app.lic.license_features_at(int(time.time())) is None
+
+
+def test_features_at_prospective_active_key_beyond_exp(app):
+    """An active key with a finite ``exp`` -- pick an epoch beyond exp
+    and the prospective scalar refuses ("will this node still have
+    alerts at our next audit?"). Same ``exp <= cutoff`` boundary the
+    scalar uses at "now"."""
+    _write_direct(app, _payload(exp_delta=30 * 86400, features=("alerts",)))
+    info = app.lic.current_license_info()
+    exp = int(info["exp"])
+    assert app.lic.license_features_at(exp - 1) == ["alerts"]
+    assert app.lic.license_features_at(exp) is None
+    assert app.lic.license_features_at(exp + 1) is None
+
+
+def test_features_at_perpetual_key_always_returns_list(app):
+    """Perpetual (no ``exp``) key -> features list at every epoch.
+    Matches :func:`license_state_at`'s perpetual branch which classifies
+    as ``"active"`` regardless of epoch."""
+    _write_direct(app, _payload(drop_exp=True, features=("alerts", "fleet")))
+    for epoch in (0, int(time.time()), 2_000_000_000):
+        assert app.lic.license_features_at(epoch) == ["alerts", "fleet"]
+
+
+def test_features_at_invalid_signature_returns_none(app):
+    """Bogus-signature file -> ``None`` at every epoch. An unsigned body
+    is untrusted whatever the perspective (an attacker who could edit
+    the payload could otherwise smuggle any features list into an
+    unsigned body, for any perspective epoch)."""
+    _write_bogus(app)
+    for epoch in (0, int(time.time()), 2_000_000_000):
+        assert app.lic.license_features_at(epoch) is None
+
+
+def test_features_at_missing_epoch_returns_none(app):
+    """Missing / non-numeric / bool epoch -> ``None`` (the perspective
+    is unusable; conservative "no entitlement" fallback matching the
+    never-mis-gate posture of the surrounding ``_at`` family)."""
+    _write_direct(app, _payload(features=("alerts",)))
+    assert app.lic.license_features_at(None) is None
+    assert app.lic.license_features_at("garbage") is None
+    assert app.lic.license_features_at("") is None
+    assert app.lic.license_features_at(True) is None
+    assert app.lic.license_features_at(False) is None
+
+
+def test_features_at_int_parseable_string_epoch(app):
+    """Int-parseable strings coerce cleanly (matches
+    :func:`license_state_at`'s ``int()`` coercion)."""
+    _write_direct(app, _payload(features=("alerts",)))
+    now = int(time.time())
+    assert app.lic.license_features_at(str(now)) == ["alerts"]
+
+
+def test_features_at_signed_but_no_features_claim_returns_empty(app):
+    """Signature-valid AS OF ``epoch`` but the payload carries no
+    ``features`` claim -> ``[]``. Distinct from ``None`` (no valid
+    license as of that time) -- callers rendering "features unlocked at
+    <date>" must NOT collapse these two branches."""
+    _write_direct(app, _payload(drop_features=True))
+    now = int(time.time())
+    assert app.lic.license_features_at(now) == []
+
+
+def test_features_at_normalises_case_and_whitespace(app):
+    """Case/whitespace normalisation is the same as
+    :func:`license_features` so gates comparing to lower-cased constants
+    don't silently miss."""
+    _write_direct(
+        app, _payload(features=(" Alerts ", "FLEET", "runtimes "))
+    )
+    now = int(time.time())
+    assert app.lic.license_features_at(now) == ["alerts", "fleet", "runtimes"]
+
+
+def test_features_at_ignores_non_string_entries(app):
+    """Non-string entries in the ``features`` list (integer, bool, dict,
+    None) are silently skipped rather than blowing up the tile -- matches
+    the scalar's handling."""
+    _write_direct(
+        app,
+        _payload(features_value=["alerts", 42, None, {"k": "v"}, "fleet"]),
+    )
+    now = int(time.time())
+    assert app.lic.license_features_at(now) == ["alerts", "fleet"]
+
+
+def test_features_at_never_raises(monkeypatch):
+    """Any underlying failure of :func:`current_license_info` collapses
+    the scalar to ``None`` -- never propagates."""
+    import clawmetry.license as _lic
+
+    def _boom():
+        raise RuntimeError("simulated corrupt install")
+
+    monkeypatch.setattr(_lic, "current_license_info", _boom)
+    assert _lic.license_features_at(int(time.time())) is None
+
+
+# -- GET /api/license/features-at -------------------------------------------
+
+
+def test_endpoint_features_at_missing_epoch(app):
+    """``?epoch=`` absent -> HTTP 200 with ``features_at=null`` +
+    ``requested_epoch=null``. Never-4xx posture matching
+    ``/api/license/state-at``."""
+    with app.app.test_client() as c:
+        resp = c.get("/api/license/features-at")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["features_at"] is None
+    assert data["requested_epoch"] is None
+
+
+def test_endpoint_features_at_non_integer_epoch(app):
+    """Non-integer / bool epoch collapses to ``features_at=null`` +
+    ``requested_epoch=null``. The "bad input" signal is
+    ``requested_epoch=null``, not a 4xx."""
+    with app.app.test_client() as c:
+        resp = c.get("/api/license/features-at?epoch=garbage")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["features_at"] is None
+    assert data["requested_epoch"] is None
+
+
+def test_endpoint_features_at_no_license(app):
+    """No license file -> ``features_at=null`` + OSS-free snapshot
+    fields, HTTP 200."""
+    now = int(time.time())
+    with app.app.test_client() as c:
+        resp = c.get(f"/api/license/features-at?epoch={now}")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["features_at"] is None
+    assert data["requested_epoch"] == now
+    assert data["features"] is None
+    assert data["expires_at"] is None
+    assert data["has_license"] is False
+    assert data["valid"] is False
+
+
+def test_endpoint_features_at_active_key_now_matches_features(app):
+    """Active key at "now": ``features_at`` byte-equals ``features``.
+    Pins the boundary the docstring guarantees."""
+    _write_direct(app, _payload(features=("runtimes", "alerts", "fleet")))
+    now = int(time.time())
+    with app.app.test_client() as c:
+        resp = c.get(f"/api/license/features-at?epoch={now}")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["features_at"] == ["alerts", "fleet", "runtimes"]
+    assert data["features"] == ["alerts", "fleet", "runtimes"]
+    assert data["features_at"] == data["features"]
+    assert data["has_license"] is True
+    assert data["valid"] is True
+
+
+def test_endpoint_features_at_retrospective_lapsed_key(app):
+    """A key that has since lapsed: retrospective at a pre-exp epoch
+    still surfaces the features list; current-time ``features`` is
+    ``null`` (lapsed now)."""
+    _write_direct(
+        app, _payload(exp_delta=-5 * 86400, features=("alerts",))
+    )
+    info = app.lic.current_license_info()
+    exp = int(info["exp"])
+    long_ago = exp - 30 * 86400
+    with app.app.test_client() as c:
+        resp = c.get(f"/api/license/features-at?epoch={long_ago}")
+    data = resp.get_json()
+    assert data["features_at"] == ["alerts"]
+    assert data["features"] is None  # lapsed now
+    assert data["has_license"] is True
+    assert data["valid"] is False
+
+
+def test_endpoint_features_at_prospective_beyond_exp(app):
+    """Active key + prospective epoch past ``exp``: ``features_at=null``
+    while ``features`` is still surfaced for the current time."""
+    _write_direct(app, _payload(exp_delta=30 * 86400, features=("alerts",)))
+    info = app.lic.current_license_info()
+    exp = int(info["exp"])
+    with app.app.test_client() as c:
+        resp = c.get(f"/api/license/features-at?epoch={exp + 1}")
+    data = resp.get_json()
+    assert data["features_at"] is None
+    assert data["features"] == ["alerts"]
+    assert data["valid"] is True
+
+
+def test_endpoint_features_at_signed_but_no_features_claim(app):
+    """Signed key with no ``features`` claim: ``features_at=[]`` (valid
+    key at that time, zero features itemised) -- distinct from ``null``."""
+    _write_direct(app, _payload(drop_features=True))
+    now = int(time.time())
+    with app.app.test_client() as c:
+        resp = c.get(f"/api/license/features-at?epoch={now}")
+    data = resp.get_json()
+    assert data["features_at"] == []
+    assert data["features"] == []
+
+
+def test_endpoint_features_at_invalid_signature(app):
+    """Bogus-signature file: ``features_at=null`` at every epoch; the
+    envelope surfaces ``has_license=true`` (a file is on disk) but
+    ``valid=false``."""
+    _write_bogus(app)
+    now = int(time.time())
+    with app.app.test_client() as c:
+        resp = c.get(f"/api/license/features-at?epoch={now}")
+    data = resp.get_json()
+    assert data["features_at"] is None
+    assert data["features"] is None
+    assert data["has_license"] is True
+    assert data["valid"] is False
+
+
+def test_endpoint_features_at_parity_with_scalar(app):
+    """Per-epoch parity: the endpoint's ``features_at`` value must match
+    :func:`license_features_at` for the same epoch. Pins the endpoint
+    against silent drift from the scalar."""
+    _write_direct(app, _payload(exp_delta=30 * 86400, features=("alerts",)))
+    info = app.lic.current_license_info()
+    exp = int(info["exp"])
+    with app.app.test_client() as c:
+        for epoch in (exp - 10 * 86400, exp - 1, exp, exp + 1):
+            resp = c.get(f"/api/license/features-at?epoch={epoch}")
+            data = resp.get_json()
+            assert data["features_at"] == app.lic.license_features_at(epoch), epoch
+
+
+def test_endpoint_features_at_shared_snapshot_agrees_with_features(app):
+    """Shared current-time snapshot fields (``features`` / ``has_license``
+    / ``valid``) must byte-equal ``/api/license/features`` for the same
+    install so a UI binding both cannot catch them disagreeing on the
+    current-time reference."""
+    _write_direct(app, _payload(features=("alerts",)))
+    now = int(time.time())
+    with app.app.test_client() as c:
+        f = c.get("/api/license/features").get_json()
+        fa = c.get(f"/api/license/features-at?epoch={now}").get_json()
+    assert fa["features"] == f["features"]
+    assert fa["has_license"] == f["has_license"]
+    assert fa["valid"] == f["valid"]
+
+
+def test_endpoint_features_at_never_5xxs(app, monkeypatch):
+    """Even if the shared snapshot blows up mid-request, the endpoint
+    still returns HTTP 200 with the OSS-free snapshot fallback + honest
+    per-request derivation."""
+    from routes import entitlement as _routes
+
+    monkeypatch.setattr(
+        _routes,
+        "_license_features_at_snapshot",
+        lambda: (_ for _ in ()).throw(RuntimeError("simulated blowup")),
+    )
+    now = int(time.time())
+    with app.app.test_client() as c:
+        resp = c.get(f"/api/license/features-at?epoch={now}")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["features"] is None
+    assert data["expires_at"] is None
+    assert data["has_license"] is False
+    assert data["valid"] is False


### PR DESCRIPTION
## Summary

Perspective-epoch flavour of `license_features` / `/api/license/features`. Where the scalar answers "which paid features does the KEY claim right now?", this pair answers "which paid features would the KEY have claimed as of `<epoch>`?" — the same retrospective / prospective question `license_state_at` answers for the license state.

- `clawmetry/license.py` — `license_features_at(epoch) -> list[str] | None`. Reuses `current_license_info` for signature + `exp` gating, refuses the invalid-signature branch (time-independent), and re-verifies the token to pull the `features` claim (matches `license_features`'s re-read). Rejects bool epochs (int subclass) and non-numeric epochs to preserve the never-mis-gate posture of the surrounding `_at` family. Returns `None` on no license / invalid sig / lapsed-at-epoch / bad epoch, `[]` on signed-but-no-features-claim key valid AT `epoch`, sorted/deduped/normalised list otherwise — matches `license_features`'s `None`-vs-`[]` distinction. Never raises.
- `routes/entitlement.py` — `/api/license/features-at` endpoint plus a `_license_features_at_snapshot` helper that carries `features` / `expires_at` / `has_license` / `valid` on the same shape the state-derived perspective-epoch tiles use so a UI binding both cannot catch them disagreeing on the current-time reference. Never 5xxs.
- `tests/test_license_features_at.py` — 24 hermetic tests: per-branch coverage on the scalar (no license, active/lapsed/perpetual/invalid key, retrospective vs prospective, drop-features → `[]`, case normalisation, non-string entries, bool + missing epoch, never-raises) plus endpoint coverage (missing/non-integer epoch, parity with scalar per-epoch, shared snapshot fields agree with `/api/license/features`, never-5xxs).

This PR does NOT bump `__version__`, does NOT enforce any gate, does NOT create a release tag. Grace-mode-clean addition of the perspective-epoch scalar + endpoint.

## Test plan

- [x] `python3 -m py_compile` on all three changed files
- [x] `ruff check` on all three changed files — clean
- [x] `python3 -m pytest tests/test_license_features_at.py -x -q` — **24 passed**
- [x] `python3 -m pytest tests/test_license_features_accessor.py tests/test_license_state_at_scalar.py tests/test_license_state_at_batch.py -q` — **117 passed** (no regressions in sibling suites)
- [x] Full test sweep across all license/entitlement tests — **1148 passed** (3 pre-existing DuckDB import errors unrelated to this diff)

## Local operator verification checklist

Scheduled autonomous agent has no local machine / running daemon / browser / cloud snapshot access, so the local operator owns these steps:

- [ ] Copy the changed files into the installed package:
  ```
  cp clawmetry/license.py ~/.clawmetry/lib/python3.*/site-packages/clawmetry/
  cp routes/entitlement.py ~/.clawmetry/lib/python3.*/site-packages/routes/
  cp tests/test_license_features_at.py ~/.clawmetry/lib/python3.*/site-packages/tests/
  ```
- [ ] Clear the bytecode cache: `find ~/.clawmetry -name __pycache__ -exec rm -rf {} +`
- [ ] Restart the daemon: `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
- [ ] Hit the new endpoint with an installed key:
  ```
  curl -s "http://localhost:8900/api/license/features-at?epoch=$(date +%s)" | jq
  curl -s "http://localhost:8900/api/license/features-at?epoch=0" | jq
  curl -s "http://localhost:8900/api/license/features-at" | jq   # missing epoch -> features_at=null
  ```
- [ ] Verify at `epoch=now`, `features_at` byte-equals `features` from `/api/license/features` for the same install (boundary parity the docstring guarantees).
- [ ] Decrypt the live cloud snapshot; browser-check that no existing UI regressed. This PR only ADDS the perspective-epoch sibling — no existing endpoint was touched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ESR1TLYK57batT4WdG8ka9)_