### PR TITLE
feat(entitlement): missing_all_at + /api/entitlement/missing-all-at

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -11726,6 +11726,167 @@ def has_all_at(
         return False
 
 
+def missing_all_at(
+    perspective_tier: str,
+    *,
+    features=None,
+    runtimes=None,
+    channels: int | None = None,
+    retention_days: int | None = None,
+    nodes: int | None = None,
+) -> dict:
+    """Hypothetical-perspective sibling of :func:`missing_all`: which subset of
+    the supplied mixed-axis bundle would tier ``perspective_tier`` NOT grant,
+    in ONE row-detail rollup?
+
+    Same relationship to :func:`missing_all` that :func:`has_all_at` has to
+    :func:`has_all`: the ``perspective_tier`` argument tells the fold which
+    STATIC per-tier grant to reason from, so a pricing-matrix denial tile
+    can bind every per-axis slot ("if you were on OSS, you'd still be
+    missing fleet + claude_code + 100 channels + 90d retention + 99 nodes")
+    off ONE call per (perspective, bundle) cell instead of five singular
+    ``_at`` round-trips + a client-side per-axis stitch. Fills the ``_at``
+    slot on the mixed-axis row-detail complement family alongside
+    :func:`has_all_at` (boolean-fold sibling) and the singular row-detail
+    ``_at`` scalars :func:`missing_features_at` / :func:`missing_runtimes_at`
+    for the two grant axes.
+
+    Returns a 5-key dict::
+
+        {
+          "features":       [<subset denied via missing_features_at>],
+          "runtimes":       [<subset denied via missing_runtimes_at>],
+          "channels":       <supplied int if has_channel_count_at is False, else None>,
+          "retention_days": <supplied int if has_retention_window_at is False, else None>,
+          "nodes":          <supplied int if has_node_count_at is False, else None>,
+        }
+
+    Per-axis rules:
+
+    * Grant axes (``features`` / ``runtimes``) delegate to
+      :func:`missing_features_at` / :func:`missing_runtimes_at` byte-for-byte
+      so the ``_at`` typo posture, dedup, and canonicalisation surface here
+      unchanged. Empty / ``None`` / non-iterable bundle -> ``[]`` on that
+      axis (nothing to check, nothing missing).
+    * Capacity axes (``channels`` / ``retention_days`` / ``nodes``) return
+      the SUPPLIED int when :func:`has_channel_count_at` /
+      :func:`has_retention_window_at` / :func:`has_node_count_at` returns
+      ``False`` under ``perspective_tier``, ``None`` otherwise (or when the
+      axis is unsupplied). Non-int capacity swallows to ``None`` on this
+      scalar; the paired :func:`has_all_at` fold reports ``False`` via the
+      strict singular scalar so the denial is coherently surfaced through
+      the paired call. ``retention_days=None`` means *unset*, NOT
+      *unlimited* -- matches :func:`has_all_at` / :func:`min_tier_for_all_at`.
+
+    **Grace-independent by construction**: every axis delegate reads the
+    static per-tier grant tables (via :func:`_hypothetical_entitlement` on
+    the grant axes and the static ``_TIER_CHANNEL_LIMIT`` /
+    ``_TIER_RETENTION_DAYS`` / ``_TIER_NODE_LIMIT`` tables on the capacity
+    axes), so the returned dict is IDENTICAL under grace vs enforce for
+    the same (perspective, bundle) pair -- diverges deliberately from
+    :func:`missing_all` (which reports every per-axis slot empty for a
+    fully-known bundle in grace via the live resolver's grace pass-through).
+    The whole point of the ``_at`` slot: ``missing_all_at("oss",
+    features=["fleet"])["features"]`` returns ``["fleet"]`` even in grace
+    (because OSS statically does not grant ``fleet``), whereas the LIVE
+    :func:`missing_all` reports ``[]`` for it via
+    :attr:`Entitlement.grace` pass-through.
+
+    Complement invariant with :func:`has_all_at`: for every fully-parseable
+    bundle, ``any(missing_all_at(p, **b).values())`` is the strict negation
+    of ``has_all_at(p, **b)`` -- pins the row-detail seat as the exact
+    perspective-shaped negation of the boolean fold. (Non-int capacity is
+    the one deliberate divergence: the row-detail slot swallows to ``None``
+    while the boolean fold collapses to ``False`` via the strict singular
+    scalar; a UI wanting a coherent "supplied but denied" story on that
+    branch should call the paired :func:`has_all_at`.)
+
+    Returns the empty per-axis shape for empty / unknown / non-string
+    ``perspective_tier`` (matches :func:`missing_features_at` /
+    :func:`missing_runtimes_at` fail-open perspective posture); the paired
+    endpoint returns 400 / 404 in that branch so callers wanting a
+    validity gate can read it there.
+
+    Never raises: any delegate failure logs a warning and collapses that
+    axis to its empty seat so a paywall diagnostics tile stays mute
+    instead of breaking.
+    """
+    empty: dict = {
+        "features": [],
+        "runtimes": [],
+        "channels": None,
+        "retention_days": None,
+        "nodes": None,
+    }
+    try:
+        p = (perspective_tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return dict(empty)
+    if not p or p not in _TIER_ORDER:
+        return dict(empty)
+    out = dict(empty)
+    try:
+        if features is not None:
+            out["features"] = list(missing_features_at(p, features))
+    except Exception as exc:
+        logger.warning(
+            "entitlements: missing_all_at(%r, ...) features axis failed: %s",
+            perspective_tier,
+            exc,
+        )
+        out["features"] = []
+    try:
+        if runtimes is not None:
+            out["runtimes"] = list(missing_runtimes_at(p, runtimes))
+    except Exception as exc:
+        logger.warning(
+            "entitlements: missing_all_at(%r, ...) runtimes axis failed: %s",
+            perspective_tier,
+            exc,
+        )
+        out["runtimes"] = []
+    try:
+        if channels is not None and isinstance(channels, int) and not isinstance(
+            channels, bool
+        ):
+            if not has_channel_count_at(p, channels):
+                out["channels"] = channels
+    except Exception as exc:
+        logger.warning(
+            "entitlements: missing_all_at(%r, ...) channels axis failed: %s",
+            perspective_tier,
+            exc,
+        )
+        out["channels"] = None
+    try:
+        if retention_days is not None and isinstance(
+            retention_days, int
+        ) and not isinstance(retention_days, bool):
+            if not has_retention_window_at(p, retention_days):
+                out["retention_days"] = retention_days
+    except Exception as exc:
+        logger.warning(
+            "entitlements: missing_all_at(%r, ...) retention_days axis failed: %s",
+            perspective_tier,
+            exc,
+        )
+        out["retention_days"] = None
+    try:
+        if nodes is not None and isinstance(nodes, int) and not isinstance(
+            nodes, bool
+        ):
+            if not has_node_count_at(p, nodes):
+                out["nodes"] = nodes
+    except Exception as exc:
+        logger.warning(
+            "entitlements: missing_all_at(%r, ...) nodes axis failed: %s",
+            perspective_tier,
+            exc,
+        )
+        out["nodes"] = None
+    return out
+
+
 def _min_tier_for_all_bundle_row(bundle) -> dict:
     """Per-bundle row shape for :func:`min_tier_for_all_batch`.
 

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -9005,6 +9005,385 @@ def api_entitlement_has_all_at():
         return jsonify(_has_all_at_fallback(tier_in))
 
 
+_MISSING_ALL_AT_KEYS = (
+    "perspective_tier",
+    "perspective_tier_label",
+    "perspective_tier_rank",
+    "features",
+    "runtimes",
+    "channels",
+    "retention_days",
+    "nodes",
+    "unknown_features",
+    "unknown_runtimes",
+    "supplied_axes",
+    "supplied_count",
+    "missing_count",
+    "any_missing",
+    "required_tier",
+    "required_tier_label",
+    "required_tier_rank",
+    "current_tier",
+    "current_tier_rank",
+    "grace",
+    "enforced",
+)
+
+
+def _missing_all_at_fallback(perspective_tier: str) -> dict:
+    """Never-5xx envelope for ``/api/entitlement/missing-all-at``.
+
+    Mirrors :func:`_has_all_at_fallback` on the paired boolean-fold sibling
+    with the ``has_all_at`` / ``allowed`` slots swapped for the row-detail
+    ``missing_count`` / ``any_missing`` rollups: on a resolver blowup the
+    endpoint still returns 200 with the same envelope shape as the happy
+    path, but every per-axis missing slot empty and ``any_missing=False``
+    so a paywall diagnostics tile that lost the resolver doesn't silently
+    render a denial banner it can no longer justify.
+
+    ``perspective_tier_label`` / ``perspective_tier_rank`` fall back to
+    ``None`` / ``-1`` (matches the sibling ``has-all-at`` fallback
+    envelope) so the envelope shape stays byte-stable across every input
+    branch, including the resolver-blowup fallback.
+    """
+    return {
+        "perspective_tier": perspective_tier,
+        "perspective_tier_label": None,
+        "perspective_tier_rank": -1,
+        "features": [],
+        "runtimes": [],
+        "channels": None,
+        "retention_days": None,
+        "nodes": None,
+        "unknown_features": [],
+        "unknown_runtimes": [],
+        "supplied_axes": [],
+        "supplied_count": 0,
+        "missing_count": 0,
+        "any_missing": False,
+        "required_tier": None,
+        "required_tier_label": None,
+        "required_tier_rank": -1,
+        "current_tier": "oss",
+        "current_tier_rank": 0,
+        "grace": True,
+        "enforced": False,
+    }
+
+
+def _missing_all_at_body(perspective_tier: str) -> dict:
+    """Happy-path body builder for ``/api/entitlement/missing-all-at``.
+
+    Perspective-shaped row-detail sibling of :func:`_has_all_at_body`:
+    applies the same per-axis normalisation (CSV known/unknown split for
+    features and runtimes with runtime-alias canonicalisation; capacity
+    axes parsed via :func:`_parse_capacity_arg` so a blank / non-int value
+    surfaces the raw string in the per-axis missing slot) then delegates
+    to :func:`clawmetry.entitlements.missing_all_at` against the SUPPLIED
+    axis values so this endpoint stays byte-parity with the module
+    scalar on the per-axis missing detail.
+
+    Every axis is OPTIONAL -- a caller can supply any (or none) of the
+    five kwargs; the envelope always carries every axis' slot for
+    byte-stable shape across every URL branch. No-axes-supplied returns
+    every per-axis slot empty and ``any_missing=False`` (matches
+    :func:`missing_all_at` empty-per-axis posture byte-for-byte and
+    mirrors ``/has-all-at``'s empty-``False`` posture).
+
+    Grace-independent by construction: :func:`missing_all_at` delegates
+    to the static-per-tier ``_at`` singular scalars, so this endpoint's
+    per-axis missing detail is IDENTICAL under grace vs enforce for the
+    same (perspective, bundle) pair -- diverges deliberately from the
+    LIVE ``/missing-all`` sibling (which reports every per-axis slot
+    empty for a fully-known bundle in grace via the resolver's grace
+    pass-through). Whole point of the ``_at`` slot:
+    ``/missing-all-at?tier=oss&features=fleet`` returns
+    ``features=["fleet"]`` even in grace (because OSS statically does
+    not grant ``fleet``), whereas LIVE ``/missing-all?features=fleet``
+    reports ``features=[]`` for it via :attr:`Entitlement.grace`
+    pass-through.
+
+    Unknown feature / runtime tokens are SURFACED inside the per-axis
+    ``features`` / ``runtimes`` missing lists AND echoed in
+    ``unknown_features`` / ``unknown_runtimes`` for a diagnostics
+    tooltip (matches the LIVE ``/missing-all`` unknown-surface posture).
+    A supplied-but-unparseable capacity axis surfaces the raw string in
+    that slot so a UI can flag the typo.
+
+    ``required_tier`` folds through
+    :func:`clawmetry.entitlements.min_tier_for_all` against the KNOWN-only
+    subsets for parity with the ``/has-all`` and ``/has-all-at``
+    envelopes.
+    """
+    from clawmetry import entitlements as _ent
+
+    features_raw = request.args.get("features")
+    runtimes_raw = request.args.get("runtimes")
+
+    known_features: list[str] = []
+    unknown_features: list[str] = []
+    features_supplied = features_raw is not None
+    if features_supplied:
+        for fid in _parse_csv_arg("features"):
+            if fid in _ent.ALL_FEATURES:
+                if fid not in known_features:
+                    known_features.append(fid)
+            elif fid not in unknown_features:
+                unknown_features.append(fid)
+
+    known_runtimes: list[str] = []
+    unknown_runtimes: list[str] = []
+    runtimes_supplied = runtimes_raw is not None
+    if runtimes_supplied:
+        for rid_raw in _parse_csv_arg("runtimes"):
+            rid = _ent.canonical_runtime(rid_raw) or rid_raw
+            if rid in _ent.ALL_RUNTIMES:
+                if rid not in known_runtimes:
+                    known_runtimes.append(rid)
+            elif rid_raw not in unknown_runtimes:
+                unknown_runtimes.append(rid_raw)
+
+    (
+        channels_present,
+        channels_ok,
+        channels_n,
+        channels_raw,
+    ) = _parse_capacity_arg("channels")
+    (
+        retention_present,
+        retention_ok,
+        retention_n,
+        retention_raw,
+    ) = _parse_capacity_arg("retention_days")
+    (
+        nodes_present,
+        nodes_ok,
+        nodes_n,
+        nodes_raw,
+    ) = _parse_capacity_arg("nodes")
+
+    supplied_axes: list[str] = []
+    if features_supplied:
+        supplied_axes.append("features")
+    if runtimes_supplied:
+        supplied_axes.append("runtimes")
+    if channels_present:
+        supplied_axes.append("channels")
+    if retention_present:
+        supplied_axes.append("retention_days")
+    if nodes_present:
+        supplied_axes.append("nodes")
+
+    # Delegate per-grant-axis to the scalar so the endpoint stays
+    # byte-parity with :func:`missing_all_at` on the known-only subsets;
+    # unknown tokens are appended AFTER the scalar so the endpoint's
+    # diagnostics surface is a strict superset of the module scalar's
+    # (matches the LIVE ``/missing-all`` sibling posture byte-for-byte).
+    features_missing: list = []
+    if features_supplied:
+        features_missing = list(
+            _ent.missing_features_at(perspective_tier, known_features)
+        )
+        for token in unknown_features:
+            if token not in features_missing:
+                features_missing.append(token)
+
+    runtimes_missing: list = []
+    if runtimes_supplied:
+        runtimes_missing = list(
+            _ent.missing_runtimes_at(perspective_tier, known_runtimes)
+        )
+        for token in unknown_runtimes:
+            if token not in runtimes_missing:
+                runtimes_missing.append(token)
+
+    # Capacity axes: raw string surfaces on a supplied-but-unparseable
+    # value so a UI can flag the typo; otherwise the scalar's per-axis
+    # missing rule (SUPPLIED int if denied, None otherwise).
+    def _capacity_missing(present: bool, ok: bool, n, raw, denied_fn):
+        if not present:
+            return None
+        if not ok:
+            return raw
+        try:
+            return n if not denied_fn(perspective_tier, n) else None
+        except Exception:
+            return None
+
+    channels_missing = _capacity_missing(
+        channels_present,
+        channels_ok,
+        channels_n,
+        channels_raw,
+        _ent.has_channel_count_at,
+    )
+    retention_missing = _capacity_missing(
+        retention_present,
+        retention_ok,
+        retention_n,
+        retention_raw,
+        _ent.has_retention_window_at,
+    )
+    nodes_missing = _capacity_missing(
+        nodes_present,
+        nodes_ok,
+        nodes_n,
+        nodes_raw,
+        _ent.has_node_count_at,
+    )
+
+    missing_count = 0
+    if features_missing:
+        missing_count += 1
+    if runtimes_missing:
+        missing_count += 1
+    if channels_missing is not None:
+        missing_count += 1
+    if retention_missing is not None:
+        missing_count += 1
+    if nodes_missing is not None:
+        missing_count += 1
+
+    required = _ent.min_tier_for_all(
+        features=known_features or None,
+        runtimes=known_runtimes or None,
+        channels=channels_n if channels_present and channels_ok else None,
+        retention_days=(
+            retention_n if retention_present and retention_ok else None
+        ),
+        nodes=nodes_n if nodes_present and nodes_ok else None,
+    )
+
+    env = _resolver_envelope(_ent)
+    required_label = _ent.tier_label(required) if required else None
+    req_rank = _ent.tier_rank(required) if required else -1
+
+    return {
+        "perspective_tier": perspective_tier,
+        "perspective_tier_label": _ent.tier_label(perspective_tier),
+        "perspective_tier_rank": _ent.tier_rank(perspective_tier),
+        "features": features_missing,
+        "runtimes": runtimes_missing,
+        "channels": channels_missing,
+        "retention_days": retention_missing,
+        "nodes": nodes_missing,
+        "unknown_features": unknown_features,
+        "unknown_runtimes": unknown_runtimes,
+        "supplied_axes": supplied_axes,
+        "supplied_count": len(supplied_axes),
+        "missing_count": missing_count,
+        "any_missing": missing_count > 0,
+        "required_tier": required,
+        "required_tier_label": required_label,
+        "required_tier_rank": req_rank,
+        "current_tier": env["current_tier"],
+        "current_tier_rank": env["current_tier_rank"],
+        "grace": env["grace"],
+        "enforced": env["enforced"],
+    }
+
+
+@bp_entitlement.route("/api/entitlement/missing-all-at")
+def api_entitlement_missing_all_at():
+    """``GET /api/entitlement/missing-all-at?tier=<perspective>
+    &features=a,b&runtimes=x,y&channels=5&retention_days=30&nodes=2`` --
+    hypothetical-perspective mixed-axis row-detail complement scalar.
+
+    Perspective-shaped row-detail sibling of ``/api/entitlement/missing-all``:
+    same aggregate mixed-axis fold, but the per-axis missing lists answer
+    "which subset would tier ``<perspective>`` NOT grant?" from the static
+    per-tier grant tables instead of "which subset does the resolved
+    entitlement not grant right now?" from the live resolver. A paywall
+    diagnostics tile that renders "on OSS you'd still be missing fleet +
+    claude_code + 100 channels + 90d retention + 99 nodes -- upgrade to
+    unlock" binds every per-axis slot directly off this URL per
+    perspective without switching the resolver.
+
+    Fills the ``_at`` slot on the mixed-axis row-detail complement family
+    alongside :func:`_has_all_at_body` (boolean-fold sibling) and the
+    singular row-detail ``_at`` endpoints ``/missing-features-at`` /
+    ``/missing-runtimes-at`` for the two grant axes.
+
+    Every axis is OPTIONAL. Supply any non-empty subset; the envelope
+    always carries every axis' slot for byte-stable shape across every
+    URL branch. Runtime-alias canonicalisation (``claude-code`` ->
+    ``claude_code``) is applied per token before the known/unknown split.
+    Capacity axes accept a single int (``5``); blank / non-int values
+    surface the raw string in the per-axis missing slot so a UI can flag
+    the typo. Unknown feature / runtime tokens are surfaced INSIDE the
+    per-axis missing list AND echoed in ``unknown_features`` /
+    ``unknown_runtimes`` for a diagnostics tooltip.
+
+    Perspective-shaped answers are **intentionally identical in grace
+    and enforce** (they read the static per-tier tables via the singular
+    ``_at`` delegates, not the resolver's ``grace`` bit) -- the whole
+    point of the ``_at`` slot: ``/missing-all-at?tier=oss&features=fleet``
+    returns ``features=["fleet"]`` even in grace (because OSS statically
+    does not grant ``fleet``), whereas the LIVE
+    ``/missing-all?features=fleet`` reports ``features=[]`` for it via
+    :attr:`Entitlement.grace` pass-through.
+
+    - **400** on missing / blank ``tier=``.
+    - **404** on unknown ``tier=`` (body carries ``which=tier``).
+    - **Never 4xxs** on axis-side inputs -- no axes supplied returns 200
+      with every per-axis slot empty and ``any_missing=false`` (matches
+      ``/missing-all`` empty posture).
+    - **Never 5xxs**: a resolver / scalar / body-builder blowup yields
+      the fallback envelope with every per-axis slot empty and
+      ``any_missing=false`` so the pricing walkthrough keeps rendering.
+
+    Envelope shape (21 keys, byte-stable across every input branch)::
+
+        {
+          "perspective_tier":       "oss",
+          "perspective_tier_label": "OSS",
+          "perspective_tier_rank":  <int>,
+          "features":               ["fleet"],           # DENIED subset (+ unknowns)
+          "runtimes":               ["claude_code"],     # DENIED subset (+ unknowns)
+          "channels":               100 | null,          # supplied int if denied, else null
+          "retention_days":         90  | null,
+          "nodes":                  99  | null,
+          "unknown_features":       ["bogus"],
+          "unknown_runtimes":       [],
+          "supplied_axes":          ["features"],
+          "supplied_count":         1,
+          "missing_count":          1,
+          "any_missing":            true,
+          "required_tier":          "cloud_pro" | null,
+          "required_tier_label":    "Pro" | null,
+          "required_tier_rank":     <int>,               # -1 when null
+          "current_tier":           "oss",
+          "current_tier_rank":      0,
+          "grace":                  true,
+          "enforced":               false
+        }
+
+    Note the deliberate absence of ``upgrade_required``: this is the
+    perspective-shaped ``_at`` slot, so comparing against the LIVE
+    current-tier rank would double-count the perspective (matches the
+    singular ``/missing-features-at`` / ``/missing-runtimes-at`` and the
+    paired ``/has-all-at`` siblings which omit it for the same reason).
+    """
+    raw_tier = request.args.get("tier")
+    tier_in = (raw_tier or "").strip().lower()
+    if not tier_in:
+        return jsonify({"error": "missing tier"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        if tier_in not in _ent._TIER_ORDER:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "tier", "tier": tier_in}
+                ),
+                404,
+            )
+        return jsonify(_missing_all_at_body(tier_in))
+    except Exception as exc:
+        logger.warning("api_entitlement_missing_all_at: error: %s", exc)
+        return jsonify(_missing_all_at_fallback(tier_in))
+
+
 @bp_entitlement.route("/api/entitlement/has-all")
 def api_entitlement_has_all():
     """``GET /api/entitlement/has-all?features=a,b&runtimes=x,y&channels=5&retention_days=30&nodes=2``

--- a/tests/test_entitlement_missing_all_at.py
+++ b/tests/test_entitlement_missing_all_at.py
@@ -1,0 +1,909 @@
+"""Tests for the hypothetical-perspective mixed-axis ``missing_all_at(...)``
+row-detail complement scalar and its paired ``/api/entitlement/missing-all-at``
+endpoint.
+
+Perspective-shaped row-detail sibling of :func:`clawmetry.entitlements.missing_all`
+(which folds the same five kwargs against the LIVE resolver): a paywall
+diagnostics tile that renders per-axis denial detail per hypothetical tier
+("if I were on OSS, you'd still be missing fleet + claude_code + 100 channels")
+binds every per-axis slot off ONE call per (perspective, bundle) cell instead
+of five singular ``_at`` round-trips + a client-side per-axis stitch.
+
+This file pins:
+
+1. Scalar per-axis rules under grace vs enforce for every combination of the
+   five axes (features / runtimes / channels / retention_days / nodes),
+   including per-axis empty / None / unknown / non-int inputs.
+2. Perspective validation (empty / non-string / unknown -> empty per-axis
+   dict at the scalar; 400 / 404 at the endpoint).
+3. **Grace-independence invariant**: ``missing_all_at(p, ...)`` returns the
+   same per-axis dict under both grace and enforce for every ``p`` and every
+   input (delegates to the singular ``_at`` scalars, which are backed by the
+   static per-tier tables via :func:`_hypothetical_entitlement`).
+4. Endpoint envelope shape parity (fixed 21-key set) across every input
+   branch so a frontend can bind fields off the URL without a branch on
+   the underlying resolver state.
+5. Never-4xx on axis-side inputs; 400 on missing / blank tier; 404 on
+   unknown tier; never 5xx.
+6. Cross-consistency with the singular ``/missing-features-at`` /
+   ``/missing-runtimes-at`` endpoints on the two grant axes.
+7. Scalar-vs-endpoint parity on the known-only subsets (the endpoint's
+   per-axis missing list is a strict superset of the scalar's -- unknown
+   tokens are appended at endpoint layer for the diagnostics tooltip).
+8. Symmetry with :func:`has_all_at`: ``any(missing_all_at(p, **b).values())``
+   is the strict negation of ``has_all_at(p, **b)`` on every fully-parseable
+   bundle.
+9. Deliberate divergence from the LIVE ``/missing-all`` sibling: a bundle
+   the resolver grants under grace can still report a non-empty per-axis
+   missing list on the OSS perspective (that's the whole point of the
+   ``_at`` slot).
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+# -- Fixtures ------------------------------------------------------------------
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    """Fresh entitlements module in OSS-free-grace mode."""
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def enforced(monkeypatch, tmp_path):
+    """Enforcement-on fixture: ``CLAWMETRY_ENFORCE=1`` flips ``ent.grace``
+    off so the grace pass-through collapses. Perspective-shaped answers
+    are intentionally identical in grace and enforce; this fixture pins
+    that invariant."""
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    importlib.reload(e)
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# -- Envelope shape ------------------------------------------------------------
+
+_MISSING_ALL_AT_KEYS = {
+    "perspective_tier",
+    "perspective_tier_label",
+    "perspective_tier_rank",
+    "features",
+    "runtimes",
+    "channels",
+    "retention_days",
+    "nodes",
+    "unknown_features",
+    "unknown_runtimes",
+    "supplied_axes",
+    "supplied_count",
+    "missing_count",
+    "any_missing",
+    "required_tier",
+    "required_tier_label",
+    "required_tier_rank",
+    "current_tier",
+    "current_tier_rank",
+    "grace",
+    "enforced",
+}
+
+_SCALAR_KEYS = {"features", "runtimes", "channels", "retention_days", "nodes"}
+
+
+def _get_json(client, url: str) -> dict:
+    resp = client.get(url)
+    assert resp.status_code == 200, url
+    return resp.get_json()
+
+
+# -- Scalar: perspective validation --------------------------------------------
+
+
+def test_missing_all_at_unknown_perspective_is_empty(ent):
+    out = ent.missing_all_at("bogus", features=["fleet"])
+    assert set(out.keys()) == _SCALAR_KEYS
+    assert out == {
+        "features": [],
+        "runtimes": [],
+        "channels": None,
+        "retention_days": None,
+        "nodes": None,
+    }
+
+
+def test_missing_all_at_empty_perspective_is_empty(ent):
+    out = ent.missing_all_at("", features=["fleet"])
+    assert out["features"] == []
+
+
+def test_missing_all_at_none_perspective_is_empty(ent):
+    out = ent.missing_all_at(None, features=["fleet"])  # type: ignore[arg-type]
+    assert out["features"] == []
+
+
+def test_missing_all_at_non_string_perspective_is_empty(ent):
+    out = ent.missing_all_at(123, features=["fleet"])  # type: ignore[arg-type]
+    assert out["features"] == []
+
+
+def test_missing_all_at_perspective_case_and_whitespace_normalised(ent):
+    a = ent.missing_all_at("  CLOUD_PRO  ", features=["fleet"])
+    b = ent.missing_all_at("cloud_pro", features=["fleet"])
+    assert a == b
+
+
+# -- Scalar: no axes supplied --------------------------------------------------
+
+
+def test_missing_all_at_no_axes_supplied_is_empty(ent):
+    """Nothing supplied -> every per-axis slot empty."""
+    for tier in ent._TIER_ORDER:
+        assert ent.missing_all_at(tier) == {
+            "features": [],
+            "runtimes": [],
+            "channels": None,
+            "retention_days": None,
+            "nodes": None,
+        }, tier
+
+
+def test_missing_all_at_no_axes_supplied_is_empty_after_enforcement(enforced):
+    for tier in enforced._TIER_ORDER:
+        out = enforced.missing_all_at(tier)
+        assert out["features"] == [] and out["runtimes"] == []
+        assert (
+            out["channels"] is None
+            and out["retention_days"] is None
+            and out["nodes"] is None
+        )
+
+
+# -- Scalar: shape stability ---------------------------------------------------
+
+
+def test_missing_all_at_shape_stable_across_axis_combos(ent):
+    combos = [
+        {"features": ["fleet"]},
+        {"runtimes": ["claude_code"]},
+        {"channels": 100},
+        {"retention_days": 90},
+        {"nodes": 99},
+        {"features": ["fleet"], "runtimes": ["claude_code"]},
+        {
+            "features": ["fleet"],
+            "runtimes": ["claude_code"],
+            "channels": 100,
+            "retention_days": 90,
+            "nodes": 99,
+        },
+    ]
+    for kw in combos:
+        out = ent.missing_all_at("oss", **kw)  # type: ignore[arg-type]
+        assert set(out.keys()) == _SCALAR_KEYS, kw
+
+
+# -- Scalar: perspective-shaped semantics on free bundles ----------------------
+
+
+def test_missing_all_at_oss_free_bundle_is_empty(ent):
+    free_f = next(iter(ent.FREE_FEATURES))
+    free_r = next(iter(ent.FREE_RUNTIMES))
+    out = ent.missing_all_at(
+        "oss",
+        features=[free_f],
+        runtimes=[free_r],
+        channels=1,
+        retention_days=1,
+        nodes=1,
+    )
+    assert out == {
+        "features": [],
+        "runtimes": [],
+        "channels": None,
+        "retention_days": None,
+        "nodes": None,
+    }
+
+
+def test_missing_all_at_every_tier_admits_free_bundle(ent):
+    free_f = next(iter(ent.FREE_FEATURES))
+    free_r = next(iter(ent.FREE_RUNTIMES))
+    for tier in ent._TIER_ORDER:
+        out = ent.missing_all_at(
+            tier,
+            features=[free_f],
+            runtimes=[free_r],
+            channels=1,
+            retention_days=1,
+            nodes=1,
+        )
+        assert not any(
+            [out["features"], out["runtimes"]]
+        ), tier
+        assert (
+            out["channels"] is None
+            and out["retention_days"] is None
+            and out["nodes"] is None
+        ), tier
+
+
+# -- Scalar: perspective-shaped semantics on paid bundles ----------------------
+
+
+def test_missing_all_at_oss_denies_paid_feature(ent):
+    paid_f = next(iter(ent.PAID_FEATURES))
+    out = ent.missing_all_at("oss", features=[paid_f])
+    assert out["features"] == [paid_f]
+
+
+def test_missing_all_at_oss_denies_paid_runtime(ent):
+    paid_r = next(iter(ent.PAID_RUNTIMES))
+    out = ent.missing_all_at("oss", runtimes=[paid_r])
+    assert out["runtimes"] == [paid_r]
+
+
+def test_missing_all_at_oss_denies_big_channels(ent):
+    out = ent.missing_all_at("oss", channels=100)
+    assert out["channels"] == 100
+
+
+def test_missing_all_at_oss_denies_big_retention(ent):
+    out = ent.missing_all_at("oss", retention_days=365)
+    assert out["retention_days"] == 365
+
+
+def test_missing_all_at_oss_denies_big_nodes(ent):
+    out = ent.missing_all_at("oss", nodes=99)
+    assert out["nodes"] == 99
+
+
+def test_missing_all_at_cloud_pro_admits_paid_bundle(ent):
+    paid_f = next(iter(ent.PAID_FEATURES))
+    paid_r = next(iter(ent.PAID_RUNTIMES))
+    out = ent.missing_all_at(
+        "cloud_pro",
+        features=[paid_f],
+        runtimes=[paid_r],
+        channels=100,
+        retention_days=90,
+        nodes=1000,
+    )
+    assert out["features"] == []
+    assert out["runtimes"] == []
+    assert out["channels"] is None
+    assert out["retention_days"] is None
+    assert out["nodes"] is None
+
+
+def test_missing_all_at_enterprise_admits_paid_bundle(ent):
+    paid_f = next(iter(ent.PAID_FEATURES))
+    paid_r = next(iter(ent.PAID_RUNTIMES))
+    out = ent.missing_all_at(
+        "enterprise",
+        features=[paid_f],
+        runtimes=[paid_r],
+        channels=999,
+        retention_days=999999,
+        nodes=99999,
+    )
+    assert out["features"] == []
+    assert out["runtimes"] == []
+    assert out["channels"] is None
+    assert out["retention_days"] is None
+    assert out["nodes"] is None
+
+
+def test_missing_all_at_oss_denies_every_axis_on_full_paid_bundle(ent):
+    paid_f = next(iter(ent.PAID_FEATURES))
+    paid_r = next(iter(ent.PAID_RUNTIMES))
+    out = ent.missing_all_at(
+        "oss",
+        features=[paid_f],
+        runtimes=[paid_r],
+        channels=100,
+        retention_days=90,
+        nodes=99,
+    )
+    assert out["features"] == [paid_f]
+    assert out["runtimes"] == [paid_r]
+    assert out["channels"] == 100
+    assert out["retention_days"] == 90
+    assert out["nodes"] == 99
+
+
+# -- Scalar: grace-independence invariant --------------------------------------
+
+
+def test_missing_all_at_grace_vs_enforce_byte_identical_on_oss(
+    monkeypatch, tmp_path
+):
+    """The whole point of the ``_at`` slot: perspective-shaped answers
+    read the static per-tier tables and are grace-independent."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    paid_f = next(iter(e.PAID_FEATURES))
+    paid_r = next(iter(e.PAID_RUNTIMES))
+    grace = e.missing_all_at(
+        "oss",
+        features=[paid_f],
+        runtimes=[paid_r],
+        channels=5,
+        retention_days=30,
+        nodes=2,
+    )
+
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    importlib.reload(e)
+    e.invalidate()
+    enforce = e.missing_all_at(
+        "oss",
+        features=[paid_f],
+        runtimes=[paid_r],
+        channels=5,
+        retention_days=30,
+        nodes=2,
+    )
+    assert grace == enforce
+    assert grace["features"] == [paid_f]
+
+
+def test_missing_all_at_grace_vs_enforce_byte_identical_on_cloud_pro(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    paid_f = next(iter(e.PAID_FEATURES))
+    paid_r = next(iter(e.PAID_RUNTIMES))
+    grace = e.missing_all_at(
+        "cloud_pro", features=[paid_f], runtimes=[paid_r], channels=5
+    )
+
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    importlib.reload(e)
+    e.invalidate()
+    enforce = e.missing_all_at(
+        "cloud_pro", features=[paid_f], runtimes=[paid_r], channels=5
+    )
+    assert grace == enforce
+    assert grace["features"] == []
+
+
+# -- Scalar: divergence from live missing_all in grace -------------------------
+
+
+def test_missing_all_at_diverges_from_missing_features_on_oss_paid_bundle(ent):
+    """LIVE missing_features reports [] in grace; _at reports the paid
+    feature from the OSS perspective (static per-tier tables). Whole
+    point of the slot."""
+    paid_f = next(iter(ent.PAID_FEATURES))
+    live = ent.missing_features([paid_f])
+    perspective = ent.missing_all_at("oss", features=[paid_f])
+    assert live == []
+    assert perspective["features"] == [paid_f]
+
+
+# -- Scalar: empty inputs on supplied axes -------------------------------------
+
+
+def test_missing_all_at_features_empty_iterable(ent):
+    out = ent.missing_all_at("cloud_pro", features=[])
+    assert out["features"] == []
+    out = ent.missing_all_at("cloud_pro", features=())
+    assert out["features"] == []
+
+
+def test_missing_all_at_runtimes_empty_iterable(ent):
+    out = ent.missing_all_at("cloud_pro", runtimes=[])
+    assert out["runtimes"] == []
+
+
+# -- Scalar: unknown / typo'd inputs -------------------------------------------
+
+
+def test_missing_all_at_unknown_feature_included_in_missing(ent):
+    """Unknown/typo'd feature surfaces IN the missing list (matches
+    :func:`missing_features_at` typo posture)."""
+    out = ent.missing_all_at("cloud_pro", features=["fleet", "bogus_xyz"])
+    # Cloud Pro grants fleet -> only the typo surfaces.
+    assert out["features"] == ["bogus_xyz"]
+
+
+def test_missing_all_at_unknown_runtime_included_in_missing(ent):
+    out = ent.missing_all_at("cloud_pro", runtimes=["openclaw", "bogus_rt"])
+    assert out["runtimes"] == ["bogus_rt"]
+
+
+# -- Scalar: non-int capacity --------------------------------------------------
+
+
+def test_missing_all_at_non_int_channels_is_none(ent):
+    """Non-int capacity swallows to None on the scalar (paired has_all_at
+    reports False via strict singular scalar; a UI wanting the coherent
+    'supplied but denied' story on this branch should call has_all_at)."""
+    out = ent.missing_all_at("cloud_pro", channels="five")  # type: ignore[arg-type]
+    assert out["channels"] is None
+
+
+def test_missing_all_at_non_int_nodes_is_none(ent):
+    out = ent.missing_all_at("cloud_pro", nodes="two")  # type: ignore[arg-type]
+    assert out["nodes"] is None
+
+
+def test_missing_all_at_non_int_retention_is_none(ent):
+    out = ent.missing_all_at("cloud_pro", retention_days="seven")  # type: ignore[arg-type]
+    assert out["retention_days"] is None
+
+
+def test_missing_all_at_bool_channels_is_none(ent):
+    """`True`/`False` on capacity axes should NOT be silently coerced to
+    1/0 via the isinstance-int leak that bool inherits from int."""
+    out = ent.missing_all_at("oss", channels=True)  # type: ignore[arg-type]
+    assert out["channels"] is None
+
+
+# -- Scalar: retention_days=None means unsupplied ------------------------------
+
+
+def test_missing_all_at_retention_none_is_unsupplied_not_unlimited(ent):
+    out = ent.missing_all_at("cloud_pro", channels=1, retention_days=None)
+    assert out["retention_days"] is None
+    assert out["channels"] is None
+
+
+# -- Scalar: symmetry with has_all_at ------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"features": ["fleet"]},
+        {"runtimes": ["claude_code"]},
+        {"channels": 100},
+        {"retention_days": 90},
+        {"nodes": 99},
+        {"features": ["fleet"], "channels": 5},
+        {
+            "features": ["fleet"],
+            "runtimes": ["claude_code"],
+            "channels": 100,
+            "retention_days": 90,
+            "nodes": 99,
+        },
+    ],
+)
+@pytest.mark.parametrize("tier", ["oss", "cloud_starter", "cloud_pro", "enterprise"])
+def test_missing_all_at_negates_has_all_at_on_fully_parseable_bundles(
+    ent, tier, kwargs
+):
+    """``any(missing_all_at(p, **b).values())`` is the strict negation of
+    ``has_all_at(p, **b)`` on every fully-parseable bundle."""
+    missing = ent.missing_all_at(tier, **kwargs)  # type: ignore[arg-type]
+    has = ent.has_all_at(tier, **kwargs)
+    any_missing = any(
+        [
+            missing["features"],
+            missing["runtimes"],
+            missing["channels"] is not None,
+            missing["retention_days"] is not None,
+            missing["nodes"] is not None,
+        ]
+    )
+    assert any_missing == (not has), (tier, kwargs, missing, has)
+
+
+# -- Scalar: cross-consistency with singular missing_*_at ----------------------
+
+
+def test_missing_all_at_features_matches_singular(ent):
+    for tier in ent._TIER_ORDER:
+        for bundle in ([], ["fleet"], ["nemo_governance"], ["fleet", "sso"]):
+            out = ent.missing_all_at(tier, features=bundle)
+            assert out["features"] == list(
+                ent.missing_features_at(tier, bundle)
+            ), (tier, bundle)
+
+
+def test_missing_all_at_runtimes_matches_singular(ent):
+    for tier in ent._TIER_ORDER:
+        for bundle in ([], ["openclaw"], ["claude_code"], ["openclaw", "claude_code"]):
+            out = ent.missing_all_at(tier, runtimes=bundle)
+            assert out["runtimes"] == list(
+                ent.missing_runtimes_at(tier, bundle)
+            ), (tier, bundle)
+
+
+# -- Scalar: never raises ------------------------------------------------------
+
+
+def test_missing_all_at_never_raises_on_features_delegate_blowup(
+    monkeypatch, ent
+):
+    def _boom(*a, **kw):
+        raise RuntimeError("delegate blowup")
+
+    monkeypatch.setattr(ent, "missing_features_at", _boom)
+    out = ent.missing_all_at("cloud_pro", features=["fleet"])
+    assert out["features"] == []
+
+
+def test_missing_all_at_never_raises_on_runtimes_delegate_blowup(
+    monkeypatch, ent
+):
+    def _boom(*a, **kw):
+        raise RuntimeError("delegate blowup")
+
+    monkeypatch.setattr(ent, "missing_runtimes_at", _boom)
+    out = ent.missing_all_at("cloud_pro", runtimes=["openclaw"])
+    assert out["runtimes"] == []
+
+
+def test_missing_all_at_never_raises_on_capacity_delegate_blowup(
+    monkeypatch, ent
+):
+    def _boom(*a, **kw):
+        raise RuntimeError("blowup")
+
+    monkeypatch.setattr(ent, "has_channel_count_at", _boom)
+    out = ent.missing_all_at("cloud_pro", channels=1)
+    assert out["channels"] is None
+
+
+# -- Endpoint: perspective validation ------------------------------------------
+
+
+def test_endpoint_missing_tier_is_400(client):
+    resp = client.get("/api/entitlement/missing-all-at")
+    assert resp.status_code == 400
+    assert resp.get_json() == {"error": "missing tier"}
+
+
+def test_endpoint_blank_tier_is_400(client):
+    resp = client.get("/api/entitlement/missing-all-at?tier=&features=fleet")
+    assert resp.status_code == 400
+    assert resp.get_json() == {"error": "missing tier"}
+
+
+def test_endpoint_unknown_tier_is_404(client):
+    resp = client.get(
+        "/api/entitlement/missing-all-at?tier=bogus_tier&features=fleet"
+    )
+    assert resp.status_code == 404
+    body = resp.get_json()
+    assert body["error"] == "unknown tier"
+    assert body["which"] == "tier"
+    assert body["tier"] == "bogus_tier"
+
+
+def test_endpoint_perspective_case_and_whitespace_normalised(client):
+    lower = _get_json(
+        client, "/api/entitlement/missing-all-at?tier=cloud_pro&features=fleet"
+    )
+    upper = _get_json(
+        client,
+        "/api/entitlement/missing-all-at?tier=%20CLOUD_PRO%20&features=fleet",
+    )
+    assert upper["features"] == lower["features"]
+    assert upper["perspective_tier"] == "cloud_pro"
+
+
+# -- Endpoint: envelope shape --------------------------------------------------
+
+
+def test_endpoint_no_axes_shape(client):
+    body = _get_json(client, "/api/entitlement/missing-all-at?tier=cloud_pro")
+    assert set(body.keys()) == _MISSING_ALL_AT_KEYS
+    assert body["perspective_tier"] == "cloud_pro"
+    assert body["features"] == []
+    assert body["runtimes"] == []
+    assert body["channels"] is None
+    assert body["retention_days"] is None
+    assert body["nodes"] is None
+    assert body["unknown_features"] == []
+    assert body["unknown_runtimes"] == []
+    assert body["supplied_axes"] == []
+    assert body["supplied_count"] == 0
+    assert body["missing_count"] == 0
+    assert body["any_missing"] is False
+
+
+def test_endpoint_all_free_axes_shape(client):
+    body = _get_json(
+        client,
+        "/api/entitlement/missing-all-at?tier=oss"
+        "&features=nemo_governance&runtimes=openclaw"
+        "&channels=1&retention_days=1&nodes=1",
+    )
+    assert set(body.keys()) == _MISSING_ALL_AT_KEYS
+    assert body["perspective_tier"] == "oss"
+    assert body["features"] == []
+    assert body["runtimes"] == []
+    assert body["channels"] is None
+    assert body["retention_days"] is None
+    assert body["nodes"] is None
+    assert body["supplied_axes"] == [
+        "features",
+        "runtimes",
+        "channels",
+        "retention_days",
+        "nodes",
+    ]
+    assert body["supplied_count"] == 5
+    assert body["missing_count"] == 0
+    assert body["any_missing"] is False
+
+
+def test_endpoint_paid_bundle_at_oss_is_denied_even_in_grace(client):
+    body = _get_json(
+        client, "/api/entitlement/missing-all-at?tier=oss&features=fleet"
+    )
+    assert body["features"] == ["fleet"]
+    assert body["missing_count"] == 1
+    assert body["any_missing"] is True
+    assert body["grace"] is True
+
+
+def test_endpoint_paid_bundle_at_cloud_pro_is_admitted(client):
+    body = _get_json(
+        client,
+        "/api/entitlement/missing-all-at?tier=cloud_pro"
+        "&features=fleet&runtimes=claude_code",
+    )
+    assert body["features"] == []
+    assert body["runtimes"] == []
+    assert body["missing_count"] == 0
+    assert body["any_missing"] is False
+
+
+def test_endpoint_full_paid_bundle_at_oss_missing_count_five(client):
+    body = _get_json(
+        client,
+        "/api/entitlement/missing-all-at?tier=oss"
+        "&features=fleet&runtimes=claude_code"
+        "&channels=100&retention_days=90&nodes=99",
+    )
+    assert body["features"] == ["fleet"]
+    assert body["runtimes"] == ["claude_code"]
+    assert body["channels"] == 100
+    assert body["retention_days"] == 90
+    assert body["nodes"] == 99
+    assert body["missing_count"] == 5
+    assert body["any_missing"] is True
+
+
+# -- Endpoint: unknown / typo tokens -------------------------------------------
+
+
+def test_endpoint_unknown_feature_surfaces_inside_missing_and_unknown_split(
+    client,
+):
+    body = _get_json(
+        client,
+        "/api/entitlement/missing-all-at?tier=cloud_pro&features=fleet,totally_fake_xyz",
+    )
+    # Cloud Pro grants fleet -> only the typo surfaces in features.
+    assert body["features"] == ["totally_fake_xyz"]
+    assert body["unknown_features"] == ["totally_fake_xyz"]
+    assert body["any_missing"] is True
+
+
+def test_endpoint_unknown_runtime_surfaces_inside_missing_and_unknown_split(
+    client,
+):
+    body = _get_json(
+        client,
+        "/api/entitlement/missing-all-at?tier=cloud_pro&runtimes=claude_code,totally_fake_rt",
+    )
+    assert body["runtimes"] == ["totally_fake_rt"]
+    assert body["unknown_runtimes"] == ["totally_fake_rt"]
+
+
+def test_endpoint_runtime_alias_canonicalisation(client):
+    """`claude-code` (hyphen) canonicalises to `claude_code` (underscore)
+    upstream of the strict scalar; a Cloud Pro perspective admits it so
+    the missing list is empty."""
+    body = _get_json(
+        client,
+        "/api/entitlement/missing-all-at?tier=cloud_pro&runtimes=claude-code",
+    )
+    assert body["runtimes"] == []
+    assert body["unknown_runtimes"] == []
+
+
+# -- Endpoint: capacity typo posture ------------------------------------------
+
+
+def test_endpoint_non_int_channels_surfaces_raw_string(client):
+    body = _get_json(
+        client, "/api/entitlement/missing-all-at?tier=cloud_pro&channels=five"
+    )
+    assert body["channels"] == "five"
+    assert body["supplied_axes"] == ["channels"]
+    assert body["any_missing"] is True
+
+
+def test_endpoint_blank_capacity_surfaces_raw_string(client):
+    body = _get_json(
+        client, "/api/entitlement/missing-all-at?tier=cloud_pro&channels="
+    )
+    # Blank capacity: raw string echoed (matches the sibling has-all-at
+    # posture where a supplied-but-unparseable axis collapses the fold).
+    assert body["supplied_axes"] == ["channels"]
+    assert body["channels"] == ""
+
+
+def test_endpoint_zero_channels_admitted_by_free_floor(client):
+    body = _get_json(
+        client, "/api/entitlement/missing-all-at?tier=oss&channels=0"
+    )
+    assert body["channels"] is None
+    assert body["missing_count"] == 0
+
+
+# -- Endpoint: cross-consistency with singular missing-*-at --------------------
+
+
+def test_endpoint_features_matches_singular_missing_features_at(client):
+    for tier in ("oss", "cloud_starter", "cloud_pro", "enterprise"):
+        url_all = (
+            f"/api/entitlement/missing-all-at?tier={tier}&features=fleet,sso"
+        )
+        url_one = (
+            f"/api/entitlement/missing-features-at?tier={tier}&features=fleet,sso"
+        )
+        body_all = _get_json(client, url_all)
+        body_one = _get_json(client, url_one)
+        assert body_all["features"] == body_one["missing"], tier
+
+
+def test_endpoint_runtimes_matches_singular_missing_runtimes_at(client):
+    for tier in ("oss", "cloud_starter", "cloud_pro", "enterprise"):
+        url_all = (
+            f"/api/entitlement/missing-all-at?tier={tier}"
+            "&runtimes=openclaw,claude_code"
+        )
+        url_one = (
+            f"/api/entitlement/missing-runtimes-at?tier={tier}"
+            "&runtimes=openclaw,claude_code"
+        )
+        body_all = _get_json(client, url_all)
+        body_one = _get_json(client, url_one)
+        assert body_all["runtimes"] == body_one["missing"], tier
+
+
+# -- Endpoint: scalar vs endpoint parity ---------------------------------------
+
+
+@pytest.mark.parametrize(
+    "url_kwargs, scalar_kwargs",
+    [
+        ("features=fleet", {"features": ["fleet"]}),
+        ("runtimes=claude_code", {"runtimes": ["claude_code"]}),
+        ("channels=100", {"channels": 100}),
+        ("retention_days=90", {"retention_days": 90}),
+        ("nodes=99", {"nodes": 99}),
+        (
+            "features=fleet&runtimes=claude_code&channels=100&retention_days=90&nodes=99",
+            {
+                "features": ["fleet"],
+                "runtimes": ["claude_code"],
+                "channels": 100,
+                "retention_days": 90,
+                "nodes": 99,
+            },
+        ),
+    ],
+)
+def test_endpoint_scalar_vs_body_parity_on_known_only_bundles(
+    client, ent, url_kwargs, scalar_kwargs
+):
+    for tier in ("oss", "cloud_starter", "cloud_pro", "enterprise"):
+        body = _get_json(
+            client, f"/api/entitlement/missing-all-at?tier={tier}&{url_kwargs}"
+        )
+        scalar = ent.missing_all_at(tier, **scalar_kwargs)  # type: ignore[arg-type]
+        for axis in ("features", "runtimes", "channels", "retention_days", "nodes"):
+            assert body[axis] == scalar[axis], (tier, axis, url_kwargs)
+
+
+# -- Endpoint: never 4xx / never 5xx across every input branch -----------------
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "/api/entitlement/missing-all-at?tier=cloud_pro",
+        "/api/entitlement/missing-all-at?tier=cloud_pro&features=",
+        "/api/entitlement/missing-all-at?tier=cloud_pro&runtimes=",
+        "/api/entitlement/missing-all-at?tier=cloud_pro&channels=",
+        "/api/entitlement/missing-all-at?tier=cloud_pro&features=totally_fake",
+        "/api/entitlement/missing-all-at?tier=cloud_pro&runtimes=totally_fake",
+        "/api/entitlement/missing-all-at?tier=cloud_pro&channels=five",
+    ],
+)
+def test_endpoint_never_4xx_on_axis_side_inputs(client, url):
+    resp = client.get(url)
+    assert resp.status_code == 200, url
+    body = resp.get_json()
+    assert set(body.keys()) == _MISSING_ALL_AT_KEYS
+
+
+def test_endpoint_never_5xx_on_body_builder_blowup(monkeypatch, client):
+    """A body-builder blowup collapses to the fallback envelope with
+    stable 21-key shape."""
+    import routes.entitlement as re_mod
+
+    def _boom(*a, **kw):
+        raise RuntimeError("body builder blowup")
+
+    monkeypatch.setattr(re_mod, "_missing_all_at_body", _boom)
+    resp = client.get("/api/entitlement/missing-all-at?tier=cloud_pro&features=fleet")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert set(body.keys()) == _MISSING_ALL_AT_KEYS
+    assert body["features"] == []
+    assert body["runtimes"] == []
+    assert body["any_missing"] is False
+
+
+# -- Endpoint: required_tier fold ----------------------------------------------
+
+
+def test_endpoint_required_tier_folds_through_min_tier_for_all(client, ent):
+    body = _get_json(
+        client, "/api/entitlement/missing-all-at?tier=oss&features=fleet"
+    )
+    expected = ent.min_tier_for_all(features=["fleet"])
+    assert body["required_tier"] == expected
+
+
+def test_endpoint_required_tier_is_none_on_no_axes(client):
+    body = _get_json(client, "/api/entitlement/missing-all-at?tier=cloud_pro")
+    assert body["required_tier"] is None
+    assert body["required_tier_label"] is None
+    assert body["required_tier_rank"] == -1
+
+
+# -- Endpoint: resolver envelope carried in grace ------------------------------
+
+
+def test_endpoint_carries_resolver_envelope(client):
+    body = _get_json(client, "/api/entitlement/missing-all-at?tier=cloud_pro")
+    assert body["grace"] is True
+    assert body["enforced"] is False
+    assert body["current_tier"] == "oss"
+    assert body["current_tier_rank"] == 0


### PR DESCRIPTION
## Summary

Perspective-shaped row-detail sibling of `missing_all`: fills the `_at` slot on the mixed-axis row-detail complement family alongside `has_all_at` (boolean-fold sibling, merged in #4722) and the singular row-detail `_at` scalars `missing_features_at` / `missing_runtimes_at` for the two grant axes. A paywall diagnostics tile that renders per-axis denial detail per hypothetical tier ("if you were on OSS, you'd still be missing fleet + claude_code + 100 channels + 90d retention + 99 nodes — upgrade to unlock") binds every per-axis slot off ONE call per (perspective, bundle) cell instead of five singular `_at` round-trips + a client-side per-axis stitch.

- **`missing_all_at(perspective_tier, *, features, runtimes, channels, retention_days, nodes)`** in `clawmetry/entitlements.py` — returns a 5-key dict: grant axes delegate to `missing_features_at` / `missing_runtimes_at` for byte-for-byte parity with the singular scalars; capacity axes return the SUPPLIED int when the paired `has_channel_count_at` / `has_retention_window_at` / `has_node_count_at` denies it, `None` otherwise (or when the axis is unsupplied). **Grace-independent by construction**: every axis delegate reads the static per-tier grant tables (via `_hypothetical_entitlement` on the grant axes and the static `_TIER_CHANNEL_LIMIT` / `_TIER_RETENTION_DAYS` / `_TIER_NODE_LIMIT` tables on the capacity axes), so the returned dict is IDENTICAL under grace vs enforce for the same `(perspective, bundle)` pair. Non-int capacity swallows to `None` on this scalar (the paired `has_all_at` reports `False` via the strict singular scalar so the denial is coherently surfaced through the paired call); `bool` on a capacity axis explicitly swallows to `None` (not coerced to 1/0 via the isinstance-int leak). Never raises: any delegate failure logs a warning and collapses that axis to its empty seat.

- **`GET /api/entitlement/missing-all-at?tier=<perspective>&features=&runtimes=&channels=&retention_days=&nodes=`** on `bp_entitlement`. **21-key envelope** mirrors `/has-all-at` field-for-field with the boolean rollup slots (`has_all_at` + `allowed`) swapped for the row-detail rollup slots (`missing_count` + `any_missing`). Unknown grant tokens are ECHOED inside the per-axis missing list (dedup preserved) and still split into `unknown_features` / `unknown_runtimes` for a diagnostics tooltip. Supplied-but-unparseable capacity axis surfaces the raw string in that slot so a UI can flag the typo. `required_tier` folds through `min_tier_for_all` against the known-only subsets for parity with `/has-all` / `/has-all-at`.

Envelope + short-circuit posture mirrors the paired `/has-all-at`:

- **400** on missing / blank `tier`.
- **404** on unknown `tier` (body carries `which=tier`).
- **Never 4xxs** on axis-side inputs — no axes supplied returns 200 with every per-axis slot empty and `any_missing=false` (matches `/missing-all` empty posture); unknown grant token or non-int capacity surfaces inside the per-axis missing list without short-circuiting.
- **Never 5xxs** — resolver / scalar / body-builder blowup collapses to the fallback envelope with every per-axis slot empty and `any_missing=false` so the pricing walkthrough keeps rendering.

Behaviour ships in **GRACE** mode: the resolver still defaults to the OSS-free entitlement so no runtime gating changes. This is purely additive to the entitlement query surface. Perspective-shaped answers are **intentionally identical in grace and enforce** (they read the static per-tier tables via the singular `_at` delegates, not the resolver's `grace` bit) — the whole point of the `_at` slot: `/missing-all-at?tier=oss&features=fleet` returns `features=["fleet"]` even in grace (because OSS statically does not grant `fleet`), whereas LIVE `/missing-all?features=fleet` reports `features=[]` for it via `Entitlement.grace` pass-through.

Symmetry invariant with `has_all_at` pinned by parametric tests: for every fully-parseable bundle, `any(missing_all_at(p, **b).values())` is the strict negation of `has_all_at(p, **b)`.

Cross-consistency parity tests keep the per-axis lists pinned byte-equal to the singular `/missing-features-at` / `/missing-runtimes-at` endpoints on every `(perspective, bundle)` pair.

## Test plan

- [x] `python3 -m py_compile clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_missing_all_at.py`
- [x] `python3 -m ruff check tests/test_entitlement_missing_all_at.py` — clean.
- [x] `python3 -m ruff check --select I,F,E9 clawmetry/entitlements.py routes/entitlement.py` — clean (pre-existing BLE001 warnings across the module are not touched).
- [x] `python3 scripts/lint_daemon_allowlist.py` — passes (no `local_store_via_daemon` calls touched).
- [x] `python3 -m pytest tests/test_entitlement_missing_all_at.py` — **97/97 pass**, covering: scalar shape stability across every axis combo (features / runtimes / channels / retention_days / nodes / mixed / empty); perspective validation (empty / non-string / unknown → empty per-axis dict at the scalar; 400 / 404 at the endpoint); tier normalisation (whitespace / case); no-axes-supplied → every per-axis slot empty across every `_TIER_ORDER` perspective; free bundle at every tier → nothing missing; paid feature / runtime / big-capacity axes at OSS → surface in the per-axis missing slot; full paid bundle at OSS → `missing_count=5`; Cloud Pro / Enterprise admit paid bundle → every per-axis slot empty; **grace-independence invariant** (byte-identical dict under grace vs enforce for every parametric bundle at OSS / Cloud Pro); deliberate divergence from LIVE `missing_features` on OSS in grace; empty / unknown / non-int inputs on each axis; unknown/typo'd feature and runtime surface INSIDE the missing list; non-int capacity swallows to `None` on the scalar; `bool` on capacity axis explicitly swallows to `None` (isinstance-int leak guard); `retention_days=None` = unset (not unlimited); **symmetry with `has_all_at`** (parametric across 4 tiers × 7 bundles); cross-consistency with singular `missing_features_at` / `missing_runtimes_at`; never-raises on features / runtimes / capacity delegate blowup; endpoint envelope 21-key shape stability across every input branch; endpoint per-axis parity with the scalar on the known-only subset; endpoint runtime-alias canonicalisation (`claude-code` → `claude_code`) upstream of the strict scalar; endpoint unknown-token surface inside missing + split into `unknown_features` / `unknown_runtimes`; endpoint non-int capacity surfaces raw string; blank capacity surfaces raw string; zero channels admitted by free floor at OSS; cross-endpoint parity with `/missing-features-at` and `/missing-runtimes-at`; scalar-vs-endpoint parity across 6 parametric bundles × 4 tiers; never-4xx on 7 axis-side input branches; never-5xx on monkeypatched body-builder blowup; `required_tier` folds through `min_tier_for_all`; resolver envelope carried in grace.
- [x] `python3 -m pytest tests/test_entitlement_has_all.py tests/test_entitlement_has_all_at.py tests/test_entitlement_missing_features_runtimes.py tests/test_entitlement_missing_features_runtimes_at.py tests/test_entitlement_api.py` — **356/356 pass** (sibling regression: no envelope drift on the paired boolean-fold `/has-all-at`, no envelope drift on the LIVE `/has-all`, no shape drift on the singular `/missing-features-at` / `/missing-runtimes-at`, no shape drift on `/api/entitlement`).

## Local operator verification checklist

Since this fire runs in an ephemeral cloud container with no access to your local daemon, `~/.openclaw`, the live cloud snapshot, or a browser, please verify against the running host once you pull this branch:

- [ ] Copy the two changed files into your live install:
  ```
  cp clawmetry/entitlements.py ~/.clawmetry/lib/python3.*/site-packages/clawmetry/
  cp routes/entitlement.py     ~/.clawmetry/lib/python3.*/site-packages/routes/
  find ~/.clawmetry/lib -name __pycache__ -type d -exec rm -rf {} +
  ```
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` to restart the daemon and pick up the new endpoint.
- [ ] `curl -s 'http://localhost:8900/api/entitlement/missing-all-at?tier=oss&features=fleet' | jq .` — expect `features=["fleet"]`, `missing_count=1`, `any_missing=true`, `perspective_tier="oss"`, `grace=true`, `required_tier="cloud_starter"` (fleet's cheapest floor).
- [ ] `curl -s 'http://localhost:8900/api/entitlement/missing-all-at?tier=oss&features=fleet&runtimes=claude_code&channels=100&retention_days=90&nodes=99' | jq .` — expect every per-axis slot filled (`features=["fleet"]`, `runtimes=["claude_code"]`, `channels=100`, `retention_days=90`, `nodes=99`), `missing_count=5`, `any_missing=true`.
- [ ] `curl -s 'http://localhost:8900/api/entitlement/missing-all-at?tier=cloud_pro&features=fleet&runtimes=claude_code' | jq .` — expect `features=[]`, `runtimes=[]`, `missing_count=0`, `any_missing=false` (Cloud Pro admits the bundle).
- [ ] `curl -s 'http://localhost:8900/api/entitlement/missing-all-at?tier=cloud_pro&features=fleet,totally_fake_xyz' | jq .` — expect `features=["totally_fake_xyz"]` (typo surfaces INSIDE missing), `unknown_features=["totally_fake_xyz"]` (split preserved for diagnostics tooltip), `any_missing=true`.
- [ ] `curl -s 'http://localhost:8900/api/entitlement/missing-all-at?tier=cloud_pro&runtimes=claude-code' | jq '.runtimes'` — expect `[]` (alias canonicalises to `claude_code` upstream of the scalar and Cloud Pro admits it).
- [ ] `curl -s 'http://localhost:8900/api/entitlement/missing-all-at?tier=cloud_pro&channels=five' | jq '.channels'` — expect `"five"` (raw string echoed for unparseable capacity), `any_missing=true`, `supplied_axes=["channels"]`.
- [ ] `curl -s 'http://localhost:8900/api/entitlement/missing-all-at?tier=oss&channels=0' | jq '.channels'` — expect `null` (zero admitted by free floor).
- [ ] `curl -sw '\n%{http_code}\n' 'http://localhost:8900/api/entitlement/missing-all-at'` — expect **400** with `{"error":"missing tier"}`.
- [ ] `curl -sw '\n%{http_code}\n' 'http://localhost:8900/api/entitlement/missing-all-at?tier=bogus&features=fleet'` — expect **404** with `{"error":"unknown tier","which":"tier","tier":"bogus"}`.
- [ ] Cross-consistency: `curl -s '.../missing-all-at?tier=oss&features=fleet,sso' | jq '.features'` should byte-equal `curl -s '.../missing-features-at?tier=oss&features=fleet,sso' | jq '.missing'`.
- [ ] Cross-consistency: `curl -s '.../missing-all-at?tier=oss&runtimes=openclaw,claude_code' | jq '.runtimes'` should byte-equal `curl -s '.../missing-runtimes-at?tier=oss&runtimes=openclaw,claude_code' | jq '.missing'`.
- [ ] Symmetry check with `/has-all-at`: for every `(tier, bundle)` you try, `any_missing` from `/missing-all-at` should be the strict negation of `has_all_at` from `/has-all-at` on the same URL args.
- [ ] Deliberate divergence check: `curl -s '.../missing-all-at?tier=oss&features=fleet' | jq '.features'` should be `["fleet"]` even though `curl -s '.../missing-features?features=fleet' | jq '.missing'` is `[]` under grace (that's the whole point of the `_at` slot).
- [ ] `curl -s 'http://localhost:8900/api/entitlement' | jq .grace` — expect **true** (nothing about the resolver / gate changed — this PR is purely additive query surface).
- [ ] Decrypt the live cloud snapshot in the browser and confirm the dashboard's entitlement panels still render (no shape regression).

This PR stays **DRAFT** until you've done the local + cloud verification above. Version bump / `[RELEASE]` PR / merge is your call.

---
_Generated by [Claude Code](https://claude.ai/code/session_016bMKFiMvAUtS9cAqUdTHYw)_