### PR TITLE
[RELEASE] Savings ideas read the spend flow: thinking_trim (carries #4513)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 0.12.648
+
+- **The savings ideas now read the spend flow.** The efficiency card on the
+  Cost tab gains a new idea, "Trim thinking on routine work", derived from
+  the measured "Where the money goes" flow: it appears only when thinking
+  makes up at least 40% of what your agents spend on output, shows the
+  measured share, and is always labeled as an estimate. Ideas are scoped
+  per runtime, so a runtime switcher selection only ever shows ideas
+  computed from that runtime's own numbers.
+
 ## 0.12.647
 
 - **Check verdicts on the conversation view.** Opening a transcript now shows


### PR DESCRIPTION
Publishes #4513 to PyPI (expected 0.12.648).

The thinking_trim idea is derived from the measured spend flow, gated (>=40% share, >=$1 window), estimate-flagged, per-runtime honest. Verified pre-merge on this node's real DuckDB (fires at 64.1% share, save about $37/mo). CI on #4513 was 30/30 green.

No cloud-repo change needed: the efficiency card renders actions generically and the copy ships in the wheel; the auto-pin bot will pick up the new version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)