### PR TITLE
fix(desktop): Self-host choice actually keeps data local (connect --keep-local)

### DIFF
--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -902,10 +902,26 @@ def _cmd_connect(args) -> None:
     # `--force` flag lets the user override after explicit confirmation.
     from clawmetry.config import is_cloud_disabled, NOCLOUD_MARKER_PATH
     # Sign in while KEEPING the nocloud marker: account + trial license yes,
-    # data egress no. Set by the Case-B "keep local-only" answer below, or
+    # data egress no. Set by the Case-B "keep local-only" answer below, by
+    # the `--keep-local` flag (the desktop app's Self-host choice), or
     # passed in directly by onboard's Self-Hosted trial path (args.keep_local),
     # which has already asked its own questions and must not be re-prompted.
     _keep_local_signin = bool(getattr(args, "keep_local", False))
+    if _keep_local_signin:
+        # A fresh self-host machine has NO marker yet (the interactive
+        # Case-B path below only runs when one already exists). Write it
+        # BEFORE any config/daemon work: the daemon must never observe a
+        # cm_ key without the marker, or it starts pushing (founder
+        # live-hit 2026-08-09 — the desktop Self-host choice passed only
+        # --defer-sync, no marker was ever written, and the node synced
+        # to cloud against an explicit local-only choice).
+        try:
+            from pathlib import Path as _P
+
+            _P(NOCLOUD_MARKER_PATH).parent.mkdir(parents=True, exist_ok=True)
+            _P(NOCLOUD_MARKER_PATH).touch(exist_ok=True)
+        except Exception:
+            pass
     if is_cloud_disabled() and not getattr(args, "force", False) and not _keep_local_signin:
         # Two cases here:
         #
@@ -1064,6 +1080,12 @@ def _cmd_connect(args) -> None:
             pass  # Already verified — reconnecting with same key
         elif getattr(args, "start_sync_now", False):
             pass  # Key from the authenticated dashboard command — already proven
+        elif getattr(args, "keep_local", False):
+            # Key captured by the desktop shell's own OAuth loopback on this
+            # machine — same already-authenticated provenance as the
+            # dashboard command above. Also runs headless (captured
+            # subprocess), where an OTP prompt would hang the onboarding.
+            pass
         else:
             from clawmetry.endpoints import is_custom_endpoint as _is_custom_ep
             if _is_custom_ep():
@@ -1252,13 +1274,19 @@ def _cmd_connect(args) -> None:
             _P(NOCLOUD_MARKER_PATH).touch()
         except Exception:
             pass
-        _dash_up = _ensure_local_dashboard()
         print()
         print("  Local-only kept: your data stays on this machine.")
-        if _dash_up:
-            print("  Dashboard: http://localhost:8900 (live now)")
+        if getattr(args, "key", None):
+            # Automated invocation (desktop shell / scripts pass --key): the
+            # caller owns its own dashboard lifecycle — spawning one on
+            # :8900 here would leave a stray duplicate next to the shell's.
+            pass
         else:
-            print("  Dashboard did not come up at http://localhost:8900. Start it: clawmetry")
+            _dash_up = _ensure_local_dashboard()
+            if _dash_up:
+                print("  Dashboard: http://localhost:8900 (live now)")
+            else:
+                print("  Dashboard did not come up at http://localhost:8900. Start it: clawmetry")
 
     print()
 
@@ -6469,6 +6497,14 @@ def main() -> None:
         action="store_true",
         dest="defer_sync",
         help="Connect but leave sync paused; start it later with `clawmetry sync`",
+    )
+    p_connect.add_argument(
+        "--keep-local",
+        action="store_true",
+        dest="keep_local",
+        help="Sign in WITHOUT enabling cloud sync: links the account (and its "
+        "trial license) but writes the local-only marker first, so data "
+        "never leaves this machine (the desktop app's Self-host choice)",
     )
     p_connect.add_argument(
         "--foreground", action="store_true", help="Run daemon in foreground"

--- a/desktop/onboarding.py
+++ b/desktop/onboarding.py
@@ -189,9 +189,14 @@ def apply_cm_key(
     ``mode`` is the user's hosting choice from the onboarding pane:
       * "cloud"    → ``--start-sync-now``: cloud sync ON (E2E-encrypted
                      snapshots to ingest.clawmetry.com).
-      * "selfhost" → ``--defer-sync`` + ``clawmetry sync``: account
-                     linked, trial provisioned, but data stays on this
-                     machine; the sync daemon runs local-only ingest.
+      * "selfhost" → ``--keep-local --defer-sync`` + ``clawmetry sync``:
+                     account linked, trial provisioned, and the local-only
+                     marker written BEFORE the key lands, so the daemon can
+                     never observe a cm_ key without it. ``--defer-sync``
+                     alone did NOT do this (founder live-hit 2026-08-09:
+                     it only skips the daemon start; connect still ran the
+                     cloud rail, and the "self-host" node pushed snapshots).
+                     The sync daemon then runs local-only ingest.
 
     We avoid duplicating any of that in the shell. Returns
     (ok, short_message). The message is user-safe (no key/token
@@ -201,10 +206,13 @@ def apply_cm_key(
         return False, "runtime venv is not ready yet"
     if not (cm_key or "").startswith("cm_"):
         return False, "invalid sign-in key"
-    mode_flag = "--defer-sync" if mode == "selfhost" else "--start-sync-now"
+    mode_flags = (
+        ["--keep-local", "--defer-sync"] if mode == "selfhost"
+        else ["--start-sync-now"]
+    )
     try:
         r = subprocess.run(
-            [str(bin_), "connect", "--key", cm_key, mode_flag],
+            [str(bin_), "connect", "--key", cm_key, *mode_flags],
             capture_output=True, text=True, timeout=timeout,
             **_win_subprocess_kwargs(),
         )

--- a/tests/test_connect_keep_local.py
+++ b/tests/test_connect_keep_local.py
@@ -1,0 +1,116 @@
+"""Regression tests for `clawmetry connect --keep-local` (desktop Self-host).
+
+Bug pinned here (founder live-hit 2026-08-09): the desktop onboarding's
+Self-host choice ran `connect --key cm_… --defer-sync`. But --defer-sync only
+skips the daemon start — cmd_connect still rode the full cloud rail
+(enable_cloud(), family-mark reset) and never wrote the nocloud marker, and
+the shell then started `clawmetry sync` itself. Net effect: a machine whose
+user explicitly chose "data stays local" pushed snapshots to cloud.
+
+`--keep-local` is the contract the desktop now uses:
+  * writes the local-only marker BEFORE any config/daemon work (the daemon
+    must never observe a cm_ key without it)
+  * never calls enable_cloud()
+  * skips the ownership OTP (the key comes from the shell's own OAuth
+    loopback — same authenticated provenance as --start-sync-now — and the
+    subprocess runs headless, where a prompt would hang onboarding)
+  * skips the :8900 dashboard spawn on automated (--key) invocations
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import pytest
+
+import clawmetry.cli as cli
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _connect_args(**overrides):
+    base = dict(
+        key="cm_test1234567890",
+        enc_key="test-enc-key",
+        key_only=False,
+        no_daemon=True,
+        start_sync_now=False,
+        defer_sync=True,
+        keep_local=False,
+        force=False,
+        custom_node_id="test-node",
+        foreground=False,
+    )
+    base.update(overrides)
+    return argparse.Namespace(**base)
+
+
+@pytest.fixture
+def keep_local_env(monkeypatch, tmp_path):
+    """Neuter network/daemon/disk; record marker + cloud-rail calls."""
+    import clawmetry.config as config
+    import clawmetry.license as license_mod
+    import clawmetry.sync as sync
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("CLAWMETRY_API_KEY", raising=False)
+    monkeypatch.delenv("CM_KEY", raising=False)
+
+    marker = tmp_path / ".clawmetry" / "nocloud"
+    monkeypatch.setattr(config, "NOCLOUD_MARKER_PATH", str(marker))
+    monkeypatch.setattr(config, "is_cloud_disabled", lambda: marker.exists())
+
+    enable_calls = []
+    monkeypatch.setattr(
+        config, "enable_cloud", lambda: enable_calls.append(1) or False
+    )
+    monkeypatch.setattr(cli, "_stop_existing_daemon", lambda: None)
+    monkeypatch.setattr(
+        sync, "validate_key", lambda *a, **k: {"node_id": "test-node"}
+    )
+    monkeypatch.setattr(sync, "save_config", lambda cfg: None)
+    monkeypatch.setattr(sync, "_derive_key_for_storage", lambda k: k)
+    monkeypatch.setattr(
+        license_mod, "auto_provision_pro", lambda *a, **k: (False, "")
+    )
+    otp_calls = []
+    monkeypatch.setattr(
+        cli, "_verify_key_ownership", lambda key: otp_calls.append(key)
+    )
+    dash_calls = []
+    monkeypatch.setattr(
+        cli, "_ensure_local_dashboard",
+        lambda *a, **k: dash_calls.append(1) or True,
+    )
+    return marker, enable_calls, otp_calls, dash_calls
+
+
+def test_keep_local_writes_marker_and_skips_cloud_rail(keep_local_env):
+    marker, enable_calls, otp_calls, dash_calls = keep_local_env
+    cli._cmd_connect(_connect_args(keep_local=True))
+    assert marker.exists(), "keep-local must write the nocloud marker"
+    assert enable_calls == [], "keep-local must never call enable_cloud()"
+    assert otp_calls == [], "OAuth-loopback key needs no second OTP"
+    assert dash_calls == [], \
+        "automated (--key) keep-local must not spawn a :8900 dashboard"
+
+
+def test_plain_cloud_connect_still_rides_cloud_rail(keep_local_env):
+    marker, enable_calls, otp_calls, dash_calls = keep_local_env
+    cli._cmd_connect(_connect_args(start_sync_now=True))
+    assert not marker.exists(), "cloud connect must not write the marker"
+    assert enable_calls == [1], "cloud connect clears the local-only marker"
+
+
+def test_connect_parser_and_desktop_wiring():
+    """The flag must exist on the connect subparser and the desktop
+    Self-host path must pass it (with --defer-sync; the shell starts
+    local-only ingest itself)."""
+    cli_src = (REPO_ROOT / "clawmetry" / "cli.py").read_text(encoding="utf-8")
+    assert '"--keep-local"' in cli_src
+    desk_src = (REPO_ROOT / "desktop" / "onboarding.py").read_text(
+        encoding="utf-8"
+    )
+    assert '"--keep-local", "--defer-sync"' in desk_src
+    assert '"--defer-sync" if mode == "selfhost"' not in desk_src


### PR DESCRIPTION
## Scope after #4694

A parallel PR (#4694) merged first and carries most of this fix (the `--keep-local` flag, OTP skip for non-interactive self-host connects, marker preservation, trial provisioning, and the dashboard-spawn guard). Conflicts are resolved by taking main's implementation; what remains here on top of it:

- **Up-front marker write** (`clawmetry/cli.py`): on a `--keep-local` sign-in the nocloud marker is written BEFORE any config or daemon work. A fresh self-host machine has no marker yet, and main's implementation only touches it at the end of the flow, leaving a window where a respawning daemon could observe a `cm_` key without the marker and start pushing.
- **`tests/test_connect_keep_local.py`**: end-to-end regression coverage of the keep-local rail through `_cmd_connect` itself: marker written, `enable_cloud()` never called, OTP skipped, no :8900 dashboard spawn on automated invocations; plus the inverse (plain cloud connect still rides the cloud rail) and parser/desktop wiring pins. Complements the OTP-gate unit tests #4694 added.

## Verification

11 tests green across `test_connect_keep_local.py`, `test_connect_otp_skip.py` (incl. #4694's additions), `test_connect_provisioning_order.py`.

?? Generated with [Claude Code](https://claude.com/claude-code)