### PR TITLE
feat(dashboard): cloud-sync toggle chip in header — one-click pause/resume

### DIFF
--- a/clawmetry/config.py
+++ b/clawmetry/config.py
@@ -152,6 +152,30 @@ def enable_cloud() -> bool:
     return False
 
 
+def disable_cloud() -> bool:
+    """Write the ``~/.clawmetry/nocloud`` marker so the daemon pauses cloud
+    sync on the next iteration. Mirror of :func:`enable_cloud`; used by the
+    dashboard header's sync toggle so users can pause sync without dropping
+    to the CLI. The marker survives updates and daemon restarts.
+
+    Returns True if a marker was newly written; False if one already
+    existed or if the write failed (best-effort, never raises).
+
+    Does NOT alter the ``CLAWMETRY_NO_CLOUD`` env var — that stays whatever
+    the operator set it to. The marker is persistent local state; the env
+    var is per-run/container config; either one activates local-only mode.
+    """
+    try:
+        if os.path.isfile(NOCLOUD_MARKER_PATH):
+            return False
+        os.makedirs(os.path.dirname(NOCLOUD_MARKER_PATH), exist_ok=True)
+        with open(NOCLOUD_MARKER_PATH, "w") as f:
+            f.write("")
+        return True
+    except Exception:
+        return False
+
+
 @dataclass
 class ClawMetryConfig:
     """

--- a/clawmetry/static/js/auth-bootstrap.js
+++ b/clawmetry/static/js/auth-bootstrap.js
@@ -134,6 +134,79 @@ function clawmetryLogout(){
   localStorage.removeItem('clawmetry-token');
   location.reload();
 }
+
+// ── Cloud-sync toggle chip (header, right of alerts bell) ──
+// Cloud sync is included in every ClawMetry plan (Self-Hosted through
+// Enterprise), so pausing it is a one-click UX toggle rather than a
+// billing decision. State reads from /api/cloud-cta/status (already
+// polled by other surfaces); writes go through /api/sync/toggle which
+// flips the ~/.clawmetry/nocloud marker the daemon polls each iteration.
+function _cmRenderSyncChip(state){
+  var el = document.getElementById('sync-toggle-btn');
+  if (!el) return;
+  var label = document.getElementById('sync-toggle-label');
+  var icon = document.getElementById('sync-toggle-icon');
+  // Show the chip only when the machine has an account linked. On a
+  // truly anonymous local-only install (never signed in), there is
+  // nothing to sync TO — showing an inert chip would be a lie.
+  if (!state || !state.account_linked) {
+    el.style.display = 'none';
+    return;
+  }
+  el.style.display = 'flex';
+  if (state.local_only) {
+    label.textContent = 'Local only';
+    el.style.color = 'var(--text-muted, #94a3b8)';
+    el.title = 'Cloud sync paused. Click to resume.';
+  } else if (state.connected) {
+    label.textContent = 'Synced';
+    el.style.color = 'var(--accent, #4ade80)';
+    el.title = 'Cloud sync active. Click to pause.';
+  } else {
+    // Account linked but not connected (e.g. transient) — still show
+    // as clickable, and let the toggle-endpoint's error message steer
+    // the user to the right recovery flow.
+    label.textContent = 'Sync';
+    el.style.color = 'var(--text-tertiary, #cbd5e1)';
+    el.title = 'Cloud sync status.';
+  }
+}
+function _cmRefreshSyncChip(){
+  fetch('/api/cloud-cta/status')
+    .then(function(r){ return r.ok ? r.json() : null; })
+    .then(_cmRenderSyncChip)
+    .catch(function(){ /* offline — leave chip as-is */ });
+}
+function clawmetryToggleSync(){
+  var el = document.getElementById('sync-toggle-btn');
+  if (el) el.style.pointerEvents = 'none';
+  fetch('/api/sync/toggle', {method:'POST'})
+    .then(function(r){
+      // 409 == no_account or env_locked — surface a small toast instead
+      // of silently failing. Fall through to refresh either way.
+      if (r.status === 409) {
+        return r.json().then(function(d){
+          try { alert(d && d.detail ? d.detail : 'Cloud sync toggle not available.'); } catch(e) {}
+          return null;
+        });
+      }
+      return r.ok ? r.json() : null;
+    })
+    .then(function(_res){ _cmRefreshSyncChip(); })
+    .catch(function(){ _cmRefreshSyncChip(); })
+    .finally(function(){
+      var e = document.getElementById('sync-toggle-btn');
+      if (e) e.style.pointerEvents = '';
+    });
+}
+// Poll on load + on tab focus (so returning from a sign-in tab
+// picks up the new account-linked state).
+document.addEventListener('DOMContentLoaded', function(){
+  setTimeout(_cmRefreshSyncChip, 400);
+});
+window.addEventListener('focus', function(){
+  _cmRefreshSyncChip();
+});
 // One-click sign-in on the machine itself after an explicit sign-out. The
 // button is hidden unless the loopback-only detected-token probe answered,
 // so this is the same trust boundary as zero-click auto-login — just gated

--- a/dashboard.py
+++ b/dashboard.py
@@ -12312,6 +12312,16 @@ DASHBOARD_HTML = r"""
   </div>
   <div class="theme-toggle" id="alerts-bell-btn" onclick="switchTab('alerts')" data-i18n-title="topbar.active_alerts" title="Active alerts" style="cursor:pointer;position:relative;"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"/><path d="M13.73 21a2 2 0 0 1-3.46 0"/></svg><span id="alerts-bell-badge" style="display:none;position:absolute;top:-4px;right:-4px;background:#ef4444;color:#fff;border-radius:10px;padding:0 4px;font-size:9px;font-weight:700;min-width:14px;line-height:14px;text-align:center;">0</span></div>
 
+  <!-- Cloud sync toggle chip. Included in every ClawMetry plan (Self-Hosted
+       through Enterprise), so it's a one-click UX toggle here rather than a
+       plan-tier decision. Hidden until the initial /api/cloud-cta/status
+       poll resolves so it doesn't flash the wrong state on first paint.
+       Refresh cadence: on load, on click, and after any focus event. -->
+  <div class="theme-toggle" id="sync-toggle-btn" onclick="clawmetryToggleSync()" title="Cloud sync" style="display:none;cursor:pointer;padding:6px 10px;gap:6px;align-items:center;">
+    <svg id="sync-toggle-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M17.5 19H9a7 7 0 1 1 6.71-9"/><polyline points="17 5 21 5 21 9"/></svg>
+    <span id="sync-toggle-label" style="font-size:11px;font-weight:600;letter-spacing:0.2px;">Sync</span>
+  </div>
+
   <div class="theme-toggle" id="logout-btn" onclick="clawmetryLogout()" data-i18n-title="topbar.logout" title="Logout" style="display:none;cursor:pointer;"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"/><polyline points="16 17 21 12 16 7"/><line x1="21" y1="12" x2="9" y2="12"/></svg></div>
   <div class="i18n-switcher" id="i18n-switcher" style="position:relative;">
     <div id="i18n-switcher-btn" onclick="i18nToggleMenu(event)" data-i18n-title="i18n.language" title="Language" style="cursor:pointer;display:flex;align-items:center;gap:6px;border:1px solid var(--border-color,rgba(255,255,255,0.22));border-radius:8px;padding:7px 10px;color:var(--text-tertiary,#cbd5e1);background:var(--button-bg,transparent);transition:all 0.15s;" onmouseover="this.style.background='rgba(127,127,127,0.12)'" onmouseout="this.style.background='var(--button-bg,transparent)'">

--- a/routes/overview.py
+++ b/routes/overview.py
@@ -1697,6 +1697,64 @@ def cloud_cta_status():
     })
 
 
+@bp_overview.route("/api/sync/toggle", methods=["POST"])
+def sync_toggle():
+    """Flip cloud sync on/off from the dashboard header chip.
+
+    Reads current state via ``is_cloud_disabled()`` and either calls
+    ``enable_cloud()`` (removes ``~/.clawmetry/nocloud``) or
+    ``disable_cloud()`` (writes it), then returns the new state. The
+    sync daemon polls the marker on each iteration, so the toggle takes
+    effect within seconds — no restart required.
+
+    Returns 409 when the user has no cm_ key on this machine and asks
+    to enable sync: without an account there is nothing to push to. The
+    dashboard should redirect them through the "Enable Cloud Sync" CTA
+    (cloud-cta/oauth-start) instead of silently no-opping.
+
+    Also refuses when ``CLAWMETRY_NO_CLOUD=1`` is set in the environment
+    — that's an explicit per-run opt-out the operator chose; the chip
+    can't override it, only the operator can (unset the env + relaunch).
+    """
+    import os as _os
+    import dashboard as _d
+    from clawmetry.config import (
+        is_cloud_disabled, enable_cloud, disable_cloud,
+        _NO_CLOUD_ENABLE_VALUES,
+    )
+
+    env_flag = _os.environ.get("CLAWMETRY_NO_CLOUD", "").strip().lower()
+    if env_flag in _NO_CLOUD_ENABLE_VALUES:
+        return jsonify({
+            "ok": False,
+            "error": "env_locked",
+            "detail": "CLAWMETRY_NO_CLOUD=1 is set in the environment; unset it and relaunch to change this from the UI.",
+        }), 409
+
+    currently_disabled = is_cloud_disabled()
+    want_enable = currently_disabled  # if disabled, toggle -> enable, and vice versa
+
+    if want_enable:
+        # Enabling: refuse if there is no account key on this machine.
+        token = _d._read_cloud_token()
+        if not token:
+            return jsonify({
+                "ok": False,
+                "error": "no_account",
+                "detail": "No cloud account linked. Sign in first via the 'Enable Cloud Sync' CTA.",
+            }), 409
+        enable_cloud()
+    else:
+        disable_cloud()
+
+    new_disabled = is_cloud_disabled()
+    return jsonify({
+        "ok": True,
+        "local_only": new_disabled,
+        "connected": (not new_disabled) and bool(_d._read_cloud_token()),
+    })
+
+
 @bp_overview.route(
     "/api/cloud-proxy/<path:cloud_path>",
     methods=["GET", "POST", "PUT", "PATCH", "DELETE"],


### PR DESCRIPTION
Closes a follow-up explicitly deferred in #4614: the header toggle to enable/disable cloud sync. User's design spec: *"at top right they can click to enable/disable cloud sync — because it's included as part of self-hosted price."*

## What ships

**Backend**
- `clawmetry/config.py`: new `disable_cloud()` mirror of `enable_cloud()`. Writes `~/.clawmetry/nocloud` (the marker the daemon polls each iteration). Idempotent, best-effort, never raises.
- `routes/overview.py`: `POST /api/sync/toggle` — flips state based on current `is_cloud_disabled()`. Refuses with 409 when:
  - the machine has no cloud account (nothing to sync to → `error: no_account`)
  - `CLAWMETRY_NO_CLOUD=1` is set in env (explicit per-run opt-out → `error: env_locked`)

**Frontend**
- `dashboard.py`: chip inserted in the header between the alerts bell and logout button. Hidden by default; JS reveals when `/api/cloud-cta/status` reports `account_linked`.
- `clawmetry/static/js/auth-bootstrap.js`: `clawmetryToggleSync()` handler, `_cmRefreshSyncChip()` state renderer. Polls on `DOMContentLoaded` and on window focus (returning from a sign-in tab picks up the new account-linked state).

## Chip states

| State | Label | Color | Title |
|---|---|---|---|
| account_linked && connected | Synced | accent (green) | "Click to pause" |
| account_linked && local_only | Local only | muted | "Click to resume" |
| !account_linked | hidden | — | — |

## Verified

- `clawmetry/config.py` unit test in isolated HOME: `disable_cloud()` writes marker; `enable_cloud()` removes it; both idempotent (return False when a no-op); `CLAWMETRY_NO_CLOUD=1` env still wins over marker state.
- `dashboard.py` + `routes/overview.py` parse.
- No new dependencies.

## Test plan
- [ ] CI green
- [ ] After next `[RELEASE]`: dashboard header shows the chip only for machines that have signed in; clicking flips between "Synced" and "Local only" within a few seconds (daemon poll cadence)

🤖 Generated with [Claude Code](https://claude.com/claude-code)