### PR TITLE
fix(connect): non-interactive callers no longer hang on encryption-key input() (root cause of trial-less cloud signups)

### DIFF
--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -1160,6 +1160,27 @@ def _cmd_connect(args) -> None:
     print()
     if not _keep_local_signin and not _server_plaintext:
         print("🔐 Encryption key protects your data end-to-end.")
+
+    # Non-interactive callers (--start-sync-now / --keep-local from the
+    # dashboard's OTP paste-and-go and the desktop pane's apply_cm_key
+    # subprocess; also any pipe/redirect where stdin isn't a TTY) must
+    # never hit `input()` — the desktop pane runs connect with
+    # capture_output=True and `input()` raises EOFError, killing the
+    # whole subprocess and leaving the user paired-but-trial-less.
+    # Founder 2026-08-13 hit exactly this: signed up via the desktop
+    # pane cloud pane, saw `Cloud Connected` in the dashboard (my
+    # _fallback_persist_cm_key from #4776 caught the failure and saved
+    # the token), but `clawmetry status` showed Free with no trial
+    # because the subprocess crashed BEFORE reaching
+    # _activate_signup_trial. In non-interactive mode we silently keep
+    # the existing key (keychain/config) or auto-generate one — the
+    # user can re-key later from Settings if they want a custom secret.
+    _non_interactive = (
+        bool(getattr(args, "start_sync_now", False))
+        or _keep_local_signin
+        or not sys.stdin.isatty()
+    )
+
     if _keep_local_signin:
         pass  # enc_key already chosen above, silently
     elif _server_plaintext:
@@ -1171,18 +1192,28 @@ def _cmd_connect(args) -> None:
     elif _kc_key:
         masked = _kc_key[:6] + "…" + _kc_key[-4:]
         print(f"  Key from OS keychain: {masked}")
-        custom_key = _input("  Press Enter to keep it, or type a new one: ").strip()
-        enc_key = _derive_key_for_storage(custom_key) if custom_key else _kc_key
+        if _non_interactive:
+            enc_key = _kc_key
+        else:
+            custom_key = _input("  Press Enter to keep it, or type a new one: ").strip()
+            enc_key = _derive_key_for_storage(custom_key) if custom_key else _kc_key
     elif _saved_enc_key:
         masked = _saved_enc_key[:6] + "…" + _saved_enc_key[-4:]
         print(f"  Existing key: {masked}")
-        custom_key = _input("  Press Enter to keep it, or type a new one: ").strip()
-        enc_key = _derive_key_for_storage(custom_key) if custom_key else _saved_enc_key
+        if _non_interactive:
+            enc_key = _saved_enc_key
+        else:
+            custom_key = _input("  Press Enter to keep it, or type a new one: ").strip()
+            enc_key = _derive_key_for_storage(custom_key) if custom_key else _saved_enc_key
     else:
-        custom_key = _input(
-            "  Enter a custom secret key (or press Enter to auto-generate): "
-        ).strip()
-        enc_key = _derive_key_for_storage(custom_key) if custom_key else generate_encryption_key()
+        if _non_interactive:
+            enc_key = generate_encryption_key()
+            print("  Encryption key auto-generated (change in Settings).")
+        else:
+            custom_key = _input(
+                "  Enter a custom secret key (or press Enter to auto-generate): "
+            ).strip()
+            enc_key = _derive_key_for_storage(custom_key) if custom_key else generate_encryption_key()
 
     if enc_key:
         _keychain_set(node_id, enc_key)  # persist to OS keychain when available

--- a/desktop/onboarding.py
+++ b/desktop/onboarding.py
@@ -330,9 +330,55 @@ def _fallback_persist_cm_key(cm_key: str) -> bool:
         cm["cloudToken"] = cm_key
         data["clawmetry"] = cm
         openclaw_path.write_text(json.dumps(data, indent=2))
-        return True
     except OSError:
         return False
+
+    # Defense-in-depth: also mint the account's 7-day Pro trial directly
+    # via /api/license/trial/signup, so a subprocess failure never leaves
+    # a user paired-but-trial-less. Founder 2026-08-13 hit exactly this:
+    # `clawmetry connect` crashed on an EOFError from an interactive
+    # input() (fixed in this same PR) BEFORE reaching
+    # _activate_signup_trial, so the fallback saved the token but the
+    # account stayed on FREE. The primary fix (non-interactive prompts)
+    # closes the specific hole, but this fallback covers every other
+    # class of subprocess failure — network hiccup, missing binary,
+    # permissions — that would otherwise re-open the same wound.
+    # Best-effort; the pairing already succeeded above, so we always
+    # return True even if trial mint fails (it can retry via CLI later).
+    _fallback_mint_trial(cm_key)
+    return True
+
+
+def _fallback_mint_trial(cm_key: str) -> None:
+    """POST /api/license/trial/signup, activate the returned key locally.
+
+    Standalone from ``clawmetry.cli._activate_signup_trial`` because that
+    function reads its api_key from ``~/.clawmetry/config.json``, which
+    the subprocess didn't get to write. This variant takes the key
+    directly. Never raises."""
+    try:
+        base = resolve_app_base()
+        req = urllib.request.Request(
+            base + "/api/license/trial/signup",
+            data=json.dumps({"api_key": cm_key}).encode(),
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=15, context=_ssl_context()) as resp:
+            body = json.loads(resp.read().decode())
+        if not (isinstance(body, dict) and body.get("ok") and body.get("key")):
+            return
+        # Server-side license activation writes ~/.clawmetry/license
+        # via clawmetry.license.activate — import lazily so the shell
+        # keeps starting cleanly even if the venv's clawmetry install
+        # is broken (the whole reason we're in the fallback).
+        try:
+            from clawmetry import license as _lic
+            _lic.activate(body["key"], node_id=_lic._node_id())
+        except Exception:
+            pass
+    except Exception:
+        pass
 
 
 def apply_cm_key(

--- a/tests/test_apply_cm_key_fallback_persist.py
+++ b/tests/test_apply_cm_key_fallback_persist.py
@@ -254,3 +254,209 @@ def test_apply_cm_key_selfhost_failure_also_persists(fake_home, tmp_path, monkey
 
     assert ok is False
     assert _openclaw_token(fake_home) == "cm_selfhost"
+
+
+# ─── Trial mint on the fallback path (founder ask 2026-08-13) ────────────
+# The subprocess fallback used to just persist the cm_ key. That left the
+# dashboard reporting "Cloud Connected" but the account on FREE with no
+# trial, because _activate_signup_trial only runs inside the (crashed)
+# `clawmetry connect` subprocess. The fallback must now ALSO mint the
+# trial directly via /api/license/trial/signup.
+
+
+def test_fallback_mints_trial_after_subprocess_failure(fake_home, monkeypatch):
+    """When the connect subprocess fails, the fallback must also POST to
+    /api/license/trial/signup so the user actually gets the trial they
+    just signed up for. Regression guard for founder report 2026-08-13:
+    dashboard showed Cloud Connected but Plan stayed Free because the
+    subprocess crashed on an EOFError before reaching
+    _activate_signup_trial."""
+    posted = {}
+
+    class _FakeResp:
+        def __enter__(self):
+            return self
+        def __exit__(self, *a):
+            return False
+        def read(self):
+            return json.dumps({"ok": True, "key": "LIC_test",
+                               "expires_at": 9999999999}).encode()
+
+    def _fake_urlopen(req, timeout=15, context=None):
+        posted["url"] = req.full_url
+        posted["body"] = json.loads(req.data.decode())
+        return _FakeResp()
+
+    monkeypatch.setattr("urllib.request.urlopen", _fake_urlopen)
+    monkeypatch.setattr(desk_onb, "_ssl_context", lambda: None)
+
+    # activate() writes ~/.clawmetry/license — capture the call
+    activated = {}
+    class _FakeLic:
+        @staticmethod
+        def activate(key, node_id=None):
+            activated["key"] = key
+            activated["node_id"] = node_id
+            return True, "ok"
+        @staticmethod
+        def _node_id():
+            return "test-node"
+    monkeypatch.setitem(sys.modules, "clawmetry.license", _FakeLic)
+
+    ok = desk_onb._fallback_persist_cm_key("cm_founder_trial")
+
+    assert ok is True
+    assert posted.get("body", {}).get("api_key") == "cm_founder_trial", (
+        "_fallback_persist_cm_key must POST the cm_ key to "
+        "/api/license/trial/signup — otherwise cloud users hit "
+        "subprocess failures land on FREE with no trial"
+    )
+    assert "/api/license/trial/signup" in posted.get("url", "")
+    assert activated.get("key") == "LIC_test", (
+        "returned license key must be activated locally via "
+        "clawmetry.license.activate — otherwise the license file is "
+        "never written and `clawmetry status` still says Free"
+    )
+
+
+def test_fallback_trial_mint_never_raises_on_network_error(fake_home, monkeypatch):
+    """Trial mint is best-effort — network failures must not break
+    pairing. The cm_ key is already saved; the trial can retry later."""
+    def _fake_urlopen(*a, **kw):
+        raise OSError("network unreachable")
+    monkeypatch.setattr("urllib.request.urlopen", _fake_urlopen)
+
+    ok = desk_onb._fallback_persist_cm_key("cm_offline_test")
+
+    assert ok is True, "network failure must not undo the pairing"
+    assert _openclaw_token(fake_home) == "cm_offline_test"
+
+
+def test_fallback_trial_mint_swallows_activate_errors(fake_home, monkeypatch):
+    """A broken clawmetry.license import must not abort the pairing —
+    this fallback runs precisely because the venv might be busted."""
+    class _FakeResp:
+        def __enter__(self):
+            return self
+        def __exit__(self, *a):
+            return False
+        def read(self):
+            return json.dumps({"ok": True, "key": "LIC_x"}).encode()
+
+    monkeypatch.setattr("urllib.request.urlopen",
+                        lambda *a, **kw: _FakeResp())
+    monkeypatch.setattr(desk_onb, "_ssl_context", lambda: None)
+
+    class _BrokenLic:
+        @staticmethod
+        def activate(*a, **kw):
+            raise RuntimeError("boom")
+        @staticmethod
+        def _node_id():
+            return "n"
+    monkeypatch.setitem(sys.modules, "clawmetry.license", _BrokenLic)
+
+    ok = desk_onb._fallback_persist_cm_key("cm_broken_venv")
+
+    assert ok is True
+
+
+def test_fallback_trial_mint_swallows_server_no_key(fake_home, monkeypatch):
+    """Server returns ok:false or omits key → don't try to activate."""
+    class _FakeResp:
+        def __enter__(self):
+            return self
+        def __exit__(self, *a):
+            return False
+        def read(self):
+            return json.dumps({"ok": False, "error": "unknown"}).encode()
+
+    monkeypatch.setattr("urllib.request.urlopen",
+                        lambda *a, **kw: _FakeResp())
+    monkeypatch.setattr(desk_onb, "_ssl_context", lambda: None)
+
+    activate_calls = []
+    class _NoLic:
+        @staticmethod
+        def activate(*a, **kw):
+            activate_calls.append(a)
+            return True, ""
+    monkeypatch.setitem(sys.modules, "clawmetry.license", _NoLic)
+
+    ok = desk_onb._fallback_persist_cm_key("cm_bad_signup")
+
+    assert ok is True
+    assert activate_calls == [], (
+        "must not activate when server returned no key"
+    )
+
+
+# ─── cli.py: --start-sync-now / non-TTY stdin must skip input() ──────────
+# The interactive encryption-key prompt raised EOFError inside the desktop
+# pane's non-interactive subprocess, killing `clawmetry connect` before
+# _activate_signup_trial could run. --start-sync-now (and any non-TTY
+# invocation) must now auto-select a key silently.
+
+
+def test_connect_start_sync_now_skips_interactive_enc_key_prompt():
+    """The specific EOFError → founder-on-Free path. Verifies via source
+    inspection that the non-interactive branches never call _input for
+    the encryption key. A previous behavior test would be too coupled
+    to _cmd_connect's many pre-conditions to run in-process; the source
+    guard is what durably prevents the regression."""
+    import inspect
+
+    from clawmetry import cli
+    src = inspect.getsource(cli._cmd_connect)
+
+    # The guard variable must exist and be composed of exactly the
+    # three signals we settled on. Change the assertion when you
+    # intentionally widen or narrow the trigger.
+    assert '_non_interactive = (' in src, (
+        "_cmd_connect must gate enc-key prompts on a _non_interactive "
+        "flag — apply_cm_key subprocesses have no TTY and input() "
+        "raises EOFError otherwise (founder 2026-08-13)"
+    )
+    assert 'getattr(args, "start_sync_now"' in src
+    assert '_keep_local_signin' in src
+    assert 'sys.stdin.isatty()' in src
+
+    # Each of the three branches that used to unconditionally prompt
+    # (_kc_key, _saved_enc_key, no-key-at-all) must now have an
+    # `if _non_interactive:` guard. Count them.
+    assert src.count('if _non_interactive:') == 3, (
+        f"expected 3 `if _non_interactive:` guards (one per enc-key "
+        f"branch that previously always prompted); found "
+        f"{src.count('if _non_interactive:')}. Missing a guard means "
+        "some non-interactive callers still crash on EOFError."
+    )
+
+
+def test_connect_non_interactive_when_stdin_not_a_tty():
+    """The trigger must fire on ANY non-TTY stdin, not just the flags —
+    a user redirecting `echo | clawmetry connect ...` shouldn't hang
+    either. Belt+braces beyond --start-sync-now."""
+    import inspect
+    from clawmetry import cli
+    src = inspect.getsource(cli._cmd_connect)
+
+    # sys.stdin.isatty() must be part of the OR chain, not just any
+    # mention elsewhere in the function. Walk the parens to find the
+    # true closing `)` of `_non_interactive = (...)`.
+    start = src.index('_non_interactive = (')
+    depth = 0
+    end = None
+    for i in range(start + len('_non_interactive = '), len(src)):
+        if src[i] == '(':
+            depth += 1
+        elif src[i] == ')':
+            depth -= 1
+            if depth == 0:
+                end = i
+                break
+    assert end is not None, "malformed _non_interactive assignment"
+    ni_block = src[start:end + 1]
+    assert 'not sys.stdin.isatty()' in ni_block, (
+        "non-interactive gate must also fire when stdin isn't a TTY, "
+        "so piped/redirected invocations don't crash on input()"
+    )


### PR DESCRIPTION
## Summary

Investigating founder report 2026-08-13 — desktop-pane cloud OTP signup landed with dashboard showing `Cloud Connected` but `clawmetry status` reporting Free + no trial — I found the **real** root cause of every trial-less cloud signup: `clawmetry connect --key cm_… --start-sync-now` was crashing on an interactive `input()` prompt for the encryption key.

```
File \"clawmetry/cli.py\", line 1182, in _cmd_connect
    custom_key = _input(\"  Enter a custom secret key (or press Enter to auto-generate): \")
File \"clawmetry/cli.py\", line 1038, in _input
    return input(prompt)
EOFError: EOF when reading a line
```

The `apply_cm_key` subprocess (desktop pane's post-OTP handler) runs with `capture_output=True` (no TTY). The enc-key `input()` fires unconditionally on every fresh install (no keychain key, no saved config key), raises `EOFError`, exit non-zero, and the process dies **BEFORE** reaching `_activate_signup_trial` at line 1242. Meanwhile #4776's `_fallback_persist_cm_key` catches the failure and saves the token — so pairing succeeds but the trial never gets minted.

This is why my earlier #4788 didn't fix the desktop-pane path: #4788 fixed the dashboard cloud modal + OAuth loopback (in-process paths), but the desktop pane goes through the CLI subprocess.

## Fix (2 parts, 1 PR)

### Part A — root cause in `clawmetry/cli.py::_cmd_connect`

Add a `_non_interactive` gate that fires on `--start-sync-now`, `--keep-local`, or `not sys.stdin.isatty()`. In non-interactive mode, silently keep the existing keychain/config key or auto-generate a fresh one instead of prompting. Users can re-key from Settings if they want a custom secret. `--start-sync-now` was already documented as \"skip prompts\" — this closes the last hole.

### Part B — defense in depth in `desktop/onboarding.py::_fallback_persist_cm_key`

Even when the connect subprocess fails (any reason: network hiccup, missing binary, permissions, whatever), also POST `/api/license/trial/signup` and activate the returned license locally. Standalone from `cli._activate_signup_trial` because that reads api_key from `~/.clawmetry/config.json` which the crashed subprocess didn't get to write.

## Test plan

- [x] 6 new tests in `tests/test_apply_cm_key_fallback_persist.py` (see commit body). 18/18 pass (6 new + 12 existing).
- [x] Related tests still green: `test_connect_provisioning_order` + `test_connect_keep_local` + `test_connect_otp_skip` + `test_cloud_cta_oauth` — 38 pass total, no regressions.
- [x] **Live-verified** on founder's machine: rescued the paired-but-Free install by running `echo \"\" | clawmetry connect --key cm_… --start-sync-now` (empty stdin = auto-generate). Result: `Pro trial active: every runtime unlocked on this machine, 7 days left.` That same silent auto-generate is now what `--start-sync-now` itself does.
- [ ] After release-on-merge fires: fresh cloud-pane OTP signup on a burner email → `clawmetry status` reports `Plan: Trial` (not `Free`) with paid runtimes watching, from a clean install with no manual rescue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)