### PR TITLE
feat(entitlement): missing_features_at + missing_runtimes_at + endpoints

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -6460,6 +6460,173 @@ def missing_runtimes(runtimes) -> list:
         return []
 
 
+def missing_features_at(perspective_tier: str, features) -> list:
+    """Hypothetical-perspective sibling of :func:`missing_features`: which
+    subset of ``features`` would tier ``perspective_tier`` NOT grant?
+
+    Fills the perspective-shaped ``_at`` slot in the row-detail complement
+    family so a pricing matrix that gates on a BUNDLE ("Starter grants
+    fleet + sso? which of these would still be locked at Starter?") can
+    bind the per-item denial list off ONE call per (perspective, bundle)
+    cell -- symmetric to :func:`has_features_at`'s boolean fold, in the
+    same relationship :func:`missing_features` has to :func:`has_features`.
+
+    Fold rule: returns the subset of ``features`` for which
+    :func:`has_feature_at` returns ``False`` under ``perspective_tier``,
+    canonicalised via ``.strip().lower()``, first-seen dedup on the
+    canonical key. Consequences of that fold, all deliberate:
+
+    * Empty / ``None`` / non-iterable ``features`` -- returns ``[]``.
+      Nothing to check, nothing missing. Mirrors :func:`missing_features`
+      on the same input byte-for-byte.
+    * Unknown / empty / non-string ``perspective_tier`` -- returns ``[]``.
+      Perspective validation lives on the OUTER helper (once per call)
+      rather than folding into per-item :func:`has_feature_at` calls, so
+      a bogus perspective fails-open on the diagnostic (no info to
+      surface) instead of marking every id missing off a validity gate
+      the caller can already read from ``perspective_tier_rank == -1``
+      on the paired endpoint. Same posture as :func:`has_features_at`'s
+      perspective validation, applied to the complement seat.
+    * Unknown / non-string / empty-string ``features`` item -- **included**
+      in the returned list in canonicalised form. The singular
+      :func:`has_feature_at` fails-closed on typos, so the complement fold
+      reflects that: a typo like
+      ``missing_features_at("pro", ["fleet", "Fleeet"])`` returns
+      ``["fleeet"]`` (only the typo) even though ``fleet`` is granted at
+      Pro, surfacing the typo at the callsite instead of a silent grant.
+      Matches :func:`missing_features` typo posture.
+    * Grace-independence: the answer is derived from the static per-tier
+      grant map via :func:`has_feature_at`'s :func:`_hypothetical_entitlement`
+      backing, so the returned list is IDENTICAL under grace vs enforce
+      for the same (perspective, bundle) pair. Diverges deliberately
+      from :func:`missing_features` (which reports ``[]`` for every
+      fully-known bundle in grace via the live resolver's grace
+      pass-through) -- the whole point of the ``_at`` slot is to render
+      the would-be-locked state alongside the live grant.
+    * Order: first-seen; dedup on canonical key.
+
+    Complement invariant with :func:`has_features_at`:
+    ``missing_features_at(p, b) == []`` iff ``has_features_at(p, b) is
+    True`` for every non-empty ``b`` -- pins the row-detail seat as the
+    exact perspective-shaped negation of the boolean fold.
+
+    Never raises: any delegate failure logs a warning and returns ``[]``
+    (matches the diagnostic fail-open posture the sibling
+    :func:`missing_features` carries; the endpoint fallback carries the
+    same empty-missing shape so a UI wired off this scalar cannot
+    silently render a denial banner on a resolver hiccup).
+    """
+    try:
+        p = (perspective_tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return []
+    if not p or p not in _TIER_ORDER:
+        return []
+    try:
+        if features is None:
+            return []
+        items = list(features)
+    except TypeError:
+        return []
+    if not items:
+        return []
+    out: list = []
+    seen: set = set()
+    try:
+        for f in items:
+            if isinstance(f, str):
+                fid = f.strip().lower()
+            else:
+                fid = ""
+            if fid in seen:
+                continue
+            seen.add(fid)
+            if not has_feature_at(p, f):
+                out.append(fid)
+        return out
+    except Exception as exc:
+        logger.warning(
+            "entitlements: missing_features_at(%r, %r) failed: %s",
+            perspective_tier,
+            features,
+            exc,
+        )
+        return []
+
+
+def missing_runtimes_at(perspective_tier: str, runtimes) -> list:
+    """Runtime-axis twin of :func:`missing_features_at`: which subset of
+    ``runtimes`` would tier ``perspective_tier`` NOT grant?
+
+    Same relationship to :func:`has_runtimes_at` that
+    :func:`missing_features_at` has to :func:`has_features_at`.
+    Delegates to :func:`has_runtime_at` per item, so the strict alias
+    posture the singular helper carries (no :func:`canonical_runtime`
+    resolution at scalar layer; a raw ``"claude-code"`` collapses to
+    ``False`` because it is not in :data:`ALL_RUNTIMES` after
+    ``.strip().lower()``, so an alias input surfaces in ``missing`` in
+    its ``.strip().lower()`` form) is inherited. Alias tolerance belongs
+    to the paired ``/api/entitlement/missing-runtimes-at`` endpoint,
+    which canonicalises per-token upstream before delegating -- matches
+    the sibling :func:`missing_runtimes` / ``/missing-runtimes`` split
+    exactly.
+
+    Fold semantics mirror :func:`missing_features_at` byte-for-byte:
+    perspective validated once against :data:`_TIER_ORDER` (fail-open on
+    empty / unknown / non-string -> ``[]``); empty / ``None`` /
+    non-iterable bundle returns ``[]``; unknown / non-string / empty /
+    alias item ids are INCLUDED in the returned list in canonical form;
+    first-seen dedup on canonical key; grace-independent by construction
+    (backed by :func:`_hypothetical_entitlement` via the singular
+    delegate).
+
+    Complement invariant with :func:`has_runtimes_at`:
+    ``missing_runtimes_at(p, b) == []`` iff ``has_runtimes_at(p, b) is
+    True`` for every non-empty canonical ``b`` -- alias-scalar inputs are
+    not part of the invariant (both scalars fail-closed on aliases; the
+    endpoint's upstream canonicalise is what re-establishes the
+    invariant at URL level).
+
+    Never raises: delegate failure -> logged warning -> ``[]``.
+    """
+    try:
+        p = (perspective_tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return []
+    if not p or p not in _TIER_ORDER:
+        return []
+    try:
+        if runtimes is None:
+            return []
+        items = list(runtimes)
+    except TypeError:
+        return []
+    if not items:
+        return []
+    out: list = []
+    seen: set = set()
+    try:
+        for rt in items:
+            if isinstance(rt, str):
+                rid = rt.strip().lower()
+            else:
+                rid = ""
+            if rid in seen:
+                continue
+            seen.add(rid)
+            if not has_runtime_at(p, rt):
+                out.append(rid)
+        return out
+    except Exception as exc:
+        logger.warning(
+            "entitlements: missing_runtimes_at(%r, %r) failed: %s",
+            perspective_tier,
+            runtimes,
+            exc,
+        )
+        return []
+
+
 def has_all(
     *,
     features=None,

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -5362,6 +5362,254 @@ def api_entitlement_missing_runtimes():
         return jsonify(_missing_bundle_fallback("runtimes", _parse_csv_arg("runtimes")))
 
 
+def _missing_bundle_at_fallback(axis: str, tier: str, tokens: list) -> dict:
+    """OSS-free / never-5xx envelope for the perspective-shaped complement
+    endpoints ``/api/entitlement/missing-features-at`` and
+    ``/api/entitlement/missing-runtimes-at``.
+
+    What-if sibling of :func:`_missing_bundle_fallback`, in the same
+    relationship :func:`_has_bundle_at_fallback` has to
+    :func:`_has_bundle_fallback`. On any resolver / helper blowup the
+    endpoint still returns 200 with the same 17-key envelope as the happy
+    path, but with ``missing=[]`` (matches the ``[]`` module scalar
+    returns on error) and the ``any_missing`` / ``upgrade_required``
+    rollups ``False`` so a paywall matrix tile that lost the resolver
+    doesn't silently render a denial banner it can no longer justify.
+    ``tier`` and ``tokens`` echo the caller's input into ``tier`` /
+    ``unknown`` so the tooltip can still surface the caller-supplied set
+    for debugging.
+    """
+    return {
+        "tier": tier,
+        axis: [],
+        "unknown": list(tokens),
+        "missing": [],
+        "kind": axis,
+        "count": 0,
+        "missing_count": 0,
+        "any_missing": False,
+        "required_tier": None,
+        "required_tier_label": None,
+        "required_tier_rank": -1,
+        "perspective_tier_rank": -1,
+        "current_tier": "oss",
+        "current_tier_rank": 0,
+        "grace": True,
+        "enforced": False,
+        "upgrade_required": False,
+    }
+
+
+def _missing_bundle_at_body(axis: str) -> dict:
+    """Happy-path body builder for ``/api/entitlement/missing-features-at``
+    /``/api/entitlement/missing-runtimes-at``.
+
+    Perspective-shaped sibling of :func:`_missing_bundle_body`: where the
+    live variant folds :func:`missing_features` / :func:`missing_runtimes`
+    against the resolved entitlement, this folds
+    :func:`missing_features_at` / :func:`missing_runtimes_at` against a
+    caller-supplied ``tier=`` perspective so a pricing matrix that gates
+    on a bundle ("which of fleet + otel_export + sso would still be
+    locked at Starter? at Pro?") can bind the per-item denial list off
+    ONE URL per cell, instead of walking the ``/has-batch`` matrix and
+    filtering ``has=False`` client-side.
+
+    Envelope shape (17 keys, byte-stable across every input branch)::
+
+        {
+          "tier":                  "<perspective tier id>" | "",
+          "features"/"runtimes":   [<known ids>],       # known-only, dedup, first-seen
+          "unknown":               [<tokens>],           # dropped tokens, echoed raw
+          "missing":               [<subset denied at tier>],
+          "kind":                  "features"/"runtimes",
+          "count":                 <int>,               # len(known)
+          "missing_count":         <int>,               # len(missing)
+          "any_missing":           <bool>,              # missing != [] OR unknown != []
+          "required_tier":         "<tier id>" | null,  # min_tier_for_<axis>(known)
+          "required_tier_label":   "<label>"  | null,
+          "required_tier_rank":    <int>,               # -1 when null
+          "perspective_tier_rank": <int>,               # -1 when tier unknown/blank
+          "current_tier":          "<live tier id>",
+          "current_tier_rank":     <int>,
+          "grace":                 <bool>,              # LIVE resolver grace bit
+          "enforced":              <bool>,
+          "upgrade_required":      <bool>,              # required_rank > perspective_rank
+        }
+
+    Runtime-axis alias canonicalisation is applied per-token upstream of
+    the strict scalar (:func:`missing_runtimes_at` does not resolve
+    aliases -- see the scalar docstring), matching the sibling
+    :func:`_missing_bundle_body` posture on the ``/missing-runtimes``
+    endpoint exactly (upstream canonicalise dedups an alias-and-canonical
+    pair to ONE row before the scalar sees it).
+
+    ``upgrade_required`` compares ``required_tier`` against the
+    PERSPECTIVE rank (not the live current rank) so a pricing-matrix row
+    that binds this field reads "no upgrade needed at this tier" (False
+    when perspective >= required) vs "upgrade needed beyond this tier"
+    -- diverges deliberately from :func:`_missing_bundle_body`'s
+    live-current comparison, matching the ``_at`` slot's what-if
+    convention.
+
+    Never 4xxs (missing / blank / unknown tier or all-unknown CSV -> 200
+    with ``missing=[]``, matching the sibling ``/missing-features``
+    posture -- a paywall matrix tile binds ``missing`` directly without
+    a pre-validation round-trip). The ``perspective_tier_rank`` slot is
+    ``-1`` for an unknown perspective so a UI can distinguish "typo
+    perspective" from "valid perspective that grants everything". Never
+    5xxs.
+    """
+    from clawmetry import entitlements as _ent
+
+    raw_tier = request.args.get("tier")
+    tier = (raw_tier or "").strip().lower()
+    param = "features" if axis == "features" else "runtimes"
+    tokens = _parse_csv_arg(param)
+
+    known: list = []
+    unknown: list = []
+    if axis == "features":
+        for fid in tokens:
+            if fid in _ent.ALL_FEATURES:
+                if fid not in known:
+                    known.append(fid)
+            elif fid not in unknown:
+                unknown.append(fid)
+        # scalar delegate receives the raw CSV so unknown tokens surface
+        # in ``missing`` (matches the sibling ``/missing-features``
+        # scalar-vs-endpoint parity contract).
+        if tier and tier in _ent._TIER_ORDER:
+            missing = _ent.missing_features_at(tier, tokens)
+        else:
+            # unknown perspective: fail-open on the diagnostic (same as
+            # scalar); ``missing`` empty, ``unknown`` still populated.
+            missing = []
+        required = _ent.min_tier_for_features(known) if known else None
+    else:
+        # Canonicalise upstream of the scalar so an alias input
+        # (``claude-code``) collapses to the granted runtime
+        # (``claude_code``) here instead of surfacing in ``missing`` --
+        # matches the :func:`_missing_bundle_body` upstream-canonicalise
+        # pattern for the sibling ``/missing-runtimes`` endpoint, and
+        # dedups an alias-and-canonical pair to ONE entry before the
+        # scalar sees it.
+        canon_tokens: list = []
+        canon_seen: set = set()
+        for rid_raw in tokens:
+            rid = _ent.canonical_runtime(rid_raw) or rid_raw
+            if rid in canon_seen:
+                continue
+            canon_seen.add(rid)
+            canon_tokens.append(rid)
+            if rid in _ent.ALL_RUNTIMES:
+                if rid not in known:
+                    known.append(rid)
+            elif rid not in unknown:
+                unknown.append(rid_raw)
+        if tier and tier in _ent._TIER_ORDER:
+            missing = _ent.missing_runtimes_at(tier, canon_tokens)
+        else:
+            missing = []
+        required = _ent.min_tier_for_runtimes(known) if known else None
+
+    env = _resolver_envelope(_ent)
+    cur_rank = env["current_tier_rank"]
+    req_rank = _ent.tier_rank(required) if required else -1
+    required_label = _ent.tier_label(required) if required else None
+    persp_rank = (
+        _ent.tier_rank(tier) if tier and tier in _ent._TIER_ORDER else -1
+    )
+    upgrade_required = (
+        bool(required) and persp_rank >= 0 and req_rank > persp_rank
+    )
+    return {
+        "tier": tier,
+        axis: known,
+        "unknown": unknown,
+        "missing": list(missing),
+        "kind": axis,
+        "count": len(known),
+        "missing_count": len(missing),
+        "any_missing": bool(missing) or bool(unknown),
+        "required_tier": required,
+        "required_tier_label": required_label,
+        "required_tier_rank": req_rank,
+        "perspective_tier_rank": persp_rank,
+        "current_tier": env["current_tier"],
+        "current_tier_rank": cur_rank,
+        "grace": env["grace"],
+        "enforced": env["enforced"],
+        "upgrade_required": upgrade_required,
+    }
+
+
+@bp_entitlement.route("/api/entitlement/missing-features-at")
+def api_entitlement_missing_features_at():
+    """``GET /api/entitlement/missing-features-at?tier=<perspective>&features=a,b,c``
+    -- perspective-shaped row-detail complement of
+    ``/api/entitlement/has-features-at``.
+
+    Returns the SUBSET of ``features`` that ``perspective_tier`` would
+    NOT grant (the exact list of ids blocking the bundle at that tier)
+    plus the surrounding tier envelope. Where ``/has-features-at`` folds
+    the bundle to ONE boolean per (perspective, bundle) cell, this
+    preserves the per-item denial so a paywall matrix column ("at
+    Starter you'd still be missing fleet, sso -- upgrade to Enterprise
+    to unlock") can bind the missing list directly off ONE URL per cell
+    instead of walking the ``/has-batch`` matrix and filtering
+    ``has=False`` client-side.
+
+    Unlike the live ``/missing-features`` sibling this endpoint is
+    perspective-shaped: even in grace
+    ``/missing-features-at?tier=oss&features=fleet,sso`` returns
+    ``missing=["fleet", "sso"]`` (because OSS-free does not statically
+    grant them), whereas ``/missing-features?features=fleet,sso`` in
+    grace returns ``missing=[]``. That is the whole point of the ``_at``
+    slot -- render the would-be-locked state alongside the live grant.
+
+    Never 4xxs (missing / blank / unknown tier or all-unknown CSV -> 200
+    with ``missing=[]``, matching the sibling ``/missing-features``
+    posture). Never 5xxs: any helper blowup collapses to
+    :func:`_missing_bundle_at_fallback`.
+    """
+    try:
+        return jsonify(_missing_bundle_at_body("features"))
+    except Exception as exc:
+        logger.warning("api_entitlement_missing_features_at: error: %s", exc)
+        tier = (request.args.get("tier") or "").strip().lower()
+        return jsonify(
+            _missing_bundle_at_fallback(
+                "features", tier, _parse_csv_arg("features")
+            )
+        )
+
+
+@bp_entitlement.route("/api/entitlement/missing-runtimes-at")
+def api_entitlement_missing_runtimes_at():
+    """``GET /api/entitlement/missing-runtimes-at?tier=<perspective>&runtimes=x,y,z``
+    -- runtime-axis twin of ``/api/entitlement/missing-features-at``.
+
+    Same 17-key envelope with ``runtimes`` in the axis-specific slot.
+    Runtime-alias canonicalisation (``claude-code`` -> ``claude_code``)
+    is applied per-token upstream at the endpoint layer so
+    ``?runtimes=claude-code,openclaw`` collapses to the canonical
+    ``claude_code,openclaw`` before hitting the strict scalar -- matches
+    the sibling ``/missing-runtimes`` endpoint's own upstream-
+    canonicalise pattern. Alias-and-canonical pair dedups to ONE row in
+    both ``runtimes`` and ``missing``. Never 4xxs; never 5xxs.
+    """
+    try:
+        return jsonify(_missing_bundle_at_body("runtimes"))
+    except Exception as exc:
+        logger.warning("api_entitlement_missing_runtimes_at: error: %s", exc)
+        tier = (request.args.get("tier") or "").strip().lower()
+        return jsonify(
+            _missing_bundle_at_fallback(
+                "runtimes", tier, _parse_csv_arg("runtimes")
+            )
+        )
+
+
 def _has_all_fallback() -> dict:
     """Never-5xx envelope for ``/api/entitlement/has-all``.
 

--- a/tests/test_entitlement_missing_features_runtimes_at.py
+++ b/tests/test_entitlement_missing_features_runtimes_at.py
@@ -1,0 +1,797 @@
+"""Tests for the perspective-shaped ``missing_features_at`` /
+``missing_runtimes_at`` complement scalars and their paired
+``/api/entitlement/missing-features-at`` /
+``/api/entitlement/missing-runtimes-at`` endpoints.
+
+Perspective-shaped siblings of :func:`missing_features` /
+:func:`missing_runtimes` in the same relationship
+:func:`has_features_at` has to :func:`has_features`: fills the
+``_at`` slot in the row-detail complement family so a pricing matrix
+that gates on a BUNDLE ("which of fleet + sso would still be locked at
+Starter? at Pro?") can bind the per-item denial list off ONE URL per
+(perspective, bundle) cell.
+
+This file pins:
+
+1. Scalar semantics: empty / None / non-iterable / unknown / all axes
+   across free / paid / mixed bundles under every real ``_TIER_ORDER``
+   perspective.
+2. Perspective validation: empty / blank / unknown / non-string
+   ``perspective_tier`` -> ``[]`` (fail-open on the diagnostic; matches
+   the sibling :func:`missing_features` "no info to surface" posture on
+   resolver blowup).
+3. Complement invariant: ``missing_features_at(p, b) == []`` iff
+   ``has_features_at(p, b) is True`` for every non-empty ``b``. Same for
+   the runtimes twin.
+4. Grace-independence: the answer is identical under grace vs enforce
+   for the same (perspective, bundle) pair (backed by
+   :func:`_hypothetical_entitlement`, grace off).
+5. Order and dedup: first-seen preserved; canonical-key dedup collapses
+   ``["fleet", "fleet"]`` -> one row.
+6. Runtime scalar alias posture: no scalar-level canonicalisation --
+   ``missing_runtimes_at("pro", ["claude-code"])`` surfaces
+   ``"claude-code"`` in ``missing`` verbatim (matches
+   :func:`has_runtimes_at` alias posture); the paired endpoint
+   canonicalises upstream.
+7. Never-raises on resolver / delegate blowup: log-and-return ``[]``.
+8. Endpoint envelope shape (fixed 17-key set) across every input branch.
+9. Never-5xx via monkeypatched blowup on both endpoints.
+10. Scalar-vs-endpoint parity: URL ``missing`` byte-equals scalar output
+    on the same (perspective, bundle) input.
+11. Cross-consistency with the sibling ``/api/entitlement/has-features-at``
+    / ``/has-runtimes-at`` -- ``any_missing`` negates the ``allowed`` /
+    ``has_*_at`` bit on the same input.
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+# ── Fixtures ───────────────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    """Fresh entitlements module in OSS-free-grace mode. The ``_at``
+    scalars are grace-independent by construction so most assertions do
+    not depend on this fixture's rollout state; it exists to keep
+    parity with the sibling ``test_entitlement_missing_features_runtimes.py``
+    setup so cross-file assertions read the same install state."""
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def enforced(monkeypatch, tmp_path):
+    """Enforcement-on fixture: pins the grace-independence contract by
+    replaying every scalar assertion under grace=False and asserting the
+    same answer as the grace ``ent`` fixture on the same input."""
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    importlib.reload(e)
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# ── Envelope shape ────────────────────────────────────────────────────────────────────────
+
+_FEATURES_KEYS = {
+    "tier",
+    "features",
+    "unknown",
+    "missing",
+    "kind",
+    "count",
+    "missing_count",
+    "any_missing",
+    "required_tier",
+    "required_tier_label",
+    "required_tier_rank",
+    "perspective_tier_rank",
+    "current_tier",
+    "current_tier_rank",
+    "grace",
+    "enforced",
+    "upgrade_required",
+}
+_RUNTIMES_KEYS = {
+    "tier",
+    "runtimes",
+    "unknown",
+    "missing",
+    "kind",
+    "count",
+    "missing_count",
+    "any_missing",
+    "required_tier",
+    "required_tier_label",
+    "required_tier_rank",
+    "perspective_tier_rank",
+    "current_tier",
+    "current_tier_rank",
+    "grace",
+    "enforced",
+    "upgrade_required",
+}
+
+
+def _get_json(client, url: str) -> dict:
+    resp = client.get(url)
+    assert resp.status_code == 200, url
+    return resp.get_json()
+
+
+def _paid_feature_tier(ent):
+    """Cheapest tier that grants at least one paid feature (used to pick a
+    perspective that flips at-least-one row from missing to granted)."""
+    for tier in ent._TIER_ORDER:
+        if tier == "oss":
+            continue
+        for f in ent.PAID_FEATURES:
+            if ent.has_feature_at(tier, f):
+                return tier
+    return None
+
+
+def _paid_runtime_tier(ent):
+    """Cheapest tier that grants at least one paid runtime."""
+    for tier in ent._TIER_ORDER:
+        if tier == "oss":
+            continue
+        for rt in ent.PAID_RUNTIMES:
+            if ent.has_runtime_at(tier, rt):
+                return tier
+    return None
+
+
+# ── missing_features_at scalar ──────────────────────────────────────────────────────────
+
+
+def test_missing_features_at_all_free_is_empty_every_tier(ent):
+    """A bundle of ONLY free features is granted at every real tier
+    (free floor lives in :func:`_hypothetical_entitlement`)."""
+    free = sorted(ent.FREE_FEATURES)
+    for tier in ent._TIER_ORDER:
+        assert ent.missing_features_at(tier, free) == []
+
+
+def test_missing_features_at_oss_denies_every_paid_feature(ent):
+    """OSS-free perspective grants no paid features -- every paid id in
+    the bundle lands in ``missing``. Grace-independent: same answer as
+    the enforce fixture below."""
+    paid = sorted(ent.PAID_FEATURES)
+    missing = ent.missing_features_at("oss", paid)
+    assert set(missing) == set(paid)
+    assert len(missing) == len(paid)
+
+
+def test_missing_features_at_enterprise_grants_every_known_feature(ent):
+    """Enterprise perspective grants every known feature -- ``missing``
+    is empty for the full paid bundle."""
+    if "enterprise" not in ent._TIER_ORDER:
+        pytest.skip("enterprise tier not in _TIER_ORDER on this build")
+    paid = sorted(ent.PAID_FEATURES)
+    assert ent.missing_features_at("enterprise", paid) == []
+
+
+def test_missing_features_at_grace_independence(ent, enforced):
+    """The scalar is grace-independent by construction: the same
+    (perspective, bundle) pair returns the same list under grace on and
+    grace off."""
+    paid = sorted(ent.PAID_FEATURES)
+    for tier in ent._TIER_ORDER:
+        grace_ans = ent.missing_features_at(tier, paid)
+        enforce_ans = enforced.missing_features_at(tier, paid)
+        assert grace_ans == enforce_ans, (tier, paid)
+
+
+def test_missing_features_at_unknown_perspective_returns_empty(ent):
+    """Unknown perspective -> ``[]`` (fail-open on the diagnostic --
+    caller can distinguish "typo perspective" from "valid perspective
+    that grants everything" via ``perspective_tier_rank == -1`` on the
+    paired endpoint)."""
+    assert ent.missing_features_at("Pro", ["fleet"]) == []  # dropped case
+    assert ent.missing_features_at("", ["fleet"]) == []
+    assert ent.missing_features_at(None, ["fleet"]) == []  # type: ignore[arg-type]
+    assert ent.missing_features_at("bogus_tier", ["fleet"]) == []
+    assert ent.missing_features_at(123, ["fleet"]) == []  # type: ignore[arg-type]
+
+
+def test_missing_features_at_unknown_feature_surfaces_at_row_level(ent):
+    """Unknown token at any valid perspective: only the typo lands in
+    ``missing`` (mirrors :func:`missing_features` typo posture)."""
+    tier = _paid_feature_tier(ent)
+    if tier is None:
+        pytest.skip("no paid-feature tier on this build")
+    # pick a paid feature granted at this tier
+    granted = next(f for f in ent.PAID_FEATURES if ent.has_feature_at(tier, f))
+    missing = ent.missing_features_at(tier, [granted, "bogus_id"])
+    assert missing == ["bogus_id"]
+
+
+def test_missing_features_at_all_unknown_surfaces_every_id(ent):
+    """All-unknown bundle: every id in ``missing`` (canonicalised)."""
+    tier = _paid_feature_tier(ent) or "oss"
+    missing = ent.missing_features_at(tier, ["bogus_a", "bogus_b"])
+    assert missing == ["bogus_a", "bogus_b"]
+
+
+def test_missing_features_at_empty_iterable_is_empty(ent):
+    for tier in ent._TIER_ORDER:
+        assert ent.missing_features_at(tier, []) == []
+        assert ent.missing_features_at(tier, ()) == []
+        assert ent.missing_features_at(tier, iter(())) == []
+
+
+def test_missing_features_at_none_is_empty(ent):
+    for tier in ent._TIER_ORDER:
+        assert ent.missing_features_at(tier, None) == []
+
+
+def test_missing_features_at_non_iterable_is_empty(ent):
+    for tier in ent._TIER_ORDER:
+        assert ent.missing_features_at(tier, 123) == []
+        assert ent.missing_features_at(tier, object()) == []
+
+
+def test_missing_features_at_case_insensitive_canonicalises(ent):
+    """Whitespace / casing on a known id normalises via the delegate;
+    at a tier that grants it, it comes back granted (empty missing)."""
+    tier = _paid_feature_tier(ent)
+    if tier is None:
+        pytest.skip("no paid-feature tier on this build")
+    granted = next(f for f in ent.PAID_FEATURES if ent.has_feature_at(tier, f))
+    assert ent.missing_features_at(
+        tier, [granted.upper(), f"  {granted}  "]
+    ) == []
+
+
+def test_missing_features_at_dedup_preserves_first_seen(ent):
+    """A repeated denied id collapses to ONE row in first-seen order."""
+    paid = sorted(ent.PAID_FEATURES)
+    a, b = paid[0], paid[1]
+    missing = ent.missing_features_at("oss", [a, b, a, b, a])
+    assert missing == [a, b]
+
+
+def test_missing_features_at_non_string_item_becomes_blank(ent):
+    """Non-string entries canonicalise to ``""`` and are INCLUDED once
+    (dedup on canonical key)."""
+    missing = ent.missing_features_at("oss", [123, None, object()])
+    assert missing == [""]
+
+
+def test_missing_features_at_never_raises_on_delegate_blowup(monkeypatch, ent):
+    """A delegate blowup collapses to ``[]`` (diagnostic fail-open) --
+    a matrix cell keeps rendering instead of throwing."""
+    def _boom(*a, **kw):
+        raise RuntimeError("delegate blew up")
+
+    monkeypatch.setattr(ent, "has_feature_at", _boom)
+    for arg in [["fleet"], ["fleet", "sso"], [], None, 123]:
+        assert ent.missing_features_at("pro", arg) == []
+
+
+# ── missing_runtimes_at scalar ─────────────────────────────────────────────────────────
+
+
+def test_missing_runtimes_at_all_free_is_empty_every_tier(ent):
+    free = sorted(ent.FREE_RUNTIMES)
+    for tier in ent._TIER_ORDER:
+        assert ent.missing_runtimes_at(tier, free) == []
+
+
+def test_missing_runtimes_at_oss_denies_every_paid_runtime(ent):
+    paid = sorted(ent.PAID_RUNTIMES)
+    missing = ent.missing_runtimes_at("oss", paid)
+    assert set(missing) == set(paid)
+    assert len(missing) == len(paid)
+
+
+def test_missing_runtimes_at_grace_independence(ent, enforced):
+    paid = sorted(ent.PAID_RUNTIMES)
+    for tier in ent._TIER_ORDER:
+        assert ent.missing_runtimes_at(tier, paid) == enforced.missing_runtimes_at(
+            tier, paid
+        )
+
+
+def test_missing_runtimes_at_unknown_perspective_returns_empty(ent):
+    assert ent.missing_runtimes_at("Pro", ["claude_code"]) == []
+    assert ent.missing_runtimes_at("", ["claude_code"]) == []
+    assert ent.missing_runtimes_at(None, ["claude_code"]) == []  # type: ignore[arg-type]
+    assert ent.missing_runtimes_at("bogus_tier", ["claude_code"]) == []
+    assert ent.missing_runtimes_at(123, ["claude_code"]) == []  # type: ignore[arg-type]
+
+
+def test_missing_runtimes_at_unknown_surfaces_at_row_level(ent):
+    tier = _paid_runtime_tier(ent)
+    if tier is None:
+        pytest.skip("no paid-runtime tier on this build")
+    granted = next(rt for rt in ent.PAID_RUNTIMES if ent.has_runtime_at(tier, rt))
+    assert ent.missing_runtimes_at(tier, [granted, "bogus_runtime"]) == [
+        "bogus_runtime"
+    ]
+
+
+def test_missing_runtimes_at_empty_iterable_is_empty(ent):
+    for tier in ent._TIER_ORDER:
+        assert ent.missing_runtimes_at(tier, []) == []
+
+
+def test_missing_runtimes_at_none_is_empty(ent):
+    for tier in ent._TIER_ORDER:
+        assert ent.missing_runtimes_at(tier, None) == []
+
+
+def test_missing_runtimes_at_non_iterable_is_empty(ent):
+    for tier in ent._TIER_ORDER:
+        assert ent.missing_runtimes_at(tier, 123) == []
+        assert ent.missing_runtimes_at(tier, object()) == []
+
+
+def test_missing_runtimes_at_scalar_does_not_alias_canonicalise(ent):
+    """Scalar mirrors :func:`has_runtimes_at` alias posture: the
+    delegate :func:`has_runtime_at` does not resolve aliases, so at the
+    scalar layer an alias input surfaces in ``missing`` in its
+    ``.strip().lower()`` form. Alias tolerance is the endpoint's job."""
+    tier = _paid_runtime_tier(ent) or "pro"
+    assert ent.missing_runtimes_at(tier, ["claude-code"]) == ["claude-code"]
+
+
+def test_missing_runtimes_at_scalar_no_dedup_across_alias_forms(ent):
+    """Consequence of no scalar-level canonicalisation."""
+    tier = _paid_runtime_tier(ent)
+    if tier is None:
+        pytest.skip("no paid-runtime tier on this build")
+    if not ent.has_runtime_at(tier, "claude_code"):
+        pytest.skip("perspective does not grant claude_code")
+    missing = ent.missing_runtimes_at(tier, ["claude-code", "claude_code"])
+    assert missing == ["claude-code"]  # canonical form granted; alias missing
+
+
+def test_missing_runtimes_at_case_insensitive(ent):
+    tier = _paid_runtime_tier(ent)
+    if tier is None:
+        pytest.skip("no paid-runtime tier on this build")
+    granted = next(rt for rt in ent.PAID_RUNTIMES if ent.has_runtime_at(tier, rt))
+    assert ent.missing_runtimes_at(tier, [granted.upper(), f"  {granted}  "]) == []
+
+
+def test_missing_runtimes_at_dedup_preserves_first_seen(ent):
+    paid = sorted(ent.PAID_RUNTIMES)
+    a, b = paid[0], paid[1]
+    missing = ent.missing_runtimes_at("oss", [a, b, a, b])
+    assert missing == [a, b]
+
+
+def test_missing_runtimes_at_never_raises_on_delegate_blowup(monkeypatch, ent):
+    def _boom(*a, **kw):
+        raise RuntimeError("delegate blew up")
+
+    monkeypatch.setattr(ent, "has_runtime_at", _boom)
+    for arg in [["openclaw"], ["claude_code", "cursor"], [], None, 123]:
+        assert ent.missing_runtimes_at("pro", arg) == []
+
+
+# ── Complement invariant: missing_*_at == [] iff has_*_at is True ─────────────────────
+
+
+@pytest.mark.parametrize(
+    "bundle",
+    [
+        ["fleet"],
+        ["fleet", "sso"],
+        ["bogus_id"],
+        ["fleet", "bogus_id"],
+    ],
+)
+def test_missing_features_at_complement_invariant(ent, bundle):
+    """``missing_features_at(p, b) == []`` iff ``has_features_at(p, b) is
+    True`` for every non-empty bundle at every real perspective."""
+    for tier in ent._TIER_ORDER:
+        # skip axes / tokens the ent build doesn't know about defensively
+        missing = ent.missing_features_at(tier, bundle)
+        has = ent.has_features_at(tier, bundle)
+        assert (missing == []) is has, (tier, bundle)
+
+
+@pytest.mark.parametrize(
+    "bundle",
+    [
+        ["openclaw"],
+        ["claude_code"],
+        ["openclaw", "claude_code"],
+        ["bogus_runtime"],
+        ["openclaw", "bogus_runtime"],
+    ],
+)
+def test_missing_runtimes_at_complement_invariant(ent, bundle):
+    for tier in ent._TIER_ORDER:
+        missing = ent.missing_runtimes_at(tier, bundle)
+        has = ent.has_runtimes_at(tier, bundle)
+        assert (missing == []) is has, (tier, bundle)
+
+
+# ── /api/entitlement/missing-features-at endpoint ────────────────────────────────────
+
+
+def test_endpoint_missing_features_at_shape_default(client):
+    """Missing-arg CSV -> 200 with 17-key envelope and empty missing."""
+    body = _get_json(client, "/api/entitlement/missing-features-at")
+    assert set(body.keys()) == _FEATURES_KEYS
+    assert body["tier"] == ""
+    assert body["features"] == []
+    assert body["unknown"] == []
+    assert body["missing"] == []
+    assert body["kind"] == "features"
+    assert body["count"] == 0
+    assert body["missing_count"] == 0
+    assert body["any_missing"] is False
+    assert body["required_tier"] is None
+    assert body["required_tier_label"] is None
+    assert body["required_tier_rank"] == -1
+    assert body["perspective_tier_rank"] == -1
+    assert body["grace"] is True
+    assert body["upgrade_required"] is False
+
+
+def test_endpoint_missing_features_at_unknown_perspective_missing_empty(client):
+    """Unknown perspective still 200; ``missing=[]`` (fail-open on the
+    diagnostic, same as scalar); ``perspective_tier_rank == -1`` so a UI
+    can distinguish typo perspective from valid-but-fully-granted."""
+    body = _get_json(
+        client,
+        "/api/entitlement/missing-features-at?tier=bogus_tier&features=fleet,sso",
+    )
+    assert set(body.keys()) == _FEATURES_KEYS
+    assert body["tier"] == "bogus_tier"
+    assert body["perspective_tier_rank"] == -1
+    assert body["features"] == ["fleet", "sso"]
+    assert body["missing"] == []
+
+
+def test_endpoint_missing_features_at_oss_denies_paid(client):
+    """OSS perspective denies every paid feature -- grace-independent."""
+    body = _get_json(
+        client,
+        "/api/entitlement/missing-features-at?tier=oss&features=fleet,sso",
+    )
+    assert set(body.keys()) == _FEATURES_KEYS
+    assert body["tier"] == "oss"
+    assert set(body["missing"]) == {"fleet", "sso"}
+    assert body["missing_count"] == 2
+    assert body["any_missing"] is True
+
+
+def test_endpoint_missing_features_at_enterprise_grants_paid(client, ent):
+    if "enterprise" not in ent._TIER_ORDER:
+        pytest.skip("enterprise tier not in _TIER_ORDER on this build")
+    body = _get_json(
+        client,
+        "/api/entitlement/missing-features-at?tier=enterprise&features=fleet,sso",
+    )
+    assert body["missing"] == []
+    assert body["any_missing"] is False
+
+
+def test_endpoint_missing_features_at_unknown_surfaces_in_missing_and_unknown(client):
+    """Unknown token surfaces in BOTH ``unknown`` (raw) and ``missing``
+    (canonicalised)."""
+    body = _get_json(
+        client,
+        "/api/entitlement/missing-features-at?tier=oss&features=fleet,bogus_id",
+    )
+    assert body["features"] == ["fleet"]
+    assert body["unknown"] == ["bogus_id"]
+    assert set(body["missing"]) == {"fleet", "bogus_id"}
+    assert body["any_missing"] is True
+
+
+def test_endpoint_missing_features_at_dedup(client):
+    """Repeated tokens collapse via _parse_csv_arg dedup."""
+    body = _get_json(
+        client,
+        "/api/entitlement/missing-features-at?tier=oss&features=fleet,fleet,sso,fleet",
+    )
+    assert body["features"] == ["fleet", "sso"]
+    assert body["count"] == 2
+
+
+def test_endpoint_missing_features_at_scalar_vs_endpoint_parity(client, ent):
+    """URL ``missing`` byte-equals module scalar on the same input."""
+    body = _get_json(
+        client,
+        "/api/entitlement/missing-features-at?tier=oss&features=fleet,bogus_id",
+    )
+    assert body["missing"] == ent.missing_features_at(
+        "oss", ["fleet", "bogus_id"]
+    )
+
+
+def test_endpoint_missing_features_at_any_missing_negates_has_features_at(client):
+    """``any_missing`` here == not ``has_features_at`` on the sibling
+    URL over the same (perspective, bundle)."""
+    for tier in ("oss", "cloud_starter", "cloud_pro", "enterprise"):
+        for csv in ("fleet,sso", "fleet"):
+            miss_body = _get_json(
+                client,
+                f"/api/entitlement/missing-features-at?tier={tier}&features={csv}",
+            )
+            has_body = _get_json(
+                client,
+                f"/api/entitlement/has-features-at?tier={tier}&features={csv}",
+            )
+            # Skip perspectives absent from _TIER_ORDER on this build.
+            if has_body["perspective_tier_rank"] == -1:
+                continue
+            assert miss_body["any_missing"] is (not has_body["has_features_at"]), (
+                tier,
+                csv,
+            )
+
+
+def test_endpoint_missing_features_at_upgrade_required_compares_to_perspective(
+    client,
+):
+    """``upgrade_required`` compares required-tier rank to PERSPECTIVE
+    rank (not live current rank) so a matrix row reads "no upgrade
+    needed at this tier" (False when perspective >= required) vs
+    "upgrade needed beyond this tier" (True when perspective <
+    required). Diverges deliberately from the live sibling's
+    live-current comparison -- the whole point of the ``_at`` slot."""
+    # OSS perspective + Enterprise-tier bundle -> upgrade_required True
+    oss_body = _get_json(
+        client,
+        "/api/entitlement/missing-features-at?tier=oss&features=fleet,sso",
+    )
+    assert oss_body["required_tier"] is not None
+    assert oss_body["upgrade_required"] is True
+
+    # Enterprise perspective + same bundle -> upgrade_required False
+    ent_body = _get_json(
+        client,
+        "/api/entitlement/missing-features-at?tier=enterprise&features=fleet,sso",
+    )
+    if ent_body["perspective_tier_rank"] != -1:
+        assert ent_body["upgrade_required"] is False
+
+
+def test_endpoint_missing_features_at_never_5xx_on_resolver_blowup(
+    monkeypatch, client
+):
+    from clawmetry import entitlements as _ent
+
+    def _boom(*a, **kw):
+        raise RuntimeError("resolver blew up")
+
+    monkeypatch.setattr(_ent, "get_entitlement", _boom)
+    resp = client.get(
+        "/api/entitlement/missing-features-at?tier=oss&features=fleet,sso"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert set(body.keys()) == _FEATURES_KEYS
+    assert body["missing"] == []
+    assert body["any_missing"] is False
+    assert body["grace"] is True
+    assert body["current_tier"] == "oss"
+
+
+def test_endpoint_missing_features_at_never_5xx_on_scalar_blowup(
+    monkeypatch, client
+):
+    from clawmetry import entitlements as _ent
+
+    def _boom(*a, **kw):
+        raise RuntimeError("scalar blew up")
+
+    monkeypatch.setattr(_ent, "missing_features_at", _boom)
+    resp = client.get(
+        "/api/entitlement/missing-features-at?tier=oss&features=fleet,sso"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert set(body.keys()) == _FEATURES_KEYS
+    assert body["missing"] == []
+
+
+# ── /api/entitlement/missing-runtimes-at endpoint ────────────────────────────────────
+
+
+def test_endpoint_missing_runtimes_at_shape_default(client):
+    body = _get_json(client, "/api/entitlement/missing-runtimes-at")
+    assert set(body.keys()) == _RUNTIMES_KEYS
+    assert body["runtimes"] == []
+    assert body["missing"] == []
+    assert body["any_missing"] is False
+
+
+def test_endpoint_missing_runtimes_at_oss_denies_paid(client):
+    body = _get_json(
+        client,
+        "/api/entitlement/missing-runtimes-at?tier=oss&runtimes=claude_code,cursor",
+    )
+    assert set(body.keys()) == _RUNTIMES_KEYS
+    assert set(body["missing"]) == {"claude_code", "cursor"}
+    assert body["missing_count"] == 2
+
+
+def test_endpoint_missing_runtimes_at_alias_canonicalises(client):
+    """Alias tokens canonicalise upstream before hitting the strict
+    scalar so ``?runtimes=claude-code`` renders as ``claude_code`` in
+    ``runtimes`` and (at a perspective that denies it) ``missing``."""
+    body = _get_json(
+        client,
+        "/api/entitlement/missing-runtimes-at?tier=oss&runtimes=claude-code",
+    )
+    assert body["runtimes"] == ["claude_code"]
+    assert body["missing"] == ["claude_code"]
+
+
+def test_endpoint_missing_runtimes_at_alias_and_canonical_dedup(client):
+    """Alias + canonical pair collapses to ONE row in ``missing``."""
+    body = _get_json(
+        client,
+        "/api/entitlement/missing-runtimes-at?tier=oss&runtimes=claude-code,claude_code",
+    )
+    assert body["missing"] == ["claude_code"]
+    assert body["missing_count"] == 1
+
+
+def test_endpoint_missing_runtimes_at_unknown_surfaces_in_missing(client):
+    body = _get_json(
+        client,
+        "/api/entitlement/missing-runtimes-at?tier=oss&runtimes=openclaw,bogus_runtime",
+    )
+    assert body["runtimes"] == ["openclaw"]
+    assert body["unknown"] == ["bogus_runtime"]
+    assert body["missing"] == ["bogus_runtime"]
+
+
+def test_endpoint_missing_runtimes_at_any_missing_negates_has_runtimes_at(client):
+    for tier in ("oss", "cloud_starter", "cloud_pro", "enterprise"):
+        for csv in ("openclaw,claude_code", "claude_code"):
+            miss_body = _get_json(
+                client,
+                f"/api/entitlement/missing-runtimes-at?tier={tier}&runtimes={csv}",
+            )
+            has_body = _get_json(
+                client,
+                f"/api/entitlement/has-runtimes-at?tier={tier}&runtimes={csv}",
+            )
+            if has_body["perspective_tier_rank"] == -1:
+                continue
+            assert miss_body["any_missing"] is (not has_body["has_runtimes_at"]), (
+                tier,
+                csv,
+            )
+
+
+def test_endpoint_missing_runtimes_at_never_5xx_on_resolver_blowup(
+    monkeypatch, client
+):
+    from clawmetry import entitlements as _ent
+
+    def _boom(*a, **kw):
+        raise RuntimeError("resolver blew up")
+
+    monkeypatch.setattr(_ent, "get_entitlement", _boom)
+    resp = client.get(
+        "/api/entitlement/missing-runtimes-at?tier=oss&runtimes=openclaw,claude_code"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert set(body.keys()) == _RUNTIMES_KEYS
+    assert body["missing"] == []
+
+
+def test_endpoint_missing_runtimes_at_never_5xx_on_scalar_blowup(
+    monkeypatch, client
+):
+    from clawmetry import entitlements as _ent
+
+    def _boom(*a, **kw):
+        raise RuntimeError("scalar blew up")
+
+    monkeypatch.setattr(_ent, "missing_runtimes_at", _boom)
+    resp = client.get(
+        "/api/entitlement/missing-runtimes-at?tier=oss&runtimes=openclaw,claude_code"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert set(body.keys()) == _RUNTIMES_KEYS
+    assert body["missing"] == []
+
+
+# ── Envelope stability across many input branches ───────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "/api/entitlement/missing-features-at",
+        "/api/entitlement/missing-features-at?tier=",
+        "/api/entitlement/missing-features-at?tier=oss",
+        "/api/entitlement/missing-features-at?tier=oss&features=",
+        "/api/entitlement/missing-features-at?tier=oss&features=fleet",
+        "/api/entitlement/missing-features-at?tier=oss&features=fleet,sso",
+        "/api/entitlement/missing-features-at?tier=oss&features=fleet,bogus_id",
+        "/api/entitlement/missing-features-at?tier=oss&features=bogus_a,bogus_b",
+        "/api/entitlement/missing-features-at?tier=oss&features=fleet,,sso,fleet",
+        "/api/entitlement/missing-features-at?tier=oss&features=%20fleet%20,SSO",
+        "/api/entitlement/missing-features-at?tier=bogus&features=fleet",
+        "/api/entitlement/missing-features-at?tier=%20PRO%20&features=fleet",
+    ],
+)
+def test_endpoint_missing_features_at_envelope_stable(client, url):
+    body = _get_json(client, url)
+    assert set(body.keys()) == _FEATURES_KEYS
+    assert body["kind"] == "features"
+    assert isinstance(body["tier"], str)
+    assert isinstance(body["features"], list)
+    assert isinstance(body["unknown"], list)
+    assert isinstance(body["missing"], list)
+    assert isinstance(body["count"], int)
+    assert isinstance(body["missing_count"], int)
+    assert body["missing_count"] == len(body["missing"])
+    assert body["count"] == len(body["features"])
+    assert isinstance(body["any_missing"], bool)
+    assert body["any_missing"] is (bool(body["missing"]) or bool(body["unknown"]))
+    assert isinstance(body["perspective_tier_rank"], int)
+    assert isinstance(body["upgrade_required"], bool)
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "/api/entitlement/missing-runtimes-at",
+        "/api/entitlement/missing-runtimes-at?tier=",
+        "/api/entitlement/missing-runtimes-at?tier=oss",
+        "/api/entitlement/missing-runtimes-at?tier=oss&runtimes=",
+        "/api/entitlement/missing-runtimes-at?tier=oss&runtimes=openclaw",
+        "/api/entitlement/missing-runtimes-at?tier=oss&runtimes=openclaw,claude_code",
+        "/api/entitlement/missing-runtimes-at?tier=oss&runtimes=claude-code",
+        "/api/entitlement/missing-runtimes-at?tier=oss&runtimes=claude-code,claude_code",
+        "/api/entitlement/missing-runtimes-at?tier=oss&runtimes=openclaw,bogus_runtime",
+        "/api/entitlement/missing-runtimes-at?tier=oss&runtimes=%20openclaw%20,CLAUDE_CODE",
+        "/api/entitlement/missing-runtimes-at?tier=bogus&runtimes=openclaw",
+    ],
+)
+def test_endpoint_missing_runtimes_at_envelope_stable(client, url):
+    body = _get_json(client, url)
+    assert set(body.keys()) == _RUNTIMES_KEYS
+    assert body["kind"] == "runtimes"
+    assert isinstance(body["tier"], str)
+    assert isinstance(body["runtimes"], list)
+    assert isinstance(body["unknown"], list)
+    assert isinstance(body["missing"], list)
+    assert body["missing_count"] == len(body["missing"])
+    assert body["count"] == len(body["runtimes"])
+    assert isinstance(body["any_missing"], bool)
+    assert body["any_missing"] is (bool(body["missing"]) or bool(body["unknown"]))
+    assert isinstance(body["perspective_tier_rank"], int)
+    assert isinstance(body["upgrade_required"], bool)


### PR DESCRIPTION
## Summary

- Adds perspective-shaped complements `missing_features_at(perspective_tier, features)` and `missing_runtimes_at(perspective_tier, runtimes)` in `clawmetry/entitlements.py`. Fills the `_at` slot in the row-detail complement family in the same relationship `has_features_at` has to `has_features`. A pricing-matrix column that gates on a bundle ("which of `fleet + sso` would still be locked at Starter? at Pro?") can bind the per-item denial list off ONE call per (perspective, bundle) cell.
- Adds paired endpoints `GET /api/entitlement/missing-features-at?tier=<perspective>&features=a,b,c` and `GET /api/entitlement/missing-runtimes-at?tier=<perspective>&runtimes=x,y,z` on `bp_entitlement` in `routes/entitlement.py`. 17-key envelope (the 15-key `missing-features` shape plus `tier` and `perspective_tier_rank`). Never 4xxs; never 5xxs.
- Adds `tests/test_entitlement_missing_features_runtimes_at.py` — 78 tests covering scalar semantics across every real `_TIER_ORDER` perspective, the complement invariant against `has_*_at`, grace-independence, endpoint envelope stability across 12+ input branches per axis, scalar-vs-endpoint parity, and never-5xx on both resolver and scalar blowup.

Scalar contract:
- Grace-independent by construction (backed by `_hypothetical_entitlement` via the per-item `has_feature_at` / `has_runtime_at` delegates), so the returned list is identical under grace vs enforce for the same (perspective, bundle) pair — the whole point of the `_at` slot.
- Fail-open on unknown perspective (`[]` — matches the sibling `missing_features` resolver-blowup posture).
- Unknown / non-string / empty item ids surface in the returned list in canonicalised form (matches the sibling scalar typo-catches-at-callsite posture).
- Runtime scalar carries the strict alias posture (`has_runtime_at("pro", "claude-code")` is `False`, so `missing_runtimes_at("pro", ["claude-code"])` surfaces `"claude-code"` in `missing` verbatim). Alias tolerance is the endpoint's job.

Endpoint contract:
- Runtime endpoint canonicalises alias tokens upstream of the strict scalar so `?runtimes=claude-code,claude_code` dedups to ONE row in both `runtimes` and `missing`.
- `upgrade_required` compares `required_tier_rank` against the **perspective** rank (not live current) so a matrix row reads "no upgrade needed at this tier" (`False` when perspective ≥ required) vs "upgrade needed beyond this tier" — diverges deliberately from the live `/missing-features` sibling's live-current comparison.
- Fallback envelope (`_missing_bundle_at_fallback`) matches the happy-path shape byte-for-byte on any resolver / helper blowup with `missing=[]` / `any_missing=False` so a paywall matrix tile does not silently render a denial banner it can no longer justify.

No behavior change: no `__version__` bump, no runtime gate flipped, no existing route modified. All existing entitlement `has_*` / `missing_*` tests still pass (189 baseline; 1405 across the broader `has_ or missing_` slice, 7 skipped).

## Test plan

- [x] `python -m py_compile clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_missing_features_runtimes_at.py`
- [x] `python -m pytest tests/test_entitlement_missing_features_runtimes_at.py` — 78 passed
- [x] `python -m pytest tests/test_entitlement_missing_features_runtimes.py tests/test_entitlement_api.py tests/test_entitlement_has_features_has_runtimes.py` — 189 passed (sibling regression)
- [x] `python -m pytest tests/ -k "entitlement and (has_ or missing_)"` — 1405 passed, 7 skipped

## Local operator verification checklist

The scheduled agent can't reach the live daemon, cloud snapshot, or a browser. Please verify on the host:

- [ ] `cp -R clawmetry/entitlements.py routes/entitlement.py ~/.clawmetry/lib/python3.11/site-packages/clawmetry/` (or the right `pythonX.Y` for your install) — keep `routes/entitlement.py` at its package-relative path in your install layout
- [ ] `find ~/.clawmetry/lib -name __pycache__ -exec rm -rf {} +`
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
- [ ] `curl -s 'http://localhost:8900/api/entitlement/missing-features-at?tier=oss&features=fleet,sso' | jq` → 17-key envelope with `missing: ["fleet", "sso"]`, `any_missing: true`, `upgrade_required: true`
- [ ] `curl -s 'http://localhost:8900/api/entitlement/missing-features-at?tier=enterprise&features=fleet,sso' | jq` → `missing: []`, `upgrade_required: false`
- [ ] `curl -s 'http://localhost:8900/api/entitlement/missing-runtimes-at?tier=oss&runtimes=claude-code,claude_code' | jq` → alias dedup, `missing: ["claude_code"]`
- [ ] `curl -s 'http://localhost:8900/api/entitlement/missing-runtimes-at?tier=bogus&runtimes=openclaw' | jq` → 200, `perspective_tier_rank: -1`, `missing: []`
- [ ] Decrypt the live cloud snapshot in the browser and confirm the sibling `/has-*-at` and `/missing-*` tiles still render unchanged (this PR is additive — no existing route touched).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Em9iShgHA5McgYv6RejHEK)_