### PR TITLE
fix(ci): add branch-protection fallback to c6-apply-ruleset POST/PUT 403

### DIFF
--- a/.github/workflows/c6-apply-ruleset.yml
+++ b/.github/workflows/c6-apply-ruleset.yml
@@ -187,10 +187,23 @@ jobs:
           if err:
               code, body = err
               if code == 403:
+                  # Mirror the GET-403 fallback: if the check is already enforced
+                  # via branch protection (e.g. the admin added it via Settings UI
+                  # or close-c6.sh), C6 is satisfied and there is nothing to fix.
+                  if branch_has_c6_check():
+                      print(
+                          f"[C6] Rulesets API {verb} 403 but 'E2E Gate (required)' is "
+                          "present in branch protection -- C6 OK."
+                      )
+                      set_output("created", "false")
+                      sys.exit(0)
                   print(
                       f"::error title=C6 Rulesets write denied::"
-                      f"Rulesets API {verb} returned 403 -- GITHUB_TOKEN cannot write rulesets. "
-                      "Fix: bash scripts/close-c6.sh (or Settings UI, ~60 s). "
+                      f"Rulesets API {verb} returned 403 -- GITHUB_TOKEN cannot write rulesets "
+                      "AND 'E2E Gate (required)' is MISSING from branch protection. "
+                      "Fastest fix (60 s): github.com/vivekchand/clawmetry/settings/branches "
+                      "> Edit main > Require status checks > add 'E2E Gate (required)'. "
+                      "Or: bash scripts/close-c6.sh. "
                       "Tracking: https://github.com/vivekchand/clawmetry/issues/4552"
                   )
                   set_output("created", "false")
@@ -212,7 +225,7 @@ jobs:
           PYEOF
 
       # Only verify if the upsert step actually created/updated a ruleset.
-      # Skipped when upsert exits 0 or 1 due to 403 (no ruleset to verify).
+      # Skipped when upsert exits 0 (403 + check already present) or exits 1.
       - name: Verify ruleset is active
         if: success() && steps.upsert.outputs.created == 'true'
         env:


### PR DESCRIPTION
## Summary

Fixes a missing fallback in `c6-apply-ruleset.yml` that caused the C6 workflow to fail on every push even after the admin closed C6 via the Settings UI or `close-c6.sh`.

**Root cause:** When `GET /rulesets` returns 403, the script already calls `branch_has_c6_check()` and exits 0 if `'E2E Gate (required)'` is already enforced via branch protection. But when `POST/PUT /rulesets` returns 403, the script exited 1 immediately without the same fallback -- even if branch protection already had the check configured.

**Fix:** Mirror the GET-403 fallback to the POST/PUT-403 path:
- If `branch_has_c6_check()` returns True: emit a `[C6] ... C6 OK` notice and exit 0
- If the check is still missing: emit the actionable `::error::` with instructions and exit 1 (same as before)

## What changes

- `c6-apply-ruleset.yml`: 16 lines added inside the `POST/PUT 403` handler to call `branch_has_c6_check()` before exiting 1

## What this does NOT change

The current failing behaviour is unchanged -- `'E2E Gate (required)'` is still absent from branch protection (tracking: #4552). This fix prevents the job from spuriously failing AFTER the admin closes C6.

## Test plan

- [x] `python3 -m py_compile .github/workflows/c6-apply-ruleset.yml` -- not applicable (YAML with inline Python)
- [x] Logic verified by inspection: GET-403 path and POST/PUT-403 path now handle the `branch_has_c6_check()` fallback identically
- [x] The inline `branch_has_c6_check()` function was added in the same recent commit that fixed the GET-403 path; this PR just wires it to the POST/PUT-403 path that was accidentally missed

## Human handoff

This PR does not close C6 on its own. To close C6 (stop the red badge), do one of:
1. **Settings UI (60 s):** [clawmetry Settings > Branches > main](https://github.com/vivekchand/clawmetry/settings/branches) > Required status checks > add `E2E Gate (required)`
2. **Terminal:** `bash scripts/close-c6.sh` (auto-installs `gh` CLI if needed)
3. **Actions:** Run "Apply required E2E status checks (C6 -- one-shot)" with a fine-grained PAT (`Administration: read+write`)

Tracking: #4552

---
_Generated by [Claude Code](https://claude.ai/code/session_01FochyTZ9yVjauhryCTS99T)_