### PR TITLE
[RELEASE] ship windowless self-update + self-healing sync daemon + global CLI to end users (carries #4657)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Unreleased
 
+- **Release: ship windowless self-update, self-healing sync daemon, global CLI, and trial-expiry banners to end users.**
+  - **Why:** carrier `[RELEASE]` so #4657 reaches PyPI and the fleet. Until this ships, every unattended Windows self-update pops a visible cmd window (seen live during an enterprise client call 2026-08-08), fresh installs that skipped sign-in show an empty dashboard forever, and desktop users have no `clawmetry` on PATH.
+  - **What:** no new code; ships #4657.
+  - **Verified:** end-to-end this release - after PyPI publish, confirm the founder's Windows 11 desktop install auto-updates to the new version (one final visible pip window from the old helper is expected), then confirm the NEXT update check produces zero visible console windows, `clawmetry --version` works in a fresh terminal, and the dashboard shows sessions with the sync daemon healed by the shell.
+
 - **Fix: mystery cmd windows flashing on Windows during self-update.**
   - **Why:** founder report 2026-08-08 — console windows popping open and closing on their own, including during a call with an enterprise client. Traced live with a process-creation monitor: (1) `clawmetry/update_respawn.py` runs detached (no console), so the `pip install` child it spawns without `CREATE_NO_WINDOW` gets a brand-new VISIBLE console for the whole seconds-to-minutes install — this fires on every real unattended update, and the fleet updates constantly; (2) a dashboard running from a source checkout can never version-converge (pip installs to site-packages, the process re-runs the checkout), so the Windows respawn plan looped forever — exit → pip → relaunch → still stale — flashing 3-4 windows per minute.
   - **What:** `update_respawn.py` runs pip with `CREATE_NO_WINDOW`; `routes/update_check.py` gains `_running_from_source_checkout()` (`.git` next to the package) and `_maybe_auto_update()` refuses to fire there, logging why.


### PR DESCRIPTION
## Why
Carrier `[RELEASE]` so #4657 reaches PyPI and the fleet. Until this ships:
- every unattended Windows self-update pops a visible cmd window for the duration of the pip install (seen live during an enterprise client call, 2026-08-08),
- fresh desktop installs that skipped sign-in show an empty dashboard forever (sync daemon never starts, no supervisor),
- desktop users have no `clawmetry` on PATH,
- a trial at 0 days left shows no warning anywhere.

## What
No new code; ships #4657 (windowless `update_respawn` pip, source-checkout auto-update guard, shell-owned sync daemon healing, single-instance guard, global CLI shim, hosting-choice onboarding pane, trial-expiry banners, i18n tooltip fixes, instant warm launches).

## Verified
Post-publish plan (per CHANGELOG entry): confirm the founder's Windows 11 desktop install auto-updates (one final visible pip window from the old helper is expected — the helper runs the OLD wheel's copy), then confirm the NEXT update cycle produces zero visible console windows, `clawmetry --version` resolves in a fresh terminal, and the dashboard shows real sessions with the shell-healed sync daemon.

Note: drift-bot on #4657 red-flagged with stale-snapshot false positives (evidence: https://github.com/vivekchand/clawmetry/pull/4657#issuecomment-5228413988). This PR runs against post-merge main — a green drift-bot here confirms blueprint and code now agree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
