### PR TITLE
feat(evals): resurrect deterministic evaluators wired to real stored events + eval_metrics table

### DIFF
--- a/clawmetry/deterministic_evaluators.py
+++ b/clawmetry/deterministic_evaluators.py
@@ -1,0 +1,419 @@
+"""
+clawmetry/deterministic_evaluators.py — cheap, code-based checks on sessions.
+
+Companion to the LLM-as-judge surface (``clawmetry/eval_runner.py``, #1619):
+where the judge spends an LLM call to score *quality*, these evaluators run a
+deterministic Python check in milliseconds with **zero LLM cost** to catch
+*structural* failures — malformed JSON, a missing required tool argument, an
+answer that is empty or runaway-long, a regex/exact mismatch. (#2862)
+
+Why both: the LLM judge is overkill for "did the agent return parseable JSON?"
+or "did the `create_file` call include a `path`?". Those are pass/fail facts a
+regex or a `json.loads` answers for free. Deterministic checks complement the
+judge — they do not replace it — and their scores share the same 0..1 shape so
+they flow into the same eval views (a 1.0 pass / 0.0 fail).
+
+Design rules:
+  * **Pure + storage-agnostic.** Each evaluator is a function of an
+    :class:`EvalInput` (the normalized output text + tool calls + error flag)
+    and a small ``config`` dict. No DuckDB, no network, no clock — so they are
+    trivially unit-testable and safe to run inline on a live session.
+  * **Never raises.** A check that hits bad input returns a failing
+    :class:`DeterministicEvalResult` with a human reason, never an exception —
+    a broken check must not take down the eval pass.
+  * **Built-ins are FREE-tier.** They run on the user's box over local data and
+    cost nothing, so they ship in OSS (no entitlement gate).
+
+Public API:
+    EvalInput(output_text=..., tool_calls=[...], had_error=False)
+    eval_input_from_events(events) -> EvalInput        # adapter Event shape
+    eval_input_from_stored_rows(rows) -> EvalInput     # DuckDB event rows
+    BUILTIN_EVALUATORS: dict[str, callable]
+    run_checks(eval_input, checks) -> list[DeterministicEvalResult]
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import logging
+import re
+from dataclasses import dataclass, field, asdict
+from typing import Any, Callable
+
+log = logging.getLogger("clawmetry.deterministic_evaluators")
+
+
+# ── Normalized input + result shapes ────────────────────────────────────────────
+
+
+@dataclass
+class EvalInput:
+    """What a deterministic check looks at, decoupled from storage.
+
+    ``output_text`` is the agent's final/assistant text. ``tool_calls`` is a
+    list of ``{"name": str, "arguments": dict}`` (other keys ignored).
+    ``had_error`` flags whether any tool result / event errored.
+    """
+
+    output_text: str = ""
+    tool_calls: list[dict[str, Any]] = field(default_factory=list)
+    had_error: bool = False
+
+
+@dataclass
+class DeterministicEvalResult:
+    """One check's verdict on one session.
+
+    ``score`` is ``1.0`` for pass / ``0.0`` for fail so it lines up with the
+    LLM-judge 0..1 score. ``passed`` is the same fact as a bool for callers
+    that prefer it. ``detail`` carries small machine-readable context (the
+    offending value, the missing keys, …) for the UI.
+    """
+
+    slug: str
+    name: str
+    score: float
+    passed: bool
+    reason: str
+    detail: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def _passed(slug: str, name: str, reason: str, **detail: Any) -> DeterministicEvalResult:
+    return DeterministicEvalResult(slug=slug, name=name, score=1.0, passed=True,
+                                   reason=reason, detail=detail)
+
+
+def _failed(slug: str, name: str, reason: str, **detail: Any) -> DeterministicEvalResult:
+    return DeterministicEvalResult(slug=slug, name=name, score=0.0, passed=False,
+                                   reason=reason, detail=detail)
+
+
+# ── Built-in evaluators ─────────────────────────────────────────────────────────
+#
+# Each takes (eval_input, config) and returns a DeterministicEvalResult. Keep
+# them small, total (never raise), and free of side effects.
+
+
+_JSON_TYPES: dict[str, type | tuple[type, ...]] = {
+    "str": str, "string": str,
+    "int": int, "integer": int,
+    "float": float,
+    "number": (int, float),
+    "bool": bool, "boolean": bool,
+    "list": list, "array": list,
+    "dict": dict, "object": dict,
+    "null": type(None),
+}
+
+
+def _parse_json(text: str):
+    """Return (ok, value_or_None). ``bool`` is excluded from int below by the
+    caller's type table where it matters; here we just parse."""
+    try:
+        return True, json.loads(text)
+    except (ValueError, TypeError):
+        return False, None
+
+
+def eval_json_parseable(inp: EvalInput, config: dict) -> DeterministicEvalResult:
+    """Pass when the output parses as JSON. The cheapest structural check there
+    is — agents asked for JSON routinely emit prose or fenced code instead."""
+    slug, name = "json-parseable", config.get("name") or "Output is valid JSON"
+    text = (inp.output_text or "").strip()
+    if not text:
+        return _failed(slug, name, "Output was empty.")
+    ok, _ = _parse_json(text)
+    if ok:
+        return _passed(slug, name, "Output parsed as JSON.")
+    return _failed(slug, name, "Output did not parse as JSON.",
+                   sample=text[:120])
+
+
+def eval_json_schema_match(inp: EvalInput, config: dict) -> DeterministicEvalResult:
+    """Pass when the output is a JSON object with the required keys (and, if
+    declared, the right types).
+
+    Config: ``required_keys`` (list[str]), ``types`` (dict[str, typename]).
+    This is a deliberately small schema check — required-key + scalar-type —
+    not a full JSON-Schema engine; that is what makes it free and dependency-
+    less.
+    """
+    slug, name = "json-schema-match", config.get("name") or "Output matches schema"
+    required = list(config.get("required_keys") or [])
+    types = dict(config.get("types") or {})
+    ok, val = _parse_json((inp.output_text or "").strip())
+    if not ok:
+        return _failed(slug, name, "Output did not parse as JSON.")
+    if not isinstance(val, dict):
+        return _failed(slug, name, f"Expected a JSON object, got {type(val).__name__}.")
+    missing = [k for k in required if k not in val]
+    if missing:
+        return _failed(slug, name, f"Missing required key(s): {', '.join(missing)}.",
+                       missing=missing)
+    bad_types: list[str] = []
+    for key, typename in types.items():
+        if key not in val:
+            continue
+        expected = _JSON_TYPES.get(str(typename).lower())
+        if expected is None:
+            continue
+        v = val[key]
+        # JSON has no separate bool/int, but Python's bool is an int subclass;
+        # treat a bool as NOT matching int/number to avoid silent passes.
+        if expected in (int, (int, float)) and isinstance(v, bool):
+            bad_types.append(f"{key} (got bool, want {typename})")
+            continue
+        if not isinstance(v, expected):
+            bad_types.append(f"{key} (got {type(v).__name__}, want {typename})")
+    if bad_types:
+        return _failed(slug, name, f"Type mismatch: {'; '.join(bad_types)}.",
+                       type_errors=bad_types)
+    return _passed(slug, name, "Output is a JSON object matching the schema.")
+
+
+def eval_regex_match(inp: EvalInput, config: dict) -> DeterministicEvalResult:
+    """Pass when ``pattern`` is found in the output. Config: ``pattern`` (str,
+    required), ``ignore_case`` (bool), ``full_match`` (bool — anchor the whole
+    string instead of search)."""
+    slug, name = "regex-match", config.get("name") or "Output matches pattern"
+    pattern = config.get("pattern")
+    if not pattern:
+        return _failed(slug, name, "No regex pattern configured.")
+    flags = re.IGNORECASE if config.get("ignore_case") else 0
+    try:
+        rx = re.compile(pattern, flags)
+    except re.error as e:
+        return _failed(slug, name, f"Invalid regex: {e}.")
+    text = inp.output_text or ""
+    hit = rx.fullmatch(text) if config.get("full_match") else rx.search(text)
+    if hit:
+        return _passed(slug, name, "Output matched the pattern.", pattern=pattern)
+    return _failed(slug, name, "Output did not match the pattern.", pattern=pattern)
+
+
+def eval_exact_match(inp: EvalInput, config: dict) -> DeterministicEvalResult:
+    """Pass when the output equals ``expected``. Config: ``expected`` (str,
+    required), ``strip`` (bool, default True), ``ignore_case`` (bool)."""
+    slug, name = "exact-match", config.get("name") or "Output equals expected"
+    if "expected" not in config:
+        return _failed(slug, name, "No expected value configured.")
+    expected = str(config["expected"])
+    actual = inp.output_text or ""
+    if config.get("strip", True):
+        expected, actual = expected.strip(), actual.strip()
+    if config.get("ignore_case"):
+        expected, actual = expected.lower(), actual.lower()
+    if actual == expected:
+        return _passed(slug, name, "Output matched exactly.")
+    return _failed(slug, name, "Output did not match the expected value.",
+                   sample=(inp.output_text or "")[:120])
+
+
+def eval_output_length_bounds(inp: EvalInput, config: dict) -> DeterministicEvalResult:
+    """Pass when the output length (characters) is within bounds. Config:
+    ``min_chars`` (int), ``max_chars`` (int) — either may be omitted. Catches
+    empty answers and runaway generations alike."""
+    slug, name = "output-length-bounds", config.get("name") or "Output length in bounds"
+    length = len(inp.output_text or "")
+    lo = config.get("min_chars")
+    hi = config.get("max_chars")
+    if lo is not None and length < int(lo):
+        return _failed(slug, name, f"Output too short: {length} < {lo} chars.",
+                       length=length, min_chars=int(lo))
+    if hi is not None and length > int(hi):
+        return _failed(slug, name, f"Output too long: {length} > {hi} chars.",
+                       length=length, max_chars=int(hi))
+    return _passed(slug, name, f"Output length {length} within bounds.", length=length)
+
+
+def eval_required_tool_args(inp: EvalInput, config: dict) -> DeterministicEvalResult:
+    """Pass when every call to ``tool`` supplied all ``args``. Config: ``tool``
+    (str, required), ``args`` (list[str], required), ``require_call`` (bool,
+    default True — fail if the tool was never called).
+
+    Catches the classic malformed tool call (e.g. a ``write_file`` with no
+    ``path``) that the LLM judge would burn a call to notice."""
+    slug, name = "required-tool-args", config.get("name") or "Required tool args present"
+    tool = config.get("tool")
+    required = list(config.get("args") or [])
+    if not tool or not required:
+        return _failed(slug, name, "No tool/args configured.")
+    calls = [c for c in (inp.tool_calls or [])
+             if isinstance(c, dict) and c.get("name") == tool]
+    if not calls:
+        if config.get("require_call", True):
+            return _failed(slug, name, f"Tool '{tool}' was never called.", tool=tool)
+        return _passed(slug, name, f"Tool '{tool}' not called (not required).", tool=tool)
+    for idx, call in enumerate(calls):
+        args = call.get("arguments")
+        if not isinstance(args, dict):
+            return _failed(slug, name,
+                           f"Call #{idx + 1} to '{tool}' had no arguments object.",
+                           tool=tool, call_index=idx)
+        missing = [a for a in required if a not in args or args[a] in (None, "")]
+        if missing:
+            return _failed(slug, name,
+                           f"Call #{idx + 1} to '{tool}' missing arg(s): "
+                           f"{', '.join(missing)}.",
+                           tool=tool, call_index=idx, missing=missing)
+    return _passed(slug, name, f"All {len(calls)} call(s) to '{tool}' had required args.",
+                   tool=tool, call_count=len(calls))
+
+
+def eval_no_tool_errors(inp: EvalInput, config: dict) -> DeterministicEvalResult:
+    """Pass when the session recorded no tool/turn error. Config: none."""
+    slug, name = "no-tool-errors", config.get("name") or "No tool errors"
+    if inp.had_error:
+        return _failed(slug, name, "Session recorded a tool/turn error.")
+    return _passed(slug, name, "No tool/turn errors recorded.")
+
+
+# slug → evaluator function. The slug is what a check config references.
+BUILTIN_EVALUATORS: dict[str, Callable[[EvalInput, dict], DeterministicEvalResult]] = {
+    "json-parseable": eval_json_parseable,
+    "json-schema-match": eval_json_schema_match,
+    "regex-match": eval_regex_match,
+    "exact-match": eval_exact_match,
+    "output-length-bounds": eval_output_length_bounds,
+    "required-tool-args": eval_required_tool_args,
+    "no-tool-errors": eval_no_tool_errors,
+}
+
+
+# ── Runner ───────────────────────────────────────────────────────────────────────
+
+
+def run_checks(eval_input: EvalInput, checks: list[dict]) -> list[DeterministicEvalResult]:
+    """Run a list of check configs against one input.
+
+    Each check is ``{"slug": <builtin slug>, "config": {...}}`` (``config``
+    optional). An unknown slug yields a failing result rather than raising, and
+    an evaluator that itself throws is caught and reported as a failure, so one
+    bad check never aborts the pass.
+    """
+    results: list[DeterministicEvalResult] = []
+    for check in checks or []:
+        slug = (check or {}).get("slug")
+        config = (check or {}).get("config") or {}
+        fn = BUILTIN_EVALUATORS.get(slug)
+        if fn is None:
+            results.append(_failed(slug or "unknown",
+                                   config.get("name") or "Unknown evaluator",
+                                   f"No built-in evaluator named '{slug}'."))
+            continue
+        try:
+            results.append(fn(eval_input, config))
+        except Exception as e:  # defensive: a check must never crash the pass
+            log.warning("deterministic eval '%s' raised: %s", slug, e)
+            results.append(_failed(slug, config.get("name") or slug,
+                                   f"Evaluator errored: {e}."))
+    return results
+
+
+# ── Best-effort extraction from unified events ──────────────────────────────────
+
+
+def eval_input_from_events(events: list) -> EvalInput:
+    """Build an :class:`EvalInput` from a session's unified ``Event`` list.
+
+    Best-effort and tolerant of either ``Event`` dataclass instances or their
+    ``to_dict()`` shape:
+      * ``output_text`` — the last non-empty event ``content`` (the agent's
+        latest textual output); falls back to the most recent content seen.
+      * ``tool_calls`` — flattened from each event's ``tool_calls`` (and a
+        single ``tool_name`` when present).
+      * ``had_error`` — any event whose type contains "error" or whose extra
+        marks ``is_error``/``isError`` true.
+    """
+    def _get(obj, key, default=None):
+        if isinstance(obj, dict):
+            return obj.get(key, default)
+        return getattr(obj, key, default)
+
+    output_text = ""
+    tool_calls: list[dict[str, Any]] = []
+    had_error = False
+    for ev in events or []:
+        etype = str(_get(ev, "type", "") or "")
+        content = _get(ev, "content", "") or ""
+        if content:
+            output_text = content  # last non-empty wins (latest output)
+        added_for_event = 0
+        for tc in (_get(ev, "tool_calls", None) or []):
+            if isinstance(tc, dict):
+                tool_calls.append({"name": tc.get("name"),
+                                   "arguments": tc.get("arguments") or tc.get("input") or {}})
+                added_for_event += 1
+        # ``tool_name`` is a fallback for events whose call list is absent;
+        # real ingested rows carry BOTH, so counting both double-counted
+        # every call (362 "calls" for a 181-call session).
+        tname = _get(ev, "tool_name", "") or ""
+        if tname and not added_for_event:
+            tool_calls.append({"name": tname, "arguments": {}})
+        extra = _get(ev, "extra", None) or {}
+        if "error" in etype.lower():
+            had_error = True
+        if isinstance(extra, dict) and (extra.get("is_error") or extra.get("isError")):
+            had_error = True
+    return EvalInput(output_text=output_text, tool_calls=tool_calls, had_error=had_error)
+
+
+# ── Bridge from stored DuckDB event rows ────────────────────────────────────────
+#
+# The rows ``LocalStore.query_events`` returns are NOT the adapter ``Event``
+# shape above: the Event fields live inside ``row["data"]``, and ingest
+# stringifies nested values (``data["tool_calls"]`` / ``data["extra"]`` arrive
+# as Python-repr or JSON strings). This bridge is why #4436 found the module
+# "unintegrated": it could never see stored data. (#2862)
+
+
+def _parse_stored_field(value: Any) -> Any:
+    """Best-effort revival of a stringified nested field: JSON first, then
+    Python literal (single-quoted repr), else the raw value."""
+    if not isinstance(value, str) or not value.strip():
+        return value
+    try:
+        return json.loads(value)
+    except (ValueError, TypeError):
+        pass
+    try:
+        return ast.literal_eval(value)
+    except (ValueError, SyntaxError, MemoryError, RecursionError):
+        return value
+
+
+def stored_row_to_event(row: dict) -> dict:
+    """Map one stored event row to the ``Event``-dict shape
+    :func:`eval_input_from_events` understands. Never raises."""
+    if not isinstance(row, dict):
+        return {}
+    data = _parse_stored_field(row.get("data"))
+    if not isinstance(data, dict):
+        data = {}
+    tool_calls = _parse_stored_field(data.get("tool_calls"))
+    extra = _parse_stored_field(data.get("extra"))
+    return {
+        "type": row.get("event_type") or data.get("type") or "",
+        "content": data.get("content") or "",
+        "tool_calls": tool_calls if isinstance(tool_calls, list) else [],
+        "tool_name": data.get("tool_name") or "",
+        "extra": extra if isinstance(extra, dict) else {},
+    }
+
+
+def eval_input_from_stored_rows(rows: list) -> EvalInput:
+    """Build an :class:`EvalInput` straight from ``query_events`` rows.
+
+    Rows come back newest-first from the store; "last output wins" needs
+    chronological order, so sort ascending by ``ts`` when present (stable
+    for ties / missing ts)."""
+    rows = [r for r in (rows or []) if isinstance(r, dict)]
+    try:
+        rows = sorted(rows, key=lambda r: str(r.get("ts") or ""))
+    except Exception:
+        pass
+    return eval_input_from_events([stored_row_to_event(r) for r in rows])

--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -1013,6 +1013,29 @@ _DDL = [
     """,
     "CREATE INDEX IF NOT EXISTS idx_eval_regression_replayed_at ON eval_regression_runs(replayed_at)",
     "CREATE INDEX IF NOT EXISTS idx_eval_regression_status     ON eval_regression_runs(status, replayed_at)",
+    # Issue #2862 (resurrected) — per-session, per-metric eval results.
+    # ``sessions.eval_score`` stays the single headline judge score; this
+    # table holds the OTHER metric verdicts on the same session (the free
+    # deterministic checks now, judge-backed named metrics later). One row
+    # per (session, metric), latest-only: a rescore overwrites in place,
+    # mirroring the sessions.eval_* upsert semantics. ``engine`` says who
+    # computed it (builtin / pro / deepeval) so the UI can label honestly.
+    """
+    CREATE TABLE IF NOT EXISTS eval_metrics (
+        session_id  VARCHAR NOT NULL,
+        metric_slug VARCHAR NOT NULL,
+        score       DOUBLE,
+        passed      BOOLEAN,
+        reason      VARCHAR,
+        detail      VARCHAR,
+        engine      VARCHAR NOT NULL,
+        judge_model VARCHAR,
+        scored_at   BIGINT  NOT NULL,
+        PRIMARY KEY (session_id, metric_slug)
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_eval_metrics_scored_at ON eval_metrics(scored_at)",
+    "CREATE INDEX IF NOT EXISTS idx_eval_metrics_slug      ON eval_metrics(metric_slug, scored_at)",
     """
     CREATE TABLE IF NOT EXISTS schema_version (
         version    INTEGER PRIMARY KEY,
@@ -8589,6 +8612,126 @@ class LocalStore:
         }
 
     # ── Issue #1619 Phase 2 — golden test suite runs ────────────────────────
+
+    # ── Issue #2862 (resurrected) — per-metric eval results ────────────────
+
+    def persist_eval_metric(
+        self,
+        *,
+        session_id: str,
+        metric_slug: str,
+        score: float | None,
+        passed: bool | None,
+        reason: str,
+        detail: str = "",
+        engine: str = "builtin",
+        judge_model: str = "",
+        scored_at: int = 0,
+    ) -> None:
+        """Upsert one metric verdict for one session. Latest-only on
+        ``(session_id, metric_slug)`` — a rescore overwrites in place."""
+        if not session_id or not metric_slug:
+            return
+        with self._write_lock:
+            try:
+                self._conn.execute(
+                    """
+                    INSERT OR REPLACE INTO eval_metrics
+                        (session_id, metric_slug, score, passed, reason,
+                         detail, engine, judge_model, scored_at)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    [
+                        session_id,
+                        metric_slug,
+                        None if score is None else float(score),
+                        None if passed is None else bool(passed),
+                        (reason or "")[:500],
+                        (detail or "")[:2000],
+                        (engine or "builtin")[:40],
+                        (judge_model or "")[:80],
+                        int(scored_at) or int(time.time() * 1000),
+                    ],
+                )
+            except Exception:
+                log.exception(
+                    "local store: persist_eval_metric failed for %s/%s",
+                    session_id, metric_slug,
+                )
+
+    def query_eval_metrics(
+        self,
+        *,
+        session_id: str | None = None,
+        metric_slug: str | None = None,
+        limit: int = 200,
+    ) -> list[dict[str, Any]]:
+        """Return metric verdicts, newest first, optionally filtered by
+        session and/or metric. Drives ``GET /api/evals/metrics``."""
+        where: list[str] = []
+        params: list[Any] = []
+        if session_id:
+            where.append("session_id = ?")
+            params.append(session_id)
+        if metric_slug:
+            where.append("metric_slug = ?")
+            params.append(metric_slug)
+        sql = (
+            "SELECT session_id, metric_slug, score, passed, reason, detail, "
+            "engine, judge_model, scored_at FROM eval_metrics"
+        )
+        if where:
+            sql += " WHERE " + " AND ".join(where)
+        sql += " ORDER BY scored_at DESC LIMIT ?"
+        params.append(max(1, min(int(limit), 1000)))
+        cols = ["session_id", "metric_slug", "score", "passed", "reason",
+                "detail", "engine", "judge_model", "scored_at"]
+        try:
+            rows = self._fetch(sql, params)
+        except Exception as e:
+            log.warning("local store: query_eval_metrics failed: %s", e)
+            return []
+        return [dict(zip(cols, r)) for r in rows]
+
+    def query_sessions_missing_eval_metrics(
+        self,
+        *,
+        engine: str = "builtin",
+        limit: int = 25,
+        lookback_hours: int = 24,
+    ) -> list[dict[str, Any]]:
+        """Completed recent sessions with NO ``eval_metrics`` row from
+        ``engine`` yet. Drives the deterministic-checks scheduler tick
+        (same completed/lookback filter as ``query_unscored_sessions``)."""
+        try:
+            from datetime import datetime, timedelta, timezone
+            cutoff = (datetime.now(timezone.utc) - timedelta(hours=lookback_hours)).isoformat()
+        except Exception:
+            cutoff = ""
+        sql = """
+            SELECT s.session_id, s.agent_type, s.status, s.total_tokens
+              FROM sessions s
+             WHERE s.total_tokens IS NOT NULL
+               AND s.total_tokens > 0
+               AND (
+                    s.ended_at IS NOT NULL
+                    OR s.status IN ('completed', 'failed', 'escalated', 'success', 'error')
+               )
+               AND (? = '' OR COALESCE(s.last_active_at, s.started_at, '') >= ?)
+               AND NOT EXISTS (
+                    SELECT 1 FROM eval_metrics m
+                     WHERE m.session_id = s.session_id AND m.engine = ?
+               )
+             ORDER BY COALESCE(s.last_active_at, s.started_at) DESC NULLS LAST
+             LIMIT ?
+        """
+        try:
+            rows = self._fetch(sql, [cutoff, cutoff, engine or "builtin", int(limit)])
+        except Exception as e:
+            log.warning("local store: query_sessions_missing_eval_metrics failed: %s", e)
+            return []
+        cols = ["session_id", "agent_type", "status", "total_tokens"]
+        return [dict(zip(cols, r)) for r in rows]
 
     def persist_eval_suite_run(
         self,

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -19005,6 +19005,21 @@ def run_daemon() -> None:
                             )
                 except Exception as _ee:
                     log.warning("evals: scheduler tick errored: %s", _ee)
+                # Free deterministic checks on the same cadence (#2862).
+                # Separate try so a judge failure never starves them and
+                # vice versa. Uses the daemon's own writer store handle.
+                try:
+                    if DETERMINISTIC_CHECKS:
+                        from clawmetry import eval_runner as _eval_runner
+                        if _eval_runner.is_enabled():
+                            n_checked = _run_deterministic_checks_tick()
+                            if n_checked:
+                                log.info(
+                                    "evals: deterministic checks on %d session(s)",
+                                    n_checked,
+                                )
+                except Exception as _de_e:
+                    log.warning("evals: deterministic tick errored: %s", _de_e)
                 last_evals_run = now_evals
 
             # Re-mirror Docker data if running in Docker mode
@@ -20078,6 +20093,69 @@ STUCK_EVAL_INTERVAL_SEC = int(os.environ.get("CLAWMETRY_STUCK_INTERVAL_SEC", "60
 # self-throttles regardless of interval.
 EVAL_INTERVAL_SEC = int(os.environ.get("CLAWMETRY_EVALS_INTERVAL_SEC", "300"))
 EVAL_BATCH = int(os.environ.get("CLAWMETRY_EVALS_BATCH", "10"))
+# Issue #2862 (resurrected) — free deterministic checks that ride the same
+# tick. Zero LLM cost, so the batch can be larger than the judge's. The
+# check list is a comma-separated set of BUILTIN_EVALUATORS slugs; configless
+# slugs only by design (configured checks belong to eval suites). Empty
+# string disables the pass entirely.
+DETERMINISTIC_CHECKS = [
+    s.strip()
+    for s in os.environ.get("CLAWMETRY_DETERMINISTIC_CHECKS", "no-tool-errors").split(",")
+    if s.strip()
+]
+DETERMINISTIC_BATCH = int(os.environ.get("CLAWMETRY_DETERMINISTIC_BATCH", "25"))
+
+
+def _run_deterministic_checks_tick() -> int:
+    """One scheduler pass of the free deterministic checks (#2862).
+
+    Picks completed sessions with no ``builtin``-engine metric rows yet,
+    bridges their stored event rows to an ``EvalInput``, runs the configured
+    checks, and upserts one ``eval_metrics`` row per (session, check).
+    Runs on the daemon's own writer store handle; returns sessions touched.
+    """
+    from clawmetry import deterministic_evaluators as _de
+    from clawmetry import local_store as _ls
+
+    store = _ls.get_store()
+    if store is None:
+        return 0
+    checks = [{"slug": slug} for slug in DETERMINISTIC_CHECKS
+              if slug in _de.BUILTIN_EVALUATORS]
+    if not checks:
+        return 0
+    pending = store.query_sessions_missing_eval_metrics(
+        engine="builtin", limit=DETERMINISTIC_BATCH, lookback_hours=24,
+    )
+    touched = 0
+    now_ms = int(time.time() * 1000)
+    for sess in pending:
+        sid = sess.get("session_id")
+        if not sid:
+            continue
+        try:
+            rows = store.query_events(session_id=sid, limit=500)
+            eval_input = _de.eval_input_from_stored_rows(rows or [])
+            for result in _de.run_checks(eval_input, checks):
+                detail = ""
+                try:
+                    detail = json.dumps(result.detail) if result.detail else ""
+                except (TypeError, ValueError):
+                    detail = ""
+                store.persist_eval_metric(
+                    session_id=sid,
+                    metric_slug=result.slug,
+                    score=result.score,
+                    passed=result.passed,
+                    reason=result.reason,
+                    detail=detail,
+                    engine="builtin",
+                    scored_at=now_ms,
+                )
+            touched += 1
+        except Exception as e:
+            log.warning("evals: deterministic checks failed for %s: %s", sid, e)
+    return touched
 # Window for the events read from DuckDB on each tick. Wider than the
 # evaluation interval so a slow tick doesn't drop events on the floor.
 _ALERTS_EVENT_LOOKBACK_SEC = 600

--- a/routes/evals.py
+++ b/routes/evals.py
@@ -12,6 +12,7 @@ Routes:
   GET   /api/evals/rubric              — raw rubric YAML text
   POST  /api/evals/rubric              — replace rubric YAML text (validates parse)
   GET   /api/evals/regression-summary  — Phase 3: aggregate replay outcomes
+  GET   /api/evals/metrics             — per-session per-metric verdicts (#2862)
 
 All endpoints degrade gracefully when the local store or eval runner is
 unavailable — the dashboard treats an empty payload as "evals not yet
@@ -146,6 +147,25 @@ def evals_recent():
         limit = 50
     rows = _store_via_daemon_or_direct("query_recent_evals", limit=limit) or []
     return jsonify({"evals": rows, "limit": limit})
+
+
+@bp_evals.route("/api/evals/metrics", methods=["GET"])
+def evals_metrics():
+    """Per-session, per-metric verdicts (#2862 resurrected). The built-in
+    deterministic checks are free-tier (they run on the user's box at zero
+    LLM cost), so this read is ungated — mirroring ``/api/evaluators``.
+    Filters: ``?session_id=`` and/or ``?metric=``; ``?limit=`` capped at 500."""
+    try:
+        limit = max(1, min(500, int(request.args.get("limit", "100"))))
+    except (TypeError, ValueError):
+        limit = 100
+    session_id = (request.args.get("session_id") or "").strip() or None
+    metric = (request.args.get("metric") or "").strip() or None
+    rows = _store_via_daemon_or_direct(
+        "query_eval_metrics",
+        session_id=session_id, metric_slug=metric, limit=limit,
+    ) or []
+    return jsonify({"metrics": rows, "limit": limit})
 
 
 @bp_evals.route("/api/evals/summary", methods=["GET"])

--- a/routes/local_query.py
+++ b/routes/local_query.py
@@ -728,6 +728,19 @@ _DAEMON_METHODS = frozenset({
     "query_recent_evals",
     "query_eval_summary",
     "persist_eval_score",
+    # Issue #2862 (resurrected) — per-metric eval verdicts (deterministic
+    # checks now, named metric engines later). Same daemon-proxy rationale
+    # as the judge surface above.
+    "query_eval_metrics",
+    "query_sessions_missing_eval_metrics",
+    "persist_eval_metric",
+    # Drive-by (make lint-daemon-allowlist was red on main): both methods
+    # exist on LocalStore and are already called through the proxy from
+    # routes/usage.py and routes/channels.py; the allowlist entries were
+    # simply never added, so those proxy calls silently returned None on
+    # daemon installs.
+    "query_cache_metrics",
+    "query_channel_delivery_health",
     # Eval->monitor loop: per-session eval/outcome fields for the two runs in
     # /api/run-compare's quality rows. Read-only; routed through the daemon
     # proxy so the dashboard process never opens the writer-locked DuckDB.

--- a/tests/test_deterministic_evaluators.py
+++ b/tests/test_deterministic_evaluators.py
@@ -1,0 +1,243 @@
+"""Tests for clawmetry/deterministic_evaluators.py (#2862).
+
+Pins the zero-LLM, code-based eval runtime: each built-in's pass/fail
+behaviour, the 0..1 score shape that lines up with the LLM-judge surface,
+the runner's never-crash contract, and the best-effort event extractor.
+"""
+from __future__ import annotations
+
+from clawmetry.deterministic_evaluators import (
+    EvalInput,
+    DeterministicEvalResult,
+    BUILTIN_EVALUATORS,
+    run_checks,
+    eval_input_from_events,
+)
+
+
+def _run(slug, config, **inp):
+    return run_checks(EvalInput(**inp), [{"slug": slug, "config": config}])[0]
+
+
+# ── score shape ────────────────────────────────────────────────────────────────
+
+def test_result_score_shape_pass_is_one_fail_is_zero():
+    ok = _run("json-parseable", {}, output_text='{"a": 1}')
+    bad = _run("json-parseable", {}, output_text="not json")
+    assert ok.passed is True and ok.score == 1.0
+    assert bad.passed is False and bad.score == 0.0
+    # mirrors the LLM-judge 0..1 range for shared views
+    assert isinstance(ok, DeterministicEvalResult)
+    assert set(ok.to_dict()) == {"slug", "name", "score", "passed", "reason", "detail"}
+
+
+# ── json-parseable ───────────────────────────────────────────────────────────────
+
+def test_json_parseable():
+    assert _run("json-parseable", {}, output_text='{"x":1}').passed
+    assert _run("json-parseable", {}, output_text="[1, 2, 3]").passed
+    assert _run("json-parseable", {}, output_text='  {"x":1}  ').passed  # stripped
+    assert not _run("json-parseable", {}, output_text="hello").passed
+    assert not _run("json-parseable", {}, output_text="").passed  # empty fails
+
+
+# ── json-schema-match ────────────────────────────────────────────────────────────
+
+def test_json_schema_required_keys():
+    cfg = {"required_keys": ["name", "age"]}
+    assert _run("json-schema-match", cfg, output_text='{"name":"a","age":3}').passed
+    r = _run("json-schema-match", cfg, output_text='{"name":"a"}')
+    assert not r.passed and r.detail["missing"] == ["age"]
+
+
+def test_json_schema_types():
+    cfg = {"required_keys": ["age"], "types": {"age": "int", "name": "str"}}
+    assert _run("json-schema-match", cfg, output_text='{"age":3,"name":"a"}').passed
+    r = _run("json-schema-match", cfg, output_text='{"age":"three","name":"a"}')
+    assert not r.passed and r.detail["type_errors"]
+
+
+def test_json_schema_bool_is_not_int():
+    # JSON true must not silently satisfy an int/number type
+    cfg = {"types": {"age": "int"}}
+    r = _run("json-schema-match", cfg, output_text='{"age": true}')
+    assert not r.passed
+
+
+def test_json_schema_non_object_fails():
+    r = _run("json-schema-match", {"required_keys": ["x"]}, output_text="[1,2]")
+    assert not r.passed
+
+
+def test_json_schema_number_accepts_int_and_float():
+    cfg = {"types": {"v": "number"}}
+    assert _run("json-schema-match", cfg, output_text='{"v": 3}').passed
+    assert _run("json-schema-match", cfg, output_text='{"v": 3.5}').passed
+
+
+# ── regex-match ──────────────────────────────────────────────────────────────────
+
+def test_regex_match():
+    assert _run("regex-match", {"pattern": r"\d{3}"}, output_text="abc 123").passed
+    assert not _run("regex-match", {"pattern": r"\d{3}"}, output_text="abc").passed
+
+
+def test_regex_ignore_case_and_full_match():
+    assert _run("regex-match", {"pattern": "hello", "ignore_case": True},
+                output_text="HELLO world").passed
+    assert _run("regex-match", {"pattern": "hi", "full_match": True},
+                output_text="hi").passed
+    assert not _run("regex-match", {"pattern": "hi", "full_match": True},
+                    output_text="hi there").passed
+
+
+def test_regex_invalid_pattern_fails_gracefully():
+    r = _run("regex-match", {"pattern": "(unclosed"}, output_text="x")
+    assert not r.passed and "Invalid regex" in r.reason
+
+
+def test_regex_missing_pattern_fails():
+    assert not _run("regex-match", {}, output_text="x").passed
+
+
+# ── exact-match ──────────────────────────────────────────────────────────────────
+
+def test_exact_match_strips_by_default():
+    assert _run("exact-match", {"expected": "yes"}, output_text="  yes \n").passed
+    assert not _run("exact-match", {"expected": "yes"}, output_text="yes please").passed
+
+
+def test_exact_match_ignore_case():
+    assert _run("exact-match", {"expected": "YES", "ignore_case": True},
+                output_text="yes").passed
+
+
+def test_exact_match_missing_expected_fails():
+    assert not _run("exact-match", {}, output_text="x").passed
+
+
+# ── output-length-bounds ─────────────────────────────────────────────────────────
+
+def test_output_length_bounds():
+    assert _run("output-length-bounds", {"min_chars": 1, "max_chars": 10},
+                output_text="hello").passed
+    assert not _run("output-length-bounds", {"min_chars": 1}, output_text="").passed
+    assert not _run("output-length-bounds", {"max_chars": 3}, output_text="toolong").passed
+    # open-ended bounds
+    assert _run("output-length-bounds", {"min_chars": 2}, output_text="ok").passed
+
+
+# ── required-tool-args ───────────────────────────────────────────────────────────
+
+def test_required_tool_args_present():
+    inp = dict(tool_calls=[{"name": "write_file",
+                            "arguments": {"path": "/x", "content": "hi"}}])
+    assert _run("required-tool-args",
+                {"tool": "write_file", "args": ["path", "content"]}, **inp).passed
+
+
+def test_required_tool_args_missing():
+    inp = dict(tool_calls=[{"name": "write_file", "arguments": {"content": "hi"}}])
+    r = _run("required-tool-args", {"tool": "write_file", "args": ["path"]}, **inp)
+    assert not r.passed and r.detail["missing"] == ["path"]
+
+
+def test_required_tool_args_empty_value_counts_as_missing():
+    inp = dict(tool_calls=[{"name": "write_file", "arguments": {"path": ""}}])
+    assert not _run("required-tool-args",
+                    {"tool": "write_file", "args": ["path"]}, **inp).passed
+
+
+def test_required_tool_args_tool_never_called():
+    r = _run("required-tool-args", {"tool": "write_file", "args": ["path"]},
+             tool_calls=[{"name": "read_file", "arguments": {"path": "/x"}}])
+    assert not r.passed
+    # require_call=False makes an absent tool a pass
+    ok = _run("required-tool-args",
+              {"tool": "write_file", "args": ["path"], "require_call": False},
+              tool_calls=[])
+    assert ok.passed
+
+
+def test_required_tool_args_checks_every_call():
+    inp = dict(tool_calls=[
+        {"name": "w", "arguments": {"path": "/a"}},
+        {"name": "w", "arguments": {}},  # second call malformed
+    ])
+    r = _run("required-tool-args", {"tool": "w", "args": ["path"]}, **inp)
+    assert not r.passed and r.detail["call_index"] == 1
+
+
+# ── no-tool-errors ───────────────────────────────────────────────────────────────
+
+def test_no_tool_errors():
+    assert _run("no-tool-errors", {}, had_error=False).passed
+    assert not _run("no-tool-errors", {}, had_error=True).passed
+
+
+# ── runner contract ──────────────────────────────────────────────────────────────
+
+def test_unknown_slug_fails_not_raises():
+    results = run_checks(EvalInput(output_text="x"), [{"slug": "nope"}])
+    assert len(results) == 1 and not results[0].passed
+    assert "No built-in evaluator" in results[0].reason
+
+
+def test_run_checks_runs_all_and_is_independent():
+    inp = EvalInput(output_text='{"a":1}')
+    results = run_checks(inp, [
+        {"slug": "json-parseable"},
+        {"slug": "output-length-bounds", "config": {"max_chars": 2}},  # fails
+    ])
+    assert [r.passed for r in results] == [True, False]
+
+
+def test_run_checks_empty_list():
+    assert run_checks(EvalInput(), []) == []
+
+
+def test_builtin_catalogue_slugs_are_callable():
+    for slug, fn in BUILTIN_EVALUATORS.items():
+        assert callable(fn), slug
+        # every built-in tolerates an empty input + empty config without raising
+        out = fn(EvalInput(), {})
+        assert isinstance(out, DeterministicEvalResult)
+        assert out.score in (0.0, 1.0)
+
+
+# ── event extractor ──────────────────────────────────────────────────────────────
+
+def test_eval_input_from_events_dict_shape():
+    events = [
+        {"type": "message", "content": "first"},
+        {"type": "tool_call", "tool_calls": [
+            {"name": "write_file", "arguments": {"path": "/x"}}]},
+        {"type": "message", "content": "final answer"},
+    ]
+    inp = eval_input_from_events(events)
+    assert inp.output_text == "final answer"  # last non-empty wins
+    assert {"name": "write_file", "arguments": {"path": "/x"}} in inp.tool_calls
+    assert inp.had_error is False
+
+
+def test_eval_input_from_events_detects_error():
+    assert eval_input_from_events([{"type": "tool_error", "content": "boom"}]).had_error
+    assert eval_input_from_events(
+        [{"type": "tool_result", "extra": {"is_error": True}}]).had_error
+
+
+def test_eval_input_from_events_reads_dataclass_events():
+    from clawmetry.adapters.base import Event
+    ev = Event(agent="openclaw", session_id="s", id="1", type="message",
+               content="hi", tool_name="bash")
+    inp = eval_input_from_events([ev])
+    assert inp.output_text == "hi"
+    assert any(c["name"] == "bash" for c in inp.tool_calls)
+
+
+def test_eval_input_from_events_input_key_alias():
+    # tool_use blocks use "input" rather than "arguments"
+    events = [{"type": "tool_call",
+               "tool_calls": [{"name": "Read", "input": {"path": "/x"}}]}]
+    inp = eval_input_from_events(events)
+    assert inp.tool_calls[0]["arguments"] == {"path": "/x"}

--- a/tests/test_deterministic_stored_bridge.py
+++ b/tests/test_deterministic_stored_bridge.py
@@ -1,0 +1,152 @@
+"""Bridge tests: stored DuckDB event rows -> EvalInput (#2862 resurrected).
+
+The module was pruned in #4436 as "unintegrated" because its extractor only
+understood the in-memory adapter ``Event`` shape, never the rows
+``LocalStore.query_events`` actually returns. These tests pin the bridge on
+REAL stored shapes captured from a live claude_code session on 2026-08-03
+(``data`` holds the Event fields; ``tool_calls``/``extra`` arrive as
+Python-repr strings, not JSON), per the no-synthetic-shapes rule.
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+from clawmetry.deterministic_evaluators import (  # noqa: E402
+    eval_input_from_events,
+    eval_input_from_stored_rows,
+    run_checks,
+    stored_row_to_event,
+)
+
+
+def _real_tool_call_row(ts="2026-08-03T12:00:01+00:00"):
+    # Verbatim shape observed via the daemon proxy: tool_calls is a
+    # PYTHON-REPR string (single quotes), and the same call also appears
+    # as data.tool_name.
+    return {
+        "session_id": "claude_code:7e71",
+        "event_type": "tool_call",
+        "ts": ts,
+        "data": {
+            "_runtime": "claude_code",
+            "content": "",
+            "role": "assistant",
+            "tool_calls": "[{'id': 'toolu_01Q4', 'input': {'command': 'cat x'}, 'name': 'Bash'}]",
+            "tool_name": "Bash",
+        },
+    }
+
+
+def _real_tool_result_row(is_error=False, ts="2026-08-03T12:00:02+00:00"):
+    return {
+        "session_id": "claude_code:7e71",
+        "event_type": "tool_result",
+        "ts": ts,
+        "data": {
+            "_runtime": "claude_code",
+            "content": '{"port": 61248}',
+            "extra": "{'isError': %s, 'toolUseId': 'toolu_01Q4'}" % is_error,
+            "role": "tool",
+        },
+    }
+
+
+def _real_message_row(content, ts="2026-08-03T12:00:03+00:00"):
+    return {
+        "session_id": "claude_code:7e71",
+        "event_type": "message",
+        "ts": ts,
+        "data": {
+            "_runtime": "claude_code",
+            "content": content,
+            "extra": "{'model': 'claude-fable-5'}",
+            "role": "assistant",
+        },
+    }
+
+
+def test_stored_row_to_event_revives_repr_strings():
+    ev = stored_row_to_event(_real_tool_call_row())
+    assert ev["type"] == "tool_call"
+    assert isinstance(ev["tool_calls"], list) and len(ev["tool_calls"]) == 1
+    assert ev["tool_calls"][0]["name"] == "Bash"
+    assert ev["tool_calls"][0]["input"] == {"command": "cat x"}
+    assert ev["tool_name"] == "Bash"
+
+
+def test_stored_rows_no_double_count_and_arguments_mapped():
+    """A real tool_call row carries BOTH data.tool_calls and data.tool_name;
+    counting both made every call count twice (a 181-call session reported
+    362). The bridge must yield exactly one call, with arguments taken from
+    the entry's ``input``."""
+    inp = eval_input_from_stored_rows([_real_tool_call_row()])
+    assert len(inp.tool_calls) == 1
+    assert inp.tool_calls[0]["name"] == "Bash"
+    assert inp.tool_calls[0]["arguments"] == {"command": "cat x"}
+
+
+def test_tool_name_fallback_still_works_without_call_list():
+    """Events that only carry tool_name (no tool_calls list) keep working."""
+    row = _real_tool_call_row()
+    row["data"].pop("tool_calls")
+    inp = eval_input_from_stored_rows([row])
+    assert len(inp.tool_calls) == 1
+    assert inp.tool_calls[0]["name"] == "Bash"
+
+
+def test_error_flag_from_repr_extra():
+    ok = eval_input_from_stored_rows([_real_tool_result_row(is_error=False)])
+    assert ok.had_error is False
+    bad = eval_input_from_stored_rows([_real_tool_result_row(is_error=True)])
+    assert bad.had_error is True
+
+
+def test_output_text_is_latest_despite_newest_first_rows():
+    """query_events returns newest-first; the bridge must sort by ts so the
+    LAST reply wins, not the first row it sees."""
+    rows = [
+        _real_message_row("final answer", ts="2026-08-03T12:00:09+00:00"),
+        _real_message_row("first draft", ts="2026-08-03T12:00:03+00:00"),
+    ]
+    inp = eval_input_from_stored_rows(rows)
+    assert inp.output_text == "final answer"
+
+
+def test_bridge_feeds_run_checks_end_to_end():
+    rows = [
+        _real_tool_call_row(),
+        _real_tool_result_row(is_error=False),
+        _real_message_row("done"),
+    ]
+    inp = eval_input_from_stored_rows(rows)
+    results = run_checks(inp, [{"slug": "no-tool-errors"}])
+    assert len(results) == 1
+    assert results[0].passed is True and results[0].score == 1.0
+
+
+def test_bridge_never_raises_on_garbage():
+    garbage = [
+        None,
+        "not a row",
+        {"event_type": "tool_call", "data": "totally }{ unparseable"},
+        {"event_type": "tool_call", "data": {"tool_calls": "[unclosed"}},
+        {},
+    ]
+    inp = eval_input_from_stored_rows(garbage)  # must not raise
+    assert inp.tool_calls == []
+
+
+def test_adapter_event_shape_unchanged():
+    """The original adapter-Event path (dicts with top-level type/content/
+    tool_calls) still extracts — the bridge is additive."""
+    inp = eval_input_from_events([
+        {"type": "message", "content": "hi",
+         "tool_calls": [{"name": "web", "arguments": {"q": "x"}}]},
+    ])
+    assert inp.output_text == "hi"
+    assert inp.tool_calls == [{"name": "web", "arguments": {"q": "x"}}]

--- a/tests/test_eval_metrics_store.py
+++ b/tests/test_eval_metrics_store.py
@@ -1,0 +1,186 @@
+"""``eval_metrics`` table round-trip + scheduler-query tests (#2862).
+
+One row per (session, metric), latest-only upsert; ``engine`` labels who
+computed the verdict. ``query_sessions_missing_eval_metrics`` drives the
+daemon's deterministic-checks tick.
+"""
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+from datetime import datetime, timezone
+
+import pytest
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+
+@pytest.fixture
+def fresh_store(tmp_path, monkeypatch):
+    monkeypatch.setenv(
+        "CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb")
+    )
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_BATCH", "1")
+
+    sys.modules.pop("clawmetry.local_store", None)
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+
+    # A live daemon on the dev box would otherwise make get_store() return
+    # the HTTP proxy (whose old daemon lacks the new methods). Tests own
+    # their tmp DB, so claim the writer like the daemon does.
+    ls.mark_writer_owner()
+    store = ls.get_store()
+    yield ls, store
+
+    try:
+        store.stop(flush=False)
+    except Exception:
+        pass
+
+
+def _now_iso():
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _seed_session(store, sid, **kw):
+    row = {
+        "session_id": sid,
+        "agent_type": "claude_code",
+        "status": "completed",
+        "total_tokens": 1200,
+        "last_active_at": _now_iso(),
+        "started_at": _now_iso(),
+    }
+    row.update(kw)
+    store.ingest_session(row)
+
+
+def test_persist_and_query_round_trip(fresh_store):
+    _, store = fresh_store
+    store.persist_eval_metric(
+        session_id="s1", metric_slug="no-tool-errors", score=1.0,
+        passed=True, reason="No tool/turn errors recorded.",
+        detail='{"n": 3}', engine="builtin", scored_at=1754000000000,
+    )
+    rows = store.query_eval_metrics(session_id="s1")
+    assert len(rows) == 1
+    r = rows[0]
+    assert r["metric_slug"] == "no-tool-errors"
+    assert r["score"] == 1.0
+    assert r["passed"] is True
+    assert r["engine"] == "builtin"
+    assert r["detail"] == '{"n": 3}'
+    assert r["scored_at"] == 1754000000000
+
+
+def test_upsert_is_latest_only(fresh_store):
+    _, store = fresh_store
+    for score, passed in [(1.0, True), (0.0, False)]:
+        store.persist_eval_metric(
+            session_id="s1", metric_slug="no-tool-errors", score=score,
+            passed=passed, reason="r", engine="builtin",
+        )
+    rows = store.query_eval_metrics(session_id="s1")
+    assert len(rows) == 1
+    assert rows[0]["score"] == 0.0 and rows[0]["passed"] is False
+
+
+def test_query_filters(fresh_store):
+    _, store = fresh_store
+    store.persist_eval_metric(session_id="s1", metric_slug="a", score=1.0,
+                              passed=True, reason="", engine="builtin")
+    store.persist_eval_metric(session_id="s1", metric_slug="b", score=0.0,
+                              passed=False, reason="", engine="deepeval")
+    store.persist_eval_metric(session_id="s2", metric_slug="a", score=0.5,
+                              passed=None, reason="", engine="builtin")
+    assert len(store.query_eval_metrics(session_id="s1")) == 2
+    assert len(store.query_eval_metrics(metric_slug="a")) == 2
+    only = store.query_eval_metrics(session_id="s1", metric_slug="b")
+    assert len(only) == 1 and only[0]["engine"] == "deepeval"
+
+
+def test_missing_metrics_query_and_engine_isolation(fresh_store):
+    _, store = fresh_store
+    _seed_session(store, "done-unchecked")
+    _seed_session(store, "done-checked")
+    _seed_session(store, "inflight", status="active", ended_at=None)
+    _seed_session(store, "empty", total_tokens=0)
+    store.persist_eval_metric(session_id="done-checked", metric_slug="no-tool-errors",
+                              score=1.0, passed=True, reason="", engine="builtin")
+    # A different engine's verdict must NOT satisfy the builtin pass.
+    store.persist_eval_metric(session_id="done-unchecked", metric_slug="answer-quality-geval",
+                              score=0.9, passed=True, reason="", engine="deepeval")
+
+    pending = store.query_sessions_missing_eval_metrics(engine="builtin", limit=10)
+    sids = {r["session_id"] for r in pending}
+    assert "done-unchecked" in sids
+    assert "done-checked" not in sids       # already has a builtin row
+    assert "inflight" not in sids           # still mutating
+    assert "empty" not in sids              # trivial
+
+
+def test_persist_never_raises_on_bad_input(fresh_store):
+    _, store = fresh_store
+    store.persist_eval_metric(session_id="", metric_slug="x", score=None,
+                              passed=None, reason="", engine="builtin")
+    store.persist_eval_metric(session_id="s", metric_slug="", score=None,
+                              passed=None, reason="", engine="builtin")
+    assert store.query_eval_metrics() == []
+
+
+def test_deterministic_tick_scores_pending_sessions(fresh_store, monkeypatch):
+    """End-to-end scheduler pass on real stored shapes: seed a completed
+    session + its events, run the daemon tick, assert a builtin verdict
+    landed and the session left the pending set."""
+    ls, store = fresh_store
+    _seed_session(store, "tick-sess")
+    store.ingest({
+        "id": "ev-1",
+        "node_id": "n1",
+        "session_id": "tick-sess",
+        "event_type": "tool_call",
+        "ts": _now_iso(),
+        "data": {
+            "_runtime": "claude_code",
+            "content": "",
+            "tool_calls": "[{'id': 't1', 'input': {'command': 'ls'}, 'name': 'Bash'}]",
+            "tool_name": "Bash",
+        },
+    })
+    store.ingest({
+        "id": "ev-2",
+        "node_id": "n1",
+        "session_id": "tick-sess",
+        "event_type": "tool_result",
+        "ts": _now_iso(),
+        "data": {"_runtime": "claude_code", "content": "ok",
+                 "extra": "{'isError': False, 'toolUseId': 't1'}"},
+    })
+    store._flush_now()
+
+    from clawmetry import sync
+    monkeypatch.setattr(sync, "DETERMINISTIC_CHECKS", ["no-tool-errors"])
+    touched = sync._run_deterministic_checks_tick()
+    assert touched == 1
+
+    rows = store.query_eval_metrics(session_id="tick-sess")
+    assert len(rows) == 1
+    assert rows[0]["metric_slug"] == "no-tool-errors"
+    assert rows[0]["passed"] is True and rows[0]["engine"] == "builtin"
+    # Second tick: nothing pending anymore.
+    assert sync._run_deterministic_checks_tick() == 0
+
+
+def test_daemon_proxy_allowlist_carries_metric_methods():
+    """The dashboard reaches the store only through the daemon proxy;
+    a method missing from the allowlist silently returns None there."""
+    from routes import local_query
+    allowed = local_query._DAEMON_METHODS
+    for m in ("persist_eval_metric", "query_eval_metrics",
+              "query_sessions_missing_eval_metrics"):
+        assert m in allowed, f"{m} missing from daemon-proxy allowlist"

--- a/tests/test_evals_route_gates.py
+++ b/tests/test_evals_route_gates.py
@@ -519,6 +519,14 @@ def test_evals_routes_wear_gate_decorator():
         "/api/evaluators (the shop-menu catalogue) must stay free; "
         "gating it would blank the upgrade CTA target under enforce."
     )
+    # Same for /api/evals/metrics (#2862): the built-in deterministic
+    # checks are free-tier by design (zero LLM cost, run on the user's
+    # box), so their read endpoint must stay ungated.
+    metrics_src = inspect.getsource(evals_module.evals_metrics)
+    assert '@gate' not in metrics_src, (
+        "/api/evals/metrics must stay free -- deterministic check "
+        "verdicts are the free tier of the evaluator library."
+    )
 
 
 def test_gate_symbol_is_shared():


### PR DESCRIPTION
## Why

#4436 pruned `deterministic_evaluators.py` as an unintegrated orphan. The root cause of it being unintegrated: its extractor only understood the in-memory adapter Event shape, never the rows `LocalStore.query_events` actually returns (Event fields nested in `row['data']`, with `tool_calls`/`extra` stringified as Python repr). This PR restores the module with the missing integration, so the free zero-LLM-cost checks finally run on real sessions.

This is also Phase 1 of the DeepEval integration plan (`.claude/DEEPEVAL_EVALS_PLAN.md`): the `eval_metrics` table with its `engine` column is the seam a DeepEval bridge (and clawmetry-pro metrics) will plug into next, without widening the one `sessions.eval_score` column.

## What

- `eval_input_from_stored_rows` / `stored_row_to_event`: bridge stored DuckDB event rows to the extractor shape (JSON-then-`ast.literal_eval` revival of stringified fields, chronological re-sort so the last reply wins)
- Double-count fix: real `tool_call` rows carry BOTH a `tool_calls` list and `tool_name`; every call counted twice (observed 362 for a 181-call session). `tool_name` is now a fallback only
- New `eval_metrics` table: one row per (session, metric), latest-only upsert, `engine` column (builtin/pro/deepeval). `persist_eval_metric` / `query_eval_metrics` / `query_sessions_missing_eval_metrics` + daemon-proxy allowlist
- Daemon tick: deterministic checks ride the existing eval scheduler cadence (`CLAWMETRY_DETERMINISTIC_CHECKS`, default `no-tool-errors`, empty string disables). Separate try so a judge outage never starves them, and vice versa
- `GET /api/evals/metrics` (ungated: built-ins are the free tier of the evaluator library; freeness pinned in `test_evals_route_gates.py` next to the catalogue pin)
- Drive-by: `make lint-daemon-allowlist` was red on main; added the two missing entries (`query_cache_metrics`, `query_channel_delivery_health`) whose proxy call sites already exist in `routes/usage.py` / `routes/channels.py` (their proxy calls silently returned None on daemon installs)

## Verification

- 102 tests green across the eval surface (`test_deterministic_stored_bridge.py`, `test_eval_metrics_store.py`, `test_deterministic_evaluators.py`, `test_evals_route_gates.py`, `test_evaluators_catalogue.py`)
- Bridge tests pin the REAL stored shapes captured from a live claude_code session via the daemon proxy on 2026-08-03 (no synthetic shapes): `tool_calls` as single-quoted Python repr with `{id,input,name}` entries, `extra` repr with `isError`
- Revert-proof: the double-count guard fails red with the fix reverted, green restored
- Scheduler test seeds a completed session + real-shape events into a tmp DuckDB and runs `sync._run_deterministic_checks_tick()` end to end: verdict row lands, session leaves the pending set, second tick is a no-op
- `scripts/lint_daemon_allowlist.py` green (was red on main); new files ruff-clean; py3.9 ast-parse clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)