### PR TITLE
feat(entitlement): has_all_bundle_batch + /api/entitlement/has-all-bundle-batch(-at)

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -11867,6 +11867,378 @@ def has_all_at_batch(
     return {"tiers": rows, "unknown": unknown}
 
 
+def _normalise_all_bundle(bundle) -> tuple:
+    """Shared per-bundle normalisation for the aggregate 5-axis bundle
+    batches (:func:`has_all_bundle_batch` /
+    :func:`has_all_bundle_batch_at` and the reverse-lookup twin
+    :func:`_min_tier_for_all_bundle_row`).
+
+    Returns ``(features, runtimes, channels, retention_days, nodes)``
+    with the same normalisation posture the singular scalars and the
+    ``/required-tier-batch`` GET endpoint use so a caller can pass an
+    unnormalised bundle dict without a re-normalise step:
+
+    * ``features`` / ``runtimes`` -- CSV-normalised via
+      :func:`_normalise_csv` (whitespace stripped, lowercased, dedup
+      preserving first-seen order). Runtime tokens additionally
+      canonicalise via :func:`canonical_runtime` so aliases
+      (``claude-code`` -> ``claude_code``) resolve the same way as the
+      singular scalars, and duplicates that collapse after
+      canonicalisation only contribute once.
+    * ``channels`` / ``retention_days`` / ``nodes`` -- coerced through
+      ``int(str(v).strip())`` with a blank / non-int collapsing to
+      ``None`` so a typo cannot silently mis-route the aggregate. This
+      is DIFFERENT from :func:`has_all`, which treats a non-int on a
+      supplied axis as a strict typo (fold collapses to ``False``); at
+      the batch layer we prefer the "unset" reading because the paired
+      endpoint echoes the normalised value back so a caller can see the
+      dropped input on the row.
+
+    Non-dict bundles collapse to the empty tuple (matches
+    :func:`_min_tier_for_all_bundle_row` never-crash posture). Never
+    raises.
+    """
+    features: list[str] = []
+    runtimes: list[str] = []
+    channels: int | None = None
+    retention_days: int | None = None
+    nodes: int | None = None
+    try:
+        raw = bundle if isinstance(bundle, dict) else {}
+        features = _normalise_csv(raw.get("features"))
+        raw_rts = _normalise_csv(raw.get("runtimes"))
+        seen: set[str] = set()
+        for rt in raw_rts:
+            canon = canonical_runtime(rt)
+            key = canon if canon and canon in ALL_RUNTIMES else rt
+            if key in seen:
+                continue
+            seen.add(key)
+            runtimes.append(key)
+
+        def _coerce_int(val):
+            if val is None:
+                return None
+            try:
+                return int(str(val).strip())
+            except (TypeError, ValueError):
+                return None
+
+        channels = _coerce_int(raw.get("channels"))
+        retention_days = _coerce_int(raw.get("retention_days"))
+        nodes = _coerce_int(raw.get("nodes"))
+    except Exception as exc:
+        logger.warning(
+            "entitlements: _normalise_all_bundle failed: %s", exc
+        )
+    return (features, runtimes, channels, retention_days, nodes)
+
+
+def _has_all_bundle_row(bundle) -> dict:
+    """Per-bundle row shape for :func:`has_all_bundle_batch`.
+
+    Normalises one aggregate 5-axis bundle via
+    :func:`_normalise_all_bundle` (feature / runtime CSV + alias
+    canonicalisation, capacity int coercion with a blank / non-int
+    collapsing to ``None``), then folds it through :func:`has_all` for
+    the LIVE aggregate boolean.
+
+    Grace posture mirrors :func:`has_all` byte-for-byte: while
+    ``ent.grace`` is ``True`` (the current rollout state) every fully-
+    known bundle reports ``has_all=True``; post-enforcement each row
+    reflects the underlying :meth:`Entitlement.allows_*` answer.
+
+    Row keys mirror the paired ``/api/entitlement/has-all-bundle-batch``
+    endpoint body minus the resolver envelope (``features``,
+    ``runtimes``, ``channels``, ``retention_days``, ``nodes``,
+    ``has_all``). Empty / all-``None`` axes (empty bundle) surface as a
+    stable row with ``has_all=False`` -- distinguishes "caller asked for
+    nothing" from "caller asked and every axis was a typo" and matches
+    the singular :func:`has_all` empty-``False`` posture.
+
+    Never raises: a per-bundle failure returns the empty row shape so
+    the batch keeps building.
+    """
+    features, runtimes, channels, retention_days, nodes = _normalise_all_bundle(
+        bundle
+    )
+    try:
+        allowed = has_all(
+            features=features or None,
+            runtimes=runtimes or None,
+            channels=channels,
+            retention_days=retention_days,
+            nodes=nodes,
+        )
+    except Exception as exc:
+        logger.warning(
+            "entitlements: _has_all_bundle_row fold failed: %s", exc
+        )
+        allowed = False
+    return {
+        "features": features,
+        "runtimes": runtimes,
+        "channels": channels,
+        "retention_days": retention_days,
+        "nodes": nodes,
+        "has_all": bool(allowed),
+    }
+
+
+def has_all_bundle_batch(bundles) -> list[dict]:
+    """Per-bundle aggregate boolean-fold grant for N caller-supplied
+    5-axis bundles in ONE round-trip.
+
+    Bundle-axis batch sibling of :func:`has_all` (which folds ONE
+    aggregate bundle to ONE boolean) on the boolean-fold slot, in the
+    same relationship :func:`min_tier_for_all_batch` has to
+    :func:`min_tier_for_all` on the reverse-lookup slot. Where the
+    singular helper answers "does the CURRENT install grant THIS whole
+    5-axis subscription state?", this answers the same question for N
+    distinct bundles at once so a paywall matrix or upgrade-walkthrough
+    surface comparing several hypothetical whole configs
+    (e.g. "Starter-shaped install vs Pro-shaped install vs Enterprise-
+    shaped install") renders off ONE call instead of N calls to
+    :func:`has_all`.
+
+    Distinct from :func:`has_features_batch` / :func:`has_runtimes_batch`
+    (which batch N *single-axis* bundles) and from :func:`has_batch`
+    (per-*item* rows for one flat bundle -- rows are individual
+    feature / runtime / capacity ids). This helper preserves the per-
+    bundle grouping AND the cross-axis aggregation: each row is the
+    aggregate fold-answer for that whole 5-axis bundle, not a fold-
+    answer per item or per single axis.
+
+    Also distinct from :func:`has_all_at_batch` (which fixes ONE bundle
+    and sweeps N perspective tiers): this fixes N bundles and reads the
+    LIVE per-install grant.
+
+    Row shape mirrors :func:`min_tier_for_all_batch` on the axis echo
+    slots (byte-parity so a UI that unions the two batches sees a
+    consistent shape) with the fold slot swapped from ``required_tier``
+    to ``has_all``::
+
+        {
+          "features":       ["fleet"],
+          "runtimes":       ["claude_code"],
+          "channels":       5 | None,
+          "retention_days": 30 | None,
+          "nodes":          2 | None,
+          "has_all":        <bool>,
+        }
+
+    Per-bundle normalisation is delegated to
+    :func:`_normalise_all_bundle`, which matches the singular endpoint
+    exactly: CSV normalisation on features / runtimes; runtime aliases
+    (``claude-code`` -> ``claude_code``) canonicalised; capacity axes
+    coerced through ``int(...)`` with a blank / non-int collapsing to
+    ``None``. Empty bundles / all-``None`` axes surface as a stable row
+    with ``has_all=False`` (matches :func:`has_all` empty-``False``
+    posture; a caller who forgot to pass any kwarg in one row of the
+    batch sees the typo at that row instead of a silent grant).
+
+    Grace posture per-row mirrors :func:`has_all` byte-for-byte: while
+    ``ent.grace`` is ``True`` every fully-known bundle reports
+    ``has_all=True``; post-enforcement each row reflects the underlying
+    :meth:`Entitlement.allows_*` answer.
+
+    Argument handling:
+
+    * ``bundles is None`` or non-iterable -- returns ``[]``.
+    * Each bundle may itself be ``None``, non-dict, or empty -- the
+      helper emits a stable row (``has_all=False`` on empty / non-dict).
+    * Non-dict bundle rows (e.g. a bare list) collapse to the empty row
+      shape (matches the never-crash posture of every other bundle
+      helper).
+
+    Critically, ``retention_days=None`` inside a bundle means *unset* --
+    NOT *unlimited*. Same posture as :func:`min_tier_for_all_batch` /
+    :func:`has_all`: asking about the unlimited-retention grant is the
+    singular :meth:`Entitlement.allows_retention_window` (``days=None``)
+    call's job and would collapse the row's kwarg-branch to "not
+    supplied" otherwise.
+
+    Never raises: per-bundle failures short-circuit to the empty row
+    shape (``has_all=False``) so the batch keeps building.
+    """
+    try:
+        if bundles is None:
+            return []
+        items = list(bundles)
+    except TypeError:
+        return []
+    out: list[dict] = []
+    for bundle in items:
+        try:
+            out.append(_has_all_bundle_row(bundle))
+        except Exception as exc:
+            logger.warning(
+                "entitlements: has_all_bundle_batch row failed: %s", exc
+            )
+            out.append(
+                {
+                    "features": [],
+                    "runtimes": [],
+                    "channels": None,
+                    "retention_days": None,
+                    "nodes": None,
+                    "has_all": False,
+                }
+            )
+    return out
+
+
+def _has_all_bundle_row_at(perspective_tier: str, bundle) -> dict:
+    """Perspective-shaped sibling of :func:`_has_all_bundle_row`.
+
+    Normalises one aggregate 5-axis bundle via
+    :func:`_normalise_all_bundle` (identical to the LIVE row helper),
+    then folds it through :func:`has_all_at` against
+    ``perspective_tier`` so the row reflects the STATIC per-tier grant
+    for that hypothetical tier instead of the LIVE resolver.
+
+    **Grace-independent by construction**: every axis in
+    :func:`has_all_at` is backed by the static per-tier grant tables
+    (via :func:`_hypothetical_entitlement` on the feature / runtime axes
+    and by :data:`_TIER_CHANNEL_LIMIT` / :data:`_TIER_RETENTION_DAYS` /
+    :data:`_TIER_NODE_LIMIT` on the capacity axes), so the per-row
+    ``has_all_at`` is identical under grace vs enforce for the same
+    ``(perspective, bundle)`` pair. Whole point of the ``_at`` slot: a
+    paywall walkthrough at OSS ("if I were on OSS today, would this
+    whole bundle land granted?") sees the would-be-locked state even
+    while the LIVE :func:`has_all_bundle_batch` reports every fully-
+    known bundle granted via grace pass-through.
+
+    Row keys mirror :func:`_has_all_bundle_row` byte-for-byte with the
+    fold slot renamed ``has_all_at`` so a UI wiring both the LIVE and
+    the perspective batches can distinguish the two answers on the same
+    ``(bundle,)`` cell. Never raises: a delegate failure returns the
+    empty row shape with ``has_all_at=False``.
+    """
+    features, runtimes, channels, retention_days, nodes = _normalise_all_bundle(
+        bundle
+    )
+    try:
+        allowed = has_all_at(
+            perspective_tier,
+            features=features or None,
+            runtimes=runtimes or None,
+            channels=channels,
+            retention_days=retention_days,
+            nodes=nodes,
+        )
+    except Exception as exc:
+        logger.warning(
+            "entitlements: _has_all_bundle_row_at(%r) fold failed: %s",
+            perspective_tier,
+            exc,
+        )
+        allowed = False
+    return {
+        "features": features,
+        "runtimes": runtimes,
+        "channels": channels,
+        "retention_days": retention_days,
+        "nodes": nodes,
+        "has_all_at": bool(allowed),
+    }
+
+
+def has_all_bundle_batch_at(
+    perspective_tier: str, bundles
+) -> list[dict] | None:
+    """Hypothetical-perspective sibling of :func:`has_all_bundle_batch`:
+    per-bundle aggregate boolean-fold grant for N 5-axis bundles in one
+    round-trip, scoped by a caller-supplied ``perspective_tier``.
+
+    Same relationship to :func:`has_all_bundle_batch` that
+    :func:`has_all_at` has to :func:`has_all` and
+    :func:`min_tier_for_all_at_batch` has to
+    :func:`min_tier_for_all_batch`: the ``perspective_tier`` argument
+    tells the fold which STATIC per-tier grant to reason from so a
+    pricing-matrix walkthrough can hydrate the per-bundle "would <tier>
+    admit this whole config?" boolean off ONE call per (perspective,
+    bundles) cell instead of N calls to :func:`has_all_at`.
+
+    **Perspective-shaped (grace-independent by design)**: unlike the
+    reverse-lookup :func:`min_tier_for_all_at_batch` (which is
+    inherently perspective-independent because the required tier is a
+    property of the bundle, not the caller), the boolean-fold answer
+    DOES depend on ``perspective_tier`` -- each row's ``has_all_at``
+    delegates to :func:`has_all_at` (backed by the static per-tier
+    tables), so the row IS shaped by the hypothetical perspective.
+    ``has_all_bundle_batch_at("oss", [{"features": ["fleet"]}])``
+    reports ``has_all_at=False`` for the fleet row even in grace --
+    that's the whole point of the ``_at`` slot.
+
+    Row shape mirrors :func:`has_all_bundle_batch` byte-for-byte on the
+    axis echo slots (byte-parity so a UI wiring both the LIVE and the
+    perspective batches sees a consistent shape) with the fold slot
+    renamed ``has_all_at``::
+
+        {
+          "features":       ["fleet"],
+          "runtimes":       ["claude_code"],
+          "channels":       5 | None,
+          "retention_days": 30 | None,
+          "nodes":          2 | None,
+          "has_all_at":     <bool>,
+        }
+
+    Perspective is validated against :data:`_TIER_ORDER` (including
+    :data:`TIER_TRIAL`); returns ``None`` for empty / unknown /
+    non-string ``perspective_tier`` (caller renders "unknown tier" /
+    404). Matches the ``None`` posture the rest of the ``_at`` mixed-
+    axis family uses (see :func:`min_tier_batch_at` /
+    :func:`min_tier_for_all_at_batch`).
+
+    Argument handling on ``bundles`` mirrors
+    :func:`has_all_bundle_batch`:
+
+    * ``bundles is None`` or non-iterable -- returns ``[]`` (perspective
+      valid but nothing to fold).
+    * Each bundle may itself be ``None``, non-dict, or empty -- the
+      helper emits a stable row (``has_all_at=False`` on empty /
+      non-dict).
+
+    Never raises: a delegate failure logs a warning and short-circuits
+    to the empty row shape so the batch keeps building. A perspective-
+    validation failure returns ``None`` so the paired endpoint can
+    surface a 404 with ``which=tier``.
+    """
+    try:
+        p = (perspective_tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if not p or p not in _TIER_ORDER:
+        return None
+    try:
+        if bundles is None:
+            return []
+        items = list(bundles)
+    except TypeError:
+        return []
+    out: list[dict] = []
+    for bundle in items:
+        try:
+            out.append(_has_all_bundle_row_at(p, bundle))
+        except Exception as exc:
+            logger.warning(
+                "entitlements: has_all_bundle_batch_at row failed: %s", exc
+            )
+            out.append(
+                {
+                    "features": [],
+                    "runtimes": [],
+                    "channels": None,
+                    "retention_days": None,
+                    "nodes": None,
+                    "has_all_at": False,
+                }
+            )
+    return out
+
+
 def _min_tier_for_all_bundle_row(bundle) -> dict:
     """Per-bundle row shape for :func:`min_tier_for_all_batch`.
 

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -38731,6 +38731,315 @@ def api_entitlement_required_tier_bundle_batch_at():
         )
 
 
+def _has_all_bundle_row_to_body(row: dict) -> dict:
+    """Coerce the aggregate boolean-fold batch helper's per-row dict to
+    a stable endpoint body shape: pass ``features`` / ``runtimes`` axis
+    echoes through as lists, capacity axes through as int-or-``None``,
+    and the ``has_all`` fold as a bool.
+
+    Kept alongside :func:`_min_tier_for_all_row_to_body` so future per-
+    row envelope adjustments (extra keys, capacity coercion) have one
+    obvious edit-site per family instead of drifting inside the
+    endpoint bodies. Never raises: a missing key surfaces as the
+    empty-row shape.
+    """
+    return {
+        "features": list(row.get("features") or []),
+        "runtimes": list(row.get("runtimes") or []),
+        "channels": row.get("channels"),
+        "retention_days": row.get("retention_days"),
+        "nodes": row.get("nodes"),
+        "has_all": bool(row.get("has_all")),
+    }
+
+
+def _has_all_bundle_row_at_to_body(row: dict) -> dict:
+    """Perspective-shaped sibling of :func:`_has_all_bundle_row_to_body`.
+
+    Byte-identical to the LIVE row body except the fold slot is renamed
+    ``has_all_at`` so a UI wiring both endpoints can distinguish the
+    two answers on the same ``(bundle,)`` cell.
+    """
+    return {
+        "features": list(row.get("features") or []),
+        "runtimes": list(row.get("runtimes") or []),
+        "channels": row.get("channels"),
+        "retention_days": row.get("retention_days"),
+        "nodes": row.get("nodes"),
+        "has_all_at": bool(row.get("has_all_at")),
+    }
+
+
+@bp_entitlement.route(
+    "/api/entitlement/has-all-bundle-batch",
+    methods=["POST"],
+)
+def api_entitlement_has_all_bundle_batch():
+    """``POST /api/entitlement/has-all-bundle-batch`` -- bundle-axis batch
+    sibling of ``/api/entitlement/has-all`` (singular boolean fold).
+
+    Where the singular ``/has-all`` GET endpoint folds ONE aggregate
+    5-axis bundle (features + runtimes + channels + retention + nodes)
+    to ONE ``has_all`` boolean at the LIVE perspective, this folds N
+    caller-supplied aggregate bundles to N ``has_all`` rows in ONE
+    round-trip so a paywall matrix or upgrade-walkthrough surface
+    comparing several hypothetical *whole* configs ("Starter-shaped
+    install vs Pro-shaped install vs Enterprise-shaped install") reads
+    the grant answer off one call instead of N calls to ``/has-all``.
+
+    Symmetric to the reverse-lookup
+    ``/api/entitlement/required-tier-bundle-batch`` on the same input
+    shape: same POST body, same per-row axis echoes, same never-crash
+    posture. The only per-row divergence is the fold slot -- this
+    returns ``has_all`` (boolean) where the reverse-lookup sibling
+    returns ``required_tier`` (id).
+
+    Distinct from ``/api/entitlement/has-features-batch`` and
+    ``/api/entitlement/has-runtimes-batch`` (which batch N *single-axis*
+    bundles) and from ``/api/entitlement/has-batch`` (per-*item* rows
+    for one flat bundle -- rows are individual feature / runtime /
+    capacity ids). This endpoint preserves per-bundle grouping AND the
+    cross-axis aggregation: each row is the aggregate fold-answer for
+    that whole 5-axis bundle, not a fold-answer per item or per single
+    axis.
+
+    Also distinct from ``/api/entitlement/has-all-at-batch`` (which
+    fixes ONE bundle and sweeps N perspective tiers): this fixes N
+    bundles and reads the LIVE per-install grant.
+
+    POST rather than GET because each bundle already carries five axes
+    and N of them can grow well past a comfortable query-string length;
+    the sibling singular ``/has-all`` endpoint uses GET where the
+    bundle is small.
+
+    Request body::
+
+        {
+          "bundles": [
+            {"features": ["fleet"], "runtimes": ["claude_code"]},
+            {"channels": 5, "retention_days": 30, "nodes": 2},
+            {}
+          ]
+        }
+
+    A shorthand ``{"bundles": {"features": ["fleet"]}}`` (a bare dict)
+    is treated as ONE bundle for symmetry with the list-of-strings
+    shorthand on ``/tiers-for-features-batch``; a missing /
+    non-list-non-dict ``bundles`` value is a 400. An empty
+    ``bundles=[]`` list is a 400 for the same reason
+    ``/required-tier-bundle-batch`` 400s on an empty ``bundles`` --
+    distinguishes "caller asked for nothing" from "caller asked and
+    every bundle was a typo".
+
+    Response shape::
+
+        {
+          "bundles": [<row>, ...],
+          "count":   <int>,        # len(bundles)
+          "current_tier":      "...",
+          "current_tier_rank": <int>,
+          "grace":             <bool>,
+          "enforced":          <bool>,
+        }
+
+    Each ``<row>`` mirrors the ``/required-tier-bundle-batch`` per-row
+    axis echoes byte-for-byte with the fold slot swapped from
+    ``required_tier`` to ``has_all``::
+
+        {
+          "features":       ["fleet"],
+          "runtimes":       ["claude_code"],
+          "channels":       5 | null,
+          "retention_days": 30 | null,
+          "nodes":          2 | null,
+          "has_all":        <bool>,
+        }
+
+    Per-bundle normalisation matches the singular ``/has-all`` and the
+    sibling ``/required-tier-bundle-batch``: CSV normalisation on
+    ``features`` / ``runtimes`` (whitespace stripped, lowercased,
+    deduplicated preserving first-seen order); runtime aliases
+    (``claude-code`` -> ``claude_code``) canonicalised; the three
+    capacity axes coerced through ``int(...)`` with a blank / non-int
+    collapsing to ``null`` so a typo cannot silently grant on the
+    aggregate. Critically, ``retention_days=null`` here means *unset*,
+    NOT *unlimited* -- matches every other batch endpoint's posture.
+
+    Grace posture per-row mirrors the LIVE ``/has-all`` byte-for-byte:
+    while ``grace`` is ``true`` (the current rollout state) every fully-
+    known bundle reports ``has_all=true``; post-enforcement each row
+    reflects the underlying :meth:`Entitlement.allows_*` answer.
+
+    - **400** when ``bundles`` is missing / non-list-non-dict / empty
+    - **Never 5xxs**: a resolver failure yields the fallback envelope
+      (empty ``bundles`` list) so the paywall matrix keeps rendering.
+    """
+    body = request.get_json(silent=True) or {}
+    bundles, err = _parse_aggregate_bundles_body(body)
+    if err == "missing":
+        return jsonify({"error": "missing bundles"}), 400
+    if err == "empty":
+        return jsonify({"error": "empty bundles"}), 400
+    if err == "bundles_must_be_list":
+        return jsonify({"error": "bundles must be a list"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        rows = _ent.has_all_bundle_batch(bundles)
+        out_rows = [_has_all_bundle_row_to_body(row) for row in rows]
+        env = _resolver_envelope(_ent)
+        return jsonify(
+            {
+                "bundles": out_rows,
+                "count": len(out_rows),
+                **env,
+            }
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_has_all_bundle_batch: error: %s", exc
+        )
+        return jsonify(
+            {
+                "bundles": [],
+                "count": 0,
+                "current_tier": "oss",
+                "current_tier_rank": 0,
+                "grace": True,
+                "enforced": False,
+            }
+        )
+
+
+@bp_entitlement.route(
+    "/api/entitlement/has-all-bundle-batch-at",
+    methods=["POST"],
+)
+def api_entitlement_has_all_bundle_batch_at():
+    """``POST /api/entitlement/has-all-bundle-batch-at?tier=<perspective>``
+    -- hypothetical-perspective sibling of
+    ``/api/entitlement/has-all-bundle-batch``.
+
+    Wraps :func:`clawmetry.entitlements.has_all_bundle_batch_at` so a
+    pricing-matrix walkthrough can call the aggregate boolean-fold
+    bundle-batch from any tier's perspective without first switching
+    the resolver. Fills the ``_at`` slot for the aggregate bundle-batch
+    boolean-fold family alongside the reverse-lookup
+    ``/required-tier-bundle-batch-at`` and the per-single-axis
+    ``_at_batch`` siblings so a caller can call the perspective-scoped
+    batch uniformly across every ``_at`` family.
+
+    **Perspective-shaped** (grace-independent by design): unlike the
+    reverse-lookup ``/required-tier-bundle-batch-at`` (whose per-row
+    ``required_tier`` is inherently perspective-independent -- the
+    required tier is a property of the bundle, not the caller), each
+    ``has_all_at`` row here DOES depend on ``perspective_tier``.
+    Per-row folds delegate to :func:`has_all_at` (backed by the static
+    per-tier tables via :func:`_hypothetical_entitlement` on the
+    feature / runtime axes and :data:`_TIER_CHANNEL_LIMIT` /
+    :data:`_TIER_RETENTION_DAYS` / :data:`_TIER_NODE_LIMIT` on the
+    capacity axes), so grace vs enforce yields byte-identical row
+    bodies (only the ``current_tier`` envelope shifts). Whole point of
+    the ``_at`` slot: at ``tier=oss`` a paid-feature bundle reports
+    ``has_all_at=false`` even in grace, whereas the LIVE
+    ``/has-all-bundle-batch`` reports ``has_all=true`` for the same
+    bundle via grace pass-through.
+
+    Request body is byte-identical to
+    ``/has-all-bundle-batch``. The extra ``tier=<perspective>`` query
+    arg is required.
+
+    Response layers ``perspective_tier`` / ``perspective_tier_label`` /
+    ``perspective_tier_rank`` on top of the bare batch envelope so a
+    caller can render "from <perspective> this bundle would be locked"
+    copy off one call::
+
+        {
+          "perspective_tier":       "cloud_pro",
+          "perspective_tier_label": "Cloud Pro",
+          "perspective_tier_rank":  <int>,
+          "bundles":                [<row>, ...],
+          "count":                  <int>,
+          "current_tier":           "...",
+          "current_tier_rank":      <int>,
+          "grace":                  <bool>,
+          "enforced":               <bool>,
+        }
+
+    Each ``<row>`` mirrors the LIVE ``/has-all-bundle-batch`` row body
+    byte-for-byte on the axis echo slots with the fold slot renamed
+    ``has_all_at``::
+
+        {
+          "features":       ["fleet"],
+          "runtimes":       ["claude_code"],
+          "channels":       5 | null,
+          "retention_days": 30 | null,
+          "nodes":          2 | null,
+          "has_all_at":     <bool>,
+        }
+
+    - **400** when ``tier=`` is missing / blank
+    - **404** when ``tier`` is unknown (body carries ``which=tier`` so a
+      caller can render the right "unknown tier" message)
+    - **400** when ``bundles`` is missing / non-list-non-dict / empty
+    - **Never 5xxs**: a resolver failure yields the fallback envelope
+      so the paywall matrix keeps rendering.
+    """
+    raw_tier = request.args.get("tier")
+    tier_in = (raw_tier or "").strip().lower()
+    if not tier_in:
+        return jsonify({"error": "missing tier"}), 400
+    body = request.get_json(silent=True) or {}
+    bundles, err = _parse_aggregate_bundles_body(body)
+    if err == "missing":
+        return jsonify({"error": "missing bundles"}), 400
+    if err == "empty":
+        return jsonify({"error": "empty bundles"}), 400
+    if err == "bundles_must_be_list":
+        return jsonify({"error": "bundles must be a list"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        if tier_in not in _ent._TIER_ORDER:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "tier", "tier": tier_in}
+                ),
+                404,
+            )
+        rows = _ent.has_all_bundle_batch_at(tier_in, bundles) or []
+        out_rows = [_has_all_bundle_row_at_to_body(row) for row in rows]
+        env = _resolver_envelope(_ent)
+        return jsonify(
+            {
+                "perspective_tier": tier_in,
+                "perspective_tier_label": _ent.tier_label(tier_in),
+                "perspective_tier_rank": _ent.tier_rank(tier_in),
+                "bundles": out_rows,
+                "count": len(out_rows),
+                **env,
+            }
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_has_all_bundle_batch_at: error: %s", exc
+        )
+        return jsonify(
+            {
+                "perspective_tier": tier_in,
+                "perspective_tier_label": None,
+                "perspective_tier_rank": -1,
+                "bundles": [],
+                "count": 0,
+                "current_tier": "oss",
+                "current_tier_rank": 0,
+                "grace": True,
+                "enforced": False,
+            }
+        )
+
+
 @bp_entitlement.route(
     "/api/entitlement/tiers-for-features-batch",
     methods=["POST"],

--- a/tests/test_entitlement_has_all_bundle_batch.py
+++ b/tests/test_entitlement_has_all_bundle_batch.py
@@ -1,0 +1,722 @@
+"""Tests for the aggregate bundle-batch boolean-fold
+``/api/entitlement/has-all-bundle-batch`` and
+``/api/entitlement/has-all-bundle-batch-at`` endpoints (plus their
+:func:`clawmetry.entitlements.has_all_bundle_batch` /
+:func:`clawmetry.entitlements.has_all_bundle_batch_at` helpers).
+
+Fills the bundle-axis batch boolean-fold slot for the aggregate 5-axis
+``/api/entitlement/has-all`` singular endpoint (which folds ONE aggregate
+bundle across features + runtimes + channels + retention + nodes to ONE
+``has_all`` boolean) so a paywall matrix or upgrade-walkthrough surface
+comparing several hypothetical *whole* configs ("Starter-shaped install
+vs Pro-shaped install vs Enterprise-shaped install") reads the grant
+answer off ONE round-trip instead of N calls to ``/has-all``. Symmetric
+to ``/required-tier-bundle-batch`` on the reverse-lookup slot: same POST
+body, same per-row axis echoes, only the fold slot diverges
+(``has_all`` bool vs ``required_tier`` id).
+
+Distinct from ``/has-all-at-batch`` (which fixes ONE bundle and sweeps N
+perspective tiers): this fixes N bundles and reads the LIVE per-install
+grant, and its ``_at`` sibling fixes N bundles at ONE perspective.
+
+These tests pin:
+
+* helper: per-bundle normalisation (feature/runtime CSV, runtime alias
+  canonicalisation, capacity int coercion, blank / non-int axes collapse
+  to ``None``, empty bundle surfaces as a stable row)
+* helper: per-row parity with the singular :func:`has_all` scalar
+* helper: never-crash contract on ``None`` / non-iterable / non-dict
+  bundle inputs
+* helper: perspective-shaping of the ``_at`` variant (deliberate
+  divergence from the LIVE helper at OSS in grace: paid feature -> False)
+* helper: perspective-validation ``None`` posture on the ``_at`` variant
+* API happy path: shape, resolver envelope, ``count``
+* API error paths: 400 on missing / non-list / empty ``bundles``
+* API single-dict shorthand
+* API per-row body byte-equals the bare singular endpoint
+* API ``_at`` perspective envelope keys + 400 on missing ``tier=``,
+  404 on unknown ``tier=``
+* API never-5xxs on a delegate crash
+* Grace vs enforce parity on the LIVE endpoint; grace-independence on
+  the ``_at`` endpoint's ``has_all_at`` fold
+* Cross-endpoint parity vs ``/required-tier-bundle-batch``: same axis
+  echoes on the same bundle
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+# -- Fixtures ------------------------------------------------------------------
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def enforced(monkeypatch, tmp_path):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    importlib.reload(e)
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# -- Row shape constants -------------------------------------------------------
+
+
+_LIVE_ROW_KEYS = {
+    "features",
+    "runtimes",
+    "channels",
+    "retention_days",
+    "nodes",
+    "has_all",
+}
+
+_AT_ROW_KEYS = {
+    "features",
+    "runtimes",
+    "channels",
+    "retention_days",
+    "nodes",
+    "has_all_at",
+}
+
+_LIVE_ENVELOPE_KEYS = {
+    "bundles",
+    "count",
+    "current_tier",
+    "current_tier_rank",
+    "grace",
+    "enforced",
+}
+
+_AT_ENVELOPE_KEYS = {
+    "perspective_tier",
+    "perspective_tier_label",
+    "perspective_tier_rank",
+    "bundles",
+    "count",
+    "current_tier",
+    "current_tier_rank",
+    "grace",
+    "enforced",
+}
+
+
+# -- helper: bundle normalisation ---------------------------------------------
+
+
+def test_helper_batch_folds_across_all_five_axes(ent):
+    rows = ent.has_all_bundle_batch(
+        [{"features": ["fleet"], "runtimes": ["claude_code"],
+          "channels": 5, "retention_days": 30, "nodes": 2}]
+    )
+    assert len(rows) == 1
+    r = rows[0]
+    assert set(r.keys()) == _LIVE_ROW_KEYS
+    assert r["features"] == ["fleet"]
+    assert r["runtimes"] == ["claude_code"]
+    assert r["channels"] == 5
+    assert r["retention_days"] == 30
+    assert r["nodes"] == 2
+    # Grace pass-through: LIVE fold reports True for every fully-known
+    # bundle while ``ent.grace`` is on.
+    assert r["has_all"] is True
+
+
+def test_helper_batch_normalises_features_csv(ent):
+    rows = ent.has_all_bundle_batch(
+        [{"features": ["FLEET", "fleet", "", "otel_export"]}]
+    )
+    assert rows[0]["features"] == ["fleet", "otel_export"]
+
+
+def test_helper_batch_canonicalises_runtime_aliases(ent):
+    rows = ent.has_all_bundle_batch(
+        [{"runtimes": ["claude-code", "codex", "claude_code"]}]
+    )
+    assert rows[0]["runtimes"] == ["claude_code", "codex"]
+
+
+def test_helper_batch_capacity_coerces_ints(ent):
+    rows = ent.has_all_bundle_batch(
+        [{"channels": "5", "retention_days": "30", "nodes": "2"}]
+    )
+    assert rows[0]["channels"] == 5
+    assert rows[0]["retention_days"] == 30
+    assert rows[0]["nodes"] == 2
+
+
+def test_helper_batch_capacity_non_int_collapses_to_none(ent):
+    """A typo on ``retention_days`` must NOT silently grant on the
+    aggregate -- it collapses to ``None`` (unset). Matches
+    :func:`min_tier_for_all_batch` posture."""
+    rows = ent.has_all_bundle_batch(
+        [{"channels": "abc", "retention_days": "", "nodes": None}]
+    )
+    assert rows[0]["channels"] is None
+    assert rows[0]["retention_days"] is None
+    assert rows[0]["nodes"] is None
+    # Empty bundle after coercion -> no axes supplied -> False.
+    assert rows[0]["has_all"] is False
+
+
+def test_helper_batch_empty_bundle_is_stable_row(ent):
+    rows = ent.has_all_bundle_batch([{}])
+    assert len(rows) == 1
+    r = rows[0]
+    assert set(r.keys()) == _LIVE_ROW_KEYS
+    assert r["features"] == []
+    assert r["runtimes"] == []
+    assert r["channels"] is None
+    assert r["retention_days"] is None
+    assert r["nodes"] is None
+    # Empty bundle: no axes supplied -> False (matches has_all).
+    assert r["has_all"] is False
+
+
+def test_helper_batch_non_dict_row_collapses_to_empty_row(ent):
+    rows = ent.has_all_bundle_batch(
+        [{"features": ["fleet"]}, "not a dict", 42]
+    )
+    assert len(rows) == 3
+    assert rows[0]["features"] == ["fleet"]
+    for r in rows[1:]:
+        assert r["features"] == []
+        assert r["has_all"] is False
+
+
+def test_helper_batch_none_returns_empty(ent):
+    assert ent.has_all_bundle_batch(None) == []
+
+
+def test_helper_batch_non_iterable_returns_empty(ent):
+    assert ent.has_all_bundle_batch(42) == []
+
+
+def test_helper_batch_empty_list_returns_empty(ent):
+    assert ent.has_all_bundle_batch([]) == []
+
+
+# -- helper: per-row parity with the singular has_all -------------------------
+
+
+def test_helper_batch_per_row_parity_with_has_all(ent):
+    """Per-row ``has_all`` byte-equals :func:`has_all` for the same
+    (canonicalised) bundle."""
+    bundles = [
+        {"features": ["fleet"], "runtimes": ["claude_code"]},
+        {"channels": 5},
+        {"retention_days": 30, "nodes": 2},
+        {"features": ["sso"]},
+        {},
+    ]
+    rows = ent.has_all_bundle_batch(bundles)
+    for row in rows:
+        expected = ent.has_all(
+            features=row["features"] or None,
+            runtimes=row["runtimes"] or None,
+            channels=row["channels"],
+            retention_days=row["retention_days"],
+            nodes=row["nodes"],
+        )
+        assert row["has_all"] is bool(expected)
+
+
+def test_helper_batch_paid_bundle_true_in_grace(ent):
+    """Grace pass-through contract: paid bundle -> True in grace."""
+    paid_f = next(iter(ent.PAID_FEATURES))
+    paid_r = next(iter(ent.PAID_RUNTIMES))
+    bundle = {"features": [paid_f], "runtimes": [paid_r], "channels": 999}
+    assert ent.has_all_bundle_batch([bundle])[0]["has_all"] is True
+
+
+def test_helper_batch_paid_bundle_false_after_enforcement(enforced):
+    """Post-enforcement: paid bundle -> False (matches has_all)."""
+    paid_f = next(iter(enforced.PAID_FEATURES))
+    paid_r = next(iter(enforced.PAID_RUNTIMES))
+    bundle = {"features": [paid_f], "runtimes": [paid_r], "channels": 999}
+    assert enforced.has_all_bundle_batch([bundle])[0]["has_all"] is False
+
+
+# -- helper: _at perspective shaping ------------------------------------------
+
+
+def test_helper_at_batch_oss_denies_paid_bundle_even_in_grace(ent):
+    """Whole point of the ``_at`` slot: OSS statically does not grant
+    paid features, so the _at variant reports ``has_all_at=False`` even
+    while the LIVE helper reports ``has_all=True`` via grace pass-through
+    on the same bundle."""
+    paid_f = next(iter(ent.PAID_FEATURES))
+    live = ent.has_all_bundle_batch([{"features": [paid_f]}])[0]
+    at = ent.has_all_bundle_batch_at("oss", [{"features": [paid_f]}])[0]
+    assert live["has_all"] is True
+    assert at["has_all_at"] is False
+
+
+@pytest.mark.parametrize(
+    "perspective",
+    ["cloud_free", "trial", "cloud_starter", "cloud_pro", "pro", "enterprise"],
+)
+def test_helper_at_batch_free_bundle_true_at_every_tier(ent, perspective):
+    free_f = next(iter(ent.FREE_FEATURES))
+    free_r = next(iter(ent.FREE_RUNTIMES))
+    rows = ent.has_all_bundle_batch_at(
+        perspective,
+        [{"features": [free_f], "runtimes": [free_r], "channels": 1}],
+    )
+    assert rows[0]["has_all_at"] is True
+
+
+def test_helper_at_batch_paid_bundle_true_at_cloud_pro(ent):
+    paid_f = next(iter(ent.PAID_FEATURES))
+    paid_r = next(iter(ent.PAID_RUNTIMES))
+    rows = ent.has_all_bundle_batch_at(
+        "cloud_pro",
+        [{"features": [paid_f], "runtimes": [paid_r]}],
+    )
+    assert rows[0]["has_all_at"] is True
+
+
+def test_helper_at_batch_row_shape(ent):
+    rows = ent.has_all_bundle_batch_at(
+        "cloud_pro", [{"features": ["fleet"], "runtimes": ["claude_code"]}]
+    )
+    assert len(rows) == 1
+    assert set(rows[0].keys()) == _AT_ROW_KEYS
+
+
+def test_helper_at_batch_grace_independent(ent, monkeypatch):
+    """The ``_at`` variant is grace-independent by construction: the
+    per-row fold reads static per-tier tables so grace vs enforce yields
+    byte-identical rows for the same ``(perspective, bundle)`` pair."""
+    bundles = [
+        {"features": ["fleet"], "runtimes": ["claude_code"]},
+        {"channels": 5, "retention_days": 30, "nodes": 2},
+        {},
+    ]
+    perspectives = ("oss", "cloud_pro", "enterprise")
+    grace_rows = {p: ent.has_all_bundle_batch_at(p, bundles) for p in perspectives}
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    importlib.reload(ent)
+    for p in perspectives:
+        assert ent.has_all_bundle_batch_at(p, bundles) == grace_rows[p]
+
+
+def test_helper_at_batch_unknown_perspective_none(ent):
+    assert ent.has_all_bundle_batch_at("bogus", [{"features": ["fleet"]}]) is None
+    assert ent.has_all_bundle_batch_at("", [{"features": ["fleet"]}]) is None
+    assert ent.has_all_bundle_batch_at(None, [{"features": ["fleet"]}]) is None
+
+
+def test_helper_at_batch_valid_perspective_none_bundles_empty_list(ent):
+    """Perspective valid but bundles ``None`` -> stable ``[]``, not
+    ``None`` (which is reserved for perspective failure)."""
+    assert ent.has_all_bundle_batch_at("cloud_pro", None) == []
+    assert ent.has_all_bundle_batch_at("cloud_pro", []) == []
+
+
+def test_helper_at_batch_non_iterable_bundles(ent):
+    assert ent.has_all_bundle_batch_at("cloud_pro", 42) == []
+
+
+# -- API: happy path ----------------------------------------------------------
+
+
+def test_api_batch_happy(client, ent):
+    r = client.post(
+        "/api/entitlement/has-all-bundle-batch",
+        json={"bundles": [
+            {"features": ["fleet"], "runtimes": ["claude_code"]},
+            {"channels": 5, "retention_days": 30, "nodes": 2},
+            {},
+        ]},
+    )
+    assert r.status_code == 200
+    j = r.get_json()
+    assert set(j.keys()) == _LIVE_ENVELOPE_KEYS
+    assert j["count"] == 3
+    assert len(j["bundles"]) == 3
+    for row in j["bundles"]:
+        assert set(row.keys()) == _LIVE_ROW_KEYS
+    assert j["bundles"][0]["features"] == ["fleet"]
+    assert j["bundles"][0]["runtimes"] == ["claude_code"]
+    assert j["bundles"][1]["channels"] == 5
+    assert j["bundles"][1]["retention_days"] == 30
+    # Empty bundle at index 2 -> has_all False.
+    assert j["bundles"][2]["has_all"] is False
+
+
+def test_api_batch_grace_paid_bundle_true(client, ent):
+    """Grace posture: paid bundle at the LIVE endpoint reports has_all=True
+    in grace (matches the singular /has-all endpoint's grace pass-through)."""
+    paid_f = next(iter(ent.PAID_FEATURES))
+    r = client.post(
+        "/api/entitlement/has-all-bundle-batch",
+        json={"bundles": [{"features": [paid_f]}]},
+    )
+    j = r.get_json()
+    assert j["bundles"][0]["has_all"] is True
+    assert j["grace"] is True
+
+
+def test_api_batch_single_dict_shorthand(client, ent):
+    r = client.post(
+        "/api/entitlement/has-all-bundle-batch",
+        json={"bundles": {"features": ["fleet"]}},
+    )
+    assert r.status_code == 200
+    j = r.get_json()
+    assert j["count"] == 1
+    assert j["bundles"][0]["features"] == ["fleet"]
+
+
+def test_api_batch_capacity_string_coerced(client, ent):
+    r = client.post(
+        "/api/entitlement/has-all-bundle-batch",
+        json={"bundles": [{"channels": "5", "retention_days": "abc"}]},
+    )
+    j = r.get_json()
+    assert j["bundles"][0]["channels"] == 5
+    # Non-int capacity collapses to null.
+    assert j["bundles"][0]["retention_days"] is None
+
+
+# -- API: error paths ---------------------------------------------------------
+
+
+def test_api_batch_missing_bundles_400(client):
+    r = client.post("/api/entitlement/has-all-bundle-batch", json={})
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "missing bundles"
+
+
+def test_api_batch_empty_bundles_400(client):
+    r = client.post(
+        "/api/entitlement/has-all-bundle-batch", json={"bundles": []}
+    )
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "empty bundles"
+
+
+def test_api_batch_non_list_bundles_400(client):
+    r = client.post(
+        "/api/entitlement/has-all-bundle-batch", json={"bundles": 42}
+    )
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "bundles must be a list"
+
+
+def test_api_batch_no_body_400(client):
+    r = client.post("/api/entitlement/has-all-bundle-batch")
+    # Empty body -> missing bundles -> 400
+    assert r.status_code == 400
+
+
+# -- API: per-row body byte-equals the singular /has-all ---------------------
+
+
+def test_api_batch_row_matches_singular_has_all(client, ent):
+    """Each per-bundle row's ``has_all`` byte-equals the singular
+    ``/has-all`` endpoint's ``has_all`` for the same bundle."""
+    bundle = {"features": ["fleet"], "runtimes": ["claude_code"]}
+    batch = client.post(
+        "/api/entitlement/has-all-bundle-batch",
+        json={"bundles": [bundle]},
+    ).get_json()
+    row = batch["bundles"][0]
+    singular = client.get(
+        "/api/entitlement/has-all"
+        "?features=fleet&runtimes=claude_code"
+    ).get_json()
+    assert row["has_all"] is bool(singular["has_all"])
+    assert row["features"] == singular["features"]
+    assert row["runtimes"] == singular["runtimes"]
+
+
+# -- API: cross-endpoint parity vs /required-tier-bundle-batch ---------------
+
+
+def test_api_batch_axis_echo_matches_required_tier_bundle_batch(client, ent):
+    """Per-row axis echoes byte-equal the sibling
+    ``/required-tier-bundle-batch``: same normalisation, same alias
+    canonicalisation, same capacity coercion. Only the fold slot
+    diverges (``has_all`` vs ``required_tier``)."""
+    bundles = [
+        {"features": ["FLEET", "fleet"], "runtimes": ["claude-code"]},
+        {"channels": "5", "retention_days": "30", "nodes": "2"},
+        {"channels": "abc"},
+    ]
+    live = client.post(
+        "/api/entitlement/has-all-bundle-batch", json={"bundles": bundles}
+    ).get_json()
+    rev = client.post(
+        "/api/entitlement/required-tier-bundle-batch",
+        json={"bundles": bundles},
+    ).get_json()
+    assert live["count"] == rev["count"]
+    for a, b in zip(live["bundles"], rev["bundles"]):
+        assert a["features"] == b["features"]
+        assert a["runtimes"] == b["runtimes"]
+        assert a["channels"] == b["channels"]
+        assert a["retention_days"] == b["retention_days"]
+        assert a["nodes"] == b["nodes"]
+
+
+# -- API: _at perspective envelope + validation ------------------------------
+
+
+def test_api_at_batch_happy(client, ent):
+    r = client.post(
+        "/api/entitlement/has-all-bundle-batch-at?tier=cloud_pro",
+        json={"bundles": [
+            {"features": ["fleet"]},
+            {"runtimes": ["claude_code"]},
+        ]},
+    )
+    assert r.status_code == 200
+    j = r.get_json()
+    assert set(j.keys()) == _AT_ENVELOPE_KEYS
+    assert j["perspective_tier"] == "cloud_pro"
+    assert j["perspective_tier_label"]
+    assert j["count"] == 2
+    for row in j["bundles"]:
+        assert set(row.keys()) == _AT_ROW_KEYS
+    assert j["bundles"][0]["features"] == ["fleet"]
+    assert j["bundles"][1]["runtimes"] == ["claude_code"]
+
+
+def test_api_at_batch_oss_denies_paid_feature_even_in_grace(client, ent):
+    """The whole point of the ``_at`` slot: at ``tier=oss`` a paid-feature
+    bundle reports ``has_all_at=false`` even while grace is on and the
+    LIVE ``/has-all-bundle-batch`` reports ``has_all=true`` for the same
+    bundle."""
+    paid_f = next(iter(ent.PAID_FEATURES))
+    live = client.post(
+        "/api/entitlement/has-all-bundle-batch",
+        json={"bundles": [{"features": [paid_f]}]},
+    ).get_json()
+    at = client.post(
+        "/api/entitlement/has-all-bundle-batch-at?tier=oss",
+        json={"bundles": [{"features": [paid_f]}]},
+    ).get_json()
+    assert live["bundles"][0]["has_all"] is True
+    assert at["bundles"][0]["has_all_at"] is False
+    # But both share the same grace envelope value (LIVE resolver unchanged).
+    assert live["grace"] is True and at["grace"] is True
+
+
+def test_api_at_batch_unknown_tier_404(client):
+    r = client.post(
+        "/api/entitlement/has-all-bundle-batch-at?tier=bogus",
+        json={"bundles": [{"features": ["fleet"]}]},
+    )
+    assert r.status_code == 404
+    j = r.get_json()
+    assert j["error"] == "unknown tier"
+    assert j["which"] == "tier"
+    assert j["tier"] == "bogus"
+
+
+def test_api_at_batch_missing_tier_400(client):
+    r = client.post(
+        "/api/entitlement/has-all-bundle-batch-at",
+        json={"bundles": [{"features": ["fleet"]}]},
+    )
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "missing tier"
+
+
+def test_api_at_batch_blank_tier_400(client):
+    r = client.post(
+        "/api/entitlement/has-all-bundle-batch-at?tier=%20",
+        json={"bundles": [{"features": ["fleet"]}]},
+    )
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "missing tier"
+
+
+def test_api_at_batch_missing_bundles_400(client):
+    r = client.post(
+        "/api/entitlement/has-all-bundle-batch-at?tier=cloud_pro", json={}
+    )
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "missing bundles"
+
+
+def test_api_at_batch_empty_bundles_400(client):
+    r = client.post(
+        "/api/entitlement/has-all-bundle-batch-at?tier=cloud_pro",
+        json={"bundles": []},
+    )
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "empty bundles"
+
+
+def test_api_at_batch_non_list_bundles_400(client):
+    r = client.post(
+        "/api/entitlement/has-all-bundle-batch-at?tier=cloud_pro",
+        json={"bundles": 42},
+    )
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "bundles must be a list"
+
+
+def test_api_at_batch_tier_case_and_whitespace_normalised(client, ent):
+    r = client.post(
+        "/api/entitlement/has-all-bundle-batch-at?tier=%20CLOUD_PRO%20",
+        json={"bundles": [{"features": ["fleet"]}]},
+    )
+    assert r.status_code == 200
+    assert r.get_json()["perspective_tier"] == "cloud_pro"
+
+
+# -- API: _at row body byte-equals the helper for known perspectives ---------
+
+
+@pytest.mark.parametrize(
+    "perspective",
+    ["cloud_free", "trial", "cloud_starter", "cloud_pro", "pro", "enterprise"],
+)
+def test_api_at_batch_row_matches_helper(client, ent, perspective):
+    bundles = [
+        {"features": ["fleet"], "runtimes": ["claude_code"]},
+        {"channels": 5, "retention_days": 30, "nodes": 2},
+        {},
+    ]
+    resp = client.post(
+        f"/api/entitlement/has-all-bundle-batch-at?tier={perspective}",
+        json={"bundles": bundles},
+    )
+    j = resp.get_json()
+    helper_rows = ent.has_all_bundle_batch_at(perspective, bundles)
+    assert len(j["bundles"]) == len(helper_rows)
+    for a, b in zip(j["bundles"], helper_rows):
+        assert a["has_all_at"] is bool(b["has_all_at"])
+        assert a["features"] == b["features"]
+        assert a["runtimes"] == b["runtimes"]
+        assert a["channels"] == b["channels"]
+        assert a["retention_days"] == b["retention_days"]
+        assert a["nodes"] == b["nodes"]
+
+
+# -- API: never-5xxs on a delegate crash --------------------------------------
+
+
+def test_api_batch_never_5xxs_on_delegate_crash(client, ent, monkeypatch):
+    def _boom(*_a, **_kw):
+        raise RuntimeError("delegate boom")
+
+    monkeypatch.setattr(ent, "has_all_bundle_batch", _boom)
+    r = client.post(
+        "/api/entitlement/has-all-bundle-batch",
+        json={"bundles": [{"features": ["fleet"]}]},
+    )
+    assert r.status_code == 200
+    j = r.get_json()
+    assert j["bundles"] == []
+    assert j["count"] == 0
+    assert set(j.keys()) == _LIVE_ENVELOPE_KEYS
+
+
+def test_api_at_batch_never_5xxs_on_delegate_crash(client, ent, monkeypatch):
+    def _boom(*_a, **_kw):
+        raise RuntimeError("delegate boom")
+
+    monkeypatch.setattr(ent, "has_all_bundle_batch_at", _boom)
+    r = client.post(
+        "/api/entitlement/has-all-bundle-batch-at?tier=cloud_pro",
+        json={"bundles": [{"features": ["fleet"]}]},
+    )
+    assert r.status_code == 200
+    j = r.get_json()
+    assert j["bundles"] == []
+    assert j["count"] == 0
+    assert j["perspective_tier"] == "cloud_pro"
+    assert set(j.keys()) == _AT_ENVELOPE_KEYS
+
+
+# -- API: grace vs enforce parity --------------------------------------------
+
+
+def test_api_batch_grace_vs_enforce_row_diverges_on_paid_bundle(
+    client, ent, monkeypatch
+):
+    """The LIVE endpoint follows grace: paid bundle -> True in grace,
+    False in enforce."""
+    paid_f = next(iter(ent.PAID_FEATURES))
+    grace = client.post(
+        "/api/entitlement/has-all-bundle-batch",
+        json={"bundles": [{"features": [paid_f]}]},
+    ).get_json()
+    assert grace["bundles"][0]["has_all"] is True
+    assert grace["grace"] is True
+
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    importlib.reload(ent)
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    enforce_client = app.test_client()
+    enforce = enforce_client.post(
+        "/api/entitlement/has-all-bundle-batch",
+        json={"bundles": [{"features": [paid_f]}]},
+    ).get_json()
+    assert enforce["bundles"][0]["has_all"] is False
+    assert enforce["grace"] is False
+
+
+def test_api_at_batch_row_grace_independent(client, ent, monkeypatch):
+    """The ``_at`` endpoint's ``has_all_at`` fold is grace-independent
+    by construction (backed by static per-tier tables). Grace vs enforce
+    yields byte-identical row bodies for the same perspective+bundle."""
+    bundles = [
+        {"features": ["fleet"], "runtimes": ["claude_code"]},
+        {"channels": 5, "retention_days": 30, "nodes": 2},
+        {},
+    ]
+    grace = client.post(
+        "/api/entitlement/has-all-bundle-batch-at?tier=oss",
+        json={"bundles": bundles},
+    ).get_json()
+
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    importlib.reload(ent)
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    enforce_client = app.test_client()
+    enforce = enforce_client.post(
+        "/api/entitlement/has-all-bundle-batch-at?tier=oss",
+        json={"bundles": bundles},
+    ).get_json()
+    assert grace["bundles"] == enforce["bundles"]


### PR DESCRIPTION
## Summary

Bundle-axis batch sibling of `has_all(...)` on the boolean-fold slot, in the same relationship `min_tier_for_all_batch` has to `min_tier_for_all` on the reverse-lookup slot. Where the singular `/has-all` GET folds ONE aggregate 5-axis bundle (features + runtimes + channels + retention + nodes) to ONE `has_all` boolean, this batches N caller-supplied aggregate bundles to N `has_all` rows in ONE round-trip so a paywall matrix or upgrade-walkthrough surface comparing several hypothetical *whole* configs ("Starter-shaped install vs Pro-shaped install vs Enterprise-shaped install") reads the grant answer off ONE call instead of N calls to `/has-all`.

Distinct from `/has-all-at-batch` (which fixes ONE bundle and sweeps N perspective tiers): this fixes N bundles and reads the LIVE per-install grant. The `_at` sibling fixes N bundles at ONE hypothetical perspective (grace-independent by construction, backed by the static per-tier tables).

- **`has_all_bundle_batch(bundles) -> list[dict]`** in `clawmetry/entitlements.py` — per-bundle normalisation via a new shared `_normalise_all_bundle(...)` helper (CSV normalisation on features/runtimes, runtime alias canonicalisation via `canonical_runtime`, capacity axes coerced through `int(...)` with a blank / non-int collapsing to `None` so a typo cannot silently grant), then folds through `has_all` for the LIVE aggregate boolean per row. Never raises: per-bundle failures short-circuit to the empty row shape (`has_all=False`) so the batch keeps building.

- **`has_all_bundle_batch_at(perspective_tier, bundles) -> list[dict] | None`** — perspective-shaped sibling; per-row fold delegates to `has_all_at` (backed by the static per-tier grant tables via `_hypothetical_entitlement` on the feature/runtime axes and `_TIER_CHANNEL_LIMIT` / `_TIER_RETENTION_DAYS` / `_TIER_NODE_LIMIT` on the capacity axes), so grace vs enforce yields byte-identical row bodies for the same `(perspective, bundle)` pair. Whole point of the `_at` slot: at `tier=oss` a paid-feature bundle reports `has_all_at=false` even while the LIVE `/has-all-bundle-batch` reports `has_all=true` via grace pass-through on the same bundle. Perspective is validated against `_TIER_ORDER` (including `trial`); returns `None` for empty / unknown / non-string perspective so the paired endpoint can surface a 404 with `which=tier`.

- **`POST /api/entitlement/has-all-bundle-batch`** on `bp_entitlement`. Request body byte-identical to `/required-tier-bundle-batch`; per-row axis echoes byte-parity with the reverse-lookup sibling on the same input (only the fold slot diverges — `has_all` bool vs `required_tier` id). 6-key envelope: `bundles`, `count`, `current_tier`, `current_tier_rank`, `grace`, `enforced`. Per-row 6-key body: `features`, `runtimes`, `channels`, `retention_days`, `nodes`, `has_all`.

- **`POST /api/entitlement/has-all-bundle-batch-at?tier=<perspective>`** — perspective-scoped variant. 9-key envelope layers `perspective_tier` / `perspective_tier_label` / `perspective_tier_rank` on top of the LIVE envelope. Per-row 6-key body renames the fold slot to `has_all_at`.

- **Shared `_normalise_all_bundle(bundle) -> tuple`** helper lifting the per-bundle normalisation shared with the reverse-lookup `min_tier_for_all_batch` family (kept as a separate helper — the existing `_min_tier_for_all_bundle_row` is untouched to keep this PR reviewable; future PRs can DRY-refactor).

Envelope + short-circuit posture mirrors the sibling `/required-tier-bundle-batch(-at)` byte-for-byte:

- **400** on missing / non-list-non-dict / empty `bundles`.
- **400** on missing / blank `tier` (`_at` variant only).
- **404** on unknown `tier` (`_at` variant only; body carries `which=tier`).
- **Never 5xxs**: resolver / helper blowup collapses to the fallback envelope with `bundles=[]` so the paywall matrix keeps rendering.

Behaviour ships in **GRACE** mode: the resolver still defaults to the OSS-free entitlement so no runtime gating changes. Purely additive to the entitlement query surface.

## Test plan

- [x] `python3 -m py_compile clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_has_all_bundle_batch.py`
- [x] `python3 -m ruff check clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_has_all_bundle_batch.py --select I,F,E9` — clean.
- [x] `python3 scripts/lint_daemon_allowlist.py` — passes (no `local_store_via_daemon` calls touched).
- [x] `python3 -m pytest tests/test_entitlement_has_all_bundle_batch.py` — **55/55 pass**, covering:
  - per-bundle normalisation across every axis (CSV features/runtimes, runtime alias canonicalisation, capacity int coercion, blank / non-int -> `None`, empty bundle -> stable row with `has_all=False`)
  - per-row parity with singular `has_all` scalar on every parametric bundle
  - never-crash on `None` / non-iterable / non-dict bundles
  - grace pass-through: paid bundle -> `True` in grace on LIVE helper
  - post-enforcement: paid bundle -> `False` on LIVE helper (matches `has_all`)
  - `_at` perspective-shaping: paid feature at OSS -> `False` even in grace (deliberate divergence from LIVE)
  - `_at` free bundle admitted at every tier in `_TIER_ORDER`
  - `_at` paid bundle admitted at `cloud_pro`
  - `_at` row shape (6-key: `features`, `runtimes`, `channels`, `retention_days`, `nodes`, `has_all_at`)
  - `_at` grace-independence: byte-identical rows under grace vs enforce for the same `(perspective, bundle)` pair
  - `_at` unknown / empty / non-string perspective -> `None`; valid perspective + `None` bundles -> `[]`; non-iterable bundles -> `[]`
  - API happy path: envelope + row shape stability
  - API grace posture: paid bundle -> `has_all=true` in grace
  - API single-dict shorthand (`{"bundles": {"features": ["fleet"]}}`)
  - API capacity string coercion (`"5"` -> `5`; `"abc"` -> `null`)
  - API error paths: 400 on missing / non-list / empty `bundles`; 400 on no body
  - API row byte-parity with singular `/has-all` on the same bundle
  - API cross-endpoint axis-echo parity vs `/required-tier-bundle-batch`
  - `_at` API envelope + row shape (9-key envelope, 6-key row)
  - `_at` API OSS-denies-paid divergence from LIVE (both share `grace=true`)
  - `_at` API 400/404 on missing/blank/unknown `tier`; 400 on missing/non-list/empty `bundles`
  - `_at` API tier case-and-whitespace normalisation
  - `_at` API per-row parity with the scalar for every parametric perspective
  - never-5xxs on delegate crash (monkeypatched helper raises) — both LIVE and `_at` endpoints collapse to their fallback envelopes with envelope shape preserved
  - LIVE grace vs enforce row divergence on paid bundle (`True` -> `False`; envelope `grace` flips)
  - `_at` grace vs enforce row identity (per-row folds unchanged; envelope `grace` flips)

- [x] `python3 -m pytest tests/test_entitlement_has_all.py tests/test_entitlement_has_all_at.py tests/test_entitlement_has_all_at_batch.py tests/test_entitlement_required_tier_bundle_batch.py tests/test_entitlement_api.py` — **295/295 pass** (sibling regression: no envelope drift on the paired boolean-fold `/has-all` / `/has-all-at` / `/has-all-at-batch`, no shape drift on `/required-tier-bundle-batch`, no shape drift on `/api/entitlement`).

## Local operator verification checklist

Since this fire runs in an ephemeral cloud container with no access to your local daemon, `~/.openclaw`, the live cloud snapshot, or a browser, please verify against the running host once you pull this branch:

- [ ] Copy the three changed files into your live install:
  ```
  cp clawmetry/entitlements.py ~/.clawmetry/lib/python3.*/site-packages/clawmetry/
  cp routes/entitlement.py     ~/.clawmetry/lib/python3.*/site-packages/routes/
  find ~/.clawmetry/lib -name __pycache__ -type d -exec rm -rf {} +
  ```
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` to restart the daemon and pick up the new endpoints.
- [ ] `curl -s -X POST 'http://localhost:8900/api/entitlement/has-all-bundle-batch' -H 'Content-Type: application/json' -d '{"bundles":[{"features":["fleet"],"runtimes":["claude_code"]},{"channels":5,"retention_days":30,"nodes":2},{}]}' | jq .` — expect a 6-key envelope with `count=3`, `bundles[0].has_all=true` (grace), `bundles[1].has_all=true` (grace), `bundles[2].has_all=false` (empty bundle), and `grace=true`.
- [ ] `curl -s -X POST 'http://localhost:8900/api/entitlement/has-all-bundle-batch' -H 'Content-Type: application/json' -d '{"bundles":[{"features":["FLEET","fleet"],"runtimes":["claude-code"]},{"channels":"5","retention_days":"abc"}]}' | jq .bundles` — expect `bundles[0].features=["fleet"]` (dedup + lowercase), `bundles[0].runtimes=["claude_code"]` (alias canonicalisation), `bundles[1].channels=5`, `bundles[1].retention_days=null` (non-int -> null).
- [ ] `curl -sw '\n%{http_code}\n' -X POST 'http://localhost:8900/api/entitlement/has-all-bundle-batch' -H 'Content-Type: application/json' -d '{}'` — expect **400** with `{"error":"missing bundles"}`.
- [ ] `curl -sw '\n%{http_code}\n' -X POST 'http://localhost:8900/api/entitlement/has-all-bundle-batch' -H 'Content-Type: application/json' -d '{"bundles":[]}'` — expect **400** with `{"error":"empty bundles"}`.
- [ ] `curl -s -X POST 'http://localhost:8900/api/entitlement/has-all-bundle-batch-at?tier=oss' -H 'Content-Type: application/json' -d '{"bundles":[{"features":["fleet"]}]}' | jq '.bundles[0].has_all_at'` — expect **false** even while `grace=true` (the whole point of the `_at` slot; paid feature at OSS is statically denied).
- [ ] `curl -s -X POST 'http://localhost:8900/api/entitlement/has-all-bundle-batch-at?tier=cloud_pro' -H 'Content-Type: application/json' -d '{"bundles":[{"features":["fleet"],"runtimes":["claude_code"]}]}' | jq '.bundles[0].has_all_at'` — expect **true** (Cloud Pro admits the bundle statically).
- [ ] `curl -sw '\n%{http_code}\n' -X POST 'http://localhost:8900/api/entitlement/has-all-bundle-batch-at' -H 'Content-Type: application/json' -d '{"bundles":[{"features":["fleet"]}]}'` — expect **400** with `{"error":"missing tier"}`.
- [ ] `curl -sw '\n%{http_code}\n' -X POST 'http://localhost:8900/api/entitlement/has-all-bundle-batch-at?tier=bogus' -H 'Content-Type: application/json' -d '{"bundles":[{"features":["fleet"]}]}'` — expect **404** with `{"error":"unknown tier","which":"tier","tier":"bogus"}`.
- [ ] Cross-endpoint parity: `curl -s -X POST 'http://localhost:8900/api/entitlement/has-all-bundle-batch' -H 'Content-Type: application/json' -d '{"bundles":[{"features":["FLEET","fleet"],"runtimes":["claude-code"],"channels":"5"}]}' | jq '.bundles[0] | {features,runtimes,channels,retention_days,nodes}'` should byte-equal the same jq slice from the sibling `curl -s -X POST 'http://localhost:8900/api/entitlement/required-tier-bundle-batch' ...` on the same bundle.
- [ ] `curl -s 'http://localhost:8900/api/entitlement' | jq .grace` — expect **true** (nothing about the resolver / gate changed — this PR is purely additive query surface).
- [ ] Decrypt the live cloud snapshot in the browser and confirm the dashboard's entitlement panels still render (no shape regression).

This PR stays **DRAFT** until you've done the local + cloud verification above. Version bump / `[RELEASE]` PR / merge is your call.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LMC29iLb3Yzp86v8i8dSuz)_