### PR TITLE
fix(ci): c6-apply-ruleset exits 1 when 403 and E2E Gate missing (honest C6 signal)

### DIFF
--- a/.github/workflows/c6-apply-ruleset.yml
+++ b/.github/workflows/c6-apply-ruleset.yml
@@ -14,16 +14,23 @@ name: Apply E2E required checks via Rulesets API (C6)
 #
 # Idempotent: upserts by name so repeated runs are safe.
 # Runs on every push to main so the ruleset self-heals if deleted.
-# On 403 (token lacks ruleset-write rights): emits a ::notice:: and
-# exits 0 -- a 403 is expected on this personal-repo plan and is
-# handled by apply-required-checks.yml's notification to #4029.
+#
+# On 403 from the Rulesets API:
+#   The workflow falls back to reading branch protection (same-repo, no
+#   admin PAT needed) to check whether E2E Gate is already configured.
+#   - If configured: exits 0 (C6 green via Settings UI or admin PAT).
+#   - If missing:    exits 1 with a clear error and fix instructions.
+#   This gives an honest CI badge -- the prior "exit 0 on all 403" approach
+#   caused false-positive "enforcement GREEN" reports (fire 5 RCA,
+#   2026-08-06: ruleset was never actually applied; c6-health-check
+#   confirmed MISSING on 2026-07-28).
 #
 # NOTE: administration:write is NOT listed in the permissions block because
 # requesting it at the workflow level causes GitHub to kill the run with 0
 # jobs on personal repos (confirmed: run #30243855242 = 0 jobs queued).
 # The Python script handles the 403 runtime error gracefully instead.
 #
-# Tracking: vivekchand/clawmetry#4029 (C6)
+# Tracking: vivekchand/clawmetry#4552 (C6, active tracker)
 
 on:
   push:
@@ -59,7 +66,7 @@ jobs:
           # Single aggregator check -- PR #4111 (merged 2026-07-27) replaced the
           # 4 individual OSS E2E checks with one "E2E Gate (required)" job in
           # e2e-gate.yml. Keep in sync with apply_required_status_checks.py and
-          # c6-health.yml. One branch-protection entry closes C6 for clawmetry.
+          # c6-schedule-heal.yml. One branch-protection entry closes C6 for clawmetry.
           REQUIRED_CHECKS = [
               "E2E Gate (required)",
           ]
@@ -90,25 +97,73 @@ jobs:
                   raw = exc.read().decode(errors="replace")
                   return None, (exc.code, raw)
 
+          def _read_required_checks():
+              """Read required check names from branch protection (no admin PAT).
+
+              Reads GET /repos/{owner}/{repo}/branches/main -- same-repo read,
+              always succeeds with GITHUB_TOKEN. Returns the set of check context
+              names currently in the required_status_checks.contexts/checks list.
+              """
+              ctx = set()
+              try:
+                  req = urllib.request.Request(
+                      f"https://api.github.com/repos/{OWNER}/{REPO}/branches/main",
+                      headers=HEADERS,
+                  )
+                  with urllib.request.urlopen(req) as r:
+                      data = json.loads(r.read())
+                  prot = data.get("protection") or {}
+                  rsc = prot.get("required_status_checks") or {}
+                  for c in rsc.get("contexts") or []:
+                      ctx.add(c)
+                  for item in rsc.get("checks") or []:
+                      if isinstance(item, dict) and item.get("context"):
+                          ctx.add(item["context"])
+              except Exception as exc:
+                  print(f"  [warn] branch protection read failed: {exc}")
+              return ctx
+
           # Fetch existing rulesets to check for an upsert target.
           rulesets, err = api("GET", f"/repos/{OWNER}/{REPO}/rulesets")
           if err:
               code, body = err
               if code == 403:
-                  # 403 is expected on personal repos where the plan does not
-                  # grant GITHUB_TOKEN ruleset-management rights. This is NOT
-                  # an error -- exit 0 so CI stays green. The admin has clear
-                  # close-C6 instructions from apply-required-checks.yml.
-                  print(
-                      "::notice title=C6 Rulesets API unavailable::"
-                      "GITHUB_TOKEN returned 403 on GET /rulesets. "
-                      "Expected on this personal-repo plan. "
-                      "Close C6 via the Settings UI (60 s) or "
-                      "apply-required-checks.yml (confirm=APPLY + PAT). "
-                      "Tracking: https://github.com/vivekchand/clawmetry/issues/4029"
-                  )
-                  set_output("created", "false")
-                  sys.exit(0)
+                  # 403: GITHUB_TOKEN cannot manage rulesets on this personal-repo plan.
+                  # Fall back to reading branch protection (same-repo, no admin PAT)
+                  # to determine whether E2E Gate is already configured by other means
+                  # (Settings UI, admin PAT, or close-c6.sh script).
+                  #
+                  # Exit 0 only if the check IS already in branch protection.
+                  # Exit 1 if not -- so the CI badge reflects the true C6 state.
+                  # The prior "exit 0 on all 403" approach caused false-positive
+                  # "enforcement GREEN" reports (fire 5 RCA, 2026-08-06).
+                  configured = _read_required_checks()
+                  missing = [c for c in REQUIRED_CHECKS if c not in configured]
+                  if not missing:
+                      print(
+                          "::notice title=C6 GREEN via branch protection::"
+                          "Rulesets API 403 (expected on this plan) but "
+                          "E2E Gate (required) is already in clawmetry/main "
+                          "required status checks. C6 is enforced. "
+                          "Tracking: https://github.com/vivekchand/clawmetry/issues/4552"
+                      )
+                      set_output("created", "false")
+                      sys.exit(0)
+                  else:
+                      print(
+                          "::error title=C6 NOT ENFORCED -- manual action needed::"
+                          "Rulesets API returned 403 (GITHUB_TOKEN cannot write rulesets "
+                          "on this plan) AND E2E Gate (required) is NOT in clawmetry/main "
+                          "required status checks. PRs can currently merge without E2E "
+                          "passing. Fix (60s, browser only): "
+                          "https://github.com/vivekchand/clawmetry/settings/branches "
+                          "-- edit main -- Require status checks -- add: "
+                          "E2E Gate (required). "
+                          "Or run: bash scripts/close-c6.sh "
+                          "Tracking: https://github.com/vivekchand/clawmetry/issues/4552"
+                      )
+                      set_output("created", "false")
+                      sys.exit(1)
               else:
                   print(f"::error::GET /rulesets failed: {code} {body[:400]}")
                   set_output("created", "false")
@@ -162,11 +217,11 @@ jobs:
               code, body = err
               if code == 403:
                   print(
-                      f"::notice title=C6 Rulesets API unavailable::"
+                      f"::notice title=C6 Rulesets write blocked::"
                       f"{verb} ruleset returned 403 -- "
                       "GITHUB_TOKEN cannot manage rulesets on this plan/repo. "
                       "Use the PAT workflow or GitHub Settings UI instead. "
-                      "Tracking: https://github.com/vivekchand/clawmetry/issues/4029"
+                      "Tracking: https://github.com/vivekchand/clawmetry/issues/4552"
                   )
                   set_output("created", "false")
                   sys.exit(0)
@@ -274,7 +329,7 @@ jobs:
           TOKEN = os.environ["GITHUB_TOKEN"]
           OWNER = "vivekchand"
           REPO = "clawmetry"
-          TRACKING_ISSUE = 4029
+          TRACKING_ISSUE = 4552
           MARKER = "<!-- c6-ruleset-applied -->"
           RUN_URL = (
               f"https://github.com/{OWNER}/{REPO}/actions/runs/"


### PR DESCRIPTION
## Problem (fire 5 RCA, 2026-08-06)

`c6-apply-ruleset.yml` has been **exiting 0 on every 403** from the Rulesets API since it was written. Because the Rulesets API always returns 403 on this personal-repo plan, the workflow NEVER actually applied the ruleset. Yet the CI badge showed green on every push to main, causing fires 1-4 to incorrectly report C6 as \"enforcement GREEN.\"

The 2026-07-28 c6-health-check confirms the real state: **`E2E Gate (required)` is MISSING from clawmetry/main required status checks.** PRs can currently merge without E2E passing.

## Fix

On 403 from the Rulesets API, the workflow now falls back to reading branch protection (same-repo read, no admin PAT needed) and:
- Exits **0** if `E2E Gate (required)` is already in branch protection (C6 was closed by Settings UI, admin PAT, or `scripts/close-c6.sh`)
- Exits **1** with a clear error + fix instructions if the check is still missing

This makes the CI badge honest. The error message includes a direct link to Settings to close C6 in 60 seconds.

## Changes

- `.github/workflows/c6-apply-ruleset.yml`: Added `_read_required_checks()` helper and changed the 403 handler to read branch protection and exit 1 when E2E Gate is missing. Updated tracking issue reference from #4029 to #4552.

## What this unblocks

Once merged, every push to main will emit a clear `::error::` annotation until the user adds `E2E Gate (required)` to branch protection. This replaces the persistent false-positive green badge.

## Acceptance test

After merge, trigger `c6-apply-ruleset.yml` via a push to main. The run should:
1. Attempt to GET /rulesets -- get 403
2. Fall back to reading branch protection -- E2E Gate missing
3. Exit 1 with `::error title=C6 NOT ENFORCED -- manual action needed::`

Once the user adds `E2E Gate (required)` via Settings UI, the next run should exit 0.

## Related

- Tracking: #4552 (fire 5 entry: 2026-08-06T20:00Z)
- PR #4553 (c6-schedule-heal push guard, separate concern)
- c6-health-check 2026-07-28: confirmed MISSING

---
_Generated by [Claude Code](https://claude.ai/code/session_014DyKoWhfKPiuM6vKHMh9QY)_