### PR TITLE
feat(trial): Continue to payment goes straight to per-account Stripe checkout

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -18,6 +18,9 @@
 (function initClawMetryHardBlockOverlay() {
   var POLL_MS_ACTIVE = 15000;    // while blocked: retry auto-refresh every 15s
   var POLL_MS_IDLE   = 60000;    // while unblocked: sanity-check every 60s
+  var POLL_MS_PAYING = 5000;     // after "Continue to payment": poll hard
+  var PAYING_WINDOW_MS = 10 * 60 * 1000;  // fast-poll for 10 min after click
+  var _checkoutClickedAt = 0;
   var OVERLAY_ID     = 'cm-hard-block-overlay';
   var STYLE_ID       = 'cm-hard-block-overlay-style';
 
@@ -113,7 +116,7 @@
     el.setAttribute('aria-modal', 'true');
     el.setAttribute('aria-labelledby', 'cm-hbo-title');
     el.setAttribute('data-cm-locked', '1');
-    var upgradeUrl = (state && state.upgrade_url) || 'https://app.clawmetry.com/upgrade';
+    var upgradeUrl = (state && (state.checkout_url || state.upgrade_url)) || 'https://app.clawmetry.com/upgrade';
     var reason = (state && state.reason) || 'A valid ClawMetry subscription is required to continue.';
     var eyebrow = state && state.expired ? 'Trial ended' : 'Subscription required';
     var daysLeft = state && typeof state.days_until_expiry === 'number' ? state.days_until_expiry : null;
@@ -150,6 +153,46 @@
         }),
       }).catch(function () {});
     } catch (e) { /* noop */ }
+
+    // Wire the payment CTA. The href (per-account checkout URL if the
+    // heartbeat cached one, else the upgrade page) is only the no-JS
+    // fallback: on click we ask /api/trial/checkout to mint a live Stripe
+    // Checkout Session for the account this node is already linked to, so
+    // the user lands directly on the card form instead of a generic
+    // upgrade page. The tab MUST be opened synchronously in the click
+    // handler (popup blockers kill window.open from inside a fetch
+    // callback) and is redirected once the URL arrives.
+    var ctaEl = el.querySelector('.cm-hbo-cta');
+    var statusElForCta = el.querySelector('.cm-hbo-status');
+    ctaEl.addEventListener('click', function (ev) {
+      ev.preventDefault();
+      _checkoutClickedAt = Date.now();
+      var payTab = null;
+      try { payTab = window.open('about:blank', '_blank'); } catch (e) { payTab = null; }
+      function go(url) {
+        if (payTab) { try { payTab.location = url; return; } catch (e) { /* fall through */ } }
+        try { window.open(url, '_blank', 'noopener'); } catch (e) { window.location.href = url; }
+      }
+      statusElForCta.className = 'cm-hbo-status';
+      statusElForCta.textContent = 'Opening secure checkout…';
+      fetch('/api/trial/checkout', { method: 'POST' })
+        .then(function (r) { return r.json().catch(function () { return {}; }); })
+        .then(function (resp) {
+          go(resp && resp.url ? resp.url : ctaEl.href);
+          statusElForCta.textContent = 'Waiting for payment. This dashboard unlocks automatically once checkout completes.';
+          // Poll hard while the user is off paying so the unlock feels
+          // instant when the license lands on the next daemon heartbeat.
+          refreshAndMaybeUnblock(true);
+        })
+        .catch(function () { go(ctaEl.href); });
+      try {
+        fetch('/api/paywall/event', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ event: 'hard_block_checkout_click' }),
+        }).catch(function () {});
+      } catch (e) { /* noop */ }
+    });
 
     // Wire activate button — POSTs to /api/license/activate (allowlisted),
     // then forces a refresh + snapshot. The overlay auto-removes itself if
@@ -247,13 +290,18 @@
       if (!existing) mount(state);
     }
     _lastBlocked = blocked;
-    var delay = blocked ? POLL_MS_ACTIVE : POLL_MS_IDLE;
+    var paying = _checkoutClickedAt && (Date.now() - _checkoutClickedAt) < PAYING_WINDOW_MS;
+    var delay = blocked ? (paying ? POLL_MS_PAYING : POLL_MS_ACTIVE) : POLL_MS_IDLE;
     if (window.__cmHardBlockTimer) clearTimeout(window.__cmHardBlockTimer);
     window.__cmHardBlockTimer = setTimeout(tick, delay);
   }
 
   function tick() {
-    refreshAndMaybeUnblock(false);
+    // While the user is off paying, force the refresh-license path so the
+    // entitlement cache is invalidated and a license the daemon just wrote
+    // is honoured on THIS tick, not after the resolver TTL expires.
+    var paying = _checkoutClickedAt && (Date.now() - _checkoutClickedAt) < PAYING_WINDOW_MS;
+    refreshAndMaybeUnblock(!!paying);
   }
 
   // First tick: read status ASAP (before any other tab hits an /api/* that

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -1187,8 +1187,44 @@ _TRIAL_STATE = {
     "plan": None,
     "trial_days_left": None,
     "upgrade_url": "https://app.clawmetry.com/cloud",
+    "checkout_url": None,    # signed per-account Stripe checkout URL, if any
     "last_log_day": "",     # YYYY-MM-DD of the last "sync paused" log
 }
+
+# Trial-state cache file the paywall overlay's backend reads
+# (clawmetry/trial_enforcement.py::persisted_trial_state). The daemon writes
+# it from heartbeat responses so the dashboard process's "Continue to payment"
+# button can point at the per-account signed Stripe checkout URL instead of
+# the generic upgrade page. In-memory _TRIAL_STATE alone is useless to the
+# dashboard: it runs in a different process and only ever sees the defaults.
+_TRIAL_STATE_FILE_PATH = os.path.expanduser("~/.clawmetry/trial_state.json")
+
+
+def _persist_trial_state_to_disk() -> None:
+    """Mirror the heartbeat's upgrade/checkout URLs into
+    ``~/.clawmetry/trial_state.json``. Idempotent (skips the write when the
+    file already matches) and best-effort — never raises."""
+    try:
+        payload = {
+            "upgrade_url": _TRIAL_STATE.get("upgrade_url"),
+            "checkout_url": _TRIAL_STATE.get("checkout_url"),
+            "plan": _TRIAL_STATE.get("plan"),
+            "sync_allowed": _TRIAL_STATE.get("sync_allowed"),
+        }
+        try:
+            if os.path.isfile(_TRIAL_STATE_FILE_PATH):
+                with open(_TRIAL_STATE_FILE_PATH, encoding="utf-8") as fh:
+                    if json.load(fh) == payload:
+                        return
+        except Exception:
+            pass
+        os.makedirs(os.path.dirname(_TRIAL_STATE_FILE_PATH), exist_ok=True)
+        tmp = _TRIAL_STATE_FILE_PATH + ".tmp"
+        with open(tmp, "w", encoding="utf-8") as fh:
+            json.dump(payload, fh)
+        os.replace(tmp, _TRIAL_STATE_FILE_PATH)
+    except Exception as exc:
+        log.debug("trial_state: persist failed: %s", exc)
 
 # Cloud-plan cache file the entitlements resolver reads. The daemon writes it
 # from heartbeat responses so a separate process (the Flask dashboard) can pick
@@ -1344,6 +1380,11 @@ def _update_trial_state(resp: dict) -> None:
         _TRIAL_STATE["trial_days_left"] = resp.get("trial_days_left")
     if resp.get("upgrade_url"):
         _TRIAL_STATE["upgrade_url"] = resp["upgrade_url"]
+    if resp.get("checkout_url"):
+        _TRIAL_STATE["checkout_url"] = resp["checkout_url"]
+    # Persist the URLs for the dashboard process (paywall "Continue to
+    # payment" button); idempotent, so cheap on every beat.
+    _persist_trial_state_to_disk()
     # Reconcile the on-disk plan cache on EVERY heartbeat (the founder ask:
     # "check & start sync at every heartbeat, for which plan it is in"). The
     # call is idempotent (a no-op when the cache already matches the live tier),

--- a/clawmetry/trial_enforcement.py
+++ b/clawmetry/trial_enforcement.py
@@ -217,25 +217,67 @@ def allowlisted_path(path: str) -> bool:
         return False
 
 
-def resolved_upgrade_url() -> str:
-    """The URL the "Continue to payment" button points at. Prefers a signed
-    per-account checkout URL the cloud handed us via heartbeat (mirrored into
-    ``CLAWMETRY_CHECKOUT_URL`` by the sync daemon), falls back to the generic
-    upgrade page, and finally to the hard-coded default. Never raises."""
+# The sync daemon persists {upgrade_url, checkout_url} from each heartbeat
+# here so the dashboard — a SEPARATE process whose in-memory copy of
+# ``sync._TRIAL_STATE`` only ever holds the module defaults — can read the
+# per-account URLs the cloud actually handed us.
+_TRIAL_STATE_PATH = "~/.clawmetry/trial_state.json"
+
+
+def persisted_trial_state() -> dict:
+    """The daemon-persisted trial-state file (``~/.clawmetry/trial_state.json``)
+    as a dict, or ``{}`` when absent/unreadable. Never raises."""
+    try:
+        import json
+        path = os.path.expanduser(_TRIAL_STATE_PATH)
+        if not os.path.isfile(path):
+            return {}
+        with open(path, encoding="utf-8") as fh:
+            data = json.load(fh)
+        return data if isinstance(data, dict) else {}
+    except Exception:
+        return {}
+
+
+def resolved_checkout_url() -> str:
+    """The signed per-account Stripe checkout URL, or ``""`` when the cloud
+    hasn't handed us one yet. Env override wins (support lever), then the
+    daemon-persisted heartbeat cache. Never raises."""
     try:
         checkout = os.environ.get(_HARD_BLOCK_CHECKOUT_URL_ENV, "").strip()
+        if checkout:
+            return checkout
+        cached = persisted_trial_state().get("checkout_url")
+        if isinstance(cached, str) and cached.strip():
+            return cached.strip()
+        return ""
+    except Exception:
+        return ""
+
+
+def resolved_upgrade_url() -> str:
+    """The URL the "Continue to payment" button points at. Prefers a signed
+    per-account checkout URL the cloud handed us via heartbeat (persisted to
+    ``~/.clawmetry/trial_state.json`` by the sync daemon, or mirrored into
+    ``CLAWMETRY_CHECKOUT_URL``), falls back to the generic upgrade page, and
+    finally to the hard-coded default. Never raises."""
+    try:
+        checkout = resolved_checkout_url()
         if checkout:
             return checkout
         upgrade = os.environ.get(_HARD_BLOCK_UPGRADE_URL_ENV, "").strip()
         if upgrade:
             return upgrade
-        # Best-effort: also read the daemon's live cache if the sync module
-        # is importable (it holds the fresher URL that heartbeats returned).
+        cached = persisted_trial_state().get("upgrade_url")
+        if isinstance(cached, str) and cached.strip():
+            return cached.strip()
+        # Best-effort: also read the daemon's live cache if we happen to run
+        # in the daemon process itself (fresher than the persisted file).
         try:
             from clawmetry import sync as _sync
-            cached = getattr(_sync, "_TRIAL_STATE", {}).get("upgrade_url")
-            if isinstance(cached, str) and cached.strip():
-                return cached.strip()
+            in_proc = getattr(_sync, "_TRIAL_STATE", {}).get("upgrade_url")
+            if isinstance(in_proc, str) and in_proc.strip():
+                return in_proc.strip()
         except Exception:
             pass
         return _DEFAULT_UPGRADE_URL
@@ -286,7 +328,9 @@ def block_payload(ent: "Entitlement | None" = None) -> dict:
             "days_until_expiry": days_left,
             "reason": reason,
             "upgrade_url": resolved_upgrade_url(),
+            "checkout_url": resolved_checkout_url() or None,
             "activation_endpoint": "/api/license/activate",
+            "checkout_endpoint": "/api/trial/checkout",
             "refresh_endpoint": "/api/trial/refresh-license",
             "status_endpoint": "/api/trial/status",
         }
@@ -297,6 +341,7 @@ def block_payload(ent: "Entitlement | None" = None) -> dict:
             "reason": "A valid ClawMetry subscription is required to continue.",
             "upgrade_url": _DEFAULT_UPGRADE_URL,
             "activation_endpoint": "/api/license/activate",
+            "checkout_endpoint": "/api/trial/checkout",
             "refresh_endpoint": "/api/trial/refresh-license",
             "status_endpoint": "/api/trial/status",
         }
@@ -320,6 +365,8 @@ __all__ = [
     "hard_block_enabled",
     "is_hard_blocked",
     "allowlisted_path",
+    "persisted_trial_state",
+    "resolved_checkout_url",
     "resolved_upgrade_url",
     "block_payload",
     "warning_window_days",

--- a/docs/TRIAL_ENFORCEMENT.md
+++ b/docs/TRIAL_ENFORCEMENT.md
@@ -48,8 +48,32 @@ in the expired state will:
 
 2. Render a **full-viewport, un-dismissable modal** (`static/js/app.js` top-
    of-file IIFE, `#cm-hard-block-overlay`) that shows the block reason, a
-   "Continue to payment →" CTA pointing at `upgrade_url`, and a paste-in
-   license-key field that hits `/api/license/activate` directly.
+   "Continue to payment →" CTA, and a paste-in license-key field that hits
+   `/api/license/activate` directly. The CTA does NOT just link to the
+   generic `upgrade_url`: on click it POSTs `/api/trial/checkout`, which
+   resolves the best payment destination for THIS install:
+
+   1. **Live Stripe Checkout Session** — the account is already known
+      locally (the node's `api_key`), so the route asks the cloud
+      (`POST /api/billing/checkout-session`, `X-Api-Key` auth) to mint a
+      per-account Checkout Session and sends the browser straight to the
+      card form (`source: "session"`).
+   2. **Heartbeat-cached `checkout_url`** when the live mint fails
+      (`source: "cached"`).
+   3. **Generic `upgrade_url`** as the last resort (`source: "upgrade"`).
+
+   The endpoint always answers HTTP 200 with a usable URL — the CTA never
+   dead-ends. After the click the overlay polls `/api/trial/refresh-license`
+   every 5s (for up to 10 minutes) so the dashboard unlocks within seconds
+   of the license landing, with no key to copy-paste.
+
+   Cross-process plumbing: the daemon persists heartbeat
+   `{upgrade_url, checkout_url}` into `~/.clawmetry/trial_state.json`
+   (`sync.py::_persist_trial_state_to_disk`), which
+   `trial_enforcement.persisted_trial_state()` reads from the dashboard
+   process. (Before this file existed, `resolved_upgrade_url()` read
+   `sync._TRIAL_STATE` in-process and only ever saw the module defaults —
+   the per-account URL never reached the button.)
 
 3. Refuse to load `clawmetry-pro` at daemon startup via
    [`clawmetry/extensions.py::load_plugins`](../clawmetry/extensions.py).
@@ -122,6 +146,17 @@ blocked by this scaffold.
 
 ### `clawmetry-cloud` (ingest + heartbeat + email + billing)
 
+0. **Add `POST /api/billing/checkout-session`** (`X-Api-Key` auth): resolve
+   the account from the node key, create a Stripe Checkout Session for the
+   Pro/Starter price (customer + email prefilled from the account), and
+   return `{ok: true, url: "https://checkout.stripe.com/..."}`. On
+   `checkout.session.completed`, mint the signed license and attach it as
+   `license_key` on the next heartbeat (item 1 below) — that is what makes
+   the OSS overlay's "pay → auto-unlock, no key to paste" loop real. The
+   session's `success_url` should say "Payment received — you can close this
+   tab; your dashboard unlocks automatically." OSS side is already live:
+   `routes/trial.py::api_trial_checkout` calls this and falls back to
+   `checkout_url`/`upgrade_url` when the endpoint 404s.
 1. **Extend heartbeat response** with `license_key` when the account
    completed checkout since the last heartbeat. Payload: raw Ed25519
    `header.payload.signature` token, matching what `clawmetry license

--- a/routes/trial.py
+++ b/routes/trial.py
@@ -286,3 +286,70 @@ def api_trial_mark_warned():
     except Exception as exc:
         _hb_log.warning("trial.mark_warned: %s", exc)
         return jsonify({"ok": False, "error": str(exc)}), 200
+
+
+# Cloud endpoint that mints a Stripe Checkout Session for the account this
+# node belongs to (X-Api-Key auth). Lives on the license server / ingest app;
+# clawmetry.license._cloud_base honours CLAWMETRY_LICENSE_SERVER /
+# CLAWMETRY_INGEST_URL for self-hosted setups.
+_CHECKOUT_SESSION_PATH = "/api/billing/checkout-session"
+
+
+def _local_api_key() -> str:
+    """The cloud account key this node is linked to, or ``""`` when the
+    install has never run ``clawmetry connect``/``login``. Never raises."""
+    try:
+        from clawmetry.sync import load_config
+        cfg = load_config() or {}
+        return str(cfg.get("api_key") or "")
+    except Exception:
+        return ""
+
+
+@bp_trial.route("/api/trial/checkout", methods=["POST"])
+def api_trial_checkout():
+    """Resolve the best "Continue to payment" destination for this install.
+
+    The account is already known locally (the node's ``api_key`` from
+    ``clawmetry connect``), so instead of dropping the user on the generic
+    upgrade page we ask the cloud to mint a per-account Stripe Checkout
+    Session and send the browser straight there: card form pre-scoped to the
+    right account, and on completion the cloud attaches the freshly-minted
+    license to the next daemon heartbeat, which unlocks the dashboard
+    automatically (no key to copy-paste).
+
+    Fallback chain — this endpoint always returns HTTP 200 with a usable URL:
+      1. live Stripe Checkout Session minted by the cloud (``source: session``)
+      2. per-account ``checkout_url`` cached from a heartbeat (``source: cached``)
+      3. generic upgrade page (``source: upgrade``)
+    """
+    from clawmetry import trial_enforcement as _te
+
+    api_key = _local_api_key()
+    if api_key:
+        try:
+            from clawmetry import license as _lic
+            base = _lic._cloud_base().rstrip("/")
+            body = json.dumps({"context": "trial_hard_block"}).encode("utf-8")
+            req = urllib.request.Request(
+                base + _CHECKOUT_SESSION_PATH,
+                data=body,
+                headers={"Content-Type": "application/json",
+                         "X-Api-Key": api_key},
+                method="POST",
+            )
+            with urllib.request.urlopen(req, timeout=10) as resp:
+                payload = json.loads(resp.read().decode("utf-8", errors="replace"))
+            url = (payload.get("url") or "").strip()
+            if payload.get("ok") and url.startswith("https://"):
+                return jsonify({"ok": True, "url": url, "source": "session"})
+        except Exception as exc:
+            # Older cloud without the endpoint (404), network trouble, or a
+            # malformed reply: all fall through to the cached / generic URL.
+            _hb_log.debug("trial.checkout: session mint failed: %s", exc)
+
+    cached = _te.resolved_checkout_url()
+    if cached:
+        return jsonify({"ok": True, "url": cached, "source": "cached"})
+    return jsonify({"ok": True, "url": _te.resolved_upgrade_url(),
+                    "source": "upgrade"})

--- a/tests/test_trial_checkout.py
+++ b/tests/test_trial_checkout.py
@@ -1,0 +1,180 @@
+"""tests/test_trial_checkout.py
+
+Guard tests for the direct-to-Stripe "Continue to payment" flow:
+
+  * POST /api/trial/checkout mints a live per-account Stripe Checkout
+    Session via the cloud when the node has an api_key, falls back to the
+    heartbeat-cached checkout_url, then to the generic upgrade page — and
+    ALWAYS answers 200 with a usable URL (the paywall CTA must never dead-end).
+  * The sync daemon persists heartbeat {upgrade_url, checkout_url} to
+    ~/.clawmetry/trial_state.json so the dashboard process (which cannot see
+    the daemon's in-memory _TRIAL_STATE) resolves the per-account URL.
+    Regression guard for the cross-process bug where resolved_upgrade_url()
+    read sync._TRIAL_STATE in the dashboard process and only ever saw the
+    module defaults.
+  * block_payload advertises checkout_endpoint so the overlay knows where
+    to ask.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+_REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _REPO not in sys.path:
+    sys.path.insert(0, _REPO)
+
+
+def _make_client():
+    from flask import Flask
+    from routes.trial import bp_trial
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_trial)
+    return app.test_client()
+
+
+class TrialCheckoutEndpointTest(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.mkdtemp(prefix="cm_checkout_")
+        from clawmetry import trial_enforcement as te
+        self._te = te
+        self._state_path = os.path.join(self._tmp, "trial_state.json")
+        self._patches = [
+            mock.patch.object(te, "_TRIAL_STATE_PATH", self._state_path),
+        ]
+        for p in self._patches:
+            p.start()
+        os.environ.pop("CLAWMETRY_CHECKOUT_URL", None)
+        os.environ.pop("CLAWMETRY_UPGRADE_URL", None)
+        self._client = _make_client()
+
+    def tearDown(self):
+        for p in self._patches:
+            p.stop()
+        shutil.rmtree(self._tmp, ignore_errors=True)
+
+    def _write_state(self, payload: dict):
+        with open(self._state_path, "w", encoding="utf-8") as fh:
+            json.dump(payload, fh)
+
+    def test_falls_back_to_upgrade_url_with_no_account_and_no_cache(self):
+        """A node that never ran `clawmetry connect` must still get a URL."""
+        with mock.patch("routes.trial._local_api_key", return_value=""):
+            resp = self._client.post("/api/trial/checkout")
+        self.assertEqual(resp.status_code, 200)
+        body = resp.get_json()
+        self.assertTrue(body["ok"])
+        self.assertEqual(body["source"], "upgrade")
+        self.assertTrue(body["url"].startswith("http"))
+
+    def test_uses_heartbeat_cached_checkout_url(self):
+        """A checkout_url the daemon persisted from a heartbeat wins over the
+        generic upgrade page when the live session mint is unavailable."""
+        self._write_state({"checkout_url": "https://checkout.stripe.com/c/pay/cs_test_abc"})
+        with mock.patch("routes.trial._local_api_key", return_value=""):
+            resp = self._client.post("/api/trial/checkout")
+        body = resp.get_json()
+        self.assertEqual(body["source"], "cached")
+        self.assertEqual(body["url"], "https://checkout.stripe.com/c/pay/cs_test_abc")
+
+    def test_mints_live_session_when_account_linked(self):
+        """With an api_key, the endpoint asks the cloud for a Stripe Checkout
+        Session and returns its URL directly."""
+        fake = io.BytesIO(json.dumps({
+            "ok": True, "url": "https://checkout.stripe.com/c/pay/cs_live_123",
+        }).encode())
+        fake.read = fake.read  # urlopen context-manager duck type
+        cm = mock.MagicMock()
+        cm.__enter__.return_value = fake
+        cm.__exit__.return_value = False
+        with mock.patch("routes.trial._local_api_key", return_value="cm_key_x"), \
+             mock.patch("urllib.request.urlopen", return_value=cm) as uo:
+            resp = self._client.post("/api/trial/checkout")
+        body = resp.get_json()
+        self.assertEqual(body["source"], "session")
+        self.assertEqual(body["url"], "https://checkout.stripe.com/c/pay/cs_live_123")
+        req = uo.call_args[0][0]
+        self.assertTrue(req.full_url.endswith("/api/billing/checkout-session"))
+        self.assertEqual(req.get_header("X-api-key"), "cm_key_x")
+
+    def test_cloud_failure_falls_back_not_500(self):
+        """An old cloud without the endpoint (404 / network error) must fall
+        back to the cached / generic URL, never surface an error."""
+        self._write_state({"checkout_url": "https://checkout.stripe.com/c/pay/cs_test_fb"})
+        with mock.patch("routes.trial._local_api_key", return_value="cm_key_x"), \
+             mock.patch("urllib.request.urlopen", side_effect=OSError("boom")):
+            resp = self._client.post("/api/trial/checkout")
+        self.assertEqual(resp.status_code, 200)
+        body = resp.get_json()
+        self.assertTrue(body["ok"])
+        self.assertEqual(body["source"], "cached")
+
+    def test_checkout_path_is_allowlisted_while_blocked(self):
+        self.assertTrue(self._te.allowlisted_path("/api/trial/checkout"))
+
+    def test_block_payload_advertises_checkout_endpoint(self):
+        payload = self._te.block_payload(None)
+        self.assertEqual(payload.get("checkout_endpoint"), "/api/trial/checkout")
+
+
+class TrialStatePersistenceTest(unittest.TestCase):
+    """The daemon → disk → dashboard handoff of the per-account URLs."""
+
+    def setUp(self):
+        self._tmp = tempfile.mkdtemp(prefix="cm_tstate_")
+        self._state_path = os.path.join(self._tmp, "trial_state.json")
+
+    def tearDown(self):
+        shutil.rmtree(self._tmp, ignore_errors=True)
+
+    def test_update_trial_state_persists_urls_for_dashboard_process(self):
+        from clawmetry import sync
+        from clawmetry import trial_enforcement as te
+
+        with mock.patch.object(sync, "_TRIAL_STATE_FILE_PATH", self._state_path), \
+             mock.patch.object(sync, "_persist_cloud_plan_to_disk"), \
+             mock.patch.object(te, "_TRIAL_STATE_PATH", self._state_path):
+            sync._update_trial_state({
+                "sync_allowed": False,
+                "plan": "trial_expired",
+                "upgrade_url": "https://app.clawmetry.com/upgrade?acct=a1",
+                "checkout_url": "https://checkout.stripe.com/c/pay/cs_hb_1",
+            })
+            self.assertTrue(os.path.isfile(self._state_path),
+                            "heartbeat must persist trial_state.json")
+            # The dashboard-process resolvers read the file, not sync memory.
+            self.assertEqual(te.resolved_checkout_url(),
+                             "https://checkout.stripe.com/c/pay/cs_hb_1")
+            self.assertEqual(te.resolved_upgrade_url(),
+                             "https://checkout.stripe.com/c/pay/cs_hb_1",
+                             "checkout_url must win over upgrade_url")
+
+    def test_env_override_beats_persisted_state(self):
+        from clawmetry import trial_enforcement as te
+        with open(self._state_path, "w", encoding="utf-8") as fh:
+            json.dump({"checkout_url": "https://checkout.stripe.com/x"}, fh)
+        with mock.patch.object(te, "_TRIAL_STATE_PATH", self._state_path), \
+             mock.patch.dict(os.environ,
+                             {"CLAWMETRY_CHECKOUT_URL": "https://support.example/fix"}):
+            self.assertEqual(te.resolved_checkout_url(),
+                             "https://support.example/fix")
+
+    def test_missing_or_corrupt_state_file_is_harmless(self):
+        from clawmetry import trial_enforcement as te
+        with mock.patch.object(te, "_TRIAL_STATE_PATH", self._state_path):
+            self.assertEqual(te.resolved_checkout_url(), "")
+            with open(self._state_path, "w", encoding="utf-8") as fh:
+                fh.write("{not json")
+            self.assertEqual(te.persisted_trial_state(), {})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Why

Founder feedback (2026-08-09, desktop trial-ended modal): "Continue to payment" should take the user directly to Stripe checkout for the account they are already logged into locally, charge, and on return auto-activate Pro/Starter. Instead the CTA linked to the generic upgrade page.

Root causes:
1. Cross-process bug: `resolved_upgrade_url()` read `sync._TRIAL_STATE` in the dashboard process, which only ever holds module defaults. Any per-account URL the cloud attached to heartbeats never reached the button.
2. No path existed to mint a live per-account Stripe Checkout Session on click.

## What

- `POST /api/trial/checkout` (routes/trial.py, already allowlisted while hard-blocked): mints a per-account Stripe Checkout Session via the cloud (`POST /api/billing/checkout-session`, X-Api-Key auth from the node's local login), falling back to the heartbeat-cached `checkout_url`, then the generic upgrade page. Always answers 200 with a usable URL, so the CTA never dead-ends on an older cloud.
- Sync daemon persists heartbeat `{upgrade_url, checkout_url}` to `~/.clawmetry/trial_state.json`; `trial_enforcement` reads that file from the dashboard process (fixes cause 1).
- Overlay CTA: opens the tab synchronously (popup-blocker safe), redirects it to the minted session URL, then force-polls `/api/trial/refresh-license` every 5s for 10 minutes, so the dashboard unlocks seconds after the license lands on a heartbeat. Pay, return, unlocked. No key to copy-paste.
- `block_payload` now advertises `checkout_endpoint` + `checkout_url`; docs updated with the flow and the clawmetry-cloud work order.

## Cloud follow-up (separate repo)

`clawmetry-cloud` needs `POST /api/billing/checkout-session` (documented in docs/TRIAL_ENFORCEMENT.md item 0). Until it ships, the new endpoint falls back exactly as before, so this PR is safe to release independently. The auto-unlock half (heartbeat `license_key`) is the already-documented contract.

## Verification

- `pytest tests/test_trial_checkout.py`: 9/9 green (fallback chain, live session mint incl. URL + auth header assertions, cloud-failure never 500s, daemon-to-dashboard persistence, env override, corrupt state file).
- `node --check clawmetry/static/js/app.js` and `py_compile` on all touched modules: clean.
- Pre-existing on this Windows lab machine and identical on unmodified origin/main (not from this change): `test_trial_hard_block.py::test_non_allowlisted_returns_402_with_correct_body` and `test_local_trial_sync_gate.py::test_no_agent_banner_suppressed_for_entitled_runtimes`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)