### PR TITLE
[RELEASE] Per-runtime Memory & Skills file browser (18 runtimes)

### DIFF
--- a/clawmetry/runtime_memory.py
+++ b/clawmetry/runtime_memory.py
@@ -34,6 +34,17 @@ If you add a new runtime, add an entry to :data:`RUNTIME_CATALOG` and — if
 its adapter reads a per-project file (like ``AGENTS.md`` / ``GEMINI.md``) —
 include it under the ``project`` roots so the workspace-relative file shows
 up alongside the global ones.
+
+Relationship to the AgentAdapter layer
+--------------------------------------
+This module is intentionally NOT sourced from ``clawmetry.adapters``.
+Adapters normalise live Session / Event streams for a runtime; this catalog
+resolves on-disk memory / skills paths. A runtime's adapter can be
+unshipped (Pro tier not installed on a free machine) while the runtime's
+memory files still exist on the user's filesystem, so the browser must
+resolve independently. When both exist, the OpenClaw adapter's session
+paths and this catalog's memory roots share the same on-disk prefix
+(``~/.openclaw/…``) but neither imports the other.
 """
 from __future__ import annotations
 

--- a/clawmetry/runtime_memory.py
+++ b/clawmetry/runtime_memory.py
@@ -1,0 +1,737 @@
+"""clawmetry/runtime_memory.py — Per-runtime Memory & Skills file browser.
+
+Each supported runtime stores its long-lived context in different places:
+Claude Code lives in ``CLAUDE.md`` + ``~/.claude/skills``, Codex in
+``AGENTS.md`` + ``~/.codex/prompts``, Cursor in ``.cursor/rules/*.mdc``, etc.
+Historically the Memory and Skills tabs in the dashboard only knew about the
+OpenClaw layout (``~/.openclaw/agents/main/memory`` + ``~/.openclaw/skills``),
+which meant users running any of the other 17 runtimes saw an empty tab even
+when their agent had a rich local knowledge base on disk.
+
+This module is the single source of truth for **where every supported runtime
+keeps memory / skills / commands / agents / hooks on disk**. The tabs, the
+routes, and the sync daemon all read the catalog here rather than hard-coding
+paths in their own copies.
+
+Design notes:
+
+- We enumerate ROOTS as ``(runtime, category, root_path, include_globs)``.
+  A "root" is a directory (or a single well-known file) that we scan;
+  ``include_globs`` are relative filename patterns under it. When ``root_path``
+  itself is a single file, it is surfaced directly with no walk.
+- Read paths are traversal-safe: ``read_runtime_file`` normalises the requested
+  path against every registered root for that runtime and rejects anything
+  that escapes.
+- Every helper is defensive — a missing directory, unreadable file, or bad
+  glob returns an empty result rather than raising. The dashboard is used by
+  non-technical users on messy laptops; crashing on a missing ``~/.codex``
+  would be a regression from the OpenClaw-only status quo.
+- Paths honour the same env-var escape hatches as ``runtime_probe.py``
+  (``OPENCLAW_HOME``, ``HERMES_HOME``, ``CLAWMETRY_ANTIGRAVITY_HOME``, …)
+  so power users who moved their data dir still see it.
+
+If you add a new runtime, add an entry to :data:`RUNTIME_CATALOG` and — if
+its adapter reads a per-project file (like ``AGENTS.md`` / ``GEMINI.md``) —
+include it under the ``project`` roots so the workspace-relative file shows
+up alongside the global ones.
+"""
+from __future__ import annotations
+
+import glob as _glob
+import os
+from dataclasses import dataclass, field
+from typing import Iterable, Optional
+
+
+# Category taxonomy shown in the UI. "memory" == free-form markdown notes
+# the agent re-reads at the top of every conversation (CLAUDE.md, MEMORY.md,
+# AGENTS.md, .cursorrules, …). "skills" == packaged capability directories
+# (SKILL.md-style). "commands" == slash-command / prompt files. "agents" ==
+# named sub-agent definitions (Claude Code's ``~/.claude/agents/*.md``).
+# "hooks" == event hooks (settings-level, not a folder browser, but listed
+# for completeness where the runtime exposes them as files).
+CATEGORIES: tuple = ("memory", "skills", "commands", "agents", "hooks")
+
+
+@dataclass
+class RootSpec:
+    """One filesystem root scanned by the browser.
+
+    ``root`` is either an absolute directory OR an absolute single file.
+    When it's a file, the browser surfaces it as one entry (no walk).
+    When it's a directory, ``include_globs`` limits which files under it
+    are listed — an empty tuple means "everything, recursive".
+    """
+
+    category: str
+    root: str
+    include_globs: tuple = ()
+    label: str = ""
+    scope: str = "global"  # "global" (per-user) or "project" (per-repo)
+    max_depth: int = 6
+
+    def expanded_root(self) -> str:
+        return os.path.expanduser(os.path.expandvars(self.root))
+
+
+@dataclass
+class RuntimeCatalogEntry:
+    """One supported runtime's memory + skills roots."""
+
+    id: str
+    label: str
+    roots: tuple = field(default_factory=tuple)
+
+
+def _env_root(env: str, fallback: str, subpath: str = "") -> str:
+    """Prefer ``$env`` if it points at an existing dir, else ``fallback``.
+
+    ``subpath`` (optional) is appended when the env var supplies a data-dir.
+    """
+    val = os.environ.get(env)
+    if val:
+        base = os.path.expanduser(val)
+        return os.path.join(base, subpath) if subpath else base
+    return fallback
+
+
+def _workspace_root() -> str:
+    """Best-guess project workspace (for per-project memory files).
+
+    Uses the dashboard's resolved WORKSPACE when the module is imported in
+    the Flask process, else the CWD. Never raises.
+    """
+    try:
+        import dashboard as _d
+        ws = getattr(_d, "WORKSPACE", None)
+        if ws and os.path.isdir(ws):
+            return ws
+    except Exception:
+        pass
+    return os.getcwd()
+
+
+def _openclaw_home() -> str:
+    return _env_root("OPENCLAW_HOME", os.path.expanduser("~/.openclaw"))
+
+
+def _catalog() -> list:
+    """Build the canonical runtime → roots catalog.
+
+    Called on every request (cheap — just string ops, no I/O). Rebuilt on
+    each call so env-var / workspace changes take effect without restart.
+    """
+    ws = _workspace_root()
+    oc_home = _openclaw_home()
+    home = os.path.expanduser("~")
+
+    catalog: list = []
+
+    # ── OpenClaw (free) ─────────────────────────────────────────────
+    catalog.append(RuntimeCatalogEntry(
+        id="openclaw", label="OpenClaw",
+        roots=(
+            RootSpec("memory", os.path.join(oc_home, "agents/main/memory"),
+                     ("*.md",), "Agent memory", "global"),
+            RootSpec("memory", os.path.join(ws, "memory"),
+                     ("*.md",), "Workspace memory", "project"),
+            RootSpec("memory", os.path.join(ws, "MEMORY.md"), label="MEMORY.md", scope="project"),
+            RootSpec("memory", os.path.join(ws, "SOUL.md"), label="SOUL.md", scope="project"),
+            RootSpec("memory", os.path.join(ws, "AGENTS.md"), label="AGENTS.md", scope="project"),
+            RootSpec("memory", os.path.join(ws, "IDENTITY.md"), label="IDENTITY.md", scope="project"),
+            RootSpec("memory", os.path.join(ws, "USER.md"), label="USER.md", scope="project"),
+            RootSpec("memory", os.path.join(ws, "TOOLS.md"), label="TOOLS.md", scope="project"),
+            RootSpec("skills", os.path.join(oc_home, "skills"),
+                     label="Installed skills", scope="global"),
+            RootSpec("skills", os.path.join(oc_home, "plugin-skills"),
+                     label="Plugin skills", scope="global"),
+            RootSpec("skills", os.path.join(ws, "skills"),
+                     label="Workspace skills", scope="project"),
+            RootSpec("agents", os.path.join(oc_home, "agents"),
+                     label="Sub-agents", scope="global", max_depth=2),
+            RootSpec("hooks", os.path.join(oc_home, "openclaw.json"),
+                     label="Config", scope="global"),
+        ),
+    ))
+
+    # ── Claude Code (Anthropic CLI) ─────────────────────────────────
+    claude_home = os.path.join(home, ".claude")
+    catalog.append(RuntimeCatalogEntry(
+        id="claude_code", label="Claude Code",
+        roots=(
+            RootSpec("memory", os.path.join(claude_home, "CLAUDE.md"),
+                     label="Global CLAUDE.md", scope="global"),
+            RootSpec("memory", os.path.join(ws, "CLAUDE.md"),
+                     label="Project CLAUDE.md", scope="project"),
+            RootSpec("memory", os.path.join(ws, "CLAUDE.local.md"),
+                     label="Project CLAUDE.local.md", scope="project"),
+            RootSpec("memory", os.path.join(ws, ".claude", "CLAUDE.md"),
+                     label="Project .claude/CLAUDE.md", scope="project"),
+            RootSpec("memory", os.path.join(claude_home, "projects"),
+                     ("**/memory/*.md", "**/MEMORY.md"),
+                     "Per-project auto-memory", "global"),
+            RootSpec("skills", os.path.join(claude_home, "skills"),
+                     label="Global skills", scope="global"),
+            RootSpec("skills", os.path.join(ws, ".claude", "skills"),
+                     label="Project skills", scope="project"),
+            RootSpec("agents", os.path.join(claude_home, "agents"),
+                     ("*.md",), "Global sub-agents", "global"),
+            RootSpec("agents", os.path.join(ws, ".claude", "agents"),
+                     ("*.md",), "Project sub-agents", "project"),
+            RootSpec("commands", os.path.join(claude_home, "commands"),
+                     ("*.md",), "Global slash commands", "global"),
+            RootSpec("commands", os.path.join(ws, ".claude", "commands"),
+                     ("*.md",), "Project slash commands", "project"),
+            RootSpec("hooks", os.path.join(claude_home, "hooks"),
+                     label="Global hooks dir", scope="global"),
+            RootSpec("hooks", os.path.join(claude_home, "settings.json"),
+                     label="Global settings.json", scope="global"),
+            RootSpec("hooks", os.path.join(ws, ".claude", "settings.json"),
+                     label="Project settings.json", scope="project"),
+            RootSpec("hooks", os.path.join(ws, ".claude", "settings.local.json"),
+                     label="Project settings.local.json", scope="project"),
+        ),
+    ))
+
+    # ── Codex (OpenAI CLI) ──────────────────────────────────────────
+    codex_home = _env_root("CODEX_HOME", os.path.join(home, ".codex"))
+    catalog.append(RuntimeCatalogEntry(
+        id="codex", label="Codex",
+        roots=(
+            RootSpec("memory", os.path.join(codex_home, "AGENTS.md"),
+                     label="Global AGENTS.md", scope="global"),
+            RootSpec("memory", os.path.join(codex_home, "instructions.md"),
+                     label="instructions.md", scope="global"),
+            RootSpec("memory", os.path.join(ws, "AGENTS.md"),
+                     label="Project AGENTS.md", scope="project"),
+            RootSpec("memory", os.path.join(ws, ".agents.md"),
+                     label=".agents.md", scope="project"),
+            RootSpec("memory", os.path.join(ws, "TEAM_GUIDE.md"),
+                     label="TEAM_GUIDE.md", scope="project"),
+            RootSpec("commands", os.path.join(codex_home, "prompts"),
+                     ("*.md",), "Custom prompts", "global"),
+            RootSpec("hooks", os.path.join(codex_home, "config.toml"),
+                     label="Global config.toml", scope="global"),
+            RootSpec("hooks", os.path.join(ws, ".codex", "config.toml"),
+                     label="Project .codex/config.toml", scope="project"),
+        ),
+    ))
+
+    # ── Cursor ──────────────────────────────────────────────────────
+    catalog.append(RuntimeCatalogEntry(
+        id="cursor", label="Cursor",
+        roots=(
+            RootSpec("memory", os.path.join(ws, ".cursor", "rules"),
+                     ("*.mdc", "*.md"), "Project rules", "project"),
+            RootSpec("memory", os.path.join(ws, ".cursorrules"),
+                     label=".cursorrules (legacy)", scope="project"),
+            RootSpec("memory", os.path.join(home, ".cursor", "rules"),
+                     ("*.mdc", "*.md"), "Global rules", "global"),
+            RootSpec("hooks", os.path.join(home, ".cursor", "mcp.json"),
+                     label="Global mcp.json", scope="global"),
+            RootSpec("hooks", os.path.join(ws, ".cursor", "mcp.json"),
+                     label="Project mcp.json", scope="project"),
+        ),
+    ))
+
+    # ── Antigravity / Gemini CLI ────────────────────────────────────
+    gemini_home = _env_root("CLAWMETRY_ANTIGRAVITY_HOME",
+                            os.path.join(home, ".gemini"))
+    catalog.append(RuntimeCatalogEntry(
+        id="antigravity", label="Antigravity",
+        roots=(
+            RootSpec("memory", os.path.join(gemini_home, "GEMINI.md"),
+                     label="Global GEMINI.md", scope="global"),
+            RootSpec("memory", os.path.join(ws, "GEMINI.md"),
+                     label="Project GEMINI.md", scope="project"),
+            RootSpec("memory", os.path.join(ws, ".agents", "GEMINI.md"),
+                     label="Project .agents/GEMINI.md", scope="project"),
+            RootSpec("memory", os.path.join(ws, "AGENTS.md"),
+                     label="Project AGENTS.md", scope="project"),
+            RootSpec("memory", os.path.join(gemini_home, "AGENTS.md"),
+                     label="Global AGENTS.md", scope="global"),
+            RootSpec("skills", os.path.join(gemini_home, "config", "skills"),
+                     label="Global skills", scope="global"),
+            RootSpec("skills", os.path.join(ws, ".agents", "skills"),
+                     label="Project skills", scope="project"),
+            RootSpec("skills", os.path.join(gemini_home, "extensions"),
+                     label="Extensions", scope="global"),
+            RootSpec("commands", os.path.join(gemini_home, "commands"),
+                     ("*.toml", "*.md"), "Custom commands", "global"),
+            RootSpec("hooks", os.path.join(gemini_home, "settings.json"),
+                     label="settings.json", scope="global"),
+        ),
+    ))
+
+    # ── Aider ───────────────────────────────────────────────────────
+    catalog.append(RuntimeCatalogEntry(
+        id="aider", label="Aider",
+        roots=(
+            RootSpec("memory", os.path.join(ws, "CONVENTIONS.md"),
+                     label="CONVENTIONS.md", scope="project"),
+            RootSpec("memory", os.path.join(home, ".aider.chat.history.md"),
+                     label="Chat history", scope="global"),
+            RootSpec("hooks", os.path.join(home, ".aider.conf.yml"),
+                     label="Global .aider.conf.yml", scope="global"),
+            RootSpec("hooks", os.path.join(ws, ".aider.conf.yml"),
+                     label="Project .aider.conf.yml", scope="project"),
+            RootSpec("hooks", os.path.join(ws, ".aider.model.settings.yml"),
+                     label=".aider.model.settings.yml", scope="project"),
+            RootSpec("hooks", os.path.join(home, ".aider.model.metadata.json"),
+                     label=".aider.model.metadata.json", scope="global"),
+        ),
+    ))
+
+    # ── opencode ────────────────────────────────────────────────────
+    opencode_home = os.path.join(home, ".config", "opencode")
+    catalog.append(RuntimeCatalogEntry(
+        id="opencode", label="opencode",
+        roots=(
+            RootSpec("memory", os.path.join(ws, "AGENTS.md"),
+                     label="Project AGENTS.md", scope="project"),
+            RootSpec("memory", os.path.join(opencode_home, "AGENTS.md"),
+                     label="Global AGENTS.md", scope="global"),
+            RootSpec("skills", os.path.join(opencode_home, "skills"),
+                     label="Global skills", scope="global"),
+            RootSpec("skills", os.path.join(ws, ".opencode", "skills"),
+                     label="Project skills", scope="project"),
+            RootSpec("agents", os.path.join(opencode_home, "agents"),
+                     ("*.md",), "Custom agents", "global"),
+            RootSpec("agents", os.path.join(ws, ".opencode", "agents"),
+                     ("*.md",), "Project agents", "project"),
+            RootSpec("agents", os.path.join(opencode_home, "modes"),
+                     ("*.md", "*.json"), "Global modes", "global"),
+            RootSpec("commands", os.path.join(opencode_home, "commands"),
+                     ("*.md",), "Global commands", "global"),
+            RootSpec("commands", os.path.join(ws, ".opencode", "commands"),
+                     ("*.md",), "Project commands", "project"),
+            RootSpec("hooks", os.path.join(opencode_home, "opencode.json"),
+                     label="Global opencode.json", scope="global"),
+            RootSpec("hooks", os.path.join(ws, "opencode.json"),
+                     label="Project opencode.json", scope="project"),
+        ),
+    ))
+
+    # ── Qwen Code ───────────────────────────────────────────────────
+    qwen_home = os.path.join(home, ".qwen")
+    catalog.append(RuntimeCatalogEntry(
+        id="qwen_code", label="Qwen Code",
+        roots=(
+            RootSpec("memory", os.path.join(qwen_home, "QWEN.md"),
+                     label="Global QWEN.md", scope="global"),
+            RootSpec("memory", os.path.join(ws, "QWEN.md"),
+                     label="Project QWEN.md", scope="project"),
+            RootSpec("memory", os.path.join(qwen_home, "memories"),
+                     ("*.md",), "Auto-memories", "global"),
+            RootSpec("memory", os.path.join(qwen_home, "memories", "pinned"),
+                     ("*.md",), "Pinned memories", "global"),
+            RootSpec("commands", os.path.join(qwen_home, "commands"),
+                     ("*.toml", "*.md"), "Custom commands", "global"),
+            RootSpec("hooks", os.path.join(qwen_home, "settings.json"),
+                     label="settings.json", scope="global"),
+        ),
+    ))
+
+    # ── GitHub Copilot (VSCode) ─────────────────────────────────────
+    catalog.append(RuntimeCatalogEntry(
+        id="copilot", label="GitHub Copilot",
+        roots=(
+            RootSpec("memory", os.path.join(ws, ".github", "copilot-instructions.md"),
+                     label="copilot-instructions.md", scope="project"),
+            RootSpec("memory", os.path.join(ws, ".github", "instructions"),
+                     ("*.instructions.md", "*.md"), "Path-scoped instructions", "project"),
+            RootSpec("memory", os.path.join(ws, "AGENTS.md"),
+                     label="AGENTS.md", scope="project"),
+            RootSpec("commands", os.path.join(ws, ".github", "prompts"),
+                     ("*.prompt.md", "*.md"), "Reusable prompts", "project"),
+            RootSpec("agents", os.path.join(ws, ".github", "chatmodes"),
+                     ("*.chatmode.md", "*.md"), "Custom chat modes", "project"),
+            RootSpec("hooks", os.path.join(ws, ".vscode", "settings.json"),
+                     label=".vscode/settings.json", scope="project"),
+        ),
+    ))
+
+    # ── Goose (Block) ───────────────────────────────────────────────
+    goose_home = os.path.join(home, ".config", "goose")
+    catalog.append(RuntimeCatalogEntry(
+        id="goose", label="Goose",
+        roots=(
+            RootSpec("memory", os.path.join(goose_home, ".goosehints"),
+                     label="Global .goosehints", scope="global"),
+            RootSpec("memory", os.path.join(ws, ".goosehints"),
+                     label="Project .goosehints", scope="project"),
+            RootSpec("memory", os.path.join(goose_home, "memory"),
+                     ("*.md",), "Global memory dir", "global"),
+            RootSpec("memory", os.path.join(ws, ".goose", "memory"),
+                     ("*.md",), "Project memory dir", "project"),
+            RootSpec("hooks", os.path.join(goose_home, "config.yaml"),
+                     label="config.yaml", scope="global"),
+            RootSpec("skills", os.path.join(goose_home, "extensions"),
+                     label="Extensions", scope="global"),
+        ),
+    ))
+
+    # ── NVIDIA NemoClaw (free) ──────────────────────────────────────
+    nemo_home = os.path.expanduser("~/.nemoclaw")
+    catalog.append(RuntimeCatalogEntry(
+        id="nemoclaw", label="NVIDIA NemoClaw",
+        roots=(
+            RootSpec("memory", os.path.join(nemo_home, "memory"),
+                     ("*.md",), "Agent memory", "global"),
+            RootSpec("memory", os.path.join(nemo_home, "agents.yaml"),
+                     label="agents.yaml", scope="global"),
+            RootSpec("skills", os.path.join(nemo_home, "skills"),
+                     label="Installed skills", scope="global"),
+            RootSpec("skills", os.path.join(nemo_home, "source", "nemoclaw-blueprint", "skills"),
+                     label="Blueprint skills", scope="global"),
+            RootSpec("hooks", os.path.join(nemo_home, "config.yaml"),
+                     label="config.yaml", scope="global"),
+            RootSpec("hooks", os.path.join(nemo_home, "model-router-config.yaml"),
+                     label="model-router-config.yaml", scope="global"),
+            RootSpec("hooks", os.path.join(nemo_home, "sandboxes.json"),
+                     label="sandboxes.json", scope="global"),
+        ),
+    ))
+
+    # ── Hermes ──────────────────────────────────────────────────────
+    hermes_home = _env_root("HERMES_HOME", os.path.expanduser("~/.hermes"))
+    catalog.append(RuntimeCatalogEntry(
+        id="hermes", label="Hermes",
+        roots=(
+            RootSpec("memory", os.path.join(hermes_home, "memory"),
+                     ("*.md",), "Agent memory", "global"),
+            RootSpec("skills", os.path.join(hermes_home, "skills"),
+                     label="Installed skills", scope="global"),
+            RootSpec("hooks", os.path.join(hermes_home, "state.db"),
+                     label="state.db", scope="global"),
+        ),
+    ))
+
+    # ── PicoClaw / NanoClaw (edge harnesses) ───────────────────────
+    for rid, label, root in (
+        ("picoclaw", "PicoClaw", os.path.expanduser("~/.picoclaw/workspace")),
+        ("nanoclaw", "NanoClaw", os.path.expanduser("~/.nanoclaw")),
+    ):
+        catalog.append(RuntimeCatalogEntry(
+            id=rid, label=label,
+            roots=(
+                RootSpec("memory", os.path.join(root, "memory"),
+                         ("*.md",), "Agent memory", "global"),
+                RootSpec("memory", os.path.join(root, "MEMORY.md"),
+                         label="MEMORY.md", scope="global"),
+                RootSpec("skills", os.path.join(root, "skills"),
+                         label="Installed skills", scope="global"),
+            ),
+        ))
+
+    # ── Pi (Inflection) ─────────────────────────────────────────────
+    pi_home = os.path.expanduser("~/.pi")
+    catalog.append(RuntimeCatalogEntry(
+        id="pi", label="Pi",
+        roots=(
+            RootSpec("memory", os.path.join(pi_home, "agent", "memory"),
+                     ("*.md",), "Agent memory", "global"),
+        ),
+    ))
+
+    # ── DeepAgents (LangChain) ──────────────────────────────────────
+    deep_home = os.path.expanduser("~/.deepagents")
+    catalog.append(RuntimeCatalogEntry(
+        id="deepagents", label="DeepAgents",
+        roots=(
+            RootSpec("memory", os.path.join(deep_home, "memory"),
+                     ("*.md",), "Agent memory", "global"),
+            RootSpec("memory", os.path.join(deep_home, "AGENTS.md"),
+                     label="Global AGENTS.md", scope="global"),
+            RootSpec("memory", os.path.join(ws, ".deepagents", "AGENTS.md"),
+                     label="Project AGENTS.md", scope="project"),
+            RootSpec("skills", os.path.join(deep_home, "skills"),
+                     label="Installed skills", scope="global"),
+        ),
+    ))
+
+    # ── n8n ─────────────────────────────────────────────────────────
+    n8n_home = _env_root("N8N_USER_FOLDER", os.path.expanduser("~/.n8n"))
+    catalog.append(RuntimeCatalogEntry(
+        id="n8n", label="n8n",
+        roots=(
+            RootSpec("skills", os.path.join(n8n_home, "custom"),
+                     label="Custom nodes", scope="global"),
+            RootSpec("hooks", os.path.join(n8n_home, "config"),
+                     label="config", scope="global"),
+            RootSpec("hooks", os.path.join(n8n_home, "database.sqlite"),
+                     label="database.sqlite", scope="global"),
+        ),
+    ))
+
+    # ── Grok Build (xAI) ────────────────────────────────────────────
+    grok_home = os.path.expanduser("~/.grok")
+    catalog.append(RuntimeCatalogEntry(
+        id="grok", label="Grok",
+        roots=(
+            RootSpec("memory", os.path.join(ws, "AGENTS.md"),
+                     label="Project AGENTS.md", scope="project"),
+            RootSpec("memory", grok_home, ("*.md", "*.json", "*.toml"),
+                     "Grok config dir", "global", max_depth=2),
+        ),
+    ))
+
+    return catalog
+
+
+_ALLOWED_DOTFILES = frozenset({".cursorrules", ".goosehints", ".agents.md",
+                                ".aider.conf.yml", ".aider.chat.history.md",
+                                ".aider.model.settings.yml",
+                                ".aider.model.metadata.json"})
+
+
+def _match_globs(name: str, rel_path: str, globs: Iterable) -> bool:
+    """True when ``name`` (or ``rel_path`` for path-shaped globs) matches
+    any of the fnmatch-style globs.
+
+    Empty glob list means "any file matches" (used for skills roots that
+    surface every subdirectory / file).
+
+    Globs that contain ``/`` are matched against the full relative path
+    (using ``fnmatch`` — good enough for the ``**/memory/*.md`` shape
+    the Claude Code auto-memory root needs). Bare-name globs match the
+    filename only.
+    """
+    from fnmatch import fnmatch
+    globs_t = tuple(globs or ())
+    if not globs_t:
+        return True
+    rel_norm = rel_path.replace(os.sep, "/")
+    for g in globs_t:
+        if "/" in g:
+            # Path-shaped glob. Expand ``**`` to a segment wildcard by
+            # matching the trailing segment pattern anywhere in the path.
+            if fnmatch(rel_norm, g.replace("**/", "*/").replace("**", "*")):
+                return True
+            # Also try the strict fnmatch (handles single-star segments).
+            if fnmatch(rel_norm, g):
+                return True
+            continue
+        if fnmatch(name, g):
+            return True
+    return False
+
+
+def _walk_dir(root: str, include_globs: tuple, max_depth: int) -> list:
+    """Depth-limited recursive walk.
+
+    Returns ``[{'path': rel_posix, 'size': int, 'mtime': int}]``. Sorted by
+    path. Never raises — returns [] on any error.
+    """
+    out: list = []
+    if not root or not os.path.isdir(root):
+        return out
+    root_abs = os.path.abspath(root)
+    for cur_dir, dirs, files in os.walk(root_abs):
+        rel_dir = os.path.relpath(cur_dir, root_abs)
+        depth = 0 if rel_dir == "." else rel_dir.count(os.sep) + 1
+        if depth > max_depth:
+            dirs[:] = []
+            continue
+        # Skip noise but keep well-known dotdirs that hold agent config.
+        dirs[:] = [
+            d for d in dirs
+            if (not d.startswith(".")
+                or d in (".claude", ".cursor", ".github", ".vscode",
+                         ".codex", ".opencode", ".agents", ".goose",
+                         ".openclaw", ".deepagents"))
+            and d not in ("__pycache__", "node_modules", ".git", "venv",
+                          ".venv", "dist", "build", ".mypy_cache")
+        ]
+        for fname in sorted(files):
+            if fname.startswith(".") and fname not in _ALLOWED_DOTFILES:
+                continue
+            fpath = os.path.join(cur_dir, fname)
+            rel = os.path.relpath(fpath, root_abs).replace(os.sep, "/")
+            if not _match_globs(fname, rel, include_globs):
+                continue
+            try:
+                st = os.stat(fpath)
+            except OSError:
+                continue
+            out.append({
+                "path": rel,
+                "size": int(st.st_size),
+                "mtime": int(st.st_mtime),
+            })
+    out.sort(key=lambda e: e["path"])
+    return out
+
+
+def list_runtimes() -> list:
+    """List every catalogued runtime with a per-category found-file count.
+
+    Shape: ``[{id, label, present, counts: {memory, skills, commands,
+    agents, hooks}, roots: [{category, root, exists, scope, label}]}]``.
+    Roots include ``exists`` so the UI can render greyed-out entries for
+    runtimes the user hasn't installed. Never raises.
+    """
+    out: list = []
+    for entry in _catalog():
+        counts = {c: 0 for c in CATEGORIES}
+        roots_info: list = []
+        present = False
+        for spec in entry.roots:
+            root = spec.expanded_root()
+            exists = os.path.exists(root)
+            n = 0
+            if exists:
+                present = True
+                if os.path.isdir(root):
+                    n = len(_walk_dir(root, spec.include_globs, spec.max_depth))
+                else:
+                    n = 1
+                counts[spec.category] = counts.get(spec.category, 0) + n
+            roots_info.append({
+                "category": spec.category,
+                "root": root,
+                "exists": exists,
+                "scope": spec.scope,
+                "label": spec.label or os.path.basename(root),
+                "count": n,
+            })
+        out.append({
+            "id": entry.id,
+            "label": entry.label,
+            "present": present,
+            "counts": counts,
+            "roots": roots_info,
+        })
+    return out
+
+
+def _entry_by_id(runtime_id: str) -> Optional[RuntimeCatalogEntry]:
+    for entry in _catalog():
+        if entry.id == runtime_id:
+            return entry
+    return None
+
+
+def list_files(runtime_id: str, category: Optional[str] = None) -> dict:
+    """List every file for one runtime, grouped by root.
+
+    Returns ``{'runtime': id, 'label': str, 'groups': [{root, label,
+    category, scope, exists, files: [...]}]}``.
+
+    ``category``, when set, filters roots to that one bucket. ``files``
+    entries are ``{path, size, mtime}`` with ``path`` relative to the
+    group's root. A root that is a single file gets one entry with
+    ``path=''`` (empty relpath) so the client can still address it.
+    """
+    entry = _entry_by_id(runtime_id)
+    if entry is None:
+        return {"runtime": runtime_id, "label": "", "groups": [], "error": "unknown_runtime"}
+
+    groups: list = []
+    for spec in entry.roots:
+        if category and spec.category != category:
+            continue
+        root = spec.expanded_root()
+        exists = os.path.exists(root)
+        files: list = []
+        if exists:
+            if os.path.isdir(root):
+                files = _walk_dir(root, spec.include_globs, spec.max_depth)
+            else:
+                # single-file root: surface it directly
+                try:
+                    st = os.stat(root)
+                    files = [{
+                        "path": "",
+                        "size": int(st.st_size),
+                        "mtime": int(st.st_mtime),
+                    }]
+                except OSError:
+                    files = []
+        groups.append({
+            "category": spec.category,
+            "root": root,
+            "label": spec.label or os.path.basename(root),
+            "scope": spec.scope,
+            "exists": exists,
+            "files": files,
+        })
+    return {"runtime": entry.id, "label": entry.label, "groups": groups}
+
+
+def read_runtime_file(runtime_id: str, root: str, path: str,
+                      max_bytes: int = 500_000) -> dict:
+    """Read one file under one of ``runtime_id``'s registered roots.
+
+    Returns ``{'ok': True, 'path', 'content', 'size', 'mtime', 'language'}``
+    or ``{'ok': False, 'error': str, 'status': int}``. ``path`` is
+    interpreted **relative to ``root``**; ``root`` MUST match one of the
+    runtime's catalog roots verbatim (post-expansion), so callers can only
+    read what the UI has already listed.
+    """
+    entry = _entry_by_id(runtime_id)
+    if entry is None:
+        return {"ok": False, "error": "unknown_runtime", "status": 404}
+
+    # Match root against catalog (post-expansion)
+    matched_spec: Optional[RootSpec] = None
+    root_norm = os.path.abspath(os.path.expanduser(root))
+    for spec in entry.roots:
+        if os.path.abspath(spec.expanded_root()) == root_norm:
+            matched_spec = spec
+            break
+    if matched_spec is None:
+        return {"ok": False, "error": "root not in catalog for runtime", "status": 403}
+
+    if os.path.isdir(root_norm):
+        full = os.path.normpath(os.path.join(root_norm, path or ""))
+        if not full.startswith(root_norm + os.sep) and full != root_norm:
+            return {"ok": False, "error": "path escapes root", "status": 403}
+    else:
+        # Single-file root: path must be empty (or match basename)
+        if path and path not in ("", os.path.basename(root_norm)):
+            return {"ok": False, "error": "path outside single-file root", "status": 403}
+        full = root_norm
+
+    if not os.path.isfile(full):
+        return {"ok": False, "error": "not a file", "status": 404}
+
+    try:
+        with open(full, "rb") as fh:
+            raw = fh.read(max_bytes)
+    except OSError as e:
+        return {"ok": False, "error": str(e), "status": 500}
+
+    try:
+        content = raw.decode("utf-8")
+        binary = False
+    except UnicodeDecodeError:
+        content = raw.decode("utf-8", errors="replace")
+        binary = True
+
+    ext = os.path.splitext(full)[1].lower().lstrip(".")
+    lang = {
+        "md": "markdown", "mdc": "markdown", "markdown": "markdown",
+        "py": "python", "sh": "bash", "js": "javascript", "ts": "typescript",
+        "json": "json", "yaml": "yaml", "yml": "yaml", "toml": "toml",
+        "html": "html", "css": "css", "sql": "sql",
+    }.get(ext, "text")
+
+    try:
+        st = os.stat(full)
+        size = int(st.st_size)
+        mtime = int(st.st_mtime)
+    except OSError:
+        size = len(raw)
+        mtime = 0
+
+    return {
+        "ok": True,
+        "path": path,
+        "content": content,
+        "size": size,
+        "mtime": mtime,
+        "language": lang,
+        "binary": binary,
+        "truncated": size > len(raw),
+    }

--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -25447,3 +25447,294 @@ async function checkLicenseExpiry() {
   }
 }
 setTimeout(checkLicenseExpiry, 1200);
+// ─────────────────────────────────────────────────────────────────────────
+// Runtime Memory & Skills browser (multi-runtime file explorer).
+//
+// Each supported runtime stores its long-lived memory and its skills in
+// different places on disk (see clawmetry/runtime_memory.py). This module
+// renders two things across the Memory + Skills tabs:
+//   1. A chip bar of runtimes (dimmed if not present on this machine)
+//   2. A file-browser view (left tree, right preview) for the picked runtime
+//
+// OpenClaw remains the default; picking it hides the browser and shows the
+// existing rich Memory / Skills UI. All other runtimes route through the
+// browser. Backwards compatible — the old view is untouched.
+// ─────────────────────────────────────────────────────────────────────────
+
+var _cmRuntimeCatalog = null;
+var _cmRuntimeSelected = { memory: 'openclaw', skills: 'openclaw' };
+
+function _cmRuntimeIsCloud() {
+  try {
+    return typeof window !== 'undefined' && window.location &&
+           /clawmetry\.com/.test(window.location.hostname);
+  } catch (e) { return false; }
+}
+
+async function _cmRuntimeFetchCatalog(force) {
+  if (_cmRuntimeCatalog && !force) return _cmRuntimeCatalog;
+  try {
+    var r = await fetch('/api/runtimes/memory-catalog');
+    if (!r.ok) throw new Error('http ' + r.status);
+    _cmRuntimeCatalog = await r.json();
+  } catch (e) {
+    _cmRuntimeCatalog = { categories: [], runtimes: [] };
+  }
+  return _cmRuntimeCatalog;
+}
+
+function _cmRuntimeIcon(id) {
+  var map = {
+    openclaw: '🦀', claude_code: '🅲', codex: '🅾', cursor: '🅲',
+    antigravity: '🅶', aider: '🅐', goose: '🪿', opencode: '🅾',
+    qwen_code: '🅠', copilot: '🅶🅓', nemoclaw: '🅝', hermes: '🅗',
+    picoclaw: '🪳', nanoclaw: '🐜', pi: '𝛑', deepagents: '🅳',
+    n8n: '🅽', grok: '🅶',
+  };
+  return map[id] || '•';
+}
+
+function _cmRuntimeChip(runtime, selected, tab, category) {
+  var count = 0;
+  if (category && runtime.counts) count = runtime.counts[category] || 0;
+  else if (runtime.counts) {
+    Object.keys(runtime.counts).forEach(function(k) { count += runtime.counts[k] || 0; });
+  }
+  var isSel = runtime.id === selected;
+  var isPresent = !!runtime.present;
+  var bg = isSel ? '#6366f1' : (isPresent ? 'var(--bg-secondary)' : 'transparent');
+  var color = isSel ? '#fff' : (isPresent ? 'var(--text-primary)' : 'var(--text-muted)');
+  var border = isSel ? '#6366f1' : 'var(--border-primary)';
+  var op = (isPresent || isSel) ? 1 : 0.55;
+  var badge = count > 0
+    ? '<span style="background:rgba(255,255,255,0.16);padding:1px 6px;border-radius:8px;font-size:10px;margin-left:6px;">' + count + '</span>'
+    : '';
+  return '<div class="cm-runtime-chip" data-runtime="' + runtime.id + '" '
+    + 'onclick="cmRuntimeSelect(\'' + tab + '\',\'' + runtime.id + '\')" '
+    + 'style="padding:4px 10px;border-radius:14px;font-size:11px;font-weight:600;cursor:pointer;'
+    + 'background:' + bg + ';color:' + color + ';border:1px solid ' + border + ';opacity:' + op + ';'
+    + 'display:inline-flex;align-items:center;gap:4px;" title="' + escHtml(runtime.label)
+    + (isPresent ? '' : ' (not detected on this machine)') + '">'
+    + escHtml(runtime.label) + badge + '</div>';
+}
+
+async function cmRuntimeMountChips(chipsEl) {
+  if (!chipsEl) return;
+  var tab = chipsEl.getAttribute('data-tab') || 'memory';
+  var category = chipsEl.getAttribute('data-category') || null;
+  chipsEl.innerHTML = '<span style="font-size:11px;color:var(--text-muted);">Loading runtimes…</span>';
+  var cat = await _cmRuntimeFetchCatalog();
+  var runtimes = (cat.runtimes || []).slice();
+  // Sort: present first, then by label
+  runtimes.sort(function(a, b) {
+    if (!!a.present !== !!b.present) return a.present ? -1 : 1;
+    return (a.label || '').localeCompare(b.label || '');
+  });
+  var sel = _cmRuntimeSelected[tab] || 'openclaw';
+  var chips = runtimes.map(function(rt) {
+    return _cmRuntimeChip(rt, sel, tab, category);
+  });
+  chipsEl.innerHTML = chips.join('');
+}
+
+function cmRuntimeSelect(tab, runtimeId) {
+  _cmRuntimeSelected[tab] = runtimeId;
+  // Re-render both chip bars if present (keeps them in sync visually)
+  var chips = document.querySelectorAll('[id$="-runtime-chips"][data-tab="' + tab + '"]');
+  chips.forEach(function(el) { cmRuntimeMountChips(el); });
+  // Toggle native OpenClaw view vs runtime file browser
+  var browser = document.getElementById(tab + '-runtime-browser');
+  if (tab === 'memory') {
+    var nativeIds = ['memory-summary-view', 'memory-access-view', 'memory-all-view'];
+    if (runtimeId === 'openclaw') {
+      nativeIds.forEach(function(id) {
+        var el = document.getElementById(id);
+        if (!el) return;
+        // Only restore the summary view by default; the other two are toggled
+        // by memorySwitchView independently.
+        if (id === 'memory-summary-view') el.style.display = '';
+      });
+      if (browser) browser.style.display = 'none';
+    } else {
+      nativeIds.forEach(function(id) {
+        var el = document.getElementById(id);
+        if (el) el.style.display = 'none';
+      });
+      if (browser) { browser.style.display = ''; cmRuntimeMountBrowser(browser, runtimeId, 'memory'); }
+    }
+  } else if (tab === 'skills') {
+    var nativeIds = ['skills-summary-row', 'skills-list', 'skills-browser'];
+    if (runtimeId === 'openclaw') {
+      nativeIds.forEach(function(id) {
+        var el = document.getElementById(id);
+        if (!el) return;
+        if (id === 'skills-summary-row' || id === 'skills-list') el.style.display = '';
+      });
+      if (browser) browser.style.display = 'none';
+    } else {
+      nativeIds.forEach(function(id) {
+        var el = document.getElementById(id);
+        if (el) el.style.display = 'none';
+      });
+      if (browser) { browser.style.display = ''; cmRuntimeMountBrowser(browser, runtimeId, 'skills'); }
+    }
+  }
+}
+
+async function cmRuntimeMountBrowser(container, runtimeId, tab) {
+  if (!container) return;
+  container.innerHTML = '<div style="padding:16px;color:var(--text-muted);font-size:12px;">Loading '
+    + escHtml(runtimeId) + '…</div>';
+  var payload;
+  try {
+    var url = '/api/runtimes/' + encodeURIComponent(runtimeId) + '/files';
+    if (tab === 'memory' || tab === 'skills') {
+      // No category filter — show everything the runtime exposes.
+    }
+    var r = await fetch(url);
+    if (!r.ok) throw new Error('http ' + r.status);
+    payload = await r.json();
+  } catch (e) {
+    container.innerHTML = '<div style="padding:16px;color:#ef4444;font-size:12px;">Failed to load: '
+      + escHtml(String(e)) + '</div>';
+    return;
+  }
+  var groups = (payload.groups || []).filter(function(g) { return g.exists; });
+  var absent = (payload.groups || []).filter(function(g) { return !g.exists; });
+  var totalFiles = groups.reduce(function(s, g) { return s + (g.files || []).length; }, 0);
+
+  if (!groups.length) {
+    container.innerHTML =
+      '<div style="padding:24px;text-align:center;color:var(--text-muted);font-size:13px;line-height:1.5;">'
+      + '<div style="font-weight:700;color:var(--text-secondary);margin-bottom:6px;">Nothing found on disk for ' + escHtml(payload.label || runtimeId) + '</div>'
+      + 'ClawMetry looks for this runtime\'s memory and skills at these paths:'
+      + '<div style="margin-top:12px;text-align:left;display:inline-block;font-family:\'JetBrains Mono\',\'SF Mono\',monospace;font-size:11px;color:var(--text-muted);">'
+      + absent.map(function(g) {
+          return '<div>• <span style="color:var(--text-secondary);">' + escHtml(g.category)
+            + '</span> <span style="opacity:0.7;">(' + escHtml(g.scope) + ')</span> — <code>' + escHtml(g.root) + '</code></div>';
+        }).join('')
+      + '</div>'
+      + '<div style="margin-top:14px;font-size:11px;">Install ' + escHtml(payload.label || runtimeId)
+      + ' or drop files at one of these paths to make them appear here.</div>'
+      + '</div>';
+    return;
+  }
+
+  // Build the two-pane layout: left tree, right preview.
+  var treeHtml = groups.map(function(g, gi) {
+    var scopePill = '<span style="font-size:9px;background:var(--bg-primary);border:1px solid var(--border-primary);border-radius:8px;padding:0 5px;margin-left:6px;color:var(--text-muted);">'
+      + escHtml(g.scope) + '</span>';
+    var catPill = '<span style="font-size:9px;background:rgba(99,102,241,0.15);color:#a5b4fc;border-radius:8px;padding:0 5px;margin-left:4px;">'
+      + escHtml(g.category) + '</span>';
+    var files = (g.files || []).map(function(f, fi) {
+      var name = f.path || g.label || '(file)';
+      var basename = name.split('/').pop();
+      var indent = (name.split('/').length - 1) * 12;
+      var kb = f.size >= 1024 ? (f.size / 1024).toFixed(1) + 'K' : f.size + 'B';
+      return '<div class="cm-rt-file" data-gi="' + gi + '" data-fi="' + fi
+        + '" onclick="cmRuntimeOpenFile(this,\'' + runtimeId + '\','
+        + gi + ',' + fi + ')" style="padding:3px 10px 3px ' + (18 + indent) + 'px;font-size:11.5px;cursor:pointer;color:var(--text-primary);display:flex;justify-content:space-between;align-items:center;gap:8px;" '
+        + 'title="' + escHtml(name) + '">'
+        + '<span style="overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">' + escHtml(basename) + '</span>'
+        + '<span style="font-size:10px;color:var(--text-muted);flex-shrink:0;">' + kb + '</span>'
+        + '</div>';
+    }).join('');
+    return '<div class="cm-rt-group" style="margin-bottom:8px;">'
+      + '<div style="padding:6px 10px 4px;font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:1px;color:var(--text-muted);display:flex;align-items:center;flex-wrap:wrap;">'
+      + escHtml(g.label) + catPill + scopePill + '</div>'
+      + '<div style="font-family:\'JetBrains Mono\',\'SF Mono\',monospace;font-size:10px;color:var(--text-muted);padding:0 10px 4px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;" title="' + escHtml(g.root) + '">' + escHtml(g.root) + '</div>'
+      + files + '</div>';
+  }).join('');
+
+  container.innerHTML =
+    '<div style="display:flex;height:calc(100vh - 260px);min-height:420px;background:var(--bg-primary);border:1px solid var(--border-primary);border-radius:8px;overflow:hidden;">'
+    + '<div id="cm-rt-tree-' + tab + '" style="width:320px;min-width:260px;flex-shrink:0;background:var(--bg-secondary);border-right:1px solid var(--border-primary);overflow-y:auto;padding:8px 0;">'
+    + '<div style="padding:8px 10px 10px;font-size:11px;color:var(--text-muted);border-bottom:1px solid var(--border-primary);margin-bottom:8px;">'
+    + escHtml(payload.label) + ' — ' + totalFiles + ' file' + (totalFiles === 1 ? '' : 's') + ' across ' + groups.length + ' location' + (groups.length === 1 ? '' : 's')
+    + '</div>' + treeHtml + '</div>'
+    + '<div style="flex:1;display:flex;flex-direction:column;overflow:hidden;">'
+    + '<div id="cm-rt-file-header-' + tab + '" style="padding:8px 14px;background:var(--bg-secondary);border-bottom:1px solid var(--border-primary);font-family:\'JetBrains Mono\',\'SF Mono\',monospace;font-size:12px;color:var(--text-secondary);min-height:32px;display:flex;align-items:center;gap:10px;">Select a file</div>'
+    + '<div id="cm-rt-file-body-' + tab + '" style="flex:1;overflow:auto;padding:16px 22px;background:var(--bg-primary);font-family:\'JetBrains Mono\',\'SF Mono\',monospace;font-size:12.5px;line-height:1.6;color:var(--text-primary);white-space:pre-wrap;word-break:break-word;">'
+    + '<div style="color:var(--text-muted);font-family:inherit;">Pick a file on the left to view its contents.</div>'
+    + '</div></div></div>';
+
+  // Stash the payload on the container so cmRuntimeOpenFile can look up
+  // (root, path) by (gi, fi) without another fetch.
+  container._cmRuntimePayload = payload;
+}
+
+async function cmRuntimeOpenFile(clickEl, runtimeId, gi, fi) {
+  var container = clickEl.closest('.runtime-file-browser');
+  if (!container || !container._cmRuntimePayload) return;
+  var tab = container.getAttribute('data-tab') || 'memory';
+  var groups = container._cmRuntimePayload.groups || [];
+  var group = groups[gi];
+  if (!group) return;
+  var file = (group.files || [])[fi];
+  if (!file) return;
+
+  // Highlight selection
+  container.querySelectorAll('.cm-rt-file').forEach(function(el) {
+    el.style.background = ''; el.style.color = 'var(--text-primary)';
+  });
+  clickEl.style.background = 'rgba(99,102,241,0.15)';
+  clickEl.style.color = '#a5b4fc';
+
+  var header = document.getElementById('cm-rt-file-header-' + tab);
+  var body = document.getElementById('cm-rt-file-body-' + tab);
+  if (header) header.innerHTML = escHtml(group.root + '/' + (file.path || ''));
+  if (body) body.innerHTML = '<div style="color:var(--text-muted);">Loading…</div>';
+
+  try {
+    var url = '/api/runtimes/' + encodeURIComponent(runtimeId)
+      + '/file?root=' + encodeURIComponent(group.root)
+      + '&path=' + encodeURIComponent(file.path || '');
+    var r = await fetch(url);
+    var d = await r.json();
+    if (!r.ok) throw new Error(d.error || ('http ' + r.status));
+    var content = d.content || '';
+    var sizeStr = (d.size >= 1024 ? (d.size / 1024).toFixed(1) + 'K' : d.size + 'B');
+    var mstr = d.mtime ? new Date(d.mtime * 1000).toLocaleString() : '';
+    if (header) header.innerHTML =
+      '<span style="color:var(--text-primary);font-weight:600;">' + escHtml((file.path || group.label || '')) + '</span>'
+      + '<span style="opacity:0.6;">·</span><span>' + escHtml(sizeStr) + '</span>'
+      + (mstr ? '<span style="opacity:0.6;">·</span><span>' + escHtml(mstr) + '</span>' : '')
+      + '<span style="opacity:0.6;">·</span><span>' + escHtml(d.language || 'text') + '</span>';
+    if (body) {
+      // Render markdown as preview when we have it (matches Memory tab UX),
+      // otherwise show raw content. cmSafeMarkdown is defined earlier in
+      // app.js and sanitizes output.
+      if ((d.language || '') === 'markdown' && typeof cmSafeMarkdown === 'function') {
+        body.style.whiteSpace = 'normal';
+        body.style.fontFamily = '';
+        body.innerHTML = cmSafeMarkdown(content);
+      } else {
+        body.style.whiteSpace = 'pre-wrap';
+        body.style.fontFamily = "'JetBrains Mono','SF Mono',monospace";
+        body.textContent = content;
+      }
+    }
+  } catch (e) {
+    if (body) body.innerHTML = '<div style="color:#ef4444;">Failed to load: '
+      + escHtml(String(e && e.message || e)) + '</div>';
+  }
+}
+
+// Hook into tab switches so the chip bars mount on first paint.
+(function _cmRuntimeInstallHooks() {
+  var origSwitchTab = (typeof switchTab === 'function') ? switchTab : null;
+  if (!origSwitchTab || origSwitchTab._cmRuntimeWrapped) return;
+  var wrapped = function(name) {
+    var out = origSwitchTab.apply(this, arguments);
+    try {
+      if (name === 'memory') {
+        cmRuntimeMountChips(document.getElementById('memory-runtime-chips'));
+      } else if (name === 'skills') {
+        cmRuntimeMountChips(document.getElementById('skills-runtime-chips'));
+      }
+    } catch (e) {}
+    return out;
+  };
+  wrapped._cmRuntimeWrapped = true;
+  window.switchTab = wrapped;
+})();

--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -25502,19 +25502,25 @@ function _cmRuntimeChip(runtime, selected, tab, category) {
   }
   var isSel = runtime.id === selected;
   var isPresent = !!runtime.present;
+  var isLocked = !!runtime.locked;
   var bg = isSel ? '#6366f1' : (isPresent ? 'var(--bg-secondary)' : 'transparent');
   var color = isSel ? '#fff' : (isPresent ? 'var(--text-primary)' : 'var(--text-muted)');
   var border = isSel ? '#6366f1' : 'var(--border-primary)';
   var op = (isPresent || isSel) ? 1 : 0.55;
-  var badge = count > 0
-    ? '<span style="background:rgba(255,255,255,0.16);padding:1px 6px;border-radius:8px;font-size:10px;margin-left:6px;">' + count + '</span>'
-    : '';
+  var badge = '';
+  if (isLocked) {
+    badge = '<span title="Paid runtime — upgrade to browse its files" style="margin-left:6px;font-size:10px;opacity:0.85;">🔒</span>';
+  } else if (count > 0) {
+    badge = '<span style="background:rgba(255,255,255,0.16);padding:1px 6px;border-radius:8px;font-size:10px;margin-left:6px;">' + count + '</span>';
+  }
+  var titleTip = isLocked
+    ? escHtml(runtime.label) + ' — paid runtime, upgrade to browse'
+    : escHtml(runtime.label) + (isPresent ? '' : ' (not detected on this machine)');
   return '<div class="cm-runtime-chip" data-runtime="' + runtime.id + '" '
     + 'onclick="cmRuntimeSelect(\'' + tab + '\',\'' + runtime.id + '\')" '
     + 'style="padding:4px 10px;border-radius:14px;font-size:11px;font-weight:600;cursor:pointer;'
     + 'background:' + bg + ';color:' + color + ';border:1px solid ' + border + ';opacity:' + op + ';'
-    + 'display:inline-flex;align-items:center;gap:4px;" title="' + escHtml(runtime.label)
-    + (isPresent ? '' : ' (not detected on this machine)') + '">'
+    + 'display:inline-flex;align-items:center;gap:4px;" title="' + titleTip + '">'
     + escHtml(runtime.label) + badge + '</div>';
 }
 
@@ -25592,6 +25598,22 @@ async function cmRuntimeMountBrowser(container, runtimeId, tab) {
       // No category filter — show everything the runtime exposes.
     }
     var r = await fetch(url);
+    if (r.status === 402) {
+      // Paid runtime the caller isn't entitled to. Show upsell CTA
+      // instead of an error — matches the OSS conversion-moment pattern.
+      var rtLabel = (_cmRuntimeCatalog && _cmRuntimeCatalog.runtimes || [])
+        .filter(function(x) { return x.id === runtimeId; })[0];
+      var label = (rtLabel && rtLabel.label) || runtimeId;
+      container.innerHTML =
+        '<div style="padding:36px 20px;text-align:center;color:var(--text-muted);font-size:13px;line-height:1.55;max-width:520px;margin:0 auto;">'
+        + '<div style="font-size:28px;margin-bottom:8px;">🔒</div>'
+        + '<div style="font-weight:700;color:var(--text-primary);margin-bottom:6px;font-size:15px;">' + escHtml(label) + ' is a paid runtime</div>'
+        + 'Upgrade your ClawMetry plan to browse this runtime\'s memory and skills files. '
+        + 'Everything ClawMetry knows about ' + escHtml(label) + ' — including where its memory lives on disk — is bundled with the paid tier that ships its adapter.'
+        + '<div style="margin-top:16px;"><a href="https://clawmetry.com/pricing" target="_blank" style="display:inline-block;background:#6366f1;color:#fff;text-decoration:none;padding:8px 16px;border-radius:8px;font-weight:600;font-size:13px;">See pricing</a></div>'
+        + '</div>';
+      return;
+    }
     if (!r.ok) throw new Error('http ' + r.status);
     payload = await r.json();
   } catch (e) {

--- a/clawmetry/templates/tabs/memory.html
+++ b/clawmetry/templates/tabs/memory.html
@@ -4,6 +4,7 @@
       <div style="font-size:18px;font-weight:700;color:var(--text-primary);" data-i18n="memory.title">Memory</div>
       <div style="font-size:12px;color:var(--text-muted);margin-top:4px;" data-i18n="memory.subtitle">Markdown files your agent reads and updates. Edit them too if you want.</div>
     </div>
+    <div id="memory-runtime-chips" data-tab="memory" data-category="memory" style="display:flex;gap:6px;flex-wrap:wrap;align-items:center;max-width:60%;"></div>
     <div style="display:flex;gap:6px;align-items:center;">
       <div class="mem-view-tab" data-view="summary" onclick="memorySwitchView('summary')" style="padding:6px 14px;border-radius:6px;font-size:12px;font-weight:600;cursor:pointer;background:var(--bg-secondary);border:1px solid var(--border-primary);color:var(--text-primary);" data-i18n="memory.view_summary">Summary</div>
       <div class="mem-view-tab" data-view="all" onclick="memorySwitchView('all')" style="padding:6px 14px;border-radius:6px;font-size:12px;font-weight:600;cursor:pointer;background:transparent;border:1px solid transparent;color:var(--text-muted);" data-i18n="memory.view_all_files">All files</div>
@@ -12,7 +13,10 @@
     </div>
   </div>
 
-  <!-- SUMMARY VIEW (IDE-style single surface) -->
+  <!-- RUNTIME FILE BROWSER (non-OpenClaw runtimes) -->
+  <div id="memory-runtime-browser" class="runtime-file-browser" data-tab="memory" data-category="memory" style="display:none;"></div>
+
+  <!-- SUMMARY VIEW (IDE-style single surface) — OpenClaw only -->
   <div id="memory-summary-view">
     <div class="mem-ide" style="display:flex;flex-direction:column;height:calc(100vh - 200px);min-height:520px;background:var(--bg-primary);border:1px solid var(--border-primary);border-radius:8px;overflow:hidden;">
 

--- a/clawmetry/templates/tabs/skills.html
+++ b/clawmetry/templates/tabs/skills.html
@@ -9,6 +9,8 @@
       <button class="refresh-btn" onclick="loadSkills()">↻ <span data-i18n="common.refresh">Refresh</span></button>
     </div>
   </div>
+  <div id="skills-runtime-chips" data-tab="skills" data-category="skills" style="display:flex;gap:6px;flex-wrap:wrap;align-items:center;margin:10px 0 4px 0;"></div>
+  <div id="skills-runtime-browser" class="runtime-file-browser" data-tab="skills" data-category="skills" style="display:none;"></div>
   <div id="skills-summary-row" style="display:flex;gap:12px;flex-wrap:wrap;margin:14px 0 16px 0;"></div>
   <div id="skills-list"><div style="color:var(--text-muted);font-size:13px;padding:16px;" data-i18n="app.loading">Loading...</div></div>
   <!-- Skills Browser (file explorer view) -->

--- a/dashboard.py
+++ b/dashboard.py
@@ -117,6 +117,7 @@ from routes.meta import bp_auth, bp_cloud_relay, bp_gateway, bp_otel, bp_otlp_tr
 from routes.compliance import bp_compliance
 from routes.nemoclaw import bp_nemoclaw
 from routes.skills import bp_skills
+from routes.runtime_memory import bp_runtime_memory
 from routes.heartbeat import bp_heartbeat
 from routes.autonomy import bp_autonomy
 from routes.selfconfig import bp_selfconfig
@@ -11890,6 +11891,7 @@ def detect_config(args=None):
         app.register_blueprint(bp_nemoclaw)
         app.register_blueprint(bp_compliance)
     app.register_blueprint(bp_skills)
+    app.register_blueprint(bp_runtime_memory)
     app.register_blueprint(bp_heartbeat)
     app.register_blueprint(bp_selfconfig)
     app.register_blueprint(bp_agents)

--- a/routes/runtime_memory.py
+++ b/routes/runtime_memory.py
@@ -1,0 +1,75 @@
+"""routes/runtime_memory.py — Per-runtime Memory & Skills browser API.
+
+Three endpoints backing the file-browser layout in the Memory and Skills
+tabs. Everything is read-only (the browser is a viewer, not an editor for
+non-OpenClaw runtimes; the OpenClaw-owned Memory tab keeps its own write
+endpoint at ``/api/file``). Traversal-safety is enforced inside
+:mod:`clawmetry.runtime_memory` — this module is a thin Flask veneer.
+
+  GET /api/runtimes/memory-catalog
+      List every catalogued runtime with per-category counts + resolved
+      root paths. Powers the runtime chip bar at the top of the tab.
+
+  GET /api/runtimes/<runtime_id>/files?category=<memory|skills|...>
+      List every file the runtime exposes, grouped by root.
+
+  GET /api/runtimes/<runtime_id>/file?root=<root>&path=<rel>
+      Read one file from within a registered root. ``root`` must appear
+      verbatim in the catalog's expanded roots list; ``path`` is relative
+      to it.
+
+None of these are gated — memory/skills catalog is universal metadata that
+every plan sees. Only the OpenClaw-specific write endpoint (still in
+``routes/infra.py``) enforces workspace-write policy.
+"""
+from __future__ import annotations
+
+from flask import Blueprint, jsonify, request
+
+from clawmetry.runtime_memory import (
+    CATEGORIES,
+    list_files,
+    list_runtimes,
+    read_runtime_file,
+)
+
+
+bp_runtime_memory = Blueprint("runtime_memory", __name__)
+
+
+@bp_runtime_memory.route("/api/runtimes/memory-catalog")
+def api_runtime_memory_catalog():
+    """List every runtime with counts. Cheap — safe to poll on tab open."""
+    return jsonify({
+        "categories": list(CATEGORIES),
+        "runtimes": list_runtimes(),
+    })
+
+
+@bp_runtime_memory.route("/api/runtimes/<runtime_id>/files")
+def api_runtime_files(runtime_id: str):
+    """List every file under one runtime, grouped by root.
+
+    Query params:
+      - category: optional filter (memory | skills | commands | agents | hooks)
+    """
+    category = (request.args.get("category") or "").strip() or None
+    if category and category not in CATEGORIES:
+        return jsonify({"error": "invalid category"}), 400
+    payload = list_files(runtime_id, category=category)
+    if payload.get("error") == "unknown_runtime":
+        return jsonify(payload), 404
+    return jsonify(payload)
+
+
+@bp_runtime_memory.route("/api/runtimes/<runtime_id>/file")
+def api_runtime_file(runtime_id: str):
+    """Read one file from one registered root of a runtime."""
+    root = request.args.get("root", "")
+    path = request.args.get("path", "")
+    if not root:
+        return jsonify({"error": "root is required"}), 400
+    result = read_runtime_file(runtime_id, root, path)
+    if not result.get("ok"):
+        return jsonify({"error": result.get("error")}), int(result.get("status", 500))
+    return jsonify(result)

--- a/routes/runtime_memory.py
+++ b/routes/runtime_memory.py
@@ -8,19 +8,32 @@ endpoint at ``/api/file``). Traversal-safety is enforced inside
 
   GET /api/runtimes/memory-catalog
       List every catalogued runtime with per-category counts + resolved
-      root paths. Powers the runtime chip bar at the top of the tab.
+      root paths, tagged with ``locked: bool``. Powers the runtime chip
+      bar at the top of the Memory / Skills tabs. Always returns every
+      runtime (locked or not) so the UI can render an honest upgrade CTA
+      without pretending the runtime is absent (per the ERS-001.3
+      "don't hide paid adapters" acceptance criterion).
 
   GET /api/runtimes/<runtime_id>/files?category=<memory|skills|...>
-      List every file the runtime exposes, grouped by root.
+      List every file the runtime exposes, grouped by root. Gated by
+      :func:`clawmetry.entitlements.allows_runtime`. Free runtimes
+      (OpenClaw, NemoClaw) are always readable; paid runtimes return
+      HTTP 402 ``upgrade_required`` when the resolved entitlement does
+      not cover them (grace still permissive — see the entitlements
+      module).
 
   GET /api/runtimes/<runtime_id>/file?root=<root>&path=<rel>
-      Read one file from within a registered root. ``root`` must appear
-      verbatim in the catalog's expanded roots list; ``path`` is relative
-      to it.
+      Read one file from within a registered root. Same entitlement gate
+      as ``/files``.
 
-None of these are gated — memory/skills catalog is universal metadata that
-every plan sees. Only the OpenClaw-specific write endpoint (still in
-``routes/infra.py``) enforces workspace-write policy.
+Design note: this module is the source of truth for **where on-disk
+memory / skills / commands / agents / hooks files live** for every
+supported runtime. It complements — and does not replace — the
+``clawmetry.adapters.AgentAdapter`` layer, which normalises live
+Session / Event data. The two concerns are intentionally separate: an
+agent adapter can be un-shipped for a runtime while the user's
+filesystem still holds that runtime's memory files, so the file browser
+must resolve independently.
 """
 from __future__ import annotations
 
@@ -33,16 +46,61 @@ from clawmetry.runtime_memory import (
     read_runtime_file,
 )
 
+try:
+    # ``allows_runtime`` returns True for OpenClaw/NemoClaw (free) and
+    # for any paid runtime covered by the resolved entitlement. In grace
+    # mode it is intentionally permissive; the OSS enforcement layer at
+    # request time is what turns a denial into HTTP 402.
+    from clawmetry.entitlements import (
+        FREE_RUNTIMES,
+        get_entitlement,
+    )
+except Exception:  # pragma: no cover — entitlements is core; only fails in tests
+    FREE_RUNTIMES = frozenset({"openclaw", "nemoclaw"})
+
+    def get_entitlement(*_a, **_k):
+        return None
+
 
 bp_runtime_memory = Blueprint("runtime_memory", __name__)
 
 
+def _runtime_is_locked(runtime_id: str) -> bool:
+    """True when this runtime needs a paid entitlement the user lacks.
+
+    Free runtimes are never locked. For paid runtimes, ``allows_runtime``
+    on the resolved entitlement is authoritative (it already honours
+    grace mode). Any exception (entitlement resolution failure) falls
+    open — we prefer showing content on the local dashboard over a
+    silent lock-out from a resolver hiccup; the actual read endpoint
+    still returns 402 if the resolver later hardens.
+    """
+    if runtime_id in FREE_RUNTIMES:
+        return False
+    try:
+        ent = get_entitlement()
+        return not bool(ent.allows_runtime(runtime_id))
+    except Exception:
+        return False
+
+
 @bp_runtime_memory.route("/api/runtimes/memory-catalog")
 def api_runtime_memory_catalog():
-    """List every runtime with counts. Cheap — safe to poll on tab open."""
+    """List every runtime with counts + a ``locked`` flag.
+
+    Cheap — safe to poll on tab open. Always returns every catalogued
+    runtime (locked or not) so the UI can render an honest upgrade CTA
+    on paid runtimes without pretending they don't exist (matches the
+    ERS-001.3 acceptance criterion: "when an extension is absent or not
+    entitled, do not present it as available" — we surface the label
+    but tag it locked, so the user sees the option and the upsell).
+    """
+    runtimes = list_runtimes()
+    for rt in runtimes:
+        rt["locked"] = _runtime_is_locked(rt["id"])
     return jsonify({
         "categories": list(CATEGORIES),
-        "runtimes": list_runtimes(),
+        "runtimes": runtimes,
     })
 
 
@@ -52,7 +110,18 @@ def api_runtime_files(runtime_id: str):
 
     Query params:
       - category: optional filter (memory | skills | commands | agents | hooks)
+
+    Returns HTTP 402 ``upgrade_required`` when the runtime is a paid
+    runtime and the resolved entitlement does not cover it. This is the
+    OSS conversion moment prescribed by ``FLYWHEEL.md`` §1b — never
+    silently disable, always surface the upgrade CTA.
     """
+    if _runtime_is_locked(runtime_id):
+        return jsonify({
+            "error": "upgrade_required",
+            "runtime": runtime_id,
+            "reason": "paid_runtime_not_entitled",
+        }), 402
     category = (request.args.get("category") or "").strip() or None
     if category and category not in CATEGORIES:
         return jsonify({"error": "invalid category"}), 400
@@ -64,7 +133,17 @@ def api_runtime_files(runtime_id: str):
 
 @bp_runtime_memory.route("/api/runtimes/<runtime_id>/file")
 def api_runtime_file(runtime_id: str):
-    """Read one file from one registered root of a runtime."""
+    """Read one file from one registered root of a runtime.
+
+    Same entitlement gate as ``/files``: paid runtimes return HTTP 402
+    when the resolved entitlement does not cover them.
+    """
+    if _runtime_is_locked(runtime_id):
+        return jsonify({
+            "error": "upgrade_required",
+            "runtime": runtime_id,
+            "reason": "paid_runtime_not_entitled",
+        }), 402
     root = request.args.get("root", "")
     path = request.args.get("path", "")
     if not root:


### PR DESCRIPTION
## Summary

- Memory + Skills tabs were OpenClaw-only. Users on the other 17 supported runtimes (Claude Code, Codex, Cursor, Antigravity, Aider, Goose, opencode, Qwen Code, Copilot, Hermes, NanoClaw/PicoClaw, DeepAgents, NemoClaw, n8n, Grok, Pi) saw empty tabs even when their agent had rich memory/skills on disk.
- New `clawmetry/runtime_memory.py` catalogs where every runtime stores memory / skills / commands / agents / hooks (honors env-var escapes like `CODEX_HOME`, `HERMES_HOME`, `CLAWMETRY_ANTIGRAVITY_HOME`, `N8N_USER_FOLDER`; includes per-project files like `CLAUDE.md`, `AGENTS.md`, `GEMINI.md`, `.cursorrules`, `.goosehints`, `.github/copilot-instructions.md`).
- New `routes/runtime_memory.py` blueprint: `/api/runtimes/memory-catalog`, `/api/runtimes/<id>/files`, `/api/runtimes/<id>/file`. Traversal-safe; **paid runtimes return HTTP 402 `upgrade_required`** when the resolved entitlement (grace-aware) does not cover them.
- Memory + Skills tabs get a runtime chip bar at the top (present runtimes show file counts; absent are dimmed; paid ones without entitlement render with 🔒 + upsell CTA). Selecting a non-OpenClaw runtime hides the OpenClaw view and mounts a two-pane file browser (left tree grouped by root, right pane renders markdown or raw). Empty runtimes render an honest "ClawMetry looks for this runtime at these paths" state.

## ⚠️ Blueprint follow-up needed (per FLYWHEEL §1f)

No existing 8090 Software Factory Blueprint covers the multi-runtime Memory & Skills file browser. See my PR comment for the drift-bot response with the full rationale + requested Blueprint updates:
- Extend Blueprint "Runtime and Session Observability" (`40e35d24-8249-4f72-b311-f311dc71aec5`) to document the catalog module + routes + UI.
- Add a Requirement pinning the entitlement semantics (catalog returns locked chips; `/files` and `/file` return HTTP 402 for paid runtimes when not entitled — this compromise reconciles ERS-001.3 with FLYWHEEL §1b's "never silently disable, always surface the upsell" rule).

## Test plan

- [x] Local smoke test: 11 runtimes detected present on dev machine, endpoints return real data
- [x] Browser end-to-end: chip navigation + file preview verified across OpenClaw / Claude Code / Antigravity / Aider on `http://localhost:8901`
- [x] Syntax: python `ast.parse` + node `new Function` pass for all touched files
- [x] All CI green except drift-bot (see PR comment)
- [ ] Blueprint update in 8090 Software Factory (human follow-up)
- [ ] After merge → [RELEASE] → PyPI publish → cloud pin verified live

🤖 Generated with [Claude Code](https://claude.com/claude-code)