### PR TITLE
Fix blank TOOL_CALL rows in Brain / Unified Activity Stream

### DIFF
--- a/routes/brain.py
+++ b/routes/brain.py
@@ -200,6 +200,83 @@ def _v3_message_content_to_text(content) -> str:
     return ""
 
 
+_TOOL_INPUT_PRIORITY_KEYS = (
+    "command", "cmd",
+    "file_path", "path", "filename",
+    "pattern", "query", "q",
+    "url",
+    "description",
+    "prompt",
+)
+
+
+def _summarise_tool_call_input(inp) -> str:
+    """Compress a tool-call input blob into a one-line preview.
+
+    Prefers a known "primary" key (command for Bash, file_path for Read/Write,
+    pattern for Grep, url for WebFetch, description/prompt as narrative
+    fallbacks). Falls back to the first string-valued entry, then a compact
+    JSON dump. Kept generic — new tool schemas fall through to the JSON path
+    without changes here.
+    """
+    if inp is None:
+        return ""
+    if isinstance(inp, str):
+        return inp
+    if isinstance(inp, dict):
+        for k in _TOOL_INPUT_PRIORITY_KEYS:
+            v = inp.get(k)
+            if isinstance(v, str) and v:
+                return v
+        for k, v in inp.items():
+            if isinstance(v, str) and v:
+                return "{}={}".format(k, v)
+        try:
+            import json as _json
+            return _json.dumps(inp, default=str)
+        except Exception:
+            return str(inp)
+    if isinstance(inp, list):
+        return ", ".join(str(x) for x in inp if x)[:180]
+    return str(inp)
+
+
+def _summarise_tool_calls(data: dict) -> str:
+    """Render the tool-call payload as ``Tool(arg preview)`` for the Brain feed.
+
+    v3 mapper stores tool-call rows with ``data.tool_calls = [{name, input}]``
+    (Anthropic/OpenAI-flavoured) and a flat ``data.tool_name`` mirror; the
+    generic flat-key extractor below returns "" for these because the top-level
+    ``content`` is an empty string and ``name`` doesn't sit at the top. Without
+    this branch the Brain feed prints TOOL_CALL rows with a blank body.
+    """
+    tool_calls = data.get("tool_calls")
+    if isinstance(tool_calls, list) and tool_calls:
+        parts = []
+        for tc in tool_calls:
+            if not isinstance(tc, dict):
+                continue
+            name = tc.get("name") or tc.get("tool_name") or ""
+            inp = tc.get("input")
+            if inp is None:
+                inp = tc.get("arguments")
+            summary = _summarise_tool_call_input(inp)
+            if len(summary) > 140:
+                summary = summary[:140] + "…"
+            if name and summary:
+                parts.append("{}({})".format(name, summary))
+            elif name:
+                parts.append(str(name))
+            elif summary:
+                parts.append(summary)
+        if parts:
+            return " · ".join(parts)
+    tn = data.get("tool_name")
+    if isinstance(tn, str) and tn:
+        return tn
+    return ""
+
+
 def _extract_brain_detail(row: dict) -> str:
     """Pull a human-readable ``detail`` snippet from a DuckDB event row, then
     collapse any OpenClaw ``<task-notification>`` envelope to its summary so the
@@ -253,6 +330,14 @@ def _extract_brain_detail_raw(row: dict) -> str:
         role = msg.get("role")
         if role in ("assistant", "user"):
             return "(thinking)" if role == "assistant" else ""
+
+    # --- Tool-call shape: data.tool_calls[i].{name,input} + data.tool_name --
+    # Emitted by the v3 mapper for TOOL_CALL rows. content is "" on these
+    # rows, so the generic flat-key loop below returns nothing and Brain
+    # prints a blank body next to the TOOL_CALL badge (user-visible bug).
+    tool_call_detail = _summarise_tool_calls(data)
+    if tool_call_detail:
+        return tool_call_detail
 
     # --- v3 mapper shape: top-level projection -----------------------------
     for k in ("finalPromptText", "completionText", "output", "result",

--- a/tests/test_brain_history_v3_event_detail.py
+++ b/tests/test_brain_history_v3_event_detail.py
@@ -238,3 +238,55 @@ def test_extract_brain_detail_unit_handles_all_shapes():
     assert br._extract_brain_detail({}) == ""
     assert br._extract_brain_detail({"data": None}) == ""
     assert br._extract_brain_detail({"data": "raw string"}) == "raw string"
+
+
+def test_extract_brain_detail_tool_call_shapes():
+    """Regression guard for the TOOL_CALL blank-body bug (2026-08-14).
+
+    The v3 mapper writes tool-call rows with ``data.tool_calls=[{name,input}]``
+    and a flat ``data.tool_name`` mirror; ``data.content`` is an empty string.
+    Without the tool-call branch, the generic flat-key extractor returned "" and
+    the Brain feed painted TOOL_CALL rows with no body next to the badge.
+    """
+    import importlib
+    import routes.brain as br
+    importlib.reload(br)
+
+    # Canonical Bash tool_call row from claude_code sync
+    assert br._extract_brain_detail({"data": {
+        "_runtime": "claude_code", "content": "", "role": "assistant",
+        "tool_calls": [{"id": "t1", "name": "Bash",
+                        "input": {"command": "ls -la", "description": "list"}}],
+        "tool_name": "Bash",
+    }}) == "Bash(ls -la)"
+
+    # Read tool prefers file_path over other keys
+    assert br._extract_brain_detail({"data": {
+        "tool_calls": [{"name": "Read",
+                        "input": {"file_path": "/x/a.py", "limit": 15}}],
+    }}) == "Read(/x/a.py)"
+
+    # Multiple tool_calls in one row render as ` · ` separated
+    assert br._extract_brain_detail({"data": {
+        "tool_calls": [
+            {"name": "Read", "input": {"file_path": "/a.py"}},
+            {"name": "Read", "input": {"file_path": "/b.py"}},
+        ],
+    }}) == "Read(/a.py) · Read(/b.py)"
+
+    # OpenAI-style ``arguments`` key is honoured alongside ``input``
+    assert br._extract_brain_detail({"data": {
+        "tool_calls": [{"name": "write_file",
+                        "arguments": {"path": "/a.txt", "content": "hi"}}],
+    }}) == "write_file(/a.txt)"
+
+    # Flat ``tool_name`` mirror is the fallback when tool_calls is missing
+    assert br._extract_brain_detail({"data": {"tool_name": "OnlyName"}}) == "OnlyName"
+
+    # Junk list entries are skipped without crashing
+    assert br._extract_brain_detail({"data": {
+        "tool_calls": [None, "x", {}, {"name": "Bash", "input": "notadict"}],
+    }}) == "Bash(notadict)"
+
+    # Empty tool_calls list → falls through to other extractors (empty here)
+    assert br._extract_brain_detail({"data": {"tool_calls": []}}) == ""


### PR DESCRIPTION
## Summary
- **User-visible bug**: TOOL_CALL rows in the Brain / Unified Activity Stream were painted with **no body** next to the badge — TOOL_RESULT and MESSAGE rows showed content, but every TOOL_CALL was blank (screenshot: report → \"why are tool calls not displayed in activity??\").
- **Cause**: v3 mapper stores tool-call rows with the tool payload under \`data.tool_calls[i].{name,input}\` (+ \`data.tool_name\` mirror) and leaves top-level \`data.content\` as \`\"\"\`. The generic flat-key extractor in \`routes/brain.py\` never looked at those keys, so \`detail\` was always empty.
- **Fix**: add a \`_summarise_tool_calls\` helper (with a small, generic input-summariser that prefers \`command\`/\`file_path\`/\`pattern\`/\`url\`/\`description\`/\`prompt\`) and wire it into \`_extract_brain_detail_raw\` right after the message-envelope branch. TOOL_RESULT and MESSAGE rows are unaffected.
- **Live verification**: on the running dashboard, 96/96 recent TOOL_CALL rows now render as \`Tool(arg preview)\` (e.g. \`Bash(rm _smoke_gate.py)\`, \`Read(/x/dashboard.py)\`, \`Edit(/Users/vivek/projects/clawmetry/routes/brain.py)\`) instead of empty cells.

## Test plan
- [x] New unit test \`test_extract_brain_detail_tool_call_shapes\` covers: canonical Bash row, Read prefers \`file_path\`, multiple tool_calls (\`·\` joined), OpenAI-style \`arguments\` key, flat \`tool_name\` mirror, junk-list entries, empty list falls through.
- [x] Existing \`test_extract_brain_detail_unit_handles_all_shapes\` still passes (no regression on message-envelope / v3 top-level / v3 mirror shapes).
- [x] Live \`/api/brain-history?limit=300\` on the running dashboard: 96/96 TOOL_CALL rows carry a non-empty \`detail\`; verified in the browser at the Brain tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)