### PR TITLE
test(e2e): OTLP ingest smoke -- POST /v1/traces to /api/spans round-trip

### DIFF
--- a/.github/workflows/oss-golden-path.yml
+++ b/.github/workflows/oss-golden-path.yml
@@ -7,6 +7,9 @@ name: OSS Golden Path (C1)
 # the user-reported bug (2026-05-17): "gateway token not passed for OSS,
 # never displays other screens." test_e2e_oss_all_tabs.py covers all 33
 # tabs; this is the first time it runs as a hard per-PR gate.
+# OTLP smoke (added 2026-08-13): POST /v1/traces -> DuckDB spans table ->
+# /api/spans round-trip (commit #4785). Runs before Playwright browser
+# install (~5s overhead, no browser needed).
 # Budget: 12 minutes wall-clock (raised from 8; Playwright chromium download
 # ~100 MB takes up to 4.5 min on a cold runner -- cache hit drops it to ~30 s;
 # C5 33-tab Playwright sweep adds ~90 s on top of the C1 9-tab sweep).
@@ -191,6 +194,22 @@ jobs:
             fi
             sleep 1
           done
+
+      # Step 5b -- OTLP trace ingest smoke (no Playwright required).
+      # Verifies the full pipeline: POST /v1/traces -> DuckDB spans table ->
+      # /api/spans returns the synthetic span. Catches regressions in the
+      # out-of-the-box OTLP receiver shipped in commit #4785 (2026-08-12).
+      # Runs BEFORE the Playwright browser install so it adds ~5s overhead
+      # regardless of whether the browser cache is warm.
+      - name: Run OTLP ingest E2E smoke
+        env:
+          CLAWMETRY_URL: http://localhost:8920
+          CLAWMETRY_TOKEN: ci-golden-token
+        run: |
+          /tmp/oss-golden/bin/python -m pytest \
+            tests/test_e2e_otlp_ingest.py \
+            -v --tb=short --junitxml=/tmp/junit-otlp.xml \
+            -m 'not quarantine'
 
       # Step 6 -- Playwright tab sweeps.
       - name: Install Playwright browsers

--- a/tests/test_e2e_otlp_ingest.py
+++ b/tests/test_e2e_otlp_ingest.py
@@ -1,0 +1,193 @@
+"""E2E smoke: OTLP trace ingest pipeline (POST /v1/traces -> /api/spans).
+
+Verifies the full pipeline introduced in commit #4785 (2026-08-12):
+
+  1. POST a synthetic OTLP JSON trace (hex traceId/spanId, no protobuf) to
+     /v1/traces.
+  2. Verify HTTP 200 -- the stdlib OTLP/JSON decoder must accept the payload.
+  3. Poll /api/spans for up to 10s for the synthetic trace to appear -- proves
+     _process_otlp_traces wrote to the DuckDB ``spans`` table and /api/spans
+     returns it.
+
+No Playwright required. Run against the golden-path server:
+
+    CLAWMETRY_URL=http://localhost:8920 CLAWMETRY_TOKEN=ci-golden-token \\
+    pytest tests/test_e2e_otlp_ingest.py -v
+
+Or against any running dashboard:
+
+    OPENCLAW_GATEWAY_TOKEN=ci-test-token python dashboard.py --port 8900 &
+    CLAWMETRY_URL=http://localhost:8900 CLAWMETRY_TOKEN=ci-test-token \\
+    pytest tests/test_e2e_otlp_ingest.py -v
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+import urllib.error
+import urllib.request
+
+import pytest
+
+BASE_URL = os.environ.get("CLAWMETRY_URL", "http://localhost:8900")
+TOKEN = os.environ.get("CLAWMETRY_TOKEN", "ci-test-token")
+
+# Unique hex IDs so this test's span is distinguishable from any ambient data.
+_TRACE_ID = "e2e00000000000000000000000000001"
+_SPAN_ID = "e2e0000000000001"
+
+# Minimal valid OTLP JSON payload (OTLP/HTTP+JSON spec).
+# Uses hex-encoded traceId/spanId and nanosecond timestamps as strings,
+# matching the format the stdlib decoder in #4785 expects.
+_OTLP_PAYLOAD: dict = {
+    "resourceSpans": [
+        {
+            "resource": {
+                "attributes": [
+                    {
+                        "key": "service.name",
+                        "value": {"stringValue": "clawmetry-e2e-otlp-smoke"},
+                    }
+                ]
+            },
+            "scopeSpans": [
+                {
+                    "scope": {"name": "e2e-smoke", "version": "1.0.0"},
+                    "spans": [
+                        {
+                            "traceId": _TRACE_ID,
+                            "spanId": _SPAN_ID,
+                            "name": "e2e-otlp-smoke-span",
+                            "kind": 1,
+                            "startTimeUnixNano": "1000000000000000000",
+                            "endTimeUnixNano": "2000000000000000000",
+                            "status": {"code": 0},
+                            "attributes": [
+                                {
+                                    "key": "e2e.smoke",
+                                    "value": {"boolValue": True},
+                                }
+                            ],
+                        }
+                    ],
+                }
+            ],
+        }
+    ]
+}
+
+
+def _auth_headers() -> dict:
+    return {
+        "Authorization": f"Bearer {TOKEN}",
+        "Content-Type": "application/json",
+    }
+
+
+def _get(path: str) -> dict:
+    req = urllib.request.Request(
+        f"{BASE_URL}{path}",
+        headers={"Authorization": f"Bearer {TOKEN}"},
+    )
+    with urllib.request.urlopen(req, timeout=10) as resp:
+        return json.loads(resp.read())
+
+
+class TestOtlpIngest:
+    """OTLP trace ingest pipeline: POST /v1/traces -> DuckDB -> /api/spans.
+
+    Acceptance test for criterion: the OTLP receiver works out of the box
+    (stdlib JSON decoder, no protobuf dep) as shipped in commit #4785.
+    """
+
+    def test_otlp_post_returns_200(self):
+        """POST /v1/traces with valid OTLP JSON must return HTTP 200.
+
+        A non-200 here means one of:
+          (a) The OTLP receiver endpoint is not registered (/v1/traces route
+              missing or blueprint not registered in dashboard.py).
+          (b) The stdlib OTLP/JSON decoder raised OtlpProtobufUnavailable
+              or a parse error (regression in clawmetry/otlp_json.py).
+          (c) The auth check rejected the bearer token (token mismatch
+              between OPENCLAW_GATEWAY_TOKEN and CLAWMETRY_TOKEN).
+        """
+        data = json.dumps(_OTLP_PAYLOAD).encode()
+        req = urllib.request.Request(
+            f"{BASE_URL}/v1/traces",
+            data=data,
+            headers=_auth_headers(),
+            method="POST",
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=10) as resp:
+                status = resp.status
+        except urllib.error.HTTPError as exc:
+            status = exc.code
+        assert status == 200, (
+            f"/v1/traces returned HTTP {status}, expected 200. "
+            f"Ensure the OTLP receiver is enabled and "
+            f"OPENCLAW_GATEWAY_TOKEN={TOKEN!r} matches the running server."
+        )
+
+    def test_otlp_span_appears_in_api_spans(self):
+        """After POST /v1/traces the synthetic span must appear in /api/spans.
+
+        Polls for up to 10s to accommodate the async ingest path: the
+        dashboard ingests OTLP spans in the sync thread, which may not
+        complete synchronously with the HTTP response to /v1/traces.
+
+        A timeout here means one of:
+          (a) _process_otlp_traces did not call clawmetry.local_store.put_span
+              (DuckDB write never happened).
+          (b) /api/spans does not query the ``spans`` table, or the daemon
+              proxy is returning an empty list instead of the DuckDB data.
+          (c) The ingest happened but the span was filtered out (e.g. by a
+              session_id filter that excluded spans with no session context).
+        """
+        # First, post the trace (tolerate prior test run already posting it).
+        data = json.dumps(_OTLP_PAYLOAD).encode()
+        req = urllib.request.Request(
+            f"{BASE_URL}/v1/traces",
+            data=data,
+            headers=_auth_headers(),
+            method="POST",
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=10):
+                pass
+        except urllib.error.HTTPError:
+            pass  # POST failure is already caught by test_otlp_post_returns_200
+
+        # Poll /api/spans for up to 10s.
+        deadline = time.monotonic() + 10.0
+        found = False
+        last_body: object = None
+        while time.monotonic() < deadline:
+            try:
+                body = _get("/api/spans")
+                last_body = body
+                spans = body.get("spans", []) if isinstance(body, dict) else []
+                for span in spans:
+                    # Match on trace_id field (the store normalises to lowercase hex).
+                    if str(span.get("trace_id", "")).lower() == _TRACE_ID.lower():
+                        found = True
+                        break
+            except Exception:
+                pass
+            if found:
+                break
+            time.sleep(0.5)
+
+        assert found, (
+            f"Synthetic span (trace_id={_TRACE_ID!r}) not found in /api/spans "
+            f"after 10s. Last /api/spans body keys: "
+            f"{list(last_body) if isinstance(last_body, dict) else type(last_body).__name__}. "
+            f"Possible causes:\n"
+            f"  (1) _process_otlp_traces did not write to DuckDB ``spans`` table;\n"
+            f"  (2) /api/spans queries a different table or filters out\n"
+            f"      spans that have no session_id;\n"
+            f"  (3) the ingest is async and 10s was not enough (unlikely on CI).\n"
+            f"Ensure the dashboard started with OPENCLAW_GATEWAY_TOKEN={TOKEN!r}."
+        )

--- a/tests/test_e2e_otlp_ingest.py
+++ b/tests/test_e2e_otlp_ingest.py
@@ -5,9 +5,14 @@ Verifies the full pipeline introduced in commit #4785 (2026-08-12):
   1. POST a synthetic OTLP JSON trace (hex traceId/spanId, no protobuf) to
      /v1/traces.
   2. Verify HTTP 200 -- the stdlib OTLP/JSON decoder must accept the payload.
-  3. Poll /api/spans for up to 10s for the synthetic trace to appear -- proves
+  3. Poll /api/spans for up to 15s for the synthetic trace to appear -- proves
      _process_otlp_traces wrote to the DuckDB ``spans`` table and /api/spans
      returns it.
+
+Timestamps: /api/spans clamps the ``since`` floor to ``now - 24h`` for
+OSS / Cloud-Free instances. The synthetic span uses ``time.time()``-based
+nanosecond timestamps so it always falls within the last minute, ensuring
+it passes the OSS 24h filter.
 
 No Playwright required. Run against the golden-path server:
 
@@ -38,6 +43,14 @@ TOKEN = os.environ.get("CLAWMETRY_TOKEN", "ci-test-token")
 _TRACE_ID = "e2e00000000000000000000000000001"
 _SPAN_ID = "e2e0000000000001"
 
+# Nanosecond timestamps computed at import time so the span always falls
+# within the last minute -- /api/spans clamps its ``since`` floor to
+# ``now - 24h`` for OSS instances, so a hardcoded historic timestamp would
+# be filtered out even when the span was correctly written to DuckDB.
+_NOW_NS: int = int(time.time() * 1_000_000_000)
+_START_NS: int = _NOW_NS - 10_000_000_000  # 10 seconds before test run
+_END_NS: int = _NOW_NS - 1_000_000_000    # 1 second before test run
+
 # Minimal valid OTLP JSON payload (OTLP/HTTP+JSON spec).
 # Uses hex-encoded traceId/spanId and nanosecond timestamps as strings,
 # matching the format the stdlib decoder in #4785 expects.
@@ -61,8 +74,8 @@ _OTLP_PAYLOAD: dict = {
                             "spanId": _SPAN_ID,
                             "name": "e2e-otlp-smoke-span",
                             "kind": 1,
-                            "startTimeUnixNano": "1000000000000000000",
-                            "endTimeUnixNano": "2000000000000000000",
+                            "startTimeUnixNano": str(_START_NS),
+                            "endTimeUnixNano": str(_END_NS),
                             "status": {"code": 0},
                             "attributes": [
                                 {
@@ -134,19 +147,25 @@ class TestOtlpIngest:
     def test_otlp_span_appears_in_api_spans(self):
         """After POST /v1/traces the synthetic span must appear in /api/spans.
 
-        Polls for up to 10s to accommodate the async ingest path: the
+        Polls for up to 15s to accommodate the async ingest path: the
         dashboard ingests OTLP spans in the sync thread, which may not
         complete synchronously with the HTTP response to /v1/traces.
+
+        Span timestamps use time.time() nanoseconds so the span always
+        falls within the last minute and is not filtered by /api/spans'
+        OSS 24h cap (Issue #1374: Cloud-Free callers are clamped to
+        now-24h; spans older than that are never returned regardless of
+        being present in the DuckDB table).
 
         A timeout here means one of:
           (a) _process_otlp_traces did not call clawmetry.local_store.put_span
               (DuckDB write never happened).
           (b) /api/spans does not query the ``spans`` table, or the daemon
               proxy is returning an empty list instead of the DuckDB data.
-          (c) The ingest happened but the span was filtered out (e.g. by a
-              session_id filter that excluded spans with no session context).
+          (c) The span was filtered out by session_id or the 24h since-cap
+              (check capped_at_24h in the last_body to confirm).
         """
-        # First, post the trace (tolerate prior test run already posting it).
+        # Post the trace (timestamps are current so they pass the 24h filter).
         data = json.dumps(_OTLP_PAYLOAD).encode()
         req = urllib.request.Request(
             f"{BASE_URL}/v1/traces",
@@ -158,10 +177,10 @@ class TestOtlpIngest:
             with urllib.request.urlopen(req, timeout=10):
                 pass
         except urllib.error.HTTPError:
-            pass  # POST failure is already caught by test_otlp_post_returns_200
+            pass  # POST failure is caught by test_otlp_post_returns_200
 
-        # Poll /api/spans for up to 10s.
-        deadline = time.monotonic() + 10.0
+        # Poll /api/spans for up to 15s.
+        deadline = time.monotonic() + 15.0
         found = False
         last_body: object = None
         while time.monotonic() < deadline:
@@ -170,7 +189,6 @@ class TestOtlpIngest:
                 last_body = body
                 spans = body.get("spans", []) if isinstance(body, dict) else []
                 for span in spans:
-                    # Match on trace_id field (the store normalises to lowercase hex).
                     if str(span.get("trace_id", "")).lower() == _TRACE_ID.lower():
                         found = True
                         break
@@ -180,14 +198,21 @@ class TestOtlpIngest:
                 break
             time.sleep(0.5)
 
+        if not found and isinstance(last_body, dict):
+            capped = last_body.get("capped_at_24h", False)
+            count = last_body.get("count", "?")
+            spans_sample = last_body.get("spans", [])[:3]
+        else:
+            capped = count = spans_sample = None
+
         assert found, (
             f"Synthetic span (trace_id={_TRACE_ID!r}) not found in /api/spans "
-            f"after 10s. Last /api/spans body keys: "
-            f"{list(last_body) if isinstance(last_body, dict) else type(last_body).__name__}. "
+            f"after 15s. Diagnostics: capped_at_24h={capped} count={count} "
+            f"first_3_spans={spans_sample}. "
             f"Possible causes:\n"
-            f"  (1) _process_otlp_traces did not write to DuckDB ``spans`` table;\n"
-            f"  (2) /api/spans queries a different table or filters out\n"
-            f"      spans that have no session_id;\n"
-            f"  (3) the ingest is async and 10s was not enough (unlikely on CI).\n"
+            f"  (1) _process_otlp_traces did not write to DuckDB spans table;\n"
+            f"  (2) /api/spans queries a different column name for trace_id;\n"
+            f"  (3) The 15s poll window was not enough (check for slow ingest).\n"
+            f"start_time_ns used: {_START_NS} (approx {int(time.time()) - _START_NS // 1_000_000_000}s ago at test time).\n"
             f"Ensure the dashboard started with OPENCLAW_GATEWAY_TOKEN={TOKEN!r}."
         )


### PR DESCRIPTION
## Summary

Adds an E2E smoke test for the OTLP trace ingest pipeline shipped in commit #4785 (2026-08-12).

**Gap closed:** `feat(otel): OTLP receiver that works out of the box` shipped with 31 unit tests but zero E2E coverage. A regression anywhere in the `POST /v1/traces -> _process_otlp_traces -> DuckDB spans table -> /api/spans` pipeline would pass all existing CI.

**What this PR adds:**

- `tests/test_e2e_otlp_ingest.py` -- two focused tests:
  - `test_otlp_post_returns_200`: POST a synthetic OTLP JSON trace (hex traceId/spanId, no protobuf dep) to `/v1/traces`, assert HTTP 200. Catches: route missing, stdlib JSON decoder broken, auth check failure.
  - `test_otlp_span_appears_in_api_spans`: after the POST, poll `/api/spans` for up to 15s for the synthetic `trace_id` to appear. Catches: `_process_otlp_traces` not writing to DuckDB, `/api/spans` not querying the `spans` table, span silently dropped.

- `.github/workflows/oss-golden-path.yml` -- new step `Run OTLP ingest E2E smoke` inserted after `Wait for session sync`, before Playwright browser install. No browser needed; adds ~5s overhead. JUnit report collected alongside C1/C5 reports.

## Test plan

- [ ] `OSS Golden Path (C1)` workflow passes on this PR (includes the new OTLP step)
- [ ] `Run OTLP ingest E2E smoke` step exits 0
- [ ] Both `test_otlp_post_returns_200` and `test_otlp_span_appears_in_api_spans` show PASSED in the JUnit artifact

## E2E Robustness Cron -- fire log

`2026-08-13T00:40Z` -- new gap identified: OTLP ingest pipeline (POST `/v1/traces` -> `/api/spans`) has zero E2E coverage despite being a new feature. PR #this closes it. Tracking issue #3970.

---
_Generated by [Claude Code](https://claude.ai/code/session_01N8tUAgVvSLDLyhhbwfK45B)_