### PR TITLE
chore: bump __version__ to 0.12.662

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -268,7 +268,7 @@ def _otlp_service_name_to_agent_type(service_name):
     return slug or "custom"
 
 
-__version__ = "0.12.661"
+__version__ = "0.12.662"
 
 # Extensions (Phase 2): import the plugin host now, but defer the actual
 # load_plugins() call until after the Flask app is created below so we can


### PR DESCRIPTION
Syncs `dashboard.py` with the `clawmetry==0.12.662` release already live on PyPI.

**Why not #4631?** The original auto-bump PR was opened by `github-actions[bot]` via `GITHUB_TOKEN`. GitHub permanently suppresses `pull_request` CI events on such PRs to prevent recursive workflow loops -- the required "E2E Gate (required)" check could never be satisfied. This replacement PR is authored by a non-GITHUB_TOKEN actor so CI fires normally.

### Changes
- `dashboard.py`: `__version__ = "0.12.661"` → `"0.12.662"` (1 line)

---
_Generated by [Claude Code](https://claude.ai/code/session_016Svswf2MmVyyzxqMcVJtSj)_