### PR TITLE
feat(health): add /api/_internal/healthz GFE-bypass liveness alias (#3357)

### DIFF
--- a/routes/health.py
+++ b/routes/health.py
@@ -5,6 +5,7 @@ Extracted from dashboard.py as Phase 5.5 of the incremental modularisation.
 Owns the routes registered on bp_health:
 
   GET  /healthz                   — liveness probe (k8s / load-balancer, unauthenticated)
+  GET  /api/_internal/healthz    — same probe at a GFE-bypass path (GFE intercepts bare /healthz on Cloud Run)
   GET  /api/reliability           — cross-session behavioral reliability trend
   GET  /api/heatmap               — activity heatmap (events per hour, N days)
   GET  /api/system-health         — comprehensive system health (services, disks, crons)
@@ -54,6 +55,7 @@ bp_health = Blueprint('health', __name__)
 
 
 @bp_health.route("/healthz")
+@bp_health.route("/api/_internal/healthz")
 def healthz():
     """Kubernetes/load-balancer liveness probe — always returns 200."""
     import dashboard as _d


### PR DESCRIPTION
## Summary

Google Cloud's frontend load balancer (GFE) intercepts the bare `/healthz` path on Cloud Run before the Flask app handles it, causing the production smoke watchdog to receive a GFE-generated 404 instead of Flask's 200. The Flask route is correct and passes unit tests — the GFE layer is the blocker.

This PR adds `/api/_internal/healthz` as a second route decorator on the existing `healthz()` handler. All `/api/*` paths in the smoke run pass through GFE cleanly (confirmed by `/api/auth/check`, `/api/analytics/track`, `/api/ingest/heartbeat` all returning expected status codes). Once deployed, the watchdog can be updated to use `/api/_internal/healthz` without any further infrastructure change.

## Changes

- `routes/health.py` — stack `@bp_health.route("/api/_internal/healthz")` on the existing `healthz()` view function (standard Flask multi-route pattern; handler body unchanged)
- `routes/health.py` module docstring — list the new route alongside `/healthz`

## Test plan

- [ ] `python3 -c 'import ast; ast.parse(open("routes/health.py").read())'` → `syntax OK` ✓ (already verified)
- [ ] Start dev server: `python3 dashboard.py --port 8900`; `curl http://localhost:8900/api/_internal/healthz` → `{"service": "clawmetry", "status": "ok", "version": "..."}` with HTTP 200
- [ ] Verify existing `/healthz` is unaffected: `curl http://localhost:8900/healthz` → same 200 response

## Bot meta
<!-- bot-autofix -->
Draft PR opened autonomously based on the plan in #3357. Marked draft for human review — mark Ready for Review once happy.

After merging: update the smoke watchdog's probe path from `/healthz` to `/api/_internal/healthz` (the watchdog config change is in vivekchand/clawmetry-cloud).

Closes #3357

---
_Generated by [Claude Code](https://claude.ai/code/session_01LE4mcDw8L49HkQjRTEM5NZ)_