### PR TITLE
[RELEASE] Self-hosted profile menu: upgrade sells the self-hosted license; Gateway settings removed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 0.12.650
+
+- **The profile menu now respects that you're self-hosted.** "Upgrade plan"
+  on a trial license opens the self-hosted pricing flow on clawmetry.com
+  (the buy modal preselected) instead of the cloud app's account funnel,
+  and "Billing & plan" only appears when the node is actually linked to a
+  cloud account. The old "Gateway settings" gear and menu item are gone:
+  the gateway wizard is first-run setup and still opens itself whenever
+  the gateway is unconfigured, which is the only time it can help.
+
 ## 0.12.648
 
 - **The savings ideas now read the spend flow.** The efficiency card on the


### PR DESCRIPTION
Release carrier for #4524 (merged as 22c8def), which missed the auto-release trigger: the workflow gates on the PR *title* containing [RELEASE], and #4524's title didn't carry it (only the squash subject did), so the publish job skipped.

This PR adds the 0.12.650 CHANGELOG entry and carries the release:

- Self-hosted trial "Upgrade plan" → clawmetry.com/pricing?deploy=self (self-hosted license checkout), no longer the cloud-account /upgrade funnel.
- "Billing & plan" (app.clawmetry.com/settings) gated on a linked cloud account.
- "Gateway settings" topbar gear + profile-menu item removed; first-run wizard behavior unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)