### PR TITLE
fix(cloud-cta): sign-in never flips a self-host install to cloud egress

### DIFF
--- a/clawmetry/static/js/gw-setup.js
+++ b/clawmetry/static/js/gw-setup.js
@@ -113,7 +113,16 @@ document.addEventListener('DOMContentLoaded', checkGwConfig);
 
 // ClawMetry Cloud CTA
 var _cloudEmail = '';
-function openCloudModal() {
+// How the modal was reached decides the OAuth rail. 'managed' (the default:
+// the "Enable Cloud Sync" CTA, the onboarding cloud card, alert sign-up CTAs)
+// sends mode=managed explicitly — clicking those IS the egress opt-in.
+// 'signin' (the profile menu's "Sign in / Create account") omits mode so the
+// backend picks the rail from the install's recorded intent: a self-host
+// machine signing back in stays local-only (founder report 2026-08-09:
+// profile-menu sign-in silently enabled cloud sync on a self-host install).
+var _cloudModalIntent = 'managed';
+function openCloudModal(intent) {
+  _cloudModalIntent = (intent === 'signin') ? 'signin' : 'managed';
   var _cmo = document.getElementById('cloud-modal-overlay');
   document.body.appendChild(_cmo);
   _cmo.style.display = 'flex';
@@ -138,7 +147,9 @@ document.addEventListener('keydown', function(e){ if(e.key==='Escape') closeClou
 var _cloudOauthTimer = null;
 function _cloudStopOauthPoll() { if (_cloudOauthTimer) { clearInterval(_cloudOauthTimer); _cloudOauthTimer = null; } }
 function cloudOauth(provider) {
-  fetch('/api/cloud-cta/oauth-start', {method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify({provider: provider})})
+  var payload = {provider: provider};
+  if (_cloudModalIntent !== 'signin') payload.mode = 'managed';
+  fetch('/api/cloud-cta/oauth-start', {method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify(payload)})
     .then(function(r){ return r.json(); })
     .then(function(d){
       if (d.ok && d.url) {
@@ -484,7 +495,7 @@ function _cmProfileRender(st) {
       + '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="11" width="18" height="11" rx="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>'
       + t('profile.e2e_key', null, 'Cloud sync key') + '</button>';
   } else {
-    h += '<button class="cm-profile-item" onclick="cmProfileClose();if(typeof openCloudModal===\'function\')openCloudModal()">'
+    h += '<button class="cm-profile-item" onclick="cmProfileClose();if(typeof openCloudModal===\'function\')openCloudModal(\'signin\')">'
       + '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 3h4a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-4"/><polyline points="10 17 15 12 10 7"/><line x1="15" y1="12" x2="3" y2="12"/></svg>'
       + t('profile.sign_in', null, 'Sign in / Create account') + '</button>';
   }

--- a/dashboard.py
+++ b/dashboard.py
@@ -17843,6 +17843,35 @@ def _account_email_for_token(token):
     return email
 
 
+def _selfhost_intent():
+    """True when this install's recorded intent is self-host (local-only).
+
+    Two signals, either wins: the nocloud marker (the daemon-facing egress
+    switch), or a recorded selfhost_* choice in ~/.clawmetry/onboarding.json
+    (survives even if some flow clears the marker). Used to pick the
+    default rail for sign-in flows that did not explicitly choose one:
+    founder report 2026-08-09 — a self-host install that signed back in
+    via the profile menu rode the managed rail, which called
+    enable_cloud() and silently started pushing snapshots. Identity and
+    egress are separate choices; sign-in alone must never flip egress on.
+    Never raises.
+    """
+    try:
+        from clawmetry.config import is_cloud_disabled
+
+        if is_cloud_disabled():
+            return True
+    except Exception:
+        pass
+    try:
+        from routes.onboarding import _read_choice_file
+
+        choice = str(_read_choice_file().get("choice", "")).strip().lower()
+        return choice.startswith("selfhost")
+    except Exception:
+        return False
+
+
 # ── One-click cloud connect via GitHub/Google OAuth (dashboard CTA) ────────────
 # The local "Enable Cloud Sync" modal can sign the user up AND connect this node
 # in one click. We reuse the same loopback browser-bridge as `clawmetry connect`:

--- a/routes/overview.py
+++ b/routes/overview.py
@@ -1823,10 +1823,19 @@ def cloud_cta_oauth_start():
 
     Starts a loopback browser-bridge and returns the cloud OAuth start URL for
     the dashboard to open in a new tab. The cm_ key the cloud mints rides back
-    over 127.0.0.1 only. mode="managed" (default) then registers this node and
+    over 127.0.0.1 only. mode="managed" then registers this node and
     starts the sync daemon; mode="selfhost" keeps data local (nocloud marker)
     and activates the account's 7-day trial license instead. The dashboard
     polls /api/cloud-cta/oauth-status.
+
+    When the caller omits ``mode``, the default follows the install's
+    recorded intent (``_selfhost_intent``): a self-host install signing back
+    in (profile menu "Sign in") stays on the identity-only selfhost rail;
+    anything else defaults to managed. Explicit modes always win — the
+    "Enable Cloud Sync" CTA sends mode="managed" because clicking it IS the
+    egress opt-in. Founder report 2026-08-09: sign-in from the profile menu
+    rode the managed rail on a self-host machine, and enable_cloud()
+    silently started pushing snapshots.
     """
     import dashboard as _d
 
@@ -1834,7 +1843,12 @@ def cloud_cta_oauth_start():
     provider = (data.get("provider") or "").strip().lower()
     if provider not in ("github", "google"):
         return jsonify({"ok": False, "error": "Unsupported provider"}), 400
-    mode = (data.get("mode") or "managed").strip().lower()
+    mode = (data.get("mode") or "").strip().lower()
+    if not mode:
+        try:
+            mode = "selfhost" if _d._selfhost_intent() else "managed"
+        except Exception:
+            mode = "managed"
     if mode not in ("managed", "selfhost"):
         return jsonify({"ok": False, "error": "Unsupported mode"}), 400
     url = _d._start_oauth_bridge(provider, mode=mode)

--- a/tests/test_cloud_cta_oauth.py
+++ b/tests/test_cloud_cta_oauth.py
@@ -78,7 +78,10 @@ def test_oauth_start_passes_mode_to_bridge(cta_app, monkeypatch):
                json={"provider": "github", "mode": "selfhost"})
     assert r.status_code == 200, r.data
     assert seen == {"provider": "github", "mode": "selfhost"}
-    # Callers that omit mode (the existing cloud modal) stay managed.
+    # Callers that omit mode follow the install's recorded intent (see
+    # test_oauth_start_omitted_mode_respects_selfhost_intent); with no
+    # self-host intent on record they stay managed.
+    monkeypatch.setattr(_d, "_selfhost_intent", lambda: False)
     c.post("/api/cloud-cta/oauth-start", json={"provider": "google"})
     assert seen["mode"] == "managed"
 
@@ -380,3 +383,61 @@ def test_cloud_cta_status_signed_out_has_no_email(cta_app, monkeypatch):
     body = cta_app.test_client().get("/api/cloud-cta/status").get_json()
     assert body["account_linked"] is False
     assert body["account_email"] == ""
+
+
+# ── Intent-resolved OAuth rail (sign-in must never flip egress on) ─────────────
+# Founder report 2026-08-09: a self-host install signing back in via the
+# profile menu rode the managed rail; _full_connect_with_key -> enable_cloud()
+# deleted the nocloud marker and the node silently started pushing snapshots.
+
+
+def test_oauth_start_omitted_mode_respects_selfhost_intent(cta_app, monkeypatch):
+    import dashboard as _d
+
+    seen = {}
+
+    def _fake(provider, mode="managed"):
+        seen["mode"] = mode
+        return "https://app.clawmetry.com/api/oauth/%s/start?cli_port=1" % provider
+
+    monkeypatch.setattr(_d, "_start_oauth_bridge", _fake)
+    monkeypatch.setattr(_d, "_selfhost_intent", lambda: True)
+    c = cta_app.test_client()
+    r = c.post("/api/cloud-cta/oauth-start", json={"provider": "github"})
+    assert r.status_code == 200, r.data
+    assert seen["mode"] == "selfhost"
+
+    # No self-host intent on record: omitted mode stays managed.
+    monkeypatch.setattr(_d, "_selfhost_intent", lambda: False)
+    c.post("/api/cloud-cta/oauth-start", json={"provider": "github"})
+    assert seen["mode"] == "managed"
+
+    # Explicit managed is a deliberate egress opt-in and always wins.
+    monkeypatch.setattr(_d, "_selfhost_intent", lambda: True)
+    c.post("/api/cloud-cta/oauth-start",
+           json={"provider": "github", "mode": "managed"})
+    assert seen["mode"] == "managed"
+
+
+def test_selfhost_intent_signals(monkeypatch, tmp_path):
+    import dashboard as _d
+    from clawmetry import config as _cfg
+    import routes.onboarding as _ob
+
+    # Marker present -> self-host, regardless of the choice file.
+    monkeypatch.setattr(_cfg, "is_cloud_disabled", lambda: True)
+    monkeypatch.setattr(_ob, "_read_choice_file", lambda: {})
+    assert _d._selfhost_intent() is True
+
+    # Marker gone but a recorded selfhost_* choice survives -> self-host.
+    monkeypatch.setattr(_cfg, "is_cloud_disabled", lambda: False)
+    monkeypatch.setattr(_ob, "_read_choice_file",
+                        lambda: {"choice": "selfhost_trial"})
+    assert _d._selfhost_intent() is True
+
+    # Managed choice / nothing on record -> managed.
+    monkeypatch.setattr(_ob, "_read_choice_file",
+                        lambda: {"choice": "managed"})
+    assert _d._selfhost_intent() is False
+    monkeypatch.setattr(_ob, "_read_choice_file", lambda: {})
+    assert _d._selfhost_intent() is False

--- a/tests/test_profile_menu.py
+++ b/tests/test_profile_menu.py
@@ -72,7 +72,7 @@ def test_gw_setup_module_wiring():
         "/api/license/status",
         "/api/cloud-cta/status",
         "clawmetryLogout()",
-        "openCloudModal()",
+        "openCloudModal(\\'signin\\')",
         "app.clawmetry.com/settings",
     ):
         assert needle in js, f"gw-setup.js missing: {needle}"
@@ -157,3 +157,20 @@ def test_profile_resolves_identity_for_cloud_oauth_accounts():
     # branch's fallback label.
     render = js.split("function _cmProfileRender", 1)[1]
     assert render.index("profile.signed_in") < render.index("profile.not_signed_in")
+
+
+def test_profile_signin_never_flips_egress_on_selfhost():
+    """The profile menu's sign-in must ride the intent-resolved rail, not
+    hardwired managed: on a self-host install, signing back in silently
+    called enable_cloud() and started pushing snapshots (founder report
+    2026-08-09). The profile entry passes the 'signin' intent, and
+    cloudOauth() then omits mode so the backend resolves it from
+    _selfhost_intent(); every other modal entry stays an explicit managed
+    egress opt-in."""
+    js = (STATIC / "js" / "gw-setup.js").read_text()
+    assert "openCloudModal(\\'signin\\')" in js
+    assert "_cloudModalIntent" in js
+    # cloudOauth sends an explicit managed mode ONLY for non-signin intents.
+    fn = js.split("function cloudOauth", 1)[1].split("function ", 1)[0]
+    assert "payload.mode = 'managed'" in fn
+    assert "_cloudModalIntent !== 'signin'" in fn


### PR DESCRIPTION
## Problem

Founder report 2026-08-09, on a self-host machine (nocloud marker, egress off by choice): the profile menu said "Not signed in" (the identity bug fixed in #4680), so the user signed back in via the menu's "Sign in / Create account". That entry opens the cloud-CTA modal, whose OAuth start defaulted to `mode=managed`; `_full_connect_with_key` then called `enable_cloud()`, deleting the nocloud marker, and the node silently started pushing snapshots. The header flipped to a green "Cloud Connected" on a machine whose whole promise was local-only.

The onboarding gate's own contract (see `routes/onboarding.py`, `_cloud_connected` docstring) is that identity and egress are separate choices; signing in must never enable egress as a side effect.

## Fix

- `dashboard.py`: `_selfhost_intent()`: true when the nocloud marker is present or `~/.clawmetry/onboarding.json` records a `selfhost_*` choice (the choice survives even if some flow clears the marker).
- `routes/overview.py`: `/api/cloud-cta/oauth-start` with `mode` omitted resolves the rail from install intent: self-host intent rides the identity-only selfhost rail (`_selfhost_signin_with_key`: marker written before the key is persisted, trial rail, no egress). Explicit modes always win.
- `gw-setup.js`: `openCloudModal(intent)`. The profile menu's sign-in passes `'signin'` (omits mode, backend resolves). The "Enable Cloud Sync" CTA, onboarding cloud card, e2e-key modal, and alert sign-up CTAs keep sending an explicit `mode: 'managed'`, because clicking those IS the egress opt-in.
- Tests: intent resolution matrix (omitted mode with and without intent, explicit managed override), `_selfhost_intent` signal tests, JS wiring pins; the existing omitted-mode bridge test now pins the intent-resolved behavior.

## Verification

- `tests/test_profile_menu.py`, `tests/test_cloud_cta_oauth.py`, `tests/test_onboarding_gate.py`: 59 passed.
- Adjacent suites (`test_cloud_toggles.py`, `test_oauth_detection.py`, `test_oauth_headless.py`, `test_placeholder_account_warning.py`, `test_first_heartbeat_onboarding.py`) show the same 4 pre-existing failures with and without this change (verified by stash A/B run on the same machine).
- Live remediation on the reporting machine: egress stopped via `POST /api/sync/toggle` (`local_only: true` confirmed by `/api/cloud-cta/status`); the account stays signed in with the amber Local-only badge.

?? Generated with [Claude Code](https://claude.com/claude-code)