### PR TITLE
fix(desktop): route window.open cross-origin URLs to the system browser

### DIFF
--- a/desktop/app.py
+++ b/desktop/app.py
@@ -74,6 +74,54 @@ WATCHER_TICK_SECS = 60
 BRAND_RED = "#E94644"
 BRAND_BG_DARK = "#0b0e14"
 
+# Injected after every navigation. WKWebView (macOS) and EdgeWebView2
+# (Windows) silently drop `window.open(...)` and `target="_blank"`
+# clicks that would need a new native window — so the Self-Host OAuth
+# flow (`cloudOauth` in gw-setup.js → `window.open(oauthUrl, '_blank')`)
+# never reaches a browser and the modal spins forever on
+# "Finish sign-in in the new browser tab."
+#
+# Route absolute cross-origin https URLs through the existing
+# DesktopAPI.open_external bridge (which already hands them to
+# webbrowser.open); leave same-origin and relative URLs (e.g. the
+# `/api/usage/export` download click) to the webview.
+_OPEN_EXTERNAL_SHIM = r"""
+(function(){
+  if (window.__clawmetryExternalShim) return;
+  window.__clawmetryExternalShim = true;
+  function isExternalHttps(u) {
+    try {
+      var url = new URL(String(u), window.location.href);
+      if (url.protocol !== 'https:') return false;
+      return url.host !== window.location.host;
+    } catch (e) { return false; }
+  }
+  function toBrowser(u) {
+    try {
+      if (window.pywebview && window.pywebview.api && window.pywebview.api.open_external) {
+        window.pywebview.api.open_external(String(u));
+        return true;
+      }
+    } catch (e) {}
+    return false;
+  }
+  var _open = window.open;
+  window.open = function(u, target, features) {
+    if (u && isExternalHttps(u) && toBrowser(u)) return null;
+    return _open.apply(window, arguments);
+  };
+  document.addEventListener('click', function(e){
+    var a = e.target && e.target.closest ? e.target.closest('a[href]') : null;
+    if (!a) return;
+    var href = a.getAttribute('href') || '';
+    if (!href || href.charAt(0) === '#') return;
+    if (isExternalHttps(href) && toBrowser(a.href)) {
+      e.preventDefault();
+    }
+  }, true);
+})();
+"""
+
 # Written by `clawmetry connect`; presence means this node has an account
 # key and the sync daemon can run.
 SYNC_CONFIG_FILE = Path.home() / ".clawmetry" / "config.json"
@@ -1286,7 +1334,18 @@ def main() -> int:
         sup.shutting_down.set()
         sup.stop()
 
+    def _install_open_external_shim():
+        # Fires on every navigation (splash, onboarding, dashboard,
+        # daemon-restart reload) so the shim always covers the current
+        # document. `window.__clawmetryExternalShim` guards against
+        # double-install if the event fires twice on one page.
+        try:
+            window.evaluate_js(_OPEN_EXTERNAL_SHIM)
+        except Exception:
+            pass
+
     window.events.closed += _on_closed
+    window.events.loaded += _install_open_external_shim
     threading.Thread(target=_boot, daemon=True).start()
 
     # js_api makes DesktopAPI methods callable as window.pywebview.api.*


### PR DESCRIPTION
## Summary
- Fixes the Self-Host sign-in flow inside the desktop app: clicking **Continue with GitHub** / **Continue with Google** was calling `window.open(oauthUrl, '_blank')`, which WKWebView (macOS) and EdgeWebView2 (Windows) silently drop when they'd need a new native window. No browser tab appeared and the modal spun forever on _"Finish sign-in in the new browser tab."_
- Injects a small shim on every `window.events.loaded` that overrides `window.open` and intercepts `<a href target=_blank>` clicks for cross-origin `https://` URLs, forwarding them to the existing `DesktopAPI.open_external` bridge (which already hands them to `webbrowser.open`). Same-origin and relative URLs (e.g. the `/api/usage/export` CSV download) are left alone so the webview handles them normally.
- Covers every other `target="_blank"` / cross-origin `window.open` link across the dashboard, not just the OAuth flow.

## Test plan
- [ ] Rebuild the desktop .dmg (`desktop/build_mac.spec`), launch it, click **Continue with GitHub** in the Self-Host modal → OAuth URL opens in the default browser and the spinner clears once the loopback bridge receives the key.
- [ ] Same flow with **Continue with Google**.
- [ ] Click any `target="_blank"` link in the dashboard (e.g. Cloud CTA, docs links) → opens in default browser.
- [ ] Click **Export CSV** in the Usage tab → still downloads via the webview (same-origin `/api/usage/export` isn't rerouted).
- [ ] Reload the daemon (watcher restart path) → shim reinstalls on the fresh page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)