### PR TITLE
fix: friendly error for `connect` when no TTY is available

### DIFF
--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -613,6 +613,11 @@ def _get_api_key_interactive() -> str:
         except OSError:
             pass
 
+    if _tty is None and not sys.stdin.isatty():
+        print("\n  ❌  Interactive sign-in needs a terminal.")
+        print("  Run this in your own shell, or pass --key cm_xxx to skip the prompt.\n")
+        sys.exit(1)
+
     def _input(prompt):
         """input() that reads from /dev/tty when stdin is a pipe."""
         if _tty is not None:
@@ -620,7 +625,12 @@ def _get_api_key_interactive() -> str:
             sys.stdout.flush()
             line = _tty.readline()
             return line.rstrip("\n")
-        return input(prompt)
+        try:
+            return input(prompt)
+        except EOFError:
+            print("\n  ❌  Interactive sign-in needs a terminal.")
+            print("  Run this in your own shell, or pass --key cm_xxx to skip the prompt.\n")
+            sys.exit(1)
 
     from clawmetry.endpoints import ingest_url as _resolve_ingest_url
     INGEST_URL = _resolve_ingest_url()


### PR DESCRIPTION
Closes #4518

## What

`clawmetry connect --force` raised a raw `EOFError` traceback when spawned in a non-TTY environment (CI, agent harness, container) where `/dev/tty` is also unavailable.

## Changes

- **`clawmetry/cli.py`** — two edits inside `_get_api_key_interactive`:
  - After the `/dev/tty` open attempt, guard: if `_tty is None and not sys.stdin.isatty()` → print a friendly message and `sys.exit(1)`. This is the primary fix.
  - Catch `EOFError` in the inner `_input()` fallback as belt-and-suspenders in case the guard is ever bypassed.

This mirrors the pattern already established in the OTP verification path at ~line 768 of the same file.

## Test plan

- [ ] Run `clawmetry connect --force </dev/null` — should print `❌  Interactive sign-in needs a terminal.` and exit 1 (no traceback).
- [ ] Run `clawmetry connect --force` from a normal interactive shell — no change in behaviour.
- [ ] In a Docker container without `/dev/tty`: same clean exit.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JTxVS6pPT5KbW5Ue3B2tdw)_