### PR TITLE
fix(desktop-artifacts): install libgirepository-2.0-dev so Linux job stops blocking every release

### DIFF
--- a/.github/workflows/desktop-artifacts.yml
+++ b/.github/workflows/desktop-artifacts.yml
@@ -337,15 +337,31 @@ jobs:
         run: |
           sudo apt-get update
           # GTK WebKit2 is the pywebview backend on Linux. The
-          # libgirepository1.0-dev / libcairo2-dev / pkg-config trio is
+          # libgirepository-2.0-dev / libcairo2-dev / pkg-config trio is
           # needed to compile PyGObject (see requirements-dev.txt) against
           # THIS job's actions/setup-python interpreter — without a
           # matching build, the frozen binary can't import `gi` at all
           # and crashes before ever opening a window.
+          #
+          # PyGObject 3.52+ (we pin 3.56.3) requires girepository-2.0 —
+          # 3.50.x was the last release on girepository-1.0. This job was
+          # installing ONLY libgirepository1.0-dev, so every meson build
+          # failed at `Dependency 'girepository-2.0' is required but not
+          # found`, the whole Linux job errored out, the strict attach
+          # step (fail_on_unmatched_files: true) skipped publishing, every
+          # release since 2026-08-10 stayed a draft, and
+          # ``releases/latest`` kept serving the 2026-08-10 build. Users
+          # downloading from clawmetry.com never got any fix shipped
+          # after that date — including the SSL cert verify fix (#4752)
+          # that the "Send code" button depends on. Install both -1.0
+          # (still needed for webkit2gtk-4.1 headers on older subdeps)
+          # and -2.0 (what PyGObject 3.52+ compiles against). ubuntu-24.04
+          # (current ubuntu-latest) has both in the default archive.
           sudo apt-get install -y \
             libgtk-3-0 libwebkit2gtk-4.1-0 gir1.2-webkit2-4.1 \
             libayatana-appindicator3-1 libnotify4 \
-            libgirepository1.0-dev libcairo2-dev pkg-config
+            libgirepository1.0-dev libgirepository-2.0-dev \
+            libcairo2-dev pkg-config
 
       - name: Install build deps
         run: |


### PR DESCRIPTION
## Root cause of "user still sees SSL cert verify failed days after #4752"

`desktop-artifacts.yml` has been failing on every run since 2026-08-10. Consequence: the download links on `clawmetry.com` (which resolve through `releases/latest/download/<file>`) still serve the **v0.12.681 .dmg from 2026-08-10**. Every desktop fix shipped after that date — including #4752's SSL cert-verify fix that the "Send code" button depends on — is stuck in an unpublished draft release. That's why the user's OTP send still errors with `CERTIFICATE_VERIFY_FAILED`.

## The failure chain

1. PyGObject 3.52+ (we pin 3.56.3) compiles against `girepository-2.0`. 3.50.x was the last release on `girepository-1.0`.
2. The Linux job installed only `libgirepository1.0-dev`, so meson-python built PyGObject and hit `Dependency 'girepository-2.0' is required but not found` — every run, deterministically.
3. Linux fails → macOS + Windows still **succeed** (their artifacts sit in the workflow-artifacts store, unreleased) → the attach step `needs: [macos, windows, linux]` never runs → the draft release that `release-on-merge.yml` created stays a draft.
4. Drafts are invisible to `releases/latest`, so every download link on `clawmetry.com` keeps serving the last complete release: **v0.12.681 from 2026-08-10**. Four draft releases sit unpublished: v0.12.682, v0.12.683, v0.12.685, v0.12.686.

## Fix

Install `libgirepository-2.0-dev` in addition to `-1.0` (the older one is kept because subdeps of `webkit2gtk-4.1` still reference the 1.0 headers). `ubuntu-24.04` (current `ubuntu-latest`) has both in the default archive, so no PPA needed.

## After this merges

1. This unblocks `release-on-merge` → `desktop-artifacts` → `publish` for every subsequent `[RELEASE]`.
2. The four already-draft releases (v0.12.682, v0.12.683, v0.12.685, v0.12.686) need one manual `gh workflow run desktop-artifacts.yml --ref v0.12.686` to build and publish, since the release tags are already cut — they don't retroactively re-fire.
3. After that manual run finishes, `releases/latest` flips to v0.12.686 (which carries every fix through #4763), the download links stop serving the 2026-08-10 build, and the user's OTP button starts working on the fresh .dmg.

## Test plan

- [ ] CI on this PR includes running `desktop-artifacts.yml` — Linux job goes green (or at least gets past the girepository step).
- [ ] After merge, manual `gh workflow run desktop-artifacts.yml --ref v0.12.686` — all three OS jobs succeed, attach step publishes the release.
- [ ] `curl -sIL https://github.com/vivekchand/clawmetry/releases/latest/download/ClawMetry-mac.dmg | head -1` shows 302 → asset landed on the newest tag.
- [ ] User redownloads .dmg, clicks Send code — OTP arrives without SSL error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)