### PR TITLE
feat(entitlement): capacity_headroom_at_path + capacity_headroom_at_path_batch + 2 endpoints

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -3677,6 +3677,176 @@ def capacity_headroom_path_batch(
     return {"tiers": rows, "unknown": unknown}
 
 
+def capacity_headroom_at_path(
+    perspective_tier: str,
+    from_tier: str,
+    to_tier: str,
+    *,
+    channels: int | None = None,
+    retention_days: int | None = None,
+    nodes: int | None = None,
+) -> list[dict] | None:
+    """What-if sibling of :func:`capacity_headroom_path`: per-rung capacity-
+    headroom path between ``from_tier`` and ``to_tier`` rendered from a
+    hypothetical ``perspective_tier``.
+
+    Fills the ``_at_path`` slot on the capacity-headroom axis alongside
+    :func:`capacity_headroom` (scalar current), :func:`capacity_headroom_at`
+    (scalar what-if), :func:`capacity_headroom_batch` (per-tier what-if
+    matrix), :func:`capacity_headroom_path` (scalar path) and
+    :func:`capacity_headroom_path_batch` (multi-destination path) so a
+    pricing-comparison walkthrough surface can call
+    ``X_at_path(perspective, from, to)`` uniformly across the whole
+    ``_at_path`` family. Headroom-shaped mirror of
+    :func:`capacity_diff_at_path` (same rung walk, headroom envelopes per
+    rung instead of marginal-transition triples) and marginal-capacity
+    twin of :func:`tier_catalog_at_path` -- same posture, per-axis usage
+    rows instead of tier-ladder rows.
+
+    Body posture matches :func:`capacity_diff_at_path` and every other
+    ``_at_path`` helper: perspective is validated against
+    :data:`_TIER_ORDER` but does NOT shape rows. Each row is byte-
+    identical to a row from :func:`capacity_headroom_path` for the same
+    ``(from_tier, to_tier)`` pair with the same per-axis usage inputs --
+    pinned by parity tests so the what-if path helper cannot drift from
+    the current-perspective sibling that also backs
+    :func:`capacity_headroom_path_batch`.
+
+    Perspective acceptance is lenient (matches :func:`capacity_headroom_at`
+    and every other ``_at`` helper): any id in :data:`_TIER_ORDER` is
+    accepted, including :data:`TIER_TRIAL`. Endpoint acceptance mirrors
+    :func:`capacity_headroom_path`: both ``from_tier`` and ``to_tier``
+    accept any id in :data:`_TIER_FEATURES` (trial is a valid endpoint
+    via the lateral / identity branches even though the walked
+    intermediate rungs exclude it -- it is not purchasable).
+
+    Per-axis "None means axis not supplied" posture matches
+    :func:`capacity_headroom_path`: an unsupplied axis stays ``None``
+    on every rung; a supplied axis is echoed on every rung and the cap
+    is walked off each rung's static cap.
+
+    Returns ``None`` when any of the three ids is unknown; empty list
+    for identity (``from == to``); single-row path for lateral
+    (same-rank, different id). Resolver-independent: delegates to
+    :func:`capacity_headroom_path`, which walks the static per-tier caps
+    via :func:`capacity_headroom_at`, so grace vs enforce yields
+    byte-identical rows -- same property the rest of the ``_path`` family
+    guarantees.
+
+    Never raises: a delegate failure logs a warning and returns
+    ``None`` so an upgrade-walkthrough surface keeps rendering instead
+    of breaking.
+    """
+    try:
+        p = (perspective_tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if p not in _TIER_ORDER:
+        return None
+    try:
+        return capacity_headroom_path(
+            from_tier,
+            to_tier,
+            channels=channels,
+            retention_days=retention_days,
+            nodes=nodes,
+        )
+    except Exception as exc:
+        logger.warning("entitlements: capacity_headroom_at_path failed: %s", exc)
+        return None
+
+
+def capacity_headroom_at_path_batch(
+    perspective_tier: str,
+    from_tier: str,
+    to_tiers,
+    *,
+    channels: int | None = None,
+    retention_days: int | None = None,
+    nodes: int | None = None,
+) -> dict | None:
+    """Batch sibling of :func:`capacity_headroom_at_path`: per-rung
+    capacity-headroom envelopes for a caller-supplied subset of destination
+    tiers all walked from a single ``from_tier`` from a hypothetical
+    ``perspective_tier`` in ONE round-trip.
+
+    Composes :func:`capacity_headroom_at_path` (scalar what-if path) and
+    :func:`capacity_headroom_path_batch` (multi-destination current-
+    perspective path). Fills the ``_at_path_batch`` slot on the capacity-
+    headroom axis alongside :func:`capacity_headroom_at`,
+    :func:`capacity_headroom_batch`, :func:`capacity_headroom_path`,
+    :func:`capacity_headroom_path_batch` and :func:`capacity_headroom_at_path`
+    so a pricing-comparison walkthrough surface can call
+    ``X_at_path_batch(perspective, from, to_tiers)`` uniformly across the
+    whole ``_at_path_batch`` family. Headroom-shaped twin of
+    :func:`capacity_diff_at_path_batch` -- same fan-out shape, per-axis
+    headroom body instead of marginal-transition body.
+
+    Per-destination row shape mirrors :func:`capacity_headroom_path_batch`::
+
+        {
+          "to":         "<tier id>",
+          "to_label":   "...",
+          "to_rank":    <int>,
+          "direction":  "upgrade" | "downgrade" | "lateral" | "identity",
+          "path":       [<capacity_headroom_at row>, ...],
+        }
+
+    Envelope::
+
+        {
+          "tiers":   [<row>, ...],
+          "unknown": ["bogus_id", ...],
+        }
+
+    Body posture matches :func:`capacity_headroom_at_path`: perspective is
+    validated against :data:`_TIER_ORDER` but does NOT shape rows. Each
+    row is byte-identical to a row from
+    :func:`capacity_headroom_path_batch` for the same
+    ``(from_tier, to_tiers)`` pair with the same per-axis usage inputs --
+    pinned by parity tests so the batch what-if path helper cannot drift
+    from the current-perspective sibling.
+
+    Supplied destination ids are normalised via :func:`_normalise_csv`
+    (whitespace stripped, lowercased, duplicates dropped, first-seen
+    order preserved). Unknown destination ids land in ``unknown[]``
+    instead of short-circuiting the batch, matching every other
+    ``*_path_batch`` sibling's posture. ``trial`` IS accepted as a
+    destination via the lateral / identity branches, matching
+    :func:`capacity_headroom_path_batch`.
+
+    Per-axis "None means axis not supplied" posture matches
+    :func:`capacity_headroom_path_batch`: an unsupplied axis stays
+    ``None`` on every rung of every destination; a supplied axis is
+    echoed on every rung and the cap is walked off each destination
+    rung's static cap.
+
+    Returns ``None`` for empty / unknown ``perspective_tier`` or
+    ``from_tier`` (caller renders "unknown tier" / 404). Never raises:
+    a per-destination failure short-circuits that id into ``unknown[]``
+    and the rest of the batch keeps building.
+    """
+    try:
+        p = (perspective_tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if p not in _TIER_ORDER:
+        return None
+    try:
+        return capacity_headroom_path_batch(
+            from_tier,
+            to_tiers,
+            channels=channels,
+            retention_days=retention_days,
+            nodes=nodes,
+        )
+    except Exception as exc:
+        logger.warning(
+            "entitlements: capacity_headroom_at_path_batch failed: %s", exc
+        )
+        return None
+
+
 def _capacity_row(from_tier: str, to_tier: str) -> dict:
     """Build one ``capacity_diff``-shape row for an arbitrary ``from -> to`` pair.
 

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -26004,6 +26004,324 @@ def api_entitlement_capacity_headroom_path_batch():
         )
 
 
+@bp_entitlement.route("/api/entitlement/capacity-headroom-at-path")
+def api_entitlement_capacity_headroom_at_path():
+    """``GET /api/entitlement/capacity-headroom-at-path?tier=<perspective>
+    &from=<from>&to=<to>&channels=<int>&retention_days=<int>&nodes=<int>``
+    -- per-rung capacity-headroom envelope along an arbitrary
+    ``from -> to`` segment, rendered from a hypothetical
+    ``perspective_tier``.
+
+    What-if sibling of ``/capacity-headroom-path``: same rung walk, same
+    per-rung headroom body (``tier`` / ``tier_label`` / ``channels`` /
+    ``retention_days`` / ``nodes`` where each per-axis row matches the
+    :func:`entitlements._headroom_row` shape), plus a ``perspective_tier``
+    echo so a pricing-comparison walkthrough surface can call
+    ``X_at_path(perspective, from, to)`` uniformly across the whole
+    ``_at_path`` slot of the capacity-headroom family (alongside
+    ``/capacity-headroom-at`` and ``/capacity-headroom-batch``, which
+    fill the scalar-what-if and batch-what-if slots). Headroom-shaped
+    mirror of ``/capacity-diff-at-path`` -- same posture, per-axis usage
+    rows instead of marginal-transition rows.
+
+    Body posture matches ``/capacity-headroom-at``: perspective is
+    validated but does not shape the rows. Each row in ``path`` is
+    byte-identical to a row from
+    ``/capacity-headroom-path?from=<from>&to=<to>`` -- pinned by parity
+    tests. Perspective acceptance is lenient: ``trial`` IS accepted
+    (matching every other ``_at`` sibling).
+
+    Response shape::
+
+        {
+          "perspective_tier":      "<tier id>",
+          "perspective_tier_rank": <int>,
+          "from":                  "<tier id>",
+          "from_label":            "...",
+          "from_rank":             <int>,
+          "to":                    "<tier id>",
+          "to_label":              "...",
+          "to_rank":               <int>,
+          "direction":             "upgrade" | "downgrade" | "lateral" | "identity",
+          "path":                  [<capacity-headroom row>, ...],
+          "current_tier":          "<tier id>",
+          "current_tier_rank":     <int>,
+          "grace":                 <bool>,
+          "enforced":              <bool>,
+        }
+
+    Per-axis ``None`` on every row means "axis not supplied" (matches
+    ``/capacity-headroom-path``'s posture). A blank, non-int, negative,
+    or ``bool``-in-disguise value on any axis short-circuits that axis
+    to ``None`` on every row -- a stray query string cannot silently
+    blank the whole walk.
+
+    - **400** when ``tier=``, ``from=`` or ``to=`` is missing / blank
+    - **404** when any id is unknown (body carries ``which: "tier" |
+      "from" | "to"`` so the caller can point at the offender)
+    - **Never 5xxs**: a resolver failure short-circuits to 404 so a
+      capacity-only pricing-comparison walkthrough surface keeps
+      rendering instead of breaking.
+    """
+    p = (request.args.get("tier") or "").strip().lower()
+    f = (request.args.get("from") or "").strip().lower()
+    t = (request.args.get("to") or "").strip().lower()
+    if not p:
+        return jsonify({"error": "missing tier"}), 400
+    if not f:
+        return jsonify({"error": "missing from"}), 400
+    if not t:
+        return jsonify({"error": "missing to"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        if p not in _ent._TIER_ORDER:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "tier", "tier": p}
+                ),
+                404,
+            )
+        if f not in _ent._TIER_FEATURES:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "from", "from": f}
+                ),
+                404,
+            )
+        if t not in _ent._TIER_FEATURES:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "to", "to": t}
+                ),
+                404,
+            )
+        kwargs: dict[str, int] = {}
+        for name in ("channels", "retention_days", "nodes"):
+            present, ok, val, _raw = _parse_capacity_arg(name)
+            if present and ok and val is not None and val >= 0:
+                kwargs[name] = val
+        path = _ent.capacity_headroom_at_path(p, f, t, **kwargs)
+        if path is None:
+            return (
+                jsonify(
+                    {
+                        "error": "unknown tier",
+                        "tier": p,
+                        "from": f,
+                        "to": t,
+                    }
+                ),
+                404,
+            )
+        from_rank = _ent.tier_rank(f)
+        to_rank = _ent.tier_rank(t)
+        if f == t:
+            direction = "identity"
+        elif from_rank == to_rank:
+            direction = "lateral"
+        elif to_rank > from_rank:
+            direction = "upgrade"
+        else:
+            direction = "downgrade"
+        try:
+            ent = _ent.get_entitlement()
+            current_tier = getattr(ent, "tier", "oss") or "oss"
+            grace = bool(getattr(ent, "grace", True))
+        except Exception:
+            current_tier = "oss"
+            grace = True
+        try:
+            enforced = bool(_ent.is_enforced())
+        except Exception:
+            enforced = False
+        return jsonify(
+            {
+                "perspective_tier": p,
+                "perspective_tier_rank": _ent.tier_rank(p),
+                "from": f,
+                "from_label": _ent.tier_label(f),
+                "from_rank": from_rank,
+                "to": t,
+                "to_label": _ent.tier_label(t),
+                "to_rank": to_rank,
+                "direction": direction,
+                "path": path,
+                "current_tier": current_tier,
+                "current_tier_rank": _ent.tier_rank(current_tier),
+                "grace": grace,
+                "enforced": enforced,
+            }
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_capacity_headroom_at_path: error: %s", exc
+        )
+        return (
+            jsonify(
+                {
+                    "error": "unknown tier",
+                    "tier": p,
+                    "from": f,
+                    "to": t,
+                }
+            ),
+            404,
+        )
+
+
+@bp_entitlement.route("/api/entitlement/capacity-headroom-at-path-batch")
+def api_entitlement_capacity_headroom_at_path_batch():
+    """``GET /api/entitlement/capacity-headroom-at-path-batch?tier=<perspective>
+    &from=<from>&to=a,b,c&channels=<int>&retention_days=<int>&nodes=<int>``
+    -- batch sibling of ``/capacity-headroom-at-path``.
+
+    Where ``/capacity-headroom-at-path`` walks the headroom rungs between
+    ONE ``(from, to)`` pair from a hypothetical ``perspective_tier``, this
+    walks ONE ``from`` to N candidate ``to`` tiers in ONE round-trip from
+    the same hypothetical perspective -- the batch what-if sibling of
+    ``/capacity-headroom-path-batch``, filling the ``_at_path_batch`` slot
+    for the capacity-headroom family. Headroom-shaped twin of
+    ``/capacity-diff-at-path-batch`` (same fan-out shape, per-axis
+    headroom body instead of marginal-transition body).
+
+    Body posture matches ``/capacity-headroom-at``: perspective is
+    validated but does not shape rows. Each row in ``tiers[].path`` is
+    byte-identical to a row from ``/capacity-headroom-path-batch`` for
+    the same ``(from, to)`` pair with the same per-axis usage inputs --
+    pinned by parity tests. Perspective acceptance is lenient: ``trial``
+    IS accepted (matching every other ``_at`` sibling).
+
+    Response shape (mirrors ``/capacity-headroom-path-batch`` plus the
+    ``perspective_tier`` echo and the resolver-context tail every
+    ``_at*`` endpoint carries)::
+
+        {
+          "perspective_tier":      "<tier id>",
+          "perspective_tier_rank": <int>,
+          "from":                  "<tier id>",
+          "from_label":            "...",
+          "from_rank":             <int>,
+          "tiers": [
+            {
+              "to":        "<tier id>",
+              "to_label":  "...",
+              "to_rank":   <int>,
+              "direction": "upgrade" | "downgrade" | "lateral" | "identity",
+              "path":      [<capacity-headroom row>, ...],
+            },
+            ...
+          ],
+          "unknown":               ["bogus_id", ...],
+          "current_tier":          "<tier id>",
+          "current_tier_rank":     <int>,
+          "grace":                 <bool>,
+          "enforced":              <bool>,
+        }
+
+    Supplied destination ids are normalised (whitespace stripped,
+    lowercased, duplicates dropped, first-seen order preserved). Unknown
+    destination ids do NOT 404 the call -- they are echoed in
+    ``unknown[]`` so a partially-bad caller still gets paths back for the
+    valid ids alongside a list of what was dropped, matching every other
+    ``*_path_batch`` sibling's posture.
+
+    Per-axis ``None`` on every row means "axis not supplied" (matches
+    ``/capacity-headroom-path-batch``'s posture). A blank, non-int,
+    negative, or ``bool``-in-disguise value on any axis short-circuits
+    that axis to ``None`` on every row of every destination -- a stray
+    query string cannot silently blank the whole matrix.
+
+    - **400** when ``tier=`` or ``from=`` is missing / blank, or ``to=``
+      is missing / empty after normalisation
+    - **404** when ``tier`` or ``from`` is unknown (body carries
+      ``which: "tier" | "from"``)
+    - **200** with bucketed unknowns for unknown destination ids -- does
+      NOT 404 the call
+    - **Never 5xxs**: a synthesis failure short-circuits to an envelope
+      with empty rows so the matrix keeps rendering.
+    """
+    p = (request.args.get("tier") or "").strip().lower()
+    f = (request.args.get("from") or "").strip().lower()
+    if not p:
+        return jsonify({"error": "missing tier"}), 400
+    if not f:
+        return jsonify({"error": "missing from"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        if p not in _ent._TIER_ORDER:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "tier", "tier": p}
+                ),
+                404,
+            )
+        if f not in _ent._TIER_FEATURES:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "from", "from": f}
+                ),
+                404,
+            )
+        targets = _parse_csv_arg("to")
+        if not targets:
+            return jsonify({"error": "supply to=<csv>"}), 400
+        kwargs: dict[str, int] = {}
+        for name in ("channels", "retention_days", "nodes"):
+            present, ok, val, _raw = _parse_capacity_arg(name)
+            if present and ok and val is not None and val >= 0:
+                kwargs[name] = val
+        batch = _ent.capacity_headroom_at_path_batch(p, f, targets, **kwargs)
+        if batch is None:
+            batch = {"tiers": [], "unknown": []}
+        try:
+            ent = _ent.get_entitlement()
+            current_tier = getattr(ent, "tier", "oss") or "oss"
+            grace = bool(getattr(ent, "grace", True))
+        except Exception:
+            current_tier = "oss"
+            grace = True
+        try:
+            enforced = bool(_ent.is_enforced())
+        except Exception:
+            enforced = False
+        return jsonify(
+            {
+                "perspective_tier": p,
+                "perspective_tier_rank": _ent.tier_rank(p),
+                "from": f,
+                "from_label": _ent.tier_label(f),
+                "from_rank": _ent.tier_rank(f),
+                "tiers": batch.get("tiers", []),
+                "unknown": batch.get("unknown", []),
+                "current_tier": current_tier,
+                "current_tier_rank": _ent.tier_rank(current_tier),
+                "grace": grace,
+                "enforced": enforced,
+            }
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_capacity_headroom_at_path_batch: error: %s", exc
+        )
+        return jsonify(
+            {
+                "perspective_tier": p,
+                "perspective_tier_rank": 0,
+                "from": f,
+                "from_label": None,
+                "from_rank": -1,
+                "tiers": [],
+                "unknown": [],
+                "current_tier": "oss",
+                "current_tier_rank": 0,
+                "grace": True,
+                "enforced": False,
+            }
+        )
+
+
 @bp_entitlement.route("/api/entitlement/tier-unlocks-path-batch")
 def api_entitlement_tier_unlocks_path_batch():
     """``GET /api/entitlement/tier-unlocks-path-batch?from=<id>&to=a,b,c``

--- a/tests/test_entitlement_capacity_headroom_at_path.py
+++ b/tests/test_entitlement_capacity_headroom_at_path.py
@@ -1,0 +1,1050 @@
+"""Tests for ``clawmetry.entitlements.capacity_headroom_at_path`` +
+``capacity_headroom_at_path_batch`` and their two HTTP endpoints
+``GET /api/entitlement/capacity-headroom-at-path`` +
+``GET /api/entitlement/capacity-headroom-at-path-batch``.
+
+Path-shaped what-if sibling of :func:`capacity_headroom_path` /
+:func:`capacity_headroom_path_batch`: renders the per-rung capacity-
+headroom envelope path between two tiers from a hypothetical
+``perspective_tier`` given caller-supplied per-axis usage in ONE
+round-trip. Fills the ``_at_path`` / ``_at_path_batch`` slots on the
+capacity-headroom axis so a pricing-comparison walkthrough surface can
+call ``X_at_path(perspective, from, to)`` uniformly across every
+``_at_path`` family member.
+
+Pins:
+
+* body byte-identical to :func:`capacity_headroom_path` /
+  :func:`capacity_headroom_path_batch` for every perspective -- the
+  perspective is validated but does NOT shape the rows (parity with
+  every other ``_at_path`` helper the ``capacity_diff_at_path`` /
+  ``feature_catalog_at_path`` / ``preview_at_path`` family ships).
+* per-rung row shape carries the ``tier`` / ``tier_label`` /
+  ``channels`` / ``retention_days`` / ``nodes`` envelope
+  :func:`capacity_headroom_at` returns.
+* per-axis "None means axis not supplied" posture: an unsupplied axis
+  stays ``None`` on every rung; a supplied axis is echoed on every
+  rung.
+* ``trial`` accepted as perspective and as endpoint / destination
+  (matching every other ``_at`` sibling's lenient posture).
+* case + whitespace normalisation on perspective, from, to.
+* helper is decoupled from the resolver -- grace vs enforce yields
+  byte-identical rows.
+* unknown / empty / garbage ids return ``None`` and never raise; a
+  per-destination failure short-circuits that id into ``unknown[]``
+  and the rest of the batch keeps building.
+* API scalar: 400 on missing args, 404 with ``which: "tier" | "from" |
+  "to"`` on unknown ids, 200 with the standard resolver-context tail
+  every ``_at*`` endpoint carries.
+* API batch: 400 on missing tier / from / empty to, 404 with
+  ``which: "tier" | "from"`` on unknown perspective / source, 200 with
+  bucketed ``unknown[]`` on partially-bad destination lists, never
+  5xxs on a synthesis failure.
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+
+_ROW_ENVELOPE_KEYS = {
+    "tier",
+    "tier_label",
+    "channels",
+    "retention_days",
+    "nodes",
+}
+_ITEM_KEYS = {"to", "to_label", "to_rank", "direction", "path"}
+_SCALAR_ENVELOPE_KEYS = {
+    "perspective_tier",
+    "perspective_tier_rank",
+    "from",
+    "from_label",
+    "from_rank",
+    "to",
+    "to_label",
+    "to_rank",
+    "direction",
+    "path",
+    "current_tier",
+    "current_tier_rank",
+    "grace",
+    "enforced",
+}
+_BATCH_ENVELOPE_KEYS = {
+    "perspective_tier",
+    "perspective_tier_rank",
+    "from",
+    "from_label",
+    "from_rank",
+    "tiers",
+    "unknown",
+    "current_tier",
+    "current_tier_rank",
+    "grace",
+    "enforced",
+}
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def enforced(monkeypatch, tmp_path):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from flask import Flask
+
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+def _all_tiers(mod):
+    return [
+        mod.TIER_OSS,
+        mod.TIER_CLOUD_FREE,
+        mod.TIER_TRIAL,
+        mod.TIER_CLOUD_STARTER,
+        mod.TIER_CLOUD_PRO,
+        mod.TIER_PRO,
+        mod.TIER_ENTERPRISE,
+    ]
+
+
+_USAGE = {"channels": 100, "retention_days": 30, "nodes": 5}
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# scalar helper: shape + happy path
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_scalar_returns_list(ent):
+    path = ent.capacity_headroom_at_path(
+        ent.TIER_CLOUD_PRO, ent.TIER_OSS, ent.TIER_ENTERPRISE, **_USAGE
+    )
+    assert isinstance(path, list)
+    assert len(path) >= 1
+
+
+def test_scalar_each_row_has_expected_shape(ent):
+    path = ent.capacity_headroom_at_path(
+        ent.TIER_CLOUD_PRO, ent.TIER_OSS, ent.TIER_ENTERPRISE, **_USAGE
+    )
+    for row in path:
+        assert isinstance(row, dict)
+        assert set(row.keys()) == _ROW_ENVELOPE_KEYS
+        assert isinstance(row["tier"], str)
+
+
+def test_scalar_identity_yields_empty(ent):
+    for tid in _all_tiers(ent):
+        assert (
+            ent.capacity_headroom_at_path(
+                ent.TIER_CLOUD_PRO, tid, tid, **_USAGE
+            )
+            == []
+        )
+
+
+def test_scalar_lateral_yields_single_row(ent):
+    """Lateral (same rank, different id) yields a one-row path."""
+    path = ent.capacity_headroom_at_path(
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_PRO,
+        **_USAGE,
+    )
+    assert isinstance(path, list)
+    assert len(path) == 1
+    assert path[0]["tier"] == ent.TIER_PRO
+
+
+def test_scalar_upgrade_walks_ascending_rungs(ent):
+    """Every walked rung should be strictly above ``from_rank`` and up
+    to ``to_rank`` inclusive (upgrade direction)."""
+    path = ent.capacity_headroom_at_path(
+        ent.TIER_CLOUD_PRO, ent.TIER_OSS, ent.TIER_ENTERPRISE, **_USAGE
+    )
+    from_rank = ent.tier_rank(ent.TIER_OSS)
+    to_rank = ent.tier_rank(ent.TIER_ENTERPRISE)
+    for row in path:
+        r = ent.tier_rank(row["tier"])
+        assert from_rank < r <= to_rank
+
+
+def test_scalar_downgrade_walks_descending_rungs(ent):
+    path = ent.capacity_headroom_at_path(
+        ent.TIER_CLOUD_PRO, ent.TIER_ENTERPRISE, ent.TIER_OSS, **_USAGE
+    )
+    from_rank = ent.tier_rank(ent.TIER_ENTERPRISE)
+    to_rank = ent.tier_rank(ent.TIER_OSS)
+    for row in path:
+        r = ent.tier_rank(row["tier"])
+        assert to_rank <= r < from_rank
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# scalar helper: byte-parity with capacity_headroom_path
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_scalar_body_parity_with_capacity_headroom_path(ent):
+    """Body byte-identical to ``capacity_headroom_path(from, to)`` for
+    every ``(perspective, from, to)`` triple in
+    ``ALL_TIERS × ALL_TIERS × ALL_TIERS``. Perspective validates but
+    does NOT shape rows."""
+    tiers = _all_tiers(ent)
+    for p in tiers:
+        for f in tiers:
+            for t in tiers:
+                got = ent.capacity_headroom_at_path(p, f, t, **_USAGE)
+                want = ent.capacity_headroom_path(f, t, **_USAGE)
+                assert got == want, (
+                    f"body drift for perspective={p} from={f} to={t}: "
+                    f"{got!r} != {want!r}"
+                )
+
+
+def test_scalar_perspective_invariance(ent):
+    """Shifting perspective across every id in ``_TIER_ORDER`` yields
+    byte-identical rows for the same ``(from, to)`` pair."""
+    baseline = ent.capacity_headroom_at_path(
+        ent.TIER_CLOUD_PRO, ent.TIER_OSS, ent.TIER_ENTERPRISE, **_USAGE
+    )
+    for p in _all_tiers(ent):
+        assert (
+            ent.capacity_headroom_at_path(
+                p, ent.TIER_OSS, ent.TIER_ENTERPRISE, **_USAGE
+            )
+            == baseline
+        ), f"perspective {p} drifted from cloud_pro baseline"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# scalar helper: per-axis usage semantics
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_scalar_unsupplied_axis_is_none_on_every_row(ent):
+    """No usage kwargs supplied -> every rung's per-axis rows are
+    ``None`` (matches capacity_headroom_path's posture)."""
+    path = ent.capacity_headroom_at_path(
+        ent.TIER_CLOUD_PRO, ent.TIER_OSS, ent.TIER_ENTERPRISE
+    )
+    for row in path:
+        assert row["channels"] is None
+        assert row["retention_days"] is None
+        assert row["nodes"] is None
+
+
+def test_scalar_only_channels_supplied(ent):
+    """Only channels supplied -> only channels row echoed on every
+    rung; retention / nodes stay ``None``."""
+    path = ent.capacity_headroom_at_path(
+        ent.TIER_CLOUD_PRO, ent.TIER_OSS, ent.TIER_ENTERPRISE, channels=25
+    )
+    for row in path:
+        assert row["channels"] is not None
+        assert row["retention_days"] is None
+        assert row["nodes"] is None
+
+
+def test_scalar_all_axes_supplied(ent):
+    path = ent.capacity_headroom_at_path(
+        ent.TIER_CLOUD_PRO, ent.TIER_OSS, ent.TIER_ENTERPRISE, **_USAGE
+    )
+    for row in path:
+        assert row["channels"] is not None
+        assert row["retention_days"] is not None
+        assert row["nodes"] is not None
+
+
+def test_scalar_row_matches_capacity_headroom_at(ent):
+    """Each rung's row byte-equals :func:`capacity_headroom_at(rung, ...)`
+    -- the scalar/what-if no-drift contract."""
+    path = ent.capacity_headroom_at_path(
+        ent.TIER_CLOUD_PRO, ent.TIER_OSS, ent.TIER_ENTERPRISE, **_USAGE
+    )
+    for row in path:
+        assert row == ent.capacity_headroom_at(row["tier"], **_USAGE)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# scalar helper: input handling / error posture
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_scalar_trial_accepted_as_perspective(ent):
+    """Trial IS accepted as perspective (lenient ``_at`` posture)."""
+    got = ent.capacity_headroom_at_path(
+        ent.TIER_TRIAL, ent.TIER_OSS, ent.TIER_ENTERPRISE, **_USAGE
+    )
+    want = ent.capacity_headroom_path(
+        ent.TIER_OSS, ent.TIER_ENTERPRISE, **_USAGE
+    )
+    assert got == want
+
+
+def test_scalar_trial_accepted_as_endpoint(ent):
+    """Trial IS accepted as ``to`` via the lateral / identity branches
+    (matches :func:`capacity_headroom_path`)."""
+    got = ent.capacity_headroom_at_path(
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_TRIAL,
+        **_USAGE,
+    )
+    # cloud_pro and trial share rank 2 -- lateral, single-row path.
+    assert isinstance(got, list)
+    assert len(got) == 1
+    assert got[0]["tier"] == ent.TIER_TRIAL
+
+
+def test_scalar_unknown_perspective_returns_none(ent):
+    assert (
+        ent.capacity_headroom_at_path(
+            "bogus_tier", ent.TIER_OSS, ent.TIER_ENTERPRISE, **_USAGE
+        )
+        is None
+    )
+
+
+def test_scalar_unknown_from_returns_none(ent):
+    assert (
+        ent.capacity_headroom_at_path(
+            ent.TIER_CLOUD_PRO, "bogus_tier", ent.TIER_ENTERPRISE, **_USAGE
+        )
+        is None
+    )
+
+
+def test_scalar_unknown_to_returns_none(ent):
+    assert (
+        ent.capacity_headroom_at_path(
+            ent.TIER_CLOUD_PRO, ent.TIER_OSS, "bogus_tier", **_USAGE
+        )
+        is None
+    )
+
+
+def test_scalar_none_perspective_returns_none(ent):
+    assert (
+        ent.capacity_headroom_at_path(
+            None, ent.TIER_OSS, ent.TIER_ENTERPRISE, **_USAGE
+        )
+        is None
+    )
+
+
+def test_scalar_empty_perspective_returns_none(ent):
+    assert (
+        ent.capacity_headroom_at_path(
+            "", ent.TIER_OSS, ent.TIER_ENTERPRISE, **_USAGE
+        )
+        is None
+    )
+
+
+def test_scalar_case_and_whitespace_normalised(ent):
+    got = ent.capacity_headroom_at_path(
+        "  Cloud_Pro  ", "  OSS  ", "  ENTERPRISE  ", **_USAGE
+    )
+    want = ent.capacity_headroom_path(
+        ent.TIER_OSS, ent.TIER_ENTERPRISE, **_USAGE
+    )
+    assert got == want
+
+
+def test_scalar_never_raises_on_weird_types(ent):
+    """A perspective coerce crash short-circuits to ``None`` rather
+    than surfacing an exception."""
+    for bad in (b"bytes", 12345, 3.14, object()):
+        assert (
+            ent.capacity_headroom_at_path(
+                bad, ent.TIER_OSS, ent.TIER_ENTERPRISE, **_USAGE
+            )
+            is None
+        )
+
+
+def test_scalar_delegate_crash_short_circuits(ent, monkeypatch):
+    """A delegate blowup logs a warning and returns ``None`` -- an
+    upgrade-walkthrough surface keeps rendering."""
+
+    def _boom(*a, **kw):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(ent, "capacity_headroom_path", _boom)
+    assert (
+        ent.capacity_headroom_at_path(
+            ent.TIER_CLOUD_PRO, ent.TIER_OSS, ent.TIER_ENTERPRISE, **_USAGE
+        )
+        is None
+    )
+
+
+def test_scalar_grace_vs_enforce_identical(ent, enforced):
+    """Helper is resolver-independent -- grace and enforce yield the
+    same rows."""
+    grace_rows = ent.capacity_headroom_at_path(
+        ent.TIER_CLOUD_PRO, ent.TIER_OSS, ent.TIER_ENTERPRISE, **_USAGE
+    )
+    enforce_rows = enforced.capacity_headroom_at_path(
+        enforced.TIER_CLOUD_PRO,
+        enforced.TIER_OSS,
+        enforced.TIER_ENTERPRISE,
+        **_USAGE,
+    )
+    assert grace_rows == enforce_rows
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# batch helper: shape + happy path
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_batch_returns_dict_shape(ent):
+    out = ent.capacity_headroom_at_path_batch(
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_OSS,
+        [ent.TIER_CLOUD_STARTER, ent.TIER_ENTERPRISE],
+        **_USAGE,
+    )
+    assert isinstance(out, dict)
+    assert set(out.keys()) == {"tiers", "unknown"}
+    assert isinstance(out["tiers"], list)
+    assert isinstance(out["unknown"], list)
+
+
+def test_batch_each_item_has_expected_shape(ent):
+    out = ent.capacity_headroom_at_path_batch(
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_OSS,
+        [ent.TIER_CLOUD_STARTER, ent.TIER_ENTERPRISE],
+        **_USAGE,
+    )
+    for item in out["tiers"]:
+        assert set(item.keys()) == _ITEM_KEYS
+        assert item["direction"] in {
+            "upgrade",
+            "downgrade",
+            "lateral",
+            "identity",
+        }
+
+
+def test_batch_body_parity_with_capacity_headroom_path_batch(ent):
+    """For every perspective, batch body byte-equals
+    :func:`capacity_headroom_path_batch(from, to_tiers)` for the same
+    ``(from, to_tiers)``."""
+    tiers = _all_tiers(ent)
+    dests = [
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_ENTERPRISE,
+        ent.TIER_TRIAL,
+    ]
+    for p in tiers:
+        for f in tiers:
+            got = ent.capacity_headroom_at_path_batch(
+                p, f, dests, **_USAGE
+            )
+            want = ent.capacity_headroom_path_batch(f, dests, **_USAGE)
+            assert got == want, (
+                f"batch body drift for perspective={p} from={f}"
+            )
+
+
+def test_batch_perspective_invariance(ent):
+    dests = [ent.TIER_CLOUD_PRO, ent.TIER_ENTERPRISE]
+    baseline = ent.capacity_headroom_at_path_batch(
+        ent.TIER_CLOUD_PRO, ent.TIER_OSS, dests, **_USAGE
+    )
+    for p in _all_tiers(ent):
+        assert (
+            ent.capacity_headroom_at_path_batch(
+                p, ent.TIER_OSS, dests, **_USAGE
+            )
+            == baseline
+        )
+
+
+def test_batch_scalar_parity(ent):
+    """Each ``tiers[].path`` byte-equals the scalar
+    :func:`capacity_headroom_at_path(perspective, from, tid)` for the
+    same id -- the scalar/batch no-drift contract."""
+    p = ent.TIER_CLOUD_PRO
+    f = ent.TIER_OSS
+    dests = [ent.TIER_CLOUD_STARTER, ent.TIER_CLOUD_PRO, ent.TIER_ENTERPRISE]
+    out = ent.capacity_headroom_at_path_batch(p, f, dests, **_USAGE)
+    by_id = {row["to"]: row for row in out["tiers"]}
+    for tid in dests:
+        assert by_id[tid]["path"] == ent.capacity_headroom_at_path(
+            p, f, tid, **_USAGE
+        )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# batch helper: per-axis usage semantics
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_batch_unsupplied_axis_is_none_on_every_row(ent):
+    out = ent.capacity_headroom_at_path_batch(
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_OSS,
+        [ent.TIER_CLOUD_STARTER, ent.TIER_ENTERPRISE],
+    )
+    for item in out["tiers"]:
+        for row in item["path"]:
+            assert row["channels"] is None
+            assert row["retention_days"] is None
+            assert row["nodes"] is None
+
+
+def test_batch_only_retention_supplied(ent):
+    out = ent.capacity_headroom_at_path_batch(
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_OSS,
+        [ent.TIER_CLOUD_STARTER, ent.TIER_ENTERPRISE],
+        retention_days=30,
+    )
+    for item in out["tiers"]:
+        for row in item["path"]:
+            assert row["retention_days"] is not None
+            assert row["channels"] is None
+            assert row["nodes"] is None
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# batch helper: input handling / error posture
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_batch_unknown_perspective_returns_none(ent):
+    assert (
+        ent.capacity_headroom_at_path_batch(
+            "bogus_tier", ent.TIER_OSS, [ent.TIER_ENTERPRISE], **_USAGE
+        )
+        is None
+    )
+
+
+def test_batch_unknown_from_returns_none(ent):
+    assert (
+        ent.capacity_headroom_at_path_batch(
+            ent.TIER_CLOUD_PRO,
+            "bogus_tier",
+            [ent.TIER_ENTERPRISE],
+            **_USAGE,
+        )
+        is None
+    )
+
+
+def test_batch_none_perspective_returns_none(ent):
+    assert (
+        ent.capacity_headroom_at_path_batch(
+            None, ent.TIER_OSS, [ent.TIER_ENTERPRISE], **_USAGE
+        )
+        is None
+    )
+
+
+def test_batch_unknown_destinations_bucketed(ent):
+    out = ent.capacity_headroom_at_path_batch(
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_OSS,
+        [ent.TIER_ENTERPRISE, "bogus_id"],
+        **_USAGE,
+    )
+    assert [row["to"] for row in out["tiers"]] == [ent.TIER_ENTERPRISE]
+    assert out["unknown"] == ["bogus_id"]
+
+
+def test_batch_all_unknown_destinations_empty_tiers(ent):
+    out = ent.capacity_headroom_at_path_batch(
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_OSS,
+        ["bogus_a", "bogus_b"],
+        **_USAGE,
+    )
+    assert out == {"tiers": [], "unknown": ["bogus_a", "bogus_b"]}
+
+
+def test_batch_trial_accepted_as_destination(ent):
+    out = ent.capacity_headroom_at_path_batch(
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_CLOUD_PRO,
+        [ent.TIER_TRIAL],
+        **_USAGE,
+    )
+    assert out["unknown"] == []
+    assert [row["to"] for row in out["tiers"]] == [ent.TIER_TRIAL]
+
+
+def test_batch_normalises_destinations(ent):
+    got = ent.capacity_headroom_at_path_batch(
+        "  cloud_pro  ",
+        "  OSS  ",
+        ["  Enterprise  ", "ENTERPRISE", "cloud_pro"],
+        **_USAGE,
+    )
+    want = ent.capacity_headroom_at_path_batch(
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_OSS,
+        [ent.TIER_ENTERPRISE, ent.TIER_CLOUD_PRO],
+        **_USAGE,
+    )
+    assert got == want
+
+
+def test_batch_grace_vs_enforce_identical(ent, enforced):
+    dests = [ent.TIER_CLOUD_PRO, ent.TIER_ENTERPRISE]
+    grace_out = ent.capacity_headroom_at_path_batch(
+        ent.TIER_CLOUD_PRO, ent.TIER_OSS, dests, **_USAGE
+    )
+    enforce_out = enforced.capacity_headroom_at_path_batch(
+        enforced.TIER_CLOUD_PRO, enforced.TIER_OSS, dests, **_USAGE
+    )
+    assert grace_out == enforce_out
+
+
+def test_batch_never_raises_on_row_crash(ent, monkeypatch):
+    """A per-destination ``capacity_headroom_path`` crash short-circuits
+    that id into ``unknown[]`` rather than surfacing an exception."""
+    real = ent.capacity_headroom_path
+
+    def _boom(f, t, **kwargs):
+        if t == ent.TIER_ENTERPRISE:
+            raise RuntimeError("boom")
+        return real(f, t, **kwargs)
+
+    monkeypatch.setattr(ent, "capacity_headroom_path", _boom)
+    out = ent.capacity_headroom_at_path_batch(
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_OSS,
+        [ent.TIER_CLOUD_STARTER, ent.TIER_ENTERPRISE],
+        **_USAGE,
+    )
+    assert ent.TIER_ENTERPRISE in out["unknown"]
+    assert [row["to"] for row in out["tiers"]] == [ent.TIER_CLOUD_STARTER]
+
+
+def test_batch_delegate_crash_short_circuits(ent, monkeypatch):
+    """A batch-delegate blowup logs a warning and returns ``None``."""
+
+    def _boom(*a, **kw):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(ent, "capacity_headroom_path_batch", _boom)
+    assert (
+        ent.capacity_headroom_at_path_batch(
+            ent.TIER_CLOUD_PRO,
+            ent.TIER_OSS,
+            [ent.TIER_ENTERPRISE],
+            **_USAGE,
+        )
+        is None
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# HTTP scalar: /capacity-headroom-at-path
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_http_scalar_happy_path(client, ent):
+    r = client.get(
+        "/api/entitlement/capacity-headroom-at-path"
+        "?tier=cloud_pro&from=oss&to=enterprise"
+        "&channels=100&retention_days=30&nodes=5"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert set(body.keys()) == _SCALAR_ENVELOPE_KEYS
+    assert body["perspective_tier"] == "cloud_pro"
+    assert body["from"] == "oss"
+    assert body["to"] == "enterprise"
+    assert body["direction"] == "upgrade"
+    assert isinstance(body["path"], list)
+    assert body["path"] == ent.capacity_headroom_at_path(
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_OSS,
+        ent.TIER_ENTERPRISE,
+        **_USAGE,
+    )
+
+
+def test_http_scalar_missing_tier_400(client):
+    r = client.get(
+        "/api/entitlement/capacity-headroom-at-path"
+        "?from=oss&to=enterprise"
+    )
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "missing tier"
+
+
+def test_http_scalar_missing_from_400(client):
+    r = client.get(
+        "/api/entitlement/capacity-headroom-at-path"
+        "?tier=cloud_pro&to=enterprise"
+    )
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "missing from"
+
+
+def test_http_scalar_missing_to_400(client):
+    r = client.get(
+        "/api/entitlement/capacity-headroom-at-path"
+        "?tier=cloud_pro&from=oss"
+    )
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "missing to"
+
+
+def test_http_scalar_unknown_tier_which_key(client):
+    r = client.get(
+        "/api/entitlement/capacity-headroom-at-path"
+        "?tier=bogus&from=oss&to=enterprise"
+    )
+    assert r.status_code == 404
+    body = r.get_json()
+    assert body["which"] == "tier"
+
+
+def test_http_scalar_unknown_from_which_key(client):
+    r = client.get(
+        "/api/entitlement/capacity-headroom-at-path"
+        "?tier=cloud_pro&from=bogus&to=enterprise"
+    )
+    assert r.status_code == 404
+    body = r.get_json()
+    assert body["which"] == "from"
+
+
+def test_http_scalar_unknown_to_which_key(client):
+    r = client.get(
+        "/api/entitlement/capacity-headroom-at-path"
+        "?tier=cloud_pro&from=oss&to=bogus"
+    )
+    assert r.status_code == 404
+    body = r.get_json()
+    assert body["which"] == "to"
+
+
+def test_http_scalar_trial_accepted_as_perspective(client, ent):
+    r = client.get(
+        "/api/entitlement/capacity-headroom-at-path"
+        "?tier=trial&from=oss&to=enterprise&channels=25"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["perspective_tier"] == "trial"
+    assert body["path"] == ent.capacity_headroom_path(
+        ent.TIER_OSS, ent.TIER_ENTERPRISE, channels=25
+    )
+
+
+def test_http_scalar_identity_path_empty(client):
+    r = client.get(
+        "/api/entitlement/capacity-headroom-at-path"
+        "?tier=cloud_pro&from=enterprise&to=enterprise"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["direction"] == "identity"
+    assert body["path"] == []
+
+
+def test_http_scalar_downgrade_direction(client):
+    r = client.get(
+        "/api/entitlement/capacity-headroom-at-path"
+        "?tier=cloud_pro&from=enterprise&to=oss"
+    )
+    assert r.status_code == 200
+    assert r.get_json()["direction"] == "downgrade"
+
+
+def test_http_scalar_case_and_whitespace_normalised(client):
+    r = client.get(
+        "/api/entitlement/capacity-headroom-at-path"
+        "?tier=%20Cloud_Pro%20&from=%20OSS%20&to=%20ENTERPRISE%20"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["perspective_tier"] == "cloud_pro"
+    assert body["from"] == "oss"
+    assert body["to"] == "enterprise"
+
+
+def test_http_scalar_body_parity_with_capacity_headroom_path(client):
+    """``path`` byte-parity with ``/capacity-headroom-path?from=&to=``
+    (the current-perspective sibling)."""
+    r_at = client.get(
+        "/api/entitlement/capacity-headroom-at-path"
+        "?tier=cloud_pro&from=oss&to=enterprise"
+        "&channels=100&retention_days=30&nodes=5"
+    )
+    r_path = client.get(
+        "/api/entitlement/capacity-headroom-path"
+        "?from=oss&to=enterprise&channels=100&retention_days=30&nodes=5"
+    )
+    assert r_at.status_code == 200
+    assert r_path.status_code == 200
+    assert r_at.get_json()["path"] == r_path.get_json()["path"]
+
+
+def test_http_scalar_perspective_invariance(client):
+    baseline = client.get(
+        "/api/entitlement/capacity-headroom-at-path"
+        "?tier=cloud_pro&from=oss&to=enterprise&channels=100"
+    ).get_json()["path"]
+    for p in (
+        "oss",
+        "cloud_free",
+        "trial",
+        "cloud_starter",
+        "pro",
+        "enterprise",
+    ):
+        got = client.get(
+            f"/api/entitlement/capacity-headroom-at-path"
+            f"?tier={p}&from=oss&to=enterprise&channels=100"
+        ).get_json()["path"]
+        assert got == baseline, f"perspective {p} drifted from cloud_pro"
+
+
+def test_http_scalar_bad_axis_ignored(client):
+    """A blank / non-int / negative value on any axis short-circuits
+    that axis to ``None`` on every row -- the whole walk still renders."""
+    r = client.get(
+        "/api/entitlement/capacity-headroom-at-path"
+        "?tier=cloud_pro&from=oss&to=enterprise"
+        "&channels=abc&retention_days=&nodes=-1"
+    )
+    assert r.status_code == 200
+    for row in r.get_json()["path"]:
+        assert row["channels"] is None
+        assert row["retention_days"] is None
+        assert row["nodes"] is None
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# HTTP batch: /capacity-headroom-at-path-batch
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_http_batch_happy_path(client):
+    r = client.get(
+        "/api/entitlement/capacity-headroom-at-path-batch"
+        "?tier=cloud_pro&from=oss"
+        "&to=cloud_starter,cloud_pro,enterprise"
+        "&channels=100&retention_days=30&nodes=5"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert set(body.keys()) == _BATCH_ENVELOPE_KEYS
+    assert body["perspective_tier"] == "cloud_pro"
+    assert body["from"] == "oss"
+    assert [row["to"] for row in body["tiers"]] == [
+        "cloud_starter",
+        "cloud_pro",
+        "enterprise",
+    ]
+    assert body["unknown"] == []
+
+
+def test_http_batch_missing_tier_400(client):
+    r = client.get(
+        "/api/entitlement/capacity-headroom-at-path-batch"
+        "?from=oss&to=enterprise"
+    )
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "missing tier"
+
+
+def test_http_batch_missing_from_400(client):
+    r = client.get(
+        "/api/entitlement/capacity-headroom-at-path-batch"
+        "?tier=cloud_pro&to=enterprise"
+    )
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "missing from"
+
+
+def test_http_batch_missing_to_400(client):
+    r = client.get(
+        "/api/entitlement/capacity-headroom-at-path-batch"
+        "?tier=cloud_pro&from=oss"
+    )
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "supply to=<csv>"
+
+
+def test_http_batch_empty_to_400(client):
+    """An empty ``to`` list normalises to zero targets and 400s."""
+    r = client.get(
+        "/api/entitlement/capacity-headroom-at-path-batch"
+        "?tier=cloud_pro&from=oss&to="
+    )
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "supply to=<csv>"
+
+
+def test_http_batch_unknown_tier_which_key(client):
+    r = client.get(
+        "/api/entitlement/capacity-headroom-at-path-batch"
+        "?tier=bogus&from=oss&to=enterprise"
+    )
+    assert r.status_code == 404
+    body = r.get_json()
+    assert body["which"] == "tier"
+
+
+def test_http_batch_unknown_from_which_key(client):
+    r = client.get(
+        "/api/entitlement/capacity-headroom-at-path-batch"
+        "?tier=cloud_pro&from=bogus&to=enterprise"
+    )
+    assert r.status_code == 404
+    body = r.get_json()
+    assert body["which"] == "from"
+
+
+def test_http_batch_partial_unknown_bucketed(client):
+    r = client.get(
+        "/api/entitlement/capacity-headroom-at-path-batch"
+        "?tier=cloud_pro&from=oss&to=enterprise,nope_tier"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert [row["to"] for row in body["tiers"]] == ["enterprise"]
+    assert body["unknown"] == ["nope_tier"]
+
+
+def test_http_batch_multi_destination(client):
+    r = client.get(
+        "/api/entitlement/capacity-headroom-at-path-batch"
+        "?tier=cloud_pro&from=oss"
+        "&to=cloud_starter,cloud_pro,enterprise,pro"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert [row["to"] for row in body["tiers"]] == [
+        "cloud_starter",
+        "cloud_pro",
+        "enterprise",
+        "pro",
+    ]
+    assert body["unknown"] == []
+
+
+def test_http_batch_body_parity_with_capacity_headroom_path_batch(client):
+    """``tiers[]`` byte-parity with ``/capacity-headroom-path-batch``
+    (the current-perspective sibling) for the same ``(from, to)``."""
+    r_at = client.get(
+        "/api/entitlement/capacity-headroom-at-path-batch"
+        "?tier=cloud_pro&from=oss&to=cloud_pro,enterprise"
+        "&channels=100&retention_days=30&nodes=5"
+    )
+    r_path = client.get(
+        "/api/entitlement/capacity-headroom-path-batch"
+        "?from=oss&to=cloud_pro,enterprise"
+        "&channels=100&retention_days=30&nodes=5"
+    )
+    assert r_at.status_code == 200
+    assert r_path.status_code == 200
+    assert r_at.get_json()["tiers"] == r_path.get_json()["tiers"]
+
+
+def test_http_batch_perspective_invariance(client):
+    baseline = client.get(
+        "/api/entitlement/capacity-headroom-at-path-batch"
+        "?tier=cloud_pro&from=oss&to=cloud_pro,enterprise"
+    ).get_json()["tiers"]
+    for p in (
+        "oss",
+        "cloud_free",
+        "trial",
+        "cloud_starter",
+        "pro",
+        "enterprise",
+    ):
+        got = client.get(
+            f"/api/entitlement/capacity-headroom-at-path-batch"
+            f"?tier={p}&from=oss&to=cloud_pro,enterprise"
+        ).get_json()["tiers"]
+        assert got == baseline, f"perspective {p} drifted from cloud_pro"
+
+
+def test_http_batch_trial_accepted_as_both_perspective_and_destination(
+    client,
+):
+    r = client.get(
+        "/api/entitlement/capacity-headroom-at-path-batch"
+        "?tier=trial&from=oss&to=trial,enterprise"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["perspective_tier"] == "trial"
+    assert body["unknown"] == []
+    assert {row["to"] for row in body["tiers"]} == {"trial", "enterprise"}
+
+
+def test_http_batch_case_and_whitespace_normalised(client):
+    r = client.get(
+        "/api/entitlement/capacity-headroom-at-path-batch"
+        "?tier=%20Cloud_Pro%20&from=%20OSS%20"
+        "&to=%20Enterprise%20,ENTERPRISE,cloud_pro"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["perspective_tier"] == "cloud_pro"
+    assert body["from"] == "oss"
+    # duplicates dropped, whitespace stripped, first-seen order preserved.
+    assert [row["to"] for row in body["tiers"]] == [
+        "enterprise",
+        "cloud_pro",
+    ]
+    assert body["unknown"] == []
+
+
+def test_http_batch_bad_axis_ignored(client):
+    """A blank / non-int / negative value on any axis short-circuits
+    that axis to ``None`` on every row of every destination."""
+    r = client.get(
+        "/api/entitlement/capacity-headroom-at-path-batch"
+        "?tier=cloud_pro&from=oss&to=cloud_pro,enterprise"
+        "&channels=abc&retention_days=&nodes=-1"
+    )
+    assert r.status_code == 200
+    for item in r.get_json()["tiers"]:
+        for row in item["path"]:
+            assert row["channels"] is None
+            assert row["retention_days"] is None
+            assert row["nodes"] is None


### PR DESCRIPTION
## Summary

- Adds `capacity_headroom_at_path(perspective, from, to, *, channels, retention_days, nodes)` / `capacity_headroom_at_path_batch(perspective, from, to_tiers, *, channels, retention_days, nodes)` — path-shaped what-if siblings of `capacity_headroom_path` / `capacity_headroom_path_batch`, filling the `_at_path` / `_at_path_batch` slots on the capacity-headroom axis alongside `capacity_headroom` (scalar current), `capacity_headroom_at` (scalar what-if), `capacity_headroom_batch` (per-tier what-if matrix), `capacity_headroom_path` (scalar path) and `capacity_headroom_path_batch` (multi-destination path). Headroom-shaped mirror of `capacity_diff_at_path` / `capacity_diff_at_path_batch` (#3531) — same rung walk, per-axis usage rows instead of marginal-transition rows. Lets a pricing-comparison walkthrough surface call `X_at_path(perspective, from, to)` uniformly across the whole `_at_path` family. Perspective is validated against `_TIER_ORDER` but does NOT shape rows; each row is byte-identical to `capacity_headroom_path` / `_path_batch` for the same `(from, to)` pair with the same per-axis usage inputs — pinned by parity tests so the what-if path helpers cannot drift from the current-perspective siblings that also back `capacity_headroom_path_batch`. Perspective acceptance is lenient (`trial` accepted, matching every other `_at` sibling). Grace-independent by construction (delegates through the resolver-independent current-perspective siblings). Wiring this in changes **no** current behavior.
- Adds paired `GET /api/entitlement/capacity-headroom-at-path` / `GET /api/entitlement/capacity-headroom-at-path-batch` endpoints on `bp_entitlement`. Envelope mirrors `/capacity-diff-at-path` / `/capacity-diff-at-path-batch` byte-for-key (`perspective_tier` / `perspective_tier_rank` echo + `from` / `from_label` / `from_rank` + `to` / `to_label` / `to_rank` / `direction` on the scalar or `tiers` / `unknown` on the batch + the resolver-context tail `current_tier` / `current_tier_rank` / `grace` / `enforced` every `_at*` endpoint carries). Per-axis "None means axis not supplied" posture matches `/capacity-headroom-path`: a blank / non-int / negative / `bool`-in-disguise value on any axis short-circuits that axis to `None` on every row (of every destination on the batch) — a stray query string cannot silently blank the whole walk / matrix. 400 on missing tier/from/to (or empty CSV on the batch); 404 with `which: "tier" | "from" | "to"` on unknown ids; 200 with bucketed `unknown[]` on partially-bad destination lists (matches every other `*_path_batch` sibling). Never 5xxs — a synthesis failure short-circuits to a 404 (scalar) or empty-rows envelope (batch) so the walkthrough surface keeps rendering.
- 68-test module `tests/test_entitlement_capacity_headroom_at_path.py` covering scalar walk semantics (identity / lateral / upgrade / downgrade), row envelope shape (`tier` / `tier_label` / `channels` / `retention_days` / `nodes`), per-rung parity with `capacity_headroom_at`, byte-parity with `capacity_headroom_path` / `_path_batch` across every `(perspective, from, to)` triple in `ALL_TIERS × ALL_TIERS × ALL_TIERS`, perspective invariance, per-axis "None = not supplied" posture (unsupplied / channels-only / retention-only / all-axes), input handling (`trial` accepted as perspective + endpoint / destination; unknown / None / empty / weird-type ids collapse to `None`; case + whitespace normalisation), delegate-crash short-circuit, grace-vs-enforce byte-identity, batch normalisation (dedup + strip + first-seen order), batch bucketed-unknown posture (partial / all-unknown), per-destination row-crash isolation into `unknown[]`, and endpoint envelope pins (400 / 404 / `which` key / status codes; `bad_axis` short-circuits to `None` on every row of every destination).

Files:
- `clawmetry/entitlements.py` — 2 new helpers (~170 lines)
- `routes/entitlement.py` — 2 new endpoints (~318 lines)
- `tests/test_entitlement_capacity_headroom_at_path.py` — new test module (68 tests)

## Test plan

- [x] `python -m py_compile clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_capacity_headroom_at_path.py` clean
- [x] `ruff check clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_capacity_headroom_at_path.py` clean
- [x] `python -m pytest tests/test_entitlement_capacity_headroom_at_path.py` — 68 pass
- [x] Sibling regression check: `tests/test_entitlement_capacity_diff_at_path.py`, `tests/test_entitlement_capacity_headroom_path.py`, `tests/test_entitlement_capacity_headroom_path_batch.py`, `tests/test_entitlement_capacity_headroom_at.py` — 148 pass

### Local operator verification checklist

Since this branch was authored in a remote container with no access to the host, running daemon, `~/.openclaw`, or live cloud snapshot, the following steps need to happen on the operator's machine before ready-for-review:

- [ ] Copy `clawmetry/entitlements.py`, `routes/entitlement.py`, `tests/test_entitlement_capacity_headroom_at_path.py` into `~/.clawmetry/lib/pythonX.Y/site-packages/clawmetry/` (and its `routes/` / `tests/` siblings)
- [ ] Clear `__pycache__` under the target install
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
- [ ] `curl -s "http://localhost:8900/api/entitlement/capacity-headroom-at-path?tier=cloud_pro&from=oss&to=enterprise&channels=100&retention_days=30&nodes=5" | jq` — expect `direction="upgrade"`, per-rung `channels` / `retention_days` / `nodes` rows, `perspective_tier="cloud_pro"`, and the resolver-context tail (`current_tier` / `grace` / `enforced`)
- [ ] `curl -s "http://localhost:8900/api/entitlement/capacity-headroom-at-path?tier=trial&from=oss&to=enterprise&channels=25" | jq` — expect `perspective_tier="trial"` (lenient `_at` posture); confirm `path` byte-equals `/capacity-headroom-path?from=oss&to=enterprise&channels=25`
- [ ] `curl -s "http://localhost:8900/api/entitlement/capacity-headroom-at-path?tier=cloud_pro&from=enterprise&to=enterprise" | jq` — expect `direction="identity"`, `path=[]`
- [ ] `curl -s "http://localhost:8900/api/entitlement/capacity-headroom-at-path?from=oss&to=enterprise" -w '\n%{http_code}\n'` — expect HTTP 400 `{"error":"missing tier"}`
- [ ] `curl -s "http://localhost:8900/api/entitlement/capacity-headroom-at-path?tier=bogus&from=oss&to=enterprise" -w '\n%{http_code}\n'` — expect HTTP 404 with `which: "tier"`
- [ ] `curl -s "``http://localhost:8900/api/entitlement/capacity-headroom-at-path-batch?tier=cloud_pro&from=oss&to=cloud_pro,enterprise,bogus&channels=100&retention_days=30&nodes=5"`` | jq` — expect `tiers` for `cloud_pro` / `enterprise` and `unknown=["bogus"]`
- [ ] `curl -s "http://localhost:8900/api/entitlement/capacity-headroom-at-path-batch?tier=cloud_pro&from=oss&to=cloud_pro,enterprise&channels=abc&retention_days=&nodes=-1" | jq` — expect every per-rung per-axis field `null` on every destination (stray query string cannot silently blank the matrix)
- [ ] Confirm sibling `/api/entitlement/capacity-headroom-path` / `/capacity-headroom-path-batch` still return byte-identical `path` / `tiers` for the same `(from, to)` inputs (no drift into shaping rows)
- [ ] Confirm `/api/entitlement` still resolves as before (no resolver-path regression)
- [ ] Decrypt the live snapshot and browser-check the dashboard still loads (no import-time regression from the new helpers)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ANePGDsmiyLHZZ48B64kkW)_