### PR TITLE
fix(sessions): Sessions tab blanked by i18n t() shadowing in the row loop

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -16028,9 +16028,13 @@ async function loadTranscripts() {
       _txWinEmpty = (_preWin > 0 && data.transcripts.length === 0);
     }
     var plumbingTotal = 0;
-    data.transcripts.forEach(function(t) {
-      var raw = String(t.id || '');
-      var titleSrc = (t.title && String(t.title).trim()) || (t.name && String(t.name).trim()) || '';
+    // NOTE: the callback param must NOT be named `t` — that shadows the global
+    // i18n t() and the score-button line below throws "t is not a function",
+    // blanking the whole tab (founder report 2026-08-09). Guarded by
+    // tests/test_app_js_t_shadowing.py.
+    data.transcripts.forEach(function(tx) {
+      var raw = String(tx.id || '');
+      var titleSrc = (tx.title && String(tx.title).trim()) || (tx.name && String(tx.name).trim()) || '';
       var looksLikeId = !titleSrc || titleSrc === raw || UUIDISH.test(titleSrc) || raw.indexOf(titleSrc) === 0;
       var title = looksLikeId ? 'Untitled session' : titleSrc;
       var isPlumbing = _isPlumbingTranscript(titleSrc);
@@ -16042,9 +16046,9 @@ async function loadTranscripts() {
       html += '<div class="transcript-name" style="overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">' + escHtml(title) + '</div>';
       html += '<div class="transcript-meta-row" style="gap:10px;">';
       html += '<span style="font-family:ui-monospace,SFMono-Regular,Menlo,monospace;color:var(--text-muted,#888);font-size:11px;" title="' + escHtml(raw) + '">' + escHtml(raw.slice(0, 8)) + '</span>';
-      html += '<span>' + t.messages + ' messages</span>';
-      if (t.size > 0) html += '<span>' + (t.size > 1024 ? (t.size/1024).toFixed(1) + ' KB' : t.size + ' B') + '</span>';
-      html += '<span>' + timeAgo(t.modified) + '</span>';
+      html += '<span>' + tx.messages + ' messages</span>';
+      if (tx.size > 0) html += '<span>' + (tx.size > 1024 ? (tx.size/1024).toFixed(1) + ' KB' : tx.size + ' B') + '</span>';
+      html += '<span>' + timeAgo(tx.modified) + '</span>';
       html += '</div></div>';
       // Score-this-conversation button (#4562): runs the same judge the daemon
       // uses via /api/evals/rescore. Empty judge key → button flips to

--- a/tests/test_app_js_t_shadowing.py
+++ b/tests/test_app_js_t_shadowing.py
@@ -1,0 +1,63 @@
+"""Guard: no callback whose parameter shadows the global i18n ``t()`` may
+call ``t(...)`` inside its body.
+
+Founder report 2026-08-09: the Sessions tab rendered "Failed to load
+transcripts" for anyone with >= 1 session. Root cause:
+``data.transcripts.forEach(function(t) {...})`` shadowed the global i18n
+helper, and the score-button line inside the loop called
+``t('transcripts.score_btn', ...)`` -> ``TypeError: t is not a function``
+-> the catch blanked the whole tab. The API was fine; only the render died.
+
+This scans app.js for every ``function(t)`` / ``function (t, ...)``
+callback, extracts the balanced-brace body, and fails if the body contains
+an i18n-style call ``t('`` or ``t("``. Auto-discovers its scope: a NEW
+shadowing callback that starts calling i18n fails CI immediately, without
+anyone hand-maintaining a list.
+"""
+
+import re
+from pathlib import Path
+
+APP_JS = (
+    Path(__file__).resolve().parents[1]
+    / "clawmetry" / "static" / "js" / "app.js"
+)
+
+# function(t), function (t), function(t, i) ... — param list STARTING with
+# a bare `t` parameter.
+_SHADOW_RE = re.compile(r"function\s*\(\s*t\s*[,)]")
+# An i18n-style call: t('key'... or t("key"... — property access like x.t(
+# is excluded by the negative lookbehind.
+_I18N_CALL_RE = re.compile(r"(?<![\w.$])t\(\s*['\"]")
+
+
+def _body_after(src: str, start: int) -> str:
+    """Return the balanced {...} body of the function starting at ``start``."""
+    brace = src.index("{", start)
+    depth = 0
+    for i in range(brace, len(src)):
+        c = src[i]
+        if c == "{":
+            depth += 1
+        elif c == "}":
+            depth -= 1
+            if depth == 0:
+                return src[brace:i + 1]
+    return src[brace:]
+
+
+def test_no_i18n_call_inside_t_shadowing_callback():
+    src = APP_JS.read_text(encoding="utf-8")
+    offenders = []
+    for m in _SHADOW_RE.finditer(src):
+        body = _body_after(src, m.start())
+        hit = _I18N_CALL_RE.search(body)
+        if hit:
+            line = src.count("\n", 0, m.start()) + 1
+            hit_line = line + body.count("\n", 0, hit.start())
+            offenders.append(
+                f"callback with param `t` at app.js:{line} calls i18n t() "
+                f"at app.js:{hit_line} - the param shadows the global t() "
+                f"and throws at runtime; rename the callback param"
+            )
+    assert not offenders, "\n".join(offenders)


### PR DESCRIPTION
## Why
Founder report 2026-08-09: the Sessions tab is dead for ANY user with at least one session. It renders 'Failed to load transcripts' (or, during a daemon restart window, the misleading 'No <runtime> sessions have a transcript yet' scoped empty state) while `/api/transcripts` returns rows normally (verified: 200, 9 rows, 70ms on the live box).

## Root cause
`data.transcripts.forEach(function(t) {...})` shadows the global i18n `t()`. The #4562 score-button line inside the loop calls `t('transcripts.score_btn', null, 'Score')` -> `TypeError: t is not a function` on the FIRST row -> `loadTranscripts`'s catch blanks the whole tab. Diagnosed by re-running the function with the catch instrumented in the live dashboard.

## What
- Renamed the loop param to `tx` (5 in-loop references), with a comment pointing at the guard.
- Guard, revert-proven: `tests/test_app_js_t_shadowing.py` scans app.js for every callback whose param list starts with bare `t` and fails if its balanced body contains an i18n-style `t('` call. There are 47 `function(t)` callbacks in app.js today; only this one called i18n inside - the guard auto-discovers any future one. Red on unfixed main (flags `app.js:16031`), green after.

## Verification
Injected the fixed function into the running dashboard (0.12.667) on the founder's machine: the previously blank tab renders all 9 session rows with titles, counts, and Score buttons.

## Blueprint note (FLYWHEEL 1f)
Bug fix restoring documented behavior - no Blueprint contract changes expected; drift-bot will confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)