### PR TITLE
fix(c6): honest exit code on Rulesets API 403, route alerts to active tracker #4552

### DIFF
--- a/.github/workflows/apply-required-checks.yml
+++ b/.github/workflows/apply-required-checks.yml
@@ -18,7 +18,7 @@ name: Apply required E2E status checks (C6 -- one-shot)
 #     With only GITHUB_TOKEN (ghs_): read-only verify path in the script
 #     (exits 0 if C6 configured, exits 1 if not -- no admin rights needed).
 #     With E2E_ADMIN_PAT: full apply + verify.
-#     On failure, posts a notification comment on tracking issue #4029.
+#     On failure, posts a notification comment on tracking issue #4552.
 #
 # TOKEN PATHS (priority order):
 #   1. inputs.pat_token  -- PAT typed into the Run workflow dialog
@@ -37,7 +37,7 @@ name: Apply required E2E status checks (C6 -- one-shot)
 #   clawmetry-landing.
 #
 # Idempotent: running multiple times is safe.
-# Tracking: vivekchand/clawmetry#4029
+# Tracking: vivekchand/clawmetry#4552
 
 on:
   workflow_dispatch:
@@ -117,7 +117,7 @@ jobs:
         run: python3 scripts/apply_required_status_checks.py
 
       # When the C6 read-only verify exits 1 (checks not yet configured on main),
-      # post or update a comment on the E2E Robustness tracking issue #4029 so the
+      # post or update a comment on the E2E Robustness tracking issue #4552 so the
       # repo admin receives a GitHub notification.
       #
       # Only fires on push-to-main (the automated verify path), NOT on manual
@@ -156,15 +156,15 @@ jobs:
 
           # Upsert: update existing comment if present, otherwise create new.
           existing_id=$(gh api -X GET \
-            "repos/${REPO}/issues/4029/comments" \
+            "repos/${REPO}/issues/4552/comments" \
             --jq 'map(select(.body | startswith("<!-- c6-notify-bot -->"))) | .[0].id // empty' \
             2>/dev/null || echo "")
           if [ -n "${existing_id}" ]; then
             gh api -X PATCH "repos/${REPO}/issues/comments/${existing_id}" \
               -f body="${BODY}" > /dev/null
-            echo "Updated existing C6 notification on #4029 (comment ${existing_id})"
+            echo "Updated existing C6 notification on #4552 (comment ${existing_id})"
           else
-            gh api -X POST "repos/${REPO}/issues/4029/comments" \
+            gh api -X POST "repos/${REPO}/issues/4552/comments" \
               -f body="${BODY}" > /dev/null
-            echo "Posted new C6 notification on #4029"
+            echo "Posted new C6 notification on #4552"
           fi

--- a/.github/workflows/c6-apply-ruleset.yml
+++ b/.github/workflows/c6-apply-ruleset.yml
@@ -14,16 +14,17 @@ name: Apply E2E required checks via Rulesets API (C6)
 #
 # Idempotent: upserts by name so repeated runs are safe.
 # Runs on every push to main so the ruleset self-heals if deleted.
-# On 403 (token lacks ruleset-write rights): emits a ::notice:: and
-# exits 0 -- a 403 is expected on this personal-repo plan and is
-# handled by apply-required-checks.yml's notification to #4029.
+# On 403 (token lacks ruleset-write rights): falls back to reading the
+# branch protection via the public branch endpoint to give an honest
+# exit code -- exits 0 if 'E2E Gate (required)' is already present,
+# exits 1 (::error::, actionable) if the check is still missing.
 #
 # NOTE: administration:write is NOT listed in the permissions block because
 # requesting it at the workflow level causes GitHub to kill the run with 0
 # jobs on personal repos (confirmed: run #30243855242 = 0 jobs queued).
 # The Python script handles the 403 runtime error gracefully instead.
 #
-# Tracking: vivekchand/clawmetry#4029 (C6)
+# Tracking: vivekchand/clawmetry#4552 (C6)
 
 on:
   push:
@@ -55,6 +56,7 @@ jobs:
           OWNER = "vivekchand"
           REPO = "clawmetry"
           RULESET_NAME = "E2E Required Status Checks (C6)"
+          C6_CHECK = "E2E Gate (required)"
 
           # Single aggregator check -- PR #4111 (merged 2026-07-27) replaced the
           # 4 individual OSS E2E checks with one "E2E Gate (required)" job in
@@ -90,25 +92,49 @@ jobs:
                   raw = exc.read().decode(errors="replace")
                   return None, (exc.code, raw)
 
+          def branch_has_c6_check():
+              """Return True if E2E Gate (required) is in branch protection.
+
+              Uses GET /branches/main -- public endpoint, works with GITHUB_TOKEN.
+              Reads both 'contexts' (legacy) and 'checks' (Settings UI) arrays.
+              """
+              data, err = api("GET", f"/repos/{OWNER}/{REPO}/branches/main")
+              if err or not data:
+                  return False
+              prot = data.get("protection") or {}
+              rsc = prot.get("required_status_checks") or {}
+              ctx = set(rsc.get("contexts") or [])
+              for item in (rsc.get("checks") or []):
+                  if isinstance(item, dict) and item.get("context"):
+                      ctx.add(item["context"])
+              return C6_CHECK in ctx
+
           # Fetch existing rulesets to check for an upsert target.
           rulesets, err = api("GET", f"/repos/{OWNER}/{REPO}/rulesets")
           if err:
               code, body = err
               if code == 403:
-                  # 403 is expected on personal repos where the plan does not
-                  # grant GITHUB_TOKEN ruleset-management rights. This is NOT
-                  # an error -- exit 0 so CI stays green. The admin has clear
-                  # close-C6 instructions from apply-required-checks.yml.
+                  # Rulesets API 403s on this personal-repo plan. Fall back to
+                  # reading the branch protection directly to give an honest exit
+                  # code: exit 0 if C6 is already configured, exit 1 if missing.
+                  if branch_has_c6_check():
+                      print(
+                          "[C6] Rulesets API 403 but 'E2E Gate (required)' is "
+                          "present in branch protection -- C6 OK."
+                      )
+                      set_output("created", "false")
+                      sys.exit(0)
                   print(
-                      "::notice title=C6 Rulesets API unavailable::"
-                      "GITHUB_TOKEN returned 403 on GET /rulesets. "
-                      "Expected on this personal-repo plan. "
-                      "Close C6 via the Settings UI (60 s) or "
-                      "apply-required-checks.yml (confirm=APPLY + PAT). "
-                      "Tracking: https://github.com/vivekchand/clawmetry/issues/4029"
+                      "::error title=C6 gap -- action needed::"
+                      "Rulesets API 403 AND 'E2E Gate (required)' is MISSING from "
+                      "branch protection. Fastest fix (60 s): "
+                      "github.com/vivekchand/clawmetry/settings/branches > "
+                      "Edit main > Require status checks > add 'E2E Gate (required)'. "
+                      "Or: bash scripts/close-c6.sh. "
+                      "Tracking: https://github.com/vivekchand/clawmetry/issues/4552"
                   )
                   set_output("created", "false")
-                  sys.exit(0)
+                  sys.exit(1)
               else:
                   print(f"::error::GET /rulesets failed: {code} {body[:400]}")
                   set_output("created", "false")
@@ -162,14 +188,13 @@ jobs:
               code, body = err
               if code == 403:
                   print(
-                      f"::notice title=C6 Rulesets API unavailable::"
-                      f"{verb} ruleset returned 403 -- "
-                      "GITHUB_TOKEN cannot manage rulesets on this plan/repo. "
-                      "Use the PAT workflow or GitHub Settings UI instead. "
-                      "Tracking: https://github.com/vivekchand/clawmetry/issues/4029"
+                      f"::error title=C6 Rulesets write denied::"
+                      f"Rulesets API {verb} returned 403 -- GITHUB_TOKEN cannot write rulesets. "
+                      "Fix: bash scripts/close-c6.sh (or Settings UI, ~60 s). "
+                      "Tracking: https://github.com/vivekchand/clawmetry/issues/4552"
                   )
                   set_output("created", "false")
-                  sys.exit(0)
+                  sys.exit(1)
               else:
                   print(f"::error::{verb} ruleset failed: {code} {body[:400]}")
                   set_output("created", "false")
@@ -187,7 +212,7 @@ jobs:
           PYEOF
 
       # Only verify if the upsert step actually created/updated a ruleset.
-      # Skipped when upsert exits 0 due to 403 (no ruleset to verify).
+      # Skipped when upsert exits 0 or 1 due to 403 (no ruleset to verify).
       - name: Verify ruleset is active
         if: success() && steps.upsert.outputs.created == 'true'
         env:
@@ -274,7 +299,7 @@ jobs:
           TOKEN = os.environ["GITHUB_TOKEN"]
           OWNER = "vivekchand"
           REPO = "clawmetry"
-          TRACKING_ISSUE = 4029
+          TRACKING_ISSUE = 4552
           MARKER = "<!-- c6-ruleset-applied -->"
           RUN_URL = (
               f"https://github.com/{OWNER}/{REPO}/actions/runs/"

--- a/scripts/apply_required_status_checks.py
+++ b/scripts/apply_required_status_checks.py
@@ -46,7 +46,7 @@ Primary repo behaviour (clawmetry):
 When run locally (GITHUB_REPOSITORY not set), the script applies all 3
 checks and requires a token with cross-repo admin access.
 
-Tracking: vivekchand/clawmetry#4029 (C6)
+Tracking: vivekchand/clawmetry#4552 (C6)
 """
 from __future__ import annotations
 
@@ -150,7 +150,7 @@ def _enable_status_checks_preserving(repo: str, contexts: list, token: str) -> N
 
     The PATCH sub-resource 404s with 'Required status checks not enabled'
     when main is protected (PR reviews, enforce_admins, ...) but the
-    status-check block was never switched on — the exact state all three
+    status-check block was never switched on -- the exact state all three
     repos were in (C6 audit red since #3970). PUT /protection REPLACES the
     whole rule, so read the current one and re-submit it faithfully with
     the status-check block added; nothing else may change.
@@ -309,7 +309,10 @@ def verify_required_checks_readonly(
     for repo in repos:
         actual = _get_branch_protection_contexts(repo, token)
         if actual is None:
-            print(f"  [{repo}] UNKNOWN: branch endpoint did not return protection info")
+            # Branch endpoint unavailable -- treat as unconfigured, not as OK.
+            # Silently continuing here would mask real C6 gaps.
+            print(f"  [{repo}] FAIL: branch endpoint unavailable -- treating as unconfigured")
+            ok = False
             continue
         required = {ctx for r, ctx in checks if r == repo}
         blocked = {ctx for r, ctx in deprecated if r == repo}
@@ -466,7 +469,7 @@ def main() -> None:
                 "  Fix: re-run the workflow and paste a fine-grained PAT into the 'pat_token' field.\n"
                 "  PAT permissions: Administration (read+write) on clawmetry, clawmetry-cloud, clawmetry-landing.\n"
                 "  Alternative: bash scripts/close-c6.sh (uses your gh CLI session, ~30 sec).\n"
-                "  Tracking: vivekchand/clawmetry#4029 (C6)"
+                "  Tracking: vivekchand/clawmetry#4552 (C6)"
             )
         # Read-only path: GITHUB_TOKEN cannot write branch protection rules.
         # Scope verification to the current repo only to avoid cross-repo 403s.


### PR DESCRIPTION
## Summary

Fixes three silent bugs that made C6 appear green for 5+ cron fires when it was actually red:

- **`c6-apply-ruleset.yml` exited 0 on every 403** even when `E2E Gate (required)` was missing from branch protection. CI badge was perpetually false-green. Fix: fall back to `GET /branches/main` (public endpoint, works with `GITHUB_TOKEN`) -- exit 0 only if the check is already present, exit 1 with `::error::` if still missing.

- **Both workflows posted C6 failure alerts to issue #4029 (CLOSED)**. The active tracker is #4552. User never received GitHub notifications about C6 failing on push-to-main. Fixed to #4552.

- **`verify_required_checks_readonly` silently continued** (`ok` unchanged) when the branch endpoint returned `None`, treating an unreachable branch as correctly configured. Now marks `ok = False` and prints `FAIL`.

## Files changed

| File | Change |
|------|--------|
| `.github/workflows/c6-apply-ruleset.yml` | 403 handler checks branch protection, exits 1 if missing; tracking ref updated to #4552 |
| `.github/workflows/apply-required-checks.yml` | Notification target updated from #4029 to #4552 |
| `scripts/apply_required_status_checks.py` | `verify_required_checks_readonly` sets `ok = False` on `None`; tracking ref updated to #4552 |

## What happens after merge

On the next push to main:
- `c6-apply-ruleset.yml` will show **RED** (honest: check is still missing)
- `apply-required-checks.yml` will post a notification on **#4552** (the open tracker you are watching)

C6 still needs the human 60-second action: **Settings > Branches > main > Require status checks > add `E2E Gate (required)`** -- or `bash scripts/close-c6.sh`.

## Test plan

- [ ] Merge this PR
- [ ] Observe next push-to-main: `c6-apply-ruleset.yml` shows red (honest badge)
- [ ] Observe notification posted on #4552 by `apply-required-checks.yml`
- [ ] Close C6 via Settings UI (60 s) or `bash scripts/close-c6.sh`
- [ ] Observe next push-to-main: both workflows go green

Tracking: #4552 (C6) -- fire 6, 2026-08-06

---
_Generated by [Claude Code](https://claude.ai/code/session_01V7XrPCPn8GehnXxX4LYBsE)_