### PR TITLE
docs(clawhub-plugin): add Windows install line to README

### DIFF
--- a/clawhub-plugin/README.md
+++ b/clawhub-plugin/README.md
@@ -14,8 +14,16 @@ openclaw plugins install clawmetry
 
 ### Via curl
 
+macOS / Linux:
+
 ```bash
 curl -fsSL https://clawmetry.com/install.sh | bash
+```
+
+Windows (cmd.exe / PowerShell — the sh line above cannot be parsed by cmd.exe):
+
+```
+curl -fsSL https://clawmetry.com/install.cmd -o install.cmd && install.cmd
 ```
 
 ### Via pip (standalone)


### PR DESCRIPTION
## Summary
The clawhub plugin README's \"Via curl\" install section only showed \`install.sh | bash\`, which cmd.exe cannot parse. Add the Windows equivalent (\`curl -fsSL https://clawmetry.com/install.cmd -o install.cmd && install.cmd\`) next to it, matching the landing page + cloud dashboard install surfaces.

## Companion PRs
- clawmetry-cloud #1934 (stale-daemon nag), #1935 (browser UA switcher), #1937 (emails + chat KB).
- clawmetry #4555 (CLI reinstall hint).
- clawmetry-landing #609 (connect + order-confirmed conversion pages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)