### PR TITLE
fix(cli): uninstall's reinstall hint matches host OS

### DIFF
--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -2339,9 +2339,14 @@ def _cmd_uninstall() -> None:
 
     print()
     print("  \033[1m\033[92m✓ ClawMetry fully uninstalled.\033[0m")
-    print(
-        "  \033[2mTo reinstall: curl -fsSL https://clawmetry.com/install.sh | bash\033[0m"
+    # Reinstall hint matches the host OS — a curl|bash line pasted into
+    # cmd.exe would just error, so Windows gets the .cmd fetch+run pair.
+    _reinstall_cmd = (
+        "curl -fsSL https://clawmetry.com/install.cmd -o install.cmd && install.cmd"
+        if sys.platform.startswith("win")
+        else "curl -fsSL https://clawmetry.com/install.sh | bash"
     )
+    print(f"  \033[2mTo reinstall: {_reinstall_cmd}\033[0m")
     print()
 
 


### PR DESCRIPTION
## Summary
- \`clawmetry uninstall\` printed \`curl -fsSL … install.sh | bash\` regardless of host, so a Windows user pasting it into cmd.exe would just error.
- Pick the command from \`sys.platform\` (this code runs on the client, so the CLI's own OS is the right signal): Windows → \`install.cmd\`, everything else → \`install.sh | bash\`.
- Companion to clawmetry-cloud #1934, which fixes the same misalignment on the hosted stale-daemon banner using the daemon-reported heartbeat platform.

## Test plan
- [ ] Windows box: \`clawmetry uninstall\` → reinstall hint shows the \`install.cmd -o install.cmd && install.cmd\` form.
- [ ] Mac/Linux: unchanged \`install.sh | bash\` form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)