### PR TITLE
feat(rules): /api/v2/rules REST backend — Rule Builder phase 1 (issue #1517)

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -148,6 +148,7 @@ from routes.runtime_ingest import bp_runtime_ingest
 from routes.audit import bp_audit
 from routes.sla import bp_sla
 from routes.hitl import bp_hitl
+from routes.rules import bp_rules
 from helpers.openapi import bp_openapi
 
 # History / time-series module
@@ -11958,6 +11959,7 @@ def detect_config(args=None):
     app.register_blueprint(bp_review)
     app.register_blueprint(bp_evals)
     app.register_blueprint(bp_hitl)
+    app.register_blueprint(bp_rules)
 
     # ── v2 React SPA (opt-in) ───────────────────────────────────────────────
     # Default OFF so existing v1 users notice nothing. Enabled when the user

--- a/routes/rules.py
+++ b/routes/rules.py
@@ -1,0 +1,182 @@
+"""
+routes/rules.py — Rule Builder backend endpoints.
+
+Phase 1 of issue #1517. Stores rule definitions as JSON files at
+``~/.clawmetry/rules/<id>.json`` and exposes a 30-day backtest against
+the local DuckDB event store via the existing daemon proxy.
+
+Routes:
+  GET    /api/v2/rules                — list saved rules
+  GET    /api/v2/rules/<rid>          — fetch one rule
+  PUT    /api/v2/rules/<rid>          — create / update a rule
+  DELETE /api/v2/rules/<rid>          — delete a rule
+  POST   /api/v2/rules/<rid>/backtest — count + sample matching events
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import re
+from datetime import datetime, timedelta, timezone
+
+from flask import Blueprint, jsonify, request
+
+bp_rules = Blueprint("rules", __name__)
+
+_ID_RE = re.compile(r"^[a-zA-Z0-9_\-]{1,80}$")
+
+
+def _rules_dir() -> pathlib.Path:
+    base = os.environ.get("CLAWMETRY_RULES_DIR") or os.path.expanduser(
+        "~/.clawmetry/rules"
+    )
+    p = pathlib.Path(base)
+    p.mkdir(parents=True, exist_ok=True)
+    return p
+
+
+def _safe_id(rid: str) -> bool:
+    return bool(_ID_RE.match(rid))
+
+
+def _load_rule(rid: str) -> dict | None:
+    path = _rules_dir() / f"{rid}.json"
+    try:
+        return json.loads(path.read_text())
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return None
+
+
+def _store_via_daemon_or_direct(method_name: str, **kwargs):
+    """Daemon HTTP proxy first, then direct DuckDB read-only fallback."""
+    try:
+        from routes.local_query import local_store_via_daemon
+
+        result = local_store_via_daemon(method_name, **kwargs)
+        if result is not None:
+            return result
+    except Exception:
+        pass
+    try:
+        from clawmetry import local_store
+
+        store = local_store.get_store(read_only=True)
+        return getattr(store, method_name)(**kwargs)
+    except Exception:
+        return None
+
+
+@bp_rules.route("/api/v2/rules", methods=["GET"])
+def list_rules():
+    """Return summary of all saved rules."""
+    try:
+        items = []
+        for fp in sorted(_rules_dir().glob("*.json")):
+            try:
+                rule = json.loads(fp.read_text())
+                items.append(
+                    {
+                        "id": fp.stem,
+                        "title": rule.get("title", fp.stem),
+                        "enabled": rule.get("enabled", True),
+                        "updated_at": rule.get("updated_at"),
+                    }
+                )
+            except Exception:
+                continue
+        return jsonify({"rules": items})
+    except Exception as exc:
+        return jsonify({"rules": [], "error": str(exc)[:300]})
+
+
+@bp_rules.route("/api/v2/rules/<rid>", methods=["GET"])
+def get_rule(rid: str):
+    """Fetch a single rule by id."""
+    if not _safe_id(rid):
+        return jsonify({"error": "invalid rule id"}), 400
+    rule = _load_rule(rid)
+    if rule is None:
+        return jsonify({"error": "not found"}), 404
+    return jsonify(rule)
+
+
+@bp_rules.route("/api/v2/rules/<rid>", methods=["PUT"])
+def put_rule(rid: str):
+    """Create or replace a rule. Body must be a JSON object."""
+    if not _safe_id(rid):
+        return jsonify({"error": "invalid rule id"}), 400
+    body = request.get_json(silent=True)
+    if not isinstance(body, dict):
+        return jsonify({"error": "body must be a JSON object"}), 400
+    body["id"] = rid
+    body["updated_at"] = datetime.now(timezone.utc).isoformat()
+    path = _rules_dir() / f"{rid}.json"
+    try:
+        path.write_text(json.dumps(body, ensure_ascii=False, indent=2))
+    except OSError as exc:
+        return jsonify({"error": str(exc)[:300]}), 500
+    return jsonify({"ok": True, "id": rid, "updated_at": body["updated_at"]})
+
+
+@bp_rules.route("/api/v2/rules/<rid>", methods=["DELETE"])
+def delete_rule(rid: str):
+    """Delete a saved rule."""
+    if not _safe_id(rid):
+        return jsonify({"error": "invalid rule id"}), 400
+    path = _rules_dir() / f"{rid}.json"
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        return jsonify({"error": "not found"}), 404
+    except OSError as exc:
+        return jsonify({"error": str(exc)[:300]}), 500
+    return jsonify({"ok": True, "id": rid})
+
+
+@bp_rules.route("/api/v2/rules/<rid>/backtest", methods=["POST"])
+def backtest_rule(rid: str):
+    """Count and sample events matching this rule over N days.
+
+    Query param: ``days`` (int, 1–90, default 30).
+    Reads ``rule.event_type`` (or ``rule.filter.event_type``) to filter events.
+    Uses ``query_events`` via the daemon proxy so the dashboard process never
+    opens DuckDB writable.
+    """
+    if not _safe_id(rid):
+        return jsonify({"error": "invalid rule id"}), 400
+    rule = _load_rule(rid)
+    if rule is None:
+        return jsonify({"error": "not found"}), 404
+
+    try:
+        days = max(1, min(90, int(request.args.get("days", 30))))
+    except (TypeError, ValueError):
+        days = 30
+
+    event_type = rule.get("event_type") or (
+        rule.get("filter") or {}
+    ).get("event_type")
+    since = (datetime.now(timezone.utc) - timedelta(days=days)).strftime(
+        "%Y-%m-%dT%H:%M:%SZ"
+    )
+
+    rows = (
+        _store_via_daemon_or_direct(
+            "query_events",
+            event_type=event_type or None,
+            since=since,
+            limit=200,
+        )
+        or []
+    )
+
+    return jsonify(
+        {
+            "rule_id": rid,
+            "window_days": days,
+            "matched": len(rows),
+            "sampled": rows[:10],
+        }
+    )

--- a/tests/test_rules_api.py
+++ b/tests/test_rules_api.py
@@ -1,0 +1,160 @@
+"""Tests for routes/rules.py — Rule Builder REST API (issue #1517)."""
+
+import json
+import os
+import pathlib
+import tempfile
+
+import pytest
+
+
+@pytest.fixture()
+def rules_dir(tmp_path, monkeypatch):
+    d = tmp_path / "rules"
+    d.mkdir()
+    monkeypatch.setenv("CLAWMETRY_RULES_DIR", str(d))
+    return d
+
+
+@pytest.fixture()
+def app(rules_dir):
+    from flask import Flask
+    from routes.rules import bp_rules
+
+    application = Flask(__name__)
+    application.register_blueprint(bp_rules)
+    application.config["TESTING"] = True
+    return application
+
+
+@pytest.fixture()
+def client(app):
+    return app.test_client()
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+def _put(client, rid, body):
+    return client.put(
+        f"/api/v2/rules/{rid}",
+        data=json.dumps(body),
+        content_type="application/json",
+    )
+
+
+def _post_backtest(client, rid, days=7):
+    return client.post(f"/api/v2/rules/{rid}/backtest?days={days}")
+
+
+# ── list ─────────────────────────────────────────────────────────────────────
+
+def test_list_empty(client):
+    r = client.get("/api/v2/rules")
+    assert r.status_code == 200
+    assert r.json["rules"] == []
+
+
+def test_list_after_put(client):
+    _put(client, "rule-a", {"title": "Rule A", "event_type": "tool.call"})
+    r = client.get("/api/v2/rules")
+    assert r.status_code == 200
+    assert len(r.json["rules"]) == 1
+    assert r.json["rules"][0]["id"] == "rule-a"
+    assert r.json["rules"][0]["title"] == "Rule A"
+
+
+# ── get ──────────────────────────────────────────────────────────────────────
+
+def test_get_missing(client):
+    r = client.get("/api/v2/rules/nonexistent")
+    assert r.status_code == 404
+
+
+def test_get_after_put(client):
+    _put(client, "my-rule", {"title": "My Rule", "enabled": False})
+    r = client.get("/api/v2/rules/my-rule")
+    assert r.status_code == 200
+    assert r.json["title"] == "My Rule"
+    assert r.json["enabled"] is False
+    assert r.json["id"] == "my-rule"
+
+
+# ── put ──────────────────────────────────────────────────────────────────────
+
+def test_put_creates(client, rules_dir):
+    r = _put(client, "rule-1", {"title": "T", "event_type": "llm.call"})
+    assert r.status_code == 200
+    assert r.json["ok"] is True
+    assert (rules_dir / "rule-1.json").exists()
+
+
+def test_put_invalid_id(client):
+    r = _put(client, "../escape", {"title": "x"})
+    assert r.status_code == 400
+
+
+def test_put_non_object_body(client):
+    r = client.put(
+        "/api/v2/rules/r1",
+        data=json.dumps([1, 2, 3]),
+        content_type="application/json",
+    )
+    assert r.status_code == 400
+
+
+def test_put_stamps_updated_at(client):
+    r = _put(client, "ts-rule", {"title": "T"})
+    assert "updated_at" in r.json
+
+
+# ── delete ───────────────────────────────────────────────────────────────────
+
+def test_delete_missing(client):
+    r = client.delete("/api/v2/rules/ghost")
+    assert r.status_code == 404
+
+
+def test_delete_removes_file(client, rules_dir):
+    _put(client, "del-me", {"title": "bye"})
+    assert (rules_dir / "del-me.json").exists()
+    r = client.delete("/api/v2/rules/del-me")
+    assert r.status_code == 200
+    assert not (rules_dir / "del-me.json").exists()
+
+
+# ── backtest ─────────────────────────────────────────────────────────────────
+
+def test_backtest_missing_rule(client):
+    r = _post_backtest(client, "no-such")
+    assert r.status_code == 404
+
+
+def test_backtest_returns_shape(client, monkeypatch):
+    _put(client, "bt-rule", {"title": "BT", "event_type": "tool.call"})
+
+    # Patch daemon call to return a controlled list of events
+    fake_events = [{"id": f"e{i}", "event_type": "tool.call"} for i in range(5)]
+
+    import routes.rules as rr
+    monkeypatch.setattr(
+        rr,
+        "_store_via_daemon_or_direct",
+        lambda *a, **kw: fake_events,
+    )
+
+    r = _post_backtest(client, "bt-rule", days=7)
+    assert r.status_code == 200
+    data = r.json
+    assert data["rule_id"] == "bt-rule"
+    assert data["window_days"] == 7
+    assert data["matched"] == 5
+    assert len(data["sampled"]) == 5
+
+
+def test_backtest_caps_days(client, monkeypatch):
+    _put(client, "cap-rule", {"title": "Cap"})
+    import routes.rules as rr
+    monkeypatch.setattr(rr, "_store_via_daemon_or_direct", lambda *a, **kw: [])
+    r = client.post("/api/v2/rules/cap-rule/backtest?days=999")
+    assert r.status_code == 200
+    assert r.json["window_days"] == 90


### PR DESCRIPTION
Closes #1517 (phase 1 — backend only)

## Summary

- **`routes/rules.py`** (new, ~160 LOC) — `bp_rules` Blueprint with 5 endpoints
- **`dashboard.py`** — 1-line import + 1-line `register_blueprint` (after `bp_hitl`)
- **`tests/test_rules_api.py`** (new, ~110 LOC) — 13 unit tests via Flask test client

## What changed

### Storage
Rules persist as JSON files at `~/.clawmetry/rules/<id>.json`, following the same pattern as Dives (`~/.clawmetry/dives/<slug>.json`). The directory is auto-created; overridable via `CLAWMETRY_RULES_DIR`.

### Endpoints

| Method | Path | Purpose |
|---|---|---|
| `GET` | `/api/v2/rules` | List all rules (id, title, enabled, updated_at) |
| `GET` | `/api/v2/rules/<id>` | Full rule definition |
| `PUT` | `/api/v2/rules/<id>` | Create / update (JSON body) |
| `DELETE` | `/api/v2/rules/<id>` | Remove |
| `POST` | `/api/v2/rules/<id>/backtest?days=30` | Count + sample matching events over N days |

### Backtest
Calls `local_store_via_daemon("query_events", event_type=..., since=..., limit=200)` — `query_events` is already in `_DAEMON_METHODS` so the proxy is fully wired. Falls back to a direct read-only DuckDB open when the daemon is not running. Returns `{matched, sampled[:10], window_days}`.

### ID validation
Rule IDs are validated against `^[a-zA-Z0-9_\-]{1,80}$` before any filesystem operation to prevent path traversal.

## What this does NOT include
- Visual node-graph builder UI (separate larger effort)
- Rule execution / enforcement hooks
- Alerting on rule violations

## Test plan

- [x] `python3 -c "import ast; ast.parse(open('routes/rules.py').read())"` — clean
- [x] `python3 -c "import ast; ast.parse(open('tests/test_rules_api.py').read())"` — clean
- [x] `from routes.rules import bp_rules` present in `dashboard.py`
- [x] `app.register_blueprint(bp_rules)` present in `dashboard.py`
- [ ] `pytest tests/test_rules_api.py` (runs in CI)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BJwXZ6ZFzz3satbi2UESbC)_