### PR TITLE
fix(uninstall): drag-to-trash leaves runtime + auto-logs user back in

### DIFF
--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -2099,13 +2099,123 @@ def _uninstall_nemoclaw_sandbox(
         pass
 
 
-def _cmd_uninstall() -> None:
-    """clawmetry uninstall — fully remove clawmetry, stop daemons, delete all files."""
+def _desktop_runtime_dir() -> "Path":
+    """Where the desktop thin-shell keeps its runtime venv + logs.
+    Mirrors ``desktop/app.py::_runtime_dir`` (kept in sync there). We
+    reimplement it here so the uninstall path doesn't have to import
+    the desktop package (which pulls pywebview into the CLI process).
+
+        macOS   ~/Library/Application Support/ClawMetry
+        Windows %LOCALAPPDATA%/ClawMetry
+        Linux   ~/.local/share/ClawMetry  (or $XDG_DATA_HOME/ClawMetry)
+    """
+    import platform as _pl
+    from pathlib import Path as _P
+
+    system = _pl.system()
+    if system == "Darwin":
+        return _P.home() / "Library" / "Application Support" / "ClawMetry"
+    if system == "Windows":
+        return _P(os.environ.get("LOCALAPPDATA", str(_P.home()))) / "ClawMetry"
+    return _P(
+        os.environ.get("XDG_DATA_HOME", str(_P.home() / ".local" / "share"))
+    ) / "ClawMetry"
+
+
+def _openclaw_sidecar_paths() -> list:
+    """Files under ``~/.openclaw`` that ClawMetry owns and is safe to
+    remove on uninstall. Deliberately excludes ``openclaw.json`` — that
+    file belongs to OpenClaw; we only strip our ``clawmetry`` key from
+    it in a separate step."""
+    from pathlib import Path as _P
+
+    home = _P.home()
+    oc = home / ".openclaw"
+    paths = [
+        oc / "clawmetry.db",
+        oc / "clawmetry.db-shm",
+        oc / "clawmetry.db-wal",
+        oc / "clawmetry-alerts.json",
+        oc / ".clawmetry",  # insights_config.json lives here
+        oc / "workspace" / ".clawmetry-fleet.db",
+        oc / "workspace" / ".clawmetry-fleet.db-shm",
+        oc / "workspace" / ".clawmetry-fleet.db-wal",
+        oc / "workspace" / ".clawmetry-metrics.json",
+    ]
+    return [p for p in paths if p.exists()]
+
+
+def _strip_clawmetry_from_openclaw_json() -> "tuple[bool, str]":
+    """Remove the ``clawmetry`` key from ``~/.openclaw/openclaw.json``.
+
+    Leaves the rest of the file intact so OpenClaw keeps working. If
+    the resulting object is empty, delete the file so a fresh install
+    doesn't inherit an empty stub. Returns (changed, path)."""
+    import json as _json
+    from pathlib import Path as _P
+
+    p = _P.home() / ".openclaw" / "openclaw.json"
+    if not p.exists():
+        return False, str(p)
+    try:
+        with p.open() as f:
+            data = _json.load(f)
+    except Exception:
+        return False, str(p)
+    if not isinstance(data, dict) or "clawmetry" not in data:
+        return False, str(p)
+    del data["clawmetry"]
+    try:
+        if not data:
+            p.unlink()
+        else:
+            with p.open("w") as f:
+                _json.dump(data, f, indent=2)
+        return True, str(p)
+    except Exception:
+        return False, str(p)
+
+
+def _cmd_uninstall(args=None) -> None:
+    """clawmetry uninstall — fully remove clawmetry, stop daemons, delete all files.
+
+    Flags (all optional; if ``args`` is None the interactive default holds):
+
+        --yes / -y     skip the interactive "type uninstall to confirm" prompt.
+                       Required for the desktop-app menu shell-out and the
+                       app-vanished watchdog.
+        --unattended   non-interactive, quiet, exit 0 even on partial failure.
+                       Implies --yes. This is what the macOS app-vanished
+                       watchdog uses.
+        --keep-data    preserve DuckDB local store + history.db (users who
+                       want their event history to survive a reinstall).
+        --dry-run      list everything that would be removed without touching
+                       disk.
+    """
     import shutil
     import platform
     import subprocess
     from pathlib import Path
     from clawmetry.sync import CONFIG_FILE, STATE_FILE, LOG_FILE
+
+    _yes = bool(getattr(args, "yes", False) or getattr(args, "unattended", False))
+    _unattended = bool(getattr(args, "unattended", False))
+    _keep_data = bool(getattr(args, "keep_data", False))
+    _dry_run = bool(getattr(args, "dry_run", False))
+
+    def _say(msg: str) -> None:
+        if not _unattended:
+            print(msg)
+
+    # Under --unattended (watchdog-driven), silence every remaining `print`
+    # in this function so the LaunchAgent's log stays clean. We restore
+    # stdout on the way out.
+    _orig_stdout = sys.stdout
+    if _unattended:
+        try:
+            sys.stdout = open(os.devnull, "w")  # noqa: SIM115 — restored below
+        except Exception:
+            pass
 
     home = Path.home()
     system = platform.system()
@@ -2167,38 +2277,109 @@ def _cmd_uninstall() -> None:
             ("NemoClaw", f"Sandbox {_sb}: stop daemon, remove config + clawmetry")
         )
 
-    # 6. pip package
+    # 6. Desktop thin-shell runtime (~/Library/Application Support/ClawMetry etc.)
+    # The .app itself lives in /Applications and is user-managed (drag-to-trash),
+    # but the pip-managed venv, bootstrap.log, and onboarding-completed.json
+    # under the runtime dir are ours to wipe. This is the piece that was
+    # silently surviving drag-to-trash and auto-logging the user back in on
+    # reinstall (support thread 2026-08-12).
+    _desktop_runtime = _desktop_runtime_dir()
+    if _desktop_runtime.exists():
+        items.append(("Desktop", f"Desktop runtime dir: {_desktop_runtime}"))
+
+    # 7. OpenClaw sidecar files ClawMetry owns (SQLite anomalies, fleet DB,
+    # insights config, alerts JSON). We DON'T touch ~/.openclaw/openclaw.json
+    # here — that file belongs to OpenClaw. The clawmetry.cloudToken key
+    # inside it is stripped separately (see step 8).
+    _oc_sidecar = _openclaw_sidecar_paths()
+    for _p in _oc_sidecar:
+        items.append(("Sidecar", f"OpenClaw sidecar file: {_p}"))
+
+    # 8. Cloud token embedded in ~/.openclaw/openclaw.json — the *file* is
+    # OpenClaw's, but the `clawmetry.cloudToken` key inside it is what caused
+    # the "auto-logged-in after drag-to-trash reinstall" surprise. Strip that
+    # key only. If openclaw.json ends up empty, the strip step deletes it.
+    _oc_json = home / ".openclaw" / "openclaw.json"
+    if _oc_json.exists():
+        try:
+            import json as _json_probe
+            with _oc_json.open() as _f:
+                _oc_data = _json_probe.load(_f)
+            if isinstance(_oc_data, dict) and "clawmetry" in _oc_data:
+                items.append(
+                    ("Token", f"Strip clawmetry.cloudToken from: {_oc_json}")
+                )
+        except Exception:
+            pass
+
+    # 9. pip package
     items.append(("Package", "pip package: clawmetry"))
 
+    if _keep_data:
+        # Filter out the DuckDB/SQLite/fleet DBs while keeping the runtime,
+        # config, and daemon teardown intact. This is the "I want to reinstall
+        # later and pick up where I left off" path.
+        def _is_data(cat: str, detail: str) -> bool:
+            data_hints = (
+                "clawmetry.db",
+                ".clawmetry-fleet",
+                "clawmetry.duckdb",
+                "history.db",
+                "Config directory",  # ~/.clawmetry holds the DuckDB
+            )
+            return any(hint in detail for hint in data_hints)
+
+        items = [(c, d) for (c, d) in items if not _is_data(c, d)]
+
+    def _restore_stdout():
+        if sys.stdout is not _orig_stdout:
+            try:
+                sys.stdout.close()
+            except Exception:
+                pass
+            sys.stdout = _orig_stdout
+
     if not items:
-        print("  Nothing to uninstall. ClawMetry does not appear to be installed.")
+        _say("  Nothing to uninstall. ClawMetry does not appear to be installed.")
+        _restore_stdout()
         return
 
-    # Show confirmation
-    print()
-    print("  \033[1m\033[91m⚠️  ClawMetry Uninstall\033[0m")
-    print("  \033[2m" + "─" * 50 + "\033[0m")
-    print()
-    print("  The following will be removed:")
-    print()
-    for category, detail in items:
-        print(f"    \033[91m✗\033[0m  [{category}] {detail}")
-    print()
-    print("  \033[2mThis action is irreversible. Your encryption key and cloud")
-    print("  config will be permanently deleted.\033[0m")
-    print()
-
-    try:
-        confirm = input("  Type 'uninstall' to confirm: ").strip()
-    except (EOFError, KeyboardInterrupt):
-        print("\n  Cancelled.")
+    if _dry_run:
+        _say("")
+        _say("  \033[1mDry run — no files touched.\033[0m")
+        _say("")
+        for category, detail in items:
+            _say(f"    \033[93m•\033[0m  [{category}] {detail}")
+        _say("")
+        _restore_stdout()
         return
 
-    if confirm != "uninstall":
-        print("  Cancelled.")
-        return
+    # Show confirmation (skipped under --yes / --unattended)
+    if not _yes:
+        print()
+        print("  \033[1m\033[91m⚠️  ClawMetry Uninstall\033[0m")
+        print("  \033[2m" + "─" * 50 + "\033[0m")
+        print()
+        print("  The following will be removed:")
+        print()
+        for category, detail in items:
+            print(f"    \033[91m✗\033[0m  [{category}] {detail}")
+        print()
+        print("  \033[2mThis action is irreversible. Your encryption key and cloud")
+        print("  config will be permanently deleted.\033[0m")
+        print()
 
-    print()
+        try:
+            confirm = input("  Type 'uninstall' to confirm: ").strip()
+        except (EOFError, KeyboardInterrupt):
+            print("\n  Cancelled.")
+            return
+
+        if confirm != "uninstall":
+            print("  Cancelled.")
+            return
+
+        print()
 
     # Execute uninstall
     # 0. Purge server-side registration (node_registry + node data)
@@ -2336,7 +2517,11 @@ def _cmd_uninstall() -> None:
     # 3. Remove config directory (includes venv). ignore_errors hides
     # locked-file failures, so verify and re-try instead of printing a
     # false success over a directory that is still there (#3914).
-    if clawmetry_dir.exists():
+    #
+    # --keep-data: skip the whole directory wipe so the DuckDB / history.db
+    # survive. The pip-uninstall above already deregistered the package, so
+    # leaving the venv on disk is harmless (it's just files).
+    if clawmetry_dir.exists() and not _keep_data:
         shutil.rmtree(clawmetry_dir, ignore_errors=True)
         if clawmetry_dir.exists():
             import time as _time_u
@@ -2344,16 +2529,16 @@ def _cmd_uninstall() -> None:
             _time_u.sleep(0.5)
             shutil.rmtree(clawmetry_dir, ignore_errors=True)
         if clawmetry_dir.exists():
-            print(f"  ⚠️  Could not fully remove {clawmetry_dir} (files in use). Remove it manually.")
+            _say(f"  ⚠️  Could not fully remove {clawmetry_dir} (files in use). Remove it manually.")
         else:
-            print(f"  ✅  Removed {clawmetry_dir}")
+            _say(f"  ✅  Removed {clawmetry_dir}")
 
     # 4. Remove config/state/log files. A locked file (e.g. sync.log under
     # a daemon that survived the stop) warns and continues, never aborts.
     for f in [CONFIG_FILE, STATE_FILE, LOG_FILE]:
         if f.exists():
             if _safe_unlink(f):
-                print(f"  ✅  Removed {f}")
+                _say(f"  ✅  Removed {f}")
 
     # 5. Remove venv installs
     for vp in venv_paths:
@@ -2401,21 +2586,86 @@ def _cmd_uninstall() -> None:
             cluster = None
         if cluster:
             for sb in _nemoclaw_sandboxes:
-                print(f"  ⏳  Uninstalling from sandbox {sb}...")
+                _say(f"  ⏳  Uninstalling from sandbox {sb}...")
                 _uninstall_nemoclaw_sandbox(cluster, sb, docker_bin=_docker)
-                print(f"  ✅  Sandbox {sb} cleaned")
+                _say(f"  ✅  Sandbox {sb} cleaned")
 
-    print()
-    print("  \033[1m\033[92m✓ ClawMetry fully uninstalled.\033[0m")
-    # Reinstall hint matches the host OS — a curl|bash line pasted into
-    # cmd.exe would just error, so Windows gets the .cmd fetch+run pair.
-    _reinstall_cmd = (
-        "curl -fsSL https://clawmetry.com/install.cmd -o install.cmd && install.cmd"
-        if sys.platform.startswith("win")
-        else "curl -fsSL https://clawmetry.com/install.sh | bash"
-    )
-    print(f"  \033[2mTo reinstall: {_reinstall_cmd}\033[0m")
-    print()
+    # 8. OpenClaw sidecar files ClawMetry owns. Skipped under --keep-data
+    # (the fleet DB + anomalies count as "data").
+    if not _keep_data:
+        for _p in _oc_sidecar:
+            try:
+                if _p.is_dir():
+                    shutil.rmtree(_p, ignore_errors=True)
+                    if not _p.exists():
+                        _say(f"  ✅  Removed {_p}")
+                else:
+                    if _safe_unlink(_p):
+                        _say(f"  ✅  Removed {_p}")
+            except Exception as _e:
+                _say(f"  ⚠️  Could not remove {_p}: {_e}")
+
+    # 9. Strip clawmetry.cloudToken from ~/.openclaw/openclaw.json. This is
+    # what caused the "auto-logged-in after drag-to-trash reinstall" surprise
+    # — a stale token in a file OpenClaw owns. We only remove our own key;
+    # the rest of openclaw.json is preserved (or the file is deleted if our
+    # key was the only thing in it).
+    _stripped, _oc_json_path = _strip_clawmetry_from_openclaw_json()
+    if _stripped:
+        _say(f"  ✅  Stripped clawmetry section from {_oc_json_path}")
+
+    # 10. Desktop thin-shell runtime dir (~/Library/Application Support/ClawMetry
+    # on macOS, %LOCALAPPDATA%/ClawMetry on Windows, ~/.local/share/ClawMetry
+    # on Linux). Holds the pip-managed venv + bootstrap.log + onboarding
+    # state. Removed LAST so we don't yank the venv out from under a running
+    # `clawmetry` process (this uninstall itself may be executing from that
+    # venv). On Windows the `.exe` self-delete pattern already handled by
+    # step 2b lets us delete the parent dir after this process exits.
+    #
+    # We don't touch /Applications/ClawMetry.app itself — that's the user's
+    # to manage (Finder → drag to Trash, or macOS Ventura+ "Move to Bin"). If
+    # this uninstall was triggered from an in-app menu the caller is expected
+    # to quit the app after the uninstall returns.
+    _desktop_runtime = _desktop_runtime_dir()
+    if _desktop_runtime.exists():
+        try:
+            shutil.rmtree(_desktop_runtime, ignore_errors=True)
+            if _desktop_runtime.exists():
+                # Retry once — venv teardown occasionally races the process
+                # exit on macOS (open file handles under load_url).
+                import time as _time_dr
+                _time_dr.sleep(0.5)
+                shutil.rmtree(_desktop_runtime, ignore_errors=True)
+            if _desktop_runtime.exists():
+                _say(
+                    f"  ⚠️  Could not fully remove {_desktop_runtime} "
+                    "(files in use). Remove it manually."
+                )
+            else:
+                _say(f"  ✅  Removed desktop runtime dir {_desktop_runtime}")
+        except Exception as _e:
+            _say(f"  ⚠️  Could not remove {_desktop_runtime}: {_e}")
+
+    if not _unattended:
+        print()
+        print("  \033[1m\033[92m✓ ClawMetry fully uninstalled.\033[0m")
+        # Reinstall hint matches the host OS — a curl|bash line pasted into
+        # cmd.exe would just error, so Windows gets the .cmd fetch+run pair.
+        _reinstall_cmd = (
+            "curl -fsSL https://clawmetry.com/install.cmd -o install.cmd && install.cmd"
+            if sys.platform.startswith("win")
+            else "curl -fsSL https://clawmetry.com/install.sh | bash"
+        )
+        print(f"  \033[2mTo reinstall: {_reinstall_cmd}\033[0m")
+        print()
+
+    # Restore stdout if we swapped it out under --unattended.
+    if sys.stdout is not _orig_stdout:
+        try:
+            sys.stdout.close()
+        except Exception:
+            pass
+        sys.stdout = _orig_stdout
 
 
 def _status_live_line(rows, prev, now):
@@ -6838,8 +7088,33 @@ def main() -> None:
     )
 
     # uninstall — fully remove clawmetry
-    sub.add_parser(
+    p_uninstall = sub.add_parser(
         "uninstall", help="Fully uninstall clawmetry (stop daemons, remove all files)"
+    )
+    p_uninstall.add_argument(
+        "-y", "--yes",
+        action="store_true",
+        help="Skip the interactive 'type uninstall to confirm' prompt "
+        "(required for desktop-app menu shell-out and the app-vanished watchdog).",
+    )
+    p_uninstall.add_argument(
+        "--unattended",
+        action="store_true",
+        help="Non-interactive, minimal output, always exit 0 even on partial "
+        "failures. Implies --yes. This is what the macOS app-vanished watchdog uses "
+        "when it detects that /Applications/ClawMetry.app has been dragged to trash.",
+    )
+    p_uninstall.add_argument(
+        "--keep-data",
+        action="store_true",
+        help="Preserve the DuckDB local store and history DB. Removes runtime, "
+        "config, and daemons; keeps event data on disk in case you reinstall.",
+    )
+    p_uninstall.add_argument(
+        "--dry-run",
+        action="store_true",
+        dest="dry_run",
+        help="List everything that would be removed without touching disk.",
     )
 
     # activate — install a self-hosted Pro/Enterprise license key
@@ -7363,7 +7638,7 @@ def main() -> None:
         elif args.cmd == "update":
             _cmd_update(args)
         elif args.cmd == "uninstall":
-            _cmd_uninstall()
+            _cmd_uninstall(args)
         elif args.cmd == "activate":
             _cmd_activate(args)
         elif args.cmd == "license":

--- a/clawmetry/watchdog.py
+++ b/clawmetry/watchdog.py
@@ -1,0 +1,238 @@
+"""macOS "app-vanished" watchdog.
+
+macOS has no OS-level uninstall hook — dragging ``/Applications/ClawMetry.app``
+to the Trash removes the app bundle but leaves the runtime venv, the cloud
+sign-in token, and the DuckDB event history on disk. On the next install the
+daemon reads the leftover token and silently signs the user back in, which
+reads as "uninstall didn't work" (support thread 2026-08-12).
+
+This module installs a LaunchAgent that polls every ``INTERVAL_SECS`` and,
+when the .app is missing but the runtime dir is present, invokes
+``clawmetry uninstall --unattended``. That command removes the runtime dir
+AND unloads this very plist (its step 1 sweeps every
+``~/Library/LaunchAgents/com.clawmetry.*.plist``), so the watchdog is
+self-cleaning.
+
+The watchdog is macOS-only. On Windows the MSI/uninstaller flow already
+runs a proper uninstall hook; on Linux there is no "drag to Trash" surface
+to fix. Callers on other platforms get a silent no-op.
+
+Called from ``desktop/app.py::_boot`` on every launch, so the plist stays
+in sync with the runtime path (which can move if the user switches homes
+or the OS Application Support path changes across major macOS versions).
+"""
+
+from __future__ import annotations
+
+import os
+import platform
+import subprocess
+import sys
+from pathlib import Path
+from typing import Optional
+
+LABEL = "com.clawmetry.app-watchdog"
+INTERVAL_SECS = 300  # 5 minutes — small enough to feel immediate, big
+# enough that launchd doesn't complain about churn.
+DEFAULT_APP_PATH = "/Applications/ClawMetry.app"
+
+
+def _plist_path() -> Path:
+    return Path.home() / "Library" / "LaunchAgents" / f"{LABEL}.plist"
+
+
+def _running_from_bundle() -> Optional[Path]:
+    """Return the path to the enclosing ``.app`` bundle if this process
+    was launched from one, else None. Used to (a) skip watchdog install
+    in dev (running ``python desktop/app.py`` shouldn't drop a plist)
+    and (b) prefer the actual bundle path over the ``/Applications``
+    default when the user installed to a non-standard location."""
+    # PyInstaller / py2app set sys.frozen. dev mode: no bundle.
+    if not getattr(sys, "frozen", False):
+        return None
+    # sys.executable inside a .app is
+    # /Applications/ClawMetry.app/Contents/MacOS/ClawMetry. Walk up to
+    # the .app boundary.
+    exe = Path(sys.executable).resolve()
+    for p in [exe, *exe.parents]:
+        if p.suffix == ".app":
+            return p
+    return None
+
+
+def _render_plist(
+    *,
+    app_path: Path,
+    runtime_dir: Path,
+    venv_clawmetry: Path,
+    interval_secs: int = INTERVAL_SECS,
+) -> str:
+    """Build the LaunchAgent XML. The shell command is idempotent — safe
+    to re-run every interval. Two guards keep it from doing anything
+    surprising:
+
+      * ``[ ! -e "$APP" ]`` — the .app is gone (either uninstalled OR
+        moved, both cases we want to wipe).
+      * ``[ -x "$CLI" ]`` — the runtime venv's clawmetry binary is
+        present and runnable. Prevents a partial-install state from
+        firing the uninstall again after we already ran it.
+    """
+    # Quote each path for a POSIX shell double-quoted context. The paths
+    # come from Python's Path objects and can contain spaces
+    # (``Application Support``) but not double-quotes on any sane macOS
+    # setup, so a simple str() is safe.
+    app = str(app_path)
+    cli = str(venv_clawmetry)
+    marker = str(runtime_dir)
+    # Two-layer teardown so this still works when the venv is half-broken:
+    #   1. Preferred path — ``clawmetry uninstall --unattended`` in the
+    #      runtime venv. Gets the full teardown (server-side unregister,
+    #      NemoClaw sandboxes, symlinks, launchd plists).
+    #   2. Fallback — if the CLI is missing or non-executable (partial
+    #      pip install / half-deleted venv), a small shell block does
+    #      the minimum wipe: cloud token, runtime dir, OpenClaw sidecar
+    #      files, and the LaunchAgent itself. Without this the user's
+    #      reported bug (drag-to-trash → auto-login on reinstall) can
+    #      persist even after the watchdog fires.
+    fallback = (
+        'rm -f "$HOME/.openclaw/clawmetry.db"* '
+        '"$HOME/.openclaw/clawmetry-alerts.json" '
+        '"$HOME/.openclaw/workspace/.clawmetry-fleet.db"* '
+        '"$HOME/.openclaw/workspace/.clawmetry-metrics.json"; '
+        'rm -rf "$HOME/.openclaw/.clawmetry"; '
+        # Strip clawmetry key from openclaw.json — python is the safe way,
+        # /usr/bin/python3 ships with macOS Big Sur+.
+        '/usr/bin/python3 -c \'import json,os,sys\n'
+        'p=os.path.expanduser("~/.openclaw/openclaw.json")\n'
+        'try:\n'
+        '  d=json.load(open(p))\n'
+        '  if isinstance(d,dict) and "clawmetry" in d:\n'
+        '    del d["clawmetry"]\n'
+        '    if d: json.dump(d,open(p,"w"),indent=2)\n'
+        '    else: os.unlink(p)\n'
+        'except Exception: pass\' 2>/dev/null; '
+        'rm -rf "$MARKER"; '
+        f'launchctl bootout "gui/$(id -u)/{LABEL}" 2>/dev/null; '
+        f'rm -f "$HOME/Library/LaunchAgents/{LABEL}.plist"'
+    )
+    cmd = (
+        f'APP="{app}"; CLI="{cli}"; MARKER="{marker}"; '
+        f'if [ ! -e "$APP" ] && [ -e "$MARKER" ]; then '
+        f'  if [ -x "$CLI" ]; then '
+        f'    "$CLI" uninstall --unattended; '
+        f'  else '
+        f'    {fallback}; '
+        f'  fi; '
+        f'fi'
+    )
+    # The shell command sits inside <string>…</string>. It contains `&&`,
+    # which is a bare ampersand as far as XML is concerned. Escape the
+    # five predefined XML entities so plutil / plist parsers accept us.
+    from xml.sax.saxutils import escape as _xml_escape
+    cmd_xml = _xml_escape(cmd, {'"': "&quot;", "'": "&apos;"})
+    stdout_log = str(runtime_dir / "watchdog.log")
+    return f"""<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>{LABEL}</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/sh</string>
+    <string>-c</string>
+    <string>{cmd_xml}</string>
+  </array>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>StartInterval</key>
+  <integer>{interval_secs}</integer>
+  <key>StandardOutPath</key>
+  <string>{stdout_log}</string>
+  <key>StandardErrorPath</key>
+  <string>{stdout_log}</string>
+</dict>
+</plist>
+"""
+
+
+def ensure_app_watchdog_installed(
+    *,
+    runtime_dir: Path,
+    venv_clawmetry: Path,
+    force: bool = False,
+) -> bool:
+    """Install (or refresh) the app-vanished watchdog LaunchAgent.
+
+    Idempotent — safe to call on every desktop launch. Returns True if
+    the plist ended up on disk and loaded, False if we skipped (dev
+    mode, non-macOS, or launchd rejected the load).
+
+    Args:
+        runtime_dir: the desktop shell's runtime dir. Its presence is
+            the "did the app leave data behind" marker the watchdog
+            script tests.
+        venv_clawmetry: absolute path to the ``clawmetry`` binary in
+            the runtime venv. The watchdog invokes this on trigger.
+        force: refresh even if the plist already matches — useful in
+            tests. Under normal launch we only rewrite on content drift.
+    """
+    if platform.system() != "Darwin":
+        return False
+
+    bundle = _running_from_bundle()
+    if bundle is None:
+        # Dev mode. Never drop a LaunchAgent from `python desktop/app.py`
+        # — it would keep pointing at the developer's checkout after they
+        # move on to something else.
+        return False
+
+    # Prefer the actual bundle path we booted from. If the user installed
+    # to a non-standard location (~/Applications, /Applications/Utilities/,
+    # a Homebrew Cask, etc.) the watchdog should watch THAT path, not the
+    # canonical /Applications one, or it will misfire every 5 minutes.
+    app_path = bundle if bundle.exists() else Path(DEFAULT_APP_PATH)
+
+    plist_path = _plist_path()
+    new_xml = _render_plist(
+        app_path=app_path,
+        runtime_dir=runtime_dir,
+        venv_clawmetry=venv_clawmetry,
+    )
+    old_xml = ""
+    if plist_path.exists():
+        try:
+            old_xml = plist_path.read_text()
+        except OSError:
+            old_xml = ""
+    if old_xml == new_xml and not force:
+        # Already installed with correct contents. Assume launchd still
+        # has it loaded — a cold boot would have re-loaded it via the
+        # ~/Library/LaunchAgents autoload.
+        return True
+
+    plist_path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        plist_path.write_text(new_xml)
+    except OSError:
+        return False
+
+    # Reload the plist so launchd picks up the new contents. bootout+bootstrap
+    # is the current-generation API; unload+load is the pre-Big Sur fallback.
+    uid = os.getuid()
+    target = f"gui/{uid}"
+    subprocess.run(
+        ["launchctl", "bootout", f"{target}/{LABEL}"],
+        check=False, capture_output=True,
+    )
+    r = subprocess.run(
+        ["launchctl", "bootstrap", target, str(plist_path)],
+        check=False, capture_output=True,
+    )
+    if r.returncode != 0:
+        # Older macOS (pre-10.11). load handles the register+start pair.
+        subprocess.run(
+            ["launchctl", "load", str(plist_path)],
+            check=False, capture_output=True,
+        )
+    return True

--- a/desktop/app.py
+++ b/desktop/app.py
@@ -1072,6 +1072,79 @@ def main() -> int:
         except Exception:
             pass
 
+    def _do_uninstall_flow() -> None:
+        """Menu handler — confirm, then shell out to
+        ``clawmetry uninstall --yes`` in the runtime venv, then quit.
+
+        The uninstall itself removes the runtime dir the venv lives in;
+        that's safe on POSIX because the venv's clawmetry binary is
+        already mmap'd by the child process (unlinked files stay open
+        for the running process). On Windows the uninstall reschedules
+        the exe delete for after we exit.
+        """
+        try:
+            ok = window.evaluate_js(
+                "confirm('Uninstall ClawMetry?\\n\\n"
+                "This removes the runtime, local event history, and your "
+                "sign-in token.\\n\\n"
+                "The app in /Applications is not deleted — drag it to "
+                "Trash separately.')"
+            )
+        except Exception:
+            ok = True  # If we can't render a dialog, assume the menu click
+            # is intent enough. The CLI would still refuse on a bad flag.
+        if not ok:
+            return
+
+        _set_status("Uninstalling ClawMetry…")
+        # Stop the daemon before removing its files: on Windows a live
+        # process holds an exclusive lock on its exe; on macOS/Linux the
+        # rmtree still works but the sync.log deletion races.
+        try:
+            sup.shutting_down.set()
+        except Exception:
+            pass
+        try:
+            sup.stop()
+        except Exception:
+            pass
+
+        venv_cli = sup._venv_clawmetry()
+        if venv_cli.exists():
+            try:
+                subprocess.run(
+                    [str(venv_cli), "uninstall", "--yes"],
+                    check=False,
+                    timeout=300,
+                )
+            except Exception:
+                pass
+
+        # Quit the app. The runtime dir is gone; a relaunch would re-bootstrap.
+        try:
+            window.destroy()
+        except Exception:
+            os._exit(0)
+
+    def _on_menu_uninstall() -> None:
+        # Menu callbacks run on the GUI thread; move the confirm+shell-out
+        # off it so evaluate_js and subprocess don't block the main loop.
+        threading.Thread(target=_do_uninstall_flow, daemon=True).start()
+
+    # Build the menu — tolerant of pywebview versions without a menu API.
+    # macOS shows this alongside the standard app menu; the item name uses
+    # the platform convention "Uninstall ClawMetry…" (ellipsis = confirms).
+    menu_items: list = []
+    try:
+        from webview.menu import Menu, MenuAction  # type: ignore
+        menu_items = [
+            Menu(APP_TITLE, [
+                MenuAction("Uninstall ClawMetry…", _on_menu_uninstall),
+            ]),
+        ]
+    except Exception:
+        menu_items = []
+
     def _boot():
         # Phase 1: bootstrap the runtime venv.
         ok = sup.bootstrap()
@@ -1080,6 +1153,21 @@ def main() -> int:
             # the carousel up with the failure text at the top so the
             # user has something to read while filing a bug.
             return
+
+        # Install the macOS app-vanished watchdog so drag-to-trash of
+        # /Applications/ClawMetry.app triggers a full uninstall without
+        # the user having to open a terminal. No-op on non-macOS and in
+        # dev mode (sys.frozen unset). See clawmetry/watchdog.py.
+        try:
+            from clawmetry.watchdog import ensure_app_watchdog_installed
+            ensure_app_watchdog_installed(
+                runtime_dir=sup.runtime,
+                venv_clawmetry=sup._venv_clawmetry(),
+            )
+        except Exception:
+            # Never let a watchdog install failure block launch — the
+            # in-app menu and manual CLI still work without it.
+            pass
 
         # Expose the CLI globally (PATH shim / symlink) and make sure
         # local ingest is running — both in the background, neither may
@@ -1202,7 +1290,11 @@ def main() -> int:
     threading.Thread(target=_boot, daemon=True).start()
 
     # js_api makes DesktopAPI methods callable as window.pywebview.api.*
-    webview.start(private_mode=False)
+    # Older pywebview versions don't accept `menu=`; fall back cleanly.
+    try:
+        webview.start(private_mode=False, menu=menu_items)
+    except TypeError:
+        webview.start(private_mode=False)
     return 0
 
 

--- a/tests/test_uninstall_drag_to_trash.py
+++ b/tests/test_uninstall_drag_to_trash.py
@@ -1,0 +1,199 @@
+"""Regression coverage for the "drag-to-trash → auto-login on reinstall"
+bug (support 2026-08-12).
+
+Three things must hold for the fix to work:
+
+  1. ``clawmetry uninstall`` strips the ``clawmetry`` key from
+     ``~/.openclaw/openclaw.json``, leaving other OpenClaw keys intact.
+     Without this, a stale cloud token silently signs the user back in.
+
+  2. The ``clawmetry uninstall --dry-run`` output lists the desktop
+     runtime dir under ``~/Library/Application Support/ClawMetry`` (the
+     thin-shell venv, bootstrap.log, onboarding-completed.json). This
+     was the piece drag-to-trash left behind pre-fix.
+
+  3. The macOS app-vanished LaunchAgent plist is valid XML/plist and
+     its shell command is well-formed sh (so plutil/launchd accept it
+     when we drop it during desktop bootstrap).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def _reload_cli(monkeypatch, home: Path):
+    """Re-import the CLI with HOME pointed at a fresh tmp dir so
+    ``Path.home()`` inside module-level constants (CONFIG_FILE etc.)
+    resolves under the tmpdir, not the developer's real home."""
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))  # Windows shim
+    sys.modules.pop("clawmetry.cli", None)
+    sys.modules.pop("clawmetry.sync", None)
+    import clawmetry.cli as cli
+    return cli
+
+
+def test_strip_clawmetry_from_openclaw_json_preserves_other_keys(
+    tmp_path, monkeypatch
+):
+    home = tmp_path / "home"
+    (home / ".openclaw").mkdir(parents=True)
+    p = home / ".openclaw" / "openclaw.json"
+    p.write_text(
+        json.dumps(
+            {
+                "clawmetry": {"cloudToken": "cm_deadbeef"},
+                "chat": {"provider": "telegram"},
+                "gateway": {"token": "keep-me"},
+            }
+        )
+    )
+
+    cli = _reload_cli(monkeypatch, home)
+    changed, path = cli._strip_clawmetry_from_openclaw_json()
+
+    assert changed is True
+    assert path == str(p)
+    remaining = json.loads(p.read_text())
+    assert "clawmetry" not in remaining
+    assert remaining["chat"]["provider"] == "telegram"
+    assert remaining["gateway"]["token"] == "keep-me"
+
+
+def test_strip_deletes_openclaw_json_when_our_key_was_the_only_content(
+    tmp_path, monkeypatch
+):
+    home = tmp_path / "home"
+    (home / ".openclaw").mkdir(parents=True)
+    p = home / ".openclaw" / "openclaw.json"
+    p.write_text(json.dumps({"clawmetry": {"cloudToken": "cm_solo"}}))
+
+    cli = _reload_cli(monkeypatch, home)
+    changed, _ = cli._strip_clawmetry_from_openclaw_json()
+
+    assert changed is True
+    # Nothing else was in the file, so we clean up the stub rather than
+    # leaving a `{}` behind for OpenClaw to trip on later.
+    assert not p.exists()
+
+
+def test_strip_is_noop_when_key_absent(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    (home / ".openclaw").mkdir(parents=True)
+    p = home / ".openclaw" / "openclaw.json"
+    p.write_text(json.dumps({"chat": {"provider": "signal"}}))
+
+    cli = _reload_cli(monkeypatch, home)
+    changed, _ = cli._strip_clawmetry_from_openclaw_json()
+
+    assert changed is False
+    # File untouched.
+    assert json.loads(p.read_text()) == {"chat": {"provider": "signal"}}
+
+
+def test_dry_run_lists_desktop_runtime_dir(tmp_path, monkeypatch, capsys):
+    """The drag-to-trash bug's root cause: this directory used to
+    survive an uninstall. The dry-run should now enumerate it so users
+    (and the fix's future maintainers) can see it will be removed."""
+    home = tmp_path / "home"
+    runtime = home / "Library" / "Application Support" / "ClawMetry"
+    runtime.mkdir(parents=True)
+    (runtime / "runtime").mkdir()
+    (runtime / "runtime" / "bootstrap.log").write_text("hello")
+
+    cli = _reload_cli(monkeypatch, home)
+
+    class _Args:
+        yes = False
+        unattended = False
+        keep_data = False
+        dry_run = True
+
+    cli._cmd_uninstall(_Args())
+    out = capsys.readouterr().out
+    assert "Desktop runtime dir" in out
+    assert str(runtime) in out
+
+
+def test_dry_run_lists_openclaw_token_strip_when_present(
+    tmp_path, monkeypatch, capsys
+):
+    home = tmp_path / "home"
+    (home / ".openclaw").mkdir(parents=True)
+    (home / ".openclaw" / "openclaw.json").write_text(
+        json.dumps({"clawmetry": {"cloudToken": "cm_x"}, "chat": {}})
+    )
+
+    cli = _reload_cli(monkeypatch, home)
+
+    class _Args:
+        yes = False
+        unattended = False
+        keep_data = False
+        dry_run = True
+
+    cli._cmd_uninstall(_Args())
+    out = capsys.readouterr().out
+    assert "Strip clawmetry.cloudToken" in out
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="macOS-only watchdog")
+def test_watchdog_plist_is_valid_plist_and_shell_syntax(tmp_path):
+    from clawmetry.watchdog import _render_plist
+
+    runtime = tmp_path / "runtime"
+    runtime.mkdir()
+    xml = _render_plist(
+        app_path=Path("/Applications/ClawMetry.app"),
+        runtime_dir=runtime,
+        venv_clawmetry=runtime / "venv" / "bin" / "clawmetry",
+    )
+    plist = tmp_path / "wd.plist"
+    plist.write_text(xml)
+
+    # plutil ships with every macOS.
+    r = subprocess.run(
+        ["plutil", "-lint", str(plist)], capture_output=True, text=True
+    )
+    assert r.returncode == 0, r.stdout + r.stderr
+
+    # The `sh` shipped with the plist has to be well-formed too.
+    # Extract the third ProgramArgument (the -c payload) via plutil.
+    cmd = subprocess.check_output(
+        ["plutil", "-extract", "ProgramArguments.2", "raw", str(plist)],
+        text=True,
+    ).strip()
+    r2 = subprocess.run(
+        ["sh", "-n", "-c", cmd], capture_output=True, text=True
+    )
+    assert r2.returncode == 0, r2.stderr
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="macOS-only watchdog")
+def test_watchdog_install_is_noop_in_dev_mode(tmp_path, monkeypatch):
+    """Dev launches (``python desktop/app.py`` with sys.frozen unset)
+    must not drop a plist. A dev-machine plist would keep pointing at
+    the developer's checkout venv forever."""
+    from clawmetry import watchdog
+
+    monkeypatch.setattr(sys, "frozen", False, raising=False)
+    # Redirect LaunchAgents dir into tmp so we don't scribble on the
+    # real one even if the guard breaks.
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    installed = watchdog.ensure_app_watchdog_installed(
+        runtime_dir=tmp_path / "runtime",
+        venv_clawmetry=tmp_path / "runtime" / "venv" / "bin" / "clawmetry",
+    )
+    assert installed is False
+    assert not (
+        tmp_path / "Library" / "LaunchAgents"
+        / f"{watchdog.LABEL}.plist"
+    ).exists()


### PR DESCRIPTION
## Summary

- Deleting `/Applications/ClawMetry.app` doesn't remove `~/Library/Application Support/ClawMetry` (venv, `bootstrap.log`, onboarding state) or strip the `clawmetry.cloudToken` key in `~/.openclaw/openclaw.json`. On reinstall the bootstrap reads the leftover token and silently signs the user back in — reads as \"uninstall didn't work\" (support thread 2026-08-12).
- Three-layer fix so drag-to-trash Just Works on macOS:
  1. `clawmetry uninstall` (`clawmetry/cli.py`) now also removes the desktop thin-shell runtime dir (per-OS), OpenClaw sidecar files ClawMetry owns (`clawmetry.db*`, `.clawmetry-fleet.db*`, `insights_config`, `clawmetry-alerts.json`), and strips ONLY the `clawmetry` key from `~/.openclaw/openclaw.json` (leaves the rest for OpenClaw; deletes the file if empty). New flags: `--yes` / `-y`, `--unattended` (silent + always exit 0), `--keep-data` (preserve DuckDB + `history.db`), `--dry-run`.
  2. Desktop menu (`desktop/app.py`) — \"Uninstall ClawMetry…\" in the app menu. Confirms via JS, stops the daemon, shells out to `<venv>/bin/clawmetry uninstall --yes`, then quits. Falls back to no menu on older pywebview versions.
  3. `clawmetry/watchdog.py` — new `com.clawmetry.app-watchdog` LaunchAgent (macOS only, installed by desktop bootstrap). Every 300s + `RunAtLoad`, if the `.app` is gone but the runtime dir is present, invokes `clawmetry uninstall --unattended`. Two-layer teardown: primary path calls the CLI; fallback is inline shell (`rm -rf`, `/usr/bin/python3` to strip the token, `launchctl bootout` self) so a partially-broken pip install can't strand state. Skipped when `sys.frozen` is unset (dev). Prefers the actual bundle path from `sys.executable` over `/Applications/ClawMetry.app` for non-standard installs.

## What is owned by whom (matters for uninstall correctness)

- **Ours to delete:** `~/.clawmetry/` (whole tree), `~/Library/Application Support/ClawMetry/`, `~/.openclaw/clawmetry*`, `~/.openclaw/.clawmetry/`, `~/.openclaw/workspace/.clawmetry-*`, `~/.openclaw/clawmetry-alerts.json`, `~/.local/bin/clawmetry`, `~/Library/LaunchAgents/com.clawmetry.*.plist`.
- **NOT ours** (edit-in-place only): `~/.openclaw/openclaw.json` — strip our key, leave the file for OpenClaw.
- **NEVER touch:** `/Applications/ClawMetry.app` itself (user-managed).

## Test plan

- [x] `pytest tests/test_uninstall_drag_to_trash.py` — 7 new tests (all pass)
- [x] `pytest tests/test_uninstall_removes_all_launchagents.py tests/test_uninstall_windows.py` — 7 existing (all pass)
- [x] `pytest -k \"uninstall or cloud_token\"` — 27 total (all pass)
- [x] `plutil -lint` accepts the rendered LaunchAgent plist
- [x] `sh -n` accepts the plist's shell command (primary + fallback path)
- [ ] Manual drag-to-trash smoke on a signed DMG install — pending release build
- [ ] Manual: install → open app menu → \"Uninstall ClawMetry…\" → confirm → app quits, runtime dir gone, cloud token stripped
- [ ] Manual on Windows: `--yes` path removes runtime + rescheduled `.exe` delete
- [ ] Manual on Linux: `--keep-data` preserves `~/.clawmetry/clawmetry.duckdb`

🤖 Generated with [Claude Code](https://claude.com/claude-code)