### PR TITLE
feat(entitlement): has_features_at_batch + has_runtimes_at_batch + endpoints

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -6319,6 +6319,150 @@ def has_runtimes_at(perspective_tier: str, runtimes) -> bool:
         return False
 
 
+def has_features_at_batch(perspective_tiers, features) -> dict:
+    """Batch what-if sibling of :func:`has_features_at`: would each caller-
+    supplied hypothetical tier grant **all** ``features``, in ONE round-trip.
+
+    Fixes ONE feature bundle and sweeps across N perspective tiers, returning
+    one row per tier with the fold boolean. Boolean-fold complement of
+    :func:`missing_features_at_batch` (per-item denial list) in the same
+    relationship :func:`has_features_at` has to :func:`missing_features_at`:
+    a pricing matrix that gates on a bundle ("does OSS grant {fleet, sso}?
+    Starter? Cloud Pro? Enterprise?") hydrates the whole column off ONE call
+    instead of N calls to :func:`has_features_at`, and pairs with
+    :func:`missing_features_at_batch` so a single row can render both "is
+    this granted?" and "which item is still locked?" side by side.
+
+    Per-tier row shape mirrors :func:`missing_features_at_batch` with the
+    per-item denial list swapped for the fold boolean::
+
+        {
+          "tier":            "<id>",
+          "tier_label":      "...",
+          "tier_rank":       <int>,
+          "has_features_at": <bool>,
+        }
+
+    Each ``has_features_at`` byte-equals :func:`has_features_at` for the same
+    ``(tier, features)`` pair -- a parity test pins this so the scalar and
+    batch what-if boolean-fold helpers cannot drift.
+
+    Envelope::
+
+        {
+          "tiers":   [<row>, ...],
+          "unknown": [<tier tokens dropped as unknown>, ...],
+        }
+
+    Tier normalisation is delegated to :func:`_normalise_csv` (whitespace
+    stripped, lowercased, dedup preserving first-seen; ``trial`` IS accepted --
+    it lives in :data:`_TIER_ORDER`). Unknown tier ids are echoed in
+    ``unknown[]`` instead of short-circuiting so a partially-bad caller still
+    gets rows for the valid tiers alongside a list of what was dropped --
+    matches :func:`missing_features_at_batch` posture byte-for-byte.
+
+    Empty / ``None`` / non-iterable ``perspective_tiers`` returns
+    ``{"tiers": [], "unknown": []}``. Empty / ``None`` ``features`` still
+    walks every valid perspective tier and emits ``has_features_at=False``
+    for each (matches :func:`has_features_at` on empty bundle byte-for-byte:
+    the vacuous-truth fold is refused so a caller who forgot the bundle
+    doesn't silently render "granted").
+
+    Grace-independent by construction: delegates per-tier to
+    :func:`has_features_at`, which is backed by
+    :func:`_hypothetical_entitlement`. Never raises: a per-tier delegate
+    failure short-circuits that id into ``unknown[]`` and the rest of the
+    batch keeps building.
+    """
+    ids = _normalise_csv(perspective_tiers)
+    rows: list[dict] = []
+    unknown: list[str] = []
+    for tid in ids:
+        if tid not in _TIER_ORDER:
+            unknown.append(tid)
+            continue
+        try:
+            allowed = has_features_at(tid, features)
+        except Exception as exc:
+            logger.warning(
+                "entitlements: has_features_at_batch row %r failed: %s",
+                tid,
+                exc,
+            )
+            unknown.append(tid)
+            continue
+        rows.append(
+            {
+                "tier": tid,
+                "tier_label": tier_label(tid),
+                "tier_rank": _TIER_RANK.get(tid, -1),
+                "has_features_at": bool(allowed),
+            }
+        )
+    return {"tiers": rows, "unknown": unknown}
+
+
+def has_runtimes_at_batch(perspective_tiers, runtimes) -> dict:
+    """Runtime-axis twin of :func:`has_features_at_batch`: would each caller-
+    supplied hypothetical tier grant **all** ``runtimes``, in ONE round-trip.
+
+    Pairs with :func:`has_features_at_batch` the same way
+    :func:`missing_runtimes_at_batch` pairs with
+    :func:`missing_features_at_batch`. Together the two boolean-fold batch
+    what-if helpers let a pricing-matrix column ("does OSS admit
+    {claude_code, cursor}? Starter? Cloud Pro?") hydrate every tier column
+    off TWO calls instead of 2 * N calls to :func:`has_runtimes_at`.
+
+    Per-tier row shape mirrors :func:`has_features_at_batch` with
+    ``has_runtimes_at`` in the fold slot::
+
+        {
+          "tier":            "<id>",
+          "tier_label":      "...",
+          "tier_rank":       <int>,
+          "has_runtimes_at": <bool>,
+        }
+
+    Runtime-alias posture is inherited from :func:`has_runtimes_at`: no
+    scalar-level canonicalisation -- a raw ``"claude-code"`` surfaces as
+    ``False`` on every row because the strict scalar sees it as an unknown
+    id. Alias tolerance belongs to the paired
+    ``/api/entitlement/has-runtimes-at-batch`` endpoint, which canonicalises
+    per-token upstream before delegating -- matches the sibling
+    :func:`missing_runtimes_at_batch` /
+    ``/api/entitlement/missing-runtimes-at-batch`` split exactly.
+
+    Tier / unknown / grace-independence / never-raise contract mirror
+    :func:`has_features_at_batch` byte-for-byte.
+    """
+    ids = _normalise_csv(perspective_tiers)
+    rows: list[dict] = []
+    unknown: list[str] = []
+    for tid in ids:
+        if tid not in _TIER_ORDER:
+            unknown.append(tid)
+            continue
+        try:
+            allowed = has_runtimes_at(tid, runtimes)
+        except Exception as exc:
+            logger.warning(
+                "entitlements: has_runtimes_at_batch row %r failed: %s",
+                tid,
+                exc,
+            )
+            unknown.append(tid)
+            continue
+        rows.append(
+            {
+                "tier": tid,
+                "tier_label": tier_label(tid),
+                "tier_rank": _TIER_RANK.get(tid, -1),
+                "has_runtimes_at": bool(allowed),
+            }
+        )
+    return {"tiers": rows, "unknown": unknown}
+
+
 def missing_features(features) -> list:
     """Row-level complement of :func:`has_features`: return the subset of
     ``features`` NOT granted by the resolved entitlement.

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -5852,6 +5852,285 @@ def api_entitlement_missing_runtimes_at_batch():
         )
 
 
+def _has_bundle_at_batch_fallback(
+    axis: str, tier_tokens: list, feature_or_runtime_tokens: list
+) -> dict:
+    """OSS-free / never-5xx envelope for
+    ``/api/entitlement/has-features-at-batch`` /
+    ``/api/entitlement/has-runtimes-at-batch``.
+
+    Boolean-fold sibling of :func:`_missing_bundle_at_batch_fallback`. On
+    any resolver / helper blowup the endpoint still returns 200 with the
+    same envelope shape as the happy path but with ``tiers=[]`` and every
+    fold-rollup fail-closed (``allowed_count=0`` / ``all_allowed=False`` /
+    ``any_allowed=False``) so a pricing-matrix column that lost the
+    resolver never silently renders a bundle grant it can't verify --
+    matches the sibling ``/has-features-at`` fallback's fail-closed
+    posture byte-for-byte. Caller-supplied tier and axis tokens echo
+    into ``unknown_tiers`` / ``unknown`` for debugging.
+    """
+    return {
+        axis: [],
+        "unknown": list(feature_or_runtime_tokens),
+        "unknown_tiers": list(tier_tokens),
+        "kind": axis,
+        "count": 0,
+        "tiers": [],
+        "allowed_count": 0,
+        "all_allowed": False,
+        "any_allowed": False,
+        "required_tier": None,
+        "required_tier_label": None,
+        "required_tier_rank": -1,
+        "current_tier": "oss",
+        "current_tier_rank": 0,
+        "grace": True,
+        "enforced": False,
+    }
+
+
+def _has_bundle_at_batch_body(axis: str) -> dict:
+    """Happy-path body builder for
+    ``/api/entitlement/has-features-at-batch`` /
+    ``/api/entitlement/has-runtimes-at-batch``.
+
+    Batch what-if sibling of :func:`_has_bundle_at_body`: where the
+    ``_at`` variant folds ONE (perspective, bundle) pair, this fixes the
+    bundle and sweeps across N perspective tiers, returning one row per
+    tier with the fold boolean plus the surrounding tier envelope so a
+    pricing-matrix column ("does OSS grant {fleet, sso}? Cloud Starter?
+    Cloud Pro? Enterprise?") hydrates the whole column off ONE URL
+    instead of N calls to ``/has-features-at``. Boolean-fold complement
+    of :func:`_missing_bundle_at_batch_body` (per-item denial list); the
+    two share the envelope shape (same tier normalisation, same
+    known / unknown split, same required-tier rollup) so a UI can render
+    "is this granted?" and "which items are still locked?" side by side
+    off the two paired endpoints.
+
+    Envelope shape (byte-stable across every input branch)::
+
+        {
+          "features"/"runtimes":  [<known ids>],          # known-only, dedup, first-seen
+          "unknown":              [<feature/runtime tokens dropped>],
+          "unknown_tiers":        [<tier tokens dropped>],
+          "kind":                 "features"/"runtimes",
+          "count":                <int>,                  # len(known)
+          "tiers": [
+            {
+              "tier":                  "<id>",
+              "tier_label":            "...",
+              "tier_rank":             <int>,
+              "has_<axis>_at":         <bool>,            # fold vs ROW's tier
+              "allowed":               <bool>,            # alias of has_<axis>_at
+              "required_tier":         "<id>" | null,     # min_tier_for_<axis>(known)
+              "required_tier_label":   "<label>" | null,
+              "required_tier_rank":    <int>,             # -1 when null
+              "upgrade_required":      <bool>,            # required_rank > tier_rank
+            },
+            ...
+          ],
+          "allowed_count":         <int>,                 # #rows with has_<axis>_at=true
+          "all_allowed":           <bool>,                # every row granted
+          "any_allowed":           <bool>,                # at least one row granted
+          "required_tier":         "<id>" | null,         # bundle-level rollup
+          "required_tier_label":   "<label>" | null,
+          "required_tier_rank":    <int>,
+          "current_tier":          "<live tier id>",
+          "current_tier_rank":     <int>,
+          "grace":                 <bool>,                # LIVE resolver grace bit
+          "enforced":              <bool>,
+        }
+
+    Runtime-axis alias canonicalisation is applied per-token upstream of
+    the strict scalar (:func:`has_runtimes_at_batch` inherits the
+    strict-scalar posture from :func:`has_runtimes_at`), matching the
+    sibling :func:`_missing_bundle_at_batch_body` /
+    ``/missing-runtimes-at-batch`` upstream-canonicalise pattern
+    byte-for-byte (an alias-and-canonical pair dedups to ONE row before
+    the scalar sees it).
+
+    Per-row ``upgrade_required`` compares ``required_tier`` against each
+    ROW's tier rank (not the live current rank) so a pricing-matrix row
+    that binds this field reads "no upgrade needed at this tier" vs
+    "upgrade needed beyond this tier" -- matches the sibling
+    :func:`_missing_bundle_at_batch_body` convention.
+
+    ``all_allowed`` folds row.allowed AND-wise (empty ``tiers`` -> False
+    to inherit the fail-closed fold posture the singular
+    :func:`has_features_at` uses on empty input). ``any_allowed`` folds
+    OR-wise (empty ``tiers`` -> False). ``allowed_count`` is the sum of
+    per-row boolean grants so a pricing-matrix header can render "3 of 5
+    tiers grant this bundle" off one field.
+
+    Never 4xxs (missing / blank / unknown tiers or all-unknown CSV -> 200
+    with ``tiers=[]``, matching the sibling ``/has-features-at`` posture).
+    Never 5xxs.
+    """
+    from clawmetry import entitlements as _ent
+
+    tier_tokens = _parse_csv_arg("tiers")
+    param = "features" if axis == "features" else "runtimes"
+    tokens = _parse_csv_arg(param)
+
+    known: list = []
+    unknown: list = []
+    if axis == "features":
+        for fid in tokens:
+            if fid in _ent.ALL_FEATURES:
+                if fid not in known:
+                    known.append(fid)
+            elif fid not in unknown:
+                unknown.append(fid)
+        scalar_tokens = tokens
+        required = _ent.min_tier_for_features(known) if known else None
+        batch = _ent.has_features_at_batch(tier_tokens, scalar_tokens)
+    else:
+        # Canonicalise upstream of the strict scalar so an alias input
+        # (``claude-code``) collapses to the granted runtime
+        # (``claude_code``) here instead of collapsing the row to
+        # ``False`` -- matches the sibling ``_missing_bundle_at_batch_body``
+        # upstream-canonicalise pattern for the ``/missing-runtimes-at-batch``
+        # endpoint, and dedups an alias-and-canonical pair to ONE entry
+        # before the scalar sees it.
+        canon_tokens: list = []
+        canon_seen: set = set()
+        for rid_raw in tokens:
+            rid = _ent.canonical_runtime(rid_raw) or rid_raw
+            if rid in canon_seen:
+                continue
+            canon_seen.add(rid)
+            canon_tokens.append(rid)
+            if rid in _ent.ALL_RUNTIMES:
+                if rid not in known:
+                    known.append(rid)
+            elif rid not in unknown:
+                unknown.append(rid_raw)
+        scalar_tokens = canon_tokens
+        required = _ent.min_tier_for_runtimes(known) if known else None
+        batch = _ent.has_runtimes_at_batch(tier_tokens, scalar_tokens)
+
+    env = _resolver_envelope(_ent)
+    req_rank = _ent.tier_rank(required) if required else -1
+    required_label = _ent.tier_label(required) if required else None
+
+    tiers_out: list[dict] = []
+    fold_key = f"has_{axis}_at"
+    for row in batch.get("tiers", []) or []:
+        try:
+            tid = row.get("tier")
+            row_allowed = bool(row.get(fold_key, False))
+        except AttributeError:
+            continue
+        row_rank = row.get("tier_rank", _ent.tier_rank(tid))
+        upgrade_required = (
+            bool(required) and row_rank >= 0 and req_rank > row_rank
+        )
+        # An unknown token in the bundle collapses the endpoint-level fold
+        # to ``False`` on EVERY row (matches the singular
+        # ``_has_bundle_at_body`` posture: ``unknown != []`` -> ``allowed=False``).
+        endpoint_allowed = row_allowed and not unknown and bool(known)
+        tiers_out.append(
+            {
+                "tier": tid,
+                "tier_label": row.get("tier_label", _ent.tier_label(tid)),
+                "tier_rank": row_rank,
+                fold_key: endpoint_allowed,
+                "allowed": endpoint_allowed,
+                "required_tier": required,
+                "required_tier_label": required_label,
+                "required_tier_rank": req_rank,
+                "upgrade_required": upgrade_required,
+            }
+        )
+
+    allowed_count = sum(1 for r in tiers_out if r["allowed"])
+    all_allowed = bool(tiers_out) and all(r["allowed"] for r in tiers_out)
+    any_allowed = any(r["allowed"] for r in tiers_out)
+
+    return {
+        axis: known,
+        "unknown": unknown,
+        "unknown_tiers": list(batch.get("unknown", []) or []),
+        "kind": axis,
+        "count": len(known),
+        "tiers": tiers_out,
+        "allowed_count": allowed_count,
+        "all_allowed": all_allowed,
+        "any_allowed": any_allowed,
+        "required_tier": required,
+        "required_tier_label": required_label,
+        "required_tier_rank": req_rank,
+        "current_tier": env["current_tier"],
+        "current_tier_rank": env["current_tier_rank"],
+        "grace": env["grace"],
+        "enforced": env["enforced"],
+    }
+
+
+@bp_entitlement.route("/api/entitlement/has-features-at-batch")
+def api_entitlement_has_features_at_batch():
+    """``GET /api/entitlement/has-features-at-batch?tiers=<a,b,...>&features=<x,y,...>``
+    -- batch what-if sibling of ``/api/entitlement/has-features-at``.
+
+    Fixes ONE feature bundle and sweeps across N perspective tiers,
+    returning one row per tier with the fold boolean plus the surrounding
+    tier envelope. Boolean-fold complement of
+    ``/api/entitlement/missing-features-at-batch`` (per-item denial list);
+    the two paired endpoints share the tier envelope so a UI can render
+    "is this granted?" and "which items are still locked?" side by side
+    without a second round of tier normalisation.
+
+    Envelope shape is fully documented on :func:`_has_bundle_at_batch_body`.
+    Never 4xxs (missing / blank / unknown tiers or all-unknown CSV -> 200
+    with ``tiers=[]``, matching the sibling ``/has-features-at`` posture --
+    a paywall matrix binds ``tiers`` directly without a pre-validation
+    round-trip). Never 5xxs: any helper blowup collapses to
+    :func:`_has_bundle_at_batch_fallback`.
+    """
+    try:
+        return jsonify(_has_bundle_at_batch_body("features"))
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_has_features_at_batch: error: %s", exc
+        )
+        return jsonify(
+            _has_bundle_at_batch_fallback(
+                "features",
+                _parse_csv_arg("tiers"),
+                _parse_csv_arg("features"),
+            )
+        )
+
+
+@bp_entitlement.route("/api/entitlement/has-runtimes-at-batch")
+def api_entitlement_has_runtimes_at_batch():
+    """``GET /api/entitlement/has-runtimes-at-batch?tiers=<a,b,...>&runtimes=<x,y,...>``
+    -- runtime-axis twin of ``/api/entitlement/has-features-at-batch``.
+
+    Same envelope with ``runtimes`` in the axis-specific slot. Runtime-
+    alias canonicalisation (``claude-code`` -> ``claude_code``) is
+    applied per-token upstream at the endpoint layer so
+    ``?runtimes=claude-code,openclaw`` collapses to the canonical
+    ``claude_code,openclaw`` before hitting the strict batch scalar --
+    matches the sibling ``/has-runtimes-at`` endpoint's own upstream-
+    canonicalise pattern. Alias-and-canonical pair dedups to ONE row in
+    both ``runtimes`` and every per-tier fold. Never 4xxs; never 5xxs.
+    """
+    try:
+        return jsonify(_has_bundle_at_batch_body("runtimes"))
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_has_runtimes_at_batch: error: %s", exc
+        )
+        return jsonify(
+            _has_bundle_at_batch_fallback(
+                "runtimes",
+                _parse_csv_arg("tiers"),
+                _parse_csv_arg("runtimes"),
+            )
+        )
+
+
 def _missing_bundle_at_path_fallback(
     axis: str,
     from_tier: str,

--- a/tests/test_entitlement_has_features_runtimes_at_batch.py
+++ b/tests/test_entitlement_has_features_runtimes_at_batch.py
@@ -1,0 +1,935 @@
+"""Tests for the batch what-if ``has_features_at_batch`` /
+``has_runtimes_at_batch`` boolean-fold scalars and their paired
+``/api/entitlement/has-features-at-batch`` /
+``/api/entitlement/has-runtimes-at-batch`` endpoints.
+
+Batch what-if siblings of :func:`has_features_at` / :func:`has_runtimes_at`
+in the same relationship :func:`missing_features_at_batch` /
+:func:`missing_runtimes_at_batch` have to :func:`missing_features_at` /
+:func:`missing_runtimes_at`: fixes ONE bundle and sweeps across N
+perspective tiers, returning one row per tier with the fold boolean so a
+pricing-matrix column ("does OSS grant {fleet, sso}? Starter? Cloud Pro?
+Enterprise?") hydrates off ONE call, and pairs row-for-row with the
+sibling ``/missing-features-at-batch`` denial-list endpoint.
+
+This file pins:
+
+1. Per-tier row parity with the scalar ``_at`` sibling on every
+   ``_TIER_ORDER`` perspective.
+2. Envelope shape stability ({tiers, unknown} scalar; fixed endpoint
+   key set) across empty / all-unknown / partially-unknown input.
+3. Tier normalisation (``_normalise_csv``) at scalar layer -- whitespace
+   stripped, lowered, dedup preserving first-seen.
+4. Unknown tier ids bucket into ``unknown[]`` / ``unknown_tiers`` (batch
+   never short-circuits on a single bad id).
+5. Empty / None / non-iterable ``perspective_tiers`` -> stable empty
+   ``{tiers: [], unknown: []}`` envelope.
+6. Grace-independence: batch answer identical under grace on vs off for
+   every ``(tiers, bundle)`` pair.
+7. Runtime scalar alias posture: no scalar-level canonicalisation --
+   a raw ``"claude-code"`` collapses each row's fold to ``False``
+   verbatim (matches :func:`has_runtimes_at`). Endpoint canonicalises
+   upstream so ``?runtimes=claude-code`` collapses to ``claude_code``.
+8. Never-raises on delegate blowup: log-and-return the empty-row shape
+   for the affected tier; unknown_tiers surfaces its id.
+9. Endpoint envelope shape (fixed key set) across every input branch;
+   per-row ``upgrade_required`` computed against the ROW's tier rank;
+   ``allowed_count`` / ``all_allowed`` / ``any_allowed`` roll-ups.
+10. Never-5xx: monkeypatch scalar / resolver blowup collapses to the
+    OSS-free ``_has_bundle_at_batch_fallback`` shape.
+11. Scalar-vs-endpoint parity: URL ``tiers[i].allowed`` byte-equals
+    scalar ``tiers[i].has_features_at`` on the same ``(tiers, bundle)``
+    input (modulo the endpoint's unknown-collapse fold).
+12. Cross-endpoint consistency vs sibling ``/missing-features-at-batch`` /
+    ``/missing-runtimes-at-batch``: a row's ``allowed`` is exactly
+    ``missing == []`` when the bundle has no unknown tokens.
+13. Cross-endpoint consistency vs sibling ``/has-features-at`` /
+    ``/has-runtimes-at``: per-row ``allowed`` equals the sibling
+    ``/has-<axis>-at?tier=<row.tier>&<axis>=<bundle>`` ``allowed``.
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+# ── Fixtures ───────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    """Fresh entitlements module in OSS-free-grace mode. The batch what-if
+    scalars are grace-independent by construction (they delegate to the
+    scalar ``_at`` sibling backed by :func:`_hypothetical_entitlement`).
+    """
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def enforced(monkeypatch, tmp_path):
+    """Enforcement-on fixture -- pins the grace-independence contract.
+    Same shape as the sibling `test_entitlement_missing_features_runtimes_at_batch`
+    module."""
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    importlib.reload(e)
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# ── Envelope shape ────────────────────────────────────────────────────────
+
+
+_ENVELOPE_KEYS_FEATURES = {
+    "features",
+    "unknown",
+    "unknown_tiers",
+    "kind",
+    "count",
+    "tiers",
+    "allowed_count",
+    "all_allowed",
+    "any_allowed",
+    "required_tier",
+    "required_tier_label",
+    "required_tier_rank",
+    "current_tier",
+    "current_tier_rank",
+    "grace",
+    "enforced",
+}
+_ENVELOPE_KEYS_RUNTIMES = {
+    "runtimes",
+    "unknown",
+    "unknown_tiers",
+    "kind",
+    "count",
+    "tiers",
+    "allowed_count",
+    "all_allowed",
+    "any_allowed",
+    "required_tier",
+    "required_tier_label",
+    "required_tier_rank",
+    "current_tier",
+    "current_tier_rank",
+    "grace",
+    "enforced",
+}
+_ROW_KEYS_FEATURES = {
+    "tier",
+    "tier_label",
+    "tier_rank",
+    "has_features_at",
+    "allowed",
+    "required_tier",
+    "required_tier_label",
+    "required_tier_rank",
+    "upgrade_required",
+}
+_ROW_KEYS_RUNTIMES = {
+    "tier",
+    "tier_label",
+    "tier_rank",
+    "has_runtimes_at",
+    "allowed",
+    "required_tier",
+    "required_tier_label",
+    "required_tier_rank",
+    "upgrade_required",
+}
+
+
+def _get_json(client, url: str) -> dict:
+    resp = client.get(url)
+    assert resp.status_code == 200, url
+    return resp.get_json()
+
+
+def _paid_feature(ent) -> str:
+    """Pick a stable paid feature id for perspective sweeps."""
+    for f in sorted(ent.PAID_FEATURES):
+        return f
+    pytest.skip("no paid features on this build")
+
+
+def _paid_runtime(ent) -> str:
+    for rt in sorted(ent.PAID_RUNTIMES):
+        return rt
+    pytest.skip("no paid runtimes on this build")
+
+
+# ── Scalar: envelope shape ─────────────────────────────────────────────────
+
+
+def test_scalar_features_envelope_shape_stable(ent):
+    r = ent.has_features_at_batch(["oss", "cloud_pro"], ["fleet"])
+    assert set(r) == {"tiers", "unknown"}
+    for row in r["tiers"]:
+        assert set(row) == {"tier", "tier_label", "tier_rank", "has_features_at"}
+
+
+def test_scalar_runtimes_envelope_shape_stable(ent):
+    r = ent.has_runtimes_at_batch(["oss"], ["openclaw"])
+    assert set(r) == {"tiers", "unknown"}
+    for row in r["tiers"]:
+        assert set(row) == {"tier", "tier_label", "tier_rank", "has_runtimes_at"}
+
+
+# ── Scalar: parity with _at sibling ───────────────────────────────────────
+
+
+def test_scalar_features_row_allowed_equals_at_scalar(ent):
+    """Per-row ``has_features_at`` byte-equals :func:`has_features_at`
+    for the same ``(tier, features)`` pair, across every ``_TIER_ORDER``
+    perspective."""
+    paid = _paid_feature(ent)
+    bundle = sorted(ent.FREE_FEATURES) + [paid]
+    tiers = list(ent._TIER_ORDER)
+    r = ent.has_features_at_batch(tiers, bundle)
+    for row in r["tiers"]:
+        assert row["has_features_at"] == ent.has_features_at(
+            row["tier"], bundle
+        )
+
+
+def test_scalar_runtimes_row_allowed_equals_at_scalar(ent):
+    paid = _paid_runtime(ent)
+    bundle = ["openclaw", paid]
+    tiers = list(ent._TIER_ORDER)
+    r = ent.has_runtimes_at_batch(tiers, bundle)
+    for row in r["tiers"]:
+        assert row["has_runtimes_at"] == ent.has_runtimes_at(
+            row["tier"], bundle
+        )
+
+
+def test_scalar_features_row_tier_label_and_rank_match_helpers(ent):
+    r = ent.has_features_at_batch(list(ent._TIER_ORDER), ["fleet"])
+    for row in r["tiers"]:
+        assert row["tier_label"] == ent.tier_label(row["tier"])
+        assert row["tier_rank"] == ent._TIER_RANK.get(row["tier"], -1)
+
+
+def test_scalar_runtimes_row_tier_label_and_rank_match_helpers(ent):
+    r = ent.has_runtimes_at_batch(list(ent._TIER_ORDER), ["openclaw"])
+    for row in r["tiers"]:
+        assert row["tier_label"] == ent.tier_label(row["tier"])
+        assert row["tier_rank"] == ent._TIER_RANK.get(row["tier"], -1)
+
+
+# ── Scalar: tier normalisation and dedup ──────────────────────────────────
+
+
+def test_scalar_features_normalises_and_dedups_tiers(ent):
+    r = ent.has_features_at_batch(
+        ["  OSS  ", "oss", "Cloud_Pro"], ["fleet"]
+    )
+    seen = [row["tier"] for row in r["tiers"]]
+    assert seen == ["oss", "cloud_pro"]
+    assert r["unknown"] == []
+
+
+def test_scalar_runtimes_normalises_and_dedups_tiers(ent):
+    r = ent.has_runtimes_at_batch(
+        ["  OSS  ", "oss", " Cloud_Pro "], ["openclaw"]
+    )
+    seen = [row["tier"] for row in r["tiers"]]
+    assert seen == ["oss", "cloud_pro"]
+
+
+def test_scalar_features_unknown_tiers_bucket_not_shortcircuit(ent):
+    r = ent.has_features_at_batch(
+        ["oss", "bogus_a", "cloud_pro", "bogus_b"], ["fleet"]
+    )
+    assert [row["tier"] for row in r["tiers"]] == ["oss", "cloud_pro"]
+    assert r["unknown"] == ["bogus_a", "bogus_b"]
+
+
+def test_scalar_runtimes_unknown_tiers_bucket_not_shortcircuit(ent):
+    r = ent.has_runtimes_at_batch(
+        ["bogus_x", "pro", "bogus_y"], ["openclaw"]
+    )
+    assert [row["tier"] for row in r["tiers"]] == ["pro"]
+    assert r["unknown"] == ["bogus_x", "bogus_y"]
+
+
+# ── Scalar: empty / None / non-iterable input ──────────────────────────────
+
+
+def test_scalar_features_empty_tiers_returns_empty_envelope(ent):
+    assert ent.has_features_at_batch([], ["fleet"]) == {
+        "tiers": [],
+        "unknown": [],
+    }
+
+
+def test_scalar_features_none_tiers_returns_empty_envelope(ent):
+    assert ent.has_features_at_batch(None, ["fleet"]) == {
+        "tiers": [],
+        "unknown": [],
+    }
+
+
+def test_scalar_features_non_iterable_tiers_returns_empty_envelope(ent):
+    assert ent.has_features_at_batch(123, ["fleet"]) == {  # type: ignore[arg-type]
+        "tiers": [],
+        "unknown": [],
+    }
+
+
+def test_scalar_features_empty_bundle_walks_tiers_with_false(ent):
+    """Empty bundle: every valid tier still emits a row with
+    ``has_features_at=False`` (parity with :func:`has_features_at` on
+    empty bundle: the vacuous-truth fold is refused)."""
+    r = ent.has_features_at_batch(["oss", "cloud_pro"], [])
+    assert [row["tier"] for row in r["tiers"]] == ["oss", "cloud_pro"]
+    assert all(row["has_features_at"] is False for row in r["tiers"])
+
+
+def test_scalar_features_none_bundle_walks_tiers_with_false(ent):
+    r = ent.has_features_at_batch(["oss"], None)
+    assert len(r["tiers"]) == 1
+    assert r["tiers"][0]["has_features_at"] is False
+
+
+def test_scalar_runtimes_empty_bundle_walks_tiers_with_false(ent):
+    r = ent.has_runtimes_at_batch(["oss", "pro"], [])
+    assert [row["tier"] for row in r["tiers"]] == ["oss", "pro"]
+    assert all(row["has_runtimes_at"] is False for row in r["tiers"])
+
+
+# ── Scalar: all-tier sweep, free vs paid semantics ─────────────────────────
+
+
+def test_scalar_features_all_free_bundle_true_at_every_tier(ent):
+    free = sorted(ent.FREE_FEATURES)
+    if not free:
+        pytest.skip("no free features on this build")
+    r = ent.has_features_at_batch(list(ent._TIER_ORDER), free)
+    for row in r["tiers"]:
+        assert row["has_features_at"] is True, row["tier"]
+
+
+def test_scalar_features_paid_bundle_at_oss_denies(ent):
+    paid = sorted(ent.PAID_FEATURES)
+    if not paid:
+        pytest.skip("no paid features on this build")
+    r = ent.has_features_at_batch(["oss"], paid)
+    assert r["tiers"][0]["has_features_at"] is False
+
+
+def test_scalar_features_paid_bundle_at_enterprise_grants(ent):
+    if "enterprise" not in ent._TIER_ORDER:
+        pytest.skip("enterprise not on this build")
+    paid = sorted(ent.PAID_FEATURES)
+    if not paid:
+        pytest.skip("no paid features on this build")
+    r = ent.has_features_at_batch(["enterprise"], paid)
+    assert r["tiers"][0]["has_features_at"] is True
+
+
+def test_scalar_runtimes_all_free_bundle_true_at_every_tier(ent):
+    free = sorted(ent.FREE_RUNTIMES)
+    if not free:
+        pytest.skip("no free runtimes on this build")
+    r = ent.has_runtimes_at_batch(list(ent._TIER_ORDER), free)
+    for row in r["tiers"]:
+        assert row["has_runtimes_at"] is True, row["tier"]
+
+
+def test_scalar_runtimes_paid_bundle_at_oss_denies(ent):
+    paid = sorted(ent.PAID_RUNTIMES)
+    if not paid:
+        pytest.skip("no paid runtimes on this build")
+    r = ent.has_runtimes_at_batch(["oss"], paid)
+    assert r["tiers"][0]["has_runtimes_at"] is False
+
+
+# ── Scalar: grace-independence ────────────────────────────────────────────
+
+
+def test_scalar_features_grace_independence_all_tiers(ent, enforced):
+    """The batch scalar delegates to :func:`has_features_at` which is
+    backed by :func:`_hypothetical_entitlement` (grace off) -- the answer
+    is identical under grace vs enforce for the same input."""
+    paid = sorted(ent.PAID_FEATURES)
+    if not paid:
+        pytest.skip("no paid features on this build")
+    for tier in ent._TIER_ORDER:
+        grace = ent.has_features_at_batch([tier], paid)
+        enf = enforced.has_features_at_batch([tier], paid)
+        assert grace == enf, tier
+
+
+def test_scalar_runtimes_grace_independence_all_tiers(ent, enforced):
+    paid = sorted(ent.PAID_RUNTIMES)
+    if not paid:
+        pytest.skip("no paid runtimes on this build")
+    for tier in ent._TIER_ORDER:
+        assert ent.has_runtimes_at_batch(
+            [tier], paid
+        ) == enforced.has_runtimes_at_batch([tier], paid), tier
+
+
+# ── Scalar: strict runtime alias posture ──────────────────────────────────
+
+
+def test_scalar_runtimes_no_alias_canonicalisation_at_scalar_layer(ent):
+    """A raw ``"claude-code"`` at the scalar layer collapses each row's
+    fold to ``False`` because the strict scalar sees the alias as an
+    unknown id (matches :func:`has_runtimes_at` posture -- endpoint
+    layer canonicalises upstream)."""
+    tier = "pro" if "pro" in ent._TIER_ORDER else "cloud_pro"
+    r = ent.has_runtimes_at_batch([tier], ["claude-code"])
+    # Even though claude-code IS granted at Pro, the strict scalar sees
+    # the alias as an unknown id and folds to False.
+    assert r["tiers"][0]["has_runtimes_at"] is False
+
+
+# ── Scalar: never raises on delegate blowup ────────────────────────────────
+
+
+def test_scalar_features_row_delegate_blowup_buckets_tier_into_unknown(
+    ent, monkeypatch
+):
+    """A per-tier delegate crash short-circuits that id into ``unknown[]``
+    and the rest of the batch keeps building."""
+    orig = ent.has_features_at
+
+    def boom(tier, features):
+        if tier == "cloud_pro":
+            raise RuntimeError("boom")
+        return orig(tier, features)
+
+    monkeypatch.setattr(ent, "has_features_at", boom)
+    r = ent.has_features_at_batch(
+        ["oss", "cloud_pro", "enterprise"], ["fleet"]
+    )
+    assert [row["tier"] for row in r["tiers"]] == ["oss", "enterprise"]
+    assert "cloud_pro" in r["unknown"]
+
+
+def test_scalar_runtimes_row_delegate_blowup_buckets_tier_into_unknown(
+    ent, monkeypatch
+):
+    orig = ent.has_runtimes_at
+
+    def boom(tier, runtimes):
+        if tier == "pro":
+            raise RuntimeError("boom")
+        return orig(tier, runtimes)
+
+    monkeypatch.setattr(ent, "has_runtimes_at", boom)
+    r = ent.has_runtimes_at_batch(
+        ["oss", "pro", "enterprise"], ["openclaw"]
+    )
+    assert [row["tier"] for row in r["tiers"]] == ["oss", "enterprise"]
+    assert "pro" in r["unknown"]
+
+
+# ── Endpoint: happy-path envelope shape ───────────────────────────────────
+
+
+def test_endpoint_features_envelope_key_set(client):
+    body = _get_json(
+        client,
+        "/api/entitlement/has-features-at-batch"
+        "?tiers=oss,cloud_pro&features=fleet,sso",
+    )
+    assert set(body) == _ENVELOPE_KEYS_FEATURES
+    for row in body["tiers"]:
+        assert set(row) == _ROW_KEYS_FEATURES
+
+
+def test_endpoint_runtimes_envelope_key_set(client):
+    body = _get_json(
+        client,
+        "/api/entitlement/has-runtimes-at-batch"
+        "?tiers=oss,pro&runtimes=openclaw,claude_code",
+    )
+    assert set(body) == _ENVELOPE_KEYS_RUNTIMES
+    for row in body["tiers"]:
+        assert set(row) == _ROW_KEYS_RUNTIMES
+
+
+# ── Endpoint: never 4xxs ──────────────────────────────────────────────────
+
+
+def test_endpoint_features_missing_tiers_returns_200(client):
+    resp = client.get("/api/entitlement/has-features-at-batch?features=fleet")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["tiers"] == []
+    assert body["unknown_tiers"] == []
+    assert body["all_allowed"] is False
+    assert body["any_allowed"] is False
+    assert body["allowed_count"] == 0
+
+
+def test_endpoint_features_missing_features_returns_200(client):
+    resp = client.get("/api/entitlement/has-features-at-batch?tiers=oss")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    # empty bundle: tier row emitted with allowed=False (fail-closed)
+    assert len(body["tiers"]) == 1
+    assert body["tiers"][0]["allowed"] is False
+    assert body["tiers"][0]["has_features_at"] is False
+
+
+def test_endpoint_features_all_unknown_tiers_returns_200_with_empty_tiers(client):
+    body = _get_json(
+        client,
+        "/api/entitlement/has-features-at-batch"
+        "?tiers=bogus_a,bogus_b&features=fleet",
+    )
+    assert body["tiers"] == []
+    assert body["unknown_tiers"] == ["bogus_a", "bogus_b"]
+
+
+def test_endpoint_runtimes_missing_tiers_returns_200(client):
+    resp = client.get(
+        "/api/entitlement/has-runtimes-at-batch?runtimes=openclaw"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["tiers"] == []
+
+
+def test_endpoint_runtimes_all_unknown_tiers_returns_200_with_empty_tiers(client):
+    body = _get_json(
+        client,
+        "/api/entitlement/has-runtimes-at-batch"
+        "?tiers=bogus&runtimes=openclaw",
+    )
+    assert body["tiers"] == []
+    assert body["unknown_tiers"] == ["bogus"]
+
+
+# ── Endpoint: per-row rollups ─────────────────────────────────────────────
+
+
+def test_endpoint_features_allowed_count_matches_row_grants(client, ent):
+    body = _get_json(
+        client,
+        "/api/entitlement/has-features-at-batch"
+        f"?tiers={','.join(ent._TIER_ORDER)}&features=fleet",
+    )
+    actual = sum(1 for row in body["tiers"] if row["allowed"])
+    assert body["allowed_count"] == actual
+
+
+def test_endpoint_features_all_allowed_folds_row_grants(client, ent):
+    """``all_allowed`` == every row.allowed True (empty tiers -> False)."""
+    body = _get_json(
+        client,
+        "/api/entitlement/has-features-at-batch"
+        f"?tiers={','.join(ent._TIER_ORDER)}&features=fleet",
+    )
+    assert body["all_allowed"] == (
+        bool(body["tiers"]) and all(r["allowed"] for r in body["tiers"])
+    )
+
+
+def test_endpoint_features_any_allowed_folds_row_grants(client, ent):
+    body = _get_json(
+        client,
+        "/api/entitlement/has-features-at-batch"
+        f"?tiers={','.join(ent._TIER_ORDER)}&features=fleet",
+    )
+    assert body["any_allowed"] == any(r["allowed"] for r in body["tiers"])
+
+
+def test_endpoint_features_row_upgrade_required_uses_row_rank(client, ent):
+    """Per-row ``upgrade_required`` compares ``required_tier`` rank
+    against the ROW's tier rank (not the live current rank), matching
+    the sibling ``/missing-features-at-batch`` convention."""
+    paid = sorted(ent.PAID_FEATURES)
+    if len(paid) < 2:
+        pytest.skip("need at least 2 paid features")
+    bundle_csv = ",".join(paid[:2])
+    tiers_csv = ",".join(list(ent._TIER_ORDER))
+    body = _get_json(
+        client,
+        f"/api/entitlement/has-features-at-batch"
+        f"?tiers={tiers_csv}&features={bundle_csv}",
+    )
+    for row in body["tiers"]:
+        req_rank = row["required_tier_rank"]
+        row_rank = row["tier_rank"]
+        if row["required_tier"] is None:
+            assert row["upgrade_required"] is False
+        else:
+            assert row["upgrade_required"] == (req_rank > row_rank)
+
+
+def test_endpoint_features_row_allowed_matches_has_features_at_field(client):
+    """``allowed`` is an alias for ``has_features_at`` on every row."""
+    body = _get_json(
+        client,
+        "/api/entitlement/has-features-at-batch"
+        "?tiers=oss,cloud_pro&features=fleet,sso",
+    )
+    for row in body["tiers"]:
+        assert row["allowed"] == row["has_features_at"]
+
+
+def test_endpoint_runtimes_row_allowed_matches_has_runtimes_at_field(client):
+    body = _get_json(
+        client,
+        "/api/entitlement/has-runtimes-at-batch"
+        "?tiers=oss,pro&runtimes=openclaw,claude_code",
+    )
+    for row in body["tiers"]:
+        assert row["allowed"] == row["has_runtimes_at"]
+
+
+# ── Endpoint: known / unknown feature split ────────────────────────────────
+
+
+def test_endpoint_features_known_unknown_split(client):
+    body = _get_json(
+        client,
+        "/api/entitlement/has-features-at-batch"
+        "?tiers=oss&features=fleet,sso,bogus_id",
+    )
+    assert body["features"] == ["fleet", "sso"]
+    assert body["unknown"] == ["bogus_id"]
+    assert body["count"] == 2
+
+
+def test_endpoint_runtimes_known_unknown_split(client):
+    body = _get_json(
+        client,
+        "/api/entitlement/has-runtimes-at-batch"
+        "?tiers=oss&runtimes=openclaw,claude_code,bogus_id",
+    )
+    assert body["runtimes"] == ["openclaw", "claude_code"]
+    assert body["unknown"] == ["bogus_id"]
+    assert body["count"] == 2
+
+
+def test_endpoint_features_unknown_token_collapses_every_row_fold(client, ent):
+    """A single unknown-token in the bundle collapses ``allowed`` to
+    ``False`` on EVERY row (matches the singular ``/has-features-at``
+    posture: ``unknown != []`` -> ``allowed=False``)."""
+    if "enterprise" not in ent._TIER_ORDER:
+        pytest.skip("enterprise not on this build")
+    body = _get_json(
+        client,
+        "/api/entitlement/has-features-at-batch"
+        "?tiers=enterprise&features=fleet,bogus_id",
+    )
+    assert body["unknown"] == ["bogus_id"]
+    # Enterprise would grant fleet alone, but the unknown token in the
+    # bundle collapses every row's fold to False.
+    for row in body["tiers"]:
+        assert row["allowed"] is False
+
+
+# ── Endpoint: runtime alias canonicalisation upstream of scalar ───────────
+
+
+def test_endpoint_runtimes_endpoint_canonicalises_alias(client, ent):
+    """``?runtimes=claude-code`` canonicalises to ``claude_code``
+    upstream of the strict batch scalar so it lands in the known list
+    (not ``unknown``) and each row's ``allowed`` reflects the granted
+    status of the canonical id -- matches sibling
+    ``/missing-runtimes-at-batch``."""
+    if "claude_code" not in ent.ALL_RUNTIMES:
+        pytest.skip("claude_code not in ALL_RUNTIMES on this build")
+    tier = "pro" if "pro" in ent._TIER_ORDER else "cloud_pro"
+    body = _get_json(
+        client,
+        f"/api/entitlement/has-runtimes-at-batch"
+        f"?tiers={tier}&runtimes=claude-code",
+    )
+    # canonicalised to claude_code, listed as known
+    assert body["runtimes"] == ["claude_code"]
+    assert body["unknown"] == []
+    row = body["tiers"][0]
+    # Pro grants claude_code -> allowed True
+    assert row["allowed"] is True
+
+
+def test_endpoint_runtimes_alias_and_canonical_dedup_to_one_row(client, ent):
+    if "claude_code" not in ent.ALL_RUNTIMES:
+        pytest.skip("claude_code not in ALL_RUNTIMES on this build")
+    body = _get_json(
+        client,
+        "/api/entitlement/has-runtimes-at-batch"
+        "?tiers=pro,oss&runtimes=claude-code,claude_code",
+    )
+    assert body["runtimes"] == ["claude_code"]
+    assert len(body["tiers"]) == 2
+
+
+# ── Endpoint: scalar-vs-endpoint parity ────────────────────────────────────
+
+
+def test_endpoint_features_row_allowed_equals_scalar_allowed(client, ent):
+    """Per-row ``allowed`` byte-equals the scalar's
+    ``has_features_at`` for the same (tiers, features), when the
+    bundle has no unknown tokens (the endpoint's unknown-collapse fold
+    is a no-op on a fully-known bundle)."""
+    paid = _paid_feature(ent)
+    bundle = sorted(ent.FREE_FEATURES) + [paid]
+    tiers = list(ent._TIER_ORDER)
+    body = _get_json(
+        client,
+        "/api/entitlement/has-features-at-batch"
+        f"?tiers={','.join(tiers)}&features={','.join(bundle)}",
+    )
+    scalar = ent.has_features_at_batch(tiers, bundle)
+    endpoint_by_tier = {row["tier"]: row["allowed"] for row in body["tiers"]}
+    scalar_by_tier = {
+        row["tier"]: row["has_features_at"] for row in scalar["tiers"]
+    }
+    assert endpoint_by_tier == scalar_by_tier
+
+
+def test_endpoint_runtimes_row_allowed_equals_scalar_canon_input(
+    client, ent
+):
+    """Endpoint canonicalises aliases upstream; the equivalent scalar
+    call must be given the canonical bundle for byte-identical parity."""
+    paid = _paid_runtime(ent)
+    bundle = ["openclaw", paid]
+    tiers = list(ent._TIER_ORDER)
+    body = _get_json(
+        client,
+        "/api/entitlement/has-runtimes-at-batch"
+        f"?tiers={','.join(tiers)}&runtimes={','.join(bundle)}",
+    )
+    scalar = ent.has_runtimes_at_batch(tiers, bundle)
+    endpoint_by_tier = {row["tier"]: row["allowed"] for row in body["tiers"]}
+    scalar_by_tier = {
+        row["tier"]: row["has_runtimes_at"] for row in scalar["tiers"]
+    }
+    assert endpoint_by_tier == scalar_by_tier
+
+
+# ── Endpoint: cross-consistency with sibling _at endpoint ─────────────────
+
+
+def test_endpoint_features_row_allowed_equals_sibling_at_endpoint(client, ent):
+    """Per-row ``allowed`` on the batch endpoint byte-equals the
+    ``/has-features-at?tier=<row.tier>&features=<bundle>`` sibling
+    ``allowed`` on the same input -- pins the two endpoints as the same
+    fold read at two granularities."""
+    paid = _paid_feature(ent)
+    bundle = sorted(ent.FREE_FEATURES) + [paid]
+    bundle_csv = ",".join(bundle)
+    tiers = list(ent._TIER_ORDER)
+    body = _get_json(
+        client,
+        "/api/entitlement/has-features-at-batch"
+        f"?tiers={','.join(tiers)}&features={bundle_csv}",
+    )
+    for row in body["tiers"]:
+        sib = _get_json(
+            client,
+            "/api/entitlement/has-features-at"
+            f"?tier={row['tier']}&features={bundle_csv}",
+        )
+        assert row["allowed"] == sib["allowed"], row["tier"]
+
+
+def test_endpoint_runtimes_row_allowed_equals_sibling_at_endpoint(client, ent):
+    paid = _paid_runtime(ent)
+    bundle = ["openclaw", paid]
+    bundle_csv = ",".join(bundle)
+    tiers = list(ent._TIER_ORDER)
+    body = _get_json(
+        client,
+        "/api/entitlement/has-runtimes-at-batch"
+        f"?tiers={','.join(tiers)}&runtimes={bundle_csv}",
+    )
+    for row in body["tiers"]:
+        sib = _get_json(
+            client,
+            "/api/entitlement/has-runtimes-at"
+            f"?tier={row['tier']}&runtimes={bundle_csv}",
+        )
+        assert row["allowed"] == sib["allowed"], row["tier"]
+
+
+# ── Endpoint: cross-consistency with sibling missing-*-at-batch endpoint ──
+
+
+def test_endpoint_features_row_allowed_iff_sibling_missing_empty(client, ent):
+    """A row's ``allowed`` is exactly ``missing == []`` on the sibling
+    ``/missing-features-at-batch`` endpoint when the bundle has no
+    unknown tokens -- the two endpoints are complementary reads of the
+    same fold."""
+    paid = _paid_feature(ent)
+    bundle = sorted(ent.FREE_FEATURES) + [paid]
+    bundle_csv = ",".join(bundle)
+    tiers_csv = ",".join(list(ent._TIER_ORDER))
+    has_body = _get_json(
+        client,
+        "/api/entitlement/has-features-at-batch"
+        f"?tiers={tiers_csv}&features={bundle_csv}",
+    )
+    miss_body = _get_json(
+        client,
+        "/api/entitlement/missing-features-at-batch"
+        f"?tiers={tiers_csv}&features={bundle_csv}",
+    )
+    miss_by_tier = {row["tier"]: row["missing"] for row in miss_body["tiers"]}
+    for row in has_body["tiers"]:
+        assert row["allowed"] == (miss_by_tier[row["tier"]] == []), row["tier"]
+
+
+def test_endpoint_runtimes_row_allowed_iff_sibling_missing_empty(client, ent):
+    paid = _paid_runtime(ent)
+    bundle = ["openclaw", paid]
+    bundle_csv = ",".join(bundle)
+    tiers_csv = ",".join(list(ent._TIER_ORDER))
+    has_body = _get_json(
+        client,
+        "/api/entitlement/has-runtimes-at-batch"
+        f"?tiers={tiers_csv}&runtimes={bundle_csv}",
+    )
+    miss_body = _get_json(
+        client,
+        "/api/entitlement/missing-runtimes-at-batch"
+        f"?tiers={tiers_csv}&runtimes={bundle_csv}",
+    )
+    miss_by_tier = {row["tier"]: row["missing"] for row in miss_body["tiers"]}
+    for row in has_body["tiers"]:
+        assert row["allowed"] == (miss_by_tier[row["tier"]] == []), row["tier"]
+
+
+# ── Endpoint: never 5xx on scalar / delegate blowup ───────────────────────
+
+
+def test_endpoint_features_never_5xx_on_scalar_blowup(client, ent, monkeypatch):
+    def boom(*a, **kw):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(ent, "has_features_at_batch", boom)
+    resp = client.get(
+        "/api/entitlement/has-features-at-batch?tiers=oss&features=fleet"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    # fallback shape: tiers empty, tokens echoed, grace envelope
+    assert body["tiers"] == []
+    assert body["features"] == []
+    assert body["unknown"] == ["fleet"]
+    assert body["unknown_tiers"] == ["oss"]
+    assert body["current_tier"] == "oss"
+    assert body["all_allowed"] is False
+    assert body["any_allowed"] is False
+    assert body["allowed_count"] == 0
+
+
+def test_endpoint_runtimes_never_5xx_on_scalar_blowup(client, ent, monkeypatch):
+    def boom(*a, **kw):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(ent, "has_runtimes_at_batch", boom)
+    resp = client.get(
+        "/api/entitlement/has-runtimes-at-batch?tiers=oss&runtimes=openclaw"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["tiers"] == []
+    assert body["runtimes"] == []
+    assert body["unknown_tiers"] == ["oss"]
+
+
+def test_endpoint_features_never_5xx_on_resolver_blowup(client, ent, monkeypatch):
+    """A resolver crash inside :func:`_resolver_envelope` still returns 200
+    with the fallback envelope."""
+    def boom():
+        raise RuntimeError("resolver down")
+
+    monkeypatch.setattr(ent, "get_entitlement", boom)
+    resp = client.get(
+        "/api/entitlement/has-features-at-batch?tiers=oss&features=fleet"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert set(body) == _ENVELOPE_KEYS_FEATURES
+    assert body["tiers"] == []
+
+
+# ── Envelope kind and count sanity ────────────────────────────────────────
+
+
+def test_endpoint_features_kind_and_count(client):
+    body = _get_json(
+        client,
+        "/api/entitlement/has-features-at-batch"
+        "?tiers=oss&features=fleet,sso",
+    )
+    assert body["kind"] == "features"
+    assert body["count"] == 2
+
+
+def test_endpoint_runtimes_kind_and_count(client):
+    body = _get_json(
+        client,
+        "/api/entitlement/has-runtimes-at-batch"
+        "?tiers=oss&runtimes=openclaw,claude_code",
+    )
+    assert body["kind"] == "runtimes"
+    assert body["count"] == 2
+
+
+def test_endpoint_features_current_tier_echoes_resolver(client, ent):
+    body = _get_json(
+        client,
+        "/api/entitlement/has-features-at-batch?tiers=oss&features=fleet",
+    )
+    live = ent.get_entitlement()
+    assert body["current_tier"] == live.tier
+    assert body["grace"] == bool(live.grace)
+
+
+# ── Preserved order + dedup at endpoint layer ─────────────────────────────
+
+
+def test_endpoint_features_dedup_preserves_first_seen_order(client):
+    body = _get_json(
+        client,
+        "/api/entitlement/has-features-at-batch"
+        "?tiers=cloud_pro,oss,cloud_pro&features=fleet,sso,fleet",
+    )
+    assert [row["tier"] for row in body["tiers"]] == ["cloud_pro", "oss"]
+    assert body["features"] == ["fleet", "sso"]
+
+
+def test_endpoint_runtimes_dedup_preserves_first_seen_order(client):
+    body = _get_json(
+        client,
+        "/api/entitlement/has-runtimes-at-batch"
+        "?tiers=pro,oss,pro&runtimes=openclaw,openclaw",
+    )
+    assert [row["tier"] for row in body["tiers"]] == ["pro", "oss"]
+    assert body["runtimes"] == ["openclaw"]


### PR DESCRIPTION
## Summary

- Adds `has_features_at_batch` / `has_runtimes_at_batch` boolean-fold batch what-if scalars completing the `has_*_at` family, in the same relationship `missing_features_at_batch` / `missing_runtimes_at_batch` (shipped in 2dff678) have to `missing_features_at` / `missing_runtimes_at`. Fixes ONE bundle and sweeps across N perspective tiers, returning one row per tier with the fold boolean.
- Adds paired `/api/entitlement/has-features-at-batch` and `/api/entitlement/has-runtimes-at-batch` endpoints on `bp_entitlement`. Envelope shape mirrors the sibling `/missing-*-at-batch` endpoints (tier normalisation, known/unknown split, upstream runtime-alias canonicalisation) with `allowed_count` / `all_allowed` / `any_allowed` roll-ups swapped in for the per-item denial list.
- Grace-independent by construction: delegates per-tier to `has_<axis>_at` which is backed by `_hypothetical_entitlement`. Wiring these into a paywall today changes **no** current behavior — resolved entitlement still defaults to OSS-free-grace.
- 58-test module `tests/test_entitlement_has_features_runtimes_at_batch.py` covering scalar and endpoint envelope shape, tier normalisation + dedup, empty / None / non-iterable input, unknown-tier bucketing, grace-independence across every `_TIER_ORDER` perspective, strict alias posture at scalar layer + endpoint canonicalisation, per-row roll-ups, scalar-vs-endpoint parity, cross-endpoint parity vs sibling `/has-<axis>-at` and `/missing-<axis>-at-batch`, and never-4xx / never-5xx.

Files:
- `clawmetry/entitlements.py` — two new scalars (~144 lines)
- `routes/entitlement.py` — `_has_bundle_at_batch_body`, `_has_bundle_at_batch_fallback`, two endpoints (~279 lines)
- `tests/test_entitlement_has_features_runtimes_at_batch.py` — new test module (58 tests)

## Test plan

- [x] `python -m py_compile clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_has_features_runtimes_at_batch.py` clean
- [x] `ruff check clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_has_features_runtimes_at_batch.py` clean
- [x] `python -m pytest tests/test_entitlement_has_features_runtimes_at_batch.py` — 58 pass
- [x] Sibling regression check: `tests/test_entitlement_missing_features_runtimes_at_batch.py`, `test_entitlement_has_features_at_has_runtimes_at.py`, `test_entitlement_has_features_has_runtimes.py`, `test_entitlement_missing_features_runtimes_at_path.py`, `test_entitlement_missing_features_runtimes_at_path_batch.py`, `test_entitlement_missing_features_runtimes_at.py` — 349 pass

### Local operator verification checklist

Since this branch was authored in a remote container with no access to the host, running daemon, `~/.openclaw`, or live cloud snapshot, the following steps need to happen on the operator's machine before ready-for-review:

- [ ] Copy `clawmetry/entitlements.py`, `routes/entitlement.py`, `tests/test_entitlement_has_features_runtimes_at_batch.py` into `~/.clawmetry/lib/pythonX.Y/site-packages/clawmetry/` (and its `routes/` / `tests/` siblings)
- [ ] Clear `__pycache__` under the target install
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
- [ ] `curl -s "http://localhost:8900/api/entitlement/has-features-at-batch?tiers=oss,cloud_pro,enterprise&features=fleet,sso" | jq` — expect 200 with `tiers[]` populated, `all_allowed=false` at OSS, `all_allowed=true` at enterprise, `unknown=[]`
- [ ] `curl -s "http://localhost:8900/api/entitlement/has-runtimes-at-batch?tiers=oss,pro&runtimes=claude-code,openclaw" | jq` — expect `runtimes=["claude_code","openclaw"]` (alias canonicalisation), row-per-tier `allowed`
- [ ] Confirm sibling `/api/entitlement/missing-features-at-batch` still returns identical `tiers[].tier` set for the same `?tiers=` input
- [ ] Confirm `/api/entitlement` still resolves as before (no resolver-path regression)
- [ ] Decrypt the live snapshot and browser-check the dashboard still loads (no import-time regression from the new helpers)

---
_Generated by [Claude Code](https://claude.ai/code/session_016AeqQ7hL5MC2T4T4YC3xi6)_