### PR TITLE
fix(ci): re-enable c6-schedule-heal scheduled monitor (closes #4542)

### DIFF
--- a/.github/workflows/c6-schedule-heal.yml
+++ b/.github/workflows/c6-schedule-heal.yml
@@ -52,6 +52,8 @@ name: C6 auto-heal (required-checks application)
 #     This workflow picks it up within 2 hours and closes C6.
 #
 # Tracking: vivekchand/clawmetry#4029
+# Schedule-resume push: 2026-08-05 (workflow auto-paused Jul 2026 after pre-C6
+# failures; C6 now green since 2026-07-31; see #4542)
 
 on:
   schedule:


### PR DESCRIPTION
## Summary

- `c6-schedule-heal.yml` has had zero scheduled runs since 2026-07-20 — GitHub auto-paused it after consecutive failures that occurred _before_ C6 branch protection was configured (2026-07-31)
- C6 is now green: `apply-required-checks.yml` shows 5 consecutive successes as of 2026-08-04
- Adds a comment to touch the file; per [GitHub docs](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#schedule), a push that modifies the file re-enables a paused schedule

## Test plan

- [ ] After merge, confirm the next 2-hourly cron tick produces a green run under [Actions → c6-schedule-heal](https://github.com/vivekchand/clawmetry/actions/workflows/c6-schedule-heal.yml)
- [ ] Green run exits at the "C6 already configured (no PAT needed)" step (C6 is green, no E2E_ADMIN_PAT needed)

Closes #4542

---
_Generated by [Claude Code](https://claude.ai/code/session_01GCBKZxbDizbVFHMFAoB3kD)_