### PR TITLE
fix(evals): golden suites grade with the user's rubric, not the shipped default

### DIFF
--- a/clawmetry/eval_suite_runner.py
+++ b/clawmetry/eval_suite_runner.py
@@ -481,9 +481,19 @@ def _evaluate_one(
     if judge_call is None:
         from clawmetry.eval_runner import _call_judge as judge_call  # type: ignore
     try:
-        from clawmetry.eval_runner import DEFAULT_RUBRIC, parse_score
+        from clawmetry.eval_runner import DEFAULT_RUBRIC, load_rubric, parse_score
+        # The USER'S rubric, not the shipped default: an operator who tuned
+        # ~/.clawmetry/evals.yaml expects the golden suites to grade with the
+        # same prompt the production judge uses (load_rubric merges user
+        # fields over DEFAULT_RUBRIC and falls back to it entirely on any
+        # parse problem, so this can only widen behavior, never lose it).
+        try:
+            rubric_prompt = str(load_rubric("default").get("prompt")
+                                or DEFAULT_RUBRIC["prompt"])
+        except Exception:
+            rubric_prompt = str(DEFAULT_RUBRIC["prompt"])
         prompt = (
-            str(DEFAULT_RUBRIC["prompt"])
+            rubric_prompt
             + "\n\n---\nTRANSCRIPT:\nUSER: "
             + test.input.strip()
             + "\n\nASSISTANT: "

--- a/tests/test_eval_suite_runner.py
+++ b/tests/test_eval_suite_runner.py
@@ -369,6 +369,10 @@ def test_local_store_eval_suite_runs_round_trip(tmp_path, monkeypatch):
     # Reset the singleton if the module is already loaded from a prior test.
     if hasattr(local_store, "_STORE"):
         local_store._STORE = None  # type: ignore[attr-defined]
+    # On a dev box with a live daemon, get_store() would return the HTTP
+    # proxy (whose daemon lacks a tmp-path store). The test owns its DB.
+    if hasattr(local_store, "mark_writer_owner"):
+        local_store.mark_writer_owner()
     try:
         store = local_store.get_store()
     except Exception as e:
@@ -388,3 +392,44 @@ def test_local_store_eval_suite_runs_round_trip(tmp_path, monkeypatch):
     assert rows[0]["status"] == "pass"
     assert rows[0]["score"] == 4.0
     assert rows[0]["sha"] == "abc123"
+
+
+# ── Regression: suites grade with the USER'S rubric, not the shipped default ──
+
+
+def test_suite_judge_uses_user_rubric_prompt(tmp_path, monkeypatch):
+    """_evaluate_one built its judge prompt from DEFAULT_RUBRIC directly,
+    silently ignoring ~/.clawmetry/evals.yaml. An operator who tuned the
+    rubric expects the golden suites to grade with the same prompt the
+    production judge uses."""
+    from clawmetry import eval_runner
+
+    rubric_file = tmp_path / "evals.yaml"
+    rubric_file.write_text(
+        "default:\n"
+        "  judge_model: claude-haiku-4-5\n"
+        "  prompt: |\n"
+        "    CUSTOM-RUBRIC-MARKER judge kindly.\n"
+        "    Output exactly two lines:\n"
+        "    SCORE: <0-5>\n"
+        "    REASON: <one short sentence>\n"
+    )
+    monkeypatch.setattr(eval_runner, "RUBRIC_PATH", rubric_file)
+
+    seen_prompts = []
+
+    def _judge(model, prompt, *, timeout=30.0):
+        seen_prompts.append(prompt)
+        return "SCORE: 5\nREASON: fine"
+
+    suite = Suite(
+        name="rubric", judge_model="claude-haiku-4-5",
+        tests=[TestCase(name="t1", input="hi", expected_tools=[],
+                        expected_outcome="any", expected_min_score=1)],
+    )
+    run = run_suite(suite, agent_call=_agent_ok(), judge_call=_judge,
+                    persist=False)
+    assert run.passed == 1
+    assert seen_prompts and "CUSTOM-RUBRIC-MARKER" in seen_prompts[0], (
+        "suite judge must grade with the user's rubric prompt"
+    )


### PR DESCRIPTION
## Why

Found during the DeepEval integration audit (`.claude/DEEPEVAL_EVALS_PLAN.md`, Phase 3): `eval_suite_runner._evaluate_one` built its judge prompt from `DEFAULT_RUBRIC` directly, silently ignoring `~/.clawmetry/evals.yaml`. An operator who tuned the rubric through the dashboard's rubric editor got default-graded golden suites with no way to tell.

## What

- The suite judge now loads the same merged rubric the production judge uses (`load_rubric("default")`), with a defensive fallback to `DEFAULT_RUBRIC` on any load error. `load_rubric` merges user fields over defaults and falls back entirely on parse problems, so this can only widen behavior, never lose it.
- Drive-by: `test_local_store_eval_suite_runs_round_trip` now claims writer ownership (`mark_writer_owner`), so it stops failing on dev boxes where a live daemon makes `get_store()` return the HTTP proxy.

Note on scope: the plan's Phase 3 originally sketched a suite-to-DeepEval-Golden converter; dropped deliberately. The suite runner already matches `expected_tools` natively, so a DeepEval ToolCorrectness pass over suites would duplicate existing behavior for added dependency surface.

## Verification

- New regression test proves the custom rubric prompt reaches the judge; red with the fix reverted, green restored
- 16/16 suite runner tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)