### PR TITLE
feat(qm): register qm as the 17th observable runtime across OSS surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Opens at **http://localhost:8900** and you're done.
 
 ClawMetry started as observability for OpenClaw, and now meters your **whole agent fleet** in one dashboard, auto-detecting each runtime on your machine:
 
-🦞 **OpenClaw** · 🟩 **NVIDIA NemoClaw** · ◆ **Claude Code** · ⬡ **OpenAI Codex** · **Cursor** · 🪿 **Goose** · ⚡ **Hermes** · **opencode** · ◈ **Qwen Code** · **Aider** · **NanoClaw** · **PicoClaw** · **Pi** · **Deep Agents** · 🔗 **n8n** · 🪐 **Antigravity** · 🐙 **GitHub Copilot** · **Grok**
+🦞 **OpenClaw** · 🟩 **NVIDIA NemoClaw** · ◆ **Claude Code** · ⬡ **OpenAI Codex** · **Cursor** · 🪿 **Goose** · ⚡ **Hermes** · **opencode** · ◈ **Qwen Code** · **Aider** · **NanoClaw** · **PicoClaw** · **Pi** · **Deep Agents** · 🔗 **n8n** · 🪐 **Antigravity** · 🐙 **GitHub Copilot** · **Grok** · **QM**
 
 OpenClaw and NemoClaw are free in the open-source app; the other runtimes light up with ClawMetry Cloud or a self-hosted Pro license. Switch runtimes from the header and every tab — cost, tokens, tools, traces — re-scopes to that runtime. See **[docs/ENTITLEMENTS.md](docs/ENTITLEMENTS.md)** for the exact free/paid split, tier matrix, `/api/entitlement` shape, and the `clawmetry license` CLI.
 
@@ -294,7 +294,7 @@ services:
 
 - Python 3.8+
 - Flask (installed automatically via pip)
-- An AI agent runtime on the same machine: OpenClaw, NVIDIA NemoClaw, Claude Code, Codex, Cursor, Goose, Hermes, opencode, Qwen Code, Aider, NanoClaw, PicoClaw, Pi, Deep Agents, n8n, Antigravity, GitHub Copilot, or Grok (or mounted volumes for Docker)
+- An AI agent runtime on the same machine: OpenClaw, NVIDIA NemoClaw, Claude Code, Codex, Cursor, Goose, Hermes, opencode, Qwen Code, Aider, NanoClaw, PicoClaw, Pi, Deep Agents, n8n, Antigravity, GitHub Copilot, Grok, or QM (or mounted volumes for Docker)
 - Linux or macOS
 
 ## NemoClaw / OpenShell Support

--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -97,6 +97,7 @@ PAID_RUNTIMES = frozenset(
         "antigravity",
         "copilot",
         "grok",
+        "qm",
     }
 )
 
@@ -122,6 +123,7 @@ RUNTIME_LABELS = {
     "antigravity": "Antigravity",
     "copilot": "GitHub Copilot",
     "grok": "Grok",
+    "qm": "QM",
 }
 
 # Canonical list of chat-channel adapters observable by ClawMetry, in the

--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -11707,6 +11707,7 @@ _NON_OPENCLAW_RUNTIME_PREFIXES = (
     "picoclaw", "nanoclaw", "hermes",
     "claude_code", "codex", "cursor", "aider", "goose", "opencode", "qwen_code",
     "pi", "deepagents", "n8n", "antigravity", "copilot", "grok",
+    "qm",
 )
 
 def _runtime_session_id_clause(runtime: str | None) -> tuple[str | None, list[str]]:

--- a/clawmetry/numbat_ingest.py
+++ b/clawmetry/numbat_ingest.py
@@ -67,6 +67,7 @@ _AGENT_TO_RUNTIME = {
     "copilot": "copilot",
     "grok": "grok",
     "pi": "pi",
+    "qm": "qm",
 }
 
 _SEVERITIES = ("info", "low", "medium", "high", "critical")

--- a/clawmetry/runtime_probe.py
+++ b/clawmetry/runtime_probe.py
@@ -84,6 +84,15 @@ RUNTIME_PROBES: tuple = (
     RuntimeProbe("grok", "Grok",
                  ("~/.grok/logs", "~/.grok/sessions", "~/.grok/bin/grok"),
                  env="CLAWMETRY_GROK_HOME"),
+    # qm (github.com/yc-software/qm) has no on-disk session store — it's a
+    # Node service backed by Postgres — so the probe looks for the npm
+    # install artefacts (typical install layouts) plus a CLAWMETRY_QM_HOME
+    # override. The adapter itself uses DATABASE_URL + qm's tables directly.
+    RuntimeProbe("qm", "QM",
+                 ("~/node_modules/@yc-software/qm",
+                  "~/.qm", "~/qm/package.json",
+                  "/opt/qm/package.json"),
+                 env="CLAWMETRY_QM_HOME"),
 )
 
 

--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -9283,7 +9283,7 @@ var _CM_RT_LABEL = {
   hermes: 'Hermes', claude_code: 'Claude Code', codex: 'Codex', cursor: 'Cursor',
   aider: 'Aider', goose: 'Goose', opencode: 'opencode', qwen_code: 'Qwen Code',
   pi: 'Pi', deepagents: 'Deep Agents', n8n: 'n8n', antigravity: 'Antigravity',
-  copilot: 'GitHub Copilot', grok: 'Grok'
+  copilot: 'GitHub Copilot', grok: 'Grok', qm: 'QM'
 };
 // The CLOSED session-prefix runtimes (the only keys that can ride a session_id
 // prefix). Foreign OTLP / OpenLLMetry apps are NOT in here — they have no

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -6416,7 +6416,7 @@ _LITE_RT_LABELS = {
     "qwen_code": "Qwen Code", "hermes": "Hermes", "picoclaw": "PicoClaw",
     "nanoclaw": "NanoClaw", "pi": "Pi", "deepagents": "Deep Agents",
     "n8n": "n8n", "antigravity": "Antigravity", "copilot": "GitHub Copilot",
-    "grok": "Grok",
+    "grok": "Grok", "qm": "QM",
 }
 
 # Activity thresholds (seconds) for classifying a detected runtime. Detecting a
@@ -11757,6 +11757,12 @@ _FAMILY_ADAPTER_SPECS = (
     ("clawmetry_pro.adapters.antigravity", "AntigravityAdapter"),
     ("clawmetry_pro.adapters.copilot", "CopilotAdapter"),
     ("clawmetry_pro.adapters.grok", "GrokAdapter"),
+    # qm (github.com/yc-software/qm, qm.ycombinator.com) — YC's Postgres-
+    # backed multiplayer agent harness. Meta-orchestrator like Hermes;
+    # delegates to Pi / OpenCode / Codex / Claude Code, so a qm user is
+    # definitionally a Pro user. Adapter reads DATABASE_URL /
+    # CLAWMETRY_QM_DATABASE_URL in read-only mode.
+    ("clawmetry_pro.adapters.qm", "QMAdapter"),
 )
 
 
@@ -12955,7 +12961,7 @@ def _build_model_attribution():
 _RUNTIME_PREFIXES = frozenset({
     "picoclaw", "nanoclaw", "hermes", "claude_code", "codex", "cursor",
     "aider", "goose", "opencode", "qwen_code", "pi", "deepagents", "n8n",
-    "antigravity", "copilot", "grok",
+    "antigravity", "copilot", "grok", "qm",
 })
 
 

--- a/routes/harness.py
+++ b/routes/harness.py
@@ -29,7 +29,7 @@ bp_harness = Blueprint("harness", __name__)
 _NON_OPENCLAW_PREFIXES = frozenset({
     "picoclaw", "nanoclaw", "hermes", "nemoclaw",
     "claude_code", "codex", "cursor", "aider", "goose", "opencode", "qwen_code",
-    "pi", "deepagents", "n8n", "antigravity", "copilot", "grok",
+    "pi", "deepagents", "n8n", "antigravity", "copilot", "grok", "qm",
 })
 
 

--- a/routes/usage.py
+++ b/routes/usage.py
@@ -56,7 +56,7 @@ bp_usage = Blueprint('usage', __name__)
 _NON_OPENCLAW_RT_SET = frozenset((
     "picoclaw", "nanoclaw", "hermes",
     "claude_code", "codex", "cursor", "aider", "goose", "opencode", "qwen_code",
-    "pi", "deepagents", "n8n", "antigravity", "copilot", "grok",
+    "pi", "deepagents", "n8n", "antigravity", "copilot", "grok", "qm",
 ))
 
 def _event_runtime(ev) -> str:
@@ -910,7 +910,7 @@ def _try_local_store_usage_forecast():
 _RUNTIME_PREFIXES = frozenset({
     "picoclaw", "nanoclaw", "hermes", "claude_code", "codex", "cursor",
     "aider", "goose", "opencode", "qwen_code", "pi", "deepagents", "n8n",
-    "antigravity", "copilot", "grok",
+    "antigravity", "copilot", "grok", "qm",
 })
 
 

--- a/tests/test_advertised_runtimes_match_catalogue.py
+++ b/tests/test_advertised_runtimes_match_catalogue.py
@@ -25,7 +25,7 @@ EXPECTED_FREE_RUNTIMES = frozenset({"openclaw", "nemoclaw"})
 EXPECTED_PAID_RUNTIMES = frozenset({
     "claude_code", "codex", "cursor", "aider", "goose",
     "opencode", "qwen_code", "hermes", "picoclaw", "nanoclaw",
-    "pi", "deepagents", "n8n", "antigravity", "copilot", "grok",
+    "pi", "deepagents", "n8n", "antigravity", "copilot", "grok", "qm",
 })
 EXPECTED_ALL_RUNTIMES = EXPECTED_FREE_RUNTIMES | EXPECTED_PAID_RUNTIMES
 

--- a/tests/test_entitlements.py
+++ b/tests/test_entitlements.py
@@ -258,10 +258,11 @@ def test_paid_runtimes_exact_membership(ent):
             "antigravity",
             "copilot",
             "grok",
+            "qm",
         }
     )
     assert ent.PAID_RUNTIMES == expected
-    assert len(ent.PAID_RUNTIMES) == 16
+    assert len(ent.PAID_RUNTIMES) == 17
 
 
 def test_all_paid_runtimes_blocked_on_oss_enforced(ent, monkeypatch):

--- a/tests/test_onboard_runtime_detection.py
+++ b/tests/test_onboard_runtime_detection.py
@@ -25,7 +25,7 @@ def test_probe_catalogue_covers_all_supported_runtimes():
     """One probe per supported runtime, ids unique, free set exact."""
     ids = [p.id for p in RUNTIME_PROBES]
     assert len(ids) == len(set(ids))
-    assert len(ids) == 18  # grok joined 2026-08-05
+    assert len(ids) == 19  # qm joined 2026-08-06 (grok 2026-08-05)
     assert FREE_RUNTIMES == {"openclaw", "nemoclaw"}
     for rt in ("claude_code", "cursor", "codex", "qwen_code", "picoclaw", "n8n"):
         assert rt in ids
@@ -130,5 +130,5 @@ def test_probes_never_raise_when_probe_explodes(monkeypatch):
         lambda self: (_ for _ in ()).throw(OSError("boom")),
     )
     results = probe_runtimes()
-    assert len(results) == 18
+    assert len(results) == 19
     assert all(p["found"] is False for p in results)

--- a/tests/test_phase4_adapter_move.py
+++ b/tests/test_phase4_adapter_move.py
@@ -44,7 +44,7 @@ def test_family_adapter_specs_target_clawmetry_pro():
     from clawmetry import sync as _s
 
     specs = _s._FAMILY_ADAPTER_SPECS
-    assert len(specs) == 16, f"expected 16 paid adapters, got {len(specs)}"
+    assert len(specs) == 17, f"expected 17 paid adapters, got {len(specs)}"
     for module_name, class_name in specs:
         assert module_name.startswith("clawmetry_pro.adapters."), (
             f"sync._FAMILY_ADAPTER_SPECS still references OSS path: "


### PR DESCRIPTION
## Summary
Adds \`qm\` (github.com/yc-software/qm, qm.ycombinator.com — YC's Postgres-backed multiplayer agent harness) to every OSS-side runtime allowlist / label table so the pro \`QMAdapter\` (companion PR clawmetry-pro#120) is actually discovered by the daemon and rendered by the dashboard.

## Six lists updated in lockstep
- \`clawmetry/sync.py::_FAMILY_ADAPTER_SPECS\` — adapter import spec so \`_family_adapter_classes()\` picks up \`QMAdapter\` and its \`detect()\` runs.
- \`clawmetry/sync.py::_LITE_RT_LABELS\` — display label for the lite runtime chip on the fleet dashboard.
- \`clawmetry/sync.py::_RUNTIME_PREFIXES\` — cross-runtime session-id prefix set that \`_runtime_of_session\` uses.
- \`clawmetry/entitlements.py::PAID_RUNTIMES\` + \`RUNTIME_LABELS\` — qm is paid-tier (mirror of Hermes; qm delegates to Pi/OpenCode/Codex/Claude Code, all Pro).
- \`clawmetry/local_store.py::_NON_OPENCLAW_RUNTIME_PREFIXES\` — DuckDB event-attribution WHERE-clause runtime filter.
- \`clawmetry/numbat_ingest.py::_AGENT_TO_RUNTIME\` — Numbat findings routed to qm bucket.
- \`clawmetry/static/js/app.js::_CM_RT_LABEL\` — frontend runtime chip label (comment already requires backend/frontend to stay in sync).

## Pin guard
\`tests/test_entitlements.py::test_paid_runtimes_are_the_expected_set\` now expects 17 paid runtimes (was 16).

## Tests
\`pytest tests/test_entitlements.py tests/test_numbat_ingest.py\` → 93 passed.

## Ships alongside
- clawmetry-pro#120 — the \`QMAdapter\` implementation itself.

## Owed follow-ups
- clawmetry-cloud: \`cm-cloud-qm\` interceptor + \`cloud_route_policy\` entry + wheel bump (steps 3-4 of pro FLYWHEEL "done" bar).
- clawmetry-landing: SUPPORTED RUNTIMES popover + \`/how-it-works#runtimes\` (14 → 15 runtime display count).

🤖 Generated with [Claude Code](https://claude.com/claude-code)