### PR TITLE
fix(onboarding): close both paths (dashboard modal + desktop pane) that re-prompt after successful OTP

### DIFF
--- a/clawmetry/static/js/gw-setup.js
+++ b/clawmetry/static/js/gw-setup.js
@@ -251,13 +251,40 @@ function cloudVerifyOtp() {
     err.style.display = '';
     return;
   }
-  fetch('https://app.clawmetry.com/api/otp/verify', {method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify({email: _cloudEmail, code: code})})
+  // Route through the LOCAL dashboard endpoint (not app.clawmetry.com
+  // directly): /api/cloud-cta/verify-otp proxies to cloud AND persists the
+  // returned cm_ key via _write_cloud_token(). Bypassing this seam — as the
+  // previous direct fetch to https://app.clawmetry.com/api/otp/verify did —
+  // set the browser cookie but left the local machine with no token, so
+  // /api/cloud-cta/status kept reporting connected=false, the onboarding
+  // gate stayed required=true, and the modal reappeared on every launch
+  // (founder report 2026-08-12).
+  fetch('/api/cloud-cta/verify-otp', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({email: _cloudEmail, code: code}),
+  })
     .then(function(r){ return r.json(); })
     .then(function(d){
-      if (d.ok && (d.token || d.api_key)) {
+      if (d.ok && d.token) {
+        // Record the choice in the dashboard's onboarding gate so the
+        // hard-gate modal never re-fires. _apply_marker_semantics() there
+        // also runs enable_cloud() + registers a persistent daemon.
+        fetch('/api/onboarding/complete', {
+          method: 'POST',
+          headers: {'Content-Type': 'application/json'},
+          body: JSON.stringify({choice: 'managed'}),
+        }).catch(function(){ /* best-effort — the token write above is what actually pairs */ });
         document.getElementById('cloud-step-otp').style.display = 'none';
         document.getElementById('cloud-step-done').style.display = '';
-        setTimeout(function(){ window.open('https://app.clawmetry.com/auth?token=' + encodeURIComponent(d.token || d.api_key), '_blank'); closeCloudModal(); _updateCloudStatus(); }, 1800);
+        setTimeout(function(){
+          try { window.open('https://app.clawmetry.com/auth?token=' + encodeURIComponent(d.token), '_blank'); } catch (e) {}
+          closeCloudModal();
+          _updateCloudStatus();
+          // Reload so /api/onboarding/state re-reads the freshly written
+          // gate file and the dashboard boots without the modal.
+          try { location.reload(); } catch (e) {}
+        }, 1800);
       } else {
         var err = document.getElementById('cloud-otp-error');
         err.textContent = d.error || 'Invalid code. Try again.';


### PR DESCRIPTION
## Summary

Two independent bugs left the onboarding gate re-prompting even after the user completed cloud sign-in. Founder report 2026-08-12: modal re-appeared on every dashboard launch, `clawmetry status` said Not connected + Free.

### Bug 1 — dashboard cloud modal never paired the local machine

`clawmetry/static/js/gw-setup.js::cloudVerifyOtp()` posted OTP directly to `https://app.clawmetry.com/api/otp/verify`. Cloud minted a key, set the browser cookie, and redirected — but the LOCAL dashboard never saw the token. `_write_cloud_token()` was never called, `/api/cloud-cta/status` stayed `connected:false`, and the gate kept firing.

**Fix:** route OTP verify through `/api/cloud-cta/verify-otp` (which persists the `cm_` key via `_write_cloud_token`), then POST `/api/onboarding/complete {choice:'managed'}` to write the gate file, enable cloud sync, register the persistent daemon, and reload so the modal never re-fires.

### Bug 2 — desktop pane recorded signed_in:false when apply_cm_key failed

`desktop/app.py::_write_onboarding_marker()` derived `signed_in` from `apply_cm_key`'s subprocess exit code. So a good OTP + valid `cm_` key + a failed `clawmetry connect` subprocess (bad venv, missing binary, transient network) → `signed_in:false, mode:""` on disk → dashboard gate re-prompts even though the USER successfully signed in.

Simultaneously, `desktop/onboarding.py::apply_cm_key` had no fallback: if the subprocess failed, the freshly-minted key was thrown away entirely.

**Fixes:**
- `apply_cm_key`: on subprocess failure, still persist the valid `cm_` key to `~/.openclaw/openclaw.json` (same path `_write_cloud_token` writes). Machine ends up paired for identity even if daemon-start / pro-provisioning didn't complete — those can be retried later.
- `_write_onboarding_marker`: `signed_in` reflects USER-perspective success (a `captured_key` was minted), not subprocess exit code. `mode` carries `captured_mode` unconditionally.

## Test plan

- [x] 12 new tests in `tests/test_desktop_onboarding.py` pinning: subprocess-failure fallback persists the key, `signed_in` is derived from key presence not exit code, marker respects the captured mode, existing keys aren't overwritten, malformed cloud responses fall through, corrupted JSON in `openclaw.json` gets replaced.
- [x] All 35 desktop-onboarding tests pass (12 new + 23 existing).
- [x] Hot-patched into local venv; verified end-to-end via a headless OAuth pair — `clawmetry status` reports `Cloud sync: ✅ Connected`, `/api/onboarding/state` returns `{required:false, source:gate, state:managed}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)