### PR TITLE
feat(harness): plain-language anatomy of an AI harness on the Harness tab

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -17501,13 +17501,13 @@ function renderToolCatalog() {
 var _cmHarnessTemplates = null;   // {runtime: template}, fetched once
 var _cmHarnessData = null;
 
-// Show the Harness nav iff a specific runtime is selected AND it has a template.
+// The Harness nav is always visible: the tab opens with the plain-language
+// "anatomy of a harness" explainer (static, works for every runtime and on
+// cloud), and adds the runtime-specific extras panel when a template exists.
 function _cmRefreshHarnessNav() {
   var nav = document.getElementById('left-nav-harness');
   if (!nav) return;
-  var rt = (typeof _cmRuntimeFilter === 'function') ? _cmRuntimeFilter() : 'all';
-  if (!rt || rt === 'all') { nav.style.display = 'none'; return; }
-  nav.style.display = (_cmHarnessTemplates && _cmHarnessTemplates[rt]) ? '' : 'none';
+  nav.style.display = '';
 }
 
 // Eagerly fetch templates at page-init so the nav can appear without waiting
@@ -17539,14 +17539,15 @@ async function loadHarness() {
     _cmHarnessData = data;
     el.innerHTML = renderHarnessPanel(tmpl, data);
   } catch (e) {
-    el.innerHTML = '<div style="color:var(--muted,#888);">Failed to load harness view: '
+    el.innerHTML = '<div style="color:var(--muted,#888);">Failed to load the runtime panel: '
       + escapeHtml(String((e && e.message) || e)) + '</div>';
   }
 }
 
 function _cmHarnessNoTemplate(rt) {
-  return '<div style="color:var(--muted,#888);line-height:1.5;">No harness panel for <b>'
-    + escapeHtml(rt) + '</b> yet.<br>Pro runtimes light up their panels when '
+  return '<div style="color:var(--muted,#888);line-height:1.5;">Nothing extra for <b>'
+    + escapeHtml(rt) + '</b> yet. The anatomy above applies to every runtime.<br>'
+    + 'Pro runtimes light up their own panels when '
     + 'clawmetry-pro is installed (Cloud Pro or a self-hosted license).</div>';
 }
 

--- a/clawmetry/static/locales/en.json
+++ b/clawmetry/static/locales/en.json
@@ -841,6 +841,7 @@
   "nav.memory_tooltip": "Persistent memory files the agent reads on boot",
   "nav.models": "Models",
   "nav.notifications": "Notifications",
+  "nav.harness": "Harness",
   "nav.runtime_extras": "Runtime extras",
   "nav.security": "Security",
   "nav.self_evolve": "Improvement tips",

--- a/clawmetry/templates/tabs/harness.html
+++ b/clawmetry/templates/tabs/harness.html
@@ -2,9 +2,72 @@
   <div style="display:flex;align-items:baseline;gap:10px;flex-wrap:wrap;margin-bottom:6px;">
     <div style="font-size:20px;font-weight:700;" id="harness-title">Harness</div>
     <div style="font-size:13px;color:var(--muted,#888);">
-      What this runtime uniquely exposes — beyond the generic tabs.
+      Everything wrapped around the model that turns "it can talk" into "it can work".
     </div>
     <button onclick="loadHarness()" style="margin-left:auto;" class="btn-ghost" title="Refresh">↻</button>
+  </div>
+
+  <!-- Anatomy of an AI harness: a plain-language map of the parts every agent
+       harness has, each linking to the ClawMetry tab where you can watch that
+       part live. Static content, no fetches: renders identically local + cloud. -->
+  <div class="card" style="padding:16px;margin-bottom:14px;" id="harness-anatomy">
+    <div style="font-size:15px;font-weight:700;margin-bottom:6px;">What is a harness?</div>
+    <div style="font-size:13px;color:var(--muted,#888);line-height:1.6;max-width:760px;">
+      An AI model on its own can only talk: you ask, it answers, it stops.
+      The <b>harness</b> is all the machinery wrapped around the model that lets it
+      actually do work: tools, memory, safety rails, and the loop that keeps it going
+      until the job is done. Claude Code, Cursor, and your agent runtimes are all
+      harnesses around the same few models. ClawMetry is a window into that machinery.
+      Each part below links to the tab where you can watch it live.
+      (Good primer: <a href="https://read.technically.dev/p/whats-harness-engineering"
+      target="_blank" rel="noopener" style="color:var(--accent,#6cf);">What's harness engineering?</a>)
+    </div>
+    <div style="display:grid;grid-template-columns:repeat(auto-fill,minmax(230px,1fr));gap:10px;margin-top:14px;">
+      <div class="card" style="padding:12px 14px;">
+        <div style="font-size:13px;font-weight:700;margin-bottom:4px;">🔁 The loop</div>
+        <div style="font-size:12.5px;color:var(--muted,#888);line-height:1.5;">The agent reads, decides, acts, checks its own work, and goes again until the task is done. This loop is what makes it an agent instead of a chatbot.</div>
+        <a href="javascript:switchTab('brain')" style="font-size:12px;color:var(--accent,#6cf);display:inline-block;margin-top:6px;">Watch it live in Activity →</a>
+      </div>
+      <div class="card" style="padding:12px 14px;">
+        <div style="font-size:13px;font-weight:700;margin-bottom:4px;">🔧 Tools</div>
+        <div style="font-size:12.5px;color:var(--muted,#888);line-height:1.5;">Tools let the agent touch the world: read and edit files, run code, search the web, call other services. No tools, no work.</div>
+        <a href="javascript:switchTab('tool-catalog')" style="font-size:12px;color:var(--accent,#6cf);display:inline-block;margin-top:6px;">See its tools →</a>
+      </div>
+      <div class="card" style="padding:12px 14px;">
+        <div style="font-size:13px;font-weight:700;margin-bottom:4px;">📚 Memory</div>
+        <div style="font-size:12.5px;color:var(--muted,#888);line-height:1.5;">Models forget everything between sessions. The harness writes notes to files so your agent remembers you, your projects, and its own lessons.</div>
+        <a href="javascript:switchTab('memory')" style="font-size:12px;color:var(--accent,#6cf);display:inline-block;margin-top:6px;">Read its memory →</a>
+      </div>
+      <div class="card" style="padding:12px 14px;">
+        <div style="font-size:13px;font-weight:700;margin-bottom:4px;">🪟 Context</div>
+        <div style="font-size:12.5px;color:var(--muted,#888);line-height:1.5;">The model can only "see" a limited window of text at once. The harness keeps that window focused, trimming old noise so quality doesn't rot.</div>
+        <a href="javascript:switchTab('context-economics')" style="font-size:12px;color:var(--accent,#6cf);display:inline-block;margin-top:6px;">See context usage →</a>
+      </div>
+      <div class="card" style="padding:12px 14px;">
+        <div style="font-size:13px;font-weight:700;margin-bottom:4px;">📦 Sandbox</div>
+        <div style="font-size:12.5px;color:var(--muted,#888);line-height:1.5;">A safe room where the agent can run code and fail freely, without reaching things it shouldn't touch.</div>
+        <a href="javascript:switchTab('security')" style="font-size:12px;color:var(--accent,#6cf);display:inline-block;margin-top:6px;">Check its sandbox →</a>
+      </div>
+      <div class="card" style="padding:12px 14px;">
+        <div style="font-size:13px;font-weight:700;margin-bottom:4px;">🚦 Guardrails</div>
+        <div style="font-size:12.5px;color:var(--muted,#888);line-height:1.5;">The rules for what the agent may do on its own and what needs your OK first, like deleting files or spending money.</div>
+        <a href="javascript:switchTab('approvals')" style="font-size:12px;color:var(--accent,#6cf);display:inline-block;margin-top:6px;">Review approvals →</a>
+      </div>
+      <div class="card" style="padding:12px 14px;">
+        <div style="font-size:13px;font-weight:700;margin-bottom:4px;">🤝 Teamwork</div>
+        <div style="font-size:12.5px;color:var(--muted,#888);line-height:1.5;">For big jobs, one agent leads and hands pieces to helper agents, then stitches the results together.</div>
+        <a href="javascript:switchTab('agents')" style="font-size:12px;color:var(--accent,#6cf);display:inline-block;margin-top:6px;">See who spawned whom →</a>
+      </div>
+      <div class="card" style="padding:12px 14px;">
+        <div style="font-size:13px;font-weight:700;margin-bottom:4px;">💬 Interfaces</div>
+        <div style="font-size:12.5px;color:var(--muted,#888);line-height:1.5;">The same agent can meet you in a terminal, on Telegram or Slack, or in a browser. Different doors, one harness behind them.</div>
+        <a href="javascript:switchTab('flow')" style="font-size:12px;color:var(--accent,#6cf);display:inline-block;margin-top:6px;">Follow the message flow →</a>
+      </div>
+    </div>
+  </div>
+
+  <div style="font-size:13px;color:var(--muted,#888);margin:0 0 6px 2px;" id="harness-extras-label">
+    What this runtime uniquely exposes, beyond the generic tabs:
   </div>
   <!-- renderHarnessPanel() fills this from the selected runtime's template -->
   <div id="harness-container" class="card" style="padding:16px;">Loading harness view…</div>

--- a/dashboard.py
+++ b/dashboard.py
@@ -12528,8 +12528,8 @@ DASHBOARD_HTML = r"""
         <div class="left-nav-item left-nav-item-sub" id="left-nav-context-economics" data-tab="context-economics" onclick="switchTab('context-economics')" title="Context-window utilization over time, compaction triggers and tokens reclaimed">
           <span class="left-nav-label" data-i18n="nav.context_usage">Context usage</span>
         </div>
-        <div class="left-nav-item left-nav-item-sub" id="left-nav-harness" data-tab="harness" onclick="switchTab('harness')" title="What the selected runtime uniquely exposes — beyond the generic tabs" style="display:none">
-          <span class="left-nav-label" data-i18n="nav.runtime_extras">Runtime extras</span>
+        <div class="left-nav-item left-nav-item-sub" id="left-nav-harness" data-tab="harness" onclick="switchTab('harness')" title="What a harness is, part by part, and where to watch each part live">
+          <span class="left-nav-label" data-i18n="nav.harness">Harness</span>
         </div>
         <div class="left-nav-item left-nav-item-sub" data-tab="dives" onclick="switchTab('dives')" title="Ask questions about your AI usage in plain English">
           <span class="left-nav-label" data-i18n="nav.ask">Ask</span>

--- a/tests/test_harness_anatomy.py
+++ b/tests/test_harness_anatomy.py
@@ -1,0 +1,77 @@
+"""Guards for the "anatomy of an AI harness" explainer on the Harness tab.
+
+The Harness tab teaches newcomers what a harness is (loop, tools, memory,
+context, sandbox, guardrails, orchestration, interfaces) and links every part
+to the live ClawMetry tab that shows it. These guards keep that promise:
+
+- the anatomy section exists and covers all eight parts,
+- every "watch it live" link targets a tab page that actually renders,
+- the Harness nav entry is always visible (it no longer hides when no
+  runtime-specific template is registered),
+- copy obeys the no-em-dash rule for user-facing text.
+"""
+import json
+import os
+import re
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+TAB = os.path.join(REPO, "clawmetry", "templates", "tabs", "harness.html")
+TABS_DIR = os.path.join(REPO, "clawmetry", "templates", "tabs")
+APP_JS = os.path.join(REPO, "clawmetry", "static", "js", "app.js")
+DASHBOARD = os.path.join(REPO, "dashboard.py")
+EN_JSON = os.path.join(REPO, "clawmetry", "static", "locales", "en.json")
+
+ANATOMY_PARTS = [
+    "The loop", "Tools", "Memory", "Context",
+    "Sandbox", "Guardrails", "Teamwork", "Interfaces",
+]
+
+
+def _read(path):
+    with open(path, encoding="utf-8") as fh:
+        return fh.read()
+
+
+def test_anatomy_section_covers_all_parts():
+    html = _read(TAB)
+    assert 'id="harness-anatomy"' in html
+    for part in ANATOMY_PARTS:
+        assert part in html, f"anatomy card missing: {part}"
+    # the primer link that credits the source article
+    assert "read.technically.dev/p/whats-harness-engineering" in html
+
+
+def test_anatomy_links_target_real_tab_pages():
+    html = _read(TAB)
+    targets = re.findall(r"switchTab\('([a-z0-9-]+)'\)", html)
+    assert len(set(targets)) >= 8, f"expected 8+ live-tab links, got {targets}"
+    for tab in set(targets):
+        page = os.path.join(TABS_DIR, f"{tab}.html")
+        assert os.path.exists(page), f"anatomy links to switchTab('{tab}') but {tab}.html does not exist"
+        assert f'id="page-{tab}"' in _read(page), f"{tab}.html lacks id=page-{tab}"
+
+
+def test_harness_nav_always_visible():
+    js = _read(APP_JS)
+    m = re.search(r"function _cmRefreshHarnessNav\(\)\s*\{(.*?)\n\}", js, re.S)
+    assert m, "app.js lost _cmRefreshHarnessNav"
+    body = m.group(1)
+    assert "'none'" not in body, "Harness nav must not hide again (anatomy applies to every runtime)"
+    # the nav element itself must not ship pre-hidden either
+    dash = _read(DASHBOARD)
+    el = re.search(r'<div[^>]*id="left-nav-harness"[^>]*>', dash)
+    assert el, "dashboard.py lost the left-nav-harness entry"
+    assert "display:none" not in el.group(0), "left-nav-harness must render visible by default"
+
+
+def test_nav_label_and_i18n_key():
+    dash = _read(DASHBOARD)
+    assert 'data-i18n="nav.harness"' in dash
+    with open(EN_JSON, encoding="utf-8") as fh:
+        en = json.load(fh)
+    assert en.get("nav.harness") == "Harness"
+
+
+def test_no_em_dashes_in_harness_copy():
+    html = _read(TAB)
+    assert "—" not in html, "em-dash found in user-facing Harness copy (banned)"


### PR DESCRIPTION
## Why

Every ClawMetry user is looking at an AI harness, but most have never heard the word. The recent primer ["What's harness engineering?"](https://read.technically.dev/p/whats-harness-engineering) frames it well: a model on its own can only talk; the harness (agent loop, tools, memory, context management, sandbox, guardrails, orchestration, interfaces) is what turns it into a working agent. ClawMetry already observes every one of those parts live, so the Harness tab now teaches them, in newcomer language, with a "watch it live" link per part. This directly serves the FLYWHEEL vision: the observability tool for people who have never used one.

## What

- `clawmetry/templates/tabs/harness.html`: new always-rendered "What is a harness?" anatomy section with 8 cards (loop, tools, memory, context, sandbox, guardrails, teamwork, interfaces), each linking via `switchTab` to the tab where that component is observable (Activity, Tool Catalog, Memory, Context usage, Security, Approvals, Agent Graph, Flow). Credits the primer article.
- `clawmetry/static/js/app.js`: `_cmRefreshHarnessNav` no longer hides the nav when no runtime template exists; `loadHarness` falls back to a friendly "nothing extra for this runtime" note under the anatomy instead of a dead end.
- `dashboard.py`: nav entry renamed "Runtime extras" -> "Harness" (`data-i18n="nav.harness"`), no longer pre-hidden.
- `clawmetry/static/locales/en.json`: adds `nav.harness` ("Runtime extras" key kept; other locales fall back to English until the i18n sync runs).
- `tests/test_harness_anatomy.py`: guards the anatomy coverage, that every live-link target is a real tab page, the always-visible nav, the i18n key, and the no-em-dash rule.

## Cloud parity / performance / runtime honesty

The anatomy section is static HTML: zero fetches, so it renders identically on the hosted dashboard, adds nothing to the request budget, and shows no numbers that could silently ignore the runtime filter. The existing runtime-extras panel below is unchanged.

## Verification

- `pytest tests/test_harness_anatomy.py tests/test_harness_templates.py` green; revert-proof done (checked out the pre-change files, guard went red 5/5, restored, green).
- Booted the worktree dashboard on an isolated `CLAWMETRY_LOCAL_STORE_PATH` (live daemon's writer lock untouched), opened it in a browser: `left-nav-harness` computed display `flex`, `#harness-anatomy` present with 8 cards, runtime without a template shows the friendly fallback, zero console errors.
- `tests/test_beginner_nav_phase_a.py` has 2 pre-existing failures on origin/main (evals/gateway nav drift, unrelated; flagged separately).

## Drift Bot note

No Blueprint currently documents the Harness tab's educational anatomy section; if drift-bot flags this, the Blueprint for the dashboard navigation/Harness tab should gain: "The Harness tab always renders a plain-language anatomy of an AI harness with links to the corresponding live tabs; runtime-specific extras render below when a template is registered."

🤖 Generated with [Claude Code](https://claude.com/claude-code)
