### PR TITLE
fix(desktop-ci): make desktop-artifacts workflow actually parse and sign

### DIFF
--- a/.github/workflows/desktop-artifacts.yml
+++ b/.github/workflows/desktop-artifacts.yml
@@ -41,21 +41,28 @@ jobs:
         run: pyinstaller --clean --noconfirm desktop/build_mac.spec
 
       # --- Code-signing + notarization ---
-      # These steps NO-OP when the secrets aren't configured, so PRs
-      # from forks and unsigned dev builds still succeed. Add these
-      # repo secrets in Settings → Secrets and variables → Actions:
+      # These steps NO-OP when the secrets aren't configured (fork PRs
+      # and unsigned dev builds), gated by shell checks inside `run:`.
+      # GitHub Actions does NOT allow `secrets.*` in workflow-level
+      # `if:` expressions (fails to parse the whole workflow), so the
+      # gate lives in the script itself.
+      #
+      # Add these repo secrets in Settings > Secrets and variables > Actions:
       #   MACOS_CERT_P12_BASE64         Developer ID Application .p12 (base64)
-      #   MACOS_CERT_P12_PASSWORD       password used when exporting the .p12
+      #   MACOS_CERT_PASSWORD           password used when exporting the .p12
       #   MACOS_SIGN_IDENTITY           e.g. "Developer ID Application: InstaLabs LLC (8LVH596RA5)"
       #   APPLE_ID                      Apple ID email
       #   APPLE_TEAM_ID                 e.g. 8LVH596RA5
-      #   APPLE_APP_SPECIFIC_PASSWORD   from https://appleid.apple.com → App-Specific Passwords
+      #   APPLE_APP_SPECIFIC_PASSWORD   from appleid.apple.com App-Specific Passwords
       - name: Import Developer ID cert into a build keychain
-        if: ${{ secrets.MACOS_CERT_P12_BASE64 != '' }}
         env:
           MACOS_CERT_P12_BASE64: ${{ secrets.MACOS_CERT_P12_BASE64 }}
-          MACOS_CERT_P12_PASSWORD: ${{ secrets.MACOS_CERT_P12_PASSWORD }}
+          MACOS_CERT_PASSWORD: ${{ secrets.MACOS_CERT_PASSWORD }}
         run: |
+          if [ -z "$MACOS_CERT_P12_BASE64" ]; then
+            echo "MACOS_CERT_P12_BASE64 not set — skipping cert import (unsigned build)."
+            exit 0
+          fi
           KEYCHAIN=$RUNNER_TEMP/build.keychain
           PASS="build-${GITHUB_RUN_ID}"
           echo "$MACOS_CERT_P12_BASE64" | base64 --decode > "$RUNNER_TEMP/cert.p12"
@@ -64,21 +71,24 @@ jobs:
           security unlock-keychain -p "$PASS" "$KEYCHAIN"
           security set-keychain-settings -lut 21600 "$KEYCHAIN"
           security import "$RUNNER_TEMP/cert.p12" -k "$KEYCHAIN" \
-            -P "$MACOS_CERT_P12_PASSWORD" -T /usr/bin/codesign
+            -P "$MACOS_CERT_PASSWORD" -T /usr/bin/codesign
           security set-key-partition-list -S apple-tool:,apple:,codesign: \
             -s -k "$PASS" "$KEYCHAIN"
           rm -f "$RUNNER_TEMP/cert.p12"
-          # Show what we imported (identities only — no keys)
           security find-identity -p codesigning -v "$KEYCHAIN"
 
       - name: Sign + notarize + staple .app
-        if: ${{ secrets.MACOS_SIGN_IDENTITY != '' }}
         env:
           MACOS_SIGN_IDENTITY: ${{ secrets.MACOS_SIGN_IDENTITY }}
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
-        run: desktop/sign_mac.sh dist/ClawMetry.app
+        run: |
+          if [ -z "$MACOS_SIGN_IDENTITY" ]; then
+            echo "MACOS_SIGN_IDENTITY not set — skipping .app signing."
+            exit 0
+          fi
+          desktop/sign_mac.sh dist/ClawMetry.app
 
       - name: Wrap into .dmg
         run: |
@@ -89,13 +99,16 @@ jobs:
             "dist/ClawMetry-${VERSION}.dmg"
 
       - name: Sign + notarize + staple the .dmg itself
-        if: ${{ secrets.MACOS_SIGN_IDENTITY != '' }}
         env:
           MACOS_SIGN_IDENTITY: ${{ secrets.MACOS_SIGN_IDENTITY }}
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
         run: |
+          if [ -z "$MACOS_SIGN_IDENTITY" ]; then
+            echo "MACOS_SIGN_IDENTITY not set — skipping .dmg signing."
+            exit 0
+          fi
           for dmg in dist/*.dmg; do
             desktop/sign_mac.sh "$dmg"
           done

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -163,7 +163,7 @@ then the workflow signs + notarizes + staples every tag build:
 | Secret | What to paste |
 |--------|---------------|
 | `MACOS_CERT_P12_BASE64` | `security find-certificate -c "Developer ID Application" -p login.keychain \| base64` — or export the cert+key from Keychain Access as `.p12` and `base64 -i cert.p12 \| pbcopy` |
-| `MACOS_CERT_P12_PASSWORD` | Password you set when exporting the .p12 |
+| `MACOS_CERT_PASSWORD` | Password you set when exporting the .p12 |
 | `MACOS_SIGN_IDENTITY` | `Developer ID Application: InstaLabs LLC (8LVH596RA5)` |
 | `APPLE_ID` | Your Apple ID email |
 | `APPLE_TEAM_ID` | `8LVH596RA5` |


### PR DESCRIPTION
## Summary

Two blockers preventing `.github/workflows/desktop-artifacts.yml` from doing anything on `main`:

1. **`if: \${{ secrets.* != '' }}` is not valid at the workflow level.** GitHub Actions fails to parse the whole workflow with `Unrecognized named-value: 'secrets'` and *no jobs run at all*. Confirmed on the post-merge dispatch attempt — the workflow errored out at load time before any step.
2. **Repo secret is `MACOS_CERT_PASSWORD`, not `MACOS_CERT_P12_PASSWORD`** — the workflow was reading an empty password even when the base64 cert imported correctly.

## Fix

- Remove all `if:` gates on `secrets.*`. Move each gate into a two-line shell check at the top of the corresponding `run:` script (`env:` is still allowed to reference secrets, so the values are in scope but the check happens at shell level).
- Rename `MACOS_CERT_P12_PASSWORD` → `MACOS_CERT_PASSWORD` in both the workflow and `desktop/README.md`.

Result: manual-dispatched runs will now succeed and produce a signed + notarized `.dmg` as a workflow artifact. Fork PRs / any invocation with the secrets unset still succeed (the guards short-circuit and skip signing).

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/desktop-artifacts.yml'))"` parses.
- [ ] Post-merge `gh workflow run desktop-artifacts.yml --ref main` completes and uploads a `clawmetry-macos` artifact.
- [ ] Downloaded `.dmg` passes `spctl --assess --type open --context context:primary-signature → accepted, source=Notarized Developer ID`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)