### PR TITLE
fix(profile): resolve identity for cloud-OAuth accounts - never show 'Not signed in' while signed in

### DIFF
--- a/clawmetry/static/js/gw-setup.js
+++ b/clawmetry/static/js/gw-setup.js
@@ -398,8 +398,10 @@ function _cmProfileFetchState() {
     var signedIn = !!(lic.valid || cta.account_linked);
     _cmProfile.state = {
       signedIn: signedIn,
-      // license `sub` is the account the key was issued to (the sign-in email)
-      who: lic.sub || '',
+      // license `sub` is the account the key was issued to (the sign-in
+      // email); a cloud-OAuth account with no local license has no sub, so
+      // fall back to the cloud account email resolved by the backend.
+      who: lic.sub || cta.account_email || '',
       tier: (lic.tier || '').toLowerCase(),
       daysLeft: (typeof lic.days_left === 'number') ? lic.days_left : null,
       licenseValid: !!lic.valid,
@@ -416,10 +418,10 @@ function _cmProfileApplyAvatar(st) {
   var btn = document.getElementById('cm-profile-btn');
   var initial = document.getElementById('cm-profile-initial');
   if (!btn || !initial) return;
-  if (st.signedIn && st.who) {
+  if (st.signedIn) {
     btn.dataset.signedIn = '1';
-    initial.textContent = st.who.charAt(0).toUpperCase();
-    btn.title = st.who;
+    initial.textContent = st.who ? st.who.charAt(0).toUpperCase() : '';
+    btn.title = st.who || t('profile.signed_in', null, 'Signed in');
   } else {
     delete btn.dataset.signedIn;
     btn.title = t('profile.account', null, 'Account');
@@ -442,8 +444,13 @@ function _cmProfileRender(st) {
   var h = '';
   // Identity header
   h += '<div style="padding:10px 10px 8px;border-bottom:1px solid var(--border-color,rgba(255,255,255,0.08));margin-bottom:4px;">';
-  if (st.signedIn && st.who) {
-    h += '<div style="font-size:13px;font-weight:700;color:var(--text-primary,#e2e8f0);word-break:break-all;">' + _cmProfileEsc(st.who) + '</div>';
+  if (st.signedIn) {
+    // Signed in but the email is unresolvable (offline, pre-claim account):
+    // still say "Signed in" — a signed-in menu that opens with "Not signed
+    // in" above Billing/Sign out is a contradiction (founder report
+    // 2026-08-09, GitHub-OAuth node with no local license).
+    var whoLine = st.who ? _cmProfileEsc(st.who) : t('profile.signed_in', null, 'Signed in');
+    h += '<div style="font-size:13px;font-weight:700;color:var(--text-primary,#e2e8f0);word-break:break-all;">' + whoLine + '</div>';
     var plan = _cmProfilePlanLine(st);
     if (plan) h += '<div style="font-size:11px;color:var(--text-muted,#94a3b8);margin-top:2px;">' + _cmProfileEsc(plan) + '</div>';
   } else {

--- a/clawmetry/static/locales/en.json
+++ b/clawmetry/static/locales/en.json
@@ -956,6 +956,7 @@
   "profile.not_signed_in": "Not signed in",
   "profile.plan": "{tier} plan",
   "profile.sign_in": "Sign in / Create account",
+  "profile.signed_in": "Signed in",
   "profile.sign_out": "Sign out",
   "profile.trial_days_left": "Trial · {days} days left",
   "profile.upgrade": "Upgrade plan",

--- a/dashboard.py
+++ b/dashboard.py
@@ -17760,6 +17760,89 @@ def _write_cloud_token(token):
         json.dump(data, f, indent=2)
 
 
+# In-memory account-email cache for /api/cloud-cta/status. `fail_at` throttles
+# cloud lookups on offline machines (retry at most once a minute) so opening
+# the profile menu never blocks on a dead network for every click.
+_ACCOUNT_EMAIL_CACHE = {"token": "", "email": "", "fail_at": 0.0}
+
+
+def _account_email_for_token(token):
+    """Resolve the sign-in email behind a cm_ key, '' if unknowable.
+
+    The profile menu needs a "who am I" for cloud-OAuth accounts that hold
+    no local license (license `sub` is empty there) — without this the
+    header says "Not signed in" on a fully signed-in, cloud-connected node
+    (founder report 2026-08-09). Resolution order:
+
+      1. ``~/.clawmetry/config.json`` → ``account_email`` (written at
+         connect time and by the claim watcher in clawmetry/sync.py).
+      2. Cloud ``/api/cloud/account?token=`` (best-effort, cached; the
+         result is persisted back into config.json when that file exists
+         so restarts skip the network hop).
+
+    Placeholder identities (``agent+<hash>@clawmetry.auto`` / ``.linked``)
+    are reported as '' — they are internal pre-claim accounts, not
+    something to show a human. Never raises.
+    """
+    if not token:
+        return ""
+
+    def _real(email):
+        e = (email or "").strip()
+        low = e.lower()
+        if low.endswith("@clawmetry.auto") or low.endswith("@clawmetry.linked"):
+            return ""
+        return e
+
+    daemon_cfg = os.path.expanduser("~/.clawmetry/config.json")
+    try:
+        with open(daemon_cfg) as f:
+            cfg = json.load(f)
+        # Only trust the stored email when it belongs to THIS key — after a
+        # reconnect under a different account the old email would be stale.
+        if cfg.get("api_key") == token:
+            e = _real(cfg.get("account_email"))
+            if e:
+                return e
+    except Exception:
+        cfg = None
+
+    if _ACCOUNT_EMAIL_CACHE["token"] == token:
+        if _ACCOUNT_EMAIL_CACHE["email"]:
+            return _ACCOUNT_EMAIL_CACHE["email"]
+        if time.time() - _ACCOUNT_EMAIL_CACHE["fail_at"] < 60:
+            return ""
+
+    email = ""
+    try:
+        import urllib.parse as _up
+        import urllib.request as _ur
+        from clawmetry.endpoints import app_url as _app_url
+
+        url = _app_url() + "/api/cloud/account?token=" + _up.quote(token)
+        with _ur.urlopen(url, timeout=3) as resp:
+            body = json.loads(resp.read() or b"{}")
+        email = _real(body.get("email") if isinstance(body, dict) else "")
+    except Exception:
+        email = ""
+
+    _ACCOUNT_EMAIL_CACHE.update(
+        {"token": token, "email": email,
+         "fail_at": 0.0 if email else time.time()}
+    )
+    if email and isinstance(cfg, dict) and cfg.get("api_key") == token:
+        # Best-effort persist so the daemon and future dashboards see it
+        # without a network hop; config.json stays 0o600 via save_config.
+        try:
+            from clawmetry.sync import save_config
+
+            cfg["account_email"] = email
+            save_config(cfg)
+        except Exception:
+            pass
+    return email
+
+
 # ── One-click cloud connect via GitHub/Google OAuth (dashboard CTA) ────────────
 # The local "Enable Cloud Sync" modal can sign the user up AND connect this node
 # in one click. We reuse the same loopback browser-bridge as `clawmetry connect`:
@@ -17814,6 +17897,17 @@ def _persist_identity_with_key(api_key):
         "connected_at": __import__("datetime").datetime.now().isoformat(),
         "encryption_key": enc_key,
     }
+    # Resolve + store the sign-in email now, while we know the network is up
+    # (we just OAuth'd through it) — the profile menu reads it via
+    # /api/cloud-cta/status and must not show "Not signed in" on a
+    # signed-in node (founder report 2026-08-09).
+    try:
+        _ACCOUNT_EMAIL_CACHE.update({"token": "", "email": "", "fail_at": 0.0})
+        acct_email = _account_email_for_token(api_key)
+        if acct_email:
+            config["account_email"] = acct_email
+    except Exception:
+        pass
     save_config(config)
     try:
         _write_cloud_token(api_key)

--- a/routes/overview.py
+++ b/routes/overview.py
@@ -1690,9 +1690,20 @@ def cloud_cta_status():
         local_only = is_cloud_disabled()
     except Exception:
         local_only = False
+    # The sign-in email behind the key — the profile menu's "who am I" for
+    # cloud-OAuth accounts that hold no local license (license `sub` is
+    # empty there). '' when unresolvable; the UI then still shows a
+    # signed-in state, just without the address.
+    account_email = ""
+    if token:
+        try:
+            account_email = _d._account_email_for_token(token) or ""
+        except Exception:
+            account_email = ""
     return jsonify({
         "connected": bool(token) and not local_only,
         "account_linked": bool(token),
+        "account_email": account_email,
         "local_only": local_only,
     })
 

--- a/tests/test_cloud_cta_oauth.py
+++ b/tests/test_cloud_cta_oauth.py
@@ -290,3 +290,93 @@ def test_selfhost_signin_survives_trial_server_outage(tmp_path, monkeypatch):
     assert nocloud.exists()
     cfg = json.loads((home / ".clawmetry" / "config.json").read_text())
     assert cfg["api_key"] == "cm_selfhost123"
+
+
+# ── Account email resolution (profile menu "who am I") ─────────────────────────
+# Bug this guards: a GitHub-OAuth cloud account holds no local license, so the
+# profile menu's identity (license `sub`) was empty and the header said
+# "Not signed in" on a fully signed-in, cloud-connected node (2026-08-09).
+
+
+def _email_env(tmp_path, monkeypatch):
+    import dashboard as _d
+
+    home = tmp_path / "home"
+    (home / ".clawmetry").mkdir(parents=True)
+    monkeypatch.setattr(_d.os.path, "expanduser",
+                        lambda p: p.replace("~", str(home)))
+    monkeypatch.setattr(
+        _d, "_ACCOUNT_EMAIL_CACHE",
+        {"token": "", "email": "", "fail_at": 0.0})
+    return _d, home
+
+
+def test_account_email_prefers_matching_config(tmp_path, monkeypatch):
+    _d, home = _email_env(tmp_path, monkeypatch)
+    (home / ".clawmetry" / "config.json").write_text(json.dumps(
+        {"api_key": "cm_abc", "account_email": "dev@example.com"}))
+    assert _d._account_email_for_token("cm_abc") == "dev@example.com"
+
+
+def test_account_email_ignores_stale_config_and_falls_back_to_cloud(
+        tmp_path, monkeypatch):
+    """config.json written under a PREVIOUS key must not leak its email."""
+    import urllib.request as _ur
+
+    _d, home = _email_env(tmp_path, monkeypatch)
+    (home / ".clawmetry" / "config.json").write_text(json.dumps(
+        {"api_key": "cm_old", "account_email": "old@example.com"}))
+    monkeypatch.setattr(
+        _ur, "urlopen",
+        lambda url, timeout=0: _FakeResp({"email": "new@example.com"}))
+    assert _d._account_email_for_token("cm_new") == "new@example.com"
+    # Stale-keyed config must NOT be overwritten with the other key's email.
+    cfg = json.loads((home / ".clawmetry" / "config.json").read_text())
+    assert cfg["account_email"] == "old@example.com"
+
+
+def test_account_email_hides_placeholder_accounts(tmp_path, monkeypatch):
+    """agent+<hash>@clawmetry.auto/.linked are internal pre-claim identities,
+    never something to show a human."""
+    import urllib.request as _ur
+
+    _d, home = _email_env(tmp_path, monkeypatch)
+    monkeypatch.setattr(
+        _ur, "urlopen",
+        lambda url, timeout=0: _FakeResp(
+            {"email": "agent+deadbeef@clawmetry.auto"}))
+    assert _d._account_email_for_token("cm_abc") == ""
+
+
+def test_account_email_offline_degrades_to_empty(tmp_path, monkeypatch):
+    import urllib.request as _ur
+
+    _d, home = _email_env(tmp_path, monkeypatch)
+
+    def _down(url, timeout=0):
+        raise OSError("connection refused")
+
+    monkeypatch.setattr(_ur, "urlopen", _down)
+    assert _d._account_email_for_token("cm_abc") == ""
+    assert _d._account_email_for_token("") == ""
+
+
+def test_cloud_cta_status_reports_account_email(cta_app, monkeypatch):
+    import dashboard as _d
+
+    monkeypatch.setattr(_d, "_read_cloud_token", lambda: "cm_abc")
+    monkeypatch.setattr(
+        _d, "_account_email_for_token",
+        lambda tok: "dev@example.com" if tok == "cm_abc" else "")
+    body = cta_app.test_client().get("/api/cloud-cta/status").get_json()
+    assert body["account_linked"] is True
+    assert body["account_email"] == "dev@example.com"
+
+
+def test_cloud_cta_status_signed_out_has_no_email(cta_app, monkeypatch):
+    import dashboard as _d
+
+    monkeypatch.setattr(_d, "_read_cloud_token", lambda: None)
+    body = cta_app.test_client().get("/api/cloud-cta/status").get_json()
+    assert body["account_linked"] is False
+    assert body["account_email"] == ""

--- a/tests/test_profile_menu.py
+++ b/tests/test_profile_menu.py
@@ -136,8 +136,24 @@ def test_sign_out_sticks_and_offers_local_signin():
 
 def test_en_catalog_has_every_profile_key_the_module_uses():
     js = (STATIC / "js" / "gw-setup.js").read_text()
-    used = set(re.findall(r"[t(\"']+(profile\.[a-z_]+)", js))
+    used = set(re.findall(r"[t(\"']+(profile\.[a-z0-9_]+)", js))
     assert used, "expected profile.* t() keys in gw-setup.js"
     catalog = json.loads((STATIC / "locales" / "en.json").read_text())
     missing = sorted(k for k in used if k not in catalog)
     assert not missing, f"en.json missing i18n keys: {missing}"
+
+
+def test_profile_resolves_identity_for_cloud_oauth_accounts():
+    """A GitHub/Google-OAuth cloud account holds no local license, so `who`
+    must fall back to /api/cloud-cta/status's account_email — and a signed-in
+    menu must NEVER render the "Not signed in" header (2026-08-09 report:
+    signed-in node showed "Not signed in" above Billing & plan / Sign out)."""
+    js = (STATIC / "js" / "gw-setup.js").read_text()
+    assert "cta.account_email" in js
+    # Signed-in-but-email-unresolvable falls back to a "Signed in" label.
+    assert "profile.signed_in" in js
+    # The not-signed-in header may only render on the signed-out branch:
+    # inside _cmProfileRender, "Not signed in" must sit AFTER the signedIn
+    # branch's fallback label.
+    render = js.split("function _cmProfileRender", 1)[1]
+    assert render.index("profile.signed_in") < render.index("profile.not_signed_in")


### PR DESCRIPTION
## Problem

On a fully signed-in, cloud-connected node (GitHub OAuth), the top-right profile menu showed "Not signed in" directly above Billing & plan, Cloud sync key, and Sign out (items that only render when signed in). Reported live on the Windows lab machine, 2026-08-09.

Root cause: the menu's identity (`who`) came only from the license `sub` (`/api/license/status`). A cloud-OAuth account with no local license has no `sub`, so `who` was empty and the header fell through to the signed-out label even though `signedIn=true` (`cta.account_linked`).

Note: the "users should not reach the dashboard without login" requirement already holds. The first-run onboarding gate (`routes/onboarding.py` plus `onboarding.js`) is a hard gate with no skip; it passed here because the GitHub sign-in did succeed. The defect was purely the misreported identity.

## Fix

- `dashboard.py`: new `_account_email_for_token()` resolves the sign-in email behind a `cm_` key: `~/.clawmetry/config.json` `account_email` when keyed to this token, else cloud `GET /api/cloud/account?token=` (3s timeout, in-memory cache, 60s failure throttle, result persisted back into config.json when it belongs to the same key). Placeholder identities (`agent+*@clawmetry.auto`, `.linked`) are hidden. OAuth connect flows (`_persist_identity_with_key`) now store `account_email` at pairing time, the same field the claim watcher in `clawmetry/sync.py` already writes.
- `/api/cloud-cta/status` now returns `account_email`.
- `gw-setup.js`: `who` falls back to `cta.account_email`; when signed in but the email is unresolvable (offline, pre-claim), the header and avatar say "Signed in", never "Not signed in".
- `en.json`: adds `profile.signed_in`.
- Tests: email resolution (config match, stale-key guard, placeholder filter, offline), status shape, JS wiring pins. Also fixes a pre-existing failure on main: the i18n-key regex in `test_profile_menu.py` truncated `profile.e2e_key` at the digit, asserting a bogus `profile.e` key.

## Verification

- `tests/test_profile_menu.py`, `tests/test_cloud_cta_oauth.py`, `tests/test_onboarding_gate.py`: 56 passed (including the previously failing i18n test).
- Live on the affected machine: `_account_email_for_token(_read_cloud_token())` resolves the real account email for the exact token that reproduced the bug.

?? Generated with [Claude Code](https://claude.com/claude-code)