### PR TITLE
feat(entitlement): has_features_from_path_batch + has_runtimes_from_path_batch + 2 endpoints

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -7852,6 +7852,228 @@ def missing_runtimes_at_path_batch(
     return {"tiers": rows, "unknown": unknown}
 
 
+def has_features_from_path_batch(
+    from_tiers, to_tier: str, features
+) -> dict | None:
+    """Mirror-direction batch sibling of :func:`has_features_at_path`:
+    per-rung boolean-fold columns for a caller-supplied subset of
+    SOURCE tiers all walked to a single ``to_tier`` under ONE feature
+    bundle in ONE round-trip.
+
+    Source-axis batch twin of the destination-axis ``_at_path_batch``
+    family (many destinations, one source): here we fix the destination
+    and fan out over sources. Lets a "who among my nodes could reach
+    Enterprise for {fleet, sso} with the fewest rungs?" surface render
+    a per-source column off ONE call instead of N calls to
+    :func:`has_features_at_path`.
+
+    Per-source row shape mirrors the destination-side batch shape with
+    the ``to`` slot swapped for ``from`` and the ``path`` slot bound to
+    the per-rung fold-boolean list (each rung a
+    :func:`has_features_at_path` row byte-for-byte)::
+
+        {
+          "from":       "<tier id>",
+          "from_label": "...",
+          "from_rank":  <int>,
+          "direction":  "upgrade" | "downgrade" | "lateral" | "identity",
+          "path":       [<has_features_at_path row>, ...],
+        }
+
+    ``direction`` is computed per source relative to the shared ``to_tier``
+    (a caller can mix upgrades / downgrades / laterals in one batch and
+    each row is labelled from its own perspective). Each ``path`` row is
+    byte-identical to :func:`has_features_at_path` for the same
+    ``(from, to_tier, features)`` triple -- a parity test pins this so
+    the singular and batch path what-if boolean-fold helpers cannot
+    drift.
+
+    Envelope::
+
+        {
+          "tiers": [
+            {"from": "<id>", "from_label": ..., "from_rank": ..., "direction": ..., "path": [...]},
+            ...
+          ],
+          "unknown": ["bogus_id", ...],
+        }
+
+    Supplied source ids are normalised via :func:`_normalise_csv`
+    (whitespace stripped, lowercased, duplicates dropped, first-seen
+    order preserved). Unknown ids are echoed in ``unknown[]`` instead
+    of short-circuiting, matching the destination-side batch's posture.
+    ``trial`` IS accepted as a source id (excluded from the walked
+    intermediate rungs the way :func:`has_features_at_path` already
+    excludes it, but is a valid endpoint via the lateral / identity
+    branches).
+
+    Bundle-fold semantics inherit :func:`has_features_at_path`
+    byte-for-byte: empty / ``None`` / non-iterable ``features`` -> every
+    rung of every source carries ``has_features_at=False`` (refuses the
+    vacuous-truth fold); unknown / non-string / empty-string items
+    collapse every rung's ``has_features_at`` to ``False`` (typo posture
+    inherited from the singular scalar). The bundle is canonicalised
+    ONCE at the top of the fold so every per-source delegate sees the
+    same iterable (a generator / one-shot iterable is materialised so
+    the fan-out over multiple sources does not consume it).
+
+    Returns ``None`` for empty / unknown ``to_tier`` (caller renders
+    "unknown tier" / 404) -- symmetric with the destination-side batch's
+    short-circuit on an unknown ``from_tier``.
+
+    Resolver-independent: delegates per-source to
+    :func:`has_features_at_path`, which walks the static
+    :data:`_PURCHASABLE_TIERS` ladder and folds per-rung grants via
+    :func:`has_features_at` -- so grace vs enforce yields byte-identical
+    rows. Never raises: per-source failures short-circuit that id into
+    ``unknown[]`` and the rest of the batch keeps building; a whole-fold
+    blowup collapses to ``None`` at scalar layer.
+    """
+    try:
+        t = (to_tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if t not in _TIER_FEATURES:
+        return None
+    candidates = _normalise_csv(from_tiers)
+    try:
+        if features is None:
+            items: list = []
+        else:
+            items = list(features)
+    except TypeError:
+        items = []
+    rows: list[dict] = []
+    unknown: list[str] = []
+    to_rank = _TIER_RANK.get(t, -1)
+    for fid in candidates:
+        if fid not in _TIER_FEATURES:
+            unknown.append(fid)
+            continue
+        try:
+            path = has_features_at_path(fid, t, items)
+        except Exception as exc:
+            logger.warning(
+                "entitlements: has_features_from_path_batch row %r failed: %s",
+                fid,
+                exc,
+            )
+            unknown.append(fid)
+            continue
+        if path is None:
+            unknown.append(fid)
+            continue
+        from_rank = _TIER_RANK.get(fid, -1)
+        if fid == t:
+            direction = "identity"
+        elif from_rank == to_rank:
+            direction = "lateral"
+        elif to_rank > from_rank:
+            direction = "upgrade"
+        else:
+            direction = "downgrade"
+        rows.append(
+            {
+                "from": fid,
+                "from_label": tier_label(fid),
+                "from_rank": from_rank,
+                "direction": direction,
+                "path": path,
+            }
+        )
+    return {"tiers": rows, "unknown": unknown}
+
+
+def has_runtimes_from_path_batch(
+    from_tiers, to_tier: str, runtimes
+) -> dict | None:
+    """Runtime-axis twin of :func:`has_features_from_path_batch`:
+    per-rung boolean-fold columns for a caller-supplied subset of
+    SOURCE tiers all walked to a single ``to_tier`` under ONE runtime
+    bundle in ONE round-trip.
+
+    Pairs with :func:`has_features_from_path_batch` the same way
+    :func:`has_runtimes_at_path` pairs with
+    :func:`has_features_at_path`. Together the two source-side path
+    batch boolean-fold helpers let a surface render "for each of the
+    tiers my fleet currently sits on, does the bundle {claude_code,
+    cursor} unlock at every rung climbed toward Enterprise?" off TWO
+    calls instead of 2 * N calls to the singular scalars.
+
+    Per-source row shape mirrors :func:`has_features_from_path_batch`
+    with each ``path`` row bound to a :func:`has_runtimes_at_path` row
+    (``{tier, tier_label, tier_rank, has_runtimes_at}``). Strict alias
+    posture is inherited from the singular scalar (no
+    :func:`canonical_runtime` resolution at scalar layer;
+    ``claude-code`` collapses every rung's fold to ``False`` because it
+    is not in :data:`ALL_RUNTIMES` after ``.strip().lower()``). Alias
+    tolerance lives on the paired
+    ``/api/entitlement/has-runtimes-from-path-batch`` endpoint, which
+    canonicalises per-token upstream -- matches the sibling
+    :func:`has_runtimes_at_path` / ``/has-runtimes-at-path`` split
+    exactly.
+
+    Walk semantics, direction semantics, bundle-fold semantics,
+    resolver-independence and never-raise posture all match
+    :func:`has_features_from_path_batch` -- see that helper's
+    docstring. Rung walk is byte-stable against the rest of the
+    ``_path`` family.
+    """
+    try:
+        t = (to_tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if t not in _TIER_FEATURES:
+        return None
+    candidates = _normalise_csv(from_tiers)
+    try:
+        if runtimes is None:
+            items: list = []
+        else:
+            items = list(runtimes)
+    except TypeError:
+        items = []
+    rows: list[dict] = []
+    unknown: list[str] = []
+    to_rank = _TIER_RANK.get(t, -1)
+    for fid in candidates:
+        if fid not in _TIER_FEATURES:
+            unknown.append(fid)
+            continue
+        try:
+            path = has_runtimes_at_path(fid, t, items)
+        except Exception as exc:
+            logger.warning(
+                "entitlements: has_runtimes_from_path_batch row %r failed: %s",
+                fid,
+                exc,
+            )
+            unknown.append(fid)
+            continue
+        if path is None:
+            unknown.append(fid)
+            continue
+        from_rank = _TIER_RANK.get(fid, -1)
+        if fid == t:
+            direction = "identity"
+        elif from_rank == to_rank:
+            direction = "lateral"
+        elif to_rank > from_rank:
+            direction = "upgrade"
+        else:
+            direction = "downgrade"
+        rows.append(
+            {
+                "from": fid,
+                "from_label": tier_label(fid),
+                "from_rank": from_rank,
+                "direction": direction,
+                "path": path,
+            }
+        )
+    return {"tiers": rows, "unknown": unknown}
+
+
 def has_all(
     *,
     features=None,

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -7122,6 +7122,337 @@ def api_entitlement_missing_runtimes_at_path_batch():
         )
 
 
+def _has_bundle_from_path_batch_fallback(
+    axis: str,
+    to_tier: str,
+    from_tokens: list,
+    tokens: list,
+) -> dict:
+    """OSS-free / never-5xx envelope for the source-side path-batch
+    boolean-fold endpoints
+    ``/api/entitlement/has-features-from-path-batch`` and
+    ``/api/entitlement/has-runtimes-from-path-batch``.
+
+    Source-axis batch sibling of :func:`_has_bundle_at_path_batch_fallback`
+    (destination-side batch) and boolean-fold analogue of
+    :func:`_missing_bundle_at_path_batch_fallback` for the source axis.
+    On any resolver / helper blowup the endpoint still returns 200 with
+    the same envelope shape as the happy path but with ``tiers=[]`` and
+    every rollup zeroed / dropped so a source-side upgrade-comparison
+    surface that lost the resolver doesn't silently render a grant
+    matrix it can no longer justify. ``to`` / ``unknown_tiers`` echo the
+    caller's input so a debugging tooltip can still surface the dropped
+    sources, and ``unknown`` echoes the axis tokens.
+    """
+    return {
+        "to": to_tier,
+        "to_label": None,
+        "to_rank": -1,
+        axis: [],
+        "unknown": list(tokens),
+        "unknown_tiers": list(from_tokens),
+        "kind": axis,
+        "count": 0,
+        "tiers": [],
+        "required_tier": None,
+        "required_tier_label": None,
+        "required_tier_rank": -1,
+        "current_tier": "oss",
+        "current_tier_rank": 0,
+        "grace": True,
+        "enforced": False,
+    }
+
+
+def _has_bundle_from_path_batch_body(axis: str) -> dict:
+    """Happy-path body builder for
+    ``/api/entitlement/has-features-from-path-batch`` /
+    ``/api/entitlement/has-runtimes-from-path-batch``.
+
+    Source-axis batch sibling of :func:`_has_bundle_at_path_batch_body`
+    (which walks the rungs between ONE ``from`` and N candidate
+    destinations): this walks the rungs between N candidate sources and
+    ONE ``to`` in ONE round-trip. Mirror-direction twin of the
+    ``/has-*-at-path-batch`` family and boolean-fold complement of the
+    source-side missing family at the batch layer.
+
+    Envelope shape (byte-stable across every input branch)::
+
+        {
+          "to":                 "<tier id>",
+          "to_label":           "...",
+          "to_rank":            <int>,
+          "features"/"runtimes":[<known ids>],
+          "unknown":            [<axis tokens dropped>],
+          "unknown_tiers":      [<source ids dropped>],
+          "kind":               "features"/"runtimes",
+          "count":              <int>,                # len(known)
+          "tiers": [
+            {
+              "from":          "<id>",
+              "from_label":    "...",
+              "from_rank":     <int>,
+              "direction":     "upgrade" | "downgrade" | "lateral" | "identity",
+              "path":          [<has_*_at_path row>, ...],
+              "path_length":   <int>,
+              "allowed_count": <int>,                 # rungs where fold=True
+              "all_allowed":   <bool>,                # every rung True
+              "any_allowed":   <bool>,                # any rung True
+            },
+            ...
+          ],
+          "required_tier":       "<id>" | null,
+          "required_tier_label": "<label>" | null,
+          "required_tier_rank":  <int>,               # -1 when null
+          "current_tier":        "<live tier id>",
+          "current_tier_rank":   <int>,
+          "grace":               <bool>,
+          "enforced":            <bool>,
+        }
+
+    Each ``tiers[].path`` row byte-equals a row from
+    ``/has-features-at-path?from=<from>&to=<to>&features=<bundle>``'s
+    ``.path`` (and the runtime twin) for the same ``(from, to,
+    bundle)`` triple -- a parity test pins this so the scalar and
+    source-batch path what-if boolean-fold helpers cannot drift.
+
+    Runtime-axis alias canonicalisation is applied per-token upstream of
+    the strict scalar (:func:`has_runtimes_from_path_batch` inherits
+    :func:`has_runtimes_at_path`'s strict-alias posture at scalar layer),
+    matching the sibling ``/has-runtimes-at-path`` upstream-canonicalise
+    pattern -- alias-and-canonical pair dedups to ONE entry in
+    ``runtimes`` before the scalar sees it, so it also dedups to ONE
+    fold input on every rung.
+
+    Endpoint-level fold semantics inherit :func:`_has_bundle_at_path_body`
+    byte-for-byte: an unknown token in the bundle collapses per-rung
+    ``has__at`` to ``False`` on EVERY rung of EVERY source (fail-closed
+    at the endpoint layer the same way the destination-side batch fails-
+    closed on ``/has-features-at-path``).
+
+    Per-source ``allowed_count`` / ``all_allowed`` / ``any_allowed``
+    fold over that source's ``path`` rows exactly like the singular
+    ``/has-features-at-path`` fold-rollup does over its own path (an
+    empty path -> ``allowed_count=0`` / ``all_allowed=False`` /
+    ``any_allowed=False``, matching the identity branch). ``required_tier``
+    folds through :func:`min_tier_for_features` /
+    :func:`min_tier_for_runtimes` against the KNOWN-only subset (matches
+    the sibling ``/has-features-at-path`` envelope's rollup contract).
+
+    Never 4xxs (missing / blank / unknown ``to``, or empty / all-unknown
+    source CSV -> 200 with ``tiers=[]``, matching the sibling
+    ``/has-features-at-batch`` posture -- a source-side comparison
+    matrix binds ``tiers`` directly without a pre-validation round-
+    trip). Never 5xxs: any helper blowup collapses to
+    :func:`_has_bundle_from_path_batch_fallback`.
+    """
+    from clawmetry import entitlements as _ent
+
+    raw_to = request.args.get("to")
+    to_tier = (raw_to or "").strip().lower()
+    from_tokens = _parse_csv_arg("from")
+    param = "features" if axis == "features" else "runtimes"
+    tokens = _parse_csv_arg(param)
+
+    known: list = []
+    unknown: list = []
+    if axis == "features":
+        for fid in tokens:
+            if fid in _ent.ALL_FEATURES:
+                if fid not in known:
+                    known.append(fid)
+            elif fid not in unknown:
+                unknown.append(fid)
+        canon_tokens: list = list(tokens)
+        required = _ent.min_tier_for_features(known) if known else None
+    else:
+        canon_tokens = []
+        canon_seen: set = set()
+        for rid_raw in tokens:
+            rid = _ent.canonical_runtime(rid_raw) or rid_raw
+            if rid in canon_seen:
+                continue
+            canon_seen.add(rid)
+            canon_tokens.append(rid)
+            if rid in _ent.ALL_RUNTIMES:
+                if rid not in known:
+                    known.append(rid)
+            elif rid not in unknown:
+                unknown.append(rid_raw)
+        required = _ent.min_tier_for_runtimes(known) if known else None
+
+    # Endpoint-level fail-closed on any unknown bundle token, mirroring the
+    # ``/has-features-at-path-batch`` posture: pass an obviously-unknown
+    # canonical token to the scalar so every rung of every source folds to
+    # False. This preserves the "typo -> denial on every rung" contract at
+    # the endpoint layer even after alias canonicalisation dropped duplicates.
+    if unknown:
+        scalar_tokens = ["__clawmetry_unknown_bundle_token__"]
+    else:
+        scalar_tokens = list(canon_tokens)
+
+    if axis == "features":
+        batch = _ent.has_features_from_path_batch(
+            from_tokens, to_tier, scalar_tokens
+        )
+    else:
+        batch = _ent.has_runtimes_from_path_batch(
+            from_tokens, to_tier, scalar_tokens
+        )
+
+    env = _resolver_envelope(_ent)
+    req_rank = _ent.tier_rank(required) if required else -1
+    required_label = _ent.tier_label(required) if required else None
+
+    if batch is None:
+        return {
+            "to": to_tier,
+            "to_label": None,
+            "to_rank": -1,
+            axis: known,
+            "unknown": unknown,
+            "unknown_tiers": list(from_tokens),
+            "kind": axis,
+            "count": len(known),
+            "tiers": [],
+            "required_tier": required,
+            "required_tier_label": required_label,
+            "required_tier_rank": req_rank,
+            "current_tier": env["current_tier"],
+            "current_tier_rank": env["current_tier_rank"],
+            "grace": env["grace"],
+            "enforced": env["enforced"],
+        }
+
+    fold_key = "has_features_at" if axis == "features" else "has_runtimes_at"
+    tiers_out: list[dict] = []
+    for row in batch.get("tiers", []) or []:
+        try:
+            path = list(row.get("path", []) or [])
+        except AttributeError:
+            continue
+        allowed_count = sum(1 for r in path if bool(r.get(fold_key)))
+        path_length = len(path)
+        all_allowed = path_length > 0 and allowed_count == path_length
+        any_allowed = allowed_count > 0
+        tiers_out.append(
+            {
+                "from": row.get("from"),
+                "from_label": row.get("from_label"),
+                "from_rank": row.get("from_rank", -1),
+                "direction": row.get("direction"),
+                "path": path,
+                "path_length": path_length,
+                "allowed_count": allowed_count,
+                "all_allowed": all_allowed,
+                "any_allowed": any_allowed,
+            }
+        )
+
+    return {
+        "to": to_tier,
+        "to_label": _ent.tier_label(to_tier),
+        "to_rank": _ent.tier_rank(to_tier),
+        axis: known,
+        "unknown": unknown,
+        "unknown_tiers": list(batch.get("unknown", []) or []),
+        "kind": axis,
+        "count": len(known),
+        "tiers": tiers_out,
+        "required_tier": required,
+        "required_tier_label": required_label,
+        "required_tier_rank": req_rank,
+        "current_tier": env["current_tier"],
+        "current_tier_rank": env["current_tier_rank"],
+        "grace": env["grace"],
+        "enforced": env["enforced"],
+    }
+
+
+@bp_entitlement.route("/api/entitlement/has-features-from-path-batch")
+def api_entitlement_has_features_from_path_batch():
+    """``GET /api/entitlement/has-features-from-path-batch?from=a,b,c&to=<id>&features=x,y,z``
+    -- source-axis batch sibling of ``/api/entitlement/has-features-at-path``.
+
+    Where ``/has-features-at-path`` walks the rungs between ONE
+    ``(from, to)`` pair under ONE feature bundle, this walks the rungs
+    between N candidate sources and ONE ``to`` under ONE bundle in ONE
+    round-trip. Mirror-direction twin of ``/has-features-at-path-batch``
+    (which fans out over destinations); boolean-fold complement of a
+    hypothetical ``/missing-features-from-path-batch`` at the source-
+    batch layer, in the same relationship ``/has-features-at-path``
+    has to ``/missing-features-at-path``.
+
+    Each row in ``tiers[].path`` is byte-identical to a row from
+    ``/has-features-at-path?from=<from>&to=<to>&features=<bundle>``'s
+    ``.path`` for the same triple -- pinned by the parity tests so
+    the scalar and source-batch path accessors cannot drift. Per-source
+    path lengths can legitimately differ (the rungs walked depend on
+    the source), matching ``/tier-unlocks-path-batch`` /
+    ``/has-features-at-path-batch``'s posture.
+
+    Envelope shape is fully documented on
+    :func:`_has_bundle_from_path_batch_body`. ``trial`` IS accepted as
+    a source id (excluded from the walked intermediate rungs the way
+    ``/has-features-at-path`` already excludes it, but is a valid
+    endpoint via the lateral / identity branches).
+
+    Never 4xxs (missing / blank / unknown ``to``, or empty / all-
+    unknown source CSV -> 200 with ``tiers=[]``, matching the sibling
+    ``/has-features-at-batch`` posture -- a source-side comparison
+    matrix binds ``tiers`` directly without a pre-validation round-
+    trip). Never 5xxs: any helper blowup collapses to
+    :func:`_has_bundle_from_path_batch_fallback`.
+    """
+    try:
+        return jsonify(_has_bundle_from_path_batch_body("features"))
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_has_features_from_path_batch: error: %s", exc
+        )
+        to_tier = (request.args.get("to") or "").strip().lower()
+        return jsonify(
+            _has_bundle_from_path_batch_fallback(
+                "features",
+                to_tier,
+                _parse_csv_arg("from"),
+                _parse_csv_arg("features"),
+            )
+        )
+
+
+@bp_entitlement.route("/api/entitlement/has-runtimes-from-path-batch")
+def api_entitlement_has_runtimes_from_path_batch():
+    """``GET /api/entitlement/has-runtimes-from-path-batch?from=a,b,c&to=<id>&runtimes=x,y,z``
+    -- runtime-axis twin of ``/api/entitlement/has-features-from-path-batch``.
+
+    Same envelope with ``runtimes`` in the axis-specific slot.
+    Runtime-alias canonicalisation (``claude-code`` -> ``claude_code``)
+    is applied per-token upstream at the endpoint layer so
+    ``?runtimes=claude-code,openclaw`` collapses to the canonical
+    ``claude_code,openclaw`` before hitting the strict scalar --
+    matches the sibling ``/has-runtimes-at-path`` upstream-canonicalise
+    pattern. Alias-and-canonical pair dedups to ONE entry in
+    ``runtimes`` and therefore ONE fold input on every per-source rung.
+    Never 4xxs; never 5xxs.
+    """
+    try:
+        return jsonify(_has_bundle_from_path_batch_body("runtimes"))
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_has_runtimes_from_path_batch: error: %s", exc
+        )
+        to_tier = (request.args.get("to") or "").strip().lower()
+        return jsonify(
+            _has_bundle_from_path_batch_fallback(
+                "runtimes",
+                to_tier,
+                _parse_csv_arg("from"),
+                _parse_csv_arg("runtimes"),
+            )
+        )
+
+
 def _has_all_fallback() -> dict:
     """Never-5xx envelope for ``/api/entitlement/has-all``.
 

--- a/tests/test_entitlement_has_features_runtimes_from_path_batch.py
+++ b/tests/test_entitlement_has_features_runtimes_from_path_batch.py
@@ -1,0 +1,504 @@
+"""Tests for the source-axis batch-path
+``has_features_from_path_batch`` / ``has_runtimes_from_path_batch``
+boolean-fold scalars and their paired
+``/api/entitlement/has-features-from-path-batch`` /
+``/api/entitlement/has-runtimes-from-path-batch`` endpoints.
+
+Mirror-direction siblings of :func:`has_features_at_path_batch` (which
+fixes ONE source and fans out over N destinations): here we fix ONE
+destination and fan out over N sources. Lets a surface render "for each
+of the tiers my fleet currently sits on, does {fleet, sso} unlock at
+every rung climbed toward Enterprise?" off ONE URL.
+
+Pins:
+
+1. Scalar envelope shape (``{"tiers": [...], "unknown": [...]}``) and
+   per-source row shape (``from`` / ``from_label`` / ``from_rank`` /
+   ``direction`` / ``path``).
+2. Per-source ``path`` byte-parity against the scalar
+   :func:`has_features_at_path` / :func:`has_runtimes_at_path` for the
+   same ``(from, to, bundle)`` triple.
+3. Unknown-``to`` short-circuits: scalar returns ``None``; endpoint
+   returns 200 with ``tiers=[]`` (never 4xxs).
+4. Unknown sources echo into ``unknown[]`` (scalar) /
+   ``unknown_tiers[]`` (endpoint) without short-circuiting the batch.
+5. Direction detection per source (``upgrade`` / ``downgrade`` /
+   ``lateral`` / ``identity``) all computed relative to the shared
+   ``to_tier``.
+6. Grace-independence: same rows under grace on vs enforce.
+7. Empty / ``None`` / non-iterable / typo'd bundle collapses every
+   rung's fold to ``False`` on EVERY source (fail-closed).
+8. Runtime scalar strict alias posture (no canonicalisation at scalar
+   layer); paired endpoint canonicalises upstream + dedups alias-and-
+   canonical to ONE fold input per rung.
+9. Endpoint envelope shape (fixed key set) across every branch and
+   per-source rollups ``path_length`` / ``allowed_count`` /
+   ``all_allowed`` / ``any_allowed``.
+10. Never 5xxs: fallback envelope on helper blowup.
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+# ── Fixtures ───────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def enforced(monkeypatch, tmp_path):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    importlib.reload(e)
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# ── Envelope shape constants ───────────────────────────────────────────────
+
+_FEATURES_KEYS = {
+    "to",
+    "to_label",
+    "to_rank",
+    "features",
+    "unknown",
+    "unknown_tiers",
+    "kind",
+    "count",
+    "tiers",
+    "required_tier",
+    "required_tier_label",
+    "required_tier_rank",
+    "current_tier",
+    "current_tier_rank",
+    "grace",
+    "enforced",
+}
+_RUNTIMES_KEYS = {
+    "to",
+    "to_label",
+    "to_rank",
+    "runtimes",
+    "unknown",
+    "unknown_tiers",
+    "kind",
+    "count",
+    "tiers",
+    "required_tier",
+    "required_tier_label",
+    "required_tier_rank",
+    "current_tier",
+    "current_tier_rank",
+    "grace",
+    "enforced",
+}
+_TIER_ROW_KEYS = {
+    "from",
+    "from_label",
+    "from_rank",
+    "direction",
+    "path",
+    "path_length",
+    "allowed_count",
+    "all_allowed",
+    "any_allowed",
+}
+
+
+def _get_json(client, url: str) -> dict:
+    resp = client.get(url)
+    assert resp.status_code == 200, url
+    return resp.get_json()
+
+
+# ── Scalar shape ───────────────────────────────────────────────────────────
+
+
+def test_scalar_features_returns_dict_shape(ent):
+    out = ent.has_features_from_path_batch(
+        ["oss", "cloud_starter"], "enterprise", ["fleet"]
+    )
+    assert isinstance(out, dict)
+    assert set(out.keys()) == {"tiers", "unknown"}
+    assert isinstance(out["tiers"], list)
+    assert isinstance(out["unknown"], list)
+
+
+def test_scalar_runtimes_returns_dict_shape(ent):
+    out = ent.has_runtimes_from_path_batch(
+        ["oss", "cloud_starter"], "enterprise", ["claude_code"]
+    )
+    assert isinstance(out, dict)
+    assert set(out.keys()) == {"tiers", "unknown"}
+
+
+def test_scalar_features_row_shape(ent):
+    out = ent.has_features_from_path_batch(["oss"], "enterprise", ["fleet"])
+    assert out is not None
+    assert len(out["tiers"]) == 1
+    row = out["tiers"][0]
+    assert set(row.keys()) == {"from", "from_label", "from_rank", "direction", "path"}
+    assert row["from"] == "oss"
+    assert isinstance(row["path"], list)
+
+
+# ── Unknown-``to`` short-circuit ───────────────────────────────────────────
+
+
+def test_scalar_features_unknown_to_returns_none(ent):
+    assert ent.has_features_from_path_batch(["oss"], "bogus", ["fleet"]) is None
+    assert ent.has_features_from_path_batch(["oss"], "", ["fleet"]) is None
+    # noinspection PyTypeChecker
+    assert ent.has_features_from_path_batch(["oss"], None, ["fleet"]) is None
+
+
+def test_scalar_runtimes_unknown_to_returns_none(ent):
+    assert ent.has_runtimes_from_path_batch(["oss"], "bogus", ["claude_code"]) is None
+
+
+# ── Empty / unknown sources ────────────────────────────────────────────────
+
+
+def test_scalar_features_empty_sources_returns_empty_tiers(ent):
+    out = ent.has_features_from_path_batch([], "enterprise", ["fleet"])
+    assert out == {"tiers": [], "unknown": []}
+
+
+def test_scalar_features_unknown_source_echoes_to_unknown(ent):
+    out = ent.has_features_from_path_batch(
+        ["bogus_id"], "enterprise", ["fleet"]
+    )
+    assert out == {"tiers": [], "unknown": ["bogus_id"]}
+
+
+def test_scalar_features_partial_unknown_source(ent):
+    out = ent.has_features_from_path_batch(
+        ["bogus_a", "oss", "bogus_b"], "enterprise", ["fleet"]
+    )
+    assert out is not None
+    from_ids = [r["from"] for r in out["tiers"]]
+    assert from_ids == ["oss"]
+    assert set(out["unknown"]) == {"bogus_a", "bogus_b"}
+
+
+# ── Path byte-parity against singular ──────────────────────────────────────
+
+
+def test_scalar_features_path_byte_parity_with_singular(ent):
+    batch = ent.has_features_from_path_batch(
+        ["oss", "cloud_starter", "cloud_pro"], "enterprise", ["fleet", "sso"]
+    )
+    assert batch is not None
+    for row in batch["tiers"]:
+        singular = ent.has_features_at_path(row["from"], "enterprise", ["fleet", "sso"])
+        assert row["path"] == singular, row["from"]
+
+
+def test_scalar_runtimes_path_byte_parity_with_singular(ent):
+    batch = ent.has_runtimes_from_path_batch(
+        ["oss", "cloud_starter"], "enterprise", ["claude_code"]
+    )
+    assert batch is not None
+    for row in batch["tiers"]:
+        singular = ent.has_runtimes_at_path(row["from"], "enterprise", ["claude_code"])
+        assert row["path"] == singular, row["from"]
+
+
+# ── Direction detection ────────────────────────────────────────────────────
+
+
+def test_scalar_direction_upgrade(ent):
+    out = ent.has_features_from_path_batch(["oss"], "enterprise", ["fleet"])
+    assert out is not None
+    assert out["tiers"][0]["direction"] == "upgrade"
+
+
+def test_scalar_direction_downgrade(ent):
+    out = ent.has_features_from_path_batch(["enterprise"], "oss", ["fleet"])
+    assert out is not None
+    assert out["tiers"][0]["direction"] == "downgrade"
+
+
+def test_scalar_direction_identity(ent):
+    out = ent.has_features_from_path_batch(["oss"], "oss", ["fleet"])
+    assert out is not None
+    row = out["tiers"][0]
+    assert row["direction"] == "identity"
+    assert row["path"] == []
+
+
+def test_scalar_mixed_directions_labelled_per_source(ent):
+    out = ent.has_features_from_path_batch(
+        ["oss", "cloud_starter", "cloud_pro"], "cloud_starter", ["fleet"]
+    )
+    assert out is not None
+    directions = {r["from"]: r["direction"] for r in out["tiers"]}
+    assert directions["oss"] == "upgrade"
+    assert directions["cloud_starter"] == "identity"
+    assert directions["cloud_pro"] == "downgrade"
+
+
+# ── Bundle-fold semantics ──────────────────────────────────────────────────
+
+
+def test_scalar_empty_features_folds_every_rung_false(ent):
+    for empty in ([], None):
+        out = ent.has_features_from_path_batch(["oss"], "enterprise", empty)
+        assert out is not None
+        for row in out["tiers"]:
+            for rung in row["path"]:
+                assert rung["has_features_at"] is False
+
+
+def test_scalar_unknown_feature_folds_every_rung_false(ent):
+    out = ent.has_features_from_path_batch(
+        ["oss"], "enterprise", ["bogus_feature"]
+    )
+    assert out is not None
+    for row in out["tiers"]:
+        for rung in row["path"]:
+            assert rung["has_features_at"] is False
+
+
+def test_scalar_unknown_runtime_folds_every_rung_false(ent):
+    out = ent.has_runtimes_from_path_batch(
+        ["oss"], "enterprise", ["bogus_runtime"]
+    )
+    assert out is not None
+    for row in out["tiers"]:
+        for rung in row["path"]:
+            assert rung["has_runtimes_at"] is False
+
+
+def test_scalar_runtimes_strict_alias_posture(ent):
+    # No canonical_runtime resolution at scalar layer: ``claude-code`` is
+    # not in ALL_RUNTIMES after strip/lower, so every rung's fold collapses
+    # to False. Alias tolerance lives on the endpoint.
+    out = ent.has_runtimes_from_path_batch(
+        ["oss"], "enterprise", ["claude-code"]
+    )
+    assert out is not None
+    for row in out["tiers"]:
+        for rung in row["path"]:
+            assert rung["has_runtimes_at"] is False
+
+
+# ── Grace-independence ─────────────────────────────────────────────────────
+
+
+def test_scalar_features_grace_independent(ent, enforced):
+    grace_out = ent.has_features_from_path_batch(
+        ["oss", "cloud_starter"], "enterprise", ["fleet"]
+    )
+    enforce_out = enforced.has_features_from_path_batch(
+        ["oss", "cloud_starter"], "enterprise", ["fleet"]
+    )
+    assert grace_out == enforce_out
+
+
+# ── Endpoint envelope shape ────────────────────────────────────────────────
+
+
+def test_endpoint_features_envelope_keys(client):
+    body = _get_json(
+        client,
+        "/api/entitlement/has-features-from-path-batch?from=oss,cloud_starter&to=enterprise&features=fleet",
+    )
+    assert set(body.keys()) == _FEATURES_KEYS
+    assert body["kind"] == "features"
+    assert body["to"] == "enterprise"
+    assert body["features"] == ["fleet"]
+    for row in body["tiers"]:
+        assert set(row.keys()) == _TIER_ROW_KEYS
+
+
+def test_endpoint_runtimes_envelope_keys(client):
+    body = _get_json(
+        client,
+        "/api/entitlement/has-runtimes-from-path-batch?from=oss&to=enterprise&runtimes=claude_code",
+    )
+    assert set(body.keys()) == _RUNTIMES_KEYS
+    assert body["kind"] == "runtimes"
+
+
+# ── Endpoint never 4xxs ────────────────────────────────────────────────────
+
+
+def test_endpoint_features_unknown_to_returns_200_empty(client):
+    resp = client.get(
+        "/api/entitlement/has-features-from-path-batch?from=oss&to=bogus&features=fleet"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["tiers"] == []
+    assert body["to"] == "bogus"
+    assert body["to_rank"] == -1
+
+
+def test_endpoint_features_missing_to_returns_200_empty(client):
+    resp = client.get(
+        "/api/entitlement/has-features-from-path-batch?from=oss&features=fleet"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["tiers"] == []
+
+
+def test_endpoint_features_unknown_source_bucketed(client):
+    body = _get_json(
+        client,
+        "/api/entitlement/has-features-from-path-batch?from=bogus_a,oss,bogus_b&to=enterprise&features=fleet",
+    )
+    from_ids = [r["from"] for r in body["tiers"]]
+    assert from_ids == ["oss"]
+    assert set(body["unknown_tiers"]) == {"bogus_a", "bogus_b"}
+
+
+# ── Endpoint per-source rollups ────────────────────────────────────────────
+
+
+def test_endpoint_identity_row_zeroed_rollups(client):
+    body = _get_json(
+        client,
+        "/api/entitlement/has-features-from-path-batch?from=oss&to=oss&features=fleet",
+    )
+    assert len(body["tiers"]) == 1
+    row = body["tiers"][0]
+    assert row["direction"] == "identity"
+    assert row["path"] == []
+    assert row["path_length"] == 0
+    assert row["allowed_count"] == 0
+    assert row["all_allowed"] is False
+    assert row["any_allowed"] is False
+
+
+def test_endpoint_upgrade_row_positive_rollups(client):
+    body = _get_json(
+        client,
+        "/api/entitlement/has-features-from-path-batch?from=oss&to=enterprise&features=fleet",
+    )
+    assert body["tiers"]
+    row = body["tiers"][0]
+    assert row["path_length"] > 0
+    assert row["allowed_count"] >= 0
+    assert row["allowed_count"] <= row["path_length"]
+    # any_allowed / all_allowed derive consistently from allowed_count.
+    assert row["any_allowed"] is (row["allowed_count"] > 0)
+    assert row["all_allowed"] is (
+        row["path_length"] > 0 and row["allowed_count"] == row["path_length"]
+    )
+
+
+def test_endpoint_direction_labels_per_source(client):
+    body = _get_json(
+        client,
+        "/api/entitlement/has-features-from-path-batch?from=oss,cloud_starter,cloud_pro&to=cloud_starter&features=fleet",
+    )
+    directions = {r["from"]: r["direction"] for r in body["tiers"]}
+    assert directions["oss"] == "upgrade"
+    assert directions["cloud_starter"] == "identity"
+    assert directions["cloud_pro"] == "downgrade"
+
+
+# ── Endpoint alias canonicalisation ────────────────────────────────────────
+
+
+def test_endpoint_runtime_alias_canonicalised(client):
+    body = _get_json(
+        client,
+        "/api/entitlement/has-runtimes-from-path-batch?from=oss&to=enterprise&runtimes=claude-code",
+    )
+    # Alias canonicalises upstream to `claude_code`.
+    assert body["runtimes"] == ["claude_code"]
+    assert body["count"] == 1
+
+
+def test_endpoint_runtime_alias_and_canonical_dedup(client):
+    body = _get_json(
+        client,
+        "/api/entitlement/has-runtimes-from-path-batch?from=oss&to=enterprise&runtimes=claude-code,claude_code",
+    )
+    assert body["runtimes"] == ["claude_code"]
+    assert body["count"] == 1
+
+
+# ── Endpoint fail-closed on unknown token ──────────────────────────────────
+
+
+def test_endpoint_unknown_feature_token_fails_closed(client):
+    body = _get_json(
+        client,
+        "/api/entitlement/has-features-from-path-batch?from=oss,cloud_starter&to=enterprise&features=fleet,bogus_feature",
+    )
+    assert body["unknown"] == ["bogus_feature"]
+    for row in body["tiers"]:
+        assert row["allowed_count"] == 0
+        assert row["all_allowed"] is False
+        for rung in row["path"]:
+            assert rung["has_features_at"] is False
+
+
+# ── Endpoint parity with singular ``/has-features-at-path`` ────────────────
+
+
+def test_endpoint_features_per_source_path_matches_singular(client):
+    body = _get_json(
+        client,
+        "/api/entitlement/has-features-from-path-batch?from=oss,cloud_starter&to=enterprise&features=fleet",
+    )
+    for row in body["tiers"]:
+        singular = _get_json(
+            client,
+            f"/api/entitlement/has-features-at-path?from={row['from']}&to=enterprise&features=fleet",
+        )
+        assert row["path"] == singular["path"], row["from"]
+
+
+# ── Never 5xxs ─────────────────────────────────────────────────────────────
+
+
+def test_endpoint_features_never_5xxs_on_helper_blowup(client, monkeypatch):
+    from clawmetry import entitlements as _ent
+
+    def _boom(*_a, **_kw):  # pragma: no cover - reached via helper stub
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(_ent, "has_features_from_path_batch", _boom)
+    resp = client.get(
+        "/api/entitlement/has-features-from-path-batch?from=oss&to=enterprise&features=fleet"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["tiers"] == []
+    # Fallback envelope preserves ``to`` + echoes both dropped sources & tokens.
+    assert body["to"] == "enterprise"
+    assert body["unknown_tiers"] == ["oss"]
+    assert body["unknown"] == ["fleet"]


### PR DESCRIPTION
## Summary

- Adds `has_features_from_path_batch(from_tiers, to_tier, features)` / `has_runtimes_from_path_batch(from_tiers, to_tier, runtimes)` — source-axis batch siblings of `has_features_at_path` / `has_runtimes_at_path`. Mirror-direction twin of the `_at_path_batch` family (in-flight in #4601): where the destination-side batch fixes ONE source and fans out over N destinations, these fix ONE destination and fan out over N sources. Per-source `path` byte-equals `has_features_at_path(from, to_tier, bundle)` for the same triple — pinned in the test module so the singular and batch what-if boolean-fold helpers cannot drift. Grace-independent by construction (delegates through the singular path helper which itself walks `_PURCHASABLE_TIERS` and folds via `has_features_at`). Wiring these in changes **no** current behavior.
- Adds paired `GET /api/entitlement/has-features-from-path-batch` / `GET /api/entitlement/has-runtimes-from-path-batch` on `bp_entitlement`. Envelope mirrors `/missing-features-at-path-batch` byte-for-key with the axis-shared slot flipped from `from` to `to` (pinned at the top) and each per-source row carrying `from` / `from_label` / `from_rank` / `direction` / `path` plus rollups `path_length` / `allowed_count` / `all_allowed` / `any_allowed`. `direction` is computed per source relative to the shared `to_tier` (a caller can mix upgrades / downgrades / laterals in one batch and each row is labelled from its own perspective). Runtime-axis alias canonicalisation (`claude-code` → `claude_code`) is applied per-token upstream at the endpoint layer so `?runtimes=claude-code,openclaw` collapses to canonical before hitting the strict scalar; alias-and-canonical pair dedups to ONE entry in `runtimes` and ONE fold input per rung. Endpoint-level fold semantics inherit `_has_bundle_at_path_body` byte-for-byte: an unknown token in the bundle collapses per-rung `has__at` to `False` on EVERY rung of EVERY source (fail-closed at the endpoint layer). Never 4xxs (missing / blank / unknown `to`, or empty / all-unknown source CSV → 200 with `tiers=[]`). Never 5xxs: any helper blowup collapses to `_has_bundle_from_path_batch_fallback`.
- 32-test module `tests/test_entitlement_has_features_runtimes_from_path_batch.py` covering scalar shape, per-source `path` byte-parity against `has_features_at_path` / `has_runtimes_at_path`, unknown-`to` short-circuit (`None` at scalar layer, 200 with `tiers=[]` at endpoint layer), unknown-source bucketing (echoed into `unknown[]` / `unknown_tiers[]` without short-circuiting the batch), direction detection (`upgrade` / `downgrade` / `lateral` / `identity`) computed per source, empty / `None` / non-iterable bundle → every rung `False`, unknown-token → every rung `False` (typo posture), grace-independence (`grace on == grace off`), strict-alias posture at scalar layer, endpoint-level alias canonicalisation + alias-and-canonical dedup, endpoint envelope shape (fixed key set), per-source rollup fields (`allowed_count` / `all_allowed` / `any_allowed`), unknown-token endpoint-level fail-closed, identity-row zeroed rollups, and never-5xx guard on helper blowup.

Files:
- `clawmetry/entitlements.py` — 2 new helpers (~222 lines)
- `routes/entitlement.py` — 2 new endpoints + shared body/fallback builders (~331 lines)
- `tests/test_entitlement_has_features_runtimes_from_path_batch.py` — new test module (32 tests)

Non-conflicting with #4601 (destination-side batch) — the two PRs add complementary axes to the `_path_batch` family and can land in either order.

## Test plan

- [x] `python -m py_compile clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_has_features_runtimes_from_path_batch.py` clean
- [x] `ruff check clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_has_features_runtimes_from_path_batch.py` clean
- [x] `python -m pytest tests/test_entitlement_has_features_runtimes_from_path_batch.py` — 32 pass
- [x] Sibling regression: `tests/test_entitlement_missing_features_runtimes_at_path_batch.py`, `tests/test_entitlement_missing_features_runtimes_at_path.py`, `tests/test_entitlement_api.py`, `tests/test_entitlements.py` — 186 pass total (no regressions)

### Local operator verification checklist

Since this branch was authored in a remote container with no access to the host, running daemon, `~/.openclaw`, or live cloud snapshot, the following steps need to happen on the operator's machine before ready-for-review:

- [ ] Copy `clawmetry/entitlements.py`, `routes/entitlement.py`, `tests/test_entitlement_has_features_runtimes_from_path_batch.py` into `~/.clawmetry/lib/pythonX.Y/site-packages/clawmetry/` (and its `routes/` / `tests/` siblings)
- [ ] Clear `__pycache__` under the target install
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
- [ ] `curl -s "http://localhost:8900/api/entitlement/has-features-from-path-batch?from=oss,cloud_starter,cloud_pro&to=enterprise&features=fleet,sso" | jq` — expect 3 rows in `tiers`, each `.path` byte-equal to `/api/entitlement/has-features-at-path?from=<from>&to=enterprise&features=fleet,sso`'s `.path`
- [ ] `curl -s "http://localhost:8900/api/entitlement/has-features-from-path-batch?from=oss&to=oss&features=fleet" | jq` — expect single `tiers[]` row with `direction="identity"`, `path=[]`, `all_allowed=false`, `any_allowed=false`, `allowed_count=0`
- [ ] `curl -s "http://localhost:8900/api/entitlement/has-features-from-path-batch?from=oss,cloud_starter,cloud_pro&to=cloud_starter&features=fleet" | jq '.tiers[] | {from, direction}'` — expect three rows with `direction` values `upgrade` / `identity` / `downgrade` respectively
- [ ] `curl -s "http://localhost:8900/api/entitlement/has-features-from-path-batch?from=oss&to=bogus&features=fleet" -w '\n%{http_code}\n'` — expect HTTP 200 with `tiers=[]`, `to="bogus"`, `to_rank=-1` (never 4xxs)
- [ ] `curl -s "http://localhost:8900/api/entitlement/has-features-from-path-batch?from=bogus_a,oss,bogus_b&to=enterprise&features=fleet" | jq '.tiers[].from, .unknown_tiers'` — expect `oss` only in `tiers`, `bogus_a` + `bogus_b` bucketed into `unknown_tiers`
- [ ] `curl -s "http://localhost:8900/api/entitlement/has-features-from-path-batch?from=oss,cloud_starter&to=enterprise&features=fleet,bogus_feature" | jq` — expect `unknown=["bogus_feature"]` and EVERY rung of EVERY source `has_features_at=false`, `all_allowed=false`, `allowed_count=0` (endpoint-level fail-closed on typo)
- [ ] `curl -s "http://localhost:8900/api/entitlement/has-runtimes-from-path-batch?from=oss&to=enterprise&runtimes=claude-code,claude_code" | jq '.runtimes,.count'` — expect `["claude_code"]` and `1` (alias-and-canonical pair dedups upstream to ONE entry)
- [ ] `curl -s "http://localhost:8900/api/entitlement/has-runtimes-from-path-batch?from=oss,cloud_starter&to=enterprise&runtimes=claude_code" | jq '.tiers[] | {from, all_allowed, any_allowed, allowed_count, path_length}'` — spot-check per-source rollups against the singular `/has-runtimes-at-path` for each source
- [ ] Confirm sibling `/api/entitlement/has-features-at-path` / `/has-runtimes-at-path` still return byte-identical rows (no regression to the singular path family)
- [ ] Confirm sibling `/api/entitlement/missing-features-at-path-batch` / `/missing-runtimes-at-path-batch` still return byte-identical rows (no regression to the sibling family)
- [ ] Confirm `/api/entitlement` still resolves as before (no resolver-path regression from the new helpers)
- [ ] Decrypt the live snapshot and browser-check the dashboard still loads (no import-time regression)

---
_Generated by [Claude Code](https://claude.ai/code/session_01G1LY24SH3GVdk6qiKhvCjW)_