### PR TITLE
chore: bump __version__ to 0.12.663

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -268,7 +268,7 @@ def _otlp_service_name_to_agent_type(service_name):
     return slug or "custom"
 
 
-__version__ = "0.12.662"
+__version__ = "0.12.663"
 
 # Extensions (Phase 2): import the plugin host now, but defer the actual
 # load_plugins() call until after the Flask app is created below so we can


### PR DESCRIPTION
Syncs `dashboard.py` with the `clawmetry==0.12.663` release already live on PyPI (triggered by #4633).

**Why not #4638?** That PR was opened by `github-actions[bot]` via `GITHUB_TOKEN`, which permanently suppresses `pull_request` CI events — the required E2E Gate can never pass on bot-authored PRs. This replacement is opened by a non-GITHUB_TOKEN actor so CI fires normally.

---
_Generated by [Claude Code](https://claude.ai/code/session_016Svswf2MmVyyzxqMcVJtSj)_