### PR TITLE
feat(entitlement): next_tier_capacity_headroom_at_batch + previous_tier_capacity_headroom_at_batch + 2 endpoints

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -14935,6 +14935,236 @@ def previous_tier_capacity_diff_at_batch() -> list[dict]:
         return []
 
 
+def _capacity_headroom_at_envelope(
+    source: str,
+    target: str | None,
+    direction: str,
+    *,
+    channels: int | None = None,
+    retention_days: int | None = None,
+    nodes: int | None = None,
+) -> dict:
+    """Private builder for the ``{next,previous}_tier_capacity_headroom_at_batch``
+    rows.
+
+    Headroom-shaped mirror of :func:`_capacity_diff_at_envelope`: where
+    that builder carries the capacity-transition triple from
+    :func:`capacity_diff_at`, this one carries the per-axis headroom
+    envelope from :func:`capacity_headroom_at` computed against the
+    ``target`` rung, pinned on both ``source`` and ``target`` and
+    labelled with a ``direction`` string echoing the batch's traversal
+    (``"upgrade"`` on the next-tier side, ``"downgrade"`` on the
+    previous-tier side).
+
+    Envelope shape matches :func:`_capacity_diff_at_envelope`
+    byte-for-key on the source / target metadata, with ``row`` renamed
+    to ``headroom`` and ``direction`` added so a UI can fold the diff
+    batch and the headroom batch into one pricing-comparison matrix
+    without re-keying::
+
+        ``{tier, tier_label, tier_rank, target, target_label, target_rank, direction, headroom}``
+
+    ``headroom`` collapses to ``None`` at the ladder ceiling / floor of
+    the source axis (``target is None``) and on a builder failure --
+    matching :func:`_capacity_diff_at_envelope`'s posture on ``row``.
+    Never raises: every fallback collapses to a fully-populated envelope
+    with ``headroom=None`` so the batch keeps the per-source row visible
+    even when its per-pair headroom could not be built.
+    """
+    src = (source or "").strip().lower()
+    headroom: dict | None = None
+    if target is not None:
+        try:
+            headroom = capacity_headroom_at(
+                target,
+                channels=channels,
+                retention_days=retention_days,
+                nodes=nodes,
+            )
+        except Exception as exc:
+            logger.warning(
+                "entitlements: _capacity_headroom_at_envelope builder failed for %s->%s: %s",
+                src,
+                target,
+                exc,
+            )
+            headroom = None
+    return {
+        "tier": src,
+        "tier_label": tier_label(src) if src in _TIER_ORDER else None,
+        "tier_rank": tier_rank(src) if src in _TIER_ORDER else -1,
+        "target": target,
+        "target_label": tier_label(target) if target else None,
+        "target_rank": tier_rank(target) if target else None,
+        "direction": direction,
+        "headroom": headroom,
+    }
+
+
+def next_tier_capacity_headroom_at_batch(
+    *,
+    channels: int | None = None,
+    retention_days: int | None = None,
+    nodes: int | None = None,
+) -> list[dict]:
+    """Batch sibling of :func:`next_tier_capacity_headroom_at`: one
+    ``next-tier-capacity-headroom-at`` envelope per purchasable source
+    tier, in one pass, given the caller-supplied per-axis usage.
+
+    Headroom-shaped mirror of :func:`next_tier_capacity_diff_at_batch`:
+    where that batch returns the marginal capacity-transition triple
+    for each ``source -> next-above-source`` pair, this batch returns
+    the per-axis headroom envelope for the same pair, computed off the
+    static per-tier caps of the ``target`` rung and the caller-supplied
+    usage. Lets a pricing-comparison matrix UI render the "on the rung
+    above each rung, given my usage, here's what my gauges would look
+    like" upgrade-tooltip column off **one** round-trip instead of N
+    calls to :func:`next_tier_capacity_headroom_at`.
+
+    Per-envelope headroom is byte-identical to
+    ``capacity_headroom_at(_next_purchasable_tier_after(source),
+    channels=..., retention_days=..., nodes=...)`` for the same source
+    and usage -- pinned in the test suite so the batch what-if cannot
+    drift from the explicit composition.
+
+    Envelope metadata is byte-parallel to
+    :func:`next_tier_capacity_diff_at_batch`: same ``tier`` /
+    ``tier_label`` / ``tier_rank`` / ``target`` / ``target_label`` /
+    ``target_rank`` on the source-anchored envelope so a UI can fold the
+    diff batch and the headroom batch into one pricing-comparison matrix
+    row-for-row. This batch additionally carries ``direction="upgrade"``
+    on every envelope so the two families do not need separate
+    "direction" callers.
+
+    Envelopes are sorted by source ``(tier_rank, tier_id)`` ascending
+    -- byte-stable against :func:`next_tier_capacity_diff_at_batch` /
+    :func:`next_tier_diff_at_batch` / :func:`next_tier_unlocks_at_batch`
+    / :func:`next_tier_locks_at_batch` so a UI can fold the batches into
+    one matrix without re-sorting client-side. Same-rank sibling tiers
+    (``cloud_pro`` / ``pro`` both at rank 2) are both returned.
+
+    Source list is :data:`_PURCHASABLE_TIERS` (trial excluded),
+    matching every other ``*_at_batch`` sibling. The source-side ceiling
+    (``enterprise`` as source -- no rung strictly above) surfaces with
+    ``target=None`` and ``headroom=None`` rather than being dropped, so
+    the matrix keeps a row for every purchasable rung. Same per-axis
+    "None means axis not supplied" posture as
+    :func:`capacity_headroom_at` and :func:`capacity_headroom_batch`:
+    an axis the caller didn't pass stays ``None`` on the inner
+    headroom row of every envelope.
+
+    Decoupled from the resolved entitlement (walks the static caps),
+    so grace vs enforce yields byte-identical envelope lists.
+
+    Never raises: a per-source builder failure collapses to
+    ``headroom=None`` on the populated envelope so the surrounding
+    envelope stays visible; an unexpected top-level failure short-
+    circuits to ``[]`` so the matrix keeps rendering instead of
+    breaking.
+    """
+    try:
+        out: list[dict] = []
+        ordered = sorted(
+            _PURCHASABLE_TIERS, key=lambda t: (_TIER_RANK.get(t, -1), t)
+        )
+        for tid in ordered:
+            target = _next_purchasable_tier_after(tid)
+            out.append(
+                _capacity_headroom_at_envelope(
+                    tid,
+                    target,
+                    "upgrade",
+                    channels=channels,
+                    retention_days=retention_days,
+                    nodes=nodes,
+                )
+            )
+        return out
+    except Exception as exc:
+        logger.warning(
+            "entitlements: next_tier_capacity_headroom_at_batch failed: %s",
+            exc,
+        )
+        return []
+
+
+def previous_tier_capacity_headroom_at_batch(
+    *,
+    channels: int | None = None,
+    retention_days: int | None = None,
+    nodes: int | None = None,
+) -> list[dict]:
+    """Batch sibling of :func:`previous_tier_capacity_headroom_at`: one
+    ``previous-tier-capacity-headroom-at`` envelope per purchasable
+    source tier, in one pass, given the caller-supplied per-axis usage.
+
+    Source-anchored downgrade-side mirror of
+    :func:`next_tier_capacity_headroom_at_batch` and headroom-shaped
+    mirror of :func:`previous_tier_capacity_diff_at_batch`. Lets a
+    pricing-comparison matrix UI render the "on the rung below each
+    rung, given my usage, here's what would break" downgrade-tooltip
+    column off **one** round-trip instead of N calls to
+    :func:`previous_tier_capacity_headroom_at`. Axes whose inner
+    ``over_limit`` flips ``True`` on any envelope are exactly the ones
+    the caller would lose headroom on when stepping down from that rung.
+
+    Per-envelope headroom is byte-identical to
+    ``capacity_headroom_at(_previous_purchasable_tier_before(source),
+    channels=..., retention_days=..., nodes=...)`` for the same source
+    and usage -- pinned in the test suite so the batch what-if cannot
+    drift from the explicit composition.
+
+    Envelope metadata is byte-parallel to
+    :func:`previous_tier_capacity_diff_at_batch` on the source / target
+    fields, and every envelope carries ``direction="downgrade"``.
+
+    Envelopes are sorted by source ``(tier_rank, tier_id)`` ascending
+    -- byte-stable against :func:`previous_tier_capacity_diff_at_batch`
+    / :func:`previous_tier_diff_at_batch` /
+    :func:`previous_tier_unlocks_at_batch` /
+    :func:`previous_tier_locks_at_batch`. Same-rank sibling tiers are
+    both returned.
+
+    Source list is :data:`_PURCHASABLE_TIERS` (trial excluded),
+    matching every other ``*_at_batch`` sibling. The source-side floor
+    (``oss`` / ``cloud_free`` as source -- no rung strictly below)
+    surfaces with ``target=None`` and ``headroom=None`` rather than
+    being dropped. Same per-axis "None means axis not supplied" posture
+    as :func:`capacity_headroom_at`.
+
+    Decoupled from the resolved entitlement (walks the static caps),
+    so grace vs enforce yields byte-identical envelope lists.
+
+    Never raises: a per-source builder failure collapses to
+    ``headroom=None`` on the populated envelope; an unexpected top-
+    level failure short-circuits to ``[]``.
+    """
+    try:
+        out: list[dict] = []
+        ordered = sorted(
+            _PURCHASABLE_TIERS, key=lambda t: (_TIER_RANK.get(t, -1), t)
+        )
+        for tid in ordered:
+            target = _previous_purchasable_tier_before(tid)
+            out.append(
+                _capacity_headroom_at_envelope(
+                    tid,
+                    target,
+                    "downgrade",
+                    channels=channels,
+                    retention_days=retention_days,
+                    nodes=nodes,
+                )
+            )
+        return out
+    except Exception as exc:
+        logger.warning(
+            "entitlements: previous_tier_capacity_headroom_at_batch failed: %s",
+            exc,
+        )
+        return []
+
+
 def next_tier_spec_at(tier: str) -> dict | None:
     """Scalar what-if sibling of :meth:`Entitlement.next_tier_spec`:
     full :func:`tier_spec_at`-shape descriptor of the rung above the

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -19577,6 +19577,191 @@ def api_entitlement_previous_tier_capacity_diff_at_batch():
         )
 
 
+@bp_entitlement.route("/api/entitlement/next-tier-capacity-headroom-at-batch")
+def api_entitlement_next_tier_capacity_headroom_at_batch():
+    """``GET /api/entitlement/next-tier-capacity-headroom-at-batch?
+    channels=<int>&retention_days=<int>&nodes=<int>`` -- batch sibling
+    of ``/api/entitlement/next-tier-capacity-headroom-at``: one
+    ``next-tier-capacity-headroom-at`` envelope per purchasable source
+    tier, in one round-trip, given the caller-supplied per-axis usage.
+
+    Headroom-shaped mirror of
+    ``/api/entitlement/next-tier-capacity-diff-at-batch``: where that
+    batch returns the marginal capacity-transition triple per source,
+    this batch returns the per-axis headroom envelope for the same
+    source -> next-above-source pair computed off the ``target`` rung's
+    static per-tier caps. Lets a pricing-comparison matrix UI render
+    the "on the rung above each rung, given my usage, here's what my
+    gauges would look like" upgrade-tooltip column off **one** call
+    instead of N calls to ``/next-tier-capacity-headroom-at``.
+
+    Response shape (envelope keys mirror
+    ``/api/entitlement/next-tier-capacity-diff-at-batch`` byte-for-key
+    on the source / target metadata, with each envelope's ``row``
+    replaced by ``headroom`` and augmented with ``direction`` echoing
+    ``"upgrade"``)::
+
+        {
+          "tiers":             [<envelope>, ...],
+          "current_tier":      "<resolved tier id>",
+          "current_tier_rank": <int>,
+          "grace":             <bool>,
+          "enforced":          <bool>,
+        }
+
+    Each ``<envelope>`` carries::
+
+        {
+          "tier":         "<source tier id>",
+          "tier_label":   "<source label>",
+          "tier_rank":    <source rank>,
+          "target":       "<next-above tier id>" | null,
+          "target_label": "<next-above label>" | null,
+          "target_rank":  <next-above rank> | null,
+          "direction":    "upgrade",
+          "headroom":     {<capacity_headroom_at row>} | null,
+        }
+
+    ``headroom`` (when non-null) matches
+    ``/api/entitlement/capacity-headroom-at?tier=<target>&channels=...`` for
+    the resolved ``target`` byte-for-byte -- pinned in the test suite so
+    the batch what-if cannot drift from the singular ``_at`` sibling.
+    Envelope metadata is byte-parallel to
+    ``/api/entitlement/next-tier-capacity-diff-at-batch`` on the
+    source / target keys so a UI can fold the two batches into one
+    matrix row-for-row.
+
+    No source query param (batch walks
+    :data:`entitlements._PURCHASABLE_TIERS`, trial excluded). At the
+    source-side ceiling (``enterprise`` as source -- no rung strictly
+    above) the envelope carries ``target=null`` and ``headroom=null``
+    rather than being dropped, so the matrix keeps a row for every
+    purchasable rung.
+
+    Per-axis ``None`` on every envelope means "axis not supplied"
+    (matches ``/capacity-headroom-batch``'s posture). A blank / non-int
+    / negative / ``bool``-in-disguise value on any axis short-circuits
+    that axis to ``None`` on every envelope's inner headroom row -- a
+    stray query string cannot silently blank the whole matrix.
+
+    Decoupled from grace vs enforce: the underlying helper walks the
+    static per-tier caps, so ``tiers`` is byte-identical across modes.
+    The envelope's ``current_tier`` / ``grace`` / ``enforced`` still
+    track the live resolver so the UI can highlight the caller's
+    current rung.
+
+    - **Never 5xxs**: a resolver failure yields an empty ``tiers`` list
+      and the grace-shape envelope so the matrix keeps rendering.
+    """
+    try:
+        from clawmetry import entitlements as _ent
+
+        kwargs: dict[str, int] = {}
+        for name in ("channels", "retention_days", "nodes"):
+            present, ok, val, _raw = _parse_capacity_arg(name)
+            if present and ok and val is not None and val >= 0:
+                kwargs[name] = val
+        rows = _ent.next_tier_capacity_headroom_at_batch(**kwargs)
+        ent = _ent.get_entitlement()
+        return jsonify(
+            {
+                "tiers": rows,
+                "current_tier": ent.tier,
+                "current_tier_rank": _ent.tier_rank(ent.tier),
+                "grace": bool(ent.grace),
+                "enforced": _ent.is_enforced(),
+            }
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_next_tier_capacity_headroom_at_batch: error: %s",
+            exc,
+        )
+        return jsonify(
+            {
+                "tiers": [],
+                "current_tier": "oss",
+                "current_tier_rank": 0,
+                "grace": True,
+                "enforced": False,
+            }
+        )
+
+
+@bp_entitlement.route("/api/entitlement/previous-tier-capacity-headroom-at-batch")
+def api_entitlement_previous_tier_capacity_headroom_at_batch():
+    """``GET /api/entitlement/previous-tier-capacity-headroom-at-batch?
+    channels=<int>&retention_days=<int>&nodes=<int>`` -- batch sibling
+    of ``/api/entitlement/previous-tier-capacity-headroom-at``: one
+    ``previous-tier-capacity-headroom-at`` envelope per purchasable
+    source tier, in one round-trip, given the caller-supplied per-axis
+    usage.
+
+    Source-anchored downgrade-side mirror of
+    ``/api/entitlement/next-tier-capacity-headroom-at-batch`` and
+    headroom-shaped mirror of
+    ``/api/entitlement/previous-tier-capacity-diff-at-batch``. Lets a
+    pricing-comparison matrix UI render the "on the rung below each
+    rung, given my usage, here's what would break" downgrade-tooltip
+    column off **one** call instead of N calls to
+    ``/previous-tier-capacity-headroom-at``.
+
+    Response shape mirrors
+    ``/api/entitlement/next-tier-capacity-headroom-at-batch``
+    byte-for-key; each envelope carries ``direction="downgrade"``.
+    ``headroom`` (when non-null) matches
+    ``/api/entitlement/capacity-headroom-at?tier=<target>&channels=...`` for
+    the resolved ``target`` byte-for-byte.
+
+    No source query param (batch walks
+    :data:`entitlements._PURCHASABLE_TIERS`, trial excluded). At the
+    source-side floor (``oss`` / ``cloud_free`` as source -- no rung
+    strictly below) the envelope carries ``target=null`` and
+    ``headroom=null`` rather than being dropped.
+
+    Same per-axis "None means axis not supplied" posture and bad-arg
+    short-circuits as
+    ``/api/entitlement/next-tier-capacity-headroom-at-batch``.
+    Grace / enforce yields byte-identical ``tiers`` payloads.
+
+    - **Never 5xxs**: a resolver failure yields an empty ``tiers`` list
+      and the grace-shape envelope so the matrix keeps rendering.
+    """
+    try:
+        from clawmetry import entitlements as _ent
+
+        kwargs: dict[str, int] = {}
+        for name in ("channels", "retention_days", "nodes"):
+            present, ok, val, _raw = _parse_capacity_arg(name)
+            if present and ok and val is not None and val >= 0:
+                kwargs[name] = val
+        rows = _ent.previous_tier_capacity_headroom_at_batch(**kwargs)
+        ent = _ent.get_entitlement()
+        return jsonify(
+            {
+                "tiers": rows,
+                "current_tier": ent.tier,
+                "current_tier_rank": _ent.tier_rank(ent.tier),
+                "grace": bool(ent.grace),
+                "enforced": _ent.is_enforced(),
+            }
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_previous_tier_capacity_headroom_at_batch: error: %s",
+            exc,
+        )
+        return jsonify(
+            {
+                "tiers": [],
+                "current_tier": "oss",
+                "current_tier_rank": 0,
+                "grace": True,
+                "enforced": False,
+            }
+        )
+
+
 @bp_entitlement.route("/api/entitlement/next-tier-spec")
 def api_entitlement_next_tier_spec():
     """``GET /api/entitlement/next-tier-spec`` -- full

--- a/tests/test_entitlement_next_prev_capacity_headroom_at_batch.py
+++ b/tests/test_entitlement_next_prev_capacity_headroom_at_batch.py
@@ -1,0 +1,830 @@
+"""Tests for ``next_tier_capacity_headroom_at_batch`` /
+``previous_tier_capacity_headroom_at_batch`` -- batch siblings of the
+scalar next / previous_tier_capacity_headroom_at what-if helpers,
+plus the companion
+``/api/entitlement/{next,previous}-tier-capacity-headroom-at-batch``
+endpoints and the private :func:`_capacity_headroom_at_envelope`
+builder they share.
+
+These helpers let a pricing-comparison matrix UI render "on the rung
+above / below each rung, given my usage, here's what my gauges
+would look like" off **one** round-trip instead of N calls to the
+scalar ``/{next,previous}-tier-capacity-headroom-at`` endpoint --
+the batch counterpart of the scalar what-ifs.
+
+Headroom-shaped mirror of
+``/{next,previous}-tier-capacity-diff-at-batch``: envelope source /
+target metadata line up byte-for-key so a UI can fold the diff and
+headroom batches into one matrix without re-keying; the diff row's
+capacity-transition triple is replaced by the per-axis headroom
+envelope; every envelope additionally carries a ``direction`` echo.
+
+Pins covered here:
+
+* helper :func:`_capacity_headroom_at_envelope` composes the source /
+  target metadata with the per-pair :func:`capacity_headroom_at`
+  envelope in the same shape as :func:`_capacity_diff_at_envelope`,
+  with ``row`` renamed ``headroom`` and ``direction`` added
+* both batches return one envelope per entry in
+  :data:`_PURCHASABLE_TIERS`, sorted by ``(tier_rank, tier_id)`` --
+  byte-parallel to
+  :func:`next_tier_capacity_diff_at_batch` /
+  :func:`previous_tier_capacity_diff_at_batch`
+* every envelope's ``headroom`` byte-equals
+  ``capacity_headroom_at(_next_purchasable_tier_after(source), ...)``
+  for the same source (or the previous-purchasable helper on the
+  downgrade side) -- the batch-vs-composition parity that stops the
+  batch what-if from drifting
+* at the source-side ceiling (``enterprise`` as source for the next
+  batch) and floor (``oss`` / ``cloud_free`` as source for the
+  previous batch) the envelope carries ``target=null`` and
+  ``headroom=null`` rather than being dropped
+* every populated envelope on the next batch carries
+  ``direction="upgrade"`` and every populated envelope on the
+  previous batch carries ``direction="downgrade"``
+* trial is excluded from the source axis (mirrors every other
+  ``*_at_batch`` sibling)
+* grace vs enforce yields the same body (the ``_at`` family walks the
+  static catalogue, not the gated resolver)
+* the helpers never raise: a per-source builder failure collapses to
+  ``headroom=null`` on the populated envelope; a top-level failure
+  short-circuits to ``[]``
+* the API endpoints never 5xx: a resolver failure yields an empty
+  ``tiers`` list and a grace-shape envelope; per-axis stray query
+  string short-circuits that axis to ``None`` on every envelope
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+_ENVELOPE_KEYS = {
+    "tier",
+    "tier_label",
+    "tier_rank",
+    "target",
+    "target_label",
+    "target_rank",
+    "direction",
+    "headroom",
+}
+
+_HEADROOM_KEYS = {
+    "tier",
+    "tier_label",
+    "channels",
+    "retention_days",
+    "nodes",
+}
+
+_HEADROOM_ROW_KEYS = {
+    "kind",
+    "used",
+    "cap",
+    "remaining",
+    "is_unlimited",
+    "at_limit",
+    "over_limit",
+    "pct_used",
+}
+
+_BATCH_RESPONSE_KEYS = {
+    "tiers",
+    "current_tier",
+    "current_tier_rank",
+    "grace",
+    "enforced",
+}
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    """Fresh entitlements module with HOME pointed at an empty tmp dir
+    so no real ~/.clawmetry/license.key or cloud_plan.json leaks in.
+    Enforcement off by default (grace mode). Both batch helpers walk
+    the static catalogue and are independent of the resolver -- the
+    fixture keeps the live resolver from surprising the test."""
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# ── _capacity_headroom_at_envelope ────────────────────────────────────────────
+
+
+def test_envelope_shape_for_known_pair(ent):
+    env = ent._capacity_headroom_at_envelope(
+        ent.TIER_OSS,
+        ent.TIER_CLOUD_STARTER,
+        "upgrade",
+        channels=3,
+        retention_days=5,
+        nodes=1,
+    )
+    assert set(env.keys()) == _ENVELOPE_KEYS
+    assert env["tier"] == ent.TIER_OSS
+    assert env["tier_label"] == ent.tier_label(ent.TIER_OSS)
+    assert env["tier_rank"] == ent.tier_rank(ent.TIER_OSS)
+    assert env["target"] == ent.TIER_CLOUD_STARTER
+    assert env["target_label"] == ent.tier_label(ent.TIER_CLOUD_STARTER)
+    assert env["target_rank"] == ent.tier_rank(ent.TIER_CLOUD_STARTER)
+    assert env["direction"] == "upgrade"
+    # headroom byte-equals the target's capacity_headroom_at for the
+    # same usage inputs.
+    assert env["headroom"] == ent.capacity_headroom_at(
+        ent.TIER_CLOUD_STARTER, channels=3, retention_days=5, nodes=1
+    )
+
+
+def test_envelope_none_target_collapses_headroom(ent):
+    # No rung above / below: target=None collapses headroom to None,
+    # envelope stays fully populated on source metadata.
+    env = ent._capacity_headroom_at_envelope(
+        ent.TIER_ENTERPRISE, None, "upgrade", channels=1
+    )
+    assert env["tier"] == ent.TIER_ENTERPRISE
+    assert env["tier_label"] == ent.tier_label(ent.TIER_ENTERPRISE)
+    assert env["target"] is None
+    assert env["target_label"] is None
+    assert env["target_rank"] is None
+    assert env["direction"] == "upgrade"
+    assert env["headroom"] is None
+
+
+def test_envelope_unknown_source_keeps_target_side_populated(ent):
+    # An unknown source still surfaces a populated envelope: the
+    # target-side metadata is intact and headroom is the target's
+    # capacity_headroom_at row unchanged.
+    env = ent._capacity_headroom_at_envelope(
+        "bogus", ent.TIER_CLOUD_STARTER, "upgrade", channels=1
+    )
+    assert set(env.keys()) == _ENVELOPE_KEYS
+    assert env["tier"] == "bogus"
+    assert env["tier_label"] is None
+    assert env["tier_rank"] == -1
+    assert env["target"] == ent.TIER_CLOUD_STARTER
+    assert env["target_label"] == ent.tier_label(ent.TIER_CLOUD_STARTER)
+    assert env["headroom"] == ent.capacity_headroom_at(
+        ent.TIER_CLOUD_STARTER, channels=1
+    )
+
+
+def test_envelope_trims_and_lowercases_source(ent):
+    env = ent._capacity_headroom_at_envelope(
+        "  OSS  ", ent.TIER_CLOUD_STARTER, "upgrade"
+    )
+    assert env["tier"] == ent.TIER_OSS
+    assert env["target"] == ent.TIER_CLOUD_STARTER
+
+
+def test_envelope_none_source_input_is_tolerated(ent):
+    # Defensive: the private builder does not raise on a None source
+    # -- the batch loops never feed None but the helper is public in
+    # the module surface.
+    env = ent._capacity_headroom_at_envelope(
+        None, ent.TIER_CLOUD_STARTER, "upgrade"
+    )
+    assert env["tier"] == ""
+    assert env["tier_label"] is None
+    assert env["target"] == ent.TIER_CLOUD_STARTER
+
+
+def test_envelope_swallows_builder_exception(ent, monkeypatch):
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "capacity_headroom_at", boom)
+    env = ent._capacity_headroom_at_envelope(
+        ent.TIER_OSS, ent.TIER_CLOUD_STARTER, "upgrade", channels=1
+    )
+    assert set(env.keys()) == _ENVELOPE_KEYS
+    assert env["target"] == ent.TIER_CLOUD_STARTER
+    assert env["headroom"] is None
+
+
+def test_envelope_direction_string_is_echoed_verbatim(ent):
+    for direction in ("upgrade", "downgrade", "arbitrary"):
+        env = ent._capacity_headroom_at_envelope(
+            ent.TIER_OSS, ent.TIER_CLOUD_STARTER, direction
+        )
+        assert env["direction"] == direction
+
+
+def test_envelope_metadata_parallel_to_diff_envelope(ent):
+    # Cross-family parity: the source / target metadata mirror the
+    # diff envelope byte-for-byte so a UI can fold the two families
+    # into one matrix.
+    headroom = ent._capacity_headroom_at_envelope(
+        ent.TIER_OSS, ent.TIER_CLOUD_STARTER, "upgrade"
+    )
+    diff = ent._capacity_diff_at_envelope(ent.TIER_OSS, ent.TIER_CLOUD_STARTER)
+    for key in ("tier", "tier_label", "tier_rank",
+                "target", "target_label", "target_rank"):
+        assert headroom[key] == diff[key]
+
+
+# ── next_tier_capacity_headroom_at_batch ──────────────────────────────────────
+
+
+def test_next_batch_returns_list_for_every_purchasable_source(ent):
+    rows = ent.next_tier_capacity_headroom_at_batch()
+    assert isinstance(rows, list)
+    assert len(rows) == len(ent._PURCHASABLE_TIERS)
+
+
+def test_next_batch_each_envelope_has_envelope_shape(ent):
+    for env in ent.next_tier_capacity_headroom_at_batch():
+        assert set(env.keys()) == _ENVELOPE_KEYS
+
+
+def test_next_batch_source_axis_matches_purchasable(ent):
+    rows = ent.next_tier_capacity_headroom_at_batch()
+    sources = {env["tier"] for env in rows}
+    assert sources == set(ent._PURCHASABLE_TIERS)
+
+
+def test_next_batch_excludes_trial_from_sources(ent):
+    sources = {
+        env["tier"] for env in ent.next_tier_capacity_headroom_at_batch()
+    }
+    assert ent.TIER_TRIAL not in sources
+
+
+def test_next_batch_sorted_by_rank_then_id(ent):
+    rows = ent.next_tier_capacity_headroom_at_batch()
+    keys = [(env["tier_rank"], env["tier"]) for env in rows]
+    assert keys == sorted(keys)
+
+
+def test_next_batch_enterprise_source_ceiling_collapses(ent):
+    rows = ent.next_tier_capacity_headroom_at_batch(channels=5)
+    ent_row = next(env for env in rows if env["tier"] == ent.TIER_ENTERPRISE)
+    assert ent_row["target"] is None
+    assert ent_row["target_label"] is None
+    assert ent_row["target_rank"] is None
+    assert ent_row["headroom"] is None
+    # Envelope still populated on the source side even at the ceiling.
+    assert ent_row["tier_label"] == ent.tier_label(ent.TIER_ENTERPRISE)
+
+
+def test_next_batch_direction_is_upgrade_on_every_envelope(ent):
+    # Direction echo pins to "upgrade" whether headroom is populated
+    # or None -- the ceiling row keeps the direction so a UI does not
+    # need to branch on the collapsed row.
+    for env in ent.next_tier_capacity_headroom_at_batch():
+        assert env["direction"] == "upgrade"
+
+
+def test_next_batch_headroom_byte_equals_composition_per_source(ent):
+    # Batch-vs-composition parity: every envelope's headroom byte-
+    # equals ``capacity_headroom_at(_next_purchasable_tier_after(src), ...)``
+    # for the same source and usage inputs.
+    rows = ent.next_tier_capacity_headroom_at_batch(
+        channels=7, retention_days=14, nodes=3
+    )
+    for env in rows:
+        expected_target = ent._next_purchasable_tier_after(env["tier"])
+        assert env["target"] == expected_target
+        if expected_target is None:
+            assert env["headroom"] is None
+            continue
+        assert env["headroom"] == ent.capacity_headroom_at(
+            expected_target, channels=7, retention_days=14, nodes=3
+        )
+
+
+def test_next_batch_headroom_row_shape_when_populated(ent):
+    rows = ent.next_tier_capacity_headroom_at_batch(
+        channels=1, retention_days=1, nodes=1
+    )
+    for env in rows:
+        if env["headroom"] is None:
+            continue
+        assert set(env["headroom"].keys()) == _HEADROOM_KEYS
+        for axis in ("channels", "retention_days", "nodes"):
+            row = env["headroom"][axis]
+            assert row is not None
+            assert set(row.keys()) == _HEADROOM_ROW_KEYS
+
+
+def test_next_batch_headroom_tier_pins_target(ent):
+    rows = ent.next_tier_capacity_headroom_at_batch(channels=1)
+    for env in rows:
+        if env["headroom"] is None:
+            continue
+        assert env["headroom"]["tier"] == env["target"]
+
+
+def test_next_batch_no_axes_supplied_yields_none_per_axis(ent):
+    # "None means axis not supplied" posture: with no channels /
+    # retention_days / nodes passed, every axis on every populated
+    # headroom envelope is None.
+    rows = ent.next_tier_capacity_headroom_at_batch()
+    for env in rows:
+        if env["headroom"] is None:
+            continue
+        assert env["headroom"]["channels"] is None
+        assert env["headroom"]["retention_days"] is None
+        assert env["headroom"]["nodes"] is None
+
+
+def test_next_batch_partial_axes_supplied_are_echoed_only_there(ent):
+    # Only channels was supplied: every populated envelope's headroom
+    # has a populated channels row and None retention_days / nodes rows.
+    rows = ent.next_tier_capacity_headroom_at_batch(channels=2)
+    saw_populated = False
+    for env in rows:
+        if env["headroom"] is None:
+            continue
+        saw_populated = True
+        assert env["headroom"]["channels"] is not None
+        assert env["headroom"]["retention_days"] is None
+        assert env["headroom"]["nodes"] is None
+    assert saw_populated
+
+
+def test_next_batch_metadata_parallel_to_diff_batch_per_source(ent):
+    # Envelope source / target metadata line up rung-for-rung with
+    # next_tier_capacity_diff_at_batch so a UI can fold the two
+    # batches into one matrix without re-sorting or re-keying.
+    headroom = {
+        env["tier"]: env for env in ent.next_tier_capacity_headroom_at_batch()
+    }
+    diff = {
+        env["tier"]: env for env in ent.next_tier_capacity_diff_at_batch()
+    }
+    assert set(headroom) == set(diff)
+    for src in headroom:
+        for key in ("tier", "tier_label", "tier_rank",
+                    "target", "target_label", "target_rank"):
+            assert headroom[src][key] == diff[src][key]
+
+
+def test_next_batch_grace_and_enforce_match(ent, monkeypatch):
+    # Catalogue-derived: enforcement must not change the body.
+    grace = ent.next_tier_capacity_headroom_at_batch(channels=1)
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    importlib.reload(ent)
+    ent.invalidate()
+    enforce = ent.next_tier_capacity_headroom_at_batch(channels=1)
+    assert enforce == grace
+
+
+def test_next_batch_independent_of_resolver(ent, monkeypatch):
+    def boom(*_, **__):
+        raise RuntimeError("resolver must not be reached")
+
+    monkeypatch.setattr(ent, "get_entitlement", boom)
+    rows = ent.next_tier_capacity_headroom_at_batch()
+    assert len(rows) == len(ent._PURCHASABLE_TIERS)
+
+
+def test_next_batch_top_level_failure_short_circuits_to_empty(
+    ent, monkeypatch
+):
+    # A crash on the top-level walker collapses to [] -- the pricing
+    # table falls back to an empty list instead of 5xxing.
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "_PURCHASABLE_TIERS", boom)
+    assert ent.next_tier_capacity_headroom_at_batch() == []
+
+
+def test_next_batch_per_row_failure_collapses_to_headroom_null(
+    ent, monkeypatch
+):
+    # A per-pair builder crash collapses the affected envelope's
+    # headroom to None while the surrounding envelope stays visible.
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "capacity_headroom_at", boom)
+    rows = ent.next_tier_capacity_headroom_at_batch(channels=1)
+    assert rows
+    for env in rows:
+        assert set(env.keys()) == _ENVELOPE_KEYS
+        assert env["headroom"] is None
+
+
+# ── previous_tier_capacity_headroom_at_batch ──────────────────────────────────
+
+
+def test_prev_batch_returns_list_for_every_purchasable_source(ent):
+    rows = ent.previous_tier_capacity_headroom_at_batch()
+    assert isinstance(rows, list)
+    assert len(rows) == len(ent._PURCHASABLE_TIERS)
+
+
+def test_prev_batch_each_envelope_has_envelope_shape(ent):
+    for env in ent.previous_tier_capacity_headroom_at_batch():
+        assert set(env.keys()) == _ENVELOPE_KEYS
+
+
+def test_prev_batch_source_axis_matches_purchasable(ent):
+    rows = ent.previous_tier_capacity_headroom_at_batch()
+    sources = {env["tier"] for env in rows}
+    assert sources == set(ent._PURCHASABLE_TIERS)
+
+
+def test_prev_batch_excludes_trial_from_sources(ent):
+    sources = {
+        env["tier"] for env in ent.previous_tier_capacity_headroom_at_batch()
+    }
+    assert ent.TIER_TRIAL not in sources
+
+
+def test_prev_batch_sorted_by_rank_then_id(ent):
+    rows = ent.previous_tier_capacity_headroom_at_batch()
+    keys = [(env["tier_rank"], env["tier"]) for env in rows]
+    assert keys == sorted(keys)
+
+
+def test_prev_batch_floor_sources_collapse(ent):
+    rows = {
+        env["tier"]: env
+        for env in ent.previous_tier_capacity_headroom_at_batch(channels=1)
+    }
+    for floor in (ent.TIER_OSS, ent.TIER_CLOUD_FREE):
+        env = rows[floor]
+        assert env["target"] is None
+        assert env["target_label"] is None
+        assert env["target_rank"] is None
+        assert env["headroom"] is None
+        assert env["tier_label"] == ent.tier_label(floor)
+
+
+def test_prev_batch_direction_is_downgrade_on_every_envelope(ent):
+    for env in ent.previous_tier_capacity_headroom_at_batch():
+        assert env["direction"] == "downgrade"
+
+
+def test_prev_batch_headroom_byte_equals_composition_per_source(ent):
+    rows = ent.previous_tier_capacity_headroom_at_batch(
+        channels=7, retention_days=14, nodes=3
+    )
+    for env in rows:
+        expected_target = ent._previous_purchasable_tier_before(env["tier"])
+        assert env["target"] == expected_target
+        if expected_target is None:
+            assert env["headroom"] is None
+            continue
+        assert env["headroom"] == ent.capacity_headroom_at(
+            expected_target, channels=7, retention_days=14, nodes=3
+        )
+
+
+def test_prev_batch_headroom_row_shape_when_populated(ent):
+    rows = ent.previous_tier_capacity_headroom_at_batch(
+        channels=1, retention_days=1, nodes=1
+    )
+    for env in rows:
+        if env["headroom"] is None:
+            continue
+        assert set(env["headroom"].keys()) == _HEADROOM_KEYS
+        for axis in ("channels", "retention_days", "nodes"):
+            row = env["headroom"][axis]
+            assert row is not None
+            assert set(row.keys()) == _HEADROOM_ROW_KEYS
+
+
+def test_prev_batch_headroom_tier_pins_target(ent):
+    rows = ent.previous_tier_capacity_headroom_at_batch(channels=1)
+    for env in rows:
+        if env["headroom"] is None:
+            continue
+        assert env["headroom"]["tier"] == env["target"]
+
+
+def test_prev_batch_no_axes_supplied_yields_none_per_axis(ent):
+    rows = ent.previous_tier_capacity_headroom_at_batch()
+    for env in rows:
+        if env["headroom"] is None:
+            continue
+        assert env["headroom"]["channels"] is None
+        assert env["headroom"]["retention_days"] is None
+        assert env["headroom"]["nodes"] is None
+
+
+def test_prev_batch_metadata_parallel_to_diff_batch_per_source(ent):
+    headroom = {
+        env["tier"]: env
+        for env in ent.previous_tier_capacity_headroom_at_batch()
+    }
+    diff = {
+        env["tier"]: env for env in ent.previous_tier_capacity_diff_at_batch()
+    }
+    assert set(headroom) == set(diff)
+    for src in headroom:
+        for key in ("tier", "tier_label", "tier_rank",
+                    "target", "target_label", "target_rank"):
+            assert headroom[src][key] == diff[src][key]
+
+
+def test_prev_batch_grace_and_enforce_match(ent, monkeypatch):
+    grace = ent.previous_tier_capacity_headroom_at_batch(channels=1)
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    importlib.reload(ent)
+    ent.invalidate()
+    enforce = ent.previous_tier_capacity_headroom_at_batch(channels=1)
+    assert enforce == grace
+
+
+def test_prev_batch_independent_of_resolver(ent, monkeypatch):
+    def boom(*_, **__):
+        raise RuntimeError("resolver must not be reached")
+
+    monkeypatch.setattr(ent, "get_entitlement", boom)
+    rows = ent.previous_tier_capacity_headroom_at_batch()
+    assert len(rows) == len(ent._PURCHASABLE_TIERS)
+
+
+def test_prev_batch_top_level_failure_short_circuits_to_empty(
+    ent, monkeypatch
+):
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "_PURCHASABLE_TIERS", boom)
+    assert ent.previous_tier_capacity_headroom_at_batch() == []
+
+
+def test_prev_batch_per_row_failure_collapses_to_headroom_null(
+    ent, monkeypatch
+):
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "capacity_headroom_at", boom)
+    rows = ent.previous_tier_capacity_headroom_at_batch(channels=1)
+    assert rows
+    for env in rows:
+        assert set(env.keys()) == _ENVELOPE_KEYS
+        assert env["headroom"] is None
+
+
+# ── cross-family parity: next vs previous ─────────────────────────────────────
+
+
+def test_next_and_previous_batches_share_source_axis(ent):
+    up = {env["tier"] for env in ent.next_tier_capacity_headroom_at_batch()}
+    down = {
+        env["tier"] for env in ent.previous_tier_capacity_headroom_at_batch()
+    }
+    assert up == down == set(ent._PURCHASABLE_TIERS)
+
+
+def test_next_and_previous_batches_swap_at_matching_pairs(ent):
+    # For every source X whose upgrade envelope resolves to a target
+    # Y that itself appears as a downgrade envelope with X as its
+    # target, the two envelopes describe the same (X, Y) pair -- the
+    # headroom rows must be recognisably paired: the upgrade row's
+    # headroom is at Y, the downgrade row's headroom is at X.
+    up = {env["tier"]: env for env in ent.next_tier_capacity_headroom_at_batch()}
+    down = {
+        env["tier"]: env
+        for env in ent.previous_tier_capacity_headroom_at_batch()
+    }
+    for src, up_env in up.items():
+        if up_env["headroom"] is None:
+            continue
+        target = up_env["target"]
+        if target not in down:
+            continue
+        down_env = down[target]
+        if down_env["target"] != src:
+            continue
+        assert up_env["headroom"]["tier"] == target
+        assert down_env["headroom"]["tier"] == src
+
+
+# ── API: /api/entitlement/next-tier-capacity-headroom-at-batch ────────────────
+
+
+def test_next_batch_endpoint_returns_envelopes(client, ent):
+    rv = client.get("/api/entitlement/next-tier-capacity-headroom-at-batch")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert set(body.keys()) == _BATCH_RESPONSE_KEYS
+    assert isinstance(body["tiers"], list)
+    assert len(body["tiers"]) == len(ent._PURCHASABLE_TIERS)
+    for env in body["tiers"]:
+        assert set(env.keys()) == _ENVELOPE_KEYS
+
+
+def test_next_batch_endpoint_resolver_context(client, ent):
+    rv = client.get("/api/entitlement/next-tier-capacity-headroom-at-batch")
+    body = rv.get_json()
+    resolved = ent.get_entitlement()
+    assert body["current_tier"] == resolved.tier
+    assert body["current_tier_rank"] == ent.tier_rank(resolved.tier)
+    assert body["grace"] == bool(resolved.grace)
+    assert body["enforced"] == ent.is_enforced()
+
+
+def test_next_batch_endpoint_matches_helper_no_axes(client, ent):
+    rv = client.get("/api/entitlement/next-tier-capacity-headroom-at-batch")
+    assert (
+        rv.get_json()["tiers"] == ent.next_tier_capacity_headroom_at_batch()
+    )
+
+
+def test_next_batch_endpoint_matches_helper_with_axes(client, ent):
+    rv = client.get(
+        "/api/entitlement/next-tier-capacity-headroom-at-batch?"
+        "channels=4&retention_days=9&nodes=2"
+    )
+    assert rv.get_json()["tiers"] == ent.next_tier_capacity_headroom_at_batch(
+        channels=4, retention_days=9, nodes=2
+    )
+
+
+def test_next_batch_endpoint_bad_axis_short_circuits(client, ent):
+    # Stray query strings for one axis must not silently blank other
+    # axes on every envelope: channels=abc + retention_days= +
+    # nodes=-1 all short-circuit to None on their axis.
+    rv = client.get(
+        "/api/entitlement/next-tier-capacity-headroom-at-batch?"
+        "channels=abc&retention_days=&nodes=-1"
+    )
+    body = rv.get_json()
+    for env in body["tiers"]:
+        if env["headroom"] is None:
+            continue
+        assert env["headroom"]["channels"] is None
+        assert env["headroom"]["retention_days"] is None
+        assert env["headroom"]["nodes"] is None
+
+
+def test_next_batch_endpoint_bool_in_disguise_short_circuits(client, ent):
+    # ``true`` / ``false`` come in as text; the parser rejects them
+    # rather than coerce them to ints so a stray typed value cannot
+    # silently blank the matrix.
+    rv = client.get(
+        "/api/entitlement/next-tier-capacity-headroom-at-batch?"
+        "channels=true&retention_days=false&nodes=True"
+    )
+    body = rv.get_json()
+    for env in body["tiers"]:
+        if env["headroom"] is None:
+            continue
+        assert env["headroom"]["channels"] is None
+        assert env["headroom"]["retention_days"] is None
+        assert env["headroom"]["nodes"] is None
+
+
+def test_next_batch_endpoint_matches_scalar_capacity_headroom_at(client, ent):
+    # Cross-endpoint parity: for every populated envelope, the batch's
+    # headroom byte-equals the scalar
+    # ``/api/entitlement/capacity-headroom-at?tier=<target>&channels=...``
+    # body -- the test that stops the batch surface from drifting from
+    # the singular ``_at`` sibling as the catalogue evolves.
+    rv = client.get(
+        "/api/entitlement/next-tier-capacity-headroom-at-batch?"
+        "channels=3&retention_days=5&nodes=1"
+    )
+    for env in rv.get_json()["tiers"]:
+        if env["headroom"] is None:
+            continue
+        scalar = client.get(
+            f"/api/entitlement/capacity-headroom-at?tier={env['target']}"
+            "&channels=3&retention_days=5&nodes=1"
+        ).get_json()
+        assert env["headroom"] == scalar
+
+
+def test_next_batch_endpoint_never_raises(client, ent, monkeypatch):
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "next_tier_capacity_headroom_at_batch", boom)
+    rv = client.get("/api/entitlement/next-tier-capacity-headroom-at-batch")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["tiers"] == []
+    assert body["current_tier"] == "oss"
+    assert body["current_tier_rank"] == 0
+    assert body["grace"] is True
+    assert body["enforced"] is False
+
+
+# ── API: /api/entitlement/previous-tier-capacity-headroom-at-batch ────────────
+
+
+def test_prev_batch_endpoint_returns_envelopes(client, ent):
+    rv = client.get(
+        "/api/entitlement/previous-tier-capacity-headroom-at-batch"
+    )
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert set(body.keys()) == _BATCH_RESPONSE_KEYS
+    assert isinstance(body["tiers"], list)
+    assert len(body["tiers"]) == len(ent._PURCHASABLE_TIERS)
+    for env in body["tiers"]:
+        assert set(env.keys()) == _ENVELOPE_KEYS
+
+
+def test_prev_batch_endpoint_resolver_context(client, ent):
+    rv = client.get(
+        "/api/entitlement/previous-tier-capacity-headroom-at-batch"
+    )
+    body = rv.get_json()
+    resolved = ent.get_entitlement()
+    assert body["current_tier"] == resolved.tier
+    assert body["current_tier_rank"] == ent.tier_rank(resolved.tier)
+    assert body["grace"] == bool(resolved.grace)
+    assert body["enforced"] == ent.is_enforced()
+
+
+def test_prev_batch_endpoint_matches_helper_no_axes(client, ent):
+    rv = client.get(
+        "/api/entitlement/previous-tier-capacity-headroom-at-batch"
+    )
+    assert (
+        rv.get_json()["tiers"]
+        == ent.previous_tier_capacity_headroom_at_batch()
+    )
+
+
+def test_prev_batch_endpoint_matches_helper_with_axes(client, ent):
+    rv = client.get(
+        "/api/entitlement/previous-tier-capacity-headroom-at-batch?"
+        "channels=4&retention_days=9&nodes=2"
+    )
+    assert (
+        rv.get_json()["tiers"]
+        == ent.previous_tier_capacity_headroom_at_batch(
+            channels=4, retention_days=9, nodes=2
+        )
+    )
+
+
+def test_prev_batch_endpoint_bad_axis_short_circuits(client, ent):
+    rv = client.get(
+        "/api/entitlement/previous-tier-capacity-headroom-at-batch?"
+        "channels=abc&retention_days=&nodes=-1"
+    )
+    body = rv.get_json()
+    for env in body["tiers"]:
+        if env["headroom"] is None:
+            continue
+        assert env["headroom"]["channels"] is None
+        assert env["headroom"]["retention_days"] is None
+        assert env["headroom"]["nodes"] is None
+
+
+def test_prev_batch_endpoint_direction_is_downgrade(client, ent):
+    rv = client.get(
+        "/api/entitlement/previous-tier-capacity-headroom-at-batch"
+    )
+    for env in rv.get_json()["tiers"]:
+        assert env["direction"] == "downgrade"
+
+
+def test_prev_batch_endpoint_matches_scalar_capacity_headroom_at(client, ent):
+    rv = client.get(
+        "/api/entitlement/previous-tier-capacity-headroom-at-batch?"
+        "channels=3&retention_days=5&nodes=1"
+    )
+    for env in rv.get_json()["tiers"]:
+        if env["headroom"] is None:
+            continue
+        scalar = client.get(
+            f"/api/entitlement/capacity-headroom-at?tier={env['target']}"
+            "&channels=3&retention_days=5&nodes=1"
+        ).get_json()
+        assert env["headroom"] == scalar
+
+
+def test_prev_batch_endpoint_never_raises(client, ent, monkeypatch):
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "previous_tier_capacity_headroom_at_batch", boom)
+    rv = client.get(
+        "/api/entitlement/previous-tier-capacity-headroom-at-batch"
+    )
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["tiers"] == []
+    assert body["current_tier"] == "oss"
+    assert body["current_tier_rank"] == 0
+    assert body["grace"] is True
+    assert body["enforced"] is False


### PR DESCRIPTION
## Summary

- Adds `next_tier_capacity_headroom_at_batch(*, channels, retention_days, nodes)` / `previous_tier_capacity_headroom_at_batch(...)` — batch what-if siblings of the scalar `next_tier_capacity_headroom_at` / `previous_tier_capacity_headroom_at` helpers (queued in #4589), filling the `_at_batch` slot on the next/previous-tier capacity-headroom axis alongside the diff family's existing `next_tier_capacity_diff_at_batch` / `previous_tier_capacity_diff_at_batch`. Each envelope's `headroom` byte-equals `capacity_headroom_at(_next_purchasable_tier_after(source), channels=..., retention_days=..., nodes=...)` (or the previous-purchasable helper on the downgrade side) for the same source and usage inputs — pinned in the test module so the batch what-if cannot drift from the explicit composition. Envelope source / target metadata is byte-parallel to `next_tier_capacity_diff_at_batch` / `previous_tier_capacity_diff_at_batch` (`tier` / `tier_label` / `tier_rank` / `target` / `target_label` / `target_rank`) so a pricing-comparison matrix UI can fold the diff and headroom batches into one row-for-row without re-sorting or re-keying. Each envelope additionally carries a `direction` echo (`"upgrade"` / `"downgrade"`). Source list is `_PURCHASABLE_TIERS` (trial excluded) sorted by `(tier_rank, tier_id)` — byte-stable against the diff / unlocks / locks `_at_batch` families. Ceiling (`enterprise` on the next batch) and floor (`oss` / `cloud_free` on the previous batch) surface with `target=null` and `headroom=null` rather than being dropped. Per-axis "None means axis not supplied" posture matches `capacity_headroom_at` / `capacity_headroom_batch`; a blank / non-int / negative / `bool`-in-disguise value on any axis short-circuits that axis to `None` on every envelope's inner headroom row. Grace-independent by construction (delegates through the resolver-independent `capacity_headroom_at`). Wiring this in changes **no** current behavior.
- Adds paired `GET /api/entitlement/next-tier-capacity-headroom-at-batch` / `GET /api/entitlement/previous-tier-capacity-headroom-at-batch` on `bp_entitlement`. Response shape mirrors `/next-tier-capacity-diff-at-batch` / `/previous-tier-capacity-diff-at-batch` byte-for-key on the source / target metadata and the resolver-context tail (`current_tier` / `current_tier_rank` / `grace` / `enforced`). Same axis-parsing (`_parse_capacity_arg` via routes/entitlement.py) as `/capacity-headroom-batch` — a stray query string cannot silently blank the whole matrix. Cross-endpoint parity test pins each populated envelope's `headroom` byte-equal to `/api/entitlement/capacity-headroom-at?tier=<target>&channels=...` for the resolved target. Never 5xxs — a resolver failure short-circuits to an empty `tiers` list on the grace-shape envelope so the matrix keeps rendering.
- 59-test module `tests/test_entitlement_next_prev_capacity_headroom_at_batch.py` covering envelope shape, composition parity per source, source-axis coverage (purchasable-only, trial excluded), sort stability (`(rank, id)`), ceiling / floor `null` collapse, per-axis "None-when-unsupplied" posture, direction echo pins on both batches, cross-family metadata parity vs `capacity_diff_at_batch`, next-vs-previous swap identity for matching pairs, grace-vs-enforce byte-identity, resolver independence, top-level-failure collapse to `[]`, per-row builder-crash collapse to `headroom=null`, and endpoint pins (envelope keys, resolver-context tail, helper parity with and without axes, bad-axis / bool-in-disguise short-circuits, scalar `/capacity-headroom-at` parity, never-5xx posture).

Files:
- `clawmetry/entitlements.py` — 1 private builder (`_capacity_headroom_at_envelope`) + 2 batch helpers (~230 lines)
- `routes/entitlement.py` — 2 new endpoints (~185 lines)
- `tests/test_entitlement_next_prev_capacity_headroom_at_batch.py` — new test module (59 tests)

## Test plan

- [x] `python -m py_compile clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_next_prev_capacity_headroom_at_batch.py` clean
- [x] `ruff check clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_next_prev_capacity_headroom_at_batch.py` clean
- [x] `python -m pytest tests/test_entitlement_next_prev_capacity_headroom_at_batch.py` — 59 pass
- [x] Sibling regression check: `tests/test_entitlement_capacity_diff_at_batch.py`, `tests/test_entitlement_capacity_headroom_batch.py`, `tests/test_entitlement_capacity_headroom_batch_api.py`, `tests/test_entitlement_next_prev_tier_diff_at_batch.py` — 127 pass, no drift

### Local operator verification checklist

Since this branch was authored in a remote container with no access to the host, running daemon, `~/.openclaw`, or live cloud snapshot, the following steps need to happen on the operator's machine before ready-for-review:

- [ ] Copy `clawmetry/entitlements.py`, `routes/entitlement.py`, `tests/test_entitlement_next_prev_capacity_headroom_at_batch.py` into `~/.clawmetry/lib/pythonX.Y/site-packages/clawmetry/` (and its `routes/` / `tests/` siblings)
- [ ] Clear `__pycache__` under the target install
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
- [ ] `curl -s "http://localhost:8900/api/entitlement/next-tier-capacity-headroom-at-batch?channels=10&retention_days=5&nodes=2" | jq` — expect one envelope per purchasable source with per-axis populated rows on `headroom` for non-ceiling sources; `direction="upgrade"` on every envelope; `target=null` + `headroom=null` on the `enterprise` envelope; resolver-context tail (`current_tier` / `current_tier_rank` / `grace` / `enforced`) populated
- [ ] `curl -s "http://localhost:8900/api/entitlement/next-tier-capacity-headroom-at-batch?channels=abc&retention_days=&nodes=-1" | jq` — expect every per-axis field `null` on every populated envelope (stray query string cannot silently blank the matrix)
- [ ] `curl -s "http://localhost:8900/api/entitlement/previous-tier-capacity-headroom-at-batch?channels=10&retention_days=5&nodes=2" | jq` — expect `direction="downgrade"` on every envelope; `target=null` + `headroom=null` on the `oss` and `cloud_free` envelopes (floor)
- [ ] Confirm every populated envelope's `headroom` byte-equals `/api/entitlement/capacity-headroom-at?tier=<target>&channels=...&retention_days=...&nodes=...` for the resolved target — the two surfaces must not drift
- [ ] Confirm sibling `/api/entitlement/next-tier-capacity-diff-at-batch` / `/previous-tier-capacity-diff-at-batch` still return byte-identical `tier` / `tier_label` / `tier_rank` / `target` / `target_label` / `target_rank` per source (no drift into the shared source/target axis)
- [ ] Confirm `/api/entitlement` still resolves as before (no resolver-path regression from the new helpers)
- [ ] Decrypt the live snapshot and browser-check the dashboard still loads (no import-time regression)

---
_Generated by [Claude Code](https://claude.ai/code/session_012dtkzLEA89HBeeoy52kfip)_