### PR TITLE
feat(entitlement): missing_features_at_path + missing_runtimes_at_path + endpoints

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -6772,6 +6772,257 @@ def missing_runtimes_at_batch(perspective_tiers, runtimes) -> dict:
     return {"tiers": rows, "unknown": unknown}
 
 
+def missing_features_at_path(
+    from_tier: str, to_tier: str, features
+) -> list[dict] | None:
+    """Arbitrary-endpoint stepwise ``missing_features_at`` path between two
+    tiers -- fixes ONE feature bundle and sweeps across every rung between
+    ``from_tier`` and ``to_tier``, returning one row per rung with the
+    per-item denial list at that rung.
+
+    Path-shaped sibling of :func:`missing_features_at_batch` (multi-source
+    what-if matrix over a caller-supplied tier list) and the bulk what-if
+    cousin of :func:`missing_features_at`. Pairs with
+    :func:`feature_catalog_path` the same way :func:`missing_features_at`
+    pairs with :func:`feature_catalog_at`: the catalog helper renders the
+    full grant per rung; this helper renders which subset of a caller-
+    supplied bundle is STILL locked at every rung. Lets an upgrade-
+    walkthrough UI render a "at which rung does each of these unlock?"
+    column off ONE round-trip, instead of first calling :func:`tier_path`
+    for the rung list and then N calls to :func:`missing_features_at`.
+
+    Per-rung row shape::
+
+        {
+          "tier":       "<id>",
+          "tier_label": "...",
+          "tier_rank":  <int>,
+          "missing":    [<subset of features denied at rung>],
+        }
+
+    Each ``missing`` list byte-equals :func:`missing_features_at` for the
+    same (rung, features) pair -- a parity test pins this so the scalar,
+    batch and path what-if complement helpers cannot drift.
+
+    Walk semantics mirror :func:`feature_catalog_path` /
+    :func:`tier_path` / :func:`capacity_diff_path` /
+    :func:`tier_unlocks_path` / :func:`tier_locks_path` /
+    :func:`preview_path` / :func:`tier_spec_path` /
+    :func:`feature_spec_path` byte-for-byte (same :data:`_PURCHASABLE_TIERS`
+    filter + same sort key + same destination-sibling exclusion) so the
+    rung ``tier`` ids from this helper line up rung-for-rung against the
+    rung ``tier`` / ``to`` / ``target`` ids from those helpers. Same-rank
+    siblings strictly between the endpoints are both included; same-rank
+    siblings of the destination are excluded so the path terminates
+    exactly at ``to_tier``.
+
+    Direction semantics (all rows share the same shape; only the sequence
+    changes):
+
+    * ``upgrade`` (ascending) -- rows climb rung by rung from the rung
+      above ``from_tier`` toward ``to_tier``; each rung's ``missing`` set
+      shrinks or stays equal as grants accumulate.
+    * ``downgrade`` (descending) -- rows shrink rung by rung; the
+      cancellation-walkthrough counterpart; each rung's ``missing`` set
+      grows or stays equal.
+    * ``lateral`` (same rank, different id) -- single-row path; row
+      carries the ``missing`` at ``to_tier``.
+    * ``identity`` (``from == to``) -- empty path; no rungs to walk.
+
+    Endpoint semantics match :func:`feature_catalog_path` / :func:`tier_path`
+    / :func:`tier_diff`: both ids accept any entry in :data:`_TIER_FEATURES`
+    (including :data:`TIER_TRIAL`, which is not purchasable -- it is
+    excluded from the walked intermediate rungs but is a valid endpoint
+    via the lateral branch). Unknown ids on either side short-circuit to
+    ``None``.
+
+    Bundle-fold semantics per rung inherit :func:`missing_features_at`
+    byte-for-byte:
+
+    * Empty / ``None`` / non-iterable ``features`` -- every rung's row
+      carries ``missing=[]`` (nothing to check on any rung).
+    * Unknown / non-string / empty-string ``features`` item -- INCLUDED
+      in every rung's ``missing`` list in canonicalised form (typo posture
+      inherited from the scalar). Grace-independent by construction (the
+      scalar is backed by :func:`_hypothetical_entitlement`).
+
+    Resolver-independent: delegates per-rung to :func:`missing_features_at`,
+    which synthesises a fresh :class:`Entitlement` per rung -- grace vs
+    enforce yields byte-identical rows, same property the rest of the
+    ``_path`` family guarantees.
+
+    Never raises: a resolver / per-rung delegate failure logs a warning
+    and returns ``None`` so a pricing-page surface keeps rendering
+    instead of breaking; matches the sibling :func:`feature_catalog_path`
+    contract.
+    """
+    try:
+        f = (from_tier or "").strip().lower()
+        t = (to_tier or "").strip().lower()
+        if f not in _TIER_FEATURES or t not in _TIER_FEATURES:
+            return None
+        # Canonicalise the bundle ONCE so the per-rung delegate sees the
+        # same iterable on every call (list() below tolerates a generator
+        # / one-shot iterable and reuses it across rungs).
+        try:
+            if features is None:
+                items: list = []
+            else:
+                items = list(features)
+        except TypeError:
+            items = []
+
+        def _row(rung: str) -> dict:
+            return {
+                "tier": rung,
+                "tier_label": tier_label(rung),
+                "tier_rank": _TIER_RANK.get(rung, -1),
+                "missing": list(missing_features_at(rung, items)),
+            }
+
+        if f == t:
+            return []
+        from_rank = _TIER_RANK.get(f, -1)
+        to_rank = _TIER_RANK.get(t, -1)
+        if from_rank == to_rank:
+            return [_row(t)]
+        ascending = to_rank > from_rank
+        if ascending:
+            ordered = sorted(
+                _PURCHASABLE_TIERS,
+                key=lambda x: (_TIER_RANK.get(x, -1), x),
+            )
+        else:
+            ordered = sorted(
+                _PURCHASABLE_TIERS,
+                key=lambda x: (-_TIER_RANK.get(x, -1), x),
+            )
+        path: list[dict] = []
+        for tid in ordered:
+            r = _TIER_RANK.get(tid, -1)
+            if ascending:
+                if r <= from_rank or r > to_rank:
+                    continue
+            else:
+                if r >= from_rank or r < to_rank:
+                    continue
+            if r == to_rank and tid != t:
+                continue
+            path.append(_row(tid))
+        return path
+    except Exception as exc:
+        logger.warning(
+            "entitlements: missing_features_at_path(%r, %r, %r) failed: %s",
+            from_tier,
+            to_tier,
+            features,
+            exc,
+        )
+        return None
+
+
+def missing_runtimes_at_path(
+    from_tier: str, to_tier: str, runtimes
+) -> list[dict] | None:
+    """Runtime-axis twin of :func:`missing_features_at_path`: fixes ONE
+    runtime bundle and sweeps across every rung between ``from_tier`` and
+    ``to_tier``, returning one row per rung with the per-item denial list
+    at that rung.
+
+    Pairs with :func:`missing_features_at_path` the same way
+    :func:`runtime_catalog_path` pairs with :func:`feature_catalog_path`.
+    Together the two path complement helpers let an upgrade-walkthrough
+    UI render a "at which rung does each of these features + runtimes
+    unlock?" column off TWO calls instead of first calling
+    :func:`tier_path` and then 2 * N calls to the scalar what-if
+    complement helpers.
+
+    Per-rung row shape mirrors :func:`missing_features_at_path` with
+    ``missing`` in the axis-shared slot::
+
+        {
+          "tier":       "<id>",
+          "tier_label": "...",
+          "tier_rank":  <int>,
+          "missing":    [<subset of runtimes denied at rung>],
+        }
+
+    Each ``missing`` list byte-equals :func:`missing_runtimes_at` for the
+    same (rung, runtimes) pair -- a parity test pins this. Strict alias
+    posture is inherited from the singular scalar (no
+    :func:`canonical_runtime` resolution at scalar layer; ``claude-code``
+    surfaces in every rung's ``missing`` verbatim). Alias tolerance lives
+    on the paired ``/api/entitlement/missing-runtimes-at-path`` endpoint,
+    which canonicalises per-token upstream -- matches the sibling
+    :func:`missing_runtimes_at` / ``/missing-runtimes-at`` split exactly.
+
+    Walk semantics, direction semantics, endpoint semantics, bundle-fold
+    semantics, resolver-independence and never-raise posture all match
+    :func:`missing_features_at_path` -- see that helper's docstring. Rung
+    walk is byte-stable against the rest of the ``_path`` family.
+    """
+    try:
+        f = (from_tier or "").strip().lower()
+        t = (to_tier or "").strip().lower()
+        if f not in _TIER_FEATURES or t not in _TIER_FEATURES:
+            return None
+        try:
+            if runtimes is None:
+                items: list = []
+            else:
+                items = list(runtimes)
+        except TypeError:
+            items = []
+
+        def _row(rung: str) -> dict:
+            return {
+                "tier": rung,
+                "tier_label": tier_label(rung),
+                "tier_rank": _TIER_RANK.get(rung, -1),
+                "missing": list(missing_runtimes_at(rung, items)),
+            }
+
+        if f == t:
+            return []
+        from_rank = _TIER_RANK.get(f, -1)
+        to_rank = _TIER_RANK.get(t, -1)
+        if from_rank == to_rank:
+            return [_row(t)]
+        ascending = to_rank > from_rank
+        if ascending:
+            ordered = sorted(
+                _PURCHASABLE_TIERS,
+                key=lambda x: (_TIER_RANK.get(x, -1), x),
+            )
+        else:
+            ordered = sorted(
+                _PURCHASABLE_TIERS,
+                key=lambda x: (-_TIER_RANK.get(x, -1), x),
+            )
+        path: list[dict] = []
+        for tid in ordered:
+            r = _TIER_RANK.get(tid, -1)
+            if ascending:
+                if r <= from_rank or r > to_rank:
+                    continue
+            else:
+                if r >= from_rank or r < to_rank:
+                    continue
+            if r == to_rank and tid != t:
+                continue
+            path.append(_row(tid))
+        return path
+    except Exception as exc:
+        logger.warning(
+            "entitlements: missing_runtimes_at_path(%r, %r, %r) failed: %s",
+            from_tier,
+            to_tier,
+            runtimes,
+            exc,
+        )
+        return None
+
+
 def has_all(
     *,
     features=None,

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -5852,6 +5852,314 @@ def api_entitlement_missing_runtimes_at_batch():
         )
 
 
+def _missing_bundle_at_path_fallback(
+    axis: str,
+    from_tier: str,
+    to_tier: str,
+    tokens: list,
+) -> dict:
+    """OSS-free / never-5xx envelope for the path-shaped complement
+    endpoints ``/api/entitlement/missing-features-at-path`` and
+    ``/api/entitlement/missing-runtimes-at-path``.
+
+    Path-shaped sibling of :func:`_missing_bundle_at_fallback`. On any
+    resolver / helper blowup the endpoint still returns 200 with the
+    same envelope shape as the happy path, but ``path=[]`` and every
+    rollup zeroed out so a pricing-page walkthrough that lost the
+    resolver doesn't silently render a denial column it can no longer
+    justify. ``from`` / ``to`` / ``tokens`` echo the caller's input into
+    the envelope + ``unknown`` so the tooltip can still surface the
+    caller-supplied set for debugging. ``direction`` collapses to
+    ``"identity"`` when ``from == to`` (matches the happy-path branch
+    for that case) and ``"unknown"`` otherwise.
+    """
+    direction = "identity" if from_tier and from_tier == to_tier else "unknown"
+    return {
+        "from": from_tier,
+        "from_label": None,
+        "from_rank": -1,
+        "to": to_tier,
+        "to_label": None,
+        "to_rank": -1,
+        "direction": direction,
+        axis: [],
+        "unknown": list(tokens),
+        "path": [],
+        "kind": axis,
+        "count": 0,
+        "path_length": 0,
+        "any_missing": False,
+        "required_tier": None,
+        "required_tier_label": None,
+        "required_tier_rank": -1,
+        "current_tier": "oss",
+        "current_tier_rank": 0,
+        "grace": True,
+        "enforced": False,
+    }
+
+
+def _missing_bundle_at_path_body(axis: str) -> dict:
+    """Happy-path body builder for
+    ``/api/entitlement/missing-features-at-path`` /
+    ``/api/entitlement/missing-runtimes-at-path``.
+
+    Path-shaped sibling of :func:`_missing_bundle_at_body`: fixes ONE
+    bundle and sweeps across every rung between ``from=`` and ``to=``,
+    returning one row per rung with the per-item denial list at that rung
+    plus the surrounding path envelope. Where ``/missing-features-at``
+    folds ONE (perspective, bundle) cell, this folds a whole path of
+    (rung, bundle) cells off ONE URL so an upgrade-walkthrough UI can
+    render "at which tier does each of these unlock?" without first
+    calling ``/tier-path`` for the rung list and then N calls to
+    ``/missing-features-at``.
+
+    Envelope shape mirrors ``/api/entitlement/feature-catalog-path``
+    exactly for the walk-metadata keys (``from`` / ``from_label`` /
+    ``from_rank`` / ``to`` / ``to_label`` / ``to_rank`` / ``direction``
+    / ``path``) so a client already binding the catalog path envelope
+    can bind this one with the same shape reader, and adds the axis-
+    shared bundle metadata (``features``/``runtimes`` / ``unknown`` /
+    ``kind`` / ``count`` / ``path_length`` / ``any_missing``), the
+    bundle rollup (``required_tier`` / ``required_tier_label`` /
+    ``required_tier_rank``) and the live resolver envelope
+    (``current_tier`` / ``current_tier_rank`` / ``grace`` /
+    ``enforced``).
+
+    Per-rung row shape byte-equals the scalar
+    :func:`missing_features_at_path` / :func:`missing_runtimes_at_path`
+    return: ``{tier, tier_label, tier_rank, missing}``. A parity test
+    pins per-rung ``missing`` byte-equals
+    ``/missing-features-at?tier=<rung>&features=<bundle>``'s ``.missing``
+    for the same (rung, bundle) pair.
+
+    Runtime-axis alias canonicalisation is applied per-token upstream
+    of the strict scalar (:func:`missing_runtimes_at_path` inherits
+    :func:`missing_runtimes_at`'s strict-alias posture at scalar layer),
+    matching the sibling ``/missing-runtimes-at`` upstream-canonicalise
+    pattern -- alias-and-canonical pair dedups to ONE entry in
+    ``runtimes`` before the scalar sees it, so it also dedups to ONE
+    entry in every rung's ``missing`` list.
+
+    ``any_missing`` is ``True`` iff any rung's ``missing`` list is
+    non-empty OR ``unknown`` is non-empty (matches the sibling
+    ``/missing-features-at`` rollup semantics extended over the path).
+
+    ``required_tier`` folds through :func:`min_tier_for_features` /
+    :func:`min_tier_for_runtimes` against the KNOWN-only subset (matches
+    the sibling ``/missing-features-at`` envelope's rollup contract),
+    NOT the path endpoints -- the rollup answers "what's the cheapest
+    tier that grants this bundle" independent of the walked window, so
+    a caller can pin the two-way comparison (path window vs cheapest-
+    grant tier) off ONE round-trip.
+
+    ``direction`` mirrors :func:`_missing_bundle_at_path_body`'s sibling
+    ``/feature-catalog-path`` values: ``upgrade`` | ``downgrade`` |
+    ``lateral`` | ``identity``.
+
+    Never 4xxs (missing / blank / unknown endpoints, or all-unknown CSV
+    -> 200 with ``path=[]`` on the unknown-endpoint branch, matching the
+    sibling ``/missing-features-at`` posture). Never 5xxs: any helper
+    blowup collapses to :func:`_missing_bundle_at_path_fallback`.
+    """
+    from clawmetry import entitlements as _ent
+
+    raw_from = request.args.get("from")
+    raw_to = request.args.get("to")
+    from_tier = (raw_from or "").strip().lower()
+    to_tier = (raw_to or "").strip().lower()
+    param = "features" if axis == "features" else "runtimes"
+    tokens = _parse_csv_arg(param)
+
+    known: list = []
+    unknown: list = []
+    if axis == "features":
+        for fid in tokens:
+            if fid in _ent.ALL_FEATURES:
+                if fid not in known:
+                    known.append(fid)
+            elif fid not in unknown:
+                unknown.append(fid)
+        canon_tokens: list = list(tokens)
+        required = _ent.min_tier_for_features(known) if known else None
+    else:
+        canon_tokens = []
+        canon_seen: set = set()
+        for rid_raw in tokens:
+            rid = _ent.canonical_runtime(rid_raw) or rid_raw
+            if rid in canon_seen:
+                continue
+            canon_seen.add(rid)
+            canon_tokens.append(rid)
+            if rid in _ent.ALL_RUNTIMES:
+                if rid not in known:
+                    known.append(rid)
+            elif rid not in unknown:
+                unknown.append(rid_raw)
+        required = _ent.min_tier_for_runtimes(known) if known else None
+
+    if axis == "features":
+        path = _ent.missing_features_at_path(from_tier, to_tier, canon_tokens)
+    else:
+        path = _ent.missing_runtimes_at_path(from_tier, to_tier, canon_tokens)
+
+    env = _resolver_envelope(_ent)
+    cur_rank = env["current_tier_rank"]
+    req_rank = _ent.tier_rank(required) if required else -1
+    required_label = _ent.tier_label(required) if required else None
+
+    if path is None:
+        # Unknown endpoint(s) -- fall through to the empty-path envelope so
+        # the client never 4xxs; ``direction`` reads ``"unknown"``.
+        direction = "unknown"
+        path_out: list = []
+        from_label = None
+        to_label = None
+        from_rank = -1
+        to_rank = -1
+    else:
+        path_out = list(path)
+        from_rank = _ent.tier_rank(from_tier)
+        to_rank = _ent.tier_rank(to_tier)
+        from_label = _ent.tier_label(from_tier)
+        to_label = _ent.tier_label(to_tier)
+        if from_tier == to_tier:
+            direction = "identity"
+        elif from_rank == to_rank:
+            direction = "lateral"
+        elif to_rank > from_rank:
+            direction = "upgrade"
+        else:
+            direction = "downgrade"
+
+    any_missing = bool(unknown) or any(
+        bool(row.get("missing")) for row in path_out
+    )
+
+    return {
+        "from": from_tier,
+        "from_label": from_label,
+        "from_rank": from_rank,
+        "to": to_tier,
+        "to_label": to_label,
+        "to_rank": to_rank,
+        "direction": direction,
+        axis: known,
+        "unknown": unknown,
+        "path": path_out,
+        "kind": axis,
+        "count": len(known),
+        "path_length": len(path_out),
+        "any_missing": any_missing,
+        "required_tier": required,
+        "required_tier_label": required_label,
+        "required_tier_rank": req_rank,
+        "current_tier": env["current_tier"],
+        "current_tier_rank": cur_rank,
+        "grace": env["grace"],
+        "enforced": env["enforced"],
+    }
+
+
+@bp_entitlement.route("/api/entitlement/missing-features-at-path")
+def api_entitlement_missing_features_at_path():
+    """``GET /api/entitlement/missing-features-at-path?from=<id>&to=<id>&features=a,b,c``
+    -- path-shaped complement of ``/api/entitlement/missing-features-at-batch``
+    (multi-source what-if matrix over a caller-supplied tier list) and
+    the bulk what-if cousin of ``/api/entitlement/missing-features-at``.
+
+    Fixes ONE feature bundle and sweeps across every rung between
+    ``from`` and ``to``, returning one row per rung with the per-item
+    denial list at that rung -- the "at which tier does each of these
+    unlock?" column an upgrade-walkthrough tooltip needs, off ONE URL
+    instead of first calling ``/tier-path`` for the rung list and then N
+    calls to ``/missing-features-at``.
+
+    Each row in ``path`` byte-equals the scalar
+    ``missing_features_at_path`` return
+    (``{tier, tier_label, tier_rank, missing}``); each ``missing`` list
+    byte-equals ``/missing-features-at?tier=<rung>&features=<bundle>``'s
+    ``.missing`` for the same (rung, bundle) pair -- pinned by the parity
+    tests so the scalar, batch and path what-if complement helpers cannot
+    drift.
+
+    Rung walk is byte-stable against ``/tier-path``,
+    ``/capacity-diff-path``, ``/tier-unlocks-path``, ``/tier-locks-path``,
+    ``/preview-path``, ``/tier-spec-path``, ``/feature-spec-path``,
+    ``/runtime-spec-path``, ``/feature-catalog-path`` and
+    ``/runtime-catalog-path`` (same ``_PURCHASABLE_TIERS`` filter + same
+    sort + same destination-sibling exclusion).
+
+    Response shape: the ``/feature-catalog-path`` envelope
+    (``from`` / ``from_label`` / ``from_rank`` / ``to`` / ``to_label`` /
+    ``to_rank`` / ``direction`` / ``path``) plus the axis-shared bundle
+    metadata (``features`` / ``unknown`` / ``kind`` / ``count`` /
+    ``path_length`` / ``any_missing``), the bundle rollup
+    (``required_tier`` / ``required_tier_label`` /
+    ``required_tier_rank``) and the live resolver envelope
+    (``current_tier`` / ``current_tier_rank`` / ``grace`` /
+    ``enforced``).
+
+    ``direction`` values: ``upgrade`` (ascending) | ``downgrade``
+    (descending) | ``lateral`` (same rank, different id, single-row
+    path) | ``identity`` (``from == to``, empty path) | ``unknown``
+    (either endpoint unknown -> empty path). Same-rank siblings strictly
+    between the endpoints are both included; same-rank siblings of the
+    destination are excluded so the path terminates exactly at ``to``.
+    ``trial`` IS accepted as an endpoint -- excluded from the walked
+    intermediate rungs (not purchasable) but valid via the lateral
+    branch.
+
+    Never 4xxs (missing / blank / unknown endpoints, or all-unknown CSV
+    -> 200 with ``path=[]``, matching the sibling
+    ``/missing-features-at`` posture). Never 5xxs: any helper blowup
+    collapses to the empty-path fallback envelope.
+    """
+    try:
+        return jsonify(_missing_bundle_at_path_body("features"))
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_missing_features_at_path: error: %s", exc
+        )
+        from_tier = (request.args.get("from") or "").strip().lower()
+        to_tier = (request.args.get("to") or "").strip().lower()
+        return jsonify(
+            _missing_bundle_at_path_fallback(
+                "features", from_tier, to_tier, _parse_csv_arg("features")
+            )
+        )
+
+
+@bp_entitlement.route("/api/entitlement/missing-runtimes-at-path")
+def api_entitlement_missing_runtimes_at_path():
+    """``GET /api/entitlement/missing-runtimes-at-path?from=<id>&to=<id>&runtimes=x,y,z``
+    -- runtime-axis twin of ``/api/entitlement/missing-features-at-path``.
+
+    Same envelope with ``runtimes`` in the axis-specific slot.
+    Runtime-alias canonicalisation (``claude-code`` -> ``claude_code``)
+    is applied per-token upstream at the endpoint layer so
+    ``?runtimes=claude-code,openclaw`` collapses to the canonical
+    ``claude_code,openclaw`` before hitting the strict scalar -- matches
+    the sibling ``/missing-runtimes-at`` upstream-canonicalise pattern.
+    Alias-and-canonical pair dedups to ONE entry in ``runtimes`` and
+    therefore ONE entry in every rung's ``missing`` list. Never 4xxs;
+    never 5xxs.
+    """
+    try:
+        return jsonify(_missing_bundle_at_path_body("runtimes"))
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_missing_runtimes_at_path: error: %s", exc
+        )
+        from_tier = (request.args.get("from") or "").strip().lower()
+        to_tier = (request.args.get("to") or "").strip().lower()
+        return jsonify(
+            _missing_bundle_at_path_fallback(
+                "runtimes", from_tier, to_tier, _parse_csv_arg("runtimes")
+            )
+        )
+
+
 def _has_all_fallback() -> dict:
     """Never-5xx envelope for ``/api/entitlement/has-all``.
 

--- a/tests/test_entitlement_missing_features_runtimes_at_path.py
+++ b/tests/test_entitlement_missing_features_runtimes_at_path.py
@@ -1,0 +1,561 @@
+"""Tests for the path-shaped ``missing_features_at_path`` /
+``missing_runtimes_at_path`` complement scalars and their paired
+``/api/entitlement/missing-features-at-path`` /
+``/api/entitlement/missing-runtimes-at-path`` endpoints.
+
+Path-shaped siblings of :func:`missing_features_at` /
+:func:`missing_runtimes_at` and complement-shaped siblings of
+:func:`feature_catalog_path` / :func:`runtime_catalog_path`: fixes ONE
+bundle and sweeps across every rung between ``from`` and ``to``,
+returning one row per rung with the per-item denial list at that rung.
+Lets an upgrade-walkthrough tooltip render "at which tier does each of
+these unlock?" off ONE URL.
+
+This file pins:
+
+1. Scalar walk semantics byte-parity with :func:`feature_catalog_path`
+   (rung ``tier`` sequence, direction detection, endpoint semantics,
+   same-rank sibling filter).
+2. Per-rung ``missing`` byte-parity with the scalar
+   :func:`missing_features_at` / :func:`missing_runtimes_at` for the
+   same (rung, bundle) pair.
+3. Bundle-fold posture inherited from the ``_at`` siblings:
+   empty / None / non-iterable bundle -> every rung's ``missing`` is
+   ``[]``; unknown / typo tokens surface in every rung's ``missing``
+   (canonicalised).
+4. Unknown-endpoint short-circuit: either endpoint unknown -> scalar
+   returns ``None``; endpoint returns 200 with ``path=[]`` and
+   ``direction="unknown"`` (never 4xxs -- matches
+   ``/missing-features-at`` posture).
+5. Direction semantics: ``upgrade`` / ``downgrade`` / ``lateral`` /
+   ``identity`` / ``unknown``.
+6. Grace-independence: same answer under grace on vs enforce for the
+   same (from, to, bundle) triple.
+7. Runtime scalar alias posture: no scalar-level canonicalisation --
+   ``missing_runtimes_at_path(f, t, ["claude-code"])`` surfaces
+   ``"claude-code"`` in every rung's ``missing`` verbatim; the paired
+   endpoint canonicalises upstream (alias-and-canonical pair dedups to
+   ONE entry in ``runtimes`` and therefore ONE entry in every rung's
+   ``missing``).
+8. Never-raises on delegate blowup: log-and-return ``None`` at scalar
+   layer; empty-path fallback envelope at endpoint layer (never 5xxs).
+9. Endpoint envelope shape (fixed key set) across every input branch,
+   including the unknown-endpoint branch.
+10. Cross-consistency with the sibling ``/feature-catalog-path`` walk:
+    same rung ``tier`` sequence rung-for-rung.
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+# ── Fixtures ───────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def enforced(monkeypatch, tmp_path):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    importlib.reload(e)
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# ── Envelope shape ─────────────────────────────────────────────────────────
+
+_FEATURES_KEYS = {
+    "from",
+    "from_label",
+    "from_rank",
+    "to",
+    "to_label",
+    "to_rank",
+    "direction",
+    "features",
+    "unknown",
+    "path",
+    "kind",
+    "count",
+    "path_length",
+    "any_missing",
+    "required_tier",
+    "required_tier_label",
+    "required_tier_rank",
+    "current_tier",
+    "current_tier_rank",
+    "grace",
+    "enforced",
+}
+_RUNTIMES_KEYS = {
+    "from",
+    "from_label",
+    "from_rank",
+    "to",
+    "to_label",
+    "to_rank",
+    "direction",
+    "runtimes",
+    "unknown",
+    "path",
+    "kind",
+    "count",
+    "path_length",
+    "any_missing",
+    "required_tier",
+    "required_tier_label",
+    "required_tier_rank",
+    "current_tier",
+    "current_tier_rank",
+    "grace",
+    "enforced",
+}
+
+
+def _get_json(client, url: str) -> dict:
+    resp = client.get(url)
+    assert resp.status_code == 200, url
+    return resp.get_json()
+
+
+# ── missing_features_at_path scalar ────────────────────────────────────────
+
+
+def test_scalar_identity_endpoints_returns_empty_path(ent):
+    """``from == to`` -> empty path (identity branch)."""
+    for tier in ent._TIER_ORDER:
+        assert ent.missing_features_at_path(tier, tier, ["fleet"]) == []
+
+
+def test_scalar_unknown_endpoint_returns_none(ent):
+    assert ent.missing_features_at_path("bogus", "pro", ["fleet"]) is None
+    assert ent.missing_features_at_path("oss", "bogus", ["fleet"]) is None
+    assert ent.missing_features_at_path("bogus_a", "bogus_b", ["fleet"]) is None
+    assert ent.missing_features_at_path("", "pro", ["fleet"]) is None
+    assert ent.missing_features_at_path(None, "pro", ["fleet"]) is None  # type: ignore[arg-type]
+
+
+def test_scalar_upgrade_path_has_rows(ent):
+    path = ent.missing_features_at_path("oss", "enterprise", ["fleet", "sso"])
+    assert isinstance(path, list) and len(path) >= 1
+    # Row shape
+    for row in path:
+        assert set(row.keys()) == {"tier", "tier_label", "tier_rank", "missing"}
+        assert isinstance(row["missing"], list)
+
+
+def test_scalar_downgrade_path_has_rows(ent):
+    path = ent.missing_features_at_path("enterprise", "oss", ["fleet", "sso"])
+    assert isinstance(path, list) and len(path) >= 1
+
+
+def test_scalar_lateral_path_single_row(ent):
+    """Same-rank different-id endpoints -> single-row path carrying the
+    ``missing`` at ``to``."""
+    same_rank_pairs = [
+        (a, b)
+        for a in ent._TIER_ORDER
+        for b in ent._TIER_ORDER
+        if a != b
+        and ent._TIER_RANK.get(a) == ent._TIER_RANK.get(b)
+        and a in ent._TIER_FEATURES
+        and b in ent._TIER_FEATURES
+    ]
+    if not same_rank_pairs:
+        pytest.skip("no same-rank pair on this build")
+    for f, t in same_rank_pairs[:3]:
+        path = ent.missing_features_at_path(f, t, ["fleet"])
+        assert isinstance(path, list) and len(path) == 1
+        assert path[0]["tier"] == t
+
+
+def test_scalar_per_rung_matches_missing_features_at(ent):
+    """Per-rung ``missing`` byte-equals ``missing_features_at(rung, bundle)``
+    for the same input -- the drift-blocker parity property."""
+    bundle = ["fleet", "sso", "otel_export"]
+    path = ent.missing_features_at_path("oss", "enterprise", bundle)
+    assert path is not None
+    for row in path:
+        assert row["missing"] == ent.missing_features_at(row["tier"], bundle)
+
+
+def test_scalar_rungs_match_feature_catalog_path(ent):
+    """Rung sequence byte-parity with :func:`feature_catalog_path` --
+    both walk the same ``_PURCHASABLE_TIERS`` filter + sort key."""
+    bundle = ["fleet"]
+    ours = ent.missing_features_at_path("oss", "enterprise", bundle)
+    catalog = ent.feature_catalog_path("oss", "enterprise")
+    assert ours is not None and catalog is not None
+    assert [r["tier"] for r in ours] == [r["tier"] for r in catalog]
+
+
+def test_scalar_empty_bundle_every_rung_empty(ent):
+    path = ent.missing_features_at_path("oss", "enterprise", [])
+    assert path is not None
+    for row in path:
+        assert row["missing"] == []
+
+
+def test_scalar_none_bundle_every_rung_empty(ent):
+    path = ent.missing_features_at_path("oss", "enterprise", None)
+    assert path is not None
+    for row in path:
+        assert row["missing"] == []
+
+
+def test_scalar_non_iterable_bundle_every_rung_empty(ent):
+    path = ent.missing_features_at_path("oss", "enterprise", 123)
+    assert path is not None
+    for row in path:
+        assert row["missing"] == []
+
+
+def test_scalar_unknown_token_surfaces_every_rung(ent):
+    path = ent.missing_features_at_path("oss", "enterprise", ["bogus_id"])
+    assert path is not None
+    for row in path:
+        assert row["missing"] == ["bogus_id"]
+
+
+def test_scalar_grace_independence(ent, enforced):
+    bundle = ["fleet", "sso"]
+    a = ent.missing_features_at_path("oss", "enterprise", bundle)
+    b = enforced.missing_features_at_path("oss", "enterprise", bundle)
+    assert a == b
+
+
+def test_scalar_upgrade_missing_set_monotone_shrink(ent):
+    """As you climb rungs, ``missing`` shrinks or stays equal (each rung
+    grants a superset of prior rungs' grants)."""
+    bundle = sorted(ent.PAID_FEATURES)
+    path = ent.missing_features_at_path("oss", "enterprise", bundle)
+    assert path is not None
+    prev_set: set = set(bundle) | set()
+    for row in path:
+        cur = set(row["missing"])
+        assert cur.issubset(prev_set), (row["tier"], cur, prev_set)
+        prev_set = cur
+
+
+def test_scalar_never_raises_on_delegate_blowup(ent, monkeypatch):
+    def _boom(*a, **kw):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(ent, "missing_features_at", _boom)
+    assert ent.missing_features_at_path("oss", "pro", ["fleet"]) is None
+
+
+# ── missing_runtimes_at_path scalar ────────────────────────────────────────
+
+
+def test_scalar_runtimes_identity_empty(ent):
+    for tier in ent._TIER_ORDER:
+        assert ent.missing_runtimes_at_path(tier, tier, ["claude_code"]) == []
+
+
+def test_scalar_runtimes_unknown_endpoint(ent):
+    assert ent.missing_runtimes_at_path("bogus", "pro", ["claude_code"]) is None
+    assert ent.missing_runtimes_at_path("oss", "bogus", ["claude_code"]) is None
+
+
+def test_scalar_runtimes_upgrade_path_rows(ent):
+    path = ent.missing_runtimes_at_path("oss", "enterprise", ["claude_code"])
+    assert isinstance(path, list) and len(path) >= 1
+    for row in path:
+        assert set(row.keys()) == {"tier", "tier_label", "tier_rank", "missing"}
+
+
+def test_scalar_runtimes_per_rung_matches_missing_runtimes_at(ent):
+    bundle = ["claude_code", "openclaw"]
+    path = ent.missing_runtimes_at_path("oss", "enterprise", bundle)
+    assert path is not None
+    for row in path:
+        assert row["missing"] == ent.missing_runtimes_at(row["tier"], bundle)
+
+
+def test_scalar_runtimes_strict_alias_posture(ent):
+    """Scalar layer does NOT resolve aliases -- ``claude-code`` surfaces
+    in every rung's ``missing`` verbatim (matches ``missing_runtimes_at``
+    docstring; endpoint canonicalises upstream)."""
+    path = ent.missing_runtimes_at_path("oss", "enterprise", ["claude-code"])
+    assert path is not None
+    for row in path:
+        assert "claude-code" in row["missing"]
+
+
+def test_scalar_runtimes_grace_independence(ent, enforced):
+    bundle = ["claude_code", "cursor"]
+    a = ent.missing_runtimes_at_path("oss", "enterprise", bundle)
+    b = enforced.missing_runtimes_at_path("oss", "enterprise", bundle)
+    assert a == b
+
+
+def test_scalar_runtimes_never_raises(ent, monkeypatch):
+    def _boom(*a, **kw):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(ent, "missing_runtimes_at", _boom)
+    assert ent.missing_runtimes_at_path("oss", "pro", ["claude_code"]) is None
+
+
+# ── Endpoint: envelope shape ───────────────────────────────────────────────
+
+
+def test_endpoint_features_envelope_shape(client):
+    body = _get_json(
+        client,
+        "/api/entitlement/missing-features-at-path?from=oss&to=enterprise&features=fleet,sso",
+    )
+    assert set(body.keys()) == _FEATURES_KEYS
+    assert body["kind"] == "features"
+    assert body["from"] == "oss"
+    assert body["to"] == "enterprise"
+
+
+def test_endpoint_runtimes_envelope_shape(client):
+    body = _get_json(
+        client,
+        "/api/entitlement/missing-runtimes-at-path?from=oss&to=enterprise&runtimes=claude_code",
+    )
+    assert set(body.keys()) == _RUNTIMES_KEYS
+    assert body["kind"] == "runtimes"
+
+
+def test_endpoint_features_missing_from_still_200(client):
+    """Never 4xxs on missing ``from=``."""
+    resp = client.get("/api/entitlement/missing-features-at-path?to=pro&features=fleet")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert set(body.keys()) == _FEATURES_KEYS
+    assert body["path"] == []
+    assert body["direction"] == "unknown"
+
+
+def test_endpoint_features_missing_to_still_200(client):
+    resp = client.get(
+        "/api/entitlement/missing-features-at-path?from=oss&features=fleet"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["path"] == []
+    assert body["direction"] == "unknown"
+
+
+def test_endpoint_features_unknown_tier_still_200(client):
+    resp = client.get(
+        "/api/entitlement/missing-features-at-path?from=bogus&to=pro&features=fleet"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert set(body.keys()) == _FEATURES_KEYS
+    assert body["path"] == []
+    assert body["direction"] == "unknown"
+
+
+def test_endpoint_features_identity_still_200(client):
+    resp = client.get(
+        "/api/entitlement/missing-features-at-path?from=oss&to=oss&features=fleet"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["direction"] == "identity"
+    assert body["path"] == []
+
+
+def test_endpoint_features_upgrade_direction(client, ent):
+    body = _get_json(
+        client,
+        "/api/entitlement/missing-features-at-path?from=oss&to=enterprise&features=fleet",
+    )
+    if body["from_rank"] == body["to_rank"]:
+        pytest.skip("no rank difference on this build")
+    assert body["direction"] == "upgrade"
+    assert body["path_length"] == len(body["path"])
+    assert body["path_length"] >= 1
+
+
+def test_endpoint_features_downgrade_direction(client, ent):
+    body = _get_json(
+        client,
+        "/api/entitlement/missing-features-at-path?from=enterprise&to=oss&features=fleet",
+    )
+    if body["from_rank"] == body["to_rank"]:
+        pytest.skip("no rank difference on this build")
+    assert body["direction"] == "downgrade"
+
+
+# ── Endpoint: per-rung parity with sibling ``/missing-features-at`` ────────
+
+
+def test_endpoint_features_per_rung_matches_missing_features_at(client):
+    body = _get_json(
+        client,
+        "/api/entitlement/missing-features-at-path?from=oss&to=enterprise&features=fleet,sso",
+    )
+    for row in body["path"]:
+        sibling = _get_json(
+            client,
+            f"/api/entitlement/missing-features-at?tier={row['tier']}&features=fleet,sso",
+        )
+        assert row["missing"] == sibling["missing"], row["tier"]
+
+
+def test_endpoint_runtimes_per_rung_matches_missing_runtimes_at(client):
+    body = _get_json(
+        client,
+        "/api/entitlement/missing-runtimes-at-path?from=oss&to=enterprise&runtimes=claude_code",
+    )
+    for row in body["path"]:
+        sibling = _get_json(
+            client,
+            f"/api/entitlement/missing-runtimes-at?tier={row['tier']}&runtimes=claude_code",
+        )
+        assert row["missing"] == sibling["missing"], row["tier"]
+
+
+# ── Endpoint: runtime alias canonicalisation upstream ──────────────────────
+
+
+def test_endpoint_runtimes_alias_canonicalised(client):
+    body = _get_json(
+        client,
+        "/api/entitlement/missing-runtimes-at-path?from=oss&to=enterprise&runtimes=claude-code",
+    )
+    # Alias resolved upstream -> ``runtimes`` list carries canonical.
+    assert body["runtimes"] == ["claude_code"]
+    # Every rung's ``missing`` is off the canonical, not the alias.
+    for row in body["path"]:
+        assert "claude-code" not in row["missing"]
+
+
+def test_endpoint_runtimes_alias_and_canonical_dedup_to_one(client):
+    body = _get_json(
+        client,
+        "/api/entitlement/missing-runtimes-at-path?from=oss&to=enterprise&runtimes=claude-code,claude_code",
+    )
+    assert body["runtimes"] == ["claude_code"]
+    assert body["count"] == 1
+    # Dedup propagates into every rung's ``missing`` list.
+    for row in body["path"]:
+        assert row["missing"].count("claude_code") <= 1
+
+
+# ── Endpoint: rung sequence byte-parity with ``/feature-catalog-path`` ─────
+
+
+def test_endpoint_features_rung_sequence_matches_feature_catalog_path(client):
+    ours = _get_json(
+        client,
+        "/api/entitlement/missing-features-at-path?from=oss&to=enterprise&features=fleet",
+    )
+    sibling = _get_json(
+        client,
+        "/api/entitlement/feature-catalog-path?from=oss&to=enterprise",
+    )
+    assert [r["tier"] for r in ours["path"]] == [r["tier"] for r in sibling["path"]]
+
+
+# ── Endpoint: rollup fields ────────────────────────────────────────────────
+
+
+def test_endpoint_features_any_missing_true_when_row_missing_nonempty(client):
+    body = _get_json(
+        client,
+        "/api/entitlement/missing-features-at-path?from=oss&to=cloud_starter&features=sso",
+    )
+    # SSO is enterprise-only, so cloud_starter rung's ``missing`` is
+    # non-empty -> rollup True.
+    assert body["any_missing"] is True
+
+
+def test_endpoint_features_any_missing_false_on_all_granted(client):
+    body = _get_json(
+        client,
+        "/api/entitlement/missing-features-at-path?from=oss&to=enterprise&features=sessions",
+    )
+    # ``sessions`` is a FREE feature -> granted at every rung -> no rung
+    # has anything missing.
+    assert body["any_missing"] is False
+
+
+def test_endpoint_features_required_tier_folds_off_known_bundle(client):
+    body = _get_json(
+        client,
+        "/api/entitlement/missing-features-at-path?from=oss&to=enterprise&features=fleet",
+    )
+    # required_tier should point at the cheapest tier granting ``fleet``.
+    assert body["required_tier"] is not None
+    assert body["required_tier_rank"] >= 0
+
+
+def test_endpoint_features_unknown_tokens_surface_in_unknown(client):
+    body = _get_json(
+        client,
+        "/api/entitlement/missing-features-at-path?from=oss&to=pro&features=bogus_id",
+    )
+    assert body["unknown"] == ["bogus_id"]
+    # Unknown-only bundle -> nothing to fold for required_tier.
+    assert body["required_tier"] is None
+
+
+# ── Endpoint: never-5xx guard ──────────────────────────────────────────────
+
+
+def test_endpoint_features_never_5xx_on_helper_blowup(client, monkeypatch):
+    import clawmetry.entitlements as _ent
+
+    def _boom(*a, **kw):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(_ent, "missing_features_at_path", _boom)
+    resp = client.get(
+        "/api/entitlement/missing-features-at-path?from=oss&to=pro&features=fleet"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert set(body.keys()) == _FEATURES_KEYS
+    assert body["path"] == []
+
+
+def test_endpoint_runtimes_never_5xx_on_helper_blowup(client, monkeypatch):
+    import clawmetry.entitlements as _ent
+
+    def _boom(*a, **kw):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(_ent, "missing_runtimes_at_path", _boom)
+    resp = client.get(
+        "/api/entitlement/missing-runtimes-at-path?from=oss&to=pro&runtimes=claude_code"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert set(body.keys()) == _RUNTIMES_KEYS
+    assert body["path"] == []


### PR DESCRIPTION
## Summary

Path-shaped complement of the recently-landed `missing_features_at` / `missing_runtimes_at` (#4517) and the currently-pending batch siblings on #4523. Fixes ONE bundle and sweeps across every rung between `from` and `to`, returning one row per rung with the per-item denial list at that rung plus the surrounding path envelope. The upgrade-walkthrough tooltip column ("at which tier does each of fleet + sso unlock?") hydrates off ONE call instead of first walking `/tier-path` and then N calls to `/missing-features-at`.

### Scalar helpers (`clawmetry/entitlements.py`)

- `missing_features_at_path(from_tier, to_tier, features) -> list | None`
- `missing_runtimes_at_path(from_tier, to_tier, runtimes) -> list | None`

Per-rung row shape `{tier, tier_label, tier_rank, missing}` where `missing` byte-equals `missing_features_at(rung, features)` / `missing_runtimes_at(rung, runtimes)` for the same (rung, bundle) pair -- parity test pins this so the scalar, batch and path what-if complement helpers cannot drift. Walk semantics (`_PURCHASABLE_TIERS` filter + sort key + destination-sibling exclusion) byte-parity with `feature_catalog_path` and every other `_path` sibling. Direction detection: upgrade / downgrade / lateral / identity. Unknown-endpoint short-circuit to `None`. Runtime scalar keeps strict-alias posture inherited from `missing_runtimes_at` (`claude-code` surfaces in every rung's `missing` verbatim); alias tolerance lives on the paired endpoint. Grace-independent by construction (delegates to the `_at` sibling backed by `_hypothetical_entitlement`). Never raises: log + return `None` on delegate blowup.

### Endpoints (`routes/entitlement.py`, `bp_entitlement`)

```
GET /api/entitlement/missing-features-at-path?from=&to=&features=
GET /api/entitlement/missing-runtimes-at-path?from=&to=&runtimes=
```

Envelope mirrors `/feature-catalog-path` for the walk metadata (`from` / `from_label` / `from_rank` / `to` / `to_label` / `to_rank` / `direction` / `path`) and adds the axis-shared bundle metadata (`features`/`runtimes` / `unknown` / `kind` / `count` / `path_length` / `any_missing`), the bundle rollup (`required_tier{,_label,_rank}`) and the live resolver envelope (`current_tier{,_rank}` / `grace` / `enforced`). Runtime endpoint canonicalises aliases upstream of the strict scalar so `claude-code,claude_code` dedups to ONE entry in `runtimes` and therefore ONE entry in every rung's `missing` list. Never 4xxs (missing / blank / unknown endpoints -> 200 with `path=[]` and `direction="unknown"`); never 5xxs (helper blowup collapses to the empty-path fallback envelope via `_missing_bundle_at_path_fallback`).

### Tests (`tests/test_entitlement_missing_features_runtimes_at_path.py`)

40 hermetic unit tests covering scalar walk semantics parity with `feature_catalog_path`, per-rung `missing` parity with the sibling `_at` scalar, direction detection, identity / unknown-endpoint short-circuits, empty / None / non-iterable / typo bundle folds, grace-independence (grace vs enforce fixture parity), strict runtime alias posture at scalar layer, endpoint envelope key set, never-4xx / never-5xx, cross-endpoint parity vs `/missing-features-at` / `/missing-runtimes-at` per row, alias canonicalisation upstream, alias-and-canonical dedup to ONE row, rung sequence byte-parity with `/feature-catalog-path`, `any_missing` / `required_tier` rollups, monotone-shrink invariant on the upgrade path.

Additive; nothing existing changes. Grace-mode posture preserved (no gate enforcement added; the path surfaces only what the static per-rung grant maps say at each hypothetical rung). Does NOT depend on the pending #4523 -- delegates only to the already-merged `missing_features_at` / `missing_runtimes_at` scalars from #4517.

## Test plan

- [x] `python3 -m py_compile clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_missing_features_runtimes_at_path.py` — passes
- [x] `python3 -m ruff check --select=F,E9,B` on the changed files — All checks passed
- [x] `python3 -m pytest tests/test_entitlement_missing_features_runtimes_at_path.py -q` — 40 passed
- [x] Sibling regression sweep — `pytest tests/test_entitlement_missing_features_runtimes_at.py tests/test_entitlement_missing_features_runtimes.py -q` — 170 passed alongside the new 40, no regressions
- [ ] Full CI matrix

## Local operator verification checklist

The web agent cannot touch the live daemon, `~/.openclaw`, the cloud snapshot, or a browser. Please verify on-host before flipping this out of draft:

- [ ] Copy the changed source files (and the new test) into the installed package:
  - `cp clawmetry/entitlements.py ~/.clawmetry/lib/python*/site-packages/clawmetry/entitlements.py`
  - `cp routes/entitlement.py ~/.clawmetry/lib/python*/site-packages/routes/entitlement.py`
  - `find ~/.clawmetry/lib/python*/site-packages/{clawmetry,routes} -name __pycache__ -exec rm -rf {} +`
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` (or the equivalent supervisor kick on non-macOS hosts)
- [ ] Happy-path features (upgrade path): `curl -s 'http://localhost:8900/api/entitlement/missing-features-at-path?from=oss&to=enterprise&features=fleet,sso' | jq '.direction, [.path[]|{tier, missing}]'` — expect `"upgrade"`; per-rung `missing` shrinks (or stays equal) as you climb; `oss`-adjacent rung includes `fleet,sso`; `enterprise` rung is `[]`
- [ ] Happy-path runtimes with alias: `curl -s 'http://localhost:8900/api/entitlement/missing-runtimes-at-path?from=oss&to=enterprise&runtimes=claude-code' | jq '.runtimes, [.path[]|{tier, missing}]'` — expect `["claude_code"]` (alias canonicalised); no rung's `missing` carries `claude-code`
- [ ] Alias-and-canonical dedup: `curl -s 'http://localhost:8900/api/entitlement/missing-runtimes-at-path?from=oss&to=pro&runtimes=claude-code,claude_code' | jq '.runtimes,.count'` — expect `["claude_code"]` and `1` (dedup to ONE row)
- [ ] Never-4xx on missing endpoints: `curl -i 'http://localhost:8900/api/entitlement/missing-features-at-path?features=fleet'` — expect **200** with `"path": []` and `"direction": "unknown"` (not 400)
- [ ] Never-4xx on unknown endpoints: `curl -i 'http://localhost:8900/api/entitlement/missing-features-at-path?from=bogus_a&to=bogus_b&features=fleet'` — expect **200** with `"path": []` and `"direction": "unknown"`
- [ ] Identity: `curl -s 'http://localhost:8900/api/entitlement/missing-features-at-path?from=oss&to=oss&features=fleet' | jq '.direction, .path'` — expect `"identity"` and `[]`
- [ ] Cross-endpoint parity vs `/missing-features-at`: pick a rung from the path and confirm `.missing` byte-equals `curl 'http://localhost:8900/api/entitlement/missing-features-at?tier=<rung>&features=fleet,sso'`'s `.missing`
- [ ] Rung sequence parity vs `/feature-catalog-path`: `.path[].tier` in the missing-at-path response matches `.path[].tier` in `curl '.../feature-catalog-path?from=oss&to=enterprise'` byte-for-byte
- [ ] Browser check: open the paywall / upgrade-walkthrough tile if wired and confirm no regression on `/missing-features-at` or `/feature-catalog-path` (this PR only adds; nothing existing is touched)
- [ ] Decrypt the live cloud snapshot and confirm the new endpoints are reachable through the relay (read-only handlers on `bp_entitlement`, no relay changes needed)

Operator owns: version bump, `[RELEASE]` PR, tag, PyPI push, and ready-for-review flip.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YRKZXP8jK9Nf139KKudPrZ)_