### PR TITLE
feat(entitlement): has_batch_at + /api/entitlement/has-batch-at

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -13270,6 +13270,249 @@ def has_batch(
         }
 
 
+def _has_row_capacity_at(
+    perspective_tier: str, key, kind: str
+) -> dict:
+    """Perspective-aware sibling of :func:`_has_row` for the three
+    capacity axes (``channels`` / ``retention_days`` / ``nodes``).
+
+    Row shape byte-parity with :func:`_has_row`; ``has`` reflects the
+    STATIC per-tier cap for ``perspective_tier`` -- matches the singular
+    :func:`has_channel_count_at` / :func:`has_retention_window_at` /
+    :func:`has_node_count_at` scalars and the batch
+    :func:`has_channel_count_at_batch` / :func:`has_retention_window_at_batch`
+    siblings on the same axes.
+
+    Deliberately does NOT route through :func:`_hypothetical_entitlement`:
+    that helper hard-codes ``node_limit=1`` regardless of tier and would
+    misreport ``allowed=False`` for e.g. ``nodes=100`` at
+    ``perspective_tier="cloud_pro"`` (which admits unlimited nodes on the
+    static cap table). Reads the static ``_TIER_*_LIMIT`` tables directly
+    so per-row ``has`` matches the singular ``_at`` scalars byte-for-byte.
+
+    ``required_tier`` is perspective-independent (delegates to
+    :func:`min_tier_for_channel_count` / :func:`min_tier_for_retention_window`
+    / :func:`min_tier_for_node_count`), matching every other ``_at`` row
+    on the capacity axes.
+
+    Never raises: any failure short-circuits to the fail-closed row shape
+    so the paywall matrix keeps rendering.
+    """
+    try:
+        n = int(key)
+    except (TypeError, ValueError):
+        return {
+            "key": str(key),
+            "kind": kind,
+            "has": False,
+            "unknown": True,
+            "required_tier": None,
+            "required_tier_label": None,
+            "required_tier_rank": -1,
+        }
+    try:
+        if kind == "channels":
+            cap = _TIER_CHANNEL_LIMIT.get(
+                perspective_tier, _FREE_CHANNEL_LIMIT
+            )
+            req = min_tier_for_channel_count(n)
+        elif kind == "retention_days":
+            cap = _TIER_RETENTION_DAYS.get(
+                perspective_tier, _TIER_RETENTION_DAYS[TIER_OSS]
+            )
+            req = min_tier_for_retention_window(n)
+        elif kind == "nodes":
+            cap = _TIER_NODE_LIMIT.get(
+                perspective_tier, _FREE_NODE_LIMIT
+            )
+            req = min_tier_for_node_count(n)
+        else:
+            return {
+                "key": str(key),
+                "kind": kind,
+                "has": False,
+                "unknown": True,
+                "required_tier": None,
+                "required_tier_label": None,
+                "required_tier_rank": -1,
+            }
+        if n <= 0:
+            has_flag = True
+        else:
+            has_flag = cap is None or n <= int(cap)
+        return {
+            "key": str(n),
+            "kind": kind,
+            "has": bool(has_flag),
+            "unknown": False,
+            "required_tier": req,
+            "required_tier_label": tier_label(req) if req else None,
+            "required_tier_rank": tier_rank(req) if req else -1,
+        }
+    except Exception as exc:
+        logger.warning(
+            "entitlements: _has_row_capacity_at(%r, %r, %r) failed: %s",
+            perspective_tier,
+            key,
+            kind,
+            exc,
+        )
+        return {
+            "key": str(key),
+            "kind": kind,
+            "has": False,
+            "unknown": True,
+            "required_tier": None,
+            "required_tier_label": None,
+            "required_tier_rank": -1,
+        }
+
+
+def has_batch_at(
+    perspective_tier: str,
+    *,
+    features=None,
+    runtimes=None,
+    channels: int | None = None,
+    retention_days: int | None = None,
+    nodes: int | None = None,
+) -> dict | None:
+    """Hypothetical-perspective sibling of :func:`has_batch`: per-item
+    boolean-gate rows for every supplied item across all five axes in
+    one pass, scoped by a caller-supplied ``perspective_tier``.
+
+    Fills the missing ``_at`` slot on the ``has_batch`` mixed-axis batch
+    family alongside :func:`min_tier_batch_at` (the perspective sibling
+    of :func:`min_tier_batch` on the reverse-lookup axis) and
+    :func:`has_feature_at` / :func:`has_runtime_at` /
+    :func:`has_channel_count_at` / :func:`has_retention_window_at` /
+    :func:`has_node_count_at` (the per-axis singular scalars). A paywall
+    matrix walkthrough at a hypothetical perspective ("if I were on
+    Starter, does this bundle of feature + runtime + capacity rows land
+    granted or locked?") renders off ONE round-trip instead of N calls
+    to the singular ``_at`` scalars + client-side row assembly.
+
+    Envelope shape mirrors :func:`has_batch` exactly (same five-axis
+    kwargs, same per-axis ``None`` "not supplied" sentinel, same
+    never-raise contract)::
+
+        {
+          "features":       [<row>, ...],
+          "runtimes":       [<row>, ...],
+          "channels":       <row> | None,
+          "retention_days": <row> | None,
+          "nodes":          <row> | None,
+        }
+
+    Each ``<row>`` carries ``key``, ``kind``, ``has`` (bool),
+    ``unknown``, ``required_tier``, ``required_tier_label`` and
+    ``required_tier_rank`` (``-1`` when ``required_tier`` is ``None``).
+
+    Perspective-shaped (grace-independent by design): unlike the LIVE
+    :func:`has_batch` sibling (which reports ``has=True`` for every
+    known row while ``ent.grace`` is ``True``), each row here reflects
+    the STATIC per-tier grant for ``perspective_tier``. Features /
+    runtimes are resolved against :func:`_hypothetical_entitlement`
+    (grace forced off, feature / runtime grants pulled from
+    :data:`_TIER_FEATURES` / :data:`_TIER_PAID_RUNTIMES`); the three
+    capacity axes read the static caps in :data:`_TIER_CHANNEL_LIMIT` /
+    :data:`_TIER_RETENTION_DAYS` / :data:`_TIER_NODE_LIMIT` directly
+    (matches the singular :func:`has_channel_count_at` / ...retention /
+    ...node scalars). ``has_batch_at("oss", features=["fleet"])``
+    returns ``has=False`` for the fleet row even in grace -- the whole
+    point of a what-if batch.
+
+    ``required_tier`` on every row is perspective-independent (delegates
+    to the singular :func:`min_tier_for_*` helpers) so a UI wiring both
+    the LIVE :func:`has_batch` and this perspective sibling sees byte-
+    identical reverse-lookup answers across the two batches.
+
+    Contract:
+
+    * ``perspective_tier`` is validated against :data:`_TIER_ORDER`
+      (including :data:`TIER_TRIAL`). Empty / non-string / unknown ->
+      ``None`` (caller renders "unknown tier" / 404). Matches the
+      ``None`` posture the rest of the ``_at`` mixed-axis family uses
+      (see :func:`min_tier_batch_at`).
+    * Feature ids normalised via :func:`_normalise_csv` (whitespace
+      stripped, lowercased, duplicates dropped preserving first-seen
+      order). Runtime ids additionally canonicalise via
+      :func:`canonical_runtime` (matches :func:`has_batch`).
+    * ``channels`` / ``retention_days`` / ``nodes`` are single ints;
+      ``None`` means "not supplied" (row slot collapses to ``None``).
+      Same posture as :func:`has_batch`: ``retention_days=None`` is
+      *unset* -- NOT *unlimited*.
+    * Unknown / non-canonical feature or runtime ids surface as one row
+      with ``unknown=True`` / ``has=False`` (strict callsite-typo fail-
+      closed posture matching the singular :func:`has_feature_at` /
+      :func:`has_runtime_at` scalars).
+
+    Never raises: a per-row failure short-circuits to the fail-closed
+    row shape so the paywall matrix keeps rendering; a perspective /
+    hypothetical build failure returns ``None`` so the caller can render
+    "unknown tier" / 404 without a stack trace.
+    """
+    try:
+        p = (perspective_tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if not p or p not in _TIER_ORDER:
+        return None
+    try:
+        hypo = _hypothetical_entitlement(p)
+    except Exception as exc:
+        logger.warning(
+            "entitlements: has_batch_at hypo build failed for %r: %s",
+            perspective_tier,
+            exc,
+        )
+        return None
+    try:
+        feats = _normalise_csv(features)
+        raw_rts = _normalise_csv(runtimes)
+        seen: set[str] = set()
+        rt_rows: list[dict] = []
+        for raw in raw_rts:
+            rt = canonical_runtime(raw)
+            key = rt if rt else raw
+            if key in seen:
+                continue
+            seen.add(key)
+            rt_rows.append(_has_row(hypo, raw, "runtime"))
+        return {
+            "features": [_has_row(hypo, f, "feature") for f in feats],
+            "runtimes": rt_rows,
+            "channels": (
+                _has_row_capacity_at(p, channels, "channels")
+                if channels is not None
+                else None
+            ),
+            "retention_days": (
+                _has_row_capacity_at(p, retention_days, "retention_days")
+                if retention_days is not None
+                else None
+            ),
+            "nodes": (
+                _has_row_capacity_at(p, nodes, "nodes")
+                if nodes is not None
+                else None
+            ),
+        }
+    except Exception as exc:
+        logger.warning(
+            "entitlements: has_batch_at failed for %r: %s",
+            perspective_tier,
+            exc,
+        )
+        return {
+            "features": [],
+            "runtimes": [],
+            "channels": None,
+            "retention_days": None,
+            "nodes": None,
+        }
+
+
 def feature_label(feature: str) -> str:
     fid = (feature or "").strip().lower()
     return FEATURE_LABELS.get(fid, fid)

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -12670,6 +12670,188 @@ def api_entitlement_has_batch():
         return jsonify(_has_batch_fallback())
 
 
+def _has_batch_at_fallback(tier_in: str) -> dict:
+    """Grace-shape fallback body for ``/api/entitlement/has-batch-at``.
+
+    Perspective-carrying sibling of :func:`_has_batch_fallback`: on a
+    resolver crash the pricing walkthrough keeps rendering with empty
+    per-axis rows AND its "from <perspective>" copy still has its
+    placeholders. Fail-closed on the ``has_all`` rollup for the same
+    reason :func:`_has_batch_fallback` does -- a paywall matrix that
+    lost the resolver must not silently render every row as granted.
+
+    Never raises: any tier-metadata blowup falls back to the raw
+    ``tier_in`` string and rank ``-1``.
+    """
+    try:
+        from clawmetry import entitlements as _ent
+
+        label = _ent.tier_label(tier_in)
+        rank = _ent.tier_rank(tier_in)
+    except Exception:
+        label = tier_in
+        rank = -1
+    return {
+        "perspective_tier": tier_in,
+        "perspective_tier_label": label,
+        "perspective_tier_rank": rank,
+        "features": [],
+        "runtimes": [],
+        "channels": None,
+        "retention_days": None,
+        "nodes": None,
+        "has_all": False,
+        "current_tier": "oss",
+        "current_tier_rank": 0,
+        "grace": True,
+        "enforced": False,
+    }
+
+
+@bp_entitlement.route("/api/entitlement/has-batch-at")
+def api_entitlement_has_batch_at():
+    """``GET /api/entitlement/has-batch-at?tier=<perspective>&features=a,b,c
+    &runtimes=x,y&channels=N&retention_days=K&nodes=M`` -- hypothetical-
+    perspective sibling of ``/api/entitlement/has-batch``.
+
+    Fills the missing ``_at`` slot on the ``has-batch`` mixed-axis batch
+    surface alongside ``/api/entitlement/min-tier-batch-at`` (the
+    perspective sibling on the reverse-lookup axis) and the singular
+    ``/has-feature-at`` / ``/has-runtime-at`` / ``/has-channel-count-at``
+    / ``/has-retention-window-at`` / ``/has-node-count-at`` scalars. A
+    paywall matrix walkthrough at a hypothetical perspective ("if I
+    were on Starter, does this bundle land granted?") renders off ONE
+    round-trip instead of N calls to the singular ``_at`` scalars +
+    client-side row assembly.
+
+    Wraps :func:`clawmetry.entitlements.has_batch_at` and layers the
+    perspective envelope (``perspective_tier`` /
+    ``perspective_tier_label`` / ``perspective_tier_rank``) plus the
+    standard resolver envelope (``current_tier`` / ``current_tier_rank``
+    / ``grace`` / ``enforced``) on top so a walkthrough surface can
+    render the "from <perspective>" copy alongside "you are here" off
+    one call.
+
+    Perspective-shaped (grace-independent by design): unlike the LIVE
+    ``/has-batch`` sibling (which reports ``has=true`` for every known
+    row while ``ent.grace`` is ``true``), each row here reflects the
+    STATIC per-tier grant for ``perspective_tier``. ``has-batch-at?
+    tier=oss&features=fleet`` returns ``has=false`` for the fleet row
+    even in grace -- the whole point of the ``_at`` slot (render the
+    would-be-locked state alongside the live grant).
+
+    Args mirror ``/has-batch`` byte-for-byte except for the additional
+    ``tier=`` perspective arg. Same CSV normalisation, same capacity-
+    axis parsing, same ``None`` = "not supplied" sentinel.
+
+    Response shape (13 keys, byte-stable across every input branch)::
+
+        {
+          "perspective_tier":       "...",
+          "perspective_tier_label": "...",
+          "perspective_tier_rank":  <int>,
+          "features":       [<row>, ...],
+          "runtimes":       [<row>, ...],
+          "channels":       <row> | None,
+          "retention_days": <row> | None,
+          "nodes":          <row> | None,
+          "has_all":            <bool>,   # True iff every emitted row is has=True AND unknown=False
+          "current_tier":       "...",
+          "current_tier_rank":  <int>,
+          "grace":              <bool>,
+          "enforced":           <bool>,
+        }
+
+    Each ``<row>`` carries ``key``, ``kind``, ``has``, ``unknown``,
+    ``required_tier``, ``required_tier_label`` and ``required_tier_rank``
+    (``-1`` when ``required_tier`` is ``None``). Per-row ``has_*_at``
+    parity with the singular ``/has-feature-at?`` /
+    ``/has-runtime-at?`` / ``/has-channel-count-at?`` /
+    ``/has-retention-window-at?`` / ``/has-node-count-at?`` endpoints is
+    pinned in the test suite so the batch cannot silently drift from
+    the singular scalars.
+
+    - **400** when ``tier=`` is missing / blank, OR when no constraint
+      axis is supplied.
+    - **404** when ``tier`` is unknown. The body carries ``which=tier``.
+    - **Never 5xxs**: a resolver failure yields the perspective-carrying
+      OSS-free shape (empty per-axis rows, ``has_all=False``) so the
+      pricing walkthrough keeps rendering.
+    """
+    raw_tier = request.args.get("tier")
+    tier_in = (raw_tier or "").strip().lower()
+    if not tier_in:
+        return jsonify({"error": "missing tier"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        if tier_in not in _ent._TIER_ORDER:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "tier", "tier": tier_in}
+                ),
+                404,
+            )
+
+        features = _parse_csv_arg("features")
+        runtimes = _parse_csv_arg("runtimes")
+        (_, channels_ok, channels_n, _) = _parse_capacity_arg("channels")
+        (_, retention_ok, retention_n, _) = _parse_capacity_arg(
+            "retention_days"
+        )
+        (_, nodes_ok, nodes_n, _) = _parse_capacity_arg("nodes")
+
+        if (
+            not features
+            and not runtimes
+            and not channels_ok
+            and not retention_ok
+            and not nodes_ok
+        ):
+            return (
+                jsonify(
+                    {
+                        "error": (
+                            "supply at least one of features=<csv>, "
+                            "runtimes=<csv>, channels=<int>, "
+                            "retention_days=<int>, or nodes=<int>"
+                        )
+                    }
+                ),
+                400,
+            )
+
+        batch = _ent.has_batch_at(
+            tier_in,
+            features=features or None,
+            runtimes=runtimes or None,
+            channels=channels_n if channels_ok else None,
+            retention_days=retention_n if retention_ok else None,
+            nodes=nodes_n if nodes_ok else None,
+        )
+        if batch is None:
+            batch = {
+                "features": [],
+                "runtimes": [],
+                "channels": None,
+                "retention_days": None,
+                "nodes": None,
+            }
+        ent = _ent.get_entitlement()
+        batch["perspective_tier"] = tier_in
+        batch["perspective_tier_label"] = _ent.tier_label(tier_in)
+        batch["perspective_tier_rank"] = _ent.tier_rank(tier_in)
+        batch["has_all"] = _has_batch_rollup(batch)
+        batch["current_tier"] = ent.tier
+        batch["current_tier_rank"] = _ent.tier_rank(ent.tier)
+        batch["grace"] = bool(ent.grace)
+        batch["enforced"] = _ent.is_enforced()
+        return jsonify(batch)
+    except Exception as exc:
+        logger.warning("api_entitlement_has_batch_at: error: %s", exc)
+        return jsonify(_has_batch_at_fallback(tier_in))
+
+
 @bp_entitlement.route("/api/entitlement/min-tier-batch-at")
 def api_entitlement_min_tier_batch_at():
     """``GET /api/entitlement/min-tier-batch-at?tier=<perspective>

--- a/tests/test_entitlement_has_batch_at.py
+++ b/tests/test_entitlement_has_batch_at.py
@@ -1,0 +1,929 @@
+"""Tests for the ``has_batch_at`` per-item boolean-gate helper and its
+paired ``/api/entitlement/has-batch-at`` endpoint -- hypothetical-
+perspective sibling of :func:`clawmetry.entitlements.has_batch` and
+per-item plural sibling of the singular ``_at`` scalars
+:func:`~clawmetry.entitlements.has_feature_at` /
+:func:`~clawmetry.entitlements.has_runtime_at` /
+:func:`~clawmetry.entitlements.has_channel_count_at` /
+:func:`~clawmetry.entitlements.has_retention_window_at` /
+:func:`~clawmetry.entitlements.has_node_count_at`.
+
+Where the LIVE :func:`has_batch` answers "does the CURRENT install
+grant every item in this bundle?" (grace pass-through: every known row
+is ``has=True`` while ``ent.grace`` is ``True``), ``has_batch_at``
+answers the perspective-shaped what-if: "would tier ``perspective_tier``
+statically grant each row?". Fills the missing ``_at`` slot on the
+mixed-axis batch surface alongside :func:`min_tier_batch_at` (the
+perspective sibling on the reverse-lookup axis).
+
+This file pins:
+
+1. Perspective validation: empty / blank / non-string / unknown ->
+   ``None`` from the helper and ``400`` / ``404`` from the endpoint,
+   matching the ``_at`` posture the rest of the family uses.
+2. Envelope shape parity (fixed key set: 13 keys) across every input
+   branch so a frontend can bind fields off the URL without a branch
+   on the underlying resolver state.
+3. Per-row shape parity across every axis (fixed 7-key row set).
+4. Per-row parity with the singular ``_at`` scalars: each row's
+   ``has`` byte-equals :func:`has_feature_at` / :func:`has_runtime_at`
+   / :func:`has_channel_count_at` / :func:`has_retention_window_at` /
+   :func:`has_node_count_at` on the same (perspective, item) pair.
+5. ``required_tier`` perspective-independence: byte-equals
+   :func:`min_tier_for_feature` / :func:`min_tier_for_runtime` /
+   :func:`min_tier_for_channel_count` /
+   :func:`min_tier_for_retention_window` /
+   :func:`min_tier_for_node_count` regardless of perspective.
+6. Grace-independence: the perspective-shaped rows are byte-identical
+   under grace vs enforce (they read static tables, not the resolver's
+   grace bit). ``has_batch_at("oss", features=["fleet"])`` reports
+   ``has=False`` even in grace -- the whole point of the ``_at`` slot.
+7. Strict-typo-fail-closed posture: unknown feature/runtime ids and
+   non-int capacity values flip ``unknown=True`` / ``has=False``.
+8. Runtime alias canonicalisation (``claude-code`` -> ``claude_code``)
+   and dedup after canonicalisation (matches :func:`has_batch`).
+9. ``retention_days=None`` means *unset*, NOT *unlimited*.
+10. Never-5xx: any resolver / hypothetical / row-shape blowup collapses
+    to the perspective-carrying grace-shape envelope.
+11. ``has_all`` rollup: True iff every emitted row is ``has=True`` AND
+    ``unknown=False`` (matches ``/has-batch``'s ``has_all`` contract).
+12. Endpoint 400 when no axis is supplied, 400 on missing ``tier=``,
+    404 on unknown ``tier=``.
+13. Cross-consistency with the singular ``/has-*-at`` endpoints on
+    ``has_*_at`` per row, and with ``/min-tier-batch-at`` on the
+    ``required_tier`` slot for every row on every axis.
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+# ── Fixtures ────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    """Fresh entitlements module in OSS-free grace mode. Matches the
+    fixture shape in ``test_entitlement_has_batch.py`` so per-row
+    assertions here reproduce the same install state the LIVE sibling
+    is pinned against."""
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def enforced(monkeypatch, tmp_path):
+    """Enforcement-on fixture: ``CLAWMETRY_ENFORCE=1`` flips
+    ``ent.grace`` off. Included to pin the perspective-shaped grace-
+    independence invariant -- ``has_batch_at`` returns byte-identical
+    rows under grace vs enforce for the same (perspective, bundle)."""
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    importlib.reload(e)
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+@pytest.fixture
+def enforced_client(enforced):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# ── Envelope + row-shape constants ──────────────────────────────────────────
+
+
+_ENVELOPE_KEYS = {
+    "perspective_tier",
+    "perspective_tier_label",
+    "perspective_tier_rank",
+    "features",
+    "runtimes",
+    "channels",
+    "retention_days",
+    "nodes",
+    "has_all",
+    "current_tier",
+    "current_tier_rank",
+    "grace",
+    "enforced",
+}
+
+_ROW_KEYS = {
+    "key",
+    "kind",
+    "has",
+    "unknown",
+    "required_tier",
+    "required_tier_label",
+    "required_tier_rank",
+}
+
+
+def _get_json(client, url: str, expected_status: int = 200) -> dict:
+    resp = client.get(url)
+    assert resp.status_code == expected_status, (
+        url,
+        resp.status_code,
+        resp.data,
+    )
+    return resp.get_json()
+
+
+def _pick_paid_feature(ent) -> str:
+    for f in sorted(ent.PAID_FEATURES):
+        return f
+    raise RuntimeError("no PAID_FEATURES ids available in the catalogue")
+
+
+def _pick_paid_runtime(ent) -> str:
+    for r in sorted(ent.PAID_RUNTIMES):
+        return r
+    raise RuntimeError("no PAID_RUNTIMES ids available in the catalogue")
+
+
+# ── Helper: perspective validation ──────────────────────────────────────────
+
+
+def test_helper_empty_perspective_returns_none(ent):
+    for bad in ["", " ", "\t"]:
+        assert ent.has_batch_at(bad, features=["fleet"]) is None, bad
+
+
+def test_helper_none_perspective_returns_none(ent):
+    assert ent.has_batch_at(None, features=["fleet"]) is None
+
+
+def test_helper_non_string_perspective_returns_none(ent):
+    for bad in [123, object(), [], {}]:
+        assert ent.has_batch_at(bad, features=["fleet"]) is None, bad
+
+
+def test_helper_unknown_perspective_returns_none(ent):
+    for bad in ["mars", "starter_plus", "pro_max", "unknown_tier"]:
+        assert ent.has_batch_at(bad, features=["fleet"]) is None, bad
+
+
+def test_helper_perspective_is_case_insensitive(ent):
+    got_upper = ent.has_batch_at("CLOUD_STARTER", features=["fleet"])
+    got_lower = ent.has_batch_at("cloud_starter", features=["fleet"])
+    assert got_upper == got_lower
+
+
+def test_helper_perspective_is_whitespace_stripped(ent):
+    got = ent.has_batch_at("  cloud_pro  ", features=["fleet"])
+    lo = ent.has_batch_at("cloud_pro", features=["fleet"])
+    assert got == lo
+
+
+def test_helper_trial_is_accepted_as_perspective(ent):
+    got = ent.has_batch_at(ent.TIER_TRIAL, features=["fleet"])
+    assert got is not None
+
+
+def test_helper_every_tier_in_order_is_accepted(ent):
+    for tier in ent._TIER_ORDER:
+        got = ent.has_batch_at(tier, features=["fleet"])
+        assert got is not None, tier
+
+
+# ── Helper: empty-call shape ────────────────────────────────────────────────
+
+
+def test_helper_empty_call_shape(ent):
+    """No axes supplied -- returns the all-empty envelope (no rows,
+    three axis slots None). Matches has_batch()'s empty-call shape."""
+    got = ent.has_batch_at("cloud_pro")
+    assert got == {
+        "features": [],
+        "runtimes": [],
+        "channels": None,
+        "retention_days": None,
+        "nodes": None,
+    }
+
+
+def test_helper_all_axes_shape(ent):
+    got = ent.has_batch_at(
+        "cloud_pro",
+        features=["fleet", "sso"],
+        runtimes=["claude_code"],
+        channels=5,
+        retention_days=30,
+        nodes=3,
+    )
+    assert set(got.keys()) == {
+        "features",
+        "runtimes",
+        "channels",
+        "retention_days",
+        "nodes",
+    }
+    for row in got["features"]:
+        assert set(row.keys()) == _ROW_KEYS
+    for row in got["runtimes"]:
+        assert set(row.keys()) == _ROW_KEYS
+    for slot in ("channels", "retention_days", "nodes"):
+        assert set(got[slot].keys()) == _ROW_KEYS
+
+
+# ── Helper: per-row parity with the singular ``_at`` scalars ────────────────
+
+
+def test_helper_features_row_has_parity_with_singular_at_scalar(ent):
+    """Every feature id in :data:`ALL_FEATURES` -- per-row ``has``
+    byte-equals :func:`has_feature_at` on the same (perspective, feature)
+    pair across every perspective in :data:`_TIER_ORDER`."""
+    for tier in ent._TIER_ORDER:
+        for fid in sorted(ent.ALL_FEATURES):
+            row = ent.has_batch_at(tier, features=[fid])["features"][0]
+            assert row["has"] is ent.has_feature_at(tier, fid), (tier, fid)
+            assert row["unknown"] is False, (tier, fid)
+
+
+def test_helper_runtimes_row_has_parity_with_singular_at_scalar(ent):
+    for tier in ent._TIER_ORDER:
+        for rt in sorted(ent.ALL_RUNTIMES):
+            row = ent.has_batch_at(tier, runtimes=[rt])["runtimes"][0]
+            assert row["has"] is ent.has_runtime_at(tier, rt), (tier, rt)
+            assert row["unknown"] is False, (tier, rt)
+
+
+def test_helper_channels_row_has_parity_with_singular_at_scalar(ent):
+    counts = [0, 1, 3, 5, 100]
+    for tier in ent._TIER_ORDER:
+        for n in counts:
+            row = ent.has_batch_at(tier, channels=n)["channels"]
+            assert row["has"] is ent.has_channel_count_at(tier, n), (tier, n)
+
+
+def test_helper_retention_days_row_has_parity_with_singular_at_scalar(ent):
+    days_values = [0, 1, 7, 30, 90, 365]
+    for tier in ent._TIER_ORDER:
+        for d in days_values:
+            row = ent.has_batch_at(tier, retention_days=d)["retention_days"]
+            assert row["has"] is ent.has_retention_window_at(tier, d), (
+                tier,
+                d,
+            )
+
+
+def test_helper_nodes_row_has_parity_with_singular_at_scalar(ent):
+    counts = [0, 1, 5, 100]
+    for tier in ent._TIER_ORDER:
+        for n in counts:
+            row = ent.has_batch_at(tier, nodes=n)["nodes"]
+            assert row["has"] is ent.has_node_count_at(tier, n), (tier, n)
+
+
+def test_helper_required_tier_is_perspective_independent(ent):
+    """``required_tier`` on every row is perspective-independent (matches
+    the singular ``_at`` scalars' shape). For every axis: the row's
+    ``required_tier`` byte-equals :func:`min_tier_for_*` regardless of
+    perspective."""
+    for tier in ent._TIER_ORDER:
+        got = ent.has_batch_at(
+            tier,
+            features=[_pick_paid_feature(ent)],
+            runtimes=[_pick_paid_runtime(ent)],
+            channels=5,
+            retention_days=30,
+            nodes=5,
+        )
+        assert got["features"][0]["required_tier"] == ent.min_tier_for_feature(
+            _pick_paid_feature(ent)
+        )
+        assert got["runtimes"][0]["required_tier"] == ent.min_tier_for_runtime(
+            _pick_paid_runtime(ent)
+        )
+        assert (
+            got["channels"]["required_tier"]
+            == ent.min_tier_for_channel_count(5)
+        )
+        assert (
+            got["retention_days"]["required_tier"]
+            == ent.min_tier_for_retention_window(30)
+        )
+        assert (
+            got["nodes"]["required_tier"] == ent.min_tier_for_node_count(5)
+        )
+
+
+# ── Helper: grace-independence ──────────────────────────────────────────────
+
+
+def test_helper_grace_independence_oss_denies_paid_feature(ent):
+    """The whole point of the ``_at`` slot: even in grace,
+    ``has_batch_at("oss", features=[paid])`` reports has=False."""
+    live = ent.get_entitlement()
+    assert live.grace is True
+    paid = _pick_paid_feature(ent)
+    row = ent.has_batch_at("oss", features=[paid])["features"][0]
+    assert row["has"] is False
+    assert row["unknown"] is False
+
+
+def test_helper_grace_independence_oss_denies_channels_above_free(ent):
+    row = ent.has_batch_at("oss", channels=5)["channels"]
+    assert row["has"] is False
+
+
+def test_helper_grace_independence_oss_denies_nodes_above_free(ent):
+    row = ent.has_batch_at("oss", nodes=5)["nodes"]
+    assert row["has"] is False
+
+
+def test_helper_grace_independence_cloud_pro_admits_paid_feature(ent):
+    paid = _pick_paid_feature(ent)
+    row = ent.has_batch_at("cloud_pro", features=[paid])["features"][0]
+    assert row["has"] is True
+
+
+def test_helper_grace_independence_cloud_pro_admits_unlimited_channels(ent):
+    row = ent.has_batch_at("cloud_pro", channels=1000)["channels"]
+    assert row["has"] is True
+
+
+def test_helper_grace_independence_cloud_pro_admits_unlimited_nodes(ent):
+    row = ent.has_batch_at("cloud_pro", nodes=1_000_000)["nodes"]
+    assert row["has"] is True
+
+
+def test_helper_grace_vs_enforced_returns_byte_identical_rows(ent, enforced):
+    """Perspective-shaped rows are grace-independent by design: same
+    (perspective, bundle) yields byte-identical rows under grace vs
+    enforce."""
+    for tier in ent._TIER_ORDER:
+        got_grace = ent.has_batch_at(
+            tier,
+            features=[_pick_paid_feature(ent)],
+            runtimes=[_pick_paid_runtime(ent)],
+            channels=5,
+            retention_days=30,
+            nodes=3,
+        )
+        got_enforced = enforced.has_batch_at(
+            tier,
+            features=[_pick_paid_feature(ent)],
+            runtimes=[_pick_paid_runtime(ent)],
+            channels=5,
+            retention_days=30,
+            nodes=3,
+        )
+        assert got_grace == got_enforced, tier
+
+
+# ── Helper: unknown / non-int / dedup / free ─────────────────────────
+
+
+def test_helper_unknown_feature_id_is_unknown_row(ent):
+    got = ent.has_batch_at("cloud_pro", features=["bogus_feature"])
+    row = got["features"][0]
+    assert row["unknown"] is True
+    assert row["has"] is False
+    assert row["required_tier"] is None
+    assert row["required_tier_rank"] == -1
+
+
+def test_helper_unknown_runtime_id_is_unknown_row(ent):
+    got = ent.has_batch_at("cloud_pro", runtimes=["bogus_runtime"])
+    row = got["runtimes"][0]
+    assert row["unknown"] is True
+    assert row["has"] is False
+
+
+def test_helper_non_int_channels_is_unknown_row(ent):
+    got = ent.has_batch_at("cloud_pro", channels="five")
+    row = got["channels"]
+    assert row["unknown"] is True
+    assert row["has"] is False
+
+
+def test_helper_non_int_retention_days_is_unknown_row(ent):
+    got = ent.has_batch_at("cloud_pro", retention_days="thirty")
+    row = got["retention_days"]
+    assert row["unknown"] is True
+    assert row["has"] is False
+
+
+def test_helper_non_int_nodes_is_unknown_row(ent):
+    got = ent.has_batch_at("cloud_pro", nodes="three")
+    row = got["nodes"]
+    assert row["unknown"] is True
+    assert row["has"] is False
+
+
+def test_helper_runtime_alias_canonicalises(ent):
+    """``claude-code`` (with a hyphen) canonicalises to
+    ``claude_code``; the row surfaces with the canonical key."""
+    got = ent.has_batch_at("cloud_pro", runtimes=["claude-code"])
+    assert len(got["runtimes"]) == 1
+    assert got["runtimes"][0]["key"] == "claude_code"
+    assert got["runtimes"][0]["unknown"] is False
+
+
+def test_helper_runtime_alias_dedup_after_canonicalisation(ent):
+    got = ent.has_batch_at(
+        "cloud_pro", runtimes=["claude-code", "claude_code"]
+    )
+    assert len(got["runtimes"]) == 1
+
+
+def test_helper_feature_ids_normalise_and_dedup(ent):
+    got = ent.has_batch_at(
+        "cloud_pro", features=["fleet", " Fleet ", "fleet"]
+    )
+    assert len(got["features"]) == 1
+
+
+def test_helper_free_feature_is_granted_on_every_perspective(ent):
+    """A FREE feature is granted on every perspective (including OSS)."""
+    free_iter = iter(sorted(ent.FREE_FEATURES))
+    try:
+        f = next(free_iter)
+    except StopIteration:
+        pytest.skip("FREE_FEATURES is empty")
+    for tier in ent._TIER_ORDER:
+        row = ent.has_batch_at(tier, features=[f])["features"][0]
+        assert row["has"] is True, (tier, f)
+
+
+def test_helper_free_runtime_is_granted_on_every_perspective(ent):
+    for tier in ent._TIER_ORDER:
+        row = ent.has_batch_at(tier, runtimes=["openclaw"])["runtimes"][0]
+        assert row["has"] is True, tier
+
+
+def test_helper_zero_and_negative_capacity_are_free_floor(ent):
+    for tier in ent._TIER_ORDER:
+        for n in [0, -1, -100]:
+            for axis in ("channels", "retention_days", "nodes"):
+                got = ent.has_batch_at(tier, **{axis: n})
+                assert got[axis]["has"] is True, (tier, axis, n)
+
+
+# ── Helper: never-raises ────────────────────────────────────────────────────
+
+
+def test_helper_never_raises_on_hypo_blowup(monkeypatch, ent):
+    def _boom(*a, **kw):
+        raise RuntimeError("hypo build blew up")
+
+    monkeypatch.setattr(ent, "_hypothetical_entitlement", _boom)
+    assert ent.has_batch_at("oss", features=["fleet"]) is None
+
+
+def test_helper_never_raises_on_normalise_blowup(monkeypatch, ent):
+    def _boom(*a, **kw):
+        raise RuntimeError("csv normalise blew up")
+
+    monkeypatch.setattr(ent, "_normalise_csv", _boom)
+    got = ent.has_batch_at("oss", features=["fleet"])
+    assert got == {
+        "features": [],
+        "runtimes": [],
+        "channels": None,
+        "retention_days": None,
+        "nodes": None,
+    }
+
+
+# ── Endpoint: error paths ───────────────────────────────────────────────────
+
+
+def test_endpoint_missing_tier_400(client):
+    resp = client.get("/api/entitlement/has-batch-at?features=fleet")
+    assert resp.status_code == 400
+    assert resp.get_json() == {"error": "missing tier"}
+
+
+def test_endpoint_blank_tier_400(client):
+    resp = client.get("/api/entitlement/has-batch-at?tier=&features=fleet")
+    assert resp.status_code == 400
+    resp = client.get("/api/entitlement/has-batch-at?tier=%20&features=fleet")
+    assert resp.status_code == 400
+
+
+def test_endpoint_unknown_tier_404_body_shape(client):
+    resp = client.get(
+        "/api/entitlement/has-batch-at?tier=bogus&features=fleet"
+    )
+    assert resp.status_code == 404
+    body = resp.get_json()
+    assert body == {"error": "unknown tier", "which": "tier", "tier": "bogus"}
+
+
+def test_endpoint_no_axis_400(client):
+    resp = client.get("/api/entitlement/has-batch-at?tier=cloud_pro")
+    assert resp.status_code == 400
+    body = resp.get_json()
+    assert "supply at least one of" in body["error"]
+
+
+def test_endpoint_blank_axes_400(client):
+    resp = client.get(
+        "/api/entitlement/has-batch-at?tier=cloud_pro&features=&runtimes="
+    )
+    assert resp.status_code == 400
+
+
+# ── Endpoint: envelope shape ────────────────────────────────────────────────
+
+
+def test_endpoint_envelope_shape(client):
+    body = _get_json(
+        client,
+        "/api/entitlement/has-batch-at?tier=cloud_pro"
+        "&features=fleet&runtimes=claude_code&channels=5&retention_days=30"
+        "&nodes=3",
+    )
+    assert set(body.keys()) == _ENVELOPE_KEYS
+    assert body["perspective_tier"] == "cloud_pro"
+    for row in body["features"]:
+        assert set(row.keys()) == _ROW_KEYS
+    for row in body["runtimes"]:
+        assert set(row.keys()) == _ROW_KEYS
+    for slot in ("channels", "retention_days", "nodes"):
+        assert set(body[slot].keys()) == _ROW_KEYS
+
+
+def test_endpoint_row_types(client):
+    body = _get_json(
+        client,
+        "/api/entitlement/has-batch-at?tier=cloud_pro&features=fleet"
+        "&runtimes=claude_code&channels=5&retention_days=30&nodes=3",
+    )
+    for row in body["features"] + body["runtimes"]:
+        assert isinstance(row["has"], bool)
+        assert isinstance(row["unknown"], bool)
+        assert isinstance(row["required_tier_rank"], int)
+    for slot in ("channels", "retention_days", "nodes"):
+        row = body[slot]
+        assert isinstance(row["has"], bool)
+        assert isinstance(row["unknown"], bool)
+
+
+def test_endpoint_perspective_tier_normalised_uppercase(client):
+    body_upper = _get_json(
+        client,
+        "/api/entitlement/has-batch-at?tier=%20CLOUD_PRO%20&features=fleet",
+    )
+    body_lower = _get_json(
+        client,
+        "/api/entitlement/has-batch-at?tier=cloud_pro&features=fleet",
+    )
+    assert body_upper["perspective_tier"] == "cloud_pro"
+    assert body_upper["features"] == body_lower["features"]
+
+
+def test_endpoint_perspective_metadata_carried(client, ent):
+    for tier in ent._TIER_ORDER:
+        body = _get_json(
+            client,
+            f"/api/entitlement/has-batch-at?tier={tier}&features=fleet",
+        )
+        assert body["perspective_tier"] == tier
+        assert body["perspective_tier_label"] == ent.tier_label(tier)
+        assert body["perspective_tier_rank"] == ent.tier_rank(tier)
+
+
+# ── Endpoint: grace-independence + has_all rollup ───────────────────────────
+
+
+def test_endpoint_oss_grace_denies_paid_feature(client, ent):
+    """Even in grace, /has-batch-at?tier=oss reports has_all=False for a
+    paid feature."""
+    paid = _pick_paid_feature(ent)
+    body = _get_json(
+        client,
+        f"/api/entitlement/has-batch-at?tier=oss&features={paid}",
+    )
+    assert body["grace"] is True
+    assert body["features"][0]["has"] is False
+    assert body["has_all"] is False
+
+
+def test_endpoint_cloud_pro_admits_paid_feature(client, ent):
+    paid = _pick_paid_feature(ent)
+    body = _get_json(
+        client,
+        f"/api/entitlement/has-batch-at?tier=cloud_pro&features={paid}",
+    )
+    assert body["features"][0]["has"] is True
+    assert body["has_all"] is True
+
+
+def test_endpoint_has_all_flips_on_single_unknown_row(client, ent):
+    """A single unknown row in the bundle flips has_all to False, even
+    when every OTHER row is granted."""
+    body = _get_json(
+        client,
+        "/api/entitlement/has-batch-at?tier=cloud_pro&features=fleet,bogus_id",
+    )
+    assert body["has_all"] is False
+
+
+def test_endpoint_has_all_vacuously_true_with_empty_features_bundle(client):
+    """When only capacity axes are supplied and they all pass, has_all is
+    True (empty feature/runtime lists are trivially satisfied)."""
+    body = _get_json(
+        client,
+        "/api/entitlement/has-batch-at?tier=cloud_pro&channels=5",
+    )
+    assert body["has_all"] is True
+
+
+def test_endpoint_enforced_mode_returns_byte_stable_envelope(
+    enforced_client, enforced
+):
+    """Perspective-shaped rows are grace-independent by design: enforced
+    mode returns byte-identical rows for the same (perspective, bundle)."""
+    paid = _pick_paid_feature(enforced)
+    body = _get_json(
+        enforced_client,
+        f"/api/entitlement/has-batch-at?tier=oss&features={paid}",
+    )
+    assert body["grace"] is False
+    assert body["enforced"] is True
+    assert body["features"][0]["has"] is False
+
+
+# ── Endpoint: never-5xx ─────────────────────────────────────────────────────
+
+
+def test_endpoint_never_5xx_on_resolver_blowup(monkeypatch, client):
+    from clawmetry import entitlements as _ent
+
+    def _boom(*a, **kw):
+        raise RuntimeError("resolver blew up")
+
+    monkeypatch.setattr(_ent, "get_entitlement", _boom)
+    resp = client.get(
+        "/api/entitlement/has-batch-at?tier=oss&features=fleet"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert set(body.keys()) == _ENVELOPE_KEYS
+    assert body["perspective_tier"] == "oss"
+    assert body["has_all"] is False
+    assert body["features"] == []
+
+
+def test_endpoint_never_5xx_on_scalar_blowup(monkeypatch, client):
+    from clawmetry import entitlements as _ent
+
+    def _boom(*a, **kw):
+        raise RuntimeError("scalar blew up")
+
+    monkeypatch.setattr(_ent, "has_batch_at", _boom)
+    resp = client.get(
+        "/api/entitlement/has-batch-at?tier=oss&features=fleet"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert set(body.keys()) == _ENVELOPE_KEYS
+
+
+# ── Endpoint: cross-consistency with singular /has-*-at endpoints ───────────
+
+
+def test_endpoint_features_row_parity_with_singular_at_endpoint(
+    client, ent
+):
+    """Every feature row's ``has_*_at`` byte-equals the singular
+    ``/api/entitlement/has-feature-at?tier=<p>&feature=<f>`` endpoint
+    body."""
+    fid = _pick_paid_feature(ent)
+    body = _get_json(
+        client,
+        f"/api/entitlement/has-batch-at?tier=cloud_pro&features={fid}",
+    )
+    singular = _get_json(
+        client,
+        f"/api/entitlement/has-feature-at?tier=cloud_pro&feature={fid}",
+    )
+    assert body["features"][0]["has"] == singular["has_feature_at"]
+
+
+def test_endpoint_runtimes_row_parity_with_singular_at_endpoint(
+    client, ent
+):
+    rt = _pick_paid_runtime(ent)
+    body = _get_json(
+        client,
+        f"/api/entitlement/has-batch-at?tier=cloud_pro&runtimes={rt}",
+    )
+    singular = _get_json(
+        client,
+        f"/api/entitlement/has-runtime-at?tier=cloud_pro&runtime={rt}",
+    )
+    assert body["runtimes"][0]["has"] == singular["has_runtime_at"]
+
+
+def test_endpoint_channels_row_parity_with_singular_at_endpoint(client):
+    body = _get_json(
+        client,
+        "/api/entitlement/has-batch-at?tier=oss&channels=5",
+    )
+    singular = _get_json(
+        client,
+        "/api/entitlement/has-channel-count-at?tier=oss&count=5",
+    )
+    assert (
+        body["channels"]["has"]
+        == singular["has_channel_count_at"]
+    )
+    assert (
+        body["channels"]["required_tier"] == singular["required_tier"]
+    )
+
+
+def test_endpoint_retention_row_parity_with_singular_at_endpoint(client):
+    body = _get_json(
+        client,
+        "/api/entitlement/has-batch-at?tier=cloud_starter&retention_days=90",
+    )
+    singular = _get_json(
+        client,
+        "/api/entitlement/has-retention-window-at?tier=cloud_starter&days=90",
+    )
+    assert (
+        body["retention_days"]["has"]
+        == singular["has_retention_window_at"]
+    )
+
+
+def test_endpoint_nodes_row_parity_with_singular_at_endpoint(client):
+    body = _get_json(
+        client,
+        "/api/entitlement/has-batch-at?tier=oss&nodes=5",
+    )
+    singular = _get_json(
+        client,
+        "/api/entitlement/has-node-count-at?tier=oss&count=5",
+    )
+    assert (
+        body["nodes"]["has"] == singular["has_node_count_at"]
+    )
+    assert body["nodes"]["required_tier"] == singular["required_tier"]
+
+
+# ── Endpoint: cross-consistency with /min-tier-batch-at ─────────────────────
+
+
+def test_endpoint_required_tier_parity_with_min_tier_batch_at(client, ent):
+    """``required_tier`` on every row byte-equals the sibling
+    ``/api/entitlement/min-tier-batch-at?tier=<p>&...`` row for the
+    same (feature / runtime / capacity value) -- a UI wiring both
+    cannot see inconsistent tier state."""
+    fid = _pick_paid_feature(ent)
+    rt = _pick_paid_runtime(ent)
+    body_has = _get_json(
+        client,
+        f"/api/entitlement/has-batch-at?tier=oss&features={fid}"
+        f"&runtimes={rt}&channels=5&retention_days=30&nodes=5",
+    )
+    body_min = _get_json(
+        client,
+        f"/api/entitlement/min-tier-batch-at?tier=oss&features={fid}"
+        f"&runtimes={rt}&channels=5&retention_days=30&nodes=5",
+    )
+    assert (
+        body_has["features"][0]["required_tier"]
+        == body_min["features"][0]["min_tier"]
+    )
+    assert (
+        body_has["runtimes"][0]["required_tier"]
+        == body_min["runtimes"][0]["min_tier"]
+    )
+    assert (
+        body_has["channels"]["required_tier"]
+        == body_min["channels"]["min_tier"]
+    )
+    assert (
+        body_has["retention_days"]["required_tier"]
+        == body_min["retention_days"]["min_tier"]
+    )
+    assert (
+        body_has["nodes"]["required_tier"] == body_min["nodes"]["min_tier"]
+    )
+
+
+# ── Endpoint: envelope stability across many input branches ─────────────────
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "/api/entitlement/has-batch-at?tier=oss&features=fleet",
+        "/api/entitlement/has-batch-at?tier=cloud_pro&features=fleet",
+        "/api/entitlement/has-batch-at?tier=enterprise&features=fleet",
+        "/api/entitlement/has-batch-at?tier=trial&features=fleet",
+        "/api/entitlement/has-batch-at?tier=oss&runtimes=claude_code",
+        "/api/entitlement/has-batch-at?tier=oss&channels=5",
+        "/api/entitlement/has-batch-at?tier=oss&retention_days=30",
+        "/api/entitlement/has-batch-at?tier=oss&nodes=5",
+        "/api/entitlement/has-batch-at?tier=oss&features=bogus_id",
+        "/api/entitlement/has-batch-at?tier=oss&features=fleet&channels=five",
+        "/api/entitlement/has-batch-at?tier=oss&features=fleet,sso"
+        "&runtimes=claude_code,codex&channels=5&retention_days=30&nodes=3",
+    ],
+)
+def test_endpoint_envelope_stable(client, url):
+    body = _get_json(client, url)
+    assert set(body.keys()) == _ENVELOPE_KEYS
+    assert isinstance(body["features"], list)
+    assert isinstance(body["runtimes"], list)
+
+
+def test_endpoint_features_supply_order_preserved(client):
+    body = _get_json(
+        client,
+        "/api/entitlement/has-batch-at?tier=cloud_pro&features=sso,fleet",
+    )
+    keys = [r["key"] for r in body["features"]]
+    assert keys == ["sso", "fleet"]
+
+
+def test_endpoint_runtime_alias_canonicalises(client):
+    body = _get_json(
+        client,
+        "/api/entitlement/has-batch-at?tier=cloud_pro&runtimes=claude-code",
+    )
+    assert body["runtimes"][0]["key"] == "claude_code"
+
+
+def test_endpoint_retention_none_is_unset(client):
+    """``retention_days`` omitted / blank means unset -- NOT unlimited.
+    The row slot collapses to None (matches has_batch)."""
+    body = _get_json(
+        client,
+        "/api/entitlement/has-batch-at?tier=cloud_pro&features=fleet",
+    )
+    assert body["retention_days"] is None
+
+
+# ── Endpoint: parity with LIVE has_batch on shape ───────────────────────────
+
+
+def test_endpoint_shape_superset_of_live_has_batch(client):
+    """The perspective sibling's envelope is a superset of the LIVE
+    /has-batch envelope: adds ``perspective_tier`` / label / rank on
+    top; everything else has the same shape."""
+    body_at = _get_json(
+        client,
+        "/api/entitlement/has-batch-at?tier=cloud_pro&features=fleet",
+    )
+    body_live = _get_json(
+        client,
+        "/api/entitlement/has-batch?features=fleet",
+    )
+    live_keys = set(body_live.keys())
+    at_keys = set(body_at.keys())
+    added = at_keys - live_keys
+    assert added == {
+        "perspective_tier",
+        "perspective_tier_label",
+        "perspective_tier_rank",
+    }
+    assert live_keys - at_keys == set()
+
+
+def test_endpoint_row_shape_matches_live_has_batch(client):
+    body_at = _get_json(
+        client,
+        "/api/entitlement/has-batch-at?tier=cloud_pro&features=fleet",
+    )
+    body_live = _get_json(
+        client,
+        "/api/entitlement/has-batch?features=fleet",
+    )
+    at_row_keys = set(body_at["features"][0].keys())
+    live_row_keys = set(body_live["features"][0].keys())
+    assert at_row_keys == live_row_keys


### PR DESCRIPTION
## Summary

Fills the missing `_at` slot on the mixed-axis `has_batch` family alongside `/api/entitlement/min-tier-batch-at` (the perspective sibling on the reverse-lookup axis) and the singular `_at` scalars `has_feature_at` / `has_runtime_at` / `has_channel_count_at` / `has_retention_window_at` / `has_node_count_at` for the five axes.

- **`has_batch_at(perspective_tier, *, features, runtimes, channels, retention_days, nodes)`** in `clawmetry/entitlements.py` — per-row `has` reflects the **STATIC** per-tier grant for `perspective_tier` so the answer is grace-independent by construction (matches the singular `_at` scalars). Features / runtimes resolve against `_hypothetical_entitlement(p)` (grace forced off; feature and runtime grants come from `_TIER_FEATURES` / `_TIER_PAID_RUNTIMES`); the three capacity axes read the static `_TIER_CHANNEL_LIMIT` / `_TIER_RETENTION_DAYS` / `_TIER_NODE_LIMIT` tables directly via a new `_has_row_capacity_at` helper. Delegating the capacity axes to `_hypothetical_entitlement` would misreport (that helper hard-codes `node_limit=1` regardless of tier and would flip `has_batch_at("cloud_pro", nodes=100)` to `has=False`), so the capacity slots read the static caps directly, matching `has_channel_count_at` / `has_retention_window_at` / `has_node_count_at` byte-for-byte.
- **`GET /api/entitlement/has-batch-at?tier=<perspective>&features=&runtimes=&channels=&retention_days=&nodes=`** on `bp_entitlement`. Envelope mirrors `/has-batch` byte-for-byte with the perspective copy (`perspective_tier` / `perspective_tier_label` / `perspective_tier_rank`) layered on top; keeps the same `has_all` rollup and the standard resolver envelope (`current_tier` / `current_tier_rank` / `grace` / `enforced`) so a walkthrough surface can render "from `<perspective>`" alongside "you are here" off one call.

Envelope + short-circuit posture mirrors the sibling `/min-tier-batch-at`:

- **400** on missing / blank `tier`.
- **400** on no axis supplied.
- **404** on unknown `tier` (body carries `which=tier`).
- **200** with `unknown=true` / `has=false` rows for non-canonical feature / runtime ids and non-int capacity values (strict callsite-typo fail-closed matching the singular `_at` scalars).
- **Never 5xx** — resolver / helper / row-shape blowup all collapse to the perspective-carrying grace-shape envelope with empty per-axis rows and `has_all=false`.

Behaviour ships in **GRACE** mode: the resolver still defaults to the OSS-free entitlement so no runtime gating changes. This is purely additive to the entitlement query surface. Perspective-shaped answers are intentionally identical in grace and enforce (they read the static per-tier tables, not the resolver's grace bit) — the whole point of the `_at` slot: `/has-batch-at?tier=oss&features=fleet` returns `has=false` for the fleet row even in grace (because OSS statically doesn't grant `fleet`), whereas the LIVE `/has-batch?features=fleet` reports `has=true` for it via `Entitlement.allows_feature`'s grace pass-through.

Per-row parity tests keep the batch outputs pinned byte-equal to the singular `has_feature_at` / `has_runtime_at` / `has_channel_count_at` / `has_retention_window_at` / `has_node_count_at` scalars and to the sibling `min_tier_batch_at` reverse-lookup rows on `required_tier`, so any future contract change on either side has to update both.

## Test plan

- [x] `python3 -m py_compile clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_has_batch_at.py`
- [x] `ruff check clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_has_batch_at.py` — clean.
- [x] `python3 scripts/lint_daemon_allowlist.py` — passes (no `local_store_via_daemon` calls touched).
- [x] `python3 -m pytest tests/test_entitlement_has_batch_at.py` — **74/74 pass**, covering: perspective validation (empty / non-string / unknown → `None` from helper, 400 / 404 from endpoint), envelope + per-row shape (13-key envelope + 7-key row set), per-row `has` byte-equal to `has_feature_at` / `has_runtime_at` across every `_TIER_ORDER` perspective × every `ALL_FEATURES` / `ALL_RUNTIMES` id, per-row `has` byte-equal to `has_channel_count_at` / `has_retention_window_at` / `has_node_count_at` across every perspective × representative counts, per-row `required_tier` perspective-independence (byte-equal to `min_tier_for_*`), grace-independence assertion (`_at` batch reports `has=false` on OSS even while `ent.grace` is True), enforced-mode fixture (`CLAWMETRY_ENFORCE=1`) returns byte-identical rows, runtime alias canonicalisation (`claude-code` → `claude_code`) with dedup, feature id CSV normalisation, `retention_days=None` = unset (not unlimited), zero / negative capacity trivially satisfied on every perspective, `has_all` rollup contract (True iff every emitted row is `has=True` AND `unknown=False`; a single unknown row flips it False), HTTP 400 on missing / blank `tier` or no axis, 404 on unknown tier (body shape pinned), never-4xx / never-5xx across every input branch (including monkeypatched resolver / scalar blowups), envelope key set stable across every input branch, cross-consistency with the singular `/has-feature-at` / `/has-runtime-at` / `/has-channel-count-at` / `/has-retention-window-at` / `/has-node-count-at` endpoints on `has_*_at` per row, cross-consistency with `/min-tier-batch-at` on `required_tier` for every axis, perspective-tier normalisation (`  CLOUD_PRO  ` → `cloud_pro`), shape parity with LIVE `/has-batch` envelope + row (superset relationship pinned).
- [x] `python3 -m pytest tests/test_entitlement_has_batch.py tests/test_entitlement_has_all.py tests/test_entitlement_min_tier_batch_at.py tests/test_entitlement_has_channel_count_at_batch.py tests/test_entitlement_has_retention_window_at_batch.py` — **275/275 pass** (sibling regression).
- [x] `python3 -m pytest tests/test_entitlement_api.py tests/test_entitlement_has_channel_count_at.py tests/test_entitlement_has_node_count_at.py tests/test_entitlement_has_retention_window_at.py` — **224/224 pass** (adjacent `_at` singular endpoint surface unchanged).

## Local operator verification checklist

Since this fire runs in an ephemeral cloud container with no access to your local daemon, `~/.openclaw`, the live cloud snapshot, or a browser, please verify against the running host once you pull this branch:

- [ ] Copy the two changed files into your live install:
  ```
  cp clawmetry/entitlements.py ~/.clawmetry/lib/python3.*/site-packages/clawmetry/
  cp routes/entitlement.py     ~/.clawmetry/lib/python3.*/site-packages/routes/
  find ~/.clawmetry/lib -name __pycache__ -type d -exec rm -rf {} +
  ```
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` to restart the daemon and pick up the new endpoint.
- [ ] `curl -s 'http://localhost:8900/api/entitlement/has-batch-at?tier=oss&features=fleet&channels=5&nodes=5' | jq .` — expect `has_all=false`; `features[0].has=false`; `channels.has=false`; `nodes.has=false`; envelope carries `perspective_tier="oss"` and the standard resolver envelope in grace.
- [ ] `curl -s 'http://localhost:8900/api/entitlement/has-batch-at?tier=cloud_pro&features=fleet&runtimes=claude_code&channels=100&retention_days=90&nodes=1000' | jq .' — expect every row `has=true`, `has_all=true` (Cloud Pro admits `fleet` + `claude_code` + unlimited capacity across all three axes on the current tier table).
- [ ] `curl -s 'http://localhost:8900/api/entitlement/has-batch-at?tier=enterprise&features=sso&retention_days=999999' | jq '.has_all'` — expect **true** (Enterprise is the only tier that admits the unlimited retention window on the current tier table).
- [ ] `curl -sw '\n%{http_code}\n' 'http://localhost:8900/api/entitlement/has-batch-at'` — expect **400** with `{"error":"missing tier"}`.
- [ ] `curl -sw '\n%{http_code}\n' 'http://localhost:8900/api/entitlement/has-batch-at?tier=cloud_pro'` — expect **400** with the "supply at least one of" body.
- [ ] `curl -sw '\n%{http_code}\n' 'http://localhost:8900/api/entitlement/has-batch-at?tier=bogus&features=fleet'` — expect **404** with `{"error":"unknown tier","which":"tier","tier":"bogus"}`.
- [ ] `curl -s 'http://localhost:8900/api/entitlement/has-batch-at?tier=cloud_pro&runtimes=claude-code' | jq '.runtimes[0].key'` — expect `"claude_code"` (alias canonicalisation matches the LIVE `/has-batch` sibling).
- [ ] `curl -s 'http://localhost:8900/api/entitlement/has-batch-at?tier=oss&features=fleet' | jq '.features[0].required_tier'` — byte-equal to `curl -s 'http://localhost:8900/api/entitlement/has-feature-at?tier=oss&feature=fleet' | jq '.required_tier'` and to `curl -s 'http://localhost:8900/api/entitlement/min-tier-batch-at?tier=oss&features=fleet' | jq '.features[0].min_tier'`.
- [ ] `curl -s 'http://localhost:8900/api/entitlement' | jq .grace` — expect **true** (nothing about the resolver / gate changed — this PR is purely additive query surface).
- [ ] Decrypt the live cloud snapshot in the browser and confirm the dashboard's entitlement panels still render (no shape regression).

This PR stays **DRAFT** until you've done the local + cloud verification above. Version bump / `[RELEASE]` PR / merge is your call.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DPpGP5VY4wkVt2SoKnXWDq)_