### PR TITLE
[RELEASE] feat(evals): verdict chips on the Evals tab (0.12.646)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 0.12.646
+
+- **The free checks show their work.** The Evals tab's recently-scored table
+  gains a Checks column: one chip per structural verdict (green pass, red
+  fail, the reason on hover). Sessions scored only by the free checks are
+  listed too, so evals visibly work out of the box before any judge key is
+  added. Fail chips say what happened ("tool errors"), never a double
+  negative. Hosted dashboards are unchanged (the verdicts live on the node).
+
 ## 0.12.644
 
 - **Where the money goes: a spend flow for the whole node.** The Cost tab now


### PR DESCRIPTION
Release PR carrying #4505 (Evals tab Checks column: per-session verdict chips from eval_metrics; free checks visible without a judge key; CLOUD_MODE unchanged).

Verified on the feature PR: Playwright walk against live node data with screenshots eyeballed; full CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)