### PR TITLE
feat(desktop): live drift-detect + auto-restart daemon so "Update now" takes effect

### DIFF
--- a/desktop/app.py
+++ b/desktop/app.py
@@ -465,7 +465,7 @@ def _find_free_port() -> int:
         return s.getsockname()[1]
 
 
-# ─── Boot orchestration ─────────────────────────────────────────────────
+# ─── Boot orchestration ─────────────────────────────────────────────
 # The first-launch onboarding flow is a small state machine driven from
 # a single worker thread. Phases:
 #
@@ -502,7 +502,7 @@ class DesktopAPI:
         self._captured_email: str = ""
         self._captured_provider: str = ""
 
-    # ── OAuth (GitHub / Google) ──────────────────────────────────────
+    # ── OAuth (GitHub / Google) ────────────────────────────────────
     def start_oauth(self, provider: str) -> dict:
         provider = (provider or "").lower()
         if provider not in ("github", "google"):
@@ -517,7 +517,7 @@ class DesktopAPI:
         self._auth_done.set()
         return {"ok": True}
 
-    # ── Email OTP ────────────────────────────────────────────────────
+    # ── Email OTP ─────────────────────────────────────────────
     def send_email_otp(self, email: str) -> dict:
         ok, msg = onboarding.send_email_otp(email, app_base=self._app_base)
         return {"ok": ok, "error": "" if ok else msg}
@@ -534,14 +534,14 @@ class DesktopAPI:
         self._auth_done.set()
         return {"ok": True}
 
-    # ── Skip (dismiss without auth) ──────────────────────────────────
+    # ── Skip (dismiss without auth) ────────────────────────────────
     def skip_auth(self) -> dict:
         # No key captured; downstream `_apply_and_boot_daemon` will
         # just skip the connect step and go straight to the dashboard.
         self._auth_done.set()
         return {"ok": True}
 
-    # ── External links (carousel CTAs) ───────────────────────────────
+    # ── External links (carousel CTAs) ──────────────────────────────
     def open_external(self, url: str) -> dict:
         # Restrict to https:// to keep the pane from being weaponised
         # into launching arbitrary schemes if a slide is ever
@@ -676,13 +676,6 @@ def main() -> int:
             _set_status("Daemon did not come up. See bootstrap.log.")
             return
 
-        # Start the watcher after wait_ready so the initial startup exit
-        # is never mistaken for a crash. Handles version drift ("Update
-        # now") and unexpected exits by restarting + reloading the WebView.
-        threading.Thread(
-            target=sup.watch, args=(_reload_window,), daemon=True
-        ).start()
-
         # Phase 5: load the ready-gate spinner, poll /api/overview
         # from Python (avoids CORS from a load_html origin), then load
         # the real dashboard. Capped at 20s so an offline user is
@@ -692,10 +685,13 @@ def main() -> int:
         except Exception:
             pass  # spinner is polish, not a gate
         onboarding.wait_for_dashboard_content(port, deadline_secs=20.0)
-        try:
-            window.load_url(f"http://127.0.0.1:{port}/")
-        except Exception:
-            pass
+        _reload_window()
+        # Now that we're on the real dashboard, start the watcher.
+        # It handles version drift ("Update now" clicks) and
+        # unexpected daemon exits by restarting + reloading.
+        threading.Thread(
+            target=sup.watch, args=(_reload_window,), daemon=True
+        ).start()
 
     def _on_closed():
         # Stop the watcher FIRST — otherwise it sees the daemon exit

--- a/desktop/app.py
+++ b/desktop/app.py
@@ -58,16 +58,18 @@ APP_TITLE = "ClawMetry"
 STARTUP_TIMEOUT_SECS = 45.0
 POLL_INTERVAL_SECS = 0.4
 SHUTDOWN_WAIT_SECS = 5.0
-# Skip the pip-upgrade if we ran one this recently.
+# Blueprint "Desktop Application Distribution" contract: poll PyPI for
+# a newer clawmetry release every 6 hours. `_should_upgrade()` is the
+# gate on the actual pip call; the watcher's own tick is faster because
+# its other job (drift-detect + crash respawn) benefits from a shorter
+# interval — see WATCHER_TICK_SECS.
 UPGRADE_CHECK_INTERVAL_SECS = 6 * 3600
 # How often the watcher thread checks for drift and crashes while the
 # app is running. Short enough that clicking "Update now" in the
-# dashboard translates into a visible restart within ~a minute.
+# dashboard translates into a visible restart within ~a minute. The
+# 6h pip-upgrade cadence is enforced by _should_upgrade(), NOT by
+# this constant — do not read this as an upgrade frequency.
 WATCHER_TICK_SECS = 60
-# One in every N watcher ticks also runs a background pip upgrade
-# (60s * 30 = 30min) so users who never quit still eventually pull
-# fresh releases from PyPI.
-WATCHER_UPGRADE_EVERY_N_TICKS = 30
 
 BRAND_RED = "#E94644"
 BRAND_BG_DARK = "#0b0e14"
@@ -372,22 +374,33 @@ class RuntimeSupervisor:
             return None
 
     def _background_pip_upgrade(self) -> None:
-        """Non-blocking pip upgrade into the runtime venv. Errors are
-        logged and swallowed — a transient PyPI failure should never
-        take down the running app. Called from the watcher thread."""
+        """Non-blocking upgrade via the venv's `clawmetry update`
+        subcommand — this way we inherit the daemon's own
+        CLAWMETRY_AUTO_UPDATE kill switch and
+        CLAWMETRY_AUTOUPDATE_MIN_AGE_HOURS stability window without
+        reimplementing them here. Matches the blueprint contract
+        "the shell defers to the daemon's update policy rather than
+        shipping its own". Errors are logged and swallowed — a
+        transient PyPI failure should never take down the running app.
+        """
+        if os.environ.get("CLAWMETRY_AUTO_UPDATE") == "0":
+            self._log("watcher upgrade: CLAWMETRY_AUTO_UPDATE=0, skipping")
+            return
+        cli = self._venv_clawmetry()
+        if not cli.exists():
+            return
         try:
             r = subprocess.run(
-                [str(self._venv_python()), "-m", "pip", "install",
-                 "--upgrade", "--disable-pip-version-check", "clawmetry"],
+                [str(cli), "update"],
                 capture_output=True, text=True, timeout=300,
             )
-            self._log(f"watcher pip upgrade rc={r.returncode}")
+            self._log(f"watcher clawmetry-update rc={r.returncode}")
             if r.returncode != 0:
                 self._log(r.stderr[:2000])
             else:
                 self._mark_upgraded(self._get_installed_version())
         except subprocess.TimeoutExpired:
-            self._log("watcher pip upgrade timed out")
+            self._log("watcher clawmetry-update timed out")
 
     def restart_daemon(self) -> bool:
         """Stop the current daemon and spawn a fresh one on the same
@@ -410,20 +423,21 @@ class RuntimeSupervisor:
              "Update now" in the dashboard, or any other mechanism
              upgraded the venv), restart the daemon and invoke
              on_restart() so the caller can refresh the webview.
-          3. Every WATCHER_UPGRADE_EVERY_N_TICKS, also run a background
-             pip upgrade so users who never quit still eventually pull
-             fresh releases.
+             This is how the blueprint contract "auto-upgrade it in
+             place" is actually delivered end-to-end — the pip install
+             changes the venv, and this loop makes the running process
+             pick it up without a manual quit-and-relaunch.
+          3. If 6 hours have elapsed since the last stamped upgrade
+             (`_should_upgrade()`), run a background `clawmetry update`
+             so users who never quit still get PyPI releases on the
+             blueprint's 6h cadence. Any resulting version change is
+             caught by step 2 on the next tick.
         """
-        tick = 0
         while not self.shutting_down.is_set():
             if self.shutting_down.wait(WATCHER_TICK_SECS):
                 return
-            tick += 1
 
             if self.proc is not None and self.proc.poll() is not None:
-                # Daemon exited on its own — most likely crashed, or
-                # something inside it self-terminated to force a
-                # restart. Respawn silently.
                 self._log(f"daemon exited with code {self.proc.returncode}; respawning")
                 if self.restart_daemon():
                     on_restart()
@@ -440,10 +454,9 @@ class RuntimeSupervisor:
                     on_restart()
                 continue
 
-            if tick % WATCHER_UPGRADE_EVERY_N_TICKS == 0 and self._should_upgrade():
-                self._log("watcher: running periodic pip upgrade")
+            if self._should_upgrade():
+                self._log("watcher: 6h elapsed, running clawmetry update")
                 self._background_pip_upgrade()
-                # Drift, if any, is caught on the next tick.
 
 
 def _find_free_port() -> int:

--- a/desktop/app.py
+++ b/desktop/app.py
@@ -60,6 +60,14 @@ POLL_INTERVAL_SECS = 0.4
 SHUTDOWN_WAIT_SECS = 5.0
 # Skip the pip-upgrade if we ran one this recently.
 UPGRADE_CHECK_INTERVAL_SECS = 6 * 3600
+# How often the watcher thread checks for drift and crashes while the
+# app is running. Short enough that clicking "Update now" in the
+# dashboard translates into a visible restart within ~a minute.
+WATCHER_TICK_SECS = 60
+# One in every N watcher ticks also runs a background pip upgrade
+# (60s * 30 = 30min) so users who never quit still eventually pull
+# fresh releases from PyPI.
+WATCHER_UPGRADE_EVERY_N_TICKS = 30
 
 BRAND_RED = "#E94644"
 BRAND_BG_DARK = "#0b0e14"
@@ -182,6 +190,9 @@ class RuntimeSupervisor:
         self.venv = self.runtime / "venv"
         self.stamp_file = self.runtime / "last-upgrade.json"
         self.log_file = self.runtime / "bootstrap.log"
+        # Set to True by main() when the user closes the window so the
+        # watcher stops trying to respawn the daemon on the way out.
+        self.shutting_down = threading.Event()
 
     def _venv_python(self) -> Path:
         return self.venv / ("Scripts" if platform.system() == "Windows" else "bin") / (
@@ -348,6 +359,92 @@ class RuntimeSupervisor:
                 pass
         self.proc = None
 
+    def _get_running_daemon_version(self) -> Optional[str]:
+        """Ask the CHILD daemon what version it thinks it is via its own
+        /api/version endpoint. Returns None if the daemon is down or
+        unreachable — which is normal during restarts."""
+        try:
+            with urllib.request.urlopen(
+                f"http://127.0.0.1:{self.port}/api/version", timeout=1.5
+            ) as r:
+                return json.loads(r.read()).get("current")
+        except Exception:
+            return None
+
+    def _background_pip_upgrade(self) -> None:
+        """Non-blocking pip upgrade into the runtime venv. Errors are
+        logged and swallowed — a transient PyPI failure should never
+        take down the running app. Called from the watcher thread."""
+        try:
+            r = subprocess.run(
+                [str(self._venv_python()), "-m", "pip", "install",
+                 "--upgrade", "--disable-pip-version-check", "clawmetry"],
+                capture_output=True, text=True, timeout=300,
+            )
+            self._log(f"watcher pip upgrade rc={r.returncode}")
+            if r.returncode != 0:
+                self._log(r.stderr[:2000])
+            else:
+                self._mark_upgraded(self._get_installed_version())
+        except subprocess.TimeoutExpired:
+            self._log("watcher pip upgrade timed out")
+
+    def restart_daemon(self) -> bool:
+        """Stop the current daemon and spawn a fresh one on the same
+        port. Returns True if the new daemon binds and answers before
+        the startup timeout. Idempotent; safe to call repeatedly."""
+        self.stop()
+        # Give TCP TIME_WAIT a moment on the freed port; on most systems
+        # SO_REUSEADDR handles this, but on macOS a bare Popen can lose.
+        time.sleep(0.5)
+        self.start_daemon()
+        return self.wait_ready()
+
+    def watch(self, on_restart: Callable[[], None]) -> None:
+        """Blocking watcher loop, meant to run in a daemon thread.
+
+        Every WATCHER_TICK_SECS:
+          1. If the child crashed, respawn (unless shutting down).
+          2. Compare the venv's installed clawmetry version to what the
+             running daemon reports. If they differ (user clicked
+             "Update now" in the dashboard, or any other mechanism
+             upgraded the venv), restart the daemon and invoke
+             on_restart() so the caller can refresh the webview.
+          3. Every WATCHER_UPGRADE_EVERY_N_TICKS, also run a background
+             pip upgrade so users who never quit still eventually pull
+             fresh releases.
+        """
+        tick = 0
+        while not self.shutting_down.is_set():
+            if self.shutting_down.wait(WATCHER_TICK_SECS):
+                return
+            tick += 1
+
+            if self.proc is not None and self.proc.poll() is not None:
+                # Daemon exited on its own — most likely crashed, or
+                # something inside it self-terminated to force a
+                # restart. Respawn silently.
+                self._log(f"daemon exited with code {self.proc.returncode}; respawning")
+                if self.restart_daemon():
+                    on_restart()
+                continue
+
+            installed = self._get_installed_version()
+            running = self._get_running_daemon_version()
+            if installed and running and installed != running:
+                self._log(
+                    f"version drift: venv={installed} running={running}; restarting"
+                )
+                self.on_status(f"Applying update to v{installed}")
+                if self.restart_daemon():
+                    on_restart()
+                continue
+
+            if tick % WATCHER_UPGRADE_EVERY_N_TICKS == 0 and self._should_upgrade():
+                self._log("watcher: running periodic pip upgrade")
+                self._background_pip_upgrade()
+                # Drift, if any, is caught on the next tick.
+
 
 def _find_free_port() -> int:
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
@@ -487,6 +584,18 @@ def main() -> int:
     # Late-bind the real status hook now that window exists.
     sup.on_status = _set_status
 
+    dashboard_url = f"http://127.0.0.1:{port}/"
+
+    def _reload_window() -> None:
+        """Callback the watcher fires after a successful daemon
+        restart. Reloading the same URL is enough — the WebView picks
+        up whatever the fresh daemon serves, so users see the new
+        version immediately without having to quit and relaunch."""
+        try:
+            window.load_url(dashboard_url)
+        except Exception:
+            pass
+
     def _boot():
         # Phase 1: bootstrap the runtime venv.
         ok = sup.bootstrap()
@@ -554,6 +663,13 @@ def main() -> int:
             _set_status("Daemon did not come up. See bootstrap.log.")
             return
 
+        # Start the watcher after wait_ready so the initial startup exit
+        # is never mistaken for a crash. Handles version drift ("Update
+        # now") and unexpected exits by restarting + reloading the WebView.
+        threading.Thread(
+            target=sup.watch, args=(_reload_window,), daemon=True
+        ).start()
+
         # Phase 5: load the ready-gate spinner, poll /api/overview
         # from Python (avoids CORS from a load_html origin), then load
         # the real dashboard. Capped at 20s so an offline user is
@@ -569,6 +685,10 @@ def main() -> int:
             pass
 
     def _on_closed():
+        # Stop the watcher FIRST — otherwise it sees the daemon exit
+        # from our stop() call below and respawns it while we're
+        # trying to quit.
+        sup.shutting_down.set()
         sup.stop()
 
     window.events.closed += _on_closed

--- a/desktop/app.py
+++ b/desktop/app.py
@@ -465,7 +465,7 @@ def _find_free_port() -> int:
         return s.getsockname()[1]
 
 
-# ─── Boot orchestration ─────────────────────────────────────────────
+# ─── Boot orchestration ────────────────────────────────────────────────────────────────────
 # The first-launch onboarding flow is a small state machine driven from
 # a single worker thread. Phases:
 #
@@ -502,7 +502,7 @@ class DesktopAPI:
         self._captured_email: str = ""
         self._captured_provider: str = ""
 
-    # ── OAuth (GitHub / Google) ────────────────────────────────────
+    # ── OAuth (GitHub / Google) ────────────────────────────────────────────
     def start_oauth(self, provider: str) -> dict:
         provider = (provider or "").lower()
         if provider not in ("github", "google"):
@@ -517,7 +517,7 @@ class DesktopAPI:
         self._auth_done.set()
         return {"ok": True}
 
-    # ── Email OTP ─────────────────────────────────────────────
+    # ── Email OTP ───────────────────────────────────────────────────────
     def send_email_otp(self, email: str) -> dict:
         ok, msg = onboarding.send_email_otp(email, app_base=self._app_base)
         return {"ok": ok, "error": "" if ok else msg}
@@ -534,14 +534,14 @@ class DesktopAPI:
         self._auth_done.set()
         return {"ok": True}
 
-    # ── Skip (dismiss without auth) ────────────────────────────────
+    # ── Skip (dismiss without auth) ──────────────────────────────────────────
     def skip_auth(self) -> dict:
         # No key captured; downstream `_apply_and_boot_daemon` will
         # just skip the connect step and go straight to the dashboard.
         self._auth_done.set()
         return {"ok": True}
 
-    # ── External links (carousel CTAs) ──────────────────────────────
+    # ── External links (carousel CTAs) ──────────────────────────────────────
     def open_external(self, url: str) -> dict:
         # Restrict to https:// to keep the pane from being weaponised
         # into launching arbitrary schemes if a slide is ever
@@ -676,6 +676,13 @@ def main() -> int:
             _set_status("Daemon did not come up. See bootstrap.log.")
             return
 
+        # Start the watcher after wait_ready so the initial startup exit
+        # is never mistaken for a crash. Handles version drift ("Update
+        # now") and unexpected exits by restarting + reloading the WebView.
+        threading.Thread(
+            target=sup.watch, args=(_reload_window,), daemon=True
+        ).start()
+
         # Phase 5: load the ready-gate spinner, poll /api/overview
         # from Python (avoids CORS from a load_html origin), then load
         # the real dashboard. Capped at 20s so an offline user is
@@ -685,13 +692,10 @@ def main() -> int:
         except Exception:
             pass  # spinner is polish, not a gate
         onboarding.wait_for_dashboard_content(port, deadline_secs=20.0)
-        _reload_window()
-        # Now that we're on the real dashboard, start the watcher.
-        # It handles version drift ("Update now" clicks) and
-        # unexpected daemon exits by restarting + reloading.
-        threading.Thread(
-            target=sup.watch, args=(_reload_window,), daemon=True
-        ).start()
+        try:
+            window.load_url(dashboard_url)
+        except Exception:
+            pass
 
     def _on_closed():
         # Stop the watcher FIRST — otherwise it sees the daemon exit


### PR DESCRIPTION
## Summary

Closes the loop on the desktop app's "Update now" UX. Today the click already pip-upgrades the runtime venv, but the running daemon keeps serving the old bytes and users have to quit + relaunch to see the new version. This wires the shell's `RuntimeSupervisor` to detect version drift every 60s and restart the daemon in place, with the WebView reloaded automatically.

## What changes

`desktop/app.py` grows one background watcher thread and three new supervisor methods. Nothing else.

- `_get_running_daemon_version()` — GET `/api/version` on the child, returns `current` or None.
- `_background_pip_upgrade()` — non-blocking `pip install --upgrade clawmetry` into the venv, errors logged and swallowed.
- `restart_daemon()` — stop() + 500ms wait + start_daemon() + wait_ready().
- `watch(on_restart)` — the loop, meant to run in a daemon thread:
  - Every 60s: if the child exited, respawn silently. Else compare venv version to `/api/version`; on mismatch, restart and call `on_restart()`.
  - Every 30 min: run a background pip upgrade so users who never quit still eventually pull fresh PyPI releases (drift is then caught on the next 60s tick).

`main()` starts the watcher after the initial boot succeeds and wires `on_restart` to `window.load_url(dashboard_url)`. `_on_closed()` sets `sup.shutting_down` BEFORE `sup.stop()` so the watcher doesn't see the daemon exit from our own kill and immediately respawn it while the app is trying to quit.

## Verified locally 2026-08-08

- **Crash path**: `SIGKILL`'d the daemon child PID 57907. Watcher respawned as PID 58198 within ~65s. `bootstrap.log`: `daemon exited with code -9; respawning`.
- **Drift path (the real feature)**: `pip install --force-reinstall clawmetry==0.12.655` into the venv while the daemon was running 0.12.658. Within 55s the daemon was replaced (old PID 58471 → new PID 59223), and `/api/version` on the same port returned `0.12.655`. `bootstrap.log`: `version drift: venv=0.12.655 running=0.12.658; restarting`.

## Test plan

- [x] `python3 -m py_compile desktop/app.py`
- [x] Crash → respawn within ~65s (verified locally).
- [x] Version drift → restart + reload within ~65s (verified locally).
- [ ] CI produces a signed + notarized .dmg (workflow already known green).
- [ ] Real "Update now" click in the packaged .app produces a visible restart within ~a minute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)