### PR TITLE
[RELEASE] Score button cloud-mode fix (carries #4572)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,10 @@
   with the judge's one-line reason on hover. If no judge key is set the
   button flips into "Set judge key →" that opens the rubric + key modal on
   the spot, so the setup lives where you first need it instead of behind
-  the small ⚙ icon on the Evals tab. Works both on the local dashboard
-  and via `app.clawmetry.com/node/*?runtime=openclaw` (cloud already
-  allowlisted the route).
+  the small ⚙ icon on the Evals tab. On `app.clawmetry.com/node/*` the
+  live-Score button is replaced with a stored-score badge computed by the
+  daemon on the machine that has the judge key + session DuckDB, since
+  scoring can't run on the cloud proxy.
 
 - **Trial ends → paid.** ClawMetry now blocks the dashboard UI + sync when
   the trial period ends, prompting checkout with an un-dismissable modal.


### PR DESCRIPTION
Release trigger PR — carries #4572 (don't show live-Score button in cloud mode) to PyPI. Merge fires `release-on-merge.yml` which bumps `__version__` past 0.12.652 and publishes the wheel; cloud auto-pins on next OSS-file push.

## Why now

#4557's Score button rendered in BOTH local and cloud dashboards. On cloud, scoring can't run (no judge key, no session DuckDB), so a click there always returned a not-useful skip. #4572 gates the button on `window.CLOUD_MODE` and, in cloud, replaces it with a stored-score badge fetched from `/api/evals/recent` (which the existing cm-cloud-evals interceptor serves from the encrypted snapshot).

## What ships

- `clawmetry/static/js/app.js` from #4572:
  - `loadTranscripts()` in CLOUD_MODE now refetches `/api/evals/recent` once per list load and builds a `sid → {score, reason}` map.
  - The row renderer shows the Score button only when `!window.CLOUD_MODE`. In cloud mode it renders a colored badge for rows that have a stored score, and nothing for rows that don't.
- `CHANGELOG.md` "Unreleased" entry updated to match the new behavior.

## Test plan

- [x] Required OSS CI green on #4572
- [ ] After merge here: `release-on-merge.yml` bumps `__version__` past 0.12.652 and publishes to PyPI
- [ ] auto-deploy-cloud fires and pins clawmetry-cloud Dockerfile to the new version
- [ ] Founder verifies live on `app.clawmetry.com/node/pharasso%2BPharma?runtime=openclaw` — Conversations tab shows stored-score badges (from daemon ticks) and no live-Score button; `localhost:8900` on the openclaw VM still shows the live Score button + no-key CTA

🤖 Generated with [Claude Code](https://claude.com/claude-code)