### PR TITLE
fix(desktop): OAuth callback page shows the ClawMetry logo instead of a raw emoji

### DIFF
--- a/desktop/onboarding.py
+++ b/desktop/onboarding.py
@@ -1030,6 +1030,15 @@ def oauth_loopback_flow(
     thread — starts + tears down its own HTTPServer."""
     base = (app_base or resolve_app_base()).rstrip("/")
 
+    logo = _asset_data_uri(
+        Path(__file__).resolve().parent / "assets",
+        "clawmetry-logo-stacked-darkbg.svg", "image/svg+xml",
+    )
+    logo_html = (
+        f"<img src='{logo}' alt='ClawMetry' style='width:180px;height:auto'/>"
+        if logo else "<div style='font-size:40px'>\U0001f99e</div>"
+    )
+
     captured: dict = {}
 
     class _Handler(http.server.BaseHTTPRequestHandler):
@@ -1050,7 +1059,7 @@ def oauth_loopback_flow(
                  "<body style='font-family:-apple-system,sans-serif;background:#0b0e14;"
                  "color:#e2e8f0;display:flex;align-items:center;justify-content:center;"
                  "height:100vh;margin:0'>"
-                 "<div style='text-align:center'><div style='font-size:40px'>\U0001f99e</div>"
+                 f"<div style='text-align:center'>{logo_html}"
                  f"<h2 style='font-weight:700'>{msg}</h2></div>"
                  "</body></html>").encode("utf-8")
             )


### PR DESCRIPTION
## What

The desktop OAuth loopback callback page ("You're connected. Return to the ClawMetry app.") showed a raw lobster emoji, which renders differently on every OS/browser and reads as unfinished. It now shows the real ClawMetry stacked logo (lobster mark + wordmark, dark-bg variant) embedded as a base64 data URI, so the page stays fully self-contained — no external asset loads, keeping the module's stdlib-only/no-assets promise.

Falls back to the emoji if the SVG can't be read, so the page never breaks.

## Screenshot (rendered page)

Verified locally by generating the exact handler HTML and screenshotting in a browser: stacked logo renders crisply above the message on the dark background, for both the success and failure messages.

## Testing

- `python -m py_compile desktop/onboarding.py`
- Verified `_asset_data_uri` resolves `desktop/assets/clawmetry-logo-stacked-darkbg.svg` to a `data:image/svg+xml;base64,` URI at import time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
