### PR TITLE
fix(update): prune stale dist-info left by partial in-place pip upgrades

### DIFF
--- a/clawmetry/distinfo_cleanup.py
+++ b/clawmetry/distinfo_cleanup.py
@@ -1,0 +1,113 @@
+"""clawmetry/distinfo_cleanup.py — prune stale dist-info left by partial upgrades.
+
+On Windows an in-place ``pip install --upgrade`` regularly runs while a
+sibling clawmetry process (dashboard child, proxy, a second daemon) still
+holds ``.pyd``/``.exe`` files from the old wheel open. pip's uninstall of
+the previous version then partially fails: the new wheel and its dist-info
+land fine, but the OLD ``clawmetry-<ver>.dist-info`` directory (and
+sometimes a ``~lawmetry*`` stash pip renamed mid-uninstall) stays behind.
+Observed live on the Windows lab machine 2026-08-10: five stale dist-infos
+(0.12.655–0.12.669) alongside the current one.
+
+Stale dist-infos are not cosmetic:
+
+* ``importlib.metadata.version("clawmetry")`` returns the FIRST matching
+  distribution in directory-listing order — on NTFS that is alphabetical,
+  so the OLDEST stale dist-info wins and every metadata-based version
+  probe lies.
+* pip itself resolves "installed version" from the same metadata, so its
+  upgrade/uninstall decisions run against the wrong RECORD.
+
+This module removes ``clawmetry-*.dist-info`` directories whose version is
+STRICTLY OLDER than the one actually installed (the running code's
+``dashboard.__version__``), plus ``~lawmetry*`` pip-uninstall corpses.
+Newer-than-current dist-infos are deliberately kept: right after an
+in-place upgrade the running process is still the old build while the new
+wheel's metadata is already on disk — deleting it would brick the fresh
+install. Callers run this at process boot and after a successful install,
+both windows in which no pip is active (updates hold the cross-process
+update lock). Never raises.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+
+log = logging.getLogger(__name__)
+
+_DIST_INFO_SUFFIX = ".dist-info"
+
+
+def _ver_tuple(v):
+    """``"0.12.660"`` -> ``(0, 12, 660)``; None when unparseable."""
+    try:
+        return tuple(int(x) for x in str(v).split("."))
+    except (TypeError, ValueError):
+        return None
+
+
+def cleanup_stale_dist_info(keep_version=None, site_packages=None,
+                            package="clawmetry"):
+    """Remove stale ``<package>-*.dist-info`` dirs and pip-uninstall corpses.
+
+    ``keep_version`` defaults to the running code's ``dashboard.__version__``
+    (the wheel actually installed); ``site_packages`` defaults to the
+    directory containing ``dashboard.py`` — in an installed wheel that IS
+    site-packages, and in a source checkout it contains no dist-info so the
+    call is a natural no-op. Returns the list of removed entry names.
+    """
+    removed = []
+    if keep_version is None:
+        try:
+            import dashboard as _d
+            keep_version = str(_d.__version__)
+        except Exception:
+            return removed
+    if site_packages is None:
+        try:
+            import dashboard as _d
+            site_packages = os.path.dirname(os.path.abspath(_d.__file__))
+        except Exception:
+            return removed
+    keep_t = _ver_tuple(keep_version)
+    if keep_t is None:
+        return removed
+
+    prefix = package + "-"
+    # pip stashes a pending uninstall by renaming the first character to
+    # "~" ("clawmetry-…" -> "~lawmetry-…"); a leftover one is a crashed or
+    # partially-failed pip run, never a live install.
+    corpse_prefix = "~" + package[1:]
+    try:
+        entries = os.listdir(site_packages)
+    except OSError:
+        return removed
+
+    for name in entries:
+        stale = False
+        if name.startswith(corpse_prefix):
+            stale = True
+        elif name.startswith(prefix) and name.endswith(_DIST_INFO_SUFFIX):
+            ver = name[len(prefix):-len(_DIST_INFO_SUFFIX)]
+            vt = _ver_tuple(ver)
+            stale = vt is not None and vt < keep_t
+        if not stale:
+            continue
+        path = os.path.join(site_packages, name)
+        try:
+            if os.path.isdir(path):
+                shutil.rmtree(path)
+            else:
+                os.remove(path)
+            removed.append(name)
+        except OSError as exc:
+            # Locked entries heal on a later boot; never block startup.
+            log.debug("stale dist-info %s not removable now: %s", name, exc)
+
+    if removed:
+        log.info("pruned %d stale %s metadata entr%s from %s: %s",
+                 len(removed), package, "y" if len(removed) == 1 else "ies",
+                 site_packages, ", ".join(sorted(removed)))
+    return removed

--- a/clawmetry/update_respawn.py
+++ b/clawmetry/update_respawn.py
@@ -27,6 +27,7 @@ Usage (spawned by routes/update_check.py, not humans):
 from __future__ import annotations
 
 import os
+import shutil
 import subprocess
 import sys
 import time
@@ -70,6 +71,48 @@ def _wait_for_pid_exit(pid: int, timeout_secs: float = 60.0) -> bool:
     return False
 
 
+def _prune_stale_dist_info(target: str, say) -> None:
+    """After a successful pip run, delete ``clawmetry-*.dist-info`` dirs
+    OLDER than ``target`` plus ``~lawmetry*`` pip-uninstall corpses.
+
+    pip's uninstall of the previous version half-fails whenever a sibling
+    clawmetry process still holds ``.pyd``/``.exe`` files open — the new
+    wheel lands but the old dist-info stays, and importlib.metadata (and
+    pip itself) then resolve the OLDEST dist-info present (alphabetical
+    listdir order; five stale dist-infos observed live 2026-08-10).
+    Duplicate of clawmetry.distinfo_cleanup by design: this module runs the
+    OLD wheel's copy and keeps zero imports from the rest of clawmetry.
+    Dist-info entries are plain metadata files, never held open, so removal
+    succeeds even while code files stay locked. Never raises."""
+    try:
+        keep = tuple(int(x) for x in target.split("."))
+    except (TypeError, ValueError):
+        return  # target "latest" / unparseable: the relaunched daemon's
+                # boot-time cleanup (routes/update_check.py) handles it
+    try:
+        import sysconfig
+        sp = sysconfig.get_paths()["purelib"]
+        for name in os.listdir(sp):
+            stale = name.startswith("~lawmetry")
+            if not stale and (name.startswith("clawmetry-")
+                              and name.endswith(".dist-info")):
+                ver = name[len("clawmetry-"):-len(".dist-info")]
+                try:
+                    stale = tuple(int(x) for x in ver.split(".")) < keep
+                except ValueError:
+                    stale = False
+            if not stale:
+                continue
+            path = os.path.join(sp, name)
+            try:
+                shutil.rmtree(path) if os.path.isdir(path) else os.remove(path)
+                say(f"[update-respawn] pruned stale metadata {name}")
+            except OSError as exc:
+                say(f"[update-respawn] could not prune {name}: {exc}")
+    except Exception as exc:
+        say(f"[update-respawn] stale-metadata prune skipped: {exc}")
+
+
 def main(argv=None) -> int:
     argv = list(sys.argv[1:] if argv is None else argv)
     if len(argv) < 4:
@@ -99,6 +142,14 @@ def main(argv=None) -> int:
     if not _wait_for_pid_exit(int(parent_pid), timeout_secs=90.0):
         _say("[update-respawn] parent did not exit in 90s; aborting (no relaunch, "
              "the still-running parent keeps serving)")
+        # Release the cross-process update lock the parent handed off to us:
+        # no pip ran, and without this the still-running parent's next check
+        # cycles all skip ("another process is updating") until the 900s
+        # staleness window breaks the lock — a silent 15-minute update stall.
+        try:
+            os.remove(os.path.expanduser("~/.clawmetry/update-in-progress.lock"))
+        except OSError:
+            pass
         return 1
 
     spec = f"clawmetry=={target}" if target and target != "latest" else "clawmetry"
@@ -121,6 +172,7 @@ def main(argv=None) -> int:
             )
             if proc.returncode == 0:
                 ok = True
+                _prune_stale_dist_info(target, _say)
                 break
             _say(f"[update-respawn] pip attempt {attempt} failed "
                  f"(exit {proc.returncode}); retrying in {wait}s")

--- a/desktop/app.py
+++ b/desktop/app.py
@@ -378,11 +378,26 @@ class RuntimeSupervisor:
         straight from the dist-info directory name — no interpreter
         spawn (the old subprocess probe cost ~1s per call, on the boot
         path and on every watcher tick). Falls back to the subprocess
-        probe only if no dist-info is found."""
+        probe only if no dist-info is found.
+
+        Multiple dist-infos can coexist: a pip upgrade that runs while
+        the daemon holds .pyd/.exe files open half-fails its uninstall
+        of the OLD version and leaves its dist-info behind (five stale
+        ones observed live, 2026-08-10). Pick the highest parsed
+        version, not the newest mtime — a partially-uninstalled stale
+        dir can carry a fresher mtime than the real install."""
         if platform.system() == "Windows":
             sp_globs = ["Lib/site-packages"]
         else:
             sp_globs = ["lib/python*/site-packages"]
+
+        def _ver_key(d: Path):
+            v = d.name[len("clawmetry-"):-len(".dist-info")]
+            try:
+                return tuple(int(x) for x in v.split("."))
+            except ValueError:
+                return (-1,)
+
         try:
             infos = [
                 d
@@ -391,7 +406,7 @@ class RuntimeSupervisor:
                 if d.is_dir()
             ]
             if infos:
-                newest = max(infos, key=lambda d: d.stat().st_mtime)
+                newest = max(infos, key=_ver_key)
                 return newest.name[len("clawmetry-"):-len(".dist-info")]
         except OSError:
             pass

--- a/routes/meta.py
+++ b/routes/meta.py
@@ -511,6 +511,18 @@ def perform_self_update(reason: str = "manual", restart: bool = True,
     except Exception:
         pass
 
+    # Prune stale dist-info dirs the upgrade may have left behind (pip's
+    # uninstall of the old version half-fails when a sibling process holds
+    # .pyd/.exe files open — the normal Windows case). Keep the version pip
+    # just installed: the OLD version's dist-info is the stale one here, and
+    # leftover stale metadata makes importlib.metadata (and pip's own
+    # installed-version resolution) report the oldest dist-info present.
+    try:
+        from clawmetry.distinfo_cleanup import cleanup_stale_dist_info
+        cleanup_stale_dist_info(keep_version=new_version)
+    except Exception:
+        pass
+
     # Arm the crash-loop rollback guard BEFORE any restart: if the new wheel
     # boot-loops, the daemon's next boots detect it and pip-roll back to
     # ``old_version`` (clawmetry/update_guard.py — firmware-OTA style).

--- a/routes/update_check.py
+++ b/routes/update_check.py
@@ -218,6 +218,15 @@ def _schedule_windows_respawn(delay_secs: float = 5.0) -> None:
         except Exception as exc:
             global _auto_update_in_progress
             _auto_update_in_progress = False
+            # The lock was riding the handoff for the HELPER to release; the
+            # helper never launched, so release it here or every check cycle
+            # silently skips ("another process is updating") until the 900s
+            # staleness window breaks it — a 15-minute invisible update
+            # stall (observed as a 12+ minute lag on the Windows lab box).
+            _release_update_lock()
+            _record_update_attempt(
+                _pending_update_target.get("version", "?"), "failed",
+                f"windows respawn handoff failed: {exc}")
             log.warning("auto-update: windows respawn failed (%s); new version "
                         "applies on next manual start", exc)
     t = threading.Timer(2.0, _respawn)
@@ -872,6 +881,21 @@ def _update_check_worker(stop_event):
     auto-update is off (CLAWMETRY_AUTO_UPDATE=0 or stored config), the
     dashboard keeps the gentle banner-only cadence.
     """
+    # Boot-time hygiene: prune stale clawmetry-*.dist-info dirs a partially
+    # failed in-place pip upgrade left behind (Windows: pip runs while a
+    # sibling process holds .pyd/.exe files open, so the OLD version's
+    # uninstall half-fails). Stale dist-infos make importlib.metadata — and
+    # pip itself — resolve the OLDEST version (alphabetical listdir order),
+    # which lies to every metadata probe (five stale dist-infos observed
+    # live on a Windows lab box, 2026-08-10). dist-info entries are plain
+    # metadata files, never held open, so this succeeds even while code
+    # files stay locked.
+    try:
+        from clawmetry.distinfo_cleanup import cleanup_stale_dist_info
+        cleanup_stale_dist_info()
+    except Exception as exc:
+        log.debug("stale dist-info cleanup failed: %s", exc)
+
     # Initial check on startup (after a boot-settle delay; interruptible).
     if stop_event.wait(60):
         return

--- a/tests/test_stale_distinfo_cleanup.py
+++ b/tests/test_stale_distinfo_cleanup.py
@@ -1,0 +1,162 @@
+"""Stale dist-info cleanup — regression guard for the Windows in-place
+upgrade leak (2026-08-10).
+
+Every in-place pip upgrade run while a sibling process held ``.pyd``/
+``.exe`` files open half-failed its uninstall of the previous version and
+left that version's ``clawmetry-*.dist-info`` behind (five stale ones,
+0.12.655–0.12.669, observed live alongside the current install). Because
+``importlib.metadata`` resolves the FIRST matching dist-info in
+directory-listing order (alphabetical on NTFS), the OLDEST stale version
+won every metadata probe, and pip's own installed-version resolution ran
+against the wrong RECORD.
+
+``clawmetry.distinfo_cleanup.cleanup_stale_dist_info`` must remove
+dist-infos strictly older than the installed version plus ``~lawmetry*``
+pip-uninstall corpses, keep the current AND any newer dist-info (the
+just-upgraded-but-not-yet-restarted window), and be wired into both the
+update-check worker boot and ``perform_self_update``.
+"""
+
+from __future__ import annotations
+
+import importlib.metadata
+
+from clawmetry.distinfo_cleanup import cleanup_stale_dist_info
+
+
+def _make_dist_info(sp, version, name="clawmetry"):
+    d = sp / f"{name}-{version}.dist-info"
+    d.mkdir(parents=True)
+    (d / "METADATA").write_text(
+        f"Metadata-Version: 2.1\nName: {name}\nVersion: {version}\n"
+    )
+    (d / "RECORD").write_text("")
+    return d
+
+
+def test_removes_stale_keeps_current_and_newer(tmp_path):
+    sp = tmp_path / "site-packages"
+    for v in ("0.12.655", "0.12.660", "0.12.669"):
+        _make_dist_info(sp, v)
+    current = _make_dist_info(sp, "0.12.674")
+    newer = _make_dist_info(sp, "0.12.700")  # mid-upgrade window: keep
+    corpse = sp / "~lawmetry-0.12.650.dist-info"
+    corpse.mkdir()
+    (corpse / "METADATA").write_text("stash")
+    other = _make_dist_info(sp, "0.12.1", name="clawmetry_pro")
+
+    removed = cleanup_stale_dist_info(
+        keep_version="0.12.674", site_packages=str(sp)
+    )
+
+    assert sorted(removed) == [
+        "clawmetry-0.12.655.dist-info",
+        "clawmetry-0.12.660.dist-info",
+        "clawmetry-0.12.669.dist-info",
+        "~lawmetry-0.12.650.dist-info",
+    ]
+    assert current.is_dir()
+    assert newer.is_dir()
+    assert other.is_dir(), "unrelated packages must never be touched"
+    assert not corpse.exists()
+
+
+def test_metadata_resolves_installed_version_after_cleanup(tmp_path):
+    """The observed symptom: importlib.metadata returned the OLDEST stale
+    dist-info's version. After cleanup exactly one clawmetry distribution
+    remains and it is the installed one."""
+    sp = tmp_path / "site-packages"
+    for v in ("0.12.655", "0.12.660", "0.12.669", "0.12.674"):
+        _make_dist_info(sp, v)
+
+    cleanup_stale_dist_info(keep_version="0.12.674", site_packages=str(sp))
+
+    versions = [
+        d.metadata["Version"]
+        for d in importlib.metadata.distributions(path=[str(sp)])
+        if (d.metadata["Name"] or "").lower() == "clawmetry"
+    ]
+    assert versions == ["0.12.674"]
+
+
+def test_noop_on_source_checkout_layout(tmp_path):
+    """A directory without dist-info entries (source checkout) is a no-op."""
+    (tmp_path / "dashboard.py").write_text("__version__ = 'x'\n")
+    assert cleanup_stale_dist_info(
+        keep_version="0.12.674", site_packages=str(tmp_path)
+    ) == []
+
+
+def test_stale_removed_even_without_current_dist_info(tmp_path):
+    """Ghost install (current version's dist-info missing): stale ones are
+    still pruned so pip's next run starts from clean metadata."""
+    sp = tmp_path / "site-packages"
+    _make_dist_info(sp, "0.12.655")
+    removed = cleanup_stale_dist_info(
+        keep_version="0.12.674", site_packages=str(sp)
+    )
+    assert removed == ["clawmetry-0.12.655.dist-info"]
+
+
+def test_unparseable_keep_version_is_noop(tmp_path):
+    sp = tmp_path / "site-packages"
+    _make_dist_info(sp, "0.12.655")
+    assert cleanup_stale_dist_info(
+        keep_version="latest", site_packages=str(sp)
+    ) == []
+    assert (sp / "clawmetry-0.12.655.dist-info").is_dir()
+
+
+def test_perform_self_update_prunes_after_install(monkeypatch, tmp_path):
+    """Wiring guard: a successful perform_self_update must invoke the
+    cleanup with the freshly installed version as keep_version."""
+    import types
+
+    import clawmetry.distinfo_cleanup as dc
+    from routes import meta
+
+    calls = []
+    monkeypatch.setattr(
+        dc, "cleanup_stale_dist_info",
+        lambda keep_version=None, **kw: calls.append(keep_version) or [],
+    )
+
+    def _fake_run(cmd, *a, **k):
+        return types.SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    def _fake_check_output(cmd, *a, **k):
+        return b"Name: clawmetry\nVersion: 0.12.674\n"
+
+    monkeypatch.setattr(meta, "_win_cleanup_old_exe_stubs", lambda: None)
+    monkeypatch.setattr(meta, "_win_rename_exe_before_pip",
+                        lambda: (None, None))
+    # Keep the crash-loop rollback guard from touching real ~/.clawmetry.
+    from clawmetry import update_guard
+    monkeypatch.setattr(update_guard, "arm_rollback_guard",
+                        lambda *a, **k: None)
+    import subprocess
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+    monkeypatch.setattr(subprocess, "check_output", _fake_check_output)
+
+    payload, status = meta.perform_self_update(reason="test", restart=False)
+
+    assert status == 200 and payload.get("ok")
+    assert calls == ["0.12.674"]
+
+
+def test_update_check_worker_boot_prunes(monkeypatch):
+    """Wiring guard: the update-check worker prunes stale dist-info at boot
+    (this is what heals a box after the Windows respawn helper upgraded)."""
+    import threading
+
+    import clawmetry.distinfo_cleanup as dc
+    from routes import update_check
+
+    called = threading.Event()
+    monkeypatch.setattr(
+        dc, "cleanup_stale_dist_info", lambda *a, **k: called.set() or []
+    )
+    stop = threading.Event()
+    stop.set()  # worker exits at the first wait, right after the cleanup
+    update_check._update_check_worker(stop)
+    assert called.is_set()


### PR DESCRIPTION
## Problem (observed live on the Windows lab machine, 2026-08-10)

Every in-place pip upgrade of the desktop/venv install leaves the previous version's `clawmetry-*.dist-info` behind: pip runs while a sibling clawmetry process (dashboard child, proxy, second daemon) holds `.pyd`/`.exe` files open, so the uninstall of the old version half-fails while the new wheel still lands. Five stale dist-infos (0.12.655–0.12.669) accumulated alongside the current install.

Consequences:
- `importlib.metadata.version("clawmetry")` resolves the **first** matching dist-info in directory-listing order (alphabetical on NTFS), i.e. the **oldest** stale one (0.12.655) — every metadata-based version probe lies, and pip itself resolves the installed version / RECORD from the same metadata.
- The daemon sat on 0.12.669 for 12+ minutes after 0.12.674 published: the Windows respawn path leaks `~/.clawmetry/update-in-progress.lock` when the helper hand-off fails or the helper aborts (parent never exited) — every subsequent 60s check cycle then silently logs "another process is updating; skipping cycle" until the 900s staleness window breaks the lock.

## Fix

- **New `clawmetry/distinfo_cleanup.py`** — removes `clawmetry-*.dist-info` dirs strictly older than the installed version plus `~lawmetry*` pip-uninstall corpses. Deliberately keeps newer-than-current metadata (the just-upgraded-but-not-yet-restarted window). Never raises; locked entries heal on a later boot.
- **Wired at update-check worker boot** (daemon + dashboard roles) and **after a successful `perform_self_update`** with `keep_version=` the just-installed version.
- **`update_respawn.py`**: stdlib-only prune after its pip run succeeds (the helper keeps zero clawmetry imports by design), and releases the update lock on the abort-because-parent-still-alive path.
- **`routes/update_check.py`**: releases the lock and records a `failed` attempt when the Windows respawn hand-off itself fails — both lock-leak paths that produced the silent 12–15 minute stall.
- **`desktop/app.py`**: `_get_installed_version` picks the highest parsed version instead of newest mtime — a partially-uninstalled stale dir can carry a fresher mtime than the real install.

## Verification

- 7 new regression tests in `tests/test_stale_distinfo_cleanup.py` (cleanup semantics, metadata resolution, no-op on source checkouts, ghost-install case, wiring into `perform_self_update` and the worker boot). All pass; neighboring `test_self_update_timeout_rollback.py` / `test_stale_cli_detection.py` still pass (21 passed, 2 skipped).
- End-to-end on a real venv seeded with the five observed stale dist-infos + a `~lawmetry` corpse: `importlib.metadata.version` reproduces the bug (returns 0.12.655) before cleanup, and returns 0.12.674 with only the current dist-info remaining after; a second pass confirms idempotence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
