### PR TITLE
fix(nav): restore Approvals/Alerts/Notifications adjacency + sync Phase-A nav guard with Evals/Gateway tabs

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -12481,17 +12481,19 @@ DASHBOARD_HTML = r"""
         <span class="left-nav-label" data-i18n="nav.alerts">Alerts</span>
         <span id="nav-alerts-badge" class="left-nav-badge" style="display:none;">0</span>
       </div>
-      <div class="left-nav-item" data-tab="evals" onclick="switchTab('evals')" data-i18n-title="nav.evals_tooltip" title="Automatic quality checks and LLM-judge scores for your agent's work">
-        <span class="left-nav-icon" aria-hidden="true">&#128300;</span>
-        <span class="left-nav-label" data-i18n="nav.evals">Evals</span>
-      </div>
       {# Notifications sits directly under its two consumers (Approvals,
          Alerts) - founder request 2026-07-29: buried in the Advanced drawer,
          nobody could find where to connect a delivery channel, so enabled
-         alert rules dead-ended at "no channels". #}
+         alert rules dead-ended at "no channels". Evals (#4295) rides Tier-1
+         below that trio so it can't split the Approvals/Alerts/Notifications
+         adjacency. #}
       <div class="left-nav-item" data-tab="notifications" onclick="switchTab('notifications')" data-i18n-title="nav.notifications_tooltip" title="Where Alerts and Approvals get delivered: Slack / Telegram / PagerDuty / Email">
         <span class="left-nav-icon" aria-hidden="true">&#9993;</span>
         <span class="left-nav-label" data-i18n="nav.notifications">Notifications</span>
+      </div>
+      <div class="left-nav-item" data-tab="evals" onclick="switchTab('evals')" data-i18n-title="nav.evals_tooltip" title="Automatic quality checks and LLM-judge scores for your agent's work">
+        <span class="left-nav-icon" aria-hidden="true">&#128300;</span>
+        <span class="left-nav-label" data-i18n="nav.evals">Evals</span>
       </div>
 
       {# Developer drawer: the deep-dive views. Pure toggle (no data-tab: the

--- a/tests/test_beginner_nav_phase_a.py
+++ b/tests/test_beginner_nav_phase_a.py
@@ -1,8 +1,9 @@
 """Guards for the Phase A beginner-IA nav restructure (UX_AUDIT.md).
 
 The contract:
-  * Tier-1 = seven plain-words items (Home, Agents, Activity, Cost,
-    Sessions, Approvals, Alerts), in that order, at the top level.
+  * Tier-1 = the plain-words beginner items (Home, Agents, Activity, Cost,
+    Sessions, Approvals, Alerts, Notifications, Evals), in that order, at
+    the top level.
   * Every expert view lives inside the Developer drawer, which is COLLAPSED
     by default (hidden attribute + JS opens only on stored cm_live_open=1).
   * The Developer group header carries NO data-tab: overview belongs to the
@@ -41,15 +42,17 @@ def _ordered_tabs(html: str) -> list:
 def test_tier1_order_and_membership():
     nav = _nav_block()
     tabs = _ordered_tabs(nav)
-    tier1 = tabs[:8]
+    tier1 = tabs[:9]
     # Notifications rides Tier-1 directly under its two consumers (Approvals,
     # Alerts) - founder request 2026-07-29: buried in the Advanced drawer,
     # nobody could find where to connect a delivery channel, so enabled alert
-    # rules dead-ended at "no channels".
+    # rules dead-ended at "no channels". Evals (#4295) joins Tier-1 AFTER
+    # notifications so it never splits that Approvals/Alerts/Notifications
+    # adjacency.
     assert tier1 == [
         "overview", "inventory", "brain", "usage",
-        "transcripts", "approvals", "alerts", "notifications",
-    ], f"Tier-1 must be the eight beginner items in order, got {tier1}"
+        "transcripts", "approvals", "alerts", "notifications", "evals",
+    ], f"Tier-1 must be the nine beginner items in order, got {tier1}"
 
 
 def test_group_header_has_no_data_tab():
@@ -74,17 +77,20 @@ def test_no_tab_lost_in_restructure():
     nav = _nav_block()
     tabs = set(_ordered_tabs(nav))
     expected = {
-        # Tier-1 (notifications promoted from Advanced, founder 2026-07-29)
+        # Tier-1 (notifications promoted from Advanced, founder 2026-07-29;
+        # evals added top-level in #4295)
         "overview", "inventory", "brain", "usage", "transcripts",
-        "approvals", "alerts", "notifications",
+        "approvals", "alerts", "notifications", "evals",
         # Developer drawer. Phase B (UX_AUDIT.md) deliberately moved the
         # session-scoped views (tracing, turn-anatomy, swimlane) OUT of the
         # nav and into the session drill-down - their pages and switchTab ids
         # still work; tests/test_session_deep_dive.py guards that entry point.
         # "context" (LLM Context) merged into context-economics 2026-08-01;
         # switchTab('context') aliases there so old deep links still land.
+        # "gateway" is the opt-in manual-token tab that replaced the legacy
+        # gateway-setup modal (#4575).
         "flow", "models", "agents",
-        "tool-catalog", "context-economics", "harness", "dives",
+        "tool-catalog", "context-economics", "harness", "dives", "gateway",
         # Advanced
         "crons", "memory", "security", "policy", "skills",
         "selfevolve", "version-impact", "nemoclaw",
@@ -103,9 +109,11 @@ def test_developer_drawer_membership():
     end = nav.index("left-nav-advanced-toggle", start)
     drawer = nav[start:end]
     got = set(_ordered_tabs(drawer))
+    # "gateway" joined the drawer in #4575 (opt-in replacement for the
+    # retired auto-popping gateway-setup modal).
     assert got == {
         "flow", "models", "agents",
-        "tool-catalog", "context-economics", "harness", "dives",
+        "tool-catalog", "context-economics", "harness", "dives", "gateway",
     }, f"Developer drawer membership drifted: {sorted(got)}"
 
 


### PR DESCRIPTION
## Why

`tests/test_beginner_nav_phase_a.py` fails on main: two deliberate, shipped nav changes were merged without updating the Phase-A guard.

- #4295 added a top-level **Evals** tab, but inserted it **between Alerts and Notifications**, breaking the founder-requested (2026-07-29) rule that Notifications sits directly under its two consumers (Approvals, Alerts). The nav comment stating that rule sat one line below the tab violating it.
- #4575 added the opt-in **Gateway** tab to the Developer drawer (replacing the retired auto-popping gateway-setup modal).

## Decision

The nav wins on **membership** (both tabs were intentional releases and stay), the founder intent wins on **order**: Evals moves below Notifications so the Approvals/Alerts/Notifications trio is contiguous again. The guard now encodes the 9-item Tier-1 order and gateway in the Developer drawer, with comments citing both PRs.

## Verification

- Revert-proof: the updated guard is **red** on the pre-fix nav (stashed the dashboard.py reorder, `test_tier1_order_and_membership` fails on evals-between-alerts-and-notifications) and **green** after the reorder.
- All 8 tests in `tests/test_beginner_nav_phase_a.py` pass.
- Checked the other tab guards (`test_c5_tab_drift_guard.py`, `test_e2e_oss_all_tabs.py`): membership-only, unaffected by the reorder; c5 drift guard passes.
- `py_compile` clean on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)