### PR TITLE
fix(dmg): drag-to-Applications layout — mirror clawmetry-mac pattern

### DIFF
--- a/.github/workflows/desktop-artifacts.yml
+++ b/.github/workflows/desktop-artifacts.yml
@@ -88,7 +88,7 @@ jobs:
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
         run: desktop/sign_mac.sh dist/ClawMetry.app
 
-      - name: Wrap into .dmg
+      - name: Wrap into .dmg (drag-to-Applications layout)
         run: |
           # Prefer the tag ref (v0.12.<n> → 0.12.<n>) over dashboard.py's
           # __version__ because release-on-merge commits the version bump
@@ -100,10 +100,62 @@ jobs:
           else
             VERSION=$(python3 -c "import re; print(re.search(r'__version__ = \"(.+?)\"', open('dashboard.py').read()).group(1))")
           fi
+
+          # Stage the .dmg contents so the mounted volume has BOTH the
+          # .app and a symlink to /Applications, giving users the standard
+          # macOS drag-to-install UX. Without this the DMG mounts to an
+          # otherwise-empty window with just ClawMetry.app, and users have
+          # to figure out on their own that they should drag it somewhere.
+          # Pattern mirrored from clawmetry-mac/.github/workflows/build-sign-release.yml.
+          STAGING="$RUNNER_TEMP/dmg-stage"
+          rm -rf "$STAGING"
+          mkdir -p "$STAGING"
+          cp -R dist/ClawMetry.app "$STAGING/"
+          ln -s /Applications "$STAGING/Applications"
+
+          # Build a writable DMG first so we can osascript the Finder into
+          # arranging the icons + hiding the toolbar, then convert to the
+          # final compressed read-only UDZO the release ships.
+          TEMP_DMG="$RUNNER_TEMP/ClawMetry-temp.dmg"
           hdiutil create -volname "ClawMetry" \
-            -srcfolder dist/ClawMetry.app \
-            -ov -format UDZO \
-            "dist/ClawMetry-${VERSION}.dmg"
+            -srcfolder "$STAGING" \
+            -ov -format UDRW -fs HFS+ \
+            "$TEMP_DMG"
+          hdiutil attach "$TEMP_DMG" -readwrite -noverify -mountpoint /Volumes/ClawMetry
+
+          osascript <<'AS'
+          tell application "Finder"
+            tell disk "ClawMetry"
+              open
+              set current view of container window to icon view
+              set toolbar visible of container window to false
+              set statusbar visible of container window to false
+              set bounds of container window to {200, 200, 800, 500}
+              set theViewOptions to icon view options of container window
+              set arrangement of theViewOptions to not arranged
+              set icon size of theViewOptions to 96
+              set text size of theViewOptions to 13
+              set position of item "ClawMetry.app" of container window to {155, 130}
+              set position of item "Applications" of container window to {445, 130}
+              close
+              open
+              update without registering applications
+              delay 2
+            end tell
+          end tell
+          AS
+
+          sync && sleep 2
+          osascript -e 'tell application "Finder" to close every window' || true
+          sleep 1
+          hdiutil detach "/Volumes/ClawMetry" -force
+
+          # Convert writable UDRW → compressed read-only UDZO (final shape).
+          hdiutil convert "$TEMP_DMG" \
+            -format UDZO -imagekey zlib-level=9 \
+            -o "dist/ClawMetry-${VERSION}.dmg"
+          rm -f "$TEMP_DMG"
+
           # Fixed-name copy so clawmetry.com/download/mac can link a stable
           # URL (GitHub's /releases/latest/download/<name>) instead of
           # bookkeeping the current version anywhere else. Placed BEFORE

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 ## Unreleased
 
+- **Fix: DMG opens with a drag-to-Applications layout instead of an empty window.**
+  - **Why:** the shipped `.dmg` mounted to a window showing only
+    `ClawMetry.app` — no `Applications` shortcut for users to drag it
+    onto. Live report 2026-08-08: *"why is there no drop to
+    applications folder — check how we did for clawmetry-mac app it's
+    a separate repo — we should reuse same approach."*
+  - **What:** rewrote the "Wrap into .dmg" step in
+    `.github/workflows/desktop-artifacts.yml` to stage the `.app` +
+    an `Applications` symlink into a directory, build a UDRW writable
+    DMG, `osascript` the Finder into positioning icons (ClawMetry.app
+    left, Applications right, 96px icons, hidden toolbar/statusbar),
+    then `hdiutil convert` to the final compressed UDZO. Signing/
+    notarization steps unchanged — they still operate on the final
+    `dist/*.dmg`. Pattern lifted from `vivekchand/clawmetry-mac`'s
+    build-sign-release workflow so both native macOS surfaces
+    (Swift menubar app + pywebview desktop app) present identical
+    drag-to-install UX.
+  - **Verified:** YAML parses locally. End-to-end verification is the
+    next release — mounting the shipped `.dmg` must show two
+    side-by-side icons (ClawMetry, Applications) in a 600x300 icon-
+    view window with no toolbar.
+
 - **Release: stable desktop-app download URLs + Windows console-window fix reach the wheel and the next signed builds.**
   - **Why:** the desktop thin-shell app had no public, permanent download link (`desktop-artifacts.yml` only produced version-suffixed GitHub Release assets reachable by digging into CI runs), and a real Windows-only bug survived because nothing had exercised those code paths end to end: the shell is built windowed (`console=False`) but every subprocess it spawns (`python -m venv`, `pip install`, the venv's `clawmetry` CLI, the daemon itself) is a console executable, so Windows flashed a console window on first launch and every relaunch. Carrier `[RELEASE]` so #4640 actually reaches the next tagged build.
   - **What:** `desktop-artifacts.yml` now uploads a fixed-name copy of each platform build (`ClawMetry-mac.dmg`, `ClawMetry-windows.zip`, `clawmetry-linux.tar.gz`) alongside the versioned one, so `github.com/vivekchand/clawmetry/releases/latest/download/<fixed-name>` always resolves to the current release with no version bookkeeping. This is what `clawmetry-landing`'s new `/download/<os>` buttons link to. `desktop/app.py` and `desktop/onboarding.py` gained a shared `_win_subprocess_kwargs()` helper applying `CREATE_NO_WINDOW` to every subprocess call on Windows (no-op elsewhere).


### PR DESCRIPTION
Shipped `.dmg` mounts to a window showing just `ClawMetry.app` — no `Applications` shortcut for drag-and-drop install. Live report:

> "why is there no drop to applications folder — check how we did for clawmetry-mac app it's a separate repo — we should reuse same approach"

## Fix
Rewrote the "Wrap into .dmg" step in `desktop-artifacts.yml` mirroring `vivekchand/clawmetry-mac`'s `build-sign-release.yml`:

- Stage: copy `.app` + `ln -s /Applications` into `$RUNNER_TEMP/dmg-stage/`
- `hdiutil create -format UDRW` writable DMG
- Mount + osascript sets Finder icon-view layout: `ClawMetry.app` at `{155,130}`, `Applications` at `{445,130}`, 96px icons, no toolbar/statusbar, 600x300 window
- `hdiutil convert -format UDZO -imagekey zlib-level=9` → final compressed read-only

Signing + notarization steps unchanged — still operate on `dist/*.dmg`.

## Test plan
- [ ] CI green
- [ ] After next release: download the `.dmg`, mount it, window shows two side-by-side icons (ClawMetry ← Applications) in an icon-view window with hidden toolbar

🤖 Generated with [Claude Code](https://claude.com/claude-code)