### PR TITLE
fix(release): keep GitHub Release draft until all desktop installers attach

### DIFF
--- a/.github/workflows/desktop-artifacts.yml
+++ b/.github/workflows/desktop-artifacts.yml
@@ -380,13 +380,23 @@ jobs:
       - name: List artifacts
         run: find artifacts -type f
 
-      - name: Attach to release
+      # release-on-merge.yml creates the Release as a DRAFT so GitHub's
+      # /releases/latest (which every clawmetry.com download button
+      # resolves through) keeps pointing at the previous COMPLETE release
+      # while these installers build. This step attaches all assets and
+      # then publishes in one go (draft: false + make_latest).
+      # fail_on_unmatched_files is deliberately true: a missing installer
+      # must keep the release draft rather than publish a "latest" whose
+      # download links 404 (seen live on v0.12.674, 2026-08-10).
+      - name: Attach to release and publish
         uses: softprops/action-gh-release@v2
         with:
+          draft: false
+          make_latest: "true"
           files: |
             artifacts/clawmetry-macos/*.dmg
             artifacts/clawmetry-windows/*.zip
             artifacts/clawmetry-windows/*.exe
             artifacts/clawmetry-linux/*.tar.gz
             artifacts/clawmetry-linux/*.AppImage
-          fail_on_unmatched_files: false
+          fail_on_unmatched_files: true

--- a/.github/workflows/release-on-merge.yml
+++ b/.github/workflows/release-on-merge.yml
@@ -380,13 +380,26 @@ jobs:
           echo "✅ PyPI install of $NEW works end-to-end"
 
       - name: Create GitHub release tag
+        # The release is created as a DRAFT and only published by
+        # desktop-artifacts.yml AFTER all installers are attached. A
+        # published-but-assetless release immediately becomes GitHub's
+        # "latest", so every clawmetry.com download button
+        # (/releases/latest/download/<fixed-name>) 404s for the minutes
+        # the desktop build takes — seen live on v0.12.674 (2026-08-10).
+        # Drafts are invisible to /releases/latest, so downloads keep
+        # serving the previous complete release until the new one is
+        # whole. Draft releases do NOT create the git tag, so push it
+        # explicitly first — the workflow dispatch below needs the ref.
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release create "v${{ steps.bump.outputs.new }}" \
-            --title "v${{ steps.bump.outputs.new }}" \
+          NEW_TAG="v${{ steps.bump.outputs.new }}"
+          git tag "$NEW_TAG" || echo "Tag already exists locally"
+          git push origin "refs/tags/$NEW_TAG" || echo "Tag already on origin, skipping"
+          gh release create "$NEW_TAG" \
+            --title "$NEW_TAG" \
             --notes "Released via PR: ${{ github.event.pull_request.title }}" \
-            --latest || echo "Release tag already exists, skipping"
+            --draft || echo "Release already exists, skipping"
 
       # GitHub deliberately suppresses `on: push: tags:` cascade triggers
       # for anything created with the default GITHUB_TOKEN (see


### PR DESCRIPTION
## Problem
Clicking any desktop-app download button on clawmetry.com 404'd right after v0.12.674 was cut (screenshot from Vivek). The buttons resolve through GitHub's `/releases/latest/download/<fixed-name>`, and `release-on-merge.yml` publishes the release (`gh release create --latest`) **before** `desktop-artifacts.yml` has built and attached the installers. The moment the empty release publishes it becomes "latest", so every download link 404s for the whole build window (and indefinitely if an installer job fails, since `fail_on_unmatched_files: false` masked partial uploads).

## Fix
- **release-on-merge.yml** — push the tag explicitly (draft releases don't create tags, and the later `workflow_dispatch --ref` needs it), then create the release with `--draft` instead of `--latest`. Drafts are invisible to `/releases/latest`, so downloads keep serving the previous complete release.
- **desktop-artifacts.yml** — the attach step now also publishes (`draft: false`, `make_latest: "true"`) and sets `fail_on_unmatched_files: true`: all five asset patterns must match or the release stays draft — a missing installer can never publish a "latest" whose links 404.

## Failure mode if a desktop build breaks
PyPI/cloud are unaffected (they key off PyPI, not the GitHub release); the release just stays draft and download buttons keep serving the last complete release — strictly better than today's 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)