### PR TITLE
[RELEASE] feat(evals): check verdict chips on the transcript view (0.12.647)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.12.647
+
+- **Check verdicts on the conversation view.** Opening a transcript now shows
+  the session's structural check chips (green pass, red fail, reason on
+  hover) in the metadata panel, the same verdicts the Evals tab lists, so
+  you can judge a conversation's health right where you read it.
+
 ## 0.12.646
 
 - **The free checks show their work.** The Evals tab's recently-scored table


### PR DESCRIPTION
Release PR carrying #4509 (Checks row with verdict chips on the transcript metadata panel; canonical-id suffix matching; CLOUD_MODE unchanged). Feature PR merged green; verified via Playwright against live node data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)