### PR TITLE
[RELEASE] Auto-update daemon-registration fix + onboarding hang fix (carries #4579)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,17 @@
   no path back to `True`. The update-check worker now heals a stale unset
   `False` for every role/tier on boot, while a real, explicit user opt-out
   (`POST /api/update-check/config`) is now tracked and never overridden.
+- **Fixed an onboarding-complete request hang introduced by the daemon-registration
+  fix above.** `register_systemd`/`register_launchd` shelled out to
+  systemctl/launchctl with no timeout, synchronously inside the
+  `/api/onboarding/complete` HTTP handler the browser's init sequence waits
+  on. A runner or container with no working user systemd/dbus session can
+  make those commands hang instead of failing fast, blocking the response
+  indefinitely (caught live via a PR's own visual-diff bot: mobile
+  screenshots stuck forever on "Initializing ClawMetry"). Every
+  `daemon_registration.py` subprocess call is now bounded to a few seconds,
+  and the registration call itself is dispatched on a background thread so
+  onboarding-complete never blocks on it at all.
 - **Retired the legacy "ClawMetry Setup" gateway-token modal.** It auto-popped
   on every dashboard load regardless of whether onboarding had already
   completed (v0.1-era UX from before the product detected 17+ non-OpenClaw


### PR DESCRIPTION
## Summary

Publishes #4579 (already merged to main) to PyPI. That PR:

- Fixes the root cause of ClawMetry silently no longer auto-updating: the browser onboarding gate (the default first-run path since 2026-07-31) never registered a persistent background daemon, so auto-update polling stopped the moment the foreground dashboard process exited.
- Adds Windows Task Scheduler persistence (previously zero reboot/crash recovery on Windows).
- Makes the `auto_update` self-heal apply to every role/tier, not just paid cloud accounts.
- Fixes a self-host trial that silently failed to activate while reporting the install as already onboarded.
- Fixes the runtime-status chip redirecting a self-hosted user to a cloud upgrade page instead of the local trial flow.
- Fixes an onboarding-complete request hang caught live via this PR's own visual-diff bot (unbounded systemctl/launchctl subprocess calls run synchronously in the request handler).

This PR only adds the CHANGELOG entry documenting the fix; `release-on-merge.yml` handles the version bump and PyPI publish.

## Test plan

- [x] All work already verified and merged in #4579 (39/39 new/changed tests passing, full CI green).
- [x] CHANGELOG entry added under `## Unreleased`.

---
_Generated by [Claude Code](https://claude.ai/code/session_014M9RFasj1Cak93j3CuF1q5)_