### PR TITLE
fix(ci): update c6-health tracking issue from #3964 to #4552

### DIFF
--- a/.github/workflows/c6-health.yml
+++ b/.github/workflows/c6-health.yml
@@ -10,7 +10,7 @@ name: C6 daily health check (branch-protection audit -- all 3 repos)
 # (can't verify) rather than "error" (broken). The health check gate
 # decision is based only on the clawmetry/main result (same-repo readable).
 #
-# On failure: posts an @-mentioned reminder to tracking issue #3964
+# On failure: posts an @-mentioned reminder to tracking issue #4552
 # at most once per calendar day. On success: posts a GREEN confirmation.
 #
 # To close C6 (any of these paths -- all take under 2 minutes):
@@ -20,7 +20,7 @@ name: C6 daily health check (branch-protection audit -- all 3 repos)
 #   2. Or: bash scripts/close-c6.sh
 #   3. Or: Settings > Branches > main > Required status checks (each repo)
 #
-# Tracking: vivekchand/clawmetry#3964
+# Tracking: vivekchand/clawmetry#4552
 
 on:
   schedule:
@@ -50,7 +50,7 @@ jobs:
 
           TOKEN = os.environ["GITHUB_TOKEN"]
           OWNER = "vivekchand"
-          TRACKING_ISSUE = 3964
+          TRACKING_ISSUE = 4552
           MARKER = "<!-- c6-health-check -->"
           # Repo this workflow runs in. GITHUB_TOKEN is repo-scoped: it can
           # read clawmetry (same-repo) but returns 403 for other repos.


### PR DESCRIPTION
## Summary

`c6-health.yml` posts the daily C6 branch-protection audit to the tracking issue -- both its GREEN/RED status comments and the 7-consecutive-green-days stop-condition countdown. It was pointing at the **closed** issue `#3964` instead of the live E2E Robustness epic `#4552`, so:

- Daily GREEN posts landed on a closed issue nobody reads
- The stop-condition comment-walk (`count_green_streak`) scanned `#3964`'s old thread instead of `#4552`
- **The 7/7-green countdown could never trigger** -- the streak always reset to 0

This complements PRs #4561 (`c6-schedule-heal.yml`) and #4563 (`c6-apply-ruleset.yml`) which fixed the same stale-reference bug in the other two C6 monitoring workflows.

## Changes

Notification targets only -- no logic change:

- `TRACKING_ISSUE = 3964` -> `4552`
- Header comment `# On failure: posts an @-mentioned reminder to tracking issue #3964` -> `#4552`
- Header comment `# Tracking: vivekchand/clawmetry#3964` -> `#4552`

## Test plan

- [ ] After merge, confirm tomorrow's 09:00 UTC cron tick posts to `#4552` (not `#3964`)
- [ ] If `clawmetry/main` already has `E2E Gate (required)` configured, the run should post `confirmed GREEN -- day N/7 of stop-condition countdown` on `#4552`
- [ ] The stop-condition countdown resets correctly from the `#4552` comment history (not the stale `#3964` thread)

Tracking: #4552

---
_Generated by [Claude Code](https://claude.ai/code/session_01G3NKDnWQCVRkoBzyonwRPU)_