### PR TITLE
fix(desktop): 6h auto-upgrade honors the min-age window and kill switch via clawmetry update --unattended

### DIFF
--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -4293,15 +4293,88 @@ def _cmd_eval_regression(args) -> None:
     sys.exit(exit_code)
 
 
-def _cmd_update() -> None:
-    """Self-update clawmetry to the latest PyPI version."""
+def _unattended_update_target(current: str):
+    """Resolve what an unattended ``clawmetry update --unattended`` run may
+    install, deferring to the DAEMON's policy helpers in
+    ``routes/update_check.py`` so the two paths cannot drift:
+
+      * ``_env_auto_update_disabled()`` — the CLAWMETRY_AUTO_UPDATE kill
+        switch, including the implicit CI-environment disable.
+      * ``_autoupdate_min_age_hours()`` + ``_newest_aged_in_version()`` —
+        the CLAWMETRY_AUTOUPDATE_MIN_AGE_HOURS stability window, targeting
+        the newest release that has aged past it (NOT the absolute latest).
+
+    Returns ``(target_version_or_None, human_reason)``. ``None`` means
+    "install nothing this cycle" — including when the policy helpers cannot
+    be imported: an unattended caller must never do MORE than the policy
+    allows, so an unevaluable policy fails closed (the caller's next
+    scheduled cycle retries).
+    """
+    import json
+    import urllib.request
+
+    try:
+        from routes.update_check import (
+            _autoupdate_min_age_hours,
+            _env_auto_update_disabled,
+            _newest_aged_in_version,
+        )
+    except Exception as exc:
+        return None, f"Update policy unavailable ({exc}); skipping unattended update"
+    if _env_auto_update_disabled():
+        return None, (
+            "Unattended updates disabled "
+            "(CLAWMETRY_AUTO_UPDATE kill switch or CI environment)"
+        )
+    try:
+        req = urllib.request.Request(
+            "https://pypi.org/pypi/clawmetry/json",
+            headers={"User-Agent": f"clawmetry/{current}"},
+        )
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            data = json.loads(resp.read().decode())
+    except Exception as exc:
+        return None, f"PyPI check failed ({exc}); skipping unattended update"
+    min_age = _autoupdate_min_age_hours()
+    target = _newest_aged_in_version(data.get("releases", {}), current, min_age)
+    if not target:
+        latest = data.get("info", {}).get("version", "") or current
+        if latest == current:
+            return None, f"Already on latest version ({current})"
+        return None, (
+            f"Newest release v{latest} has not aged past the "
+            f"{min_age:g}h stability window yet; nothing to install"
+        )
+    return target, (
+        f"Unattended target: v{target} "
+        f"(newest release aged past the {min_age:g}h stability window)"
+    )
+
+
+def _cmd_update(args=None) -> None:
+    """Self-update clawmetry to the latest PyPI version.
+
+    ``--unattended`` (the desktop shell's 6h background path) routes target
+    selection through the daemon's update policy (kill switch + stability
+    window) via ``_unattended_update_target`` and pins the pip install to
+    that version; the plain interactive command keeps installing the
+    absolute latest.
+    """
     import subprocess
 
+    unattended = bool(getattr(args, "unattended", False))
     try:
         from dashboard import __version__ as current
     except Exception:
         current = "unknown"
     print(f"Current version: {current}")
+    install_spec = "clawmetry"
+    if unattended:
+        target, reason = _unattended_update_target(current)
+        print(reason)
+        if not target:
+            return
+        install_spec = f"clawmetry=={target}"
     print("Checking for updates...")
     try:
         result = subprocess.run(
@@ -4312,7 +4385,7 @@ def _cmd_update() -> None:
                 "install",
                 "--upgrade",
                 "--break-system-packages",
-                "clawmetry",
+                install_spec,
             ],
             capture_output=True,
             text=True,
@@ -6744,7 +6817,19 @@ def main() -> None:
     )
 
     # update — self-update to latest PyPI version
-    sub.add_parser("update", help="Update clawmetry to the latest version")
+    p_update = sub.add_parser("update", help="Update clawmetry to the latest version")
+    p_update.add_argument(
+        "--unattended",
+        action="store_true",
+        help=(
+            "Apply the daemon's unattended-update policy instead of blindly "
+            "upgrading: honor the CLAWMETRY_AUTO_UPDATE kill switch (including "
+            "implicit CI disable) and the CLAWMETRY_AUTOUPDATE_MIN_AGE_HOURS "
+            "stability window, installing the newest aged-in release (pinned) "
+            "rather than the absolute latest. Used by the desktop shell's 6h "
+            "background upgrade."
+        ),
+    )
 
     # mcp — start MCP server on stdio (issue #2859)
     sub.add_parser(
@@ -7276,7 +7361,7 @@ def main() -> None:
         elif args.cmd == "mcp":
             _cmd_mcp(args)
         elif args.cmd == "update":
-            _cmd_update()
+            _cmd_update(args)
         elif args.cmd == "uninstall":
             _cmd_uninstall()
         elif args.cmd == "activate":

--- a/desktop/app.py
+++ b/desktop/app.py
@@ -85,6 +85,23 @@ SYNC_DISCOVERY_FILE = Path.home() / ".clawmetry" / "local_query.json"
 SYNC_START_RETRY_SECS = 300
 
 
+def _auto_update_disabled() -> bool:
+    """Kill-switch parse for the shell's unattended upgrades, mirroring the
+    daemon's routes/update_check.py::_env_auto_update_disabled (the shell
+    cannot import the venv's clawmetry package, so the semantics are
+    duplicated here — keep the two in sync): an explicit truthy value
+    re-arms, any explicit falsy value disables (not just the literal "0"),
+    and CI environments are implicitly disabled so an ephemeral runner
+    never swaps its code out mid-job."""
+    val = os.environ.get("CLAWMETRY_AUTO_UPDATE", "").strip().lower()
+    if val in ("1", "true", "yes", "on"):
+        return False
+    if val in ("0", "false", "no", "off"):
+        return True
+    ci = os.environ.get("CI", "").strip().lower()
+    return ci not in ("", "0", "false")
+
+
 def _pid_alive(pid: int) -> bool:
     """Best-effort 'is this PID a live process'. Never raises."""
     if pid <= 0:
@@ -629,27 +646,48 @@ class RuntimeSupervisor:
             return None
 
     def _background_pip_upgrade(self) -> None:
-        """Non-blocking upgrade via the venv's `clawmetry update`
-        subcommand — this way we inherit the daemon's own
-        CLAWMETRY_AUTO_UPDATE kill switch and
-        CLAWMETRY_AUTOUPDATE_MIN_AGE_HOURS stability window without
-        reimplementing them here. Matches the blueprint contract
-        "the shell defers to the daemon's update policy rather than
-        shipping its own". Errors are logged and swallowed — a
-        transient PyPI failure should never take down the running app.
+        """Non-blocking upgrade via the venv's `clawmetry update
+        --unattended` subcommand — the flag makes the CLI apply the
+        daemon's own update policy (routes/update_check.py): the
+        CLAWMETRY_AUTO_UPDATE kill switch (incl. implicit CI disable)
+        and the CLAWMETRY_AUTOUPDATE_MIN_AGE_HOURS stability window,
+        pinning to the newest aged-in release. Matches the blueprint
+        contract "the shell defers to the daemon's update policy rather
+        than shipping its own"; the local _auto_update_disabled() check
+        is only a cheap pre-flight with the same semantics. Errors are
+        logged and swallowed — a transient PyPI failure should never
+        take down the running app.
         """
-        if os.environ.get("CLAWMETRY_AUTO_UPDATE") == "0":
-            self._log("watcher upgrade: CLAWMETRY_AUTO_UPDATE=0, skipping")
+        if _auto_update_disabled():
+            self._log(
+                "watcher upgrade: auto-update disabled "
+                "(CLAWMETRY_AUTO_UPDATE kill switch or CI env), skipping"
+            )
             return
         cli = self._venv_clawmetry()
         if not cli.exists():
             return
         try:
             r = subprocess.run(
-                [str(cli), "update"],
+                [str(cli), "update", "--unattended"],
                 capture_output=True, text=True, timeout=300,
                 **_win_subprocess_kwargs(),
             )
+            if r.returncode != 0 and "--unattended" in (r.stderr or "") \
+                    and "unrecognized arguments" in (r.stderr or ""):
+                # Bootstrap compat: the venv still runs a clawmetry from
+                # before the flag existed, so no unattended run can ever
+                # succeed — one plain update to get onto a version that
+                # understands the policy flag.
+                self._log(
+                    "watcher upgrade: venv clawmetry predates --unattended; "
+                    "falling back to plain update once"
+                )
+                r = subprocess.run(
+                    [str(cli), "update"],
+                    capture_output=True, text=True, timeout=300,
+                    **_win_subprocess_kwargs(),
+                )
             self._log(f"watcher clawmetry-update rc={r.returncode}")
             if r.returncode != 0:
                 self._log(r.stderr[:2000])

--- a/tests/test_cli_unattended_update.py
+++ b/tests/test_cli_unattended_update.py
@@ -1,0 +1,236 @@
+"""`clawmetry update --unattended` must defer to the daemon's update policy.
+
+Bug pinned here: the desktop shell's 6h auto-upgrade path shelled the venv's
+`clawmetry update`, which was a bare `pip install --upgrade clawmetry` that
+read neither CLAWMETRY_AUTOUPDATE_MIN_AGE_HOURS nor CLAWMETRY_AUTO_UPDATE —
+so a desktop install silently ignored the operator's stability window and
+kill switch that the daemon's own updater (routes/update_check.py) honors.
+The fix adds `--unattended`, which routes target selection through the very
+same policy helpers (no duplicated semantics) and pins the pip install to
+the newest aged-in release.
+"""
+import json
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from types import SimpleNamespace
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+import clawmetry.cli as cli  # noqa: E402
+import routes.update_check as uc  # noqa: E402
+
+
+def _iso(hours_ago):
+    return (
+        datetime.now(timezone.utc) - timedelta(hours=hours_ago)
+    ).isoformat().replace("+00:00", "Z")
+
+
+def _pypi_payload(latest, releases_spec):
+    """releases_spec: {version: hours_ago}."""
+    return {
+        "info": {"version": latest},
+        "releases": {
+            ver: [{"upload_time_iso_8601": _iso(ago)}]
+            for ver, ago in releases_spec.items()
+        },
+    }
+
+
+class _FakeResp:
+    def __init__(self, payload):
+        self._body = json.dumps(payload).encode()
+
+    def read(self):
+        return self._body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+def _patch_pypi(monkeypatch, payload):
+    import urllib.request
+
+    monkeypatch.setattr(
+        urllib.request, "urlopen", lambda req, timeout=10: _FakeResp(payload)
+    )
+
+
+def _arm(monkeypatch):
+    """Explicitly re-arm auto-update so the test is deterministic even on a
+    CI runner (where the implicit CI disable would otherwise kick in)."""
+    monkeypatch.setenv("CLAWMETRY_AUTO_UPDATE", "1")
+
+
+# ── kill switch ──────────────────────────────────────────────────────────────
+
+def test_kill_switch_blocks_unattended_before_any_network(monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_AUTO_UPDATE", "0")
+    import urllib.request
+
+    def _boom(*a, **k):
+        raise AssertionError("PyPI must not be contacted when the kill switch is on")
+
+    monkeypatch.setattr(urllib.request, "urlopen", _boom)
+    target, reason = cli._unattended_update_target("0.12.500")
+    assert target is None
+    assert "kill switch" in reason.lower() or "disabled" in reason.lower()
+
+
+def test_richer_falsy_values_block_unattended(monkeypatch):
+    # The daemon's parser accepts false/no/off, not just the literal "0".
+    for val in ("false", "no", "off", "FALSE"):
+        monkeypatch.setenv("CLAWMETRY_AUTO_UPDATE", val)
+        target, _ = cli._unattended_update_target("0.12.500")
+        assert target is None, val
+
+
+def test_ci_environment_implicitly_blocks_unattended(monkeypatch):
+    monkeypatch.delenv("CLAWMETRY_AUTO_UPDATE", raising=False)
+    monkeypatch.setenv("CI", "true")
+    target, _ = cli._unattended_update_target("0.12.500")
+    assert target is None
+
+
+# ── stability window ─────────────────────────────────────────────────────────
+
+def test_min_age_window_pins_newest_aged_in_release(monkeypatch):
+    _arm(monkeypatch)
+    monkeypatch.setenv("CLAWMETRY_AUTOUPDATE_MIN_AGE_HOURS", "48")
+    _patch_pypi(monkeypatch, _pypi_payload("0.12.518", {
+        "0.12.500": 200, "0.12.510": 60, "0.12.518": 2,
+    }))
+    target, reason = cli._unattended_update_target("0.12.500")
+    # 0.12.518 is the absolute latest but only 2h old; 0.12.510 has aged in.
+    assert target == "0.12.510"
+    assert "0.12.510" in reason
+
+
+def test_min_age_window_installs_nothing_when_all_too_fresh(monkeypatch):
+    _arm(monkeypatch)
+    monkeypatch.setenv("CLAWMETRY_AUTOUPDATE_MIN_AGE_HOURS", "48")
+    _patch_pypi(monkeypatch, _pypi_payload("0.12.518", {
+        "0.12.500": 200, "0.12.514": 20, "0.12.518": 2,
+    }))
+    target, reason = cli._unattended_update_target("0.12.500")
+    assert target is None
+    assert "stability window" in reason
+
+
+def test_default_zero_window_targets_latest(monkeypatch):
+    _arm(monkeypatch)
+    monkeypatch.delenv("CLAWMETRY_AUTOUPDATE_MIN_AGE_HOURS", raising=False)
+    _patch_pypi(monkeypatch, _pypi_payload("0.12.518", {
+        "0.12.500": 200, "0.12.518": 0.01,
+    }))
+    target, _ = cli._unattended_update_target("0.12.500")
+    assert target == "0.12.518"
+
+
+def test_policy_reuses_daemon_helpers_not_a_copy(monkeypatch):
+    """Drift guard: the CLI must consult routes/update_check.py's selection
+    logic, so a future policy change there automatically applies here."""
+    _arm(monkeypatch)
+    _patch_pypi(monkeypatch, _pypi_payload("0.12.518", {"0.12.518": 100}))
+    sentinel = {"called": False}
+
+    def _fake_newest(releases, current, min_age):
+        sentinel["called"] = True
+        return "9.9.9"
+
+    monkeypatch.setattr(uc, "_newest_aged_in_version", _fake_newest)
+    target, _ = cli._unattended_update_target("0.12.500")
+    assert sentinel["called"]
+    assert target == "9.9.9"
+
+
+def test_policy_import_failure_fails_closed(monkeypatch):
+    """If the policy helpers cannot be evaluated, an unattended run must
+    install NOTHING (never more than the policy allows)."""
+    import builtins
+
+    real_import = builtins.__import__
+
+    def _blocked(name, *a, **k):
+        if name.startswith("routes.update_check") or name == "routes":
+            raise ImportError("simulated broken install")
+        return real_import(name, *a, **k)
+
+    monkeypatch.setattr(builtins, "__import__", _blocked)
+    target, reason = cli._unattended_update_target("0.12.500")
+    assert target is None
+    assert "policy unavailable" in reason.lower()
+
+
+# ── _cmd_update wiring ───────────────────────────────────────────────────────
+
+def _run_recorder(monkeypatch, returncode=0, stdout=""):
+    import subprocess
+
+    calls = []
+
+    def _fake_run(cmd, **kw):
+        calls.append(cmd)
+        return SimpleNamespace(returncode=returncode, stdout=stdout, stderr="")
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+    return calls
+
+
+def test_cmd_update_unattended_skip_runs_no_pip(monkeypatch, capsys):
+    calls = _run_recorder(monkeypatch)
+    monkeypatch.setattr(
+        cli, "_unattended_update_target",
+        lambda current: (None, "Unattended updates disabled (test)"),
+    )
+    cli._cmd_update(SimpleNamespace(unattended=True))
+    assert calls == []
+    assert "disabled" in capsys.readouterr().out.lower()
+
+
+def test_cmd_update_unattended_pins_target_version(monkeypatch):
+    from dashboard import __version__ as current
+
+    # Report the current version back from the post-install probe so the
+    # command takes the quiet "already latest" branch (no daemon restart).
+    calls = _run_recorder(monkeypatch, returncode=0, stdout=current + "\n")
+    monkeypatch.setattr(
+        cli, "_unattended_update_target",
+        lambda cur: ("0.12.999", "Unattended target: v0.12.999"),
+    )
+    cli._cmd_update(SimpleNamespace(unattended=True))
+    pip_cmd = calls[0]
+    assert "clawmetry==0.12.999" in pip_cmd
+    assert "clawmetry" not in pip_cmd[pip_cmd.index("clawmetry==0.12.999") + 1:]
+
+
+def test_cmd_update_plain_still_upgrades_unpinned(monkeypatch):
+    from dashboard import __version__ as current
+
+    calls = _run_recorder(monkeypatch, returncode=0, stdout=current + "\n")
+
+    def _no_policy(cur):
+        raise AssertionError("plain update must not consult unattended policy")
+
+    monkeypatch.setattr(cli, "_unattended_update_target", _no_policy)
+    cli._cmd_update(SimpleNamespace(unattended=False))
+    assert "clawmetry" in calls[0]
+
+
+def test_real_parser_wires_unattended_into_cmd_update(monkeypatch):
+    """The desktop shell shells `clawmetry update --unattended`; if the flag
+    ever disappears from the real parser, every desktop install would trip
+    the shell's one-shot compat fallback and silently run policy-free
+    upgrades forever."""
+    captured = {}
+    monkeypatch.setattr(
+        cli, "_cmd_update", lambda args=None: captured.setdefault("args", args)
+    )
+    monkeypatch.setattr(sys, "argv", ["clawmetry", "update", "--unattended"])
+    cli.main()
+    assert getattr(captured["args"], "unattended", False) is True

--- a/tests/test_desktop_unattended_update.py
+++ b/tests/test_desktop_unattended_update.py
@@ -1,0 +1,153 @@
+"""The desktop shell's 6h auto-upgrade must honor the daemon's update policy.
+
+Bug pinned here: desktop/app.py's watcher shelled a plain `clawmetry update`
+(a bare pip upgrade that ignores CLAWMETRY_AUTOUPDATE_MIN_AGE_HOURS and
+CLAWMETRY_AUTO_UPDATE) and its own kill-switch pre-check compared the env
+var to the literal string "0" only, missing false/no/off and the implicit
+CI disable that routes/update_check.py::_env_auto_update_disabled applies.
+Now the shell passes --unattended (the CLI applies the daemon policy) and
+the pre-check mirrors the daemon's parser exactly.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+import desktop.app as dapp  # noqa: E402
+import routes.update_check as uc  # noqa: E402
+
+
+# ── kill-switch parsing parity with the daemon ───────────────────────────────
+
+@pytest.mark.parametrize("val", ["0", "false", "no", "off", "FALSE", " Off "])
+def test_explicit_falsy_disables(monkeypatch, val):
+    monkeypatch.setenv("CLAWMETRY_AUTO_UPDATE", val)
+    assert dapp._auto_update_disabled() is True
+
+
+@pytest.mark.parametrize("val", ["1", "true", "yes", "on", "TRUE"])
+def test_explicit_truthy_rearms_even_in_ci(monkeypatch, val):
+    monkeypatch.setenv("CLAWMETRY_AUTO_UPDATE", val)
+    monkeypatch.setenv("CI", "true")
+    assert dapp._auto_update_disabled() is False
+
+
+def test_ci_implicitly_disables_when_unset(monkeypatch):
+    monkeypatch.delenv("CLAWMETRY_AUTO_UPDATE", raising=False)
+    monkeypatch.setenv("CI", "true")
+    assert dapp._auto_update_disabled() is True
+
+
+def test_enabled_by_default_outside_ci(monkeypatch):
+    monkeypatch.delenv("CLAWMETRY_AUTO_UPDATE", raising=False)
+    monkeypatch.delenv("CI", raising=False)
+    assert dapp._auto_update_disabled() is False
+
+
+@pytest.mark.parametrize("auto_update", ["", "0", "1", "false", "no", "off",
+                                         "true", "yes", "on", "garbage"])
+@pytest.mark.parametrize("ci", ["", "0", "false", "true", "1"])
+def test_parity_with_daemon_parser(monkeypatch, auto_update, ci):
+    """Drift guard: the shell's duplicated parser must agree with
+    routes/update_check.py::_env_auto_update_disabled for every combo."""
+    if auto_update:
+        monkeypatch.setenv("CLAWMETRY_AUTO_UPDATE", auto_update)
+    else:
+        monkeypatch.delenv("CLAWMETRY_AUTO_UPDATE", raising=False)
+    if ci:
+        monkeypatch.setenv("CI", ci)
+    else:
+        monkeypatch.delenv("CI", raising=False)
+    assert dapp._auto_update_disabled() == uc._env_auto_update_disabled()
+
+
+# ── the watcher's upgrade shell-out ──────────────────────────────────────────
+
+def _stub_shell(tmp_path):
+    cli = tmp_path / "clawmetry"
+    cli.write_text("stub")
+    stub = SimpleNamespace(
+        logs=[], upgraded=[],
+    )
+    stub._log = stub.logs.append
+    stub._venv_clawmetry = lambda: cli
+    stub._get_installed_version = lambda: "0.12.999"
+    stub._mark_upgraded = stub.upgraded.append
+    return stub, cli
+
+
+def test_upgrade_passes_unattended_flag(monkeypatch, tmp_path):
+    monkeypatch.setenv("CLAWMETRY_AUTO_UPDATE", "1")
+    stub, cli = _stub_shell(tmp_path)
+    calls = []
+
+    def _fake_run(cmd, **kw):
+        calls.append(cmd)
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(dapp.subprocess, "run", _fake_run)
+    dapp.RuntimeSupervisor._background_pip_upgrade(stub)
+    assert calls == [[str(cli), "update", "--unattended"]]
+    assert stub.upgraded == ["0.12.999"]
+
+
+def test_kill_switch_skips_shell_out_entirely(monkeypatch, tmp_path):
+    monkeypatch.setenv("CLAWMETRY_AUTO_UPDATE", "no")  # not just "0"
+    stub, _cli = _stub_shell(tmp_path)
+
+    def _boom(cmd, **kw):
+        raise AssertionError("must not shell out when the kill switch is on")
+
+    monkeypatch.setattr(dapp.subprocess, "run", _boom)
+    dapp.RuntimeSupervisor._background_pip_upgrade(stub)
+    assert any("disabled" in line for line in stub.logs)
+
+
+def test_pre_unattended_venv_falls_back_to_plain_update_once(monkeypatch, tmp_path):
+    """Bootstrap: a venv still running a clawmetry from before the flag
+    existed rejects --unattended (argparse rc=2). The shell must retry a
+    plain update once so the venv can reach a version that understands the
+    policy flag, instead of failing every 6h cycle forever."""
+    monkeypatch.setenv("CLAWMETRY_AUTO_UPDATE", "1")
+    stub, cli = _stub_shell(tmp_path)
+    calls = []
+
+    def _fake_run(cmd, **kw):
+        calls.append(cmd)
+        if "--unattended" in cmd:
+            return SimpleNamespace(
+                returncode=2, stdout="",
+                stderr="clawmetry: error: unrecognized arguments: --unattended",
+            )
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(dapp.subprocess, "run", _fake_run)
+    dapp.RuntimeSupervisor._background_pip_upgrade(stub)
+    assert calls == [
+        [str(cli), "update", "--unattended"],
+        [str(cli), "update"],
+    ]
+    assert stub.upgraded == ["0.12.999"]
+
+
+def test_real_update_failure_does_not_trigger_plain_fallback(monkeypatch, tmp_path):
+    """Only the unrecognized-flag signature may demote to a plain update;
+    a genuine failure (network, pip) must NOT bypass the policy."""
+    monkeypatch.setenv("CLAWMETRY_AUTO_UPDATE", "1")
+    stub, cli = _stub_shell(tmp_path)
+    calls = []
+
+    def _fake_run(cmd, **kw):
+        calls.append(cmd)
+        return SimpleNamespace(returncode=1, stdout="", stderr="network unreachable")
+
+    monkeypatch.setattr(dapp.subprocess, "run", _fake_run)
+    dapp.RuntimeSupervisor._background_pip_upgrade(stub)
+    assert calls == [[str(cli), "update", "--unattended"]]
+    assert stub.upgraded == []


### PR DESCRIPTION
## Why

The desktop shell's 6h auto-upgrade path (`desktop/app.py::_background_pip_upgrade`) shelled the venv's `clawmetry update`, which was a bare `pip install --upgrade clawmetry`. It read neither `CLAWMETRY_AUTOUPDATE_MIN_AGE_HOURS` nor `CLAWMETRY_AUTO_UPDATE`, so a desktop install silently ignored the operator's stability window and kill switch that the daemon's own updater (`routes/update_check.py`) honors. The shell's pre-check also compared `CLAWMETRY_AUTO_UPDATE` to the literal `"0"` only, missing the daemon's richer parsing (false/no/off, plus the implicit CI disable). The Desktop Application Distribution blueprint in 8090 Software Factory documents this as a known follow-up; this PR closes it (the blueprint should be marked resolved on merge, I could not reach the Software Factory MCP from this session).

## What

- **`clawmetry update --unattended`** (new flag, used by the shell): target selection defers to the daemon's policy helpers in `routes/update_check.py` (`_env_auto_update_disabled`, `_autoupdate_min_age_hours`, `_newest_aged_in_version`), so the two paths cannot drift. It installs the newest release that has aged past the stability window, pinned (`clawmetry==X`), not the absolute latest; when the kill switch is on, CI is detected, nothing has aged in, or the policy cannot be imported, it installs nothing (fails closed). Plain interactive `clawmetry update` is unchanged.
- **`desktop/app.py`**: passes `--unattended`; the local kill-switch pre-check now mirrors the daemon parser exactly (documented as a duplicate to keep in sync, since the shell cannot import the venv's package). A one-shot plain-update fallback fires only on the argparse unrecognized-arguments signature, so venvs predating the flag can bootstrap onto a version that understands it; genuine failures do NOT bypass policy.

## Verification

- `python -m pytest tests/test_cli_unattended_update.py tests/test_desktop_unattended_update.py tests/test_autoupdate_newest_aged.py`: 84 passed (Windows 11, Python from the lab venv).
- Revert-proof: with `clawmetry/cli.py` and `desktop/app.py` stashed back to the un-fixed code, the new suite goes 79 failed; restored, all green.
- Tests include a parser-parity drift guard: for a matrix of `CLAWMETRY_AUTO_UPDATE` x `CI` values, `desktop.app._auto_update_disabled()` must agree with `routes.update_check._env_auto_update_disabled()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
