### PR TITLE
Sweep and remove stale clawmetry duplicates during install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,38 @@
 ## Unreleased
 
+- **Fix: installers now sweep and remove stale clawmetry duplicates instead of only detecting them.**
+  - **Why:** #4335 (`clawmetry/installs.py`) taught the CLI to *detect and
+    warn* about a stale clawmetry copy elsewhere on PATH, but nothing
+    actually removed one — `install.ps1`/`install.sh` only ever cleaned up a
+    previous install at their OWN target directory, and `install.cmd` has no
+    dedicated venv at all, so re-running it (or switching between it and
+    `install.ps1`) leaves the old copy installed and dormant. Live-reproduced
+    2026-08-07: a plain `pip install --user` into a system Python left
+    clawmetry 0.11.99 dormant next to a current 0.12.655 dedicated-venv
+    install — harmless here only because PATH ordering happened to favor the
+    venv.
+  - **What:** all three canonical installers (`install.sh`, `install.ps1`,
+    `install.cmd`) now sweep every python/python3 interpreter reachable on
+    PATH before installing and `pip uninstall -y clawmetry` from every one of
+    them except the venv/target they're about to (re)build; best-effort,
+    never fails the install (`|| true` under install.sh's `set -e`).
+    `install.cmd` additionally removes a leftover `install.ps1`-created venv
+    at `%LOCALAPPDATA%\clawmetry` since it has no venv of its own and the two
+    would otherwise coexist and shadow each other. `clawmetry/doctor.py`'s
+    install census is unchanged and still catches whatever a sweep can't
+    reach (e.g. a copy on a PATH entry that wasn't scanned).
+  - **Verified:** 10 new tests (`tests/test_installer_stale_sweep.py`:
+    bash -n / PowerShell parser syntax checks, sweep ordering before the
+    install step, own-install-dir exclusion, best-effort-under-`set -e`), all
+    16 pre-existing `install.sh` tests still green; reproduced the exact live
+    scenario on the affected machine — reinstalled clawmetry into a second
+    system Python, confirmed both `install.cmd` and `install.ps1` detected
+    and removed it via `pip show`/`pip uninstall` before reinstalling fresh,
+    `clawmetry --version` correct afterward. `install.sh` not behaviorally
+    re-run beyond `bash -n` (Windows dev machine, no macOS/Linux box handy);
+    behavioral proof for all three lands in
+    `.github/workflows/install-test.yml`.
+
 - **Added qm as the 17th observable runtime.** qm
   (github.com/yc-software/qm, qm.ycombinator.com) is YC's Postgres-
   backed multiplayer agent harness (launched 2026-07-29 MIT). Because

--- a/install.cmd
+++ b/install.cmd
@@ -30,6 +30,36 @@ if %ERRORLEVEL% NEQ 0 (
     exit /b 1
 )
 
+REM Stale-duplicate sweep: this installer puts clawmetry directly into
+REM whichever python/python3 is on PATH, with no dedicated venv. If a
+REM DIFFERENT python (or the install.ps1 dedicated venv) also has clawmetry,
+REM whichever one PATH resolves first silently shadows the other and
+REM `clawmetry --version` can report a stale version even though this
+REM install is current. Sweep every python/python3 found on PATH and
+REM uninstall clawmetry from all of them before installing fresh.
+set "CM_SEEN="
+for /f "delims=" %%P in ('where python 2^>nul') do call :cm_sweep_stale "%%P"
+for /f "delims=" %%P in ('where python3 2^>nul') do call :cm_sweep_stale "%%P"
+if exist "%LOCALAPPDATA%\clawmetry" (
+    echo   → Removing stale dedicated-venv install...
+    rmdir /s /q "%LOCALAPPDATA%\clawmetry" 2>nul
+)
+goto :cm_sweep_done
+
+:cm_sweep_stale
+set "CM_PYEXE=%~1"
+echo %CM_SEEN%| findstr /I /C:"%CM_PYEXE%" >nul 2>&1
+if not errorlevel 1 goto :eof
+set "CM_SEEN=%CM_SEEN%;%CM_PYEXE%"
+"%CM_PYEXE%" -m pip show clawmetry >nul 2>&1
+if not errorlevel 1 (
+    echo   → Removing stale clawmetry copy from %CM_PYEXE%...
+    "%CM_PYEXE%" -m pip uninstall -y clawmetry >nul 2>&1
+)
+goto :eof
+
+:cm_sweep_done
+
 echo   → Installing clawmetry...
 %PYTHON% -m pip install --upgrade clawmetry >nul 2>&1
 if %ERRORLEVEL% NEQ 0 (

--- a/install.ps1
+++ b/install.ps1
@@ -38,6 +38,47 @@ Write-Host "→ Using $python ($(& $python --version 2>&1))"
 # Install directory
 $installDir = "$env:LOCALAPPDATA\clawmetry"
 
+# ── Stale-duplicate sweep ────────────────────────────────────────────────
+# The dedicated venv above is the ONLY environment auto-update keeps current.
+# A clawmetry copy left behind in some OTHER interpreter (e.g. a system-wide
+# `pip install --user clawmetry` from before this installer switched to a
+# per-app venv, or a leftover from install.cmd) never updates, and if it
+# happens to resolve first on PATH it shadows the venv binary — `clawmetry
+# --version` then reports a stale version while the real install is current.
+# Sweep every python interpreter reachable on PATH and uninstall clawmetry
+# from all of them except the one we're about to (re)build.
+$seenPython = New-Object System.Collections.Generic.HashSet[string]
+$pyCandidates = @()
+foreach ($cmd in @("python", "python3")) {
+    try {
+        $cmdInfo = Get-Command $cmd -All -ErrorAction SilentlyContinue
+        foreach ($c in $cmdInfo) { $pyCandidates += $c.Source }
+    } catch {}
+}
+try {
+    $launcherList = & py -0p 2>&1
+    foreach ($line in $launcherList) {
+        if ($line -match '(?m)^\s*\S+\s+(.+\\python\.exe)\s*$') {
+            $pyCandidates += $Matches[1]
+        }
+    }
+} catch {}
+
+foreach ($pyExe in $pyCandidates) {
+    if (-not $pyExe) { continue }
+    $resolved = $null
+    try { $resolved = (Resolve-Path -LiteralPath $pyExe -ErrorAction Stop).Path } catch { $resolved = $pyExe }
+    if (-not $seenPython.Add($resolved.ToLowerInvariant())) { continue }
+    if ($resolved.ToLowerInvariant().StartsWith($installDir.ToLowerInvariant())) { continue }
+    try {
+        & $resolved -m pip show clawmetry 2>&1 | Out-Null
+        if ($LASTEXITCODE -eq 0) {
+            Write-Host "→ Removing stale clawmetry copy from $resolved..."
+            & $resolved -m pip uninstall -y clawmetry 2>&1 | Out-Null
+        }
+    } catch {}
+}
+
 # Remove old install for clean state
 if (Test-Path $installDir) {
     Write-Host "→ Removing previous installation..."

--- a/install.sh
+++ b/install.sh
@@ -166,7 +166,34 @@ case "$OS" in
     echo -e "${RED}  ✗ Unsupported OS: $OS (macOS and Linux only)${NC}"
     exit 1
     ;;
-esac 
+esac
+
+# ── Stale-duplicate sweep ─────────────────────────────────────────────────
+# The venv at $INSTALL_DIR is the ONLY environment auto-update keeps current.
+# A clawmetry copy left behind in some OTHER interpreter (e.g. a plain
+# `pip install --user clawmetry` from before this installer switched to a
+# per-app venv, or a Homebrew/pyenv python that got `pip install`ed into
+# directly) never updates, and if it resolves first on PATH it shadows the
+# venv binary — `clawmetry --version` then reports a stale version while the
+# real install is current. Sweep every python3 interpreter reachable on PATH
+# and uninstall clawmetry from all of them except the venv we're about to
+# (re)build. Best-effort: never fail the install over a sweep miss.
+_cm_seen_pythons=""
+IFS=':' read -r -a _cm_path_dirs <<< "$PATH"
+for _cm_dir in "${_cm_path_dirs[@]}"; do
+  for _cm_name in python3 python; do
+    _cm_candidate="$_cm_dir/$_cm_name"
+    [ -x "$_cm_candidate" ] || continue
+    _cm_real=$(cd "$(dirname "$_cm_candidate")" 2>/dev/null && pwd -P)/$(basename "$_cm_candidate")
+    case " $_cm_seen_pythons " in *" $_cm_real "*) continue ;; esac
+    _cm_seen_pythons="$_cm_seen_pythons $_cm_real"
+    case "$_cm_real" in "$INSTALL_DIR"/*) continue ;; esac
+    if "$_cm_real" -m pip show clawmetry >/dev/null 2>&1; then
+      echo -e "  ${DIM}→ Removing stale clawmetry copy from $_cm_real...${NC}"
+      $USE_SUDO "$_cm_real" -m pip uninstall -y clawmetry >/dev/null 2>&1 || true
+    fi
+  done
+done
 
 # ── Early exit: already up to date ──────────────────────────────────────────
 if [ -x "$INSTALL_DIR/bin/clawmetry" ]; then

--- a/tests/test_installer_stale_sweep.py
+++ b/tests/test_installer_stale_sweep.py
@@ -1,0 +1,160 @@
+"""Regression tests for the installers' stale-duplicate sweep.
+
+Bug pinned by these tests
+--------------------------
+
+``install.ps1``/``install.sh`` only ever cleaned up a previous install at
+their OWN target directory. A clawmetry copy left behind in some OTHER
+Python environment (a pre-venv ``pip install --user clawmetry``, or a run of
+the no-venv ``install.cmd`` on a machine that later switched to the venv
+installer) was never touched. Auto-update only keeps the daemon's own venv
+current, so the stray copy goes stale forever, and if it happens to resolve
+first on PATH it *shadows* the real binary — ``clawmetry --version`` then
+reports a stale version while the real install is current (see
+``clawmetry/doctor.py``'s install census, which only warns about this after
+the fact; it never removes anything).
+
+Live-reproduced on a user machine (2026-08-07): a plain ``pip install
+--user`` into a system Python left clawmetry 0.11.99 installed and dormant
+next to a current 0.12.655 dedicated-venv install. All three installers now
+sweep every python/python3 interpreter reachable on PATH and
+``pip uninstall`` clawmetry from every one of them except the venv/target
+they are about to (re)build, before installing fresh.
+
+We can't run a full installer against a real second Python interpreter in
+CI's default job (see ``.github/workflows/install-test.yml`` for the
+behavioural run), so these tests assert the sweep code is present, ordered
+before the install step, and that install.sh remains valid bash / install.ps1
+remains valid PowerShell after the edit.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+INSTALL_SH = REPO_ROOT / "install.sh"
+INSTALL_PS1 = REPO_ROOT / "install.ps1"
+INSTALL_CMD = REPO_ROOT / "install.cmd"
+
+
+def _read(path: Path) -> str:
+    assert path.exists(), f"{path.name} missing at {path}"
+    return path.read_text()
+
+
+# ── install.sh ────────────────────────────────────────────────────────────
+
+def test_install_sh_syntax_is_valid() -> None:
+    bash = shutil.which("bash")
+    assert bash, "bash not found on PATH — required to syntax-check install.sh"
+    result = subprocess.run(
+        [bash, "-n", str(INSTALL_SH)], capture_output=True, text=True,
+    )
+    assert result.returncode == 0, f"bash -n failed: {result.stderr}"
+
+
+def test_install_sh_sweeps_other_pythons_before_installing() -> None:
+    body = _read(INSTALL_SH)
+    sweep_idx = body.find("Stale-duplicate sweep")
+    venv_idx = body.find("Install into venv")
+    assert sweep_idx != -1, "install.sh must contain the stale-duplicate sweep"
+    assert venv_idx != -1
+    assert sweep_idx < venv_idx, (
+        "the sweep must run BEFORE the real install so a stray copy can't "
+        "keep shadowing the freshly (re)built venv"
+    )
+    assert '-m pip show clawmetry' in body
+    assert '-m pip uninstall -y clawmetry' in body
+
+
+def test_install_sh_sweep_never_touches_own_install_dir() -> None:
+    """The sweep must skip interpreters INSIDE $INSTALL_DIR — that copy is
+    the one about to be (re)built, not a stale duplicate."""
+    body = _read(INSTALL_SH)
+    sweep = body[body.find("Stale-duplicate sweep"): body.find("Install into venv")]
+    assert '"$INSTALL_DIR"/*) continue ;;' in sweep
+
+
+def test_install_sh_sweep_is_best_effort_under_set_dash_e() -> None:
+    """install.sh runs with `set -e`; a pip uninstall failure on some
+    unrelated interpreter must never abort the whole install."""
+    body = _read(INSTALL_SH)
+    assert "set -e" in body.splitlines()[3], "expected `set -e` near the top of install.sh"
+    sweep = body[body.find("Stale-duplicate sweep"): body.find("Install into venv")]
+    assert "pip uninstall -y clawmetry >/dev/null 2>&1 || true" in sweep
+
+
+# ── install.ps1 ───────────────────────────────────────────────────────────
+
+def test_install_ps1_sweeps_other_pythons_before_installing() -> None:
+    body = _read(INSTALL_PS1)
+    sweep_idx = body.find("Stale-duplicate sweep")
+    venv_idx = body.find("Create venv")
+    assert sweep_idx != -1, "install.ps1 must contain the stale-duplicate sweep"
+    assert venv_idx != -1
+    assert sweep_idx < venv_idx, (
+        "the sweep must run BEFORE the venv is created so a stray copy "
+        "can't keep shadowing it"
+    )
+    assert "-m pip show clawmetry" in body
+    assert "-m pip uninstall -y clawmetry" in body
+
+
+def test_install_ps1_sweep_never_touches_own_install_dir() -> None:
+    body = _read(INSTALL_PS1)
+    sweep = body[body.find("Stale-duplicate sweep"): body.find("Create venv")]
+    assert "$installDir" in sweep
+    assert "StartsWith($installDir" in sweep
+
+
+def test_install_ps1_syntax_is_valid() -> None:
+    pwsh = shutil.which("pwsh") or shutil.which("powershell")
+    if not pwsh:
+        import pytest
+
+        pytest.skip("no PowerShell interpreter on PATH to syntax-check install.ps1")
+    script = (
+        "$e=$null; [System.Management.Automation.Language.Parser]::ParseFile("
+        f"'{INSTALL_PS1}', [ref]$null, [ref]$e) | Out-Null; "
+        "if ($e) { $e | ForEach-Object { Write-Error $_ }; exit 1 } else { exit 0 }"
+    )
+    result = subprocess.run(
+        [pwsh, "-NoProfile", "-Command", script], capture_output=True, text=True,
+    )
+    assert result.returncode == 0, f"PowerShell parse failed: {result.stderr}"
+
+
+# ── install.cmd ───────────────────────────────────────────────────────────
+
+def test_install_cmd_sweeps_other_pythons_before_installing() -> None:
+    body = _read(INSTALL_CMD)
+    sweep_idx = body.find(":cm_sweep_stale")
+    install_idx = body.find("Installing clawmetry...")
+    assert sweep_idx != -1, "install.cmd must contain the stale-duplicate sweep"
+    assert install_idx != -1
+    assert sweep_idx < install_idx, (
+        "the sweep must run BEFORE the pip install so a stray copy elsewhere "
+        "on PATH can't keep shadowing the fresh one"
+    )
+    assert "pip show clawmetry" in body
+    assert "pip uninstall -y clawmetry" in body
+
+
+def test_install_cmd_also_removes_the_dedicated_venv_install() -> None:
+    """install.cmd installs straight into system Python with no venv of its
+    own; a leftover install.ps1-created venv at %LOCALAPPDATA%\\clawmetry
+    would otherwise coexist and whichever wins PATH order shadows the other."""
+    body = _read(INSTALL_CMD)
+    assert '"%LOCALAPPDATA%\\clawmetry"' in body
+    assert "rmdir /s /q" in body
+
+
+def test_install_cmd_sweep_has_matching_goto_labels() -> None:
+    body = _read(INSTALL_CMD)
+    assert ":cm_sweep_stale" in body
+    assert ":cm_sweep_done" in body
+    assert "goto :cm_sweep_done" in body
+    assert "goto :eof" in body


### PR DESCRIPTION
## Summary
- All three canonical installers (`install.sh`, `install.ps1`, `install.cmd`) now sweep every `python`/`python3` interpreter on PATH and `pip uninstall clawmetry` from each one except the venv/target about to be (re)built, **before** installing fresh.
- `install.cmd` also removes a leftover `install.ps1`-created venv at `%LOCALAPPDATA%\clawmetry`, since it has no dedicated venv of its own and the two installers would otherwise coexist and shadow each other on PATH.
- Follow-up to #4335 (`clawmetry/installs.py`), which added *detection* of stale duplicate installs (the doctor census + CLI warning) but never removal. This closes the loop: installers now actively clean up, the census still catches whatever a sweep can't reach.

## Why
Live-reproduced on a user machine: a plain `pip install --user clawmetry` into a system Python left clawmetry 0.11.99 dormant next to a current 0.12.655 dedicated-venv install. Harmless there only because PATH ordering happened to favor the venv copy — on a machine where it doesn't, `clawmetry --version`/`clawmetry status` report a stale version while the real daemon is current, reading as "auto-update is broken" (the exact failure #4335 was built to explain, not fix).

## Test plan
- [x] `tests/test_installer_stale_sweep.py` — 10 new tests: bash -n / PowerShell parser syntax checks, sweep-runs-before-install ordering, own-install-dir exclusion, best-effort-under-`set -e`
- [x] All 16 pre-existing `install.sh` tests still green
- [x] Reproduced the live scenario: reinstalled clawmetry into a second system Python, confirmed both `install.cmd` and `install.ps1` detect and remove it via `pip show`/`pip uninstall` before reinstalling fresh, `clawmetry --version` correct afterward
- [ ] `install.sh` not behaviorally re-run beyond `bash -n` here (Windows dev machine, no macOS/Linux box handy) — behavioral proof for all three lands in `.github/workflows/install-test.yml` on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
