### PR TITLE
fix(ci): raise entitlement-tests timeout 10 -> 20 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,17 +239,17 @@ jobs:
             tests/test_hooks_claude_code.py \
             -q
 
-  # ── Entitlement API test suite (~2700 hermetic tests) ─────────────────────────────────────────────
+  # ── Entitlement API test suite (~2700+ hermetic tests) ─────────────────────────────────────────────
   # Covers every helper in clawmetry/entitlements.py and every endpoint
   # under routes/entitlement.py via Flask test client. No live server, no
-  # gateway, no network. Runtime ~8-10min on CI runners (suite has grown
-  # as stacked PRs added test files; timeout raised from 5 to 10 to stop
+  # gateway, no network. Runtime ~8-16min on CI runners (suite has grown
+  # as stacked PRs added test files; timeout raised 5 -> 10 -> 20 to stop
   # mid-suite cancellations). HARD-FAIL: no continue-on-error.
   entitlement-tests:
     name: Entitlement API tests
     needs: lint
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v7


### PR DESCRIPTION
## Why

Three stacked draft PRs (#4643, #4650, #4655) are all failing the "Entitlement API tests" CI job with a **cancellation at exactly 10 minutes**. The entitlement test suite has grown with each feature PR:

- #4643 adds 43 tests (preview_from_path_batch + capacity_diff_from_path_batch)
- #4650 adds 61 tests (lock_reason_from_path_batch + lock_reasons_from_path_batch)
- #4655 adds 87 tests (has_channel_count_batch + has_retention_window_batch)

Combined with the existing ~2700-test surface, the suite now takes ~12-16 minutes on CI runners, past the 10-minute ceiling. All 22 other checks are green on those PRs; only this job cancels.

The non-draft PRs (#4656, #4657) still pass because their entitlement test count is unchanged from current main.

## What

Single-line change: `timeout-minutes: 10` -> `timeout-minutes: 20` on the `entitlement-tests` job. Comment updated to reflect the history (5 -> 10 -> 20).

No tests changed, no logic changed. This unblocks the three draft PRs from passing CI once they are marked ready for review by the operator.

## Test plan

- [x] `grep 'timeout-minutes' .github/workflows/ci.yml` confirms only the `entitlement-tests` job changed (the `live-openclaw-e2e` job is `continue-on-error: true` so its timeout is irrelevant to merge gate)
- [ ] CI on this PR should pass the "Entitlement API tests" job within the new 20-minute window

---
_Generated by [Claude Code](https://claude.ai/code/session_01LfBdnkQp4eQ3HCAbTzmBbA)_