### PR TITLE
feat(entitlement): has_features_bundle_batch + has_runtimes_bundle_batch + endpoints

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -7426,6 +7426,279 @@ def has_runtimes_at_batch(perspective_tiers, runtimes) -> dict:
     return {"tiers": rows, "unknown": unknown}
 
 
+def _has_features_bundle_row(bundle) -> dict:
+    """Per-bundle row shape for :func:`has_features_bundle_batch`.
+
+    Normalises the bundle exactly the way the singular
+    ``/api/entitlement/has-features`` endpoint does (whitespace stripped,
+    lowercased, deduplicated preserving first-seen order; unknown ids
+    bucketed into ``unknown`` instead of collapsing the whole fold
+    silently) then folds it through :func:`has_features` for the scalar
+    boolean answer.
+
+    Row keys mirror the reverse-lookup sibling
+    :func:`_min_tier_for_features_bundle_row` on every axis but the fold
+    slot: ``features``, ``unknown``, ``kind``, ``count`` are byte-
+    identical so a caller can pair the two bundle-batch rows on the
+    same input; the fold slot swaps ``min_tier*`` for ``has_features``
+    (bool) matching :func:`has_features` -- the singular scalar in the
+    same relationship :func:`min_tier_for_features` has on the reverse-
+    lookup slot.
+
+    An unknown / non-string token echoes into ``unknown`` but ALSO
+    collapses ``has_features`` to ``False`` (inherits :func:`has_features`
+    fold semantics: a typo fails the fold instead of silently granting
+    the bundle even in grace). An empty / all-unknown bundle surfaces as
+    a stable row with ``has_features=False`` so the batch keeps building.
+    Never raises: a per-bundle failure returns the empty row shape with
+    the fold ``False``.
+    """
+    known: list[str] = []
+    unknown: list[str] = []
+    seen: set[str] = set()
+    try:
+        raw_items = list(bundle) if bundle is not None else []
+    except TypeError:
+        raw_items = []
+    for token in raw_items:
+        try:
+            fid = str(token).strip().lower()
+        except Exception:
+            continue
+        if not fid or fid in seen:
+            continue
+        seen.add(fid)
+        if fid in ALL_FEATURES:
+            known.append(fid)
+        else:
+            unknown.append(fid)
+    # Fold rule matches has_features: unknown -> False; empty bundle ->
+    # False (vacuous-truth refused so a caller who forgot the bundle does
+    # not silently render "granted"). Delegates to has_features on the
+    # KNOWN list only after enforcing "no unknown items" so the singular
+    # has_features(known)=True answer cannot mask a typo the row surfaces
+    # via ``unknown``.
+    try:
+        if unknown or not known:
+            allowed = False
+        else:
+            allowed = bool(has_features(known))
+    except Exception as exc:
+        logger.warning(
+            "entitlements: _has_features_bundle_row fold failed: %s", exc
+        )
+        allowed = False
+    return {
+        "features": known,
+        "unknown": unknown,
+        "kind": "features",
+        "count": len(known),
+        "has_features": allowed,
+    }
+
+
+def _has_runtimes_bundle_row(bundle) -> dict:
+    """Runtime-axis twin of :func:`_has_features_bundle_row`.
+
+    Applies :func:`canonical_runtime` before the :data:`ALL_RUNTIMES`
+    membership check so aliases (``claude-code`` -> ``claude_code``)
+    resolve the same way they do on the singular endpoint; duplicates
+    that collapse after canonicalisation only contribute one row.
+    Unknown runtime tokens are echoed into ``unknown`` using the raw
+    lowercased id (matching :func:`_min_tier_for_runtimes_bundle_row`
+    fallback shape). Same fold semantics as
+    :func:`_has_features_bundle_row`: unknown or empty collapses
+    ``has_runtimes`` to ``False``. Never raises.
+    """
+    known: list[str] = []
+    unknown: list[str] = []
+    seen: set[str] = set()
+    try:
+        raw_items = list(bundle) if bundle is not None else []
+    except TypeError:
+        raw_items = []
+    for token in raw_items:
+        try:
+            raw = str(token).strip().lower()
+        except Exception:
+            continue
+        if not raw:
+            continue
+        canon = canonical_runtime(raw)
+        if canon and canon in ALL_RUNTIMES:
+            if canon in seen:
+                continue
+            seen.add(canon)
+            known.append(canon)
+        else:
+            if raw in seen:
+                continue
+            seen.add(raw)
+            unknown.append(raw)
+    try:
+        if unknown or not known:
+            allowed = False
+        else:
+            allowed = bool(has_runtimes(known))
+    except Exception as exc:
+        logger.warning(
+            "entitlements: _has_runtimes_bundle_row fold failed: %s", exc
+        )
+        allowed = False
+    return {
+        "runtimes": known,
+        "unknown": unknown,
+        "kind": "runtimes",
+        "count": len(known),
+        "has_runtimes": allowed,
+    }
+
+
+def has_features_bundle_batch(bundles) -> list[dict]:
+    """Per-bundle boolean-fold "does the CURRENT install grant this whole
+    bundle?" for N caller-supplied feature bundles in ONE round-trip.
+
+    Bundle-axis batch sibling of :func:`has_features` (which folds ONE
+    bundle to ONE boolean) in the same relationship
+    :func:`min_tier_for_features_batch` has to
+    :func:`min_tier_for_features` on the reverse-lookup slot. Where the
+    singular scalar answers "does the CURRENT install allow all these
+    features?" this batches the same question for N distinct feature
+    bundles at once so a paywall matrix or upgrade-walkthrough surface
+    comparing several hypothetical feature sets ("starter add-ons vs
+    pro add-ons vs enterprise add-ons") reads the LIVE grant answer off
+    ONE call instead of N calls to :func:`has_features`.
+
+    Distinct from :func:`has_features_at_batch` (which fixes ONE feature
+    bundle and sweeps N perspective tiers): this fixes N bundles and
+    reads the LIVE per-install grant. Boolean-fold sibling of
+    :func:`min_tier_for_features_batch` on the same input; the two rows
+    pair on the same ``features`` / ``unknown`` / ``kind`` / ``count``
+    axes so a UI can render "granted here? / cheapest tier that grants
+    it?" side by side per bundle.
+
+    Row shape (5 keys) mirrors the reverse-lookup sibling row minus the
+    tier slots plus the boolean-fold slot::
+
+        {
+          "features":     ["fleet", "sso"],
+          "unknown":      ["bogus"],
+          "kind":         "features",
+          "count":        2,
+          "has_features": <bool>,
+        }
+
+    Per-bundle normalisation matches :func:`has_features` /
+    :func:`_min_tier_for_features_bundle_row`: whitespace stripped,
+    lowercased, deduplicated preserving first-seen order; unknown ids
+    bucketed into ``unknown`` instead of silently collapsing the fold
+    without surfacing the typo. Any unknown token collapses the row's
+    ``has_features`` to ``False`` (inherits :func:`has_features` typo-
+    catches-at-callsite posture: ``has_features(["fleet", "Fleeet"])``
+    is ``False`` even in grace). Empty / all-unknown bundles surface as
+    a stable row with ``has_features=False``.
+
+    Argument handling:
+
+    * ``bundles is None`` or non-iterable -- returns ``[]``.
+    * Each bundle may itself be ``None``, non-iterable, or empty -- the
+      helper emits the empty row shape rather than raising.
+    * Non-string tokens inside a bundle are coerced via ``str(...)``
+      (matches the singular endpoint's silent-drop posture for garbage).
+
+    Grace pass-through: while ``ent.grace`` is ``True`` and every item
+    is a known id, the per-row fold reports ``True`` (each
+    :func:`has_feature` reports ``True`` in grace), so wiring this into
+    a paywall matrix today changes NO current behavior. Diverges
+    deliberately from :func:`_min_tier_for_features_bundle_row` (which
+    is grace-independent by construction, backed by the static per-tier
+    grant map); the LIVE row here reflects the running install so the
+    matrix can pair "cheapest tier" and "granted right now" per bundle.
+
+    Never raises: per-bundle failures short-circuit to the empty row
+    shape (``has_features=False``) so the batch keeps building.
+    """
+    try:
+        if bundles is None:
+            return []
+        items = list(bundles)
+    except TypeError:
+        return []
+    out: list[dict] = []
+    for bundle in items:
+        try:
+            out.append(_has_features_bundle_row(bundle))
+        except Exception as exc:
+            logger.warning(
+                "entitlements: has_features_bundle_batch row failed: %s",
+                exc,
+            )
+            out.append(
+                {
+                    "features": [],
+                    "unknown": [],
+                    "kind": "features",
+                    "count": 0,
+                    "has_features": False,
+                }
+            )
+    return out
+
+
+def has_runtimes_bundle_batch(bundles) -> list[dict]:
+    """Runtime-axis twin of :func:`has_features_bundle_batch`: per-bundle
+    boolean-fold "does the CURRENT install grant this whole bundle?" for
+    N caller-supplied runtime bundles in ONE round-trip.
+
+    Same relationship to :func:`has_runtimes` that
+    :func:`has_features_bundle_batch` has to :func:`has_features` and
+    that :func:`min_tier_for_runtimes_batch` has to
+    :func:`min_tier_for_runtimes` on the reverse-lookup slot. Pairs
+    with :func:`has_features_bundle_batch` the same way
+    :func:`min_tier_for_runtimes_batch` pairs with
+    :func:`min_tier_for_features_batch`: together the two boolean-fold
+    bundle-batch helpers let a pricing matrix column ("does the LIVE
+    install admit {claude_code, cursor}? {openclaw}? {aider, goose}?")
+    hydrate every bundle off ONE call per axis instead of N calls to
+    :func:`has_runtimes`.
+
+    Row shape (5 keys) mirrors :func:`has_features_bundle_batch` with
+    ``runtimes`` in the axis slot and ``has_runtimes`` in the fold slot;
+    runtime-alias posture is inherited from
+    :func:`_has_runtimes_bundle_row` -- aliases canonicalise before the
+    :data:`ALL_RUNTIMES` membership check so a caller does not need to
+    normalise before calling.
+
+    Never raises. Contract otherwise mirrors
+    :func:`has_features_bundle_batch` byte-for-byte.
+    """
+    try:
+        if bundles is None:
+            return []
+        items = list(bundles)
+    except TypeError:
+        return []
+    out: list[dict] = []
+    for bundle in items:
+        try:
+            out.append(_has_runtimes_bundle_row(bundle))
+        except Exception as exc:
+            logger.warning(
+                "entitlements: has_runtimes_bundle_batch row failed: %s",
+                exc,
+            )
+            out.append(
+                {
+                    "runtimes": [],
+                    "unknown": [],
+                    "kind": "runtimes",
+                    "count": 0,
+                    "has_runtimes": False,
+                }
+            )
+    return out
+
+
 def missing_features(features) -> list:
     """Row-level complement of :func:`has_features`: return the subset of
     ``features`` NOT granted by the resolved entitlement.

--- a/docs/ENTITLEMENTS.md
+++ b/docs/ENTITLEMENTS.md
@@ -193,15 +193,80 @@ family of preview/diff/batch helpers. The stable everyday endpoints are:
 | `GET /api/entitlement/required-tier?feature=<f>` | Cheapest tier that includes the given feature/runtime/channel-count/etc. |
 
 Beyond these there is a large family of preview / batch / capacity /
-"at-tier" / rollup (`has-all`, `missing-all`) / row-detail
-complement (`missing-features`, `missing-runtimes`) endpoints that
-let a UI answer questions like "what does tier X look like at N
-channels", "which tiers are affordable at this node count", "what
-does the path from tier A to tier B unlock at each step", "does the
-resolved install grant this whole bundle in one boolean fold" and
-"what's blocking the upgrade off ONE per-axis denial payload". They
-all read the same in-memory tier matrix and never mutate state. See
-`routes/entitlement.py` for the full list.
+'at-tier' / rollup (`has-all`, `missing-all`, `missing-all-at`) /
+row-detail complement (`missing-features`, `missing-runtimes`) /
+multi-bundle boolean-fold (`has-features-bundle-batch`,
+`has-runtimes-bundle-batch`) endpoints that let a UI answer questions
+like "what does tier X look like at N channels", "which tiers are
+affordable at this node count", "what does the path from tier A to tier B
+unlock at each step", "does the resolved install grant this whole bundle
+in one boolean fold" and "what's blocking the upgrade off ONE per-axis
+denial payload". They all read the same in-memory tier matrix and never
+mutate state. See `routes/entitlement.py` for the full list.
+
+### Boolean-fold bundle-batch endpoints
+
+`POST /api/entitlement/has-features-bundle-batch` and `POST
+/api/entitlement/has-runtimes-bundle-batch` fold N caller-supplied
+feature/runtime bundles to N `has_*` booleans in one round-trip — the
+boolean-fold sibling of `/min-tier-for-features-batch` /
+`/min-tier-for-runtimes-batch` on the same bundle axis.
+
+**Request body** (byte-identical to the `min-tier-for-*-batch` siblings):
+
+```json
+{"bundles": [["fleet", "sso"], ["otel_export"], []]}
+```
+
+A bare list-of-strings is treated as one bundle (single-bundle shorthand).
+400 on missing / non-list / empty `bundles` key.
+
+**Response envelope** (6 keys):
+
+```json
+{
+  "bundles":          [...],
+  "count":            3,
+  "current_tier":     "oss",
+  "current_tier_rank": 0,
+  "grace":            true,
+  "enforced":         false
+}
+```
+
+**Per-bundle row** (5 keys; `has_features` / `has_runtimes` mirrors the
+singular scalar's return-slot name):
+
+```json
+{
+  "features":     ["fleet", "sso"],
+  "unknown":      [],
+  "kind":         "features",
+  "count":        2,
+  "has_features": true
+}
+```
+
+The `features`/`runtimes`, `unknown`, `kind`, and `count` keys are
+byte-identical to the corresponding `/min-tier-for-*-batch` rows so a UI
+can render "granted right now?" and "cheapest tier that grants it?"
+side-by-side per bundle from two calls.
+
+**Behaviour notes:**
+
+- An unknown token anywhere in a bundle collapses that row's `has_*` to
+  `false` (matches the singular `has_features` / `has_runtimes`
+  typo-at-callsite posture — a typo surfaces via `unknown[]` instead of
+  silently appearing granted).
+- Empty, all-unknown, `None`, and non-iterable bundles surface as a stable
+  row with `has_*: false`.
+- Runtime aliases are canonicalised per-bundle before the membership check
+  (`claude-code` → `claude_code`); unknown ids echo raw into `unknown[]`.
+- Never raises: per-bundle failures short-circuit to the empty row shape so
+  the batch keeps building.
+- Ships in GRACE mode — `has_*` reads the live grant via the same resolver
+  as the singular scalar. A paid feature returns `true` in grace; FREE
+  runtimes return `true` on the live install regardless of rollout state.
 
 Every endpoint is defensive: a resolver failure falls back to the OSS-
 free snapshot (identical shape) rather than 500-ing, so a UI can rely

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -38438,6 +38438,213 @@ def api_entitlement_min_tier_for_runtimes_batch():
         )
 
 
+def _has_bundle_row_body(row: dict, list_key: str) -> dict:
+    """Normalise a ``has_features_bundle_batch`` /
+    ``has_runtimes_bundle_batch`` helper row for the endpoint response.
+
+    Boolean-fold sibling of :func:`_min_tier_for_bundle_row_to_body`:
+    same ``list_key`` / ``unknown`` / ``kind`` / ``count`` axes, but the
+    tier slots are swapped for a single ``has_<axis>`` bool matching the
+    fold-slot name on the singular ``/api/entitlement/has-features`` /
+    ``/has-runtimes`` endpoint body. Never raises; a missing key
+    surfaces as the empty-row shape with ``has_<axis>=False`` so the
+    batch envelope is byte-stable across every branch.
+    """
+    fold_key = f"has_{list_key}"
+    return {
+        list_key: list(row.get(list_key) or []),
+        "unknown": list(row.get("unknown") or []),
+        "kind": row.get("kind"),
+        "count": int(row.get("count") or 0),
+        fold_key: bool(row.get(fold_key)),
+    }
+
+
+@bp_entitlement.route(
+    "/api/entitlement/has-features-bundle-batch",
+    methods=["POST"],
+)
+def api_entitlement_has_features_bundle_batch():
+    """``POST /api/entitlement/has-features-bundle-batch`` -- bundle-axis
+    batch boolean-fold sibling of ``/api/entitlement/has-features``.
+
+    Where the singular endpoint folds ONE bundle of features to ONE
+    ``has_features`` boolean on the LIVE install, this folds N caller-
+    supplied feature bundles to N ``has_features`` rows in ONE round-
+    trip. Distinct from ``/has-features-at-batch`` (which fixes ONE
+    feature bundle and sweeps N perspective tiers): this fixes N
+    bundles and reads the LIVE per-install grant. Boolean-fold sibling
+    of ``/min-tier-for-features-batch`` on the reverse-lookup slot; the
+    two responses pair on the same ``features`` / ``unknown`` / ``kind``
+    / ``count`` axes so a UI can render "granted right now? / cheapest
+    tier that grants it?" side by side per bundle off two calls.
+
+    Use case: a paywall matrix or upgrade-walkthrough surface comparing
+    several hypothetical feature sets ("starter add-ons vs pro add-ons
+    vs enterprise add-ons") hydrates the LIVE-grant column off ONE
+    round-trip instead of N calls to ``/has-features``.
+
+    POST rather than GET because the caller-supplied set of bundles can
+    grow past a comfortable query-string length; the sibling singular
+    endpoint uses GET+CSV where the bundle is small.
+
+    Request body::
+
+        {
+          "bundles": [
+            ["fleet", "sso"],
+            ["otel_export"],
+            []
+          ]
+        }
+
+    A shorthand ``{"bundles": ["fleet", "sso"]}`` (bare list of strings)
+    is treated as ONE bundle, matching the singular endpoint's bare-CSV
+    posture; a missing / non-list ``bundles`` value is a 400. An empty
+    ``bundles=[]`` list is a 400 for the same reason the singular
+    endpoint 400s on an empty ``features=`` -- distinguishes "caller
+    asked for nothing" from "caller asked and every token was unknown".
+
+    Response shape::
+
+        {
+          "bundles": [<row>, ...],
+          "count":   <int>,        # len(bundles)
+          "current_tier":      "...",
+          "current_tier_rank": <int>,
+          "grace":             <bool>,
+          "enforced":          <bool>,
+        }
+
+    Each ``<row>`` is byte-stable across every input branch::
+
+        {
+          "features":     ["fleet", "sso"],
+          "unknown":      ["bogus"],
+          "kind":         "features",
+          "count":        2,
+          "has_features": <bool>,
+        }
+
+    Per-bundle normalisation matches the singular endpoint: whitespace
+    stripped, lowercased, deduplicated preserving first-seen order;
+    unknown ids bucketed into the per-bundle ``unknown`` list instead
+    of mis-collapsing the fold. Any unknown token collapses that row's
+    ``has_features`` to ``False`` (inherits the singular typo-catches-
+    at-callsite posture). Empty / all-unknown bundles surface as a
+    stable row with ``has_features=False`` (does NOT short-circuit the
+    batch).
+
+    - **400** when ``bundles`` is missing / non-list / empty
+    - **Never 5xxs**: a resolver failure yields the fallback envelope
+      (empty ``bundles`` list) so the paywall matrix keeps rendering.
+    """
+    body = request.get_json(silent=True) or {}
+    bundles, err = _parse_bundles_body(body)
+    if err == "missing":
+        return jsonify({"error": "missing bundles"}), 400
+    if err == "empty":
+        return jsonify({"error": "empty bundles"}), 400
+    if err == "bundles_must_be_list":
+        return jsonify({"error": "bundles must be a list"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        rows = _ent.has_features_bundle_batch(bundles)
+        out_rows = [_has_bundle_row_body(row, "features") for row in rows]
+        env = _resolver_envelope(_ent)
+        return jsonify(
+            {
+                "bundles": out_rows,
+                "count": len(out_rows),
+                **env,
+            }
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_has_features_bundle_batch: error: %s", exc
+        )
+        return jsonify(
+            {
+                "bundles": [],
+                "count": 0,
+                "current_tier": "oss",
+                "current_tier_rank": 0,
+                "grace": True,
+                "enforced": False,
+            }
+        )
+
+
+@bp_entitlement.route(
+    "/api/entitlement/has-runtimes-bundle-batch",
+    methods=["POST"],
+)
+def api_entitlement_has_runtimes_bundle_batch():
+    """``POST /api/entitlement/has-runtimes-bundle-batch`` -- runtime-
+    axis twin of ``/api/entitlement/has-features-bundle-batch``.
+
+    Same never-5xx posture, same partial-unknown bucketing, same POST
+    envelope. Runtime aliases (``claude-code`` -> ``claude_code``) are
+    canonicalised per bundle through
+    :func:`clawmetry.entitlements.canonical_runtime` so a caller does
+    not need to normalise before calling; unknown ids land in the per-
+    bundle ``unknown`` and collapse that row's ``has_runtimes`` to
+    ``False`` (a typo does NOT silently render "granted" even in
+    grace).
+
+    Request body::
+
+        {
+          "bundles": [
+            ["claude_code", "codex"],
+            ["openclaw"],
+            []
+          ]
+        }
+
+    Response shape and error paths mirror
+    ``/has-features-bundle-batch`` exactly, with ``kind="runtimes"``,
+    a ``runtimes`` list in place of ``features``, and ``has_runtimes``
+    in place of ``has_features`` per row.
+    """
+    body = request.get_json(silent=True) or {}
+    bundles, err = _parse_bundles_body(body)
+    if err == "missing":
+        return jsonify({"error": "missing bundles"}), 400
+    if err == "empty":
+        return jsonify({"error": "empty bundles"}), 400
+    if err == "bundles_must_be_list":
+        return jsonify({"error": "bundles must be a list"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        rows = _ent.has_runtimes_bundle_batch(bundles)
+        out_rows = [_has_bundle_row_body(row, "runtimes") for row in rows]
+        env = _resolver_envelope(_ent)
+        return jsonify(
+            {
+                "bundles": out_rows,
+                "count": len(out_rows),
+                **env,
+            }
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_has_runtimes_bundle_batch: error: %s", exc
+        )
+        return jsonify(
+            {
+                "bundles": [],
+                "count": 0,
+                "current_tier": "oss",
+                "current_tier_rank": 0,
+                "grace": True,
+                "enforced": False,
+            }
+        )
+
+
 def _parse_aggregate_bundles_body(body, key: str = "bundles"):
     """Extract a list of aggregate 5-axis bundle dicts from a JSON POST body.
 

--- a/tests/test_entitlement_has_bundle_batch.py
+++ b/tests/test_entitlement_has_bundle_batch.py
@@ -1,0 +1,558 @@
+"""Tests for the bundle-batch ``/api/entitlement/has-features-bundle-batch``
+and ``/api/entitlement/has-runtimes-bundle-batch`` endpoints.
+
+Boolean-fold bundle-axis batch sibling of the singular
+``/api/entitlement/has-features`` / ``/api/entitlement/has-runtimes``
+endpoints (which fold ONE bundle to ONE ``has_*`` boolean on the LIVE
+install), in the same relationship
+``/api/entitlement/min-tier-for-features-batch`` /
+``/api/entitlement/min-tier-for-runtimes-batch`` have to the reverse-
+lookup singular endpoints. Wraps the
+:func:`clawmetry.entitlements.has_features_bundle_batch` /
+:func:`clawmetry.entitlements.has_runtimes_bundle_batch` helpers.
+
+Distinct from ``/has-features-at-batch`` (which fixes ONE bundle and
+sweeps N perspective tiers): this fixes N bundles and reads the LIVE
+per-install grant.
+
+These tests pin:
+
+* helper: per-bundle normalisation (whitespace, lowercase, dedup
+  preserving first-seen order), unknown-id bucketing, runtime alias
+  canonicalisation, empty / all-unknown bundles surface as a stable
+  row with ``has_*=False``
+* helper: unknown item collapses the row's fold ``False`` (typo-
+  catches-at-callsite posture)
+* helper: per-row parity with the singular scalar
+  (``has_features_bundle_batch([b])[0]['has_features']`` byte-equals
+  ``has_features(b)``) on the KNOWN slice
+* helper: never-raise on ``None`` / non-iterable / non-dict bundles
+* API happy path: 6-key envelope, 5-key row, ``count``, ``kind``
+* API error paths: 400 on missing / non-list / empty ``bundles``
+* API single-dict / bare-string shorthand ('bundles': ['fleet', 'sso'])
+* API row byte-parity vs the singular scalar on the same known bundle
+* API cross-endpoint axis-echo parity vs
+  ``/min-tier-for-features-batch`` / ``/min-tier-for-runtimes-batch``
+  on ``features`` / ``unknown`` / ``kind`` / ``count``
+* API never-5xxs on a delegate crash (monkey-patched helper raises)
+* grace vs enforce fold divergence (paid feature -> True in grace,
+  False after enforcement — matches ``has_features`` grace posture)
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# ── helper: bundle normalisation ─────────────────────────────────────────
+
+
+def test_helper_features_bundle_batch_dedups_and_lowers(ent):
+    rows = ent.has_features_bundle_batch(
+        [["fleet", "", "FLEET", "sso"], ["otel_export"]]
+    )
+    assert len(rows) == 2
+    assert rows[0]["features"] == ["fleet", "sso"]
+    assert rows[0]["unknown"] == []
+    assert rows[0]["count"] == 2
+    assert rows[1]["features"] == ["otel_export"]
+
+
+def test_helper_features_bundle_batch_buckets_unknown(ent):
+    rows = ent.has_features_bundle_batch([["fleet", "bogus"]])
+    assert rows[0]["features"] == ["fleet"]
+    assert rows[0]["unknown"] == ["bogus"]
+    # Unknown collapses the fold to False even in grace.
+    assert rows[0]["has_features"] is False
+
+
+def test_helper_features_bundle_batch_empty_bundle_stable_row(ent):
+    rows = ent.has_features_bundle_batch([[]])
+    assert len(rows) == 1
+    r = rows[0]
+    assert r["features"] == []
+    assert r["unknown"] == []
+    assert r["kind"] == "features"
+    assert r["count"] == 0
+    assert r["has_features"] is False
+
+
+def test_helper_features_bundle_batch_all_unknown_stable_row(ent):
+    rows = ent.has_features_bundle_batch([["bogus1", "bogus2"]])
+    r = rows[0]
+    assert r["features"] == []
+    assert r["unknown"] == ["bogus1", "bogus2"]
+    assert r["count"] == 0
+    assert r["has_features"] is False
+
+
+def test_helper_features_bundle_batch_none_returns_empty(ent):
+    assert ent.has_features_bundle_batch(None) == []
+
+
+def test_helper_features_bundle_batch_non_iterable_returns_empty(ent):
+    assert ent.has_features_bundle_batch(42) == []
+
+
+def test_helper_features_bundle_batch_none_bundle_stable_row(ent):
+    rows = ent.has_features_bundle_batch([None, ["fleet"]])
+    assert len(rows) == 2
+    assert rows[0] == {
+        "features": [],
+        "unknown": [],
+        "kind": "features",
+        "count": 0,
+        "has_features": False,
+    }
+    assert rows[1]["features"] == ["fleet"]
+
+
+def test_helper_features_bundle_batch_non_string_tokens_coerce(ent):
+    # Non-string tokens coerce via str(); numeric tokens land in unknown.
+    rows = ent.has_features_bundle_batch([[42, "fleet"]])
+    assert rows[0]["features"] == ["fleet"]
+    assert "42" in rows[0]["unknown"]
+    # Unknown collapses fold to False.
+    assert rows[0]["has_features"] is False
+
+
+def test_helper_runtimes_bundle_batch_canonicalises_aliases(ent):
+    rows = ent.has_runtimes_bundle_batch(
+        [["claude-code", "codex", "claude_code"]]
+    )
+    # Canonicalisation + dedup after canonicalisation.
+    assert rows[0]["runtimes"] == ["claude_code", "codex"]
+    assert rows[0]["unknown"] == []
+
+
+def test_helper_runtimes_bundle_batch_buckets_unknown(ent):
+    rows = ent.has_runtimes_bundle_batch([["claude_code", "bogus_rt"]])
+    assert rows[0]["runtimes"] == ["claude_code"]
+    assert rows[0]["unknown"] == ["bogus_rt"]
+    assert rows[0]["has_runtimes"] is False
+
+
+def test_helper_runtimes_bundle_batch_openclaw_free_grants(ent):
+    rows = ent.has_runtimes_bundle_batch([["openclaw"]])
+    # openclaw is the free runtime; every install grants it, so LIVE
+    # fold is True across every rollout state.
+    assert rows[0]["runtimes"] == ["openclaw"]
+    assert rows[0]["has_runtimes"] is True
+
+
+def test_helper_runtimes_bundle_batch_none_returns_empty(ent):
+    assert ent.has_runtimes_bundle_batch(None) == []
+
+
+# ── helper: per-row parity with the singular scalar ──────────────────────
+
+
+def test_helper_features_bundle_batch_per_row_parity_with_scalar(ent):
+    """Per-row ``has_features`` byte-equals the singular scalar for
+    every KNOWN-only bundle (unknown items collapse the row to False
+    without querying the scalar — that divergence is tested separately
+    above)."""
+    bundles = [
+        ["fleet", "sso"],
+        ["otel_export"],
+        ["fleet"],
+        ["sso"],
+        [],
+    ]
+    rows = ent.has_features_bundle_batch(bundles)
+    for row, bundle in zip(rows, bundles):
+        # Reproduce the helper's normalisation for the singular
+        # comparison (KNOWN slice only).
+        seen: set[str] = set()
+        known: list[str] = []
+        for tok in bundle:
+            s = tok.strip().lower()
+            if s and s in ent.ALL_FEATURES and s not in seen:
+                seen.add(s)
+                known.append(s)
+        singular = ent.has_features(known) if known else False
+        assert row["has_features"] == singular
+
+
+def test_helper_runtimes_bundle_batch_per_row_parity_with_scalar(ent):
+    bundles = [
+        ["openclaw"],
+        ["claude-code", "codex"],
+        ["claude_code"],
+        [],
+    ]
+    rows = ent.has_runtimes_bundle_batch(bundles)
+    for row, bundle in zip(rows, bundles):
+        seen: set[str] = set()
+        known: list[str] = []
+        for tok in bundle:
+            c = ent.canonical_runtime(tok.strip().lower())
+            if c and c in ent.ALL_RUNTIMES and c not in seen:
+                seen.add(c)
+                known.append(c)
+        singular = ent.has_runtimes(known) if known else False
+        assert row["has_runtimes"] == singular
+
+
+# ── helper: grace pass-through ───────────────────────────────────────────
+
+
+def test_helper_features_bundle_batch_grace_paid_feature_true(ent):
+    # In grace (default OSS-free rollout), a paid-only feature still
+    # reads True from has_features via the resolver's grace pass-through
+    # -- matches the singular has_features scalar posture.
+    assert ent.get_entitlement().grace is True
+    rows = ent.has_features_bundle_batch([["fleet"]])
+    assert rows[0]["has_features"] is True
+
+
+def test_helper_features_bundle_batch_never_raises_on_bad_bundle(ent):
+    # A non-iterable per-bundle entry doesn't raise: normalisation
+    # collapses it to the empty row shape.
+    rows = ent.has_features_bundle_batch([42, ["fleet"]])
+    assert len(rows) == 2
+    assert rows[0]["has_features"] is False
+
+
+# ── API: happy path ──────────────────────────────────────────────────────
+
+
+_ROW_ENVELOPE = {
+    "unknown",
+    "kind",
+    "count",
+}
+
+
+def _row_keys(axis: str) -> set[str]:
+    return _ROW_ENVELOPE | {axis, f"has_{axis}"}
+
+
+def test_api_features_bundle_batch_happy(client, ent):
+    r = client.post(
+        "/api/entitlement/has-features-bundle-batch",
+        json={"bundles": [["fleet", "sso"], ["otel_export"], []]},
+    )
+    assert r.status_code == 200
+    j = r.get_json()
+    assert set(j.keys()) == {
+        "bundles",
+        "count",
+        "current_tier",
+        "current_tier_rank",
+        "grace",
+        "enforced",
+    }
+    assert j["count"] == 3
+    assert len(j["bundles"]) == 3
+    for row in j["bundles"]:
+        assert set(row.keys()) == _row_keys("features")
+        assert row["kind"] == "features"
+    assert j["bundles"][0]["features"] == ["fleet", "sso"]
+    # Grace-on install: known paid features fold True.
+    assert j["bundles"][0]["has_features"] is True
+    assert j["bundles"][2]["features"] == []
+    assert j["bundles"][2]["has_features"] is False
+
+
+def test_api_runtimes_bundle_batch_happy(client, ent):
+    r = client.post(
+        "/api/entitlement/has-runtimes-bundle-batch",
+        json={"bundles": [["claude-code", "codex"], ["openclaw"]]},
+    )
+    assert r.status_code == 200
+    j = r.get_json()
+    assert j["count"] == 2
+    for row in j["bundles"]:
+        assert set(row.keys()) == _row_keys("runtimes")
+        assert row["kind"] == "runtimes"
+    # Canonicalisation applied.
+    assert j["bundles"][0]["runtimes"] == ["claude_code", "codex"]
+    assert j["bundles"][1]["runtimes"] == ["openclaw"]
+    # openclaw is FREE_RUNTIMES so LIVE fold is True regardless of grace.
+    assert j["bundles"][1]["has_runtimes"] is True
+
+
+def test_api_features_bundle_batch_single_bundle_shorthand(client, ent):
+    """A bare list of strings is treated as ONE bundle (matches the
+    singular endpoint's bare-CSV posture and the reverse-lookup
+    /min-tier-for-features-batch endpoint)."""
+    r = client.post(
+        "/api/entitlement/has-features-bundle-batch",
+        json={"bundles": ["fleet", "sso"]},
+    )
+    assert r.status_code == 200
+    j = r.get_json()
+    assert j["count"] == 1
+    assert j["bundles"][0]["features"] == ["fleet", "sso"]
+
+
+def test_api_runtimes_bundle_batch_single_bundle_shorthand(client, ent):
+    r = client.post(
+        "/api/entitlement/has-runtimes-bundle-batch",
+        json={"bundles": ["claude_code", "codex"]},
+    )
+    assert r.status_code == 200
+    j = r.get_json()
+    assert j["count"] == 1
+    assert j["bundles"][0]["runtimes"] == ["claude_code", "codex"]
+
+
+def test_api_features_bundle_batch_unknown_bucketed(client, ent):
+    r = client.post(
+        "/api/entitlement/has-features-bundle-batch",
+        json={"bundles": [["fleet", "bogus"]]},
+    )
+    j = r.get_json()
+    assert j["bundles"][0]["features"] == ["fleet"]
+    assert j["bundles"][0]["unknown"] == ["bogus"]
+    # Unknown collapses fold to False even in grace.
+    assert j["bundles"][0]["has_features"] is False
+
+
+# ── API: error paths ─────────────────────────────────────────────────────
+
+
+def test_api_features_bundle_batch_missing_bundles_400(client):
+    r = client.post("/api/entitlement/has-features-bundle-batch", json={})
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "missing bundles"
+
+
+def test_api_features_bundle_batch_empty_bundles_400(client):
+    r = client.post(
+        "/api/entitlement/has-features-bundle-batch",
+        json={"bundles": []},
+    )
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "empty bundles"
+
+
+def test_api_features_bundle_batch_non_list_bundles_400(client):
+    r = client.post(
+        "/api/entitlement/has-features-bundle-batch",
+        json={"bundles": 42},
+    )
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "bundles must be a list"
+
+
+def test_api_features_bundle_batch_no_body_400(client):
+    r = client.post("/api/entitlement/has-features-bundle-batch")
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "missing bundles"
+
+
+def test_api_runtimes_bundle_batch_missing_bundles_400(client):
+    r = client.post("/api/entitlement/has-runtimes-bundle-batch", json={})
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "missing bundles"
+
+
+def test_api_runtimes_bundle_batch_empty_bundles_400(client):
+    r = client.post(
+        "/api/entitlement/has-runtimes-bundle-batch",
+        json={"bundles": []},
+    )
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "empty bundles"
+
+
+def test_api_runtimes_bundle_batch_non_list_bundles_400(client):
+    r = client.post(
+        "/api/entitlement/has-runtimes-bundle-batch",
+        json={"bundles": "not-a-list"},
+    )
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "bundles must be a list"
+
+
+# ── API: row byte-parity with the singular scalar ────────────────────────
+
+
+def test_api_features_bundle_batch_row_parity_with_singular_scalar(
+    client, ent
+):
+    """Per-row ``has_features`` byte-equals ``has_features`` on the
+    KNOWN slice of the same bundle -- the paywall matrix column reads
+    identical values whether it queries the singular scalar per row or
+    the bundle-batch endpoint once."""
+    for bundle in (
+        ["fleet", "sso"],
+        ["otel_export"],
+        ["fleet"],
+        ["sso"],
+    ):
+        r = client.post(
+            "/api/entitlement/has-features-bundle-batch",
+            json={"bundles": [bundle]},
+        )
+        row = r.get_json()["bundles"][0]
+        # KNOWN slice = every item passed since bundle is all known.
+        assert row["has_features"] == ent.has_features(bundle)
+
+
+def test_api_runtimes_bundle_batch_row_parity_with_singular_scalar(
+    client, ent
+):
+    for bundle in (
+        ["openclaw"],
+        ["claude_code"],
+        ["claude_code", "codex"],
+    ):
+        r = client.post(
+            "/api/entitlement/has-runtimes-bundle-batch",
+            json={"bundles": [bundle]},
+        )
+        row = r.get_json()["bundles"][0]
+        assert row["has_runtimes"] == ent.has_runtimes(bundle)
+
+
+# ── API: cross-endpoint axis echo parity ────────────────────────────────
+
+
+def test_api_features_bundle_batch_axis_echo_parity_vs_min_tier(
+    client, ent
+):
+    """The axis / unknown / kind / count slice of each row byte-equals
+    the same slice on ``/min-tier-for-features-batch`` on the same
+    input bundle (only the fold slot diverges -- ``has_features`` bool
+    here vs ``required_tier`` id on the reverse-lookup sibling)."""
+    bundles = [["FLEET", "fleet", "sso"], ["bogus", "otel_export"], []]
+
+    r_has = client.post(
+        "/api/entitlement/has-features-bundle-batch",
+        json={"bundles": bundles},
+    ).get_json()
+    r_mtr = client.post(
+        "/api/entitlement/min-tier-for-features-batch",
+        json={"bundles": bundles},
+    ).get_json()
+
+    for row_has, row_mtr in zip(r_has["bundles"], r_mtr["bundles"]):
+        for k in ("features", "unknown", "kind", "count"):
+            assert row_has[k] == row_mtr[k], k
+
+
+def test_api_runtimes_bundle_batch_axis_echo_parity_vs_min_tier(
+    client, ent
+):
+    bundles = [
+        ["claude-code", "codex", "claude_code"],
+        ["openclaw", "bogus_rt"],
+        [],
+    ]
+    r_has = client.post(
+        "/api/entitlement/has-runtimes-bundle-batch",
+        json={"bundles": bundles},
+    ).get_json()
+    r_mtr = client.post(
+        "/api/entitlement/min-tier-for-runtimes-batch",
+        json={"bundles": bundles},
+    ).get_json()
+    for row_has, row_mtr in zip(r_has["bundles"], r_mtr["bundles"]):
+        for k in ("runtimes", "unknown", "kind", "count"):
+            assert row_has[k] == row_mtr[k], k
+
+
+# ── API: never-5xxs on delegate crash ────────────────────────────────────
+
+
+def test_api_features_bundle_batch_never_5xxs_on_delegate_crash(
+    monkeypatch, client, ent
+):
+    def _boom(bundles):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(ent, "has_features_bundle_batch", _boom)
+    r = client.post(
+        "/api/entitlement/has-features-bundle-batch",
+        json={"bundles": [["fleet"]]},
+    )
+    assert r.status_code == 200
+    j = r.get_json()
+    # Fallback envelope shape preserved.
+    assert set(j.keys()) == {
+        "bundles",
+        "count",
+        "current_tier",
+        "current_tier_rank",
+        "grace",
+        "enforced",
+    }
+    assert j["bundles"] == []
+    assert j["count"] == 0
+
+
+def test_api_runtimes_bundle_batch_never_5xxs_on_delegate_crash(
+    monkeypatch, client, ent
+):
+    def _boom(bundles):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(ent, "has_runtimes_bundle_batch", _boom)
+    r = client.post(
+        "/api/entitlement/has-runtimes-bundle-batch",
+        json={"bundles": [["openclaw"]]},
+    )
+    assert r.status_code == 200
+    j = r.get_json()
+    assert j["bundles"] == []
+    assert j["count"] == 0
+
+
+# ── grace vs enforce fold divergence ─────────────────────────────────────
+
+
+def test_helper_features_bundle_batch_grace_vs_enforce_diverges(
+    monkeypatch, tmp_path
+):
+    """Paid feature reads True under grace (matches ``has_features``
+    grace pass-through) and False after enforcement."""
+    import clawmetry.entitlements as e
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    # GRACE mode (default).
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    importlib.reload(e)
+    e.invalidate()
+    grace_rows = e.has_features_bundle_batch([["fleet"]])
+    assert e.get_entitlement().grace is True
+    assert grace_rows[0]["has_features"] is True
+
+    # ENFORCE mode.
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    importlib.reload(e)
+    e.invalidate()
+    enforce_rows = e.has_features_bundle_batch([["fleet"]])
+    assert e.get_entitlement().grace is False
+    assert enforce_rows[0]["has_features"] is False
+
+    # Reset for other tests.
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    importlib.reload(e)
+    e.invalidate()


### PR DESCRIPTION
## Summary

Boolean-fold bundle-axis batch siblings of `has_features` / `has_runtimes` in the same relationship `min_tier_for_features_batch` has to `min_tier_for_features` on the reverse-lookup slot. Where the singular scalars fold ONE bundle to ONE `has_*` boolean on the LIVE install, these batch N caller-supplied feature-list / runtime-list bundles to N `has_*` rows in ONE round-trip so a paywall matrix or upgrade-walkthrough surface comparing several hypothetical bundles ("starter add-ons vs pro add-ons vs enterprise add-ons") reads the LIVE grant answer off ONE call instead of N calls to the singular scalar.

Distinct from `/has-features-at-batch` / `/has-runtimes-at-batch` (which fix ONE bundle and sweep N perspective tiers): this fixes N bundles and reads the LIVE per-install grant. Boolean-fold sibling of `/min-tier-for-features-batch` / `/min-tier-for-runtimes-batch` on the reverse-lookup slot; the two responses pair on the same `axis` / `unknown` / `kind` / `count` axes so a UI can render "granted right now? / cheapest tier that grants it?" side by side per bundle off two calls.

- **`has_features_bundle_batch(bundles) -> list[dict]`** and **`has_runtimes_bundle_batch(bundles) -> list[dict]`** in `clawmetry/entitlements.py`, plus shared per-bundle normalisation helpers `_has_features_bundle_row` / `_has_runtimes_bundle_row`. Row shape (5 keys) mirrors the reverse-lookup sibling `_min_tier_for_features_bundle_row` on `axis` / `unknown` / `kind` / `count` and swaps the tier slots for the `has_<axis>` boolean matching the singular scalar's return-slot name:

  ```
  {
    "features":     ["fleet", "sso"],
    "unknown":      ["bogus"],
    "kind":         "features",
    "count":        2,
    "has_features": <bool>,
  }
  ```

- **Any unknown token collapses the row's `has_<axis>` to False** (inherits `has_features` / `has_runtimes` typo-catches-at-callsite posture: `has_features(["fleet", "Fleeet"])` is `False` even in grace so a typo surfaces via `unknown[]` instead of silently rendering "granted"). Empty / all-unknown / `None` / non-iterable bundles surface as a stable row with `has_<axis>=False`. Never raises: per-bundle failures short-circuit to the empty row shape so the batch keeps building.

- Runtime aliases (`claude-code` → `claude_code`) canonicalise per bundle through `canonical_runtime` before the `ALL_RUNTIMES` membership check so a caller does not need to normalise before calling; unknown ids echo raw into `unknown[]` and collapse that row's `has_runtimes` to `False`.

- **`POST /api/entitlement/has-features-bundle-batch`** and **`POST /api/entitlement/has-runtimes-bundle-batch`** on `bp_entitlement`. Request body is byte-identical to `/min-tier-for-features-batch` — same `_parse_bundles_body` parser is reused so single-dict / bare-list shorthand, 400 on missing / non-list / empty `bundles`, and never-5xxs on delegate crash all match the sibling exactly. Response envelope is 6-key (`bundles`, `count`, `current_tier`, `current_tier_rank`, `grace`, `enforced`); per-row body is 5-key.

- **Shared `_has_bundle_row_body(row, list_key)`** helper in `routes/entitlement.py` (boolean-fold sibling of `_min_tier_for_bundle_row_to_body`) renames the fold slot to `has_<axis>` matching the singular endpoint body.

Behaviour ships in **GRACE** mode: the resolver still defaults to the OSS-free entitlement so no runtime gating changes. Purely additive to the entitlement query surface.

## Test plan

- [x] `python3 -m py_compile clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_has_bundle_batch.py`
- [x] `python3 -m ruff check clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_has_bundle_batch.py --select I,F,E9` — clean.
- [x] `python3 scripts/lint_daemon_allowlist.py` — passes (no `local_store_via_daemon` calls touched).
- [x] `python3 -m pytest tests/test_entitlement_has_bundle_batch.py` — **35/35 pass**, covering:
  - per-bundle normalisation across every axis (dedup / lowercase / whitespace / runtime-alias canonicalisation / non-string-token coercion / unknown bucketing)
  - unknown item collapses the row's fold to `False` (typo-catches-at-callsite)
  - empty / all-unknown / `None` / non-iterable bundles surface as a stable row with `has_<axis>=False`
  - never-raise on `None` / non-iterable / bad bundle entries
  - grace pass-through: paid feature (`fleet`) row reads `True` in grace via `has_features` resolver pass-through
  - `openclaw` (FREE_RUNTIMES) row reads `True` on the LIVE install regardless of rollout state
  - per-row parity with the singular scalar on the KNOWN slice (`has_features_bundle_batch([b])[0]['has_features']` byte-equals `has_features(b)` when the bundle is all known)
  - API happy path: 6-key envelope, 5-key row, `count`, `kind`
  - API single-bundle shorthand (`{"bundles": ["fleet", "sso"]}` — matches singular endpoint's bare-CSV posture)
  - API unknown token bucketed into `unknown[]` and collapses `has_<axis>` to `False`
  - API error paths: 400 on missing / non-list / empty `bundles`; 400 on no body
  - API row byte-parity with the singular scalar on the same known bundle
  - API cross-endpoint axis-echo parity vs `/min-tier-for-features-batch` / `/min-tier-for-runtimes-batch` on `axis` / `unknown` / `kind` / `count`
  - API never-5xxs on delegate crash (monkey-patched helper raises) — falls back to empty envelope with envelope shape preserved
  - grace vs enforce fold divergence on a paid feature (`fleet` → `True` in grace, `False` after enforcement — matches `has_features` grace posture)

- [x] `python3 -m pytest tests/test_entitlement_min_tier_for_bundle_batch.py tests/test_entitlement_has_all.py tests/test_entitlement_has_all_at.py tests/test_entitlement_has_all_at_batch.py tests/test_entitlement_has_features_at_has_runtimes_at.py tests/test_entitlement_api.py` — **386/386 pass** (sibling regression: no envelope drift on the paired boolean-fold `/has-features` / `/has-runtimes` / `/has-all` / `/has-all-at` / `/has-all-at-batch`, no shape drift on `/min-tier-for-features-batch` / `/min-tier-for-runtimes-batch`, no shape drift on `/api/entitlement`).

## Local operator verification checklist

Since this fire runs in an ephemeral cloud container with no access to your local daemon, `~/.openclaw`, the live cloud snapshot, or a browser, please verify against the running host once you pull this branch:

- [ ] Copy the three changed files into your live install:
  ```
  cp clawmetry/entitlements.py ~/.clawmetry/lib/python3.*/site-packages/clawmetry/
  cp routes/entitlement.py     ~/.clawmetry/lib/python3.*/site-packages/routes/
  find ~/.clawmetry/lib -name __pycache__ -type d -exec rm -rf {} +
  ```
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` to restart the daemon and pick up the new endpoints.
- [ ] Happy path (features):
  ```
  curl -s -X POST 'http://localhost:8900/api/entitlement/has-features-bundle-batch' \
       -H 'Content-Type: application/json' \
       -d '{"bundles":[["fleet","sso"],["otel_export"],[]]}' | jq .
  ```
  Expect a 6-key envelope with `count=3`, `bundles[0].has_features=true` (grace), `bundles[1].has_features=true` (grace), `bundles[2].has_features=false` (empty bundle), and `grace=true`.
- [ ] Happy path (runtimes) — alias canonicalisation:
  ```
  curl -s -X POST 'http://localhost:8900/api/entitlement/has-runtimes-bundle-batch' \
       -H 'Content-Type: application/json' \
       -d '{"bundles":[["claude-code","codex"],["openclaw"]]}' | jq .bundles
  ```
  Expect `bundles[0].runtimes=["claude_code","codex"]` (alias canonicalised), `bundles[1].runtimes=["openclaw"]`, `bundles[1].has_runtimes=true` (FREE_RUNTIMES is granted LIVE regardless of rollout state).
- [ ] Unknown token collapses fold:
  ```
  curl -s -X POST 'http://localhost:8900/api/entitlement/has-features-bundle-batch' \
       -H 'Content-Type: application/json' \
       -d '{"bundles":[["fleet","bogus"]]}' | jq '.bundles[0]'
  ```
  Expect `features=["fleet"]`, `unknown=["bogus"]`, `has_features=false` (unknown token catches the typo instead of silently granting).
- [ ] Single-bundle shorthand:
  ```
  curl -s -X POST 'http://localhost:8900/api/entitlement/has-features-bundle-batch' \
       -H 'Content-Type: application/json' \
       -d '{"bundles":["fleet","sso"]}' | jq '.count, .bundles[0].features'
  ```
  Expect `count=1`, `features=["fleet","sso"]` (bare list-of-strings treated as ONE bundle).
- [ ] Error paths:
  ```
  curl -sw '\n%{http_code}\n' -X POST 'http://localhost:8900/api/entitlement/has-features-bundle-batch' \
       -H 'Content-Type: application/json' -d '{}'
  # → 400  {"error":"missing bundles"}
  curl -sw '\n%{http_code}\n' -X POST 'http://localhost:8900/api/entitlement/has-features-bundle-batch' \
       -H 'Content-Type: application/json' -d '{"bundles":[]}'
  # → 400  {"error":"empty bundles"}
  curl -sw '\n%{http_code}\n' -X POST 'http://localhost:8900/api/entitlement/has-features-bundle-batch' \
       -H 'Content-Type: application/json' -d '{"bundles":42}'
  # → 400  {"error":"bundles must be a list"}
  ```
- [ ] Cross-endpoint parity — the axis / unknown / kind / count slice byte-equals the reverse-lookup sibling:
  ```
  diff <(curl -s -X POST 'http://localhost:8900/api/entitlement/has-features-bundle-batch' \
           -H 'Content-Type: application/json' \
           -d '{"bundles":[["FLEET","fleet","sso"],["bogus","otel_export"],[]]}' \
        | jq '[.bundles[] | {features,unknown,kind,count}]') \
       <(curl -s -X POST 'http://localhost:8900/api/entitlement/min-tier-for-features-batch' \
           -H 'Content-Type: application/json' \
           -d '{"bundles":[["FLEET","fleet","sso"],["bogus","otel_export"],[]]}' \
        | jq '[.bundles[] | {features,unknown,kind,count}]')
  ```
  Expect no diff.
- [ ] `curl -s 'http://localhost:8900/api/entitlement' | jq .grace` — expect **true** (nothing about the resolver / gate changed — this PR is purely additive query surface).
- [ ] Decrypt the live cloud snapshot in the browser and confirm the dashboard's entitlement panels still render (no shape regression).

This PR stays **DRAFT** until you've done the local + cloud verification above. Version bump / `[RELEASE]` PR / merge is your call.

---
_Generated by [Claude Code](https://claude.ai/code/session_019zestj3haxdsfmLeks7MJT)_