### PR TITLE
fix(banner): active trial no longer says 'Your trial ends today' while days remain

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -24692,13 +24692,16 @@ async function checkLicenseExpiry() {
     var e = await fetch('/api/entitlement', { credentials: 'same-origin' }).then(function (r) { return r.json(); });
     var expiredTrial = !!(e && e.expired && e.tier === 'trial');
     var expiredPaid = !!(e && e.expired && e.is_paid && e.tier !== 'trial');
-    // Trial ending (or already in grace): say it LOUD before the cliff,
-    // not after. days_until_expiry === 0 means "ends today"; grace means
-    // the expiry date passed and enforcement is pending. Both previously
-    // rendered nothing anywhere in the UI.
+    // Trial ending: say it LOUD before the cliff, not after.
+    // days_until_expiry === 0 means "ends today". `e.grace` must NOT
+    // gate this: it is the global paywall-rollout flag (true on every
+    // install until enforcement goes live), not a statement about this
+    // trial's expiry — keying on it made a freshly-activated 7-day
+    // trial read "ends today". A trial whose expiry actually passed
+    // surfaces via `e.expired` above.
     var days = (e && typeof e.days_until_expiry === 'number') ? e.days_until_expiry : null;
     var endingTrial = !!(e && !e.expired && e.tier === 'trial'
-      && (e.grace === true || (days !== null && days <= 3)));
+      && days !== null && days <= 3);
     if (!expiredTrial && !expiredPaid && !endingTrial) { banner.style.display = 'none'; return; }
     // A dismissed EXPIRED banner stays gone for 24h; a dismissed
     // countdown comes back after 4h — the clock is literally running.
@@ -24710,7 +24713,7 @@ async function checkLicenseExpiry() {
       msg.textContent = t('banners.license_expired_msg', null,
         'Your license has expired. Renew to keep every runtime.');
     } else if (msg && endingTrial) {
-      if (e.grace === true || days === null || days <= 0) {
+      if (days <= 0) {
         msg.textContent = t('banners.trial_ends_today_msg', null,
           'Your trial ends today. Upgrade now to keep every runtime — after that, this node drops to the free tier.');
       } else {

--- a/tests/test_expired_license_banner.py
+++ b/tests/test_expired_license_banner.py
@@ -63,6 +63,23 @@ def test_js_gates_on_expired_entitlement_only():
     assert "24 * 3600 * 1000" in block
 
 
+def test_js_never_keys_countdown_on_grace_flag():
+    """``grace`` on /api/entitlement is the GLOBAL paywall-rollout flag
+    (``not is_enforced()`` — true on every install until enforcement goes
+    live), not a per-trial expiry signal. Keying the countdown on it made
+    a freshly-activated 7-day trial read "Your trial ends today"
+    (2026-08-10 lab repro: license valid 6 more days, banner said ends
+    today next to the license email saying Aug 17)."""
+    js = _read("clawmetry/static/js/app.js")
+    anchor = js.find("async function checkLicenseExpiry")
+    assert anchor != -1
+    block = js[anchor:anchor + 3000]
+    assert "e.grace ===" not in block and "e.grace)" not in block, (
+        "the trial-countdown banner must never gate on the grace flag — "
+        "use days_until_expiry / expired only"
+    )
+
+
 def test_locale_keys_present_in_en():
     en = json.loads(_read("clawmetry/static/locales/en.json"))
     for key in ("banners.trial_expired_msg", "banners.license_expired_msg",


### PR DESCRIPTION
## Problem
A user with a freshly-activated self-hosted **trial license (6 days left, valid until Aug 17)** sees the red banner **"Your trial ends today. Upgrade now to keep every runtime"** right next to the license email saying Aug 17. Flatly contradictory trial messaging at the exact moment a trial user decides whether to pay.

## Root cause
`checkLicenseExpiry()` in `clawmetry/static/js/app.js` keyed the countdown on the entitlement's `grace` flag, misreading it as "expiry passed, enforcement pending". In reality `grace = not is_enforced()` (`clawmetry/entitlements.py:2366`) is the **global paywall-rollout flag**, true on every install until enforcement goes live. So every active trial rendered "ends today" regardless of `days_until_expiry`.

Live repro on the lab node (`/api/entitlement`): `tier=trial, source=license, expired=false, days_until_expiry=6, grace=true` -> banner said "ends today".

## Fix
Gate the countdown on `days_until_expiry` / `expired` only; drop `grace` from both the trigger and the message selection. A trial whose expiry actually passed still surfaces via `e.expired` (the expired-trial branch).

## Verification
- New guard test `test_js_never_keys_countdown_on_grace_flag` proved **red on un-fixed app.js, green after** (revert -> red -> restore -> green).
- Ran the old vs new predicate against the live node's real entitlement payload in the running dashboard: old logic shows "ends today", fixed logic shows no banner at 6 days remaining.
- `tests/test_expired_license_banner.py` all 5 pass; `node --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)