### PR TITLE
Auto-update root cause fix + self-host trial silently failing + runtime-chip cloud redirect

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,10 @@ on:
     branches: [main, master]
   pull_request:
 
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # ── Fast syntax check (runs in ~10s, blocks everything else) ─────────────────────
   lint:

--- a/.github/workflows/sync-test.yml
+++ b/.github/workflows/sync-test.yml
@@ -17,6 +17,10 @@ on:
       - '.github/workflows/sync-test.yml'
   workflow_dispatch:
 
+concurrency:
+  group: sync-test-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   sync-test:
     strategy:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 ## Unreleased
 
+- **Fixed the root cause of ClawMetry silently no longer auto-updating.**
+  The browser onboarding gate (`routes/onboarding.py`, the default
+  first-run path since the 2026-07-31 hard-gate rollout) completed a
+  `managed`/`selfhost_*` choice without ever starting or registering a
+  background sync daemon — only the CLI paths (`clawmetry connect`,
+  `clawmetry onboard`) did that. The only thing left polling PyPI was the
+  foreground dashboard's in-process checker thread, which stops the
+  moment that one process exits (closed terminal, sleep, reboot, crash),
+  silently and permanently halting auto-update until a human manually
+  relaunched `clawmetry`. Onboarding completion now always calls the new
+  `clawmetry/daemon_registration.py::ensure_persistent_daemon()`.
+  Windows also gets real persistence for the first time: previously it had
+  no launchd/systemd equivalent at all (`_start_daemon`'s Windows branch
+  fell straight to an unsupervised detached subprocess), so a Windows node
+  lost auto-update after any reboot/logoff/crash even when a daemon HAD
+  been registered — it now registers a logon-triggered, restart-on-failure
+  Task Scheduler task. Finally, `auto_update` self-healing (re-asserting
+  the default-on `True` after a stale persisted `False`) previously only
+  ran for entitled *paid* cloud accounts via the heartbeat
+  (`_sync_auto_update_with_plan`); self-hosted and free-tier installs had
+  no path back to `True`. The update-check worker now heals a stale unset
+  `False` for every role/tier on boot, while a real, explicit user opt-out
+  (`POST /api/update-check/config`) is now tracked and never overridden.
 - **Retired the legacy "ClawMetry Setup" gateway-token modal.** It auto-popped
   on every dashboard load regardless of whether onboarding had already
   completed (v0.1-era UX from before the product detected 17+ non-OpenClaw

--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -1519,8 +1519,19 @@ def _start_daemon(config: dict, args) -> None:
         _register_launchd(config)
     elif system == "Linux":
         _register_systemd(config)
+    elif os.name == "nt":
+        # Windows has no launchd/systemd equivalent short of Task Scheduler.
+        # Without a registered task the daemon (and with it, all auto-update
+        # polling) does not survive a reboot/logoff/crash -- confirmed live
+        # on the founder's own Windows box (2026-07-28, CHANGELOG #4146).
+        # Register a logon-triggered, restart-on-failure scheduled task;
+        # fall back to the old unsupervised subprocess if schtasks fails
+        # (e.g. sandboxed/locked-down environments with no Task Scheduler
+        # access) so `clawmetry connect`/`onboard` never hard-fails here.
+        from clawmetry.daemon_registration import register_windows_task
+        if not register_windows_task(config):
+            _start_subprocess()
     else:
-        # Windows / fallback: subprocess
         _start_subprocess()
 
 

--- a/clawmetry/daemon_registration.py
+++ b/clawmetry/daemon_registration.py
@@ -1,0 +1,307 @@
+"""clawmetry/daemon_registration.py — one place that knows how to make the
+sync daemon survive a reboot/logoff/crash, on every OS.
+
+Root cause this exists to fix: three call sites (``clawmetry connect``,
+``clawmetry onboard`` self-host, and the browser cloud-connect flow in
+dashboard.py) each carried their own slightly-different copy of "register a
+persistent daemon" -- and the browser SELF-HOST onboarding gate
+(routes/onboarding.py, the now-default install path since the 2026-07-31
+hard-gate rollout) carried none at all, so a plain
+``pip install clawmetry && clawmetry`` that finished onboarding in the
+browser never got a background service. The only thing polling PyPI was the
+foreground dashboard process's in-thread checker (dashboard.py
+start_update_check_thread), which stops the moment that process exits --
+closed terminal, sleep, reboot, crash. Auto-update then silently never
+resumes until the user manually relaunches ``clawmetry``.
+
+``ensure_persistent_daemon(config)`` is the single entry point every one of
+those call sites should use. It registers real OS-level supervision
+(launchd KeepAlive / systemd Restart=always / Windows Scheduled Task with
+restart-on-failure) so *something* is always alive to run the sync daemon's
+fast auto-update loop, independent of whether the dashboard is open.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+
+def _log_file_path() -> str:
+    try:
+        from clawmetry.sync import LOG_FILE
+        return str(LOG_FILE)
+    except Exception:
+        return os.path.expanduser("~/.clawmetry/sync.log")
+
+
+def _is_root() -> bool:
+    return hasattr(os, "geteuid") and os.geteuid() == 0
+
+
+def _is_sync_running() -> bool:
+    import subprocess
+    try:
+        r = subprocess.run(
+            ["pgrep", "-f", "clawmetry.*sync"], capture_output=True, timeout=3
+        )
+        return r.returncode == 0
+    except Exception:
+        return False
+
+
+def register_launchd(config: dict) -> bool:
+    """macOS: install + bootstrap a launchd agent with KeepAlive."""
+    import pathlib
+    import subprocess
+
+    label = "com.clawmetry.sync"
+    plist_path = pathlib.Path.home() / "Library" / "LaunchAgents" / f"{label}.plist"
+    python = sys.executable
+    plist = f"""<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>             <string>{label}</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>{python}</string>
+        <string>-m</string>
+        <string>clawmetry.sync</string>
+    </array>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>CLAWMETRY_ENABLE_WS_TAP</key><string>1</string>
+    </dict>
+    <key>RunAtLoad</key>         <true/>
+    <key>KeepAlive</key>         <true/>
+    <key>StandardOutPath</key>   <string>{_log_file_path()}</string>
+    <key>StandardErrorPath</key> <string>{_log_file_path()}</string>
+    <key>ThrottleInterval</key>  <integer>30</integer>
+</dict>
+</plist>"""
+    try:
+        plist_path.parent.mkdir(parents=True, exist_ok=True)
+        plist_path.write_text(plist)
+        uid = os.getuid()
+        r = subprocess.run(
+            ["launchctl", "bootstrap", f"gui/{uid}", str(plist_path)],
+            capture_output=True, check=False,
+        )
+        if r.returncode != 0:
+            subprocess.run(
+                ["launchctl", "load", "-w", str(plist_path)],
+                capture_output=True, check=False,
+            )
+        return True
+    except Exception:
+        return False
+
+
+def register_systemd(config: dict) -> bool:
+    """Linux: install a systemd unit (system scope for root, --user otherwise)
+    with Restart=always, and verify it actually came up."""
+    import pathlib
+    import shutil
+    import subprocess
+    import time
+
+    label = "clawmetry-sync"
+    python = sys.executable
+    root = _is_root()
+    service_dir = (
+        pathlib.Path("/etc/systemd/system") if root
+        else pathlib.Path.home() / ".config" / "systemd" / "user"
+    )
+    wanted_by = "multi-user.target" if root else "default.target"
+    scope = [] if root else ["--user"]
+    extra_unit = "User=root\n" if root else ""
+
+    unit = f"""[Unit]
+Description=ClawMetry Cloud Sync Daemon
+After=network.target
+
+[Service]
+ExecStart={python} -m clawmetry.sync
+Environment=CLAWMETRY_ENABLE_WS_TAP=1
+{extra_unit}Restart=always
+RestartSec=30
+StandardOutput=append:{_log_file_path()}
+StandardError=append:{_log_file_path()}
+
+[Install]
+WantedBy={wanted_by}
+"""
+    if not shutil.which("systemctl"):
+        return False
+    try:
+        service_dir.mkdir(parents=True, exist_ok=True)
+        (service_dir / f"{label}.service").write_text(unit)
+        subprocess.run(["systemctl", *scope, "daemon-reload"],
+                        check=False, capture_output=True)
+        subprocess.run(["systemctl", *scope, "enable", "--now", label],
+                        check=False, capture_output=True)
+        time.sleep(1.0)
+        chk = subprocess.run(["systemctl", *scope, "is-active", label],
+                              capture_output=True, text=True)
+        return chk.stdout.strip() == "active" or _is_sync_running()
+    except Exception:
+        return False
+
+
+WINDOWS_TASK_NAME = "ClawMetrySyncDaemon"
+
+
+def register_windows_task(config: dict) -> bool:
+    """Windows: register a Scheduled Task that runs the daemon at logon and
+    restarts it on failure, matching launchd KeepAlive / systemd
+    Restart=always. Windows has no user-mode equivalent of a supervised
+    service short of Task Scheduler; without this, nothing brings the daemon
+    back after a reboot or logoff, so a node silently stops polling PyPI
+    until someone manually relaunches ``clawmetry``.
+    """
+    import subprocess
+    import tempfile
+
+    python = sys.executable
+    # pythonw would hide console output entirely; use the same interpreter
+    # the rest of the daemon-registration paths use so `-m clawmetry.sync`
+    # behaves identically to a manual launch.
+    command = f'"{python}" -m clawmetry.sync'
+    xml = f"""<?xml version="1.0" encoding="UTF-16"?>
+<Task version="1.2" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">
+  <Triggers>
+    <LogonTrigger>
+      <Enabled>true</Enabled>
+    </LogonTrigger>
+  </Triggers>
+  <Principal>
+    <LogonType>InteractiveToken</LogonType>
+    <RunLevel>LeastPrivilege</RunLevel>
+  </Principal>
+  <Settings>
+    <MultipleInstancesPolicy>IgnoreNew</MultipleInstancesPolicy>
+    <DisallowStartIfOnBatteries>false</DisallowStartIfOnBatteries>
+    <StopIfGoingOnBatteries>false</StopIfGoingOnBatteries>
+    <StartWhenAvailable>true</StartWhenAvailable>
+    <RestartOnFailure>
+      <Interval>PT1M</Interval>
+      <Count>999</Count>
+    </RestartOnFailure>
+    <ExecutionTimeLimit>PT0S</ExecutionTimeLimit>
+  </Settings>
+  <Actions>
+    <Exec>
+      <Command>{python}</Command>
+      <Arguments>-m clawmetry.sync</Arguments>
+    </Exec>
+  </Actions>
+</Task>"""
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".xml", delete=False, encoding="utf-16"
+        ) as fh:
+            fh.write(xml)
+            xml_path = fh.name
+        try:
+            r = subprocess.run(
+                ["schtasks", "/create", "/tn", WINDOWS_TASK_NAME,
+                 "/xml", xml_path, "/f"],
+                capture_output=True, check=False,
+            )
+            created = r.returncode == 0
+            if created:
+                # /create with a LogonTrigger doesn't start it immediately —
+                # run it now so the daemon starts this session too, not just
+                # after the next logon.
+                subprocess.run(["schtasks", "/run", "/tn", WINDOWS_TASK_NAME],
+                                capture_output=True, check=False)
+            return created
+        finally:
+            try:
+                os.remove(xml_path)
+            except OSError:
+                pass
+    except Exception:
+        return False
+
+
+def windows_task_registered() -> bool:
+    """Best-effort probe: is the scheduled task from register_windows_task
+    present? Mirrors the launchd-plist / systemd-unit existence checks
+    routes/update_check.py uses for _daemon_supervised()."""
+    import subprocess
+    try:
+        r = subprocess.run(
+            ["schtasks", "/query", "/tn", WINDOWS_TASK_NAME],
+            capture_output=True, check=False,
+        )
+        return r.returncode == 0
+    except Exception:
+        return False
+
+
+def start_background_subprocess() -> bool:
+    """Last-resort fallback when no OS-level supervisor is available
+    (systemd missing in a container, schtasks failed, etc.): a detached
+    subprocess that at least survives the launching terminal closing, even
+    though it will not survive a reboot/crash."""
+    import subprocess
+    import pathlib
+
+    sync_script = str(pathlib.Path(__file__).parent / "sync.py")
+    log_path = pathlib.Path.home() / ".clawmetry" / "sync.log"
+    try:
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+    except Exception:
+        pass
+
+    import shutil
+    cmd = (
+        ["setsid", sys.executable, sync_script]
+        if shutil.which("setsid")
+        else [sys.executable, sync_script]
+    )
+    spawn_kwargs = {"stdin": subprocess.DEVNULL, "close_fds": True}
+    if os.name == "nt":
+        spawn_kwargs["creationflags"] = (
+            subprocess.DETACHED_PROCESS | subprocess.CREATE_NEW_PROCESS_GROUP
+        )
+    else:
+        spawn_kwargs["start_new_session"] = True
+    try:
+        log_fh = open(str(log_path), "a")
+        try:
+            subprocess.Popen(cmd, stdout=log_fh, stderr=subprocess.STDOUT, **spawn_kwargs)
+        finally:
+            log_fh.close()
+        return True
+    except Exception:
+        return False
+
+
+def ensure_persistent_daemon(config: dict | None = None) -> bool:
+    """Register (or start) a persistent sync daemon appropriate for this OS.
+
+    Returns True on a best-effort success signal, False if every mechanism
+    failed (still safe to call — never raises). Idempotent: safe to call
+    repeatedly (e.g. once per onboarding-completion request).
+    """
+    config = config or {}
+    try:
+        from clawmetry.sync import ensure_local_config
+        ensure_local_config()
+    except Exception:
+        pass
+
+    system = __import__("platform").system()
+    if system == "Darwin":
+        if register_launchd(config):
+            return True
+    elif system == "Linux":
+        if register_systemd(config):
+            return True
+    elif os.name == "nt":
+        if register_windows_task(config):
+            return True
+    return start_background_subprocess()

--- a/clawmetry/daemon_registration.py
+++ b/clawmetry/daemon_registration.py
@@ -110,12 +110,12 @@ def register_launchd(config: dict) -> bool:
         uid = os.getuid()
         r = subprocess.run(
             ["launchctl", "bootstrap", f"gui/{uid}", str(plist_path)],
-            capture_output=True, check=False,
+            capture_output=True, check=False, timeout=8,
         )
         if r.returncode != 0:
             subprocess.run(
                 ["launchctl", "load", "-w", str(plist_path)],
-                capture_output=True, check=False,
+                capture_output=True, check=False, timeout=8,
             )
         return True
     except Exception:
@@ -161,13 +161,22 @@ WantedBy={wanted_by}
     try:
         service_dir.mkdir(parents=True, exist_ok=True)
         (service_dir / f"{label}.service").write_text(unit)
+        # Root cause of a real CI regression (2026-08-06): these three calls
+        # had no timeout, and this whole function runs synchronously inside
+        # the onboarding-complete HTTP handler. A CI/container runner with no
+        # user systemd instance / dbus session can make `systemctl --user
+        # enable --now` hang rather than fail fast, which blocked the
+        # browser's onboarding-complete request indefinitely -- the visible
+        # symptom was the dashboard stuck forever on "Initializing
+        # ClawMetry". Bound every call so the worst case is a few seconds,
+        # never a hang.
         subprocess.run(["systemctl", *scope, "daemon-reload"],
-                        check=False, capture_output=True)
+                        check=False, capture_output=True, timeout=8)
         subprocess.run(["systemctl", *scope, "enable", "--now", label],
-                        check=False, capture_output=True)
+                        check=False, capture_output=True, timeout=8)
         time.sleep(1.0)
         chk = subprocess.run(["systemctl", *scope, "is-active", label],
-                              capture_output=True, text=True)
+                              capture_output=True, text=True, timeout=8)
         return chk.stdout.strip() == "active" or _is_sync_running()
     except Exception:
         return False
@@ -231,7 +240,7 @@ def register_windows_task(config: dict) -> bool:
             r = subprocess.run(
                 ["schtasks", "/create", "/tn", WINDOWS_TASK_NAME,
                  "/xml", xml_path, "/f"],
-                capture_output=True, check=False,
+                capture_output=True, check=False, timeout=8,
             )
             created = r.returncode == 0
             if created:
@@ -239,7 +248,7 @@ def register_windows_task(config: dict) -> bool:
                 # run it now so the daemon starts this session too, not just
                 # after the next logon.
                 subprocess.run(["schtasks", "/run", "/tn", WINDOWS_TASK_NAME],
-                                capture_output=True, check=False)
+                                capture_output=True, check=False, timeout=8)
             return created
         finally:
             try:
@@ -258,7 +267,7 @@ def windows_task_registered() -> bool:
     try:
         r = subprocess.run(
             ["schtasks", "/query", "/tn", WINDOWS_TASK_NAME],
-            capture_output=True, check=False,
+            capture_output=True, check=False, timeout=8,
         )
         return r.returncode == 0
     except Exception:

--- a/clawmetry/daemon_registration.py
+++ b/clawmetry/daemon_registration.py
@@ -40,6 +40,30 @@ def _is_root() -> bool:
 
 
 def _is_sync_running() -> bool:
+    """Liveness probe for the sync daemon.
+
+    Prefers the daemon's own PID lock (``~/.clawmetry/sync.pid`` +
+    ``process_control.is_alive``) over a ``pgrep -f`` substring match:
+    ``pgrep -f "clawmetry.*sync"`` matches against a process's *entire*
+    command line, so it false-positives on anything that merely mentions
+    both words — a shell wrapper, an editor, a CI step, even an unrelated
+    diagnostic command — not just a genuinely running daemon. A false
+    positive here makes ``register_systemd``'s post-registration check
+    silently report success on containers without systemd (the exact case
+    this module exists to cover), leaving nothing actually supervising the
+    daemon. Fall back to pgrep only if the PID file is unreadable.
+    """
+    try:
+        from clawmetry.sync import _pid_file
+        from clawmetry.process_control import is_alive
+
+        pid_path = _pid_file()
+        if pid_path.exists():
+            return is_alive(int(pid_path.read_text().strip()))
+        return False
+    except Exception:
+        pass
+
     import subprocess
     try:
         r = subprocess.run(

--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -23851,8 +23851,8 @@ setTimeout(checkUpdateStatus, 5000);
       if (!it) return;
       var rt = it.getAttribute('data-rt');
       if (it.getAttribute('data-locked')) {
-        window.open('https://app.clawmetry.com/upgrade?source=runtime_chip', '_blank', 'noopener');
         _closeMenu();
+        try { _cmShowRuntimePaywall(rt, _label(rt)); } catch (e) {}
         return;
       }
       _closeMenu();

--- a/routes/onboarding.py
+++ b/routes/onboarding.py
@@ -153,6 +153,30 @@ def _apply_marker_semantics(choice: str) -> None:
         log.warning("onboarding: marker update failed: %s", exc)
 
 
+def _ensure_daemon_for_choice(choice: str) -> None:
+    """Every choice this gate can record must end with a PERSISTENT
+    background daemon, not just an in-process dashboard thread.
+
+    Root cause this closes: before this call, ``managed``/``selfhost_*``
+    completion here only touched the nocloud marker (_apply_marker_semantics)
+    -- nothing started or registered a background sync daemon. The CLI paths
+    (`clawmetry connect`, `clawmetry onboard` self-host) already register one
+    via `_start_daemon`, but this browser gate is the DEFAULT onboarding path
+    since the 2026-07-31 hard-gate rollout, and it registered nothing. The
+    only thing left polling PyPI was the foreground dashboard's in-thread
+    checker, which stops the moment that process exits (closed terminal,
+    sleep, reboot, crash) -- silently and permanently halting auto-update
+    until the user manually relaunches `clawmetry`. Best-effort: never let a
+    registration failure break onboarding completion itself.
+    """
+    try:
+        from clawmetry.daemon_registration import ensure_persistent_daemon
+
+        ensure_persistent_daemon({"local_only": choice != "managed"})
+    except Exception as exc:
+        log.warning("onboarding: daemon registration failed: %s", exc)
+
+
 @bp_onboarding.route("/api/onboarding/state")
 def api_onboarding_state():
     try:
@@ -201,6 +225,7 @@ def api_onboarding_complete():
                         "error": "Activate a license or trial first."}), 409
     _write_choice_file(choice)
     _apply_marker_semantics(choice)
+    _ensure_daemon_for_choice(choice)
     _ping_onboarded(choice)
     return jsonify({"ok": True, "state": choice})
 
@@ -225,5 +250,6 @@ def api_onboarding_activate_license():
     state = _license_state() or "selfhost_license"
     _write_choice_file(state)
     _apply_marker_semantics(state)
+    _ensure_daemon_for_choice(state)
     _ping_onboarded(state)
     return jsonify({"ok": True, "state": state, "message": msg})

--- a/routes/onboarding.py
+++ b/routes/onboarding.py
@@ -94,9 +94,30 @@ def _license_state() -> str:
 
 
 def _cloud_connected() -> bool:
+    """A cloud token alone means "chose managed" ONLY when self-host was
+    never the intent. ``_selfhost_signin_with_key`` (dashboard.py) writes
+    the SAME cloud token as the managed-connect flow purely to carry
+    identity for the trial-signup call -- it touches the nocloud marker
+    FIRST, before persisting that token. If the trial-signup half of that
+    flow then fails (network error, cloud-side rejection, anything caught
+    by its broad ``except Exception: pass``), the account is linked but no
+    license/trial was ever activated -- yet this fallback used to report
+    "already onboarded, state=managed" on every later page load anyway,
+    because it only checked for the token's existence, not what it was
+    for. That silently stranded a failed self-host trial attempt on the
+    live dashboard with everything locked and no way to see the error or
+    retry (live-hit 2026-08-06: linked account showed plan "free", no
+    license file, but the gate never required a choice again). Self-host
+    intent (the nocloud marker) takes precedence: a token minted under it
+    is identity-only until an explicit choice or a license is on record,
+    both of which are already checked earlier in ``_resolve_state()``.
+    """
     try:
         import dashboard as _d
+        from clawmetry.config import is_cloud_disabled as _icd
 
+        if _icd():
+            return False
         return bool(_d._read_cloud_token())
     except Exception:
         return False

--- a/routes/onboarding.py
+++ b/routes/onboarding.py
@@ -36,6 +36,7 @@ chose managed by signing up.
 import json
 import logging
 import os
+import threading
 import time
 
 from flask import Blueprint, jsonify, request
@@ -189,13 +190,28 @@ def _ensure_daemon_for_choice(choice: str) -> None:
     sleep, reboot, crash) -- silently and permanently halting auto-update
     until the user manually relaunches `clawmetry`. Best-effort: never let a
     registration failure break onboarding completion itself.
-    """
-    try:
-        from clawmetry.daemon_registration import ensure_persistent_daemon
 
-        ensure_persistent_daemon({"local_only": choice != "managed"})
+    Dispatched off the request thread on purpose (2026-08-06 CI regression):
+    ``ensure_persistent_daemon`` shells out to systemctl/launchctl/schtasks,
+    and even with a bounded per-call timeout that's still real, synchronous
+    latency this HTTP handler's caller (the browser) is waiting on. Running
+    it in a background thread means a slow or flaky OS registration can
+    never delay -- let alone hang -- the onboarding-complete response the
+    dashboard's init sequence is blocked on.
+    """
+    def _run() -> None:
+        try:
+            from clawmetry.daemon_registration import ensure_persistent_daemon
+
+            ensure_persistent_daemon({"local_only": choice != "managed"})
+        except Exception as exc:
+            log.warning("onboarding: daemon registration failed: %s", exc)
+
+    try:
+        threading.Thread(target=_run, daemon=True).start()
     except Exception as exc:
-        log.warning("onboarding: daemon registration failed: %s", exc)
+        log.warning("onboarding: daemon registration dispatch failed: %s", exc)
+        _run()
 
 
 @bp_onboarding.route("/api/onboarding/state")

--- a/routes/update_check.py
+++ b/routes/update_check.py
@@ -77,6 +77,9 @@ def _daemon_supervised():
             unit = (Path.home() / ".config" / "systemd" / "user"
                     / "clawmetry-sync.service")
             return unit.exists() or bool(os.environ.get("INVOCATION_ID"))
+        if os.name == "nt":
+            from clawmetry.daemon_registration import windows_task_registered
+            return windows_task_registered()
     except Exception:
         pass
     return False
@@ -354,6 +357,17 @@ def _get_update_check_config():
         # nobody, and the hosted dashboard rendered blank cards against old
         # snapshots. An observability sidecar must keep itself current.
         "auto_update": True,
+        # True only once a human has actually POSTed a value for "auto_update"
+        # via /api/update-check/config (see api_update_check_config_post).
+        # Distinguishes a REAL opt-out from a stale row a self-hosted/free
+        # node never gets a chance to self-heal: _sync_auto_update_with_plan
+        # (clawmetry/sync.py) already re-asserts auto_update=True on every
+        # cloud heartbeat, but ONLY for entitled paid tiers -- a self-hosted
+        # or free-tier node with a leftover pre-0.12.494 auto_update=False
+        # row had no path back to True. _update_check_worker's boot-time
+        # heal (below) uses this flag to heal the stale case universally
+        # while still respecting an explicit user opt-out.
+        "auto_update_user_set": False,
         "dismissed_version": "",
         "last_check_at": 0,
     }
@@ -387,6 +401,26 @@ def _set_update_check_config(updates):
             )
         db.commit()
         db.close()
+
+
+def _heal_stale_auto_update_flag(config):
+    """Universal one-time self-heal for a stale ``auto_update=False`` row.
+
+    ``clawmetry/sync.py::_sync_auto_update_with_plan`` already re-asserts
+    auto_update=True on every cloud heartbeat, but ONLY for entitled paid
+    cloud tiers -- a self-hosted or free-tier node that picked up a stale
+    False (pre-0.12.494 default, or a long-gone UI toggle) had no path back
+    to the current True default, "self-hosted or cloud sync" be damned. This
+    runs for every role/tier on worker boot and heals the flag UNLESS a
+    human explicitly set it via POST /api/update-check/config
+    (auto_update_user_set), so a real opt-out is never overridden.
+    """
+    try:
+        if not config.get("auto_update") and not config.get("auto_update_user_set"):
+            _set_update_check_config({"auto_update": True})
+            config["auto_update"] = True
+    except Exception:
+        pass
 
 
 def _record_update_check(current, latest, update_available, changelog_url=""):
@@ -818,6 +852,7 @@ def _update_check_worker(stop_event):
         return
 
     config = _get_update_check_config()
+    _heal_stale_auto_update_flag(config)
     if config.get("check_on_startup", True):
         _check_for_update()
 
@@ -888,6 +923,11 @@ def api_update_check_config_post():
     data = request.get_json(silent=True) or {}
     allowed_keys = ["enabled", "check_on_startup", "check_daily", "auto_update", "dismissed_version"]
     updates = {k: v for k, v in data.items() if k in allowed_keys}
+    # A real POST here is the only thing that means "a human explicitly
+    # chose this" -- mark it so the universal self-heal in
+    # _update_check_worker never overwrites a deliberate auto_update=False.
+    if "auto_update" in updates:
+        updates["auto_update_user_set"] = True
     _set_update_check_config(updates)
     return jsonify({"ok": True})
 

--- a/tests/test_auto_update.py
+++ b/tests/test_auto_update.py
@@ -139,7 +139,11 @@ def test_propagation_lag_gets_short_backoff(monkeypatch):
 
 
 def test_auto_update_in_allowed_config_keys(monkeypatch):
-    """The config setter must accept `auto_update` (else the toggle is a no-op)."""
+    """The config setter must accept `auto_update` (else the toggle is a no-op).
+
+    A real POST also stamps auto_update_user_set=True, so the universal
+    self-heal (test_auto_update_self_heal.py) never overwrites a choice a
+    human actually made."""
     from flask import Flask
     uc = _uc()
     captured = {}
@@ -147,7 +151,8 @@ def test_auto_update_in_allowed_config_keys(monkeypatch):
     app = Flask(__name__)
     with app.test_request_context(json={"auto_update": True, "bogus": "x"}):
         uc.api_update_check_config_post()
-    assert captured == {"auto_update": True}, "auto_update must pass the allow-list, bogus keys filtered"
+    assert captured == {"auto_update": True, "auto_update_user_set": True}, \
+        "auto_update must pass the allow-list, bogus keys filtered, and be marked user-set"
 
 
 def test_auto_update_installs_given_target(monkeypatch):

--- a/tests/test_auto_update_self_heal.py
+++ b/tests/test_auto_update_self_heal.py
@@ -1,0 +1,92 @@
+"""Universal self-heal for a stuck auto_update=False row.
+
+Root cause: clawmetry/sync.py::_sync_auto_update_with_plan already
+re-asserts auto_update=True on every cloud heartbeat, but ONLY for entitled
+PAID cloud tiers (`if not tier or tier == "cloud_free": return`) -- a
+self-hosted or free-tier node whose persisted update_check_config row has a
+stale False (written before the 0.12.494 default flip, or via some old UI
+toggle) had NO path back to True. This is the asymmetry the user flagged
+("self hosted or cloud sync -- whatever it is -- should still auto update").
+
+_heal_stale_auto_update_flag makes the heal universal -- any role, any
+tier, connected or not -- while still respecting a real, explicit opt-out
+recorded via POST /api/update-check/config (auto_update_user_set=True).
+"""
+from __future__ import annotations
+
+import importlib
+
+
+def _uc():
+    import routes.update_check as uc
+    return importlib.reload(uc)
+
+
+def test_heals_stale_unset_false_to_true(monkeypatch):
+    uc = _uc()
+    captured = {}
+    monkeypatch.setattr(uc, "_set_update_check_config", lambda u: captured.update(u))
+    config = {"auto_update": False, "auto_update_user_set": False}
+    uc._heal_stale_auto_update_flag(config)
+    assert captured == {"auto_update": True}
+    assert config["auto_update"] is True, "caller's in-memory config must reflect the heal immediately"
+
+
+def test_respects_explicit_user_opt_out(monkeypatch):
+    uc = _uc()
+    calls = []
+    monkeypatch.setattr(uc, "_set_update_check_config", lambda u: calls.append(u))
+    config = {"auto_update": False, "auto_update_user_set": True}
+    uc._heal_stale_auto_update_flag(config)
+    assert calls == [], "a real user opt-out must never be overridden"
+    assert config["auto_update"] is False
+
+
+def test_noop_when_already_true(monkeypatch):
+    uc = _uc()
+    calls = []
+    monkeypatch.setattr(uc, "_set_update_check_config", lambda u: calls.append(u))
+    uc._heal_stale_auto_update_flag({"auto_update": True, "auto_update_user_set": False})
+    assert calls == []
+
+
+def test_never_raises_on_persistence_failure(monkeypatch):
+    uc = _uc()
+
+    def boom(u):
+        raise RuntimeError("fleet db locked")
+    monkeypatch.setattr(uc, "_set_update_check_config", boom)
+    uc._heal_stale_auto_update_flag({"auto_update": False, "auto_update_user_set": False})  # must not raise
+
+
+def test_worker_boot_applies_the_heal(monkeypatch):
+    """_update_check_worker must call the heal exactly once at boot,
+    before the startup check, for every role -- not just for paid cloud
+    tiers via the heartbeat-only _sync_auto_update_with_plan path."""
+    uc = _uc()
+
+    class _StopEvent:
+        def __init__(self):
+            self.calls = 0
+
+        def wait(self, secs):
+            self.calls += 1
+            # First call is the boot-settle delay -- let it through (False)
+            # so the worker reaches the heal; stop it right after.
+            return self.calls > 1
+
+        def is_set(self):
+            return self.calls > 1
+
+    # Pin the fast-loop check so the second stop_event.wait() (the fast-loop
+    # interval) is reached deterministically and the worker exits there,
+    # instead of falling into the banner-only branch and hitting real
+    # network code (_check_for_update -> pypi.org).
+    uc._process_role = "daemon"
+    monkeypatch.setattr(uc, "_get_update_check_config",
+                         lambda: {"auto_update": False, "auto_update_user_set": False,
+                                  "check_on_startup": False, "enabled": False})
+    healed = []
+    monkeypatch.setattr(uc, "_heal_stale_auto_update_flag", lambda cfg: healed.append(cfg))
+    uc._update_check_worker(_StopEvent())
+    assert len(healed) == 1

--- a/tests/test_daemon_registration.py
+++ b/tests/test_daemon_registration.py
@@ -1,0 +1,195 @@
+"""clawmetry/daemon_registration.py — the shared "make the sync daemon
+survive a reboot/logoff/crash" helper, and the two call sites that regressed
+without it: cli.py's Windows branch of _start_daemon, and
+routes/update_check.py's _daemon_supervised probe.
+
+Windows previously had NO persistent-service equivalent of launchd
+KeepAlive / systemd Restart=always -- _start_daemon fell through to a bare
+detached subprocess with zero reboot/crash/logoff recovery, so a Windows
+node silently stopped auto-updating (and ingesting) after any restart until
+a human manually relaunched `clawmetry`. These tests pin the Task Scheduler
+registration this fix adds, and its wiring into supervision detection.
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import clawmetry.daemon_registration as dreg
+
+
+class _Res:
+    def __init__(self, rc=0, stdout=""):
+        self.returncode = rc
+        self.stdout = stdout
+
+
+def test_register_windows_task_invokes_schtasks_with_restart_on_failure(monkeypatch):
+    calls = []
+
+    def _run(cmd, *a, **k):
+        calls.append(cmd)
+        return _Res(0)
+
+    monkeypatch.setattr("subprocess.run", _run)
+    written = {}
+
+    def _fake_tempfile(mode, suffix, delete, encoding):
+        import io
+
+        class _FH:
+            name = "/tmp/fake-task.xml"
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+            def write(self, content):
+                written["xml"] = content
+
+        return _FH()
+
+    monkeypatch.setattr("tempfile.NamedTemporaryFile", _fake_tempfile)
+    monkeypatch.setattr(os, "remove", lambda p: None)
+
+    ok = dreg.register_windows_task({})
+    assert ok is True
+
+    create_calls = [c for c in calls if "/create" in c]
+    assert len(create_calls) == 1
+    create_cmd = create_calls[0]
+    assert "schtasks" in create_cmd[0]
+    assert dreg.WINDOWS_TASK_NAME in create_cmd
+    assert "/f" in create_cmd  # overwrite an existing registration idempotently
+
+    # The task definition itself must restart on failure and run at logon,
+    # matching launchd KeepAlive / systemd Restart=always semantics.
+    assert "<RestartOnFailure>" in written["xml"]
+    assert "<LogonTrigger>" in written["xml"]
+    assert "-m clawmetry.sync" in written["xml"]
+
+    # A successful /create must also /run the task immediately so THIS
+    # session gets the daemon too, not just the next logon.
+    run_calls = [c for c in calls if "/run" in c]
+    assert len(run_calls) == 1
+
+
+def test_register_windows_task_returns_false_on_schtasks_failure(monkeypatch):
+    # tempfile creation raising is the simplest way to force the "something
+    # went wrong" branch -> the function must fail closed (return False),
+    # never raise, so callers can fall back safely.
+    def _boom(**k):
+        raise OSError("no temp dir")
+    monkeypatch.setattr("tempfile.NamedTemporaryFile", _boom)
+    assert dreg.register_windows_task({}) is False
+
+
+def test_windows_task_registered_reflects_schtasks_query(monkeypatch):
+    monkeypatch.setattr("subprocess.run", lambda cmd, *a, **k: _Res(0))
+    assert dreg.windows_task_registered() is True
+
+    monkeypatch.setattr("subprocess.run", lambda cmd, *a, **k: _Res(1))
+    assert dreg.windows_task_registered() is False
+
+    def _boom(*a, **k):
+        raise FileNotFoundError("schtasks not on PATH")
+    monkeypatch.setattr("subprocess.run", _boom)
+    assert dreg.windows_task_registered() is False
+
+
+def test_ensure_persistent_daemon_dispatches_by_platform(monkeypatch):
+    monkeypatch.setattr("clawmetry.sync.ensure_local_config", lambda: None, raising=False)
+
+    monkeypatch.setattr("platform.system", lambda: "Darwin")
+    calls = []
+    monkeypatch.setattr(dreg, "register_launchd", lambda cfg: calls.append("launchd") or True)
+    assert dreg.ensure_persistent_daemon({}) is True
+    assert calls == ["launchd"]
+
+    calls.clear()
+    monkeypatch.setattr("platform.system", lambda: "Linux")
+    monkeypatch.setattr(dreg, "register_systemd", lambda cfg: calls.append("systemd") or True)
+    assert dreg.ensure_persistent_daemon({}) is True
+    assert calls == ["systemd"]
+
+    calls.clear()
+    monkeypatch.setattr("platform.system", lambda: "Windows")
+    monkeypatch.setattr(os, "name", "nt")
+    monkeypatch.setattr(dreg, "register_windows_task", lambda cfg: calls.append("winreg") or True)
+    assert dreg.ensure_persistent_daemon({}) is True
+    assert calls == ["winreg"]
+
+
+def test_ensure_persistent_daemon_falls_back_to_background_subprocess(monkeypatch):
+    monkeypatch.setattr("clawmetry.sync.ensure_local_config", lambda: None, raising=False)
+    monkeypatch.setattr("platform.system", lambda: "Linux")
+    monkeypatch.setattr(dreg, "register_systemd", lambda cfg: False)
+    calls = []
+    monkeypatch.setattr(dreg, "start_background_subprocess", lambda: calls.append(1) or True)
+    assert dreg.ensure_persistent_daemon({}) is True
+    assert calls == [1]
+
+
+def test_ensure_persistent_daemon_never_raises_on_bad_config(monkeypatch):
+    monkeypatch.setattr("clawmetry.sync.ensure_local_config",
+                         lambda: (_ for _ in ()).throw(RuntimeError("boom")),
+                         raising=False)
+    monkeypatch.setattr("platform.system", lambda: "Linux")
+    monkeypatch.setattr(dreg, "register_systemd", lambda cfg: True)
+    assert dreg.ensure_persistent_daemon(None) is True
+
+
+# ── Wiring: cli.py _start_daemon's Windows branch ──────────────────────────
+
+def test_start_daemon_windows_branch_uses_task_scheduler(monkeypatch):
+    import clawmetry.cli as cli
+
+    monkeypatch.setattr("platform.system", lambda: "Windows")
+    monkeypatch.setattr(cli.os, "name", "nt")
+    calls = []
+    monkeypatch.setattr("clawmetry.daemon_registration.register_windows_task",
+                         lambda cfg: calls.append(cfg) or True)
+    fallback_calls = []
+    monkeypatch.setattr(cli, "_start_subprocess", lambda: fallback_calls.append(1))
+
+    args = type("Args", (), {"foreground": False})()
+    cli._start_daemon({"node_id": "n1"}, args)
+
+    assert calls == [{"node_id": "n1"}]
+    assert fallback_calls == [], "Task Scheduler succeeded, must not fall back"
+
+
+def test_start_daemon_windows_branch_falls_back_when_schtasks_unavailable(monkeypatch):
+    import clawmetry.cli as cli
+
+    monkeypatch.setattr("platform.system", lambda: "Windows")
+    monkeypatch.setattr(cli.os, "name", "nt")
+    monkeypatch.setattr("clawmetry.daemon_registration.register_windows_task",
+                         lambda cfg: False)
+    fallback_calls = []
+    monkeypatch.setattr(cli, "_start_subprocess", lambda: fallback_calls.append(1))
+
+    args = type("Args", (), {"foreground": False})()
+    cli._start_daemon({"node_id": "n1"}, args)
+
+    assert fallback_calls == [1], "schtasks failed, must fall back to unsupervised subprocess"
+
+
+# ── Wiring: routes/update_check.py's _daemon_supervised Windows detection ──
+
+def test_daemon_supervised_detects_windows_task(monkeypatch):
+    import routes.update_check as uc
+
+    monkeypatch.setattr(uc.sys, "platform", "win32")
+    monkeypatch.setattr(uc.os, "name", "nt")
+    monkeypatch.setattr("clawmetry.daemon_registration.windows_task_registered",
+                         lambda: True)
+    assert uc._daemon_supervised() is True
+
+    monkeypatch.setattr("clawmetry.daemon_registration.windows_task_registered",
+                         lambda: False)
+    assert uc._daemon_supervised() is False

--- a/tests/test_daemon_registration.py
+++ b/tests/test_daemon_registration.py
@@ -101,6 +101,49 @@ def test_windows_task_registered_reflects_schtasks_query(monkeypatch):
     assert dreg.windows_task_registered() is False
 
 
+def test_register_systemd_bounds_every_subprocess_call(monkeypatch, tmp_path):
+    """2026-08-06 CI regression: these calls had no timeout, and this whole
+    function runs synchronously inside the onboarding-complete HTTP handler.
+    A runner with no user systemd/dbus session can make `systemctl --user
+    enable --now` hang instead of failing fast -- visible live as the
+    dashboard stuck forever on "Initializing ClawMetry" for mobile E2E
+    screenshots. Every systemctl call here must be bounded."""
+    monkeypatch.setattr(dreg, "_is_root", lambda: False)
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+    monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/systemctl")
+    calls = []
+
+    def _run(cmd, *a, **k):
+        calls.append((cmd, k))
+        return _Res(0, "active")
+
+    monkeypatch.setattr("subprocess.run", _run)
+    monkeypatch.setattr("time.sleep", lambda s: None)
+
+    assert dreg.register_systemd({}) is True
+    assert len(calls) == 3, "daemon-reload, enable --now, is-active"
+    for cmd, kwargs in calls:
+        assert kwargs.get("timeout") is not None, f"no timeout on {cmd}"
+
+
+def test_register_launchd_bounds_every_subprocess_call(monkeypatch):
+    monkeypatch.setattr("platform.system", lambda: "Darwin")
+    calls = []
+
+    def _run(cmd, *a, **k):
+        calls.append((cmd, k))
+        return _Res(1)  # force the fallback `launchctl load` branch too
+
+    monkeypatch.setattr("subprocess.run", _run)
+    monkeypatch.setattr(os, "getuid", lambda: 501, raising=False)
+
+    dreg.register_launchd({})
+
+    assert len(calls) == 2, "bootstrap + the load -w fallback"
+    for cmd, kwargs in calls:
+        assert kwargs.get("timeout") is not None, f"no timeout on {cmd}"
+
+
 def test_ensure_persistent_daemon_dispatches_by_platform(monkeypatch):
     monkeypatch.setattr("clawmetry.sync.ensure_local_config", lambda: None, raising=False)
 

--- a/tests/test_onboarding_gate.py
+++ b/tests/test_onboarding_gate.py
@@ -28,6 +28,9 @@ def ob(monkeypatch, tmp_path):
     monkeypatch.setattr(mod, "_cloud_connected", lambda: False)
     monkeypatch.setattr(mod, "_ping_onboarded", lambda choice: None)
     monkeypatch.setattr(mod, "_apply_marker_semantics", lambda choice: None)
+    # Must never actually register/spawn a real daemon during a unit test —
+    # see test_ensure_daemon_for_choice_* below for the real coverage.
+    monkeypatch.setattr(mod, "_ensure_daemon_for_choice", lambda choice: None)
     # Strip every env that legitimately suppresses the gate — including
     # the CI vars GitHub Actions itself sets, or the "fresh install
     # requires onboarding" tests would pass locally and fail in CI.
@@ -253,3 +256,76 @@ def test_marker_semantics_managed_clears_nocloud(monkeypatch, tmp_path):
     monkeypatch.delenv("CLAWMETRY_NO_CLOUD", raising=False)
     mod._apply_marker_semantics("managed")
     assert not marker.exists()
+
+
+# ── Persistent daemon registration on onboarding completion ────────────────
+#
+# Root cause: this gate is the DEFAULT onboarding path (browser, since the
+# 2026-07-31 hard-gate rollout) and used to complete a choice without ever
+# starting/registering a background sync daemon -- only the CLI paths
+# (`clawmetry connect` / `clawmetry onboard`) did that. Only the in-process
+# dashboard thread was left polling PyPI, which stops the moment that one
+# process exits. These tests pin that both completion endpoints now always
+# attempt daemon registration, and that _ensure_daemon_for_choice never lets
+# a registration failure break onboarding completion itself.
+
+def test_complete_managed_registers_persistent_daemon(ob, client, monkeypatch):
+    monkeypatch.setattr(ob, "_cloud_connected", lambda: True)
+    calls = []
+    monkeypatch.setattr(ob, "_ensure_daemon_for_choice", calls.append)
+    r = client.post("/api/onboarding/complete", json={"choice": "managed"})
+    assert r.get_json()["ok"] is True
+    assert calls == ["managed"]
+
+
+def test_complete_selfhost_registers_persistent_daemon(ob, client, monkeypatch):
+    monkeypatch.setattr(ob, "_license_state", lambda: "selfhost_trial")
+    calls = []
+    monkeypatch.setattr(ob, "_ensure_daemon_for_choice", calls.append)
+    r = client.post("/api/onboarding/complete", json={"choice": "selfhost_trial"})
+    assert r.get_json()["ok"] is True
+    assert calls == ["selfhost_trial"]
+
+
+def test_activate_license_registers_persistent_daemon(ob, client, monkeypatch):
+    import types
+    fake_lic = types.SimpleNamespace(
+        activate=lambda key, actor="": (True, "activated"))
+    monkeypatch.setitem(sys.modules, "clawmetry.license", fake_lic)
+    import clawmetry
+    monkeypatch.setattr(clawmetry, "license", fake_lic, raising=False)
+    monkeypatch.setattr(ob, "_license_state", lambda: "selfhost_license")
+    calls = []
+    monkeypatch.setattr(ob, "_ensure_daemon_for_choice", calls.append)
+    r = client.post("/api/onboarding/activate-license",
+                    json={"key": "CLAW1.aaa.bbb"})
+    assert r.get_json()["ok"] is True
+    assert calls == ["selfhost_license"]
+
+
+def test_ensure_daemon_for_choice_calls_shared_registration(monkeypatch):
+    """selfhost_* choices must register a LOCAL-ONLY daemon (no cloud
+    egress), managed must not."""
+    import routes.onboarding as mod
+    import clawmetry.daemon_registration as dreg
+
+    calls = []
+    monkeypatch.setattr(dreg, "ensure_persistent_daemon", lambda cfg: calls.append(cfg))
+    mod._ensure_daemon_for_choice("selfhost_trial")
+    assert calls == [{"local_only": True}]
+
+    calls.clear()
+    mod._ensure_daemon_for_choice("managed")
+    assert calls == [{"local_only": False}]
+
+
+def test_ensure_daemon_for_choice_never_raises(monkeypatch):
+    """A registration failure (no systemd, schtasks unavailable, sandboxed
+    environment, ...) must never break onboarding completion."""
+    import routes.onboarding as mod
+    import clawmetry.daemon_registration as dreg
+
+    def boom(cfg):
+        raise RuntimeError("no supervisor available here")
+    monkeypatch.setattr(dreg, "ensure_persistent_daemon", boom)
+    mod._ensure_daemon_for_choice("selfhost_license")  # must not raise

--- a/tests/test_onboarding_gate.py
+++ b/tests/test_onboarding_gate.py
@@ -232,6 +232,55 @@ def test_selfhost_modal_is_in_live_dashboard_html():
         "selfhost-modal must be included after #zoom-wrapper closes (fixed overlay rule)"
 
 
+# ── _cloud_connected() must not confuse identity-linking with "chose managed" ──
+#
+# Live-hit 2026-08-06: the self-host Google/GitHub sign-in flow
+# (_selfhost_signin_with_key in dashboard.py) writes the SAME cloud token as
+# the managed-connect flow purely to carry identity into the trial-signup
+# call, and touches the nocloud marker FIRST. When the trial-signup half of
+# that flow then failed silently, the account was linked (token on disk) but
+# no license/trial was ever activated -- yet _cloud_connected() only checked
+# whether a token existed, so _resolve_state() reported the install as
+# already onboarded ("managed") on every later page load, with no license
+# and everything locked, and no way to see an error or retry the trial.
+
+def test_cloud_connected_ignores_token_under_nocloud_marker(monkeypatch, tmp_path):
+    import routes.onboarding as mod
+    from clawmetry import config as _cfg
+
+    marker = tmp_path / "nocloud"
+    marker.write_text("")
+    monkeypatch.setattr(_cfg, "NOCLOUD_MARKER_PATH", str(marker))
+    monkeypatch.delenv("CLAWMETRY_NO_CLOUD", raising=False)
+
+    import dashboard as _d
+    monkeypatch.setattr(_d, "_read_cloud_token", lambda: "cm_faketoken")
+
+    assert mod._cloud_connected() is False, (
+        "a cloud token written under self-host intent (nocloud marker set) "
+        "must not be read as 'chose managed' -- it strands a failed trial "
+        "attempt on a permanently-skipped onboarding gate"
+    )
+
+
+def test_cloud_connected_true_without_nocloud_marker(monkeypatch, tmp_path):
+    import routes.onboarding as mod
+    from clawmetry import config as _cfg
+
+    marker = tmp_path / "nocloud-not-written"
+    monkeypatch.setattr(_cfg, "NOCLOUD_MARKER_PATH", str(marker))
+    monkeypatch.delenv("CLAWMETRY_NO_CLOUD", raising=False)
+
+    import dashboard as _d
+    monkeypatch.setattr(_d, "_read_cloud_token", lambda: "cm_faketoken")
+
+    assert mod._cloud_connected() is True, (
+        "a real managed-connect token (no self-host marker) must still "
+        "satisfy the gate -- this is the grandfather path for pre-gate "
+        "managed installs"
+    )
+
+
 def test_marker_semantics_selfhost_writes_nocloud(monkeypatch, tmp_path):
     """NOCLOUD_MARKER_PATH is a plain str; the old .parent/.touch calls
     raised AttributeError into the broad except, so the marker was silently

--- a/tests/test_onboarding_gate.py
+++ b/tests/test_onboarding_gate.py
@@ -352,12 +352,28 @@ def test_activate_license_registers_persistent_daemon(ob, client, monkeypatch):
     assert calls == ["selfhost_license"]
 
 
+class _SyncThread:
+    """Runs the target immediately on .start() instead of on a real thread,
+    so tests can assert on _run()'s side effects deterministically -- the
+    production code dispatches via threading.Thread on purpose (see
+    _ensure_daemon_for_choice's docstring: onboarding-complete must never
+    block the HTTP response on a slow/hanging systemctl/launchctl/schtasks
+    call), but that async dispatch is exactly what these tests don't want."""
+
+    def __init__(self, target, daemon=True):
+        self._target = target
+
+    def start(self):
+        self._target()
+
+
 def test_ensure_daemon_for_choice_calls_shared_registration(monkeypatch):
     """selfhost_* choices must register a LOCAL-ONLY daemon (no cloud
     egress), managed must not."""
     import routes.onboarding as mod
     import clawmetry.daemon_registration as dreg
 
+    monkeypatch.setattr(mod.threading, "Thread", _SyncThread)
     calls = []
     monkeypatch.setattr(dreg, "ensure_persistent_daemon", lambda cfg: calls.append(cfg))
     mod._ensure_daemon_for_choice("selfhost_trial")
@@ -374,7 +390,28 @@ def test_ensure_daemon_for_choice_never_raises(monkeypatch):
     import routes.onboarding as mod
     import clawmetry.daemon_registration as dreg
 
+    monkeypatch.setattr(mod.threading, "Thread", _SyncThread)
+
     def boom(cfg):
         raise RuntimeError("no supervisor available here")
     monkeypatch.setattr(dreg, "ensure_persistent_daemon", boom)
     mod._ensure_daemon_for_choice("selfhost_license")  # must not raise
+
+
+def test_ensure_daemon_for_choice_dispatches_off_request_thread(monkeypatch):
+    """The real regression this closes (2026-08-06 CI): registration used to
+    run synchronously inside the onboarding-complete handler, so a hanging
+    systemctl/launchctl call blocked the HTTP response the browser's init
+    sequence was waiting on (visible as the dashboard stuck forever on
+    "Initializing ClawMetry"). Must be dispatched via threading.Thread, not
+    called inline."""
+    import routes.onboarding as mod
+
+    calls = []
+    monkeypatch.setattr(
+        mod.threading, "Thread",
+        lambda target, daemon=True: calls.append((target, daemon)) or _SyncThread(target),
+    )
+    mod._ensure_daemon_for_choice("selfhost_trial")
+    assert len(calls) == 1
+    assert calls[0][1] is True, "must be a daemon thread so it never blocks process exit"

--- a/tests/test_runtime_switcher_gating.py
+++ b/tests/test_runtime_switcher_gating.py
@@ -89,7 +89,19 @@ def test_switcher_change_handler_intercepts_locked_clicks(app_js):
 def test_runtime_paywall_overlay_present(app_js):
     """``_cmShowRuntimePaywall`` builds the overlay with the upgrade CTA and
     a paywall_view telemetry beacon — pins the contract the runtime-switcher
-    click interception depends on."""
+    click interception depends on.
+
+    Founder spec (2026-07-30): a locked runtime must lead to sign-in -> trial
+    license -> unlocked runtimes right here, never a pricing tab or an
+    external cloud redirect (a self-hosted user choosing a trial must not be
+    bounced to a cloud account page — that's the whole point of self-host).
+    This test used to assert the OLD `app.clawmetry.com/upgrade` redirect,
+    which had already been replaced by the local email+code trial flow below
+    without the test being updated (live-hit 2026-08-06: an actual redirect
+    regression on the separate bottom-right runtime-chip menu went unnoticed
+    because this file only pinned the (correct) header dropdown's overlay,
+    not the second switch point — see test_runtime_switcher_gating.py's
+    chip-menu test)."""
     pattern = re.compile(
         r"function\s+_cmShowRuntimePaywall\s*\([^)]*\)\s*\{(.*?)\nfunction\s",
         re.DOTALL,
@@ -100,9 +112,45 @@ def test_runtime_paywall_overlay_present(app_js):
     # Telemetry: paywall_view event for funnel attribution.
     assert "paywall_view" in body
     assert "/api/paywall/event" in body
-    # Upgrade CTA points at the cloud upgrade flow with the harness attached.
-    assert "app.clawmetry.com/upgrade" in body
-    assert "source=runtime-switcher" in body
+    # The CTA drives a local sign-in -> trial flow, not an external redirect.
+    assert "/api/cloud-cta/send-otp" in body
+    assert "/api/trial/activate" in body
+    assert "app.clawmetry.com/upgrade" not in body, (
+        "the in-dashboard paywall must not bounce a self-hosted user to the "
+        "cloud account page — it activates the trial locally"
+    )
     # Both buttons present: dismiss + start trial.
     assert "_cmRtPaywallCancel" in body
-    assert "Start free trial" in body
+    assert "Start 7-day free trial" in body
+
+
+def test_runtime_chip_locked_click_opens_local_paywall_not_cloud_redirect(app_js):
+    """The bottom-right runtime chip (a second, self-described 'mirror' of
+    the header switcher) must intercept a locked-runtime click the same way
+    the header switcher does: open the local ``_cmShowRuntimePaywall`` modal,
+    not bounce straight to the cloud account site.
+
+    Live-hit 2026-08-06 (self-hosted trial user, reported directly): clicking
+    a locked runtime in this chip's menu opened
+    ``app.clawmetry.com/upgrade?source=runtime_chip`` in a new tab instead —
+    a self-hosted user trying to start a local trial got redirected to a
+    cloud account page with no bearing on their local install. The header
+    dropdown's onChange handler (``_cmOnGlobalRuntimeChange``, tested above
+    in ``test_switcher_change_handler_intercepts_locked_clicks``) already
+    did this correctly; the chip's own click handler diverged."""
+    pattern = re.compile(
+        r"m\.addEventListener\('click',\s*function\s*\(ev\)\s*\{(.*?)\n\s*\}\);",
+        re.DOTALL,
+    )
+    m = pattern.search(app_js)
+    assert m, "runtime-chip menu click handler not found"
+    body = m.group(1)
+    assert "data-locked" in body, "locked-item branch missing from chip click handler"
+    assert "_cmShowRuntimePaywall" in body, (
+        "chip's locked-click branch must open the local paywall modal, "
+        "same as the header switcher"
+    )
+    assert "window.open" not in body and "app.clawmetry.com" not in body, (
+        "chip must not redirect a locked click to the cloud site — that "
+        "strands a self-hosted user trying to start a local trial"
+    )


### PR DESCRIPTION
## Summary

- The browser onboarding gate (`routes/onboarding.py`) has been the default first-run path since the 2026-07-31 hard-gate rollout, but its completion handlers only touched the nocloud marker file — they never started or registered a background sync daemon. The only thing left polling PyPI was the foreground dashboard&#39;s in-process checker thread, which stops the moment that one process exits (closed terminal, sleep, reboot, crash), silently and permanently halting auto-update until a human manually relaunched `clawmetry`. Onboarding completion now calls a new `clawmetry/daemon_registration.py::ensure_persistent_daemon()` for every choice (managed, selfhost_license, selfhost_trial).
- Windows gets real daemon persistence for the first time: it had no launchd/systemd equivalent, so `_start_daemon`&#39;s Windows branch fell straight to an unsupervised detached subprocess with zero reboot/crash recovery. It now registers a logon-triggered, restart-on-failure Task Scheduler task (`schtasks`), falling back to the old subprocess only if that fails. `_daemon_supervised()` now detects it too.
- The `auto_update` config flag&#39;s self-heal (re-asserting the default-on `True` after a stale persisted `False`) previously only ran for entitled paid cloud accounts via the heartbeat path (`_sync_auto_update_with_plan`) — self-hosted and free-tier installs had no path back to `True`. The update-check worker now heals a stale unset `False` for every role/tier on boot, while a real explicit user opt-out (`POST /api/update-check/config`) is tracked via a new `auto_update_user_set` flag and never overridden.
- `ci.yml` and `sync-test.yml` had no `concurrency` block, unlike every other workflow in this repo — a push to this PR queued a brand new full CI run without cancelling the previous one, so 4+ superseded runs piled up in the shared runner queue and starved the newest commit&#39;s jobs for over an hour. Added the same concurrency-group pattern used elsewhere in the repo.
- **Self-host trial silently failing** (found live, on a real self-hosted Windows install, mid-PR): the Google/GitHub self-host sign-in card writes a cloud token purely to carry identity into a trial-signup call, before that call has even run. If the trial-signup half then fails for any reason, the account is linked (token on disk) but no license/trial is ever activated — yet the onboarding gate&#39;s `_cloud_connected()` check only looked at whether a token existed, not what it was for, so it reported the install as already onboarded (&#34;managed&#34;) on every later page load. No error, no way to retry, just a permanently half-onboarded dashboard with everything locked. Fixed `_cloud_connected()` to treat a token written under self-host intent (nocloud marker set) as identity-only, not proof of a completed managed choice.
- **Runtime-chip cloud redirect** (found investigating the above): the bottom-right runtime-status chip&#39;s locked-runtime click handler opened `app.clawmetry.com/upgrade` in a new tab, redirecting a self-hosted user to a cloud account page instead of the local sign-in-then-trial modal the header dropdown already uses correctly for the identical click. Wired the chip to the same local `_cmShowRuntimePaywall` flow. Also corrected `tests/test_runtime_switcher_gating.py`, which had gone stale asserting the old cloud-redirect behavior for the (already-fixed) header paywall modal — exactly the kind of drift that let the chip regression go unnoticed.
- **Onboarding-complete request hang** (caught live by this PR's own visual-diff bot, mobile screenshots stuck forever on "Initializing ClawMetry"): the daemon-registration call added above (`register_systemd`/`register_launchd`) shelled out to systemctl/launchctl with no timeout, synchronously inside the `/api/onboarding/complete` HTTP handler the browser's init sequence waits on. A runner/container with no working user systemd/dbus session can make those commands hang instead of failing fast. Bounded every subprocess call in `daemon_registration.py` to a few seconds, and moved the registration call onto a background thread so onboarding-complete never blocks on it at all, regardless of how slow the underlying OS call is.

## Test plan

- [x] New `tests/test_daemon_registration.py`: Windows Task Scheduler registration (`schtasks /create` with `RestartOnFailure`/`LogonTrigger`), `windows_task_registered()` probe, `ensure_persistent_daemon()` platform dispatch + fallback, wiring into `cli.py::_start_daemon`&#39;s Windows branch and `routes/update_check.py::_daemon_supervised()`, plus new tests pinning a `timeout=` on every systemctl/launchctl subprocess call.
- [x] Extended `tests/test_onboarding_gate.py`: both `/api/onboarding/complete` and `/api/onboarding/activate-license` now trigger daemon registration for every choice, dispatched via `threading.Thread` (not called inline) so it never blocks the response; a registration failure never breaks onboarding completion; tests pin `_cloud_connected()` ignoring a token written under the nocloud marker while still honoring a real managed-connect token.
- [x] New `tests/test_auto_update_self_heal.py`: stale unset `auto_update=False` heals to `True` on worker boot for every role/tier; an explicit user opt-out (`auto_update_user_set=True`) is never overridden; heal failures never raise.
- [x] Updated `tests/test_auto_update.py::test_auto_update_in_allowed_config_keys` for the new `auto_update_user_set` stamping behavior.
- [x] Corrected + extended `tests/test_runtime_switcher_gating.py`: the paywall-overlay test now pins the current local-trial-flow contract instead of the stale cloud-redirect one, plus a new dedicated test for the runtime chip&#39;s locked-click handler.
- [x] `ruff check` / `py_compile` clean on every changed Python file.
- [x] Full local pytest run of every changed/added test file green (39/39 for the onboarding + daemon-registration suites after the hang fix). A full repo-wide `pytest tests/` run was also done as a sanity check — it surfaces ~1000 pre-existing failures unrelated to this diff (confirmed via `git stash` + re-run on the unmodified base commit) that trace to this sandbox&#39;s environment (missing DuckDB fixtures/extensions), not to anything in this PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_014M9RFasj1Cak93j3CuF1q5)_