### PR TITLE
[RELEASE] feat(grok): xAI Grok — 18th runtime (0.12.652, carries #4547)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@
   the dashboard unlocks within one 60s cycle with no restart. Set
   `CLAWMETRY_HARD_BLOCK=0` to opt out (support only). Details:
   `docs/TRIAL_ENFORCEMENT.md`.
+- **xAI Grok is the 18th observed runtime.** The Grok Build CLI (Rust binary
+  at `~/.grok/bin/grok`, installed via `curl x.ai/cli/install.sh`) now shows
+  up across the dashboard when Pro is licensed. Token accounting reads the
+  global `~/.grok/logs/unified.jsonl` (VERIFIED `shell.turn.inference_done`
+  row shape from the cereblab wire-level analysis + openusage#646); session
+  listing walks `~/.grok/sessions/<encoded-cwd>/<uuid>/`; cost derives via
+  the freshly-added `providers_pricing.xai` rates (grok-4 $3/$15, grok-3
+  $3/$15, grok-3-mini $0.30/$0.50, grok-code-fast-1 $0.20/$1.50, grok-2
+  $2/$10). Adapter lives in clawmetry-pro (0.7.4). Undocumented msg-name
+  branches parse defensively, so a wrong field guess produces NO data,
+  never fabricated data.
+- **Grok's outbound repo-upload panel.** The pro adapter surfaces the raw
+  `repo_state.upload.enqueued` manifests from `unified.jsonl` on
+  `Session.extra.uploadedPayloads` (fileId, size_bytes, file_count,
+  repo_path) plus a `uploadedBytesTotal` aggregate. The Grok tab can
+  render "what left your machine to xAI this session", a differentiated
+  view no other runtime needs, and the direct answer to the July 2026
+  disclosure that Grok Build silently uploaded entire repos to a
+  `grok-code-session-traces` GCS bucket.
 
 ## 0.12.650
 


### PR DESCRIPTION
## Summary

Bumps ClawMetry to `0.12.651` and publishes to PyPI, shipping xAI Grok Build CLI as the 18th observed runtime end to end.

Carries:
- **OSS #4547** (merged) — 13-file registry wiring + xAI Grok pricing in `providers_pricing.py`
- **Pro #118 / #119** (merged) — `GrokAdapter` (330 lines, defensive) + version bump 0.7.4
- **Cloud #1936** (merged) — `wheels/clawmetry_pro-0.7.4-py3-none-any.whl` for `/api/license/download`

`release-on-merge.yml` will bump `__version__` in `dashboard.py` to `0.12.651` and upload to PyPI on merge.

## What ships to users

- Detect `~/.grok/bin/grok` and register Grok as the 18th runtime.
- Read tokens + cost from `~/.grok/logs/unified.jsonl` via the VERIFIED `shell.turn.inference_done` row shape.
- Walk `~/.grok/sessions/<enc-cwd>/<uuid>/{summary.json,events.jsonl}` for per-session metadata.
- Cost via `providers_pricing.xai` with grok-family rates from x.ai/pricing (grok-4 $3/$15, grok-code-fast-1 $0.20/$1.50, grok-3-mini $0.30/$0.50, etc.).
- **Grok-only differentiator**: `Session.extra.uploadedPayloads` surfaces the raw `repo_state.upload.enqueued` manifests so the Grok tab can render "what left your machine to xAI this session" — the direct answer to the July 2026 disclosure that Grok Build silently uploaded repos to a `grok-code-session-traces` GCS bucket.

## Verified before release

- OSS wiring PR: ~30/30 CI checks green (E2E Gate, MOAT, Live OpenClaw E2E, sync matrix 3 OS x 3 Py, pip install 3 OS, wheel + asset presence)
- Pro adapter PR: 17/17 conformance jobs + fixture cost-conformance + drift-bot green; adapter test suite 17/17 locally
- Wheel: `zipfile`-verified GrokAdapter class + `_PAID_ADAPTERS` registration + `__version__ = 0.7.4`
- Cost derivation sanity: grok-4-latest 4359 in / 332 out → $0.018 (matches ballpark); grok-code-fast-1 1900 in / 650 out → $0.0014

## Verification after merge

- [ ] `release-on-merge.yml` completes; PyPI has `clawmetry==0.12.651`
- [ ] Cloud pin bumps to `0.12.651`, deploys, daemons pick up the 0.7.4 wheel via `/api/license/download`
- [ ] Daemon log line reads `clawmetry-pro: registered 16/16 closed runtime adapters` (was 15/15)
- [ ] Live SuperGrok Heavy install → real Grok session → decrypted snapshot shows `grok:<uuid>` sessions

Tracked in WO-15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)