### PR TITLE
[RELEASE] Ship first end-to-end signed .dmg with onboarding pane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 ## Unreleased
 
+- **Release: first `.dmg` that ships end-to-end signed + notarized + first-launch onboarding.**
+  - **Why:** the desktop bundle capability landed in stages this evening —
+    (a) the thin-shell PyInstaller `.app` (#4602), (b) signing pipeline
+    wiring (#4603), (c) workflow-file syntax fix (#4605), (d) `pyinstaller`
+    marker fix + release-on-merge tag cascade (#4608), (e) `actions: write`
+    permission + tag-derived VERSION (#4612), and (f) the first-launch
+    onboarding pane itself (#4614). Each release since v0.12.658 had one
+    or more of those pieces missing. This release is the first one where
+    the complete chain fires end-to-end from a single `[RELEASE]` merge:
+    PyPI wheel publishes, tag pushes, `desktop-artifacts.yml` auto-fires
+    on the tag (permission fix), macOS PyInstaller finds pyinstaller
+    (marker fix), signs and notarizes both `.app` and `.dmg` (secrets
+    wiring), and attaches everything to the GitHub Release named for the
+    right version (VERSION fix). And when the user opens the `.dmg`, the
+    first-launch onboarding pane runs — GitHub/Google/Email OTP sign-in,
+    auto Pro trial provisioning for entitled accounts, cross-sell
+    carousel during bootstrap, dashboard-content-ready gate — instead
+    of dropping them on an anonymous empty dashboard.
+  - **What:** no new code changes in THIS release — a `[RELEASE]` carrier
+    to fire the full pipeline for the first time end-to-end. The prior
+    `## Unreleased` entries describe the actual changes shipping.
+  - **Verified:** end-to-end verification IS this release. Success bar:
+    (1) `release-on-merge` bumps to `v0.12.<n>` and pushes tag WITHOUT
+    manual intervention, (2) `desktop-artifacts.yml` auto-fires on the
+    tag WITHOUT a manual `gh workflow run`, (3) all three OS jobs green,
+    (4) release attaches `ClawMetry-{correct_version}.dmg` (not stale
+    by one version), (5) `spctl --assess --type open` on the downloaded
+    `.dmg` returns `accepted, source=Notarized Developer ID`, (6) first
+    launch shows the onboarding pane.
+
 - **Feature: desktop app now onboards new users natively — sign-in pane, auto Pro trial, cross-sell carousel, dashboard-content-ready gate.**
   - **Why:** a user who chose the `.dmg` over `pip install` is the highest-intent
     surface we have; the old shell was a passive webview that dropped them on


### PR DESCRIPTION
## Summary
Carrier `[RELEASE]` — no code changes. Fires the full pipeline end-to-end for the first time.

## What lands with this release
- **PyPI**: `clawmetry==0.12.<n>` (routine wheel)
- **GitHub Release**: `ClawMetry-{version}.dmg` (macOS, signed + notarized), `ClawMetry-{version}-windows.zip`, `clawmetry-{version}-linux-x86_64.tar.gz`
- **User-facing new capability on macOS**: first-launch onboarding pane — GitHub/Google/Email OTP sign-in, auto Pro trial for entitled accounts (via `auto_provision_pro`), Ubuntu-installer-style cross-sell carousel during bootstrap, dashboard-content-ready gate before swap

## Verification bar (this release IS the verification)
- [ ] `release-on-merge` bumps to `v0.12.<n>` and pushes tag WITHOUT me touching anything
- [ ] `desktop-artifacts.yml` auto-fires on the tag WITHOUT a manual `gh workflow run` (regression check for #4612's `actions: write` fix)
- [ ] All three OS jobs green
- [ ] Release attaches `ClawMetry-{correct-version}.dmg` — filename must match tag (regression check for #4612's VERSION fix)
- [ ] `spctl --assess --type open` on downloaded `.dmg` returns `accepted, source=Notarized Developer ID`
- [ ] First launch: onboarding pane appears (bootstrap carousel → auth pane → dashboard)

## Trail
- #4602 — thin-shell PyInstaller `.app`
- #4603 — signing pipeline wired (six Apple secrets)
- #4605 — workflow-file syntax (`secrets.*` in `if:`) fix
- #4608 — pyinstaller marker fix + release-on-merge tag cascade
- #4612 — `actions: write` permission + tag-derived VERSION
- #4614 — first-launch onboarding pane
- **THIS** — carrier release; if this ships clean, all six of the above are verified end-to-end for real

🤖 Generated with [Claude Code](https://claude.com/claude-code)