### PR TITLE
feat(entitlement): tier_unlocks_from_path_batch + tier_locks_from_path_batch + 2 endpoints

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -20738,6 +20738,211 @@ def tier_locks_path_batch(
     return {"tiers": rows, "unknown": unknown}
 
 
+def tier_unlocks_from_path_batch(
+    from_tiers, to_tier: str
+) -> dict | None:
+    """Mirror-direction batch sibling of :func:`tier_unlocks_path`:
+    per-rung marginal-unlocks rows for a caller-supplied subset of
+    SOURCE tiers all walked to a single ``to_tier`` in ONE round-trip.
+
+    Source-axis batch twin of :func:`tier_unlocks_path_batch` (many
+    destinations, one source): here we fix the destination and fan out
+    over sources. Lets a "which of my nodes could climb to Enterprise
+    with the fewest new grants along the way?" surface render a per-
+    source column off ONE call instead of N calls to
+    :func:`tier_unlocks_path`. Same relationship
+    :func:`has_features_from_path_batch` has to
+    :func:`has_features_at_path_batch`.
+
+    Per-source row shape mirrors the destination-side batch shape with
+    the ``to`` slot swapped for ``from``::
+
+        {
+          "from":       "<tier id>",
+          "from_label": "...",
+          "from_rank":  <int>,
+          "direction":  "upgrade" | "downgrade" | "lateral" | "identity",
+          "path":       [<tier_unlocks_path row>, ...],
+        }
+
+    ``direction`` is computed per source relative to the shared
+    ``to_tier`` (a caller can mix upgrades / downgrades / laterals in
+    one batch and each row is labelled from its own perspective). Each
+    ``path`` row is byte-identical to a row from
+    :func:`tier_unlocks_path` for the same ``(from, to_tier)`` pair --
+    a parity test pins this so the scalar and source-batch path
+    helpers cannot drift.
+
+    Envelope::
+
+        {
+          "tiers": [
+            {"from": "<id>", "from_label": ..., "from_rank": ..., "direction": ..., "path": [...]},
+            ...
+          ],
+          "unknown": ["bogus_id", ...],
+        }
+
+    Supplied source ids are normalised via :func:`_normalise_csv`
+    (whitespace stripped, lowercased, duplicates dropped, first-seen
+    order preserved). Unknown ids are echoed in ``unknown[]`` instead
+    of short-circuiting, matching the destination-side batch's posture
+    and the sibling :func:`has_features_from_path_batch`. ``trial``
+    IS accepted as a source id (excluded from the walked intermediate
+    rungs the way :func:`tier_unlocks_path` already excludes it, but
+    is a valid endpoint via the lateral / identity branches).
+
+    Returns ``None`` for empty / unknown ``to_tier`` (caller renders
+    "unknown tier" / 404) -- symmetric with the destination-side
+    batch's short-circuit on an unknown ``from_tier``.
+
+    Resolver-independent: delegates per-source to
+    :func:`tier_unlocks_path`, which walks the static
+    :data:`_PURCHASABLE_TIERS` ladder and folds per-rung marginal
+    grants via :func:`_unlocks_row` -- so grace vs enforce yields
+    byte-identical rows. Never raises: per-source failures short-
+    circuit that id into ``unknown[]`` and the rest of the batch keeps
+    building; a whole-fold blowup collapses to ``None`` at scalar
+    layer.
+    """
+    try:
+        t = (to_tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if t not in _TIER_FEATURES:
+        return None
+    candidates = _normalise_csv(from_tiers)
+    rows: list[dict] = []
+    unknown: list[str] = []
+    to_rank = _TIER_RANK.get(t, -1)
+    for fid in candidates:
+        if fid not in _TIER_FEATURES:
+            unknown.append(fid)
+            continue
+        try:
+            path = tier_unlocks_path(fid, t)
+        except Exception as exc:
+            logger.warning(
+                "entitlements: tier_unlocks_from_path_batch row %r failed: %s",
+                fid,
+                exc,
+            )
+            unknown.append(fid)
+            continue
+        if path is None:
+            unknown.append(fid)
+            continue
+        from_rank = _TIER_RANK.get(fid, -1)
+        if fid == t:
+            direction = "identity"
+        elif from_rank == to_rank:
+            direction = "lateral"
+        elif to_rank > from_rank:
+            direction = "upgrade"
+        else:
+            direction = "downgrade"
+        rows.append(
+            {
+                "from": fid,
+                "from_label": tier_label(fid),
+                "from_rank": from_rank,
+                "direction": direction,
+                "path": path,
+            }
+        )
+    return {"tiers": rows, "unknown": unknown}
+
+
+def tier_locks_from_path_batch(
+    from_tiers, to_tier: str
+) -> dict | None:
+    """Marginal-loss mirror of :func:`tier_unlocks_from_path_batch`:
+    per-rung marginal-locks rows for a caller-supplied subset of
+    SOURCE tiers all walked to a single ``to_tier`` in ONE round-trip.
+
+    Source-axis batch twin of :func:`tier_locks_path_batch` (many
+    destinations, one source): here we fix the destination and fan out
+    over sources. Lets a downgrade-walkthrough "which of my nodes
+    would lose the most if we consolidated to Cloud Starter?" surface
+    render a per-source column off ONE call instead of N calls to
+    :func:`tier_locks_path`.
+
+    Per-source row shape mirrors :func:`tier_unlocks_from_path_batch`
+    with each ``path`` row bound to a :func:`tier_locks_path` row::
+
+        {
+          "from":       "<tier id>",
+          "from_label": "...",
+          "from_rank":  <int>,
+          "direction":  "upgrade" | "downgrade" | "lateral" | "identity",
+          "path":       [<tier_locks_path row>, ...],
+        }
+
+    ``direction`` is computed per source relative to the shared
+    ``to_tier`` -- a caller can mix directions in one batch and each
+    row is labelled from its own perspective. Each ``path`` row is
+    byte-identical to a row from :func:`tier_locks_path` for the same
+    ``(from, to_tier)`` pair -- a parity test pins this so the scalar
+    and source-batch path helpers cannot drift.
+
+    Envelope / normalisation / unknown-bucketing / ``trial`` posture
+    all match :func:`tier_unlocks_from_path_batch` byte-for-byte --
+    see that helper's docstring.
+
+    Returns ``None`` for empty / unknown ``to_tier``. Resolver-
+    independent: delegates per-source to :func:`tier_locks_path`,
+    which walks the static :data:`_PURCHASABLE_TIERS` ladder and folds
+    per-rung marginal losses via :func:`_locks_row` -- so grace vs
+    enforce yields byte-identical rows. Never raises.
+    """
+    try:
+        t = (to_tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if t not in _TIER_FEATURES:
+        return None
+    candidates = _normalise_csv(from_tiers)
+    rows: list[dict] = []
+    unknown: list[str] = []
+    to_rank = _TIER_RANK.get(t, -1)
+    for fid in candidates:
+        if fid not in _TIER_FEATURES:
+            unknown.append(fid)
+            continue
+        try:
+            path = tier_locks_path(fid, t)
+        except Exception as exc:
+            logger.warning(
+                "entitlements: tier_locks_from_path_batch row %r failed: %s",
+                fid,
+                exc,
+            )
+            unknown.append(fid)
+            continue
+        if path is None:
+            unknown.append(fid)
+            continue
+        from_rank = _TIER_RANK.get(fid, -1)
+        if fid == t:
+            direction = "identity"
+        elif from_rank == to_rank:
+            direction = "lateral"
+        elif to_rank > from_rank:
+            direction = "upgrade"
+        else:
+            direction = "downgrade"
+        rows.append(
+            {
+                "from": fid,
+                "from_label": tier_label(fid),
+                "from_rank": from_rank,
+                "direction": direction,
+                "path": path,
+            }
+        )
+    return {"tiers": rows, "unknown": unknown}
+
+
 def preview_path_batch(from_tier: str, to_tiers) -> dict | None:
     """Batch sibling of :func:`preview_path`: per-rung cumulative
     ``Entitlement.to_dict`` snapshots for a caller-supplied subset of

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -28100,6 +28100,181 @@ def api_entitlement_tier_locks_path_batch():
 
 
 
+@bp_entitlement.route("/api/entitlement/tier-unlocks-from-path-batch")
+def api_entitlement_tier_unlocks_from_path_batch():
+    """``GET /api/entitlement/tier-unlocks-from-path-batch?from=a,b,c&to=<id>``
+    -- source-axis batch sibling of ``/api/entitlement/tier-unlocks-path``.
+
+    Where ``/tier-unlocks-path`` walks the rungs between ONE
+    ``(from, to)`` pair, this walks the rungs between N candidate
+    sources and ONE ``to`` in ONE round-trip. Mirror-direction twin of
+    ``/tier-unlocks-path-batch`` (which fans out over destinations);
+    marginal-grant source-batch companion of
+    ``/tier-locks-from-path-batch`` (locks) and same relationship
+    ``/has-features-from-path-batch`` has to
+    ``/has-features-at-path-batch``.
+
+    Use case: a fleet-view "for each of the tiers my nodes currently
+    sit on, show me the newly-unlocked features + runtimes at every
+    rung climbed to reach Enterprise" surface hydrates the per-rung
+    marginal unlocks for every source off ONE call instead of N calls
+    to ``/tier-unlocks-path``. Same-rank siblings strictly between
+    each ``(from, to)`` pair are included in each per-source path;
+    same-rank siblings of the shared ``to`` are excluded so each per-
+    source path terminates exactly at ``to``. Per-source path lengths
+    can legitimately differ (the rungs walked depend on the source),
+    matching ``/tier-unlocks-path-batch`` /
+    ``/has-features-from-path-batch``'s posture.
+
+    Each row in ``tiers[].path`` is byte-identical to a row from
+    ``/tier-unlocks-path?from=<from>&to=<to>`` -- pinned by parity
+    tests so the scalar and source-batch path accessors cannot drift.
+    Supplied source ids are normalised (whitespace stripped,
+    lowercased, duplicates dropped, first-seen order preserved).
+    Unknown ids do not 404 the call -- they are echoed in
+    ``unknown[]`` so a partially-bad caller still gets paths back for
+    the valid ids.
+
+    Response shape::
+
+        {
+          "to":       "<tier id>",
+          "to_label": "...",
+          "to_rank":  <int>,
+          "tiers": [
+            {
+              "from":       "<tier id>",
+              "from_label": "...",
+              "from_rank":  <int>,
+              "direction":  "upgrade" | "downgrade" | "lateral" | "identity",
+              "path":       [<tier-unlocks row>, ...],
+            },
+            ...
+          ],
+          "unknown":  ["bogus_id", ...],
+        }
+
+    - **400** when ``to=`` is missing / blank, or ``from=`` is missing
+      / empty after normalisation
+    - **404** when ``to`` is unknown (body carries ``which: "tier"``)
+    - **200** with bucketed unknowns for unknown source ids -- does
+      NOT 404 the call, matching every other batch sibling
+    - **Never 5xxs**: a synthesis failure short-circuits to an
+      envelope with empty rows so the matrix keeps rendering.
+    """
+    t = (request.args.get("to") or "").strip().lower()
+    if not t:
+        return jsonify({"error": "missing to"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        if t not in _ent._TIER_ORDER:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "tier", "tier": t}
+                ),
+                404,
+            )
+        sources = _parse_csv_arg("from")
+        if not sources:
+            return jsonify({"error": "supply from=<csv>"}), 400
+        batch = _ent.tier_unlocks_from_path_batch(sources, t)
+        if batch is None:
+            batch = {"tiers": [], "unknown": []}
+        return jsonify(
+            {
+                "to": t,
+                "to_label": _ent.tier_label(t),
+                "to_rank": _ent.tier_rank(t),
+                "tiers": batch.get("tiers", []),
+                "unknown": batch.get("unknown", []),
+            }
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_tier_unlocks_from_path_batch: error: %s", exc
+        )
+        return jsonify(
+            {
+                "to": t,
+                "to_label": None,
+                "to_rank": -1,
+                "tiers": [],
+                "unknown": [],
+            }
+        )
+
+
+@bp_entitlement.route("/api/entitlement/tier-locks-from-path-batch")
+def api_entitlement_tier_locks_from_path_batch():
+    """``GET /api/entitlement/tier-locks-from-path-batch?from=a,b,c&to=<id>``
+    -- source-axis batch sibling of ``/api/entitlement/tier-locks-path``.
+
+    Marginal-loss mirror of ``/tier-unlocks-from-path-batch`` (same
+    source-batch axis, per-rung locks body instead of unlocks body)
+    and source-axis twin of ``/tier-locks-path-batch`` (which fans
+    over destinations). Same envelope, same per-source row shape, same
+    unknown-bucketing posture as ``/tier-unlocks-from-path-batch`` --
+    only the inner ``path`` list changes body.
+
+    Use case: a fleet-consolidation "for each tier a node might drop
+    to, show me the losses at every rung walked down from where each
+    node currently sits" surface hydrates the per-rung marginal losses
+    for every source off ONE call instead of N calls to
+    ``/tier-locks-path``.
+
+    Each row in ``tiers[].path`` is byte-identical to a row from
+    ``/tier-locks-path?from=<from>&to=<to>`` -- pinned by parity tests
+    so the scalar and source-batch path accessors cannot drift.
+
+    Response shape mirrors ``/tier-unlocks-from-path-batch`` with the
+    per-rung body swapped for tier-locks rows. Never 4xxs / 5xxs
+    beyond the same short-circuit set (missing / unknown ``to`` ->
+    400 / 404; helper blowup -> 200 with empty rows).
+    """
+    t = (request.args.get("to") or "").strip().lower()
+    if not t:
+        return jsonify({"error": "missing to"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        if t not in _ent._TIER_ORDER:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "tier", "tier": t}
+                ),
+                404,
+            )
+        sources = _parse_csv_arg("from")
+        if not sources:
+            return jsonify({"error": "supply from=<csv>"}), 400
+        batch = _ent.tier_locks_from_path_batch(sources, t)
+        if batch is None:
+            batch = {"tiers": [], "unknown": []}
+        return jsonify(
+            {
+                "to": t,
+                "to_label": _ent.tier_label(t),
+                "to_rank": _ent.tier_rank(t),
+                "tiers": batch.get("tiers", []),
+                "unknown": batch.get("unknown", []),
+            }
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_tier_locks_from_path_batch: error: %s", exc
+        )
+        return jsonify(
+            {
+                "to": t,
+                "to_label": None,
+                "to_rank": -1,
+                "tiers": [],
+                "unknown": [],
+            }
+        )
+
+
 @bp_entitlement.route("/api/entitlement/tier-path-batch")
 def api_entitlement_tier_path_batch():
     """``GET /api/entitlement/tier-path-batch?from=<id>&to=a,b,c`` --

--- a/tests/test_entitlement_tier_unlocks_locks_from_path_batch.py
+++ b/tests/test_entitlement_tier_unlocks_locks_from_path_batch.py
@@ -1,0 +1,541 @@
+"""Tests for ``tier_unlocks_from_path_batch(from_tiers, to)`` /
+``tier_locks_from_path_batch(from_tiers, to)`` plus their HTTP endpoints.
+
+Mirror-direction siblings of ``tier_unlocks_path_batch`` /
+``tier_locks_path_batch`` (which fix ONE source and fan out over N
+destinations): here we fix ONE destination and fan out over N sources.
+Source-axis batch cousins of ``has_features_from_path_batch`` /
+``has_runtimes_from_path_batch``.
+
+Each per-source ``path`` must be byte-identical to the matching scalar
+``tier_unlocks_path`` / ``tier_locks_path`` payload for the same
+``(from, to)`` pair -- pinned by the parity tests below so the scalar
+and source-batch path helpers cannot drift.
+
+Coverage:
+
+* per-source ``path`` byte-equal to the scalar path helper's payload
+* per-source ``direction`` computed from tier ranks relative to the
+  shared ``to`` (upgrade / downgrade / lateral / identity)
+* helper envelope (``tiers`` + ``unknown``) and per-row shape
+  (``from`` / ``from_label`` / ``from_rank`` / ``direction`` / ``path``)
+* HTTP envelope (``to`` / ``to_label`` / ``to_rank`` + ``tiers`` +
+  ``unknown``)
+* input normalised (whitespace stripped, lowercased, duplicates dropped,
+  first-seen order preserved)
+* unknown source ids echoed in ``unknown[]`` instead of 404'ing
+* identity ``from == to`` yields a single-row envelope whose ``path``
+  is ``[]``
+* lateral (same rank, different id) yields a single-row envelope whose
+  ``path`` has one row
+* ``trial`` accepted as both source and destination (matches the scalar
+  helpers)
+* unknown / empty / garbage destination returns ``None`` (helper) /
+  400 / 404 (HTTP)
+* helpers never raise -- a per-source failure short-circuits that id
+  into ``unknown[]`` and the rest of the batch keeps building
+* HTTP endpoints 400 on missing / empty input, 404 on unknown
+  destination, never 5xx on a helper failure
+* grace vs enforce yields identical rows
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+
+_ITEM_KEYS = {"from", "from_label", "from_rank", "direction", "path"}
+_HELPER_ENVELOPE_KEYS = {"tiers", "unknown"}
+_HTTP_ENVELOPE_KEYS = {
+    "to",
+    "to_label",
+    "to_rank",
+    "tiers",
+    "unknown",
+}
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from flask import Flask
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# ── tier_unlocks_from_path_batch: helper-level ────────────────────────────────
+
+
+def test_unlocks_helper_returns_dict_shape(ent):
+    out = ent.tier_unlocks_from_path_batch(
+        [ent.TIER_OSS, ent.TIER_CLOUD_STARTER], ent.TIER_ENTERPRISE
+    )
+    assert isinstance(out, dict)
+    assert set(out.keys()) == _HELPER_ENVELOPE_KEYS
+    assert isinstance(out["tiers"], list)
+    assert isinstance(out["unknown"], list)
+
+
+def test_unlocks_helper_each_row_carries_expected_keys(ent):
+    out = ent.tier_unlocks_from_path_batch(
+        [ent.TIER_OSS, ent.TIER_CLOUD_STARTER], ent.TIER_ENTERPRISE
+    )
+    for row in out["tiers"]:
+        assert set(row.keys()) == _ITEM_KEYS
+        assert isinstance(row["from"], str)
+        assert isinstance(row["from_label"], str)
+        assert isinstance(row["from_rank"], int)
+        assert row["direction"] in {
+            "upgrade",
+            "downgrade",
+            "lateral",
+            "identity",
+        }
+        assert isinstance(row["path"], list)
+
+
+def test_unlocks_helper_per_row_path_byte_equal_to_scalar(ent):
+    """Pin: per-source ``path`` is byte-identical to the scalar
+    :func:`tier_unlocks_path` payload for the same ``(from, to)`` pair."""
+    sources = [
+        ent.TIER_OSS,
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+    ]
+    out = ent.tier_unlocks_from_path_batch(sources, ent.TIER_ENTERPRISE)
+    by_id = {row["from"]: row["path"] for row in out["tiers"]}
+    for fid in sources:
+        assert by_id[fid] == ent.tier_unlocks_path(fid, ent.TIER_ENTERPRISE)
+
+
+def test_unlocks_helper_per_row_path_matches_at_path_batch_column(ent):
+    """The per-source column produced by fanning sources equals the per-
+    destination column from the destination-side batch for the mirror
+    pair -- both delegate to the same scalar, so a caller can pick the
+    axis that matches its query shape without shape drift."""
+    sources = [ent.TIER_OSS, ent.TIER_CLOUD_STARTER, ent.TIER_CLOUD_PRO]
+    to_tier = ent.TIER_ENTERPRISE
+    from_batch = ent.tier_unlocks_from_path_batch(sources, to_tier)
+    for row in from_batch["tiers"]:
+        dest_batch = ent.tier_unlocks_path_batch(row["from"], [to_tier])
+        assert dest_batch["tiers"][0]["path"] == row["path"]
+
+
+def test_unlocks_helper_direction_matches_ranks(ent):
+    """Direction is derived per source relative to the shared ``to`` --
+    upgrade / downgrade / lateral / identity."""
+    sources = [
+        ent.TIER_OSS,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_PRO,
+        ent.TIER_ENTERPRISE,
+    ]
+    out = ent.tier_unlocks_from_path_batch(sources, ent.TIER_CLOUD_PRO)
+    by_id = {row["from"]: row["direction"] for row in out["tiers"]}
+    # cloud_pro rank == pro rank == 2
+    assert by_id[ent.TIER_OSS] == "upgrade"
+    assert by_id[ent.TIER_CLOUD_PRO] == "identity"
+    assert by_id[ent.TIER_PRO] == "lateral"
+    assert by_id[ent.TIER_ENTERPRISE] == "downgrade"
+
+
+def test_unlocks_helper_supply_order_preserved(ent):
+    sources = [ent.TIER_ENTERPRISE, ent.TIER_CLOUD_STARTER, ent.TIER_OSS]
+    out = ent.tier_unlocks_from_path_batch(sources, ent.TIER_CLOUD_PRO)
+    assert [row["from"] for row in out["tiers"]] == sources
+
+
+def test_unlocks_helper_normalises_input(ent):
+    out = ent.tier_unlocks_from_path_batch(
+        ["  CLOUD_STARTER  ", "cloud_pro", "cloud_starter", ""],
+        ent.TIER_ENTERPRISE,
+    )
+    assert [row["from"] for row in out["tiers"]] == [
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+    ]
+
+
+def test_unlocks_helper_accepts_csv_string(ent):
+    out = ent.tier_unlocks_from_path_batch(
+        "cloud_starter,cloud_pro,oss", ent.TIER_ENTERPRISE
+    )
+    assert [row["from"] for row in out["tiers"]] == [
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_OSS,
+    ]
+
+
+def test_unlocks_helper_unknown_ids_echoed(ent):
+    out = ent.tier_unlocks_from_path_batch(
+        [ent.TIER_OSS, "bogus_id", "still_bogus"], ent.TIER_ENTERPRISE
+    )
+    assert [row["from"] for row in out["tiers"]] == [ent.TIER_OSS]
+    assert set(out["unknown"]) == {"bogus_id", "still_bogus"}
+
+
+def test_unlocks_helper_identity_row_carries_empty_path(ent):
+    out = ent.tier_unlocks_from_path_batch(
+        [ent.TIER_CLOUD_PRO], ent.TIER_CLOUD_PRO
+    )
+    assert len(out["tiers"]) == 1
+    assert out["tiers"][0]["direction"] == "identity"
+    assert out["tiers"][0]["path"] == []
+
+
+def test_unlocks_helper_lateral_row_has_single_step(ent):
+    out = ent.tier_unlocks_from_path_batch(
+        [ent.TIER_PRO], ent.TIER_CLOUD_PRO
+    )
+    assert len(out["tiers"]) == 1
+    assert out["tiers"][0]["direction"] == "lateral"
+    assert len(out["tiers"][0]["path"]) == 1
+    assert out["tiers"][0]["path"][0]["tier"] == ent.TIER_CLOUD_PRO
+
+
+def test_unlocks_helper_trial_accepted_as_source(ent):
+    """``trial`` is not purchasable but IS a valid endpoint -- matches
+    :func:`tier_unlocks_path`."""
+    out = ent.tier_unlocks_from_path_batch(
+        [ent.TIER_TRIAL], ent.TIER_ENTERPRISE
+    )
+    assert out["unknown"] == []
+    assert len(out["tiers"]) == 1
+    assert out["tiers"][0]["from"] == ent.TIER_TRIAL
+
+
+def test_unlocks_helper_unknown_to_returns_none(ent):
+    assert (
+        ent.tier_unlocks_from_path_batch([ent.TIER_OSS], "not_a_tier")
+        is None
+    )
+
+
+def test_unlocks_helper_empty_from_list_yields_empty_envelope(ent):
+    out = ent.tier_unlocks_from_path_batch([], ent.TIER_ENTERPRISE)
+    assert out == {"tiers": [], "unknown": []}
+
+
+def test_unlocks_helper_garbage_inputs_never_raise(ent):
+    assert ent.tier_unlocks_from_path_batch([], "") is None
+    assert ent.tier_unlocks_from_path_batch(None, None) is None  # type: ignore[arg-type]
+    assert ent.tier_unlocks_from_path_batch("  ", "  ") is None
+
+
+def test_unlocks_helper_grace_and_enforce_yield_identical_output(
+    ent, monkeypatch
+):
+    sources = [ent.TIER_OSS, ent.TIER_CLOUD_STARTER, ent.TIER_CLOUD_PRO]
+    grace = ent.tier_unlocks_from_path_batch(sources, ent.TIER_ENTERPRISE)
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    enforced = ent.tier_unlocks_from_path_batch(sources, ent.TIER_ENTERPRISE)
+    assert grace == enforced
+
+
+def test_unlocks_helper_row_failure_short_circuits_id(ent, monkeypatch):
+    """A per-source failure pushes that id into ``unknown[]`` while the
+    rest of the batch keeps building."""
+    real = ent.tier_unlocks_path
+
+    def fake(f, t):
+        if f == ent.TIER_CLOUD_STARTER:
+            raise RuntimeError("boom")
+        return real(f, t)
+
+    monkeypatch.setattr(ent, "tier_unlocks_path", fake)
+    out = ent.tier_unlocks_from_path_batch(
+        [ent.TIER_CLOUD_STARTER, ent.TIER_OSS], ent.TIER_ENTERPRISE
+    )
+    assert [row["from"] for row in out["tiers"]] == [ent.TIER_OSS]
+    assert ent.TIER_CLOUD_STARTER in out["unknown"]
+
+
+# ── tier_locks_from_path_batch: helper-level ─────────────────────────────────
+
+
+def test_locks_helper_returns_dict_shape(ent):
+    out = ent.tier_locks_from_path_batch(
+        [ent.TIER_ENTERPRISE, ent.TIER_CLOUD_PRO], ent.TIER_OSS
+    )
+    assert isinstance(out, dict)
+    assert set(out.keys()) == _HELPER_ENVELOPE_KEYS
+
+
+def test_locks_helper_per_row_path_byte_equal_to_scalar(ent):
+    sources = [ent.TIER_ENTERPRISE, ent.TIER_CLOUD_PRO, ent.TIER_CLOUD_STARTER]
+    out = ent.tier_locks_from_path_batch(sources, ent.TIER_OSS)
+    by_id = {row["from"]: row["path"] for row in out["tiers"]}
+    for fid in sources:
+        assert by_id[fid] == ent.tier_locks_path(fid, ent.TIER_OSS)
+
+
+def test_locks_helper_per_row_path_matches_at_path_batch_column(ent):
+    sources = [ent.TIER_ENTERPRISE, ent.TIER_CLOUD_PRO, ent.TIER_CLOUD_STARTER]
+    to_tier = ent.TIER_OSS
+    from_batch = ent.tier_locks_from_path_batch(sources, to_tier)
+    for row in from_batch["tiers"]:
+        dest_batch = ent.tier_locks_path_batch(row["from"], [to_tier])
+        assert dest_batch["tiers"][0]["path"] == row["path"]
+
+
+def test_locks_helper_direction_matches_ranks(ent):
+    sources = [
+        ent.TIER_ENTERPRISE,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_PRO,
+        ent.TIER_OSS,
+    ]
+    out = ent.tier_locks_from_path_batch(sources, ent.TIER_CLOUD_PRO)
+    by_id = {row["from"]: row["direction"] for row in out["tiers"]}
+    assert by_id[ent.TIER_ENTERPRISE] == "downgrade"
+    assert by_id[ent.TIER_CLOUD_PRO] == "identity"
+    assert by_id[ent.TIER_PRO] == "lateral"
+    assert by_id[ent.TIER_OSS] == "upgrade"
+
+
+def test_locks_helper_identity_row_carries_empty_path(ent):
+    out = ent.tier_locks_from_path_batch([ent.TIER_OSS], ent.TIER_OSS)
+    assert out["tiers"][0]["direction"] == "identity"
+    assert out["tiers"][0]["path"] == []
+
+
+def test_locks_helper_trial_accepted_as_source(ent):
+    out = ent.tier_locks_from_path_batch([ent.TIER_TRIAL], ent.TIER_OSS)
+    assert out["unknown"] == []
+    assert len(out["tiers"]) == 1
+    assert out["tiers"][0]["from"] == ent.TIER_TRIAL
+
+
+def test_locks_helper_unknown_to_returns_none(ent):
+    assert (
+        ent.tier_locks_from_path_batch([ent.TIER_OSS], "not_a_tier") is None
+    )
+
+
+def test_locks_helper_unknown_ids_echoed(ent):
+    out = ent.tier_locks_from_path_batch(
+        [ent.TIER_ENTERPRISE, "bogus_id"], ent.TIER_OSS
+    )
+    assert [row["from"] for row in out["tiers"]] == [ent.TIER_ENTERPRISE]
+    assert out["unknown"] == ["bogus_id"]
+
+
+def test_locks_helper_grace_and_enforce_yield_identical_output(
+    ent, monkeypatch
+):
+    sources = [ent.TIER_ENTERPRISE, ent.TIER_CLOUD_PRO, ent.TIER_PRO]
+    grace = ent.tier_locks_from_path_batch(sources, ent.TIER_OSS)
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    enforced = ent.tier_locks_from_path_batch(sources, ent.TIER_OSS)
+    assert grace == enforced
+
+
+def test_locks_helper_row_failure_short_circuits_id(ent, monkeypatch):
+    real = ent.tier_locks_path
+
+    def fake(f, t):
+        if f == ent.TIER_ENTERPRISE:
+            raise RuntimeError("boom")
+        return real(f, t)
+
+    monkeypatch.setattr(ent, "tier_locks_path", fake)
+    out = ent.tier_locks_from_path_batch(
+        [ent.TIER_ENTERPRISE, ent.TIER_CLOUD_PRO], ent.TIER_OSS
+    )
+    assert [row["from"] for row in out["tiers"]] == [ent.TIER_CLOUD_PRO]
+    assert ent.TIER_ENTERPRISE in out["unknown"]
+
+
+# ── cross-family symmetry ─────────────────────────────────────────────────────
+
+
+def test_unlocks_and_locks_from_path_batch_walk_same_length(ent):
+    """Rung counts from :func:`tier_unlocks_from_path_batch` (ascending)
+    and :func:`tier_locks_from_path_batch` (descending) match for the
+    mirror endpoints -- both walks visit every purchasable rung
+    strictly between the endpoints plus the destination."""
+    up = ent.tier_unlocks_from_path_batch([ent.TIER_OSS], ent.TIER_ENTERPRISE)
+    down = ent.tier_locks_from_path_batch(
+        [ent.TIER_ENTERPRISE], ent.TIER_OSS
+    )
+    assert len(up["tiers"][0]["path"]) == len(down["tiers"][0]["path"])
+
+
+# ── /api/entitlement/tier-unlocks-from-path-batch endpoint ───────────────────
+
+
+def test_http_unlocks_envelope_keys(client, ent):
+    r = client.get(
+        "/api/entitlement/tier-unlocks-from-path-batch"
+        f"?from={ent.TIER_OSS}&to={ent.TIER_ENTERPRISE}"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert set(body.keys()) == _HTTP_ENVELOPE_KEYS
+
+
+def test_http_unlocks_body_matches_helper(client, ent):
+    r = client.get(
+        "/api/entitlement/tier-unlocks-from-path-batch"
+        f"?from={ent.TIER_OSS},{ent.TIER_CLOUD_STARTER},{ent.TIER_CLOUD_PRO}"
+        f"&to={ent.TIER_ENTERPRISE}"
+    )
+    body = r.get_json()
+    helper = ent.tier_unlocks_from_path_batch(
+        [ent.TIER_OSS, ent.TIER_CLOUD_STARTER, ent.TIER_CLOUD_PRO],
+        ent.TIER_ENTERPRISE,
+    )
+    assert body["tiers"] == helper["tiers"]
+    assert body["unknown"] == helper["unknown"]
+    assert body["to"] == ent.TIER_ENTERPRISE
+    assert body["to_rank"] == ent.tier_rank(ent.TIER_ENTERPRISE)
+    assert body["to_label"] == ent.tier_label(ent.TIER_ENTERPRISE)
+
+
+def test_http_unlocks_missing_to_400(client):
+    r = client.get("/api/entitlement/tier-unlocks-from-path-batch")
+    assert r.status_code == 400
+
+
+def test_http_unlocks_missing_from_400(client, ent):
+    r = client.get(
+        "/api/entitlement/tier-unlocks-from-path-batch"
+        f"?to={ent.TIER_ENTERPRISE}"
+    )
+    assert r.status_code == 400
+
+
+def test_http_unlocks_bad_to_404(client, ent):
+    r = client.get(
+        "/api/entitlement/tier-unlocks-from-path-batch"
+        f"?from={ent.TIER_OSS}&to=bogus"
+    )
+    assert r.status_code == 404
+    body = r.get_json()
+    assert body["which"] == "tier"
+
+
+def test_http_unlocks_unknown_from_bucketed_200(client, ent):
+    r = client.get(
+        "/api/entitlement/tier-unlocks-from-path-batch"
+        f"?from={ent.TIER_OSS},bogus&to={ent.TIER_ENTERPRISE}"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert [row["from"] for row in body["tiers"]] == [ent.TIER_OSS]
+    assert body["unknown"] == ["bogus"]
+
+
+def test_http_unlocks_never_5xx_on_helper_failure(client, ent, monkeypatch):
+    def fake(*_a, **_k):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(ent, "tier_unlocks_from_path_batch", fake)
+    r = client.get(
+        "/api/entitlement/tier-unlocks-from-path-batch"
+        f"?from={ent.TIER_OSS}&to={ent.TIER_ENTERPRISE}"
+    )
+    assert r.status_code < 500
+
+
+def test_http_unlocks_trial_source_accepted(client, ent):
+    r = client.get(
+        "/api/entitlement/tier-unlocks-from-path-batch"
+        f"?from={ent.TIER_TRIAL}&to={ent.TIER_ENTERPRISE}"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["unknown"] == []
+    assert len(body["tiers"]) == 1
+    assert body["tiers"][0]["from"] == ent.TIER_TRIAL
+
+
+# ── /api/entitlement/tier-locks-from-path-batch endpoint ─────────────────────
+
+
+def test_http_locks_envelope_keys(client, ent):
+    r = client.get(
+        "/api/entitlement/tier-locks-from-path-batch"
+        f"?from={ent.TIER_ENTERPRISE}&to={ent.TIER_OSS}"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert set(body.keys()) == _HTTP_ENVELOPE_KEYS
+
+
+def test_http_locks_body_matches_helper(client, ent):
+    r = client.get(
+        "/api/entitlement/tier-locks-from-path-batch"
+        f"?from={ent.TIER_ENTERPRISE},{ent.TIER_CLOUD_PRO},{ent.TIER_CLOUD_STARTER}"
+        f"&to={ent.TIER_OSS}"
+    )
+    body = r.get_json()
+    helper = ent.tier_locks_from_path_batch(
+        [ent.TIER_ENTERPRISE, ent.TIER_CLOUD_PRO, ent.TIER_CLOUD_STARTER],
+        ent.TIER_OSS,
+    )
+    assert body["tiers"] == helper["tiers"]
+    assert body["unknown"] == helper["unknown"]
+    assert body["to"] == ent.TIER_OSS
+
+
+def test_http_locks_missing_to_400(client):
+    r = client.get("/api/entitlement/tier-locks-from-path-batch")
+    assert r.status_code == 400
+
+
+def test_http_locks_missing_from_400(client, ent):
+    r = client.get(
+        f"/api/entitlement/tier-locks-from-path-batch?to={ent.TIER_OSS}"
+    )
+    assert r.status_code == 400
+
+
+def test_http_locks_bad_to_404(client):
+    r = client.get(
+        "/api/entitlement/tier-locks-from-path-batch?from=oss&to=bogus"
+    )
+    assert r.status_code == 404
+    body = r.get_json()
+    assert body["which"] == "tier"
+
+
+def test_http_locks_unknown_from_bucketed_200(client, ent):
+    r = client.get(
+        "/api/entitlement/tier-locks-from-path-batch"
+        f"?from={ent.TIER_ENTERPRISE},bogus&to={ent.TIER_OSS}"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert [row["from"] for row in body["tiers"]] == [ent.TIER_ENTERPRISE]
+    assert body["unknown"] == ["bogus"]
+
+
+def test_http_locks_never_5xx_on_helper_failure(client, ent, monkeypatch):
+    def fake(*_a, **_k):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(ent, "tier_locks_from_path_batch", fake)
+    r = client.get(
+        "/api/entitlement/tier-locks-from-path-batch"
+        f"?from={ent.TIER_ENTERPRISE}&to={ent.TIER_OSS}"
+    )
+    assert r.status_code < 500


### PR DESCRIPTION
## Summary

- Adds `tier_unlocks_from_path_batch(from_tiers, to_tier)` / `tier_locks_from_path_batch(from_tiers, to_tier)` — mirror-direction batch siblings of the existing `tier_unlocks_path_batch` / `tier_locks_path_batch` (which fix ONE source and fan out over N destinations). Here we fix the destination and fan out over N sources, returning per-source rung walks in ONE round-trip. Source-axis analogues of the recently-merged `has_features_from_path_batch` / `has_runtimes_from_path_batch` family (#4621). Per-source `path` byte-equals `tier_unlocks_path(from, to_tier)` (and the tier_locks counterpart) for the same pair — pinned by parity tests so the scalar and source-batch path helpers cannot drift. Grace-independent by construction (delegates walk `_PURCHASABLE_TIERS` and fold per-rung marginal grants / losses via the existing `_unlocks_row` / `_locks_row` helpers, so grace vs enforce yields byte-identical rows). Wiring these in changes **no** current behavior.
- Adds paired `GET /api/entitlement/tier-unlocks-from-path-batch` / `GET /api/entitlement/tier-locks-from-path-batch` on `bp_entitlement`. Envelope mirrors `/tier-unlocks-path-batch` byte-for-key on the walk-metadata slots with the source/destination axis swapped: `to` / `to_label` / `to_rank` replace the current-`from` slot at the envelope level, and each `tiers[]` row carries `from` / `from_label` / `from_rank` / `direction` / `path` (direction computed per source relative to the shared `to_tier`, upgrade / downgrade / lateral / identity). 400 on missing `from` / `to`; 404 on unknown `to` (body carries `which: "tier"`); 200 with bucketed unknowns for unknown source ids; never 5xxs (any helper blowup collapses to an envelope with empty rows).
- 43-test module `tests/test_entitlement_tier_unlocks_locks_from_path_batch.py` covering helper envelope + row shape, per-source `path` byte-parity against scalar `tier_unlocks_path` / `tier_locks_path`, cross-parity against the destination-side batch's per-destination column for the same `(from, to)` pair, direction detection, source-supply-order preservation, whitespace / case / dedup normalisation, CSV-string acceptance, unknown-source bucketing, identity / lateral edge cases, `trial` acceptance as source and destination, unknown-`to` short-circuit, empty / `None` / garbage input never raises, grace-independence, per-source failure short-circuit, endpoint envelope shape (fixed key set), 400 / 404 branches, unknown-source bucketing at the endpoint layer, `trial` source acceptance at the endpoint layer, and never-5xx guard on helper blowup.

### Where this fits in the helper matrix

Completes the four-corner `{unlocks, locks}` × `{at_path_batch, from_path_batch}` coverage for the tier_unlocks/tier_locks path family:

|                 | fan-out over destinations (`_path_batch`) | fan-out over sources (`_from_path_batch`) |
|-----------------|-------------------------------------------|--------------------------------------------|
| `tier_unlocks_*`| merged (existing)                          | **this PR**                                |
| `tier_locks_*`  | merged (existing)                          | **this PR**                                |

Same source-batch axis the `has_*_from_path_batch` (#4621) family fills for the boolean-fold scalars.

Files:
- `clawmetry/entitlements.py` — 2 new helpers (~190 lines)
- `routes/entitlement.py` — 2 new endpoints (~170 lines)
- `tests/test_entitlement_tier_unlocks_locks_from_path_batch.py` — new test module (43 tests, all pass)

## Test plan

- [x] `python -m py_compile clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_tier_unlocks_locks_from_path_batch.py` clean
- [x] `ruff check clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_tier_unlocks_locks_from_path_batch.py` clean
- [x] `python -m pytest tests/test_entitlement_tier_unlocks_locks_from_path_batch.py` — 43 pass
- [x] Sibling regression: `tests/test_entitlement_tier_unlocks_locks_path_batch.py`, `tests/test_entitlement_has_features_runtimes_from_path_batch.py`, `tests/test_entitlement_tier_unlocks_locks_at_path.py` — 139 pass total (no regressions)

### Local operator verification checklist

This branch was authored in a remote container with no access to the host, running daemon, `~/.openclaw`, or the live cloud snapshot, so the following need to happen on the operator's machine before ready-for-review:

- [ ] Copy `clawmetry/entitlements.py`, `routes/entitlement.py`, `tests/test_entitlement_tier_unlocks_locks_from_path_batch.py` into `~/.clawmetry/lib/pythonX.Y/site-packages/clawmetry/` (and its `routes/` / `tests/` siblings)
- [ ] Clear `__pycache__` under the target install
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
- [ ] `curl -s "http://localhost:8900/api/entitlement/tier-unlocks-from-path-batch?from=oss,cloud_starter,cloud_pro&to=enterprise" | jq` — expect 3 rows in `tiers`, each `.path` byte-equal to `/api/entitlement/tier-unlocks-path?from=<src>&to=enterprise`'s payload for the same source
- [ ] `curl -s "http://localhost:8900/api/entitlement/tier-locks-from-path-batch?from=enterprise,cloud_pro,cloud_starter&to=oss" | jq` — expect 3 rows in `tiers`, each `.path` byte-equal to `/api/entitlement/tier-locks-path?from=<src>&to=oss`'s payload for the same source
- [ ] `curl -s "http://localhost:8900/api/entitlement/tier-unlocks-from-path-batch?from=cloud_pro&to=cloud_pro" | jq` — expect a single `tiers[]` row with `direction="identity"`, `path=[]`
- [ ] `curl -s "http://localhost:8900/api/entitlement/tier-unlocks-from-path-batch?from=pro&to=cloud_pro" | jq` — expect a single `tiers[]` row with `direction="lateral"` and `path` length 1
- [ ] `curl -s "http://localhost:8900/api/entitlement/tier-unlocks-from-path-batch?from=oss,bogus_a,cloud_starter,bogus_b&to=enterprise" -w '\n%{http_code}\n' | jq '.tiers[].from, .unknown'` — expect HTTP 200 with `["oss","cloud_starter"]` in `tiers` and `["bogus_a","bogus_b"]` in `unknown`
- [ ] `curl -s "http://localhost:8900/api/entitlement/tier-unlocks-from-path-batch?from=oss&to=bogus" -w '\n%{http_code}\n'` — expect HTTP 404 with `which="tier"`
- [ ] `curl -s "http://localhost:8900/api/entitlement/tier-unlocks-from-path-batch?to=enterprise" -w '\n%{http_code}\n'` — expect HTTP 400 (missing `from`)
- [ ] `curl -s "http://localhost:8900/api/entitlement/tier-unlocks-from-path-batch?from=oss" -w '\n%{http_code}\n'` — expect HTTP 400 (missing `to`)
- [ ] Confirm sibling `/api/entitlement/tier-unlocks-path-batch` / `/tier-locks-path-batch` still return byte-identical rows (no regression to the destination-side batch family)
- [ ] Confirm sibling `/api/entitlement/has-features-from-path-batch` / `/has-runtimes-from-path-batch` still return byte-identical rows (no regression to the boolean-fold source-batch family)
- [ ] Confirm `/api/entitlement` still resolves as before (no resolver-path regression from the new helpers)
- [ ] Decrypt the live snapshot and browser-check the dashboard still loads (no import-time regression)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CPuMsT1iiwAB1xWQf6c15S)_