### PR TITLE
[RELEASE] Score button per conversation (carries #4557)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 ## Unreleased
 
+- **Score any conversation, right where you read it.** Every row in the
+  Conversations tab gets a small **Score** button that runs the same judge
+  the daemon uses (via `POST /api/evals/rescore/<session_id>`). Result
+  renders inline as a colored badge — green ≥ 4, amber ≥ 2.5, red below —
+  with the judge's one-line reason on hover. If no judge key is set the
+  button flips into "Set judge key →" that opens the rubric + key modal on
+  the spot, so the setup lives where you first need it instead of behind
+  the small ⚙ icon on the Evals tab. Works both on the local dashboard
+  and via `app.clawmetry.com/node/*?runtime=openclaw` (cloud already
+  allowlisted the route).
+
 - **Trial ends → paid.** ClawMetry now blocks the dashboard UI + sync when
   the trial period ends, prompting checkout with an un-dismissable modal.
   Signed licenses land automatically over the heartbeat after payment, so


### PR DESCRIPTION
Release trigger PR — carries #4557 (Score button per conversation) to PyPI. Merge fires `release-on-merge.yml` which bumps `__version__`, publishes the wheel, and tags a new release.

## What ships (from #4557)

- `clawmetry/static/js/app.js` — Score button on every transcript row + `scoreTranscript(sid)` that POSTs to the existing `/api/evals/rescore/<session_id>`, renders the returned score/reason inline as a colored badge (green ≥4, amber ≥2.5, red <2.5), and flips into a 'Set judge key →' affordance opening `openEvalRubricModal()` when the daemon returns a no-key skip.
- `clawmetry/static/locales/en.json` — six new keys with English fallbacks in the JS.

## Why now

Vivek reported live that the Evals tab reads like a status page for something someone else configured. No verb, no way to spot-check a bad session, judge-key modal invisible behind a tiny ⚙. This turns Conversations into the action surface: scroll to the session that felt off, click **Score**, get an inline verdict — or a one-click path into the setup modal at exactly the moment you need it.

## Cross-repo

None required. `cloud_route_policy/policy.py:1703` already allowlists `POST /api/evals/rescore/<session_id>`, so this works on `app.clawmetry.com/node/*?runtime=openclaw` the moment the runtime pin updates.

## Test plan

- [x] Required OSS CI green on #4557
- [ ] After merge here: `release-on-merge.yml` bumps `__version__` past 0.12.650 and publishes to PyPI
- [ ] Openclaw runtime picks up the new wheel
- [ ] Live verify: `app.clawmetry.com/node/pharasso%2BPharma?runtime=openclaw` — Conversations tab, click Score, confirm the badge or the 'Set judge key →' CTA