### PR TITLE
feat(entitlement): has_all_bundle + has_all_bundle_at + /api/entitlement/has-all-bundle{,-at}

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -12822,6 +12822,47 @@ def _has_all_bundle_row(bundle) -> dict:
     }
 
 
+def has_all_bundle(bundle) -> dict:
+    """Row-detail scalar sibling of :func:`has_all_bundle_batch` for ONE
+    aggregate 5-axis bundle.
+
+    Folds ONE ``{features, runtimes, channels, retention_days, nodes}``
+    bundle to the canonical batch-row shape at the LIVE resolver.
+    A caller that already holds a bundle in batch-row shape (from an
+    upstream :func:`has_all_bundle_batch` echo, a paywall matrix cell,
+    or an upgrade-walkthrough tile that renders one bundle at a time)
+    can re-fold it here without wrapping in a length-one list and
+    unwrapping ``[0]``.
+
+    Distinct from :func:`has_all` (whose diagnostic envelope carries
+    unknown-token splits, ``required_tier`` resolution, and the
+    ``upgrade_required`` rollup): this returns the stripped six-key row
+    shape the bundle-batch family emits so a UI wiring the singular and
+    the batch off the same helper sees byte-identical rows.
+
+    Delegates row construction to :func:`_has_all_bundle_row` so the
+    scalar cannot drift from the batch row helper. Grace posture
+    mirrors :func:`has_all` byte-for-byte: while ``ent.grace`` is
+    ``True`` every fully-known bundle reports ``has_all=True``.
+
+    Never raises: a delegate failure returns the empty row shape
+    (``has_all=False``) so a caller wiring the scalar into a gate
+    cannot 500 on a malformed bundle.
+    """
+    try:
+        return _has_all_bundle_row(bundle)
+    except Exception as exc:
+        logger.warning("entitlements: has_all_bundle fold failed: %s", exc)
+        return {
+            "features": [],
+            "runtimes": [],
+            "channels": None,
+            "retention_days": None,
+            "nodes": None,
+            "has_all": False,
+        }
+
+
 def has_all_bundle_batch(bundles) -> list[dict]:
     """Per-bundle aggregate boolean-fold grant for N caller-supplied
     5-axis bundles in ONE round-trip.
@@ -12979,6 +13020,62 @@ def _has_all_bundle_row_at(perspective_tier: str, bundle) -> dict:
         "nodes": nodes,
         "has_all_at": bool(allowed),
     }
+
+
+def has_all_bundle_at(perspective_tier: str, bundle) -> dict | None:
+    """Perspective-shaped row-detail scalar sibling of
+    :func:`has_all_bundle_batch_at` for ONE aggregate 5-axis bundle.
+
+    Folds ONE ``{features, runtimes, channels, retention_days, nodes}``
+    bundle to the canonical batch-row shape against the STATIC
+    per-tier grant tables for ``perspective_tier`` (the ``_at`` slot).
+    Grace-independent by construction: the delegate
+    :func:`_has_all_bundle_row_at` reads from
+    :func:`_hypothetical_entitlement` on the feature / runtime axes
+    and :data:`_TIER_CHANNEL_LIMIT` / :data:`_TIER_RETENTION_DAYS` /
+    :data:`_TIER_NODE_LIMIT` on the capacity axes, so the row body is
+    byte-identical under grace vs enforce for the same
+    ``(perspective, bundle)`` pair.
+
+    Fills the singular-row slot alongside :func:`has_all_bundle` so a
+    paywall walkthrough tile rendering one hypothetical cell at a time
+    ("from Starter, would this whole bundle land granted?") reads the
+    perspective answer without wrapping in a length-one list and
+    unwrapping ``[0]`` from :func:`has_all_bundle_batch_at`.
+
+    Returns ``None`` for an empty / blank / non-string / unknown
+    ``perspective_tier`` -- matches the ``None``-on-unknown posture of
+    :func:`has_all_bundle_batch_at`, :func:`has_all_at`,
+    :func:`min_tier_for_all_at`, and the paired
+    ``/api/entitlement/has-all-bundle-at?tier=`` endpoint (which 400s
+    on missing / blank and 404s on unknown).
+
+    Never raises on the bundle side: a delegate failure on a valid
+    perspective returns the empty row shape (``has_all_at=False``) so a
+    caller wiring the scalar into a gate cannot 500 on a malformed
+    bundle.
+    """
+    if not isinstance(perspective_tier, str):
+        return None
+    tier_key = perspective_tier.strip().lower()
+    if not tier_key or tier_key not in _TIER_ORDER:
+        return None
+    try:
+        return _has_all_bundle_row_at(tier_key, bundle)
+    except Exception as exc:
+        logger.warning(
+            "entitlements: has_all_bundle_at(%r) fold failed: %s",
+            perspective_tier,
+            exc,
+        )
+        return {
+            "features": [],
+            "runtimes": [],
+            "channels": None,
+            "retention_days": None,
+            "nodes": None,
+            "has_all_at": False,
+        }
 
 
 def has_all_bundle_batch_at(

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -39918,6 +39918,261 @@ def _has_all_bundle_row_at_to_body(row: dict) -> dict:
     }
 
 
+def _parse_single_bundle_body(body, key: str = "bundle"):
+    """Extract ONE aggregate 5-axis bundle dict from a JSON POST body.
+
+    Singular sibling of :func:`_parse_aggregate_bundles_body` for the
+    scalar ``/has-all-bundle`` / ``/has-all-bundle-at`` endpoints. Accepts
+    either ``{"bundle": {"features": ["fleet"], ...}}`` (the wrapped
+    form matching every other singular POST body in this module) or the
+    bare-dict shorthand ``{"features": ["fleet"], ...}`` (so a caller
+    can post the same body they would GET on ``/has-all`` as one dict
+    without an outer wrapper).
+
+    Returns ``(bundle, err)`` with ``err`` ``None`` on success, or one
+    of:
+
+    * ``bundle_must_be_object`` -- the top-level body is not a dict,
+      OR ``body[key]`` is present but is not a dict.
+    * ``missing`` -- neither ``body[key]`` nor a bare shorthand is
+      present (i.e. body is ``{}`` or contains only unrelated keys).
+
+    A blank ``body[key]={}`` (explicit empty bundle) is a valid input
+    and returns ``({}, None)`` -- the fold layer collapses it to the
+    stable empty row (``has_all=False``) matching the ``has_all`` empty
+    posture.
+    """
+    if not isinstance(body, dict):
+        return None, "bundle_must_be_object"
+    if key in body:
+        raw = body.get(key)
+        if raw is None:
+            return None, "missing"
+        if not isinstance(raw, dict):
+            return None, "bundle_must_be_object"
+        return dict(raw), None
+    # Shorthand: bare-dict body IS the bundle (matches /has-all GET args).
+    known = ("features", "runtimes", "channels", "retention_days", "nodes")
+    if any(axis in body for axis in known):
+        return {axis: body[axis] for axis in known if axis in body}, None
+    return None, "missing"
+
+
+@bp_entitlement.route(
+    "/api/entitlement/has-all-bundle",
+    methods=["POST"],
+)
+def api_entitlement_has_all_bundle():
+    """``POST /api/entitlement/has-all-bundle`` -- singular row-detail
+    scalar sibling of ``/api/entitlement/has-all-bundle-batch``.
+
+    Folds ONE caller-supplied aggregate 5-axis bundle
+    (``features + runtimes + channels + retention_days + nodes``) to
+    the canonical batch-row shape at the LIVE resolver in one
+    round-trip so a paywall walkthrough tile rendering one bundle
+    cell at a time (an upgrade-walkthrough carousel, a "does this
+    hypothetical config land granted?" diagnostics popover) reads the
+    row without wrapping in a length-one list and unwrapping ``[0]``
+    from ``/has-all-bundle-batch``.
+
+    Distinct from the singular ``/api/entitlement/has-all`` GET
+    endpoint (whose 19-key diagnostic envelope carries unknown-token
+    splits, ``required_tier`` resolution, and the ``upgrade_required``
+    rollup): this returns the stripped six-key batch-row shape so a UI
+    wiring the singular and the batch off the same helper sees
+    byte-identical rows. Post-tier switch or grace flip the two
+    endpoints stay in lockstep because :func:`has_all_bundle` delegates
+    to the same :func:`_has_all_bundle_row` helper as the batch.
+
+    POST rather than GET so the request body is byte-identical to the
+    batch endpoint's per-row shape -- a caller with a single bundle in
+    hand can POST it as-is without stitching a CSV query string.
+
+    Request body::
+
+        {"bundle": {"features": ["fleet"], "runtimes": ["claude_code"],
+                    "channels": 5, "retention_days": 30, "nodes": 2}}
+
+    A shorthand where the top-level body IS the bundle
+    (``{"features": ["fleet"]}``) is also accepted so the same body the
+    ``/has-all`` GET endpoint takes as query args maps 1:1 to a POST
+    body. Missing / non-object ``bundle`` value is a 400.
+
+    Response layers the resolver envelope on top of the batch-row
+    shape (byte-identical to the batch's per-row body plus the
+    envelope so a caller can render "on <tier>, is this granted?"
+    without a second call)::
+
+        {
+          "features":          ["fleet"],
+          "runtimes":          ["claude_code"],
+          "channels":          5 | null,
+          "retention_days":    30 | null,
+          "nodes":             2 | null,
+          "has_all":           <bool>,
+          "current_tier":      "...",
+          "current_tier_rank": <int>,
+          "grace":             <bool>,
+          "enforced":          <bool>,
+        }
+
+    - **400** when ``bundle`` is missing / non-object.
+    - **Never 5xxs**: a resolver failure yields the fallback envelope
+      (empty row shape with ``has_all=false``) so the paywall tile
+      keeps rendering.
+    """
+    body = request.get_json(silent=True) or {}
+    bundle, err = _parse_single_bundle_body(body)
+    if err == "missing":
+        return jsonify({"error": "missing bundle"}), 400
+    if err == "bundle_must_be_object":
+        return jsonify({"error": "bundle must be an object"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        row = _ent.has_all_bundle(bundle)
+        out = _has_all_bundle_row_to_body(row)
+        env = _resolver_envelope(_ent)
+        return jsonify({**out, **env})
+    except Exception as exc:
+        logger.warning("api_entitlement_has_all_bundle: error: %s", exc)
+        return jsonify(
+            {
+                "features": [],
+                "runtimes": [],
+                "channels": None,
+                "retention_days": None,
+                "nodes": None,
+                "has_all": False,
+                "current_tier": "oss",
+                "current_tier_rank": 0,
+                "grace": True,
+                "enforced": False,
+            }
+        )
+
+
+@bp_entitlement.route(
+    "/api/entitlement/has-all-bundle-at",
+    methods=["POST"],
+)
+def api_entitlement_has_all_bundle_at():
+    """``POST /api/entitlement/has-all-bundle-at?tier=<perspective>`` --
+    hypothetical-perspective sibling of
+    ``/api/entitlement/has-all-bundle``.
+
+    Wraps :func:`clawmetry.entitlements.has_all_bundle_at` so a
+    pricing-matrix or upgrade-walkthrough tile can call the aggregate
+    boolean-fold singular from any tier's perspective without first
+    switching the resolver. Fills the ``_at`` slot for the singular
+    aggregate-bundle boolean-fold family alongside the batch
+    ``/has-all-bundle-batch-at`` and the ``_at`` siblings of the
+    per-single-axis bundle helpers so a caller can call the
+    perspective-scoped singular uniformly across every ``_at`` family.
+
+    Grace-independent by construction: :func:`has_all_bundle_at` reads
+    from the static per-tier grant tables via
+    :func:`_hypothetical_entitlement` on the feature / runtime axes and
+    :data:`_TIER_CHANNEL_LIMIT` / :data:`_TIER_RETENTION_DAYS` /
+    :data:`_TIER_NODE_LIMIT` on the capacity axes, so the row body is
+    byte-identical under grace vs enforce for the same
+    ``(perspective, bundle)`` pair. Whole point of the ``_at`` slot: at
+    ``tier=oss`` a paid-feature bundle reports ``has_all_at=false`` even
+    in grace, whereas the LIVE ``/has-all-bundle`` reports
+    ``has_all=true`` for the same bundle via grace pass-through.
+
+    Request body is byte-identical to ``/has-all-bundle``. The extra
+    ``tier=<perspective>`` query arg is required.
+
+    Response layers ``perspective_tier`` /
+    ``perspective_tier_label`` / ``perspective_tier_rank`` on top of
+    the singular row body with the fold slot renamed ``has_all_at``::
+
+        {
+          "perspective_tier":       "cloud_pro",
+          "perspective_tier_label": "Cloud Pro",
+          "perspective_tier_rank":  <int>,
+          "features":               ["fleet"],
+          "runtimes":               ["claude_code"],
+          "channels":               5 | null,
+          "retention_days":         30 | null,
+          "nodes":                  2 | null,
+          "has_all_at":             <bool>,
+          "current_tier":           "...",
+          "current_tier_rank":      <int>,
+          "grace":                  <bool>,
+          "enforced":               <bool>,
+        }
+
+    - **400** when ``tier=`` is missing / blank.
+    - **404** when ``tier`` is unknown (body carries ``which=tier`` so
+      a caller can render the right "unknown tier" message).
+    - **400** when ``bundle`` is missing / non-object.
+    - **Never 5xxs**: a resolver failure yields the fallback envelope
+      so the paywall matrix keeps rendering.
+    """
+    raw_tier = request.args.get("tier")
+    tier_in = (raw_tier or "").strip().lower()
+    if not tier_in:
+        return jsonify({"error": "missing tier"}), 400
+    body = request.get_json(silent=True) or {}
+    bundle, err = _parse_single_bundle_body(body)
+    if err == "missing":
+        return jsonify({"error": "missing bundle"}), 400
+    if err == "bundle_must_be_object":
+        return jsonify({"error": "bundle must be an object"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        if tier_in not in _ent._TIER_ORDER:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "tier", "tier": tier_in}
+                ),
+                404,
+            )
+        row = _ent.has_all_bundle_at(tier_in, bundle) or {
+            "features": [],
+            "runtimes": [],
+            "channels": None,
+            "retention_days": None,
+            "nodes": None,
+            "has_all_at": False,
+        }
+        out = _has_all_bundle_row_at_to_body(row)
+        env = _resolver_envelope(_ent)
+        label = _ent.tier_label(tier_in)
+        rank = _ent.tier_rank(tier_in)
+        return jsonify(
+            {
+                "perspective_tier": tier_in,
+                "perspective_tier_label": label,
+                "perspective_tier_rank": rank,
+                **out,
+                **env,
+            }
+        )
+    except Exception as exc:
+        logger.warning("api_entitlement_has_all_bundle_at: error: %s", exc)
+        return jsonify(
+            {
+                "perspective_tier": tier_in,
+                "perspective_tier_label": None,
+                "perspective_tier_rank": -1,
+                "features": [],
+                "runtimes": [],
+                "channels": None,
+                "retention_days": None,
+                "nodes": None,
+                "has_all_at": False,
+                "current_tier": "oss",
+                "current_tier_rank": 0,
+                "grace": True,
+                "enforced": False,
+            }
+        )
+
+
 @bp_entitlement.route(
     "/api/entitlement/has-all-bundle-batch",
     methods=["POST"],

--- a/tests/test_entitlement_has_all_bundle.py
+++ b/tests/test_entitlement_has_all_bundle.py
@@ -1,0 +1,576 @@
+"""Tests for the singular row-detail
+``/api/entitlement/has-all-bundle`` and
+``/api/entitlement/has-all-bundle-at`` endpoints (plus their
+:func:`clawmetry.entitlements.has_all_bundle` /
+:func:`clawmetry.entitlements.has_all_bundle_at` helpers).
+
+Fills the singular-row slot for the aggregate 5-axis bundle boolean-fold
+family alongside the batch ``/has-all-bundle-batch`` /
+``/has-all-bundle-batch-at`` endpoints so a paywall walkthrough tile
+rendering one hypothetical whole-config cell at a time reads the row
+without wrapping in a length-one list and unwrapping ``[0]`` from the
+batch.
+
+Distinct from the singular ``/api/entitlement/has-all`` GET endpoint
+(whose 19-key diagnostic envelope carries unknown-token splits,
+``required_tier`` resolution, and the ``upgrade_required`` rollup): the
+singulars here return the stripped six-key batch-row shape so a UI
+wiring the singular and the batch off the same helper sees byte-
+identical rows across the two endpoints.
+
+These tests pin:
+
+* helper: row shape byte-parity with :func:`has_all_bundle_batch`
+* helper: never-crash on ``None`` / non-dict / scalar bundle inputs
+* helper: perspective-shaping of the ``_at`` variant (deliberate
+  divergence from the LIVE helper at OSS in grace: paid feature -> False)
+* helper: perspective-validation ``None`` posture on the ``_at`` variant
+  (empty / blank / non-string / unknown perspective -> ``None``)
+* API happy path: shape (batch row + resolver envelope), 200
+* API error paths: 400 on missing / non-object ``bundle``
+* API bare-dict shorthand (top-level body IS the bundle)
+* API per-body byte-equals the batch's per-row body on the same bundle
+* API ``_at`` perspective envelope keys + 400 on missing ``tier=``,
+  404 on unknown ``tier=``, 400 on missing ``bundle``
+* API never-5xxs on a delegate crash
+* Grace vs enforce parity on the LIVE endpoint; grace-independence on
+  the ``_at`` endpoint's ``has_all_at`` fold
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+# -- Fixtures ------------------------------------------------------------------
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def enforced(monkeypatch, tmp_path):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    importlib.reload(e)
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# -- Row shape constants -------------------------------------------------------
+
+
+_LIVE_ROW_KEYS = {
+    "features",
+    "runtimes",
+    "channels",
+    "retention_days",
+    "nodes",
+    "has_all",
+}
+
+_AT_ROW_KEYS = {
+    "features",
+    "runtimes",
+    "channels",
+    "retention_days",
+    "nodes",
+    "has_all_at",
+}
+
+_LIVE_ENVELOPE_KEYS = _LIVE_ROW_KEYS | {
+    "current_tier",
+    "current_tier_rank",
+    "grace",
+    "enforced",
+}
+
+_AT_ENVELOPE_KEYS = _AT_ROW_KEYS | {
+    "perspective_tier",
+    "perspective_tier_label",
+    "perspective_tier_rank",
+    "current_tier",
+    "current_tier_rank",
+    "grace",
+    "enforced",
+}
+
+
+# -- helper: has_all_bundle -----------------------------------------------------
+
+
+def test_helper_scalar_folds_across_all_five_axes(ent):
+    row = ent.has_all_bundle(
+        {
+            "features": ["fleet"],
+            "runtimes": ["claude_code"],
+            "channels": 5,
+            "retention_days": 30,
+            "nodes": 2,
+        }
+    )
+    assert set(row.keys()) == _LIVE_ROW_KEYS
+    assert row["features"] == ["fleet"]
+    assert row["runtimes"] == ["claude_code"]
+    assert row["channels"] == 5
+    assert row["retention_days"] == 30
+    assert row["nodes"] == 2
+    # Grace pass-through: LIVE fold reports True for every fully-known
+    # bundle while ent.grace is on.
+    assert row["has_all"] is True
+
+
+def test_helper_scalar_row_byte_equals_batch_row(ent):
+    """Row shape byte-parity contract: the singular row byte-equals
+    the batch row for the same bundle, on every axis + fold + shape."""
+    bundles = [
+        {"features": ["fleet"], "runtimes": ["claude_code"]},
+        {"channels": 5},
+        {"retention_days": 30, "nodes": 2},
+        {"features": ["sso"]},
+        {"features": ["FLEET", "fleet"], "runtimes": ["claude-code"]},
+        {"channels": "abc", "retention_days": "", "nodes": None},
+        {},
+    ]
+    for bundle in bundles:
+        singular = ent.has_all_bundle(bundle)
+        batch = ent.has_all_bundle_batch([bundle])[0]
+        assert singular == batch
+
+
+def test_helper_scalar_empty_bundle_is_stable_row(ent):
+    row = ent.has_all_bundle({})
+    assert set(row.keys()) == _LIVE_ROW_KEYS
+    assert row["features"] == []
+    assert row["runtimes"] == []
+    assert row["channels"] is None
+    assert row["retention_days"] is None
+    assert row["nodes"] is None
+    # Empty bundle: no axes supplied -> False (matches has_all).
+    assert row["has_all"] is False
+
+
+def test_helper_scalar_none_bundle_is_stable_row(ent):
+    """Never-crash on ``None`` bundle: delegate returns a stable empty
+    row shape (matches the batch's non-dict-row collapse)."""
+    row = ent.has_all_bundle(None)
+    assert set(row.keys()) == _LIVE_ROW_KEYS
+    assert row["has_all"] is False
+
+
+def test_helper_scalar_non_dict_bundle_is_stable_row(ent):
+    """Non-dict input (scalar, list) collapses to the empty row shape."""
+    for bad in ("not a dict", 42, [1, 2, 3]):
+        row = ent.has_all_bundle(bad)
+        assert set(row.keys()) == _LIVE_ROW_KEYS
+        assert row["features"] == []
+        assert row["has_all"] is False
+
+
+def test_helper_scalar_paid_bundle_true_in_grace(ent):
+    """Grace pass-through contract: paid bundle -> True in grace."""
+    paid_f = next(iter(ent.PAID_FEATURES))
+    paid_r = next(iter(ent.PAID_RUNTIMES))
+    bundle = {"features": [paid_f], "runtimes": [paid_r], "channels": 999}
+    assert ent.has_all_bundle(bundle)["has_all"] is True
+
+
+def test_helper_scalar_paid_bundle_false_when_enforced(enforced):
+    """Post-enforcement: paid bundle folds through the LIVE resolver's
+    per-axis grants -- OSS-shaped install denies the paid feature."""
+    paid_f = next(iter(enforced.PAID_FEATURES))
+    row = enforced.has_all_bundle({"features": [paid_f]})
+    assert row["has_all"] is False
+
+
+# -- helper: has_all_bundle_at (perspective-shaped) ---------------------------
+
+
+def test_helper_scalar_at_shapes_by_perspective(ent):
+    """Whole point of the ``_at`` slot: at OSS a paid-feature bundle
+    reports has_all_at=False even in grace (grace-independent by design)
+    where the LIVE helper reports has_all=True via grace pass-through."""
+    paid_f = next(iter(ent.PAID_FEATURES))
+    bundle = {"features": [paid_f]}
+    live = ent.has_all_bundle(bundle)
+    at_oss = ent.has_all_bundle_at("oss", bundle)
+    assert live["has_all"] is True  # grace pass-through
+    assert at_oss["has_all_at"] is False  # static OSS grant table
+    assert set(at_oss.keys()) == _AT_ROW_KEYS
+
+
+def test_helper_scalar_at_enterprise_grants_everything(ent):
+    """Enterprise perspective grants every axis in the catalog."""
+    paid_f = next(iter(ent.PAID_FEATURES))
+    paid_r = next(iter(ent.PAID_RUNTIMES))
+    bundle = {
+        "features": [paid_f],
+        "runtimes": [paid_r],
+        "channels": 100,
+        "retention_days": 365,
+        "nodes": 100,
+    }
+    row = ent.has_all_bundle_at("enterprise", bundle)
+    assert row["has_all_at"] is True
+
+
+def test_helper_scalar_at_row_byte_equals_batch_row_at(ent):
+    """Row shape byte-parity contract for the ``_at`` variant: the
+    singular row byte-equals the batch row on the same
+    (perspective, bundle)."""
+    paid_f = next(iter(ent.PAID_FEATURES))
+    perspectives = ["oss", "cloud_starter", "cloud_pro", "enterprise"]
+    bundles = [
+        {"features": ["fleet"]},
+        {"runtimes": ["claude_code"]},
+        {"features": [paid_f]},
+        {"channels": 5},
+        {"retention_days": 30, "nodes": 2},
+        {},
+    ]
+    for tier in perspectives:
+        for bundle in bundles:
+            singular = ent.has_all_bundle_at(tier, bundle)
+            batch = ent.has_all_bundle_batch_at(tier, [bundle])[0]
+            assert singular == batch
+
+
+def test_helper_scalar_at_grace_independent(ent, enforced):
+    """Grace-independence contract: has_all_bundle_at row body is
+    byte-identical under grace vs enforce for the same
+    (perspective, bundle)."""
+    paid_f = next(iter(ent.PAID_FEATURES))
+    for bundle in (
+        {"features": ["fleet"]},
+        {"features": [paid_f]},
+        {"channels": 5},
+        {},
+    ):
+        for tier in ("oss", "cloud_starter", "cloud_pro", "enterprise"):
+            grace_row = ent.has_all_bundle_at(tier, bundle)
+            enforce_row = enforced.has_all_bundle_at(tier, bundle)
+            assert grace_row == enforce_row
+
+
+def test_helper_scalar_at_unknown_perspective_returns_none(ent):
+    for bad in ("bogus", "starter", "cloud-pro", "OSS_TYPO"):
+        assert ent.has_all_bundle_at(bad, {"features": ["fleet"]}) is None
+
+
+def test_helper_scalar_at_blank_perspective_returns_none(ent):
+    for bad in ("", "   ", None, 42, [], {}):
+        assert ent.has_all_bundle_at(bad, {"features": ["fleet"]}) is None
+
+
+def test_helper_scalar_at_perspective_case_normalised(ent):
+    """Perspective tier is ``.strip().lower()``-canonicalised so an
+    upper-case perspective still resolves rather than falling through
+    to ``None`` on the unknown-perspective branch."""
+    ref = ent.has_all_bundle_at("oss", {"features": ["fleet"]})
+    for variant in ("OSS", "  oss  ", "Oss"):
+        assert ent.has_all_bundle_at(variant, {"features": ["fleet"]}) == ref
+
+
+# -- API: /api/entitlement/has-all-bundle -------------------------------------
+
+
+def test_api_happy_path_shape(client):
+    r = client.post(
+        "/api/entitlement/has-all-bundle",
+        json={
+            "bundle": {
+                "features": ["fleet"],
+                "runtimes": ["claude_code"],
+                "channels": 5,
+                "retention_days": 30,
+                "nodes": 2,
+            }
+        },
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert set(body.keys()) == _LIVE_ENVELOPE_KEYS
+    assert body["features"] == ["fleet"]
+    assert body["runtimes"] == ["claude_code"]
+    assert body["channels"] == 5
+    assert body["retention_days"] == 30
+    assert body["nodes"] == 2
+    assert body["has_all"] is True  # grace pass-through
+    assert body["grace"] is True
+    assert body["enforced"] is False
+
+
+def test_api_bare_dict_shorthand(client):
+    """Top-level body IS the bundle (matches the shape a caller would
+    hand to the ``/has-all`` GET endpoint as query args)."""
+    r = client.post(
+        "/api/entitlement/has-all-bundle",
+        json={"features": ["fleet"], "channels": 5},
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["features"] == ["fleet"]
+    assert body["channels"] == 5
+
+
+def test_api_wrapped_and_shorthand_equivalent(client):
+    wrapped = client.post(
+        "/api/entitlement/has-all-bundle",
+        json={"bundle": {"features": ["fleet"]}},
+    ).get_json()
+    shorthand = client.post(
+        "/api/entitlement/has-all-bundle",
+        json={"features": ["fleet"]},
+    ).get_json()
+    assert wrapped == shorthand
+
+
+def test_api_400_missing_bundle(client):
+    r = client.post("/api/entitlement/has-all-bundle", json={})
+    assert r.status_code == 400
+    assert r.get_json() == {"error": "missing bundle"}
+
+
+def test_api_400_bundle_null(client):
+    r = client.post("/api/entitlement/has-all-bundle", json={"bundle": None})
+    assert r.status_code == 400
+    assert r.get_json() == {"error": "missing bundle"}
+
+
+def test_api_400_bundle_not_object(client):
+    r = client.post(
+        "/api/entitlement/has-all-bundle", json={"bundle": [1, 2, 3]}
+    )
+    assert r.status_code == 400
+    assert r.get_json() == {"error": "bundle must be an object"}
+
+
+def test_api_row_byte_equals_batch_row(client):
+    """Cross-endpoint per-row parity contract: the singular endpoint's
+    row body byte-equals the batch endpoint's per-row body for the same
+    bundle."""
+    bundles = [
+        {"features": ["fleet"]},
+        {"channels": 5},
+        {"features": ["FLEET"], "runtimes": ["claude-code"]},
+        {},
+    ]
+    for bundle in bundles:
+        s = client.post(
+            "/api/entitlement/has-all-bundle", json={"bundle": bundle}
+        ).get_json()
+        b = client.post(
+            "/api/entitlement/has-all-bundle-batch",
+            json={"bundles": [bundle]},
+        ).get_json()
+        # Strip envelope keys before comparing per-row body.
+        s_row = {k: v for k, v in s.items() if k in _LIVE_ROW_KEYS}
+        b_row = b["bundles"][0]
+        assert s_row == b_row
+
+
+def test_api_empty_bundle_is_stable_row(client):
+    r = client.post(
+        "/api/entitlement/has-all-bundle", json={"bundle": {}}
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["features"] == []
+    assert body["runtimes"] == []
+    assert body["channels"] is None
+    assert body["retention_days"] is None
+    assert body["nodes"] is None
+    assert body["has_all"] is False
+
+
+def test_api_never_5xxs_on_delegate_crash(client, monkeypatch):
+    from clawmetry import entitlements as _ent
+
+    def boom(*a, **kw):
+        raise RuntimeError("simulated resolver blowup")
+
+    monkeypatch.setattr(_ent, "has_all_bundle", boom)
+    r = client.post(
+        "/api/entitlement/has-all-bundle",
+        json={"bundle": {"features": ["fleet"]}},
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert set(body.keys()) == _LIVE_ENVELOPE_KEYS
+    assert body["has_all"] is False
+
+
+# -- API: /api/entitlement/has-all-bundle-at ----------------------------------
+
+
+def test_api_at_happy_path_shape(client):
+    r = client.post(
+        "/api/entitlement/has-all-bundle-at?tier=enterprise",
+        json={"bundle": {"features": ["fleet"], "channels": 100}},
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert set(body.keys()) == _AT_ENVELOPE_KEYS
+    assert body["perspective_tier"] == "enterprise"
+    assert isinstance(body["perspective_tier_label"], str)
+    assert isinstance(body["perspective_tier_rank"], int)
+    assert body["has_all_at"] is True
+
+
+def test_api_at_oss_perspective_denies_paid_feature_in_grace(client, ent):
+    """Perspective divergence: at OSS in grace, a paid feature still
+    reports has_all_at=false (grace-independent by design)."""
+    paid_f = next(iter(ent.PAID_FEATURES))
+    r = client.post(
+        "/api/entitlement/has-all-bundle-at?tier=oss",
+        json={"bundle": {"features": [paid_f]}},
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["has_all_at"] is False
+    assert body["grace"] is True  # LIVE resolver still in grace
+
+
+def test_api_at_400_missing_tier(client):
+    r = client.post(
+        "/api/entitlement/has-all-bundle-at",
+        json={"bundle": {"features": ["fleet"]}},
+    )
+    assert r.status_code == 400
+    assert r.get_json() == {"error": "missing tier"}
+
+
+def test_api_at_400_blank_tier(client):
+    r = client.post(
+        "/api/entitlement/has-all-bundle-at?tier=%20%20",
+        json={"bundle": {"features": ["fleet"]}},
+    )
+    assert r.status_code == 400
+    assert r.get_json() == {"error": "missing tier"}
+
+
+def test_api_at_404_unknown_tier(client):
+    r = client.post(
+        "/api/entitlement/has-all-bundle-at?tier=bogus",
+        json={"bundle": {"features": ["fleet"]}},
+    )
+    assert r.status_code == 404
+    body = r.get_json()
+    assert body["error"] == "unknown tier"
+    assert body["which"] == "tier"
+    assert body["tier"] == "bogus"
+
+
+def test_api_at_400_missing_bundle(client):
+    r = client.post(
+        "/api/entitlement/has-all-bundle-at?tier=oss", json={}
+    )
+    assert r.status_code == 400
+    assert r.get_json() == {"error": "missing bundle"}
+
+
+def test_api_at_400_bundle_not_object(client):
+    r = client.post(
+        "/api/entitlement/has-all-bundle-at?tier=oss",
+        json={"bundle": 42},
+    )
+    assert r.status_code == 400
+    assert r.get_json() == {"error": "bundle must be an object"}
+
+
+def test_api_at_row_byte_equals_batch_row_at(client):
+    """Cross-endpoint per-row parity contract for the ``_at`` variant."""
+    bundles = [
+        {"features": ["fleet"]},
+        {"channels": 5},
+        {"features": ["FLEET"], "runtimes": ["claude-code"]},
+        {},
+    ]
+    for tier in ("oss", "cloud_starter", "cloud_pro", "enterprise"):
+        for bundle in bundles:
+            s = client.post(
+                f"/api/entitlement/has-all-bundle-at?tier={tier}",
+                json={"bundle": bundle},
+            ).get_json()
+            b = client.post(
+                f"/api/entitlement/has-all-bundle-batch-at?tier={tier}",
+                json={"bundles": [bundle]},
+            ).get_json()
+            s_row = {k: v for k, v in s.items() if k in _AT_ROW_KEYS}
+            b_row = b["bundles"][0]
+            assert s_row == b_row
+
+
+def test_api_at_never_5xxs_on_delegate_crash(client, monkeypatch):
+    from clawmetry import entitlements as _ent
+
+    def boom(*a, **kw):
+        raise RuntimeError("simulated resolver blowup")
+
+    monkeypatch.setattr(_ent, "has_all_bundle_at", boom)
+    r = client.post(
+        "/api/entitlement/has-all-bundle-at?tier=cloud_pro",
+        json={"bundle": {"features": ["fleet"]}},
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert set(body.keys()) == _AT_ENVELOPE_KEYS
+    assert body["has_all_at"] is False
+    assert body["perspective_tier"] == "cloud_pro"
+
+
+def test_api_bare_dict_shorthand_at(client):
+    """Bare-dict shorthand also works on the ``_at`` endpoint."""
+    ref = client.post(
+        "/api/entitlement/has-all-bundle-at?tier=oss",
+        json={"bundle": {"features": ["fleet"]}},
+    ).get_json()
+    short = client.post(
+        "/api/entitlement/has-all-bundle-at?tier=oss",
+        json={"features": ["fleet"]},
+    ).get_json()
+    assert ref == short
+
+
+# -- Cross-endpoint: LIVE / _at fold-slot divergence ---------------------------
+
+
+def test_api_live_and_at_row_share_axis_echoes(client):
+    """LIVE and _at endpoints emit byte-identical axis echoes on the
+    same bundle -- only the fold slot name/value diverges
+    (has_all vs has_all_at)."""
+    bundle = {"features": ["fleet"], "channels": 5}
+    live = client.post(
+        "/api/entitlement/has-all-bundle", json={"bundle": bundle}
+    ).get_json()
+    at = client.post(
+        "/api/entitlement/has-all-bundle-at?tier=cloud_pro",
+        json={"bundle": bundle},
+    ).get_json()
+    for axis in ("features", "runtimes", "channels", "retention_days", "nodes"):
+        assert live[axis] == at[axis]


### PR DESCRIPTION
## Summary

- Adds `has_all_bundle(bundle)` and `has_all_bundle_at(perspective_tier, bundle)` scalars in `clawmetry/entitlements.py` — singular row-detail siblings of the merged `has_all_bundle_batch` / `has_all_bundle_batch_at`. Thin delegates to the already-merged `_has_all_bundle_row` / `_has_all_bundle_row_at` row helpers so the singular row cannot drift from the batch row.
- Adds `POST /api/entitlement/has-all-bundle` and `POST /api/entitlement/has-all-bundle-at?tier=<perspective>` in `routes/entitlement.py` on `bp_entitlement`. Accepts either `{"bundle": {...}}` or a bare-dict shorthand (`{"features": [...]}`) so the same body a caller would hand `/has-all` as query args maps 1:1 to a POST body. Response layers the resolver envelope on top of the batch-row shape so a UI wiring the singular and the batch off the same helper sees byte-identical rows.
- Purely additive query surface; ships in **GRACE** mode (no behaviour change, no gate flipped). Grace-independent by construction on the `_at` variant (delegates read from the static per-tier grant tables).

## Why this one, and why now

The queue already carries five open entitlement PRs (#4759, #4746, #4744, #4743, #4742) — all elaborating `_at_path` / `_batch_at` / `_bundle_batch` variants that build on each other. Rather than stack a sixth on those still-unmerged foundations, this fills a distinct singular-row gap: the batch helpers `has_all_bundle_batch` and `has_all_bundle_batch_at` are already merged on `main`, but there is no singular scalar sibling — a caller with one bundle in hand must wrap in a length-one list and unwrap `[0]`. Two thin delegates + two endpoints close that.

Delegates only touch helpers **already merged on `main`** (`_has_all_bundle_row`, `_has_all_bundle_row_at`, `_TIER_ORDER`, `_hypothetical_entitlement`, `_TIER_CHANNEL_LIMIT` / `_TIER_RETENTION_DAYS` / `_TIER_NODE_LIMIT`, `tier_label`, `tier_rank`), so it lands cleanly regardless of the review order on the rest of the stack.

## What / where

| File | Change |
|------|--------|
| `clawmetry/entitlements.py` | `has_all_bundle(bundle) -> dict` (+41 LOC) inserted right after `_has_all_bundle_row`. `has_all_bundle_at(perspective_tier, bundle) -> dict \| None` (+56 LOC) inserted right after `_has_all_bundle_row_at`. Both delegate to their respective row helpers. `has_all_bundle_at` returns `None` for empty / blank / non-string / unknown `perspective_tier` (paired endpoint 400s on missing / blank, 404s on unknown). Perspective tier is `.strip().lower()`-canonicalised. Grace-independent by construction on the `_at` variant. |
| `routes/entitlement.py` | `_parse_single_bundle_body` (+37 LOC) — singular sibling of `_parse_aggregate_bundles_body`. Accepts `{"bundle": {...}}` or the bare-dict shorthand where the top-level body IS the bundle. `POST /api/entitlement/has-all-bundle` (+81 LOC) and `POST /api/entitlement/has-all-bundle-at?tier=` (+137 LOC) inserted right before `api_entitlement_has_all_bundle_batch`. Response layers the resolver envelope on top of the batch-row shape. Never 5xxs (fallback envelope). |
| `tests/test_entitlement_has_all_bundle.py` | **34 tests**. Helper: row byte-parity with `has_all_bundle_batch` across every axis + fold + shape; never-crash on `None` / non-dict / scalar bundle; perspective divergence at OSS in grace (paid feature → `has_all_at=False` even though the LIVE fold reports True via grace pass-through); perspective-validation `None` posture on empty / blank / non-string / unknown; case normalisation (`"OSS"` → `"oss"`); grace-independence of the `_at` fold. API: happy path shape, bare-dict shorthand, 400 / 404 error paths, byte-equal per-row body with the batch endpoint on the same bundle, never-5xxs on a monkey-patched delegate crash, cross-endpoint axis-echo parity (LIVE and `_at` share axis echoes, only the fold slot diverges). |

## Local test results

- `pytest tests/test_entitlement_has_all_bundle.py -q` → **34 passed** in ~3.4 s.
- Sibling regression sweep (`has_all_bundle_batch`, `has_all`, `has_all_at`, `has_all_at_batch`, `min_tier`, `min_tier_at`, `required_tier_bundle_batch`, `entitlement_api`) → **472/472 passed**.
- `python -m py_compile` clean on all three modified files.

## Envelope shape (byte-stable across every input branch)

`POST /api/entitlement/has-all-bundle` — batch-row + resolver envelope:

```
{
  "features":          ["fleet"],
  "runtimes":          ["claude_code"],
  "channels":          5 | null,
  "retention_days":    30 | null,
  "nodes":             2 | null,
  "has_all":           <bool>,
  "current_tier":      "...",
  "current_tier_rank": <int>,
  "grace":             <bool>,
  "enforced":          <bool>
}
```

`POST /api/entitlement/has-all-bundle-at?tier=<perspective>` — batch-row + perspective + resolver envelope:

```
{
  "perspective_tier":       "cloud_pro",
  "perspective_tier_label": "Cloud Pro",
  "perspective_tier_rank":  <int>,
  "features":               ["fleet"],
  "runtimes":               ["claude_code"],
  "channels":               5 | null,
  "retention_days":         30 | null,
  "nodes":                  2 | null,
  "has_all_at":             <bool>,
  "current_tier":           "...",
  "current_tier_rank":      <int>,
  "grace":                  <bool>,
  "enforced":               <bool>
}
```

Per-row axis echoes byte-equal the paired batch endpoints (`/has-all-bundle-batch`, `/has-all-bundle-batch-at`) on the same bundle; only the fold slot (`has_all` vs `has_all_at`) and the resolver / perspective envelopes diverge.

## Local operator verification checklist

The agent has no access to the running daemon, `~/.openclaw`, the live cloud snapshot, or a browser, so the following must be verified locally before flipping the PR out of draft:

- [ ] Copy the changed files into the site-packages install (`~/.clawmetry/lib/python3.X/site-packages/clawmetry/entitlements.py`, `~/.clawmetry/lib/python3.X/site-packages/routes/entitlement.py`).
- [ ] Clear `__pycache__/` in both directories.
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` (macOS) or equivalent daemon restart.
- [ ] Smoke the endpoints on the host:
  - `curl -s 'http://localhost:8900/api/entitlement/has-all-bundle' -H 'Content-Type: application/json' -d '{"bundle":{"features":["fleet"]}}' | jq .` — expect `has_all=true` (grace pass-through), row keys `{features, runtimes, channels, retention_days, nodes, has_all}` plus the resolver envelope.
  - `curl -s 'http://localhost:8900/api/entitlement/has-all-bundle' -H 'Content-Type: application/json' -d '{"features":["fleet"]}' | jq .` — bare-dict shorthand; response byte-equals the wrapped form.
  - `curl -s 'http://localhost:8900/api/entitlement/has-all-bundle-at?tier=oss' -H 'Content-Type: application/json' -d '{"bundle":{"features":["fleet"]}}' | jq .` — expect `has_all_at=false` (OSS statically denies fleet, even in grace).
  - `curl -s 'http://localhost:8900/api/entitlement/has-all-bundle-at?tier=enterprise' -H 'Content-Type: application/json' -d '{"bundle":{"features":["fleet","sso"],"runtimes":["claude_code"],"channels":100,"retention_days":365,"nodes":100}}' | jq .` — expect `has_all_at=true` (Enterprise grants everything).
  - `curl -sw '%{http_code}\n' -o /dev/null 'http://localhost:8900/api/entitlement/has-all-bundle' -H 'Content-Type: application/json' -d '{}'` — expect **400** (missing bundle).
  - `curl -sw '%{http_code}\n' -o /dev/null 'http://localhost:8900/api/entitlement/has-all-bundle-at?tier=bogus' -H 'Content-Type: application/json' -d '{"bundle":{}}'` — expect **404**, body `{"error":"unknown tier","which":"tier","tier":"bogus"}`.
  - `curl -sw '%{http_code}\n' -o /dev/null 'http://localhost:8900/api/entitlement/has-all-bundle-at' -H 'Content-Type: application/json' -d '{"bundle":{}}'` — expect **400** (missing tier).
- [ ] Confirm axis-echo parity: the LIVE and `_at` singulars return byte-identical `features` / `runtimes` / `channels` / `retention_days` / `nodes` slots on the same bundle; only the fold slot (`has_all` vs `has_all_at`) diverges.
- [ ] Decrypt the live cloud snapshot and confirm the endpoints respond in the hosted relay.
- [ ] Browser-check the paywall walkthrough tile if any UI has been rewired to consume the new endpoints (this PR does not rewire any UI yet — the endpoints are a strict additive query-surface expansion).

---
_Generated by [Claude Code](https://claude.ai/code/session_01F3ni7ADUsQqqFyAqbZFhV5)_