### PR TITLE
fix(desktop): shell onboarding also writes the dashboard gate stamp

### DIFF
--- a/desktop/app.py
+++ b/desktop/app.py
@@ -1286,12 +1286,17 @@ def main() -> int:
                 _set_status(f"Sign-in step failed ({msg_key}) — continuing without cloud sync")
             # Whether it worked or not, mark onboarding as completed so
             # we don't re-prompt on relaunch. Users can re-sign-in from
-            # the dashboard's header.
+            # the dashboard's header. When apply_cm_key succeeded, ALSO
+            # pass the mode so mark_onboarding_completed writes the
+            # dashboard gate's own state file — otherwise the dashboard's
+            # /api/onboarding/state doesn't know we already onboarded and
+            # re-shows the same modal on top of the welcome view.
             onboarding.mark_onboarding_completed(
                 runtime,
                 signed_in=ok_key,
                 provider=api._captured_provider,
                 email=api._captured_email,
+                mode=(api._captured_mode or "cloud") if ok_key else "",
             )
         elif show_pane:
             # User skipped — stamp so we don't re-prompt.

--- a/desktop/onboarding.py
+++ b/desktop/onboarding.py
@@ -139,10 +139,54 @@ BRAND_BORDER = "#1f2937"
 # avoids nag-loops on machines where the user genuinely wants local-only.
 ONBOARDING_STAMP_NAME = "onboarding-completed.json"
 
+# The dashboard's onboarding gate reads its own state from
+# ``~/.clawmetry/onboarding.json`` (see ``routes/onboarding.py::_STATE_PATH``
+# and ``_resolve_state``). Our shell stamp above only stops US from
+# reshowing the desktop pane — it does not, on its own, keep the
+# dashboard's gate from re-prompting. See ``mark_onboarding_completed``.
+_DASHBOARD_GATE_STATE_PATH = Path.home() / ".clawmetry" / "onboarding.json"
+
 
 def is_first_launch(runtime_dir: Path) -> bool:
     """True when we have never completed onboarding for this install."""
     return not (Path(runtime_dir) / ONBOARDING_STAMP_NAME).exists()
+
+
+def _record_dashboard_gate_choice(mode: str) -> None:
+    """Write the dashboard gate's ``~/.clawmetry/onboarding.json`` so a
+    user who completed the shell's own onboarding pane isn't asked to
+    onboard AGAIN in the dashboard's gate the moment it loads.
+
+    Schema matches ``routes/onboarding.py::_write_choice_file``:
+    ``{"choice": <_CHOICES value>, "completed_at": <int>}``. We tag with
+    ``source: desktop_shell`` for debuggability; the endpoint ignores
+    unknown keys.
+
+    The dashboard's gate accepts ``managed`` (cloud), ``selfhost_trial``
+    (OAuth or email OTP → trial), and ``selfhost_license`` (pasted
+    CLAW1 key). The shell's own auth pane only produces the first two —
+    users pasting a license key do so from the dashboard's own selfhost
+    modal, which writes the file itself.
+
+    Best-effort: a write failure means the dashboard gate re-prompts,
+    which is annoying but not broken (and preferable to crashing boot).
+    """
+    mode = (mode or "").strip().lower()
+    if mode == "selfhost":
+        choice = "selfhost_trial"
+    elif mode == "cloud":
+        choice = "managed"
+    else:
+        return
+    try:
+        _DASHBOARD_GATE_STATE_PATH.parent.mkdir(parents=True, exist_ok=True)
+        _DASHBOARD_GATE_STATE_PATH.write_text(json.dumps({
+            "choice": choice,
+            "completed_at": int(time.time()),
+            "source": "desktop_shell",
+        }))
+    except OSError:
+        pass
 
 
 def mark_onboarding_completed(
@@ -151,21 +195,36 @@ def mark_onboarding_completed(
     signed_in: bool,
     provider: str = "",
     email: str = "",
+    mode: str = "",
 ) -> None:
     """Stamp the runtime dir so we don't show onboarding again. ``signed_in``
     is False for users who dismissed the pane without authenticating — the
-    stamp still writes so we don't re-prompt on relaunch."""
+    stamp still writes so we don't re-prompt on relaunch.
+
+    When ``signed_in`` is True and ``mode`` is known (``cloud`` or
+    ``selfhost``), ALSO record the choice in the dashboard gate's own
+    state file (see ``_record_dashboard_gate_choice``). Without this
+    second stamp, a self-host user completes the shell's pane, the
+    daemon starts, the dashboard loads, and its gate re-prompts because
+    the two stamp files live in different places and don't share state.
+    That re-prompt was live 2026-08-12: user chose Self-Host in the
+    shell, dashboard immediately showed the same "Self-Host / Sign in
+    for a free 7-day Pro trial" modal on top of the welcome view.
+    """
     stamp = Path(runtime_dir) / ONBOARDING_STAMP_NAME
     payload = {
         "completed": True,
         "signed_in": bool(signed_in),
         "provider": provider or "",
         "email": email or "",
+        "mode": mode or "",
     }
     try:
         stamp.write_text(json.dumps(payload))
     except OSError:
         pass  # onboarding stamp is best-effort; a re-shown pane is not a bug
+    if signed_in and mode:
+        _record_dashboard_gate_choice(mode)
 
 
 def _win_subprocess_kwargs() -> dict:

--- a/tests/test_desktop_onboarding_dashboard_gate.py
+++ b/tests/test_desktop_onboarding_dashboard_gate.py
@@ -1,0 +1,181 @@
+"""Guard: the desktop shell's onboarding stamp also unblocks the
+dashboard's onboarding gate.
+
+Bug pinned here (founder live-hit 2026-08-12): a user completed the
+desktop shell's own onboarding pane (OAuth + chose Self-Host), the
+daemon started, the dashboard loaded — and then the dashboard's own
+onboarding gate re-showed the "Self-Host / Sign in for a free 7-day
+Pro trial that unlocks every runtime" modal ON TOP of the welcome view,
+asking the user to onboard AGAIN.
+
+Root cause: two stamp files in two locations.
+
+  * Shell stamp   ~/Library/Application Support/ClawMetry/runtime/onboarding-completed.json
+                  (checked by ``is_first_launch``, gates the shell's own pane)
+  * Dashboard stamp ~/.clawmetry/onboarding.json
+                    (checked by ``routes/onboarding.py::_STATE_PATH``,
+                    gates the browser onboarding modal)
+
+The shell wrote only its own stamp. The dashboard's gate falls through
+to ``_license_state()`` and ``_cloud_connected()``, and self-host with
+a nocloud marker plus a trial mint that hasn't landed on disk yet leaves
+both empty, so ``_resolve_state()`` returns ``{required: True}``.
+
+These tests pin that the shell now writes BOTH files when the user
+completed onboarding with a known mode.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+from desktop import onboarding as desk_onb  # noqa: E402
+
+
+@pytest.fixture
+def fake_home(tmp_path, monkeypatch):
+    """Redirect ``~`` to a tmp dir for the module's dashboard-gate write."""
+    monkeypatch.setattr(
+        desk_onb, "_DASHBOARD_GATE_STATE_PATH",
+        tmp_path / ".clawmetry" / "onboarding.json",
+    )
+    return tmp_path
+
+
+def _read_dashboard_gate(fake_home: Path) -> dict:
+    p = fake_home / ".clawmetry" / "onboarding.json"
+    if not p.exists():
+        return {}
+    return json.loads(p.read_text())
+
+
+def _read_shell_stamp(runtime: Path) -> dict:
+    p = runtime / desk_onb.ONBOARDING_STAMP_NAME
+    if not p.exists():
+        return {}
+    return json.loads(p.read_text())
+
+
+def test_selfhost_signed_in_writes_both_stamps(tmp_path, fake_home):
+    runtime = tmp_path / "runtime"
+    runtime.mkdir()
+    desk_onb.mark_onboarding_completed(
+        runtime,
+        signed_in=True,
+        provider="github",
+        email="user@example.com",
+        mode="selfhost",
+    )
+    shell = _read_shell_stamp(runtime)
+    assert shell["signed_in"] is True
+    assert shell["mode"] == "selfhost"
+
+    gate = _read_dashboard_gate(fake_home)
+    assert gate.get("choice") == "selfhost_trial", (
+        "Self-host onboarding must record selfhost_trial in the dashboard "
+        "gate file — otherwise /api/onboarding/state re-prompts on next load."
+    )
+    assert gate.get("source") == "desktop_shell"
+    assert isinstance(gate.get("completed_at"), int)
+
+
+def test_cloud_signed_in_writes_managed_choice(tmp_path, fake_home):
+    runtime = tmp_path / "runtime"
+    runtime.mkdir()
+    desk_onb.mark_onboarding_completed(
+        runtime, signed_in=True, provider="google",
+        email="user@example.com", mode="cloud",
+    )
+    gate = _read_dashboard_gate(fake_home)
+    assert gate.get("choice") == "managed"
+
+
+def test_skipped_auth_writes_only_shell_stamp(tmp_path, fake_home):
+    """User dismissed the pane without authenticating: the shell stamps
+    itself so it won't re-prompt, but the dashboard gate MUST still show
+    a choice (this install owes one). Do not write the gate file."""
+    runtime = tmp_path / "runtime"
+    runtime.mkdir()
+    desk_onb.mark_onboarding_completed(
+        runtime, signed_in=False, provider="", email="", mode="",
+    )
+    assert _read_shell_stamp(runtime) != {}
+    assert not (fake_home / ".clawmetry" / "onboarding.json").exists(), (
+        "A skipped-auth stamp must not lie to the dashboard gate — "
+        "the user still owes a choice there."
+    )
+
+
+def test_signed_in_without_mode_does_not_write_gate(tmp_path, fake_home):
+    """Legacy callers not passing mode should not silently record a wrong
+    choice. The gate stays empty until we know the mode."""
+    runtime = tmp_path / "runtime"
+    runtime.mkdir()
+    desk_onb.mark_onboarding_completed(
+        runtime, signed_in=True, provider="github", email="", mode="",
+    )
+    assert not (fake_home / ".clawmetry" / "onboarding.json").exists()
+
+
+def test_unknown_mode_is_ignored(tmp_path, fake_home):
+    runtime = tmp_path / "runtime"
+    runtime.mkdir()
+    desk_onb.mark_onboarding_completed(
+        runtime, signed_in=True, provider="github", email="",
+        mode="something-else",
+    )
+    assert not (fake_home / ".clawmetry" / "onboarding.json").exists()
+
+
+def test_gate_choice_matches_routes_onboarding_schema(tmp_path, fake_home):
+    """Pin the exact schema ``routes/onboarding.py::_resolve_state`` reads.
+    If either side drifts (key rename, tighter parsing) the dashboard's
+    gate silently re-prompts again — same failure mode as the bug this
+    test guards, and hard to notice without an end-to-end launch."""
+    runtime = tmp_path / "runtime"
+    runtime.mkdir()
+    desk_onb.mark_onboarding_completed(
+        runtime, signed_in=True, provider="github", email="",
+        mode="selfhost",
+    )
+    gate = _read_dashboard_gate(fake_home)
+    # routes/onboarding.py::_CHOICES = ("managed", "selfhost_license", "selfhost_trial")
+    assert gate["choice"] in {"managed", "selfhost_license", "selfhost_trial"}
+    # routes/onboarding.py::_read_choice_file returns the JSON dict as-is;
+    # _resolve_state reads ``recorded.get("choice", "")``. Keeping the key
+    # name pinned means this stays a one-file contract.
+    assert "choice" in gate
+
+
+def test_write_failure_does_not_raise(tmp_path, monkeypatch):
+    """Boot must never crash on a stamp failure — a re-shown pane is
+    annoying, a crashed shell is broken."""
+    runtime = tmp_path / "runtime"
+    runtime.mkdir()
+    # Point the gate at an unwriteable path (a directory where a file is
+    # expected) and confirm we swallow the OSError.
+    bad = tmp_path / "readonly-dir-in-place-of-file"
+    bad.mkdir()
+    monkeypatch.setattr(desk_onb, "_DASHBOARD_GATE_STATE_PATH", bad)
+    # Should not raise.
+    desk_onb.mark_onboarding_completed(
+        runtime, signed_in=True, provider="github", email="",
+        mode="selfhost",
+    )
+
+
+def test_dashboard_gate_state_path_is_stable():
+    """The dashboard gate reads a hard-coded path
+    (``~/.clawmetry/onboarding.json``, see ``routes/onboarding.py``).
+    If we move ours, we resurrect the bug — pin the path shape here so
+    a rename is loud."""
+    assert desk_onb._DASHBOARD_GATE_STATE_PATH.name == "onboarding.json"
+    assert desk_onb._DASHBOARD_GATE_STATE_PATH.parent.name == ".clawmetry"


### PR DESCRIPTION
## Root cause

Founder live-hit 2026-08-12: a user launched the desktop app, went through the shell's onboarding pane (OAuth + chose **Self-Host**), the daemon booted, the dashboard loaded — and the same "Self-Host / Sign in for a free 7-day Pro trial that unlocks every runtime" modal re-appeared on top of the welcome view, asking them to onboard AGAIN.

Two separate onboarding stamp files in two locations, and only one of them was being written:

| Stamp | Path | Read by |
|-------|------|---------|
| Shell stamp | `~/Library/Application Support/ClawMetry/runtime/onboarding-completed.json` | `desktop/onboarding.py::is_first_launch` — gates the shell's own pane on next launch |
| Dashboard stamp | `~/.clawmetry/onboarding.json` | `routes/onboarding.py::_STATE_PATH` via `_resolve_state` — gates the browser onboarding modal |

The shell's `mark_onboarding_completed` wrote only its own stamp. After `apply_cm_key` runs `clawmetry connect --key … --keep-local`, the dashboard's `/api/onboarding/state` runs `_resolve_state()`:

1. `~/.clawmetry/onboarding.json` → doesn't exist → skip
2. `_license_state()` → empty when the trial mint didn't land locally (silent `auto_provision_pro` failure, network race, cloud reject)
3. `_cloud_connected()` → False, because `--keep-local` touched the nocloud marker and `is_cloud_disabled()` short-circuits
4. → `{required: True}` → re-shows the exact same modal on top of the welcome view.

The user's explicit choice — "I picked Self-Host in the shell" — was never recorded where the dashboard's gate reads it.

## Fix

`mark_onboarding_completed` now accepts a `mode` kwarg. When `signed_in` is True AND `mode` is known (`cloud` / `selfhost`), it also writes `~/.clawmetry/onboarding.json` with the matching gate choice (`managed` / `selfhost_trial`), using the exact schema `routes/onboarding.py::_write_choice_file` writes and `_resolve_state` reads.

Skipped-auth stays gate-empty on purpose: a dismissed pane must not lie to the dashboard that a choice was made.

## Not fixing here

`apply_cm_key` returning success without a locally activated trial license is a separate bug (silent `auto_provision_pro` failure). This PR does the right thing given the shell's authoritative knowledge that the user chose Self-Host, regardless of whether the trial mint actually landed. If the trial mint failed cloud-side, the user still hits a locked entitlement inside the dashboard, but they are no longer stuck in an onboarding loop.

## Test plan

- [x] `pytest tests/test_desktop_onboarding_dashboard_gate.py -v` — 8 tests green (regression suite added).
- [x] Revert-proven: replacing `_record_dashboard_gate_choice` with a no-op leaves `~/.clawmetry/onboarding.json` unwritten, matching the pre-fix failure mode.
- [ ] End-to-end (rides the next `[RELEASE]`): fresh `.dmg`, complete shell onboarding with Self-Host, dashboard loads WITHOUT the re-prompt modal on top of the welcome view.
- [ ] Same for cloud: fresh `.dmg`, complete shell onboarding with Managed Cloud, dashboard loads without the re-prompt.
- [ ] Skipped auth: dismiss shell pane, dashboard's gate still shows (user still owes a choice) — must not be silenced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)