### PR TITLE
fix(gate): Claude Code hook uses pythonw.exe so no console window pops on Windows

### DIFF
--- a/clawmetry/claude_code_gate.py
+++ b/clawmetry/claude_code_gate.py
@@ -243,8 +243,23 @@ def _clear_state() -> None:
         pass
 
 
+def _windowless_python(py: str, is_windows: bool, exists=os.path.exists) -> str:
+    """python.exe is a console executable: when Claude Code runs under a
+    windowless parent (the desktop app), every hook invocation makes Windows
+    allocate a VISIBLE console — and a gated call keeps it on screen until
+    the human decides. pythonw.exe (same dir, GUI subsystem) never allocates
+    one; the hook still talks over the pipes Claude Code attaches, and
+    hook_main tolerates absent std streams (fail-open). Pure function so the
+    swap is testable on any OS."""
+    if is_windows and py.lower().endswith("python.exe"):
+        pyw = os.path.join(os.path.dirname(py), "pythonw.exe")
+        if exists(pyw):
+            return pyw
+    return py
+
+
 def _hook_command(base: str) -> str:
-    py = sys.executable or "python3"
+    py = _windowless_python(sys.executable or "python3", os.name == "nt")
     return f"{py} -m clawmetry hook claude-code --base {base}"
 
 

--- a/tests/test_runtime_gates_and_hooks.py
+++ b/tests/test_runtime_gates_and_hooks.py
@@ -434,7 +434,10 @@ def test_cc_gate_install_merges_and_uninstall_removes_only_ours(cc_gate):
     cmd = ours["hooks"][0]["command"]
     assert ccg.HOOK_CMD_MARKER in cmd
     assert "--base http://127.0.0.1:8900" in cmd
-    assert cmd.startswith(sys.executable)
+    # On Windows the console python.exe is swapped for pythonw.exe so the
+    # hook never flashes (or parks) a console window under the desktop app.
+    assert cmd.startswith(
+        ccg._windowless_python(sys.executable, os.name == "nt"))
     assert ours["hooks"][0]["timeout"] == 120 + 60  # policy + buffer
     assert s["model"] == "opus"                     # rest of file untouched
     st = json.loads(open(ccg._STATE_PATH).read())
@@ -471,6 +474,24 @@ def test_cc_gate_install_merges_and_uninstall_removes_only_ours(cc_gate):
 
     # Uninstall again (no state) → no-op, never raises.
     ccg.gate_handler(False, [])
+
+
+def test_cc_gate_windowless_python_swap():
+    import clawmetry.claude_code_gate as ccg
+    py = r"C:\v\Scripts\python.exe"
+    pyw = r"C:\v\Scripts\pythonw.exe"
+    # Windows + pythonw present → swapped (case-insensitive on the exe name).
+    assert ccg._windowless_python(py, True, exists=lambda p: p == pyw) == pyw
+    assert ccg._windowless_python(
+        r"C:\v\Scripts\PYTHON.EXE", True,
+        exists=lambda p: p.lower() == pyw.lower(),
+    ).lower() == pyw.lower()
+    # pythonw missing → untouched.
+    assert ccg._windowless_python(py, True, exists=lambda p: False) == py
+    # Not python.exe (already pythonw, or a posix path) → untouched.
+    assert ccg._windowless_python(pyw, True, exists=lambda p: True) == pyw
+    assert ccg._windowless_python(
+        "/usr/bin/python3", False, exists=lambda p: True) == "/usr/bin/python3"
 
 
 def test_cc_gate_does_not_stack_on_manual_cloud_hook(cc_gate):


### PR DESCRIPTION
## Why

The PreToolUse approval-gate hook command was built from sys.executable, i.e. the venv's console-mode python.exe. When Claude Code runs under a windowless parent (the desktop app), every gated tool call (Bash, WebFetch, WebSearch) made Windows allocate a visible console window for the hook process. Worse, a call parked for approval kept that window on screen until the human decided (the hook timeout is policy window + buffer, up to 7 days). Users see terminal windows randomly popping up over the app.

## What

`_hook_command()` now swaps python.exe for the adjacent pythonw.exe (GUI subsystem, never allocates a console) via a pure, unit-tested helper `_windowless_python()`. Non-Windows installs and venvs without pythonw.exe are untouched. Existing installs self-heal: the installer refreshes any marker-matched entry whose command differs, on the next watcher tick.

## Verification

- 23/23 tests green in `tests/test_runtime_gates_and_hooks.py`; new assertions proven RED on the un-fixed module (revert -> red -> restore -> green).
- Live on the Windows lab install (0.12.679 venv, patched in place): `gate_handler(True, ...)` rewrote the real `~/.claude/settings.json` entry to the pythonw command, replacing the stale python.exe one.
- Hook client exercised under pythonw with explicit pipes (exactly how Claude Code spawns hooks): stdin/stdout pipes work (`subprocess.run(..., input=..., capture_output=True)` round-trip), and the real `-m clawmetry hook claude-code` fast path against an unreachable server read stdin, ran its retry loop, and failed open (rc=0, no output) per contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)