### PR TITLE
feat(desktop): stable, version-less download URLs for Windows/macOS/Linux builds

### DIFF
--- a/.github/workflows/desktop-artifacts.yml
+++ b/.github/workflows/desktop-artifacts.yml
@@ -104,6 +104,12 @@ jobs:
             -srcfolder dist/ClawMetry.app \
             -ov -format UDZO \
             "dist/ClawMetry-${VERSION}.dmg"
+          # Fixed-name copy so clawmetry.com/download/mac can link a stable
+          # URL (GitHub's /releases/latest/download/<name>) instead of
+          # bookkeeping the current version anywhere else. Placed BEFORE
+          # the sign step below so it rides the same `dist/*.dmg` signing
+          # loop as the versioned file.
+          cp "dist/ClawMetry-${VERSION}.dmg" "dist/ClawMetry-mac.dmg"
 
       - name: Sign + notarize + staple the .dmg itself
         if: env.HAS_SIGN == 'true'
@@ -152,6 +158,10 @@ jobs:
             $version = (Select-String -Path ../dashboard.py -Pattern '__version__ = "(.+?)"').Matches.Groups[1].Value
           }
           Compress-Archive -Path ClawMetry -DestinationPath "ClawMetry-$version-windows.zip"
+          # Fixed-name copy so clawmetry.com/download/windows can link a
+          # stable URL (GitHub's /releases/latest/download/<name>) instead
+          # of bookkeeping the current version anywhere else.
+          Copy-Item "ClawMetry-$version-windows.zip" "ClawMetry-windows.zip" -Force
 
       - uses: actions/upload-artifact@v4
         with:
@@ -194,6 +204,10 @@ jobs:
             VERSION=$(python3 -c "import re; print(re.search(r'__version__ = \"(.+?)\"', open('../dashboard.py').read()).group(1))")
           fi
           tar czf "clawmetry-${VERSION}-linux-x86_64.tar.gz" clawmetry
+          # Fixed-name copy so clawmetry.com/download/linux can link a
+          # stable URL (GitHub's /releases/latest/download/<name>) instead
+          # of bookkeeping the current version anywhere else.
+          cp "clawmetry-${VERSION}-linux-x86_64.tar.gz" "clawmetry-linux.tar.gz"
 
       - uses: actions/upload-artifact@v4
         with:

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -100,6 +100,17 @@ is not supported — those builds happen in
 [`.github/workflows/desktop-artifacts.yml`](../.github/workflows/desktop-artifacts.yml)
 on push of a `v*.*.*` tag or manual dispatch.
 
+### Stable download URLs
+
+Each build job also copies its artifact to a fixed, version-less
+filename (`ClawMetry-mac.dmg`, `ClawMetry-windows.zip`,
+`clawmetry-linux.tar.gz`) alongside the version-suffixed one, both
+uploaded to the same GitHub Release. That makes
+`https://github.com/vivekchand/clawmetry/releases/latest/download/<fixed-name>`
+a URL that always resolves to the current release with no version
+bookkeeping anywhere else — clawmetry-landing's `/download/<os>`
+routes (see that repo's `app.py`) redirect straight to these.
+
 ## Regenerating icons
 
 The generated `.icns` / `.ico` / PNG are committed so CI doesn't need

--- a/desktop/app.py
+++ b/desktop/app.py
@@ -151,6 +151,17 @@ def _runtime_dir() -> Path:
     return d
 
 
+def _win_subprocess_kwargs() -> dict:
+    """Extra Popen/run kwargs that stop Windows from flashing a console
+    window. The desktop app is built windowed (console=False), but every
+    subprocess it spawns (python.exe, pip, clawmetry.exe) is a console
+    executable — without CREATE_NO_WINDOW, Windows opens a new console
+    for each one, visible for the duration of the call. No-op elsewhere."""
+    if platform.system() == "Windows":
+        return {"creationflags": subprocess.CREATE_NO_WINDOW}  # type: ignore[attr-defined]
+    return {}
+
+
 def _bootstrap_python() -> Optional[str]:
     """A real Python interpreter the shell can use to create a venv.
     PyInstaller's bundled interpreter can't (its `sys.executable` is
@@ -170,6 +181,7 @@ def _bootstrap_python() -> Optional[str]:
                 r = subprocess.run(
                     [p, "-c", "import sys,venv,pip; print(sys.version_info[:2])"],
                     capture_output=True, text=True, timeout=6,
+                    **_win_subprocess_kwargs(),
                 )
                 if r.returncode == 0:
                     return p
@@ -239,6 +251,7 @@ class RuntimeSupervisor:
                 [str(py), "-c",
                  "import importlib.metadata as m; print(m.version('clawmetry'))"],
                 capture_output=True, text=True, timeout=8,
+                **_win_subprocess_kwargs(),
             )
             if r.returncode == 0:
                 return r.stdout.strip()
@@ -264,6 +277,7 @@ class RuntimeSupervisor:
                 subprocess.run(
                     [py, "-m", "venv", str(self.venv)],
                     check=True, capture_output=True, text=True, timeout=60,
+                    **_win_subprocess_kwargs(),
                 )
                 self._log(f"venv created via {py}")
             except subprocess.CalledProcessError as e:
@@ -281,6 +295,7 @@ class RuntimeSupervisor:
                     [str(self._venv_python()), "-m", "pip", "install",
                      "--upgrade", "--disable-pip-version-check", "clawmetry"],
                     capture_output=True, text=True, timeout=300,
+                    **_win_subprocess_kwargs(),
                 )
                 self._log(f"pip install rc={r.returncode}")
                 if r.returncode != 0:
@@ -318,7 +333,14 @@ class RuntimeSupervisor:
             "env": env,
         }
         if os.name == "nt":
-            kwargs["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP  # type: ignore[attr-defined]
+            # CREATE_NEW_PROCESS_GROUP lets stop() target the child alone
+            # with CTRL_BREAK_EVENT; CREATE_NO_WINDOW stops it from
+            # flashing a console (stdout/stderr going to DEVNULL doesn't
+            # suppress the window itself — console allocation happens
+            # regardless of stream redirection).
+            kwargs["creationflags"] = (  # type: ignore[attr-defined]
+                subprocess.CREATE_NEW_PROCESS_GROUP | subprocess.CREATE_NO_WINDOW
+            )
         else:
             kwargs["start_new_session"] = True
         self.proc = subprocess.Popen(argv, **kwargs)
@@ -393,6 +415,7 @@ class RuntimeSupervisor:
             r = subprocess.run(
                 [str(cli), "update"],
                 capture_output=True, text=True, timeout=300,
+                **_win_subprocess_kwargs(),
             )
             self._log(f"watcher clawmetry-update rc={r.returncode}")
             if r.returncode != 0:

--- a/desktop/onboarding.py
+++ b/desktop/onboarding.py
@@ -114,6 +114,18 @@ def mark_onboarding_completed(
         pass  # onboarding stamp is best-effort; a re-shown pane is not a bug
 
 
+def _win_subprocess_kwargs() -> dict:
+    """Extra Popen/run kwargs that stop Windows from flashing a console
+    window when this windowed (console=False) shell spawns a console
+    executable (the venv's python.exe / clawmetry.exe). No-op elsewhere.
+    Mirrors app.py's helper — duplicated rather than imported to keep
+    onboarding.py importable standalone (app.py imports IT, not vice
+    versa)."""
+    if platform.system() == "Windows":
+        return {"creationflags": subprocess.CREATE_NO_WINDOW}  # type: ignore[attr-defined]
+    return {}
+
+
 # ─── Runtime detection ──────────────────────────────────────────────────
 # The clawmetry package (which lives in the runtime venv) has the
 # canonical detection logic in ``clawmetry/entitlements.py``. From the
@@ -148,6 +160,7 @@ def detect_runtimes_via_venv(venv_python: Path, *, timeout: float = 6.0) -> list
         r = subprocess.run(
             [str(py), "-c", script],
             capture_output=True, text=True, timeout=timeout,
+            **_win_subprocess_kwargs(),
         )
         if r.returncode == 0:
             data = json.loads(r.stdout.strip() or "[]")
@@ -182,6 +195,7 @@ def apply_cm_key(venv_clawmetry: Path, cm_key: str, *, timeout: float = 60.0) ->
         r = subprocess.run(
             [str(bin_), "connect", "--key", cm_key, "--start-sync-now"],
             capture_output=True, text=True, timeout=timeout,
+            **_win_subprocess_kwargs(),
         )
         if r.returncode == 0:
             return True, "signed in"


### PR DESCRIPTION
## Summary

- Verified the desktop thin-shell app (`desktop/app.py`) end-to-end on this machine: real venv bootstrap, real `pip install clawmetry` from PyPI, real onboarding auth pane, real daemon spawn, real dashboard render, no errors.
- Found and fixed a real Windows-only bug while cross-checking the platform branches this Linux box can't execute: the desktop shell is built windowed (`console=False`), but every subprocess it spawns (`python -m venv`, `pip install`, the venv's `clawmetry` CLI for version checks/connect/update, the daemon itself) is a console executable — without `CREATE_NO_WINDOW`, Windows flashes a console window for each one, on first launch and every subsequent relaunch. Fixed with a shared `_win_subprocess_kwargs()` helper applied to every subprocess call in `desktop/app.py` and `desktop/onboarding.py`.
- `desktop-artifacts.yml` now also uploads a fixed-name copy of each platform build (`ClawMetry-mac.dmg`, `ClawMetry-windows.zip`, `clawmetry-linux.tar.gz`) to the same GitHub Release, so `github.com/vivekchand/clawmetry/releases/latest/download/<fixed-name>` always resolves to the current release with no version bookkeeping. This sets up `clawmetry-landing` to link real, tracked "Download for Windows/macOS/Linux" buttons (companion PR in that repo).

## Test plan

- [x] Ran `desktop/app.py` under Xvfb with the GTK-WebKit backend (Linux equivalent of WebView2): venv creation succeeded, real `pip install --upgrade clawmetry` completed (landed on 0.12.662), the real onboarding auth pane rendered and a real OTP send round-tripped against the live backend, "Skip for now" advanced to a real local daemon (`clawmetry --no-debug --port <free>`) serving a working `/api/overview` with no exceptions in `bootstrap.log`.
- [x] Re-ran the same flow after the `CREATE_NO_WINDOW` fix — identical behavior confirmed, since the fix is a no-op outside `platform.system() == "Windows"`.
- [x] `python3 -m py_compile desktop/app.py desktop/onboarding.py` — clean.
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/desktop-artifacts.yml'))"` — valid YAML.
- [x] Confirmed via GitHub Actions API that `desktop-artifacts.yml`'s existing `actions/upload-artifact` and release `softprops/action-gh-release` glob patterns (`dist/*.dmg` / `*.zip` / `*.tar.gz`) already match the new fixed-name files without any further workflow changes.
- [ ] Fixed-name URLs resolve with `curl -I` — pending the next tagged release (this PR doesn't cut one by itself).

---
_Generated by [Claude Code](https://claude.ai/code/session_01MFXj1vwXfX6ufgQhXykwuZ)_