### PR TITLE
[RELEASE] Retire legacy gateway modal, Plan: status line, free-tier hard-block fix (carries #4575)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 ## Unreleased
 
+- **Retired the legacy "ClawMetry Setup" gateway-token modal.** It auto-popped
+  on every dashboard load regardless of whether onboarding had already
+  completed (v0.1-era UX from before the product detected 17+ non-OpenClaw
+  runtimes). The existing onboarding-gate modal (managed cloud vs self-host,
+  which already tracks completion correctly via `/api/onboarding/state`) is
+  now the only first-run gate. A new opt-in "Gateway" tab under the
+  Developer drawer still lets real OpenClaw users paste a gateway token
+  manually. The Agents (Inventory) tab now shows an upgrade nudge for a
+  detected-but-not-yet-entitled runtime instead of a "sync starting up"
+  message that would never resolve.
+- **`clawmetry status` shows an explicit `Plan:` line** (Free / Trial /
+  Trial Expired / Starter / Pro), unconditional unlike the old `License:`
+  block, which stayed silent whenever no local key file existed.
+- **Expired trials now actually stop ingesting new paid-runtime data.**
+  `sync_family_runtimes` checks `entitlements.allows_runtime()` per adapter
+  per sync cycle. Previously only an install-time "is the pro wheel on
+  disk" check gated ingestion, so a trial that later expired kept
+  ingesting new Claude Code/Codex/etc. sessions indefinitely once the
+  wheel had landed once.
+- **Fixed a same-day regression in the trial-end hard-block gate**
+  (`clawmetry/trial_enforcement.py`, shipped default-on earlier the same
+  day): it was hard-blocking (HTTP 402) every plain OSS/free install, not
+  just an expired trial or subscription. Verified live before the fix: a
+  fresh `pip install clawmetry` with no license or cloud account returned
+  `hard_blocked: true, source: "oss"` on `/api/sessions` and
+  `/api/overview` and never finished booting the dashboard. Now only a
+  source that was actually on a paid or trial tier and has since passed
+  its expiry is blocked; a never-entitled install passes through
+  untouched. See `docs/TRIAL_ENFORCEMENT.md`.
+
 - **Score any conversation, right where you read it.** Every row in the
   Conversations tab gets a small **Score** button that runs the same judge
   the daemon uses (via `POST /api/evals/rescore/<session_id>`). Result

--- a/docs/TRIAL_ENFORCEMENT.md
+++ b/docs/TRIAL_ENFORCEMENT.md
@@ -1,21 +1,22 @@
 # Trial-end hard block
 
-> **Status: OSS-side enforcement shipped default-ON as of 2026-08-06. Cloud-side email + heartbeat payload extensions land alongside. Legitimate paying customers with valid signed licenses are unaffected — only unpaid / expired installs hit the block.**
+> **Status: OSS-side enforcement shipped default-ON as of 2026-08-06, corrected 2026-08-06 to exempt the free tier. Cloud-side email + heartbeat payload extensions land alongside. Legitimate paying customers with valid signed licenses are unaffected. A plain OSS/cloud_free install that never had a trial or license is ALSO unaffected: only a source that was actually on a paid or trial tier and has since passed its expiry hits the block.**
 >
 > This document is the design-note for the paywall enforcement layer added
 > alongside [`clawmetry/trial_enforcement.py`](../clawmetry/trial_enforcement.py).
 > Its companion, [`docs/ENTITLEMENTS.md`](./ENTITLEMENTS.md), documents the
 > tier + resolver model. This file is only about what happens *when* the
-> resolver reports an unpaid / expired install.
+> resolver reports a lapsed paid/trial install.
 
 ## What ships in OSS today
 
-**Default ON.** Every install whose entitlement resolves to unpaid (OSS /
-cloud_free) or expired (trial past deadline, or a paid tier that lapsed)
-will hit the block. Explicitly set `CLAWMETRY_HARD_BLOCK=0` (or `false` /
-`no` / `off`) to opt out — kept as a support lever for the rare case of a
-legitimate paying customer whose license file corrupted mid-renewal. Under
-default-ON, a ClawMetry install in this state will:
+**Default ON, scoped to a lapsed paid/trial state only.** An install whose
+entitlement resolves to a source that WAS on a paid or trial tier and has
+now passed its `expiry` will hit the block. Explicitly set
+`CLAWMETRY_HARD_BLOCK=0` (or `false` / `no` / `off`) to opt out, kept as a
+support lever for the rare case of a legitimate paying customer whose
+license file corrupted mid-renewal. Under default-ON, a ClawMetry install
+in the expired state will:
 
 1. Return HTTP `402 Payment Required` with header `X-Clawmetry-Trial-Blocked: 1`
    for **every** request outside the small allowlist defined in
@@ -25,18 +26,25 @@ default-ON, a ClawMetry install in this state will:
    ```json
    {
      "hard_blocked": true,
-     "tier": "oss",
-     "source": "oss",
-     "expired": false,
-     "expiry": null,
-     "days_until_expiry": null,
-     "reason": "ClawMetry Pro is required to continue using this install.",
+     "tier": "trial",
+     "source": "license",
+     "expired": true,
+     "expiry": 1785937657.06,
+     "days_until_expiry": 0,
+     "reason": "Your ClawMetry trial has ended.",
      "upgrade_url": "https://app.clawmetry.com/upgrade",
      "activation_endpoint": "/api/license/activate",
      "refresh_endpoint": "/api/trial/refresh-license",
      "status_endpoint": "/api/trial/status"
    }
    ```
+
+   A plain OSS/`cloud_free` install (`tier: "oss"`, `source: "oss"`, never
+   entitled) never reaches this block: `is_hard_blocked()` returns `False`
+   for it regardless of `CLAWMETRY_HARD_BLOCK`. Corrected 2026-08-06 (was
+   shipped blocking this case too for a few hours; live-verified before the
+   fix that a fresh `pip install clawmetry` with no license/trial never
+   finished booting, since every `/api/*` call it depends on 402'd).
 
 2. Render a **full-viewport, un-dismissable modal** (`static/js/app.js` top-
    of-file IIFE, `#cm-hard-block-overlay`) that shows the block reason, a
@@ -92,9 +100,14 @@ are the specific loophole this closes.
 
 Paying customers with a valid signed Ed25519 license file on disk are
 NOT affected — the resolver returns `is_paid=True` + unexpired, which
-short-circuits the block predicate. Only unpaid (OSS / cloud_free) and
-expired (trial past deadline, or a paid subscription that lapsed) installs
-hit the paywall.
+short-circuits the block predicate. Only a source that WAS on a paid or
+trial tier and has since passed its `expiry` (trial past deadline, or a
+paid subscription that lapsed) hits the paywall. Plain OSS / `cloud_free`
+(never entitled at all) is exempt: it was never the loophole this closes,
+and the original shipped predicate over-applied "not currently paid" to
+mean "block", instead of "was paid/trialing and lapsed, block". Corrected
+the same day once the live symptom (a fresh free install stuck forever on
+"Initializing ClawMetry") surfaced.
 
 The `CLAWMETRY_HARD_BLOCK=0` opt-out exists solely as a support lever for
 the rare case of a legitimate paying customer whose license file


### PR DESCRIPTION
## Summary

Release PR for #4575 (already merged to main). CHANGELOG entry plus a correction to
`docs/TRIAL_ENFORCEMENT.md`, whose example payload and prose described blocking every
plain OSS/free install as intended behavior. That description was itself a same-day
regression fixed in #4575: verified live that a fresh `pip install clawmetry` with no
license or cloud account never finished booting (every `/api/*` call 402'd). The doc now
matches the corrected code and the free-tier promise stated throughout
`docs/ENTITLEMENTS.md` and every repo's `CLAUDE.md`/`FLYWHEEL.md`.

## Test plan

- [x] CHANGELOG entry added under `[Unreleased]`
- [x] `docs/TRIAL_ENFORCEMENT.md` example payload and prose corrected to match the shipped
      `_resolver_says_unpaid_or_expired` behavior
- [x] No em-dashes or double-dashes in either doc change (checked with a grep before commit)
- [x] This PR carries no code changes beyond docs; #4575's own CI run (31/31 green) already
      covers the code

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_014M9RFasj1Cak93j3CuF1q5

---
_Generated by [Claude Code](https://claude.ai/code/session_014M9RFasj1Cak93j3CuF1q5)_