### PR TITLE
feat(evals): optional DeepEval metric engine (clawmetry[deepeval]) behind our own judge

### DIFF
--- a/clawmetry/deepeval_bridge.py
+++ b/clawmetry/deepeval_bridge.py
@@ -1,0 +1,487 @@
+"""
+clawmetry/deepeval_bridge.py — optional DeepEval metric engine (local-first).
+
+DeepEval (Apache-2.0, github.com/confident-ai/deepeval) ships the best OSS
+catalogue of agent metrics (argument correctness, multi-turn conversation
+quality, G-Eval custom criteria). This bridge lets ClawMetry run a curated
+subset of those metrics on completed sessions WITHOUT giving up the moat:
+
+  * **Optional extra.** DeepEval pulls ~70 transitive packages, so it can
+    never be a base dependency (deps stay flask+waitress+cryptography+duckdb).
+    Install with ``pip install clawmetry[deepeval]``; everything in this
+    module degrades to an honest skip when the import is missing, and
+    importing THIS module never imports deepeval (lazy, guarded).
+  * **Telemetry forced off.** DeepEval phones PostHog by default and once
+    shipped a release that exported host-app spans to its vendor account
+    (confident-ai/deepeval#2497). ``_force_local_env()`` sets the opt-out
+    env vars BEFORE any deepeval import, every time, no exceptions.
+  * **The judge is OURS.** Metrics run against ``ClawMetryJudgeLLM``, a thin
+    DeepEvalBaseLLM wrapper over ``eval_runner._call_judge`` — the user's own
+    provider + key (Anthropic/OpenAI/Google/OpenRouter/custom incl. keyless
+    local servers), redaction upstream, no vendor SDKs, cost visible to the
+    interceptor. DeepEval's own model classes are never used, so no judge
+    traffic can bypass the provider the user configured.
+  * **Honest degrade everywhere.** No extra -> skip. No judge key -> skip
+    (never spend). Judge/schema failure -> a persisted skip row (score NULL,
+    reason recorded) so the scheduler doesn't retry-burn the same session.
+
+Scored results land in the ``eval_metrics`` table with ``engine='deepeval'``
+(one row per session+metric, latest-only), the same surface the free
+deterministic checks write to.
+
+Scheduling: OFF by default. Judge-backed metrics spend money, so the daemon
+tick only runs when ``CLAWMETRY_DEEPEVAL_METRICS`` names at least one metric
+(comma-separated slugs from ``SUPPORTED_METRICS``).
+
+Public API:
+    is_available() -> bool
+    supported_metrics() -> list[str]
+    score_session_deepeval(session_id, *, metrics=None, store=None,
+                           judge_call=None, dry_run=False) -> list[dict]
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import time
+from typing import Any, Callable
+
+log = logging.getLogger("clawmetry.deepeval_bridge")
+
+
+# Curated metric set v1. Values: which test-case shape the metric consumes.
+# TaskCompletion is deliberately absent (it needs DeepEval @observe traces,
+# which post-hoc stored sessions do not have). Tool-correctness is absent
+# here because it needs expected_tools — that is suite territory, where the
+# golden YAML supplies them.
+SUPPORTED_METRICS: dict[str, str] = {
+    "argument-correctness": "single_turn",
+    "conversation-completeness": "conversational",
+}
+
+# Env knobs. Rate limit is separate from the answer-quality judge cap: this
+# engine can run several judge calls per session.
+RATE_LIMIT_PER_HOUR = int(os.environ.get("CLAWMETRY_DEEPEVAL_RATE_LIMIT", "50"))
+MAX_OUTPUT_CHARS = int(os.environ.get("CLAWMETRY_DEEPEVAL_MAX_OUTPUT", "4000"))
+MAX_TURNS = int(os.environ.get("CLAWMETRY_DEEPEVAL_MAX_TURNS", "40"))
+MAX_TOOL_CALLS = int(os.environ.get("CLAWMETRY_DEEPEVAL_MAX_TOOLS", "50"))
+JUDGE_MAX_TOKENS = int(os.environ.get("CLAWMETRY_DEEPEVAL_JUDGE_MAX_TOKENS", "1500"))
+
+# The env contract that keeps DeepEval fully local. Forced (not setdefault):
+# the privacy posture is not user-tunable through this code path.
+_LOCAL_ENV = {
+    "DEEPEVAL_TELEMETRY_OPT_OUT": "1",
+    "ERROR_REPORTING": "0",
+    "DEEPEVAL_UPDATE_WARNING_OPT_IN": "0",
+}
+
+
+def _force_local_env() -> None:
+    """Set DeepEval's telemetry opt-outs. MUST run before any deepeval
+    import; called from every entry point that may trigger one."""
+    for k, v in _LOCAL_ENV.items():
+        os.environ[k] = v
+
+
+def is_available() -> bool:
+    """True when the ``deepeval`` package is installed (the clawmetry[deepeval]
+    extra). Probes the spec WITHOUT importing — importing deepeval is heavy
+    (pydantic v2 + OTel + rich) and must stay off the CLI startup path."""
+    try:
+        import importlib.util
+        return importlib.util.find_spec("deepeval") is not None
+    except Exception:
+        return False
+
+
+def supported_metrics() -> list[str]:
+    return list(SUPPORTED_METRICS)
+
+
+_DEEPEVAL_NS: dict[str, Any] | None = None
+
+
+def _deepeval_ns() -> dict[str, Any]:
+    """Import deepeval lazily (telemetry env first) and cache the symbols the
+    bridge needs. Raises ImportError when the extra is not installed."""
+    global _DEEPEVAL_NS
+    if _DEEPEVAL_NS is not None:
+        return _DEEPEVAL_NS
+    _force_local_env()
+    from deepeval.metrics import (  # noqa: PLC0415
+        ArgumentCorrectnessMetric,
+        ConversationCompletenessMetric,
+    )
+    from deepeval.models.base_model import DeepEvalBaseLLM  # noqa: PLC0415
+    from deepeval.test_case import (  # noqa: PLC0415
+        ConversationalTestCase,
+        LLMTestCase,
+        ToolCall,
+        Turn,
+    )
+    _DEEPEVAL_NS = {
+        "ArgumentCorrectnessMetric": ArgumentCorrectnessMetric,
+        "ConversationCompletenessMetric": ConversationCompletenessMetric,
+        "DeepEvalBaseLLM": DeepEvalBaseLLM,
+        "ConversationalTestCase": ConversationalTestCase,
+        "LLMTestCase": LLMTestCase,
+        "ToolCall": ToolCall,
+        "Turn": Turn,
+    }
+    return _DEEPEVAL_NS
+
+
+# ── The judge: DeepEval schema contract over ClawMetry's own HTTP judge ────────
+
+_FENCE_RE = re.compile(r"```(?:json)?\s*(.*?)```", re.DOTALL)
+
+
+def _extract_json(raw: str) -> Any:
+    """Pull the first JSON object out of a judge reply that may wrap it in
+    prose or a code fence (small local models routinely do)."""
+    m = _FENCE_RE.search(raw or "")
+    if m:
+        raw = m.group(1)
+    start = (raw or "").find("{")
+    end = (raw or "").rfind("}")
+    if start == -1 or end <= start:
+        raise ValueError("no JSON object in judge reply")
+    return json.loads(raw[start:end + 1])
+
+
+_JUDGE_CLS: type | None = None
+
+
+def _judge_cls() -> type:
+    """Build (once) the DeepEvalBaseLLM subclass that routes every metric
+    judge call through ``eval_runner._call_judge``: the user's configured
+    provider + key, redacted inputs, interceptor-visible spend."""
+    global _JUDGE_CLS
+    if _JUDGE_CLS is not None:
+        return _JUDGE_CLS
+    ns = _deepeval_ns()
+
+    class ClawMetryJudgeLLM(ns["DeepEvalBaseLLM"]):
+        def __init__(self, model: str, judge_call: Callable[..., str] | None = None):
+            self.model = model
+            self._judge_call = judge_call
+            self.calls = 0
+
+        def load_model(self):
+            return self
+
+        def get_model_name(self) -> str:
+            return f"clawmetry-judge:{self.model}"
+
+        def _raw(self, prompt: str) -> str:
+            from clawmetry import eval_runner
+            self.calls += 1
+            caller = self._judge_call or eval_runner._call_judge
+            return caller(
+                self.model, prompt,
+                timeout=eval_runner.JUDGE_TIMEOUT_SECS,
+                max_tokens=JUDGE_MAX_TOKENS,
+            )
+
+        def generate(self, prompt: str, schema: Any = None):
+            if schema is None:
+                return self._raw(prompt)
+            # DeepEval metrics require a populated pydantic model back.
+            # Ask for schema-conformant JSON; one corrective retry, then a
+            # final raise that the per-metric runner catches as a skip.
+            sch = json.dumps(schema.model_json_schema())
+            ask = (
+                prompt
+                + "\n\nRespond with ONLY a JSON object that validates against "
+                  "this JSON schema. No prose, no code fences.\nSCHEMA: " + sch
+            )
+            last_err: Exception | None = None
+            for _attempt in range(2):
+                raw = self._raw(ask)
+                try:
+                    return schema.model_validate(_extract_json(raw))
+                except Exception as e:  # noqa: BLE001 — retried once, then raised
+                    last_err = e
+                    ask = (
+                        prompt
+                        + "\n\nYour previous reply was not valid JSON for the "
+                          "schema (" + str(e)[:120] + "). Respond with ONLY the "
+                          "JSON object, nothing else.\nSCHEMA: " + sch
+                    )
+            raise RuntimeError(f"judge schema contract failed: {last_err}")
+
+        async def a_generate(self, prompt: str, schema: Any = None):
+            return self.generate(prompt, schema)
+
+    _JUDGE_CLS = ClawMetryJudgeLLM
+    return _JUDGE_CLS
+
+
+# ── Test-case builders (redacted before anything reaches a metric) ─────────────
+
+
+def _redact(text: str) -> str:
+    try:
+        from clawmetry import eval_runner
+        return eval_runner._redact_for_judge(text or "")
+    except Exception:
+        return text or ""
+
+
+def _build_single_turn_case(rows: list, ns: dict[str, Any]):
+    """LLMTestCase: first user prompt, last assistant reply, tool calls."""
+    from clawmetry import deterministic_evaluators as de
+
+    turns = de.turns_from_stored_rows(rows)
+    eval_input = de.eval_input_from_stored_rows(rows)
+    first_user = next((t["content"] for t in turns if t["role"] == "user"), "")
+    # The reply being judged must be an actual ASSISTANT turn; the raw
+    # output_text fallback would happily grade the user's own words on a
+    # session with no reply yet.
+    actual = next(
+        (t["content"] for t in reversed(turns) if t["role"] == "assistant"), "")
+    if not actual:
+        return None
+    tools = []
+    for tc in eval_input.tool_calls[:MAX_TOOL_CALLS]:
+        name = tc.get("name")
+        if not name:
+            continue
+        args = tc.get("arguments")
+        tools.append(ns["ToolCall"](
+            name=str(name),
+            input_parameters=args if isinstance(args, dict) else {},
+        ))
+    return ns["LLMTestCase"](
+        input=_redact(first_user)[:MAX_OUTPUT_CHARS] or "(no prompt captured)",
+        actual_output=_redact(actual)[:MAX_OUTPUT_CHARS],
+        tools_called=tools,
+    )
+
+
+def _build_conversational_case(rows: list, ns: dict[str, Any]):
+    """ConversationalTestCase from the session's chronological turns."""
+    from clawmetry import deterministic_evaluators as de
+
+    turns = de.turns_from_stored_rows(rows)
+    if len(turns) < 2 or not any(t["role"] == "user" for t in turns):
+        return None
+    tail = turns[-MAX_TURNS:]
+    return ns["ConversationalTestCase"](turns=[
+        ns["Turn"](role=t["role"], content=_redact(t["content"])[:MAX_OUTPUT_CHARS])
+        for t in tail
+    ])
+
+
+def _build_metric(slug: str, judge: Any, ns: dict[str, Any]):
+    if slug == "argument-correctness":
+        return ns["ArgumentCorrectnessMetric"](
+            model=judge, async_mode=False, include_reason=True,
+        )
+    if slug == "conversation-completeness":
+        return ns["ConversationCompletenessMetric"](
+            model=judge, async_mode=False, include_reason=True,
+        )
+    raise ValueError(f"unsupported deepeval metric {slug!r}")
+
+
+# ── Rate limiter (reuse the judge's sliding-window impl) ───────────────────────
+
+_LIMITER = None
+
+
+def _rate_limiter():
+    global _LIMITER
+    if _LIMITER is None:
+        from clawmetry import eval_runner
+        _LIMITER = eval_runner._RateLimiter(RATE_LIMIT_PER_HOUR)
+    return _LIMITER
+
+
+# ── The scorer ─────────────────────────────────────────────────────────────────
+
+
+def _judge_ready() -> bool:
+    """A judge call can succeed on this box: configured provider has a key,
+    or is the custom provider with a base URL (keyless local server OK)."""
+    try:
+        from clawmetry import eval_runner
+        rubric = eval_runner.load_rubric("default") or {}
+        provider = eval_runner.judge_provider_for(rubric)
+        if provider == "custom":
+            return bool(eval_runner.judge_base_url())
+        return bool(eval_runner._judge_api_key_for_provider(provider))
+    except Exception:
+        return False
+
+
+def score_session_deepeval(
+    session_id: str,
+    *,
+    metrics: list[str] | None = None,
+    store: Any = None,
+    judge_call: Callable[..., str] | None = None,
+    dry_run: bool = False,
+) -> list[dict[str, Any]]:
+    """Run the requested DeepEval metrics on one stored session.
+
+    Returns one result dict per metric: ``{session_id, metric_slug, score,
+    passed, reason, engine, judge_model, scored_at, skipped, skip_reason}``.
+    Persists non-dry-run results (including judge-error skips, so the
+    scheduler never retry-burns a broken session). Returns ``[]`` when evals
+    are disabled, deepeval is not installed, or there is nothing to score.
+    """
+    from clawmetry import eval_runner
+
+    if not eval_runner.is_enabled():
+        return []
+    slugs = [s for s in (metrics or list(SUPPORTED_METRICS))
+             if s in SUPPORTED_METRICS]
+    if not slugs:
+        return []
+    if not is_available():
+        log.info("deepeval bridge: package not installed; skipping "
+                 "(pip install clawmetry[deepeval])")
+        return []
+    if judge_call is None and not _judge_ready():
+        # Quiet skip, never spend, nothing persisted: key may appear later.
+        return []
+
+    scored_at = int(time.time() * 1000)
+    rubric = eval_runner.load_rubric("default") or {}
+    judge_model = str(rubric.get("judge_model")
+                      or eval_runner.DEFAULT_RUBRIC["judge_model"])
+
+    rows = _load_rows(session_id, store)
+    if not rows:
+        return []
+
+    try:
+        ns = _deepeval_ns()
+    except Exception as e:  # import half-broken (version conflict etc.)
+        log.warning("deepeval bridge: import failed: %s", e)
+        return []
+
+    judge = _judge_cls()(judge_model, judge_call=judge_call)
+    results: list[dict[str, Any]] = []
+    cases: dict[str, Any] = {}
+    for slug in slugs:
+        shape = SUPPORTED_METRICS[slug]
+        if shape not in cases:
+            builder = (_build_single_turn_case if shape == "single_turn"
+                       else _build_conversational_case)
+            try:
+                cases[shape] = builder(rows, ns)
+            except Exception as e:  # noqa: BLE001 — builder must not kill the pass
+                log.warning("deepeval bridge: case build failed (%s): %s", shape, e)
+                cases[shape] = None
+        case = cases[shape]
+        base = {
+            "session_id": session_id, "metric_slug": slug, "engine": "deepeval",
+            "judge_model": judge_model, "scored_at": scored_at,
+        }
+        if case is None:
+            results.append({**base, "score": None, "passed": None,
+                            "reason": "not enough transcript to build this metric's input",
+                            "skipped": True, "skip_reason": "no_input"})
+            continue
+        if judge_call is None and not _rate_limiter().allow():
+            results.append({**base, "score": None, "passed": None,
+                            "reason": f"rate limit hit ({RATE_LIMIT_PER_HOUR}/hour)",
+                            "skipped": True, "skip_reason": "rate_limit"})
+            continue
+        try:
+            metric = _build_metric(slug, judge, ns)
+            metric.measure(case)
+            score = float(metric.score) if metric.score is not None else None
+            results.append({
+                **base,
+                "score": score,
+                "passed": bool(metric.is_successful()) if score is not None else None,
+                "reason": str(metric.reason or "")[:500],
+                "skipped": False, "skip_reason": None,
+            })
+        except Exception as e:  # noqa: BLE001 — a judge outage is a skip, not a crash
+            log.warning("deepeval bridge: %s failed for %s: %s", slug, session_id, e)
+            results.append({**base, "score": None, "passed": None,
+                            "reason": f"judge error: {type(e).__name__}",
+                            "skipped": True, "skip_reason": "judge_error"})
+
+    if not dry_run:
+        _persist(results, store)
+    return results
+
+
+def _load_rows(session_id: str, store: Any) -> list:
+    try:
+        s = store
+        if s is None:
+            from clawmetry import local_store
+            s = local_store.get_store()
+        return s.query_events(session_id=session_id, limit=500) or []
+    except Exception:
+        return []
+
+
+def _persist(results: list[dict[str, Any]], store: Any) -> None:
+    """Write every non-empty verdict (including judge-error skips) through
+    the store so the session leaves the pending set. Never raises."""
+    try:
+        s = store
+        if s is None:
+            from clawmetry import local_store
+            s = local_store.get_store()
+        for r in results:
+            # Do not mark no_input/rate_limit skips as done: the transcript
+            # may still be filling in, and a rate-limited session deserves a
+            # retry next tick. judge_error IS persisted (retrying would burn
+            # the same call again).
+            if r.get("skip_reason") in ("no_input", "rate_limit"):
+                continue
+            s.persist_eval_metric(
+                session_id=r["session_id"],
+                metric_slug=r["metric_slug"],
+                score=r.get("score"),
+                passed=r.get("passed"),
+                reason=r.get("reason") or "",
+                detail="",
+                engine="deepeval",
+                judge_model=r.get("judge_model") or "",
+                scored_at=r.get("scored_at") or 0,
+            )
+    except Exception:
+        log.warning("deepeval bridge: persist failed", exc_info=True)
+
+
+def score_pending_deepeval(*, batch_size: int = 5, store: Any = None) -> int:
+    """Scheduler entry: run the env-configured metrics over sessions that
+    have no deepeval verdicts yet. Returns sessions touched. All the guards
+    (enabled/available/key/rate) live in ``score_session_deepeval``."""
+    metrics = [s.strip() for s in
+               os.environ.get("CLAWMETRY_DEEPEVAL_METRICS", "").split(",")
+               if s.strip() and s.strip() in SUPPORTED_METRICS]
+    if not metrics:
+        return 0
+    if not (is_available() and _judge_ready()):
+        return 0
+    try:
+        s = store
+        if s is None:
+            from clawmetry import local_store
+            s = local_store.get_store()
+        pending = s.query_sessions_missing_eval_metrics(
+            engine="deepeval", limit=batch_size, lookback_hours=24,
+        )
+    except Exception:
+        return 0
+    touched = 0
+    for sess in pending or []:
+        sid = sess.get("session_id")
+        if not sid:
+            continue
+        if score_session_deepeval(sid, metrics=metrics, store=s):
+            touched += 1
+    return touched

--- a/clawmetry/deterministic_evaluators.py
+++ b/clawmetry/deterministic_evaluators.py
@@ -411,9 +411,50 @@ def eval_input_from_stored_rows(rows: list) -> EvalInput:
     Rows come back newest-first from the store; "last output wins" needs
     chronological order, so sort ascending by ``ts`` when present (stable
     for ties / missing ts)."""
+    rows = _sorted_stored_rows(rows)
+    return eval_input_from_events([stored_row_to_event(r) for r in rows])
+
+
+def _sorted_stored_rows(rows: list) -> list[dict]:
     rows = [r for r in (rows or []) if isinstance(r, dict)]
     try:
         rows = sorted(rows, key=lambda r: str(r.get("ts") or ""))
     except Exception:
         pass
-    return eval_input_from_events([stored_row_to_event(r) for r in rows])
+    return rows
+
+
+# Event types that identify the speaker when ``data.role`` is absent.
+# Mirrors eval_runner's prompt/response unions (v3 + legacy shapes).
+_USER_TURN_TYPES = frozenset({"prompt.submitted", "user", "subagent:user"})
+_ASSISTANT_TURN_TYPES = frozenset({
+    "model.completed", "assistant", "message", "subagent:assistant",
+})
+
+
+def turns_from_stored_rows(rows: list) -> list[dict[str, Any]]:
+    """Chronological ``[{"role": "user"|"assistant", "content": str}, ...]``
+    from stored event rows: the conversation shape multi-turn evaluators
+    (and the DeepEval bridge) consume.
+
+    ``data.role`` wins when present (claude_code rows carry it); otherwise
+    the event type decides. Tool traffic and empty turns are dropped."""
+    turns: list[dict[str, Any]] = []
+    for row in _sorted_stored_rows(rows):
+        data = _parse_stored_field(row.get("data"))
+        if not isinstance(data, dict):
+            data = {}
+        content = data.get("content") or ""
+        if not isinstance(content, str) or not content.strip():
+            continue
+        role = str(data.get("role") or "").strip().lower()
+        if role not in ("user", "assistant"):
+            etype = str(row.get("event_type") or "").lower()
+            if etype in _USER_TURN_TYPES:
+                role = "user"
+            elif etype in _ASSISTANT_TURN_TYPES:
+                role = "assistant"
+            else:
+                continue
+        turns.append({"role": role, "content": content})
+    return turns

--- a/clawmetry/eval_runner.py
+++ b/clawmetry/eval_runner.py
@@ -1021,12 +1021,16 @@ def _judge_request(
     return choices[0].get("message", {}).get("content", "") or ""
 
 
-def _call_judge(model: str, prompt: str, *, timeout: float = 30.0) -> str:
+def _call_judge(
+    model: str, prompt: str, *, timeout: float = 30.0, max_tokens: int = 200,
+) -> str:
     """Call the configured judge provider with the user's own key.
 
     Back-compat entry point (clawmetry-pro's faithfulness evaluator calls
     this with ``(model, prompt, timeout=...)``). Provider comes from the
     rubric's ``judge_provider`` when set, else is inferred from the model id.
+    ``max_tokens`` defaults to the classic SCORE/REASON budget; structured
+    judges (the DeepEval bridge) pass a larger cap for JSON replies.
     """
     rubric = load_rubric("default")
     if str(rubric.get("judge_model") or "") == (model or ""):
@@ -1039,6 +1043,7 @@ def _call_judge(model: str, prompt: str, *, timeout: float = 30.0) -> str:
         prompt,
         api_key=_judge_api_key_for_provider(provider),
         timeout=timeout,
+        max_tokens=max_tokens,
     )
 
 

--- a/clawmetry/evaluators.py
+++ b/clawmetry/evaluators.py
@@ -54,13 +54,26 @@ STATUS_LIVE = "live"            # shipped + computed today
 STATUS_PARTIAL = "partial"     # computed, but heuristic / not yet content-grounded
 STATUS_PRO = "pro"             # value comes from the Pro plugin; locked without it
 STATUS_NEEDS_KEY = "needs_key"  # shipped, but idle on THIS box until a judge key is set
+STATUS_NEEDS_EXTRA = "needs_extra"  # idle until an optional pip extra is installed
 
 # Slugs whose compute path is the LLM-as-judge (clawmetry/eval_runner.py) and so
 # cannot produce a value without a judge API key on the box. Used by
 # catalogue_with_coverage to downgrade their per-box status honestly.
 # faithfulness (Pro) reuses eval_runner._call_judge + the same key, so a
 # registered hook without a key is still idle and must not badge "Live".
-_JUDGE_BACKED_SLUGS = frozenset({"answer-quality", "faithfulness"})
+_JUDGE_BACKED_SLUGS = frozenset({
+    "answer-quality", "faithfulness",
+    "argument-correctness", "conversation-completeness",
+})
+
+# Slugs computed by the optional DeepEval engine (clawmetry/deepeval_bridge.py,
+# pip install clawmetry[deepeval]). On a box where the extra is missing they
+# downgrade to needs_extra; installed-but-keyless downgrades to needs_key via
+# _JUDGE_BACKED_SLUGS above (needs_extra wins when both apply: installing the
+# engine is the first step).
+_DEEPEVAL_BACKED_SLUGS = frozenset({
+    "argument-correctness", "conversation-completeness",
+})
 
 
 # ── The catalogue — single source of truth ──────────────────────────────────────
@@ -214,6 +227,37 @@ EVALUATOR_CATALOGUE: list[dict[str, Any]] = [
         "value_field": None,
     },
     {
+        "slug": "argument-correctness",
+        "name": "Did the agent use its tools right?",
+        "description": (
+            "An LLM judge checks whether each tool call the agent made used "
+            "sensible inputs for the task at hand. Powered by the optional "
+            "DeepEval engine, running locally on your own key."
+        ),
+        "category": CATEGORY_AGENT,
+        "tier": TIER_FREE,
+        "status": STATUS_LIVE,
+        "computed_in": "DeepEval metric engine, local (pip install clawmetry[deepeval])",
+        "source": "clawmetry.deepeval_bridge:score_session_deepeval",
+        "value_field": None,
+    },
+    {
+        "slug": "conversation-completeness",
+        "name": "Did the conversation get finished?",
+        "description": (
+            "An LLM judge reads the whole back and forth and checks whether "
+            "what the user asked for was actually delivered by the end. "
+            "Powered by the optional DeepEval engine, running locally on your "
+            "own key."
+        ),
+        "category": CATEGORY_QUALITY,
+        "tier": TIER_FREE,
+        "status": STATUS_LIVE,
+        "computed_in": "DeepEval metric engine, local (pip install clawmetry[deepeval])",
+        "source": "clawmetry.deepeval_bridge:score_session_deepeval",
+        "value_field": None,
+    },
+    {
         "slug": "faithfulness",
         "name": "Was every claim backed by the evidence?",
         "description": (
@@ -337,6 +381,20 @@ def catalogue_with_coverage(
         for e in cat:
             if e["slug"] in _JUDGE_BACKED_SLUGS and e["status"] == STATUS_LIVE:
                 e["status"] = STATUS_NEEDS_KEY
+    if store is not None:
+        # DeepEval-backed entries need the optional extra ON THIS BOX before
+        # a judge key even matters; needs_extra therefore overrides needs_key.
+        # No store (the cloud container) keeps the static status, mirroring
+        # the needs_key rule above.
+        try:
+            from clawmetry import deepeval_bridge
+            deepeval_ok = deepeval_bridge.is_available()
+        except Exception:
+            deepeval_ok = False
+        if not deepeval_ok:
+            for e in cat:
+                if e["slug"] in _DEEPEVAL_BACKED_SLUGS:
+                    e["status"] = STATUS_NEEDS_EXTRA
     payload: dict[str, Any] = {
         "evaluators": cat,
         "total": len(cat),

--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -3561,6 +3561,8 @@ async function loadEvaluators() {
       statusLabel = t("evaluators.status_partial", null, "Early"); statusColor = '#f59e0b';
     } else if (e.status === 'needs_key') {
       statusLabel = t("evaluators.status_needs_key", null, "Needs key"); statusColor = '#f59e0b';
+    } else if (e.status === 'needs_extra') {
+      statusLabel = t("evaluators.status_needs_extra", null, "Needs install"); statusColor = '#f59e0b';
     } else {
       statusLabel = t("evaluators.status_soon", null, "With Pro"); statusColor = 'var(--text-muted)';
     }
@@ -3585,6 +3587,10 @@ async function loadEvaluators() {
     if (e.status === 'needs_key') {
       html += '<div style="margin-top:8px;font-size:11px;"><a href="#" onclick="openEvalRubricModal();return false;" style="color:#f59e0b;font-weight:600;text-decoration:none;">' +
         t("evaluators.set_key", null, "Add a judge API key to turn this on") + ' &rarr;</a></div>';
+    }
+    if (e.status === 'needs_extra') {
+      html += '<div style="margin-top:8px;font-size:11px;color:#f59e0b;font-weight:600;">' +
+        t("evaluators.needs_extra_hint", null, "Turn on with: pip install clawmetry[deepeval]") + '</div>';
     }
     html += '</div>';
   });

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -19020,6 +19020,16 @@ def run_daemon() -> None:
                                 )
                 except Exception as _de_e:
                     log.warning("evals: deterministic tick errored: %s", _de_e)
+                # Optional DeepEval metric engine, same cadence. OFF unless
+                # CLAWMETRY_DEEPEVAL_METRICS names metrics (judge spend is
+                # opt-in). All guards (installed/key/rate) live in the bridge.
+                try:
+                    from clawmetry import deepeval_bridge as _deb
+                    n_deep = _deb.score_pending_deepeval(batch_size=DEEPEVAL_BATCH)
+                    if n_deep:
+                        log.info("evals: deepeval metrics on %d session(s)", n_deep)
+                except Exception as _deb_e:
+                    log.warning("evals: deepeval tick errored: %s", _deb_e)
                 last_evals_run = now_evals
 
             # Re-mirror Docker data if running in Docker mode
@@ -20104,6 +20114,9 @@ DETERMINISTIC_CHECKS = [
     if s.strip()
 ]
 DETERMINISTIC_BATCH = int(os.environ.get("CLAWMETRY_DETERMINISTIC_BATCH", "25"))
+# DeepEval bridge batch: small because each session can cost several judge
+# calls. The engine itself is opt-in via CLAWMETRY_DEEPEVAL_METRICS.
+DEEPEVAL_BATCH = int(os.environ.get("CLAWMETRY_DEEPEVAL_BATCH", "5"))
 
 
 def _run_deterministic_checks_tick() -> int:

--- a/docs/EVALS_DEEPEVAL.md
+++ b/docs/EVALS_DEEPEVAL.md
@@ -1,0 +1,51 @@
+# DeepEval metric engine (optional)
+
+ClawMetry can run a curated set of [DeepEval](https://github.com/confident-ai/deepeval) agent metrics on your finished sessions, fully locally, using your own judge API key. DeepEval is Apache-2.0 and ships the strongest open-source catalogue of agent metrics; ClawMetry embeds it as an optional engine without giving up its privacy posture: your transcripts never leave your machine except to the judge provider you configured.
+
+## Install
+
+```bash
+pip install "clawmetry[deepeval]"
+```
+
+The extra exists because DeepEval pulls roughly 70 packages. The base ClawMetry install stays small and never imports it. Python 3.10+ is required for the extra.
+
+## Turn it on
+
+The engine costs judge calls, so it is off until you name the metrics you want:
+
+```bash
+export CLAWMETRY_DEEPEVAL_METRICS="argument-correctness,conversation-completeness"
+```
+
+Then restart the sync daemon. Sessions are scored a few minutes after they finish, on the same scheduler as the answer-quality judge. Results land in the local DuckDB `eval_metrics` table and are served by `GET /api/evals/metrics`.
+
+The judge key and provider are the same ones the answer-quality judge uses: set them in the dashboard (Evals tab) or via `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / `GEMINI_API_KEY` / `OPENROUTER_API_KEY`, or point the `custom` provider at a local OpenAI-compatible server such as Ollama for a completely key-free, offline setup.
+
+## Metrics
+
+| Slug | Question it answers | Needs |
+|------|--------------------|-------|
+| `argument-correctness` | Did each tool call use sensible inputs for the task? | judge key |
+| `conversation-completeness` | Was what the user asked for actually delivered by the end? | judge key |
+
+DeepEval's Task Completion metric is not offered: it requires DeepEval's own tracing decorators inside the agent process, which does not fit ClawMetry's read-only, post-hoc model. Tool Correctness (comparing against expected tools) belongs to golden suites, where the suite YAML supplies the expectation.
+
+## Privacy contract
+
+- DeepEval telemetry is force-disabled in code before the library is ever imported (`DEEPEVAL_TELEMETRY_OPT_OUT=1`, error reporting off). This is not configurable through ClawMetry.
+- No Confident AI account is used or required; nothing is uploaded.
+- All judge traffic goes through ClawMetry's own provider-direct HTTP judge: your configured provider, your key, with secrets and emails redacted from transcripts before they leave the box.
+- Verified in development with a socket audit: a full metric run against a local Ollama judge makes zero external network connections.
+
+## Knobs
+
+| Env var | Default | Meaning |
+|---------|---------|---------|
+| `CLAWMETRY_DEEPEVAL_METRICS` | empty (off) | Comma-separated metric slugs to run |
+| `CLAWMETRY_DEEPEVAL_BATCH` | 5 | Sessions per scheduler tick |
+| `CLAWMETRY_DEEPEVAL_RATE_LIMIT` | 50 | Judge-call budget per hour for this engine |
+| `CLAWMETRY_DEEPEVAL_JUDGE_MAX_TOKENS` | 1500 | Judge reply budget (JSON verdicts) |
+| `CLAWMETRY_DEEPEVAL_MAX_TURNS` | 40 | Conversation tail length fed to multi-turn metrics |
+
+`CLAWMETRY_EVALS_ENABLED=0` turns this engine off along with the rest of the eval system.

--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,12 @@ setup(
         # Kept for back-compat with `pip install clawmetry[relay]` calls
         # in old install scripts. No-op in 0.12.166+.
         "relay": [],
+        # Optional DeepEval metric engine (clawmetry/deepeval_bridge.py).
+        # Heavy on purpose-built installs only: deepeval pulls ~70 transitive
+        # packages, so it must never move into install_requires. <5 pins out
+        # the fast-moving major; 3.10+ marker because deepeval needs >=3.9
+        # and its posthog pin needs >=3.10.
+        "deepeval": ['deepeval>=4.1,<5; python_version >= "3.10"'],
     },
     entry_points={
         "console_scripts": [

--- a/tests/test_deepeval_bridge.py
+++ b/tests/test_deepeval_bridge.py
@@ -1,0 +1,420 @@
+"""DeepEval bridge tests (clawmetry/deepeval_bridge.py).
+
+CI does not install the ``deepeval`` extra, so these tests run against a FAKE
+in-memory deepeval package installed via a meta-path loader. That is exactly
+the point: the bridge must import, degrade, and stay honest with or without
+the real package, and the telemetry opt-out contract must be provable without
+letting real deepeval code anywhere near the test env.
+
+The judge JSON-schema contract and the zero-egress claim were additionally
+proven against REAL deepeval 4.1.5 + a local Ollama judge in the Phase 0
+spike (socket-spy: zero external connects); the fakes here pin the wiring.
+"""
+from __future__ import annotations
+
+import importlib
+import importlib.abc
+import importlib.util
+import json
+import os
+import sys
+import types
+
+import pytest
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+_FAKE_MODULES = (
+    "deepeval",
+    "deepeval.metrics",
+    "deepeval.models",
+    "deepeval.models.base_model",
+    "deepeval.test_case",
+)
+
+# Captured by the fake loader at "import deepeval" time.
+_IMPORT_TIME_ENV: dict[str, str | None] = {}
+
+
+class _Recorder:
+    """Shared mutable state the fake metrics write into."""
+
+    def __init__(self):
+        self.measured_cases: list = []
+        self.metric_should_raise = False
+
+
+def _build_fake_deepeval(recorder: _Recorder) -> dict[str, types.ModuleType]:
+    deepeval = types.ModuleType("deepeval")
+    deepeval.__version__ = "4.1.5-fake"
+    deepeval.__path__ = []  # mark as package
+
+    base_model = types.ModuleType("deepeval.models.base_model")
+
+    class DeepEvalBaseLLM:
+        pass
+
+    base_model.DeepEvalBaseLLM = DeepEvalBaseLLM
+    models_pkg = types.ModuleType("deepeval.models")
+    models_pkg.__path__ = []
+
+    test_case = types.ModuleType("deepeval.test_case")
+
+    class _Simple:
+        def __init__(self, **kw):
+            self.__dict__.update(kw)
+
+    class LLMTestCase(_Simple):
+        pass
+
+    class ToolCall(_Simple):
+        pass
+
+    class ConversationalTestCase(_Simple):
+        pass
+
+    class Turn(_Simple):
+        pass
+
+    test_case.LLMTestCase = LLMTestCase
+    test_case.ToolCall = ToolCall
+    test_case.ConversationalTestCase = ConversationalTestCase
+    test_case.Turn = Turn
+
+    metrics = types.ModuleType("deepeval.metrics")
+
+    class _FakeSchema:
+        """Stands in for the pydantic response model DeepEval passes to
+        ``generate`` — enough surface to exercise the bridge's contract."""
+
+        @staticmethod
+        def model_json_schema():
+            return {"type": "object", "properties": {"verdict": {"type": "string"}}}
+
+        @staticmethod
+        def model_validate(data):
+            if not isinstance(data, dict) or "verdict" not in data:
+                raise ValueError("missing verdict")
+            return {"validated": data}
+
+    class _FakeMetric:
+        def __init__(self, model=None, async_mode=True, include_reason=True):
+            self.model = model
+            self.async_mode = async_mode
+            self.score = None
+            self.reason = None
+
+        def measure(self, case):
+            if recorder.metric_should_raise:
+                raise RuntimeError("judge exploded")
+            recorder.measured_cases.append((type(self).__name__, case))
+            # Exercise the judge's schema path exactly like a real metric.
+            out = self.model.generate("judge this", schema=_FakeSchema)
+            assert out == {"validated": {"verdict": "ok"}}
+            self.score = 0.8
+            self.reason = "fake reason"
+            return self.score
+
+        def is_successful(self):
+            return (self.score or 0) >= 0.5
+
+    class ArgumentCorrectnessMetric(_FakeMetric):
+        pass
+
+    class ConversationCompletenessMetric(_FakeMetric):
+        pass
+
+    metrics.ArgumentCorrectnessMetric = ArgumentCorrectnessMetric
+    metrics.ConversationCompletenessMetric = ConversationCompletenessMetric
+
+    return {
+        "deepeval": deepeval,
+        "deepeval.metrics": metrics,
+        "deepeval.models": models_pkg,
+        "deepeval.models.base_model": base_model,
+        "deepeval.test_case": test_case,
+    }
+
+
+class _FakeDeepevalFinder(importlib.abc.MetaPathFinder, importlib.abc.Loader):
+    """Serves the fake modules through the real import machinery so the
+    bridge's ``import deepeval...`` statements trigger exec_module, letting
+    us capture what the environment looked like AT import time."""
+
+    def __init__(self, modules):
+        self.modules = modules
+
+    def find_spec(self, fullname, path=None, target=None):
+        if fullname in self.modules:
+            return importlib.util.spec_from_loader(fullname, self)
+        return None
+
+    def create_module(self, spec):
+        return self.modules[spec.name]
+
+    def exec_module(self, module):
+        if module.__name__ == "deepeval":
+            _IMPORT_TIME_ENV["telemetry_opt_out"] = os.environ.get(
+                "DEEPEVAL_TELEMETRY_OPT_OUT")
+            _IMPORT_TIME_ENV["error_reporting"] = os.environ.get(
+                "ERROR_REPORTING")
+
+
+@pytest.fixture
+def bridge(monkeypatch):
+    """Fresh bridge module + fake deepeval on the import path."""
+    recorder = _Recorder()
+    fakes = _build_fake_deepeval(recorder)
+    finder = _FakeDeepevalFinder(fakes)
+    for name in _FAKE_MODULES:
+        monkeypatch.delitem(sys.modules, name, raising=False)
+    sys.meta_path.insert(0, finder)
+    monkeypatch.delenv("DEEPEVAL_TELEMETRY_OPT_OUT", raising=False)
+    monkeypatch.delenv("CLAWMETRY_DEEPEVAL_METRICS", raising=False)
+    _IMPORT_TIME_ENV.clear()
+
+    sys.modules.pop("clawmetry.deepeval_bridge", None)
+    import clawmetry.deepeval_bridge as deb
+    importlib.reload(deb)
+
+    yield deb, recorder
+
+    try:
+        sys.meta_path.remove(finder)
+    except ValueError:
+        pass
+    for name in _FAKE_MODULES:
+        sys.modules.pop(name, None)
+    sys.modules.pop("clawmetry.deepeval_bridge", None)
+
+
+class _FakeStore:
+    def __init__(self, rows):
+        self.rows = rows
+        self.persisted: list[dict] = []
+
+    def query_events(self, *, session_id=None, limit=500):
+        return self.rows
+
+    def persist_eval_metric(self, **kw):
+        self.persisted.append(kw)
+
+
+def _real_shape_rows(secret=""):
+    """Rows in the REAL stored shape (data dict, repr-string nesting)."""
+    return [
+        {"event_type": "message", "ts": "2026-08-03T12:00:01+00:00",
+         "data": {"role": "user", "content": "please check the deploy"}},
+        {"event_type": "tool_call", "ts": "2026-08-03T12:00:02+00:00",
+         "data": {"role": "assistant", "content": "",
+                  "tool_calls": "[{'id': 't1', 'input': {'command': 'kubectl get pods'}, 'name': 'Bash'}]",
+                  "tool_name": "Bash"}},
+        {"event_type": "message", "ts": "2026-08-03T12:00:03+00:00",
+         "data": {"role": "assistant",
+                  "content": "Deploy is healthy." + secret}},
+    ]
+
+
+def _ok_judge(model, prompt, *, timeout=30.0, max_tokens=200):
+    return '{"verdict": "ok"}'
+
+
+# ── Import hygiene + telemetry contract ─────────────────────────────────────
+
+
+def test_importing_bridge_never_imports_deepeval():
+    for name in _FAKE_MODULES:
+        sys.modules.pop(name, None)
+    sys.modules.pop("clawmetry.deepeval_bridge", None)
+    import clawmetry.deepeval_bridge  # noqa: F401
+    assert "deepeval" not in sys.modules, (
+        "clawmetry.deepeval_bridge must lazy-import deepeval; importing it "
+        "at module load would put ~70 packages on the CLI startup path"
+    )
+
+
+def test_importing_clawmetry_never_imports_deepeval_bridge_eagerly():
+    assert "deepeval" not in sys.modules
+
+
+def test_telemetry_optout_set_before_deepeval_import(bridge):
+    deb, recorder = bridge
+    assert _IMPORT_TIME_ENV == {}  # nothing imported yet
+    store = _FakeStore(_real_shape_rows())
+    deb.score_session_deepeval(
+        "s1", metrics=["argument-correctness"], store=store,
+        judge_call=_ok_judge,
+    )
+    assert _IMPORT_TIME_ENV.get("telemetry_opt_out") == "1", (
+        "DEEPEVAL_TELEMETRY_OPT_OUT must be set BEFORE the deepeval import "
+        "(the v3.7.7 exfiltration incident, confident-ai/deepeval#2497)"
+    )
+    assert _IMPORT_TIME_ENV.get("error_reporting") == "0"
+
+
+# ── Scoring end-to-end (fake engine, real-shape rows) ───────────────────────
+
+
+def test_score_session_persists_engine_rows(bridge):
+    deb, recorder = bridge
+    store = _FakeStore(_real_shape_rows())
+    results = deb.score_session_deepeval(
+        "s1", metrics=["argument-correctness", "conversation-completeness"],
+        store=store, judge_call=_ok_judge,
+    )
+    assert len(results) == 2
+    assert all(r["engine"] == "deepeval" for r in results)
+    assert all(r["score"] == 0.8 and r["passed"] is True for r in results)
+    assert len(store.persisted) == 2
+    assert {p["metric_slug"] for p in store.persisted} == {
+        "argument-correctness", "conversation-completeness"}
+    # The single-turn case carried the real tool call, revived from repr.
+    kinds = {k for k, _ in recorder.measured_cases}
+    assert kinds == {"ArgumentCorrectnessMetric", "ConversationCompletenessMetric"}
+    single = next(c for k, c in recorder.measured_cases
+                  if k == "ArgumentCorrectnessMetric")
+    assert [tc.name for tc in single.tools_called] == ["Bash"]
+    assert single.tools_called[0].input_parameters == {"command": "kubectl get pods"}
+
+
+def test_secrets_are_redacted_before_metrics_see_them(bridge):
+    deb, recorder = bridge
+    secret = " Deploy key is sk-ant-api03-abcdefghijklmnopqrstuvwxyz0123456789ABCDEF"
+    store = _FakeStore(_real_shape_rows(secret=secret))
+    deb.score_session_deepeval(
+        "s1", metrics=["argument-correctness", "conversation-completeness"],
+        store=store, judge_call=_ok_judge,
+    )
+    for _kind, case in recorder.measured_cases:
+        blob = json.dumps(case.__dict__, default=lambda o: o.__dict__)
+        assert "sk-ant-api03" not in blob, (
+            "transcript text must pass _redact_for_judge before any metric"
+        )
+
+
+def test_judge_error_persists_skip_row_no_retry_burn(bridge):
+    deb, recorder = bridge
+    recorder.metric_should_raise = True
+    store = _FakeStore(_real_shape_rows())
+    results = deb.score_session_deepeval(
+        "s1", metrics=["argument-correctness"], store=store,
+        judge_call=_ok_judge,
+    )
+    assert results[0]["skipped"] is True
+    assert results[0]["skip_reason"] == "judge_error"
+    # Persisted anyway: the session must leave the pending set, otherwise the
+    # scheduler would re-spend on the same broken session every tick.
+    assert len(store.persisted) == 1
+    assert store.persisted[0]["score"] is None
+
+
+def test_no_input_skip_is_not_persisted(bridge):
+    deb, _ = bridge
+    store = _FakeStore([
+        {"event_type": "message", "ts": "t",
+         "data": {"role": "user", "content": "hello"}},
+    ])  # no assistant reply -> neither case buildable
+    results = deb.score_session_deepeval(
+        "s1", metrics=["argument-correctness", "conversation-completeness"],
+        store=store, judge_call=_ok_judge,
+    )
+    assert all(r["skip_reason"] == "no_input" for r in results)
+    assert store.persisted == []
+
+
+def test_missing_package_is_quiet_empty(bridge, monkeypatch):
+    deb, _ = bridge
+    monkeypatch.setattr(deb, "is_available", lambda: False)
+    store = _FakeStore(_real_shape_rows())
+    assert deb.score_session_deepeval("s1", store=store, judge_call=_ok_judge) == []
+    assert store.persisted == []
+
+
+def test_no_judge_key_never_spends(bridge, monkeypatch):
+    deb, recorder = bridge
+    monkeypatch.setattr(deb, "_judge_ready", lambda: False)
+    store = _FakeStore(_real_shape_rows())
+    assert deb.score_session_deepeval("s1", store=store) == []
+    assert store.persisted == [] and recorder.measured_cases == []
+
+
+def test_scheduler_entry_is_opt_in(bridge, monkeypatch):
+    deb, _ = bridge
+    calls = []
+    monkeypatch.setattr(deb, "score_session_deepeval",
+                        lambda sid, **kw: calls.append(sid) or [{"x": 1}])
+    # No env -> off, even with everything else ready.
+    monkeypatch.setattr(deb, "is_available", lambda: True)
+    monkeypatch.setattr(deb, "_judge_ready", lambda: True)
+    assert deb.score_pending_deepeval(store=_FakeStore([])) == 0
+    assert calls == []
+    # Env set -> runs over the pending set.
+    monkeypatch.setenv("CLAWMETRY_DEEPEVAL_METRICS", "argument-correctness")
+
+    class _S(_FakeStore):
+        def query_sessions_missing_eval_metrics(self, **kw):
+            assert kw.get("engine") == "deepeval"
+            return [{"session_id": "a"}, {"session_id": "b"}]
+
+    assert deb.score_pending_deepeval(store=_S([])) == 2
+    assert calls == ["a", "b"]
+
+
+# ── Catalogue honesty ───────────────────────────────────────────────────────
+
+
+def test_catalogue_needs_extra_downgrade(monkeypatch):
+    from clawmetry import evaluators
+
+    class _Store:
+        def query_eval_summary(self, **kw):
+            return {"total": 1, "scored": 0}
+
+        def query_outcomes(self, **kw):
+            return []
+
+    import clawmetry.deepeval_bridge as deb
+    monkeypatch.setattr(deb, "is_available", lambda: False)
+    p = evaluators.catalogue_with_coverage(_Store(), judge_ready=True)
+    by = {e["slug"]: e for e in p["evaluators"]}
+    assert by["argument-correctness"]["status"] == "needs_extra"
+    assert by["conversation-completeness"]["status"] == "needs_extra"
+    # needs_extra outranks needs_key: installing the engine is step one.
+    p2 = evaluators.catalogue_with_coverage(_Store(), judge_ready=False)
+    by2 = {e["slug"]: e for e in p2["evaluators"]}
+    assert by2["argument-correctness"]["status"] == "needs_extra"
+
+    # Cloud (no store): static status preserved, never mislabels a node.
+    p3 = evaluators.catalogue_with_coverage(None, judge_ready=None)
+    by3 = {e["slug"]: e for e in p3["evaluators"]}
+    assert by3["argument-correctness"]["status"] == "live"
+
+    # Extra installed + key present -> live on-box too.
+    monkeypatch.setattr(deb, "is_available", lambda: True)
+    p4 = evaluators.catalogue_with_coverage(_Store(), judge_ready=True)
+    by4 = {e["slug"]: e for e in p4["evaluators"]}
+    assert by4["argument-correctness"]["status"] == "live"
+
+    # Installed but keyless -> needs_key (they are judge-backed).
+    p5 = evaluators.catalogue_with_coverage(_Store(), judge_ready=False)
+    by5 = {e["slug"]: e for e in p5["evaluators"]}
+    assert by5["argument-correctness"]["status"] == "needs_key"
+
+
+@pytest.mark.skipif(
+    importlib.util.find_spec("deepeval") is None,
+    reason="real deepeval not installed (clawmetry[deepeval] extra)",
+)
+def test_real_deepeval_judge_class_builds():
+    """Smoke against the real package when present: the wrapper subclasses
+    the real DeepEvalBaseLLM and the lazy namespace resolves."""
+    sys.modules.pop("clawmetry.deepeval_bridge", None)
+    import clawmetry.deepeval_bridge as deb
+    ns = deb._deepeval_ns()
+    judge = deb._judge_cls()("claude-haiku-4-5", judge_call=_ok_judge)
+    assert judge.get_model_name().startswith("clawmetry-judge:")
+    from deepeval.models.base_model import DeepEvalBaseLLM
+    assert isinstance(judge, DeepEvalBaseLLM)
+    assert ns["LLMTestCase"] is not None

--- a/tests/test_deterministic_stored_bridge.py
+++ b/tests/test_deterministic_stored_bridge.py
@@ -141,6 +141,36 @@ def test_bridge_never_raises_on_garbage():
     assert inp.tool_calls == []
 
 
+def test_turns_from_stored_rows_roles_and_order():
+    from clawmetry.deterministic_evaluators import turns_from_stored_rows
+    rows = [
+        _real_message_row("the answer", ts="2026-08-03T12:00:05+00:00"),
+        _real_tool_call_row(ts="2026-08-03T12:00:03+00:00"),   # no content -> dropped
+        {"event_type": "message", "ts": "2026-08-03T12:00:01+00:00",
+         "data": {"_runtime": "claude_code", "content": "the question",
+                  "role": "user"}},
+    ]
+    turns = turns_from_stored_rows(rows)
+    assert turns == [
+        {"role": "user", "content": "the question"},
+        {"role": "assistant", "content": "the answer"},
+    ]
+
+
+def test_turns_role_inferred_from_event_type_when_absent():
+    from clawmetry.deterministic_evaluators import turns_from_stored_rows
+    rows = [
+        {"event_type": "prompt.submitted", "ts": "1",
+         "data": {"content": "do the thing"}},
+        {"event_type": "model.completed", "ts": "2",
+         "data": {"content": "did the thing"}},
+        {"event_type": "gateway.metric", "ts": "3",
+         "data": {"content": "not a turn"}},
+    ]
+    turns = turns_from_stored_rows(rows)
+    assert [t["role"] for t in turns] == ["user", "assistant"]
+
+
 def test_adapter_event_shape_unchanged():
     """The original adapter-Event path (dicts with top-level type/content/
     tool_calls) still extracts — the bridge is additive."""

--- a/tests/test_evaluators_catalogue.py
+++ b/tests/test_evaluators_catalogue.py
@@ -41,6 +41,7 @@ def test_catalogue_shape_and_tiers():
         "agent-efficiency", "agent-tool-error-detector",
         "pii-detector", "secrets-detector", "prompt-injection-detector",
         "hallucination-risk", "faithfulness",
+        "argument-correctness", "conversation-completeness",
     ):
         assert slug in slugs, f"missing evaluator {slug}"
     for e in cat:


### PR DESCRIPTION
## Why

Phase 2 of the DeepEval integration plan (`.claude/DEEPEVAL_EVALS_PLAN.md`, research 2026-08-03). DeepEval (Apache-2.0, 17k stars) ships the best OSS agent-metric catalogue, but it can never be a base dependency: one `pip install deepeval` pulls ~70 transitive packages including mandatory posthog + sentry-sdk + grpcio, and release v3.7.7 shipped a TracerProvider hijack that exported host-app spans to the vendor's account (confident-ai/deepeval#2497). This PR embeds it the only acceptable way: opt-in extra, lazy import, telemetry force-disabled in code before import, and every judge call routed through OUR provider-direct judge so no transcript can bypass the user's configured provider.

**Stacked on #4487** (eval_metrics table + deterministic checks). Will be retargeted to main once that merges.

## What

- `setup.py`: `clawmetry[deepeval]` extra (`deepeval>=4.1,<5; python_version >= "3.10"`)
- `clawmetry/deepeval_bridge.py`: lazy namespace import; `_force_local_env()` sets `DEEPEVAL_TELEMETRY_OPT_OUT=1` + error-reporting off before any import; `ClawMetryJudgeLLM(DeepEvalBaseLLM)` wraps `eval_runner._call_judge` (user's key/provider incl. keyless custom/Ollama, redaction upstream, interceptor-visible cost) with a JSON-schema retry contract
- Curated metric set v1: `argument-correctness`, `conversation-completeness`. TaskCompletion deliberately excluded (needs DeepEval's `@observe` traces, incompatible with read-only post-hoc sessions); tool-correctness reserved for golden suites (Phase 3) where `expected_tools` exist
- Persistence: `eval_metrics` rows with `engine='deepeval'`. Judge-error skips ARE persisted (prevents retry-burn); no-input and rate-limit skips are not (retry is correct there)
- Scheduler: rides the eval tick, opt-in via `CLAWMETRY_DEEPEVAL_METRICS` (default off, judge calls cost money), batch 5, separate 50/hr cap
- Catalogue: two new free entries with honest per-box states: `needs_extra` (extra missing, wins over key state), `needs_key` (installed, keyless), static `live` preserved on cloud so a keyless container never mislabels a node. app.js renders both badges with an install hint
- `turns_from_stored_rows` extractor in deterministic_evaluators (generic, reusable)
- `eval_runner._call_judge`: back-compat `max_tokens` passthrough (default 200 unchanged)
- `docs/EVALS_DEEPEVAL.md`

## Verification

- 115 tests green **without** deepeval installed. A fake deepeval package served through a meta-path loader proves: importing the bridge never imports deepeval; the telemetry env is set at deepeval import time; secrets are redacted before any metric sees a test case (sk-ant token assertion); judge-error persists a skip row; scheduler entry is env-gated opt-in
- Real-package E2E in a py3.10 venv with deepeval==4.1.5 + a local Ollama judge through the production `_judge_request` (custom provider): both metrics scored, 2 rows persisted
- Phase 0 spike socket audit: full metric run with telemetry opted out makes zero external connections (all traffic 127.0.0.1)
- `node --check` clean on app.js; new files ruff-clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)