### PR TITLE
feat(entitlement): has_node_count_at_batch + /api/entitlement/has-node-count-at-batch

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -6590,6 +6590,161 @@ def has_node_count_batch(counts) -> list[dict]:
     return out
 
 
+def has_node_count_at_batch(perspective_tier: str, counts) -> list[dict] | None:
+    """Hypothetical-perspective per-value boolean-gate rows on the
+    ``nodes`` capacity axis in ONE round-trip. Perspective-shaped
+    sibling of :func:`has_node_count_at` (singular) and node-axis twin
+    of :func:`has_channel_count_at_batch` / :func:`has_retention_window_at_batch`
+    on the capacity-axis ``_at_batch`` matrix.
+
+    Fills the last ``_at_batch`` slot on the ``nodes`` capacity axis
+    alongside :func:`min_tier_for_node_count_at_batch` (the perspective-
+    tier variant of the reverse-lookup batch on the same axis). A
+    pricing-matrix walkthrough comparing several hypothetical node
+    counts from a fixed perspective ("at OSS -- does 1 / 5 / 25 / 100
+    nodes fit?") renders off ONE URL per perspective instead of ``N``
+    calls to :func:`has_node_count_at` + client-side row assembly.
+
+    Row shape is byte-parity with :func:`has_channel_count_at_batch`
+    and :func:`has_node_count_batch` so a UI already wired for either
+    sibling batch can rebind without reshaping::
+
+        {
+          "key":                "<normalised int as str>",
+          "kind":               "nodes",
+          "has":                <bool>,       # perspective's static cap admits count
+          "unknown":            <bool>,       # True iff non-int input
+          "required_tier":      "<tier id>" | None,   # min_tier_for_node_count(count)
+          "required_tier_label":"<label>"   | None,
+          "required_tier_rank": <int>,        # -1 when required_tier None
+        }
+
+    Perspective-shaped (grace-independent by design): unlike the live
+    :func:`has_node_count_batch` sibling (which will report
+    ``has=True`` for every finite count while ``ent.grace`` is
+    ``True``), each row here reflects the STATIC per-tier cap in
+    :data:`_TIER_NODE_LIMIT` -- ``has_node_count_at_batch("oss", [5])``
+    returns ``has=False`` even in grace, which is the whole point of
+    the ``_at`` slot (render the would-be-locked state alongside the
+    live grant). The perspective-independent ``required_tier`` slot is
+    delegated to :func:`min_tier_for_node_count` so it stays byte-
+    parity with the sibling ``has_node_count_batch`` /
+    ``has_node_count`` / ``min_tier_for_node_count`` scalars for the
+    same count.
+
+    Contract:
+
+    * ``perspective_tier`` is validated against :data:`_TIER_ORDER`
+      (including :data:`TIER_TRIAL`). Empty / non-string / unknown ->
+      ``None`` (caller renders "unknown tier" / 404). Matches the
+      ``None`` posture the rest of the ``_at_batch`` family uses for
+      the perspective-validation failure mode (see
+      :func:`has_channel_count_at_batch` and
+      :func:`min_tier_for_node_count_at_batch`).
+    * ``counts`` is any iterable. ``None`` or non-iterable -> ``[]``
+      (mirrors :func:`has_node_count_batch`).
+    * Per-value dedup by ``str(int(raw))`` when parseable, else
+      ``str(raw)``. First-seen order preserved.
+    * Non-int items surface as one row with ``unknown=True`` /
+      ``has=False`` (strict callsite-typo fail-closed posture matching
+      :func:`has_node_count_at`).
+    * ``count <= 0`` -- ``has=True`` (trivially satisfied by the free
+      floor on every perspective, mirrors :func:`has_node_count_at`'s
+      zero contract); ``required_tier="oss"`` per
+      :func:`min_tier_for_node_count`.
+    * Positive int -- ``has`` reflects the perspective's cap in
+      :data:`_TIER_NODE_LIMIT` (``None`` there means unlimited, any
+      integer is the hard cap); ``required_tier`` is the cheapest tier
+      admitting ``count`` per :func:`min_tier_for_node_count`.
+
+    Never raises: any per-row failure short-circuits to the fail-
+    closed row shape so the paywall matrix keeps rendering.
+    """
+    try:
+        p = (perspective_tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if not p or p not in _TIER_ORDER:
+        return None
+    try:
+        if counts is None:
+            return []
+        items = list(counts)
+    except TypeError:
+        return []
+    try:
+        cap = _TIER_NODE_LIMIT.get(p, _FREE_NODE_LIMIT)
+    except Exception as exc:
+        logger.warning(
+            "entitlements: has_node_count_at_batch(%r) cap lookup failed: %s",
+            perspective_tier,
+            exc,
+        )
+        return None
+    out: list[dict] = []
+    seen: set[str] = set()
+    for raw in items:
+        try:
+            n = int(raw)
+            key = str(n)
+            parsed_ok = True
+        except (TypeError, ValueError):
+            key = str(raw)
+            n = None
+            parsed_ok = False
+        if key in seen:
+            continue
+        seen.add(key)
+        if not parsed_ok:
+            out.append(
+                {
+                    "key": key,
+                    "kind": "nodes",
+                    "has": False,
+                    "unknown": True,
+                    "required_tier": None,
+                    "required_tier_label": None,
+                    "required_tier_rank": -1,
+                }
+            )
+            continue
+        try:
+            if n <= 0:
+                has_flag = True
+            else:
+                has_flag = cap is None or n <= int(cap)
+            req = min_tier_for_node_count(n)
+            out.append(
+                {
+                    "key": key,
+                    "kind": "nodes",
+                    "has": bool(has_flag),
+                    "unknown": False,
+                    "required_tier": req,
+                    "required_tier_label": tier_label(req) if req else None,
+                    "required_tier_rank": tier_rank(req) if req else -1,
+                }
+            )
+        except Exception as exc:
+            logger.warning(
+                "entitlements: has_node_count_at_batch row(%r) failed: %s",
+                raw,
+                exc,
+            )
+            out.append(
+                {
+                    "key": key,
+                    "kind": "nodes",
+                    "has": False,
+                    "unknown": True,
+                    "required_tier": None,
+                    "required_tier_label": None,
+                    "required_tier_rank": -1,
+                }
+            )
+    return out
+
+
 def has_features(features) -> bool:
     """Boolean-gate scalar: does the CURRENT install allow **all** ``features``?
 

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -38559,3 +38559,209 @@ def _runtime_detection_counts(probes: list) -> dict:
         "unlocked": unlocked,
         "locked": locked,
     }
+
+
+def _has_node_count_at_batch_row_to_body(row: dict, count_raw: str) -> dict:
+    """Translate a :func:`has_node_count_at_batch` scalar row into the
+    endpoint body row shape.
+
+    Perspective-shaped batch sibling of
+    :func:`_has_node_count_batch_row_to_body`. Rekeys ``has`` ->
+    ``has_node_count_at`` / ``allowed`` (matches the singular
+    ``/api/entitlement/has-node-count-at`` body), replaces the
+    normalised-str ``key`` with an int ``count`` (or ``null`` on non-
+    int input) plus the caller's raw ``count_raw`` echo, and layers a
+    conjugated human ``label`` ("1 node" / "5 nodes") matching the
+    sibling ``/min-tier-for-node-count-at-batch`` shape.
+
+    Drops the ``upgrade_required`` bit that
+    :func:`_has_node_count_batch_row_to_body` carries: this is the
+    perspective-shaped ``_at`` slot, so "would tier X admit this?" is
+    the row's whole point -- comparing that answer against the LIVE
+    current-tier rank would double-count the perspective in the paywall
+    matrix cell (matches the singular ``/has-node-count-at`` sibling,
+    which omits ``upgrade_required`` for the same reason).
+
+    Never raises: missing keys / bad rows surface as the all-``None``
+    row shape so the batch keeps building.
+    """
+    try:
+        n = int(row.get("key"))
+        count: int | None = n
+        label = f"{n} node" if n == 1 else f"{n} nodes"
+    except (TypeError, ValueError):
+        count = None
+        label = None
+    req_rank = row.get("required_tier_rank")
+    if req_rank is None:
+        req_rank = -1
+    has_flag = bool(row.get("has"))
+    return {
+        "count": count,
+        "count_raw": count_raw,
+        "kind": "node_count",
+        "label": label,
+        "has_node_count_at": has_flag,
+        "allowed": has_flag,
+        "unknown": bool(row.get("unknown")),
+        "required_tier": row.get("required_tier"),
+        "required_tier_label": row.get("required_tier_label"),
+        "required_tier_rank": req_rank,
+    }
+
+
+def _has_node_count_at_batch_fallback(tier_in: str) -> dict:
+    """Grace-shape fallback body for
+    ``/api/entitlement/has-node-count-at-batch``. Sibling of
+    :func:`_has_node_count_batch_fallback` with the perspective envelope
+    layered on: on a resolver crash the pricing surface keeps rendering
+    with an empty ``rows`` list instead of a stack trace, and the "from
+    <perspective>" copy still has its placeholders.
+
+    Never raises: any tier-metadata blowup falls back to the raw
+    ``tier_in`` string and rank ``0``.
+    """
+    try:
+        from clawmetry import entitlements as _ent
+
+        label = _ent.tier_label(tier_in)
+        rank = _ent.tier_rank(tier_in)
+    except Exception:
+        label = tier_in
+        rank = 0
+    return {
+        "kind": "node_count",
+        "count": 0,
+        "rows": [],
+        "perspective_tier": tier_in,
+        "perspective_tier_label": label,
+        "perspective_tier_rank": rank,
+        "current_tier": "oss",
+        "current_tier_rank": 0,
+        "grace": True,
+        "enforced": False,
+    }
+
+
+@bp_entitlement.route("/api/entitlement/has-node-count-at-batch")
+def api_entitlement_has_node_count_at_batch():
+    """``GET /api/entitlement/has-node-count-at-batch?tier=<perspective>
+    &counts=1,5,100`` -- per-value what-if boolean-gate batch sibling of
+    ``/api/entitlement/has-node-count-at`` on the ``nodes`` capacity
+    axis.
+
+    Perspective-shaped twin of ``/api/entitlement/has-node-count-batch``
+    (which uses the LIVE resolved entitlement). Fills the last
+    ``_at_batch`` slot on the ``nodes`` capacity axis alongside
+    ``/api/entitlement/min-tier-for-node-count-at-batch`` (the
+    perspective-tier variant of the reverse-lookup batch on the same
+    axis).
+
+    Where the singular ``/has-node-count-at?tier=<perspective>&count=<N>``
+    answers ONE (``has_node_count_at``, ``required_tier``) pair per
+    request, this batch answers all requested counts in ONE round-trip
+    so a pricing-matrix walkthrough ("at OSS -- does 1 / 5 / 25 / 100
+    nodes fit?") binds off one URL per perspective instead of ``N``
+    calls to ``/has-node-count-at?tier=oss&count=<N>``.
+
+    - **400** when ``tier=`` is missing / blank, OR when ``counts=`` is
+      missing / blank / only-commas.
+    - **404** when ``tier`` is unknown (body carries ``which=tier``).
+    - **Never 5xxs**: resolver failure -> perspective-carrying grace
+      body with empty ``rows``.
+
+    Per-row body shape (mirrors the sibling
+    ``/has-node-count-batch`` per-row shape with ``has_node_count_at``
+    in place of ``has_node_count`` and no ``upgrade_required`` bit --
+    the ``_at`` slot is perspective-shaped, so comparing against the
+    LIVE current-tier rank would double-count the perspective; matches
+    the singular ``/has-node-count-at`` sibling which omits it for the
+    same reason)::
+
+        {
+          "count":              <int> | null,
+          "count_raw":          "<stripped raw token>",
+          "kind":               "node_count",
+          "label":              "1 node" | "5 nodes" | null,
+          "has_node_count_at":  <bool>,
+          "allowed":            <bool>,               # mirror of has_node_count_at
+          "unknown":            <bool>,               # true iff non-int input
+          "required_tier":      "<tier id>" | null,
+          "required_tier_label":"<label>"   | null,
+          "required_tier_rank": <int>,                # -1 when required_tier null
+        }
+
+    Envelope wraps ``rows`` with ``kind`` / ``count`` (row count) plus
+    ``perspective_tier`` / ``perspective_tier_label`` /
+    ``perspective_tier_rank`` and the standard resolver envelope
+    (``current_tier`` / ``current_tier_rank`` / ``grace`` /
+    ``enforced``) so a UI can render "you are here" alongside the
+    per-row grants under the requested perspective.
+
+    Perspective-shaped (grace-independent by design): unlike the LIVE
+    ``/has-node-count-batch`` sibling (which reports ``allowed=true``
+    for every finite count while ``ent.grace`` is ``True``), each row
+    here reflects the STATIC per-tier cap in :data:`_TIER_NODE_LIMIT`
+    -- ``has-node-count-at-batch?tier=oss&counts=5`` returns
+    ``allowed=false`` even in grace, which is the whole point of the
+    ``_at`` slot.
+
+    Cross-consistency: each row's ``has_node_count_at`` byte-equals the
+    singular ``/api/entitlement/has-node-count-at`` endpoint for the
+    same (``tier``, ``count``) pair; each row's ``required_tier``
+    byte-equals the sibling
+    ``/api/entitlement/min-tier-for-node-count-at-batch`` row for the
+    same count.
+    """
+    raw_tier = request.args.get("tier")
+    tier_in = (raw_tier or "").strip().lower()
+    if not tier_in:
+        return jsonify({"error": "missing tier"}), 400
+    values, err = _parse_capacity_batch_csv("counts", unlimited_ok=False)
+    if err == "missing":
+        return jsonify({"error": "missing counts"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        if tier_in not in _ent._TIER_ORDER:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "tier", "tier": tier_in}
+                ),
+                404,
+            )
+        helper_rows = _ent.has_node_count_at_batch(tier_in, values) or []
+        raw_by_key: dict[str, str] = {}
+        for raw in values:
+            try:
+                key = str(int(raw))
+            except (TypeError, ValueError):
+                key = str(raw)
+            raw_by_key.setdefault(key, str(raw))
+        rows = [
+            _has_node_count_at_batch_row_to_body(
+                r,
+                raw_by_key.get(str(r.get("key")), str(r.get("key"))),
+            )
+            for r in helper_rows
+        ]
+        ent = _ent.get_entitlement()
+        return jsonify(
+            {
+                "kind": "node_count",
+                "count": len(rows),
+                "rows": rows,
+                "perspective_tier": tier_in,
+                "perspective_tier_label": _ent.tier_label(tier_in),
+                "perspective_tier_rank": _ent.tier_rank(tier_in),
+                "current_tier": ent.tier,
+                "current_tier_rank": _ent.tier_rank(ent.tier),
+                "grace": bool(ent.grace),
+                "enforced": _ent.is_enforced(),
+            }
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_has_node_count_at_batch: error: %s", exc
+        )
+        return jsonify(_has_node_count_at_batch_fallback(tier_in))

--- a/tests/test_entitlement_has_node_count_at_batch.py
+++ b/tests/test_entitlement_has_node_count_at_batch.py
@@ -1,0 +1,711 @@
+"""Tests for the ``has_node_count_at_batch`` hypothetical-perspective per-
+value boolean-gate scalar and its paired
+``/api/entitlement/has-node-count-at-batch`` endpoint.
+
+Perspective-shaped batch sibling of :func:`has_node_count_at` (singular)
+and node-axis twin of :func:`has_channel_count_at_batch` /
+:func:`has_retention_window_at_batch` on the capacity-axis
+``_at_batch`` matrix. Fills the last ``_at_batch`` slot on the ``nodes``
+capacity axis alongside :func:`min_tier_for_node_count_at_batch` (the
+perspective-tier variant of the reverse-lookup batch on the same axis).
+
+Where the singular ``/has-node-count-at?tier=<perspective>&count=<N>``
+answers ONE (``has_node_count_at``, ``required_tier``) pair per request,
+this batch answers all requested counts in ONE round-trip so a pricing-
+matrix walkthrough ("at OSS -- does 1 / 5 / 25 / 100 nodes fit?") binds
+off one URL per perspective instead of ``N`` calls to
+``/has-node-count-at?tier=oss&count=<N>``.
+
+This file pins:
+
+1. Scalar semantics: empty / None / non-string / unknown perspective ->
+   ``None`` (matches :func:`has_channel_count_at_batch` posture);
+   None / non-iterable ``counts`` -> ``[]``; non-int items surface as
+   one row with ``unknown=True`` / ``has=False`` (strict callsite-typo
+   posture); zero / negative counts are trivially satisfied by the free
+   floor on every perspective; positive counts reflect the perspective's
+   STATIC cap in :data:`_TIER_NODE_LIMIT` (grace-independent by design).
+2. Per-value dedup by normalised int key, preserving first-seen order.
+3. Per-row byte-parity with :func:`has_node_count_at` (boolean gate) and
+   :func:`min_tier_for_node_count` (perspective-independent reverse
+   lookup) across a mixed (perspective, count) grid.
+4. Endpoint envelope shape (fixed key set) across every input branch;
+   ``label`` conjugation matches the sibling
+   ``/min-tier-for-node-count-at-batch`` row shape ("1 node" /
+   "5 nodes").
+5. Missing / blank ``?tier=`` or ``?counts=`` -> 400; unknown ``tier``
+   -> 404 with body ``{"error": "unknown tier", "which": "tier",
+   "tier": ...}``. Every other input branch is never-4xx / never-5xx
+   (resolver / scalar / row-shape helper blowups all collapse to the
+   grace-shape envelope with an empty ``rows`` list).
+6. Cross-consistency with the singular
+   ``/api/entitlement/has-node-count-at`` and the sibling
+   ``/api/entitlement/min-tier-for-node-count-at-batch`` endpoints on
+   the ``has_node_count_at`` / ``required_tier`` slots -- byte-parity
+   per row so a paywall matrix wiring both cannot see inconsistent
+   tier state.
+7. Grace-independence assertion: the ``_at`` batch reports ``has=false``
+   on OSS even while ``ent.grace`` is True, whereas the LIVE
+   :func:`has_node_count_batch` sibling reports True for every finite
+   count in grace. Enforced-mode fixture returns byte-stable envelope
+   with identical rows (perspective is grace-independent by design).
+8. No ``upgrade_required`` bit on the row shape: this is the
+   perspective-shaped ``_at`` slot, so comparing against the LIVE
+   current-tier rank would double-count the perspective in the paywall
+   matrix cell (matches the singular ``/has-node-count-at`` sibling
+   which omits it for the same reason).
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+# ── Fixtures ────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    """Fresh entitlements module in OSS-free grace mode -- matches the
+    fixture shape in ``tests/test_entitlement_has_node_count_at.py`` so
+    per-row assertions here reproduce the same install state the
+    singular scalar is pinned against."""
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def enforced(monkeypatch, tmp_path):
+    """Enforcement-on fixture: ``CLAWMETRY_ENFORCE=1`` flips
+    ``ent.grace`` off. Included to pin the perspective-shaped grace-
+    independence invariant -- ``has_node_count_at_batch`` returns the
+    same rows under grace vs enforce for the same (perspective, counts)
+    pair."""
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    importlib.reload(e)
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+@pytest.fixture
+def enforced_client(enforced):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# ── Envelope shape ──────────────────────────────────────────────────────────
+
+
+_ROW_KEYS = {
+    "count",
+    "count_raw",
+    "kind",
+    "label",
+    "has_node_count_at",
+    "allowed",
+    "unknown",
+    "required_tier",
+    "required_tier_label",
+    "required_tier_rank",
+}
+
+_ENVELOPE_KEYS = {
+    "kind",
+    "count",
+    "rows",
+    "perspective_tier",
+    "perspective_tier_label",
+    "perspective_tier_rank",
+    "current_tier",
+    "current_tier_rank",
+    "grace",
+    "enforced",
+}
+
+
+def _get_json(client, url: str, expected_status: int = 200) -> dict:
+    resp = client.get(url)
+    assert resp.status_code == expected_status, (url, resp.status_code)
+    return resp.get_json()
+
+
+# ── Scalar-level tests ─────────────────────────────────────────────────────
+
+
+def test_scalar_empty_perspective_returns_none(ent):
+    for bad in ["", " ", "\t"]:
+        assert ent.has_node_count_at_batch(bad, [1, 5]) is None, bad
+
+
+def test_scalar_non_string_perspective_returns_none(ent):
+    for bad in [None, 123, object(), []]:
+        assert ent.has_node_count_at_batch(bad, [1, 5]) is None, bad
+
+
+def test_scalar_unknown_perspective_returns_none(ent):
+    for bad in ["mars", "pro_plus", "starter", "unknown_tier"]:
+        assert ent.has_node_count_at_batch(bad, [1, 5]) is None, bad
+
+
+def test_scalar_known_perspective_returns_list(ent):
+    for tier in ent._TIER_ORDER:
+        rows = ent.has_node_count_at_batch(tier, [5])
+        assert isinstance(rows, list), tier
+        assert len(rows) == 1, tier
+
+
+def test_scalar_perspective_normalised_uppercase(ent):
+    """``strip().lower()`` before ``_TIER_ORDER`` check -- ``ENTERPRISE`` is
+    the same perspective as ``enterprise``."""
+    r_upper = ent.has_node_count_at_batch("  ENTERPRISE  ", [5])
+    r_lower = ent.has_node_count_at_batch("enterprise", [5])
+    assert r_upper == r_lower
+
+
+def test_scalar_none_counts_returns_empty(ent):
+    assert ent.has_node_count_at_batch("oss", None) == []
+
+
+def test_scalar_non_iterable_counts_returns_empty(ent):
+    assert ent.has_node_count_at_batch("oss", 5) == []
+    assert ent.has_node_count_at_batch("oss", True) == []
+
+
+def test_scalar_empty_iterable_counts_returns_empty(ent):
+    assert ent.has_node_count_at_batch("oss", []) == []
+    assert ent.has_node_count_at_batch("oss", ()) == []
+    assert ent.has_node_count_at_batch("oss", set()) == []
+
+
+def test_scalar_zero_and_negative_are_free_floor_on_every_perspective(ent):
+    """``count <= 0`` is trivially satisfied by the free floor on every
+    real tier (mirrors :func:`has_node_count_at`'s zero contract)."""
+    for tier in ent._TIER_ORDER:
+        rows = ent.has_node_count_at_batch(tier, [0, -1, -100])
+        assert len(rows) == 3, tier
+        for row in rows:
+            assert row["has"] is True, (tier, row)
+            assert row["unknown"] is False, (tier, row)
+            assert row["required_tier"] == "oss", (tier, row)
+
+
+def test_scalar_oss_cap_is_one(ent):
+    """OSS statically caps at ``_FREE_NODE_LIMIT`` = 1. Any count above 1
+    collapses to has=False regardless of grace state."""
+    rows = ent.has_node_count_at_batch("oss", [1, 2, 5, 10_000])
+    by_key = {r["key"]: r for r in rows}
+    assert by_key["1"]["has"] is True
+    for k in ("2", "5", "10000"):
+        assert by_key[k]["has"] is False, k
+        assert by_key[k]["unknown"] is False, k
+
+
+def test_scalar_paid_tiers_are_unlimited(ent):
+    """Every tier whose ``_TIER_NODE_LIMIT[tier] is None`` admits any
+    positive count. Verifies the static per-tier cap table drives the
+    per-row ``has`` slot."""
+    for tier in ent._TIER_ORDER:
+        cap = ent._TIER_NODE_LIMIT.get(tier, ent._FREE_NODE_LIMIT)
+        rows = ent.has_node_count_at_batch(tier, [1, 100, 1_000_000])
+        by_key = {r["key"]: r for r in rows}
+        if cap is None:
+            for k in ("1", "100", "1000000"):
+                assert by_key[k]["has"] is True, (tier, k)
+        else:
+            # Finite cap: admits <= cap, denies > cap.
+            for k in ("1", "100", "1000000"):
+                n = int(k)
+                assert by_key[k]["has"] is (n <= cap), (tier, k)
+
+
+def test_scalar_non_int_is_unknown_false(ent):
+    rows = ent.has_node_count_at_batch(
+        "cloud_pro", ["five", None, [], object()]
+    )
+    assert len(rows) == 4
+    for row in rows:
+        assert row["has"] is False, row
+        assert row["unknown"] is True, row
+        assert row["required_tier"] is None
+        assert row["required_tier_rank"] == -1
+
+
+def test_scalar_dedupes_by_int_key(ent):
+    """Duplicates by normalised int key collapse, first-seen order preserved."""
+    rows = ent.has_node_count_at_batch("cloud_pro", [5, 5, "5", 1, 1, 5])
+    keys = [r["key"] for r in rows]
+    assert keys == ["5", "1"]
+
+
+def test_scalar_dedupes_non_int_by_raw_string(ent):
+    rows = ent.has_node_count_at_batch("cloud_pro", ["five", "five", "six"])
+    assert [r["key"] for r in rows] == ["five", "six"]
+
+
+def test_scalar_string_int_parses(ent):
+    """``int("5")`` succeeds, so a string-int is treated as the int itself
+    (matches :func:`has_node_count_at`)."""
+    rows = ent.has_node_count_at_batch("cloud_pro", ["1", "5"])
+    assert [r["key"] for r in rows] == ["1", "5"]
+    for row in rows:
+        assert row["unknown"] is False
+        assert row["has"] is True  # cloud_pro is unlimited
+
+
+def test_scalar_row_shape_keys(ent):
+    row = ent.has_node_count_at_batch("cloud_pro", [5])[0]
+    assert set(row.keys()) == {
+        "key",
+        "kind",
+        "has",
+        "unknown",
+        "required_tier",
+        "required_tier_label",
+        "required_tier_rank",
+    }
+    assert row["kind"] == "nodes"
+
+
+def test_scalar_parity_with_singular_has_node_count_at(ent):
+    """Every row's ``has`` byte-equals :func:`has_node_count_at` on the
+    same (perspective, count) pair across every tier."""
+    counts = [0, 1, 2, 5, 10, 100, 1_000]
+    for tier in ent._TIER_ORDER:
+        rows = ent.has_node_count_at_batch(tier, counts)
+        for row in rows:
+            n = int(row["key"])
+            assert row["has"] is ent.has_node_count_at(tier, n), (tier, n)
+
+
+def test_scalar_required_tier_perspective_independent(ent):
+    """``required_tier`` byte-equals :func:`min_tier_for_node_count` on the
+    same count for every perspective -- the reverse-lookup answer is
+    perspective-independent by design (matches
+    :func:`has_channel_count_at_batch`)."""
+    counts = [0, 1, 2, 5, 100]
+    baseline = {n: ent.min_tier_for_node_count(n) for n in counts}
+    for tier in ent._TIER_ORDER:
+        rows = ent.has_node_count_at_batch(tier, counts)
+        for row in rows:
+            n = int(row["key"])
+            assert row["required_tier"] == baseline[n], (tier, n)
+
+
+def test_scalar_grace_independence_oss_denies_above_free_floor(ent):
+    """The whole point of the ``_at`` slot: ``has_node_count_at_batch("oss",
+    [5])`` returns ``has=False`` even while ``ent.grace`` is True,
+    unlike the LIVE :func:`has_node_count_batch` sibling."""
+    live = ent.get_entitlement()
+    assert live.grace is True
+    assert ent.has_node_count_batch([5])[0]["has"] is True
+    assert ent.has_node_count_at_batch("oss", [5])[0]["has"] is False
+
+
+def test_scalar_enforced_mode_returns_same_rows(ent, enforced):
+    """Perspective-shaped rows are grace-independent by design: the same
+    (perspective, counts) pair produces byte-identical rows under grace
+    vs enforce."""
+    counts = [0, 1, 5, 100, "five"]
+    for tier in ent._TIER_ORDER:
+        assert ent.has_node_count_at_batch(
+            tier, counts
+        ) == enforced.has_node_count_at_batch(tier, counts), tier
+
+
+def test_scalar_never_raises_on_cap_lookup_blowup(monkeypatch, ent):
+    """A ``_TIER_NODE_LIMIT`` lookup blowup returns ``None`` (matches the
+    perspective-validation failure mode) instead of raising."""
+
+    class _Boom(dict):
+        def get(self, *_a, **_kw):
+            raise RuntimeError("cap lookup blew up")
+
+    monkeypatch.setattr(ent, "_TIER_NODE_LIMIT", _Boom())
+    assert ent.has_node_count_at_batch("oss", [1, 5]) is None
+
+
+def test_scalar_never_raises_on_min_tier_blowup(monkeypatch, ent):
+    """A per-row ``min_tier_for_node_count`` blowup short-circuits to the
+    fail-closed row shape so the batch keeps building."""
+
+    def _boom(*_a, **_kw):
+        raise RuntimeError("min tier blew up")
+
+    monkeypatch.setattr(ent, "min_tier_for_node_count", _boom)
+    rows = ent.has_node_count_at_batch("oss", [1, 5])
+    assert len(rows) == 2
+    for row in rows:
+        assert row["has"] is False
+        assert row["unknown"] is True
+        assert row["required_tier"] is None
+
+
+# ── Endpoint envelope shape ────────────────────────────────────────────────
+
+
+def test_endpoint_missing_tier_400(client):
+    resp = client.get("/api/entitlement/has-node-count-at-batch?counts=5")
+    assert resp.status_code == 400
+    assert resp.get_json() == {"error": "missing tier"}
+
+
+def test_endpoint_blank_tier_400(client):
+    resp = client.get(
+        "/api/entitlement/has-node-count-at-batch?tier=&counts=5"
+    )
+    assert resp.status_code == 400
+    resp = client.get(
+        "/api/entitlement/has-node-count-at-batch?tier=%20&counts=5"
+    )
+    assert resp.status_code == 400
+
+
+def test_endpoint_missing_counts_400(client):
+    resp = client.get("/api/entitlement/has-node-count-at-batch?tier=oss")
+    assert resp.status_code == 400
+    assert resp.get_json() == {"error": "missing counts"}
+
+
+def test_endpoint_blank_counts_400(client):
+    resp = client.get(
+        "/api/entitlement/has-node-count-at-batch?tier=oss&counts="
+    )
+    assert resp.status_code == 400
+    resp = client.get(
+        "/api/entitlement/has-node-count-at-batch?tier=oss&counts=%20%20"
+    )
+    assert resp.status_code == 400
+
+
+def test_endpoint_unknown_tier_404_body_shape(client):
+    resp = client.get(
+        "/api/entitlement/has-node-count-at-batch?tier=bogus&counts=5"
+    )
+    assert resp.status_code == 404
+    body = resp.get_json()
+    assert body == {"error": "unknown tier", "which": "tier", "tier": "bogus"}
+
+
+def test_endpoint_envelope_shape(client):
+    body = _get_json(
+        client,
+        "/api/entitlement/has-node-count-at-batch?tier=oss&counts=1,5,100",
+    )
+    assert set(body.keys()) == _ENVELOPE_KEYS
+    assert body["kind"] == "node_count"
+    assert body["count"] == 3
+    assert isinstance(body["rows"], list)
+    assert len(body["rows"]) == 3
+    assert body["perspective_tier"] == "oss"
+    assert body["current_tier"] == "oss"
+    assert body["current_tier_rank"] == 0
+    for row in body["rows"]:
+        assert set(row.keys()) == _ROW_KEYS
+
+
+def test_endpoint_row_types(client):
+    body = _get_json(
+        client,
+        "/api/entitlement/has-node-count-at-batch?tier=cloud_pro&counts=1,5",
+    )
+    for row in body["rows"]:
+        assert isinstance(row["count"], int) or row["count"] is None
+        assert isinstance(row["count_raw"], str)
+        assert row["kind"] == "node_count"
+        assert isinstance(row["label"], (str, type(None)))
+        assert isinstance(row["has_node_count_at"], bool)
+        assert isinstance(row["allowed"], bool)
+        assert row["has_node_count_at"] == row["allowed"]
+        assert isinstance(row["unknown"], bool)
+        assert isinstance(row["required_tier_rank"], int)
+
+
+def test_endpoint_no_upgrade_required_bit(client):
+    """The ``_at`` slot is perspective-shaped, so ``upgrade_required``
+    would double-count the perspective. Matches the singular
+    ``/has-node-count-at`` sibling which omits it for the same reason."""
+    body = _get_json(
+        client,
+        "/api/entitlement/has-node-count-at-batch?tier=oss&counts=1,5",
+    )
+    for row in body["rows"]:
+        assert "upgrade_required" not in row
+
+
+def test_endpoint_label_conjugation(client):
+    """Label matches the sibling ``/min-tier-for-node-count-at-batch`` shape."""
+    body = _get_json(
+        client,
+        "/api/entitlement/has-node-count-at-batch?tier=cloud_pro&counts=1,5,100",
+    )
+    by_count = {r["count"]: r for r in body["rows"]}
+    assert by_count[1]["label"] == "1 node"
+    assert by_count[5]["label"] == "5 nodes"
+    assert by_count[100]["label"] == "100 nodes"
+
+
+def test_endpoint_deduped(client):
+    body = _get_json(
+        client,
+        "/api/entitlement/has-node-count-at-batch?tier=cloud_pro&counts=5,5,1,5,1",
+    )
+    counts = [r["count"] for r in body["rows"]]
+    assert counts == [5, 1]
+
+
+def test_endpoint_oss_grace_independence(client):
+    """``/has-node-count-at-batch?tier=oss`` reports ``allowed=false`` for
+    counts above the free floor EVEN IN GRACE -- the whole point of the
+    ``_at`` slot."""
+    body = _get_json(
+        client,
+        "/api/entitlement/has-node-count-at-batch?tier=oss&counts=1,5,100",
+    )
+    assert body["grace"] is True
+    by_count = {r["count"]: r for r in body["rows"]}
+    assert by_count[1]["allowed"] is True
+    assert by_count[5]["allowed"] is False
+    assert by_count[100]["allowed"] is False
+
+
+def test_endpoint_paid_tier_all_positive_true(client):
+    body = _get_json(
+        client,
+        "/api/entitlement/has-node-count-at-batch?tier=cloud_pro&counts=1,5,100,10000",
+    )
+    for row in body["rows"]:
+        assert row["allowed"] is True
+        assert row["has_node_count_at"] is True
+
+
+def test_endpoint_zero_and_negative_free_floor(client):
+    body = _get_json(
+        client,
+        "/api/entitlement/has-node-count-at-batch?tier=oss&counts=0,-1,-100",
+    )
+    for row in body["rows"]:
+        assert row["allowed"] is True
+        assert row["required_tier"] == "oss"
+
+
+def test_endpoint_non_int_tokens_unknown(client):
+    body = _get_json(
+        client,
+        "/api/entitlement/has-node-count-at-batch?tier=cloud_pro&counts=five,ten,1",
+    )
+    by_raw = {r["count_raw"]: r for r in body["rows"]}
+    assert by_raw["five"]["unknown"] is True
+    assert by_raw["five"]["allowed"] is False
+    assert by_raw["five"]["count"] is None
+    assert by_raw["ten"]["unknown"] is True
+    assert by_raw["1"]["unknown"] is False
+    assert by_raw["1"]["count"] == 1
+
+
+def test_endpoint_whitespace_tokens_dropped(client):
+    body = _get_json(
+        client,
+        "/api/entitlement/has-node-count-at-batch?tier=cloud_pro&counts=1,%20,5,%20%20",
+    )
+    counts = [r["count"] for r in body["rows"]]
+    assert counts == [1, 5]
+
+
+def test_endpoint_perspective_tier_normalised_uppercase(client):
+    """``strip().lower()`` before ``_TIER_ORDER`` check -- ``ENTERPRISE`` is
+    the same perspective as ``enterprise``."""
+    body_upper = _get_json(
+        client,
+        "/api/entitlement/has-node-count-at-batch?tier=%20ENTERPRISE%20&counts=5",
+    )
+    body_lower = _get_json(
+        client,
+        "/api/entitlement/has-node-count-at-batch?tier=enterprise&counts=5",
+    )
+    assert body_upper["perspective_tier"] == "enterprise"
+    assert body_upper["rows"] == body_lower["rows"]
+
+
+def test_endpoint_never_5xx_on_resolver_blowup(monkeypatch, client):
+    from clawmetry import entitlements as _ent
+
+    def _boom(*a, **kw):
+        raise RuntimeError("resolver blew up")
+
+    monkeypatch.setattr(_ent, "get_entitlement", _boom)
+    resp = client.get(
+        "/api/entitlement/has-node-count-at-batch?tier=oss&counts=1,5"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert set(body.keys()) == _ENVELOPE_KEYS
+    assert body["rows"] == []
+    assert body["count"] == 0
+    assert body["perspective_tier"] == "oss"
+
+
+def test_endpoint_never_5xx_on_scalar_blowup(monkeypatch, client):
+    from clawmetry import entitlements as _ent
+
+    def _boom(*a, **kw):
+        raise RuntimeError("scalar blew up")
+
+    monkeypatch.setattr(_ent, "has_node_count_at_batch", _boom)
+    resp = client.get(
+        "/api/entitlement/has-node-count-at-batch?tier=oss&counts=1,5"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["rows"] == []
+
+
+def test_endpoint_never_5xx_on_row_shape_blowup(monkeypatch, client):
+    import routes.entitlement as ent_route
+
+    def _boom(*a, **kw):
+        raise RuntimeError("row shape blew up")
+
+    monkeypatch.setattr(
+        ent_route, "_has_node_count_at_batch_row_to_body", _boom
+    )
+    resp = client.get(
+        "/api/entitlement/has-node-count-at-batch?tier=oss&counts=1,5"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["rows"] == []
+
+
+# ── Cross-consistency with sibling endpoints ──────────────────────────────
+
+
+def test_endpoint_required_tier_parity_with_min_tier_at_batch(client):
+    """``required_tier`` on each row byte-equals the sibling
+    ``/api/entitlement/min-tier-for-node-count-at-batch`` row for the
+    same count -- a UI wiring both cannot see inconsistent tier state."""
+    body_has = _get_json(
+        client,
+        "/api/entitlement/has-node-count-at-batch?tier=oss&counts=1,5,100",
+    )
+    body_min = _get_json(
+        client,
+        "/api/entitlement/min-tier-for-node-count-at-batch?tier=oss&counts=1,5,100",
+    )
+    has_rt = {r["count"]: r["required_tier"] for r in body_has["rows"]}
+    min_rt = {r["item"]: r["required_tier"] for r in body_min["rows"]}
+    assert has_rt == min_rt
+
+
+def test_endpoint_has_node_count_at_parity_with_singular(client):
+    """Every row's ``has_node_count_at`` byte-equals the singular
+    ``/api/entitlement/has-node-count-at`` endpoint for the same
+    (perspective, count) pair."""
+    body = _get_json(
+        client,
+        "/api/entitlement/has-node-count-at-batch?tier=oss&counts=1,5,100,0",
+    )
+    for row in body["rows"]:
+        n = row["count"]
+        singular = _get_json(
+            client,
+            f"/api/entitlement/has-node-count-at?tier=oss&count={n}",
+        )
+        assert row["has_node_count_at"] == singular["has_node_count_at"], n
+        assert row["required_tier"] == singular["required_tier"], n
+        assert row["required_tier_rank"] == singular["required_tier_rank"], n
+
+
+def test_endpoint_scalar_vs_endpoint_parity(client, ent):
+    body = _get_json(
+        client,
+        "/api/entitlement/has-node-count-at-batch?tier=oss&counts=0,1,5,100",
+    )
+    scalar = ent.has_node_count_at_batch("oss", [0, 1, 5, 100])
+    assert len(body["rows"]) == len(scalar)
+    for row, s in zip(body["rows"], scalar):
+        assert row["has_node_count_at"] is s["has"]
+        assert row["required_tier"] == s["required_tier"]
+        assert row["unknown"] is s["unknown"]
+
+
+# ── Envelope stability across many input branches ────────────────────────
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "/api/entitlement/has-node-count-at-batch?tier=oss&counts=1",
+        "/api/entitlement/has-node-count-at-batch?tier=oss&counts=1,5,100",
+        "/api/entitlement/has-node-count-at-batch?tier=oss&counts=0",
+        "/api/entitlement/has-node-count-at-batch?tier=oss&counts=-1",
+        "/api/entitlement/has-node-count-at-batch?tier=oss&counts=five,1",
+        "/api/entitlement/has-node-count-at-batch?tier=oss&counts=1,1,1",
+        "/api/entitlement/has-node-count-at-batch?tier=oss&counts=%201%20,%205%20",
+        "/api/entitlement/has-node-count-at-batch?tier=cloud_pro&counts=1,5,100",
+        "/api/entitlement/has-node-count-at-batch?tier=enterprise&counts=1,10000",
+        "/api/entitlement/has-node-count-at-batch?tier=trial&counts=1,5",
+    ],
+)
+def test_endpoint_envelope_stable(client, url):
+    body = _get_json(client, url)
+    assert set(body.keys()) == _ENVELOPE_KEYS
+    assert body["kind"] == "node_count"
+    assert isinstance(body["rows"], list)
+    assert body["count"] == len(body["rows"])
+    for row in body["rows"]:
+        assert set(row.keys()) == _ROW_KEYS
+
+
+def test_endpoint_enforced_mode_returns_byte_stable_envelope(enforced_client):
+    """Perspective-shaped rows are grace-independent by design: the
+    enforced-mode envelope still returns byte-stable rows for the same
+    (perspective, counts) pair."""
+    body = _get_json(
+        enforced_client,
+        "/api/entitlement/has-node-count-at-batch?tier=oss&counts=1,5,100",
+    )
+    by_count = {r["count"]: r for r in body["rows"]}
+    assert by_count[1]["has_node_count_at"] is True
+    assert by_count[5]["has_node_count_at"] is False
+    assert by_count[100]["has_node_count_at"] is False
+    assert body["grace"] is False
+    assert body["enforced"] is True
+
+
+def test_endpoint_perspective_envelope_carries_correct_metadata(client, ent):
+    """``perspective_tier_label`` / ``perspective_tier_rank`` byte-equal
+    :func:`tier_label` / :func:`tier_rank` on the perspective."""
+    for tier in ent._TIER_ORDER:
+        body = _get_json(
+            client,
+            f"/api/entitlement/has-node-count-at-batch?tier={tier}&counts=5",
+        )
+        assert body["perspective_tier"] == tier
+        assert body["perspective_tier_label"] == ent.tier_label(tier)
+        assert body["perspective_tier_rank"] == ent.tier_rank(tier)


### PR DESCRIPTION
## Summary

Fills the last `_at_batch` slot on the `nodes` capacity axis alongside `min_tier_for_node_count_at_batch` (the perspective-tier variant of the reverse-lookup batch on the same axis). Completes the perspective-shaped batch matrix across the three capacity axes: `has_node_count_at_batch` (this PR) + `has_channel_count_at_batch` + `has_retention_window_at_batch` (both landing in #4661).

- **`has_node_count_at_batch(perspective_tier, counts)`** in `clawmetry/entitlements.py` — per-row `has` reflects the **STATIC** per-tier cap in `_TIER_NODE_LIMIT` so the answer is grace-independent by construction (matches `has_node_count_at`). Row shape is byte-parity with `has_node_count_batch` on the sibling LIVE axis so a UI already wired for that batch can rebind without reshaping. `required_tier` is perspective-independent (delegates to `min_tier_for_node_count`).
- **`GET /api/entitlement/has-node-count-at-batch?tier=&counts=1,5,100`** on `bp_entitlement`. `400` on missing/blank `tier` or `counts`, `404` on unknown `tier` (body carries `which=tier`), never 5xx on resolver blowup. Per-row body has `count` / `count_raw` / `kind` / `label` / `has_node_count_at` / `allowed` / `unknown` / `required_tier` / `required_tier_label` / `required_tier_rank`; envelope wraps `rows` with `perspective_tier` / `perspective_tier_label` / `perspective_tier_rank` plus the standard resolver envelope. No `upgrade_required` bit — this is the perspective-shaped `_at` slot, so comparing against the LIVE current-tier rank would double-count the perspective (matches the singular `/has-node-count-at` sibling which omits it for the same reason).

Envelope + short-circuit posture is byte-parity with the sibling `has-channel-count-at-batch` / `has-retention-window-at-batch` endpoints (from #4661) and with the reverse-lookup `min-tier-for-node-count-at-batch` sibling on the same axis:

- **400** on missing / blank `tier`.
- **400** on missing / blank `counts`.
- **404** on unknown `tier` (body carries `which=tier`).
- **200** with `unknown=true` / `has_node_count_at=false` rows for non-int junk tokens (strict callsite-typo fail-closed matching the singular `has_node_count_at` scalar).
- **Never 5xx** — resolver / scalar / row-shape helper blowup all collapse to the grace-shape envelope with an empty `rows` list.

Behaviour ships in **GRACE** mode: the resolver still defaults to the OSS-free entitlement so no runtime gating changes. This is purely additive to the entitlement query surface. Perspective-shaped answers are intentionally identical in grace and enforce (they read the static `_TIER_NODE_LIMIT` table, not the resolver's grace bit) — the whole point of the `_at` slot: `/has-node-count-at-batch?tier=oss&counts=5` returns `allowed=false` even in grace (because the OSS-free tier statically caps at 1 node), whereas the LIVE sibling `/has-node-count-batch` would report `allowed=true` for every finite count via `Entitlement.allows_node_count`'s grace-passthrough.

Per-row parity tests keep the batch outputs pinned byte-equal to the singular `has_node_count_at` scalar and to the sibling `min_tier_for_node_count_at_batch` reverse-lookup rows, so any future contract change on either side has to update both.

Independent of #4661: the node-axis endpoint uses its own `_has_node_count_at_batch_row_to_body` / `_has_node_count_at_batch_fallback` helpers rather than the shared `_has_capacity_at_batch_row_to_body` #4661 introduces, so this branch merges cleanly whether #4661 goes first or second. A follow-up refactor pass can consolidate the three axes onto the shared helper once both PRs land.

## Test plan

- [x] `python3 -m py_compile clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_has_node_count_at_batch.py`
- [x] `ruff check clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_has_node_count_at_batch.py` — clean.
- [x] `python3 scripts/lint_daemon_allowlist.py` — passes (no `local_store_via_daemon` calls touched).
- [x] `python3 -m pytest tests/test_entitlement_has_node_count_at_batch.py` — **56/56 pass**, covering: perspective validation (empty/unknown/non-string → `None`), helper envelope + per-row shape on the scalar, per-row `has` byte-equal to `has_node_count_at` on every `_TIER_ORDER` perspective, per-row `required_tier` byte-equal to `min_tier_for_node_count` (perspective-independent), input normalisation (whitespace / dedupe / order preserved), csv token acceptance, zero / negative free-floor rows on every perspective, OSS static cap = 1 assertion, paid-tier unlimited-cap assertion, HTTP 400 on missing/blank `tier` or `counts`, 404 on unknown tier (body shape pinned), never-4xx / never-5xx across every input branch (including monkeypatched resolver / scalar / row-shape blowups), envelope key set stable across every input branch, `label` conjugation matches the sibling `/min-tier-for-node-count-at-batch` shape ("1 node" / "5 nodes"), cross-consistency with the singular `/has-node-count-at` endpoint on `has_node_count_at` + `required_tier` + `required_tier_rank`, cross-consistency with the sibling `/min-tier-for-node-count-at-batch` on `required_tier`, perspective-tier normalisation (`  ENTERPRISE  ` -> `enterprise`), grace-independence assertion (`_at` batch reports `has=false` on OSS even while `ent.grace` is True), enforced-mode fixture (`CLAWMETRY_ENFORCE=1`) still returns byte-stable envelope with identical rows (perspective is grace-independent by design), no-`upgrade_required` assertion on the row shape.
- [x] `python3 -m pytest tests/test_entitlement_has_node_count_batch.py tests/test_entitlement_has_node_count_at.py tests/test_entitlement_has_channel_count_at.py tests/test_entitlement_has_node_count.py tests/test_entitlement_api.py` — **214/214 pass** (sibling regression).
- [x] `python3 -m pytest tests/test_entitlement_has_batch.py tests/test_entitlement_capacity_perval_at_batch.py tests/test_entitlement_min_tier.py` — **198/198 pass** (adjacent `_at_batch` / capacity / min-tier surface unchanged).

## Local operator verification checklist

Since this fire runs in an ephemeral cloud container with no access to your local daemon, `~/.openclaw`, the live cloud snapshot, or a browser, please verify against the running host once you pull this branch:

- [ ] Copy the three changed files into your live install:
  ```
  cp clawmetry/entitlements.py ~/.clawmetry/lib/python3.*/site-packages/clawmetry/
  cp routes/entitlement.py     ~/.clawmetry/lib/python3.*/site-packages/routes/
  find ~/.clawmetry/lib -name __pycache__ -type d -exec rm -rf {} +
  ```
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` to restart the daemon and pick up the new endpoint.
- [ ] `curl -s 'http://localhost:8900/api/entitlement/has-node-count-at-batch?tier=oss&counts=1,2,5,100' | jq .` — expect one row per count; row for `1` `allowed=true`, rows for `2` / `5` / `100` `allowed=false` (OSS caps at 1 node), all in grace.
- [ ] `curl -s 'http://localhost:8900/api/entitlement/has-node-count-at-batch?tier=cloud_pro&counts=1,5,100,10000' | jq '.rows[].allowed'` — expect **every row true** (paid tiers are unlimited on the nodes axis).
- [ ] `curl -s 'http://localhost:8900/api/entitlement/has-node-count-at-batch?tier=enterprise&counts=1000000' | jq '.rows[0].allowed'` — expect **true** (Enterprise is unlimited on nodes).
- [ ] `curl -sw '\n%{http_code}\n' 'http://localhost:8900/api/entitlement/has-node-count-at-batch'` — expect **400** with `{"error":"missing tier"}`.
- [ ] `curl -sw '\n%{http_code}\n' 'http://localhost:8900/api/entitlement/has-node-count-at-batch?tier=oss'` — expect **400** with `{"error":"missing counts"}`.
- [ ] `curl -sw '\n%{http_code}\n' 'http://localhost:8900/api/entitlement/has-node-count-at-batch?tier=bogus&counts=5'` — expect **404** with `{"error":"unknown tier","which":"tier","tier":"bogus"}`.
- [ ] `curl -s 'http://localhost:8900/api/entitlement/has-node-count-at-batch?tier=oss&counts=five,5' | jq .` — expect **200**; the `five` row has `unknown: true` / `has_node_count_at: false`, the `5` row has `unknown: false` / `has_node_count_at: false` (OSS caps at 1 node).
- [ ] `curl -s 'http://localhost:8900/api/entitlement/has-node-count-at-batch?tier=oss&counts=5' | jq '.rows[0].required_tier'` — byte-equal to `curl -s 'http://localhost:8900/api/entitlement/has-node-count-at?tier=oss&count=5' | jq '.required_tier'` and to `curl -s 'http://localhost:8900/api/entitlement/min-tier-for-node-count-at-batch?tier=oss&counts=5' | jq '.rows[0].required_tier'`.
- [ ] `curl -s 'http://localhost:8900/api/entitlement' | jq .grace` — expect **true** (nothing about the resolver / gate changed — this PR is purely additive query surface).
- [ ] Decrypt the live cloud snapshot in the browser and confirm the dashboard's entitlement panels still render (no shape regression).

This PR stays **DRAFT** until you've done the local + cloud verification above. Version bump / `[RELEASE]` PR / merge is your call.

---
_Generated by [Claude Code](https://claude.ai/code/session_017GbrukUp6kgtm1A3Wwexks)_