### PR TITLE
feat(entitlement): has_all_at_batch + /api/entitlement/has-all-at-batch

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -11726,6 +11726,147 @@ def has_all_at(
         return False
 
 
+def has_all_at_batch(
+    perspective_tiers,
+    *,
+    features=None,
+    runtimes=None,
+    channels: int | None = None,
+    retention_days: int | None = None,
+    nodes: int | None = None,
+) -> dict:
+    """Batch what-if sibling of :func:`has_all_at`: would each caller-supplied
+    hypothetical tier grant the WHOLE mixed-axis bundle, in ONE round-trip.
+
+    Fixes ONE 5-axis bundle and sweeps across N perspective tiers, returning
+    one row per tier with the aggregate fold boolean plus the surrounding
+    tier envelope. Mixed-axis extension of :func:`has_features_at_batch` /
+    :func:`has_runtimes_at_batch` (which fold one axis at a time): where the
+    single-axis batch helpers answer "does each tier admit this feature/
+    runtime bundle?", this one answers "does each tier admit the whole
+    subscription state?" so a pricing-matrix column can hydrate the mixed-
+    axis grant off ONE call instead of five ``_at_batch`` round-trips + a
+    client-side AND-chain.
+
+    Fold rule per row: delegates to :func:`has_all_at` for that
+    ``(perspective_tier, bundle)`` pair -- inherits every axis's typo /
+    empty / non-int posture without a divergent code path here. **Grace-
+    independent by construction**: every per-row delegate is backed by the
+    static per-tier grant tables (via :func:`_hypothetical_entitlement` on
+    the feature / runtime axes and the static ``_TIER_CHANNEL_LIMIT`` /
+    ``_TIER_RETENTION_DAYS`` / ``_TIER_NODE_LIMIT`` tables on the capacity
+    axes), so the per-row answer is identical under grace vs enforce for
+    the same ``(perspective, bundle)`` pair. Whole point of the ``_at``
+    slot: ``has_all_at_batch(["oss", "cloud_pro"], features=["fleet"])``
+    reports ``has_all_at=False`` for the ``oss`` row even in grace
+    (because OSS statically does not grant ``fleet``).
+
+    Per-tier row shape mirrors :func:`has_features_at_batch` with
+    ``has_all_at`` in the fold slot::
+
+        {
+          "tier":         "<id>",
+          "tier_label":   "...",
+          "tier_rank":    <int>,
+          "has_all_at":   <bool>,
+        }
+
+    Envelope mirrors :func:`has_features_at_batch` byte-for-byte::
+
+        {
+          "tiers":   [<row>, ...],
+          "unknown": [<tier tokens dropped as unknown>, ...],
+        }
+
+    Each ``has_all_at`` byte-equals :func:`has_all_at` for the same
+    ``(tier, bundle)`` pair -- a parity test pins this so the scalar and
+    batch what-if aggregate helpers cannot drift.
+
+    Kwarg semantics mirror :func:`has_all_at` / :func:`has_all` exactly
+    (same 5-axis signature so a caller can pass identical kwargs to any of
+    the three helpers without a re-normalise):
+
+    * ``features=None`` / ``runtimes=None`` -- axis unsupplied, skipped
+      per-row (contributes ``True`` to each row's fold).
+    * ``features=[]`` / ``runtimes=[]`` -- axis supplied but empty. This
+      COLLAPSES every row's fold to ``False`` for the same callsite-typo
+      posture :func:`has_all_at` carries on its empty inputs.
+    * ``channels=None`` / ``retention_days=None`` / ``nodes=None`` --
+      axis unsupplied, skipped. Critically, ``retention_days=None``
+      means *unset*, NOT *unlimited*.
+    * Non-int capacity value (str, list, ...) on ``channels`` / ``nodes``
+      / ``retention_days`` -- collapses EVERY row's fold to ``False``
+      (mirrors :func:`has_all_at`'s strict-``False`` typo posture on the
+      same axis).
+    * No axes supplied at all -- every row's fold reports ``False``
+      (matches :func:`has_all_at` / :func:`has_all` empty-``False``
+      posture; a caller who forgot to pass any kwarg sees the typo at the
+      callsite instead of a silent grant on every tier column).
+    * Unknown / typo'd feature or runtime id in an otherwise-known bundle
+      -- collapses every row's fold to ``False`` via the singular
+      :func:`has_features_at` / :func:`has_runtimes_at` typo posture. A
+      UI wanting to distinguish "denied by tier" from "typo" should call
+      :func:`min_tier_for_all_batch` (per-bundle aggregate floor) or the
+      singular ``_at`` scalars for the per-axis story.
+
+    Tier normalisation is delegated to :func:`_normalise_csv` (whitespace
+    stripped, lowercased, dedup preserving first-seen; ``trial`` IS
+    accepted -- it lives in :data:`_TIER_ORDER`). Unknown tier ids are
+    echoed in ``unknown[]`` instead of short-circuiting so a partially-
+    bad caller still gets rows for the valid tiers alongside a list of
+    what was dropped -- matches :func:`has_features_at_batch` /
+    :func:`missing_features_at_batch` posture byte-for-byte.
+
+    Runtime-alias posture is inherited from :func:`has_runtimes_at`: no
+    scalar-level canonicalisation -- a raw ``"claude-code"`` surfaces as
+    ``False`` on every row because the strict scalar sees it as an
+    unknown id. Alias tolerance belongs to the paired
+    ``/api/entitlement/has-all-at-batch`` endpoint, which canonicalises
+    per-token upstream before delegating -- matches the sibling
+    :func:`has_runtimes_at_batch` /
+    ``/api/entitlement/has-runtimes-at-batch`` split exactly.
+
+    Empty / ``None`` / non-iterable ``perspective_tiers`` returns
+    ``{"tiers": [], "unknown": []}``.
+
+    Never raises: a per-tier delegate failure short-circuits that id into
+    ``unknown[]`` and the rest of the batch keeps building.
+    """
+    ids = _normalise_csv(perspective_tiers)
+    rows: list[dict] = []
+    unknown: list[str] = []
+    for tid in ids:
+        if tid not in _TIER_ORDER:
+            unknown.append(tid)
+            continue
+        try:
+            allowed = has_all_at(
+                tid,
+                features=features,
+                runtimes=runtimes,
+                channels=channels,
+                retention_days=retention_days,
+                nodes=nodes,
+            )
+        except Exception as exc:
+            logger.warning(
+                "entitlements: has_all_at_batch row %r failed: %s",
+                tid,
+                exc,
+            )
+            unknown.append(tid)
+            continue
+        rows.append(
+            {
+                "tier": tid,
+                "tier_label": tier_label(tid),
+                "tier_rank": _TIER_RANK.get(tid, -1),
+                "has_all_at": bool(allowed),
+            }
+        )
+    return {"tiers": rows, "unknown": unknown}
+
+
 def _min_tier_for_all_bundle_row(bundle) -> dict:
     """Per-bundle row shape for :func:`min_tier_for_all_batch`.
 

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -9005,6 +9005,406 @@ def api_entitlement_has_all_at():
         return jsonify(_has_all_at_fallback(tier_in))
 
 
+def _has_all_at_batch_fallback(
+    tier_tokens: list,
+    feature_tokens: list,
+    runtime_tokens: list,
+) -> dict:
+    """Never-5xx envelope for ``/api/entitlement/has-all-at-batch``.
+
+    Mixed-axis batch sibling of :func:`_has_all_at_fallback` (single-
+    perspective) and :func:`_has_bundle_at_batch_fallback` (single-axis
+    batch). On any resolver / helper blowup the endpoint still returns
+    200 with the same envelope shape as the happy path but with
+    ``tiers=[]`` and every fold-rollup fail-closed (``allowed_count=0`` /
+    ``all_allowed=False`` / ``any_allowed=False``) so a pricing-matrix
+    column that lost the resolver never silently renders a bundle grant
+    it can't verify. Caller-supplied tier / feature / runtime tokens
+    echo into ``unknown_tiers`` / ``unknown_features`` /
+    ``unknown_runtimes`` for debugging.
+    """
+    return {
+        "features": [],
+        "runtimes": [],
+        "channels": None,
+        "retention_days": None,
+        "nodes": None,
+        "unknown_features": list(feature_tokens),
+        "unknown_runtimes": list(runtime_tokens),
+        "unknown_tiers": list(tier_tokens),
+        "supplied_axes": [],
+        "supplied_count": 0,
+        "tiers": [],
+        "allowed_count": 0,
+        "all_allowed": False,
+        "any_allowed": False,
+        "required_tier": None,
+        "required_tier_label": None,
+        "required_tier_rank": -1,
+        "current_tier": "oss",
+        "current_tier_rank": 0,
+        "grace": True,
+        "enforced": False,
+    }
+
+
+def _has_all_at_batch_body() -> dict:
+    """Happy-path body builder for ``/api/entitlement/has-all-at-batch``.
+
+    Batch what-if sibling of :func:`_has_all_at_body`: where the single-
+    perspective ``/has-all-at`` folds ONE ``(perspective_tier, bundle)``
+    pair, this fixes the bundle and sweeps across N perspective tiers,
+    returning one row per tier with the aggregate mixed-axis fold boolean
+    plus the surrounding tier envelope. Mixed-axis extension of
+    :func:`_has_bundle_at_batch_body` (single-axis batch): where the
+    ``/has-features-at-batch`` / ``/has-runtimes-at-batch`` variants
+    answer "does each tier admit this single-axis bundle?", this one
+    answers "does each tier admit the whole subscription state?" so a
+    pricing-matrix column hydrates the mixed-axis grant off ONE URL
+    instead of five ``_at-batch`` round-trips + a client-side AND-chain.
+
+    Every axis is OPTIONAL -- a caller can supply any (or none) of the
+    five axis kwargs; the fold answers off just those axes per row and
+    every unsupplied axis is skipped (contributes ``True`` to each row's
+    fold). The envelope always carries every axis' slot for byte-stable
+    shape across every URL branch. No axes supplied collapses every
+    row's ``has_all_at`` to ``False`` (matches :func:`has_all_at` /
+    :func:`_has_all_at_body` empty-``False`` posture byte-for-byte).
+
+    Grace-independent by construction: :func:`has_all_at_batch`
+    delegates per-row to :func:`has_all_at`, which reads the static per-
+    tier grant tables via the singular ``_at`` scalars -- so each row's
+    ``has_all_at`` bit is IDENTICAL under grace vs enforce for the same
+    ``(row.tier, bundle)`` pair, and diverges deliberately from the LIVE
+    ``/has-all`` sibling (which grants every fully-known bundle in grace
+    via the resolver's grace pass-through). Whole point of the ``_at``
+    slot: ``/has-all-at-batch?tiers=oss,cloud_pro&features=fleet``
+    returns the ``oss`` row's ``has_all_at=false`` even in grace
+    (because OSS statically does not grant ``fleet``).
+
+    ``required_tier`` folds through
+    :func:`clawmetry.entitlements.min_tier_for_all` against the KNOWN-
+    only subsets for parity with the LIVE ``/api/entitlement/has-all``
+    envelope. Perspective-independent by design; the same bundle rollup
+    is also echoed into each row via ``required_tier`` /
+    ``required_tier_label`` / ``required_tier_rank`` so a per-row cell
+    can render "cheapest tier that unlocks this bundle" alongside
+    "granted at this row's tier" off one row bind.
+
+    Per-row ``upgrade_required`` compares the bundle-level
+    ``required_tier`` against each ROW's tier rank (not the live current
+    rank), matching the sibling :func:`_has_bundle_at_batch_body`
+    convention: a pricing-matrix row that binds this field reads "no
+    upgrade needed at this tier" vs "upgrade needed beyond this tier".
+
+    Runtime-alias canonicalisation is applied per-token upstream of the
+    strict scalar (:func:`has_all_at_batch` inherits the strict-scalar
+    posture from :func:`has_runtimes_at`), matching the sibling
+    :func:`_has_bundle_at_batch_body` upstream-canonicalise pattern
+    byte-for-byte (an alias-and-canonical pair dedups to ONE entry in
+    ``runtimes`` before the scalar sees it).
+
+    ``all_allowed`` folds row.allowed AND-wise (empty ``tiers`` ->
+    False to inherit the fail-closed fold posture the singular
+    :func:`has_all_at` uses on empty input). ``any_allowed`` folds
+    OR-wise (empty ``tiers`` -> False). ``allowed_count`` is the sum
+    of per-row boolean grants so a pricing-matrix header can render
+    "3 of 5 tiers grant this bundle" off one field.
+
+    An unknown token in the bundle (unknown feature id / unknown
+    runtime id / non-int capacity) collapses the endpoint-level fold
+    to ``False`` on EVERY row (matches the sibling
+    :func:`_has_bundle_at_batch_body` and :func:`_has_all_at_body`
+    posture: an ``unknown != []`` axis or a non-parseable capacity
+    denies every row).
+
+    Envelope shape (21 keys, byte-stable across every input branch)::
+
+        {
+          "features":            ["fleet"],           # known ids only
+          "runtimes":            ["claude_code"],     # canonicalised, known only
+          "channels":            5 | null,            # parsed int or null
+          "retention_days":      30 | null,
+          "nodes":               2 | null,
+          "unknown_features":    ["bogus"],           # tokens not in ALL_FEATURES
+          "unknown_runtimes":    [],                  # tokens not in ALL_RUNTIMES
+          "unknown_tiers":       ["bogus"],           # tier tokens dropped
+          "supplied_axes":       ["features", "channels"],
+          "supplied_count":      2,
+          "tiers": [
+            {
+              "tier":                "cloud_pro",
+              "tier_label":          "Pro",
+              "tier_rank":           <int>,
+              "has_all_at":          true,            # fold vs ROW's tier
+              "allowed":             true,            # alias of has_all_at
+              "required_tier":       "cloud_pro" | null,
+              "required_tier_label": "Pro" | null,
+              "required_tier_rank":  <int>,           # -1 when null
+              "upgrade_required":    <bool>           # req_rank > row.tier_rank
+            }, ...
+          ],
+          "allowed_count":       <int>,               # #rows with has_all_at=true
+          "all_allowed":         <bool>,              # every row granted
+          "any_allowed":         <bool>,              # at least one row granted
+          "required_tier":       "cloud_pro" | null,  # bundle-level rollup
+          "required_tier_label": "Pro" | null,
+          "required_tier_rank":  <int>,
+          "current_tier":        "<live tier id>",
+          "current_tier_rank":   <int>,
+          "grace":               <bool>,              # LIVE resolver grace bit
+          "enforced":            <bool>
+        }
+    """
+    from clawmetry import entitlements as _ent
+
+    tier_tokens = _parse_csv_arg("tiers")
+
+    features_raw = request.args.get("features")
+    runtimes_raw = request.args.get("runtimes")
+
+    known_features: list[str] = []
+    unknown_features: list[str] = []
+    features_supplied = features_raw is not None
+    if features_supplied:
+        for fid in _parse_csv_arg("features"):
+            if fid in _ent.ALL_FEATURES:
+                if fid not in known_features:
+                    known_features.append(fid)
+            elif fid not in unknown_features:
+                unknown_features.append(fid)
+
+    known_runtimes: list[str] = []
+    unknown_runtimes: list[str] = []
+    runtimes_supplied = runtimes_raw is not None
+    if runtimes_supplied:
+        for rid_raw in _parse_csv_arg("runtimes"):
+            rid = _ent.canonical_runtime(rid_raw) or rid_raw
+            if rid in _ent.ALL_RUNTIMES:
+                if rid not in known_runtimes:
+                    known_runtimes.append(rid)
+            elif rid_raw not in unknown_runtimes:
+                unknown_runtimes.append(rid_raw)
+
+    (
+        channels_present,
+        channels_ok,
+        channels_n,
+        _channels_raw,
+    ) = _parse_capacity_arg("channels")
+    (
+        retention_present,
+        retention_ok,
+        retention_n,
+        _retention_raw,
+    ) = _parse_capacity_arg("retention_days")
+    (
+        nodes_present,
+        nodes_ok,
+        nodes_n,
+        _nodes_raw,
+    ) = _parse_capacity_arg("nodes")
+
+    supplied_axes: list[str] = []
+    if features_supplied:
+        supplied_axes.append("features")
+    if runtimes_supplied:
+        supplied_axes.append("runtimes")
+    if channels_present:
+        supplied_axes.append("channels")
+    if retention_present:
+        supplied_axes.append("retention_days")
+    if nodes_present:
+        supplied_axes.append("nodes")
+
+    # An unknown token on ANY axis (or a non-int on a capacity axis)
+    # collapses the endpoint-level fold to ``False`` on every row --
+    # matches the sibling ``_has_all_at_body`` / ``_has_bundle_at_batch_body``
+    # posture so a paywall matrix can't silently render a grant for a
+    # bundle that already has a callsite typo in it.
+    endpoint_denies_all = (
+        (channels_present and not channels_ok)
+        or (retention_present and not retention_ok)
+        or (nodes_present and not nodes_ok)
+        or (features_supplied and (unknown_features or not known_features))
+        or (runtimes_supplied and (unknown_runtimes or not known_runtimes))
+    )
+
+    if endpoint_denies_all:
+        batch = {"tiers": [], "unknown": []}
+        # Still walk the tier tokens so ``unknown_tiers`` echoes the
+        # bogus perspective ids caller-side even when the bundle already
+        # denies every row -- keeps the envelope shape stable across
+        # every input branch and matches the sibling
+        # ``_has_bundle_at_batch_body`` upstream-canonicalise pattern.
+        for tid_raw in tier_tokens:
+            tid = (tid_raw or "").strip().lower()
+            if not tid or tid not in _ent._TIER_ORDER:
+                batch["unknown"].append(tid_raw)
+                continue
+            batch["tiers"].append(
+                {
+                    "tier": tid,
+                    "tier_label": _ent.tier_label(tid),
+                    "tier_rank": _ent._TIER_RANK.get(tid, -1),
+                    "has_all_at": False,
+                }
+            )
+    else:
+        batch = _ent.has_all_at_batch(
+            tier_tokens,
+            features=known_features if features_supplied else None,
+            runtimes=known_runtimes if runtimes_supplied else None,
+            channels=channels_n if channels_present else None,
+            retention_days=retention_n if retention_present else None,
+            nodes=nodes_n if nodes_present else None,
+        )
+
+    required = _ent.min_tier_for_all(
+        features=known_features or None,
+        runtimes=known_runtimes or None,
+        channels=channels_n if channels_present and channels_ok else None,
+        retention_days=(
+            retention_n if retention_present and retention_ok else None
+        ),
+        nodes=nodes_n if nodes_present and nodes_ok else None,
+    )
+
+    env = _resolver_envelope(_ent)
+    required_label = _ent.tier_label(required) if required else None
+    req_rank = _ent.tier_rank(required) if required else -1
+
+    tiers_out: list[dict] = []
+    for row in batch.get("tiers", []) or []:
+        try:
+            tid = row.get("tier")
+            row_allowed = bool(row.get("has_all_at", False))
+        except AttributeError:
+            continue
+        row_rank = row.get("tier_rank", _ent.tier_rank(tid))
+        upgrade_required = (
+            bool(required) and row_rank >= 0 and req_rank > row_rank
+        )
+        tiers_out.append(
+            {
+                "tier": tid,
+                "tier_label": row.get("tier_label", _ent.tier_label(tid)),
+                "tier_rank": row_rank,
+                "has_all_at": row_allowed,
+                "allowed": row_allowed,
+                "required_tier": required,
+                "required_tier_label": required_label,
+                "required_tier_rank": req_rank,
+                "upgrade_required": upgrade_required,
+            }
+        )
+
+    allowed_count = sum(1 for r in tiers_out if r["allowed"])
+    all_allowed = bool(tiers_out) and all(r["allowed"] for r in tiers_out)
+    any_allowed = any(r["allowed"] for r in tiers_out)
+
+    return {
+        "features": known_features,
+        "runtimes": known_runtimes,
+        "channels": channels_n if channels_present and channels_ok else None,
+        "retention_days": (
+            retention_n if retention_present and retention_ok else None
+        ),
+        "nodes": nodes_n if nodes_present and nodes_ok else None,
+        "unknown_features": unknown_features,
+        "unknown_runtimes": unknown_runtimes,
+        "unknown_tiers": list(batch.get("unknown", []) or []),
+        "supplied_axes": supplied_axes,
+        "supplied_count": len(supplied_axes),
+        "tiers": tiers_out,
+        "allowed_count": allowed_count,
+        "all_allowed": all_allowed,
+        "any_allowed": any_allowed,
+        "required_tier": required,
+        "required_tier_label": required_label,
+        "required_tier_rank": req_rank,
+        "current_tier": env["current_tier"],
+        "current_tier_rank": env["current_tier_rank"],
+        "grace": env["grace"],
+        "enforced": env["enforced"],
+    }
+
+
+@bp_entitlement.route("/api/entitlement/has-all-at-batch")
+def api_entitlement_has_all_at_batch():
+    """``GET /api/entitlement/has-all-at-batch?tiers=<a,b,...>
+    &features=<x,y,...>&runtimes=<r,s,...>&channels=N&retention_days=K
+    &nodes=M`` -- batch what-if sibling of ``/api/entitlement/has-all-at``.
+
+    Fixes ONE mixed-axis bundle and sweeps across N perspective tiers,
+    returning one row per tier with the aggregate mixed-axis fold boolean
+    plus the surrounding tier envelope. Mixed-axis extension of
+    ``/api/entitlement/has-features-at-batch`` /
+    ``/api/entitlement/has-runtimes-at-batch`` (single-axis batch): a
+    pricing-matrix column ("does OSS admit fleet + claude_code + 100
+    channels + 90d retention + 100 nodes? Starter? Cloud Pro? Enterprise?")
+    hydrates the whole column off ONE URL instead of five ``_at-batch``
+    round-trips + a client-side AND-chain. Fills the ``_at_batch`` slot
+    on the mixed-axis rollup family alongside :func:`has_all_at` (the
+    singular per-perspective scalar) and :func:`min_tier_for_all_at_batch`
+    (the reverse-lookup batch sibling).
+
+    Every axis is OPTIONAL. Supply any non-empty subset; the fold answers
+    off just those axes per row and every unsupplied axis is skipped
+    (contributes ``True`` to each row's fold). Runtime-alias
+    canonicalisation (``claude-code`` -> ``claude_code``) is applied per
+    token upstream of the strict scalar. Capacity axes accept a single
+    int (``5``); blank / non-int values collapse every row's
+    ``has_all_at`` to ``False`` (matches the singular capacity ``_at``
+    scalars' strict-``False`` typo posture).
+
+    Perspective-shaped answers are **intentionally identical in grace
+    and enforce** (they read the static per-tier tables via the singular
+    ``_at`` delegates, not the resolver's ``grace`` bit) -- the whole
+    point of the ``_at`` slot:
+    ``/has-all-at-batch?tiers=oss,cloud_pro&features=fleet`` returns the
+    ``oss`` row's ``has_all_at=false`` even in grace (because OSS
+    statically does not grant ``fleet``), whereas the LIVE
+    ``/has-all?features=fleet`` reports ``true`` for it via
+    :attr:`Entitlement.grace` pass-through.
+
+    - **Never 4xxs** on any input branch: missing / blank / all-unknown
+      ``tiers=`` returns 200 with ``tiers=[]`` (matches the sibling
+      ``/has-features-at-batch`` posture -- a paywall matrix binds
+      ``tiers`` directly without a pre-validation round-trip). No axes
+      supplied returns 200 with ``tiers`` still populated but every
+      row's ``has_all_at=false`` (matches the singular
+      ``/has-all-at`` empty-``False`` posture). Unknown token / non-int
+      capacity in the bundle collapses every row to ``False`` with the
+      offending token surfaced via ``unknown_features`` /
+      ``unknown_runtimes``.
+    - **Never 5xxs**: a resolver / scalar / body-builder blowup yields
+      the fallback envelope with ``tiers=[]`` so the pricing walkthrough
+      keeps rendering.
+
+    Envelope shape is fully documented on :func:`_has_all_at_batch_body`.
+
+    Per-row parity is pinned by tests: each row's ``has_all_at`` byte-
+    equals :func:`has_all_at` for the same ``(row.tier, bundle)`` pair,
+    and byte-equals ``/api/entitlement/has-all-at?tier=<row.tier>&...``'s
+    ``has_all_at`` on the same bundle -- so any future contract change
+    on either side has to update both.
+    """
+    try:
+        return jsonify(_has_all_at_batch_body())
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_has_all_at_batch: error: %s", exc
+        )
+        return jsonify(
+            _has_all_at_batch_fallback(
+                _parse_csv_arg("tiers"),
+                _parse_csv_arg("features"),
+                _parse_csv_arg("runtimes"),
+            )
+        )
+
+
 @bp_entitlement.route("/api/entitlement/has-all")
 def api_entitlement_has_all():
     """``GET /api/entitlement/has-all?features=a,b&runtimes=x,y&channels=5&retention_days=30&nodes=2``

--- a/tests/test_entitlement_has_all_at_batch.py
+++ b/tests/test_entitlement_has_all_at_batch.py
@@ -1,0 +1,848 @@
+"""Tests for the batch what-if mixed-axis ``has_all_at_batch`` boolean-fold
+scalar and its paired ``/api/entitlement/has-all-at-batch`` endpoint.
+
+Batch what-if sibling of :func:`has_all_at` (single perspective, mixed-axis
+fold) in the same relationship :func:`has_features_at_batch` /
+:func:`has_runtimes_at_batch` have to :func:`has_features_at` /
+:func:`has_runtimes_at`: fixes ONE mixed-axis bundle and sweeps across N
+perspective tiers, returning one row per tier with the aggregate mixed-
+axis fold boolean so a pricing-matrix column ("does OSS admit fleet +
+claude_code + 100 channels + 90d retention + 100 nodes? Starter? Cloud
+Pro? Enterprise?") hydrates off ONE call instead of five ``_at-batch``
+round-trips + a client-side AND-chain.
+
+This file pins:
+
+1. Scalar envelope shape ({tiers, unknown}) + per-row shape (4 keys) stable
+   across every input branch.
+2. Per-row ``has_all_at`` byte-parity with :func:`has_all_at` scalar on
+   every ``_TIER_ORDER`` perspective and every axis combination.
+3. Tier normalisation via :func:`_normalise_csv` (whitespace / case /
+   dedup) at the scalar layer; unknown tier ids bucket into ``unknown[]``
+   without short-circuiting the batch.
+4. Empty / None / non-iterable ``perspective_tiers`` -> stable empty
+   ``{tiers: [], unknown: []}`` envelope.
+5. Grace-independence invariant: scalar returns byte-identical rows under
+   grace vs enforce for every ``(perspectives, bundle)`` pair.
+6. Runtime scalar-alias posture: no scalar-level canonicalisation (matches
+   :func:`has_runtimes_at`); alias tolerance belongs to the endpoint.
+7. Kwarg semantics mirror :func:`has_all_at`: unsupplied axis skipped;
+   empty features/runtimes list -> every row False; non-int capacity ->
+   every row False; no axes supplied -> every row False.
+8. Endpoint envelope shape (fixed 21-key set) + per-row shape (9-key set)
+   stable across every input branch.
+9. Runtime-alias canonicalisation applied per-token upstream at the
+   endpoint layer (``?runtimes=claude-code`` -> canonical ``claude_code``).
+10. Never-4xx on any input (missing / blank / unknown tiers or bundle -
+    always 200); never-5xx: monkeypatch scalar / resolver blowup collapses
+    to :func:`_has_all_at_batch_fallback`.
+11. Scalar-vs-endpoint parity: per-row endpoint ``has_all_at`` byte-equals
+    the scalar's ``has_all_at`` on the same ``(tier, bundle)`` pair
+    (modulo the endpoint's unknown-collapse fold, which is documented).
+12. Cross-endpoint parity vs sibling ``/has-all-at``: for any
+    ``(perspective, bundle)`` cell, this endpoint's per-row ``has_all_at``
+    equals ``/has-all-at?tier=<row.tier>&<bundle>``'s ``has_all_at``.
+13. Cross-endpoint parity vs the single-axis batch siblings
+    ``/has-features-at-batch`` / ``/has-runtimes-at-batch``: for a
+    single-axis bundle, per-row ``has_all_at`` equals sibling's per-row
+    ``has_features_at`` / ``has_runtimes_at``.
+14. Deliberate divergence from the LIVE ``/has-all`` sibling: on the OSS
+    perspective and a paid-feature bundle, ``has_all_at=false`` even in
+    grace (that's the whole point of the ``_at`` slot).
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    """Fresh entitlements module in OSS-free-grace mode. The batch what-if
+    scalars are grace-independent by construction (they delegate to
+    :func:`has_all_at`, which is backed by the static per-tier tables)."""
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def enforced(monkeypatch, tmp_path):
+    """Enforcement-on fixture -- pins the grace-independence contract."""
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    importlib.reload(e)
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# ── Envelope shape constants ──────────────────────────────────────────────
+
+
+_SCALAR_ENVELOPE_KEYS = {"tiers", "unknown"}
+_SCALAR_ROW_KEYS = {"tier", "tier_label", "tier_rank", "has_all_at"}
+
+_ENDPOINT_ENVELOPE_KEYS = {
+    "features",
+    "runtimes",
+    "channels",
+    "retention_days",
+    "nodes",
+    "unknown_features",
+    "unknown_runtimes",
+    "unknown_tiers",
+    "supplied_axes",
+    "supplied_count",
+    "tiers",
+    "allowed_count",
+    "all_allowed",
+    "any_allowed",
+    "required_tier",
+    "required_tier_label",
+    "required_tier_rank",
+    "current_tier",
+    "current_tier_rank",
+    "grace",
+    "enforced",
+}
+_ENDPOINT_ROW_KEYS = {
+    "tier",
+    "tier_label",
+    "tier_rank",
+    "has_all_at",
+    "allowed",
+    "required_tier",
+    "required_tier_label",
+    "required_tier_rank",
+    "upgrade_required",
+}
+
+
+def _get_json(client, url: str) -> dict:
+    resp = client.get(url)
+    assert resp.status_code == 200, (url, resp.status_code, resp.data[:200])
+    return resp.get_json()
+
+
+def _paid_feature(ent) -> str:
+    for f in sorted(ent.PAID_FEATURES):
+        return f
+    pytest.skip("no paid features on this build")
+
+
+def _paid_runtime(ent) -> str:
+    for rt in sorted(ent.PAID_RUNTIMES):
+        return rt
+    pytest.skip("no paid runtimes on this build")
+
+
+# ── Scalar: envelope shape ────────────────────────────────────────────────
+
+
+def test_scalar_envelope_shape_stable_features(ent):
+    r = ent.has_all_at_batch(["oss", "cloud_pro"], features=["fleet"])
+    assert set(r) == _SCALAR_ENVELOPE_KEYS
+    for row in r["tiers"]:
+        assert set(row) == _SCALAR_ROW_KEYS
+
+
+def test_scalar_envelope_shape_stable_runtimes(ent):
+    r = ent.has_all_at_batch(["oss", "cloud_pro"], runtimes=["openclaw"])
+    assert set(r) == _SCALAR_ENVELOPE_KEYS
+    for row in r["tiers"]:
+        assert set(row) == _SCALAR_ROW_KEYS
+
+
+def test_scalar_envelope_shape_stable_capacity(ent):
+    r = ent.has_all_at_batch(["oss", "cloud_pro"], channels=1)
+    assert set(r) == _SCALAR_ENVELOPE_KEYS
+    for row in r["tiers"]:
+        assert set(row) == _SCALAR_ROW_KEYS
+
+
+def test_scalar_envelope_shape_stable_mixed(ent):
+    r = ent.has_all_at_batch(
+        ["oss", "cloud_pro"],
+        features=["fleet"],
+        runtimes=["openclaw"],
+        channels=1,
+        retention_days=1,
+        nodes=1,
+    )
+    assert set(r) == _SCALAR_ENVELOPE_KEYS
+    for row in r["tiers"]:
+        assert set(row) == _SCALAR_ROW_KEYS
+
+
+def test_scalar_envelope_shape_stable_empty(ent):
+    r = ent.has_all_at_batch([])
+    assert r == {"tiers": [], "unknown": []}
+
+
+# ── Scalar: per-row parity with has_all_at singular ───────────────────────
+
+
+def test_scalar_row_parity_features_only(ent):
+    paid = _paid_feature(ent)
+    tiers = list(ent._TIER_ORDER)
+    r = ent.has_all_at_batch(tiers, features=[paid])
+    for row in r["tiers"]:
+        assert row["has_all_at"] == ent.has_all_at(
+            row["tier"], features=[paid]
+        ), row
+
+
+def test_scalar_row_parity_runtimes_only(ent):
+    paid = _paid_runtime(ent)
+    tiers = list(ent._TIER_ORDER)
+    r = ent.has_all_at_batch(tiers, runtimes=[paid])
+    for row in r["tiers"]:
+        assert row["has_all_at"] == ent.has_all_at(
+            row["tier"], runtimes=[paid]
+        ), row
+
+
+def test_scalar_row_parity_capacity_channels(ent):
+    tiers = list(ent._TIER_ORDER)
+    for count in (0, 1, 5, 50, 999):
+        r = ent.has_all_at_batch(tiers, channels=count)
+        for row in r["tiers"]:
+            assert row["has_all_at"] == ent.has_all_at(
+                row["tier"], channels=count
+            ), (row, count)
+
+
+def test_scalar_row_parity_capacity_retention(ent):
+    tiers = list(ent._TIER_ORDER)
+    for days in (1, 30, 90, 365):
+        r = ent.has_all_at_batch(tiers, retention_days=days)
+        for row in r["tiers"]:
+            assert row["has_all_at"] == ent.has_all_at(
+                row["tier"], retention_days=days
+            ), (row, days)
+
+
+def test_scalar_row_parity_capacity_nodes(ent):
+    tiers = list(ent._TIER_ORDER)
+    for count in (1, 2, 10, 100):
+        r = ent.has_all_at_batch(tiers, nodes=count)
+        for row in r["tiers"]:
+            assert row["has_all_at"] == ent.has_all_at(
+                row["tier"], nodes=count
+            ), (row, count)
+
+
+def test_scalar_row_parity_mixed_bundle(ent):
+    paid_f = _paid_feature(ent)
+    paid_r = _paid_runtime(ent)
+    tiers = list(ent._TIER_ORDER)
+    kwargs = dict(
+        features=[paid_f],
+        runtimes=[paid_r],
+        channels=100,
+        retention_days=90,
+        nodes=100,
+    )
+    r = ent.has_all_at_batch(tiers, **kwargs)
+    for row in r["tiers"]:
+        assert row["has_all_at"] == ent.has_all_at(row["tier"], **kwargs), row
+
+
+def test_scalar_row_label_and_rank_match_helpers(ent):
+    r = ent.has_all_at_batch(list(ent._TIER_ORDER), features=["fleet"])
+    for row in r["tiers"]:
+        assert row["tier_label"] == ent.tier_label(row["tier"])
+        assert row["tier_rank"] == ent._TIER_RANK.get(row["tier"], -1)
+
+
+# ── Scalar: tier normalisation ────────────────────────────────────────────
+
+
+def test_scalar_normalises_and_dedups_tiers(ent):
+    r = ent.has_all_at_batch(
+        ["  OSS  ", "oss", "Cloud_Pro"], features=["fleet"]
+    )
+    assert [row["tier"] for row in r["tiers"]] == ["oss", "cloud_pro"]
+    assert r["unknown"] == []
+
+
+def test_scalar_unknown_tiers_bucket_not_shortcircuit(ent):
+    r = ent.has_all_at_batch(
+        ["oss", "bogus_a", "cloud_pro", "bogus_b"], features=["fleet"]
+    )
+    assert [row["tier"] for row in r["tiers"]] == ["oss", "cloud_pro"]
+    assert r["unknown"] == ["bogus_a", "bogus_b"]
+
+
+def test_scalar_none_perspectives_returns_empty(ent):
+    assert ent.has_all_at_batch(None, features=["fleet"]) == {
+        "tiers": [],
+        "unknown": [],
+    }
+
+
+def test_scalar_non_iterable_perspectives_returns_empty(ent):
+    assert ent.has_all_at_batch(123, features=["fleet"]) == {  # type: ignore[arg-type]
+        "tiers": [],
+        "unknown": [],
+    }
+
+
+# ── Scalar: kwarg semantics parity with has_all_at ────────────────────────
+
+
+def test_scalar_no_axes_supplied_every_row_false(ent):
+    r = ent.has_all_at_batch(["oss", "cloud_pro"])
+    assert all(row["has_all_at"] is False for row in r["tiers"])
+
+
+def test_scalar_empty_features_list_every_row_false(ent):
+    r = ent.has_all_at_batch(["oss", "cloud_pro"], features=[])
+    assert all(row["has_all_at"] is False for row in r["tiers"])
+
+
+def test_scalar_empty_runtimes_list_every_row_false(ent):
+    r = ent.has_all_at_batch(["oss", "cloud_pro"], runtimes=[])
+    assert all(row["has_all_at"] is False for row in r["tiers"])
+
+
+def test_scalar_non_int_channels_every_row_false(ent):
+    r = ent.has_all_at_batch(
+        ["oss", "cloud_pro"], channels="five"  # type: ignore[arg-type]
+    )
+    assert all(row["has_all_at"] is False for row in r["tiers"])
+
+
+def test_scalar_non_int_retention_every_row_false(ent):
+    r = ent.has_all_at_batch(
+        ["oss", "cloud_pro"], retention_days="thirty"  # type: ignore[arg-type]
+    )
+    assert all(row["has_all_at"] is False for row in r["tiers"])
+
+
+def test_scalar_non_int_nodes_every_row_false(ent):
+    r = ent.has_all_at_batch(
+        ["oss", "cloud_pro"], nodes=["a"]  # type: ignore[arg-type]
+    )
+    assert all(row["has_all_at"] is False for row in r["tiers"])
+
+
+def test_scalar_unknown_feature_typo_collapses_every_row(ent):
+    r = ent.has_all_at_batch(
+        list(ent._TIER_ORDER), features=["fleeet"]  # typo
+    )
+    assert all(row["has_all_at"] is False for row in r["tiers"])
+
+
+def test_scalar_unknown_runtime_typo_collapses_every_row(ent):
+    r = ent.has_all_at_batch(
+        list(ent._TIER_ORDER), runtimes=["totally_fake_rt"]
+    )
+    assert all(row["has_all_at"] is False for row in r["tiers"])
+
+
+# ── Scalar: alias posture (strict scalar; alias tolerance is at endpoint) ─
+
+
+def test_scalar_runtime_alias_stays_strict(ent):
+    """Raw ``claude-code`` on the strict scalar collapses to ``False`` on
+    every row (matches :func:`has_runtimes_at`). Alias tolerance belongs
+    to the endpoint upstream layer."""
+    r = ent.has_all_at_batch(list(ent._TIER_ORDER), runtimes=["claude-code"])
+    assert all(row["has_all_at"] is False for row in r["tiers"])
+
+
+def test_scalar_runtime_canonical_id_grants_at_paid_tiers(ent):
+    """Canonical form works at scalar layer."""
+    r = ent.has_all_at_batch(list(ent._TIER_ORDER), runtimes=["claude_code"])
+    row_by_tier = {row["tier"]: row for row in r["tiers"]}
+    # OSS statically doesn't grant paid runtimes.
+    assert row_by_tier["oss"]["has_all_at"] is False
+    # cloud_pro statically grants paid runtimes.
+    assert row_by_tier["cloud_pro"]["has_all_at"] is True
+
+
+# ── Scalar: free-vs-paid semantics ────────────────────────────────────────
+
+
+def test_scalar_all_free_bundle_true_at_every_tier_features(ent):
+    free = sorted(ent.FREE_FEATURES)
+    if not free:
+        pytest.skip("no free features on this build")
+    r = ent.has_all_at_batch(list(ent._TIER_ORDER), features=free)
+    for row in r["tiers"]:
+        assert row["has_all_at"] is True, row["tier"]
+
+
+def test_scalar_paid_feature_bundle_denied_at_oss(ent):
+    paid = _paid_feature(ent)
+    r = ent.has_all_at_batch(["oss"], features=[paid])
+    assert r["tiers"][0]["has_all_at"] is False
+
+
+def test_scalar_paid_feature_bundle_granted_at_enterprise(ent):
+    if "enterprise" not in ent._TIER_ORDER:
+        pytest.skip("enterprise not on this build")
+    paid = _paid_feature(ent)
+    r = ent.has_all_at_batch(["enterprise"], features=[paid])
+    assert r["tiers"][0]["has_all_at"] is True
+
+
+def test_scalar_free_runtime_true_at_every_tier(ent):
+    free = sorted(ent.FREE_RUNTIMES)
+    if not free:
+        pytest.skip("no free runtimes on this build")
+    r = ent.has_all_at_batch(list(ent._TIER_ORDER), runtimes=free)
+    for row in r["tiers"]:
+        assert row["has_all_at"] is True, row["tier"]
+
+
+# ── Scalar: grace-independence ────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"features": ["fleet"]},
+        {"runtimes": ["claude_code"]},
+        {"channels": 100},
+        {"retention_days": 90},
+        {"nodes": 100},
+        {
+            "features": ["fleet"],
+            "runtimes": ["claude_code"],
+            "channels": 100,
+            "retention_days": 90,
+            "nodes": 100,
+        },
+    ],
+)
+def test_scalar_grace_independence_matches_at_scalar(ent, kwargs):
+    tiers = list(ent._TIER_ORDER)
+    batch = ent.has_all_at_batch(tiers, **kwargs)
+    for row in batch["tiers"]:
+        assert row["has_all_at"] == ent.has_all_at(row["tier"], **kwargs), (
+            row,
+            kwargs,
+        )
+
+
+def test_scalar_grace_off_returns_identical_rows(enforced, monkeypatch, tmp_path):
+    """Batch answer identical under enforce vs grace for every
+    (perspectives, bundle) pair -- the delegate is grace-independent by
+    construction."""
+    tiers = list(enforced._TIER_ORDER)
+    kwargs = {"features": ["fleet"], "channels": 100, "nodes": 100}
+    enforced_batch = enforced.has_all_at_batch(tiers, **kwargs)
+    # Flip back to grace and re-run: same answer.
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    try:
+        grace_batch = e.has_all_at_batch(tiers, **kwargs)
+        # Rows may differ only if tier ordering changed (they don't).
+        for erow, grow in zip(enforced_batch["tiers"], grace_batch["tiers"]):
+            assert erow["tier"] == grow["tier"]
+            assert erow["has_all_at"] == grow["has_all_at"], (erow, grow)
+    finally:
+        e.invalidate()
+
+
+# ── Scalar: never-raises ──────────────────────────────────────────────────
+
+
+def test_scalar_never_raises_on_delegate_blowup(ent, monkeypatch):
+    def _boom(*args, **kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(ent, "has_all_at", _boom)
+    r = ent.has_all_at_batch(["oss", "cloud_pro"], features=["fleet"])
+    # Both rows short-circuit into unknown[]; envelope stays stable.
+    assert r["tiers"] == []
+    assert r["unknown"] == ["oss", "cloud_pro"]
+
+
+# ── Endpoint: envelope shape ──────────────────────────────────────────────
+
+
+def test_endpoint_envelope_shape_no_args(client):
+    body = _get_json(client, "/api/entitlement/has-all-at-batch")
+    assert set(body) == _ENDPOINT_ENVELOPE_KEYS
+    assert body["tiers"] == []
+
+
+def test_endpoint_envelope_shape_mixed_bundle(client):
+    body = _get_json(
+        client,
+        "/api/entitlement/has-all-at-batch?tiers=oss,cloud_pro"
+        "&features=fleet&runtimes=claude_code"
+        "&channels=100&retention_days=90&nodes=100",
+    )
+    assert set(body) == _ENDPOINT_ENVELOPE_KEYS
+    for row in body["tiers"]:
+        assert set(row) == _ENDPOINT_ROW_KEYS
+
+
+def test_endpoint_envelope_shape_only_tiers(client):
+    body = _get_json(
+        client, "/api/entitlement/has-all-at-batch?tiers=oss,cloud_pro"
+    )
+    assert set(body) == _ENDPOINT_ENVELOPE_KEYS
+    # Tiers still emitted; every row False (no axes supplied).
+    assert [row["tier"] for row in body["tiers"]] == ["oss", "cloud_pro"]
+    assert all(row["has_all_at"] is False for row in body["tiers"])
+
+
+def test_endpoint_envelope_shape_bogus_tier(client):
+    body = _get_json(
+        client,
+        "/api/entitlement/has-all-at-batch?tiers=oss,bogus,cloud_pro&features=fleet",
+    )
+    assert set(body) == _ENDPOINT_ENVELOPE_KEYS
+    assert body["unknown_tiers"] == ["bogus"]
+    assert [row["tier"] for row in body["tiers"]] == ["oss", "cloud_pro"]
+
+
+def test_endpoint_envelope_shape_unknown_feature(client):
+    body = _get_json(
+        client,
+        "/api/entitlement/has-all-at-batch?tiers=oss,cloud_pro&features=fleet,totally_fake",
+    )
+    assert set(body) == _ENDPOINT_ENVELOPE_KEYS
+    assert body["unknown_features"] == ["totally_fake"]
+    assert all(row["has_all_at"] is False for row in body["tiers"])
+
+
+def test_endpoint_envelope_shape_unknown_runtime(client):
+    body = _get_json(
+        client,
+        "/api/entitlement/has-all-at-batch?tiers=oss,cloud_pro&runtimes=openclaw,totally_fake_rt",
+    )
+    assert set(body) == _ENDPOINT_ENVELOPE_KEYS
+    assert body["unknown_runtimes"] == ["totally_fake_rt"]
+    assert all(row["has_all_at"] is False for row in body["tiers"])
+
+
+def test_endpoint_envelope_shape_non_int_capacity(client):
+    body = _get_json(
+        client,
+        "/api/entitlement/has-all-at-batch?tiers=oss,cloud_pro&channels=five",
+    )
+    assert set(body) == _ENDPOINT_ENVELOPE_KEYS
+    assert body["channels"] is None
+    assert all(row["has_all_at"] is False for row in body["tiers"])
+
+
+# ── Endpoint: supplied_axes tracking ──────────────────────────────────────
+
+
+def test_endpoint_supplied_axes_features_only(client):
+    body = _get_json(
+        client,
+        "/api/entitlement/has-all-at-batch?tiers=oss&features=fleet",
+    )
+    assert body["supplied_axes"] == ["features"]
+    assert body["supplied_count"] == 1
+
+
+def test_endpoint_supplied_axes_all_five(client):
+    body = _get_json(
+        client,
+        "/api/entitlement/has-all-at-batch?tiers=oss&features=fleet"
+        "&runtimes=claude_code&channels=1&retention_days=1&nodes=1",
+    )
+    assert body["supplied_axes"] == [
+        "features",
+        "runtimes",
+        "channels",
+        "retention_days",
+        "nodes",
+    ]
+    assert body["supplied_count"] == 5
+
+
+def test_endpoint_supplied_axes_empty(client):
+    body = _get_json(client, "/api/entitlement/has-all-at-batch?tiers=oss")
+    assert body["supplied_axes"] == []
+    assert body["supplied_count"] == 0
+
+
+# ── Endpoint: runtime alias canonicalisation upstream ─────────────────────
+
+
+def test_endpoint_runtime_alias_canonicalises(client):
+    body = _get_json(
+        client,
+        "/api/entitlement/has-all-at-batch?tiers=cloud_pro&runtimes=claude-code",
+    )
+    # The alias flips to canonical form; cloud_pro admits claude_code.
+    assert body["runtimes"] == ["claude_code"]
+    assert body["unknown_runtimes"] == []
+    assert body["tiers"][0]["has_all_at"] is True
+
+
+def test_endpoint_runtime_alias_dedups_pair(client):
+    body = _get_json(
+        client,
+        "/api/entitlement/has-all-at-batch?tiers=cloud_pro"
+        "&runtimes=claude-code,claude_code",
+    )
+    # Alias + canonical collapse to one row before the scalar sees them.
+    assert body["runtimes"] == ["claude_code"]
+
+
+# ── Endpoint: rollups ─────────────────────────────────────────────────────
+
+
+def test_endpoint_all_allowed_and_any_allowed_paid_feature(client, ent):
+    body = _get_json(
+        client,
+        "/api/entitlement/has-all-at-batch?tiers=oss,cloud_pro&features=fleet",
+    )
+    # OSS false, cloud_pro true.
+    assert body["all_allowed"] is False
+    assert body["any_allowed"] is True
+    assert body["allowed_count"] == 1
+
+
+def test_endpoint_all_allowed_all_free(client, ent):
+    body = _get_json(
+        client,
+        "/api/entitlement/has-all-at-batch?tiers=oss,cloud_pro"
+        "&runtimes=openclaw",
+    )
+    # Free runtime -> every row True.
+    assert body["all_allowed"] is True
+    assert body["any_allowed"] is True
+    assert body["allowed_count"] == 2
+
+
+def test_endpoint_all_allowed_empty_tiers(client):
+    body = _get_json(client, "/api/entitlement/has-all-at-batch?tiers=&features=fleet")
+    assert body["all_allowed"] is False  # empty tiers -> False (fail-closed)
+    assert body["any_allowed"] is False
+
+
+# ── Endpoint: per-row upgrade_required ────────────────────────────────────
+
+
+def test_endpoint_upgrade_required_flips_at_required_tier(client, ent):
+    body = _get_json(
+        client,
+        "/api/entitlement/has-all-at-batch?tiers=oss,cloud_starter,cloud_pro,enterprise&features=fleet",
+    )
+    required_tier = body["required_tier"]
+    required_rank = body["required_tier_rank"]
+    assert required_tier is not None
+    for row in body["tiers"]:
+        expected_upgrade = row["tier_rank"] < required_rank
+        assert row["upgrade_required"] is expected_upgrade, row
+
+
+# ── Endpoint: never-4xx ───────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "/api/entitlement/has-all-at-batch",
+        "/api/entitlement/has-all-at-batch?tiers=",
+        "/api/entitlement/has-all-at-batch?tiers=bogus",
+        "/api/entitlement/has-all-at-batch?tiers=oss",
+        "/api/entitlement/has-all-at-batch?tiers=oss&features=",
+        "/api/entitlement/has-all-at-batch?tiers=oss&channels=",
+        "/api/entitlement/has-all-at-batch?tiers=oss&channels=five",
+        "/api/entitlement/has-all-at-batch?tiers=oss&features=totally_fake",
+        "/api/entitlement/has-all-at-batch?tiers=oss&runtimes=totally_fake_rt",
+    ],
+)
+def test_endpoint_never_4xx(client, url):
+    resp = client.get(url)
+    assert resp.status_code == 200, (url, resp.status_code)
+
+
+# ── Endpoint: never-5xx (monkeypatched blowup) ────────────────────────────
+
+
+def test_endpoint_never_5xx_on_body_builder_blowup(client, ent, monkeypatch):
+    from routes import entitlement as _routes
+
+    def _boom():
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(_routes, "_has_all_at_batch_body", _boom)
+    resp = client.get(
+        "/api/entitlement/has-all-at-batch?tiers=oss,bogus&features=fleet"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    # Fallback envelope shape stable.
+    assert set(body) == _ENDPOINT_ENVELOPE_KEYS
+    assert body["tiers"] == []
+    assert body["unknown_tiers"] == ["oss", "bogus"]
+    assert body["unknown_features"] == ["fleet"]
+    assert body["all_allowed"] is False
+    assert body["any_allowed"] is False
+
+
+def test_endpoint_never_5xx_on_scalar_blowup(client, ent, monkeypatch):
+    def _boom(*a, **k):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(ent, "has_all_at_batch", _boom)
+    resp = client.get(
+        "/api/entitlement/has-all-at-batch?tiers=oss,cloud_pro&features=fleet"
+    )
+    # The endpoint call site swallows the RuntimeError into the fallback
+    # envelope because ``has_all_at_batch`` is imported inside the body
+    # builder each request (via ``from clawmetry import entitlements``).
+    # Either way: 200 with envelope stable.
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert set(body) == _ENDPOINT_ENVELOPE_KEYS
+
+
+# ── Endpoint: scalar-vs-endpoint parity ───────────────────────────────────
+
+
+def test_endpoint_row_parity_with_scalar(client, ent):
+    body = _get_json(
+        client,
+        "/api/entitlement/has-all-at-batch?tiers=oss,cloud_starter,cloud_pro,enterprise"
+        "&features=fleet&channels=100",
+    )
+    # Reconstruct known values the endpoint would pass to the scalar.
+    for row in body["tiers"]:
+        assert row["has_all_at"] == ent.has_all_at(
+            row["tier"], features=["fleet"], channels=100
+        ), row
+
+
+# ── Cross-endpoint: parity with /has-all-at ───────────────────────────────
+
+
+def test_cross_endpoint_row_parity_with_has_all_at(client):
+    for tier in ("oss", "cloud_starter", "cloud_pro", "enterprise"):
+        one = _get_json(
+            client,
+            f"/api/entitlement/has-all-at?tier={tier}"
+            "&features=fleet&channels=100",
+        )
+        batch = _get_json(
+            client,
+            f"/api/entitlement/has-all-at-batch?tiers={tier}"
+            "&features=fleet&channels=100",
+        )
+        assert (
+            batch["tiers"][0]["has_all_at"] == one["has_all_at"]
+        ), (tier, batch["tiers"][0], one)
+
+
+# ── Cross-endpoint: parity with /has-features-at-batch on single axis ─────
+
+
+def test_cross_endpoint_features_axis_parity(client):
+    body_all = _get_json(
+        client,
+        "/api/entitlement/has-all-at-batch?tiers=oss,cloud_pro,enterprise&features=fleet",
+    )
+    body_features = _get_json(
+        client,
+        "/api/entitlement/has-features-at-batch?tiers=oss,cloud_pro,enterprise&features=fleet",
+    )
+    for row_all, row_feat in zip(body_all["tiers"], body_features["tiers"]):
+        assert row_all["tier"] == row_feat["tier"]
+        assert row_all["has_all_at"] == row_feat["has_features_at"], (
+            row_all,
+            row_feat,
+        )
+
+
+def test_cross_endpoint_runtimes_axis_parity(client):
+    body_all = _get_json(
+        client,
+        "/api/entitlement/has-all-at-batch?tiers=oss,cloud_pro,enterprise&runtimes=claude_code",
+    )
+    body_runtimes = _get_json(
+        client,
+        "/api/entitlement/has-runtimes-at-batch?tiers=oss,cloud_pro,enterprise&runtimes=claude_code",
+    )
+    for row_all, row_rt in zip(body_all["tiers"], body_runtimes["tiers"]):
+        assert row_all["tier"] == row_rt["tier"]
+        assert row_all["has_all_at"] == row_rt["has_runtimes_at"], (
+            row_all,
+            row_rt,
+        )
+
+
+# ── Deliberate divergence from LIVE /has-all in grace ─────────────────────
+
+
+def test_endpoint_diverges_from_live_has_all_on_oss_paid_feature(client):
+    """The LIVE ``/has-all`` grants any fully-known bundle in grace via
+    the resolver pass-through, but ``/has-all-at-batch`` reads the
+    static per-tier tables and reports ``has_all_at=false`` on the OSS
+    row for a paid feature -- that's the whole point of the ``_at``
+    slot."""
+    body_at_batch = _get_json(
+        client,
+        "/api/entitlement/has-all-at-batch?tiers=oss&features=fleet",
+    )
+    body_live = _get_json(
+        client, "/api/entitlement/has-all?features=fleet"
+    )
+    assert body_live["has_all"] is True  # grace grants it live
+    assert body_at_batch["tiers"][0]["has_all_at"] is False  # static OSS denies
+
+
+# ── Resolver envelope carried on the endpoint ─────────────────────────────
+
+
+def test_endpoint_carries_resolver_envelope_in_grace(client):
+    body = _get_json(
+        client, "/api/entitlement/has-all-at-batch?tiers=oss&features=fleet"
+    )
+    assert body["grace"] is True
+    assert body["enforced"] is False
+    assert body["current_tier"] == "oss"
+    assert body["current_tier_rank"] == 0
+
+
+# ── Sanity: retention_days=None on kwarg semantics ───────────────────────
+
+
+def test_scalar_retention_none_unset_not_unlimited(ent):
+    # Passing retention_days=None means "unset" (skipped); doesn't
+    # collapse the fold or route to Enterprise-only.
+    r_none = ent.has_all_at_batch(["oss"], retention_days=None)
+    r_zero = ent.has_all_at_batch(["oss"], retention_days=0)
+    # None -> no axis supplied -> row False (empty-False posture).
+    assert r_none["tiers"][0]["has_all_at"] is False
+    # 0 -> supplied and trivially satisfied at OSS.
+    assert r_zero["tiers"][0]["has_all_at"] is True


### PR DESCRIPTION
## Summary

Fills the missing `_at_batch` slot on the mixed-axis `has_all` family alongside `min_tier_for_all_at_batch` (the reverse-lookup batch sibling) and the singular `_at` scalars `has_feature_at` / `has_runtime_at` / `has_channel_count_at` / `has_retention_window_at` / `has_node_count_at` for the five axes. Batch what-if sibling of `has_all_at`: fixes ONE mixed-axis bundle and sweeps across N perspective tiers, returning one row per tier with the aggregate mixed-axis fold boolean plus the surrounding tier envelope. Mixed-axis extension of `has_features_at_batch` / `has_runtimes_at_batch` (single-axis batch): a pricing-matrix column ("does OSS admit fleet + claude_code + 100 channels + 90d retention + 100 nodes? Starter? Cloud Pro? Enterprise?") hydrates the whole column off ONE URL instead of five `_at-batch` round-trips + a client-side AND-chain.

- **`has_all_at_batch(perspective_tiers, *, features, runtimes, channels, retention_days, nodes)`** in `clawmetry/entitlements.py` — per-row delegates to `has_all_at` for that `(perspective, bundle)` pair so each row inherits every axis's typo / empty / non-int posture without a divergent code path here. **Grace-independent by construction**: every per-row delegate reads the static per-tier grant tables (via `_hypothetical_entitlement` on the feature / runtime axes and the static `_TIER_CHANNEL_LIMIT` / `_TIER_RETENTION_DAYS` / `_TIER_NODE_LIMIT` tables on the capacity axes), so each row's answer is identical under grace vs enforce for the same `(row.tier, bundle)` pair. Per-tier row shape mirrors `has_features_at_batch` with `has_all_at` in the fold slot; envelope `{"tiers": [...], "unknown": [...]}` byte-parity with the single-axis siblings. Tier normalisation delegated to `_normalise_csv` (whitespace / case / dedup); unknown tier ids bucket into `unknown[]` without short-circuiting the batch. Never raises: a per-tier delegate failure short-circuits that id into `unknown[]` and the rest of the batch keeps building.

- **`GET /api/entitlement/has-all-at-batch?tiers=&features=&runtimes=&channels=&retention_days=&nodes=`** on `bp_entitlement`. **21-key envelope**: shared bundle metadata (`features` / `runtimes` / `channels` / `retention_days` / `nodes` + `unknown_features` / `unknown_runtimes` / `unknown_tiers`), `supplied_axes` / `supplied_count`, per-tier rows (9 keys each: `tier` / `tier_label` / `tier_rank` / `has_all_at` / `allowed` alias / `required_tier` + label + rank / `upgrade_required`), rollups (`allowed_count` / `all_allowed` / `any_allowed`), bundle-level `required_tier` + label + rank, and the standard resolver envelope (`current_tier` / `current_tier_rank` / `grace` / `enforced`) so a walkthrough surface can render the whole tier column off one call. Runtime-alias canonicalisation (`claude-code` → `claude_code`) applied per-token upstream of the strict scalar. Unknown token or non-int capacity collapses every row's `has_all_at` to `False` with the offending token surfaced via `unknown_features` / `unknown_runtimes` (matches sibling `_has_bundle_at_batch_body` posture byte-for-byte). Per-row `upgrade_required` compares the bundle-level `required_tier` against each ROW's tier rank (not the live current rank), matching the sibling `_has_bundle_at_batch_body` convention.

Envelope + short-circuit posture:

- **Never 4xxs** on any input branch: missing / blank / all-unknown `tiers=` returns 200 with `tiers=[]` (matches `/has-features-at-batch` posture — a paywall matrix binds `tiers` directly without a pre-validation round-trip). No axes supplied returns 200 with `tiers` populated but every row's `has_all_at=false` (matches `/has-all-at` empty-`False` posture). Unknown token / non-int capacity collapses every row to `False` with the offending token echoed.
- **Never 5xxs**: resolver / scalar / body-builder blowup collapses to the fallback envelope with `tiers=[]` and every rollup fail-closed.

Behaviour ships in **GRACE** mode: the resolver still defaults to the OSS-free entitlement so no runtime gating changes. This is purely additive to the entitlement query surface. Perspective-shaped answers are **intentionally identical in grace and enforce** (they read the static per-tier tables via the singular `_at` delegates, not the resolver's `grace` bit) — the whole point of the `_at` slot: `/has-all-at-batch?tiers=oss,cloud_pro&features=fleet` reports the `oss` row's `has_all_at=false` even in grace (because OSS statically does not grant `fleet`), whereas the LIVE `/has-all?features=fleet` reports `true` for it via `Entitlement.grace` pass-through.

Per-row parity tests keep the batch outputs pinned byte-equal to `has_all_at` for the same `(tier, bundle)` pair, to the singular `/has-all-at?tier=<row.tier>&...` endpoint on the same bundle, and to the sibling `/has-features-at-batch` / `/has-runtimes-at-batch` per-row `has_features_at` / `has_runtimes_at` on single-axis bundles, so any future contract change on either side has to update both.

## Test plan

- [x] `python3 -m py_compile clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_has_all_at_batch.py`
- [x] `ruff check clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_has_all_at_batch.py` — clean.
- [x] `python3 scripts/lint_daemon_allowlist.py` — passes (no `local_store_via_daemon` calls touched).
- [x] `python3 -m pytest tests/test_entitlement_has_all_at_batch.py` — **72/72 pass**, covering: scalar envelope shape stability across every axis combo (features / runtimes / channels / retention_days / nodes / mixed / empty); per-row `has_all_at` byte-parity with the singular `has_all_at` scalar on every `_TIER_ORDER` perspective × every axis (features-only / runtimes-only / channels / retention / nodes / mixed 5-axis bundle); per-row `tier_label` / `tier_rank` match `tier_label()` / `_TIER_RANK`; tier normalisation (whitespace / case / dedup); unknown tier ids bucket into `unknown[]` without short-circuiting the batch; empty / None / non-iterable `perspective_tiers` → stable empty envelope; kwarg semantics parity with `has_all_at` (no axes → every row False; empty features/runtimes list → every row False; non-int channels/retention/nodes → every row False; unknown feature/runtime token → every row False); strict runtime-alias posture at scalar layer (raw `claude-code` → False; canonical `claude_code` → True at paid tiers); all-free bundle True at every tier; paid-feature bundle denied at OSS / granted at Enterprise; grace-independence invariant (batch identical under grace vs enforce for every parametric bundle); never-raises on delegate blowup (short-circuits affected rows to `unknown[]`); endpoint envelope shape stability (21-key set) across every input branch; endpoint row shape stability (9-key set); `supplied_axes` / `supplied_count` tracking; runtime-alias canonicalisation applied upstream at the endpoint layer (`claude-code` → canonical, dedups against `claude_code`); `all_allowed` / `any_allowed` / `allowed_count` rollups (paid-feature mixed / all-free / empty-tiers fail-closed); per-row `upgrade_required` flips at `required_tier`; never-4xx across every input branch (no args / empty tiers / bogus tier / no axes / empty CSVs / blank capacity / non-int capacity / unknown feature / unknown runtime); never-5xx (monkeypatched body-builder blowup collapses to fallback envelope with stable 21-key shape; monkeypatched scalar blowup); scalar-vs-endpoint parity; cross-endpoint parity with `/has-all-at` per-row; cross-endpoint single-axis parity with `/has-features-at-batch` and `/has-runtimes-at-batch` (per-row `has_all_at` byte-equals `has_features_at` / `has_runtimes_at`); deliberate divergence from LIVE `/has-all` on the OSS perspective in grace; resolver envelope carried in grace; `retention_days=None` = unset (not unlimited).
- [x] `python3 -m pytest tests/test_entitlement_has_all_at.py tests/test_entitlement_has_features_runtimes_at_batch.py tests/test_entitlement_has_all.py tests/test_entitlement_api.py` — **244/244 pass** (sibling regression: no envelope drift on the LIVE `/has-all-at` sibling, no shape drift on the single-axis `_at_batch` siblings, no shape drift on `/has-all` or `/api/entitlement`).

## Local operator verification checklist

Since this fire runs in an ephemeral cloud container with no access to your local daemon, `~/.openclaw`, the live cloud snapshot, or a browser, please verify against the running host once you pull this branch:

- [ ] Copy the three changed files into your live install:
  ```
  cp clawmetry/entitlements.py ~/.clawmetry/lib/python3.*/site-packages/clawmetry/
  cp routes/entitlement.py     ~/.clawmetry/lib/python3.*/site-packages/routes/
  find ~/.clawmetry/lib -name __pycache__ -type d -exec rm -rf {} +
  ```
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` to restart the daemon and pick up the new endpoint.
- [ ] `curl -s 'http://localhost:8900/api/entitlement/has-all-at-batch?tiers=oss,cloud_pro&features=fleet' | jq .` — expect the 21-key envelope with `tiers=[{oss row has_all_at=false, upgrade_required=true}, {cloud_pro row has_all_at=true, upgrade_required=false}]`, `all_allowed=false`, `any_allowed=true`, `allowed_count=1`, `unknown_tiers=[]`, `unknown_features=[]`, resolver envelope with `grace=true`.
- [ ] `curl -s '``http://localhost:8900/api/entitlement/has-all-at-batch?tiers=oss,cloud_starter,cloud_pro,enterprise&features=fleet&runtimes=claude_code&channels=100&retention_days=90&nodes=100'`` | jq .` — expect OSS row `has_all_at=false`; higher paid tiers where all five axes fit (cloud_pro / enterprise) `has_all_at=true`.
- [ ] `curl -s 'http://localhost:8900/api/entitlement/has-all-at-batch?tiers=oss,cloud_pro&runtimes=claude-code' | jq '.runtimes'` — expect `["claude_code"]` (alias canonicalisation matches the sibling endpoints).
- [ ] `curl -s 'http://localhost:8900/api/entitlement/has-all-at-batch?tiers=oss,cloud_pro&features=fleet,totally_fake_xyz' | jq '.unknown_features'` — expect `["totally_fake_xyz"]`; every row's `has_all_at=false` (endpoint-level unknown-collapse fold).
- [ ] `curl -s 'http://localhost:8900/api/entitlement/has-all-at-batch?tiers=oss,bogus_a,cloud_pro,bogus_b&features=fleet' | jq '.unknown_tiers'` — expect `["bogus_a", "bogus_b"]`; valid tier rows still populated.
- [ ] `curl -s 'http://localhost:8900/api/entitlement/has-all-at-batch?tiers=oss,cloud_pro&channels=five' | jq '.channels'` — expect `null`; every row `has_all_at=false`.
- [ ] `curl -sw '\n%{http_code}\n' 'http://localhost:8900/api/entitlement/has-all-at-batch'` — expect **200** with `tiers=[]`, `all_allowed=false`, `any_allowed=false` (never-4xx contract).
- [ ] Cross-consistency: for any perspective tier `<T>` and same bundle, `curl -s '.../has-all-at-batch?tiers=<T>&...' | jq '.tiers[0].has_all_at'` should byte-equal `curl -s '.../has-all-at?tier=<T>&...' | jq '.has_all_at'`.
- [ ] Cross-consistency (single-axis features): `curl -s '.../has-all-at-batch?tiers=oss,cloud_pro,enterprise&features=fleet' | jq '.tiers[].has_all_at'` should byte-equal `curl -s '.../has-features-at-batch?tiers=oss,cloud_pro,enterprise&features=fleet' | jq '.tiers[].has_features_at'`.
- [ ] Cross-consistency (single-axis runtimes): `curl -s '.../has-all-at-batch?tiers=oss,cloud_pro,enterprise&runtimes=claude_code' | jq '.tiers[].has_all_at'` should byte-equal `curl -s '.../has-runtimes-at-batch?tiers=oss,cloud_pro,enterprise&runtimes=claude_code' | jq '.tiers[].has_runtimes_at'`.
- [ ] Deliberate divergence check: `curl -s '.../has-all-at-batch?tiers=oss&features=fleet' | jq '.tiers[0].has_all_at'` should be **false** even though `curl -s '.../has-all?features=fleet' | jq '.has_all'` is **true** under grace (that's the whole point of the `_at` slot).
- [ ] `curl -s 'http://localhost:8900/api/entitlement' | jq .grace` — expect **true** (nothing about the resolver / gate changed — this PR is purely additive query surface).
- [ ] Decrypt the live cloud snapshot in the browser and confirm the dashboard's entitlement panels still render (no shape regression).

This PR stays **DRAFT** until you've done the local + cloud verification above. Version bump / `[RELEASE]` PR / merge is your call.

---
_Generated by [Claude Code](https://claude.ai/code/session_016s6qT5pxkgrgAc8vMbSHkP)_