### PR TITLE
fix(desktop): self-host sign-in provisions the 7-day trial (connect --keep-local)

### DIFF
--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -1062,8 +1062,20 @@ def _cmd_connect(args) -> None:
     if getattr(args, "key", None):
         if _saved_api_key and api_key == _saved_api_key:
             pass  # Already verified — reconnecting with same key
-        elif getattr(args, "start_sync_now", False):
-            pass  # Key from the authenticated dashboard command — already proven
+        elif (
+            getattr(args, "start_sync_now", False)
+            or getattr(args, "defer_sync", False)
+            or getattr(args, "keep_local", False)
+        ):
+            # Key from the authenticated dashboard command (--start-sync-now)
+            # or the desktop onboarding's self-host path (--defer-sync). Both
+            # flags only exist on machine-generated invocations whose key was
+            # just minted in an OAuth/OTP-verified session. --defer-sync runs
+            # non-interactively (no stdin), so an OTP prompt here doesn't just
+            # add friction, it kills the sign-in: _verify_key_ownership exits 1
+            # without a tty, the trial never provisions, and a self-host user
+            # is left on the OSS tier with every runtime locked.
+            pass
         else:
             from clawmetry.endpoints import is_custom_endpoint as _is_custom_ep
             if _is_custom_ep():
@@ -1252,13 +1264,17 @@ def _cmd_connect(args) -> None:
             _P(NOCLOUD_MARKER_PATH).touch()
         except Exception:
             pass
-        _dash_up = _ensure_local_dashboard()
         print()
         print("  Local-only kept: your data stays on this machine.")
-        if _dash_up:
-            print("  Dashboard: http://localhost:8900 (live now)")
-        else:
-            print("  Dashboard did not come up at http://localhost:8900. Start it: clawmetry")
+        # --defer-sync means a supervisor (the desktop app) manages the
+        # daemon and dashboard itself — spawning a second dashboard here
+        # would race it for the DuckDB writer lock.
+        if not getattr(args, "defer_sync", False):
+            _dash_up = _ensure_local_dashboard()
+            if _dash_up:
+                print("  Dashboard: http://localhost:8900 (live now)")
+            else:
+                print("  Dashboard did not come up at http://localhost:8900. Start it: clawmetry")
 
     print()
 
@@ -1307,11 +1323,12 @@ def _cmd_connect(args) -> None:
         print()
         print("  All done! Your dashboard: http://localhost:8900")
         print()
-        try:
-            import webbrowser
-            webbrowser.open("http://localhost:8900")
-        except Exception:
-            pass
+        if not getattr(args, "defer_sync", False):
+            try:
+                import webbrowser
+                webbrowser.open("http://localhost:8900")
+            except Exception:
+                pass
         return
 
     # Open browser with encryption key in URL fragment (never sent to server)
@@ -6483,6 +6500,14 @@ def main() -> None:
         "--force",
         action="store_true",
         help="Override the persistent local-only marker (#1937) and connect anyway",
+    )
+    p_connect.add_argument(
+        "--keep-local",
+        action="store_true",
+        dest="keep_local",
+        help="Sign in for the account + trial license but keep this install "
+        "local-only: the nocloud marker stays, no snapshots ever leave "
+        "this machine (the desktop app's Self-Hosted choice uses this)",
     )
 
     # setup — alias for onboard (new user-facing name)

--- a/desktop/onboarding.py
+++ b/desktop/onboarding.py
@@ -189,9 +189,10 @@ def apply_cm_key(
     ``mode`` is the user's hosting choice from the onboarding pane:
       * "cloud"    → ``--start-sync-now``: cloud sync ON (E2E-encrypted
                      snapshots to ingest.clawmetry.com).
-      * "selfhost" → ``--defer-sync`` + ``clawmetry sync``: account
-                     linked, trial provisioned, but data stays on this
-                     machine; the sync daemon runs local-only ingest.
+      * "selfhost" → ``--keep-local --defer-sync`` + ``clawmetry sync``:
+                     account linked, trial provisioned, nocloud marker
+                     kept, data stays on this machine; the sync daemon
+                     runs local-only ingest.
 
     We avoid duplicating any of that in the shell. Returns
     (ok, short_message). The message is user-safe (no key/token
@@ -201,10 +202,18 @@ def apply_cm_key(
         return False, "runtime venv is not ready yet"
     if not (cm_key or "").startswith("cm_"):
         return False, "invalid sign-in key"
-    mode_flag = "--defer-sync" if mode == "selfhost" else "--start-sync-now"
+    # selfhost: --keep-local preserves the nocloud marker (sign-in must not
+    # flip a self-host install to cloud sync), skips the ownership OTP that
+    # would otherwise kill this non-interactive subprocess, and still mints
+    # the account's 7-day trial; --defer-sync leaves daemon/dashboard
+    # management to this shell.
+    mode_flags = (
+        ["--keep-local", "--defer-sync"] if mode == "selfhost"
+        else ["--start-sync-now"]
+    )
     try:
         r = subprocess.run(
-            [str(bin_), "connect", "--key", cm_key, mode_flag],
+            [str(bin_), "connect", "--key", cm_key, *mode_flags],
             capture_output=True, text=True, timeout=timeout,
             **_win_subprocess_kwargs(),
         )

--- a/tests/test_connect_otp_skip.py
+++ b/tests/test_connect_otp_skip.py
@@ -64,6 +64,43 @@ def test_start_sync_now_skips_ownership_otp(connect_env):
     assert connect_env == []
 
 
+def test_defer_sync_skips_ownership_otp(connect_env):
+    """The desktop onboarding's self-host path runs
+    `connect --key cm_… --defer-sync` non-interactively (no stdin). The key
+    was just minted by the pane's own OAuth/OTP flow, so a second OTP is not
+    only friction — without a tty _verify_key_ownership exits 1, the trial
+    never provisions, and the self-host user lands on OSS with every runtime
+    locked (2026-08-09 lab-machine regression)."""
+    cli._cmd_connect(_connect_args(defer_sync=True))
+    assert connect_env == []
+
+
+def test_keep_local_skips_otp_and_never_reenables_cloud(
+    connect_env, monkeypatch, tmp_path
+):
+    """`connect --key cm_… --keep-local --defer-sync` is the desktop app's
+    Self-Hosted onboarding command. It must (a) skip the ownership OTP
+    (non-interactive subprocess), (b) leave the nocloud marker in place, and
+    (c) never call enable_cloud — signing in must not switch a self-host
+    install to cloud sync."""
+    import clawmetry.config as config
+
+    marker = tmp_path / "nocloud"
+    marker.write_text("")
+    monkeypatch.setattr(config, "NOCLOUD_MARKER_PATH", str(marker))
+    enable_calls = []
+    monkeypatch.setattr(
+        config, "enable_cloud", lambda: enable_calls.append(True)
+    )
+    monkeypatch.setattr(cli, "_activate_signup_trial", lambda: False)
+
+    cli._cmd_connect(_connect_args(keep_local=True, defer_sync=True))
+
+    assert connect_env == []
+    assert marker.exists()
+    assert enable_calls == []
+
+
 def test_plain_key_connect_still_asks_otp(connect_env):
     cli._cmd_connect(_connect_args(start_sync_now=False))
     assert connect_env == ["cm_test1234567890"]


### PR DESCRIPTION
## Why
Live regression on the Windows desktop app (v0.12.673): a user who signs in with GitHub and picks **Self-host** during onboarding gets NO trial: `onboarding-completed.json` ends `{signed_in: false}`, no `~/.clawmetry/config.json` is written, `/api/entitlement` stays `tier: oss`, and every runtime except OpenClaw/NemoClaw shows locked despite the promised 7-day all-runtimes trial.

## Root causes (three, compounding)
1. `_cmd_connect`'s ownership-OTP gate exempts `--start-sync-now` (cloud path) but not the desktop self-host path (`--defer-sync`). `_verify_key_ownership` does `sys.exit(1)` when there is no tty, and the desktop runs connect as a non-interactive subprocess, so the sign-in dies before writing anything.
2. Even past OTP, a plain connect removes the `nocloud` marker (`enable_cloud()`) and queues a full cloud backfill, i.e. signing in flips a self-host install to cloud sync - the exact regression d65218eeb was guarding against.
3. The correct keep-local seam (marker kept, no data egress, trial minted via the license rail which is deliberately not marker-gated) existed only as an internal argparse Namespace inside the interactive `onboard` wizard - unreachable from a subprocess.

## What
- New `clawmetry connect --keep-local` flag exposing the keep-local sign-in path.
- OTP exemption extended to machine-generated invocations (`--defer-sync`, `--keep-local`); rationale unchanged from the existing `--start-sync-now` exemption (the cm_ key is a bearer credential; client-side OTP never stopped a key holder).
- Keep-local + `--defer-sync` skips `_ensure_local_dashboard()` and the browser open: the desktop supervisor owns the daemon, and a second dashboard would race it for the DuckDB writer lock.
- `desktop/onboarding.py` self-host mode now passes `--keep-local --defer-sync`.

## Verification
- `tests/test_connect_otp_skip.py::test_defer_sync_skips_ownership_otp` proved RED on unfixed code (stash -> fail -> pop -> pass).
- `test_keep_local_skips_otp_and_never_reenables_cloud`: marker preserved, `enable_cloud` never called, no OTP.
- Live replay on the affected lab machine: `connect --key ... --keep-local --defer-sync` non-interactively passes the OTP gate, keeps the marker, writes config, and hands provisioning to the license rail (previous behavior: hard exit at the OTP tty check).
- Full file compile + the 8 connect tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)