### PR TITLE
Derive the advertised runtime count from the entitlement catalogue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,14 @@ jobs:
       - name: Lint (warnings only, don't fail)
         run: ruff check dashboard.py --select E,W --ignore E501,W503 || true
 
+      # The advertised runtime count lives in prose across the README, its
+      # translations, FLYWHEEL.md, the CLI and the desktop copy, and every one
+      # of those drifted from the catalogue before this guard existed
+      # (2026-08-15: catalogue 20, README 14, PyPI 12). setup.py derives the
+      # PyPI summary; this keeps the rest honest.
+      - name: Runtime count matches the entitlement catalogue
+        run: python3 scripts/sync_runtime_count.py --check
+
       # Silent-CLI class guard (#3791): rebinding sys.stdout/sys.stderr to a
       # new TextIOWrapper over the same buffer orphans the previous wrapper;
       # its GC finalizer closes the SHARED buffer, and every later print(),
@@ -226,6 +234,7 @@ jobs:
             tests/test_channel_event_chokepoint.py \
             tests/test_no_direct_get_store_in_routes.py \
             tests/test_moat_bug_class_v3_event_shape_gate.py \
+            tests/test_runtime_count_copy_sync.py \
             tests/test_local_query_api.py \
             tests/test_local_query_dispatch_edge_cases.py \
             tests/test_query_contract_drift.py \

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -39,7 +39,7 @@ C4Context
 title C1: ClawMetry (open source) system context
 
 Person(dev, "Developer / Operator", "Runs AI agents; wants to see what they do and what they cost")
-System(clawmetry, "ClawMetry", "Local-first, real-time observability for 12 agent runtimes. Reads what your agents already write; never modifies them.")
+System(clawmetry, "ClawMetry", "Local-first, real-time observability for 20 agent runtimes. Reads what your agents already write; never modifies them.")
 
 System_Ext(runtimes, "AI Agent Runtimes", "OpenClaw + NVIDIA NemoClaw (free in OSS) and, with the optional Pro plugin, Claude Code, Codex, Cursor, Goose, Hermes, Aider, NanoClaw, opencode, PicoClaw, Qwen Code")
 System_Ext(gateway, "OpenClaw Gateway", "WebSocket control plane (JSON-RPC, :18789) for live data + cron RPC")

--- a/AUDIT.md
+++ b/AUDIT.md
@@ -18,7 +18,7 @@
 ## Audit method (the only valid "pass")
 1. Walk the trial path: hosted dashboard as a trial user, switch runtimes, click the tab → zero blank/wrong/error states + clean console.
 2. For data/observability features: send a **real** message/turn and watch it travel channel → daemon → DuckDB → handler → rendered tab → (cloud) snapshot.
-3. Verify across **all 12 runtimes**, not just OpenClaw (`/api/runtimes`).
+3. Verify across **all 20 runtimes**, not just OpenClaw (`/api/runtimes`).
 4. For device-facing slices: the 4-repo chain (pro adapter → OSS `_build_device_summary` → cloud wheel/relay → firmware render).
 
 ---

--- a/FLYWHEEL.md
+++ b/FLYWHEEL.md
@@ -26,10 +26,10 @@ The north star: **don't stop at "code compiles." Stop at "verified working in pr
 > - **Before adding any poller/fetch, ask:** does this need to run on *every* tab? every *N* seconds? can it reuse an existing fetch or the snapshot?
 > - **Measure before shipping:** open the Network panel / Resource Timing and confirm no endpoint is fetched N× per cycle and no background poller fires off its own screen. "It works" is not enough — "it works without a request storm" is the bar.
 
-> ## Multi-runtime: ClawMetry observes 12 agent runtimes, not just OpenClaw (non-negotiable)
-> **ClawMetry is runtime-neutral. It observes 12 AI agent runtimes, not OpenClaw alone.** Free on every plan: **OpenClaw, NVIDIA NemoClaw**. Also supported: **Aider, Claude Code, Codex, Cursor, Goose, Hermes, NanoClaw, opencode, PicoClaw, Qwen Code**. The enabled set is live at `GET /api/runtimes` (authed); read it, never hardcode a stale copy.
+> ## Multi-runtime: ClawMetry observes 20 agent runtimes, not just OpenClaw (non-negotiable)
+> **ClawMetry is runtime-neutral. It observes 20 AI agent runtimes, not OpenClaw alone.** Free on every plan: **OpenClaw, NVIDIA NemoClaw**. Also supported: **Aider, Antigravity, Claude Code, Codex, Cursor, Deep Agents, DeepSeek Harness, GitHub Copilot, Goose, Grok, Hermes, n8n, NanoClaw, opencode, Pi, PicoClaw, QM, Qwen Code**. The enabled set is live at `GET /api/runtimes` (authed); read it, never hardcode a stale copy. The *count* in prose is derived from `FREE_RUNTIMES | PAID_RUNTIMES` and enforced by `scripts/sync_runtime_count.py` (see section 2a).
 > - **User-facing copy and UI must never imply OpenClaw-only.** Framing like "designed for OpenClaw agents", "your OpenClaw machine", "No OpenClaw detected", or "Looking for OpenClaw activity" is a bug. Use runtime-neutral language ("your AI agent", "the machine your agent runs on") or name the runtimes ("OpenClaw, NVIDIA NemoClaw + 10 more runtimes", matching the homepage install card). Naming runtimes is public; pricing and tier internals stay private.
-> - **Verify across all 12 runtimes, end to end.** Never ship a change verified only on OpenClaw. Use a `/workflow` to fan out a per-runtime E2E check: one agent per runtime that installs or configures it, runs a real turn, and asserts it lands correctly (in Brain by agent_type, in the right tab, with cost and tokens). "Works on OpenClaw" is not "works".
+> - **Verify across all 20 runtimes, end to end.** Never ship a change verified only on OpenClaw. Use a `/workflow` to fan out a per-runtime E2E check: one agent per runtime that installs or configures it, runs a real turn, and asserts it lands correctly (in Brain by agent_type, in the right tab, with cost and tokens). "Works on OpenClaw" is not "works".
 > Burned 2026-06-01: the docs FAQ said "ClawMetry is designed for OpenClaw agents" and the cloud empty-states plus the radar assumed OpenClaw-only. Many surfaces still need this sweep; when you touch a screen, fix its runtime framing.
 
 ---
@@ -155,6 +155,32 @@ Separately, **check [Pending Work Orders](https://factory.8090.ai) regularly**, 
 - Match surrounding style: `snake_case` funcs, minimal deps (Flask + waitress + cryptography), never crash on bad input (graceful fallbacks + a logged warning).
 - **No em-dashes (`—`, U+2014), no double-dashes (`--`), no `X, Y, and Z [emdash] coda` pattern in user-facing copy.** That pattern is an AI-tell, and the user has explicitly banned it. Applies to: landing HTML, dashboard banners, marketing copy, blog posts, CHANGELOG release entries, bounty and job posts (incl. external platforms like rentahuman.ai), public docs, email templates, modal copy, and any PR description users see. Allowed in: code comments, internal notes in `docs/`, commit messages, and internal-only PR bodies. Use a comma, parenthetical, colon, or full stop instead. **Belt-and-braces:** before sending any user-facing text (a PR via someone else's API, a CHANGELOG entry, landing copy, modal text), grep the payload for `—` or `--` and refuse to send if matched. Burned twice: 2026-05-26 on landing PR #211 (em-dashes in marketing copy), 2026-05-28 on the rentahuman.ai bounty redraft (em-dashes everywhere despite the rule being in memory, so the user had to re-flag it).
 - **Keep business internals out of this public repo.** This repo is public — investors, competitors, and prospective hires browse it. Any doc with live revenue/MRR/funnel/conversion numbers or monetization/pricing strategy (conversion roadmaps, conversion PRDs, pricing analysis) goes in **`clawmetry-cloud/docs/` (private), NEVER `clawmetry/docs/`**. Same rule as `[intel/*]` issues. Before creating any doc, ask: would this leak positioning, lead pipeline, or revenue if a competitor read it? If yes → private repo. (Burned 2026-05-26: a conversion roadmap + PRDs with the real paying-customer/MRR funnel were written into public `docs/` and had to be relocated.)
+
+## 2a. Adding a runtime: the count is derived, never hand-edited
+
+`FREE_RUNTIMES | PAID_RUNTIMES` in `clawmetry/entitlements.py` is the **only**
+place the supported-runtime set is declared. Everything that quotes a number
+hangs off it:
+
+| Surface | How it stays true |
+|---|---|
+| PyPI summary (`setup.py`) | **Derived.** `setup.py` parses `entitlements.py` at build time, so it cannot drift. |
+| README, translations, FLYWHEEL, ARCHITECTURE, AUDIT, CLI, desktop onboarding, device page | **Rewritten** by `python3 scripts/sync_runtime_count.py`. |
+| All of the above | **Enforced** by `tests/test_runtime_count_copy_sync.py`, which fails CI on drift. Also runs via `make lint`. |
+| Landing pages, GitHub repo description | **Not covered by this repo's CI.** Update `clawmetry-landing` and `gh repo edit --description` by hand in the same sprint. |
+
+So the loop when a runtime lands is: add it to `PAID_RUNTIMES` (or `FREE_RUNTIMES`),
+add its label to `RUNTIME_LABELS`, add it to the README grid, then run
+`python3 scripts/sync_runtime_count.py` and commit what it rewrites.
+
+If a number in prose legitimately is *not* the supported-runtime count (a free-tier
+count, a dated research note, a capacity estimate), add it to `EXEMPT` in the script
+with the reason. Do not reword the prose to dodge the regex.
+
+Burned 2026-08-15: the catalogue said 20 while the README said 14, PyPI said 12, and
+FLYWHEEL said 12, across 27 stale mentions in 16 files. Maintainers of external lists
+click through, and a PyPI page contradicting the homepage is the kind of thing that
+gets a submission closed.
 
 ## 3. Verify locally BEFORE the PR (the loop that actually catches bugs)
 

--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ moat-check:
 moat-check-drive:
 	@python3 scripts/accuracy_harness/keystone_e2e.py
 
-lint: lint-py lint-js lint-daemon-allowlist
+lint: lint-py lint-js lint-daemon-allowlist lint-runtime-count
 
 # Issue #1267: every `local_store_via_daemon("X")` / `_ls_call("X")` call
 # in routes/ must reference a method that's in the daemon's allowlist
@@ -87,6 +87,11 @@ lint: lint-py lint-js lint-daemon-allowlist
 # legacy paths; surfaced as 6 s timeouts).
 lint-daemon-allowlist:
 	@python3 scripts/lint_daemon_allowlist.py
+
+# The advertised runtime count must match FREE_RUNTIMES | PAID_RUNTIMES.
+# Fix drift with: python3 scripts/sync_runtime_count.py
+lint-runtime-count:
+	@python3 scripts/sync_runtime_count.py --check
 
 lint-py:
 	python3 -c "import ast; ast.parse(open('dashboard.py').read()); print('Python syntax OK')"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 <a href="https://www.producthunt.com/products/clawmetry?embed=true&utm_source=badge-top-post-badge&utm_medium=badge&utm_campaign=badge-clawmetry-for-openclaw" target="_blank"><img src="https://api.producthunt.com/widgets/embed-image/v1/top-post-badge.svg?post_id=1081207&theme=light&period=daily&t=1771491508782" alt="ClawMetry - #5 Product of the Day on Product Hunt" width="250" height="54" /></a>
 
-**See your agent think.** Real-time observability for **14 AI agent runtimes**: [OpenClaw](https://github.com/openclaw/openclaw), [NVIDIA NemoClaw](https://github.com/NVIDIA/NemoClaw), Claude Code, OpenAI Codex & 10 more. One dashboard for your whole agent fleet.
+**See your agent think.** Real-time observability for **20 AI agent runtimes**: [OpenClaw](https://github.com/openclaw/openclaw), [NVIDIA NemoClaw](https://github.com/NVIDIA/NemoClaw), Claude Code, OpenAI Codex & 16 more. One dashboard for your whole agent fleet.
 
 > 🌐 **Read this in:** [English](README.md) · [简体中文](docs/i18n/zh-CN/README.md) · [日本語](docs/i18n/ja/README.md) · [한국어](docs/i18n/ko/README.md) · [Español](docs/i18n/es/README.md) · [Português (BR)](docs/i18n/pt-BR/README.md) · [Français](docs/i18n/fr/README.md) · [Deutsch](docs/i18n/de/README.md) · [हिन्दी](docs/i18n/hi/README.md) · [العربية](docs/i18n/ar/README.md) · [Русский](docs/i18n/ru/README.md) · [more →](docs/i18n/)
 
@@ -22,11 +22,11 @@ Opens at **http://localhost:8900** and you're done.
 
 ![Flow Visualization](https://clawmetry.com/screenshots/flow.png)
 
-## Works with 14 agent runtimes
+## Works with 20 agent runtimes
 
 ClawMetry started as observability for OpenClaw, and now meters your **whole agent fleet** in one dashboard, auto-detecting each runtime on your machine:
 
-🦞 **OpenClaw** · 🟩 **NVIDIA NemoClaw** · ◆ **Claude Code** · ⬡ **OpenAI Codex** · **Cursor** · 🪿 **Goose** · ⚡ **Hermes** · **opencode** · ◈ **Qwen Code** · **Aider** · **NanoClaw** · **PicoClaw** · **Pi** · **Deep Agents** · 🔗 **n8n** · 🪐 **Antigravity** · 🐙 **GitHub Copilot** · **Grok** · **QM**
+🦞 **OpenClaw** · 🟩 **NVIDIA NemoClaw** · ◆ **Claude Code** · ⬡ **OpenAI Codex** · **Cursor** · 🪿 **Goose** · ⚡ **Hermes** · **opencode** · ◈ **Qwen Code** · **Aider** · **NanoClaw** · **PicoClaw** · **Pi** · **Deep Agents** · 🔗 **n8n** · 🪐 **Antigravity** · 🐙 **GitHub Copilot** · **Grok** · **QM** · 🐋 **DeepSeek Harness**
 
 OpenClaw and NemoClaw are free in the open-source app; the other runtimes light up with ClawMetry Cloud or a self-hosted Pro license. Switch runtimes from the header and every tab — cost, tokens, tools, traces — re-scopes to that runtime. See **[docs/ENTITLEMENTS.md](docs/ENTITLEMENTS.md)** for the exact free/paid split, tier matrix, `/api/entitlement` shape, and the `clawmetry license` CLI.
 

--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -1283,7 +1283,7 @@ def _cmd_connect(args) -> None:
         from clawmetry.license import auto_provision_pro
         _pro_installed, _pro_msg = auto_provision_pro(api_key, node_id)
         if _pro_installed:
-            print("  Pro adapters installed - all 14 runtimes available.")
+            print("  Pro adapters installed - all 20 runtimes available.")
         elif _pro_msg:
             # Entitled but the wheel could not be installed right now; surface a
             # quiet hint without alarming the user (connect still succeeded).
@@ -3883,7 +3883,7 @@ def _cmd_onboard(args) -> None:
     print()
     print(f"  {BOLD('Plans')} {DIM('(same either way; each tier includes the one before):')}")
     print(f"    {DIM('Free    $0          watch OpenClaw + NVIDIA NemoClaw, forever')}")
-    print(f"    {DIM('Starter $9/node/mo  everything in Free + observability for all 14 runtimes')}")
+    print(f"    {DIM('Starter $9/node/mo  everything in Free + observability for all 20 runtimes')}")
     print(f"    {DIM('Pro    $19/node/mo  everything in Starter + governance (alerts, approvals, evals)')}")
     print()
     print(f"  {BOLD('How do you want to run ClawMetry?')}")

--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -104,6 +104,15 @@ PAID_RUNTIMES = frozenset(
 
 ALL_RUNTIMES = FREE_RUNTIMES | PAID_RUNTIMES
 
+# The number quoted in user-facing copy ("observability for N agent
+# runtimes"). Derived here so there is exactly one place to change when a
+# runtime lands. ``setup.py`` parses this file for it (so the PyPI summary
+# cannot drift), ``scripts/sync_runtime_count.py`` rewrites every other
+# surface from it, and ``tests/test_runtime_count_copy_sync.py`` fails CI
+# if any surface disagrees. Burned 2026-08-15: README said 14, PyPI said
+# 12, FLYWHEEL said 12, the catalogue said 20.
+RUNTIME_COUNT = len(ALL_RUNTIMES)
+
 # Display labels for every known runtime.
 RUNTIME_LABELS = {
     "openclaw": "OpenClaw",

--- a/clawmetry/license.py
+++ b/clawmetry/license.py
@@ -677,7 +677,7 @@ def _download_and_install_pro(payload: dict) -> str:
 def auto_provision_pro(api_key: str, node_id: str | None = None) -> tuple[bool, str]:
     """CLOUD ACCOUNT path, called by ``clawmetry connect`` after the cm_ key is
     saved. Ask the cloud whether this account is ENTITLED to clawmetry-pro and,
-    if so, download+install the wheel so the node gets all 14 runtimes.
+    if so, download+install the wheel so the node gets all 20 runtimes.
 
     HARD RULES enforced here:
       * Pro is installed ONLY for an entitled plan (Starter/Pro/Trial/

--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -25316,7 +25316,7 @@ function clearSwimlaneLanes() {
 }
 
 // One-click preset: most-recent session per distinct runtime (cap 4). This is
-// the headline demo path — the 14 runtimes side by side. Respects the global
+// the headline demo path — the 20 runtimes side by side. Respects the global
 // runtime switcher: when scoped to one runtime, only that runtime is picked.
 function swimlanePresetPerRuntime() {
   var rtFilter = (typeof _cmRuntimeFilter === 'function') ? _cmRuntimeFilter() : 'all';

--- a/clawmetry/templates/tabs/gateway.html
+++ b/clawmetry/templates/tabs/gateway.html
@@ -4,7 +4,7 @@
   Replaces the old "ClawMetry Setup" wizard that used to force itself open
   on every dashboard load regardless of whether the user actually runs
   OpenClaw (v0.1-era UX, from back when OpenClaw was the only runtime
-  ClawMetry watched). Now that the product detects 17+ runtimes, most
+  ClawMetry watched). Now that the product detects 20+ runtimes, most
   installs never touch this page — first-run onboarding (managed cloud vs
   self-host) is handled by onboarding.js instead. This page just gives real
   OpenClaw users a place to paste their gateway token, same endpoint

--- a/desktop/onboarding.py
+++ b/desktop/onboarding.py
@@ -482,7 +482,7 @@ CROSS_SELL_SLIDES = [
         "eyebrow": "You just installed ClawMetry.",
         "title": "Every AI agent on this machine, in one dashboard.",
         "body": (
-            "Watch spend, sessions, and errors across 14+ runtimes in real time. "
+            "Watch spend, sessions, and errors across 20+ runtimes in real time. "
             "Cost breakdowns per model, per skill, per session. Loop detection. "
             "Budget alerts. All read-only, all local, all yours."
         ),

--- a/docs/i18n/el/README.md
+++ b/docs/i18n/el/README.md
@@ -11,7 +11,7 @@
 
 <a href="https://www.producthunt.com/products/clawmetry?embed=true&utm_source=badge-top-post-badge&utm_medium=badge&utm_campaign=badge-clawmetry-for-openclaw" target="_blank"><img src="https://api.producthunt.com/widgets/embed-image/v1/top-post-badge.svg?post_id=1081207&theme=light&period=daily&t=1771491508782" alt="ClawMetry - #5 Product of the Day on Product Hunt" width="250" height="54" /></a>
 
-**Δες τον agent σου να σκέφτεται.** Παρατήρηση σε πραγματικό χρόνο για **14 AI agent runtimes**: [OpenClaw](https://github.com/openclaw/openclaw), [NVIDIA NemoClaw](https://github.com/NVIDIA/NemoClaw), Claude Code, OpenAI Codex και 10 ακόμα. Ένα dashboard για ολόκληρο τον στόλο agents σου.
+**Δες τον agent σου να σκέφτεται.** Παρατήρηση σε πραγματικό χρόνο για **20 AI agent runtimes**: [OpenClaw](https://github.com/openclaw/openclaw), [NVIDIA NemoClaw](https://github.com/NVIDIA/NemoClaw), Claude Code, OpenAI Codex και 10 ακόμα. Ένα dashboard για ολόκληρο τον στόλο agents σου.
 
 > 🌐 **Διάβασέ το στα:** [English](README.md) · [简体中文](docs/i18n/zh-CN/README.md) · [日本語](docs/i18n/ja/README.md) · [한국어](docs/i18n/ko/README.md) · [Español](docs/i18n/es/README.md) · [Português (BR)](docs/i18n/pt-BR/README.md) · [Français](docs/i18n/fr/README.md) · [Deutsch](docs/i18n/de/README.md) · [हिन्दी](docs/i18n/hi/README.md) · [العربية](docs/i18n/ar/README.md) · [Русский](docs/i18n/ru/README.md) · [περισσότερα →](docs/i18n/)
 
@@ -25,7 +25,7 @@ pip install clawmetry && clawmetry
 
 ![Flow Visualization](https://clawmetry.com/screenshots/flow.png)
 
-## Λειτουργεί με 14 agent runtimes
+## Λειτουργεί με 20 agent runtimes
 
 Το ClawMetry ξεκίνησε ως παρατήρηση για το OpenClaw, και τώρα μετράει ολόκληρο τον **στόλο agents** σου σε ένα dashboard, ανιχνεύοντας αυτόματα κάθε runtime στο μηχάνημά σου:
 

--- a/docs/i18n/es-419/README.md
+++ b/docs/i18n/es-419/README.md
@@ -11,7 +11,7 @@
 
 <a href="https://www.producthunt.com/products/clawmetry?embed=true&utm_source=badge-top-post-badge&utm_medium=badge&utm_campaign=badge-clawmetry-for-openclaw" target="_blank"><img src="https://api.producthunt.com/widgets/embed-image/v1/top-post-badge.svg?post_id=1081207&theme=light&period=daily&t=1771491508782" alt="ClawMetry - #5 Product of the Day on Product Hunt" width="250" height="54" /></a>
 
-**Mira pensar a tu agente.** Observabilidad en tiempo real para **14 runtimes de agentes de IA**: [OpenClaw](https://github.com/openclaw/openclaw), [NVIDIA NemoClaw](https://github.com/NVIDIA/NemoClaw), Claude Code, OpenAI Codex y 10 más. Un solo dashboard para toda tu flota de agentes.
+**Mira pensar a tu agente.** Observabilidad en tiempo real para **20 runtimes de agentes de IA**: [OpenClaw](https://github.com/openclaw/openclaw), [NVIDIA NemoClaw](https://github.com/NVIDIA/NemoClaw), Claude Code, OpenAI Codex y 10 más. Un solo dashboard para toda tu flota de agentes.
 
 > 🌐 **Lee esto en:** [English](README.md) · [简体中文](docs/i18n/zh-CN/README.md) · [日本語](docs/i18n/ja/README.md) · [한국어](docs/i18n/ko/README.md) · [Español](docs/i18n/es/README.md) · [Português (BR)](docs/i18n/pt-BR/README.md) · [Français](docs/i18n/fr/README.md) · [Deutsch](docs/i18n/de/README.md) · [हिन्दी](docs/i18n/hi/README.md) · [العربية](docs/i18n/ar/README.md) · [Русский](docs/i18n/ru/README.md) · [más →](docs/i18n/)
 
@@ -25,7 +25,7 @@ Se abre en **http://localhost:8900** y listo.
 
 ![Flow Visualization](https://clawmetry.com/screenshots/flow.png)
 
-## Funciona con 14 runtimes de agentes
+## Funciona con 20 runtimes de agentes
 
 ClawMetry comenzó como observabilidad para OpenClaw, y ahora mide toda tu **flota de agentes** en un solo dashboard, detectando automáticamente cada runtime en tu máquina:
 

--- a/docs/i18n/es/README.md
+++ b/docs/i18n/es/README.md
@@ -11,7 +11,7 @@
 
 <a href="https://www.producthunt.com/products/clawmetry?embed=true&utm_source=badge-top-post-badge&utm_medium=badge&utm_campaign=badge-clawmetry-for-openclaw" target="_blank"><img src="https://api.producthunt.com/widgets/embed-image/v1/top-post-badge.svg?post_id=1081207&theme=light&period=daily&t=1771491508782" alt="ClawMetry - #5 Product of the Day on Product Hunt" width="250" height="54" /></a>
 
-**Observa cómo piensa tu agente.** Observabilidad en tiempo real para **14 runtimes de agentes de IA**: [OpenClaw](https://github.com/openclaw/openclaw), [NVIDIA NemoClaw](https://github.com/NVIDIA/NemoClaw), Claude Code, OpenAI Codex y 10 más. Un solo panel para toda tu flota de agentes.
+**Observa cómo piensa tu agente.** Observabilidad en tiempo real para **20 runtimes de agentes de IA**: [OpenClaw](https://github.com/openclaw/openclaw), [NVIDIA NemoClaw](https://github.com/NVIDIA/NemoClaw), Claude Code, OpenAI Codex y 10 más. Un solo panel para toda tu flota de agentes.
 
 > 🌐 **Lee esto en:** [English](README.md) · [简体中文](docs/i18n/zh-CN/README.md) · [日本語](docs/i18n/ja/README.md) · [한국어](docs/i18n/ko/README.md) · [Español](docs/i18n/es/README.md) · [Português (BR)](docs/i18n/pt-BR/README.md) · [Français](docs/i18n/fr/README.md) · [Deutsch](docs/i18n/de/README.md) · [हिन्दी](docs/i18n/hi/README.md) · [العربية](docs/i18n/ar/README.md) · [Русский](docs/i18n/ru/README.md) · [más →](docs/i18n/)
 
@@ -25,7 +25,7 @@ Se abre en **http://localhost:8900** y listo.
 
 ![Flow Visualization](https://clawmetry.com/screenshots/flow.png)
 
-## Funciona con 14 runtimes de agentes
+## Funciona con 20 runtimes de agentes
 
 ClawMetry comenzó como observabilidad para OpenClaw, y ahora mide **toda tu flota de agentes** en un solo panel, detectando automáticamente cada runtime en tu máquina:
 

--- a/docs/i18n/fr/README.md
+++ b/docs/i18n/fr/README.md
@@ -11,7 +11,7 @@
 
 <a href="https://www.producthunt.com/products/clawmetry?embed=true&utm_source=badge-top-post-badge&utm_medium=badge&utm_campaign=badge-clawmetry-for-openclaw" target="_blank"><img src="https://api.producthunt.com/widgets/embed-image/v1/top-post-badge.svg?post_id=1081207&theme=light&period=daily&t=1771491508782" alt="ClawMetry - #5 Product of the Day on Product Hunt" width="250" height="54" /></a>
 
-**Voyez votre agent penser.** Observabilité en temps réel pour **14 runtimes d'agents IA** : [OpenClaw](https://github.com/openclaw/openclaw), [NVIDIA NemoClaw](https://github.com/NVIDIA/NemoClaw), Claude Code, OpenAI Codex et 10 autres. Un seul tableau de bord pour toute votre flotte d'agents.
+**Voyez votre agent penser.** Observabilité en temps réel pour **20 runtimes d'agents IA** : [OpenClaw](https://github.com/openclaw/openclaw), [NVIDIA NemoClaw](https://github.com/NVIDIA/NemoClaw), Claude Code, OpenAI Codex et 10 autres. Un seul tableau de bord pour toute votre flotte d'agents.
 
 > 🌐 **Lire ceci en :** [English](README.md) · [简体中文](docs/i18n/zh-CN/README.md) · [日本語](docs/i18n/ja/README.md) · [한국어](docs/i18n/ko/README.md) · [Español](docs/i18n/es/README.md) · [Português (BR)](docs/i18n/pt-BR/README.md) · [Français](docs/i18n/fr/README.md) · [Deutsch](docs/i18n/de/README.md) · [हिन्दी](docs/i18n/hi/README.md) · [العربية](docs/i18n/ar/README.md) · [Русский](docs/i18n/ru/README.md) · [plus →](docs/i18n/)
 
@@ -25,7 +25,7 @@ S'ouvre sur **http://localhost:8900** et c'est tout.
 
 ![Flow Visualization](https://clawmetry.com/screenshots/flow.png)
 
-## Compatible avec 14 runtimes d'agents
+## Compatible avec 20 runtimes d'agents
 
 ClawMetry a démarré comme outil d'observabilité pour OpenClaw, et mesure désormais **toute votre flotte d'agents** dans un seul tableau de bord, en détectant automatiquement chaque runtime sur votre machine :
 

--- a/docs/i18n/pt-BR/README.md
+++ b/docs/i18n/pt-BR/README.md
@@ -11,7 +11,7 @@
 
 <a href="https://www.producthunt.com/products/clawmetry?embed=true&utm_source=badge-top-post-badge&utm_medium=badge&utm_campaign=badge-clawmetry-for-openclaw" target="_blank"><img src="https://api.producthunt.com/widgets/embed-image/v1/top-post-badge.svg?post_id=1081207&theme=light&period=daily&t=1771491508782" alt="ClawMetry - #5 Product of the Day on Product Hunt" width="250" height="54" /></a>
 
-**Veja seu agente pensar.** Observabilidade em tempo real para **14 runtimes de agentes de IA**: [OpenClaw](https://github.com/openclaw/openclaw), [NVIDIA NemoClaw](https://github.com/NVIDIA/NemoClaw), Claude Code, OpenAI Codex e mais 10. Um único painel para toda a sua frota de agentes.
+**Veja seu agente pensar.** Observabilidade em tempo real para **20 runtimes de agentes de IA**: [OpenClaw](https://github.com/openclaw/openclaw), [NVIDIA NemoClaw](https://github.com/NVIDIA/NemoClaw), Claude Code, OpenAI Codex e mais 10. Um único painel para toda a sua frota de agentes.
 
 > 🌐 **Leia isto em:** [English](README.md) · [简体中文](docs/i18n/zh-CN/README.md) · [日本語](docs/i18n/ja/README.md) · [한국어](docs/i18n/ko/README.md) · [Español](docs/i18n/es/README.md) · [Português (BR)](docs/i18n/pt-BR/README.md) · [Français](docs/i18n/fr/README.md) · [Deutsch](docs/i18n/de/README.md) · [हिन्दी](docs/i18n/hi/README.md) · [العربية](docs/i18n/ar/README.md) · [Русский](docs/i18n/ru/README.md) · [mais →](docs/i18n/)
 
@@ -25,7 +25,7 @@ Abre em **http://localhost:8900** e pronto.
 
 ![Flow Visualization](https://clawmetry.com/screenshots/flow.png)
 
-## Funciona com 14 runtimes de agentes
+## Funciona com 20 runtimes de agentes
 
 O ClawMetry começou como observabilidade para o OpenClaw, e agora monitora **toda a sua frota de agentes** em um único painel, detectando automaticamente cada runtime na sua máquina:
 

--- a/docs/i18n/pt-PT/README.md
+++ b/docs/i18n/pt-PT/README.md
@@ -11,7 +11,7 @@
 
 <a href="https://www.producthunt.com/products/clawmetry?embed=true&utm_source=badge-top-post-badge&utm_medium=badge&utm_campaign=badge-clawmetry-for-openclaw" target="_blank"><img src="https://api.producthunt.com/widgets/embed-image/v1/top-post-badge.svg?post_id=1081207&theme=light&period=daily&t=1771491508782" alt="ClawMetry - #5 Product of the Day on Product Hunt" width="250" height="54" /></a>
 
-**Veja o seu agente a pensar.** Observabilidade em tempo real para **14 runtimes de agentes de IA**: [OpenClaw](https://github.com/openclaw/openclaw), [NVIDIA NemoClaw](https://github.com/NVIDIA/NemoClaw), Claude Code, OpenAI Codex e mais 10. Um único painel para toda a sua frota de agentes.
+**Veja o seu agente a pensar.** Observabilidade em tempo real para **20 runtimes de agentes de IA**: [OpenClaw](https://github.com/openclaw/openclaw), [NVIDIA NemoClaw](https://github.com/NVIDIA/NemoClaw), Claude Code, OpenAI Codex e mais 10. Um único painel para toda a sua frota de agentes.
 
 > 🌐 **Leia isto em:** [English](README.md) · [简体中文](docs/i18n/zh-CN/README.md) · [日本語](docs/i18n/ja/README.md) · [한국어](docs/i18n/ko/README.md) · [Español](docs/i18n/es/README.md) · [Português (BR)](docs/i18n/pt-BR/README.md) · [Français](docs/i18n/fr/README.md) · [Deutsch](docs/i18n/de/README.md) · [हिन्दी](docs/i18n/hi/README.md) · [العربية](docs/i18n/ar/README.md) · [Русский](docs/i18n/ru/README.md) · [mais →](docs/i18n/)
 
@@ -25,7 +25,7 @@ Abre em **http://localhost:8900** e está pronto.
 
 ![Flow Visualization](https://clawmetry.com/screenshots/flow.png)
 
-## Funciona com 14 runtimes de agentes
+## Funciona com 20 runtimes de agentes
 
 O ClawMetry começou como observabilidade para o OpenClaw e agora mede toda a sua **frota de agentes** num único painel, detetando automaticamente cada runtime na sua máquina:
 

--- a/routes/device.py
+++ b/routes/device.py
@@ -338,7 +338,7 @@ _DEVICE_PREVIEW_HTML = """<!doctype html>
         <button class="deny" onclick="decide('deny')">Deny</button>
       </div>
     </div>
-    <div class="foot">one device · <b>all 14 runtimes</b></div>
+    <div class="foot">one device · <b>all 20 runtimes</b></div>
   </div>
 <script>
 const MOODS = {

--- a/scripts/sync_runtime_count.py
+++ b/scripts/sync_runtime_count.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""Keep the advertised runtime count in sync with the entitlement catalogue.
+
+``clawmetry/entitlements.py`` is the source of truth: the supported runtime
+count is ``len(FREE_RUNTIMES | PAID_RUNTIMES)``. That number also appears in
+prose across the README, its translations, FLYWHEEL.md, ARCHITECTURE.md, the
+CLI, the desktop onboarding copy and the device page, and every one of those
+drifted apart before this script existed (2026-08-15: README said 14, PyPI
+said 12, FLYWHEEL said 12, the catalogue said 20).
+
+Usage::
+
+    python3 scripts/sync_runtime_count.py            # rewrite every surface
+    python3 scripts/sync_runtime_count.py --check    # report drift, exit 1
+
+``tests/test_runtime_count_copy_sync.py`` calls :func:`check` so CI fails on
+drift, and ``setup.py`` derives the PyPI summary from the same catalogue so
+that surface cannot go stale at all.
+
+When a number here is legitimately *not* the supported-runtime count (a tier
+bullet counting free runtimes, a dated changelog line, a capacity estimate),
+add it to :data:`EXEMPT` with the reason rather than reshaping the prose.
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+# "14 runtimes", "12 AI agent runtimes", "14+ runtimes", "20 agent runtimes".
+COUNT_RE = re.compile(r"\b(\d{1,3})(\+?) ((?:AI )?(?:agent )?runtimes)\b")
+
+# Directories that legitimately carry historic or unrelated numbers.
+SKIP_DIRS = {
+    ".git", ".worktrees", "node_modules", "__pycache__", ".venv", "venv",
+    "build", "dist", ".mypy_cache", ".pytest_cache", "tests",
+}
+SKIP_FILES = {
+    "CHANGELOG.md",          # dated history, must keep the number of its day
+    "sync_runtime_count.py",  # this file's own docstring
+}
+SCAN_SUFFIXES = {".py", ".md", ".html", ".js", ".json", ".sh", ".ps1", ".cmd", ".yml", ".yaml"}
+
+# (path suffix, substring that must appear on the line) -> why it is not the
+# supported-runtime count. Matched lines are left alone by both check and fix.
+EXEMPT: list[tuple[str, str, str]] = [
+    ("clawmetry/entitlements.py", "2 runtimes", "free-tier count, not the total"),
+    ("clawmetry/entitlements.py", "4 runtimes", "per-tier capacity, not the total"),
+    ("routes/entitlement.py", "2 runtimes", "free-tier count in the API fallback"),
+    ("clawmetry/sync.py", "10 runtimes", "rollup sizing estimate, not the catalogue"),
+    ("docs/WHAT_USERS_WANT.md", "18 runtimes total", "dated research note"),
+    ("clawmetry/runtime_memory.py", "other 17 runtimes", "historic bug narrative, means all-but-one"),
+]
+
+# The English README pairs the count with "OpenClaw, NemoClaw, Claude Code,
+# OpenAI Codex & N more", so N is the total minus the four named runtimes.
+NAMED_IN_TAGLINE = 4
+MORE_RE = re.compile(r"& \d{1,3} more\b")
+
+# The same phrase exists in the translated READMEs, but the wording differs per
+# language ("y 10 mas", "et 10 autres", "kai 10 akoma", ...) and a regex sweep
+# across 35 locales would silently mangle the ones it half-matched. Those are
+# reported by --check instead of rewritten, so a human updates them knowingly.
+MORE_RE_I18N = re.compile(r"[^\s]{1,3} ?\d{1,3} ?(?:more|más|mais|autres|ακόμα|weitere|более|أخرى|अन्य)\b")
+
+
+def catalogue_count() -> int:
+    """Supported runtime count, parsed (not imported) from entitlements.py."""
+    src = (REPO / "clawmetry" / "entitlements.py").read_text(encoding="utf-8")
+    total = 0
+    for block in (
+        r"FREE_RUNTIMES = frozenset\(\{(.*?)\}\)",
+        r"PAID_RUNTIMES = frozenset\(\s*\{(.*?)\}\s*\)",
+    ):
+        m = re.search(block, src, re.S)
+        if not m:
+            raise SystemExit(f"could not parse {block!r} from entitlements.py")
+        total += len(re.findall(r'"[a-z0-9_]+"', m.group(1)))
+    if total < 2:
+        raise SystemExit("parsed an implausible runtime count from entitlements.py")
+    return total
+
+
+def _is_exempt(rel: str, line: str) -> bool:
+    return any(rel.endswith(path) and needle in line for path, needle, _ in EXEMPT)
+
+
+def _files() -> list[Path]:
+    out = []
+    for p in REPO.rglob("*"):
+        if not p.is_file() or p.suffix not in SCAN_SUFFIXES:
+            continue
+        if p.name in SKIP_FILES or SKIP_DIRS & set(p.relative_to(REPO).parts):
+            continue
+        out.append(p)
+    return sorted(out)
+
+
+def check(expected: int | None = None) -> list[tuple[str, int, str, str]]:
+    """Return [(relpath, lineno, found, line)] for every stale count."""
+    expected = catalogue_count() if expected is None else expected
+    drift = []
+    for path in _files():
+        rel = str(path.relative_to(REPO))
+        try:
+            lines = path.read_text(encoding="utf-8").splitlines()
+        except UnicodeDecodeError:
+            continue
+        for n, line in enumerate(lines, 1):
+            if _is_exempt(rel, line):
+                continue
+            for m in COUNT_RE.finditer(line):
+                if int(m.group(1)) != expected:
+                    drift.append((rel, n, m.group(0), line.strip()))
+            if rel == "README.md":
+                for m in MORE_RE.finditer(line):
+                    if m.group(0) != f"& {expected - NAMED_IN_TAGLINE} more":
+                        drift.append((rel, n, m.group(0), line.strip()))
+    return drift
+
+
+def check_translated_taglines(expected: int | None = None) -> list[tuple[str, int, str]]:
+    """Report "and N more" phrases in translated READMEs for manual review.
+
+    Not part of :func:`check` because these are never rewritten automatically
+    (see :data:`MORE_RE_I18N`), so failing CI on them would block every runtime
+    addition on 35 translations.
+    """
+    expected = catalogue_count() if expected is None else expected
+    want = expected - NAMED_IN_TAGLINE
+    stale = []
+    for path in sorted((REPO / "docs" / "i18n").rglob("README.md")):
+        rel = str(path.relative_to(REPO))
+        for n, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+            for m in MORE_RE_I18N.finditer(line):
+                if str(want) not in m.group(0):
+                    stale.append((rel, n, m.group(0).strip()))
+    return stale
+
+
+def fix(expected: int | None = None) -> list[str]:
+    """Rewrite every stale count in place. Returns the paths touched."""
+    expected = catalogue_count() if expected is None else expected
+    touched = []
+    for path in _files():
+        rel = str(path.relative_to(REPO))
+        try:
+            original = path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            continue
+        out = []
+        changed = False
+        for line in original.splitlines(keepends=True):
+            if _is_exempt(rel, line):
+                out.append(line)
+                continue
+            new = COUNT_RE.sub(lambda m: f"{expected}{m.group(2)} {m.group(3)}", line)
+            if rel == "README.md":
+                new = MORE_RE.sub(f"& {expected - NAMED_IN_TAGLINE} more", new)
+            changed |= new != line
+            out.append(new)
+        if changed:
+            path.write_text("".join(out), encoding="utf-8")
+            touched.append(rel)
+    return touched
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--check", action="store_true", help="report drift, do not rewrite")
+    args = ap.parse_args()
+
+    expected = catalogue_count()
+
+    def _report_translations() -> None:
+        stale = check_translated_taglines(expected)
+        if stale:
+            print(f"\nnote: {len(stale)} translated tagline(s) still say the old "
+                  f"'and N more' (want {expected - NAMED_IN_TAGLINE}); these are "
+                  "never rewritten automatically:")
+            for rel, n, found in stale:
+                print(f"  {rel}:{n}: {found}")
+
+    if args.check:
+        drift = check(expected)
+        if not drift:
+            print(f"runtime count in sync at {expected} across every surface")
+            _report_translations()
+            return 0
+        print(f"runtime count drift (catalogue says {expected}):\n")
+        for rel, n, found, line in drift:
+            print(f"  {rel}:{n}: {found!r}\n      {line}")
+        print(f"\n{len(drift)} stale mention(s). Fix with: python3 {Path(__file__).relative_to(REPO)}")
+        _report_translations()
+        return 1
+
+    touched = fix(expected)
+    if not touched:
+        print(f"runtime count already in sync at {expected}")
+    else:
+        print(f"rewrote {len(touched)} file(s) to {expected} runtimes:")
+        for rel in touched:
+            print(f"  {rel}")
+    _report_translations()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/setup.py
+++ b/setup.py
@@ -8,10 +8,29 @@ with open("README.md", "r", encoding="utf-8") as f:
 with open("dashboard.py", "r", encoding="utf-8") as f:
     version = re.search(r'__version__\s*=\s*"(.+?)"', f.read()).group(1)
 
+# Single source of truth: FREE_RUNTIMES | PAID_RUNTIMES in
+# clawmetry/entitlements.py. Parsed rather than imported because setup.py
+# runs before the package is installed. Keeping the PyPI summary derived
+# means it cannot go stale when a runtime lands (it said 12 while the
+# catalogue said 20 until 2026-08-15).
+with open("clawmetry/entitlements.py", "r", encoding="utf-8") as f:
+    _ent_src = f.read()
+runtime_count = sum(
+    len(re.findall(r'"[a-z0-9_]+"', re.search(block, _ent_src, re.S).group(1)))
+    for block in (
+        r"FREE_RUNTIMES = frozenset\(\{(.*?)\}\)",
+        r"PAID_RUNTIMES = frozenset\(\s*\{(.*?)\}\s*\)",
+    )
+)
+assert runtime_count > 1, "failed to parse runtime catalogue from entitlements.py"
+
 setup(
     name="clawmetry",
     version=version,
-    description="ClawMetry - Real-time observability for 12 AI agent runtimes (OpenClaw, NVIDIA NemoClaw, Claude Code, Codex & more)",
+    description=(
+        f"ClawMetry - Real-time observability for {runtime_count} AI agent runtimes "
+        "(OpenClaw, NVIDIA NemoClaw, Claude Code, Codex & more)"
+    ),
     long_description=long_description,
     long_description_content_type="text/markdown",
     author="Vivek Chand",

--- a/tests/test_runtime_count_copy_sync.py
+++ b/tests/test_runtime_count_copy_sync.py
@@ -1,0 +1,113 @@
+"""CI guard against runtime-count drift in user-facing copy.
+
+Sibling of ``test_advertised_runtimes_match_catalogue.py``: that one pins the
+*set* of runtime ids, this one pins the *number* quoted in prose. Both hang off
+``clawmetry/entitlements.py``.
+
+Burned 2026-08-15: ``FREE_RUNTIMES | PAID_RUNTIMES`` had 20 entries while the
+README said 14, the PyPI summary said 12 and FLYWHEEL.md said 12, over 27 stale
+mentions in 16 files. Nobody noticed because every surface was edited by hand and
+none of them were checked against the catalogue.
+"""
+from __future__ import annotations
+
+import importlib.util
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+SCRIPT = REPO / "scripts" / "sync_runtime_count.py"
+
+
+def _load_sync_module():
+    spec = importlib.util.spec_from_file_location("sync_runtime_count", SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def sync():
+    assert SCRIPT.exists(), f"missing {SCRIPT}; the count guard cannot run"
+    return _load_sync_module()
+
+
+def test_script_parses_the_same_count_the_package_computes(sync):
+    """The script regex-parses entitlements.py (setup.py does too, since it runs
+    before the package is importable). If that parse ever diverges from the real
+    ``len(ALL_RUNTIMES)``, every downstream surface is confidently wrong."""
+    from clawmetry.entitlements import ALL_RUNTIMES, RUNTIME_COUNT
+
+    assert RUNTIME_COUNT == len(ALL_RUNTIMES)
+    assert sync.catalogue_count() == RUNTIME_COUNT, (
+        f"scripts/sync_runtime_count.py parsed {sync.catalogue_count()} runtimes "
+        f"but the catalogue has {RUNTIME_COUNT}. The frozenset literals in "
+        f"entitlements.py were probably reformatted; update the regexes in the script."
+    )
+
+
+def test_no_surface_quotes_a_stale_runtime_count(sync):
+    """Every "N runtimes" in shipped copy must equal the catalogue count."""
+    drift = sync.check()
+    if drift:
+        detail = "\n".join(f"  {rel}:{n}: {found!r}" for rel, n, found, _ in drift)
+        pytest.fail(
+            f"{len(drift)} surface(s) quote a stale runtime count "
+            f"(catalogue says {sync.catalogue_count()}):\n{detail}\n\n"
+            f"Fix with: python3 scripts/sync_runtime_count.py"
+        )
+
+
+def test_pypi_summary_is_derived_not_hardcoded():
+    """setup.py must compute its description, so the PyPI page cannot go stale.
+
+    Checked by source-scan rather than by running setup.py, because importing it
+    executes ``setup()``.
+    """
+    src = (REPO / "setup.py").read_text(encoding="utf-8")
+    assert "entitlements.py" in src, "setup.py no longer reads the runtime catalogue"
+    assert re.search(r"description=\(?\s*f?\"", src), "setup.py description is not an f-string"
+    assert not re.search(
+        r'description="ClawMetry - Real-time observability for \d+', src
+    ), "setup.py hardcodes a runtime count again; derive it from entitlements.py"
+
+
+def test_setup_py_description_reports_the_catalogue_count():
+    """End to end: the string that reaches PyPI carries the real count."""
+    from clawmetry.entitlements import RUNTIME_COUNT
+
+    out = subprocess.run(
+        [sys.executable, "setup.py", "--description"],
+        cwd=REPO, capture_output=True, text=True, timeout=120,
+    )
+    assert out.returncode == 0, f"setup.py --description failed:\n{out.stderr[-2000:]}"
+    summary = out.stdout.strip().splitlines()[-1]
+    assert f"{RUNTIME_COUNT} AI agent runtimes" in summary, (
+        f"PyPI summary does not carry the catalogue count {RUNTIME_COUNT}: {summary!r}"
+    )
+
+
+def test_readme_grid_names_every_supported_runtime():
+    """A count alone is not enough: the README grid must name each runtime too.
+
+    Burned in the same sweep: the grid listed 19 of 20 (DeepSeek Harness shipped
+    to the catalogue and the landing page but never reached the README).
+    """
+    from clawmetry.entitlements import ALL_RUNTIMES, RUNTIME_LABELS
+
+    readme = (REPO / "README.md").read_text(encoding="utf-8")
+    # Label spelling in the README is allowed to be friendlier than the raw
+    # catalogue label (e.g. "OpenAI Codex" for "Codex"), so match on the label
+    # as a substring rather than requiring an exact token.
+    missing = sorted(
+        RUNTIME_LABELS[r] for r in ALL_RUNTIMES
+        if RUNTIME_LABELS.get(r) and RUNTIME_LABELS[r] not in readme
+    )
+    assert not missing, (
+        f"README.md never names these supported runtimes: {missing}. "
+        f"Add them to the 'Works with N agent runtimes' grid."
+    )


### PR DESCRIPTION
## The problem

`FREE_RUNTIMES | PAID_RUNTIMES` has 20 entries. Every surface that quotes that number disagreed with it:

| Surface | Said | Should say |
|---|---|---|
| PyPI summary (`setup.py`) | 12 | 20 |
| README tagline and heading | 14 | 20 |
| FLYWHEEL.md (3 places) | 12 | 20 |
| ARCHITECTURE.md, AUDIT.md | 12 | 20 |
| `clawmetry/cli.py` (2 user-facing prints) | 14 | 20 |
| `routes/device.py`, `desktop/onboarding.py` | 14 / 14+ | 20 |
| 6 translated READMEs | 14 | 20 |

27 stale mentions in 16 files. Nobody caught it because each surface was edited by hand and none were checked against the catalogue.

This surfaced while submitting ClawMetry to external awesome lists: maintainers click through, and a PyPI page saying 12 next to a homepage saying 20 is the kind of thing that gets a submission closed.

## The fix, in three layers

**Derived.** `setup.py` parses `entitlements.py` at build time (same pattern it already uses for `__version__`), so the PyPI summary is computed rather than typed. That surface can no longer drift at all.

**Fixable.** `scripts/sync_runtime_count.py` rewrites every remaining surface from the catalogue in one command. It scans the whole repo rather than a hardcoded file list, so a new file with a stale count gets caught too.

**Enforced.** `tests/test_runtime_count_copy_sync.py` plus a `ci.yml` lint step fail on drift, with the fix command in the failure message. Verified it actually bites: adding a fake 21st runtime to `PAID_RUNTIMES` turns CI red with `27 surface(s) quote a stale runtime count (catalogue says 21)`.

## Two things the count guard cannot reach

The README grid named 19 of 20 runtimes (DeepSeek Harness shipped to the catalogue and the landing page but never reached the README), and FLYWHEEL's "Also supported" line listed 10 of the 18 paid runtimes. Both fixed, and the new test asserts every `RUNTIME_LABELS` entry appears in the README so the grid cannot fall behind again.

## Scope limits, stated rather than implied

- The landing repo and the GitHub repo description are outside this CI. FLYWHEEL section 2a says so and names them as manual steps in the same sprint.
- The `and N more` phrase in the translated taglines is reported by `--check` but never rewritten, because a regex sweep across 35 locales would silently mangle the half-matches. Six locales are listed in the output for a translator.
- Numbers that legitimately are not the runtime count (free-tier counts, a dated research note, a rollup sizing estimate) are in `EXEMPT` with their reason, rather than reworded to dodge the regex.

## Verification

```
python3 -m pytest tests/test_runtime_count_copy_sync.py -v     5 passed
python3 -m pytest tests/test_advertised_runtimes_match_catalogue.py -q   7 passed
ruff check scripts/ tests/test_runtime_count_copy_sync.py setup.py      clean
make lint-runtime-count                                        in sync at 20
python3 setup.py --description       ... for 20 AI agent runtimes ...
```