### PR TITLE
feat(entitlement): has_all_at + /api/entitlement/has-all-at

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -11455,6 +11455,122 @@ def min_tier_for_all_at(
         return None
 
 
+def has_all_at(
+    perspective_tier: str,
+    *,
+    features=None,
+    runtimes=None,
+    channels: int | None = None,
+    retention_days: int | None = None,
+    nodes: int | None = None,
+) -> bool:
+    """Hypothetical-perspective sibling of :func:`has_all`: would tier
+    ``perspective_tier`` grant **every** supplied axis in ONE mixed-bundle
+    fold?
+
+    Same relationship to :func:`has_all` that the singular ``_at`` scalars
+    (:func:`has_feature_at` / :func:`has_runtime_at` /
+    :func:`has_channel_count_at` / :func:`has_retention_window_at` /
+    :func:`has_node_count_at`) have to their current-perspective siblings:
+    the ``perspective_tier`` argument tells the fold which STATIC per-tier
+    grant to reason from, so a pricing-matrix cell can answer "would Pro
+    admit this whole bundle?" off ONE call instead of five singular
+    ``_at`` round-trips + a client-side AND-chain.
+
+    Fold rule: returns ``True`` iff every SUPPLIED axis' per-item ``_at``
+    gate returns ``True`` against ``perspective_tier``. Delegates per axis
+    to :func:`has_features_at` / :func:`has_runtimes_at` /
+    :func:`has_channel_count_at` / :func:`has_retention_window_at` /
+    :func:`has_node_count_at` so each axis inherits that scalar's typo /
+    empty / non-int / unknown-perspective posture without a divergent code
+    path here. **Grace-independent by construction**: every delegate is
+    backed by the static per-tier grant tables (via
+    :func:`_hypothetical_entitlement` on the feature / runtime axes and by
+    the static ``_TIER_CHANNEL_LIMIT`` / ``_TIER_RETENTION_DAYS`` /
+    ``_TIER_NODE_LIMIT`` tables on the capacity axes), so the answer is
+    identical under grace vs enforce for the same
+    (perspective, bundle) pair -- diverges deliberately from
+    :func:`has_all` (which grants every fully-known bundle in grace via
+    the live resolver's grace pass-through). Whole point of the ``_at``
+    slot is to render the would-be-locked state alongside the live grant.
+
+    Kwarg semantics mirror :func:`has_all` exactly (same signature so a
+    caller can pass identical kwargs to both helpers without a
+    re-normalise):
+
+    * ``features=None`` / ``runtimes=None`` -- axis unsupplied, skipped
+      entirely (contributes ``True`` to the fold).
+    * ``features=[]`` / ``runtimes=[]`` -- axis supplied but empty. This
+      COLLAPSES the fold to ``False`` for the same callsite-typo posture
+      :func:`has_features_at` / :func:`has_runtimes_at` carry on their
+      empty inputs.
+    * ``channels=None`` / ``retention_days=None`` / ``nodes=None`` --
+      axis unsupplied, skipped. Critically ``retention_days=None`` here
+      means *unset*, NOT *unlimited* -- matches :func:`has_all`.
+    * Non-int capacity value (str, list, ...) on ``channels`` / ``nodes``
+      / ``retention_days`` -- collapses the fold to ``False`` (mirrors
+      the singular ``_at`` capacity scalars' strict-``False`` typo
+      posture).
+    * No axes supplied at all -- returns ``False``. Matches
+      :func:`has_all` empty-``False`` posture so a caller who forgot to
+      pass any of the five kwargs sees the typo at the callsite instead
+      of a silent grant. Distinct from :func:`min_tier_for_all_at`
+      (returns ``None`` on the same input -- nothing-to-compute); here
+      the boolean seat collapses to strict ``False``.
+    * Unknown / empty / non-string ``perspective_tier`` -- returns
+      ``False``. Perspective validation lives on the OUTER helper (once
+      per call) rather than folding into per-item ``_at`` calls, so a
+      bogus perspective fails-closed in one place. Same fail-closed
+      posture as :func:`has_features_at` on an unknown perspective.
+    * Unknown / typo'd feature or runtime id in an otherwise-known
+      bundle -- collapses the whole fold to ``False`` via the singular
+      :func:`has_features_at` / :func:`has_runtimes_at` typo posture. A
+      UI wanting to distinguish "denied by tier" from "typo" should call
+      the per-axis singular ``_at`` scalars (or
+      :func:`min_tier_for_all_at`) for the per-axis story.
+
+    Never raises: any delegate failure logs a warning and returns
+    ``False`` so a caller can bind this into a boolean AND-chain without
+    a try/except.
+    """
+    try:
+        p = (perspective_tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return False
+    if not p or p not in _TIER_ORDER:
+        return False
+    try:
+        supplied_any = False
+        if features is not None:
+            supplied_any = True
+            if not has_features_at(p, features):
+                return False
+        if runtimes is not None:
+            supplied_any = True
+            if not has_runtimes_at(p, runtimes):
+                return False
+        if channels is not None:
+            supplied_any = True
+            if not has_channel_count_at(p, channels):
+                return False
+        if retention_days is not None:
+            supplied_any = True
+            if not has_retention_window_at(p, retention_days):
+                return False
+        if nodes is not None:
+            supplied_any = True
+            if not has_node_count_at(p, nodes):
+                return False
+        return supplied_any
+    except Exception as exc:
+        logger.warning(
+            "entitlements: has_all_at(%r, ...) failed: %s",
+            perspective_tier,
+            exc,
+        )
+        return False
+
+
 def _min_tier_for_all_bundle_row(bundle) -> dict:
     """Per-bundle row shape for :func:`min_tier_for_all_batch`.
 

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -8681,6 +8681,330 @@ def _has_all_body() -> dict:
     }
 
 
+_HAS_ALL_AT_KEYS = (
+    "perspective_tier",
+    "perspective_tier_label",
+    "perspective_tier_rank",
+    "features",
+    "runtimes",
+    "channels",
+    "retention_days",
+    "nodes",
+    "unknown_features",
+    "unknown_runtimes",
+    "supplied_axes",
+    "supplied_count",
+    "has_all_at",
+    "allowed",
+    "required_tier",
+    "required_tier_label",
+    "required_tier_rank",
+    "current_tier",
+    "current_tier_rank",
+    "grace",
+    "enforced",
+)
+
+
+def _has_all_at_fallback(perspective_tier: str) -> dict:
+    """Never-5xx envelope for ``/api/entitlement/has-all-at``.
+
+    Mirrors :func:`_has_all_fallback` on the LIVE sibling with the
+    perspective slot layered on top: on a resolver blowup the endpoint
+    still returns 200 with the same envelope shape as the happy path,
+    but ``has_all_at`` / ``allowed`` ``False`` and every axis empty so a
+    pricing-matrix cell that lost the resolver doesn't silently grant a
+    hypothetical bundle it can no longer evaluate.
+
+    ``perspective_tier_label`` / ``perspective_tier_rank`` fall back to
+    ``None`` / ``-1`` (matches the sibling ``min-tier-batch-at``
+    fallback envelope) so the envelope shape stays byte-stable across
+    every input branch, including the resolver-blowup fallback.
+    """
+    return {
+        "perspective_tier": perspective_tier,
+        "perspective_tier_label": None,
+        "perspective_tier_rank": -1,
+        "features": [],
+        "runtimes": [],
+        "channels": None,
+        "retention_days": None,
+        "nodes": None,
+        "unknown_features": [],
+        "unknown_runtimes": [],
+        "supplied_axes": [],
+        "supplied_count": 0,
+        "has_all_at": False,
+        "allowed": False,
+        "required_tier": None,
+        "required_tier_label": None,
+        "required_tier_rank": -1,
+        "current_tier": "oss",
+        "current_tier_rank": 0,
+        "grace": True,
+        "enforced": False,
+    }
+
+
+def _has_all_at_body(perspective_tier: str) -> dict:
+    """Happy-path body builder for ``/api/entitlement/has-all-at``.
+
+    Perspective-shaped sibling of :func:`_has_all_body`: applies the same
+    per-axis normalisation (CSV known/unknown split for features and
+    runtimes with runtime-alias canonicalisation; capacity axes parsed
+    via :func:`_parse_capacity_arg` so a blank / non-int value collapses
+    the axis to ``False`` in the fold) then delegates to
+    :func:`clawmetry.entitlements.has_all_at` against the SUPPLIED axis
+    values so this endpoint stays byte-parity with the module scalar.
+
+    Every axis is OPTIONAL -- a caller can supply any (or none) of the
+    five kwargs; the fold answers off just those axes and every
+    unsupplied axis is skipped (contributes ``True`` to the fold). The
+    envelope always carries every axis' slot for byte-stable shape
+    across every URL branch. No-axes-supplied collapses ``has_all_at``
+    to ``False`` (matches :func:`has_all_at` empty-``False`` posture
+    byte-for-byte).
+
+    Grace-independent by construction: :func:`has_all_at` delegates to
+    the static-per-tier ``_at`` singular scalars, so this endpoint's
+    ``has_all_at`` bit is IDENTICAL under grace vs enforce for the same
+    (perspective, bundle) pair -- diverges deliberately from the LIVE
+    ``/has-all`` sibling (which grants every fully-known bundle in
+    grace via the resolver's grace pass-through). Whole point of the
+    ``_at`` slot: ``/has-all-at?tier=oss&features=fleet`` returns
+    ``has_all_at=false`` even in grace (because OSS statically does not
+    grant ``fleet``), whereas LIVE ``/has-all?features=fleet`` reports
+    ``true`` for it via :attr:`Entitlement.grace` pass-through.
+
+    ``required_tier`` folds through
+    :func:`clawmetry.entitlements.min_tier_for_all` against the KNOWN-only
+    subsets for parity with the LIVE ``/api/entitlement/has-all``
+    envelope. Perspective-independent by design (delegates to
+    :func:`min_tier_for_all`, which walks the static per-tier caps);
+    matches ``min_tier_for_all_at``'s pinned parity contract.
+    """
+    from clawmetry import entitlements as _ent
+
+    features_raw = request.args.get("features")
+    runtimes_raw = request.args.get("runtimes")
+
+    known_features: list[str] = []
+    unknown_features: list[str] = []
+    features_supplied = features_raw is not None
+    if features_supplied:
+        for fid in _parse_csv_arg("features"):
+            if fid in _ent.ALL_FEATURES:
+                if fid not in known_features:
+                    known_features.append(fid)
+            elif fid not in unknown_features:
+                unknown_features.append(fid)
+
+    known_runtimes: list[str] = []
+    unknown_runtimes: list[str] = []
+    runtimes_supplied = runtimes_raw is not None
+    if runtimes_supplied:
+        for rid_raw in _parse_csv_arg("runtimes"):
+            rid = _ent.canonical_runtime(rid_raw) or rid_raw
+            if rid in _ent.ALL_RUNTIMES:
+                if rid not in known_runtimes:
+                    known_runtimes.append(rid)
+            elif rid_raw not in unknown_runtimes:
+                unknown_runtimes.append(rid_raw)
+
+    (
+        channels_present,
+        channels_ok,
+        channels_n,
+        _channels_raw,
+    ) = _parse_capacity_arg("channels")
+    (
+        retention_present,
+        retention_ok,
+        retention_n,
+        _retention_raw,
+    ) = _parse_capacity_arg("retention_days")
+    (
+        nodes_present,
+        nodes_ok,
+        nodes_n,
+        _nodes_raw,
+    ) = _parse_capacity_arg("nodes")
+
+    supplied_axes: list[str] = []
+    if features_supplied:
+        supplied_axes.append("features")
+    if runtimes_supplied:
+        supplied_axes.append("runtimes")
+    if channels_present:
+        supplied_axes.append("channels")
+    if retention_present:
+        supplied_axes.append("retention_days")
+    if nodes_present:
+        supplied_axes.append("nodes")
+
+    if (
+        (channels_present and not channels_ok)
+        or (retention_present and not retention_ok)
+        or (nodes_present and not nodes_ok)
+        or (features_supplied and (unknown_features or not known_features))
+        or (runtimes_supplied and (unknown_runtimes or not known_runtimes))
+    ):
+        has_flag = False
+    else:
+        has_flag = _ent.has_all_at(
+            perspective_tier,
+            features=known_features if features_supplied else None,
+            runtimes=known_runtimes if runtimes_supplied else None,
+            channels=channels_n if channels_present else None,
+            retention_days=retention_n if retention_present else None,
+            nodes=nodes_n if nodes_present else None,
+        )
+
+    required = _ent.min_tier_for_all(
+        features=known_features or None,
+        runtimes=known_runtimes or None,
+        channels=channels_n if channels_present and channels_ok else None,
+        retention_days=(
+            retention_n if retention_present and retention_ok else None
+        ),
+        nodes=nodes_n if nodes_present and nodes_ok else None,
+    )
+
+    env = _resolver_envelope(_ent)
+    required_label = _ent.tier_label(required) if required else None
+    req_rank = _ent.tier_rank(required) if required else -1
+
+    return {
+        "perspective_tier": perspective_tier,
+        "perspective_tier_label": _ent.tier_label(perspective_tier),
+        "perspective_tier_rank": _ent.tier_rank(perspective_tier),
+        "features": known_features,
+        "runtimes": known_runtimes,
+        "channels": channels_n if channels_present and channels_ok else None,
+        "retention_days": (
+            retention_n if retention_present and retention_ok else None
+        ),
+        "nodes": nodes_n if nodes_present and nodes_ok else None,
+        "unknown_features": unknown_features,
+        "unknown_runtimes": unknown_runtimes,
+        "supplied_axes": supplied_axes,
+        "supplied_count": len(supplied_axes),
+        "has_all_at": bool(has_flag),
+        "allowed": bool(has_flag),
+        "required_tier": required,
+        "required_tier_label": required_label,
+        "required_tier_rank": req_rank,
+        "current_tier": env["current_tier"],
+        "current_tier_rank": env["current_tier_rank"],
+        "grace": env["grace"],
+        "enforced": env["enforced"],
+    }
+
+
+@bp_entitlement.route("/api/entitlement/has-all-at")
+def api_entitlement_has_all_at():
+    """``GET /api/entitlement/has-all-at?tier=<perspective>
+    &features=a,b&runtimes=x,y&channels=5&retention_days=30&nodes=2`` --
+    hypothetical-perspective mixed-axis boolean-gate scalar.
+
+    Perspective-shaped sibling of ``/api/entitlement/has-all``: same
+    aggregate mixed-axis fold, but the boolean answers "would tier
+    ``<perspective>`` grant everything?" from the static per-tier grant
+    tables instead of "does the resolved entitlement grant everything
+    right now?" from the live resolver. A pricing-matrix walkthrough
+    that renders "if I were on Pro, this whole bundle would be
+    granted -- upgrade?" binds ``allowed`` directly off this URL per
+    perspective without switching the resolver.
+
+    Fills the ``_at`` slot on the mixed-axis rollup family alongside
+    :func:`min_tier_for_all_at` (scalar tier-id sibling) and the singular
+    ``_at`` scalars (``has_feature_at`` / ``has_runtime_at`` /
+    ``has_channel_count_at`` / ``has_retention_window_at`` /
+    ``has_node_count_at``), and completes the mixed-axis batch matrix
+    alongside ``/has-batch-at`` (per-row perspective sibling of
+    ``/has-batch``).
+
+    Every axis is OPTIONAL. Supply any non-empty subset; the fold
+    answers off just those axes and every unsupplied axis is skipped
+    (contributes ``True`` to the fold). Runtime-alias canonicalisation
+    (``claude-code`` -> ``claude_code``) is applied per token before
+    the known/unknown split. Capacity axes accept a single int (``5``);
+    blank / non-int values collapse ``has_all_at`` to ``False`` (matches
+    the singular capacity ``_at`` scalars' strict-``False`` typo
+    posture).
+
+    Perspective-shaped answers are **intentionally identical in grace
+    and enforce** (they read the static per-tier tables via the singular
+    ``_at`` delegates, not the resolver's ``grace`` bit) -- the whole
+    point of the ``_at`` slot: ``/has-all-at?tier=oss&features=fleet``
+    returns ``has_all_at=false`` even in grace (because OSS statically
+    does not grant ``fleet``), whereas the LIVE
+    ``/has-all?features=fleet`` reports ``true`` for it via
+    :attr:`Entitlement.grace` pass-through.
+
+    - **400** on missing / blank ``tier=``.
+    - **404** on unknown ``tier=`` (body carries ``which=tier``).
+    - **Never 4xxs** on axis-side inputs -- no axes supplied returns 200
+      with ``has_all_at=false`` (matches ``/has-all`` empty-``False``
+      posture); non-int capacity / unknown token collapses
+      ``has_all_at`` to ``False`` with the offending token surfaced via
+      ``unknown_features`` / ``unknown_runtimes``.
+    - **Never 5xxs**: a resolver / scalar / body-builder blowup yields
+      the fallback envelope with ``has_all_at=false`` so the pricing
+      walkthrough keeps rendering.
+
+    Envelope shape (21 keys, byte-stable across every input branch)::
+
+        {
+          "perspective_tier":       "cloud_pro",
+          "perspective_tier_label": "Pro",
+          "perspective_tier_rank":  <int>,
+          "features":               ["fleet"],           # known ids only
+          "runtimes":               ["claude_code"],     # canonicalised, known only
+          "channels":               5 | null,            # parsed int or null
+          "retention_days":         30 | null,
+          "nodes":                  2 | null,
+          "unknown_features":       ["bogus"],           # tokens not in ALL_FEATURES
+          "unknown_runtimes":       [],                  # tokens not in ALL_RUNTIMES
+          "supplied_axes":          ["features", "channels"],
+          "supplied_count":         2,
+          "has_all_at":             true,                # perspective boolean
+          "allowed":                true,                # alias of has_all_at
+          "required_tier":          "cloud_pro" | null,
+          "required_tier_label":    "Pro" | null,
+          "required_tier_rank":     <int>,               # -1 when null
+          "current_tier":           "oss",
+          "current_tier_rank":      0,
+          "grace":                  true,
+          "enforced":               false
+        }
+
+    Note the deliberate absence of ``upgrade_required``: this is the
+    perspective-shaped ``_at`` slot, so comparing against the LIVE
+    current-tier rank would double-count the perspective (matches the
+    singular ``/has-feature-at`` / ``/has-runtime-at`` / ``/has-batch-at``
+    siblings which omit it for the same reason).
+    """
+    raw_tier = request.args.get("tier")
+    tier_in = (raw_tier or "").strip().lower()
+    if not tier_in:
+        return jsonify({"error": "missing tier"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        if tier_in not in _ent._TIER_ORDER:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "tier", "tier": tier_in}
+                ),
+                404,
+            )
+        return jsonify(_has_all_at_body(tier_in))
+    except Exception as exc:
+        logger.warning("api_entitlement_has_all_at: error: %s", exc)
+        return jsonify(_has_all_at_fallback(tier_in))
+
+
 @bp_entitlement.route("/api/entitlement/has-all")
 def api_entitlement_has_all():
     """``GET /api/entitlement/has-all?features=a,b&runtimes=x,y&channels=5&retention_days=30&nodes=2``

--- a/tests/test_entitlement_has_all_at.py
+++ b/tests/test_entitlement_has_all_at.py
@@ -1,0 +1,915 @@
+"""Tests for the hypothetical-perspective mixed-axis ``has_all_at(...)``
+boolean-gate scalar and its paired ``/api/entitlement/has-all-at`` endpoint.
+
+Perspective-shaped sibling of :func:`clawmetry.entitlements.has_all` (which
+folds the same five kwargs against the LIVE resolver): a pricing-matrix
+walkthrough that gates on the full subscription state per hypothetical tier
+("if I were on Cloud Pro, would this whole bundle be granted?") binds ONE
+boolean per (perspective, bundle) cell off ONE call instead of five singular
+``_at`` round-trips + a client-side AND-chain.
+
+This file pins:
+
+1. Scalar fold under grace vs enforce for every combination of the five
+   axes (features / runtimes / channels / retention_days / nodes),
+   including per-axis empty / None / unknown / non-int inputs.
+2. Perspective validation (empty / non-string / unknown -> ``False`` at
+   the scalar; 400 / 404 at the endpoint).
+3. **Grace-independence invariant**: ``has_all_at(p, ...) ==
+   has_all_at(p, ...)`` under both grace and enforce for every ``p`` and
+   every input (delegates to the singular ``_at`` scalars, which are
+   backed by the static per-tier tables via
+   :func:`_hypothetical_entitlement`).
+4. Endpoint envelope shape parity (fixed 21-key set) across every input
+   branch so a frontend can bind fields off the URL without a branch on
+   the underlying resolver state.
+5. Never-4xx on axis-side inputs; 400 on missing / blank tier; 404 on
+   unknown tier; never 5xx.
+6. Cross-consistency with the singular ``/has-feature-at`` /
+   ``/has-runtime-at`` / ``/has-channel-count-at`` /
+   ``/has-retention-window-at`` / ``/has-node-count-at`` endpoints: for
+   any (perspective, single-axis) query, this endpoint's ``has_all_at``
+   equals the sibling scalar byte-for-byte.
+7. Scalar-vs-endpoint parity: the URL ``has_all_at`` value equals the
+   module-level scalar byte-for-byte on the same (parseable) input.
+8. Deliberate divergence from the LIVE ``/has-all`` sibling: a bundle
+   the resolver grants under grace can still report
+   ``has_all_at=false`` on the OSS perspective (that's the whole point
+   of the ``_at`` slot).
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+# -- Fixtures ------------------------------------------------------------------
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    """Fresh entitlements module in OSS-free-grace mode."""
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def enforced(monkeypatch, tmp_path):
+    """Enforcement-on fixture: ``CLAWMETRY_ENFORCE=1`` flips ``ent.grace``
+    off so the grace pass-through collapses. Perspective-shaped answers
+    are intentionally identical in grace and enforce; this fixture pins
+    that invariant."""
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    importlib.reload(e)
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# -- Envelope shape ------------------------------------------------------------
+
+_HAS_ALL_AT_KEYS = {
+    "perspective_tier",
+    "perspective_tier_label",
+    "perspective_tier_rank",
+    "features",
+    "runtimes",
+    "channels",
+    "retention_days",
+    "nodes",
+    "unknown_features",
+    "unknown_runtimes",
+    "supplied_axes",
+    "supplied_count",
+    "has_all_at",
+    "allowed",
+    "required_tier",
+    "required_tier_label",
+    "required_tier_rank",
+    "current_tier",
+    "current_tier_rank",
+    "grace",
+    "enforced",
+}
+
+
+def _get_json(client, url: str) -> dict:
+    resp = client.get(url)
+    assert resp.status_code == 200, url
+    return resp.get_json()
+
+
+# -- Scalar: perspective validation --------------------------------------------
+
+
+def test_has_all_at_unknown_perspective_is_false(ent):
+    assert ent.has_all_at("bogus", features=["fleet"]) is False
+
+
+def test_has_all_at_empty_perspective_is_false(ent):
+    assert ent.has_all_at("", features=["fleet"]) is False
+
+
+def test_has_all_at_none_perspective_is_false(ent):
+    assert ent.has_all_at(None, features=["fleet"]) is False  # type: ignore[arg-type]
+
+
+def test_has_all_at_non_string_perspective_is_false(ent):
+    assert ent.has_all_at(123, features=["fleet"]) is False  # type: ignore[arg-type]
+
+
+def test_has_all_at_perspective_case_and_whitespace_normalised(ent):
+    assert (
+        ent.has_all_at("  CLOUD_PRO  ", features=["fleet"])
+        == ent.has_all_at("cloud_pro", features=["fleet"])
+    )
+
+
+# -- Scalar: no axes supplied --------------------------------------------------
+
+
+def test_has_all_at_no_axes_supplied_is_false(ent):
+    """Nothing supplied collapses to False -- matches has_all."""
+    for tier in ent._TIER_ORDER:
+        assert ent.has_all_at(tier) is False, tier
+
+
+def test_has_all_at_no_axes_supplied_is_false_after_enforcement(enforced):
+    for tier in enforced._TIER_ORDER:
+        assert enforced.has_all_at(tier) is False, tier
+
+
+# -- Scalar: perspective-shaped semantics on free bundles ----------------------
+
+
+def test_has_all_at_oss_free_bundle_is_true(ent):
+    free_f = next(iter(ent.FREE_FEATURES))
+    free_r = next(iter(ent.FREE_RUNTIMES))
+    assert (
+        ent.has_all_at(
+            "oss",
+            features=[free_f],
+            runtimes=[free_r],
+            channels=1,
+            retention_days=1,
+            nodes=1,
+        )
+        is True
+    )
+
+
+def test_has_all_at_every_tier_admits_free_bundle(ent):
+    free_f = next(iter(ent.FREE_FEATURES))
+    free_r = next(iter(ent.FREE_RUNTIMES))
+    for tier in ent._TIER_ORDER:
+        assert (
+            ent.has_all_at(
+                tier,
+                features=[free_f],
+                runtimes=[free_r],
+                channels=1,
+                retention_days=1,
+                nodes=1,
+            )
+            is True
+        ), tier
+
+
+# -- Scalar: perspective-shaped semantics on paid bundles ----------------------
+
+
+def test_has_all_at_oss_denies_paid_feature(ent):
+    paid_f = next(iter(ent.PAID_FEATURES))
+    assert ent.has_all_at("oss", features=[paid_f]) is False
+
+
+def test_has_all_at_oss_denies_paid_runtime(ent):
+    paid_r = next(iter(ent.PAID_RUNTIMES))
+    assert ent.has_all_at("oss", runtimes=[paid_r]) is False
+
+
+def test_has_all_at_cloud_pro_admits_paid_bundle(ent):
+    paid_f = next(iter(ent.PAID_FEATURES))
+    paid_r = next(iter(ent.PAID_RUNTIMES))
+    assert (
+        ent.has_all_at(
+            "cloud_pro",
+            features=[paid_f],
+            runtimes=[paid_r],
+            channels=100,
+            retention_days=90,
+            nodes=1000,
+        )
+        is True
+    )
+
+
+def test_has_all_at_enterprise_admits_paid_bundle(ent):
+    paid_f = next(iter(ent.PAID_FEATURES))
+    paid_r = next(iter(ent.PAID_RUNTIMES))
+    assert (
+        ent.has_all_at(
+            "enterprise",
+            features=[paid_f],
+            runtimes=[paid_r],
+            channels=999,
+            retention_days=999,
+            nodes=99999,
+        )
+        is True
+    )
+
+
+# -- Scalar: grace-independence invariant --------------------------------------
+
+
+def test_has_all_at_grace_vs_enforce_byte_identical_on_oss(monkeypatch, tmp_path):
+    """The whole point of the ``_at`` slot: perspective-shaped answers
+    read the static per-tier tables and are grace-independent."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    paid_f = next(iter(e.PAID_FEATURES))
+    paid_r = next(iter(e.PAID_RUNTIMES))
+    grace = e.has_all_at(
+        "oss",
+        features=[paid_f],
+        runtimes=[paid_r],
+        channels=5,
+        retention_days=30,
+        nodes=2,
+    )
+
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    importlib.reload(e)
+    e.invalidate()
+    enforce = e.has_all_at(
+        "oss",
+        features=[paid_f],
+        runtimes=[paid_r],
+        channels=5,
+        retention_days=30,
+        nodes=2,
+    )
+    assert grace == enforce
+    assert grace is False
+
+
+def test_has_all_at_grace_vs_enforce_byte_identical_on_cloud_pro(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    paid_f = next(iter(e.PAID_FEATURES))
+    paid_r = next(iter(e.PAID_RUNTIMES))
+    grace = e.has_all_at(
+        "cloud_pro", features=[paid_f], runtimes=[paid_r], channels=5
+    )
+
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    importlib.reload(e)
+    e.invalidate()
+    enforce = e.has_all_at(
+        "cloud_pro", features=[paid_f], runtimes=[paid_r], channels=5
+    )
+    assert grace == enforce
+    assert grace is True
+
+
+# -- Scalar: divergence from live has_all in grace -----------------------------
+
+
+def test_has_all_diverges_from_has_all_at_on_oss_paid_bundle(ent):
+    """LIVE has_all reports True in grace; _at reports False from the
+    OSS perspective (static per-tier tables). Whole point of the slot."""
+    paid_f = next(iter(ent.PAID_FEATURES))
+    live = ent.has_all(features=[paid_f])
+    perspective = ent.has_all_at("oss", features=[paid_f])
+    assert live is True
+    assert perspective is False
+
+
+# -- Scalar: empty inputs on supplied axes -------------------------------------
+
+
+def test_has_all_at_features_empty_iterable_is_false(ent):
+    assert ent.has_all_at("cloud_pro", features=[]) is False
+    assert ent.has_all_at("cloud_pro", features=()) is False
+
+
+def test_has_all_at_runtimes_empty_iterable_is_false(ent):
+    assert ent.has_all_at("cloud_pro", runtimes=[]) is False
+
+
+def test_has_all_at_empty_features_supplied_denies_even_with_other_axes(ent):
+    assert ent.has_all_at("cloud_pro", features=[], channels=1) is False
+
+
+# -- Scalar: unknown / typo'd inputs -------------------------------------------
+
+
+def test_has_all_at_unknown_feature_collapses_fold(ent):
+    assert ent.has_all_at("cloud_pro", features=["fleet", "bogus_xyz"]) is False
+
+
+def test_has_all_at_unknown_runtime_collapses_fold(ent):
+    assert (
+        ent.has_all_at("cloud_pro", runtimes=["openclaw", "bogus_rt"]) is False
+    )
+
+
+def test_has_all_at_unknown_feature_wins_over_other_axes(ent):
+    assert (
+        ent.has_all_at(
+            "cloud_pro",
+            features=["bogus_xyz"],
+            runtimes=["openclaw"],
+            channels=1,
+        )
+        is False
+    )
+
+
+# -- Scalar: non-int capacity --------------------------------------------------
+
+
+def test_has_all_at_non_int_channels_is_false(ent):
+    assert ent.has_all_at("cloud_pro", channels="five") is False  # type: ignore[arg-type]
+
+
+def test_has_all_at_non_int_nodes_is_false(ent):
+    assert ent.has_all_at("cloud_pro", nodes="two") is False  # type: ignore[arg-type]
+
+
+def test_has_all_at_non_int_retention_is_false(ent):
+    assert ent.has_all_at("cloud_pro", retention_days="seven") is False  # type: ignore[arg-type]
+
+
+# -- Scalar: retention_days=None means unsupplied ------------------------------
+
+
+def test_has_all_at_retention_none_is_unsupplied_not_unlimited(ent):
+    assert ent.has_all_at("cloud_pro", channels=1, retention_days=None) is True
+    assert ent.has_all_at("cloud_pro", channels=1) is True
+
+
+# -- Scalar: never raises ------------------------------------------------------
+
+
+def test_has_all_at_never_raises_on_delegate_blowup(monkeypatch, ent):
+    def _boom(*a, **kw):
+        raise RuntimeError("delegate blowup")
+
+    monkeypatch.setattr(ent, "has_features_at", _boom)
+    assert ent.has_all_at("cloud_pro", features=["fleet"]) is False
+
+
+def test_has_all_at_never_raises_on_capacity_delegate_blowup(monkeypatch, ent):
+    def _boom(*a, **kw):
+        raise RuntimeError("blowup")
+
+    monkeypatch.setattr(ent, "has_channel_count_at", _boom)
+    assert ent.has_all_at("cloud_pro", channels=1) is False
+
+
+# -- Endpoint: perspective validation ------------------------------------------
+
+
+def test_endpoint_missing_tier_is_400(client):
+    resp = client.get("/api/entitlement/has-all-at")
+    assert resp.status_code == 400
+    assert resp.get_json() == {"error": "missing tier"}
+
+
+def test_endpoint_blank_tier_is_400(client):
+    resp = client.get("/api/entitlement/has-all-at?tier=&features=fleet")
+    assert resp.status_code == 400
+    assert resp.get_json() == {"error": "missing tier"}
+
+
+def test_endpoint_unknown_tier_is_404(client):
+    resp = client.get(
+        "/api/entitlement/has-all-at?tier=bogus_tier&features=fleet"
+    )
+    assert resp.status_code == 404
+    body = resp.get_json()
+    assert body["error"] == "unknown tier"
+    assert body["which"] == "tier"
+    assert body["tier"] == "bogus_tier"
+
+
+def test_endpoint_perspective_case_and_whitespace_normalised(client):
+    lower = _get_json(client, "/api/entitlement/has-all-at?tier=cloud_pro&features=fleet")
+    upper = _get_json(client, "/api/entitlement/has-all-at?tier=%20CLOUD_PRO%20&features=fleet")
+    assert upper["has_all_at"] == lower["has_all_at"]
+    assert upper["perspective_tier"] == "cloud_pro"
+
+
+# -- Endpoint: envelope shape --------------------------------------------------
+
+
+def test_endpoint_no_axes_shape(client):
+    body = _get_json(client, "/api/entitlement/has-all-at?tier=cloud_pro")
+    assert set(body.keys()) == _HAS_ALL_AT_KEYS
+    assert body["perspective_tier"] == "cloud_pro"
+    assert body["features"] == []
+    assert body["runtimes"] == []
+    assert body["channels"] is None
+    assert body["retention_days"] is None
+    assert body["nodes"] is None
+    assert body["unknown_features"] == []
+    assert body["unknown_runtimes"] == []
+    assert body["supplied_axes"] == []
+    assert body["supplied_count"] == 0
+    assert body["has_all_at"] is False
+    assert body["allowed"] is False
+
+
+def test_endpoint_all_free_axes_shape(client):
+    body = _get_json(
+        client,
+        "/api/entitlement/has-all-at?tier=oss"
+        "&features=nemo_governance&runtimes=openclaw"
+        "&channels=1&retention_days=1&nodes=1",
+    )
+    assert set(body.keys()) == _HAS_ALL_AT_KEYS
+    assert body["perspective_tier"] == "oss"
+    assert body["features"] == ["nemo_governance"]
+    assert body["runtimes"] == ["openclaw"]
+    assert body["channels"] == 1
+    assert body["retention_days"] == 1
+    assert body["nodes"] == 1
+    assert body["supplied_axes"] == [
+        "features",
+        "runtimes",
+        "channels",
+        "retention_days",
+        "nodes",
+    ]
+    assert body["supplied_count"] == 5
+    assert body["has_all_at"] is True
+    assert body["allowed"] is True
+
+
+def test_endpoint_paid_bundle_at_cloud_pro_is_true(client):
+    body = _get_json(
+        client,
+        "/api/entitlement/has-all-at?tier=cloud_pro"
+        "&features=fleet&runtimes=claude_code",
+    )
+    assert body["has_all_at"] is True
+    assert body["allowed"] is True
+
+
+def test_endpoint_paid_bundle_at_oss_is_false_even_in_grace(client):
+    body = _get_json(
+        client, "/api/entitlement/has-all-at?tier=oss&features=fleet"
+    )
+    assert body["has_all_at"] is False
+    assert body["allowed"] is False
+    assert body["grace"] is True
+
+
+def test_endpoint_supplied_axes_order_stable(client):
+    body = _get_json(
+        client,
+        "/api/entitlement/has-all-at?tier=cloud_pro&nodes=1&features=fleet"
+        "&channels=1&retention_days=1&runtimes=claude_code",
+    )
+    assert body["supplied_axes"] == [
+        "features",
+        "runtimes",
+        "channels",
+        "retention_days",
+        "nodes",
+    ]
+
+
+# -- Endpoint: unknown tokens --------------------------------------------------
+
+
+def test_endpoint_unknown_feature_collapses_bundle(client):
+    body = _get_json(
+        client,
+        "/api/entitlement/has-all-at?tier=cloud_pro"
+        "&features=fleet,totally_fake_xyz",
+    )
+    assert body["features"] == ["fleet"]
+    assert body["unknown_features"] == ["totally_fake_xyz"]
+    assert body["has_all_at"] is False
+    assert body["allowed"] is False
+
+
+def test_endpoint_unknown_runtime_collapses_bundle(client):
+    body = _get_json(
+        client,
+        "/api/entitlement/has-all-at?tier=cloud_pro"
+        "&runtimes=openclaw,totally_fake_rt",
+    )
+    assert body["runtimes"] == ["openclaw"]
+    assert body["unknown_runtimes"] == ["totally_fake_rt"]
+    assert body["has_all_at"] is False
+
+
+def test_endpoint_runtime_alias_canonicalises(client):
+    body = _get_json(
+        client,
+        "/api/entitlement/has-all-at?tier=cloud_pro"
+        "&runtimes=claude-code,claude_code",
+    )
+    assert body["runtimes"] == ["claude_code"]
+    assert body["unknown_runtimes"] == []
+    assert body["has_all_at"] is True
+
+
+# -- Endpoint: capacity axes ---------------------------------------------------
+
+
+def test_endpoint_non_int_channels_collapses_bundle(client):
+    body = _get_json(
+        client, "/api/entitlement/has-all-at?tier=cloud_pro&channels=five"
+    )
+    assert body["supplied_axes"] == ["channels"]
+    assert body["channels"] is None
+    assert body["has_all_at"] is False
+
+
+def test_endpoint_blank_channels_collapses_bundle(client):
+    body = _get_json(
+        client, "/api/entitlement/has-all-at?tier=cloud_pro&channels="
+    )
+    assert body["supplied_axes"] == ["channels"]
+    assert body["channels"] is None
+    assert body["has_all_at"] is False
+
+
+def test_endpoint_zero_channels_is_true(client):
+    body = _get_json(
+        client, "/api/entitlement/has-all-at?tier=cloud_pro&channels=0"
+    )
+    assert body["supplied_axes"] == ["channels"]
+    assert body["channels"] == 0
+    assert body["has_all_at"] is True
+
+
+def test_endpoint_oss_denies_five_nodes(client):
+    body = _get_json(
+        client, "/api/entitlement/has-all-at?tier=oss&nodes=5"
+    )
+    assert body["nodes"] == 5
+    assert body["has_all_at"] is False
+
+
+def test_endpoint_cloud_pro_admits_thousand_nodes(client):
+    body = _get_json(
+        client, "/api/entitlement/has-all-at?tier=cloud_pro&nodes=1000"
+    )
+    assert body["nodes"] == 1000
+    assert body["has_all_at"] is True
+
+
+# -- Endpoint: enforce mode has byte-stable rows -------------------------------
+
+
+def test_endpoint_perspective_grace_and_enforce_byte_identical(
+    monkeypatch, tmp_path
+):
+    """Perspective-shaped answers must be identical grace vs enforce
+    for the same (perspective, bundle) input."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    grace_client = app.test_client()
+    grace_body = grace_client.get(
+        "/api/entitlement/has-all-at?tier=cloud_pro"
+        "&features=fleet&runtimes=claude_code&channels=5"
+    ).get_json()
+
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    importlib.reload(e)
+    e.invalidate()
+    enforce_app = Flask(__name__)
+    enforce_app.register_blueprint(bp_entitlement)
+    enforce_body = enforce_app.test_client().get(
+        "/api/entitlement/has-all-at?tier=cloud_pro"
+        "&features=fleet&runtimes=claude_code&channels=5"
+    ).get_json()
+
+    assert grace_body["has_all_at"] == enforce_body["has_all_at"]
+    assert grace_body["perspective_tier"] == enforce_body["perspective_tier"]
+    assert grace_body["features"] == enforce_body["features"]
+    assert grace_body["runtimes"] == enforce_body["runtimes"]
+    assert grace_body["channels"] == enforce_body["channels"]
+    assert grace_body["required_tier"] == enforce_body["required_tier"]
+    assert grace_body["grace"] != enforce_body["grace"]
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+
+
+# -- Endpoint: never 5xx -------------------------------------------------------
+
+
+def test_endpoint_never_5xx_on_body_blowup(monkeypatch, client):
+    def _boom(*a, **kw):
+        raise RuntimeError("blowup in body builder")
+
+    monkeypatch.setattr("routes.entitlement._has_all_at_body", _boom)
+    resp = client.get(
+        "/api/entitlement/has-all-at?tier=cloud_pro&features=fleet&channels=5"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert set(body.keys()) == _HAS_ALL_AT_KEYS
+    assert body["has_all_at"] is False
+    assert body["allowed"] is False
+    assert body["perspective_tier"] == "cloud_pro"
+
+
+def test_endpoint_never_5xx_on_scalar_blowup(monkeypatch, client):
+    from clawmetry import entitlements as _ent
+
+    def _boom(*a, **kw):
+        raise RuntimeError("boom in scalar")
+
+    monkeypatch.setattr(_ent, "has_all_at", _boom)
+    resp = client.get(
+        "/api/entitlement/has-all-at?tier=cloud_pro&features=fleet"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert set(body.keys()) == _HAS_ALL_AT_KEYS
+    assert body["has_all_at"] is False
+
+
+# -- Endpoint: never 4xx on axis-side inputs (400 only on tier=) ---------------
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "/api/entitlement/has-all-at?tier=cloud_pro",
+        "/api/entitlement/has-all-at?tier=cloud_pro&features=",
+        "/api/entitlement/has-all-at?tier=cloud_pro&runtimes=",
+        "/api/entitlement/has-all-at?tier=cloud_pro&channels=",
+        "/api/entitlement/has-all-at?tier=cloud_pro&features=fleet&channels=notanint",
+        "/api/entitlement/has-all-at?tier=cloud_pro&features=bogus_only",
+        "/api/entitlement/has-all-at?tier=cloud_pro&features=fleet,,,",
+        "/api/entitlement/has-all-at?tier=oss&nodes=100",
+        "/api/entitlement/has-all-at?tier=trial&features=fleet",
+    ],
+)
+def test_endpoint_never_4xx_on_axis_side(client, url):
+    resp = client.get(url)
+    assert resp.status_code == 200, url
+    body = resp.get_json()
+    assert set(body.keys()) == _HAS_ALL_AT_KEYS
+
+
+# -- Endpoint: scalar-vs-endpoint parity ---------------------------------------
+
+
+@pytest.mark.parametrize(
+    "url,tier,features,runtimes,channels,retention_days,nodes",
+    [
+        (
+            "/api/entitlement/has-all-at?tier=oss&features=fleet",
+            "oss",
+            ["fleet"],
+            None,
+            None,
+            None,
+            None,
+        ),
+        (
+            "/api/entitlement/has-all-at?tier=cloud_pro&features=fleet&runtimes=claude_code",
+            "cloud_pro",
+            ["fleet"],
+            ["claude_code"],
+            None,
+            None,
+            None,
+        ),
+        (
+            "/api/entitlement/has-all-at?tier=oss&channels=5&nodes=2",
+            "oss",
+            None,
+            None,
+            5,
+            None,
+            2,
+        ),
+        (
+            "/api/entitlement/has-all-at?tier=oss&features=nemo_governance"
+            "&runtimes=openclaw&channels=1&retention_days=1&nodes=1",
+            "oss",
+            ["nemo_governance"],
+            ["openclaw"],
+            1,
+            1,
+            1,
+        ),
+        (
+            "/api/entitlement/has-all-at?tier=enterprise"
+            "&features=fleet,bogus_xyz",
+            "enterprise",
+            ["fleet", "bogus_xyz"],
+            None,
+            None,
+            None,
+            None,
+        ),
+    ],
+)
+def test_endpoint_matches_scalar(
+    client, ent, url, tier, features, runtimes, channels, retention_days, nodes
+):
+    body = _get_json(client, url)
+    expected = ent.has_all_at(
+        tier,
+        features=features,
+        runtimes=runtimes,
+        channels=channels,
+        retention_days=retention_days,
+        nodes=nodes,
+    )
+    assert body["has_all_at"] is expected
+    assert body["allowed"] is expected
+
+
+# -- Cross-consistency with singular _at endpoints -----------------------------
+
+
+@pytest.mark.parametrize(
+    "tier,feature",
+    [
+        ("oss", "fleet"),
+        ("cloud_pro", "fleet"),
+        ("enterprise", "sso"),
+    ],
+)
+def test_cross_consistent_with_has_feature_at(client, tier, feature):
+    all_body = _get_json(
+        client,
+        f"/api/entitlement/has-all-at?tier={tier}&features={feature}",
+    )
+    single = _get_json(
+        client,
+        f"/api/entitlement/has-feature-at?tier={tier}&feature={feature}",
+    )
+    assert all_body["has_all_at"] is single["has_feature_at"]
+
+
+@pytest.mark.parametrize(
+    "tier,runtime",
+    [
+        ("oss", "claude_code"),
+        ("cloud_pro", "claude_code"),
+        ("cloud_pro", "codex"),
+    ],
+)
+def test_cross_consistent_with_has_runtime_at(client, tier, runtime):
+    all_body = _get_json(
+        client,
+        f"/api/entitlement/has-all-at?tier={tier}&runtimes={runtime}",
+    )
+    single = _get_json(
+        client,
+        f"/api/entitlement/has-runtime-at?tier={tier}&runtime={runtime}",
+    )
+    assert all_body["has_all_at"] is single["has_runtime_at"]
+
+
+@pytest.mark.parametrize(
+    "tier,count",
+    [
+        ("oss", 1),
+        ("oss", 100),
+        ("cloud_pro", 5),
+        ("cloud_pro", 999),
+    ],
+)
+def test_cross_consistent_with_has_channel_count_at(client, tier, count):
+    all_body = _get_json(
+        client,
+        f"/api/entitlement/has-all-at?tier={tier}&channels={count}",
+    )
+    single = _get_json(
+        client,
+        f"/api/entitlement/has-channel-count-at?tier={tier}&count={count}",
+    )
+    assert all_body["has_all_at"] is single["has_channel_count_at"]
+
+
+@pytest.mark.parametrize(
+    "tier,count",
+    [
+        ("oss", 1),
+        ("oss", 5),
+        ("cloud_pro", 1000),
+    ],
+)
+def test_cross_consistent_with_has_node_count_at(client, tier, count):
+    all_body = _get_json(
+        client,
+        f"/api/entitlement/has-all-at?tier={tier}&nodes={count}",
+    )
+    single = _get_json(
+        client,
+        f"/api/entitlement/has-node-count-at?tier={tier}&count={count}",
+    )
+    assert all_body["has_all_at"] is single["has_node_count_at"]
+
+
+# -- Divergence from LIVE /has-all --------------------------------------------
+
+
+def test_divergence_from_live_has_all_on_oss_paid_feature(client):
+    """LIVE /has-all reports True in grace for a paid feature; /has-all-at
+    at OSS reports False (the whole point of the _at slot)."""
+    live = _get_json(client, "/api/entitlement/has-all?features=fleet")
+    perspective = _get_json(
+        client, "/api/entitlement/has-all-at?tier=oss&features=fleet"
+    )
+    assert live["has_all"] is True
+    assert perspective["has_all_at"] is False
+
+
+def test_agreement_with_live_has_all_when_perspective_matches_current(client):
+    """When perspective_tier == current_tier the boolean equals the LIVE
+    /has-all rollup byte-for-byte for the same fully-known bundle."""
+    live = _get_json(
+        client,
+        "/api/entitlement/has-all?features=nemo_governance&runtimes=openclaw",
+    )
+    cur = live["current_tier"]
+    perspective = _get_json(
+        client,
+        f"/api/entitlement/has-all-at?tier={cur}"
+        "&features=nemo_governance&runtimes=openclaw",
+    )
+    assert live["has_all"] is perspective["has_all_at"]
+
+
+# -- Envelope key set stability across every input branch ----------------------
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "/api/entitlement/has-all-at?tier=oss",
+        "/api/entitlement/has-all-at?tier=cloud_pro&features=fleet",
+        "/api/entitlement/has-all-at?tier=enterprise&features=fleet&runtimes=claude_code&channels=5&retention_days=30&nodes=100",
+        "/api/entitlement/has-all-at?tier=oss&features=bogus",
+        "/api/entitlement/has-all-at?tier=oss&channels=notanint",
+        "/api/entitlement/has-all-at?tier=trial&features=fleet",
+    ],
+)
+def test_envelope_keyset_stable(client, url):
+    body = _get_json(client, url)
+    assert set(body.keys()) == _HAS_ALL_AT_KEYS
+
+
+def test_envelope_omits_upgrade_required(client):
+    """Perspective-shaped ``_at`` slots deliberately omit
+    ``upgrade_required`` -- comparing against the LIVE current-tier
+    rank would double-count the perspective (matches the singular
+    ``/has-feature-at`` / ``/has-runtime-at`` siblings)."""
+    body = _get_json(
+        client, "/api/entitlement/has-all-at?tier=cloud_pro&features=fleet"
+    )
+    assert "upgrade_required" not in body


### PR DESCRIPTION
## Summary

Fills the missing perspective-shaped `_at` slot on the mixed-axis rollup family alongside `min_tier_for_all_at` (scalar tier-id sibling) and the singular `_at` scalars `has_feature_at` / `has_runtime_at` / `has_channel_count_at` / `has_retention_window_at` / `has_node_count_at`. Rollup twin of `has_batch_at` (per-row perspective mixed-axis sibling) — where the batch endpoint answers *"which axes in this bundle would tier `<perspective>` grant?"* per row, this endpoint folds the same bundle to ONE boolean.

- **`has_all_at(perspective_tier, *, features, runtimes, channels, retention_days, nodes)`** in `clawmetry/entitlements.py` — perspective-shaped mixed-axis boolean rollup. **Grace-independent by construction**: delegates per axis to the singular `_at` scalars which are backed by the static per-tier grant tables via `_hypothetical_entitlement` (features/runtimes) and the static `_TIER_CHANNEL_LIMIT` / `_TIER_RETENTION_DAYS` / `_TIER_NODE_LIMIT` tables (capacity axes). Fold rule mirrors `has_all` byte-for-byte (empty iterable / non-int / unknown token / no-axes-supplied all collapse to `False`); perspective validation lives on the OUTER helper (once per call) rather than folding into per-item calls, so a bogus perspective fails-closed in one place.

- **`GET /api/entitlement/has-all-at?tier=&features=&runtimes=&channels=&retention_days=&nodes=`** on `bp_entitlement`. Envelope mirrors `/has-all` byte-for-byte with the perspective copy (`perspective_tier` / `perspective_tier_label` / `perspective_tier_rank`) layered on top; keeps the same `has_all_at` / `allowed` rollup and the standard resolver envelope (`current_tier` / `current_tier_rank` / `grace` / `enforced`) so a walkthrough surface can render "if I were on `<perspective>`" alongside "you are here" off one call. **21-key envelope** (deliberately drops `upgrade_required` — comparing against LIVE current-tier rank would double-count the perspective; matches the singular `/has-feature-at` / `/has-runtime-at` / `/has-batch-at` siblings which omit it for the same reason).

Envelope + short-circuit posture:

- **400** on missing / blank `tier`.
- **404** on unknown `tier` (body carries `which=tier`).
- **Never 4xxs** on axis-side inputs — no axes supplied returns 200 with `has_all_at=false` (matches `/has-all` empty-`False` posture); non-int capacity / unknown token collapses `has_all_at` to `False` with the offending token surfaced via `unknown_features` / `unknown_runtimes`.
- **Never 5xxs** — resolver / scalar / body-builder blowup collapses to the fallback envelope with empty axes and `has_all_at=false`.

Behaviour ships in **GRACE** mode: the resolver still defaults to the OSS-free entitlement so no runtime gating changes. This is purely additive to the entitlement query surface. Perspective-shaped answers are intentionally identical in grace and enforce (they read the static per-tier tables via the singular `_at` delegates, not the resolver's `grace` bit) — the whole point of the `_at` slot: `/has-all-at?tier=oss&features=fleet` returns `has_all_at=false` even in grace (because OSS statically does not grant `fleet`), whereas LIVE `/has-all?features=fleet` reports `true` for it via the resolver's grace pass-through.

Cross-consistency parity tests keep the rollup output pinned byte-equal to the singular `has_feature_at` / `has_runtime_at` / `has_channel_count_at` / `has_node_count_at` scalars on every (perspective, single-axis) query, so any future contract change on either side has to update both.

## Test plan

- [x] `python3 -m py_compile clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_has_all_at.py`
- [x] `ruff check clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_has_all_at.py` — clean.
- [x] `python3 scripts/lint_daemon_allowlist.py` — passes (no `local_store_via_daemon` calls touched).
- [x] `python3 -m pytest tests/test_entitlement_has_all_at.py` — **84/84 pass**, covering: perspective validation (empty / non-string / unknown → `False` from scalar, 400 / 404 from endpoint), no-axes strict-`False` on every `_TIER_ORDER` perspective, per-axis empty iterable / unknown token / non-int capacity → `False`, per-axis singular delegation (`has_all_at(p, features=[free_f])` byte-equals `has_feature_at(p, free_f)`), free bundle admitted on every tier, paid bundle admitted on `cloud_pro` / `enterprise` and denied on `oss` / `cloud_starter`, **grace-vs-enforce byte-identical** invariant across both `oss` and `cloud_pro` perspectives (reloaded module fixtures), documented divergence from LIVE `has_all` on the OSS perspective (LIVE `True` in grace vs perspective `False`), perspective-tier normalisation (`  CLOUD_PRO  ` → `cloud_pro`), 21-key envelope stability across every input branch, no-axes → 200 with `False`, `/has-all-at?tier=cloud_pro&channels=` (blank) → 200 with `False`, `/has-all-at?tier=cloud_pro&channels=notanint` → 200 with `False`, `/has-all-at?tier=cloud_pro&features=bogus_only` → 200 with `False` + `unknown_features=["bogus_only"]`, runtime-alias canonicalisation (`claude-code` → `claude_code`) with dedup, `supplied_axes` in canonical order regardless of URL arg order, never-5xx on body / scalar blowup (monkeypatched to raise), 400 on missing / blank `tier`, 404 on unknown `tier` (body shape pinned), scalar↔endpoint parity across five parametric bundles, cross-consistency with the singular `/has-feature-at` / `/has-runtime-at` / `/has-channel-count-at` / `/has-node-count-at` endpoints (rollup `has_all_at` byte-equal to the single-axis `has_*_at` for every parametric case), agreement with LIVE `/has-all` when perspective matches current tier, absence of `upgrade_required` in the perspective envelope.
- [x] `python3 -m pytest tests/test_entitlement_has_all.py tests/test_entitlement_api.py tests/test_entitlement_min_tier.py` — **132/132 pass** (sibling regression: no envelope drift on the LIVE `/has-all` sibling, no shape drift on `/api/entitlement`, no floor drift on `min_tier_for_*` scalars).
- [x] `python3 -m pytest tests/ -k entitlement` — **9518/9518 pass** across the entitlement surface (the 8 collection errors in the sandbox are pre-existing `duckdb` module-import failures unrelated to this change; the entitlement suite itself is clean).

## Local operator verification checklist

Since this fire runs in an ephemeral cloud container with no access to your local daemon, `~/.openclaw`, the live cloud snapshot, or a browser, please verify against the running host once you pull this branch:

- [ ] Copy the two changed files into your live install:
  ```
  cp clawmetry/entitlements.py ~/.clawmetry/lib/python3.*/site-packages/clawmetry/
  cp routes/entitlement.py     ~/.clawmetry/lib/python3.*/site-packages/routes/
  find ~/.clawmetry/lib -name __pycache__ -type d -exec rm -rf {} +
  ```
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` to restart the daemon and pick up the new endpoint.
- [ ] `curl -s 'http://localhost:8900/api/entitlement/has-all-at?tier=oss&features=fleet' | jq .` — expect `has_all_at=false`, `allowed=false`, `perspective_tier="oss"`, `grace=true` (perspective-shaped: OSS statically does not grant `fleet`, even in grace).
- [ ] `curl -s 'http://localhost:8900/api/entitlement/has-all?features=fleet' | jq .has_all` — expect **`true`** for the same feature under the LIVE sibling (grace pass-through). Documents the deliberate divergence from `/has-all-at?tier=oss`.
- [ ] `curl -s 'http://localhost:8900/api/entitlement/has-all-at?tier=cloud_pro&features=fleet&runtimes=claude_code&channels=100&retention_days=90&nodes=1000' | jq .` — expect `has_all_at=true`, every axis populated (`features=["fleet"]`, `runtimes=["claude_code"]`, `channels=100`, `retention_days=90`, `nodes=1000`), `perspective_tier="cloud_pro"`.
- [ ] `curl -s 'http://localhost:8900/api/entitlement/has-all-at?tier=enterprise&features=sso&retention_days=999999' | jq '.has_all_at'` — expect **true** (Enterprise is the only tier that admits the unlimited retention window on the current tier table).
- [ ] `curl -sw '\n%{http_code}\n' 'http://localhost:8900/api/entitlement/has-all-at'` — expect **400** with `{"error":"missing tier"}`.
- [ ] `curl -sw '\n%{http_code}\n' 'http://localhost:8900/api/entitlement/has-all-at?tier=&features=fleet'` — expect **400** with `{"error":"missing tier"}`.
- [ ] `curl -sw '\n%{http_code}\n' 'http://localhost:8900/api/entitlement/has-all-at?tier=bogus&features=fleet'` — expect **404** with `{"error":"unknown tier","which":"tier","tier":"bogus"}`.
- [ ] `curl -sw '\n%{http_code}\n' 'http://localhost:8900/api/entitlement/has-all-at?tier=cloud_pro'` — expect **200** with `has_all_at=false`, `supplied_count=0` (no axes → strict `False`, matches `/has-all` empty posture).
- [ ] `curl -s 'http://localhost:8900/api/entitlement/has-all-at?tier=cloud_pro&runtimes=claude-code' | jq '.runtimes[0]'` — expect `"claude_code"` (alias canonicalisation matches the LIVE `/has-all` sibling).
- [ ] `curl -s 'http://localhost:8900/api/entitlement/has-all-at?tier=oss&features=fleet' | jq '.has_all_at'` — byte-equal to `curl -s 'http://localhost:8900/api/entitlement/has-feature-at?tier=oss&feature=fleet' | jq '.has_feature_at'` (cross-endpoint parity for the single-axis case).
- [ ] `curl -s 'http://localhost:8900/api/entitlement' | jq .grace` — expect **true** (nothing about the resolver / gate changed — this PR is purely additive query surface).
- [ ] Decrypt the live cloud snapshot in the browser and confirm the dashboard's entitlement panels still render (no shape regression).

This PR stays **DRAFT** until you've done the local + cloud verification above. Version bump / `[RELEASE]` PR / merge is your call.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BZKdDmwqNPFzdrbvLHQuoo)_