### PR TITLE
[RELEASE] Make Memory + Skills real: one runtime picker, files that open, per-runtime cloud sync

### DIFF
--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -398,6 +398,8 @@ _DDL = [
         sha256        VARCHAR,
         size_bytes    INTEGER,
         updated_at    BIGINT NOT NULL,
+        category      VARCHAR DEFAULT 'memory',
+        root          VARCHAR,
         PRIMARY KEY (agent_type, agent_id, path)
     )
     """,
@@ -1259,6 +1261,15 @@ _MIGRATIONS_V2 = [
     # Issue #3719 — per-cron-job model attribution (openclaw Quick Create
     # lets users pick an agent-turn model; harness exposes it per job).
     ("crons",    "model",             "VARCHAR"),
+    # memory_blobs used to hold only OpenClaw workspace memory, so the bucket
+    # was implicit. It now carries every runtime's memory AND skills files
+    # (clawmetry/runtime_memory.py), which the Memory and Skills tabs must be
+    # able to tell apart — hence an explicit category. Existing rows are all
+    # OpenClaw memory, which the default covers.
+    ("memory_blobs", "category",      "VARCHAR DEFAULT 'memory'"),
+    # Absolute root the relative `path` hangs off, so a cloud viewer can show
+    # where on disk the file lives without re-deriving it from the runtime.
+    ("memory_blobs", "root",          "VARCHAR"),
 ]
 
 # ── Integrity / hash-chain (Issue #2200) ────────────────────────────────────
@@ -2394,11 +2405,14 @@ class LocalStore:
                 continue
         return out
 
-    def ingest_memory_blob(self, blob_row: dict[str, Any]) -> None:
+    def ingest_memory_blob(self, blob_row: dict[str, Any]) -> bool:
         """Upsert one memory blob (e.g. CLAUDE.md, ~/.openclaw/memory/notes.md).
 
-        Required: agent_type, path. Optional: agent_id, blob, sha256, ts.
-        Re-ingesting with the same sha256 is a no-op (cheap dedup)."""
+        Required: agent_type, path. Optional: agent_id, blob, sha256, ts,
+        category, root. Re-ingesting with the same sha256 is a no-op (cheap
+        dedup). Returns True when a row was actually written, False when the
+        content was unchanged — callers that report "N files ingested" need
+        to be able to tell a steady-state tick from a real one."""
         atype = blob_row.get("agent_type")
         path = blob_row.get("path")
         if not atype or not path:
@@ -2424,18 +2438,23 @@ class LocalStore:
                 )
                 row = cur.fetchone()
                 if row and row[0] == sha:
-                    return
+                    return False
             self._conn.execute("""
                 INSERT INTO memory_blobs (
-                    agent_type, agent_id, path, ts, blob, sha256, size_bytes, updated_at
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                    agent_type, agent_id, path, ts, blob, sha256, size_bytes,
+                    updated_at, category, root
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 ON CONFLICT (agent_type, agent_id, path) DO UPDATE SET
                     ts         = excluded.ts,
                     blob       = excluded.blob,
                     sha256     = excluded.sha256,
                     size_bytes = excluded.size_bytes,
-                    updated_at = excluded.updated_at
-            """, [atype, agent_id, path, blob_row.get("ts"), blob, sha, size, now_ms])
+                    updated_at = excluded.updated_at,
+                    category   = excluded.category,
+                    root       = excluded.root
+            """, [atype, agent_id, path, blob_row.get("ts"), blob, sha, size, now_ms,
+                  blob_row.get("category") or "memory", blob_row.get("root")])
+        return True
 
     def ingest_channel(self, ch: dict[str, Any]) -> None:
         """Upsert one OpenClaw channel-context row. Required: session_id.
@@ -8571,6 +8590,7 @@ class LocalStore:
         agent_type: str | None = None,
         agent_id: str | None = None,
         path_prefix: str | None = None,
+        category: str | None = None,
         limit: int = 200,
     ) -> list[dict[str, Any]]:
         """Read memory-blob rows. Defaults to most recent first.
@@ -8601,10 +8621,12 @@ class LocalStore:
             clauses.append("agent_id = ?"); params.append(agent_id)
         if path_prefix:
             clauses.append("path LIKE ?"); params.append(f"{path_prefix}%")
+        if category:
+            clauses.append("category = ?"); params.append(category)
         where = ("WHERE " + " AND ".join(clauses)) if clauses else ""
         sql = f"""
             SELECT agent_type, agent_id, path, ts, blob, sha256,
-                   size_bytes, updated_at
+                   size_bytes, updated_at, category, root
             FROM memory_blobs
             {where}
             ORDER BY updated_at DESC
@@ -8612,7 +8634,7 @@ class LocalStore:
         """
         params.append(int(limit))
         cols = ["agent_type", "agent_id", "path", "ts", "blob", "sha256",
-                "size_bytes", "updated_at"]
+                "size_bytes", "updated_at", "category", "root"]
         out: list[dict[str, Any]] = []
         for r in self._fetch(sql, params):
             d = dict(zip(cols, r))

--- a/clawmetry/runtime_memory.py
+++ b/clawmetry/runtime_memory.py
@@ -185,6 +185,11 @@ def _catalog() -> list:
                      label="Global skills", scope="global"),
             RootSpec("skills", os.path.join(ws, ".claude", "skills"),
                      label="Project skills", scope="project"),
+            # Most Claude Code users never write a ~/.claude/skills file —
+            # their skills arrive as plugins. Without this root the Skills
+            # tab read "nothing found" for a machine with 30+ live skills.
+            RootSpec("skills", os.path.join(claude_home, "plugins", "marketplaces"),
+                     ("**/SKILL.md",), "Plugin skills", "global", max_depth=8),
             RootSpec("agents", os.path.join(claude_home, "agents"),
                      ("*.md",), "Global sub-agents", "global"),
             RootSpec("agents", os.path.join(ws, ".claude", "agents"),
@@ -667,7 +672,36 @@ def list_files(runtime_id: str, category: Optional[str] = None) -> dict:
             "exists": exists,
             "files": files,
         })
+    for g in groups:
+        g["runtime"] = entry.id
+        g["runtime_label"] = entry.label
     return {"runtime": entry.id, "label": entry.label, "groups": groups}
+
+
+def list_all_files(category: Optional[str] = None,
+                   allowed: Optional[Iterable] = None) -> dict:
+    """Aggregate :func:`list_files` across every catalogued runtime.
+
+    Backs the "All runtimes" scope of the Memory / Skills browser. Only
+    groups that actually exist on disk are returned — the per-runtime
+    view is where we spell out the paths we looked at and came up empty,
+    because listing every absent root for 20 runtimes would be a wall of
+    noise rather than an answer.
+
+    ``allowed``, when given, restricts the sweep to that set of runtime
+    ids (the caller passes the entitled ones so a locked paid runtime's
+    file paths never leak into an aggregate the user can't open).
+    """
+    allowed_set = set(allowed) if allowed is not None else None
+    groups: list = []
+    for entry in _catalog():
+        if allowed_set is not None and entry.id not in allowed_set:
+            continue
+        payload = list_files(entry.id, category=category)
+        for g in payload.get("groups") or ():
+            if g.get("exists") and (g.get("files") or []):
+                groups.append(g)
+    return {"runtime": "all", "label": "All runtimes", "groups": groups}
 
 
 def read_runtime_file(runtime_id: str, root: str, path: str,

--- a/clawmetry/runtime_memory.py
+++ b/clawmetry/runtime_memory.py
@@ -49,6 +49,7 @@ paths and this catalog's memory roots share the same on-disk prefix
 from __future__ import annotations
 
 import glob as _glob
+import json
 import os
 from dataclasses import dataclass, field
 from typing import Iterable, Optional
@@ -126,6 +127,53 @@ def _openclaw_home() -> str:
     return _env_root("OPENCLAW_HOME", os.path.expanduser("~/.openclaw"))
 
 
+def _claude_plugin_skill_roots(claude_home: str) -> list:
+    """RootSpecs for Claude Code skills that ship inside installed plugins.
+
+    Most Claude Code users never create ``~/.claude/skills`` — their skills
+    arrive as plugins — so without this the Skills tab reads "nothing found"
+    on a machine with dozens of live skills.
+
+    The authority is ``plugins/installed_plugins.json``, NOT a walk of
+    ``~/.claude/plugins``:
+
+      - ``marketplaces/`` is the catalogue of AVAILABLE plugins. Walking it
+        lists skills the user has not installed.
+      - ``cache/`` retains superseded versions side by side (telegram 0.0.6
+        next to the live 0.0.7), so a blind walk double-counts.
+
+    Reading the manifest gives exactly the installPaths that are live. Never
+    raises — a malformed manifest just yields no plugin roots.
+    """
+    manifest = os.path.join(claude_home, "plugins", "installed_plugins.json")
+    out: list = []
+    try:
+        with open(manifest, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+    except Exception:
+        return out
+    seen: set = set()
+    for name, entries in (data.get("plugins") or {}).items():
+        if not isinstance(entries, list):
+            continue
+        for ent in entries:
+            path = (ent or {}).get("installPath") or ""
+            if not path:
+                continue
+            skills_dir = os.path.join(path, "skills")
+            if skills_dir in seen or not os.path.isdir(skills_dir):
+                continue
+            seen.add(skills_dir)
+            short = str(name).split("@")[0]
+            out.append(RootSpec(
+                "skills", skills_dir, ("**/SKILL.md",),
+                f"Plugin: {short}",
+                "project" if (ent or {}).get("scope") == "project" else "global",
+                max_depth=4,
+            ))
+    return out
+
+
 def _catalog() -> list:
     """Build the canonical runtime → roots catalog.
 
@@ -185,11 +233,9 @@ def _catalog() -> list:
                      label="Global skills", scope="global"),
             RootSpec("skills", os.path.join(ws, ".claude", "skills"),
                      label="Project skills", scope="project"),
-            # Most Claude Code users never write a ~/.claude/skills file —
-            # their skills arrive as plugins. Without this root the Skills
-            # tab read "nothing found" for a machine with 30+ live skills.
-            RootSpec("skills", os.path.join(claude_home, "plugins", "marketplaces"),
-                     ("**/SKILL.md",), "Plugin skills", "global", max_depth=8),
+            # Plugin skills are appended below from installed_plugins.json —
+            # see _claude_plugin_skill_roots() for why that file and not a
+            # walk of ~/.claude/plugins.
             RootSpec("agents", os.path.join(claude_home, "agents"),
                      ("*.md",), "Global sub-agents", "global"),
             RootSpec("agents", os.path.join(ws, ".claude", "agents"),
@@ -206,7 +252,7 @@ def _catalog() -> list:
                      label="Project settings.json", scope="project"),
             RootSpec("hooks", os.path.join(ws, ".claude", "settings.local.json"),
                      label="Project settings.local.json", scope="project"),
-        ),
+        ) + tuple(_claude_plugin_skill_roots(claude_home)),
     ))
 
     # ── Codex (OpenAI CLI) ──────────────────────────────────────────
@@ -543,7 +589,22 @@ def _walk_dir(root: str, include_globs: tuple, max_depth: int) -> list:
     if not root or not os.path.isdir(root):
         return out
     root_abs = os.path.abspath(root)
-    for cur_dir, dirs, files in os.walk(root_abs):
+    # followlinks=True: a skill directory is very often a SYMLINK
+    # (``<repo>/.claude/skills/x -> <repo>/.agents/skills/x`` is how one skill
+    # serves several runtimes). os.walk defaults to followlinks=False, which
+    # reports the link in ``dirs`` and never descends — the skill vanishes
+    # with no error. ``visited`` on realpath keeps a symlink cycle from
+    # walking forever.
+    visited: set = set()
+    for cur_dir, dirs, files in os.walk(root_abs, followlinks=True):
+        try:
+            real = os.path.realpath(cur_dir)
+        except OSError:
+            real = cur_dir
+        if real in visited:
+            dirs[:] = []
+            continue
+        visited.add(real)
         rel_dir = os.path.relpath(cur_dir, root_abs)
         depth = 0 if rel_dir == "." else rel_dir.count(os.sep) + 1
         if depth > max_depth:

--- a/clawmetry/runtime_memory.py
+++ b/clawmetry/runtime_memory.py
@@ -682,6 +682,31 @@ def list_runtimes() -> list:
     return out
 
 
+#: The Skills tab's buckets. The catalog has five categories and the UI has
+#: two tabs: Memory owns ``memory``, Skills owns everything else — the things
+#: an agent can invoke or is configured by. Splitting Skills down to the
+#: ``skills`` bucket alone would leave slash commands, sub-agent definitions
+#: and hooks collected but displayed nowhere.
+SKILLS_TAB_CATEGORIES: tuple = ("skills", "commands", "agents", "hooks")
+
+
+def parse_categories(category) -> set:
+    """Normalise a category filter into a set of valid category names.
+
+    Accepts ``None`` (no filter), one name, a comma-separated string, or an
+    iterable. Unknown names are dropped rather than raising — the caller
+    validates for a 400; this stays permissive so an internal caller can't
+    trip on a stray empty segment.
+    """
+    if not category:
+        return set()
+    if isinstance(category, str):
+        parts = [c.strip() for c in category.split(",")]
+    else:
+        parts = [str(c).strip() for c in category]
+    return {c for c in parts if c in CATEGORIES}
+
+
 def _entry_by_id(runtime_id: str) -> Optional[RuntimeCatalogEntry]:
     for entry in _catalog():
         if entry.id == runtime_id:
@@ -695,18 +720,24 @@ def list_files(runtime_id: str, category: Optional[str] = None) -> dict:
     Returns ``{'runtime': id, 'label': str, 'groups': [{root, label,
     category, scope, exists, files: [...]}]}``.
 
-    ``category``, when set, filters roots to that one bucket. ``files``
-    entries are ``{path, size, mtime}`` with ``path`` relative to the
-    group's root. A root that is a single file gets one entry with
+    ``category`` filters roots. It accepts one bucket (``"memory"``) or a
+    comma-separated set (``"skills,commands,agents,hooks"``) — the catalog
+    has five categories and the UI has two tabs, so the Skills tab asks for
+    the four non-memory buckets in one call rather than leaving commands,
+    sub-agent definitions and hooks with nowhere to appear.
+
+    ``files`` entries are ``{path, size, mtime}`` with ``path`` relative to
+    the group's root. A root that is a single file gets one entry with
     ``path=''`` (empty relpath) so the client can still address it.
     """
     entry = _entry_by_id(runtime_id)
     if entry is None:
         return {"runtime": runtime_id, "label": "", "groups": [], "error": "unknown_runtime"}
 
+    wanted = parse_categories(category)
     groups: list = []
     for spec in entry.roots:
-        if category and spec.category != category:
+        if wanted and spec.category not in wanted:
             continue
         root = spec.expanded_root()
         exists = os.path.exists(root)

--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -25980,6 +25980,9 @@ async function cmRuntimeMountBrowser(container, runtimeId, tab) {
   // like a copy of Memory; splitting Skills down to `skills` alone would
   // instead leave commands/agents/hooks collected but displayed nowhere.
   var category = (tab === 'skills') ? 'skills,commands,agents,hooks' : 'memory';
+  // What to CALL that set in copy. The tab name, not the raw filter — a
+  // header reading "skills,commands,agents,hooks" is an implementation detail.
+  var catWord = (tab === 'skills') ? 'skills' : 'memory';
   try {
     var url = '/api/runtimes/' + encodeURIComponent(runtimeId) + '/files'
       + '?category=' + encodeURIComponent(category);
@@ -26012,7 +26015,6 @@ async function cmRuntimeMountBrowser(container, runtimeId, tab) {
   var totalFiles = groups.reduce(function(s, g) { return s + (g.files || []).length; }, 0);
 
   if (!groups.length) {
-    var catWord = (category === 'skills') ? 'skills' : 'memory';
     var emptyHead = (runtimeId === 'all')
       ? 'No ' + catWord + ' files found for any runtime'
       : 'No ' + catWord + ' files found for ' + escHtml(payload.label || scopeLabel);
@@ -26069,7 +26071,7 @@ async function cmRuntimeMountBrowser(container, runtimeId, tab) {
     '<div style="display:flex;height:calc(100vh - 260px);min-height:420px;background:var(--bg-primary);border:1px solid var(--border-primary);border-radius:8px;overflow:hidden;">'
     + '<div id="cm-rt-tree-' + tab + '" style="width:320px;min-width:260px;flex-shrink:0;background:var(--bg-secondary);border-right:1px solid var(--border-primary);overflow-y:auto;padding:8px 0;">'
     + '<div style="padding:8px 10px 10px;font-size:11px;color:var(--text-muted);border-bottom:1px solid var(--border-primary);margin-bottom:8px;">'
-    + escHtml(payload.label || scopeLabel) + ' · ' + category + ' — ' + totalFiles + ' file' + (totalFiles === 1 ? '' : 's') + ' across ' + groups.length + ' location' + (groups.length === 1 ? '' : 's')
+    + escHtml(payload.label || scopeLabel) + ' · ' + catWord + ' — ' + totalFiles + ' file' + (totalFiles === 1 ? '' : 's') + ' across ' + groups.length + ' location' + (groups.length === 1 ? '' : 's')
     + '</div>' + treeHtml + '</div>'
     + '<div style="flex:1;display:flex;flex-direction:column;overflow:hidden;">'
     + '<div id="cm-rt-file-header-' + tab + '" style="padding:8px 14px;background:var(--bg-secondary);border-bottom:1px solid var(--border-primary);font-family:\'JetBrains Mono\',\'SF Mono\',monospace;font-size:12px;color:var(--text-secondary);min-height:32px;display:flex;align-items:center;gap:10px;">Select a file</div>'

--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -10159,13 +10159,17 @@ function _cmClientFilterRt(rt) {
 // aggregates — do the per-runtime slicing instead.
 var _CM_RT_AGGREGATE = {};
 // Tabs that are NODE-WIDE concepts, not per-runtime: crons run on the gateway,
-// memory/skills are workspace-level, security is machine posture, self-evolve is
-// node findings. The runtime selector simply does not apply to these.
+// security is machine posture, self-evolve is node findings. The runtime
+// selector simply does not apply to these.
 var _CM_RT_NODEWIDE = {
   // approvals + alerts left this map 2026-08-03: approvals rows filter by
   // the requesting session's runtime prefix, and alert rules carry their own
   // per-rule scope (runtime column, node-wide chip when 'all').
-  crons: 1, memory: 1, security: 1, skills: 1, selfevolve: 1,
+  // memory + skills left it 2026-08-14: every runtime keeps its memory and
+  // skills in its OWN place on disk (clawmetry/runtime_memory.py), so these
+  // tabs scope for real off the global switcher. Calling them node-wide was
+  // what pushed a redundant per-tab runtime picker into the page.
+  crons: 1, security: 1, selfevolve: 1,
   policy: 1, nemoclaw: 1, notifications: 1, dives: 1,
   clusters: 1, actions: 1,
   // logs + version-impact are NOT node-wide: logs stream a specific runtime's
@@ -25827,17 +25831,35 @@ setTimeout(checkLicenseExpiry, 1200);
 //
 // Each supported runtime stores its long-lived memory and its skills in
 // different places on disk (see clawmetry/runtime_memory.py). This module
-// renders two things across the Memory + Skills tabs:
-//   1. A chip bar of runtimes (dimmed if not present on this machine)
-//   2. A file-browser view (left tree, right preview) for the picked runtime
+// renders a file-browser view (left tree, right preview) for whichever
+// runtime the GLOBAL runtime switcher is on.
 //
-// OpenClaw remains the default; picking it hides the browser and shows the
-// existing rich Memory / Skills UI. All other runtimes route through the
-// browser. Backwards compatible — the old view is untouched.
+// There is deliberately no per-tab runtime picker. An earlier cut shipped a
+// chip bar inside each tab, which meant three runtime selectors on screen at
+// once (header dropdown, nav dropdown, chip bar) that could disagree with
+// each other. The global switcher is the only runtime control; these tabs
+// read it via _cmRuntimeFilter() and re-render from switchTab() when it
+// changes.
+//
+// Scope rules:
+//   'openclaw'  → the rich native Memory/Skills UI (edit + history), because
+//                 OpenClaw is the one runtime we can write back to.
+//   'all'       → every entitled runtime's files, grouped by runtime.
+//   <other>     → that runtime's files only.
 // ─────────────────────────────────────────────────────────────────────────
 
 var _cmRuntimeCatalog = null;
-var _cmRuntimeSelected = { memory: 'openclaw', skills: 'openclaw' };
+
+// Which runtime each tab is currently RENDERING. Mirrors the global filter;
+// kept per-tab only so a re-entrant switchTab() can skip a redundant fetch.
+var _cmRuntimeSelected = { memory: 'all', skills: 'all' };
+
+// The global runtime switcher's value, normalised for these two tabs.
+function _cmRuntimeScopeForTab() {
+  var rt = 'all';
+  try { if (typeof _cmRuntimeFilter === 'function') rt = _cmRuntimeFilter() || 'all'; } catch (e) {}
+  return rt || 'all';
+}
 
 function _cmRuntimeIsCloud() {
   try {
@@ -25869,109 +25891,95 @@ function _cmRuntimeIcon(id) {
   return map[id] || '•';
 }
 
-function _cmRuntimeChip(runtime, selected, tab, category) {
-  var count = 0;
-  if (category && runtime.counts) count = runtime.counts[category] || 0;
-  else if (runtime.counts) {
-    Object.keys(runtime.counts).forEach(function(k) { count += runtime.counts[k] || 0; });
-  }
-  var isSel = runtime.id === selected;
-  var isPresent = !!runtime.present;
-  var isLocked = !!runtime.locked;
-  var bg = isSel ? '#6366f1' : (isPresent ? 'var(--bg-secondary)' : 'transparent');
-  var color = isSel ? '#fff' : (isPresent ? 'var(--text-primary)' : 'var(--text-muted)');
-  var border = isSel ? '#6366f1' : 'var(--border-primary)';
-  var op = (isPresent || isSel) ? 1 : 0.55;
-  var badge = '';
-  if (isLocked) {
-    badge = '<span title="Paid runtime — upgrade to browse its files" style="margin-left:6px;font-size:10px;opacity:0.85;">🔒</span>';
-  } else if (count > 0) {
-    badge = '<span style="background:rgba(255,255,255,0.16);padding:1px 6px;border-radius:8px;font-size:10px;margin-left:6px;">' + count + '</span>';
-  }
-  var titleTip = isLocked
-    ? escHtml(runtime.label) + ' — paid runtime, upgrade to browse'
-    : escHtml(runtime.label) + (isPresent ? '' : ' (not detected on this machine)');
-  return '<div class="cm-runtime-chip" data-runtime="' + runtime.id + '" '
-    + 'onclick="cmRuntimeSelect(\'' + tab + '\',\'' + runtime.id + '\')" '
-    + 'style="padding:4px 10px;border-radius:14px;font-size:11px;font-weight:600;cursor:pointer;'
-    + 'background:' + bg + ';color:' + color + ';border:1px solid ' + border + ';opacity:' + op + ';'
-    + 'display:inline-flex;align-items:center;gap:4px;" title="' + titleTip + '">'
-    + escHtml(runtime.label) + badge + '</div>';
-}
+// Native (OpenClaw-only) view containers per tab. Shown when the global
+// runtime switcher is on 'openclaw'; hidden otherwise so the file browser
+// owns the surface.
+var _CM_RT_NATIVE_VIEWS = {
+  memory: ['memory-summary-view', 'memory-access-view', 'memory-all-view'],
+  skills: ['skills-summary-row', 'skills-list', 'skills-browser'],
+};
+// Which of those come back on when we return to OpenClaw. memorySwitchView /
+// the Skills grid toggle own the rest.
+var _CM_RT_NATIVE_DEFAULT = {
+  memory: { 'memory-summary-view': 1 },
+  skills: { 'skills-summary-row': 1, 'skills-list': 1 },
+};
 
-async function cmRuntimeMountChips(chipsEl) {
-  if (!chipsEl) return;
-  var tab = chipsEl.getAttribute('data-tab') || 'memory';
-  var category = chipsEl.getAttribute('data-category') || null;
-  chipsEl.innerHTML = '<span style="font-size:11px;color:var(--text-muted);">Loading runtimes…</span>';
-  var cat = await _cmRuntimeFetchCatalog();
-  var runtimes = (cat.runtimes || []).slice();
-  // Sort: present first, then by label
-  runtimes.sort(function(a, b) {
-    if (!!a.present !== !!b.present) return a.present ? -1 : 1;
-    return (a.label || '').localeCompare(b.label || '');
-  });
-  var sel = _cmRuntimeSelected[tab] || 'openclaw';
-  var chips = runtimes.map(function(rt) {
-    return _cmRuntimeChip(rt, sel, tab, category);
-  });
-  chipsEl.innerHTML = chips.join('');
-}
-
+// Render one tab for the runtime the global switcher is on. Called from
+// switchTab(), which _cmOnGlobalRuntimeChange() re-invokes on every switcher
+// change — so this is the single place the two tabs react to runtime scope.
 function cmRuntimeSelect(tab, runtimeId) {
+  if (!runtimeId) runtimeId = _cmRuntimeScopeForTab();
   _cmRuntimeSelected[tab] = runtimeId;
-  // Re-render both chip bars if present (keeps them in sync visually)
-  var chips = document.querySelectorAll('[id$="-runtime-chips"][data-tab="' + tab + '"]');
-  chips.forEach(function(el) { cmRuntimeMountChips(el); });
-  // Toggle native OpenClaw view vs runtime file browser
   var browser = document.getElementById(tab + '-runtime-browser');
-  if (tab === 'memory') {
-    var nativeIds = ['memory-summary-view', 'memory-access-view', 'memory-all-view'];
-    if (runtimeId === 'openclaw') {
-      nativeIds.forEach(function(id) {
-        var el = document.getElementById(id);
-        if (!el) return;
-        // Only restore the summary view by default; the other two are toggled
-        // by memorySwitchView independently.
-        if (id === 'memory-summary-view') el.style.display = '';
-      });
-      if (browser) browser.style.display = 'none';
-    } else {
-      nativeIds.forEach(function(id) {
-        var el = document.getElementById(id);
-        if (el) el.style.display = 'none';
-      });
-      if (browser) { browser.style.display = ''; cmRuntimeMountBrowser(browser, runtimeId, 'memory'); }
-    }
-  } else if (tab === 'skills') {
-    var nativeIds = ['skills-summary-row', 'skills-list', 'skills-browser'];
-    if (runtimeId === 'openclaw') {
-      nativeIds.forEach(function(id) {
-        var el = document.getElementById(id);
-        if (!el) return;
-        if (id === 'skills-summary-row' || id === 'skills-list') el.style.display = '';
-      });
-      if (browser) browser.style.display = 'none';
-    } else {
-      nativeIds.forEach(function(id) {
-        var el = document.getElementById(id);
-        if (el) el.style.display = 'none';
-      });
-      if (browser) { browser.style.display = ''; cmRuntimeMountBrowser(browser, runtimeId, 'skills'); }
-    }
+  var native = _CM_RT_NATIVE_VIEWS[tab] || [];
+  var defaults = _CM_RT_NATIVE_DEFAULT[tab] || {};
+  // Controls that only drive the OpenClaw-native view (Memory's
+  // Summary / All files / Access log switch, the Skills Grid button). They
+  // do nothing to the file browser, so showing them over it is a dead control.
+  var nativeCtl = (tab === 'memory')
+    ? document.querySelectorAll('#page-memory .mem-view-tab')
+    : document.querySelectorAll('#page-skills .refresh-btn[onclick*="skills-browser"]');
+  if (runtimeId === 'openclaw') {
+    native.forEach(function(id) {
+      var el = document.getElementById(id);
+      if (el && defaults[id]) el.style.display = '';
+    });
+    nativeCtl.forEach(function(el) { el.style.display = ''; });
+    if (browser) browser.style.display = 'none';
+    return;
   }
+  native.forEach(function(id) {
+    var el = document.getElementById(id);
+    if (el) el.style.display = 'none';
+  });
+  nativeCtl.forEach(function(el) { el.style.display = 'none'; });
+  if (browser) {
+    browser.style.display = '';
+    cmRuntimeMountBrowser(browser, runtimeId, tab);
+  }
+}
+
+// Row label for one file in the runtime tree.
+//
+// Naming a row by its basename is fine for `no-em-dashes.md` and useless for
+// the container filenames every runtime reuses — a Skills tree rendered as
+// thirty identical "SKILL.md" rows tells you nothing. For those, name the row
+// after the directory that actually identifies it (the skill folder, the
+// project folder), dropping the structural segments in between.
+var _CM_RT_GENERIC_FILE = {
+  'SKILL.md': 1, 'MEMORY.md': 1, 'CLAUDE.md': 1, 'AGENTS.md': 1,
+  'GEMINI.md': 1, 'README.md': 1, 'index.md': 1, 'settings.json': 1,
+};
+var _CM_RT_GENERIC_DIR = {
+  skills: 1, memory: 1, plugins: 1, external_plugins: 1, marketplaces: 1,
+  commands: 1, agents: 1, hooks: 1, '.claude': 1, '.agents': 1,
+};
+function _cmRtDisplayName(rel, fallback) {
+  var segs = String(rel || '').split('/').filter(Boolean);
+  if (!segs.length) return fallback || '(file)';
+  var base = segs[segs.length - 1];
+  if (!_CM_RT_GENERIC_FILE[base]) return base;
+  var parts = segs.slice(0, -1).filter(function(s) { return !_CM_RT_GENERIC_DIR[s]; });
+  if (!parts.length) return base;
+  return parts.slice(-2).join('/');
 }
 
 async function cmRuntimeMountBrowser(container, runtimeId, tab) {
   if (!container) return;
+  var scopeLabel = (runtimeId === 'all')
+    ? 'all runtimes'
+    : ((typeof _cmRuntimeLabel === 'function' ? _cmRuntimeLabel(runtimeId) : runtimeId) || runtimeId);
   container.innerHTML = '<div style="padding:16px;color:var(--text-muted);font-size:12px;">Loading '
-    + escHtml(runtimeId) + '…</div>';
+    + escHtml(scopeLabel) + '…</div>';
   var payload;
+  // The Memory tab shows memory files; the Skills tab shows skills. Without
+  // this the two tabs rendered byte-identical trees (every category the
+  // runtime exposes), which is what made Skills look like a copy of Memory.
+  var category = (tab === 'skills') ? 'skills' : 'memory';
   try {
-    var url = '/api/runtimes/' + encodeURIComponent(runtimeId) + '/files';
-    if (tab === 'memory' || tab === 'skills') {
-      // No category filter — show everything the runtime exposes.
-    }
+    var url = '/api/runtimes/' + encodeURIComponent(runtimeId) + '/files'
+      + '?category=' + encodeURIComponent(category);
     var r = await fetch(url);
     if (r.status === 402) {
       // Paid runtime the caller isn't entitled to. Show upsell CTA
@@ -26001,18 +26009,23 @@ async function cmRuntimeMountBrowser(container, runtimeId, tab) {
   var totalFiles = groups.reduce(function(s, g) { return s + (g.files || []).length; }, 0);
 
   if (!groups.length) {
+    var catWord = (category === 'skills') ? 'skills' : 'memory';
+    var emptyHead = (runtimeId === 'all')
+      ? 'No ' + catWord + ' files found for any runtime'
+      : 'No ' + catWord + ' files found for ' + escHtml(payload.label || scopeLabel);
+    var pathList = absent.map(function(g) {
+      return '<div>• <span style="color:var(--text-secondary);">' + escHtml(g.label || g.category)
+        + '</span> <span style="opacity:0.7;">(' + escHtml(g.scope) + ')</span> — <code>' + escHtml(g.root) + '</code></div>';
+    }).join('');
     container.innerHTML =
       '<div style="padding:24px;text-align:center;color:var(--text-muted);font-size:13px;line-height:1.5;">'
-      + '<div style="font-weight:700;color:var(--text-secondary);margin-bottom:6px;">Nothing found on disk for ' + escHtml(payload.label || runtimeId) + '</div>'
-      + 'ClawMetry looks for this runtime\'s memory and skills at these paths:'
-      + '<div style="margin-top:12px;text-align:left;display:inline-block;font-family:\'JetBrains Mono\',\'SF Mono\',monospace;font-size:11px;color:var(--text-muted);">'
-      + absent.map(function(g) {
-          return '<div>• <span style="color:var(--text-secondary);">' + escHtml(g.category)
-            + '</span> <span style="opacity:0.7;">(' + escHtml(g.scope) + ')</span> — <code>' + escHtml(g.root) + '</code></div>';
-        }).join('')
-      + '</div>'
-      + '<div style="margin-top:14px;font-size:11px;">Install ' + escHtml(payload.label || runtimeId)
-      + ' or drop files at one of these paths to make them appear here.</div>'
+      + '<div style="font-weight:700;color:var(--text-secondary);margin-bottom:6px;">' + emptyHead + '</div>'
+      + (pathList
+          ? ('ClawMetry looked here:'
+             + '<div style="margin-top:12px;text-align:left;display:inline-block;font-family:\'JetBrains Mono\',\'SF Mono\',monospace;font-size:11px;color:var(--text-muted);">'
+             + pathList + '</div>'
+             + '<div style="margin-top:14px;font-size:11px;">Drop files at one of these paths to make them appear here.</div>')
+          : '<div style="margin-top:8px;font-size:12px;">Pick a specific runtime in the runtime switcher to see the exact paths ClawMetry checks for it.</div>')
       + '</div>';
     return;
   }
@@ -26021,15 +26034,21 @@ async function cmRuntimeMountBrowser(container, runtimeId, tab) {
   var treeHtml = groups.map(function(g, gi) {
     var scopePill = '<span style="font-size:9px;background:var(--bg-primary);border:1px solid var(--border-primary);border-radius:8px;padding:0 5px;margin-left:6px;color:var(--text-muted);">'
       + escHtml(g.scope) + '</span>';
-    var catPill = '<span style="font-size:9px;background:rgba(99,102,241,0.15);color:#a5b4fc;border-radius:8px;padding:0 5px;margin-left:4px;">'
-      + escHtml(g.category) + '</span>';
+    // The tab already names the category, so the only pill worth the room is
+    // which runtime a group came from — and only when we're showing several.
+    var rtPill = (runtimeId === 'all' && g.runtime_label)
+      ? ('<span style="font-size:9px;background:rgba(99,102,241,0.15);color:#a5b4fc;border-radius:8px;padding:0 5px;margin-left:4px;">'
+         + escHtml(g.runtime_label) + '</span>')
+      : '';
     var files = (g.files || []).map(function(f, fi) {
       var name = f.path || g.label || '(file)';
-      var basename = name.split('/').pop();
-      var indent = (name.split('/').length - 1) * 12;
+      var basename = _cmRtDisplayName(f.path, g.label);
+      // Cap the depth indent — plugin skills nest 5+ deep and an uncapped
+      // indent pushed the name clean out of a 320px column.
+      var indent = Math.min((name.split('/').length - 1) * 12, 24);
       var kb = f.size >= 1024 ? (f.size / 1024).toFixed(1) + 'K' : f.size + 'B';
       return '<div class="cm-rt-file" data-gi="' + gi + '" data-fi="' + fi
-        + '" onclick="cmRuntimeOpenFile(this,\'' + runtimeId + '\','
+        + '" onclick="cmRuntimeOpenFile(this,'
         + gi + ',' + fi + ')" style="padding:3px 10px 3px ' + (18 + indent) + 'px;font-size:11.5px;cursor:pointer;color:var(--text-primary);display:flex;justify-content:space-between;align-items:center;gap:8px;" '
         + 'title="' + escHtml(name) + '">'
         + '<span style="overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">' + escHtml(basename) + '</span>'
@@ -26038,7 +26057,7 @@ async function cmRuntimeMountBrowser(container, runtimeId, tab) {
     }).join('');
     return '<div class="cm-rt-group" style="margin-bottom:8px;">'
       + '<div style="padding:6px 10px 4px;font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:1px;color:var(--text-muted);display:flex;align-items:center;flex-wrap:wrap;">'
-      + escHtml(g.label) + catPill + scopePill + '</div>'
+      + escHtml(g.label) + rtPill + scopePill + '</div>'
       + '<div style="font-family:\'JetBrains Mono\',\'SF Mono\',monospace;font-size:10px;color:var(--text-muted);padding:0 10px 4px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;" title="' + escHtml(g.root) + '">' + escHtml(g.root) + '</div>'
       + files + '</div>';
   }).join('');
@@ -26047,7 +26066,7 @@ async function cmRuntimeMountBrowser(container, runtimeId, tab) {
     '<div style="display:flex;height:calc(100vh - 260px);min-height:420px;background:var(--bg-primary);border:1px solid var(--border-primary);border-radius:8px;overflow:hidden;">'
     + '<div id="cm-rt-tree-' + tab + '" style="width:320px;min-width:260px;flex-shrink:0;background:var(--bg-secondary);border-right:1px solid var(--border-primary);overflow-y:auto;padding:8px 0;">'
     + '<div style="padding:8px 10px 10px;font-size:11px;color:var(--text-muted);border-bottom:1px solid var(--border-primary);margin-bottom:8px;">'
-    + escHtml(payload.label) + ' — ' + totalFiles + ' file' + (totalFiles === 1 ? '' : 's') + ' across ' + groups.length + ' location' + (groups.length === 1 ? '' : 's')
+    + escHtml(payload.label || scopeLabel) + ' · ' + category + ' — ' + totalFiles + ' file' + (totalFiles === 1 ? '' : 's') + ' across ' + groups.length + ' location' + (groups.length === 1 ? '' : 's')
     + '</div>' + treeHtml + '</div>'
     + '<div style="flex:1;display:flex;flex-direction:column;overflow:hidden;">'
     + '<div id="cm-rt-file-header-' + tab + '" style="padding:8px 14px;background:var(--bg-secondary);border-bottom:1px solid var(--border-primary);font-family:\'JetBrains Mono\',\'SF Mono\',monospace;font-size:12px;color:var(--text-secondary);min-height:32px;display:flex;align-items:center;gap:10px;">Select a file</div>'
@@ -26057,10 +26076,21 @@ async function cmRuntimeMountBrowser(container, runtimeId, tab) {
 
   // Stash the payload on the container so cmRuntimeOpenFile can look up
   // (root, path) by (gi, fi) without another fetch.
-  container._cmRuntimePayload = payload;
+  //
+  // `groups` — the EXISTS-ONLY list — is what the tree was indexed over, so
+  // that is what has to be stashed. Stashing payload.groups (which also holds
+  // the roots we looked at and didn't find) shifted every gi: on a runtime
+  // whose first roots are absent, clicking file 0 resolved to an absent group,
+  // found no files, and returned silently. That was the "clicking a file does
+  // nothing" bug — it only ever worked when every root happened to exist.
+  container._cmRuntimePayload = {
+    runtime: payload.runtime,
+    label: payload.label,
+    groups: groups,
+  };
 }
 
-async function cmRuntimeOpenFile(clickEl, runtimeId, gi, fi) {
+async function cmRuntimeOpenFile(clickEl, gi, fi) {
   var container = clickEl.closest('.runtime-file-browser');
   if (!container || !container._cmRuntimePayload) return;
   var tab = container.getAttribute('data-tab') || 'memory';
@@ -26069,6 +26099,10 @@ async function cmRuntimeOpenFile(clickEl, runtimeId, gi, fi) {
   if (!group) return;
   var file = (group.files || [])[fi];
   if (!file) return;
+  // Read against the group's OWN runtime, not the tab's scope: under the
+  // "All runtimes" scope the tab's runtime is the literal 'all', which is a
+  // list-only sentinel and 404s on the single-file read endpoint.
+  var runtimeId = group.runtime || container._cmRuntimePayload.runtime || 'openclaw';
 
   // Highlight selection
   container.querySelectorAll('.cm-rt-file').forEach(function(el) {
@@ -26117,17 +26151,17 @@ async function cmRuntimeOpenFile(clickEl, runtimeId, gi, fi) {
   }
 }
 
-// Hook into tab switches so the chip bars mount on first paint.
+// Hook into tab switches so the browser renders on first paint AND whenever
+// the global runtime switcher changes — _cmOnGlobalRuntimeChange() re-invokes
+// switchTab() for the current tab, so this one hook covers both.
 (function _cmRuntimeInstallHooks() {
   var origSwitchTab = (typeof switchTab === 'function') ? switchTab : null;
   if (!origSwitchTab || origSwitchTab._cmRuntimeWrapped) return;
   var wrapped = function(name) {
     var out = origSwitchTab.apply(this, arguments);
     try {
-      if (name === 'memory') {
-        cmRuntimeMountChips(document.getElementById('memory-runtime-chips'));
-      } else if (name === 'skills') {
-        cmRuntimeMountChips(document.getElementById('skills-runtime-chips'));
+      if (name === 'memory' || name === 'skills') {
+        cmRuntimeSelect(name, _cmRuntimeScopeForTab());
       }
     } catch (e) {}
     return out;

--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -25973,10 +25973,13 @@ async function cmRuntimeMountBrowser(container, runtimeId, tab) {
   container.innerHTML = '<div style="padding:16px;color:var(--text-muted);font-size:12px;">Loading '
     + escHtml(scopeLabel) + '…</div>';
   var payload;
-  // The Memory tab shows memory files; the Skills tab shows skills. Without
-  // this the two tabs rendered byte-identical trees (every category the
-  // runtime exposes), which is what made Skills look like a copy of Memory.
-  var category = (tab === 'skills') ? 'skills' : 'memory';
+  // Memory owns the `memory` bucket; Skills owns the other four — skills,
+  // slash commands, sub-agent definitions and hooks are all "things the agent
+  // can invoke or is configured by". Without this split the two tabs rendered
+  // byte-identical trees (every category), which is what made Skills look
+  // like a copy of Memory; splitting Skills down to `skills` alone would
+  // instead leave commands/agents/hooks collected but displayed nowhere.
+  var category = (tab === 'skills') ? 'skills,commands,agents,hooks' : 'memory';
   try {
     var url = '/api/runtimes/' + encodeURIComponent(runtimeId) + '/files'
       + '?category=' + encodeURIComponent(category);

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -11656,7 +11656,10 @@ def sync_runtime_memory_files(config: dict, state: dict, paths: dict) -> int:
         rt_id = entry.get("id") or ""
         if not rt_id or not _allowed(rt_id):
             continue
-        for category in ("memory", "skills"):
+        # Memory tab reads `memory`; Skills tab reads the other four. Ingest
+        # all five or the Skills tab is empty in cloud for everything except
+        # the `skills` bucket.
+        for category in ("memory",) + runtime_memory.SKILLS_TAB_CATEGORIES:
             try:
                 payload = runtime_memory.list_files(rt_id, category=category)
             except Exception:

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -8514,6 +8514,23 @@ def _build_memory_cache_pushes(config: dict) -> list:
             and (_now - float(_memory_push_state.get("ts") or 0)) < MEMORY_PUSH_MIN_INTERVAL_SEC):
         return []
 
+    # Catalog labels for the roots these rows came from, so a cloud viewer can
+    # head a group "Plugin: telegram" / "Global settings.json" the way the
+    # local browser does, instead of falling back to the last path segment
+    # (which renders every installed plugin as "skills" and one as "0.0.7").
+    # Derived here rather than stored per row: the label is static catalog
+    # config, not per-file data, and deriving costs one catalog walk per push.
+    root_meta: dict = {}
+    try:
+        from clawmetry import runtime_memory as _rm
+        for _entry in _rm.list_runtimes():
+            for _root in _entry.get("roots") or ():
+                root_meta[(_entry.get("id"), _root.get("root"))] = (
+                    _root.get("label") or "", _root.get("scope") or "",
+                )
+    except Exception:
+        root_meta = {}
+
     files: list[dict] = []
     contents: list[dict] = []
     seen: set = set()
@@ -8544,14 +8561,20 @@ def _build_memory_cache_pushes(config: dict) -> list:
         # file on a cloud that hasn't deployed yet. `rel` is the new
         # display-only field (path relative to the root it was found under).
         rel = path[len(root):].lstrip("/") if (root and path.startswith(root)) else path
+        rt_id = r.get("agent_type") or "openclaw"
+        label, scope = root_meta.get((rt_id, root), ("", ""))
         files.append({
             "name":     path,
             "path":     path,
             "rel":      rel or path,
             "size":     int(size or 0),
-            "runtime":  r.get("agent_type") or "openclaw",
+            "runtime":  rt_id,
             "category": r.get("category") or "memory",
             "root":     root,
+            # Display-only, and both optional: a consumer that predates them
+            # falls back to the path segment / omits the scope pill.
+            "label":    label,
+            "scope":    scope,
         })
         body = content[:MEMORY_CONTENT_TRUNCATE]
         if spent + len(body) > MEMORY_CACHE_TOTAL_BUDGET:
@@ -11684,9 +11707,16 @@ def sync_runtime_memory_files(config: dict, state: dict, paths: dict) -> int:
                     try:
                         with open(abs_path, "rb") as fh:
                             raw = fh.read(RUNTIME_MEMORY_MAX_BYTES)
-                        text = raw.decode("utf-8", errors="replace")
                     except Exception:
                         continue
+                    # Some catalogued roots are single non-text files —
+                    # Hermes' state.db, n8n's database.sqlite. Decoding those
+                    # with errors="replace" would push 200KB of mojibake per
+                    # heartbeat and render as garbage in the viewer. A NUL in
+                    # the head is the cheap, reliable binary tell.
+                    if b"\x00" in raw[:8192]:
+                        continue
+                    text = raw.decode("utf-8", errors="replace")
                     try:
                         if store.ingest_memory_blob({
                             "agent_type": rt_id,

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -8446,8 +8446,21 @@ def _build_brain_cache_pushes(config: dict) -> list:
 # Cloud read path: ``routes/cloud.py:cloud_memory_files``.
 
 MEMORY_CACHE_TTL_SEC = 21600       # 6h — matches Brain TTL; files change slowly
-MEMORY_CACHE_LIMIT = 200            # plenty for SOUL.md/USER.md/AGENTS.md/etc.
-MEMORY_CONTENT_TRUNCATE = 500_000   # mirrors routes/infra.py truncation
+MEMORY_CACHE_LIMIT = 600            # every runtime's memory + skills, not just OpenClaw's
+MEMORY_CONTENT_TRUNCATE = 120_000   # per file
+# Total plaintext budget for one push. MEMORY_CACHE_LIMIT × the per-file cap is
+# a 72MB worst case, which is not a heartbeat payload. Files past the budget
+# are still LISTED (so the tree is honest about what exists) with empty
+# content, and the viewer says to open them locally.
+MEMORY_CACHE_TOTAL_BUDGET = 6_000_000
+# Re-push floor. The snapshot used to be a handful of OpenClaw markdown files,
+# so rebuilding it on every 60s heartbeat cost nothing. Now that it carries
+# every runtime's memory AND skills it can run to several MB, and pushing that
+# once a minute would be gigabytes of egress a day for data that changes
+# hourly at best. Push when the content actually changed, or when we're
+# halfway to the cache TTL and the cloud copy needs refreshing either way.
+MEMORY_PUSH_MIN_INTERVAL_SEC = MEMORY_CACHE_TTL_SEC // 2
+_memory_push_state: dict = {"fingerprint": None, "ts": 0.0}
 
 
 def _build_memory_cache_pushes(config: dict) -> list:
@@ -8486,9 +8499,26 @@ def _build_memory_cache_pushes(config: dict) -> list:
         return []
     if not rows:
         return []
+    # Change-gate before the expensive part (JSON encode + AES of several MB).
+    # The sha256 column is exactly the per-file content hash we need.
+    try:
+        import hashlib as _hl
+        fp = _hl.sha256("|".join(sorted(
+            f"{r.get('path')}:{r.get('sha256')}" for r in rows
+        )).encode()).hexdigest()
+    except Exception:
+        fp = None
+    _now = time.time()
+    if (fp is not None
+            and fp == _memory_push_state.get("fingerprint")
+            and (_now - float(_memory_push_state.get("ts") or 0)) < MEMORY_PUSH_MIN_INTERVAL_SEC):
+        return []
+
     files: list[dict] = []
     contents: list[dict] = []
     seen: set = set()
+    spent = 0
+    dropped = 0
     for r in rows:
         path = r.get("path") or ""
         if not path or path in seen:
@@ -8507,23 +8537,48 @@ def _build_memory_cache_pushes(config: dict) -> list:
         size = r.get("size_bytes")
         if size is None:
             size = len(content.encode("utf-8", errors="replace"))
-        files.append({"name": path, "path": path, "size": int(size or 0)})
-        # Truncate per-file content to bound the encrypted blob size — the
-        # cloud Memory IDE shows a viewer pane (no diffing), so >500KB per
-        # file is wasted heartbeat bandwidth.
-        contents.append({"path": path, "content": content[:MEMORY_CONTENT_TRUNCATE]})
+        root = r.get("root") or ""
+        # Display name: relative to the root the file was found under, so the
+        # cloud tree can group the same way the local browser does.
+        rel = path[len(root):].lstrip("/") if (root and path.startswith(root)) else path
+        files.append({
+            "name":     rel or path,
+            "path":     path,
+            "size":     int(size or 0),
+            "runtime":  r.get("agent_type") or "openclaw",
+            "category": r.get("category") or "memory",
+            "root":     root,
+        })
+        body = content[:MEMORY_CONTENT_TRUNCATE]
+        if spent + len(body) > MEMORY_CACHE_TOTAL_BUDGET:
+            body = ""
+            dropped += 1
+        else:
+            spent += len(body)
+        contents.append({"path": path, "content": body})
     if not files:
         return []
+    if dropped:
+        log.info("memory cache push: %d of %d files listed without content "
+                 "(%d byte budget reached)", dropped, len(files),
+                 MEMORY_CACHE_TOTAL_BUDGET)
     payload = {
         "memory_state":   {"files": files},
         "memory_content": contents,
         "_source":        "local_store",
         "_shape":         "memory_files",
+        "_content_dropped": dropped,
     }
     try:
         blob = encrypt_payload(payload, enc_key)
     except Exception:
         return []
+    # Only arm the gate once we have a blob to hand back — a failed encode
+    # must not suppress the next attempt for three hours.
+    _memory_push_state["fingerprint"] = fp
+    _memory_push_state["ts"] = _now
+    log.info("memory cache push: %d files, %.1f MB plaintext",
+             len(files), spent / 1_000_000.0)
     owner_hash = _owner_hash_for_token(api_key)
     return [{
         "key":    f"memory:{owner_hash}:{node_id}:files",
@@ -11529,6 +11584,120 @@ def sync_session_metadata(config: dict, state: dict = None) -> int:
         log.warning(f"Session metadata sync failed: {e}")
         _record_sync_progress("session_metadata", 0, 0)
         return 0
+
+
+# ── Per-runtime memory + skills ingest ───────────────────────────────────────
+#
+# ``sync_memory`` below only ever looked at the OpenClaw workspace
+# (MEMORY.md / SOUL.md / memory/*.md). On a machine that runs Claude Code,
+# Codex or Cursor and has no OpenClaw workspace memory, that collected zero
+# files, so nothing landed in ``memory_blobs``, so the heartbeat had nothing
+# to push, so the cloud Memory tab sat on "Syncing memory files…" forever and
+# then fell through to "No memory data synced". The files were right there on
+# disk the whole time — we just never read them.
+#
+# This walks the same catalog the local Memory/Skills browser uses
+# (``clawmetry.runtime_memory``) so local and cloud show the same thing.
+
+# Bounds. These are per (runtime, category) and exist to keep the heartbeat
+# blob sane on a machine with hundreds of memory files — a Claude Code user
+# with 30 projects has ~430 auto-memory files alone.
+RUNTIME_MEMORY_MAX_FILES = 250
+RUNTIME_MEMORY_MAX_BYTES = 200_000
+
+
+def sync_runtime_memory_files(config: dict, state: dict, paths: dict) -> int:
+    """Ingest every entitled runtime's memory + skills files into DuckDB.
+
+    Local-first and local-only: this writes to the store, and the existing
+    heartbeat cache push (``_build_memory_cache_pushes``) is what carries it
+    to cloud. Returns the number of files written (dedup means a steady-state
+    tick returns 0). Never raises — a runtime whose root has moved must not
+    take the daemon down.
+    """
+    if not _sync_allowed():
+        return 0
+    try:
+        from clawmetry import local_store, runtime_memory
+    except Exception:
+        return 0
+
+    # Never ingest a paid runtime the user isn't entitled to — that would
+    # push its file contents to cloud behind the paywall's back.
+    try:
+        from clawmetry.entitlements import FREE_RUNTIMES, get_entitlement
+        ent = get_entitlement()
+
+        def _allowed(rt_id: str) -> bool:
+            if rt_id in FREE_RUNTIMES:
+                return True
+            try:
+                return bool(ent.allows_runtime(rt_id))
+            except Exception:
+                return False
+    except Exception:
+        def _allowed(rt_id: str) -> bool:
+            return True
+
+    try:
+        store = local_store.get_store()
+    except Exception as e:
+        log.debug("runtime memory ingest: store unavailable (%s)", e)
+        return 0
+
+    now_iso = datetime.now(timezone.utc).isoformat()
+    written = 0
+    scanned = 0
+    for entry in runtime_memory.list_runtimes():
+        rt_id = entry.get("id") or ""
+        if not rt_id or not _allowed(rt_id):
+            continue
+        for category in ("memory", "skills"):
+            try:
+                payload = runtime_memory.list_files(rt_id, category=category)
+            except Exception:
+                continue
+            for group in payload.get("groups") or ():
+                if not group.get("exists"):
+                    continue
+                root = group.get("root") or ""
+                files = list(group.get("files") or ())
+                # Newest first, then cap — if we have to drop files, drop the
+                # stale ones rather than an arbitrary alphabetical tail.
+                files.sort(key=lambda f: f.get("mtime") or 0, reverse=True)
+                if len(files) > RUNTIME_MEMORY_MAX_FILES:
+                    log.debug("runtime memory: %s/%s capped %d→%d files under %s",
+                              rt_id, category, len(files),
+                              RUNTIME_MEMORY_MAX_FILES, root)
+                    files = files[:RUNTIME_MEMORY_MAX_FILES]
+                for f in files:
+                    rel = f.get("path") or ""
+                    abs_path = os.path.join(root, rel) if rel else root
+                    scanned += 1
+                    try:
+                        with open(abs_path, "rb") as fh:
+                            raw = fh.read(RUNTIME_MEMORY_MAX_BYTES)
+                        text = raw.decode("utf-8", errors="replace")
+                    except Exception:
+                        continue
+                    try:
+                        if store.ingest_memory_blob({
+                            "agent_type": rt_id,
+                            "agent_id":   "main",
+                            # Absolute path: `rel` alone collides across the
+                            # several roots one runtime registers per category.
+                            "path":       abs_path,
+                            "category":   category,
+                            "root":       root,
+                            "ts":         now_iso,
+                            "blob":       text,
+                        }):
+                            written += 1
+                    except Exception:
+                        continue
+    if written:
+        log.info("  Runtime memory/skills: %d of %d files ingested", written, scanned)
+    return written
 
 
 def sync_memory(config: dict, state: dict, paths: dict) -> int:
@@ -18742,6 +18911,10 @@ def run_daemon() -> None:
     except Exception as e:
         log.warning(f"  Memory sync error: {e}")
     try:
+        sync_runtime_memory_files(config, state, paths)
+    except Exception as e:
+        log.warning(f"  Runtime memory/skills sync error: {e}")
+    try:
         recent_ev = sync_sessions_recent(config, state, paths, minutes=60)
         save_state(state)
         log.info(f"  Recent sessions: {recent_ev} events synced")
@@ -19166,6 +19339,10 @@ def run_daemon() -> None:
 
             # ── High-priority: memory, flow metrics, subagents, recent sessions ──
             mem = sync_memory(config, state, paths)
+            try:
+                sync_runtime_memory_files(config, state, paths)
+            except Exception as _rme:
+                log.warning("runtime memory/skills sync error: %s", _rme)
             snap = 0
             now_snap = time.time()
             if now_snap - last_snapshot > snapshot_interval:

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -8538,12 +8538,16 @@ def _build_memory_cache_pushes(config: dict) -> list:
         if size is None:
             size = len(content.encode("utf-8", errors="replace"))
         root = r.get("root") or ""
-        # Display name: relative to the root the file was found under, so the
-        # cloud tree can group the same way the local browser does.
+        # `name` stays the join key the cloud viewer matches against
+        # memory_content[].path — an older cloud build looks the content up by
+        # files[].name, so changing it to a display string would blank every
+        # file on a cloud that hasn't deployed yet. `rel` is the new
+        # display-only field (path relative to the root it was found under).
         rel = path[len(root):].lstrip("/") if (root and path.startswith(root)) else path
         files.append({
-            "name":     rel or path,
+            "name":     path,
             "path":     path,
+            "rel":      rel or path,
             "size":     int(size or 0),
             "runtime":  r.get("agent_type") or "openclaw",
             "category": r.get("category") or "memory",

--- a/clawmetry/templates/tabs/memory.html
+++ b/clawmetry/templates/tabs/memory.html
@@ -4,7 +4,8 @@
       <div style="font-size:18px;font-weight:700;color:var(--text-primary);" data-i18n="memory.title">Memory</div>
       <div style="font-size:12px;color:var(--text-muted);margin-top:4px;" data-i18n="memory.subtitle">Markdown files your agent reads and updates. Edit them too if you want.</div>
     </div>
-    <div id="memory-runtime-chips" data-tab="memory" data-category="memory" style="display:flex;gap:6px;flex-wrap:wrap;align-items:center;max-width:60%;"></div>
+    <!-- No runtime picker here on purpose: the global runtime switcher is the
+         only one. See _CM_RT_NODEWIDE / cmRuntimeSelect in static/js/app.js. -->
     <div style="display:flex;gap:6px;align-items:center;">
       <div class="mem-view-tab" data-view="summary" onclick="memorySwitchView('summary')" style="padding:6px 14px;border-radius:6px;font-size:12px;font-weight:600;cursor:pointer;background:var(--bg-secondary);border:1px solid var(--border-primary);color:var(--text-primary);" data-i18n="memory.view_summary">Summary</div>
       <div class="mem-view-tab" data-view="all" onclick="memorySwitchView('all')" style="padding:6px 14px;border-radius:6px;font-size:12px;font-weight:600;cursor:pointer;background:transparent;border:1px solid transparent;color:var(--text-muted);" data-i18n="memory.view_all_files">All files</div>

--- a/clawmetry/templates/tabs/skills.html
+++ b/clawmetry/templates/tabs/skills.html
@@ -9,8 +9,8 @@
       <button class="refresh-btn" onclick="loadSkills()">↻ <span data-i18n="common.refresh">Refresh</span></button>
     </div>
   </div>
-  <div id="skills-runtime-chips" data-tab="skills" data-category="skills" style="display:flex;gap:6px;flex-wrap:wrap;align-items:center;margin:10px 0 4px 0;"></div>
-  <div id="skills-runtime-browser" class="runtime-file-browser" data-tab="skills" data-category="skills" style="display:none;"></div>
+  <!-- No runtime picker here on purpose — the global runtime switcher owns it. -->
+  <div id="skills-runtime-browser" class="runtime-file-browser" data-tab="skills" data-category="skills" style="display:none;margin-top:10px;"></div>
   <div id="skills-summary-row" style="display:flex;gap:12px;flex-wrap:wrap;margin:14px 0 16px 0;"></div>
   <div id="skills-list"><div style="color:var(--text-muted);font-size:13px;padding:16px;" data-i18n="app.loading">Loading...</div></div>
   <!-- Skills Browser (file explorer view) -->

--- a/routes/runtime_memory.py
+++ b/routes/runtime_memory.py
@@ -117,6 +117,30 @@ def api_runtime_memory_catalog():
     })
 
 
+@bp_runtime_memory.route("/api/runtimes/all/files")
+def api_runtime_files_all():
+    """Aggregate every entitled runtime's files for one category.
+
+    A dedicated rule rather than a magic value inside
+    :func:`api_runtime_files` — Werkzeug matches this static rule ahead of
+    the ``<runtime_id>`` converter either way, and a grep for the URL the
+    frontend actually calls should land on a handler.
+
+    Never returns 402. This is the DEFAULT scope of the Memory and Skills
+    tabs, so paywalling it because the user also happens to have an
+    unentitled runtime installed would paywall the free runtimes they ARE
+    entitled to. Locked runtimes are simply left out of the sweep; the
+    conversion moment stays on an explicit per-runtime selection, which
+    still 402s below.
+    """
+    category = (request.args.get("category") or "").strip() or None
+    if category and category not in CATEGORIES:
+        return jsonify({"error": "invalid category"}), 400
+    allowed = [rt["id"] for rt in list_runtimes()
+               if not _runtime_is_locked(rt["id"])]
+    return jsonify(list_all_files(category=category, allowed=allowed))
+
+
 @bp_runtime_memory.route("/api/runtimes/<runtime_id>/files")
 def api_runtime_files(runtime_id: str):
     """List every file under one runtime, grouped by root.
@@ -139,9 +163,10 @@ def api_runtime_files(runtime_id: str):
     if category and category not in CATEGORIES:
         return jsonify({"error": "invalid category"}), 400
     if runtime_id == "all":
-        allowed = [rt["id"] for rt in list_runtimes()
-                   if not _runtime_is_locked(rt["id"])]
-        return jsonify(list_all_files(category=category, allowed=allowed))
+        # Defensive: the static rule above normally wins the match. Kept so
+        # a caller that reaches here (a blueprint mounted under a prefix, a
+        # hand-built url_for) still gets the aggregate rather than a 404.
+        return api_runtime_files_all()
     if _runtime_is_locked(runtime_id):
         return jsonify({
             "error": "upgrade_required",

--- a/routes/runtime_memory.py
+++ b/routes/runtime_memory.py
@@ -22,6 +22,18 @@ endpoint at ``/api/file``). Traversal-safety is enforced inside
       not cover them (grace still permissive — see the entitlements
       module).
 
+      ``runtime_id`` may be the literal ``all``, which sweeps every
+      entitled runtime and returns only groups that exist on disk, each
+      tagged with its owning ``runtime`` / ``runtime_label``. This is the
+      DEFAULT scope of the Memory and Skills tabs (the global runtime
+      switcher's "All runtimes"), so it never 402s — a locked runtime is
+      left out of the sweep instead, because paywalling the aggregate
+      would also paywall the free runtimes the user IS entitled to. The
+      conversion moment stays on an explicit per-runtime selection.
+
+      ``all`` is a list-only sentinel: read a file back through the
+      ``runtime`` its group carries, never through ``all``.
+
   GET /api/runtimes/<runtime_id>/file?root=<root>&path=<rel>
       Read one file from within a registered root. Same entitlement gate
       as ``/files``.

--- a/routes/runtime_memory.py
+++ b/routes/runtime_memory.py
@@ -41,6 +41,7 @@ from flask import Blueprint, jsonify, request
 
 from clawmetry.runtime_memory import (
     CATEGORIES,
+    list_all_files,
     list_files,
     list_runtimes,
     read_runtime_file,
@@ -111,20 +112,30 @@ def api_runtime_files(runtime_id: str):
     Query params:
       - category: optional filter (memory | skills | commands | agents | hooks)
 
+    ``runtime_id`` may be the literal ``all``, which aggregates every
+    runtime the caller is entitled to. That is the default scope of the
+    Memory / Skills tabs (the global runtime switcher's "All runtimes"),
+    so it must never 402 — locked runtimes are simply left out of the
+    sweep rather than turning the whole page into an upsell.
+
     Returns HTTP 402 ``upgrade_required`` when the runtime is a paid
     runtime and the resolved entitlement does not cover it. This is the
     OSS conversion moment prescribed by ``FLYWHEEL.md`` §1b — never
     silently disable, always surface the upgrade CTA.
     """
+    category = (request.args.get("category") or "").strip() or None
+    if category and category not in CATEGORIES:
+        return jsonify({"error": "invalid category"}), 400
+    if runtime_id == "all":
+        allowed = [rt["id"] for rt in list_runtimes()
+                   if not _runtime_is_locked(rt["id"])]
+        return jsonify(list_all_files(category=category, allowed=allowed))
     if _runtime_is_locked(runtime_id):
         return jsonify({
             "error": "upgrade_required",
             "runtime": runtime_id,
             "reason": "paid_runtime_not_entitled",
         }), 402
-    category = (request.args.get("category") or "").strip() or None
-    if category and category not in CATEGORIES:
-        return jsonify({"error": "invalid category"}), 400
     payload = list_files(runtime_id, category=category)
     if payload.get("error") == "unknown_runtime":
         return jsonify(payload), 404

--- a/routes/runtime_memory.py
+++ b/routes/runtime_memory.py
@@ -56,6 +56,7 @@ from clawmetry.runtime_memory import (
     list_all_files,
     list_files,
     list_runtimes,
+    parse_categories,
     read_runtime_file,
 )
 
@@ -134,7 +135,7 @@ def api_runtime_files_all():
     still 402s below.
     """
     category = (request.args.get("category") or "").strip() or None
-    if category and category not in CATEGORIES:
+    if category and not parse_categories(category):
         return jsonify({"error": "invalid category"}), 400
     allowed = [rt["id"] for rt in list_runtimes()
                if not _runtime_is_locked(rt["id"])]
@@ -160,7 +161,7 @@ def api_runtime_files(runtime_id: str):
     silently disable, always surface the upgrade CTA.
     """
     category = (request.args.get("category") or "").strip() or None
-    if category and category not in CATEGORIES:
+    if category and not parse_categories(category):
         return jsonify({"error": "invalid category"}), 400
     if runtime_id == "all":
         # Defensive: the static rule above normally wins the match. Kept so


### PR DESCRIPTION
Founder feedback: "they both seem to be vaporware". Three reported symptoms, plus the reason the cloud tab never had data.

## 1. Duplicate runtime pickers
Memory and Skills were listed in `_CM_RT_NODEWIDE` (telling the global switcher "runtime does not apply here") and then rendered their own per-tab chip bar. Three pickers on screen that could disagree.

Removed the chip bars. Both tabs now scope off the global switcher, with a new `all` aggregate (`/api/runtimes/all/files`) for the default scope.

## 2. Clicking a file did nothing
```js
var groups = (payload.groups || []).filter(g => g.exists);  // tree indexed over THIS
...
container._cmRuntimePayload = payload;                       // handler read THIS
```
Every `gi` was shifted by however many absent roots came first, so the click resolved to a group with no files and returned silently. It only worked when every catalogued root happened to exist — which is why it looked fine under the all-runtimes scope (that endpoint only returns existing groups) and dead on a specific runtime.

## 3. Skills mirrored Memory
`cmRuntimeMountBrowser` had a literal empty `if` block where the category filter belonged, so both tabs fetched every category and rendered identical trees. Now passes `category=memory` / `category=skills`.

## 4. Why cloud was empty
`sync_memory` only ever collected the OpenClaw workspace (`MEMORY.md`, `SOUL.md`, `memory/*.md`). On a machine running Claude Code with no OpenClaw workspace memory that collects **zero** files → `memory_blobs` empty → no heartbeat push → cloud shows "Syncing memory files…" forever, then "No memory data synced". Meanwhile 400+ memory files sat on disk.

`sync_runtime_memory_files` walks the same catalog the local browser uses, for every entitled runtime, memory + skills, into `memory_blobs` (new `category` + `root` columns, migration included). Locked paid runtimes are skipped so nothing leaks past the paywall.

The push is change-gated on a content fingerprint with a 3h refresh floor — it carries several MB now, and rebuilding it every 60s heartbeat would be gigabytes of egress a day. Content past a 6MB budget is **listed without a body** rather than silently dropped.

## Also
- Claude Code skills resolve from `~/.claude/plugins/marketplaces`. Most users never write `~/.claude/skills` — skills arrive as plugins — so the tab read "nothing found" on a machine with 31 live ones.
- Tree rows name themselves after the identifying directory (`discord/access`) instead of thirty identical `SKILL.md` rows.
- The OpenClaw-only controls (Summary / All files / Access log, Skills Grid) hide when the file browser owns the surface instead of sitting there dead.

## Verification
Real browser (Playwright, local dashboard on :8901), four scopes, all green:

| scope | chip bars | files | click loads content |
|---|---|---|---|
| Memory · Claude Code | 0 | 429 | yes |
| Skills · Claude Code | 0 | 31 | yes |
| Memory · all runtimes | 0 | 431 | yes |
| Skills · all runtimes | 0 | 437 | yes |

Daemon ingest against an isolated DuckDB: 540 files across 9 runtimes with correct categories; second run returns 0 (dedup); cache push builds once then gates.

`tests/test_memory_cache_push.py` and `tests/test_skills_fidelity_local_store.py` fail identically on clean `origin/main` in this environment — pre-existing, not from this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)