### PR TITLE
[RELEASE] Fix desktop-artifacts workflow (secrets.* not allowed in step-level if:)

### DIFF
--- a/.github/workflows/desktop-artifacts.yml
+++ b/.github/workflows/desktop-artifacts.yml
@@ -19,6 +19,14 @@ jobs:
   macos:
     name: macOS .app + .dmg (signed + notarized when secrets are set)
     runs-on: macos-latest
+    # The `secrets` context is not available in step-level `if:` conditionals
+    # (the workflow parser rejects it — GitHub restricts `secrets` to `env:`,
+    # `with:`, and `run:`). Hoist the presence checks into job-level `env` so
+    # steps can gate on `env.HAS_*`, which IS legal in `if:`. The values are
+    # 'true' / 'false' strings because that is what `!= ''` evaluates to.
+    env:
+      HAS_CERT: ${{ secrets.MACOS_CERT_P12_BASE64 != '' }}
+      HAS_SIGN: ${{ secrets.MACOS_SIGN_IDENTITY != '' }}
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v7
@@ -51,7 +59,7 @@ jobs:
       #   APPLE_TEAM_ID                 e.g. 8LVH596RA5
       #   APPLE_APP_SPECIFIC_PASSWORD   from https://appleid.apple.com → App-Specific Passwords
       - name: Import Developer ID cert into a build keychain
-        if: ${{ secrets.MACOS_CERT_P12_BASE64 != '' }}
+        if: env.HAS_CERT == 'true'
         env:
           MACOS_CERT_P12_BASE64: ${{ secrets.MACOS_CERT_P12_BASE64 }}
           MACOS_CERT_P12_PASSWORD: ${{ secrets.MACOS_CERT_P12_PASSWORD }}
@@ -72,7 +80,7 @@ jobs:
           security find-identity -p codesigning -v "$KEYCHAIN"
 
       - name: Sign + notarize + staple .app
-        if: ${{ secrets.MACOS_SIGN_IDENTITY != '' }}
+        if: env.HAS_SIGN == 'true'
         env:
           MACOS_SIGN_IDENTITY: ${{ secrets.MACOS_SIGN_IDENTITY }}
           APPLE_ID: ${{ secrets.APPLE_ID }}
@@ -89,7 +97,7 @@ jobs:
             "dist/ClawMetry-${VERSION}.dmg"
 
       - name: Sign + notarize + staple the .dmg itself
-        if: ${{ secrets.MACOS_SIGN_IDENTITY != '' }}
+        if: env.HAS_SIGN == 'true'
         env:
           MACOS_SIGN_IDENTITY: ${{ secrets.MACOS_SIGN_IDENTITY }}
           APPLE_ID: ${{ secrets.APPLE_ID }}
@@ -175,6 +183,12 @@ jobs:
     needs: [macos, windows, linux]
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
+    # softprops/action-gh-release needs write access to the Contents API
+    # to attach files to the existing tag's Release. Default GITHUB_TOKEN
+    # scope is read-only when the org sets that as the default; declare
+    # explicitly so the step never silently 403s.
+    permissions:
+      contents: write
     steps:
       - uses: actions/download-artifact@v4
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 ## Unreleased
 
+- **Fix: desktop-artifacts workflow now parses — signed `.dmg` ships on tag push instead of failing at the workflow-file level.**
+  - **Why:** the wiring release (v0.12.656) attempted to gate the signing
+    steps with `if: ${{ secrets.MACOS_SIGN_IDENTITY != '' }}` at step level.
+    GitHub Actions rejects `secrets.*` inside `if:` — that context is only
+    legal in `env:`, `with:`, and `run:`. The parser refused the whole
+    workflow file, so every run (both the tag push and a manual dispatch
+    for retry) failed at "This run likely failed because of a workflow
+    file issue" before any job started. Net effect: `clawmetry 0.12.656`
+    published to PyPI cleanly but the GitHub Release for that tag had
+    zero binary assets attached.
+  - **What:** hoist the presence checks to job-level `env` and gate the
+    steps on `env.HAS_CERT` / `env.HAS_SIGN`, which is legal in `if:`.
+    Also declare `permissions: contents: write` on the release job so
+    `softprops/action-gh-release@v2` can attach files even when the org
+    default GITHUB_TOKEN scope is read-only. First tag on which the fix
+    lands is the one this release cuts.
+  - **Verified:** YAML parses locally (`python3 -c "import yaml; yaml.safe_load(...)"`);
+    no `secrets.*` references remain inside any `if:` conditional
+    (`grep -nE '^\s*if:.*secrets\.'` returns nothing). End-to-end
+    verification comes with this release's tag push — the macOS job
+    must import the cert, sign both the `.app` and the `.dmg`, and the
+    release job must attach all three OS bundles to the GitHub Release.
+
 - **Release: macOS desktop `.dmg` now ships signed + notarized on every tag push.**
   - **Why:** the desktop-app scaffold landed in #4602 with the signing pipeline
     wired but the six Apple credentials were not yet in the repo, so


### PR DESCRIPTION
## Summary
Follow-up to #4603. `v0.12.656` published to PyPI cleanly but the GitHub Release had zero binary assets because `desktop-artifacts.yml` gated its signing steps with `if: \${{ secrets.MACOS_SIGN_IDENTITY != '' }}`. GitHub Actions rejects `secrets.*` in `if:` — that context is only legal in `env:`, `with:`, and `run:`. The parser refused the whole workflow file and every run of it failed at "workflow file issue" before any job started.

## The fix
- Hoist presence checks to job-level `env: HAS_CERT / HAS_SIGN` and gate the steps on `env.HAS_*` instead. That IS legal in `if:`.
- Declare `permissions: contents: write` on the release job so `softprops/action-gh-release@v2` never silently 403s when the org's default `GITHUB_TOKEN` scope is read-only.

## Verified locally
- YAML parses (\`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/desktop-artifacts.yml'))"\` → \`ok, jobs: ['macos', 'windows', 'linux', 'release']\`).
- No \`secrets.*\` references remain inside any \`if:\` (\`grep -nE '^\\s*if:.*secrets\\.' .github/workflows/desktop-artifacts.yml\` → empty).

## End-to-end verification is this release
After merge, `release-on-merge.yml` will tag `v0.12.657`, which triggers `desktop-artifacts.yml`. That run must:
- macOS: import cert into build keychain, sign+notarize+staple both `.app` and `.dmg`, upload `dist/ClawMetry-0.12.657.dmg`
- Windows: build + zip
- Linux: build + tar.gz
- Release: attach all three to the `v0.12.657` GitHub Release

## Test plan
- [ ] CI green on this PR
- [ ] Merge → `release-on-merge` bumps to `0.12.657` and pushes tag
- [ ] `desktop-artifacts.yml` on the tag: macOS job succeeds
- [ ] Post-release: `curl -L $(gh release view v0.12.657 -R vivekchand/clawmetry --json assets -q '.assets[]|select(.name|endswith(".dmg")).url')` → `spctl --assess --type open` returns \`accepted, source=Notarized Developer ID\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)