### PR TITLE
fix(onboarding): cloud sign-in activates 7-day Pro trial (parity with self-host)

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -18037,15 +18037,70 @@ def _persist_identity_with_key(api_key):
     return node_id, enc_key
 
 
+def _activate_trial_for_key(api_key) -> str:
+    """Mint-or-reuse the account's 7-day Pro trial for ``api_key``.
+
+    Mirrors ``clawmetry.cli._activate_signup_trial`` — same
+    ``/api/license/trial/signup`` endpoint, same idempotent server
+    semantics — but takes the key as an argument so in-process pairing
+    paths (dashboard cloud modal OTP, OAuth loopback bridge) can call it
+    without having to first round-trip through
+    ``~/.clawmetry/config.json``. Returns
+    ``'active' | 'expired' | 'unavailable'`` for the caller to surface;
+    every failure path returns ``'unavailable'`` (never raises).
+
+    Founder ask 2026-08-12: cloud users MUST get the same 7-day Pro
+    trial that self-host users get on sign-in, so they can experience
+    the full product before deciding to pay. Previously the cloud rail
+    only enabled sync and left the account on FREE.
+    """
+    if not (api_key or "").startswith("cm_"):
+        return "unavailable"
+    try:
+        import urllib.request as _ur
+        from clawmetry import license as _lic
+
+        req = _ur.Request(
+            _lic._cloud_base() + "/api/license/trial/signup",
+            data=json.dumps({"api_key": api_key}).encode(),
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with _ur.urlopen(req, timeout=15) as resp:
+            body = json.loads(resp.read().decode())
+        if not (isinstance(body, dict) and body.get("ok")):
+            return "unavailable"
+        if body.get("expired"):
+            return "expired"
+        if not body.get("key"):
+            return "unavailable"
+        ok, _msg = _lic.activate(body["key"], node_id=_lic._node_id())
+        return "active" if ok else "unavailable"
+    except Exception:
+        return "unavailable"
+
+
 def _full_connect_with_key(api_key):
     """Register this node with a verified cm_ key and start syncing.
 
     Mirrors the non-interactive parts of `clawmetry connect`: persist the
-    identity (_persist_identity_with_key), then opt into egress and ensure
-    the sync daemon is running. Returns (node_id, enc_key). Never raises
-    for non-fatal issues.
+    identity (_persist_identity_with_key), mint-or-reuse the account's
+    7-day Pro trial (same rail as the CLI's ``_activate_signup_trial``
+    and as ``_selfhost_signin_with_key``), opt into egress, and ensure
+    the sync daemon is running. Returns (node_id, enc_key, trial) where
+    trial is ``'active' | 'expired' | 'unavailable'``. Never raises for
+    non-fatal issues.
     """
     node_id, enc_key = _persist_identity_with_key(api_key)
+
+    # Mint-or-reuse the 7-day Pro trial so cloud users get the same
+    # "unlock every runtime for 7 days" onboarding self-host already
+    # gets. Founder ask 2026-08-12 — without this the cloud rail was
+    # asymmetric: self-host signup started the trial, cloud signup did
+    # not, so cloud users couldn't experience the full product before
+    # the paywall. Runs BEFORE _restart_sync_daemon so the daemon sees
+    # the freshly activated license on its first poll.
+    trial = _activate_trial_for_key(api_key)
 
     # Clear the local-only marker so the daemon actually pushes to cloud. A
     # local-only install writes ~/.clawmetry/nocloud; without this the connect
@@ -18062,7 +18117,7 @@ def _full_connect_with_key(api_key):
     # if absent" would leave it local-only forever, so we restart unconditionally.
     _restart_sync_daemon()
 
-    return node_id, enc_key
+    return node_id, enc_key, trial
 
 
 def _restart_sync_daemon():
@@ -18117,28 +18172,11 @@ def _selfhost_signin_with_key(api_key):
 
     node_id, _enc = _persist_identity_with_key(api_key)
 
-    trial = "unavailable"
-    try:
-        import urllib.request as _ur
-        from clawmetry import license as _lic
-
-        req = _ur.Request(
-            _lic._cloud_base() + "/api/license/trial/signup",
-            data=json.dumps({"api_key": api_key}).encode(),
-            headers={"Content-Type": "application/json"},
-            method="POST",
-        )
-        with _ur.urlopen(req, timeout=15) as resp:
-            body = json.loads(resp.read().decode())
-        if isinstance(body, dict) and body.get("ok"):
-            if body.get("expired"):
-                trial = "expired"
-            elif body.get("key"):
-                ok, _msg = _lic.activate(body["key"], node_id=_lic._node_id())
-                if ok:
-                    trial = "active"
-    except Exception:
-        pass
+    # Same trial rail as _full_connect_with_key (cloud) and
+    # clawmetry.cli._activate_signup_trial — mint-or-reuse the 7-day
+    # Pro trial. Delegated to the shared helper so cloud + self-host
+    # never drift on trial semantics again (founder ask 2026-08-12).
+    trial = _activate_trial_for_key(api_key)
 
     # Same as the email-OTP trial path: make sure the local ingest daemon is
     # running (it stays local-only under the marker written above).
@@ -18234,10 +18272,10 @@ def _start_oauth_bridge(provider, mode="managed"):
                                  "mode": mode, "node_id": node_id, "enc_key": "",
                                  "trial": trial, "error": ""}
             else:
-                node_id, enc_key = _full_connect_with_key(tok)
+                node_id, enc_key, trial = _full_connect_with_key(tok)
                 _OAUTH_BRIDGE = {"status": "connected", "provider": provider,
                                  "mode": mode, "node_id": node_id,
-                                 "enc_key": enc_key, "trial": "", "error": ""}
+                                 "enc_key": enc_key, "trial": trial, "error": ""}
         except Exception as e:  # pragma: no cover - defensive
             _OAUTH_BRIDGE = {"status": "error", "provider": provider, "mode": mode,
                              "node_id": "", "enc_key": "", "trial": "",

--- a/routes/overview.py
+++ b/routes/overview.py
@@ -1931,8 +1931,28 @@ def cloud_cta_verify_otp():
         with _ur.urlopen(_req, timeout=10) as _resp:
             result = _jr.loads(_resp.read())
             if result.get("token"):
-                _d._write_cloud_token(result["token"])
-                return jsonify({"ok": True, "token": result["token"]})
+                # Route through _full_connect_with_key so this path is
+                # symmetric with the OAuth loopback bridge AND with
+                # `clawmetry connect --start-sync-now` — persist identity
+                # into ~/.clawmetry/config.json, mint-or-reuse the 7-day
+                # Pro trial, enable cloud egress, restart the sync daemon.
+                # The earlier one-liner _write_cloud_token() persisted only
+                # the cm_ key and left the account on FREE with no trial;
+                # founder ask 2026-08-12: cloud users must get the same
+                # 7-day trial self-host gets, or they can't experience the
+                # full product before deciding to pay.
+                trial = "unavailable"
+                try:
+                    _node_id, _enc_key, trial = _d._full_connect_with_key(result["token"])
+                except Exception:
+                    # If _full_connect_with_key fails, still persist the
+                    # token — pairing is more important than daemon restart
+                    # or trial activation, which recover naturally later.
+                    try:
+                        _d._write_cloud_token(result["token"])
+                    except Exception:
+                        pass
+                return jsonify({"ok": True, "token": result["token"], "trial": trial})
             return jsonify({"ok": False, "error": result.get("error", "Invalid code")})
     except Exception as _ex:
         try:

--- a/tests/test_cloud_cta_oauth.py
+++ b/tests/test_cloud_cta_oauth.py
@@ -154,10 +154,14 @@ def test_full_connect_writes_config_and_clears_nocloud(tmp_path, monkeypatch):
     monkeypatch.setattr(_d, "_is_macos", lambda: False)
     monkeypatch.setattr(_d, "_is_linux", lambda: False)
     monkeypatch.setattr(_d, "_start_daemon_background", lambda: None)
+    # Neutralize trial activation — its own semantics are covered by
+    # test_full_connect_activates_trial below.
+    monkeypatch.setattr(_d, "_activate_trial_for_key", lambda tok: "unavailable")
 
-    node_id, enc_key = _d._full_connect_with_key("cm_testkey123")
+    node_id, enc_key, trial = _d._full_connect_with_key("cm_testkey123")
     assert node_id == "node-xyz"
     assert enc_key  # auto-generated
+    assert trial in ("active", "expired", "unavailable")
 
     cfg = json.loads((home / ".clawmetry" / "config.json").read_text())
     assert cfg["api_key"] == "cm_testkey123"
@@ -441,3 +445,216 @@ def test_selfhost_intent_signals(monkeypatch, tmp_path):
     assert _d._selfhost_intent() is False
     monkeypatch.setattr(_ob, "_read_choice_file", lambda: {})
     assert _d._selfhost_intent() is False
+
+
+# ─── 7-day Pro trial parity (founder ask 2026-08-12) ────────────────────
+# Cloud sign-in used to leave the account on FREE while self-host activated
+# the 7-day Pro trial. Both rails must now hit the same
+# /api/license/trial/signup endpoint via _activate_trial_for_key so cloud
+# users can experience every runtime before deciding to pay.
+
+
+def test_activate_trial_for_key_rejects_non_cm_prefix(monkeypatch):
+    """Guard: only real cm_ keys reach the cloud trial endpoint."""
+    import dashboard as _d
+
+    def _boom(*_a, **_k):
+        raise AssertionError("must not call urlopen for non-cm_ keys")
+
+    monkeypatch.setattr("urllib.request.urlopen", _boom)
+    assert _d._activate_trial_for_key("") == "unavailable"
+    assert _d._activate_trial_for_key("bogus") == "unavailable"
+    assert _d._activate_trial_for_key(None) == "unavailable"
+
+
+def test_activate_trial_for_key_returns_active_on_fresh_signup(monkeypatch):
+    """Happy path: cloud mints a key, _lic.activate accepts it → 'active'."""
+    import dashboard as _d
+    from clawmetry import license as _lic
+
+    class _FakeResp:
+        def __init__(self, body):
+            self._body = body
+        def __enter__(self):
+            return self
+        def __exit__(self, *a):
+            return False
+        def read(self):
+            import json as _j
+            return _j.dumps(self._body).encode()
+
+    def _fake_urlopen(_req, timeout=15):
+        return _FakeResp({"ok": True, "key": "LIC_test", "expires_at": 9999999999})
+
+    monkeypatch.setattr("urllib.request.urlopen", _fake_urlopen)
+    monkeypatch.setattr(_lic, "activate", lambda key, node_id=None: (True, "ok"))
+    monkeypatch.setattr(_lic, "_node_id", lambda: "node-xyz")
+    monkeypatch.setattr(_lic, "_cloud_base", lambda: "https://app.example.com")
+
+    assert _d._activate_trial_for_key("cm_valid_signup_key") == "active"
+
+
+def test_activate_trial_for_key_returns_expired_when_server_says_so(monkeypatch):
+    """A returning user whose trial has ended must NOT be reported as active."""
+    import dashboard as _d
+    from clawmetry import license as _lic
+
+    class _FakeResp:
+        def __enter__(self):
+            return self
+        def __exit__(self, *a):
+            return False
+        def read(self):
+            import json as _j
+            return _j.dumps({"ok": True, "expired": True}).encode()
+
+    monkeypatch.setattr("urllib.request.urlopen", lambda *a, **k: _FakeResp())
+    # activate() must not be called on an expired trial.
+    monkeypatch.setattr(_lic, "activate", lambda *a, **k: (_ for _ in ()).throw(
+        AssertionError("expired trial must not activate")))
+    monkeypatch.setattr(_lic, "_cloud_base", lambda: "https://app.example.com")
+
+    assert _d._activate_trial_for_key("cm_returning_expired") == "expired"
+
+
+def test_activate_trial_for_key_swallows_network_errors(monkeypatch):
+    """Offline / server-down must never crash the pairing path."""
+    import dashboard as _d
+    from clawmetry import license as _lic
+
+    def _fake_urlopen(*_a, **_k):
+        raise OSError("network unreachable")
+
+    monkeypatch.setattr("urllib.request.urlopen", _fake_urlopen)
+    monkeypatch.setattr(_lic, "_cloud_base", lambda: "https://app.example.com")
+
+    assert _d._activate_trial_for_key("cm_offline_test") == "unavailable"
+
+
+def test_full_connect_activates_trial(monkeypatch, tmp_path):
+    """The cloud sign-in path (_full_connect_with_key) MUST call
+    _activate_trial_for_key with the freshly-verified cm_ key.
+
+    Regression guard for founder report 2026-08-12: before this fix cloud
+    signup left the account on FREE with no trial, so cloud users saw
+    Runtimes locked and couldn't experience the paid product before the
+    paywall — while self-host users got the 7-day trial automatically."""
+    import dashboard as _d
+    from clawmetry import sync as _sync
+
+    home = tmp_path / "home"
+    (home / ".clawmetry").mkdir(parents=True)
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setattr(_d.os.path, "expanduser",
+                        lambda p: p.replace("~", str(home)))
+    monkeypatch.setattr(_sync, "CONFIG_DIR", home / ".clawmetry")
+    monkeypatch.setattr(_sync, "CONFIG_FILE", home / ".clawmetry" / "config.json")
+    monkeypatch.setattr(_sync, "validate_key", lambda *a, **k: {"node_id": "n1"})
+    monkeypatch.setattr(_d, "_write_cloud_token", lambda tok: None)
+    monkeypatch.setattr(_d, "_is_sync_running", lambda: True)
+    monkeypatch.setattr(_d, "_is_macos", lambda: False)
+    monkeypatch.setattr(_d, "_is_linux", lambda: False)
+    monkeypatch.setattr(_d, "_start_daemon_background", lambda: None)
+
+    seen = {}
+    def _fake_trial(tok):
+        seen["key"] = tok
+        return "active"
+    monkeypatch.setattr(_d, "_activate_trial_for_key", _fake_trial)
+
+    node_id, enc_key, trial = _d._full_connect_with_key("cm_founder_signup")
+
+    assert seen.get("key") == "cm_founder_signup", (
+        "_full_connect_with_key must forward the exact cm_ key to "
+        "_activate_trial_for_key — cloud users get NO trial otherwise"
+    )
+    assert trial == "active"
+    assert node_id == "n1"
+    assert enc_key
+
+
+def test_verify_otp_activates_trial(monkeypatch):
+    """The dashboard cloud modal OTP path (/api/cloud-cta/verify-otp) must
+    route through _full_connect_with_key so trial activation happens for
+    OTP signups the same way it happens for OAuth signups."""
+    import dashboard as _d
+    import routes.overview as _ov
+    from flask import Flask
+
+    app = Flask(__name__)
+    app.register_blueprint(_ov.bp_overview)
+
+    # Fake cloud OTP verify — returns a valid cm_ token.
+    class _FakeResp:
+        def __enter__(self):
+            return self
+        def __exit__(self, *a):
+            return False
+        def read(self):
+            import json as _j
+            return _j.dumps({"ok": True, "token": "cm_from_otp"}).encode()
+
+    monkeypatch.setattr("urllib.request.urlopen", lambda *a, **k: _FakeResp())
+
+    seen = {}
+    def _fake_full_connect(tok):
+        seen["key"] = tok
+        return "n2", "enc", "active"
+    monkeypatch.setattr(_d, "_full_connect_with_key", _fake_full_connect)
+
+    client = app.test_client()
+    resp = client.post("/api/cloud-cta/verify-otp",
+                       json={"email": "user@test.com", "code": "123456"})
+    body = resp.get_json()
+
+    assert body.get("ok") is True
+    assert body.get("token") == "cm_from_otp"
+    assert body.get("trial") == "active", (
+        "verify-otp must surface the trial state so the frontend can "
+        "confirm the 7-day rail activated"
+    )
+    assert seen.get("key") == "cm_from_otp", (
+        "verify-otp must route the token through _full_connect_with_key "
+        "(NOT just _write_cloud_token) — otherwise cloud OTP users get "
+        "no trial and can't experience paid runtimes before paywall"
+    )
+
+
+def test_selfhost_and_cloud_use_same_trial_helper(monkeypatch, tmp_path):
+    """DRY guard: both signin helpers must share _activate_trial_for_key
+    so cloud and self-host can never drift on trial semantics again."""
+    import dashboard as _d
+    from clawmetry import sync as _sync, config as _cfg
+
+    home = tmp_path / "home"
+    (home / ".clawmetry").mkdir(parents=True)
+    marker = home / ".clawmetry" / "nocloud"
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setattr(_d.os.path, "expanduser",
+                        lambda p: p.replace("~", str(home)))
+    monkeypatch.setattr(_sync, "CONFIG_DIR", home / ".clawmetry")
+    monkeypatch.setattr(_sync, "CONFIG_FILE", home / ".clawmetry" / "config.json")
+    monkeypatch.setattr(_sync, "validate_key", lambda *a, **k: {"node_id": "n"})
+    monkeypatch.setattr(_cfg, "NOCLOUD_MARKER_PATH", str(marker))
+    monkeypatch.setattr(_d, "_write_cloud_token", lambda tok: None)
+    monkeypatch.setattr(_d, "_is_sync_running", lambda: True)
+    monkeypatch.setattr(_d, "_is_macos", lambda: False)
+    monkeypatch.setattr(_d, "_is_linux", lambda: False)
+    monkeypatch.setattr(_d, "_start_daemon_background", lambda: None)
+    # Neutralize the routes.trial ensure_local_daemon call.
+    import types as _t
+    fake_mod = _t.SimpleNamespace(_ensure_local_daemon=lambda: None)
+    monkeypatch.setitem(__import__("sys").modules, "routes.trial", fake_mod)
+
+    calls = []
+    monkeypatch.setattr(_d, "_activate_trial_for_key",
+                        lambda tok: calls.append(tok) or "active")
+
+    _d._full_connect_with_key("cm_cloud")
+    _d._selfhost_signin_with_key("cm_selfhost")
+
+    assert calls == ["cm_cloud", "cm_selfhost"], (
+        "both cloud and self-host sign-in helpers must call the SAME "
+        "trial helper — the founder ask 2026-08-12 was exactly that "
+        "parity between the two rails"
+    )


### PR DESCRIPTION
## Summary

Founder ask 2026-08-12 (asap): *\"when user clicks ClawMetry Cloud in onboarding we should start the 7-day Pro trial, same as we do for self-host — users should experience the full product for 7 days so they can start paying after end of 7 days.\"*

Cloud signups landed on **FREE** with paid runtimes locked; self-host signups got the full 7-day rail. Exactly backwards from what gets users onto Pro after the trial ends.

## Root cause

Only `clawmetry connect` (CLI + desktop pane's `apply_cm_key` subprocess) called `_activate_signup_trial` → `/api/license/trial/signup`. Three in-process cloud pairing paths skipped it entirely:

1. Dashboard cloud modal OTP (`/api/cloud-cta/verify-otp`) — only called `_write_cloud_token`.
2. OAuth loopback bridge (cloud rail) → `_full_connect_with_key` — persisted identity, enabled cloud, restarted daemon, but no trial. Meanwhile the sibling `_selfhost_signin_with_key` DID mint the trial.
3. Any direct caller of `_write_cloud_token`.

## Fix

- **`dashboard._activate_trial_for_key(api_key)`** — new helper, takes the cm_ key directly so in-process paths don't need to bounce through `~/.clawmetry/config.json` first. Returns `'active' | 'expired' | 'unavailable'`, never raises.
- **`_full_connect_with_key`** — calls the helper before `enable_cloud()`/daemon restart. Return grows from `(node_id, enc_key)` → `(node_id, enc_key, trial)`. OAuth bridge callback updated to unpack the new tuple and surface trial state on `_OAUTH_BRIDGE`.
- **`_selfhost_signin_with_key`** — replaces its inline trial block with a call to the same helper. Cloud + self-host now share ONE trial rail.
- **`/api/cloud-cta/verify-otp`** — routes through `_full_connect_with_key` instead of just `_write_cloud_token`, so OTP signups mint the trial too. Response body gains `trial`. Falls back to `_write_cloud_token` on exceptions so pairing succeeds even if daemon restart / trial mint fails.

## Test plan

- [x] 6 new tests in `tests/test_cloud_cta_oauth.py` pinning:
  - `_activate_trial_for_key` rejects non-cm_ prefixes without touching the network; happy path returns `'active'`; expired trial returns `'expired'` without calling `activate()`; network errors return `'unavailable'` without raising.
  - `_full_connect_with_key` MUST call `_activate_trial_for_key` with the exact cm_ key.
  - `/api/cloud-cta/verify-otp` MUST route through `_full_connect_with_key` (NOT `_write_cloud_token`).
  - DRY guard: cloud + self-host helpers call the SAME trial helper — pinned so a future refactor can't reintroduce the drift.
- [x] All 27 tests in `test_cloud_cta_oauth.py` green (6 new + 21 existing).
- [x] Related CLI trial tests still green: `test_connect_provisioning_order` + `test_onboard_local_default` + `test_connect_otp_skip` + `test_login_bare_namespace` — 31 pass total, no regressions.

## Shipping

- pip wheel: ships via next `[RELEASE]` carrier — fleet auto-updates within ~6h; anyone on the CTA path stops seeing FREE + locked runtimes immediately after sign-in.
- .dmg desktop pane: unaffected (already went through `clawmetry connect` which already activated the trial). This PR closes the parity gap for the browser/OTP/OAuth surfaces only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)