### PR TITLE
[RELEASE] Trial paywall — carry #4832 to PyPI + cloud

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -324,7 +324,7 @@ def _otlp_service_name_to_agent_type(service_name):
     return slug or "custom"
 
 
-__version__ = "0.12.696"
+__version__ = "0.12.697"
 
 # Extensions (Phase 2): import the plugin host now, but defer the actual
 # load_plugins() call until after the Flask app is created below so we can


### PR DESCRIPTION
## Summary

Carrier release for #4832 (paywall enforcement fix). That PR merged as 0.12.696 without `[RELEASE]` in the title, so release-on-merge skipped and PyPI never got the wheel. This minimal bump to **0.12.697** gets the paywall out live.

## Ships

The full paywall fix from #4832 (already on main):
- `dashboard_claudecode.py` deleted — dead code, never wired into any live UI (-2070 LoC)
- Main dashboard's `before_request` gate is now runtime-scope-aware (`?runtime=` / `?scope=` / `X-Clawmetry-Runtime` header + URL-prefix classification)
- `POST /api/trial/continue-free` + `POST /api/trial/exit-free` free-mode escape via `~/.clawmetry/free_only.marker`
- Overlay grows a "Continue free with OpenClaw + NanoClaw only" secondary CTA
- `_MINIMAL_OSS_FREE_SNAPSHOT` fail-closed — merges live `hard_blocked` on top so a resolver crash can't silently dismiss the modal
- TrialHardBlockPaywall Blueprint updated to v4 to describe the new fallback (drift-bot green)

## Test plan

- [x] All 31 checks green on #4832 pre-merge
- [x] 140 unit tests pass locally (10 new hard-block + 130 existing)
- [ ] Once `release-on-merge` publishes: verify PyPI has 0.12.697
- [ ] Once cloud is pinned: verify `app.clawmetry.com` shows the paywall for the trial-expired account from the founder screenshots
- [ ] Verify "Continue free" click lands on `?runtime=openclaw`; OpenClaw dashboard renders; clicking a paid runtime tab re-triggers the modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)