### PR TITLE
fix(onboarding): dashboard gate honours the desktop shell's onboarding stamp

### DIFF
--- a/routes/onboarding.py
+++ b/routes/onboarding.py
@@ -36,8 +36,10 @@ chose managed by signing up.
 import json
 import logging
 import os
+import platform
 import threading
 import time
+from pathlib import Path
 
 from flask import Blueprint, jsonify, request
 
@@ -124,8 +126,112 @@ def _cloud_connected() -> bool:
         return False
 
 
+def _desktop_shell_runtime_dir() -> Path:
+    """Where the desktop shell keeps its per-user runtime state, mirroring
+    ``desktop/app.py::_runtime_dir`` byte-for-byte so the two agree on the
+    file to look for. Duplicated (not imported) because the ``desktop``
+    package is only bundled into the .app; the pip wheel — which serves
+    the dashboard everywhere — does not ship it."""
+    system = platform.system()
+    if system == "Darwin":
+        base = Path.home() / "Library" / "Application Support" / "ClawMetry"
+    elif system == "Windows":
+        base = Path(os.environ.get("LOCALAPPDATA") or str(Path.home())) / "ClawMetry"
+    else:
+        base = Path(
+            os.environ.get("XDG_DATA_HOME") or str(Path.home() / ".local" / "share")
+        ) / "ClawMetry"
+    return base / "runtime"
+
+
+def _desktop_shell_stamp() -> dict:
+    """Read the desktop shell's own ``onboarding-completed.json``, if any.
+
+    Written by ``desktop/onboarding.py::mark_onboarding_completed`` after
+    the user completes the shell's native onboarding pane
+    (OAuth / email OTP → hosting choice). Payload:
+    ``{completed, signed_in, provider, email, mode}`` — ``mode`` was added
+    in #4758; pre-#4758 stamps omit it.
+
+    Returns the parsed dict or ``{}`` on any failure (missing file, corrupt
+    JSON, wrong shape). Never raises."""
+    stamp = _desktop_shell_runtime_dir() / "onboarding-completed.json"
+    try:
+        with stamp.open("r", encoding="utf-8") as fh:
+            data = json.load(fh)
+        return data if isinstance(data, dict) else {}
+    except Exception:
+        return {}
+
+
+def _shell_stamp_choice() -> str:
+    """Map the shell stamp to a value from ``_CHOICES``, or ``''`` when the
+    user hasn't completed the shell pane or dismissed it without signing
+    in — in which case the browser gate still owes a prompt.
+
+    Two failure modes this closes (both live-hit 2026-08-12):
+
+    1. **Deployment lag.** ``desktop/`` code ships only inside the .app
+       bundle and reaches users on a new .dmg download; the pip wheel
+       auto-updates every 6h. If we relied on the shell to also write the
+       browser gate's own file (#4758), every user on any pre-#4758 .dmg
+       would still see the modal re-appear after finishing shell
+       onboarding — until they redownloaded. Reading the shell stamp
+       here inverts that: the fix rides the pip wheel and reaches the
+       whole fleet on the next update, regardless of installer age.
+
+    2. **Silent trial-mint failures.** When the shell's ``apply_cm_key``
+       runs ``clawmetry connect --key … --keep-local``, cloud may accept
+       the key but reject the trial (network blip, cloud-side error).
+       ``connect`` exits 0 anyway, so the shell stamps ``signed_in=True``
+       but no ``license.key`` lands. Then ``_license_state()`` is empty,
+       ``_cloud_connected()`` short-circuits on the nocloud marker, and
+       the gate falls through to ``{required: True}``. Recognising the
+       explicit user choice in the shell stamp resolves the re-prompt;
+       missing entitlement then surfaces inside the dashboard where the
+       user can retry, instead of trapping them in an onboarding loop.
+
+    Mode resolution for older .dmg stamps that lack the field: infer from
+    the nocloud marker, which is the same self-host intent signal
+    ``_cloud_connected()`` respects."""
+    stamp = _desktop_shell_stamp()
+    if not stamp.get("completed"):
+        return ""
+    if not stamp.get("signed_in"):
+        return ""
+    mode = str(stamp.get("mode", "")).strip().lower()
+    if mode == "selfhost":
+        return "selfhost_trial"
+    if mode == "cloud":
+        return "managed"
+    # Pre-#4758 .dmg: mode field wasn't recorded. Infer from what
+    # apply_cm_key would have left behind on the machine.
+    try:
+        from clawmetry.config import is_cloud_disabled as _icd
+
+        if _icd():
+            return "selfhost_trial"
+    except Exception:
+        pass
+    return "managed"
+
+
 def _resolve_state() -> dict:
-    """The single source of truth the gate JS renders from."""
+    """The single source of truth the gate JS renders from.
+
+    Precedence, most-authoritative first:
+      1. Explicit choice recorded in the browser gate's own file.
+      2. Active local license (trial or paid).
+      3. Explicit choice recorded by the DESKTOP SHELL's onboarding pane
+         (see ``_shell_stamp_choice`` — pip-wheel-side mirror of #4758,
+         reaches users regardless of installer age).
+      4. Cloud token with no self-host intent recorded anywhere.
+
+    The shell check sits BELOW the local license check on purpose: a
+    live license is a stronger signal than "user clicked something in
+    the shell N days ago" (they could have since let the trial expire),
+    and we want ``state`` to reflect what the user can actually DO now
+    when the two disagree."""
     recorded = _read_choice_file()
     choice = str(recorded.get("choice", "")).strip().lower()
     if choice in _CHOICES:
@@ -133,6 +239,10 @@ def _resolve_state() -> dict:
     lic = _license_state()
     if lic:
         return {"required": False, "state": lic, "source": "license"}
+    shell_choice = _shell_stamp_choice()
+    if shell_choice:
+        return {"required": False, "state": shell_choice,
+                "source": "desktop_shell"}
     if _cloud_connected():
         return {"required": False, "state": "managed", "source": "cloud"}
     return {"required": True, "state": "none", "source": "none"}

--- a/tests/test_onboarding_gate.py
+++ b/tests/test_onboarding_gate.py
@@ -26,6 +26,13 @@ def ob(monkeypatch, tmp_path):
     monkeypatch.setattr(mod, "_STATE_PATH", str(tmp_path / "onboarding.json"))
     monkeypatch.setattr(mod, "_license_state", lambda: "")
     monkeypatch.setattr(mod, "_cloud_connected", lambda: False)
+    # Isolate the desktop shell stamp path too: on a dev box with the
+    # real .app installed, ``_desktop_shell_stamp`` would read the real
+    # user's onboarding-completed.json and the fresh-install tests here
+    # would falsely see the machine as already-onboarded.
+    _shell_dir = tmp_path / "desktop-shell-runtime"
+    _shell_dir.mkdir()
+    monkeypatch.setattr(mod, "_desktop_shell_runtime_dir", lambda: _shell_dir)
     monkeypatch.setattr(mod, "_ping_onboarded", lambda choice: None)
     monkeypatch.setattr(mod, "_apply_marker_semantics", lambda choice: None)
     # Must never actually register/spawn a real daemon during a unit test —

--- a/tests/test_onboarding_state_reads_desktop_shell_stamp.py
+++ b/tests/test_onboarding_state_reads_desktop_shell_stamp.py
@@ -1,0 +1,274 @@
+"""Guard: the dashboard's onboarding gate recognises the desktop shell's
+own onboarding stamp — regardless of installer age.
+
+Bug pinned here (founder live-hit 2026-08-12, second failure of the
+same day): after fixing #4758 (shell writes ~/.clawmetry/onboarding.json
+when it completes onboarding), the founder reopened the .dmg they
+already had installed and STILL saw the "Welcome to ClawMetry / Where
+should ClawMetry keep an eye on your agents?" gate — because the .dmg
+they had was pre-#4758, so the shell never wrote the browser gate's
+file. The pip wheel auto-updates every 6h; the .app bundle only
+updates when the user redownloads. Any fix that lives only in
+``desktop/`` reaches users days late.
+
+This test pins the dashboard-side fix: ``_resolve_state()`` also reads
+the desktop shell's ``onboarding-completed.json`` (the file the shell
+has always written, from every .dmg version). That fix rides the pip
+wheel and reaches every install on the next auto-update.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+
+@pytest.fixture
+def isolated(tmp_path, monkeypatch):
+    """Fresh module import + tmp paths for the browser gate file, the
+    desktop shell stamp, and the nocloud marker."""
+    from routes import onboarding as m
+
+    # Redirect the browser gate's own state file into tmp.
+    gate_state = tmp_path / "browser_gate" / "onboarding.json"
+    monkeypatch.setattr(m, "_STATE_PATH", str(gate_state))
+
+    # Redirect the desktop shell's runtime dir into tmp.
+    shell_runtime = tmp_path / "shell_runtime"
+    shell_runtime.mkdir()
+    monkeypatch.setattr(m, "_desktop_shell_runtime_dir",
+                        lambda: shell_runtime)
+
+    # By default: no license, no cloud token, cloud enabled (no nocloud).
+    monkeypatch.setattr(m, "_license_state", lambda: "")
+    monkeypatch.setattr(m, "_cloud_connected", lambda: False)
+
+    yield m, gate_state, shell_runtime
+
+
+def _write_shell_stamp(shell_runtime: Path, payload: dict) -> None:
+    (shell_runtime / "onboarding-completed.json").write_text(
+        json.dumps(payload)
+    )
+
+
+def _write_gate_choice(gate_state: Path, choice: str) -> None:
+    gate_state.parent.mkdir(parents=True, exist_ok=True)
+    gate_state.write_text(json.dumps({"choice": choice, "completed_at": 1}))
+
+
+# ── Baseline: no stamps anywhere → gate prompts (unchanged behavior) ──
+
+def test_no_stamps_gate_required(isolated):
+    m, gate_state, shell_runtime = isolated
+    assert m._resolve_state() == {
+        "required": True, "state": "none", "source": "none",
+    }
+
+
+# ── The bug: shell stamped selfhost, dashboard now recognises it ──
+
+def test_new_dmg_selfhost_stamp_is_recognized(isolated):
+    """New .dmg (post-#4758) writes explicit mode=selfhost. Dashboard
+    treats it as selfhost_trial without touching the gate file."""
+    m, gate_state, shell_runtime = isolated
+    _write_shell_stamp(shell_runtime, {
+        "completed": True, "signed_in": True,
+        "provider": "github", "email": "u@example.com",
+        "mode": "selfhost",
+    })
+    result = m._resolve_state()
+    assert result == {
+        "required": False, "state": "selfhost_trial",
+        "source": "desktop_shell",
+    }
+    assert not gate_state.exists(), (
+        "The dashboard-side fix must not write the gate file — that "
+        "would race with #4758's shell-side write."
+    )
+
+
+def test_new_dmg_cloud_stamp_is_recognized(isolated):
+    m, gate_state, shell_runtime = isolated
+    _write_shell_stamp(shell_runtime, {
+        "completed": True, "signed_in": True,
+        "provider": "google", "email": "u@example.com",
+        "mode": "cloud",
+    })
+    result = m._resolve_state()
+    assert result["required"] is False
+    assert result["state"] == "managed"
+    assert result["source"] == "desktop_shell"
+
+
+# ── Old .dmg (pre-#4758) has no mode field. Infer from nocloud marker. ──
+
+def test_old_dmg_no_mode_with_nocloud_marker_is_selfhost(isolated, monkeypatch):
+    """Pre-#4758 stamp has no mode. Nocloud marker present (shell ran
+    `clawmetry connect --keep-local`) — self-host was the intent."""
+    m, gate_state, shell_runtime = isolated
+    _write_shell_stamp(shell_runtime, {
+        "completed": True, "signed_in": True,
+        "provider": "github", "email": "u@example.com",
+    })
+    monkeypatch.setattr(
+        "clawmetry.config.is_cloud_disabled", lambda: True,
+    )
+    result = m._resolve_state()
+    assert result == {
+        "required": False, "state": "selfhost_trial",
+        "source": "desktop_shell",
+    }
+
+
+def test_old_dmg_no_mode_without_nocloud_is_managed(isolated, monkeypatch):
+    """Pre-#4758 stamp, no nocloud marker → managed onboarding."""
+    m, gate_state, shell_runtime = isolated
+    _write_shell_stamp(shell_runtime, {
+        "completed": True, "signed_in": True,
+        "provider": "google", "email": "u@example.com",
+    })
+    monkeypatch.setattr(
+        "clawmetry.config.is_cloud_disabled", lambda: False,
+    )
+    result = m._resolve_state()
+    assert result["state"] == "managed"
+    assert result["source"] == "desktop_shell"
+
+
+# ── Dismissed shell pane MUST still prompt the browser gate ──
+
+def test_shell_stamp_without_signed_in_does_not_bypass_gate(isolated):
+    """User dismissed the shell pane without signing in. Shell stamps
+    signed_in=False so it doesn't re-prompt itself, but the dashboard
+    MUST still show the gate — the user owes a choice."""
+    m, gate_state, shell_runtime = isolated
+    _write_shell_stamp(shell_runtime, {
+        "completed": True, "signed_in": False,
+        "provider": "", "email": "", "mode": "",
+    })
+    result = m._resolve_state()
+    assert result["required"] is True
+
+
+def test_shell_stamp_without_completed_is_ignored(isolated):
+    m, gate_state, shell_runtime = isolated
+    _write_shell_stamp(shell_runtime, {
+        "completed": False, "signed_in": True, "mode": "selfhost",
+    })
+    result = m._resolve_state()
+    assert result["required"] is True
+
+
+# ── Non-desktop install: no stamp file, no change to existing behavior ──
+
+def test_pip_install_no_desktop_falls_through(isolated):
+    """User did `pip install clawmetry && clawmetry` without ever
+    touching the .app. No shell stamp exists → gate check runs the old
+    flow (this test is the same as the baseline; kept explicit so a
+    future refactor that reorders _resolve_state doesn't accidentally
+    require a shell dir)."""
+    m, gate_state, shell_runtime = isolated
+    result = m._resolve_state()
+    assert result["required"] is True
+
+
+# ── Precedence: license and browser-gate file still win ──
+
+def test_browser_gate_file_still_wins_over_shell_stamp(isolated):
+    """If the user goes through the BROWSER gate after the shell pane
+    (say they clicked something in the dashboard), the browser file is
+    the more recent explicit choice and must take precedence."""
+    m, gate_state, shell_runtime = isolated
+    _write_shell_stamp(shell_runtime, {
+        "completed": True, "signed_in": True, "mode": "selfhost",
+    })
+    _write_gate_choice(gate_state, "managed")
+    result = m._resolve_state()
+    assert result["state"] == "managed"
+    assert result["source"] == "gate"
+
+
+def test_local_license_still_wins_over_shell_stamp(isolated, monkeypatch):
+    """An active local license reflects the user's ACTUAL entitlement,
+    which is a stronger signal than the historical shell choice — a
+    trial-then-paid user's state should be their license, not the trial
+    stamp from months ago."""
+    m, gate_state, shell_runtime = isolated
+    _write_shell_stamp(shell_runtime, {
+        "completed": True, "signed_in": True, "mode": "selfhost",
+    })
+    monkeypatch.setattr(m, "_license_state", lambda: "selfhost_license")
+    result = m._resolve_state()
+    assert result["state"] == "selfhost_license"
+    assert result["source"] == "license"
+
+
+# ── Robustness ──
+
+def test_corrupt_shell_stamp_falls_through(isolated):
+    m, gate_state, shell_runtime = isolated
+    (shell_runtime / "onboarding-completed.json").write_text("not-json{")
+    result = m._resolve_state()
+    assert result["required"] is True
+
+
+def test_shell_stamp_wrong_shape_falls_through(isolated):
+    m, gate_state, shell_runtime = isolated
+    (shell_runtime / "onboarding-completed.json").write_text('"a string"')
+    result = m._resolve_state()
+    assert result["required"] is True
+
+
+def test_unknown_mode_infers_from_environment(isolated, monkeypatch):
+    m, gate_state, shell_runtime = isolated
+    _write_shell_stamp(shell_runtime, {
+        "completed": True, "signed_in": True, "mode": "banana",
+    })
+    monkeypatch.setattr(
+        "clawmetry.config.is_cloud_disabled", lambda: True,
+    )
+    # Unknown mode falls into the "infer" path, which returns
+    # selfhost_trial when nocloud is set.
+    assert m._resolve_state()["state"] == "selfhost_trial"
+
+
+# ── The shell-stamp-path shape is pinned so a rename is loud ──
+
+def test_shell_stamp_lives_under_ClawMetry_runtime():
+    """Path shape must stay in sync with
+    ``desktop/app.py::_runtime_dir`` — if the shell moves its stamp,
+    this test flags the rename before the fix silently stops firing."""
+    from routes import onboarding as m
+    p = m._desktop_shell_runtime_dir()
+    assert p.name == "runtime"
+    assert p.parent.name == "ClawMetry"
+
+
+# ── Revert-guard: the shell-stamp branch is actually WIRED into
+#    _resolve_state (not just present as a dead helper) ──
+
+def test_shell_stamp_branch_is_reachable_in_resolve_state(isolated):
+    """If a future refactor accidentally drops the ``_shell_stamp_choice``
+    call from ``_resolve_state``, this test goes red before the bug
+    ships. Contrived setup that only ``_shell_stamp_choice`` can
+    satisfy: no gate file, no license, no cloud, only a shell stamp."""
+    m, gate_state, shell_runtime = isolated
+    _write_shell_stamp(shell_runtime, {
+        "completed": True, "signed_in": True, "mode": "cloud",
+    })
+    result = m._resolve_state()
+    assert result["required"] is False, (
+        "_resolve_state stopped consulting _shell_stamp_choice — the "
+        "onboarding gate will re-prompt users who already completed "
+        "shell onboarding. See #4758 and the follow-up dashboard-side "
+        "fix."
+    )


### PR DESCRIPTION
## What is going on

Founder live-hit 2026-08-12 (second failure of the same day, on top of the modal you saw earlier): after completing the desktop shell's onboarding pane and picking Self-Host, the dashboard's **Welcome to ClawMetry / Where should ClawMetry keep an eye on your agents?** gate re-appeared on the very next screen.

## Where the desktop app stores its onboarding answer

`desktop/onboarding.py::mark_onboarding_completed` writes a stamp file at:

| OS | Path |
|----|------|
| macOS | `~/Library/Application Support/ClawMetry/runtime/onboarding-completed.json` |
| Windows | `%LOCALAPPDATA%/ClawMetry/runtime/onboarding-completed.json` |
| Linux | `${XDG_DATA_HOME:-~/.local/share}/ClawMetry/runtime/onboarding-completed.json` |

Payload: `{completed, signed_in, provider, email, mode}`. The `mode` field (`cloud`/`selfhost`) was added in #4758; pre-#4758 .dmg builds omit it.

The dashboard's `routes/onboarding.py::_resolve_state()` was **never reading this file** — so the shell's answer was invisible to the browser gate. The gate consulted only `~/.clawmetry/onboarding.json`, the local license, and the cloud token, all three of which are empty for a fresh Self-Host completion whose trial mint hasn't landed on disk yet.

## Why my earlier fix (#4758) didn't reach the user

`desktop/` ships **only** inside the .app bundle (PyInstaller-frozen); it is **not** in the pip wheel (I confirmed via `setup.py::packages` and `desktop/build_mac.spec`). So changes to `desktop/onboarding.py` reach a user only when they download a fresh `.dmg`. The pip wheel that serves the dashboard auto-updates every 6h. Any fix that lives in `desktop/` is deployment-lagged by however long between installer rebuilds — days at worst.

## The fix

Mirror the same idea on the pip-wheel side, where it reaches the whole fleet on the next 6h auto-update: `_resolve_state()` now also reads the desktop shell's `onboarding-completed.json` and treats `signed_in=True` as an explicit choice:

- **new-.dmg stamp** (has `mode` field) → return `managed` / `selfhost_trial` directly.
- **old-.dmg stamp** (no `mode` field) → infer from `~/.clawmetry/nocloud`, the same self-host intent signal `_cloud_connected()` already respects.
- **dismissed-pane stamp** (`signed_in=False`) → do NOT bypass the gate; the user still owes a choice.

Precedence in `_resolve_state()`: explicit browser gate file → active local license → shell stamp → cloud token. Shell check sits below the license check so trial-then-paid users' state reflects their actual entitlement rather than the historical shell choice.

Path shape mirrors `desktop/app.py::_runtime_dir` byte-for-byte — duplicated (not imported) because the pip wheel doesn't ship `desktop/`. A test pins the path shape so a future rename in either place is loud.

## Also fixed

`tests/test_onboarding_gate.py` fixture didn't isolate the shell stamp path. On a dev box with the real `.app` installed (like mine), the pre-fix fixture let the fresh-install test read my real user's stamp and falsely see the machine as already-onboarded. Fixture now points at a tmp dir.

## Test plan

- [x] `pytest tests/test_onboarding_state_reads_desktop_shell_stamp.py -v` — 15 tests green.
- [x] `pytest tests/ -k onboard -q` — 97 passed (existing + new).
- [x] Wire-up guard: a test named `test_shell_stamp_branch_is_reachable_in_resolve_state` fails loudly if a future refactor drops the `_shell_stamp_choice()` call.
- [ ] Ride the next `[RELEASE]`, wait for PyPI wheel + 6h auto-update, then reopen the current .dmg → dashboard should load straight into content, no gate re-prompt.
- [ ] On a fresh install with no `.app`, gate still shows on first dashboard load (pip-only users unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)