### PR TITLE
Session replay: canonical schema + replay_events table (part 1 of #4813)

### DIFF
--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -8011,6 +8011,58 @@ class LocalStore:
             out.append(d)
         return out
 
+    def query_replay_events(
+        self,
+        *,
+        session_id: str,
+        limit: int = 2000,
+    ) -> list[dict[str, Any]]:
+        """Read canonical replay-event rows for one session (#4813).
+
+        Returned rows are in ``ts`` ascending, then ``span_id`` ascending
+        order — replay is played forward, and the tie-break by span_id
+        gives a deterministic order when many events share the same
+        millisecond (adapter emissions in a tight loop).
+
+        BLOB columns (``payload``, ``mode``, ``approval``) are decoded
+        back to JSON dicts where valid so ``/api/replay-tree`` can hand
+        rows to the tree-builder without a second decode. The endpoint
+        layer (routes/sessions.py) then groups the flat list into
+        turns/delegations/workflows/approvals.
+
+        Empty list is the expected shape until adapter ``iter_replay_events``
+        implementations start writing (per-runtime issues #4815, #4816, +
+        13 Pro adapters). Not an error.
+        """
+        sql = """
+            SELECT span_id, parent_span_id, session_id, runtime, kind, ts,
+                   payload, mode, approval, created_at
+            FROM replay_events
+            WHERE session_id = ?
+            ORDER BY ts ASC, span_id ASC
+            LIMIT ?
+        """
+        cols = ["span_id", "parent_span_id", "session_id", "runtime", "kind",
+                "ts", "payload", "mode", "approval", "created_at"]
+        out: list[dict[str, Any]] = []
+        for r in self._fetch(sql, [session_id, int(limit)]):
+            d = dict(zip(cols, r))
+            for blob_col in ("payload", "mode", "approval"):
+                raw = d.get(blob_col)
+                if raw is None:
+                    continue
+                try:
+                    text = (raw.decode("utf-8")
+                            if isinstance(raw, (bytes, bytearray)) else raw)
+                    try:
+                        d[blob_col] = json.loads(text)
+                    except (ValueError, TypeError):
+                        d[blob_col] = text
+                except UnicodeDecodeError:
+                    d[blob_col] = None
+            out.append(d)
+        return out
+
     def query_approvals(
         self,
         *,

--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -1181,6 +1181,33 @@ _DDL = [
     "ALTER TABLE external_api_calls ADD COLUMN IF NOT EXISTS input_tokens INTEGER",
     "ALTER TABLE external_api_calls ADD COLUMN IF NOT EXISTS output_tokens INTEGER",
     "ALTER TABLE external_api_calls ADD COLUMN IF NOT EXISTS model VARCHAR",
+    # Issue #4813 — canonical replay-event stream. Feeds the runtime-aware
+    # replay UI (Task/Agent/Workflow fanouts, subagent DAGs, cascades,
+    # per-turn mode changes, approval decisions). Written by adapter
+    # ``iter_replay_events`` implementations via the sync daemon; read by
+    # ``/api/replay-tree/<session_id>``. See ``clawmetry/replay_schema.py``
+    # for the canonical event shape.
+    #
+    # parent_span_id is the DELEGATION edge (parent Task spawned this
+    # child). NOT the transcript-chain parent — do not conflate.
+    """
+    CREATE TABLE IF NOT EXISTS replay_events (
+        span_id        VARCHAR PRIMARY KEY,
+        parent_span_id VARCHAR,
+        session_id     VARCHAR NOT NULL,
+        runtime        VARCHAR NOT NULL,
+        kind           VARCHAR NOT NULL,
+        ts             DOUBLE  NOT NULL,
+        payload        BLOB,
+        mode           BLOB,
+        approval       BLOB,
+        created_at     BIGINT  NOT NULL
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_replay_events_session_ts   ON replay_events(session_id, ts)",
+    "CREATE INDEX IF NOT EXISTS idx_replay_events_parent       ON replay_events(parent_span_id)",
+    "CREATE INDEX IF NOT EXISTS idx_replay_events_runtime_kind ON replay_events(runtime, kind)",
+    "CREATE INDEX IF NOT EXISTS idx_replay_events_created_at   ON replay_events(created_at)",
 ]
 
 

--- a/clawmetry/query_contract.py
+++ b/clawmetry/query_contract.py
@@ -276,6 +276,18 @@ QUERY_CONTRACT: dict = {
                "spawn edges. Optional runtime arg scopes to one runtime "
                "('openclaw' matches legacy NULL agent_type).",
     },
+    "replay_events": {
+        "status": STATUS_LIVE,
+        "args": {
+            "session_id": _arg(required=True),
+            "limit": _arg(default=2000, lo=1, hi=10000),
+        },
+        "trust": TRUST_E2E,
+        "backing": "query_replay_events",
+        "doc": "Canonical replay-event rows for one session (#4813). Rows in "
+               "kind-agnostic order; the /api/replay-tree endpoint groups "
+               "them into turns/delegations/workflows/approvals.",
+    },
 }
 
 

--- a/clawmetry/replay_schema.py
+++ b/clawmetry/replay_schema.py
@@ -1,0 +1,175 @@
+"""Canonical replay-event schema.
+
+Neutral event shape every runtime adapter maps its native events into,
+so the transcript viewer can render a single runtime-aware replay UI
+across Claude Code sidechains, OpenClaw subagent/flow DAGs, Antigravity
+cascades, n8n workflow executions, Codex per-turn approval policies, etc.
+
+Motivating issue: openclaw/clawmetry#4813. Full initiative index in
+``project_session_replay_initiative_2026_08_14`` memory note.
+
+Design notes:
+
+- ``parent_span_id`` is the DELEGATION edge (parent Task/Agent spawned
+  this child). It is NOT the transcript-chain parent — OpenClaw v3
+  ``parentId`` and Qwen Code ``parentUuid`` are chains, not trees;
+  conflating the two silently breaks the delegation tree UI.
+- ``kind`` uses dotted names so the renderer can dispatch on prefix
+  (``llm.*``, ``tool.*``, ``agent.*``, ``workflow.*``, ``approval.*``).
+- ``mode`` and ``approval`` are optional side-channels — most events
+  don't change mode and don't concern an approval; only ``mode.changed``
+  and ``approval.*`` events populate them.
+- ``payload`` is deliberately open — kind-specific fields go there.
+  Renderer must tolerate missing keys.
+
+The DuckDB table backing this schema is ``replay_events``, declared
+in ``clawmetry/local_store.py`` alongside ``events`` and ``spans``.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal, TypedDict
+
+# ── Canonical event kinds ────────────────────────────────────────────────
+# Grouped by prefix so the JS renderer can dispatch on the leading token.
+
+KIND_LLM_CALL = "llm.call"
+KIND_LLM_RESPONSE = "llm.response"
+KIND_THINKING = "thinking"
+KIND_TOOL_CALL = "tool.call"
+KIND_TOOL_RESULT = "tool.result"
+KIND_AGENT_SPAWN = "agent.spawn"
+KIND_AGENT_RETURN = "agent.return"
+KIND_WORKFLOW_START = "workflow.start"
+KIND_WORKFLOW_STAGE = "workflow.stage"
+KIND_WORKFLOW_END = "workflow.end"
+KIND_APPROVAL_REQUESTED = "approval.requested"
+KIND_APPROVAL_DECIDED = "approval.decided"
+KIND_MODE_CHANGED = "mode.changed"
+KIND_COMPACTION = "compaction"
+
+ALL_KINDS: tuple[str, ...] = (
+    KIND_LLM_CALL,
+    KIND_LLM_RESPONSE,
+    KIND_THINKING,
+    KIND_TOOL_CALL,
+    KIND_TOOL_RESULT,
+    KIND_AGENT_SPAWN,
+    KIND_AGENT_RETURN,
+    KIND_WORKFLOW_START,
+    KIND_WORKFLOW_STAGE,
+    KIND_WORKFLOW_END,
+    KIND_APPROVAL_REQUESTED,
+    KIND_APPROVAL_DECIDED,
+    KIND_MODE_CHANGED,
+    KIND_COMPACTION,
+)
+
+# ── Enums for the side-channel dicts ─────────────────────────────────────
+
+PermissionMode = Literal[
+    "default",
+    "acceptEdits",
+    "plan",
+    "bypassPermissions",   # Claude Code YOLO
+    "yolo",                # generic alias
+    "unknown",             # runtime has no signal; render "not captured"
+]
+
+SandboxMode = Literal[
+    "read-only",
+    "workspace-write",
+    "danger-full-access",
+    "container",           # NanoClaw etc.
+    "unknown",
+]
+
+ApprovalStatus = Literal[
+    "requested",
+    "approved",
+    "denied",
+    "edited",              # user modified tool args before approving
+    "timeout",
+]
+
+ApprovalResolver = Literal[
+    "user",
+    "hook",
+    "policy",
+    "model",               # apiRefusalCategory / apiRefusalExplanation
+    "unknown",
+]
+
+
+class ModeChip(TypedDict, total=False):
+    permission: PermissionMode | None
+    sandbox: SandboxMode | None
+    collaboration: str | None  # runtime-native token, no enum
+
+
+class ApprovalInfo(TypedDict, total=False):
+    status: ApprovalStatus
+    decision_reason: str | None
+    resolver: ApprovalResolver | None
+    edit_diff: dict[str, Any] | None   # {"before": tool_args, "after": tool_args}
+
+
+class ReplayEvent(TypedDict, total=False):
+    """One canonical replay event. Written to ``replay_events`` DuckDB
+    table by the daemon, read by ``/api/replay-tree/<session_id>``.
+    """
+    ts: float
+    kind: str                    # one of ALL_KINDS
+    span_id: str
+    parent_span_id: str | None   # delegation edge, NOT transcript chain
+    session_id: str
+    runtime: str                 # runtime_kind, e.g. "claude_code"
+    payload: dict[str, Any]
+    mode: ModeChip | None
+    approval: ApprovalInfo | None
+
+
+# ── Validators / helpers ─────────────────────────────────────────────────
+
+
+def is_valid_kind(kind: str) -> bool:
+    return kind in ALL_KINDS
+
+
+def validate(event: dict[str, Any]) -> list[str]:
+    """Return a list of validation errors. Empty list = valid.
+
+    Cheap enough to run on every insert; not a hard requirement (the
+    DuckDB write is authoritative) but useful in tests and when an
+    adapter is under active development.
+    """
+    errors: list[str] = []
+    if "ts" not in event:
+        errors.append("missing ts")
+    elif not isinstance(event["ts"], (int, float)):
+        errors.append("ts must be numeric (unix seconds)")
+    if "kind" not in event:
+        errors.append("missing kind")
+    elif not is_valid_kind(event["kind"]):
+        errors.append(f"unknown kind: {event['kind']}")
+    if "span_id" not in event or not event["span_id"]:
+        errors.append("missing span_id")
+    if "session_id" not in event or not event["session_id"]:
+        errors.append("missing session_id")
+    if "runtime" not in event or not event["runtime"]:
+        errors.append("missing runtime")
+    # mode.changed events must carry a non-empty mode dict; nothing else
+    # should carry one (adapters that emit e.g. mode on every tool call
+    # bloat the store and confuse the mode-marker UI).
+    kind = event.get("kind")
+    if kind == KIND_MODE_CHANGED:
+        if not event.get("mode"):
+            errors.append("mode.changed event must include a mode dict")
+    elif event.get("mode") is not None:
+        errors.append(f"mode field only valid on {KIND_MODE_CHANGED} events")
+    # approval side-channel is only valid on approval.* events.
+    if kind and kind.startswith("approval.") and not event.get("approval"):
+        errors.append(f"{kind} event must include an approval dict")
+    elif kind and not kind.startswith("approval.") and event.get("approval") is not None:
+        errors.append("approval field only valid on approval.* events")
+    return errors

--- a/clawmetry/static/css/dashboard.css
+++ b/clawmetry/static/css/dashboard.css
@@ -2378,3 +2378,63 @@ body.has-profile-menu #logout-btn { display: none !important; }
   .cm-tr-pop-cols { grid-template-columns: 1fr; }
   .cm-tr-abs { border-right: none; border-bottom: 1px solid var(--border-primary); }
 }
+
+/* === Runtime-aware replay tree — skeleton (#4813 part 3) ==============
+   Dormant until an adapter populates replay_events. Compact, monochrome
+   defaults; per-runtime templates (Claude Code #4815, OpenClaw #4816,
+   Pro adapters) may layer richer styles via registerKindRenderer().
+*/
+.replay-tree { display: flex; flex-direction: column; gap: 10px; padding: 4px 0; }
+.replay-tree-mode-chip {
+  display: inline-block; padding: 3px 10px; border-radius: 12px;
+  font-size: 11px; font-weight: 600; letter-spacing: 0.5px;
+  background: var(--bg-tertiary); color: var(--text-secondary);
+  border: 1px solid var(--border-primary); align-self: flex-start;
+}
+.replay-tree-mode-chip[data-yolo="1"] {
+  background: color-mix(in srgb, #d63b3b 24%, var(--bg-tertiary));
+  border-color: #d63b3b; color: #fff;
+}
+.replay-tree-workflows { display: flex; flex-direction: column; gap: 6px; }
+.replay-tree-workflow { border-left: 3px solid var(--accent); padding: 6px 10px;
+  background: var(--bg-secondary); border-radius: 6px; }
+.replay-tree-workflow > summary { cursor: pointer; font-weight: 600;
+  color: var(--text-primary); }
+.replay-tree-turn {
+  border: 1px solid var(--border-secondary); border-radius: 8px;
+  padding: 10px 12px; background: var(--bg-secondary);
+}
+.replay-tree-turn-header {
+  display: flex; align-items: center; gap: 8px;
+  font-size: 12px; color: var(--text-muted);
+  margin-bottom: 6px; padding-bottom: 6px;
+  border-bottom: 1px dashed var(--border-secondary);
+}
+.replay-tree-turn-id { font-weight: 600; color: var(--text-secondary); }
+.replay-tree-badge {
+  padding: 2px 6px; border-radius: 4px; font-size: 11px; font-weight: 600;
+  background: var(--bg-tertiary); color: var(--text-secondary);
+}
+.replay-tree-badge.approvals { background: color-mix(in srgb, #4a9eff 18%, var(--bg-tertiary)); }
+.replay-tree-event {
+  padding: 3px 0; font-family: var(--font-mono, monospace); font-size: 12px;
+  color: var(--text-secondary); display: flex; gap: 8px;
+}
+.replay-tree-kind {
+  min-width: 100px; color: var(--accent); font-weight: 600;
+}
+.replay-tree-body { color: var(--text-muted); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.replay-tree-kind-agent .replay-tree-kind { color: #b070ff; }
+.replay-tree-kind-workflow .replay-tree-kind { color: #ffa060; }
+.replay-tree-kind-approval .replay-tree-kind { color: #4a9eff; }
+.replay-tree-kind-tool .replay-tree-kind { color: #70cfa0; }
+.replay-tree-delegations {
+  margin-left: 16px; padding-left: 10px;
+  border-left: 2px solid var(--border-secondary);
+}
+.replay-tree-delegations[data-depth="2"] { border-left-color: var(--accent); }
+.replay-tree-delegations[data-depth="3"] { border-left-color: #b070ff; }
+.replay-tree-delegation > summary {
+  cursor: pointer; font-size: 12px; color: var(--text-muted);
+  padding: 2px 0;
+}

--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -26043,3 +26043,196 @@ async function cmRuntimeOpenFile(clickEl, runtimeId, gi, fi) {
   wrapped._cmRuntimeWrapped = true;
   window.switchTab = wrapped;
 })();
+
+// ═══════════════════════════════════════════════════════════════════════
+// Runtime-aware replay tree — skeleton (#4813 part 3)
+// ═══════════════════════════════════════════════════════════════════════
+// Fetches /api/replay-tree/<sid> and renders the nested runtime-aware
+// view (mode chip, workflow lane, turn chapters with inline delegations,
+// approvals rail). Dormant until adapter mappers land — when the tree
+// returns row_count=0 the caller falls back to the flat _replayRenderCurrent
+// path (no dead UI per FLYWHEEL §0a.4).
+//
+// Wire-up into openTranscriptModal happens in #4814 (mode + approvals)
+// once there's real data to render. For now the skeleton is reachable
+// via window._debugReplayTree(sessionId) for manual verification during
+// per-runtime mapper development.
+(function _cmReplayTree() {
+  'use strict';
+
+  async function fetchReplayTree(sessionId) {
+    var url = '/api/replay-tree/' + encodeURIComponent(sessionId);
+    var r = await fetch(url, { credentials: 'same-origin' });
+    if (!r.ok) throw new Error('replay-tree ' + r.status);
+    return await r.json();
+  }
+
+  function _escape(s) {
+    if (s == null) return '';
+    return String(s).replace(/[&<>"']/g, function(c) {
+      return ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'})[c];
+    });
+  }
+
+  // Runtime dispatcher — mirrors the pattern at app.js:16729 (Harness tab
+  // templates). Each runtime can register a per-kind override; unknown
+  // runtimes fall through to the neutral renderer.
+  var _KIND_RENDERERS = {};   // key = runtime + ':' + kind, value = fn(ev) -> html
+  function registerKindRenderer(runtime, kind, fn) {
+    _KIND_RENDERERS[runtime + ':' + kind] = fn;
+  }
+  function _renderEvent(ev, runtime) {
+    var custom = _KIND_RENDERERS[(runtime || ev.runtime) + ':' + ev.kind];
+    if (typeof custom === 'function') return custom(ev);
+    // Neutral fallback — one line per event, prefix by kind.
+    var kindLabel = _escape(ev.kind || 'event');
+    var body = '';
+    if (ev.payload && typeof ev.payload === 'object') {
+      body = _escape(JSON.stringify(ev.payload).slice(0, 200));
+    }
+    return '<div class="replay-tree-event replay-tree-kind-' +
+           _escape((ev.kind || '').split('.')[0]) + '">' +
+           '<span class="replay-tree-kind">' + kindLabel + '</span>' +
+           (body ? '<span class="replay-tree-body">' + body + '</span>' : '') +
+           '</div>';
+  }
+
+  function _renderDelegations(delegations, runtime, depth) {
+    depth = depth || 1;
+    if (!delegations || !delegations.length) return '';
+    var html = '<div class="replay-tree-delegations" data-depth="' + depth + '">';
+    for (var i = 0; i < delegations.length; i++) {
+      var d = delegations[i];
+      html += '<details class="replay-tree-delegation" open>';
+      html += '<summary>↳ delegated span ' + _escape(d.span_id) + '</summary>';
+      for (var j = 0; j < (d.events || []).length; j++) {
+        html += _renderEvent(d.events[j], runtime);
+      }
+      // Nested delegations render recursively — arbitrary depth (issue
+      // #4815 Claude Code Task nesting stresses this).
+      html += _renderDelegations(d.delegations, runtime, depth + 1);
+      html += '</details>';
+    }
+    html += '</div>';
+    return html;
+  }
+
+  function _renderTurn(turn, runtime) {
+    var html = '<section class="replay-tree-turn" data-turn-id="' +
+               _escape(turn.turn_id) + '">';
+    // Approvals rail summary badge on the turn header.
+    var approvalCount = (turn.approvals || []).length;
+    var deniedCount = (turn.approvals || []).filter(function(a) {
+      return a.approval && a.approval.status === 'denied';
+    }).length;
+    var badges = '';
+    if (approvalCount) {
+      badges += ' <span class="replay-tree-badge approvals" title="' +
+                approvalCount + ' approvals (' + deniedCount + ' denied)">' +
+                '✓' + approvalCount + (deniedCount ? ' ✗' + deniedCount : '') +
+                '</span>';
+    }
+    html += '<header class="replay-tree-turn-header">' +
+            '<span class="replay-tree-turn-id">turn ' + _escape(turn.turn_id) + '</span>' +
+            badges + '</header>';
+    // Events (llm.*, tool.*, thinking, mode.changed, compaction).
+    for (var i = 0; i < (turn.events || []).length; i++) {
+      html += _renderEvent(turn.events[i], runtime);
+    }
+    // Inline delegations under the turn that spawned them.
+    html += _renderDelegations(turn.delegations, runtime, 1);
+    html += '</section>';
+    return html;
+  }
+
+  function _renderModeChip(mode) {
+    if (!mode || !mode.permission) return '';
+    var isYolo = mode.permission === 'bypassPermissions' || mode.permission === 'yolo';
+    return '<div class="replay-tree-mode-chip" data-yolo="' +
+           (isYolo ? '1' : '0') + '" title="sandbox: ' +
+           _escape(mode.sandbox || 'unknown') + '">' +
+           _escape(mode.permission) + '</div>';
+  }
+
+  function _renderWorkflows(workflows, runtime) {
+    if (!workflows || !workflows.length) return '';
+    var html = '<div class="replay-tree-workflows">';
+    for (var i = 0; i < workflows.length; i++) {
+      var wf = workflows[i];
+      html += '<details class="replay-tree-workflow" open>';
+      html += '<summary>⚙ workflow ' + _escape(wf.span_id) + ' (' +
+              (wf.events || []).length + ' stages)</summary>';
+      for (var j = 0; j < (wf.events || []).length; j++) {
+        html += _renderEvent(wf.events[j], runtime);
+      }
+      html += '</details>';
+    }
+    html += '</div>';
+    return html;
+  }
+
+  function renderTree(tree, mountEl) {
+    if (!mountEl) return false;
+    if (!tree || !tree.row_count) {
+      // Honest empty state — caller falls back to the flat renderer.
+      mountEl.innerHTML = '';
+      return false;
+    }
+    var html = '<div class="replay-tree" data-runtime="' +
+               _escape(tree.runtime || 'unknown') + '">';
+    html += _renderModeChip(tree.mode);
+    html += _renderWorkflows(tree.workflows, tree.runtime);
+    for (var i = 0; i < (tree.turns || []).length; i++) {
+      html += _renderTurn(tree.turns[i], tree.runtime);
+    }
+    html += '</div>';
+    mountEl.innerHTML = html;
+    return true;
+  }
+
+  async function debugReplayTree(sessionId) {
+    // Manual verification hook — creates a floating panel with the
+    // rendered tree. Adapter authors call this to visualize their
+    // iter_replay_events output during development.
+    var panel = document.getElementById('_replay-tree-debug-panel');
+    if (!panel) {
+      panel = document.createElement('div');
+      panel.id = '_replay-tree-debug-panel';
+      panel.style.cssText = 'position:fixed;top:20px;right:20px;width:600px;' +
+        'max-height:80vh;overflow:auto;background:var(--bg-elevated,#111);' +
+        'color:var(--text,#eee);border:1px solid var(--border,#444);padding:12px;' +
+        'z-index:10000;font-family:monospace;font-size:12px;';
+      var close = document.createElement('button');
+      close.textContent = '×';
+      close.style.cssText = 'position:absolute;top:4px;right:8px;background:none;color:inherit;border:none;font-size:20px;cursor:pointer;';
+      close.onclick = function() { panel.remove(); };
+      panel.appendChild(close);
+      document.body.appendChild(panel);
+    }
+    panel.innerHTML = '<div>Fetching /api/replay-tree/' +
+                      _escape(sessionId) + ' …</div>';
+    try {
+      var tree = await fetchReplayTree(sessionId);
+      var mount = document.createElement('div');
+      panel.appendChild(mount);
+      var rendered = renderTree(tree, mount);
+      if (!rendered) {
+        mount.innerHTML = '<div style="color:var(--text-muted,#888);padding:16px;">' +
+          'Empty tree — no replay_events for this session yet. ' +
+          'Adapter mappers land in #4815 (Claude Code), #4816 (OpenClaw), ' +
+          'and 13 Pro adapter issues.</div>';
+      }
+    } catch (e) {
+      panel.innerHTML += '<div style="color:#f66;">error: ' +
+                        _escape(String(e)) + '</div>';
+    }
+  }
+
+  // Public surface — small, so #4814 and per-runtime mappers can extend.
+  window._cmReplayTree = {
+    fetchReplayTree: fetchReplayTree,
+    renderTree: renderTree,
+    registerKindRenderer: registerKindRenderer,
+  };
+  window._debugReplayTree = debugReplayTree;
+})();

--- a/docs/QUERY_CONTRACT.md
+++ b/docs/QUERY_CONTRACT.md
@@ -41,6 +41,7 @@ test enforces both directions).
 | `external_calls` | live | e2e | `query_external_calls` | `session_id`, `since`, `until`, `limit` (default 200, range 1..2000) | External (non-LLM) API calls captured by the interceptor. |
 | `health` | live | plaintext | `health` | (none) | Store health snapshot (engine, size, ring depth, flush age). |
 | `models` | live | plaintext | `query_rollup_model_daily` | `runtime`, `since`, `until`, `limit` (default 1000, range 1..10000) | Per-model daily token/cost rollup across runtimes. |
+| `replay_events` | live | e2e | `query_replay_events` | `session_id` (required), `limit` (default 2000, range 1..10000) | Canonical replay-event rows for one session (#4813). Rows in kind-agnostic order; the /api/replay-tree endpoint groups them into turns/delegations/workflows/approvals. |
 | `rollup_sessions` | live | e2e | `query_rollup_sessions` | `runtime`, `limit` (default 200, range 1..2000) | Per-session materialized summary (title, status, totals, stuck flag). |
 | `runtimes` | live | plaintext | `query_rollup_runtime_daily` | `since`, `until`, `limit` (default 1000, range 1..10000) | Per-runtime daily activity/cost rollup (claude_code, openclaw, ...). |
 | `search` | live | e2e | `query_search` | `q` (required), `model`, `status`, `since`, `until`, `limit` (default 50, range 1..500) | Full-text search over session titles and eval reasons. |
@@ -54,4 +55,4 @@ test enforces both directions).
 | `session` | planned | e2e | `query_sessions_table` | `session_id` (required) | Single-session detail row (title, status, outcome, totals). |
 | `usage` | planned | plaintext | `rollup_usage_daily` | `runtime`, `since`, `until` | Daily token/cost usage series (input/output/cache splits). |
 
-Live methods: 13. Planned methods: 5.
+Live methods: 14. Planned methods: 5.

--- a/routes/local_query.py
+++ b/routes/local_query.py
@@ -262,6 +262,14 @@ def _coerce_args(shape: str, raw: dict) -> dict:
             "until": raw.get("until"),
             "limit": _safe_int(raw.get("limit"), default=500, lo=1, hi=2000),
         }
+    if shape == "replay_events":
+        sid = raw.get("session_id")
+        if not sid:
+            raise ValueError("replay_events shape requires session_id")
+        return {
+            "session_id": sid,
+            "limit": _safe_int(raw.get("limit"), default=2000, lo=1, hi=10000),
+        }
     raise ValueError(f"unknown shape: {shape}")
 
 
@@ -479,6 +487,26 @@ def http_agent_graph():
     try:
         args = _coerce_args("agent_graph", request.args.to_dict())
         return jsonify(_dispatch("agent_graph", args))
+    except Exception as e:
+        return jsonify({"error": str(e)[:300]}), 500
+
+
+@bp_local_query.route("/api/local/replay-events/<path:session_id>", methods=["GET"])
+def http_replay_events(session_id: str):
+    """Flat canonical replay-event rows for one session (#4813).
+
+    Powers ``/api/replay-tree/<session_id>`` (the tree-building endpoint
+    lives in ``routes/sessions.py``). Returned rows are ts-ascending; the
+    endpoint layer groups them into turns/delegations/workflows.
+    Empty ``rows`` is the honest shape until adapter mappers land.
+    """
+    try:
+        raw = dict(request.args.to_dict())
+        raw["session_id"] = session_id
+        args = _coerce_args("replay_events", raw)
+        return jsonify(_dispatch("replay_events", args))
+    except ValueError as e:
+        return jsonify({"error": str(e)[:300]}), 400
     except Exception as e:
         return jsonify({"error": str(e)[:300]}), 500
 

--- a/routes/sessions.py
+++ b/routes/sessions.py
@@ -2981,6 +2981,147 @@ def api_session_lineage(session_id):
     })
 
 
+@bp_sessions.route("/api/replay-tree/<path:session_id>")
+def api_replay_tree(session_id):
+    """Runtime-aware replay-tree for one session (#4813).
+
+    Reads canonical replay-event rows from the ``replay_events`` DuckDB
+    table (populated by adapter ``iter_replay_events`` mappers — Claude
+    Code #4815, OpenClaw #4816, Pro adapters #123–#135) and groups them
+    into the nested shape the runtime-aware transcript viewer consumes.
+
+    Returns::
+
+        {
+          "session_id": ...,
+          "runtime":    <latest runtime seen, or null>,
+          "mode":       <latest mode.changed payload, or null>,
+          "turns":      [{turn_id, events[], delegations[], approvals[]}],
+          "workflows":  [{span_id, kind, events[]}]
+        }
+
+    Empty ``turns`` / ``workflows`` is the honest shape until adapter
+    mappers land — the JS renderer falls back to the flat transcript
+    viewer when the tree comes back empty (no dead UI per FLYWHEEL
+    §0a.4). Cloud parity: the cloud dashboard reads the same shape
+    from its snapshot slice once the snapshot writer path lands.
+    """
+    try:
+        rows = _ls_call("query_replay_events", session_id=session_id) or []
+    except Exception:
+        rows = []
+    return jsonify(_build_replay_tree(session_id, rows))
+
+
+def _build_replay_tree(session_id: str, rows: list[dict]) -> dict:
+    """Group flat canonical replay-event rows into the tree the transcript
+    viewer consumes. Pure function, easy to test.
+
+    Grouping rules (see clawmetry/replay_schema.py for kind semantics):
+
+    - ``mode.changed`` events feed the top-level ``mode`` field (latest
+      value wins) — the mode chip in the UI header.
+    - ``workflow.*`` events are collected into ``workflows`` at the top
+      level; workflow.start creates the group, workflow.stage/end append.
+    - ``agent.spawn`` / ``agent.return`` establish the delegation edges.
+      A child span (``parent_span_id`` set) attaches under its parent as
+      a ``delegations`` entry; the parent turn shows the delegation
+      inline. Nested delegation (child of child) attaches under that
+      child, arbitrary depth.
+    - Everything else (llm.*, tool.*, thinking, approval.*, compaction)
+      is a "turn" event. Turns are chunked by the ordering of
+      ``llm.call``/``llm.response`` roots — one root = one turn — so a
+      transcript with 12 user prompts renders as 12 turn chapters.
+    """
+    latest_mode = None
+    latest_runtime = None
+    workflows_by_span: dict[str, dict] = {}
+    turns: list[dict] = []
+    events_by_span: dict[str, dict] = {}
+    children_by_parent: dict[str, list[dict]] = {}
+    approvals_by_span: dict[str, list[dict]] = {}
+    _current_turn: dict | None = None
+
+    for row in rows:
+        kind = row.get("kind") or ""
+        latest_runtime = row.get("runtime") or latest_runtime
+        events_by_span[row.get("span_id") or ""] = row
+        parent = row.get("parent_span_id")
+        if parent:
+            children_by_parent.setdefault(parent, []).append(row)
+
+        if kind == "mode.changed":
+            latest_mode = row.get("mode") or latest_mode
+            continue
+        if kind.startswith("workflow."):
+            root = row.get("parent_span_id") or row.get("span_id") or ""
+            grp = workflows_by_span.setdefault(root, {
+                "span_id": root,
+                "kind": "workflow",
+                "events": [],
+            })
+            grp["events"].append(row)
+            continue
+        if kind.startswith("approval."):
+            gate = row.get("parent_span_id") or row.get("span_id") or ""
+            approvals_by_span.setdefault(gate, []).append(row)
+            continue
+        # llm.*, tool.*, thinking, agent.*, compaction — turn-level events.
+        # Start a new turn on every llm.call at the session root (no parent).
+        if kind == "llm.call" and not parent:
+            _current_turn = {
+                "turn_id": row.get("span_id"),
+                "events": [row],
+                "delegations": [],
+                "approvals": [],
+            }
+            turns.append(_current_turn)
+        elif _current_turn is not None:
+            _current_turn["events"].append(row)
+        else:
+            # Event before any llm.call — synthetic turn-0 bucket.
+            if not turns:
+                turns.append({
+                    "turn_id": "turn-0",
+                    "events": [],
+                    "delegations": [],
+                    "approvals": [],
+                })
+            turns[0]["events"].append(row)
+
+    # Fold delegations into the turn that spawned them. agent.spawn events
+    # carry parent_span_id pointing at the parent's llm.response; the
+    # child session's events live under events_by_span keyed on the
+    # spawn's span_id.
+    for turn in turns:
+        spawn_ids = [
+            e.get("span_id") for e in turn["events"]
+            if (e.get("kind") or "").startswith("agent.spawn")
+        ]
+        for spawn_id in spawn_ids:
+            children = children_by_parent.get(spawn_id, [])
+            turn["delegations"].append({
+                "span_id": spawn_id,
+                "events": children,
+                # nested-depth support lands with #4815 (Claude Code mapper).
+                "delegations": [],
+            })
+        # Attach approvals gated on any event in this turn.
+        for e in turn["events"]:
+            sid = e.get("span_id")
+            if sid and sid in approvals_by_span:
+                turn["approvals"].extend(approvals_by_span[sid])
+
+    return {
+        "session_id": session_id,
+        "runtime":    latest_runtime,
+        "mode":       latest_mode,
+        "turns":      turns,
+        "workflows":  list(workflows_by_span.values()),
+        "row_count":  len(rows),
+    }
+
+
 @bp_sessions.route("/api/delegation-tree")
 def api_delegation_tree():
     """Agent delegation chains -- inspired by AgentWeave provenance tracing.

--- a/tests/fixtures/query_contract/replay_events.json
+++ b/tests/fixtures/query_contract/replay_events.json
@@ -1,0 +1,7 @@
+{
+  "_elapsed_ms": "<volatile>",
+  "_shape": "replay_events",
+  "_via": "<volatile>",
+  "count": 0,
+  "rows": []
+}

--- a/tests/replay_tree.test.mjs
+++ b/tests/replay_tree.test.mjs
@@ -1,0 +1,128 @@
+// JS-side smoke test for the replay-tree skeleton (#4813 part 3).
+//
+// Extracts the _cmReplayTree IIFE from app.js, runs it against a stubbed
+// window + document, and asserts the public surface + core behavior:
+//   1. window._cmReplayTree + window._debugReplayTree land on the window
+//   2. renderTree returns false for an empty tree (fallback trigger)
+//   3. renderTree returns true and populates innerHTML for a non-empty tree
+
+import fs from 'fs';
+
+const src = fs.readFileSync(
+  new URL('../clawmetry/static/js/app.js', import.meta.url), 'utf8');
+
+const start = src.indexOf('(function _cmReplayTree() {');
+if (start < 0) throw new Error('_cmReplayTree IIFE not found in app.js');
+const end = src.indexOf('})();', start) + 5;
+const code = src.slice(start, end);
+
+// Minimal DOM stub — the module only touches innerHTML / classList /
+// createElement in renderTree; debugReplayTree is not exercised here.
+class _StubEl {
+  constructor(tag) {
+    this.tagName = (tag || 'div').toUpperCase();
+    this.children = [];
+    this._innerHTML = '';
+    this.style = { cssText: '' };
+    this.classList = { add: () => {}, remove: () => {}, toggle: () => {} };
+  }
+  get innerHTML() { return this._innerHTML; }
+  set innerHTML(v) { this._innerHTML = v; }
+  appendChild(c) { this.children.push(c); return c; }
+  remove() {}
+}
+const document = {
+  createElement: (tag) => new _StubEl(tag),
+  getElementById: () => null,
+  body: new _StubEl('body'),
+};
+const window = {};
+const fetch = () => Promise.reject(new Error('fetch not exercised'));
+
+const fn = new Function(
+  'window', 'document', 'fetch',
+  code + '; return {api: window._cmReplayTree, debug: window._debugReplayTree};'
+);
+const {api, debug} = fn(window, document, fetch);
+
+let pass = 0, fail = 0;
+const check = (name, cond) => {
+  if (cond) pass++;
+  else { fail++; console.log('FAIL:', name); }
+};
+
+check('public API exposed', api && typeof api.renderTree === 'function' &&
+                            typeof api.fetchReplayTree === 'function' &&
+                            typeof api.registerKindRenderer === 'function');
+check('debug hook exposed', typeof debug === 'function');
+
+// Empty tree → false + cleared mount.
+const emptyMount = new _StubEl('div');
+const rEmpty = api.renderTree({row_count: 0, turns: [], workflows: []}, emptyMount);
+check('empty tree returns false', rEmpty === false);
+check('empty tree clears mount', emptyMount.innerHTML === '');
+
+// Non-empty tree → true + populated mount, mode chip + turn rendered.
+const tree = {
+  session_id: 's1',
+  runtime: 'claude_code',
+  row_count: 3,
+  mode: {permission: 'bypassPermissions', sandbox: 'danger-full-access'},
+  workflows: [],
+  turns: [{
+    turn_id: 'u1',
+    events: [
+      {span_id: 'u1', kind: 'llm.call', payload: {prompt: 'hi'}, runtime: 'claude_code'},
+      {span_id: 'a1', kind: 'llm.response', payload: {}, runtime: 'claude_code'},
+    ],
+    delegations: [],
+    approvals: [],
+  }],
+};
+const populatedMount = new _StubEl('div');
+const rFull = api.renderTree(tree, populatedMount);
+check('non-empty tree returns true', rFull === true);
+check('tree wrapper rendered', populatedMount.innerHTML.includes('class="replay-tree"'));
+check('yolo mode chip painted', populatedMount.innerHTML.includes('data-yolo="1"'));
+check('turn rendered', populatedMount.innerHTML.includes('data-turn-id="u1"'));
+check('llm.call event rendered', populatedMount.innerHTML.includes('llm.call'));
+
+// Custom kind renderer wins over neutral fallback.
+api.registerKindRenderer('claude_code', 'llm.call', () => '<div class="CUSTOM"></div>');
+const customMount = new _StubEl('div');
+api.renderTree(tree, customMount);
+check('custom kind renderer wins', customMount.innerHTML.includes('CUSTOM'));
+
+// Delegations render inline under their spawning turn.
+const treeWithDelegation = {
+  session_id: 's2',
+  runtime: 'claude_code',
+  row_count: 4,
+  mode: null,
+  workflows: [],
+  turns: [{
+    turn_id: 'u1',
+    events: [
+      {span_id: 'u1', kind: 'llm.call', runtime: 'claude_code'},
+      {span_id: 'spawn1', kind: 'agent.spawn', runtime: 'claude_code'},
+    ],
+    delegations: [{
+      span_id: 'spawn1',
+      events: [{span_id: 'child-u1', kind: 'llm.call', runtime: 'claude_code'}],
+      delegations: [],
+    }],
+    approvals: [],
+  }],
+};
+const delegMount = new _StubEl('div');
+api.renderTree(treeWithDelegation, delegMount);
+check('delegation wrapper rendered',
+      delegMount.innerHTML.includes('replay-tree-delegations'));
+check('delegation summary references spawn id',
+      delegMount.innerHTML.includes('delegated span spawn1'));
+
+if (fail > 0) {
+  console.log(`\n${pass} passed, ${fail} failed`);
+  process.exit(1);
+}
+console.log(`${pass} passed`);

--- a/tests/test_local_query_dispatch_edge_cases.py
+++ b/tests/test_local_query_dispatch_edge_cases.py
@@ -80,7 +80,11 @@ def test_known_shapes_are_exactly_the_allowlist(lq_app):
                                "models", "runtimes", "rollup_sessions",
                                # #1012 Agent Graph tab (Phase 6 Tracing):
                                # cross-session spawn topology from spans.
-                               "agent_graph"}, (
+                               "agent_graph",
+                               # #4813 session-replay: canonical replay-event
+                               # rows for one session, e2e-classed (carries
+                               # LLM message + tool-arg payloads).
+                               "replay_events"}, (
         "the dispatch allowlist changed — review for new query surface before "
         "widening what the relay/cloud can ask the local store to run "
         f"(got {sorted(lq._SHAPES)})"

--- a/tests/test_query_contract_drift.py
+++ b/tests/test_query_contract_drift.py
@@ -173,6 +173,8 @@ EXPECTED_TRUST = {
     "search": "e2e",
     # #1012 Agent Graph: aggregate node/edge counts only, no content.
     "agent_graph": "plaintext",
+    # #4813 replay events: carry LLM message/tool-arg payloads -> e2e.
+    "replay_events": "e2e",
 }
 
 

--- a/tests/test_query_contract_goldens.py
+++ b/tests/test_query_contract_goldens.py
@@ -48,6 +48,8 @@ DISPATCH_ARGS = {
     "rollup_sessions": {},
     # #1012 (Agent Graph tab, Phase 6 Tracing): spawn topology from spans.
     "agent_graph": {},
+    # #4813 session-replay: canonical replay-event rows for one session.
+    "replay_events": {"session_id": "sess-a"},
 }
 
 # health() fields that legitimately vary run-to-run / machine-to-machine.

--- a/tests/test_replay_schema.py
+++ b/tests/test_replay_schema.py
@@ -1,0 +1,174 @@
+"""Tests for the canonical replay-event schema (#4813).
+
+Foundation tests only: module imports, kind enum coverage, validator
+correctness, and DuckDB table creation. Adapter-specific mapping tests
+live with their adapters (Claude Code #4815, OpenClaw #4816, Pro
+adapters in clawmetry-pro).
+"""
+
+from __future__ import annotations
+
+import tempfile
+import time
+from pathlib import Path
+
+import duckdb
+import pytest
+
+from clawmetry import replay_schema
+from clawmetry.replay_schema import (
+    ALL_KINDS,
+    KIND_AGENT_SPAWN,
+    KIND_APPROVAL_DECIDED,
+    KIND_APPROVAL_REQUESTED,
+    KIND_LLM_CALL,
+    KIND_MODE_CHANGED,
+    KIND_TOOL_CALL,
+    is_valid_kind,
+    validate,
+)
+
+
+def _valid_llm_event() -> dict:
+    return {
+        "ts": time.time(),
+        "kind": KIND_LLM_CALL,
+        "span_id": "span-1",
+        "parent_span_id": None,
+        "session_id": "sess-1",
+        "runtime": "claude_code",
+        "payload": {"model": "claude-opus-4-7"},
+    }
+
+
+# ── kind enum ────────────────────────────────────────────────────────────
+
+
+def test_all_kinds_are_unique():
+    assert len(ALL_KINDS) == len(set(ALL_KINDS))
+
+
+def test_kinds_use_dotted_prefixes():
+    # Renderer dispatches on prefix; leading dot-token must be stable.
+    prefixes = {k.split(".")[0] for k in ALL_KINDS if "." in k}
+    assert prefixes >= {"llm", "tool", "agent", "workflow", "approval", "mode"}
+
+
+def test_is_valid_kind():
+    for k in ALL_KINDS:
+        assert is_valid_kind(k), k
+    assert not is_valid_kind("bogus.kind")
+    assert not is_valid_kind("")
+
+
+# ── validator ────────────────────────────────────────────────────────────
+
+
+def test_validate_accepts_minimal_event():
+    assert validate(_valid_llm_event()) == []
+
+
+def test_validate_flags_missing_required_fields():
+    errs = validate({})
+    assert any("ts" in e for e in errs)
+    assert any("kind" in e for e in errs)
+    assert any("span_id" in e for e in errs)
+    assert any("session_id" in e for e in errs)
+    assert any("runtime" in e for e in errs)
+
+
+def test_validate_flags_unknown_kind():
+    ev = _valid_llm_event()
+    ev["kind"] = "gremlin.event"
+    assert any("unknown kind" in e for e in validate(ev))
+
+
+def test_mode_required_only_on_mode_changed():
+    # Missing mode on mode.changed → error.
+    ev = _valid_llm_event()
+    ev["kind"] = KIND_MODE_CHANGED
+    assert any("mode.changed" in e for e in validate(ev))
+    ev["mode"] = {"permission": "bypassPermissions"}
+    assert validate(ev) == []
+    # Mode on a non-mode.changed event → error (prevents adapter bloat).
+    ev2 = _valid_llm_event()
+    ev2["mode"] = {"permission": "default"}
+    assert any("mode field only valid" in e for e in validate(ev2))
+
+
+def test_approval_required_only_on_approval_events():
+    ev = _valid_llm_event()
+    ev["kind"] = KIND_APPROVAL_REQUESTED
+    assert any("approval dict" in e for e in validate(ev))
+    ev["approval"] = {"status": "requested"}
+    assert validate(ev) == []
+    ev2 = _valid_llm_event()
+    ev2["kind"] = KIND_TOOL_CALL
+    ev2["approval"] = {"status": "approved"}
+    assert any("approval field only valid" in e for e in validate(ev2))
+
+
+def test_agent_spawn_kind_present():
+    # Regression guard: the whole delegation-tree UI depends on this kind.
+    assert KIND_AGENT_SPAWN in ALL_KINDS
+    assert KIND_APPROVAL_DECIDED in ALL_KINDS
+
+
+# ── DuckDB table shape ───────────────────────────────────────────────────
+
+
+def test_replay_events_table_creates_and_accepts_a_row():
+    """The DDL in local_store.py must be valid DuckDB and accept a row
+    matching the ReplayEvent shape (blobs for payload/mode/approval)."""
+    from clawmetry import local_store  # heavy import; keep test-scoped
+
+    with tempfile.TemporaryDirectory() as tmp:
+        db_path = Path(tmp) / "test.duckdb"
+        conn = duckdb.connect(str(db_path))
+        try:
+            for stmt in local_store._DDL:
+                conn.execute(stmt)
+            conn.execute(
+                """
+                INSERT INTO replay_events
+                  (span_id, parent_span_id, session_id, runtime, kind, ts,
+                   payload, mode, approval, created_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                [
+                    "span-1", None, "sess-1", "claude_code",
+                    KIND_LLM_CALL, time.time(),
+                    b"{}", None, None, int(time.time() * 1000),
+                ],
+            )
+            row = conn.execute(
+                "SELECT span_id, session_id, runtime, kind FROM replay_events"
+            ).fetchone()
+            assert row == ("span-1", "sess-1", "claude_code", KIND_LLM_CALL)
+        finally:
+            conn.close()
+
+
+def test_replay_events_indexes_exist():
+    """The four indexes we rely on for the endpoint's queries must exist."""
+    from clawmetry import local_store
+
+    with tempfile.TemporaryDirectory() as tmp:
+        db_path = Path(tmp) / "test.duckdb"
+        conn = duckdb.connect(str(db_path))
+        try:
+            for stmt in local_store._DDL:
+                conn.execute(stmt)
+            names = {
+                row[0]
+                for row in conn.execute(
+                    "SELECT index_name FROM duckdb_indexes() "
+                    "WHERE table_name = 'replay_events'"
+                ).fetchall()
+            }
+            assert "idx_replay_events_session_ts" in names
+            assert "idx_replay_events_parent" in names
+            assert "idx_replay_events_runtime_kind" in names
+            assert "idx_replay_events_created_at" in names
+        finally:
+            conn.close()

--- a/tests/test_replay_tree_endpoint.py
+++ b/tests/test_replay_tree_endpoint.py
@@ -1,0 +1,250 @@
+"""Tests for /api/replay-tree/<sid> + query_replay_events (#4813 part 2).
+
+Foundation tests: query method reads rows correctly, endpoint returns
+the empty shape when no rows exist, and _build_replay_tree correctly
+folds turns / delegations / workflows / approvals / mode changes from
+a flat canonical event stream.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+
+import pytest
+
+
+# ── query_replay_events (store method) ───────────────────────────────────
+
+
+@pytest.fixture
+def store(tmp_path, monkeypatch):
+    """Fresh writable LocalStore per test.
+
+    Skips the get_store() singleton (which returns a ProxyStore forwarding
+    through the real daemon on developer machines) — we want a direct
+    LocalStore for isolated schema tests. DB_PATH is captured at import
+    time, so we monkeypatch the module attribute rather than the env var.
+    """
+    from pathlib import Path
+    from clawmetry import local_store as ls
+
+    monkeypatch.setattr(ls, "DB_PATH", Path(str(tmp_path / "t.duckdb")))
+    ls._reset_singleton_for_tests()
+    s = ls.LocalStore(read_only=False)
+    s.start()
+    try:
+        yield s
+    finally:
+        try:
+            s.stop(flush=True)
+        except Exception:
+            pass
+        ls._reset_singleton_for_tests()
+
+
+def test_query_replay_events_empty_for_unknown_session(store):
+    """Fresh store with no rows → empty list, not an error."""
+    assert store.query_replay_events(session_id="does-not-exist") == []
+
+
+def test_query_replay_events_roundtrips_row_with_blobs(store):
+    """Insert one row directly, read it back, verify blobs decode to dicts."""
+    from clawmetry.replay_schema import KIND_AGENT_SPAWN
+
+    with store._write_lock:
+        store._conn.execute(
+            """
+            INSERT INTO replay_events
+              (span_id, parent_span_id, session_id, runtime, kind, ts,
+               payload, mode, approval, created_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                "span-A", None, "sess-1", "claude_code",
+                KIND_AGENT_SPAWN, 100.0,
+                json.dumps({"prompt": "hi"}).encode(),
+                None, None,
+                int(time.time() * 1000),
+            ],
+        )
+    rows = store.query_replay_events(session_id="sess-1")
+    assert len(rows) == 1
+    r = rows[0]
+    assert r["span_id"] == "span-A"
+    assert r["kind"] == KIND_AGENT_SPAWN
+    assert r["payload"] == {"prompt": "hi"}   # decoded to dict
+    assert r["mode"] is None
+    assert r["approval"] is None
+
+
+# ── _build_replay_tree (pure grouping fn) ────────────────────────────────
+
+
+def _e(**kw):
+    """Compact event builder with sensible defaults."""
+    return {
+        "span_id": kw.get("span_id"),
+        "parent_span_id": kw.get("parent_span_id"),
+        "session_id": kw.get("session_id", "sess-1"),
+        "runtime": kw.get("runtime", "claude_code"),
+        "kind": kw["kind"],
+        "ts": kw.get("ts", 0.0),
+        "payload": kw.get("payload"),
+        "mode": kw.get("mode"),
+        "approval": kw.get("approval"),
+    }
+
+
+def test_build_tree_empty_rows_returns_honest_shape():
+    from routes.sessions import _build_replay_tree
+
+    out = _build_replay_tree("sess-x", [])
+    assert out == {
+        "session_id": "sess-x",
+        "runtime": None,
+        "mode": None,
+        "turns": [],
+        "workflows": [],
+        "row_count": 0,
+    }
+
+
+def test_build_tree_groups_events_by_turn():
+    from routes.sessions import _build_replay_tree
+
+    rows = [
+        _e(span_id="u1", kind="llm.call", ts=1.0),
+        _e(span_id="a1", kind="llm.response", ts=2.0, parent_span_id="u1"),
+        _e(span_id="t1", kind="tool.call", ts=3.0, parent_span_id="a1"),
+        _e(span_id="tr1", kind="tool.result", ts=4.0, parent_span_id="t1"),
+        _e(span_id="u2", kind="llm.call", ts=5.0),
+        _e(span_id="a2", kind="llm.response", ts=6.0, parent_span_id="u2"),
+    ]
+    out = _build_replay_tree("s1", rows)
+    assert len(out["turns"]) == 2
+    assert out["turns"][0]["turn_id"] == "u1"
+    assert len(out["turns"][0]["events"]) == 4
+    assert out["turns"][1]["turn_id"] == "u2"
+    assert len(out["turns"][1]["events"]) == 2
+    assert out["runtime"] == "claude_code"
+
+
+def test_build_tree_captures_latest_mode():
+    from routes.sessions import _build_replay_tree
+
+    rows = [
+        _e(span_id="m1", kind="mode.changed", ts=0.0,
+           mode={"permission": "default"}),
+        _e(span_id="u1", kind="llm.call", ts=1.0),
+        _e(span_id="m2", kind="mode.changed", ts=2.0,
+           mode={"permission": "bypassPermissions"}),
+    ]
+    out = _build_replay_tree("s1", rows)
+    assert out["mode"] == {"permission": "bypassPermissions"}
+
+
+def test_build_tree_folds_delegations_under_spawn():
+    from routes.sessions import _build_replay_tree
+
+    rows = [
+        _e(span_id="u1", kind="llm.call", ts=1.0),
+        _e(span_id="a1", kind="llm.response", ts=2.0, parent_span_id="u1"),
+        _e(span_id="spawn1", kind="agent.spawn", ts=3.0, parent_span_id="a1"),
+        # child events attached under spawn1 via parent_span_id
+        _e(span_id="child-u1", kind="llm.call", ts=4.0, parent_span_id="spawn1"),
+        _e(span_id="child-a1", kind="llm.response", ts=5.0, parent_span_id="spawn1"),
+    ]
+    out = _build_replay_tree("s1", rows)
+    assert len(out["turns"]) == 1
+    turn = out["turns"][0]
+    assert len(turn["delegations"]) == 1
+    d = turn["delegations"][0]
+    assert d["span_id"] == "spawn1"
+    assert len(d["events"]) == 2
+    assert [e["span_id"] for e in d["events"]] == ["child-u1", "child-a1"]
+
+
+def test_build_tree_groups_workflow_events():
+    from routes.sessions import _build_replay_tree
+
+    rows = [
+        _e(span_id="wf1", kind="workflow.start", ts=0.0),
+        _e(span_id="s1", kind="workflow.stage", ts=1.0, parent_span_id="wf1"),
+        _e(span_id="s2", kind="workflow.stage", ts=2.0, parent_span_id="wf1"),
+        _e(span_id="wfe", kind="workflow.end", ts=3.0, parent_span_id="wf1"),
+    ]
+    out = _build_replay_tree("s1", rows)
+    assert len(out["workflows"]) == 1
+    wf = out["workflows"][0]
+    assert len(wf["events"]) == 4
+
+
+def test_build_tree_attaches_approvals_to_gated_event():
+    from routes.sessions import _build_replay_tree
+
+    rows = [
+        _e(span_id="u1", kind="llm.call", ts=1.0),
+        _e(span_id="a1", kind="llm.response", ts=2.0, parent_span_id="u1"),
+        _e(span_id="t1", kind="tool.call", ts=3.0, parent_span_id="a1"),
+        _e(span_id="ap1", kind="approval.requested", ts=3.1,
+           parent_span_id="t1",
+           approval={"status": "requested"}),
+        _e(span_id="ap2", kind="approval.decided", ts=3.2,
+           parent_span_id="t1",
+           approval={"status": "approved", "resolver": "user"}),
+        _e(span_id="tr1", kind="tool.result", ts=4.0, parent_span_id="t1"),
+    ]
+    out = _build_replay_tree("s1", rows)
+    assert len(out["turns"]) == 1
+    assert len(out["turns"][0]["approvals"]) == 2
+
+
+def test_build_tree_synthetic_turn_zero_when_events_precede_first_call():
+    from routes.sessions import _build_replay_tree
+
+    rows = [
+        _e(span_id="sys", kind="thinking", ts=0.0),
+        _e(span_id="u1", kind="llm.call", ts=1.0),
+    ]
+    out = _build_replay_tree("s1", rows)
+    assert len(out["turns"]) == 2
+    assert out["turns"][0]["turn_id"] == "turn-0"
+
+
+# ── endpoint honesty: empty session returns valid empty shape ────────────
+
+
+def test_endpoint_returns_empty_shape_for_unknown_session(store, monkeypatch):
+    """No replay_events for the session → honest empty shape, HTTP 200.
+    Guards against the 'no dead UI' FLYWHEEL rule (§0a.4).
+
+    Uses a minimal Flask app with just bp_sessions registered — importing
+    dashboard.app doesn't register blueprints (they're registered inside
+    main() at first-run), so we scaffold the smallest surface that hosts
+    the /api/replay-tree route.
+    """
+    from flask import Flask
+    from routes.sessions import bp_sessions
+    from clawmetry import local_store as ls
+
+    # Force _ls_call's daemon-proxy to miss so it falls back to the
+    # direct-open path against our tmp store — otherwise it'd hit the
+    # real ~/.clawmetry daemon on a developer machine.
+    monkeypatch.setattr(
+        "routes.local_query.local_store_via_daemon",
+        lambda *a, **kw: None,
+    )
+    monkeypatch.setattr(ls, "get_store", lambda read_only=False: store)
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_sessions)
+    client = app.test_client()
+
+    r = client.get("/api/replay-tree/sess-nope")
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["session_id"] == "sess-nope"
+    assert body["turns"] == []
+    assert body["workflows"] == []
+    assert body["row_count"] == 0


### PR DESCRIPTION
Part 1 of #4813 (session-replay initiative — 5 OSS + 13 Pro issues, index in `project_session_replay_initiative_2026_08_14` memory).

Draft so follow-up commits can land the `/api/replay-tree/<id>` endpoint and the JS renderer skeleton on the same branch before review.

## What's in this commit

- **`clawmetry/replay_schema.py`** — canonical `ReplayEvent` TypedDict + `ALL_KINDS` enum + `ModeChip`/`ApprovalInfo` side-channels + `validate()` with strict rules (mode field only on `mode.changed`, approval field only on `approval.*` — prevents adapter bloat).
- **`clawmetry/local_store.py`** — `replay_events` DuckDB table with 4 indices covering the endpoint's query paths.
- **`tests/test_replay_schema.py`** — 11 tests: kind enum uniqueness/prefix invariants, validator, DuckDB table shape + index presence. All green locally.

## What's coming on this same branch (before it leaves draft)

- `/api/replay-tree/<session_id>` in `routes/sessions.py` — returns nested `{turns, delegations, workflows, approvals}` shape read from `replay_events`.
- `_renderReplayTree` skeleton in `clawmetry/static/js/app.js` — extends `_renderTurnChapter` (line ~15600) with a `delegations` prop and a `_renderSubagentBlock` for nested children. Runtime dispatcher in the same pattern as the Harness tab template system at `app.js:16729`.

## Test plan

- [x] `pytest tests/test_replay_schema.py` — 11 pass
- [ ] Endpoint returns empty `{turns:[], delegations:[], workflows:[]}` for a session with no `replay_events` rows (backward-compat)
- [ ] Renderer skeleton loads without regressing the existing session-trace redesign (PR #4802, 0.12.694) — old flat renderer stays as the fallback until a runtime declares `runtime_kind` on its events
- [ ] Verify live: land a fixture, decrypt cloud snapshot, browser-screenshot the transcript view (per FLYWHEEL §"done bar")

## Design decisions preserved

- `parent_span_id` = **delegation edge only**, NOT transcript-chain parent (OpenClaw v3 `parentId` + Qwen Code `parentUuid` are chains, not trees — memory `reference_openclaw_v3_parentid_is_chain`)
- Kind names use dotted prefixes so the JS renderer can dispatch on prefix (`llm.*`, `tool.*`, `agent.*`, `workflow.*`, `approval.*`)
- Payload/mode/approval stored as BLOB in DuckDB (JSON bodies) — same pattern as `events.data`
- The writer lock stays with the daemon per `feedback_local_store_fetch_takes_writelock`

Refs #4813. Blocks #4814 (mode + approvals ingest), #4815 (Claude Code mapper), #4816 (OpenClaw mapper), all 13 Pro adapter issues.