### PR TITLE
feat(tts): Fish Audio S2.1 cost backfill for tts.* events (#4724)

### DIFF
--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -6316,6 +6316,70 @@ class LocalStore:
             return 0
         return len(updates)
 
+    def backfill_tts_event_costs(self, *, batch: int = 5000) -> int:
+        """#4724: populate cost_usd for TTS voice events that arrived without it.
+
+        Fish Audio S2.1 (hosted) and other TTS providers bill per-character.
+        Voice events store char_count + provider in their data blob; this method
+        derives cost_usd via estimate_tts_cost_usd. Fish S2 Pro (isLocal=True)
+        and macOS Talk (local TTS) have no per-call API cost and are skipped.
+        Idempotent: only rows with cost_usd NULL/0 and char_count > 0 are
+        updated. Returns rows updated. Daemon-only (needs the writer connection)."""
+        try:
+            from clawmetry.providers_pricing import estimate_tts_cost_usd
+        except Exception:
+            return 0
+        try:
+            rows = self._conn.execute(
+                "SELECT id, data FROM events "
+                "WHERE (cost_usd IS NULL OR cost_usd = 0) "
+                "AND event_type LIKE 'tts.%' "
+                "LIMIT ?",
+                [int(batch)],
+            ).fetchall()
+        except Exception:
+            return 0
+        updates: list[tuple] = []
+        for (eid, data) in rows:
+            try:
+                if isinstance(data, (bytes, bytearray)):
+                    data = _ccr.maybe_decompress(data)
+                    data = bytes(data).decode("utf-8", "replace")
+                obj = json.loads(data) if isinstance(data, str) else data
+            except Exception:
+                continue
+            if not isinstance(obj, dict):
+                continue
+            # Skip local TTS (Fish S2 Pro, macOS Talk) — no API billing cost.
+            if obj.get("isLocal"):
+                continue
+            char_count = obj.get("char_count")
+            if not char_count:
+                continue
+            try:
+                char_count = int(char_count)
+            except (TypeError, ValueError):
+                continue
+            if char_count <= 0:
+                continue
+            # Resolve provider: explicit field first, fall back to ttsModel
+            # (Fish Audio events may carry either spelling).
+            provider = str(obj.get("provider") or obj.get("ttsModel") or "")
+            if not provider:
+                continue
+            cost = estimate_tts_cost_usd(provider, char_count)
+            if cost and cost > 0:
+                updates.append((float(cost), eid))
+        if not updates:
+            return 0
+        try:
+            self._conn.executemany(
+                "UPDATE events SET cost_usd = ? WHERE id = ?", updates
+            )
+        except Exception:
+            return 0
+        return len(updates)
+
     def backfill_benign_errors(self, *, after_id: str = "", batch: int = 5000):
         """#2196: clear the error flag on historical tool results whose body
         matches a known-benign signature (see ``clawmetry.error_signal``).

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -5744,6 +5744,11 @@ def sync_voice_log_events(config: dict, state: dict, paths: dict) -> int:
                             # are only present on tts.* records; None for others.
                             "char_count":  obj.get("char_count") or obj.get("characterCount") or obj.get("text_length"),
                             "voice_id":    obj.get("voice_id") or obj.get("voiceId"),
+                            # Fish Audio TTS fields (#4724): ttsModel and isLocal
+                            # are needed by backfill_tts_event_costs to route S2
+                            # Pro (local, $0) away from hosted S2.1 synthesis.
+                            "ttsModel":    obj.get("ttsModel") or obj.get("fishModel") or None,
+                            "isLocal":     obj.get("isLocal") if obj.get("isLocal") is not None else obj.get("is_local"),
                         }, separators=(",", ":")),
                     })
                 offsets[fname] = f.tell()
@@ -14648,6 +14653,30 @@ def _backfill_event_costs_once(store) -> None:
         log.debug("cost backfill failed: %s", _e)
 
 
+_tts_cost_backfill_done = False
+
+
+def _backfill_tts_event_costs_once(store) -> None:
+    """#4724: drain the TTS cost_usd backfill once per daemon process. Derives
+    cost from char_count × TTS provider rate for tts.* events that arrived with
+    cost_usd=NULL/0. Bounded batches; never raises."""
+    global _tts_cost_backfill_done
+    if _tts_cost_backfill_done:
+        return
+    _tts_cost_backfill_done = True
+    try:
+        total = 0
+        for _ in range(40):  # cap: 40 × 5000 = up to 200k rows / process
+            n = store.backfill_tts_event_costs(batch=5000)
+            total += n
+            if n < 5000:
+                break
+        if total:
+            log.info("TTS cost backfill: populated cost_usd for %d voice events (#4724)", total)
+    except Exception as _e:
+        log.debug("TTS cost backfill failed: %s", _e)
+
+
 _benign_backfill_done = False
 
 
@@ -14697,6 +14726,10 @@ def _build_daily_usage(days=14):
         # so the Cost tab showed ~$0). Runs once per process, on the daemon's
         # writer handle, draining in bounded batches before we read costs.
         _backfill_event_costs_once(store)
+        # #4724: one-time backfill of cost_usd for TTS voice events (tts.*)
+        # that carry char_count + provider but no pre-computed cost. Derives
+        # cost via estimate_tts_cost_usd (Fish Audio S2.1 = $0.015/1K chars).
+        _backfill_tts_event_costs_once(store)
         # #2196: one-time backfill to clear flagged-but-benign tool errors
         # (read-guards / transient timeouts) on history, so error counts match
         # the at-ingest correction. Same writer handle, bounded batches.

--- a/tests/test_tts_observability.py
+++ b/tests/test_tts_observability.py
@@ -85,6 +85,89 @@ def test_estimate_tts_cost_prefix_match():
     assert cost > 0.0, "Prefix-matched TTS provider should return non-zero cost"
 
 
+# ---------------------------------------------------------------------------
+# Fish Audio TTS pricing (#4724)
+# ---------------------------------------------------------------------------
+
+def test_estimate_tts_cost_fish_audio_hosted():
+    from clawmetry.providers_pricing import estimate_tts_cost_usd
+
+    # 1000 chars @ $0.015/1K = $0.015
+    cost = estimate_tts_cost_usd("fish-audio", 1000)
+    assert abs(cost - 0.015) < 1e-7, f"Fish Audio S2.1 1K chars should be $0.015, got {cost}"
+
+
+def test_estimate_tts_cost_fish_short_alias():
+    from clawmetry.providers_pricing import estimate_tts_cost_usd
+
+    cost = estimate_tts_cost_usd("fish", 1000)
+    assert abs(cost - 0.015) < 1e-7, f"'fish' alias 1K chars should be $0.015, got {cost}"
+
+
+def test_estimate_tts_cost_fish_s2_pro_local():
+    from clawmetry.providers_pricing import estimate_tts_cost_usd
+
+    # S2 Pro is self-hosted (local TTS) — no per-call API cost
+    cost = estimate_tts_cost_usd("fish-s2-pro", 5000)
+    assert cost == 0.0, f"Fish S2 Pro (local) should be $0.0, got {cost}"
+
+
+def test_tts_provider_rates_includes_fish_audio():
+    from clawmetry.providers_pricing import TTS_PROVIDER_RATES
+
+    assert "fish-audio" in TTS_PROVIDER_RATES, "fish-audio must be in TTS_PROVIDER_RATES"
+    assert TTS_PROVIDER_RATES["fish-audio"] > 0, "fish-audio rate must be positive"
+    assert "fish-s2-pro" in TTS_PROVIDER_RATES, "fish-s2-pro must be in TTS_PROVIDER_RATES"
+    assert TTS_PROVIDER_RATES["fish-s2-pro"] == 0.0, "fish-s2-pro (local) rate must be 0.0"
+
+
+def test_voice_event_data_captures_fish_audio_fields():
+    """The data blob written by sync_voice_log_events must carry ttsModel and
+    isLocal so backfill_tts_event_costs can route hosted vs local Fish Audio."""
+    import json
+
+    obj = {
+        "event_type": "tts.speak",
+        "provider":   "fish-audio",
+        "char_count": 800,
+        "ttsModel":   "fish-audio-s2.1",
+        "isLocal":    False,
+        "voice_id":   "en-US-Standard-A",
+    }
+    # Simulate the json.dumps call in sync_voice_log_events
+    data = {
+        "provider":   obj.get("provider"),
+        "char_count": obj.get("char_count") or obj.get("characterCount") or obj.get("text_length"),
+        "voice_id":   obj.get("voice_id") or obj.get("voiceId"),
+        "ttsModel":   obj.get("ttsModel") or obj.get("fishModel") or None,
+        "isLocal":    obj.get("isLocal") if obj.get("isLocal") is not None else obj.get("is_local"),
+    }
+    parsed = json.loads(json.dumps(data))
+    assert parsed.get("provider") == "fish-audio"
+    assert parsed.get("char_count") == 800
+    assert parsed.get("ttsModel") == "fish-audio-s2.1"
+    assert parsed.get("isLocal") is False
+
+
+def test_voice_event_data_fish_s2_pro_is_local():
+    """Fish S2 Pro events must have isLocal=True so the backfill skips them."""
+    import json
+
+    obj = {
+        "event_type": "tts.speak",
+        "char_count": 500,
+        "ttsModel":   "fish-s2-pro",
+        "isLocal":    True,
+    }
+    data = {
+        "ttsModel": obj.get("ttsModel") or obj.get("fishModel") or None,
+        "isLocal":  obj.get("isLocal") if obj.get("isLocal") is not None else obj.get("is_local"),
+        "char_count": obj.get("char_count"),
+    }
+    parsed = json.loads(json.dumps(data))
+    assert parsed.get("isLocal") is True, "Fish S2 Pro must carry isLocal=True"
+
+
 def test_tts_provider_rates_table_present():
     from clawmetry.providers_pricing import TTS_PROVIDER_RATES
 


### PR DESCRIPTION
## Summary

Fish Audio S2.1 TTS usage has been invisible on the Cost tab despite having correct pricing in `TTS_PROVIDER_RATES`. This PR closes the gap by wiring `char_count × rate → cost_usd` for all `tts.*` voice events, with Fish S2 Pro (local/self-hosted, $0) routed correctly away from hosted synthesis.

## Changes

- **`clawmetry/sync.py` — `sync_voice_log_events`**: Persist `ttsModel` and `isLocal` in the data blob stored for each voice event. These two fields were extracted by the adapter but not passed through to DuckDB, so the backfill had no way to distinguish hosted Fish S2.1 (`isLocal=False`) from local S2 Pro (`isLocal=True`).

- **`clawmetry/local_store.py` — new `backfill_tts_event_costs()`**: Parallel to the existing `backfill_event_costs()` for LLM tokens. Queries `tts.*` events where `cost_usd IS NULL OR cost_usd = 0`, reads `char_count` + `provider` (falling back to `ttsModel`) from the data blob, skips `isLocal=True` rows, calls `estimate_tts_cost_usd(provider, char_count)`, and writes `cost_usd`. Idempotent.

- **`clawmetry/sync.py` — `_backfill_tts_event_costs_once()` + wiring**: New one-shot sentinel matching `_backfill_event_costs_once()`. Called from `_build_daily_usage()` before cost reads, so historical Fish Audio sessions surface their real spend on the next daemon start.

- **`tests/test_tts_observability.py`**: 6 new assertions — hosted Fish Audio pricing ($0.015/1K), short `fish` alias, S2 Pro ($0.0), `TTS_PROVIDER_RATES` membership check, data-blob field capture for both hosted and local cases. All 18 tests pass.

## Test plan

- [x] `python3 -m pytest tests/test_tts_observability.py -v` — **18/18 pass**
- [x] `python3 -c 'import ast; ast.parse(open("clawmetry/sync.py").read())'` — clean
- [x] `python3 -c 'import ast; ast.parse(open("clawmetry/local_store.py").read())'` — clean
- [ ] Local verification: ingest a synthetic `tts.speak` event (`provider=fish-audio, char_count=1000`), call `store.backfill_tts_event_costs()`, confirm `cost_usd ≈ 0.015`
- [ ] Cost tab shows non-zero Fish Audio spend after a `launchctl kickstart` on a real install with Talk history

## Bot meta
<!-- bot-autofix -->
Draft PR opened autonomously based on the plan in #4724. Marked draft for human review — mark Ready for Review once happy.

Closes #4724

---
_Generated by [Claude Code](https://claude.ai/code/session_0163T3GFUE8bVaopzufLuBaF)_