### PR TITLE
feat(ingest): capture trusted-proxy device pairing events in DuckDB

### DIFF
--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -693,6 +693,25 @@ _DDL = [
     "CREATE INDEX IF NOT EXISTS idx_audit_log_ts     ON audit_log(ts)",
     "CREATE INDEX IF NOT EXISTS idx_audit_log_actor  ON audit_log(actor, ts)",
     "CREATE INDEX IF NOT EXISTS idx_audit_log_action ON audit_log(action, ts)",
+    # Issue #4593 — trusted-proxy device pairing audit events.
+    # One row per observed device-pairing state (new device or approval_method
+    # change).  approval_method is "auto" or "manual"; scope_cap is the
+    # non-admin scope list JSON.  Idempotent via PRIMARY KEY on id.
+    """
+    CREATE TABLE IF NOT EXISTS device_pairing_events (
+        id              VARCHAR PRIMARY KEY,
+        ts              VARCHAR NOT NULL,
+        device_id       VARCHAR NOT NULL,
+        label           VARCHAR,
+        approval_method VARCHAR NOT NULL,
+        scope_cap       VARCHAR,
+        identity        VARCHAR,
+        node_id         VARCHAR NOT NULL DEFAULT ''
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_dpe_ts              ON device_pairing_events(ts DESC)",
+    "CREATE INDEX IF NOT EXISTS idx_dpe_device_id       ON device_pairing_events(device_id, ts)",
+    "CREATE INDEX IF NOT EXISTS idx_dpe_approval_method ON device_pairing_events(approval_method, ts)",
     # Issue #2201 — asset registry. Evidence + review layer that turns
     # individual agent discoveries (Self-Evolve findings, useful prompts,
     # improved skills) into reviewable, reusable assets without auto-promoting
@@ -8093,6 +8112,68 @@ class LocalStore:
         """
         params.append(int(limit))
         cols = ["id", "ts", "actor", "action", "target", "session_id", "result"]
+        return [dict(zip(cols, r)) for r in self._fetch(sql, params)]
+
+    # ── Issue #4593 — trusted-proxy device pairing events ────────────────────
+
+    def ingest_device_pairing_event(self, event: dict) -> None:
+        """Upsert one trusted-proxy device-pairing audit row.
+
+        Required key: ``id`` (``"device-pairing:<device_id>:<approval_method>"``).
+        ``approval_method`` must be ``"auto"`` or ``"manual"``.
+        """
+        eid = event.get("id")
+        if not eid:
+            raise ValueError("device_pairing_event must include 'id'")
+        from datetime import datetime
+        ts = event.get("ts") or datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S")
+        with self._write_lock:
+            self._conn.execute("""
+                INSERT INTO device_pairing_events (
+                    id, ts, device_id, label, approval_method, scope_cap, identity, node_id
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT (id) DO UPDATE SET
+                    label           = COALESCE(excluded.label,           device_pairing_events.label),
+                    approval_method = COALESCE(excluded.approval_method, device_pairing_events.approval_method),
+                    scope_cap       = COALESCE(excluded.scope_cap,       device_pairing_events.scope_cap),
+                    identity        = COALESCE(excluded.identity,        device_pairing_events.identity)
+            """, [
+                str(eid),
+                ts,
+                event.get("device_id", ""),
+                event.get("label"),
+                event.get("approval_method", "manual"),
+                event.get("scope_cap"),
+                event.get("identity"),
+                event.get("node_id") or "",
+            ])
+
+    def query_device_pairing_events(
+        self,
+        *,
+        approval_method: str | None = None,
+        since: str | None = None,
+        limit: int = 200,
+    ) -> list:
+        """Read device-pairing-event rows, most-recent first."""
+        clauses: list = []
+        params: list = []
+        if approval_method:
+            clauses.append("approval_method = ?")
+            params.append(approval_method)
+        if since:
+            clauses.append("ts >= ?")
+            params.append(since)
+        where = ("WHERE " + " AND ".join(clauses)) if clauses else ""
+        sql = f"""
+            SELECT id, ts, device_id, label, approval_method, scope_cap, identity, node_id
+            FROM device_pairing_events
+            {where}
+            ORDER BY ts DESC, id
+            LIMIT ?
+        """
+        params.append(int(limit))
+        cols = ["id", "ts", "device_id", "label", "approval_method", "scope_cap", "identity", "node_id"]
         return [dict(zip(cols, r)) for r in self._fetch(sql, params)]
 
     def query_routing_savings(

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -11066,6 +11066,88 @@ def sync_tool_policy(config: dict, state: dict, paths: dict) -> int:
     return n
 
 
+# Issue #4593 — process-lifetime dedup sentinel for device-pairing events.
+# Keyed by "device_id:approval_method"; value is the ISO timestamp of first
+# observation.  A manual→auto upgrade produces a distinct key and a second row.
+_SEEN_PAIRING_DEVICES: dict = {}
+
+
+def sync_device_pairing_events(config: dict, state: dict = None, paths: dict = None) -> int:
+    """Snapshot trusted-proxy device-pairing state and persist new rows to DuckDB.
+
+    Calls the existing ``_gateway_trusted_proxy_devices()`` adapter function
+    (introduced in #3885) which reads ``gateway.status`` / ``gateway.devices``
+    RPCs and normalises device pairing state.  For each device whose
+    ``device_id + approval_method`` hasn't been observed this process lifetime,
+    writes one audit row to ``device_pairing_events``.
+
+    Never raises; all errors are logged at DEBUG level.
+    """
+    global _SEEN_PAIRING_DEVICES
+    try:
+        from clawmetry.adapters.openclaw import _gateway_trusted_proxy_devices
+    except Exception as _e:
+        log.debug("sync_device_pairing_events: adapter unavailable: %s", _e)
+        return 0
+    try:
+        from clawmetry import local_store as _ls
+        store = _ls.get_store()
+    except Exception as _e:
+        log.debug("sync_device_pairing_events: local_store unavailable: %s", _e)
+        return 0
+
+    node_id = config.get("node_id", "") if isinstance(config, dict) else ""
+    try:
+        result = _gateway_trusted_proxy_devices()
+    except Exception as _e:
+        log.debug("sync_device_pairing_events: RPC failed: %s", _e)
+        return 0
+
+    devices = result.get("gatewayTrustedProxyDevices") or []
+    if not devices:
+        return 0
+
+    import json as _json
+    from datetime import datetime, timezone
+    now_iso = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S")
+    n = 0
+    for dev in devices:
+        if not isinstance(dev, dict):
+            continue
+        device_id = str(dev.get("id") or "")
+        if not device_id:
+            continue
+        approval_method = "auto" if dev.get("autoApproved") else "manual"
+        seen_key = f"{device_id}:{approval_method}"
+        if seen_key in _SEEN_PAIRING_DEVICES:
+            continue
+        _SEEN_PAIRING_DEVICES[seen_key] = now_iso
+
+        approved_at = dev.get("approvedAt") or now_iso
+        scope_cap = dev.get("scopeCap")
+        scope_str = _json.dumps(scope_cap) if isinstance(scope_cap, (list, dict)) else scope_cap
+
+        try:
+            store.ingest_device_pairing_event({
+                "id": f"device-pairing:{device_id}:{approval_method}",
+                "ts": str(approved_at),
+                "device_id": device_id,
+                "label": dev.get("label"),
+                "approval_method": approval_method,
+                "scope_cap": scope_str,
+                "identity": dev.get("label"),
+                "node_id": node_id,
+            })
+            n += 1
+        except Exception as _e_in:
+            log.debug("sync_device_pairing_events: ingest failed for %s: %s", device_id, _e_in)
+
+    if n:
+        store.flush()
+        log.debug("sync_device_pairing_events: ingested %d new rows", n)
+    return n
+
+
 def sync_session_metadata(config: dict, state: dict = None) -> int:
     """Sync OpenClaw session metadata rows to cloud sessions table.
 
@@ -18531,6 +18613,13 @@ def run_daemon() -> None:
             log.info(f"  Tool policy: {tp} agent rows ingested")
     except Exception as e:
         log.warning(f"  Tool-policy ingest error: {e}")
+    # Trusted-proxy device pairing audit events (#4593) — initial snapshot.
+    try:
+        dp = sync_device_pairing_events(config, state, paths)
+        if dp:
+            log.info(f"  Device pairing: {dp} new events ingested")
+    except Exception as e:
+        log.warning(f"  Device-pairing ingest error: {e}")
     # Sync today's log lines immediately so Brain tab shows the most recent
     # activity right away — older log history is backfilled later
     try:
@@ -19019,6 +19108,12 @@ def run_daemon() -> None:
                 except Exception as _e_tp:
                     log.debug("sync_tool_policy error (non-fatal): %s", _e_tp)
                 last_tool_policy = now_tp
+
+            # ── Trusted-proxy device pairing events (#4593) ──────────────
+            try:
+                sync_device_pairing_events(config, state, paths)
+            except Exception as _e_dp:
+                log.debug("sync_device_pairing_events error (non-fatal): %s", _e_dp)
 
             # ── Low-priority: log lines (real-time covered by streamer) ──
             lg = 0


### PR DESCRIPTION
Closes #4593

## Summary

- **New DuckDB table** `device_pairing_events` in `local_store.py` — stores one audit row per `device_id:approval_method` pair (auto vs manual), with indexes on `ts`, `device_id`, and `approval_method`
- **New ingest/query methods** `ingest_device_pairing_event()` and `query_device_pairing_events()` on the `LocalStore` class, following the same pattern as `ingest_audit_log_entry` / `query_audit_log`
- **New sync function** `sync_device_pairing_events()` in `sync.py` — calls the existing `_gateway_trusted_proxy_devices()` adapter (introduced in #3885, already polls `gateway.status`/`gateway.devices`), deduplicates via a process-lifetime sentinel, and upserts new rows; registered in both the startup phase and steady-state loop

The adapter function already normalises `device_id`, `autoApproved`, `label`, `scopeCap`, and `approvedAt` — this PR adds only the missing ingest layer. A manual→auto upgrade produces a distinct row (different `approval_method`) giving operators an audit trail of scope escalations.

## Test plan

- [ ] Syntax valid: `python3 -c "import ast; ast.parse(open('clawmetry/local_store.py').read())"` — passes
- [ ] Syntax valid: `python3 -c "import ast; ast.parse(open('clawmetry/sync.py').read())"` — passes
- [ ] No new ruff errors on changed files
- [ ] With a live OpenClaw gateway: start the daemon, confirm `device_pairing_events` table is created and rows appear for paired devices; confirm `store.query_device_pairing_events()` returns them; confirm manual→auto upgrade appends a second row

---
_Generated by [Claude Code](https://claude.ai/code/session_01HLtEHVW9dkoHFNbJHL3Aou)_