### PR TITLE
fix(trial): persist trial-warning day to disk so daemon restarts do not re-fire the warning POST

### DIFF
--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -1451,6 +1451,48 @@ _TRIAL_WARNING_STATE = {
     "last_warn_day": "",   # YYYY-MM-DD of the last warning we sent
 }
 
+# Same file routes/trial.py's /api/trial/mark-warned writes ({"YYYY-MM-DD":
+# days_left}); sharing it means either writer suppresses the other's re-fire.
+# The in-memory guard alone resets on every daemon restart, and auto-update
+# restarts the daemon on every release (often several per day), so without the
+# disk check each restart re-fired /ingest/trial-warning (2026-08-10 trial-email
+# spam RCA).
+_TRIAL_WARNINGS_PATH = os.path.expanduser("~/.clawmetry/trial_warnings.json")
+
+
+def _trial_warning_sent_on(day: str) -> bool:
+    """True when ``day`` (YYYY-MM-DD) is already recorded on disk. Never raises."""
+    try:
+        if not os.path.isfile(_TRIAL_WARNINGS_PATH):
+            return False
+        with open(_TRIAL_WARNINGS_PATH, encoding="utf-8") as fh:
+            data = json.load(fh)
+        return isinstance(data, dict) and day in data
+    except Exception:
+        return False
+
+
+def _record_trial_warning(day: str, days_left: int) -> None:
+    """Persist ``{day: days_left}`` into the warnings file. Never raises."""
+    try:
+        os.makedirs(os.path.dirname(_TRIAL_WARNINGS_PATH), exist_ok=True)
+        existing = {}
+        if os.path.isfile(_TRIAL_WARNINGS_PATH):
+            try:
+                with open(_TRIAL_WARNINGS_PATH, encoding="utf-8") as fh:
+                    existing = json.load(fh) or {}
+            except Exception:
+                existing = {}
+        if not isinstance(existing, dict):
+            existing = {}
+        existing[day] = days_left
+        tmp = _TRIAL_WARNINGS_PATH + ".tmp"
+        with open(tmp, "w", encoding="utf-8") as fh:
+            json.dump(existing, fh)
+        os.replace(tmp, _TRIAL_WARNINGS_PATH)
+    except Exception as exc:
+        log.debug("trial-warning persist failed: %s", exc)
+
 
 def _maybe_install_license_from_heartbeat(resp: dict) -> None:
     """Persist a signed license key the cloud attached to this heartbeat.
@@ -1512,10 +1554,12 @@ def _maybe_send_trial_warning(resp: dict) -> None:
     fire ``POST /ingest/trial-warning`` on the cloud so it can send the
     customer a "your trial ends in N days — click to upgrade" email.
 
-    Rate-limited: at most one warning per UTC day per daemon process. The
-    cloud is authoritative on email throttling itself; this guard just
-    prevents a daemon that beats every 30s from spamming the cloud with 2880
-    identical warnings.
+    Rate-limited: at most one warning per UTC day, guarded both in memory
+    (fast path for a daemon that beats every 30s) and on disk
+    (``~/.clawmetry/trial_warnings.json``) so an auto-update restart — which
+    happens on every release, often several times a day — doesn't reset the
+    guard and re-fire the POST. The cloud is authoritative on email
+    throttling itself.
 
     Never raises."""
     if not isinstance(resp, dict):
@@ -1537,7 +1581,12 @@ def _maybe_send_trial_warning(resp: dict) -> None:
     today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
     if _TRIAL_WARNING_STATE["last_warn_day"] == today:
         return
+    if _trial_warning_sent_on(today):
+        # A previous daemon process (pre-restart) already warned today.
+        _TRIAL_WARNING_STATE["last_warn_day"] = today
+        return
     _TRIAL_WARNING_STATE["last_warn_day"] = today
+    _record_trial_warning(today, days_i)
     try:
         cfg = load_config() or {}
         api_key = cfg.get("api_key")

--- a/tests/test_trial_warning_restart_persist.py
+++ b/tests/test_trial_warning_restart_persist.py
@@ -1,0 +1,107 @@
+"""The trial-warning once-per-day guard must survive a daemon restart.
+
+_maybe_send_trial_warning throttles POST /ingest/trial-warning via the
+in-memory _TRIAL_WARNING_STATE["last_warn_day"]. Auto-update restarts the
+daemon on every release (often several per day), which resets that guard —
+each restart re-fired the POST and the cloud emailed the customer again
+(2026-08-10 trial-email spam RCA: one account got 5+ "trial has ended"
+emails in a single day). The fix persists the warned day to
+~/.clawmetry/trial_warnings.json (the same file routes/trial.py's
+/api/trial/mark-warned writes) so a fresh process sees it and stays quiet.
+
+Hermetic: no real HTTP, no real home directory.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+import pytest
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+
+def _fresh_sync(monkeypatch, tmp_path):
+    """Import clawmetry.sync fresh (simulates a daemon process start) with
+    the warnings file redirected into tmp_path and network/config stubbed."""
+    sys.modules.pop('clawmetry.sync', None)
+    import clawmetry.sync as s
+    monkeypatch.setattr(
+        s, '_TRIAL_WARNINGS_PATH', str(tmp_path / 'trial_warnings.json'))
+    monkeypatch.setattr(s, 'load_config', lambda: {'api_key': 'cm_test'})
+    posts = []
+    monkeypatch.setattr(
+        s, '_post', lambda *a, **kw: posts.append(a) or {})
+    return s, posts
+
+
+IN_WINDOW = {'trial_days_left': 1}  # default warning window is 2 days
+
+
+def test_first_warning_fires_and_persists(monkeypatch, tmp_path):
+    s, posts = _fresh_sync(monkeypatch, tmp_path)
+    s._maybe_send_trial_warning(IN_WINDOW)
+    assert len(posts) == 1, 'first in-window heartbeat should warn'
+    data = json.loads((tmp_path / 'trial_warnings.json').read_text())
+    today = s.datetime.now(s.timezone.utc).strftime('%Y-%m-%d')
+    assert data == {today: 1}
+
+
+def test_same_process_second_beat_is_throttled(monkeypatch, tmp_path):
+    s, posts = _fresh_sync(monkeypatch, tmp_path)
+    s._maybe_send_trial_warning(IN_WINDOW)
+    s._maybe_send_trial_warning(IN_WINDOW)
+    assert len(posts) == 1
+
+
+def test_restart_does_not_refire(monkeypatch, tmp_path):
+    """The regression: a fresh process (auto-update restart) must see the
+    on-disk record and NOT re-POST the same day."""
+    s1, posts1 = _fresh_sync(monkeypatch, tmp_path)
+    s1._maybe_send_trial_warning(IN_WINDOW)
+    assert len(posts1) == 1
+
+    # Simulate the daemon restarting: brand-new module, empty in-memory state.
+    s2, posts2 = _fresh_sync(monkeypatch, tmp_path)
+    assert s2._TRIAL_WARNING_STATE['last_warn_day'] == ''
+    s2._maybe_send_trial_warning(IN_WINDOW)
+    assert posts2 == [], (
+        'restarted daemon re-fired /ingest/trial-warning on the same UTC day')
+    # And the fast-path cache is primed so later beats skip the disk read.
+    assert s2._TRIAL_WARNING_STATE['last_warn_day'] != ''
+
+
+def test_corrupt_warnings_file_never_raises(monkeypatch, tmp_path):
+    s, posts = _fresh_sync(monkeypatch, tmp_path)
+    (tmp_path / 'trial_warnings.json').write_text('{not json!!')
+    s._maybe_send_trial_warning(IN_WINDOW)  # must not raise
+    assert len(posts) == 1, 'corrupt state file should fail open (warn once)'
+    # And the write path repairs the file.
+    data = json.loads((tmp_path / 'trial_warnings.json').read_text())
+    assert isinstance(data, dict) and len(data) == 1
+
+
+def test_mark_warned_endpoint_record_suppresses_daemon(monkeypatch, tmp_path):
+    """The file is shared with routes/trial.py's /api/trial/mark-warned —
+    a record written by that endpoint must also suppress the daemon POST."""
+    s, posts = _fresh_sync(monkeypatch, tmp_path)
+    today = s.datetime.now(s.timezone.utc).strftime('%Y-%m-%d')
+    (tmp_path / 'trial_warnings.json').write_text(json.dumps({today: 1}))
+    s._maybe_send_trial_warning(IN_WINDOW)
+    assert posts == []
+
+
+def test_unreadable_dir_never_raises(monkeypatch, tmp_path):
+    """Persistence failure must not break the warning itself (never raises)."""
+    s, posts = _fresh_sync(monkeypatch, tmp_path)
+    # Point the warnings file somewhere unwritable-ish: a path whose parent
+    # is an existing FILE, so makedirs/open both fail.
+    blocker = tmp_path / 'blocker'
+    blocker.write_text('x')
+    monkeypatch.setattr(
+        s, '_TRIAL_WARNINGS_PATH', str(blocker / 'trial_warnings.json'))
+    s._maybe_send_trial_warning(IN_WINDOW)  # must not raise
+    assert len(posts) == 1


### PR DESCRIPTION
## Why

`_maybe_send_trial_warning` in `clawmetry/sync.py` throttles `POST /ingest/trial-warning` (the "your trial ends in N days" email trigger) with only the in-memory `_TRIAL_WARNING_STATE["last_warn_day"]`. Auto-update restarts the daemon on every release, often several times a day, and each restart reset the guard and re-fired the POST. Result: the 2026-08-10 trial-email spam RCA, where one account received 5+ "trial has ended" emails in a single day. Cloud-side dedup landed in clawmetry-cloud PR #1970; this is the daemon-side half.

## What

- Persist the warned day to `~/.clawmetry/trial_warnings.json`, the same `{"YYYY-MM-DD": days_left}` file `routes/trial.py`'s `/api/trial/mark-warned` already writes, so either writer suppresses the other's re-fire.
- On each in-window heartbeat: fast-path in-memory check first, then the disk check (a hit primes the in-memory cache), then record to disk before POSTing.
- Both helpers (`_trial_warning_sent_on`, `_record_trial_warning`) never raise: corrupt or unwritable state files fail open (warn once, repair the file where possible), matching the function's never-raise contract.

## Verification

- New regression suite `tests/test_trial_warning_restart_persist.py` (6 tests): first warning fires + persists, same-process throttle, **restart does not re-fire** (fresh module import against the same state file), corrupt file never raises + is repaired, a `/api/trial/mark-warned` record suppresses the daemon POST, unwritable path never raises.
- Revert-proof: with the `sync.py` change stashed, the suite goes red (6 failed); with the fix, 6 passed. Existing `tests/test_sync_trial_gating.py` still green (19 passed total).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
