### PR TITLE
fix(ci): update c6-schedule-heal tracking issue to #4552, re-enable paused schedule

### DIFF
--- a/.github/workflows/c6-schedule-heal.yml
+++ b/.github/workflows/c6-schedule-heal.yml
@@ -51,7 +51,7 @@ name: C6 auto-heal (required-checks application)
 #     Value: same PAT from Option B
 #     This workflow picks it up within 2 hours and closes C6.
 #
-# Tracking: vivekchand/clawmetry#4029
+# Tracking: vivekchand/clawmetry#4552
 
 on:
   schedule:
@@ -250,7 +250,7 @@ print(json.dumps(sorted(set(a) | set(b))))
               echo "- [Settings > Secrets > New secret](https://github.com/vivekchand/clawmetry/settings/secrets/actions/new)"
               echo "  Name: \`E2E_ADMIN_PAT\`, Value: same PAT from Option B"
               echo ""
-              echo "Tracking: [#4029](https://github.com/vivekchand/clawmetry/issues/4029)"
+              echo "Tracking: [#4552](https://github.com/vivekchand/clawmetry/issues/4552)"
             fi
           } >> "$GITHUB_STEP_SUMMARY"
 
@@ -263,7 +263,7 @@ print(json.dumps(sorted(set(a) | set(b))))
         run: |
           echo "C6 is GREEN -- all required E2E status checks are configured on clawmetry/main."
           echo "Branch protection is correctly set. E2E_ADMIN_PAT is not needed."
-          echo "Tracking: https://github.com/vivekchand/clawmetry/issues/4029"
+          echo "Tracking: https://github.com/vivekchand/clawmetry/issues/4552"
 
       # Daily ping on the tracking issue when C6 is still unclosed.
       # Runs only on the 10:15 UTC daily schedule (not every 2-hour run)
@@ -282,7 +282,7 @@ print(json.dumps(sorted(set(a) | set(b))))
         run: |
           TODAY=$(date -u +%Y-%m-%d)
           BODY="<!-- c6-daily-ping --> **C6 daily ping ${TODAY}:** clawmetry/main branch protection does not yet require E2E checks. 6/7 criteria green. Fastest close: [Settings > Branches > main](https://github.com/vivekchand/clawmetry/settings/branches) > Required status checks > add \`E2E Gate (required)\` (60 s, no token needed). Or run \`bash scripts/close-c6.sh\` from a terminal."
-          gh issue comment 4029 --repo vivekchand/clawmetry --body "$BODY"
+          gh issue comment 4552 --repo vivekchand/clawmetry --body "$BODY"
 
       # Exit 1 only on schedule (never on push -- this workflow is informational on push).
       # Signals to the admin that E2E_ADMIN_PAT is needed to auto-heal C6.
@@ -296,7 +296,7 @@ print(json.dumps(sorted(set(a) | set(b))))
           echo ""
           echo "ACTION REQUIRED: Add E2E_ADMIN_PAT to close C6."
           echo "See the job summary above for a formatted status report and close options."
-          echo "Tracking: https://github.com/vivekchand/clawmetry/issues/4029"
+          echo "Tracking: https://github.com/vivekchand/clawmetry/issues/4552"
           exit 1
 
       - name: Apply required E2E status checks (C6)
@@ -319,6 +319,6 @@ print(json.dumps(sorted(set(a) | set(b))))
             echo "- [clawmetry-cloud branch protection](https://github.com/vivekchand/clawmetry-cloud/settings/branches)"
             echo "- [clawmetry-landing branch protection](https://github.com/vivekchand/clawmetry-landing/settings/branches)"
             echo ""
-            echo "Tracking: [#4029](https://github.com/vivekchand/clawmetry/issues/4029)"
+            echo "Tracking: [#4552](https://github.com/vivekchand/clawmetry/issues/4552)"
           } >> "$GITHUB_STEP_SUMMARY"
-          echo "C6 auto-heal complete. Tracking: https://github.com/vivekchand/clawmetry/issues/4029"
+          echo "C6 auto-heal complete. Tracking: https://github.com/vivekchand/clawmetry/issues/4552"

--- a/.github/workflows/c6-schedule-heal.yml
+++ b/.github/workflows/c6-schedule-heal.yml
@@ -12,6 +12,11 @@ name: C6 auto-heal (required-checks application)
 # already provides equivalent status information, so the push trigger is
 # redundant. See issue #4029 for context.
 #
+# Schedule paused: 2026-07-20 (GitHub auto-paused after consecutive failures
+# that predated C6 branch protection being configured on 2026-07-31).
+# Schedule re-enabled: 2026-08-06 (this push re-enables it; per GitHub docs,
+# any push that modifies a workflow file un-pauses a paused schedule).
+#
 # When E2E_ADMIN_PAT is NOT set:
 #   - reads current branch protection state (read-only, no admin needed)
 #   - if clawmetry/main checks already configured: exits 0 (C6 green)


### PR DESCRIPTION
## Summary

- `c6-schedule-heal.yml` has had zero scheduled runs since 2026-07-20 because GitHub auto-paused it after consecutive failures that predated C6 being configured.
- Per [GitHub docs](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#schedule), a push that modifies the workflow file re-enables a paused schedule. This commit does exactly that.
- Also updates all tracking issue references from the closed issue #4029 to the live E2E Robustness epic #4552, so daily pings and step summary links land on the correct open issue.

Previous attempt PR #4549 was closed without merging; this replaces it.

## Changes

- `c6-schedule-heal.yml`: header `Tracking:` comment, all `gh issue comment`, all step-summary tracking links, and all error-message tracking URLs updated from #4029 to #4552.
- Historical context comment (`See issue #4029 for context.` about the push-trigger removal) is intentionally left pointing to #4029 as it is a factual cross-reference, not a notification target.

## Test plan

- [ ] After merge, confirm the next 2-hourly cron tick produces a run under [Actions -> c6-schedule-heal](https://github.com/vivekchand/clawmetry/actions/workflows/c6-schedule-heal.yml) (schedule re-enabled by this push)
- [ ] If the ruleset applied by `c6-apply-ruleset.yml` is active, the run should exit at "C6 already configured (no PAT needed)" -- confirming C6 is GREEN
- [ ] If the run exits at "Error: E2E_ADMIN_PAT not set", the ruleset was not applied; use Settings > Branches or `bash scripts/close-c6.sh` to add `E2E Gate (required)` to branch protection

Closes #4542
Tracking: #4552

---
_Generated by [Claude Code](https://claude.ai/code/session_01YAacGqxQpc2zjGwkGgNMth)_