### PR TITLE
[RELEASE] Ship drag-to-Applications DMG layout to end users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 ## Unreleased
 
+- **Release: ship the drag-to-Applications DMG layout to end users.**
+  - **Why:** #4646 rewrote the DMG-build step but no signed `.dmg`
+    carries the new layout yet. Carrier `[RELEASE]` so users see the
+    two-icon drag-and-drop window on the next download instead of the
+    lone `ClawMetry.app`.
+  - **What:** no new code; ships #4646.
+  - **Verified:** end-to-end this release — download the fresh `.dmg`,
+    mount, confirm the window shows ClawMetry + Applications side-by-
+    side in a 600x300 icon-view window with hidden toolbar.
+
 - **Fix: DMG opens with a drag-to-Applications layout instead of an empty window.**
   - **Why:** the shipped `.dmg` mounted to a window showing only
     `ClawMetry.app` — no `Applications` shortcut for users to drag it


### PR DESCRIPTION
Carrier for #4646. No new code. Ships the new DMG-build step into a signed .dmg.

## Test plan
- [ ] release-on-merge auto-cascades to desktop-artifacts
- [ ] Downloaded .dmg mounts to a 600x300 icon-view window with ClawMetry.app + Applications side by side
- [ ] spctl still accepts

🤖 Generated with [Claude Code](https://claude.com/claude-code)