### PR TITLE
fix(desktop-release): actions:write permission + tag-first version selection

### DIFF
--- a/.github/workflows/desktop-artifacts.yml
+++ b/.github/workflows/desktop-artifacts.yml
@@ -90,7 +90,16 @@ jobs:
 
       - name: Wrap into .dmg
         run: |
-          VERSION=$(python3 -c "import re; print(re.search(r'__version__ = \"(.+?)\"', open('dashboard.py').read()).group(1))")
+          # Prefer the tag ref (v0.12.<n> → 0.12.<n>) over dashboard.py's
+          # __version__ because release-on-merge commits the version bump
+          # in a SEPARATE follow-up PR, so at the tag ref dashboard.py is
+          # still stale by one release. Falls back to dashboard.py for
+          # non-tag runs (manual dispatch on main, PR CI).
+          if [ -n "${GITHUB_REF_NAME:-}" ] && [[ "$GITHUB_REF_NAME" == v*.*.* ]]; then
+            VERSION="${GITHUB_REF_NAME#v}"
+          else
+            VERSION=$(python3 -c "import re; print(re.search(r'__version__ = \"(.+?)\"', open('dashboard.py').read()).group(1))")
+          fi
           hdiutil create -volname "ClawMetry" \
             -srcfolder dist/ClawMetry.app \
             -ov -format UDZO \
@@ -133,8 +142,15 @@ jobs:
       - name: Zip distribution folder
         working-directory: dist
         shell: pwsh
+        # Same tag-first version selection as the macOS job — see comment
+        # there. Falls back to dashboard.py __version__ for non-tag runs.
         run: |
-          $version = (Select-String -Path ../dashboard.py -Pattern '__version__ = "(.+?)"').Matches.Groups[1].Value
+          $refName = $Env:GITHUB_REF_NAME
+          if ($refName -and $refName -match '^v\d+\.\d+\.\d+$') {
+            $version = $refName.Substring(1)
+          } else {
+            $version = (Select-String -Path ../dashboard.py -Pattern '__version__ = "(.+?)"').Matches.Groups[1].Value
+          }
           Compress-Archive -Path ClawMetry -DestinationPath "ClawMetry-$version-windows.zip"
 
       - uses: actions/upload-artifact@v4
@@ -169,8 +185,14 @@ jobs:
 
       - name: Tarball distribution folder
         working-directory: dist
+        # Same tag-first version selection as the macOS job — see comment
+        # there. Falls back to dashboard.py __version__ for non-tag runs.
         run: |
-          VERSION=$(python3 -c "import re; print(re.search(r'__version__ = \"(.+?)\"', open('../dashboard.py').read()).group(1))")
+          if [ -n "${GITHUB_REF_NAME:-}" ] && [[ "$GITHUB_REF_NAME" == v*.*.* ]]; then
+            VERSION="${GITHUB_REF_NAME#v}"
+          else
+            VERSION=$(python3 -c "import re; print(re.search(r'__version__ = \"(.+?)\"', open('../dashboard.py').read()).group(1))")
+          fi
           tar czf "clawmetry-${VERSION}-linux-x86_64.tar.gz" clawmetry
 
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/release-on-merge.yml
+++ b/.github/workflows/release-on-merge.yml
@@ -14,6 +14,13 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      # actions: write is required by the "Kick tag-triggered workflows"
+      # step below — without it, `gh workflow run desktop-artifacts.yml`
+      # returns HTTP 403: Resource not accessible by integration. Verified
+      # 2026-08-07 on v0.12.658: dispatch step succeeded (because of `|| echo`)
+      # but silently 403'd, so desktop-artifacts had to be dispatched by hand
+      # to attach the .dmg to the release.
+      actions: write
 
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
Two small follow-ups after v0.12.658 shipped signed .dmgs. **Non-release PR** — no version bump.

## 1. `actions: write` on release-on-merge.yml
The auto-dispatch step I added in #4608 needs `actions: write` on the job's permissions block. Without it, `gh workflow run desktop-artifacts.yml` returns HTTP 403 (Resource not accessible by integration), and the `|| echo` fallback masks the failure. Verified on v0.12.658: the dispatch step "succeeded" but no run appeared — the .dmg only reached the release because I manually re-dispatched.

## 2. Tag-first VERSION selection in desktop-artifacts.yml
The bundles' VERSION was read from `dashboard.py __version__`. At a release tag ref, that's stale by one release (release-on-merge commits the bump in a follow-up PR after cutting the tag). Result: `v0.12.658` release shipped `ClawMetry-0.12.655.dmg` instead of `ClawMetry-0.12.658.dmg`.

Fixed all three OS jobs to prefer `GITHUB_REF_NAME` when it's a `v*.*.*` tag; falls back to `dashboard.py __version__` for manual dispatches and PR CI runs.

## Verified
- Both workflow YAMLs parse locally.
- No behavior change for non-tag runs (dispatch on `main` etc.) — same fallback.

## Test plan
- [ ] Next `[RELEASE]` PR merge: `release-on-merge` auto-dispatches desktop-artifacts without 403
- [ ] Bundles attached to the release are named `ClawMetry-0.12.<n>.dmg` matching the tag, not the pre-bump version

🤖 Generated with [Claude Code](https://claude.com/claude-code)