### PR TITLE
[RELEASE] trial-end hard-block enforcement (carries #4566)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## Unreleased
+
+- **Trial ends → paid.** ClawMetry now blocks the dashboard UI + sync when
+  the trial period ends, prompting checkout with an un-dismissable modal.
+  Signed licenses land automatically over the heartbeat after payment, so
+  the dashboard unlocks within one 60s cycle with no restart. Set
+  `CLAWMETRY_HARD_BLOCK=0` to opt out (support only). Details:
+  `docs/TRIAL_ENFORCEMENT.md`.
+
 ## 0.12.650
 
 - **The profile menu now respects that you're self-hosted.** "Upgrade plan"


### PR DESCRIPTION
## Summary

Release trigger PR — carries [feat(entitlements): trial-end hard-block enforcement (default-ON) (#4566)](https://github.com/vivekchand/clawmetry/pull/4566) to PyPI. Merge fires \`release-on-merge.yml\` which bumps \`__version__\`, publishes the wheel, and tags a new release.

## What ships

- \`clawmetry/trial_enforcement.py\` — default-ON hard-block layer.
- \`routes/trial.py\` — \`/api/trial/status\`, \`/api/trial/refresh-license\`, \`/api/trial/mark-warned\`.
- \`dashboard.py\` — \`before_request\` gate returning 402 on non-allowlisted paths while blocked.
- \`clawmetry/static/js/app.js\` — un-dismissable full-viewport paywall overlay with "Continue to payment" CTA + paste-license flow + auto-clear poller.
- \`clawmetry/sync.py\` — heartbeat license auto-install (writes 0600 to \`~/.clawmetry/license.key\`) + 2-day trial-warning ping.
- \`clawmetry/extensions.py\` — refuses to load \`clawmetry-pro\` while hard-blocked.
- \`docs/TRIAL_ENFORCEMENT.md\` — design + rollout + allowlist doc.
- \`tests/test_trial_hard_block.py\` — 5 guard tests covering default-ON, allowlist, 402 payload, opt-out, entitlement parity.

## Cross-repo companion

Cloud PR [clawmetry-cloud #1938](https://github.com/vivekchand/clawmetry-cloud/pull/1938) shipped + deployed earlier this session:
- Extends \`/ingest/heartbeat\` with \`license_key\` (24h Redis marker), \`upgrade_url\`, \`trial_days_left\`.
- New \`POST /ingest/trial-warning\` endpoint that sends the "trial ends soon / has ended" email via existing Resend pipeline.

## Test plan

- [x] All required OSS CI green on #4566 (30 pass, drift-bot soft-fail only)
- [x] Cloud PR #1938 merged + deployed live; \`app.clawmetry.com\` returns 200
- [ ] After merge here: \`release-on-merge.yml\` bumps version + publishes to PyPI
- [ ] Founder verifies live: pip install -U clawmetry on a fresh trial-expired install → paywall renders → paste license → dashboard unlocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)