### PR TITLE
fix(install): unify installer tagline across ps1/sh/cmd

### DIFF
--- a/install.cmd
+++ b/install.cmd
@@ -4,7 +4,7 @@ REM Usage: curl -fsSL https://clawmetry.com/install.cmd -o install.cmd && instal
 
 echo.
 echo   🦞 ClawMetry Installer
-echo   Real-time observability for OpenClaw agents
+echo   Real-time observability ^& governance for AI agents
 echo.
 
 REM Check for Python

--- a/install.ps1
+++ b/install.ps1
@@ -2,7 +2,7 @@
 # Usage: irm https://raw.githubusercontent.com/vivekchand/clawmetry/main/install.ps1 | iex
 $ErrorActionPreference = "Stop"
 
-Write-Host "🔭 Installing Clawmetry — OpenClaw Observability Dashboard" -ForegroundColor Cyan
+Write-Host "🦞 ClawMetry  Real-time observability & governance for AI agents" -ForegroundColor Cyan
 Write-Host ""
 
 # Check for Python

--- a/install.sh
+++ b/install.sh
@@ -12,7 +12,7 @@ DIM='\033[2m'
 NC='\033[0m'
 
 echo ""
-echo -e "  ${BOLD}🦞 ClawMetry${NC}  ${DIM}Observability for your AI agents${NC}"
+echo -e "  ${BOLD}🦞 ClawMetry${NC}  ${DIM}Real-time observability & governance for AI agents${NC}"
 echo -e "  $(printf '%.0s─' {1..50})"
 echo ""
 


### PR DESCRIPTION
## Summary
- Windows installer said **"Installing Clawmetry — OpenClaw Observability Dashboard"**, which has been outdated ever since we grew past OpenClaw-only. Screenshot from a real user install today attached in the issue that prompted this.
- Mac/Linux script said the truer but shorter "Observability for your AI agents."
- All three (`install.ps1`, `install.sh`, `install.cmd`) now match the canonical hero line served on clawmetry.com: **Real-time observability & governance for AI agents**.
- Kept the 🦞 mascot, dropped the em dash per marketing rule (no em dashes in copy); escaped `&` as `^&` in the .cmd so batch doesn't split the echo on the ampersand.

## Test plan
- [x] `git diff` shows only the 3 tagline lines changed (nothing else touched)
- [ ] CI `install-test.yml` still green (bash/ps1/cmd smoke runs + shellcheck)
- [ ] After merge, `curl -fsSL https://clawmetry.com/install.sh | head` shows the new tagline
- [ ] After merge, `irm https://clawmetry.com/install.ps1` shows the new tagline

🤖 Generated with [Claude Code](https://claude.com/claude-code)