### PR TITLE
[RELEASE] feat(evals): deterministic checks live + optional DeepEval engine + suite rubric fix (0.12.643)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,32 @@
+## 0.12.643
+
+- **Free deterministic checks now actually run.** The zero-LLM-cost structural
+  evaluators (tool errors, JSON validity, required tool args, length bounds)
+  were pruned in #4436 as an unintegrated orphan; the real gap was that they
+  never understood stored event rows. They are back, bridged to the real
+  DuckDB shapes, and the sync daemon scores every completed session with them
+  on the eval cadence at zero cost, no key needed
+  (CLAWMETRY_DETERMINISTIC_CHECKS, default no-tool-errors). Verdicts land in
+  the new per-metric eval_metrics table and are served by
+  GET /api/evals/metrics. Also fixes a double-count that reported every tool
+  call twice to the extractors.
+- **Optional DeepEval metric engine.** `pip install "clawmetry[deepeval]"`
+  (Python 3.10+) adds two judge-backed agent metrics from the Apache-2.0
+  DeepEval library: "Did the agent use its tools right?" (argument
+  correctness) and "Did the conversation get finished?" (conversation
+  completeness). Runs fully locally: DeepEval telemetry is force-disabled in
+  code before the library ever imports, no vendor account is used, and every
+  judge call goes through ClawMetry's own provider-direct judge (your key,
+  your provider, transcripts redacted first; keyless local servers like
+  Ollama work too). Off by default; enable by naming metrics in
+  CLAWMETRY_DEEPEVAL_METRICS. The evaluator library shows honest per-box
+  states: "Needs install" without the extra, "Needs key" without a judge key.
+  See docs/EVALS_DEEPEVAL.md.
+- **Golden suites grade with YOUR rubric.** `clawmetry eval --suite` judged
+  with the shipped default rubric even when ~/.clawmetry/evals.yaml had a
+  tuned one; the suite judge now uses the same merged rubric as the
+  production judge.
+
 ## 0.12.641
 
 - Re-publish of 0.12.640 (same ghost-wheel race as 0.12.636: the release


### PR DESCRIPTION
Release PR carrying #4487 (deterministic evaluators resurrected + eval_metrics table), #4492 (optional DeepEval metric engine, `clawmetry[deepeval]`), and #4493 (suite runner grades with the user's rubric) to PyPI.

All three feature PRs merged green individually. CHANGELOG entry added for 0.12.643 (workflow bumps from max(PyPI 0.12.642, dashboard 0.12.641) + 1).

Verification already done on the feature PRs: 115+ tests across the eval surface, fake-package telemetry/lazy-import proofs, real deepeval 4.1.5 + Ollama E2E with zero external egress, revert-proofed guards. Post-publish: node upgrade + daemon restart + live eval_metrics verification will follow per FLYWHEEL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)