### PR TITLE
feat(entitlement): missing_features_bundle_batch + missing_runtimes_bundle_batch + endpoints

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -11115,6 +11115,263 @@ def min_tier_for_runtimes_batch(bundles) -> list[dict]:
     return out
 
 
+def _missing_features_bundle_row(bundle) -> dict:
+    """Per-bundle row shape for :func:`missing_features_bundle_batch`.
+
+    Normalises one feature bundle exactly the way
+    :func:`_min_tier_for_features_bundle_row` does (whitespace stripped,
+    lowercased, deduplicated preserving first-seen order; unknown ids
+    bucketed into ``unknown`` instead of leaking into the ``missing``
+    walk), then folds the KNOWN slice through :func:`missing_features`
+    for the row-detail complement.
+
+    Row keys mirror :func:`_min_tier_for_features_bundle_row` on the
+    axis-echo slots (``features``, ``unknown``, ``kind``, ``count``) so
+    a UI that unions the two batches sees a consistent per-bundle
+    shape; the fold slot is ``missing`` instead of ``min_tier`` to
+    match the singular :func:`missing_features` return-slot name.
+
+    Grace posture mirrors :func:`missing_features` byte-for-byte:
+    while ``ent.grace`` is ``True`` (the current rollout state) every
+    fully-known bundle reports ``missing=[]``; post-enforcement each
+    row reflects the underlying :func:`has_feature` per-item answer.
+    Empty / all-unknown bundles surface as a stable row with
+    ``missing=[]`` (nothing known to check, nothing missing --
+    matches :func:`missing_features` empty-``[]`` posture).
+
+    Never raises: a per-bundle failure returns the empty row shape so
+    the batch keeps building.
+    """
+    known: list[str] = []
+    unknown: list[str] = []
+    seen: set[str] = set()
+    try:
+        raw_items = list(bundle) if bundle is not None else []
+    except TypeError:
+        raw_items = []
+    for token in raw_items:
+        try:
+            fid = str(token).strip().lower()
+        except Exception:
+            continue
+        if not fid or fid in seen:
+            continue
+        seen.add(fid)
+        if fid in ALL_FEATURES:
+            known.append(fid)
+        else:
+            unknown.append(fid)
+    try:
+        missing = list(missing_features(known)) if known else []
+    except Exception as exc:
+        logger.warning(
+            "entitlements: _missing_features_bundle_row fold failed: %s", exc
+        )
+        missing = []
+    return {
+        "features": known,
+        "unknown": unknown,
+        "kind": "features",
+        "count": len(known),
+        "missing": missing,
+    }
+
+
+def _missing_runtimes_bundle_row(bundle) -> dict:
+    """Runtime-axis twin of :func:`_missing_features_bundle_row`.
+
+    Applies :func:`canonical_runtime` before the :data:`ALL_RUNTIMES`
+    membership check so aliases (``claude-code`` -> ``claude_code``)
+    resolve the same way they do on the singular endpoint; duplicates
+    that collapse after canonicalisation only contribute one row.
+    Unknown runtime tokens are echoed into ``unknown`` using the raw
+    lowercased id (matches :func:`_min_tier_for_runtimes_bundle_row`
+    posture) and never leak into the ``missing`` walk.
+
+    Grace posture mirrors :func:`missing_runtimes` byte-for-byte;
+    :data:`FREE_RUNTIMES` (``openclaw``) reports ``missing=[]`` on the
+    LIVE install regardless of rollout state. Never raises.
+    """
+    known: list[str] = []
+    unknown: list[str] = []
+    seen: set[str] = set()
+    try:
+        raw_items = list(bundle) if bundle is not None else []
+    except TypeError:
+        raw_items = []
+    for token in raw_items:
+        try:
+            raw = str(token).strip().lower()
+        except Exception:
+            continue
+        if not raw:
+            continue
+        canon = canonical_runtime(raw)
+        if canon and canon in ALL_RUNTIMES:
+            if canon in seen:
+                continue
+            seen.add(canon)
+            known.append(canon)
+        else:
+            if raw in seen:
+                continue
+            seen.add(raw)
+            unknown.append(raw)
+    try:
+        missing = list(missing_runtimes(known)) if known else []
+    except Exception as exc:
+        logger.warning(
+            "entitlements: _missing_runtimes_bundle_row fold failed: %s", exc
+        )
+        missing = []
+    return {
+        "runtimes": known,
+        "unknown": unknown,
+        "kind": "runtimes",
+        "count": len(known),
+        "missing": missing,
+    }
+
+
+def missing_features_bundle_batch(bundles) -> list[dict]:
+    """Per-bundle row-detail complement grant for N caller-supplied
+    feature bundles in ONE round-trip.
+
+    Row-detail sibling of :func:`missing_features` (which folds ONE
+    bundle to ONE ``missing`` list) on the LIVE per-install slot, in
+    the same relationship :func:`min_tier_for_features_batch` has to
+    :func:`min_tier_for_features` on the reverse-lookup slot. Where
+    the singular scalar answers "which subset of THIS bundle isn't
+    granted on the CURRENT install?", this answers the same question
+    for N distinct bundles at once so a paywall diagnostics matrix or
+    upgrade-walkthrough surface comparing several hypothetical
+    feature sets ("starter add-ons vs pro add-ons vs enterprise
+    add-ons -- which items each is still missing on the LIVE grant?")
+    hydrates the whole column off ONE call instead of N calls to
+    :func:`missing_features`.
+
+    Row shape mirrors :func:`_min_tier_for_features_bundle_row` on the
+    axis-echo slots (byte-parity so a UI that unions the two batches
+    sees a consistent shape) with the fold slot renamed ``missing`` to
+    match :func:`missing_features` return-slot name::
+
+        {
+          "features": ["fleet", "sso"],
+          "unknown":  ["bogus"],
+          "kind":     "features",
+          "count":    2,
+          "missing":  [<subset not granted on LIVE>],
+        }
+
+    Per-bundle normalisation matches the singular endpoint: whitespace
+    stripped, lowercased, deduplicated preserving first-seen order;
+    unknown ids bucketed into the per-bundle ``unknown`` list instead
+    of leaking into the ``missing`` walk (a typo does NOT silently
+    render as "denied"; it surfaces via ``unknown[]``, matching
+    :func:`_min_tier_for_features_bundle_row` posture). Empty /
+    all-unknown bundles surface as a stable row with ``missing=[]``
+    (nothing known to check, nothing missing -- matches
+    :func:`missing_features` empty-``[]`` posture).
+
+    Grace posture per-row mirrors :func:`missing_features` byte-for-
+    byte: while ``ent.grace`` is ``True`` every fully-known bundle
+    reports ``missing=[]``; post-enforcement each row reflects the
+    underlying :meth:`Entitlement.allows_feature` answer per item.
+
+    Distinct from :func:`missing_features_at_batch` (which fixes ONE
+    bundle and sweeps N perspective tiers): this fixes N bundles and
+    reads the LIVE per-install grant.
+
+    Argument handling:
+
+    * ``bundles is None`` or non-iterable -- returns ``[]``.
+    * Each bundle may itself be ``None``, non-iterable, or empty --
+      the helper emits the empty row shape rather than raising.
+    * Non-string tokens inside a bundle are coerced via ``str(...)``
+      (matches :func:`_min_tier_for_features_bundle_row` silent-drop
+      posture for garbage).
+
+    Never raises: per-bundle failures short-circuit to the empty row
+    shape so the batch keeps building.
+    """
+    try:
+        if bundles is None:
+            return []
+        items = list(bundles)
+    except TypeError:
+        return []
+    out: list[dict] = []
+    for bundle in items:
+        try:
+            out.append(_missing_features_bundle_row(bundle))
+        except Exception as exc:
+            logger.warning(
+                "entitlements: missing_features_bundle_batch row failed: %s",
+                exc,
+            )
+            out.append(
+                {
+                    "features": [],
+                    "unknown": [],
+                    "kind": "features",
+                    "count": 0,
+                    "missing": [],
+                }
+            )
+    return out
+
+
+def missing_runtimes_bundle_batch(bundles) -> list[dict]:
+    """Runtime-axis twin of :func:`missing_features_bundle_batch`.
+
+    Same per-bundle grouping (each row folds one whole bundle rather
+    than one item), same never-5xx posture, same partial-unknown
+    bucketing. Runtime aliases (``claude-code`` -> ``claude_code``)
+    canonicalise per bundle through :func:`canonical_runtime` before
+    intersection with :data:`ALL_RUNTIMES`, matching the singular
+    ``/api/entitlement/missing-runtimes`` endpoint; unknown tokens are
+    echoed into the per-bundle ``unknown`` using the raw lowercased id
+    and drop from the ``missing`` walk (a typo does NOT silently
+    render as "denied").
+
+    :data:`FREE_RUNTIMES` (``openclaw``) reports ``missing=[]`` on
+    every row on the LIVE install regardless of rollout state (the
+    LIVE resolver always grants free runtimes).
+
+    Row shape mirrors :func:`_min_tier_for_runtimes_bundle_row` on the
+    axis-echo slots, with ``kind="runtimes"`` and a ``runtimes`` list
+    in place of ``features``; the fold slot is ``missing`` (byte-
+    parity with :func:`missing_features_bundle_batch`).
+
+    Never raises.
+    """
+    try:
+        if bundles is None:
+            return []
+        items = list(bundles)
+    except TypeError:
+        return []
+    out: list[dict] = []
+    for bundle in items:
+        try:
+            out.append(_missing_runtimes_bundle_row(bundle))
+        except Exception as exc:
+            logger.warning(
+                "entitlements: missing_runtimes_bundle_batch row failed: %s",
+                exc,
+            )
+            out.append(
+                {
+                    "runtimes": [],
+                    "unknown": [],
+                    "kind": "runtimes",
+                    "count": 0,
+                    "missing": [],
+                }
+            )
+    return out
+
+
 def min_tier_for_features_at_batch(
     perspective_tier: str, bundles
 ) -> list[dict] | None:

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -38438,6 +38438,231 @@ def api_entitlement_min_tier_for_runtimes_batch():
         )
 
 
+def _missing_bundle_row_body(row: dict, list_key: str) -> dict:
+    """Row-body helper for the ``/missing-<axis>-bundle-batch`` endpoints.
+
+    Row-detail sibling of :func:`_min_tier_for_bundle_row_to_body` on
+    the boolean-fold slot's complement seat. Row schema mirrors the
+    reverse-lookup helper on the axis-echo slots (``features`` /
+    ``runtimes`` / ``unknown`` / ``kind`` / ``count``) with the
+    ``min_tier*`` triple / ``free`` slots swapped for a single
+    ``missing`` list matching the singular
+    ``/api/entitlement/missing-features`` /
+    ``/api/entitlement/missing-runtimes`` body's ``missing`` slot.
+
+    Never raises: missing / non-list slots surface as the empty-row
+    shape.
+    """
+    return {
+        list_key: list(row.get(list_key) or []),
+        "unknown": list(row.get("unknown") or []),
+        "kind": row.get("kind"),
+        "count": int(row.get("count") or 0),
+        "missing": list(row.get("missing") or []),
+    }
+
+
+@bp_entitlement.route(
+    "/api/entitlement/missing-features-bundle-batch",
+    methods=["POST"],
+)
+def api_entitlement_missing_features_bundle_batch():
+    """``POST /api/entitlement/missing-features-bundle-batch`` -- row-
+    detail complement of ``/api/entitlement/has-features-bundle-batch``
+    on the LIVE per-install slot.
+
+    Where the singular ``/api/entitlement/missing-features`` folds ONE
+    bundle to ONE per-item denial list, this folds N caller-supplied
+    feature bundles to N per-bundle ``missing`` rows in ONE round-trip
+    so a paywall diagnostics matrix or upgrade-walkthrough surface
+    comparing several hypothetical feature sets ("starter add-ons vs
+    pro add-ons vs enterprise add-ons -- which items each is still
+    missing on the LIVE grant?") hydrates the whole column off ONE
+    call instead of N calls to ``/missing-features``.
+
+    Distinct from ``/missing-features-at-batch`` (which fixes ONE
+    bundle and sweeps N perspective tiers): this fixes N bundles and
+    reads the LIVE per-install grant. Row-detail sibling of the
+    reverse-lookup ``/min-tier-for-features-batch`` on the boolean-
+    fold slot's complement seat -- the two responses pair on the same
+    ``features`` / ``unknown`` / ``kind`` / ``count`` axes so a UI
+    can render "denied right now? / cheapest tier that grants it?"
+    side by side per bundle off two calls.
+
+    POST rather than GET because the caller-supplied set of bundles
+    can grow past a comfortable query-string length; the sibling
+    singular ``/missing-features`` endpoint uses GET+CSV where the
+    bundle is small.
+
+    Request body::
+
+        {
+          "bundles": [
+            ["fleet", "sso"],
+            ["otel_export"],
+            []
+          ]
+        }
+
+    A shorthand ``{"bundles": ["fleet", "sso"]}`` (bare list of
+    strings) is treated as ONE bundle, matching the singular
+    endpoint's bare-CSV posture; a missing / non-list ``bundles``
+    value is a 400. An empty ``bundles=[]`` is a 400 for the same
+    reason ``/min-tier-for-features-batch`` 400s on empty input --
+    distinguishes "caller asked for nothing" from "caller asked and
+    every bundle was empty".
+
+    Response shape::
+
+        {
+          "bundles": [<row>, ...],
+          "count":   <int>,        # len(bundles)
+          "current_tier":      "...",
+          "current_tier_rank": <int>,
+          "grace":             <bool>,
+          "enforced":          <bool>,
+        }
+
+    Each ``<row>`` is byte-identical to
+    :func:`_min_tier_for_bundle_row_to_body` on the axis-echo slots
+    with the ``min_tier*`` / ``free`` slots swapped for a ``missing``
+    list matching the singular endpoint's ``missing`` slot::
+
+        {
+          "features": ["fleet", "sso"],
+          "unknown":  ["bogus"],
+          "kind":     "features",
+          "count":    2,
+          "missing":  [<subset not granted on LIVE>],
+        }
+
+    Per-bundle normalisation matches the singular endpoint: whitespace
+    stripped, lowercased, deduplicated preserving first-seen order;
+    unknown ids bucketed into the per-bundle ``unknown`` list instead
+    of leaking into ``missing`` (a typo surfaces via ``unknown[]``
+    rather than silently rendering "denied"). Empty / all-unknown
+    bundles surface as a stable row with ``missing=[]`` (matches
+    :func:`missing_features` empty-``[]`` posture).
+
+    Grace posture per-row mirrors ``/missing-features`` byte-for-byte:
+    while ``grace`` is ``True`` (the current rollout state) every
+    fully-known bundle reports ``missing=[]``; post-enforcement each
+    row reflects the underlying :meth:`Entitlement.allows_feature`
+    answer per item.
+
+    - **400** when ``bundles`` is missing / non-list / empty
+    - **Never 5xxs**: a resolver / delegate failure yields the fallback
+      envelope (empty ``bundles`` list) so the paywall matrix keeps
+      rendering.
+    """
+    body = request.get_json(silent=True) or {}
+    bundles, err = _parse_bundles_body(body)
+    if err == "missing":
+        return jsonify({"error": "missing bundles"}), 400
+    if err == "empty":
+        return jsonify({"error": "empty bundles"}), 400
+    if err == "bundles_must_be_list":
+        return jsonify({"error": "bundles must be a list"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        rows = _ent.missing_features_bundle_batch(bundles)
+        out_rows = [_missing_bundle_row_body(row, "features") for row in rows]
+        env = _resolver_envelope(_ent)
+        return jsonify(
+            {
+                "bundles": out_rows,
+                "count": len(out_rows),
+                **env,
+            }
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_missing_features_bundle_batch: error: %s", exc
+        )
+        return jsonify(
+            {
+                "bundles": [],
+                "count": 0,
+                "current_tier": "oss",
+                "current_tier_rank": 0,
+                "grace": True,
+                "enforced": False,
+            }
+        )
+
+
+@bp_entitlement.route(
+    "/api/entitlement/missing-runtimes-bundle-batch",
+    methods=["POST"],
+)
+def api_entitlement_missing_runtimes_bundle_batch():
+    """``POST /api/entitlement/missing-runtimes-bundle-batch`` -- runtime-
+    axis twin of ``/api/entitlement/missing-features-bundle-batch``.
+
+    Same never-5xx posture, same partial-unknown bucketing, same POST
+    envelope. Runtime aliases (``claude-code`` -> ``claude_code``) are
+    canonicalised per bundle through
+    :func:`clawmetry.entitlements.canonical_runtime` so a caller does
+    not need to normalise before calling; unknown ids land in the
+    per-bundle ``unknown`` and drop from the ``missing`` walk (a typo
+    does NOT silently render as "denied").
+
+    :data:`clawmetry.entitlements.FREE_RUNTIMES` (``openclaw``)
+    reports ``missing=[]`` on every row on the LIVE install
+    regardless of rollout state.
+
+    Request body::
+
+        {
+          "bundles": [
+            ["claude_code", "codex"],
+            ["openclaw"],
+            []
+          ]
+        }
+
+    Response shape and error paths mirror
+    ``/missing-features-bundle-batch`` exactly, with ``kind="runtimes"``
+    and a ``runtimes`` list in place of ``features`` per row.
+    """
+    body = request.get_json(silent=True) or {}
+    bundles, err = _parse_bundles_body(body)
+    if err == "missing":
+        return jsonify({"error": "missing bundles"}), 400
+    if err == "empty":
+        return jsonify({"error": "empty bundles"}), 400
+    if err == "bundles_must_be_list":
+        return jsonify({"error": "bundles must be a list"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        rows = _ent.missing_runtimes_bundle_batch(bundles)
+        out_rows = [_missing_bundle_row_body(row, "runtimes") for row in rows]
+        env = _resolver_envelope(_ent)
+        return jsonify(
+            {
+                "bundles": out_rows,
+                "count": len(out_rows),
+                **env,
+            }
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_missing_runtimes_bundle_batch: error: %s", exc
+        )
+        return jsonify(
+            {
+                "bundles": [],
+                "count": 0,
+                "current_tier": "oss",
+                "current_tier_rank": 0,
+                "grace": True,
+                "enforced": False,
+            }
+        )
+
+
 def _parse_aggregate_bundles_body(body, key: str = "bundles"):
     """Extract a list of aggregate 5-axis bundle dicts from a JSON POST body.
 

--- a/tests/test_entitlement_missing_bundle_batch.py
+++ b/tests/test_entitlement_missing_bundle_batch.py
@@ -1,0 +1,665 @@
+"""Tests for the bundle-batch ``/api/entitlement/missing-features-bundle-batch``
+and ``/api/entitlement/missing-runtimes-bundle-batch`` endpoints (plus
+their :func:`clawmetry.entitlements.missing_features_bundle_batch` /
+:func:`clawmetry.entitlements.missing_runtimes_bundle_batch` helpers).
+
+Row-detail complement of the sibling boolean-fold
+``/has-features-bundle-batch`` / ``/has-runtimes-bundle-batch`` on the
+LIVE per-install slot: where the boolean-fold answers "does the CURRENT
+install grant this whole bundle?" for N caller-supplied bundles, this
+answers "which subset of THIS bundle isn't granted?" for the same N
+bundles in ONE round-trip. Reverse-lookup sibling of
+``/min-tier-for-features-batch`` / ``/min-tier-for-runtimes-batch`` on
+the axis-echo slots (``features`` / ``runtimes`` / ``unknown`` /
+``kind`` / ``count``) so a UI can render "cheapest tier that grants it?
+/ denied right now?" side by side per bundle off two calls.
+
+These tests pin:
+
+* helper: per-bundle normalisation (whitespace, lowercase, dedup
+  preserving first-seen order), unknown-id bucketing, runtime alias
+  canonicalisation, empty / all-unknown bundles surface as a stable row
+* helper: grace pass-through (paid feature in grace -> ``missing=[]``)
+* helper: post-enforce paid feature surfaces in ``missing``
+* helper: :data:`FREE_RUNTIMES` (``openclaw``) reports ``missing=[]``
+  on the LIVE install regardless of rollout state
+* helper: per-row parity with the singular
+  :func:`missing_features` / :func:`missing_runtimes` on the known slice
+* helper: never-crash on ``None`` / non-iterable / non-list bundle input
+* API happy path: 6-key envelope, 5-key row, ``count``, ``kind``
+* API single-bundle shorthand (bare-CSV posture)
+* API error paths: 400 on missing / non-list / empty ``bundles``
+* API cross-endpoint axis-echo parity with
+  ``/min-tier-for-features-batch`` / ``/min-tier-for-runtimes-batch``
+* API row-shape byte-parity with the singular
+  ``/missing-features`` / ``/missing-runtimes`` ``missing`` slot on
+  the same known bundle
+* API never-5xxs on a monkey-patched delegate crash
+* grace vs enforce fold divergence on a paid bundle
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+# ── Fixtures ─────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def enforced(monkeypatch, tmp_path):
+    """Enforcement-on fixture: ``CLAWMETRY_ENFORCE=1`` flips
+    ``ent.grace`` off so the grace pass-through collapses and paid
+    axes report their post-enforce denial in ``missing``."""
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    importlib.reload(e)
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+@pytest.fixture
+def enforced_client(enforced):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# ── Row / envelope shape constants ───────────────────────────────────────
+
+
+_FEATURES_ROW_KEYS = {"features", "unknown", "kind", "count", "missing"}
+_RUNTIMES_ROW_KEYS = {"runtimes", "unknown", "kind", "count", "missing"}
+_ENVELOPE_KEYS = {
+    "bundles",
+    "count",
+    "current_tier",
+    "current_tier_rank",
+    "grace",
+    "enforced",
+}
+
+
+# ── helper: bundle normalisation ─────────────────────────────────────────
+
+
+def test_helper_features_dedups_and_lowers(ent):
+    rows = ent.missing_features_bundle_batch(
+        [["fleet", "", "SSO", "fleet"], ["otel_export"]]
+    )
+    assert len(rows) == 2
+    assert rows[0]["features"] == ["fleet", "sso"]
+    assert rows[0]["unknown"] == []
+    assert rows[0]["count"] == 2
+    assert rows[0]["kind"] == "features"
+    assert rows[1]["features"] == ["otel_export"]
+
+
+def test_helper_features_buckets_unknown(ent):
+    rows = ent.missing_features_bundle_batch([["fleet", "bogus", "Bogus"]])
+    r = rows[0]
+    assert r["features"] == ["fleet"]
+    assert r["unknown"] == ["bogus"]
+    assert r["count"] == 1
+
+
+def test_helper_features_strips_whitespace(ent):
+    rows = ent.missing_features_bundle_batch([["  fleet  ", "\tsso\n"]])
+    assert rows[0]["features"] == ["fleet", "sso"]
+
+
+def test_helper_features_empty_bundle_stable_row(ent):
+    rows = ent.missing_features_bundle_batch([[]])
+    r = rows[0]
+    assert r["features"] == []
+    assert r["unknown"] == []
+    assert r["count"] == 0
+    assert r["missing"] == []
+    assert r["kind"] == "features"
+
+
+def test_helper_features_all_unknown_stable_row(ent):
+    rows = ent.missing_features_bundle_batch([["bogus1", "bogus2"]])
+    r = rows[0]
+    assert r["features"] == []
+    assert r["unknown"] == ["bogus1", "bogus2"]
+    assert r["missing"] == []
+
+
+def test_helper_features_none_returns_empty(ent):
+    assert ent.missing_features_bundle_batch(None) == []
+
+
+def test_helper_features_non_iterable_returns_empty(ent):
+    assert ent.missing_features_bundle_batch(42) == []
+
+
+def test_helper_features_none_bundle_row_stable(ent):
+    rows = ent.missing_features_bundle_batch([None, ["fleet"]])
+    assert rows[0] == {
+        "features": [],
+        "unknown": [],
+        "kind": "features",
+        "count": 0,
+        "missing": [],
+    }
+    assert rows[1]["features"] == ["fleet"]
+
+
+def test_helper_features_non_iterable_row_stable(ent):
+    rows = ent.missing_features_bundle_batch([42, ["fleet"]])
+    assert rows[0]["features"] == []
+    assert rows[0]["missing"] == []
+    assert rows[1]["features"] == ["fleet"]
+
+
+def test_helper_runtimes_canonicalises_aliases(ent):
+    rows = ent.missing_runtimes_bundle_batch(
+        [["claude-code", "codex", "claude_code"]]
+    )
+    r = rows[0]
+    assert r["runtimes"] == ["claude_code", "codex"]
+    assert r["unknown"] == []
+    assert r["kind"] == "runtimes"
+
+
+def test_helper_runtimes_buckets_unknown(ent):
+    rows = ent.missing_runtimes_bundle_batch([["claude_code", "bogus_rt"]])
+    assert rows[0]["runtimes"] == ["claude_code"]
+    assert rows[0]["unknown"] == ["bogus_rt"]
+
+
+def test_helper_runtimes_free_runtime_missing_empty_in_grace(ent):
+    """openclaw is FREE_RUNTIMES; missing is empty regardless of rollout."""
+    rows = ent.missing_runtimes_bundle_batch([["openclaw"]])
+    assert rows[0]["runtimes"] == ["openclaw"]
+    assert rows[0]["missing"] == []
+
+
+def test_helper_runtimes_free_runtime_missing_empty_after_enforce(enforced):
+    rows = enforced.missing_runtimes_bundle_batch([["openclaw"]])
+    assert rows[0]["missing"] == []
+
+
+# ── helper: grace pass-through vs post-enforce fold ──────────────────────
+
+
+def test_helper_features_grace_pass_through(ent):
+    """Paid feature (fleet) is granted in grace; missing=[]."""
+    rows = ent.missing_features_bundle_batch([["fleet", "sso"]])
+    assert rows[0]["features"] == ["fleet", "sso"]
+    assert rows[0]["missing"] == []
+
+
+def test_helper_features_enforce_reports_paid_missing(enforced):
+    rows = enforced.missing_features_bundle_batch([["fleet", "sso"]])
+    assert rows[0]["features"] == ["fleet", "sso"]
+    assert set(rows[0]["missing"]) == {"fleet", "sso"}
+
+
+def test_helper_runtimes_grace_pass_through(ent):
+    """Paid runtime (claude_code) is granted in grace; missing=[]."""
+    rows = ent.missing_runtimes_bundle_batch([["claude_code", "codex"]])
+    assert rows[0]["runtimes"] == ["claude_code", "codex"]
+    assert rows[0]["missing"] == []
+
+
+def test_helper_runtimes_enforce_reports_paid_missing(enforced):
+    rows = enforced.missing_runtimes_bundle_batch([["claude_code", "codex"]])
+    assert set(rows[0]["missing"]) == {"claude_code", "codex"}
+
+
+def test_helper_features_multiple_bundles_grace(ent):
+    rows = ent.missing_features_bundle_batch(
+        [["fleet"], ["sso", "otel_export"], []]
+    )
+    assert len(rows) == 3
+    assert rows[0]["missing"] == []
+    assert rows[1]["missing"] == []
+    assert rows[2]["missing"] == []
+
+
+def test_helper_features_multiple_bundles_enforce(enforced):
+    rows = enforced.missing_features_bundle_batch(
+        [["fleet"], ["sso", "otel_export"], []]
+    )
+    assert set(rows[0]["missing"]) == {"fleet"}
+    assert set(rows[1]["missing"]) == {"sso", "otel_export"}
+    assert rows[2]["missing"] == []
+
+
+# ── helper: per-row parity with the singular scalar ──────────────────────
+
+
+@pytest.mark.parametrize(
+    "bundle",
+    [
+        ["fleet", "sso"],
+        ["otel_export"],
+        ["fleet"],
+        ["sso"],
+        [],
+    ],
+)
+def test_helper_features_per_row_parity_with_singular_grace(ent, bundle):
+    """Per-bundle ``missing`` byte-equals the singular helper on the
+    known slice."""
+    row = ent.missing_features_bundle_batch([bundle])[0]
+    known = [f for f in row["features"]]
+    singular = list(ent.missing_features(known)) if known else []
+    assert row["missing"] == singular
+
+
+@pytest.mark.parametrize(
+    "bundle",
+    [
+        ["fleet", "sso"],
+        ["otel_export"],
+        ["fleet"],
+    ],
+)
+def test_helper_features_per_row_parity_with_singular_enforce(
+    enforced, bundle
+):
+    row = enforced.missing_features_bundle_batch([bundle])[0]
+    known = [f for f in row["features"]]
+    singular = list(enforced.missing_features(known)) if known else []
+    assert row["missing"] == singular
+
+
+@pytest.mark.parametrize(
+    "bundle",
+    [
+        ["claude-code", "codex"],
+        ["openclaw"],
+        ["claude_code"],
+        [],
+    ],
+)
+def test_helper_runtimes_per_row_parity_with_singular_grace(ent, bundle):
+    row = ent.missing_runtimes_bundle_batch([bundle])[0]
+    known = [rt for rt in row["runtimes"]]
+    singular = list(ent.missing_runtimes(known)) if known else []
+    assert row["missing"] == singular
+
+
+@pytest.mark.parametrize(
+    "bundle",
+    [
+        ["claude-code", "codex"],
+        ["openclaw"],
+        ["claude_code"],
+    ],
+)
+def test_helper_runtimes_per_row_parity_with_singular_enforce(
+    enforced, bundle
+):
+    row = enforced.missing_runtimes_bundle_batch([bundle])[0]
+    known = [rt for rt in row["runtimes"]]
+    singular = list(enforced.missing_runtimes(known)) if known else []
+    assert row["missing"] == singular
+
+
+# ── helper: never-raise contract ─────────────────────────────────────────
+
+
+def test_helper_features_never_raises_on_bad_bundle(ent):
+    # Non-string tokens are coerced via str(); mixed garbage should not crash.
+    rows = ent.missing_features_bundle_batch(
+        [[None, 42, object()], ["fleet"]]
+    )
+    assert len(rows) == 2
+
+
+def test_helper_runtimes_never_raises_on_bad_bundle(ent):
+    rows = ent.missing_runtimes_bundle_batch(
+        [[None, 42, object()], ["claude_code"]]
+    )
+    assert len(rows) == 2
+
+
+# ── API: happy path ──────────────────────────────────────────────────────
+
+
+def test_api_features_happy(client, ent):
+    r = client.post(
+        "/api/entitlement/missing-features-bundle-batch",
+        json={"bundles": [["fleet", "sso"], ["otel_export"], []]},
+    )
+    assert r.status_code == 200
+    j = r.get_json()
+    assert set(j.keys()) == _ENVELOPE_KEYS
+    assert j["count"] == 3
+    assert len(j["bundles"]) == 3
+    for row in j["bundles"]:
+        assert set(row.keys()) == _FEATURES_ROW_KEYS
+        assert row["kind"] == "features"
+    assert j["bundles"][0]["features"] == ["fleet", "sso"]
+    # grace pass-through
+    assert j["bundles"][0]["missing"] == []
+    assert j["bundles"][2]["features"] == []
+    assert j["bundles"][2]["missing"] == []
+
+
+def test_api_runtimes_happy(client, ent):
+    r = client.post(
+        "/api/entitlement/missing-runtimes-bundle-batch",
+        json={"bundles": [["claude-code", "codex"], ["openclaw"]]},
+    )
+    assert r.status_code == 200
+    j = r.get_json()
+    assert set(j.keys()) == _ENVELOPE_KEYS
+    assert j["count"] == 2
+    for row in j["bundles"]:
+        assert set(row.keys()) == _RUNTIMES_ROW_KEYS
+        assert row["kind"] == "runtimes"
+    assert j["bundles"][0]["runtimes"] == ["claude_code", "codex"]
+    assert j["bundles"][1]["runtimes"] == ["openclaw"]
+    # FREE_RUNTIMES: missing is empty regardless
+    assert j["bundles"][1]["missing"] == []
+
+
+def test_api_features_single_bundle_shorthand(client, ent):
+    """Bare list of strings is treated as ONE bundle (matches the
+    singular endpoint's bare-CSV posture)."""
+    r = client.post(
+        "/api/entitlement/missing-features-bundle-batch",
+        json={"bundles": ["fleet", "sso"]},
+    )
+    assert r.status_code == 200
+    j = r.get_json()
+    assert j["count"] == 1
+    assert j["bundles"][0]["features"] == ["fleet", "sso"]
+
+
+def test_api_features_unknown_bucketed(client, ent):
+    r = client.post(
+        "/api/entitlement/missing-features-bundle-batch",
+        json={"bundles": [["fleet", "bogus"]]},
+    )
+    assert r.status_code == 200
+    row = r.get_json()["bundles"][0]
+    assert row["features"] == ["fleet"]
+    assert row["unknown"] == ["bogus"]
+    # unknown does NOT leak into missing; grace pass-through keeps it empty
+    assert row["missing"] == []
+
+
+def test_api_runtimes_alias_canonicalised(client, ent):
+    r = client.post(
+        "/api/entitlement/missing-runtimes-bundle-batch",
+        json={"bundles": [["claude-code", "claude_code"]]},
+    )
+    row = r.get_json()["bundles"][0]
+    assert row["runtimes"] == ["claude_code"]
+    assert row["unknown"] == []
+
+
+# ── API: error paths ─────────────────────────────────────────────────────
+
+
+def test_api_features_missing_bundles_400(client):
+    r = client.post(
+        "/api/entitlement/missing-features-bundle-batch", json={}
+    )
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "missing bundles"
+
+
+def test_api_features_empty_bundles_400(client):
+    r = client.post(
+        "/api/entitlement/missing-features-bundle-batch",
+        json={"bundles": []},
+    )
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "empty bundles"
+
+
+def test_api_features_non_list_bundles_400(client):
+    r = client.post(
+        "/api/entitlement/missing-features-bundle-batch",
+        json={"bundles": 42},
+    )
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "bundles must be a list"
+
+
+def test_api_features_no_body_400(client):
+    r = client.post("/api/entitlement/missing-features-bundle-batch")
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "missing bundles"
+
+
+def test_api_runtimes_missing_bundles_400(client):
+    r = client.post(
+        "/api/entitlement/missing-runtimes-bundle-batch", json={}
+    )
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "missing bundles"
+
+
+def test_api_runtimes_empty_bundles_400(client):
+    r = client.post(
+        "/api/entitlement/missing-runtimes-bundle-batch",
+        json={"bundles": []},
+    )
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "empty bundles"
+
+
+def test_api_runtimes_non_list_bundles_400(client):
+    r = client.post(
+        "/api/entitlement/missing-runtimes-bundle-batch",
+        json={"bundles": {"not": "a list"}},
+    )
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "bundles must be a list"
+
+
+# ── API: cross-endpoint axis-echo parity ─────────────────────────────────
+
+
+def test_api_features_axis_echo_parity_with_min_tier_batch(client):
+    """features / unknown / kind / count byte-equal
+    /min-tier-for-features-batch on the same body."""
+    body = {
+        "bundles": [
+            ["FLEET", "fleet", "sso"],
+            ["bogus", "otel_export"],
+            [],
+        ]
+    }
+    missing_bat = client.post(
+        "/api/entitlement/missing-features-bundle-batch", json=body
+    ).get_json()
+    tier_bat = client.post(
+        "/api/entitlement/min-tier-for-features-batch", json=body
+    ).get_json()
+    axes = ("features", "unknown", "kind", "count")
+    for m, t in zip(missing_bat["bundles"], tier_bat["bundles"]):
+        for k in axes:
+            assert m[k] == t[k]
+
+
+def test_api_runtimes_axis_echo_parity_with_min_tier_batch(client):
+    body = {
+        "bundles": [
+            ["claude-code", "codex"],
+            ["openclaw"],
+            ["bogus_rt"],
+        ]
+    }
+    missing_bat = client.post(
+        "/api/entitlement/missing-runtimes-bundle-batch", json=body
+    ).get_json()
+    tier_bat = client.post(
+        "/api/entitlement/min-tier-for-runtimes-batch", json=body
+    ).get_json()
+    axes = ("runtimes", "unknown", "kind", "count")
+    for m, t in zip(missing_bat["bundles"], tier_bat["bundles"]):
+        for k in axes:
+            assert m[k] == t[k]
+
+
+# ── API: row-shape parity with the singular missing endpoints ────────────
+
+
+def test_api_features_row_missing_matches_singular_endpoint(client):
+    """Per-bundle ``missing`` byte-equals the singular endpoint's
+    ``missing`` slot for the same known bundle."""
+    bundle = ["fleet", "sso"]
+    batch = client.post(
+        "/api/entitlement/missing-features-bundle-batch",
+        json={"bundles": [bundle]},
+    ).get_json()
+    singular = client.get(
+        "/api/entitlement/missing-features?features=" + ",".join(bundle)
+    ).get_json()
+    assert batch["bundles"][0]["missing"] == singular["missing"]
+
+
+def test_api_runtimes_row_missing_matches_singular_endpoint(client):
+    bundle = ["claude_code", "codex"]
+    batch = client.post(
+        "/api/entitlement/missing-runtimes-bundle-batch",
+        json={"bundles": [bundle]},
+    ).get_json()
+    singular = client.get(
+        "/api/entitlement/missing-runtimes?runtimes=" + ",".join(bundle)
+    ).get_json()
+    assert batch["bundles"][0]["missing"] == singular["missing"]
+
+
+# ── API: never-5xxs on delegate crash ────────────────────────────────────
+
+
+def test_api_features_never_5xxs_on_delegate_crash(
+    client, ent, monkeypatch
+):
+    def _boom(*_a, **_kw):
+        raise RuntimeError("delegate boom")
+
+    monkeypatch.setattr(ent, "missing_features_bundle_batch", _boom)
+    r = client.post(
+        "/api/entitlement/missing-features-bundle-batch",
+        json={"bundles": [["fleet"]]},
+    )
+    assert r.status_code == 200
+    j = r.get_json()
+    assert j["bundles"] == []
+    assert j["count"] == 0
+
+
+def test_api_runtimes_never_5xxs_on_delegate_crash(
+    client, ent, monkeypatch
+):
+    def _boom(*_a, **_kw):
+        raise RuntimeError("delegate boom")
+
+    monkeypatch.setattr(ent, "missing_runtimes_bundle_batch", _boom)
+    r = client.post(
+        "/api/entitlement/missing-runtimes-bundle-batch",
+        json={"bundles": [["claude_code"]]},
+    )
+    assert r.status_code == 200
+    j = r.get_json()
+    assert j["bundles"] == []
+
+
+# ── grace vs enforce fold divergence ─────────────────────────────────────
+
+
+def test_api_features_grace_fold_pass_through(client):
+    """Under grace the LIVE resolver pass-through keeps paid features
+    granted, so ``missing`` is empty."""
+    r = client.post(
+        "/api/entitlement/missing-features-bundle-batch",
+        json={"bundles": [["fleet"]]},
+    )
+    j = r.get_json()
+    assert j["bundles"][0]["features"] == ["fleet"]
+    assert j["bundles"][0]["missing"] == []
+
+
+def test_api_features_enforce_fold_denies_paid(enforced_client):
+    """Under enforce the LIVE resolver denies paid features, so
+    ``missing`` surfaces the whole bundle."""
+    r = enforced_client.post(
+        "/api/entitlement/missing-features-bundle-batch",
+        json={"bundles": [["fleet"]]},
+    )
+    j = r.get_json()
+    assert j["bundles"][0]["features"] == ["fleet"]
+    assert j["bundles"][0]["missing"] == ["fleet"]
+
+
+def test_api_runtimes_grace_fold_pass_through(client):
+    r = client.post(
+        "/api/entitlement/missing-runtimes-bundle-batch",
+        json={"bundles": [["claude_code"]]},
+    )
+    j = r.get_json()
+    assert j["bundles"][0]["runtimes"] == ["claude_code"]
+    assert j["bundles"][0]["missing"] == []
+
+
+def test_api_runtimes_enforce_fold_denies_paid(enforced_client):
+    r = enforced_client.post(
+        "/api/entitlement/missing-runtimes-bundle-batch",
+        json={"bundles": [["claude_code"]]},
+    )
+    j = r.get_json()
+    assert j["bundles"][0]["runtimes"] == ["claude_code"]
+    assert j["bundles"][0]["missing"] == ["claude_code"]
+
+
+# ── envelope resolver-slot stability ─────────────────────────────────────
+
+
+def test_api_features_envelope_grace_flags(client):
+    r = client.post(
+        "/api/entitlement/missing-features-bundle-batch",
+        json={"bundles": [["fleet"]]},
+    )
+    j = r.get_json()
+    assert j["grace"] is True
+    assert j["enforced"] is False
+
+
+def test_api_runtimes_envelope_grace_flags(client):
+    r = client.post(
+        "/api/entitlement/missing-runtimes-bundle-batch",
+        json={"bundles": [["claude_code"]]},
+    )
+    j = r.get_json()
+    assert j["grace"] is True
+    assert j["enforced"] is False


### PR DESCRIPTION
## Summary

Row-detail complement of `has_features_bundle_batch` / `has_runtimes_bundle_batch` (draft #4737, the LIVE per-install boolean-fold slot) for N caller-supplied bundles in ONE round-trip. Reverse-lookup sibling of `min_tier_for_features_batch` / `min_tier_for_runtimes_batch` on the axis-echo slots (`features` / `runtimes` / `unknown` / `kind` / `count`) with the fold slot swapped for a `missing` list matching the singular `missing_features` / `missing_runtimes` return-slot name. A paywall diagnostics matrix or upgrade-walkthrough surface comparing several hypothetical feature/runtime sets ("starter add-ons vs pro add-ons vs enterprise add-ons — which items each is still missing on the LIVE grant?") hydrates the whole column off ONE call instead of N calls to the singular scalars.

Distinct from `/missing-features-at-batch` / `/missing-runtimes-at-batch` (which fix ONE bundle and sweep N perspective tiers): this fixes N bundles and reads the LIVE per-install grant. Pairs with `/min-tier-for-features-batch` / `/min-tier-for-runtimes-batch` on the same `features` / `runtimes` / `unknown` / `kind` / `count` axes so a UI can render "cheapest tier that grants it? / denied right now?" side by side per bundle off two calls.

- **`missing_features_bundle_batch(bundles) -> list[dict]`** and **`missing_runtimes_bundle_batch(bundles) -> list[dict]`** in `clawmetry/entitlements.py`, plus per-bundle `_missing_features_bundle_row` / `_missing_runtimes_bundle_row` helpers. Row shape (5 keys) mirrors `_min_tier_for_features_bundle_row` on the axis-echo slots and swaps the tier slots for a `missing` list:

  ```
  {
    "features"/"runtimes": ["fleet", "sso"],
    "unknown":             ["bogus"],
    "kind":                "features"/"runtimes",
    "count":               2,
    "missing":             [<subset not granted on LIVE>],
  }
  ```

- **Grace pass-through mirrors `missing_features` / `missing_runtimes` byte-for-byte**: while `ent.grace` is `True` (the current rollout state) every fully-known bundle reports `missing=[]`; post-enforcement each row reflects the underlying `Entitlement.allows_*` answer per item. FREE_RUNTIMES (`openclaw`) reports `missing=[]` on every row on the LIVE install regardless of rollout state.

- **Unknown token bucketing** matches `_min_tier_for_features_bundle_row`: unknown ids land in the per-bundle `unknown` list and never leak into the `missing` walk (a typo surfaces via `unknown[]` rather than silently rendering "denied"). Runtime aliases (`claude-code` → `claude_code`) canonicalise per bundle through `canonical_runtime`. Empty / all-unknown / `None` / non-iterable bundles surface as a stable row with `missing=[]`. Never raises: per-bundle failures short-circuit to the empty row shape.

- **`POST /api/entitlement/missing-features-bundle-batch`** and **`POST /api/entitlement/missing-runtimes-bundle-batch`** on `bp_entitlement`. Request body reuses the shared `_parse_bundles_body` parser (byte-identical to `/min-tier-for-features-batch`: single-list / bare-list shorthand, 400 on missing / non-list / empty `bundles`, never-5xxs on delegate crash). Response envelope is 6-key (`bundles`, `count`, `current_tier`, `current_tier_rank`, `grace`, `enforced`); per-row body is 5-key.

- **Shared `_missing_bundle_row_body(row, list_key)`** helper in `routes/entitlement.py` (row-detail sibling of `_min_tier_for_bundle_row_to_body`) renames the fold slot to `missing` matching the singular endpoints.

Behaviour ships in **GRACE** mode: the resolver still defaults to the OSS-free entitlement so no runtime gating changes. Purely additive to the entitlement query surface.

## Test plan

- [x] `python3 -m py_compile clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_missing_bundle_batch.py`
- [x] `python3 -m ruff check clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_missing_bundle_batch.py --select I,F,E9` — clean.
- [x] `python3 scripts/lint_daemon_allowlist.py` — passes (no `local_store_via_daemon` calls touched).
- [x] `python3 -m pytest tests/test_entitlement_missing_bundle_batch.py` — **60/60 pass**, covering:
  - per-bundle normalisation across every axis (dedup / lowercase / whitespace / runtime-alias canonicalisation / non-string-token coercion / unknown bucketing)
  - grace pass-through (paid `fleet` / `claude_code` row reports `missing=[]` in grace via `missing_features` / `missing_runtimes` resolver pass-through)
  - post-enforce paid feature / runtime surfaces in `missing`
  - FREE_RUNTIMES (`openclaw`) `missing=[]` regardless of rollout state (both grace + enforce)
  - unknown token bucketed into `unknown[]` and never leaks into `missing`
  - empty / all-unknown / `None` / non-iterable bundles surface as a stable row with `missing=[]`
  - never-raises on `None` / non-iterable / bad bundle entries
  - per-row parity with the singular scalar on the KNOWN slice under both grace and enforce (`missing_features_bundle_batch([b])[0]['missing']` byte-equals `missing_features(known(b))`)
  - API happy path: 6-key envelope, 5-key row, `count`, `kind`
  - API single-bundle shorthand (`{"bundles": ["fleet", "sso"]}`)
  - API unknown token bucketed into `unknown[]` and never leaks into `missing` (grace pass-through keeps it empty)
  - API runtime-alias canonicalisation (`claude-code` → `claude_code`)
  - API error paths: 400 on missing / non-list / empty `bundles`; 400 on no body
  - API cross-endpoint axis-echo parity with `/min-tier-for-features-batch` / `/min-tier-for-runtimes-batch`
  - API row `missing` byte-equals the singular `/missing-features` / `/missing-runtimes` endpoint's `missing` slot on the same known bundle
  - API never-5xxs on monkeypatched delegate crash (helper monkey-patched to raise) — falls back to empty envelope with envelope shape preserved
  - grace fold pass-through on the LIVE endpoint (paid `fleet` → `missing=[]` under grace)
  - enforce fold denies paid (paid `fleet` → `missing=["fleet"]` under CLAWMETRY_ENFORCE=1)
  - resolver-envelope-slot stability (`grace=true`, `enforced=false` in the current rollout state)

- [x] `python3 -m pytest tests/test_entitlement_min_tier_for_bundle_batch.py tests/test_entitlement_missing_features_runtimes.py tests/test_entitlement_missing_features_runtimes_at.py tests/test_entitlement_missing_features_runtimes_at_batch.py tests/test_entitlement_missing_features_runtimes_at_path.py tests/test_entitlement_has_all_bundle_batch.py tests/test_entitlement_api.py` — **461/461 pass** end-to-end (sibling regression: no envelope drift on the reverse-lookup `/min-tier-for-features-batch` / `/min-tier-for-runtimes-batch`, no shape drift on the row-detail singular `/missing-features` / `/missing-runtimes` / `_at` / `_at_batch` / `_at_path`, no shape drift on the aggregate `/has-all-bundle-batch`, no shape drift on `/api/entitlement`).

Note: the 9 collection errors under `tests/ -k entitlement` are pre-existing `duckdb` / `google.protobuf` module-import failures in the sandbox (unrelated files: `test_agent_cli.py`, `test_duckdb_relay_integration.py`, `test_e2e.py`, `test_event_id_unification_and_dedup.py`, `test_event_metrics_extraction.py`, `test_local_store_multi_agent.py`, `test_local_store_rename.py`, `test_obs_gap_openclaw_voice_lifecycle_3014.py`, `test_spans_otlp_edge_cases.py`); the entitlement suite itself is clean.

## Local operator verification checklist

Since this fire runs in an ephemeral cloud container with no access to your local daemon, `~/.openclaw`, the live cloud snapshot, or a browser, please verify against the running host once you pull this branch:

- [ ] Copy the three changed files into your live install:
  ```
  cp clawmetry/entitlements.py ~/.clawmetry/lib/python3.*/site-packages/clawmetry/
  cp routes/entitlement.py     ~/.clawmetry/lib/python3.*/site-packages/routes/
  find ~/.clawmetry/lib -name __pycache__ -type d -exec rm -rf {} +
  ```
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` to restart the daemon and pick up the new endpoints.
- [ ] Happy path (features):
  ```
  curl -s -X POST 'http://localhost:8900/api/entitlement/missing-features-bundle-batch' \
       -H 'Content-Type: application/json' \
       -d '{"bundles":[["fleet","sso"],["otel_export"],[]]}' | jq .
  ```
  Expect a 6-key envelope with `count=3`, every row's `missing=[]` (grace pass-through), `grace=true`.
- [ ] Happy path (runtimes) — alias canonicalisation + free-runtime pass-through:
  ```
  curl -s -X POST 'http://localhost:8900/api/entitlement/missing-runtimes-bundle-batch' \
       -H 'Content-Type: application/json' \
       -d '{"bundles":[["claude-code","codex"],["openclaw"]]}' | jq .bundles
  ```
  Expect `bundles[0].runtimes=["claude_code","codex"]` (alias canonicalised) with `missing=[]` (grace), and `bundles[1].runtimes=["openclaw"]` with `missing=[]` (FREE_RUNTIMES pass-through regardless of rollout state).
- [ ] Unknown token surfaces in `unknown[]` and never leaks into `missing`:
  ```
  curl -s -X POST 'http://localhost:8900/api/entitlement/missing-features-bundle-batch' \
       -H 'Content-Type: application/json' \
       -d '{"bundles":[["fleet","bogus"]]}' | jq '.bundles[0]'
  ```
  Expect `features=["fleet"]`, `unknown=["bogus"]`, `missing=[]` (grace pass-through keeps fleet granted; typo caught via `unknown[]`).
- [ ] Single-bundle shorthand:
  ```
  curl -s -X POST 'http://localhost:8900/api/entitlement/missing-features-bundle-batch' \
       -H 'Content-Type: application/json' \
       -d '{"bundles":["fleet","sso"]}' | jq '.count, .bundles[0].features'
  ```
  Expect `count=1`, `features=["fleet","sso"]` (bare list-of-strings treated as ONE bundle).
- [ ] Error paths:
  ```
  curl -sw '\n%{http_code}\n' -X POST 'http://localhost:8900/api/entitlement/missing-features-bundle-batch' \
       -H 'Content-Type: application/json' -d '{}'
  # → 400  {"error":"missing bundles"}
  curl -sw '\n%{http_code}\n' -X POST 'http://localhost:8900/api/entitlement/missing-features-bundle-batch' \
       -H 'Content-Type: application/json' -d '{"bundles":[]}'
  # → 400  {"error":"empty bundles"}
  curl -sw '\n%{http_code}\n' -X POST 'http://localhost:8900/api/entitlement/missing-features-bundle-batch' \
       -H 'Content-Type: application/json' -d '{"bundles":42}'
  # → 400  {"error":"bundles must be a list"}
  ```
- [ ] Cross-endpoint axis-echo parity — the `features` / `unknown` / `kind` / `count` slice byte-equals the reverse-lookup sibling:
  ```
  diff <(curl -s -X POST 'http://localhost:8900/api/entitlement/missing-features-bundle-batch' \
           -H 'Content-Type: application/json' \
           -d '{"bundles":[["FLEET","fleet","sso"],["bogus","otel_export"],[]]}' \
        | jq '[.bundles[] | {features,unknown,kind,count}]') \
       <(curl -s -X POST 'http://localhost:8900/api/entitlement/min-tier-for-features-batch' \
           -H 'Content-Type: application/json' \
           -d '{"bundles":[["FLEET","fleet","sso"],["bogus","otel_export"],[]]}' \
        | jq '[.bundles[] | {features,unknown,kind,count}]')
  ```
  Expect no diff.
- [ ] Row-shape parity with the singular endpoint — per-bundle `missing` byte-equals the singular `/missing-features` on the same known bundle:
  ```
  diff <(curl -s -X POST 'http://localhost:8900/api/entitlement/missing-features-bundle-batch' \
           -H 'Content-Type: application/json' \
           -d '{"bundles":[["fleet","sso"]]}' | jq '.bundles[0].missing') \
       <(curl -s 'http://localhost:8900/api/entitlement/missing-features?features=fleet,sso' | jq '.missing')
  ```
  Expect no diff.
- [ ] `curl -s 'http://localhost:8900/api/entitlement' | jq .grace` — expect **true** (nothing about the resolver / gate changed — this PR is purely additive query surface).
- [ ] Decrypt the live cloud snapshot in the browser and confirm the dashboard's entitlement panels still render (no shape regression).

This PR stays **DRAFT** until you've done the local + cloud verification above. Version bump / `[RELEASE]` PR / merge is your call.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RKwqbixQHznoA9kanczjQ7)_