### PR TITLE
[RELEASE] Multi-runtime Memory & Skills browser: one picker, working clicks, real cloud data

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -10165,7 +10165,10 @@ var _CM_RT_NODEWIDE = {
   // approvals + alerts left this map 2026-08-03: approvals rows filter by
   // the requesting session's runtime prefix, and alert rules carry their own
   // per-rule scope (runtime column, node-wide chip when 'all').
-  crons: 1, memory: 1, security: 1, skills: 1, selfevolve: 1,
+  // memory + skills left this map 2026-08-14: the multi-runtime file
+  // browser scopes both tabs to the selected runtime (catalog in
+  // clawmetry/runtime_memory.py), so the "node-wide" banner would lie.
+  crons: 1, security: 1, selfevolve: 1,
   policy: 1, nemoclaw: 1, notifications: 1, dives: 1,
   clusters: 1, actions: 1,
   // logs + version-impact are NOT node-wide: logs stream a specific runtime's
@@ -25826,18 +25829,31 @@ setTimeout(checkLicenseExpiry, 1200);
 // Runtime Memory & Skills browser (multi-runtime file explorer).
 //
 // Each supported runtime stores its long-lived memory and its skills in
-// different places on disk (see clawmetry/runtime_memory.py). This module
-// renders two things across the Memory + Skills tabs:
-//   1. A chip bar of runtimes (dimmed if not present on this machine)
-//   2. A file-browser view (left tree, right preview) for the picked runtime
+// different places on disk (see clawmetry/runtime_memory.py). Both tabs
+// scope to the GLOBAL runtime selection (_cmRuntimeFilter — the top
+// dropdown / ?runtime= pin); there is deliberately no second picker
+// inside the tab (founder: "there are already 2 dropdowns to switch
+// runtime").
 //
-// OpenClaw remains the default; picking it hides the browser and shows the
-// existing rich Memory / Skills UI. All other runtimes route through the
-// browser. Backwards compatible — the old view is untouched.
+// Per-tab category split: Memory shows the runtime's `memory` roots;
+// Skills shows `skills` + `commands` + `agents` + `hooks`.
+//
+// Data path: locally the browser reads /api/runtimes/<id>/files straight
+// off the disk. On cloud the container has none of those paths, so the
+// cloud dashboard overrides window._cmCloudRuntimeFiles to serve the
+// E2E-encrypted catalog the daemon pushes on heartbeat
+// (sync.py:_build_runtime_files_cache_pushes) — decrypted client-side,
+// file contents inline.
+//
+// OpenClaw keeps its rich native Memory UI (editor, history, access log)
+// in both environments; every other runtime routes through the browser.
+// Skills on cloud routes through the browser for ALL runtimes including
+// OpenClaw (the native skills view has no cloud data path).
 // ─────────────────────────────────────────────────────────────────────────
 
 var _cmRuntimeCatalog = null;
-var _cmRuntimeSelected = { memory: 'openclaw', skills: 'openclaw' };
+var _CM_RT_TAB_CATS = { memory: ['memory'], skills: ['skills', 'commands', 'agents', 'hooks'] };
+var _cmRtBrowserPollTries = { memory: 0, skills: 0 };
 
 function _cmRuntimeIsCloud() {
   try {
@@ -25869,96 +25885,64 @@ function _cmRuntimeIcon(id) {
   return map[id] || '•';
 }
 
-function _cmRuntimeChip(runtime, selected, tab, category) {
-  var count = 0;
-  if (category && runtime.counts) count = runtime.counts[category] || 0;
-  else if (runtime.counts) {
-    Object.keys(runtime.counts).forEach(function(k) { count += runtime.counts[k] || 0; });
-  }
-  var isSel = runtime.id === selected;
-  var isPresent = !!runtime.present;
-  var isLocked = !!runtime.locked;
-  var bg = isSel ? '#6366f1' : (isPresent ? 'var(--bg-secondary)' : 'transparent');
-  var color = isSel ? '#fff' : (isPresent ? 'var(--text-primary)' : 'var(--text-muted)');
-  var border = isSel ? '#6366f1' : 'var(--border-primary)';
-  var op = (isPresent || isSel) ? 1 : 0.55;
-  var badge = '';
-  if (isLocked) {
-    badge = '<span title="Paid runtime — upgrade to browse its files" style="margin-left:6px;font-size:10px;opacity:0.85;">🔒</span>';
-  } else if (count > 0) {
-    badge = '<span style="background:rgba(255,255,255,0.16);padding:1px 6px;border-radius:8px;font-size:10px;margin-left:6px;">' + count + '</span>';
-  }
-  var titleTip = isLocked
-    ? escHtml(runtime.label) + ' — paid runtime, upgrade to browse'
-    : escHtml(runtime.label) + (isPresent ? '' : ' (not detected on this machine)');
-  return '<div class="cm-runtime-chip" data-runtime="' + runtime.id + '" '
-    + 'onclick="cmRuntimeSelect(\'' + tab + '\',\'' + runtime.id + '\')" '
-    + 'style="padding:4px 10px;border-radius:14px;font-size:11px;font-weight:600;cursor:pointer;'
-    + 'background:' + bg + ';color:' + color + ';border:1px solid ' + border + ';opacity:' + op + ';'
-    + 'display:inline-flex;align-items:center;gap:4px;" title="' + titleTip + '">'
-    + escHtml(runtime.label) + badge + '</div>';
+// Which runtime the Memory/Skills tabs are scoped to right now: the global
+// runtime selection, defaulting to OpenClaw when 'all' / unset.
+function cmRuntimeCurrent() {
+  var rt = (typeof _cmRuntimeFilter === 'function') ? _cmRuntimeFilter() : '';
+  if (!rt || rt === 'all') return 'openclaw';
+  return rt;
 }
 
-async function cmRuntimeMountChips(chipsEl) {
-  if (!chipsEl) return;
-  var tab = chipsEl.getAttribute('data-tab') || 'memory';
-  var category = chipsEl.getAttribute('data-category') || null;
-  chipsEl.innerHTML = '<span style="font-size:11px;color:var(--text-muted);">Loading runtimes…</span>';
-  var cat = await _cmRuntimeFetchCatalog();
-  var runtimes = (cat.runtimes || []).slice();
-  // Sort: present first, then by label
-  runtimes.sort(function(a, b) {
-    if (!!a.present !== !!b.present) return a.present ? -1 : 1;
-    return (a.label || '').localeCompare(b.label || '');
-  });
-  var sel = _cmRuntimeSelected[tab] || 'openclaw';
-  var chips = runtimes.map(function(rt) {
-    return _cmRuntimeChip(rt, sel, tab, category);
-  });
-  chipsEl.innerHTML = chips.join('');
+// Full file payload for one runtime. Local: disk via /api/runtimes. Cloud:
+// window._cmCloudRuntimeFiles (decrypted heartbeat blob, contents inline).
+// Normalised result: {runtime, label, groups} | {locked:true} |
+// {pending:true} | {error: str}.
+async function _cmRuntimeFilesPayload(runtimeId) {
+  if (typeof window._cmCloudRuntimeFiles === 'function') {
+    return window._cmCloudRuntimeFiles(runtimeId);
+  }
+  var r = await fetch('/api/runtimes/' + encodeURIComponent(runtimeId) + '/files');
+  if (r.status === 402) return { locked: true, runtime: runtimeId };
+  if (r.status === 404) return { runtime: runtimeId, label: runtimeId, groups: [], unknown: true };
+  if (!r.ok) throw new Error('http ' + r.status);
+  return r.json();
 }
 
-function cmRuntimeSelect(tab, runtimeId) {
-  _cmRuntimeSelected[tab] = runtimeId;
-  // Re-render both chip bars if present (keeps them in sync visually)
-  var chips = document.querySelectorAll('[id$="-runtime-chips"][data-tab="' + tab + '"]');
-  chips.forEach(function(el) { cmRuntimeMountChips(el); });
-  // Toggle native OpenClaw view vs runtime file browser
+// Show either the native OpenClaw view or the runtime file browser on a
+// tab, based on the global runtime. Called on tab switch AND on runtime
+// switch (both hooks installed below).
+function cmRuntimeApplyView(tab) {
   var browser = document.getElementById(tab + '-runtime-browser');
-  if (tab === 'memory') {
-    var nativeIds = ['memory-summary-view', 'memory-access-view', 'memory-all-view'];
-    if (runtimeId === 'openclaw') {
-      nativeIds.forEach(function(id) {
-        var el = document.getElementById(id);
-        if (!el) return;
-        // Only restore the summary view by default; the other two are toggled
-        // by memorySwitchView independently.
-        if (id === 'memory-summary-view') el.style.display = '';
-      });
-      if (browser) browser.style.display = 'none';
-    } else {
-      nativeIds.forEach(function(id) {
-        var el = document.getElementById(id);
-        if (el) el.style.display = 'none';
-      });
-      if (browser) { browser.style.display = ''; cmRuntimeMountBrowser(browser, runtimeId, 'memory'); }
-    }
-  } else if (tab === 'skills') {
-    var nativeIds = ['skills-summary-row', 'skills-list', 'skills-browser'];
-    if (runtimeId === 'openclaw') {
-      nativeIds.forEach(function(id) {
-        var el = document.getElementById(id);
-        if (!el) return;
-        if (id === 'skills-summary-row' || id === 'skills-list') el.style.display = '';
-      });
-      if (browser) browser.style.display = 'none';
-    } else {
-      nativeIds.forEach(function(id) {
-        var el = document.getElementById(id);
-        if (el) el.style.display = 'none';
-      });
-      if (browser) { browser.style.display = ''; cmRuntimeMountBrowser(browser, runtimeId, 'skills'); }
-    }
+  if (!browser) return;
+  var rt = cmRuntimeCurrent();
+  var isCloud = _cmRuntimeIsCloud();
+  // OpenClaw memory keeps its rich native editor everywhere. OpenClaw
+  // skills keeps the native catalog locally only — on cloud that view has
+  // no data path, so the browser (fed by the heartbeat blob) takes over.
+  var useNative = rt === 'openclaw' && !(isCloud && tab === 'skills');
+  var nativeIds = tab === 'memory'
+    ? ['memory-summary-view', 'memory-access-view', 'memory-all-view']
+    : ['skills-summary-row', 'skills-list', 'skills-browser'];
+  var restoreIds = tab === 'memory'
+    ? { 'memory-summary-view': 1 }
+    : { 'skills-summary-row': 1, 'skills-list': 1 };
+  var toggles = document.querySelectorAll('#page-' + tab + ' .mem-view-tab');
+  if (useNative) {
+    nativeIds.forEach(function(id) {
+      var el = document.getElementById(id);
+      if (el && restoreIds[id]) el.style.display = '';
+    });
+    Array.prototype.forEach.call(toggles, function(el) { el.style.display = ''; });
+    browser.style.display = 'none';
+  } else {
+    nativeIds.forEach(function(id) {
+      var el = document.getElementById(id);
+      if (el) el.style.display = 'none';
+    });
+    Array.prototype.forEach.call(toggles, function(el) { el.style.display = 'none'; });
+    browser.style.display = '';
+    _cmRtBrowserPollTries[tab] = 0;
+    cmRuntimeMountBrowser(browser, rt, tab);
   }
 }
 
@@ -25968,36 +25952,75 @@ async function cmRuntimeMountBrowser(container, runtimeId, tab) {
     + escHtml(runtimeId) + '…</div>';
   var payload;
   try {
-    var url = '/api/runtimes/' + encodeURIComponent(runtimeId) + '/files';
-    if (tab === 'memory' || tab === 'skills') {
-      // No category filter — show everything the runtime exposes.
-    }
-    var r = await fetch(url);
-    if (r.status === 402) {
-      // Paid runtime the caller isn't entitled to. Show upsell CTA
-      // instead of an error — matches the OSS conversion-moment pattern.
-      var rtLabel = (_cmRuntimeCatalog && _cmRuntimeCatalog.runtimes || [])
-        .filter(function(x) { return x.id === runtimeId; })[0];
-      var label = (rtLabel && rtLabel.label) || runtimeId;
-      container.innerHTML =
-        '<div style="padding:36px 20px;text-align:center;color:var(--text-muted);font-size:13px;line-height:1.55;max-width:520px;margin:0 auto;">'
-        + '<div style="font-size:28px;margin-bottom:8px;">🔒</div>'
-        + '<div style="font-weight:700;color:var(--text-primary);margin-bottom:6px;font-size:15px;">' + escHtml(label) + ' is a paid runtime</div>'
-        + 'Upgrade your ClawMetry plan to browse this runtime\'s memory and skills files. '
-        + 'Everything ClawMetry knows about ' + escHtml(label) + ' — including where its memory lives on disk — is bundled with the paid tier that ships its adapter.'
-        + '<div style="margin-top:16px;"><a href="https://clawmetry.com/pricing" target="_blank" style="display:inline-block;background:#6366f1;color:#fff;text-decoration:none;padding:8px 16px;border-radius:8px;font-weight:600;font-size:13px;">See pricing</a></div>'
-        + '</div>';
-      return;
-    }
-    if (!r.ok) throw new Error('http ' + r.status);
-    payload = await r.json();
+    payload = await _cmRuntimeFilesPayload(runtimeId);
   } catch (e) {
     container.innerHTML = '<div style="padding:16px;color:#ef4444;font-size:12px;">Failed to load: '
       + escHtml(String(e)) + '</div>';
     return;
   }
-  var groups = (payload.groups || []).filter(function(g) { return g.exists; });
-  var absent = (payload.groups || []).filter(function(g) { return !g.exists; });
+  if (payload && payload.pending) {
+    // Cloud cache miss — the daemon pushes the catalog on its next
+    // heartbeat. Poll a bounded number of times, then settle into an
+    // honest "not synced yet" state.
+    var tries = _cmRtBrowserPollTries[tab] || 0;
+    if (tries < 8) {
+      _cmRtBrowserPollTries[tab] = tries + 1;
+      container.innerHTML =
+        '<div style="padding:60px 20px;text-align:center;color:var(--text-muted);font-size:13px;line-height:1.6;">'
+        + '<div style="font-size:28px;margin-bottom:10px;">🔄</div>'
+        + '<div style="font-weight:700;color:var(--text-secondary);margin-bottom:4px;">Syncing files from your machine…</div>'
+        + 'Your agent pushes its memory &amp; skills files on the next heartbeat.<br>This usually takes under a minute.</div>';
+      setTimeout(function() {
+        var el = document.getElementById(tab + '-runtime-browser');
+        if (el && el.style.display !== 'none' && cmRuntimeCurrent() === runtimeId) {
+          cmRuntimeMountBrowser(el, runtimeId, tab);
+        }
+      }, 12000);
+      return;
+    }
+    container.innerHTML =
+      '<div style="padding:40px 20px;text-align:center;color:var(--text-muted);font-size:13px;line-height:1.6;">'
+      + 'No file snapshot from this node yet. Make sure the ClawMetry daemon is running '
+      + '(<code>clawmetry status</code>) and on version 0.12.705 or newer, then check back.</div>';
+    return;
+  }
+  if (payload && payload.needkey) {
+    // Cloud with no stored E2E key: reuse the cloud dashboard's key
+    // prompt (it stores the key and re-mounts this view on unlock).
+    if (typeof window._cmRenderKeyPrompt === 'function') {
+      window._cmRenderKeyPrompt(container);
+    } else {
+      container.innerHTML = '<div style="padding:40px 20px;text-align:center;color:var(--text-muted);font-size:13px;">'
+        + 'Files are end-to-end encrypted. Open the Memory tab to enter your secret key.</div>';
+    }
+    return;
+  }
+  if (payload && payload.locked) {
+    // Paid runtime the caller isn't entitled to. Show upsell CTA
+    // instead of an error — matches the OSS conversion-moment pattern.
+    var rtLabel = (_cmRuntimeCatalog && _cmRuntimeCatalog.runtimes || [])
+      .filter(function(x) { return x.id === runtimeId; })[0];
+    var label = payload.label || (rtLabel && rtLabel.label) || runtimeId;
+    container.innerHTML =
+      '<div style="padding:36px 20px;text-align:center;color:var(--text-muted);font-size:13px;line-height:1.55;max-width:520px;margin:0 auto;">'
+      + '<div style="font-size:28px;margin-bottom:8px;">🔒</div>'
+      + '<div style="font-weight:700;color:var(--text-primary);margin-bottom:6px;font-size:15px;">' + escHtml(label) + ' is a paid runtime</div>'
+      + 'Upgrade your ClawMetry plan to browse this runtime\'s memory and skills files. '
+      + 'Everything ClawMetry knows about ' + escHtml(label) + ' — including where its memory lives on disk — is bundled with the paid tier that ships its adapter.'
+      + '<div style="margin-top:16px;"><a href="https://clawmetry.com/pricing" target="_blank" style="display:inline-block;background:#6366f1;color:#fff;text-decoration:none;padding:8px 16px;border-radius:8px;font-weight:600;font-size:13px;">See pricing</a></div>'
+      + '</div>';
+    return;
+  }
+  _cmRtBrowserPollTries[tab] = 0;
+  // Per-tab category split: Memory shows memory roots, Skills shows
+  // skills/commands/agents/hooks. This is what makes the two tabs show
+  // DIFFERENT content (they previously shared one unfiltered listing).
+  var cats = _CM_RT_TAB_CATS[tab] || null;
+  var allGroups = (payload.groups || []).filter(function(g) {
+    return !cats || cats.indexOf(g.category) !== -1;
+  });
+  var groups = allGroups.filter(function(g) { return g.exists; });
+  var absent = allGroups.filter(function(g) { return !g.exists; });
   var totalFiles = groups.reduce(function(s, g) { return s + (g.files || []).length; }, 0);
 
   if (!groups.length) {
@@ -26055,17 +26078,18 @@ async function cmRuntimeMountBrowser(container, runtimeId, tab) {
     + '<div style="color:var(--text-muted);font-family:inherit;">Pick a file on the left to view its contents.</div>'
     + '</div></div></div>';
 
-  // Stash the payload on the container so cmRuntimeOpenFile can look up
-  // (root, path) by (gi, fi) without another fetch.
-  container._cmRuntimePayload = payload;
+  // Stash the RENDERED (category-filtered, exists-only) groups so
+  // cmRuntimeOpenFile resolves (gi, fi) against exactly what the tree
+  // shows. Indexing into the raw payload was the "click does nothing"
+  // bug: the tree skipped absent groups, so gi pointed at the wrong root.
+  container._cmRuntimeGroups = groups;
 }
 
 async function cmRuntimeOpenFile(clickEl, runtimeId, gi, fi) {
   var container = clickEl.closest('.runtime-file-browser');
-  if (!container || !container._cmRuntimePayload) return;
+  if (!container || !container._cmRuntimeGroups) return;
   var tab = container.getAttribute('data-tab') || 'memory';
-  var groups = container._cmRuntimePayload.groups || [];
-  var group = groups[gi];
+  var group = container._cmRuntimeGroups[gi];
   if (!group) return;
   var file = (group.files || [])[fi];
   if (!file) return;
@@ -26083,12 +26107,20 @@ async function cmRuntimeOpenFile(clickEl, runtimeId, gi, fi) {
   if (body) body.innerHTML = '<div style="color:var(--text-muted);">Loading…</div>';
 
   try {
-    var url = '/api/runtimes/' + encodeURIComponent(runtimeId)
-      + '/file?root=' + encodeURIComponent(group.root)
-      + '&path=' + encodeURIComponent(file.path || '');
-    var r = await fetch(url);
-    var d = await r.json();
-    if (!r.ok) throw new Error(d.error || ('http ' + r.status));
+    var d;
+    if (typeof file.content === 'string') {
+      // Cloud path: contents ship inline in the decrypted heartbeat blob —
+      // there is no per-file endpoint to hit.
+      var lang = /\.md$/i.test(file.path || group.root || '') ? 'markdown' : 'text';
+      d = { content: file.content, size: file.size, mtime: file.mtime, language: lang };
+    } else {
+      var url = '/api/runtimes/' + encodeURIComponent(runtimeId)
+        + '/file?root=' + encodeURIComponent(group.root)
+        + '&path=' + encodeURIComponent(file.path || '');
+      var r = await fetch(url);
+      d = await r.json();
+      if (!r.ok) throw new Error(d.error || ('http ' + r.status));
+    }
     var content = d.content || '';
     var sizeStr = (d.size >= 1024 ? (d.size / 1024).toFixed(1) + 'K' : d.size + 'B');
     var mstr = d.mtime ? new Date(d.mtime * 1000).toLocaleString() : '';
@@ -26117,23 +26149,38 @@ async function cmRuntimeOpenFile(clickEl, runtimeId, gi, fi) {
   }
 }
 
-// Hook into tab switches so the chip bars mount on first paint.
+// Hooks: apply the right view (native vs browser) when the user opens the
+// tab AND when the global runtime selection changes while the tab is open.
 (function _cmRuntimeInstallHooks() {
   var origSwitchTab = (typeof switchTab === 'function') ? switchTab : null;
-  if (!origSwitchTab || origSwitchTab._cmRuntimeWrapped) return;
-  var wrapped = function(name) {
-    var out = origSwitchTab.apply(this, arguments);
-    try {
-      if (name === 'memory') {
-        cmRuntimeMountChips(document.getElementById('memory-runtime-chips'));
-      } else if (name === 'skills') {
-        cmRuntimeMountChips(document.getElementById('skills-runtime-chips'));
-      }
-    } catch (e) {}
-    return out;
-  };
-  wrapped._cmRuntimeWrapped = true;
-  window.switchTab = wrapped;
+  if (origSwitchTab && !origSwitchTab._cmRuntimeWrapped) {
+    var wrapped = function(name) {
+      var out = origSwitchTab.apply(this, arguments);
+      try {
+        if (name === 'memory' || name === 'skills') cmRuntimeApplyView(name);
+      } catch (e) {}
+      return out;
+    };
+    wrapped._cmRuntimeWrapped = true;
+    window.switchTab = wrapped;
+  }
+  // Runtime switch entry point: every runtime change funnels through
+  // _cmApplyRuntimeTabVisibility, so piggyback on it to re-scope an open
+  // Memory/Skills tab without a reload.
+  var origVis = (typeof _cmApplyRuntimeTabVisibility === 'function') ? _cmApplyRuntimeTabVisibility : null;
+  if (origVis && !origVis._cmRuntimeWrapped) {
+    var wrappedVis = function() {
+      var out = origVis.apply(this, arguments);
+      try {
+        var cur = (typeof _cmCurrentTab !== 'undefined') ? _cmCurrentTab : null;
+        if (cur === 'memory' || cur === 'skills') cmRuntimeApplyView(cur);
+      } catch (e) {}
+      return out;
+    };
+    wrappedVis._cmRuntimeWrapped = true;
+    window._cmApplyRuntimeTabVisibility = wrappedVis;
+    _cmApplyRuntimeTabVisibility = wrappedVis;
+  }
 })();
 
 // ═══════════════════════════════════════════════════════════════════════

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -7731,6 +7731,16 @@ def send_heartbeat(config: dict) -> bool:
             payload.setdefault("cache_pushes", []).extend(mem_pushes)
     except Exception as _mp_e:
         log.debug("memory cache_push build failed (continuing): %s", _mp_e)
+    # Multi-runtime Memory & Skills browser: every runtime's on-disk
+    # memory/skills/commands/agents/hooks files, E2E-encrypted, so the
+    # cloud file browser paints real content instead of an empty shell.
+    # Throttled internally (10 min rebuild). Best-effort.
+    try:
+        rtf_pushes = _build_runtime_files_cache_pushes(config)
+        if rtf_pushes:
+            payload.setdefault("cache_pushes", []).extend(rtf_pushes)
+    except Exception as _rtf_e:
+        log.debug("runtime-files cache_push build failed (continuing): %s", _rtf_e)
     # Phase 6 of relay-v2 (#1640): cron-run history per job so the cloud Cron
     # modal paints run timelines from cache instead of showing cache_pending.
     try:
@@ -8481,7 +8491,14 @@ def _build_memory_cache_pushes(config: dict) -> list:
         return []
     try:
         store = local_store.get_store(read_only=True)
-        rows = store.query_memory_blobs(limit=MEMORY_CACHE_LIMIT)
+        # agent_type + agent_id filters matter: memory_blobs also holds
+        # every runtime's catalog files (see _build_runtime_files_cache_
+        # pushes — those rows use agent_id=<category> with absolute paths).
+        # The OpenClaw Memory IDE must only list the workspace-relative
+        # rows the legacy ingest writes under agent_id='main'.
+        rows = store.query_memory_blobs(agent_type="openclaw",
+                                        agent_id="main",
+                                        limit=MEMORY_CACHE_LIMIT)
     except Exception:
         return []
     if not rows:
@@ -8530,6 +8547,160 @@ def _build_memory_cache_pushes(config: dict) -> list:
         "ttl_s":  MEMORY_CACHE_TTL_SEC,
         "blob":   blob,
     }]
+
+
+# ── Runtime files cache push (multi-runtime Memory & Skills browser) ────────
+# The Memory / Skills file browser (clawmetry/runtime_memory.py catalog)
+# resolves where EVERY runtime keeps its on-disk memory, skills, commands,
+# agents and hooks files. Locally the dashboard reads the disk directly via
+# /api/runtimes/<id>/files; on cloud the container has none of those paths,
+# so without this push the browser is an empty shell. Same E2E envelope as
+# the memory push: encrypted blob under
+# ``runtime_files:{owner_hash}:{node_id}:catalog``; the browser holds the
+# key, cloud only stores ciphertext.
+#
+# Decrypted payload shape (consumed by app.js cmRuntimeMountBrowser via the
+# cloud override in clawmetry-cloud/dashboard.py):
+#
+#   {"runtimes": [{"id", "label", "locked", "groups": [
+#       {"category", "root", "label", "scope", "exists",
+#        "files": [{"path", "size", "mtime", "content"}, ...]}]}],
+#    "_shape": "runtime_files"}
+#
+# The full-catalog disk walk is throttled to every RUNTIME_FILES_REBUILD_SEC
+# — these files change slowly and the walk stats hundreds of paths.
+
+RUNTIME_FILES_CACHE_TTL_SEC = 21600     # 6h — matches memory/brain TTL
+RUNTIME_FILES_REBUILD_SEC = 600         # rebuild the blob at most every 10 min
+RUNTIME_FILES_MAX_PER_FILE = 100_000    # per-file content truncation (bytes)
+RUNTIME_FILES_MAX_TOTAL = 2_500_000     # total content budget pre-encryption
+RUNTIME_FILES_MAX_FILES = 500           # across all runtimes
+
+_runtime_files_push_cache: dict = {"ts": 0.0, "pushes": None}
+
+
+def _runtime_locked_for_push(runtime_id: str) -> bool:
+    """Mirror routes/runtime_memory.py:_runtime_is_locked (fall-open)."""
+    try:
+        from clawmetry.entitlements import FREE_RUNTIMES, get_entitlement
+        if runtime_id in FREE_RUNTIMES:
+            return False
+        return not bool(get_entitlement().allows_runtime(runtime_id))
+    except Exception:
+        return False
+
+
+def _build_runtime_files_cache_pushes(config: dict) -> list:
+    """Heartbeat cache_push entry with every runtime's memory/skills files.
+
+    One throttled pass does double duty: it snapshots file contents for the
+    encrypted cloud push AND ingests the same plaintext rows into the local
+    DuckDB store (``memory_blobs`` with ``agent_type=<runtime_id>``,
+    ``agent_id=<category>``) so the moat keeps a queryable copy. Both halves
+    are best-effort; any failure returns ``[]`` and the heartbeat continues.
+    """
+    enc_key = config.get("encryption_key")
+    api_key = config.get("api_key", "")
+    node_id = config.get("node_id", "")
+    if not (enc_key and api_key and node_id):
+        return []
+    now = time.time()
+    cached = _runtime_files_push_cache
+    if cached["pushes"] is not None and now - cached["ts"] < RUNTIME_FILES_REBUILD_SEC:
+        return cached["pushes"]
+    try:
+        from clawmetry.runtime_memory import list_files, list_runtimes, read_runtime_file
+    except Exception:
+        return []
+
+    total_bytes = 0
+    total_files = 0
+    runtimes_out: list = []
+    blob_rows: list = []
+    now_iso = datetime.now(timezone.utc).isoformat()
+    try:
+        catalog = list_runtimes()
+    except Exception:
+        return []
+    for rt in catalog:
+        locked = _runtime_locked_for_push(rt["id"])
+        if not rt.get("present"):
+            continue
+        if locked:
+            # Honest upsell on cloud: the runtime exists on this machine but
+            # the plan doesn't cover it. Label only, no file contents.
+            runtimes_out.append({"id": rt["id"], "label": rt["label"],
+                                 "locked": True, "groups": []})
+            continue
+        try:
+            listing = list_files(rt["id"])
+        except Exception:
+            continue
+        groups_out: list = []
+        for g in listing.get("groups", []):
+            if not g.get("exists"):
+                groups_out.append({k: g[k] for k in
+                                   ("category", "root", "label", "scope", "exists")} | {"files": []})
+                continue
+            files_out: list = []
+            for f in g.get("files", []):
+                if total_files >= RUNTIME_FILES_MAX_FILES or total_bytes >= RUNTIME_FILES_MAX_TOTAL:
+                    break
+                content = ""
+                try:
+                    got = read_runtime_file(rt["id"], g["root"], f.get("path") or "",
+                                            max_bytes=RUNTIME_FILES_MAX_PER_FILE)
+                    if got.get("ok") and not got.get("binary"):
+                        content = got.get("content") or ""
+                except Exception:
+                    content = ""
+                total_files += 1
+                total_bytes += len(content)
+                files_out.append({"path": f.get("path") or "", "size": f.get("size", 0),
+                                  "mtime": f.get("mtime", 0), "content": content})
+                if content:
+                    rel = f.get("path") or ""
+                    blob_rows.append({
+                        "agent_type": rt["id"],
+                        "agent_id": g.get("category") or "memory",
+                        "path": (g["root"] + "/" + rel) if rel else g["root"],
+                        "ts": now_iso,
+                        "blob": content,
+                    })
+            groups_out.append({"category": g.get("category"), "root": g.get("root"),
+                               "label": g.get("label"), "scope": g.get("scope"),
+                               "exists": True, "files": files_out})
+        runtimes_out.append({"id": rt["id"], "label": rt["label"],
+                             "locked": False, "groups": groups_out})
+
+    # Moat: keep the plaintext copy queryable in DuckDB (sha256 dedup in the
+    # store makes re-ingest of unchanged files a no-op).
+    if blob_rows:
+        try:
+            from clawmetry import local_store
+            store = local_store.get_store()
+            for row in blob_rows:
+                store.ingest_memory_blob(row)
+        except Exception as _ie:
+            log.debug("runtime-files DuckDB ingest failed (push continues): %s", _ie)
+
+    if not runtimes_out:
+        _runtime_files_push_cache.update(ts=now, pushes=[])
+        return []
+    payload = {"runtimes": runtimes_out, "_shape": "runtime_files",
+               "_source": "runtime_memory_catalog"}
+    try:
+        blob = encrypt_payload(payload, enc_key)
+    except Exception:
+        return []
+    owner_hash = _owner_hash_for_token(api_key)
+    pushes = [{
+        "key":    f"runtime_files:{owner_hash}:{node_id}:catalog",
+        "ttl_s":  RUNTIME_FILES_CACHE_TTL_SEC,
+        "blob":   blob,
+    }]
+    _runtime_files_push_cache.update(ts=now, pushes=pushes)
+    return pushes
 
 
 # ── Crons list cache push (cloud#948 — Crons tab fix) ───────────────────────

--- a/clawmetry/templates/tabs/memory.html
+++ b/clawmetry/templates/tabs/memory.html
@@ -4,7 +4,8 @@
       <div style="font-size:18px;font-weight:700;color:var(--text-primary);" data-i18n="memory.title">Memory</div>
       <div style="font-size:12px;color:var(--text-muted);margin-top:4px;" data-i18n="memory.subtitle">Markdown files your agent reads and updates. Edit them too if you want.</div>
     </div>
-    <div id="memory-runtime-chips" data-tab="memory" data-category="memory" style="display:flex;gap:6px;flex-wrap:wrap;align-items:center;max-width:60%;"></div>
+    {# Runtime scoping comes from the global runtime switcher — no second
+       picker inside the tab (founder call 2026-08-14). #}
     <div style="display:flex;gap:6px;align-items:center;">
       <div class="mem-view-tab" data-view="summary" onclick="memorySwitchView('summary')" style="padding:6px 14px;border-radius:6px;font-size:12px;font-weight:600;cursor:pointer;background:var(--bg-secondary);border:1px solid var(--border-primary);color:var(--text-primary);" data-i18n="memory.view_summary">Summary</div>
       <div class="mem-view-tab" data-view="all" onclick="memorySwitchView('all')" style="padding:6px 14px;border-radius:6px;font-size:12px;font-weight:600;cursor:pointer;background:transparent;border:1px solid transparent;color:var(--text-muted);" data-i18n="memory.view_all_files">All files</div>

--- a/clawmetry/templates/tabs/skills.html
+++ b/clawmetry/templates/tabs/skills.html
@@ -9,7 +9,8 @@
       <button class="refresh-btn" onclick="loadSkills()">↻ <span data-i18n="common.refresh">Refresh</span></button>
     </div>
   </div>
-  <div id="skills-runtime-chips" data-tab="skills" data-category="skills" style="display:flex;gap:6px;flex-wrap:wrap;align-items:center;margin:10px 0 4px 0;"></div>
+  {# Runtime scoping comes from the global runtime switcher — no second
+     picker inside the tab (founder call 2026-08-14). #}
   <div id="skills-runtime-browser" class="runtime-file-browser" data-tab="skills" data-category="skills" style="display:none;"></div>
   <div id="skills-summary-row" style="display:flex;gap:12px;flex-wrap:wrap;margin:14px 0 16px 0;"></div>
   <div id="skills-list"><div style="color:var(--text-muted);font-size:13px;padding:16px;" data-i18n="app.loading">Loading...</div></div>

--- a/tests/test_runtime_files_cache_push.py
+++ b/tests/test_runtime_files_cache_push.py
@@ -1,0 +1,206 @@
+"""Tests for the multi-runtime file-catalog heartbeat cache push.
+
+``_build_runtime_files_cache_pushes`` (clawmetry/sync.py) is what makes the
+Memory / Skills file browser real on cloud: it snapshots every present
+runtime's memory/skills/commands/agents/hooks files from the
+``clawmetry.runtime_memory`` catalog, E2E-encrypts them under
+``runtime_files:{owner_hash}:{node}:catalog`` and rides the heartbeat.
+Without it the cloud browser is an empty shell (founder: "vaporware").
+
+Covers:
+  1. Happy path: present runtime → push entry, key/ttl shape, decrypted
+     payload holds groups + inline file contents.
+  2. Locked paid runtime → label-only stub (honest upsell, no contents).
+  3. Absent runtime → excluded entirely.
+  4. No encryption key → no push (never plaintext).
+  5. Moat side-effect: the same pass ingests plaintext rows into DuckDB
+     ``memory_blobs`` with agent_type=<runtime>, agent_id=<category> —
+     and the legacy OpenClaw memory push does NOT pick those rows up.
+  6. Throttle: rebuilds are cached for RUNTIME_FILES_REBUILD_SEC.
+"""
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+
+import pytest
+
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+
+FAKE_CATALOG = [
+    {"id": "claude_code", "label": "Claude Code", "present": True,
+     "counts": {"memory": 1, "skills": 1}, "roots": []},
+    {"id": "cursor", "label": "Cursor", "present": True,
+     "counts": {"memory": 1}, "roots": []},
+    {"id": "codex", "label": "Codex", "present": False,
+     "counts": {}, "roots": []},
+]
+
+FAKE_LISTINGS = {
+    "claude_code": {
+        "runtime": "claude_code", "label": "Claude Code",
+        "groups": [
+            {"category": "memory", "root": "/home/u/.claude/CLAUDE.md",
+             "label": "Global CLAUDE.md", "scope": "global", "exists": True,
+             "files": [{"path": "", "size": 24, "mtime": 1755000000}]},
+            {"category": "skills", "root": "/home/u/.claude/skills",
+             "label": "Global skills", "scope": "global", "exists": True,
+             "files": [{"path": "review/SKILL.md", "size": 30, "mtime": 1755000001}]},
+            {"category": "commands", "root": "/home/u/.claude/commands",
+             "label": "Global slash commands", "scope": "global", "exists": False,
+             "files": []},
+        ],
+    },
+    "cursor": {
+        "runtime": "cursor", "label": "Cursor",
+        "groups": [
+            {"category": "memory", "root": "/home/u/.cursor/rules",
+             "label": "Rules", "scope": "global", "exists": True,
+             "files": [{"path": "main.mdc", "size": 12, "mtime": 1755000002}]},
+        ],
+    },
+}
+
+FAKE_CONTENTS = {
+    ("/home/u/.claude/CLAUDE.md", ""): "# CLAUDE.md\nglobal memory\n",
+    ("/home/u/.claude/skills", "review/SKILL.md"): "# review skill\ndo reviews\n",
+    ("/home/u/.cursor/rules", "main.mdc"): "cursor rules\n",
+}
+
+
+@pytest.fixture
+def sync_with_fake_catalog(tmp_path, monkeypatch):
+    """Reload sync + local_store against a fresh DuckDB and monkeypatch the
+    runtime_memory catalog to a deterministic fake (no real disk walk).
+    ``cursor`` is made to look entitlement-locked. Yields (sync, config)."""
+    monkeypatch.setenv(
+        "CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb")
+    )
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_BATCH", "1")
+
+    sys.modules.pop("clawmetry.local_store", None)
+    sys.modules.pop("clawmetry.sync", None)
+
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    # A real daemon on the dev machine would otherwise turn get_store()
+    # into a _ProxyStore aimed at the daemon's DB (see test_detectors.py).
+    ls.mark_writer_owner()
+    import clawmetry.sync as s
+    importlib.reload(s)
+
+    import clawmetry.runtime_memory as rm
+    monkeypatch.setattr(rm, "list_runtimes", lambda: [dict(r) for r in FAKE_CATALOG])
+    monkeypatch.setattr(
+        rm, "list_files",
+        lambda rt, category=None: FAKE_LISTINGS.get(
+            rt, {"runtime": rt, "label": rt, "groups": []}),
+    )
+
+    def _fake_read(rt, root, path, max_bytes=100_000):
+        content = FAKE_CONTENTS.get((root, path))
+        if content is None:
+            return {"ok": False, "error": "not a file", "status": 404}
+        return {"ok": True, "path": path, "content": content,
+                "size": len(content), "mtime": 1755000000,
+                "language": "markdown", "binary": False}
+
+    monkeypatch.setattr(rm, "read_runtime_file", _fake_read)
+    monkeypatch.setattr(
+        s, "_runtime_locked_for_push", lambda rt_id: rt_id == "cursor")
+    # Fresh throttle cache per test.
+    s._runtime_files_push_cache.update(ts=0.0, pushes=None)
+
+    config = {
+        "node_id":        "node-rtf-test",
+        "api_key":        "cm_rtf_test_token",
+        "encryption_key": s.generate_encryption_key(),
+    }
+    yield s, config
+
+
+def _decrypt(s, pushes, config):
+    return s.decrypt_payload(pushes[0]["blob"], config["encryption_key"])
+
+
+def test_push_key_ttl_and_shape(sync_with_fake_catalog):
+    s, config = sync_with_fake_catalog
+    pushes = s._build_runtime_files_cache_pushes(config)
+    assert len(pushes) == 1
+    owner_hash = s._owner_hash_for_token(config["api_key"])
+    assert pushes[0]["key"] == f"runtime_files:{owner_hash}:node-rtf-test:catalog"
+    assert pushes[0]["ttl_s"] == s.RUNTIME_FILES_CACHE_TTL_SEC
+    payload = _decrypt(s, pushes, config)
+    assert payload["_shape"] == "runtime_files"
+    ids = [r["id"] for r in payload["runtimes"]]
+    assert "claude_code" in ids
+    cc = [r for r in payload["runtimes"] if r["id"] == "claude_code"][0]
+    mem = [g for g in cc["groups"] if g["category"] == "memory"][0]
+    assert mem["files"][0]["content"] == "# CLAUDE.md\nglobal memory\n"
+    skills = [g for g in cc["groups"] if g["category"] == "skills"][0]
+    assert skills["files"][0]["path"] == "review/SKILL.md"
+    assert "do reviews" in skills["files"][0]["content"]
+    # Absent group still listed (exists=False, no files) so the UI can show
+    # the "looked here" hint.
+    cmds = [g for g in cc["groups"] if g["category"] == "commands"][0]
+    assert cmds["exists"] is False and cmds["files"] == []
+
+
+def test_locked_runtime_is_label_only_stub(sync_with_fake_catalog):
+    s, config = sync_with_fake_catalog
+    payload = _decrypt(s, s._build_runtime_files_cache_pushes(config), config)
+    cur = [r for r in payload["runtimes"] if r["id"] == "cursor"][0]
+    assert cur["locked"] is True
+    assert cur["groups"] == []
+    # No cursor content anywhere in the payload.
+    import json
+    assert "cursor rules" not in json.dumps(payload)
+
+
+def test_absent_runtime_excluded(sync_with_fake_catalog):
+    s, config = sync_with_fake_catalog
+    payload = _decrypt(s, s._build_runtime_files_cache_pushes(config), config)
+    assert "codex" not in [r["id"] for r in payload["runtimes"]]
+
+
+def test_no_encryption_key_no_push(sync_with_fake_catalog):
+    s, config = sync_with_fake_catalog
+    config = dict(config, encryption_key=None)
+    assert s._build_runtime_files_cache_pushes(config) == []
+
+
+def test_moat_ingest_and_legacy_memory_push_isolation(sync_with_fake_catalog):
+    s, config = sync_with_fake_catalog
+    s._build_runtime_files_cache_pushes(config)
+    from clawmetry import local_store
+    store = local_store.get_store()
+    rows = store.query_memory_blobs(agent_type="claude_code")
+    assert rows, "runtime files must land in memory_blobs (moat)"
+    by_id = {r["agent_id"] for r in rows}
+    assert by_id <= {"memory", "skills", "commands", "agents", "hooks"}
+    # The legacy OpenClaw memory push must not pick these rows up.
+    mem_pushes = s._build_memory_cache_pushes(config)
+    if mem_pushes:  # empty store for openclaw/main → usually []
+        decoded = s.decrypt_payload(mem_pushes[0]["blob"], config["encryption_key"])
+        paths = [f["path"] for f in decoded["memory_content"]]
+        assert not any("/.claude/" in p for p in paths)
+
+
+def test_rebuild_throttled(sync_with_fake_catalog, monkeypatch):
+    s, config = sync_with_fake_catalog
+    first = s._build_runtime_files_cache_pushes(config)
+    assert first
+    import clawmetry.runtime_memory as rm
+
+    def _boom():
+        raise AssertionError("catalog re-walked inside throttle window")
+
+    monkeypatch.setattr(rm, "list_runtimes", _boom)
+    second = s._build_runtime_files_cache_pushes(config)
+    assert second == first


### PR DESCRIPTION
Follow-through on today's founder feedback (duplicate runtime picker, dead file clicks, Skills mirroring Memory, nothing syncing on cloud). Full write-up in the commit message; the short version:

- **One runtime picker**: chip bars removed; Memory/Skills scope to the global runtime selection and re-scope live on switch. `memory`/`skills` leave `_CM_RT_NODEWIDE` (banner stopped lying).
- **File clicks fixed**: tree indices now resolve against the filtered groups they were rendered from (previously off-by-absent-groups → wrong root → dead clicks).
- **Skills ≠ Memory**: per-tab category split (memory vs skills+commands+agents+hooks).
- **Cloud data path**: daemon pushes an E2E-encrypted per-runtime file catalog (contents inline, bounded) on heartbeat; browser decrypts client-side via a cloud-installed override; same pass ingests into DuckDB `memory_blobs` for the moat. Legacy OpenClaw memory push gains agent_type/agent_id filters so the flows stay isolated.

Cloud halves (route + JS override) ship in clawmetry-cloud with the pin PR.

New tests: `tests/test_runtime_files_cache_push.py` (6 green). Known-red locally-only: `test_memory_cache_push.py` (pre-existing daemon-proxy env issue, green in CI), `test_beginner_nav_phase_a.py::test_developer_drawer_membership` (pre-existing `tracing` drift on main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)