### PR TITLE
fix(hooks): validate binary path before returning already_present or skipping gate

### DIFF
--- a/clawmetry/claude_code_gate.py
+++ b/clawmetry/claude_code_gate.py
@@ -196,11 +196,26 @@ def _entry_is_ours(entry: dict) -> bool:
     return False
 
 
+def _cmd_binary_exists(cmd: str) -> bool:
+    """Return True if the hook command's binary is runnable.
+
+    Only validates absolute paths — bare command names depend on PATH at
+    execution time and cannot be reliably pre-checked here.
+    """
+    if not cmd:
+        return False
+    first = cmd.split()[0]
+    if os.path.isabs(first):
+        return os.access(first, os.X_OK)
+    return True
+
+
 def _entry_is_foreign_clawmetry(entry: dict) -> bool:
     for h in (entry or {}).get("hooks") or []:
         cmd = h.get("command") or ""
         if any(m in cmd for m in _FOREIGN_CLAWMETRY_MARKERS):
-            return True
+            if _cmd_binary_exists(cmd):
+                return True
     return False
 
 

--- a/clawmetry/hooks_claude_code.py
+++ b/clawmetry/hooks_claude_code.py
@@ -403,12 +403,49 @@ def _write_settings(path: str, settings: dict) -> None:
     os.replace(tmp, path)
 
 
+def _cmd_binary_exists(cmd: str) -> bool:
+    """Return True if the hook command's binary is runnable.
+
+    Only validates absolute paths — bare command names depend on PATH at
+    execution time and cannot be reliably pre-checked here.
+    """
+    if not cmd:
+        return False
+    first = cmd.split()[0]
+    if os.path.isabs(first):
+        return os.access(first, os.X_OK)
+    return True
+
+
+def _drop_stale_our_hooks(entries: list) -> bool:
+    """Remove entries that carry our marker but whose binary is no longer
+    executable.  Returns True if anything was pruned."""
+    removed = False
+    for entry in list(entries):
+        hooks = entry.get("hooks") or []
+        stale = [
+            h for h in hooks
+            if any(m in (h.get("command") or "") for m in _HOOK_CMD_MARKERS)
+            and not _cmd_binary_exists(h.get("command") or "")
+        ]
+        if not stale:
+            continue
+        surviving = [h for h in hooks if h not in stale]
+        if surviving:
+            entry["hooks"] = surviving
+        else:
+            entries.remove(entry)
+        removed = True
+    return removed
+
+
 def _has_our_hook(entries: list) -> bool:
     for entry in entries or []:
         for h in (entry.get("hooks") or []):
             cmd = h.get("command") or ""
             if any(m in cmd for m in _HOOK_CMD_MARKERS):
-                return True
+                if _cmd_binary_exists(cmd):
+                    return True
     return False
 
 
@@ -446,8 +483,11 @@ def install(settings_path: "str | None" = None, matcher: str = "*") -> dict:
         settings = _read_settings(path)
         hooks = settings.setdefault("hooks", {})
         added = []
+        modified = False
 
         pretool = hooks.setdefault("PreToolUse", [])
+        if _drop_stale_our_hooks(pretool):
+            modified = True
         if not _has_our_hook(pretool):
             pretool.append({
                 "matcher": matcher,
@@ -456,8 +496,11 @@ def install(settings_path: "str | None" = None, matcher: str = "*") -> dict:
                            "timeout": _PRETOOL_TIMEOUT_S}],
             })
             added.append("PreToolUse")
+            modified = True
 
         notification = hooks.setdefault("Notification", [])
+        if _drop_stale_our_hooks(notification):
+            modified = True
         if not _has_our_hook(notification):
             notification.append({
                 "hooks": [{"type": "command",
@@ -465,10 +508,13 @@ def install(settings_path: "str | None" = None, matcher: str = "*") -> dict:
                            "timeout": _NOTIFICATION_TIMEOUT_S}],
             })
             added.append("Notification")
+            modified = True
 
         # Stop = bookkeeping only (clears the "needs you at the desk" row
         # for the session; no push) — see main_stop.
         stop = hooks.setdefault("Stop", [])
+        if _drop_stale_our_hooks(stop):
+            modified = True
         if not _has_our_hook(stop):
             stop.append({
                 "hooks": [{"type": "command",
@@ -476,8 +522,9 @@ def install(settings_path: "str | None" = None, matcher: str = "*") -> dict:
                            "timeout": _NOTIFICATION_TIMEOUT_S}],
             })
             added.append("Stop")
+            modified = True
 
-        if added:
+        if modified:
             _write_settings(path, settings)
         _write_marker(["PreToolUse", "Notification", "Stop"])
         return {"status": "installed" if added else "already_present",


### PR DESCRIPTION
Closes #4490

## What

- `_has_our_hook()` in `hooks_claude_code.py` returned `True` purely on command-string presence, so `hooks install` returned `already_present` even when the hooked binary was gone (absolute path, removed venv, etc.).
- `_entry_is_foreign_clawmetry()` in `claude_code_gate.py` had the same flaw — a stale manual-hook entry triggered `skipped: manual-hook-present` permanently, blocking the auto-gate even though the hook silently no-oped on every call.

## Changes

**`clawmetry/hooks_claude_code.py`**
- Add `_cmd_binary_exists(cmd)`: validates absolute-path binaries via `os.access(path, os.X_OK)`; bare command names return `True` (PATH-dependent at execution time, can't be reliably pre-checked).
- Add `_drop_stale_our_hooks(entries)`: prunes hook entries carrying our marker whose absolute-path binary is missing; returns `True` if anything was removed.
- Update `_has_our_hook()` to require a live binary (via `_cmd_binary_exists`).
- Update `install()` to call `_drop_stale_our_hooks` on each event list before checking, so a re-run repairs broken entries rather than skipping them.

**`clawmetry/claude_code_gate.py`**
- Same `_cmd_binary_exists` helper.
- Update `_entry_is_foreign_clawmetry()` to validate the binary before treating a manual-hook entry as blocking.

## Test plan

- All 25 existing unit tests in `tests/test_hooks_claude_code.py` pass, including the idempotency test.
- `_drop_stale_our_hooks` prunes entries where the binary is an absolute path that doesn't exist; entries with bare names are left alone.

---
_Generated by [Claude Code](https://claude.ai/code/session_0143uGv831JXcAWAtuZJ81kL)_