### PR TITLE
[RELEASE] fix(sync): rotate family-adapter walk — starvation-proof ingest (0.12.643)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 ## 0.12.643
 
+- **Family ingest is starvation-proof.** The per-cycle adapter walk now
+  rotates its start position (cursor persisted in daemon state), so a daemon
+  that keeps dying mid-pass — e.g. a native crash loop under launchd
+  KeepAlive — still reaches every runtime within a few passes. Previously a
+  bounced daemon restarted the walk in the same fixed order every run:
+  runtimes early in the list kept ingesting while the tail (Copilot,
+  Antigravity) silently never landed, leaving their sessions missing and
+  per-runtime rollups/scoped alerts reading $0.
+
+## 0.12.643
+
 - **Free deterministic checks now actually run.** The zero-LLM-cost structural
   evaluators (tool errors, JSON validity, required tool args, length bounds)
   were pruned in #4436 as an unintegrated orphan; the real gap was that they

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -12215,7 +12215,26 @@ def sync_family_runtimes(config: dict, state: dict, paths: dict) -> int:
     openclaw_spawned_claude = _openclaw_spawned_claude_ids()
 
     _ingest_rev = _family_ingest_rev()
-    for cls in _family_adapter_classes():
+    # Starvation-proof ordering: rotate the adapter start position every pass.
+    # A daemon that dies mid-pass (live-hit 2026-08-03: duckdb SIGTRAP crash
+    # loop, launchd KeepAlive respawn every ~8 min) used to restart the walk
+    # from the SAME fixed order each run — adapters early in the list
+    # (claude_code, with hundreds of sessions) always ingested while adapters
+    # at the tail (copilot, antigravity) were NEVER reached: their sessions
+    # silently missing, per-runtime rollups/alerts reading $0. Rotating the
+    # start index each pass guarantees every adapter is first-in-line within
+    # N passes, so even a chronically bounced daemon converges on full
+    # coverage. The rotation cursor lives in daemon state (survives restarts
+    # via sync-state.json).
+    _classes = list(_family_adapter_classes())
+    if _classes:
+        try:
+            _rot = int(state.get("family_adapter_rotation") or 0) % len(_classes)
+        except (TypeError, ValueError):
+            _rot = 0
+        state["family_adapter_rotation"] = _rot + 1
+        _classes = _classes[_rot:] + _classes[:_rot]
+    for cls in _classes:
         try:
             adapter = cls()  # construct once (discovery globs/DB opens are not free)
             if not adapter.detect().detected:

--- a/dashboard.py
+++ b/dashboard.py
@@ -268,7 +268,7 @@ def _otlp_service_name_to_agent_type(service_name):
     return slug or "custom"
 
 
-__version__ = "0.12.641"
+__version__ = "0.12.643"
 
 # Extensions (Phase 2): import the plugin host now, but defer the actual
 # load_plugins() call until after the Flask app is created below so we can

--- a/tests/test_family_ingest_rotation.py
+++ b/tests/test_family_ingest_rotation.py
@@ -1,0 +1,75 @@
+"""Family-ingest starvation fix: the adapter walk rotates its start position
+each pass (live-hit 2026-08-03: a crash-looping daemon that died mid-pass
+always restarted the walk in the same fixed order, so tail adapters —
+copilot, antigravity — were never reached and their sessions silently
+missed ingest while early adapters kept flowing).
+
+Pure-unit: patches _family_adapter_classes with sentinel classes whose
+constructors RECORD the visit order, then asserts consecutive passes start
+at successive offsets and the cursor survives in the daemon state dict
+(persisted via sync-state.json in production)."""
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import patch
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+from clawmetry import sync  # noqa: E402
+
+
+def _sentinels(n):
+    visits = []
+
+    def make(i):
+        class _A:
+            name = f"rt{i}"
+
+            def __init__(self):
+                visits.append(self.name)
+                raise RuntimeError("stop after recording visit order")
+        _A.__name__ = f"A{i}"
+        return _A
+
+    return [make(i) for i in range(n)], visits
+
+
+def _run_pass(classes, state):
+    with patch.object(sync, "_family_adapter_classes", return_value=classes), \
+         patch.object(sync, "_sync_allowed", return_value=True), \
+         patch.object(sync, "_openclaw_spawned_claude_ids", return_value=set(),
+                      create=True):
+        try:
+            sync.sync_family_runtimes({"node_id": "n", "api_key": "k"}, state, {})
+        except Exception:
+            pass
+
+
+def test_rotation_advances_each_pass():
+    classes, visits = _sentinels(4)
+    state = {}
+    _run_pass(classes, state)
+    first_pass = list(visits)
+    assert first_pass[0] == "rt0" and len(first_pass) == 4
+    visits.clear()
+    _run_pass(classes, state)
+    assert visits[0] == "rt1", visits  # rotated by one
+    assert set(visits) == {"rt0", "rt1", "rt2", "rt3"}  # still full coverage
+    visits.clear()
+    _run_pass(classes, state)
+    assert visits[0] == "rt2", visits
+    assert state["family_adapter_rotation"] == 3
+
+
+def test_rotation_cursor_survives_restart_shape():
+    """A daemon restart reloads state from sync-state.json — a plain int in
+    the dict. Corrupt values degrade to offset 0, never crash."""
+    classes, visits = _sentinels(3)
+    _run_pass(classes, {"family_adapter_rotation": "garbage"})
+    assert visits[0] == "rt0"
+    visits.clear()
+    _run_pass(classes, {"family_adapter_rotation": 7})  # 7 % 3 == 1
+    assert visits[0] == "rt1"


### PR DESCRIPTION
Found live while end-to-end-testing runtime-scoped alerts on the founder node: a duckdb SIGTRAP crash loop (separate issue — mitigated by upgrading duckdb 1.4.4→1.4.5 on the node) meant the daemon died mid-family-pass every ~8 minutes. Because the walk always started in the same fixed order, early adapters kept ingesting while **tail adapters (copilot, antigravity) were never reached** — sessions silently missing, per-runtime rollups empty, scoped alert rules reading $0.

- Rotate the adapter start position each pass; cursor persists in daemon state (sync-state.json), modulo the list length, corrupt values degrade to 0.
- Guarantees full coverage within N passes regardless of daemon lifespan.
- 2 unit tests; family-ingest suites green with pro on path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)