### PR TITLE
Polished Grafana-style date/time range picker on Activity & Sessions

### DIFF
--- a/clawmetry/static/css/dashboard.css
+++ b/clawmetry/static/css/dashboard.css
@@ -1876,3 +1876,152 @@ body.has-profile-menu #logout-btn { display: none !important; }
 }
 .cm-profile-item:hover { background: rgba(127, 127, 127, 0.12); }
 .cm-profile-item.cm-profile-danger { color: #f87171; }
+
+/* ────────────────────────────────────────────────────────────────────────
+ * cm-tr: Grafana-style date/time range picker (static/js/time-range-picker.js).
+ * Used on the Activity (brain) and Sessions (transcripts) screens.
+ * ──────────────────────────────────────────────────────────────────────── */
+.cm-tr { position: relative; display: inline-block; }
+.cm-tr-trigger {
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 6px 12px 6px 10px;
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  border: 1px solid var(--border-primary);
+  border-radius: 8px;
+  font-size: 12px; font-weight: 600; font-family: inherit;
+  cursor: pointer;
+  box-shadow: var(--card-shadow);
+  transition: border-color 0.15s, box-shadow 0.15s, transform 0.05s;
+  min-width: 168px; max-width: 340px;
+  line-height: 1.2;
+}
+.cm-tr-trigger:hover { border-color: var(--bg-accent); box-shadow: var(--card-shadow-hover); }
+.cm-tr-trigger[aria-expanded="true"] {
+  border-color: var(--bg-accent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--bg-accent) 20%, transparent);
+}
+.cm-tr-trigger .cm-tr-icon { color: var(--text-muted); flex: none; }
+.cm-tr-trigger .cm-tr-trigger-label { flex: 1 1 auto; text-align: left; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.cm-tr-trigger .cm-tr-caret { color: var(--text-muted); flex: none; }
+.cm-tr-trigger.is-live .cm-tr-icon { color: #22c55e; }
+.cm-tr-trigger.is-live .cm-tr-trigger-label::before {
+  content: '';
+  display: inline-block; width: 6px; height: 6px; border-radius: 50%;
+  background: #22c55e; margin-right: 6px; vertical-align: middle;
+  box-shadow: 0 0 0 3px color-mix(in srgb, #22c55e 30%, transparent);
+  animation: cm-tr-live-pulse 1.6s ease-in-out infinite;
+}
+@keyframes cm-tr-live-pulse {
+  0%,100% { opacity: 1; transform: scale(1); }
+  50%     { opacity: 0.55; transform: scale(0.85); }
+}
+
+.cm-tr-pop {
+  position: fixed;
+  z-index: 1000;
+  min-width: 480px; max-width: 92vw;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-primary);
+  border-radius: 12px;
+  box-shadow: 0 12px 28px rgba(16, 24, 40, 0.18), 0 4px 10px rgba(16, 24, 40, 0.10);
+  overflow: hidden;
+  color: var(--text-primary);
+  font-size: 12px;
+}
+.cm-tr-pop[hidden] { display: none; }
+.cm-tr-pop-cols {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0;
+}
+.cm-tr-abs, .cm-tr-quick {
+  padding: 14px 14px 12px;
+}
+.cm-tr-abs { border-right: 1px solid var(--border-primary); }
+.cm-tr-h {
+  font-size: 11px; text-transform: uppercase; letter-spacing: 0.6px;
+  color: var(--text-muted); font-weight: 700;
+  margin-bottom: 10px;
+}
+.cm-tr-l {
+  display: block;
+  font-size: 11px; color: var(--text-secondary); font-weight: 600;
+  margin-bottom: 10px;
+}
+.cm-tr-l input[type="datetime-local"] {
+  display: block; margin-top: 4px;
+  width: 100%;
+  padding: 8px 10px;
+  background: var(--bg-primary);
+  border: 1px solid var(--border-primary);
+  border-radius: 8px;
+  color: var(--text-primary);
+  font-size: 13px; font-family: inherit; font-variant-numeric: tabular-nums;
+  color-scheme: light dark;
+  transition: border-color 0.15s, box-shadow 0.15s;
+}
+.cm-tr-l input[type="datetime-local"]:focus {
+  outline: none;
+  border-color: var(--bg-accent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--bg-accent) 20%, transparent);
+}
+.cm-tr-apply {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 100%; margin-top: 4px;
+  padding: 8px 12px;
+  background: var(--bg-accent); color: #fff;
+  border: 1px solid var(--bg-accent);
+  border-radius: 8px;
+  font-size: 12px; font-weight: 700; font-family: inherit;
+  cursor: pointer;
+  transition: filter 0.15s, transform 0.05s;
+}
+.cm-tr-apply:hover { filter: brightness(1.08); }
+.cm-tr-apply:active { transform: translateY(1px); }
+.cm-tr-hint { margin-top: 8px; font-size: 11px; color: var(--text-muted); }
+
+.cm-tr-quick-list {
+  display: flex; flex-direction: column; gap: 2px;
+  max-height: 300px; overflow-y: auto;
+  padding-right: 2px;
+}
+.cm-tr-quick-item {
+  display: flex; align-items: center; gap: 8px;
+  text-align: left;
+  padding: 7px 10px;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  color: var(--text-primary);
+  font-size: 12px; font-weight: 500; font-family: inherit;
+  cursor: pointer;
+  transition: background 0.12s, color 0.12s, border-color 0.12s;
+}
+.cm-tr-quick-item:hover {
+  background: color-mix(in srgb, var(--bg-accent) 10%, transparent);
+  color: var(--text-primary);
+}
+.cm-tr-quick-item.active {
+  background: color-mix(in srgb, var(--bg-accent) 16%, transparent);
+  border-color: color-mix(in srgb, var(--bg-accent) 40%, transparent);
+  color: var(--text-primary);
+  font-weight: 700;
+}
+.cm-tr-quick-item.cm-tr-live { color: var(--text-primary); font-weight: 700; }
+.cm-tr-live-dot {
+  width: 8px; height: 8px; border-radius: 50%;
+  background: #22c55e;
+  box-shadow: 0 0 0 3px color-mix(in srgb, #22c55e 30%, transparent);
+  animation: cm-tr-live-pulse 1.6s ease-in-out infinite;
+}
+.cm-tr-quick-sep {
+  height: 1px; background: var(--border-primary);
+  margin: 4px 2px;
+}
+
+@media (max-width: 640px) {
+  .cm-tr-pop { min-width: 92vw; }
+  .cm-tr-pop-cols { grid-template-columns: 1fr; }
+  .cm-tr-abs { border-right: none; border-bottom: 1px solid var(--border-primary); }
+}

--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -5137,9 +5137,50 @@ function _brainRangeHuman(sinceIso, untilIso) {
 }
 
 function _brainSetRangeActiveBtn(key) {
+  // Legacy no-op-safe shim: the crude button strip was replaced by the
+  // Grafana-style picker (static/js/time-range-picker.js), which owns its
+  // own "active" state. If any legacy button strip is still present (e.g.
+  // an older embed), keep it in sync as a courtesy.
   document.querySelectorAll('#brain-range-bar .brain-range-btn').forEach(function(b) {
     b.classList.toggle('active', b.getAttribute('data-range') === String(key));
   });
+}
+
+// Mount the reusable Grafana-style time range picker on the Brain tab.
+// Idempotent: safe to call every time we render the tab; only initializes
+// once per DOM insertion. Wires the picker's onChange to the existing
+// setBrainTimeRange / applyBrainAbsoluteRange helpers so the rest of the
+// page (SSE, density chart, banner) reacts unchanged.
+function _brainMountRangePicker() {
+  var host = document.getElementById('brain-range-picker');
+  if (!host || host._cmTimeRange) return;
+  if (!window.cmTimeRangePicker) return;
+  var initial = _brainRange
+    ? { since: _brainRange.since, until: _brainRange.until }
+    : 'live';
+  window.cmTimeRangePicker.mount(host, {
+    name: 'brain',
+    showLive: true,
+    initial: initial,
+    onChange: function(r) {
+      if (r.mode === 'live') { setBrainTimeRange('live'); return; }
+      if (r.mode === 'quick') { setBrainTimeRange(r.seconds); return; }
+      if (r.mode === 'absolute') { applyBrainAbsoluteRange(r.since, r.until); return; }
+    }
+  });
+}
+
+// Explicit ISO from/until entry point used by the picker's absolute mode.
+// applyBrainCustomRange() still works and reads from the (now removed)
+// <input> fields — kept as a no-op-if-fields-missing shim for compat.
+function applyBrainAbsoluteRange(sinceIso, untilIso) {
+  var s = new Date(sinceIso), u = new Date(untilIso);
+  if (isNaN(s.getTime()) || isNaN(u.getTime())) return;
+  if (s.getTime() > u.getTime()) { var tmp = s; s = u; u = tmp; }
+  _brainRange = {since: _brainRangeIso(s), until: _brainRangeIso(u)};
+  _brainRangeRetries = 0;
+  _brainSetRangeActiveBtn('custom');
+  _enterBrainHistoryMode();
 }
 
 function _brainUpdateRangeUI() {
@@ -7820,6 +7861,10 @@ window.selfevolveRun = async function () {
 };
 
 async function loadBrainPage(silent) {
+  // Mount the Grafana-style date/time-range picker on first paint (and
+  // re-mount if the tab was rebuilt). Idempotent by design — the helper
+  // no-ops when the container already has a picker attached.
+  try { _brainMountRangePicker(); } catch (e) {}
   // Cloud iframe doesn't proxy /api/brain-history (live event stream is
   // local-only). Without this branch, `loadBrainPage` returned silently and
   // left the inline `Loading...` placeholder in `#brain-stream` forever
@@ -15948,9 +15993,49 @@ window.toggleTranscriptPlumbing = function() {
 var _transcriptRange = null;
 
 function _txSetRangeActiveBtn(key) {
+  // Legacy no-op-safe shim: the crude button strip was replaced by the
+  // Grafana-style picker (static/js/time-range-picker.js), which owns its
+  // own "active" state. Keep any legacy button strip in sync as a courtesy.
   document.querySelectorAll('#tx-range-bar .brain-range-btn').forEach(function(b) {
     b.classList.toggle('active', b.getAttribute('data-range') === String(key));
   });
+}
+
+// Mount the reusable Grafana-style time range picker on the Sessions tab.
+// Wires the picker's onChange to setTranscriptTimeRange (Live/quick) and
+// applyTranscriptAbsoluteRange (absolute From/To) so the existing filter
+// logic + "Viewing history" banner keep working unchanged.
+function _transcriptsMountRangePicker() {
+  var host = document.getElementById('transcripts-range-picker');
+  if (!host || host._cmTimeRange) return;
+  if (!window.cmTimeRangePicker) return;
+  var initial = _transcriptRange
+    ? { since: new Date(_transcriptRange.sinceMs).toISOString(),
+        until: new Date(_transcriptRange.untilMs).toISOString() }
+    : 'live';
+  window.cmTimeRangePicker.mount(host, {
+    name: 'transcripts',
+    showLive: true,
+    initial: initial,
+    onChange: function(r) {
+      if (r.mode === 'live') { setTranscriptTimeRange('live'); return; }
+      if (r.mode === 'quick') { setTranscriptTimeRange(r.seconds); return; }
+      if (r.mode === 'absolute') { applyTranscriptAbsoluteRange(r.since, r.until); return; }
+    }
+  });
+}
+
+// Explicit ISO from/until entry point used by the picker's absolute mode.
+// applyTranscriptCustomRange() still works and reads from the (now removed)
+// <input> fields — kept as a no-op-if-fields-missing shim for compat.
+function applyTranscriptAbsoluteRange(sinceIso, untilIso) {
+  var s = new Date(sinceIso), u = new Date(untilIso);
+  if (isNaN(s.getTime()) || isNaN(u.getTime())) return;
+  if (s.getTime() > u.getTime()) { var tmp = s; s = u; u = tmp; }
+  _transcriptRange = {sinceMs: s.getTime(), untilMs: u.getTime()};
+  _txSetRangeActiveBtn('custom');
+  _txUpdateRangeUI();
+  loadTranscripts();
 }
 
 function _txUpdateRangeUI() {
@@ -16017,6 +16102,13 @@ function applyTranscriptCustomRange() {
 }
 
 async function loadTranscripts() {
+  // Mount the Grafana-style date/time-range picker on first paint.
+  // Idempotent — the helper no-ops when already attached.
+  try { _transcriptsMountRangePicker(); } catch (e) {}
+  // Surface a small counter next to the picker: how many rows survived the
+  // window filter this load. Cleared when no window is active.
+  var _rangeCountEl = document.getElementById('transcripts-range-count');
+  if (_rangeCountEl) _rangeCountEl.textContent = '';
   try {
     // In cloud mode we can't score live (no key, no session DuckDB) but the
     // snapshot carries recent scores at /api/evals/recent. Refetch each
@@ -16066,6 +16158,7 @@ async function loadTranscripts() {
     // i.e. strict last-activity-in-window.
     var _txWin = _transcriptRange;
     var _txWinEmpty = false;
+    var _txWinHidden = 0;
     if (_txWin) {
       var _preWin = data.transcripts.length;
       data.transcripts = data.transcripts.filter(function(t) {
@@ -16073,7 +16166,19 @@ async function loadTranscripts() {
         var start = t.started || mod;
         return start <= _txWin.untilMs && mod >= _txWin.sinceMs;
       });
+      _txWinHidden = _preWin - data.transcripts.length;
       _txWinEmpty = (_preWin > 0 && data.transcripts.length === 0);
+    }
+    // Post the "X sessions in this window · Y hidden" counter next to the picker.
+    var _rcEl = document.getElementById('transcripts-range-count');
+    if (_rcEl) {
+      if (_txWin) {
+        var _shown = data.transcripts.length;
+        _rcEl.textContent = _shown + ' session' + (_shown === 1 ? '' : 's') +
+          ' in this window' + (_txWinHidden ? ' · ' + _txWinHidden + ' hidden' : '');
+      } else {
+        _rcEl.textContent = '';
+      }
     }
     var plumbingTotal = 0;
     // NOTE: the callback param must NOT be named `t` — that shadows the global

--- a/clawmetry/static/js/time-range-picker.js
+++ b/clawmetry/static/js/time-range-picker.js
@@ -1,0 +1,342 @@
+/*
+ * Grafana-style date/time range picker.
+ *
+ * A drop-in, self-contained component used by the Activity (brain) and
+ * Sessions (transcripts) screens to pick a live/quick/absolute time window
+ * without wrestling with the native <input type="datetime-local"> UX.
+ *
+ * Public API:
+ *   window.cmTimeRangePicker.mount(container, {
+ *     showLive: true,           // include the ● Live option
+ *     initial: 'live' | seconds | {since, until},
+ *     onChange: function(range){ ... }
+ *   })
+ *
+ * Range object passed to onChange:
+ *   { mode:'live' }
+ *   { mode:'quick',    seconds, since, until, label }
+ *   { mode:'absolute',          since, until, label }
+ */
+(function () {
+  'use strict';
+
+  var QUICK_RANGES = [
+    { label: 'Last 5 minutes',  seconds: 5 * 60 },
+    { label: 'Last 15 minutes', seconds: 15 * 60 },
+    { label: 'Last 30 minutes', seconds: 30 * 60 },
+    { label: 'Last 1 hour',     seconds: 60 * 60 },
+    { label: 'Last 3 hours',    seconds: 3 * 3600 },
+    { label: 'Last 6 hours',    seconds: 6 * 3600 },
+    { label: 'Last 12 hours',   seconds: 12 * 3600 },
+    { label: 'Last 24 hours',   seconds: 24 * 3600 },
+    { label: 'Last 2 days',     seconds: 2 * 86400 },
+    { label: 'Last 7 days',     seconds: 7 * 86400 },
+    { label: 'Last 30 days',    seconds: 30 * 86400 },
+    { label: 'Last 90 days',    seconds: 90 * 86400 }
+  ];
+
+  function pad(n) { return (n < 10 ? '0' : '') + n; }
+
+  function fmtLocalDatetimeInput(d) {
+    return d.getFullYear() + '-' + pad(d.getMonth() + 1) + '-' + pad(d.getDate()) +
+           'T' + pad(d.getHours()) + ':' + pad(d.getMinutes());
+  }
+
+  function fmtHuman(d) {
+    // "Aug 12, 14:37" for compact display; year only when not this year.
+    var now = new Date();
+    var opts = { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' };
+    if (d.getFullYear() !== now.getFullYear()) opts.year = 'numeric';
+    try { return d.toLocaleString(undefined, opts); }
+    catch (e) { return d.toISOString(); }
+  }
+
+  function quickLabelForSeconds(s) {
+    for (var i = 0; i < QUICK_RANGES.length; i++) {
+      if (QUICK_RANGES[i].seconds === s) return QUICK_RANGES[i].label;
+    }
+    // Fall back to a human-ish duration for arbitrary seconds.
+    if (s < 3600) return 'Last ' + Math.round(s / 60) + ' minutes';
+    if (s < 86400) return 'Last ' + Math.round(s / 3600) + ' hours';
+    return 'Last ' + Math.round(s / 86400) + ' days';
+  }
+
+  // Build the range object emitted to callers.
+  function buildRange(mode, opts) {
+    opts = opts || {};
+    if (mode === 'live') return { mode: 'live' };
+    if (mode === 'quick') {
+      var now = new Date();
+      var since = new Date(now.getTime() - opts.seconds * 1000);
+      return {
+        mode: 'quick',
+        seconds: opts.seconds,
+        since: since.toISOString(),
+        until: now.toISOString(),
+        label: quickLabelForSeconds(opts.seconds)
+      };
+    }
+    if (mode === 'absolute') {
+      var s = new Date(opts.since);
+      var u = new Date(opts.until);
+      return {
+        mode: 'absolute',
+        since: s.toISOString(),
+        until: u.toISOString(),
+        label: fmtHuman(s) + ' → ' + fmtHuman(u)
+      };
+    }
+    return { mode: 'live' };
+  }
+
+  // Persist per-instance selection so revisits feel sticky.
+  function keyFor(name) { return 'cm-timerange:' + (name || 'default'); }
+  function saveState(name, state) {
+    try { localStorage.setItem(keyFor(name), JSON.stringify(state)); } catch (e) {}
+  }
+  function loadState(name) {
+    try {
+      var raw = localStorage.getItem(keyFor(name));
+      return raw ? JSON.parse(raw) : null;
+    } catch (e) { return null; }
+  }
+
+  function mount(container, options) {
+    options = options || {};
+    var name = options.name || (container.id || 'default');
+    var showLive = options.showLive !== false;
+    var initial = options.initial != null ? options.initial : (showLive ? 'live' : 60 * 60);
+    var onChange = options.onChange || function () {};
+
+    // State kept on the DOM node so callers can inspect via .getRange()
+    var state = { mode: 'live', seconds: null, since: null, until: null, label: 'Live' };
+
+    // Root markup.
+    container.classList.add('cm-tr');
+    container.innerHTML = ''
+      + '<button type="button" class="cm-tr-trigger" aria-haspopup="dialog" aria-expanded="false">'
+      +   '<svg class="cm-tr-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>'
+      +   '<span class="cm-tr-trigger-label">Live</span>'
+      +   '<svg class="cm-tr-caret" width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>'
+      + '</button>'
+      + '<div class="cm-tr-pop" role="dialog" aria-label="Select time range" hidden>'
+      +   '<div class="cm-tr-pop-cols">'
+      +     '<div class="cm-tr-abs">'
+      +       '<div class="cm-tr-h">Absolute time range</div>'
+      +       '<label class="cm-tr-l">From'
+      +         '<input type="datetime-local" class="cm-tr-from" step="60">'
+      +       '</label>'
+      +       '<label class="cm-tr-l">To'
+      +         '<input type="datetime-local" class="cm-tr-to" step="60">'
+      +       '</label>'
+      +       '<button type="button" class="cm-tr-apply">Apply time range</button>'
+      +       '<div class="cm-tr-hint">Times are in your local timezone.</div>'
+      +     '</div>'
+      +     '<div class="cm-tr-quick">'
+      +       '<div class="cm-tr-h">Quick ranges</div>'
+      +       '<div class="cm-tr-quick-list" role="listbox"></div>'
+      +     '</div>'
+      +   '</div>'
+      + '</div>';
+
+    var trigger = container.querySelector('.cm-tr-trigger');
+    var triggerLabel = container.querySelector('.cm-tr-trigger-label');
+    var pop = container.querySelector('.cm-tr-pop');
+    var fromInput = container.querySelector('.cm-tr-from');
+    var toInput = container.querySelector('.cm-tr-to');
+    var applyBtn = container.querySelector('.cm-tr-apply');
+    var quickList = container.querySelector('.cm-tr-quick-list');
+
+    // Fill quick-ranges panel (+ Live at top if requested).
+    var quickHtml = '';
+    if (showLive) {
+      quickHtml += '<button type="button" class="cm-tr-quick-item cm-tr-live" data-live="1">'
+                +    '<span class="cm-tr-live-dot"></span>Live · streaming'
+                +  '</button>'
+                +  '<div class="cm-tr-quick-sep"></div>';
+    }
+    QUICK_RANGES.forEach(function (r) {
+      quickHtml += '<button type="button" class="cm-tr-quick-item" data-secs="' + r.seconds + '">'
+                +    r.label
+                +  '</button>';
+    });
+    quickList.innerHTML = quickHtml;
+
+    function markActiveQuick() {
+      var items = quickList.querySelectorAll('.cm-tr-quick-item');
+      for (var i = 0; i < items.length; i++) items[i].classList.remove('active');
+      if (state.mode === 'live') {
+        var liveEl = quickList.querySelector('[data-live="1"]');
+        if (liveEl) liveEl.classList.add('active');
+      } else if (state.mode === 'quick' && state.seconds) {
+        var q = quickList.querySelector('[data-secs="' + state.seconds + '"]');
+        if (q) q.classList.add('active');
+      }
+    }
+
+    function updateTriggerLabel() {
+      triggerLabel.textContent = state.label || 'Live';
+      trigger.classList.toggle('is-live', state.mode === 'live');
+      trigger.classList.toggle('is-custom', state.mode === 'absolute');
+      trigger.classList.toggle('is-quick', state.mode === 'quick');
+    }
+
+    function applyState(next, persist, notify) {
+      state = next;
+      updateTriggerLabel();
+      markActiveQuick();
+      if (persist !== false) {
+        saveState(name, {
+          mode: state.mode, seconds: state.seconds,
+          since: state.since, until: state.until
+        });
+      }
+      if (notify !== false) onChange(state);
+    }
+
+    function selectLive() {
+      applyState(Object.assign(buildRange('live'), { label: 'Live' }), true, true);
+      closePop();
+    }
+
+    function selectQuick(seconds) {
+      var r = buildRange('quick', { seconds: seconds });
+      applyState(r, true, true);
+      closePop();
+    }
+
+    function selectAbsolute() {
+      if (!fromInput.value || !toInput.value) return;
+      var s = new Date(fromInput.value), u = new Date(toInput.value);
+      if (isNaN(s.getTime()) || isNaN(u.getTime())) return;
+      if (s.getTime() > u.getTime()) { var tmp = s; s = u; u = tmp; }
+      var r = buildRange('absolute', { since: s, until: u });
+      applyState(r, true, true);
+      closePop();
+    }
+
+    function prefillAbsoluteInputs() {
+      // Seed from current state so opening the picker while in a window
+      // shows that window, not a stale "an hour ago → now".
+      var now = new Date();
+      var to = (state.mode !== 'live' && state.until) ? new Date(state.until) : now;
+      var from;
+      if (state.mode !== 'live' && state.since) from = new Date(state.since);
+      else from = new Date(now.getTime() - 3600 * 1000);
+      fromInput.value = fmtLocalDatetimeInput(from);
+      toInput.value = fmtLocalDatetimeInput(to);
+    }
+
+    function openPop() {
+      prefillAbsoluteInputs();
+      pop.hidden = false;
+      trigger.setAttribute('aria-expanded', 'true');
+      // Position: fixed so it escapes overflow parents; anchor to trigger.
+      positionPop();
+      // Rebind outside-click on next tick so this same click doesn't close it.
+      setTimeout(function () {
+        document.addEventListener('mousedown', outsideClick, true);
+        document.addEventListener('keydown', escKey, true);
+        window.addEventListener('resize', positionPop);
+        window.addEventListener('scroll', positionPop, true);
+      }, 0);
+    }
+
+    function closePop() {
+      pop.hidden = true;
+      trigger.setAttribute('aria-expanded', 'false');
+      document.removeEventListener('mousedown', outsideClick, true);
+      document.removeEventListener('keydown', escKey, true);
+      window.removeEventListener('resize', positionPop);
+      window.removeEventListener('scroll', positionPop, true);
+    }
+
+    function positionPop() {
+      var r = trigger.getBoundingClientRect();
+      // Prefer aligning right edge; fall back to left if it would clip.
+      pop.style.position = 'fixed';
+      pop.style.top = (r.bottom + 6) + 'px';
+      // Measure after making visible.
+      pop.style.left = '0px';
+      pop.style.visibility = 'hidden';
+      var w = pop.offsetWidth;
+      var right = r.right;
+      var left = right - w;
+      if (left < 8) left = Math.min(r.left, window.innerWidth - w - 8);
+      if (left < 8) left = 8;
+      pop.style.left = left + 'px';
+      pop.style.visibility = '';
+      // If it overflows bottom, flip above the trigger.
+      var h = pop.offsetHeight;
+      if (r.bottom + 6 + h > window.innerHeight - 8) {
+        var top = r.top - 6 - h;
+        if (top < 8) top = 8;
+        pop.style.top = top + 'px';
+      }
+    }
+
+    function outsideClick(ev) {
+      if (pop.contains(ev.target) || trigger.contains(ev.target)) return;
+      closePop();
+    }
+    function escKey(ev) { if (ev.key === 'Escape') { closePop(); trigger.focus(); } }
+
+    // Trigger + quick-list wiring.
+    trigger.addEventListener('click', function () {
+      pop.hidden ? openPop() : closePop();
+    });
+    quickList.addEventListener('click', function (ev) {
+      var btn = ev.target.closest('.cm-tr-quick-item');
+      if (!btn) return;
+      if (btn.getAttribute('data-live') === '1') { selectLive(); return; }
+      var secs = parseInt(btn.getAttribute('data-secs'), 10);
+      if (secs > 0) selectQuick(secs);
+    });
+    applyBtn.addEventListener('click', selectAbsolute);
+    // Enter inside either date field also applies.
+    [fromInput, toInput].forEach(function (el) {
+      el.addEventListener('keydown', function (ev) {
+        if (ev.key === 'Enter') { ev.preventDefault(); selectAbsolute(); }
+      });
+    });
+
+    // Restore saved state, then honor explicit `initial` if the caller gave one.
+    var restored = loadState(name);
+    var start;
+    if (restored) {
+      if (restored.mode === 'live') start = buildRange('live');
+      else if (restored.mode === 'quick' && restored.seconds) start = buildRange('quick', { seconds: restored.seconds });
+      else if (restored.mode === 'absolute' && restored.since && restored.until) start = buildRange('absolute', { since: restored.since, until: restored.until });
+    }
+    if (!start) {
+      if (initial === 'live') start = buildRange('live');
+      else if (typeof initial === 'number') start = buildRange('quick', { seconds: initial });
+      else if (initial && initial.since && initial.until) start = buildRange('absolute', { since: initial.since, until: initial.until });
+      else start = buildRange('live');
+    }
+    if (start.mode === 'live') start.label = 'Live';
+    // Apply without notifying so callers can subscribe after mount() and
+    // then read the initial value themselves via getRange().
+    applyState(start, false, false);
+
+    // Public per-instance API.
+    var api = {
+      getRange: function () { return state; },
+      setRange: function (next, notify) {
+        var built;
+        if (next === 'live') built = buildRange('live');
+        else if (typeof next === 'number') built = buildRange('quick', { seconds: next });
+        else if (next && next.since && next.until) built = buildRange('absolute', { since: next.since, until: next.until });
+        else built = buildRange('live');
+        if (built.mode === 'live') built.label = 'Live';
+        applyState(built, true, notify !== false);
+      },
+      open: openPop,
+      close: closePop
+    };
+    container._cmTimeRange = api;
+    return api;
+  }
+
+  window.cmTimeRangePicker = { mount: mount, QUICK_RANGES: QUICK_RANGES };
+})();

--- a/clawmetry/templates/tabs/brain.html
+++ b/clawmetry/templates/tabs/brain.html
@@ -127,25 +127,14 @@
           font-size:11px;
           color:var(--text-muted);
           " data-i18n="brain.activity_density">Activity density · last 60 min (30s buckets)</div>
-        <!-- Date-time range picker: investigate any window ("what happened
-             at 3AM?"). Live = streaming default; presets freeze a window
-             ending now; Custom takes an explicit from/to. Handlers in
-             app.js (setBrainTimeRange / applyBrainCustomRange). -->
-        <div id="brain-range-bar" style="display:flex;align-items:center;gap:4px;flex-wrap:wrap;" data-i18n-title="brain.range_tooltip" title="Show activity from a specific time window">
-          <button class="brain-range-btn time-btn active" data-range="live" onclick="setBrainTimeRange('live',this)" data-i18n="brain.range_live">● Live</button>
-          <button class="brain-range-btn time-btn" data-range="3600" onclick="setBrainTimeRange(3600,this)">1h</button>
-          <button class="brain-range-btn time-btn" data-range="21600" onclick="setBrainTimeRange(21600,this)">6h</button>
-          <button class="brain-range-btn time-btn" data-range="86400" onclick="setBrainTimeRange(86400,this)">24h</button>
-          <button class="brain-range-btn time-btn" data-range="custom" id="brain-range-custom-btn" onclick="toggleBrainCustomRange(this)" data-i18n="brain.range_custom">Custom…</button>
-        </div>
+        <!-- Grafana-style date/time range picker. The <div> is mounted by
+             cmTimeRangePicker (static/js/time-range-picker.js); selection
+             is forwarded to setBrainTimeRange / applyBrainAbsoluteRange
+             in app.js so the rest of the Activity page (density chart,
+             SSE, banner) reacts unchanged. -->
+        <div id="brain-range-picker" title="Show activity from a specific time window"></div>
       </div>
-      <div id="brain-custom-range" style="display:none;align-items:center;gap:6px;flex-wrap:wrap;margin-bottom:8px;font-size:11px;color:var(--text-muted);">
-        <span data-i18n="brain.range_from">From</span>
-        <input type="datetime-local" class="brain-dtl" id="brain-range-from" step="60" onclick="_brainOpenPicker(this)" style="padding:4px 6px;background:var(--bg-primary);border:1px solid var(--border);border-radius:6px;color:var(--text-primary);font-size:11px;font-family:inherit;">
-        <span data-i18n="brain.range_to">to</span>
-        <input type="datetime-local" class="brain-dtl" id="brain-range-to" step="60" onclick="_brainOpenPicker(this)" style="padding:4px 6px;background:var(--bg-primary);border:1px solid var(--border);border-radius:6px;color:var(--text-primary);font-size:11px;font-family:inherit;">
-        <button class="refresh-btn" onclick="applyBrainCustomRange()" style="font-weight:600;" data-i18n="brain.range_apply">Show this window</button>
-      </div>
+      <div id="brain-custom-range" style="display:none;"></div>
       <div id="brain-history-banner" style="display:none;align-items:center;gap:8px;flex-wrap:wrap;background:rgba(245,158,11,0.08);border:1px solid rgba(245,158,11,0.35);border-radius:6px;padding:6px 10px;margin-bottom:8px;font-size:12px;color:#f59e0b;">
         <span>🕰 <span data-i18n="brain.viewing_history">Viewing history</span> · <span id="brain-history-banner-text" style="font-weight:600;"></span></span>
         <span id="brain-history-banner-status" style="color:var(--text-muted);font-size:11px;"></span>

--- a/clawmetry/templates/tabs/transcripts.html
+++ b/clawmetry/templates/tabs/transcripts.html
@@ -1,25 +1,15 @@
 <div class="page" id="page-transcripts">
-  <div class="refresh-bar">
+  <div class="refresh-bar" style="align-items:center;gap:10px;">
     <button class="refresh-btn" onclick="loadTranscripts()">↻ <span data-i18n="common.refresh">Refresh</span></button>
-    <!-- Time-window picker (post-mortem digging): same pattern as the Brain
-         range bar — Live is the default; a window filters the conversation
-         list to sessions active inside it. -->
-    <div id="tx-range-bar" style="display:flex;align-items:center;gap:4px;flex-wrap:wrap;margin-left:auto;" data-i18n-title="transcripts.range_tooltip" title="Show sessions active in a specific time window">
-      <button class="brain-range-btn time-btn active" data-range="live" onclick="setTranscriptTimeRange('live',this)" data-i18n="brain.range_live">● Live</button>
-      <button class="brain-range-btn time-btn" data-range="3600" onclick="setTranscriptTimeRange(3600,this)">1h</button>
-      <button class="brain-range-btn time-btn" data-range="21600" onclick="setTranscriptTimeRange(21600,this)">6h</button>
-      <button class="brain-range-btn time-btn" data-range="86400" onclick="setTranscriptTimeRange(86400,this)">24h</button>
-      <button class="brain-range-btn time-btn" data-range="604800" onclick="setTranscriptTimeRange(604800,this)">7d</button>
-      <button class="brain-range-btn time-btn" data-range="custom" id="tx-range-custom-btn" onclick="toggleTranscriptCustomRange(this)" data-i18n="brain.range_custom">Custom…</button>
-    </div>
+    <!-- Grafana-style date/time-range picker (static/js/time-range-picker.js).
+         Filters the sessions list by active-in-window. Wired into the
+         existing setTranscriptTimeRange / applyTranscriptAbsoluteRange
+         helpers in app.js, so the "Viewing history" banner + filter logic
+         keep working unchanged. Mounted by _transcriptsMountRangePicker(). -->
+    <div id="transcripts-range-picker" title="Show sessions active in a specific time window"></div>
+    <span id="transcripts-range-count" style="font-size:11px;color:var(--text-muted);"></span>
   </div>
-  <div id="tx-custom-range" style="display:none;align-items:center;gap:6px;flex-wrap:wrap;margin-bottom:8px;font-size:11px;color:var(--text-muted);">
-    <span data-i18n="brain.range_from">From</span>
-    <input type="datetime-local" class="brain-dtl" id="tx-range-from" step="60" onclick="_brainOpenPicker(this)" style="padding:4px 6px;background:var(--bg-primary);border:1px solid var(--border);border-radius:6px;color:var(--text-primary);font-size:11px;font-family:inherit;">
-    <span data-i18n="brain.range_to">to</span>
-    <input type="datetime-local" class="brain-dtl" id="tx-range-to" step="60" onclick="_brainOpenPicker(this)" style="padding:4px 6px;background:var(--bg-primary);border:1px solid var(--border);border-radius:6px;color:var(--text-primary);font-size:11px;font-family:inherit;">
-    <button class="refresh-btn" onclick="applyTranscriptCustomRange()" style="font-weight:600;" data-i18n="brain.range_apply">Show this window</button>
-  </div>
+  <div id="tx-custom-range" style="display:none;"></div>
   <div id="tx-history-banner" style="display:none;align-items:center;justify-content:space-between;gap:10px;flex-wrap:wrap;border:1px solid rgba(245,158,11,0.5);border-radius:8px;padding:8px 12px;margin-bottom:10px;font-size:12px;color:#f59e0b;">
     <span>🕐 <span data-i18n="transcripts.viewing_history">Viewing history</span> · <span id="tx-history-banner-text"></span></span>
     <button class="refresh-btn" onclick="setTranscriptTimeRange('live')" style="font-weight:600;" data-i18n="brain.back_to_live">● Back to live</button>

--- a/dashboard.py
+++ b/dashboard.py
@@ -269,7 +269,7 @@ def _otlp_service_name_to_agent_type(service_name):
     return slug or "custom"
 
 
-__version__ = "0.12.685"
+__version__ = "0.12.688"
 
 # Extensions (Phase 2): import the plugin host now, but defer the actual
 # load_plugins() call until after the Flask app is created below so we can
@@ -12696,6 +12696,7 @@ DASHBOARD_HTML = r"""
 {% endif %}
 <script src="{{ url_for('static', filename='js/i18n.js', v=version) }}"></script>
 <script src="{{ url_for('static', filename='js/runtime-logos.js', v=version) }}"></script>
+<script src="{{ url_for('static', filename='js/time-range-picker.js', v=version) }}"></script>
 <script src="{{ url_for('static', filename='js/app.js', v=version) }}"></script>
 </div> <!-- end zoom-wrapper -->
 


### PR DESCRIPTION
## Summary
- Replace the crude Live/1h/6h/24h/Custom button strips on the Activity (brain) and Sessions (transcripts) screens with one reusable Grafana-style picker.
- Trigger button shows the active window ("● Live" / "Last 6 hours" / "Aug 12, 09:00 → 15:00") with a pulsing live indicator; popover has 12 quick ranges + absolute From/To inputs.
- Backend contracts untouched — picker forwards to the existing set{Brain,Transcript}TimeRange helpers plus new apply{...}AbsoluteRange entry points. SSE, density chart, "Viewing history" banner, and the session-active-in-window filter all keep working unchanged.
- Includes a small "N sessions in this window · M hidden" counter on the Sessions screen.
- Version bump to 0.12.688 so release-on-merge auto-publishes to PyPI + cloud.

## Files
- new: `clawmetry/static/js/time-range-picker.js` (reusable `window.cmTimeRangePicker.mount(...)` module)
- css:  `.cm-tr-*` appended to `clawmetry/static/css/dashboard.css` (light + dark themed)
- html: `clawmetry/templates/tabs/brain.html`, `clawmetry/templates/tabs/transcripts.html`
- py:   `dashboard.py` (script tag + version bump)
- js:   `clawmetry/static/js/app.js` (mount helpers + absolute-range entry points, no-op-safe legacy shims)

## Test plan
- [x] Headless Chromium smoke test on both screens: cold-start "● Live", picker opens with 13 items (Live + 12 quick), quick pick applies and sets `_brainRange`/`_transcriptRange`, absolute From/To picks apply and produce human-readable label, back-to-live works, no console errors.
- [x] Sessions counter reads "50 sessions in this window" against a real workspace after picking Last 30 days.
- [x] `python3 -m py_compile dashboard.py` + `node -c` on both JS files pass.
- [ ] CI green.
- [ ] Post-deploy: verify live at https://clawmetry.com after `[RELEASE]` tag lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)