### PR TITLE
fix(c6): re-enable c6-schedule-heal cron (GitHub paused it after past failures)

### DIFF
--- a/.github/workflows/c6-schedule-heal.yml
+++ b/.github/workflows/c6-schedule-heal.yml
@@ -12,6 +12,14 @@ name: C6 auto-heal (required-checks application)
 # already provides equivalent status information, so the push trigger is
 # redundant. See issue #4029 for context.
 #
+# 2026-08-05: File touched to re-enable the GitHub-paused schedule (#4542).
+# GitHub auto-pauses scheduled workflows after consistent exit-1 failures.
+# The schedule was dark since 2026-07-20 while C6 was not yet configured;
+# C6 is now green (E2E gate enforced on clawmetry/main -- confirmed by
+# apply-required-checks.yml: 5 consecutive passes on 2026-08-04). A push
+# to main that modifies this file resumes the cron within minutes.
+# Subsequent scheduled runs exit 0 via the "C6 already configured" step.
+#
 # When E2E_ADMIN_PAT is NOT set:
 #   - reads current branch protection state (read-only, no admin needed)
 #   - if clawmetry/main checks already configured: exits 0 (C6 green)


### PR DESCRIPTION
## Summary

Closes #4542.

The `c6-schedule-heal.yml` scheduled workflow has had zero runs since 2026-07-20. GitHub auto-pauses scheduled workflows after they consistently exit with an error; the workflow was failing (exit 1) during the period when C6 was not yet configured. Since 2026-07-31 C6 IS configured, but the schedule never resumed because GitHub requires either a `workflow_dispatch` trigger or a push to `main` that modifies the workflow file.

**This PR is that push.** No logic changes -- comment-only update explaining the re-enable.

## What changes

`.github/workflows/c6-schedule-heal.yml` -- added a comment block (lines 15-21) documenting:
- Why the file was touched (re-enable the paused schedule)
- Evidence C6 is green (`apply-required-checks.yml`: 5 consecutive passes on 2026-08-04)
- How a file-modify push re-enables GitHub's cron

## Acceptance test

After merge, wait up to 2 hours for the `0 */2 * * *` schedule to fire. The run should exit 0 via the "C6 already configured" step (since `checks_ok == true`). Visible at: https://github.com/vivekchand/clawmetry/actions/workflows/c6-schedule-heal.yml

## No-op safety

The workflow logic is unchanged. If somehow C6 regresses (checks removed), the next scheduled run exits 1 and surfaces the issue via the red badge -- exactly the monitoring behaviour this workflow is designed for.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CXGfhhGXDgkuUu4mcUb5yr)_