### PR TITLE
fix(accuracy-harness): skip cleanly when openclaw/daemon unavailable (#4583)

### DIFF
--- a/scripts/accuracy_harness/_lib.py
+++ b/scripts/accuracy_harness/_lib.py
@@ -7,13 +7,14 @@ shims in one place means a future ``alerts.py`` / ``crons.py`` /
 and a fix to (e.g.) the daemon discovery flow only needs to land once.
 
 Public surface:
-    DEFAULT_DASHBOARD_PORTS, GH_REPO, OPENCLAW_BIN
+    DEFAULT_DASHBOARD_PORTS, GH_REPO, OPENCLAW_BIN, OPENCLAW_AVAILABLE
     http_get_json, http_post_json
     discover_dashboard_url, discover_daemon, daemon_event_count
     daemon_call (generic ``__local_query__/<method>`` proxy)
     drive_openclaw_message, extract_openclaw_usage
     file_drift_issue_per_endpoint, format_drift_issue_body
     file_consolidated_issue (meta-runner roll-up — one issue per day, idempotent)
+    exit_skip (early-exit helper for missing prerequisites)
 """
 from __future__ import annotations
 
@@ -35,6 +36,13 @@ DEFAULT_DASHBOARD_PORTS = (8900, 8903, 8905)
 GH_REPO = "vivekchand/clawmetry"
 OPENCLAW_BIN = shutil.which("openclaw") or "openclaw"
 LOCAL_QUERY_DISCOVERY = Path.home() / ".clawmetry" / "local_query.json"
+
+# True when the openclaw CLI is reachable. Set OPENCLAW_BIN_AVAILABLE=1 to
+# override (e.g. when the binary is on PATH but shutil.which misses it due
+# to PATH differences between an interactive shell and a cron/cloud sandbox).
+OPENCLAW_AVAILABLE: bool = (
+    bool(shutil.which("openclaw")) or bool(os.environ.get("OPENCLAW_BIN_AVAILABLE"))
+)
 
 
 # ─── HTTP shims ─────────────────────────────────────────────────────────────
@@ -104,6 +112,23 @@ def wait_for_event(predicate, *, timeout: float = 30.0,
             return last
         _time.sleep(interval)
     return last
+
+
+def exit_skip(harness_name: str, reason: str) -> None:
+    """Exit 0 with a parseable ``summary: 0 pass / 0 drift`` line when a
+    harness cannot run because its prerequisites are missing (no ``openclaw``
+    binary, no running daemon, etc.).
+
+    Exit code 0 is "PASS" to the meta-runner (``all.py``), so it won't file
+    a consolidated issue for a known-unavailable sandbox. The printed summary
+    line is what the meta-runner's ``SUMMARY_RE`` parses.
+
+    To force a harness to run when the binary is not on PATH, set
+    ``OPENCLAW_BIN_AVAILABLE=1`` in the environment.
+    """
+    print(f"[harness] {harness_name} SKIP — {reason}")
+    print("summary: 0 pass / 0 drift")
+    sys.exit(0)
 
 
 # ─── Discovery ──────────────────────────────────────────────────────────────

--- a/scripts/accuracy_harness/alerts.py
+++ b/scripts/accuracy_harness/alerts.py
@@ -44,8 +44,10 @@ from datetime import datetime, timezone
 from typing import Any
 
 from _lib import (  # noqa: E402
+    OPENCLAW_AVAILABLE,
     discover_dashboard_url,
     drive_openclaw_message,
+    exit_skip,
     extract_openclaw_usage,
     file_drift_issue_per_endpoint,
     http_delete_json,
@@ -54,7 +56,7 @@ from _lib import (  # noqa: E402
     wait_for_event,
 )
 
-# ─── Config ─────────────────────────────────────────────────────────────────
+# ─── Config ──────────────────────────────────────────────────────────────────
 
 TRIPPING_THRESHOLD_USD = 0.001          # any real opus turn blows past this
 FORCED_INJECT_USD = 0.01                # synthetic spend pushed through hook
@@ -64,7 +66,7 @@ WEBHOOK_WAIT_S = 10
 NATURAL_TICK_WAIT_S = 90                # fallback if hook disabled
 
 
-# ─── Data classes ───────────────────────────────────────────────────────────
+# ─── Data classes ──────────────────────────────────────────────────────────────
 
 @dataclass
 class AlertGround:
@@ -142,7 +144,7 @@ class _WebhookCapture:
                 pass
 
 
-# ─── Drive ──────────────────────────────────────────────────────────────────
+# ─── Drive ─────────────────────────────────────────────────────────────────────
 
 def _estimate_cost_from_usage(usage: dict) -> float:
     """Estimate USD for the openclaw turn using the same pricing table the
@@ -209,7 +211,7 @@ def delete_rule(dashboard_url: str, rule_id: str) -> bool:
         return False
 
 
-# ─── Trip + wait ────────────────────────────────────────────────────────────
+# ─── Trip + wait ─────────────────────────────────────────────────────────────
 
 def force_trip_via_hook(dashboard_url: str, rule_id: str) -> dict | None:
     try:
@@ -249,7 +251,7 @@ def wait_for_webhook(capture: _WebhookCapture, timeout_s: float) -> dict | None:
                           timeout=timeout_s, interval=0.25, description="webhook")
 
 
-# ─── Asserts ────────────────────────────────────────────────────────────────
+# ─── Asserts ───────────────────────────────────────────────────────────────────
 
 def _eq(endpoint, stage, metric, ground, actual, notes="") -> CheckResult:
     return CheckResult(endpoint=endpoint, window_label=stage, metric=metric,
@@ -366,7 +368,7 @@ def assert_cleanup(dashboard_url, ground) -> list[CheckResult]:
     )]
 
 
-# ─── Drift issue body ──────────────────────────────────────────────────────
+# ─── Drift issue body ────────────────────────────────────────────────────────
 
 def _format_alerts_issue_body(endpoint, cs, ground, dashboard_url) -> str:
     rows = "\n".join(
@@ -400,7 +402,7 @@ def _format_alerts_issue_body(endpoint, cs, ground, dashboard_url) -> str:
     )
 
 
-# ─── Main ───────────────────────────────────────────────────────────────────
+# ─── Main ───────────────────────────────────────────────────────────────────────
 
 def run_harness(args) -> int:
     print(f"[harness] alerts accuracy audit — {datetime.now(timezone.utc).isoformat()}")
@@ -513,7 +515,7 @@ def run_harness(args) -> int:
     return 1
 
 
-# ─── CLI ────────────────────────────────────────────────────────────────────
+# ─── CLI ───────────────────────────────────────────────────────────────────────
 
 def parse_args() -> argparse.Namespace:
     p = argparse.ArgumentParser(description=__doc__,
@@ -526,6 +528,10 @@ def parse_args() -> argparse.Namespace:
 
 
 def main() -> int:
+    if not OPENCLAW_AVAILABLE:
+        exit_skip("alerts",
+                  "openclaw binary not on PATH; set OPENCLAW_BIN_AVAILABLE=1 "
+                  "with the binary available to run this harness")
     args = parse_args()
     try:
         return run_harness(args)

--- a/scripts/accuracy_harness/approvals.py
+++ b/scripts/accuracy_harness/approvals.py
@@ -39,14 +39,15 @@ from datetime import datetime, timezone
 from typing import Any
 
 from _lib import (  # noqa: E402
+    daemon_call,
     discover_daemon,
     discover_dashboard_url,
-    daemon_call,
+    exit_skip,
     file_drift_issue_per_endpoint,
     http_get_json,
 )
 
-# ─── Config ─────────────────────────────────────────────────────────────────
+# ─── Config ──────────────────────────────────────────────────────────────────
 
 DEFAULT_RESOLVER = "harness@accuracy-audit"
 QUEUE_FLUSH_TIMEOUT_S = 10
@@ -68,7 +69,7 @@ SCHEMA_FIELDS = {
 }
 
 
-# ─── Data classes ───────────────────────────────────────────────────────────
+# ─── Data classes ──────────────────────────────────────────────────────────────
 
 @dataclass
 class ApprovalGroundTruth:
@@ -101,7 +102,7 @@ class CheckResult:
         return 0 if self.passed else 1
 
 
-# ─── Drive: synthetic approval via daemon proxy ─────────────────────────────
+# ─── Drive: synthetic approval via daemon proxy ────────────────────────────
 
 def drive_synthetic_approval(daemon: dict, *,
                               decision_target: str,
@@ -144,7 +145,7 @@ def drive_synthetic_approval(daemon: dict, *,
     )
 
 
-# ─── Wait: poll until row appears in DuckDB ─────────────────────────────────
+# ─── Wait: poll until row appears in DuckDB ─────────────────────────────
 
 def wait_for_pending_row(daemon: dict, approval_id: str,
                           timeout_s: int = QUEUE_FLUSH_TIMEOUT_S) -> dict | None:
@@ -174,7 +175,7 @@ def wait_for_decided_row(daemon: dict, approval_id: str, expected_status: str,
     return None
 
 
-# ─── Assertion builders ─────────────────────────────────────────────────────
+# ─── Assertion builders ────────────────────────────────────────────────────────
 
 def _eq_check(endpoint: str, stage: str, metric: str,
               ground: Any, actual: Any) -> CheckResult:
@@ -276,7 +277,7 @@ def assert_pending_no_longer_lists(payload: dict | None,
     )]
 
 
-# ─── Issue body builder ─────────────────────────────────────────────────────
+# ─── Issue body builder ───────────────────────────────────────────────────────
 
 def _format_approvals_issue_body(endpoint: str,
                                   cs: list[CheckResult],
@@ -404,10 +405,10 @@ def run_harness(args: argparse.Namespace) -> int:
 
     daemon = discover_daemon()
     if not daemon:
-        print("[harness] FATAL: daemon not discoverable; "
-              "the approvals harness needs a running daemon to ingest + "
-              "decide rows. See ~/.clawmetry/local_query.json.", file=sys.stderr)
-        return 2
+        exit_skip("approvals",
+                  "sync daemon not discoverable "
+                  "(~/.clawmetry/local_query.json missing or daemon not running); "
+                  "the approvals harness requires a live ClawMetry daemon")
     print(f"[harness] daemon proxy: 127.0.0.1:{daemon['port']}")
 
     run_id = uuid.uuid4().hex[:8]
@@ -462,7 +463,7 @@ def run_harness(args: argparse.Namespace) -> int:
     return 1
 
 
-# ─── CLI ────────────────────────────────────────────────────────────────────
+# ─── CLI ───────────────────────────────────────────────────────────────────────
 
 def parse_args() -> argparse.Namespace:
     p = argparse.ArgumentParser(description=__doc__,

--- a/scripts/accuracy_harness/tokens.py
+++ b/scripts/accuracy_harness/tokens.py
@@ -56,11 +56,13 @@ from typing import Any
 from _lib import (  # noqa: E402  (script entry-point, sys.path tweaked below)
     DEFAULT_DASHBOARD_PORTS,
     GH_REPO,
+    OPENCLAW_AVAILABLE,
     OPENCLAW_BIN,
     daemon_event_count,
     discover_daemon,
     discover_dashboard_url,
     drive_openclaw_message,
+    exit_skip,
     extract_openclaw_usage,
     file_drift_issue_per_endpoint,
     http_get_json,
@@ -73,7 +75,7 @@ FLUSH_TIMEOUT_S = 30
 FLUSH_POLL_INTERVAL_S = 1.0
 
 
-# ─── Data classes ───────────────────────────────────────────────────────────
+# ─── Data classes ──────────────────────────────────────────────────────────────
 
 @dataclass
 class GroundTruth:
@@ -119,7 +121,7 @@ class CheckResult:
         return self.actual - self.ground
 
 
-# ─── Endpoint scrapers ──────────────────────────────────────────────────────
+# ─── Endpoint scrapers ────────────────────────────────────────────────────────
 
 def fetch_api_usage(dashboard_url: str) -> dict:
     # /api/usage carries today/week/month + per-day breakdown. There is NO
@@ -131,7 +133,7 @@ def fetch_context_anatomy(dashboard_url: str) -> dict:
     return http_get_json(f"{dashboard_url}/api/context-anatomy", timeout=10.0)
 
 
-# ─── Window math ────────────────────────────────────────────────────────────
+# ─── Window math ──────────────────────────────────────────────────────────────
 
 def today_iso() -> str:
     return datetime.now().strftime("%Y-%m-%d")
@@ -419,7 +421,7 @@ def _format_tokens_issue_body(
     return "\n".join(lines)
 
 
-# ─── CLI ────────────────────────────────────────────────────────────────────
+# ─── CLI ───────────────────────────────────────────────────────────────────────
 
 def parse_args() -> argparse.Namespace:
     p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
@@ -438,6 +440,10 @@ def parse_args() -> argparse.Namespace:
 
 
 def main() -> int:
+    if not OPENCLAW_AVAILABLE:
+        exit_skip("tokens",
+                  "openclaw binary not on PATH; set OPENCLAW_BIN_AVAILABLE=1 "
+                  "with the binary available to run this harness")
     args = parse_args()
     try:
         return run_harness(args)


### PR DESCRIPTION
## Problem

All three accuracy harnesses (`tokens.py`, `alerts.py`, `approvals.py`) exit `rc=2` ("error") in cloud sandboxes where the `openclaw` binary is absent or the sync daemon isn't running. The meta-runner (`all.py`) treats any non-zero exit as a failure and files a consolidated GitHub issue — accumulating 65+ empty `accuracy-audit-status` reports.

## Root cause

- `tokens.py` and `alerts.py`: call `drive_openclaw_message()` → `subprocess.run([OPENCLAW_BIN, ...])` → `FileNotFoundError` when the binary isn't on PATH → unhandled exception → `rc=2`
- `approvals.py`: calls `discover_daemon()`, gets `None`, prints a `FATAL` message to stderr and `return 2`

The meta-runner maps `rc=0 → "pass"`, `rc=1 → "drift"`, `rc=else → "error"`, and only skips filing an issue when `overall_exit_code == 0`.

## Fix

**`_lib.py`** — add two new exports:
- `OPENCLAW_AVAILABLE: bool` — `True` when `shutil.which("openclaw")` finds the binary, or when `OPENCLAW_BIN_AVAILABLE=1` is set in the environment
- `exit_skip(harness_name, reason)` — prints `[harness] NAME SKIP — reason` + `summary: 0 pass / 0 drift` then `sys.exit(0)`; the `summary:` line is what `all.py`'s `SUMMARY_RE` parses, and exit 0 maps to "PASS"

**`tokens.py`** and **`alerts.py`** — import `OPENCLAW_AVAILABLE` and `exit_skip`; add an early guard at the top of `main()`:
```python
if not OPENCLAW_AVAILABLE:
    exit_skip("tokens", "openclaw binary not on PATH; set OPENCLAW_BIN_AVAILABLE=1 ...")
```

**`approvals.py`** — import `exit_skip`; replace the `return 2` daemon-not-found path with:
```python
exit_skip("approvals", "sync daemon not discoverable ...")
```

## Result

In a sandbox with no `openclaw` binary and no daemon, all three harnesses now exit 0 with `summary: 0 pass / 0 drift`. The meta-runner parses this as PASS, `overall_exit_code` returns 0, and no consolidated issue is filed.

To run the harnesses in a properly configured environment, set `OPENCLAW_BIN_AVAILABLE=1` (with `openclaw` on PATH) — the guard is bypassed and the harness runs normally.

## Files changed

| File | Change |
|---|---|
| `scripts/accuracy_harness/_lib.py` | Add `OPENCLAW_AVAILABLE` constant + `exit_skip()` helper |
| `scripts/accuracy_harness/tokens.py` | Import + call `exit_skip` when binary absent |
| `scripts/accuracy_harness/alerts.py` | Import + call `exit_skip` when binary absent |
| `scripts/accuracy_harness/approvals.py` | Import + call `exit_skip` when daemon absent |

Closes #4583

---
_Generated by [Claude Code](https://claude.ai/code/session_01JLNqGuyhS3RAQiHCgPSiD9)_