### PR TITLE
[RELEASE] Fix macOS .dmg build (pyinstaller excluded on darwin) + auto-fire desktop-artifacts on tag

### DIFF
--- a/.github/workflows/release-on-merge.yml
+++ b/.github/workflows/release-on-merge.yml
@@ -381,6 +381,26 @@ jobs:
             --notes "Released via PR: ${{ github.event.pull_request.title }}" \
             --latest || echo "Release tag already exists, skipping"
 
+      # GitHub deliberately suppresses `on: push: tags:` cascade triggers
+      # for anything created with the default GITHUB_TOKEN (see
+      # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow).
+      # So the tag we just created will NOT auto-fire desktop-artifacts.yml,
+      # publish.yml, or any other tag-triggered workflow. Kick them
+      # explicitly here — matches the actual intent of "when we cut a
+      # release, build the desktop bundles." Verified 2026-08-07: without
+      # this step, v0.12.656 and v0.12.657 published to PyPI cleanly but
+      # left the GitHub Release with zero binary assets attached.
+      - name: Kick tag-triggered workflows the token can't cascade
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          NEW_TAG="v${{ steps.bump.outputs.new }}"
+          echo "▸ Dispatching desktop-artifacts.yml against $NEW_TAG"
+          gh workflow run desktop-artifacts.yml \
+            --repo ${{ github.repository }} \
+            --ref "$NEW_TAG" \
+            || echo "⚠ desktop-artifacts dispatch failed (non-blocking)"
+
       - name: Open PR for version bump
         # Branch protection on main blocks direct pushes. The wheel is
         # already on PyPI + the release tag exists, so this step just keeps

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,40 @@
 ## Unreleased
 
+- **Fix: macOS `.dmg` now actually builds — pyinstaller was excluded from macOS via a stray sys_platform marker; release-on-merge now kicks tag-triggered workflows the GITHUB_TOKEN can't cascade.**
+  - **Why:** two bugs in a row prevented v0.12.656 and v0.12.657 from
+    shipping desktop bundles even though PyPI got the wheels cleanly.
+    (1) `desktop/requirements-dev.txt` pinned pyinstaller with
+    `sys_platform != "darwin"` — literally excluding it on macOS. The
+    workflow's macOS job then runs `pyinstaller --clean --noconfirm
+    desktop/build_mac.spec` and dies with exit 127 ("command not
+    found"). The comment above the workflow step even says "PyInstaller
+    (not py2app)" but the requirements file thought it was
+    py2app-on-mac. (2) `release-on-merge.yml` creates the release tag
+    with the default GITHUB_TOKEN, and GitHub Actions deliberately
+    suppresses cascade triggers for GITHUB_TOKEN events — so the
+    `on: push: tags:` gate on `desktop-artifacts.yml` never fired even
+    after the workflow-file syntax fix in v0.12.657. Every release
+    since v0.12.656 has needed a manual `gh workflow run
+    desktop-artifacts.yml --ref v0.12.<n>` to build the bundles.
+  - **What:** (1) collapse the pyinstaller line in
+    `desktop/requirements-dev.txt` to a single unconditional
+    `pyinstaller>=6.0` and drop the unused py2app + `setuptools<70`
+    macOS pins — all three build specs are PyInstaller specs, py2app
+    is not on the shipping path. (2) add an explicit
+    `gh workflow run desktop-artifacts.yml --ref v0.12.<n>` step at
+    the end of `release-on-merge.yml` right after the `gh release
+    create` step, so every future release fires the desktop-bundle
+    build automatically. Non-blocking (`|| echo`) so a dispatch failure
+    never blocks the PyPI publish that already succeeded upstream.
+  - **Verified:** locally,
+    `pip install -r desktop/requirements-dev.txt` on macOS installs
+    pyinstaller (was previously silently skipped by the sys_platform
+    marker). The `gh workflow run` step is idempotent and safe on
+    re-runs. End-to-end verification is this release: the tag push
+    must produce a signed+notarized `.dmg` + Windows `.zip` + Linux
+    `.tar.gz` attached to the GitHub Release WITHOUT any manual
+    dispatch step from me.
+
 - **Fix: desktop-artifacts workflow now parses — signed `.dmg` ships on tag push instead of failing at the workflow-file level.**
   - **Why:** the wiring release (v0.12.656) attempted to gate the signing
     steps with `if: ${{ secrets.MACOS_SIGN_IDENTITY != '' }}` at step level.

--- a/desktop/requirements-dev.txt
+++ b/desktop/requirements-dev.txt
@@ -7,10 +7,9 @@ Pillow>=10.0
 # webkit2 on Linux). Uses the OS's own webview engine, so the bundle
 # stays small — no Chromium ships inside the .app.
 pywebview>=5.0
-# macOS bundler. py2app<=0.28 still imports pkg_resources at load time,
-# which setuptools>=70 dropped from the default install. Pin setuptools
-# under 70 whenever py2app is in the build set.
-py2app>=0.28; sys_platform == "darwin"
-setuptools<70; sys_platform == "darwin"
-# Windows / Linux bundler
-pyinstaller>=6.0; sys_platform != "darwin"
+# Bundler for all three OSes. build_mac.spec / build_windows.spec /
+# build_linux.spec are all PyInstaller specs. py2app is intentionally
+# NOT the mac shipping path: py2app 0.28.x has a broken macOS version
+# check on Tahoe / macOS 26 and refuses to build. setup_py2app.py is
+# kept in-tree only for the day py2app catches up.
+pyinstaller>=6.0


### PR DESCRIPTION
## Summary
Follow-up to #4603 and #4605. `v0.12.656` and `v0.12.657` published to PyPI cleanly but both GitHub Releases have zero binary assets. Two root causes:

### 1. `pyinstaller` was excluded on macOS
`desktop/requirements-dev.txt:16` had:
```
pyinstaller>=6.0; sys_platform != "darwin"
```
The workflow then ran `pyinstaller --clean --noconfirm desktop/build_mac.spec` on `macos-latest` and died with exit 127. The comment above the workflow step even says "PyInstaller (not py2app)" — the requirements file just disagreed.

Fixed by collapsing to `pyinstaller>=6.0` (unconditional) and dropping the unused py2app + `setuptools<70` macOS pins. All three build specs are PyInstaller specs; py2app is not on the shipping path.

### 2. `release-on-merge` tag doesn't cascade
`release-on-merge.yml` creates the release tag with the default `GITHUB_TOKEN`. Per [GitHub's docs](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow), events triggered by the `GITHUB_TOKEN` never fire cascade workflows. So `on: push: tags:` on `desktop-artifacts.yml` never fired for `v0.12.656` or `v0.12.657` — both times I had to manually `gh workflow run desktop-artifacts.yml --ref v0.12.<n>`.

Fixed by adding an explicit dispatch step right after `gh release create`:
```yaml
- name: Kick tag-triggered workflows the token can't cascade
  run: |
    gh workflow run desktop-artifacts.yml --ref "v${NEW}" \
      || echo "⚠ desktop-artifacts dispatch failed (non-blocking)"
```

Non-blocking so a dispatch failure never blocks the PyPI publish that already succeeded upstream.

## Verified locally
- Both workflow YAMLs parse (`python3 -c 'import yaml; yaml.safe_load(open(...))'`).
- On macOS: `pip install -r desktop/requirements-dev.txt` now installs pyinstaller (previously silently skipped).

## End-to-end verification is this release
On merge:
1. `release-on-merge.yml` bumps to `0.12.658`, publishes wheel to PyPI, creates the `v0.12.658` GitHub Release, then explicitly dispatches `desktop-artifacts.yml` on the new tag.
2. `desktop-artifacts.yml` on `v0.12.658` must: build all three OS bundles (macOS PyInstaller path finally works), sign+notarize+staple the `.dmg`, attach all three to the GitHub Release — **without me running any manual dispatch step**.

## Test plan
- [ ] CI green on this PR
- [ ] `release-on-merge` bumps to `0.12.658`, creates release, dispatches desktop-artifacts
- [ ] `desktop-artifacts` run on `v0.12.658` — all three jobs green, release job attaches assets
- [ ] `gh release view v0.12.658 --json assets` shows `.dmg`, `.zip`, `.tar.gz`
- [ ] Download the `.dmg`, `spctl --assess --type open` returns `accepted, source=Notarized Developer ID`

🤖 Generated with [Claude Code](https://claude.com/claude-code)