### PR TITLE
feat(cli): --turn-off-cloud-sync purges cloud data + kicks daemon

### DIFF
--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -6370,13 +6370,143 @@ def _cmd_login(args) -> None:
     _cmd_connect(args)
 
 
+def _purge_cloud_data(api_key: str, *, timeout: float = 15.0) -> tuple[bool, str]:
+    """POST /api/account/purge-data — flush every trace of THIS account's
+    telemetry from the cloud while keeping the account itself.
+
+    Sister of the local ``--turn-off-cloud-sync`` marker flip: the marker
+    stops future egress; this call deletes what already landed on the cloud.
+    Best-effort — returns ``(ok, message)`` and never raises: if the network
+    is down or the cloud rejects, local-only mode is still in effect and
+    the user can retry the purge later. Skipped for self-hosted endpoints
+    (``CLAWMETRY_ENDPOINT`` set) — the operator owns that data plane.
+    """
+    if not api_key:
+        return (True, "no account linked")
+    try:
+        from clawmetry.endpoints import ingest_url, is_custom_endpoint
+    except Exception as e:
+        return (False, f"endpoints module unavailable: {e}")
+    if is_custom_endpoint():
+        return (True, "self-hosted endpoint — skipping managed-cloud purge")
+    import json as _json
+    import urllib.error as _ue
+    import urllib.request as _ur
+    url = ingest_url().rstrip("/") + "/api/account/purge-data"
+    req = _ur.Request(
+        url,
+        data=_json.dumps({"confirm": "PURGE_DATA"}).encode("utf-8"),
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        },
+        method="POST",
+    )
+    try:
+        with _ur.urlopen(req, timeout=timeout) as resp:
+            body = _json.loads(resp.read().decode("utf-8", errors="replace"))
+    except _ue.HTTPError as e:
+        detail = ""
+        try:
+            detail = e.read().decode("utf-8", errors="replace")[:200]
+        except Exception:
+            pass
+        # A cloud that predates this endpoint answers 404. Fall back to
+        # per-node DELETE so at least the visible node disappears.
+        if e.code in (404, 405):
+            return _purge_cloud_node_fallback(api_key, timeout=timeout)
+        return (False, f"HTTP {e.code}{': ' + detail if detail else ''}")
+    except (_ue.URLError, TimeoutError, OSError) as e:
+        return (False, f"network error: {e}")
+    except Exception as e:
+        return (False, f"unexpected: {e}")
+    purged = body.get("purged") or {}
+    total = sum(v for v in purged.values() if isinstance(v, int) and v > 0)
+    return (True, f"deleted {total} row(s) across {len(purged)} table(s)")
+
+
+def _purge_cloud_node_fallback(api_key: str, *, timeout: float = 15.0) -> tuple[bool, str]:
+    """Older cloud without ``/api/account/purge-data``: purge just this
+    node via the per-node DELETE endpoint. Covers the visible fleet row
+    even when the account-scoped purge isn't deployed yet.
+    """
+    import json as _json
+    import urllib.error as _ue
+    import urllib.parse as _up
+    import urllib.request as _ur
+    from clawmetry.endpoints import ingest_url
+    from clawmetry.sync import CONFIG_FILE
+
+    node_id = ""
+    try:
+        with open(CONFIG_FILE, "r", encoding="utf-8") as f:
+            node_id = (_json.load(f) or {}).get("node_id") or ""
+    except Exception:
+        pass
+    if not node_id:
+        return (False, "no node_id in config; cloud already has no /api/account/purge-data")
+    url = (ingest_url().rstrip("/") + "/api/cloud/nodes/"
+           + _up.quote(node_id, safe=""))
+    req = _ur.Request(
+        url,
+        headers={"Authorization": f"Bearer {api_key}"},
+        method="DELETE",
+    )
+    try:
+        with _ur.urlopen(req, timeout=timeout) as resp:
+            body = _json.loads(resp.read().decode("utf-8", errors="replace"))
+    except _ue.HTTPError as e:
+        return (False, f"per-node DELETE HTTP {e.code}")
+    except (_ue.URLError, TimeoutError, OSError) as e:
+        return (False, f"per-node DELETE network error: {e}")
+    except Exception as e:
+        return (False, f"per-node DELETE unexpected: {e}")
+    purged = body.get("purged") or {}
+    total = sum(v for v in purged.values() if isinstance(v, int) and v > 0)
+    return (True, f"per-node fallback: deleted {total} row(s) (upgrade cloud for account-scoped purge)")
+
+
+def _kick_daemon_for_toggle() -> None:
+    """Bounce the sync daemon so any in-flight snapshot upload aborts.
+
+    The nocloud marker gates every subsequent ``_post`` call, so the
+    daemon self-stops within seconds even without a restart. But a
+    snapshot POST that is ALREADY streaming its body can complete before
+    the next marker check — restarting kills it mid-stream, so the user's
+    "no more data goes to the cloud" expectation holds instantly. Best-
+    effort; a machine without launchd/systemd (or without permission to
+    poke either) just falls back to the marker-check behaviour.
+    """
+    import platform
+    import subprocess as _sp
+    system = platform.system()
+    try:
+        if system == "Darwin":
+            uid = os.getuid()
+            _sp.run(["launchctl", "kickstart", "-k",
+                     f"gui/{uid}/com.clawmetry.sync"],
+                    capture_output=True, check=False, timeout=5)
+        elif system == "Linux":
+            import shutil
+            if shutil.which("systemctl"):
+                for _scope in (["--user"], []):
+                    _sp.run(["systemctl", *_scope, "restart", "clawmetry-sync"],
+                            capture_output=True, check=False, timeout=5)
+    except Exception:
+        pass
+
+
 def _cmd_cloud_toggle(enable: bool) -> int:
     """--turn-on-cloud-sync / --turn-off-cloud-sync.
 
-    Pure marker flip: the daemon checks ``is_cloud_disabled()`` on every
-    cloud POST, so the switch takes effect within seconds WITHOUT a daemon
-    restart. OFF keeps the account key (unlike `clawmetry disconnect`) —
-    it only stops data egress; the local dashboard keeps working.
+    OFF: writes the ``~/.clawmetry/nocloud`` marker (stops future egress),
+    then flushes every trace of this account's data from the cloud so the
+    fleet page immediately shows zero data — best-effort; local-only still
+    applies even if the purge call fails. Keeps the account key (unlike
+    ``clawmetry disconnect``) so the user can flip sync back on later.
+
+    ON: pure marker flip — the daemon checks ``is_cloud_disabled()`` on
+    every cloud POST, so egress resumes within seconds without a restart.
     """
     import json as _json
     from clawmetry import config as _cfg
@@ -6423,6 +6553,34 @@ def _cmd_cloud_toggle(enable: bool) -> int:
     print("    • The local dashboard at http://localhost:8900 keeps working.")
     print("    • Your account login is kept; turn back on any time with:")
     print("        clawmetry --turn-on-cloud-sync")
+
+    # Kick the daemon so an in-flight snapshot upload can't outrace the
+    # marker check that gates the NEXT POST.
+    _kick_daemon_for_toggle()
+
+    # Flush every trace of this account's data from the cloud. Best-effort:
+    # local-only is already in effect regardless of what the network does.
+    api_key = ""
+    try:
+        with open(os.path.expanduser("~/.clawmetry/config.json"), "r",
+                  encoding="utf-8") as f:
+            api_key = (_json.load(f) or {}).get("api_key") or ""
+    except Exception:
+        pass
+    if os.environ.get("CLAWMETRY_TOGGLE_SKIP_PURGE") == "1":
+        print("    (skipping cloud purge: CLAWMETRY_TOGGLE_SKIP_PURGE=1)")
+    elif api_key:
+        print()
+        print("  Deleting cloud copy of your data…")
+        ok, msg = _purge_cloud_data(api_key)
+        if ok:
+            print(f"    ✅  Cloud data purged: {msg}")
+            print("       Your account (login, plan) is kept.")
+        else:
+            print(f"    ⚠️  Cloud purge did not complete: {msg}")
+            print("       Local-only is still in effect (nothing new is being")
+            print("       uploaded). Retry the purge with:")
+            print("         clawmetry --turn-off-cloud-sync")
     return 0
 
 

--- a/tests/test_cloud_toggles.py
+++ b/tests/test_cloud_toggles.py
@@ -3,8 +3,10 @@
 
 The toggles are a pure flip of the ~/.clawmetry/nocloud marker — the daemon
 checks is_cloud_disabled() on every cloud POST, so no restart is involved.
-OFF must keep the account key (only `disconnect` removes it). The help text
-must advertise all of it (explicit product requirement).
+OFF must keep the account key (only `disconnect` removes it) AND must call
+the cloud to purge every trace of the account's telemetry so the fleet page
+shows zero data immediately. The help text must advertise all of it
+(explicit product requirement).
 """
 from __future__ import annotations
 
@@ -22,6 +24,11 @@ def marker(tmp_path, monkeypatch):
     monkeypatch.setattr(cm_config, "NOCLOUD_MARKER_PATH", str(path))
     monkeypatch.delenv("CLAWMETRY_NO_CLOUD", raising=False)
     monkeypatch.setenv("HOME", str(tmp_path))  # isolate ~/.clawmetry reads
+    # Every "OFF" test opts out of the real network purge by default —
+    # tests that specifically exercise the purge stub it explicitly.
+    monkeypatch.setenv("CLAWMETRY_TOGGLE_SKIP_PURGE", "1")
+    # Never bounce a real daemon from a test.
+    monkeypatch.setattr(cli, "_kick_daemon_for_toggle", lambda: None)
     return path
 
 
@@ -102,3 +109,199 @@ def test_help_text_advertises_cloud_commands():
         "--turn-off-cloud-sync",
     ):
         assert token in dashboard.HELP_TEXT, token
+
+
+# ── purge-on-toggle-off ────────────────────────────────────────────────────
+
+def test_turn_off_purges_cloud_data_with_account_key(marker, tmp_path,
+                                                     monkeypatch, capsys):
+    """OFF must call the cloud purge with the account key AND write the marker.
+    The purge is best-effort — the marker + local-only guarantee stands even
+    if the network fails, but on the happy path we tell the user what was
+    deleted so they trust the switch.
+    """
+    monkeypatch.delenv("CLAWMETRY_TOGGLE_SKIP_PURGE", raising=False)
+    cfg = tmp_path / ".clawmetry" / "config.json"
+    cfg.parent.mkdir(parents=True)
+    cfg.write_text('{"api_key": "cm_purge_target", "node_id": "n1"}')
+
+    seen = {}
+
+    def _fake_purge(api_key, **kw):
+        seen["api_key"] = api_key
+        return (True, "deleted 42 row(s) across 7 table(s)")
+
+    monkeypatch.setattr(cli, "_purge_cloud_data", _fake_purge)
+    rc = cli._cmd_cloud_toggle(False)
+    assert rc == 0
+    assert seen["api_key"] == "cm_purge_target"
+    assert marker.is_file()
+    assert "cm_purge_target" in cfg.read_text(), "account key must survive"
+    out = capsys.readouterr().out
+    assert "Cloud data purged" in out
+    assert "42 row" in out
+
+
+def test_turn_off_surfaces_purge_failure_but_still_local_only(marker, tmp_path,
+                                                               monkeypatch, capsys):
+    """A network / cloud error must not undo the local-only flip. The user
+    gets a retry hint; the marker is still on disk and the daemon is still
+    kicked."""
+    monkeypatch.delenv("CLAWMETRY_TOGGLE_SKIP_PURGE", raising=False)
+    cfg = tmp_path / ".clawmetry" / "config.json"
+    cfg.parent.mkdir(parents=True)
+    cfg.write_text('{"api_key": "cm_offline", "node_id": "n1"}')
+    monkeypatch.setattr(cli, "_purge_cloud_data",
+                        lambda k, **kw: (False, "network error: cloud down"))
+
+    rc = cli._cmd_cloud_toggle(False)
+    assert rc == 0
+    assert marker.is_file()
+    out = capsys.readouterr().out
+    assert "did not complete" in out
+    assert "network error" in out
+    assert "Retry" in out or "retry" in out
+
+
+def test_turn_off_without_account_skips_purge(marker, tmp_path,
+                                              monkeypatch, capsys):
+    """No account linked → nothing to purge; still writes the marker."""
+    monkeypatch.delenv("CLAWMETRY_TOGGLE_SKIP_PURGE", raising=False)
+    called = []
+    monkeypatch.setattr(cli, "_purge_cloud_data",
+                        lambda k, **kw: called.append(k) or (True, ""))
+
+    # config.json exists but has no api_key
+    cfg = tmp_path / ".clawmetry" / "config.json"
+    cfg.parent.mkdir(parents=True)
+    cfg.write_text('{"node_id": "n1"}')
+    rc = cli._cmd_cloud_toggle(False)
+    assert rc == 0
+    assert marker.is_file()
+    assert called == [], "must not call purge with no account key"
+
+
+def test_turn_off_kicks_daemon(marker, tmp_path, monkeypatch):
+    """The daemon must be bounced so an in-flight snapshot upload can't
+    outrace the marker check that gates the next POST."""
+    kicked = []
+    monkeypatch.setattr(cli, "_kick_daemon_for_toggle",
+                        lambda: kicked.append(True))
+    cfg = tmp_path / ".clawmetry" / "config.json"
+    cfg.parent.mkdir(parents=True)
+    cfg.write_text('{"api_key": "cm_kick"}')
+    cli._cmd_cloud_toggle(False)
+    assert kicked == [True]
+
+
+def test_purge_cloud_data_posts_confirm_and_bearer(monkeypatch):
+    """Wire-shape guard: the request must be POST + JSON confirm token +
+    Bearer auth against /api/account/purge-data on the resolved ingest URL."""
+    import json as _json
+    import io as _io
+
+    from clawmetry import cli as cli_mod
+
+    captured = {}
+
+    class _FakeResp:
+        def __init__(self, payload):
+            self._payload = _json.dumps(payload).encode()
+
+        def read(self):
+            return self._payload
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    def _fake_urlopen(req, timeout=None):
+        captured["url"] = req.full_url
+        captured["method"] = req.get_method()
+        captured["headers"] = dict(req.header_items())
+        captured["body"] = req.data
+        return _FakeResp({"ok": True,
+                          "purged": {"events": 3, "sessions": 2},
+                          "cache_deleted": 0,
+                          "kept": ["users", "stripe"]})
+
+    monkeypatch.setattr("urllib.request.urlopen", _fake_urlopen)
+    monkeypatch.delenv("CLAWMETRY_ENDPOINT", raising=False)
+    monkeypatch.delenv("CLAWMETRY_INGEST_URL", raising=False)
+
+    ok, msg = cli_mod._purge_cloud_data("cm_wireshape_key")
+    assert ok, msg
+    assert "5 row" in msg  # 3 + 2
+    assert captured["method"] == "POST"
+    assert captured["url"].endswith("/api/account/purge-data")
+    assert captured["url"].startswith("https://ingest.clawmetry.com")
+    # Header names come back title-cased through urllib.
+    lower_headers = {k.lower(): v for k, v in captured["headers"].items()}
+    assert lower_headers.get("authorization") == "Bearer cm_wireshape_key"
+    assert lower_headers.get("content-type") == "application/json"
+    assert _json.loads(captured["body"].decode()) == {"confirm": "PURGE_DATA"}
+
+
+def test_purge_cloud_data_skips_self_hosted_endpoint(monkeypatch):
+    """Self-hosted deployments own the data plane — the managed-cloud purge
+    endpoint is not theirs to call."""
+    from clawmetry import cli as cli_mod
+    calls = []
+    monkeypatch.setenv("CLAWMETRY_ENDPOINT", "https://self.hosted.example.com")
+    monkeypatch.setattr("urllib.request.urlopen",
+                        lambda *a, **kw: calls.append(True))
+    ok, msg = cli_mod._purge_cloud_data("cm_any_key")
+    assert ok
+    assert "self-hosted" in msg
+    assert calls == []
+
+
+def test_purge_cloud_data_falls_back_to_per_node_on_old_cloud(monkeypatch,
+                                                              tmp_path):
+    """A cloud that predates /api/account/purge-data returns 404. We keep
+    the user's expectation ('data gone from cloud') by falling back to the
+    per-node DELETE so at least the visible fleet row disappears."""
+    import json as _json
+    import urllib.error as _ue
+    from clawmetry import cli as cli_mod
+
+    calls = []
+
+    class _FakeResp:
+        def __init__(self, payload):
+            self._payload = _json.dumps(payload).encode()
+
+        def read(self):
+            return self._payload
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    def _fake_urlopen(req, timeout=None):
+        calls.append((req.full_url, req.get_method()))
+        if "/api/account/purge-data" in req.full_url:
+            raise _ue.HTTPError(req.full_url, 404, "Not Found", {}, None)
+        return _FakeResp({"ok": True, "purged": {"events": 5, "nodes": 1}})
+
+    monkeypatch.setattr("urllib.request.urlopen", _fake_urlopen)
+    monkeypatch.delenv("CLAWMETRY_ENDPOINT", raising=False)
+    monkeypatch.delenv("CLAWMETRY_INGEST_URL", raising=False)
+
+    # per-node fallback reads node_id from ~/.clawmetry/config.json
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg = tmp_path / ".clawmetry" / "config.json"
+    cfg.parent.mkdir(parents=True)
+    cfg.write_text('{"api_key": "cm_old_cloud", "node_id": "the-only-node"}')
+    from clawmetry import sync as sync_mod
+    monkeypatch.setattr(sync_mod, "CONFIG_FILE", cfg)
+
+    ok, msg = cli_mod._purge_cloud_data("cm_old_cloud")
+    assert ok, msg
+    assert "per-node fallback" in msg
+    assert any(url.endswith("/api/cloud/nodes/the-only-node") and method == "DELETE"
+               for url, method in calls)


### PR DESCRIPTION
## Summary

Founder-reported 2026-08-13: `clawmetry status` correctly showed `Cloud sync: ⏸ Local-only (account linked)` after `--turn-off-cloud-sync`, but the app.clawmetry.com/cloud page still showed 1 node "Syncing…" with all runtime counts intact. The marker stopped future pushes but did nothing about the encrypted snapshots + node rows that had already landed on the cloud.

This PR makes OFF live up to the user's expectation: "the moment cloud sync is off, delete every trace of it from the cloud."

After writing the `~/.clawmetry/nocloud` marker, `_cmd_cloud_toggle(False)` now also:

1. **Kicks the sync daemon** (`launchctl kickstart -k` / `systemctl restart`) so any snapshot POST that's already mid-body-stream aborts — the marker check gates the *next* POST, not the one already on the wire.
2. **Calls the cloud purge**: `POST /api/account/purge-data` with `{"confirm":"PURGE_DATA"}` and the account's cm_ token. That endpoint (paired PR clawmetry-cloud#1988) drops every owner_hash + email-scoped row from the live schema (`information_schema`-discovered, so drift-proof), while **keeping** the users row and Stripe subscription so `--turn-on-cloud-sync` re-enables in one command.

**Best-effort.** Local-only is already in effect when the purge call is made, so a network error / offline machine / older cloud that predates the endpoint doesn't undo the OFF state — we print a retry hint. Older clouds get a per-node DELETE fallback via `/api/cloud/nodes/<id>` so at least the visible fleet row disappears.

**Skip flags:**
- `CLAWMETRY_TOGGLE_SKIP_PURGE=1` — automation that wants just the marker flip.
- `CLAWMETRY_ENDPOINT` set (self-hosted) — skips managed-cloud purge entirely.

## Test plan

- [x] `tests/test_cloud_toggles.py`: grew from 7 → 14 tests, all green locally
  - Happy-path purge (account key wired through, row counts surfaced)
  - Purge failure → local-only still holds, user sees retry hint
  - No account linked → marker written, no purge call
  - Daemon kick invoked on OFF
  - Wire-shape guard: POST + Bearer + `PURGE_DATA` confirm to `/api/account/purge-data` on resolved ingest URL
  - Self-hosted endpoint opt-out
  - Per-node DELETE fallback on 404 (older cloud)
- [ ] After clawmetry-cloud#1988 is deployed and this ships as `[RELEASE]`: on a live paired install, `clawmetry --turn-off-cloud-sync` → refresh app.clawmetry.com/cloud → 0 nodes, 0 sessions.

## Depends on

- clawmetry-cloud#1988 must be deployed **before** this ships as `[RELEASE]`, or the OSS call hits 404 and falls back to per-node DELETE (which is still safe, just less complete).

🤖 Generated with [Claude Code](https://claude.com/claude-code)