### PR TITLE
feat(efficiency): Cache Hit Rate + Routing Advisor tiles

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -14572,6 +14572,154 @@ function _renderEfficiencyCardInner(card, eff) {
     + '</div>';
 }
 
+// ===== Cache Hit Rate + Routing Advisor cards =====
+// Uber-play companions to the Efficiency grade (Aug 2026 earnings-call framing
+// — "the next phase is efficiency"). Both derive from _cmLoadEfficiency's
+// shared /api/efficiency cache (60s TTL + in-flight dedup already there), so
+// they are cloud-safe by construction (cm-cloud-efficiency serves that URL
+// from the snapshot) and add ZERO fetches on tab load. Perf-first per
+// FLYWHEEL §5 "share, don't duplicate."
+function _cmFmtUsd(n) {
+  n = Number(n) || 0;
+  if (n >= 1000) return '$' + Math.round(n).toLocaleString();
+  if (n >= 10) return '$' + Math.round(n);
+  if (n >= 1) return '$' + n.toFixed(1);
+  return '$' + n.toFixed(2);
+}
+var _CM_CACHE_LEFT_ON_TABLE_FRAC = 0.5;
+var _CM_CACHE_READ_MULT = 0.1;
+// Derive the Cache-Hit tile payload from an efficiency scope, mirroring the
+// server-side helper in routes/usage.py::_cache_hit_shape. Pure JS, never
+// throws — bad shape returns nulls the render code hides on.
+function _cmEffCacheHitShape(scope) {
+  var m = (scope && scope.metrics) || {};
+  var tin = Number(m.tokens_in) || 0;
+  var cr = Number(m.cache_read) || 0;
+  var cw = Number(m.cache_write) || 0;
+  var denom = tin + cr;
+  var hit = denom > 0 ? (cr / denom * 100.0) : null;
+  var saved = Number((scope && scope.cache_saved_monthly_usd)) || 0;
+  var projected = Number((scope && scope.projected_monthly_cost_usd)) || 0;
+  var leaked = 0;
+  if (hit !== null && hit < 100 && projected > 0 && tin > 0) {
+    var weight = (tin + cr + cw) > 0 ? (tin / (tin + cr + cw)) : 0;
+    var monthlyInput = projected * weight;
+    leaked = monthlyInput * _CM_CACHE_LEFT_ON_TABLE_FRAC * (1 - _CM_CACHE_READ_MULT);
+  }
+  return {
+    hit: hit, saved: saved, leaked: leaked,
+    insufficient: !!(scope && scope.insufficient_data),
+    haveData: (denom > 0 && projected > 0)
+  };
+}
+function renderCacheHitRateCard() {
+  var title = document.getElementById('cache-hit-rate-title');
+  var card = document.getElementById('cache-hit-rate-card');
+  if (!card) return;
+  _cmLoadEfficiency(function (eff) {
+    if (!eff) { if (title) title.style.display = 'none'; card.style.display = 'none'; return; }
+    var rt = (typeof _cmRuntimeFilter === 'function') ? _cmRuntimeFilter() : 'all';
+    // _cmLoadEfficiency fetches with ?runtime=<id> when scoped, so the payload
+    // is already the correct scope in either mode. Node-wide it also carries
+    // a byRuntime map that we ignore here.
+    var s = _cmEffCacheHitShape(eff);
+    if (!s.haveData || s.insufficient) {
+      if (title) title.style.display = 'none';
+      card.style.display = 'none';
+      return;
+    }
+    var hitColor = s.hit >= 60 ? '#22c55e' : (s.hit >= 30 ? '#f59e0b' : '#ef4444');
+    var scopeLine = _cmEffScopeLine(rt);
+    var frac = Math.round(_CM_CACHE_LEFT_ON_TABLE_FRAC * 100);
+    if (title) title.style.display = '';
+    card.style.display = '';
+    card.innerHTML = '<div style="display:flex;gap:24px;flex-wrap:wrap;padding:16px;">'
+      + '<div style="flex:0 0 200px;min-width:180px;">'
+        + '<div style="font-size:11px;font-weight:600;letter-spacing:.06em;text-transform:uppercase;color:var(--text-muted);">Cache hit rate</div>'
+        + '<div style="font-size:40px;font-weight:800;color:' + hitColor + ';line-height:1.05;margin:6px 0 2px;">' + s.hit.toFixed(1) + '%</div>'
+        + '<div style="font-size:11px;color:var(--text-muted);">' + escHtml(scopeLine) + '</div>'
+      + '</div>'
+      + '<div style="flex:1;min-width:220px;display:flex;gap:24px;flex-wrap:wrap;">'
+        + '<div style="min-width:120px;">'
+          + '<div style="font-size:11px;font-weight:600;letter-spacing:.06em;text-transform:uppercase;color:var(--text-muted);">Already saved</div>'
+          + '<div style="font-size:22px;font-weight:700;color:#22c55e;margin:4px 0;">' + _cmFmtUsd(s.saved) + '<span style="font-size:12px;font-weight:500;color:var(--text-muted);">/mo</span></div>'
+          + '<div style="font-size:11px;color:var(--text-muted);">measured from cached reads</div>'
+        + '</div>'
+        + '<div style="min-width:140px;">'
+          + '<div style="font-size:11px;font-weight:600;letter-spacing:.06em;text-transform:uppercase;color:var(--text-muted);">Left on the table</div>'
+          + '<div style="font-size:22px;font-weight:700;color:' + (s.leaked > 0 ? '#f59e0b' : 'var(--text-muted)') + ';margin:4px 0;">' + _cmFmtUsd(s.leaked) + '<span style="font-size:12px;font-weight:500;color:var(--text-muted);">/mo</span></div>'
+          + '<div style="font-size:11px;color:var(--text-muted);">estimate · assumes ' + frac + '% of misses were cacheable</div>'
+        + '</div>'
+      + '</div>'
+      + '</div>';
+  });
+}
+// Pull the model_downgrade actions from an efficiency scope. Mirror of the
+// server-side helper (routes/usage.py::_extract_downgrade_suggestions).
+function _cmEffDowngradeSuggestions(scope) {
+  var out = [];
+  ((scope && scope.actions) || []).forEach(function (a) {
+    if (a.id !== 'model_downgrade') return;
+    var save = Number(a.savings_monthly_usd) || 0;
+    if (save <= 0) return;
+    var d = a.data || {};
+    out.push({
+      current_model: a.model || '',
+      suggested_model: d.target_model || '',
+      calls: Number(d.calls) || 0,
+      avg_tokens_out: Number(d.avg_tokens_out) || 0,
+      potential_savings_monthly_usd: save
+    });
+  });
+  out.sort(function (a, b) { return b.potential_savings_monthly_usd - a.potential_savings_monthly_usd; });
+  return out;
+}
+function renderRoutingAdvisorCard() {
+  var title = document.getElementById('routing-advisor-title');
+  var card = document.getElementById('routing-advisor-card');
+  if (!card) return;
+  _cmLoadEfficiency(function (eff) {
+    if (!eff) { if (title) title.style.display = 'none'; card.style.display = 'none'; return; }
+    var rt = (typeof _cmRuntimeFilter === 'function') ? _cmRuntimeFilter() : 'all';
+    // Same rationale as renderCacheHitRateCard — _cmLoadEfficiency scopes.
+    var suggestions = _cmEffDowngradeSuggestions(eff);
+    if (!suggestions.length) {
+      if (title) title.style.display = 'none';
+      card.style.display = 'none';
+      return;
+    }
+    var potential = 0;
+    suggestions.forEach(function (s) { potential += s.potential_savings_monthly_usd; });
+    var scopeLine = _cmEffScopeLine(rt);
+    var rows = suggestions.slice(0, 5).map(function (s) {
+      var save = _cmFmtUsd(s.potential_savings_monthly_usd);
+      var calls = s.calls.toLocaleString();
+      return '<div style="display:flex;gap:10px;align-items:baseline;padding:10px 0;border-top:1px solid var(--border-primary,#1f2937);">'
+        + '<div style="flex:1;min-width:0;">'
+          + '<div style="font-size:13px;color:var(--text-primary);"><span style="font-weight:600;">' + escHtml(s.current_model || 'model') + '</span> <span style="color:var(--text-muted);">→</span> <span style="font-weight:600;color:#22c55e;">' + escHtml(s.suggested_model || 'cheaper sibling') + '</span></div>'
+          + '<div style="font-size:11px;color:var(--text-muted);margin-top:2px;">' + calls + ' calls in window · avg ' + Math.round(s.avg_tokens_out) + ' output tokens</div>'
+        + '</div>'
+        + '<div style="font-size:13px;font-weight:700;color:#22c55e;white-space:nowrap;">save about ' + save + '/mo</div>'
+      + '</div>';
+    }).join('');
+    if (title) title.style.display = '';
+    card.style.display = '';
+    card.innerHTML = '<div style="display:flex;gap:24px;flex-wrap:wrap;padding:16px;">'
+      + '<div style="flex:0 0 220px;min-width:200px;">'
+        + '<div style="font-size:11px;font-weight:600;letter-spacing:.06em;text-transform:uppercase;color:var(--text-muted);">Potential savings</div>'
+        + '<div style="font-size:34px;font-weight:800;color:#f59e0b;line-height:1.05;margin:6px 0 2px;">' + _cmFmtUsd(potential) + '<span style="font-size:13px;font-weight:500;color:var(--text-muted);">/mo</span></div>'
+        + '<div style="font-size:11px;color:var(--text-muted);">from ' + suggestions.length + ' safe swap' + (suggestions.length === 1 ? '' : 's') + '</div>'
+        + '<div style="font-size:11px;color:var(--text-muted);margin-top:10px;">' + escHtml(scopeLine) + '</div>'
+      + '</div>'
+      + '<div style="flex:1;min-width:280px;">'
+        + '<div style="font-size:14px;font-weight:600;color:var(--text-primary);">Safe same-provider downgrades</div>'
+        + '<div style="font-size:12px;color:var(--text-muted);margin:2px 0 4px;">Prompts running on a heavier model that would have scored the same on its cheaper sibling. Guarded resolver, never cross-provider.</div>'
+        + rows
+      + '</div>'
+    + '</div>';
+  });
+}
+
 // ===== Usage / Token Tracking =====
 
 // QW4: the "Token Usage (14 days)" title + card hide together when the series
@@ -14601,6 +14749,10 @@ async function loadUsage() {
   // state even when an unrelated usage loader throws below (on nodes where
   // /api/usage fails, the tail of the try block never runs).
   try { renderEfficiencyCard(); } catch (_eEff) {}
+  // Both derive from the same _cmLoadEfficiency cache so they cost nothing
+  // extra on cloud (cm-cloud-efficiency serves the URL from the snapshot).
+  try { renderCacheHitRateCard(); } catch (_eChr) {}
+  try { renderRoutingAdvisorCard(); } catch (_eRa) {}
   try { loadSpendFlow(); } catch (_eSf) {}
   try { _cmUpdateUsageFleetNote(); } catch (_eFleet) {}
   try {

--- a/clawmetry/templates/tabs/usage.html
+++ b/clawmetry/templates/tabs/usage.html
@@ -38,6 +38,17 @@
        `efficiency` snapshot slice on cloud). Hidden until the slice answers; honest
        collecting/empty states are rendered by JS, never a silent blank. -->
   <div class="card" id="efficiency-card" style="display:none;margin-bottom:16px;"></div>
+  <!-- Cache Hit Rate (Uber-play #1) — derived client-side from /api/efficiency
+       cache (same slice the efficiency grade uses; cloud-safe via the existing
+       cm-cloud-efficiency interceptor). Shows $ that caching already saved and
+       a conservative estimate of $ left on the table. JS: renderCacheHitRateCard(). -->
+  <div class="section-title" id="cache-hit-rate-title" style="display:none;">🎯 Cache Hit Rate <span style="font-size:11px;font-weight:400;color:var(--text-muted);margin-left:8px;">what caching already saved · what you are leaving on the table</span></div>
+  <div class="card" id="cache-hit-rate-card" style="display:none;margin-bottom:16px;"></div>
+  <!-- Routing Advisor (Uber-play #2) — derived client-side from /api/efficiency
+       cache (same rationale). Shows potential monthly savings from safe
+       same-provider model downgrades. JS: renderRoutingAdvisorCard(). -->
+  <div class="section-title" id="routing-advisor-title" style="display:none;">🔀 Routing Advisor <span style="font-size:11px;font-weight:400;color:var(--text-muted);margin-left:8px;">safe same-provider swaps · potential monthly savings</span></div>
+  <div class="card" id="routing-advisor-card" style="display:none;margin-bottom:16px;"></div>
   <!-- Spend Flow (feat/spend-flow): where the money goes, as a flow — input
        context categories -> runtime -> output categories, tokens + dollars.
        Filled by app.js loadSpendFlow() from /api/spend-flow (cloud: the

--- a/routes/usage.py
+++ b/routes/usage.py
@@ -4521,6 +4521,175 @@ def api_efficiency():
 
 
 # ---------------------------------------------------------------------------
+# Efficiency companion endpoints — Cache-Hit Rate + Routing Advisor.
+# Public API surface (v1 consumers, mobile). The dashboard tab derives both
+# card contents client-side from the shared /api/efficiency cache so they
+# work on cloud through the existing cm-cloud-efficiency interceptor without
+# needing per-endpoint interceptors. These handlers stay for external readers.
+# Both never 500 and reconcile with /api/efficiency by construction.
+# ---------------------------------------------------------------------------
+
+# "$ left on the table" is deliberately conservative: only a fraction of a
+# miss's input tokens is realistically cacheable, so the caller-visible number
+# is flagged as an estimate rather than a hard claim.
+_CACHE_LEFT_ON_TABLE_CACHEABLE_FRACTION = 0.5
+# Cache multiplier for Anthropic reads (mirror of providers_pricing._CACHE_READ_MULT;
+# inlined to avoid a routes<->core round-trip for one float).
+_CACHE_READ_MULT_FOR_ESTIMATE = 0.1
+
+
+def _cache_hit_shape(slice_dict, days):
+    """Reduce a build_efficiency_slice() scope to the Cache-Hit tile payload."""
+    metrics = (slice_dict or {}).get("metrics") or {}
+    tokens_in = int(metrics.get("tokens_in") or 0)
+    cache_read = int(metrics.get("cache_read") or 0)
+    denom = tokens_in + cache_read
+    hit_rate = round(cache_read / denom * 100.0, 2) if denom > 0 else None
+    saved_monthly = float((slice_dict or {}).get("cache_saved_monthly_usd") or 0.0)
+    window_cost = float(metrics.get("window_cost_usd") or 0.0)
+    projected = float((slice_dict or {}).get("projected_monthly_cost_usd") or 0.0)
+    left_on_table_monthly = 0.0
+    if hit_rate is not None and hit_rate < 100.0 and projected > 0 and tokens_in > 0:
+        cache_write = int(metrics.get("cache_write") or 0)
+        weight = (
+            tokens_in / (tokens_in + cache_read + cache_write)
+            if (tokens_in + cache_read + cache_write) > 0 else 0.0
+        )
+        monthly_input_cost = projected * weight
+        left_on_table_monthly = round(
+            monthly_input_cost
+            * _CACHE_LEFT_ON_TABLE_CACHEABLE_FRACTION
+            * (1.0 - _CACHE_READ_MULT_FOR_ESTIMATE),
+            4,
+        )
+    return {
+        "cache_hit_rate_pct":        hit_rate,
+        "tokens_in":                 tokens_in,
+        "cache_read":                cache_read,
+        "cache_saved_monthly_usd":   round(saved_monthly, 4),
+        "left_on_table_monthly_usd": left_on_table_monthly,
+        "left_on_table_estimate":    True,
+        "cacheable_fraction_used":   _CACHE_LEFT_ON_TABLE_CACHEABLE_FRACTION,
+        "window_cost_usd":           round(window_cost, 4),
+        "insufficient_data":         bool((slice_dict or {}).get("insufficient_data")),
+        "window_days":               days,
+    }
+
+
+@bp_usage.route("/api/efficiency/cache-hit-rate")
+def api_efficiency_cache_hit_rate():
+    """Prompt cache hit rate, $ saved, and conservative $ left on the table.
+
+    Reuses ``build_efficiency_slice`` so the node-wide number reconciles with
+    ``/api/efficiency`` by construction. Returns a node total plus a
+    ``byRuntime`` map. ``left_on_table_monthly_usd`` is flagged as an estimate
+    (underlying cacheable fraction exposed in the payload). Never 500s.
+    """
+    try:
+        days = int(request.args.get("days") or 30)
+    except (TypeError, ValueError):
+        days = 30
+    days = max(7, min(90, days))
+    empty_scope = _cache_hit_shape({"insufficient_data": True}, days)
+    try:
+        from clawmetry.efficiency import build_efficiency_slice
+        rows = _ls_call("query_efficiency_rollup", days=days) or []
+        slice_all = build_efficiency_slice(rows, days=days)
+    except Exception:
+        return jsonify({"schema": 1, "window_days": days,
+                        "node": empty_scope, "byRuntime": {}})
+    node = _cache_hit_shape(slice_all, days)
+    by_rt = {}
+    for rt, entry in (slice_all.get("byRuntime") or {}).items():
+        by_rt[rt] = _cache_hit_shape(entry, days)
+    return jsonify({"schema": 1, "window_days": days,
+                    "node": node, "byRuntime": by_rt})
+
+
+def _extract_downgrade_suggestions(slice_dict):
+    """Pull the model_downgrade actions out of a scope, with target model + $."""
+    out = []
+    for a in ((slice_dict or {}).get("actions") or []):
+        if a.get("id") != "model_downgrade":
+            continue
+        data = a.get("data") or {}
+        savings = float(a.get("savings_monthly_usd") or 0.0)
+        if savings <= 0:
+            continue
+        out.append({
+            "current_model":                a.get("model") or "",
+            "suggested_model":              data.get("target_model") or "",
+            "calls":                        int(data.get("calls") or 0),
+            "avg_tokens_out":               float(data.get("avg_tokens_out") or 0.0),
+            "window_cost_usd":              float(data.get("window_cost_usd") or 0.0),
+            "target_window_cost_usd":       float(data.get("target_window_cost_usd") or 0.0),
+            "potential_savings_monthly_usd": round(savings, 4),
+        })
+    out.sort(key=lambda r: -r["potential_savings_monthly_usd"])
+    return out
+
+
+@bp_usage.route("/api/efficiency/routing-advisor")
+def api_efficiency_routing_advisor():
+    """Model-routing recommendations + already-realised routing savings.
+
+    Two numbers side by side from the same DuckDB store:
+      * ``potential`` — build_efficiency_slice's ``model_downgrade`` actions
+        (safe same-provider swaps only; the resolver in
+        ``providers_pricing.downgrade_model_name`` is guarded) reshaped as a
+        per-model advisor list.
+      * ``realised`` — the aggregate over ``auto_downgraded`` events that
+        actually ran (``query_routing_savings``).
+    Node total + ``byRuntime`` map. Never 500s.
+    """
+    try:
+        days = int(request.args.get("days") or 30)
+    except (TypeError, ValueError):
+        days = 30
+    days = max(7, min(90, days))
+    empty = {"schema": 1, "window_days": days,
+             "node": {"suggestions": [], "potential_monthly_usd": 0.0,
+                      "realised": {"total_savings_usd": 0.0,
+                                   "total_substitutions": 0, "by_pair": []},
+                      "insufficient_data": True},
+             "byRuntime": {}}
+    try:
+        from clawmetry.efficiency import build_efficiency_slice
+        rows = _ls_call("query_efficiency_rollup", days=days) or []
+        slice_all = build_efficiency_slice(rows, days=days)
+    except Exception:
+        return jsonify(empty)
+    try:
+        realised = _ls_call("query_routing_savings", days=days) or {}
+    except Exception:
+        realised = {}
+    realised_shape = {
+        "total_savings_usd":   round(float(realised.get("total_savings_usd") or 0.0), 4),
+        "total_substitutions": int(realised.get("total_substitutions") or 0),
+        "by_pair":             realised.get("by_pair") or [],
+    }
+    node_sugg = _extract_downgrade_suggestions(slice_all)
+    node = {
+        "suggestions":           node_sugg,
+        "potential_monthly_usd": round(sum(s["potential_savings_monthly_usd"]
+                                           for s in node_sugg), 4),
+        "realised":              realised_shape,
+        "insufficient_data":     bool(slice_all.get("insufficient_data")),
+    }
+    by_rt = {}
+    for rt, entry in (slice_all.get("byRuntime") or {}).items():
+        sugg = _extract_downgrade_suggestions(entry)
+        by_rt[rt] = {
+            "suggestions":           sugg,
+            "potential_monthly_usd": round(sum(s["potential_savings_monthly_usd"]
+                                               for s in sugg), 4),
+            "insufficient_data":     bool(entry.get("insufficient_data")),
+        }
+    return jsonify({"schema": 1, "window_days": days,
+                    "node": node, "byRuntime": by_rt})
+
+
+# ---------------------------------------------------------------------------
 # Issue #2837 sub-task #1 — Compression Potential card
 # ---------------------------------------------------------------------------
 

--- a/tests/test_efficiency.py
+++ b/tests/test_efficiency.py
@@ -390,3 +390,120 @@ def test_endpoint_never_500s_on_store_failure(monkeypatch):
     body = resp.get_json()
     assert body["insufficient_data"] is True
     assert body["grade"] is None
+
+
+# ── GET /api/efficiency/cache-hit-rate + /routing-advisor ───────────────────
+# Uber-play companion endpoints (Aug 2026 earnings-call framing). The dashboard
+# tab derives both cards CLIENT-SIDE from the shared /api/efficiency cache; the
+# endpoints below are the public API surface (v1 consumers, mobile, benchmark
+# report). Same monkeypatch pattern as the tests above.
+
+def test_cache_hit_rate_endpoint_node_and_runtime(efficiency_app):
+    app, calls = efficiency_app
+    resp = app.test_client().get("/api/efficiency/cache-hit-rate")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["schema"] == 1
+    assert body["window_days"] == 30
+    node = body["node"]
+    # Seeded rows: tokens_in=130k node-wide, cache_read=70k -> ~35% hit rate.
+    assert node["cache_hit_rate_pct"] == pytest.approx(35.0, abs=0.01)
+    assert node["insufficient_data"] is False
+    assert node["left_on_table_estimate"] is True
+    assert node["cacheable_fraction_used"] == 0.5
+    assert node["left_on_table_monthly_usd"] >= 0
+    assert node["cache_saved_monthly_usd"] > 0
+    assert set(body["byRuntime"].keys()) == {"claude_code", "openclaw"}
+    assert body["byRuntime"]["claude_code"]["cache_hit_rate_pct"] == pytest.approx(70.0, abs=0.01)
+    assert body["byRuntime"]["openclaw"]["cache_hit_rate_pct"] == pytest.approx(0.0, abs=0.01)
+
+
+def test_cache_hit_rate_endpoint_days_clamped_and_never_500(monkeypatch):
+    import routes.usage as usage_mod
+
+    def boom(method_name, **kwargs):
+        raise RuntimeError("store exploded")
+
+    monkeypatch.setattr(usage_mod, "_ls_call", boom)
+    app = Flask(__name__)
+    app.register_blueprint(usage_mod.bp_usage)
+    client = app.test_client()
+    resp = client.get("/api/efficiency/cache-hit-rate?days=500")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["window_days"] == 90
+    assert body["node"]["insufficient_data"] is True
+    assert body["byRuntime"] == {}
+
+
+def test_routing_advisor_endpoint_shape_and_swap_math(efficiency_app):
+    app, calls = efficiency_app
+    resp = app.test_client().get("/api/efficiency/routing-advisor")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["schema"] == 1
+    node = body["node"]
+    assert "realised" in node
+    # No auto_downgraded events seeded -> realised totals are zero, honestly.
+    assert node["realised"]["total_savings_usd"] == 0.0
+    assert node["realised"]["total_substitutions"] == 0
+    # Any surviving suggestion must resolve to a KNOWN safe downgrade target.
+    for s in node["suggestions"]:
+        assert s["current_model"]
+        assert s["suggested_model"]
+        assert s["potential_savings_monthly_usd"] > 0
+        target = downgrade_model_name(s["current_model"], default_auto_downgrade_map())
+        assert s["suggested_model"] == target or target == ""
+    assert set(body["byRuntime"].keys()) == {"claude_code", "openclaw"}
+
+
+def test_routing_advisor_realised_pulled_from_store(monkeypatch):
+    import routes.usage as usage_mod
+
+    seen: list = []
+
+    def fake_ls_call(method_name, **kwargs):
+        seen.append(method_name)
+        if method_name == "query_efficiency_rollup":
+            return [
+                _row(runtime="claude_code", tokens_in=1_000, tokens_out=1_000,
+                     cost_usd=0.01, calls=1),
+            ]
+        if method_name == "query_routing_savings":
+            return {
+                "total_savings_usd": 4.2,
+                "total_substitutions": 17,
+                "by_pair": [{"from": "gpt-4o", "to": "gpt-4o-mini",
+                             "savings_usd": 4.2, "count": 17}],
+            }
+        return None
+
+    monkeypatch.setattr(usage_mod, "_ls_call", fake_ls_call)
+    app = Flask(__name__)
+    app.register_blueprint(usage_mod.bp_usage)
+    resp = app.test_client().get("/api/efficiency/routing-advisor")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["node"]["realised"]["total_savings_usd"] == 4.2
+    assert body["node"]["realised"]["total_substitutions"] == 17
+    assert len(body["node"]["realised"]["by_pair"]) == 1
+    assert "query_routing_savings" in seen
+    assert "query_efficiency_rollup" in seen
+
+
+def test_routing_advisor_never_500s_on_store_failure(monkeypatch):
+    import routes.usage as usage_mod
+
+    def boom(method_name, **kwargs):
+        raise RuntimeError("store exploded")
+
+    monkeypatch.setattr(usage_mod, "_ls_call", boom)
+    app = Flask(__name__)
+    app.register_blueprint(usage_mod.bp_usage)
+    resp = app.test_client().get("/api/efficiency/routing-advisor")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["node"]["insufficient_data"] is True
+    assert body["node"]["suggestions"] == []
+    assert body["node"]["potential_monthly_usd"] == 0.0
+    assert body["byRuntime"] == {}


### PR DESCRIPTION
## Summary

Two new tiles land directly under the existing Efficiency grade in the Usage tab, answering the two efficiency tactics Uber's CTO named on the Aug 6, 2026 earnings call: **prompt caching** and **default model selection**.

Both tiles derive client-side from the shared `/api/efficiency` cache (`_cmLoadEfficiency`, 60s TTL + in-flight dedup), so:

- **Zero new fetches per tab load** (FLYWHEEL §5 "share, don't duplicate").
- **Cloud-safe by construction**: the existing `cm-cloud-efficiency` interceptor serves `/api/efficiency` from the snapshot, so both cards render identically on app.clawmetry.com without a new interceptor. Hard Gate #1 (cloud parity) satisfied without touching the cloud repo.

Two backend endpoints stay for external API consumers (mobile, `/api/v1`, benchmark tooling):

- `GET /api/efficiency/cache-hit-rate` — hit rate, `$` saved, `$` left on the table (flagged as estimate; cacheable-fraction constant exposed in the payload per §0a rule 5).
- `GET /api/efficiency/routing-advisor` — potential + realised routing savings, node total + `byRuntime` map.

Both reconcile with `/api/efficiency` by construction, honour `?days=` clamping, and never 500.

### What the tiles show

**Cache-Hit tile:**
- current hit rate (color-coded 60% green / 30% amber / else red)
- measured `$` already saved from cached reads
- conservative `$` left on the table (estimate, labelled)

**Routing Advisor tile:**
- total potential `$` monthly savings
- top 5 safe same-provider downgrades (current -> suggested, calls, avg output tokens)
- suggestions come from `providers_pricing.downgrade_model_name` (guarded resolver: never cross-provider, never a bare-family splice that synthesises a non-existent id)

### Verification

- 36/36 tests in `tests/test_efficiency.py` pass (5 new endpoint tests join the existing suite: shape, per-runtime scoping, `?days=` clamp, realised pull, never-500 on store failure).
- Served `static/js/app.js` contains `renderCacheHitRateCard`, `renderRoutingAdvisorCard`, `_cmEffCacheHitShape` — grep-confirmed.
- Rendered `tabs/usage.html` (via Jinja) contains `cache-hit-rate-card` and `routing-advisor-card` — grep-confirmed. FLYWHEEL Hard Gate 4 (No Dead UI) satisfied.

### Why now

Uber's CTO on the Aug 6 earnings call: *"We are nearing the end of the so-called tokenmaxxing era. The next phase will not be characterized by who spends the most tokens, but about how people use them as efficiently as possible."* Adoption of frontier AI tools at Uber quadrupled since January while cost per token trended down, thanks to prompt caching, default model selection, per-engineer visibility, and open-weight experiments.

Every CTO in the S&P 500 heard that quote. This ships the two most CFO-legible answers in Uber's playbook, straight into the Efficiency surface.

## Test plan

- [ ] CI matrix (lint + tests + install-test + sync-test) all green.
- [ ] After merge, cut a `[RELEASE]` PR so PyPI publishes and the cloud can bump.
- [ ] Post-release: bump `clawmetry` pin in `clawmetry-cloud/Dockerfile`, verify a browser screenshot of the Cache-Hit + Routing Advisor tiles on app.clawmetry.com within 5 minutes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)