### PR TITLE
fix(desktop): uninstall removes app runtime so reinstall re-onboards; account-data wipe is an explicit checkbox

### DIFF
--- a/desktop/installer/windows.nsi
+++ b/desktop/installer/windows.nsi
@@ -43,6 +43,7 @@ Unicode true
 !insertmacro MUI_PAGE_FINISH
 
 !insertmacro MUI_UNPAGE_CONFIRM
+!insertmacro MUI_UNPAGE_COMPONENTS
 !insertmacro MUI_UNPAGE_INSTFILES
 
 !insertmacro MUI_LANGUAGE "English"
@@ -80,15 +81,49 @@ Section "ClawMetry" SecMain
   WriteRegDWORD HKCU "${UNINSTALL_KEY}" "NoRepair" 1
 SectionEnd
 
-Section "Uninstall"
-  ; Program files only — the runtime venv under %LOCALAPPDATA%\ClawMetry\runtime
-  ; and the account config under %USERPROFILE%\.clawmetry are left in place,
-  ; same as every other installer here: uninstalling the app doesn't wipe
-  ; the user's synced data or a fresh reinstall's ability to skip re-onboarding.
+; Founder bug 2026-08-08: uninstall + reinstall showed no onboarding, because
+; the old uninstaller removed only $INSTDIR and left the app runtime (venv,
+; onboarding stamp, logs) under %LOCALAPPDATA%\ClawMetry behind. Uninstalling
+; now removes everything the app created. Account data (~\.clawmetry) is its
+; own checkbox because it holds the E2E encryption key: deleting it makes
+; already-synced cloud snapshots permanently undecryptable, so the user must
+; see that choice, not have it made silently.
+
+Section "un.ClawMetry program + runtime" UnSecMain
+  SectionIn RO  ; always removed — this IS the uninstall
+
+  ; Stop the shell and any daemon running out of the runtime venv so file
+  ; locks don't leave half the tree behind. ExecWait + /F: no prompts.
+  ExecWait `taskkill /F /T /IM ClawMetry.exe`
+  ExecWait `powershell -NoProfile -Command "Get-CimInstance Win32_Process | Where-Object { $$_.ExecutablePath -like '$LOCALAPPDATA\ClawMetry\runtime\*' } | ForEach-Object { Stop-Process -Id $$_.ProcessId -Force }"`
+
   RMDir /r "$INSTDIR"
   Delete "$SMPROGRAMS\ClawMetry\ClawMetry.lnk"
   Delete "$SMPROGRAMS\ClawMetry\Uninstall ClawMetry.lnk"
   RMDir "$SMPROGRAMS\ClawMetry"
   Delete "$DESKTOP\ClawMetry.lnk"
   DeleteRegKey HKCU "${UNINSTALL_KEY}"
+
+  ; App-created runtime state: the venv, the onboarding-completed stamp, and
+  ; logs. Removing the stamp is what makes a reinstall re-onboard.
+  RMDir /r "$LOCALAPPDATA\ClawMetry\runtime"
+  ; Global CLI shim dir (present on installs whose app.py wrote it). The
+  ; user-PATH entry it registered is stripped by the shim-aware uninstaller
+  ; work; deleting the dir here keeps a stale shim from shadowing pip's.
+  RMDir /r "$LOCALAPPDATA\ClawMetry\bin"
+  ; Remove the parent only if nothing else claimed it (RMDir without /r is
+  ; a no-op on a non-empty dir).
+  RMDir "$LOCALAPPDATA\ClawMetry"
 SectionEnd
+
+Section "un.Account data + E2E encryption keys (~\.clawmetry)" UnSecData
+  ; WARNING surfaced in the components page description: this deletes the
+  ; node identity and the AES-256-GCM key — encrypted snapshots already in
+  ; the cloud can never be decrypted again.
+  RMDir /r "$PROFILE\.clawmetry"
+SectionEnd
+
+!insertmacro MUI_UNFUNCTION_DESCRIPTION_BEGIN
+  !insertmacro MUI_DESCRIPTION_TEXT ${UnSecMain} "Removes the ClawMetry app, its runtime (bundled Python environment, onboarding state, logs), shortcuts, and registry entries."
+  !insertmacro MUI_DESCRIPTION_TEXT ${UnSecData} "Also deletes ~\.clawmetry: your node identity, API key, and end-to-end encryption key. WARNING: encrypted snapshots already synced to ClawMetry Cloud become permanently unreadable. Uncheck to keep your keys for a later reinstall."
+!insertmacro MUI_UNFUNCTION_DESCRIPTION_END

--- a/tests/test_windows_installer_uninstall_cleanup.py
+++ b/tests/test_windows_installer_uninstall_cleanup.py
@@ -1,0 +1,84 @@
+"""Windows uninstaller cleanup contract (founder bug 2026-08-08).
+
+Uninstall + reinstall showed no onboarding: the uninstaller removed only
+$INSTDIR and left %LOCALAPPDATA%\\ClawMetry\\runtime (venv + the
+onboarding-completed.json stamp + logs) behind, so `is_first_launch()`
+stayed False forever. These assertions pin the uninstall contract:
+
+  * the runtime dir (and with it the onboarding stamp) is always removed;
+  * running processes are stopped first so file locks can't strand the tree;
+  * account data (~\\.clawmetry, holding the E2E encryption key) is removed
+    only via a user-visible components-page choice, never silently as part
+    of the mandatory section.
+
+Static contract-pinning on the .nsi source: makensis only runs in the
+desktop-artifacts workflow, so this is the guard that runs on every PR.
+"""
+
+import re
+from pathlib import Path
+
+NSI = Path(__file__).resolve().parents[1] / "desktop" / "installer" / "windows.nsi"
+
+
+def _nsi_text() -> str:
+    return NSI.read_text(encoding="utf-8")
+
+
+def _uninstall_sections(text: str) -> dict:
+    """Map uninstaller section header line -> section body."""
+    sections = {}
+    for m in re.finditer(
+        r'^Section\s+"(un\.[^"]+)"[^\n]*\n(.*?)^SectionEnd',
+        text,
+        re.M | re.S,
+    ):
+        sections[m.group(1)] = m.group(2)
+    return sections
+
+
+def test_uninstaller_removes_runtime_dir_in_mandatory_section():
+    sections = _uninstall_sections(_nsi_text())
+    mandatory = [body for body in sections.values() if "SectionIn RO" in body]
+    assert mandatory, "uninstaller must have a mandatory (SectionIn RO) section"
+    assert any(
+        r'RMDir /r "$LOCALAPPDATA\ClawMetry\runtime"' in body for body in mandatory
+    ), (
+        "the mandatory uninstall section must remove "
+        r"%LOCALAPPDATA%\ClawMetry\runtime - leaving it behind strands the "
+        "onboarding-completed.json stamp and a reinstall never re-onboards"
+    )
+
+
+def test_uninstaller_stops_running_processes_before_removal():
+    text = _nsi_text()
+    assert "taskkill" in text, "uninstaller must stop ClawMetry.exe before removal"
+    assert "Stop-Process" in text, (
+        "uninstaller must stop daemon processes running from the runtime venv, "
+        "or Windows file locks leave a half-deleted tree"
+    )
+
+
+def test_account_data_removal_is_a_visible_choice_not_silent():
+    text = _nsi_text()
+    sections = _uninstall_sections(text)
+    data_sections = [
+        (name, body) for name, body in sections.items() if ".clawmetry" in body
+    ]
+    assert data_sections, (
+        "uninstaller must offer removing ~\\.clawmetry (full cleanup was an "
+        "explicit founder ask 2026-08-08)"
+    )
+    for name, body in data_sections:
+        assert "SectionIn RO" not in body, (
+            f"section '{name}' deletes ~\\.clawmetry (the E2E encryption key!) "
+            "but is mandatory - key deletion must be a user-visible choice"
+        )
+    assert "MUI_UNPAGE_COMPONENTS" in text, (
+        "uninstaller needs the components page so the account-data section is "
+        "an actual visible checkbox"
+    )
+    assert re.search(r"MUI_DESCRIPTION_TEXT.*(encryption|unreadable)", text), (
+        "the account-data checkbox must warn that deleting the key makes "
+        "synced snapshots unreadable"
+    )


### PR DESCRIPTION
## Why
Founder report 2026-08-08: uninstalled + reinstalled the Windows desktop app and no onboarding (sign-in) appeared. Root cause on the live lab box: the uninstaller removes only `$INSTDIR` and leaves `%LOCALAPPDATA%\ClawMetry\runtime` behind, so `onboarding-completed.json` (written 14:47 during the first install) keeps `is_first_launch()` False forever, and a ~300MB venv survives 'uninstall'. Founder directive: everything linked to ClawMetry should be cleaned up on uninstall.

## What
`desktop/installer/windows.nsi` uninstaller:
- Stops `ClawMetry.exe` (taskkill /T) and any process running from the runtime venv (Stop-Process by ExecutablePath) so Windows file locks can't strand a half-deleted tree
- Mandatory section now also removes `%LOCALAPPDATA%\ClawMetry\runtime` (venv, onboarding stamp, logs) and `%LOCALAPPDATA%\ClawMetry\bin` (global CLI shim dir), then the empty parent
- New components page (`MUI_UNPAGE_COMPONENTS`): 'Account data + E2E encryption keys (~\.clawmetry)' is a **default-checked but visible and uncheckable** section, with a description warning that deleting the AES-256-GCM key makes already-synced cloud snapshots permanently unreadable. Full cleanup is the default per the founder ask; silent key destruction is the one thing this must never do.

## Guard (same-PR, revert-proven)
`tests/test_windows_installer_uninstall_cleanup.py` pins the contract: runtime dir removed in the mandatory (SectionIn RO) section; processes stopped before removal; `.clawmetry` deletion only in a non-mandatory section with the components page + warning present. Ran the same assertions against the pre-fix `origin/main` nsi: both key markers absent (test red), green after the fix.

## Verification
- Guard test: 3/3 pass in the worktree
- Local `makensis` compile against a stand-in build folder: result posted in a follow-up comment (NSIS was being installed via winget at PR-open time); will not merge without it
- Note: the in-flight desktop branch that strips the shim's user-PATH entry composes with this; removing the bin dir here is complementary, not conflicting

🤖 Generated with [Claude Code](https://claude.com/claude-code)