### PR TITLE
feat(entitlement): missing_features_at_path_batch + missing_runtimes_at_path_batch + endpoints

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -7023,6 +7023,238 @@ def missing_runtimes_at_path(
         return None
 
 
+def missing_features_at_path_batch(
+    from_tier: str, to_tiers, features
+) -> dict | None:
+    """Batch sibling of :func:`missing_features_at_path`: per-rung denial
+    lists for a caller-supplied subset of destination tiers all walked
+    from a single ``from_tier`` under ONE feature bundle in ONE round-
+    trip.
+
+    Multi-destination twin of :func:`tier_unlocks_path_batch` (same
+    fan-out shape, per-item denial body instead of marginal-grant body)
+    and complement-shaped sibling of :func:`tier_locks_path_batch`
+    (unlocks and locks each answer "what marginal grants / losses at
+    every rung"; this answers "which of MY bundle is still locked at
+    every rung"). Lets an upgrade-comparison surface render "from my
+    current rung, here are the 3 tiers I'm considering -- for the
+    bundle {fleet, sso} show me which items are still locked at every
+    rung climbed to reach each" off ONE call instead of N calls to
+    :func:`missing_features_at_path`.
+
+    Per-destination row shape mirrors :func:`tier_unlocks_path_batch`
+    exactly with the axis-shared ``path`` slot bound to the per-rung
+    denial list::
+
+        {
+          "to":         "<tier id>",
+          "to_label":   "...",
+          "to_rank":    <int>,
+          "direction":  "upgrade" | "downgrade" | "lateral" | "identity",
+          "path":       [<missing_features_at_path row>, ...],
+        }
+
+    Each ``path`` row is byte-identical to a row from
+    :func:`missing_features_at_path` for the same ``(from_tier, to,
+    features)`` triple -- a parity test pins this so the scalar and
+    batch path what-if complement helpers cannot drift. The walked
+    rungs are destination-specific (the path's rung set depends on
+    ``to``), so per-destination ``path`` lengths can legitimately
+    differ -- this matches :func:`tier_unlocks_path_batch` /
+    :func:`tier_locks_path_batch` / :func:`capacity_diff_path_batch` /
+    :func:`tier_spec_path_batch`'s posture and differs from
+    :func:`feature_spec_path_batch` / :func:`runtime_spec_path_batch`
+    whose rungs are axis-id-agnostic.
+
+    Shape::
+
+        {
+          "tiers": [
+            {"to": "<id>", "to_label": ..., "to_rank": ..., "direction": ..., "path": [...]},
+            ...
+          ],
+          "unknown": ["bogus_id", ...],
+        }
+
+    Supplied destination ids are normalised via :func:`_normalise_csv`
+    (whitespace stripped, lowercased, duplicates dropped, first-seen
+    order preserved). Unknown ids are echoed in ``unknown[]`` instead
+    of short-circuiting -- a partially-bad caller still gets paths
+    back for the valid ids alongside a list of what was dropped,
+    matching :func:`tier_unlocks_path_batch` /
+    :func:`tier_locks_path_batch`'s posture. ``trial`` IS accepted as
+    a destination (excluded from the walked intermediate rungs the
+    way :func:`missing_features_at_path` already excludes it, but is
+    a valid endpoint via the lateral / identity branches).
+
+    Bundle-fold semantics inherit :func:`missing_features_at_path`
+    byte-for-byte: empty / ``None`` / non-iterable ``features`` ->
+    every rung of every destination carries ``missing=[]``; unknown
+    / non-string / empty-string items surface in every rung's
+    ``missing`` in canonicalised form (typo posture inherited from
+    the singular scalar). The bundle is canonicalised ONCE at the
+    top of the fold so every per-destination delegate sees the same
+    iterable (a generator / one-shot iterable is materialised so the
+    fan-out over multiple destinations does not consume it).
+
+    Returns ``None`` for empty / unknown ``from_tier`` (caller
+    renders "unknown tier" / 404).
+
+    Resolver-independent: delegates per-destination to
+    :func:`missing_features_at_path`, which walks the static
+    :data:`_PURCHASABLE_TIERS` ladder and folds per-rung denials via
+    :func:`missing_features_at` -- so grace vs enforce yields
+    byte-identical rows. Never raises: per-destination failures
+    short-circuit that id into ``unknown[]`` and the rest of the
+    batch keeps building; a whole-fold blowup collapses to ``None``
+    at scalar layer.
+    """
+    try:
+        f = (from_tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if f not in _TIER_FEATURES:
+        return None
+    candidates = _normalise_csv(to_tiers)
+    try:
+        if features is None:
+            items: list = []
+        else:
+            items = list(features)
+    except TypeError:
+        items = []
+    rows: list[dict] = []
+    unknown: list[str] = []
+    from_rank = _TIER_RANK.get(f, -1)
+    for tid in candidates:
+        if tid not in _TIER_FEATURES:
+            unknown.append(tid)
+            continue
+        try:
+            path = missing_features_at_path(f, tid, items)
+        except Exception as exc:
+            logger.warning(
+                "entitlements: missing_features_at_path_batch row %r failed: %s",
+                tid,
+                exc,
+            )
+            unknown.append(tid)
+            continue
+        if path is None:
+            unknown.append(tid)
+            continue
+        to_rank = _TIER_RANK.get(tid, -1)
+        if f == tid:
+            direction = "identity"
+        elif from_rank == to_rank:
+            direction = "lateral"
+        elif to_rank > from_rank:
+            direction = "upgrade"
+        else:
+            direction = "downgrade"
+        rows.append(
+            {
+                "to": tid,
+                "to_label": tier_label(tid),
+                "to_rank": to_rank,
+                "direction": direction,
+                "path": path,
+            }
+        )
+    return {"tiers": rows, "unknown": unknown}
+
+
+def missing_runtimes_at_path_batch(
+    from_tier: str, to_tiers, runtimes
+) -> dict | None:
+    """Runtime-axis twin of :func:`missing_features_at_path_batch`:
+    per-rung denial lists for a caller-supplied subset of destination
+    tiers all walked from a single ``from_tier`` under ONE runtime
+    bundle in ONE round-trip.
+
+    Pairs with :func:`missing_features_at_path_batch` the same way
+    :func:`missing_runtimes_at_path` pairs with
+    :func:`missing_features_at_path`. Together the two path-batch
+    complement helpers let an upgrade-comparison surface render "from
+    my current rung, here are the 3 tiers I'm considering -- for the
+    bundle {claude_code, cursor} show me which items are still locked
+    at every rung climbed to reach each" off TWO calls instead of
+    2 * N calls to the singular scalars.
+
+    Per-destination row shape mirrors
+    :func:`missing_features_at_path_batch` with each ``path`` row
+    bound to a :func:`missing_runtimes_at_path` row (``{tier,
+    tier_label, tier_rank, missing}``). Strict alias posture is
+    inherited from the singular scalar (no
+    :func:`canonical_runtime` resolution at scalar layer;
+    ``claude-code`` surfaces in every rung's ``missing`` verbatim).
+    Alias tolerance lives on the paired
+    ``/api/entitlement/missing-runtimes-at-path-batch`` endpoint,
+    which canonicalises per-token upstream -- matches the sibling
+    :func:`missing_runtimes_at_path` /
+    ``/missing-runtimes-at-path`` split exactly.
+
+    Walk semantics, direction semantics, bundle-fold semantics,
+    resolver-independence and never-raise posture all match
+    :func:`missing_features_at_path_batch` -- see that helper's
+    docstring. Rung walk is byte-stable against the rest of the
+    ``_path_batch`` family.
+    """
+    try:
+        f = (from_tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if f not in _TIER_FEATURES:
+        return None
+    candidates = _normalise_csv(to_tiers)
+    try:
+        if runtimes is None:
+            items: list = []
+        else:
+            items = list(runtimes)
+    except TypeError:
+        items = []
+    rows: list[dict] = []
+    unknown: list[str] = []
+    from_rank = _TIER_RANK.get(f, -1)
+    for tid in candidates:
+        if tid not in _TIER_FEATURES:
+            unknown.append(tid)
+            continue
+        try:
+            path = missing_runtimes_at_path(f, tid, items)
+        except Exception as exc:
+            logger.warning(
+                "entitlements: missing_runtimes_at_path_batch row %r failed: %s",
+                tid,
+                exc,
+            )
+            unknown.append(tid)
+            continue
+        if path is None:
+            unknown.append(tid)
+            continue
+        to_rank = _TIER_RANK.get(tid, -1)
+        if f == tid:
+            direction = "identity"
+        elif from_rank == to_rank:
+            direction = "lateral"
+        elif to_rank > from_rank:
+            direction = "upgrade"
+        else:
+            direction = "downgrade"
+        rows.append(
+            {
+                "to": tid,
+                "to_label": tier_label(tid),
+                "to_rank": to_rank,
+                "direction": direction,
+                "path": path,
+            }
+        )
+    return {"tiers": rows, "unknown": unknown}
+
+
 def has_all(
     *,
     features=None,

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -6160,6 +6160,323 @@ def api_entitlement_missing_runtimes_at_path():
         )
 
 
+def _missing_bundle_at_path_batch_fallback(
+    axis: str,
+    from_tier: str,
+    to_tokens: list,
+    tokens: list,
+) -> dict:
+    """OSS-free / never-5xx envelope for the path-batch complement
+    endpoints ``/api/entitlement/missing-features-at-path-batch`` and
+    ``/api/entitlement/missing-runtimes-at-path-batch``.
+
+    Batch-path sibling of :func:`_missing_bundle_at_path_fallback`. On
+    any resolver / helper blowup the endpoint still returns 200 with
+    the same envelope shape as the happy path but with ``tiers=[]``
+    and every rollup zeroed / dropped so a pricing-comparison surface
+    that lost the resolver doesn't silently render a denial matrix it
+    can no longer justify. ``from`` / ``unknown_tiers`` echo the
+    caller's input so a debugging tooltip can still surface the
+    dropped destinations, and ``unknown`` echoes the axis tokens.
+    """
+    return {
+        "from": from_tier,
+        "from_label": None,
+        "from_rank": -1,
+        axis: [],
+        "unknown": list(tokens),
+        "unknown_tiers": list(to_tokens),
+        "kind": axis,
+        "count": 0,
+        "tiers": [],
+        "required_tier": None,
+        "required_tier_label": None,
+        "required_tier_rank": -1,
+        "current_tier": "oss",
+        "current_tier_rank": 0,
+        "grace": True,
+        "enforced": False,
+    }
+
+
+def _missing_bundle_at_path_batch_body(axis: str) -> dict:
+    """Happy-path body builder for
+    ``/api/entitlement/missing-features-at-path-batch`` /
+    ``/api/entitlement/missing-runtimes-at-path-batch``.
+
+    Batch-path sibling of :func:`_missing_bundle_at_path_body` (which
+    walks the rungs between ONE ``(from, to)`` pair): this walks the
+    rungs between ONE ``from`` and N candidate destinations in ONE
+    round-trip. Multi-destination twin of the path-shaped
+    ``/tier-unlocks-path-batch`` (same fan-out shape, per-item denial
+    body instead of marginal-grant body) and matrix-shaped cousin of
+    ``/missing-features-at-batch`` (which fans out over perspective
+    tiers rather than destinations).
+
+    Envelope shape (byte-stable across every input branch)::
+
+        {
+          "from":               "<tier id>",
+          "from_label":         "...",
+          "from_rank":          <int>,
+          "features"/"runtimes":[<known ids>],
+          "unknown":            [<axis tokens dropped>],
+          "unknown_tiers":      [<destination ids dropped>],
+          "kind":               "features"/"runtimes",
+          "count":              <int>,                # len(known)
+          "tiers": [
+            {
+              "to":          "<id>",
+              "to_label":    "...",
+              "to_rank":     <int>,
+              "direction":   "upgrade" | "downgrade" | "lateral" | "identity",
+              "path":        [<missing_*_at_path row>, ...],
+              "path_length": <int>,
+              "any_missing": <bool>,
+            },
+            ...
+          ],
+          "required_tier":       "<id>" | null,
+          "required_tier_label": "<label>" | null,
+          "required_tier_rank":  <int>,               # -1 when null
+          "current_tier":        "<live tier id>",
+          "current_tier_rank":   <int>,
+          "grace":               <bool>,
+          "enforced":            <bool>,
+        }
+
+    Each ``tiers[].path`` row byte-equals a row from
+    ``/missing-features-at-path?from=<from>&to=<to>&features=<bundle>``'s
+    ``.path`` (and the runtime twin) for the same ``(from, to,
+    bundle)`` triple -- a parity test pins this so the scalar and
+    batch path what-if complement helpers cannot drift.
+
+    Runtime-axis alias canonicalisation is applied per-token upstream
+    of the strict scalar (:func:`missing_runtimes_at_path_batch`
+    inherits :func:`missing_runtimes_at_path`'s strict-alias posture
+    at scalar layer), matching the sibling ``/missing-runtimes-at-path``
+    upstream-canonicalise pattern -- alias-and-canonical pair dedups
+    to ONE entry in ``runtimes`` before the scalar sees it, so it
+    also dedups to ONE entry in every rung's ``missing`` list.
+
+    Per-destination ``any_missing`` is ``True`` iff any rung in that
+    destination's ``path`` has a non-empty ``missing`` list OR the
+    top-level ``unknown`` list is non-empty (matches the singular
+    ``/missing-features-at-path`` rollup semantics applied per
+    destination). ``required_tier`` folds through
+    :func:`min_tier_for_features` / :func:`min_tier_for_runtimes`
+    against the KNOWN-only subset (matches the sibling
+    ``/missing-features-at-path`` envelope's rollup contract),
+    independent of any per-destination endpoint.
+
+    Never 4xxs (missing / blank / unknown ``from`` -> 200 with
+    ``tiers=[]``, matching the sibling ``/missing-features-at-batch``
+    posture -- a pricing-comparison matrix binds ``tiers`` directly
+    without a pre-validation round-trip). Never 5xxs: any helper
+    blowup collapses to :func:`_missing_bundle_at_path_batch_fallback`.
+    """
+    from clawmetry import entitlements as _ent
+
+    raw_from = request.args.get("from")
+    from_tier = (raw_from or "").strip().lower()
+    to_tokens = _parse_csv_arg("to")
+    param = "features" if axis == "features" else "runtimes"
+    tokens = _parse_csv_arg(param)
+
+    known: list = []
+    unknown: list = []
+    if axis == "features":
+        for fid in tokens:
+            if fid in _ent.ALL_FEATURES:
+                if fid not in known:
+                    known.append(fid)
+            elif fid not in unknown:
+                unknown.append(fid)
+        canon_tokens: list = list(tokens)
+        required = _ent.min_tier_for_features(known) if known else None
+    else:
+        canon_tokens = []
+        canon_seen: set = set()
+        for rid_raw in tokens:
+            rid = _ent.canonical_runtime(rid_raw) or rid_raw
+            if rid in canon_seen:
+                continue
+            canon_seen.add(rid)
+            canon_tokens.append(rid)
+            if rid in _ent.ALL_RUNTIMES:
+                if rid not in known:
+                    known.append(rid)
+            elif rid not in unknown:
+                unknown.append(rid_raw)
+        required = _ent.min_tier_for_runtimes(known) if known else None
+
+    if axis == "features":
+        batch = _ent.missing_features_at_path_batch(
+            from_tier, to_tokens, canon_tokens
+        )
+    else:
+        batch = _ent.missing_runtimes_at_path_batch(
+            from_tier, to_tokens, canon_tokens
+        )
+
+    env = _resolver_envelope(_ent)
+    req_rank = _ent.tier_rank(required) if required else -1
+    required_label = _ent.tier_label(required) if required else None
+
+    if batch is None:
+        # Unknown / blank ``from`` -- fall through to the empty-tiers envelope
+        # so the client never 4xxs, matching the ``/missing-*-at-batch``
+        # posture. ``unknown_tiers`` still echoes the caller's ``to=`` set for
+        # debugging.
+        return {
+            "from": from_tier,
+            "from_label": None,
+            "from_rank": -1,
+            axis: known,
+            "unknown": unknown,
+            "unknown_tiers": list(to_tokens),
+            "kind": axis,
+            "count": len(known),
+            "tiers": [],
+            "required_tier": required,
+            "required_tier_label": required_label,
+            "required_tier_rank": req_rank,
+            "current_tier": env["current_tier"],
+            "current_tier_rank": env["current_tier_rank"],
+            "grace": env["grace"],
+            "enforced": env["enforced"],
+        }
+
+    tiers_out: list[dict] = []
+    for row in batch.get("tiers", []) or []:
+        try:
+            path = list(row.get("path", []) or [])
+        except AttributeError:
+            continue
+        any_missing = bool(unknown) or any(
+            bool(r.get("missing")) for r in path
+        )
+        tiers_out.append(
+            {
+                "to": row.get("to"),
+                "to_label": row.get("to_label"),
+                "to_rank": row.get("to_rank", -1),
+                "direction": row.get("direction"),
+                "path": path,
+                "path_length": len(path),
+                "any_missing": any_missing,
+            }
+        )
+
+    return {
+        "from": from_tier,
+        "from_label": _ent.tier_label(from_tier),
+        "from_rank": _ent.tier_rank(from_tier),
+        axis: known,
+        "unknown": unknown,
+        "unknown_tiers": list(batch.get("unknown", []) or []),
+        "kind": axis,
+        "count": len(known),
+        "tiers": tiers_out,
+        "required_tier": required,
+        "required_tier_label": required_label,
+        "required_tier_rank": req_rank,
+        "current_tier": env["current_tier"],
+        "current_tier_rank": env["current_tier_rank"],
+        "grace": env["grace"],
+        "enforced": env["enforced"],
+    }
+
+
+@bp_entitlement.route("/api/entitlement/missing-features-at-path-batch")
+def api_entitlement_missing_features_at_path_batch():
+    """``GET /api/entitlement/missing-features-at-path-batch?from=<id>&to=a,b,c&features=x,y,z``
+    -- batch sibling of ``/api/entitlement/missing-features-at-path``.
+
+    Where ``/missing-features-at-path`` walks the rungs between ONE
+    ``(from, to)`` pair under ONE feature bundle, this walks the
+    rungs between ONE ``from`` and N candidate ``to`` tiers under
+    ONE bundle in ONE round-trip. Pairs with
+    ``/missing-features-at-path`` the same way
+    ``/tier-unlocks-path-batch`` pairs with ``/tier-unlocks-path``:
+    scalar -> matrix in one call. Multi-destination twin of
+    ``/tier-unlocks-path-batch`` (same fan-out shape, per-item denial
+    body instead of marginal-grant body) and matrix-shaped cousin of
+    ``/missing-features-at-batch`` (which fans out over perspective
+    tiers rather than destinations).
+
+    Each row in ``tiers[].path`` is byte-identical to a row from
+    ``/missing-features-at-path?from=<from>&to=<to>&features=<bundle>``'s
+    ``.path`` for the same triple -- pinned by the parity tests so
+    the scalar and batch path accessors cannot drift. Per-destination
+    path lengths can legitimately differ (the rungs walked depend on
+    the destination), matching ``/tier-unlocks-path-batch`` /
+    ``/tier-locks-path-batch`` / ``/capacity-diff-path-batch``'s
+    posture.
+
+    Envelope shape is fully documented on
+    :func:`_missing_bundle_at_path_batch_body`. ``trial`` IS accepted
+    as a destination (excluded from the walked intermediate rungs the
+    way ``/missing-features-at-path`` already excludes it, but is a
+    valid endpoint via the lateral / identity branches).
+
+    Never 4xxs (missing / blank / unknown ``from``, or empty / all-
+    unknown destination CSV -> 200 with ``tiers=[]``, matching the
+    sibling ``/missing-features-at-batch`` posture -- a pricing-
+    comparison matrix binds ``tiers`` directly without a pre-
+    validation round-trip). Never 5xxs: any helper blowup collapses
+    to :func:`_missing_bundle_at_path_batch_fallback`.
+    """
+    try:
+        return jsonify(_missing_bundle_at_path_batch_body("features"))
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_missing_features_at_path_batch: error: %s", exc
+        )
+        from_tier = (request.args.get("from") or "").strip().lower()
+        return jsonify(
+            _missing_bundle_at_path_batch_fallback(
+                "features",
+                from_tier,
+                _parse_csv_arg("to"),
+                _parse_csv_arg("features"),
+            )
+        )
+
+
+@bp_entitlement.route("/api/entitlement/missing-runtimes-at-path-batch")
+def api_entitlement_missing_runtimes_at_path_batch():
+    """``GET /api/entitlement/missing-runtimes-at-path-batch?from=<id>&to=a,b,c&runtimes=x,y,z``
+    -- runtime-axis twin of ``/api/entitlement/missing-features-at-path-batch``.
+
+    Same envelope with ``runtimes`` in the axis-specific slot.
+    Runtime-alias canonicalisation (``claude-code`` ->
+    ``claude_code``) is applied per-token upstream at the endpoint
+    layer so ``?runtimes=claude-code,openclaw`` collapses to the
+    canonical ``claude_code,openclaw`` before hitting the strict
+    scalar -- matches the sibling ``/missing-runtimes-at-path``
+    upstream-canonicalise pattern. Alias-and-canonical pair dedups
+    to ONE entry in ``runtimes`` and therefore ONE entry in every
+    per-destination rung's ``missing`` list. Never 4xxs; never
+    5xxs.
+    """
+    try:
+        return jsonify(_missing_bundle_at_path_batch_body("runtimes"))
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_missing_runtimes_at_path_batch: error: %s", exc
+        )
+        from_tier = (request.args.get("from") or "").strip().lower()
+        return jsonify(
+            _missing_bundle_at_path_batch_fallback(
+                "runtimes",
+                from_tier,
+                _parse_csv_arg("to"),
+                _parse_csv_arg("runtimes"),
+            )
+        )
+
+
 def _has_all_fallback() -> dict:
     """Never-5xx envelope for ``/api/entitlement/has-all``.
 

--- a/tests/test_entitlement_missing_features_runtimes_at_path_batch.py
+++ b/tests/test_entitlement_missing_features_runtimes_at_path_batch.py
@@ -1,0 +1,554 @@
+"""Tests for the batch-path ``missing_features_at_path_batch`` /
+``missing_runtimes_at_path_batch`` complement scalars and their paired
+``/api/entitlement/missing-features-at-path-batch`` /
+``/api/entitlement/missing-runtimes-at-path-batch`` endpoints.
+
+Batch-path siblings of :func:`missing_features_at_path` /
+:func:`missing_runtimes_at_path`: fix ONE bundle and walk the rungs
+between ONE ``from`` and N candidate destinations in ONE round-trip.
+Lets an upgrade-comparison surface render "for the bundle {fleet,
+sso}, at which rung does each of these unlock on the way to each of
+{starter, pro, enterprise}?" off ONE URL.
+
+This file pins:
+
+1. Scalar shape ({"tiers": [...], "unknown": [...]}) and byte-parity
+   with :func:`tier_unlocks_path_batch` / :func:`tier_locks_path_batch`
+   for the per-destination envelope (``to`` / ``to_label`` / ``to_rank``
+   / ``direction`` / ``path``).
+2. Per-destination ``path`` byte-parity with the scalar
+   :func:`missing_features_at_path` / :func:`missing_runtimes_at_path`
+   for the same ``(from, to, bundle)`` triple.
+3. Unknown-``from`` short-circuit: scalar returns ``None``; endpoint
+   returns 200 with ``tiers=[]`` (never 4xxs -- matches
+   ``/missing-features-at-batch`` posture).
+4. Unknown destinations echo into ``unknown[]`` (scalar) /
+   ``unknown_tiers[]`` (endpoint) without short-circuiting the batch.
+5. Direction detection per destination:
+   ``upgrade`` / ``downgrade`` / ``lateral`` / ``identity``.
+6. Grace-independence: same answer under grace on vs enforce for the
+   same ``(from, to_list, bundle)`` triple.
+7. Runtime scalar alias posture: no scalar-level canonicalisation --
+   ``missing_runtimes_at_path_batch(f, [t], ["claude-code"])`` surfaces
+   ``"claude-code"`` in every rung's ``missing`` verbatim; the paired
+   endpoint canonicalises upstream (alias-and-canonical pair dedups to
+   ONE entry in ``runtimes`` and therefore ONE entry in every rung's
+   ``missing``).
+8. Never-raises on delegate blowup: log-and-drop the destination into
+   ``unknown[]`` at scalar layer; empty-tiers fallback envelope at
+   endpoint layer (never 5xxs).
+9. Endpoint envelope shape (fixed key set) across every input branch,
+   including the unknown-``from`` branch and the empty-``to`` branch.
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+# ── Fixtures ───────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def enforced(monkeypatch, tmp_path):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    importlib.reload(e)
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# ── Envelope shape ─────────────────────────────────────────────────────────
+
+_FEATURES_KEYS = {
+    "from",
+    "from_label",
+    "from_rank",
+    "features",
+    "unknown",
+    "unknown_tiers",
+    "kind",
+    "count",
+    "tiers",
+    "required_tier",
+    "required_tier_label",
+    "required_tier_rank",
+    "current_tier",
+    "current_tier_rank",
+    "grace",
+    "enforced",
+}
+_RUNTIMES_KEYS = {
+    "from",
+    "from_label",
+    "from_rank",
+    "runtimes",
+    "unknown",
+    "unknown_tiers",
+    "kind",
+    "count",
+    "tiers",
+    "required_tier",
+    "required_tier_label",
+    "required_tier_rank",
+    "current_tier",
+    "current_tier_rank",
+    "grace",
+    "enforced",
+}
+_TIER_ROW_KEYS = {"to", "to_label", "to_rank", "direction", "path", "path_length", "any_missing"}
+
+
+def _get_json(client, url: str) -> dict:
+    resp = client.get(url)
+    assert resp.status_code == 200, url
+    return resp.get_json()
+
+
+# ── missing_features_at_path_batch scalar ──────────────────────────────────
+
+
+def test_scalar_features_returns_dict_shape(ent):
+    out = ent.missing_features_at_path_batch("oss", ["pro", "enterprise"], ["fleet"])
+    assert isinstance(out, dict)
+    assert set(out.keys()) == {"tiers", "unknown"}
+    assert isinstance(out["tiers"], list)
+    assert isinstance(out["unknown"], list)
+
+
+def test_scalar_features_unknown_from_returns_none(ent):
+    assert ent.missing_features_at_path_batch("bogus", ["pro"], ["fleet"]) is None
+    assert ent.missing_features_at_path_batch("", ["pro"], ["fleet"]) is None
+    assert ent.missing_features_at_path_batch(None, ["pro"], ["fleet"]) is None  # type: ignore[arg-type]
+
+
+def test_scalar_features_empty_destinations_returns_empty_tiers(ent):
+    out = ent.missing_features_at_path_batch("oss", [], ["fleet"])
+    assert out == {"tiers": [], "unknown": []}
+
+
+def test_scalar_features_unknown_destination_echoes_to_unknown(ent):
+    out = ent.missing_features_at_path_batch("oss", ["bogus_id"], ["fleet"])
+    assert out is not None
+    assert out["tiers"] == []
+    assert out["unknown"] == ["bogus_id"]
+
+
+def test_scalar_features_mixed_valid_and_unknown_partial_ok(ent):
+    out = ent.missing_features_at_path_batch(
+        "oss", ["enterprise", "bogus_id"], ["fleet"]
+    )
+    assert out is not None
+    assert [row["to"] for row in out["tiers"]] == ["enterprise"]
+    assert out["unknown"] == ["bogus_id"]
+
+
+def test_scalar_features_dedup_and_normalise_destinations(ent):
+    out = ent.missing_features_at_path_batch(
+        "oss", " ENTERPRISE , enterprise , enterprise ", ["fleet"]
+    )
+    assert out is not None
+    assert [row["to"] for row in out["tiers"]] == ["enterprise"]
+
+
+def test_scalar_features_per_destination_row_shape(ent):
+    out = ent.missing_features_at_path_batch(
+        "oss", ["pro", "enterprise"], ["fleet", "sso"]
+    )
+    assert out is not None
+    for row in out["tiers"]:
+        assert set(row.keys()) == {"to", "to_label", "to_rank", "direction", "path"}
+        assert isinstance(row["path"], list)
+
+
+def test_scalar_features_per_destination_path_matches_scalar(ent):
+    """Per-destination ``path`` byte-equals scalar
+    :func:`missing_features_at_path` for the same triple -- the
+    drift-blocker parity property."""
+    bundle = ["fleet", "sso", "otel_export"]
+    out = ent.missing_features_at_path_batch(
+        "oss", ["cloud_starter", "cloud_pro", "enterprise"], bundle
+    )
+    assert out is not None
+    for row in out["tiers"]:
+        expected = ent.missing_features_at_path("oss", row["to"], bundle)
+        assert row["path"] == expected, row["to"]
+
+
+def test_scalar_features_identity_row_has_empty_path(ent):
+    out = ent.missing_features_at_path_batch("oss", ["oss"], ["fleet"])
+    assert out is not None
+    assert len(out["tiers"]) == 1
+    assert out["tiers"][0]["direction"] == "identity"
+    assert out["tiers"][0]["path"] == []
+
+
+def test_scalar_features_direction_detection(ent):
+    out = ent.missing_features_at_path_batch(
+        "cloud_starter", ["oss", "cloud_starter", "enterprise"], ["fleet"]
+    )
+    assert out is not None
+    by_to = {row["to"]: row for row in out["tiers"]}
+    assert by_to["oss"]["direction"] == "downgrade"
+    assert by_to["cloud_starter"]["direction"] == "identity"
+    assert by_to["enterprise"]["direction"] == "upgrade"
+
+
+def test_scalar_features_empty_bundle_every_rung_empty(ent):
+    out = ent.missing_features_at_path_batch("oss", ["enterprise"], [])
+    assert out is not None
+    for row in out["tiers"]:
+        for r in row["path"]:
+            assert r["missing"] == []
+
+
+def test_scalar_features_none_bundle_every_rung_empty(ent):
+    out = ent.missing_features_at_path_batch("oss", ["enterprise"], None)
+    assert out is not None
+    for row in out["tiers"]:
+        for r in row["path"]:
+            assert r["missing"] == []
+
+
+def test_scalar_features_non_iterable_bundle_every_rung_empty(ent):
+    out = ent.missing_features_at_path_batch("oss", ["enterprise"], 123)
+    assert out is not None
+    for row in out["tiers"]:
+        for r in row["path"]:
+            assert r["missing"] == []
+
+
+def test_scalar_features_grace_independence(ent, enforced):
+    bundle = ["fleet", "sso"]
+    a = ent.missing_features_at_path_batch(
+        "oss", ["cloud_starter", "enterprise"], bundle
+    )
+    b = enforced.missing_features_at_path_batch(
+        "oss", ["cloud_starter", "enterprise"], bundle
+    )
+    assert a == b
+
+
+def test_scalar_features_never_raises_on_delegate_blowup(ent, monkeypatch):
+    def _boom(*a, **kw):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(ent, "missing_features_at_path", _boom)
+    out = ent.missing_features_at_path_batch("oss", ["pro"], ["fleet"])
+    assert out is not None
+    assert out["tiers"] == []
+    assert "pro" in out["unknown"]
+
+
+# ── missing_runtimes_at_path_batch scalar ──────────────────────────────────
+
+
+def test_scalar_runtimes_returns_dict_shape(ent):
+    out = ent.missing_runtimes_at_path_batch(
+        "oss", ["pro", "enterprise"], ["claude_code"]
+    )
+    assert isinstance(out, dict)
+    assert set(out.keys()) == {"tiers", "unknown"}
+
+
+def test_scalar_runtimes_unknown_from_returns_none(ent):
+    assert ent.missing_runtimes_at_path_batch("bogus", ["pro"], ["claude_code"]) is None
+
+
+def test_scalar_runtimes_per_destination_path_matches_scalar(ent):
+    bundle = ["claude_code", "openclaw"]
+    out = ent.missing_runtimes_at_path_batch(
+        "oss", ["cloud_starter", "enterprise"], bundle
+    )
+    assert out is not None
+    for row in out["tiers"]:
+        expected = ent.missing_runtimes_at_path("oss", row["to"], bundle)
+        assert row["path"] == expected, row["to"]
+
+
+def test_scalar_runtimes_strict_alias_posture(ent):
+    """Scalar layer does NOT resolve aliases -- ``claude-code`` surfaces
+    in every rung's ``missing`` verbatim (matches
+    ``missing_runtimes_at_path`` docstring; endpoint canonicalises
+    upstream)."""
+    out = ent.missing_runtimes_at_path_batch("oss", ["enterprise"], ["claude-code"])
+    assert out is not None
+    for row in out["tiers"]:
+        for r in row["path"]:
+            assert "claude-code" in r["missing"]
+
+
+def test_scalar_runtimes_grace_independence(ent, enforced):
+    bundle = ["claude_code", "cursor"]
+    a = ent.missing_runtimes_at_path_batch(
+        "oss", ["cloud_starter", "enterprise"], bundle
+    )
+    b = enforced.missing_runtimes_at_path_batch(
+        "oss", ["cloud_starter", "enterprise"], bundle
+    )
+    assert a == b
+
+
+def test_scalar_runtimes_never_raises_on_delegate_blowup(ent, monkeypatch):
+    def _boom(*a, **kw):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(ent, "missing_runtimes_at_path", _boom)
+    out = ent.missing_runtimes_at_path_batch("oss", ["pro"], ["claude_code"])
+    assert out is not None
+    assert out["tiers"] == []
+    assert "pro" in out["unknown"]
+
+
+# ── Endpoint: envelope shape ───────────────────────────────────────────────
+
+
+def test_endpoint_features_envelope_shape(client):
+    body = _get_json(
+        client,
+        "/api/entitlement/missing-features-at-path-batch?from=oss&to=cloud_starter,enterprise&features=fleet,sso",
+    )
+    assert set(body.keys()) == _FEATURES_KEYS
+    assert body["kind"] == "features"
+    assert body["from"] == "oss"
+    for row in body["tiers"]:
+        assert set(row.keys()) == _TIER_ROW_KEYS
+        assert isinstance(row["path"], list)
+        assert row["path_length"] == len(row["path"])
+
+
+def test_endpoint_runtimes_envelope_shape(client):
+    body = _get_json(
+        client,
+        "/api/entitlement/missing-runtimes-at-path-batch?from=oss&to=enterprise&runtimes=claude_code",
+    )
+    assert set(body.keys()) == _RUNTIMES_KEYS
+    assert body["kind"] == "runtimes"
+    for row in body["tiers"]:
+        assert set(row.keys()) == _TIER_ROW_KEYS
+
+
+# ── Endpoint: never-4xx posture ────────────────────────────────────────────
+
+
+def test_endpoint_features_missing_from_still_200(client):
+    resp = client.get(
+        "/api/entitlement/missing-features-at-path-batch?to=pro&features=fleet"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert set(body.keys()) == _FEATURES_KEYS
+    assert body["tiers"] == []
+
+
+def test_endpoint_features_unknown_from_still_200(client):
+    resp = client.get(
+        "/api/entitlement/missing-features-at-path-batch?from=bogus&to=pro&features=fleet"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert set(body.keys()) == _FEATURES_KEYS
+    assert body["tiers"] == []
+    # ``unknown_tiers`` echoes the caller's ``to=`` set so the tooltip
+    # can still show what was dropped.
+    assert body["unknown_tiers"] == ["pro"]
+
+
+def test_endpoint_features_empty_to_still_200(client):
+    resp = client.get(
+        "/api/entitlement/missing-features-at-path-batch?from=oss&features=fleet"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["tiers"] == []
+    assert body["from"] == "oss"
+
+
+def test_endpoint_features_unknown_destinations_bucketed(client):
+    body = _get_json(
+        client,
+        "/api/entitlement/missing-features-at-path-batch?from=oss&to=bogus_a,enterprise,bogus_b&features=fleet",
+    )
+    assert [row["to"] for row in body["tiers"]] == ["enterprise"]
+    assert set(body["unknown_tiers"]) == {"bogus_a", "bogus_b"}
+
+
+# ── Endpoint: per-destination parity with singular ``/missing-*-at-path`` ──
+
+
+def test_endpoint_features_per_destination_matches_singular(client):
+    body = _get_json(
+        client,
+        "/api/entitlement/missing-features-at-path-batch?from=oss&to=cloud_starter,cloud_pro,enterprise&features=fleet,sso",
+    )
+    for row in body["tiers"]:
+        sibling = _get_json(
+            client,
+            f"/api/entitlement/missing-features-at-path?from=oss&to={row['to']}&features=fleet,sso",
+        )
+        assert row["path"] == sibling["path"], row["to"]
+        assert row["direction"] == sibling["direction"], row["to"]
+
+
+def test_endpoint_runtimes_per_destination_matches_singular(client):
+    body = _get_json(
+        client,
+        "/api/entitlement/missing-runtimes-at-path-batch?from=oss&to=cloud_starter,enterprise&runtimes=claude_code",
+    )
+    for row in body["tiers"]:
+        sibling = _get_json(
+            client,
+            f"/api/entitlement/missing-runtimes-at-path?from=oss&to={row['to']}&runtimes=claude_code",
+        )
+        assert row["path"] == sibling["path"], row["to"]
+
+
+# ── Endpoint: direction detection ──────────────────────────────────────────
+
+
+def test_endpoint_features_direction_detection(client):
+    body = _get_json(
+        client,
+        "/api/entitlement/missing-features-at-path-batch?from=cloud_starter&to=oss,cloud_starter,enterprise&features=fleet",
+    )
+    by_to = {row["to"]: row for row in body["tiers"]}
+    assert by_to["oss"]["direction"] == "downgrade"
+    assert by_to["cloud_starter"]["direction"] == "identity"
+    assert by_to["cloud_starter"]["path"] == []
+    assert by_to["enterprise"]["direction"] == "upgrade"
+
+
+# ── Endpoint: runtime alias canonicalisation upstream ──────────────────────
+
+
+def test_endpoint_runtimes_alias_canonicalised(client):
+    body = _get_json(
+        client,
+        "/api/entitlement/missing-runtimes-at-path-batch?from=oss&to=enterprise&runtimes=claude-code",
+    )
+    # Alias resolved upstream -> ``runtimes`` list carries canonical.
+    assert body["runtimes"] == ["claude_code"]
+    # Every per-destination rung's ``missing`` is off the canonical, not
+    # the alias.
+    for row in body["tiers"]:
+        for r in row["path"]:
+            assert "claude-code" not in r["missing"]
+
+
+def test_endpoint_runtimes_alias_and_canonical_dedup_to_one(client):
+    body = _get_json(
+        client,
+        "/api/entitlement/missing-runtimes-at-path-batch?from=oss&to=enterprise&runtimes=claude-code,claude_code",
+    )
+    assert body["runtimes"] == ["claude_code"]
+    assert body["count"] == 1
+    for row in body["tiers"]:
+        for r in row["path"]:
+            assert r["missing"].count("claude_code") <= 1
+
+
+# ── Endpoint: rollup fields ────────────────────────────────────────────────
+
+
+def test_endpoint_features_any_missing_true_when_row_missing_nonempty(client):
+    body = _get_json(
+        client,
+        "/api/entitlement/missing-features-at-path-batch?from=oss&to=cloud_starter&features=sso",
+    )
+    # SSO is enterprise-only, so cloud_starter path's rung has a
+    # non-empty ``missing`` -> per-destination rollup True.
+    assert body["tiers"][0]["any_missing"] is True
+
+
+def test_endpoint_features_any_missing_false_on_all_granted(client):
+    body = _get_json(
+        client,
+        "/api/entitlement/missing-features-at-path-batch?from=oss&to=enterprise&features=sessions",
+    )
+    # ``sessions`` is a FREE feature -> granted at every rung -> no
+    # per-destination rollup carries missing.
+    for row in body["tiers"]:
+        assert row["any_missing"] is False
+
+
+def test_endpoint_features_required_tier_folds_off_known_bundle(client):
+    body = _get_json(
+        client,
+        "/api/entitlement/missing-features-at-path-batch?from=oss&to=enterprise&features=fleet",
+    )
+    # required_tier should point at the cheapest tier granting ``fleet``.
+    assert body["required_tier"] is not None
+    assert body["required_tier_rank"] >= 0
+
+
+def test_endpoint_features_unknown_tokens_surface_in_unknown(client):
+    body = _get_json(
+        client,
+        "/api/entitlement/missing-features-at-path-batch?from=oss&to=pro&features=bogus_id",
+    )
+    assert body["unknown"] == ["bogus_id"]
+    # Unknown-only bundle -> nothing to fold for required_tier.
+    assert body["required_tier"] is None
+
+
+# ── Endpoint: never-5xx guard ──────────────────────────────────────────────
+
+
+def test_endpoint_features_never_5xx_on_helper_blowup(client, monkeypatch):
+    import clawmetry.entitlements as _ent
+
+    def _boom(*a, **kw):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(_ent, "missing_features_at_path_batch", _boom)
+    resp = client.get(
+        "/api/entitlement/missing-features-at-path-batch?from=oss&to=pro&features=fleet"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert set(body.keys()) == _FEATURES_KEYS
+    assert body["tiers"] == []
+
+
+def test_endpoint_runtimes_never_5xx_on_helper_blowup(client, monkeypatch):
+    import clawmetry.entitlements as _ent
+
+    def _boom(*a, **kw):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(_ent, "missing_runtimes_at_path_batch", _boom)
+    resp = client.get(
+        "/api/entitlement/missing-runtimes-at-path-batch?from=oss&to=pro&runtimes=claude_code"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert set(body.keys()) == _RUNTIMES_KEYS
+    assert body["tiers"] == []


### PR DESCRIPTION
## Summary

Adds the batch-path fan-out siblings of the singular `missing_features_at_path` / `missing_runtimes_at_path` complement helpers: fix ONE bundle and walk the rungs between ONE `from` and N candidate destinations in ONE round-trip.

Structural twin of `tier_unlocks_path_batch` / `tier_locks_path_batch` (same per-destination `{to, to_label, to_rank, direction, path}` shape); matrix-shaped cousin of the existing `missing-*-at-batch` (which fans out over perspective tiers instead of destinations).

## What lands

### Scalars (`clawmetry/entitlements.py`)

- `missing_features_at_path_batch(from_tier, to_tiers, features) -> dict | None` — delegates per-destination to `missing_features_at_path`. Returns `{"tiers": [...], "unknown": [...]}` or `None` on unknown `from`. Bundle canonicalised once so a generator is safe to fan out.
- `missing_runtimes_at_path_batch(from_tier, to_tiers, runtimes) -> dict | None` — runtime-axis twin. Strict-alias posture inherited from the singular scalar (no `canonical_runtime` resolution at scalar layer; alias tolerance lives on the endpoint).

Both never raise: per-destination failures short-circuit that id into `unknown[]` and the rest of the batch keeps building; a whole-fold blowup collapses to `None`. Grace-independent by construction — every per-destination path delegates through `missing_*_at_path` which walks the static `_PURCHASABLE_TIERS` ladder.

### HTTP endpoints (`routes/entitlement.py`, `bp_entitlement`)

- `GET /api/entitlement/missing-features-at-path-batch?from=<id>&to=<csv>&features=<csv>`
- `GET /api/entitlement/missing-runtimes-at-path-batch?from=<id>&to=<csv>&runtimes=<csv>` — runtime-axis twin, with per-token alias canonicalisation upstream so `?runtimes=claude-code,openclaw` collapses to `claude_code,openclaw` before hitting the strict scalar. Alias-and-canonical pair dedups to ONE entry.

Envelope (byte-stable across every input branch):

```
{
  "from":               "<tier id>",
  "from_label":         "...",
  "from_rank":          <int>,
  "features"/"runtimes":[<known ids>],
  "unknown":            [<axis tokens dropped>],
  "unknown_tiers":      [<destination ids dropped>],
  "kind":               "features"/"runtimes",
  "count":              <int>,
  "tiers": [
    {"to": "...", "to_label": "...", "to_rank": <int>,
     "direction": "upgrade"|"downgrade"|"lateral"|"identity",
     "path": [<missing_*_at_path row>, ...],
     "path_length": <int>,
     "any_missing": <bool>},
    ...
  ],
  "required_tier":       "<id>" | null,
  "required_tier_label": "<label>" | null,
  "required_tier_rank":  <int>,
  "current_tier":        "<live tier id>",
  "current_tier_rank":   <int>,
  "grace":               <bool>,
  "enforced":            <bool>
}
```

Both endpoints follow the never-4xx / never-5xx posture of the `missing-*` family: missing / blank / unknown `from`, or empty / all-unknown destination CSV → 200 with `tiers=[]`; any helper blowup collapses to `_missing_bundle_at_path_batch_fallback` so a pricing-comparison matrix binds `tiers` directly without a pre-validation round-trip.

### Tests (`tests/test_entitlement_missing_features_runtimes_at_path_batch.py`)

38 new tests, all green locally:

- Scalar shape + `{tiers, unknown}` byte-parity with `tier_unlocks_path_batch`.
- Per-destination `path` byte-parity with the singular `missing_*_at_path` for the same `(from, to, bundle)` triple — the drift-blocker parity property.
- Unknown-`from` short-circuit (scalar → `None`, endpoint → 200 with `tiers=[]` + `unknown_tiers` echo).
- Mixed valid + unknown destinations bucketed without short-circuiting.
- Direction detection per destination.
- Grace-independence under `CLAWMETRY_ENFORCE=1`.
- Runtime scalar strict-alias posture; endpoint upstream-canonicalisation with alias/canonical dedup.
- Never-raises on delegate blowup at both scalar and endpoint layers.
- Endpoint envelope shape (fixed key set) across every input branch.

Sibling test files (`test_entitlement_missing_features_runtimes_at_path`, `test_entitlement_missing_features_runtimes_at_batch`) still green (92/92) — no regression to the singular / matrix accessors.

## Local operator verification checklist

Automated tests + `py_compile` are green in CI, but the read-only draft cannot touch the live daemon / cloud snapshot. Recommended steps for the operator on their machine:

- [ ] Copy changed files into the installed package tree, e.g.:
  ```
  cp clawmetry/entitlements.py ~/.clawmetry/lib/python3.11/site-packages/clawmetry/
  cp routes/entitlement.py     ~/.clawmetry/lib/python3.11/site-packages/routes/
  find ~/.clawmetry/lib/python3.11/site-packages/clawmetry ~/.clawmetry/lib/python3.11/site-packages/routes -name __pycache__ -type d -exec rm -rf {} +
  ```
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` (macOS) — restart the daemon so the new routes register on the running Flask app.
- [ ] `curl -s 'http://localhost:8900/api/entitlement/missing-features-at-path-batch?from=oss&to=cloud_starter,enterprise&features=fleet,sso' | jq .` — sanity-check the envelope in the real daemon.
- [ ] `curl -s 'http://localhost:8900/api/entitlement/missing-runtimes-at-path-batch?from=oss&to=enterprise&runtimes=claude-code' | jq '.runtimes, .tiers[0].path[0].missing'` — verify upstream alias canonicalisation lands in the live wire response.
- [ ] Decrypt the live cloud snapshot and confirm the daemon is happy after the restart (dashboard tabs render, no route-registration warnings in the daemon log).
- [ ] Browser check: pull up the dashboard and confirm no console errors from the entitlement tab.

## Rollout posture

Pure additive: two new module-scope helpers + two new HTTP routes. No existing code paths change. Both helpers are resolver-independent (walk the static `_PURCHASABLE_TIERS` ladder), so grace vs enforce yields byte-identical responses — wiring these into a UI today changes NO current behavior.

Not touching `__version__`, no `[RELEASE]` PR, no gate flipped — kept in DRAFT for operator local + cloud verification per FLYWHEEL.md.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XVVDTvH2CYiHFLJirujx61)_